### PR TITLE
refactor(scripts): split git-cleanup phase-drivers into decide/execute pairs (#2994)

### DIFF
--- a/.agents/scripts/lib/orchestration/git-cleanup/phases/phase-drivers.js
+++ b/.agents/scripts/lib/orchestration/git-cleanup/phases/phase-drivers.js
@@ -6,8 +6,15 @@
  * `plan`/`execute` pair, applies the `--dry-run` / `--yes` semantics,
  * and emits the operator-facing log lines.
  *
- * Split out of `cli.js` so each phase file stays under Story #2466's
- * 200-LOC ceiling.
+ * ## Decide / Execute split (Story #2994)
+ *
+ * `runBranchPhase`, `runFastForwardPhase`, and `runStashPhase` each
+ * delegate to a pure `decideXPhase(state)` that returns a plain action
+ * record `{ kind, args }`, and an impure `executeXPhase(action, ctx)`
+ * that performs I/O. The `runXPhase` sequencer composes the two,
+ * inserting the interactive prompt between them when the action's
+ * `kind` is `'prompt-then-execute'`. The split keeps the branching
+ * logic unit-testable without spinning up git or stdin.
  *
  * @module lib/orchestration/git-cleanup/phases/phase-drivers
  */
@@ -51,48 +58,105 @@ function emitExecutionHuman(result) {
   else Logger.error(summary);
 }
 
-/* node:coverage ignore next */
-export async function runFastForwardPhase(opts, cwd, baseBranch) {
-  Logger.info(`${TAG} ── phase: fast-forward-main ──`);
-  const plan = planFastForward({ cwd, baseBranch });
+// =====================================================================
+// Fast-forward phase
+// =====================================================================
+
+/**
+ * Pure: decide what the fast-forward phase should do given the plan.
+ *
+ * Returns an action record:
+ *  - `{ kind: 'skip', result }`               — base branch can't FF
+ *  - `{ kind: 'dry-run', result }`            — dry-run mode
+ *  - `{ kind: 'prompt-then-execute', promptMessage, declinedResult, executeArgs }`
+ *  - `{ kind: 'execute', executeArgs }`       — --yes mode, run immediately
+ *
+ * @param {object} state
+ * @param {object} state.plan        Output of `planFastForward`.
+ * @param {object} state.opts        CLI options (`dryRun`, `yes`).
+ * @param {string} state.baseBranch  Base branch name.
+ * @param {string} state.cwd         Working directory (for execute args).
+ */
+export function decideFastForwardPhase(state) {
+  const { plan, opts, baseBranch, cwd } = state;
   if (!plan.runnable) {
-    Logger.info(`${TAG} ⏭️  ${baseBranch} skipped: ${plan.reason}`);
     return {
-      ok: true,
-      applied: false,
-      skipped: true,
-      reason: plan.reason,
-      behind: plan.behind ?? 0,
+      kind: 'skip',
+      result: {
+        ok: true,
+        applied: false,
+        skipped: true,
+        reason: plan.reason,
+        behind: plan.behind ?? 0,
+      },
+      logMessage: `${TAG} ⏭️  ${baseBranch} skipped: ${plan.reason}`,
     };
   }
   if (opts.dryRun) {
-    Logger.info(
-      `${TAG} DRY RUN — would fast-forward ${baseBranch} by ${plan.behind} commit(s)`,
-    );
     return {
-      ok: true,
-      applied: false,
-      skipped: true,
-      reason: 'dry-run',
-      behind: plan.behind,
+      kind: 'dry-run',
+      result: {
+        ok: true,
+        applied: false,
+        skipped: true,
+        reason: 'dry-run',
+        behind: plan.behind,
+      },
+      logMessage: `${TAG} DRY RUN — would fast-forward ${baseBranch} by ${plan.behind} commit(s)`,
     };
   }
+  const executeArgs = { cwd, baseBranch, plan };
   if (!opts.yes) {
-    const go = await promptYesNo(
-      `${TAG} Fast-forward ${baseBranch} by ${plan.behind} commit(s)?`,
-    );
-    if (!go) {
-      return {
+    return {
+      kind: 'prompt-then-execute',
+      promptMessage: `${TAG} Fast-forward ${baseBranch} by ${plan.behind} commit(s)?`,
+      declinedResult: {
         ok: true,
         applied: false,
         skipped: true,
         reason: 'declined',
         behind: plan.behind,
-      };
-    }
+      },
+      executeArgs,
+    };
   }
-  return executeFastForward({ cwd, baseBranch, plan });
+  return { kind: 'execute', executeArgs };
 }
+
+/**
+ * Impure: perform the fast-forward action returned by
+ * `decideFastForwardPhase`. Returns the phase result.
+ */
+export async function executeFastForwardPhase(action) {
+  if (action.kind === 'skip' || action.kind === 'dry-run') {
+    if (action.logMessage) Logger.info(action.logMessage);
+    return action.result;
+  }
+  if (action.kind === 'execute') {
+    return executeFastForward(action.executeArgs);
+  }
+  throw new Error(
+    `executeFastForwardPhase: unsupported action kind '${action.kind}'`,
+  );
+}
+
+/* node:coverage ignore next */
+export async function runFastForwardPhase(opts, cwd, baseBranch) {
+  Logger.info(`${TAG} ── phase: fast-forward-main ──`);
+  const plan = planFastForward({ cwd, baseBranch });
+  const action = decideFastForwardPhase({ plan, opts, baseBranch, cwd });
+  if (action.kind === 'prompt-then-execute') {
+    if (action.logMessage) Logger.info(action.logMessage);
+    const go = await promptYesNo(action.promptMessage);
+    if (!go) return action.declinedResult;
+    return executeFastForward(action.executeArgs);
+  }
+  return executeFastForwardPhase(action);
+}
+
+// =====================================================================
+// Prune phase (unchanged — low CRAP, kept for parity)
+// =====================================================================
 
 /* node:coverage ignore next */
 export async function runPrunePhase(opts, cwd) {
@@ -118,6 +182,67 @@ export async function runPrunePhase(opts, cwd) {
   return executePrune({ cwd });
 }
 
+// =====================================================================
+// Branch phase
+// =====================================================================
+
+/**
+ * Pure: decide what the branch-reap phase should do given the plan.
+ *
+ * Returns an action record:
+ *  - `{ kind: 'no-candidates', result }`       — empty plan, nothing to reap
+ *  - `{ kind: 'dry-run', result }`             — dry-run mode (plan only)
+ *  - `{ kind: 'prompt-then-execute', promptMessage, declinedResult, executeArgs, plan }`
+ *  - `{ kind: 'execute', executeArgs, plan }`  — --yes mode
+ *
+ * @param {object} state
+ * @param {object} state.plan         Output of `planCleanup`.
+ * @param {object} state.opts         CLI options (`dryRun`, `yes`, `remote`).
+ * @param {string} state.cwd          Working directory.
+ */
+export function decideBranchPhase(state) {
+  const { plan, opts, cwd } = state;
+  if (opts.dryRun) {
+    return { kind: 'dry-run', plan, result: { plan, result: null } };
+  }
+  if (plan.candidates.length === 0) {
+    return { kind: 'no-candidates', plan, result: { plan, result: null } };
+  }
+  const executeArgs = {
+    candidates: plan.candidates,
+    cwd,
+    remote: opts.remote,
+  };
+  if (!opts.yes) {
+    return {
+      kind: 'prompt-then-execute',
+      plan,
+      promptMessage: `${TAG} Reap ${plan.candidates.length} merged branch(es)${opts.remote ? ' (including origin)' : ''}?`,
+      declinedResult: { plan, result: null, declined: true },
+      executeArgs,
+    };
+  }
+  return { kind: 'execute', plan, executeArgs };
+}
+
+/**
+ * Impure: perform the branch-reap action returned by `decideBranchPhase`.
+ * Returns the phase result `{ plan, result, declined? }`.
+ */
+export async function executeBranchPhase(action) {
+  if (action.kind === 'dry-run' || action.kind === 'no-candidates') {
+    return action.result;
+  }
+  if (action.kind === 'execute') {
+    const result = executeCleanup(action.executeArgs);
+    emitExecutionHuman(result);
+    return { plan: action.plan, result };
+  }
+  throw new Error(
+    `executeBranchPhase: unsupported action kind '${action.kind}'`,
+  );
+}
+
 /* node:coverage ignore next */
 export async function runBranchPhase(opts, cwd, baseBranch) {
   Logger.info(`${TAG} ── phase: branches ──`);
@@ -132,24 +257,87 @@ export async function runBranchPhase(opts, cwd, baseBranch) {
     includeRemoteOnly: opts.remote === true,
   });
   emitDryRunHuman(plan, baseBranch);
-  if (opts.dryRun || plan.candidates.length === 0) {
-    return { plan, result: null };
+  const action = decideBranchPhase({ plan, opts, cwd });
+  if (action.kind === 'prompt-then-execute') {
+    const go = await promptYesNo(action.promptMessage);
+    if (!go) return action.declinedResult;
+    const result = executeCleanup(action.executeArgs);
+    emitExecutionHuman(result);
+    return { plan, result };
   }
-  if (!opts.yes) {
-    const go = await promptYesNo(
-      `${TAG} Reap ${plan.candidates.length} merged branch(es)${opts.remote ? ' (including origin)' : ''}?`,
-    );
-    if (!go) {
-      return { plan, result: null, declined: true };
-    }
+  return executeBranchPhase(action);
+}
+
+// =====================================================================
+// Stash phase
+// =====================================================================
+
+/**
+ * Pure: decide what the stash-triage phase should do given the plan.
+ *
+ * Returns an action record:
+ *  - `{ kind: 'no-stashes', result }`        — nothing to triage
+ *  - `{ kind: 'dry-run', result, stashes }`  — dry-run mode
+ *  - `{ kind: 'execute-allowlist', executeArgs }` — --yes / --json mode
+ *  - `{ kind: 'execute-interactive', executeArgs }` — interactive prompt
+ *
+ * @param {object} state
+ * @param {Array}  state.stashes  Output of `planStashes().stashes`.
+ * @param {object} state.opts     CLI options (`dryRun`, `yes`, `json`,
+ *                                `dropStashes`).
+ * @param {string} state.cwd     Working directory.
+ */
+export function decideStashPhase(state) {
+  const { stashes, opts, cwd } = state;
+  if (stashes.length === 0) {
+    return {
+      kind: 'no-stashes',
+      result: { ok: true, actions: [], failures: [] },
+    };
   }
-  const result = executeCleanup({
-    candidates: plan.candidates,
-    cwd,
-    remote: opts.remote,
-  });
-  emitExecutionHuman(result);
-  return { plan, result };
+  if (opts.dryRun) {
+    return {
+      kind: 'dry-run',
+      stashes,
+      result: {
+        ok: true,
+        actions: stashes.map((s) => ({ ref: s.ref, action: 'keep' })),
+        failures: [],
+      },
+    };
+  }
+  if (opts.yes || opts.json) {
+    return {
+      kind: 'execute-allowlist',
+      executeArgs: { cwd, stashes, allowlist: opts.dropStashes },
+    };
+  }
+  return {
+    kind: 'execute-interactive',
+    executeArgs: { cwd, stashes },
+  };
+}
+
+/**
+ * Impure: perform the stash-triage action returned by `decideStashPhase`.
+ * Returns the phase result.
+ */
+export async function executeStashPhase(action) {
+  if (action.kind === 'no-stashes' || action.kind === 'dry-run') {
+    return action.result;
+  }
+  if (action.kind === 'execute-allowlist') {
+    const { cwd, stashes, allowlist } = action.executeArgs;
+    const decideFn = buildAllowlistDecider(allowlist);
+    return executeStashes({ cwd, stashes, decideFn });
+  }
+  if (action.kind === 'execute-interactive') {
+    const { cwd, stashes } = action.executeArgs;
+    return executeStashes({ cwd, stashes, decideFn: promptStashDecision });
+  }
+  throw new Error(
+    `executeStashPhase: unsupported action kind '${action.kind}'`,
+  );
 }
 
 /* node:coverage ignore next */
@@ -167,15 +355,7 @@ export async function runStashPhase(opts, cwd) {
     Logger.info(
       `${TAG} DRY RUN — ${stashes.length} stash(es) listed; no drops applied`,
     );
-    return {
-      ok: true,
-      actions: stashes.map((s) => ({ ref: s.ref, action: 'keep' })),
-      failures: [],
-    };
   }
-  const decideFn =
-    opts.yes || opts.json
-      ? buildAllowlistDecider(opts.dropStashes)
-      : promptStashDecision;
-  return executeStashes({ cwd, stashes, decideFn });
+  const action = decideStashPhase({ stashes, opts, cwd });
+  return executeStashPhase(action);
 }

--- a/tests/lib/orchestration/git-cleanup-phase-drivers-decide.test.js
+++ b/tests/lib/orchestration/git-cleanup-phase-drivers-decide.test.js
@@ -1,0 +1,257 @@
+/**
+ * Unit tests for the pure decide* functions in `phase-drivers.js`
+ * (Story #2994 CRAP-30+ refactor).
+ *
+ * These tests cover every branch of the decision logic without any
+ * git, prompt, or filesystem I/O. The companion impure executeXPhase
+ * functions are exercised through the existing integration suites
+ * (`tests/scripts/git-cleanup*.test.js`).
+ */
+
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import {
+  decideBranchPhase,
+  decideFastForwardPhase,
+  decideStashPhase,
+} from '../../../.agents/scripts/lib/orchestration/git-cleanup/phases/phase-drivers.js';
+
+// ---------------------------------------------------------------------
+// decideFastForwardPhase
+// ---------------------------------------------------------------------
+
+describe('decideFastForwardPhase', () => {
+  const cwd = '/repo';
+  const baseBranch = 'main';
+
+  it('returns skip when the plan is not runnable (with reason and behind)', () => {
+    const plan = { runnable: false, reason: 'dirty-tree', behind: 0 };
+    const action = decideFastForwardPhase({
+      plan,
+      opts: {},
+      baseBranch,
+      cwd,
+    });
+    assert.equal(action.kind, 'skip');
+    assert.deepEqual(action.result, {
+      ok: true,
+      applied: false,
+      skipped: true,
+      reason: 'dirty-tree',
+      behind: 0,
+    });
+    assert.match(action.logMessage, /skipped: dirty-tree/);
+  });
+
+  it('skip path defaults behind to 0 when plan omits it', () => {
+    const plan = { runnable: false, reason: 'no-upstream' };
+    const action = decideFastForwardPhase({
+      plan,
+      opts: {},
+      baseBranch,
+      cwd,
+    });
+    assert.equal(action.result.behind, 0);
+  });
+
+  it('returns dry-run action when --dry-run is set on a runnable plan', () => {
+    const plan = { runnable: true, behind: 3 };
+    const action = decideFastForwardPhase({
+      plan,
+      opts: { dryRun: true },
+      baseBranch,
+      cwd,
+    });
+    assert.equal(action.kind, 'dry-run');
+    assert.deepEqual(action.result, {
+      ok: true,
+      applied: false,
+      skipped: true,
+      reason: 'dry-run',
+      behind: 3,
+    });
+    assert.match(action.logMessage, /DRY RUN.*main.*3 commit/);
+  });
+
+  it('returns prompt-then-execute when interactive (no --yes)', () => {
+    const plan = { runnable: true, behind: 5 };
+    const action = decideFastForwardPhase({
+      plan,
+      opts: {},
+      baseBranch,
+      cwd,
+    });
+    assert.equal(action.kind, 'prompt-then-execute');
+    assert.match(action.promptMessage, /Fast-forward main by 5 commit/);
+    assert.deepEqual(action.declinedResult, {
+      ok: true,
+      applied: false,
+      skipped: true,
+      reason: 'declined',
+      behind: 5,
+    });
+    assert.deepEqual(action.executeArgs, { cwd, baseBranch, plan });
+  });
+
+  it('returns execute (no prompt) when --yes is set', () => {
+    const plan = { runnable: true, behind: 1 };
+    const action = decideFastForwardPhase({
+      plan,
+      opts: { yes: true },
+      baseBranch,
+      cwd,
+    });
+    assert.equal(action.kind, 'execute');
+    assert.deepEqual(action.executeArgs, { cwd, baseBranch, plan });
+  });
+});
+
+// ---------------------------------------------------------------------
+// decideBranchPhase
+// ---------------------------------------------------------------------
+
+describe('decideBranchPhase', () => {
+  const cwd = '/repo';
+
+  it('returns dry-run when --dry-run is set, even with candidates', () => {
+    const plan = { candidates: [{ name: 'feature/x' }] };
+    const action = decideBranchPhase({ plan, opts: { dryRun: true }, cwd });
+    assert.equal(action.kind, 'dry-run');
+    assert.deepEqual(action.result, { plan, result: null });
+  });
+
+  it('returns dry-run when --dry-run set and candidates is empty', () => {
+    const plan = { candidates: [] };
+    const action = decideBranchPhase({ plan, opts: { dryRun: true }, cwd });
+    assert.equal(action.kind, 'dry-run');
+    assert.deepEqual(action.result, { plan, result: null });
+  });
+
+  it('returns no-candidates when plan is empty and not dry-run', () => {
+    const plan = { candidates: [] };
+    const action = decideBranchPhase({ plan, opts: {}, cwd });
+    assert.equal(action.kind, 'no-candidates');
+    assert.deepEqual(action.result, { plan, result: null });
+  });
+
+  it('returns prompt-then-execute when interactive with candidates', () => {
+    const plan = { candidates: [{ name: 'a' }, { name: 'b' }] };
+    const action = decideBranchPhase({ plan, opts: {}, cwd });
+    assert.equal(action.kind, 'prompt-then-execute');
+    assert.match(action.promptMessage, /Reap 2 merged branch\(es\)\?/);
+    assert.deepEqual(action.declinedResult, {
+      plan,
+      result: null,
+      declined: true,
+    });
+    assert.deepEqual(action.executeArgs, {
+      candidates: plan.candidates,
+      cwd,
+      remote: undefined,
+    });
+  });
+
+  it('prompt message mentions "including origin" when --remote is set', () => {
+    const plan = { candidates: [{ name: 'a' }] };
+    const action = decideBranchPhase({ plan, opts: { remote: true }, cwd });
+    assert.equal(action.kind, 'prompt-then-execute');
+    assert.match(action.promptMessage, /including origin/);
+    assert.equal(action.executeArgs.remote, true);
+  });
+
+  it('returns execute when --yes is set with candidates', () => {
+    const plan = { candidates: [{ name: 'c' }] };
+    const action = decideBranchPhase({
+      plan,
+      opts: { yes: true, remote: true },
+      cwd,
+    });
+    assert.equal(action.kind, 'execute');
+    assert.deepEqual(action.executeArgs, {
+      candidates: plan.candidates,
+      cwd,
+      remote: true,
+    });
+  });
+});
+
+// ---------------------------------------------------------------------
+// decideStashPhase
+// ---------------------------------------------------------------------
+
+describe('decideStashPhase', () => {
+  const cwd = '/repo';
+
+  it('returns no-stashes when stash list is empty', () => {
+    const action = decideStashPhase({ stashes: [], opts: {}, cwd });
+    assert.equal(action.kind, 'no-stashes');
+    assert.deepEqual(action.result, { ok: true, actions: [], failures: [] });
+  });
+
+  it('returns dry-run with keep-actions for every stash on --dry-run', () => {
+    const stashes = [
+      { ref: 'stash@{0}', createdAt: '2026-01-01', message: 'wip a' },
+      { ref: 'stash@{1}', createdAt: '2026-01-02', message: 'wip b' },
+    ];
+    const action = decideStashPhase({
+      stashes,
+      opts: { dryRun: true },
+      cwd,
+    });
+    assert.equal(action.kind, 'dry-run');
+    assert.deepEqual(action.result, {
+      ok: true,
+      actions: [
+        { ref: 'stash@{0}', action: 'keep' },
+        { ref: 'stash@{1}', action: 'keep' },
+      ],
+      failures: [],
+    });
+    assert.equal(action.stashes, stashes);
+  });
+
+  it('returns execute-allowlist when --yes is set', () => {
+    const stashes = [{ ref: 'stash@{0}', createdAt: 'x', message: 'm' }];
+    const action = decideStashPhase({
+      stashes,
+      opts: { yes: true, dropStashes: ['stash@{0}'] },
+      cwd,
+    });
+    assert.equal(action.kind, 'execute-allowlist');
+    assert.deepEqual(action.executeArgs, {
+      cwd,
+      stashes,
+      allowlist: ['stash@{0}'],
+    });
+  });
+
+  it('returns execute-allowlist when --json is set', () => {
+    const stashes = [{ ref: 'stash@{0}', createdAt: 'x', message: 'm' }];
+    const action = decideStashPhase({
+      stashes,
+      opts: { json: true },
+      cwd,
+    });
+    assert.equal(action.kind, 'execute-allowlist');
+    assert.equal(action.executeArgs.allowlist, undefined);
+  });
+
+  it('returns execute-interactive when neither --yes nor --json', () => {
+    const stashes = [{ ref: 'stash@{0}', createdAt: 'x', message: 'm' }];
+    const action = decideStashPhase({ stashes, opts: {}, cwd });
+    assert.equal(action.kind, 'execute-interactive');
+    assert.deepEqual(action.executeArgs, { cwd, stashes });
+  });
+
+  it('--yes takes precedence over interactive even without dropStashes', () => {
+    const stashes = [{ ref: 'stash@{0}', createdAt: 'x', message: 'm' }];
+    const action = decideStashPhase({
+      stashes,
+      opts: { yes: true },
+      cwd,
+    });
+    assert.equal(action.kind, 'execute-allowlist');
+    assert.equal(action.executeArgs.allowlist, undefined);
+  });
+});


### PR DESCRIPTION
Closes #2994

_Auto-opened by `/single-story-deliver`._