### PR TITLE
feat(single-story-execute): standalone Story workflow for top-level work units

### DIFF
--- a/.agents/scripts/single-story-close.js
+++ b/.agents/scripts/single-story-close.js
@@ -1,0 +1,330 @@
+#!/usr/bin/env node
+/* node:coverage ignore file */
+
+/**
+ * single-story-close.js — Close a standalone Story (no parent Epic).
+ *
+ * Counterpart to `story-close.js` for the `/single-story-execute` workflow.
+ * The framework's main `story-close.js` runs pre-merge gates with
+ * baseline-attribution wiring, merges into `epic/<id>` --no-ff, pushes the
+ * Epic branch, cascades to the parent Feature/Epic, regenerates the
+ * dispatch manifest, and refreshes the dashboard. None of that applies to
+ * a standalone Story — its target is `main`, its merge mechanism is a
+ * human-approved PR, and there is no parent to cascade to.
+ *
+ * What this script does:
+ *   1. Resolve the worktree path (if worktree isolation is enabled).
+ *   2. Run the canonical close-validation gate chain (typecheck, lint,
+ *      test, format, maintainability, coverage, crap) against
+ *      `agentSettings.baseBranch` as the baseline ref. `--skip-validation`
+ *      bypasses this step.
+ *   3. Push the Story branch to `origin`.
+ *   4. Open (or reuse) a PR against `baseBranch` via `gh pr create`. The
+ *      PR body carries `Closes #<storyId>` so the GitHub merge auto-closes
+ *      the issue when the operator merges.
+ *   5. Flip the Story to `agent::done` (PR merge handles the issue close).
+ *   6. Reap the worktree when `reapOnSuccess` is enabled.
+ *
+ * What this script does NOT do (and why):
+ *   - Skips the epic-merge-lock — no concurrent Stories to serialize.
+ *   - Skips `dispatchRecovery` — no resume-from-conflict state machine.
+ *   - Skips `runAutoRefresh` — bounded-baseline drift is an Epic concern.
+ *   - Skips `runPostMergePipeline` — no cascade, no dashboard, no manifest.
+ *   - Does NOT merge to `main` directly — the PR is the human gate. The
+ *     Story branch stays alive until the operator merges; the worktree is
+ *     reaped after the PR opens because the branch is no longer needed
+ *     locally.
+ *
+ * Usage:
+ *   node single-story-close.js --story <STORY_ID> [--cwd <main-repo>]
+ *                              [--skip-validation]
+ *
+ * Exit codes: 0 ok, 1 error.
+ *
+ * @see .agents/workflows/single-story-execute.md
+ */
+
+import { execFileSync } from 'node:child_process';
+import nodeFs from 'node:fs';
+import path from 'node:path';
+import { parseSprintArgs } from './lib/cli-args.js';
+import { runAsCli } from './lib/cli-utils.js';
+import {
+  buildDefaultGates,
+  runCloseValidation,
+} from './lib/close-validation.js';
+import { PROJECT_ROOT, resolveConfig } from './lib/config-resolver.js';
+import { getStoryBranch, gitSync } from './lib/git-utils.js';
+import { Logger } from './lib/Logger.js';
+import { clearActiveStoryEnv } from './lib/observability/active-story-env.js';
+import { createProvider } from './lib/provider-factory.js';
+import { WorktreeManager } from './lib/worktree-manager.js';
+
+const progress = Logger.createProgress('single-story-close', { stderr: true });
+
+/**
+ * Close a standalone Story. Exported for testing.
+ */
+export async function runSingleStoryClose({
+  storyId: storyIdParam,
+  cwd: cwdParam,
+  skipValidation: skipValidationParam,
+  injectedProvider,
+  injectedConfig,
+} = {}) {
+  const parsed =
+    storyIdParam !== undefined
+      ? {
+          storyId: storyIdParam,
+          cwd: cwdParam ?? null,
+          skipValidation: !!skipValidationParam,
+        }
+      : parseSprintArgs();
+  const { storyId } = parsed;
+  const skipValidation = skipValidationParam ?? parsed.skipValidation ?? false;
+  const cwd = path.resolve(cwdParam ?? parsed.cwd ?? PROJECT_ROOT);
+
+  if (!storyId) {
+    Logger.fatal(
+      'Usage: node single-story-close.js --story <STORY_ID> [--cwd <main-repo>] [--skip-validation]',
+    );
+  }
+
+  const config = injectedConfig || resolveConfig({ cwd });
+  const { agentSettings, orchestration } = config;
+  const provider = injectedProvider || createProvider(orchestration);
+
+  const baseBranch = agentSettings.baseBranch ?? 'main';
+  const storyBranch = getStoryBranch(0, storyId);
+
+  progress('INIT', `Closing standalone Story #${storyId}...`);
+
+  const story = await provider.getTicket(storyId);
+  if (story.state === 'closed') {
+    progress('NOOP', `Story #${storyId} is already closed. Nothing to do.`);
+    return {
+      success: true,
+      result: {
+        storyId,
+        standalone: true,
+        action: 'noop',
+        reason: 'already-closed',
+      },
+    };
+  }
+
+  // Resolve worktree path (read-only check — does the dir exist on disk?).
+  const worktreeRoot = orchestration?.worktreeIsolation?.root ?? '.worktrees';
+  const worktreePathCandidate = path.resolve(
+    cwd,
+    worktreeRoot,
+    `story-${storyId}`,
+  );
+  const worktreePath = nodeFs.existsSync(worktreePathCandidate)
+    ? worktreePathCandidate
+    : null;
+
+  // Step 1: gates. The standalone path uses the canonical close-validation
+  // chain so the experience matches Epic-attached Stories — only the
+  // baseline ref changes (main, not epic/<id>).
+  if (!skipValidation) {
+    progress(
+      'VALIDATE',
+      `Running close-validation gates against baseline ${baseBranch}${worktreePath ? ` in ${worktreePath}` : ''}...`,
+    );
+    const validation = await runCloseValidation({
+      cwd,
+      worktreePath,
+      gates: buildDefaultGates({ agentSettings, epicBranch: baseBranch }),
+      log: (m) => Logger.info(m),
+      storyId,
+      // useEvidence requires both storyId AND epicId; pass 0 to satisfy
+      // the predicate so the per-Story evidence cache is reused across
+      // re-runs of close on the same SHA.
+      epicId: 0,
+    });
+    if (!validation.ok) {
+      const [first] = validation.failed;
+      const { gate, status, cwd: gateCwd } = first;
+      throw new Error(
+        `[single-story-close] Gate failed: ${gate.name} (exit ${status})${gateCwd ? ` in ${gateCwd}` : ''}.` +
+          (gate.hint ? ` ${gate.hint}` : ''),
+      );
+    }
+    progress('VALIDATE', '✅ All gates passed.');
+  } else {
+    progress('VALIDATE', '⏭ Skipped (--skip-validation).');
+  }
+
+  // Step 2: push the Story branch. `git push -u` makes the local branch
+  // track origin/story-<id> so subsequent fetches are cheap.
+  progress('GIT', `Pushing ${storyBranch} to origin...`);
+  try {
+    gitSync(cwd, 'push', '--no-verify', '-u', 'origin', storyBranch);
+    progress('GIT', `✅ Pushed ${storyBranch}.`);
+  } catch (err) {
+    throw new Error(
+      `[single-story-close] git push failed for ${storyBranch}: ${err?.message ?? err}`,
+    );
+  }
+
+  // Step 3: open (or reuse) a PR to `baseBranch`. `gh pr view --head` is
+  // not available on all gh versions, so we probe with `gh pr list
+  // --head <branch>` and fall back to `gh pr create`.
+  const prUrl = ensurePullRequest({
+    cwd,
+    storyId,
+    storyTitle: story.title,
+    storyBranch,
+    baseBranch,
+  });
+
+  // Step 4: flip Story label to agent::done. The GitHub issue stays open
+  // until the operator merges the PR (which fires the `Closes #<id>`
+  // auto-close).
+  try {
+    const labels = (story.labels || [])
+      .filter((l) => !l.startsWith('agent::'))
+      .concat('agent::done');
+    await provider.updateTicket(storyId, { labels });
+    progress('LABELS', `🏷️  Story #${storyId} → agent::done`);
+  } catch (err) {
+    Logger.error(
+      `[single-story-close] ⚠️ Failed to flip Story labels: ${err?.message ?? err}`,
+    );
+  }
+
+  // Step 5: reap worktree. The branch is still alive on origin so the PR
+  // can land; the local worktree is no longer needed.
+  let worktreeReaped = false;
+  const reapEnabled = orchestration?.worktreeIsolation?.reapOnSuccess !== false;
+  if (worktreePath && reapEnabled) {
+    try {
+      const wm = new WorktreeManager({
+        repoRoot: cwd,
+        config: orchestration?.worktreeIsolation,
+        logger: {
+          info: (m) => progress('WORKTREE', m),
+          warn: (m) => progress('WORKTREE', `⚠️ ${m}`),
+          error: (m) => Logger.error(`[single-story-close] ${m}`),
+        },
+      });
+      await wm.reap(storyId);
+      worktreeReaped = true;
+      progress('WORKTREE', `🧹 Reaped worktree for story-${storyId}.`);
+    } catch (err) {
+      Logger.error(
+        `[single-story-close] ⚠️ Failed to reap worktree: ${err?.message ?? err}`,
+      );
+    }
+  }
+
+  // Clear the trace-hook env vars so subsequent tooling falls back to the
+  // no-op branch instead of pointing at a (now-reaped) worktree.
+  try {
+    clearActiveStoryEnv({
+      logger: { warn: (m) => progress('ENV', `⚠️ ${m}`) },
+    });
+  } catch {
+    // Non-fatal.
+  }
+
+  const result = {
+    storyId,
+    standalone: true,
+    storyBranch,
+    baseBranch,
+    prUrl,
+    pushed: true,
+    worktreeReaped,
+    note: 'PR open against baseBranch. Operator merges via GitHub UI to close the issue (Closes #<id> auto-close).',
+  };
+
+  Logger.info(
+    `\n--- STORY CLOSE RESULT ---\n${JSON.stringify(result, null, 2)}\n--- END RESULT ---\n`,
+  );
+  progress('DONE', `✅ Standalone Story #${storyId}: PR ready → ${prUrl}`);
+  return { success: true, result };
+}
+
+/**
+ * Probe for an existing open PR with `head = storyBranch`; create one if
+ * none exists. Returns the PR URL. Exported for testing.
+ */
+export function ensurePullRequest({
+  cwd,
+  storyId,
+  storyTitle,
+  storyBranch,
+  baseBranch,
+}) {
+  const ghEnv = { ...process.env };
+  try {
+    // `gh pr list --head <branch> --state open --json url -q .[0].url`
+    // returns the PR URL or an empty string when no PR matches.
+    const existing = execFileSync(
+      'gh',
+      [
+        'pr',
+        'list',
+        '--head',
+        storyBranch,
+        '--state',
+        'open',
+        '--json',
+        'url',
+        '-q',
+        '.[0].url // empty',
+      ],
+      { cwd, encoding: 'utf8', env: ghEnv },
+    ).trim();
+    if (existing) {
+      progress('PR', `Reusing existing PR: ${existing}`);
+      return existing;
+    }
+  } catch (err) {
+    // `gh pr list` failure is recoverable — fall through to create. Log
+    // the error so an auth issue surfaces visibly.
+    Logger.warn?.(
+      `[single-story-close] ⚠️ \`gh pr list\` probe failed (continuing to create): ${err?.message ?? err}`,
+    );
+  }
+
+  progress('PR', `Opening PR for ${storyBranch} → ${baseBranch}...`);
+  const title = storyTitle?.trim()
+    ? `${storyTitle} (#${storyId})`
+    : `Story #${storyId}`;
+  const body = [
+    `Closes #${storyId}`,
+    '',
+    `_Auto-opened by \`/single-story-execute\`._`,
+  ].join('\n');
+  try {
+    const url = execFileSync(
+      'gh',
+      [
+        'pr',
+        'create',
+        '--base',
+        baseBranch,
+        '--head',
+        storyBranch,
+        '--title',
+        title,
+        '--body',
+        body,
+      ],
+      { cwd, encoding: 'utf8', env: ghEnv },
+    ).trim();
+    progress('PR', `✅ Opened: ${url}`);
+    return url;
+  } catch (err) {
+    throw new Error(
+      `[single-story-close] \`gh pr create\` failed: ${err?.message ?? err}`,
+    );
+  }
+}
+
+runAsCli(import.meta.url, runSingleStoryClose, {
+  source: 'single-story-close',
+});

