### PR TITLE
chore(scripts): add logger.debug to silent-return catch sites in BDD scanners (#2997)

### DIFF
--- a/.agents/scripts/lib/bdd-runner-detect.js
+++ b/.agents/scripts/lib/bdd-runner-detect.js
@@ -43,6 +43,8 @@ import path from 'node:path';
 import yaml from 'js-yaml';
 import picomatch from 'picomatch';
 
+import { Logger } from './Logger.js';
+
 /**
  * Known BDD runner package names → pending-tag string the runner honours.
  *
@@ -121,6 +123,7 @@ export async function verifyBddRunnerPendingTag(opts = {}) {
   const readPkg = opts.readPkg ?? ((p) => readFile(p, 'utf8'));
   const listWorkspacePkgPaths =
     opts.listWorkspacePkgPaths ?? defaultListWorkspacePkgPaths;
+  const logger = opts.logger ?? Logger;
   const rootPkgPath = path.join(cwd, 'package.json');
 
   let raw;
@@ -147,9 +150,17 @@ export async function verifyBddRunnerPendingTag(opts = {}) {
 
   let workspacePkgPaths = [];
   try {
-    workspacePkgPaths = await listWorkspacePkgPaths({ cwd, rootPkg, readPkg });
-  } catch (_err) {
+    workspacePkgPaths = await listWorkspacePkgPaths({
+      cwd,
+      rootPkg,
+      readPkg,
+      logger,
+    });
+  } catch (err) {
     // Workspace discovery failure is non-fatal: degrade to root-only scan.
+    logger.debug(
+      `[bdd-runner-detect] workspace discovery failed for ${cwd}: ${err?.message ?? err}`,
+    );
     workspacePkgPaths = [];
   }
 
@@ -157,13 +168,19 @@ export async function verifyBddRunnerPendingTag(opts = {}) {
     let wsRaw;
     try {
       wsRaw = await readPkg(wsPkgPath);
-    } catch (_err) {
+    } catch (err) {
+      logger.debug(
+        `[bdd-runner-detect] readPkg failed for workspace ${wsPkgPath}: ${err?.message ?? err}`,
+      );
       continue;
     }
     let wsPkg;
     try {
       wsPkg = JSON.parse(wsRaw);
-    } catch (_err) {
+    } catch (err) {
+      logger.debug(
+        `[bdd-runner-detect] JSON parse failed for workspace ${wsPkgPath}: ${err?.message ?? err}`,
+      );
       continue;
     }
     Object.assign(
@@ -203,13 +220,14 @@ export async function verifyBddRunnerPendingTag(opts = {}) {
  *
  * @returns {Promise<string[]>}
  */
-async function defaultListWorkspacePkgPaths({ cwd, rootPkg }) {
-  const patterns = readWorkspacePatterns(cwd, rootPkg);
+async function defaultListWorkspacePkgPaths({ cwd, rootPkg, logger }) {
+  const log = logger ?? Logger;
+  const patterns = readWorkspacePatterns(cwd, rootPkg, log);
   if (patterns.length === 0) return [];
-  return expandWorkspacePatterns(cwd, patterns);
+  return expandWorkspacePatterns(cwd, patterns, log);
 }
 
-function readWorkspacePatterns(cwd, rootPkg) {
+function readWorkspacePatterns(cwd, rootPkg, logger) {
   const yamlPath = path.join(cwd, 'pnpm-workspace.yaml');
   if (existsSync(yamlPath)) {
     try {
@@ -218,8 +236,11 @@ function readWorkspacePatterns(cwd, rootPkg) {
       if (parsed && Array.isArray(parsed.packages)) {
         return parsed.packages.filter((p) => typeof p === 'string');
       }
-    } catch (_err) {
+    } catch (err) {
       // unparseable yaml → fall through to package.json workspaces
+      logger.debug(
+        `[bdd-runner-detect] pnpm-workspace.yaml parse failed for ${yamlPath}: ${err?.message ?? err}`,
+      );
     }
   }
 
@@ -244,7 +265,7 @@ function readWorkspacePatterns(cwd, rootPkg) {
  *   - recursive globs: `packages/**`
  *   - exclusion patterns prefixed with `!` (pnpm/npm convention)
  */
-function expandWorkspacePatterns(cwd, patterns) {
+function expandWorkspacePatterns(cwd, patterns, logger) {
   const includes = patterns.filter((p) => !p.startsWith('!'));
   const excludes = patterns
     .filter((p) => p.startsWith('!'))
@@ -272,7 +293,7 @@ function expandWorkspacePatterns(cwd, patterns) {
       i++;
     }
     const baseDir = path.join(cwd, ...literalSegments);
-    if (!existsSyncDir(baseDir)) continue;
+    if (!existsSyncDir(baseDir, logger)) continue;
     const recursive = segments.slice(i).includes('**');
     const includeMatcher = picomatch(pattern);
     walkPackages({
@@ -282,6 +303,7 @@ function expandWorkspacePatterns(cwd, patterns) {
       excludeMatchers,
       recursive,
       results,
+      logger,
     });
   }
 
@@ -295,11 +317,15 @@ function walkPackages({
   excludeMatchers,
   recursive,
   results,
+  logger,
 }) {
   let entries;
   try {
     entries = readdirSync(dir, { withFileTypes: true });
-  } catch (_err) {
+  } catch (err) {
+    logger?.debug(
+      `[bdd-runner-detect] readdir failed for ${dir}: ${err?.message ?? err}`,
+    );
     return;
   }
   for (const entry of entries) {
@@ -319,6 +345,7 @@ function walkPackages({
         excludeMatchers,
         recursive,
         results,
+        logger,
       });
     }
   }
@@ -332,10 +359,13 @@ function toPosix(p) {
   return p.split(path.sep).join('/');
 }
 
-function existsSyncDir(p) {
+function existsSyncDir(p, logger) {
   try {
     return existsSync(p) && statSync(p).isDirectory();
-  } catch (_err) {
+  } catch (err) {
+    logger?.debug(
+      `[bdd-runner-detect] stat failed for ${p}: ${err?.message ?? err}`,
+    );
     return false;
   }
 }
@@ -368,6 +398,7 @@ const CANONICAL_FEATURE_ROOTS = Object.freeze([
  */
 export function resolveFeatureRoots(opts = {}) {
   const cwd = opts.cwd ?? process.cwd();
+  const logger = opts.logger ?? Logger;
   const roots = [];
   for (const candidate of CANONICAL_FEATURE_ROOTS) {
     const abs = path.join(cwd, candidate);
@@ -375,8 +406,11 @@ export function resolveFeatureRoots(opts = {}) {
       if (existsSync(abs) && statSync(abs).isDirectory()) {
         roots.push(abs);
       }
-    } catch (_err) {
+    } catch (err) {
       // Unreadable path → treat as absent. Non-blocking by design.
+      logger.debug(
+        `[bdd-runner-detect] feature-root probe failed for ${abs}: ${err?.message ?? err}`,
+      );
     }
   }
   return roots;

--- a/.agents/scripts/lib/bdd-scenario-scanner.js
+++ b/.agents/scripts/lib/bdd-scenario-scanner.js
@@ -27,33 +27,40 @@
 import { readdirSync, readFileSync, statSync } from 'node:fs';
 import path from 'node:path';
 
+import { Logger } from './Logger.js';
+
 /**
  * Recursively list every file with a `.feature` extension under one of
  * the given roots. Returns absolute paths; never throws on permission
  * errors — unreadable directories are simply skipped.
  *
  * @param {string[]} roots
+ * @param {{ logger?: { debug: Function } }} [opts]
  * @returns {string[]}
  */
-export function listFeatureFiles(roots) {
+export function listFeatureFiles(roots, opts = {}) {
+  const logger = opts.logger ?? Logger;
   const out = [];
   for (const root of roots ?? []) {
-    walk(root, out);
+    walk(root, out, logger);
   }
   return out;
 }
 
-function walk(dir, acc) {
+function walk(dir, acc, logger) {
   let entries;
   try {
     entries = readdirSync(dir, { withFileTypes: true });
-  } catch (_err) {
+  } catch (err) {
+    logger.debug(
+      `[bdd-scenario-scanner] readdir failed for ${dir}: ${err?.message ?? err}`,
+    );
     return;
   }
   for (const entry of entries) {
     const abs = path.join(dir, entry.name);
     if (entry.isDirectory()) {
-      walk(abs, acc);
+      walk(abs, acc, logger);
       continue;
     }
     if (!entry.isFile()) continue;
@@ -61,7 +68,10 @@ function walk(dir, acc) {
     try {
       const stat = statSync(abs);
       if (stat.size > 256 * 1024) continue; // skip obviously bogus inputs
-    } catch (_err) {
+    } catch (err) {
+      logger.debug(
+        `[bdd-scenario-scanner] stat failed for ${abs}: ${err?.message ?? err}`,
+      );
       continue;
     }
     acc.push(abs);
@@ -225,13 +235,17 @@ function finalize(scenario) {
  */
 export function scanBddScenarios(opts = {}) {
   const { featureRoots = [] } = opts;
-  const files = listFeatureFiles(featureRoots);
+  const logger = opts.logger ?? Logger;
+  const files = listFeatureFiles(featureRoots, { logger });
   const out = [];
   for (const file of files) {
     let body;
     try {
       body = readFileSync(file, 'utf8');
-    } catch (_err) {
+    } catch (err) {
+      logger.debug(
+        `[bdd-scenario-scanner] readFile failed for ${file}: ${err?.message ?? err}`,
+      );
       continue;
     }
     const scenarios = parseFeatureBody(body);

--- a/.agents/scripts/lib/codebase-snapshot.js
+++ b/.agents/scripts/lib/codebase-snapshot.js
@@ -37,6 +37,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 
 import { gitSpawn } from './git-utils.js';
+import { Logger } from './Logger.js';
 
 /**
  * Allowed tier values for `planning.codebaseSnapshot.tier`. Mirrored
@@ -207,13 +208,16 @@ function listRecentlyTouchedDirs(cwd, window) {
  * @param {string} cwd
  * @returns {object}
  */
-function readPackageManifestSurface(cwd) {
+function readPackageManifestSurface(cwd, logger) {
   const pkgPath = path.join(cwd, 'package.json');
   if (!fs.existsSync(pkgPath)) return {};
   let parsed;
   try {
     parsed = JSON.parse(fs.readFileSync(pkgPath, 'utf8'));
-  } catch (_err) {
+  } catch (err) {
+    logger.debug(
+      `[codebase-snapshot] package.json read/parse failed for ${pkgPath}: ${err?.message ?? err}`,
+    );
     return {};
   }
   const exportsField = parsed.exports;
@@ -286,7 +290,7 @@ function extractExportSignatures(body) {
  * @param {string[]} tracked
  * @returns {Array<{ path: string, exports: string[] }>}
  */
-function collectSignatures(cwd, tracked) {
+function collectSignatures(cwd, tracked, logger) {
   const out = [];
   for (const rel of tracked) {
     const ext = path.extname(rel).toLowerCase();
@@ -295,14 +299,20 @@ function collectSignatures(cwd, tracked) {
     let stat;
     try {
       stat = fs.statSync(abs);
-    } catch (_err) {
+    } catch (err) {
+      logger.debug(
+        `[codebase-snapshot] stat failed for ${abs}: ${err?.message ?? err}`,
+      );
       continue;
     }
     if (stat.size > 64 * 1024) continue;
     let body;
     try {
       body = fs.readFileSync(abs, 'utf8');
-    } catch (_err) {
+    } catch (err) {
+      logger.debug(
+        `[codebase-snapshot] readFile failed for ${abs}: ${err?.message ?? err}`,
+      );
       continue;
     }
     const exports = extractExportSignatures(body);
@@ -359,6 +369,7 @@ function detectTestSurface(cwd, pkg) {
  */
 export function buildCodebaseSnapshot(opts = {}) {
   const cwd = opts.cwd ?? process.cwd();
+  const logger = opts.logger ?? Logger;
   const cfg = resolveSnapshotConfig({
     tier: opts.tier,
     include: opts.include,
@@ -372,7 +383,7 @@ export function buildCodebaseSnapshot(opts = {}) {
   );
   filtered.sort();
 
-  const pkg = readPackageManifestSurface(cwd);
+  const pkg = readPackageManifestSurface(cwd, logger);
   const recentlyTouched = listRecentlyTouchedDirs(cwd, cfg.recentCommitWindow);
   const testSurface = detectTestSurface(cwd, pkg);
 
@@ -396,7 +407,7 @@ export function buildCodebaseSnapshot(opts = {}) {
   };
 
   if (cfg.tier === 'medium') {
-    snapshot.signatures = collectSignatures(cwd, filtered);
+    snapshot.signatures = collectSignatures(cwd, filtered, logger);
   }
 
   return snapshot;

--- a/tests/bdd-scenario-scanner.test.js
+++ b/tests/bdd-scenario-scanner.test.js
@@ -8,6 +8,7 @@ import { resolveFeatureRoots } from '../.agents/scripts/lib/bdd-runner-detect.js
 import {
   extractOutcomeKeywords,
   findBestScenarioMatch,
+  listFeatureFiles,
   parseFeatureBody,
   scanBddScenarios,
   scoreMatch,
@@ -154,6 +155,24 @@ describe('scanBddScenarios — directory walk', () => {
     } finally {
       cleanup();
     }
+  });
+});
+
+describe('listFeatureFiles — observability for unreadable paths (Story #2997)', () => {
+  it('calls logger.debug with the unreadable path when readdir fails', () => {
+    const calls = [];
+    const logger = {
+      debug: (msg) => calls.push(msg),
+    };
+    const missing = path.join(tmpdir(), `bdd-scanner-missing-${Date.now()}`);
+    const out = listFeatureFiles([missing], { logger });
+    assert.deepEqual(out, []);
+    assert.equal(calls.length, 1);
+    assert.match(calls[0], /\[bdd-scenario-scanner\] readdir failed/);
+    assert.ok(
+      calls[0].includes(missing),
+      `expected debug payload to include the unreadable path; got: ${calls[0]}`,
+    );
   });
 });
 


### PR DESCRIPTION
Closes #2997

_Auto-opened by `/single-story-deliver`._