### PR TITLE
feat(observability): measure & de-duplicate /epic-deliver (Epic #3019)

### DIFF
--- a/.agents/full-agentrc.json
+++ b/.agents/full-agentrc.json
@@ -109,7 +109,8 @@
     },
     "deliverRunner": {
       "concurrencyCap": 3,
-      "progressReportIntervalSec": 120
+      "progressReportIntervalSec": 120,
+      "verifyConcurrencyCap": 4
     },
     "worktreeIsolation": {
       "enabled": true,

--- a/.agents/schemas/agentrc.schema.json
+++ b/.agents/schemas/agentrc.schema.json
@@ -238,7 +238,12 @@
       "type": "object",
       "properties": {
         "concurrencyCap": { "type": "integer", "minimum": 1 },
-        "progressReportIntervalSec": { "type": "integer", "minimum": 0 }
+        "progressReportIntervalSec": { "type": "integer", "minimum": 0 },
+        "verifyConcurrencyCap": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Bounded-concurrency cap for the per-wave verifyWaveResults loop (Epic #3019 Tech Spec §1.4). Separate from the wave-execution `concurrencyCap` so operators can tune ticket-verification parallelism independently of Story dispatch parallelism. Default 4."
+        }
       },
       "additionalProperties": false
     },

--- a/.agents/schemas/agentrc.schema.json
+++ b/.agents/schemas/agentrc.schema.json
@@ -247,6 +247,37 @@
       },
       "additionalProperties": false
     },
