### PR TITLE
fix(workspace): include .mcp.json in default bootstrap file set

### DIFF
--- a/.agents/full-agentrc.json
+++ b/.agents/full-agentrc.json
@@ -119,7 +119,7 @@
       "allowSymlinkOnWindows": false,
       "reapOnSuccess": true,
       "reapOnCancel": true,
-      "bootstrapFiles": [".env"]
+      "bootstrapFiles": [".env", ".mcp.json"]
     },
     "signals": {
       "hotspot": { "p95Multiplier": 1.25 },

--- a/.agents/schemas/agentrc.schema.json
+++ b/.agents/schemas/agentrc.schema.json
@@ -349,7 +349,8 @@
         "reapOnCancel": { "type": "boolean" },
         "bootstrapFiles": {
           "type": "array",
-          "items": { "type": "string", "minLength": 1 }
+          "items": { "type": "string", "minLength": 1 },
+          "default": [".env", ".mcp.json"]
         }
       },
       "additionalProperties": false,

--- a/.agents/scripts/lib/config-settings-schema.js
+++ b/.agents/scripts/lib/config-settings-schema.js
@@ -313,6 +313,7 @@ const WORKTREE_ISOLATION_SCHEMA = {
     bootstrapFiles: {
       type: 'array',
       items: { type: 'string', minLength: 1 },
+      default: ['.env', '.mcp.json'],
     },
   },
   additionalProperties: false,

--- a/.agents/scripts/lib/config/worktree-isolation.js
+++ b/.agents/scripts/lib/config/worktree-isolation.js
@@ -18,7 +18,7 @@ export const WORKTREE_ISOLATION_DEFAULTS = Object.freeze({
   allowSymlinkOnWindows: false,
   reapOnSuccess: true,
   reapOnCancel: true,
-  bootstrapFiles: Object.freeze(['.env']),
+  bootstrapFiles: Object.freeze(['.env', '.mcp.json']),
 });
 
 /**

--- a/.agents/scripts/lib/workspace-provisioner.js
+++ b/.agents/scripts/lib/workspace-provisioner.js
@@ -2,10 +2,10 @@
  * workspace-provisioner.js
  *
  * Central authority for populating a fresh worktree (or remote-runner checkout)
- * with gitignored workspace files — `.env` by default, plus any other files
- * declared in `.agentrc.json orchestration.workspaceFiles`. Every caller that
- * needs these files in a non-main checkout should go through this module;
- * ad-hoc copy logic elsewhere in the codebase is a bug.
+ * with gitignored workspace files — `.env` and `.mcp.json` by default, plus
+ * any other files declared in `.agentrc.json orchestration.workspaceFiles`.
+ * Every caller that needs these files in a non-main checkout should go
+ * through this module; ad-hoc copy logic elsewhere in the codebase is a bug.
  *
  * Public API:
  *   - `provision({ sourceRoot, targetWorktree, files?, logger? })` — copies
@@ -17,14 +17,14 @@
  *   - `resolveWorkspaceFiles(orchestrationConfig)` — resolves the list honoring
  *     the new `orchestration.workspaceFiles` key, the legacy
  *     `orchestration.worktreeIsolation.bootstrapFiles`, and the default.
- *   - `DEFAULT_WORKSPACE_FILES` — `['.env']`.
+ *   - `DEFAULT_WORKSPACE_FILES` — `['.env', '.mcp.json']`.
  */
 
 import fs from 'node:fs';
 import path from 'node:path';
 import { NOOP_LOGGER } from './Logger.js';
 
