### PR TITLE
feat(manifest): hoist Agent Operating Procedures to top of manifest.md

### DIFF
--- a/.agents/scripts/lib/presentation/manifest-formatter.js
+++ b/.agents/scripts/lib/presentation/manifest-formatter.js
@@ -540,6 +540,13 @@ function _formatManifestMarkdownUncached(manifest) {
   );
   lines.push('');
 
+  // --- Top <details> block: operating procedures + full symbol legend.
+  // Sits directly under the meta line so an operator opening the manifest
+  // sees the run-instructions and the symbol key before scrolling the wave
+  // tables. The only HTML in the document; collapsed by default.
+  lines.push(renderProceduresAndLegendDetails(epicId));
+  lines.push('');
+
   // --- Wave Summary Table (Stories only — Features are containers) ---
   const allItems =
     manifest.storyManifest ||
@@ -555,11 +562,6 @@ function _formatManifestMarkdownUncached(manifest) {
     const nestedBlock = renderNestedWaveSections(storyManifest);
     if (nestedBlock) lines.push(nestedBlock);
   }
-
-  // --- Bottom <details> block: operating procedures + full symbol legend.
-  // The only HTML in the document; collapsed by default.
-  lines.push(renderProceduresAndLegendDetails(epicId));
-  lines.push('');
 
   // --- Agent Telemetry ---
   /* node:coverage ignore next */


### PR DESCRIPTION
## Summary
- Move the collapsed `<details>` block (Agent Operating Procedures & symbol reference) from the bottom of `manifest.md` to directly under the meta line, so operators see run instructions and the symbol key before scrolling past the wave tables.
- Pure render change in `.agents/scripts/lib/presentation/manifest-formatter.js`; no other surface affected.

## Test plan
- [x] `node --test tests/lib/manifest-formatter.test.js tests/manifest-renderer.test.js tests/lib/presentation/manifest-formatter-layout.test.js tests/lib/presentation/manifest-formatter-end-to-end.test.js`
- [x] `node --test tests/scripts/manifest-formatter-fromspec.test.js tests/scripts/dispatcher-fromspec.test.js tests/lib/manifest-renderer.test.js tests/lib/manifest-formatter-cache.test.js`

🤖 Generated with [Claude Code](https://claude.com/claude-code)