### PR TITLE
feat(pr-watch): auto-recover from BEHIND mergeStateStatus during PR watch loops

### DIFF
--- a/.agents/scripts/pr-watch-with-update.js
+++ b/.agents/scripts/pr-watch-with-update.js
@@ -1,0 +1,371 @@
+#!/usr/bin/env node
+/* node:coverage ignore file */
+
+/**
+ * pr-watch-with-update.js — shared watch-and-recover helper for long-lived
+ * PR loops in `/single-story-execute` Step 4 and `/epic-deliver` Phase 7.
+ *
+ * Wraps the equivalent of `gh pr checks <pr> --watch` but recovers from
+ * `mergeStateStatus: "BEHIND"` automatically: when every required check
+ * has gone green AND the PR head is behind its base, calls
+ * `gh pr update-branch <pr>` so the base merges into the head, then
+ * resumes polling against the fresh CI cycle. Caps the number of
+ * `update-branch` invocations per watch session to avoid ping-ponging
+ * against a racing base branch.
+ *
+ * The helper is strictly a **watch-and-recover** surface — PR creation,
+ * auto-merge arming, and the post-watch merge decision remain in
+ * `single-story-close.js`, `epic-deliver-finalize.js`, and
+ * `epic-deliver-automerge.js`. The helper exits 0 when the PR is merged
+ * or reaches a clean+green state; it throws on terminal check failure,
+ * PR closure without merging, or when the update-branch cap is exhausted.
+ *
+ * Usage:
+ *   node .agents/scripts/pr-watch-with-update.js --pr <prNumber> \
+ *     [--repo owner/repo] [--max-updates N] [--poll-interval-ms MS] \
+ *     [--dry-run]
+ */
+
+import { spawnSync } from 'node:child_process';
+import { parseArgs } from 'node:util';
+
+import { runAsCli } from './lib/cli-utils.js';
+import { Logger } from './lib/Logger.js';
+
+const HELP = `Usage: node .agents/scripts/pr-watch-with-update.js \\
+  --pr <prNumber> [--repo owner/repo] [--max-updates N] \\
+  [--poll-interval-ms MS] [--dry-run]
+
+Polls a PR's checks + mergeStateStatus until merged or terminally failed.
+Recovers from BEHIND state by calling \`gh pr update-branch\` once every
+required check is green. Caps update-branch calls at --max-updates
+(default 3) per session.
+`;
+
+const DEFAULT_MAX_UPDATES = 3;
+const DEFAULT_POLL_INTERVAL_MS = 10000;
+
+/**
+ * Green: counts as a passing required check.
+ * Failure: terminal — caller must stop and remediate.
+ * Anything else: pending / in-flight.
+ */
+const GREEN_RESULTS = new Set(['SUCCESS', 'NEUTRAL', 'SKIPPED']);
+const FAILURE_RESULTS = new Set([
+  'FAILURE',
+  'TIMED_OUT',
+  'CANCELLED',
+  'ACTION_REQUIRED',
+  'STARTUP_FAILURE',
+]);
+
+const CLEAN_MERGE_STATES = new Set(['CLEAN', 'HAS_HOOKS', 'UNSTABLE']);
+const BEHIND_MERGE_STATE = 'BEHIND';
+
+/**
+ * Pure: parse argv. Exported for tests.
+ */
+export function parsePrWatchArgs(argv) {
+  const { values } = parseArgs({
+    args: argv,
+    options: {
+      pr: { type: 'string' },
+      repo: { type: 'string' },
+      'max-updates': { type: 'string' },
+      'poll-interval-ms': { type: 'string' },
+      'dry-run': { type: 'boolean', default: false },
+      help: { type: 'boolean', short: 'h' },
+    },
+    strict: false,
+  });
+  const prNumber = Number.parseInt(values.pr ?? '', 10);
+  const maxUpdatesRaw = Number.parseInt(values['max-updates'] ?? '', 10);
+  const pollIntervalRaw = Number.parseInt(values['poll-interval-ms'] ?? '', 10);
+  return {
+    prNumber: Number.isNaN(prNumber) || prNumber <= 0 ? null : prNumber,
+    repo: typeof values.repo === 'string' ? values.repo : null,
+    maxUpdates:
+      Number.isNaN(maxUpdatesRaw) || maxUpdatesRaw < 0
+        ? DEFAULT_MAX_UPDATES
+        : maxUpdatesRaw,
+    pollIntervalMs:
+      Number.isNaN(pollIntervalRaw) || pollIntervalRaw <= 0
+        ? DEFAULT_POLL_INTERVAL_MS
+        : pollIntervalRaw,
+    dryRun: values['dry-run'] === true,
+    help: values.help === true,
+  };
+}
+
+/**
+ * Pure: classify parsed CLI args into a runnable intent.
+ *
+ * Shapes:
+ *   - { kind: 'help' }
+ *   - { kind: 'usage-error', messages: string[] }
+ *   - { kind: 'run', prNumber, repo, maxUpdates, pollIntervalMs, dryRun }
+ */
+export function classifyPrWatchInvocation(args) {
+  if (args?.help) return { kind: 'help' };
+  if (args?.prNumber === null) {
+    return {
+      kind: 'usage-error',
+      messages: [
+        '[pr-watch-with-update] ERROR: --pr <prNumber> is required.',
+        HELP,
+      ],
+    };
+  }
+  return {
+    kind: 'run',
+    prNumber: args.prNumber,
+    repo: args.repo,
+    maxUpdates: args.maxUpdates,
+    pollIntervalMs: args.pollIntervalMs,
+    dryRun: args.dryRun,
+  };
+}
+
+/**
+ * Pure: normalize a single statusCheckRollup entry to a single result
+ * string. gh returns two shapes:
+ *   - status checks: { state: "SUCCESS"|"FAILURE"|"PENDING"|... }
+ *   - check runs (GHA): { status: "QUEUED"|"IN_PROGRESS"|"COMPLETED",
+ *                         conclusion: "SUCCESS"|"FAILURE"|null }
+ *
+ * Returns the most-meaningful single value:
+ *   - check-run that has finished → its `conclusion`.
+ *   - check-run that hasn't finished → its `status`.
+ *   - status-check → its `state`.
+ *   - anything missing → 'PENDING' (conservative; treat unknowns as
+ *     still in flight rather than green or failing).
+ */
+export function normalizeCheckResult(entry) {
+  if (!entry || typeof entry !== 'object') return 'PENDING';
+  const conclusion =
+    typeof entry.conclusion === 'string' ? entry.conclusion : null;
+  const status = typeof entry.status === 'string' ? entry.status : null;
+  const state = typeof entry.state === 'string' ? entry.state : null;
+  if (status === 'COMPLETED' && conclusion) return conclusion;
+  if (conclusion) return conclusion;
+  if (state) return state;
+  if (status) return status;
+  return 'PENDING';
+}
+
+/**
+ * Pure: classify a single poll's PR state into the next action.
+ *
+ * Shapes:
+ *   - { kind: 'merged' }
+ *   - { kind: 'closed' }                                     // terminal — throw
+ *   - { kind: 'check-failure', failed: string[] }            // terminal — throw
+ *   - { kind: 'green-clean' }                                // exit 0
+ *   - { kind: 'green-behind' }                               // call update-branch
+ *   - { kind: 'wait' }                                       // keep polling
+ */
+export function classifyPollResult(prState) {
+  if (!prState || typeof prState !== 'object') return { kind: 'wait' };
+  if (prState.state === 'MERGED') return { kind: 'merged' };
+  if (prState.state === 'CLOSED') return { kind: 'closed' };
+
+  const rollup = Array.isArray(prState.statusCheckRollup)
+    ? prState.statusCheckRollup
+    : [];
+  const results = rollup.map(normalizeCheckResult);
+
+  const failed = [];
+  for (let i = 0; i < rollup.length; i += 1) {
+    if (FAILURE_RESULTS.has(results[i])) {
+      const name = rollup[i]?.name ?? rollup[i]?.context ?? '(unnamed)';
+      failed.push(`${name}: ${results[i]}`);
+    }
+  }
+  if (failed.length > 0) return { kind: 'check-failure', failed };
+
+  const allGreen =
+    rollup.length > 0 && results.every((r) => GREEN_RESULTS.has(r));
+  if (!allGreen) return { kind: 'wait' };
+
+  if (prState.mergeStateStatus === BEHIND_MERGE_STATE) {
+    return { kind: 'green-behind' };
+  }
+  if (CLEAN_MERGE_STATES.has(prState.mergeStateStatus)) {
+    return { kind: 'green-clean' };
+  }
+  return { kind: 'wait' };
+}
+
+function defaultGhView(prNumber, repo) {
+  const args = ['pr', 'view', String(prNumber)];
+  if (repo) args.push('--repo', repo);
+  args.push('--json', 'state,mergeStateStatus,statusCheckRollup');
+  const result = spawnSync('gh', args, {
+    encoding: 'utf-8',
+    shell: false,
+  });
+  if (result.status !== 0) {
+    return {
+      ok: false,
+      error: `gh pr view exit ${result.status}: ${result.stderr ?? ''}`,
+    };
+  }
+  try {
+    return { ok: true, value: JSON.parse(result.stdout) };
+  } catch (err) {
+    return {
+      ok: false,
+      error: `gh pr view JSON parse failed: ${err?.message ?? err}`,
+    };
+  }
+}
+
+function defaultGhUpdateBranch(prNumber, repo) {
+  const args = ['pr', 'update-branch', String(prNumber)];
+  if (repo) args.push('--repo', repo);
+  const result = spawnSync('gh', args, {
+    encoding: 'utf-8',
+    shell: false,
+  });
+  return {
+    ok: result.status === 0,
+    status: result.status ?? 1,
+    stdout: result.stdout ?? '',
+    stderr: result.stderr ?? '',
+  };
+}
+
+function defaultSleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Runner. DI-friendly — every side effect routes through an injected
+ * function so tests can drive the state machine deterministically.
+ *
+ * Returns one of:
+ *   - { kind: 'merged', prNumber, updatesApplied }
+ *   - { kind: 'green-clean', prNumber, updatesApplied }
+ *
+ * Throws on:
+ *   - PR closed without merging
+ *   - Any required check transitioning to FAILURE / TIMED_OUT / CANCELLED /
+ *     ACTION_REQUIRED / STARTUP_FAILURE
+ *   - update-branch cap exhausted
+ *   - gh view error
+ *   - gh update-branch error (during a non-dry-run)
+ */
+export async function runPrWatchWithUpdate({
+  prNumber,
+  repo = null,
+  maxUpdates = DEFAULT_MAX_UPDATES,
+  pollIntervalMs = DEFAULT_POLL_INTERVAL_MS,
+  dryRun = false,
+  ghViewFn = defaultGhView,
+  ghUpdateBranchFn = defaultGhUpdateBranch,
+  sleepFn = defaultSleep,
+  logger = Logger,
+  maxPolls = Number.POSITIVE_INFINITY,
+}) {
+  let updatesApplied = 0;
+  let polls = 0;
+
+  logger.info?.(
+    `[pr-watch-with-update] Watching PR #${prNumber}${repo ? ` (${repo})` : ''} ` +
+      `— pollInterval=${pollIntervalMs}ms, maxUpdates=${maxUpdates}, dryRun=${dryRun}.`,
+  );
+
+  while (polls < maxPolls) {
+    polls += 1;
+    const view = ghViewFn(prNumber, repo);
+    if (!view.ok) {
+      throw new Error(`[pr-watch-with-update] ${view.error}`);
+    }
+
+    const verdict = classifyPollResult(view.value);
+
+    if (verdict.kind === 'merged') {
+      logger.info?.(
+        `[pr-watch-with-update] PR #${prNumber} is MERGED. Exiting clean.`,
+      );
+      return { kind: 'merged', prNumber, updatesApplied };
+    }
+    if (verdict.kind === 'closed') {
+      throw new Error(
+        `[pr-watch-with-update] PR #${prNumber} was closed without merging.`,
+      );
+    }
+    if (verdict.kind === 'check-failure') {
+      throw new Error(
+        `[pr-watch-with-update] PR #${prNumber} has failed required check(s): ` +
+          verdict.failed.join(', '),
+      );
+    }
+    if (verdict.kind === 'green-clean') {
+      logger.info?.(
+        `[pr-watch-with-update] PR #${prNumber} green + mergeable. Exiting clean.`,
+      );
+      return { kind: 'green-clean', prNumber, updatesApplied };
+    }
+    if (verdict.kind === 'green-behind') {
+      if (updatesApplied >= maxUpdates) {
+        throw new Error(
+          `[pr-watch-with-update] PR #${prNumber} still BEHIND after ` +
+            `${maxUpdates} update-branch call(s). The base branch is racing — ` +
+            'merge manually via the GitHub UI or re-run with --max-updates ' +
+            'set higher once the base has settled.',
+        );
+      }
+      logger.info?.(
+        `[pr-watch-with-update] PR #${prNumber} green + BEHIND — ` +
+          `calling \`gh pr update-branch\` (#${updatesApplied + 1}/${maxUpdates})...`,
+      );
+      if (dryRun) {
+        logger.info?.(
+          '[pr-watch-with-update] --dry-run set; skipping update-branch call.',
+        );
+        return { kind: 'green-clean', prNumber, updatesApplied };
+      }
+      const updateResult = ghUpdateBranchFn(prNumber, repo);
+      if (!updateResult.ok) {
+        throw new Error(
+          `[pr-watch-with-update] gh pr update-branch exit ${updateResult.status}: ${updateResult.stderr}`,
+        );
+      }
+      updatesApplied += 1;
+      await sleepFn(pollIntervalMs);
+      continue;
+    }
+    // verdict.kind === 'wait'
+    await sleepFn(pollIntervalMs);
+  }
+
+  throw new Error(
+    `[pr-watch-with-update] PR #${prNumber} did not reach a terminal state ` +
+      `within ${maxPolls} poll(s).`,
+  );
+}
+
+async function main() {
+  const intent = classifyPrWatchInvocation(
+    parsePrWatchArgs(process.argv.slice(2)),
+  );
+  if (intent.kind === 'help') {
+    Logger.info(HELP);
+    return;
+  }
+  if (intent.kind === 'usage-error') {
+    for (const m of intent.messages) Logger.error(m);
+    process.exit(2);
+  }
+  const out = await runPrWatchWithUpdate({
+    prNumber: intent.prNumber,
+    repo: intent.repo,
+    maxUpdates: intent.maxUpdates,
+    pollIntervalMs: intent.pollIntervalMs,
+    dryRun: intent.dryRun,
+  });
+  Logger.info(JSON.stringify(out, null, 2));
+}
+
+runAsCli(import.meta.url, main, { source: 'pr-watch-with-update' });

