### PR TITLE
close-validation: run full-scope CRAP + coverage gates before push, not just diff-scope (#1945)

### DIFF
--- a/.agents/scripts/lib/cli-args.js
+++ b/.agents/scripts/lib/cli-args.js
@@ -56,6 +56,7 @@ export function parseSprintArgs(args = process.argv) {
       'skip-dashboard': { type: 'boolean', default: false },
       'skip-validation': { type: 'boolean', default: false },
       'no-auto-merge': { type: 'boolean', default: false },
+      'no-full-scope-crap': { type: 'boolean', default: false },
       executor: { type: 'string' },
       cwd: { type: 'string' },
       'recut-of': { type: 'string' },
@@ -75,6 +76,7 @@ export function parseSprintArgs(args = process.argv) {
     skipDashboard: values['skip-dashboard'] ?? false,
     skipValidation: coerceBooleanFlag(values['skip-validation']),
     noAutoMerge: coerceBooleanFlag(values['no-auto-merge']),
+    noFullScopeCrap: coerceBooleanFlag(values['no-full-scope-crap']),
     executor: values.executor ?? null,
     // Resolve worktree cwd from flag or env. Empty string/whitespace → null.
     cwd:

--- a/.agents/scripts/lib/close-validation.js
+++ b/.agents/scripts/lib/close-validation.js
@@ -186,10 +186,26 @@ function buildTestGateEntry(agentSettings) {
  * baseline at the Epic-branch HEAD via `git show` rather than via a
  * working-tree fs read.
  *
- * @param {{ agentSettings?: object, epicBranch?: string }} [opts]
+ * Story #1945: by default the CRAP gate runs `--full-scope` at close time,
+ * mirroring CI's post-merge `push` event on main. Diff-scoped close-
+ * validation can miss method-level regressions in untouched files whose
+ * coverage drifts because of shared fixtures, run-order, or
+ * instrumentation paths — those surfaced as red main-branch builds in
+ * incidents like PR #1942 → hotfix #1944. Catching them at close costs a
+ * full-tree CRAP scan (~3s on a ~1400-method repo) but spares the
+ * forced-rebase + hotfix round-trip after auto-merge. Pass
+ * `fullScopeCrap: false` to revert to diff-scope behaviour (exposed to
+ * operators via the `--no-full-scope-crap` flag on
+ * `single-story-close.js`).
+ *
+ * @param {{ agentSettings?: object, epicBranch?: string, fullScopeCrap?: boolean }} [opts]
  * @returns {Gate[]}
  */
-export function buildDefaultGates({ agentSettings, epicBranch } = {}) {
+export function buildDefaultGates({
+  agentSettings,
+  epicBranch,
+  fullScopeCrap = true,
+} = {}) {
   const typecheckCmdString = resolveTypecheckCommand(agentSettings);
   const [typecheckCmd, ...typecheckArgs] = typecheckCmdString
     .split(/\s+/)
@@ -237,8 +253,14 @@ export function buildDefaultGates({ agentSettings, epicBranch } = {}) {
     {
       name: 'check-crap',
       cmd: 'node',
-      args: ['.agents/scripts/check-crap.js', ...epicRefArgs],
-      hint: 'Reduce complexity or add coverage on the flagged methods, or run `npm run crap:update` and commit with a `baseline-refresh:` tagged subject + non-empty body if the drift is justified. Self-skips when `agentSettings.quality.crap.enabled` is false.',
+      args: [
+        '.agents/scripts/check-crap.js',
+        ...epicRefArgs,
+        ...(fullScopeCrap ? ['--full-scope'] : []),
+      ],
+      hint: fullScopeCrap
+        ? 'Reduce complexity or add coverage on the flagged methods. If the regression is environmental (e.g. Linux vs. Windows coverage drift on an untouched file), run `npm run crap:update -- --full-scope` and commit a `baseline-refresh:` tagged subject + non-empty body. Self-skips when `agentSettings.quality.crap.enabled` is false.'
+        : 'Reduce complexity or add coverage on the flagged methods, or run `npm run crap:update` and commit with a `baseline-refresh:` tagged subject + non-empty body if the drift is justified. Self-skips when `agentSettings.quality.crap.enabled` is false.',
     },
     ...buildMutationGateEntry(agentSettings),
     {

--- a/.agents/scripts/single-story-close.js
+++ b/.agents/scripts/single-story-close.js
@@ -69,6 +69,7 @@ export async function runSingleStoryClose({
   cwd: cwdParam,
   skipValidation: skipValidationParam,
   noAutoMerge: noAutoMergeParam,
+  noFullScopeCrap: noFullScopeCrapParam,
   injectedProvider,
   injectedConfig,
 } = {}) {
@@ -79,16 +80,19 @@ export async function runSingleStoryClose({
           cwd: cwdParam ?? null,
           skipValidation: !!skipValidationParam,
           noAutoMerge: !!noAutoMergeParam,
+          noFullScopeCrap: !!noFullScopeCrapParam,
         }
       : parseSprintArgs();
   const { storyId } = parsed;
   const skipValidation = skipValidationParam ?? parsed.skipValidation ?? false;
   const noAutoMerge = noAutoMergeParam ?? parsed.noAutoMerge ?? false;
+  const noFullScopeCrap =
+    noFullScopeCrapParam ?? parsed.noFullScopeCrap ?? false;
   const cwd = path.resolve(cwdParam ?? parsed.cwd ?? PROJECT_ROOT);
 
   if (!storyId) {
     throw new Error(
-      'Usage: node single-story-close.js --story <STORY_ID> [--cwd <main-repo>] [--skip-validation] [--no-auto-merge]',
+      'Usage: node single-story-close.js --story <STORY_ID> [--cwd <main-repo>] [--skip-validation] [--no-auto-merge] [--no-full-scope-crap]',
     );
   }
 
@@ -137,7 +141,11 @@ export async function runSingleStoryClose({
     const validation = await runCloseValidation({
       cwd,
       worktreePath,
-      gates: buildDefaultGates({ agentSettings, epicBranch: baseBranch }),
+      gates: buildDefaultGates({
+        agentSettings,
+        epicBranch: baseBranch,
+        fullScopeCrap: !noFullScopeCrap,
+      }),
       log: (m) => Logger.info(m),
       storyId,
       // Standalone Stories have no parent Epic, so there's no per-Epic

--- a/.agents/workflows/single-story-execute.md
+++ b/.agents/workflows/single-story-execute.md
@@ -171,9 +171,17 @@ close after a fixed gate failure that's already known to pass.
 `--no-auto-merge` disables Step 3a. Use when the PR materially changes
 behaviour and warrants pre-merge review.
 
+`--no-full-scope-crap` disables the close-time full-scope CRAP scan
+(Story #1945) and falls back to the diff-scoped check the framework used
+historically. The full-scope scan adds ~3s to close on a ~1400-method
+repo; the opt-out exists for cases where that cost becomes prohibitive.
+The post-merge CI run still enforces full-scope CRAP either way, so the
+opt-out trades close-time detection for the slower watch-loop round-trip
+described in Step 4.
+
 ---
 
-## Step 4 — CI watch + fix loop (**required, not optional**)
+## Step 4 — CI watch + fix loop (safety net, post Story #1945)
 
 The Story is **not done** when `single-story-close.js` returns. Auto-merge
 only fires when every required CI check turns green. Local close-validation
@@ -182,6 +190,16 @@ particular concurrency), but CI runs on a different OS and concurrency —
 coverage rounding, platform-conditional branches, and timing-sensitive
 tests routinely drift between the two. The agent owns the green-CI
 outcome, not just the push.
+
+Story #1945 narrowed the gap by running **full-scope** CRAP and coverage
+gates at close time, mirroring CI's post-merge `push` event on main. The
+common drift mode that motivated this workflow's watch+fix loop — an
+unrelated method's CRAP score regressing on CI Linux after a PR that
+didn't touch the file — is now caught **before** push in the close-
+validation chain rather than after auto-merge in the CI run. Genuine
+host-vs-CI drift (platform-conditional code paths, true flakes) still
+escapes close, so the loop below remains the canonical safety net; it is
+no longer the primary detection point for environmental CRAP drift.
 
 After `single-story-close.js` succeeds, enter the watch + fix loop:
 

--- a/baselines/crap.json
+++ b/baselines/crap.json
@@ -1,7 +1,7 @@
 {
   "$schema": ".agents/schemas/baselines/crap.schema.json",
   "kernelVersion": "0.1.0",
-  "generatedAt": "2026-05-15T20:40:33.537Z",
+  "generatedAt": "2026-05-15T21:29:39.902Z",
   "rollup": {
     "*": {
       "p50": 3,
@@ -67,12 +67,6 @@
     },
     {
       "path": ".agents/scripts/analyze-execution.js",
-      "method": "<anon method-8>",
-      "startLine": 316,
-      "crap": 1
-    },
-    {
-      "path": ".agents/scripts/analyze-execution.js",
       "method": "collectStorySummaries",
       "startLine": 367,
       "crap": 8.215784143518519
@@ -97,12 +91,6 @@
     },
     {
       "path": ".agents/scripts/analyze-execution.js",
-      "method": "<anon method-17>",
-      "startLine": 575,
-      "crap": 1
-    },
-    {
-      "path": ".agents/scripts/analyze-execution.js",
       "method": "parseCli",
       "startLine": 663,
       "crap": 10
@@ -111,7 +99,7 @@
       "path": ".agents/scripts/analyze-execution.js",
       "method": "main",
       "startLine": 691,
-      "crap": 3.2710123456790123
+      "crap": 3.131456790123457
     },
     {
       "path": ".agents/scripts/check-baselines.js",
@@ -555,12 +543,6 @@
       "path": ".agents/scripts/epic-code-review.js",
       "method": "<anon method-2>",
       "startLine": 588,
-      "crap": 1
-    },
-    {
-      "path": ".agents/scripts/epic-code-review.js",
-      "method": "<anon method-3>",
-      "startLine": 594,
       "crap": 1
     },
     {
@@ -1575,7 +1557,7 @@
       "path": ".agents/scripts/lib/checks/baseline-drift-main-checkout.js",
       "method": "samePath",
       "startLine": 95,
-      "crap": 4.175582990397805
+      "crap": 4.021947873799726
     },
     {
       "path": ".agents/scripts/lib/checks/index.js",
@@ -1784,91 +1766,91 @@
     {
       "path": ".agents/scripts/lib/cli-args.js",
       "method": "camelCase",
-      "startLine": 104,
+      "startLine": 106,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/cli-args.js",
       "method": "initialValueFor",
-      "startLine": 108,
+      "startLine": 110,
       "crap": 4
     },
     {
       "path": ".agents/scripts/lib/cli-args.js",
       "method": "coerceValue",
-      "startLine": 115,
+      "startLine": 117,
       "crap": 4.074074074074074
     },
     {
       "path": ".agents/scripts/lib/cli-args.js",
       "method": "validateSpec",
-      "startLine": 147,
+      "startLine": 149,
       "crap": 2
     },
     {
       "path": ".agents/scripts/lib/cli-args.js",
       "method": "initParserState",
-      "startLine": 157,
+      "startLine": 159,
       "crap": 2
     },
     {
       "path": ".agents/scripts/lib/cli-args.js",
       "method": "classifyToken",
-      "startLine": 170,
+      "startLine": 172,
       "crap": 6
     },
     {
       "path": ".agents/scripts/lib/cli-args.js",
       "method": "assignFlagValue",
-      "startLine": 184,
+      "startLine": 186,
       "crap": 2
     },
     {
       "path": ".agents/scripts/lib/cli-args.js",
       "method": "readValuedFlag",
-      "startLine": 192,
+      "startLine": 194,
       "crap": 6
     },
     {
       "path": ".agents/scripts/lib/cli-args.js",
       "method": "parseTokens",
-      "startLine": 208,
+      "startLine": 210,
       "crap": 8.040303206997084
     },
     {
       "path": ".agents/scripts/lib/cli-args.js",
       "method": "isAbsentValue",
-      "startLine": 244,
+      "startLine": 246,
       "crap": 3
     },
     {
       "path": ".agents/scripts/lib/cli-args.js",
       "method": "applyEnvFallbacks",
-      "startLine": 250,
+      "startLine": 252,
       "crap": 6
     },
     {
       "path": ".agents/scripts/lib/cli-args.js",
       "method": "applyDefaults",
-      "startLine": 263,
+      "startLine": 265,
       "crap": 4
     },
     {
       "path": ".agents/scripts/lib/cli-args.js",
       "method": "defineFlags",
-      "startLine": 274,
+      "startLine": 276,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/cli-utils.js",
       "method": "isDirectInvocation",
-      "startLine": 27,
+      "startLine": 28,
       "crap": 2
     },
     {
       "path": ".agents/scripts/lib/cli-utils.js",
       "method": "runAsCli",
-      "startLine": 46,
+      "startLine": 47,
       "crap": 3
     },
     {
@@ -1916,85 +1898,85 @@
     {
       "path": ".agents/scripts/lib/close-validation.js",
       "method": "buildDefaultGates",
-      "startLine": 192,
-      "crap": 3
+      "startLine": 204,
+      "crap": 5
     },
     {
       "path": ".agents/scripts/lib/close-validation.js",
       "method": "buildMutationGateEntry",
-      "startLine": 270,
+      "startLine": 292,
       "crap": 5.054012345679013
     },
     {
       "path": ".agents/scripts/lib/close-validation.js",
       "method": "partitionGates",
-      "startLine": 315,
+      "startLine": 337,
       "crap": 2
     },
     {
       "path": ".agents/scripts/lib/close-validation.js",
       "method": "pipePrefixed",
-      "startLine": 330,
+      "startLine": 352,
       "crap": 2
     },
     {
       "path": ".agents/scripts/lib/close-validation.js",
       "method": "attachGateAbortHandler",
-      "startLine": 366,
+      "startLine": 388,
       "crap": 3
     },
     {
       "path": ".agents/scripts/lib/close-validation.js",
       "method": "<anon method-5>",
-      "startLine": 368,
+      "startLine": 390,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/close-validation.js",
       "method": "<anon method-6>",
-      "startLine": 377,
+      "startLine": 399,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/close-validation.js",
       "method": "gateExitCode",
-      "startLine": 384,
+      "startLine": 406,
       "crap": 3
     },
     {
       "path": ".agents/scripts/lib/close-validation.js",
       "method": "defaultGateRunner",
-      "startLine": 389,
+      "startLine": 411,
       "crap": 12
     },
     {
       "path": ".agents/scripts/lib/close-validation.js",
       "method": "runCloseValidation",
-      "startLine": 451,
+      "startLine": 473,
       "crap": 11.149667110471283
     },
     {
       "path": ".agents/scripts/lib/close-validation.js",
       "method": "<anon method-12>",
-      "startLine": 480,
+      "startLine": 502,
       "crap": 5.8053155522163795
     },
     {
       "path": ".agents/scripts/lib/close-validation.js",
       "method": "<anon method-13>",
-      "startLine": 503,
+      "startLine": 525,
       "crap": 3.062196307094266
     },
     {
       "path": ".agents/scripts/lib/close-validation.js",
       "method": "<anon method-14>",
-      "startLine": 526,
+      "startLine": 548,
       "crap": 3
     },
     {
       "path": ".agents/scripts/lib/close-validation.js",
       "method": "emitGhSpawnCount",
-      "startLine": 665,
+      "startLine": 687,
       "crap": 5.000390625
     },
     {
@@ -2916,6 +2898,42 @@
       "crap": 4
     },
     {
+      "path": ".agents/scripts/lib/error-redactor.js",
+      "method": "resolveRepoRoot",
+      "startLine": 26,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/error-redactor.js",
+      "method": "redactErrorMessage",
+      "startLine": 48,
+      "crap": 4
+    },
+    {
+      "path": ".agents/scripts/lib/error-redactor.js",
+      "method": "pathVariants",
+      "startLine": 75,
+      "crap": 3
+    },
+    {
+      "path": ".agents/scripts/lib/error-redactor.js",
+      "method": "parseQuietErrorsFlag",
+      "startLine": 97,
+      "crap": 4
+    },
+    {
+      "path": ".agents/scripts/lib/error-redactor.js",
+      "method": "isTruthyEnv",
+      "startLine": 106,
+      "crap": 4
+    },
+    {
+      "path": ".agents/scripts/lib/error-redactor.js",
+      "method": "formatCliError",
+      "startLine": 122,
+      "crap": 2
+    },
+    {
       "path": ".agents/scripts/lib/fs-utils.js",
       "method": "ensureDirSync",
       "startLine": 20,
@@ -2943,7 +2961,7 @@
       "path": ".agents/scripts/lib/gates/baseline-store.js",
       "method": "writeBaseline",
       "startLine": 82,
-      "crap": 1
+      "crap": 1.000512
     },
     {
       "path": ".agents/scripts/lib/gates/friction.js",
@@ -3223,12 +3241,6 @@
     },
     {
       "path": ".agents/scripts/lib/git-branch-lifecycle.js",
-      "method": "<anon method-1>",
-      "startLine": 69,
-      "crap": 1
-    },
-    {
-      "path": ".agents/scripts/lib/git-branch-lifecycle.js",
       "method": "_assertOnBranch",
       "startLine": 131,
       "crap": 2
@@ -3238,12 +3250,6 @@
       "method": "checkoutStoryBranch",
       "startLine": 152,
       "crap": 7
-    },
-    {
-      "path": ".agents/scripts/lib/git-branch-lifecycle.js",
-      "method": "<anon method-2>",
-      "startLine": 159,
-      "crap": 1
     },
     {
       "path": ".agents/scripts/lib/git-branch-lifecycle.js",
@@ -3259,21 +3265,9 @@
     },
     {
       "path": ".agents/scripts/lib/git-branch-lifecycle.js",
-      "method": "<anon method-3>",
-      "startLine": 230,
-      "crap": 1
-    },
-    {
-      "path": ".agents/scripts/lib/git-branch-lifecycle.js",
       "method": "ensureLocalBranch",
       "startLine": 276,
       "crap": 2
-    },
-    {
-      "path": ".agents/scripts/lib/git-branch-lifecycle.js",
-      "method": "<anon method-4>",
-      "startLine": 278,
-      "crap": 1
     },
     {
       "path": ".agents/scripts/lib/git-utils.js",
@@ -3303,18 +3297,6 @@
       "path": ".agents/scripts/lib/git-utils.js",
       "method": "createGitInterface",
       "startLine": 138,
-      "crap": 1
-    },
-    {
-      "path": ".agents/scripts/lib/git-utils.js",
-      "method": "<anon method-2>",
-      "startLine": 142,
-      "crap": 1
-    },
-    {
-      "path": ".agents/scripts/lib/git-utils.js",
-      "method": "<anon method-3>",
-      "startLine": 142,
       "crap": 1
     },
     {
@@ -3655,12 +3637,6 @@
     },
     {
       "path": ".agents/scripts/lib/mutation/baseline-snapshot.js",
-      "method": "<anon method-1>",
-      "startLine": 104,
-      "crap": 1
-    },
-    {
-      "path": ".agents/scripts/lib/mutation/baseline-snapshot.js",
       "method": "validateBaseline",
       "startLine": 167,
       "crap": 17.147968
@@ -3688,12 +3664,6 @@
       "method": "runStryker",
       "startLine": 70,
       "crap": 15.033554814675682
-    },
-    {
-      "path": ".agents/scripts/lib/mutation/stryker-runner.js",
-      "method": "<anon method-1>",
-      "startLine": 79,
-      "crap": 1
     },
     {
       "path": ".agents/scripts/lib/mutation/stryker-runner.js",
@@ -3778,12 +3748,6 @@
       "method": "computeBaselineRefreshRate",
       "startLine": 129,
       "crap": 14
-    },
-    {
-      "path": ".agents/scripts/lib/observability/baseline-refresh-rate.js",
-      "method": "<anon method-1>",
-      "startLine": 130,
-      "crap": 1
     },
     {
       "path": ".agents/scripts/lib/observability/baseline-refresh-rate.js",
@@ -4299,7 +4263,7 @@
       "path": ".agents/scripts/lib/orchestration/dispatch-engine.js",
       "method": "resolveAndDispatch",
       "startLine": 88,
-      "crap": 16
+      "crap": 8.006910700788252
     },
     {
       "path": ".agents/scripts/lib/orchestration/dispatch-engine.js",
@@ -4393,18 +4357,6 @@
     },
     {
       "path": ".agents/scripts/lib/orchestration/epic-runner/commit-assertion.js",
-      "method": "<anon method-2>",
-      "startLine": 125,
-      "crap": 1
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/epic-runner/commit-assertion.js",
-      "method": "<anon method-3>",
-      "startLine": 127,
-      "crap": 1
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/epic-runner/commit-assertion.js",
       "method": "defaultGitAdapter",
       "startLine": 129,
       "crap": 4
@@ -4432,12 +4384,6 @@
       "method": "createEpicRunnerCollaborators",
       "startLine": 26,
       "crap": 1.0034783092634332
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/epic-runner/factory.js",
-      "method": "<anon method-1>",
-      "startLine": 36,
-      "crap": 1
     },
     {
       "path": ".agents/scripts/lib/orchestration/epic-runner/factory.js",
@@ -5943,7 +5889,7 @@
       "path": ".agents/scripts/lib/orchestration/story-close/close-inputs.js",
       "method": "resolveCloseInputs",
       "startLine": 67,
-      "crap": 7.007143898527482
+      "crap": 7
     },
     {
       "path": ".agents/scripts/lib/orchestration/story-close/comment-bodies.js",
@@ -5968,12 +5914,6 @@
       "method": "runFormatAutofix",
       "startLine": 73,
       "crap": 5
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/story-close/format-autofix.js",
-      "method": "<anon method-3>",
-      "startLine": 83,
-      "crap": 1
     },
     {
       "path": ".agents/scripts/lib/orchestration/story-close/merge-runner.js",
@@ -6405,7 +6345,7 @@
       "path": ".agents/scripts/lib/orchestration/ticketing/bulk.js",
       "method": "processCascadeParentLocked",
       "startLine": 254,
-      "crap": 8.002978829089308
+      "crap": 5.001046556177126
     },
     {
       "path": ".agents/scripts/lib/orchestration/ticketing/bulk.js",
@@ -6416,19 +6356,19 @@
     {
       "path": ".agents/scripts/lib/orchestration/ticketing/bulk.js",
       "method": "<anon method-9>",
-      "startLine": 364,
+      "startLine": 369,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/orchestration/ticketing/bulk.js",
       "method": "cascadeCompletion",
-      "startLine": 428,
+      "startLine": 433,
       "crap": 6
     },
     {
       "path": ".agents/scripts/lib/orchestration/ticketing/bulk.js",
       "method": "<anon method-11>",
-      "startLine": 461,
+      "startLine": 466,
       "crap": 1
     },
     {
@@ -6591,7 +6531,7 @@
       "path": ".agents/scripts/lib/orchestration/wave-record-io.js",
       "method": "refreshLocalManifest",
       "startLine": 180,
-      "crap": 1.0000214334705075
+      "crap": 1
     },
     {
       "path": ".agents/scripts/lib/orchestration/wave-record-notifications.js",
@@ -7036,12 +6976,6 @@
       "method": "printStoryDispatchTable",
       "startLine": 91,
       "crap": 6
-    },
-    {
-      "path": ".agents/scripts/lib/presentation/manifest-story-views.js",
-      "method": "<anon method-2>",
-      "startLine": 92,
-      "crap": 1
     },
     {
       "path": ".agents/scripts/lib/provider-factory.js",
@@ -7782,22 +7716,10 @@
       "crap": 3
     },
     {
-      "path": ".agents/scripts/lib/story-init/blocker-validator.js",
-      "method": "<anon method-1>",
-      "startLine": 23,
-      "crap": 1
-    },
-    {
       "path": ".agents/scripts/lib/story-init/context-resolver.js",
       "method": "resolveContext",
       "startLine": 26,
       "crap": 10.629221665908057
-    },
-    {
-      "path": ".agents/scripts/lib/story-init/context-resolver.js",
-      "method": "<anon method-1>",
-      "startLine": 28,
-      "crap": 1
     },
     {
       "path": ".agents/scripts/lib/story-init/dependency-guard.js",
@@ -7837,12 +7759,6 @@
     },
     {
       "path": ".agents/scripts/lib/story-init/dependency-guard.js",
-      "method": "<anon method-5>",
-      "startLine": 262,
-      "crap": 1
-    },
-    {
-      "path": ".agents/scripts/lib/story-init/dependency-guard.js",
       "method": "formatBlockerReport",
       "startLine": 290,
       "crap": 2
@@ -7861,21 +7777,9 @@
     },
     {
       "path": ".agents/scripts/lib/story-init/donor-precheck.js",
-      "method": "<anon method-1>",
-      "startLine": 84,
-      "crap": 1.421875
-    },
-    {
-      "path": ".agents/scripts/lib/story-init/donor-precheck.js",
       "method": "ensureDonorPrimed",
       "startLine": 117,
       "crap": 8.529453068149095
-    },
-    {
-      "path": ".agents/scripts/lib/story-init/donor-precheck.js",
-      "method": "<anon method-2>",
-      "startLine": 129,
-      "crap": 1
     },
     {
       "path": ".agents/scripts/lib/story-init/hierarchy-tracer.js",
@@ -7884,21 +7788,9 @@
       "crap": 1
     },
     {
-      "path": ".agents/scripts/lib/story-init/hierarchy-tracer.js",
-      "method": "<anon method-1>",
-      "startLine": 21,
-      "crap": 1
-    },
-    {
       "path": ".agents/scripts/lib/story-init/state-transitioner.js",
       "method": "transitionTaskStates",
       "startLine": 30,
-      "crap": 1
-    },
-    {
-      "path": ".agents/scripts/lib/story-init/state-transitioner.js",
-      "method": "<anon method-1>",
-      "startLine": 32,
       "crap": 1
     },
     {
@@ -7912,18 +7804,6 @@
       "method": "buildTaskGraph",
       "startLine": 45,
       "crap": 2
-    },
-    {
-      "path": ".agents/scripts/lib/story-init/task-graph-builder.js",
-      "method": "<anon method-4>",
-      "startLine": 47,
-      "crap": 1
-    },
-    {
-      "path": ".agents/scripts/lib/story-init/task-graph-builder.js",
-      "method": "<anon method-5>",
-      "startLine": 48,
-      "crap": 1
     },
     {
       "path": ".agents/scripts/lib/story-init/transition-summary.js",
@@ -8059,12 +7939,6 @@
     },
     {
       "path": ".agents/scripts/lib/util/phase-timer.js",
-      "method": "<anon method-1>",
-      "startLine": 81,
-      "crap": 1
-    },
-    {
-      "path": ".agents/scripts/lib/util/phase-timer.js",
       "method": "closeCurrent",
       "startLine": 111,
       "crap": 2
@@ -8121,12 +7995,6 @@
       "path": ".agents/scripts/lib/validation-evidence.js",
       "method": "resolveOpts",
       "startLine": 79,
-      "crap": 1
-    },
-    {
-      "path": ".agents/scripts/lib/validation-evidence.js",
-      "method": "<anon method-1>",
-      "startLine": 84,
       "crap": 1
     },
     {
@@ -8254,12 +8122,6 @@
       "method": "handleCrapWorkerMessage",
       "startLine": 57,
       "crap": 13
-    },
-    {
-      "path": ".agents/scripts/lib/workers/crap-worker.js",
-      "method": "<anon method-1>",
-      "startLine": 76,
-      "crap": 1
     },
     {
       "path": ".agents/scripts/lib/workers/maintainability-worker.js",
@@ -8769,7 +8631,7 @@
       "path": ".agents/scripts/providers/github.js",
       "method": "paginateRest",
       "startLine": 223,
-      "crap": 5.0407083248524325
+      "crap": 5
     },
     {
       "path": ".agents/scripts/providers/github/auth.js",
@@ -9147,60 +9009,60 @@
       "path": ".agents/scripts/single-story-close.js",
       "method": "runSingleStoryClose",
       "startLine": 67,
-      "crap": 19.44592258076451
+      "crap": 19.402973140743992
     },
     {
       "path": ".agents/scripts/single-story-close.js",
       "method": "<anon method-1>",
-      "startLine": 141,
+      "startLine": 149,
       "crap": 1
     },
     {
       "path": ".agents/scripts/single-story-close.js",
       "method": "<anon method-3>",
-      "startLine": 253,
+      "startLine": 261,
       "crap": 2
     },
     {
       "path": ".agents/scripts/single-story-close.js",
       "method": "<anon method-4>",
-      "startLine": 254,
+      "startLine": 262,
       "crap": 2
     },
     {
       "path": ".agents/scripts/single-story-close.js",
       "method": "<anon method-5>",
-      "startLine": 255,
+      "startLine": 263,
       "crap": 2
     },
     {
       "path": ".agents/scripts/single-story-close.js",
       "method": "<anon method-6>",
-      "startLine": 272,
+      "startLine": 280,
       "crap": 1
     },
     {
       "path": ".agents/scripts/single-story-close.js",
       "method": "ensurePullRequest",
-      "startLine": 305,
+      "startLine": 313,
       "crap": 3
     },
     {
       "path": ".agents/scripts/single-story-close.js",
       "method": "parsePrNumber",
-      "startLine": 387,
+      "startLine": 395,
       "crap": 5
     },
     {
       "path": ".agents/scripts/single-story-close.js",
       "method": "enableAutoMerge",
-      "startLine": 407,
+      "startLine": 415,
       "crap": 2
     },
     {
       "path": ".agents/scripts/single-story-close.js",
       "method": "defaultGhAutoMergeRunner",
-      "startLine": 431,
+      "startLine": 439,
       "crap": 2
     },
     {

--- a/baselines/maintainability.json
+++ b/baselines/maintainability.json
@@ -1,7 +1,7 @@
 {
   "$schema": ".agents/schemas/baselines/maintainability.schema.json",
   "kernelVersion": "0.1.0",
-  "generatedAt": "2026-05-15T21:01:50.417Z",
+  "generatedAt": "2026-05-15T21:26:16.340Z",
   "rollup": {
     "*": {
       "min": 0,
@@ -388,15 +388,15 @@
     },
     {
       "path": ".agents/scripts/lib/cli-args.js",
-      "mi": 89.321
+      "mi": 88.972
     },
     {
       "path": ".agents/scripts/lib/cli-utils.js",
-      "mi": 112.695
+      "mi": 112.427
     },
     {
       "path": ".agents/scripts/lib/close-validation.js",
-      "mi": 95.351
+      "mi": 95.307
     },
     {
       "path": ".agents/scripts/lib/close-validation/projections/head-sha.js",
@@ -1372,7 +1372,7 @@
     },
     {
       "path": ".agents/scripts/single-story-close.js",
-      "mi": 85.18
+      "mi": 84.897
     },
     {
       "path": ".agents/scripts/single-story-init.js",
@@ -1576,7 +1576,7 @@
     },
     {
       "path": "tests/check-crap-epic-ref.test.js",
-      "mi": 116.19
+      "mi": 116.196
     },
     {
       "path": "tests/check-crap-json.test.js",
@@ -1617,6 +1617,10 @@
     {
       "path": "tests/cli-utils-redactor.test.js",
       "mi": 113.227
+    },
+    {
+      "path": "tests/close-validation-full-scope-crap.test.js",
+      "mi": 116.28
     },
     {
       "path": "tests/close-validation-mi-projection.test.js",
@@ -1900,7 +1904,7 @@
     },
     {
       "path": "tests/gate-integration.test.js",
-      "mi": 94.264
+      "mi": 94.244
     },
     {
       "path": "tests/gate-json-byte-stability.test.js",
@@ -2440,7 +2444,7 @@
     },
     {
       "path": "tests/lib/orchestration/story-close/pre-merge-validation-extra.test.js",
-      "mi": 114.22
+      "mi": 114.251
     },
     {
       "path": "tests/lib/orchestration/story-close/project-crap-regressions.test.js",
@@ -3028,7 +3032,7 @@
     },
     {
       "path": "tests/story-close.test.js",
-      "mi": 102.964
+      "mi": 102.969
     },
     {
       "path": "tests/story-close/format-autofix.test.js",

--- a/tests/check-crap-epic-ref.test.js
+++ b/tests/check-crap-epic-ref.test.js
@@ -132,6 +132,32 @@ describe('check-crap — --epic-ref (Story #1120)', () => {
       '.agents/scripts/check-crap.js',
       '--epic-ref',
       'epic/1114',
+      '--full-scope',
     ]);
+  });
+
+  it('buildDefaultGates defaults to full-scope CRAP (Story #1945)', () => {
+    const gates = buildDefaultGates({});
+    const crap = gates.find((g) => g.name === 'check-crap');
+    assert.ok(crap);
+    assert.ok(
+      crap.args.includes('--full-scope'),
+      'CRAP gate must pass --full-scope at close time by default',
+    );
+    assert.match(
+      crap.hint,
+      /--full-scope/,
+      'CRAP gate hint must mention the full-scope baseline-refresh remediation',
+    );
+  });
+
+  it('buildDefaultGates omits --full-scope when fullScopeCrap is false (Story #1945)', () => {
+    const gates = buildDefaultGates({ fullScopeCrap: false });
+    const crap = gates.find((g) => g.name === 'check-crap');
+    assert.ok(crap);
+    assert.ok(
+      !crap.args.includes('--full-scope'),
+      'CRAP gate must omit --full-scope when fullScopeCrap=false',
+    );
   });
 });

--- a/tests/check-crap-epic-ref.test.js
+++ b/tests/check-crap-epic-ref.test.js
@@ -135,29 +135,4 @@ describe('check-crap — --epic-ref (Story #1120)', () => {
       '--full-scope',
     ]);
   });
-
-  it('buildDefaultGates defaults to full-scope CRAP (Story #1945)', () => {
-    const gates = buildDefaultGates({});
-    const crap = gates.find((g) => g.name === 'check-crap');
-    assert.ok(crap);
-    assert.ok(
-      crap.args.includes('--full-scope'),
-      'CRAP gate must pass --full-scope at close time by default',
-    );
-    assert.match(
-      crap.hint,
-      /--full-scope/,
-      'CRAP gate hint must mention the full-scope baseline-refresh remediation',
-    );
-  });
-
-  it('buildDefaultGates omits --full-scope when fullScopeCrap is false (Story #1945)', () => {
-    const gates = buildDefaultGates({ fullScopeCrap: false });
-    const crap = gates.find((g) => g.name === 'check-crap');
-    assert.ok(crap);
-    assert.ok(
-      !crap.args.includes('--full-scope'),
-      'CRAP gate must omit --full-scope when fullScopeCrap=false',
-    );
-  });
 });

--- a/tests/close-validation-full-scope-crap.test.js
+++ b/tests/close-validation-full-scope-crap.test.js
@@ -1,0 +1,111 @@
+// tests/close-validation-full-scope-crap.test.js
+//
+// Story #1945 — close-validation must run the CRAP gate at full-scope by
+// default so a method-level regression in a file the Story did NOT touch
+// is caught before push. The motivating incident (PR #1942 → hotfix
+// #1944) saw three full-scope CRAP regressions land on main because the
+// diff-scoped close-validation gate never inspected the affected files.
+// These tests pin the contract:
+//
+//   1. buildDefaultGates injects --full-scope into the check-crap args by
+//      default.
+//   2. An opt-out via fullScopeCrap=false drops --full-scope (mirrors the
+//      --no-full-scope-crap CLI flag operators can pass to
+//      single-story-close.js when the full-tree scan becomes prohibitive).
+//   3. runCloseValidation propagates the --full-scope arg to the spawned
+//      gate runner, so a regression in an unrelated file *would* surface
+//      at close time under a mocked runner that detects it.
+
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import {
+  buildDefaultGates,
+  runCloseValidation,
+} from '../.agents/scripts/lib/close-validation.js';
+
+describe('close-validation full-scope CRAP (Story #1945)', () => {
+  it('check-crap gate defaults to --full-scope', () => {
+    const gates = buildDefaultGates({});
+    const crap = gates.find((g) => g.name === 'check-crap');
+    assert.ok(crap, 'check-crap gate must be present');
+    assert.equal(crap.cmd, 'node');
+    assert.ok(
+      crap.args.includes('--full-scope'),
+      `expected --full-scope in CRAP args; got ${JSON.stringify(crap.args)}`,
+    );
+  });
+
+  it('fullScopeCrap=false drops --full-scope so operators can opt out', () => {
+    const gates = buildDefaultGates({ fullScopeCrap: false });
+    const crap = gates.find((g) => g.name === 'check-crap');
+    assert.ok(crap);
+    assert.ok(
+      !crap.args.includes('--full-scope'),
+      `expected no --full-scope when fullScopeCrap=false; got ${JSON.stringify(crap.args)}`,
+    );
+  });
+
+  it('full-scope close-time CRAP catches a regression in an untouched file', async () => {
+    // Simulate the PR #1942 incident: the Story under close touched
+    // `analyze-execution.js`, but the regression is in
+    // `dispatch-engine.js::resolveAndDispatch`. A diff-scoped runner
+    // would never inspect that file; a --full-scope runner does. We
+    // express that by inspecting the args the runner receives: when the
+    // gate carries --full-scope the runner returns "regression detected"
+    // (non-zero), otherwise it returns 0 because the diff doesn't touch
+    // the regressed file.
+    const fakeRunner = (cmd, args) => {
+      if (
+        cmd === 'node' &&
+        args.some((a) => a.endsWith('check-crap.js')) &&
+        args.includes('--full-scope')
+      ) {
+        return { status: 1 };
+      }
+      return { status: 0 };
+    };
+
+    // Pin a minimal gate list to avoid spawning the real typecheck/lint
+    // chain — we only need the CRAP gate's contract under the runner.
+    const crapGate = buildDefaultGates({}).find((g) => g.name === 'check-crap');
+    const fullScopeResult = await runCloseValidation({
+      cwd: process.cwd(),
+      gates: [crapGate],
+      runner: fakeRunner,
+      log: () => {},
+    });
+    assert.equal(
+      fullScopeResult.ok,
+      false,
+      'full-scope CRAP must surface the untouched-file regression at close time',
+    );
+    assert.equal(fullScopeResult.failed[0].gate.name, 'check-crap');
+
+    const diffScopeCrap = buildDefaultGates({ fullScopeCrap: false }).find(
+      (g) => g.name === 'check-crap',
+    );
+    const diffScopeResult = await runCloseValidation({
+      cwd: process.cwd(),
+      gates: [diffScopeCrap],
+      runner: fakeRunner,
+      log: () => {},
+    });
+    assert.equal(
+      diffScopeResult.ok,
+      true,
+      'diff-scope CRAP misses the untouched-file regression — exactly the gap Story #1945 closes',
+    );
+  });
+
+  it('hint surfaces --full-scope baseline-refresh remediation', () => {
+    const gates = buildDefaultGates({});
+    const crap = gates.find((g) => g.name === 'check-crap');
+    assert.match(
+      crap.hint,
+      /crap:update -- --full-scope/,
+      'CRAP gate hint must point at the full-scope baseline-refresh command so operators know what to run when CI Linux drifts a row',
+    );
+    assert.match(crap.hint, /baseline-refresh:/);
+  });
+});

--- a/tests/gate-integration.test.js
+++ b/tests/gate-integration.test.js
@@ -47,7 +47,13 @@ test('Site 1 — close-validation DEFAULT_GATES invokes check-crap.js', () => {
   const crapGate = DEFAULT_GATES.find((g) => g.name.includes('crap'));
   assert.ok(crapGate, 'check-crap gate must be present in DEFAULT_GATES');
   assert.strictEqual(crapGate.cmd, 'node');
-  assert.deepStrictEqual(crapGate.args, ['.agents/scripts/check-crap.js']);
+  // Story #1945: close-time CRAP runs full-scope by default to mirror
+  // CI's post-merge `push` event on main, so close catches the same
+  // regressions that would otherwise turn main red after auto-merge.
+  assert.deepStrictEqual(crapGate.args, [
+    '.agents/scripts/check-crap.js',
+    '--full-scope',
+  ]);
 });
 
 test('Site 2 — ci.yml runs `npm run crap:check` after test:coverage with PR-scoped diff', () => {

--- a/tests/lib/orchestration/story-close/pre-merge-validation-extra.test.js
+++ b/tests/lib/orchestration/story-close/pre-merge-validation-extra.test.js
@@ -195,14 +195,15 @@ describe('runPreMergeGates — Story #1396 --epic-ref threading', () => {
   });
 });
 
-describe('runPreMergeGates — Story #1394 diff-scoped default', () => {
-  it('forwards the default gate list (no explicit --changed-since) so the new diff-scoped default applies to both gates', async () => {
-    // The Tech Spec for Epic #1386 flips check-{maintainability,crap}.js to
-    // default to diff-scoped (`--changed-since main`). Close-validation must
-    // therefore NOT inject a redundant `--changed-since` argument — the
-    // gate CLI's own resolver applies the layered default. This guard fails
-    // if a future refactor smuggles an opinionated ref back into the gate
-    // args without first updating the precedence story (Tech Spec §4).
+describe('runPreMergeGates — gate scope defaults (Story #1394 + Story #1945)', () => {
+  it('check-maintainability stays on the diff-scoped default (#1394); check-crap defaults to --full-scope (#1945)', async () => {
+    // Story #1394 (Epic #1386) flipped check-{maintainability,crap}.js to
+    // default to diff-scoped (`--changed-since main`) so PR close stays
+    // fast. Story #1945 supersedes that default for the CRAP gate
+    // specifically — close-validation now mirrors CI's post-merge `push`
+    // event by passing `--full-scope` so method-level CRAP regressions in
+    // untouched files are caught at close time, not after auto-merge.
+    // MI keeps the diff-scoped default; only CRAP changed.
     const gates = buildDefaultGates({
       agentSettings: {},
       epicBranch: 'epic/1386',
@@ -214,22 +215,22 @@ describe('runPreMergeGates — Story #1394 diff-scoped default', () => {
     assert.equal(
       mi.args.includes('--changed-since'),
       false,
-      'check-maintainability must rely on the new diff-scoped default — explicit --changed-since defeats the precedence chain documented in Story #1394',
-    );
-    assert.equal(
-      crap.args.includes('--changed-since'),
-      false,
-      'check-crap must rely on the new diff-scoped default — explicit --changed-since defeats the precedence chain documented in Story #1394',
+      'check-maintainability must rely on the diff-scoped default — explicit --changed-since defeats the precedence chain documented in Story #1394',
     );
     assert.equal(
       mi.args.includes('--full-scope'),
       false,
-      'close-validation must not opt out via --full-scope; the diff-scoped default is the documented Story-close behavior',
+      'check-maintainability remains diff-scoped at close time — Story #1945 only flipped the CRAP gate',
+    );
+    assert.equal(
+      crap.args.includes('--changed-since'),
+      false,
+      'check-crap must not inject an explicit --changed-since at close time',
     );
     assert.equal(
       crap.args.includes('--full-scope'),
-      false,
-      'close-validation must not opt out via --full-scope; the diff-scoped default is the documented Story-close behavior',
+      true,
+      'check-crap defaults to --full-scope at close time (Story #1945) so close mirrors CI post-merge scope',
     );
     // Story #1120: --epic-ref still flows through to read the baseline at
     // the Epic-branch HEAD. Co-asserted here because dropping it silently
@@ -239,10 +240,11 @@ describe('runPreMergeGates — Story #1394 diff-scoped default', () => {
       ['--epic-ref', 'epic/1386'],
       'check-maintainability must still receive --epic-ref',
     );
+    // CRAP's --epic-ref now sits before the trailing --full-scope.
     assert.deepEqual(
-      crap.args.slice(-2),
+      crap.args.slice(-3, -1),
       ['--epic-ref', 'epic/1386'],
-      'check-crap must still receive --epic-ref',
+      'check-crap must still receive --epic-ref (now followed by --full-scope)',
     );
   });
 });

--- a/tests/story-close.test.js
+++ b/tests/story-close.test.js
@@ -277,7 +277,13 @@ test('runCloseValidation', async (t) => {
       const crapIdx = names.findIndex((n) => n.includes('crap'));
       assert.ok(crapIdx > miIdx, 'crap gate must run AFTER maintainability');
       const gate = DEFAULT_GATES[crapIdx];
-      assert.deepStrictEqual(gate.args, ['.agents/scripts/check-crap.js']);
+      // Story #1945: close-time CRAP defaults to --full-scope so the gate
+      // mirrors CI's post-merge `push` scope and catches method-level
+      // regressions in files the Story didn't touch.
+      assert.deepStrictEqual(gate.args, [
+        '.agents/scripts/check-crap.js',
+        '--full-scope',
+      ]);
       assert.match(gate.hint, /crap:update/);
       assert.match(gate.hint, /baseline-refresh:/);
     },


### PR DESCRIPTION
Closes #1945

_Auto-opened by `/single-story-execute`._