--- a/.agents/scripts/single-story-init.js
+++ b/.agents/scripts/single-story-init.js
@@ -1,0 +1,325 @@
+#!/usr/bin/env node
+/* node:coverage ignore file */
+
+/**
+ * single-story-init.js — Initialize a standalone Story (no parent Epic).
+ *
+ * Counterpart to `story-init.js` for the `/single-story-execute` workflow.
+ * The framework's main `story-init.js` requires an `Epic: #N` reference in
+ * the Story body to trace hierarchy, seed the Story branch from
+ * `epic/<id>`, and gate execution on the epic's dispatch manifest. None of
+ * that applies to a standalone Story — a top-level work unit that branches
+ * directly from `main` and opens its PR straight to `main`.
+ *
+ * What this script does:
+ *   1. Validate the Story (type::story, not closed).
+ *   2. Fetch origin.
+ *   3. Create the Story branch from `agentSettings.baseBranch` (default
+ *      `main`) — local-only, no remote push at this stage.
+ *   4. Materialise a worktree at `.worktrees/story-<id>/` when worktree
+ *      isolation is enabled; otherwise check out the branch in-place.
+ *   5. Upsert a `story-init` structured comment carrying
+ *      `standalone: true`.
+ *   6. Flip the Story to `agent::executing`.
+ *
+ * What this script does NOT do (and why):
+ *   - Skips `traceHierarchy` — no Epic → no PRD/Tech-Spec.
+ *   - Skips `runDispatchManifestGuard` — no dispatch manifest exists for a
+ *     standalone Story.
+ *   - Skips `validateBlockers` against the body's `Blocked by:` markers —
+ *     pre-flight is still the operator's responsibility, but the Epic-scope
+ *     blocker chain doesn't fit.
+ *   - Skips child-Task transitions — a standalone Story is treated as
+ *     atomic (one branch, one commit-set, one PR).
+ *
+ * Usage: `node single-story-init.js --story <STORY_ID> [--dry-run]`
+ * Exit codes: 0 ok, 1 error.
+ *
+ * @see .agents/workflows/single-story-execute.md
+ */
+
+import path from 'node:path';
+import { parseSprintArgs } from './lib/cli-args.js';
+import { runAsCli } from './lib/cli-utils.js';
+import {
+  PROJECT_ROOT,
+  resolveConfig,
+  resolveRuntime,
+} from './lib/config-resolver.js';
+import {
+  branchExistsLocally,
+  branchExistsRemotely,
+} from './lib/git-branch-lifecycle.js';
+import {
+  getStoryBranch,
+  gitFetchWithRetry,
+  gitSpawn,
+  gitSync,
+} from './lib/git-utils.js';
+import { Logger } from './lib/Logger.js';
+import { TYPE_LABELS } from './lib/label-constants.js';
+import { setActiveStoryEnv } from './lib/observability/active-story-env.js';
+import { upsertStructuredComment } from './lib/orchestration/ticketing.js';
+import { createProvider } from './lib/provider-factory.js';
+import { WorktreeManager } from './lib/worktree-manager.js';
+
+const progress = Logger.createProgress('single-story-init', { stderr: true });
+
+/**
+ * Initialize a standalone Story. Exported for testing.
+ */
+export async function runSingleStoryInit({
+  storyId: storyIdParam,
+  dryRun: dryRunParam,
+  cwd: cwdParam,
+  injectedProvider,
+  injectedConfig,
+} = {}) {
+  const parsed =
+    storyIdParam !== undefined
+      ? {
+          storyId: storyIdParam,
+          dryRun: !!dryRunParam,
+          cwd: cwdParam ?? null,
+        }
+      : parseSprintArgs();
+  const { storyId, dryRun } = parsed;
+  const cwd = path.resolve(cwdParam ?? parsed.cwd ?? PROJECT_ROOT);
+
+  if (!storyId) {
+    Logger.fatal(
+      'Usage: node single-story-init.js --story <STORY_ID> [--dry-run]',
+    );
+  }
+
+  const config = injectedConfig || resolveConfig({ cwd });
+  const { agentSettings, orchestration } = config;
+  const provider = injectedProvider || createProvider(orchestration);
+
+  const baseBranch = agentSettings.baseBranch ?? 'main';
+  // The first arg is unused (legacy epicId slot); pass 0 to satisfy the
+  // numeric-validation guard.
+  const storyBranch = getStoryBranch(0, storyId);
+
+  const runtime = resolveRuntime({ config });
+  progress(
+    'ENV',
+    `worktreeIsolation=${runtime.worktreeEnabled ? 'on' : 'off'} (${runtime.worktreeEnabledSource})`,
+  );
+  progress('INIT', `Initializing standalone Story #${storyId}...`);
+
+  const story = await provider.getTicket(storyId);
+  if (!story.labels.includes(TYPE_LABELS.STORY)) {
+    throw new Error(
+      `Issue #${storyId} is not a Story (labels: ${story.labels.join(', ')}). Use /story-execute or /epic-deliver for Epic-attached work.`,
+    );
+  }
+  if (story.state === 'closed') {
+    throw new Error(`Story #${storyId} is already closed.`);
+  }
+
+  progress(
+    'CONTEXT',
+    `Standalone Story: "${story.title}" → branch ${storyBranch} from ${baseBranch}.`,
+  );
+
+  let workCwd = cwd;
+  let worktreeCreated = false;
+  let installStatus = { status: 'skipped', reason: 'dry-run' };
+
+  if (!dryRun) {
+    progress('GIT', 'Fetching remote refs...');
+    const fetchResult = await gitFetchWithRetry(cwd, 'origin');
+    if (fetchResult.attempts > 1) {
+      progress(
+        'GIT',
+        `Fetch completed after ${fetchResult.attempts} attempt(s) — packed-refs contention.`,
+      );
+    }
+
+    // Ensure baseBranch exists locally so we can branch from it. If only
+    // remote-tracking is present, materialize the local ref.
+    if (!branchExistsLocally(baseBranch, cwd)) {
+      const r = gitSpawn(cwd, 'fetch', 'origin', `${baseBranch}:${baseBranch}`);
+      if (r.status !== 0) {
+        throw new Error(
+          `Failed to fetch base branch ${baseBranch}: ${r.stderr || '(no stderr)'}`,
+        );
+      }
+    }
+
+    // Seed the Story branch. Three cases, idempotent in all of them:
+    //   - already local → noop
+    //   - remote only   → fetch
+    //   - neither       → create from baseBranch
+    const localHas = branchExistsLocally(storyBranch, cwd);
+    const remoteHas = branchExistsRemotely(storyBranch, cwd);
+    if (!localHas && remoteHas) {
+      progress('GIT', `Fetching remote story branch: ${storyBranch}`);
+      const r = gitSpawn(
+        cwd,
+        'fetch',
+        'origin',
+        `${storyBranch}:${storyBranch}`,
+      );
+      if (r.status !== 0) {
+        throw new Error(
+          `Failed to fetch story branch ${storyBranch}: ${r.stderr || '(no stderr)'}`,
+        );
+      }
+    } else if (!localHas && !remoteHas) {
+      progress(
+        'GIT',
+        `Creating story branch ref: ${storyBranch} from ${baseBranch}`,
+      );
+      const r = gitSpawn(cwd, 'branch', storyBranch, baseBranch);
+      if (r.status !== 0) {
+        throw new Error(
+          `Failed to create story branch ${storyBranch}: ${r.stderr || '(no stderr)'}`,
+        );
+      }
+    } else {
+      progress('GIT', `Reusing existing local story branch: ${storyBranch}`);
+    }
+
+    // Worktree (or single-tree fallback).
+    if (runtime.worktreeEnabled) {
+      const wm = new WorktreeManager({
+        repoRoot: cwd,
+        config: orchestration?.worktreeIsolation,
+        logger: {
+          info: (m) => progress('WORKTREE', m),
+          warn: (m) => progress('WORKTREE', `⚠️ ${m}`),
+          error: (m) => Logger.error(`[single-story-init] ${m}`),
+        },
+      });
+      const ensured = await wm.ensure(storyId, storyBranch);
+      workCwd = ensured.path;
+      worktreeCreated = ensured.created;
+      installStatus = ensured.installStatus ?? installStatus;
+      progress(
+        'WORKTREE',
+        `${ensured.created ? '✨ Created' : '♻️  Reusing'} worktree: ${ensured.path}`,
+      );
+    } else {
+      // Single-tree mode: check out the branch on the main checkout.
+      gitSync(cwd, 'checkout', storyBranch);
+      installStatus = { status: 'skipped', reason: 'single-tree-mode' };
+    }
+
+    try {
+      setActiveStoryEnv({
+        epicId: 0,
+        storyId,
+        workCwd,
+        logger: {
+          warn: (m) => progress('ENV', `⚠️ ${m}`),
+        },
+      });
+    } catch (err) {
+      Logger.error(
+        `[single-story-init] ⚠️ Failed to set active-Story env: ${err?.message ?? err}`,
+      );
+    }
+  }
+
+  const dependenciesInstalled =
+    installStatus.status === 'installed'
+      ? 'true'
+      : installStatus.status === 'failed'
+        ? 'false'
+        : 'skipped';
+
+  const result = {
+    storyId,
+    epicId: null,
+    standalone: true,
+    storyBranch,
+    baseBranch,
+    storyTitle: story.title,
+    worktreeEnabled: runtime.worktreeEnabled,
+    workCwd,
+    worktreeCreated,
+    installStatus,
+    dependenciesInstalled,
+    installFailed: installStatus.status === 'failed',
+    dryRun,
+  };
+
+  // Upsert the `story-init` structured comment + flip Story to executing.
+  // Both are no-ops under --dry-run.
+  if (!dryRun) {
+    try {
+      await upsertStructuredComment(
+        provider,
+        storyId,
+        'story-init',
+        renderSingleStoryInitComment(result),
+      );
+      progress(
+        'COMMENT',
+        `📝 Upserted story-init structured comment on #${storyId}.`,
+      );
+    } catch (err) {
+      Logger.error(
+        `[single-story-init] ⚠️ Failed to upsert story-init structured comment: ${err?.message ?? err}`,
+      );
+    }
+
+    try {
+      const labels = (story.labels || [])
+        .filter((l) => !l.startsWith('agent::'))
+        .concat('agent::executing');
+      await provider.updateTicket(storyId, { labels });
+      progress('LABELS', `🏷️  Story #${storyId} → agent::executing`);
+    } catch (err) {
+      Logger.error(
+        `[single-story-init] ⚠️ Failed to flip Story labels: ${err?.message ?? err}`,
+      );
+    }
+  }
+
+  Logger.info('\n--- STORY INIT RESULT ---');
+  Logger.info(JSON.stringify(result, null, 2));
+  Logger.info('--- END RESULT ---\n');
+  progress(
+    'DONE',
+    dryRun
+      ? '✅ Dry-run complete. No git or ticket changes made.'
+      : `✅ Standalone Story #${storyId} initialized on ${storyBranch}.`,
+  );
+
+  return { success: true, result };
+}
+
+export function renderSingleStoryInitComment(result) {
+  const payload = {
+    storyId: result.storyId,
+    epicId: null,
+    standalone: true,
+    storyBranch: result.storyBranch,
+    baseBranch: result.baseBranch,
+    worktreeEnabled: result.worktreeEnabled,
+    workCwd: result.workCwd,
+    worktreeCreated: result.worktreeCreated,
+    dependenciesInstalled: result.dependenciesInstalled,
+    installStatus: result.installStatus,
+  };
+  return [
+    '## Story init (standalone)',
+    '',
+    `- **standalone:** \`true\``,
+    `- **storyBranch:** \`${result.storyBranch}\``,
+    `- **baseBranch:** \`${result.baseBranch}\``,
+    `- **workCwd:** \`${result.workCwd}\``,
+    `- **worktreeEnabled:** \`${result.worktreeEnabled}\``,
+    `- **dependenciesInstalled:** \`${result.dependenciesInstalled}\``,
+    '',
+    '```json',
+    JSON.stringify(payload, null, 2),
+    '```',
+    '',
+  ].join('\n');
+}
+
+runAsCli(import.meta.url, runSingleStoryInit, { source: 'single-story-init' });