-export const DEFAULT_WORKSPACE_FILES = ['.env'];
+export const DEFAULT_WORKSPACE_FILES = ['.env', '.mcp.json'];
 
 /**
  * Resolve the list of workspace files to provision.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -135,7 +135,7 @@ top-level keys are validation errors.
 | `worktreeIsolation.allowSymlinkOnWindows` | No | `boolean` | — | — |
 | `worktreeIsolation.reapOnSuccess` | No | `boolean` | — | — |
 | `worktreeIsolation.reapOnCancel` | No | `boolean` | — | — |
-| `worktreeIsolation.bootstrapFiles` | No | `array<string>` | — | — |
+| `worktreeIsolation.bootstrapFiles` | No | `array<string>` | `[".env",".mcp.json"]` | — |
 | `signals` | No | `object` | — | Nested configuration block. |
 | `signals.hotspot` | No | `object` | — | Nested configuration block. |
 | `signals.hotspot.p95Multiplier` | No | `number` | — | — |
@@ -471,7 +471,7 @@ checkout's HEAD.
 | `allowSymlinkOnWindows` | No              | `false`          | Permit symlink strategy on Windows (requires admin/dev mode). |
 | `reapOnSuccess`         | No              | `true`           | Reap the worktree after a successful Story close.            |
 | `reapOnCancel`          | No              | `true`           | Reap the worktree if the Story is cancelled.                 |
-| `bootstrapFiles`        | No              | `[]`             | Untracked files (e.g. `.env`) copied into each new worktree. |
+| `bootstrapFiles`        | No              | `[".env", ".mcp.json"]` | Untracked files copied into each new worktree. |
 
 ### `delivery.signals`
 

--- a/tests/lib/workspace-provisioner.test.js
+++ b/tests/lib/workspace-provisioner.test.js
@@ -28,8 +28,8 @@ function quietLogger() {
   };
 }
 
-test('DEFAULT_WORKSPACE_FILES is [.env]', () => {
-  assert.deepEqual(DEFAULT_WORKSPACE_FILES, ['.env']);
+test('DEFAULT_WORKSPACE_FILES is [.env, .mcp.json]', () => {
+  assert.deepEqual(DEFAULT_WORKSPACE_FILES, ['.env', '.mcp.json']);
 });
 
 test('resolveWorkspaceFiles: prefers workspaceFiles', () => {
@@ -52,7 +52,7 @@ test('resolveWorkspaceFiles: defaults when unset', () => {
   assert.deepEqual(resolveWorkspaceFiles({}), DEFAULT_WORKSPACE_FILES);
 });
 
-test('provision: copies .env into a fresh worktree by default', () => {
+test('provision: copies .env and .mcp.json into a fresh worktree by default', () => {
   const { src, dst } = makeRoots();
   fs.writeFileSync(path.join(src, '.env'), 'TOKEN=1\n');
   fs.writeFileSync(path.join(src, '.mcp.json'), '{"mcpServers":{}}\n');
@@ -64,11 +64,14 @@ test('provision: copies .env into a fresh worktree by default', () => {
     logger,
   });
 
-  assert.deepEqual(result.copied, ['.env']);
+  assert.deepEqual(result.copied.sort(), ['.env', '.mcp.json']);
   assert.equal(result.skipped.length, 0);
   assert.equal(result.missing.length, 0);
   assert.equal(fs.readFileSync(path.join(dst, '.env'), 'utf8'), 'TOKEN=1\n');
-  assert.equal(fs.existsSync(path.join(dst, '.mcp.json')), false);
+  assert.equal(
+    fs.readFileSync(path.join(dst, '.mcp.json'), 'utf8'),
+    '{"mcpServers":{}}\n',
+  );
 });
 
 test('provision: preserves existing target files (no overwrite)', () => {


### PR DESCRIPTION
## Summary

- Default worktree bootstrap file list was `[.env]` only, so freshly-created worktrees never received `.mcp.json`. The existing `worktree-bootstrap-env` check already treats `.mcp.json` as a required bootstrap file alongside `.env`, so the default was inconsistent with the check.
- Align `DEFAULT_WORKSPACE_FILES` (workspace-provisioner) and `WORKTREE_ISOLATION_DEFAULTS.bootstrapFiles` (config/worktree-isolation) to `['.env', '.mcp.json']`.
- Advertise the new default in the JSON Schema mirror (`agentrc.schema.json`) and the AJV runtime schema (`config-settings-schema.js`); regenerate `docs/configuration.md` and update `full-agentrc.json` reference. Update the workspace-provisioner test that previously asserted `.mcp.json` was **not** copied by default.

## Test plan

- [x] `node --test tests/lib/workspace-provisioner.test.js tests/lib/config-resolver-worktree.test.js tests/lib/worktree/bootstrapper.test.js tests/lib/checks/worktree-bootstrap-env.test.js` — all 35 pass
- [x] `node --test tests/config-schema-mirror-drift.test.js` — schema mirror clean
- [x] `npm run lint` (incl. docs:check) — clean