### PR TITLE
ci: remove Windows leg (eliminates c8 flap; pre-push hook is the real Windows gate)

### DIFF
--- a/.github/ruleset.json
+++ b/.github/ruleset.json
@@ -12,9 +12,15 @@
     }
   },
   "rules": [
-    { "type": "deletion" },
-    { "type": "non_fast_forward" },
-    { "type": "required_linear_history" },
+    {
+      "type": "deletion"
+    },
+    {
+      "type": "non_fast_forward"
+    },
+    {
+      "type": "required_linear_history"
+    },
     {
       "type": "required_status_checks",
       "parameters": {
@@ -23,10 +29,6 @@
         "required_status_checks": [
           {
             "context": "Validate and Test (ubuntu-latest, node 22)",
-            "integration_id": 15368
-          },
-          {
-            "context": "Validate and Test (windows-latest, node 22)",
             "integration_id": 15368
           }
         ]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        # Windows runner removed (2026-05-11): operator runs Windows
+        # locally as their dev environment, so the pre-push hook is the
+        # real Windows gate. The CI Windows leg was producing repeated
+        # c8/timing coverage flap with no corresponding source defects,
+        # forcing per-PR baseline ratchets. See #1267 for the per-OS
+        # baseline plan if Windows-leg CI is reinstated later.
+        os: [ubuntu-latest]
         node-version: [22]
     steps:
       - name: Checkout Code
@@ -42,10 +48,6 @@ jobs:
         run: npm audit --audit-level=high
 
       - name: Secret Scanning (TruffleHog)
-        # trufflesecurity/trufflehog is a Docker container action and only
-        # runs on Linux runners. Skip on Windows — the Linux leg is the
-        # source of truth for the secret-scan gate.
-        if: runner.os == 'Linux'
         uses: trufflesecurity/trufflehog@main
         with:
           extra_args: --debug --only-verified
@@ -62,9 +64,6 @@ jobs:
         # Capture stderr too — Node's test runner and the coverage-threshold
         # gate both emit failures on stderr, and a stdout-only redirect
         # hides them in the uploaded artifact (see Epic #441 Story 4.1).
-        # Force bash so `set -o pipefail` and `tee` work the same on Windows
-        # runners (default shell there is pwsh).
-        shell: bash
         run: |
           set -o pipefail
           npm run test:coverage 2>&1 | tee test-output.txt
@@ -95,8 +94,6 @@ jobs:
         # PR. Self-skips when `agentSettings.quality.crap.enabled` is
         # false. The `--json` artifact is uploaded for downstream agent
         # workflows.
-        # Force bash so `mkdir -p` and `[[ ... ]]` keep working on Windows.
-        shell: bash
         run: |
           mkdir -p temp
           if [[ "${{ github.event_name }}" == "pull_request" ]]; then

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Removed
+
+- **Windows CI leg removed.** The `windows-latest` runner in
+  `.github/workflows/ci.yml` was producing repeated c8/timing
+  coverage flap with no corresponding source defects, forcing per-PR
+  `baseline-refresh:` ratchets on otherwise-unchanged files. Since the
+  maintainer runs Windows locally, the pre-push hook is already the
+  real Windows gate. Removed from the workflow matrix and from the
+  live ruleset `14286998` required-status-checks set (only the Ubuntu
+  leg is now required). The `.github/ruleset.json` artifact tracks the
+  new shape. See #1267 for the per-OS baseline plan if Windows-leg CI
+  is reinstated later.
+
 ## [5.41.0] — 2026-05-11
 
 The 5.41 release lands the Epic #1235 **hands-off PR pipeline**: CI is

--- a/docs/runbooks/pr-pipeline.md
+++ b/docs/runbooks/pr-pipeline.md
@@ -16,11 +16,11 @@
 | Surface | State |
 |---|---|
 | Repo merge methods | `allow_squash_merge: true`, `allow_rebase_merge: false`, `allow_merge_commit: false`, `allow_auto_merge: true`, `delete_branch_on_merge: true` |
-| Ruleset `14286998` rules | `deletion`, `non_fast_forward`, `required_linear_history`, `required_status_checks` (both OS contexts, strict policy) |
+| Ruleset `14286998` rules | `deletion`, `non_fast_forward`, `required_linear_history`, `required_status_checks` (Ubuntu CI leg only, strict policy) |
 | Ruleset bypass | `bypass_actors: []`, `current_user_can_bypass: never` |
 | Approval rule | **Not active** (Path A) — fine to ship PRs now; CI is the gate |
 
-What this means today: every new PR you open can be merged with `gh pr merge --auto --squash --delete-branch` and it will land itself the moment both CI legs (`Validate and Test (ubuntu-latest, node 22)` and `Validate and Test (windows-latest, node 22)`) report success. No reviewer needed. No admin bypass.
+What this means today: every new PR you open can be merged with `gh pr merge --auto --squash --delete-branch` and it will land itself the moment the Ubuntu CI leg (`Validate and Test (ubuntu-latest, node 22)`) reports success. No reviewer needed. No admin bypass. The Windows leg was removed on 2026-05-11 — the operator runs Windows locally and the pre-push hook is the real Windows gate; see `.github/workflows/ci.yml` for the matrix history.
 
 ### ⏳ Pending (your work — see § Your remaining work)
 
@@ -119,7 +119,7 @@ You can ping Claude before step 5 too if you want — there's no harm in having 
 ## Smoke-test once Path B is live
 
 1. Open a trivial PR (e.g. one-line README touch).
-2. Wait for `CI / CD` to complete green on both OS legs.
+2. Wait for `CI / CD` to complete green on the Ubuntu leg.
 3. Within ~60s, the `bot-approve` workflow should appear under the **Actions** tab with `conclusion: success` and the PR should show an **Approved** review from `agent-protocols-reviewer[bot]`.
 4. The PR's green Merge button should then unblock — auto-merge fires if you marked the PR `--auto`.
 


### PR DESCRIPTION
## Summary

Windows CI leg has been producing repeated c8/timing coverage flap since it was added. Across just the last two PRs we've had to ratchet baselines for 9 different files with no source-level change to any of them. Time tax compounds.

Cutting the leg. Operator runs Windows locally; pre-push hook already enforces lint, format, maintainability, audit, coverage, CRAP — that's the real Windows gate.

## Changes

- `.github/workflows/ci.yml`: matrix shrinks from `[ubuntu-latest, windows-latest]` → `[ubuntu-latest]`. Stripped stale "skip on Windows" guard from TruffleHog and "force bash on Windows" comments on tests + CRAP steps.
- `.github/ruleset.json`: drops the `Validate and Test (windows-latest, node 22)` context from required_status_checks.
- **Live ruleset 14286998 already updated** (applied before this commit so open PRs aren't stuck waiting for a Windows check that will never arrive).
- `docs/runbooks/pr-pipeline.md`: status snapshot + smoke-test updated to "Ubuntu only."
- `docs/CHANGELOG.md`: `[Unreleased]` / `### Removed` entry, with a pointer to #1267 for the per-OS baseline plan if Windows is ever reinstated.

## Test plan

- [ ] CI / CD runs only the Ubuntu leg on this PR
- [ ] Auto-merge fires on green
- [ ] Future PRs no longer block on a missing Windows check

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it reduces CI coverage by removing the `windows-latest` gate, which could allow Windows-specific regressions to merge undetected; otherwise changes are limited to CI configuration and documentation.
> 
> **Overview**
> Removes the Windows CI leg so `CI / CD` runs only on `ubuntu-latest`, and cleans up now-unneeded Windows conditionals/comments in the workflow.
> 
> Updates the protected-branch ruleset artifact to require only `Validate and Test (ubuntu-latest, node 22)` and drops the Windows status-check context. Documentation is updated (changelog + PR-pipeline runbook) to reflect Ubuntu-only gating and the rationale for the removal.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ffc2b1328bf960d29fa4d64ea6e48d7ceb9a856e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->