### PR TITLE
🧪 Add test for fs read errors in loadEnv

### DIFF
--- a/tests/lib/env-loader.test.js
+++ b/tests/lib/env-loader.test.js
@@ -80,4 +80,17 @@ describe('loadEnv', () => {
     assert.strictEqual(process.env.TEST_A, '1');
     assert.strictEqual(process.env.TEST_B, '2');
   });
+
+  it('fails silently when fs throws an error', (t) => {
+    // Ensure the file exists so readFileSync is called
+    fs.writeFileSync(path.join(tmpDir, '.env'), 'TEST_KEY=1\n');
+
+    // Mock readFileSync to throw an error
+    t.mock.method(fs, 'readFileSync', () => {
+      throw new Error('EACCES: permission denied');
+    });
+
+    // Should not throw
+    assert.doesNotThrow(() => loadEnv(tmpDir));
+  });
 });


### PR DESCRIPTION
🎯 **What:** The testing gap addressed is the missing test case for fs read errors when reading the `.env` file in `loadEnv`.
📊 **Coverage:** A new test case has been added to cover the scenario where `fs.readFileSync` throws an error.
✨ **Result:** The `env-loader.js` file now has better test coverage, ensuring `loadEnv` gracefully handles and silences file reading errors.

---
*PR created automatically by Jules for task [13101287419902943806](https://jules.google.com/task/13101287419902943806) started by @dsj1984*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: test-only change that validates `loadEnv` doesn’t throw when `fs.readFileSync` fails; no production logic is modified.
> 
> **Overview**
> Adds a new `loadEnv` unit test to ensure it *fails silently* when reading an existing `.env` throws (mocking `fs.readFileSync` to raise `EACCES`). This closes a coverage gap around the function’s try/catch error-handling behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ab46499b118224d09e65698c227dd215b81b9990. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->