### PR TITLE
story-close: cap Auto-resolved-file footer at 100 chars (commitlint footer-max-line-length) (#3160)

### DIFF
--- a/.agents/scripts/lib/git-merge-orchestrator.js
+++ b/.agents/scripts/lib/git-merge-orchestrator.js
@@ -195,21 +195,67 @@ export function mergeFeatureBranch(cwd, featureBranch, vlog, opts = {}) {
 }
 
 /**
- * Build a merge-commit trailer documenting which files were auto-resolved
- * by accepting the feature-branch version and how many lines of the base
- * version were discarded. Human-readable, grep-friendly.
+ * Build a merge-commit message body + trailer documenting which files were
+ * auto-resolved by accepting the feature-branch version and how many lines
+ * of the base version were discarded.
+ *
+ * The output is split into three blocks separated by blank lines so
+ * commitlint's per-line caps (`body-max-line-length` and
+ * `footer-max-line-length`, both default 100) all pass:
+ *
+ *   1. Header sentence.
+ *   2. Body prose listing each file and its discarded line count.
+ *   3. `Auto-resolved-file:` trailers — one per file, path only, so the
+ *      verbose line count never appears on the footer line.
+ *
+ * Paths that would still bust the per-line cap are middle-truncated with
+ * an ellipsis. This is a last-resort safety net for pathological repo
+ * layouts; the common case (short relative paths) emits the full path.
+ *
+ * Exported for contract testing of the cap behaviour.
  *
  * @param {Array<{ file: string, discardedLines: number }>} resolved
+ * @param {{ maxLineLength?: number }} [opts]
  * @returns {string}
  */
-function buildAutoResolveTrailer(resolved) {
+export function buildAutoResolveTrailer(resolved, opts = {}) {
+  const maxLineLength = opts.maxLineLength ?? 100;
   const header =
     'Auto-resolved-conflicts: accepted feature branch for the following file(s).';
-  const body = resolved
-    .map(
-      (r) =>
-        `Auto-resolved-file: ${r.file} (discarded ${r.discardedLines} base line(s))`,
-    )
-    .join('\n');
-  return `${header}\n${body}`;
+
+  const bodyLines = resolved.map((r) => {
+    const suffix = `: discarded ${r.discardedLines} base line(s)`;
+    const prefix = '- ';
+    const available = maxLineLength - prefix.length - suffix.length;
+    return `${prefix}${truncatePathForLine(r.file, available)}${suffix}`;
+  });
+
+  const trailerKey = 'Auto-resolved-file: ';
+  const trailerLines = resolved.map((r) => {
+    const available = maxLineLength - trailerKey.length;
+    return `${trailerKey}${truncatePathForLine(r.file, available)}`;
+  });
+
+  return `${header}\n\n${bodyLines.join('\n')}\n\n${trailerLines.join('\n')}`;
+}
+
+/**
+ * Middle-truncate a path with an ellipsis so it fits within `max`
+ * characters. When `max` is too small to keep any meaningful slice
+ * (≤ 4 chars after the ellipsis), the leading characters win — the
+ * tail is dropped and an ellipsis is appended. Pure helper, no I/O.
+ *
+ * @param {string} p
+ * @param {number} max
+ * @returns {string}
+ */
+function truncatePathForLine(p, max) {
+  if (max <= 0) return '…';
+  if (p.length <= max) return p;
+  const ellipsis = '…';
+  const keep = max - ellipsis.length;
+  if (keep <= 4) return `${p.slice(0, max - 1)}${ellipsis}`;
+  const head = Math.ceil(keep / 2);
+  const tail = Math.floor(keep / 2);
+  return `${p.slice(0, head)}${ellipsis}${p.slice(p.length - tail)}`;
 }

--- a/tests/lib/git-merge-orchestrator-trailer.test.js
+++ b/tests/lib/git-merge-orchestrator-trailer.test.js
@@ -1,0 +1,112 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { buildAutoResolveTrailer } from '../../.agents/scripts/lib/git-merge-orchestrator.js';
+
+/**
+ * Contract: every line of the generated message (header, body, trailers)
+ * stays within commitlint's per-line caps for body and footer. The cap
+ * regression that motivated Story #3160 produced footer lines like
+ *
+ *   Auto-resolved-file: baselines/crap.json (discarded 13305 base line(s))
+ *
+ * which busted the 100-char `footer-max-line-length` default in
+ * `@commitlint/config-conventional` and rejected the auto-resolution merge
+ * commit deterministically during `story-close`.
+ */
+
+const MAX = 100;
+
+function lines(message) {
+  return message.split('\n');
+}
+
+test('buildAutoResolveTrailer: typical case keeps every line within cap', () => {
+  const message = buildAutoResolveTrailer([
+    { file: 'baselines/crap.json', discardedLines: 13305 },
+    { file: 'baselines/maintainability.json', discardedLines: 4210 },
+  ]);
+  for (const line of lines(message)) {
+    assert.ok(
+      line.length <= MAX,
+      `line exceeds ${MAX} chars (${line.length}): "${line}"`,
+    );
+  }
+});
+
+test('buildAutoResolveTrailer: emits one Auto-resolved-file trailer per file with no count on the footer line', () => {
+  const message = buildAutoResolveTrailer([
+    { file: 'baselines/crap.json', discardedLines: 13305 },
+    { file: 'baselines/maintainability.json', discardedLines: 4210 },
+  ]);
+  const trailerLines = lines(message).filter((l) =>
+    l.startsWith('Auto-resolved-file:'),
+  );
+  assert.equal(trailerLines.length, 2);
+  for (const line of trailerLines) {
+    assert.ok(
+      !/discarded/.test(line),
+      `trailer line must not carry the discarded-line count: "${line}"`,
+    );
+    assert.ok(
+      !/\(.*\)/.test(line),
+      `trailer line must not carry a parenthetical: "${line}"`,
+    );
+  }
+});
+
+test('buildAutoResolveTrailer: discarded-line counts are reported in body prose', () => {
+  const message = buildAutoResolveTrailer([
+    { file: 'baselines/crap.json', discardedLines: 13305 },
+  ]);
+  assert.match(message, /discarded 13305 base line\(s\)/);
+});
+
+test('buildAutoResolveTrailer: pathological long path + huge discard count still fits', () => {
+  const longPath =
+    'packages/very/deeply/nested/sub/sub/sub/sub/module/with/quite-a-long-baseline-file-name.json';
+  const message = buildAutoResolveTrailer([
+    { file: longPath, discardedLines: 9_999_999 },
+  ]);
+  for (const line of lines(message)) {
+    assert.ok(
+      line.length <= MAX,
+      `line exceeds ${MAX} chars (${line.length}): "${line}"`,
+    );
+  }
+  // The trailer still names the file (possibly middle-truncated with an
+  // ellipsis), but the `Auto-resolved-file:` key is present.
+  assert.match(message, /Auto-resolved-file: /);
+});
+
+test('buildAutoResolveTrailer: pathological many-file batch all stay within cap', () => {
+  const resolved = Array.from({ length: 25 }, (_, i) => ({
+    file: `baselines/very-long-baseline-${i.toString().padStart(4, '0')}.json`,
+    discardedLines: 100_000 + i,
+  }));
+  const message = buildAutoResolveTrailer(resolved);
+  for (const line of lines(message)) {
+    assert.ok(
+      line.length <= MAX,
+      `line exceeds ${MAX} chars (${line.length}): "${line}"`,
+    );
+  }
+});
+
+test('buildAutoResolveTrailer: respects an explicit smaller cap on body + trailer lines', () => {
+  const message = buildAutoResolveTrailer(
+    [{ file: 'a/b/c/very-long-filename.json', discardedLines: 1234567 }],
+    { maxLineLength: 80 },
+  );
+  // The cap governs the generated body and trailer lines; the static
+  // header sentence is a fixed announcement that callers compose around.
+  const generated = lines(message).filter(
+    (l) => l.startsWith('- ') || l.startsWith('Auto-resolved-file:'),
+  );
+  for (const line of generated) {
+    assert.ok(
+      line.length <= 80,
+      `generated line exceeds 80 chars (${line.length}): "${line}"`,
+    );
+  }
+});


### PR DESCRIPTION
Closes #3160

_Auto-opened by `/single-story-deliver`._