### PR TITLE
feat(manifest): trim dispatch manifest markdown for clean top-to-bottom flow

### DIFF
--- a/.agents/scripts/lib/presentation/manifest-formatter.js
+++ b/.agents/scripts/lib/presentation/manifest-formatter.js
@@ -117,17 +117,17 @@ export function slugifyHeading(text) {
 }
 
 /**
- * Build the visible H2 text for a wave row, e.g. `🚀 Wave 0 — Ready`. Used
- * both as the row label in the TOC and (later, by Task #1212) as the literal
- * `## …` text in the per-wave section. Centralising the formatting here is
- * what lets `slugifyHeading` produce identical slugs on both sides.
+ * Build the visible H2 text for a wave row, e.g. `🚀 Wave 0`. The status
+ * word lives only in the Wave Summary TOC; the H2 carries the emoji as a
+ * visual anchor and nothing else, so the per-wave section reads cleanly
+ * top-to-bottom without echoing the table.
  *
- * @param {string} waveLabel  e.g. `Wave 0` or `Ungrouped`
- * @param {string} statusLabel e.g. `✅ Done`, `🚀 Ready`, `⏳ Blocked`
+ * @param {string} waveLabel e.g. `Wave 0` or `Ungrouped`
+ * @param {string} emoji     e.g. `🚀`, `⏳`, `✅`
  * @returns {string}
  */