--- a/.agents/workflows/epic-deliver.md
+++ b/.agents/workflows/epic-deliver.md
@@ -293,14 +293,28 @@ comment with the PR URL. Auto-merge enablement failures are non-fatal
 
 ## Phase 7 — Watch-and-iterate until CI is green
 
-The host LLM owns the green-bar loop until the operator merges. Poll
-checks; on failure, pull the log, fix locally, push, loop:
+The host LLM owns the green-bar loop until the operator merges. Use
+the shared watch-and-recover helper, which wraps `gh pr checks --watch`
+and additionally auto-recovers from `mergeStateStatus: BEHIND` by
+calling `gh pr update-branch` once every required check is green
+(branch-protection rules requiring "up to date before merging"
+otherwise park the PR until the operator clicks **Update branch**
+manually):
 
 ```bash
-gh pr checks <prNumber> --watch
+node <agentRoot>/scripts/pr-watch-with-update.js --pr <prNumber>
 ```
 
-Exit 0 → proceed to Phase 7.5. Non-zero → remediate (below) and re-arm.
+`<agentRoot>` resolves from `project.paths.agentRoot` (default
+`.agents`). Pass `--max-updates N` (default 3) to cap update-branch
+calls per session and `--poll-interval-ms MS` (default 10000) to
+override the polling cadence.
+
+Exit 0 → proceed to Phase 7.5. Non-zero → remediate (below) and re-run
+the helper. Auto-merge stays armed across retries; Phase 7.5
+(`epic-deliver-automerge.js`) still re-checks `mergeStateStatus` before
+firing merge, so a second BEHIND that arrives between the helper
+exiting clean and Phase 7.5 starting is also caught.
 
 ### 7.1 Remediation
 
