### PR TITLE
Nest per-Story temp dirs under `stories/` and fix divergent dispatch-state path (#2940)

### DIFF
--- a/.agents/schemas/signal-event.schema.json
+++ b/.agents/schemas/signal-event.schema.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://github.com/dsj1984/mandrel/blob/main/.agents/schemas/signal-event.schema.json",
   "title": "SignalEvent",
-  "description": "One NDJSON line emitted by the signals writer (Epic #1030). Runtime events live in append-only NDJSON on local disk under temp/epic-<eid>/story-<sid>/signals.ndjson; tickets carry only summaries (story-perf-summary, epic-perf-report). `kind: trace` is the raw tool-call trace; the named kinds are derived signals.",
+  "description": "One NDJSON line emitted by the signals writer (Epic #1030). Runtime events live in append-only NDJSON on local disk under temp/epic-<eid>/stories/story-<sid>/signals.ndjson; tickets carry only summaries (story-perf-summary, epic-perf-report). `kind: trace` is the raw tool-call trace; the named kinds are derived signals.",
   "type": "object",
   "additionalProperties": false,
   "required": ["ts", "kind", "source", "epicId", "storyId"],

--- a/.agents/schemas/validation-evidence.schema.json
+++ b/.agents/schemas/validation-evidence.schema.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "validation-evidence",
   "title": "Validation Evidence",
-  "description": "Per-scope record of which validation gates have passed against which commit SHA. Written by lib/validation-evidence.js under the per-Epic temp tree at temp/epic-<epicId>/validation-evidence.json (Epic-scoped) or temp/epic-<epicId>/story-<storyId>/validation-evidence.json (Story-scoped); both are gitignored via temp/. Consumed by close-validation, epic-code-review, and /epic-deliver Phase 3 (close-validation) to skip identical re-runs against an already-validated tree. The `storyId` field carries the scope id and equals the epic id for Epic-scoped records.",
+  "description": "Per-scope record of which validation gates have passed against which commit SHA. Written by lib/validation-evidence.js under the per-Epic temp tree at temp/epic-<epicId>/validation-evidence.json (Epic-scoped) or temp/epic-<epicId>/stories/story-<storyId>/validation-evidence.json (Story-scoped); both are gitignored via temp/. Consumed by close-validation, epic-code-review, and /epic-deliver Phase 3 (close-validation) to skip identical re-runs against an already-validated tree. The `storyId` field carries the scope id and equals the epic id for Epic-scoped records.",
   "type": "object",
   "required": ["storyId", "schemaVersion", "records"],
   "properties": {

--- a/.agents/scripts/analyze-execution.js
+++ b/.agents/scripts/analyze-execution.js
@@ -4,14 +4,14 @@
  * analyze-execution.js — single writer of the structured perf-summary
  * comments (Epic #1030 / Story #1123).
  *
- * Reads NDJSON from `temp/epic-<eid>/story-<sid>/signals.ndjson` and
+ * Reads NDJSON from `temp/epic-<eid>/stories/story-<sid>/signals.ndjson` and
  * upserts one of two structured comments:
  *
  *   - `--story <sid> --epic <eid>` (Story mode): posts
  *     `<!-- structured:story-perf-summary -->` on the Story ticket. The
  *     payload combines the Story's NDJSON signals with the timing
  *     summary written by `post-merge-close.js` to
- *     `temp/epic-<eid>/story-<sid>/phase-timings.json` (path overridable
+ *     `temp/epic-<eid>/stories/story-<sid>/phase-timings.json` (path overridable
  *     via `--phase-timings <path>`).
  *
  *   - `--epic <eid>` (Epic mode): rolls up every Story under the Epic by
@@ -108,7 +108,7 @@ async function readPhaseTimings(epicId, storyId, config, overridePath) {
 
 /**
  * Throw-away ghSpawnCount reader (Story #1795 / Epic #1788). Looks for
- * the `temp/epic-<eid>/story-<sid>/gh-spawn-count.json` file written by
+ * the `temp/epic-<eid>/stories/story-<sid>/gh-spawn-count.json` file written by
  * `close-validation.emitGhSpawnCount` immediately before the perf-summary
  * phase spawns this analyzer. Returns the integer count when present and
  * well-formed; `null` when absent or unparseable. Callers treat `null` as

--- a/.agents/scripts/dispatcher.js
+++ b/.agents/scripts/dispatcher.js
@@ -211,10 +211,10 @@ function logStoryManifestPaths(manifest) {
   if (eid && stories.length === 1) {
     const sid = stories[0].storyId;
     Logger.info(
-      `\n[Dispatcher] ✅ Story manifest: temp/epic-${eid}/story-${sid}/manifest.json`,
+      `\n[Dispatcher] ✅ Story manifest: temp/epic-${eid}/stories/story-${sid}/manifest.json`,
     );
     Logger.info(
-      `[Dispatcher] 📄 Markdown: temp/epic-${eid}/story-${sid}/manifest.md\n`,
+      `[Dispatcher] 📄 Markdown: temp/epic-${eid}/stories/story-${sid}/manifest.md\n`,
     );
     return;
   }

--- a/.agents/scripts/lib/close-validation.js
+++ b/.agents/scripts/lib/close-validation.js
@@ -627,7 +627,7 @@ export {
  * Throw-away ghSpawnCount emitter (Story #1795 / Epic #1788).
  *
  * Writes the current `gh-exec` spawn counter to
- * `temp/epic-<eid>/story-<sid>/gh-spawn-count.json` so the
+ * `temp/epic-<eid>/stories/story-<sid>/gh-spawn-count.json` so the
  * `analyze-execution.js` child process can read it and emit a
  * `ghSpawnCount` field on the `story-perf-summary` payload. The Story-
  * close orchestrator calls this inside `runPostMergeClose` right before

--- a/.agents/scripts/lib/config/temp-paths.js
+++ b/.agents/scripts/lib/config/temp-paths.js
@@ -15,13 +15,21 @@
  *     ├─ manifest.md          (dispatch manifest)
  *     ├─ retro.md             (mirror of GitHub retro at Epic close)
  *     ├─ perf-report.md       (analyzer output, Epic-level)
+ *     ├─ lifecycle.ndjson     (lifecycle bus ledger)
  *     ├─ checkpoints/...      (epic-runner state store)
  *     ├─ <name>               (epicArtifactPath escape hatch)
- *     └─ story-<sid>/
- *        ├─ manifest.md       (story dispatch manifest)
- *        ├─ signals.ndjson    (append-only signals writer)
- *        ├─ perf-summary.md
- *        └─ <name>            (storyArtifactPath escape hatch)
+ *     └─ stories/
+ *        └─ story-<sid>/
+ *           ├─ manifest.md       (story dispatch manifest)
+ *           ├─ signals.ndjson    (append-only signals writer)
+ *           ├─ perf-summary.md
+ *           ├─ story-init.state.json   (dispatch-state writer)
+ *           └─ <name>            (storyArtifactPath escape hatch)
+ *
+ * Standalone Stories (no parent Epic) follow the same shape under
+ * `<tempRoot>/standalone/stories/story-<sid>/`. The `stories/` segment
+ * was introduced by Story #2940 to visually separate per-Epic artifacts
+ * from per-Story siblings.
  *
  * tempRoot resolution: the helper accepts an optional `config` argument
  * (the full resolved config `{ agentSettings, ... }` or the bare
@@ -150,14 +158,19 @@ export function epicTempDir(eid, config) {
 }
 
 /**
- * `temp/epic-<eid>/story-<sid>/` — every Story-scoped artifact lives
- * under here.
+ * `temp/epic-<eid>/stories/story-<sid>/` — every Story-scoped artifact
+ * lives under here.
  *
  * Story #2874: accepts `eid === null` for standalone Stories (no
  * parent Epic). The standalone variant routes to
- * `<tempRoot>/standalone/story-<sid>/` so signals + traces from
+ * `<tempRoot>/standalone/stories/story-<sid>/` so signals + traces from
  * `/single-story-deliver` runs still land in a stable, scannable
  * location instead of being dropped on the floor.
+ *
+ * Story #2940 introduced the intermediate `stories/` segment so that
+ * per-Epic top-level artifacts (`prd.md`, `techspec.md`, `manifest.md`,
+ * `retro.md`, `lifecycle.ndjson`, `baselines/`, `checkpoints/`) are
+ * visually and structurally separated from the per-Story siblings.
  *
  * @param {number|null} eid
  * @param {number} sid
@@ -170,12 +183,12 @@ export function storyTempDir(eid, sid, config) {
     checkedEid === null
       ? path.join(tempRootFrom(config), 'standalone')
       : epicTempDir(checkedEid, config);
-  return path.join(parent, `story-${storyId(sid)}`);
+  return path.join(parent, 'stories', `story-${storyId(sid)}`);
 }
 
 /**
- * `temp/epic-<eid>/story-<sid>/signals.ndjson` — append-only signal
- * stream consumed by the analyzer (Epic #1030 AC1).
+ * `temp/epic-<eid>/stories/story-<sid>/signals.ndjson` — append-only
+ * signal stream consumed by the analyzer (Epic #1030 AC1).
  *
  * @param {number} eid
  * @param {number} sid

--- a/.agents/scripts/lib/observability/perf-aggregator.js
+++ b/.agents/scripts/lib/observability/perf-aggregator.js
@@ -202,7 +202,7 @@ function phaseTimingsMs(timing) {
 
 /**
  * Compute the StoryPerfSummary payload from a list of NDJSON events
- * sampled out of `temp/epic-<eid>/story-<sid>/signals.ndjson` plus an
+ * sampled out of `temp/epic-<eid>/stories/story-<sid>/signals.ndjson` plus an
  * optional phase-timer summary.
  *
  * @param {Iterable<object>} events

--- a/.agents/scripts/lib/observability/signals-writer.js
+++ b/.agents/scripts/lib/observability/signals-writer.js
@@ -2,7 +2,7 @@
  * Append-only signals/trace writer (Epic #1030 Story #1041).
  *
  * Centralizes the per-(epic, story) NDJSON streams under
- * `temp/epic-<eid>/story-<sid>/signals.ndjson` (and a sibling
+ * `temp/epic-<eid>/stories/story-<sid>/signals.ndjson` (and a sibling
  * `traces.ndjson` for trace-shaped records). Detector modules and the
  * runtime trace hook all funnel through this writer so the on-disk
  * shape stays under one schema and one set of robustness guarantees.
@@ -18,7 +18,7 @@
  *     fire from inside per-Story sub-agents that may exit abruptly, and
  *     a buffered tail would silently disappear on `process.exit`.
  *   - **Lazy directory creation.** The first write to a fresh Story
- *     creates `temp/epic-<eid>/story-<sid>/` via `fs.mkdir(..., { recursive: true })`.
+ *     creates `temp/epic-<eid>/stories/story-<sid>/` via `fs.mkdir(..., { recursive: true })`.
  *     `epicId` / `storyId` are required positive integers — the
  *     `temp-paths.js` helpers assert this before we touch the disk.
  *
@@ -141,7 +141,7 @@ async function appendOne(targetPath, record) {
 }
 
 /**
- * Append one signal record to `temp/epic-<eid>/story-<sid>/signals.ndjson`.
+ * Append one signal record to `temp/epic-<eid>/stories/story-<sid>/signals.ndjson`.
  *
  * The `signal` is written verbatim — callers (detectors) own its shape
  * (kind, severity, message, etc.). The writer adds nothing. Errors are
@@ -192,7 +192,7 @@ export async function appendEpicSignal(args) {
 }
 
 /**
- * Append one trace record to `temp/epic-<eid>/story-<sid>/traces.ndjson`.
+ * Append one trace record to `temp/epic-<eid>/stories/story-<sid>/traces.ndjson`.
  * Same robustness contract as `appendSignal` — never throws.
  *
  * @param {{ epicId: number, storyId: number, trace: unknown, config?: object }} args

--- a/.agents/scripts/lib/observability/source-classifier.js
+++ b/.agents/scripts/lib/observability/source-classifier.js
@@ -5,7 +5,7 @@
  * `.agents/` submodule).
  *
  * Used by `signals-writer.js#appendSignal` / `appendEpicSignal` so every
- * record in `temp/epic-<eid>/story-<sid>/signals.ndjson` carries an
+ * record in `temp/epic-<eid>/stories/story-<sid>/signals.ndjson` carries an
  * authoritative `source` field, allowing downstream retro consumers to
  * route framework signals back to mandrel and keep consumer signals in
  * the host project (Epic #2547 / Story #2553).

--- a/.agents/scripts/lib/observability/tool-trace-hook.js
+++ b/.agents/scripts/lib/observability/tool-trace-hook.js
@@ -5,7 +5,7 @@
  * PostToolUse hook entries. Resolves the active Epic + Story from
  * environment variables (`CC_EPIC_ID` / `CC_STORY_ID`), pairs Pre/Post
  * tool-call events, and appends one `kind:"trace"` NDJSON line per tool
- * call to `temp/epic-<eid>/story-<sid>/traces.ndjson` via the
+ * call to `temp/epic-<eid>/stories/story-<sid>/traces.ndjson` via the
  * `signals-writer.appendTrace` helper.
  *
  * Robustness contract (Tech Spec #1032 §observability + §security):

--- a/.agents/scripts/lib/orchestration/detectors-phase.js
+++ b/.agents/scripts/lib/orchestration/detectors-phase.js
@@ -107,7 +107,7 @@ function isValidIdPair(eid, sid) {
 
 /**
  * Run the rework + retry detectors for one Story and persist every
- * emission to `temp/epic-<eid>/story-<sid>/signals.ndjson`.
+ * emission to `temp/epic-<eid>/stories/story-<sid>/signals.ndjson`.
  *
  * @param {{
  *   epicId: number|string,

--- a/.agents/scripts/lib/orchestration/epic-deliver-reconcile.js
+++ b/.agents/scripts/lib/orchestration/epic-deliver-reconcile.js
@@ -11,8 +11,8 @@
  * a `ITicketingProvider`-shaped provider, and a repo root, it enumerates
  * the Epic's direct children (Stories) that still carry `agent::executing`
  * or `agent::closing`, reads each Story's recorded dispatch PID from
- * `temp/epic-<id>/<storyId>/story-init.state.json`, probes that PID's
- * liveness, and groups each Story into one of three buckets:
+ * `temp/epic-<id>/stories/story-<storyId>/story-init.state.json`, probes
+ * that PID's liveness, and groups each Story into one of three buckets:
  *
  *   - `live`     — the recorded PID is alive (do not touch).
  *   - `dead`     — the PID was recorded but the process is gone (re-dispatch).
@@ -27,8 +27,8 @@
  */
 
 import fs from 'node:fs';
-import path from 'node:path';
 import { AGENT_LABELS } from '../label-constants.js';
+import { dispatchStateFilePath } from '../story-init/dispatch-state-writer.js';
 
 /**
  * Default PID liveness probe. Uses `process.kill(pid, 0)` which is a
@@ -53,31 +53,29 @@ export function defaultProbePid(pid) {
 
 /**
  * Read the dispatch PID for a Story from
- * `temp/epic-<epicId>/<storyId>/story-init.state.json`. Returns `null` when
- * the file does not exist or carries no recognized PID field — the caller
- * will classify the Story as `unknown` in that case.
+ * `temp/epic-<epicId>/stories/story-<storyId>/story-init.state.json`.
+ * Returns `null` when the file does not exist or carries no recognized
+ * PID field — the caller will classify the Story as `unknown` in that
+ * case.
  *
  * Recognized field names (in order of precedence):
  *
  *   - `dispatchPid` — the canonical name written by Story #2535's writer
  *     in `lib/story-init/dispatch-state-writer.js`.
  *   - `pid`         — legacy name accepted for backward compatibility
- *     with state files written before the writer landed (and with the
- *     pre-existing test fixtures that seed `pid` directly).
+ *     with the pre-existing test fixtures that seed `pid` directly.
+ *
+ * Path resolution is delegated to `dispatchStateFilePath` from the
+ * writer module so the reader and writer cannot drift apart (Story
+ * #2940).
  *
  * @param {string} repoRoot
- * @param {number|string} epicId
- * @param {number|string} storyId
+ * @param {number} epicId
+ * @param {number} storyId
  * @returns {number|null}
  */
 export function readDispatchPid(repoRoot, epicId, storyId) {
-  const statePath = path.join(
-    repoRoot,
-    'temp',
-    `epic-${epicId}`,
-    String(storyId),
-    'story-init.state.json',
-  );
+  const statePath = dispatchStateFilePath({ repoRoot, epicId, storyId });
   if (!fs.existsSync(statePath)) return null;
   let raw;
   try {

--- a/.agents/scripts/lib/orchestration/post-merge-pipeline.js
+++ b/.agents/scripts/lib/orchestration/post-merge-pipeline.js
@@ -12,7 +12,7 @@
  *   4. notification        — fire the story-complete webhook.
  *   5. dashboard-refresh   — regenerate the dispatch manifest.
  *   6. temp-cleanup        — delete the per-Story manifest pair under
- *                            `temp/epic-<eid>/story-<sid>/manifest.{md,json}`
+ *                            `temp/epic-<eid>/stories/story-<sid>/manifest.{md,json}`
  *                            (Epic #1030 Story #1040). Falls back to the
  *                            legacy flat `temp/story-manifest-<id>.{md,json}`
  *                            layout when `epicId` is unknown — both paths
@@ -635,7 +635,7 @@ export async function tempCleanupPhase(ctx) {
   const log = reapPhaseLogger(progress);
   const unlink = unlinkFn ?? (await import('node:fs/promises')).unlink;
 
-  // Per-Epic layout (Epic #1030 Story #1040): `temp/epic-<eid>/story-<sid>/manifest.{md,json}`.
+  // Per-Epic layout (Epic #1030 Story #1040): `temp/epic-<eid>/stories/story-<sid>/manifest.{md,json}`.
   // Legacy flat layout: `temp/story-manifest-<sid>.{md,json}`. The migration
   // tolerates both — try the per-Epic path first when `epicId` is known,
   // and always sweep the legacy path so a half-migrated cohort doesn't
@@ -647,11 +647,11 @@ export async function tempCleanupPhase(ctx) {
     targets.push(
       {
         path: storyArtifactPath(eid, sid, 'manifest.md', config),
-        label: `temp/epic-${epicId}/story-${storyId}/manifest.md`,
+        label: `temp/epic-${epicId}/stories/story-${storyId}/manifest.md`,
       },
       {
         path: storyArtifactPath(eid, sid, 'manifest.json', config),
-        label: `temp/epic-${epicId}/story-${storyId}/manifest.json`,
+        label: `temp/epic-${epicId}/stories/story-${storyId}/manifest.json`,
       },
     );
   }

--- a/.agents/scripts/lib/orchestration/story-close/post-merge-close.js
+++ b/.agents/scripts/lib/orchestration/story-close/post-merge-close.js
@@ -17,7 +17,7 @@
  * comment post was replaced by a `perf-summary` phase inside
  * post-merge-pipeline.js that shells out to `analyze-execution.js`. The
  * timer summary is written to a per-Story JSON file under
- * `temp/epic-<eid>/story-<sid>/phase-timings.json` so the analyzer can
+ * `temp/epic-<eid>/stories/story-<sid>/phase-timings.json` so the analyzer can
  * read it; this helper writes the file and hands the path to the pipeline.
  */
 

--- a/.agents/scripts/lib/presentation/manifest-persistence.js
+++ b/.agents/scripts/lib/presentation/manifest-persistence.js
@@ -3,7 +3,7 @@
  *
  * File I/O for dispatch / story manifests. All fs writes land under the
  * per-Epic tree (`temp/epic-<id>/manifest.{md,json}` for Epic dispatch
- * manifests; `temp/epic-<id>/story-<sid>/manifest.{md,json}` for Story
+ * manifests; `temp/epic-<id>/stories/story-<sid>/manifest.{md,json}` for Story
  * execution manifests — see Epic #1030 Story #1040 / Task #1053). The
  * formatter is injected so this module is testable against a tmpdir
  * without touching the real filesystem layout.
@@ -139,7 +139,7 @@ export function persistManifest(manifest, opts = {}) {
   let mdPath = null;
 
   if (manifest.type === 'story-execution') {
-    // Story manifests live under `temp/epic-<eid>/story-<sid>/`. When the
+    // Story manifests live under `temp/epic-<eid>/stories/story-<sid>/`. When the
     // manifest carries multiple stories, fall back to the first entry's
     // epicId for the directory key (the dispatcher only ever bundles
     // stories that share an Epic; the multi-Epic case is a hand-rolled

--- a/.agents/scripts/lib/signals/read.js
+++ b/.agents/scripts/lib/signals/read.js
@@ -145,12 +145,15 @@ async function* streamFile(target, kindFilter) {
 }
 
 /**
- * List every `story-<id>/signals.ndjson` path under the Epic's
+ * List every `stories/story-<id>/signals.ndjson` path under the Epic's
  * `<tempRoot>/epic-<epic>/` directory. Returns an empty array when the
  * Epic directory is missing.
  *
  * The returned paths are sorted by Story ID ascending so the iterator's
  * output is stable across runs.
+ *
+ * Story #2940 nested per-Story directories under a `stories/` segment.
+ * Epic-level signals continue to live at the Epic root.
  *
  * @param {number} epic
  * @param {object | undefined} config
@@ -158,24 +161,39 @@ async function* streamFile(target, kindFilter) {
  */
 async function listEpicStorySignalsFiles(epic, config) {
   const epicDir = epicTempDir(epic, config);
-  let entries;
+  let epicEntries;
   try {
-    entries = await fs.readdir(epicDir, { withFileTypes: true });
+    epicEntries = await fs.readdir(epicDir, { withFileTypes: true });
   } catch {
     return [];
   }
-  const storyIds = [];
   let hasEpicLevelSignals = false;
-  for (const ent of entries) {
-    if (ent.isDirectory()) {
+  let hasStoriesDir = false;
+  for (const ent of epicEntries) {
+    if (ent.isDirectory() && ent.name === 'stories') {
+      hasStoriesDir = true;
+    } else if (ent.isFile() && ent.name === 'signals.ndjson') {
+      // Story #1430 — wave-runner lifecycle signals land here.
+      hasEpicLevelSignals = true;
+    }
+  }
+  const storyIds = [];
+  if (hasStoriesDir) {
+    let storyEntries;
+    try {
+      storyEntries = await fs.readdir(path.join(epicDir, 'stories'), {
+        withFileTypes: true,
+      });
+    } catch {
+      storyEntries = [];
+    }
+    for (const ent of storyEntries) {
+      if (!ent.isDirectory()) continue;
       const m = /^story-(\d+)$/.exec(ent.name);
       if (!m) continue;
       const sid = Number.parseInt(m[1], 10);
       if (!isPositiveInt(sid)) continue;
       storyIds.push(sid);
-    } else if (ent.isFile() && ent.name === 'signals.ndjson') {
-      // Story #1430 — wave-runner lifecycle signals land here.
-      hasEpicLevelSignals = true;
     }
   }
   storyIds.sort((a, b) => a - b);

--- a/.agents/scripts/lib/story-init/dispatch-state-writer.js
+++ b/.agents/scripts/lib/story-init/dispatch-state-writer.js
@@ -2,10 +2,16 @@
  * lib/story-init/dispatch-state-writer.js — Story #2535 (Epic #2527).
  *
  * Writes the per-Story dispatch state file at
- * `temp/epic-<epicId>/<storyId>/story-init.state.json` so the host-crash
- * watchdog (`reconcileEpicAgentLabels` in
+ * `temp/epic-<epicId>/stories/story-<storyId>/story-init.state.json` so
+ * the host-crash watchdog (`reconcileEpicAgentLabels` in
  * `lib/orchestration/epic-deliver-reconcile.js`) can probe the dispatch
  * PID's liveness and classify Stories as `live` / `dead` / `unknown`.
+ *
+ * Story #2940 routed both the writer and the reconciler reader through
+ * `storyArtifactPath` in `lib/config/temp-paths.js`. Before that, both
+ * sides hand-rolled `temp/epic-<id>/<storyId>/...` — a bare numeric
+ * directory next to the canonical `stories/story-<sid>/` tree. Both
+ * sides now share the helper as the single producer of the path.
  *
  * Before this writer existed, every Story that the watchdog inspected
  * classified as `unknown` because no PID was ever recorded. With the
@@ -30,27 +36,34 @@
 
 import fs from 'node:fs';
 import path from 'node:path';
+import { storyArtifactPath } from '../config/temp-paths.js';
+
+export const DISPATCH_STATE_FILENAME = 'story-init.state.json';
 
 /**
- * Compute the canonical state-file path for a given Story.
+ * Compute the canonical state-file path for a given Story. Delegates to
+ * `storyArtifactPath` from `lib/config/temp-paths.js` so the writer and
+ * the reconciler reader cannot drift apart.
  *
  * @param {object} args
  * @param {string} args.repoRoot Absolute path to the main repo root (where
  *   `temp/` lives). The state file is intentionally written under the
  *   main repo's `temp/` tree, not the worktree's — the reconciler reads
  *   from there too.
- * @param {number|string} args.epicId
- * @param {number|string} args.storyId
+ * @param {number} args.epicId
+ * @param {number} args.storyId
+ * @param {object} [args.config]  Optional resolved config; when omitted
+ *   the helper defaults `tempRoot` to `'temp'`.
  * @returns {string}
  */
-export function dispatchStateFilePath({ repoRoot, epicId, storyId }) {
-  return path.join(
-    repoRoot,
-    'temp',
-    `epic-${epicId}`,
-    String(storyId),
-    'story-init.state.json',
+export function dispatchStateFilePath({ repoRoot, epicId, storyId, config }) {
+  const rel = storyArtifactPath(
+    epicId,
+    storyId,
+    DISPATCH_STATE_FILENAME,
+    config,
   );
+  return path.join(repoRoot, rel);
 }
 
 /**
@@ -80,9 +93,10 @@ export function buildDispatchStatePayload({
 
 /**
  * Write the dispatch state file for a Story. Idempotent: overwrites an
- * existing file. Creates the `temp/epic-<id>/<storyId>/` directory tree
- * when missing. Returns the absolute path written so callers (and tests)
- * can assert location.
+ * existing file. Creates the
+ * `temp/epic-<id>/stories/story-<storyId>/` directory tree when missing.
+ * Returns the absolute path written so callers (and tests) can assert
+ * location.
  *
  * @param {object} args
  * @param {string} args.repoRoot      Absolute path to the main repo root.
@@ -92,6 +106,8 @@ export function buildDispatchStatePayload({
  * @param {string} args.worktreePath  Absolute path to the worktree.
  * @param {number} [args.dispatchPid] Defaults to `process.pid`.
  * @param {string} [args.startedAt]   Defaults to `new Date().toISOString()`.
+ * @param {object} [args.config]      Optional resolved config bag forwarded
+ *   to the path helper.
  * @returns {{path:string,payload:object}}
  */
 export function writeDispatchStateFile({
@@ -102,6 +118,7 @@ export function writeDispatchStateFile({
   worktreePath,
   dispatchPid = process.pid,
   startedAt,
+  config,
 }) {
   if (typeof repoRoot !== 'string' || repoRoot.length === 0) {
     throw new Error(
@@ -129,7 +146,12 @@ export function writeDispatchStateFile({
     );
   }
 
-  const filePath = dispatchStateFilePath({ repoRoot, epicId, storyId });
+  const filePath = dispatchStateFilePath({
+    repoRoot,
+    epicId,
+    storyId,
+    config,
+  });
   fs.mkdirSync(path.dirname(filePath), { recursive: true });
   const payload = buildDispatchStatePayload({
     dispatchPid,

--- a/.agents/scripts/story-init.js
+++ b/.agents/scripts/story-init.js
@@ -249,7 +249,8 @@ export async function runStoryInit({
     installStatus = branchResult.installStatus ?? installStatus;
 
     // Story #2535 — write the per-Story dispatch state file under the
-    // main repo's `temp/epic-<id>/<storyId>/story-init.state.json` so the
+    // main repo's
+    // `temp/epic-<id>/stories/story-<storyId>/story-init.state.json` so the
     // host-crash watchdog (`reconcileEpicAgentLabels`) can probe this
     // Story's dispatch PID and classify the Story as live / dead / unknown
     // instead of always falling back to `unknown`. Non-fatal: a failed

--- a/.agents/workflows/helpers/signals.md
+++ b/.agents/workflows/helpers/signals.md
@@ -19,7 +19,7 @@ description: >-
 ## Overview
 
 `signals-view.js` is the operator-facing viewer for the consolidated
-signals stream. It reads `temp/epic-<eid>/story-<sid>/signals.ndjson` via
+signals stream. It reads `temp/epic-<eid>/stories/story-<sid>/signals.ndjson` via
 [`lib/signals/read`](../../scripts/lib/signals/read.js), builds an
 in-memory span-tree via
 [`lib/signals/buildSpanTree`](../../scripts/lib/signals/span-tree.js), and

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -330,7 +330,7 @@ envelope so Phase 7 stays non-blocking.
 | Module                                              | Role                                                                                                                                                  |
 | --------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `lib/orchestration/epic-runner/commit-assertion.js` | Post-wave guard — a "done" wave whose stories produced zero commits on `origin/story-<id>` is reclassified as `halted` instead of silently passing.   |
-| `lib/observability/signals-writer.js`               | Append-only NDJSON writer for `friction` / trace records under `temp/epic-<eid>/story-<sid>/signals.ndjson`. The single producer for the telemetry pipeline; the consolidated reader (`lib/observability/signals-reader.js`) is the sole consumer. |
+| `lib/observability/signals-writer.js`               | Append-only NDJSON writer for `friction` / trace records under `temp/epic-<eid>/stories/story-<sid>/signals.ndjson`. The single producer for the telemetry pipeline; the consolidated reader (`lib/observability/signals-reader.js`) is the sole consumer. |
 | `lib/orchestration/column-sync.js`                  | Drives the Projects v2 Status column from `agent::` labels (best-effort). Invoked from inside `transitionTicketState` (Story #2548) so every label flip — Epic, Story, Task — mirrors onto the board.                  |
 
 `CommitAssertion`'s default git adapter falls back to a `resolves #<storyId>`
@@ -866,7 +866,7 @@ detectors and config keys were dropped under Epic #1721 (see ADR in
 [`docs/decisions.md`](decisions.md)) but the names remain in
 `EVENT_KINDS` so a future re-introduction does not need a schema bump.
 Records are written **append-only to local disk** under
-`temp/epic-<eid>/story-<sid>/signals.ndjson` (and a sibling
+`temp/epic-<eid>/stories/story-<sid>/signals.ndjson` (and a sibling
 `traces.ndjson` for `kind: trace`). GitHub tickets receive **summaries
 only**, never raw events.
 
@@ -1017,7 +1017,7 @@ Local close-validation, `epic-code-review`, and `/epic-deliver` Phase 3
 run the wrapper records
 `{ gateName, commitSha, commandConfigHash, timestamp }` under the per-Epic
 tree at `temp/epic-<epicId>/validation-evidence.json` for Epic-scoped
-gates and `temp/epic-<epicId>/story-<storyId>/validation-evidence.json`
+gates and `temp/epic-<epicId>/stories/story-<storyId>/validation-evidence.json`
 for Story-scoped gates (both gitignored via `temp/`). Callers must pass
 both `--scope-id` and `--epic-id`. Subsequent invocations against the same
 `git rev-parse HEAD` and resolved command config skip in milliseconds.

--- a/docs/data-dictionary.md
+++ b/docs/data-dictionary.md
@@ -8,7 +8,7 @@ Mandrel orchestration engine.
 ## SignalEvent (`signals.ndjson` line)
 
 One newline-terminated JSON object emitted by `signals-writer.appendSignal`
-to `temp/epic-<eid>/story-<sid>/signals.ndjson` (and a sibling
+to `temp/epic-<eid>/stories/story-<sid>/signals.ndjson` (and a sibling
 `traces.ndjson` for `kind: trace`). Closed taxonomy of seven record kinds —
 `friction`, `hotspot`, `rework`, `churn`, `idle`, `retry`, `trace` — defined
 by Epic #1030. Schema lives at
@@ -74,7 +74,7 @@ into one rolled-up report. Schema lives at
 
 ## FrictionEvent (`friction` NDJSON signal)
 
-Appended to `temp/epic-<eid>/story-<sid>/signals.ndjson` by
+Appended to `temp/epic-<eid>/stories/story-<sid>/signals.ndjson` by
 `signals-writer.appendSignal` when detector or gate-failure paths
 trip. (Pre Epic #1030 Story #1042 the same payload was posted as a
 GitHub structured comment by the now-deleted in-process emitter.)
@@ -243,7 +243,7 @@ the Epic is the SSOT; the on-disk file is a renderer cache regenerable via
 | `progress-signals/stalled-worktree.js`              | Detector | Mechanical `ProgressReporter` detector; flags Stories where `agent::done` ships with a live `.worktrees/story-<id>/` directory still on disk.                                                          |
 | `progress-signals/maintainability-drift.js`         | Detector | Mechanical detector; emits a Notable bullet when the maintainability score for any tracked file drifts negatively from the wave-start baseline.                                                        |
 | `progress-signals/crap-drift.js`                    | Detector | Mechanical detector; per-method CRAP drift versus a wave-start baseline. Surfaces a `🧨 CRAP drift: <file>::<method> <score> (ceiling <N>)` bullet when a method crosses the configured ceiling or rises by ≥ threshold. |
-| `signals-writer.appendSignal`                       | Helper   | Append-only NDJSON writer at `lib/observability/signals-writer.js`. Writes one JSON record per line to `temp/epic-<eid>/story-<sid>/signals.ndjson`. Consumers: `diagnose-friction.js`, `story-close.js` reap-failure (via `post-merge-pipeline.js`), `epic-runner/progress-reporter.js` poller-failure, `check-maintainability.js`, and `check-crap.js`. Replaced the deleted in-process emitter class in Epic #1030 Story #1042. |
+| `signals-writer.appendSignal`                       | Helper   | Append-only NDJSON writer at `lib/observability/signals-writer.js`. Writes one JSON record per line to `temp/epic-<eid>/stories/story-<sid>/signals.ndjson`. Consumers: `diagnose-friction.js`, `story-close.js` reap-failure (via `post-merge-pipeline.js`), `epic-runner/progress-reporter.js` poller-failure, `check-maintainability.js`, and `check-crap.js`. Replaced the deleted in-process emitter class in Epic #1030 Story #1042. |
 | `--reap-discard-after-merge` / `--no-reap-discard-after-merge` | CLI flag | `/epic-deliver` Phase 7 flag. Default force-reaps worktrees whose Story branch is already merged into `epic/<id>` (per `git merge-base --is-ancestor`), discarding uncommitted post-merge drift; the `--no-` form preserves prior skip-on-uncommitted behavior. Force-reap emits a `friction` comment listing discarded paths. |
 | Version-bump-intent snapshot                        | Checkpoint | `/epic-deliver` Phase 0.5 parses the Epic body for `Release target:` / `--segment` directives and posts a `notification` structured comment on the Epic (marker `<!-- notification: version-bump-intent -->`) when they disagree with `release.autoVersionBump`.            |
 | Launcher-level config validation                    | Contract | `validateOrchestrationConfig(config)` runs in `main()` of `epic-runner.js`, `plan-runner.js`, `epic-plan-spec.js`, and `epic-plan-decompose.js` — a schema-invalid `.agentrc.json` exits non-zero before any long-running flow begins. |
@@ -382,7 +382,7 @@ Evidence is per-clone, gitignored, and never committed.
 
 Evidence is keyed on `{ scopeId, gateName }` and lives under the per-Epic
 tree at `temp/epic-<epicId>/validation-evidence.json` (Epic-scoped) or
-`temp/epic-<epicId>/story-<storyId>/validation-evidence.json`
+`temp/epic-<epicId>/stories/story-<storyId>/validation-evidence.json`
 (Story-scoped). Callers must thread both the scope id and the owning Epic
 id through the wrapper. The wrapper at `evidence-gate.js` is the only
 writer; close-validation, `epic-code-review`, and `/epic-deliver` Phase 4

--- a/docs/patterns.md
+++ b/docs/patterns.md
@@ -583,7 +583,7 @@ being captured.
 
 `lib/observability/signals-writer.js#appendSignal` appends one
 newline-terminated JSON record per friction event to
-`temp/epic-<eid>/story-<sid>/signals.ndjson`. Records are best-effort
+`temp/epic-<eid>/stories/story-<sid>/signals.ndjson`. Records are best-effort
 (any fs failure is logged via `Logger.warn` and swallowed — observability
 must not halt the runner) and are picked up out-of-band by the analyzer
 (Epic #1030).
@@ -1036,7 +1036,7 @@ across phases against the same tree, the framework wraps each invocation
 in `evidence-gate.js`. On success the wrapper writes
 `{ gateName, commitSha, commandConfigHash, timestamp }` under the per-Epic
 tree at `temp/epic-<epicId>/validation-evidence.json` (Epic-scoped) or
-`temp/epic-<epicId>/story-<storyId>/validation-evidence.json`
+`temp/epic-<epicId>/stories/story-<storyId>/validation-evidence.json`
 (Story-scoped). The next caller reads the record, compares against `git
 rev-parse HEAD` and the resolved command config, and skips when both
 match.

--- a/tests/analyze-execution.test.js
+++ b/tests/analyze-execution.test.js
@@ -69,14 +69,14 @@ afterEach(() => {
 });
 
 async function seedSignals(eid, sid, lines) {
-  const dir = path.join(workRoot, `epic-${eid}`, `story-${sid}`);
+  const dir = path.join(workRoot, `epic-${eid}`, 'stories', `story-${sid}`);
   await fs.mkdir(dir, { recursive: true });
   const body = `${lines.map((l) => JSON.stringify(l)).join('\n')}\n`;
   await fs.writeFile(path.join(dir, 'signals.ndjson'), body);
 }
 
 async function seedPhaseTimings(eid, sid, payload) {
-  const dir = path.join(workRoot, `epic-${eid}`, `story-${sid}`);
+  const dir = path.join(workRoot, `epic-${eid}`, 'stories', `story-${sid}`);
   await fs.mkdir(dir, { recursive: true });
   await fs.writeFile(
     path.join(dir, 'phase-timings.json'),

--- a/tests/diagnose-friction.test.js
+++ b/tests/diagnose-friction.test.js
@@ -3,7 +3,7 @@
  *
  * Tests the diagnose-friction.js script, which wraps commands and on
  * failure appends a structured `friction` signal to the per-Story
- * `temp/epic-<eid>/story-<sid>/signals.ndjson` stream via
+ * `temp/epic-<eid>/stories/story-<sid>/signals.ndjson` stream via
  * `signals-writer.appendSignal`.
  *
  * Story #1042 cut the GitHub-comment side: there is no longer a
@@ -131,6 +131,7 @@ describe('diagnose-friction.js — appends friction signal to NDJSON', () => {
       tmpRoot,
       'temp',
       'epic-1030',
+      'stories',
       'story-1042',
       'signals.ndjson',
     );
@@ -186,6 +187,7 @@ describe('diagnose-friction.js — appends friction signal to NDJSON', () => {
       tmpRoot,
       'temp',
       'epic-1030',
+      'stories',
       'story-1042',
       'signals.ndjson',
     );

--- a/tests/gate-friction.test.js
+++ b/tests/gate-friction.test.js
@@ -70,6 +70,7 @@ describe('emitFrictionSignal', () => {
     const signalsPath = path.join(
       tmpRoot,
       'epic-7',
+      'stories',
       'story-42',
       'signals.ndjson',
     );

--- a/tests/lib/config/temp-paths.test.js
+++ b/tests/lib/config/temp-paths.test.js
@@ -77,7 +77,7 @@ describe('lib/config/temp-paths.js — Epic / Story directory helpers', () => {
   it('builds the canonical story dir', () => {
     assert.equal(
       storyTempDir(1030, 1042),
-      path.join('temp', 'epic-1030', 'story-1042'),
+      path.join('temp', 'epic-1030', 'stories', 'story-1042'),
     );
   });
 
@@ -91,10 +91,10 @@ describe('lib/config/temp-paths.js — Epic / Story directory helpers', () => {
 });
 
 describe('lib/config/temp-paths.js — signals + canonical artifact paths', () => {
-  it('signalsFile resolves to story-<sid>/signals.ndjson', () => {
+  it('signalsFile resolves to stories/story-<sid>/signals.ndjson', () => {
     assert.equal(
       signalsFile(1030, 1042),
-      path.join('temp', 'epic-1030', 'story-1042', 'signals.ndjson'),
+      path.join('temp', 'epic-1030', 'stories', 'story-1042', 'signals.ndjson'),
     );
   });
 
@@ -121,11 +121,17 @@ describe('lib/config/temp-paths.js — signals + canonical artifact paths', () =
   it('Story-level canonical filenames live under the Story dir', () => {
     assert.equal(
       storyManifestPath(1030, 1042),
-      path.join('temp', 'epic-1030', 'story-1042', 'manifest.md'),
+      path.join('temp', 'epic-1030', 'stories', 'story-1042', 'manifest.md'),
     );
     assert.equal(
       storyPerfSummaryPath(1030, 1042),
-      path.join('temp', 'epic-1030', 'story-1042', 'perf-summary.md'),
+      path.join(
+        'temp',
+        'epic-1030',
+        'stories',
+        'story-1042',
+        'perf-summary.md',
+      ),
     );
   });
 });
@@ -138,7 +144,7 @@ describe('lib/config/temp-paths.js — artifact-name guards', () => {
     );
     assert.equal(
       storyArtifactPath(1030, 1042, 'custom.txt'),
-      path.join('temp', 'epic-1030', 'story-1042', 'custom.txt'),
+      path.join('temp', 'epic-1030', 'stories', 'story-1042', 'custom.txt'),
     );
   });
 
@@ -210,7 +216,15 @@ describe('lib/config/temp-paths.js — path.join semantics (Windows + POSIX)', (
     );
     assert.equal(
       signalsFile(1030, 1042, cfg),
-      path.join('a', 'b', 'temp', 'epic-1030', 'story-1042', 'signals.ndjson'),
+      path.join(
+        'a',
+        'b',
+        'temp',
+        'epic-1030',
+        'stories',
+        'story-1042',
+        'signals.ndjson',
+      ),
     );
   });
 
@@ -220,23 +234,29 @@ describe('lib/config/temp-paths.js — path.join semantics (Windows + POSIX)', (
     // the exact separator that ships on the host.
     const dir = storyTempDir(1030, 1042);
     assert.ok(
-      dir.includes(`epic-1030${SEP}story-1042`),
+      dir.includes(`epic-1030${SEP}stories${SEP}story-1042`),
       `expected platform separator '${SEP}' in ${dir}`,
     );
   });
 });
 
 describe('lib/config/temp-paths.js — standalone Story routing (Story #2874)', () => {
-  it('storyTempDir(null, sid) routes to <tempRoot>/standalone/story-<sid>', () => {
+  it('storyTempDir(null, sid) routes to <tempRoot>/standalone/stories/story-<sid>', () => {
     const dir = storyTempDir(null, 1042);
-    assert.equal(dir, path.join('temp', 'standalone', 'story-1042'));
+    assert.equal(dir, path.join('temp', 'standalone', 'stories', 'story-1042'));
   });
 
   it('signalsFile(null, sid) routes through the standalone parent', () => {
     const file = signalsFile(null, 1042);
     assert.equal(
       file,
-      path.join('temp', 'standalone', 'story-1042', 'signals.ndjson'),
+      path.join(
+        'temp',
+        'standalone',
+        'stories',
+        'story-1042',
+        'signals.ndjson',
+      ),
     );
   });
 
@@ -244,7 +264,7 @@ describe('lib/config/temp-paths.js — standalone Story routing (Story #2874)', 
     const file = storyArtifactPath(null, 7, 'manifest.md');
     assert.equal(
       file,
-      path.join('temp', 'standalone', 'story-7', 'manifest.md'),
+      path.join('temp', 'standalone', 'stories', 'story-7', 'manifest.md'),
     );
   });
 
@@ -252,7 +272,7 @@ describe('lib/config/temp-paths.js — standalone Story routing (Story #2874)', 
     const cfg = { project: { paths: { tempRoot: path.join('a', 'b') } } };
     assert.equal(
       storyTempDir(null, 7, cfg),
-      path.join('a', 'b', 'standalone', 'story-7'),
+      path.join('a', 'b', 'standalone', 'stories', 'story-7'),
     );
   });
 

--- a/tests/lib/manifest-persistence.test.js
+++ b/tests/lib/manifest-persistence.test.js
@@ -86,6 +86,7 @@ test('persistence: writes story-manifest json + md under per-Story dir', () => {
     root,
     'temp',
     'epic-999099',
+    'stories',
     'story-42',
     'manifest.md',
   );
@@ -93,13 +94,17 @@ test('persistence: writes story-manifest json + md under per-Story dir', () => {
     root,
     'temp',
     'epic-999099',
+    'stories',
     'story-42',
     'manifest.json',
   );
-  assert.ok(fs.existsSync(mdPath), 'epic-999099/story-42/manifest.md missing');
+  assert.ok(
+    fs.existsSync(mdPath),
+    'epic-999099/stories/story-42/manifest.md missing',
+  );
   assert.ok(
     fs.existsSync(jsonPath),
-    'epic-999099/story-42/manifest.json missing',
+    'epic-999099/stories/story-42/manifest.json missing',
   );
   const md = fs.readFileSync(mdPath, 'utf8');
   assert.ok(md.includes('Story #42'));

--- a/tests/lib/observability/perf-aggregator.regression.test.js
+++ b/tests/lib/observability/perf-aggregator.regression.test.js
@@ -113,7 +113,7 @@ describe('perf-aggregator regression — streaming-from-store path', () => {
   beforeEach(async () => {
     workRoot = mkdtempSync(path.join(tmpdir(), 'perf-aggregator-regression-'));
     cfg = { project: { paths: { tempRoot: workRoot } } };
-    const dir = path.join(workRoot, 'epic-1030', 'story-1041');
+    const dir = path.join(workRoot, 'epic-1030', 'stories', 'story-1041');
     await fs.mkdir(dir, { recursive: true });
     const raw = await fs.readFile(FIXTURE_NDJSON, 'utf8');
     await fs.writeFile(path.join(dir, 'signals.ndjson'), raw, 'utf8');

--- a/tests/lib/observability/render/epic-perf-report-hotspot.test.js
+++ b/tests/lib/observability/render/epic-perf-report-hotspot.test.js
@@ -60,7 +60,12 @@ async function writeEpicSignals(events) {
 }
 
 async function writeStorySignals(events) {
-  const dir = path.join(workRoot, `epic-${EPIC_ID}`, `story-${STORY_ID}`);
+  const dir = path.join(
+    workRoot,
+    `epic-${EPIC_ID}`,
+    'stories',
+    `story-${STORY_ID}`,
+  );
   await fs.mkdir(dir, { recursive: true });
   const body = events.map((e) => JSON.stringify(e)).join('\n');
   await fs.writeFile(path.join(dir, 'signals.ndjson'), `${body}\n`, 'utf8');

--- a/tests/lib/observability/render/story-perf-summary-detectors.test.js
+++ b/tests/lib/observability/render/story-perf-summary-detectors.test.js
@@ -47,7 +47,12 @@ let cfg;
 beforeEach(async () => {
   workRoot = mkdtempSync(path.join(tmpdir(), 'story-perf-summary-detectors-'));
   cfg = { project: { paths: { tempRoot: workRoot } } };
-  const dir = path.join(workRoot, `epic-${EPIC_ID}`, `story-${STORY_ID}`);
+  const dir = path.join(
+    workRoot,
+    `epic-${EPIC_ID}`,
+    'stories',
+    `story-${STORY_ID}`,
+  );
   await fs.mkdir(dir, { recursive: true });
 });
 
@@ -59,6 +64,7 @@ async function writeSignals(events) {
   const target = path.join(
     workRoot,
     `epic-${EPIC_ID}`,
+    'stories',
     `story-${STORY_ID}`,
     'signals.ndjson',
   );

--- a/tests/lib/observability/signals-writer.test.js
+++ b/tests/lib/observability/signals-writer.test.js
@@ -36,9 +36,21 @@ afterEach(() => {
 });
 
 const signalsPath = (eid, sid) =>
-  path.join(workRoot, `epic-${eid}`, `story-${sid}`, 'signals.ndjson');
+  path.join(
+    workRoot,
+    `epic-${eid}`,
+    'stories',
+    `story-${sid}`,
+    'signals.ndjson',
+  );
 const tracesPath = (eid, sid) =>
-  path.join(workRoot, `epic-${eid}`, `story-${sid}`, 'traces.ndjson');
+  path.join(
+    workRoot,
+    `epic-${eid}`,
+    'stories',
+    `story-${sid}`,
+    'traces.ndjson',
+  );
 
 describe('signals-writer — appendSignal correctness', () => {
   it('writes 100 valid newline-terminated JSON lines', async () => {

--- a/tests/lib/observability/tool-trace-hook.test.js
+++ b/tests/lib/observability/tool-trace-hook.test.js
@@ -38,11 +38,25 @@ const ORIGINAL_ENV = { ...process.env };
 // The hook calls appendTrace without a `config` arg, so the writer
 // resolves tempRoot via the project default of `'temp'` relative to
 // process.cwd(). We chdir into `workRoot` per-test, so the on-disk
-// layout is `<workRoot>/temp/epic-<eid>/story-<sid>/...`.
+// layout is `<workRoot>/temp/epic-<eid>/stories/story-<sid>/...`.
 const tracesPath = (eid, sid) =>
-  path.join(workRoot, 'temp', `epic-${eid}`, `story-${sid}`, 'traces.ndjson');
+  path.join(
+    workRoot,
+    'temp',
+    `epic-${eid}`,
+    'stories',
+    `story-${sid}`,
+    'traces.ndjson',
+  );
 const signalsPath = (eid, sid) =>
-  path.join(workRoot, 'temp', `epic-${eid}`, `story-${sid}`, 'signals.ndjson');
+  path.join(
+    workRoot,
+    'temp',
+    `epic-${eid}`,
+    'stories',
+    `story-${sid}`,
+    'signals.ndjson',
+  );
 
 beforeEach(() => {
   workRoot = mkdtempSync(path.join(tmpdir(), 'tool-trace-hook-'));
@@ -166,7 +180,14 @@ describe('tool-trace-hook — Pre/Post pairing', () => {
     );
 
     const raw = await fs.readFile(
-      path.join(workRoot, 'temp', 'epic-1030', 'story-1043', 'traces.ndjson'),
+      path.join(
+        workRoot,
+        'temp',
+        'epic-1030',
+        'stories',
+        'story-1043',
+        'traces.ndjson',
+      ),
       'utf8',
     );
     const lines = raw.trim().split('\n');
@@ -199,7 +220,14 @@ describe('tool-trace-hook — Pre/Post pairing', () => {
     );
 
     const raw = await fs.readFile(
-      path.join(workRoot, 'temp', 'epic-1030', 'story-1043', 'traces.ndjson'),
+      path.join(
+        workRoot,
+        'temp',
+        'epic-1030',
+        'stories',
+        'story-1043',
+        'traces.ndjson',
+      ),
       'utf8',
     );
     const lines = raw.trim().split('\n');
@@ -239,7 +267,14 @@ describe('tool-trace-hook — hashing & privacy', () => {
     );
 
     const raw = await fs.readFile(
-      path.join(workRoot, 'temp', 'epic-1030', 'story-1043', 'traces.ndjson'),
+      path.join(
+        workRoot,
+        'temp',
+        'epic-1030',
+        'stories',
+        'story-1043',
+        'traces.ndjson',
+      ),
       'utf8',
     );
     // The raw secret must NOT appear anywhere in the file.
@@ -268,7 +303,14 @@ describe('tool-trace-hook — hashing & privacy', () => {
     );
 
     const raw = await fs.readFile(
-      path.join(workRoot, 'temp', 'epic-1030', 'story-1043', 'traces.ndjson'),
+      path.join(
+        workRoot,
+        'temp',
+        'epic-1030',
+        'stories',
+        'story-1043',
+        'traces.ndjson',
+      ),
       'utf8',
     );
     assert.equal(
@@ -367,7 +409,14 @@ describe('tool-trace-hook — normalizedHash on trace records (Story #1768 / Tas
     );
 
     const raw = await fs.readFile(
-      path.join(workRoot, 'temp', 'epic-1030', 'story-1043', 'traces.ndjson'),
+      path.join(
+        workRoot,
+        'temp',
+        'epic-1030',
+        'stories',
+        'story-1043',
+        'traces.ndjson',
+      ),
       'utf8',
     );
     const trace = JSON.parse(raw.trim());
@@ -406,7 +455,14 @@ describe('tool-trace-hook — normalizedHash on trace records (Story #1768 / Tas
     );
 
     const raw = await fs.readFile(
-      path.join(workRoot, 'temp', 'epic-1030', 'story-1043', 'traces.ndjson'),
+      path.join(
+        workRoot,
+        'temp',
+        'epic-1030',
+        'stories',
+        'story-1043',
+        'traces.ndjson',
+      ),
       'utf8',
     );
     const lines = raw
@@ -448,7 +504,14 @@ describe('tool-trace-hook — normalizedHash on trace records (Story #1768 / Tas
     );
 
     const raw = await fs.readFile(
-      path.join(workRoot, 'temp', 'epic-1030', 'story-1043', 'traces.ndjson'),
+      path.join(
+        workRoot,
+        'temp',
+        'epic-1030',
+        'stories',
+        'story-1043',
+        'traces.ndjson',
+      ),
       'utf8',
     );
     const lines = raw
@@ -477,7 +540,14 @@ describe('tool-trace-hook — normalizedHash on trace records (Story #1768 / Tas
     );
 
     const raw = await fs.readFile(
-      path.join(workRoot, 'temp', 'epic-1030', 'story-1043', 'traces.ndjson'),
+      path.join(
+        workRoot,
+        'temp',
+        'epic-1030',
+        'stories',
+        'story-1043',
+        'traces.ndjson',
+      ),
       'utf8',
     );
     const lines = raw
@@ -510,7 +580,14 @@ describe('tool-trace-hook — normalizedHash on trace records (Story #1768 / Tas
     }
 
     const raw = await fs.readFile(
-      path.join(workRoot, 'temp', 'epic-1030', 'story-1043', 'traces.ndjson'),
+      path.join(
+        workRoot,
+        'temp',
+        'epic-1030',
+        'stories',
+        'story-1043',
+        'traces.ndjson',
+      ),
       'utf8',
     );
     const lines = raw
@@ -548,7 +625,14 @@ describe('tool-trace-hook — normalizedHash on trace records (Story #1768 / Tas
     );
 
     const raw = await fs.readFile(
-      path.join(workRoot, 'temp', 'epic-1030', 'story-1043', 'traces.ndjson'),
+      path.join(
+        workRoot,
+        'temp',
+        'epic-1030',
+        'stories',
+        'story-1043',
+        'traces.ndjson',
+      ),
       'utf8',
     );
     const lines = raw
@@ -573,7 +657,14 @@ describe('tool-trace-hook — normalizedHash on trace records (Story #1768 / Tas
     );
 
     const raw = await fs.readFile(
-      path.join(workRoot, 'temp', 'epic-1030', 'story-1043', 'traces.ndjson'),
+      path.join(
+        workRoot,
+        'temp',
+        'epic-1030',
+        'stories',
+        'story-1043',
+        'traces.ndjson',
+      ),
       'utf8',
     );
     const trace = JSON.parse(raw.trim());

--- a/tests/lib/orchestration/post-merge-pipeline.test.js
+++ b/tests/lib/orchestration/post-merge-pipeline.test.js
@@ -26,7 +26,7 @@ import {
 /**
  * Friction signals land on disk as NDJSON via
  * `signals-writer.appendSignal` (Epic #1030 Story #1042), which
- * resolves `temp/epic-<eid>/story-<sid>/signals.ndjson` relative to
+ * resolves `temp/epic-<eid>/stories/story-<sid>/signals.ndjson` relative to
  * `process.cwd()`. The reap-failure tests below switch cwd to a fresh
  * tmpdir so the asserted writes never collide with the repo's real
  * `temp/` tree.
@@ -39,6 +39,7 @@ function readFrictionSignals(epicId, storyId) {
     workRoot,
     'temp',
     `epic-${epicId}`,
+    'stories',
     `story-${storyId}`,
     'signals.ndjson',
   );
@@ -490,6 +491,7 @@ describe('worktreeReapPhase', () => {
       const configuredPath = path.join(
         configuredTempRoot,
         'epic-9',
+        'stories',
         'story-1',
         'signals.ndjson',
       );
@@ -695,17 +697,21 @@ describe('tempCleanupPhase', () => {
         throw err;
       },
     });
-    // Per-Epic: epic-200/story-100/manifest.{md,json} (2)
+    // Per-Epic: epic-200/stories/story-100/manifest.{md,json} (2)
     // Legacy:   story-manifest-100.{md,json} (2)
     assert.equal(attempted.length, 4);
     assert.ok(
       attempted.some((p) =>
-        p.replaceAll('\\', '/').endsWith('epic-200/story-100/manifest.md'),
+        p
+          .replaceAll('\\', '/')
+          .endsWith('epic-200/stories/story-100/manifest.md'),
       ),
     );
     assert.ok(
       attempted.some((p) =>
-        p.replaceAll('\\', '/').endsWith('epic-200/story-100/manifest.json'),
+        p
+          .replaceAll('\\', '/')
+          .endsWith('epic-200/stories/story-100/manifest.json'),
       ),
     );
     assert.ok(attempted.some((p) => p.endsWith('story-manifest-100.md')));

--- a/tests/lib/signals/read.test.js
+++ b/tests/lib/signals/read.test.js
@@ -47,7 +47,7 @@ const baseEnvelope = (overrides = {}) => ({
 });
 
 function storyDir(epic, story) {
-  return path.join(workRoot, `epic-${epic}`, `story-${story}`);
+  return path.join(workRoot, `epic-${epic}`, 'stories', `story-${story}`);
 }
 
 async function writeSignalsFile(epic, story, lines) {

--- a/tests/lib/story-init/dispatch-state-writer.test.js
+++ b/tests/lib/story-init/dispatch-state-writer.test.js
@@ -4,9 +4,9 @@
  *
  * Unit coverage for the dispatch-state writer that records a Story's
  * dispatch PID + worktree state under
- * `temp/epic-<epicId>/<storyId>/story-init.state.json`. The reconciler
- * (`lib/orchestration/epic-deliver-reconcile.js`) reads from the same
- * path; this writer is the producer side of that contract.
+ * `temp/epic-<epicId>/stories/story-<storyId>/story-init.state.json`.
+ * The reconciler (`lib/orchestration/epic-deliver-reconcile.js`) reads
+ * from the same path; this writer is the producer side of that contract.
  *
  * Tests sandbox the repo root under `tmpdir` so the filesystem write is
  * fully isolated from the real repo's `temp/` tree.
@@ -34,7 +34,7 @@ afterEach(() => {
 });
 
 describe('dispatchStateFilePath', () => {
-  it('returns the canonical path under temp/epic-<id>/<storyId>/', () => {
+  it('returns the canonical path under temp/epic-<id>/stories/story-<sid>/', () => {
     const p = dispatchStateFilePath({
       repoRoot: '/repo',
       epicId: 42,
@@ -42,7 +42,14 @@ describe('dispatchStateFilePath', () => {
     });
     assert.equal(
       p,
-      path.join('/repo', 'temp', 'epic-42', '100', 'story-init.state.json'),
+      path.join(
+        '/repo',
+        'temp',
+        'epic-42',
+        'stories',
+        'story-100',
+        'story-init.state.json',
+      ),
     );
   });
 });

--- a/tests/lib/validation-evidence.test.js
+++ b/tests/lib/validation-evidence.test.js
@@ -58,11 +58,12 @@ function baseOpts(extra = {}) {
   };
 }
 
-test('evidencePath() resolves a Story-scoped path under temp/epic-<eid>/story-<sid>/', () => {
+test('evidencePath() resolves a Story-scoped path under temp/epic-<eid>/stories/story-<sid>/', () => {
   const expected = path.join(
     FAKE_CWD,
     'temp',
     'epic-802',
+    'stories',
     'story-901',
     'validation-evidence.json',
   );

--- a/tests/manifest-renderer.test.js
+++ b/tests/manifest-renderer.test.js
@@ -339,8 +339,8 @@ test('persistManifest', async (t) => {
     };
 
     persistManifest(manifest, { projectRoot });
-    // Per-Epic layout: `temp/epic-<eid>/story-<sid>/manifest.{md,json}`.
-    const storyDir = path.join(tempDir, 'epic-999001', 'story-888');
+    // Per-Epic layout: `temp/epic-<eid>/stories/story-<sid>/manifest.{md,json}`.
+    const storyDir = path.join(tempDir, 'epic-999001', 'stories', 'story-888');
     assert.ok(
       fs.existsSync(path.join(storyDir, 'manifest.json')),
       'per-Story manifest.json',

--- a/tests/scripts/epic-deliver-reconcile.dead-classification.test.js
+++ b/tests/scripts/epic-deliver-reconcile.dead-classification.test.js
@@ -6,7 +6,7 @@
  * a Story whose recorded dispatch PID has been killed as `dead` rather
  * than `unknown`. Before Story #2535 landed, every Story classified as
  * `unknown` because nothing wrote a PID into
- * `temp/epic-<id>/<storyId>/story-init.state.json`. With the
+ * `temp/epic-<id>/stories/story-<storyId>/story-init.state.json`. With the
  * `dispatch-state-writer` writing the file at story-init time, the
  * reconciler's `defaultProbePid` (which uses `process.kill(pid, 0)`)
  * now has a real signal to probe.

--- a/tests/scripts/epic-deliver-reconcile.test.js
+++ b/tests/scripts/epic-deliver-reconcile.test.js
@@ -56,7 +56,13 @@ function fakeProvider(children) {
 
 /** Write a Story's dispatch PID state file under the sandbox repo root. */
 function seedPid(repoRoot, epicId, storyId, pid) {
-  const dir = path.join(repoRoot, 'temp', `epic-${epicId}`, String(storyId));
+  const dir = path.join(
+    repoRoot,
+    'temp',
+    `epic-${epicId}`,
+    'stories',
+    `story-${storyId}`,
+  );
   fs.mkdirSync(dir, { recursive: true });
   fs.writeFileSync(
     path.join(dir, 'story-init.state.json'),
@@ -91,7 +97,13 @@ describe('readDispatchPid', () => {
   });
 
   it('returns null when the state file lacks a pid field', () => {
-    const dir = path.join(repoRoot, 'temp', `epic-${EPIC_ID}`, '9998');
+    const dir = path.join(
+      repoRoot,
+      'temp',
+      `epic-${EPIC_ID}`,
+      'stories',
+      'story-9998',
+    );
     fs.mkdirSync(dir, { recursive: true });
     fs.writeFileSync(
       path.join(dir, 'story-init.state.json'),

--- a/tests/signals-view.test.js
+++ b/tests/signals-view.test.js
@@ -64,7 +64,7 @@ function captureStdout() {
 }
 
 async function writeSignalsFile(rootDir, epic, story, events) {
-  const dir = path.join(rootDir, `epic-${epic}`, `story-${story}`);
+  const dir = path.join(rootDir, `epic-${epic}`, 'stories', `story-${story}`);
   await fs.mkdir(dir, { recursive: true });
   const target = path.join(dir, 'signals.ndjson');
   await fs.writeFile(


### PR DESCRIPTION
Closes #2940

_Auto-opened by `/single-story-deliver`._