### PR TITLE
fix(epic-plan): --emit-context writes log lines to stdout, polluting JSON envelope (#2055)

### DIFF
--- a/.agents/scripts/epic-plan-decompose.js
+++ b/.agents/scripts/epic-plan-decompose.js
@@ -47,7 +47,7 @@ import {
   resolveConfig,
   validateOrchestrationConfig,
 } from './lib/config-resolver.js';
-import { Logger } from './lib/Logger.js';
+import { Logger, STDERR_LOGGER } from './lib/Logger.js';
 import { AGENT_LABELS, TYPE_LABELS } from './lib/label-constants.js';
 import { PlanRunnerContext } from './lib/orchestration/context.js';
 import {
@@ -890,17 +890,23 @@ async function main() {
   }
   const provider = createProvider(config.orchestration);
 
+  const emitContext = values['emit-context'];
+
   try {
     await drainPendingCleanupAtBoot({
       repoRoot: PROJECT_ROOT,
       orchestration: config.orchestration,
       provider,
+      // In --emit-context mode stdout is reserved for the JSON envelope;
+      // route every drain/sweep log line through stderr so the captured
+      // file is unconditionally parseable.
+      logger: emitContext ? STDERR_LOGGER : undefined,
     });
   } catch (err) {
     Logger.warn(`[epic-plan-decompose] worktree sweep skipped: ${err.message}`);
   }
 
-  if (values['emit-context']) {
+  if (emitContext) {
     const ctx = await buildDecompositionContext(epicId, provider, config, {
       fullContext: values['full-context'],
     });

--- a/.agents/scripts/epic-plan-spec.js
+++ b/.agents/scripts/epic-plan-spec.js
@@ -49,7 +49,7 @@ import {
   validateOrchestrationConfig,
 } from './lib/config-resolver.js';
 import * as gitUtils from './lib/git-utils.js';
-import { Logger } from './lib/Logger.js';
+import { Logger, STDERR_LOGGER } from './lib/Logger.js';
 import { AGENT_LABELS, TYPE_LABELS } from './lib/label-constants.js';
 import { PlanRunnerContext } from './lib/orchestration/context.js';
 import { buildDocsContext } from './lib/orchestration/doc-reader.js';
@@ -475,11 +475,17 @@ async function main() {
   }
   const provider = createProvider(orchestration);
 
+  const emitContext = values['emit-context'];
+
   try {
     await drainPendingCleanupAtBoot({
       repoRoot: PROJECT_ROOT,
       orchestration,
       provider,
+      // In --emit-context mode stdout is reserved for the JSON envelope;
+      // route every drain/sweep log line through stderr so the captured
+      // file is unconditionally parseable.
+      logger: emitContext ? STDERR_LOGGER : undefined,
     });
   } catch (err) {
     Logger.warn(
@@ -487,7 +493,7 @@ async function main() {
     );
   }
 
-  if (values['emit-context']) {
+  if (emitContext) {
     const ctx = await buildAuthoringContext(epicId, provider, settings, {
       fullContext: values['full-context'],
     });

--- a/.agents/scripts/lib/Logger.js
+++ b/.agents/scripts/lib/Logger.js
@@ -81,3 +81,18 @@ export const NOOP_LOGGER = Object.freeze({
   warn() {},
   error() {},
 });
+
+/**
+ * Frozen logger that routes every level to **stderr**. Use this when a
+ * caller's stdout is a structured payload (e.g. `--emit-context` JSON
+ * envelopes from `epic-plan-spec.js` / `epic-plan-decompose.js`) and any
+ * progress/telemetry log must not interleave with the payload. Mirrors the
+ * `{ info, warn, error, debug }` shape that the orchestration helpers
+ * accept via optional `logger` arguments.
+ */
+export const STDERR_LOGGER = Object.freeze({
+  debug: (message) => console.error(message),
+  info: (message) => console.error(message),
+  warn: (message) => console.error(message),
+  error: (message) => console.error(message),
+});

--- a/tests/scripts/epic-plan-emit-context-stdout-clean.test.js
+++ b/tests/scripts/epic-plan-emit-context-stdout-clean.test.js
@@ -1,0 +1,172 @@
+/**
+ * tests/scripts/epic-plan-emit-context-stdout-clean.test.js — Story #2055
+ *
+ * Contract: when `epic-plan-spec.js` / `epic-plan-decompose.js` boot in
+ * `--emit-context` mode, stdout is reserved for the JSON envelope. Every
+ * worktree-sweep / pending-cleanup drain log line must arrive on stderr so
+ * the captured file is unconditionally parseable as JSON by downstream
+ * skills (no `tail -n +N` workarounds required).
+ *
+ * The two scripts share the same `drainPendingCleanupAtBoot` wrapper plus
+ * the `sweepStaleStoryWorktrees` callee under it; both honour the optional
+ * `logger` argument. Exercising the wrapper with the production wiring is
+ * sufficient to lock the contract — the CLI `main()` paths in both scripts
+ * now compute `emitContext` once and forward `STDERR_LOGGER` into this
+ * same entry point.
+ *
+ * Negative control: invoking the wrapper with the legacy default (`console`)
+ * proves the bug exists today — the `[epic-plan-spec] worktree sweep:
+ * reaped=…` summary line lands on stdout via `console.info`. The positive
+ * test then proves that swapping to `STDERR_LOGGER` removes every stdout
+ * write while keeping the same log line visible on stderr.
+ */
+
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { describe, it } from 'node:test';
+
+import { drainPendingCleanupAtBoot } from '../../.agents/scripts/epic-plan-spec.js';
+import { STDERR_LOGGER } from '../../.agents/scripts/lib/Logger.js';
+
+function tmpRepo() {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'emit-ctx-stdout-'));
+  fs.mkdirSync(path.join(tmp, '.worktrees'), { recursive: true });
+  return tmp;
+}
+
+function stubGitEmptyWorktreeList() {
+  return {
+    gitSpawn: (_cwd, ...args) => {
+      // `git worktree list --porcelain` returns an empty list (no
+      // registered worktrees → sweep emits its summary line with reaped=0).
+      if (args[0] === 'worktree' && args[1] === 'list') {
+        return { status: 0, stdout: '', stderr: '' };
+      }
+      // `git worktree prune` at the end of the sweep — no-op.
+      return { status: 0, stdout: '', stderr: '' };
+    },
+  };
+}
+
+function stubProviderWithGetTicket() {
+  return {
+    getTicket: async () => null,
+  };
+}
+
+/**
+ * Capture every byte that would have been written to a stdio stream's
+ * write surface during `fn`. Hooks both `console.log`/`console.info`/etc.
+ * and the underlying `process.stdout.write` / `process.stderr.write` so a
+ * caller using either channel is intercepted.
+ */
+async function captureIO(fn) {
+  const stdout = [];
+  const stderr = [];
+
+  const origStdoutWrite = process.stdout.write.bind(process.stdout);
+  const origStderrWrite = process.stderr.write.bind(process.stderr);
+  const origConsoleLog = console.log;
+  const origConsoleInfo = console.info;
+  const origConsoleWarn = console.warn;
+  const origConsoleError = console.error;
+  const origConsoleDebug = console.debug;
+
+  process.stdout.write = (chunk) => {
+    stdout.push(String(chunk));
+    return true;
+  };
+  process.stderr.write = (chunk) => {
+    stderr.push(String(chunk));
+    return true;
+  };
+  console.log = (...args) => stdout.push(`${args.join(' ')}\n`);
+  console.info = (...args) => stdout.push(`${args.join(' ')}\n`);
+  console.warn = (...args) => stderr.push(`${args.join(' ')}\n`);
+  console.error = (...args) => stderr.push(`${args.join(' ')}\n`);
+  console.debug = (...args) => stderr.push(`${args.join(' ')}\n`);
+
+  try {
+    await fn();
+  } finally {
+    process.stdout.write = origStdoutWrite;
+    process.stderr.write = origStderrWrite;
+    console.log = origConsoleLog;
+    console.info = origConsoleInfo;
+    console.warn = origConsoleWarn;
+    console.error = origConsoleError;
+    console.debug = origConsoleDebug;
+  }
+
+  return { stdout: stdout.join(''), stderr: stderr.join('') };
+}
+
+describe('epic-plan --emit-context: stdout is reserved for JSON', () => {
+  it("NEGATIVE CONTROL: default logger leaks sweep summary to stdout (today's bug)", async () => {
+    const repoRoot = tmpRepo();
+    try {
+      const { stdout } = await captureIO(async () => {
+        await drainPendingCleanupAtBoot({
+          repoRoot,
+          orchestration: undefined,
+          provider: stubProviderWithGetTicket(),
+          git: stubGitEmptyWorktreeList(),
+        });
+      });
+      assert.match(
+        stdout,
+        /worktree sweep:/i,
+        'default logger (console.info) writes the sweep summary to stdout — this is the bug Story #2055 fixes',
+      );
+    } finally {
+      fs.rmSync(repoRoot, { recursive: true, force: true });
+    }
+  });
+
+  it('STDERR_LOGGER routes the sweep summary off stdout entirely', async () => {
+    const repoRoot = tmpRepo();
+    try {
+      const { stdout, stderr } = await captureIO(async () => {
+        await drainPendingCleanupAtBoot({
+          repoRoot,
+          orchestration: undefined,
+          provider: stubProviderWithGetTicket(),
+          git: stubGitEmptyWorktreeList(),
+          logger: STDERR_LOGGER,
+        });
+      });
+      assert.equal(
+        stdout,
+        '',
+        `stdout must be empty under STDERR_LOGGER; got: ${JSON.stringify(stdout)}`,
+      );
+      assert.match(
+        stderr,
+        /worktree sweep:/i,
+        'sweep summary is still visible — just on stderr where the operator can see it',
+      );
+    } finally {
+      fs.rmSync(repoRoot, { recursive: true, force: true });
+    }
+  });
+
+  it('STDERR_LOGGER preserves the legacy result shape (drained/persistent/remaining)', async () => {
+    const repoRoot = tmpRepo();
+    try {
+      const result = await drainPendingCleanupAtBoot({
+        repoRoot,
+        orchestration: undefined,
+        provider: stubProviderWithGetTicket(),
+        git: stubGitEmptyWorktreeList(),
+        logger: STDERR_LOGGER,
+      });
+      assert.ok('drained' in result, 'result has drained alias');
+      assert.ok('persistent' in result, 'result has persistent alias');
+      assert.equal(typeof result.remaining, 'number', 'remaining is numeric');
+    } finally {
+      fs.rmSync(repoRoot, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
Closes #2055

_Auto-opened by `/single-story-execute`._