### PR TITLE
feat(planning): decomposer cross-cutting rule covers listener registries + widely-used-symbol deletion (#2962)

### DIFF
--- a/.agents/schemas/agentrc.schema.json
+++ b/.agents/schemas/agentrc.schema.json
@@ -186,7 +186,13 @@
         "context": { "$ref": "#/$defs/planningContext" },
         "codebaseSnapshot": { "$ref": "#/$defs/codebaseSnapshot" },
         "failOnSharedEditors": { "type": "boolean" },
-        "requireExplicitCrossStoryDeps": { "type": "boolean" }
+        "requireExplicitCrossStoryDeps": { "type": "boolean" },
+        "failOnRegistryConflicts": { "type": "boolean" },
+        "failOnLargeFanOut": { "type": "boolean" },
+        "largeFanOutThreshold": { "type": "integer", "minimum": 0 },
+        "crossCuttingRegistries": {
+          "$ref": "#/$defs/listOrExtenderOfStrings"
+        }
       },
       "additionalProperties": false
     },

--- a/.agents/scripts/lib/orchestration/epic-plan-decompose/phases/cli.js
+++ b/.agents/scripts/lib/orchestration/epic-plan-decompose/phases/cli.js
@@ -35,13 +35,14 @@ const CLI_OPTIONS = {
   force: { type: 'boolean', default: false },
   resume: { type: 'boolean', default: false },
   'allow-over-budget': { type: 'boolean', default: false },
+  'allow-large-fan-out': { type: 'boolean', default: false },
   'emit-context': { type: 'boolean', default: false },
   pretty: { type: 'boolean', default: false },
   'full-context': { type: 'boolean', default: false },
 };
 
 const USAGE =
