### PR TITLE
refactor(manifest): migrate helpers to canonical config pointers

### DIFF
--- a/.agents/scripts/lib/presentation/manifest-persistence.js
+++ b/.agents/scripts/lib/presentation/manifest-persistence.js
@@ -62,12 +62,13 @@ function sweepOne(target) {
  * `temp/epic-<id>/manifest.{md,json}` in Epic #1030 / Story #1040;
  * sweeping on each render keeps a single canonical artefact in the
  * epic dir. Idempotent: returns `{ removed: [] }` when nothing to do.
+ *
+ * @param {number} epicId
+ * @param {{ projectRoot?: string, config?: object, logger?: { info?: Function } }} [opts]
  */
 export function deleteLegacyFlatManifest(epicId, opts = {}) {
   const projectRoot = opts.projectRoot ?? getProjectRoot();
-  const resolved = opts.agentSettings
-    ? { agentSettings: opts.agentSettings }
-    : safeResolveConfig(projectRoot);
+  const resolved = opts.config ?? safeResolveConfig(projectRoot);
   const logger = opts.logger ?? console;
 
   const targets = ['md', 'json'].map((ext) =>
@@ -120,19 +121,18 @@ export function atomicWrite(finalPath, content) {
  * spec file is present alongside the Epic (Story #1501) without
  * coupling persistence to the spec loader.
  *
+ * Config resolution: the caller may pass the canonical resolved config
+ * via `opts.config` (story-init does this to avoid a redundant resolve);
+ * otherwise the helper lazy-resolves so `epicArtifactPath` /
+ * `storyArtifactPath` honour any `project.paths.tempRoot` override.
+ *
  * @param {object} manifest
- * @param {{ projectRoot?: string, agentSettings?: object, markdown?: string }} [opts]
+ * @param {{ projectRoot?: string, config?: object, markdown?: string }} [opts]
  * @returns {{ persisted: boolean, path: string|null, error: string|null }}
  */
 export function persistManifest(manifest, opts = {}) {
   const projectRoot = opts.projectRoot ?? getProjectRoot();
-  // Resolve config once so `epicArtifactPath` / `storyArtifactPath`
-  // honour any `agentSettings.paths.tempRoot` override. agentSettings can
-  // also be threaded via `opts.agentSettings` (story-init does this to
-  // avoid a redundant resolve).
-  const resolved = opts.agentSettings
-    ? { agentSettings: opts.agentSettings }
-    : safeResolveConfig(projectRoot);
+  const resolved = opts.config ?? safeResolveConfig(projectRoot);
   const tempPathsConfig = resolved;
 
   let jsonPath = null;
@@ -179,7 +179,7 @@ export function persistManifest(manifest, opts = {}) {
     // manifest.{md,json} pair (resolves #1126).
     deleteLegacyFlatManifest(epicId, {
       projectRoot,
-      agentSettings: opts.agentSettings ?? resolved.agentSettings,
+      config: resolved,
     });
     const relJson = epicArtifactPath(epicId, 'manifest.json', tempPathsConfig);
     const relMd = epicArtifactPath(epicId, 'manifest.md', tempPathsConfig);
@@ -197,9 +197,7 @@ export function persistManifest(manifest, opts = {}) {
       typeof opts.markdown === 'string'
         ? opts.markdown
         : manifest.type === 'story-execution'
-          ? formatStoryManifestMarkdown(manifest, {
-              agentSettings: opts.agentSettings ?? resolved.agentSettings,
-            })
+          ? formatStoryManifestMarkdown(manifest, { config: resolved })
           : formatManifestMarkdown(manifest);
 
     // Ensure both parent directories exist (`temp/epic-<id>/` and
@@ -225,6 +223,6 @@ function safeResolveConfig(projectRoot) {
   try {
     return resolveConfig({ cwd: projectRoot });
   } catch {
-    return { agentSettings: undefined };
+    return undefined;
   }
 }

--- a/.agents/scripts/lib/presentation/manifest-renderer.js
+++ b/.agents/scripts/lib/presentation/manifest-renderer.js
@@ -42,14 +42,15 @@ export {
  * Backwards-compatible Markdown renderer for story-execution manifests.
  * Resolves config internally to cite the canonical script paths. The pure
  * variant lives at `manifest-formatter.js::formatStoryManifestMarkdown` — new
- * call-sites should prefer that and inject `agentSettings` explicitly.
+ * call-sites should prefer that and inject the canonical `config` bag
+ * explicitly.
  *
  * @param {object} manifest
  * @returns {string}
  */
 export function renderStoryManifestMarkdown(manifest) {
-  const { agentSettings } = resolveConfig();
-  return formatStoryManifestMarkdown(manifest, { agentSettings });
+  const config = resolveConfig();
+  return formatStoryManifestMarkdown(manifest, { config });
 }
 
 /**

--- a/.agents/scripts/lib/presentation/manifest-story-views.js
+++ b/.agents/scripts/lib/presentation/manifest-story-views.js
@@ -15,22 +15,23 @@ import { AGENT_LABELS } from '../label-constants.js';
 
 /**
  * Format the per-story execution manifest. Pure: caller must supply
- * `opts.agentSettings` (the resolved `agentSettings` bag) so we can cite
- * the canonical `story-init.js` / `story-close.js` paths without touching
+ * `opts.config` (the canonical resolved config bag) so we can cite the
+ * canonical `story-init.js` / `story-close.js` paths without touching
  * `resolveConfig` (fs).
  *
- * `scriptsRoot` lives under `agentSettings.paths.*` post-Epic #773 Story 9
- * (it was a flat agentSettings key prior). The fallback string keeps the
- * formatter usable in tiny test fixtures that omit the paths block.
+ * Reads `config.project.paths.scriptsRoot` and `config.project.commands.*`
+ * from the post-reshape canonical blocks (Epic #1720). The fallback
+ * strings keep the formatter usable in tiny test fixtures that omit the
+ * paths / commands block.
  *
  * @param {object} manifest
- * @param {{ agentSettings: { paths?: { scriptsRoot?: string }, commands?: { validate?: string, test?: string } } }} opts
+ * @param {{ config?: { project?: { paths?: { scriptsRoot?: string }, commands?: { validate?: string, test?: string } } } }} [opts]
  * @returns {string}
  */
 export function formatStoryManifestMarkdown(manifest, opts = {}) {
-  const agentSettings = opts.agentSettings ?? {};
-  const scriptsRoot = agentSettings.paths?.scriptsRoot ?? '.agents/scripts';
-  const commands = agentSettings.commands ?? {};
+  const project = opts.config?.project ?? {};
+  const scriptsRoot = project.paths?.scriptsRoot ?? '.agents/scripts';
+  const commands = project.commands ?? {};
   const validateCmd = commands.validate ?? 'npm run lint';
   const testCmd = commands.test ?? 'npm test';
 

--- a/tests/lib/manifest-formatter.test.js
+++ b/tests/lib/manifest-formatter.test.js
@@ -141,11 +141,13 @@ test('formatter: story execution manifest respects injected settings', () => {
       ],
     },
     {
-      agentSettings: {
-        paths: { scriptsRoot: 'custom/scripts' },
-        commands: {
-          validate: 'npm run check',
-          test: 'npm run spec',
+      config: {
+        project: {
+          paths: { scriptsRoot: 'custom/scripts' },
+          commands: {
+            validate: 'npm run check',
+            test: 'npm run spec',
+          },
         },
       },
     },
@@ -154,7 +156,7 @@ test('formatter: story execution manifest respects injected settings', () => {
   assert.ok(md.includes('Run `npm run check` and `npm run spec`'));
 });
 
-test('formatter: story execution manifest falls back to defaults when agentSettings absent', () => {
+test('formatter: story execution manifest falls back to defaults when config absent', () => {
   const md = formatStoryManifestMarkdown({
     generatedAt: '2026-04-20T00:00:00.000Z',
     stories: [],

--- a/tests/lib/manifest-persistence.test.js
+++ b/tests/lib/manifest-persistence.test.js
@@ -74,11 +74,13 @@ test('persistence: writes story-manifest json + md under per-Story dir', () => {
   };
   persistManifest(manifest, {
     projectRoot: root,
-    agentSettings: {
-      paths: { scriptsRoot: '.agents/scripts' },
-      commands: {
-        validate: 'npm run lint',
-        test: 'npm test',
+    config: {
+      project: {
+        paths: { scriptsRoot: '.agents/scripts' },
+        commands: {
+          validate: 'npm run lint',
+          test: 'npm test',
+        },
       },
     },
   });
@@ -122,9 +124,11 @@ test('persistence: story-execution manifest with no epicId falls back to legacy 
   };
   persistManifest(manifest, {
     projectRoot: root,
-    agentSettings: {
-      paths: { scriptsRoot: '.agents/scripts' },
-      commands: { validate: 'npm run lint', test: 'npm test' },
+    config: {
+      project: {
+        paths: { scriptsRoot: '.agents/scripts' },
+        commands: { validate: 'npm run lint', test: 'npm test' },
+      },
     },
   });
   const legacyMd = path.join(root, 'temp', 'story-manifest-42.md');


### PR DESCRIPTION
## Summary

Migrates manifest persistence + story-view helpers off the legacy `{ agentSettings }` opts onto the canonical `{ config }` opts. Reads `config.project.paths.scriptsRoot` and `config.project.commands.{validate,test}` from the post-Epic #1720 canonical blocks instead of the soon-to-be-deleted `agentSettings` shim.

Mechanical sweep across:
- `.agents/scripts/lib/presentation/manifest-persistence.js`
- `.agents/scripts/lib/presentation/manifest-story-views.js`
- `.agents/scripts/lib/presentation/manifest-renderer.js` (single internal caller)
- Test fixtures updated to pass the canonical `config` shape.

Prep for Story #2947 final shim deletion under Epic #2880 (Feature #2887 hard cutover).

## Test plan
- [x] `node --test tests/lib/manifest-persistence.test.js tests/lib/manifest-formatter.test.js tests/manifest-renderer.test.js` — 71 tests pass
- [x] `git grep -nE '\bagentSettings\b|\borchestration\b'` returns no matches in the two target files
- [x] `tests/lib/presentation/*.test.js` — 55 tests pass
- [x] `tests/scripts/dispatcher-fromspec.test.js` — 6 tests pass

Closes #2945