### PR TITLE
refactor(epic-plan): unify Epic canonical headings (Context/Goal/Non-Goals/Scope/AC)

### DIFF
--- a/.agents/SDLC.md
+++ b/.agents/SDLC.md
@@ -191,8 +191,8 @@ mode:
 
 1. **Sharpen the idea.** The `idea-refinement` skill drives a divergent →
    convergent → sharpen loop and emits a markdown one-pager with the
-   canonical sections (Problem Statement, Recommended Direction, Key
-   Assumptions, MVP Scope, Not Doing).
+   five canonical Epic sections (Context, Goal, Non-Goals, Scope,
+   Acceptance Criteria).
 2. **Cross-Epic duplicate search.** `lib/duplicate-search.js` queries the
    open Epics in the repo, scores by title + body keyword overlap, and
    surfaces matches above a threshold. The operator either confirms the
@@ -223,9 +223,12 @@ The framework reads the Epic and autonomously builds the entire work breakdown.
 > **Epic Clarity Gate (`/epic-plan` Phase 6).** Before PRD / Tech Spec /
 > Acceptance Spec authoring kicks off, `/epic-plan` scores the Epic body
 > against the five canonical sections from
-> [`templates/epic-from-idea.md`](templates/epic-from-idea.md) (Problem,
-> Direction, Assumptions, MVP Scope, Not Doing). The rubric is
-> deterministic (section-presence; threshold ≥ 4 of 5). A `clear` verdict
+> [`templates/epic-from-idea.md`](templates/epic-from-idea.md) (Context,
+> Goal, Non-Goals, Scope, Acceptance Criteria). Common legacy heading
+> variants (`Problem`, `Direction`, `MVP Scope`, `Not Doing`,
+> `Out of Scope`) are accepted by the scorer's regex for back-compat.
+> The rubric is deterministic (section-presence; threshold ≥ 4 of 5). A
+> `clear` verdict
 > skips fast with no prompt; a `needs-refinement` verdict drops into the
 > `idea-refinement` skill seeded from the current Epic body, surfaces a
 > HITL diff, and on approval persists the sharpened body via

--- a/.agents/scripts/lib/epic-plan-clarity.js
+++ b/.agents/scripts/lib/epic-plan-clarity.js
@@ -2,27 +2,35 @@
  * epic-plan-clarity.js — Phase 6 Epic Clarity Gate scoring.
  *
  * Pure, deterministic rubric: parse the Epic body for the five canonical
- * sections defined by `.agents/templates/epic-from-idea.md` (Problem,
- * Direction, Assumptions, MVP Scope, Not Doing) and emit a verdict of
+ * sections defined by `.agents/templates/epic-from-idea.md` (Context,
+ * Goal, Non-Goals, Scope, Acceptance Criteria) and emit a verdict of
  * `clear` (≥ 4 of 5 sections present) or `needs-refinement` along with a
  * gap list for the refinement loop seed.
  *
- * Heading variants matched per Story #2128 / Phase 6:
- *   - `## Problem` or `## Problem Statement`
- *   - `## Direction` or `## Recommended Direction`
- *   - `## Assumptions`, `## Key Assumptions`, or `## Key Assumptions to Validate`
- *   - `## MVP Scope`
- *   - `## Not Doing` or `## Not Doing (and Why)`
+ * Heading variants accepted per canonical section (back-compat with the
+ * pre-canonical-headings ideation shape):
+ *   - `## Context`, `## Background`, `## Problem`, `## Problem Statement`,
+ *     `## Context & Problem`
+ *   - `## Goal`, `## Goals`, `## Objective`, `## Objectives`,
+ *     `## Direction`, `## Recommended Direction`
+ *   - `## Non-Goals`, `## Non Goals`, `## Out of Scope`, `## Not Doing`,
+ *     `## Not Doing (and Why)`
+ *   - `## Scope`, `## Scope (...)`, `## MVP Scope`, `## Proposed Scope`,
+ *     `## Work Breakdown`
+ *   - `## Acceptance Criteria`, `## Acceptance`, `## AC`
  *
  * Pure ESM, no I/O.
  */
 
 const SECTION_RE = {
-  problem: /^##\s+Problem(?:\s+Statement)?\s*$/im,
-  direction: /^##\s+(?:Recommended\s+)?Direction\s*$/im,
-  assumptions: /^##\s+(?:Key\s+)?Assumptions(?:\s+to\s+Validate)?\s*$/im,
-  mvpScope: /^##\s+MVP\s+Scope\s*$/im,
-  notDoing: /^##\s+Not\s+Doing(?:\s+\(and\s+Why\))?\s*$/im,
+  context:
+    /^##\s+(?:Context(?:\s+&\s+Problem)?|Background|Problem(?:\s+Statement)?)\s*$/im,
+  goal: /^##\s+(?:Goals?|Objectives?|(?:Recommended\s+)?Direction)\s*$/im,
+  nonGoals:
+    /^##\s+(?:Non[\s-]?Goals|Out\s+of\s+Scope|Not\s+Doing(?:\s+\(and\s+Why\))?)\s*$/im,
+  scope:
+    /^##\s+(?:MVP\s+|Proposed\s+)?Scope(?:\s+\([^)]+\))?\s*$|^##\s+Work\s+Breakdown\s*$/im,
+  acceptanceCriteria: /^##\s+(?:Acceptance(?:\s+Criteria)?|AC)\s*$/im,
 };
 
 /**
@@ -30,11 +38,11 @@ const SECTION_RE = {
  * tests, downstream tooling) can iterate without re-deriving the list.
  */
 export const SECTION_NAMES = Object.freeze([
-  'problem',
-  'direction',
-  'assumptions',
-  'mvpScope',
-  'notDoing',
+  'context',
+  'goal',
+  'nonGoals',
+  'scope',
+  'acceptanceCriteria',
 ]);
 
 const CLEAR_THRESHOLD = 4;

