### PR TITLE
Windows pre-push: `lint-baseline.js check` ignores agentrc override and crashes on default (#2750)

### DIFF
--- a/.agents/scripts/lint-baseline.js
+++ b/.agents/scripts/lint-baseline.js
@@ -31,6 +31,36 @@ const PROJECT_ROOT = path.resolve(__dirname, '../..');
  */
 const EXECUTION_MAX_BUFFER = 10485760;
 
+/**
+ * Allowlist of command names that resolve via shell-launcher shims on
+ * Windows (`.cmd` / `.bat`). Node's `spawnSync({ shell: false })` cannot
+ * execute `.cmd` files (post CVE-2024-27980), so commands beginning with
+ * one of these names are invoked through the platform shell. Restricting
+ * `shell: true` to this fixed set keeps the command-injection surface
+ * minimal while making the default `npx eslint …` invocation portable.
+ */
+const SHIM_LAUNCHERS = new Set(['npx', 'npm', 'pnpm', 'pnpx', 'yarn']);
+
+/**
+ * Decide how `spawnSync` should be invoked for `cmdConfig`. Returns the
+ * full argument tuple — exported for unit testing the shim-detection
+ * logic without a real process spawn.
+ *
+ * @param {string} cmdConfig — operator-configured command string.
+ * @returns {{ shell: boolean, command: string, args: string[] }}
+ */
+export function pickSpawnShape(cmdConfig) {
+  const parsedArgs = parseArgsStringToArgv(cmdConfig);
+  if (parsedArgs.length === 0) {
+    return { shell: false, command: '', args: [] };
+  }
+  const head = parsedArgs[0];
+  if (SHIM_LAUNCHERS.has(head)) {
+    return { shell: true, command: cmdConfig, args: [] };
+  }
+  return { shell: false, command: head, args: parsedArgs.slice(1) };
+}
+
 // Shared core: extract the JSON-array tail from shell output, then tally
 // errors/warnings. `detailed=true` also returns per-file counts + rule
 // histogram (used by `diff` + `captureBaseline` to attribute regressions).
@@ -94,20 +124,19 @@ function runLintShared(
   gateModeOpts,
   detailed,
 ) {
-  const parsedArgs = parseArgsStringToArgv(cmdConfig);
-  if (parsedArgs.length === 0) {
+  const shape = pickSpawnShape(cmdConfig);
+  if (shape.command === '') {
     Logger.warn(`⚠️ [lint-baseline] Empty command configuration provided.`);
     return detailed
       ? { errorCount: 0, warningCount: 0, byFile: {} }
       : { errorCount: 0, warningCount: 0 };
   }
-  const cmd = parsedArgs.shift();
-  const result = spawnSync(cmd, parsedArgs, {
+  const result = spawnSync(shape.command, shape.args, {
     cwd: PROJECT_ROOT,
     encoding: 'utf-8',
     timeout: executionTimeoutMs,
     maxBuffer: executionMaxBuffer,
-    shell: false,
+    shell: shape.shell,
   });
   try {
     return parseLintShared(result.stdout.trim(), detailed);
@@ -425,9 +454,7 @@ export async function runLintBaselineCli(values, deps = {}) {
   }
 
   const cfg = deps.resolveConfig ? deps.resolveConfig() : resolveConfig();
-  const cmdConfig = getCommands({
-    agentSettings: cfg.agentSettings,
-  }).lintBaseline;
+  const cmdConfig = getCommands(cfg).lintBaseline;
   const baselinePathRel = getBaselines({ agentSettings: cfg.agentSettings })
     .lint.path;
   const projectRoot = deps.projectRoot ?? PROJECT_ROOT;

--- a/tests/lint-baseline-spawn-shape.test.js
+++ b/tests/lint-baseline-spawn-shape.test.js
@@ -1,0 +1,131 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import {
+  pickSpawnShape,
+  runLintBaselineCli,
+} from '../.agents/scripts/lint-baseline.js';
+
+/**
+ * Story #2750 — Windows pre-push: `lint-baseline.js check` ignored the
+ * `.agentrc.json` override and crashed on the default `npx eslint`
+ * because `spawnSync({ shell: false })` cannot resolve Windows `.cmd`
+ * shims. These tests pin both regressions closed:
+ *
+ *   1. `pickSpawnShape` enables `shell: true` for shim launchers
+ *      (`npx`, `npm`, `pnpm`, `pnpx`, `yarn`) and uses `shell: false`
+ *      with parsed argv for everything else.
+ *   2. `runLintBaselineCli` reads `project.commands.lintBaseline` from
+ *      the resolved config (Bug 1: the previous call site passed
+ *      `{ agentSettings }` and `getCommands` reads `project.commands`,
+ *      so every operator override was silently dropped to defaults).
+ */
+
+/* --------------------------------------------------------------------- */
+/* Bug 2 — shim-launcher spawn shape                                     */
+/* --------------------------------------------------------------------- */
+
+test('pickSpawnShape — npx commands route through shell:true with full string', () => {
+  const shape = pickSpawnShape('npx eslint . --format json');
+  assert.equal(shape.shell, true);
+  assert.equal(shape.command, 'npx eslint . --format json');
+  assert.deepEqual(shape.args, []);
+});
+
+test('pickSpawnShape — npm/pnpm/pnpx/yarn are all treated as shim launchers', () => {
+  for (const head of ['npm', 'pnpm', 'pnpx', 'yarn']) {
+    const shape = pickSpawnShape(`${head} run lint`);
+    assert.equal(shape.shell, true, `${head} should use shell:true`);
+    assert.equal(shape.command, `${head} run lint`);
+    assert.deepEqual(shape.args, []);
+  }
+});
+
+test('pickSpawnShape — node and other bare binaries use shell:false with parsed argv', () => {
+  const shape = pickSpawnShape('node scripts/lint.js --format json');
+  assert.equal(shape.shell, false);
+  assert.equal(shape.command, 'node');
+  assert.deepEqual(shape.args, ['scripts/lint.js', '--format', 'json']);
+});
+
+test('pickSpawnShape — empty string returns the empty-command sentinel', () => {
+  const shape = pickSpawnShape('');
+  assert.equal(shape.shell, false);
+  assert.equal(shape.command, '');
+  assert.deepEqual(shape.args, []);
+});
+
+test('pickSpawnShape — shim head with quoted args preserves quoting via shell', () => {
+  const shape = pickSpawnShape('npx eslint "src/foo bar.js" --format json');
+  assert.equal(shape.shell, true);
+  // Whole string is handed to the shell — no argv parsing on this path.
+  assert.equal(shape.command, 'npx eslint "src/foo bar.js" --format json');
+});
+
+/* --------------------------------------------------------------------- */
+/* Bug 1 — runLintBaselineCli honors project.commands.lintBaseline       */
+/* --------------------------------------------------------------------- */
+
+function fakeRunners(captured) {
+  // The runner only needs to record cmdConfig and return a non-degraded
+  // envelope — we are testing the config-resolution path, not the
+  // ESLint invocation.
+  const sink = (cmdConfig) => {
+    captured.push(cmdConfig);
+    return { errorCount: 0, warningCount: 0 };
+  };
+  return { capture: sink, check: sink, diff: sink };
+}
+
+test('runLintBaselineCli — operator override on project.commands.lintBaseline is honored', async () => {
+  const captured = [];
+  const result = await runLintBaselineCli(
+    { mode: 'check', gateModeArgv: [] },
+    {
+      resolveConfig: () => ({
+        project: {
+          commands: { lintBaseline: 'node scripts/custom-lint.mjs' },
+          baselines: { lint: { path: 'baselines/lint.json' } },
+        },
+        agentSettings: {},
+      }),
+      runners: fakeRunners(captured),
+      projectRoot: '/tmp',
+    },
+  );
+  assert.equal(result.exitCode, 0);
+  assert.equal(captured.length, 1);
+  assert.equal(captured[0], 'node scripts/custom-lint.mjs');
+});
+
+test('runLintBaselineCli — falls back to framework default when override is absent', async () => {
+  const captured = [];
+  await runLintBaselineCli(
+    { mode: 'check', gateModeArgv: [] },
+    {
+      resolveConfig: () => ({
+        project: {
+          commands: {},
+          baselines: { lint: { path: 'baselines/lint.json' } },
+        },
+        agentSettings: {},
+      }),
+      runners: fakeRunners(captured),
+      projectRoot: '/tmp',
+    },
+  );
+  assert.equal(captured.length, 1);
+  // The framework default — sourced from COMMANDS_DEFAULTS.lintBaseline.
+  assert.equal(captured[0], 'npx eslint . --format json');
+});
+
+test('runLintBaselineCli — validation-error when mode is unknown', async () => {
+  const result = await runLintBaselineCli(
+    { mode: 'banana', gateModeArgv: [] },
+    {
+      resolveConfig: () => ({ project: {}, agentSettings: {} }),
+      runners: fakeRunners([]),
+    },
+  );
+  assert.equal(result.exitCode, 1);
+  assert.equal(result.result.kind, 'validation-error');
+});


### PR DESCRIPTION
Closes #2750

_Auto-opened by `/single-story-deliver`._