### PR TITLE
fix(release): use PAT so release-please PRs trigger CI

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -23,11 +23,24 @@ jobs:
       # is a supply-chain risk vector (CWE-1357). Bump deliberately when a
       # new release-please-action ships; `npm run audit-security` flags
       # any reversion to `@main` / `@master`.
+      #
+      # Token preference: RELEASE_PLEASE_TOKEN (operator-managed PAT or
+      # GitHub App installation token) first, default GITHUB_TOKEN as
+      # fallback. The default GITHUB_TOKEN deliberately does NOT trigger
+      # downstream workflows on PRs it opens (GitHub's anti-recursion
+      # safeguard), so release PRs opened under it never run the required
+      # `Validate and Test` check and cannot satisfy branch protection on
+      # `main`. A user-scoped PAT (or App token) acts like a real user,
+      # so workflows fire normally and auto-merge can clear the gate
+      # without operator intervention. Create the PAT once (fine-scoped
+      # to this repo with `contents: write` + `pull-requests: write` +
+      # `workflows: write`) and store as the `RELEASE_PLEASE_TOKEN`
+      # repository secret.
       - name: Run release-please
         id: release
         uses: googleapis/release-please-action@v5.0.0
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -114,14 +114,69 @@ Releases are automated by
 1. Land Conventional Commits on `main` (the rules in
    [`.agents/rules/git-conventions.md`](.agents/rules/git-conventions.md)
    already enforce the commit-message contract).
