### PR TITLE
fix(story-close): assert final label is agent::done before returning success (#2961)

### DIFF
--- a/.agents/scripts/lib/orchestration/story-close/phases/close.js
+++ b/.agents/scripts/lib/orchestration/story-close/phases/close.js
@@ -22,8 +22,49 @@
 
 import { PROJECT_ROOT } from '../../../config-resolver.js';
 import { Logger } from '../../../Logger.js';
+import { STATE_LABELS } from '../../ticketing.js';
 import { runFinalizeMerge, runResumeMerge } from '../merge-runner.js';
 import { runPostMergeClose } from '../post-merge-close.js';
+
+/**
+ * Story #2961 — final assertion that the Story ticket reached
+ * `agent::done` after the post-merge cascade. The cascade is the single
+ * writer of the `closing → done` label flip; without this readback,
+ * `runStoryClose` returns `success: true` even when the flip silently
+ * failed (the failure mode that Epic #2880 wave 0's friction note
+ * F-W0-2 surfaced via the runner's GitHub probe — see Story #2894).
+ *
+ * Outcomes:
+ *   - `{ ok: true }` — ticket has `agent::done` (or is closed).
+ *   - `{ ok: false, actualLabels }` — cascade returned but the label
+ *     never reached `agent::done`. The caller must downgrade
+ *     `success: true` → `success: false`.
+ *   - `{ ok: 'skipped', warning }` — `provider.getTicket` threw. The
+ *     verification could not run, but the close itself succeeded, so
+ *     the caller returns the success envelope with a `warnings[]` entry.
+ */
+export async function verifyFinalStoryLabel({ provider, storyId }) {
+  if (!provider || typeof provider.getTicket !== 'function') {
+    return {
+      ok: 'skipped',
+      warning: `label-verification-skipped: provider.getTicket unavailable`,
+    };
+  }
+  let ticket;
+  try {
+    ticket = await provider.getTicket(storyId, { fresh: true });
+  } catch (err) {
+    return {
+      ok: 'skipped',
+      warning: `label-verification-skipped: ${err?.message ?? err}`,
+    };
+  }
+  const labels = Array.isArray(ticket?.labels) ? ticket.labels : [];
+  if (labels.includes(STATE_LABELS.DONE) || ticket?.state === 'closed') {
+    return { ok: true };
+  }
+  return { ok: false, actualLabels: labels };
+}
 
 /**
  * Run the merge step. Skipped entirely on the already-merged resume path
@@ -117,15 +158,60 @@ export async function runPostMergePhase(ctx) {
  * The caller (`runStoryCloseLocked` in story-close.js) marks the
  * `close` phase on its phase timer before calling in.
  */
+/**
+ * Pure envelope builder. Given the post-merge `result` and the
+ * `verifyFinalStoryLabel` verdict, returns the close-result envelope
+ * `runClosePhase` will surface back to `runStoryClose`. Exported so the
+ * contract test can drive the failure / skipped / success branches
+ * without spinning up the merge + cascade pipeline.
+ */
+export function buildCloseEnvelope({ result, verdict, storyId }) {
+  if (verdict.ok === false) {
+    const failedResult = {
+      ...result,
+      status: 'failed',
+      phase: 'closing',
+      reason: 'label-transition-failed',
+      actualLabels: verdict.actualLabels,
+    };
+    Logger.warn?.(
+      `[story-close] ❌ Story #${storyId} cascade returned but label is not ` +
+        `${STATE_LABELS.DONE} (actual: ${JSON.stringify(verdict.actualLabels)}). ` +
+        `Returning failure envelope.`,
+    );
+    return { success: false, result: failedResult };
+  }
+  if (verdict.ok === 'skipped') {
+    return {
+      success: true,
+      result: { ...result, warnings: [verdict.warning] },
+    };
+  }
+  return { success: true, result };
+}
+
 export async function runClosePhase(ctx) {
   await runMergePhase(ctx);
   const result = await runPostMergePhase(ctx);
+
+  // Story #2961 — final readback before declaring success. The
+  // post-merge cascade is the single writer for the `closing → done`
+  // label flip; if it silently failed, surface a failure envelope here
+  // rather than relying on the runner's downstream GitHub probe.
+  const verdict = await verifyFinalStoryLabel({
+    provider: ctx.provider,
+    storyId: ctx.storyId,
+  });
+  const envelope = buildCloseEnvelope({ result, verdict, storyId: ctx.storyId });
+
   Logger.info(
-    `\n--- STORY CLOSE RESULT ---\n${JSON.stringify(result, null, 2)}\n--- END RESULT ---\n`,
+    `\n--- STORY CLOSE RESULT ---\n${JSON.stringify(envelope.result, null, 2)}\n--- END RESULT ---\n`,
   );
-  ctx.progress(
-    'DONE',
-    `✅ Story #${ctx.storyId} merged into ${ctx.epicBranch}. ${result.ticketsClosed.length} ticket(s) closed.`,
-  );
-  return { success: true, result };
+  if (envelope.success) {
+    ctx.progress(
+      'DONE',
+      `✅ Story #${ctx.storyId} merged into ${ctx.epicBranch}. ${envelope.result.ticketsClosed.length} ticket(s) closed.`,
+    );
+  }
+  return envelope;
 }

--- a/.agents/scripts/lib/orchestration/story-close/phases/close.js
+++ b/.agents/scripts/lib/orchestration/story-close/phases/close.js
@@ -154,11 +154,6 @@ export async function runPostMergePhase(ctx) {
 }
 
 /**
- * Composite phase: merge → post-merge close → serialise result.
- * The caller (`runStoryCloseLocked` in story-close.js) marks the
- * `close` phase on its phase timer before calling in.
- */
-/**
  * Pure envelope builder. Given the post-merge `result` and the
  * `verifyFinalStoryLabel` verdict, returns the close-result envelope
  * `runClosePhase` will surface back to `runStoryClose`. Exported so the
@@ -190,6 +185,12 @@ export function buildCloseEnvelope({ result, verdict, storyId }) {
   return { success: true, result };
 }
 
+/**
+ * Composite phase: merge → post-merge close → final-label readback →
+ * envelope serialise. The caller (`runStoryCloseLocked` in
+ * story-close.js) marks the `close` phase on its phase timer before
+ * calling in.
+ */
 export async function runClosePhase(ctx) {
   await runMergePhase(ctx);
   const result = await runPostMergePhase(ctx);
@@ -202,7 +203,11 @@ export async function runClosePhase(ctx) {
     provider: ctx.provider,
     storyId: ctx.storyId,
   });
-  const envelope = buildCloseEnvelope({ result, verdict, storyId: ctx.storyId });
+  const envelope = buildCloseEnvelope({
+    result,
+    verdict,
+    storyId: ctx.storyId,
+  });
 
   Logger.info(
     `\n--- STORY CLOSE RESULT ---\n${JSON.stringify(envelope.result, null, 2)}\n--- END RESULT ---\n`,

--- a/tests/contract/finalize/story-close-final-label-assertion.test.js
+++ b/tests/contract/finalize/story-close-final-label-assertion.test.js
@@ -1,0 +1,148 @@
+/**
+ * tests/contract/finalize/story-close-final-label-assertion.test.js
+ *
+ * Story #2961 — `story-close.js` must never return `success: true` when
+ * the Story ticket has not actually reached `agent::done` after the
+ * post-merge cascade. Mirrors the runner-side `verifyWaveResults`
+ * downgrade so the discrepancy fires at the close boundary instead of
+ * one phase later.
+ *
+ * Covers the two new exports in `phases/close.js`:
+ *   - `verifyFinalStoryLabel` (the GitHub readback)
+ *   - `buildCloseEnvelope`    (the envelope shape decision)
+ */
+
+import { strict as assert } from 'node:assert';
+import { describe, it, mock } from 'node:test';
+
+import {
+  buildCloseEnvelope,
+  verifyFinalStoryLabel,
+} from '../../../.agents/scripts/lib/orchestration/story-close/phases/close.js';
+
+const baseResult = () => ({
+  storyId: 100,
+  epicId: 1,
+  action: 'merged',
+  merged: true,
+  ticketsClosed: [100],
+  cascadedTo: [],
+  cascadeFailed: [],
+});
+
+describe('verifyFinalStoryLabel — Story #2961', () => {
+  it('returns ok=true when the ticket carries agent::done', async () => {
+    const provider = {
+      getTicket: mock.fn(async () => ({ labels: ['agent::done'] })),
+    };
+    const verdict = await verifyFinalStoryLabel({ provider, storyId: 100 });
+    assert.deepEqual(verdict, { ok: true });
+  });
+
+  it('returns ok=true when the ticket is closed even without the label', async () => {
+    const provider = {
+      getTicket: mock.fn(async () => ({ labels: [], state: 'closed' })),
+    };
+    const verdict = await verifyFinalStoryLabel({ provider, storyId: 100 });
+    assert.deepEqual(verdict, { ok: true });
+  });
+
+  it('returns ok=false with actualLabels when the cascade left agent::closing sticky', async () => {
+    const provider = {
+      getTicket: mock.fn(async () => ({ labels: ['agent::closing'] })),
+    };
+    const verdict = await verifyFinalStoryLabel({ provider, storyId: 100 });
+    assert.deepEqual(verdict, {
+      ok: false,
+      actualLabels: ['agent::closing'],
+    });
+  });
+
+  it('downgrades to skipped + warning when getTicket throws', async () => {
+    const provider = {
+      getTicket: mock.fn(async () => {
+        throw new Error('rate-limited');
+      }),
+    };
+    const verdict = await verifyFinalStoryLabel({ provider, storyId: 100 });
+    assert.equal(verdict.ok, 'skipped');
+    assert.match(verdict.warning, /label-verification-skipped: rate-limited/);
+  });
+
+  it('downgrades to skipped when provider.getTicket is missing', async () => {
+    const verdict = await verifyFinalStoryLabel({
+      provider: {},
+      storyId: 100,
+    });
+    assert.equal(verdict.ok, 'skipped');
+    assert.match(verdict.warning, /getTicket unavailable/);
+  });
+});
+
+describe('buildCloseEnvelope — Story #2961', () => {
+  it('returns the pristine success envelope when the verdict is ok=true', () => {
+    const result = baseResult();
+    const envelope = buildCloseEnvelope({
+      result,
+      verdict: { ok: true },
+      storyId: 100,
+    });
+    assert.deepEqual(envelope, { success: true, result });
+    assert.equal(envelope.result.status, undefined);
+    assert.equal(envelope.result.warnings, undefined);
+  });
+
+  it('downgrades to success:false with the failure shape when the verdict is ok=false', () => {
+    const result = baseResult();
+    const envelope = buildCloseEnvelope({
+      result,
+      verdict: { ok: false, actualLabels: ['agent::closing'] },
+      storyId: 100,
+    });
+    assert.equal(envelope.success, false);
+    assert.equal(envelope.result.status, 'failed');
+    assert.equal(envelope.result.phase, 'closing');
+    assert.equal(envelope.result.reason, 'label-transition-failed');
+    assert.deepEqual(envelope.result.actualLabels, ['agent::closing']);
+    // The underlying merged-state fields are preserved so an operator
+    // can still tell that the merge itself succeeded.
+    assert.equal(envelope.result.merged, true);
+    assert.deepEqual(envelope.result.ticketsClosed, [100]);
+  });
+
+  it('returns success:true with a warnings entry when verification was skipped', () => {
+    const result = baseResult();
+    const envelope = buildCloseEnvelope({
+      result,
+      verdict: {
+        ok: 'skipped',
+        warning: 'label-verification-skipped: 503 from upstream',
+      },
+      storyId: 100,
+    });
+    assert.equal(envelope.success, true);
+    assert.deepEqual(envelope.result.warnings, [
+      'label-verification-skipped: 503 from upstream',
+    ]);
+    assert.equal(envelope.result.merged, true);
+    assert.equal(envelope.result.status, undefined);
+  });
+
+  it('simulated transient agent::closing → agent::done flip failure exits via the failure shape', () => {
+    // Acceptance criterion phrasing: "Contract test simulating a
+    // transient `agent::closing → agent::done` label flip failure
+    // exits via the new failure shape, not the success shape."
+    const verdict = { ok: false, actualLabels: ['agent::closing'] };
+    const envelope = buildCloseEnvelope({
+      result: baseResult(),
+      verdict,
+      storyId: 100,
+    });
+    assert.notEqual(
+      envelope.success,
+      true,
+      'success:true would mask the discrepancy that Story #2894 hit',
+    );
+    assert.equal(envelope.result.reason, 'label-transition-failed');
+  });
+});


### PR DESCRIPTION
Closes #2961

_Auto-opened by `/single-story-deliver`._