### PR TITLE
fix(orchestration): own Projects v2 Status column — audit conflicting workflows + post-merge re-sync (#2845)

### DIFF
--- a/.agents/scripts/agents-bootstrap-github.js
+++ b/.agents/scripts/agents-bootstrap-github.js
@@ -25,6 +25,12 @@ import {
 } from './lib/bootstrap/ci-workflow-template.js';
 import { confirm as defaultHitlConfirm } from './lib/bootstrap/hitl-confirm.js';
 import { applyMergeMethods } from './lib/bootstrap/merge-methods.js';
+import {
+  auditProjectWorkflows,
+  formatAuditSummary,
+  reapConflictingWorkflows,
+  resolveProjectIdByNumber,
+} from './lib/bootstrap/workflow-audit.js';
 import { runAsCli } from './lib/cli-utils.js';
 import {
   GhAuthError,
@@ -360,6 +366,79 @@ async function ensureViews(provider, log) {
   }
 }
 
+/**
+ * Audit the project's built-in workflows and, when explicitly opted-in
+ * via `--reap-conflicting-workflows`, delete the ones that race against
+ * the orchestrator's `ColumnSync` writes. Default behaviour is
+ * advisory: warn loudly with the operator-driven remediation hint, do
+ * not mutate. Story #2845.
+ *
+ * Returns a structured envelope the bootstrap summary renders, even
+ * when the audit was skipped (no projectId) so callers don't need a
+ * separate "did this run" guard.
+ *
+ * @param {object} provider
+ * @param {number} projectNumber
+ * @param {boolean} reap
+ * @param {(line: string) => void} log
+ */
+async function auditAndOptionallyReapWorkflows(
+  provider,
+  projectNumber,
+  reap,
+  log,
+) {
+  let projectId = null;
+  try {
+    projectId = await resolveProjectIdByNumber({ provider, projectNumber });
+  } catch (err) {
+    log(
+      `[bootstrap] Workflow audit: could not resolve project id — ${err.message}.`,
+    );
+    return { skipped: true, reason: 'project-id-unresolved' };
+  }
+  if (!projectId) {
+    log(
+      `[bootstrap] Workflow audit: project #${projectNumber} not visible to viewer — skipping.`,
+    );
+    return { skipped: true, reason: 'project-not-visible' };
+  }
+  let audit;
+  try {
+    audit = await auditProjectWorkflows({ provider, projectId });
+  } catch (err) {
+    log(`[bootstrap] Workflow audit failed: ${err.message} — skipping.`);
+    return { skipped: true, reason: 'audit-failed', error: err.message };
+  }
+  log(`[bootstrap] Workflow audit — ${formatAuditSummary(audit)}.`);
+  if (audit.conflicting.length === 0) {
+    return { audit, reaped: [], action: 'no-conflicts' };
+  }
+  const names = audit.conflicting.map((w) => w.name).join(', ');
+  if (!reap) {
+    log(
+      `[bootstrap] ⚠️ Conflicting workflows enabled: ${names}. ` +
+        `These race against the orchestrator's ColumnSync writes and ` +
+        `typically leave closed Stories stuck at "In Progress" on the ` +
+        `board (see Story #2813 for the reproduction). Remediation: ` +
+        `(a) re-run with --reap-conflicting-workflows to delete them, ` +
+        `or (b) toggle them off in the GitHub UI under ` +
+        `Project → Workflows. The orchestrator's post-merge ` +
+        `resync-status-column.js CLI defends against both unless you ` +
+        `also disable that step.`,
+    );
+    return { audit, reaped: [], action: 'warn-only' };
+  }
+  log(
+    `[bootstrap] Reaping ${audit.conflicting.length} conflicting workflow(s): ${names}...`,
+  );
+  const { reaped } = await reapConflictingWorkflows({ provider, audit });
+  log(
+    `[bootstrap] ✅ Deleted ${reaped.length} workflow(s): ${reaped.map((r) => r.name).join(', ')}.`,
+  );
+  return { audit, reaped, action: 'reaped' };
+}
+
 async function ensureProjectFields(provider, project, log) {
   log(
     `[bootstrap] Ensuring ${PROJECT_FIELD_DEFS.length} project fields on project #${project.projectNumber}...`,
@@ -514,6 +593,22 @@ export async function runBootstrap(orchestration, opts = {}) {
     log('[bootstrap] No active project — skipping legacy project-field setup.');
   }
 
+  // Story #2845 — audit project workflows for the ones that race against
+  // the orchestrator's ColumnSync writes (notably `Pull request merged`
+  // and `Pull request linked to issue`, which both rewrite Status as a
+  // side-effect of auto-merge). When `--reap-conflicting-workflows` is
+  // set, also delete the offenders via `deleteProjectV2Workflow` (the
+  // only programmatic action GraphQL exposes today — `enabled` is
+  // read-only).
+  const workflowAudit = projectReady
+    ? await auditAndOptionallyReapWorkflows(
+        provider,
+        project.projectNumber,
+        opts.reapConflictingWorkflows === true,
+        log,
+      )
+    : { skipped: true, reason: 'no-project' };
+
   // Consumer-facing bootstrap promotes the framework's CI-gates-only
   // stance: branch protection with enforce_admins + 0-approval-count and
   // the squash-only merge-method allowlist. Behavior-shifting drift on
@@ -562,6 +657,7 @@ export async function runBootstrap(orchestration, opts = {}) {
     project,
     statusField,
     views,
+    workflowAudit,
     branchProtection,
     mergeMethods,
   };
@@ -591,6 +687,16 @@ function formatBranchProtectionSummary(bp) {
   return bp.status;
 }
 
+function formatWorkflowAuditSummary(wa) {
+  if (!wa) return 'not-run';
+  if (wa.skipped) return `skipped (${wa.reason})`;
+  if (wa.action === 'no-conflicts') return 'no conflicting workflows';
+  if (wa.action === 'warn-only')
+    return `warned (${wa.audit.conflicting.length} conflicting; pass --reap-conflicting-workflows to delete)`;
+  if (wa.action === 'reaped') return `reaped ${wa.reaped.length} workflow(s)`;
+  return wa.action ?? 'unknown';
+}
+
 function formatMergeMethodsSummary(mm) {
   if (!mm) return 'not-run';
   if (mm.status === 'unchanged') return 'unchanged (already at target stance)';
@@ -614,6 +720,9 @@ function printSummary(result) {
     : '';
   Logger.info(
     `Views — created: ${result.views.created.length}, skipped: ${result.views.skipped.length}${unavailableSuffix}`,
+  );
+  Logger.info(
+    `Workflow audit: ${formatWorkflowAuditSummary(result.workflowAudit)}`,
   );
   Logger.info(
     `Branch protection: ${formatBranchProtectionSummary(result.branchProtection)}`,
@@ -684,6 +793,13 @@ async function main() {
   // these flags are the documented escape hatches.
   const assumeYes = process.argv.includes('--assume-yes');
   const assumeNo = process.argv.includes('--assume-no');
+  // Story #2845 — opt-in destructive flag. When set, the workflow-audit
+  // step calls `deleteProjectV2Workflow` for every conflicting built-in
+  // (e.g. "Pull request merged", "Pull request linked to issue"). Default
+  // is warn-only because the GraphQL mutation is irreversible.
+  const reapConflictingWorkflows = process.argv.includes(
+    '--reap-conflicting-workflows',
+  );
 
   try {
     const result = await runBootstrap(config.orchestration, {
@@ -694,6 +810,7 @@ async function main() {
       agentSettings: config.agentSettings,
       assumeYes,
       assumeNo,
+      reapConflictingWorkflows,
     });
     printSummary(result);
   } catch (err) {

--- a/.agents/scripts/lib/bootstrap/workflow-audit.js
+++ b/.agents/scripts/lib/bootstrap/workflow-audit.js
@@ -1,0 +1,256 @@
+/**
+ * bootstrap/workflow-audit — audit the GitHub Projects v2 built-in
+ * workflows for the project board, classifying each enabled workflow
+ * against an allowlist (Story #2845).
+ *
+ * Motivation:
+ *   The orchestrator's `ColumnSync` writes the Status column at every
+ *   `transitionTicketState` call and documents "I own Status" at
+ *   [`column-sync.js:21-27`]. GitHub Projects v2 ships several built-in
+ *   workflows that *also* write the Status column as side-effects of
+ *   issue / PR events. When both are enabled, the bot frequently gets
+ *   the last write on `agent::done` transitions (PR merged ~2 minutes
+ *   after the orchestrator's flip), leaving closed Stories stuck at
+ *   `In Progress` on the board even though the issue is closed and
+ *   labeled `agent::done`. Reproduced on Story #2813.
+ *
+ * Surface:
+ *   - {@link CONFLICTING_WORKFLOWS} / {@link COMPATIBLE_WORKFLOWS} —
+ *     frozen allowlists keyed by GitHub's built-in workflow `name`
+ *     field.
+ *   - {@link auditProjectWorkflows} — pure-ish (one GraphQL read) that
+ *     classifies the project's currently-enabled workflows and returns
+ *     a structured envelope.
+ *   - {@link reapConflictingWorkflows} — opt-in destructive helper
+ *     that issues `deleteProjectV2Workflow` for every entry in the
+ *     audit's `conflicting` set. Fails fast on the first mutation
+ *     error (no partial-reap state).
+ *
+ * GraphQL surface note:
+ *   `ProjectV2Workflow` exposes `enabled` as `NON_NULL` but **read-only**
+ *   — GraphQL ships no `updateProjectV2Workflow` mutation at the time
+ *   of this Story. The only programmatic action is
+ *   `deleteProjectV2Workflow`, which is irreversible from the API
+ *   (the operator must re-create deleted built-ins from the GitHub UI).
+ *   If GitHub later adds a toggle mutation, swap delete for toggle in
+ *   {@link reapConflictingWorkflows}.
+ */
+
+/**
+ * Workflows that **must not** be enabled when the orchestrator owns
+ * the Status column. Each entry writes Status as a side-effect of an
+ * event the orchestrator already handles (close, PR merge, PR link),
+ * and the bot's write typically arrives *after* the orchestrator's
+ * — clobbering the intended terminal state.
+ *
+ * Names match GitHub's built-in `ProjectV2Workflow.name` literals.
+ */
+export const CONFLICTING_WORKFLOWS = Object.freeze([
+  'Pull request merged',
+  'Pull request linked to issue',
+]);
+
+/**
+ * Workflows that are safe to leave on. Either they don't touch the
+ * Status column, or they touch it in a way the orchestrator's writes
+ * agree with (`Item closed` sets Status to `Done`, which matches
+ * `agent::done`).
+ *
+ * Surfaced informationally in the audit envelope so operators can see
+ * what was inspected without re-querying.
+ */
+export const COMPATIBLE_WORKFLOWS = Object.freeze([
+  'Item closed',
+  'Item added to project',
+  'Auto-add to project',
+  'Auto-add sub-issues to project',
+  'Auto-close issue',
+]);
+
+const CONFLICTING_SET = new Set(CONFLICTING_WORKFLOWS);
+const COMPATIBLE_SET = new Set(COMPATIBLE_WORKFLOWS);
+
+const LIST_WORKFLOWS_QUERY = `
+  query($projectId: ID!) {
+    node(id: $projectId) {
+      ... on ProjectV2 {
+        workflows(first: 50) {
+          nodes { id name number enabled }
+        }
+      }
+    }
+  }`;
+
+const DELETE_WORKFLOW_MUTATION = `
+  mutation($workflowId: ID!) {
+    deleteProjectV2Workflow(input: { workflowId: $workflowId }) {
+      projectV2 { id }
+    }
+  }`;
+
+/**
+ * Classify a single workflow row against the allowlists.
+ *
+ * Pure helper — exported for test pinning.
+ *
+ * @param {{ name: string, enabled: boolean }} workflow
+ * @returns {'conflicting'|'compatible'|'unknown'|'disabled-conflicting'|'disabled-other'}
+ */
+export function classifyWorkflow(workflow) {
+  const name = workflow?.name ?? '';
+  const enabled = workflow?.enabled === true;
+  if (CONFLICTING_SET.has(name)) {
+    return enabled ? 'conflicting' : 'disabled-conflicting';
+  }
+  if (COMPATIBLE_SET.has(name)) {
+    return 'compatible';
+  }
+  return enabled ? 'unknown' : 'disabled-other';
+}
+
+/**
+ * Query the project's built-in workflows and classify each one. Returns
+ * a structured envelope the bootstrap step can render and the reap
+ * helper can act on.
+ *
+ * @param {{
+ *   provider: { graphql: Function },
+ *   projectId: string,
+ * }} args
+ * @returns {Promise<{
+ *   projectId: string,
+ *   total: number,
+ *   conflicting: Array<{ id: string, name: string, number: number }>,
+ *   compatible: Array<{ id: string, name: string, number: number }>,
+ *   unknown: Array<{ id: string, name: string, number: number }>,
+ *   disabled: Array<{ id: string, name: string, number: number }>,
+ * }>}
+ */
+export async function auditProjectWorkflows(args) {
+  const { provider, projectId } = args ?? {};
+  if (!provider || typeof provider.graphql !== 'function') {
+    throw new TypeError(
+      'auditProjectWorkflows requires a provider with graphql',
+    );
+  }
+  if (typeof projectId !== 'string' || projectId.length === 0) {
+    throw new TypeError('auditProjectWorkflows requires a non-empty projectId');
+  }
+  const data = await provider.graphql(LIST_WORKFLOWS_QUERY, { projectId });
+  const nodes = data?.node?.workflows?.nodes ?? [];
+  const conflicting = [];
+  const compatible = [];
+  const unknown = [];
+  const disabled = [];
+  for (const node of nodes) {
+    const row = { id: node.id, name: node.name, number: node.number };
+    const klass = classifyWorkflow(node);
+    if (klass === 'conflicting') conflicting.push(row);
+    else if (klass === 'compatible') compatible.push(row);
+    else if (klass === 'unknown') unknown.push(row);
+    else disabled.push(row);
+  }
+  return {
+    projectId,
+    total: nodes.length,
+    conflicting,
+    compatible,
+    unknown,
+    disabled,
+  };
+}
+
+/**
+ * Delete every workflow in the audit's `conflicting` set. Fails fast on
+ * the first mutation error — leaves the remaining workflows untouched
+ * rather than producing a partially-reaped board, because the operator
+ * cannot easily tell which workflows were deleted versus which were
+ * preserved when looking at the post-failure board state.
+ *
+ * Returns the per-workflow outcome so callers can log a deterministic
+ * summary even on partial success (the failure path will throw, but the
+ * happy path returns the full ordered list for printing).
+ *
+ * @param {{
+ *   provider: { graphql: Function },
+ *   audit: ReturnType<typeof auditProjectWorkflows> extends Promise<infer R> ? R : never,
+ * }} args
+ * @returns {Promise<{ reaped: Array<{ id: string, name: string }> }>}
+ */
+export async function reapConflictingWorkflows(args) {
+  const { provider, audit } = args ?? {};
+  if (!provider || typeof provider.graphql !== 'function') {
+    throw new TypeError(
+      'reapConflictingWorkflows requires a provider with graphql',
+    );
+  }
+  if (!audit || !Array.isArray(audit.conflicting)) {
+    throw new TypeError(
+      'reapConflictingWorkflows requires an audit envelope with .conflicting[]',
+    );
+  }
+  const reaped = [];
+  for (const wf of audit.conflicting) {
+    try {
+      await provider.graphql(DELETE_WORKFLOW_MUTATION, { workflowId: wf.id });
+      reaped.push({ id: wf.id, name: wf.name });
+    } catch (err) {
+      throw new Error(
+        `[workflow-audit] Failed to delete workflow "${wf.name}" (id=${wf.id}): ${err?.message ?? err}. ` +
+          `${reaped.length} workflow(s) were already deleted before this failure: ${
+            reaped.map((r) => r.name).join(', ') || '(none)'
+          }.`,
+      );
+    }
+  }
+  return { reaped };
+}
+
+/**
+ * Resolve a Project v2 node id from a project number against the viewer
+ * scope. Used by the bootstrap CLI to convert the resolver's
+ * `projectNumber` into the node id required by
+ * {@link auditProjectWorkflows}. Returns `null` when the viewer cannot
+ * see the project (e.g. missing scope, project not under viewer) so the
+ * caller can degrade gracefully.
+ *
+ * @param {{ provider: { graphql: Function }, projectNumber: number }} args
+ * @returns {Promise<string|null>}
+ */
+export async function resolveProjectIdByNumber(args) {
+  const { provider, projectNumber } = args ?? {};
+  if (!provider || typeof provider.graphql !== 'function') {
+    throw new TypeError(
+      'resolveProjectIdByNumber requires a provider with graphql',
+    );
+  }
+  if (!Number.isInteger(projectNumber) || projectNumber <= 0) {
+    throw new TypeError(
+      'resolveProjectIdByNumber requires a positive integer projectNumber',
+    );
+  }
+  try {
+    const data = await provider.graphql(
+      `query($n: Int!) { viewer { projectV2(number: $n) { id } } }`,
+      { n: projectNumber },
+    );
+    return data?.viewer?.projectV2?.id ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Render a human-readable summary line for the audit. Pure — exported
+ * so the bootstrap CLI and tests share the same formatting.
+ *
+ * @param {Awaited<ReturnType<typeof auditProjectWorkflows>>} audit
+ * @returns {string}
+ */
+export function formatAuditSummary(audit) {
+  const c = audit.conflicting.length;
+  const ok = audit.compatible.length;
+  const u = audit.unknown.length;
+  const d = audit.disabled.length;
+  return `workflows: ${audit.total} scanned — ${c} conflicting, ${ok} compatible, ${u} unknown, ${d} disabled`;
+}

--- a/.agents/scripts/lib/orchestration/reassert-status-column.js
+++ b/.agents/scripts/lib/orchestration/reassert-status-column.js
@@ -1,0 +1,77 @@
+/**
+ * reassert-status-column — re-fire `ColumnSync` against a ticket's
+ * current label set so the GitHub Projects v2 Status column matches the
+ * orchestrator's view (Story #2845).
+ *
+ * Why a dedicated helper:
+ *   `transitionTicketState` already calls `syncProjectStatusColumn` at
+ *   label-flip time, but the GitHub built-in `Pull request merged` /
+ *   `Pull request linked to issue` workflows fire ~minutes after the
+ *   PR auto-merges and overwrite Status. The orchestrator's close path
+ *   has long-since exited by then, so "the last write" is the bot's.
+ *   This helper is invoked AFTER the merge confirmation step (via the
+ *   `resync-status-column.js` CLI the `/single-story-deliver` workflow
+ *   doc calls) to reassert authority and win the race deterministically.
+ *
+ *   Operators who disable the conflicting bot workflows (via the
+ *   `--reap-conflicting-workflows` bootstrap flag) get the same outcome
+ *   without needing the re-sync, but the helper is cheap to fire and
+ *   defends against bot workflows that get re-enabled later or that
+ *   GitHub adds in the future.
+ *
+ * Surface:
+ *   - {@link reassertStatusColumn} — read the ticket's current labels,
+ *     pick the canonical column via {@link columnForLabels}, push it
+ *     via `ColumnSync.sync`. Returns the sync envelope.
+ */
+
+import { ColumnSync, columnForLabels } from './column-sync.js';
+
+/**
+ * Re-assert the Status column for a single ticket. Reads the ticket's
+ * current labels so the caller doesn't have to pass them (the typical
+ * use site is a post-merge CLI that knows the ticket id only).
+ *
+ * Returns the same envelope shape as `ColumnSync.sync`:
+ *   - `{ status: 'synced', column }` — the mutation landed.
+ *   - `{ status: 'skipped', reason }` — no-op for an enumerated reason
+ *     (`no-matching-label`, `no-project`, `no-meta`, `no-option-<col>`,
+ *     `not-on-project`).
+ *
+ * Throws when the provider is unusable. Other failures (GraphQL,
+ * network) propagate from `ColumnSync.sync` and `provider.getTicket` —
+ * callers wrap in try/catch if they want best-effort semantics.
+ *
+ * @param {{
+ *   provider: { getTicket: Function, graphql: Function, owner: string, repo: string, projectNumber?: number|null },
+ *   ticketId: number,
+ *   logger?: { info: Function, warn: Function },
+ * }} args
+ * @returns {Promise<{ status: string, column?: string, reason?: string }>}
+ */
+export async function reassertStatusColumn(args) {
+  const { provider, ticketId, logger } = args ?? {};
+  if (!provider || typeof provider.getTicket !== 'function') {
+    throw new TypeError(
+      'reassertStatusColumn requires a provider with getTicket',
+    );
+  }
+  if (typeof provider.graphql !== 'function') {
+    throw new TypeError(
+      'reassertStatusColumn requires a provider with graphql (for ColumnSync)',
+    );
+  }
+  if (!Number.isInteger(ticketId) || ticketId <= 0) {
+    throw new TypeError(
+      'reassertStatusColumn requires a positive integer ticketId',
+    );
+  }
+  const ticket = await provider.getTicket(ticketId);
+  const labels = Array.isArray(ticket?.labels) ? ticket.labels : [];
+  const targetColumn = columnForLabels(labels);
+  if (!targetColumn) {
+    return { status: 'skipped', reason: 'no-matching-label' };
+  }
+  const sync = new ColumnSync({ provider, logger: logger ?? console });
+  return sync.sync(ticketId, labels);
+}

--- a/.agents/scripts/resync-status-column.js
+++ b/.agents/scripts/resync-status-column.js
@@ -1,0 +1,114 @@
+#!/usr/bin/env node
+/* node:coverage ignore file */
+
+/**
+ * resync-status-column.js — re-assert the GitHub Projects v2 Status
+ * column for a ticket after auto-merge has fired (Story #2845).
+ *
+ * The `/single-story-deliver` and `/story-deliver` workflow docs call
+ * this CLI after Step 5 confirms `state: "MERGED"` so the orchestrator
+ * wins the race against the GitHub built-in `Pull request merged`
+ * workflow, which would otherwise overwrite Status to whatever value
+ * the bot's rule prescribes (typically `In Progress`) ~minutes after
+ * the merge lands.
+ *
+ * Idempotent: re-running on a ticket whose Status already matches the
+ * derived target returns the same `synced` envelope and issues the
+ * same single GraphQL mutation. No retries — callers re-run the CLI if
+ * the bot's overwrite arrives later than expected.
+ *
+ * Usage:
+ *   node .agents/scripts/resync-status-column.js --ticket <id>
+ *   node .agents/scripts/resync-status-column.js --story <id>   # alias
+ *
+ * Exit codes:
+ *   0 — sync succeeded OR was skipped for a documented reason
+ *       (`no-project`, `no-meta`, `not-on-project`).
+ *   1 — provider error, GraphQL error, or invalid input.
+ *
+ * The CLI prints a single-line JSON envelope to stdout:
+ *   `{ ticketId, status, column?, reason? }`
+ */
+
+import { parseArgs } from 'node:util';
+import { runAsCli } from './lib/cli-utils.js';
+import { resolveConfig } from './lib/config-resolver.js';
+import { Logger } from './lib/Logger.js';
+import { reassertStatusColumn } from './lib/orchestration/reassert-status-column.js';
+import { createProvider } from './lib/provider-factory.js';
+
+const HELP = `Usage: node .agents/scripts/resync-status-column.js \\
+  --ticket <id> | --story <id> [--provider github]
+
+Re-asserts the Projects v2 Status column for the ticket based on its
+current agent::* label set. Intended to run after auto-merge fires, to
+overwrite any post-merge bot-driven Status flip.
+
+Flags:
+  --ticket   GitHub issue number (required, or pass --story).
+  --story    Alias for --ticket.
+  --provider Provider name (default: value in .agentrc.json orchestration).
+  --help     Show this message.
+`;
+
+export function parseArgv(argv) {
+  const { values } = parseArgs({
+    args: argv,
+    options: {
+      ticket: { type: 'string' },
+      story: { type: 'string' },
+      provider: { type: 'string' },
+      help: { type: 'boolean' },
+    },
+    strict: false,
+  });
+  return values;
+}
+
+/**
+ * Pure input-validation extracted so it can be tested without spawning
+ * a subprocess. Returns `{ ticketId, errors }` — `errors` is empty on
+ * success.
+ *
+ * @param {Record<string, unknown>} values
+ */
+export function validateRequiredArgs(values) {
+  const raw = values.ticket ?? values.story ?? '';
+  const ticketId = Number.parseInt(raw, 10);
+  const errors = [];
+  if (!Number.isFinite(ticketId) || ticketId <= 0) {
+    errors.push('--ticket <id> (or --story <id>) is required.');
+  }
+  return { ticketId, errors };
+}
+
+export async function main(argv = process.argv.slice(2)) {
+  const values = parseArgv(argv);
+  if (values.help) {
+    process.stdout.write(HELP);
+    return;
+  }
+  const { ticketId, errors } = validateRequiredArgs(values);
+  if (errors.length) {
+    for (const e of errors) {
+      process.stderr.write(`[resync-status-column] ${e}\n`);
+    }
+    process.stderr.write(HELP);
+    process.exit(2);
+  }
+
+  const { orchestration } = resolveConfig();
+  const effectiveOrchestration = values.provider
+    ? { ...orchestration, provider: values.provider }
+    : orchestration;
+  const provider = createProvider(effectiveOrchestration);
+
+  const result = await reassertStatusColumn({
+    provider,
+    ticketId,
+    logger: Logger,
+  });
+  process.stdout.write(`${JSON.stringify({ ticketId, ...result })}\n`);
+}
+
+runAsCli(import.meta.url, main, { source: 'resync-status-column' });

--- a/.agents/workflows/single-story-deliver.md
+++ b/.agents/workflows/single-story-deliver.md
@@ -335,6 +335,46 @@ gate. The operator reviews and merges via the GitHub UI; the same
 
 ---
 
+## Step 5.5 — Re-assert Status column (**required, not optional**)
+
+The GitHub Projects v2 built-in workflows `Pull request merged` and
+`Pull request linked to issue` are enabled by default on most boards
+and fire ~minutes *after* auto-merge lands. They overwrite the Status
+field as a side-effect, clobbering the `Done` value `single-story-close.js`
+set at `agent::done` flip-time and leaving closed Stories stuck at
+`In Progress` on the board (reproduced on Story #2813). The
+orchestrator's close path has already exited by then, so the bot
+gets the last write.
+
+Re-assert authority once the merge confirms:
+
+```bash
+node .agents/scripts/resync-status-column.js --story <storyId>
+```
+
+What this does:
+
+- Reads the ticket's current `agent::*` label set (now `agent::done`).
+- Re-fires the same `ColumnSync` mutation `transitionTicketState` used
+  at close, overwriting the bot's late write.
+- Prints a single-line JSON envelope: `{ ticketId, status, column?, reason? }`.
+
+Idempotent: re-running on a ticket whose Status already matches the
+target returns the same envelope and issues the same single GraphQL
+mutation. No-op skips (`no-project`, `no-meta`, `not-on-project`)
+exit 0 with the reason in the envelope so the workflow can continue.
+
+Operators who have already disabled the conflicting bot workflows via
+`agents-bootstrap-github.js --reap-conflicting-workflows` can still
+run this step safely — the re-assert is cheap and defends against
+re-enabled or future bot workflows.
+
+Skip Step 5.5 only when the operator opted out of auto-merge AND has
+not yet merged the PR (no `agent::done` to re-assert yet) — run it
+after the manual merge instead.
+
+---
+
 ## Step 6 — Local branch cleanup (**required, not optional**)
 
 GitHub deletes the **remote** branch on auto-merge (via the

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,33 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+### Fixed — Story #2845: own Projects v2 Status column (audit + post-merge re-sync)
+
+The orchestrator's `ColumnSync` writes Status at `transitionTicketState`
+time, but GitHub's built-in `Pull request merged` / `Pull request linked
+to issue` workflows fire minutes after auto-merge and overwrite Status —
+typically leaving closed Stories stuck at `In Progress` on the board
+(reproduced on Story #2813). This change closes the race on both axes.
+Closes #2845.
+
+- **Bootstrap workflow audit.** `agents-bootstrap-github.js` now audits
+  `projectV2.workflows` after project provisioning and surfaces a
+  warning for any enabled workflow in
+  `lib/bootstrap/workflow-audit.js#CONFLICTING_WORKFLOWS`. The warning
+  names the offenders and points operators at the two remediation paths.
+- **Opt-in destructive cleanup.** Passing
+  `--reap-conflicting-workflows` to `agents-bootstrap-github.js`
+  calls `deleteProjectV2Workflow` for each conflicting entry
+  (fail-fast on the first mutation error; the GraphQL API has no
+  toggle mutation — `ProjectV2Workflow.enabled` is read-only).
+- **Post-merge re-assert CLI.** New
+  `.agents/scripts/resync-status-column.js` re-fires `ColumnSync`
+  against the orchestrator's view of the Status column. The
+  `/single-story-deliver` workflow doc invokes it as Step 5.5 after
+  merge confirmation so the orchestrator wins the race even when the
+  bot workflows stay enabled. Shared via the new
+  `lib/orchestration/reassert-status-column.js` helper.
+
 ### Added — Story #2813: per-Task model-attribution structured comments + rollup
 
 Each Task ticket now receives a `model-attribution` structured comment when it

--- a/tests/bootstrap/workflow-audit.test.js
+++ b/tests/bootstrap/workflow-audit.test.js
@@ -1,0 +1,237 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import {
+  auditProjectWorkflows,
+  COMPATIBLE_WORKFLOWS,
+  CONFLICTING_WORKFLOWS,
+  classifyWorkflow,
+  formatAuditSummary,
+  reapConflictingWorkflows,
+  resolveProjectIdByNumber,
+} from '../../.agents/scripts/lib/bootstrap/workflow-audit.js';
+
+function makeProvider({
+  workflowsByProjectId = {},
+  viewerProjectId = null,
+  throwOnDelete = null,
+} = {}) {
+  const calls = { graphql: [] };
+  return {
+    calls,
+    async graphql(query, vars) {
+      calls.graphql.push({ query, vars });
+      if (query.includes('viewer') && query.includes('projectV2')) {
+        if (viewerProjectId === 'THROW') throw new Error('scope missing');
+        return {
+          viewer: {
+            projectV2: viewerProjectId ? { id: viewerProjectId } : null,
+          },
+        };
+      }
+      if (query.includes('node(id:') || query.includes('node(id: $projectId')) {
+        const nodes = workflowsByProjectId[vars.projectId] ?? [];
+        return { node: { workflows: { nodes } } };
+      }
+      if (query.includes('deleteProjectV2Workflow')) {
+        if (throwOnDelete?.includes(vars.workflowId)) {
+          throw new Error(`mock-delete-failure for ${vars.workflowId}`);
+        }
+        return { deleteProjectV2Workflow: { projectV2: { id: 'PRJ' } } };
+      }
+      throw new Error(
+        `unexpected graphql query in test: ${query.slice(0, 80)}`,
+      );
+    },
+  };
+}
+
+describe('classifyWorkflow', () => {
+  it('flags enabled conflicting workflows as conflicting', () => {
+    for (const name of CONFLICTING_WORKFLOWS) {
+      assert.equal(classifyWorkflow({ name, enabled: true }), 'conflicting');
+    }
+  });
+
+  it('passes enabled compatible workflows as compatible', () => {
+    for (const name of COMPATIBLE_WORKFLOWS) {
+      assert.equal(classifyWorkflow({ name, enabled: true }), 'compatible');
+    }
+  });
+
+  it('reports disabled conflicting workflows separately so reap is no-op', () => {
+    assert.equal(
+      classifyWorkflow({ name: 'Pull request merged', enabled: false }),
+      'disabled-conflicting',
+    );
+  });
+
+  it('classifies unknown enabled workflows as unknown', () => {
+    assert.equal(
+      classifyWorkflow({ name: 'Custom workflow', enabled: true }),
+      'unknown',
+    );
+  });
+
+  it('classifies unknown disabled workflows as disabled-other', () => {
+    assert.equal(
+      classifyWorkflow({ name: 'Custom workflow', enabled: false }),
+      'disabled-other',
+    );
+  });
+});
+
+describe('auditProjectWorkflows', () => {
+  it('partitions the project workflows into conflicting / compatible / unknown / disabled', async () => {
+    const provider = makeProvider({
+      workflowsByProjectId: {
+        PRJ: [
+          { id: 'w1', number: 1, name: 'Pull request merged', enabled: true },
+          {
+            id: 'w2',
+            number: 2,
+            name: 'Pull request linked to issue',
+            enabled: true,
+          },
+          { id: 'w3', number: 3, name: 'Item closed', enabled: true },
+          { id: 'w4', number: 4, name: 'Custom enabled', enabled: true },
+          { id: 'w5', number: 5, name: 'Custom disabled', enabled: false },
+        ],
+      },
+    });
+    const audit = await auditProjectWorkflows({ provider, projectId: 'PRJ' });
+    assert.equal(audit.total, 5);
+    assert.deepEqual(
+      audit.conflicting.map((w) => w.name),
+      ['Pull request merged', 'Pull request linked to issue'],
+    );
+    assert.deepEqual(
+      audit.compatible.map((w) => w.name),
+      ['Item closed'],
+    );
+    assert.deepEqual(
+      audit.unknown.map((w) => w.name),
+      ['Custom enabled'],
+    );
+    assert.deepEqual(
+      audit.disabled.map((w) => w.name),
+      ['Custom disabled'],
+    );
+  });
+
+  it('handles a project with no workflows gracefully', async () => {
+    const provider = makeProvider({ workflowsByProjectId: { PRJ: [] } });
+    const audit = await auditProjectWorkflows({ provider, projectId: 'PRJ' });
+    assert.equal(audit.total, 0);
+    assert.equal(audit.conflicting.length, 0);
+  });
+
+  it('rejects bad inputs', async () => {
+    await assert.rejects(
+      auditProjectWorkflows({ provider: {}, projectId: 'PRJ' }),
+      /provider with graphql/,
+    );
+    await assert.rejects(
+      auditProjectWorkflows({ provider: makeProvider(), projectId: '' }),
+      /non-empty projectId/,
+    );
+  });
+});
+
+describe('reapConflictingWorkflows', () => {
+  it('deletes every workflow in the audit.conflicting set in order', async () => {
+    const provider = makeProvider();
+    const audit = {
+      conflicting: [
+        { id: 'w1', name: 'Pull request merged', number: 1 },
+        { id: 'w2', name: 'Pull request linked to issue', number: 2 },
+      ],
+    };
+    const { reaped } = await reapConflictingWorkflows({ provider, audit });
+    assert.deepEqual(
+      reaped.map((r) => r.id),
+      ['w1', 'w2'],
+    );
+    const deleteCalls = provider.calls.graphql.filter((c) =>
+      c.query.includes('deleteProjectV2Workflow'),
+    );
+    assert.equal(deleteCalls.length, 2);
+  });
+
+  it('fails fast and names the surviving offenders when a delete throws', async () => {
+    const provider = makeProvider({ throwOnDelete: ['w2'] });
+    const audit = {
+      conflicting: [
+        { id: 'w1', name: 'Pull request merged', number: 1 },
+        { id: 'w2', name: 'Pull request linked to issue', number: 2 },
+        { id: 'w3', name: 'Unreached', number: 3 },
+      ],
+    };
+    await assert.rejects(
+      reapConflictingWorkflows({ provider, audit }),
+      /Failed to delete workflow "Pull request linked to issue".*1 workflow\(s\) were already deleted before this failure: Pull request merged/s,
+    );
+  });
+
+  it('rejects malformed inputs', async () => {
+    await assert.rejects(
+      reapConflictingWorkflows({ provider: {}, audit: { conflicting: [] } }),
+      /provider with graphql/,
+    );
+    await assert.rejects(
+      reapConflictingWorkflows({ provider: makeProvider(), audit: null }),
+      /audit envelope with .conflicting/,
+    );
+  });
+});
+
+describe('resolveProjectIdByNumber', () => {
+  it('returns the viewer project id for a known number', async () => {
+    const provider = makeProvider({ viewerProjectId: 'PVT_abc' });
+    const id = await resolveProjectIdByNumber({ provider, projectNumber: 1 });
+    assert.equal(id, 'PVT_abc');
+  });
+
+  it('returns null when the viewer cannot see the project', async () => {
+    const provider = makeProvider({ viewerProjectId: null });
+    assert.equal(
+      await resolveProjectIdByNumber({ provider, projectNumber: 99 }),
+      null,
+    );
+  });
+
+  it('returns null on GraphQL failure (degrades gracefully)', async () => {
+    const provider = makeProvider({ viewerProjectId: 'THROW' });
+    assert.equal(
+      await resolveProjectIdByNumber({ provider, projectNumber: 1 }),
+      null,
+    );
+  });
+
+  it('rejects bad inputs', async () => {
+    await assert.rejects(
+      resolveProjectIdByNumber({ provider: {}, projectNumber: 1 }),
+      /provider with graphql/,
+    );
+    await assert.rejects(
+      resolveProjectIdByNumber({ provider: makeProvider(), projectNumber: 0 }),
+      /positive integer projectNumber/,
+    );
+  });
+});
+
+describe('formatAuditSummary', () => {
+  it('renders counts in a stable single-line shape', () => {
+    const audit = {
+      total: 5,
+      conflicting: [{ name: 'a' }, { name: 'b' }],
+      compatible: [{ name: 'c' }],
+      unknown: [{ name: 'd' }],
+      disabled: [{ name: 'e' }],
+    };
+    assert.equal(
+      formatAuditSummary(audit),
+      'workflows: 5 scanned — 2 conflicting, 1 compatible, 1 unknown, 1 disabled',
+    );
+  });
+});

--- a/tests/lib/orchestration/reassert-status-column.test.js
+++ b/tests/lib/orchestration/reassert-status-column.test.js
@@ -1,0 +1,152 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import { reassertStatusColumn } from '../../../.agents/scripts/lib/orchestration/reassert-status-column.js';
+
+/**
+ * Provider fake that records every GraphQL call and supports the four
+ * queries ColumnSync issues:
+ *   1. viewer.projectV2(number) → project metadata
+ *   2. repository.issue.projectItems → item id
+ *   3. updateProjectV2ItemFieldValue → mutation
+ * Plus our own getTicket(id) for label-readback.
+ *
+ * The fake also exposes a `simulateBotOverwrite()` hook so tests can
+ * mimic the GitHub `Pull request merged` workflow stomping on Status
+ * between the close-time write and the post-merge re-assert.
+ */
+function makeProvider({
+  ticketLabels = {},
+  projectNumber = 1,
+  projectId = 'PVT_abc',
+  statusFieldId = 'STAT_field',
+  statusOptions = { 'In Progress': 'OPT_inprog', Done: 'OPT_done' },
+  itemIdByTicket = {},
+} = {}) {
+  const calls = { graphql: [], getTicket: [], statusByItem: {} };
+  return {
+    owner: 'acme',
+    repo: 'widgets',
+    projectNumber,
+    calls,
+    async getTicket(id) {
+      calls.getTicket.push(id);
+      return { id, labels: ticketLabels[id] ?? [] };
+    },
+    async graphql(query, vars) {
+      calls.graphql.push({ query, vars });
+      if (query.includes('viewer') && query.includes('projectV2(number')) {
+        return {
+          viewer: {
+            projectV2: {
+              id: projectId,
+              field: {
+                id: statusFieldId,
+                options: Object.entries(statusOptions).map(([name, id]) => ({
+                  id,
+                  name,
+                })),
+              },
+            },
+          },
+        };
+      }
+      if (
+        query.includes('repository(owner') &&
+        query.includes('issue(number')
+      ) {
+        const itemId = itemIdByTicket[vars.number];
+        return {
+          repository: {
+            issue: {
+              projectItems: {
+                nodes: itemId
+                  ? [{ id: itemId, project: { id: projectId } }]
+                  : [],
+              },
+            },
+          },
+        };
+      }
+      if (query.includes('updateProjectV2ItemFieldValue')) {
+        calls.statusByItem[vars.itemId] = vars.optionId;
+        return {
+          updateProjectV2ItemFieldValue: { projectV2Item: { id: vars.itemId } },
+        };
+      }
+      throw new Error(`unexpected graphql query: ${query.slice(0, 60)}`);
+    },
+    simulateBotOverwrite(itemId, optionId) {
+      calls.statusByItem[itemId] = optionId;
+    },
+  };
+}
+
+describe('reassertStatusColumn', () => {
+  it('reads ticket labels and syncs the canonical column for agent::done', async () => {
+    const provider = makeProvider({
+      ticketLabels: { 2813: ['type::story', 'agent::done'] },
+      itemIdByTicket: { 2813: 'PVTI_abc' },
+    });
+    const result = await reassertStatusColumn({ provider, ticketId: 2813 });
+    assert.equal(result.status, 'synced');
+    assert.equal(result.column, 'Done');
+    assert.equal(provider.calls.statusByItem.PVTI_abc, 'OPT_done');
+  });
+
+  it('post-merge race: re-assert overwrites a simulated bot flip back to In Progress', async () => {
+    const provider = makeProvider({
+      ticketLabels: { 7: ['agent::done'] },
+      itemIdByTicket: { 7: 'PVTI_seven' },
+    });
+    // Initial close-time write — orchestrator sets Done.
+    await reassertStatusColumn({ provider, ticketId: 7 });
+    assert.equal(provider.calls.statusByItem.PVTI_seven, 'OPT_done');
+    // Bot fires its post-merge workflow 2 minutes later, stomping on Done.
+    provider.simulateBotOverwrite('PVTI_seven', 'OPT_inprog');
+    assert.equal(provider.calls.statusByItem.PVTI_seven, 'OPT_inprog');
+    // Workflow doc step 5.5 re-runs the CLI; the re-assert wins.
+    const after = await reassertStatusColumn({ provider, ticketId: 7 });
+    assert.equal(after.status, 'synced');
+    assert.equal(after.column, 'Done');
+    assert.equal(provider.calls.statusByItem.PVTI_seven, 'OPT_done');
+  });
+
+  it('skips cleanly when the ticket has no recognised agent:: label', async () => {
+    const provider = makeProvider({
+      ticketLabels: { 99: ['type::story'] },
+    });
+    const result = await reassertStatusColumn({ provider, ticketId: 99 });
+    assert.equal(result.status, 'skipped');
+    assert.equal(result.reason, 'no-matching-label');
+    assert.equal(provider.calls.graphql.length, 0);
+  });
+
+  it('skips cleanly when the issue is not on the configured project board', async () => {
+    const provider = makeProvider({
+      ticketLabels: { 5: ['agent::executing'] },
+      itemIdByTicket: {}, // no item registered for #5
+    });
+    const result = await reassertStatusColumn({ provider, ticketId: 5 });
+    assert.equal(result.status, 'skipped');
+    assert.equal(result.reason, 'not-on-project');
+  });
+
+  it('rejects bad inputs', async () => {
+    await assert.rejects(
+      reassertStatusColumn({ provider: {}, ticketId: 1 }),
+      /provider with getTicket/,
+    );
+    await assert.rejects(
+      reassertStatusColumn({
+        provider: { getTicket: () => null },
+        ticketId: 1,
+      }),
+      /provider with graphql/,
+    );
+    await assert.rejects(
+      reassertStatusColumn({ provider: makeProvider(), ticketId: 0 }),
+      /positive integer ticketId/,
+    );
+  });
+});

--- a/tests/resync-status-column-cli.test.js
+++ b/tests/resync-status-column-cli.test.js
@@ -1,0 +1,41 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import {
+  parseArgv,
+  validateRequiredArgs,
+} from '../.agents/scripts/resync-status-column.js';
+
+describe('resync-status-column CLI', () => {
+  it('accepts --ticket', () => {
+    const v = parseArgv(['--ticket', '2813']);
+    const { ticketId, errors } = validateRequiredArgs(v);
+    assert.equal(ticketId, 2813);
+    assert.deepEqual(errors, []);
+  });
+
+  it('accepts --story as an alias for --ticket', () => {
+    const v = parseArgv(['--story', '2813']);
+    const { ticketId, errors } = validateRequiredArgs(v);
+    assert.equal(ticketId, 2813);
+    assert.deepEqual(errors, []);
+  });
+
+  it('rejects missing id with a clear message', () => {
+    const { errors } = validateRequiredArgs(parseArgv([]));
+    assert.equal(errors.length, 1);
+    assert.match(errors[0], /--ticket <id> .* --story <id>.* required/);
+  });
+
+  it('rejects non-positive ids', () => {
+    const { errors } = validateRequiredArgs(parseArgv(['--ticket', '0']));
+    assert.equal(errors.length, 1);
+  });
+
+  it('rejects non-numeric ids', () => {
+    const { errors } = validateRequiredArgs(
+      parseArgv(['--ticket', 'not-a-number']),
+    );
+    assert.equal(errors.length, 1);
+  });
+});


### PR DESCRIPTION
Closes #2845

_Auto-opened by `/single-story-deliver`._