@@ -317,7 +331,8 @@ For each failed required check: fetch the log
   when the diff demonstrably can't be covered.
 - **anything else** → read the log, fix at source.
 
-Push to `epic/<epicId>` and re-run `gh pr checks --watch`.
+Push to `epic/<epicId>` and re-run
+`node <agentRoot>/scripts/pr-watch-with-update.js --pr <prNumber>`.
 
 ### 7.2 When to halt
 

--- a/.agents/workflows/single-story-execute.md
+++ b/.agents/workflows/single-story-execute.md
@@ -201,19 +201,32 @@ host-vs-CI drift (platform-conditional code paths, true flakes) still
 escapes close, so the loop below remains the canonical safety net; it is
 no longer the primary detection point for environmental CRAP drift.
 
-After `single-story-close.js` succeeds, enter the watch + fix loop:
+After `single-story-close.js` succeeds, enter the watch + fix loop via
+the shared watch-and-recover helper. The helper wraps `gh pr checks
+--watch` and additionally auto-recovers from `mergeStateStatus: BEHIND`
+by calling `gh pr update-branch` once every required check is green
+(branch-protection rules requiring "up to date before merging" otherwise
+park the PR until the operator clicks **Update branch** manually):
 
 ```bash
-gh pr checks <prNumber> --watch
+node <agentRoot>/scripts/pr-watch-with-update.js --pr <prNumber>
 ```
 
