### PR TITLE
feat(orchestration): record model attribution as structured comments on tasks + rollup (#2813)

### DIFF
--- a/.agents/schemas/model-attribution.schema.json
+++ b/.agents/schemas/model-attribution.schema.json
@@ -1,0 +1,49 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://github.com/dsj1984/mandrel/blob/main/.agents/schemas/model-attribution.schema.json",
+  "title": "ModelAttribution",
+  "description": "Payload of the <!-- structured:model-attribution --> comment upserted onto a Task ticket at the moment it transitions to agent::executing (Story #2813). One entry per Task. Story- and Epic-level breakdowns are derived at query time from the child Tasks' attribution comments — there is no Story/Epic-scope emission.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["kind", "ticketId", "model", "source", "recordedAt"],
+  "properties": {
+    "kind": { "type": "string", "const": "model-attribution" },
+    "ticketId": {
+      "type": "integer",
+      "minimum": 1,
+      "description": "GitHub Issue number of the Task this attribution is recorded on."
+    },
+    "model": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id"],
+      "properties": {
+        "id": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Canonical model identifier (e.g. 'claude-opus-4-7', 'claude-sonnet-4-6'), or the sentinel 'unknown' when neither SDK metadata nor a runtime env var supplied an identity."
+        },
+        "family": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Coarse model family label for rollup grouping (e.g. 'Opus', 'Sonnet', 'Haiku'). Optional; derived from the id when present."
+        }
+      }
+    },
+    "source": {
+      "type": "string",
+      "enum": ["sdk-metadata", "env", "unknown"],
+      "description": "Provenance of the model identification, in fallback order: 'sdk-metadata' (resolved from the SDK response), 'env' (resolved from a runtime env var), 'unknown' (neither was available)."
+    },
+    "recordedAt": {
+      "type": "string",
+      "format": "date-time",
+      "description": "ISO-8601 timestamp at which the attribution was recorded."
+    },
+    "sdkMetadata": {
+      "type": "object",
+      "description": "Opaque pass-through fields lifted from the SDK response metadata when available (e.g. response id, usage hints). Never required; never relied upon by the rollup helper.",
+      "additionalProperties": true
+    }
+  }
+}

