### PR TITLE
pre-push: allow story-close recovery push to bypass coverage gate when work already integrated (#3162)

### DIFF
--- a/.agents/scripts/check-prepush-recovery.js
+++ b/.agents/scripts/check-prepush-recovery.js
@@ -1,0 +1,90 @@
+#!/usr/bin/env node
+/**
+ * check-prepush-recovery.js — gate decision for the pre-push coverage step.
+ *
+ * Story #3162. The pre-push hook normally runs `coverage-capture.js` +
+ * `crap:check` on every push. During a `story-close.js` recovery (operator
+ * pushing `epic/<id>` to unblock a run after a merge-orchestrator failure),
+ * a pre-existing coverage regression on `epic/<id>` — unrelated to the
+ * Story under recovery — hard-blocks the push and forces a `--no-verify`
+ * bypass, which violates the global "no hook bypass" rule.
+ *
+ * This script is the scoped escape hatch. It exits 0 ("skip coverage gate")
+ * only when BOTH conditions hold:
+ *
+ *   1. `STORY_CLOSE_RECOVERY=1` is set in the environment.
+ *   2. At least one ref being pushed has a local ref of the shape
+ *      `refs/heads/epic/<id>` (parsed from the pre-push stdin protocol).
+ *
+ * Otherwise it exits 1 ("run coverage gate as today"). The narrow scope is
+ * deliberate: a generic env-var bypass would erode the gate; tying the
+ * skip to an epic-branch target keeps every other push honest.
+ *
+ * Stdin contract (git pre-push hook protocol): zero or more lines, each
+ *   `<local_ref> <local_sha> <remote_ref> <remote_sha>`
+ * separated by whitespace. Empty stdin (no refs being pushed) yields exit 1.
+ */
+
+import { runAsCli } from './lib/cli-utils.js';
+
+const EPIC_REF_PATTERN = /^refs\/heads\/epic\//;
+const SKIP_LOG = '[pre-push] coverage gate skipped by STORY_CLOSE_RECOVERY';
+
+/**
+ * Parse pre-push stdin into the list of local refs being pushed. Lines with
+ * fewer than four whitespace-separated tokens are tolerated (git in practice
+ * always emits four, but defensive parsing keeps the helper robust against
+ * empty pushes and trailing whitespace).
+ *
+ * @param {string} stdin
+ * @returns {string[]} local ref names (first token of each non-empty line)
+ */
+export function parsePrePushLocalRefs(stdin) {
+  if (typeof stdin !== 'string' || stdin.length === 0) return [];
+  return stdin
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((line) => line.split(/\s+/)[0])
+    .filter(Boolean);
+}
+
+/**
+ * Pure decision function. `true` means "skip the coverage gate".
+ *
+ * @param {object} input
+ * @param {string|undefined} input.env  value of STORY_CLOSE_RECOVERY
+ * @param {string[]} input.localRefs    parsed local refs
+ * @returns {boolean}
+ */
+export function shouldSkipCoverageGate({ env, localRefs }) {
+  if (env !== '1') return false;
+  if (!Array.isArray(localRefs) || localRefs.length === 0) return false;
+  return localRefs.some((ref) => EPIC_REF_PATTERN.test(ref));
+}
+
+async function readStdin() {
+  if (process.stdin.isTTY) return '';
+  let data = '';
+  process.stdin.setEncoding('utf8');
+  for await (const chunk of process.stdin) data += chunk;
+  return data;
+}
+
+async function main() {
+  const stdin = await readStdin();
+  const localRefs = parsePrePushLocalRefs(stdin);
+  const skip = shouldSkipCoverageGate({
+    env: process.env.STORY_CLOSE_RECOVERY,
+    localRefs,
+  });
+  if (skip) {
+    process.stdout.write(`${SKIP_LOG}\n`);
+    process.exit(0);
+  }
+  process.exit(1);
+}
+
+runAsCli(import.meta.url, main);
+
+export const __testing = { EPIC_REF_PATTERN, SKIP_LOG };

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -9,10 +9,28 @@
 # CI (.github/workflows/ci.yml) remains the authoritative full gate on every PR.
 #
 # Optional: PREPUSH_AUDIT=1 re-enables npm audit (CI still audits on PR/push).
+#
+# Optional: STORY_CLOSE_RECOVERY=1 — scoped escape hatch (Story #3162) for
+# story-close.js recovery paths. When set AND the push targets an
+# `epic/<id>` branch, the coverage + CRAP gate is skipped so the operator
+# can unblock a recovery push without `--no-verify`. All other gates still
+# run; non-epic pushes ignore the env var. Skip is announced on stdout so
+# the bypass is auditable.
+
+# Capture the pre-push ref protocol from stdin so the recovery-gate helper
+# can inspect it. Consumed unconditionally — downstream steps do not read
+# stdin, and not consuming it would leak into the next command on some
+# shells.
+PREPUSH_REFS=$(cat)
 
 node .agents/scripts/quality-preview.js --changed-since origin/main
 if [ "${PREPUSH_AUDIT:-0}" = "1" ]; then
   npm audit --audit-level=high
 fi
-node .agents/scripts/coverage-capture.js --skip-when-no-crap-files --ref origin/main
-npm run crap:check
+
+if printf '%s' "$PREPUSH_REFS" | node .agents/scripts/check-prepush-recovery.js; then
+  : # coverage + CRAP gate skipped; helper printed the audit log line
+else
+  node .agents/scripts/coverage-capture.js --skip-when-no-crap-files --ref origin/main
+  npm run crap:check
+fi

--- a/tests/contract/check-prepush-recovery.test.js
+++ b/tests/contract/check-prepush-recovery.test.js
@@ -1,0 +1,163 @@
+/**
+ * tests/contract/check-prepush-recovery.test.js — Story #3162.
+ *
+ * Contract: the pre-push coverage-gate skip helper must exit 0 (skip the
+ * gate) only when STORY_CLOSE_RECOVERY=1 AND the push targets an
+ * `epic/<id>` ref; in every other combination it must exit 1 so the
+ * coverage chain still runs as today.
+ *
+ * We pin both the pure decision function and the CLI surface (exit code
+ * + the auditable log line) because the CLI is the contract the husky
+ * hook depends on.
+ */
+
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import path from 'node:path';
+import { test } from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+import {
+  parsePrePushLocalRefs,
+  shouldSkipCoverageGate,
+} from '../../.agents/scripts/check-prepush-recovery.js';
+
+const REPO_ROOT = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '..',
+  '..',
+);
+const SCRIPT = path.join(
+  REPO_ROOT,
+  '.agents',
+  'scripts',
+  'check-prepush-recovery.js',
+);
+const SKIP_LOG = '[pre-push] coverage gate skipped by STORY_CLOSE_RECOVERY';
+
+const EPIC_REF_LINE =
+  'refs/heads/epic/123 deadbeefdeadbeefdeadbeefdeadbeefdeadbeef ' +
+  'refs/heads/epic/123 0000000000000000000000000000000000000000';
+const STORY_REF_LINE =
+  'refs/heads/story-104 deadbeefdeadbeefdeadbeefdeadbeefdeadbeef ' +
+  'refs/heads/story-104 0000000000000000000000000000000000000000';
+const MAIN_REF_LINE =
+  'refs/heads/main deadbeefdeadbeefdeadbeefdeadbeefdeadbeef ' +
+  'refs/heads/main 0000000000000000000000000000000000000000';
+
+function runHelper({ env, stdin }) {
+  return spawnSync(process.execPath, [SCRIPT], {
+    input: stdin ?? '',
+    env: { ...process.env, ...env },
+    encoding: 'utf8',
+  });
+}
+
+test('parsePrePushLocalRefs — extracts local ref from each non-empty line', () => {
+  const refs = parsePrePushLocalRefs(`${EPIC_REF_LINE}\n${STORY_REF_LINE}\n`);
+  assert.deepEqual(refs, ['refs/heads/epic/123', 'refs/heads/story-104']);
+});
+
+test('parsePrePushLocalRefs — empty / whitespace stdin yields empty array', () => {
+  assert.deepEqual(parsePrePushLocalRefs(''), []);
+  assert.deepEqual(parsePrePushLocalRefs('\n\n'), []);
+  assert.deepEqual(parsePrePushLocalRefs(undefined), []);
+});
+
+test('shouldSkipCoverageGate — skip ONLY when env=1 AND an epic/<id> ref is in the push', () => {
+  // Happy path: env set + epic ref → skip.
+  assert.equal(
+    shouldSkipCoverageGate({ env: '1', localRefs: ['refs/heads/epic/123'] }),
+    true,
+  );
+  // Mixed push that includes an epic ref → skip (operator pushing multiple
+  // branches in one invocation; the recovery push is in there).
+  assert.equal(
+    shouldSkipCoverageGate({
+      env: '1',
+      localRefs: ['refs/heads/story-104', 'refs/heads/epic/9'],
+    }),
+    true,
+  );
+});
+
+test('shouldSkipCoverageGate — env unset → never skip, even with epic ref', () => {
+  assert.equal(
+    shouldSkipCoverageGate({
+      env: undefined,
+      localRefs: ['refs/heads/epic/123'],
+    }),
+    false,
+  );
+  assert.equal(
+    shouldSkipCoverageGate({ env: '0', localRefs: ['refs/heads/epic/123'] }),
+    false,
+  );
+  // Loose truthy values are NOT honored — must be exactly "1" so a stray
+  // STORY_CLOSE_RECOVERY=true in shell history cannot accidentally bypass.
+  assert.equal(
+    shouldSkipCoverageGate({ env: 'true', localRefs: ['refs/heads/epic/123'] }),
+    false,
+  );
+});
+
+test('shouldSkipCoverageGate — env=1 but no epic ref → do not skip', () => {
+  assert.equal(
+    shouldSkipCoverageGate({ env: '1', localRefs: ['refs/heads/story-104'] }),
+    false,
+  );
+  assert.equal(
+    shouldSkipCoverageGate({ env: '1', localRefs: ['refs/heads/main'] }),
+    false,
+  );
+  assert.equal(shouldSkipCoverageGate({ env: '1', localRefs: [] }), false);
+});
+
+test('shouldSkipCoverageGate — ref must be exactly under refs/heads/epic/ (no prefix tricks)', () => {
+  // A branch literally named "epic-foo" must NOT match — only the
+  // canonical epic/<id> shape qualifies.
+  assert.equal(
+    shouldSkipCoverageGate({ env: '1', localRefs: ['refs/heads/epic-foo'] }),
+    false,
+  );
+  // Tag refs do not count even if they contain "epic/" in the name.
+  assert.equal(
+    shouldSkipCoverageGate({ env: '1', localRefs: ['refs/tags/epic/123'] }),
+    false,
+  );
+});
+
+test('CLI — exits 0 and emits audit log when env=1 + epic ref on stdin', () => {
+  const result = runHelper({
+    env: { STORY_CLOSE_RECOVERY: '1' },
+    stdin: `${EPIC_REF_LINE}\n`,
+  });
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, new RegExp(SKIP_LOG.replace(/[[\]]/g, '\\$&')));
+});
+
+test('CLI — exits 1 (run coverage) when env unset, even with epic ref', () => {
+  const result = runHelper({
+    env: { STORY_CLOSE_RECOVERY: '' },
+    stdin: `${EPIC_REF_LINE}\n`,
+  });
+  assert.equal(result.status, 1);
+  assert.doesNotMatch(result.stdout, /skipped/);
+});
+
+test('CLI — exits 1 (run coverage) when env=1 but no epic ref in push', () => {
+  const result = runHelper({
+    env: { STORY_CLOSE_RECOVERY: '1' },
+    stdin: `${STORY_REF_LINE}\n${MAIN_REF_LINE}\n`,
+  });
+  assert.equal(result.status, 1);
+  assert.doesNotMatch(result.stdout, /skipped/);
+});
+
+test('CLI — exits 1 when stdin is empty (no refs to push)', () => {
+  const result = runHelper({
+    env: { STORY_CLOSE_RECOVERY: '1' },
+    stdin: '',
+  });
+  assert.equal(result.status, 1);
+});

