### PR TITLE
Harden epic close — auto-close planning tickets and de-fragilize Epic closure (#1951)

### DIFF
--- a/.agents/scripts/epic-close.js
+++ b/.agents/scripts/epic-close.js
@@ -2,40 +2,51 @@
 /* node:coverage ignore file */
 
 /**
- * epic-close.js — Epic-level close entry point with preflight guard.
+ * epic-close.js — Epic-level close entry point.
  *
- * Wires the self-healing checks registry into the front of any Epic-close
- * flow. Runs `runChecks({ scope: 'epic-close', autoFix: true })` against
- * the assembled state probe; if any `blocker` finding survives, prints a
- * `id · summary · fixCommand` table and exits with code 2 (the project's
- * reserved "preflight refused" exit code, mirrored by `story-close.js`
- * and the npm test wrapper).
+ * Two responsibilities:
  *
- * On a clean preflight (no blockers, possibly some auto-corrected
- * findings), the script logs the auto-fix summary and delegates to the
- * existing close-tail logic. The close-tail is intentionally a no-op
- * placeholder today — epic-close is currently a thin front-door that
- * exists so future work can pipe Epic-level integration tasks (PR merge,
- * branch reap, retro hook) through a single preflight-guarded entry.
+ *   1. Run the self-healing checks registry (scope=`epic-close`,
+ *      autoFix=true) as a preflight guard. Any surviving `blocker`
+ *      finding short-circuits with exit code 2 ("preflight refused").
+ *
+ *   2. On a clean preflight, run the post-merge close-tail (Story
+ *      #1951):
+ *        - Close the Epic's planning artifacts (PRD + Tech Spec) via
+ *          `closePlanningArtifacts`. Best-effort.
+ *        - Verify the Epic ticket is `state: 'closed'` via
+ *          `verifyAndRecoverEpicClose`; if GitHub did not auto-close
+ *          it (typically because the PR-driven `Closes #N` was
+ *          suppressed), apply a recovery transition to `agent::done`.
+ *
+ * Idempotent. Re-running against an Epic whose planning artifacts and
+ * Epic ticket are already closed is a no-op (each ticket transition is
+ * a no-op when the label already matches).
  *
  * Usage:
- *   node .agents/scripts/epic-close.js [--epic <epicId>]
+ *   node .agents/scripts/epic-close.js --epic <epicId>
  *
  * Exit codes:
- *   0 → preflight clean, delegated close-tail succeeded
- *   1 → unexpected error (anything other than preflight refusal)
+ *   0 → preflight clean, close-tail completed (or skipped where not applicable)
+ *   1 → unexpected error
  *   2 → preflight refused (blocker findings)
  *
  * @see .agents/scripts/lib/preflight-runner.js
- * @see .agents/README.md#self-healing-checks
+ * @see .agents/scripts/epic-deliver-finalize.js
  */
 
+import {
+  closePlanningArtifacts as defaultClosePlanningArtifacts,
+  verifyAndRecoverEpicClose as defaultVerifyAndRecoverEpicClose,
+} from './epic-deliver-finalize.js';
 import { runAsCli } from './lib/cli-utils.js';
+import { resolveConfig as defaultResolveConfig } from './lib/config-resolver.js';
 import { Logger } from './lib/Logger.js';
 import {
   PREFLIGHT_REFUSED_EXIT_CODE,
   runPreflight,
 } from './lib/preflight-runner.js';
+import { createProvider as defaultCreateProvider } from './lib/provider-factory.js';
 
 /** Default Logger adapter — same shape preflight-runner uses. */
 const DEFAULT_LOGGER = {
@@ -45,18 +56,90 @@ const DEFAULT_LOGGER = {
 };
 
 /**
- * Run the epic-close entry point. Exported for testing — the unit test
- * harness drives this directly with injected probes / fixture registry
- * rather than spawning a subprocess.
+ * Run the close-tail: planning-artifact close + Epic state recovery.
+ * Exported so the unit-test harness can drive it directly without
+ * having to thread fixture probes through the preflight runner.
+ *
+ * @param {{
+ *   epicId: number,
+ *   provider: object,
+ *   logger?: object,
+ *   closePlanningArtifactsFn?: typeof defaultClosePlanningArtifacts,
+ *   verifyAndRecoverEpicCloseFn?: typeof defaultVerifyAndRecoverEpicClose,
+ * }} opts
+ * @returns {Promise<{
+ *   planningClose: object,
+ *   epicClose: object,
+ * }>}
+ */
+export async function runEpicCloseTail({
+  epicId,
+  provider,
+  logger = DEFAULT_LOGGER,
+  closePlanningArtifactsFn = defaultClosePlanningArtifacts,
+  verifyAndRecoverEpicCloseFn = defaultVerifyAndRecoverEpicClose,
+} = {}) {
+  if (!Number.isInteger(epicId) || epicId <= 0) {
+    throw new TypeError(
+      'runEpicCloseTail: epicId is required (positive integer).',
+    );
+  }
+  if (!provider) {
+    throw new TypeError('runEpicCloseTail: provider is required.');
+  }
+
+  // Read the Epic so we have `linkedIssues.{prd,techSpec}` for the
+  // planning-close step. `getEpic` is preferred (parses linkedIssues
+  // out of the body); fall back to `getTicket` for test doubles.
+  let epic = null;
+  try {
+    if (typeof provider.getEpic === 'function') {
+      epic = await provider.getEpic(epicId);
+    } else if (typeof provider.getTicket === 'function') {
+      epic = await provider.getTicket(epicId);
+    }
+  } catch (err) {
+    logger.warn?.(
+      `[epic-close] failed to read Epic #${epicId}: ${err?.message ?? err}`,
+    );
+  }
+
+  const planningClose = await closePlanningArtifactsFn({
+    epicId,
+    epic,
+    provider,
+    logger,
+  });
+
+  const epicClose = await verifyAndRecoverEpicCloseFn({
+    epicId,
+    provider,
+    logger,
+  });
+
+  return { planningClose, epicClose };
+}
+
+/**
+ * Run the epic-close entry point. Exported for testing.
  *
  * @param {object} [opts]
- * @param {string} [opts.epicId]
+ * @param {number|string} [opts.epicId]
  * @param {string} [opts.cwd=process.cwd()]
  * @param {object} [opts.probes]   Test-only — forwarded to assembleState.
  * @param {object} [opts.registry] Test-only — bypass loadRegistry.
  * @param {string} [opts.dir]      Test-only fixture directory.
  * @param {{ info?: Function, warn?: Function, error?: Function }} [opts.logger]
- * @returns {Promise<{ status: 'ok' | 'blocked', findings: Array, fixed: Array }>}
+ * @param {object} [opts.injectedProvider] Test-only — bypass createProvider.
+ * @param {object} [opts.injectedConfig]   Test-only — bypass resolveConfig.
+ * @param {Function} [opts.runEpicCloseTailFn] Test seam for the close-tail body.
+ * @returns {Promise<{
+ *   status: 'ok' | 'blocked',
+ *   findings: Array,
+ *   fixed: Array,
+ *   planningClose?: object,
+ *   epicClose?: object,
+ * }>}
  */
 export async function runEpicClose({
   epicId,
@@ -65,9 +148,17 @@ export async function runEpicClose({
   registry,
   dir,
   logger = DEFAULT_LOGGER,
+  injectedProvider,
+  injectedConfig,
+  resolveConfigFn = defaultResolveConfig,
+  createProviderFn = defaultCreateProvider,
+  runEpicCloseTailFn = runEpicCloseTail,
 } = {}) {
+  const parsedEpicId = Number.parseInt(epicId, 10);
+  const haveEpicId = Number.isInteger(parsedEpicId) && parsedEpicId > 0;
+
   logger.info(
-    `[epic-close] Running preflight checks (scope=epic-close) for Epic #${epicId ?? '?'}...`,
+    `[epic-close] Running preflight checks (scope=epic-close) for Epic #${haveEpicId ? parsedEpicId : '?'}...`,
   );
   const preflight = await runPreflight({
     scope: 'epic-close',
@@ -85,18 +176,37 @@ export async function runEpicClose({
       fixed: preflight.fixed,
     };
   }
-  // Close-tail placeholder. Today epic-close.js exists as the preflight
-  // front door; subsequent Stories under Epic #1143 may add PR merge, retro
-  // hook, and branch reap here. The placeholder logs that the front door
-  // is clear so operators can distinguish "preflight passed; nothing to
-  // do" from "preflight passed; close-tail ran" in audit logs.
+
+  if (!haveEpicId) {
+    logger.warn(
+      '[epic-close] preflight clean — --epic <id> not supplied; skipping close-tail.',
+    );
+    return {
+      status: 'ok',
+      findings: preflight.findings,
+      fixed: preflight.fixed,
+    };
+  }
+
+  const config = injectedConfig ?? resolveConfigFn({ cwd });
+  const provider = injectedProvider ?? createProviderFn(config.orchestration);
+
+  logger.info(`[epic-close] Running close-tail for Epic #${parsedEpicId}...`);
+  const tail = await runEpicCloseTailFn({
+    epicId: parsedEpicId,
+    provider,
+    logger,
+  });
   logger.info(
-    '[epic-close] preflight clean — close-tail is currently a no-op.',
+    `[epic-close] complete — planning: prd=${tail.planningClose.prd.status} techSpec=${tail.planningClose.techSpec.status}; epic=${tail.epicClose.status}.`,
   );
+
   return {
     status: 'ok',
     findings: preflight.findings,
     fixed: preflight.fixed,
+    planningClose: tail.planningClose,
+    epicClose: tail.epicClose,
   };
 }
 

--- a/.agents/scripts/epic-deliver-finalize.js
+++ b/.agents/scripts/epic-deliver-finalize.js
@@ -39,7 +39,11 @@ import {
   emitEpicComplete,
   runHotspotDetection,
 } from './lib/orchestration/epic-runner/progress-reporter.js';
-import { upsertStructuredComment } from './lib/orchestration/ticketing.js';
+import {
+  STATE_LABELS,
+  transitionTicketState,
+  upsertStructuredComment,
+} from './lib/orchestration/ticketing.js';
 import { createProvider } from './lib/provider-factory.js';
 import { notify as defaultNotify } from './notify.js';
 
@@ -277,6 +281,142 @@ export async function reconcileBaselinesOnEpicBranch({
 }
 
 /**
+ * Close the Epic's linked PRD and Tech Spec planning artifacts.
+ *
+ * The cascade walker in `lib/orchestration/ticketing/bulk.js` does not
+ * recurse upward into the Epic (and historically excluded planning
+ * tickets), so without this helper the PRD / Tech Spec stay
+ * `agent::executing` (or whatever they were set to during planning)
+ * forever. Beyond cosmetics, leaving planning tickets open as native
+ * sub-issues of the Epic suppresses GitHub's PR-driven auto-close on
+ * the Epic itself when sub-issue parent-close rules apply — closing
+ * them here is what lets the `Closes #${epicId}` footer actually fire.
+ *
+ * Best-effort: a failure on one ticket logs a warn and is reported in
+ * the result envelope; it never blocks the PR from opening.
+ *
+ * @param {{
+ *   epicId: number,
+ *   epic: { linkedIssues?: { prd?: number|null, techSpec?: number|null } } | null,
+ *   provider: object,
+ *   logger?: object,
+ *   transitionFn?: typeof transitionTicketState,
+ * }} args
+ * @returns {Promise<{
+ *   prd: { id: number|null, status: 'closed'|'skipped'|'failed', detail?: string },
+ *   techSpec: { id: number|null, status: 'closed'|'skipped'|'failed', detail?: string },
+ * }>}
+ */
+export async function closePlanningArtifacts({
+  epicId,
+  epic,
+  provider,
+  logger = Logger,
+  transitionFn = transitionTicketState,
+} = {}) {
+  const result = {
+    prd: { id: null, status: 'skipped' },
+    techSpec: { id: null, status: 'skipped' },
+  };
+  const prdId = epic?.linkedIssues?.prd ?? null;
+  const techSpecId = epic?.linkedIssues?.techSpec ?? null;
+
+  for (const [kind, id] of [
+    ['prd', prdId],
+    ['techSpec', techSpecId],
+  ]) {
+    if (!Number.isInteger(id) || id <= 0) {
+      result[kind] = { id: null, status: 'skipped', detail: 'no-link' };
+      continue;
+    }
+    try {
+      // cascade:false avoids walking up the parent chain — the Epic is
+      // closed by GitHub when the operator merges the PR (or by the
+      // recovery path below), not by a cascade.
+      await transitionFn(provider, id, STATE_LABELS.DONE, { cascade: false });
+      result[kind] = { id, status: 'closed' };
+      logger.info?.(
+        `[epic-deliver-finalize] Closed planning artifact ${kind} #${id} for Epic #${epicId}.`,
+      );
+    } catch (err) {
+      const detail = err?.message ?? String(err);
+      result[kind] = { id, status: 'failed', detail };
+      logger.warn?.(
+        `[epic-deliver-finalize] Failed to close planning artifact ${kind} #${id}: ${detail}`,
+      );
+    }
+  }
+  return result;
+}
+
+/**
+ * Verify the Epic ticket reached `state: 'closed'` after the PR-driven
+ * auto-close window. If it is still open, transition it explicitly via
+ * `transitionTicketState`. Returns a structured envelope so callers can
+ * surface "primary auto-close worked" vs "recovery fired" in audit logs.
+ *
+ * Failures are non-fatal — a recovery attempt that throws leaves the
+ * Epic open and is reported in the envelope; the operator can re-run
+ * `/epic-close` or close manually.
+ *
+ * @param {{
+ *   epicId: number,
+ *   provider: object,
+ *   logger?: object,
+ *   transitionFn?: typeof transitionTicketState,
+ * }} args
+ * @returns {Promise<{
+ *   status: 'already-closed'|'recovered'|'still-open'|'check-failed',
+ *   priorState?: string,
+ *   detail?: string,
+ * }>}
+ */
+export async function verifyAndRecoverEpicClose({
+  epicId,
+  provider,
+  logger = Logger,
+  transitionFn = transitionTicketState,
+} = {}) {
+  let snapshot;
+  try {
+    if (typeof provider.invalidateTicket === 'function') {
+      try {
+        provider.invalidateTicket(epicId);
+      } catch {
+        // best-effort cache invalidation
+      }
+    }
+    snapshot = await provider.getTicket(epicId);
+  } catch (err) {
+    const detail = err?.message ?? String(err);
+    logger.warn?.(
+      `[epic-deliver-finalize] Epic #${epicId} close-verify read failed: ${detail}`,
+    );
+    return { status: 'check-failed', detail };
+  }
+  if (snapshot?.state === 'closed') {
+    return { status: 'already-closed', priorState: 'closed' };
+  }
+  logger.warn?.(
+    `[epic-deliver-finalize] Epic #${epicId} still open after PR finalize — applying recovery transition to agent::done.`,
+  );
+  try {
+    await transitionFn(provider, epicId, STATE_LABELS.DONE, { cascade: false });
+    return { status: 'recovered', priorState: snapshot?.state ?? 'open' };
+  } catch (err) {
+    const detail = err?.message ?? String(err);
+    logger.warn?.(
+      `[epic-deliver-finalize] Epic #${epicId} recovery transition failed: ${detail}`,
+    );
+    return {
+      status: 'still-open',
+      priorState: snapshot?.state ?? 'open',
+      detail,
+    };
+  }
+}
+
+/**
  * End-to-end finalize. DI-friendly.
  *
  * @param {{
@@ -309,6 +449,7 @@ export async function runEpicDeliverFinalize({
   upsertCommentFn = upsertStructuredComment,
   notifyFn = defaultNotify,
   reconcileBaselinesFn = reconcileBaselinesOnEpicBranch,
+  closePlanningArtifactsFn = closePlanningArtifacts,
 } = {}) {
   if (!Number.isInteger(epicId) || epicId <= 0) {
     throw new TypeError(
@@ -398,7 +539,16 @@ export async function runEpicDeliverFinalize({
   // 3. gh pr create.
   let epic;
   try {
-    epic = await provider.getTicket?.(epicId);
+    // Prefer `getEpic` so `linkedIssues.{prd,techSpec}` are parsed out of
+    // the Epic body for the planning-close phase below. Fall back to
+    // `getTicket` for providers / test doubles that do not expose the
+    // Epic-shaped reader — those callers will skip planning close
+    // because `linkedIssues` will be absent.
+    if (typeof provider.getEpic === 'function') {
+      epic = await provider.getEpic(epicId);
+    } else if (typeof provider.getTicket === 'function') {
+      epic = await provider.getTicket(epicId);
+    }
   } catch (err) {
     logger.warn?.(
       `[epic-deliver-finalize] failed to fetch Epic #${epicId} title: ${err?.message ?? err}`,
@@ -482,6 +632,18 @@ export async function runEpicDeliverFinalize({
     }
   }
 
+  // 3b. Close the Epic's planning artifacts (PRD + Tech Spec). The
+  // cascade walker does not auto-close them and leaving them open as
+  // native sub-issues of the Epic blocks GitHub's `Closes #${epicId}`
+  // auto-close path. Best-effort: failures land in the envelope but do
+  // not abort the rest of finalize.
+  const planningClose = await closePlanningArtifactsFn({
+    epicId,
+    epic,
+    provider,
+    logger,
+  });
+
   // 4. Post hand-off comment.
   const handoff = buildHandoffBody({ epicId, prUrl });
   let postedHandoff = false;
@@ -523,6 +685,7 @@ export async function runEpicDeliverFinalize({
     postedHandoff,
     autoMergeEnabled,
     reconcile,
+    planningClose,
   };
 }
 

--- a/.agents/scripts/lib/orchestration/ticketing/bulk.js
+++ b/.agents/scripts/lib/orchestration/ticketing/bulk.js
@@ -326,27 +326,32 @@ async function processCascadeParentLocked(
     );
     if (!allDone) return { cascadedTo, failed };
 
-    // EXCLUSION: Epics and Planning tickets (PRDs, Tech Specs) do not
-    // auto-close via cascade.
-    //   - Epics close via formal /epic-deliver (their own machinery
-    //     handles branch merges, version bumps, release tags).
-    //   - Planning tickets (context::prd, context::tech-spec) close by
-    //     operator once the Epic is finalized.
+    // EXCLUSION: Epics do not auto-close via cascade. Epics close via
+    // formal /epic-deliver (its own machinery handles branch merges,
+    // PR-driven `Closes #N` auto-close, and a recovery transition in
+    // `epic-deliver-finalize.js`).
     //
-    // Features, by contrast, DO auto-close via cascade. A Feature is a
-    // purely hierarchical grouping — no standalone branch, no merge
-    // step. When its last child Story closes, the Feature is complete
-    // by definition. Operators who need Feature-level AC verification
+    // Planning tickets (context::prd, context::tech-spec) DO close via
+    // cascade now (Story #1951). Previously they were excluded under
+    // the assumption that the operator would close them manually
+    // post-merge — but that step never reliably happened and leaving
+    // them open as native sub-issues of the Epic blocks GitHub from
+    // honoring the Epic's `Closes #N` footer. The Epic finalize phase
+    // also closes them explicitly; this cascade branch is the
+    // defense-in-depth path when a Story's tasklist references a
+    // planning ticket directly.
+    //
+    // Features auto-close via cascade. A Feature is a purely
+    // hierarchical grouping — no standalone branch, no merge step.
+    // When its last child Story closes, the Feature is complete by
+    // definition. Operators who need Feature-level AC verification
     // should encode it in the final child Story, not rely on a manual
     // close step.
     const parent = await provider.getTicket(parentId);
     const isEpic = parent.labels.includes(TYPE_LABELS.EPIC);
-    const isPlanning =
-      parent.labels.includes('context::prd') ||
-      parent.labels.includes('context::tech-spec');
-    if (isEpic || isPlanning) {
+    if (isEpic) {
       logger.warn(
-        `[Ticketing] Cascade reached ${isEpic ? 'Epic' : 'Planning'} #${parentId}. Skipping auto-close (Epics close via the operator's PR merge; Planning tickets close manually post-merge).`,
+        `[Ticketing] Cascade reached Epic #${parentId}. Skipping auto-close (Epics close via the operator's PR merge or /epic-close recovery).`,
       );
       return { cascadedTo, failed };
     }

--- a/baselines/maintainability.json
+++ b/baselines/maintainability.json
@@ -1,7 +1,7 @@
 {
   "$schema": ".agents/schemas/baselines/maintainability.schema.json",
   "kernelVersion": "0.1.0",
-  "generatedAt": "2026-05-15T19:49:56.516Z",
+  "generatedAt": "2026-05-15T21:01:50.417Z",
   "rollup": {
     "*": {
       "min": 0,
@@ -100,7 +100,7 @@
     },
     {
       "path": ".agents/scripts/epic-close.js",
-      "mi": 112.275
+      "mi": 97.229
     },
     {
       "path": ".agents/scripts/epic-code-review.js",
@@ -116,7 +116,7 @@
     },
     {
       "path": ".agents/scripts/epic-deliver-finalize.js",
-      "mi": 83.992
+      "mi": 81.364
     },
     {
       "path": ".agents/scripts/epic-deliver-note-intervention.js",
@@ -980,7 +980,7 @@
     },
     {
       "path": ".agents/scripts/lib/orchestration/ticketing/bulk.js",
-      "mi": 96.862
+      "mi": 97.182
     },
     {
       "path": ".agents/scripts/lib/orchestration/ticketing/reads.js",
@@ -1740,7 +1740,7 @@
     },
     {
       "path": "tests/epic-close-preflight.test.js",
-      "mi": 108.119
+      "mi": 105.181
     },
     {
       "path": "tests/epic-code-review-run.test.js",
@@ -2855,6 +2855,10 @@
       "mi": 101.796
     },
     {
+      "path": "tests/scripts/epic-close-planning-artifacts.test.js",
+      "mi": 105.012
+    },
+    {
       "path": "tests/scripts/epic-deliver-automerge.test.js",
       "mi": 113.219
     },
@@ -2868,7 +2872,7 @@
     },
     {
       "path": "tests/scripts/epic-deliver-finalize.test.js",
-      "mi": 108.083
+      "mi": 107.331
     },
     {
       "path": "tests/scripts/epic-deliver-note-intervention.test.js",

--- a/tests/epic-close-preflight.test.js
+++ b/tests/epic-close-preflight.test.js
@@ -84,23 +84,65 @@ describe('runEpicClose preflight', () => {
 
   it('proceeds with status ok when no findings exist (empty registry)', async () => {
     const logger = makeLogger();
+    const tailCalls = [];
+    const stubTail = async (args) => {
+      tailCalls.push(args);
+      return {
+        planningClose: {
+          prd: { id: null, status: 'skipped' },
+          techSpec: { id: null, status: 'skipped' },
+        },
+        epicClose: { status: 'already-closed' },
+      };
+    };
     const result = await runEpicClose({
       epicId: 1143,
       probes: noopProbes,
       registry: [],
       logger,
+      runEpicCloseTailFn: stubTail,
+      injectedProvider: {},
+      injectedConfig: { orchestration: {} },
     });
     assert.equal(result.status, 'ok');
     assert.deepEqual(result.findings, []);
     assert.deepEqual(result.fixed, []);
-    // Placeholder close-tail message lands on info.
+    // Close-tail ran with the parsed epicId.
+    assert.equal(tailCalls.length, 1);
+    assert.equal(tailCalls[0].epicId, 1143);
+    // Close-tail completion lands on info.
     const info = logger._lines.info.join('\n');
-    assert.match(info, /preflight clean/);
+    assert.match(info, /\[epic-close\] complete/);
+  });
+
+  it('skips close-tail when --epic is not supplied (preflight-only mode)', async () => {
+    const logger = makeLogger();
+    let tailCalled = false;
+    const result = await runEpicClose({
+      probes: noopProbes,
+      registry: [],
+      logger,
+      runEpicCloseTailFn: async () => {
+        tailCalled = true;
+        return {};
+      },
+    });
+    assert.equal(result.status, 'ok');
+    assert.equal(tailCalled, false);
+    const warn = logger._lines.warn.join('\n');
+    assert.match(warn, /skipping close-tail/);
   });
 
   it('logs auto-corrected findings via logFixes without blocking', async () => {
     const logger = makeLogger();
     let fixCalls = 0;
+    const stubTail = async () => ({
+      planningClose: {
+        prd: { id: null, status: 'skipped' },
+        techSpec: { id: null, status: 'skipped' },
+      },
+      epicClose: { status: 'already-closed' },
+    });
     const autoCheck = {
       id: 'fixture-epic-close-auto',
       severity: 'warning',
@@ -126,6 +168,9 @@ describe('runEpicClose preflight', () => {
       probes: noopProbes,
       registry: [autoCheck],
       logger,
+      runEpicCloseTailFn: stubTail,
+      injectedProvider: {},
+      injectedConfig: { orchestration: {} },
     });
     assert.equal(result.status, 'ok');
     assert.equal(result.findings.length, 0);

--- a/tests/scripts/epic-close-planning-artifacts.test.js
+++ b/tests/scripts/epic-close-planning-artifacts.test.js
@@ -1,0 +1,426 @@
+/**
+ * epic-close-planning-artifacts.test.js — Story #1951
+ *
+ * Covers the planning-artifact close + Epic-state recovery helpers and
+ * their composition in `runEpicCloseTail`. Drives the helpers directly
+ * with stub providers and transition functions — no preflight, no
+ * provider factory.
+ */
+
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import { runEpicCloseTail } from '../../.agents/scripts/epic-close.js';
+import {
+  closePlanningArtifacts,
+  verifyAndRecoverEpicClose,
+} from '../../.agents/scripts/epic-deliver-finalize.js';
+import {
+  __resetParentCascadeLocks,
+  __setCascadeRetryDelays,
+  cascadeCompletion,
+} from '../../.agents/scripts/lib/orchestration/ticketing.js';
+
+function makeLogger() {
+  const lines = { info: [], warn: [], error: [] };
+  return {
+    info: (m) => lines.info.push(m),
+    warn: (m) => lines.warn.push(m),
+    error: (m) => lines.error.push(m),
+    _lines: lines,
+  };
+}
+
+describe('closePlanningArtifacts', () => {
+  it('closes both PRD and Tech Spec when linked, cascade:false', async () => {
+    const calls = [];
+    const transitionFn = async (_provider, id, state, opts) => {
+      calls.push({ id, state, opts });
+    };
+    const result = await closePlanningArtifacts({
+      epicId: 100,
+      epic: { linkedIssues: { prd: 101, techSpec: 102 } },
+      provider: {},
+      logger: makeLogger(),
+      transitionFn,
+    });
+    assert.equal(result.prd.status, 'closed');
+    assert.equal(result.prd.id, 101);
+    assert.equal(result.techSpec.status, 'closed');
+    assert.equal(result.techSpec.id, 102);
+    assert.equal(calls.length, 2);
+    assert.equal(calls[0].id, 101);
+    assert.equal(calls[0].opts.cascade, false);
+    assert.equal(calls[1].id, 102);
+    assert.equal(calls[1].opts.cascade, false);
+  });
+
+  it('reports per-ticket partial failure without throwing', async () => {
+    const transitionFn = async (_provider, id) => {
+      if (id === 102) throw new Error('boom: tech spec transient');
+    };
+    const logger = makeLogger();
+    const result = await closePlanningArtifacts({
+      epicId: 100,
+      epic: { linkedIssues: { prd: 101, techSpec: 102 } },
+      provider: {},
+      logger,
+      transitionFn,
+    });
+    assert.equal(result.prd.status, 'closed');
+    assert.equal(result.techSpec.status, 'failed');
+    assert.match(result.techSpec.detail, /boom/);
+    // Failure log surfaced on warn, not error.
+    assert.equal(logger._lines.warn.length, 1);
+    assert.match(logger._lines.warn[0], /techSpec #102/);
+  });
+
+  it('skips when linkedIssues is missing entirely', async () => {
+    const calls = [];
+    const result = await closePlanningArtifacts({
+      epicId: 100,
+      epic: null,
+      provider: {},
+      logger: makeLogger(),
+      transitionFn: async (_p, id) => calls.push(id),
+    });
+    assert.equal(result.prd.status, 'skipped');
+    assert.equal(result.techSpec.status, 'skipped');
+    assert.equal(calls.length, 0);
+  });
+
+  it('skips when only one of PRD / Tech Spec is linked', async () => {
+    const calls = [];
+    const result = await closePlanningArtifacts({
+      epicId: 100,
+      epic: { linkedIssues: { prd: 101, techSpec: null } },
+      provider: {},
+      logger: makeLogger(),
+      transitionFn: async (_p, id) => calls.push(id),
+    });
+    assert.equal(result.prd.status, 'closed');
+    assert.equal(result.techSpec.status, 'skipped');
+    assert.equal(result.techSpec.detail, 'no-link');
+    assert.deepEqual(calls, [101]);
+  });
+});
+
+describe('verifyAndRecoverEpicClose', () => {
+  it('returns already-closed when Epic state is already closed', async () => {
+    const provider = {
+      getTicket: async () => ({ state: 'closed' }),
+    };
+    const transitionCalls = [];
+    const result = await verifyAndRecoverEpicClose({
+      epicId: 200,
+      provider,
+      logger: makeLogger(),
+      transitionFn: async (_p, id) => transitionCalls.push(id),
+    });
+    assert.equal(result.status, 'already-closed');
+    assert.equal(transitionCalls.length, 0);
+  });
+
+  it('fires recovery transition when Epic is still open', async () => {
+    const provider = {
+      getTicket: async () => ({ state: 'open' }),
+    };
+    const transitionCalls = [];
+    const transitionFn = async (_p, id, state, opts) => {
+      transitionCalls.push({ id, state, opts });
+    };
+    const logger = makeLogger();
+    const result = await verifyAndRecoverEpicClose({
+      epicId: 200,
+      provider,
+      logger,
+      transitionFn,
+    });
+    assert.equal(result.status, 'recovered');
+    assert.equal(result.priorState, 'open');
+    assert.equal(transitionCalls.length, 1);
+    assert.equal(transitionCalls[0].id, 200);
+    assert.equal(transitionCalls[0].opts.cascade, false);
+    assert.match(logger._lines.warn.join('\n'), /still open after PR finalize/);
+  });
+
+  it('returns still-open when recovery transition itself throws', async () => {
+    const provider = {
+      getTicket: async () => ({ state: 'open' }),
+    };
+    const transitionFn = async () => {
+      throw new Error('gh 403');
+    };
+    const result = await verifyAndRecoverEpicClose({
+      epicId: 200,
+      provider,
+      logger: makeLogger(),
+      transitionFn,
+    });
+    assert.equal(result.status, 'still-open');
+    assert.match(result.detail, /gh 403/);
+  });
+
+  it('returns check-failed when the snapshot read throws', async () => {
+    const provider = {
+      getTicket: async () => {
+        throw new Error('rate limited');
+      },
+    };
+    const transitionCalls = [];
+    const result = await verifyAndRecoverEpicClose({
+      epicId: 200,
+      provider,
+      logger: makeLogger(),
+      transitionFn: async () => transitionCalls.push(1),
+    });
+    assert.equal(result.status, 'check-failed');
+    assert.match(result.detail, /rate limited/);
+    assert.equal(transitionCalls.length, 0);
+  });
+
+  it('calls provider.invalidateTicket before reading when available', async () => {
+    const invalidated = [];
+    const provider = {
+      getTicket: async () => ({ state: 'closed' }),
+      invalidateTicket: (id) => invalidated.push(id),
+    };
+    await verifyAndRecoverEpicClose({
+      epicId: 200,
+      provider,
+      logger: makeLogger(),
+      transitionFn: async () => {},
+    });
+    assert.deepEqual(invalidated, [200]);
+  });
+});
+
+describe('runEpicCloseTail (idempotency + composition)', () => {
+  it('composes planning-close + epic-recovery and returns both envelopes', async () => {
+    const provider = {
+      getEpic: async () => ({
+        id: 300,
+        title: 'Test Epic',
+        body: 'PRD: #301\nTech Spec: #302',
+        linkedIssues: { prd: 301, techSpec: 302 },
+      }),
+    };
+    const planningCalls = [];
+    const closePlanningArtifactsFn = async ({ epicId, epic }) => {
+      planningCalls.push({ epicId, prd: epic?.linkedIssues?.prd });
+      return {
+        prd: { id: 301, status: 'closed' },
+        techSpec: { id: 302, status: 'closed' },
+      };
+    };
+    const verifyAndRecoverEpicCloseFn = async () => ({
+      status: 'recovered',
+      priorState: 'open',
+    });
+    const out = await runEpicCloseTail({
+      epicId: 300,
+      provider,
+      logger: makeLogger(),
+      closePlanningArtifactsFn,
+      verifyAndRecoverEpicCloseFn,
+    });
+    assert.equal(out.planningClose.prd.status, 'closed');
+    assert.equal(out.epicClose.status, 'recovered');
+    assert.equal(planningCalls[0].prd, 301);
+  });
+
+  it('is idempotent — running against an already-closed Epic with already-closed planning tickets is a no-op envelope', async () => {
+    // Simulate: planning tickets already done (transitionFn no-ops),
+    // Epic already closed.
+    const provider = {
+      getEpic: async () => ({
+        id: 300,
+        linkedIssues: { prd: 301, techSpec: 302 },
+      }),
+      getTicket: async () => ({ state: 'closed' }),
+    };
+    const transitionCalls = [];
+    const transitionFn = async (_p, id) => transitionCalls.push(id);
+    const out = await runEpicCloseTail({
+      epicId: 300,
+      provider,
+      logger: makeLogger(),
+      closePlanningArtifactsFn: (args) =>
+        closePlanningArtifacts({ ...args, transitionFn }),
+      verifyAndRecoverEpicCloseFn: (args) =>
+        verifyAndRecoverEpicClose({ ...args, transitionFn }),
+    });
+    // Planning transitions did fire (the helper does not pre-check state —
+    // transitionTicketState is itself idempotent under the agent::done
+    // label) but the Epic state-recovery short-circuits to already-closed.
+    assert.equal(out.planningClose.prd.status, 'closed');
+    assert.equal(out.planningClose.techSpec.status, 'closed');
+    assert.equal(out.epicClose.status, 'already-closed');
+    assert.deepEqual(transitionCalls, [301, 302]);
+  });
+
+  it('throws TypeError for invalid epicId', async () => {
+    await assert.rejects(
+      () => runEpicCloseTail({ epicId: 0, provider: {} }),
+      /positive integer/,
+    );
+    await assert.rejects(
+      () => runEpicCloseTail({ epicId: 100 }),
+      /provider is required/,
+    );
+  });
+
+  it('cascade no longer excludes planning tickets (Story #1951)', async () => {
+    // Regression: a PRD (context::prd) used to short-circuit the cascade.
+    // After Story #1951 the cascade closes planning parents the same way
+    // it closes Features.
+    __resetParentCascadeLocks();
+    __setCascadeRetryDelays({ delays: [1, 1, 1], sleep: async () => {} });
+    try {
+      const tickets = {
+        // PRD parent — previously excluded, now eligible.
+        500: {
+          id: 500,
+          labels: ['agent::executing', 'context::prd'],
+          body: 'PRD body',
+          state: 'open',
+        },
+        // Story child that already closed and references the PRD.
+        501: {
+          id: 501,
+          labels: ['agent::done', 'type::story'],
+          body: 'Story 501\nparent: #500',
+          state: 'closed',
+        },
+      };
+      const updateRecords = [];
+      const provider = {
+        async getTicket(id) {
+          return tickets[id];
+        },
+        async updateTicket(id, mutations) {
+          updateRecords.push({ id, mutations });
+          if (mutations.labels?.add?.includes('agent::done')) {
+            tickets[id] = {
+              ...tickets[id],
+              labels: ['agent::done', 'context::prd'],
+              state: 'closed',
+            };
+          }
+        },
+        async postComment() {},
+        async getTicketDependencies(id) {
+          const t = tickets[id];
+          const matches = t?.body
+            ? [...t.body.matchAll(/parent:\s*#(\d+)/gi)]
+            : [];
+          return {
+            blocks: matches.map((m) => Number.parseInt(m[1], 10)),
+            blockedBy: [],
+          };
+        },
+        async getSubTickets(id) {
+          if (id === 500) return [tickets[501]];
+          return [];
+        },
+        invalidateTicket() {},
+      };
+      const result = await cascadeCompletion(provider, 501);
+      assert.deepEqual(result.cascadedTo, [500]);
+      assert.deepEqual(result.failed, []);
+      const flipped = updateRecords.find((r) => r.id === 500);
+      assert.ok(flipped, 'PRD #500 must be updated by the cascade');
+      assert.ok(
+        flipped.mutations.labels?.add?.includes('agent::done'),
+        'PRD #500 must transition to agent::done',
+      );
+    } finally {
+      __setCascadeRetryDelays();
+      __resetParentCascadeLocks();
+    }
+  });
+
+  it('cascade still excludes Epics (Epic exclusion stays)', async () => {
+    __resetParentCascadeLocks();
+    __setCascadeRetryDelays({ delays: [1, 1, 1], sleep: async () => {} });
+    try {
+      const tickets = {
+        600: {
+          id: 600,
+          labels: ['agent::executing', 'type::epic'],
+          body: 'Epic body',
+          state: 'open',
+        },
+        601: {
+          id: 601,
+          labels: ['agent::done', 'type::story'],
+          body: 'Story 601\nparent: #600',
+          state: 'closed',
+        },
+      };
+      const updateRecords = [];
+      const provider = {
+        async getTicket(id) {
+          return tickets[id];
+        },
+        async updateTicket(id, mutations) {
+          updateRecords.push({ id, mutations });
+        },
+        async postComment() {},
+        async getTicketDependencies(id) {
+          const t = tickets[id];
+          const matches = t?.body
+            ? [...t.body.matchAll(/parent:\s*#(\d+)/gi)]
+            : [];
+          return {
+            blocks: matches.map((m) => Number.parseInt(m[1], 10)),
+            blockedBy: [],
+          };
+        },
+        async getSubTickets(id) {
+          if (id === 600) return [tickets[601]];
+          return [];
+        },
+        invalidateTicket() {},
+      };
+      const result = await cascadeCompletion(provider, 601);
+      assert.deepEqual(result.cascadedTo, []);
+      // Epic must NOT have been updated by the cascade.
+      assert.equal(
+        updateRecords.find((r) => r.id === 600),
+        undefined,
+      );
+    } finally {
+      __setCascadeRetryDelays();
+      __resetParentCascadeLocks();
+    }
+  });
+
+  it('falls back to getTicket when provider lacks getEpic', async () => {
+    const provider = {
+      getTicket: async (id) => ({
+        id,
+        linkedIssues: { prd: 401, techSpec: 402 },
+      }),
+    };
+    const planningCalls = [];
+    const closePlanningArtifactsFn = async ({ epic }) => {
+      planningCalls.push(epic?.linkedIssues?.prd);
+      return {
+        prd: { id: 401, status: 'closed' },
+        techSpec: { id: 402, status: 'closed' },
+      };
+    };
+    const verifyAndRecoverEpicCloseFn = async () => ({
+      status: 'already-closed',
+    });
+    await runEpicCloseTail({
+      epicId: 400,
+      provider,
+      logger: makeLogger(),
+      closePlanningArtifactsFn,
+      verifyAndRecoverEpicCloseFn,
+    });
+    assert.deepEqual(planningCalls, [401]);
+  });
+});

--- a/tests/scripts/epic-deliver-finalize.test.js
+++ b/tests/scripts/epic-deliver-finalize.test.js
@@ -491,3 +491,118 @@ test('runEpicDeliverFinalize: rejects missing/invalid epicId', async () => {
     /positive integer/,
   );
 });
+
+test('runEpicDeliverFinalize: closes planning artifacts after gh pr create succeeds (Story #1951)', async () => {
+  // Verifies the new 3b phase: the Epic's linked PRD and Tech Spec are
+  // closed via the injected `closePlanningArtifactsFn` after the PR is
+  // opened, and the result is surfaced in the envelope as `planningClose`.
+  const provider = {
+    async getEpic(id) {
+      return {
+        id,
+        title: 'Test Epic',
+        linkedIssues: { prd: 9001, techSpec: 9002 },
+      };
+    },
+    async getTicket(id) {
+      return { id, title: 'fallback' };
+    },
+  };
+  const { fn: gitSpawnFn } = makeGitSpawnFn([
+    { matcher: (args) => args[0] === 'fetch', response: { status: 0 } },
+    { matcher: (args) => args[0] === 'merge-base', response: { status: 0 } },
+    {
+      matcher: (args) => args[0] === 'rev-list',
+      response: { status: 0, stdout: '1' },
+    },
+    { matcher: (args) => args[0] === 'push', response: { status: 0 } },
+  ]);
+  const planningCalls = [];
+  const closePlanningArtifactsFn = async ({ epicId, epic, provider: p }) => {
+    planningCalls.push({
+      epicId,
+      prd: epic?.linkedIssues?.prd,
+      hasProvider: !!p,
+    });
+    return {
+      prd: { id: 9001, status: 'closed' },
+      techSpec: { id: 9002, status: 'closed' },
+    };
+  };
+  const out = await runEpicDeliverFinalize({
+    epicId: 1942,
+    cwd: '.',
+    injectedProvider: provider,
+    injectedConfig: {
+      agentSettings: { baseBranch: 'main' },
+      orchestration: {},
+    },
+    loggerImpl: { info: () => {}, warn: () => {}, error: () => {} },
+    gitSpawnFn,
+    ghSpawnFn: () => ({
+      status: 0,
+      stdout: 'https://github.com/me/repo/pull/123\n',
+      stderr: '',
+    }),
+    upsertCommentFn: async () => ({ commentId: 1 }),
+    notifyFn: () => Promise.resolve(),
+    closePlanningArtifactsFn,
+  });
+
+  assert.equal(planningCalls.length, 1);
+  assert.equal(planningCalls[0].epicId, 1942);
+  assert.equal(planningCalls[0].prd, 9001);
+  assert.equal(planningCalls[0].hasProvider, true);
+  assert.deepEqual(out.planningClose, {
+    prd: { id: 9001, status: 'closed' },
+    techSpec: { id: 9002, status: 'closed' },
+  });
+});
+
+test('runEpicDeliverFinalize: planning-close partial failure does not block finalize', async () => {
+  // PRD closes ok, Tech Spec transition throws — finalize must still
+  // succeed and report `planningClose.techSpec.status === 'failed'`.
+  const provider = {
+    async getEpic(id) {
+      return { id, linkedIssues: { prd: 9001, techSpec: 9002 } };
+    },
+  };
+  const { fn: gitSpawnFn } = makeGitSpawnFn([
+    { matcher: (args) => args[0] === 'fetch', response: { status: 0 } },
+    { matcher: (args) => args[0] === 'merge-base', response: { status: 0 } },
+    {
+      matcher: (args) => args[0] === 'rev-list',
+      response: { status: 0, stdout: '1' },
+    },
+    { matcher: (args) => args[0] === 'push', response: { status: 0 } },
+  ]);
+  const closePlanningArtifactsFn = async () => ({
+    prd: { id: 9001, status: 'closed' },
+    techSpec: { id: 9002, status: 'failed', detail: 'transient gh 500' },
+  });
+  const out = await runEpicDeliverFinalize({
+    epicId: 1942,
+    cwd: '.',
+    injectedProvider: provider,
+    injectedConfig: {
+      agentSettings: { baseBranch: 'main' },
+      orchestration: {},
+    },
+    loggerImpl: { info: () => {}, warn: () => {}, error: () => {} },
+    gitSpawnFn,
+    ghSpawnFn: () => ({
+      status: 0,
+      stdout: 'https://github.com/me/repo/pull/123\n',
+      stderr: '',
+    }),
+    upsertCommentFn: async () => ({ commentId: 1 }),
+    notifyFn: () => Promise.resolve(),
+    closePlanningArtifactsFn,
+  });
+
+  assert.equal(out.pushed, true);
+  assert.equal(out.prUrl, 'https://github.com/me/repo/pull/123');
+  assert.equal(out.postedHandoff, true);
+  assert.equal(out.blocker, undefined);
+  assert.equal(out.planningClose.techSpec.status, 'failed');
+});


### PR DESCRIPTION
Closes #1951

_Auto-opened by `/single-story-execute`._