### PR TITLE
single-story-execute: sweep merged story branches at init (#1822)

### DIFF
--- a/.agents/scripts/lib/single-story-sweep.js
+++ b/.agents/scripts/lib/single-story-sweep.js
@@ -1,0 +1,151 @@
+/**
+ * single-story-sweep.js — Sweep merged `story-*` branches at init.
+ *
+ * Wraps `git-cleanup-branches.js` with a fixed policy tuned for the
+ * `/single-story-execute` boot path:
+ *
+ *   - Scope: `story-*` only (never touches `epic/*`, `story/<id>/*`, etc.).
+ *   - Mode:  --execute --remote (delete local + origin + prune trackers).
+ *   - Skip:  the current run's `storyBranch` is always excluded, even if a
+ *            stale PR for the same id were already merged.
+ *   - Errors are caught and surfaced in the envelope. The caller MUST NOT
+ *            propagate sweep failures — story init proceeds either way.
+ *
+ * Re-exports the same `planCleanup` / `executeCleanup` injection seams so
+ * tests can stub git/`gh` without touching the CLI.
+ */
+
+import {
+  buildGlobFilter,
+  executeCleanup as defaultExecuteCleanup,
+  planCleanup as defaultPlanCleanup,
+} from '../git-cleanup-branches.js';
+
+const STORY_BRANCH_INCLUDE = 'story-*';
+
+/**
+ * Sweep merged `story-*` branches in `cwd`.
+ *
+ * @param {{
+ *   cwd: string,
+ *   baseBranch: string,
+ *   currentStoryBranch: string,
+ *   logger?: { info?: (m: string) => void, warn?: (m: string) => void },
+ *   planCleanupFn?: typeof defaultPlanCleanup,
+ *   executeCleanupFn?: typeof defaultExecuteCleanup,
+ * }} args
+ * @returns {{
+ *   ok: boolean,
+ *   skipped: boolean,
+ *   candidates: number,
+ *   localDeleted: number,
+ *   remoteDeleted: number,
+ *   failures: Array<{ branch: string|null, scope: string, stderr?: string }>,
+ *   error?: string,
+ * }}
+ */
+export function sweepMergedStoryBranches({
+  cwd,
+  baseBranch,
+  currentStoryBranch,
+  logger = {},
+  planCleanupFn = defaultPlanCleanup,
+  executeCleanupFn = defaultExecuteCleanup,
+} = {}) {
+  const log = {
+    info: typeof logger.info === 'function' ? logger.info : () => {},
+    warn: typeof logger.warn === 'function' ? logger.warn : () => {},
+  };
+
+  if (typeof cwd !== 'string' || cwd.length === 0) {
+    return zeroResult({ error: 'cwd is required' });
+  }
+  if (typeof baseBranch !== 'string' || baseBranch.length === 0) {
+    return zeroResult({ error: 'baseBranch is required' });
+  }
+
+  // Exclude the current story branch. `currentStoryBranch` may be absent
+  // when the caller is sweeping outside an init context (e.g. tests).
+  const exclude =
+    typeof currentStoryBranch === 'string' && currentStoryBranch.length > 0
+      ? [currentStoryBranch]
+      : [];
+  const filter = buildGlobFilter({
+    include: [STORY_BRANCH_INCLUDE],
+    exclude,
+  });
+
+  let plan;
+  try {
+    plan = planCleanupFn({ cwd, baseBranch, filter });
+  } catch (err) {
+    const msg = err?.message ?? String(err);
+    log.warn(`[single-story-sweep] plan failed: ${msg}`);
+    return zeroResult({ error: `plan: ${msg}` });
+  }
+
+  if (plan.candidates.length === 0) {
+    log.info('[single-story-sweep] no merged story branches to reap.');
+    return {
+      ok: true,
+      skipped: false,
+      candidates: 0,
+      localDeleted: 0,
+      remoteDeleted: 0,
+      failures: [],
+    };
+  }
+
+  let result;
+  try {
+    result = executeCleanupFn({
+      candidates: plan.candidates,
+      cwd,
+      remote: true,
+    });
+  } catch (err) {
+    const msg = err?.message ?? String(err);
+    log.warn(`[single-story-sweep] execute failed: ${msg}`);
+    return {
+      ok: false,
+      skipped: false,
+      candidates: plan.candidates.length,
+      localDeleted: 0,
+      remoteDeleted: 0,
+      failures: [{ branch: null, scope: 'execute', stderr: msg }],
+      error: `execute: ${msg}`,
+    };
+  }
+
+  const localDeleted = result.local.filter((r) => r.ok).length;
+  const remoteDeleted = result.remote.filter((r) => r.ok).length;
+  const summary = `${localDeleted} local + ${remoteDeleted} remote`;
+  if (result.ok) {
+    log.info(`[single-story-sweep] reaped ${summary}.`);
+  } else {
+    log.warn(
+      `[single-story-sweep] reaped ${summary} with ${result.failures.length} failure(s) — init continues.`,
+    );
+  }
+
+  return {
+    ok: result.ok,
+    skipped: false,
+    candidates: plan.candidates.length,
+    localDeleted,
+    remoteDeleted,
+    failures: result.failures,
+  };
+}
+
+function zeroResult({ error }) {
+  return {
+    ok: false,
+    skipped: true,
+    candidates: 0,
+    localDeleted: 0,
+    remoteDeleted: 0,
+    failures: [],
+    error,
+  };
+}

--- a/.agents/scripts/single-story-init.js
+++ b/.agents/scripts/single-story-init.js
@@ -61,6 +61,7 @@ import { TYPE_LABELS } from './lib/label-constants.js';
 import { setActiveStoryEnv } from './lib/observability/active-story-env.js';
 import { upsertStructuredComment } from './lib/orchestration/ticketing.js';
 import { createProvider } from './lib/provider-factory.js';
+import { sweepMergedStoryBranches } from './lib/single-story-sweep.js';
 import { WorktreeManager } from './lib/worktree-manager.js';
 
 const progress = Logger.createProgress('single-story-init', { stderr: true });
@@ -74,6 +75,7 @@ export async function runSingleStoryInit({
   cwd: cwdParam,
   injectedProvider,
   injectedConfig,
+  injectedSweep,
 } = {}) {
   const parsed =
     storyIdParam !== undefined
@@ -134,6 +136,39 @@ export async function runSingleStoryInit({
       progress(
         'GIT',
         `Fetch completed after ${fetchResult.attempts} attempt(s) — packed-refs contention.`,
+      );
+    }
+
+    // Reap previously-merged `story-*` branches before we start a new one,
+    // so stale local + origin refs do not accumulate across runs. The sweep
+    // excludes the current run's `storyBranch` and never blocks init: any
+    // sweep failure is logged but does not throw.
+    const sweepFn = injectedSweep ?? sweepMergedStoryBranches;
+    try {
+      const sweep = sweepFn({
+        cwd,
+        baseBranch,
+        currentStoryBranch: storyBranch,
+        logger: {
+          info: (m) => progress('CLEANUP', m),
+          warn: (m) => progress('CLEANUP', `⚠️ ${m}`),
+        },
+      });
+      if (sweep.error) {
+        progress(
+          'CLEANUP',
+          `⚠️ sweep returned error (init continues): ${sweep.error}`,
+        );
+      } else if (sweep.candidates > 0) {
+        progress(
+          'CLEANUP',
+          `🧹 reaped ${sweep.localDeleted} local + ${sweep.remoteDeleted} remote story branch(es).`,
+        );
+      }
+    } catch (err) {
+      progress(
+        'CLEANUP',
+        `⚠️ sweep threw (init continues): ${err?.message ?? err}`,
       );
     }
 

--- a/.agents/workflows/single-story-execute.md
+++ b/.agents/workflows/single-story-execute.md
@@ -67,8 +67,18 @@ The script validates `type::story`, fetches `origin`, seeds
 `story-init` structured comment carrying `standalone: true`, and flips
 the Story to `agent::executing`.
 
+Between the fetch and the branch-seed step, the script also runs a
+**merged-`story-*` sweep**: it invokes the same primitive as
+`git-cleanup-branches.js` scoped to `story-*` only, in
+`--execute --remote` mode, with the current run's `story-<id>` branch
+excluded from the candidate list. Local refs, the matching `origin/`
+ref, and stale tracking refs for any merged sibling stories are reaped
+in one pass. The sweep never blocks init — failures are logged and the
+new story is initialized regardless.
+
 Capture `workCwd` from the result envelope. Add `--dry-run` to inspect
-the planned actions without git or ticket mutations.
+the planned actions without git or ticket mutations (dry-run also skips
+the sweep).
 
 ### Step 0.5 — `cd` into the workCwd
 

--- a/baselines/coverage.json
+++ b/baselines/coverage.json
@@ -231,7 +231,7 @@
   },
   ".agents/scripts/lib/cli-args.js": {
     "lines": 98.21,
-    "branches": 89.19,
+    "branches": 89.29,
     "functions": 100
   },
   ".agents/scripts/lib/cli-utils.js": {
@@ -555,8 +555,8 @@
     "functions": 100
   },
   ".agents/scripts/lib/orchestration/dispatch-engine.js": {
-    "lines": 82.74,
-    "branches": 76.92,
+    "lines": 92.39,
+    "branches": 85.71,
     "functions": 100
   },
   ".agents/scripts/lib/orchestration/dispatch-pipeline.js": {
@@ -906,12 +906,12 @@
   },
   ".agents/scripts/lib/presentation/manifest-formatter.js": {
     "lines": 97.14,
-    "branches": 85.02,
+    "branches": 85.53,
     "functions": 100
   },
   ".agents/scripts/lib/presentation/manifest-persistence.js": {
     "lines": 97.39,
-    "branches": 77.55,
+    "branches": 79.59,
     "functions": 100
   },
   ".agents/scripts/lib/presentation/manifest-renderer.js": {
@@ -968,6 +968,11 @@
     "lines": 100,
     "branches": 100,
     "functions": null
+  },
+  ".agents/scripts/lib/single-story-sweep.js": {
+    "lines": 100,
+    "branches": 90,
+    "functions": 100
   },
   ".agents/scripts/lib/spec/index.js": {
     "lines": 100,
@@ -1160,8 +1165,8 @@
     "functions": 100
   },
   ".agents/scripts/providers/github.js": {
-    "lines": 86.13,
-    "branches": 72.37,
+    "lines": 86.25,
+    "branches": 73.04,
     "functions": 86.67
   },
   ".agents/scripts/providers/github/projects-v2-graphql.js": {

--- a/tests/scripts/single-story-sweep.test.js
+++ b/tests/scripts/single-story-sweep.test.js
@@ -1,0 +1,190 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import { sweepMergedStoryBranches } from '../../.agents/scripts/lib/single-story-sweep.js';
+
+/**
+ * Build a `planCleanup` fake that returns the supplied candidates after
+ * applying the same `filter` the real implementation uses. Lets the test
+ * assert that the current-story branch is excluded by the include/exclude
+ * filter even when the underlying lister would have surfaced it.
+ */
+function makePlanFake(candidatePool) {
+  return ({ filter = () => true } = {}) => ({
+    candidates: candidatePool.filter((c) => filter(c.branch)),
+    skipped: candidatePool
+      .filter((c) => !filter(c.branch))
+      .map((c) => ({ branch: c.branch, reason: 'filtered' })),
+  });
+}
+
+function makeExecuteFake({ failures = [], extraLocalDropped = 0 } = {}) {
+  return ({ candidates }) => {
+    const local = candidates.map((c) => ({ branch: c.branch, ok: true }));
+    const remote = candidates.map((c) => ({ branch: c.branch, ok: true }));
+    // Allow simulating partial failures via injected `failures`.
+    for (let i = 0; i < extraLocalDropped && local.length > 0; i += 1) {
+      local[local.length - 1 - i].ok = false;
+    }
+    return {
+      worktrees: [],
+      local,
+      remote,
+      prune: { attempted: true, ok: true, remote: 'origin', pruned: [] },
+      failures,
+      ok: failures.length === 0,
+    };
+  };
+}
+
+describe('sweepMergedStoryBranches', () => {
+  it('reaps every merged story-* candidate the planner surfaces', () => {
+    const candidates = [
+      { branch: 'story-100', detectedBy: 'gh' },
+      { branch: 'story-101', detectedBy: 'gh' },
+    ];
+    const logs = [];
+    const result = sweepMergedStoryBranches({
+      cwd: '/tmp/repo',
+      baseBranch: 'main',
+      currentStoryBranch: 'story-200',
+      logger: { info: (m) => logs.push(['info', m]) },
+      planCleanupFn: makePlanFake(candidates),
+      executeCleanupFn: makeExecuteFake(),
+    });
+    assert.equal(result.ok, true);
+    assert.equal(result.candidates, 2);
+    assert.equal(result.localDeleted, 2);
+    assert.equal(result.remoteDeleted, 2);
+    assert.deepEqual(result.failures, []);
+  });
+
+  it('excludes the current story branch even when merged', () => {
+    // Planner pool includes the run's own branch — the filter must drop it.
+    const candidates = [
+      { branch: 'story-200', detectedBy: 'gh' }, // current
+      { branch: 'story-100', detectedBy: 'gh' },
+    ];
+    const result = sweepMergedStoryBranches({
+      cwd: '/tmp/repo',
+      baseBranch: 'main',
+      currentStoryBranch: 'story-200',
+      planCleanupFn: makePlanFake(candidates),
+      executeCleanupFn: makeExecuteFake(),
+    });
+    assert.equal(result.candidates, 1, 'current story not a candidate');
+    assert.equal(result.localDeleted, 1);
+  });
+
+  it('also excludes non-story branches via the include glob', () => {
+    const candidates = [
+      { branch: 'feat/foo', detectedBy: 'gh' },
+      { branch: 'epic/123', detectedBy: 'gh' },
+      { branch: 'story-7', detectedBy: 'gh' },
+    ];
+    const result = sweepMergedStoryBranches({
+      cwd: '/tmp/repo',
+      baseBranch: 'main',
+      currentStoryBranch: 'story-9',
+      planCleanupFn: makePlanFake(candidates),
+      executeCleanupFn: makeExecuteFake(),
+    });
+    assert.equal(result.candidates, 1);
+    assert.equal(
+      result.localDeleted,
+      1,
+      'only story-* branches are reaped — feat/* and epic/* pass through',
+    );
+  });
+
+  it('returns a zero envelope (no execute call) when there are no candidates', () => {
+    let executeCalled = false;
+    const result = sweepMergedStoryBranches({
+      cwd: '/tmp/repo',
+      baseBranch: 'main',
+      currentStoryBranch: 'story-1',
+      planCleanupFn: () => ({ candidates: [], skipped: [] }),
+      executeCleanupFn: () => {
+        executeCalled = true;
+        return { local: [], remote: [], failures: [], ok: true };
+      },
+    });
+    assert.equal(result.ok, true);
+    assert.equal(result.candidates, 0);
+    assert.equal(executeCalled, false, 'execute skipped on empty plan');
+  });
+
+  it('captures plan-time errors and never throws', () => {
+    const warns = [];
+    const result = sweepMergedStoryBranches({
+      cwd: '/tmp/repo',
+      baseBranch: 'main',
+      currentStoryBranch: 'story-1',
+      logger: { warn: (m) => warns.push(m) },
+      planCleanupFn: () => {
+        throw new Error('git not available');
+      },
+      executeCleanupFn: makeExecuteFake(),
+    });
+    assert.equal(result.ok, false);
+    assert.equal(result.skipped, true);
+    assert.match(result.error ?? '', /plan: git not available/);
+    assert.equal(warns.length, 1);
+  });
+
+  it('captures execute-time errors and reports them in the envelope', () => {
+    const candidates = [{ branch: 'story-100', detectedBy: 'gh' }];
+    const result = sweepMergedStoryBranches({
+      cwd: '/tmp/repo',
+      baseBranch: 'main',
+      currentStoryBranch: 'story-200',
+      planCleanupFn: makePlanFake(candidates),
+      executeCleanupFn: () => {
+        throw new Error('worktree busy');
+      },
+    });
+    assert.equal(result.ok, false);
+    assert.equal(result.candidates, 1);
+    assert.match(result.error ?? '', /execute: worktree busy/);
+    assert.equal(result.failures.length, 1);
+    assert.equal(result.failures[0].scope, 'execute');
+  });
+
+  it('surfaces partial reap failures without throwing', () => {
+    const candidates = [
+      { branch: 'story-100', detectedBy: 'gh' },
+      { branch: 'story-101', detectedBy: 'gh' },
+    ];
+    const result = sweepMergedStoryBranches({
+      cwd: '/tmp/repo',
+      baseBranch: 'main',
+      currentStoryBranch: 'story-200',
+      planCleanupFn: makePlanFake(candidates),
+      executeCleanupFn: makeExecuteFake({
+        extraLocalDropped: 1,
+        failures: [{ branch: 'story-101', scope: 'local', stderr: 'pinned' }],
+      }),
+    });
+    assert.equal(result.ok, false);
+    assert.equal(result.candidates, 2);
+    assert.equal(result.localDeleted, 1, 'one local succeeded, one failed');
+    assert.equal(result.failures.length, 1);
+  });
+
+  it('rejects malformed inputs (cwd / baseBranch) without throwing', () => {
+    const noCwd = sweepMergedStoryBranches({
+      baseBranch: 'main',
+      currentStoryBranch: 'story-1',
+    });
+    assert.equal(noCwd.ok, false);
+    assert.equal(noCwd.skipped, true);
+    assert.match(noCwd.error ?? '', /cwd is required/);
+
+    const noBase = sweepMergedStoryBranches({
+      cwd: '/tmp/repo',
+      currentStoryBranch: 'story-1',
+    });
+    assert.equal(noBase.ok, false);
+    assert.match(noBase.error ?? '', /baseBranch is required/);
+  });
+});


### PR DESCRIPTION
Closes #1822

_Auto-opened by `/single-story-execute`._