### PR TITLE
chore(release): cap release-please at minor bumps

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -123,6 +123,26 @@ Releases are automated by
    The existing `dist` sync in `ci.yml` propagates the new
    `.agents/VERSION` to consumers.
 
+#### Major-version policy
+
+`release-please-config.json` sets `"versioning": "always-bump-minor"`,
+which caps automatic bumps at the minor axis even when commits carry
+`BREAKING CHANGE:` footers or `!` markers. Major versions require
+**manual operator intervention**:
+
+1. Land the breaking work on `main` as usual (Conventional Commits).
+2. On the release PR that release-please opens, either:
+   - **Edit `package.json`, `.agents/VERSION`, and `docs/CHANGELOG.md`
+     in-place** on the release branch to set the major version
+     (release-please will respect the edits and tag accordingly), OR
+   - **Add a one-shot commit on `main`** with `Release-As: X.0.0` in
+     the trailer — release-please will adopt that as the proposed
+     version on its next run.
+
+The cap is intentional: it prevents an inadvertent `BREAKING CHANGE:`
+footer from auto-tagging a major release without an explicit human
+decision.
+
 ---
 
 ## Key Reference Documents

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -10,6 +10,7 @@
     ".": {
       "package-name": "mandrel",
       "changelog-path": "docs/CHANGELOG.md",
+      "versioning": "always-bump-minor",
       "extra-files": [
         {
           "type": "generic",


### PR DESCRIPTION
## Summary

Sets `versioning: "always-bump-minor"` in `release-please-config.json` so a `BREAKING CHANGE:` footer or `!`-marked commit can never auto-propose a major version. Major bumps now require explicit operator intervention.

This is the belt-and-suspenders follow-up to #1925 (release-please adoption + 1.0.0 reset). The bogus #1927 (`chore(main): release 2.0.0`) — opened because release-please scanned full history before the v1.0.0 anchor was tagged — was the trigger.

## Why

The original v6.0.0 → 1.0.0 reset surfaced this risk: release-please's first post-merge run scanned pre-rebrand history (the v1.0.0 anchor tag wasn't pushed yet) and proposed 2.0.0 from old `BREAKING CHANGE:` footers in archived commits. v1.0.0 is now tagged on `main` and `dist-v1.0.0` on `dist`. The cap ensures that even if a future post-rebrand commit accidentally carries a `BREAKING CHANGE:` footer, the major axis stays frozen until a human asks for it.

## Manual major-bump path

Two operator-driven options, documented in the AGENTS.md Release Checklist:

1. Edit `package.json`, `.agents/VERSION`, and `docs/CHANGELOG.md` directly on the open release PR branch.
2. Push a one-shot commit on `main` with `Release-As: X.0.0` in the trailer — release-please will adopt it.

## Test plan

- [x] `release-please-config.json` validates against its JSON Schema.
- [ ] After merge, the release-please workflow runs on `main`. Confirm it opens (or refrains from opening) a sensible release PR — anchored at v1.0.0, no automatic major proposed.

Closes the loose end from #1925.

🤖 Generated with [Claude Code](https://claude.com/claude-code)