--- a/.agents/workflows/single-story-execute.md
+++ b/.agents/workflows/single-story-execute.md
@@ -1,0 +1,192 @@
+---
+description:
+  Execute a standalone Story (no parent Epic) end-to-end. Creates a branch
+  from main, implements the changes in a worktree, runs gates, pushes, and
+  opens a PR directly against main.
+---
+
+# /single-story-execute #[Story ID]
+
+## Overview
+
+`/single-story-execute` is the standalone counterpart to
+[`/story-execute`](story-execute.md). Use it for a Story that is **not**
+attached to an Epic — refactors carved out of closed Epics, framework
+maintenance, or any work small enough that the Epic-Centric ceremony
+(PRD + Tech Spec + decomposition + dispatch manifest + cascade) would be
+overhead rather than help.
+
+```text
+/single-story-execute <storyId>
+  → single-story-init.js          (branch from main, worktree, agent::executing)
+  → agent implements + commits     (operator works in the worktree)
+  → single-story-close.js          (gates, push, gh pr create → main, agent::done)
+```
+
+**When to use `/single-story-execute` vs. `/story-execute`:**
+
+| Trait                         | `/single-story-execute`                              | `/story-execute`                                        |
+| ----------------------------- | ---------------------------------------------------- | ------------------------------------------------------- |
+| Parent Epic                   | None (no `Epic: #N` in body)                         | Required (`Epic: #N` in body)                           |
+| Branch base                   | `agentSettings.baseBranch` (default `main`)          | `epic/<epicId>`                                         |
+| Merge target                  | `main` via PR                                        | `epic/<epicId>` via `--no-ff` merge                     |
+| Cascade up to Feature/Epic    | No                                                   | Yes                                                     |
+| Dispatch manifest interaction | None                                                 | Read at init, regenerated at close                      |
+| Child Task ceremony           | None (standalone Story is atomic)                    | Required (per-Task `task-commit.js` loop)               |
+
+If the Story has an `Epic: #N` reference, use `/story-execute`. If it
+doesn't, use this workflow.
+
+## Prerequisites
+
+1. A GitHub Issue with the `type::story` label and **no** `Epic: #N`
+   reference in its body.
+2. `GITHUB_TOKEN` or `gh auth status` clean — `gh pr create` runs at close.
+3. The base branch (`agentSettings.baseBranch`, default `main`) exists on
+   both local and `origin`.
+
+---
+
+## Step 0 — Initialize (`single-story-init.js`)
+
+Run from the **main checkout** (the worktree does not exist yet):
+
+```bash
+node .agents/scripts/single-story-init.js --story <storyId>
+```
+
+> **Execution mode.** Like `story-init.js`, this command can take 3–6
+> minutes when the worktree's per-tree install runs. Invoke synchronously
+> with `Bash(timeout: 600000)`. Do **not** use `run_in_background` +
+> `Monitor` — a sub-agent that exits mid-install leaves the worktree
+> half-bootstrapped.
+
+The script validates `type::story`, fetches `origin`, seeds
+`story-<id>` from `baseBranch`, materializes a worktree (when
+`orchestration.worktreeIsolation.enabled` is true), upserts a
+`story-init` structured comment carrying `standalone: true`, and flips
+the Story to `agent::executing`.
+
+Capture `workCwd` from the result envelope. Add `--dry-run` to inspect
+the planned actions without git or ticket mutations.
+
+### Step 0.5 — `cd` into the workCwd
+
+```bash
+cd "<workCwd from Step 0 result>"
+```
+
+All subsequent commands run from this directory.
+
+---
+
+## Step 1 — Implementation
+
+A standalone Story is **atomic** — there are no child Tasks, no per-Task
+`task-commit.js` ceremony, no wave dispatch. Work happens in one or more
+commits on the `story-<id>` branch.
+
+Operator/agent responsibilities while in the worktree:
+
+1. Read the Story body. Treat its acceptance criteria as the contract.
+2. Implement the changes.
+3. Commit on the Story branch. Conventional-commit format is encouraged
+   but not enforced — the PR title carries the canonical summary.
+4. Iterate (read tests, run targeted gates, edit, commit) until the
+   acceptance criteria are met.
+
+Recommended quick gates while iterating (each is fast enough to run on
+save):
+
+```bash
+npm run typecheck
+npm run lint
+npm test -- --grep "<scope>"
+```
+
+The full close-validation chain runs in Step 3; the gates above are
+advisory pre-flight.
+
+> Conflict with `main` mid-implementation → resolve as you would any
+> branch rebase. There is no `epic/<id>` intermediate, so the rebase
+> base is `main` directly.
+
+---
+
+## Step 2 — Validate (deferred to close)
+
+`single-story-close.js` runs the canonical close-validation chain
+(typecheck, lint, test, format, maintainability, coverage, crap) before
+it pushes. Do **not** pre-run those gates here unless interactively
+iterating on a fix.
+
+---
+
+## Step 3 — Close (`single-story-close.js`)
+
+Invoke from the main checkout (or pass `--cwd <main-repo>` from inside
+the worktree):
+
+```bash
+node <main-repo>/.agents/scripts/single-story-close.js --story <storyId> --cwd <main-repo>
+```
+
+The script:
+
+1. Runs the close-validation gates against `baseBranch` as the baseline.
+   On any gate failure it throws — the operator fixes and re-runs close.
+2. Pushes `story-<id>` to `origin`.
+3. Probes for an existing open PR with `head = story-<id>`. If none
+   exists, opens one via `gh pr create --base <baseBranch>`. The PR
+   body carries `Closes #<storyId>` so the GitHub merge auto-closes the
+   issue.
+4. Flips the Story to `agent::done`. The GitHub issue stays open until
+   the operator merges the PR.
+5. Reaps the worktree when `orchestration.worktreeIsolation.reapOnSuccess`
+   is enabled.
+
+`--skip-validation` bypasses Step 1 (gates). Use only when re-running
+close after a fixed gate failure that's already known to pass.
+
+---
+
+## Step 4 — Human merge
+
+The PR is the merge gate. The operator reviews and merges via the
+GitHub UI; the `Closes #<id>` auto-close fires when the merge lands on
+`main`.
+
+---
+
+## Idempotence
+
+- `single-story-init.js` re-prints the same `workCwd` without recreating
+  the worktree when one already exists for `story-<id>`.
+- `single-story-close.js` short-circuits when the Story is already
+  closed (returns `{ action: 'noop', reason: 'already-closed' }`).
+- The PR probe (`gh pr list --head <branch> --state open`) reuses an
+  existing open PR rather than opening a duplicate.
+
+Re-running `/single-story-execute` against an already-closed Story is
+safe.
+
+---
+
+## Constraints
+
+- **Never** push the Story branch directly to `main`. The PR is the only
+  merge surface.
+- **Always** `cd` into the `workCwd` returned by Step 0 before editing.
+- **Always** pass `--cwd <main-repo>` to `single-story-close.js` when
+  invoking from inside a worktree (worktree-local branch deletion fails
+  when run from inside the worktree).
+- **MCP fallback**: if `agent-protocols` MCP tools fail, fall back to
+  `node .agents/scripts/update-ticket-state.js --task <id> --state <state>`
+  for label transitions.
+
+---
+
+## See also
+
+- [`/story-execute`](story-execute.md) — Epic-attached Story execution.
+- [`/epic-deliver`](epic-deliver.md) — full Epic wave loop.