--- a/.agents/scripts/lib/orchestration/model-attribution.js
+++ b/.agents/scripts/lib/orchestration/model-attribution.js
@@ -1,0 +1,391 @@
+/**
+ * model-attribution.js — Task-scoped model attribution comments + rollup
+ * (Story #2813).
+ *
+ * Records which Claude model executed each Task as a structured comment on
+ * the Task ticket. Story- and Epic-level mixes are computed at query time
+ * by walking the child Tasks' comments — no Story/Epic-scope emission is
+ * written.
+ *
+ * Surface:
+ *
+ *   - {@link resolveModelIdentity} — pure resolver that picks an identity
+ *     from the fallback chain (SDK metadata → env var → 'unknown'
+ *     sentinel) and tags the source. Pure: no IO, no Date.now().
+ *   - {@link buildModelAttributionPayload} — shape the canonical payload
+ *     from a resolved identity + ticketId + timestamp.
+ *   - {@link validateModelAttributionPayload} — hand-rolled validator
+ *     matching `.agents/schemas/model-attribution.schema.json`. Returns
+ *     `{ ok: true }` or `{ ok: false, errors: string[] }`.
+ *   - {@link renderModelAttributionBody} — markdown body + fenced JSON
+ *     block (same fence convention as the other structured comments in
+ *     this repo so the shared `parseFencedJsonComment` can read it back).
+ *   - {@link emitModelAttribution} — idempotent upsert against a Task
+ *     ticket. Throws on validator failure (no comment written).
+ *   - {@link parseModelAttributionComment} — readback helper for the
+ *     rollup walker; returns `null` on missing/malformed payloads.
+ *   - {@link rollupModelAttribution} — given a Story or Epic ticket id,
+ *     walks `getSubTickets`, collects attribution comments, returns
+ *     `{ totalTasks, byModel: {...}, missing: N }`.
+ */
+
+import { parseFencedJsonComment } from './structured-comment-parser.js';
+import { findStructuredComment, upsertStructuredComment } from './ticketing.js';
+
+export const MODEL_ATTRIBUTION_TYPE = 'model-attribution';
+
+/**
+ * Sentinel returned by {@link resolveModelIdentity} when neither the SDK
+ * metadata nor the runtime env var supplied a model id. Exported so tests
+ * and downstream consumers can compare without re-spelling the literal.
+ */
+export const UNKNOWN_MODEL_ID = 'unknown';
+
+/**
+ * Env vars consulted as the second-priority resolver source. Listed in
+ * priority order — the first one set wins.
+ */
+const ENV_VAR_CANDIDATES = Object.freeze(['CLAUDE_MODEL', 'ANTHROPIC_MODEL']);
+
+/**
+ * Derive the coarse family label from a canonical model id. Used for the
+ * rollup-friendly `family` field. Returns `null` when the id does not
+ * match a recognised family pattern (the rollup helper falls back to the
+ * full id in that case so unknown models still aggregate distinctly).
+ *
+ * Recognises Anthropic Claude families: Opus, Sonnet, Haiku.
+ *
+ * @param {string} id
+ * @returns {string | null}
+ */
+export function deriveFamily(id) {
+  if (typeof id !== 'string') return null;
+  const lower = id.toLowerCase();
+  if (lower.includes('opus')) return 'Opus';
+  if (lower.includes('sonnet')) return 'Sonnet';
+  if (lower.includes('haiku')) return 'Haiku';
+  return null;
+}
+
+/**
+ * Resolve the active model identity using the documented fallback chain:
+ *
+ *   1. `sdkMetadata.modelId` (or `.model`) when present and non-empty.
+ *   2. `CLAUDE_MODEL` / `ANTHROPIC_MODEL` env vars (first non-empty wins).
+ *   3. The `UNKNOWN_MODEL_ID` sentinel.
+ *
+ * Pure: accepts the env bag as an injectable argument so tests can pin
+ * the resolver without mutating `process.env`. Production callers default
+ * to `process.env`.
+ *
+ * @param {object} [opts]
+ * @param {object|null} [opts.sdkMetadata] — SDK response metadata.
+ * @param {Record<string, string|undefined>} [opts.env=process.env]
+ * @returns {{ id: string, family: string|null, source: 'sdk-metadata'|'env'|'unknown', sdkMetadata?: object }}
+ */
+export function resolveModelIdentity(opts = {}) {
+  const { sdkMetadata = null, env = process.env } = opts;
+
+  const sdkId =
+    sdkMetadata && typeof sdkMetadata === 'object'
+      ? (typeof sdkMetadata.modelId === 'string' && sdkMetadata.modelId) ||
+        (typeof sdkMetadata.model === 'string' && sdkMetadata.model) ||
+        null
+      : null;
+  if (sdkId) {
+    return {
+      id: sdkId,
+      family: deriveFamily(sdkId),
+      source: 'sdk-metadata',
+      sdkMetadata,
+    };
+  }
+
+  for (const name of ENV_VAR_CANDIDATES) {
+    const value = env?.[name];
+    if (typeof value === 'string' && value.length > 0) {
+      return {
+        id: value,
+        family: deriveFamily(value),
+        source: 'env',
+      };
+    }
+  }
+
+  return {
+    id: UNKNOWN_MODEL_ID,
+    family: null,
+    source: 'unknown',
+  };
+}
+
+/**
+ * Build the canonical payload object from a resolved identity. Separated
+ * from {@link emitModelAttribution} so callers (and tests) can shape the
+ * payload without triggering the upsert side-effect.
+ *
+ * @param {{
+ *   ticketId: number,
+ *   identity: ReturnType<typeof resolveModelIdentity>,
+ *   recordedAt?: string,
+ * }} args
+ * @returns {object}
+ */
+export function buildModelAttributionPayload(args) {
+  const { ticketId, identity, recordedAt } = args ?? {};
+  const payload = {
+    kind: MODEL_ATTRIBUTION_TYPE,
+    ticketId,
+    model: identity?.family
+      ? { id: identity.id, family: identity.family }
+      : { id: identity?.id },
+    source: identity?.source,
+    recordedAt: recordedAt ?? new Date().toISOString(),
+  };
+  if (identity?.sdkMetadata && typeof identity.sdkMetadata === 'object') {
+    payload.sdkMetadata = identity.sdkMetadata;
+  }
+  return payload;
+}
+
+const VALID_SOURCES = new Set(['sdk-metadata', 'env', 'unknown']);
+const ISO_8601_RE =
+  /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})$/;
+
+/**
+ * Hand-rolled validator matching
+ * `.agents/schemas/model-attribution.schema.json`. Returns
+ * `{ ok: true }` on success, `{ ok: false, errors: string[] }` on
+ * failure. The error strings are stable enough to assert against in
+ * tests.
+ *
+ * The codebase does not pull in `ajv` for runtime schema validation
+ * (signals + structured comments use hand-rolled shape guards — see
+ * `lib/signals/schema.js`). We follow the same pattern here so the
+ * schema file stays the documented SSOT and the validator is the
+ * runtime gate.
+ *
+ * @param {unknown} payload
+ * @returns {{ ok: true } | { ok: false, errors: string[] }}
+ */
+export function validateModelAttributionPayload(payload) {
+  const errors = [];
+  if (
+    payload === null ||
+    typeof payload !== 'object' ||
+    Array.isArray(payload)
+  ) {
+    return { ok: false, errors: ['payload must be a plain object'] };
+  }
+  if (payload.kind !== MODEL_ATTRIBUTION_TYPE) {
+    errors.push(`kind must be "${MODEL_ATTRIBUTION_TYPE}"`);
+  }
+  if (!Number.isInteger(payload.ticketId) || payload.ticketId <= 0) {
+    errors.push('ticketId must be a positive integer');
+  }
+  if (
+    !payload.model ||
+    typeof payload.model !== 'object' ||
+    Array.isArray(payload.model)
+  ) {
+    errors.push('model must be an object');
+  } else {
+    if (typeof payload.model.id !== 'string' || payload.model.id.length === 0) {
+      errors.push('model.id must be a non-empty string');
+    }
+    if (
+      payload.model.family !== undefined &&
+      (typeof payload.model.family !== 'string' ||
+        payload.model.family.length === 0)
+    ) {
+      errors.push('model.family, when present, must be a non-empty string');
+    }
+  }
+  if (
+    typeof payload.source !== 'string' ||
+    !VALID_SOURCES.has(payload.source)
+  ) {
+    errors.push(`source must be one of: ${[...VALID_SOURCES].join(', ')}`);
+  }
+  if (
+    typeof payload.recordedAt !== 'string' ||
+    !ISO_8601_RE.test(payload.recordedAt)
+  ) {
+    errors.push('recordedAt must be an ISO-8601 timestamp string');
+  }
+  if (
+    payload.sdkMetadata !== undefined &&
+    (payload.sdkMetadata === null ||
+      typeof payload.sdkMetadata !== 'object' ||
+      Array.isArray(payload.sdkMetadata))
+  ) {
+    errors.push('sdkMetadata, when present, must be an object');
+  }
+  return errors.length ? { ok: false, errors } : { ok: true };
+}
+
+/**
+ * Render the markdown body that gets upserted as the structured comment.
+ * Body is a one-line summary followed by the canonical payload inside a
+ * fenced ```json``` block so downstream readers can use the shared
+ * `parseFencedJsonComment` helper without bespoke parsing.
+ *
+ * @param {object} payload — already validated.
+ * @returns {string}
+ */
+export function renderModelAttributionBody(payload) {
+  const id = payload.model?.id ?? UNKNOWN_MODEL_ID;
+  const family = payload.model?.family ? ` (${payload.model.family})` : '';
+  const sourceLabel =
+    payload.source === 'sdk-metadata'
+      ? 'SDK metadata'
+      : payload.source === 'env'
+        ? 'env var'
+        : 'unknown source';
+  const header = `🤖 Model attribution: \`${id}\`${family} · via ${sourceLabel}`;
+  return [header, '', '```json', JSON.stringify(payload, null, 2), '```'].join(
+    '\n',
+  );
+}
+
+/**
+ * Emit (idempotently) the model-attribution comment onto a Task ticket.
+ * Validates the payload before any IO — a malformed payload throws and
+ * writes nothing to the provider.
+ *
+ * @param {{
+ *   provider: import('../ITicketingProvider.js').ITicketingProvider,
+ *   ticketId: number,
+ *   sdkMetadata?: object|null,
+ *   env?: Record<string, string|undefined>,
+ *   recordedAt?: string,
+ * }} args
+ * @returns {Promise<{ payload: object, body: string }>}
+ */
+export async function emitModelAttribution(args) {
+  const { provider, ticketId, sdkMetadata, env, recordedAt } = args ?? {};
+  if (!provider || typeof provider.postComment !== 'function') {
+    throw new TypeError(
+      'emitModelAttribution requires a provider with postComment',
+    );
+  }
+  if (!Number.isInteger(ticketId) || ticketId <= 0) {
+    throw new TypeError(
+      'emitModelAttribution requires a positive integer ticketId',
+    );
+  }
+  const identity = resolveModelIdentity({ sdkMetadata, env });
+  const payload = buildModelAttributionPayload({
+    ticketId,
+    identity,
+    recordedAt,
+  });
+  const result = validateModelAttributionPayload(payload);
+  if (!result.ok) {
+    throw new Error(
+      `model-attribution payload failed validation: ${result.errors.join('; ')}`,
+    );
+  }
+  const body = renderModelAttributionBody(payload);
+  await upsertStructuredComment(
+    provider,
+    ticketId,
+    MODEL_ATTRIBUTION_TYPE,
+    body,
+  );
+  return { payload, body };
+}
+
+/**
+ * Read back a model-attribution comment from a ticket. Returns the
+ * parsed payload, or `null` when the comment is missing or its payload
+ * fails validation (malformed payloads are treated as "no attribution"
+ * so a single corrupt comment does not poison the whole rollup).
+ *
+ * @param {{
+ *   provider: import('../ITicketingProvider.js').ITicketingProvider,
+ *   ticketId: number,
+ * }} args
+ * @returns {Promise<object|null>}
+ */
+export async function parseModelAttributionComment(args) {
+  const { provider, ticketId } = args ?? {};
+  const comment = await findStructuredComment(
+    provider,
+    ticketId,
+    MODEL_ATTRIBUTION_TYPE,
+  );
+  if (!comment) return null;
+  const parsed = parseFencedJsonComment(comment);
+  if (!parsed) return null;
+  const result = validateModelAttributionPayload(parsed);
+  return result.ok ? parsed : null;
+}
+
+/**
+ * Walk the immediate children of a Story or Epic, read each child's
+ * model-attribution comment (when present), and aggregate per-model
+ * counts. Tasks with no attribution comment are counted under
+ * `missing`.
+ *
+ * Rollup is keyed by `model.family` when present, otherwise by
+ * `model.id` so unknown families still aggregate distinctly. The
+ * envelope also exposes the per-id breakdown for callers that want a
+ * finer-grained view.
+ *
+ * @param {{
+ *   provider: import('../ITicketingProvider.js').ITicketingProvider,
+ *   parentId: number,
+ * }} args
+ * @returns {Promise<{
+ *   parentId: number,
+ *   totalTasks: number,
+ *   missing: number,
+ *   byModel: Record<string, number>,
+ *   byId: Record<string, number>,
+ * }>}
+ */
+export async function rollupModelAttribution(args) {
+  const { provider, parentId } = args ?? {};
+  if (!provider || typeof provider.getSubTickets !== 'function') {
+    throw new TypeError(
+      'rollupModelAttribution requires a provider with getSubTickets',
+    );
+  }
+  if (!Number.isInteger(parentId) || parentId <= 0) {
+    throw new TypeError(
+      'rollupModelAttribution requires a positive integer parentId',
+    );
+  }
+  const children = (await provider.getSubTickets(parentId)) ?? [];
+  const byModel = {};
+  const byId = {};
+  let missing = 0;
+  for (const child of children) {
+    const childId = Number(child?.id);
+    if (!Number.isInteger(childId) || childId <= 0) {
+      missing += 1;
+      continue;
+    }
+    const payload = await parseModelAttributionComment({
+      provider,
+      ticketId: childId,
+    });
+    if (!payload) {
+      missing += 1;
+      continue;
+    }
+    const familyKey =
+      payload.model?.family ?? payload.model?.id ?? UNKNOWN_MODEL_ID;
+    const idKey = payload.model?.id ?? UNKNOWN_MODEL_ID;
+    byModel[familyKey] = (byModel[familyKey] ?? 0) + 1;
+    byId[idKey] = (byId[idKey] ?? 0) + 1;
+  }
+  return {
+    parentId,
+    totalTasks: children.length,
+    missing,
+    byModel,
+    byId,
+  };
+}

