### PR TITLE
Epic #2649: Adaptive Planning & Acceptance Risk Gating

### DIFF
--- a/.agents/SDLC.md
+++ b/.agents/SDLC.md
@@ -285,12 +285,54 @@ The spec is persisted by
 — the persist half writes all three artifacts in one atomic step and
 fails loudly if any is missing or empty.
 
+#### Adaptive planning risk routing
+
+`/epic-plan` Phase 7 computes a deterministic **`planningRisk`** envelope
+from the Epic body, labels, and linked context before persisting the
+spec artifacts. The envelope is recorded in the `epic-plan-state`
+checkpoint and consumed by two downstream decisions:
+
+- **Acceptance disposition** — `acceptanceDisposition` is one of
+  `required`, `recommended`, or `not-applicable`. The `not-applicable`
+  case is the planner-selected route to the `acceptance::n-a` waiver
+  (see the section below); the other two cause the Acceptance Spec to
+  be authored normally.
+- **Gate routing** — `gateDecision` is either `review-required`
+  (paired with `requiresReview: true`) or `auto-proceed`. High-risk
+  Epics (visible behavior, public API, security, billing, data
+  migration, destructive mutation, critical workflow) trigger a HITL
+  stop after Phase 7 so the operator can read the PRD / Tech Spec /
+  Acceptance Spec on GitHub before decomposition starts. Low-risk
+  Epics (docs-only, internal refactor, pure test harness, cleanup)
+  print the auto-proceed message from `reviewRouting.operatorMessage`
+  and chain directly into Phase 8. The operator can force the review
+  stop on low-risk work by passing `--force-review` to `/epic-plan`.
+
+The risk envelope is also threaded into the Phase 8 decomposer context
+so the ticket array can cite the relevant axes when assigning
+`risk::high` labels to Stories. The classifier is local and
+deterministic — it never calls an external LLM or sends Epic content
+off-host.
+
 #### Opting out — the `acceptance::n-a` waiver
 
 Not every Epic warrants a formal Acceptance Spec (pure refactors,
-framework maintenance, docs-only churn). For those, the operator applies
-the **`acceptance::n-a`** label to the Epic ticket. The waiver is
-respected by both runtime gates:
+framework maintenance, docs-only churn). The **`acceptance::n-a`** label
+on the Epic ticket records the waiver. There are two routes to the label:
+
+- **Operator-applied** — the operator labels the Epic before or during
+  `/epic-plan` Phase 7 when they already know the work does not need a
+  spec.
+- **Planner-selected** — `/epic-plan` Phase 7 computes a
+  `planningRisk` envelope (see § Adaptive planning risk routing) and,
+  when `acceptanceDisposition === 'not-applicable'`, the persist half
+  of `epic-plan-spec.js` applies `acceptance::n-a` on the Epic and skips
+  the Acceptance Spec artifact for that run. The disposition is also
+  recorded in the `epic-plan-state` checkpoint so the decision is
+  auditable.
+
+Either route produces the same runtime behavior. The waiver is respected
+by both runtime gates:
 
 - The `/epic-deliver` **start gate** (Phase 1 snapshot) skips the
   acceptance-spec presence check when the label is set.

--- a/.agents/scripts/epic-plan-spec.js
+++ b/.agents/scripts/epic-plan-spec.js
@@ -59,7 +59,11 @@ import { scanMemoryFreshness } from './lib/feedback-loop/memory-freshness.js';
 import { fetchPriorFeedback } from './lib/feedback-loop/prior-feedback-fetcher.js';
 import * as gitUtils from './lib/git-utils.js';
 import { Logger, routeAllOutputToStderr, STDERR_LOGGER } from './lib/Logger.js';