-export function waveHeadingText(waveLabel, statusLabel) {
-  return `${statusLabel} ${waveLabel}`;
+export function waveHeadingText(waveLabel, emoji) {
+  return `${emoji} ${waveLabel}`;
 }
 
 /**
@@ -143,6 +143,33 @@ export function renderProgressBar(percent, opts = {}) {
   const pct = Math.max(0, Math.min(100, Number(percent) || 0));
   const filled = Math.round((pct / 100) * width);
   return '█'.repeat(filled) + '░'.repeat(width - filled);
+}
+
+/**
+ * Derive the per-wave status label and emoji used by both the TOC table and
+ * the per-wave H2 heading. Single source of truth so the TOC link slug and
+ * the H2 anchor stay in lock-step.
+ *
+ * @param {number} waveIdx                — current wave index (or -1)
+ * @param {Map<number, { tasks: number, done: number }>} waveStats
+ * @param {number[]} sortedWaves          — every wave index in ascending order
+ * @returns {{ emoji: string, word: string, label: string }}
+ */
+export function deriveWaveStatus(waveIdx, waveStats, sortedWaves) {
+  const stat = waveStats.get(waveIdx);
+  const isDone = stat && stat.tasks > 0 && stat.done === stat.tasks;
+  if (isDone) return { emoji: '✅', word: 'Done', label: '✅ Done' };
+  const isReady =
+    waveIdx === 0 ||
+    sortedWaves
+      .filter((sw) => sw < waveIdx)
+      .every((sw) => {
+        const swStat = waveStats.get(sw);
+        return swStat.done === swStat.tasks;
+      });
+  return isReady
+    ? { emoji: '🚀', word: 'Ready', label: '🚀 Ready' }
+    : { emoji: '⏳', word: 'Blocked', label: '⏳ Blocked' };
 }
 
 /**
@@ -171,67 +198,25 @@ export function renderWaveSections(waveEligible) {
   const lines = [
     '## Wave Summary',
     '',
-    '| Wave | Status | Progress | Stories | Tasks |',
-    '| :--- | :--- | :--- | :--- | :--- |',
+    '| Wave | Status | Stories | Tasks |',
+    '| :--- | :--- | :--- | :--- |',
   ];
 
   for (const w of sortedWaves) {
     const stat = waveStats.get(w);
-    const isDone = stat.tasks > 0 && stat.done === stat.tasks;
     const waveLabel = w === -1 ? 'Ungrouped' : `Wave ${w}`;
-    const isReady =
-      w === 0 ||
-      sortedWaves
-        .filter((sw) => sw < w)
-        .every((sw) => {
-          const swStat = waveStats.get(sw);
-          return swStat.done === swStat.tasks;
-        });
-
-    const statusLabel = isDone
-      ? '✅ Done'
-      : isReady
-        ? '🚀 Ready'
-        : '⏳ Blocked';
-    const wavePct =
-      stat.tasks > 0 ? Math.round((stat.done / stat.tasks) * 100) : 0;
-    const waveBar = renderProgressBar(wavePct, { width: 10 });
-    // The TOC cell links into the per-wave H2 section emitted downstream
-    // (Task #1212). The slug is derived from the same heading text both
-    // sides will use, so the anchor stays correct as long as both call
-    // `waveHeadingText` + `slugifyHeading` in lock-step.
-    const headingText = waveHeadingText(waveLabel, statusLabel);
+    const status = deriveWaveStatus(w, waveStats, sortedWaves);
+    // The TOC cell links into the matching per-wave H2 section. Both sides
+    // call `waveHeadingText` + `slugifyHeading` so the anchor stays correct.
+    const headingText = waveHeadingText(waveLabel, status.emoji);
     const anchor = slugifyHeading(headingText);
     const waveCell = `[${waveLabel}](#${anchor})`;
     lines.push(
-      `| ${waveCell} | ${statusLabel} | ${waveBar} ${wavePct}% | ${stat.stories} | ${stat.done}/${stat.tasks} |`,
+      `| ${waveCell} | ${status.label} | ${stat.stories} | ${stat.done}/${stat.tasks} |`,
     );
   }
   lines.push('');
   return lines.join('\n');
-}
-
-// Legacy `renderStoryTable` (`## Execution Plan` table + per-wave H3 rows)
-// was removed in Story #1194 Task #1212; the same surface is now produced
-// inline by `renderNestedWaveSections` below.
-
-/**
- * One-line decoder rendered as a single blockquote. Sits directly under the
- * Wave Summary TOC table (Story #1194 Task #1214) so steady-state readers can
- * decipher symbols without scrolling to the bottom <details> block.
- *
- * Pure: no inputs, no I/O. The legend mirrors the symbols emitted by
- * `deriveStorySymbol`, `deriveWaveStatusLabel`, `renderProgressBar`, and the
- * `*(after #N)*` callout from Task #1213.
- *
- * @returns {string}
- */
-export function renderInlineLegend() {
-  return [
-    '> **Legend:** Status `⬜ pending · 🔄 in-flight · ✅ done · 🚧 blocked` ·',
-    '> Wave `🚀 Ready · ⏳ Blocked · ✅ Done` · Progress `█ done / ░ remaining` ·',
-    '> `*(after #N)*` marks an in-Story dependency on Task #N.',
-  ].join('\n');
 }
 
 /**
@@ -363,36 +348,9 @@ export function computeStoryProgress(story) {
 }
 
 /**
- * Derive the per-wave status label used by both the TOC row and the H2
- * heading. Mirrors the logic in `renderWaveSections` so callers (and Task
- * #1212's nested layout) share one source of truth.
- *
- * @param {number} waveIdx                — current wave index (or -1)
- * @param {Map<number, { tasks: number, done: number }>} waveStats
- * @param {number[]} sortedWaves          — every wave index in ascending order
- * @returns {string} `'✅ Done' | '🚀 Ready' | '⏳ Blocked'`
- */
-function deriveWaveStatusLabel(waveIdx, waveStats, sortedWaves) {
-  const stat = waveStats.get(waveIdx);
-  const isDone = stat && stat.tasks > 0 && stat.done === stat.tasks;
-  if (isDone) return '✅ Done';
-  const isReady =
-    waveIdx === 0 ||
-    sortedWaves
-      .filter((sw) => sw < waveIdx)
-      .every((sw) => {
-        const swStat = waveStats.get(sw);
-        return swStat.done === swStat.tasks;
-      });
-  return isReady ? '🚀 Ready' : '⏳ Blocked';
-}
-
-/**
- * Render one `## Wave N — <Status>` section per wave with nested per-Story
- * H3 headings and inline checkbox Task lists. Replaces the legacy split
- * between `## Execution Plan` and `## Story Details` (Story #1194 Task
- * #1212): the TOC links from `renderWaveSections` jump straight into these
- * H2 anchors.
+ * Render one `## <emoji> Wave N` section per wave with nested per-Story H3
+ * headings and inline checkbox Task lists. The TOC links from
+ * `renderWaveSections` jump straight into these H2 anchors.
  *
  * @param {object[]} storyManifest
  * @returns {string} Markdown block, or empty string when nothing to render.
@@ -427,35 +385,35 @@ export function renderNestedWaveSections(storyManifest) {
     const stories = waveGroups.get(waveIdx);
     const stat = waveStats.get(waveIdx);
     const waveLabel = waveIdx === -1 ? 'Ungrouped' : `Wave ${waveIdx}`;
-    const statusLabel = deriveWaveStatusLabel(waveIdx, waveStats, sortedWaves);
+    const status = deriveWaveStatus(waveIdx, waveStats, sortedWaves);
 
     // The H2 text and slug must match `renderWaveSections` exactly so the
     // TOC links land on the right anchor.
-    lines.push(`## ${waveHeadingText(waveLabel, statusLabel)}`);
+    lines.push(`## ${waveHeadingText(waveLabel, status.emoji)}`);
     lines.push('');
 
-    // Single-line wave summary: progress + parallel hint.
-    const wavePct =
-      stat.tasks > 0 ? Math.round((stat.done / stat.tasks) * 100) : 0;
-    const parallelHint =
-      stories.length > 1
-        ? ` · ✅ ${stories.length} stories can run in parallel`
-        : '';
+    // Single-line wave summary. Add a context-specific tail only when it
+    // tells the reader something the table doesn't: which wave is gating
+    // a Blocked one, or that a Ready wave fans out in parallel.
+    let tail = '';
+    if (status.word === 'Blocked') {
+      const priorWaves = sortedWaves.filter((sw) => sw < waveIdx);
+      const lastPrior = priorWaves[priorWaves.length - 1];
+      if (lastPrior !== undefined) tail = ` · gated on Wave ${lastPrior}`;
+    } else if (status.word === 'Ready' && stories.length > 1) {
+      tail = ` · ${stories.length} run in parallel`;
+    }
     lines.push(
-      `> ${stories.length} stor${stories.length === 1 ? 'y' : 'ies'} · ${stat.done}/${stat.tasks} tasks (${wavePct}%)${parallelHint}`,
+      `> ${stories.length} stor${stories.length === 1 ? 'y' : 'ies'} · ${stat.done}/${stat.tasks} tasks${tail}`,
     );
     lines.push('');
 
     for (const story of stories) {
       const sp = computeStoryProgress(story);
-      const bar = renderProgressBar(sp.pct, { width: 10 });
       const symbol = deriveStorySymbol(story);
       const titleCandidate = story.storyTitle || story.storySlug || '';
-      // Estimate placeholder is filled in by the wave-dispatch-and-estimator
-      // story; leaving the literal `~?` keeps the column visible so the
-      // estimator drop-in doesn't have to alter the layout.
       lines.push(
-        `### ${symbol} #${story.storyId} — ${titleCandidate} · \`${story.branchName}\` · ${bar} ${sp.pct}% · ~?`,
+        `### ${symbol} #${story.storyId} — ${titleCandidate} · ${sp.done}/${sp.total} tasks`,
       );
       lines.push('');
 
@@ -568,31 +526,17 @@ function _formatManifestMarkdownUncached(manifest) {
   const lines = [];
 
   // --- Header ---
+  // Title + subtitle + a single meta line that folds the timestamp and the
+  // task / story / wave totals together. The Wave Summary table (next)
+  // breaks the totals down per wave, so a hero progress block here would
+  // just echo the same numbers a third time.
   lines.push(`# 📋 Dispatch Manifest — Epic #${epicId}`);
   lines.push('');
   lines.push(`> **${epicTitle}**`);
   lines.push('');
-  lines.push(`_Generated ${generatedAt}_`);
-  lines.push('');
-
-  // The Operating Procedures + full symbol legend now live inside the
-  // bottom `<details>` block (Story #1194 Task #1214) so steady-state
-  // readers see the Sprint Progress hero immediately.
-
-  // --- Hero Progress Bar ---
-  const pct = progress.taskPct;
-  const bar = renderProgressBar(pct);
-  const statusEmoji = pct === 100 ? '🎉' : pct >= 50 ? '🔥' : '🏗️';
-  lines.push(`## ${statusEmoji} Sprint Progress`);
-  lines.push('');
-  lines.push('```');
+  const waveCount = progress.storyWaveCount;
   lines.push(
-    `  ${bar}  ${pct}%  (${summary.doneTasks}/${summary.totalTasks} tasks)`,
-  );
-  lines.push('```');
-  lines.push('');
-  lines.push(
-    `> **Stories:** ${progress.doneStories}/${progress.totalStories} complete · **Tasks:** ${summary.doneTasks}/${summary.totalTasks} complete`,
+    `_Generated ${generatedAt} · ${summary.doneTasks}/${summary.totalTasks} tasks · ${progress.doneStories}/${progress.totalStories} stories · ${waveCount} wave${waveCount === 1 ? '' : 's'}_`,
   );
   lines.push('');
 
@@ -606,25 +550,14 @@ function _formatManifestMarkdownUncached(manifest) {
   const waveBlock = renderWaveSections(waveEligible);
   if (waveBlock) lines.push(waveBlock);
 
-  // --- Inline legend (Story #1194 Task #1214) ---
-  // Sits directly under the Wave Summary table and above the first per-wave
-  // H2 so steady-state readers can decode the symbols at a glance. The full
-  // legend (with explanations) lives in the bottom <details> block.
-  lines.push(renderInlineLegend());
-  lines.push('');
-
   // --- Per-wave H2 sections nesting Stories (H3) and Tasks (checkbox lists)
-  // (Story #1194 Task #1212): one anchor per Wave; the Wave Summary TOC
-  // jumps into these headings. Replaces the legacy `## Execution Plan` +
-  // `## Story Details` split.
   if (storyManifest && storyManifest.length > 0) {
     const nestedBlock = renderNestedWaveSections(storyManifest);
     if (nestedBlock) lines.push(nestedBlock);
   }
 
-  // --- Bottom <details> block (Story #1194 Task #1214) ---
-  // Operating procedures + full symbol legend, collapsed by default. This
-  // is the only HTML in the manifest by AC.
+  // --- Bottom <details> block: operating procedures + full symbol legend.
+  // The only HTML in the document; collapsed by default.
   lines.push(renderProceduresAndLegendDetails(epicId));
   lines.push('');
 

--- a/baselines/coverage.json
+++ b/baselines/coverage.json
@@ -810,8 +810,8 @@
     "functions": 100
   },
   ".agents/scripts/lib/presentation/manifest-formatter.js": {
-    "lines": 96.74,
-    "branches": 83.96,
+    "lines": 96.44,
+    "branches": 84.27,
     "functions": 100
   },
   ".agents/scripts/lib/presentation/manifest-persistence.js": {

--- a/baselines/crap.json
+++ b/baselines/crap.json
@@ -544,6 +544,60 @@
       "startLine": 614
     },
     {
+      "crap": 7,
+      "file": ".agents/scripts/epic-deliver-automerge.js",
+      "method": "parseAutomergeArgs",
+      "startLine": 47
+    },
+    {
+      "crap": 1,
+      "file": ".agents/scripts/epic-deliver-automerge.js",
+      "method": "buildGhMergeArgs",
+      "startLine": 79
+    },
+    {
+      "crap": 2,
+      "file": ".agents/scripts/epic-deliver-automerge.js",
+      "method": "defaultGhSpawn",
+      "startLine": 83
+    },
+    {
+      "crap": 9,
+      "file": ".agents/scripts/epic-deliver-automerge.js",
+      "method": "runEpicDeliverAutomerge",
+      "startLine": 122
+    },
+    {
+      "crap": 30,
+      "file": ".agents/scripts/epic-deliver-automerge.js",
+      "method": "main",
+      "startLine": 202
+    },
+    {
+      "crap": 3,
+      "file": ".agents/scripts/epic-deliver-cleanup.js",
+      "method": "parseCleanupArgs",
+      "startLine": 47
+    },
+    {
+      "crap": 5,
+      "file": ".agents/scripts/epic-deliver-cleanup.js",
+      "method": "runEpicDeliverCleanup",
+      "startLine": 82
+    },
+    {
+      "crap": 4,
+      "file": ".agents/scripts/epic-deliver-cleanup.js",
+      "method": "renderSummaryLines",
+      "startLine": 162
+    },
+    {
+      "crap": 30,
+      "file": ".agents/scripts/epic-deliver-cleanup.js",
+      "method": "main",
+      "startLine": 175
+    },
+    {
       "crap": 1,
       "file": ".agents/scripts/epic-deliver-finalize.js",
       "method": "buildPrCreateArgs",
@@ -596,6 +650,24 @@
       "file": ".agents/scripts/epic-deliver-finalize.js",
       "method": "main",
       "startLine": 350
+    },
+    {
+      "crap": 7,
+      "file": ".agents/scripts/epic-deliver-note-intervention.js",
+      "method": "parseNoteArgs",
+      "startLine": 48
+    },
+    {
+      "crap": 6,
+      "file": ".agents/scripts/epic-deliver-note-intervention.js",
+      "method": "runNoteIntervention",
+      "startLine": 84
+    },
+    {
+      "crap": 20,
+      "file": ".agents/scripts/epic-deliver-note-intervention.js",
+      "method": "main",
+      "startLine": 115
     },
     {
       "crap": 4.006503073718437,
@@ -2674,6 +2746,30 @@
       "startLine": 311
     },
     {
+      "crap": 3,
+      "file": ".agents/scripts/lib/orchestration/automerge-predicate.js",
+      "method": "parseSeverityCounts",
+      "startLine": 41
+    },
+    {
+      "crap": 3,
+      "file": ".agents/scripts/lib/orchestration/automerge-predicate.js",
+      "method": "<anon method-1>",
+      "startLine": 45
+    },
+    {
+      "crap": 25.015443015501585,
+      "file": ".agents/scripts/lib/orchestration/automerge-predicate.js",
+      "method": "deriveAutoMergeVerdict",
+      "startLine": 83
+    },
+    {
+      "crap": 5,
+      "file": ".agents/scripts/lib/orchestration/automerge-predicate.js",
+      "method": "evaluateAutoMergePredicate",
+      "startLine": 200
+    },
+    {
       "crap": 7.0087619547876425,
       "file": ".agents/scripts/lib/orchestration/code-review.js",
       "method": "runCodeReview",
@@ -4180,82 +4276,76 @@
       "startLine": 141
     },
     {
-      "crap": 10,
+      "crap": 6,
       "file": ".agents/scripts/lib/presentation/manifest-formatter.js",
-      "method": "renderWaveSections",
-      "startLine": 155
+      "method": "deriveWaveStatus",
+      "startLine": 158
     },
     {
-      "crap": 1,
+      "crap": 5,
       "file": ".agents/scripts/lib/presentation/manifest-formatter.js",
-      "method": "renderInlineLegend",
-      "startLine": 229
+      "method": "renderWaveSections",
+      "startLine": 182
     },
     {
       "crap": 1,
       "file": ".agents/scripts/lib/presentation/manifest-formatter.js",
       "method": "renderProceduresAndLegendDetails",
-      "startLine": 246
+      "startLine": 231
     },
     {
       "crap": 13.061588921282798,
       "file": ".agents/scripts/lib/presentation/manifest-formatter.js",
       "method": "topoSortTasks",
-      "startLine": 293
+      "startLine": 278
     },
     {
       "crap": 2,
       "file": ".agents/scripts/lib/presentation/manifest-formatter.js",
       "method": "computeStoryProgress",
-      "startLine": 357
+      "startLine": 342
     },
     {
-      "crap": 6,
-      "file": ".agents/scripts/lib/presentation/manifest-formatter.js",
-      "method": "deriveWaveStatusLabel",
-      "startLine": 375
-    },
-    {
-      "crap": 16.00014814814815,
+      "crap": 18.0001875,
       "file": ".agents/scripts/lib/presentation/manifest-formatter.js",
       "method": "renderNestedWaveSections",
-      "startLine": 400
+      "startLine": 358
     },
     {
       "crap": 1,
       "file": ".agents/scripts/lib/presentation/manifest-formatter.js",
       "method": "hashManifest",
-      "startLine": 529
+      "startLine": 487
     },
     {
       "crap": 1,
       "file": ".agents/scripts/lib/presentation/manifest-formatter.js",
       "method": "__resetManifestFormatterCache",
-      "startLine": 539
+      "startLine": 497
     },
     {
       "crap": 5,
       "file": ".agents/scripts/lib/presentation/manifest-formatter.js",
       "method": "formatManifestMarkdown",
-      "startLine": 545
+      "startLine": 503
     },
     {
-      "crap": 13.657950387700984,
+      "crap": 14.563826200895583,
       "file": ".agents/scripts/lib/presentation/manifest-formatter.js",
       "method": "_formatManifestMarkdownUncached",
-      "startLine": 565
+      "startLine": 523
     },
     {
       "crap": 4,
       "file": ".agents/scripts/lib/presentation/manifest-formatter.js",
       "method": "formatStoryManifestMarkdown",
-      "startLine": 680
+      "startLine": 613
     },
     {
       "crap": 6,
       "file": ".agents/scripts/lib/presentation/manifest-formatter.js",
       "method": "printStoryDispatchTable",
-      "startLine": 745
+      "startLine": 678
     },
     {
       "crap": 1,

--- a/baselines/maintainability.json
+++ b/baselines/maintainability.json
@@ -389,7 +389,7 @@
   "tests/lib/maintainability-engine.test.js": 107.883,
   "tests/lib/maintainability-utils-extra.test.js": 113.827,
   "tests/lib/manifest-formatter-cache.test.js": 90.952,
-  "tests/lib/manifest-formatter.test.js": 94.74,
+  "tests/lib/manifest-formatter.test.js": 93.14,
   "tests/lib/manifest-persistence.test.js": 90.804,
   "tests/lib/manifest-renderer-eligibility.test.js": 121.964,
   "tests/lib/manifest-renderer-post.test.js": 110.146,

--- a/tests/lib/manifest-formatter.test.js
+++ b/tests/lib/manifest-formatter.test.js
@@ -3,10 +3,10 @@ import test from 'node:test';
 import {
   computeProgress,
   computeStoryProgress,
+  deriveWaveStatus,
   formatManifestMarkdown,
   formatStoryManifestMarkdown,
   printStoryDispatchTable,
-  renderInlineLegend,
   renderManifestMarkdown,
   renderNestedWaveSections,
   renderProceduresAndLegendDetails,
@@ -65,25 +65,35 @@ function epicManifest(overrides = {}) {
   };
 }
 
-test('formatter: renders epic header, progress, wave TOC, and nested H2/H3 layout', () => {
+test('formatter: renders epic header, meta line, wave TOC, and nested H2/H3 layout', () => {
   const md = formatManifestMarkdown(epicManifest());
   assert.ok(md.includes('# 📋 Dispatch Manifest — Epic #42'));
   assert.ok(md.includes('> **Demo Epic**'));
-  // TOC table
+  // Meta line folds timestamp + totals on one line; no separate hero section.
+  assert.ok(md.includes('1/4 tasks · 0/2 stories · 2 waves'));
+  assert.ok(!md.includes('## 🏗️ Sprint Progress'));
+  assert.ok(!md.includes('Sprint Progress'));
+  // TOC table — no Progress column (Tasks already shows done/total).
   assert.ok(md.includes('## Wave Summary'));
-  assert.ok(md.includes('| Wave | Status | Progress | Stories | Tasks |'));
-  // Per-wave H2 sections (replace legacy Execution Plan / Story Details)
-  assert.ok(md.includes('## 🚀 Ready Wave 0'));
-  assert.ok(md.includes('## ⏳ Blocked Wave 1'));
-  // Per-Story H3 carries symbol, #id, branch in backticks, 10-cell bar
-  assert.ok(md.includes('### 🔄 #101 — '));
-  assert.ok(md.includes('`story-101`'));
+  assert.ok(md.includes('| Wave | Status | Stories | Tasks |'));
+  assert.ok(!md.includes('| Wave | Status | Progress |'));
+  // Per-wave H2 carries emoji + label only (status word lives in the TOC).
+  assert.ok(md.includes('## 🚀 Wave 0'));
+  assert.ok(md.includes('## ⏳ Wave 1'));
+  assert.ok(!md.includes('## 🚀 Ready Wave 0'));
+  // Per-Story H3 carries symbol, #id, title, done/total tasks. No branch
+  // backticks, no progress bar, no `~?` ETA placeholder.
+  assert.ok(md.includes('### 🔄 #101 — Alpha Story · 1/2 tasks'));
+  assert.ok(!md.includes('`story-101`'));
+  assert.ok(!md.includes('~?'));
   // Tasks render as plain checkbox lines
   assert.ok(md.includes('- [x] #201 — t-a1'));
   assert.ok(md.includes('- [ ] #203 — t-b1'));
   // Legacy headings are gone
   assert.ok(!md.includes('## Execution Plan'));
   assert.ok(!md.includes('## Story Details'));
+  // Inline legend blockquote retired — full legend lives in <details>.
+  assert.ok(!md.includes('**Legend:**'));
 });
 
 test('formatter: feature containers row when features present', () => {
@@ -240,22 +250,26 @@ test('renderProgressBar: respects custom width and clamps out-of-range input', (
   assert.equal(renderProgressBar(-10, { width: 4 }), '░░░░');
 });
 
-test('renderWaveSections: renders one row per wave with status & mini bar', () => {
+test('renderWaveSections: renders one row per wave with status (no Progress column)', () => {
   const md = renderWaveSections(epicManifest().storyManifest);
   assert.ok(md.includes('## Wave Summary'));
-  assert.ok(md.includes('| Wave | Status | Progress | Stories | Tasks |'));
-  // The wave-cell is now a markdown link to the corresponding H2 anchor.
+  assert.ok(md.includes('| Wave | Status | Stories | Tasks |'));
+  assert.ok(!md.includes('| Wave | Status | Progress |'));
+  // The wave-cell is a markdown link to the corresponding H2 anchor.
   assert.ok(md.includes('| [Wave 0](#'));
   assert.ok(md.includes('| [Wave 1](#'));
   assert.ok(md.includes('🚀 Ready'));
   assert.ok(md.includes('⏳ Blocked'));
 });
 
-test('renderWaveSections: each TOC row links to the slug of its wave heading', () => {
+test('renderWaveSections: each TOC row links to the slug of its emoji-only wave heading', () => {
   const md = renderWaveSections(epicManifest().storyManifest);
-  // Wave 0 (no prior waves) is Ready; Wave 1 depends on incomplete Wave 0 → Blocked.
-  const expectedW0 = `#${slugifyHeading(waveHeadingText('Wave 0', '🚀 Ready'))}`;
-  const expectedW1 = `#${slugifyHeading(waveHeadingText('Wave 1', '⏳ Blocked'))}`;
+  // The H2 emits `## <emoji> Wave N`, so the TOC anchor strips the emoji
+  // and produces `wave-N`.
+  const expectedW0 = `#${slugifyHeading(waveHeadingText('Wave 0', '🚀'))}`;
+  const expectedW1 = `#${slugifyHeading(waveHeadingText('Wave 1', '⏳'))}`;
+  assert.equal(expectedW0, '#wave-0');
+  assert.equal(expectedW1, '#wave-1');
   assert.ok(
     md.includes(`| [Wave 0](${expectedW0}) |`),
     `expected Wave 0 link to ${expectedW0}`,
@@ -264,6 +278,30 @@ test('renderWaveSections: each TOC row links to the slug of its wave heading', (
     md.includes(`| [Wave 1](${expectedW1}) |`),
     `expected Wave 1 link to ${expectedW1}`,
   );
+});
+
+test('deriveWaveStatus: returns emoji + word + label for Ready / Blocked / Done', () => {
+  const stats = new Map([
+    [0, { tasks: 2, done: 2 }],
+    [1, { tasks: 2, done: 0 }],
+    [2, { tasks: 2, done: 0 }],
+  ]);
+  const sorted = [0, 1, 2];
+  assert.deepEqual(deriveWaveStatus(0, stats, sorted), {
+    emoji: '✅',
+    word: 'Done',
+    label: '✅ Done',
+  });
+  assert.deepEqual(deriveWaveStatus(1, stats, sorted), {
+    emoji: '🚀',
+    word: 'Ready',
+    label: '🚀 Ready',
+  });
+  assert.deepEqual(deriveWaveStatus(2, stats, sorted), {
+    emoji: '⏳',
+    word: 'Blocked',
+    label: '⏳ Blocked',
+  });
 });
 
 test('slugifyHeading: lowercases ASCII headings', () => {
@@ -315,7 +353,7 @@ test('renderWaveSections: marks a wave done when every task completed', () => {
   assert.ok(md.includes('✅ Done'));
 });
 
-test('renderNestedWaveSections: emits one ## Wave H2 per wave with H3 stories and checkbox tasks', () => {
+test('renderNestedWaveSections: emits one ## emoji Wave N H2 per wave with H3 stories and checkbox tasks', () => {
   const manifest = epicManifest();
   manifest.storyManifest.push({
     storyId: 103,
@@ -327,18 +365,29 @@ test('renderNestedWaveSections: emits one ## Wave H2 per wave with H3 stories an
     tasks: [{ taskId: 205, taskSlug: 't-c1', status: 'agent::ready' }],
   });
   const md = renderNestedWaveSections(manifest.storyManifest);
-  // One H2 per wave; legacy headings gone
+  // One H2 per wave; legacy headings gone; status word stays out of the
+  // heading (it's already in the Wave Summary table).
   assert.ok(!md.includes('## Execution Plan'));
   assert.ok(!md.includes('## Story Details'));
-  const w0 = md.match(/^## 🚀 Ready Wave 0$/gm) || [];
-  const w1 = md.match(/^## ⏳ Blocked Wave 1$/gm) || [];
+  const w0 = md.match(/^## 🚀 Wave 0$/gm) || [];
+  const w1 = md.match(/^## ⏳ Wave 1$/gm) || [];
   assert.equal(w0.length, 1, 'exactly one Wave 0 H2');
   assert.equal(w1.length, 1, 'exactly one Wave 1 H2');
-  // Single-line wave summary with parallel hint when stories > 1
-  assert.ok(md.includes('✅ 2 stories can run in parallel'));
-  // Per-Story H3 carries symbol, #id, branch in backticks, 10-cell bar
-  assert.ok(md.includes('### 🔄 #101 — Alpha Story · `story-101` ·'));
-  assert.ok(md.match(/### 🔄 #101.*[█░]{10}/));
+  // Wave 1 is Blocked → tail names the gating wave.
+  assert.ok(md.includes('· gated on Wave 0'));
+  // Wave 0 is Ready with 1 story → no parallel tail.
+  // Switch Story 103 into Wave 0 to exercise the parallel hint.
+  const md2 = renderNestedWaveSections([
+    ...manifest.storyManifest.slice(0, 1),
+    { ...manifest.storyManifest[2], earliestWave: 0 },
+  ]);
+  assert.ok(md2.includes('· 2 run in parallel'));
+  // Per-Story H3: symbol + #id + title + done/total tasks; no branch
+  // backticks, no progress bar, no `~?` ETA placeholder.
+  assert.ok(md.includes('### 🔄 #101 — Alpha Story · 1/2 tasks'));
+  assert.ok(!md.includes('`story-101`'));
+  assert.ok(!md.includes('~?'));
+  assert.ok(!/### 🔄 #101.*[█░]/.test(md));
   // Tasks rendered as plain checkbox lines (no HTML, no bold)
   assert.ok(md.includes('- [x] #201 — t-a1'));
   assert.ok(md.includes('- [ ] #205 — t-c1'));
@@ -570,25 +619,8 @@ test('computeStoryProgress: derives pct, done, total from story.tasks[]', () => 
 });
 
 // ---------------------------------------------------------------------------
-// Inline legend + bottom <details> block (Story #1194 Task #1214)
+// Bottom <details> block (operating procedures + full symbol legend)
 // ---------------------------------------------------------------------------
-
-test('renderInlineLegend: renders a single blockquote covering every emitted symbol', () => {
-  const md = renderInlineLegend();
-  // Every line in the legend must be a blockquote line.
-  for (const line of md.split('\n')) {
-    assert.ok(line.startsWith('> '), `legend line not blockquote: "${line}"`);
-  }
-  // Decoder mentions every symbol family the manifest emits.
-  assert.match(md, /⬜.*pending/);
-  assert.match(md, /🔄.*in-flight/);
-  assert.match(md, /✅.*done/);
-  assert.match(md, /🚧.*blocked/i);
-  assert.match(md, /🚀 Ready/);
-  assert.match(md, /⏳ Blocked/);
-  assert.match(md, /█.*░/);
-  assert.match(md, /\*\(after #N\)\*/);
-});
 
 test('renderProceduresAndLegendDetails: emits exactly one <details>/</details> pair', () => {
   const md = renderProceduresAndLegendDetails(42);
@@ -609,7 +641,7 @@ test('renderProceduresAndLegendDetails: emits exactly one <details>/</details> p
   assert.match(md, /\/epic-deliver 42/);
 });
 
-test('formatManifestMarkdown: bottom <details> block is the only HTML; inline legend sits between TOC and first H2', () => {
+test('formatManifestMarkdown: bottom <details> block is the only HTML; first wave H2 follows the TOC directly', () => {
   const md = formatManifestMarkdown(epicManifest());
   // Exactly one <details> tag pair in the entire rendered document.
   assert.equal(
@@ -625,21 +657,21 @@ test('formatManifestMarkdown: bottom <details> block is the only HTML; inline le
   // Strip the details block, then assert the rest contains no HTML tags.
   const detailsRe = /<details>[\s\S]*?<\/details>/;
   const outsideDetails = md.replace(detailsRe, '');
-  // Match any HTML tag outside the details block.
   const stray = outsideDetails.match(/<[a-zA-Z/][^>]*>/g) || [];
   assert.deepEqual(
     stray,
     [],
     `unexpected HTML tags outside <details> block: ${JSON.stringify(stray)}`,
   );
-  // Inline legend sits between the Wave Summary table and the first wave H2.
-  const tocPos = md.indexOf('| Wave | Status | Progress | Stories | Tasks |');
-  const legendPos = md.indexOf('**Legend:**');
-  const firstH2Pos = md.search(/^## 🚀 Ready Wave 0$/m);
+  // No inline legend — full legend lives in <details> only.
+  assert.ok(!md.includes('**Legend:**'));
+  // First wave H2 follows the TOC table directly.
+  const tocPos = md.indexOf('| Wave | Status | Stories | Tasks |');
+  const firstH2Pos = md.search(/^## 🚀 Wave 0$/m);
   assert.ok(tocPos >= 0, 'TOC table missing');
-  assert.ok(legendPos > tocPos, 'inline legend should follow the TOC table');
-  assert.ok(firstH2Pos > legendPos, 'first wave H2 should follow the legend');
-  // No top-level "## 🤖 Agent Operating Procedures" anymore — that moved
-  // into the bottom <details> block.
+  assert.ok(firstH2Pos > tocPos, 'first wave H2 should follow the TOC');
+  // No top-level "## 🤖 Agent Operating Procedures" or Sprint Progress
+  // headings anymore — both folded into the meta line / details block.
   assert.ok(!md.includes('## 🤖 Agent Operating Procedures'));
+  assert.ok(!md.includes('Sprint Progress'));
 });

--- a/tests/lib/manifest-renderer.test.js
+++ b/tests/lib/manifest-renderer.test.js
@@ -31,7 +31,7 @@ test('manifest-renderer: renders simple manifest', () => {
   // Verify Wave Header and Table Structure
   assert.ok(output.includes('## Wave Summary'), 'Missing waves section');
   assert.ok(
-    output.includes('| Wave | Status | Progress | Stories | Tasks |'),
+    output.includes('| Wave | Status | Stories | Tasks |'),
     'Missing wave summary table header',
   );
   assert.ok(output.includes('Wave 1'), 'Missing wave row data');

--- a/tests/lib/presentation/manifest-formatter-end-to-end.test.js
+++ b/tests/lib/presentation/manifest-formatter-end-to-end.test.js
@@ -1,50 +1,28 @@
 /**
- * End-to-end manifest regeneration fixture (Story #1198 Task #1230).
+ * End-to-end manifest regeneration fixture.
  *
  * Renders a synthetic Epic with multiple waves, a cross-Story Task
  * dependency that survives Story-edge promotion, and inferred
  * file-contention edges through `formatManifestMarkdown`, then asserts
- * every Acceptance-Criteria item from the PRD's Manifest-rendering
- * section. This is the canonical regression for Epic #1178 — referenced
- * from `docs/CHANGELOG.md`.
+ * the post-cleanup layout (see `feat/manifest-ux-cleanup`):
  *
- * Coverage matrix (PRD Manifest-rendering AC → assertion):
- *
- *   • single nested Wave → Story → Task layout
- *       → no `## Execution Plan` / `## Story Details` headings
- *   • Sprint summary at top
- *       → `## 🏗️ Sprint Progress` heading + done/total counts
- *   • Wave Summary TOC table with anchor links
- *       → every `[Wave N](#…)` link round-trips to a real H2 anchor via
- *         `slugifyHeading`
- *   • inline legend blockquote between TOC and first wave H2
- *   • per-wave H2 nests Stories with branch + per-Story progress bar +
- *     per-Story estimate placeholder
- *       → `### <symbol> #<id> — <title> · \`story-<id>\` · <bar> N% · ~?`
- *   • Tasks rendered in execution order with `*(after #N)*` for in-Story
- *     dependencies; cross-Story dependencies do NOT render as `*(after #)*`
- *     (they are handled at the wave-ordering layer by the analyzer's
- *     Story-edge promotion in `dependency-analyzer.js`)
- *   • native `- [ ]` / `- [x]` checkboxes everywhere; no HTML inside task
- *     lines
- *   • exactly one bottom `<details>` block; no other HTML tags anywhere
- *   • TOC link slugs match the H2 emoji-prefixed text via `slugifyHeading`
- *
- * Per-Story progress bar derived from `tasks[].status` is exercised by
- * mixing `agent::done`, `agent::executing`, `agent::ready`, and
- * `agent::blocked` Task statuses across the synthetic fixture.
- *
- * Deferred AC documentation:
- *
- *   The PRD also lists `Dispatch (⌈N/cap⌉ rounds)` + `Est. wall-clock`
- *   Wave Summary columns, calibrated estimator range display
- *   (P25–P75), and a per-wave "Decomposition notes" subsection driven by
- *   `analysis.decompositionNotes`. The renderer integration for those
- *   items did not land on `epic/1178` (Stories #1195 / #1196 closed
- *   without their formatter wiring reaching the Epic branch). The
- *   fixture asserts the *current* shipped output exactly so any future
- *   wiring patch will trip these locks and force the author to extend
- *   the assertions in lock-step.
+ *   • Title + subtitle + a single `_Generated …_` meta line that folds
+ *     timestamp + done/total tasks + done/total stories + wave count
+ *     (no separate Sprint Progress hero block, no follow-on counts
+ *     blockquote).
+ *   • Wave Summary TOC table — `Wave | Status | Stories | Tasks` (no
+ *     Progress column; the Tasks cell already shows done/total).
+ *   • Per-wave `## <emoji> Wave N` H2 (status word lives only in the
+ *     TOC). Each H2 is followed by a one-line blockquote that adds a
+ *     "gated on Wave M" tail for Blocked waves and a "N run in parallel"
+ *     tail for Ready waves with multiple Stories.
+ *   • Per-Story `### <symbol> #<id> — <title> · X/Y tasks` H3 (no branch
+ *     backticks, no progress bar, no `~?` ETA placeholder).
+ *   • Tasks render as native `- [x]`/`- [ ]` checkboxes in topo order
+ *     with `*(after #N)*` callouts for in-Story dependencies only.
+ *   • Exactly one bottom `<details>` block carrying the operating
+ *     procedures + full symbol legend; no other HTML anywhere.
+ *   • TOC anchors round-trip to the matching H2 via `slugifyHeading`.
  */
 
 import assert from 'node:assert/strict';
@@ -165,14 +143,19 @@ test('e2e fixture: layout has no legacy Execution Plan / Story Details headings'
   );
 });
 
-test('e2e fixture: Sprint Progress hero shows done/total task counts', () => {
+test('e2e fixture: header meta line folds done/total tasks + stories + wave count', () => {
   __resetManifestFormatterCache();
   const md = formatManifestMarkdown(buildE2EFixture());
-  assert.match(md, /^## (?:🏗️|🔥|🎉) Sprint Progress$/m);
-  // Hero progress bar carries the literal `(4/14 tasks)` count.
-  assert.match(md, /\(4\/14 tasks\)/);
-  // The per-Story counts surface in a follow-on blockquote.
-  assert.match(md, /\*\*Stories:\*\* \d+\/5 complete · \*\*Tasks:\*\* 4\/14/);
+  // No Sprint Progress hero anymore — meta line carries the totals.
+  assert.doesNotMatch(md, /Sprint Progress/);
+  assert.doesNotMatch(md, /^## (?:🏗️|🔥|🎉)/m);
+  // Single `_Generated …_` line carries timestamp + tasks + stories +
+  // wave count. Story #100 is the only one with all tasks done; the
+  // fixture has 5 stories total.
+  assert.match(
+    md,
+    /_Generated 2026-05-11T00:00:00\.000Z · 4\/14 tasks · 0\/5 stories · 3 waves_/,
+  );
 });
 
 test('e2e fixture: every Wave Summary TOC link round-trips to a real H2 anchor', () => {
@@ -197,34 +180,46 @@ test('e2e fixture: every Wave Summary TOC link round-trips to a real H2 anchor',
   }
 });
 
-test('e2e fixture: inline legend blockquote sits between the TOC table and the first wave H2', () => {
+test('e2e fixture: first wave H2 follows the TOC table directly (no inline legend)', () => {
   __resetManifestFormatterCache();
   const md = formatManifestMarkdown(buildE2EFixture());
-  const tocPos = md.indexOf('| Wave | Status | Progress | Stories | Tasks |');
-  const legendPos = md.indexOf('**Legend:**');
-  const firstH2Pos = md.search(/^## (?:🚀 Ready|✅ Done|⏳ Blocked) Wave 0$/m);
+  const tocPos = md.indexOf('| Wave | Status | Stories | Tasks |');
+  const firstH2Pos = md.search(/^## (?:🚀|✅|⏳) Wave 0$/m);
   assert.ok(tocPos > 0, 'TOC table must render');
-  assert.ok(legendPos > tocPos, 'inline legend must sit after the TOC');
-  assert.ok(firstH2Pos > legendPos, 'first wave H2 must sit after the legend');
+  assert.ok(firstH2Pos > tocPos, 'first wave H2 must sit after the TOC');
+  // Inline legend was retired — full legend lives in the bottom <details>.
+  assert.doesNotMatch(md, /\*\*Legend:\*\*/);
 });
 
-test('e2e fixture: per-Story heading carries branch name, progress bar, percent, and estimate placeholder', () => {
+test('e2e fixture: per-Story heading carries done/total tasks (no branch, no bar, no ~?)', () => {
   __resetManifestFormatterCache();
   const md = formatManifestMarkdown(buildE2EFixture());
-  // Story #100: 2 of 3 tasks done → 67%.
+  // Story #100: 2 of 3 tasks done.
   assert.match(
     md,
-    /^### .* #100 — Sprint Bootstrap · `story-100` · [█░]+ 67% · ~\?$/m,
-    'Story #100 heading must carry branch + progress bar + 67% + ~? estimate',
+    /^### .* #100 — Sprint Bootstrap · 2\/3 tasks$/m,
+    'Story #100 heading must carry done/total tasks',
   );
-  // Story #200: 0 of 3 done → 0%.
+  // Story #200: 0 of 3 done.
   assert.match(
     md,
-    /^### .* #200 — Render TOC · `story-200` · [█░]+ 0% · ~\?$/m,
-    'Story #200 heading must carry branch + progress bar + 0% + ~? estimate',
+    /^### .* #200 — Render TOC · 0\/3 tasks$/m,
+    'Story #200 heading must carry done/total tasks',
   );
   // Story #300 has a blocked Task → 🚧 symbol on the H3.
   assert.match(md, /^### 🚧 #300 — Order Tasks/m);
+  // Decorations the old format carried are gone everywhere.
+  assert.doesNotMatch(md, /`story-\d+`/, 'no branch backticks in H3s');
+  assert.doesNotMatch(md, /~\?/, 'no ETA placeholder');
+  // Per-Story progress bar removed (the long `[█░]+ NN%` ribbon is gone).
+  assert.doesNotMatch(
+    md
+      .split('\n')
+      .filter((l) => l.startsWith('### '))
+      .join('\n'),
+    /[█░]/,
+    'no progress bar in H3s',
+  );
 });
 
 test('e2e fixture: in-Story Task dependency renders as `*(after #N)*`; cross-Story dep does NOT', () => {

--- a/tests/lib/presentation/manifest-formatter-layout.test.js
+++ b/tests/lib/presentation/manifest-formatter-layout.test.js
@@ -1,14 +1,15 @@
 /**
- * End-to-end manifest layout fixture (Story #1194 Task #1215).
+ * End-to-end manifest layout fixture.
  *
  * Renders a synthetic 4-wave / 7-Story / 19-Task manifest through
  * `formatManifestMarkdown` and asserts the structural invariants of the
- * nested Wave → Story → Task layout shipped by Tasks #1210–#1214:
+ * post-cleanup layout (see `feat/manifest-ux-cleanup`):
  *
  *   • No legacy `## Execution Plan` or `## Story Details` headings.
  *   • Every Wave Summary TOC link round-trips to a real H2 anchor via
  *     the `slugifyHeading` helper.
- *   • An inline legend blockquote sits between the TOC and the first H2.
+ *   • The first wave H2 follows the TOC table directly — no inline
+ *     legend blockquote.
  *   • Exactly one bottom `<details>` block; no other HTML tags appear
  *     anywhere else in the rendered output.
  *   • Every Task line uses native markdown checkboxes (`- [ ]` / `- [x]`)
@@ -159,18 +160,15 @@ test('layout fixture: every Wave Summary TOC link round-trips to a real H2 ancho
   }
 });
 
-test('layout fixture: inline legend blockquote sits directly between TOC and first wave H2', () => {
+test('layout fixture: first wave H2 follows the TOC table directly (no inline legend)', () => {
   __resetManifestFormatterCache();
   const md = formatManifestMarkdown(buildLayoutFixture());
-  const tocPos = md.indexOf('| Wave | Status | Progress | Stories | Tasks |');
-  const legendPos = md.indexOf('**Legend:**');
-  const firstH2Pos = md.search(/^## (?:🚀 Ready|✅ Done|⏳ Blocked) Wave 0$/m);
+  const tocPos = md.indexOf('| Wave | Status | Stories | Tasks |');
+  const firstH2Pos = md.search(/^## (?:🚀|✅|⏳) Wave 0$/m);
   assert.ok(tocPos >= 0, 'TOC table missing');
-  assert.ok(legendPos > tocPos, 'inline legend should sit after the TOC table');
-  assert.ok(
-    firstH2Pos > legendPos,
-    'first wave H2 should sit after the inline legend',
-  );
+  assert.ok(firstH2Pos > tocPos, 'first wave H2 should sit after the TOC');
+  // Inline legend retired — full legend lives in the bottom <details>.
+  assert.doesNotMatch(md, /\*\*Legend:\*\*/);
 });
 
 test('layout fixture: exactly one bottom <details> block, no other HTML tags anywhere', () => {

--- a/tests/manifest-renderer.test.js
+++ b/tests/manifest-renderer.test.js
@@ -80,7 +80,7 @@ test('renderManifestMarkdown', async (t) => {
     assert.match(output, /\/epic-deliver/);
   });
 
-  await t.test('renders 0% progress bar when no tasks done', () => {
+  await t.test('header meta line carries done/total task counts', () => {
     const manifest = makeBaseManifest({
       summary: {
         totalTasks: 4,
@@ -91,39 +91,11 @@ test('renderManifestMarkdown', async (t) => {
       },
     });
     const output = renderManifestMarkdown(manifest);
-    assert.match(output, /0%/);
     assert.match(output, /0\/4 tasks/);
-    // Should use construction emoji for 0%
-    assert.match(output, /🏗️/);
-  });
-
-  await t.test('renders 100% progress bar and celebration emoji', () => {
-    const manifest = makeBaseManifest({
-      summary: {
-        totalTasks: 4,
-        doneTasks: 4,
-        progressPercent: 100,
-        totalWaves: 1,
-        dispatched: 4,
-      },
-    });
-    const output = renderManifestMarkdown(manifest);
-    assert.match(output, /100%/);
-    assert.match(output, /🎉/);
-  });
-
-  await t.test('renders fire emoji for 50%+ progress', () => {
-    const manifest = makeBaseManifest({
-      summary: {
-        totalTasks: 4,
-        doneTasks: 2,
-        progressPercent: 50,
-        totalWaves: 1,
-        dispatched: 2,
-      },
-    });
-    const output = renderManifestMarkdown(manifest);
-    assert.match(output, /🔥/);
+    // Hero progress block + status emoji are gone — the meta line carries
+    // the totals and the Wave Summary table breaks them down per wave.
+    assert.doesNotMatch(output, /Sprint Progress/);
+    assert.doesNotMatch(output, /🏗️|🔥|🎉/);
   });
 
   await t.test('renders wave summary table for stories', () => {


### PR DESCRIPTION
## Summary

Cuts redundancy and presentation chrome from the Epic dispatch manifest so it reads cleanly when the agent runs an Epic end-to-end. Behaviour preserved: checkboxes still drive workflow state, `*(after #N)*` callouts still mark in-Story dependencies, the TOC → H2 anchor round-trip still works.

**Specific changes:**

- Drop `## Sprint Progress` hero + the follow-on `Stories/Tasks complete` blockquote. Their numbers fold into a single `_Generated …_` meta line under the title (timestamp + done/total tasks + done/total stories + wave count). The Wave Summary table breaks the same totals down per wave, so the hero was a third echo.
- Drop the `Progress` column from the Wave Summary table — `Tasks` already shows `done/total`; the bar + percent didn't add signal.
- Drop the inline `Legend:` blockquote between the TOC and the first wave H2. Full legend stays in the bottom `<details>` block.
- Per-wave H2 becomes `## <emoji> Wave N` (status word lives only in the TOC, not echoed in the heading).
- Per-Story H3 trims to `### <symbol> #<id> — <title> · X/Y tasks`. Branch backticks, per-Story progress bar, and the `~?` ETA placeholder are gone.
- Per-wave summary blockquote tail now only appears when it adds signal: the gating wave for Blocked rows, or "N run in parallel" for Ready rows with multiple Stories.

**Baseline refresh commits:**

- `tests/lib/manifest-formatter.test.js` maintainability 94.74 → 93.14 (one new test, expanded assertions; file size, no extra complexity).
- `.agents/scripts/lib/presentation/manifest-formatter.js` coverage 96.74 → 96.44 lines, 83.96 → 84.27 branches (removed code that was previously exercised).
- CRAP refresh covers the slight bump in `renderNestedWaveSections` + `_formatManifestMarkdownUncached` and drains four files added by PR #1275 that weren't yet in the CRAP baseline.

## Test plan

- [x] `node --test tests/lib/manifest-formatter.test.js tests/lib/manifest-renderer.test.js tests/manifest-renderer.test.js tests/lib/presentation/manifest-formatter-end-to-end.test.js tests/lib/presentation/manifest-formatter-layout.test.js` — all pass
- [x] `npm test` — 2913 / 2915 pass (2 pre-existing skips, 0 fails)
- [x] `npm run lint` — clean
- [ ] Regenerate `temp/epic-1143/manifest.md` and `temp/epic-1185/manifest.md` from their existing dispatch-manifest comments and eyeball-check the new layout

🤖 Generated with [Claude Code](https://claude.com/claude-code)