--- a/.agents/scripts/lib/orchestration/ticketing/reads.js
+++ b/.agents/scripts/lib/orchestration/ticketing/reads.js
@@ -106,6 +106,16 @@ export const STRUCTURED_COMMENT_TYPES = Object.freeze([
   // invocation always failed with "Invalid structured-comment type". One
   // entry per Epic; re-runs replace prior content.
   'audit-results',
+  // Story #2813 — `story-task-progress.js` upserts a `model-attribution`
+  // comment on a Task ticket at the moment it transitions to
+  // `agent::executing`, recording which Claude model was actively
+  // executing the work. One entry per Task (upsert is idempotent across
+  // resume re-runs). Story- and Epic-level rollups are computed at query
+  // time by `rollupModelAttribution` in
+  // `lib/orchestration/model-attribution.js` — no Story/Epic-scope
+  // emissions are written. Schema:
+  // `.agents/schemas/model-attribution.schema.json`.
+  'model-attribution',
 ]);
 
 export const WAVE_TYPE_PATTERN = WAVE_MARKER_RE;

--- a/.agents/scripts/story-task-progress.js
+++ b/.agents/scripts/story-task-progress.js
@@ -72,6 +72,7 @@ import {
   STORY_RUN_PROGRESS_TYPE,
   upsertStoryRunProgress,
 } from './lib/orchestration/epic-runner/story-run-progress-writer.js';