--- a/.agents/workflows/story-execute.md
+++ b/.agents/workflows/story-execute.md
@@ -28,6 +28,13 @@ The argument is always a **Story ID** (`type::story`). Epic IDs go through
 [`/epic-deliver`](epic-execute.md); Tasks are not directly executable —
 they are implemented by their parent Story's loop.
 
+**Standalone Stories** (no `Epic: #N` in body) use
+[`/single-story-execute`](single-story-execute.md) instead — that workflow
+branches from `main`, opens its PR directly to `main`, and skips the
+Epic-scoped machinery (cascade, dispatch manifest, dashboard regen).
+`/story-execute` requires a parent Epic and will refuse to initialize a
+Story that lacks the `Epic: #N` reference.
+
 > **Worktree isolation.** When `orchestration.worktreeIsolation.enabled` is
 > `true`, Step 0 creates a worktree at `.worktrees/story-<id>/` and prints
 > its absolute path as `workCwd`. You **must** `cd` into that path before


### PR DESCRIPTION
## Summary

Adds `/single-story-execute` for Stories that aren't attached to an Epic — refactors carved out of closed Epics, framework maintenance, and other top-level work units where the Epic-Centric ceremony (PRD + Tech Spec + decomposition + dispatch manifest + cascade) is overhead rather than help.

