### PR TITLE
framework-gap: bdd-runner-detect.js misses workspace-declared runners in pnpm monorepos (#2956)

### DIFF
--- a/.agents/scripts/lib/bdd-runner-detect.js
+++ b/.agents/scripts/lib/bdd-runner-detect.js
@@ -1,6 +1,6 @@
 /**
  * BDD runner detection + pending-tag verification (Epic #2001 Story #2094
- * Task #2103).
+ * Task #2103; workspace-aware extension from Story #2956).
  *
  * Used by `epic-plan-spec.js#buildAuthoringContext` to decide whether the
  * acceptance-spec body should plan **features-first** Story ordering (a real
@@ -15,6 +15,19 @@
  * support which pending/skip tag. We do not boot the runner. This keeps
  * `/epic-plan` Phase 7 hermetic and offline.
  *
+ * **Workspace awareness (Story #2956).** In a pnpm / npm / yarn monorepo the
+ * BDD runner is rarely a root devDependency — it lives in the workspace
+ * package that owns the e2e suite (e.g. `apps/web/package.json`). The
+ * detector reads the root `package.json` first and then unions in
+ * dependencies from every declared workspace package, so an `apps/*` shaped
+ * monorepo no longer falls back to "no runner detected" when the runner
+ * sits one level down. Workspace declarations are read from
+ * `pnpm-workspace.yaml` (`packages:` field) or the root `package.json`
+ * `workspaces` field (array or `{ packages: [] }` object form).
+ * Preferred-first ordering is preserved by iterating
+ * `BDD_RUNNER_TAG_TABLE` against the union of all collected deps — the
+ * first runner present in *any* package wins.
+ *
  * Output shape (returned to the planner-context envelope):
  *
  *   { runner: 'cucumber-js',         pendingTag: '@skip',     supported: true,  fallback: false }
@@ -24,9 +37,11 @@
  *     reason: 'no-bdd-runner-detected' }
  */
 
-import { existsSync, statSync } from 'node:fs';
+import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs';
 import { readFile } from 'node:fs/promises';
 import path from 'node:path';
+import yaml from 'js-yaml';
+import picomatch from 'picomatch';
 
 /**
  * Known BDD runner package names → pending-tag string the runner honours.
@@ -87,22 +102,30 @@ const FALLBACK = Object.freeze({
 
 /**
  * Verify which BDD runner (if any) the project ships and whether it
- * supports a pending/skip tag. Pure — only reads `package.json` from disk.
+ * supports a pending/skip tag. Reads the root `package.json` and (when
+ * declared) every workspace `package.json` so monorepos that house the
+ * runner in `apps/<name>` or `packages/<name>` resolve correctly.
  *
  * @param {object} [opts]
  * @param {string} [opts.cwd] - Project root holding `package.json`.
  * @param {(p: string) => Promise<string>} [opts.readPkg] - Override for
- *   tests; receives the resolved absolute path to `package.json`.
+ *   tests; receives the resolved absolute path to a `package.json`.
+ * @param {(ctx: { cwd: string, rootPkg: object, readPkg: Function }) => Promise<string[]>} [opts.listWorkspacePkgPaths]
+ *   Override for tests; returns absolute paths to workspace `package.json`
+ *   files. Defaults to scanning `pnpm-workspace.yaml` then the root
+ *   `package.json` `workspaces` field and expanding their glob patterns.
  * @returns {Promise<{ runner: string|null, pendingTag: string|null, supported: boolean, fallback: boolean, reason?: string }>}
  */
 export async function verifyBddRunnerPendingTag(opts = {}) {
   const cwd = opts.cwd ?? process.cwd();
   const readPkg = opts.readPkg ?? ((p) => readFile(p, 'utf8'));
-  const pkgPath = path.join(cwd, 'package.json');
+  const listWorkspacePkgPaths =
+    opts.listWorkspacePkgPaths ?? defaultListWorkspacePkgPaths;
+  const rootPkgPath = path.join(cwd, 'package.json');
 
   let raw;
   try {
-    raw = await readPkg(pkgPath);
+    raw = await readPkg(rootPkgPath);
   } catch (err) {
     if (err && err.code === 'ENOENT') {
       return { ...FALLBACK, reason: 'package-json-missing' };
@@ -110,20 +133,48 @@ export async function verifyBddRunnerPendingTag(opts = {}) {
     throw err;
   }
 
-  let pkg;
+  let rootPkg;
   try {
-    pkg = JSON.parse(raw);
+    rootPkg = JSON.parse(raw);
   } catch (err) {
     return { ...FALLBACK, reason: `package-json-parse-error:${err.message}` };
   }
 
-  const deps = {
-    ...(pkg.dependencies ?? {}),
-    ...(pkg.devDependencies ?? {}),
+  const allDeps = {
+    ...(rootPkg.dependencies ?? {}),
+    ...(rootPkg.devDependencies ?? {}),
   };
 
+  let workspacePkgPaths = [];
+  try {
+    workspacePkgPaths = await listWorkspacePkgPaths({ cwd, rootPkg, readPkg });
+  } catch (_err) {
+    // Workspace discovery failure is non-fatal: degrade to root-only scan.
+    workspacePkgPaths = [];
+  }
+
+  for (const wsPkgPath of workspacePkgPaths) {
+    let wsRaw;
+    try {
+      wsRaw = await readPkg(wsPkgPath);
+    } catch (_err) {
+      continue;
+    }
+    let wsPkg;
+    try {
+      wsPkg = JSON.parse(wsRaw);
+    } catch (_err) {
+      continue;
+    }
+    Object.assign(
+      allDeps,
+      wsPkg.dependencies ?? {},
+      wsPkg.devDependencies ?? {},
+    );
+  }
+
   for (const [runner, pendingTag] of Object.entries(BDD_RUNNER_TAG_TABLE)) {
-    if (Object.hasOwn(deps, runner)) {
+    if (Object.hasOwn(allDeps, runner)) {
       return {
         runner,
         pendingTag,
@@ -134,6 +185,159 @@ export async function verifyBddRunnerPendingTag(opts = {}) {
   }
 
   return { ...FALLBACK };
+}
+
+/**
+ * Default workspace discovery: read `pnpm-workspace.yaml` (`packages:`
+ * field) then the root `package.json` `workspaces` field, expand the
+ * glob patterns against `cwd`, and return the resulting workspace
+ * `package.json` absolute paths.
+ *
+ * Returns `[]` (silent) on any of:
+ *   - no `pnpm-workspace.yaml` and no `workspaces` field
+ *   - YAML parse failure
+ *   - patterns matching no on-disk directories
+ *
+ * Failures here are non-fatal so a malformed workspace file can never
+ * block planner-context emission.
+ *
+ * @returns {Promise<string[]>}
+ */
+async function defaultListWorkspacePkgPaths({ cwd, rootPkg }) {
+  const patterns = readWorkspacePatterns(cwd, rootPkg);
+  if (patterns.length === 0) return [];
+  return expandWorkspacePatterns(cwd, patterns);
+}
+
+function readWorkspacePatterns(cwd, rootPkg) {
+  const yamlPath = path.join(cwd, 'pnpm-workspace.yaml');
+  if (existsSync(yamlPath)) {
+    try {
+      const raw = readFileSync(yamlPath, 'utf8');
+      const parsed = yaml.load(raw);
+      if (parsed && Array.isArray(parsed.packages)) {
+        return parsed.packages.filter((p) => typeof p === 'string');
+      }
+    } catch (_err) {
+      // unparseable yaml → fall through to package.json workspaces
+    }
+  }
+
+  if (rootPkg) {
+    const ws = rootPkg.workspaces;
+    if (Array.isArray(ws)) {
+      return ws.filter((p) => typeof p === 'string');
+    }
+    if (ws && Array.isArray(ws.packages)) {
+      return ws.packages.filter((p) => typeof p === 'string');
+    }
+  }
+
+  return [];
+}
+
+/**
+ * Expand a list of workspace glob patterns into absolute paths to each
+ * matching `package.json`. Handles:
+ *   - literal directory entries (no glob chars): `apps/web`
+ *   - single-segment globs: `apps/*`, `packages/*`
+ *   - recursive globs: `packages/**`
+ *   - exclusion patterns prefixed with `!` (pnpm/npm convention)
+ */
+function expandWorkspacePatterns(cwd, patterns) {
+  const includes = patterns.filter((p) => !p.startsWith('!'));
+  const excludes = patterns
+    .filter((p) => p.startsWith('!'))
+    .map((p) => p.slice(1));
+  const excludeMatchers = excludes.map((e) => picomatch(e));
+
+  const results = new Set();
+
+  for (const pattern of includes) {
+    if (!hasGlobChar(pattern)) {
+      const dir = path.join(cwd, pattern);
+      const pkgPath = path.join(dir, 'package.json');
+      const rel = toPosix(path.relative(cwd, dir));
+      if (existsSync(pkgPath) && !excludeMatchers.some((m) => m(rel))) {
+        results.add(pkgPath);
+      }
+      continue;
+    }
+
+    const segments = pattern.split('/');
+    const literalSegments = [];
+    let i = 0;
+    while (i < segments.length && !hasGlobChar(segments[i])) {
+      literalSegments.push(segments[i]);
+      i++;
+    }
+    const baseDir = path.join(cwd, ...literalSegments);
+    if (!existsSyncDir(baseDir)) continue;
+    const recursive = segments.slice(i).includes('**');
+    const includeMatcher = picomatch(pattern);
+    walkPackages({
+      dir: baseDir,
+      relBase: literalSegments.join('/'),
+      includeMatcher,
+      excludeMatchers,
+      recursive,
+      results,
+    });
+  }
+
+  return [...results];
+}
+
+function walkPackages({
+  dir,
+  relBase,
+  includeMatcher,
+  excludeMatchers,
+  recursive,
+  results,
+}) {
+  let entries;
+  try {
+    entries = readdirSync(dir, { withFileTypes: true });
+  } catch (_err) {
+    return;
+  }
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue;
+    if (entry.name === 'node_modules' || entry.name === '.git') continue;
+    const rel = relBase ? `${relBase}/${entry.name}` : entry.name;
+    const full = path.join(dir, entry.name);
+    if (includeMatcher(rel) && !excludeMatchers.some((m) => m(rel))) {
+      const pkgPath = path.join(full, 'package.json');
+      if (existsSync(pkgPath)) results.add(pkgPath);
+    }
+    if (recursive) {
+      walkPackages({
+        dir: full,
+        relBase: rel,
+        includeMatcher,
+        excludeMatchers,
+        recursive,
+        results,
+      });
+    }
+  }
+}
+
+function hasGlobChar(s) {
+  return /[*?[]/.test(s);
+}
+
+function toPosix(p) {
+  return p.split(path.sep).join('/');
+}
+
+function existsSyncDir(p) {
+  try {
+    return existsSync(p) && statSync(p).isDirectory();
+  } catch (_err) {
+    return false;
+  }
 }
 
 /**

--- a/tests/bdd-runner-detect.test.js
+++ b/tests/bdd-runner-detect.test.js
@@ -1,5 +1,8 @@
 import assert from 'node:assert/strict';
-import { describe, it } from 'node:test';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, it } from 'node:test';
 
 import {
   BDD_RUNNER_TAG_TABLE,
@@ -100,6 +103,241 @@ describe('bdd-runner-detect:verifyBddRunnerPendingTag', () => {
     // Table is frozen — guard against accidental mutation by callers.
     assert.throws(() => {
       BDD_RUNNER_TAG_TABLE['some-new-runner'] = '@skip';
+    });
+  });
+
+  // Story #2956 — workspace-aware detection. The runner often lives in a
+  // workspace package (e.g. `apps/web/package.json`) in pnpm/npm/yarn
+  // monorepos; the detector must union deps across the root and every
+  // declared workspace before deciding to fall back.
+  describe('workspace-aware detection (Story #2956)', () => {
+    it('detects a runner declared in a workspace package.json', async () => {
+      const result = await verifyBddRunnerPendingTag({
+        cwd: '/repo',
+        readPkg: async (p) => {
+          if (
+            p.endsWith('/repo/package.json') ||
+            p.endsWith('\\repo\\package.json')
+          ) {
+            return JSON.stringify({ name: 'root', dependencies: {} });
+          }
+          if (
+            p.endsWith('apps/web/package.json') ||
+            p.endsWith('apps\\web\\package.json')
+          ) {
+            return JSON.stringify({
+              name: 'web',
+              devDependencies: { 'playwright-bdd': '^8.5.1' },
+            });
+          }
+          throw Object.assign(new Error('not found'), { code: 'ENOENT' });
+        },
+        listWorkspacePkgPaths: async ({ cwd }) => [
+          `${cwd}/apps/web/package.json`,
+        ],
+      });
+      assert.equal(result.runner, 'playwright-bdd');
+      assert.equal(result.pendingTag, '@skip');
+      assert.equal(result.supported, true);
+      assert.equal(result.fallback, false);
+    });
+
+    it('falls back when no workspace package declares a runner', async () => {
+      const result = await verifyBddRunnerPendingTag({
+        cwd: '/repo',
+        readPkg: async (p) => {
+          if (p.endsWith('package.json')) {
+            return JSON.stringify({ dependencies: { lodash: '*' } });
+          }
+          throw Object.assign(new Error('not found'), { code: 'ENOENT' });
+        },
+        listWorkspacePkgPaths: async ({ cwd }) => [
+          `${cwd}/apps/web/package.json`,
+          `${cwd}/packages/ui/package.json`,
+        ],
+      });
+      assert.equal(result.runner, null);
+      assert.equal(result.fallback, true);
+      assert.equal(result.reason, 'no-bdd-runner-detected');
+    });
+
+    it('preserves preferred-first ordering across root and workspaces', async () => {
+      // Root declares cucumber-js (later in the preferred-first table);
+      // workspace declares playwright-bdd (first). The first runner in
+      // BDD_RUNNER_TAG_TABLE that appears anywhere wins.
+      const result = await verifyBddRunnerPendingTag({
+        cwd: '/repo',
+        readPkg: async (p) => {
+          if (
+            p.endsWith('/repo/package.json') ||
+            p.endsWith('\\repo\\package.json')
+          ) {
+            return JSON.stringify({
+              devDependencies: { 'cucumber-js': '^9.0.0' },
+            });
+          }
+          if (p.includes('apps')) {
+            return JSON.stringify({
+              devDependencies: { 'playwright-bdd': '^8.5.1' },
+            });
+          }
+          throw Object.assign(new Error('not found'), { code: 'ENOENT' });
+        },
+        listWorkspacePkgPaths: async ({ cwd }) => [
+          `${cwd}/apps/web/package.json`,
+        ],
+      });
+      assert.equal(result.runner, 'playwright-bdd');
+    });
+
+    it('ignores unreadable workspace package.json files (non-fatal)', async () => {
+      const result = await verifyBddRunnerPendingTag({
+        cwd: '/repo',
+        readPkg: async (p) => {
+          if (
+            p.endsWith('/repo/package.json') ||
+            p.endsWith('\\repo\\package.json')
+          ) {
+            return JSON.stringify({
+              devDependencies: { '@cucumber/cucumber': '^11.0.0' },
+            });
+          }
+          // Every workspace pkg "fails to read" — must not crash; root match
+          // still wins.
+          throw new Error('boom');
+        },
+        listWorkspacePkgPaths: async ({ cwd }) => [
+          `${cwd}/apps/web/package.json`,
+        ],
+      });
+      assert.equal(result.runner, '@cucumber/cucumber');
+    });
+
+    it('ignores unparseable workspace package.json files (non-fatal)', async () => {
+      const result = await verifyBddRunnerPendingTag({
+        cwd: '/repo',
+        readPkg: async (p) => {
+          if (
+            p.endsWith('/repo/package.json') ||
+            p.endsWith('\\repo\\package.json')
+          ) {
+            return JSON.stringify({ dependencies: {} });
+          }
+          return '{ not valid json';
+        },
+        listWorkspacePkgPaths: async ({ cwd }) => [
+          `${cwd}/apps/web/package.json`,
+        ],
+      });
+      assert.equal(result.fallback, true);
+      assert.equal(result.reason, 'no-bdd-runner-detected');
+    });
+
+    // Real-filesystem tests for the default workspace-discovery path.
+    // The injection-free tests above cover the union/preference logic;
+    // these probe the actual yaml + glob-expansion implementation against
+    // an isolated temp directory.
+    describe('default discovery against the filesystem', () => {
+      let root;
+      beforeEach(() => {
+        root = mkdtempSync(path.join(tmpdir(), 'bdd-runner-detect-'));
+      });
+      afterEach(() => {
+        rmSync(root, { recursive: true, force: true });
+      });
+
+      const writePkg = (rel, pkg) => {
+        const dir = path.join(root, rel);
+        mkdirSync(dir, { recursive: true });
+        writeFileSync(path.join(dir, 'package.json'), JSON.stringify(pkg));
+      };
+
+      it('expands pnpm-workspace.yaml `apps/*` to find a runner one level down', async () => {
+        writePkg('.', { name: 'root', private: true, devDependencies: {} });
+        writePkg('apps/web', {
+          name: 'web',
+          devDependencies: { 'playwright-bdd': '^8.5.1' },
+        });
+        writeFileSync(
+          path.join(root, 'pnpm-workspace.yaml'),
+          'packages:\n  - apps/*\n  - packages/*\n',
+        );
+        const result = await verifyBddRunnerPendingTag({ cwd: root });
+        assert.equal(result.runner, 'playwright-bdd');
+        assert.equal(result.fallback, false);
+      });
+
+      it('expands a `workspaces` array on the root package.json', async () => {
+        writePkg('.', {
+          name: 'root',
+          private: true,
+          workspaces: ['apps/*'],
+        });
+        writePkg('apps/api', {
+          name: 'api',
+          devDependencies: { '@cucumber/cucumber': '^11.0.0' },
+        });
+        const result = await verifyBddRunnerPendingTag({ cwd: root });
+        assert.equal(result.runner, '@cucumber/cucumber');
+      });
+
+      it('expands a `workspaces.packages` object form (yarn classic)', async () => {
+        writePkg('.', {
+          name: 'root',
+          private: true,
+          workspaces: { packages: ['apps/*'] },
+        });
+        writePkg('apps/mobile', {
+          name: 'mobile',
+          devDependencies: { 'cucumber-js': '^9.0.0' },
+        });
+        const result = await verifyBddRunnerPendingTag({ cwd: root });
+        assert.equal(result.runner, 'cucumber-js');
+      });
+
+      it('honours `!` exclusion patterns in pnpm-workspace.yaml', async () => {
+        writePkg('.', { name: 'root', private: true });
+        writePkg('apps/web', {
+          name: 'web',
+          devDependencies: { 'playwright-bdd': '^8.5.1' },
+        });
+        writeFileSync(
+          path.join(root, 'pnpm-workspace.yaml'),
+          'packages:\n  - apps/*\n  - "!apps/web"\n',
+        );
+        const result = await verifyBddRunnerPendingTag({ cwd: root });
+        // apps/web is excluded → no runner detected anywhere.
+        assert.equal(result.fallback, true);
+        assert.equal(result.reason, 'no-bdd-runner-detected');
+      });
+
+      it('walks recursive `packages/**` patterns', async () => {
+        writePkg('.', { name: 'root', private: true });
+        writePkg('packages/qa/e2e', {
+          name: 'e2e',
+          devDependencies: { 'playwright-bdd': '^8.5.1' },
+        });
+        writeFileSync(
+          path.join(root, 'pnpm-workspace.yaml'),
+          'packages:\n  - "packages/**"\n',
+        );
+        const result = await verifyBddRunnerPendingTag({ cwd: root });
+        assert.equal(result.runner, 'playwright-bdd');
+      });
+    });
+
+    it('treats workspace discovery failure as non-fatal (degrades to root scan)', async () => {
+      const result = await verifyBddRunnerPendingTag({
+        cwd: '/repo',
+        readPkg: async () =>
+          JSON.stringify({
+            devDependencies: { 'playwright-bdd': '^8.0.0' },
+          }),
+        listWorkspacePkgPaths: async () => {
+          throw new Error('workspace discovery exploded');
+        },
+      });
+      assert.equal(result.runner, 'playwright-bdd');
     });
   });
 });


### PR DESCRIPTION
Closes #2956

_Auto-opened by `/single-story-deliver`._