+import { emitModelAttribution } from './lib/orchestration/model-attribution.js';
 import { parseFencedJsonComment } from './lib/orchestration/structured-comment-parser.js';
 import {
   findStructuredComment,
@@ -385,6 +386,18 @@ export async function runStoryTaskProgress(args) {
       notify: null,
       cascade: true,
     });
+    // Story #2813 — record which Claude model is executing this Task.
+    // Best-effort: a network or schema failure here must never block the
+    // transition itself. `emitModelAttribution` is idempotent (upsert),
+    // so a resume that re-enters this path with a different model will
+    // overwrite the prior attribution rather than duplicate it.
+    try {
+      await emitModelAttribution({ provider, ticketId: taskId });
+    } catch (err) {
+      Logger.warn(
+        `[story-task-progress] model-attribution emit failed for #${taskId}: ${err?.message ?? err}`,
+      );
+    }
   }
 
   // 2b. Per-Task close: when the Task transitions to `done` with a recorded

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,29 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+### Added — Story #2813: per-Task model-attribution structured comments + rollup
+
+Each Task ticket now receives a `model-attribution` structured comment when it
+transitions to `agent::executing`, recording which Claude model executed the
+work (resolved from SDK response metadata → `CLAUDE_MODEL`/`ANTHROPIC_MODEL`
+env vars → an `unknown` sentinel). Closes #2813.
+
+- **New structured-comment kind** `'model-attribution'` is registered in
+  `STRUCTURED_COMMENT_TYPES` and documented by
+  `.agents/schemas/model-attribution.schema.json`.
+- **Hand-rolled validator** at the upsert seam rejects malformed payloads
+  without writing to the provider, matching the pattern used by
+  `lib/signals/schema.js` and the existing structured-comment kinds.
+- **Per-Task emit** is wired into `story-task-progress.js` after the
+  `agent::executing` label flip — best-effort, never blocks the transition,
+  idempotent across resume re-runs.
+- **Rollup helper** `rollupModelAttribution({ provider, parentId })` walks
+  the Story's or Epic's immediate children, parses each child's attribution
+  comment, and returns `{ totalTasks, missing, byModel, byId }` so retros
+  can render the per-Epic model mix (e.g. "Opus 60% / Sonnet 40%") without
+  scraping external billing exports. No automatic Story/Epic emission —
+  rollup is query-time only.
+
 ### Removed — Epic #2586: retire `/audit-fan-out` workflow
 
 The broken parallel fan-out orchestrator `/audit-fan-out` is retired. Its