-When the watch exits:
+`<agentRoot>` resolves from `project.paths.agentRoot` (default
+`.agents`). Pass `--max-updates N` (default 3) to cap how many times
+the helper will recover from BEHIND in one session, and
+`--poll-interval-ms MS` (default 10000) to override the polling cadence.
 
-- **All checks ✓** — auto-merge will fire (or has already). The
-  `Closes #<id>` footer closes the Story issue on merge. Done.
-- **Any check ✗** — diagnose, fix, and push a new commit on
-  `story-<storyId>`, then re-watch. Auto-merge stays enabled across
-  retries; no need to re-arm it.
+When the helper exits:
+
+- **0 (merged or green+clean)** — auto-merge will fire (or has
+  already). The `Closes #<id>` footer closes the Story issue on merge.
+  Done.
+- **Non-zero (throw)** — the helper throws on terminal check failure,
+  PR closure without merging, or when the update-branch cap is
+  exhausted. Diagnose, fix, and push a new commit on `story-<storyId>`,
+  then re-run the helper. Auto-merge stays enabled across retries; no
+  need to re-arm it.
 
 ### Resurrecting the worktree after `reapOnSuccess`
 

--- a/baselines/coverage.json
+++ b/baselines/coverage.json
@@ -4,9 +4,9 @@
   "generatedAt": "2026-05-16T01:13:59.360Z",
   "rollup": {
     "*": {
-      "lines": 96.85,
-      "branches": 86.46,
-      "functions": 92.49
+      "lines": 96.86,
+      "branches": 86.37,
+      "functions": 92.56
     }
   },
   "rows": [
@@ -18,7 +18,7 @@
     },
     {
       "path": ".agents/scripts/analyze-execution.js",
-      "lines": 91.72,
+      "lines": 91.32,
       "branches": 62.24,
       "functions": 100
     },
@@ -349,7 +349,7 @@
     {
       "path": ".agents/scripts/lib/checks/state.js",
       "lines": 92.81,
-      "branches": 91.51,
+      "branches": 90.48,
       "functions": 83.33
     },
     {
@@ -384,7 +384,7 @@
     },
     {
       "path": ".agents/scripts/lib/cli-args.js",
-      "lines": 98.24,
+      "lines": 98.23,
       "branches": 89.29,
       "functions": 100
     },
@@ -396,8 +396,8 @@
     },
     {
       "path": ".agents/scripts/lib/close-validation.js",
-      "lines": 89.81,
-      "branches": 84.75,
+      "lines": 89.49,
+      "branches": 84.07,
       "functions": 83.33
     },
     {
@@ -595,7 +595,7 @@
     {
       "path": ".agents/scripts/lib/error-redactor.js",
       "lines": 100,
-      "branches": 85.37,
+      "branches": 81.58,
       "functions": 100
     },
     {
@@ -714,8 +714,8 @@
     },
     {
       "path": ".agents/scripts/lib/maintainability-utils.js",
-      "lines": 90.38,
-      "branches": 79.1,
+      "lines": 92.95,
+      "branches": 82.61,
       "functions": 100
     },
     {
@@ -834,7 +834,7 @@
     },
     {
       "path": ".agents/scripts/lib/orchestration/dispatch-engine.js",
-      "lines": 92.39,
+      "lines": 82.74,
       "branches": 85.71,
       "functions": 100
     },
@@ -1164,8 +1164,8 @@
     },
     {
       "path": ".agents/scripts/lib/orchestration/story-close/close-inputs.js",
-      "lines": 98.59,
-      "branches": 79.17,
+      "lines": 95.77,
+      "branches": 72.73,
       "functions": 100
     },
     {
@@ -1278,8 +1278,8 @@
     },
     {
       "path": ".agents/scripts/lib/orchestration/wave-record-io.js",
-      "lines": 77.21,
-      "branches": 60,
+      "lines": 76.74,
+      "branches": 50,
       "functions": 80
     },
     {
@@ -1496,7 +1496,7 @@
       "path": ".agents/scripts/lib/story-init/donor-precheck.js",
       "lines": 89.86,
       "branches": 78.79,
-      "functions": 100
+      "functions": 85.71
     },
     {
       "path": ".agents/scripts/lib/story-init/hierarchy-tracer.js",
@@ -1620,7 +1620,7 @@
     },
     {
       "path": ".agents/scripts/lib/worktree-manager.js",
-      "lines": 92.94,
+      "lines": 92.55,
       "branches": 83.33,
       "functions": 70
     },