--- a/tests/pre-push-hook.test.js
+++ b/tests/pre-push-hook.test.js
@@ -45,3 +45,26 @@ test('pre-push — optional audit remains opt-in via PREPUSH_AUDIT', () => {
   assert.match(hook, /PREPUSH_AUDIT/);
   assert.match(hook, /npm audit --audit-level=high/);
 });
+
+// Story #3162 — STORY_CLOSE_RECOVERY env var gates a scoped coverage skip
+// for operator recovery pushes targeting epic/<id>. The hook delegates the
+// decision to check-prepush-recovery.js so the gating logic stays testable
+// in isolation; here we assert the wiring is present.
+test('pre-push — STORY_CLOSE_RECOVERY scoped skip wired to coverage gate', () => {
+  const hook = readPrePush();
+  assert.match(hook, /STORY_CLOSE_RECOVERY/);
+  assert.match(hook, /check-prepush-recovery\.js/);
+  // The skip branch must wrap BOTH coverage-capture and crap:check so a
+  // pre-existing CRAP regression on epic/<id> also clears (the CRAP gate
+  // reads the freshly-captured coverage; gating only the capture would
+  // leave CRAP failing on stale numbers).
+  const helperIdx = hook.indexOf('check-prepush-recovery.js');
+  const captureIdx = hook.indexOf(
+    'coverage-capture.js --skip-when-no-crap-files',
+  );
+  const crapIdx = hook.indexOf('npm run crap:check');
+  assert.ok(
+    helperIdx > -1 && captureIdx > helperIdx && crapIdx > captureIdx,
+    'recovery helper must precede both coverage-capture and crap:check so both are gated',
+  );
+});


### PR DESCRIPTION
Closes #3162

_Auto-opened by `/single-story-deliver`._