### PR TITLE
Stop story-init.js from leaking temp/epic-<id>/ snapshot commits to the epic ref (#1815)

### DIFF
--- a/.agents/scripts/lib/cli-args.js
+++ b/.agents/scripts/lib/cli-args.js
@@ -55,6 +55,7 @@ export function parseSprintArgs(args = process.argv) {
       'dry-run': { type: 'boolean', default: false },
       'skip-dashboard': { type: 'boolean', default: false },
       'skip-validation': { type: 'boolean', default: false },
+      'no-auto-merge': { type: 'boolean', default: false },
       executor: { type: 'string' },
       cwd: { type: 'string' },
       'recut-of': { type: 'string' },
@@ -73,6 +74,7 @@ export function parseSprintArgs(args = process.argv) {
     dryRun: values['dry-run'] ?? false,
     skipDashboard: values['skip-dashboard'] ?? false,
     skipValidation: coerceBooleanFlag(values['skip-validation']),
+    noAutoMerge: coerceBooleanFlag(values['no-auto-merge']),
     executor: values.executor ?? null,
     // Resolve worktree cwd from flag or env. Empty string/whitespace → null.
     cwd:

--- a/.agents/scripts/lib/story-init/branch-initializer.js
+++ b/.agents/scripts/lib/story-init/branch-initializer.js
@@ -18,7 +18,6 @@
 
 import nodeFs from 'node:fs';
 import nodePath from 'node:path';
-import { forkAndCommitEpicSnapshot as defaultForkAndCommitEpicSnapshot } from '../baseline-snapshot.js';
 import { resolveWorkingPath } from '../config-resolver.js';
 import {
   branchExistsLocally,
@@ -224,46 +223,8 @@ async function fetchMainRefs({ mainCwd, progress }) {
   }
 }
 
-export function reportSnapshotFork(snapshot, epicBranch, progress) {
-  if (snapshot?.commit?.committed) {
-    progress(
-      'GIT',
-      `🧊 Forked main baselines → ${epicBranch} (commit ${snapshot.commit.sha?.slice(0, 7)}).`,
-    );
-    return;
-  }
-  progress(
-    'GIT',
-    `🧊 Snapshot fork skipped: ${snapshot?.commit?.reason ?? 'no-files'}.`,
-  );
-}
-
-export function maybeForkSnapshot({
-  epicId,
-  epicBranch,
-  mainCwd,
-  forkAndCommitEpicSnapshot,
-  progress,
-}) {
-  // Story #1585 (Epic #1471): defer the baseline-snapshot fork from
-  // /epic-plan to first-story-init so plan-time stays git-state-free and
-  // the snapshot reflects the current main rather than stale main at plan
-  // time. Idempotent + non-fatal on missing source baselines.
-  if (epicId === undefined || epicId === null) return;
-  try {
-    const snapshot = forkAndCommitEpicSnapshot({ epicId, cwd: mainCwd });
-    reportSnapshotFork(snapshot, epicBranch, progress);
-  } catch (err) {
-    progress(
-      'GIT',
-      `⚠️ snapshot fork failed (non-fatal): ${err?.message ?? err}`,
-    );
-  }
-}
-
 export async function bootstrapWorktree({
   epicBranch,
-  epicId,
   storyBranch,
   storyId,
   baseBranch,
@@ -273,17 +234,9 @@ export async function bootstrapWorktree({
   fs = nodeFs,
   path = nodePath,
   onPhase,
-  forkAndCommitEpicSnapshot = defaultForkAndCommitEpicSnapshot,
 }) {
   await fetchMainRefs({ mainCwd, progress });
   ensureEpicBranchRef(epicBranch, baseBranch, mainCwd, { progress });
-  maybeForkSnapshot({
-    epicId,
-    epicBranch,
-    mainCwd,
-    forkAndCommitEpicSnapshot,
-    progress,
-  });
   ensureStoryBranchSeed({ storyBranch, epicBranch, mainCwd, progress });
 
   const wm = new WorktreeManager({
@@ -325,7 +278,6 @@ export async function bootstrapWorktree({
  * @param {object} [deps.fs]
  * @param {object} deps.input
  * @param {number} deps.input.storyId
- * @param {number} [deps.input.epicId]
  * @param {string} deps.input.epicBranch
  * @param {string} deps.input.storyBranch
  * @param {string} deps.input.baseBranch
@@ -341,7 +293,6 @@ export async function bootstrapWorktree({
 export async function initializeBranch({ logger, fs = nodeFs, input }) {
   const {
     storyId,
-    epicId,
     epicBranch,
     storyBranch,
     baseBranch,
@@ -355,7 +306,6 @@ export async function initializeBranch({ logger, fs = nodeFs, input }) {
   if (worktreeEnabled) {
     const wtResult = await bootstrapWorktree({
       epicBranch,
-      epicId,
       storyBranch,
       storyId,
       baseBranch,

--- a/.agents/scripts/single-story-close.js
+++ b/.agents/scripts/single-story-close.js
@@ -69,6 +69,7 @@ export async function runSingleStoryClose({
   storyId: storyIdParam,
   cwd: cwdParam,
   skipValidation: skipValidationParam,
+  noAutoMerge: noAutoMergeParam,
   injectedProvider,
   injectedConfig,
 } = {}) {
@@ -78,15 +79,17 @@ export async function runSingleStoryClose({
           storyId: storyIdParam,
           cwd: cwdParam ?? null,
           skipValidation: !!skipValidationParam,
+          noAutoMerge: !!noAutoMergeParam,
         }
       : parseSprintArgs();
   const { storyId } = parsed;
   const skipValidation = skipValidationParam ?? parsed.skipValidation ?? false;
+  const noAutoMerge = noAutoMergeParam ?? parsed.noAutoMerge ?? false;
   const cwd = path.resolve(cwdParam ?? parsed.cwd ?? PROJECT_ROOT);
 
   if (!storyId) {
     Logger.fatal(
-      'Usage: node single-story-close.js --story <STORY_ID> [--cwd <main-repo>] [--skip-validation]',
+      'Usage: node single-story-close.js --story <STORY_ID> [--cwd <main-repo>] [--skip-validation] [--no-auto-merge]',
     );
   }
 
@@ -187,6 +190,42 @@ export async function runSingleStoryClose({
     baseBranch,
   });
 
+  // Step 3a: enable GitHub native auto-merge so the PR squash-merges itself
+  // when required checks pass. Mirrors `epic-deliver-finalize.js`. Default
+  // is on for the standalone path because a single-story PR has no
+  // intermediate review surface; opt-out via `--no-auto-merge` when the
+  // operator wants to inspect the diff before clicking merge. Failures are
+  // non-fatal — the operator retains the manual merge path through the
+  // GitHub UI.
+  const prNumber = parsePrNumber(prUrl);
+  let autoMergeEnabled = false;
+  let autoMergeReason = null;
+  if (noAutoMerge) {
+    autoMergeReason = 'disabled-by-flag';
+    progress('PR', '⏭  Auto-merge disabled (--no-auto-merge).');
+  } else if (prNumber == null) {
+    autoMergeReason = 'pr-number-unparseable';
+    progress(
+      'PR',
+      `⚠️ Auto-merge skipped: could not parse PR number from URL ${prUrl}.`,
+    );
+  } else {
+    const result = enableAutoMerge({ cwd, prNumber });
+    if (result.enabled) {
+      autoMergeEnabled = true;
+      progress(
+        'PR',
+        `✅ Auto-merge enabled on PR #${prNumber} (squash, delete-branch).`,
+      );
+    } else {
+      autoMergeReason = result.reason;
+      progress(
+        'PR',
+        `⚠️ Auto-merge enablement failed (${result.reason}) — operator can merge manually.`,
+      );
+    }
+  }
+
   // Step 4: flip Story label to agent::done. The GitHub issue stays open
   // until the operator merges the PR (which fires the `Closes #<id>`
   // auto-close).
@@ -243,9 +282,14 @@ export async function runSingleStoryClose({
     storyBranch,
     baseBranch,
     prUrl,
+    prNumber,
     pushed: true,
+    autoMergeEnabled,
+    autoMergeReason,
     worktreeReaped,
-    note: 'PR open against baseBranch. Operator merges via GitHub UI to close the issue (Closes #<id> auto-close).',
+    note: autoMergeEnabled
+      ? 'PR open against baseBranch with auto-merge enabled. GitHub will squash-merge when required checks pass; the Closes #<id> footer auto-closes the issue.'
+      : 'PR open against baseBranch. Operator merges via GitHub UI to close the issue (Closes #<id> auto-close).',
   };
 
   Logger.info(
@@ -330,6 +374,75 @@ export function ensurePullRequest({
     throw new Error(
       `[single-story-close] \`gh pr create\` failed: ${err?.message ?? err}`,
     );
+  }
+}
+
+/**
+ * Extract the numeric PR ID from a `gh pr create` URL. The CLI returns a
+ * URL like `https://github.com/<owner>/<repo>/pull/<n>`; we want `<n>`.
+ * Returns `null` when the URL doesn't match. Exported for testing.
+ *
+ * @param {string|null|undefined} prUrl
+ * @returns {number|null}
+ */
+export function parsePrNumber(prUrl) {
+  if (typeof prUrl !== 'string') return null;
+  const match = prUrl.match(/\/pull\/(\d+)(?:[/?#]|$)/);
+  if (!match) return null;
+  const n = Number.parseInt(match[1], 10);
+  return Number.isInteger(n) && n > 0 ? n : null;
+}
+
+/**
+ * Enable GitHub native auto-merge on the PR. Mirrors the call in
+ * `epic-deliver-finalize.js`: squash strategy, delete the branch on merge.
+ * Non-fatal — returns `{ enabled: false, reason }` on any failure so the
+ * caller can fall back to the operator-merges-button path.
+ *
+ * Exported for testing; the injection seam lets tests stub the `gh`
+ * invocation without touching the network.
+ *
+ * @param {{ cwd: string, prNumber: number, runner?: (args: string[], opts: object) => { status: number, stdout?: string, stderr?: string } }} opts
+ * @returns {{ enabled: boolean, reason?: string }}
+ */
+export function enableAutoMerge({ cwd, prNumber, runner }) {
+  const exec = runner ?? defaultGhAutoMergeRunner;
+  try {
+    const result = exec(
+      [
+        'pr',
+        'merge',
+        String(prNumber),
+        '--auto',
+        '--squash',
+        '--delete-branch',
+      ],
+      { cwd },
+    );
+    if (result.status === 0) return { enabled: true };
+    return {
+      enabled: false,
+      reason: `gh-exit-${result.status}: ${(result.stderr ?? '').trim().slice(0, 200)}`,
+    };
+  } catch (err) {
+    return { enabled: false, reason: `gh-spawn-error: ${err?.message ?? err}` };
+  }
+}
+
+function defaultGhAutoMergeRunner(args, { cwd }) {
+  try {
+    const stdout = execFileSync('gh', args, {
+      cwd,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    return { status: 0, stdout, stderr: '' };
+  } catch (err) {
+    return {
+      status: typeof err.status === 'number' ? err.status : 1,
+      stdout: err.stdout?.toString?.() ?? '',
+      stderr: err.stderr?.toString?.() ?? String(err?.message ?? err),
+    };
   }
 }
 

--- a/.agents/workflows/single-story-execute.md
+++ b/.agents/workflows/single-story-execute.md
@@ -140,21 +140,46 @@ The script:
    exists, opens one via `gh pr create --base <baseBranch>`. The PR
    body carries `Closes #<storyId>` so the GitHub merge auto-closes the
    issue.
+3a. **Enables GitHub native auto-merge by default** via
+   `gh pr merge <prNumber> --auto --squash --delete-branch`. Once CI's
+   required checks turn green, GitHub squash-merges the PR and deletes
+   the source branch — the operator does not need to babysit the merge
+   button. Mirrors the `/epic-deliver` finalize path. Failure is
+   non-fatal: the operator retains the manual merge surface in the
+   GitHub UI. Pass `--no-auto-merge` to opt out when the PR needs a
+   pre-merge eyeball.
 4. Flips the Story to `agent::done`. The GitHub issue stays open until
-   the operator merges the PR.
+   the auto-merge fires (or until the operator merges manually); the
+   `Closes #<id>` PR footer auto-closes the issue on merge.
 5. Reaps the worktree when `delivery.worktreeIsolation.reapOnSuccess`
    is enabled.
 
 `--skip-validation` bypasses Step 1 (gates). Use only when re-running
 close after a fixed gate failure that's already known to pass.
 
+`--no-auto-merge` disables Step 3a. Use when the PR materially changes
+behaviour and warrants pre-merge review.
+
 ---
 
-## Step 4 — Human merge
+## Step 4 — Merge
 
-The PR is the merge gate. The operator reviews and merges via the
-GitHub UI; the `Closes #<id>` auto-close fires when the merge lands on
-`main`.
+With auto-merge enabled (default), no operator action is needed —
+GitHub squash-merges the PR when required checks pass and the
+`Closes #<id>` footer auto-closes the issue.
+
+With `--no-auto-merge`, the PR is the merge gate. The operator reviews
+and merges via the GitHub UI; the same `Closes #<id>` auto-close fires
+when the merge lands on `main`.
+
+Optional: watch CI progress from the terminal with
+
+```bash
+gh pr checks <prNumber> --watch
+```
+
+The `prNumber` field is included in the close-script result envelope
+so a wrapper can pipe it straight in.
 
 ---
 

--- a/baselines/coverage.json
+++ b/baselines/coverage.json
@@ -230,8 +230,8 @@
     "functions": 100
   },
   ".agents/scripts/lib/cli-args.js": {
-    "lines": 98.21,
-    "branches": 89.19,
+    "lines": 98.23,
+    "branches": 89.29,
     "functions": 100
   },
   ".agents/scripts/lib/cli-utils.js": {
@@ -416,7 +416,7 @@
   },
   ".agents/scripts/lib/git-utils.js": {
     "lines": 95.26,
-    "branches": 75.41,
+    "branches": 82.54,
     "functions": 89.47
   },
   ".agents/scripts/lib/Graph.js": {
@@ -555,8 +555,8 @@
     "functions": 100
   },
   ".agents/scripts/lib/orchestration/dispatch-engine.js": {
-    "lines": 82.74,
-    "branches": 76.92,
+    "lines": 92.39,
+    "branches": 85.71,
     "functions": 100
   },
   ".agents/scripts/lib/orchestration/dispatch-pipeline.js": {
@@ -906,12 +906,12 @@
   },
   ".agents/scripts/lib/presentation/manifest-formatter.js": {
     "lines": 97.14,
-    "branches": 85.02,
+    "branches": 85.53,
     "functions": 100
   },
   ".agents/scripts/lib/presentation/manifest-persistence.js": {
     "lines": 97.39,
-    "branches": 77.55,
+    "branches": 79.59,
     "functions": 100
   },
   ".agents/scripts/lib/presentation/manifest-renderer.js": {
@@ -1160,8 +1160,8 @@
     "functions": 100
   },
   ".agents/scripts/providers/github.js": {
-    "lines": 86.13,
-    "branches": 72.37,
+    "lines": 86.25,
+    "branches": 73.04,
     "functions": 86.67
   },
   ".agents/scripts/providers/github/projects-v2-graphql.js": {
@@ -1183,6 +1183,11 @@
     "lines": 92.9,
     "branches": 73.12,
     "functions": 86.67
+  },
+  ".agents/scripts/single-story-close.js": {
+    "lines": 29.05,
+    "branches": 73.33,
+    "functions": 40
   },
   ".agents/scripts/sync-claude-commands.js": {
     "lines": 93.41,

--- a/baselines/crap.json
+++ b/baselines/crap.json
@@ -1213,79 +1213,79 @@
       "crap": 1,
       "file": ".agents/scripts/lib/cli-args.js",
       "method": "camelCase",
-      "startLine": 102
+      "startLine": 104
     },
     {
       "crap": 4,
       "file": ".agents/scripts/lib/cli-args.js",
       "method": "initialValueFor",
-      "startLine": 106
+      "startLine": 108
     },
     {
       "crap": 4.074074074074074,
       "file": ".agents/scripts/lib/cli-args.js",
       "method": "coerceValue",
-      "startLine": 113
+      "startLine": 115
     },
     {
       "crap": 2,
       "file": ".agents/scripts/lib/cli-args.js",
       "method": "validateSpec",
-      "startLine": 145
+      "startLine": 147
     },
     {
       "crap": 2,
       "file": ".agents/scripts/lib/cli-args.js",
       "method": "initParserState",
-      "startLine": 155
+      "startLine": 157
     },
     {
       "crap": 6,
       "file": ".agents/scripts/lib/cli-args.js",
       "method": "classifyToken",
-      "startLine": 168
+      "startLine": 170
     },
     {
       "crap": 2,
       "file": ".agents/scripts/lib/cli-args.js",
       "method": "assignFlagValue",
-      "startLine": 182
+      "startLine": 184
     },
     {
       "crap": 6,
       "file": ".agents/scripts/lib/cli-args.js",
       "method": "readValuedFlag",
-      "startLine": 190
+      "startLine": 192
     },
     {
       "crap": 8.040303206997084,
       "file": ".agents/scripts/lib/cli-args.js",
       "method": "parseTokens",
-      "startLine": 206
+      "startLine": 208
     },
     {
       "crap": 3,
       "file": ".agents/scripts/lib/cli-args.js",
       "method": "isAbsentValue",
-      "startLine": 242
+      "startLine": 244
     },
     {
       "crap": 6,
       "file": ".agents/scripts/lib/cli-args.js",
       "method": "applyEnvFallbacks",
-      "startLine": 248
+      "startLine": 250
     },
     {
       "crap": 4,
       "file": ".agents/scripts/lib/cli-args.js",
       "method": "applyDefaults",
-      "startLine": 261
+      "startLine": 263
     },
     {
       "crap": 1,
       "file": ".agents/scripts/lib/cli-args.js",
       "method": "defineFlags",
-      "startLine": 272
+      "startLine": 274
     },
     {
       "crap": 2,
@@ -3316,7 +3316,7 @@
       "startLine": 74
     },
     {
-      "crap": 16,
+      "crap": 8.006910700788252,
       "file": ".agents/scripts/lib/orchestration/dispatch-engine.js",
       "method": "resolveAndDispatch",
       "startLine": 88
@@ -7078,7 +7078,7 @@
       "startLine": 421
     },
     {
-      "crap": 5.0407083248524325,
+      "crap": 5,
       "file": ".agents/scripts/providers/github.js",
       "method": "paginateRest",
       "startLine": 460
@@ -7352,6 +7352,36 @@
       "file": ".agents/scripts/signals-view.js",
       "method": "<anon method-3>",
       "startLine": 299
+    },
+    {
+      "crap": 375.37185158400007,
+      "file": ".agents/scripts/single-story-close.js",
+      "method": "runSingleStoryClose",
+      "startLine": 68
+    },
+    {
+      "crap": 11.635180467691642,
+      "file": ".agents/scripts/single-story-close.js",
+      "method": "ensurePullRequest",
+      "startLine": 306
+    },
+    {
+      "crap": 5,
+      "file": ".agents/scripts/single-story-close.js",
+      "method": "parsePrNumber",
+      "startLine": 388
+    },
+    {
+      "crap": 2,
+      "file": ".agents/scripts/single-story-close.js",
+      "method": "enableAutoMerge",
+      "startLine": 408
+    },
+    {
+      "crap": 6,
+      "file": ".agents/scripts/single-story-close.js",
+      "method": "defaultGhAutoMergeRunner",
+      "startLine": 432
     },
     {
       "crap": 2,

--- a/tests/lib/story-init/branch-initializer-pure.test.js
+++ b/tests/lib/story-init/branch-initializer-pure.test.js
@@ -6,11 +6,7 @@
 
 import assert from 'node:assert/strict';
 import test from 'node:test';
-import {
-  maybeForkSnapshot,
-  planStoryBranchSeed,
-  reportSnapshotFork,
-} from '../../../.agents/scripts/lib/story-init/branch-initializer.js';
+import { planStoryBranchSeed } from '../../../.agents/scripts/lib/story-init/branch-initializer.js';
 
 test('planStoryBranchSeed: local branch present → no-op', () => {
   assert.equal(
@@ -35,77 +31,4 @@ test('planStoryBranchSeed: neither side has it → create from epic', () => {
     planStoryBranchSeed({ localHas: false, remoteHas: false }),
     'create',
   );
-});
-
-test('reportSnapshotFork: logs commit SHA when committed', () => {
-  const calls = [];
-  const progress = (kind, msg) => calls.push({ kind, msg });
-  reportSnapshotFork(
-    { commit: { committed: true, sha: 'abc1234deadbeef' } },
-    'epic/42',
-    progress,
-  );
-  assert.equal(calls.length, 1);
-  assert.match(calls[0].msg, /Forked main baselines → epic\/42/);
-  assert.match(calls[0].msg, /abc1234/);
-});
-
-test('reportSnapshotFork: logs skip reason when not committed', () => {
-  const calls = [];
-  reportSnapshotFork(
-    { commit: { committed: false, reason: 'no-change' } },
-    'epic/42',
-    (_k, m) => calls.push(m),
-  );
-  assert.match(calls[0], /Snapshot fork skipped: no-change/);
-});
-
-test('reportSnapshotFork: defaults to no-files when reason is absent', () => {
-  const calls = [];
-  reportSnapshotFork(null, 'epic/42', (_k, m) => calls.push(m));
-  assert.match(calls[0], /Snapshot fork skipped: no-files/);
-});
-
-test('maybeForkSnapshot: skips entirely when epicId is null', () => {
-  let called = false;
-  maybeForkSnapshot({
-    epicId: null,
-    epicBranch: 'epic/42',
-    mainCwd: '/repo',
-    forkAndCommitEpicSnapshot: () => {
-      called = true;
-      return { commit: { committed: true } };
-    },
-    progress: () => {},
-  });
-  assert.equal(called, false);
-});
-
-test('maybeForkSnapshot: invokes fork helper and reports outcome', () => {
-  const calls = [];
-  maybeForkSnapshot({
-    epicId: 42,
-    epicBranch: 'epic/42',
-    mainCwd: '/repo',
-    forkAndCommitEpicSnapshot: () => ({
-      commit: { committed: true, sha: 'cafef00d' },
-    }),
-    progress: (_, m) => calls.push(m),
-  });
-  assert.match(calls[0], /Forked main baselines/);
-});
-
-test('maybeForkSnapshot: swallows fork failures and warns', () => {
-  const calls = [];
-  maybeForkSnapshot({
-    epicId: 42,
-    epicBranch: 'epic/42',
-    mainCwd: '/repo',
-    forkAndCommitEpicSnapshot: () => {
-      throw new Error('boom');
-    },
-    progress: (_, m) => calls.push(m),
-  });
-  assert.match(calls[0], /snapshot fork failed/);
-  assert.match(calls[0], /boom/);
 });

--- a/tests/lib/story-init/no-temp-commit-on-epic.test.js
+++ b/tests/lib/story-init/no-temp-commit-on-epic.test.js
@@ -1,0 +1,72 @@
+/**
+ * Regression test for Story #1815: `story-init.js` must never produce a
+ * commit on the epic ref that touches `temp/`. Previously the
+ * `forkAndCommitEpicSnapshot` path baked `temp/epic-<id>/baselines/*.json`
+ * blobs into a `chore(baseline-snapshot):` commit on `epic/<id>` that was
+ * never pushed to origin. Subsequent sub-agents on the same Epic saw
+ * "local ahead of origin" at preflight and reset, wiping legitimate work.
+ *
+ * The fix removed the call from `bootstrapWorktree`. This test guards
+ * against re-introduction.
+ */
+
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import * as branchInitializer from '../../../.agents/scripts/lib/story-init/branch-initializer.js';
+
+test('branch-initializer no longer exports maybeForkSnapshot', () => {
+  assert.equal(
+    branchInitializer.maybeForkSnapshot,
+    undefined,
+    'maybeForkSnapshot must not be re-introduced — it commits temp/ files to epic/<id>',
+  );
+});
+
+test('branch-initializer no longer exports reportSnapshotFork', () => {
+  assert.equal(
+    branchInitializer.reportSnapshotFork,
+    undefined,
+    'reportSnapshotFork was the friend-helper of the removed snapshot fork',
+  );
+});
+
+test('bootstrapWorktree signature does not accept forkAndCommitEpicSnapshot dep', async () => {
+  // The function still exists for the worktree-isolated branch path;
+  // assert that callers cannot inject the snapshot helper anymore.
+  // We probe by calling with a tracker — if the dep is honoured we'd see
+  // a side effect; we expect it to be ignored entirely.
+  const calls = [];
+  let threw = null;
+  try {
+    await branchInitializer.bootstrapWorktree({
+      epicBranch: 'epic/9999',
+      storyBranch: 'story-9999',
+      storyId: 9999,
+      baseBranch: 'main',
+      mainCwd: '/nonexistent-path-for-test',
+      wtConfig: { enabled: false },
+      progress: () => {},
+      // This key used to be honoured; assert it's a no-op now.
+      forkAndCommitEpicSnapshot: () => {
+        calls.push('fork');
+        return { commit: { committed: true, sha: 'deadbeef' } };
+      },
+    });
+  } catch (err) {
+    // We expect a real failure because mainCwd doesn't exist; that's fine —
+    // the only thing under test is whether the snapshot helper was called.
+    threw = err;
+  }
+  assert.equal(
+    calls.length,
+    0,
+    'forkAndCommitEpicSnapshot must not be invoked from bootstrapWorktree',
+  );
+  // Sanity: we did exercise the function (or hit an early error before any
+  // call site that could have invoked the helper).
+  assert.ok(
+    threw !== null,
+    'bootstrapWorktree should have raised against the non-existent mainCwd',
+  );
+});

--- a/tests/single-story-close-auto-merge.test.js
+++ b/tests/single-story-close-auto-merge.test.js
@@ -1,0 +1,124 @@
+/**
+ * tests/single-story-close-auto-merge.test.js — unit tests for the
+ * auto-merge helpers added to `single-story-close.js` (Story #1815).
+ *
+ * Covers:
+ *   - `parsePrNumber` parses well-formed PR URLs and rejects junk.
+ *   - `enableAutoMerge` returns `{ enabled: true }` on `gh` exit 0 and
+ *     `{ enabled: false, reason }` on non-zero / spawn errors.
+ *   - Spawn args wire `--auto --squash --delete-branch` so GitHub merges
+ *     the PR when required checks pass and deletes the source branch.
+ */
+
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import {
+  enableAutoMerge,
+  parsePrNumber,
+} from '../.agents/scripts/single-story-close.js';
+
+describe('parsePrNumber', () => {
+  it('extracts the numeric id from a canonical GitHub PR URL', () => {
+    assert.equal(
+      parsePrNumber('https://github.com/dsj1984/mandrel/pull/1815'),
+      1815,
+    );
+  });
+
+  it('handles trailing slashes', () => {
+    assert.equal(
+      parsePrNumber('https://github.com/dsj1984/mandrel/pull/1815/'),
+      1815,
+    );
+  });
+
+  it('handles query strings and fragments', () => {
+    assert.equal(
+      parsePrNumber('https://github.com/owner/repo/pull/42?diff=split#diff-1'),
+      42,
+    );
+  });
+
+  it('returns null for URLs without /pull/<n>', () => {
+    assert.equal(
+      parsePrNumber('https://github.com/dsj1984/mandrel/issues/1815'),
+      null,
+    );
+    assert.equal(parsePrNumber('https://github.com/dsj1984/mandrel'), null);
+  });
+
+  it('returns null for non-string inputs', () => {
+    assert.equal(parsePrNumber(null), null);
+    assert.equal(parsePrNumber(undefined), null);
+    assert.equal(parsePrNumber(42), null);
+  });
+});
+
+describe('enableAutoMerge', () => {
+  it('passes --auto --squash --delete-branch to gh and reports enabled on exit 0', () => {
+    let capturedArgs = null;
+    let capturedOpts = null;
+    const runner = (args, opts) => {
+      capturedArgs = args;
+      capturedOpts = opts;
+      return { status: 0, stdout: 'ok', stderr: '' };
+    };
+    const result = enableAutoMerge({
+      cwd: '/repo',
+      prNumber: 123,
+      runner,
+    });
+    assert.deepEqual(result, { enabled: true });
+    assert.deepEqual(capturedArgs, [
+      'pr',
+      'merge',
+      '123',
+      '--auto',
+      '--squash',
+      '--delete-branch',
+    ]);
+    assert.deepEqual(capturedOpts, { cwd: '/repo' });
+  });
+
+  it('reports enabled:false with reason when gh exits non-zero', () => {
+    const runner = () => ({
+      status: 22,
+      stdout: '',
+      stderr: 'Pull request not in a state allowing auto-merge.',
+    });
+    const result = enableAutoMerge({
+      cwd: '/repo',
+      prNumber: 123,
+      runner,
+    });
+    assert.equal(result.enabled, false);
+    assert.match(result.reason, /gh-exit-22/);
+    assert.match(result.reason, /allowing auto-merge/);
+  });
+
+  it('reports enabled:false on spawn errors', () => {
+    const runner = () => {
+      throw new Error('ENOENT: gh not installed');
+    };
+    const result = enableAutoMerge({
+      cwd: '/repo',
+      prNumber: 123,
+      runner,
+    });
+    assert.equal(result.enabled, false);
+    assert.match(result.reason, /gh-spawn-error/);
+    assert.match(result.reason, /ENOENT/);
+  });
+
+  it('truncates very long stderr to keep the reason field readable', () => {
+    const longStderr = 'x'.repeat(500);
+    const runner = () => ({ status: 1, stderr: longStderr });
+    const result = enableAutoMerge({
+      cwd: '/repo',
+      prNumber: 123,
+      runner,
+    });
+    assert.ok(result.reason.length < 250);
+  });
+});


### PR DESCRIPTION
Closes #1815

_Auto-opened by `/single-story-execute`._