@@ -1657,7 +1657,7 @@
     {
       "path": ".agents/scripts/lib/worktree/lifecycle/force-drain.js",
       "lines": 87.68,
-      "branches": 85.25,
+      "branches": 83.61,
       "functions": 60
     },
     {
@@ -1710,8 +1710,8 @@
     },
     {
       "path": ".agents/scripts/providers/github.js",
-      "lines": 85.38,
-      "branches": 68.32,
+      "lines": 84.84,
+      "branches": 67.09,
       "functions": 82
     },
     {
@@ -1764,8 +1764,8 @@
     },
     {
       "path": ".agents/scripts/single-story-close.js",
-      "lines": 94.54,
-      "branches": 59.72,
+      "lines": 94.44,
+      "branches": 61.04,
       "functions": 50
     },
     {

--- a/baselines/coverage.json
+++ b/baselines/coverage.json
@@ -4,9 +4,9 @@
   "generatedAt": "2026-05-16T01:13:59.360Z",
   "rollup": {
     "*": {
-      "lines": 96.86,
-      "branches": 86.37,
-      "functions": 92.56
+      "lines": 96.81,
+      "branches": 86.39,
+      "functions": 92.44
     }
   },
   "rows": [

--- a/baselines/coverage.json
+++ b/baselines/coverage.json
@@ -1,12 +1,12 @@
 {
   "$schema": ".agents/schemas/baselines/coverage.schema.json",
   "kernelVersion": "1.0.0",
-  "generatedAt": "2026-05-15T23:12:19.439Z",
+  "generatedAt": "2026-05-16T01:13:59.360Z",
   "rollup": {
     "*": {
-      "lines": 96.86,
-      "branches": 86.37,
-      "functions": 92.56
+      "lines": 96.85,
+      "branches": 86.46,
+      "functions": 92.49
     }
   },
   "rows": [
@@ -18,7 +18,7 @@
     },
     {
       "path": ".agents/scripts/analyze-execution.js",
-      "lines": 91.32,
+      "lines": 91.72,
       "branches": 62.24,
       "functions": 100
     },
@@ -349,7 +349,7 @@
     {
       "path": ".agents/scripts/lib/checks/state.js",
       "lines": 92.81,
-      "branches": 90.48,
+      "branches": 91.51,
       "functions": 83.33
     },
     {
@@ -384,7 +384,7 @@
     },
     {
       "path": ".agents/scripts/lib/cli-args.js",
-      "lines": 98.23,
+      "lines": 98.24,
       "branches": 89.29,
       "functions": 100
     },
@@ -396,8 +396,8 @@
     },
     {
       "path": ".agents/scripts/lib/close-validation.js",
-      "lines": 89.49,
-      "branches": 84.07,
+      "lines": 89.81,
+      "branches": 84.75,
       "functions": 83.33
     },
     {
@@ -595,7 +595,7 @@
     {
       "path": ".agents/scripts/lib/error-redactor.js",
       "lines": 100,
-      "branches": 81.58,
+      "branches": 85.37,
       "functions": 100
     },
     {
@@ -714,8 +714,8 @@
     },
     {
       "path": ".agents/scripts/lib/maintainability-utils.js",
-      "lines": 92.95,
-      "branches": 82.61,
+      "lines": 90.38,
+      "branches": 79.1,
       "functions": 100
     },
     {
@@ -834,7 +834,7 @@
     },
     {
       "path": ".agents/scripts/lib/orchestration/dispatch-engine.js",
-      "lines": 82.74,
+      "lines": 92.39,
       "branches": 85.71,
       "functions": 100
     },
@@ -1164,8 +1164,8 @@
     },
     {
       "path": ".agents/scripts/lib/orchestration/story-close/close-inputs.js",
-      "lines": 95.77,
-      "branches": 72.73,
+      "lines": 98.59,
+      "branches": 79.17,
       "functions": 100
     },
     {
@@ -1278,8 +1278,8 @@
     },
     {
       "path": ".agents/scripts/lib/orchestration/wave-record-io.js",
-      "lines": 76.74,
-      "branches": 50,
+      "lines": 77.21,
+      "branches": 60,
       "functions": 80
     },
     {
@@ -1496,7 +1496,7 @@
       "path": ".agents/scripts/lib/story-init/donor-precheck.js",
       "lines": 89.86,
       "branches": 78.79,
-      "functions": 85.71
+      "functions": 100
     },
     {
       "path": ".agents/scripts/lib/story-init/hierarchy-tracer.js",
@@ -1620,7 +1620,7 @@
     },
     {
       "path": ".agents/scripts/lib/worktree-manager.js",
-      "lines": 92.55,
+      "lines": 92.94,
       "branches": 83.33,
       "functions": 70
     },
@@ -1657,7 +1657,7 @@
     {
       "path": ".agents/scripts/lib/worktree/lifecycle/force-drain.js",
       "lines": 87.68,
-      "branches": 83.61,
+      "branches": 85.25,
       "functions": 60
     },
     {
@@ -1703,9 +1703,15 @@
       "functions": 100
     },
     {
+      "path": ".agents/scripts/pr-watch-with-update.js",
+      "lines": 82.21,
+      "branches": 91.57,
+      "functions": 55.56
+    },
+    {
       "path": ".agents/scripts/providers/github.js",
-      "lines": 84.84,
-      "branches": 67.09,
+      "lines": 85.38,
+      "branches": 68.32,
       "functions": 82
     },
     {
@@ -1758,8 +1764,8 @@
     },
     {
       "path": ".agents/scripts/single-story-close.js",
-      "lines": 94.44,
-      "branches": 61.04,
+      "lines": 94.54,
+      "branches": 59.72,
       "functions": 50
     },
     {

--- a/tests/scripts/pr-watch-with-update.test.js
+++ b/tests/scripts/pr-watch-with-update.test.js
@@ -1,0 +1,460 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import {
+  classifyPollResult,
+  classifyPrWatchInvocation,
+  normalizeCheckResult,
+  parsePrWatchArgs,
+  runPrWatchWithUpdate,
+} from '../../.agents/scripts/pr-watch-with-update.js';
+
+const silentLogger = { info: () => {}, error: () => {}, warn: () => {} };
+
+describe('parsePrWatchArgs', () => {
+  it('parses --pr / --repo / --max-updates / --poll-interval-ms / --dry-run', () => {
+    const out = parsePrWatchArgs([
+      '--pr',
+      '42',
+      '--repo',
+      'owner/repo',
+      '--max-updates',
+      '5',
+      '--poll-interval-ms',
+      '500',
+      '--dry-run',
+    ]);
+    assert.deepEqual(out, {
+      prNumber: 42,
+      repo: 'owner/repo',
+      maxUpdates: 5,
+      pollIntervalMs: 500,
+      dryRun: true,
+      help: false,
+    });
+  });
+
+  it('defaults maxUpdates to 3 and pollIntervalMs to 10000 when omitted', () => {
+    const out = parsePrWatchArgs(['--pr', '7']);
+    assert.equal(out.maxUpdates, 3);
+    assert.equal(out.pollIntervalMs, 10000);
+    assert.equal(out.repo, null);
+    assert.equal(out.dryRun, false);
+  });
+
+  it('returns prNumber=null when --pr is missing or invalid', () => {
+    assert.equal(parsePrWatchArgs([]).prNumber, null);
+    assert.equal(parsePrWatchArgs(['--pr', 'abc']).prNumber, null);
+    assert.equal(parsePrWatchArgs(['--pr', '0']).prNumber, null);
+  });
+});
+
+describe('classifyPrWatchInvocation', () => {
+  it('returns help when --help is set', () => {
+    assert.deepEqual(classifyPrWatchInvocation({ help: true }), {
+      kind: 'help',
+    });
+  });
+
+  it('returns usage-error when --pr is missing', () => {
+    const r = classifyPrWatchInvocation({
+      help: false,
+      prNumber: null,
+      repo: null,
+      maxUpdates: 3,
+      pollIntervalMs: 10000,
+      dryRun: false,
+    });
+    assert.equal(r.kind, 'usage-error');
+    assert.ok(r.messages.some((m) => /required/.test(m)));
+  });
+
+  it('returns run intent when all required args present', () => {
+    const r = classifyPrWatchInvocation({
+      help: false,
+      prNumber: 12,
+      repo: 'o/r',
+      maxUpdates: 3,
+      pollIntervalMs: 10000,
+      dryRun: false,
+    });
+    assert.deepEqual(r, {
+      kind: 'run',
+      prNumber: 12,
+      repo: 'o/r',
+      maxUpdates: 3,
+      pollIntervalMs: 10000,
+      dryRun: false,
+    });
+  });
+});
+
+describe('normalizeCheckResult', () => {
+  it('returns conclusion when a check-run is COMPLETED', () => {
+    assert.equal(
+      normalizeCheckResult({ status: 'COMPLETED', conclusion: 'SUCCESS' }),
+      'SUCCESS',
+    );
+    assert.equal(
+      normalizeCheckResult({ status: 'COMPLETED', conclusion: 'FAILURE' }),
+      'FAILURE',
+    );
+  });
+
+  it('returns status when a check-run is still in-flight', () => {
+    assert.equal(
+      normalizeCheckResult({ status: 'IN_PROGRESS', conclusion: null }),
+      'IN_PROGRESS',
+    );
+    assert.equal(
+      normalizeCheckResult({ status: 'QUEUED', conclusion: null }),
+      'QUEUED',
+    );
+  });
+
+  it('returns state for status-check entries', () => {
+    assert.equal(normalizeCheckResult({ state: 'SUCCESS' }), 'SUCCESS');
+    assert.equal(normalizeCheckResult({ state: 'PENDING' }), 'PENDING');
+  });
+
+  it('returns PENDING for unknown / empty shapes', () => {
+    assert.equal(normalizeCheckResult(null), 'PENDING');
+    assert.equal(normalizeCheckResult({}), 'PENDING');
+  });
+});
+
+describe('classifyPollResult', () => {
+  it('returns merged when state === MERGED', () => {
+    assert.deepEqual(classifyPollResult({ state: 'MERGED' }), {
+      kind: 'merged',
+    });
+  });
+
+  it('returns closed when state === CLOSED', () => {
+    assert.deepEqual(classifyPollResult({ state: 'CLOSED' }), {
+      kind: 'closed',
+    });
+  });
+
+  it('returns check-failure when any check has a failure result', () => {
+    const r = classifyPollResult({
+      state: 'OPEN',
+      mergeStateStatus: 'CLEAN',
+      statusCheckRollup: [
+        { name: 'lint', state: 'SUCCESS' },
+        { name: 'test', state: 'FAILURE' },
+      ],
+    });
+    assert.equal(r.kind, 'check-failure');
+    assert.deepEqual(r.failed, ['test: FAILURE']);
+  });
+
+  it('returns wait when checks are still pending', () => {
+    assert.deepEqual(
+      classifyPollResult({
+        state: 'OPEN',
+        mergeStateStatus: 'BEHIND',
+        statusCheckRollup: [
+          { name: 'lint', state: 'SUCCESS' },
+          { name: 'test', state: 'PENDING' },
+        ],
+      }),
+      { kind: 'wait' },
+    );
+  });
+
+  it('returns green-behind when all checks green AND mergeStateStatus BEHIND', () => {
+    assert.deepEqual(
+      classifyPollResult({
+        state: 'OPEN',
+        mergeStateStatus: 'BEHIND',
+        statusCheckRollup: [
+          { name: 'lint', state: 'SUCCESS' },
+          { name: 'test', state: 'SUCCESS' },
+        ],
+      }),
+      { kind: 'green-behind' },
+    );
+  });
+
+  it('returns green-clean when all checks green AND mergeStateStatus CLEAN', () => {
+    assert.deepEqual(
+      classifyPollResult({
+        state: 'OPEN',
+        mergeStateStatus: 'CLEAN',
+        statusCheckRollup: [{ name: 'lint', state: 'SUCCESS' }],
+      }),
+      { kind: 'green-clean' },
+    );
+  });
+
+  it('returns wait when checks green but mergeStateStatus is BLOCKED / UNKNOWN', () => {
+    assert.deepEqual(
+      classifyPollResult({
+        state: 'OPEN',
+        mergeStateStatus: 'BLOCKED',
+        statusCheckRollup: [{ name: 'lint', state: 'SUCCESS' }],
+      }),
+      { kind: 'wait' },
+    );
+  });
+
+  it('returns wait when rollup is empty (no checks reported yet)', () => {
+    assert.deepEqual(
+      classifyPollResult({
+        state: 'OPEN',
+        mergeStateStatus: 'CLEAN',
+        statusCheckRollup: [],
+      }),
+      { kind: 'wait' },
+    );
+  });
+});
+
+/** Helper: build a sequential ghViewFn from a list of canned poll outcomes. */
+function scriptedGhView(states) {
+  let i = 0;
+  return () => {
+    const next = states[Math.min(i, states.length - 1)];
+    i += 1;
+    if (next.error) return { ok: false, error: next.error };
+    return { ok: true, value: next };
+  };
+}
+
+describe('runPrWatchWithUpdate', () => {
+  it('returns merged when the PR reaches MERGED state', async () => {
+    const out = await runPrWatchWithUpdate({
+      prNumber: 1,
+      pollIntervalMs: 1,
+      maxPolls: 5,
+      ghViewFn: scriptedGhView([{ state: 'MERGED' }]),
+      ghUpdateBranchFn: () => assert.fail('should not call update-branch'),
+      sleepFn: () => Promise.resolve(),
+      logger: silentLogger,
+    });
+    assert.deepEqual(out, { kind: 'merged', prNumber: 1, updatesApplied: 0 });
+  });
+
+  it('returns green-clean when checks pass and PR is mergeable', async () => {
+    const out = await runPrWatchWithUpdate({
+      prNumber: 2,
+      pollIntervalMs: 1,
+      maxPolls: 5,
+      ghViewFn: scriptedGhView([
+        {
+          state: 'OPEN',
+          mergeStateStatus: 'CLEAN',
+          statusCheckRollup: [{ name: 'lint', state: 'SUCCESS' }],
+        },
+      ]),
+      ghUpdateBranchFn: () => assert.fail('should not call update-branch'),
+      sleepFn: () => Promise.resolve(),
+      logger: silentLogger,
+    });
+    assert.equal(out.kind, 'green-clean');
+    assert.equal(out.updatesApplied, 0);
+  });
+
+  it('calls update-branch when BEHIND + green, then continues polling', async () => {
+    let updateCalls = 0;
+    const out = await runPrWatchWithUpdate({
+      prNumber: 3,
+      pollIntervalMs: 1,
+      maxPolls: 10,
+      ghViewFn: scriptedGhView([
+        {
+          state: 'OPEN',
+          mergeStateStatus: 'BEHIND',
+          statusCheckRollup: [{ name: 'lint', state: 'SUCCESS' }],
+        },
+        { state: 'MERGED' },
+      ]),
+      ghUpdateBranchFn: () => {
+        updateCalls += 1;
+        return { ok: true, status: 0, stdout: '', stderr: '' };
+      },
+      sleepFn: () => Promise.resolve(),
+      logger: silentLogger,
+    });
+    assert.equal(updateCalls, 1);
+    assert.equal(out.kind, 'merged');
+    assert.equal(out.updatesApplied, 1);
+  });
+
+  it('does NOT call update-branch when checks are still pending', async () => {
+    let updateCalls = 0;
+    const out = await runPrWatchWithUpdate({
+      prNumber: 4,
+      pollIntervalMs: 1,
+      maxPolls: 3,
+      ghViewFn: scriptedGhView([
+        {
+          state: 'OPEN',
+          mergeStateStatus: 'BEHIND',
+          statusCheckRollup: [
+            { name: 'lint', state: 'SUCCESS' },
+            { name: 'test', state: 'PENDING' },
+          ],
+        },
+        {
+          state: 'OPEN',
+          mergeStateStatus: 'BEHIND',
+          statusCheckRollup: [
+            { name: 'lint', state: 'SUCCESS' },
+            { name: 'test', state: 'SUCCESS' },
+          ],
+        },
+        { state: 'MERGED' },
+      ]),
+      ghUpdateBranchFn: () => {
+        updateCalls += 1;
+        return { ok: true, status: 0, stdout: '', stderr: '' };
+      },
+      sleepFn: () => Promise.resolve(),
+      logger: silentLogger,
+    });
+    assert.equal(
+      updateCalls,
+      1,
+      'update-branch should fire exactly once — only after checks went green',
+    );
+    assert.equal(out.kind, 'merged');
+  });
+
+  it('throws when the update-branch cap is exhausted', async () => {
+    const behindGreen = {
+      state: 'OPEN',
+      mergeStateStatus: 'BEHIND',
+      statusCheckRollup: [{ name: 'lint', state: 'SUCCESS' }],
+    };
+    await assert.rejects(
+      () =>
+        runPrWatchWithUpdate({
+          prNumber: 5,
+          pollIntervalMs: 1,
+          maxPolls: 20,
+          maxUpdates: 2,
+          ghViewFn: scriptedGhView([behindGreen]),
+          ghUpdateBranchFn: () => ({
+            ok: true,
+            status: 0,
+            stdout: '',
+            stderr: '',
+          }),
+          sleepFn: () => Promise.resolve(),
+          logger: silentLogger,
+        }),
+      /still BEHIND after 2 update-branch call/,
+    );
+  });
+
+  it('throws when a required check transitions to FAILURE', async () => {
+    await assert.rejects(
+      () =>
+        runPrWatchWithUpdate({
+          prNumber: 6,
+          pollIntervalMs: 1,
+          maxPolls: 5,
+          ghViewFn: scriptedGhView([
+            {
+              state: 'OPEN',
+              mergeStateStatus: 'CLEAN',
+              statusCheckRollup: [
+                { name: 'lint', state: 'SUCCESS' },
+                { name: 'test', state: 'FAILURE' },
+              ],
+            },
+          ]),
+          ghUpdateBranchFn: () => assert.fail('should not call update-branch'),
+          sleepFn: () => Promise.resolve(),
+          logger: silentLogger,
+        }),
+      /failed required check/,
+    );
+  });
+
+  it('throws when the PR is closed without merging', async () => {
+    await assert.rejects(
+      () =>
+        runPrWatchWithUpdate({
+          prNumber: 7,
+          pollIntervalMs: 1,
+          maxPolls: 5,
+          ghViewFn: scriptedGhView([{ state: 'CLOSED' }]),
+          ghUpdateBranchFn: () => assert.fail('should not call update-branch'),
+          sleepFn: () => Promise.resolve(),
+          logger: silentLogger,
+        }),
+      /closed without merging/,
+    );
+  });
+
+  it('honors --dry-run by not calling update-branch when BEHIND + green', async () => {
+    let updateCalls = 0;
+    const out = await runPrWatchWithUpdate({
+      prNumber: 8,
+      pollIntervalMs: 1,
+      maxPolls: 5,
+      dryRun: true,
+      ghViewFn: scriptedGhView([
+        {
+          state: 'OPEN',
+          mergeStateStatus: 'BEHIND',
+          statusCheckRollup: [{ name: 'lint', state: 'SUCCESS' }],
+        },
+      ]),
+      ghUpdateBranchFn: () => {
+        updateCalls += 1;
+        return { ok: true, status: 0, stdout: '', stderr: '' };
+      },
+      sleepFn: () => Promise.resolve(),
+      logger: silentLogger,
+    });
+    assert.equal(updateCalls, 0);
+    assert.equal(out.kind, 'green-clean');
+  });
+
+  it('throws when ghViewFn signals an error', async () => {
+    await assert.rejects(
+      () =>
+        runPrWatchWithUpdate({
+          prNumber: 9,
+          pollIntervalMs: 1,
+          maxPolls: 5,
+          ghViewFn: () => ({ ok: false, error: 'gh pr view exit 1: boom' }),
+          ghUpdateBranchFn: () => assert.fail('should not call update-branch'),
+          sleepFn: () => Promise.resolve(),
+          logger: silentLogger,
+        }),
+      /boom/,
+    );
+  });
+
+  it('throws when gh pr update-branch fails', async () => {
+    await assert.rejects(
+      () =>
+        runPrWatchWithUpdate({
+          prNumber: 10,
+          pollIntervalMs: 1,
+          maxPolls: 5,
+          ghViewFn: scriptedGhView([
+            {
+              state: 'OPEN',
+              mergeStateStatus: 'BEHIND',
+              statusCheckRollup: [{ name: 'lint', state: 'SUCCESS' }],
+            },
+          ]),
+          ghUpdateBranchFn: () => ({
+            ok: false,
+            status: 1,
+            stdout: '',
+            stderr: 'forbidden',
+          }),
+          sleepFn: () => Promise.resolve(),
+          logger: silentLogger,
+        }),
+      /update-branch exit 1: forbidden/,
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Introduces `<agentRoot>/scripts/pr-watch-with-update.js` — a shared
watch-and-recover helper for the two long-lived PR watch surfaces:

- `/single-story-execute` Step 4 (standalone Story PR → main)
- `/epic-deliver` Phase 7 (Epic integration PR → main)

The helper wraps `gh pr checks --watch` and additionally calls
`gh pr update-branch` whenever `mergeStateStatus: BEHIND` is hit AND
every required check has gone green. That covers the exact scenario
where branch-protection's "require branches to be up to date before
merging" parks an auto-merge-armed PR until someone clicks **Update
branch** manually — observed on PR #2003 (Story #2002).

## What it does NOT do

- Replace `single-story-close.js` / `epic-deliver-finalize.js` /
  `epic-deliver-automerge.js`. Those still own PR creation, auto-merge
  arming, and the post-watch merge decision.
- Auto-update when checks are pending or failing. The trigger is
  strictly **green + behind** — updating a PR that has failing checks
  just burns CI minutes; updating one with pending checks pre-empts the
  cycle that's already in flight.
- Ping-pong against a racing base. A configurable per-session cap
  (default 3) prevents infinite update-branch loops; past the cap, the
  helper throws and yields to the operator.

## Files

- `.agents/scripts/pr-watch-with-update.js` — new helper (DI-friendly
  runner, pure parser/intent/poll-classifier exports).
- `tests/scripts/pr-watch-with-update.test.js` — 28 unit tests covering
  every branch of the decision matrix.
- `.agents/workflows/single-story-execute.md` — Step 4 updated to call
  the helper. Uses `<agentRoot>` placeholder.
- `.agents/workflows/epic-deliver.md` — Phase 7 updated to call the
  helper. Uses `<agentRoot>` placeholder. Phase 7.5 (automerge) is
  unchanged.
- `baselines/coverage.json` — ratcheted to include the new script.

## Test plan

- [x] All 28 new unit tests pass.
- [x] Full \`npm test\` suite: 4865 pass, 0 fail, 2 skipped.
- [x] \`npm run lint\` clean (markdownlint + biome).
- [x] \`npx biome ci\` clean on changed files.
- [ ] Integration: next standalone Story or Epic-deliver flow exercises
      the helper against a real PR.

Closes #2007