The motivating case: #1430 (the wave-runner extraction carved out of the closed Epic B #1180) is currently orphan-typed and cannot run through `/story-execute` — `story-init.js`'s context resolver throws because there's no \`Epic: #N\` reference in the body. This PR adds a parallel workflow purpose-built for that shape.

## What's added

- **`single-story-init.js`** — Validate `type::story`, fetch origin, seed `story-<id>` from `agentSettings.baseBranch` (default `main`), materialize a worktree at `.worktrees/story-<id>/`, upsert a `story-init` structured comment with `standalone: true`, flip the Story to `agent::executing`.
- **`single-story-close.js`** — Run the canonical close-validation gates against `baseBranch` as the baseline, push the Story branch, open (or reuse) a PR to `baseBranch` via `gh pr create` with \`Closes #<id>\` in the body, flip the Story to `agent::done`, reap the worktree.
- **`single-story-execute.md`** — Workflow documentation. Comparison table for `/single-story-execute` vs. `/story-execute` so operators pick the right one.
- One-liner in **`story-execute.md`** cross-referencing the new workflow.

## What it deliberately skips (and why)

The standalone path bypasses every piece of the Epic-Centric machinery that doesn't apply when there's no parent Epic:

- **No epic-merge-lock** — there are no concurrent Stories merging into a shared epic branch.
- **No `dispatchRecovery`** — no resume-from-conflict state machine.
- **No `runAutoRefresh`** — bounded-baseline drift is an Epic-scoped concern.
- **No `runPostMergePipeline`** — no cascade, no dashboard, no manifest regen.
- **No direct merge to `main`** — the PR is the human gate. The Story branch stays alive until the operator merges; the worktree is reaped after the PR opens because the branch is no longer needed locally. The PR body's \`Closes #<id>\` fires the GitHub auto-close on merge.

## Compatibility

- `/story-execute` is untouched — it still requires an `Epic: #N` reference and refuses to initialize stories that lack it.
- No changes to `story-init.js`, `story-close.js`, `branch-initializer.js`, `context-resolver.js`, or any of the post-merge pipeline. Zero risk to the SDL critical path.
- Worktree isolation, the canonical close-validation chain, the worktree-manager, and the trace-hook env all reused as-is.

## Test plan

- [x] `npm run sync:commands` — both `/single-story-execute` and `/story-execute` register.
- [x] `node single-story-init.js --story 1430 --dry-run` — resolves story title, branches `story-1430` from `main`, standalone flag set.
- [x] `npm run typecheck` clean.
- [x] `npm run lint` — no new findings introduced (the existing 3 warnings / 4 infos predate this PR).
- [ ] Follow-up PR: run `/single-story-execute 1430` end-to-end on #1430 (the wave-runner extraction) as the first real-world exercise. That PR will land #1430 itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)