-  'Usage: epic-plan-decompose.js --epic <EpicId> (--emit-context [--pretty] [--full-context] | --tickets <file>) [--force | --resume] [--allow-over-budget]';
+  'Usage: epic-plan-decompose.js --epic <EpicId> (--emit-context [--pretty] [--full-context] | --tickets <file>) [--force | --resume] [--allow-over-budget] [--allow-large-fan-out]';
 
 function parseEpicId(rawEpic) {
   if (!rawEpic) throw new Error(USAGE);
@@ -126,6 +127,7 @@ async function runPersistPath({ epicId, provider, config, values }) {
       force: values.force,
       resume: values.resume,
       allowOverBudget: values['allow-over-budget'],
+      allowLargeFanOut: values['allow-large-fan-out'],
     });
   } catch (err) {
     await reportPartialFailure({ epicId, provider, err });

--- a/.agents/scripts/lib/orchestration/epic-plan-decompose/phases/persist-helpers.js
+++ b/.agents/scripts/lib/orchestration/epic-plan-decompose/phases/persist-helpers.js
@@ -19,6 +19,7 @@
  * @module lib/orchestration/epic-plan-decompose/phases/persist-helpers
  */
 
+import { gitSpawn } from '../../../git-utils.js';
 import { Logger } from '../../../Logger.js';
 import { TYPE_LABELS } from '../../../label-constants.js';
 import {
@@ -63,9 +64,47 @@ export function buildEpicSpecInput(epic, epicId) {
   return epicSpecInput;
 }
 
-export function validateTickets(tickets, config) {
+/**
+ * Default fan-out counter — counts distinct files at `baseBranchRef` that
+ * reference the basename (without extension) of the deleted path. Uses
+ * `git grep -l` for a streaming-friendly probe; an empty grep returns
+ * exit code 1 which we map to a count of 0.
+ *
+ * Story #2962. Injected via opts in tests; this default runs in production.
+ */
+export function makeDefaultFanOutCounter({ baseBranchRef, cwd }) {
+  return ({ path }) => {
+    const lastSlash = path.lastIndexOf('/');
+    const base = lastSlash === -1 ? path : path.slice(lastSlash + 1);
+    const dotIdx = base.lastIndexOf('.');
+    const stem = dotIdx > 0 ? base.slice(0, dotIdx) : base;
+    if (stem.length < 3) return 0;
+    const result = gitSpawn(
+      cwd ?? process.cwd(),
+      'grep',
+      '-l',
+      '--fixed-strings',
+      stem,
+      baseBranchRef,
+    );
+    if (result.status !== 0) return 0;
+    const lines = result.stdout.split('\n').filter((l) => l.trim().length > 0);
+    // Exclude the deleted file itself from the call-site count.
+    return lines.filter((l) => !l.endsWith(`:${path}`)).length;
+  };
+}
+
+export function validateTickets(tickets, config, opts = {}) {
   const baseBranchRef = config?.baseBranch ?? 'main';
   const conflictPolicy = resolveConflictPolicy(config);
+  if (typeof opts.fanOutCounter === 'function') {
+    conflictPolicy.fanOutCounter = opts.fanOutCounter;
+  } else if (!conflictPolicy.fanOutCounter) {
+    conflictPolicy.fanOutCounter = makeDefaultFanOutCounter({
+      baseBranchRef,
+      cwd: opts.cwd,
+    });
+  }
   const validated = validateAndNormalizeTickets(tickets, {
     baseBranchRef,
     conflictPolicy,

--- a/.agents/scripts/lib/orchestration/epic-plan-decompose/phases/persist.js
+++ b/.agents/scripts/lib/orchestration/epic-plan-decompose/phases/persist.js
@@ -58,7 +58,7 @@ import { RECONCILE_CLI, spawnReconcilerApply } from './reconcile-spawn.js';
  * @param {import('../../../ITicketingProvider.js').ITicketingProvider} provider
  * @param {{ tickets: Array<object> }} payload
  * @param {object} config
- * @param {{ force?: boolean, resume?: boolean, allowOverBudget?: boolean, spawnSync?: typeof defaultSpawnSync, reconcileCli?: string, writeSpecFn?: typeof writeSpec, renderSpecFn?: typeof renderSpec, cwd?: string, runHealthcheckFn?: typeof defaultRunPlanHealthcheck, skipHealthcheck?: boolean }} [opts]
+ * @param {{ force?: boolean, resume?: boolean, allowOverBudget?: boolean, allowLargeFanOut?: boolean, fanOutCounter?: (arg: { path: string }) => number, spawnSync?: typeof defaultSpawnSync, reconcileCli?: string, writeSpecFn?: typeof writeSpec, renderSpecFn?: typeof renderSpec, cwd?: string, runHealthcheckFn?: typeof defaultRunPlanHealthcheck, skipHealthcheck?: boolean }} [opts]
  */
 export async function runDecomposePhase(
   epicId,
@@ -69,6 +69,8 @@ export async function runDecomposePhase(
     force = false,
     resume = false,
     allowOverBudget = false,
+    allowLargeFanOut = false,
+    fanOutCounter = undefined,
     spawnSync = defaultSpawnSync,
     reconcileCli = RECONCILE_CLI,
     writeSpecFn = writeSpec,
@@ -101,12 +103,22 @@ export async function runDecomposePhase(
       `[epic-plan-decompose] Persisting an over-budget decomposition: ${tickets.length} tickets vs. budget ${maxTickets} (operator override --allow-over-budget).`,
     );
   }
-  await seedPlanState(provider, epicId, epic);
-
+  // Story #2962 — run cross-validation BEFORE the plan-state mutation so
+  // the fan-out gate (and any future hard gate) can refuse persist
+  // without leaving a half-initialised epic-plan-state behind.
   Logger.info(
     `[epic-plan-decompose] Running cross-validation on ${tickets.length} tickets...`,
   );
-  const validated = validateTickets(tickets, config);
+  const validated = validateTickets(tickets, config, { fanOutCounter, cwd });
+
+  // Refuse to persist when any Task declares a deletion whose call-site
+  // fan-out exceeds the configured threshold, unless the operator has
+  // passed `--allow-large-fan-out`. The planner cannot reduce call sites
+  // by re-prompting, so this gate sits at persist time (like
+  // `--allow-over-budget`) rather than in the auto-redrive loop.
+  enforceFanOutGate(validated.findings, allowLargeFanOut);
+
+  await seedPlanState(provider, epicId, epic);
 
   Logger.info(
     `[epic-plan-decompose] Rendering spec for Epic #${epicId} (${validated.length} tickets)...`,
@@ -184,6 +196,32 @@ export async function runDecomposePhase(
  * @param {typeof defaultRunPlanHealthcheck} args.runHealthcheckFn
  * @returns {Promise<{ ok: boolean, waived?: boolean, reason?: string|null }>}
  */
+function enforceFanOutGate(findings, allowLargeFanOut) {
+  const fanOut = (findings ?? []).filter((f) => f.kind === 'fan-out-warning');
+  if (fanOut.length === 0) return;
+  if (allowLargeFanOut) {
+    for (const f of fanOut) {
+      Logger.warn(
+        `[epic-plan-decompose] Persisting a large-fan-out deletion: ` +
+          `Task "${f.taskSlug}" deletes "${f.path}" with ${f.callSiteCount} ` +
+          `call site(s) (threshold ${f.threshold}). Operator override --allow-large-fan-out.`,
+      );
+    }
+    return;
+  }
+  const lines = fanOut
+    .map(
+      (f) =>
+        `  - Task "${f.taskSlug}" (Story "${f.storySlug}") deletes "${f.path}" — ${f.callSiteCount} call site(s) (threshold ${f.threshold})`,
+    )
+    .join('\n');
+  throw new Error(
+    `[epic-plan-decompose] ${fanOut.length} Task(s) declare large-fan-out deletions:\n${lines}\n\n` +
+      `Split each deletion into a subsystem-by-subsystem migration across multiple Stories, ` +
+      `or rerun --allow-large-fan-out after confirming the deletion is intentional.`,
+  );
+}
+
 async function runHealthcheckGate({ epicId, epic, runHealthcheckFn }) {
   Logger.info(
     `[epic-plan-decompose] Running post-plan readiness healthcheck for Epic #${epicId}...`,

--- a/.agents/scripts/lib/orchestration/epic-plan-decompose/phases/planning-artifacts.js
+++ b/.agents/scripts/lib/orchestration/epic-plan-decompose/phases/planning-artifacts.js
@@ -10,6 +10,9 @@
  * @module lib/orchestration/epic-plan-decompose/phases/planning-artifacts
  */
 
+import { resolveListValue } from '../../../config/shared.js';
+import { _internal as conflictInternal } from '../../ticket-validator-conflicts.js';
+
 /**
  * Ensure the supplied Epic body carries a `## Planning Artifacts` section.
  * Idempotent — when the section already exists the body is returned
@@ -52,9 +55,21 @@ export function ensurePlanningArtifacts(body, linkedIssues) {
  */
 export function resolveConflictPolicy(cfg) {
   const planning = cfg?.planning;
-  return {
+  const policy = {
     failOnSharedEditors: planning?.failOnSharedEditors === true,
     requireExplicitCrossStoryDeps:
       planning?.requireExplicitCrossStoryDeps === true,
+    failOnRegistryConflicts: planning?.failOnRegistryConflicts === true,
+    failOnLargeFanOut: planning?.failOnLargeFanOut === true,
   };
+  if (Number.isFinite(planning?.largeFanOutThreshold)) {
+    policy.largeFanOutThreshold = planning.largeFanOutThreshold;
+  }
+  if (planning?.crossCuttingRegistries !== undefined) {
+    policy.registries = resolveListValue(
+      conflictInternal.DEFAULT_REGISTRY_PATTERNS,
+      planning.crossCuttingRegistries,
+    );
+  }
+  return policy;
 }

--- a/.agents/scripts/lib/orchestration/ticket-validator-conflicts.js
+++ b/.agents/scripts/lib/orchestration/ticket-validator-conflicts.js
@@ -45,7 +45,47 @@
 const DEFAULT_POLICY = Object.freeze({
   failOnSharedEditors: false,
   requireExplicitCrossStoryDeps: false,
+  failOnRegistryConflicts: false,
+  largeFanOutThreshold: 10,
+  registries: null, // null = use DEFAULT_REGISTRY_PATTERNS
+  fanOutCounter: null, // null = no fan-out probe (skip)
 });
+
+/**
+ * Default cross-cutting registry / barrel files. Story #2962 — these are
+ * files whose primary purpose is to wire siblings together (registries,
+ * handler maps, listener barrels). When two or more concurrent Stories
+ * either edit the registry directly OR create sibling files that need
+ * registration in it, the registry edits collide on every Story-to-Epic
+ * close after the first.
+ *
+ * Patterns support two shapes:
+ *   - exact path  — `lib/orchestration/lifecycle/listeners/index.js`
+ *   - `**` suffix — `**\/listeners/index.js` (matches any depth)
+ */
+const DEFAULT_REGISTRY_PATTERNS = Object.freeze([
+  'lib/orchestration/lifecycle/listeners/index.js',
+  '**/listeners/index.js',
+  '**/handlers/index.js',
+]);
+
+function matchRegistryPattern(path, pattern) {
+  if (pattern.startsWith('**/')) {
+    const tail = pattern.slice(3);
+    return path === tail || path.endsWith(`/${tail}`);
+  }
+  return path === pattern;
+}
+
+function isRegistryPath(path, patterns) {
+  for (const p of patterns) if (matchRegistryPattern(path, p)) return true;
+  return false;
+}
+
+function parentDirOf(path) {
+  const idx = path.lastIndexOf('/');
+  return idx <= 0 ? '' : path.slice(0, idx);
+}
 
 /**
  * Extract the path-shaped head from a single `body.changes` bullet.
@@ -242,6 +282,236 @@ function computeImplicitDepFindings(consumers, producers, reach, severity) {
 }
 
 /**
+ * Index every object-form `body.changes` entry by `{ path, assumption }`
+ * along with its parent Task/Story so the registry-and-fan-out passes can
+ * reason about creates/deletes without re-walking the ticket array.
+ */
+function indexAssumptionEntries(tasks) {
+  const entries = [];
+  for (const task of tasks) {
+    const body = task?.body;
+    if (!body || typeof body !== 'object') continue;
+    const changes = Array.isArray(body.changes) ? body.changes : [];
+    for (const change of changes) {
+      if (
+        change === null ||
+        typeof change !== 'object' ||
+        typeof change.path !== 'string' ||
+        change.path.length === 0
+      )
+        continue;
+      entries.push({
+        path: change.path,
+        assumption: change.assumption ?? null,
+        storySlug: storySlugOf(task),
+        taskSlug: task.slug,
+      });
+    }
+  }
+  return entries;
+}
+
+/**
+ * Compute `cross-cutting-registries` findings (Story #2962).
+ *
+ * A registry/barrel file (e.g. `lib/orchestration/lifecycle/listeners/index.js`)
+ * collides whenever two or more concurrent Stories either
+ *
+ *   (a) directly edit the registry file, OR
+ *   (b) create a new sibling file in the same directory that the registry
+ *       would have to wire up.
+ *
+ * For each known registry pattern (`patterns`), we collect every Story whose
+ * Tasks satisfy (a) or (b). When ≥2 such Stories sit in the same wave (no
+ * transitive `depends_on` between them), emit a single finding keyed by the
+ * registry path.
+ */
+function computeRegistryFindings({
+  tasks,
+  reach,
+  patterns,
+  producers,
+  assumptionEntries,
+  severity,
+}) {
+  const findings = [];
+  // Build the matching registry path set from producer & creator paths.
+  const registryHits = new Map(); // registryPath -> Map<storySlug, producers[]>
+  function bump(registryPath, entry) {
+    let perStory = registryHits.get(registryPath);
+    if (!perStory) {
+      perStory = new Map();
+      registryHits.set(registryPath, perStory);
+    }
+    const existing = perStory.get(entry.storySlug) ?? [];
+    existing.push(entry);
+    perStory.set(entry.storySlug, existing);
+  }
+  // (a) direct registry edits — accept both legacy string-form producers
+  // (from `indexProducers`) and modern object-form `{ path, assumption }`
+  // entries (from `indexAssumptionEntries`).
+  for (const [path, entries] of producers.entries()) {
+    if (!isRegistryPath(path, patterns)) continue;
+    for (const e of entries) {
+      bump(path, {
+        storySlug: e.storySlug,
+        taskSlug: e.taskSlug,
+        path,
+        reason: 'edits-registry',
+      });
+    }
+  }
+  for (const e of assumptionEntries) {
+    if (!isRegistryPath(e.path, patterns)) continue;
+    bump(e.path, {
+      storySlug: e.storySlug,
+      taskSlug: e.taskSlug,
+      path: e.path,
+      reason: 'edits-registry',
+    });
+  }
+  // (b) sibling creates that would require registration in a registry.
+  // A registry path's parent dir defines its "registration scope" — any
+  // new file in that scope is a wiring candidate.
+  const scopeByRegistry = new Map();
+  for (const task of tasks) {
+    const body = task?.body;
+    if (!body || typeof body !== 'object') continue;
+    for (const change of body.changes ?? []) {
+      if (
+        change === null ||
+        typeof change !== 'object' ||
+        change.assumption !== 'creates' ||
+        typeof change.path !== 'string'
+      )
+        continue;
+      const childParent = parentDirOf(change.path);
+      if (!childParent) continue;
+      for (const reg of registryRegistry(
+        producers,
+        assumptionEntries,
+        patterns,
+        scopeByRegistry,
+      )) {
+        if (reg.parentDir !== childParent) continue;
+        bump(reg.path, {
+          storySlug: storySlugOf(task),
+          taskSlug: task.slug,
+          path: change.path,
+          reason: 'creates-sibling',
+        });
+      }
+    }
+  }
+  for (const [registryPath, perStory] of registryHits.entries()) {
+    const stories = Array.from(perStory.keys());
+    if (stories.length < 2) continue;
+    const cluster = new Set();
+    for (let i = 0; i < stories.length; i += 1) {
+      for (let j = i + 1; j < stories.length; j += 1) {
+        if (inSameWave(reach, stories[i], stories[j])) {
+          cluster.add(stories[i]);
+          cluster.add(stories[j]);
+        }
+      }
+    }
+    if (cluster.size === 0) continue;
+    const clusterSlugs = Array.from(cluster).sort();
+    const producerList = [];
+    for (const slug of clusterSlugs) {
+      for (const p of perStory.get(slug) ?? []) producerList.push(p);
+    }
+    findings.push({
+      kind: 'cross-cutting-registries',
+      severity,
+      registryPath,
+      storySlugs: clusterSlugs,
+      producers: producerList,
+    });
+  }
+  return findings;
+}
+
+/**
+ * Resolve the set of registry paths that should be considered in scope for
+ * the sibling-create check. We treat any path that already matches a
+ * registry pattern (whether produced by a Task or not — the path exists in
+ * the project) as in-scope. To stay path-knowledge-free at plan time, we
+ * only consider patterns that are explicit paths (no `**`) or that match a
+ * path produced by some Task in the spec.
+ */
+function registryRegistry(producers, assumptionEntries, patterns, cache) {
+  if (cache.size > 0) return cache.values();
+  // Explicit (no-glob) patterns: always in scope as their own path.
+  for (const pat of patterns) {
+    if (pat.startsWith('**/')) continue;
+    cache.set(pat, { path: pat, parentDir: parentDirOf(pat) });
+  }
+  // Glob patterns: in scope iff some Task in the spec references a matching
+  // path via changes (edits or creates). Avoids false positives when a
+  // glob pattern doesn't apply to this repo at all.
+  for (const path of producers.keys()) {
+    if (cache.has(path)) continue;
+    if (isRegistryPath(path, patterns)) {
+      cache.set(path, { path, parentDir: parentDirOf(path) });
+    }
+  }
+  for (const e of assumptionEntries) {
+    if (cache.has(e.path)) continue;
+    if (isRegistryPath(e.path, patterns)) {
+      cache.set(e.path, { path: e.path, parentDir: parentDirOf(e.path) });
+    }
+  }
+  return cache.values();
+}
+
+/**
+ * Compute `fan-out-warning` findings (Story #2962).
+ *
+ * For each `body.changes` entry whose `assumption` is `"deletes"` (or
+ * `"refactors-existing"` when the planner declared a symbol replacement),
+ * count the number of distinct files in the base branch that reference
+ * the deleted module via its basename. When the count exceeds the
+ * configured `largeFanOutThreshold`, emit a finding.
+ *
+ * The default severity is always `'soft'` — the persist gate enforces a
+ * hard refusal via the `--allow-large-fan-out` operator flag, since the
+ * planner cannot reduce call sites by re-prompting. Severity may still be
+ * upgraded to `'hard'` via `failOnLargeFanOut` for callers that want the
+ * standard `errors[]` path (e.g. CI dry-runs).
+ */
+function computeFanOutFindings({
+  assumptionEntries,
+  threshold,
+  counter,
+  severity,
+}) {
+  if (typeof counter !== 'function') return [];
+  if (!Number.isFinite(threshold) || threshold < 0) return [];
+  const findings = [];
+  const cache = new Map();
+  for (const entry of assumptionEntries) {
+    if (entry.assumption !== 'deletes') continue;
+    let count = cache.get(entry.path);
+    if (count === undefined) {
+      count = counter({ path: entry.path }) ?? 0;
+      cache.set(entry.path, count);
+    }
+    if (count <= threshold) continue;
+    findings.push({
+      kind: 'fan-out-warning',
+      severity,
+      taskSlug: entry.taskSlug,
+      storySlug: entry.storySlug,
+      path: entry.path,
+      callSiteCount: count,
+      threshold,
+    });
+  }
+  return findings;
+}
+
+/**
  * Public entry point. Walks the normalized ticket spec once and returns
  * the structured cross-Story findings array. The caller's `policy` flags
  * decide whether each finding class lands as `'soft'` (advisory, won't
@@ -253,17 +523,30 @@ function computeImplicitDepFindings(consumers, producers, reach, severity) {
  * @param {object}    [input.policy]
  * @param {boolean}   [input.policy.failOnSharedEditors=false]
  * @param {boolean}   [input.policy.requireExplicitCrossStoryDeps=false]
+ * @param {boolean}   [input.policy.failOnRegistryConflicts=false]
+ * @param {boolean}   [input.policy.failOnLargeFanOut=false]
+ * @param {number}    [input.policy.largeFanOutThreshold=10]
+ * @param {string[]}  [input.policy.registries]  Registry patterns (defaults to DEFAULT_REGISTRY_PATTERNS).
+ * @param {(arg: { path: string }) => number} [input.policy.fanOutCounter] Optional probe; when omitted the fan-out pass is skipped.
  * @returns {ConflictFinding[]}
  */
 export function computeConflictFindings({ tasks, stories, policy } = {}) {
   const merged = { ...DEFAULT_POLICY, ...(policy ?? {}) };
-  const producers = indexProducers(tasks ?? []);
-  const consumers = indexConsumers(tasks ?? [], producers);
+  const taskList = tasks ?? [];
+  const producers = indexProducers(taskList);
+  const consumers = indexConsumers(taskList, producers);
   const reach = computeStoryReachability(stories ?? []);
+  const assumptionEntries = indexAssumptionEntries(taskList);
   const sharedSeverity = merged.failOnSharedEditors ? 'hard' : 'soft';
   const implicitSeverity = merged.requireExplicitCrossStoryDeps
     ? 'hard'
     : 'soft';
+  const registrySeverity = merged.failOnRegistryConflicts ? 'hard' : 'soft';
+  const fanOutSeverity = merged.failOnLargeFanOut ? 'hard' : 'soft';
+  const patterns =
+    Array.isArray(merged.registries) && merged.registries.length > 0
+      ? merged.registries
+      : DEFAULT_REGISTRY_PATTERNS;
   return [
     ...computeSharedEditorFindings(producers, reach, sharedSeverity),
     ...computeImplicitDepFindings(
@@ -272,6 +555,20 @@ export function computeConflictFindings({ tasks, stories, policy } = {}) {
       reach,
       implicitSeverity,
     ),
+    ...computeRegistryFindings({
+      tasks: taskList,
+      reach,
+      patterns,
+      producers,
+      assumptionEntries,
+      severity: registrySeverity,
+    }),
+    ...computeFanOutFindings({
+      assumptionEntries,
+      threshold: merged.largeFanOutThreshold,
+      counter: merged.fanOutCounter,
+      severity: fanOutSeverity,
+    }),
   ];
 }
 
@@ -288,7 +585,14 @@ export function renderHardConflictError(finding) {
   if (finding.kind === 'implicit-cross-story-dep') {
     return `Implicit cross-Story dependency: Task "${finding.consumer.taskSlug}" in Story "${finding.consumer.storySlug}" references "${finding.path}" (produced by Task "${finding.producer.taskSlug}" in Story "${finding.producer.storySlug}") via body.${finding.consumer.sourceField}, but Story "${finding.consumer.storySlug}" has no depends_on link to Story "${finding.producer.storySlug}". Add depends_on: ["${finding.producer.storySlug}"] to the consumer Story or remove the reference.`;
   }
-  return `Conflict finding ${finding.kind} on path "${finding.path}".`;
+  if (finding.kind === 'cross-cutting-registries') {
+    const stories = finding.storySlugs.map((s) => `"${s}"`).join(', ');
+    return `Cross-cutting registry conflict: ${finding.storySlugs.length} concurrent Stories (${stories}) edit or register into "${finding.registryPath}". Add depends_on chains between them so the registry updates serialize, or split the registration into a dedicated late-wave wiring Story.`;
+  }
+  if (finding.kind === 'fan-out-warning') {
+    return `Large fan-out: Task "${finding.taskSlug}" in Story "${finding.storySlug}" deletes "${finding.path}" with ${finding.callSiteCount} call site(s) on the base branch (threshold ${finding.threshold}). Split into a subsystem-by-subsystem migration across multiple Stories, or rerun --allow-large-fan-out after confirming the deletion is intentional.`;
+  }
+  return `Conflict finding ${finding.kind} on path "${finding.path ?? '<unknown>'}".`;
 }
 
 // Internal helpers exposed for unit tests; not part of the public surface.
@@ -300,5 +604,12 @@ export const _internal = {
   inSameWave,
   computeSharedEditorFindings,
   computeImplicitDepFindings,
+  indexAssumptionEntries,
+  computeRegistryFindings,
+  computeFanOutFindings,
+  matchRegistryPattern,
+  isRegistryPath,
+  parentDirOf,
   DEFAULT_POLICY,
+  DEFAULT_REGISTRY_PATTERNS,
 };

--- a/.agents/scripts/lib/orchestration/ticket-validator.js
+++ b/.agents/scripts/lib/orchestration/ticket-validator.js
@@ -627,14 +627,19 @@ export function validateAndNormalizeTickets(tickets, opts = {}) {
     policy: opts.conflictPolicy,
   });
   const findings = [...sizingFindings, ...conflictFindings];
+  const CONFLICT_KINDS = new Set([
+    'shared-editor',
+    'implicit-cross-story-dep',
+    'cross-cutting-registries',
+    'fan-out-warning',
+  ]);
   const errors = findings
     .filter((f) => f.severity === 'hard')
-    .map((f) => {
-      if (f.kind === 'shared-editor' || f.kind === 'implicit-cross-story-dep') {
-        return renderHardConflictError(f);
-      }
-      return renderHardFindingError(f);
-    });
+    .map((f) =>
+      CONFLICT_KINDS.has(f.kind)
+        ? renderHardConflictError(f)
+        : renderHardFindingError(f),
+    );
   // Append per-Task path-assumption mismatches (Story #2636) to the
   // hard-error list. The decompose loop already gates on
   // `errors.length > 0` to trigger a re-prompt, so the new check

--- a/.agents/skills/core/epic-plan-decompose-author/SKILL.md
+++ b/.agents/skills/core/epic-plan-decompose-author/SKILL.md
@@ -256,6 +256,40 @@ Shared configuration files (non-exhaustive):
 - Any single file under a `schemas/` directory if it is the only producer
   of a contract consumed by other Stories — those consumers MUST
   `depends_on` the producer
+- **Registry / barrel files** (Story #2962). Files whose primary purpose
+  is to wire siblings together (listener registries, handler maps,
+  manifest barrels) collide whenever two concurrent Stories *create new
+  files* that the registry must import. The validator recognises this
+  class via `planning.crossCuttingRegistries` (extender-shaped). The
+  framework default list is:
+  - `lib/orchestration/lifecycle/listeners/index.js`
+  - `**/listeners/index.js`
+  - `**/handlers/index.js`
+
+  Trigger: two or more concurrent Stories either edit a registry path
+  directly **or** declare `assumption: creates` for a file in the
+  registry's parent directory. Remediation is the same as the shared
+  configuration files above — sequential `depends_on` between the
+  Stories, or a dedicated late-wave wiring Story. Consumers extend the
+  list per-project via `planning.crossCuttingRegistries` in
+  `.agentrc.json` (accepts `["…"]` to replace or `{ append: [...] }` to
+  add to the framework default).
+
+### WIDELY-USED SYMBOL DELETION (Story #2962):
+
+When a Task's `body.changes` declares `{ path, assumption: "deletes" }`,
+the decomposer probes the base branch at plan time via `git grep -l`
+for files that reference the deleted module's basename. When the count
+exceeds `planning.largeFanOutThreshold` (default `10`), the validator
+emits a `fan-out-warning` finding and `epic-plan-decompose` refuses to
+persist unless the operator passes `--allow-large-fan-out`.
+
+This gate exists because re-prompting the planner cannot reduce a
+deletion's call-site count — the only safe remediations are to split
+the deletion into a subsystem-by-subsystem migration across multiple
+Stories or to confirm the deletion is intentional and bypass the gate
+with the flag. The threshold is configurable per-project via
+`planning.largeFanOutThreshold` in `.agentrc.json`.
 
 Within-Story carve-out: two Tasks inside the **same** Story may edit a
 shared file freely — they merge together on the same Story branch and

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -108,6 +108,10 @@ top-level keys are validation errors.
 | `codebaseSnapshot.recentCommitWindow` | No | `integer` | — | — |
 | `failOnSharedEditors` | No | `boolean` | — | — |
 | `requireExplicitCrossStoryDeps` | No | `boolean` | — | — |
+| `failOnRegistryConflicts` | No | `boolean` | — | — |
+| `failOnLargeFanOut` | No | `boolean` | — | — |
+| `largeFanOutThreshold` | No | `integer` | — | — |
+| `crossCuttingRegistries` | No | `string[]` or `{ append?, prepend? }` | — | — |
 
 ### `delivery` (optional)
 

--- a/tests/lib/orchestration/ticket-validator-cross-cutting.test.js
+++ b/tests/lib/orchestration/ticket-validator-cross-cutting.test.js
@@ -1,0 +1,342 @@
+// tests/lib/orchestration/ticket-validator-cross-cutting.test.js
+//
+// Story #2962 — contract tests for the two new cross-cutting rules in
+// the decomposer validator:
+//
+//   1. `cross-cutting-registries` finding when two or more concurrent
+//      Stories add new files that would be imported by a registry / barrel
+//      file (e.g. `lib/orchestration/lifecycle/listeners/index.js`), or
+//      directly edit the registry.
+//   2. `fan-out-warning` finding when a Task declares a deletion whose
+//      call-site fan-out exceeds the configured threshold (counted via
+//      the injectable `fanOutCounter` probe).
+//
+// Run: node --test tests/lib/orchestration/ticket-validator-cross-cutting.test.js
+
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { runDecomposePhase } from '../../../.agents/scripts/lib/orchestration/epic-plan-decompose/phases/persist.js';
+import { validateAndNormalizeTickets } from '../../../.agents/scripts/lib/orchestration/ticket-validator.js';
+import {
+  _internal,
+  computeConflictFindings,
+} from '../../../.agents/scripts/lib/orchestration/ticket-validator-conflicts.js';
+
+const FEATURE = Object.freeze({
+  type: 'feature',
+  slug: 'f-x',
+  title: 'Feature',
+});
+
+function makeStory(slug, extras = {}) {
+  return {
+    type: 'story',
+    slug,
+    parent_slug: 'f-x',
+    title: `Story ${slug}`,
+    ...extras,
+  };
+}
+
+function makeTask(slug, parentSlug, body, extras = {}) {
+  return {
+    type: 'task',
+    slug,
+    parent_slug: parentSlug,
+    title: `Task ${slug}`,
+    body: {
+      goal: `Goal for ${slug}.`,
+      acceptance: ['observable criterion'],
+      verify: ['npm test (unit)'],
+      ...body,
+    },
+    ...extras,
+  };
+}
+
+describe('cross-cutting-registries finding (Story #2962)', () => {
+  it('emits crossCuttingRegistries when 2+ Stories create new files under the listeners registry directory', () => {
+    const tickets = [
+      FEATURE,
+      makeStory('s-a'),
+      makeStory('s-b'),
+      makeTask('t-a', 's-a', {
+        changes: [
+          {
+            path: 'lib/orchestration/lifecycle/listeners/foo-listener.js',
+            assumption: 'creates',
+          },
+        ],
+      }),
+      makeTask('t-b', 's-b', {
+        changes: [
+          {
+            path: 'lib/orchestration/lifecycle/listeners/bar-listener.js',
+            assumption: 'creates',
+          },
+        ],
+      }),
+      // The registry path itself must be in scope; declare it as
+      // refactors-existing so the rule recognises the parent dir.
+      makeTask('t-wire', 's-a', {
+        changes: [
+          {
+            path: 'lib/orchestration/lifecycle/listeners/index.js',
+            assumption: 'refactors-existing',
+          },
+        ],
+      }),
+    ];
+    const result = validateAndNormalizeTickets(tickets);
+    const registry = result.findings.filter(
+      (f) => f.kind === 'cross-cutting-registries',
+    );
+    assert.equal(registry.length, 1, 'one registry finding');
+    assert.equal(
+      registry[0].registryPath,
+      'lib/orchestration/lifecycle/listeners/index.js',
+    );
+    assert.deepEqual(registry[0].storySlugs, ['s-a', 's-b']);
+    assert.equal(registry[0].severity, 'soft');
+    assert.deepEqual(result.errors, []);
+  });
+
+  it('suppresses the finding when a depends_on chain serialises the Stories', () => {
+    const tickets = [
+      FEATURE,
+      makeStory('s-a'),
+      makeStory('s-b', { depends_on: ['s-a'] }),
+      makeTask('t-a', 's-a', {
+        changes: [
+          {
+            path: 'lib/orchestration/lifecycle/listeners/foo-listener.js',
+            assumption: 'creates',
+          },
+          {
+            path: 'lib/orchestration/lifecycle/listeners/index.js',
+            assumption: 'refactors-existing',
+          },
+        ],
+      }),
+      makeTask('t-b', 's-b', {
+        changes: [
+          {
+            path: 'lib/orchestration/lifecycle/listeners/bar-listener.js',
+            assumption: 'creates',
+          },
+        ],
+      }),
+    ];
+    const result = validateAndNormalizeTickets(tickets);
+    const registry = result.findings.filter(
+      (f) => f.kind === 'cross-cutting-registries',
+    );
+    assert.deepEqual(registry, []);
+  });
+
+  it('failOnRegistryConflicts=true upgrades the finding to hard and renders an errors[] line', () => {
+    const tickets = [
+      FEATURE,
+      makeStory('s-a'),
+      makeStory('s-b'),
+      makeTask('t-a', 's-a', {
+        changes: [
+          {
+            path: 'lib/orchestration/lifecycle/listeners/index.js',
+            assumption: 'refactors-existing',
+          },
+        ],
+      }),
+      makeTask('t-b', 's-b', {
+        changes: [
+          {
+            path: 'lib/orchestration/lifecycle/listeners/index.js',
+            assumption: 'refactors-existing',
+          },
+        ],
+      }),
+    ];
+    const result = validateAndNormalizeTickets(tickets, {
+      conflictPolicy: { failOnRegistryConflicts: true },
+    });
+    const registry = result.findings.filter(
+      (f) => f.kind === 'cross-cutting-registries',
+    );
+    assert.equal(registry.length, 1);
+    assert.equal(registry[0].severity, 'hard');
+    assert.equal(result.errors.length, 1);
+    assert.match(result.errors[0], /Cross-cutting registry conflict/);
+    assert.match(
+      result.errors[0],
+      /lib\/orchestration\/lifecycle\/listeners\/index\.js/,
+    );
+  });
+
+  it('matchRegistryPattern matches both explicit and **/ suffix patterns', () => {
+    const { matchRegistryPattern } = _internal;
+    assert.equal(
+      matchRegistryPattern(
+        'lib/orchestration/lifecycle/listeners/index.js',
+        'lib/orchestration/lifecycle/listeners/index.js',
+      ),
+      true,
+    );
+    assert.equal(
+      matchRegistryPattern('src/app/handlers/index.js', '**/handlers/index.js'),
+      true,
+    );
+    assert.equal(
+      matchRegistryPattern('handlers/index.js', '**/handlers/index.js'),
+      true,
+    );
+    assert.equal(
+      matchRegistryPattern('src/app/handlers/main.js', '**/handlers/index.js'),
+      false,
+    );
+  });
+});
+
+describe('fan-out-warning finding (Story #2962)', () => {
+  it('emits fan-out-warning when a deletes-assumption Task exceeds the threshold', () => {
+    const tickets = [
+      FEATURE,
+      makeStory('s-a'),
+      makeTask('t-a', 's-a', {
+        changes: [{ path: 'lib/legacy/old-shim.js', assumption: 'deletes' }],
+      }),
+    ];
+    const result = validateAndNormalizeTickets(tickets, {
+      conflictPolicy: {
+        largeFanOutThreshold: 10,
+        fanOutCounter: () => 50,
+      },
+    });
+    const fanOut = result.findings.filter((f) => f.kind === 'fan-out-warning');
+    assert.equal(fanOut.length, 1);
+    assert.equal(fanOut[0].path, 'lib/legacy/old-shim.js');
+    assert.equal(fanOut[0].callSiteCount, 50);
+    assert.equal(fanOut[0].threshold, 10);
+    assert.equal(fanOut[0].taskSlug, 't-a');
+    assert.equal(fanOut[0].severity, 'soft');
+  });
+
+  it('does not emit when the call-site count is within the threshold', () => {
+    const tickets = [
+      FEATURE,
+      makeStory('s-a'),
+      makeTask('t-a', 's-a', {
+        changes: [{ path: 'lib/legacy/old-shim.js', assumption: 'deletes' }],
+      }),
+    ];
+    const result = validateAndNormalizeTickets(tickets, {
+      conflictPolicy: {
+        largeFanOutThreshold: 10,
+        fanOutCounter: () => 3,
+      },
+    });
+    const fanOut = result.findings.filter((f) => f.kind === 'fan-out-warning');
+    assert.deepEqual(fanOut, []);
+  });
+
+  it('skips the fan-out probe entirely when no counter is injected', () => {
+    const findings = computeConflictFindings({
+      tasks: [
+        makeTask('t-a', 's-a', {
+          changes: [{ path: 'lib/x.js', assumption: 'deletes' }],
+        }),
+      ],
+      stories: [makeStory('s-a')],
+      policy: { largeFanOutThreshold: 10 },
+    });
+    assert.deepEqual(
+      findings.filter((f) => f.kind === 'fan-out-warning'),
+      [],
+    );
+  });
+});
+
+describe('fan-out persist gate (Story #2962)', () => {
+  // runDecomposePhase MUST refuse to persist when a fan-out-warning is
+  // present and `allowLargeFanOut` is not set. Mirrors the over-budget
+  // gate the persist phase already enforces.
+  const buildEpic = () => ({
+    id: 1,
+    title: 'E',
+    body: '',
+    labels: ['type::epic'],
+    linkedIssues: { prd: 10, techSpec: 11 },
+  });
+
+  const buildProvider = (epic) => ({
+    async getEpic() {
+      return epic;
+    },
+    async getTicket(id) {
+      return { id, body: 'b' };
+    },
+    async updateTicket() {},
+    async createTicket() {
+      return { id: 999, url: 'u' };
+    },
+    async getTickets() {
+      return [];
+    },
+    async getTicketComments() {
+      return [];
+    },
+    async createTicketComment() {
+      return { id: 1 };
+    },
+    async updateTicketComment() {
+      return { id: 1 };
+    },
+  });
+
+  const buildFanOutTickets = () => [
+    FEATURE,
+    makeStory('s-a'),
+    makeTask('t-a', 's-a', {
+      changes: [{ path: 'lib/legacy/widely-used.js', assumption: 'deletes' }],
+    }),
+  ];
+
+  it('throws a deterministic fan-out error when the threshold is exceeded and --allow-large-fan-out is not set', async () => {
+    const epic = buildEpic();
+    const provider = buildProvider(epic);
+    const tickets = buildFanOutTickets();
+    await assert.rejects(
+      () =>
+        runDecomposePhase(
+          1,
+          provider,
+          { tickets },
+          { planning: { maxTickets: 60, largeFanOutThreshold: 10 } },
+          { fanOutCounter: () => 50 },
+        ),
+      /large-fan-out|--allow-large-fan-out|50 call site/i,
+    );
+  });
+
+  it('lets the persist phase proceed past the fan-out gate when allowLargeFanOut is set', async () => {
+    const epic = buildEpic();
+    const provider = buildProvider(epic);
+    const tickets = buildFanOutTickets();
+    let err;
+    try {
+      await runDecomposePhase(
+        1,
+        provider,
+        { tickets },
+        { planning: { maxTickets: 60, largeFanOutThreshold: 10 } },
+        { fanOutCounter: () => 50, allowLargeFanOut: true },
+      );
+    } catch (e) {
+      err = e;
+    }
+    assert.ok(err, 'persist will throw downstream (no spec writer wired)');
+    assert.ok(
+      !/large-fan-out|--allow-large-fan-out/i.test(err.message),
+      `allow-large-fan-out run must NOT be rejected for fan-out reasons (got: ${err.message})`,
+    );
+  });
+});


### PR DESCRIPTION
Closes #2962

_Auto-opened by `/single-story-deliver`._