--- a/.agents/scripts/lib/epic-plan-ideation.js
+++ b/.agents/scripts/lib/epic-plan-ideation.js
@@ -15,15 +15,25 @@
 
 import { TYPE_LABELS } from './label-constants.js';
 
+// Canonical section keys match the rendered template at
+// `.agents/templates/epic-from-idea.md`. The regex accepts both the
+// new canonical headings and the pre-canonical-headings ideation shape
+// so an in-flight one-pager parses cleanly during the transition. The
+// older `assumptions` key is accepted as input but is no longer a
+// canonical rendered section — it lands implicitly in `context` if the
+// one-pager carries one.
 const SECTION_RE = {
-  problem: /^##\s+Problem\s+Statement\s*$/im,
-  direction: /^##\s+Recommended\s+Direction\s*$/im,
-  assumptions: /^##\s+Key\s+Assumptions(?:\s+to\s+Validate)?\s*$/im,
-  mvpScope: /^##\s+MVP\s+Scope\s*$/im,
-  notDoing: /^##\s+Not\s+Doing(?:\s+\(and\s+Why\))?\s*$/im,
+  context:
+    /^##\s+(?:Context(?:\s+&\s+Problem)?|Background|Problem(?:\s+Statement)?)\s*$/im,
+  goal: /^##\s+(?:Goals?|Objectives?|(?:Recommended\s+)?Direction)\s*$/im,
+  nonGoals:
+    /^##\s+(?:Non[\s-]?Goals|Out\s+of\s+Scope|Not\s+Doing(?:\s+\(and\s+Why\))?)\s*$/im,
+  scope:
+    /^##\s+(?:MVP\s+|Proposed\s+)?Scope(?:\s+\([^)]+\))?\s*$|^##\s+Work\s+Breakdown\s*$/im,
+  acceptanceCriteria: /^##\s+(?:Acceptance(?:\s+Criteria)?|AC)\s*$/im,
 };
 
