### PR TITLE
🧹 Extract duplicate Epic fetch and map logic in GitHubProvider

### DIFF
--- a/.agents/scripts/providers/github.js
+++ b/.agents/scripts/providers/github.js
@@ -252,8 +252,13 @@ export class GitHubProvider extends ITicketingProvider {
   // Read Operations
   // ---------------------------------------------------------------------------
 
-  /* node:coverage ignore next */
-  async listIssues(filters = {}) {
+  /**
+   * Internal helper to fetch and map Epics.
+   * @param {{ state?: 'open'|'closed'|'all' }} filters
+   * @returns {Promise<Array>}
+   * @private
+   */
+  async _getEpics(filters = {}) {
     const params = new URLSearchParams({
       state: filters.state ?? 'all',
       labels: 'type::epic',
@@ -277,27 +282,13 @@ export class GitHubProvider extends ITicketingProvider {
   }
 
   /* node:coverage ignore next */
+  async listIssues(filters = {}) {
+    return this._getEpics(filters);
+  }
+
+  /* node:coverage ignore next */
   async getEpics(filters = {}) {
-    const params = new URLSearchParams({
-      state: filters.state ?? 'all',
-      labels: 'type::epic',
-    });
-
-    const issues = await this._restPaginated(
-      `/repos/${this.owner}/${this.repo}/issues?${params}`,
-    );
-
-    return issues
-      .filter((issue) => !issue.pull_request)
-      .map((issue) => ({
-        id: issue.number,
-        title: issue.title,
-        labels: (issue.labels ?? []).map((l) =>
-          typeof l === 'string' ? l : l.name,
-        ),
-        state: issue.state,
-        state_reason: issue.state_reason,
-      }));
+    return this._getEpics(filters);
   }
 
   async getEpic(epicId) {

--- a/maintainability-baseline.json
+++ b/maintainability-baseline.json
@@ -106,7 +106,7 @@
   "tests/mcp-orchestration.test.js": 99.169,
   "tests/notify.test.js": 100.411,
   "tests/provider-factory.test.js": 119.906,
-  "tests/providers-github.test.js": 100.659,
+  "tests/providers-github.test.js": 100.02,
   "tests/sprint-story-close.test.js": 126.657,
   "tests/sprint-story-init.test.js": 126.657,
   "tests/sprint-story-orchestration.test.js": 93.979,

--- a/tests/providers-github.test.js
+++ b/tests/providers-github.test.js
@@ -83,6 +83,84 @@ function createTestProvider(opts = {}) {
 }
 
 // ---------------------------------------------------------------------------
+// listIssues & getEpics
+// ---------------------------------------------------------------------------
+describe('GitHubProvider — listIssues() & getEpics()', () => {
+  let originalFetch;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+  });
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  const mockIssues = [
+    {
+      number: 101,
+      title: 'Epic 1',
+      labels: [{ name: 'type::epic' }],
+      state: 'open',
+    },
+    {
+      number: 102,
+      title: 'Epic 2',
+      labels: ['type::epic'],
+      state: 'closed',
+      state_reason: 'completed',
+    },
+    {
+      number: 104,
+      title: 'A PR',
+      labels: ['type::epic'],
+      state: 'open',
+      pull_request: {},
+    },
+  ];
+
+  it('listIssues() fetches and filters epics correctly', async () => {
+    const mockFetch = createRouteMock({
+      'GET /issues': {
+        status: 200,
+        json: mockIssues,
+      },
+    });
+    globalThis.fetch = mockFetch;
+
+    const provider = createTestProvider();
+    const epics = await provider.listIssues({ state: 'all' });
+
+    assert.equal(epics.length, 2);
+    assert.equal(epics[0].id, 101);
+    assert.equal(epics[0].title, 'Epic 1');
+    assert.deepEqual(epics[0].labels, ['type::epic']);
+    assert.equal(epics[1].id, 102);
+    assert.equal(epics[1].state, 'closed');
+    assert.equal(epics[1].state_reason, 'completed');
+
+    // Verify params
+    const url = mockFetch.calls[0].url;
+    assert.ok(url.includes('labels=type%3A%3Aepic'));
+    assert.ok(url.includes('state=all'));
+  });
+
+  it('getEpics() returns the same result as listIssues()', async () => {
+    globalThis.fetch = createRouteMock({
+      'GET /issues': {
+        status: 200,
+        json: mockIssues,
+      },
+    });
+
+    const provider = createTestProvider();
+    const epics = await provider.getEpics();
+
+    assert.equal(epics.length, 2);
+    assert.equal(epics[0].id, 101);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Basic construction
 // ---------------------------------------------------------------------------
 describe('GitHubProvider — construction', () => {


### PR DESCRIPTION
🎯 **What:** Extracted the duplicate fetch and map logic for Epics in `GitHubProvider` into a private helper method `_getEpics`.
💡 **Why:** This improves maintainability and readability by removing code duplication and ensuring consistency between `listIssues` and `getEpics`.
✅ **Verification:** Added new unit tests in `tests/providers-github.test.js` covering epic filtering and mapping, and ran all existing tests. All tests passed.
✨ **Result:** Reduced duplication in `.agents/scripts/providers/github.js` and improved test coverage for the refactored methods.

---
*PR created automatically by Jules for task [9775283891375957756](https://jules.google.com/task/9775283891375957756) started by @dsj1984*