--- a/tests/lib/orchestration/model-attribution.test.js
+++ b/tests/lib/orchestration/model-attribution.test.js
@@ -1,0 +1,297 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  buildModelAttributionPayload,
+  deriveFamily,
+  emitModelAttribution,
+  MODEL_ATTRIBUTION_TYPE,
+  parseModelAttributionComment,
+  renderModelAttributionBody,
+  resolveModelIdentity,
+  rollupModelAttribution,
+  UNKNOWN_MODEL_ID,
+  validateModelAttributionPayload,
+} from '../../../.agents/scripts/lib/orchestration/model-attribution.js';
+import { structuredCommentMarker } from '../../../.agents/scripts/lib/orchestration/ticketing.js';
+
+function makeProvider(initialComments = [], subTicketsByParent = {}) {
+  const comments = [...initialComments];
+  let nextId = 1000;
+  return {
+    comments,
+    subTicketsByParent,
+    async postComment(ticketId, { type, body }) {
+      const id = nextId++;
+      comments.push({ id, ticketId, type, body });
+      return { commentId: id };
+    },
+    async getTicketComments(ticketId) {
+      return comments.filter((c) => c.ticketId === ticketId);
+    },
+    async deleteComment(id) {
+      const idx = comments.findIndex((c) => c.id === id);
+      if (idx >= 0) comments.splice(idx, 1);
+    },
+    async getSubTickets(parentId) {
+      return subTicketsByParent[parentId] ?? [];
+    },
+  };
+}
+
+test('deriveFamily: maps known Anthropic ids to coarse family labels', () => {
+  assert.equal(deriveFamily('claude-opus-4-7'), 'Opus');
+  assert.equal(deriveFamily('claude-sonnet-4-6'), 'Sonnet');
+  assert.equal(deriveFamily('claude-haiku-4-5-20251001'), 'Haiku');
+  assert.equal(deriveFamily('some-other-model'), null);
+  assert.equal(deriveFamily(null), null);
+});
+
+test('resolveModelIdentity: prefers SDK metadata over env over sentinel', () => {
+  const got = resolveModelIdentity({
+    sdkMetadata: { modelId: 'claude-opus-4-7', responseId: 'r1' },
+    env: { CLAUDE_MODEL: 'claude-sonnet-4-6' },
+  });
+  assert.equal(got.id, 'claude-opus-4-7');
+  assert.equal(got.family, 'Opus');
+  assert.equal(got.source, 'sdk-metadata');
+  assert.deepEqual(got.sdkMetadata, {
+    modelId: 'claude-opus-4-7',
+    responseId: 'r1',
+  });
+});
+
+test('resolveModelIdentity: falls back to env when SDK metadata is absent', () => {
+  const got = resolveModelIdentity({
+    sdkMetadata: null,
+    env: { CLAUDE_MODEL: 'claude-sonnet-4-6' },
+  });
+  assert.equal(got.id, 'claude-sonnet-4-6');
+  assert.equal(got.family, 'Sonnet');
+  assert.equal(got.source, 'env');
+  assert.equal(got.sdkMetadata, undefined);
+});
+
+test('resolveModelIdentity: ANTHROPIC_MODEL is consulted when CLAUDE_MODEL is empty', () => {
+  const got = resolveModelIdentity({
+    env: { CLAUDE_MODEL: '', ANTHROPIC_MODEL: 'claude-haiku-4-5' },
+  });
+  assert.equal(got.id, 'claude-haiku-4-5');
+  assert.equal(got.source, 'env');
+});
+
+test('resolveModelIdentity: returns unknown sentinel when no source is available', () => {
+  const got = resolveModelIdentity({ env: {} });
+  assert.equal(got.id, UNKNOWN_MODEL_ID);
+  assert.equal(got.family, null);
+  assert.equal(got.source, 'unknown');
+});
+
+test('validateModelAttributionPayload: accepts a well-formed payload', () => {
+  const payload = buildModelAttributionPayload({
+    ticketId: 42,
+    identity: resolveModelIdentity({
+      sdkMetadata: { modelId: 'claude-opus-4-7' },
+    }),
+    recordedAt: '2026-05-21T12:00:00.000Z',
+  });
+  assert.deepEqual(validateModelAttributionPayload(payload), { ok: true });
+});
+
+test('validateModelAttributionPayload: rejects malformed payloads with stable messages', () => {
+  const bad = validateModelAttributionPayload({
+    kind: 'wrong-kind',
+    ticketId: 0,
+    model: { id: '' },
+    source: 'magic',
+    recordedAt: 'yesterday',
+    sdkMetadata: 'not-an-object',
+  });
+  assert.equal(bad.ok, false);
+  const joined = bad.errors.join(' | ');
+  assert.match(joined, /kind must be "model-attribution"/);
+  assert.match(joined, /ticketId must be a positive integer/);
+  assert.match(joined, /model.id must be a non-empty string/);
+  assert.match(joined, /source must be one of/);
+  assert.match(joined, /recordedAt must be an ISO-8601 timestamp/);
+  assert.match(joined, /sdkMetadata, when present, must be an object/);
+});
+
+test('validateModelAttributionPayload: rejects non-object input', () => {
+  assert.equal(validateModelAttributionPayload(null).ok, false);
+  assert.equal(validateModelAttributionPayload([]).ok, false);
+  assert.equal(validateModelAttributionPayload('hi').ok, false);
+});
+
+test('renderModelAttributionBody: contains the header and a fenced JSON block', () => {
+  const payload = buildModelAttributionPayload({
+    ticketId: 7,
+    identity: {
+      id: 'claude-opus-4-7',
+      family: 'Opus',
+      source: 'sdk-metadata',
+    },
+    recordedAt: '2026-05-21T00:00:00.000Z',
+  });
+  const body = renderModelAttributionBody(payload);
+  assert.match(body, /Model attribution: `claude-opus-4-7`/);
+  assert.match(body, /\(Opus\)/);
+  assert.match(body, /via SDK metadata/);
+  assert.match(body, /```json[\s\S]*"kind": "model-attribution"[\s\S]*```/);
+});
+
+test('emitModelAttribution: writes one comment, validates payload, and is idempotent on resume', async () => {
+  const provider = makeProvider();
+  const first = await emitModelAttribution({
+    provider,
+    ticketId: 555,
+    sdkMetadata: { modelId: 'claude-opus-4-7' },
+  });
+  assert.equal(first.payload.kind, MODEL_ATTRIBUTION_TYPE);
+  assert.equal(first.payload.model.id, 'claude-opus-4-7');
+  assert.equal(provider.comments.length, 1);
+
+  // Resume: second emit replaces the first (upsert), not duplicates it.
+  await emitModelAttribution({
+    provider,
+    ticketId: 555,
+    sdkMetadata: { modelId: 'claude-sonnet-4-6' },
+  });
+  const attributions = provider.comments.filter(
+    (c) => c.ticketId === 555 && c.type === MODEL_ATTRIBUTION_TYPE,
+  );
+  assert.equal(attributions.length, 1, 'upsert must collapse to one comment');
+  assert.match(attributions[0].body, /claude-sonnet-4-6/);
+});
+
+test('emitModelAttribution: rejects bad inputs without writing', async () => {
+  const provider = makeProvider();
+  await assert.rejects(
+    emitModelAttribution({ provider, ticketId: 0 }),
+    /positive integer ticketId/,
+  );
+  await assert.rejects(
+    emitModelAttribution({ provider: {}, ticketId: 1 }),
+    /provider with postComment/,
+  );
+  assert.equal(provider.comments.length, 0);
+});
+
+test('parseModelAttributionComment: returns null when no comment is present', async () => {
+  const provider = makeProvider();
+  const got = await parseModelAttributionComment({ provider, ticketId: 9 });
+  assert.equal(got, null);
+});
+
+test('parseModelAttributionComment: returns null for a malformed payload (does not poison rollup)', async () => {
+  const marker = structuredCommentMarker(MODEL_ATTRIBUTION_TYPE);
+  const provider = makeProvider([
+    {
+      id: 1,
+      ticketId: 9,
+      type: 'comment',
+      body: `${marker}\n\n\`\`\`json\n${JSON.stringify({ kind: 'wrong' })}\n\`\`\``,
+    },
+  ]);
+  const got = await parseModelAttributionComment({ provider, ticketId: 9 });
+  assert.equal(got, null);
+});
+
+test('rollupModelAttribution: aggregates per-family counts and surfaces missing attributions', async () => {
+  const marker = structuredCommentMarker(MODEL_ATTRIBUTION_TYPE);
+  const makeBody = (ticketId, id, family) =>
+    `${marker}\n\n\`\`\`json\n${JSON.stringify({
+      kind: MODEL_ATTRIBUTION_TYPE,
+      ticketId,
+      model: { id, family },
+      source: 'env',
+      recordedAt: '2026-05-21T00:00:00.000Z',
+    })}\n\`\`\``;
+  const provider = makeProvider(
+    [
+      {
+        id: 1,
+        ticketId: 11,
+        type: 'c',
+        body: makeBody(11, 'claude-opus-4-7', 'Opus'),
+      },
+      {
+        id: 2,
+        ticketId: 12,
+        type: 'c',
+        body: makeBody(12, 'claude-opus-4-7', 'Opus'),
+      },
+      {
+        id: 3,
+        ticketId: 13,
+        type: 'c',
+        body: makeBody(13, 'claude-sonnet-4-6', 'Sonnet'),
+      },
+      // Task #14 deliberately has no attribution comment — counts under `missing`.
+    ],
+    {
+      999: [
+        { id: 11, title: 't1' },
+        { id: 12, title: 't2' },
+        { id: 13, title: 't3' },
+        { id: 14, title: 't4' },
+      ],
+    },
+  );
+
+  const got = await rollupModelAttribution({ provider, parentId: 999 });
+  assert.equal(got.parentId, 999);
+  assert.equal(got.totalTasks, 4);
+  assert.equal(got.missing, 1);
+  assert.deepEqual(got.byModel, { Opus: 2, Sonnet: 1 });
+  assert.deepEqual(got.byId, {
+    'claude-opus-4-7': 2,
+    'claude-sonnet-4-6': 1,
+  });
+});
+
+test('rollupModelAttribution: returns zeroed envelope for a parent with no children', async () => {
+  const provider = makeProvider([], { 42: [] });
+  const got = await rollupModelAttribution({ provider, parentId: 42 });
+  assert.deepEqual(got, {
+    parentId: 42,
+    totalTasks: 0,
+    missing: 0,
+    byModel: {},
+    byId: {},
+  });
+});
+
+test('rollupModelAttribution: rejects bad inputs', async () => {
+  await assert.rejects(
+    rollupModelAttribution({ provider: {}, parentId: 1 }),
+    /provider with getSubTickets/,
+  );
+  await assert.rejects(
+    rollupModelAttribution({ provider: makeProvider(), parentId: 0 }),
+    /positive integer parentId/,
+  );
+});
+
+test('rollupModelAttribution: end-to-end emit → readback → rollup against the same provider', async () => {
+  const provider = makeProvider([], {
+    700: [
+      { id: 701, title: 'a' },
+      { id: 702, title: 'b' },
+    ],
+  });
+  await emitModelAttribution({
+    provider,
+    ticketId: 701,
+    sdkMetadata: { modelId: 'claude-opus-4-7' },
+  });
+  await emitModelAttribution({
+    provider,
+    ticketId: 702,
+    env: { CLAUDE_MODEL: 'claude-sonnet-4-6' },
+  });
+  const rollup = await rollupModelAttribution({ provider, parentId: 700 });
+  assert.equal(rollup.totalTasks, 2);
+  assert.equal(rollup.missing, 0);
+  assert.deepEqual(rollup.byModel, { Opus: 1, Sonnet: 1 });
+});

