### PR TITLE
🧹 Code health: Extract edge collection logic in `autoSerializeOverlaps`

### DIFF
--- a/.agents/scripts/lib/orchestration/dependency-analyzer.js
+++ b/.agents/scripts/lib/orchestration/dependency-analyzer.js
@@ -34,37 +34,11 @@ export function autoSerializeOverlaps(manifest, adjacency) {
   );
 
   const reachable = computeReachability(adjacency);
-  const pendingEdges = []; // [ [fromId, toId], ... ]
-
-  for (let i = 0; i < manifest.tasks.length; i++) {
-    for (let j = i + 1; j < manifest.tasks.length; j++) {
-      const taskA = manifest.tasks[i];
-      const taskB = manifest.tasks[j];
-
-      // Bookend tasks manage lifecycle, not files — skip them
-      if (isBookendTask(taskA) || isBookendTask(taskB)) continue;
-
-      // Skip if neither task declares focusAreas — scope-only matches are not
-      // sufficient evidence of file-level conflict
-      const setA = focusSets.get(taskA.id);
-      const setB = focusSets.get(taskB.id);
-      if (setA.size === 0 && setB.size === 0) continue;
-
-      const isGlobalA = taskA.scope === 'root' || setA.has('*');
-      const isGlobalB = taskB.scope === 'root' || setB.has('*');
-      const overlap =
-        isGlobalA || isGlobalB || [...setA].some((a) => setB.has(a));
-
-      if (overlap) {
-        const aReachesB = reachable.get(taskA.id)?.has(taskB.id);
-        const bReachesA = reachable.get(taskB.id)?.has(taskA.id);
-
-        if (!aReachesB && !bReachesA) {
-          pendingEdges.push([taskA.id, taskB.id]);
-        }
-      }
-    }
-  }
+  const pendingEdges = _collectPendingEdges(
+    manifest.tasks,
+    focusSets,
+    reachable,
+  );
 
   // Phase B: apply all collected edges in a single pass & rebuild once
   const graphMutated = pendingEdges.length > 0;
@@ -305,3 +279,39 @@ export function computeStoryWaves(storyGroups, explicitDeps) {
 
 // Exported for targeted unit testing; not part of the stable module API.
 export const __test = { rollUpStoryFocus, addFocusOverlapEdges };
+
+/**
+ * Internal helper to find all pairs of tasks that overlap but don't yet have
+ * a dependency ordering between them.
+ *
+ * @param {object[]} tasks     — The array of tasks to check.
+ * @param {Map}      focusSets — Map of taskId to Set of focus areas.
+ * @param {Map}      reachable — Reachability matrix to check existing paths.
+ * @returns {Array[]}            List of [fromId, toId] pairs.
+ */
+function _collectPendingEdges(tasks, focusSets, reachable) {
+  const pendingEdges = [];
+  for (let i = 0; i < tasks.length; i++) {
+    for (let j = i + 1; j < tasks.length; j++) {
+      const taskA = tasks[i];
+      const taskB = tasks[j];
+      if (isBookendTask(taskA) || isBookendTask(taskB)) continue;
+
+      const setA = focusSets.get(taskA.id);
+      const setB = focusSets.get(taskB.id);
+      if (setA.size === 0 && setB.size === 0) continue;
+
+      const isGlobalA = taskA.scope === 'root' || setA.has('*');
+      const isGlobalB = taskB.scope === 'root' || setB.has('*');
+      const overlap =
+        isGlobalA || isGlobalB || [...setA].some((a) => setB.has(a));
+
+      if (overlap) {
+        const aReachesB = reachable.get(taskA.id)?.has(taskB.id);
+        const bReachesA = reachable.get(taskB.id)?.has(taskA.id);
+        if (!aReachesB && !bReachesA) pendingEdges.push([taskA.id, taskB.id]);
+      }
+    }
+  }
+  return pendingEdges;
+}


### PR DESCRIPTION
## 🧹 Code Health Improvement: Refactor `autoSerializeOverlaps`

🎯 **What:** The inner nested loops in `.agents/scripts/lib/orchestration/dependency-analyzer.js` responsible for identifying task overlap edges were extracted into a new helper function `_collectPendingEdges`.
💡 **Why:** This drastically shortens the `autoSerializeOverlaps` function, making it easier to read the high-level orchestration logic without getting bogged down in the low-level graph edge discovery.
✅ **Verification:** Verified via `npm run test` (including `tests/dependency-analyzer.test.js`) and linted with `npm run format`/`npm run lint` to ensure no functionality changed and code formatting is preserved.
✨ **Result:** Improved separation of concerns, shorter functions, better readability.

---
*PR created automatically by Jules for task [14888055100747318989](https://jules.google.com/task/14888055100747318989) started by @dsj1984*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure refactor that moves the overlap edge-discovery loop into a private helper without changing the dependency-serialization behavior; low risk aside from potential subtle ordering/parameter issues.
> 
> **Overview**
> **Refactors overlap dependency discovery** in `autoSerializeOverlaps` by moving the nested task-pair scan into a new internal helper `_collectPendingEdges`.
> 
> No functional behavior is intended to change; the main function now delegates to the helper to produce the same `pendingEdges` list before applying dependencies and re-checking for cycles.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f49fd2ff984ecc4b07da2cc8ae2b3188182992fa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->