### PR TITLE
Bug: parent cascade misses Features when Story bodies lack the `parent: #N` footer (resume reconciler strips it) (#2982)

### DIFF
--- a/.agents/scripts/lib/orchestration/epic-spec-reconciler-apply.js
+++ b/.agents/scripts/lib/orchestration/epic-spec-reconciler-apply.js
@@ -486,12 +486,13 @@ async function applyRelink(op, provider, slugToIssue) {
       }
     }
   }
-  if (op.dependsOn) {
-    const footer = renderDependsOnFooter(op.dependsOn.after, slugToIssue);
-    await provider.updateTicket(op.issueNumber, {
-      body: footer ? footer.trimStart() : '',
-    });
-  }
+  // Story #2982 — dependsOn edge changes no longer write the body here.
+  // The diff engine recomposes the canonical orchestrator footer
+  // (`---\nparent:`/`Epic:`/`blocked by`) and routes a body change
+  // through `applyUpdate`. Writing it from the relink path stripped
+  // description + parent + Epic on every dep change. The relink op
+  // remains the authoritative carrier of the dependsOn delta for the
+  // state writer and for the parent sub-issue add/remove above.
   return {
     slug: op.slug,
     entity: op.entity,

--- a/.agents/scripts/lib/orchestration/epic-spec-reconciler-diff.js
+++ b/.agents/scripts/lib/orchestration/epic-spec-reconciler-diff.js
@@ -80,6 +80,10 @@
  *     issue with an empty body.
  */
 
+import {
+  composeTaskBody,
+  stripOrchestratorFooter,
+} from '../templates/task-body-renderer.js';
 import { assertPlanLabelAllowList } from './epic-spec-reconciler-discriminator.js';
 import {
   closeOp,
@@ -169,6 +173,56 @@ function normaliseBody(value) {
 }
 
 /**
+ * Compose the canonical orchestrator footer onto a spec body for non-epic
+ * entities. Resolves `parentSlug`/`dependsOn` slugs against the running
+ * `state.mapping` so the rendered footer carries the live issue numbers.
+ * Pure: identical inputs produce a byte-identical body.
+ *
+ * Story #2982 — without this re-composition, a body Update sourced from
+ * the YAML spec writes just the description, silently stripping
+ * `parent: #N` / `Epic: #M` / `blocked by #X` and breaking the cascade.
+ *
+ * @param {{entity: string, parentSlug?: string|null, dependsOn?: string[]}} specEntity
+ * @param {string} specBody
+ * @param {{state?: StateInput}} ctx
+ * @returns {string}
+ */
+function composeBodyWithFooter(specEntity, specBody, ctx) {
+  const state = ctx?.state ?? {};
+  const mapping = state.mapping ?? {};
+  const parentSlug = specEntity.parentSlug ?? null;
+  const parentId =
+    parentSlug && mapping[parentSlug]
+      ? mapping[parentSlug].issueNumber
+      : undefined;
+  // Without a resolved parent we cannot render a meaningful footer.
+  // Fall back to the raw spec body — apply still writes something the
+  // operator can inspect; the missing-parent case is rare (the only
+  // current trigger is a relink-in-flight where the new parent has not
+  // landed yet, which surfaces elsewhere via the relink op anyway).
+  if (typeof parentId !== 'number') return specBody;
+  const epicId = typeof state.epicId === 'number' ? state.epicId : undefined;
+  const dependencies = Array.isArray(specEntity.dependsOn)
+    ? specEntity.dependsOn
+        .map((slug) => mapping[slug]?.issueNumber)
+        .filter((id) => typeof id === 'number')
+    : [];
+  // Strip any orchestrator footer the spec already carries before
+  // recomposing. Without the strip we double-wrap when the spec body
+  // round-tripped through `reverse-bootstrap` (which stores the raw GH
+  // body verbatim, footer included) or any other producer that emits a
+  // canonical-form body. With the strip, the function is idempotent
+  // against its own output and against the createTicket-rendered shape.
+  const head = stripOrchestratorFooter(specBody);
+  return composeTaskBody({
+    body: head,
+    parentId,
+    epicId,
+    dependencies,
+  });
+}
+
+/**
  * Pick the ghState observation for an issue number, coercing the key
  * type so numeric and string keys interop.
  *
@@ -190,7 +244,7 @@ function ghObservation(ghState, issueNumber) {
  * @param {StateMappingEntry} mapping
  * @returns {Record<string, {before: unknown, after: unknown}>}
  */
-function fieldChanges(specEntity, obs, mapping) {
+function fieldChanges(specEntity, obs, mapping, ctx = {}) {
   const changes = {};
   if (!obs) {
     // Mapped but GH side missing → treat as full update (apply will
@@ -213,8 +267,27 @@ function fieldChanges(specEntity, obs, mapping) {
   if (typeof specEntity.body === 'string') {
     const specBody = specEntity.body;
     const obsBody = normaliseBody(obs.body);
-    if (specBody !== obsBody) {
-      changes.body = { before: obsBody, after: specBody };
+    const isEpic = specEntity.entity === ENTITY_KINDS.EPIC;
+    if (isEpic) {
+      if (specBody !== obsBody) {
+        changes.body = { before: obsBody, after: specBody };
+      }
+    } else {
+      // Story #2982 — for non-epic entities, compare the spec body
+      // (re-composed with the canonical orchestrator footer) against
+      // the raw GH body. Single comparison catches:
+      //   • description-only changes,
+      //   • parent/Epic id changes (footer differs),
+      //   • dependsOn changes (`blocked by` block differs),
+      //   • duplicated footer blocks (obs has more than one),
+      //   • missing footer (obs has none).
+      // Emit a body change only when the canonical form differs from
+      // what is on GH today — and write the canonical form back, so the
+      // footer cascade-readers depend on stays intact across resumes.
+      const after = composeBodyWithFooter(specEntity, specBody, ctx);
+      if (after !== obsBody) {
+        changes.body = { before: obsBody, after };
+      }
     }
   }
   const effectiveAfterLabels =
@@ -408,7 +481,7 @@ export function diff({ spec, state, ghState } = {}) {
 
     // Mapped: check for content updates.
     const obs = ghObservation(ghState, mapped.issueNumber);
-    const changes = fieldChanges(entity, obs, mapped);
+    const changes = fieldChanges(entity, obs, mapped, { state });
     if (Object.keys(changes).length > 0) {
       plan.updates.push(
         updateOp({

--- a/.agents/scripts/lib/orchestration/ticketing/bulk.js
+++ b/.agents/scripts/lib/orchestration/ticketing/bulk.js
@@ -449,6 +449,33 @@ export async function cascadeCompletion(provider, ticketId, opts = {}) {
     parsedParents = parentMatch.map((m) => Number.parseInt(m[1], 10));
   }
 
+  // Story #2982 — third fallback: GitHub's native Sub-Issues API. The
+  // resume reconciler can strip the `parent: #N` orchestrator footer
+  // from a Story body (see Issue 2 in #2982); without the body marker
+  // the cascade silently returned `{ cascadedTo: [], failed: [] }` and
+  // left intermediate Feature tickets stranded OPEN. The native link is
+  // independent of body text, so consult it when the first two
+  // strategies came back empty.
+  if (
+    parsedParents.length === 0 &&
+    typeof provider._getNativeParent === 'function' &&
+    ticket.nodeId
+  ) {
+    try {
+      const nativeParent = await provider._getNativeParent(
+        ticket.nodeId,
+        ticketId,
+      );
+      if (typeof nativeParent === 'number') {
+        parsedParents = [nativeParent];
+      }
+    } catch (err) {
+      Logger.warn(
+        `[cascadeCompletion] native parent lookup failed for #${ticketId}: ${err.message}`,
+      );
+    }
+  }
+
   if (parsedParents.length === 0) {
     return { cascadedTo: [], failed: [] };
   }

--- a/.agents/scripts/lib/templates/task-body-renderer.js
+++ b/.agents/scripts/lib/templates/task-body-renderer.js
@@ -124,3 +124,37 @@ export function composeTaskBody({
 export function hasStructuredHeader(markdownBody) {
   return /^## Goal\n/.test((markdownBody ?? '').trimStart());
 }
+
+/**
+ * Strip the canonical orchestrator footer from a rendered body and return
+ * just the description portion. The footer is anchored on a line that
+ * matches `^---$` followed immediately by `parent: #\d+`; everything from
+ * that `---` line onward (including any trailing `blocked by` block) is
+ * removed. Trailing whitespace is trimmed so the returned string is byte-
+ * stable when fed back through `composeTaskBody`.
+ *
+ * Story #2982 — the `/epic-plan` decompose `--resume` reconciler compared
+ * a spec body (description only) against a GH body (description + footer)
+ * and emitted a destructive Update that wrote just the description back,
+ * stripping the canonical footer that the cascade depends on. The diff
+ * engine now strips the footer before comparison so a body whose
+ * description already matches no longer flaps; the apply engine
+ * re-composes the canonical footer when a genuine description change
+ * lands, so the footer is invariant across reconciles.
+ *
+ * Safe to call on bodies without a footer — returns the input unchanged
+ * (modulo trailing-whitespace trim).
+ *
+ * @param {string|null|undefined} markdownBody
+ * @returns {string}
+ */
+export function stripOrchestratorFooter(markdownBody) {
+  const body = typeof markdownBody === 'string' ? markdownBody : '';
+  // Match a `---` line followed by `parent: #N` on the next line. The
+  // multi-line flag anchors `^---$` per line; `[ \t]*` tolerates trailing
+  // whitespace after the separator. Greedy from the match through end of
+  // string captures any trailing `Epic:`/`audit-snapshot:`/`blocked by`
+  // lines (and any later dup-footer blocks) in one pass.
+  const FOOTER_RE = /\n?---[ \t]*\r?\n+parent:\s*#\d+[\s\S]*$/;
+  return body.replace(FOOTER_RE, '').replace(/\s+$/, '');
+}

--- a/.agents/scripts/providers/github.js
+++ b/.agents/scripts/providers/github.js
@@ -134,6 +134,7 @@ const DELEGATIONS = [
   ['updateTicket', 'tickets.updateTicket'],
   ['_applyLabelMutations', 'tickets._applyLabelMutations'],
   ['_getNativeSubIssues', 'subIssues.getNativeSubIssues'],
+  ['_getNativeParent', 'subIssues.getNativeParent'],
   ['addSubIssue', 'subIssues.addSubIssue'],
   ['removeSubIssue', 'subIssues.removeSubIssue'],
   ['reconcileSubIssueLinks', 'subIssues.reconcileSubIssueLinks'],

--- a/.agents/scripts/providers/github/errors.js
+++ b/.agents/scripts/providers/github/errors.js
@@ -221,3 +221,22 @@ export const REMOVE_SUB_ISSUE_MUTATION = `
       subIssue { number }
     }
   }`;
+
+// Story #2982 — native parent lookup for the cascade upward walk. The
+// inverse of `SUB_ISSUES_QUERY`: given a child Issue node, fetch the
+// `parent` field exposed by the Sub-Issues feature so `cascadeCompletion`
+// can resolve a parent even when the child body lacks the `parent: #N`
+// orchestrator footer.
+export const PARENT_ISSUE_QUERY = `query($id: ID!) {
+  node(id: $id) {
+    ... on Issue {
+      parent {
+        number
+        databaseId
+        id
+        title
+        state
+      }
+    }
+  }
+}`;

--- a/.agents/scripts/providers/github/sub-issues.js
+++ b/.agents/scripts/providers/github/sub-issues.js
@@ -30,6 +30,7 @@ import { concurrentMap } from '../../lib/util/concurrent-map.js';
 import {
   ADD_SUB_ISSUE_MUTATION,
   classifyGithubError as defaultClassifyGithubError,
+  PARENT_ISSUE_QUERY,
   REMOVE_SUB_ISSUE_MUTATION,
   SUB_ISSUES_QUERY,
   withTransientRetry,
@@ -131,6 +132,52 @@ export class SubIssueGateway {
       throw err;
     }
     return childIds;
+  }
+
+  /**
+   * Strategy 2 — native GitHub Sub-Issues, inverse direction. Given a
+   * child Issue node, return the parent's issue number (or `null` when
+   * the child has no native parent link, or the feature is disabled on
+   * this repo). Story #2982: used by `cascadeCompletion` as a third
+   * fallback so a Story whose body lost the `parent: #N` orchestrator
+   * footer still cascades upward to its true Sub-Issue parent.
+   *
+   * @param {string} childNodeId  GraphQL node ID of the child Issue.
+   * @param {number} childNumber  Issue number, for log context only.
+   * @returns {Promise<number|null>}
+   */
+  async getNativeParent(childNodeId, childNumber) {
+    if (!childNodeId) return null;
+    try {
+      const data = await withTransientRetry(
+        () =>
+          this._ghGraphql(
+            PARENT_ISSUE_QUERY,
+            { id: childNodeId },
+            { headers: { 'GraphQL-Features': 'sub_issues' } },
+          ),
+        {
+          label: `getNativeParent child=#${childNumber}`,
+          classify: this._classify,
+          onRetry: defaultRetryWarn,
+        },
+      );
+      const parent = data?.node?.parent;
+      if (!parent || typeof parent.number !== 'number') return null;
+      return parent.number;
+    } catch (err) {
+      const category = this._classify(err);
+      if (category === 'feature-disabled') {
+        Logger.warn(
+          `[GitHubProvider] sub-issues parent lookup unavailable (child #${childNumber})`,
+        );
+        return null;
+      }
+      Logger.error(
+        `[GitHubProvider] native parent lookup failed (child #${childNumber}, category=${category}): ${err.message}`,
+      );
+      throw err;
+    }
   }
 
   /**

--- a/tests/lib/orchestration/ticketing/bulk.test.js
+++ b/tests/lib/orchestration/ticketing/bulk.test.js
@@ -343,3 +343,124 @@ describe('ticketing/bulk — cascadeParentState (Story #2676)', () => {
     assert.deepEqual(result.failed, []);
   });
 });
+
+/**
+ * Story #2982 — regression: a Story whose body lost the `parent: #N`
+ * orchestrator footer (and whose `blocks:` deps are empty) must still
+ * cascade upward to its native Sub-Issue parent so intermediate
+ * Features cascade-close when their last child completes.
+ */
+class NativeParentMock extends ITicketingProvider {
+  constructor() {
+    super();
+    this.updates = [];
+    this.comments = [];
+    this.nativeParentCalls = [];
+    // Hierarchy: Feature 200 ← Story 50 (body has no parent: marker)
+    this.tickets = {
+      50: {
+        id: 50,
+        nodeId: 'NODE_STORY_50',
+        labels: ['agent::done', 'type::story'],
+        // Description-only body — the reconciler stripped the canonical
+        // footer (see Issue 2 in #2982). Without the body marker AND
+        // without `blocks:` deps, the only signal of the parent is the
+        // native Sub-Issues link.
+        body: 'Story description with no orchestrator footer.',
+        state: 'closed',
+      },
+      200: {
+        id: 200,
+        nodeId: 'NODE_FEAT_200',
+        labels: ['agent::executing', 'type::feature'],
+        body: 'Feature body',
+        state: 'open',
+      },
+    };
+    this.deps = {
+      50: { blocks: [], blockedBy: [] },
+      200: { blocks: [], blockedBy: [] },
+    };
+    this.subTickets = {
+      50: [],
+      200: [this.tickets[50]],
+    };
+  }
+  async getTicket(id) {
+    return this.tickets[id];
+  }
+  async updateTicket(id, mutations) {
+    this.updates.push({ id, mutations });
+    if (mutations.labels) {
+      const rm = mutations.labels.remove || [];
+      const add = mutations.labels.add || [];
+      let current = this.tickets[id].labels.filter((l) => !rm.includes(l));
+      current = [...new Set([...current, ...add])];
+      this.tickets[id].labels = current;
+    }
+    if (mutations.state !== undefined) this.tickets[id].state = mutations.state;
+  }
+  async postComment(id, payload) {
+    this.comments.push({ id, payload });
+  }
+  async getTicketDependencies(id) {
+    return this.deps[id];
+  }
+  async getSubTickets(id) {
+    return this.subTickets[id].map((t) => this.tickets[t.id]);
+  }
+  async _getNativeParent(nodeId, number) {
+    this.nativeParentCalls.push({ nodeId, number });
+    if (number === 50) return 200;
+    return null;
+  }
+}
+
+describe('ticketing/bulk — cascadeCompletion native parent fallback (Story #2982)', () => {
+  it('cascades to the native Sub-Issue parent when body markers and blocks are absent', async () => {
+    const mock = new NativeParentMock();
+    __resetParentCascadeLocks();
+    __setCascadeRetryDelays({ delays: [] });
+    const result = await cascadeCompletion(mock, 50);
+    const childLookup = mock.nativeParentCalls.find((c) => c.number === 50);
+    assert.ok(
+      childLookup,
+      'native parent lookup should fire for the child Story #50',
+    );
+    assert.deepEqual(result.cascadedTo, [200]);
+    assert.deepEqual(result.failed, []);
+    assert.equal(
+      mock.tickets[200].labels.includes(STATE_LABELS.DONE),
+      true,
+      'Feature should flip to agent::done via native-parent cascade',
+    );
+  });
+
+  it('skips the native fallback when blocks already supplies a parent', async () => {
+    const mock = new NativeParentMock();
+    __resetParentCascadeLocks();
+    __setCascadeRetryDelays({ delays: [] });
+    mock.deps[50] = { blocks: [200], blockedBy: [] };
+    await cascadeCompletion(mock, 50);
+    const childLookup = mock.nativeParentCalls.find((c) => c.number === 50);
+    assert.equal(
+      childLookup,
+      undefined,
+      'should not query native parent for #50 when blocks names the parent',
+    );
+  });
+
+  it('skips the native fallback when the body footer names a parent', async () => {
+    const mock = new NativeParentMock();
+    __resetParentCascadeLocks();
+    __setCascadeRetryDelays({ delays: [] });
+    mock.tickets[50].body = 'desc\n\n---\nparent: #200';
+    await cascadeCompletion(mock, 50);
+    const childLookup = mock.nativeParentCalls.find((c) => c.number === 50);
+    assert.equal(
+      childLookup,
+      undefined,
+      'should not query native parent for #50 when body footer names the parent',
+    );
+  });
+});

--- a/tests/providers/github-surface-parity.test.js
+++ b/tests/providers/github-surface-parity.test.js
@@ -47,6 +47,7 @@ function buildProvider() {
   };
   provider.subIssues = {
     getNativeSubIssues: async () => 'subIssues.getNativeSubIssues',
+    getNativeParent: async () => 'subIssues.getNativeParent',
     addSubIssue: async () => 'subIssues.addSubIssue',
     removeSubIssue: async () => 'subIssues.removeSubIssue',
     reconcileSubIssueLinks: async () => 'subIssues.reconcileSubIssueLinks',
@@ -132,6 +133,7 @@ describe('providers/github.js — surface parity (Story #2462 / Task #2481)', ()
       ['_applyLabelMutations', [1, {}, false], 'tickets._applyLabelMutations'],
       // sub-issues
       ['_getNativeSubIssues', ['NODE', 1], 'subIssues.getNativeSubIssues'],
+      ['_getNativeParent', ['NODE', 1], 'subIssues.getNativeParent'],
       ['addSubIssue', [1, 'NODE'], 'subIssues.addSubIssue'],
       ['removeSubIssue', [1, 2], 'subIssues.removeSubIssue'],
       ['reconcileSubIssueLinks', [1], 'subIssues.reconcileSubIssueLinks'],

--- a/tests/providers/github/sub-issues.test.js
+++ b/tests/providers/github/sub-issues.test.js
@@ -41,8 +41,12 @@ const cacheMod = await import(
 );
 
 const { SubIssueGateway } = subIssuesMod;
-const { ADD_SUB_ISSUE_MUTATION, REMOVE_SUB_ISSUE_MUTATION, SUB_ISSUES_QUERY } =
-  errorsMod;
+const {
+  ADD_SUB_ISSUE_MUTATION,
+  PARENT_ISSUE_QUERY,
+  REMOVE_SUB_ISSUE_MUTATION,
+  SUB_ISSUES_QUERY,
+} = errorsMod;
 const { createInlineTicketCache } = cacheMod;
 
 describe('providers/github/sub-issues.js — SubIssueGateway', () => {
@@ -191,6 +195,49 @@ describe('providers/github/sub-issues.js — SubIssueGateway', () => {
     });
     const ids = await gateway.getNativeSubIssues('parent_node', 1);
     assert.deepEqual(ids, []);
+  });
+
+  it('getNativeParent: returns the parent issue number via the PARENT_ISSUE_QUERY (Story #2982)', async () => {
+    const calls = [];
+    const ghGraphql = async (query, variables) => {
+      calls.push({ query, variables });
+      return { node: { parent: { number: 784, id: 'NODE_PARENT' } } };
+    };
+    const gateway = new SubIssueGateway({ ghGraphql });
+    const parent = await gateway.getNativeParent('NODE_CHILD', 50);
+    assert.equal(parent, 784);
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0].query, PARENT_ISSUE_QUERY);
+    assert.deepEqual(calls[0].variables, { id: 'NODE_CHILD' });
+  });
+
+  it('getNativeParent: returns null when the child has no parent link', async () => {
+    const ghGraphql = async () => ({ node: { parent: null } });
+    const gateway = new SubIssueGateway({ ghGraphql });
+    const parent = await gateway.getNativeParent('NODE_CHILD', 50);
+    assert.equal(parent, null);
+  });
+
+  it('getNativeParent: returns null when the sub-issues feature is disabled', async () => {
+    const ghGraphql = async () => {
+      throw new Error('feature off');
+    };
+    const classify = () => 'feature-disabled';
+    const gateway = new SubIssueGateway({
+      ghGraphql,
+      classifyGithubError: classify,
+    });
+    const parent = await gateway.getNativeParent('NODE_CHILD', 50);
+    assert.equal(parent, null);
+  });
+
+  it('getNativeParent: returns null when called with no node id', async () => {
+    const ghGraphql = async () => {
+      throw new Error('should not be called');
+    };
+    const gateway = new SubIssueGateway({ ghGraphql });
+    const parent = await gateway.getNativeParent(undefined, 50);
+    assert.equal(parent, null);
   });
 
   it('reconcileSubIssueLinks: backfills missing links and reports the totals', async () => {

--- a/tests/scripts/epic-reconcile.bootstrap.test.js
+++ b/tests/scripts/epic-reconcile.bootstrap.test.js
@@ -110,7 +110,12 @@ function buildQuiescentFixture() {
     {
       id: FEATURE_ID,
       title: 'Migration Feature',
-      body: `Feature body.\n\n---\nparent: #${EPIC_ID}\nEpic: #${EPIC_ID}`,
+      // Canonical form per `renderOrchestratorFooter`: when parent IS
+      // the Epic, the renderer skips the redundant `Epic: #N` line.
+      // Story #2982 — the reconciler diff now normalises non-canonical
+      // bodies on reconcile, so the fixture must already be canonical
+      // for the bootstrap round-trip to be a no-op.
+      body: `Feature body.\n\n---\nparent: #${EPIC_ID}`,
       labels: ['type::feature'],
     },
     {

--- a/tests/scripts/epic-spec-reconciler.apply.test.js
+++ b/tests/scripts/epic-spec-reconciler.apply.test.js
@@ -393,7 +393,13 @@ describe('reconciler apply — relink path', () => {
     assert.deepEqual(add.args, [8002, 5010]);
   });
 
-  it('rewrites dependsOn footer through updateTicket body mutation', async () => {
+  it('does not write the body from the relink path (Story #2982)', async () => {
+    // Story #2982 — the relink op previously wrote a body containing
+    // only the `blocked by` footer, which stripped description +
+    // `parent: #N` + `Epic: #M` on every dependsOn change. The diff
+    // engine now recomposes the canonical orchestrator footer and
+    // routes the body update through `applyUpdate`; relink dispatches
+    // only the parent sub-issue add/remove (when parent changed).
     const provider = new StubProvider();
     const plan = emptyPlan();
     plan.relinks.push(
@@ -407,8 +413,8 @@ describe('reconciler apply — relink path', () => {
     await apply(plan, provider, {
       slugToIssue: { 'story-blocker': 7001 },
     });
-    const call = provider.calls.find((c) => c.kind === 'updateTicket');
-    assert.match(call.args[1].body, /blocked by #7001/);
+    const updateCalls = provider.calls.filter((c) => c.kind === 'updateTicket');
+    assert.equal(updateCalls.length, 0);
   });
 });
 

--- a/tests/scripts/epic-spec-reconciler.diff.test.js
+++ b/tests/scripts/epic-spec-reconciler.diff.test.js
@@ -632,3 +632,179 @@ describe('reconciler diff — Epic body preservation when spec omits body (Story
     assert.equal(epicUpdate, undefined);
   });
 });
+
+/**
+ * Story #2982 — the resume reconciler stripped the canonical
+ * orchestrator footer (`---\nparent: #N\n[Epic: #M\n][blocked by #X\n]`)
+ * from Story bodies. Two-part contract:
+ *   • A Story whose description matches the spec must not emit a
+ *     destructive body Update just because GH carries the canonical
+ *     footer (or a duplicated one).
+ *   • When the description genuinely changes, the emitted body Update
+ *     must carry the canonical footer in its `after` value so apply
+ *     writes it back intact.
+ */
+describe('reconciler diff — orchestrator footer preservation (Story #2982)', () => {
+  function buildInputs({ specBody, obsBody }) {
+    const spec = {
+      epic: {
+        id: 7000,
+        title: 'Cascade Epic',
+        labels: ['type::epic'],
+        body: 'epic body',
+      },
+      features: [
+        {
+          slug: 'feat-cascade',
+          title: 'Cascade Feature',
+          labels: ['type::feature'],
+          stories: [
+            {
+              slug: 'story-cascade',
+              title: 'Cascade Story',
+              labels: ['type::story'],
+              body: specBody,
+              wave: 0,
+              dependsOn: ['story-dep'],
+              tasks: [],
+            },
+            {
+              slug: 'story-dep',
+              title: 'Dep Story',
+              labels: ['type::story'],
+              body: 'dep description',
+              wave: 0,
+              dependsOn: [],
+              tasks: [],
+            },
+          ],
+        },
+      ],
+    };
+    const state = {
+      epicId: 7000,
+      mapping: {
+        epic: { issueNumber: 7000, entity: 'epic', parentSlug: null },
+        'feat-cascade': {
+          issueNumber: 7100,
+          entity: 'feature',
+          parentSlug: 'epic',
+        },
+        'story-cascade': {
+          issueNumber: 7200,
+          entity: 'story',
+          parentSlug: 'feat-cascade',
+          dependsOn: ['story-dep'],
+        },
+        'story-dep': {
+          issueNumber: 7201,
+          entity: 'story',
+          parentSlug: 'feat-cascade',
+          dependsOn: [],
+        },
+      },
+    };
+    const ghState = {
+      7000: {
+        title: 'Cascade Epic',
+        body: 'epic body',
+        labels: ['type::epic'],
+      },
+      7100: {
+        title: 'Cascade Feature',
+        body: '',
+        labels: ['type::feature'],
+      },
+      7200: {
+        title: 'Cascade Story',
+        body: obsBody,
+        labels: ['type::story'],
+      },
+      7201: {
+        title: 'Dep Story',
+        body: 'dep description',
+        labels: ['type::story'],
+      },
+    };
+    return { spec, state, ghState };
+  }
+
+  const canonicalFooter =
+    '\n\n---\nparent: #7100\nEpic: #7000\n\nblocked by #7201';
+
+  it('does not flap when GH already carries the canonical footer (description match)', () => {
+    const description = 'story description';
+    const { spec, state, ghState } = buildInputs({
+      specBody: description,
+      obsBody: `${description}${canonicalFooter}`,
+    });
+    const plan = diff({ spec, state, ghState });
+    const storyUpdate = plan.updates.find((op) => op.slug === 'story-cascade');
+    assert.equal(
+      storyUpdate,
+      undefined,
+      'no body Update should fire when description matches and footer is canonical',
+    );
+  });
+
+  it('recomposes the canonical footer onto the after value when description changes', () => {
+    const { spec, state, ghState } = buildInputs({
+      specBody: 'new description',
+      obsBody: `old description${canonicalFooter}`,
+    });
+    const plan = diff({ spec, state, ghState });
+    const storyUpdate = plan.updates.find((op) => op.slug === 'story-cascade');
+    assert.ok(storyUpdate, 'an Update should fire when description changes');
+    assert.ok(storyUpdate.changes.body);
+    assert.match(storyUpdate.changes.body.after, /^new description/);
+    assert.match(storyUpdate.changes.body.after, /\n---\nparent: #7100\n/);
+    assert.match(storyUpdate.changes.body.after, /Epic: #7000/);
+    assert.match(storyUpdate.changes.body.after, /blocked by #7201/);
+  });
+
+  it('emits an Update that normalises a duplicated footer block to a single canonical form', () => {
+    const description = 'story description';
+    // Epic #775 reproduction: dup `blocked by` lines outside the
+    // separator plus the canonical footer underneath.
+    const obsBody = `${description}\n\nblocked by #7201\n\n---\nparent: #7100\nEpic: #7000\n\nblocked by #7201`;
+    const { spec, state, ghState } = buildInputs({
+      specBody: description,
+      obsBody,
+    });
+    const plan = diff({ spec, state, ghState });
+    const storyUpdate = plan.updates.find((op) => op.slug === 'story-cascade');
+    assert.ok(
+      storyUpdate,
+      'an Update should fire to collapse the duplicated trailer',
+    );
+    const after = storyUpdate.changes.body.after;
+    assert.match(after, /^story description\n\n---\nparent: #7100\n/);
+    const parentMatches = after.match(/parent: #7100/g) ?? [];
+    assert.equal(
+      parentMatches.length,
+      1,
+      'recomposed body must carry exactly one parent: marker',
+    );
+    const blockedMatches = after.match(/blocked by #7201/g) ?? [];
+    assert.equal(
+      blockedMatches.length,
+      1,
+      'recomposed body must carry exactly one blocked by marker',
+    );
+  });
+
+  it('recomposes the canonical footer when the GH body has no footer (resume after strip)', () => {
+    const description = 'story description';
+    const { spec, state, ghState } = buildInputs({
+      specBody: description,
+      obsBody: description,
+    });
+    const plan = diff({ spec, state, ghState });
+    const storyUpdate = plan.updates.find((op) => op.slug === 'story-cascade');
+    assert.ok(
+      storyUpdate,
+      'an Update should fire to restore the missing footer',
+    );
+    assert.match(storyUpdate.changes.body.after, /\n---\nparent: #7100\n/);
+  });
+});


### PR DESCRIPTION
Closes #2982

_Auto-opened by `/single-story-deliver`._