-const ORDER = ['problem', 'direction', 'assumptions', 'mvpScope', 'notDoing'];
+const ORDER = ['context', 'goal', 'nonGoals', 'scope', 'acceptanceCriteria'];
 
 /**
  * Extract the five canonical sections from an idea-refinement one-pager.
@@ -32,11 +42,11 @@ const ORDER = ['problem', 'direction', 'assumptions', 'mvpScope', 'notDoing'];
  *   `idea-refinement` skill.
  * @returns {{
  *   title: string,
- *   problem: string,
- *   direction: string,
- *   assumptions: string,
- *   mvpScope: string,
- *   notDoing: string,
+ *   context: string,
+ *   goal: string,
+ *   nonGoals: string,
+ *   scope: string,
+ *   acceptanceCriteria: string,
  * }}
  */
 export function parseOnePager(onePager) {
@@ -58,18 +68,27 @@ export function parseOnePager(onePager) {
   positions.sort((a, b) => a.start - b.start);
 
   const sections = {
-    problem: '',
-    direction: '',
-    assumptions: '',
-    mvpScope: '',
-    notDoing: '',
+    context: '',
+    goal: '',
+    nonGoals: '',
+    scope: '',
+    acceptanceCriteria: '',
   };
 
+  // Generic next-heading regex — slice up to the next `## ` heading,
+  // not just the next canonical one, so non-canonical sections the
+  // author included (e.g. "Open Questions") don't get folded into the
+  // preceding canonical section.
+  const NEXT_HEADING_RE = /^##\s+/m;
   for (let i = 0; i < positions.length; i += 1) {
     const cur = positions[i];
-    const next = positions[i + 1];
     const sliceStart = cur.start + cur.headingLength;
-    const sliceEnd = next ? next.start : onePager.length;
+    const rest = onePager.slice(sliceStart);
+    const nextMatch = rest.match(NEXT_HEADING_RE);
+    const sliceEnd =
+      nextMatch && typeof nextMatch.index === 'number'
+        ? sliceStart + nextMatch.index
+        : onePager.length;
     sections[cur.key] = onePager.slice(sliceStart, sliceEnd).trim();
   }
 

--- a/.agents/skills/core/idea-refinement/SKILL.md
+++ b/.agents/skills/core/idea-refinement/SKILL.md
@@ -50,13 +50,17 @@ bash /mnt/skills/user/idea-refine/scripts/idea-refine.sh
 ## Output
 
 The final output is a markdown one-pager saved to `docs/ideas/[idea-name].md`
-(after user confirmation), containing:
+(after user confirmation), containing the five canonical Epic sections:
 
-- Problem Statement
-- Recommended Direction
-- Key Assumptions
-- MVP Scope
-- Not Doing list
+- Context (problem framing + current state)
+- Goal (desired outcome)
+- Non-Goals (explicit exclusions)
+- Scope (the in-scope MVP and how it tests the core assumption)
+- Acceptance Criteria (how we'll know it worked)
+
+Assumptions and open questions are recorded in the body of the relevant
+section (typically under Context or Scope) rather than carved into their
+own headings — the canonical five drive the `/epic-plan` clarity gate.
 
 ## Detailed Instructions
 
@@ -177,9 +181,10 @@ lands in the Phase 3 one-pager.
 
 5. **Stop condition.** Phase 2 ends when no branches remain unresolved.
    Resolutions feed directly into the Phase 3 one-pager: confirmed bets
-   become "Key Assumptions" with their validation strategy; rejected
-   branches become "Not Doing" entries with the reason; chosen scope
-   becomes "MVP Scope".
+   land in the **Context** section with their validation strategy
+   inline; rejected branches become **Non-Goals** entries with the
+   reason; chosen scope becomes the **Scope** section; verifiable
+   outcomes from the resolved decisions become **Acceptance Criteria**.
 
 **Be honest, not supportive.** If an idea is weak, say so with kindness. A
 good ideation partner is not a yes-machine. Push back on complexity,
@@ -193,41 +198,50 @@ it inside the grill loop, not after the one-pager is already written.
 
 #### Phase 3: Sharpen & Ship
 
-Produce a concrete artifact — a markdown one-pager that moves work forward:
+Produce a concrete artifact — a markdown one-pager that moves work forward.
+The five canonical headings below match `.agents/templates/epic-from-idea.md`
+and the `/epic-plan` clarity gate; emit them verbatim so the renderer can
+substitute the body into a new Epic without translation.
 
 ```markdown
 # [Idea Name]
 
-## Problem Statement
+## Context
 
-[One-sentence "How Might We" framing]
+[One-sentence "How Might We" framing followed by the current-state pain
+or motivation in 1-2 short paragraphs. Surface the key assumptions you
+are betting on inline — assumptions live here, not in a separate
+heading.]
 
-## Recommended Direction
+## Goal
 
-[The chosen direction and why — 2-3 paragraphs max]
+[The chosen direction and the outcome it produces — 2-3 paragraphs max.
+Frame in terms of the end-state the user reaches, not the implementation
+path.]
 
-## Key Assumptions to Validate
-
-- [ ] [Assumption 1 — how to test it]
-- [ ] [Assumption 2 — how to test it]
-- [ ] [Assumption 3 — how to test it]
-
-## MVP Scope
-
-[The minimum version that tests the core assumption. What's in, what's out.]
-
-## Not Doing (and Why)
+## Non-Goals
 
 - [Thing 1] — [reason]
 - [Thing 2] — [reason]
 - [Thing 3] — [reason]
+
+## Scope
+
+[The minimum version that tests the core assumption. What's in, what's
+out, and how it sequences into stories.]
+
+## Acceptance Criteria
+
+- [ ] [Verifiable outcome 1 — phrased so a reviewer can check it]
+- [ ] [Verifiable outcome 2]
+- [ ] [Verifiable outcome 3]
 
 ## Open Questions
 
 - [Question that needs answering before building]
 ```
 
-**The "Not Doing" list is arguably the most valuable part.** Focus is about
+**The "Non-Goals" list is arguably the most valuable part.** Focus is about
 saying no to good ideas. Make the trade-offs explicit.
 
 Ask the user if they'd like to save this to `docs/ideas/[idea-name].md` (or a
@@ -265,7 +279,7 @@ sessions look like.
 - Skipping the "who is this for" question
 - No assumptions surfaced before committing to a direction
 - Yes-machining weak ideas instead of pushing back with specificity
-- Producing a plan without a "Not Doing" list
+- Producing a plan without a "Non-Goals" list
 - Ignoring existing codebase constraints when ideating inside a project
 - Jumping straight to Phase 3 output without running Phases 1 and 2
 - Batching grill-loop questions (asking 3+ at once) instead of one at a time
@@ -284,7 +298,7 @@ After completing an ideation session:
 - [ ] Hidden assumptions are explicitly listed with validation strategies
 - [ ] Every open decision branch was either resolved in the grill loop or
       consciously deferred (with the deferral reason recorded)
-- [ ] A "Not Doing" list makes trade-offs explicit
+- [ ] A "Non-Goals" list makes trade-offs explicit
 - [ ] The output is a concrete artifact (markdown one-pager), not just
       conversation
 - [ ] The user confirmed the final direction before any implementation work

--- a/.agents/templates/epic-from-idea.md
+++ b/.agents/templates/epic-from-idea.md
@@ -1,21 +1,21 @@
 # {{title}}
 
-## Problem
+## Context
 
-{{problem}}
+{{context}}
 
-## Direction
+## Goal
 
-{{direction}}
+{{goal}}
 
-## Assumptions
+## Non-Goals
 
-{{assumptions}}
+{{nonGoals}}
 
-## MVP Scope
+## Scope
 
-{{mvpScope}}
+{{scope}}
 
-## Not Doing
+## Acceptance Criteria
 
-{{notDoing}}
+{{acceptanceCriteria}}

--- a/.agents/workflows/epic-plan.md
+++ b/.agents/workflows/epic-plan.md
@@ -108,10 +108,10 @@ new Epic is genuinely distinct).
    [`.agents/scripts/lib/epic-plan-ideation.js`](../scripts/lib/epic-plan-ideation.js).
    The `template` argument is the contents of
    [`.agents/templates/epic-from-idea.md`](../templates/epic-from-idea.md),
-   which carries the five canonical sections (Problem, Direction,
-   Assumptions, MVP Scope, Not Doing). Sections missing from the
-   one-pager are rendered as `_(not specified)_` rather than left as
-   raw `{{token}}` placeholders.
+   which carries the five canonical sections (Context, Goal, Non-Goals,
+   Scope, Acceptance Criteria). Sections missing from the one-pager are
+   rendered as `_(not specified)_` rather than left as raw `{{token}}`
+   placeholders.
 
 2. **HITL stop — confirm the body**: Display the rendered body to the
    operator and **STOP**. Do not proceed to Phase 4 until the user
@@ -165,9 +165,13 @@ Runs on every existing-Epic invocation, immediately after Phase 5
 Spec). The gate scores the Epic body against the five canonical
 sections from
 [`.agents/templates/epic-from-idea.md`](../templates/epic-from-idea.md)
-(Problem, Direction, Assumptions, MVP Scope, Not Doing) and either
+(Context, Goal, Non-Goals, Scope, Acceptance Criteria) and either
 skips fast (when the Epic body is already clear) or drops into a
-refinement loop seeded from the current Epic body.
+refinement loop seeded from the current Epic body. The scorer also
+accepts common heading variants for back-compat (e.g. `## Problem`,
+`## Direction`, `## MVP Scope`, `## Not Doing`, `## Out of Scope`) so
+hand-authored Epics that predate the canonical headings continue to
+pass without rewording.
 
 The rubric is deterministic: section-presence against the five
 canonical headings. The threshold is ≥ 4 of 5 sections present →

--- a/tests/epic-plan-clarity.test.js
+++ b/tests/epic-plan-clarity.test.js
@@ -3,12 +3,13 @@
  * Clarity Gate scoring rubric.
  *
  * Covers:
- *  - All 5 sections present (ideation-style long headings) → clear
- *  - All 5 sections present (template-style short headings) → clear
+ *  - All 5 sections present (canonical headings) → clear
+ *  - All 5 sections present (legacy ideation-shape headings) → clear
+ *  - All 5 sections present (Epic 2173-style technical-Epic headings) → clear
  *  - 4 present + 1 missing → clear (threshold ≥ 4 of 5)
  *  - 3 present + 2 placeholder → needs-refinement
  *  - Empty body → needs-refinement with all 5 in gap list
- *  - Heading variants: `## Problem Statement`, `## Recommended Direction`
+ *  - Heading variants per canonical section
  */
 
 import assert from 'node:assert/strict';
@@ -18,7 +19,31 @@ import {
   scoreEpicBody,
 } from '../.agents/scripts/lib/epic-plan-clarity.js';
 
-const LONG_HEADINGS_BODY = `# Foo Epic
+const CANONICAL_BODY = `# Foo Epic
+
+## Context
+
+Real users hit X today; the current flow has Y pain.
+
+## Goal
+
+Get users to Z without the Y pain.
+
+## Non-Goals
+
+- W — out of scope.
+
+## Scope
+
+Ship Z narrowly behind a flag.
+
+## Acceptance Criteria
+
+- [ ] A
+- [ ] B
+`;
+
+const LEGACY_IDEATION_BODY = `# Foo Epic
 
 ## Problem Statement
 
@@ -28,11 +53,6 @@ Real users hit X.
 
 Do Y.
 
-## Key Assumptions to Validate
-
-- A
-- B
-
 ## MVP Scope
 
 Ship Y narrowly.
@@ -40,35 +60,52 @@ Ship Y narrowly.
 ## Not Doing (and Why)
 
 - Z — out of scope.
+
+## Acceptance Criteria
+
+- [ ] A
 `;
 
-const SHORT_HEADINGS_BODY = `# Foo Epic
+const TECHNICAL_EPIC_BODY = `# Refactor Epic
 
-## Problem
+## Context
 
-Real users hit X.
+Four overlapping paths do the same thing inconsistently.
 
-## Direction
+## Goal
 
-Do Y.
+Unify behind a single service.
 
-## Assumptions
+## Non-Goals
 
-- A
-- B
+- Lifecycle restructuring lives in a sibling epic.
 
-## MVP Scope
+## Scope (proposed stories)
 
-Ship Y narrowly.
+1. Unified service + tests
+2. Migrate callers
 
-## Not Doing
+## Acceptance Criteria
 
-- Z — out of scope.
+1. Single code path enforced by lint rule.
+2. Default behaviour matches the unified contract.
+
+## Design
+
+Sketch of the unified service API.
+
+## Migration / Risk
+
+Behavior change at the manual CLI documented in CHANGELOG.
+
+## Out of Scope
+
+Replacing baseline file formats.
 `;
 
 describe('scoreEpicBody', () => {
-  it('returns clear with all five long-form ideation headings present', () => {
-    const result = scoreEpicBody({ body: LONG_HEADINGS_BODY });
+  it('returns clear with all five canonical headings present', () => {
+    const result = scoreEpicBody({ body: CANONICAL_BODY });
     assert.equal(result.verdict, 'clear');
     assert.deepEqual(result.missingOrPlaceholder, []);
     assert.equal(result.sections.length, 5);
@@ -77,61 +114,67 @@ describe('scoreEpicBody', () => {
     }
   });
 
-  it('returns clear with all five short-form template headings present', () => {
-    const result = scoreEpicBody({ body: SHORT_HEADINGS_BODY });
+  it('returns clear with legacy ideation-shape headings present', () => {
+    const result = scoreEpicBody({ body: LEGACY_IDEATION_BODY });
     assert.equal(result.verdict, 'clear');
     assert.deepEqual(result.missingOrPlaceholder, []);
   });
 
-  it('returns clear when 4 of 5 sections are present (Not Doing missing)', () => {
+  it('returns clear for a technical Epic that uses Context / Goal / Non-Goals / Scope (proposed stories) / Acceptance Criteria', () => {
+    const result = scoreEpicBody({ body: TECHNICAL_EPIC_BODY });
+    assert.equal(result.verdict, 'clear');
+    assert.deepEqual(result.missingOrPlaceholder, []);
+  });
+
+  it('returns clear when 4 of 5 sections are present (Acceptance Criteria missing)', () => {
     const body = `# Foo
 
-## Problem
+## Context
 P
 
-## Direction
-D
+## Goal
+G
 
-## Assumptions
-A
+## Non-Goals
+- N
 
-## MVP Scope
+## Scope
 M
 `;
     const result = scoreEpicBody({ body });
     assert.equal(result.verdict, 'clear');
-    assert.deepEqual(result.missingOrPlaceholder, ['notDoing']);
-    const notDoing = result.sections.find((s) => s.name === 'notDoing');
-    assert.equal(notDoing.status, 'missing');
+    assert.deepEqual(result.missingOrPlaceholder, ['acceptanceCriteria']);
+    const ac = result.sections.find((s) => s.name === 'acceptanceCriteria');
+    assert.equal(ac.status, 'missing');
   });
 
   it('returns needs-refinement when 3 present + 2 placeholder', () => {
     const body = `# Foo
 
-## Problem
-Real problem.
+## Context
+Real context.
 
-## Direction
+## Goal
 _(not specified)_
 
-## Assumptions
-- a
+## Non-Goals
+- n
 
-## MVP Scope
+## Scope
 _(not specified)_
 
-## Not Doing
-- z
+## Acceptance Criteria
+- ac
 `;
     const result = scoreEpicBody({ body });
     assert.equal(result.verdict, 'needs-refinement');
     assert.equal(result.missingOrPlaceholder.length, 2);
-    assert.ok(result.missingOrPlaceholder.includes('direction'));
-    assert.ok(result.missingOrPlaceholder.includes('mvpScope'));
-    const direction = result.sections.find((s) => s.name === 'direction');
-    assert.equal(direction.status, 'placeholder');
-    const mvp = result.sections.find((s) => s.name === 'mvpScope');
-    assert.equal(mvp.status, 'placeholder');
+    assert.ok(result.missingOrPlaceholder.includes('goal'));
+    assert.ok(result.missingOrPlaceholder.includes('scope'));
+    const goal = result.sections.find((s) => s.name === 'goal');
+    assert.equal(goal.status, 'placeholder');
+    const scope = result.sections.find((s) => s.name === 'scope');
+    assert.equal(scope.status, 'placeholder');
   });
 
   it('returns needs-refinement with all 5 in gap list for empty body', () => {
@@ -152,34 +195,92 @@ _(not specified)_
     assert.equal(result.missingOrPlaceholder.length, 5);
   });
 
-  it('matches the `## Problem Statement` heading variant', () => {
+  it('matches the `## Problem Statement` heading variant for context', () => {
     const body = `## Problem Statement\nfoo\n`;
     const result = scoreEpicBody({ body });
-    const problem = result.sections.find((s) => s.name === 'problem');
-    assert.equal(problem.status, 'present');
+    const context = result.sections.find((s) => s.name === 'context');
+    assert.equal(context.status, 'present');
   });
 
-  it('matches the `## Recommended Direction` heading variant', () => {
+  it('matches the `## Background` heading variant for context', () => {
+    const body = `## Background\nfoo\n`;
+    const result = scoreEpicBody({ body });
+    const context = result.sections.find((s) => s.name === 'context');
+    assert.equal(context.status, 'present');
+  });
+
+  it('matches the `## Recommended Direction` heading variant for goal', () => {
     const body = `## Recommended Direction\nbar\n`;
     const result = scoreEpicBody({ body });
-    const direction = result.sections.find((s) => s.name === 'direction');
-    assert.equal(direction.status, 'present');
+    const goal = result.sections.find((s) => s.name === 'goal');
+    assert.equal(goal.status, 'present');
+  });
+
+  it('matches the `## Objectives` heading variant for goal', () => {
+    const body = `## Objectives\nbar\n`;
+    const result = scoreEpicBody({ body });
+    const goal = result.sections.find((s) => s.name === 'goal');
+    assert.equal(goal.status, 'present');
+  });
+
+  it('matches `## Out of Scope` and `## Not Doing` heading variants for non-goals', () => {
+    for (const heading of ['## Out of Scope', '## Not Doing', '## Non Goals']) {
+      const body = `${heading}\n- thing\n`;
+      const result = scoreEpicBody({ body });
+      const nonGoals = result.sections.find((s) => s.name === 'nonGoals');
+      assert.equal(
+        nonGoals.status,
+        'present',
+        `${heading} should match nonGoals`,
+      );
+    }
+  });
+
+  it('matches `## MVP Scope` and `## Scope (proposed stories)` for scope', () => {
+    for (const heading of [
+      '## MVP Scope',
+      '## Scope (proposed stories)',
+      '## Proposed Scope',
+      '## Work Breakdown',
+    ]) {
+      const body = `${heading}\ncontent\n`;
+      const result = scoreEpicBody({ body });
+      const scope = result.sections.find((s) => s.name === 'scope');
+      assert.equal(scope.status, 'present', `${heading} should match scope`);
+    }
+  });
+
+  it('matches `## AC` and `## Acceptance` heading variants for acceptance criteria', () => {
+    for (const heading of [
+      '## AC',
+      '## Acceptance',
+      '## Acceptance Criteria',
+    ]) {
+      const body = `${heading}\n- ac\n`;
+      const result = scoreEpicBody({ body });
+      const ac = result.sections.find((s) => s.name === 'acceptanceCriteria');
+      assert.equal(
+        ac.status,
+        'present',
+        `${heading} should match acceptanceCriteria`,
+      );
+    }
   });
 
   it('treats whitespace-only section content as placeholder', () => {
-    const body = `## Problem
+    const body = `## Context
 \t  \n
-## Direction
+## Goal
 present text
-## Assumptions
+## Non-Goals
 - a
-## MVP Scope
+## Scope
 m
-## Not Doing
-n
+## Acceptance Criteria
+- ac
 `;
     const result = scoreEpicBody({ body });
-    const problem = result.sections.find((s) => s.name === 'problem');
-    assert.equal(problem.status, 'placeholder');
+    const context = result.sections.find((s) => s.name === 'context');
+    assert.equal(context.status, 'placeholder');
   });
 });

--- a/tests/update-epic-from-one-pager.test.js
+++ b/tests/update-epic-from-one-pager.test.js
@@ -28,25 +28,25 @@ const TEMPLATE_PATH = path.resolve(
 
 const ONE_PAGER = `# Refined Idea
 
-## Problem Statement
+## Context
 
 Customers cannot search past invoices.
 
-## Recommended Direction
+## Goal
 
 Add a full-text invoice search endpoint backed by Postgres GIN.
 
-## Key Assumptions to Validate
+## Non-Goals
 
-- Search latency stays under 500ms on representative tenant data.
+- Full-text on attachments — out of MVP.
 
-## MVP Scope
+## Scope
 
 In: invoices owned by the requesting tenant. Out: cross-tenant search.
 
-## Not Doing (and Why)
+## Acceptance Criteria
 
-- Full-text on attachments — out of MVP.
+- [ ] Search latency stays under 500ms on representative tenant data.
 `;
 
 describe('updateEpicFromOnePager', () => {

--- a/tests/workflows/epic-plan-ideation.test.js
+++ b/tests/workflows/epic-plan-ideation.test.js
@@ -3,7 +3,8 @@
  * Phase 0c/0d helpers used by the s-plan-ideation entry of /epic-plan.
  *
  * Covers:
- *  - parseOnePager extracts the five canonical sections + title
+ *  - parseOnePager extracts the five canonical sections + title from
+ *    both the new canonical heading shape and the legacy ideation shape
  *  - renderEpicBody substitutes template tokens and flags missing
  *    sections
  *  - openEpicFromOnePager calls the injected createIssue port with the
@@ -29,7 +30,33 @@ const TEMPLATE_PATH = path.resolve(
   '../../.agents/templates/epic-from-idea.md',
 );
 
-const SAMPLE_ONE_PAGER = `# Webhook Idempotency Layer
+const CANONICAL_ONE_PAGER = `# Webhook Idempotency Layer
+
+## Context
+
+Duplicate webhook deliveries cause double-charged invoices. We bet
+that replays arrive within 24h.
+
+## Goal
+
+Introduce a fingerprint-keyed dedup store with 24h TTL. The store sits
+in front of the webhook handler and short-circuits replays.
+
+## Non-Goals
+
+- Cross-region replication — single-region MVP is enough.
+
+## Scope
+
+In: Stripe + GitHub webhooks. Out: per-tenant TTL tuning.
+
+## Acceptance Criteria
+
+- [ ] Duplicate Stripe webhook within 24h does not produce a second invoice.
+- [ ] Latency overhead on the happy path stays under 5ms p95.
+`;
+
+const LEGACY_ONE_PAGER = `# Webhook Idempotency Layer
 
 ## Problem Statement
 
@@ -40,11 +67,6 @@ Duplicate webhook deliveries cause double-charged invoices.
 Introduce a fingerprint-keyed dedup store with 24h TTL. The store sits
 in front of the webhook handler and short-circuits replays.
 
-## Key Assumptions to Validate
-
-- [ ] Replays arrive within 24h
-- [ ] Fingerprint hash is stable across providers
-
 ## MVP Scope
 
 In: Stripe + GitHub webhooks. Out: per-tenant TTL tuning.
@@ -52,25 +74,37 @@ In: Stripe + GitHub webhooks. Out: per-tenant TTL tuning.
 ## Not Doing (and Why)
 
 - Cross-region replication — single-region MVP is enough.
+
+## Acceptance Criteria
+
+- [ ] Duplicate Stripe webhook within 24h does not produce a second invoice.
 `;
 
 describe('parseOnePager', () => {
-  it('extracts title and all five canonical sections', () => {
-    const out = parseOnePager(SAMPLE_ONE_PAGER);
+  it('extracts title and all five canonical sections from the canonical shape', () => {
+    const out = parseOnePager(CANONICAL_ONE_PAGER);
     assert.equal(out.title, 'Webhook Idempotency Layer');
-    assert.match(out.problem, /Duplicate webhook deliveries/);
-    assert.match(out.direction, /fingerprint-keyed dedup store/);
-    assert.match(out.assumptions, /Replays arrive within 24h/);
-    assert.match(out.mvpScope, /Stripe \+ GitHub webhooks/);
-    assert.match(out.notDoing, /Cross-region replication/);
+    assert.match(out.context, /Duplicate webhook deliveries/);
+    assert.match(out.goal, /fingerprint-keyed dedup store/);
+    assert.match(out.nonGoals, /Cross-region replication/);
+    assert.match(out.scope, /Stripe \+ GitHub webhooks/);
+    assert.match(out.acceptanceCriteria, /Duplicate Stripe webhook/);
+  });
+
+  it('parses the legacy ideation-shape one-pager (Problem / Direction / MVP Scope / Not Doing)', () => {
+    const out = parseOnePager(LEGACY_ONE_PAGER);
+    assert.equal(out.title, 'Webhook Idempotency Layer');
+    assert.match(out.context, /Duplicate webhook deliveries/);
+    assert.match(out.goal, /fingerprint-keyed dedup store/);
+    assert.match(out.nonGoals, /Cross-region replication/);
+    assert.match(out.scope, /Stripe \+ GitHub webhooks/);
+    assert.match(out.acceptanceCriteria, /Duplicate Stripe webhook/);
   });
 
   it('returns Untitled Epic when no h1 is present', () => {
-    const out = parseOnePager(
-      '## Problem Statement\nthing\n## Recommended Direction\nway',
-    );
+    const out = parseOnePager('## Context\nthing\n## Goal\nway');
     assert.equal(out.title, 'Untitled Epic');
-    assert.match(out.problem, /thing/);
+    assert.match(out.context, /thing/);
   });
 
   it('rejects empty input', () => {
@@ -83,27 +117,27 @@ describe('renderEpicBody', () => {
   it('substitutes all five section tokens against the canonical template', () => {
     const template = fs.readFileSync(TEMPLATE_PATH, 'utf8');
     const { title, body } = renderEpicBody({
-      onePager: SAMPLE_ONE_PAGER,
+      onePager: CANONICAL_ONE_PAGER,
       template,
     });
     assert.equal(title, 'Webhook Idempotency Layer');
     assert.match(body, /^# Webhook Idempotency Layer/m);
-    assert.match(body, /## Problem\n\nDuplicate webhook/);
-    assert.match(body, /## Direction\n\nIntroduce a fingerprint-keyed/);
-    assert.match(body, /## Assumptions\n\n- \[ \] Replays/);
-    assert.match(body, /## MVP Scope\n\nIn: Stripe/);
-    assert.match(body, /## Not Doing\n\n- Cross-region/);
+    assert.match(body, /## Context\n\nDuplicate webhook/);
+    assert.match(body, /## Goal\n\nIntroduce a fingerprint-keyed/);
+    assert.match(body, /## Non-Goals\n\n- Cross-region/);
+    assert.match(body, /## Scope\n\nIn: Stripe/);
+    assert.match(body, /## Acceptance Criteria\n\n- \[ \] Duplicate Stripe/);
     // No leftover {{ tokens
     assert.ok(!body.includes('{{'));
   });
 
   it('flags missing sections instead of leaving raw tokens', () => {
     const template = fs.readFileSync(TEMPLATE_PATH, 'utf8');
-    const minimal =
-      '# Tiny Epic\n\n## Problem Statement\n\nOnly a problem here.\n';
+    const minimal = '# Tiny Epic\n\n## Context\n\nOnly a context here.\n';
     const { body } = renderEpicBody({ onePager: minimal, template });
-    assert.match(body, /## Direction\n\n_\(not specified\)_/);
-    assert.match(body, /## MVP Scope\n\n_\(not specified\)_/);
+    assert.match(body, /## Goal\n\n_\(not specified\)_/);
+    assert.match(body, /## Scope\n\n_\(not specified\)_/);
+    assert.match(body, /## Acceptance Criteria\n\n_\(not specified\)_/);
     assert.ok(!body.includes('{{'));
   });
 });
@@ -118,7 +152,7 @@ describe('openEpicFromOnePager', () => {
     };
 
     const out = await openEpicFromOnePager({
-      onePager: SAMPLE_ONE_PAGER,
+      onePager: CANONICAL_ONE_PAGER,
       template,
       createIssue,
     });
@@ -133,7 +167,7 @@ describe('openEpicFromOnePager', () => {
         `state::* label leaked into payload: ${lbl}`,
       );
     }
-    assert.match(captured.body, /## Problem\n\nDuplicate webhook/);
+    assert.match(captured.body, /## Context\n\nDuplicate webhook/);
 
     // Returned envelope
     assert.equal(out.id, 4242);
@@ -147,7 +181,7 @@ describe('openEpicFromOnePager', () => {
     await assert.rejects(
       () =>
         openEpicFromOnePager({
-          onePager: SAMPLE_ONE_PAGER,
+          onePager: CANONICAL_ONE_PAGER,
           template,
           createIssue: 'not-a-fn',
         }),
@@ -160,7 +194,7 @@ describe('openEpicFromOnePager', () => {
     await assert.rejects(
       () =>
         openEpicFromOnePager({
-          onePager: SAMPLE_ONE_PAGER,
+          onePager: CANONICAL_ONE_PAGER,
           template,
           createIssue: async () => ({ url: 'no-id' }),
         }),


### PR DESCRIPTION
## Summary

Replaces the `/epic-plan` Phase 6 clarity gate's product-flavored
canonical heading set (Problem / Direction / Assumptions / MVP Scope /
Not Doing) with an engineering-flavored set that fits all Epic types:

**Context / Goal / Non-Goals / Scope / Acceptance Criteria**

Surfaced while planning [#2173](https://github.com/dsj1984/mandrel/issues/2173)
(Unified Baseline Refresh Service), whose hand-authored body
(Context / Goal / Non-Goals / Design / Scope / Acceptance Criteria /
Migration / Out of Scope) failed the gate despite being more complete
than the old canonical demanded.

## Why this set

| Concern | Old canonical | New canonical | Rationale |
|---|---|---|---|
| Pain / current state | Problem | **Context** | Broader; covers refactor framing as well as user problems |
| Outcome | Direction | **Goal** | Outcome-focused rather than solution-leaning |
| Exclusions | Not Doing | **Non-Goals** | Conventional engineering language |
| Work breakdown | MVP Scope | **Scope** | Works for non-MVP work (migrations, refactors) |
| Done-criteria | _absent_ | **Acceptance Criteria** | Load-bearing for every Epic type |
| Assumptions | Assumptions | _(inline in Context)_ | Forced section created empty placeholders for technical Epics |

Threshold unchanged at **4/5**. The scorer accepts common legacy
variants (`Problem`, `Direction`, `MVP Scope`, `Not Doing`,
`Out of Scope`, `Background`, `Objectives`, `Scope (proposed stories)`,
`AC`, etc.) so already-planned Epics on the old shape continue to
pass without rewording.

## Surface

- [.agents/templates/epic-from-idea.md](.agents/templates/epic-from-idea.md) — new 5-section template
- [.agents/scripts/lib/epic-plan-clarity.js](.agents/scripts/lib/epic-plan-clarity.js) — new `SECTION_NAMES` + variant regex
- [.agents/scripts/lib/epic-plan-ideation.js](.agents/scripts/lib/epic-plan-ideation.js) — `parseOnePager` keys + variant regex
- [.agents/skills/core/idea-refinement/SKILL.md](.agents/skills/core/idea-refinement/SKILL.md) — Phase 3 one-pager output spec
- [.agents/workflows/epic-plan.md](.agents/workflows/epic-plan.md) & [.agents/SDLC.md](.agents/SDLC.md) — doc references
- 3 test files updated; 29 tests cover canonical shape, legacy shape, technical-Epic shape, and all heading variants

## Test plan

- [x] `npm test` — 5222 pass / 2 skipped / 0 fail
- [x] `npm run lint` — clean (markdownlint + biome)
- [x] Verified `scoreEpicBody` returns `clear` against Epic #2173's hand-authored body
- [ ] Verify CI is green
- [ ] Verify clarity gate still passes for at least one legacy-shape Epic body (smoke test the back-compat regex on an existing Epic)