-2. release-please opens a `chore(main): release X.Y.Z` PR. Review the
-   auto-generated entry in `docs/CHANGELOG.md` and the bumps to
-   `package.json` and `.agents/VERSION`.
-3. Merge the release PR. The workflow creates the GitHub Release, tags
-   `main` with `vX.Y.Z`, and mirrors a `dist-vX.Y.Z` tag onto the
-   `dist` branch tip so submodule consumers can pin to the release.
+2. release-please opens a `chore(main): release X.Y.Z` PR with
+   auto-merge enabled (squash). Review the auto-generated entry in
+   `docs/CHANGELOG.md` and the bumps to `package.json` and
+   `.agents/VERSION` if you want; otherwise no operator action is
+   needed.
+3. CI fires on the release PR automatically (because release-please
+   uses the operator-managed `RELEASE_PLEASE_TOKEN` PAT — see
+   [§ One-time PAT setup](#one-time-pat-setup) below). Once
+   `Validate and Test` passes, GitHub squash-merges the release PR,
+   which triggers the workflow to create the GitHub Release, tag
+   `main` with `vX.Y.Z`, and mirror a `dist-vX.Y.Z` tag onto `dist`.
    The existing `dist` sync in `ci.yml` propagates the new
    `.agents/VERSION` to consumers.
+
+#### One-time PAT setup
+
+GitHub's default `secrets.GITHUB_TOKEN` cannot trigger downstream
+workflows on PRs it opens (an anti-recursion safeguard), so release
+PRs opened under the default token never run the required
+`Validate and Test` status check and stay stuck in `BLOCKED` forever.
+Configure a Personal Access Token once to break the deadlock:
+
+1. Create a fine-grained PAT at
+   <https://github.com/settings/personal-access-tokens/new>:
+   - **Resource owner:** `dsj1984`
+   - **Repository access:** Only this repository (`mandrel`)
+   - **Repository permissions:**
+     - `Contents` → **Read and write**
+     - `Pull requests` → **Read and write**
+     - `Workflows` → **Read and write** (release-please-action requires
+       this to update workflow files when needed)
+     - `Issues` → **Read and write** (auto-close `Closes #` references)
+   - **Expiration:** As long as you want — re-rotate at expiry.
+2. Add the token as a repository secret named **`RELEASE_PLEASE_TOKEN`**
+   at <https://github.com/dsj1984/mandrel/settings/secrets/actions>.
+3. Re-run release-please (push any commit, or
+   `gh workflow run release-please.yml --repo dsj1984/mandrel`). The
+   refreshed PR will open under the PAT identity and `Validate and
+   Test` will fire automatically.
+
+Alternative: install a GitHub App with the same permissions and feed
+its installation token in via the same secret name. Apps have a higher
+ceiling on automation throughput than PATs.
+
+#### Major-version policy
+
+`release-please-config.json` sets `"versioning": "always-bump-minor"`,
+which caps automatic bumps at the minor axis even when commits carry
+`BREAKING CHANGE:` footers or `!` markers. Major versions require
+**manual operator intervention**:
+
+1. Land the breaking work on `main` as usual (Conventional Commits).
+2. On the release PR that release-please opens, either:
+   - **Edit `package.json`, `.agents/VERSION`, and `docs/CHANGELOG.md`
+     in-place** on the release branch to set the major version
+     (release-please will respect the edits and tag accordingly), OR
+   - **Add a one-shot commit on `main`** with `Release-As: X.0.0` in
+     the trailer — release-please will adopt that as the proposed
+     version on its next run.
+
+The cap is intentional: it prevents an inadvertent `BREAKING CHANGE:`
+footer from auto-tagging a major release without an explicit human
+decision.
 
 #### Major-version policy
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -178,26 +178,6 @@ The cap is intentional: it prevents an inadvertent `BREAKING CHANGE:`
 footer from auto-tagging a major release without an explicit human
 decision.
 
-#### Major-version policy
-
-`release-please-config.json` sets `"versioning": "always-bump-minor"`,
-which caps automatic bumps at the minor axis even when commits carry
-`BREAKING CHANGE:` footers or `!` markers. Major versions require
-**manual operator intervention**:
-
-1. Land the breaking work on `main` as usual (Conventional Commits).
-2. On the release PR that release-please opens, either:
-   - **Edit `package.json`, `.agents/VERSION`, and `docs/CHANGELOG.md`
-     in-place** on the release branch to set the major version
-     (release-please will respect the edits and tag accordingly), OR
-   - **Add a one-shot commit on `main`** with `Release-As: X.0.0` in
-     the trailer — release-please will adopt that as the proposed
-     version on its next run.
-
-The cap is intentional: it prevents an inadvertent `BREAKING CHANGE:`
-footer from auto-tagging a major release without an explicit human
-decision.
-
 ---
 
 ## Key Reference Documents


### PR DESCRIPTION
## Summary

Switches `.github/workflows/release-please.yml` to read its token from `secrets.RELEASE_PLEASE_TOKEN` (operator-managed PAT or GitHub App installation token) with `secrets.GITHUB_TOKEN` as fallback.

## Why

This is the root cause of #1930 sitting forever at `mergeStateStatus: BLOCKED` with `statusCheckRollup: []`. GitHub's default `secrets.GITHUB_TOKEN` deliberately does **not** trigger downstream workflows on PRs it opens (an anti-recursion safeguard). Release-please opens its PRs under that token, so the required `Validate and Test` check (per the `main` branch ruleset, id `14286998`) never fires and auto-merge cannot clear the gate.

A user-scoped PAT or GitHub App token acts like a real identity, so workflows fire normally. The fallback expression keeps the workflow loadable if the secret is unset (CI/lint won't break before the operator creates the PAT).

## One-time operator setup after this lands

1. Create a fine-grained PAT scoped to this repo with `Contents:write`, `Pull requests:write`, `Workflows:write`, `Issues:write` permissions.
2. Add it as repository secret `RELEASE_PLEASE_TOKEN`.
3. Re-run release-please (push any commit, or `gh workflow run release-please.yml`). The refreshed release PR will fire `Validate and Test` and auto-merge through.

Detailed steps live in [AGENTS.md § One-time PAT setup](AGENTS.md#one-time-pat-setup).

## Test plan

- [x] Workflow file passes YAML parse (IDE / actions linter clean apart from a benign "secret name not yet declared" warning that resolves when the secret is created).
- [ ] After merge: operator creates the PAT, re-triggers release-please, and confirms `Validate and Test` fires on the resulting release PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)