--- a/tests/story-deliver/story-task-progress.test.js
+++ b/tests/story-deliver/story-task-progress.test.js
@@ -434,6 +434,78 @@ test('runStoryTaskProgress: state=executing returns skip:true when prior run clo
   assert.equal(provider.updates.length, 0);
 });
 
+test('runStoryTaskProgress: state=executing emits a model-attribution comment on the Task (Story #2813)', async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'story-task-progress-'));
+  const cachePath = path.join(dir, 'story-50-progress.json');
+  writeCache(cachePath, {
+    storyId: 50,
+    branch: 'story-50',
+    tasks: [{ id: 501, title: 'attr-target', state: 'pending' }],
+  });
+  const provider = makeProvider([]);
+  provider.tickets[501] = { id: 501, labels: ['agent::ready'], state: 'open' };
+  const priorEnv = process.env.CLAUDE_MODEL;
+  process.env.CLAUDE_MODEL = 'claude-opus-4-7';
+  try {
+    await runStoryTaskProgress({
+      storyId: 50,
+      taskId: 501,
+      state: 'executing',
+      provider,
+      cachePath,
+    });
+  } finally {
+    if (priorEnv === undefined) delete process.env.CLAUDE_MODEL;
+    else process.env.CLAUDE_MODEL = priorEnv;
+  }
+  const attribution = provider.comments.find(
+    (c) => c.ticketId === 501 && c.type === 'model-attribution',
+  );
+  assert.ok(attribution, 'expected one model-attribution comment on Task #501');
+  assert.match(attribution.body, /claude-opus-4-7/);
+});
+
+test('runStoryTaskProgress: state=executing tolerates a model-attribution emit failure', async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'story-task-progress-'));
+  const cachePath = path.join(dir, 'story-51-progress.json');
+  writeCache(cachePath, {
+    storyId: 51,
+    branch: 'story-51',
+    tasks: [{ id: 511, title: 'attr-fail', state: 'pending' }],
+  });
+  const provider = makeProvider([]);
+  provider.tickets[511] = { id: 511, labels: ['agent::ready'], state: 'open' };
+  // First postComment (the model-attribution upsert) throws; subsequent
+  // story-run-progress upsert must still succeed.
+  let postCalls = 0;
+  const originalPost = provider.postComment.bind(provider);
+  provider.postComment = async function postCommentFailing(ticketId, args) {
+    postCalls++;
+    if (postCalls === 1 && args.type === 'model-attribution') {
+      throw new Error('simulated network failure');
+    }
+    return originalPost(ticketId, args);
+  };
+
+  const result = await runStoryTaskProgress({
+    storyId: 51,
+    taskId: 511,
+    state: 'executing',
+    provider,
+    cachePath,
+  });
+  assert.equal(result.taskState, 'executing');
+  // Label transition must have landed despite the emit failure.
+  assert.ok(provider.tickets[511].labels.includes('agent::executing'));
+  // story-run-progress comment must have been written.
+  assert.ok(
+    provider.comments.some(
+      (c) => c.ticketId === 51 && c.type === 'story-run-progress',
+    ),
+    'story-run-progress upsert must still succeed after attribution failure',
+  );
+});
+
 test('runStoryTaskProgress: state=executing does NOT skip when prior commit is missing from HEAD (resume after branch loss)', async () => {
   const repo = makeTmpGitRepo();
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'story-task-progress-'));


### PR DESCRIPTION
Closes #2813

_Auto-opened by `/single-story-deliver`._