+    "retro": {
+      "type": "object",
+      "description": "Story #3042 (Epic #3019). Operator-tunable retro behaviour. Currently exposes `perfThresholds`, the gates the retro perf-signals classifier uses to decide which signals to surface in the `## Performance Signals` / `## Recommended Follow-Ons` retro sections.",
+      "properties": {
+        "perfThresholds": {
+          "type": "object",
+          "description": "Gates for `classifyPerfSignals` (lib/orchestration/retro-perf-heuristics.js). Defaults are 0.6 / 0.4 / 2.",
+          "properties": {
+            "utilisation": {
+              "type": "number",
+              "minimum": 0,
+              "maximum": 1,
+              "description": "Per-wave utilisation threshold. Waves whose `utilisation` is strictly below this value emit a `low-utilisation` signal. Default 0.6."
+            },
+            "bootstrapShare": {
+              "type": "number",
+              "minimum": 0,
+              "maximum": 1,
+              "description": "Maximum acceptable share of cumulative Story execution time spent in the story-init phase. When exceeded the retro emits a `high-bootstrap-share` signal. Default 0.4."
+            },
+            "capBindingRunLength": {
+              "type": "integer",
+              "minimum": 1,
+              "description": "Minimum run length of consecutive cap-binding waves before the retro emits a `cap-binding-run` signal. Default 2."
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
     "epicAudit": {
       "type": "object",
       "properties": {
@@ -698,6 +729,7 @@
         "mergeWatch": { "$ref": "#/$defs/mergeWatch" },
         "epicAudit": { "$ref": "#/$defs/epicAudit" },
         "codeReview": { "$ref": "#/$defs/codeReview" },
+        "retro": { "$ref": "#/$defs/retro" },
         "ci": {
           "type": "object",
           "properties": {

--- a/.agents/schemas/epic-perf-report.schema.json
+++ b/.agents/schemas/epic-perf-report.schema.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://github.com/dsj1984/mandrel/blob/main/.agents/schemas/epic-perf-report.schema.json",
   "title": "EpicPerfReport",
-  "description": "Payload of the <!-- structured:epic-perf-report --> comment posted once per Epic at close, alongside the retro (Epic #1030).",
+  "description": "Payload of the <!-- structured:epic-perf-report --> comment posted once per Epic at close, alongside the retro (Epic #1030; waveParallelism utilisation rows added under Epic #3019 / Story #3025).",
   "type": "object",
   "additionalProperties": false,
   "required": [
@@ -33,23 +33,25 @@
     },
     "waveParallelism": {
       "type": "array",
-      "description": "Per-wave parallelism utilization. utilization = wallClockMs / sumStoryMs (lower is better; ideal is 1/N).",
+      "description": "Per-wave parallelism utilisation. utilisation = summedStoryMs / (wallClockMs * concurrencyCap), clamped to [0,1] (Epic #3019 / Story #3025).",
       "items": {
         "type": "object",
         "additionalProperties": false,
         "required": [
-          "wave",
+          "waveIndex",
           "wallClockMs",
-          "sumStoryMs",
-          "utilization",
-          "stories"
+          "summedStoryMs",
+          "utilisation",
+          "capBinding",
+          "verifyConcurrencyCap"
         ],
         "properties": {
-          "wave": { "type": "integer", "minimum": 0 },
+          "waveIndex": { "type": "integer", "minimum": 0 },
           "wallClockMs": { "type": "integer", "minimum": 0 },
-          "sumStoryMs": { "type": "integer", "minimum": 0 },
-          "utilization": { "type": "number", "minimum": 0 },
-          "stories": { "type": "integer", "minimum": 0 }
+          "summedStoryMs": { "type": "integer", "minimum": 0 },
+          "utilisation": { "type": "number", "minimum": 0, "maximum": 1 },
+          "capBinding": { "type": "boolean" },
+          "verifyConcurrencyCap": { "type": "integer", "minimum": 1 }
         }
       }
     },

--- a/.agents/scripts/analyze-execution.js
+++ b/.agents/scripts/analyze-execution.js
@@ -52,9 +52,9 @@ import {
   computeStoryPerfSummary,
 } from './lib/observability/perf-aggregator.js';
 import { forEachLine } from './lib/observability/signals-writer.js';
-import { read as readSignals } from './lib/signals/read.js';
 import { upsertStructuredComment } from './lib/orchestration/ticketing.js';
 import { createProvider } from './lib/provider-factory.js';
+import { read as readSignals } from './lib/signals/read.js';
 
 /**
  * Stream every lifecycle event under the Epic into an in-memory array

--- a/.agents/scripts/analyze-execution.js
+++ b/.agents/scripts/analyze-execution.js
@@ -52,8 +52,57 @@ import {
   computeStoryPerfSummary,
 } from './lib/observability/perf-aggregator.js';
 import { forEachLine } from './lib/observability/signals-writer.js';
+import { read as readSignals } from './lib/signals/read.js';
 import { upsertStructuredComment } from './lib/orchestration/ticketing.js';
 import { createProvider } from './lib/provider-factory.js';
+
+/**
+ * Stream every lifecycle event under the Epic into an in-memory array
+ * (Story #3025 / Task #3030). The perf-aggregator's wave-parallelism
+ * reducer needs a single chronological iterable spanning wave-start /
+ * wave-complete / state-transition events; the canonical reader walks
+ * the epic-level signals.ndjson first, then each per-Story stream in
+ * ascending Story-ID order, so that ordering matches the wave-tick
+ * emit order at runtime.
+ *
+ * Returns `[]` on any reader failure so the analyzer keeps composing
+ * its other report sections.
+ */
+async function readEpicLifecycleEvents(epicId, config, logger) {
+  const events = [];
+  try {
+    for await (const evt of readSignals({ epic: epicId, config })) {
+      if (evt && typeof evt === 'object') events.push(evt);
+    }
+  } catch (err) {
+    logger?.warn?.(
+      `[analyze-execution] readEpicLifecycleEvents(${epicId}) failed (non-fatal): ${
+        err instanceof Error ? err.message : String(err)
+      }`,
+    );
+  }
+  return events;
+}
+
+/**
+ * Resolve the wave-execution concurrency cap from the resolved config
+ * (`delivery.deliverRunner.concurrencyCap`), falling back to the
+ * dispatcher's safe default of 2. Story #3025 / Task #3030.
+ */
+function resolveConcurrencyCap(config) {
+  const cap = config?.delivery?.deliverRunner?.concurrencyCap;
+  return Number.isInteger(cap) && cap >= 1 ? cap : 2;
+}
+
+/**
+ * Resolve the verify-results concurrency cap from the resolved config
+ * (`delivery.deliverRunner.verifyConcurrencyCap`), falling back to 4.
+ * Story #3025 / Task #3030.
+ */
+function resolveVerifyConcurrencyCap(config) {
+  const cap = config?.delivery?.deliverRunner?.verifyConcurrencyCap;
+  return Number.isInteger(cap) && cap >= 1 ? cap : 4;
+}
 
 const STORY_PERF_TYPE = 'story-perf-summary';
 const EPIC_PERF_TYPE = 'epic-perf-report';
@@ -585,10 +634,34 @@ export async function runEpicMode(ctx) {
   logger.info?.(`[analyze-execution] epic-mode epic=#${epicId}`);
 
   const summaries = await collectFn(provider, epicId, logger);
-  const payload = computeEpicPerfReport(summaries, {
+
+  // Story #3025 / Task #3030 — forward lifecycle events to the
+  // aggregator so the report's `waveParallelism` array is populated
+  // (the analyzer used to omit the field, leaving the report at `[]`).
+  const readLifecycleEventsFn =
+    ctx.readLifecycleEventsFn ?? readEpicLifecycleEvents;
+  const lifecycleEvents = ctx.config
+    ? await readLifecycleEventsFn(epicId, ctx.config, logger)
+    : [];
+  const concurrencyCap = resolveConcurrencyCap(ctx.config);
+  const verifyConcurrencyCap = resolveVerifyConcurrencyCap(ctx.config);
+
+  // Only forward `events` when we actually have something — passing an
+  // empty array suppresses the friction-from-summaries fallback in
+  // `computeEpicPerfReport.buildSignalCounts`, which would zero the
+  // counts for callers that have summaries but no lifecycle stream
+  // (e.g. legacy/test paths without a `config`).
+  const reportOpts = {
     epicId,
     generatedAt: now().toISOString(),
-  });
+    concurrencyCap,
+    verifyConcurrencyCap,
+  };
+  if (lifecycleEvents.length > 0) {
+    reportOpts.events = lifecycleEvents;
+  }
+
+  const payload = computeEpicPerfReport(summaries, reportOpts);
 
   // Story #1400 / Task #1427 — baseline-refresh-rate row. Pure reporter
   // operates on a fixture of git-log records gathered by the injected

--- a/.agents/scripts/epic-close.js
+++ b/.agents/scripts/epic-close.js
@@ -40,6 +40,7 @@ import { runAsCli } from './lib/cli-utils.js';
 import { resolveConfig as defaultResolveConfig } from './lib/config-resolver.js';
 import {
   closePlanningArtifacts as defaultClosePlanningArtifacts,
+  emitEpicPerfReport as defaultEmitEpicPerfReport,
   verifyAndRecoverEpicClose as defaultVerifyAndRecoverEpicClose,
 } from './lib/epic-close-tail-helpers.js';
 import { Logger } from './lib/Logger.js';
@@ -64,21 +65,28 @@ const DEFAULT_LOGGER = {
  * @param {{
  *   epicId: number,
  *   provider: object,
+ *   config?: object,
+ *   cwd?: string,
  *   logger?: object,
  *   closePlanningArtifactsFn?: typeof defaultClosePlanningArtifacts,
  *   verifyAndRecoverEpicCloseFn?: typeof defaultVerifyAndRecoverEpicClose,
+ *   emitEpicPerfReportFn?: typeof defaultEmitEpicPerfReport,
  * }} opts
  * @returns {Promise<{
  *   planningClose: object,
  *   epicClose: object,
+ *   perfReport: object,
  * }>}
  */
 export async function runEpicCloseTail({
   epicId,
   provider,
+  config,
+  cwd,
   logger = DEFAULT_LOGGER,
   closePlanningArtifactsFn = defaultClosePlanningArtifacts,
   verifyAndRecoverEpicCloseFn = defaultVerifyAndRecoverEpicClose,
+  emitEpicPerfReportFn = defaultEmitEpicPerfReport,
 } = {}) {
   if (!Number.isInteger(epicId) || epicId <= 0) {
     throw new TypeError(
@@ -118,7 +126,20 @@ export async function runEpicCloseTail({
     logger,
   });
 
-  return { planningClose, epicClose };
+  // Story #3029 / Task #3040 — emit the epic-perf-report alongside the
+  // close tail so the report is persisted under temp/epic-<id>/ even
+  // when the operator does not separately run analyze-execution.
+  // Friction-not-fatal: a throw here is logged + swallowed by the
+  // helper so the close still completes.
+  const perfReport = await emitEpicPerfReportFn({
+    epicId,
+    provider,
+    config,
+    cwd,
+    logger,
+  });
+
+  return { planningClose, epicClose, perfReport };
 }
 
 /**
@@ -140,6 +161,7 @@ export async function runEpicCloseTail({
  *   fixed: Array,
  *   planningClose?: object,
  *   epicClose?: object,
+ *   perfReport?: object,
  * }>}
  */
 export async function runEpicClose({
@@ -196,10 +218,12 @@ export async function runEpicClose({
   const tail = await runEpicCloseTailFn({
     epicId: parsedEpicId,
     provider,
+    config,
+    cwd,
     logger,
   });
   logger.info(
-    `[epic-close] complete — planning: prd=${tail.planningClose.prd.status} techSpec=${tail.planningClose.techSpec.status}; epic=${tail.epicClose.status}.`,
+    `[epic-close] complete — planning: prd=${tail.planningClose.prd.status} techSpec=${tail.planningClose.techSpec.status}; epic=${tail.epicClose.status}; perfReport=${tail.perfReport?.status ?? 'skipped'}.`,
   );
 
   return {
@@ -208,6 +232,7 @@ export async function runEpicClose({
     fixed: preflight.fixed,
     planningClose: tail.planningClose,
     epicClose: tail.epicClose,
+    perfReport: tail.perfReport,
   };
 }
 

--- a/.agents/scripts/epic-deliver-preflight.js
+++ b/.agents/scripts/epic-deliver-preflight.js
@@ -56,6 +56,10 @@ import { getPreflight, resolveConfig } from './lib/config-resolver.js';
 import { Logger } from './lib/Logger.js';
 import { runBuildWaveDagPhase } from './lib/orchestration/epic-runner/phases/build-wave-dag.js';
 import { runSnapshotPhase } from './lib/orchestration/epic-runner/phases/snapshot.js';
+import {
+  computeBaseSha,
+  writePreflightCache,
+} from './lib/orchestration/preflight-cache.js';
 import { upsertStructuredComment } from './lib/orchestration/ticketing.js';
 import { createProvider } from './lib/provider-factory.js';
 
@@ -290,6 +294,25 @@ export async function runPreflight({
   const storyCount = Array.isArray(state.stories) ? state.stories.length : 0;
   const waveCount = Array.isArray(state.waves) ? state.waves.length : 0;
 
+  // Persist the snapshot/DAG envelope so `epic-deliver-prepare.js` can
+  // reuse it instead of re-walking the hierarchy. The cache key is a
+  // deterministic fingerprint of the Epic ticket returned by the same
+  // `getTicket(epicId)` call that drove `runSnapshotPhase`, so any drift
+  // (label, body, updatedAt) forces a cache miss in prepare.
+  const baseSha = computeBaseSha(state.epic);
+  let cacheWritten = false;
+  if (!dryRun) {
+    await writePreflightCache({
+      epicId,
+      baseSha,
+      epic: state.epic,
+      stories: state.stories,
+      waves: state.waves,
+      cwd,
+    });
+    cacheWritten = true;
+  }
+
   const estimate = computeEstimate({
     storyCount,
     waveCount,
@@ -304,6 +327,8 @@ export async function runPreflight({
     ...estimate,
     breaches,
     thresholds,
+    baseSha,
+    cacheWritten,
   };
 
   if (post && !dryRun) {

--- a/.agents/scripts/epic-deliver-prepare.js
+++ b/.agents/scripts/epic-deliver-prepare.js
@@ -42,6 +42,10 @@ import {
 import { runBuildWaveDagPhase } from './lib/orchestration/epic-runner/phases/build-wave-dag.js';
 import { runSnapshotPhase } from './lib/orchestration/epic-runner/phases/snapshot.js';
 import { StoryLauncher } from './lib/orchestration/epic-runner/story-launcher.js';
+import {
+  computeBaseSha,
+  readPreflightCache,
+} from './lib/orchestration/preflight-cache.js';
 import { createProvider } from './lib/provider-factory.js';
 
 const HELP = `Usage: node .agents/scripts/epic-deliver-prepare.js --epic <epicId> [--ignore-concurrency-hazards]
@@ -97,10 +101,33 @@ export async function runEpicDeliverPrepare({
   const { deliverRunner } = getRunners(config);
   const concurrencyCap = deliverRunner.concurrencyCap;
 
+  // Story #3027: try the preflight cache first so we don't re-walk Epic
+  // → Feature → Story when `epic-deliver-preflight.js` already did. The
+  // cache key is a deterministic fingerprint of the Epic ticket; a
+  // single getTicket(epicId) round-trip confirms the cache is still
+  // valid. Cache miss or baseSha mismatch → fall back to a fresh pass.
   const ctx = { epicId, provider };
   let state = {};
-  state = await runSnapshotPhase(ctx, {}, state);
-  state = await runBuildWaveDagPhase(ctx, {}, state);
+  let cacheStatus = 'miss';
+  const cached = await readPreflightCache({ epicId, cwd });
+  if (cached) {
+    const freshEpic = await provider.getTicket(epicId);
+    const freshBaseSha = computeBaseSha(freshEpic);
+    if (freshBaseSha === cached.baseSha) {
+      state = {
+        epic: cached.epic,
+        stories: cached.stories,
+        waves: cached.waves,
+      };
+      cacheStatus = 'hit';
+    } else {
+      cacheStatus = 'stale';
+    }
+  }
+  if (cacheStatus !== 'hit') {
+    state = await runSnapshotPhase(ctx, {}, state);
+    state = await runBuildWaveDagPhase(ctx, {}, state);
+  }
 
   // Cross-Story concurrency-hazard gate (Story #2297). Findings come in
   // via DI; no default loader is wired yet — production callers will
@@ -172,6 +199,7 @@ export async function runEpicDeliverPrepare({
       checkpointState.lastUpdatedAt ??
       new Date().toISOString(),
     concurrencyHazardsBypassed: gate.bypassed,
+    preflightCache: cacheStatus,
   };
 }
 

--- a/.agents/scripts/epic-execute-record-wave.js
+++ b/.agents/scripts/epic-execute-record-wave.js
@@ -200,6 +200,7 @@ export async function runEpicExecuteRecordWave({
   const { verified, discrepancies } = await verifyWaveResults({
     provider,
     results: validated,
+    concurrencyCap: deliverRunner.verifyConcurrencyCap,
   });
 
   // 3. Cross-look manifest titles for the rollup rows.

--- a/.agents/scripts/epic-execute-record-wave.js
+++ b/.agents/scripts/epic-execute-record-wave.js
@@ -46,7 +46,7 @@ import * as epicRunStateStore from './lib/orchestration/epic-run-state-store.js'
 import { upsertEpicRunProgress } from './lib/orchestration/epic-runner/progress-reporter.js';
 import {
   loadManifestTitleMap,
-  refreshLocalManifest,
+  refreshDispatchManifest,
   resolveResolvedResults,
   verifyWaveResults,
 } from './lib/orchestration/wave-record-io.js';
@@ -65,7 +65,7 @@ import { notify } from './notify.js';
 export {
   loadManifestTitleMap,
   normalizeReturns,
-  refreshLocalManifest,
+  refreshDispatchManifest,
   resolveResolvedResults,
   verifyWaveResults,
 } from './lib/orchestration/wave-record-io.js';
@@ -147,7 +147,7 @@ export function parseInputArg(value, deps = {}) {
  *   injectedProvider?: object,
  *   injectedConfig?: object,
  *   injectedNotify?: (ticketId: number, payload: object) => Promise<void>,
- *   injectedRefreshLocalManifest?: (args: { epicId: number }) => Promise<void>,
+ *   injectedRefreshDispatchManifest?: (args: { epicId: number, provider?: object }) => Promise<object>,
  *   now?: () => Date,
  * }} args
  */
@@ -161,7 +161,7 @@ export async function runEpicExecuteRecordWave({
   injectedProvider,
   injectedConfig,
   injectedNotify,
-  injectedRefreshLocalManifest,
+  injectedRefreshDispatchManifest,
   now = () => new Date(),
 } = {}) {
   validateEpicWave(epicId, wave);
@@ -264,16 +264,18 @@ export async function runEpicExecuteRecordWave({
     blockedStoryIds: projection.blockedStoryIds,
   });
 
-  // 8. Refresh the local `temp/epic-<id>/manifest.{md,json}` so the
-  //    operator-facing on-disk view reflects this wave's progress. The
-  //    wave-runner architecture (Epic #1182) replaced the dispatcher's
-  //    per-wave refresh loop; without this hop the manifest is frozen at
-  //    planning time and shows `0/N tasks` even after Stories merge.
-  //    Best-effort: failure here must not block the wave loop.
-  const refreshManifest = injectedRefreshLocalManifest ?? refreshLocalManifest;
-  await refreshManifest({ epicId }).catch((err) => {
+  // 8. Refresh the dispatch manifest in-process so the operator-facing
+  //    on-disk view (`temp/epic-<id>/manifest.{md,json}`) and the
+  //    `dispatch-manifest` Epic comment reflect this wave's progress.
+  //    Story #3026 replaced the historical `dispatcher.js --dry-run`
+  //    subprocess spawn with an in-process `resolveAndDispatch` + pure
+  //    `renderManifest` call. Best-effort: failure here must not block
+  //    the wave loop.
+  const refreshManifest =
+    injectedRefreshDispatchManifest ?? refreshDispatchManifest;
+  await refreshManifest({ epicId, provider }).catch((err) => {
     Logger.warn(
-      `[record-wave] Non-fatal: could not refresh local manifest for Epic #${epicId} — ${err?.message ?? 'unknown error'}`,
+      `[record-wave] Non-fatal: could not refresh dispatch manifest for Epic #${epicId} — ${err?.message ?? 'unknown error'}`,
     );
   });
 

--- a/.agents/scripts/lib/config-resolver.js
+++ b/.agents/scripts/lib/config-resolver.js
@@ -74,6 +74,7 @@ export {
   resolveMaintainabilityQuality,
   resolveQuality,
 } from './config/quality.js';
+export { DEFAULT_RETRO, getRetro } from './config/retro.js';
 export {
   DEFAULT_DECOMPOSER,
   DEFAULT_STORY_MERGE_RETRY,

--- a/.agents/scripts/lib/config-settings-schema.js
+++ b/.agents/scripts/lib/config-settings-schema.js
@@ -293,6 +293,7 @@ const DELIVER_RUNNER_SCHEMA = {
   properties: {
     concurrencyCap: { type: 'integer', minimum: 1 },
     progressReportIntervalSec: { type: 'integer', minimum: 0 },
+    verifyConcurrencyCap: { type: 'integer', minimum: 1 },
   },
   additionalProperties: false,
 };

--- a/.agents/scripts/lib/config-settings-schema.js
+++ b/.agents/scripts/lib/config-settings-schema.js
@@ -298,6 +298,34 @@ const DELIVER_RUNNER_SCHEMA = {
   additionalProperties: false,
 };
 
+/**
+ * `delivery.retro.perfThresholds` (Story #3042, Task #3043) — operator-tunable
+ * gates for the retro perf-signals classifier. Defaults are documented inline
+ * here and mirrored in `lib/orchestration/retro-perf-heuristics.js
+ * (DEFAULT_RETRO_PERF_THRESHOLDS)` and the static schema mirror.
+ *
+ * `utilisation` / `bootstrapShare` are unit-interval ratios; values outside
+ * [0, 1] fall back to defaults at the resolver. `capBindingRunLength` is a
+ * positive integer count of consecutive cap-binding waves.
+ */
+const RETRO_PERF_THRESHOLDS_SCHEMA = {
+  type: 'object',
+  properties: {
+    utilisation: { type: 'number', minimum: 0, maximum: 1 },
+    bootstrapShare: { type: 'number', minimum: 0, maximum: 1 },
+    capBindingRunLength: { type: 'integer', minimum: 1 },
+  },
+  additionalProperties: false,
+};
+
+const RETRO_SCHEMA = {
+  type: 'object',
+  properties: {
+    perfThresholds: RETRO_PERF_THRESHOLDS_SCHEMA,
+  },
+  additionalProperties: false,
+};
+
 const WORKTREE_ISOLATION_SCHEMA = {
   type: 'object',
   properties: {
@@ -633,6 +661,7 @@ const DELIVERY_SCHEMA = {
     mergeWatch: MERGE_WATCH_SCHEMA,
     epicAudit: EPIC_AUDIT_SCHEMA,
     codeReview: CODE_REVIEW_SCHEMA,
+    retro: RETRO_SCHEMA,
     ci: CI_DELIVERY_SCHEMA,
     preflight: PREFLIGHT_SCHEMA,
     // Cross-Story concurrency-hazard gate (Story #2297). When true,

--- a/.agents/scripts/lib/config/retro.js
+++ b/.agents/scripts/lib/config/retro.js
@@ -1,0 +1,77 @@
+/**
+ * Retro accessor (Story #3042 / Task #3043 — Epic #3019).
+ *
+ * Resolves `.agentrc.json → delivery.retro` into the canonical shape the
+ * retro-runner consumes. Currently exposes only `perfThresholds`, the
+ * operator-tunable gates for the perf-signals classifier in
+ * `lib/orchestration/retro-perf-heuristics.js`.
+ *
+ * Defaults mirror `DEFAULT_RETRO_PERF_THRESHOLDS` in the heuristics module
+ * (single source of behavioural truth; this resolver is a thin merge layer).
+ */
+
+/**
+ * Default perf-threshold trio applied when `.agentrc.json` omits
+ * `delivery.retro.perfThresholds` (or any of its sub-keys). Frozen so
+ * downstream callers cannot accidentally mutate the resolver's defaults
+ * across processes.
+ *
+ * Keep in lockstep with `DEFAULT_RETRO_PERF_THRESHOLDS` in
+ * `lib/orchestration/retro-perf-heuristics.js` and the schema mirror in
+ * `agentrc.schema.json → $defs.retro.properties.perfThresholds`.
+ */
+export const DEFAULT_RETRO = Object.freeze({
+  perfThresholds: Object.freeze({
+    utilisation: 0.6,
+    bootstrapShare: 0.4,
+    capBindingRunLength: 2,
+  }),
+});
+
+/**
+ * Read the merged retro block. Returns the canonical shape:
+ *
+ *   {
+ *     perfThresholds: {
+ *       utilisation: number,
+ *       bootstrapShare: number,
+ *       capBindingRunLength: number,
+ *     },
+ *   }
+ *
+ * Each sub-key falls back to its documented default when the resolved
+ * `.agentrc.json` omits it. Out-of-range values fall back to defaults too —
+ * the AJV schema rejects them before they reach this accessor, but the
+ * resolver stays defensive so unit-test fixtures and degraded configs
+ * never produce nonsensical thresholds.
+ *
+ * @param {object | null | undefined} config
+ * @returns {{ perfThresholds: { utilisation: number, bootstrapShare: number, capBindingRunLength: number } }}
+ */
+export function getRetro(config) {
+  const user = config?.delivery?.retro?.perfThresholds ?? {};
+  const defaults = DEFAULT_RETRO.perfThresholds;
+  return {
+    perfThresholds: {
+      utilisation: resolveUnit(user.utilisation, defaults.utilisation),
+      bootstrapShare: resolveUnit(user.bootstrapShare, defaults.bootstrapShare),
+      capBindingRunLength: resolvePositiveInt(
+        user.capBindingRunLength,
+        defaults.capBindingRunLength,
+      ),
+    },
+  };
+}
+
+function resolveUnit(value, fallback) {
+  if (typeof value !== 'number' || !Number.isFinite(value)) return fallback;
+  if (value < 0 || value > 1) return fallback;
+  return value;
+}
+
+function resolvePositiveInt(value, fallback) {
+  if (typeof value !== 'number' || !Number.isInteger(value) || value < 1) {
+    return fallback;
+  }
+  return value;
+}

--- a/.agents/scripts/lib/config/runners.js
+++ b/.agents/scripts/lib/config/runners.js
@@ -19,10 +19,16 @@ export const DEFAULT_DECOMPOSER = Object.freeze({
 });
 
 /** Hardcoded deliver-runner concurrency cap. Operators override via
- * `delivery.deliverRunner.concurrencyCap` in `.agentrc.json`. */
+ * `delivery.deliverRunner.concurrencyCap` in `.agentrc.json`.
+ *
+ * `verifyConcurrencyCap` (Epic #3019 Tech Spec §1.4 / Story #3024) is a
+ * separate knob that bounds the `verifyWaveResults` loop independently
+ * of Story-dispatch concurrency, so operators can tune ticket-verify
+ * parallelism without raising the wave fan-out. Default 4. */
 const DEFAULT_DELIVER_RUNNER = Object.freeze({
   concurrencyCap: 3,
   progressReportIntervalSec: 120,
+  verifyConcurrencyCap: 4,
 });
 
 /**
@@ -46,7 +52,7 @@ export const DEFAULT_CODE_REVIEW = Object.freeze({
  *
  * @param {object | null | undefined} config
  * @returns {{
- *   deliverRunner: { concurrencyCap: number, progressReportIntervalSec: number },
+ *   deliverRunner: { concurrencyCap: number, progressReportIntervalSec: number, verifyConcurrencyCap: number },
  *   epicAudit: { maxFixAttempts: number, maxFixScopeFiles: number },
  *   codeReview: { maxFixAttempts: number, maxFixScopeFiles: number },
  *   storyMergeRetry: { maxAttempts: number, backoffMs: readonly number[] },
@@ -65,6 +71,9 @@ export function getRunners(config) {
       progressReportIntervalSec:
         deliverRunnerUser.progressReportIntervalSec ??
         DEFAULT_DELIVER_RUNNER.progressReportIntervalSec,
+      verifyConcurrencyCap:
+        deliverRunnerUser.verifyConcurrencyCap ??
+        DEFAULT_DELIVER_RUNNER.verifyConcurrencyCap,
     },
     epicAudit: {
       maxFixAttempts:

--- a/.agents/scripts/lib/config/temp-paths.js
+++ b/.agents/scripts/lib/config/temp-paths.js
@@ -243,6 +243,23 @@ export const epicPerfReportPath = (eid, config) =>
   epicArtifactPath(eid, 'perf-report.md', config);
 
 /**
+ * `temp/epic-<eid>/epic-perf-report.json` — canonical JSON snapshot of
+ * the `epic-perf-report` payload persisted at /epic-deliver close
+ * (Epic #3019 / Story #3029 / Task #3040). Written by the
+ * `emitEpicPerfReport` close-tail helper alongside the
+ * `epic-perf-report` structured comment so the report is discoverable
+ * from the file system without round-tripping the ticketing provider,
+ * and so the `epic-handoff` structured close comment can link it by
+ * relative path.
+ *
+ * @param {number} eid
+ * @param {object} [config]
+ * @returns {string}
+ */
+export const epicPerfReportJsonPath = (eid, config) =>
+  epicArtifactPath(eid, 'epic-perf-report.json', config);
+
+/**
  * `temp/epic-<eid>/lifecycle.ndjson` — append-only lifecycle bus ledger
  * (Story #2510). The LedgerWriter persists every emitted/completed/failed
  * record here; the TraceLogger renders the companion markdown from it.

--- a/.agents/scripts/lib/epic-close-tail-helpers.js
+++ b/.agents/scripts/lib/epic-close-tail-helpers.js
@@ -17,6 +17,10 @@
  * side effects.
  */
 
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { runEpicMode as defaultRunEpicMode } from '../analyze-execution.js';
+import { epicPerfReportJsonPath } from './config/temp-paths.js';
 import { Logger } from './Logger.js';
 import {
   STATE_LABELS,
@@ -175,4 +179,116 @@ export async function verifyAndRecoverEpicClose({
       detail,
     };
   }
+}
+
+/**
+ * Invoke `analyze-execution.runEpicMode` from the close tail and persist
+ * the resulting `epic-perf-report` payload to
+ * `temp/epic-<id>/epic-perf-report.json` (Epic #3019 / Story #3029 /
+ * Task #3040). The analyzer already upserts the structured comment on
+ * the Epic; this helper exists so the report is also reachable on disk
+ * without a provider round-trip, and so the `epic-handoff` close
+ * comment can link to it by relative path.
+ *
+ * Friction-not-fatal contract: any throw from the analyzer, the
+ * filesystem write, or the cwd lookup is caught, logged as a `warn`,
+ * and surfaced in the result envelope. The close tail must still
+ * complete in that case — the report is observability output, not a
+ * gating signal. Callers should record the failure (e.g. via the
+ * friction lifecycle event) but MUST NOT throw.
+ *
+ * @param {{
+ *   epicId: number,
+ *   provider: object,
+ *   config?: object,
+ *   cwd?: string,
+ *   logger?: object,
+ *   analyzeFn?: typeof defaultRunEpicMode,
+ *   writeFileFn?: (p: string, data: string, encoding: string) => Promise<void>,
+ *   mkdirFn?: (p: string, opts: object) => Promise<unknown>,
+ *   now?: () => Date,
+ * }} args
+ * @returns {Promise<{
+ *   status: 'ok'|'failed',
+ *   path: string|null,
+ *   commentId: number|null,
+ *   payload: object|null,
+ *   detail?: string,
+ * }>}
+ */
+export async function emitEpicPerfReport({
+  epicId,
+  provider,
+  config,
+  cwd,
+  logger = Logger,
+  analyzeFn = defaultRunEpicMode,
+  writeFileFn = fs.writeFile,
+  mkdirFn = fs.mkdir,
+  now,
+} = {}) {
+  if (!Number.isInteger(epicId) || epicId <= 0) {
+    throw new TypeError(
+      'emitEpicPerfReport: epicId is required (positive integer).',
+    );
+  }
+  if (!provider) {
+    throw new TypeError('emitEpicPerfReport: provider is required.');
+  }
+
+  let result;
+  try {
+    result = await analyzeFn({
+      epicId,
+      provider,
+      config,
+      cwd,
+      logger,
+      ...(typeof now === 'function' ? { now } : {}),
+    });
+  } catch (err) {
+    const detail = err?.message ?? String(err);
+    logger.warn?.(
+      `[epic-close-tail] emitEpicPerfReport: analyze-execution threw for Epic #${epicId} (non-fatal): ${detail}`,
+    );
+    return {
+      status: 'failed',
+      path: null,
+      commentId: null,
+      payload: null,
+      detail,
+    };
+  }
+
+  const target = epicPerfReportJsonPath(epicId, config);
+  try {
+    await mkdirFn(path.dirname(target), { recursive: true });
+    await writeFileFn(
+      target,
+      `${JSON.stringify(result?.payload ?? {}, null, 2)}\n`,
+      'utf8',
+    );
+  } catch (err) {
+    const detail = err?.message ?? String(err);
+    logger.warn?.(
+      `[epic-close-tail] emitEpicPerfReport: failed to persist ${target} (non-fatal): ${detail}`,
+    );
+    return {
+      status: 'failed',
+      path: target,
+      commentId: result?.commentId ?? null,
+      payload: result?.payload ?? null,
+      detail,
+    };
+  }
+
+  logger.info?.(
+    `[epic-close-tail] Persisted epic-perf-report.json at ${target} for Epic #${epicId}.`,
+  );
+  return {
+    status: 'ok',
+    path: target,
+    commentId: result?.commentId ?? null,
+    payload: result?.payload ?? null,
+  };
 }

--- a/.agents/scripts/lib/observability/perf-aggregator.js
+++ b/.agents/scripts/lib/observability/perf-aggregator.js
@@ -367,6 +367,209 @@ function aggregateTopHotspots(summaries) {
 const DEFAULT_VERIFY_CONCURRENCY_CAP = 4;
 
 /**
+ * Default wave-execution concurrency cap used when the caller does not
+ * supply `concurrencyCap` to {@link computeWaveParallelismRows}. The
+ * project default (`delivery.deliverRunner.concurrencyCap`) is 2 today;
+ * the value here is the safe fallback for offline / test contexts.
+ */
+const DEFAULT_WAVE_CONCURRENCY_CAP = 2;
+
+function tsOf(evt) {
+  return evt?.ts ?? evt?.timestamp ?? null;
+}
+
+function tsToMs(ts) {
+  if (typeof ts !== 'string') return null;
+  const n = Date.parse(ts);
+  return Number.isFinite(n) ? n : null;
+}
+
+function storyIdOf(evt) {
+  const raw = evt?.story ?? evt?.storyId;
+  const n = Number(raw);
+  return Number.isInteger(n) && n > 0 ? n : null;
+}
+
+/**
+ * Compute per-wave parallelism rows from a chronological iterable of
+ * lifecycle events (Task #3028, Epic #3019 / Story #3025).
+ *
+ * Wave windows are bracketed by `wave-start` (carrying `index` +
+ * `stories[]`) and the matching `wave-complete` (same `index`). When no
+ * `wave-complete` is observed for a wave, the wave's wallClockMs falls
+ * back to the timestamp of the last in-wave event observed (so partial
+ * runs still emit a row). When `wave-start` is missing entirely we emit
+ * no row for that wave.
+ *
+ * Per-Story durations within a wave come from `state-transition` events
+ * (`agent::executing` → `agent::done`) for the Story IDs the
+ * `wave-start` payload enumerated. We bracket the **first**
+ * `executing` transition and the **last** terminal transition (`done`,
+ * `blocked`, or `failed`) per Story; if a Story is missing one boundary
+ * its contribution to `summedStoryMs` is 0.
+ *
+ * Field contract (per the extended `epic-perf-report.schema.json`):
+ *   - `waveIndex`: integer ≥ 0, from `wave-start.index`
+ *   - `wallClockMs`: integer ≥ 0, `(waveEnd - waveStart)` in ms
+ *   - `summedStoryMs`: integer ≥ 0, Σ per-Story `(end - start)`
+ *   - `utilisation`: `summedStoryMs / (wallClockMs * concurrencyCap)`,
+ *     clamped to `[0, 1]`. Zero when `wallClockMs === 0` or cap is 0.
+ *   - `capBinding`: true when `summedStoryMs / wallClockMs >=
+ *     concurrencyCap`, false otherwise (and false when wallClockMs
+ *     is 0).
+ *   - `verifyConcurrencyCap`: forwarded from `opts.verifyConcurrencyCap`
+ *     (or the project default 4) so the post-merge close comment can
+ *     attribute saturation back to the cap value in force at the time.
+ *
+ * @param {Iterable<object>} events
+ * @param {{
+ *   concurrencyCap?: number,
+ *   verifyConcurrencyCap?: number,
+ * }} [opts]
+ * @returns {Array<{
+ *   waveIndex: number,
+ *   wallClockMs: number,
+ *   summedStoryMs: number,
+ *   utilisation: number,
+ *   capBinding: boolean,
+ *   verifyConcurrencyCap: number,
+ * }>}
+ */
+export function computeWaveParallelismRows(events, opts = {}) {
+  const concurrencyCap =
+    Number.isInteger(opts.concurrencyCap) && opts.concurrencyCap >= 1
+      ? opts.concurrencyCap
+      : DEFAULT_WAVE_CONCURRENCY_CAP;
+  const verifyConcurrencyCap =
+    Number.isInteger(opts.verifyConcurrencyCap) && opts.verifyConcurrencyCap >= 1
+      ? opts.verifyConcurrencyCap
+      : DEFAULT_VERIFY_CONCURRENCY_CAP;
+
+  // Materialise the iterable so we can do multiple passes; events are
+  // typically a few thousand per Epic at most.
+  const evtArr = [];
+  for (const e of events ?? []) {
+    if (isObject(e) && typeof e.kind === 'string') evtArr.push(e);
+  }
+
+  // Index Story state-transition windows: first `agent::executing` →
+  // last terminal (`agent::done` | `agent::blocked` | `agent::failed`).
+  const storyWindows = new Map(); // storyId → { startMs, endMs }
+  for (const evt of evtArr) {
+    if (evt.kind !== 'state-transition') continue;
+    const sid = storyIdOf(evt);
+    if (sid == null) continue;
+    const ms = tsToMs(tsOf(evt));
+    if (ms == null) continue;
+    const to =
+      (isObject(evt.details) && evt.details.to) ?? evt.to ?? evt.toState;
+    const rec = storyWindows.get(sid) ?? { startMs: null, endMs: null };
+    if (to === 'agent::executing') {
+      if (rec.startMs == null || ms < rec.startMs) rec.startMs = ms;
+    } else if (
+      to === 'agent::done' ||
+      to === 'agent::blocked' ||
+      to === 'agent::failed'
+    ) {
+      if (rec.endMs == null || ms > rec.endMs) rec.endMs = ms;
+    }
+    storyWindows.set(sid, rec);
+  }
+
+  // Bucket wave-start / wave-complete events by index.
+  const waves = new Map(); // index → { startMs, endMs, stories: number[] }
+
+  for (const evt of evtArr) {
+    const ts = tsToMs(tsOf(evt));
+    if (ts == null) continue;
+    if (evt.kind === 'wave-start') {
+      const idx = Number(evt.index);
+      if (!Number.isInteger(idx) || idx < 0) continue;
+      const storiesField = Array.isArray(evt.stories) ? evt.stories : [];
+      const storyIds = storiesField
+        .map((s) => {
+          const n = Number(isObject(s) ? s.id ?? s.storyId : s);
+          return Number.isInteger(n) && n > 0 ? n : null;
+        })
+        .filter((n) => n != null);
+      const rec = waves.get(idx) ?? {
+        startMs: null,
+        endMs: null,
+        stories: [],
+      };
+      if (rec.startMs == null || ts < rec.startMs) rec.startMs = ts;
+      rec.stories = storyIds;
+      waves.set(idx, rec);
+    } else if (evt.kind === 'wave-complete') {
+      const idx = Number(evt.index);
+      if (!Number.isInteger(idx) || idx < 0) continue;
+      const rec = waves.get(idx) ?? {
+        startMs: null,
+        endMs: null,
+        stories: [],
+      };
+      if (rec.endMs == null || ts > rec.endMs) rec.endMs = ts;
+      waves.set(idx, rec);
+    }
+  }
+
+  // Fallback: if a wave never saw `wave-complete`, walk the events
+  // chronologically and use the max ts observed between this wave's
+  // start and the next wave's start as the wallClock terminator.
+  const orderedWaves = [...waves.entries()].sort((a, b) => a[0] - b[0]);
+  for (let i = 0; i < orderedWaves.length; i += 1) {
+    const [idx, rec] = orderedWaves[i];
+    if (rec.endMs != null) continue;
+    const startMs = rec.startMs;
+    if (startMs == null) continue;
+    const nextStartMs =
+      i + 1 < orderedWaves.length ? orderedWaves[i + 1][1].startMs : Infinity;
+    let maxMs = startMs;
+    for (const evt of evtArr) {
+      const ts = tsToMs(tsOf(evt));
+      if (ts == null) continue;
+      if (ts >= startMs && ts < nextStartMs && ts > maxMs) maxMs = ts;
+    }
+    rec.endMs = maxMs;
+    waves.set(idx, rec);
+  }
+
+  // Build rows.
+  const rows = [];
+  for (const [idx, rec] of orderedWaves) {
+    if (rec.startMs == null) continue;
+    const wallClockMs = Math.max(0, Math.floor((rec.endMs ?? rec.startMs) - rec.startMs));
+    let summedStoryMs = 0;
+    for (const sid of rec.stories) {
+      const w = storyWindows.get(sid);
+      if (!w || w.startMs == null || w.endMs == null) continue;
+      const dur = w.endMs - w.startMs;
+      if (Number.isFinite(dur) && dur > 0) summedStoryMs += Math.floor(dur);
+    }
+    let utilisation = 0;
+    let capBinding = false;
+    if (wallClockMs > 0 && concurrencyCap > 0) {
+      utilisation = clamp(
+        summedStoryMs / (wallClockMs * concurrencyCap),
+        0,
+        1,
+      );
+      capBinding = summedStoryMs / wallClockMs >= concurrencyCap;
+    }
+    rows.push({
+      waveIndex: idx,
+      wallClockMs,
+      summedStoryMs,
+      utilisation,
+      capBinding,
+      verifyConcurrencyCap,
+    });
+  }
+
+  return rows;
+}
+
+/**
  * Clamp `n` to the inclusive range [lo, hi]. Returns `lo` for NaN /
  * non-finite inputs so the coercer stays well-behaved on garbage.
  *
@@ -460,9 +663,22 @@ export function computeEpicPerfReport(perStorySummaries, opts) {
     .sort((a, b) => b.frictionCount - a.frictionCount)
     .slice(0, 5);
 
-  const waveParallelism = Array.isArray(opts.waveParallelism)
-    ? opts.waveParallelism.map((row) => coerceWaveParallelismRow(row))
-    : [];
+  let waveParallelism;
+  if (Array.isArray(opts.waveParallelism)) {
+    waveParallelism = opts.waveParallelism.map((row) =>
+      coerceWaveParallelismRow(row),
+    );
+  } else if (opts.events) {
+    // Derive rows from the raw lifecycle event stream when the caller
+    // hands us the events but no pre-computed array (Story #3025 /
+    // Task #3028).
+    waveParallelism = computeWaveParallelismRows(opts.events, {
+      concurrencyCap: opts.concurrencyCap,
+      verifyConcurrencyCap: opts.verifyConcurrencyCap,
+    });
+  } else {
+    waveParallelism = [];
+  }
 
   return {
     kind: 'epic-perf-report',

--- a/.agents/scripts/lib/observability/perf-aggregator.js
+++ b/.agents/scripts/lib/observability/perf-aggregator.js
@@ -359,6 +359,64 @@ function aggregateTopHotspots(summaries) {
     .slice(0, 5);
 }
 
+/**
+ * Default verify-concurrency cap when the caller does not override it.
+ * Mirrors the default for `delivery.deliverRunner.verifyConcurrencyCap`
+ * in `.agentrc.json` (Epic #3019 Tech Spec §1.4).
+ */
+const DEFAULT_VERIFY_CONCURRENCY_CAP = 4;
+
+/**
+ * Clamp `n` to the inclusive range [lo, hi]. Returns `lo` for NaN /
+ * non-finite inputs so the coercer stays well-behaved on garbage.
+ *
+ * @param {number} n
+ * @param {number} lo
+ * @param {number} hi
+ * @returns {number}
+ */
+function clamp(n, lo, hi) {
+  if (!Number.isFinite(n)) return lo;
+  if (n < lo) return lo;
+  if (n > hi) return hi;
+  return n;
+}
+
+/**
+ * Coerce a single waveParallelism input row into the schema-canonical
+ * shape `{ waveIndex, wallClockMs, summedStoryMs, utilisation,
+ * capBinding, verifyConcurrencyCap }` (Story #3025).
+ *
+ * - Numeric fields are floored to non-negative integers (or clamped
+ *   numbers for utilisation) so the JSON-schema `integer` / `minimum: 0`
+ *   constraints hold by construction.
+ * - `utilisation` is clamped to `[0, 1]` per the Tech Spec
+ *   contract (§1.1).
+ * - `capBinding` is coerced to boolean.
+ * - `verifyConcurrencyCap` falls back to the project default (4) when the
+ *   caller omits it or supplies a non-positive integer; the schema
+ *   requires `minimum: 1` so 0 is not a valid carrier value.
+ *
+ * Exported for unit-testing the coercer in isolation.
+ *
+ * @param {object | null | undefined} row
+ * @returns {{ waveIndex: number, wallClockMs: number, summedStoryMs: number, utilisation: number, capBinding: boolean, verifyConcurrencyCap: number }}
+ */
+export function coerceWaveParallelismRow(row) {
+  const src = isObject(row) ? row : {};
+  const cap = Number(src.verifyConcurrencyCap);
+  const verifyConcurrencyCap =
+    Number.isInteger(cap) && cap >= 1 ? cap : DEFAULT_VERIFY_CONCURRENCY_CAP;
+  return {
+    waveIndex: nonNegativeInt(src.waveIndex),
+    wallClockMs: nonNegativeInt(src.wallClockMs),
+    summedStoryMs: nonNegativeInt(src.summedStoryMs),
+    utilisation: clamp(nonNegativeNumber(src.utilisation), 0, 1),
+    capBinding: Boolean(src.capBinding),
+    verifyConcurrencyCap,
+  };
+}
+
 export function computeEpicPerfReport(perStorySummaries, opts) {
   if (!isObject(opts)) {
     throw new TypeError('computeEpicPerfReport: opts is required');
@@ -403,13 +461,7 @@ export function computeEpicPerfReport(perStorySummaries, opts) {
     .slice(0, 5);
 
   const waveParallelism = Array.isArray(opts.waveParallelism)
-    ? opts.waveParallelism.map((row) => ({
-        wave: nonNegativeInt(row?.wave),
-        wallClockMs: nonNegativeInt(row?.wallClockMs),
-        sumStoryMs: nonNegativeInt(row?.sumStoryMs),
-        utilization: nonNegativeNumber(row?.utilization),
-        stories: nonNegativeInt(row?.stories),
-      }))
+    ? opts.waveParallelism.map((row) => coerceWaveParallelismRow(row))
     : [];
 
   return {

--- a/.agents/scripts/lib/observability/perf-aggregator.js
+++ b/.agents/scripts/lib/observability/perf-aggregator.js
@@ -441,7 +441,8 @@ export function computeWaveParallelismRows(events, opts = {}) {
       ? opts.concurrencyCap
       : DEFAULT_WAVE_CONCURRENCY_CAP;
   const verifyConcurrencyCap =
-    Number.isInteger(opts.verifyConcurrencyCap) && opts.verifyConcurrencyCap >= 1
+    Number.isInteger(opts.verifyConcurrencyCap) &&
+    opts.verifyConcurrencyCap >= 1
       ? opts.verifyConcurrencyCap
       : DEFAULT_VERIFY_CONCURRENCY_CAP;
 
@@ -488,7 +489,7 @@ export function computeWaveParallelismRows(events, opts = {}) {
       const storiesField = Array.isArray(evt.stories) ? evt.stories : [];
       const storyIds = storiesField
         .map((s) => {
-          const n = Number(isObject(s) ? s.id ?? s.storyId : s);
+          const n = Number(isObject(s) ? (s.id ?? s.storyId) : s);
           return Number.isInteger(n) && n > 0 ? n : null;
         })
         .filter((n) => n != null);
@@ -538,7 +539,10 @@ export function computeWaveParallelismRows(events, opts = {}) {
   const rows = [];
   for (const [idx, rec] of orderedWaves) {
     if (rec.startMs == null) continue;
-    const wallClockMs = Math.max(0, Math.floor((rec.endMs ?? rec.startMs) - rec.startMs));
+    const wallClockMs = Math.max(
+      0,
+      Math.floor((rec.endMs ?? rec.startMs) - rec.startMs),
+    );
     let summedStoryMs = 0;
     for (const sid of rec.stories) {
       const w = storyWindows.get(sid);
@@ -549,11 +553,7 @@ export function computeWaveParallelismRows(events, opts = {}) {
     let utilisation = 0;
     let capBinding = false;
     if (wallClockMs > 0 && concurrencyCap > 0) {
-      utilisation = clamp(
-        summedStoryMs / (wallClockMs * concurrencyCap),
-        0,
-        1,
-      );
+      utilisation = clamp(summedStoryMs / (wallClockMs * concurrencyCap), 0, 1);
       capBinding = summedStoryMs / wallClockMs >= concurrencyCap;
     }
     rows.push({

--- a/.agents/scripts/lib/orchestration/finalize/post-handoff-comment.js
+++ b/.agents/scripts/lib/orchestration/finalize/post-handoff-comment.js
@@ -16,10 +16,79 @@
  * Story #2894 / Task #2909 (Epic #2880).
  */
 
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { epicPerfReportJsonPath } from '../../config/temp-paths.js';
 import { Logger } from '../../Logger.js';
 import { upsertStructuredComment as defaultUpsertStructuredComment } from '../ticketing.js';
 
 export const EPIC_HANDOFF_MARKER = 'epic-handoff';
+
+/**
+ * Format a millisecond duration as a compact wall-clock string for the
+ * per-wave perf summary lines. Sub-second values render as `<n>ms`;
+ * second-scale values as `<n.n>s`; minute-scale values as `<m>m<ss>s`.
+ * Story #3029 / Task #3041.
+ *
+ * @param {number} ms
+ * @returns {string}
+ */
+function formatDurationMs(ms) {
+  const n = Number.isFinite(ms) ? Math.max(0, Math.floor(ms)) : 0;
+  if (n < 1000) return `${n}ms`;
+  if (n < 60000) return `${(n / 1000).toFixed(1)}s`;
+  const minutes = Math.floor(n / 60000);
+  const seconds = Math.floor((n % 60000) / 1000);
+  return `${minutes}m${seconds.toString().padStart(2, '0')}s`;
+}
+
+/**
+ * Render the Performance Report section appended to the `epic-handoff`
+ * comment body. Returns an empty string when `perfReport` is null /
+ * undefined (no JSON on disk → section omitted) so callers can splice
+ * the result in unconditionally.
+ *
+ * Output contract (Story #3029 / Task #3041):
+ *   - `## Performance Report` heading
+ *   - One relative link line to `temp/epic-<id>/epic-perf-report.json`
+ *   - One bullet per wave: `Wave N: <wall> wall / <story> story / util <pct>% [cap binding]`
+ *
+ * @param {{
+ *   relativePath: string,
+ *   waveParallelism: Array<{ waveIndex: number, wallClockMs: number, summedStoryMs: number, utilisation: number, capBinding: boolean, verifyConcurrencyCap?: number }>,
+ * } | null | undefined} perfReport
+ * @returns {string}
+ */
+export function renderPerfReportSection(perfReport) {
+  if (!perfReport || typeof perfReport.relativePath !== 'string') return '';
+  const waves = Array.isArray(perfReport.waveParallelism)
+    ? perfReport.waveParallelism
+    : [];
+  const lines = [];
+  lines.push('');
+  lines.push('## Performance Report');
+  lines.push('');
+  lines.push(
+    `Persisted to [\`${perfReport.relativePath}\`](${perfReport.relativePath}).`,
+  );
+  lines.push('');
+  if (waves.length === 0) {
+    lines.push('No wave-parallelism rows recorded.');
+  } else {
+    for (const wave of waves) {
+      const wall = formatDurationMs(wave.wallClockMs);
+      const story = formatDurationMs(wave.summedStoryMs);
+      const util = Number.isFinite(wave.utilisation)
+        ? (wave.utilisation * 100).toFixed(0)
+        : '0';
+      const capLabel = wave.capBinding ? 'cap binding' : 'cap not binding';
+      lines.push(
+        `- Wave ${wave.waveIndex}: ${wall} wall / ${story} story / util ${util}% [${capLabel}]`,
+      );
+    }
+  }
+  return lines.join('\n');
+}
 
 /**
  * Render the `epic-handoff` comment body. Pure helper — exported so the
@@ -30,7 +99,12 @@ export const EPIC_HANDOFF_MARKER = 'epic-handoff';
  * @returns {string} markdown body (without the structured-comment marker
  *   prefix — the marker is prepended by `upsertStructuredComment`).
  */
-export function renderHandoffBody({ epicId, prNumber, prUrl = null } = {}) {
+export function renderHandoffBody({
+  epicId,
+  prNumber,
+  prUrl = null,
+  perfReport = null,
+} = {}) {
   const lines = [];
   lines.push('### 🤝 Epic handoff — PR opened');
   lines.push('');
@@ -44,6 +118,14 @@ export function renderHandoffBody({ epicId, prNumber, prUrl = null } = {}) {
   lines.push(
     'Auto-merge will arm once the watch-and-iterate gate (Phase 8) confirms required checks are green.',
   );
+  // Story #3029 / Task #3041 — Performance Report section. Empty string
+  // is returned when no perf report is available, so the existing body
+  // shape is preserved for handoffs that fire before the close tail has
+  // emitted a report (e.g. legacy replays).
+  const perfSection = renderPerfReportSection(perfReport);
+  if (perfSection.length > 0) {
+    lines.push(perfSection);
+  }
   lines.push('');
   lines.push('```json');
   lines.push(
@@ -55,6 +137,66 @@ export function renderHandoffBody({ epicId, prNumber, prUrl = null } = {}) {
   );
   lines.push('```');
   return lines.join('\n');
+}
+
+/**
+ * Default loader: read the canonical `epic-perf-report.json` written by
+ * the close-tail (`emitEpicPerfReport`) from disk and shape it into the
+ * `{ relativePath, waveParallelism }` envelope `renderPerfReportSection`
+ * expects. Returns `null` on any failure (missing file, malformed JSON,
+ * unreadable directory) so the handoff comment degrades gracefully to
+ * the pre-Story-#3029 body shape rather than blocking the PR open.
+ *
+ * `relativePath` is computed relative to `cwd` so consumers cloning the
+ * repo can follow the link from the rendered comment. When the report
+ * path resolves outside `cwd`, falls back to the absolute path (rare —
+ * happens only for callers that point `tempRoot` outside the repo).
+ *
+ * @param {{ epicId: number, config?: object, cwd?: string }} args
+ * @returns {Promise<{ relativePath: string, waveParallelism: Array<object> } | null>}
+ */
+export async function loadPerfReportFromDisk({
+  epicId,
+  config,
+  cwd = process.cwd(),
+} = {}) {
+  if (!Number.isInteger(epicId) || epicId < 1) return null;
+  let absPath;
+  try {
+    absPath = epicPerfReportJsonPath(epicId, config);
+  } catch {
+    return null;
+  }
+  let raw;
+  try {
+    raw = await fs.readFile(absPath, 'utf8');
+  } catch {
+    return null;
+  }
+  let payload;
+  try {
+    payload = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+  if (!payload || typeof payload !== 'object') return null;
+  let relativePath;
+  try {
+    const rel = path.relative(cwd, absPath);
+    relativePath =
+      rel && !rel.startsWith('..') && !path.isAbsolute(rel) ? rel : absPath;
+    // Normalize Windows backslashes so the rendered Markdown link works
+    // on both POSIX consumers and Windows operators.
+    relativePath = relativePath.split(path.sep).join('/');
+  } catch {
+    relativePath = absPath;
+  }
+  return {
+    relativePath,
+    waveParallelism: Array.isArray(payload.waveParallelism)
+      ? payload.waveParallelism
+      : [],
+  };
 }
 
 /**
@@ -76,6 +218,10 @@ export async function postHandoffComment({
   prNumber,
   prUrl,
   provider,
+  config,
+  cwd,
+  perfReport,
+  loadPerfReportFn = loadPerfReportFromDisk,
   upsertStructuredCommentFn = defaultUpsertStructuredComment,
   logger = Logger,
 } = {}) {
@@ -92,7 +238,27 @@ export async function postHandoffComment({
   if (!provider) {
     throw new TypeError('postHandoffComment: provider is required');
   }
-  const body = renderHandoffBody({ epicId, prNumber, prUrl: prUrl ?? null });
+  // Story #3029 / Task #3041 — if an explicit `perfReport` envelope is
+  // not supplied, fall back to reading the persisted JSON written by
+  // the close-tail. Any loader failure resolves to `null` and the
+  // Performance Report section is silently omitted.
+  let resolvedPerfReport = perfReport;
+  if (resolvedPerfReport === undefined) {
+    try {
+      resolvedPerfReport = await loadPerfReportFn({ epicId, config, cwd });
+    } catch (err) {
+      logger.warn?.(
+        `[finalize/post-handoff-comment] perf-report load failed for Epic #${epicId} (non-fatal): ${err?.message ?? err}`,
+      );
+      resolvedPerfReport = null;
+    }
+  }
+  const body = renderHandoffBody({
+    epicId,
+    prNumber,
+    prUrl: prUrl ?? null,
+    perfReport: resolvedPerfReport,
+  });
   try {
     const result = await upsertStructuredCommentFn(
       provider,

--- a/.agents/scripts/lib/orchestration/preflight-cache.js
+++ b/.agents/scripts/lib/orchestration/preflight-cache.js
@@ -44,7 +44,9 @@ import path from 'node:path';
  */
 export function preflightCachePath({ epicId, cwd }) {
   if (!Number.isInteger(epicId) || epicId <= 0) {
-    throw new TypeError('preflightCachePath: epicId must be a positive integer');
+    throw new TypeError(
+      'preflightCachePath: epicId must be a positive integer',
+    );
   }
   const root = cwd ?? process.cwd();
   return path.join(root, 'temp', `epic-${epicId}`, 'preflight-snapshot.json');
@@ -71,8 +73,7 @@ export function computeBaseSha(epic) {
   const labels = Array.isArray(epic.labels)
     ? [...epic.labels].map(String).sort()
     : [];
-  const updatedAt =
-    typeof epic.updatedAt === 'string' ? epic.updatedAt : null;
+  const updatedAt = typeof epic.updatedAt === 'string' ? epic.updatedAt : null;
   const payload = JSON.stringify({ id, body, labels, updatedAt });
   return createHash('sha256').update(payload).digest('hex');
 }
@@ -128,10 +129,14 @@ export async function writePreflightCache({
   capturedAt,
 }) {
   if (!Number.isInteger(epicId) || epicId <= 0) {
-    throw new TypeError('writePreflightCache: epicId must be a positive integer');
+    throw new TypeError(
+      'writePreflightCache: epicId must be a positive integer',
+    );
   }
   if (typeof baseSha !== 'string' || !baseSha) {
-    throw new TypeError('writePreflightCache: baseSha must be a non-empty string');
+    throw new TypeError(
+      'writePreflightCache: baseSha must be a non-empty string',
+    );
   }
   if (!epic || typeof epic !== 'object') {
     throw new TypeError('writePreflightCache: epic must be an object');

--- a/.agents/scripts/lib/orchestration/preflight-cache.js
+++ b/.agents/scripts/lib/orchestration/preflight-cache.js
@@ -1,0 +1,159 @@
+/**
+ * preflight-cache.js — Epic #3019 / Story #3027.
+ *
+ * Cache adapter for the snapshot/DAG envelope produced by
+ * `epic-deliver-preflight.js` so `epic-deliver-prepare.js` can skip the
+ * second walk of Epic → Feature → Story when the underlying Epic ticket
+ * has not drifted between the two operator invocations.
+ *
+ * Contract:
+ *   - Cache file lives at `<cwd>/temp/epic-<epicId>/preflight-snapshot.json`.
+ *   - Envelope shape:
+ *       {
+ *         epicId: number,
+ *         baseSha: string,        // deterministic fingerprint of the Epic
+ *                                 // snapshot returned by provider.getTicket
+ *         capturedAt: string,     // ISO-8601 timestamp
+ *         epic: object,           // the snapshot from runSnapshotPhase
+ *         stories: object[],      // the open Story tickets from runBuildWaveDagPhase
+ *         waves: Array<Array<object>>, // wave DAG (ids + labels preserved)
+ *       }
+ *   - `computeBaseSha(epic)` derives the cache key from the same provider
+ *     call (`getTicket(epicId)`) used to walk the hierarchy. The hash
+ *     covers the Epic's id, body, labels (sorted), and (when present)
+ *     `updatedAt` — the same fields that drive Story discovery and the
+ *     acceptance-spec gate.
+ *   - Cache miss is signalled by `readCache` returning `null`. Callers
+ *     MUST fall back to a fresh snapshot/DAG pass.
+ *   - `writeCache` creates the parent directory recursively and writes
+ *     atomically (write to `<path>.tmp` then rename).
+ *
+ * The module is pure JS / node:fs — no provider dependency — so tests
+ * can exercise it without spinning up a GitHub mock.
+ */
+
+import { createHash } from 'node:crypto';
+import { mkdir, readFile, rename, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+
+/**
+ * Resolve the on-disk path for an Epic's preflight cache.
+ *
+ * @param {{ epicId: number, cwd?: string }} args
+ * @returns {string}
+ */
+export function preflightCachePath({ epicId, cwd }) {
+  if (!Number.isInteger(epicId) || epicId <= 0) {
+    throw new TypeError('preflightCachePath: epicId must be a positive integer');
+  }
+  const root = cwd ?? process.cwd();
+  return path.join(root, 'temp', `epic-${epicId}`, 'preflight-snapshot.json');
+}
+
+/**
+ * Stable string fingerprint of an Epic snapshot. The hash is keyed on the
+ * exact fields `runSnapshotPhase` reads (`getTicket(epicId)` return value)
+ * so that any drift the snapshot phase would observe forces a cache miss.
+ *
+ * Labels are sorted to absorb GitHub's non-deterministic label order
+ * across responses. The hash is sha256; we return the full hex digest so
+ * the cache key is collision-resistant for the lifetime of a delivery.
+ *
+ * @param {{ id?: number|string, number?: number|string, body?: string, labels?: string[], updatedAt?: string }} epic
+ * @returns {string}
+ */
+export function computeBaseSha(epic) {
+  if (!epic || typeof epic !== 'object') {
+    throw new TypeError('computeBaseSha: epic snapshot must be an object');
+  }
+  const id = epic.id ?? epic.number ?? null;
+  const body = typeof epic.body === 'string' ? epic.body : '';
+  const labels = Array.isArray(epic.labels)
+    ? [...epic.labels].map(String).sort()
+    : [];
+  const updatedAt =
+    typeof epic.updatedAt === 'string' ? epic.updatedAt : null;
+  const payload = JSON.stringify({ id, body, labels, updatedAt });
+  return createHash('sha256').update(payload).digest('hex');
+}
+
+/**
+ * Read the cached preflight envelope from disk. Returns `null` when the
+ * file is missing or unreadable — callers MUST treat that as a cache
+ * miss and fall back to a fresh snapshot/DAG pass.
+ *
+ * The function intentionally swallows `ENOENT` and JSON-parse errors so
+ * a stale or partially-written file does not poison `epic-deliver-prepare`.
+ *
+ * @param {{ epicId: number, cwd?: string }} args
+ * @returns {Promise<object | null>}
+ */
+export async function readPreflightCache({ epicId, cwd }) {
+  const cachePath = preflightCachePath({ epicId, cwd });
+  let raw;
+  try {
+    raw = await readFile(cachePath, 'utf8');
+  } catch (err) {
+    if (err && err.code === 'ENOENT') return null;
+    throw err;
+  }
+  try {
+    const parsed = JSON.parse(raw);
+    if (!parsed || typeof parsed !== 'object') return null;
+    if (parsed.epicId !== epicId) return null;
+    if (typeof parsed.baseSha !== 'string' || !parsed.baseSha) return null;
+    if (!parsed.epic || typeof parsed.epic !== 'object') return null;
+    if (!Array.isArray(parsed.stories)) return null;
+    if (!Array.isArray(parsed.waves)) return null;
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Persist the preflight envelope to disk. Writes atomically via tmp +
+ * rename so concurrent readers never observe a partial file.
+ *
+ * @param {{ epicId: number, baseSha: string, epic: object, stories: object[], waves: Array<Array<object>>, cwd?: string, capturedAt?: string }} args
+ * @returns {Promise<{ cachePath: string, baseSha: string }>}
+ */
+export async function writePreflightCache({
+  epicId,
+  baseSha,
+  epic,
+  stories,
+  waves,
+  cwd,
+  capturedAt,
+}) {
+  if (!Number.isInteger(epicId) || epicId <= 0) {
+    throw new TypeError('writePreflightCache: epicId must be a positive integer');
+  }
+  if (typeof baseSha !== 'string' || !baseSha) {
+    throw new TypeError('writePreflightCache: baseSha must be a non-empty string');
+  }
+  if (!epic || typeof epic !== 'object') {
+    throw new TypeError('writePreflightCache: epic must be an object');
+  }
+  if (!Array.isArray(stories)) {
+    throw new TypeError('writePreflightCache: stories must be an array');
+  }
+  if (!Array.isArray(waves)) {
+    throw new TypeError('writePreflightCache: waves must be an array');
+  }
+  const cachePath = preflightCachePath({ epicId, cwd });
+  await mkdir(path.dirname(cachePath), { recursive: true });
+  const envelope = {
+    epicId,
+    baseSha,
+    capturedAt: capturedAt ?? new Date().toISOString(),
+    epic,
+    stories,
+    waves,
+  };
+  const tmp = `${cachePath}.tmp`;
+  await writeFile(tmp, `${JSON.stringify(envelope, null, 2)}\n`, 'utf8');
+  await rename(tmp, cachePath);
+  return { cachePath, baseSha };
+}

--- a/.agents/scripts/lib/orchestration/retro-perf-heuristics.js
+++ b/.agents/scripts/lib/orchestration/retro-perf-heuristics.js
@@ -1,0 +1,268 @@
+/**
+ * lib/orchestration/retro-perf-heuristics.js — classify perf signals.
+ *
+ * Story #3042 / Task #3045 (Epic #3019). Pure functions that turn the
+ * `epic-perf-report.waveParallelism` row shape (Story #3025) into a flat
+ * list of perf signals. The retro renderer (`./retro/phases/compose-body.js`)
+ * consumes the list to surface a `## Performance Signals` section and a
+ * `## Recommended Follow-Ons` paste-ready stanza per signal.
+ *
+ * Signals (kinds):
+ *
+ *   - `low-utilisation` — any wave whose `utilisation < thresholds.utilisation`.
+ *     One signal per offending wave. The signal carries the wave index and
+ *     the observed utilisation so the renderer can name the offender.
+ *
+ *   - `high-bootstrap-share` — emitted when the summed `story-init` /
+ *     bootstrap phase time across all waves exceeds
+ *     `thresholds.bootstrapShare` of the cumulative `summedStoryMs`. This is
+ *     a single signal across the whole report (not one per wave) because the
+ *     framework remediation is an Epic-wide bootstrap-cost story, not a
+ *     per-wave tweak. The signal payload carries the observed share.
+ *
+ *   - `cap-binding-run` — emitted when `>= thresholds.capBindingRunLength`
+ *     consecutive waves report `capBinding: true`. One signal per maximal
+ *     run, carrying the run's first/last wave index and the run length so
+ *     the renderer can attribute the run-length back to the deliver-runner
+ *     concurrency cap.
+ *
+ * Threshold contract (`.agentrc.json → delivery.retro.perfThresholds`):
+ *
+ *   - `utilisation`: number in [0, 1]. Default 0.6.
+ *   - `bootstrapShare`: number in [0, 1]. Default 0.4.
+ *   - `capBindingRunLength`: positive integer. Default 2.
+ *
+ * The function is total: it never throws on malformed input. A missing or
+ * malformed `report` returns `[]`. A missing `thresholds` falls back to the
+ * documented defaults.
+ */
+
+/**
+ * Defaults mirroring `.agentrc.json → delivery.retro.perfThresholds` so
+ * callers (and tests) can omit `thresholds` and get the same behaviour as
+ * a resolved config with no overrides. Keep in lockstep with
+ * `lib/config/runners.js` (or wherever the resolver default lives) and the
+ * `agentrc.schema.json` defaults stanza.
+ */
+export const DEFAULT_RETRO_PERF_THRESHOLDS = Object.freeze({
+  utilisation: 0.6,
+  bootstrapShare: 0.4,
+  capBindingRunLength: 2,
+});
+
+function isObject(v) {
+  return v != null && typeof v === 'object' && !Array.isArray(v);
+}
+
+function clampUnit(n, fallback) {
+  if (typeof n !== 'number' || !Number.isFinite(n)) return fallback;
+  // Out-of-range values fall back to the documented default rather than
+  // being clamped — operators wiring nonsensical thresholds should see the
+  // safe default applied, not a silent 0/1 substitute that subtly changes
+  // the heuristic.
+  if (n < 0 || n > 1) return fallback;
+  return n;
+}
+
+function positiveInt(n, fallback) {
+  if (typeof n !== 'number' || !Number.isFinite(n)) return fallback;
+  if (!Number.isInteger(n) || n < 1) return fallback;
+  return n;
+}
+
+/**
+ * Resolve the threshold trio against the documented defaults. Exported for
+ * the test surface so callers can verify the fallback semantics in
+ * isolation.
+ *
+ * @param {object|null|undefined} thresholds
+ * @returns {{ utilisation: number, bootstrapShare: number, capBindingRunLength: number }}
+ */
+export function resolvePerfThresholds(thresholds) {
+  const src = isObject(thresholds) ? thresholds : {};
+  return {
+    utilisation: clampUnit(
+      src.utilisation,
+      DEFAULT_RETRO_PERF_THRESHOLDS.utilisation,
+    ),
+    bootstrapShare: clampUnit(
+      src.bootstrapShare,
+      DEFAULT_RETRO_PERF_THRESHOLDS.bootstrapShare,
+    ),
+    capBindingRunLength: positiveInt(
+      src.capBindingRunLength,
+      DEFAULT_RETRO_PERF_THRESHOLDS.capBindingRunLength,
+    ),
+  };
+}
+
+/**
+ * Extract the validated `waveParallelism` rows from the report. Rows whose
+ * `waveIndex` is not a non-negative integer are dropped (the schema requires
+ * one, but the heuristics module must tolerate malformed historical reports).
+ *
+ * @param {object|null|undefined} report
+ * @returns {Array<{ waveIndex: number, wallClockMs: number, summedStoryMs: number, utilisation: number, capBinding: boolean }>}
+ */
+function extractRows(report) {
+  if (!isObject(report)) return [];
+  const arr = Array.isArray(report.waveParallelism)
+    ? report.waveParallelism
+    : [];
+  return arr
+    .filter(
+      (r) =>
+        isObject(r) &&
+        Number.isInteger(r.waveIndex) &&
+        r.waveIndex >= 0,
+    )
+    .map((r) => ({
+      waveIndex: r.waveIndex,
+      wallClockMs:
+        typeof r.wallClockMs === 'number' && r.wallClockMs > 0
+          ? r.wallClockMs
+          : 0,
+      summedStoryMs:
+        typeof r.summedStoryMs === 'number' && r.summedStoryMs > 0
+          ? r.summedStoryMs
+          : 0,
+      utilisation:
+        typeof r.utilisation === 'number' && Number.isFinite(r.utilisation)
+          ? r.utilisation
+          : 0,
+      capBinding: Boolean(r.capBinding),
+    }));
+}
+
+/**
+ * Build the `low-utilisation` signals — one per wave whose `utilisation` is
+ * strictly below the threshold. Returns `[]` when no row crosses the gate.
+ */
+function detectLowUtilisation(rows, threshold) {
+  const out = [];
+  for (const row of rows) {
+    if (row.utilisation < threshold) {
+      out.push({
+        kind: 'low-utilisation',
+        waveIndex: row.waveIndex,
+        utilisation: row.utilisation,
+        threshold,
+      });
+    }
+  }
+  return out;
+}
+
+/**
+ * Sum the bootstrap (story-init) phase time across per-Story summaries on the
+ * report. Returns the absolute milliseconds. Falls back to 0 when no Story
+ * summary in the report carries a `phaseTimingsMs['story-init']` entry — in
+ * that case the share check necessarily returns no signal.
+ */
+function sumBootstrapMs(report) {
+  if (!isObject(report)) return 0;
+  const stories = Array.isArray(report.storyPerfSummaries)
+    ? report.storyPerfSummaries
+    : [];
+  let total = 0;
+  for (const s of stories) {
+    if (!isObject(s)) continue;
+    const timings = isObject(s.phaseTimingsMs) ? s.phaseTimingsMs : null;
+    if (!timings) continue;
+    const v = timings['story-init'];
+    if (typeof v === 'number' && Number.isFinite(v) && v > 0) {
+      total += v;
+    }
+  }
+  return total;
+}
+
+/**
+ * Build the (at-most-one) `high-bootstrap-share` signal. Returns `[]` when
+ * either the cumulative `summedStoryMs` is zero (no wave timing) or the
+ * observed bootstrap share is at-or-below the threshold.
+ */
+function detectHighBootstrapShare(rows, report, threshold) {
+  const totalStoryMs = rows.reduce((acc, r) => acc + r.summedStoryMs, 0);
+  if (totalStoryMs <= 0) return [];
+  const bootstrapMs = sumBootstrapMs(report);
+  if (bootstrapMs <= 0) return [];
+  const share = bootstrapMs / totalStoryMs;
+  if (share <= threshold) return [];
+  return [
+    {
+      kind: 'high-bootstrap-share',
+      share,
+      bootstrapMs,
+      summedStoryMs: totalStoryMs,
+      threshold,
+    },
+  ];
+}
+
+/**
+ * Walk the rows in `waveIndex` order and emit one `cap-binding-run` signal
+ * per maximal run of consecutive `capBinding: true` waves whose length is at
+ * least `threshold`.
+ */
+function detectCapBindingRuns(rows, threshold) {
+  const ordered = [...rows].sort((a, b) => a.waveIndex - b.waveIndex);
+  const out = [];
+  let runStart = null;
+  let runLen = 0;
+  for (let i = 0; i < ordered.length; i += 1) {
+    const row = ordered[i];
+    if (row.capBinding) {
+      if (runStart === null) runStart = row.waveIndex;
+      runLen += 1;
+      // End of array? Flush the run.
+      if (i === ordered.length - 1 && runLen >= threshold) {
+        out.push({
+          kind: 'cap-binding-run',
+          fromWaveIndex: runStart,
+          toWaveIndex: row.waveIndex,
+          runLength: runLen,
+          threshold,
+        });
+      }
+    } else {
+      if (runLen >= threshold && runStart !== null) {
+        out.push({
+          kind: 'cap-binding-run',
+          fromWaveIndex: runStart,
+          toWaveIndex: ordered[i - 1].waveIndex,
+          runLength: runLen,
+          threshold,
+        });
+      }
+      runStart = null;
+      runLen = 0;
+    }
+  }
+  return out;
+}
+
+/**
+ * Classify perf signals from an `epic-perf-report` payload.
+ *
+ * Always returns an array of signal objects. The array is empty when no
+ * signal trips. The caller (retro renderer) is responsible for suppressing
+ * the entire `## Performance Signals` and `## Recommended Follow-Ons`
+ * sections when this returns `[]`.
+ *
+ * @param {object|null|undefined} report   `epic-perf-report` payload.
+ * @param {object|null|undefined} thresholds  Optional override of
+ *   `{ utilisation, bootstrapShare, capBindingRunLength }`. Defaults
+ *   resolve via `DEFAULT_RETRO_PERF_THRESHOLDS`.
+ * @returns {Array<object>} Signal list.
+ */
+export function classifyPerfSignals(report, thresholds) {
+  const resolved = resolvePerfThresholds(thresholds);
+  const rows = extractRows(report);
+  if (rows.length === 0) return [];
+  const signals = [];
+  signals.push(...detectLowUtilisation(rows, resolved.utilisation));
+  signals.push(...detectHighBootstrapShare(rows, report, resolved.bootstrapShare));
+  signals.push(...detectCapBindingRuns(rows, resolved.capBindingRunLength));
+  return signals;
+}

--- a/.agents/scripts/lib/orchestration/retro-perf-heuristics.js
+++ b/.agents/scripts/lib/orchestration/retro-perf-heuristics.js
@@ -111,10 +111,7 @@ function extractRows(report) {
     : [];
   return arr
     .filter(
-      (r) =>
-        isObject(r) &&
-        Number.isInteger(r.waveIndex) &&
-        r.waveIndex >= 0,
+      (r) => isObject(r) && Number.isInteger(r.waveIndex) && r.waveIndex >= 0,
     )
     .map((r) => ({
       waveIndex: r.waveIndex,
@@ -262,7 +259,9 @@ export function classifyPerfSignals(report, thresholds) {
   if (rows.length === 0) return [];
   const signals = [];
   signals.push(...detectLowUtilisation(rows, resolved.utilisation));
-  signals.push(...detectHighBootstrapShare(rows, report, resolved.bootstrapShare));
+  signals.push(
+    ...detectHighBootstrapShare(rows, report, resolved.bootstrapShare),
+  );
   signals.push(...detectCapBindingRuns(rows, resolved.capBindingRunLength));
   return signals;
 }

--- a/.agents/scripts/lib/orchestration/retro-runner.js
+++ b/.agents/scripts/lib/orchestration/retro-runner.js
@@ -115,6 +115,7 @@ export async function runRetro(opts = {}) {
     assembleStateFn = assembleState,
     cwd,
     fsImpl = nodeFs,
+    perfThresholds = null,
   } = opts;
 
   if (!Number.isInteger(epicId) || epicId <= 0) {
@@ -152,6 +153,7 @@ export async function runRetro(opts = {}) {
       cwd,
       fsImpl,
       startedAt,
+      perfThresholds,
       onMirrorWritten: (p) => {
         retroPathWritten = p;
       },

--- a/.agents/scripts/lib/orchestration/retro/phases/compose-body.js
+++ b/.agents/scripts/lib/orchestration/retro/phases/compose-body.js
@@ -10,6 +10,7 @@
  * `manualInterventions` count into the body composer.
  */
 
+import { classifyPerfSignals } from '../../retro-perf-heuristics.js';
 import { isCleanManifest } from '../../retro-heuristics.js';
 
 /**
@@ -53,6 +54,7 @@ export function composeRetroBody(input) {
     epicId,
     epicTitle = `Epic ${epicId}`,
     counts,
+    storyPerfSummaries = [],
     epicPerfReport = null,
     parkedFollowOns = { recuts: [], parked: [] },
     routedProposals = null,
@@ -60,6 +62,7 @@ export function composeRetroBody(input) {
     tasksFirstTry = 0,
     timestamp = new Date().toISOString(),
     forceFull = false,
+    perfThresholds = null,
   } = input;
 
   const interventions = normalizeInterventionCount(counts?.interventions);
@@ -158,6 +161,19 @@ export function composeRetroBody(input) {
       ? ['### Action Items for Next Epic', '', legacyActionItemsBody]
       : routedSectionsBlock;
 
+  // Story #3042 — Performance Signals + Recommended Follow-Ons. Both
+  // sections are emitted only when (1) the persisted epic-perf-report is
+  // present AND (2) `classifyPerfSignals` returns at least one signal.
+  // Otherwise the entire pair is suppressed so the retro stays compact.
+  const perfReportForHeuristics = epicPerfReport
+    ? { ...epicPerfReport, storyPerfSummaries }
+    : null;
+  const perfSignals = perfReportForHeuristics
+    ? classifyPerfSignals(perfReportForHeuristics, perfThresholds)
+    : [];
+  const perfSignalsSection = renderPerfSignalsSection(perfSignals);
+  const followOnsSection = renderFollowOnsSection(perfSignals);
+
   const body = [
     heading,
     '',
@@ -189,9 +205,145 @@ export function composeRetroBody(input) {
     '',
     ...actionSection,
     '',
+    ...perfSignalsSection,
+    ...followOnsSection,
     completeMarker,
   ].join('\n');
   return { body, compact: false, scorecard };
+}
+
+/**
+ * Pure: render the `## Performance Signals` section. Returns `[]` (so the
+ * caller can spread it conditionally) when no signal trips. The renderer
+ * emits one bullet per signal, naming the kind, the offending wave(s),
+ * the observed value, and the threshold that produced the signal.
+ *
+ * @param {Array<object>} signals
+ * @returns {string[]}
+ */
+function renderPerfSignalsSection(signals) {
+  if (!Array.isArray(signals) || signals.length === 0) return [];
+  const lines = ['## Performance Signals', ''];
+  for (const s of signals) {
+    lines.push(`- ${describeSignal(s)}`);
+  }
+  lines.push('');
+  return lines;
+}
+
+/**
+ * Pure: render the `## Recommended Follow-Ons` section. One stanza per
+ * signal, each carrying a Conventional-Commits-shaped title and a body
+ * including the suggested `meta::framework-gap` label.
+ *
+ * Each stanza is a `gh issue create` command operators can paste directly:
+ * the title is in Conventional-Commits form, and the body names the
+ * trigger metric so the planner has the context for triage.
+ *
+ * @param {Array<object>} signals
+ * @returns {string[]}
+ */
+function renderFollowOnsSection(signals) {
+  if (!Array.isArray(signals) || signals.length === 0) return [];
+  const lines = ['## Recommended Follow-Ons', ''];
+  for (const s of signals) {
+    const title = followOnTitle(s);
+    const body = followOnBody(s);
+    lines.push(`- **${title}**`);
+    lines.push('');
+    lines.push('```sh');
+    lines.push(
+      `gh issue create --title ${shellEscape(title)} --label meta::framework-gap --body ${shellEscape(body)}`,
+    );
+    lines.push('```');
+    lines.push('');
+  }
+  return lines;
+}
+
+/**
+ * Human-readable one-liner for a perf signal — used as the bullet text
+ * under `## Performance Signals`. Pure; signal kinds it doesn't know
+ * collapse to a generic shape so the renderer never produces empty
+ * strings for forward-compatible signal kinds.
+ *
+ * @param {object} s
+ * @returns {string}
+ */
+function describeSignal(s) {
+  if (!s || typeof s !== 'object') return 'unknown perf signal';
+  if (s.kind === 'low-utilisation') {
+    const pct = formatPercent(s.utilisation);
+    const thr = formatPercent(s.threshold);
+    return `low-utilisation: wave ${s.waveIndex} ran at ${pct} (threshold ${thr})`;
+  }
+  if (s.kind === 'high-bootstrap-share') {
+    const pct = formatPercent(s.share);
+    const thr = formatPercent(s.threshold);
+    return `high-bootstrap-share: story-init consumed ${pct} of Story execution time (threshold ${thr})`;
+  }
+  if (s.kind === 'cap-binding-run') {
+    return `cap-binding-run: waves ${s.fromWaveIndex}–${s.toWaveIndex} (${s.runLength} consecutive waves) saturated the concurrency cap`;
+  }
+  return `${s.kind ?? 'unknown'} perf signal`;
+}
+
+/**
+ * Conventional-Commits-shaped title for a perf signal's follow-on. Pure.
+ *
+ * @param {object} s
+ * @returns {string}
+ */
+function followOnTitle(s) {
+  if (!s || typeof s !== 'object') return 'perf: investigate unknown perf signal';
+  if (s.kind === 'low-utilisation') {
+    return `perf(epic-deliver): investigate low utilisation in wave ${s.waveIndex}`;
+  }
+  if (s.kind === 'high-bootstrap-share') {
+    return 'perf(story-init): reduce bootstrap share of Story execution time';
+  }
+  if (s.kind === 'cap-binding-run') {
+    return `perf(deliver-runner): raise concurrency cap to break ${s.runLength}-wave cap-binding run`;
+  }
+  return `perf: investigate ${s.kind} signal`;
+}
+
+/**
+ * Body for the paste-ready follow-on stanza. Includes the trigger metric
+ * so the planner has the context for triage.
+ *
+ * @param {object} s
+ * @returns {string}
+ */
+function followOnBody(s) {
+  const trigger = describeSignal(s);
+  return [
+    `Auto-suggested by retro-perf-heuristics (Story #3042).`,
+    ``,
+    `Trigger: ${trigger}.`,
+    ``,
+    `Apply the meta::framework-gap label so /epic-plan Phase 0 surfaces it on the next planning pass.`,
+  ].join('\n');
+}
+
+function formatPercent(n) {
+  if (typeof n !== 'number' || !Number.isFinite(n)) return 'n/a';
+  return `${(n * 100).toFixed(1)}%`;
+}
+
+/**
+ * Minimal POSIX shell-quote for the `gh issue create` paste-ready
+ * command. We single-quote and escape embedded single quotes so the
+ * stanza works under bash/zsh/PowerShell-Core. The retro body is
+ * read-only documentation, so the quoting is a UX convenience, not a
+ * security boundary — but the helper is total nonetheless.
+ *
+ * @param {string} s
+ * @returns {string}
+ */
+function shellEscape(s) {
+  const str = String(s ?? '');
+  return `'${str.replace(/'/g, `'\\''`)}'`;
 }
 
 /**

--- a/.agents/scripts/lib/orchestration/retro/phases/compose-body.js
+++ b/.agents/scripts/lib/orchestration/retro/phases/compose-body.js
@@ -295,7 +295,8 @@ function describeSignal(s) {
  * @returns {string}
  */
 function followOnTitle(s) {
-  if (!s || typeof s !== 'object') return 'perf: investigate unknown perf signal';
+  if (!s || typeof s !== 'object')
+    return 'perf: investigate unknown perf signal';
   if (s.kind === 'low-utilisation') {
     return `perf(epic-deliver): investigate low utilisation in wave ${s.waveIndex}`;
   }

--- a/.agents/scripts/lib/orchestration/retro/phases/compose-body.js
+++ b/.agents/scripts/lib/orchestration/retro/phases/compose-body.js
@@ -10,8 +10,8 @@
  * `manualInterventions` count into the body composer.
  */
 
-import { classifyPerfSignals } from '../../retro-perf-heuristics.js';
 import { isCleanManifest } from '../../retro-heuristics.js';
+import { classifyPerfSignals } from '../../retro-perf-heuristics.js';
 
 /**
  * Pure: clamp a candidate count to a non-negative integer. Used to

--- a/.agents/scripts/lib/orchestration/retro/phases/post-and-mirror.js
+++ b/.agents/scripts/lib/orchestration/retro/phases/post-and-mirror.js
@@ -45,6 +45,7 @@ export async function composeAndPostRetro({
   fsImpl = nodeFs,
   startedAt,
   onMirrorWritten,
+  perfThresholds = null,
 }) {
   const signals = await gatherFn({ epicId, provider, logger });
 
@@ -79,6 +80,7 @@ export async function composeAndPostRetro({
     tasksFirstTry,
     timestamp,
     forceFull,
+    perfThresholds,
   });
 
   const findings = await collectRetroFindings({

--- a/.agents/scripts/lib/orchestration/wave-record-io.js
+++ b/.agents/scripts/lib/orchestration/wave-record-io.js
@@ -21,9 +21,9 @@
  * `node dispatcher.js --dry-run` cold-start cost.
  */
 
+import { Logger } from '../Logger.js';
 import { renderManifestFromManifest } from '../presentation/dispatch-manifest-render.js';
 import { persistManifest } from '../presentation/manifest-persistence.js';
-import { Logger } from '../Logger.js';
 import { resolveAndDispatch } from './dispatch-engine.js';
 import {
   reconcileStoryFromGitHub,

--- a/.agents/scripts/lib/orchestration/wave-record-io.js
+++ b/.agents/scripts/lib/orchestration/wave-record-io.js
@@ -1,30 +1,40 @@
 /**
  * wave-record-io.js — impure helpers for the record-wave CLI: ticket
  * verification, manifest title lookup, returns reconciliation, and the
- * dispatcher refresh hop.
+ * dispatch-manifest refresh hop.
  *
- * These functions all hit the provider (or spawn a subprocess) and are
- * intentionally kept out of `wave-record-projection.js`, which is the pure
- * projection layer. The parent CLI imports both modules and threads the
- * I/O results through the projection.
+ * These functions all hit the provider and are intentionally kept out of
+ * `wave-record-projection.js`, which is the pure projection layer. The
+ * parent CLI imports both modules and threads the I/O results through
+ * the projection.
  *
  * Every entry point here is fire-and-forget on the "best-effort" surfaces
- * (manifest lookup, dispatcher refresh) and explicit-throw on the
+ * (manifest lookup, dispatch-manifest refresh) and explicit-throw on the
  * authoritative ones (`verifyWaveResults` and `resolveResolvedResults`
  * decide what `complete` actually means after the network call lands).
+ *
+ * Story #3026 — `refreshDispatchManifest` replaced the historical
+ * `refreshLocalManifest` subprocess spawn. The refresh runs in-process
+ * through `resolveAndDispatch` + the pure `renderManifest` helper, then
+ * upserts the `dispatch-manifest` structured comment so the Epic ticket
+ * stays in sync with on-disk state without paying the per-wave
+ * `node dispatcher.js --dry-run` cold-start cost.
  */
 
-import { spawn } from 'node:child_process';
-import path from 'node:path';
-import { fileURLToPath } from 'node:url';
-
+import { renderManifestFromManifest } from '../presentation/dispatch-manifest-render.js';
+import { persistManifest } from '../presentation/manifest-persistence.js';
 import { Logger } from '../Logger.js';
+import { resolveAndDispatch } from './dispatch-engine.js';
 import {
   reconcileStoryFromGitHub,
   renderMalformedReturnsFriction,
 } from './epic-runner/sub-agent-return.js';
 import { parseFencedJsonComment } from './structured-comment-parser.js';
-import { findStructuredComment, postStructuredComment } from './ticketing.js';
+import {
+  findStructuredComment,
+  postStructuredComment,
+  upsertStructuredComment,
+} from './ticketing.js';
 import { normalizeReturnsPure } from './wave-record-projection.js';
 
 /**
@@ -166,50 +176,75 @@ export async function resolveResolvedResults({
 }
 
 /**
- * Re-render `temp/epic-<id>/manifest.{md,json}` from live GitHub state.
+ * Re-render the dispatch manifest from live GitHub state and upsert the
+ * `dispatch-manifest` structured comment on the Epic.
  *
- * Spawns `dispatcher.js <epicId> --dry-run` in a subprocess so the existing
- * fetch-Epic / build-manifest / persist-manifest pipeline runs end-to-end
- * without coupling this CLI to the dispatcher internals. Stdout/stderr are
- * piped to a single buffer so failures can be logged but never pollute
- * this script's JSON envelope output.
+ * Story #3026 — runs in-process through `resolveAndDispatch` + the pure
+ * `renderManifest` helper. The historical subprocess spawn of
+ * `dispatcher.js <epicId> --dry-run` is gone: it cost a Node cold start
+ * and a full `.agents/` module graph re-import on every wave tick, and
+ * produced the same comment body the helper now renders directly.
  *
- * @param {{ epicId: number, dispatcherPath?: string, runner?: typeof spawn, scriptsDir?: string }} opts
- * @returns {Promise<void>}
+ * `temp/epic-<id>/manifest.{md,json}` is still re-persisted so the
+ * operator-facing on-disk view stays current — the wave-runner
+ * architecture (Epic #1182) replaced the dispatcher's per-wave refresh
+ * loop and without this hop the manifest is frozen at planning time.
+ *
+ * The function is fail-soft at the persist + upsert boundary so a
+ * transient GitHub blip cannot block the wave loop; the
+ * `resolveAndDispatch` call itself throws as before because that signals
+ * "we cannot read the Epic at all".
+ *
+ * @param {{
+ *   epicId: number,
+ *   provider?: object,
+ *   dispatch?: typeof resolveAndDispatch,
+ *   upsertComment?: typeof upsertStructuredComment,
+ *   persist?: typeof persistManifest,
+ * }} opts
+ * @returns {Promise<{
+ *   epicId: number,
+ *   body: string,
+ *   posted: boolean,
+ *   reason?: string,
+ * }>}
  */
-export async function refreshLocalManifest({
+export async function refreshDispatchManifest({
   epicId,
-  dispatcherPath,
-  runner = spawn,
-  scriptsDir,
-}) {
-  // `lib/orchestration/wave-record-io.js` lives two directories below
-  // `.agents/scripts/`, so resolve the dispatcher relative to that root
-  // unless the caller injected an explicit override.
-  const baseDir =
-    scriptsDir ?? fileURLToPath(new URL('../../', import.meta.url));
-  const dispatcher = dispatcherPath ?? path.join(baseDir, 'dispatcher.js');
-  await new Promise((resolve, reject) => {
-    const child = runner(
-      process.execPath,
-      [dispatcher, String(epicId), '--dry-run'],
-      { stdio: ['ignore', 'pipe', 'pipe'] },
+  provider,
+  dispatch = resolveAndDispatch,
+  upsertComment = upsertStructuredComment,
+  persist = persistManifest,
+} = {}) {
+  if (!Number.isInteger(epicId) || epicId <= 0) {
+    throw new TypeError(
+      'refreshDispatchManifest: epicId must be a positive integer',
     );
-    let stderr = '';
-    child.stderr?.on('data', (chunk) => {
-      stderr += chunk.toString();
-    });
-    child.on('error', reject);
-    child.on('close', (code) => {
-      if (code === 0) {
-        resolve();
-      } else {
-        reject(
-          new Error(
-            `dispatcher.js --dry-run exited ${code}; stderr: ${stderr.slice(0, 500)}`,
-          ),
-        );
-      }
-    });
+  }
+  const manifest = await dispatch({
+    ticketId: epicId,
+    dryRun: true,
+    provider,
   });
+  try {
+    persist(manifest);
+  } catch (err) {
+    Logger.warn(
+      `[wave-record-io] Non-fatal: could not persist manifest for Epic #${epicId} — ${err?.message ?? 'unknown error'}`,
+    );
+  }
+  const body = renderManifestFromManifest(manifest);
+  if (!provider || typeof provider.postComment !== 'function') {
+    return { epicId, body, posted: false, reason: 'no-provider' };
+  }
+  try {
+    await upsertComment(provider, epicId, 'dispatch-manifest', body);
+    return { epicId, body, posted: true };
+  } catch (err) {
+    const message = err?.message ?? String(err);
+    Logger.warn(
+      `[wave-record-io] Non-fatal: could not upsert dispatch-manifest comment for Epic #${epicId} — ${message}`,
+    );
+    return { epicId, body, posted: false, reason: message };
+  }
 }

--- a/.agents/scripts/lib/orchestration/wave-record-io.js
+++ b/.agents/scripts/lib/orchestration/wave-record-io.js
@@ -21,6 +21,7 @@
  * `node dispatcher.js --dry-run` cold-start cost.
  */
 
+import { concurrentMap } from '../util/concurrent-map.js';
 import { Logger } from '../Logger.js';
 import { renderManifestFromManifest } from '../presentation/dispatch-manifest-render.js';
 import { persistManifest } from '../presentation/manifest-persistence.js';
@@ -38,6 +39,13 @@ import {
 import { normalizeReturnsPure } from './wave-record-projection.js';
 
 /**
+ * Default cap for {@link verifyWaveResults}. Mirrors the default for
+ * `delivery.deliverRunner.verifyConcurrencyCap` in `.agentrc.json`
+ * (Epic #3019 Tech Spec §1.4 / Story #3024).
+ */
+const DEFAULT_VERIFY_CONCURRENCY_CAP = 4;
+
+/**
  * Normalize raw `--returns` payload (per-Story sub-agent return texts) into
  * the same shape `validateResults` produces. Entries that fail to parse are
  * reconciled from GitHub and recorded as parse failures; the caller posts a
@@ -53,6 +61,54 @@ export async function normalizeReturns({ provider, returns } = {}) {
 }
 
 /**
+ * Verify a single result row: pass-through when the row is not claiming
+ * `done`, otherwise re-fetch the ticket and emit either the verified row
+ * (label/state agrees) or a `{ verified, discrepancy }` pair when the
+ * claim disagrees with GitHub. Network failures surface as
+ * `verify-error` discrepancies — they cannot prove the claim either way
+ * so the row is downgraded to `failed`.
+ *
+ * Extracted as a per-row mapper so {@link verifyWaveResults} can run the
+ * verifications through {@link concurrentMap} under a bounded cap.
+ *
+ * @param {object} r
+ * @param {{ getTicket: Function }} provider
+ * @returns {Promise<{ verified: object, discrepancy: object|null }>}
+ */
+async function verifySingleResult(r, provider) {
+  if (r.status !== 'done') {
+    return { verified: r, discrepancy: null };
+  }
+  let ticket;
+  try {
+    ticket = await provider.getTicket(r.storyId, { fresh: true });
+  } catch (err) {
+    const message = err?.message ?? String(err);
+    return {
+      verified: { ...r, status: 'failed', verifyError: message },
+      discrepancy: {
+        storyId: r.storyId,
+        claimed: 'done',
+        actual: 'verify-error',
+        verifyError: message,
+      },
+    };
+  }
+  const labels = ticket?.labels ?? [];
+  const isDone = labels.includes('agent::done') || ticket?.state === 'closed';
+  if (isDone) {
+    return { verified: r, discrepancy: null };
+  }
+  const actualLabel =
+    labels.find((l) => typeof l === 'string' && l.startsWith('agent::')) ??
+    'unknown';
+  return {
+    verified: { ...r, status: 'failed' },
+    discrepancy: { storyId: r.storyId, claimed: 'done', actual: actualLabel },
+  };
+}
+
+/**
  * Re-fetch each Story's actual ticket state and downgrade any
  * `status: 'done'` claim whose ticket has not actually reached
  * `agent::done` (or `state: 'closed'`). Returns the verified rows plus
@@ -65,48 +121,44 @@ export async function normalizeReturns({ provider, returns } = {}) {
  * an unverifiable `done` must not let the wave aggregate to `complete`,
  * which is what callers read as "GitHub agrees everything is done."
  *
- * @param {{ provider: { getTicket?: Function }, results: Array<object> }} args
+ * Story #3024 — verification runs through {@link concurrentMap} under a
+ * bounded cap (default 4, override via
+ * `delivery.deliverRunner.verifyConcurrencyCap`). Per-row failures are
+ * captured inside the mapper so one Story's `getTicket` throw cannot
+ * abort the whole wave — the per-row try/catch lives in
+ * {@link verifySingleResult} and turns into a `verify-error`
+ * discrepancy rather than a rejected mapper. Input order is preserved
+ * (mapper-index → output-index), matching the previous serial behaviour.
+ *
+ * @param {{
+ *   provider: { getTicket?: Function },
+ *   results: Array<object>,
+ *   concurrencyCap?: number,
+ * }} args
  */
-export async function verifyWaveResults({ provider, results } = {}) {
+export async function verifyWaveResults({
+  provider,
+  results,
+  concurrencyCap,
+} = {}) {
   if (!provider || typeof provider.getTicket !== 'function') {
     return { verified: results ?? [], discrepancies: [] };
   }
+  const cap =
+    Number.isInteger(concurrencyCap) && concurrencyCap >= 1
+      ? concurrencyCap
+      : DEFAULT_VERIFY_CONCURRENCY_CAP;
+  const rows = results ?? [];
+  const outcomes = await concurrentMap(
+    rows,
+    (r) => verifySingleResult(r, provider),
+    { concurrency: cap },
+  );
   const verified = [];
   const discrepancies = [];
-  for (const r of results ?? []) {
-    if (r.status !== 'done') {
-      verified.push(r);
-      continue;
-    }
-    let ticket;
-    try {
-      ticket = await provider.getTicket(r.storyId, { fresh: true });
-    } catch (err) {
-      const message = err?.message ?? String(err);
-      discrepancies.push({
-        storyId: r.storyId,
-        claimed: 'done',
-        actual: 'verify-error',
-        verifyError: message,
-      });
-      verified.push({ ...r, status: 'failed', verifyError: message });
-      continue;
-    }
-    const labels = ticket?.labels ?? [];
-    const isDone = labels.includes('agent::done') || ticket?.state === 'closed';
-    if (isDone) {
-      verified.push(r);
-      continue;
-    }
-    const actualLabel =
-      labels.find((l) => typeof l === 'string' && l.startsWith('agent::')) ??
-      'unknown';
-    discrepancies.push({
-      storyId: r.storyId,
-      claimed: 'done',
-      actual: actualLabel,
-    });
-    verified.push({ ...r, status: 'failed' });
+  for (const out of outcomes) {
+    verified.push(out.verified);
+    if (out.discrepancy) discrepancies.push(out.discrepancy);
   }
   return { verified, discrepancies };
 }

--- a/.agents/scripts/lib/orchestration/wave-record-io.js
+++ b/.agents/scripts/lib/orchestration/wave-record-io.js
@@ -21,10 +21,10 @@
  * `node dispatcher.js --dry-run` cold-start cost.
  */
 
-import { concurrentMap } from '../util/concurrent-map.js';
 import { Logger } from '../Logger.js';
 import { renderManifestFromManifest } from '../presentation/dispatch-manifest-render.js';
 import { persistManifest } from '../presentation/manifest-persistence.js';
+import { concurrentMap } from '../util/concurrent-map.js';
 import { resolveAndDispatch } from './dispatch-engine.js';
 import {
   reconcileStoryFromGitHub,

--- a/.agents/scripts/lib/presentation/dispatch-manifest-render.js
+++ b/.agents/scripts/lib/presentation/dispatch-manifest-render.js
@@ -1,0 +1,95 @@
+/**
+ * dispatch-manifest-render.js — pure helper that renders the
+ * `dispatch-manifest` structured-comment body posted on an Epic.
+ *
+ * Extracted from `manifest-renderer.js::postManifestEpicComment` so the
+ * wave-runner's manifest refresh hop can render the same Markdown in
+ * process without spawning `dispatcher.js --dry-run`.
+ *
+ * No top-level side effects — safe to import from tests without
+ * triggering GitHub I/O.
+ */
+
+/**
+ * Pure: project a full dispatch manifest into the `{ stories }` shape
+ * `renderManifest` accepts. Returns the canonical, non-feature,
+ * non-ungrouped story rows used by the Epic-level dispatch-manifest
+ * comment.
+ *
+ * @param {object} manifest
+ * @returns {{ storyId: number|string, wave: number, title: string }[]}
+ */
+export function projectStoriesFromManifest(manifest) {
+  const storyManifest = manifest?.storyManifest ?? [];
+  return storyManifest
+    .filter((s) => s && s.type !== 'feature' && s.storyId !== '__ungrouped__')
+    .map((s) => ({
+      storyId: s.storyId,
+      wave: s.earliestWave ?? -1,
+      title: s.storyTitle ?? s.storySlug ?? '',
+    }));
+}
+
+/**
+ * Pure: count distinct, non-(-1) wave indexes across `stories`.
+ *
+ * @param {{ wave: number }[]} stories
+ */
+export function countWaves(stories) {
+  const set = new Set();
+  for (const s of stories ?? []) {
+    if (s && typeof s.wave === 'number' && s.wave !== -1) set.add(s.wave);
+  }
+  return set.size;
+}
+
+/**
+ * Pure: render the dispatch-manifest comment body for an Epic.
+ *
+ * The output is byte-identical to the body
+ * `postManifestEpicComment` historically built inline, so it can be
+ * upserted by either the dispatcher (CLI path) or the wave-runner
+ * (in-process refresh path) without behavioural drift.
+ *
+ * @param {{
+ *   epicId: number,
+ *   stories: { storyId: number|string, wave: number, title: string }[],
+ *   generatedAt: string,
+ * }} args
+ * @returns {string}
+ */
+export function renderManifest({ epicId, stories, generatedAt }) {
+  if (!Number.isFinite(epicId) && typeof epicId !== 'number') {
+    throw new TypeError('renderManifest: epicId is required');
+  }
+  const list = Array.isArray(stories) ? stories : [];
+  const waveCount = countWaves(list);
+  return [
+    `## 📋 Dispatch Manifest — Epic #${epicId}`,
+    '',
+    `- **Waves:** ${waveCount || 1}`,
+    `- **Stories:** ${list.length}`,
+    `- **Generated:** ${generatedAt}`,
+    '',
+    'Source of truth for the wave-completeness gate run at `/epic-deliver`.',
+    '',
+    '```json',
+    JSON.stringify({ stories: list }, null, 2),
+    '```',
+  ].join('\n');
+}
+
+/**
+ * Convenience: render directly from a full manifest object. Equivalent
+ * to `renderManifest({ epicId, stories: projectStoriesFromManifest(m),
+ * generatedAt: m.generatedAt })`.
+ *
+ * @param {object} manifest
+ */
+export function renderManifestFromManifest(manifest) {
+  return renderManifest({
+    epicId: manifest?.epicId,
+    stories: projectStoriesFromManifest(manifest),
+    generatedAt: manifest?.generatedAt,
+  });
+}

--- a/.agents/scripts/lib/presentation/manifest-renderer.js
+++ b/.agents/scripts/lib/presentation/manifest-renderer.js
@@ -17,6 +17,7 @@ import {
   renderParkedFollowOnsComment,
 } from '../orchestration/parked-follow-ons.js';
 import { upsertStructuredComment } from '../orchestration/ticketing.js';
+import { renderManifestFromManifest } from './dispatch-manifest-render.js';
 import {
   buildManifestFromSpec,
   formatManifestMarkdown,
@@ -101,32 +102,10 @@ export async function postManifestEpicComment(manifest, provider) {
   const skipReason = classifyEpicCommentEligibility(manifest, provider);
   if (skipReason) return { posted: false, reason: skipReason };
 
-  const storyManifest = manifest.storyManifest ?? [];
-  const waveEligible = storyManifest.filter((s) => s.type !== 'feature');
-  const waveSet = new Set(
-    waveEligible.map((s) => s.earliestWave).filter((w) => w !== -1),
-  );
-  const stories = waveEligible
-    .filter((s) => s.storyId !== '__ungrouped__')
-    .map((s) => ({
-      storyId: s.storyId,
-      wave: s.earliestWave ?? -1,
-      title: s.storyTitle ?? s.storySlug ?? '',
-    }));
-
-  const body = [
-    `## 📋 Dispatch Manifest — Epic #${manifest.epicId}`,
-    '',
-    `- **Waves:** ${waveSet.size || 1}`,
-    `- **Stories:** ${stories.length}`,
-    `- **Generated:** ${manifest.generatedAt}`,
-    '',
-    'Source of truth for the wave-completeness gate run at `/epic-deliver`.',
-    '',
-    '```json',
-    JSON.stringify({ stories }, null, 2),
-    '```',
-  ].join('\n');
+  // Body rendering lives in the pure `dispatch-manifest-render.js`
+  // helper so the wave-runner's in-process refresh hop can produce a
+  // byte-identical body without spawning `dispatcher.js --dry-run`.
+  const body = renderManifestFromManifest(manifest);
 
   try {
     await upsertStructuredComment(

--- a/.agents/scripts/lib/wave-runner/tick.js
+++ b/.agents/scripts/lib/wave-runner/tick.js
@@ -17,8 +17,8 @@ import { existsSync, readFileSync } from 'node:fs';
 import { epicLedgerPath } from '../config/temp-paths.js';
 import { AGENT_LABELS } from '../label-constants.js';
 import { appendEpicSignal } from '../observability/signals-writer.js';
-import { collectHaltedStoryIds } from '../orchestration/epic-runner/phases/iterate-waves.js';
 import * as epicRunStateStoreModule from '../orchestration/epic-run-state-store.js';
+import { collectHaltedStoryIds } from '../orchestration/epic-runner/phases/iterate-waves.js';
 import { detectRecurringFailures } from '../orchestration/recurring-failure-detector.js';
 import { upsertStructuredComment as defaultUpsertStructuredComment } from '../orchestration/ticketing.js';
 

--- a/.agents/scripts/lib/wave-runner/tick.js
+++ b/.agents/scripts/lib/wave-runner/tick.js
@@ -17,6 +17,7 @@ import { existsSync, readFileSync } from 'node:fs';
 import { epicLedgerPath } from '../config/temp-paths.js';
 import { AGENT_LABELS } from '../label-constants.js';
 import { appendEpicSignal } from '../observability/signals-writer.js';
+import { collectHaltedStoryIds } from '../orchestration/epic-runner/phases/iterate-waves.js';
 import * as epicRunStateStoreModule from '../orchestration/epic-run-state-store.js';
 import { detectRecurringFailures } from '../orchestration/recurring-failure-detector.js';
 import { upsertStructuredComment as defaultUpsertStructuredComment } from '../orchestration/ticketing.js';
@@ -141,12 +142,19 @@ export async function tick(args = {}) {
     wavePlanSize: wavePlan.length,
   };
 
+  // Story #3026 — match the iterate-waves resume-check cache strategy:
+  // only Stories that the checkpoint marks as halted on a prior wave
+  // are force-refreshed. Every other Story serves the tick fetch from
+  // the provider's in-process cache, eliminating the per-wave
+  // `fresh: true` round-trip we historically issued for every Story.
+  const haltedStoryIds = collectHaltedStoryIds(state);
   let waveStates;
   try {
     waveStates = await Promise.all(
       wavePlan.map(async (s) => {
         const id = storyIdOf(s);
-        const ticket = await provider.getTicket(id, { fresh: true });
+        const opts = haltedStoryIds.has(id) ? { fresh: true } : {};
+        const ticket = await provider.getTicket(id, opts);
         return {
           id,
           title: s.title ?? ticket?.title,

--- a/baselines/crap.json
+++ b/baselines/crap.json
@@ -1,106 +1,16 @@
 {
   "$schema": ".agents/schemas/baselines/crap.schema.json",
   "kernelVersion": "0.1.0",
-  "generatedAt": "2026-05-26T20:18:41.910Z",
+  "generatedAt": "2026-05-26T22:03:04.383Z",
   "rollup": {
     "*": {
       "p50": 3,
-      "p95": 12,
+      "p95": 12.006059669598093,
       "max": 52.501371135067686,
       "methodsAbove20": 31
     }
   },
   "rows": [
-    {
-      "path": ".agents/scripts/analyze-execution.js",
-      "method": "readStorySignals",
-      "startLine": 70,
-      "crap": 1
-    },
-    {
-      "path": ".agents/scripts/analyze-execution.js",
-      "method": "readPhaseTimings",
-      "startLine": 89,
-      "crap": 6.141711619769646
-    },
-    {
-      "path": ".agents/scripts/analyze-execution.js",
-      "method": "readGhSpawnCount",
-      "startLine": 117,
-      "crap": 6.189364674940412
-    },
-    {
-      "path": ".agents/scripts/analyze-execution.js",
-      "method": "renderStoryBody",
-      "startLine": 147,
-      "crap": 3
-    },
-    {
-      "path": ".agents/scripts/analyze-execution.js",
-      "method": "renderQualityGateFrictionBlock",
-      "startLine": 192,
-      "crap": 4
-    },
-    {
-      "path": ".agents/scripts/analyze-execution.js",
-      "method": "renderBaselineRefreshRateRow",
-      "startLine": 217,
-      "crap": 4
-    },
-    {
-      "path": ".agents/scripts/analyze-execution.js",
-      "method": "renderEpicBody",
-      "startLine": 236,
-      "crap": 4
-    },
-    {
-      "path": ".agents/scripts/analyze-execution.js",
-      "method": "extractStoryPerfSummaryFromComment",
-      "startLine": 284,
-      "crap": 6.013119533527696
-    },
-    {
-      "path": ".agents/scripts/analyze-execution.js",
-      "method": "runStoryMode",
-      "startLine": 313,
-      "crap": 2.015056241426612
-    },
-    {
-      "path": ".agents/scripts/analyze-execution.js",
-      "method": "collectStorySummaries",
-      "startLine": 367,
-      "crap": 8.215784143518519
-    },
-    {
-      "path": ".agents/scripts/analyze-execution.js",
-      "method": "gatherEpicCommitsFromGit",
-      "startLine": 427,
-      "crap": 4.184216709744554
-    },
-    {
-      "path": ".agents/scripts/analyze-execution.js",
-      "method": "aggregateBaselineFrictionFromSignals",
-      "startLine": 475,
-      "crap": 2.000067432020095
-    },
-    {
-      "path": ".agents/scripts/analyze-execution.js",
-      "method": "runEpicMode",
-      "startLine": 572,
-      "crap": 6.085333333333334
-    },
-    {
-      "path": ".agents/scripts/analyze-execution.js",
-      "method": "parseCli",
-      "startLine": 663,
-      "crap": 10
-    },
-    {
-      "path": ".agents/scripts/analyze-execution.js",
-      "method": "main",
-      "startLine": 691,
-      "crap": 3.131456790123457
-    },
     {
       "path": ".agents/scripts/bootstrap.js",
       "method": "buildQuestions",
@@ -5266,90 +5176,6 @@
       "method": "roundRate",
       "startLine": 210,
       "crap": 2
-    },
-    {
-      "path": ".agents/scripts/lib/observability/perf-aggregator.js",
-      "method": "nonNegativeInt",
-      "startLine": 58,
-      "crap": 3
-    },
-    {
-      "path": ".agents/scripts/lib/observability/perf-aggregator.js",
-      "method": "nonNegativeNumber",
-      "startLine": 64,
-      "crap": 3
-    },
-    {
-      "path": ".agents/scripts/lib/observability/perf-aggregator.js",
-      "method": "frictionByCategory",
-      "startLine": 77,
-      "crap": 5
-    },
-    {
-      "path": ".agents/scripts/lib/observability/perf-aggregator.js",
-      "method": "topSlowPhasesVsBaseline",
-      "startLine": 101,
-      "crap": 11.009944933015534
-    },
-    {
-      "path": ".agents/scripts/lib/observability/perf-aggregator.js",
-      "method": "reworkScore",
-      "startLine": 134,
-      "crap": 9
-    },
-    {
-      "path": ".agents/scripts/lib/observability/perf-aggregator.js",
-      "method": "retryDensity",
-      "startLine": 170,
-      "crap": 6
-    },
-    {
-      "path": ".agents/scripts/lib/observability/perf-aggregator.js",
-      "method": "phaseTimingsMs",
-      "startLine": 192,
-      "crap": 6
-    },
-    {
-      "path": ".agents/scripts/lib/observability/perf-aggregator.js",
-      "method": "computeStoryPerfSummary",
-      "startLine": 212,
-      "crap": 10.013486404018948
-    },
-    {
-      "path": ".agents/scripts/lib/observability/perf-aggregator.js",
-      "method": "collectValidStorySamples",
-      "startLine": 277,
-      "crap": 4
-    },
-    {
-      "path": ".agents/scripts/lib/observability/perf-aggregator.js",
-      "method": "buildSignalCounts",
-      "startLine": 296,
-      "crap": 6
-    },
-    {
-      "path": ".agents/scripts/lib/observability/perf-aggregator.js",
-      "method": "aggregateTopHotspots",
-      "startLine": 334,
-      "crap": 4
-    },
-    {
-      "path": ".agents/scripts/lib/observability/perf-aggregator.js",
-      "method": "computeEpicPerfReport",
-      "startLine": 362,
-      "crap": 8.00204761504837
-    },
-    {
-      "path": ".agents/scripts/lib/observability/perf-aggregator.js",
-      "method": "computeStoryPerfSummaryFromStore",
-      "startLine": 451,
-      "crap": 3.009
-    },
-    {
-      "path": ".agents/scripts/lib/observability/perf-aggregator.js",
-      "method": "computeEpicPerfReportFromStore",
-      "startLine": 490,
-      "crap": 3.0146549969468754
     },
     {
       "path": ".agents/scripts/lib/observability/signals-writer.js",
@@ -10908,36 +10734,6 @@
       "crap": 3
     },
     {
-      "path": ".agents/scripts/lib/orchestration/wave-record-io.js",
-      "method": "normalizeReturns",
-      "startLine": 38,
-      "crap": 1.5787037037037037
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/wave-record-io.js",
-      "method": "verifyWaveResults",
-      "startLine": 60,
-      "crap": 7.854629152150125
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/wave-record-io.js",
-      "method": "loadManifestTitleMap",
-      "startLine": 110,
-      "crap": 5.700539437235749
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/wave-record-io.js",
-      "method": "resolveResolvedResults",
-      "startLine": 137,
-      "crap": 5.286333333333333
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/wave-record-io.js",
-      "method": "refreshLocalManifest",
-      "startLine": 180,
-      "crap": 1.9189600480109739
-    },
-    {
       "path": ".agents/scripts/lib/orchestration/wave-record-notifications.js",
       "method": "buildNotifyFn",
       "startLine": 33,
@@ -11374,42 +11170,6 @@
       "method": "renderImplicitDepBullet",
       "startLine": 288,
       "crap": 2
-    },
-    {
-      "path": ".agents/scripts/lib/presentation/manifest-renderer.js",
-      "method": "renderStoryManifestMarkdown",
-      "startLine": 50,
-      "crap": 1
-    },
-    {
-      "path": ".agents/scripts/lib/presentation/manifest-renderer.js",
-      "method": "isEpicManifest",
-      "startLine": 61,
-      "crap": 4
-    },
-    {
-      "path": ".agents/scripts/lib/presentation/manifest-renderer.js",
-      "method": "providerCanPostComment",
-      "startLine": 72,
-      "crap": 2
-    },
-    {
-      "path": ".agents/scripts/lib/presentation/manifest-renderer.js",
-      "method": "classifyEpicCommentEligibility",
-      "startLine": 84,
-      "crap": 3
-    },
-    {
-      "path": ".agents/scripts/lib/presentation/manifest-renderer.js",
-      "method": "postManifestEpicComment",
-      "startLine": 99,
-      "crap": 3
-    },
-    {
-      "path": ".agents/scripts/lib/presentation/manifest-renderer.js",
-      "method": "postParkedFollowOnsComment",
-      "startLine": 154,
-      "crap": 3
     },
     {
       "path": ".agents/scripts/lib/presentation/manifest-story-views.js",

--- a/baselines/crap.json
+++ b/baselines/crap.json
@@ -1,11 +1,11 @@
 {
   "$schema": ".agents/schemas/baselines/crap.schema.json",
   "kernelVersion": "0.1.0",
-  "generatedAt": "2026-05-26T22:03:04.383Z",
+  "generatedAt": "2026-05-26T22:19:53.079Z",
   "rollup": {
     "*": {
       "p50": 3,
-      "p95": 12.006059669598093,
+      "p95": 12.010699859060178,
       "max": 52.501371135067686,
       "methodsAbove20": 31
     }
@@ -3420,126 +3420,6 @@
       "crap": 3.072
     },
     {
-      "path": ".agents/scripts/lib/config/temp-paths.js",
-      "method": "getResolveConfig",
-      "startLine": 46,
-      "crap": 6
-    },
-    {
-      "path": ".agents/scripts/lib/config/temp-paths.js",
-      "method": "tempRootFrom",
-      "startLine": 67,
-      "crap": 5
-    },
-    {
-      "path": ".agents/scripts/lib/config/temp-paths.js",
-      "method": "tempRootAsync",
-      "startLine": 85,
-      "crap": 1.512
-    },
-    {
-      "path": ".agents/scripts/lib/config/temp-paths.js",
-      "method": "<anon method-1>",
-      "startLine": 91,
-      "crap": 3
-    },
-    {
-      "path": ".agents/scripts/lib/config/temp-paths.js",
-      "method": "<anon method-2>",
-      "startLine": 107,
-      "crap": 4
-    },
-    {
-      "path": ".agents/scripts/lib/config/temp-paths.js",
-      "method": "<anon method-3>",
-      "startLine": 117,
-      "crap": 3
-    },
-    {
-      "path": ".agents/scripts/lib/config/temp-paths.js",
-      "method": "<anon method-4>",
-      "startLine": 126,
-      "crap": 6
-    },
-    {
-      "path": ".agents/scripts/lib/config/temp-paths.js",
-      "method": "epicTempDir",
-      "startLine": 148,
-      "crap": 1
-    },
-    {
-      "path": ".agents/scripts/lib/config/temp-paths.js",
-      "method": "storyTempDir",
-      "startLine": 167,
-      "crap": 2
-    },
-    {
-      "path": ".agents/scripts/lib/config/temp-paths.js",
-      "method": "signalsFile",
-      "startLine": 185,
-      "crap": 1
-    },
-    {
-      "path": ".agents/scripts/lib/config/temp-paths.js",
-      "method": "epicArtifactPath",
-      "startLine": 200,
-      "crap": 1
-    },
-    {
-      "path": ".agents/scripts/lib/config/temp-paths.js",
-      "method": "storyArtifactPath",
-      "startLine": 215,
-      "crap": 1
-    },
-    {
-      "path": ".agents/scripts/lib/config/temp-paths.js",
-      "method": "<anon method-5>",
-      "startLine": 221,
-      "crap": 1
-    },
-    {
-      "path": ".agents/scripts/lib/config/temp-paths.js",
-      "method": "<anon method-6>",
-      "startLine": 223,
-      "crap": 1
-    },
-    {
-      "path": ".agents/scripts/lib/config/temp-paths.js",
-      "method": "<anon method-7>",
-      "startLine": 225,
-      "crap": 1
-    },
-    {
-      "path": ".agents/scripts/lib/config/temp-paths.js",
-      "method": "<anon method-8>",
-      "startLine": 227,
-      "crap": 1
-    },
-    {
-      "path": ".agents/scripts/lib/config/temp-paths.js",
-      "method": "<anon method-9>",
-      "startLine": 229,
-      "crap": 1
-    },
-    {
-      "path": ".agents/scripts/lib/config/temp-paths.js",
-      "method": "<anon method-10>",
-      "startLine": 245,
-      "crap": 1
-    },
-    {
-      "path": ".agents/scripts/lib/config/temp-paths.js",
-      "method": "<anon method-11>",
-      "startLine": 250,
-      "crap": 1
-    },
-    {
-      "path": ".agents/scripts/lib/config/temp-paths.js",
-      "method": "<anon method-12>",
-      "startLine": 252,
-      "crap": 1
-    },
-    {
       "path": ".agents/scripts/lib/config/validate-orchestration.js",
       "method": "validateOrchestrationConfig",
       "startLine": 33,
@@ -3964,18 +3844,6 @@
       "method": "loadEnv",
       "startLine": 7,
       "crap": 2
-    },
-    {
-      "path": ".agents/scripts/lib/epic-close-tail-helpers.js",
-      "method": "closePlanningArtifacts",
-      "startLine": 54,
-      "crap": 1
-    },
-    {
-      "path": ".agents/scripts/lib/epic-close-tail-helpers.js",
-      "method": "verifyAndRecoverEpicClose",
-      "startLine": 135,
-      "crap": 3.000845229151014
     },
     {
       "path": ".agents/scripts/lib/epic-merge-lock.js",

--- a/baselines/crap.json
+++ b/baselines/crap.json
@@ -1,7 +1,7 @@
 {
   "$schema": ".agents/schemas/baselines/crap.schema.json",
   "kernelVersion": "0.1.0",
-  "generatedAt": "2026-05-26T20:18:41.910Z",
+  "generatedAt": "2026-05-26T22:00:01.282Z",
   "rollup": {
     "*": {
       "p50": 3,
@@ -11,96 +11,6 @@
     }
   },
   "rows": [
-    {
-      "path": ".agents/scripts/analyze-execution.js",
-      "method": "readStorySignals",
-      "startLine": 70,
-      "crap": 1
-    },
-    {
-      "path": ".agents/scripts/analyze-execution.js",
-      "method": "readPhaseTimings",
-      "startLine": 89,
-      "crap": 6.141711619769646
-    },
-    {
-      "path": ".agents/scripts/analyze-execution.js",
-      "method": "readGhSpawnCount",
-      "startLine": 117,
-      "crap": 6.189364674940412
-    },
-    {
-      "path": ".agents/scripts/analyze-execution.js",
-      "method": "renderStoryBody",
-      "startLine": 147,
-      "crap": 3
-    },
-    {
-      "path": ".agents/scripts/analyze-execution.js",
-      "method": "renderQualityGateFrictionBlock",
-      "startLine": 192,
-      "crap": 4
-    },
-    {
-      "path": ".agents/scripts/analyze-execution.js",
-      "method": "renderBaselineRefreshRateRow",
-      "startLine": 217,
-      "crap": 4
-    },
-    {
-      "path": ".agents/scripts/analyze-execution.js",
-      "method": "renderEpicBody",
-      "startLine": 236,
-      "crap": 4
-    },
-    {
-      "path": ".agents/scripts/analyze-execution.js",
-      "method": "extractStoryPerfSummaryFromComment",
-      "startLine": 284,
-      "crap": 6.013119533527696
-    },
-    {
-      "path": ".agents/scripts/analyze-execution.js",
-      "method": "runStoryMode",
-      "startLine": 313,
-      "crap": 2.015056241426612
-    },
-    {
-      "path": ".agents/scripts/analyze-execution.js",
-      "method": "collectStorySummaries",
-      "startLine": 367,
-      "crap": 8.215784143518519
-    },
-    {
-      "path": ".agents/scripts/analyze-execution.js",
-      "method": "gatherEpicCommitsFromGit",
-      "startLine": 427,
-      "crap": 4.184216709744554
-    },
-    {
-      "path": ".agents/scripts/analyze-execution.js",
-      "method": "aggregateBaselineFrictionFromSignals",
-      "startLine": 475,
-      "crap": 2.000067432020095
-    },
-    {
-      "path": ".agents/scripts/analyze-execution.js",
-      "method": "runEpicMode",
-      "startLine": 572,
-      "crap": 6.085333333333334
-    },
-    {
-      "path": ".agents/scripts/analyze-execution.js",
-      "method": "parseCli",
-      "startLine": 663,
-      "crap": 10
-    },
-    {
-      "path": ".agents/scripts/analyze-execution.js",
-      "method": "main",
-      "startLine": 691,
-      "crap": 3.131456790123457
-    },
     {
       "path": ".agents/scripts/bootstrap.js",
       "method": "buildQuestions",
@@ -5266,90 +5176,6 @@
       "method": "roundRate",
       "startLine": 210,
       "crap": 2
-    },
-    {
-      "path": ".agents/scripts/lib/observability/perf-aggregator.js",
-      "method": "nonNegativeInt",
-      "startLine": 58,
-      "crap": 3
-    },
-    {
-      "path": ".agents/scripts/lib/observability/perf-aggregator.js",
-      "method": "nonNegativeNumber",
-      "startLine": 64,
-      "crap": 3
-    },
-    {
-      "path": ".agents/scripts/lib/observability/perf-aggregator.js",
-      "method": "frictionByCategory",
-      "startLine": 77,
-      "crap": 5
-    },
-    {
-      "path": ".agents/scripts/lib/observability/perf-aggregator.js",
-      "method": "topSlowPhasesVsBaseline",
-      "startLine": 101,
-      "crap": 11.009944933015534
-    },
-    {
-      "path": ".agents/scripts/lib/observability/perf-aggregator.js",
-      "method": "reworkScore",
-      "startLine": 134,
-      "crap": 9
-    },
-    {
-      "path": ".agents/scripts/lib/observability/perf-aggregator.js",
-      "method": "retryDensity",
-      "startLine": 170,
-      "crap": 6
-    },
-    {
-      "path": ".agents/scripts/lib/observability/perf-aggregator.js",
-      "method": "phaseTimingsMs",
-      "startLine": 192,
-      "crap": 6
-    },
-    {
-      "path": ".agents/scripts/lib/observability/perf-aggregator.js",
-      "method": "computeStoryPerfSummary",
-      "startLine": 212,
-      "crap": 10.013486404018948
-    },
-    {
-      "path": ".agents/scripts/lib/observability/perf-aggregator.js",
-      "method": "collectValidStorySamples",
-      "startLine": 277,
-      "crap": 4
-    },
-    {
-      "path": ".agents/scripts/lib/observability/perf-aggregator.js",
-      "method": "buildSignalCounts",
-      "startLine": 296,
-      "crap": 6
-    },
-    {
-      "path": ".agents/scripts/lib/observability/perf-aggregator.js",
-      "method": "aggregateTopHotspots",
-      "startLine": 334,
-      "crap": 4
-    },
-    {
-      "path": ".agents/scripts/lib/observability/perf-aggregator.js",
-      "method": "computeEpicPerfReport",
-      "startLine": 362,
-      "crap": 8.00204761504837
-    },
-    {
-      "path": ".agents/scripts/lib/observability/perf-aggregator.js",
-      "method": "computeStoryPerfSummaryFromStore",
-      "startLine": 451,
-      "crap": 3.009
-    },
-    {
-      "path": ".agents/scripts/lib/observability/perf-aggregator.js",
-      "method": "computeEpicPerfReportFromStore",
-      "startLine": 490,
-      "crap": 3.0146549969468754
     },
     {
       "path": ".agents/scripts/lib/observability/signals-writer.js",

--- a/baselines/crap.json
+++ b/baselines/crap.json
@@ -1,11 +1,11 @@
 {
   "$schema": ".agents/schemas/baselines/crap.schema.json",
   "kernelVersion": "0.1.0",
-  "generatedAt": "2026-05-26T22:03:04.383Z",
+  "generatedAt": "2026-05-26T22:24:49.218Z",
   "rollup": {
     "*": {
       "p50": 3,
-      "p95": 12.006059669598093,
+      "p95": 12.010699859060178,
       "max": 52.501371135067686,
       "methodsAbove20": 31
     }
@@ -3342,12 +3342,6 @@
       "crap": 1
     },
     {
-      "path": ".agents/scripts/lib/config/runners.js",
-      "method": "getRunners",
-      "startLine": 56,
-      "crap": 1
-    },
-    {
       "path": ".agents/scripts/lib/config/runtime.js",
       "method": "resolveWorktreeEnabled",
       "startLine": 32,
@@ -3418,126 +3412,6 @@
       "method": "previewValue",
       "startLine": 234,
       "crap": 3.072
-    },
-    {
-      "path": ".agents/scripts/lib/config/temp-paths.js",
-      "method": "getResolveConfig",
-      "startLine": 46,
-      "crap": 6
-    },
-    {
-      "path": ".agents/scripts/lib/config/temp-paths.js",
-      "method": "tempRootFrom",
-      "startLine": 67,
-      "crap": 5
-    },
-    {
-      "path": ".agents/scripts/lib/config/temp-paths.js",
-      "method": "tempRootAsync",
-      "startLine": 85,
-      "crap": 1.512
-    },
-    {
-      "path": ".agents/scripts/lib/config/temp-paths.js",
-      "method": "<anon method-1>",
-      "startLine": 91,
-      "crap": 3
-    },
-    {
-      "path": ".agents/scripts/lib/config/temp-paths.js",
-      "method": "<anon method-2>",
-      "startLine": 107,
-      "crap": 4
-    },
-    {
-      "path": ".agents/scripts/lib/config/temp-paths.js",
-      "method": "<anon method-3>",
-      "startLine": 117,
-      "crap": 3
-    },
-    {
-      "path": ".agents/scripts/lib/config/temp-paths.js",
-      "method": "<anon method-4>",
-      "startLine": 126,
-      "crap": 6
-    },
-    {
-      "path": ".agents/scripts/lib/config/temp-paths.js",
-      "method": "epicTempDir",
-      "startLine": 148,
-      "crap": 1
-    },
-    {
-      "path": ".agents/scripts/lib/config/temp-paths.js",
-      "method": "storyTempDir",
-      "startLine": 167,
-      "crap": 2
-    },
-    {
-      "path": ".agents/scripts/lib/config/temp-paths.js",
-      "method": "signalsFile",
-      "startLine": 185,
-      "crap": 1
-    },
-    {
-      "path": ".agents/scripts/lib/config/temp-paths.js",
-      "method": "epicArtifactPath",
-      "startLine": 200,
-      "crap": 1
-    },
-    {
-      "path": ".agents/scripts/lib/config/temp-paths.js",
-      "method": "storyArtifactPath",
-      "startLine": 215,
-      "crap": 1
-    },
-    {
-      "path": ".agents/scripts/lib/config/temp-paths.js",
-      "method": "<anon method-5>",
-      "startLine": 221,
-      "crap": 1
-    },
-    {
-      "path": ".agents/scripts/lib/config/temp-paths.js",
-      "method": "<anon method-6>",
-      "startLine": 223,
-      "crap": 1
-    },
-    {
-      "path": ".agents/scripts/lib/config/temp-paths.js",
-      "method": "<anon method-7>",
-      "startLine": 225,
-      "crap": 1
-    },
-    {
-      "path": ".agents/scripts/lib/config/temp-paths.js",
-      "method": "<anon method-8>",
-      "startLine": 227,
-      "crap": 1
-    },
-    {
-      "path": ".agents/scripts/lib/config/temp-paths.js",
-      "method": "<anon method-9>",
-      "startLine": 229,
-      "crap": 1
-    },
-    {
-      "path": ".agents/scripts/lib/config/temp-paths.js",
-      "method": "<anon method-10>",
-      "startLine": 245,
-      "crap": 1
-    },
-    {
-      "path": ".agents/scripts/lib/config/temp-paths.js",
-      "method": "<anon method-11>",
-      "startLine": 250,
-      "crap": 1
-    },
-    {
-      "path": ".agents/scripts/lib/config/temp-paths.js",
-      "method": "<anon method-12>",
-      "startLine": 252,
-      "crap": 1
     },
     {
       "path": ".agents/scripts/lib/config/validate-orchestration.js",
@@ -3964,18 +3838,6 @@
       "method": "loadEnv",
       "startLine": 7,
       "crap": 2
-    },
-    {
-      "path": ".agents/scripts/lib/epic-close-tail-helpers.js",
-      "method": "closePlanningArtifacts",
-      "startLine": 54,
-      "crap": 1
-    },
-    {
-      "path": ".agents/scripts/lib/epic-close-tail-helpers.js",
-      "method": "verifyAndRecoverEpicClose",
-      "startLine": 135,
-      "crap": 3.000845229151014
     },
     {
       "path": ".agents/scripts/lib/epic-merge-lock.js",

--- a/baselines/crap.json
+++ b/baselines/crap.json
@@ -1,11 +1,11 @@
 {
   "$schema": ".agents/schemas/baselines/crap.schema.json",
   "kernelVersion": "0.1.0",
-  "generatedAt": "2026-05-26T22:24:49.218Z",
+  "generatedAt": "2026-05-26T22:49:31.214Z",
   "rollup": {
     "*": {
       "p50": 3,
-      "p95": 12.010699859060178,
+      "p95": 12.006059669598093,
       "max": 52.501371135067686,
       "methodsAbove20": 31
     }
@@ -3094,42 +3094,6 @@
       "method": "formatMaintainabilityProjection",
       "startLine": 278,
       "crap": 4
-    },
-    {
-      "path": ".agents/scripts/lib/config-resolver.js",
-      "method": "applyGithubDefaults",
-      "startLine": 110,
-      "crap": 2
-    },
-    {
-      "path": ".agents/scripts/lib/config-resolver.js",
-      "method": "applyCommandsDefaults",
-      "startLine": 123,
-      "crap": 1
-    },
-    {
-      "path": ".agents/scripts/lib/config-resolver.js",
-      "method": "applyDeliveryDefaults",
-      "startLine": 133,
-      "crap": 1
-    },
-    {
-      "path": ".agents/scripts/lib/config-resolver.js",
-      "method": "applyDefaults",
-      "startLine": 146,
-      "crap": 3
-    },
-    {
-      "path": ".agents/scripts/lib/config-resolver.js",
-      "method": "buildLegacyShim",
-      "startLine": 178,
-      "crap": 2
-    },
-    {
-      "path": ".agents/scripts/lib/config-resolver.js",
-      "method": "resolveConfig",
-      "startLine": 230,
-      "crap": 9
     },
     {
       "path": ".agents/scripts/lib/config/baselines.js",
@@ -8668,96 +8632,6 @@
       "method": "composeRoutedProposals",
       "startLine": 293,
       "crap": 18.00029650589763
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/retro-runner.js",
-      "method": "sumFriction",
-      "startLine": 59,
-      "crap": 6
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/retro-runner.js",
-      "method": "collectDescendants",
-      "startLine": 77,
-      "crap": 4
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/retro-runner.js",
-      "method": "warnIfEpicLooksPopulated",
-      "startLine": 120,
-      "crap": 4.291587694999271
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/retro-runner.js",
-      "method": "gatherRetroSignals",
-      "startLine": 162,
-      "crap": 12.027811485254988
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/retro-runner.js",
-      "method": "normalizeInterventionCount",
-      "startLine": 342,
-      "crap": 4
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/retro-runner.js",
-      "method": "composeRetroBody",
-      "startLine": 372,
-      "crap": 10.000885645167903
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/retro-runner.js",
-      "method": "renderRoutedSections",
-      "startLine": 527,
-      "crap": 16
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/retro-runner.js",
-      "method": "runRetro",
-      "startLine": 655,
-      "crap": 9.00173611111111
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/retro-runner.js",
-      "method": "<anon method-13>",
-      "startLine": 709,
-      "crap": 1
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/retro-runner.js",
-      "method": "composeAndPostRetro",
-      "startLine": 733,
-      "crap": 6.001684664942517
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/retro-runner.js",
-      "method": "collectRetroFindings",
-      "startLine": 851,
-      "crap": 2.053989849908217
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/retro-runner.js",
-      "method": "appendChecksSection",
-      "startLine": 891,
-      "crap": 4
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/retro-runner.js",
-      "method": "escapeCell",
-      "startLine": 901,
-      "crap": 1
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/retro-runner.js",
-      "method": "renderFindingRow",
-      "startLine": 905,
-      "crap": 1
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/retro-runner.js",
-      "method": "renderFindingsSection",
-      "startLine": 913,
-      "crap": 1
     },
     {
       "path": ".agents/scripts/lib/orchestration/review-providers/codex.js",

--- a/baselines/maintainability.json
+++ b/baselines/maintainability.json
@@ -1,12 +1,12 @@
 {
   "$schema": ".agents/schemas/baselines/maintainability.schema.json",
   "kernelVersion": "0.1.0",
-  "generatedAt": "2026-05-26T22:03:04.080Z",
+  "generatedAt": "2026-05-26T22:19:52.780Z",
   "rollup": {
     "*": {
       "min": 52.885,
-      "p50": 104.033,
-      "p95": 121.479
+      "p50": 104.034,
+      "p95": 121.484
     }
   },
   "rows": [
@@ -69,10 +69,6 @@
     {
       "path": ".agents/scripts/drain-pending-cleanup.js",
       "mi": 106.069
-    },
-    {
-      "path": ".agents/scripts/epic-close.js",
-      "mi": 97.229
     },
     {
       "path": ".agents/scripts/epic-deliver-note-intervention.js",
@@ -439,10 +435,6 @@
       "mi": 89.732
     },
     {
-      "path": ".agents/scripts/lib/config/temp-paths.js",
-      "mi": 115.364
-    },
-    {
       "path": ".agents/scripts/lib/config/validate-orchestration.js",
       "mi": 90.007
     },
@@ -489,10 +481,6 @@
     {
       "path": ".agents/scripts/lib/env-loader.js",
       "mi": 102.643
-    },
-    {
-      "path": ".agents/scripts/lib/epic-close-tail-helpers.js",
-      "mi": 86.611
     },
     {
       "path": ".agents/scripts/lib/epic-merge-lock.js",

--- a/baselines/maintainability.json
+++ b/baselines/maintainability.json
@@ -1,11 +1,11 @@
 {
   "$schema": ".agents/schemas/baselines/maintainability.schema.json",
   "kernelVersion": "0.1.0",
-  "generatedAt": "2026-05-22T19:41:38.387Z",
+  "generatedAt": "2026-05-26T22:03:04.080Z",
   "rollup": {
     "*": {
       "min": 52.885,
-      "p50": 103.928,
+      "p50": 104.033,
       "p95": 121.479
     }
   },
@@ -17,10 +17,6 @@
     {
       "path": ".agents/scripts/agents-bootstrap-github.js",
       "mi": 90.654
-    },
-    {
-      "path": ".agents/scripts/analyze-execution.js",
-      "mi": 92.659
     },
     {
       "path": ".agents/scripts/assert-branch.js",
@@ -81,14 +77,6 @@
     {
       "path": ".agents/scripts/epic-deliver-note-intervention.js",
       "mi": 86.917
-    },
-    {
-      "path": ".agents/scripts/epic-deliver-prepare.js",
-      "mi": 88.724
-    },
-    {
-      "path": ".agents/scripts/epic-execute-record-wave.js",
-      "mi": 86.415
     },
     {
       "path": ".agents/scripts/epic-plan-clarity.js",
@@ -631,10 +619,6 @@
       "mi": 92.391
     },
     {
-      "path": ".agents/scripts/lib/observability/perf-aggregator.js",
-      "mi": 90.921
-    },
-    {
       "path": ".agents/scripts/lib/observability/signals-writer.js",
       "mi": 88.188
     },
@@ -1067,10 +1051,6 @@
       "mi": 117.783
     },
     {
-      "path": ".agents/scripts/lib/orchestration/wave-record-io.js",
-      "mi": 101.734
-    },
-    {
       "path": ".agents/scripts/lib/orchestration/wave-record-notifications.js",
       "mi": 98.996
     },
@@ -1117,10 +1097,6 @@
     {
       "path": ".agents/scripts/lib/presentation/manifest-render-waves.js",
       "mi": 99.181
-    },
-    {
-      "path": ".agents/scripts/lib/presentation/manifest-renderer.js",
-      "mi": 106.634
     },
     {
       "path": ".agents/scripts/lib/presentation/manifest-story-views.js",
@@ -2007,10 +1983,6 @@
       "mi": 91.379
     },
     {
-      "path": "tests/epic-execute/epic-execute-record-wave.test.js",
-      "mi": 100.065
-    },
-    {
       "path": "tests/epic-plan-clarity.test.js",
       "mi": 112.367
     },
@@ -2593,10 +2565,6 @@
     {
       "path": "tests/lib/observability/perf-aggregator.regression.test.js",
       "mi": 109.72
-    },
-    {
-      "path": "tests/lib/observability/perf-aggregator.test.js",
-      "mi": 93.272
     },
     {
       "path": "tests/lib/observability/render/epic-perf-report-hotspot.test.js",
@@ -3397,10 +3365,6 @@
     {
       "path": "tests/schemas/epic-perf-report.schema.test.js",
       "mi": 104.452
-    },
-    {
-      "path": "tests/schemas/signal-schemas.test.js",
-      "mi": 106.52
     },
     {
       "path": "tests/scripts/agents-bootstrap-github-protection.test.js",

--- a/baselines/maintainability.json
+++ b/baselines/maintainability.json
@@ -1,11 +1,11 @@
 {
   "$schema": ".agents/schemas/baselines/maintainability.schema.json",
   "kernelVersion": "0.1.0",
-  "generatedAt": "2026-05-22T19:41:38.387Z",
+  "generatedAt": "2026-05-26T22:00:00.968Z",
   "rollup": {
     "*": {
       "min": 52.885,
-      "p50": 103.928,
+      "p50": 104.017,
       "p95": 121.479
     }
   },
@@ -17,10 +17,6 @@
     {
       "path": ".agents/scripts/agents-bootstrap-github.js",
       "mi": 90.654
-    },
-    {
-      "path": ".agents/scripts/analyze-execution.js",
-      "mi": 92.659
     },
     {
       "path": ".agents/scripts/assert-branch.js",
@@ -81,10 +77,6 @@
     {
       "path": ".agents/scripts/epic-deliver-note-intervention.js",
       "mi": 86.917
-    },
-    {
-      "path": ".agents/scripts/epic-deliver-prepare.js",
-      "mi": 88.724
     },
     {
       "path": ".agents/scripts/epic-execute-record-wave.js",
@@ -629,10 +621,6 @@
     {
       "path": ".agents/scripts/lib/observability/baseline-refresh-rate.js",
       "mi": 92.391
-    },
-    {
-      "path": ".agents/scripts/lib/observability/perf-aggregator.js",
-      "mi": 90.921
     },
     {
       "path": ".agents/scripts/lib/observability/signals-writer.js",
@@ -2595,10 +2583,6 @@
       "mi": 109.72
     },
     {
-      "path": "tests/lib/observability/perf-aggregator.test.js",
-      "mi": 93.272
-    },
-    {
       "path": "tests/lib/observability/render/epic-perf-report-hotspot.test.js",
       "mi": 104.293
     },
@@ -3397,10 +3381,6 @@
     {
       "path": "tests/schemas/epic-perf-report.schema.test.js",
       "mi": 104.452
-    },
-    {
-      "path": "tests/schemas/signal-schemas.test.js",
-      "mi": 106.52
     },
     {
       "path": "tests/scripts/agents-bootstrap-github-protection.test.js",

--- a/baselines/maintainability.json
+++ b/baselines/maintainability.json
@@ -1,12 +1,12 @@
 {
   "$schema": ".agents/schemas/baselines/maintainability.schema.json",
   "kernelVersion": "0.1.0",
-  "generatedAt": "2026-05-26T22:03:04.080Z",
+  "generatedAt": "2026-05-26T22:24:48.897Z",
   "rollup": {
     "*": {
       "min": 52.885,
       "p50": 104.033,
-      "p95": 121.479
+      "p95": 121.484
     }
   },
   "rows": [
@@ -69,10 +69,6 @@
     {
       "path": ".agents/scripts/drain-pending-cleanup.js",
       "mi": 106.069
-    },
-    {
-      "path": ".agents/scripts/epic-close.js",
-      "mi": 97.229
     },
     {
       "path": ".agents/scripts/epic-deliver-note-intervention.js",
@@ -423,10 +419,6 @@
       "mi": 84.456
     },
     {
-      "path": ".agents/scripts/lib/config/runners.js",
-      "mi": 104.754
-    },
-    {
       "path": ".agents/scripts/lib/config/runtime.js",
       "mi": 99.384
     },
@@ -437,10 +429,6 @@
     {
       "path": ".agents/scripts/lib/config/sync-agentrc.js",
       "mi": 89.732
-    },
-    {
-      "path": ".agents/scripts/lib/config/temp-paths.js",
-      "mi": 115.364
     },
     {
       "path": ".agents/scripts/lib/config/validate-orchestration.js",
@@ -489,10 +477,6 @@
     {
       "path": ".agents/scripts/lib/env-loader.js",
       "mi": 102.643
-    },
-    {
-      "path": ".agents/scripts/lib/epic-close-tail-helpers.js",
-      "mi": 86.611
     },
     {
       "path": ".agents/scripts/lib/epic-merge-lock.js",
@@ -2341,10 +2325,6 @@
     {
       "path": "tests/lib/config-resolver.test.js",
       "mi": 103.732
-    },
-    {
-      "path": "tests/lib/config-runners.test.js",
-      "mi": 112.579
     },
     {
       "path": "tests/lib/config/github.test.js",

--- a/baselines/maintainability.json
+++ b/baselines/maintainability.json
@@ -1,7 +1,7 @@
 {
   "$schema": ".agents/schemas/baselines/maintainability.schema.json",
   "kernelVersion": "0.1.0",
-  "generatedAt": "2026-05-22T19:41:38.387Z",
+  "generatedAt": "2026-05-26T21:55:35.465Z",
   "rollup": {
     "*": {
       "min": 52.885,
@@ -81,10 +81,6 @@
     {
       "path": ".agents/scripts/epic-deliver-note-intervention.js",
       "mi": 86.917
-    },
-    {
-      "path": ".agents/scripts/epic-deliver-prepare.js",
-      "mi": 88.724
     },
     {
       "path": ".agents/scripts/epic-execute-record-wave.js",

--- a/baselines/maintainability.json
+++ b/baselines/maintainability.json
@@ -1,7 +1,7 @@
 {
   "$schema": ".agents/schemas/baselines/maintainability.schema.json",
   "kernelVersion": "0.1.0",
-  "generatedAt": "2026-05-26T22:24:48.897Z",
+  "generatedAt": "2026-05-26T22:49:30.839Z",
   "rollup": {
     "*": {
       "min": 52.885,
@@ -897,10 +897,6 @@
     {
       "path": ".agents/scripts/lib/orchestration/retro-heuristics.js",
       "mi": 112.227
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/retro-runner.js",
-      "mi": 87.227
     },
     {
       "path": ".agents/scripts/lib/orchestration/spec-renderer.js",

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -127,6 +127,7 @@ top-level keys are validation errors.
 | `deliverRunner` | No | `object` | — | Nested configuration block. |
 | `deliverRunner.concurrencyCap` | No | `integer` | — | — |
 | `deliverRunner.progressReportIntervalSec` | No | `integer` | — | — |
+| `deliverRunner.verifyConcurrencyCap` | No | `integer` | — | Bounded-concurrency cap for the per-wave verifyWaveResults loop (Epic #3019 Tech Spec §1.4). Separate from the wave-execution `concurrencyCap` so operators can tune ticket-verification parallelism independently of Story dispatch parallelism. Default 4. |
 | `worktreeIsolation` | No | `object` | — | Nested configuration block. |
 | `worktreeIsolation.enabled` | No | `boolean` | — | — |
 | `worktreeIsolation.root` | No | `string` | — | — |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -255,6 +255,11 @@ top-level keys are validation errors.
 | `codeReview.providerConfig` | No | `object` | — | Optional escape hatch for adapter-specific configuration. No documented keys in Epic #2815; reserved so future adapters can be configured without another schema migration. |
 | `codeReview.maxFixAttempts` | No | `integer` | — | Maximum auto-fix retry attempts per finding in /epic-deliver Phase 5 (code-review). 0 disables auto-fix. Default 3. |
 | `codeReview.maxFixScopeFiles` | No | `integer` | — | Maximum file count a single auto-fix may modify before escalating to agent::blocked. Default 5. |
+| `retro` | No | `object` | — | Story #3042 (Epic #3019). Operator-tunable retro behaviour. Currently exposes `perfThresholds`, the gates the retro perf-signals classifier uses to decide which signals to surface in the `## Performance Signals` / `## Recommended Follow-Ons` retro sections. |
+| `retro.perfThresholds` | No | `object` | — | Gates for `classifyPerfSignals` (lib/orchestration/retro-perf-heuristics.js). Defaults are 0.6 / 0.4 / 2. |
+| `retro.perfThresholds.utilisation` | No | `number` | — | Per-wave utilisation threshold. Waves whose `utilisation` is strictly below this value emit a `low-utilisation` signal. Default 0.6. |
+| `retro.perfThresholds.bootstrapShare` | No | `number` | — | Maximum acceptable share of cumulative Story execution time spent in the story-init phase. When exceeded the retro emits a `high-bootstrap-share` signal. Default 0.4. |
+| `retro.perfThresholds.capBindingRunLength` | No | `integer` | — | Minimum run length of consecutive cap-binding waves before the retro emits a `cap-binding-run` signal. Default 2. |
 | `ci` | No | `object` | — | Nested configuration block. |
 | `ci.skipForStoryPushes` | No | `boolean` | — | Story #2899 (Epic #2880, F13). When true (default), task-commit.js appends a '[skip ci]' trailer to per-Task Story-branch commit subjects so per-Task pushes do not stampede the CI fleet. The Epic-branch merge commit produced by story-close.js never carries the marker, regardless of this flag. |
 | `preflight` | No | `object` | — | Story #2899 (Epic #2880, F13). Thresholds consumed by `.agents/scripts/epic-deliver-preflight.js`. When any value is exceeded the preflight envelope flags a breach and /epic-deliver Phase 1 surfaces it via agent::blocked. |

--- a/tests/agentrc-retro-perf-thresholds.test.js
+++ b/tests/agentrc-retro-perf-thresholds.test.js
@@ -1,0 +1,163 @@
+// tests/agentrc-retro-perf-thresholds.test.js
+/**
+ * Story #3042 / Task #3043 — `delivery.retro.perfThresholds` config keys.
+ *
+ * Confirms:
+ *   - The static JSON Schema (`agentrc.schema.json`) accepts the keys with
+ *     correct types/bounds and rejects invalid values.
+ *   - The mirror schema (`config-settings-schema.js`) exposes the same
+ *     shape under `delivery.retro.perfThresholds`.
+ *   - `getRetro(config)` exposes resolved keys with defaults 0.6 / 0.4 / 2
+ *     when `.agentrc.json` omits them, and forwards a configured value.
+ */
+
+import { strict as assert } from 'node:assert';
+import { readFile } from 'node:fs/promises';
+import { describe, it } from 'node:test';
+import { fileURLToPath } from 'node:url';
+import Ajv from 'ajv/dist/2020.js';
+
+import { getRetro } from '../.agents/scripts/lib/config/retro.js';
+import { AGENTRC_SCHEMA } from '../.agents/scripts/lib/config-settings-schema.js';
+
+const REPO_ROOT = fileURLToPath(new URL('..', import.meta.url));
+
+async function loadAgentRcSchema() {
+  const path = `${REPO_ROOT}.agents/schemas/agentrc.schema.json`;
+  const raw = await readFile(path, 'utf8');
+  return JSON.parse(raw);
+}
+
+function compileRetroValidator(rootSchema) {
+  const ajv = new Ajv({ allErrors: true, strict: false });
+  ajv.addSchema(rootSchema, 'agentrc.schema.json');
+  return ajv.compile({ $ref: 'agentrc.schema.json#/$defs/retro' });
+}
+
+describe('delivery.retro.perfThresholds (Story #3043)', () => {
+  it('agentrc.schema.json accepts the perfThresholds object', async () => {
+    const schema = await loadAgentRcSchema();
+    const validate = compileRetroValidator(schema);
+    const ok = validate({
+      perfThresholds: {
+        utilisation: 0.6,
+        bootstrapShare: 0.4,
+        capBindingRunLength: 2,
+      },
+    });
+    assert.ok(
+      ok,
+      `schema should accept the canonical shape, errors: ${JSON.stringify(validate.errors)}`,
+    );
+    assert.equal(validate({ perfThresholds: {} }), true);
+    assert.equal(validate({}), true);
+  });
+
+  it('agentrc.schema.json rejects out-of-range or non-numeric thresholds', async () => {
+    const schema = await loadAgentRcSchema();
+    const validate = compileRetroValidator(schema);
+    assert.equal(
+      validate({ perfThresholds: { utilisation: -0.1 } }),
+      false,
+      'utilisation < 0 should fail',
+    );
+    assert.equal(
+      validate({ perfThresholds: { utilisation: 1.5 } }),
+      false,
+      'utilisation > 1 should fail',
+    );
+    assert.equal(
+      validate({ perfThresholds: { bootstrapShare: 2 } }),
+      false,
+      'bootstrapShare > 1 should fail',
+    );
+    assert.equal(
+      validate({ perfThresholds: { capBindingRunLength: 0 } }),
+      false,
+      'capBindingRunLength must be >= 1',
+    );
+    assert.equal(
+      validate({ perfThresholds: { capBindingRunLength: 1.5 } }),
+      false,
+      'capBindingRunLength must be integer',
+    );
+  });
+
+  it('config-settings-schema mirror exposes perfThresholds on delivery.retro', () => {
+    const retro = AGENTRC_SCHEMA?.properties?.delivery?.properties?.retro;
+    assert.ok(retro, 'delivery.retro sub-schema present');
+    const perfThresholds = retro.properties?.perfThresholds;
+    assert.ok(perfThresholds, 'perfThresholds sub-schema present');
+    assert.equal(perfThresholds.properties?.utilisation?.type, 'number');
+    assert.equal(perfThresholds.properties?.bootstrapShare?.type, 'number');
+    assert.equal(
+      perfThresholds.properties?.capBindingRunLength?.type,
+      'integer',
+    );
+  });
+
+  it('getRetro exposes defaults 0.6 / 0.4 / 2 when config omits the keys', () => {
+    const resolved = getRetro({});
+    assert.deepEqual(resolved.perfThresholds, {
+      utilisation: 0.6,
+      bootstrapShare: 0.4,
+      capBindingRunLength: 2,
+    });
+  });
+
+  it('getRetro exposes defaults when delivery / retro is missing entirely', () => {
+    assert.deepEqual(getRetro(null).perfThresholds, {
+      utilisation: 0.6,
+      bootstrapShare: 0.4,
+      capBindingRunLength: 2,
+    });
+    assert.deepEqual(getRetro(undefined).perfThresholds, {
+      utilisation: 0.6,
+      bootstrapShare: 0.4,
+      capBindingRunLength: 2,
+    });
+    assert.deepEqual(getRetro({ delivery: {} }).perfThresholds, {
+      utilisation: 0.6,
+      bootstrapShare: 0.4,
+      capBindingRunLength: 2,
+    });
+  });
+
+  it('getRetro forwards configured values', () => {
+    const resolved = getRetro({
+      delivery: {
+        retro: {
+          perfThresholds: {
+            utilisation: 0.8,
+            bootstrapShare: 0.3,
+            capBindingRunLength: 3,
+          },
+        },
+      },
+    });
+    assert.deepEqual(resolved.perfThresholds, {
+      utilisation: 0.8,
+      bootstrapShare: 0.3,
+      capBindingRunLength: 3,
+    });
+  });
+
+  it('getRetro falls back to defaults for invalid runtime values', () => {
+    const resolved = getRetro({
+      delivery: {
+        retro: {
+          perfThresholds: {
+            utilisation: -1,
+            bootstrapShare: 2,
+            capBindingRunLength: 0,
+          },
+        },
+      },
+    });
+    assert.deepEqual(resolved.perfThresholds, {
+      utilisation: 0.6,
+      bootstrapShare: 0.4,
+      capBindingRunLength: 2,
+    });
+  });
+});

--- a/tests/agentrc-verify-cap.test.js
+++ b/tests/agentrc-verify-cap.test.js
@@ -48,7 +48,10 @@ describe('delivery.deliverRunner.verifyConcurrencyCap (Story #3024)', () => {
     const schema = await loadAgentRcSchema();
     const validate = compileDeliverRunnerValidator(schema);
     const ok = validate({ verifyConcurrencyCap: 4 });
-    assert.ok(ok, `schema should accept cap=4, errors: ${JSON.stringify(validate.errors)}`);
+    assert.ok(
+      ok,
+      `schema should accept cap=4, errors: ${JSON.stringify(validate.errors)}`,
+    );
     assert.equal(validate({ verifyConcurrencyCap: 16 }), true);
     assert.equal(
       validate({

--- a/tests/agentrc-verify-cap.test.js
+++ b/tests/agentrc-verify-cap.test.js
@@ -15,16 +15,16 @@
 
 import { strict as assert } from 'node:assert';
 import { readFile } from 'node:fs/promises';
-import { fileURLToPath } from 'node:url';
 import { describe, it } from 'node:test';
+import { fileURLToPath } from 'node:url';
 import Ajv from 'ajv/dist/2020.js';
 
 import { getRunners } from '../.agents/scripts/lib/config/runners.js';
+import { AGENTRC_SCHEMA } from '../.agents/scripts/lib/config-settings-schema.js';
 import {
   coerceWaveParallelismRow,
   computeEpicPerfReport,
 } from '../.agents/scripts/lib/observability/perf-aggregator.js';
-import { AGENTRC_SCHEMA } from '../.agents/scripts/lib/config-settings-schema.js';
 
 const REPO_ROOT = fileURLToPath(new URL('..', import.meta.url));
 

--- a/tests/agentrc-verify-cap.test.js
+++ b/tests/agentrc-verify-cap.test.js
@@ -1,0 +1,171 @@
+// tests/agentrc-verify-cap.test.js
+/**
+ * Story #3024 / Task #3038 — `delivery.deliverRunner.verifyConcurrencyCap`
+ * config key.
+ *
+ * Confirms:
+ *   - The JSON Schema (`agentrc.schema.json`) accepts the key as a
+ *     positive integer and rejects non-integer / sub-1 values.
+ *   - The mirror schema (`config-settings-schema.js`) accepts the key.
+ *   - `getRunners(config)` exposes `verifyConcurrencyCap` with default 4
+ *     when `.agentrc.json` omits it, and forwards a configured value.
+ *   - The resolved cap flows into each `waveParallelism` row emitted by
+ *     `computeEpicPerfReport` (via `coerceWaveParallelismRow`).
+ */
+
+import { strict as assert } from 'node:assert';
+import { readFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import { describe, it } from 'node:test';
+import Ajv from 'ajv/dist/2020.js';
+
+import { getRunners } from '../.agents/scripts/lib/config/runners.js';
+import {
+  coerceWaveParallelismRow,
+  computeEpicPerfReport,
+} from '../.agents/scripts/lib/observability/perf-aggregator.js';
+import { AGENTRC_SCHEMA } from '../.agents/scripts/lib/config-settings-schema.js';
+
+const REPO_ROOT = fileURLToPath(new URL('..', import.meta.url));
+
+async function loadAgentRcSchema() {
+  const path = `${REPO_ROOT}.agents/schemas/agentrc.schema.json`;
+  const raw = await readFile(path, 'utf8');
+  return JSON.parse(raw);
+}
+
+/** Compile a validator targeted at the `deliverRunner` $def in isolation
+ * so the test exercises the verify-cap shape without dragging in every
+ * unrelated `required` constraint on the root agentrc shape. */
+function compileDeliverRunnerValidator(rootSchema) {
+  const ajv = new Ajv({ allErrors: true, strict: false });
+  ajv.addSchema(rootSchema, 'agentrc.schema.json');
+  return ajv.compile({ $ref: 'agentrc.schema.json#/$defs/deliverRunner' });
+}
+
+describe('delivery.deliverRunner.verifyConcurrencyCap (Story #3024)', () => {
+  it('agentrc.schema.json accepts verifyConcurrencyCap as a positive integer', async () => {
+    const schema = await loadAgentRcSchema();
+    const validate = compileDeliverRunnerValidator(schema);
+    const ok = validate({ verifyConcurrencyCap: 4 });
+    assert.ok(ok, `schema should accept cap=4, errors: ${JSON.stringify(validate.errors)}`);
+    assert.equal(validate({ verifyConcurrencyCap: 16 }), true);
+    assert.equal(
+      validate({
+        concurrencyCap: 3,
+        progressReportIntervalSec: 120,
+        verifyConcurrencyCap: 8,
+      }),
+      true,
+      'all three keys together should validate',
+    );
+  });
+
+  it('agentrc.schema.json rejects non-integer / sub-1 verifyConcurrencyCap', async () => {
+    const schema = await loadAgentRcSchema();
+    const validate = compileDeliverRunnerValidator(schema);
+    assert.equal(
+      validate({ verifyConcurrencyCap: 0 }),
+      false,
+      'cap=0 should fail (minimum: 1)',
+    );
+    assert.equal(
+      validate({ verifyConcurrencyCap: 1.5 }),
+      false,
+      'cap=1.5 should fail (integer)',
+    );
+    assert.equal(
+      validate({ verifyConcurrencyCap: 'four' }),
+      false,
+      'cap="four" should fail (integer)',
+    );
+  });
+
+  it('config-settings-schema mirror exposes verifyConcurrencyCap on deliverRunner', () => {
+    const deliverRunner =
+      AGENTRC_SCHEMA?.properties?.delivery?.properties?.deliverRunner;
+    assert.ok(deliverRunner, 'delivery.deliverRunner sub-schema present');
+    const prop = deliverRunner.properties?.verifyConcurrencyCap;
+    assert.ok(prop, 'verifyConcurrencyCap should be a declared property');
+    assert.equal(prop.type, 'integer');
+    assert.equal(prop.minimum, 1);
+  });
+
+  it('getRunners defaults verifyConcurrencyCap to 4 when omitted', () => {
+    const runners = getRunners({});
+    assert.equal(runners.deliverRunner.verifyConcurrencyCap, 4);
+  });
+
+  it('getRunners defaults verifyConcurrencyCap to 4 when delivery is missing entirely', () => {
+    const runners = getRunners(null);
+    assert.equal(runners.deliverRunner.verifyConcurrencyCap, 4);
+  });
+
+  it('getRunners forwards a configured verifyConcurrencyCap', () => {
+    const runners = getRunners({
+      delivery: { deliverRunner: { verifyConcurrencyCap: 8 } },
+    });
+    assert.equal(runners.deliverRunner.verifyConcurrencyCap, 8);
+  });
+
+  it('coerceWaveParallelismRow stamps verifyConcurrencyCap on the row', () => {
+    const row = coerceWaveParallelismRow({
+      waveIndex: 0,
+      wallClockMs: 1000,
+      summedStoryMs: 1500,
+      utilisation: 0.75,
+      capBinding: true,
+      verifyConcurrencyCap: 6,
+    });
+    assert.equal(row.verifyConcurrencyCap, 6);
+  });
+
+  it('coerceWaveParallelismRow falls back to 4 when cap is missing or invalid', () => {
+    const row = coerceWaveParallelismRow({
+      waveIndex: 0,
+      wallClockMs: 1000,
+      summedStoryMs: 500,
+      utilisation: 0.25,
+      capBinding: false,
+    });
+    assert.equal(row.verifyConcurrencyCap, 4);
+
+    const row2 = coerceWaveParallelismRow({
+      waveIndex: 1,
+      wallClockMs: 100,
+      summedStoryMs: 100,
+      utilisation: 1,
+      capBinding: false,
+      verifyConcurrencyCap: 0,
+    });
+    assert.equal(row2.verifyConcurrencyCap, 4);
+  });
+
+  it('computeEpicPerfReport carries verifyConcurrencyCap into each waveParallelism row', () => {
+    const report = computeEpicPerfReport([], {
+      epicId: 99,
+      generatedAt: '2026-05-26T00:00:00Z',
+      waveParallelism: [
+        {
+          waveIndex: 0,
+          wallClockMs: 1000,
+          summedStoryMs: 1000,
+          utilisation: 0.5,
+          capBinding: false,
+          verifyConcurrencyCap: 4,
+        },
+        {
+          waveIndex: 1,
+          wallClockMs: 2000,
+          summedStoryMs: 4000,
+          utilisation: 1,
+          capBinding: true,
+          verifyConcurrencyCap: 8,
+        },
+      ],
+    });
+    assert.equal(report.waveParallelism.length, 2);
+    assert.equal(report.waveParallelism[0].verifyConcurrencyCap, 4);
+    assert.equal(report.waveParallelism[1].verifyConcurrencyCap, 8);
+  });
+});

--- a/tests/analyze-execution-wave-parallelism.test.js
+++ b/tests/analyze-execution-wave-parallelism.test.js
@@ -1,0 +1,170 @@
+/**
+ * Unit tests for `analyze-execution.js`'s wave-parallelism wiring
+ * (Epic #3019 / Story #3025 / Task #3030).
+ *
+ * The analyzer's Epic-mode used to omit lifecycle events when calling
+ * `computeEpicPerfReport`, which left `waveParallelism` at `[]` on the
+ * persisted epic-perf-report comment. This test pins the post-fix
+ * contract: when a fixture lifecycle log seeds N waves, the resulting
+ * report carries N rows with non-zero `wallClockMs` on each row that
+ * has matching wave-start / wave-complete events.
+ */
+
+import assert from 'node:assert/strict';
+import { mkdtempSync, rmSync } from 'node:fs';
+import fs from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, it } from 'node:test';
+
+import { runEpicMode } from '../.agents/scripts/analyze-execution.js';
+
+function createFakeProvider({ subTickets = {} } = {}) {
+  const commentStore = new Map();
+  let nextCommentId = 5000;
+  return {
+    async getSubTickets(parentId) {
+      return subTickets[parentId] ?? [];
+    },
+    async getTicketComments(ticketId) {
+      return [...(commentStore.get(Number(ticketId)) ?? [])];
+    },
+    async deleteComment(commentId) {
+      for (const [, list] of commentStore) {
+        const i = list.findIndex((c) => c.id === commentId);
+        if (i >= 0) list.splice(i, 1);
+      }
+    },
+    async postComment(ticketId, payload) {
+      const id = ++nextCommentId;
+      const list = commentStore.get(Number(ticketId)) ?? [];
+      list.push({ id, body: payload.body, type: payload.type });
+      commentStore.set(Number(ticketId), list);
+      return { commentId: id };
+    },
+    _commentStore: commentStore,
+  };
+}
+
+let workRoot;
+let config;
+
+beforeEach(() => {
+  workRoot = mkdtempSync(path.join(tmpdir(), 'analyze-wave-'));
+  config = { project: { paths: { tempRoot: workRoot } } };
+});
+
+afterEach(() => {
+  rmSync(workRoot, { recursive: true, force: true });
+});
+
+async function seedEpicSignals(eid, lines) {
+  const dir = path.join(workRoot, `epic-${eid}`);
+  await fs.mkdir(dir, { recursive: true });
+  const body = `${lines.map((l) => JSON.stringify(l)).join('\n')}\n`;
+  await fs.writeFile(path.join(dir, 'signals.ndjson'), body);
+}
+
+function extractReportPayload(body) {
+  const m = body.match(/```json\s*\n([\s\S]*?)\n```/);
+  assert.ok(m, 'expected fenced JSON in epic-perf-report body');
+  return JSON.parse(m[1]);
+}
+
+describe('analyze-execution Epic mode — waveParallelism wiring (Story #3025)', () => {
+  it('produces one waveParallelism row per wave in the lifecycle log with non-zero wallClockMs', async () => {
+    const epicId = 3019;
+    // Seed an epic-level signals.ndjson with two complete waves.
+    await seedEpicSignals(epicId, [
+      {
+        kind: 'wave-start',
+        ts: '2026-05-26T00:00:00.000Z',
+        epic: epicId,
+        index: 0,
+        totalWaves: 2,
+        stories: [{ id: 1 }],
+      },
+      {
+        kind: 'state-transition',
+        ts: '2026-05-26T00:00:01.000Z',
+        epic: epicId,
+        story: 1,
+        details: { to: 'agent::executing' },
+      },
+      {
+        kind: 'state-transition',
+        ts: '2026-05-26T00:00:04.000Z',
+        epic: epicId,
+        story: 1,
+        details: { to: 'agent::done' },
+      },
+      {
+        kind: 'wave-complete',
+        ts: '2026-05-26T00:00:05.000Z',
+        epic: epicId,
+        index: 0,
+        totalWaves: 2,
+      },
+      {
+        kind: 'wave-start',
+        ts: '2026-05-26T00:00:10.000Z',
+        epic: epicId,
+        index: 1,
+        totalWaves: 2,
+        stories: [{ id: 2 }],
+      },
+      {
+        kind: 'state-transition',
+        ts: '2026-05-26T00:00:11.000Z',
+        epic: epicId,
+        story: 2,
+        details: { to: 'agent::executing' },
+      },
+      {
+        kind: 'state-transition',
+        ts: '2026-05-26T00:00:18.000Z',
+        epic: epicId,
+        story: 2,
+        details: { to: 'agent::done' },
+      },
+      {
+        kind: 'wave-complete',
+        ts: '2026-05-26T00:00:20.000Z',
+        epic: epicId,
+        index: 1,
+        totalWaves: 2,
+      },
+    ]);
+
+    const provider = createFakeProvider({ subTickets: { [epicId]: [] } });
+
+    const result = await runEpicMode({
+      epicId,
+      provider,
+      config,
+      // Stub the git-log gatherer + friction aggregator so the test does
+      // not need a real repo or per-Story NDJSON; the assertions in this
+      // test are wave-parallelism-specific.
+      gatherEpicCommitsFn: async () => [],
+      aggregateFrictionFn: async () => null,
+    });
+
+    const payload = result.payload;
+    assert.equal(payload.kind, 'epic-perf-report');
+    // AC#1: waveParallelism array length equals the number of waves
+    // observed in the lifecycle log.
+    assert.equal(payload.waveParallelism.length, 2);
+    // AC#2: each row carries non-zero wallClockMs.
+    for (const row of payload.waveParallelism) {
+      assert.ok(
+        row.wallClockMs > 0,
+        `expected non-zero wallClockMs, got ${row.wallClockMs} for wave ${row.waveIndex}`,
+      );
+    }
+    // Re-extract via the rendered comment body to pin the on-the-wire shape.
+    const stored = provider._commentStore.get(epicId);
+    assert.ok(stored && stored.length === 1, 'expected one upserted comment');
+    const fromBody = extractReportPayload(stored[0].body);
+    assert.equal(fromBody.waveParallelism.length, 2);
+  });
+});

--- a/tests/dispatch-manifest-render.test.js
+++ b/tests/dispatch-manifest-render.test.js
@@ -149,12 +149,7 @@ describe('projectStoriesFromManifest', () => {
 describe('countWaves', () => {
   it('counts distinct non-(-1) wave indexes', () => {
     assert.equal(
-      countWaves([
-        { wave: 0 },
-        { wave: 0 },
-        { wave: 1 },
-        { wave: -1 },
-      ]),
+      countWaves([{ wave: 0 }, { wave: 0 }, { wave: 1 }, { wave: -1 }]),
       2,
     );
   });

--- a/tests/dispatch-manifest-render.test.js
+++ b/tests/dispatch-manifest-render.test.js
@@ -1,0 +1,166 @@
+/**
+ * dispatch-manifest-render.test.js
+ *
+ * Unit coverage for the pure `renderManifest` helper extracted from
+ * `manifest-renderer.js::postManifestEpicComment`. The fixture-derived
+ * expected body is the byte-for-byte string the inline builder produced
+ * before extraction — any drift in this snapshot is a contract change.
+ */
+
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import {
+  countWaves,
+  projectStoriesFromManifest,
+  renderManifest,
+  renderManifestFromManifest,
+} from '../.agents/scripts/lib/presentation/dispatch-manifest-render.js';
+
+const FIXTURE_GENERATED_AT = '2026-05-26T12:00:00.000Z';
+
+function makeFixtureManifest() {
+  return {
+    epicId: 9001,
+    generatedAt: FIXTURE_GENERATED_AT,
+    storyManifest: [
+      {
+        storyId: 9002,
+        storyTitle: 'First story',
+        storySlug: 'first-story',
+        type: 'story',
+        earliestWave: 0,
+      },
+      {
+        storyId: 9003,
+        storyTitle: 'Second story',
+        storySlug: 'second-story',
+        type: 'story',
+        earliestWave: 1,
+      },
+      {
+        // feature rows are filtered out
+        storyId: 9000,
+        storyTitle: 'Parent feature',
+        type: 'feature',
+        earliestWave: 0,
+      },
+      {
+        // ungrouped sentinel is filtered out
+        storyId: '__ungrouped__',
+        storyTitle: 'Ungrouped',
+        type: 'story',
+        earliestWave: -1,
+      },
+    ],
+  };
+}
+
+const EXPECTED_BODY = [
+  '## 📋 Dispatch Manifest — Epic #9001',
+  '',
+  '- **Waves:** 2',
+  '- **Stories:** 2',
+  `- **Generated:** ${FIXTURE_GENERATED_AT}`,
+  '',
+  'Source of truth for the wave-completeness gate run at `/epic-deliver`.',
+  '',
+  '```json',
+  JSON.stringify(
+    {
+      stories: [
+        { storyId: 9002, wave: 0, title: 'First story' },
+        { storyId: 9003, wave: 1, title: 'Second story' },
+      ],
+    },
+    null,
+    2,
+  ),
+  '```',
+].join('\n');
+
+describe('renderManifest', () => {
+  it('renders the dispatch-manifest body byte-for-byte from a fixture Epic', () => {
+    const manifest = makeFixtureManifest();
+    const body = renderManifest({
+      epicId: manifest.epicId,
+      stories: projectStoriesFromManifest(manifest),
+      generatedAt: manifest.generatedAt,
+    });
+    assert.equal(body, EXPECTED_BODY);
+  });
+
+  it('renderManifestFromManifest matches the deconstructed call', () => {
+    const manifest = makeFixtureManifest();
+    assert.equal(renderManifestFromManifest(manifest), EXPECTED_BODY);
+  });
+
+  it('reports `Waves: 1` when no story carries a real wave index', () => {
+    const body = renderManifest({
+      epicId: 9001,
+      stories: [{ storyId: 1, wave: -1, title: 't' }],
+      generatedAt: FIXTURE_GENERATED_AT,
+    });
+    assert.match(body, /- \*\*Waves:\*\* 1$/m);
+    assert.match(body, /- \*\*Stories:\*\* 1$/m);
+  });
+
+  it('throws when epicId is missing', () => {
+    assert.throws(
+      () =>
+        renderManifest({
+          stories: [],
+          generatedAt: FIXTURE_GENERATED_AT,
+        }),
+      /epicId is required/,
+    );
+  });
+});
+
+describe('projectStoriesFromManifest', () => {
+  it('filters features and the ungrouped sentinel, projects {storyId, wave, title}', () => {
+    const projected = projectStoriesFromManifest(makeFixtureManifest());
+    assert.deepEqual(projected, [
+      { storyId: 9002, wave: 0, title: 'First story' },
+      { storyId: 9003, wave: 1, title: 'Second story' },
+    ]);
+  });
+
+  it('falls back to storySlug when storyTitle is absent', () => {
+    const projected = projectStoriesFromManifest({
+      storyManifest: [
+        {
+          storyId: 1,
+          type: 'story',
+          storySlug: 'fallback-slug',
+          earliestWave: 0,
+        },
+      ],
+    });
+    assert.equal(projected[0].title, 'fallback-slug');
+  });
+
+  it('returns [] for a manifest with no storyManifest', () => {
+    assert.deepEqual(projectStoriesFromManifest({}), []);
+    assert.deepEqual(projectStoriesFromManifest(null), []);
+  });
+});
+
+describe('countWaves', () => {
+  it('counts distinct non-(-1) wave indexes', () => {
+    assert.equal(
+      countWaves([
+        { wave: 0 },
+        { wave: 0 },
+        { wave: 1 },
+        { wave: -1 },
+      ]),
+      2,
+    );
+  });
+
+  it('returns 0 for an empty list', () => {
+    assert.equal(countWaves([]), 0);
+    assert.equal(countWaves(null), 0);
+  });
+});

--- a/tests/dispatcher-dry-run.test.js
+++ b/tests/dispatcher-dry-run.test.js
@@ -1,0 +1,85 @@
+/**
+ * dispatcher-dry-run.test.js
+ *
+ * After Story #3026 extracted the dispatch-manifest body into
+ * `dispatch-manifest-render.js`, the `manifest-renderer.js` facade — the
+ * code path dispatcher.js drives during `--dry-run` — must produce a
+ * body byte-identical to the helper output. This is the regression net
+ * that catches inline-builder drift in the facade.
+ */
+
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import { renderManifestFromManifest } from '../.agents/scripts/lib/presentation/dispatch-manifest-render.js';
+import { postManifestEpicComment } from '../.agents/scripts/lib/presentation/manifest-renderer.js';
+
+class CaptureProvider {
+  constructor() {
+    this.posted = [];
+  }
+  async getTicketComments() {
+    return [];
+  }
+  async postComment(ticketId, payload) {
+    this.posted.push({ ticketId, payload });
+    return { id: 1 };
+  }
+  async deleteComment() {}
+}
+
+function makeFixtureManifest() {
+  return {
+    epicId: 7777,
+    generatedAt: '2026-05-26T13:00:00.000Z',
+    type: 'epic',
+    storyManifest: [
+      {
+        storyId: 7001,
+        storyTitle: 'Alpha story',
+        type: 'story',
+        earliestWave: 0,
+      },
+      {
+        storyId: 7002,
+        storyTitle: 'Beta story',
+        type: 'story',
+        earliestWave: 1,
+      },
+    ],
+  };
+}
+
+describe('dispatcher dry-run body parity', () => {
+  it('postManifestEpicComment posts the helper-rendered body byte-for-byte', async () => {
+    const manifest = makeFixtureManifest();
+    const provider = new CaptureProvider();
+
+    const result = await postManifestEpicComment(manifest, provider);
+
+    assert.equal(result.posted, true);
+    assert.equal(provider.posted.length, 1);
+    const expected = renderManifestFromManifest(manifest);
+    // upsertStructuredComment prepends a marker line + blank line.
+    const [ticketId, payload] = [
+      provider.posted[0].ticketId,
+      provider.posted[0].payload,
+    ];
+    assert.equal(ticketId, manifest.epicId);
+    assert.equal(payload.type, 'dispatch-manifest');
+    assert.ok(
+      payload.body.endsWith(expected),
+      `body should end with helper-rendered output; got:\n${payload.body}`,
+    );
+  });
+
+  it('skips upsert when the manifest is a story-execution manifest', async () => {
+    const provider = new CaptureProvider();
+    const result = await postManifestEpicComment(
+      { type: 'story-execution', epicId: 1 },
+      provider,
+    );
+    assert.equal(result.posted, false);
+    assert.equal(provider.posted.length, 0);
+  });
+});

--- a/tests/epic-close-comment-perf-link.test.js
+++ b/tests/epic-close-comment-perf-link.test.js
@@ -1,0 +1,198 @@
+/**
+ * epic-close-comment-perf-link.test.js — Story #3029 / Task #3041.
+ *
+ * The `epic-handoff` structured close comment is extended with a
+ * `## Performance Report` section linking the JSON artifact persisted by
+ * the close-tail (`emitEpicPerfReport`) and a one-line-per-wave summary.
+ * These tests drive the renderer + `postHandoffComment` directly:
+ *
+ *   1. `renderHandoffBody` includes the `## Performance Report` heading
+ *      + a relative link to `temp/epic-<id>/epic-perf-report.json` +
+ *      one bullet per `waveParallelism` row.
+ *   2. The bullet format matches `Wave N: <wallClock> wall /
+ *      <summedStory> story / util <pct>% [cap binding|cap not binding]`.
+ *   3. Empty waveParallelism degrades to a graceful "no rows" line.
+ *   4. Missing perfReport keeps the legacy body shape (no heading).
+ *   5. `postHandoffComment` calls the injected loader and forwards its
+ *      envelope into the body.
+ *   6. A loader failure degrades to the legacy body shape and surfaces a
+ *      warn log, never throwing.
+ */
+
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import {
+  postHandoffComment,
+  renderHandoffBody,
+} from '../.agents/scripts/lib/orchestration/finalize/post-handoff-comment.js';
+
+function makeLogger() {
+  const lines = { info: [], warn: [], error: [] };
+  return {
+    info: (m) => lines.info.push(m),
+    warn: (m) => lines.warn.push(m),
+    error: (m) => lines.error.push(m),
+    _lines: lines,
+  };
+}
+
+const baseWaveRows = [
+  {
+    waveIndex: 0,
+    wallClockMs: 90000, // 1m30s
+    summedStoryMs: 150000, // 2m30s
+    utilisation: 0.833,
+    capBinding: true,
+    verifyConcurrencyCap: 4,
+  },
+  {
+    waveIndex: 1,
+    wallClockMs: 4200, // 4.2s
+    summedStoryMs: 4200,
+    utilisation: 1.0,
+    capBinding: false,
+    verifyConcurrencyCap: 4,
+  },
+];
+
+describe('renderHandoffBody — Performance Report section', () => {
+  it('includes the ## Performance Report heading + relative link when perfReport is supplied', () => {
+    const body = renderHandoffBody({
+      epicId: 900,
+      prNumber: 1234,
+      prUrl: 'https://github.com/org/repo/pull/1234',
+      perfReport: {
+        relativePath: 'temp/epic-900/epic-perf-report.json',
+        waveParallelism: baseWaveRows,
+      },
+    });
+    assert.match(body, /^## Performance Report$/m);
+    assert.match(
+      body,
+      /\[`temp\/epic-900\/epic-perf-report\.json`\]\(temp\/epic-900\/epic-perf-report\.json\)/,
+    );
+  });
+
+  it('renders one bullet per wave with the canonical wall/story/util/cap format', () => {
+    const body = renderHandoffBody({
+      epicId: 900,
+      prNumber: 1234,
+      perfReport: {
+        relativePath: 'temp/epic-900/epic-perf-report.json',
+        waveParallelism: baseWaveRows,
+      },
+    });
+    // Wave 0 — minute-scale durations + cap binding.
+    assert.match(
+      body,
+      /Wave 0: 1m30s wall \/ 2m30s story \/ util 83% \[cap binding\]/,
+    );
+    // Wave 1 — second-scale durations + cap not binding.
+    assert.match(
+      body,
+      /Wave 1: 4\.2s wall \/ 4\.2s story \/ util 100% \[cap not binding\]/,
+    );
+  });
+
+  it('degrades to a "no rows" line when waveParallelism is empty', () => {
+    const body = renderHandoffBody({
+      epicId: 900,
+      prNumber: 1234,
+      perfReport: {
+        relativePath: 'temp/epic-900/epic-perf-report.json',
+        waveParallelism: [],
+      },
+    });
+    assert.match(body, /## Performance Report/);
+    assert.match(body, /No wave-parallelism rows recorded\./);
+  });
+
+  it('omits the Performance Report section entirely when perfReport is null', () => {
+    const body = renderHandoffBody({
+      epicId: 900,
+      prNumber: 1234,
+      prUrl: 'https://github.com/org/repo/pull/1234',
+      perfReport: null,
+    });
+    assert.doesNotMatch(body, /Performance Report/);
+    // Legacy body shape preserved.
+    assert.match(body, /Epic handoff — PR opened/);
+    assert.match(body, /Auto-merge will arm once/);
+  });
+});
+
+describe('postHandoffComment — wires the perf-report loader into the body', () => {
+  it('invokes the injected loader and forwards its envelope into the rendered body', async () => {
+    const loaderCalls = [];
+    const upsertCalls = [];
+    const result = await postHandoffComment({
+      epicId: 900,
+      prNumber: 1234,
+      prUrl: 'https://github.com/org/repo/pull/1234',
+      provider: {},
+      config: { project: { paths: { tempRoot: '/tmp/test' } } },
+      cwd: '/repo',
+      loadPerfReportFn: async (args) => {
+        loaderCalls.push(args);
+        return {
+          relativePath: 'temp/epic-900/epic-perf-report.json',
+          waveParallelism: baseWaveRows,
+        };
+      },
+      upsertStructuredCommentFn: async (provider, ticketId, marker, body) => {
+        upsertCalls.push({ provider, ticketId, marker, body });
+        return { commentId: 9999 };
+      },
+      logger: makeLogger(),
+    });
+    assert.equal(loaderCalls.length, 1);
+    assert.equal(loaderCalls[0].epicId, 900);
+    assert.equal(loaderCalls[0].cwd, '/repo');
+    assert.equal(upsertCalls.length, 1);
+    assert.equal(upsertCalls[0].ticketId, 900);
+    assert.match(upsertCalls[0].body, /## Performance Report/);
+    assert.match(upsertCalls[0].body, /Wave 0:/);
+    assert.equal(result.commentId, 9999);
+  });
+
+  it('degrades silently when the loader throws — body keeps the legacy shape', async () => {
+    const logger = makeLogger();
+    const upsertCalls = [];
+    await postHandoffComment({
+      epicId: 900,
+      prNumber: 1234,
+      prUrl: 'https://github.com/org/repo/pull/1234',
+      provider: {},
+      loadPerfReportFn: async () => {
+        throw new Error('ENOENT: missing report');
+      },
+      upsertStructuredCommentFn: async (_p, _t, _m, body) => {
+        upsertCalls.push(body);
+        return { commentId: 1 };
+      },
+      logger,
+    });
+    assert.equal(upsertCalls.length, 1);
+    assert.doesNotMatch(upsertCalls[0], /Performance Report/);
+    assert.equal(logger._lines.warn.length, 1);
+    assert.match(logger._lines.warn[0], /perf-report load failed/);
+  });
+
+  it('omits the Performance Report section when the loader resolves null (no JSON on disk)', async () => {
+    const upsertCalls = [];
+    await postHandoffComment({
+      epicId: 900,
+      prNumber: 1234,
+      prUrl: 'https://github.com/org/repo/pull/1234',
+      provider: {},
+      loadPerfReportFn: async () => null,
+      upsertStructuredCommentFn: async (_p, _t, _m, body) => {
+        upsertCalls.push(body);
+        return { commentId: 1 };
+      },
+      logger: makeLogger(),
+    });
+    assert.doesNotMatch(upsertCalls[0], /Performance Report/);
+  });
+});

--- a/tests/epic-close-tail-perf-report.test.js
+++ b/tests/epic-close-tail-perf-report.test.js
@@ -1,0 +1,224 @@
+/**
+ * epic-close-tail-perf-report.test.js — Story #3029 / Task #3040.
+ *
+ * The close tail (`epic-close.js`) auto-emits the `epic-perf-report`
+ * artifact alongside the planning-close + epic-state recovery so the
+ * report is reachable on disk under `temp/epic-<id>/` without operator
+ * action. These tests drive `emitEpicPerfReport` directly with a stub
+ * analyzer + stub fs writer:
+ *
+ *   1. Happy path — writes `epic-perf-report.json` whose JSON parses
+ *      against `.agents/schemas/epic-perf-report.schema.json` and
+ *      returns `{ status: 'ok' }`.
+ *   2. Analyzer throw — surfaces a friction-not-fatal envelope so the
+ *      close tail still completes; the exception is logged as `warn`,
+ *      not rethrown.
+ *   3. Filesystem write throw — same friction-not-fatal contract.
+ *   4. `runEpicCloseTail` wires the helper through — a stub
+ *      `emitEpicPerfReportFn` is invoked with the resolved `epicId`,
+ *      `provider`, `config`, and `cwd`, and its envelope is forwarded
+ *      under `result.perfReport`.
+ */
+
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { describe, it } from 'node:test';
+import { fileURLToPath } from 'node:url';
+import Ajv from 'ajv';
+import addFormats from 'ajv-formats';
+
+import { runEpicCloseTail } from '../.agents/scripts/epic-close.js';
+import { emitEpicPerfReport } from '../.agents/scripts/lib/epic-close-tail-helpers.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const SCHEMA_PATH = path.resolve(
+  __dirname,
+  '..',
+  '.agents',
+  'schemas',
+  'epic-perf-report.schema.json',
+);
+
+const epicPerfReportSchema = JSON.parse(readFileSync(SCHEMA_PATH, 'utf8'));
+
+function compileSchema() {
+  const ajv = new Ajv({ allErrors: true, strict: false });
+  addFormats(ajv);
+  return ajv.compile(epicPerfReportSchema);
+}
+
+function makeLogger() {
+  const lines = { info: [], warn: [], error: [] };
+  return {
+    info: (m) => lines.info.push(m),
+    warn: (m) => lines.warn.push(m),
+    error: (m) => lines.error.push(m),
+    _lines: lines,
+  };
+}
+
+function buildSchemaConformantPayload(epicId, overrides = {}) {
+  return {
+    kind: 'epic-perf-report',
+    epicId,
+    generatedAt: '2026-05-26T22:00:00.000Z',
+    signalCounts: { friction: 0, hotspot: 0, rework: 0, retry: 0 },
+    waveParallelism: [
+      {
+        waveIndex: 0,
+        wallClockMs: 120000,
+        summedStoryMs: 200000,
+        utilisation: 0.833,
+        capBinding: true,
+        verifyConcurrencyCap: 4,
+      },
+    ],
+    topHotspots: [],
+    mostFrictionStories: [],
+    ...overrides,
+  };
+}
+
+describe('emitEpicPerfReport — friction-not-fatal close-tail helper', () => {
+  it('writes epic-perf-report.json that conforms to the schema (happy path)', async () => {
+    const payload = buildSchemaConformantPayload(900);
+    const stubAnalyze = async () => ({
+      commentId: 5050,
+      payload,
+      baselineRefreshRate: null,
+      qualityGateFriction: null,
+    });
+    const writes = [];
+    const mkdirCalls = [];
+    const result = await emitEpicPerfReport({
+      epicId: 900,
+      provider: {},
+      // Config drives `epicPerfReportJsonPath` through the configured
+      // tempRoot. Use an inline fixture root so the test does not write
+      // to the real `temp/`.
+      config: { project: { paths: { tempRoot: '/tmp/test-epic-close-tail' } } },
+      cwd: '/repo',
+      logger: makeLogger(),
+      analyzeFn: stubAnalyze,
+      writeFileFn: async (target, data) => {
+        writes.push({ target, data });
+      },
+      mkdirFn: async (dir, opts) => {
+        mkdirCalls.push({ dir, opts });
+      },
+    });
+
+    assert.equal(result.status, 'ok');
+    assert.match(result.path, /epic-perf-report\.json$/);
+    assert.equal(result.commentId, 5050);
+    assert.equal(writes.length, 1);
+    assert.equal(mkdirCalls.length, 1);
+    assert.equal(mkdirCalls[0].opts.recursive, true);
+
+    // Persisted JSON conforms to the schema.
+    const persisted = JSON.parse(writes[0].data);
+    const validate = compileSchema();
+    const ok = validate(persisted);
+    assert.equal(
+      ok,
+      true,
+      `persisted epic-perf-report.json failed schema: ${JSON.stringify(validate.errors)}`,
+    );
+    assert.equal(persisted.epicId, 900);
+    assert.equal(persisted.waveParallelism[0].verifyConcurrencyCap, 4);
+  });
+
+  it('treats analyzer throws as friction-not-fatal (status: failed, no rethrow)', async () => {
+    const logger = makeLogger();
+    const stubAnalyze = async () => {
+      throw new Error('boom: analyze-execution exploded');
+    };
+    const result = await emitEpicPerfReport({
+      epicId: 900,
+      provider: {},
+      config: {},
+      cwd: '/repo',
+      logger,
+      analyzeFn: stubAnalyze,
+      writeFileFn: async () => {
+        throw new Error('writeFile should not be invoked when analyze throws');
+      },
+      mkdirFn: async () => {},
+    });
+
+    assert.equal(result.status, 'failed');
+    assert.equal(result.path, null);
+    assert.equal(result.payload, null);
+    assert.match(result.detail, /boom: analyze-execution exploded/);
+    // The friction is logged on warn so the close-tail orchestrator can
+    // record it via the lifecycle bus but never blocks on it.
+    assert.equal(logger._lines.warn.length, 1);
+    assert.match(logger._lines.warn[0], /analyze-execution threw/);
+  });
+
+  it('treats filesystem write throws as friction-not-fatal', async () => {
+    const logger = makeLogger();
+    const payload = buildSchemaConformantPayload(901);
+    const stubAnalyze = async () => ({ commentId: 1, payload });
+    const result = await emitEpicPerfReport({
+      epicId: 901,
+      provider: {},
+      config: {},
+      cwd: '/repo',
+      logger,
+      analyzeFn: stubAnalyze,
+      writeFileFn: async () => {
+        throw new Error('EACCES: read-only temp');
+      },
+      mkdirFn: async () => {},
+    });
+
+    assert.equal(result.status, 'failed');
+    assert.match(result.detail, /EACCES/);
+    assert.equal(result.payload, payload);
+    assert.equal(logger._lines.warn.length, 1);
+    assert.match(logger._lines.warn[0], /failed to persist/);
+  });
+});
+
+describe('runEpicCloseTail — emitEpicPerfReport is wired into the tail', () => {
+  it('invokes emitEpicPerfReportFn with epicId, provider, config, cwd and surfaces its envelope', async () => {
+    const calls = [];
+    const stubPlanningClose = async () => ({
+      prd: { id: 1, status: 'closed' },
+      techSpec: { id: 2, status: 'closed' },
+      acceptanceSpec: { id: null, status: 'skipped' },
+    });
+    const stubVerifyEpic = async () => ({ status: 'already-closed' });
+    const stubEmitPerf = async (args) => {
+      calls.push(args);
+      return {
+        status: 'ok',
+        path: '/tmp/test/epic-900/epic-perf-report.json',
+        commentId: 7070,
+        payload: buildSchemaConformantPayload(900),
+      };
+    };
+
+    const result = await runEpicCloseTail({
+      epicId: 900,
+      provider: { getEpic: async () => ({ linkedIssues: {} }) },
+      config: { project: { paths: { tempRoot: '/tmp/test' } } },
+      cwd: '/repo',
+      logger: makeLogger(),
+      closePlanningArtifactsFn: stubPlanningClose,
+      verifyAndRecoverEpicCloseFn: stubVerifyEpic,
+      emitEpicPerfReportFn: stubEmitPerf,
+    });
+
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0].epicId, 900);
+    assert.equal(calls[0].cwd, '/repo');
+    assert.deepEqual(calls[0].config, {
+      project: { paths: { tempRoot: '/tmp/test' } },
+    });
+    assert.equal(result.perfReport.status, 'ok');
+    assert.equal(result.perfReport.commentId, 7070);
+  });
+});

--- a/tests/epic-deliver-preflight-cache.test.js
+++ b/tests/epic-deliver-preflight-cache.test.js
@@ -1,0 +1,204 @@
+// tests/epic-deliver-preflight-cache.test.js
+/**
+ * Unit tests — Story #3027 Task #3036 (Epic #3019).
+ *
+ * `epic-deliver-preflight.js` MUST persist its snapshot/DAG result to
+ * `temp/epic-<id>/preflight-snapshot.json` so `epic-deliver-prepare.js`
+ * can reuse the envelope instead of re-walking Epic → Feature → Story.
+ *
+ * Acceptance:
+ *   - Running the preflight writes the cache file with `epic`, `stories`,
+ *     and `waves` populated from `runSnapshotPhase` + `runBuildWaveDagPhase`.
+ *   - The envelope carries a `baseSha` derived from the same `getTicket`
+ *     call used to walk the hierarchy. Re-computing the digest off the
+ *     persisted `epic` snapshot reproduces the stored value byte-for-byte.
+ *   - `--dry-run` is side-effect-light: no file is written.
+ */
+
+import assert from 'node:assert/strict';
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, it } from 'node:test';
+
+import { runPreflight } from '../.agents/scripts/epic-deliver-preflight.js';
+import {
+  computeBaseSha,
+  preflightCachePath,
+} from '../.agents/scripts/lib/orchestration/preflight-cache.js';
+
+function buildFakeProvider({ epicId, stories, epicOverrides = {} }) {
+  return {
+    async getTicket(id) {
+      if (id !== epicId) return null;
+      return {
+        id: epicId,
+        number: epicId,
+        labels: ['type::epic', 'acceptance::n-a'],
+        body: '',
+        title: `Epic #${epicId}`,
+        updatedAt: '2026-05-26T00:00:00Z',
+        ...epicOverrides,
+      };
+    },
+    async getSubTickets(_id) {
+      return stories;
+    },
+  };
+}
+
+const FAKE_CONFIG = {
+  delivery: {
+    preflight: {
+      maxStories: null,
+      maxWaves: null,
+      maxInstallCostSeconds: null,
+      maxGithubApiRequests: null,
+      maxClaudeQuotaTokens: null,
+    },
+  },
+  orchestration: { provider: 'github' },
+};
+
+describe('epic-deliver-preflight cache write', () => {
+  let workCwd;
+
+  beforeEach(async () => {
+    workCwd = await mkdtemp(path.join(tmpdir(), 'preflight-cache-'));
+  });
+
+  afterEach(async () => {
+    await rm(workCwd, { recursive: true, force: true });
+  });
+
+  it('persists snapshot+DAG envelope to temp/epic-<id>/preflight-snapshot.json', async () => {
+    const stories = [101, 102].map((id) => ({
+      id,
+      number: id,
+      labels: ['type::story'],
+      body: '',
+      title: `Story #${id}`,
+      state: 'open',
+    }));
+    const provider = buildFakeProvider({ epicId: 4242, stories });
+
+    const envelope = await runPreflight({
+      epicId: 4242,
+      cwd: workCwd,
+      injectedProvider: provider,
+      injectedConfig: FAKE_CONFIG,
+    });
+
+    assert.equal(envelope.cacheWritten, true);
+    assert.equal(typeof envelope.baseSha, 'string');
+    assert.ok(envelope.baseSha.length > 0);
+
+    const cachePath = preflightCachePath({ epicId: 4242, cwd: workCwd });
+    const raw = await readFile(cachePath, 'utf8');
+    const cached = JSON.parse(raw);
+
+    assert.equal(cached.epicId, 4242);
+    assert.equal(cached.baseSha, envelope.baseSha);
+    assert.equal(typeof cached.capturedAt, 'string');
+    assert.equal(cached.epic.id, 4242);
+    assert.ok(Array.isArray(cached.stories));
+    assert.equal(cached.stories.length, 2);
+    assert.ok(Array.isArray(cached.waves));
+    assert.equal(cached.waves.length, 1);
+  });
+
+  it('baseSha is derived from the same getTicket snapshot used to walk the hierarchy', async () => {
+    const stories = [201].map((id) => ({
+      id,
+      number: id,
+      labels: ['type::story'],
+      body: '',
+      title: `Story #${id}`,
+      state: 'open',
+    }));
+    const provider = buildFakeProvider({ epicId: 7777, stories });
+
+    const envelope = await runPreflight({
+      epicId: 7777,
+      cwd: workCwd,
+      injectedProvider: provider,
+      injectedConfig: FAKE_CONFIG,
+    });
+
+    const cachePath = preflightCachePath({ epicId: 7777, cwd: workCwd });
+    const cached = JSON.parse(await readFile(cachePath, 'utf8'));
+
+    // Re-deriving the digest off the persisted epic snapshot reproduces
+    // the stored baseSha byte-for-byte. This is the cache key prepare
+    // will compare against.
+    const recomputed = computeBaseSha(cached.epic);
+    assert.equal(recomputed, envelope.baseSha);
+    assert.equal(recomputed, cached.baseSha);
+  });
+
+  it('--dry-run does NOT write the cache file', async () => {
+    const stories = [301].map((id) => ({
+      id,
+      number: id,
+      labels: ['type::story'],
+      body: '',
+      title: `Story #${id}`,
+      state: 'open',
+    }));
+    const provider = buildFakeProvider({ epicId: 5151, stories });
+
+    const envelope = await runPreflight({
+      epicId: 5151,
+      cwd: workCwd,
+      dryRun: true,
+      injectedProvider: provider,
+      injectedConfig: FAKE_CONFIG,
+    });
+
+    assert.equal(envelope.cacheWritten, false);
+    const cachePath = preflightCachePath({ epicId: 5151, cwd: workCwd });
+    await assert.rejects(
+      () => readFile(cachePath, 'utf8'),
+      (err) => err.code === 'ENOENT',
+    );
+  });
+
+  it('differing label or body produces a distinct baseSha', () => {
+    const a = computeBaseSha({
+      id: 1,
+      body: '',
+      labels: ['a'],
+      updatedAt: '2026-05-26T00:00:00Z',
+    });
+    const b = computeBaseSha({
+      id: 1,
+      body: '',
+      labels: ['b'],
+      updatedAt: '2026-05-26T00:00:00Z',
+    });
+    const c = computeBaseSha({
+      id: 1,
+      body: 'changed',
+      labels: ['a'],
+      updatedAt: '2026-05-26T00:00:00Z',
+    });
+    assert.notEqual(a, b);
+    assert.notEqual(a, c);
+  });
+
+  it('label order does not affect baseSha (sorted before hashing)', () => {
+    const a = computeBaseSha({
+      id: 1,
+      body: '',
+      labels: ['x', 'y', 'z'],
+      updatedAt: '2026-05-26T00:00:00Z',
+    });
+    const b = computeBaseSha({
+      id: 1,
+      body: '',
+      labels: ['z', 'y', 'x'],
+      updatedAt: '2026-05-26T00:00:00Z',
+    });
+    assert.equal(a, b);
+  });
+});

--- a/tests/epic-deliver-prepare-cache.test.js
+++ b/tests/epic-deliver-prepare-cache.test.js
@@ -1,0 +1,216 @@
+// tests/epic-deliver-prepare-cache.test.js
+/**
+ * Unit tests — Story #3027 Task #3037 (Epic #3019).
+ *
+ * `epic-deliver-prepare.js` MUST read the preflight cache
+ * (`temp/epic-<id>/preflight-snapshot.json`) and skip the duplicate
+ * snapshot+DAG walk when the cached envelope's `baseSha` matches the
+ * fresh `getTicket(epicId)` digest. Cache miss or baseSha drift falls
+ * back to a fresh `runSnapshotPhase` + `runBuildWaveDagPhase` pass.
+ *
+ * Acceptance:
+ *   - Hit path: cache file present, baseSha matches → no `getSubTickets`
+ *     calls are made by prepare. `runSnapshotPhase` is effectively a no-op
+ *     because the wave DAG is reconstructed from the cache.
+ *   - Miss path: cache absent → fresh snapshot+DAG pass runs as before.
+ *   - Stale path: cache present but baseSha mismatch → fresh pass runs
+ *     and the stale envelope is ignored.
+ */
+
+import assert from 'node:assert/strict';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, it } from 'node:test';
+
+import { runEpicDeliverPrepare } from '../.agents/scripts/epic-deliver-prepare.js';
+import {
+  computeBaseSha,
+  writePreflightCache,
+} from '../.agents/scripts/lib/orchestration/preflight-cache.js';
+
+function buildCountingProvider({ epicId, stories, epicOverrides = {} }) {
+  const counts = { getTicket: 0, getSubTickets: 0 };
+  const checkpoints = new Map();
+  const provider = {
+    async getTicket(id) {
+      counts.getTicket++;
+      if (id !== epicId) return null;
+      return {
+        id: epicId,
+        number: epicId,
+        labels: ['type::epic', 'acceptance::n-a'],
+        body: '',
+        title: `Epic #${epicId}`,
+        updatedAt: '2026-05-26T00:00:00Z',
+        ...epicOverrides,
+      };
+    },
+    async getSubTickets(_id) {
+      counts.getSubTickets++;
+      return stories;
+    },
+    // The state store reads/writes structured comments; stub them.
+    async listComments(_ticketId) {
+      return Array.from(checkpoints.values());
+    },
+    async getTicketComments(_ticketId) {
+      return Array.from(checkpoints.values());
+    },
+    async postComment(_ticketId, payload) {
+      const id = checkpoints.size + 1;
+      checkpoints.set(id, { id, body: payload.body, type: payload.type });
+      return { id };
+    },
+    async updateComment(commentId, payload) {
+      const existing = checkpoints.get(commentId) ?? { id: commentId };
+      checkpoints.set(commentId, { ...existing, ...payload });
+      return { id: commentId };
+    },
+    async deleteComment(id) {
+      checkpoints.delete(id);
+    },
+    _counts: counts,
+  };
+  return provider;
+}
+
+const FAKE_CONFIG = {
+  github: { owner: 'test', repo: 'test', projectNumber: 1 },
+  delivery: {
+    deliverRunner: { concurrencyCap: 4 },
+  },
+  orchestration: { provider: 'github' },
+};
+
+describe('epic-deliver-prepare cache read', () => {
+  let workCwd;
+
+  beforeEach(async () => {
+    workCwd = await mkdtemp(path.join(tmpdir(), 'prepare-cache-'));
+  });
+
+  afterEach(async () => {
+    await rm(workCwd, { recursive: true, force: true });
+  });
+
+  it('reuses cached envelope when baseSha matches (no second getSubTickets)', async () => {
+    const epicId = 9001;
+    const stories = [11, 12].map((id) => ({
+      id,
+      number: id,
+      labels: ['type::story'],
+      body: '',
+      title: `Story #${id}`,
+      state: 'open',
+    }));
+    const epicSnapshot = {
+      id: epicId,
+      number: epicId,
+      labels: ['type::epic', 'acceptance::n-a'],
+      body: '',
+      title: `Epic #${epicId}`,
+      updatedAt: '2026-05-26T00:00:00Z',
+    };
+    const baseSha = computeBaseSha(epicSnapshot);
+    await writePreflightCache({
+      epicId,
+      baseSha,
+      epic: epicSnapshot,
+      stories,
+      waves: [stories],
+      cwd: workCwd,
+    });
+
+    const provider = buildCountingProvider({ epicId, stories });
+    const result = await runEpicDeliverPrepare({
+      epicId,
+      cwd: workCwd,
+      injectedProvider: provider,
+      injectedConfig: FAKE_CONFIG,
+    });
+
+    assert.equal(result.preflightCache, 'hit');
+    assert.equal(result.totalWaves, 1);
+    assert.equal(result.plan.length, 1);
+    assert.equal(result.plan[0].stories.length, 2);
+    // Cache hit: getSubTickets MUST NOT have been called by prepare
+    // (the snapshot+DAG walk is what we're skipping).
+    assert.equal(provider._counts.getSubTickets, 0);
+    // getTicket is called once to fingerprint the Epic for baseSha
+    // comparison. The state-store may also call getTicket while reading
+    // the checkpoint, so we assert a small upper bound rather than 1.
+    assert.ok(provider._counts.getTicket >= 1);
+  });
+
+  it('falls back to a fresh snapshot+DAG pass when the cache is missing', async () => {
+    const epicId = 9002;
+    const stories = [21].map((id) => ({
+      id,
+      number: id,
+      labels: ['type::story'],
+      body: '',
+      title: `Story #${id}`,
+      state: 'open',
+    }));
+    const provider = buildCountingProvider({ epicId, stories });
+
+    const result = await runEpicDeliverPrepare({
+      epicId,
+      cwd: workCwd,
+      injectedProvider: provider,
+      injectedConfig: FAKE_CONFIG,
+    });
+
+    assert.equal(result.preflightCache, 'miss');
+    assert.equal(result.totalWaves, 1);
+    assert.equal(result.plan.length, 1);
+    // Miss: the snapshot phase walked the hierarchy via getSubTickets.
+    assert.ok(provider._counts.getSubTickets >= 1);
+  });
+
+  it('falls back to a fresh pass when the cached baseSha is stale', async () => {
+    const epicId = 9003;
+    const stories = [31, 32].map((id) => ({
+      id,
+      number: id,
+      labels: ['type::story'],
+      body: '',
+      title: `Story #${id}`,
+      state: 'open',
+    }));
+    // Seed the cache with a baseSha derived from an Epic snapshot that
+    // does NOT match what the provider will return (different body).
+    const staleEpic = {
+      id: epicId,
+      number: epicId,
+      labels: ['type::epic', 'acceptance::n-a'],
+      body: 'stale body — pre-replan',
+      title: `Epic #${epicId}`,
+      updatedAt: '2026-05-25T00:00:00Z',
+    };
+    await writePreflightCache({
+      epicId,
+      baseSha: computeBaseSha(staleEpic),
+      epic: staleEpic,
+      stories: [],
+      waves: [[]],
+      cwd: workCwd,
+    });
+
+    const provider = buildCountingProvider({ epicId, stories });
+    const result = await runEpicDeliverPrepare({
+      epicId,
+      cwd: workCwd,
+      injectedProvider: provider,
+      injectedConfig: FAKE_CONFIG,
+    });
+
+    assert.equal(result.preflightCache, 'stale');
+    // Stale: the fresh pass reflects the *current* hierarchy, not the
+    // empty wave the stale cache carried.
+    assert.equal(result.totalWaves, 1);
+    assert.equal(result.plan[0].stories.length, 2);
+    assert.ok(provider._counts.getSubTickets >= 1);
+  });
+});

--- a/tests/epic-execute/epic-execute-record-wave.test.js
+++ b/tests/epic-execute/epic-execute-record-wave.test.js
@@ -57,7 +57,7 @@ const TEST_CONFIG = {
 /** Skip subprocess `dispatcher.js --dry-run` — not under test here. */
 const FAST_RECORD = {
   injectedConfig: TEST_CONFIG,
-  injectedRefreshLocalManifest: async () => {},
+  injectedRefreshDispatchManifest: async () => ({}),
   // Stub out the curated webhook emits by default so tests that don't
   // care about notify routing can't reach the real notify() (which would
   // POST to the operator's Slack webhook when NODE_ENV isn't 'test', e.g.
@@ -217,7 +217,7 @@ describe('parseInputArg', () => {
 });
 
 describe('runEpicExecuteRecordWave', () => {
-  it('routes manifest refresh through injectedRefreshLocalManifest', async () => {
+  it('routes manifest refresh through injectedRefreshDispatchManifest', async () => {
     let refreshEpicId;
     const provider = createFakeProvider();
     await seedCheckpoint(provider, 700);
@@ -226,8 +226,9 @@ describe('runEpicExecuteRecordWave', () => {
       wave: 0,
       results: [{ storyId: 1, status: 'done' }],
       injectedProvider: provider,
-      injectedRefreshLocalManifest: async ({ epicId }) => {
+      injectedRefreshDispatchManifest: async ({ epicId }) => {
         refreshEpicId = epicId;
+        return { epicId, body: '', posted: false };
       },
     });
     assert.equal(refreshEpicId, 700);

--- a/tests/lib/config-runners.test.js
+++ b/tests/lib/config-runners.test.js
@@ -35,6 +35,7 @@ describe('getRunners', () => {
     assert.deepEqual(r.deliverRunner, {
       concurrencyCap: 5,
       progressReportIntervalSec: 60,
+      verifyConcurrencyCap: 4,
     });
   });
 

--- a/tests/lib/observability/perf-aggregator.test.js
+++ b/tests/lib/observability/perf-aggregator.test.js
@@ -247,32 +247,41 @@ describe('computeEpicPerfReport', () => {
     ]);
   });
 
-  it('coerces waveParallelism rows to non-negative integers', () => {
+  it('coerces waveParallelism rows to the schema-canonical utilisation shape', () => {
     const out = computeEpicPerfReport([], {
       epicId: 1,
       waveParallelism: [
         {
-          wave: 1,
+          waveIndex: 1,
           wallClockMs: 1000,
-          sumStoryMs: 4000,
-          utilization: 0.25,
-          stories: 4,
+          summedStoryMs: 4000,
+          utilisation: 0.25,
+          capBinding: true,
+          verifyConcurrencyCap: 4,
         },
         {
-          wave: -2,
+          waveIndex: -2,
           wallClockMs: 'bad',
-          sumStoryMs: null,
-          utilization: -1,
-          stories: 1.7,
+          summedStoryMs: null,
+          utilisation: -1,
+          capBinding: 0,
+          verifyConcurrencyCap: 0,
         },
       ],
     });
     assert.equal(out.waveParallelism.length, 2);
-    assert.equal(out.waveParallelism[1].wave, 0);
+    // First row passes through (already canonical).
+    assert.equal(out.waveParallelism[0].waveIndex, 1);
+    assert.equal(out.waveParallelism[0].capBinding, true);
+    assert.equal(out.waveParallelism[0].verifyConcurrencyCap, 4);
+    // Second row coerces garbage to safe defaults.
+    assert.equal(out.waveParallelism[1].waveIndex, 0);
     assert.equal(out.waveParallelism[1].wallClockMs, 0);
-    assert.equal(out.waveParallelism[1].sumStoryMs, 0);
-    assert.equal(out.waveParallelism[1].utilization, 0);
-    assert.equal(out.waveParallelism[1].stories, 1);
+    assert.equal(out.waveParallelism[1].summedStoryMs, 0);
+    assert.equal(out.waveParallelism[1].utilisation, 0);
+    assert.equal(out.waveParallelism[1].capBinding, false);
+    // verifyConcurrencyCap falls back to the project default when omitted/invalid.
+    assert.equal(out.waveParallelism[1].verifyConcurrencyCap, 4);
   });
 
   it('rejects bad epicId', () => {

--- a/tests/perf-aggregator-shape.test.js
+++ b/tests/perf-aggregator-shape.test.js
@@ -1,0 +1,102 @@
+/**
+ * Schema-shape tests for the extended `waveParallelism[]` row (Epic #3019
+ * / Story #3025 / Task #3034).
+ *
+ * Pins the post-reshape contract: rows now carry
+ * `{ waveIndex, wallClockMs, summedStoryMs, utilisation, capBinding,
+ * verifyConcurrencyCap }`, with `summedStoryMs` as a required field.
+ */
+
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { describe, it } from 'node:test';
+import { fileURLToPath } from 'node:url';
+import Ajv from 'ajv';
+import addFormats from 'ajv-formats';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const SCHEMA_PATH = path.resolve(
+  __dirname,
+  '..',
+  '.agents',
+  'schemas',
+  'epic-perf-report.schema.json',
+);
+
+const schema = JSON.parse(readFileSync(SCHEMA_PATH, 'utf8'));
+
+function compile() {
+  const ajv = new Ajv({ allErrors: true, strict: false });
+  addFormats(ajv);
+  return ajv.compile(schema);
+}
+
+function basePayload(overrides = {}) {
+  return {
+    kind: 'epic-perf-report',
+    epicId: 3019,
+    generatedAt: '2026-05-26T21:00:00.000Z',
+    signalCounts: {
+      friction: 0,
+      hotspot: 0,
+      rework: 0,
+      churn: 0,
+      idle: 0,
+      retry: 0,
+    },
+    waveParallelism: [],
+    topHotspots: [],
+    mostFrictionStories: [],
+    ...overrides,
+  };
+}
+
+describe('epic-perf-report.schema.json — waveParallelism utilisation row shape (Story #3025)', () => {
+  it('validates a row with { waveIndex, wallClockMs, summedStoryMs, utilisation, capBinding, verifyConcurrencyCap }', () => {
+    const validate = compile();
+    const ok = validate(
+      basePayload({
+        waveParallelism: [
+          {
+            waveIndex: 0,
+            wallClockMs: 60000,
+            summedStoryMs: 90000,
+            utilisation: 0.75,
+            capBinding: false,
+            verifyConcurrencyCap: 4,
+          },
+        ],
+      }),
+    );
+    assert.equal(ok, true, JSON.stringify(validate.errors));
+  });
+
+  it('rejects a row missing summedStoryMs', () => {
+    const validate = compile();
+    const ok = validate(
+      basePayload({
+        waveParallelism: [
+          {
+            waveIndex: 0,
+            wallClockMs: 60000,
+            // summedStoryMs intentionally omitted
+            utilisation: 0.5,
+            capBinding: false,
+            verifyConcurrencyCap: 4,
+          },
+        ],
+      }),
+    );
+    assert.equal(ok, false);
+    const errors = validate.errors ?? [];
+    const missing = errors.find(
+      (e) =>
+        e.keyword === 'required' && e.params?.missingProperty === 'summedStoryMs',
+    );
+    assert.ok(
+      missing,
+      `expected missing summedStoryMs error, got: ${JSON.stringify(errors)}`,
+    );
+  });
+});

--- a/tests/perf-aggregator-shape.test.js
+++ b/tests/perf-aggregator-shape.test.js
@@ -92,7 +92,8 @@ describe('epic-perf-report.schema.json — waveParallelism utilisation row shape
     const errors = validate.errors ?? [];
     const missing = errors.find(
       (e) =>
-        e.keyword === 'required' && e.params?.missingProperty === 'summedStoryMs',
+        e.keyword === 'required' &&
+        e.params?.missingProperty === 'summedStoryMs',
     );
     assert.ok(
       missing,

--- a/tests/perf-aggregator-wave-parallelism.test.js
+++ b/tests/perf-aggregator-wave-parallelism.test.js
@@ -1,0 +1,164 @@
+/**
+ * Unit tests for `computeWaveParallelismRows` and the
+ * `computeEpicPerfReport(events)` derivation path (Epic #3019 /
+ * Story #3025 / Task #3028).
+ *
+ * Covers:
+ *   - Single-wave happy path: utilisation = summedStoryMs /
+ *     (wallClockMs * concurrencyCap), clamped to [0, 1].
+ *   - Multi-wave run: each wave is bracketed by its own
+ *     `wave-start` / `wave-complete` pair.
+ *   - Zero-Story wave: produces a row whose summedStoryMs / utilisation
+ *     are both 0 without throwing.
+ *   - Clamping edge: when summedStoryMs / wallClockMs ≥ concurrencyCap,
+ *     utilisation clamps at 1 and capBinding flips true.
+ */
+
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import {
+  computeEpicPerfReport,
+  computeWaveParallelismRows,
+} from '../.agents/scripts/lib/observability/perf-aggregator.js';
+
+function tx({ ts, story, to }) {
+  return {
+    kind: 'state-transition',
+    ts,
+    story,
+    details: { to },
+  };
+}
+
+function waveStart({ ts, index, stories, totalWaves = 1 }) {
+  return {
+    kind: 'wave-start',
+    ts,
+    index,
+    totalWaves,
+    stories: stories.map((id) => ({ id })),
+  };
+}
+
+function waveComplete({ ts, index, totalWaves = 1 }) {
+  return { kind: 'wave-complete', ts, index, totalWaves };
+}
+
+describe('computeWaveParallelismRows — Story #3025 / Task #3028', () => {
+  it('single wave: utilisation = summedStoryMs / (wallClockMs * cap), capBinding false when below cap', () => {
+    // Wave 0 wall-clock = 10s; Stories 1+2 each ran 6s in serial-ish overlap.
+    const events = [
+      waveStart({ ts: '2026-05-26T00:00:00.000Z', index: 0, stories: [1, 2] }),
+      tx({ ts: '2026-05-26T00:00:01.000Z', story: 1, to: 'agent::executing' }),
+      tx({ ts: '2026-05-26T00:00:07.000Z', story: 1, to: 'agent::done' }),
+      tx({ ts: '2026-05-26T00:00:02.000Z', story: 2, to: 'agent::executing' }),
+      tx({ ts: '2026-05-26T00:00:08.000Z', story: 2, to: 'agent::done' }),
+      waveComplete({ ts: '2026-05-26T00:00:10.000Z', index: 0 }),
+    ];
+    const rows = computeWaveParallelismRows(events, {
+      concurrencyCap: 2,
+      verifyConcurrencyCap: 4,
+    });
+    assert.equal(rows.length, 1);
+    const r = rows[0];
+    assert.equal(r.waveIndex, 0);
+    assert.equal(r.wallClockMs, 10000);
+    // Story 1: 6000ms, Story 2: 6000ms → summed = 12000ms
+    assert.equal(r.summedStoryMs, 12000);
+    // utilisation = 12000 / (10000 * 2) = 0.6
+    assert.equal(Math.round(r.utilisation * 1000) / 1000, 0.6);
+    assert.equal(r.capBinding, false);
+    assert.equal(r.verifyConcurrencyCap, 4);
+  });
+
+  it('multi-wave: emits one row per wave with independent windows', () => {
+    const events = [
+      waveStart({
+        ts: '2026-05-26T00:00:00.000Z',
+        index: 0,
+        stories: [1],
+        totalWaves: 2,
+      }),
+      tx({ ts: '2026-05-26T00:00:01.000Z', story: 1, to: 'agent::executing' }),
+      tx({ ts: '2026-05-26T00:00:03.000Z', story: 1, to: 'agent::done' }),
+      waveComplete({
+        ts: '2026-05-26T00:00:05.000Z',
+        index: 0,
+        totalWaves: 2,
+      }),
+      waveStart({
+        ts: '2026-05-26T00:00:10.000Z',
+        index: 1,
+        stories: [2],
+        totalWaves: 2,
+      }),
+      tx({ ts: '2026-05-26T00:00:11.000Z', story: 2, to: 'agent::executing' }),
+      tx({ ts: '2026-05-26T00:00:15.000Z', story: 2, to: 'agent::done' }),
+      waveComplete({
+        ts: '2026-05-26T00:00:20.000Z',
+        index: 1,
+        totalWaves: 2,
+      }),
+    ];
+    const rows = computeWaveParallelismRows(events, { concurrencyCap: 2 });
+    assert.equal(rows.length, 2);
+    assert.equal(rows[0].waveIndex, 0);
+    assert.equal(rows[0].wallClockMs, 5000);
+    assert.equal(rows[0].summedStoryMs, 2000);
+    assert.equal(rows[1].waveIndex, 1);
+    assert.equal(rows[1].wallClockMs, 10000);
+    assert.equal(rows[1].summedStoryMs, 4000);
+  });
+
+  it('zero-Story wave: row emitted with summedStoryMs and utilisation = 0', () => {
+    const events = [
+      waveStart({ ts: '2026-05-26T00:00:00.000Z', index: 0, stories: [] }),
+      waveComplete({ ts: '2026-05-26T00:00:05.000Z', index: 0 }),
+    ];
+    const rows = computeWaveParallelismRows(events, { concurrencyCap: 2 });
+    assert.equal(rows.length, 1);
+    assert.equal(rows[0].summedStoryMs, 0);
+    assert.equal(rows[0].utilisation, 0);
+    assert.equal(rows[0].capBinding, false);
+    assert.equal(rows[0].wallClockMs, 5000);
+  });
+
+  it('clamping edge: utilisation clamps to 1 and capBinding flips true at saturation', () => {
+    // Two Stories each ran 10s in a 10s wave with cap=2: summed=20000,
+    // wallClock=10000, summed/wall = 2 ≥ cap → capBinding true,
+    // utilisation = 20000 / (10000 * 2) = 1.0.
+    const events = [
+      waveStart({ ts: '2026-05-26T00:00:00.000Z', index: 0, stories: [1, 2] }),
+      tx({ ts: '2026-05-26T00:00:00.000Z', story: 1, to: 'agent::executing' }),
+      tx({ ts: '2026-05-26T00:00:10.000Z', story: 1, to: 'agent::done' }),
+      tx({ ts: '2026-05-26T00:00:00.000Z', story: 2, to: 'agent::executing' }),
+      tx({ ts: '2026-05-26T00:00:10.000Z', story: 2, to: 'agent::done' }),
+      waveComplete({ ts: '2026-05-26T00:00:10.000Z', index: 0 }),
+    ];
+    const rows = computeWaveParallelismRows(events, { concurrencyCap: 2 });
+    assert.equal(rows.length, 1);
+    assert.equal(rows[0].wallClockMs, 10000);
+    assert.equal(rows[0].summedStoryMs, 20000);
+    assert.equal(rows[0].utilisation, 1);
+    assert.equal(rows[0].capBinding, true);
+  });
+
+  it('computeEpicPerfReport derives waveParallelism when handed raw events', () => {
+    const events = [
+      waveStart({ ts: '2026-05-26T00:00:00.000Z', index: 0, stories: [1] }),
+      tx({ ts: '2026-05-26T00:00:01.000Z', story: 1, to: 'agent::executing' }),
+      tx({ ts: '2026-05-26T00:00:03.000Z', story: 1, to: 'agent::done' }),
+      waveComplete({ ts: '2026-05-26T00:00:05.000Z', index: 0 }),
+    ];
+    const report = computeEpicPerfReport([], {
+      epicId: 3019,
+      events,
+      concurrencyCap: 2,
+      verifyConcurrencyCap: 4,
+    });
+    assert.equal(report.waveParallelism.length, 1);
+    assert.equal(report.waveParallelism[0].waveIndex, 0);
+    assert.equal(report.waveParallelism[0].summedStoryMs, 2000);
+  });
+});

--- a/tests/retro-perf-heuristics.test.js
+++ b/tests/retro-perf-heuristics.test.js
@@ -49,9 +49,7 @@ describe('classifyPerfSignals (Story #3045)', () => {
           capBinding: true,
         },
       ],
-      storyPerfSummaries: [
-        { phaseTimingsMs: { 'story-init': 100 } },
-      ],
+      storyPerfSummaries: [{ phaseTimingsMs: { 'story-init': 100 } }],
     });
     const signals = classifyPerfSignals(report);
     assert.deepEqual(signals, []);
@@ -127,9 +125,7 @@ describe('classifyPerfSignals (Story #3045)', () => {
           capBinding: false,
         },
       ],
-      storyPerfSummaries: [
-        { phaseTimingsMs: { 'story-init': 100 } },
-      ],
+      storyPerfSummaries: [{ phaseTimingsMs: { 'story-init': 100 } }],
     });
     const signals = classifyPerfSignals(report);
     assert.equal(
@@ -242,14 +238,8 @@ describe('classifyPerfSignals (Story #3045)', () => {
       bootstrapShare: 0.4,
       capBindingRunLength: 2,
     });
-    assert.equal(
-      signals.filter((s) => s.kind === 'low-utilisation').length,
-      2,
-    );
-    assert.equal(
-      signals.filter((s) => s.kind === 'cap-binding-run').length,
-      1,
-    );
+    assert.equal(signals.filter((s) => s.kind === 'low-utilisation').length, 2);
+    assert.equal(signals.filter((s) => s.kind === 'cap-binding-run').length, 1);
   });
 
   it('resolvePerfThresholds falls back to documented defaults', () => {
@@ -257,15 +247,15 @@ describe('classifyPerfSignals (Story #3045)', () => {
       resolvePerfThresholds(undefined),
       DEFAULT_RETRO_PERF_THRESHOLDS,
     );
-    assert.deepEqual(resolvePerfThresholds(null), DEFAULT_RETRO_PERF_THRESHOLDS);
+    assert.deepEqual(
+      resolvePerfThresholds(null),
+      DEFAULT_RETRO_PERF_THRESHOLDS,
+    );
     assert.deepEqual(resolvePerfThresholds({}), DEFAULT_RETRO_PERF_THRESHOLDS);
     assert.deepEqual(
       resolvePerfThresholds({ utilisation: -1, capBindingRunLength: 0 }),
       DEFAULT_RETRO_PERF_THRESHOLDS,
     );
-    assert.equal(
-      resolvePerfThresholds({ utilisation: 0.5 }).utilisation,
-      0.5,
-    );
+    assert.equal(resolvePerfThresholds({ utilisation: 0.5 }).utilisation, 0.5);
   });
 });

--- a/tests/retro-perf-heuristics.test.js
+++ b/tests/retro-perf-heuristics.test.js
@@ -1,0 +1,271 @@
+// tests/retro-perf-heuristics.test.js
+/**
+ * Story #3042 / Task #3045 — `classifyPerfSignals` heuristics over the
+ * `epic-perf-report.waveParallelism` row shape.
+ *
+ * Confirms each of the three signal kinds and the no-signal happy path:
+ *   - `low-utilisation` per wave below the threshold.
+ *   - `high-bootstrap-share` when summed story-init time exceeds threshold
+ *     of the cumulative summedStoryMs.
+ *   - `cap-binding-run` for runs of consecutive capBinding waves.
+ *   - Empty array when no signal trips.
+ */
+
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'node:test';
+
+import {
+  classifyPerfSignals,
+  DEFAULT_RETRO_PERF_THRESHOLDS,
+  resolvePerfThresholds,
+} from '../.agents/scripts/lib/orchestration/retro-perf-heuristics.js';
+
+function makeReport({ waveParallelism = [], storyPerfSummaries = [] } = {}) {
+  return {
+    kind: 'epic-perf-report',
+    epicId: 99,
+    generatedAt: '2026-05-26T00:00:00Z',
+    waveParallelism,
+    storyPerfSummaries,
+  };
+}
+
+describe('classifyPerfSignals (Story #3045)', () => {
+  it('returns [] when no signal trips', () => {
+    const report = makeReport({
+      waveParallelism: [
+        {
+          waveIndex: 0,
+          wallClockMs: 1000,
+          summedStoryMs: 1500,
+          utilisation: 0.75,
+          capBinding: false,
+        },
+        {
+          waveIndex: 1,
+          wallClockMs: 2000,
+          summedStoryMs: 2400,
+          utilisation: 0.6,
+          capBinding: true,
+        },
+      ],
+      storyPerfSummaries: [
+        { phaseTimingsMs: { 'story-init': 100 } },
+      ],
+    });
+    const signals = classifyPerfSignals(report);
+    assert.deepEqual(signals, []);
+  });
+
+  it('returns low-utilisation per wave below threshold', () => {
+    const report = makeReport({
+      waveParallelism: [
+        {
+          waveIndex: 0,
+          wallClockMs: 1000,
+          summedStoryMs: 400,
+          utilisation: 0.2,
+          capBinding: false,
+        },
+        {
+          waveIndex: 1,
+          wallClockMs: 1000,
+          summedStoryMs: 1500,
+          utilisation: 0.75,
+          capBinding: false,
+        },
+        {
+          waveIndex: 2,
+          wallClockMs: 1000,
+          summedStoryMs: 200,
+          utilisation: 0.1,
+          capBinding: false,
+        },
+      ],
+    });
+    const signals = classifyPerfSignals(report);
+    const lows = signals.filter((s) => s.kind === 'low-utilisation');
+    assert.equal(lows.length, 2);
+    assert.equal(lows[0].waveIndex, 0);
+    assert.equal(lows[0].utilisation, 0.2);
+    assert.equal(lows[0].threshold, DEFAULT_RETRO_PERF_THRESHOLDS.utilisation);
+    assert.equal(lows[1].waveIndex, 2);
+  });
+
+  it('returns high-bootstrap-share when story-init dwarfs wave time', () => {
+    const report = makeReport({
+      waveParallelism: [
+        {
+          waveIndex: 0,
+          wallClockMs: 1000,
+          summedStoryMs: 1000,
+          utilisation: 0.75,
+          capBinding: false,
+        },
+      ],
+      storyPerfSummaries: [
+        { phaseTimingsMs: { 'story-init': 500 } },
+        { phaseTimingsMs: { 'story-init': 200 } },
+      ],
+    });
+    const signals = classifyPerfSignals(report);
+    const highs = signals.filter((s) => s.kind === 'high-bootstrap-share');
+    assert.equal(highs.length, 1);
+    assert.equal(highs[0].bootstrapMs, 700);
+    assert.equal(highs[0].summedStoryMs, 1000);
+    assert.equal(highs[0].share, 0.7);
+  });
+
+  it('does not emit high-bootstrap-share when bootstrap is small', () => {
+    const report = makeReport({
+      waveParallelism: [
+        {
+          waveIndex: 0,
+          wallClockMs: 1000,
+          summedStoryMs: 1000,
+          utilisation: 0.75,
+          capBinding: false,
+        },
+      ],
+      storyPerfSummaries: [
+        { phaseTimingsMs: { 'story-init': 100 } },
+      ],
+    });
+    const signals = classifyPerfSignals(report);
+    assert.equal(
+      signals.filter((s) => s.kind === 'high-bootstrap-share').length,
+      0,
+    );
+  });
+
+  it('returns cap-binding-run when consecutive waves cap-bind', () => {
+    const report = makeReport({
+      waveParallelism: [
+        {
+          waveIndex: 0,
+          wallClockMs: 1000,
+          summedStoryMs: 1500,
+          utilisation: 0.75,
+          capBinding: false,
+        },
+        {
+          waveIndex: 1,
+          wallClockMs: 1000,
+          summedStoryMs: 2000,
+          utilisation: 1,
+          capBinding: true,
+        },
+        {
+          waveIndex: 2,
+          wallClockMs: 1000,
+          summedStoryMs: 2000,
+          utilisation: 1,
+          capBinding: true,
+        },
+        {
+          waveIndex: 3,
+          wallClockMs: 1000,
+          summedStoryMs: 2000,
+          utilisation: 1,
+          capBinding: true,
+        },
+      ],
+    });
+    const signals = classifyPerfSignals(report);
+    const runs = signals.filter((s) => s.kind === 'cap-binding-run');
+    assert.equal(runs.length, 1);
+    assert.equal(runs[0].fromWaveIndex, 1);
+    assert.equal(runs[0].toWaveIndex, 3);
+    assert.equal(runs[0].runLength, 3);
+  });
+
+  it('does not emit cap-binding-run for single-wave bindings', () => {
+    const report = makeReport({
+      waveParallelism: [
+        {
+          waveIndex: 0,
+          wallClockMs: 1000,
+          summedStoryMs: 2000,
+          utilisation: 1,
+          capBinding: true,
+        },
+        {
+          waveIndex: 1,
+          wallClockMs: 1000,
+          summedStoryMs: 1500,
+          utilisation: 0.75,
+          capBinding: false,
+        },
+        {
+          waveIndex: 2,
+          wallClockMs: 1000,
+          summedStoryMs: 2000,
+          utilisation: 1,
+          capBinding: true,
+        },
+      ],
+    });
+    const signals = classifyPerfSignals(report);
+    const runs = signals.filter((s) => s.kind === 'cap-binding-run');
+    assert.equal(runs.length, 0);
+  });
+
+  it('returns [] when report is malformed', () => {
+    assert.deepEqual(classifyPerfSignals(null), []);
+    assert.deepEqual(classifyPerfSignals(undefined), []);
+    assert.deepEqual(classifyPerfSignals({}), []);
+    assert.deepEqual(classifyPerfSignals({ waveParallelism: 'nope' }), []);
+  });
+
+  it('respects custom thresholds', () => {
+    const report = makeReport({
+      waveParallelism: [
+        {
+          waveIndex: 0,
+          wallClockMs: 1000,
+          summedStoryMs: 1500,
+          utilisation: 0.75,
+          capBinding: true,
+        },
+        {
+          waveIndex: 1,
+          wallClockMs: 1000,
+          summedStoryMs: 1500,
+          utilisation: 0.75,
+          capBinding: true,
+        },
+      ],
+    });
+    // Raise utilisation threshold so 0.75 is "low"; require run length 2.
+    const signals = classifyPerfSignals(report, {
+      utilisation: 0.8,
+      bootstrapShare: 0.4,
+      capBindingRunLength: 2,
+    });
+    assert.equal(
+      signals.filter((s) => s.kind === 'low-utilisation').length,
+      2,
+    );
+    assert.equal(
+      signals.filter((s) => s.kind === 'cap-binding-run').length,
+      1,
+    );
+  });
+
+  it('resolvePerfThresholds falls back to documented defaults', () => {
+    assert.deepEqual(
+      resolvePerfThresholds(undefined),
+      DEFAULT_RETRO_PERF_THRESHOLDS,
+    );
+    assert.deepEqual(resolvePerfThresholds(null), DEFAULT_RETRO_PERF_THRESHOLDS);
+    assert.deepEqual(resolvePerfThresholds({}), DEFAULT_RETRO_PERF_THRESHOLDS);
+    assert.deepEqual(
+      resolvePerfThresholds({ utilisation: -1, capBindingRunLength: 0 }),
+      DEFAULT_RETRO_PERF_THRESHOLDS,
+    );
+    assert.equal(
+      resolvePerfThresholds({ utilisation: 0.5 }).utilisation,
+      0.5,
+    );
+  });
+});

--- a/tests/retro-runner-perf-signals.test.js
+++ b/tests/retro-runner-perf-signals.test.js
@@ -173,7 +173,11 @@ describe('retro-runner perf-signals rendering (Story #3044)', () => {
       counts: baseCounts(),
       epicPerfReport,
       storyPerfSummaries: [],
-      perfThresholds: { utilisation: 0.1, bootstrapShare: 0.4, capBindingRunLength: 2 },
+      perfThresholds: {
+        utilisation: 0.1,
+        bootstrapShare: 0.4,
+        capBindingRunLength: 2,
+      },
       forceFull: true,
     });
     // utilisation threshold lowered below the observed 0.2 → no signal.
@@ -198,9 +202,7 @@ describe('retro-runner perf-signals rendering (Story #3044)', () => {
       epicId: 99,
       counts: baseCounts(),
       epicPerfReport,
-      storyPerfSummaries: [
-        { phaseTimingsMs: { 'story-init': 700 } },
-      ],
+      storyPerfSummaries: [{ phaseTimingsMs: { 'story-init': 700 } }],
       forceFull: true,
     });
     assert.match(body, /high-bootstrap-share/);

--- a/tests/retro-runner-perf-signals.test.js
+++ b/tests/retro-runner-perf-signals.test.js
@@ -1,0 +1,209 @@
+// tests/retro-runner-perf-signals.test.js
+/**
+ * Story #3042 / Task #3044 — retro-runner wires `classifyPerfSignals`
+ * into the composed retro body. Confirms:
+ *
+ *   - `## Performance Signals` section lists each classified signal when
+ *     the persisted epic-perf-report is present and signals trip.
+ *   - `## Recommended Follow-Ons` section contains one stanza per signal,
+ *     each with a Conventional-Commits-shaped title and a body that
+ *     includes the `meta::framework-gap` label.
+ *   - Both sections are omitted entirely when no signal trips OR when the
+ *     epic-perf-report is absent (null).
+ */
+
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'node:test';
+
+import { composeRetroBody } from '../.agents/scripts/lib/orchestration/retro/phases/compose-body.js';
+
+function baseCounts(overrides = {}) {
+  return {
+    friction: 1,
+    parked: 0,
+    recuts: 0,
+    hotfixes: 0,
+    hitl: 0,
+    interventions: 0,
+    ...overrides,
+  };
+}
+
+describe('retro-runner perf-signals rendering (Story #3044)', () => {
+  it('renders Performance Signals + Recommended Follow-Ons when signals trip', () => {
+    const epicPerfReport = {
+      kind: 'epic-perf-report',
+      epicId: 99,
+      waveParallelism: [
+        {
+          waveIndex: 0,
+          wallClockMs: 1000,
+          summedStoryMs: 200,
+          utilisation: 0.1,
+          capBinding: false,
+        },
+        {
+          waveIndex: 1,
+          wallClockMs: 1000,
+          summedStoryMs: 2000,
+          utilisation: 1,
+          capBinding: true,
+        },
+        {
+          waveIndex: 2,
+          wallClockMs: 1000,
+          summedStoryMs: 2000,
+          utilisation: 1,
+          capBinding: true,
+        },
+      ],
+    };
+
+    const { body, compact } = composeRetroBody({
+      epicId: 99,
+      counts: baseCounts(),
+      epicPerfReport,
+      storyPerfSummaries: [],
+      forceFull: true,
+    });
+
+    assert.equal(compact, false);
+    assert.match(body, /^## Performance Signals$/m);
+    assert.match(body, /^## Recommended Follow-Ons$/m);
+    // low-utilisation bullet for wave 0
+    assert.match(body, /low-utilisation: wave 0/);
+    // cap-binding-run bullet covering waves 1-2
+    assert.match(body, /cap-binding-run: waves 1.{1,3}2/);
+    // Conventional-Commits-shaped title in follow-on stanza
+    assert.match(body, /perf\(epic-deliver\): investigate low utilisation/);
+    // meta::framework-gap label hint present
+    assert.match(body, /meta::framework-gap/);
+    // gh issue create paste-ready stanza present
+    assert.match(body, /gh issue create --title/);
+  });
+
+  it('omits both sections when no signal trips', () => {
+    const epicPerfReport = {
+      kind: 'epic-perf-report',
+      epicId: 99,
+      waveParallelism: [
+        {
+          waveIndex: 0,
+          wallClockMs: 1000,
+          summedStoryMs: 1500,
+          utilisation: 0.75,
+          capBinding: false,
+        },
+      ],
+    };
+
+    const { body } = composeRetroBody({
+      epicId: 99,
+      counts: baseCounts(),
+      epicPerfReport,
+      storyPerfSummaries: [],
+      forceFull: true,
+    });
+
+    assert.doesNotMatch(body, /## Performance Signals/);
+    assert.doesNotMatch(body, /## Recommended Follow-Ons/);
+  });
+
+  it('omits both sections when epic-perf-report is absent', () => {
+    const { body } = composeRetroBody({
+      epicId: 99,
+      counts: baseCounts(),
+      epicPerfReport: null,
+      storyPerfSummaries: [],
+      forceFull: true,
+    });
+
+    assert.doesNotMatch(body, /## Performance Signals/);
+    assert.doesNotMatch(body, /## Recommended Follow-Ons/);
+  });
+
+  it('renders one follow-on stanza per signal', () => {
+    const epicPerfReport = {
+      kind: 'epic-perf-report',
+      epicId: 99,
+      waveParallelism: [
+        {
+          waveIndex: 0,
+          wallClockMs: 1000,
+          summedStoryMs: 100,
+          utilisation: 0.05,
+          capBinding: false,
+        },
+        {
+          waveIndex: 1,
+          wallClockMs: 1000,
+          summedStoryMs: 100,
+          utilisation: 0.05,
+          capBinding: false,
+        },
+      ],
+    };
+    const { body } = composeRetroBody({
+      epicId: 99,
+      counts: baseCounts(),
+      epicPerfReport,
+      storyPerfSummaries: [],
+      forceFull: true,
+    });
+    const followOnMatches = body.match(/gh issue create --title/g) ?? [];
+    assert.equal(followOnMatches.length, 2);
+  });
+
+  it('respects custom perfThresholds to suppress signals', () => {
+    const epicPerfReport = {
+      kind: 'epic-perf-report',
+      epicId: 99,
+      waveParallelism: [
+        {
+          waveIndex: 0,
+          wallClockMs: 1000,
+          summedStoryMs: 400,
+          utilisation: 0.2,
+          capBinding: false,
+        },
+      ],
+    };
+    const { body } = composeRetroBody({
+      epicId: 99,
+      counts: baseCounts(),
+      epicPerfReport,
+      storyPerfSummaries: [],
+      perfThresholds: { utilisation: 0.1, bootstrapShare: 0.4, capBindingRunLength: 2 },
+      forceFull: true,
+    });
+    // utilisation threshold lowered below the observed 0.2 → no signal.
+    assert.doesNotMatch(body, /## Performance Signals/);
+  });
+
+  it('renders high-bootstrap-share when storyPerfSummaries carry story-init', () => {
+    const epicPerfReport = {
+      kind: 'epic-perf-report',
+      epicId: 99,
+      waveParallelism: [
+        {
+          waveIndex: 0,
+          wallClockMs: 1000,
+          summedStoryMs: 1000,
+          utilisation: 0.75,
+          capBinding: false,
+        },
+      ],
+    };
+    const { body } = composeRetroBody({
+      epicId: 99,
+      counts: baseCounts(),
+      epicPerfReport,
+      storyPerfSummaries: [
+        { phaseTimingsMs: { 'story-init': 700 } },
+      ],
+      forceFull: true,
+    });
+    assert.match(body, /high-bootstrap-share/);
+    assert.match(body, /perf\(story-init\): reduce bootstrap share/);
+  });
+});

--- a/tests/schemas/signal-schemas.test.js
+++ b/tests/schemas/signal-schemas.test.js
@@ -190,11 +190,12 @@ describe('epic-perf-report.schema.json', () => {
       },
       waveParallelism: [
         {
-          wave: 0,
+          waveIndex: 0,
           wallClockMs: 720000,
-          sumStoryMs: 1800000,
-          utilization: 0.4,
-          stories: 3,
+          summedStoryMs: 1800000,
+          utilisation: 0.4,
+          capBinding: false,
+          verifyConcurrencyCap: 4,
         },
       ],
       topHotspots: [{ phase: 'implement', occurrences: 3, avgRatio: 1.31 }],

--- a/tests/wave-record-io-manifest-refresh.test.js
+++ b/tests/wave-record-io-manifest-refresh.test.js
@@ -1,0 +1,143 @@
+/**
+ * wave-record-io-manifest-refresh.test.js
+ *
+ * Story #3026 — verifies that `refreshDispatchManifest` runs in-process
+ * (no `child_process.spawn` / `spawnSync`) and produces a comment body
+ * byte-identical to the helper-rendered output.
+ */
+
+import assert from 'node:assert/strict';
+import child_process from 'node:child_process';
+import { describe, it, mock } from 'node:test';
+
+import { renderManifestFromManifest } from '../.agents/scripts/lib/presentation/dispatch-manifest-render.js';
+import { refreshDispatchManifest } from '../.agents/scripts/lib/orchestration/wave-record-io.js';
+
+const FIXTURE_MANIFEST = {
+  epicId: 4242,
+  generatedAt: '2026-05-26T14:00:00.000Z',
+  type: 'epic',
+  storyManifest: [
+    {
+      storyId: 4101,
+      storyTitle: 'Refresh story A',
+      type: 'story',
+      earliestWave: 0,
+    },
+    {
+      storyId: 4102,
+      storyTitle: 'Refresh story B',
+      type: 'story',
+      earliestWave: 1,
+    },
+  ],
+};
+
+function buildProvider() {
+  return {
+    postComment: mock.fn(async () => ({ id: 99 })),
+  };
+}
+
+describe('refreshDispatchManifest', () => {
+  it('renders + upserts the dispatch-manifest comment in-process', async () => {
+    const provider = buildProvider();
+    const dispatch = mock.fn(async () => FIXTURE_MANIFEST);
+    const upsertComment = mock.fn(async () => ({ commentId: 1 }));
+    const persist = mock.fn(() => {});
+
+    const result = await refreshDispatchManifest({
+      epicId: FIXTURE_MANIFEST.epicId,
+      provider,
+      dispatch,
+      upsertComment,
+      persist,
+    });
+
+    assert.equal(result.posted, true);
+    assert.equal(result.epicId, FIXTURE_MANIFEST.epicId);
+    assert.equal(result.body, renderManifestFromManifest(FIXTURE_MANIFEST));
+
+    assert.equal(dispatch.mock.callCount(), 1);
+    const dispatchArg = dispatch.mock.calls[0].arguments[0];
+    assert.equal(dispatchArg.ticketId, FIXTURE_MANIFEST.epicId);
+    assert.equal(dispatchArg.dryRun, true);
+    assert.strictEqual(dispatchArg.provider, provider);
+
+    assert.equal(persist.mock.callCount(), 1);
+    assert.strictEqual(persist.mock.calls[0].arguments[0], FIXTURE_MANIFEST);
+
+    assert.equal(upsertComment.mock.callCount(), 1);
+    const [calledProvider, ticketId, type, body] =
+      upsertComment.mock.calls[0].arguments;
+    assert.strictEqual(calledProvider, provider);
+    assert.equal(ticketId, FIXTURE_MANIFEST.epicId);
+    assert.equal(type, 'dispatch-manifest');
+    assert.equal(body, renderManifestFromManifest(FIXTURE_MANIFEST));
+  });
+
+  it('never invokes child_process.spawn or spawnSync', async () => {
+    const spawnSpy = mock.method(child_process, 'spawn', () => {
+      throw new Error(
+        'refreshDispatchManifest must not call child_process.spawn',
+      );
+    });
+    const spawnSyncSpy = mock.method(child_process, 'spawnSync', () => {
+      throw new Error(
+        'refreshDispatchManifest must not call child_process.spawnSync',
+      );
+    });
+
+    try {
+      await refreshDispatchManifest({
+        epicId: FIXTURE_MANIFEST.epicId,
+        provider: buildProvider(),
+        dispatch: async () => FIXTURE_MANIFEST,
+        upsertComment: async () => ({ commentId: 1 }),
+        persist: () => {},
+      });
+    } finally {
+      spawnSpy.mock.restore();
+      spawnSyncSpy.mock.restore();
+    }
+
+    assert.equal(spawnSpy.mock.callCount(), 0);
+    assert.equal(spawnSyncSpy.mock.callCount(), 0);
+  });
+
+  it('returns {posted:false, reason:"no-provider"} when no provider is supplied', async () => {
+    const result = await refreshDispatchManifest({
+      epicId: FIXTURE_MANIFEST.epicId,
+      dispatch: async () => FIXTURE_MANIFEST,
+      persist: () => {},
+    });
+    assert.equal(result.posted, false);
+    assert.equal(result.reason, 'no-provider');
+    assert.equal(result.body, renderManifestFromManifest(FIXTURE_MANIFEST));
+  });
+
+  it('downgrades comment upsert failures to a non-fatal {posted:false} result', async () => {
+    const result = await refreshDispatchManifest({
+      epicId: FIXTURE_MANIFEST.epicId,
+      provider: buildProvider(),
+      dispatch: async () => FIXTURE_MANIFEST,
+      upsertComment: async () => {
+        throw new Error('github 502');
+      },
+      persist: () => {},
+    });
+    assert.equal(result.posted, false);
+    assert.equal(result.reason, 'github 502');
+  });
+
+  it('rejects non-positive epicId inputs', async () => {
+    await assert.rejects(
+      () => refreshDispatchManifest({ epicId: 0 }),
+      /epicId must be a positive integer/,
+    );
+    await assert.rejects(
+      () => refreshDispatchManifest({}),
+      /epicId must be a positive integer/,
+    );
+  });
+});

--- a/tests/wave-record-io-manifest-refresh.test.js
+++ b/tests/wave-record-io-manifest-refresh.test.js
@@ -9,9 +9,8 @@
 import assert from 'node:assert/strict';
 import child_process from 'node:child_process';
 import { describe, it, mock } from 'node:test';
-
-import { renderManifestFromManifest } from '../.agents/scripts/lib/presentation/dispatch-manifest-render.js';
 import { refreshDispatchManifest } from '../.agents/scripts/lib/orchestration/wave-record-io.js';
+import { renderManifestFromManifest } from '../.agents/scripts/lib/presentation/dispatch-manifest-render.js';
 
 const FIXTURE_MANIFEST = {
   epicId: 4242,

--- a/tests/wave-record-io-verify-concurrency.test.js
+++ b/tests/wave-record-io-verify-concurrency.test.js
@@ -101,7 +101,10 @@ describe('verifyWaveResults — bounded concurrency (Story #3024)', () => {
     // Half the rows are *not* actually done on GitHub → discrepancy.
     const labelsByStory = new Map();
     for (let i = 0; i < 10; i += 1) {
-      labelsByStory.set(100 + i, i % 2 === 0 ? ['agent::done'] : ['agent::executing']);
+      labelsByStory.set(
+        100 + i,
+        i % 2 === 0 ? ['agent::done'] : ['agent::executing'],
+      );
     }
     const provider = buildLabelMapProvider(labelsByStory);
     const { verified, discrepancies } = await verifyWaveResults({
@@ -116,7 +119,9 @@ describe('verifyWaveResults — bounded concurrency (Story #3024)', () => {
     }
     // Five odd-indexed Stories should be discrepancies.
     assert.equal(discrepancies.length, 5);
-    const disStoryIds = discrepancies.map((d) => d.storyId).sort((a, b) => a - b);
+    const disStoryIds = discrepancies
+      .map((d) => d.storyId)
+      .sort((a, b) => a - b);
     assert.deepEqual(disStoryIds, [101, 103, 105, 107, 109]);
     for (const d of discrepancies) {
       assert.equal(d.claimed, 'done');

--- a/tests/wave-record-io-verify-concurrency.test.js
+++ b/tests/wave-record-io-verify-concurrency.test.js
@@ -1,0 +1,271 @@
+// tests/wave-record-io-verify-concurrency.test.js
+/**
+ * Story #3024 / Task #3031 — bounded-concurrency verifyWaveResults.
+ *
+ * Confirms:
+ *   - Results array larger than the cap completes with one outcome per
+ *     row, preserving input order and the same discrepancy surface the
+ *     serial implementation produced.
+ *   - A per-row `provider.getTicket` throw degrades that row to a
+ *     `verify-error` discrepancy rather than aborting the whole wave.
+ *   - The cap is honoured at runtime: never more than `cap` mappers in
+ *     flight at once.
+ *   - The default cap is 4 when `concurrencyCap` is omitted.
+ */
+
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'node:test';
+
+import { verifyWaveResults } from '../.agents/scripts/lib/orchestration/wave-record-io.js';
+
+/**
+ * Build a provider whose `getTicket` is gated on a manually-released
+ * promise per story. Returns the provider + a `release(storyId, ticket)`
+ * helper plus an `inFlight()` probe so the test can assert the cap.
+ */
+function buildGatedProvider() {
+  const gates = new Map(); // storyId → { resolve, reject, promise }
+  let inFlight = 0;
+  let maxInFlight = 0;
+  const provider = {
+    async getTicket(storyId) {
+      inFlight += 1;
+      if (inFlight > maxInFlight) maxInFlight = inFlight;
+      try {
+        let gate = gates.get(storyId);
+        if (!gate) {
+          gate = {};
+          gate.promise = new Promise((resolve, reject) => {
+            gate.resolve = resolve;
+            gate.reject = reject;
+          });
+          gates.set(storyId, gate);
+        }
+        const outcome = await gate.promise;
+        if (outcome && outcome.throw) throw outcome.throw;
+        return outcome.ticket;
+      } finally {
+        inFlight -= 1;
+      }
+    },
+  };
+  return {
+    provider,
+    release(storyId, ticket) {
+      let gate = gates.get(storyId);
+      if (!gate) {
+        gate = {};
+        gate.promise = new Promise((resolve, reject) => {
+          gate.resolve = resolve;
+          gate.reject = reject;
+        });
+        gates.set(storyId, gate);
+      }
+      gate.resolve({ ticket });
+    },
+    failWith(storyId, err) {
+      let gate = gates.get(storyId);
+      if (!gate) {
+        gate = {};
+        gate.promise = new Promise((resolve, reject) => {
+          gate.resolve = resolve;
+          gate.reject = reject;
+        });
+        gates.set(storyId, gate);
+      }
+      gate.resolve({ throw: err });
+    },
+    maxInFlight: () => maxInFlight,
+  };
+}
+
+/** Build a simple non-gated provider that returns a label map synchronously. */
+function buildLabelMapProvider(labelsByStory, throwForStory) {
+  return {
+    async getTicket(storyId) {
+      if (throwForStory && throwForStory.has(storyId)) {
+        throw throwForStory.get(storyId);
+      }
+      const labels = labelsByStory.get(storyId) ?? ['agent::done'];
+      return { labels, state: 'open' };
+    },
+  };
+}
+
+describe('verifyWaveResults — bounded concurrency (Story #3024)', () => {
+  it('verifies every Story when results length exceeds cap, preserving discrepancies', async () => {
+    const results = [];
+    for (let i = 0; i < 10; i += 1) {
+      results.push({ storyId: 100 + i, status: 'done' });
+    }
+    // Half the rows are *not* actually done on GitHub → discrepancy.
+    const labelsByStory = new Map();
+    for (let i = 0; i < 10; i += 1) {
+      labelsByStory.set(100 + i, i % 2 === 0 ? ['agent::done'] : ['agent::executing']);
+    }
+    const provider = buildLabelMapProvider(labelsByStory);
+    const { verified, discrepancies } = await verifyWaveResults({
+      provider,
+      results,
+      concurrencyCap: 3,
+    });
+    assert.equal(verified.length, 10, 'one verified row per input');
+    // Order preserved: storyIds in input order.
+    for (let i = 0; i < 10; i += 1) {
+      assert.equal(verified[i].storyId, 100 + i);
+    }
+    // Five odd-indexed Stories should be discrepancies.
+    assert.equal(discrepancies.length, 5);
+    const disStoryIds = discrepancies.map((d) => d.storyId).sort((a, b) => a - b);
+    assert.deepEqual(disStoryIds, [101, 103, 105, 107, 109]);
+    for (const d of discrepancies) {
+      assert.equal(d.claimed, 'done');
+      assert.equal(d.actual, 'agent::executing');
+    }
+    // Verified rows for the discrepant Stories are downgraded to failed.
+    for (const sid of [101, 103, 105, 107, 109]) {
+      const row = verified.find((r) => r.storyId === sid);
+      assert.equal(row.status, 'failed');
+    }
+  });
+
+  it('continues verifying other Stories when one provider.getTicket throws', async () => {
+    const results = [
+      { storyId: 200, status: 'done' },
+      { storyId: 201, status: 'done' },
+      { storyId: 202, status: 'done' },
+    ];
+    const labelsByStory = new Map([
+      [200, ['agent::done']],
+      // 201 → throws
+      [202, ['agent::done']],
+    ]);
+    const throwForStory = new Map([[201, new Error('boom-network')]]);
+    const provider = buildLabelMapProvider(labelsByStory, throwForStory);
+
+    const { verified, discrepancies } = await verifyWaveResults({
+      provider,
+      results,
+      concurrencyCap: 2,
+    });
+    assert.equal(verified.length, 3, 'all three rows present');
+    // Order preserved.
+    assert.deepEqual(
+      verified.map((r) => r.storyId),
+      [200, 201, 202],
+    );
+    // The throwing row is the only discrepancy.
+    assert.equal(discrepancies.length, 1);
+    assert.equal(discrepancies[0].storyId, 201);
+    assert.equal(discrepancies[0].actual, 'verify-error');
+    assert.equal(discrepancies[0].verifyError, 'boom-network');
+    // Row 201 downgraded to failed + carries verifyError.
+    assert.equal(verified[1].status, 'failed');
+    assert.equal(verified[1].verifyError, 'boom-network');
+    // Rows 200 / 202 remain done.
+    assert.equal(verified[0].status, 'done');
+    assert.equal(verified[2].status, 'done');
+  });
+
+  it('honours the concurrencyCap at runtime', async () => {
+    const cap = 2;
+    const n = 6;
+    const results = [];
+    for (let i = 0; i < n; i += 1) {
+      results.push({ storyId: 300 + i, status: 'done' });
+    }
+    const gate = buildGatedProvider();
+
+    // Kick off verifyWaveResults; do not await yet — we need to release gates.
+    const verifyPromise = verifyWaveResults({
+      provider: gate.provider,
+      results,
+      concurrencyCap: cap,
+    });
+
+    // Give the scheduler a turn to spin up the first batch of workers.
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    assert.ok(
+      gate.maxInFlight() <= cap,
+      `inFlight (${gate.maxInFlight()}) must never exceed cap (${cap})`,
+    );
+
+    // Release every gate so the test terminates.
+    for (let i = 0; i < n; i += 1) {
+      gate.release(300 + i, { labels: ['agent::done'], state: 'open' });
+    }
+    const { verified, discrepancies } = await verifyPromise;
+    assert.equal(verified.length, n);
+    assert.equal(discrepancies.length, 0);
+    assert.ok(
+      gate.maxInFlight() <= cap,
+      `inFlight (${gate.maxInFlight()}) must never exceed cap (${cap}) across the full run`,
+    );
+  });
+
+  it('defaults the cap to 4 when concurrencyCap is omitted', async () => {
+    const cap = 4;
+    const n = 8;
+    const results = [];
+    for (let i = 0; i < n; i += 1) {
+      results.push({ storyId: 400 + i, status: 'done' });
+    }
+    const gate = buildGatedProvider();
+
+    const verifyPromise = verifyWaveResults({
+      provider: gate.provider,
+      results,
+    });
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    assert.ok(
+      gate.maxInFlight() <= cap,
+      `inFlight (${gate.maxInFlight()}) must never exceed default cap (${cap})`,
+    );
+    assert.equal(
+      gate.maxInFlight(),
+      cap,
+      `expected default cap (${cap}) workers to be in flight, saw ${gate.maxInFlight()}`,
+    );
+    for (let i = 0; i < n; i += 1) {
+      gate.release(400 + i, { labels: ['agent::done'], state: 'open' });
+    }
+    const { verified } = await verifyPromise;
+    assert.equal(verified.length, n);
+  });
+
+  it('passes through rows whose status is not done without calling getTicket', async () => {
+    let callCount = 0;
+    const provider = {
+      async getTicket() {
+        callCount += 1;
+        return { labels: ['agent::done'], state: 'open' };
+      },
+    };
+    const results = [
+      { storyId: 500, status: 'blocked' },
+      { storyId: 501, status: 'failed' },
+      { storyId: 502, status: 'done' },
+    ];
+    const { verified, discrepancies } = await verifyWaveResults({
+      provider,
+      results,
+      concurrencyCap: 4,
+    });
+    assert.equal(callCount, 1, 'only the done row triggers a fetch');
+    assert.equal(verified.length, 3);
+    assert.equal(discrepancies.length, 0);
+    assert.equal(verified[0].status, 'blocked');
+    assert.equal(verified[1].status, 'failed');
+    assert.equal(verified[2].status, 'done');
+  });
+
+  it('returns inputs unchanged when provider has no getTicket', async () => {
+    const results = [
+      { storyId: 600, status: 'done' },
+      { storyId: 601, status: 'done' },
+    ];
+    const out = await verifyWaveResults({ provider: {}, results });
+    assert.deepEqual(out.verified, results);
+    assert.deepEqual(out.discrepancies, []);
+  });
+});

--- a/tests/wave-tick-fresh-fetch.test.js
+++ b/tests/wave-tick-fresh-fetch.test.js
@@ -1,0 +1,111 @@
+/**
+ * wave-tick-fresh-fetch.test.js
+ *
+ * Story #3026 — verifies the wave-runner tick fetches Story labels
+ * without `{ fresh: true }` for the cache-warm path and only force-
+ * refreshes Stories that the checkpoint flagged as halted on a prior
+ * wave (mirroring `iterate-waves`).
+ */
+
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import { tick } from '../.agents/scripts/lib/wave-runner/tick.js';
+
+function makeCheckpoint({ haltedStoryIds = [] } = {}) {
+  return {
+    currentWave: 0,
+    totalWaves: 1,
+    plan: [[1001, 1002]],
+    waves: [
+      {
+        index: 0,
+        status: 'halted',
+        stories: haltedStoryIds.map((id) => ({ storyId: id })),
+      },
+    ],
+  };
+}
+
+function makeProvider({ tickets } = {}) {
+  const calls = [];
+  return {
+    calls,
+    async getTicket(id, opts = {}) {
+      calls.push({ id, opts: { ...opts } });
+      const ticket = tickets[id];
+      if (!ticket) return null;
+      return ticket;
+    },
+  };
+}
+
+const STORY_TICKETS = {
+  1001: { id: 1001, title: 'Halted Story', labels: ['agent::executing'] },
+  1002: { id: 1002, title: 'Fresh Story', labels: ['agent::ready'] },
+};
+
+describe('wave-runner tick fresh-fetch policy', () => {
+  it('fetches all Stories with {} when none are flagged halted', async () => {
+    const provider = makeProvider({ tickets: STORY_TICKETS });
+    const checkpoint = makeCheckpoint({ haltedStoryIds: [] });
+
+    await tick({
+      epic: 9000,
+      collaborators: {
+        provider,
+        epicRunStateStore: { read: async () => checkpoint },
+        signalEmit: async () => {},
+        inFlightReader: async () => [],
+        recurringFailureReporter: async () => {},
+      },
+    });
+
+    const byId = new Map(provider.calls.map((c) => [c.id, c.opts]));
+    assert.deepEqual(byId.get(1001), {});
+    assert.deepEqual(byId.get(1002), {});
+  });
+
+  it('keeps {fresh:true} only for Stories in haltedStoryIds', async () => {
+    const provider = makeProvider({ tickets: STORY_TICKETS });
+    const checkpoint = makeCheckpoint({ haltedStoryIds: [1001] });
+
+    await tick({
+      epic: 9000,
+      collaborators: {
+        provider,
+        epicRunStateStore: { read: async () => checkpoint },
+        signalEmit: async () => {},
+        inFlightReader: async () => [],
+        recurringFailureReporter: async () => {},
+      },
+    });
+
+    const byId = new Map(provider.calls.map((c) => [c.id, c.opts]));
+    assert.deepEqual(byId.get(1001), { fresh: true });
+    assert.deepEqual(byId.get(1002), {});
+  });
+
+  it('treats a missing waves array as no-halted (cache-warm everything)', async () => {
+    const provider = makeProvider({ tickets: STORY_TICKETS });
+    const checkpoint = {
+      currentWave: 0,
+      totalWaves: 1,
+      plan: [[1001]],
+      // no `waves` field — pre-resume cold start
+    };
+
+    await tick({
+      epic: 9000,
+      collaborators: {
+        provider,
+        epicRunStateStore: { read: async () => checkpoint },
+        signalEmit: async () => {},
+        inFlightReader: async () => [],
+        recurringFailureReporter: async () => {},
+      },
+    });
+
+    assert.deepEqual(provider.calls[0].opts, {});
+  });
+});


### PR DESCRIPTION
## Summary

Implements Epic #3019 — measure & de-duplicate `/epic-deliver`. Six Stories across three waves landed on `epic/3019`:

**Wave 0 (parallel):**
- #3025 — Populate `waveParallelism` on `epic-perf-report` (per-wave wallClock/summedStory/utilisation/capBinding rows)
- #3026 — Replace dispatcher subprocess with in-process manifest helper (`lib/presentation/dispatch-manifest-render.js`); drop unconditional `{ fresh: true }` from wave-tick/iterate-waves
- #3027 — Merge preflight + prepare snapshot/DAG passes via `lib/orchestration/preflight-cache.js` keyed on baseSha

**Wave 1 (depends on Wave 0):**
- #3024 — Bound `verifyWaveResults` concurrency (new `delivery.deliverRunner.verifyConcurrencyCap`, default 4)
- #3029 — Auto-emit `epic-perf-report.json` from epic-close tail; link from structured close comment

**Wave 2 (depends on Wave 1):**
- #3042 — Retro surfaces perf signals (utilisation %, bootstrap share %, cap-binding runs) and emits paste-ready `meta::framework-gap` follow-on text; thresholds tunable via `delivery.retro.perfThresholds`

## Acceptance against Epic body

- ✅ Close comment links a perf report with per-wave wall-clock, summed Story time, utilisation %
- ✅ Preflight + prepare make one combined snapshot/DAG pass (cache hit path)
- ✅ No `dispatcher.js` subprocess during wave recording
- ✅ `verifyWaveResults` runs under bounded cap (config-driven, observable)
- ✅ Retro surfaces utilisation/bootstrap/cap-binding signals with operator-pasteable follow-on text
- ✅ Per-Story attribution and `agent::*` lifecycle transitions unchanged
- ✅ Acceptance Spec waived (`acceptance::n-a`) per planner risk envelope — project has no BDD runner / feature files; verification carried by unit + integration suites

## Quality signals from `/epic-deliver` close

- **Lint**: pass (biome + docs:check + lifecycle-doc-drift + check-doc-links + skills:check)
- **Tests**: 7151 pass, 0 fail, 2 skipped (60.8s)
- **Baselines**: 0 breaches, 0 regressions (crap + maintainability both improved)
- **Epic audit**: 9 lenses, 0 critical/high, 3 🟢 low (module-size watch, perf instrumentation note, test-tier note)
- **Code review**: 0 critical/high, 2 🟡 medium, 3 🟢 low — non-blocking; medium findings are good follow-on Story candidates (CR-1 O(n²) orphan-wave fallback in `computeWaveParallelismRows`; CR-2 duplicated default literals between `retro-perf-heuristics.js` and `lib/config/retro.js`)

## Manual interventions during delivery

This Epic does not qualify for auto-merge (two recorded manual interventions):

1. Story #3024 sub-agent removed a stale epic-merge lock (PID 15008 no longer running) after first close attempt failed
2. Parent host flipped Story #3024 from `agent::closing` to `agent::done` manually after the lock recovery left the label stuck

A separate `meta::framework-gap` issue ([#3050](https://github.com/dsj1984/mandrel/issues/3050)) was also filed during planning for an unrelated reconciler bug stripping `acceptance::n-a` between Phase 7 and Phase 8.

## Follow-ons surfaced

- [#3050](https://github.com/dsj1984/mandrel/issues/3050) — `epic-plan-decompose` reconciler strips `acceptance::n-a` label
- CR-1, CR-2 from code review (above) — worth a single small Story to fold both fixes

Closes #3019

🤖 Generated with [Claude Code](https://claude.com/claude-code)
