### PR TITLE
ci: drop --full-scope flag from push-to-main maintainability check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,15 +60,12 @@ jobs:
 
       - name: Maintainability Check
         # Epic #1943: scope is resolved by the unified dispatcher via
-        # delivery.quality.gateScoping (.agentrc.json) — diffRef defaults to
-        # main on PR runs; push-to-main runs use --full-scope so untouched
-        # files still surface regressions.
-        run: |
-          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
-            npm run maintainability:check
-          else
-            npm run maintainability:check -- --full-scope
-          fi
+        # delivery.quality.gateScoping (.agentrc.json) — diffRef defaults
+        # to main on PR runs; push-to-main runs set BASELINE_SCOPE=full so
+        # untouched files still surface regressions.
+        env:
+          BASELINE_SCOPE: ${{ github.event_name == 'pull_request' && '' || 'full' }}
+        run: npm run maintainability:check
 
       - name: Run Tests with Coverage
         # Capture stderr too — Node's test runner and the coverage-threshold


### PR DESCRIPTION
## Summary

Hotfix for main CI breakage post-Epic #1943 merge. The unified `check-baselines.js` dispatcher does not accept `--full-scope` as a CLI flag — scope is resolved via `delivery.quality.gateScoping` in `.agentrc.json` or via the `BASELINE_SCOPE` env var.

**Failure** (run [25951239280](https://github.com/dsj1984/mandrel/actions/runs/25951239280)):

```
> mandrel@1.3.0 maintainability:check
> node .agents/scripts/check-baselines.js --gate maintainability --full-scope
{ "schemaVersion": "1", "error": "unknown flag \"--full-scope\"" }
##[error]Process completed with exit code 3.
```

**Fix**: switch the push-to-main branch of the Maintainability Check step to set `BASELINE_SCOPE=full` env var instead of passing the flag.

## Test plan

- [x] PR triggers `Validate and Test` workflow (PR runs use empty `BASELINE_SCOPE` → diff scope, same as before).
- [ ] Once merged, the post-merge `push` event on main runs with `BASELINE_SCOPE=full` and exits 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)