### PR TITLE
fix(single-story): fast-forward local main after deliver

### DIFF
--- a/.agents/scripts/single-story-init.js
+++ b/.agents/scripts/single-story-init.js
@@ -62,6 +62,10 @@ import { Logger } from './lib/Logger.js';
 import { TYPE_LABELS } from './lib/label-constants.js';
 import { setActiveStoryEnv } from './lib/observability/active-story-env.js';
 import {
+  executeFastForward,
+  planFastForward,
+} from './lib/orchestration/git-cleanup/phases/fast-forward.js';
+import {
   STATE_LABELS,
   transitionTicketState,
   upsertStructuredComment,
@@ -256,6 +260,39 @@ export async function runSingleStoryInit({
       if (r.status !== 0) {
         throw new Error(
           `Failed to fetch base branch ${baseBranch}: ${r.stderr || '(no stderr)'}`,
+        );
+      }
+    } else {
+      // `git fetch origin` updates remote-tracking refs only; local
+      // `main` stays at the pre-merge tip until fast-forwarded. Use the
+      // same helper as `/git-cleanup --fast-forward-main` (checkout base +
+      // `merge --ff-only`) so new `story-*` branches seed from origin's
+      // tip when the main checkout is clean (Story #2744).
+      const ffPlan = planFastForward({ cwd, baseBranch });
+      const ff = executeFastForward({
+        cwd,
+        baseBranch,
+        plan: ffPlan,
+        logger: {
+          info: (m) => progress('GIT', m.replace(/^\[git-cleanup\]\s*/, '')),
+          warn: (m) =>
+            progress('GIT', `⚠️ ${m.replace(/^\[git-cleanup\]\s*/, '')}`),
+        },
+      });
+      if (ff.applied) {
+        progress(
+          'GIT',
+          `Fast-forwarded local ${baseBranch} by ${ff.behind} commit(s).`,
+        );
+      } else if (ff.reason === 'not-fast-forward') {
+        progress(
+          'GIT',
+          `⚠️ local ${baseBranch} is not a fast-forward behind origin/${baseBranch}; seeding from local tip.`,
+        );
+      } else if (ff.reason === 'dirty-tree') {
+        progress(
+          'GIT',
+          `⚠️ working tree dirty; skipped fast-forward of ${baseBranch}.`,
         );
       }
     }

--- a/.agents/workflows/single-story-deliver.md
+++ b/.agents/workflows/single-story-deliver.md
@@ -346,24 +346,41 @@ invocation, but that's next-run cleanup, not end-of-run cleanup. Stale
 local refs accumulate between sessions, clutter `git branch`, and shadow
 the lessons the sweep is meant to surface.
 
-After Step 5 confirms `state: "MERGED"`, prune the local ref and
-tracking refs:
+**Why local `main` goes stale:** `single-story-init.js` seeds new
+`story-<id>` branches from the **local** `baseBranch` ref (default
+`main`). Auto-merge updates **`origin/main`** on GitHub; nothing in
+close or the old Step 6 command updated **local `main`**. The next init
+then forked from a tip six merges behind until you manually pulled.
+`single-story-init` also attempts the same fast-forward after `git fetch`
+when the main checkout is clean (defense in depth if Step 6 was skipped).
+Step 6 must still run `--fast-forward-main` so local `main` is current
+before the next session — init may skip when the tree is dirty or the
+operator is mid-checkout on another branch.
+
+After Step 5 confirms `state: "MERGED"`, prune the story ref **and**
+fast-forward local `main` (or `project.baseBranch`):
 
 ```bash
 node .agents/scripts/git-cleanup.js \
   --execute \
   --remote \
   --yes \
+  --fast-forward-main \
   --branches \
   --include "story-<storyId>"
 ```
 
 What this does:
 
-- **`--branches`** narrows the run to the merged-branch reap phase
-  (skips `--fast-forward-main`, `--prune-remotes`, `--stashes`).
-- **`--include "story-<storyId>"`** scopes the sweep to this Story's
-  ref only — sibling stories in flight are untouched.
+- **`--fast-forward-main`** fetches `origin/<baseBranch>` and
+  `git merge --ff-only` on the main checkout when the tree is clean and
+  the local base is strictly behind remote. Skipped when already current,
+  dirty, or diverged (see `/git-cleanup`).
+- **`--branches`** reaps the merged `story-<storyId>` ref (worktree,
+  local branch, stale `origin/` tracking ref). Does not run
+  `--prune-remotes` or `--stashes` unless you add those flags.
+- **`--include "story-<storyId>"`** scopes the branch reap to this
+  Story's ref only — sibling stories in flight are untouched.
 - **`--execute --remote --yes`** actually deletes the local ref, prunes
   the matching `origin/` tracking ref, and runs non-interactively.
 

--- a/tests/scripts/git-cleanup-pipeline.test.js
+++ b/tests/scripts/git-cleanup-pipeline.test.js
@@ -85,6 +85,19 @@ describe('git-cleanup pipeline — parseCleanupArgs (Story #2466)', () => {
     assert.equal(opts.phases.stashes, false);
   });
 
+  it('Step 6 may combine --fast-forward-main with --branches', () => {
+    const opts = parseCleanupArgs([
+      '--fast-forward-main',
+      '--branches',
+      '--include',
+      'story-99',
+    ]);
+    assert.equal(opts.phases.fastForwardMain, true);
+    assert.equal(opts.phases.branches, true);
+    assert.equal(opts.phases.pruneRemotes, false);
+    assert.deepEqual(opts.include, ['story-99']);
+  });
+
   it('--execute and --remote propagate; --dry-run wins over --execute', () => {
     const a = parseCleanupArgs(['--execute', '--remote']);
     assert.equal(a.execute, true);


### PR DESCRIPTION
## Summary

- **Root cause:** Step 6 of `/single-story-deliver` ran `git-cleanup` with `--branches` only, which explicitly skips `--fast-forward-main`. Auto-merge updates `origin/main` on GitHub but local `main` stayed at the pre-deliver tip; the next `single-story-init` seeded `story-*` from that stale ref (`git branch story-N main`).
- **Step 6:** Add `--fast-forward-main` to the required cleanup command (documented in `.agents/workflows/single-story-deliver.md`).
- **Init defense:** After `git fetch`, `single-story-init.js` calls the same `planFastForward` / `executeFastForward` helpers when the main checkout is clean.

Follow-up to #2751 / #2744.

## Test plan

- [x] `node --test tests/scripts/git-cleanup-pipeline.test.js` (combined flags)
- [ ] CI Validate and Test