### PR TITLE
fix(epic-plan-decompose): reconciler strips type::epic and risk::* labels from parent Epic on persist (#2056)

### DIFF
--- a/.agents/scripts/lib/orchestration/epic-spec-reconciler-diff.js
+++ b/.agents/scripts/lib/orchestration/epic-spec-reconciler-diff.js
@@ -109,6 +109,56 @@ function labelsEqual(a, b) {
 }
 
 /**
+ * Label-namespace prefixes that the reconciler must NOT strip from the
+ * Epic on persist. The decomposer renders the Epic spec entry from
+ * `{ id, title }` only — it does not carry `epic.labels` through — so
+ * a naive replace-style label diff would propose removing operator-
+ * managed metadata that lives in these namespaces.
+ *
+ * Why: Story #2056 / Epic #1994 — `/epic-plan` was silently stripping
+ * `type::epic` and `risk::*` from the parent Epic on every decompose,
+ * which then broke `dispatcher.js` (`type "unknown"`). Defence-in-depth
+ * lives here in the diff engine: even if a future spec author drops
+ * these labels, the reconciler will not propose their removal.
+ *
+ * Symmetry with the `agent::*` allow-list (owned by the wave-runner,
+ * defended in `epic-spec-reconciler-discriminator.js`): the diff engine
+ * treats both namespaces as out-of-scope for structural reconciliation,
+ * but via different mechanisms — `agent::*` is rejected at construction
+ * time, while these structural namespaces are merged into the Epic's
+ * after-set so the comparison stays a no-op.
+ */
+const PROTECTED_EPIC_LABEL_NAMESPACES = Object.freeze(['type::', 'risk::']);
+
+/**
+ * @param {unknown} label
+ * @returns {boolean}
+ */
+function isProtectedEpicLabel(label) {
+  if (typeof label !== 'string') return false;
+  return PROTECTED_EPIC_LABEL_NAMESPACES.some((ns) => label.startsWith(ns));
+}
+
+/**
+ * Return the spec's label list for the Epic entity, augmented with any
+ * protected-namespace labels observed on the live GH issue. Stable
+ * across calls (uses a Set to deduplicate). When neither input carries
+ * anything to merge, the original `specLabels` reference is returned
+ * unchanged so callers that compare references stay correct.
+ *
+ * @param {string[]|undefined} specLabels
+ * @param {string[]|undefined} obsLabels
+ * @returns {string[]|undefined}
+ */
+function mergeProtectedEpicLabels(specLabels, obsLabels) {
+  if (!Array.isArray(obsLabels) || obsLabels.length === 0) return specLabels;
+  const preserved = obsLabels.filter(isProtectedEpicLabel);
+  if (preserved.length === 0) return specLabels;
+  const merged = new Set([...(specLabels ?? []), ...preserved]);
+  return [...merged];
+}
+
+/**
  * Treat undefined/null body as the empty string for comparison.
  *
  * @param {string|undefined|null} value
@@ -156,10 +206,14 @@ function fieldChanges(specEntity, obs, mapping) {
   if (specBody !== obsBody) {
     changes.body = { before: obsBody, after: specBody };
   }
-  if (!labelsEqual(specEntity.labels, obs.labels)) {
+  const effectiveAfterLabels =
+    specEntity.entity === ENTITY_KINDS.EPIC
+      ? mergeProtectedEpicLabels(specEntity.labels, obs.labels)
+      : specEntity.labels;
+  if (!labelsEqual(effectiveAfterLabels, obs.labels)) {
     changes.labels = {
       before: [...(obs.labels ?? [])].sort(),
-      after: [...(specEntity.labels ?? [])].sort(),
+      after: [...(effectiveAfterLabels ?? [])].sort(),
     };
   }
   // wave is story-only; only fire when both sides carry an integer and

--- a/tests/scripts/epic-spec-reconciler.diff.test.js
+++ b/tests/scripts/epic-spec-reconciler.diff.test.js
@@ -310,3 +310,210 @@ describe('reconciler diff — purity', () => {
     assert.equal(JSON.stringify(fixture.ghState), before);
   });
 });
+
+describe('reconciler diff — Epic protected-label preservation (Story #2056)', () => {
+  // Reproduces the Epic #1994 / 2026-05-16 sequence: `/epic-plan` runs
+  // `epic-plan-decompose.js`, which renders the Epic spec entry from
+  // `{ id, title }` only (labels are not threaded through). The pre-fix
+  // diff engine emitted `labels: [type::epic, risk::medium, ...] → []`
+  // which then propagated to GH and stripped `type::epic` — leaving the
+  // dispatcher unable to resolve the ticket's type. The fix preserves
+  // `type::*` and `risk::*` labels by merging them from the observed
+  // GH state into the Epic's after-set, so the diff is a no-op for
+  // those namespaces no matter what the spec author drops.
+
+  const EPIC_ISSUE = 1994;
+  const STORY_ISSUE = 2000;
+
+  function buildInputs({ obsEpicLabels, specEpicLabels }) {
+    const spec = {
+      epic: { id: EPIC_ISSUE, title: 'Some Epic' },
+      features: [
+        {
+          slug: 'feat-x',
+          title: 'feat x',
+          stories: [
+            {
+              slug: 'story-x',
+              title: 'story x',
+              wave: 0,
+              tasks: [],
+            },
+          ],
+        },
+      ],
+    };
+    if (specEpicLabels !== undefined) {
+      spec.epic.labels = specEpicLabels;
+    }
+    const state = {
+      epicId: EPIC_ISSUE,
+      mapping: {
+        epic: { issueNumber: EPIC_ISSUE, entity: 'epic' },
+        'feat-x': {
+          issueNumber: EPIC_ISSUE + 1,
+          entity: 'feature',
+          parentSlug: 'epic',
+        },
+        'story-x': {
+          issueNumber: STORY_ISSUE,
+          entity: 'story',
+          parentSlug: 'feat-x',
+        },
+      },
+    };
+    const ghState = {
+      [EPIC_ISSUE]: {
+        title: 'Some Epic',
+        body: '',
+        labels: obsEpicLabels,
+      },
+      [EPIC_ISSUE + 1]: {
+        title: 'feat x',
+        body: '',
+        labels: [],
+      },
+      [STORY_ISSUE]: {
+        title: 'story x',
+        body: '',
+        labels: [],
+      },
+    };
+    return { spec, state, ghState };
+  }
+
+  it('does not emit an Epic Update when only protected labels diverge', () => {
+    const { spec, state, ghState } = buildInputs({
+      obsEpicLabels: ['type::epic', 'risk::medium'],
+      // Spec omits Epic labels entirely (the decomposer's current shape).
+      specEpicLabels: undefined,
+    });
+    const plan = diff({ spec, state, ghState });
+    const epicUpdate = plan.updates.find((op) => op.slug === 'epic');
+    assert.equal(
+      epicUpdate,
+      undefined,
+      'Epic Update should not be emitted when only protected-namespace labels would be stripped',
+    );
+  });
+
+  it('preserves type::epic and risk::* in labels.after when an Update is emitted for the Epic', () => {
+    // Title drift forces an Update op; labels payload should still
+    // protect the type/risk namespaces in the after-set.
+    const { spec, state, ghState } = buildInputs({
+      obsEpicLabels: ['type::epic', 'risk::high', 'agent::review-spec'],
+      specEpicLabels: undefined,
+    });
+    ghState[EPIC_ISSUE].title = 'Stale Title';
+    const plan = diff({ spec, state, ghState });
+    const epicUpdate = plan.updates.find((op) => op.slug === 'epic');
+    assert.ok(epicUpdate, 'Epic Update should be emitted when title drifts');
+    // Title drift is recorded.
+    assert.deepEqual(epicUpdate.changes.title, {
+      before: 'Stale Title',
+      after: 'Some Epic',
+    });
+    // Labels diff exists because `agent::review-spec` is still observed
+    // (the wave-runner removes it via setEpicLabel after decompose), but
+    // the after-set MUST carry the protected labels.
+    assert.ok(
+      epicUpdate.changes.labels,
+      'labels change should be present when agent::* differs',
+    );
+    assert.deepEqual(epicUpdate.changes.labels.after.sort(), [
+      'risk::high',
+      'type::epic',
+    ]);
+    assert.deepEqual(epicUpdate.changes.labels.before.sort(), [
+      'agent::review-spec',
+      'risk::high',
+      'type::epic',
+    ]);
+  });
+
+  it('never emits labels: [...] → [] for the Epic when protected labels are observed', () => {
+    // The bug report's exact pre-state.
+    const { spec, state, ghState } = buildInputs({
+      obsEpicLabels: ['agent::review-spec', 'risk::medium', 'type::epic'],
+      specEpicLabels: undefined,
+    });
+    const plan = diff({ spec, state, ghState });
+    const epicUpdate = plan.updates.find((op) => op.slug === 'epic');
+    if (epicUpdate?.changes.labels) {
+      assert.notDeepEqual(
+        epicUpdate.changes.labels.after,
+        [],
+        'labels.after for the Epic must not be empty when protected labels are observed',
+      );
+    }
+  });
+
+  it('does not protect type::/risk:: namespaces on Feature/Story entities (scope: Epic only)', () => {
+    // Sibling entities go through the existing replace-style diff —
+    // this keeps the fix surgical and aligned with the Story body's
+    // explicit scope ("from parent Epic").
+    const spec = {
+      epic: { id: EPIC_ISSUE, title: 'Some Epic', labels: ['type::epic'] },
+      features: [
+        {
+          slug: 'feat-x',
+          title: 'feat x',
+          stories: [
+            {
+              slug: 'story-x',
+              title: 'story x',
+              wave: 0,
+              tasks: [],
+            },
+          ],
+        },
+      ],
+    };
+    const state = {
+      epicId: EPIC_ISSUE,
+      mapping: {
+        epic: { issueNumber: EPIC_ISSUE, entity: 'epic' },
+        'feat-x': {
+          issueNumber: EPIC_ISSUE + 1,
+          entity: 'feature',
+          parentSlug: 'epic',
+        },
+        'story-x': {
+          issueNumber: STORY_ISSUE,
+          entity: 'story',
+          parentSlug: 'feat-x',
+        },
+      },
+    };
+    const ghState = {
+      [EPIC_ISSUE]: {
+        title: 'Some Epic',
+        body: '',
+        labels: ['type::epic'],
+      },
+      [EPIC_ISSUE + 1]: {
+        title: 'feat x',
+        body: '',
+        labels: ['risk::medium'],
+      },
+      [STORY_ISSUE]: {
+        title: 'story x',
+        body: '',
+        labels: ['type::story'],
+      },
+    };
+    const plan = diff({ spec, state, ghState });
+    const featUpdate = plan.updates.find((op) => op.slug === 'feat-x');
+    const storyUpdate = plan.updates.find((op) => op.slug === 'story-x');
+    assert.ok(
+      featUpdate,
+      'Feature with observed risk:: drift should emit an Update',
+    );
+    assert.deepEqual(featUpdate.changes.labels.after, []);
+    assert.ok(
+      storyUpdate,
+      'Story with observed type:: drift should emit an Update',
+    );
+    assert.deepEqual(storyUpdate.changes.labels.after, []);
+  });
+});


### PR DESCRIPTION
Closes #2056

_Auto-opened by `/single-story-execute`._