### PR TITLE
fix(retro): align retro-runner with ITicketingProvider; add no-op guard; count manual interventions (#2289)

### DIFF
--- a/.agents/scripts/lib/orchestration/epic-deliver-close-tail.js
+++ b/.agents/scripts/lib/orchestration/epic-deliver-close-tail.js
@@ -342,12 +342,29 @@ export async function runEpicDeliverCloseTail(opts = {}) {
   }
 
   // ---------- Phase E: retro ----------
+  // Re-read the checkpoint so the retro scorecard reflects the latest
+  // `manualInterventions` count. Out-of-band recovery (`epic-deliver-note-
+  // intervention.js`) can append entries between the close-tail's prior
+  // crash and this resume — Story #2289 makes that count visible in the
+  // retro instead of silently dropping it. A read failure degrades to 0
+  // so retro never blocks on checkpoint corruption.
   const e = await runPhase({
     ...phaseCtx,
     phase: 'retro',
     nextPhase: 'finalize',
     errorReason: 'retro-error',
-    body: () => runRetroFn({ epicId, provider, logger }),
+    body: async () => {
+      const interventionCount = await readInterventionCount(
+        checkpointer,
+        logger,
+      );
+      return runRetroFn({
+        epicId,
+        provider,
+        logger,
+        manualInterventions: interventionCount,
+      });
+    },
     onResult: (retro) => {
       result.retro = retro;
       return null;
@@ -442,6 +459,25 @@ function finishResult(result, blocker, phasesRun, phasesSkipped) {
   result.phasesRun = phasesRun;
   result.phasesSkipped = phasesSkipped;
   return result;
+}
+
+/**
+ * Read the checkpoint's `manualInterventions` array length, used by
+ * Phase E to inflate the retro scorecard. A missing or corrupt checkpoint
+ * collapses to 0 — the retro must never fail closed on observability data.
+ */
+async function readInterventionCount(checkpointer, logger) {
+  try {
+    const state = (await checkpointer.read()) ?? {};
+    return Array.isArray(state.manualInterventions)
+      ? state.manualInterventions.length
+      : 0;
+  } catch (err) {
+    logger?.warn?.(
+      `[close-tail] could not read manualInterventions for retro scorecard: ${messageOf(err)}`,
+    );
+    return 0;
+  }
 }
 
 // Re-export phase list so consumers (the contract test, the slash-command

--- a/.agents/scripts/lib/orchestration/retro-heuristics.js
+++ b/.agents/scripts/lib/orchestration/retro-heuristics.js
@@ -2,7 +2,7 @@
  * Heuristics that drive which retro path the `epic-retro` helper composes.
  *
  * The compact three-section retro fires when the Epic's dispatch manifest
- * carries zero friction signals. Non-zero on any of the five dimensions
+ * carries zero friction signals. Non-zero on any of the six dimensions
  * routes back to the full six-section retro. Keeping the predicate here
  * (pure, no I/O) guards the clean-sprint definition from drifting as the
  * retro helper markdown evolves.
@@ -14,34 +14,41 @@
  * comment fan-out. The predicate signature stays unchanged — the input
  * is still a single integer count — so callers only need to swap their
  * data source.
+ *
+ * Story #2289 — added `interventions`, sourced from the checkpointer's
+ * `manualInterventions` array. The same list disqualifies the Epic from
+ * auto-merge, so the retro shape and the auto-merge gate now agree on
+ * what "clean" means.
  */
 
 /**
  * Evaluate whether an Epic's dispatch manifest counts qualify for the
  * compact retro path.
  *
- * All five signals must be zero. Any non-zero value (including negatives,
+ * All six signals must be zero. Any non-zero value (including negatives,
  * which are invalid but treated defensively as "non-clean") returns false.
  * Non-number inputs are treated as missing and default to zero so callers
  * can omit dimensions they have not yet gathered — a call with no arguments
  * returns true.
  *
  * @param {Object} [counts]
- * @param {number} [counts.friction=0]  Aggregate friction-event count, summed from `story-perf-summary.frictionByCategory` across the Epic's descendants (Story #1046).
- * @param {number} [counts.parked=0]    Count of parked follow-on Stories (no manifest lineage).
- * @param {number} [counts.recuts=0]    Count of Stories carrying a `<!-- recut-of: #N -->` marker.
- * @param {number} [counts.hotfixes=0]  Count of Tasks that flipped to `status::blocked` mid-sprint.
- * @param {number} [counts.hitl=0]      Count of tickets that raised an `agent::blocked` event mid-sprint (the runtime HITL pause point).
+ * @param {number} [counts.friction=0]      Aggregate friction-event count, summed from `story-perf-summary.frictionByCategory` across the Epic's descendants (Story #1046).
+ * @param {number} [counts.parked=0]        Count of parked follow-on Stories (no manifest lineage).
+ * @param {number} [counts.recuts=0]        Count of Stories carrying a `<!-- recut-of: #N -->` marker.
+ * @param {number} [counts.hotfixes=0]      Count of Tasks that flipped to `status::blocked` mid-sprint.
+ * @param {number} [counts.hitl=0]          Count of tickets that raised an `agent::blocked` event mid-sprint (the runtime HITL pause point).
+ * @param {number} [counts.interventions=0] Count of recorded manual interventions (the same `manualInterventions` list the auto-merge predicate consults — Story #2289).
  * @returns {boolean}
  */
 export function isCleanManifest(counts = {}) {
-  const { friction, parked, recuts, hotfixes, hitl } = counts;
+  const { friction, parked, recuts, hotfixes, hitl, interventions } = counts;
   return (
     normalize(friction) === 0 &&
     normalize(parked) === 0 &&
     normalize(recuts) === 0 &&
     normalize(hotfixes) === 0 &&
-    normalize(hitl) === 0
+    normalize(hitl) === 0 &&
+    normalize(interventions) === 0
   );
 }
 

--- a/.agents/scripts/lib/orchestration/retro-runner.js
+++ b/.agents/scripts/lib/orchestration/retro-runner.js
@@ -58,6 +58,10 @@ function sumFriction(byCategory) {
  * Walk every descendant ticket of `epicId` once. Returns the flat list with
  * each ticket's labels + body + state — the consumer derives its own
  * counts from this snapshot. Pure with respect to the provider injection.
+ *
+ * `provider.getSubTickets` is part of the `ITicketingProvider` contract;
+ * the call is **not** optional-chained so a missing method (or a typo'd
+ * test stub) surfaces as a thrown error rather than a silent empty graph.
  */
 async function collectDescendants(provider, epicId) {
   const visited = new Set([epicId]);
@@ -65,7 +69,7 @@ async function collectDescendants(provider, epicId) {
   const queue = [epicId];
   while (queue.length > 0) {
     const id = queue.shift();
-    const subs = (await provider.getSubIssues?.(id)) ?? [];
+    const subs = (await provider.getSubTickets(id)) ?? [];
     for (const sub of subs) {
       const subId = Number(sub?.id ?? sub?.number);
       if (!Number.isInteger(subId) || visited.has(subId)) continue;
@@ -77,10 +81,51 @@ async function collectDescendants(provider, epicId) {
   return out;
 }
 
+// Detects #NNN issue references in an Epic body — any match means the Epic
+// likely has child Stories enumerated in the planning artifact, so a
+// zero-descendant walk is suspicious.
+const EPIC_BODY_REFERENCE = /#\d+/;
+
+/**
+ * Defensive guard: when the descendant walker returned zero, probe the
+ * Epic ticket itself. If the Epic exists and its body references child
+ * issues (e.g., `#123` planning refs), the empty walk is almost certainly
+ * a contract drift in the underlying provider — emit a loud warn so the
+ * silent failure surfaces. Probe errors degrade silently (the guard is
+ * best-effort observability, not a correctness gate).
+ */
+async function warnIfEpicLooksPopulated({ epicId, provider, logger }) {
+  let epic;
+  try {
+    epic = await provider.getTicket?.(epicId);
+  } catch (err) {
+    logger?.warn?.(
+      `[retro-runner] guard: getTicket(#${epicId}) failed (continuing): ${err?.message ?? err}`,
+    );
+    return;
+  }
+  if (!epic) return;
+  const body = typeof epic.body === 'string' ? epic.body : '';
+  if (!EPIC_BODY_REFERENCE.test(body)) return;
+  logger?.warn?.(
+    `[retro-runner] WARNING: Epic #${epicId} body references child issues, ` +
+      'but the descendant walker returned zero — retro will under-report ' +
+      'friction. Possible provider contract drift in getSubTickets.',
+  );
+}
+
 /**
  * Read raw retro signals from the GitHub graph. Pure with respect to the
  * provider injection — exported so tests can drive the predicate end-to-end
  * with a stub provider.
+ *
+ * When `descendants.length === 0`, the function probes `provider.getTicket`
+ * to distinguish "Epic legitimately empty" from "the descendant walker
+ * silently returned nothing under a populated Epic" (the failure mode the
+ * pre-Story #2289 `getSubIssues` contract drift produced). A populated
+ * Epic with zero walked descendants emits a loud warn via the supplied
+ * `logger` so the silent failure becomes visible. Probe failure degrades
+ * gracefully — the function never throws on the guard alone.
  *
  * @returns {Promise<{
  *   stories: Array<{ id: number, body?: string, labels?: string[] }>,
@@ -91,8 +136,11 @@ async function collectDescendants(provider, epicId) {
  *   parkedFollowOns: { recuts: object[], parked: object[], present: boolean },
  * }>}
  */
-export async function gatherRetroSignals({ epicId, provider }) {
+export async function gatherRetroSignals({ epicId, provider, logger }) {
   const descendants = await collectDescendants(provider, epicId);
+  if (descendants.length === 0) {
+    await warnIfEpicLooksPopulated({ epicId, provider, logger });
+  }
   const stories = descendants.filter((t) =>
     (t.labels ?? []).includes(TYPE_LABELS.STORY),
   );
@@ -183,13 +231,31 @@ export async function gatherRetroSignals({ epicId, provider }) {
 }
 
 /**
+ * Pure: clamp a candidate count to a non-negative integer. Used to
+ * normalize the `manualInterventions` count plumbed in from the
+ * checkpointer state before it lands in the scorecard. Non-finite,
+ * negative, or non-numeric values collapse to 0.
+ */
+function normalizeInterventionCount(value) {
+  if (typeof value !== 'number' || !Number.isFinite(value) || value < 0) {
+    return 0;
+  }
+  return Math.trunc(value);
+}
+
+/**
  * Pure: compose the retro markdown body. Exported for tests so they can
  * verify the body shape without round-tripping through a stub provider.
+ *
+ * Story #2289 adds `counts.interventions` — sourced from the checkpointer's
+ * `manualInterventions` array (the same list that disqualifies an Epic
+ * from auto-merge). Non-zero interventions route to the full retro shape
+ * via `isCleanManifest`.
  *
  * @param {{
  *   epicId: number,
  *   epicTitle?: string,
- *   counts: { friction: number, parked: number, recuts: number, hotfixes: number, hitl: number },
+ *   counts: { friction: number, parked: number, recuts: number, hotfixes: number, hitl: number, interventions?: number },
  *   storyPerfSummaries?: object[],
  *   epicPerfReport?: object|null,
  *   parkedFollowOns?: { recuts: object[], parked: object[] },
@@ -213,7 +279,8 @@ export function composeRetroBody(input) {
     forceFull = false,
   } = input;
 
-  const compact = !forceFull && isCleanManifest(counts);
+  const interventions = normalizeInterventionCount(counts?.interventions);
+  const compact = !forceFull && isCleanManifest({ ...counts, interventions });
   const heading = `## 🪞 Sprint Retrospective — Epic #${epicId}: ${epicTitle}`;
   const generatedLine = `_Generated ${timestamp}_`;
   const scorecardRows = [
@@ -221,6 +288,7 @@ export function composeRetroBody(input) {
     `| Tasks Completed First Try    | ${tasksFirstTry} |`,
     `| Tasks Requiring Hotfix       | ${counts.hotfixes} |`,
     `| agent::blocked Events Raised | ${counts.hitl} |`,
+    `| Manual Interventions         | ${interventions} |`,
     `| Friction Events              | ${counts.friction} |`,
   ];
   const scorecard = {
@@ -231,6 +299,7 @@ export function composeRetroBody(input) {
     friction: counts.friction,
     parked: counts.parked,
     recuts: counts.recuts,
+    interventions,
   };
   const completeMarker = `<!-- retro-complete: ${timestamp} -->`;
 
@@ -240,7 +309,7 @@ export function composeRetroBody(input) {
       '',
       generatedLine,
       '',
-      '🟢 Clean sprint — zero friction, zero parked follow-ons, zero recuts, zero hotfixes, zero agent::blocked events.',
+      '🟢 Clean sprint — zero friction, zero parked follow-ons, zero recuts, zero hotfixes, zero agent::blocked events, zero manual interventions.',
       '',
       '### Sprint Scorecard',
       '',
@@ -346,6 +415,7 @@ export function composeRetroBody(input) {
  *   logger?: { info?: Function, warn?: Function },
  *   forceFull?: boolean,
  *   timestamp?: string,
+ *   manualInterventions?: number,
  *   gatherFn?: typeof gatherRetroSignals,
  *   composeFn?: typeof composeRetroBody,
  *   upsertFn?: typeof upsertStructuredComment,
@@ -369,6 +439,7 @@ export async function runRetro(opts = {}) {
     logger,
     forceFull = false,
     timestamp,
+    manualInterventions = 0,
     gatherFn = gatherRetroSignals,
     composeFn = composeRetroBody,
     upsertFn = upsertStructuredComment,
@@ -386,7 +457,7 @@ export async function runRetro(opts = {}) {
   }
 
   logger?.info?.(`[retro-runner] Composing retro for Epic #${epicId}...`);
-  const signals = await gatherFn({ epicId, provider });
+  const signals = await gatherFn({ epicId, provider, logger });
 
   // Best-effort fetch of the Epic title for the heading.
   let epicTitle;
@@ -406,10 +477,11 @@ export async function runRetro(opts = {}) {
   const hotfixCount = signals.counts.hotfixes;
   const tasksFirstTry = Math.max(0, tasksTotal - hotfixCount);
 
+  const interventions = normalizeInterventionCount(manualInterventions);
   const { body, compact, scorecard } = composeFn({
     epicId,
     epicTitle,
-    counts: signals.counts,
+    counts: { ...signals.counts, interventions },
     storyPerfSummaries: signals.storyPerfSummaries,
     epicPerfReport: signals.epicPerfReport,
     parkedFollowOns: signals.parkedFollowOns,

--- a/tests/lib/orchestration/retro-mirror-write.test.js
+++ b/tests/lib/orchestration/retro-mirror-write.test.js
@@ -41,7 +41,7 @@ function makeProvider(epicId, storyId, taskId) {
     [storyId, [{ id: taskId, number: taskId, labels: ['type::task'] }]],
   ]);
   return {
-    async getSubIssues(id) {
+    async getSubTickets(id) {
       return subIssuesByParent.get(id) ?? [];
     },
     async getTicketComments() {

--- a/tests/lib/orchestration/retro-runner.test.js
+++ b/tests/lib/orchestration/retro-runner.test.js
@@ -104,7 +104,7 @@ function makeProvider(graph) {
   return {
     posted: postedComments,
     deleted: deletedCommentIds,
-    async getSubIssues(id) {
+    async getSubTickets(id) {
       return subIssuesByParent.get(id) ?? [];
     },
     async getTicketComments(id) {
@@ -289,4 +289,175 @@ test('gatherRetroSignals: aggregates friction across stories', async () => {
   const signals = await gatherRetroSignals({ epicId: 110, provider });
   assert.equal(signals.counts.friction, 7);
   assert.equal(signals.storyPerfSummaries.length, 2);
+});
+
+// --- Story #2289 regression coverage ---
+
+test('runRetro: throws when provider is missing getSubTickets (no silent compact)', async () => {
+  // Pre-#2289, retro-runner called `provider.getSubIssues?.()` with an
+  // optional-chain — a provider that only implemented `getSubTickets`
+  // (per the ITicketingProvider contract) silently produced an empty
+  // descendant set. Now the call is unconditional, so the missing method
+  // throws and surfaces the contract drift instead of producing a wrong
+  // compact retro.
+  const provider = {
+    async getTicket() {
+      return { id: 500, title: 'Epic missing getSubTickets', body: '' };
+    },
+    async getTicketComments() {
+      return [];
+    },
+  };
+  await assert.rejects(() =>
+    runRetro({
+      epicId: 500,
+      provider,
+      timestamp: '2026-05-17T00:00:00.000Z',
+    }),
+  );
+});
+
+test('gatherRetroSignals: warns when descendants empty but Epic body references children', async () => {
+  // Defensive guard: if the walker returns zero descendants under an Epic
+  // whose body references child issues (`#123` planning refs), emit a
+  // warn so the silent failure surfaces. The guard is logger-only — it
+  // never throws and never blocks retro composition.
+  const provider = {
+    async getSubTickets() {
+      return [];
+    },
+    async getTicketComments() {
+      return [];
+    },
+    async getTicket(id) {
+      if (id === 600) {
+        return {
+          id: 600,
+          title: 'Populated Epic',
+          body: 'Children: #601 #602 #603',
+        };
+      }
+      return null;
+    },
+  };
+  const warns = [];
+  const signals = await gatherRetroSignals({
+    epicId: 600,
+    provider,
+    logger: { warn: (msg) => warns.push(msg) },
+  });
+  assert.equal(signals.tasks.length, 0);
+  assert.ok(
+    warns.some((line) => /under-report|contract drift|WARNING/i.test(line)),
+    `expected a warn line about the empty descendant walk, got: ${warns.join('\n') || '<none>'}`,
+  );
+});
+
+test('gatherRetroSignals: no warn when descendants empty and Epic body has no child refs', async () => {
+  // A truly empty / no-op Epic (body has no `#NNN` refs) should not
+  // trigger the guard — otherwise every legitimately-empty Epic would
+  // generate noise on every retro.
+  const provider = {
+    async getSubTickets() {
+      return [];
+    },
+    async getTicketComments() {
+      return [];
+    },
+    async getTicket(id) {
+      if (id === 601) {
+        return {
+          id: 601,
+          title: 'Empty Epic',
+          body: 'No child references in this body.',
+        };
+      }
+      return null;
+    },
+  };
+  const warns = [];
+  await gatherRetroSignals({
+    epicId: 601,
+    provider,
+    logger: { warn: (msg) => warns.push(msg) },
+  });
+  assert.equal(
+    warns.length,
+    0,
+    `expected no warns for genuinely empty Epic, got: ${warns.join('\n')}`,
+  );
+});
+
+test('composeRetroBody: interventions > 0 routes to full retro and shows scorecard row', async () => {
+  const { body, compact, scorecard } = composeRetroBody({
+    epicId: 700,
+    epicTitle: 'Intervention Epic',
+    counts: {
+      friction: 0,
+      parked: 0,
+      recuts: 0,
+      hotfixes: 0,
+      hitl: 0,
+      interventions: 5,
+    },
+    tasksTotal: 4,
+    tasksFirstTry: 4,
+    timestamp: '2026-05-17T01:00:00.000Z',
+  });
+  assert.equal(compact, false, 'expected full retro when interventions > 0');
+  assert.equal(scorecard.interventions, 5);
+  assert.match(body, /Manual Interventions {9}\| 5/);
+  assert.match(body, /What Went Well/);
+});
+
+test('runRetro: surfaces manualInterventions count in scorecard', async () => {
+  const provider = makeProvider({
+    epic: { id: 800, title: 'Intervention Epic' },
+    stories: [
+      {
+        id: 810,
+        labels: ['type::story'],
+        perfSummary: {
+          kind: 'story-perf-summary',
+          frictionByCategory: {},
+        },
+      },
+    ],
+    tasks: [{ id: 820, parentStoryId: 810, labels: ['type::task'] }],
+  });
+  const out = await runRetro({
+    epicId: 800,
+    provider,
+    manualInterventions: 3,
+    timestamp: '2026-05-17T02:00:00.000Z',
+  });
+  assert.equal(out.scorecard.interventions, 3);
+  // Five recorded interventions otherwise clean must still render full.
+  assert.equal(out.compact, false);
+  assert.match(provider.posted[0].body, /Manual Interventions {9}\| 3/);
+});
+
+test('runRetro: ignores non-finite manualInterventions (defensive)', async () => {
+  const provider = makeProvider({
+    epic: { id: 900, title: 'Defensive Epic' },
+    stories: [
+      {
+        id: 910,
+        labels: ['type::story'],
+        perfSummary: {
+          kind: 'story-perf-summary',
+          frictionByCategory: {},
+        },
+      },
+    ],
+    tasks: [{ id: 920, parentStoryId: 910, labels: ['type::task'] }],
+  });
+  const out = await runRetro({
+    epicId: 900,
+    provider,
+    manualInterventions: Number.NaN,
+    timestamp: '2026-05-17T03:00:00.000Z',
+  });
+  assert.equal(out.scorecard.interventions, 0);
+  assert.equal(out.compact, true);
 });

--- a/tests/lib/retro-heuristics.test.js
+++ b/tests/lib/retro-heuristics.test.js
@@ -21,9 +21,23 @@ test('isCleanManifest - no arguments returns true (all dimensions default to 0)'
 });
 
 test('isCleanManifest - each single non-zero signal returns false', () => {
-  const dimensions = ['friction', 'parked', 'recuts', 'hotfixes', 'hitl'];
+  const dimensions = [
+    'friction',
+    'parked',
+    'recuts',
+    'hotfixes',
+    'hitl',
+    'interventions',
+  ];
   for (const dim of dimensions) {
-    const counts = { friction: 0, parked: 0, recuts: 0, hotfixes: 0, hitl: 0 };
+    const counts = {
+      friction: 0,
+      parked: 0,
+      recuts: 0,
+      hotfixes: 0,
+      hitl: 0,
+      interventions: 0,
+    };
     counts[dim] = 1;
     assert.strictEqual(
       isCleanManifest(counts),
@@ -97,4 +111,21 @@ test('isCleanManifest - hitl reflects agent::blocked event count (fixture replay
   // tally, so the heuristic falls back to the compact retro.
   fixture.hitl = 0;
   assert.strictEqual(isCleanManifest(fixture), true);
+});
+
+// Story #2289 — interventions count now feeds the predicate so the retro
+// shape agrees with the auto-merge gate on what "clean" means.
+test('isCleanManifest - interventions > 0 disqualifies the compact path', () => {
+  assert.strictEqual(
+    isCleanManifest({
+      friction: 0,
+      parked: 0,
+      recuts: 0,
+      hotfixes: 0,
+      hitl: 0,
+      interventions: 5,
+    }),
+    false,
+    'recorded manual interventions should route to the full retro',
+  );
 });

--- a/tests/workflows/epic-deliver.test.js
+++ b/tests/workflows/epic-deliver.test.js
@@ -448,3 +448,63 @@ test('runEpicDeliverCloseTail: rejects missing args', async () => {
     /runFinalizeFn is required/,
   );
 });
+
+// Story #2289 — Phase E reads the checkpoint's manualInterventions count
+// at retro entry (post-resume, not at close-tail start) and passes the
+// length to runRetro so the scorecard reflects out-of-band intervention
+// records the host LLM appended via epic-deliver-note-intervention.js.
+test('runEpicDeliverCloseTail: passes manualInterventions count from checkpoint to runRetro', async () => {
+  const provider = makeCheckpointProvider();
+  const checkpointer = new Checkpointer({ provider, epicId: 42 });
+  // Seed the checkpoint with two recorded interventions before the
+  // close-tail runs Phase E.
+  await checkpointer.write({
+    epicId: 42,
+    phase: 'retro',
+    manualInterventions: [
+      {
+        reason: 'manual git reset',
+        source: 'host-llm',
+        ts: '2026-05-17T00:00:00.000Z',
+      },
+      {
+        reason: 'AskUserQuestion override',
+        source: 'host-llm',
+        ts: '2026-05-17T00:01:00.000Z',
+      },
+    ],
+  });
+
+  let retroArgs = null;
+  await runEpicDeliverCloseTail({
+    epicId: 42,
+    provider,
+    runWaveGateFn: async () => ({ exitCode: 0 }),
+    runHierarchyGateFn: async () => ({ exitCode: 0 }),
+    runCodeReviewFn: async () => ({
+      status: 'ok',
+      severity: { critical: 0, high: 0, medium: 0, suggestion: 0 },
+      halted: false,
+      blockerReason: null,
+      posted: true,
+    }),
+    runRetroFn: async (args) => {
+      retroArgs = args;
+      return { posted: true, compact: false, scorecard: {}, body: '' };
+    },
+    runFinalizeFn: async () => ({
+      epicId: 42,
+      ffOk: true,
+      pushed: true,
+      prUrl: 'https://x/pull/1',
+      postedHandoff: true,
+    }),
+  });
+
+  assert.ok(retroArgs, 'expected runRetroFn to be invoked');
+  assert.equal(
+    retroArgs.manualInterventions,
+    2,
+    'expected the close-tail to forward the checkpoint count to runRetro',
+  );
+});


### PR DESCRIPTION
Closes #2289

_Auto-opened by `/single-story-deliver`._