### PR TITLE
fix(baselines): maintainability/crap update writes worktree-relative paths instead of repo-relative (#2079)

### DIFF
--- a/.agents/scripts/lib/baseline-snapshot.js
+++ b/.agents/scripts/lib/baseline-snapshot.js
@@ -2,7 +2,7 @@ import { spawnSync as defaultSpawnSync } from 'node:child_process';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
-
+import { canonicalise as canonicalisePath } from './baselines/path-canon.js';
 import {
   getBaselines as defaultGetBaselines,
   getQuality as defaultGetQuality,
@@ -476,10 +476,14 @@ export async function regenerateMainFromTree({
     // Make scores cwd-relative so the on-disk shape matches the existing
     // baseline. saveBaseline sorts keys for determinism; mirror that here so
     // the byte-equality check below is meaningful.
+    // Story #2079: route every key through path-canon so a worktree-relative
+    // resolution (e.g. cwd = main checkout, scanned files inside a worktree)
+    // cannot leak `.worktrees/<workspace>/` into the on-disk baseline.
     const relScores = Object.create(null);
     for (const key of Object.keys(scores)) {
       const rel = path.isAbsolute(key) ? path.relative(cwd, key) : key;
-      relScores[rel.split(path.sep).join('/')] = scores[key];
+      const posixRel = rel.split(path.sep).join('/');
+      relScores[canonicalisePath(posixRel)] = scores[key];
     }
     const sortedScores = Object.keys(relScores)
       .sort()

--- a/.agents/scripts/lib/crap-utils.js
+++ b/.agents/scripts/lib/crap-utils.js
@@ -1,5 +1,6 @@
 import fs from 'node:fs';
 import path from 'node:path';
+import { canonicalise as canonicalisePath } from './baselines/path-canon.js';
 import { findCoverageEntry } from './coverage-utils.js';
 import { runOnPool } from './cpu-pool.js';
 import { calculateCrapForSource } from './crap-engine.js';
@@ -306,9 +307,14 @@ export async function scanAndScore({
 
   // Build the work-queue first so scopeFile filtering happens before
   // any I/O / IPC. `scannedFiles` is the in-scope count.
+  // Story #2079: route every relPath through path-canon so a scan from
+  // inside `.worktrees/<workspace>/` (with cwd pointing at the main
+  // checkout) cannot leak the worktree prefix into the on-disk baseline's
+  // `file` / `path` keys downstream.
   const queue = [];
   for (const abs of files) {
-    const relPath = path.relative(cwd, abs).replace(/\\/g, '/');
+    const rawRel = path.relative(cwd, abs).replace(/\\/g, '/');
+    const relPath = canonicalisePath(rawRel);
     if (scopeSet && !scopeSet.has(relPath)) continue;
     queue.push({ abs, relPath, requireCoverage });
   }

--- a/.agents/scripts/lib/orchestration/story-close/auto-refresh-runner.js
+++ b/.agents/scripts/lib/orchestration/story-close/auto-refresh-runner.js
@@ -54,6 +54,7 @@ import { evaluateAutoRefresh as defaultEvaluateAutoRefresh } from '../../auto-re
 import { regenerateMainFromTree as defaultRegenerateMainFromTree } from '../../baseline-snapshot.js';
 import * as crapKind from '../../baselines/kinds/crap.js';
 import * as miKind from '../../baselines/kinds/maintainability.js';
+import { assertCanonical, canonicalise } from '../../baselines/path-canon.js';
 import { getBaselineEpsilon as defaultGetBaselineEpsilon } from '../../config/quality.js';
 import {
   getBaselines as defaultGetBaselines,
@@ -153,10 +154,22 @@ function readBaselineRows({ kind, baselinePath, fsImpl = fs }) {
  * @returns {{ miRewritten: boolean, crapRewritten: boolean }}
  */
 // MI: re-emit the legacy `{path: mi}` flat-map shape with sorted keys.
+// Story #2079: canonicalise every row's path at the write boundary so a
+// regen produced from inside `.worktrees/<workspace>/` cannot leak its
+// worktree prefix into the on-disk baseline. The shared writer in
+// `lib/baselines/writer.js` already canonicalises via path-canon; this
+// emitter bypasses that writer to preserve the legacy flat-map shape, so
+// we apply the same defence inline. `assertCanonical` after canonicalise
+// is the belt-and-braces — if a future change to canonicalise misses a
+// case, the assertion throws rather than silently writing a bad key.
 function emitMiFlatMap(miAbs, stabilised, fsImpl) {
   const flatMap = Object.create(null);
   for (const row of stabilised) {
-    if (row && typeof row.path === 'string') flatMap[row.path] = row.mi;
+    if (row && typeof row.path === 'string') {
+      const canonical = canonicalise(row.path);
+      assertCanonical(canonical);
+      flatMap[canonical] = row.mi;
+    }
   }
   const sorted = Object.keys(flatMap)
     .sort()
@@ -181,10 +194,19 @@ function emitCrapEnvelope(crapAbs, stabilised, fsImpl) {
   const usesFileField = (envelope.rows ?? []).some(
     (r) => r && typeof r.file === 'string' && typeof r.path !== 'string',
   );
+  // Story #2079: canonicalise every row's key field so a regen produced
+  // from inside `.worktrees/<workspace>/` cannot leak its prefix here.
   envelope.rows = crapKind.sortRows(stabilised).map((row) => {
-    if (!usesFileField) return row;
-    const { path: rowPath, ...rest } = row;
-    return { ...rest, file: rowPath };
+    const rawKey = row.path ?? row.file;
+    if (typeof rawKey !== 'string') return row;
+    const canonical = canonicalise(rawKey);
+    assertCanonical(canonical);
+    const rest = { ...row };
+    delete rest.path;
+    delete rest.file;
+    return usesFileField
+      ? { ...rest, file: canonical }
+      : { ...rest, path: canonical };
   });
   fsImpl.mkdirSync(path.dirname(crapAbs), { recursive: true });
   fsImpl.writeFileSync(crapAbs, `${JSON.stringify(envelope, null, 2)}\n`);

--- a/baselines/maintainability.json
+++ b/baselines/maintainability.json
@@ -1,12 +1,12 @@
 {
   "$schema": ".agents/schemas/baselines/maintainability.schema.json",
   "kernelVersion": "0.1.0",
-  "generatedAt": "2026-05-16T14:30:43.790Z",
+  "generatedAt": "2026-05-16T15:45:26.263Z",
   "rollup": {
     "*": {
       "min": 0,
       "p50": 102.991,
-      "p95": 121.235
+      "p95": 121.071
     }
   },
   "rows": [
@@ -29,6 +29,10 @@
     {
       "path": ".agents/scripts/audit-orchestrator.js",
       "mi": 97.27
+    },
+    {
+      "path": ".agents/scripts/bootstrap.js",
+      "mi": 90.765
     },
     {
       "path": ".agents/scripts/check-baselines.js",
@@ -317,6 +321,14 @@
     {
       "path": ".agents/scripts/lib/bootstrap/merge-methods.js",
       "mi": 88.908
+    },
+    {
+      "path": ".agents/scripts/lib/bootstrap/project-bootstrap.js",
+      "mi": 88.638
+    },
+    {
+      "path": ".agents/scripts/lib/bootstrap/prompt.js",
+      "mi": 81.839
     },
     {
       "path": ".agents/scripts/lib/bootstrap/quality-bootstrap.js",
@@ -1663,6 +1675,14 @@
       "mi": 106.594
     },
     {
+      "path": "tests/bootstrap/project-bootstrap.test.js",
+      "mi": 106.624
+    },
+    {
+      "path": "tests/bootstrap/prompt.test.js",
+      "mi": 120.14
+    },
+    {
       "path": "tests/bootstrap/quality-bootstrap.test.js",
       "mi": 99.581
     },
@@ -2076,7 +2096,7 @@
     },
     {
       "path": "tests/lib/baseline-snapshot.test.js",
-      "mi": 106.638
+      "mi": 107.462
     },
     {
       "path": "tests/lib/branch-name-guard.test.js",

--- a/tests/lib/baseline-snapshot.test.js
+++ b/tests/lib/baseline-snapshot.test.js
@@ -313,6 +313,109 @@ describe('regenerateMainFromTree', () => {
     assert.equal(crapEntry.reason, 'no-coverage');
     assert.equal(logger.warn.mock.callCount(), 1);
   });
+
+  // Story #2079 — defence-in-depth against worktree-relative path leakage in
+  // the on-disk maintainability baseline. The scoring helper can hand back
+  // keys that are either absolute (file scanner inside a worktree) or
+  // relative-but-prefixed (resolver mismatch produces a `.worktrees/...` key
+  // even when cwd ≠ worktree). Both shapes used to leak verbatim into the
+  // flat-map baseline that ships in `baselines/maintainability.json` and
+  // blocked subsequent close-validation runs on sibling Stories. The fix
+  // routes every key through `path-canon` after the cwd-relative reduction
+  // so the prefix is stripped regardless of upstream resolution accidents.
+  it('canonicalises path-style worktree-prefixed keys before persisting maintainability scores', async () => {
+    const miPath = abs('baselines/maintainability.json');
+    const crapPath = abs('baselines/crap.json');
+    const fsImpl = makeFsShim({
+      [miPath]: '{}\n',
+      [crapPath]: '{}\n',
+    });
+    let captured = null;
+    await regenerateMainFromTree({
+      cwd: FAKE_CWD,
+      resolveConfig: () => ({ agentSettings: {} }),
+      getBaselines: () => BASELINES_RESOLVED,
+      getQuality: () => QUALITY_RESOLVED,
+      logger: silentLogger(),
+      fsImpl,
+      scanDirectoryFn: () => [],
+      calculateAllFn: async () => ({
+        // Relative-but-prefixed shape — bug repro from Story #2029's close,
+        // where the scoring resolver produced keys carrying the worktree
+        // segment even though cwd was the main checkout.
+        '.worktrees/story-2029/.agents/scripts/foo.js': 92,
+        // Clean shape — passes through unchanged.
+        '.agents/scripts/bar.js': 85,
+      }),
+      saveMaintainabilityFn: (scores) => {
+        captured = scores;
+      },
+      scanAndScoreFn: async () => ({ rows: [] }),
+      buildBaselineEnvelopeFn: () => ({ rows: [], escomplexVersion: '0.1.0' }),
+      saveCrapFn: () => {},
+      loadCoverageFn: () => ({}),
+      resolveEscomplexVersionFn: () => '0.1.0',
+      resolveTsTranspilerVersionFn: () => '5.9.3',
+    });
+
+    assert.ok(captured, 'saveMaintainabilityFn must have been invoked');
+    const keys = Object.keys(captured);
+    for (const k of keys) {
+      assert.ok(
+        !k.startsWith('.worktrees/'),
+        `key must not carry .worktrees/ prefix; got "${k}"`,
+      );
+    }
+    // The prefixed input collapses into the canonical key — preserves the score.
+    assert.equal(captured['.agents/scripts/foo.js'], 92);
+    assert.equal(captured['.agents/scripts/bar.js'], 85);
+  });
+
+  it('canonicalises absolute-into-worktree keys produced by an in-worktree file scanner', async () => {
+    const miPath = abs('baselines/maintainability.json');
+    const crapPath = abs('baselines/crap.json');
+    const fsImpl = makeFsShim({
+      [miPath]: '{}\n',
+      [crapPath]: '{}\n',
+    });
+    let captured = null;
+    await regenerateMainFromTree({
+      cwd: FAKE_CWD,
+      resolveConfig: () => ({ agentSettings: {} }),
+      getBaselines: () => BASELINES_RESOLVED,
+      getQuality: () => QUALITY_RESOLVED,
+      logger: silentLogger(),
+      fsImpl,
+      scanDirectoryFn: () => [],
+      calculateAllFn: async () => ({
+        // Absolute path inside a worktree, with cwd as the main checkout —
+        // `path.relative` returns `.worktrees/<workspace>/...`, which must
+        // be stripped before the key reaches the on-disk baseline.
+        [path.resolve(
+          FAKE_CWD,
+          '.worktrees/story-2029/.agents/scripts/baz.js',
+        )]: 77,
+      }),
+      saveMaintainabilityFn: (scores) => {
+        captured = scores;
+      },
+      scanAndScoreFn: async () => ({ rows: [] }),
+      buildBaselineEnvelopeFn: () => ({ rows: [], escomplexVersion: '0.1.0' }),
+      saveCrapFn: () => {},
+      loadCoverageFn: () => ({}),
+      resolveEscomplexVersionFn: () => '0.1.0',
+      resolveTsTranspilerVersionFn: () => '5.9.3',
+    });
+
+    assert.ok(captured, 'saveMaintainabilityFn must have been invoked');
+    for (const k of Object.keys(captured)) {
+      assert.ok(
+        !k.startsWith('.worktrees/'),
+        `key must not carry .worktrees/ prefix; got "${k}"`,
+      );
+    }
+    assert.equal(captured['.agents/scripts/baz.js'], 77);
+  });
 });
 
 /**


### PR DESCRIPTION
Closes #2079

_Auto-opened by `/single-story-execute`._