### PR TITLE
refactor(scripts): split runPreMergeValidation into summarizer + emitter (#2995)

### DIFF
--- a/.agents/scripts/lib/orchestration/story-close/phases/gates.js
+++ b/.agents/scripts/lib/orchestration/story-close/phases/gates.js
@@ -13,8 +13,17 @@
  *     spawns tripped its watchdog; caller routes through
  *     `emitSpawnTimeoutBlockedResult`.
  *
+ * Story #2995 split the pre-merge body into a pure summarizer
+ * (`summarizeGateResults`) plus a side-effecting emitter
+ * (`emitGateOutcome`). `runPreMergeValidation` is now a thin sequencer:
+ * it runs the format-autofix and attribution gate side effects, hands
+ * the raw outcomes to the summarizer, and then routes through the
+ * emitter. Output is byte-identical to the pre-refactor function.
+ *
  * Public surface:
  *   - shouldSkipValidation(input)
+ *   - summarizeGateResults(results)
+ *   - emitGateOutcome(summary, ctx)
  *   - runPreMergeValidation(input)
  *   - emitBaselineBlockedResult(input)
  */
@@ -82,10 +91,130 @@ export function shouldSkipValidation({
 }
 
 /**
+ * Pure aggregator over the raw outcomes produced by the close-validation
+ * side effects (Story #2995 split). Consumes the format-autofix outcome
+ * and the attribution-aware gate outcome, then classifies the combined
+ * result into a verdict + blocker/advisory lists.
+ *
+ * Verdicts:
+ *   - `'blocked-timeout'` — format-autofix spawn watchdog tripped, or the
+ *     attribution gate chain itself returned `blocked-timeout`. The
+ *     originating outcome is carried on the blocker entry so the emitter
+ *     can return the canonical envelope verbatim.
+ *   - `'blocked'`         — attribution gate chain reported baseline
+ *     drift not attributable to the Story.
+ *   - `'ok'`              — gates passed; the maintainability projection
+ *     should be emitted and the gate envelope returned to the caller.
+ *
+ * Inputs are tolerated as `null`/`undefined` so callers that only ran a
+ * subset of the chain (resume paths, partial mocks) get a deterministic
+ * `'ok'` verdict instead of a thrown error.
+ *
+ * NO I/O. NO logger calls. NO label transitions. This function is the
+ * unit-testable shape of the pre-merge decision.
+ */
+export function summarizeGateResults({
+  formatAutofixOutcome = null,
+  gateOutcome = null,
+} = {}) {
+  if (formatAutofixOutcome?.timedOut) {
+    return {
+      verdict: 'blocked-timeout',
+      blockers: [
+        {
+          kind: 'format-autofix-timeout',
+          formatAutofixOutcome,
+        },
+      ],
+      advisories: [],
+    };
+  }
+  if (gateOutcome?.status === 'blocked') {
+    return {
+      verdict: 'blocked',
+      blockers: [
+        {
+          kind: 'baseline-drift',
+          gateOutcome,
+        },
+      ],
+      advisories: [],
+    };
+  }
+  if (gateOutcome?.status === 'blocked-timeout') {
+    return {
+      verdict: 'blocked-timeout',
+      blockers: [
+        {
+          kind: 'gate-timeout',
+          gateOutcome,
+        },
+      ],
+      advisories: [],
+    };
+  }
+  return {
+    verdict: 'ok',
+    blockers: [],
+    advisories: [],
+    gateOutcome,
+  };
+}
+
+/**
+ * Side-effecting emitter: consumes a `summarizeGateResults` summary plus
+ * the orchestration context and performs the actions implied by the
+ * verdict (Story #2995 split).
+ *
+ * - `blocked-timeout` from format-autofix → return the canonical
+ *   timeout envelope built from `formatAutofixOutcome`.
+ * - `blocked` / `blocked-timeout` from the attribution gate chain →
+ *   return the gate outcome verbatim (caller routes through
+ *   `emitBaselineBlockedResult` / spawn-timeout handler).
+ * - `ok` → emit the maintainability projection (Logger side effect) and
+ *   return the gate outcome verbatim.
+ *
+ * Maintaining output byte-equivalence with the pre-refactor function is
+ * the contract: the gate-outcome objects flow through unchanged.
+ */
+export function emitGateOutcome(summary, ctx) {
+  if (summary.verdict === 'blocked-timeout') {
+    const blocker = summary.blockers[0];
+    if (blocker?.kind === 'format-autofix-timeout') {
+      const fao = blocker.formatAutofixOutcome;
+      return {
+        status: 'blocked-timeout',
+        gateName: 'format-autofix',
+        exitCode: fao.exitCode ?? 124,
+        spawnCmd: fao.writeCmdString ?? null,
+        timeoutMs: fao.timeoutMs ?? null,
+      };
+    }
+    return blocker?.gateOutcome ?? null;
+  }
+  if (summary.verdict === 'blocked') {
+    return summary.blockers[0]?.gateOutcome ?? null;
+  }
+  // verdict === 'ok'
+  emitMaintainabilityProjection({
+    cwd: ctx.cwd,
+    epicBranch: ctx.epicBranch,
+    storyBranch: ctx.storyBranch,
+    config: ctx.config,
+    logger: Logger,
+  });
+  return summary.gateOutcome;
+}
+
+/**
  * Run the close-validation gate chain against the Story worktree. The
  * format-autofix self-heal step runs first (Story #2165 — bounded
  * timeout) and short-circuits the chain when the formatter spawn is
  * SIGKILLed. Otherwise the attribution-aware gate chain runs.
+ *
+ * Story #2995 split this body into a pure summarizer
+ * (`summarizeGateResults`) + a side-effecting emitter
+ * (`emitGateOutcome`). This function is now a thin sequencer.
  *
  * Returns the gate envelope verbatim so the caller can route by
  * `status` (`blocked` vs `blocked-timeout` vs `ok`).
@@ -128,13 +257,13 @@ export async function runPreMergeValidation({
     logger: Logger,
   });
   if (formatAutofixOutcome?.timedOut) {
-    return {
-      status: 'blocked-timeout',
-      gateName: 'format-autofix',
-      exitCode: formatAutofixOutcome.exitCode ?? 124,
-      spawnCmd: formatAutofixOutcome.writeCmdString ?? null,
-      timeoutMs: formatAutofixOutcome.timeoutMs ?? null,
-    };
+    const summary = summarizeGateResults({ formatAutofixOutcome });
+    return emitGateOutcome(summary, {
+      cwd,
+      epicBranch,
+      storyBranch,
+      config,
+    });
   }
   const gateOutcome = await runPreMergeGatesWithAttribution({
     cwd,
@@ -149,14 +278,14 @@ export async function runPreMergeValidation({
     provider,
     bus,
   });
-  if (gateOutcome?.status === 'blocked') return gateOutcome;
-  if (gateOutcome?.status === 'blocked-timeout') return gateOutcome;
-  emitMaintainabilityProjection({
+  const summary = summarizeGateResults({
+    formatAutofixOutcome,
+    gateOutcome,
+  });
+  return emitGateOutcome(summary, {
     cwd,
     epicBranch,
     storyBranch,
     config,
-    logger: Logger,
   });
-  return gateOutcome;
 }

--- a/tests/story-close/summarize-gate-results.test.js
+++ b/tests/story-close/summarize-gate-results.test.js
@@ -1,0 +1,128 @@
+/**
+ * Unit tests for `summarizeGateResults` (Story #2995 — split
+ * `runPreMergeValidation` into a pure summarizer + side-effecting
+ * emitter). Covers every branch of the verdict classifier.
+ */
+
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import { summarizeGateResults } from '../../.agents/scripts/lib/orchestration/story-close/phases/gates.js';
+
+describe('summarizeGateResults', () => {
+  it('returns blocked-timeout when format-autofix tripped its watchdog', () => {
+    const formatAutofixOutcome = {
+      timedOut: true,
+      exitCode: 124,
+      writeCmdString: 'biome format --write .',
+      timeoutMs: 60000,
+    };
+    const summary = summarizeGateResults({ formatAutofixOutcome });
+    assert.equal(summary.verdict, 'blocked-timeout');
+    assert.equal(summary.blockers.length, 1);
+    assert.equal(summary.blockers[0].kind, 'format-autofix-timeout');
+    assert.equal(
+      summary.blockers[0].formatAutofixOutcome,
+      formatAutofixOutcome,
+    );
+    assert.deepEqual(summary.advisories, []);
+  });
+
+  it('prefers format-autofix timeout over a downstream gate outcome', () => {
+    // If both outcomes are present and the format step already timed
+    // out, the summarizer must short-circuit on the format step. The
+    // sequencer never reaches the attribution gate in this case, but
+    // the summarizer must remain deterministic against partial inputs.
+    const formatAutofixOutcome = { timedOut: true };
+    const gateOutcome = { status: 'blocked' };
+    const summary = summarizeGateResults({
+      formatAutofixOutcome,
+      gateOutcome,
+    });
+    assert.equal(summary.verdict, 'blocked-timeout');
+    assert.equal(summary.blockers[0].kind, 'format-autofix-timeout');
+  });
+
+  it('returns blocked when the attribution gate reports baseline drift', () => {
+    const gateOutcome = {
+      status: 'blocked',
+      nonAttributable: ['src/a.ts', 'src/b.ts'],
+      commentId: 'abc123',
+    };
+    const summary = summarizeGateResults({ gateOutcome });
+    assert.equal(summary.verdict, 'blocked');
+    assert.equal(summary.blockers.length, 1);
+    assert.equal(summary.blockers[0].kind, 'baseline-drift');
+    assert.equal(summary.blockers[0].gateOutcome, gateOutcome);
+    assert.deepEqual(summary.advisories, []);
+  });
+
+  it('returns blocked-timeout when the attribution gate spawn timed out', () => {
+    const gateOutcome = {
+      status: 'blocked-timeout',
+      gateName: 'lint',
+      exitCode: 124,
+    };
+    const summary = summarizeGateResults({ gateOutcome });
+    assert.equal(summary.verdict, 'blocked-timeout');
+    assert.equal(summary.blockers.length, 1);
+    assert.equal(summary.blockers[0].kind, 'gate-timeout');
+    assert.equal(summary.blockers[0].gateOutcome, gateOutcome);
+  });
+
+  it('returns ok when gates pass with a status:ok envelope', () => {
+    const gateOutcome = { status: 'ok' };
+    const summary = summarizeGateResults({
+      formatAutofixOutcome: { timedOut: false },
+      gateOutcome,
+    });
+    assert.equal(summary.verdict, 'ok');
+    assert.deepEqual(summary.blockers, []);
+    assert.deepEqual(summary.advisories, []);
+    assert.equal(summary.gateOutcome, gateOutcome);
+  });
+
+  it('returns ok for the empty-results case', () => {
+    const summary = summarizeGateResults({});
+    assert.equal(summary.verdict, 'ok');
+    assert.deepEqual(summary.blockers, []);
+    assert.deepEqual(summary.advisories, []);
+    assert.equal(summary.gateOutcome, null);
+  });
+
+  it('returns ok when called with no argument at all', () => {
+    // The sequencer always passes an object, but defensive default
+    // matters because the summarizer is documented as pure.
+    const summary = summarizeGateResults();
+    assert.equal(summary.verdict, 'ok');
+    assert.deepEqual(summary.blockers, []);
+    assert.equal(summary.gateOutcome, null);
+  });
+
+  it('treats falsy formatAutofixOutcome.timedOut as a non-blocker', () => {
+    const formatAutofixOutcome = { timedOut: false };
+    const gateOutcome = { status: 'ok' };
+    const summary = summarizeGateResults({
+      formatAutofixOutcome,
+      gateOutcome,
+    });
+    assert.equal(summary.verdict, 'ok');
+  });
+
+  it('does not invent advisories or mutate inputs', () => {
+    const gateOutcome = { status: 'blocked', nonAttributable: ['x'] };
+    const frozen = Object.freeze({ ...gateOutcome });
+    const summary = summarizeGateResults({ gateOutcome: frozen });
+    assert.equal(summary.verdict, 'blocked');
+    assert.deepEqual(summary.advisories, []);
+    // Verify input was not mutated.
+    assert.deepEqual(frozen, { status: 'blocked', nonAttributable: ['x'] });
+  });
+
+  it('performs no I/O — invocation is synchronous and side-effect free', () => {
+    // Sentinel: if the summarizer ever grew an async/IO hop, the
+    // returned value would be a Promise. Lock it down.
+    const result = summarizeGateResults({ gateOutcome: { status: 'ok' } });
+    assert.equal(typeof result.then, 'undefined');
+  });
+});


### PR DESCRIPTION
Closes #2995

_Auto-opened by `/single-story-deliver`._