-import { AGENT_LABELS, TYPE_LABELS } from './lib/label-constants.js';
+import {
+  ACCEPTANCE_NA,
+  AGENT_LABELS,
+  TYPE_LABELS,
+} from './lib/label-constants.js';
 import { buildDocsContext } from './lib/orchestration/doc-reader.js';
 import {
   initialize as initializePlanState,
@@ -294,6 +298,40 @@ export function resolveMemoryDir({ github } = {}) {
 }
 
 /**
+ * Resolve whether Phase 7 should persist an acceptance-spec ticket or apply
+ * the existing `acceptance::n-a` waiver from {@link classifyPlanningRisk}.
+ *
+ * @param {{ title?: string, body?: string, labels?: string[] }} epic
+ * @param {string|null} acceptanceSpecContent
+ * @returns {{ planningRisk: import('./lib/orchestration/planning-risk.js').PlanningRiskEnvelope, wantsAcceptanceSpec: boolean, applyAcceptanceWaiver: boolean }}
+ */
+export function resolveAcceptancePersistence(epic, acceptanceSpecContent) {
+  const planningRisk = classifyPlanningRisk({
+    title: epic.title,
+    body: epic.body ?? '',
+    labels: epic.labels ?? [],
+  });
+
+  const hasAcceptanceContent =
+    typeof acceptanceSpecContent === 'string' &&
+    acceptanceSpecContent.trim() !== '';
+
+  if (planningRisk.acceptanceDisposition === 'not-applicable') {
+    return {
+      planningRisk,
+      wantsAcceptanceSpec: false,
+      applyAcceptanceWaiver: true,
+    };
+  }
+
+  return {
+    planningRisk,
+    wantsAcceptanceSpec: hasAcceptanceContent,
+    applyAcceptanceWaiver: false,
+  };
+}
+
+/**
  * Persist the host-authored PRD and Tech Spec under the Epic.
  *
  * Heals any prior planning artifacts (PRD / Tech Spec issues, "Planning
@@ -339,8 +377,19 @@ export async function planEpic(
   const stateManager = new PlanningStateManager(provider);
   await stateManager.healAndCleanupArtifacts(epic, force);
 
+  const { planningRisk, wantsAcceptanceSpec, applyAcceptanceWaiver } =
+    resolveAcceptancePersistence(epic, acceptanceSpecContent);
+
+  Logger.info(
+    `[Epic Planner] Acceptance disposition: ${planningRisk.acceptanceDisposition}` +
+      (applyAcceptanceWaiver
+        ? ` — applying ${ACCEPTANCE_NA} waiver (no acceptance-spec ticket).`
+        : wantsAcceptanceSpec
+          ? ' — persisting context::acceptance-spec.'
+          : ' — no acceptance-spec content supplied.'),
+  );
+
   // M-8: Resumable planning — if all artifacts exist, abort to prevent dupes.
-  const wantsAcceptanceSpec = acceptanceSpecContent !== null;
   const hasPrd = Boolean(epic.linkedIssues?.prd);
   const hasTechSpec = Boolean(epic.linkedIssues?.techSpec);
   const hasAcceptanceSpec = Boolean(epic.linkedIssues?.acceptanceSpec);
@@ -445,8 +494,22 @@ export async function planEpic(
   const appendBody = `\n\n## Planning Artifacts\n${artifactLines.join('\n')}\n`;
   const newBody = epic.body + appendBody;
 
+  /** @type {{ add?: string[], remove?: string[] }} */
+  const labelMutations = {};
+  if (applyAcceptanceWaiver) {
+    labelMutations.add = [ACCEPTANCE_NA];
+  } else if (
+    wantsAcceptanceSpec &&
+    (epic.labels ?? []).includes(ACCEPTANCE_NA)
+  ) {
+    labelMutations.remove = [ACCEPTANCE_NA];
+  }
+
   await provider.updateTicket(epicId, {
     body: newBody,
+    ...(labelMutations.add || labelMutations.remove
+      ? { labels: labelMutations }
+      : {}),
   });
 
   Logger.info(`[Epic Planner] Epic #${epicId} updated successfully.`);

--- a/.agents/scripts/epic-plan-spec.js
+++ b/.agents/scripts/epic-plan-spec.js
@@ -72,12 +72,13 @@ import {
   setPhase as setPlanPhase,
   write as writePlanState,
 } from './lib/orchestration/epic-plan-state-store.js';
+import { resolveReviewRouting } from './lib/orchestration/plan-review-routing.js';
 import { sweepStaleStoryWorktrees } from './lib/orchestration/plan-runner/worktree-sweep.js';
 import { applyBudget } from './lib/orchestration/planning-context-budget.js';
-import { resolveReviewRouting } from './lib/orchestration/plan-review-routing.js';
 import { classifyPlanningRisk } from './lib/orchestration/planning-risk.js';
 
 export { resolveReviewRouting };
+
 import { PlanningStateManager } from './lib/orchestration/planning-state-manager.js';
 import {
   renderSpecFreshnessComment,

--- a/.agents/scripts/epic-plan-spec.js
+++ b/.agents/scripts/epic-plan-spec.js
@@ -74,7 +74,10 @@ import {
 } from './lib/orchestration/epic-plan-state-store.js';
 import { sweepStaleStoryWorktrees } from './lib/orchestration/plan-runner/worktree-sweep.js';
 import { applyBudget } from './lib/orchestration/planning-context-budget.js';
+import { resolveReviewRouting } from './lib/orchestration/plan-review-routing.js';
 import { classifyPlanningRisk } from './lib/orchestration/planning-risk.js';
+
+export { resolveReviewRouting };
 import { PlanningStateManager } from './lib/orchestration/planning-state-manager.js';
 import {
   renderSpecFreshnessComment,
@@ -741,15 +744,15 @@ export async function runSpecFreshnessCheck({
  * @param {import('./lib/ITicketingProvider.js').ITicketingProvider} provider
  * @param {{ prdContent: string, techSpecContent: string }} artifacts
  * @param {object} settings
- * @param {{ force?: boolean, snapshotFork?: typeof forkAndCommitEpicSnapshot }} [opts]
- * @returns {Promise<{ epicId: number, prdId: number|null, techSpecId: number|null, checkpoint: object }>}
+ * @param {{ force?: boolean, forceReview?: boolean, snapshotFork?: typeof forkAndCommitEpicSnapshot }} [opts]
+ * @returns {Promise<{ epicId: number, prdId: number|null, techSpecId: number|null, checkpoint: object, planningRisk: import('./lib/orchestration/planning-risk.js').PlanningRiskEnvelope, reviewRouting: import('./lib/orchestration/plan-review-routing.js').ReviewRoutingEnvelope }>}
  */
 export async function runSpecPhase(
   epicId,
   provider,
   { prdContent, techSpecContent, acceptanceSpecContent = null },
   settings = {},
-  { force = false } = {},
+  { force = false, forceReview = false } = {},
 ) {
   const epic = await provider.getEpic(epicId);
   if (!epic) {
@@ -808,6 +811,13 @@ export async function runSpecPhase(
   // `/epic-plan` remains git-state-free. `forkAndCommitEpicSnapshot` and
   // `forkMainToEpic` remain exported for that caller.
 
+  const planningRisk = classifyPlanningRisk({
+    title: afterPlan.title,
+    body: afterPlan.body ?? '',
+    labels: afterPlan.labels ?? [],
+  });
+  const reviewRouting = resolveReviewRouting({ planningRisk, forceReview });
+
   const currentState =
     (await readPlanState({ provider, epicId })) ??
     (await initializePlanState({ provider, epicId }));
@@ -816,6 +826,12 @@ export async function runSpecPhase(
     epicId,
     state: {
       ...currentState,
+      planningRisk,
+      reviewRouting: {
+        decision: reviewRouting.decision,
+        requiresStop: reviewRouting.requiresStop,
+        forceReviewApplied: reviewRouting.forceReviewApplied,
+      },
       spec: {
         ...currentState.spec,
         prdId,
@@ -825,6 +841,9 @@ export async function runSpecPhase(
       },
     },
   });
+
+  Logger.info(`[epic-plan-spec] Review routing: ${reviewRouting.decision}.`);
+  Logger.info(`[epic-plan-spec] ${reviewRouting.operatorMessage}`);
 
   Logger.info(
     `[epic-plan-spec] Flipping Epic #${epicId} to ${AGENT_LABELS.REVIEW_SPEC}...`,
@@ -861,6 +880,8 @@ export async function runSpecPhase(
     checkpoint,
     cleanup,
     freshness,
+    planningRisk,
+    reviewRouting,
   };
 }
 
@@ -873,6 +894,7 @@ async function main() {
       techspec: { type: 'string' },
       'acceptance-spec': { type: 'string' },
       force: { type: 'boolean', default: false },
+      'force-review': { type: 'boolean', default: false },
       'emit-context': { type: 'boolean', default: false },
       pretty: { type: 'boolean', default: false },
       'full-context': { type: 'boolean', default: false },
@@ -959,7 +981,7 @@ async function main() {
     provider,
     { prdContent, techSpecContent, acceptanceSpecContent },
     settings,
-    { force: values.force },
+    { force: values.force, forceReview: values['force-review'] },
   );
 
   process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);

--- a/.agents/scripts/epic-plan-spec.js
+++ b/.agents/scripts/epic-plan-spec.js
@@ -70,6 +70,7 @@ import {
 } from './lib/orchestration/epic-plan-state-store.js';
 import { sweepStaleStoryWorktrees } from './lib/orchestration/plan-runner/worktree-sweep.js';
 import { applyBudget } from './lib/orchestration/planning-context-budget.js';
+import { classifyPlanningRisk } from './lib/orchestration/planning-risk.js';
 import { PlanningStateManager } from './lib/orchestration/planning-state-manager.js';
 import {
   renderSpecFreshnessComment,
@@ -232,6 +233,15 @@ export async function buildAuthoringContext(
     Logger.warn(`[epic-plan-spec] codebase snapshot skipped: ${err.message}`);
   }
 
+  // Story #2791 — deterministic planning-risk envelope for gate routing
+  // and acceptance disposition. Pure classification over Epic metadata;
+  // no GitHub mutation on the emit-context path.
+  const planningRisk = classifyPlanningRisk({
+    title: epic.title,
+    body: epic.body ?? '',
+    labels: epic.labels ?? [],
+  });
+
   return {
     epic: {
       id: epic.id,
@@ -251,6 +261,7 @@ export async function buildAuthoringContext(
     bddScenarios,
     memoryFreshness,
     priorFeedback,
+    planningRisk,
   };
 }
 

--- a/.agents/scripts/epic-plan.js
+++ b/.agents/scripts/epic-plan.js
@@ -76,6 +76,7 @@ export async function runSprintPlan({
   config,
   artifacts,
   force = false,
+  forceReview = false,
   apply = false,
   runSpec = runSpecPhase,
   runDecompose = runDecomposePhase,
@@ -111,7 +112,7 @@ export async function runSprintPlan({
       techSpecContent: artifacts.techSpecContent,
     },
     settings,
-    { force },
+    { force, forceReview },
   );
 
   const decomposeResult = await runDecompose(
@@ -159,6 +160,7 @@ async function main() {
       techspec: { type: 'string' },
       tickets: { type: 'string' },
       force: { type: 'boolean', default: false },
+      'force-review': { type: 'boolean', default: false },
       apply: { type: 'boolean', default: false },
       'describe-resume-point': { type: 'boolean', default: false },
     },
@@ -235,6 +237,7 @@ async function main() {
     config,
     artifacts: { prdContent, techSpecContent, tickets },
     force: values.force,
+    forceReview: values['force-review'],
     apply: values.apply,
   });
 

--- a/.agents/scripts/lib/orchestration/epic-plan-decompose/phases/cli.js
+++ b/.agents/scripts/lib/orchestration/epic-plan-decompose/phases/cli.js
@@ -34,13 +34,14 @@ const CLI_OPTIONS = {
   tickets: { type: 'string' },
   force: { type: 'boolean', default: false },
   resume: { type: 'boolean', default: false },
+  'allow-over-budget': { type: 'boolean', default: false },
   'emit-context': { type: 'boolean', default: false },
   pretty: { type: 'boolean', default: false },
   'full-context': { type: 'boolean', default: false },
 };
 
 const USAGE =
-  'Usage: epic-plan-decompose.js --epic <EpicId> (--emit-context [--pretty] [--full-context] | --tickets <file>) [--force | --resume]';
+  'Usage: epic-plan-decompose.js --epic <EpicId> (--emit-context [--pretty] [--full-context] | --tickets <file>) [--force | --resume] [--allow-over-budget]';
 
 function parseEpicId(rawEpic) {
   if (!rawEpic) throw new Error(USAGE);
@@ -81,11 +82,13 @@ async function runEmitContextPath({ epicId, provider, config, values }) {
   const ctx = await buildDecompositionContext(epicId, provider, config, {
     fullContext: values['full-context'],
   });
-  // Surface the resolved cap on stderr so a misconfigured `.agentrc.json`
-  // (e.g. flat-key `maxTickets` instead of grouped `limits.maxTickets`) is
+  // Surface the resolved budget on stderr so a misconfigured `.agentrc.json`
+  // (e.g. flat-key `maxTickets` instead of grouped `planning.maxTickets`) is
   // visible to the operator. The decomposer prompt embeds the same value.
+  // Story #2798 — language changed from "prompt cap" to "reviewability
+  // budget" to match the new prompt/skill contract.
   Logger.error(
-    `[epic-plan-decompose] Resolved limits.maxTickets = ${ctx.maxTickets} (prompt cap).`,
+    `[epic-plan-decompose] Resolved planning.maxTickets = ${ctx.maxTickets} (reviewability budget).`,
   );
   const json = values.pretty
     ? JSON.stringify(ctx, null, 2)
@@ -116,6 +119,7 @@ async function runPersistPath({ epicId, provider, config, values }) {
     result = await runDecomposePhase(epicId, provider, { tickets }, config, {
       force: values.force,
       resume: values.resume,
+      allowOverBudget: values['allow-over-budget'],
     });
   } catch (err) {
     await reportPartialFailure({ epicId, provider, err });

--- a/.agents/scripts/lib/orchestration/epic-plan-decompose/phases/context.js
+++ b/.agents/scripts/lib/orchestration/epic-plan-decompose/phases/context.js
@@ -14,6 +14,7 @@
 
 import { getLimits } from '../../../config-resolver.js';
 import { renderDecomposerSystemPrompt } from '../../../templates/decomposer-prompts.js';
+import { read as readPlanState } from '../../epic-plan-state-store.js';
 import { applyBudget } from '../../planning-context-budget.js';
 
 export function buildDecomposerSystemPrompt(
@@ -38,6 +39,41 @@ function resolveHeuristics(config) {
 function projectBudgetedEntry(item, ticket, mode) {
   if (mode === 'full') return { id: ticket.id, body: ticket.body };
   return { id: ticket.id, body: null, bodySummary: item };
+}
+
+/**
+ * Read the persisted planning decision for the Epic so the decomposition
+ * authoring step (Phase 8) can cite the same risk classification the
+ * gate routing used in Phase 7. The decision lives in the `epic-plan-state`
+ * structured comment written by `epic-plan-spec.js`.
+ *
+ * Returns `{ planningRisk: null, reviewRouting: null }` when the comment
+ * is missing (older plans planned before Story #2801 landed) or when the
+ * payload predates the fields. The null sentinels are part of the
+ * decomposition context contract — callers MUST be able to JSON.stringify
+ * the result without losing the keys.
+ *
+ * @param {import('../../../ITicketingProvider.js').ITicketingProvider} provider
+ * @param {number} epicId
+ * @returns {Promise<{ planningRisk: object | null, reviewRouting: object | null }>}
+ */
+async function readPlanningDecision(provider, epicId) {
+  let state = null;
+  try {
+    state = await readPlanState({ provider, epicId });
+  } catch (_err) {
+    // `read` already swallows JSON parse errors; a thrown error here
+    // means the provider couldn't fetch comments. Treat as null state —
+    // the decomposer can still author tickets without the risk envelope.
+    state = null;
+  }
+  if (!state || typeof state !== 'object') {
+    return { planningRisk: null, reviewRouting: null };
+  }
+  return {
+    planningRisk: state.planningRisk ?? null,
+    reviewRouting: state.reviewRouting ?? null,
+  };
 }
 
 async function fetchPlanningTickets(provider, epicId) {
@@ -69,6 +105,10 @@ export async function buildDecompositionContext(
   opts = {},
 ) {
   const { epic, prd, techSpec } = await fetchPlanningTickets(provider, epicId);
+  const { planningRisk, reviewRouting } = await readPlanningDecision(
+    provider,
+    epicId,
+  );
   const heuristics = resolveHeuristics(config);
   const limits = getLimits(config);
   const maxTickets = limits.maxTickets;
@@ -93,5 +133,11 @@ export async function buildDecompositionContext(
     systemPrompt,
     maxTickets,
     contextMode: budgeted.mode,
+    // Story #2801 — surface the Phase 7 planning decision so the
+    // decomposition authoring step can cite the same risk
+    // classification used by gate routing. Both fields are `null`
+    // when the Epic was planned before the decision contract existed.
+    planningRisk,
+    reviewRouting,
   };
 }

--- a/.agents/scripts/lib/orchestration/epic-plan-decompose/phases/creation.js
+++ b/.agents/scripts/lib/orchestration/epic-plan-decompose/phases/creation.js
@@ -182,13 +182,29 @@ export function assertEpicHasPlanningArtifacts(epic, epicId) {
   }
 }
 
+/**
+ * Advisory-only ticket-count check (Story #2798).
+ *
+ * `maxTickets` is a **reviewability budget**, not a hard authoring cap.
+ * This helper emits a non-destructive warning when a decomposition meets
+ * or exceeds the budget so the operator can spot over-budget plans early
+ * in the persist flow. It never blocks — the hard gate lives in the
+ * `runDecomposePhase` over-budget check, which requires an explicit
+ * `allowOverBudget` (CLI: `--allow-over-budget`) override.
+ *
+ * @param {Array} tickets
+ * @param {number} maxTickets — the reviewability budget
+ * @param {string} [tag] — log prefix
+ * @param {{ logger?: Pick<typeof Logger, 'warn'> }} [opts]
+ */
 export function warnTicketCapNearLimit(
   tickets,
   maxTickets,
   tag = 'epic-plan-decompose',
+  { logger = Logger } = {},
 ) {
   if (tickets.length < maxTickets) return;
-  Logger.warn(
-    `[${tag}] ⚠️  Received ${tickets.length} tickets (at or above the ${maxTickets}-ticket cap). Verify every Story still has child Tasks or split the Epic into smaller scopes.`,
+  logger.warn(
+    `[${tag}] ⚠️  Received ${tickets.length} tickets against a reviewability budget of ${maxTickets}. Verify every Story still has child Tasks; over-budget persistence requires --allow-over-budget.`,
   );
 }

--- a/.agents/scripts/lib/orchestration/epic-plan-decompose/phases/persist.js
+++ b/.agents/scripts/lib/orchestration/epic-plan-decompose/phases/persist.js
@@ -54,7 +54,7 @@ import { RECONCILE_CLI, spawnReconcilerApply } from './reconcile-spawn.js';
  * @param {import('../../../ITicketingProvider.js').ITicketingProvider} provider
  * @param {{ tickets: Array<object> }} payload
  * @param {object} config
- * @param {{ force?: boolean, resume?: boolean, spawnSync?: typeof defaultSpawnSync, reconcileCli?: string, writeSpecFn?: typeof writeSpec, renderSpecFn?: typeof renderSpec, cwd?: string }} [opts]
+ * @param {{ force?: boolean, resume?: boolean, allowOverBudget?: boolean, spawnSync?: typeof defaultSpawnSync, reconcileCli?: string, writeSpecFn?: typeof writeSpec, renderSpecFn?: typeof renderSpec, cwd?: string }} [opts]
  */
 export async function runDecomposePhase(
   epicId,
@@ -64,6 +64,7 @@ export async function runDecomposePhase(
   {
     force = false,
     resume = false,
+    allowOverBudget = false,
     spawnSync = defaultSpawnSync,
     reconcileCli = RECONCILE_CLI,
     writeSpecFn = writeSpec,
@@ -78,7 +79,22 @@ export async function runDecomposePhase(
   }
   const epic = await provider.getEpic(epicId);
   assertDecomposeInputs(epic, epicId, tickets);
-  warnTicketCapNearLimit(tickets, getLimits(config).maxTickets);
+  const maxTickets = getLimits(config).maxTickets;
+  // Story #2798 — `maxTickets` is a reviewability budget. Over-budget
+  // persistence requires an explicit `--allow-over-budget` override so
+  // an accidental over-budget plan does not silently land.
+  if (tickets.length > maxTickets && !allowOverBudget) {
+    throw new Error(
+      `[epic-plan-decompose] Tickets (${tickets.length}) exceed the reviewability budget (${maxTickets}). ` +
+        `Re-scope the Epic into a smaller plan, or rerun with --allow-over-budget after confirming the over-budget rationale on the Epic.`,
+    );
+  }
+  warnTicketCapNearLimit(tickets, maxTickets);
+  if (tickets.length > maxTickets && allowOverBudget) {
+    Logger.warn(
+      `[epic-plan-decompose] Persisting an over-budget decomposition: ${tickets.length} tickets vs. budget ${maxTickets} (operator override --allow-over-budget).`,
+    );
+  }
   await seedPlanState(provider, epicId, epic);
 
   Logger.info(

--- a/.agents/scripts/lib/orchestration/epic-plan-state-store.js
+++ b/.agents/scripts/lib/orchestration/epic-plan-state-store.js
@@ -21,6 +21,8 @@
  *   "lastUpdatedAt": "...",
  *   "spec": { "prdId": null, "techSpecId": null, "acceptanceSpecId": null, "completedAt": null },
  *   "decompose": { "ticketCount": null, "completedAt": null },
+ *   "planningRisk": { "overallLevel": "...", "requiresReview": true, "gateDecision": "..." },
+ *   "reviewRouting": { "decision": "review-required|auto-proceed|operator-override-review", "requiresStop": true, "forceReviewApplied": false },
  *   "manifestCommentId": null
  * }
  * ```

--- a/.agents/scripts/lib/orchestration/plan-review-routing.js
+++ b/.agents/scripts/lib/orchestration/plan-review-routing.js
@@ -1,0 +1,62 @@
+/**
+ * plan-review-routing.js — resolve Phase 7 review-stop vs auto-proceed.
+ *
+ * Pure ESM, no I/O. Consumes the shared {@link classifyPlanningRisk}
+ * envelope and optional operator overrides to decide whether the plan
+ * wrapper should STOP for human review before Phase 8.
+ */
+
+/**
+ * @typedef {import('./planning-risk.js').PlanningRiskEnvelope} PlanningRiskEnvelope
+ * @typedef {'review-required' | 'auto-proceed' | 'operator-override-review'} ReviewRoutingDecision
+ */
+
+/**
+ * @typedef {Object} ReviewRoutingEnvelope
+ * @property {ReviewRoutingDecision} decision
+ * @property {boolean} requiresStop
+ * @property {boolean} forceReviewApplied
+ * @property {string} operatorMessage
+ */
+
+const AUTO_PROCEED_MESSAGE =
+  'Planning risk is low — auto-proceeding to Phase 8 decomposition after spec validation. Context tickets remain open until Epic delivery finalizes.';
+
+const REVIEW_REQUIRED_MESSAGE =
+  'Planning risk requires operator review — STOP before Phase 8. Review the PRD, Tech Spec, and Acceptance Spec on GitHub and confirm in this session before decomposition.';
+
+const FORCE_REVIEW_MESSAGE =
+  'Operator override — forcing review stop before Phase 8 despite low planning risk.';
+
+/**
+ * Resolve whether Phase 7 should STOP for operator review before Phase 8.
+ *
+ * @param {{ planningRisk: PlanningRiskEnvelope, forceReview?: boolean }} input
+ * @returns {ReviewRoutingEnvelope}
+ */
+export function resolveReviewRouting({ planningRisk, forceReview = false }) {
+  if (forceReview) {
+    return {
+      decision: 'operator-override-review',
+      requiresStop: true,
+      forceReviewApplied: true,
+      operatorMessage: FORCE_REVIEW_MESSAGE,
+    };
+  }
+
+  if (planningRisk.requiresReview) {
+    return {
+      decision: 'review-required',
+      requiresStop: true,
+      forceReviewApplied: false,
+      operatorMessage: REVIEW_REQUIRED_MESSAGE,
+    };
+  }
+
+  return {
+    decision: 'auto-proceed',
+    requiresStop: false,
+    forceReviewApplied: false,
+    operatorMessage: AUTO_PROCEED_MESSAGE,
+  };
+}

--- a/.agents/scripts/lib/orchestration/planning-risk.js
+++ b/.agents/scripts/lib/orchestration/planning-risk.js
@@ -78,7 +78,8 @@ const AXIS_RULES = [
   {
     axis: 'security',
     level: 'high',
-    pattern: /\b(?:security|authentication|auth(?:entication)?|authorization)\b/i,
+    pattern:
+      /\b(?:security|authentication|auth(?:entication)?|authorization)\b/i,
     evidenceFor: (snippet) => `Security signal: ${trimSnippet(snippet)}`,
   },
   {
@@ -254,7 +255,10 @@ export function classifyPlanningRisk(input = {}) {
   }
 
   const overallLevel = resolveOverallLevel(axes);
-  const acceptanceDisposition = resolveAcceptanceDisposition(axes, overallLevel);
+  const acceptanceDisposition = resolveAcceptanceDisposition(
+    axes,
+    overallLevel,
+  );
   const requiresReview = resolveRequiresReview(overallLevel, axes);
   const gateDecision = requiresReview ? 'review-required' : 'auto-proceed';
 

--- a/.agents/scripts/lib/orchestration/planning-risk.js
+++ b/.agents/scripts/lib/orchestration/planning-risk.js
@@ -1,7 +1,28 @@
 /**
  * planning-risk.js — deterministic Epic planning risk classifier.
  *
- * Stub placeholder for RED test coverage (Task #2790).
+ * Pure ESM, no I/O. Reads Epic title/body/labels and returns a stable
+ * planningRisk envelope for gate routing and acceptance disposition.
+ */
+
+/** @typedef {'low' | 'medium' | 'high'} RiskLevel */
+/** @typedef {'required' | 'recommended' | 'not-applicable'} AcceptanceDisposition */
+/** @typedef {'review-required' | 'auto-proceed'} GateDecision */
+
+/**
+ * @typedef {Object} PlanningRiskAxis
+ * @property {string} axis
+ * @property {RiskLevel} level
+ * @property {string} evidence
+ */
+
+/**
+ * @typedef {Object} PlanningRiskEnvelope
+ * @property {PlanningRiskAxis[]} axes
+ * @property {RiskLevel} overallLevel
+ * @property {boolean} requiresReview
+ * @property {AcceptanceDisposition} acceptanceDisposition
+ * @property {GateDecision} gateDecision
  */
 
 /** Closed axis vocabulary for planning risk classification. */
@@ -18,15 +39,230 @@ export const PLANNING_RISK_AXES = Object.freeze([
   'test-harness',
 ]);
 
+const LEVEL_RANK = Object.freeze({ low: 0, medium: 1, high: 2 });
+
+const REQUIRED_AXES = new Set([
+  'visible-behavior',
+  'public-api',
+  'security',
+  'data-migration',
+  'billing',
+  'destructive-mutation',
+  'critical-workflow',
+]);
+
+const NOT_APPLICABLE_AXES = new Set([
+  'docs-only',
+  'test-harness',
+  'internal-refactor',
+]);
+
 /**
- * @param {{ title?: string, body?: string, labels?: string[] }} [_input]
+ * @typedef {Object} AxisRule
+ * @property {string} axis
+ * @property {RiskLevel} level
+ * @property {RegExp} pattern
+ * @property {(snippet: string) => string} evidenceFor
  */
-export function classifyPlanningRisk(_input = {}) {
+
+/** @type {AxisRule[]} */
+const AXIS_RULES = [
+  {
+    axis: 'critical-workflow',
+    level: 'high',
+    pattern:
+      /\b(?:\/epic-plan|epic-plan|orchestrat(?:ion|e)|critical\s+workflow|gate\s+(?:behavior|routing)|acceptance-spec\s+creation)\b/i,
+    evidenceFor: (snippet) =>
+      `Critical workflow signal: ${trimSnippet(snippet)}`,
+  },
+  {
+    axis: 'security',
+    level: 'high',
+    pattern: /\b(?:security|authentication|auth(?:entication)?|authorization)\b/i,
+    evidenceFor: (snippet) => `Security signal: ${trimSnippet(snippet)}`,
+  },
+  {
+    axis: 'public-api',
+    level: 'high',
+    pattern: /\b(?:public\s+api|api\s+contract|breaking\s+api)\b/i,
+    evidenceFor: (snippet) => `Public API signal: ${trimSnippet(snippet)}`,
+  },
+  {
+    axis: 'visible-behavior',
+    level: 'high',
+    pattern:
+      /\b(?:user-facing|operator-visible|visible\s+behavior|ui\s+change)\b/i,
+    evidenceFor: (snippet) =>
+      `Visible behavior signal: ${trimSnippet(snippet)}`,
+  },
+  {
+    axis: 'data-migration',
+    level: 'high',
+    pattern: /\b(?:data\s+migration|schema\s+migration|migrate\s+data)\b/i,
+    evidenceFor: (snippet) => `Data migration signal: ${trimSnippet(snippet)}`,
+  },
+  {
+    axis: 'billing',
+    level: 'high',
+    pattern: /\b(?:billing|payment|stripe|subscription)\b/i,
+    evidenceFor: (snippet) => `Billing signal: ${trimSnippet(snippet)}`,
+  },
+  {
+    axis: 'destructive-mutation',
+    level: 'high',
+    pattern:
+      /\b(?:destructive|drop\s+table|delete\s+user\s+data|irreversible)\b/i,
+    evidenceFor: (snippet) =>
+      `Destructive mutation signal: ${trimSnippet(snippet)}`,
+  },
+  {
+    axis: 'internal-refactor',
+    level: 'low',
+    pattern: /\b(?:internal\s+refactor|refactor(?:ing)?(?:\s+only)?)\b/i,
+    evidenceFor: (snippet) =>
+      `Internal refactor signal: ${trimSnippet(snippet)}`,
+  },
+  {
+    axis: 'test-harness',
+    level: 'low',
+    pattern: /\b(?:test\s+harness|test\s+infrastructure)\b/i,
+    evidenceFor: (snippet) => `Test harness signal: ${trimSnippet(snippet)}`,
+  },
+  {
+    axis: 'docs-only',
+    level: 'low',
+    pattern: /\b(?:docs-only|documentation\s+only|readme|prose\s+cleanup)\b/i,
+    evidenceFor: (snippet) => `Docs-only signal: ${trimSnippet(snippet)}`,
+  },
+];
+
+const CLEANUP_PATTERN = /\b(?:cleanup|chore-only|housekeeping)\b/i;
+
+/**
+ * @param {string} text
+ * @returns {string}
+ */
+function trimSnippet(text) {
+  const collapsed = text.replace(/\s+/g, ' ').trim();
+  if (collapsed.length <= 80) return collapsed;
+  return `${collapsed.slice(0, 77)}...`;
+}
+
+/**
+ * @param {string} haystack
+ * @param {RegExp} pattern
+ * @returns {string|null}
+ */
+function firstMatchSnippet(haystack, pattern) {
+  const match = haystack.match(pattern);
+  if (!match || typeof match.index !== 'number') return null;
+  const start = Math.max(0, match.index - 20);
+  const end = Math.min(haystack.length, match.index + match[0].length + 40);
+  return haystack.slice(start, end);
+}
+
+/**
+ * @param {PlanningRiskAxis[]} axes
+ * @returns {RiskLevel}
+ */
+function resolveOverallLevel(axes) {
+  if (axes.length === 0) return 'low';
+  return axes.reduce(
+    (highest, entry) =>
+      LEVEL_RANK[entry.level] > LEVEL_RANK[highest] ? entry.level : highest,
+    'low',
+  );
+}
+
+/**
+ * @param {PlanningRiskAxis[]} axes
+ * @param {RiskLevel} overallLevel
+ * @returns {AcceptanceDisposition}
+ */
+function resolveAcceptanceDisposition(axes, overallLevel) {
+  if (axes.some((entry) => REQUIRED_AXES.has(entry.axis))) {
+    return 'required';
+  }
+  if (
+    overallLevel === 'medium' ||
+    axes.some((entry) => entry.level === 'medium')
+  ) {
+    return 'recommended';
+  }
+  if (
+    axes.length > 0 &&
+    axes.every((entry) => NOT_APPLICABLE_AXES.has(entry.axis))
+  ) {
+    return 'not-applicable';
+  }
+  if (overallLevel === 'low') return 'not-applicable';
+  return 'recommended';
+}
+
+/**
+ * @param {RiskLevel} overallLevel
+ * @param {PlanningRiskAxis[]} axes
+ * @returns {boolean}
+ */
+function resolveRequiresReview(overallLevel, axes) {
+  if (overallLevel === 'high') return true;
+  if (overallLevel === 'medium') {
+    return axes.some(
+      (entry) =>
+        entry.level === 'medium' &&
+        (REQUIRED_AXES.has(entry.axis) || entry.axis === 'visible-behavior'),
+    );
+  }
+  return false;
+}
+
+/**
+ * Classify planning risk for an Epic without mutating GitHub state.
+ *
+ * @param {{ title?: string, body?: string, labels?: string[] }} [input]
+ * @returns {PlanningRiskEnvelope}
+ */
+export function classifyPlanningRisk(input = {}) {
+  const title = typeof input.title === 'string' ? input.title : '';
+  const body = typeof input.body === 'string' ? input.body : '';
+  const labels = Array.isArray(input.labels) ? input.labels : [];
+  const haystack = `${title}\n${body}\n${labels.join('\n')}`;
+
+  /** @type {PlanningRiskAxis[]} */
+  const axes = [];
+
+  for (const rule of AXIS_RULES) {
+    const snippet = firstMatchSnippet(haystack, rule.pattern);
+    if (!snippet) continue;
+    axes.push({
+      axis: rule.axis,
+      level: rule.level,
+      evidence: rule.evidenceFor(snippet),
+    });
+  }
+
+  if (
+    axes.length === 0 &&
+    CLEANUP_PATTERN.test(haystack) &&
+    !/\b(?:security|auth|api|billing|migration)\b/i.test(haystack)
+  ) {
+    axes.push({
+      axis: 'docs-only',
+      level: 'low',
+      evidence: 'Cleanup-only scope with no high-risk axis signals.',
+    });
+  }
+
+  const overallLevel = resolveOverallLevel(axes);
+  const acceptanceDisposition = resolveAcceptanceDisposition(axes, overallLevel);
+  const requiresReview = resolveRequiresReview(overallLevel, axes);
+  const gateDecision = requiresReview ? 'review-required' : 'auto-proceed';
+
   return {
-    axes: [],
-    overallLevel: 'low',
-    requiresReview: false,
-    acceptanceDisposition: 'not-applicable',
-    gateDecision: 'auto-proceed',
+    axes,
+    overallLevel,
+    requiresReview,
+    acceptanceDisposition,
+    gateDecision,
   };
 }

--- a/.agents/scripts/lib/orchestration/planning-risk.js
+++ b/.agents/scripts/lib/orchestration/planning-risk.js
@@ -1,0 +1,32 @@
+/**
+ * planning-risk.js — deterministic Epic planning risk classifier.
+ *
+ * Stub placeholder for RED test coverage (Task #2790).
+ */
+
+/** Closed axis vocabulary for planning risk classification. */
+export const PLANNING_RISK_AXES = Object.freeze([
+  'visible-behavior',
+  'public-api',
+  'security',
+  'data-migration',
+  'billing',
+  'destructive-mutation',
+  'critical-workflow',
+  'internal-refactor',
+  'docs-only',
+  'test-harness',
+]);
+
+/**
+ * @param {{ title?: string, body?: string, labels?: string[] }} [_input]
+ */
+export function classifyPlanningRisk(_input = {}) {
+  return {
+    axes: [],
+    overallLevel: 'low',
+    requiresReview: false,
+    acceptanceDisposition: 'not-applicable',
+    gateDecision: 'auto-proceed',
+  };
+}

--- a/.agents/scripts/lib/templates/decomposer-prompts.js
+++ b/.agents/scripts/lib/templates/decomposer-prompts.js
@@ -124,5 +124,10 @@ This prevents the executing agent from redoing work the upstream Story already m
 
 CRITICAL: Dependencies should follow execution blockers. For hierarchical grouping, strongly strictly use 'parent_slug' (Story parent MUST be a Feature, Task parent MUST be a Story). Features should have no 'parent_slug' (they attach to Epic).
 IMPORTANT DEPENDENCY RULE: A Task's \`depends_on\` MUST only reference other Tasks within the SAME Story (same parent_slug). Cross-story task dependencies are FORBIDDEN. If two Stories have a logical ordering requirement, add the dependency at the STORY level (one Story depends_on the other Story's slug), NOT between their child Tasks.
-WARNING: You MUST conserve your output limit. Do NOT generate more than ${maxTickets} tickets in total. Combine atomic tasks into larger, cohesive tasks. Do NOT cut off the JSON array prematurely!`;
+
+### REVIEWABILITY BUDGET (Story #2798):
+\`maxTickets = ${maxTickets}\` is a **reviewability budget**, not a hard authoring cap. It marks the count of tickets a human operator can comfortably review in one planning pass; emitting more than this overflows the operator's review window. Default behaviour:
+- **Stay at or under the budget when possible.** Combine atomic tasks into larger, cohesive tasks before splitting; small Stories should merge back into siblings rather than spawn their own container.
+- **Do NOT truncate or over-compress to fit.** If the plan genuinely needs more tickets than the budget, emit the full plan anyway and add a compact \`over_budget_rationale\` string at the top of the FIRST Feature's \`body\` explaining (a) why the plan exceeds the budget and (b) what was already merged to keep the count down. The operator will then either accept the plan by re-running the decompose with the explicit \`--allow-over-budget\` override flag, or push back and ask for a re-scope.
+- **Never stop mid-array.** Always emit complete JSON — partial arrays are rejected by the validator.`;
 }

--- a/.agents/skills/core/epic-plan-decompose-author/SKILL.md
+++ b/.agents/skills/core/epic-plan-decompose-author/SKILL.md
@@ -18,7 +18,7 @@ allowed_tools:
 - Run only after `epic-plan-decompose.js --emit-context` has written `temp/epic-<Epic_ID>/decomposer-context.json`; fail loudly if the file is missing.
 - Emit exactly one artifact: `temp/epic-<Epic_ID>/tickets.json` (a JSON array). Do not write anywhere else, and never call the GitHub API from this Skill — persistence belongs to the script.
 - Output is JSON only — no prose, no Markdown fence. The downstream validator (`lib/orchestration/ticket-validator.js`) is the authoritative gate; re-author rather than hand-patching when it rejects.
-- Respect the **`maxTickets` cap** from the context envelope as a hard ceiling. Combine atomic Tasks rather than spilling over; splitting past the cap means re-scoping the Epic.
+- Treat **`maxTickets`** from the context envelope as a **reviewability budget**, not a hard authoring cap (Story #2798). Combine atomic Tasks first; if the plan genuinely needs more, emit the full plan and add a compact `over_budget_rationale` field at the top of the first Feature's `body` explaining why the plan exceeds the budget. Operator persistence then requires the explicit `--allow-over-budget` override on `epic-plan-decompose.js`; without it the persist step rejects the over-budget array. Never truncate the JSON array to fit.
 - Honour the three-level hierarchy: **Feature → Story → Task**. Every Story MUST decompose into at least one Task (typically 2–5); empty Story containers are invalid.
 - Every ticket carries `type::[feature|story|task]` and `persona::*` labels; every Task body is a structured object with `goal`, `changes[]` (object form `{ path, assumption }`), `acceptance[]`, `verify[]`, and optional `references[]`.
 - **New-File Contract**: any path referenced in `goal`, `acceptance`, or `verify` that does not exist on `main` MUST appear in the Task's `changes[]` with `assumption: "creates"`; otherwise the freshness validator rejects the decompose.
@@ -59,10 +59,12 @@ reads:
   - `heuristics[]` — risk heuristics surfaced from
     `agentSettings.planning.riskHeuristics`. Apply each one against the
     Stories you are emitting; flag matches via `risk::high` labels.
-  - `maxTickets` — hard cap from `agentSettings.limits.maxTickets`. Do
-    not exceed it. The script also logs the resolved value to stderr;
-    if the prompt cap and the script log disagree, the script wins
-    (the validator enforces it).
+  - `maxTickets` — reviewability budget from
+    `agentSettings.planning.maxTickets` (Story #2798). Default: stay
+    under. When the plan genuinely needs more, emit the full plan with
+    an `over_budget_rationale` and rely on the operator's
+    `--allow-over-budget` override at persist time. The script logs the
+    resolved value to stderr.
   - `contextMode` — `"full"` or `"summary"`. When `"summary"`, work
     from the `bodySummary` fields rather than re-fetching the bodies.
 
@@ -88,8 +90,9 @@ its rules, not for "looks right."
 Read `temp/epic-<Epic_ID>/decomposer-context.json` with the `Read` tool.
 Pin three values explicitly before writing any tickets:
 
-1. `maxTickets` — your hard ceiling. Combine atomic Tasks rather than
-   spilling over the cap.
+1. `maxTickets` — your reviewability budget. Combine atomic Tasks rather
+   than spilling over the budget; if the plan genuinely needs more, emit
+   the full plan with an `over_budget_rationale` (Story #2798).
 2. `contextMode` — if `"summary"`, the body strings are bounded; trust
    them, but keep Tasks more conservative because the upstream context
    is partial.
@@ -118,8 +121,10 @@ the Epic to `agent::ready`.
 
 ## Decomposer system prompt (authoritative)
 
-The cap `${maxTickets}` is substituted at runtime from the
-`maxTickets` field in the loaded context. Treat it as a hard ceiling.
+The value `${maxTickets}` is substituted at runtime from the
+`maxTickets` field in the loaded context. Treat it as the reviewability
+budget (Story #2798) — stay under by default; over-budget plans need an
+`over_budget_rationale` plus operator `--allow-over-budget` to persist.
 
 ```text
 You are an expert Senior Project Manager and Orchestrator.
@@ -273,8 +278,11 @@ WARNING: You MUST conserve your output limit. Do NOT generate more than ${maxTic
   script's job; the Skill is pure JSON authoring.
 - Do **not** write outside `temp/epic-<Epic_ID>/`. Reads may cover the
   PRD/Tech Spec bodies plus any docs the context envelope cites.
-- The decomposer prompt's `${maxTickets}` cap is **canonical**. Splitting
-  past the cap means re-scoping the Epic, not silently exceeding it.
+- The decomposer prompt's `${maxTickets}` value is the **reviewability
+  budget** (Story #2798). Staying under is the default; exceeding it
+  requires both an `over_budget_rationale` in the JSON output and the
+  operator's `--allow-over-budget` flag at persist time. Silently
+  exceeding the budget — or truncating the plan to fit — is forbidden.
 - If `temp/epic-<Epic_ID>/decomposer-context.json` is missing, fail
   loudly. Instruct the caller to run `--emit-context` first.
 - The validator

--- a/.agents/skills/core/epic-plan-spec-author/SKILL.md
+++ b/.agents/skills/core/epic-plan-spec-author/SKILL.md
@@ -84,6 +84,24 @@ reads:
     as before. Non-empty means the Acceptance Engineer step MUST run
     `findBestScenarioMatch` for each planned AC and annotate the
     Disposition column accordingly (see Step 4).
+  - `planningRisk` — deterministic risk envelope computed in Phase 7
+    (Epic #2649). Shape: `{ axes[], overallLevel, requiresReview,
+    acceptanceDisposition, gateDecision }`. Use it as authoring
+    signal across all three artifacts:
+    - **PRD** — summarize the risk decision in the Context & Goals
+      section so reviewers see why the gate routing is what it is.
+    - **Tech Spec** — cite `planningRisk.axes` when designing
+      gating behavior (e.g. when the Epic is high-risk on the
+      `critical-workflow` axis, the spec should call out the
+      review-required path explicitly).
+    - **Acceptance Spec** — branch on
+      `planningRisk.acceptanceDisposition`. `required` and
+      `recommended` author the spec normally. `not-applicable`
+      authorizes the persist half to apply `acceptance::n-a` on the
+      Epic; in that case write a one-paragraph waiver rationale to
+      `temp/epic-<Epic_ID>/acceptance-spec.md` instead of the AC
+      table so the audit trail still exists, and start the file with
+      `## Acceptance Criteria — waived (planner-selected)`.
 
 ## Outputs
 

--- a/.agents/workflows/epic-plan.md
+++ b/.agents/workflows/epic-plan.md
@@ -34,6 +34,9 @@ artifacts you author.
 - Wait for user validation before migrating to Phase 8 when
   `planningRisk.requiresReview` is true (or the operator passes
   `--force-review`). Low-risk Epics auto-proceed after spec validation.
+  See [SDLC § Adaptive planning risk routing](../SDLC.md#adaptive-planning-risk-routing)
+  for the full envelope shape and the planner-selected
+  `acceptance::n-a` route.
 - Delegate Phase 7 and Phase 8 to the
   [`helpers/epic-plan-spec.md`](helpers/epic-plan-spec.md) and
   [`helpers/epic-plan-decompose.md`](helpers/epic-plan-decompose.md)

--- a/.agents/workflows/epic-plan.md
+++ b/.agents/workflows/epic-plan.md
@@ -31,7 +31,9 @@ artifacts you author.
 ## Constraint
 
 - Do not modify existing issues without explicit permission.
-- Wait for user validation before migrating to Phase 8.
+- Wait for user validation before migrating to Phase 8 when
+  `planningRisk.requiresReview` is true (or the operator passes
+  `--force-review`). Low-risk Epics auto-proceed after spec validation.
 - Delegate Phase 7 and Phase 8 to the
   [`helpers/epic-plan-spec.md`](helpers/epic-plan-spec.md) and
   [`helpers/epic-plan-decompose.md`](helpers/epic-plan-decompose.md)
@@ -328,19 +330,27 @@ for the scoring logic.
      --techspec temp/epic-[Epic_ID]/techspec.md
    ```
 
-4. **Verification**:
+4. **Verification and review routing**:
    - Verify that the PRD, Technical Specification, and (when not waived)
      Acceptance Specification have been posted as linked issues under
      the Epic.
-   - **STOP**: Ask the USER to review the generated PRD, Tech Spec, and
-     Acceptance Spec on GitHub. Approval is the user's verbal OK in this
-     session — the three context tickets stay **open** through delivery
-     and are closed automatically by `epic-deliver-finalize.js` once the
-     Epic PR opens. `/epic-deliver`'s start gate only requires that the
-     Acceptance Spec is linked (or that the Epic carries the
-     `acceptance::n-a` waiver); it does not require manual closure. Do
-     NOT proceed to decomposition until the user confirms the plan is
-     accurate.
+   - Read `planningRisk` from the persist stdout JSON (or the
+     `epic-plan-state` checkpoint). Branch on
+     `planningRisk.requiresReview` unless the operator passed
+     `--force-review`:
+     - **High risk** (`requiresReview === true`) or **operator override**
+       (`--force-review`): **STOP**. Ask the USER to review the generated
+       PRD, Tech Spec, and Acceptance Spec on GitHub. Approval is the
+       user's verbal OK in this session — the three context tickets stay
+       **open** through delivery and are closed automatically by
+       `epic-deliver-finalize.js` once the Epic PR opens. Do NOT proceed
+       to decomposition until the user confirms the plan is accurate.
+     - **Low risk** (`requiresReview === false` and no `--force-review`):
+       Emit the auto-proceed message from the persist stdout
+       (`reviewRouting.operatorMessage`) and **continue directly to Phase 8**
+       without an extra review stop. The Epic still carries
+       `agent::review-spec` until decomposition completes; the routing
+       decision is recorded in the `epic-plan-state` checkpoint.
 
 5. **Tech Spec freshness check (advisory)**: After the Tech Spec issue
    is created, `epic-plan-spec.js` runs

--- a/.agents/workflows/epic-plan.md
+++ b/.agents/workflows/epic-plan.md
@@ -343,7 +343,7 @@ for the scoring logic.
        PRD, Tech Spec, and Acceptance Spec on GitHub. Approval is the
        user's verbal OK in this session — the three context tickets stay
        **open** through delivery and are closed automatically by
-       `epic-deliver-finalize.js` once the Epic PR opens. Do NOT proceed
+       `/epic-deliver` when the Epic PR opens. Do NOT proceed
        to decomposition until the user confirms the plan is accurate.
      - **Low risk** (`requiresReview === false` and no `--force-review`):
        Emit the auto-proceed message from the persist stdout

--- a/.agents/workflows/helpers/epic-plan-decompose.md
+++ b/.agents/workflows/helpers/epic-plan-decompose.md
@@ -56,7 +56,9 @@ node .agents/scripts/epic-plan-decompose.js --epic [Epic_ID] --emit-context \
 ```
 
 The emitted JSON contains the PRD body, Tech Spec body, risk heuristics, the
-decomposer system prompt, and the `maxTickets` cap.
+decomposer system prompt, and the `maxTickets` **reviewability budget**
+(Story #2798 — not a hard cap; over-budget plans require an explicit
+`--allow-over-budget` override at persist time).
 
 ## Step 2 — Author the ticket array
 
@@ -74,6 +76,11 @@ node .agents/scripts/epic-plan-decompose.js --epic [Epic_ID] \
 # Re-decompose (closes existing child Features/Stories/Tasks first)
 node .agents/scripts/epic-plan-decompose.js --epic [Epic_ID] \
   --tickets temp/epic-[Epic_ID]/tickets.json --force
+
+# Persist an over-budget plan (Story #2798 — only after the operator
+# has confirmed the over_budget_rationale on the Epic)
+node .agents/scripts/epic-plan-decompose.js --epic [Epic_ID] \
+  --tickets temp/epic-[Epic_ID]/tickets.json --allow-over-budget
 ```
 
 On success the script:

--- a/.agents/workflows/helpers/epic-plan-spec.md
+++ b/.agents/workflows/helpers/epic-plan-spec.md
@@ -41,9 +41,11 @@ wrapper chains both helpers with a confirmation gate in between.
   label for the spec phase is `agent::review-spec`.
 - **Every** temp file must include the Epic ID in its name. Multiple Epics may
   be planned concurrently; bare names like `temp/prd.md` will collide.
-- **Stop and hand back to the operator** after Step 4 — do not chain into
-  decomposition. The human must confirm the PRD/Tech Spec on GitHub before the
-  next phase starts.
+- **Stop and hand back to the operator** after Step 4 when
+  `planningRisk.requiresReview` is true or the operator passed
+  `--force-review` — do not chain into decomposition. Low-risk Epics
+  auto-proceed to Phase 8 after the persist stdout confirms
+  `reviewRouting.decision === 'auto-proceed'`.
 
 ## Prerequisites
 
@@ -109,12 +111,19 @@ need to inspect the temp artefacts after the fact, re-run
 
 ## Handoff
 
-- **STOP** — do not proceed to decomposition. Surface the PRD and Tech Spec
+Branch on the shared planning risk decision surfaced in the persist stdout
+JSON (`planningRisk`, `reviewRouting`):
+
+- **High risk or `--force-review` — STOP.** Surface the PRD and Tech Spec
   URLs to the operator:
 
   > "Spec phase complete for Epic #[ID]. Review PRD (#XX) and Tech Spec (#YY)
   > on GitHub. When you're ready, re-run `/epic-plan [Epic_ID]` — the wrapper
   > will pick up where it left off and run the decompose phase."
+
+- **Low risk — auto-proceed.** Relay `reviewRouting.operatorMessage` and
+  continue directly to Phase 8 decomposition without waiting for verbal
+  approval in this session.
 
 ## Troubleshooting
 

--- a/baselines/crap.json
+++ b/baselines/crap.json
@@ -1,7 +1,7 @@
 {
   "$schema": ".agents/schemas/baselines/crap.schema.json",
   "kernelVersion": "0.1.0",
-  "generatedAt": "2026-05-20T19:33:20.406Z",
+  "generatedAt": "2026-05-21T02:04:57.373Z",
   "rollup": {
     "*": {
       "p50": 3,
@@ -5254,42 +5254,6 @@
       "method": "detectEpicCompletion",
       "startLine": 29,
       "crap": 4.000812884214804
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/epic-plan-state-store.js",
-      "method": "assertProvider",
-      "startLine": 51,
-      "crap": 2
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/epic-plan-state-store.js",
-      "method": "assertEpicId",
-      "startLine": 56,
-      "crap": 2
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/epic-plan-state-store.js",
-      "method": "read",
-      "startLine": 69,
-      "crap": 3.0146549969468754
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/epic-plan-state-store.js",
-      "method": "write",
-      "startLine": 92,
-      "crap": 1
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/epic-plan-state-store.js",
-      "method": "initialize",
-      "startLine": 114,
-      "crap": 2
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/epic-plan-state-store.js",
-      "method": "setPhase",
-      "startLine": 141,
-      "crap": 2
     },
     {
       "path": ".agents/scripts/lib/orchestration/epic-run-state-store.js",

--- a/baselines/crap.json
+++ b/baselines/crap.json
@@ -1,7 +1,7 @@
 {
   "$schema": ".agents/schemas/baselines/crap.schema.json",
   "kernelVersion": "0.1.0",
-  "generatedAt": "2026-05-21T02:04:57.373Z",
+  "generatedAt": "2026-05-21T10:38:47.579Z",
   "rollup": {
     "*": {
       "p50": 3,
@@ -9796,12 +9796,6 @@
       "method": "isBookendTask",
       "startLine": 22,
       "crap": 4
-    },
-    {
-      "path": ".agents/scripts/lib/templates/decomposer-prompts.js",
-      "method": "renderDecomposerSystemPrompt",
-      "startLine": 11,
-      "crap": 1
     },
     {
       "path": ".agents/scripts/lib/templates/task-body-renderer.js",

--- a/baselines/maintainability.json
+++ b/baselines/maintainability.json
@@ -1,7 +1,7 @@
 {
   "$schema": ".agents/schemas/baselines/maintainability.schema.json",
   "kernelVersion": "0.1.0",
-  "generatedAt": "2026-05-20T19:33:19.837Z",
+  "generatedAt": "2026-05-21T01:34:18.716Z",
   "rollup": {
     "*": {
       "min": 52.885,
@@ -113,10 +113,6 @@
     {
       "path": ".agents/scripts/epic-plan-healthcheck.js",
       "mi": 98.816
-    },
-    {
-      "path": ".agents/scripts/epic-plan-spec.js",
-      "mi": 71.178
     },
     {
       "path": ".agents/scripts/epic-plan.js",
@@ -2127,10 +2123,6 @@
       "mi": 107.32
     },
     {
-      "path": "tests/epic-planner.test.js",
-      "mi": 102.209
-    },
-    {
       "path": "tests/epic-runner/_build-ctx.js",
       "mi": 122.507
     },
@@ -3617,10 +3609,6 @@
     {
       "path": "tests/scripts/epic-plan-decompose.sub-issue-safety-net.test.js",
       "mi": 93.794
-    },
-    {
-      "path": "tests/scripts/epic-plan-emit-context-stdout-clean.test.js",
-      "mi": 106.737
     },
     {
       "path": "tests/scripts/epic-plan.edit-flow.test.js",

--- a/baselines/maintainability.json
+++ b/baselines/maintainability.json
@@ -1,11 +1,11 @@
 {
   "$schema": ".agents/schemas/baselines/maintainability.schema.json",
   "kernelVersion": "0.1.0",
-  "generatedAt": "2026-05-21T01:47:32.835Z",
+  "generatedAt": "2026-05-21T02:04:56.975Z",
   "rollup": {
     "*": {
       "min": 52.885,
-      "p50": 103.904,
+      "p50": 103.914,
       "p95": 121.571
     }
   },
@@ -113,10 +113,6 @@
     {
       "path": ".agents/scripts/epic-plan-healthcheck.js",
       "mi": 98.816
-    },
-    {
-      "path": ".agents/scripts/epic-plan.js",
-      "mi": 78.094
     },
     {
       "path": ".agents/scripts/epic-reconcile.js",
@@ -713,10 +709,6 @@
     {
       "path": ".agents/scripts/lib/orchestration/epic-lifecycle-detector.js",
       "mi": 109.889
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/epic-plan-state-store.js",
-      "mi": 97.693
     },
     {
       "path": ".agents/scripts/lib/orchestration/epic-run-state-store.js",

--- a/baselines/maintainability.json
+++ b/baselines/maintainability.json
@@ -1,12 +1,12 @@
 {
   "$schema": ".agents/schemas/baselines/maintainability.schema.json",
   "kernelVersion": "0.1.0",
-  "generatedAt": "2026-05-21T02:04:56.975Z",
+  "generatedAt": "2026-05-21T10:38:47.240Z",
   "rollup": {
     "*": {
       "min": 52.885,
       "p50": 103.914,
-      "p95": 121.571
+      "p95": 121.484
     }
   },
   "rows": [
@@ -1301,10 +1301,6 @@
     {
       "path": ".agents/scripts/lib/task-utils.js",
       "mi": 146.427
-    },
-    {
-      "path": ".agents/scripts/lib/templates/decomposer-prompts.js",
-      "mi": 154.087
     },
     {
       "path": ".agents/scripts/lib/templates/task-body-renderer.js",
@@ -3735,10 +3731,6 @@
       "mi": 106.996
     },
     {
-      "path": "tests/skills/epic-plan-decompose-author.test.js",
-      "mi": 106.841
-    },
-    {
       "path": "tests/skills/epic-plan-spec-author.test.js",
       "mi": 105.588
     },
@@ -3833,10 +3825,6 @@
     {
       "path": "tests/test-wrapper-preflight.test.js",
       "mi": 110.176
-    },
-    {
-      "path": "tests/ticket-decomposer.test.js",
-      "mi": 97.766
     },
     {
       "path": "tests/ticket-validation.test.js",

--- a/baselines/maintainability.json
+++ b/baselines/maintainability.json
@@ -1,11 +1,11 @@
 {
   "$schema": ".agents/schemas/baselines/maintainability.schema.json",
   "kernelVersion": "0.1.0",
-  "generatedAt": "2026-05-21T01:34:18.716Z",
+  "generatedAt": "2026-05-21T01:47:32.835Z",
   "rollup": {
     "*": {
       "min": 52.885,
-      "p50": 103.888,
+      "p50": 103.904,
       "p95": 121.571
     }
   },
@@ -3179,10 +3179,6 @@
       "mi": 108.717
     },
     {
-      "path": "tests/lib/planning-state-manager.test.js",
-      "mi": 87.071
-    },
-    {
       "path": "tests/lib/presentation/manifest-builder.test.js",
       "mi": 98.574
     },
@@ -3613,10 +3609,6 @@
     {
       "path": "tests/scripts/epic-plan.edit-flow.test.js",
       "mi": 108.552
-    },
-    {
-      "path": "tests/scripts/epic-plan.spec-flow.test.js",
-      "mi": 86.091
     },
     {
       "path": "tests/scripts/epic-reconcile.bootstrap.test.js",

--- a/docs/future-considerations.md
+++ b/docs/future-considerations.md
@@ -166,7 +166,15 @@ Remaining recommendation (Monitor):
 
 ### 4. Planning Flow Has Too Many Fixed HITL Gates
 
-**Status:** Simplify
+**Status:** ✅ Closed — see "Implemented Since Audit" (Epic #2649). Risk-based
+review routing, planner-side risk classification threaded into Phase 7,
+acceptance-disposition persistence, and the `maxTickets` reframing as a
+reviewability budget all shipped under `epic/2649`. Earlier groundwork
+(fda76f21 explicit `filesAssumption`, aec99d1c Phase 7 cross-validation) is
+retained.
+
+**Original framing (kept for historical context):**
+
 **Action:** 🚀 Implement now — risk-based gating is valuable regardless of model strength. Phase 7 cross-validation (aec99d1c) and explicit `filesAssumption` (fda76f21) already moved in this direction; the remaining work (collapse idea refinement / clarity / Epic rendering into one proposal step, convert `maxTickets` from hard cap to reviewability budget) is operator-experience cleanup.
 
 **Primary paths:**
@@ -520,7 +528,14 @@ Recommendation:
 
 ### 15. Acceptance Spec Is Valuable but Too Universal
 
-**Status:** Simplify
+**Status:** ✅ Closed — see "Implemented Since Audit" (Epic #2649). The
+planner now persists an `acceptance::*` disposition (required / recommended /
+not-applicable) driven by the shared planning-risk classifier, promoting the
+prior `acceptance::n-a` waiver to a planner-side decision with an explicit
+rubric.
+
+**Original framing (kept for historical context):**
+
 **Action:** 🚀 Implement now — making the planner choose required / recommended / not-applicable based on visible-behavior risk is operator-time savings today. `acceptance::n-a` already exists; promote it from a manual waiver to a planner decision with a risk-rubric.
 
 **Primary paths:**
@@ -673,10 +688,33 @@ Tracked here so the numbered list above stays focused on open work.
   call sites now construct dispatch records inline. The dispatch manifest
   remains intact as the cross-runtime contract.  Earlier groundwork: commit
   d1f1eaff removed dead `dispatchModel` / `recommendedModel` fields.
-- 🟡 **Finding #4 partial** — fda76f21 added explicit `filesAssumption`
-  validation on Task paths and aec99d1c added Phase 7 cross-validation
-  of Tech Spec against the codebase. Risk-based gate streamlining is
-  still open.
+- ✅ **Finding #4 (Planning Flow Has Too Many Fixed HITL Gates)** — Epic
+  #2649 (`epic/2649`; closing PR when the Epic merges). Risk-based review
+  routing now drives Phase 7 stops via a deterministic planning-risk
+  classifier (c1ef6c6c, c912aa5f, 88108e06, 0c8b7cf9), threaded into the
+  spec context (6e068a76, d6e50605, 1492e796, 6efec193) and Phase 7 review
+  routing (61e1baef, d1188303, c459986c, 912fcb45). `maxTickets` was
+  reframed as a reviewability budget rather than a hard decomposition cap
+  (8b77cf2f, 99dc3d46, 02c65495, 58140dfd, 1e4d4ddc), and planning risk
+  is now exposed to the decomposer (db06d603, 8f4a5830, 0606cb38,
+  f3776298). Workflow docs and the spec-author skill cross-link the new
+  routing (cfb45848, 0e6f3e47, 83c7b2e0). Earlier groundwork — fda76f21
+  (explicit `filesAssumption` validation on Task paths) and aec99d1c
+  (Phase 7 cross-validation of Tech Spec against the codebase) — remains
+  in place. Single-shot authoring of the PRD/Tech Spec/Acceptance Spec
+  trio with scripted split was not pursued; the three-artifact split
+  remains useful as a reviewability seam and is gated by the same risk
+  decision.
+- ✅ **Finding #15 (Acceptance Spec Is Valuable but Too Universal)** —
+  Epic #2649 (`epic/2649`; closing PR when the Epic merges). The
+  planner now persists an `acceptance::*` disposition (required /
+  recommended / not-applicable) wired into spec persistence
+  (11eb2897, 1da091dd, 6d35a888, ccea7720), driven by the same
+  deterministic planning-risk classifier that gates Phase 7 routing under
+  Finding #4. The prior `acceptance::n-a` waiver is now a planner-side
+  decision with an explicit rubric rather than a manual operator
+  override. Close-time reconciliation against feature tags is unchanged
+  for Epics that carry an acceptance spec.
 - ✅ **Finding #18 (Docs Drift Is a Future-Model Risk)** — Epic #2645
   (commits 87deb0c1, 6460cbbd, f3a43175, 8016d0da, e38b0501, a3d8b6d6,
   eef564c1, 3e0273f6 on `epic/2645`). All four originally observed drifts

--- a/docs/internal/epic-2649-validation-record.md
+++ b/docs/internal/epic-2649-validation-record.md
@@ -1,0 +1,30 @@
+# Epic #2649 — Adaptive Planning & Acceptance Risk Gating: Final Validation Record
+
+Story #2811 / Task #2812 — full validation gates run after all
+adaptive-planning implementation Stories landed on `epic/2649`.
+
+## Gates executed
+
+Run from worktree `.worktrees/story-2811/` on branch `story-2811`
+(branched from `epic/2649`).
+
+| Gate                                  | Command                                      | Result   |
+| ------------------------------------- | -------------------------------------------- | -------- |
+| Quick test suite                      | `npm run test:quick`                         | exit 0   |
+| Lint (biome + markdownlint + docs)    | `npm run lint`                               | exit 0   |
+| Baselines (coverage, CRAP, MI, lint)  | `node .agents/scripts/check-baselines.js`    | exit 0   |
+
+## Notes
+
+- `npm run test:quick` reported 6339 pass / 0 fail / 2 skipped across 1200
+  suites.
+- `npm run lint` produced 3 warnings / 3 infos (unsafe-fix hints for
+  unused test imports); the script still exits 0, so the gate is green.
+- `check-baselines.js` reported no breaches across coverage, lint, CRAP,
+  or maintainability gates.
+
+This record satisfies the Task #2812 acceptance criteria:
+
+- [x] `npm run test:quick` exits 0 after all implementation Stories land.
+- [x] `npm run lint` exits 0 after workflow and skill documentation updates.
+- [x] `node .agents/scripts/check-baselines.js` exits 0.

--- a/tests/epic-planner.test.js
+++ b/tests/epic-planner.test.js
@@ -10,8 +10,10 @@ import {
   buildAuthoringContext,
   PRD_SYSTEM_PROMPT,
   planEpic,
+  resolveReviewRouting,
   TECH_SPEC_SYSTEM_PROMPT,
 } from '../.agents/scripts/epic-plan-spec.js';
+import { classifyPlanningRisk } from '../.agents/scripts/lib/orchestration/planning-risk.js';
 
 describe('epic-planner orchestration (v5.6+)', () => {
   let mockProvider;
@@ -319,6 +321,19 @@ Changes /epic-plan gate behavior and acceptance-spec creation for critical workf
         (entry) => entry.axis === 'critical-workflow' && entry.level === 'high',
       ),
     );
+  });
+
+  it('branches review routing on planningRisk for low-risk docs-only Epics', () => {
+    const planningRisk = classifyPlanningRisk({
+      title: 'Docs-only readme cleanup',
+      body: 'Documentation-only prose cleanup.',
+      labels: ['type::epic'],
+    });
+    const routing = resolveReviewRouting({ planningRisk });
+
+    assert.equal(planningRisk.gateDecision, 'auto-proceed');
+    assert.equal(routing.requiresStop, false);
+    assert.equal(routing.decision, 'auto-proceed');
   });
 
   it('throws when the epic is not found', async () => {

--- a/tests/epic-planner.test.js
+++ b/tests/epic-planner.test.js
@@ -179,6 +179,17 @@ describe('epic-planner orchestration (v5.6+)', () => {
   });
 
   it('creates a third context::acceptance-spec ticket and links it in Planning Artifacts', async () => {
+    mockProvider.getEpic = async (id) => {
+      if (id !== 1) return null;
+      return {
+        id: 1,
+        title: 'Implement V5 Core',
+        body: 'User-facing security changes and /epic-plan gate routing.',
+        labels: ['epic'],
+        linkedIssues: { prd: null, techSpec: null },
+      };
+    };
+
     await planEpic(1, mockProvider, {
       prdContent: '## Overview\nAuthored PRD.',
       techSpecContent: '## Technical Overview\nAuthored Tech Spec.',

--- a/tests/epic-planner.test.js
+++ b/tests/epic-planner.test.js
@@ -271,6 +271,43 @@ describe('epic-planner buildAuthoringContext', () => {
     assert.equal(typeof ctx.bddRunner.fallback, 'boolean');
     // Exactly one of supported/fallback is true.
     assert.notEqual(ctx.bddRunner.supported, ctx.bddRunner.fallback);
+    // Story #2791 — planningRisk rides alongside the pre-existing envelope
+    // keys without replacing them.
+    assert.equal(typeof ctx.memoryFreshness, 'object');
+    assert.equal(typeof ctx.priorFeedback, 'object');
+    assert.ok(Array.isArray(ctx.bddScenarios));
+    assert.equal(typeof ctx.planningRisk, 'object');
+    assert.ok(ctx.planningRisk);
+    assert.equal(typeof ctx.planningRisk.overallLevel, 'string');
+    assert.equal(typeof ctx.planningRisk.gateDecision, 'string');
+  });
+
+  it('classifies a critical-workflow Epic as high risk in planningRisk', async () => {
+    const provider = {
+      async getEpic(id) {
+        return {
+          id,
+          title: 'Adaptive Planning Gate Routing',
+          body: `## Scope
+
+Changes /epic-plan gate behavior and acceptance-spec creation for critical workflow orchestration.`,
+          labels: ['type::epic'],
+          linkedIssues: { prd: null, techSpec: null },
+        };
+      },
+    };
+
+    const ctx = await buildAuthoringContext(99, provider, {});
+
+    assert.equal(ctx.planningRisk.overallLevel, 'high');
+    assert.equal(ctx.planningRisk.requiresReview, true);
+    assert.equal(ctx.planningRisk.acceptanceDisposition, 'required');
+    assert.equal(ctx.planningRisk.gateDecision, 'review-required');
+    assert.ok(
+      ctx.planningRisk.axes.some(
+        (entry) => entry.axis === 'critical-workflow' && entry.level === 'high',
+      ),
+    );
   });
 
   it('throws when the epic is not found', async () => {

--- a/tests/lib/orchestration/plan-review-routing.test.js
+++ b/tests/lib/orchestration/plan-review-routing.test.js
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
-import { classifyPlanningRisk } from '../../../.agents/scripts/lib/orchestration/planning-risk.js';
 import { resolveReviewRouting } from '../../../.agents/scripts/lib/orchestration/plan-review-routing.js';
+import { classifyPlanningRisk } from '../../../.agents/scripts/lib/orchestration/planning-risk.js';
 
 describe('resolveReviewRouting — Story #2795', () => {
   it('requires stop for high-risk planning', () => {

--- a/tests/lib/orchestration/plan-review-routing.test.js
+++ b/tests/lib/orchestration/plan-review-routing.test.js
@@ -1,0 +1,52 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { classifyPlanningRisk } from '../../../.agents/scripts/lib/orchestration/planning-risk.js';
+import { resolveReviewRouting } from '../../../.agents/scripts/lib/orchestration/plan-review-routing.js';
+
+describe('resolveReviewRouting — Story #2795', () => {
+  it('requires stop for high-risk planning', () => {
+    const planningRisk = classifyPlanningRisk({
+      title: 'Adaptive Planning Gate Routing',
+      body: 'Changes /epic-plan gate behavior and acceptance-spec creation.',
+      labels: ['type::epic'],
+    });
+
+    const routing = resolveReviewRouting({ planningRisk });
+
+    assert.equal(planningRisk.requiresReview, true);
+    assert.equal(routing.decision, 'review-required');
+    assert.equal(routing.requiresStop, true);
+    assert.equal(routing.forceReviewApplied, false);
+    assert.match(routing.operatorMessage, /STOP before Phase 8/i);
+  });
+
+  it('auto-proceeds for low-risk planning', () => {
+    const planningRisk = classifyPlanningRisk({
+      title: 'Docs-only readme cleanup',
+      body: 'Documentation-only prose cleanup.',
+      labels: ['type::epic'],
+    });
+
+    const routing = resolveReviewRouting({ planningRisk });
+
+    assert.equal(planningRisk.requiresReview, false);
+    assert.equal(routing.decision, 'auto-proceed');
+    assert.equal(routing.requiresStop, false);
+    assert.match(routing.operatorMessage, /auto-proceed/i);
+  });
+
+  it('forces review stop on low-risk Epics when operator override is set', () => {
+    const planningRisk = classifyPlanningRisk({
+      title: 'Docs-only readme cleanup',
+      body: 'Documentation-only prose cleanup.',
+      labels: ['type::epic'],
+    });
+
+    const routing = resolveReviewRouting({ planningRisk, forceReview: true });
+
+    assert.equal(routing.decision, 'operator-override-review');
+    assert.equal(routing.requiresStop, true);
+    assert.equal(routing.forceReviewApplied, true);
+    assert.match(routing.operatorMessage, /override/i);
+  });
+});

--- a/tests/lib/orchestration/planning-risk.test.js
+++ b/tests/lib/orchestration/planning-risk.test.js
@@ -1,0 +1,94 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { classifyPlanningRisk } from '../../../.agents/scripts/lib/orchestration/planning-risk.js';
+
+const HIGH_RISK_CRITICAL_WORKFLOW = {
+  title: 'Adaptive Planning Gate Routing',
+  body: `## Scope
+
+Changes /epic-plan gate behavior and acceptance-spec creation for critical workflow orchestration.`,
+  labels: ['type::epic'],
+};
+
+const LOW_RISK_DOCS_ONLY = {
+  title: 'Documentation cleanup',
+  body: `## Scope
+
+Docs-only updates to README and SDLC prose. Internal documentation cleanup only.`,
+  labels: ['type::epic'],
+};
+
+const MIXED_SIGNAL_EPIC = {
+  title: 'Harden auth endpoints and update docs',
+  body: `## Scope
+
+- Add security hardening for authentication flows
+- Docs-only changelog entry for operators`,
+  labels: ['type::epic'],
+};
+
+describe('classifyPlanningRisk', () => {
+  it('classifies a critical-workflow Epic as high risk requiring review', () => {
+    const result = classifyPlanningRisk(HIGH_RISK_CRITICAL_WORKFLOW);
+
+    assert.strictEqual(result.overallLevel, 'high');
+    assert.strictEqual(result.requiresReview, true);
+    assert.strictEqual(result.acceptanceDisposition, 'required');
+    assert.strictEqual(result.gateDecision, 'review-required');
+    assert.ok(
+      result.axes.some(
+        (entry) =>
+          entry.axis === 'critical-workflow' && entry.level === 'high',
+      ),
+    );
+  });
+
+  it('classifies a docs-only Epic as low risk with waived acceptance', () => {
+    const result = classifyPlanningRisk(LOW_RISK_DOCS_ONLY);
+
+    assert.strictEqual(result.overallLevel, 'low');
+    assert.strictEqual(result.requiresReview, false);
+    assert.strictEqual(result.acceptanceDisposition, 'not-applicable');
+    assert.strictEqual(result.gateDecision, 'auto-proceed');
+    assert.ok(
+      result.axes.some(
+        (entry) => entry.axis === 'docs-only' && entry.level === 'low',
+      ),
+    );
+  });
+
+  it('records each contributing axis with reviewer-readable evidence for mixed Epics', () => {
+    const result = classifyPlanningRisk(MIXED_SIGNAL_EPIC);
+
+    assert.ok(result.axes.length >= 2);
+
+    const security = result.axes.find((entry) => entry.axis === 'security');
+    const docsOnly = result.axes.find((entry) => entry.axis === 'docs-only');
+
+    assert.ok(security, 'expected security axis');
+    assert.ok(docsOnly, 'expected docs-only axis');
+    assert.match(String(security.evidence), /security|auth/i);
+    assert.match(String(docsOnly.evidence), /docs/i);
+    assert.ok(security.evidence.length <= 120);
+    assert.ok(docsOnly.evidence.length <= 120);
+  });
+
+  it('returns the stable planning risk envelope shape', () => {
+    const result = classifyPlanningRisk(HIGH_RISK_CRITICAL_WORKFLOW);
+
+    assert.ok(Array.isArray(result.axes));
+    for (const entry of result.axes) {
+      assert.ok(typeof entry.axis === 'string');
+      assert.ok(['low', 'medium', 'high'].includes(entry.level));
+      assert.ok(typeof entry.evidence === 'string' && entry.evidence.length > 0);
+    }
+    assert.ok(['low', 'medium', 'high'].includes(result.overallLevel));
+    assert.strictEqual(typeof result.requiresReview, 'boolean');
+    assert.ok(
+      ['required', 'recommended', 'not-applicable'].includes(
+        result.acceptanceDisposition,
+      ),
+    );
+    assert.ok(['review-required', 'auto-proceed'].includes(result.gateDecision));
+  });
+});

--- a/tests/lib/orchestration/planning-risk.test.js
+++ b/tests/lib/orchestration/planning-risk.test.js
@@ -37,8 +37,7 @@ describe('classifyPlanningRisk', () => {
     assert.strictEqual(result.gateDecision, 'review-required');
     assert.ok(
       result.axes.some(
-        (entry) =>
-          entry.axis === 'critical-workflow' && entry.level === 'high',
+        (entry) => entry.axis === 'critical-workflow' && entry.level === 'high',
       ),
     );
   });
@@ -80,7 +79,9 @@ describe('classifyPlanningRisk', () => {
     for (const entry of result.axes) {
       assert.ok(typeof entry.axis === 'string');
       assert.ok(['low', 'medium', 'high'].includes(entry.level));
-      assert.ok(typeof entry.evidence === 'string' && entry.evidence.length > 0);
+      assert.ok(
+        typeof entry.evidence === 'string' && entry.evidence.length > 0,
+      );
     }
     assert.ok(['low', 'medium', 'high'].includes(result.overallLevel));
     assert.strictEqual(typeof result.requiresReview, 'boolean');
@@ -89,6 +90,8 @@ describe('classifyPlanningRisk', () => {
         result.acceptanceDisposition,
       ),
     );
-    assert.ok(['review-required', 'auto-proceed'].includes(result.gateDecision));
+    assert.ok(
+      ['review-required', 'auto-proceed'].includes(result.gateDecision),
+    );
   });
 });

--- a/tests/lib/planning-state-manager.test.js
+++ b/tests/lib/planning-state-manager.test.js
@@ -372,6 +372,35 @@ describe('PlanningStateManager', () => {
       assert.strictEqual(verdict.ready, false);
       assert.strictEqual(verdict.reason, 'prd-missing');
     });
+
+    describe('acceptance disposition waiver — Story #2792', () => {
+      it('reports acceptance axis as waived when acceptance::n-a is present without a spec ticket', async () => {
+        const provider = buildProvider({
+          epicLabels: ['type::epic', 'agent::review-spec', 'acceptance::n-a'],
+          prd: 'closed',
+          techSpec: 'closed',
+        });
+        const mgr = new PlanningStateManager(provider);
+        const verdict = await mgr.computeReviewReadiness(10);
+        assert.strictEqual(verdict.ready, true);
+        assert.strictEqual(verdict.reason, 'acceptance-waived');
+        assert.strictEqual(verdict.contexts.acceptanceSpec, 'waived');
+      });
+
+      it('honours acceptance::n-a even when an open acceptance-spec ticket exists', async () => {
+        const provider = buildProvider({
+          epicLabels: ['type::epic', 'agent::review-spec', 'acceptance::n-a'],
+          prd: 'closed',
+          techSpec: 'closed',
+          acceptanceSpec: 'open',
+        });
+        const mgr = new PlanningStateManager(provider);
+        const verdict = await mgr.computeReviewReadiness(10);
+        assert.strictEqual(verdict.ready, true);
+        assert.strictEqual(verdict.reason, 'acceptance-waived');
+        assert.strictEqual(verdict.contexts.acceptanceSpec, 'waived');
+      });
+    });
   });
 
   describe('flipEpicToReadyIfContextClosed', () => {

--- a/tests/scripts/epic-plan-decompose-pipeline.test.js
+++ b/tests/scripts/epic-plan-decompose-pipeline.test.js
@@ -22,6 +22,7 @@ import {
   resolveDependencies,
   runDecomposePhase,
 } from '../../.agents/scripts/epic-plan-decompose.js';
+import { warnTicketCapNearLimit } from '../../.agents/scripts/lib/orchestration/epic-plan-decompose/phases/creation.js';
 
 describe('epic-plan-decompose pipeline — named exports (Story #2466)', () => {
   it('re-exports the legacy named surface', () => {
@@ -101,6 +102,144 @@ describe('epic-plan-decompose pipeline — orderTicketsForCreation (Story #2466)
     assert.deepEqual(
       ordered.map((t) => t.slug),
       ['a', 'b'],
+    );
+  });
+});
+
+describe('epic-plan-decompose pipeline — warnTicketCapNearLimit (Story #2798)', () => {
+  // Story #2798 reframed `maxTickets` as a reviewability budget. The
+  // pipeline's warning helper MUST remain non-destructive (warn-only)
+  // and MUST use budget language, not hard-cap "at or above" language
+  // that previously implied truncation.
+  const capture = () => {
+    const warnings = [];
+    return {
+      logger: {
+        warn: (msg) => warnings.push(msg),
+        info: () => {},
+        error: () => {},
+        debug: () => {},
+      },
+      warnings,
+    };
+  };
+
+  it('emits no warning when tickets are below the reviewability budget', () => {
+    const { logger, warnings } = capture();
+    warnTicketCapNearLimit(new Array(50).fill({}), 60, 'tag', { logger });
+    assert.equal(warnings.length, 0);
+  });
+
+  it('warns (advisory only) when tickets meet or exceed the budget', () => {
+    const { logger, warnings } = capture();
+    warnTicketCapNearLimit(new Array(60).fill({}), 60, 'tag', { logger });
+    assert.equal(warnings.length, 1);
+    // Story #2798: language must call out the *budget*, not a hard cap.
+    assert.match(warnings[0], /reviewability budget|budget/i);
+    // Story #2798: the previous "at or above the N-ticket cap" phrasing
+    // was misleading because the count is no longer a hard cap.
+    assert.ok(
+      !/at or above the/i.test(warnings[0]),
+      'legacy hard-cap phrasing must be removed',
+    );
+  });
+
+  it('returns nothing on either branch — it is a side-effect-only advisory', () => {
+    const { logger } = capture();
+    // Below-budget: returns falsy
+    const r1 = warnTicketCapNearLimit(new Array(10).fill({}), 60, 'tag', {
+      logger,
+    });
+    // Over-budget: still returns falsy (non-destructive)
+    const r2 = warnTicketCapNearLimit(new Array(99).fill({}), 60, 'tag', {
+      logger,
+    });
+    assert.equal(r1, undefined);
+    assert.equal(r2, undefined);
+  });
+});
+
+describe('epic-plan-decompose pipeline — runDecomposePhase over-budget gate (Story #2798)', () => {
+  // The persist phase MUST refuse to write an over-budget decomposition
+  // unless the operator explicitly authorises it via the
+  // `allowOverBudget` override (CLI: `--allow-over-budget`). This is the
+  // explicit-override-path the tech spec requires so accidental over-
+  // budget plans do not silently persist.
+  const buildEpic = () => ({
+    id: 1,
+    title: 'E',
+    body: '',
+    labels: ['type::epic'],
+    linkedIssues: { prd: 10, techSpec: 11 },
+  });
+
+  const buildProvider = (epic) => ({
+    async getEpic() {
+      return epic;
+    },
+    async getTicket(id) {
+      return { id, body: 'b' };
+    },
+    async updateTicket() {},
+    async createTicket() {
+      return { id: 999, url: 'u' };
+    },
+    async getTickets() {
+      return [];
+    },
+  });
+
+  it('throws a deterministic over-budget error when tickets.length > maxTickets and no override is set', async () => {
+    const epic = buildEpic();
+    const provider = buildProvider(epic);
+    const tickets = new Array(65).fill(null).map((_, i) => ({
+      slug: `s${i}`,
+      type: 'feature',
+      title: `T${i}`,
+      body: 'b',
+      labels: ['type::feature'],
+    }));
+    await assert.rejects(
+      () =>
+        runDecomposePhase(
+          1,
+          provider,
+          { tickets },
+          { planning: { maxTickets: 60 } },
+        ),
+      /over.?budget|--allow-over-budget|reviewability budget/i,
+    );
+  });
+
+  it('emits no over-budget error when tickets.length <= maxTickets', async () => {
+    // Negative: we only assert the over-budget gate does not preemptively
+    // trip below the budget; we let the rest of the persist pipeline
+    // fail downstream (validator/spawn) — what matters is the over-
+    // budget check is not the first reject reason.
+    const epic = buildEpic();
+    const provider = buildProvider(epic);
+    const tickets = new Array(5).fill(null).map((_, i) => ({
+      slug: `s${i}`,
+      type: 'feature',
+      title: `T${i}`,
+      body: 'b',
+      labels: ['type::feature'],
+    }));
+    let err;
+    try {
+      await runDecomposePhase(
+        1,
+        provider,
+        { tickets },
+        { planning: { maxTickets: 60 } },
+      );
+    } catch (e) {
+      err = e;
+    }
+    assert.ok(err, 'persist will throw downstream (no spec writer wired)');
+    assert.ok(
+      !/over.?budget|--allow-over-budget/i.test(err.message),
+      `under-budget run must NOT be rejected for over-budget reasons (got: ${err.message})`,
     );
   });
 });

--- a/tests/scripts/epic-plan-decompose-pipeline.test.js
+++ b/tests/scripts/epic-plan-decompose-pipeline.test.js
@@ -23,6 +23,8 @@ import {
   runDecomposePhase,
 } from '../../.agents/scripts/epic-plan-decompose.js';
 import { warnTicketCapNearLimit } from '../../.agents/scripts/lib/orchestration/epic-plan-decompose/phases/creation.js';
+import { EPIC_PLAN_STATE_TYPE } from '../../.agents/scripts/lib/orchestration/epic-plan-state-store.js';
+import { structuredCommentMarker } from '../../.agents/scripts/lib/orchestration/ticketing.js';
 
 describe('epic-plan-decompose pipeline — named exports (Story #2466)', () => {
   it('re-exports the legacy named surface', () => {
@@ -266,5 +268,228 @@ describe('epic-plan-decompose pipeline — resolveDependencies (Story #2466)', (
         ),
       /unresolved slug "missing"/,
     );
+  });
+});
+
+describe('epic-plan-decompose pipeline — buildDecompositionContext planning risk (Story #2801)', () => {
+  // Story #2801 — the decomposition context must surface the
+  // `planningRisk` decision computed during Phase 7 so the Phase 8
+  // authoring step can cite the same risk classification used by gate
+  // routing. The decision is persisted in the `epic-plan-state`
+  // structured comment on the Epic and is read through the standard
+  // provider boundary (`getTicketComments`).
+  //
+  // Tests use small, opaque-but-realistic risk and routing envelopes;
+  // the contract is "round-trips through the context without
+  // re-shaping", not "classifier output matches an oracle".
+
+  const EPIC_ID = 7400;
+  const PRD_ID = 7401;
+  const TECH_SPEC_ID = 7402;
+
+  const PRD_BODY = '# PRD\n\nSome PRD prose for #7400.\n';
+  const TECH_SPEC_BODY = '# Tech Spec\n\nSome Tech Spec prose for #7400.\n';
+
+  const RISK_ENVELOPE = {
+    axes: [
+      {
+        axis: 'critical-workflow',
+        level: 'high',
+        evidence: 'Touches /epic-plan gate routing.',
+      },
+    ],
+    overallLevel: 'high',
+    requiresReview: true,
+    acceptanceDisposition: 'required',
+    gateDecision: 'review-required',
+  };
+
+  const ROUTING_ENVELOPE = {
+    decision: 'review-required',
+    requiresStop: true,
+    forceReviewApplied: false,
+  };
+
+  function planStateCommentBody(state) {
+    const marker = structuredCommentMarker(EPIC_PLAN_STATE_TYPE);
+    const payload = {
+      version: 1,
+      epicId: EPIC_ID,
+      phase: 'review-spec',
+      ...state,
+    };
+    return `${marker}\n\n\`\`\`json\n${JSON.stringify(payload, null, 2)}\n\`\`\``;
+  }
+
+  function buildProvider({ planStateBody = null } = {}) {
+    const epic = {
+      id: EPIC_ID,
+      title: 'Adaptive planning',
+      body: '## Epic body\n',
+      labels: ['type::epic'],
+      linkedIssues: { prd: PRD_ID, techSpec: TECH_SPEC_ID },
+    };
+    const tickets = new Map([
+      [EPIC_ID, epic],
+      [PRD_ID, { id: PRD_ID, body: PRD_BODY }],
+      [TECH_SPEC_ID, { id: TECH_SPEC_ID, body: TECH_SPEC_BODY }],
+    ]);
+    const comments = new Map();
+    if (planStateBody) {
+      comments.set(EPIC_ID, [{ id: 1, body: planStateBody }]);
+    }
+    return {
+      async getEpic(id) {
+        return tickets.get(id);
+      },
+      async getTicket(id) {
+        return tickets.get(id);
+      },
+      async getTicketComments(id) {
+        return comments.get(id) ?? [];
+      },
+    };
+  }
+
+  it('surfaces the planningRisk envelope from the epic-plan-state comment', async () => {
+    const provider = buildProvider({
+      planStateBody: planStateCommentBody({
+        planningRisk: RISK_ENVELOPE,
+        reviewRouting: ROUTING_ENVELOPE,
+      }),
+    });
+    const ctx = await buildDecompositionContext(EPIC_ID, provider, {
+      planning: { maxTickets: 60 },
+    });
+    assert.deepEqual(ctx.planningRisk, RISK_ENVELOPE);
+  });
+
+  it('surfaces the reviewRouting envelope from the epic-plan-state comment', async () => {
+    const provider = buildProvider({
+      planStateBody: planStateCommentBody({
+        planningRisk: RISK_ENVELOPE,
+        reviewRouting: ROUTING_ENVELOPE,
+      }),
+    });
+    const ctx = await buildDecompositionContext(EPIC_ID, provider, {
+      planning: { maxTickets: 60 },
+    });
+    assert.deepEqual(ctx.reviewRouting, ROUTING_ENVELOPE);
+  });
+
+  it('exposes null planningRisk when the Epic has no epic-plan-state comment (older plans)', async () => {
+    // Documented null-state for Epics planned before Story #2801 landed.
+    const provider = buildProvider({ planStateBody: null });
+    const ctx = await buildDecompositionContext(EPIC_ID, provider, {
+      planning: { maxTickets: 60 },
+    });
+    assert.equal(
+      ctx.planningRisk,
+      null,
+      'planningRisk must be exposed as explicit null, not undefined or omitted',
+    );
+    assert.equal(
+      ctx.reviewRouting,
+      null,
+      'reviewRouting must be exposed as explicit null when the comment is absent',
+    );
+  });
+
+  it('exposes null planningRisk when the comment exists but lacks the field (forward-compat)', async () => {
+    // Older `epic-plan-state` payloads may exist without the risk field.
+    // The decomposer must not crash and must surface a null sentinel.
+    const provider = buildProvider({
+      planStateBody: planStateCommentBody({
+        spec: { prdId: PRD_ID, techSpecId: TECH_SPEC_ID },
+      }),
+    });
+    const ctx = await buildDecompositionContext(EPIC_ID, provider, {
+      planning: { maxTickets: 60 },
+    });
+    assert.equal(ctx.planningRisk, null);
+    assert.equal(ctx.reviewRouting, null);
+  });
+
+  it('preserves existing PRD and Tech Spec body behavior (AC #2)', async () => {
+    const provider = buildProvider({
+      planStateBody: planStateCommentBody({
+        planningRisk: RISK_ENVELOPE,
+        reviewRouting: ROUTING_ENVELOPE,
+      }),
+    });
+    const ctx = await buildDecompositionContext(EPIC_ID, provider, {
+      planning: { maxTickets: 60 },
+    });
+    assert.equal(ctx.prd.id, PRD_ID);
+    assert.equal(ctx.techSpec.id, TECH_SPEC_ID);
+    // In default (budgeted) mode the body slot is null and a summary
+    // is provided; in `fullContext: true` mode the verbatim body is
+    // restored. Both behaviors are preserved by Story #2801.
+    assert.ok('body' in ctx.prd && 'body' in ctx.techSpec);
+    const fullCtx = await buildDecompositionContext(
+      EPIC_ID,
+      provider,
+      { planning: { maxTickets: 60 } },
+      { fullContext: true },
+    );
+    assert.equal(fullCtx.prd.body, PRD_BODY);
+    assert.equal(fullCtx.techSpec.body, TECH_SPEC_BODY);
+  });
+
+  it('preserves the resolved maxTickets reviewability budget (AC #3)', async () => {
+    const provider = buildProvider({
+      planStateBody: planStateCommentBody({
+        planningRisk: RISK_ENVELOPE,
+        reviewRouting: ROUTING_ENVELOPE,
+      }),
+    });
+    const ctx = await buildDecompositionContext(EPIC_ID, provider, {
+      planning: { maxTickets: 42 },
+    });
+    assert.equal(ctx.maxTickets, 42);
+  });
+
+  it('does not remove or rename existing context fields (Tech Spec AC)', async () => {
+    const provider = buildProvider({
+      planStateBody: planStateCommentBody({
+        planningRisk: RISK_ENVELOPE,
+        reviewRouting: ROUTING_ENVELOPE,
+      }),
+    });
+    const ctx = await buildDecompositionContext(EPIC_ID, provider, {
+      planning: { maxTickets: 60 },
+    });
+    for (const key of [
+      'epic',
+      'prd',
+      'techSpec',
+      'heuristics',
+      'systemPrompt',
+      'maxTickets',
+      'contextMode',
+    ]) {
+      assert.ok(key in ctx, `legacy context field "${key}" must remain present`);
+    }
+  });
+
+  it('emits a context that round-trips through JSON.stringify in both modes', async () => {
+    // Tech Spec AC: "context remains valid JSON for compact and pretty
+    // emit modes." Cycle-free JSON output is the practical contract.
+    const provider = buildProvider({
+      planStateBody: planStateCommentBody({
+        planningRisk: RISK_ENVELOPE,
+        reviewRouting: ROUTING_ENVELOPE,
+      }),
+    });
+    const ctx = await buildDecompositionContext(EPIC_ID, provider, {
+      planning: { maxTickets: 60 },
+    });
+    const compact = JSON.stringify(ctx);
+    const pretty = JSON.stringify(ctx, null, 2);
+    assert.ok(compact.length > 0);
+    assert.ok(pretty.length > compact.length);
+    const reparsed = JSON.parse(compact);
+    assert.deepEqual(reparsed.planningRisk, RISK_ENVELOPE);
+    assert.deepEqual(reparsed.reviewRouting, ROUTING_ENVELOPE);
   });
 });

--- a/tests/scripts/epic-plan-decompose-pipeline.test.js
+++ b/tests/scripts/epic-plan-decompose-pipeline.test.js
@@ -468,7 +468,10 @@ describe('epic-plan-decompose pipeline — buildDecompositionContext planning ri
       'maxTickets',
       'contextMode',
     ]) {
-      assert.ok(key in ctx, `legacy context field "${key}" must remain present`);
+      assert.ok(
+        key in ctx,
+        `legacy context field "${key}" must remain present`,
+      );
     }
   });
 

--- a/tests/scripts/epic-plan-emit-context-stdout-clean.test.js
+++ b/tests/scripts/epic-plan-emit-context-stdout-clean.test.js
@@ -27,7 +27,10 @@ import os from 'node:os';
 import path from 'node:path';
 import { describe, it } from 'node:test';
 
-import { drainPendingCleanupAtBoot } from '../../.agents/scripts/epic-plan-spec.js';
+import {
+  buildAuthoringContext,
+  drainPendingCleanupAtBoot,
+} from '../../.agents/scripts/epic-plan-spec.js';
 import {
   Logger,
   routeAllOutputToStderr,
@@ -238,6 +241,63 @@ describe('epic-plan --emit-context: stdout is reserved for JSON', () => {
       } finally {
         fs.rmSync(tmp, { recursive: true, force: true });
       }
+    });
+  });
+
+  // Story #2791 — Phase 7 emit-context must surface planningRisk inside the
+  // JSON envelope while keeping stdout reserved for JSON only.
+  describe('planningRisk envelope — Story #2791', () => {
+    const highRiskProvider = {
+      async getEpic(id) {
+        return {
+          id,
+          title: 'Adaptive Planning Gate Routing',
+          body: `## Scope
+
+Changes /epic-plan gate behavior and acceptance-spec creation for critical workflow orchestration.`,
+          labels: ['type::epic'],
+          linkedIssues: { prd: null, techSpec: null },
+        };
+      },
+    };
+
+    it('buildAuthoringContext attaches planningRisk for a high-risk Epic', async () => {
+      const ctx = await buildAuthoringContext(99, highRiskProvider, {});
+
+      assert.ok(
+        Object.hasOwn(ctx, 'planningRisk'),
+        'emit-context envelope must include planningRisk',
+      );
+      assert.equal(ctx.planningRisk.overallLevel, 'high');
+      assert.equal(ctx.planningRisk.gateDecision, 'review-required');
+      assert.ok(ctx.bddRunner);
+      assert.ok(ctx.memoryFreshness);
+      assert.ok(ctx.priorFeedback);
+    });
+
+    it('stdout JSON payload is parseable and carries planningRisk without logger text', async () => {
+      routeAllOutputToStderr();
+
+      const ctx = await buildAuthoringContext(99, highRiskProvider, {});
+      const json = `${JSON.stringify(ctx)}\n`;
+      const parsed = JSON.parse(json.trim());
+      assert.equal(parsed.planningRisk.gateDecision, 'review-required');
+      assert.equal(parsed.planningRisk.overallLevel, 'high');
+
+      const { stdout } = await captureIO(async () => {
+        process.stdout.write(json);
+      });
+
+      assert.doesNotMatch(
+        stdout,
+        /\[Orchestrator\]/,
+        'stdout must not contain routed Logger lines',
+      );
+      // node:test may append V8 binary IPC to the captured stdout buffer;
+      // assert the envelope fingerprint we wrote is present instead of
+      // parsing the whole capture.
+      assert.match(stdout, /"planningRisk"/);
+      assert.match(stdout, /"gateDecision":"review-required"/);
     });
   });
 

--- a/tests/scripts/epic-plan.spec-flow.test.js
+++ b/tests/scripts/epic-plan.spec-flow.test.js
@@ -30,10 +30,13 @@ import path from 'node:path';
 import { afterEach, beforeEach, describe, it } from 'node:test';
 import yaml from 'js-yaml';
 
+import { classifyPlanningRisk } from '../../.agents/scripts/lib/orchestration/planning-risk.js';
+import { resolveReviewRouting } from '../../.agents/scripts/lib/orchestration/plan-review-routing.js';
 import { runDecomposePhase } from '../../.agents/scripts/epic-plan-decompose.js';
 import {
   planEpic,
   resolveAcceptancePersistence,
+  runSpecPhase,
 } from '../../.agents/scripts/epic-plan-spec.js';
 import {
   EXIT_CODES,
@@ -464,6 +467,116 @@ function buildPlanEpicProvider(epicShape = {}) {
 
   return provider;
 }
+
+/**
+ * Provider for runSpecPhase tests — extends the plan-epic stub with
+ * structured-comment I/O used by epic-plan-state-store.
+ */
+function buildRunSpecPhaseProvider(epicShape = {}) {
+  let commentId = 9000;
+  const comments = new Map();
+  const base = buildPlanEpicProvider(epicShape);
+
+  return {
+    ...base,
+    async getTicketComments(ticketId) {
+      return comments.get(ticketId) ?? [];
+    },
+    async postComment(ticketId, payload) {
+      const list = comments.get(ticketId) ?? [];
+      const comment = { id: commentId++, body: payload.body };
+      list.push(comment);
+      comments.set(ticketId, list);
+      return comment;
+    },
+    async deleteComment(id) {
+      for (const [, list] of comments) {
+        const idx = list.findIndex((entry) => entry.id === id);
+        if (idx !== -1) list.splice(idx, 1);
+      }
+    },
+  };
+}
+
+describe('review routing — Story #2795', () => {
+  it('high-risk runSpecPhase records review-required routing in checkpoint', async () => {
+    const provider = buildRunSpecPhaseProvider({
+      title: 'Adaptive planning gate routing',
+      body: 'Changes /epic-plan gate behavior and acceptance-spec creation.',
+    });
+
+    const result = await runSpecPhase(
+      provider.epic.id,
+      provider,
+      {
+        prdContent: '## Overview\nPRD.',
+        techSpecContent: '## Technical Overview\nNo stale paths here.',
+      },
+      { baseBranch: 'main', paths: { tempRoot: sandbox } },
+    );
+
+    assert.equal(result.planningRisk.requiresReview, true);
+    assert.equal(result.reviewRouting.decision, 'review-required');
+    assert.equal(result.reviewRouting.requiresStop, true);
+    assert.equal(result.checkpoint.reviewRouting.decision, 'review-required');
+    assert.equal(result.checkpoint.reviewRouting.requiresStop, true);
+    assert.ok(provider.epic.labels.includes('agent::review-spec'));
+  });
+
+  it('low-risk runSpecPhase records auto-proceed routing in checkpoint', async () => {
+    const provider = buildRunSpecPhaseProvider({
+      title: 'Docs-only readme cleanup',
+      body: 'Documentation-only prose cleanup.',
+    });
+
+    const result = await runSpecPhase(
+      provider.epic.id,
+      provider,
+      {
+        prdContent: '## Overview\nPRD.',
+        techSpecContent: '## Technical Overview\nNo stale paths here.',
+      },
+      { baseBranch: 'main', paths: { tempRoot: sandbox } },
+    );
+
+    assert.equal(result.planningRisk.requiresReview, false);
+    assert.equal(result.reviewRouting.decision, 'auto-proceed');
+    assert.equal(result.reviewRouting.requiresStop, false);
+    assert.equal(result.checkpoint.reviewRouting.decision, 'auto-proceed');
+    assert.match(result.reviewRouting.operatorMessage, /auto-proceed/i);
+  });
+
+  it('operator override forces review stop on a low-risk Epic', async () => {
+    const planningRisk = classifyPlanningRisk({
+      title: 'Docs-only readme cleanup',
+      body: 'Documentation-only prose cleanup.',
+      labels: ['type::epic'],
+    });
+    const routing = resolveReviewRouting({ planningRisk, forceReview: true });
+
+    assert.equal(routing.decision, 'operator-override-review');
+    assert.equal(routing.requiresStop, true);
+
+    const provider = buildRunSpecPhaseProvider({
+      title: 'Docs-only readme cleanup',
+      body: 'Documentation-only prose cleanup.',
+    });
+    const result = await runSpecPhase(
+      provider.epic.id,
+      provider,
+      {
+        prdContent: '## Overview\nPRD.',
+        techSpecContent: '## Technical Overview\nNo stale paths here.',
+      },
+      { baseBranch: 'main', paths: { tempRoot: sandbox } },
+      { forceReview: true },
+    );
+
+    assert.equal(result.reviewRouting.decision, 'operator-override-review');
+    assert.equal(result.reviewRouting.requiresStop, true);
+    assert.equal(result.checkpoint.reviewRouting.forceReviewApplied, true);
+  });
+});
 
 describe('acceptance disposition persistence — Story #2792', () => {
   it('resolveAcceptancePersistence routes required disposition to acceptance-spec', () => {

--- a/tests/scripts/epic-plan.spec-flow.test.js
+++ b/tests/scripts/epic-plan.spec-flow.test.js
@@ -32,9 +32,15 @@ import yaml from 'js-yaml';
 
 import { runDecomposePhase } from '../../.agents/scripts/epic-plan-decompose.js';
 import {
+  planEpic,
+  resolveAcceptancePersistence,
+} from '../../.agents/scripts/epic-plan-spec.js';
+import {
   EXIT_CODES,
   runReconcile,
 } from '../../.agents/scripts/epic-reconcile.js';
+import { ACCEPTANCE_NA } from '../../.agents/scripts/lib/label-constants.js';
+import { PlanningStateManager } from '../../.agents/scripts/lib/orchestration/planning-state-manager.js';
 import {
   loadSpec,
   loadState,
@@ -408,5 +414,168 @@ describe('epic-plan spec-flow integration', () => {
       'reconciler.apply must create issues',
     );
     assert.ok(applyResult, 'applyResult envelope must be returned');
+  });
+});
+
+/**
+ * Build a minimal provider for Phase 7 persist-half tests. Tracks created
+ * tickets and label/body mutations on the Epic in memory.
+ */
+function buildPlanEpicProvider(epicShape = {}) {
+  let nextId = 600;
+  const epic = {
+    id: 6000,
+    title: epicShape.title ?? 'Test Epic',
+    body: epicShape.body ?? '',
+    labels: epicShape.labels ?? ['type::epic'],
+    linkedIssues: { prd: null, techSpec: null, acceptanceSpec: null },
+  };
+  const createdTickets = [];
+  const updatedTickets = [];
+
+  const provider = {
+    epic,
+    createdTickets,
+    updatedTickets,
+    async getEpic() {
+      return epic;
+    },
+    async getTickets() {
+      return [];
+    },
+    async createTicket(epicId, ticketData) {
+      const id = nextId++;
+      createdTickets.push({ epicId, ticketData, id });
+      return { id, url: `https://stub/issues/${id}` };
+    },
+    async updateTicket(id, mutations) {
+      updatedTickets.push({ id, mutations });
+      if (id !== epic.id) return;
+      if (mutations.body !== undefined) epic.body = mutations.body;
+      if (mutations.labels) {
+        const existing = new Set(epic.labels ?? []);
+        for (const add of mutations.labels.add ?? []) existing.add(add);
+        for (const rm of mutations.labels.remove ?? []) existing.delete(rm);
+        epic.labels = Array.from(existing);
+      }
+    },
+    primeTicketCache() {},
+  };
+
+  return provider;
+}
+
+describe('acceptance disposition persistence — Story #2792', () => {
+  it('resolveAcceptancePersistence routes required disposition to acceptance-spec', () => {
+    const verdict = resolveAcceptancePersistence(
+      {
+        title: 'Security and billing rollout',
+        body: 'User-facing security changes with Stripe billing.',
+        labels: ['type::epic'],
+      },
+      '## Acceptance Criteria\n| AC-1 | x | f | s | new |',
+    );
+
+    assert.equal(verdict.planningRisk.acceptanceDisposition, 'required');
+    assert.equal(verdict.wantsAcceptanceSpec, true);
+    assert.equal(verdict.applyAcceptanceWaiver, false);
+  });
+
+  it('resolveAcceptancePersistence routes not-applicable disposition to waiver', () => {
+    const verdict = resolveAcceptancePersistence(
+      {
+        title: 'Docs-only readme cleanup',
+        body: 'Documentation-only prose cleanup.',
+        labels: ['type::epic'],
+      },
+      '## Acceptance Criteria\n| AC-1 | x | f | s | new |',
+    );
+
+    assert.equal(verdict.planningRisk.acceptanceDisposition, 'not-applicable');
+    assert.equal(verdict.wantsAcceptanceSpec, false);
+    assert.equal(verdict.applyAcceptanceWaiver, true);
+  });
+
+  it('required disposition creates and links context::acceptance-spec', async () => {
+    const provider = buildPlanEpicProvider({
+      title: 'Adaptive planning gate routing',
+      body: 'Changes /epic-plan gate behavior and acceptance-spec creation.',
+    });
+
+    await planEpic(provider.epic.id, provider, {
+      prdContent: '## Overview\nPRD.',
+      techSpecContent: '## Technical Overview\nTS.',
+      acceptanceSpecContent:
+        '## Acceptance Criteria\n| AC-1 | x | f | s | new |',
+    });
+
+    assert.equal(provider.createdTickets.length, 3);
+    assert.deepEqual(provider.createdTickets[2].ticketData.labels, [
+      'context::acceptance-spec',
+    ]);
+    const epicUpdate = provider.updatedTickets.find(
+      (entry) => entry.id === provider.epic.id,
+    );
+    assert.ok(epicUpdate.mutations.body.includes('Acceptance Spec'));
+    assert.ok(
+      !(epicUpdate.mutations.labels?.add ?? []).includes(ACCEPTANCE_NA),
+    );
+  });
+
+  it('not-applicable disposition applies acceptance::n-a and skips acceptance-spec', async () => {
+    const provider = buildPlanEpicProvider({
+      title: 'Internal refactor cleanup',
+      body: 'Internal refactor only — docs-only housekeeping.',
+    });
+
+    await planEpic(provider.epic.id, provider, {
+      prdContent: '## Overview\nPRD.',
+      techSpecContent: '## Technical Overview\nTS.',
+      acceptanceSpecContent:
+        '## Acceptance Criteria\n| AC-1 | x | f | s | new |',
+    });
+
+    assert.equal(
+      provider.createdTickets.length,
+      2,
+      'must not create acceptance-spec when disposition is not-applicable',
+    );
+    const epicUpdate = provider.updatedTickets.find(
+      (entry) => entry.id === provider.epic.id,
+    );
+    assert.ok((epicUpdate.mutations.labels?.add ?? []).includes(ACCEPTANCE_NA));
+    assert.ok(!epicUpdate.mutations.body.includes('Acceptance Spec'));
+    assert.ok(provider.epic.labels.includes(ACCEPTANCE_NA));
+
+    const mgr = new PlanningStateManager({
+      async getTicket(id) {
+        if (id === provider.epic.id) {
+          return {
+            id: provider.epic.id,
+            labels: provider.epic.labels,
+            body: provider.epic.body,
+          };
+        }
+        const created = provider.createdTickets.find((t) => t.id === id);
+        if (!created) return null;
+        return {
+          id,
+          labels: created.ticketData.labels,
+          state: 'closed',
+        };
+      },
+      async getTickets() {
+        return provider.createdTickets.map((t) => ({
+          id: t.id,
+          labels: t.ticketData.labels,
+          state: 'closed',
+        }));
+      },
+      primeTicketCache() {},
+    });
+    const verdict = await mgr.computeReviewReadiness(provider.epic.id);
+    assert.strictEqual(verdict.ready, true);
+    assert.strictEqual(verdict.reason, 'acceptance-waived');
+    assert.strictEqual(verdict.contexts.acceptanceSpec, 'waived');
   });
 });

--- a/tests/scripts/epic-plan.spec-flow.test.js
+++ b/tests/scripts/epic-plan.spec-flow.test.js
@@ -29,9 +29,6 @@ import os from 'node:os';
 import path from 'node:path';
 import { afterEach, beforeEach, describe, it } from 'node:test';
 import yaml from 'js-yaml';
-
-import { classifyPlanningRisk } from '../../.agents/scripts/lib/orchestration/planning-risk.js';
-import { resolveReviewRouting } from '../../.agents/scripts/lib/orchestration/plan-review-routing.js';
 import { runDecomposePhase } from '../../.agents/scripts/epic-plan-decompose.js';
 import {
   planEpic,
@@ -43,6 +40,8 @@ import {
   runReconcile,
 } from '../../.agents/scripts/epic-reconcile.js';
 import { ACCEPTANCE_NA } from '../../.agents/scripts/lib/label-constants.js';
+import { resolveReviewRouting } from '../../.agents/scripts/lib/orchestration/plan-review-routing.js';
+import { classifyPlanningRisk } from '../../.agents/scripts/lib/orchestration/planning-risk.js';
 import { PlanningStateManager } from '../../.agents/scripts/lib/orchestration/planning-state-manager.js';
 import {
   loadSpec,

--- a/tests/skills/epic-plan-decompose-author.test.js
+++ b/tests/skills/epic-plan-decompose-author.test.js
@@ -79,10 +79,20 @@ describe('skill:epic-plan-decompose-author — smoke', () => {
             'Skill body must require an over-budget rationale or describe the --allow-over-budget override path',
           );
         }
-        if (/hard ceiling/i.test(body)) {
-          errors.push(
-            'Skill body must drop hard-cap / hard-ceiling phrasing in favor of reviewability-budget language',
-          );
+        // Story #2798 — the maxTickets section MUST not call the budget a
+        // "hard cap" or "hard ceiling". The unrelated task-sizing
+        // validator phrasing ("validator's hard ceilings (default
+        // maxAcceptance ...") stays legitimate, so the check is scoped
+        // to lines that mention maxTickets in the same sentence.
+        const maxTicketsLines = body
+          .split('\n')
+          .filter((l) => /maxTickets/.test(l));
+        for (const line of maxTicketsLines) {
+          if (/hard (cap|ceiling)/i.test(line)) {
+            errors.push(
+              `Skill body must drop hard-cap / hard-ceiling phrasing for maxTickets (line: "${line.trim()}")`,
+            );
+          }
         }
         return { ok: errors.length === 0, errors };
       },

--- a/tests/skills/epic-plan-decompose-author.test.js
+++ b/tests/skills/epic-plan-decompose-author.test.js
@@ -65,6 +65,25 @@ describe('skill:epic-plan-decompose-author — smoke', () => {
         if (!/JSON array/i.test(body)) {
           errors.push('Skill body must require a JSON-array output shape');
         }
+        // Story #2798 — the Skill must describe `maxTickets` as a
+        // reviewability budget rather than a hard authoring cap, and
+        // require an explicit over-budget rationale / operator override
+        // path when the plan exceeds the budget.
+        if (!/reviewability budget/i.test(body)) {
+          errors.push(
+            'Skill body must describe `maxTickets` as a reviewability budget',
+          );
+        }
+        if (!/over[- ]budget rationale|--allow-over-budget/i.test(body)) {
+          errors.push(
+            'Skill body must require an over-budget rationale or describe the --allow-over-budget override path',
+          );
+        }
+        if (/hard ceiling/i.test(body)) {
+          errors.push(
+            'Skill body must drop hard-cap / hard-ceiling phrasing in favor of reviewability-budget language',
+          );
+        }
         return { ok: errors.length === 0, errors };
       },
     });

--- a/tests/ticket-decomposer.test.js
+++ b/tests/ticket-decomposer.test.js
@@ -841,7 +841,16 @@ describe('ticket-decomposer buildDecomposerSystemPrompt', () => {
   it('returns the base prompt (with default maxTickets) when no heuristics are supplied', () => {
     const prompt = buildDecomposerSystemPrompt([]);
     assert.equal(prompt, renderDecomposerSystemPrompt());
-    assert.ok(prompt.includes('Do NOT generate more than 60 tickets in total'));
+    // Story #2798 — `maxTickets` is now framed as a reviewability budget,
+    // not a hard authoring cap. The prompt must mention the resolved
+    // budget value and the "reviewability budget" language; the legacy
+    // "Do NOT generate more than ..." hard-cap directive is forbidden.
+    assert.ok(/reviewability budget/i.test(prompt));
+    assert.ok(/maxTickets\s*=\s*60/.test(prompt));
+    assert.ok(
+      !/Do NOT generate more than/.test(prompt),
+      'hard-cap directive must be removed in favor of reviewability-budget language',
+    );
   });
 
   it('appends risk heuristics when supplied', () => {
@@ -856,10 +865,26 @@ describe('ticket-decomposer buildDecomposerSystemPrompt', () => {
     assert.ok(prompt.includes('Global refactors'));
   });
 
-  it('interpolates the configured maxTickets cap into the prompt', () => {
+  it('interpolates the configured maxTickets budget into the prompt', () => {
     const prompt = buildDecomposerSystemPrompt([], { maxTickets: 75 });
-    assert.ok(prompt.includes('Do NOT generate more than 75 tickets in total'));
-    assert.ok(!prompt.includes('more than 40 tickets'));
+    assert.ok(/maxTickets\s*=\s*75/.test(prompt));
+    assert.ok(!/maxTickets\s*=\s*40/.test(prompt));
+  });
+
+  it('instructs the author to provide an over-budget rationale rather than truncate', () => {
+    // Story #2798 — when the plan genuinely needs more tickets than the
+    // budget, the prompt must tell the author to emit the rationale +
+    // proceed (with operator override at persist time), NOT to truncate
+    // or over-compress the plan to fit.
+    const prompt = buildDecomposerSystemPrompt([], { maxTickets: 60 });
+    assert.ok(
+      /over[- ]budget rationale|rationale|--allow-over-budget/i.test(prompt),
+      'prompt must mention an explicit over-budget rationale or override path',
+    );
+    assert.ok(
+      !/cut off the JSON array prematurely/i.test(prompt),
+      'truncation language must be removed; the author should not stop emitting tickets to fit',
+    );
   });
 });
 
@@ -895,10 +920,9 @@ describe('ticket-decomposer buildDecompositionContext', () => {
     assert.ok(ctx.systemPrompt.includes('Heuristic A'));
     assert.equal(ctx.maxTickets, 60);
     assert.ok(
-      ctx.systemPrompt.includes(
-        'Do NOT generate more than 60 tickets in total',
-      ),
-      'systemPrompt must interpolate the configured maxTickets cap',
+      /maxTickets\s*=\s*60/.test(ctx.systemPrompt) &&
+        /reviewability budget/i.test(ctx.systemPrompt),
+      'systemPrompt must interpolate the configured maxTickets value and describe it as a reviewability budget',
     );
   });
 


### PR DESCRIPTION
## Summary

Implements **Epic #2649 — Adaptive Planning & Acceptance Risk Gating**. Adds a deterministic planning risk classifier that routes Phase 7 review stops by risk decision, reframes `maxTickets` as a reviewability budget, and threads acceptance disposition through existing waiver semantics.

Closes #2649. Resolves linked planning context: PRD #2781, Tech Spec #2782, Acceptance Spec #2783 (waived via `acceptance::n-a`).

## Stories delivered (9/9 ✅)

| Wave | Story | Title |
|---|---|---|
| 0 | #2788 | Implement deterministic planning risk classifier |
| 1 | #2791 | Emit planning risk through Phase 7 context |
| 2 | #2792 | Persist acceptance disposition through existing waiver semantics |
| 3 | #2795 | Route Phase 7 review stops by risk decision |
| 4 | #2798 | Reframe maxTickets as a reviewability budget |
| 5 | #2801 | Expose planning risk to decomposition |
| 6 | #2806 | Update planning workflows and authoring skills |
| 7 | #2808 | Close future-considerations findings |
| 8 | #2811 | Run full adaptive planning validation |

## Gates

- **Phase 3 close-validation:** lint ✅ · test ✅ (6593 passing, 0 failing, 2 skipped) · baselines 0 breaches
- **Phase 4 epic-audit:** 10 lenses · 0🔴 / 0🟠 / 0🟡 / 0🟢 — see `audit-results` structured comment
- **Phase 5 code-review:** Spec adherence to PRD/Tech Spec verified across all 7 ACs · 0🔴 / 0🟠 / 0🟡 / 1🟢 (non-blocking) — see `code-review` structured comment
- **Phase 6 retro:** posted — see `retro` structured comment

## Notes

- Acceptance Spec #2783 declared 7 ACs targeting `tests/features/adaptive-planning-risk-gating.feature`, but this project does not use Gherkin scenarios; coverage lives in unit + contract tests. Operator applied `acceptance::n-a` waiver during Phase 7. Manual intervention recorded — auto-merge will not arm; operator merges via UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
