### PR TITLE
story-close --resume: detect Story diff already integrated via rebased commits (fast path) (#3161)

### DIFF
--- a/.agents/scripts/lib/orchestration/story-close-recovery.js
+++ b/.agents/scripts/lib/orchestration/story-close-recovery.js
@@ -12,7 +12,11 @@
  *   - `already-merged`       — the story tip is reachable from `origin/epic/<id>`
  *                              already (typical Windows partial-reap recovery
  *                              path: merge + push succeeded but worktree reap
- *                              or ticket transitions stalled).
+ *                              or ticket transitions stalled), OR the story
+ *                              diff is fully present on `origin/epic/<id>` as
+ *                              rebased commits with different SHAs (manual
+ *                              recovery path, detected via `git cherry`
+ *                              patch-id comparison; Story #3161).
  *   - `pushed-unmerged`      — the story branch is on origin and not yet merged.
  *   - `fresh`                — no prior close activity detected.
  */
@@ -45,6 +49,9 @@ const DEFAULT_GIT_ADAPTER = {
   },
   fetchOrigin(cwd, ref) {
     return gitSpawn(cwd, 'fetch', '--quiet', 'origin', ref);
+  },
+  cherry(cwd, upstream, head) {
+    return gitSpawn(cwd, 'cherry', upstream, head);
   },
 };
 
@@ -170,6 +177,47 @@ export function detectPriorPhase({
           resolvedDetail = {
             remoteStoryRef: `origin/${storyBranch}`,
             remoteEpicRef: epicRef,
+          };
+          break;
+        }
+      }
+    }
+
+    // c) Rebased equivalents (Story #3161). Story tip is not an ancestor
+    //    of `origin/epic/<id>`, but every commit on the Story branch is
+    //    patch-equivalent (`git cherry`) to a commit already on the Epic.
+    //    Surfaces the manual-recovery case where the operator rebased
+    //    Story content directly onto `epic/<id>` so the diff is present
+    //    as commits with different SHAs and no `(resolves #<id>)` merge
+    //    commit. Without this branch, `assertMergeReachable` throws at
+    //    resume time and strands close at `agent::closing`.
+    if (!merged && git.cherry) {
+      const candidates = [];
+      const localStoryRefName = `refs/heads/${storyBranch}`;
+      if (git.showRef && git.showRef(cwd, localStoryRefName)?.status === 0) {
+        candidates.push({ ref: storyBranch, kind: 'local' });
+      }
+      if (lsrOut.length > 0) {
+        candidates.push({ ref: `origin/${storyBranch}`, kind: 'remote' });
+      }
+      const remoteEpicRef = `origin/epic/${epicId}`;
+      for (const cand of candidates) {
+        const cherry = git.cherry(cwd, remoteEpicRef, cand.ref);
+        if (!cherry || cherry.status !== 0) continue;
+        const lines = (cherry.stdout ?? '')
+          .toString()
+          .split('\n')
+          .map((l) => l.trim())
+          .filter(Boolean);
+        if (lines.length === 0) continue;
+        if (lines.every((l) => l.startsWith('- '))) {
+          merged = true;
+          resolvedDetail = {
+            [cand.kind === 'local' ? 'localStoryRef' : 'remoteStoryRef']:
+              cand.ref,
+            remoteEpicRef,
+            via: 'rebased-equivalents',
+            equivalents: lines.length,
           };
           break;
         }

--- a/.agents/scripts/lib/orchestration/story-close/post-merge-close.js
+++ b/.agents/scripts/lib/orchestration/story-close/post-merge-close.js
@@ -35,6 +35,7 @@ import { clearActiveStoryEnv as defaultClearActiveStoryEnv } from '../../observa
 import {
   checkHeadAncestor,
   hasMergeCommitForStory,
+  hasRebasedEquivalents,
 } from '../../worktree/lifecycle/merge-reachability.js';
 import { runPostMergePipeline as defaultRunPostMergePipeline } from '../post-merge-pipeline.js';
 import {
@@ -54,16 +55,23 @@ import {
  * the push's retry logic logged success while the remote silently dropped
  * us.
  *
- * Two-phase check mirrors `worktree/lifecycle/merge-reachability.js`:
+ * Three-phase check mirrors `worktree/lifecycle/merge-reachability.js`:
  *   1. `git merge-base --is-ancestor` on the Story branch HEAD.
  *   2. Fallback `git log --grep=resolves #<storyId>` on the Epic branch
  *      (the `--no-ff` merge commit's subject is the durable proof).
+ *   3. Fallback `git cherry <epicBranch> <storyBranch>` patch-id check
+ *      (Story #3161) — every commit on the Story branch is patch-
+ *      equivalent to a commit already on `epicBranch`. Surfaces the
+ *      manual-recovery case where the operator rebased Story content
+ *      directly onto the Epic so the diff is present as commits with
+ *      different SHAs.
  *
- * Throws when neither check passes — the caller's `try/finally` keeps the
+ * Throws when no check passes — the caller's `try/finally` keeps the
  * Story at `agent::closing` so a `/story-execute --resume` can re-enter
  * the post-merge phase rather than re-running preflight.
  *
- * Story #2144 / Task #2155.
+ * Story #2144 / Task #2155; Story #3161 extends with the rebased-
+ * equivalents path.
  *
  * @param {object} args
  * @param {string} args.cwd        Main-repo working directory.
@@ -89,7 +97,8 @@ export function assertMergeReachable({
   if (headRes.status !== 0) {
     // Branch ref already gone (e.g. a prior partial close deleted it) →
     // fall straight to the merge-commit grep, which is the durable proof
-    // path.
+    // path. The cherry/patch-id fallback cannot run without the branch
+    // ref, so we skip it on this path.
     if (hasMergeCommitForStory(ctx, storyBranch, epicBranch)) {
       return { reachable: true, reason: 'merge-commit-reachable' };
     }
@@ -107,12 +116,16 @@ export function assertMergeReachable({
   if (hasMergeCommitForStory(ctx, storyBranch, epicBranch)) {
     return { reachable: true, reason: 'merge-commit-reachable' };
   }
+  if (hasRebasedEquivalents(ctx, storyBranch, epicBranch)) {
+    return { reachable: true, reason: 'rebased-equivalents' };
+  }
   const headShort = headSha.slice(0, 7) || 'HEAD';
   throw new Error(
     `story-close: merge verification failed for #${storyId} — ` +
       `\`${storyBranch}\` head=${headShort} is not reachable from \`${epicBranch}\` ` +
       `and no \`(resolves #${storyId})\` merge commit found on \`${epicBranch}\` ` +
-      `(ancestor=${ancestor.outcome}). Story remains at \`agent::closing\`; ` +
+      `(ancestor=${ancestor.outcome}); patch-id equivalents not detected. ` +
+      `Story remains at \`agent::closing\`; ` +
       `re-run with \`--resume\` once the merge is on \`${epicBranch}\`.`,
   );
 }

--- a/.agents/scripts/lib/worktree/lifecycle/merge-reachability.js
+++ b/.agents/scripts/lib/worktree/lifecycle/merge-reachability.js
@@ -100,7 +100,45 @@ export function hasMergeCommitForStory(ctx, branch, epicRef) {
 }
 
 /**
- * Run the full two-phase merge-reachability gate. Returns the same
+ * Predicate: are every commit on `branch` patch-equivalent to a commit
+ * already on `epicRef`? Runs `git cherry <epicRef> <branch>` and returns
+ * `true` when every output line starts with `- ` (already upstream by
+ * patch-id). Returns `false` when:
+ *
+ *   - `git cherry` exits non-zero,
+ *   - the output is empty (no commits to compare — the trivial-ancestor
+ *     case is already covered by `checkHeadAncestor`), or
+ *   - any output line starts with `+ ` (a commit on `branch` whose
+ *     patch-id is not present upstream).
+ *
+ * Surfaces the "Story diff already integrated as rebased equivalents"
+ * recovery case: operator manually rebased the Story's content onto
+ * `epic/<id>` during recovery, so the diff is on the Epic branch as
+ * commits with **different SHAs** but the same patch-ids. The ancestor
+ * check returns `false` (Story tip's own commits are not ancestors), and
+ * no `(resolves #<id>)` merge commit exists — but the work is
+ * functionally integrated.
+ *
+ * Story #3161 — surfaced during Epic #3078 delivery on Story #3122.
+ *
+ * @param {object} ctx
+ * @param {string} branch Branch with commits to test (e.g. `story-3122`).
+ * @param {string} epicRef Epic ref to test against (e.g. `origin/epic/3078`).
+ * @returns {boolean}
+ */
+export function hasRebasedEquivalents(ctx, branch, epicRef) {
+  const res = ctx.git.gitSpawn(ctx.repoRoot, 'cherry', epicRef, branch);
+  if (res.status !== 0) return false;
+  const lines = (res.stdout || '')
+    .split('\n')
+    .map((l) => l.trim())
+    .filter(Boolean);
+  if (lines.length === 0) return false;
+  return lines.every((line) => line.startsWith('- '));
+}
+
+/**
+ * Run the full three-phase merge-reachability gate. Returns the same
  * `{ safe, reason }` envelope `isSafeToRemove` does, so callers can chain
  * the verdict directly into the parent return value.
  *
@@ -127,6 +165,9 @@ export async function checkMergeReachability(ctx, wtPath, branch, epicRef) {
 
   if (hasMergeCommitForStory(ctx, branch, epicRef)) {
     return { safe: true, reason: 'merge-commit-reachable' };
+  }
+  if (hasRebasedEquivalents(ctx, branch, epicRef)) {
+    return { safe: true, reason: 'rebased-equivalents' };
   }
   return {
     safe: false,

--- a/tests/lib/worktree/lifecycle/merge-reachability.test.js
+++ b/tests/lib/worktree/lifecycle/merge-reachability.test.js
@@ -153,10 +153,7 @@ describe('hasRebasedEquivalents', () => {
     const ctx = fakeCtx([
       { status: 0, stdout: '- aaaa1111\n- bbbb2222\n- cccc3333\n' },
     ]);
-    assert.equal(
-      hasRebasedEquivalents(ctx, 'story-42', 'origin/epic/1'),
-      true,
-    );
+    assert.equal(hasRebasedEquivalents(ctx, 'story-42', 'origin/epic/1'), true);
     assert.deepEqual(ctx.calls[0].args, [
       'cherry',
       'origin/epic/1',
@@ -165,9 +162,7 @@ describe('hasRebasedEquivalents', () => {
   });
 
   it('returns false when any line starts with "+ " (unintegrated commit)', () => {
-    const ctx = fakeCtx([
-      { status: 0, stdout: '- aaaa1111\n+ dddd4444\n' },
-    ]);
+    const ctx = fakeCtx([{ status: 0, stdout: '- aaaa1111\n+ dddd4444\n' }]);
     assert.equal(
       hasRebasedEquivalents(ctx, 'story-42', 'origin/epic/1'),
       false,
@@ -183,9 +178,7 @@ describe('hasRebasedEquivalents', () => {
   });
 
   it('returns false when cherry exits non-zero', () => {
-    const ctx = fakeCtx([
-      { status: 128, stderr: 'fatal: bad revision' },
-    ]);
+    const ctx = fakeCtx([{ status: 128, stderr: 'fatal: bad revision' }]);
     assert.equal(
       hasRebasedEquivalents(ctx, 'story-42', 'origin/epic/1'),
       false,

--- a/tests/lib/worktree/lifecycle/merge-reachability.test.js
+++ b/tests/lib/worktree/lifecycle/merge-reachability.test.js
@@ -13,6 +13,7 @@ import {
   checkHeadAncestor,
   checkMergeReachability,
   hasMergeCommitForStory,
+  hasRebasedEquivalents,
   resolveHeadSha,
 } from '../../../../.agents/scripts/lib/worktree/lifecycle/merge-reachability.js';
 
@@ -147,6 +148,51 @@ describe('hasMergeCommitForStory', () => {
   });
 });
 
+describe('hasRebasedEquivalents', () => {
+  it('returns true when every cherry line starts with "- " (all patch-equivalent)', () => {
+    const ctx = fakeCtx([
+      { status: 0, stdout: '- aaaa1111\n- bbbb2222\n- cccc3333\n' },
+    ]);
+    assert.equal(
+      hasRebasedEquivalents(ctx, 'story-42', 'origin/epic/1'),
+      true,
+    );
+    assert.deepEqual(ctx.calls[0].args, [
+      'cherry',
+      'origin/epic/1',
+      'story-42',
+    ]);
+  });
+
+  it('returns false when any line starts with "+ " (unintegrated commit)', () => {
+    const ctx = fakeCtx([
+      { status: 0, stdout: '- aaaa1111\n+ dddd4444\n' },
+    ]);
+    assert.equal(
+      hasRebasedEquivalents(ctx, 'story-42', 'origin/epic/1'),
+      false,
+    );
+  });
+
+  it('returns false when cherry stdout is empty (trivial-ancestor case handled elsewhere)', () => {
+    const ctx = fakeCtx([{ status: 0, stdout: '' }]);
+    assert.equal(
+      hasRebasedEquivalents(ctx, 'story-42', 'origin/epic/1'),
+      false,
+    );
+  });
+
+  it('returns false when cherry exits non-zero', () => {
+    const ctx = fakeCtx([
+      { status: 128, stderr: 'fatal: bad revision' },
+    ]);
+    assert.equal(
+      hasRebasedEquivalents(ctx, 'story-42', 'origin/epic/1'),
+      false,
+    );
+  });
+});
+
 describe('checkMergeReachability', () => {
   it('propagates resolveHeadSha failure as safe:false', async () => {
     const ctx = fakeCtx([{ status: 128, stderr: 'fatal: HEAD missing' }]);
@@ -193,11 +239,26 @@ describe('checkMergeReachability', () => {
     });
   });
 
-  it('reports unmerged-commits when both gates fail', async () => {
+  it('falls back to rebased-equivalents when grep misses but cherry shows all patch-equivalent (Story #3161)', async () => {
     const ctx = fakeCtx([
       { status: 0, stdout: 'abc1234' }, // rev-parse HEAD
       { status: 1 }, // ancestor: not ancestor
       { status: 0, stdout: '' }, // grep: no match
+      { status: 0, stdout: '- aaaa1111\n- bbbb2222\n' }, // cherry: all upstream
+    ]);
+    const out = await checkMergeReachability(ctx, '/wt', 'story-42', 'epic/1');
+    assert.deepEqual(out, {
+      safe: true,
+      reason: 'rebased-equivalents',
+    });
+  });
+
+  it('reports unmerged-commits when all three gates fail', async () => {
+    const ctx = fakeCtx([
+      { status: 0, stdout: 'abc1234' }, // rev-parse HEAD
+      { status: 1 }, // ancestor: not ancestor
+      { status: 0, stdout: '' }, // grep: no match
+      { status: 0, stdout: '- aaaa1111\n+ bbbb2222\n' }, // cherry: + present
     ]);
     const out = await checkMergeReachability(ctx, '/wt', 'story-42', 'epic/1');
     assert.deepEqual(out, {
@@ -206,8 +267,12 @@ describe('checkMergeReachability', () => {
     });
   });
 
-  it('reports unmerged-commits without spawning grep for non-story branches', async () => {
-    const ctx = fakeCtx([{ status: 0, stdout: 'abc1234' }, { status: 1 }]);
+  it('reports unmerged-commits without spawning grep for non-story branches (cherry still runs)', async () => {
+    const ctx = fakeCtx([
+      { status: 0, stdout: 'abc1234' },
+      { status: 1 },
+      { status: 0, stdout: '' }, // cherry: empty (no equivalents)
+    ]);
     const out = await checkMergeReachability(
       ctx,
       '/wt',

--- a/tests/story-close-recovery.test.js
+++ b/tests/story-close-recovery.test.js
@@ -23,6 +23,9 @@ function makeGit({
   // a custom `showRefByRef` map). Default `false` keeps legacy behavior.
   localStoryExists = false,
   showRefByRef = null,
+  // cherry: per-(upstream, head) override. Each value is a `{ status, stdout }`
+  // bag, the same shape gitSpawn returns. Default exit 1 (no equivalents).
+  cherryByPair = null,
 } = {}) {
   return {
     status(cwd) {
@@ -51,6 +54,13 @@ function makeGit({
         return { status: 0 };
       }
       return { status: 1 };
+    },
+    cherry(_cwd, upstream, head) {
+      if (cherryByPair) {
+        const key = `${upstream}←${head}`;
+        if (key in cherryByPair) return cherryByPair[key];
+      }
+      return { status: 1, stdout: '' };
     },
   };
 }
@@ -170,6 +180,120 @@ test('detectPriorPhase', async (t) => {
       assert.strictEqual(result.phase, RECOVERY_STATES.ALREADY_MERGED);
       assert.strictEqual(result.detail.localStoryRef, 'story-100');
       assert.strictEqual(result.detail.remoteEpicRef, 'origin/epic/42');
+    },
+  );
+
+  await t.test(
+    'returns already-merged via rebased-equivalents when local branch tip is not ancestor but all commits patch-equivalent on origin/epic/<id> (Story #3161)',
+    () => {
+      // Manual recovery path: operator rebased Story #3122's content
+      // directly onto `epic/3078` so the diff landed as commits with
+      // different SHAs. Story tip is not an ancestor of `origin/epic/<id>`
+      // and no `(resolves #<id>)` merge commit exists, but `git cherry`
+      // reports every Story commit as patch-equivalent to a commit
+      // already on the Epic. Expected outcome = ALREADY_MERGED via
+      // rebased-equivalents → resume from post-merge.
+      const result = detectPriorPhase({
+        cwd: CWD,
+        storyId: 100,
+        epicId: 42,
+        git: makeGit({
+          lsRemote: '',
+          localStoryExists: true,
+          // No ancestor relationship — both checks return non-zero.
+          ancestorExit: 1,
+          cherryByPair: {
+            'origin/epic/42←story-100': {
+              status: 0,
+              stdout: '- aaaa1111\n- bbbb2222\n- cccc3333\n',
+            },
+          },
+        }),
+        fs: makeFs([]),
+      });
+      assert.strictEqual(result.phase, RECOVERY_STATES.ALREADY_MERGED);
+      assert.strictEqual(result.detail.via, 'rebased-equivalents');
+      assert.strictEqual(result.detail.localStoryRef, 'story-100');
+      assert.strictEqual(result.detail.remoteEpicRef, 'origin/epic/42');
+      assert.strictEqual(result.detail.equivalents, 3);
+    },
+  );
+
+  await t.test(
+    'rebased-equivalents path also works against the remote story branch when local ref is absent',
+    () => {
+      const result = detectPriorPhase({
+        cwd: CWD,
+        storyId: 100,
+        epicId: 42,
+        git: makeGit({
+          lsRemote: 'abc123\trefs/heads/story-100\n',
+          localStoryExists: false,
+          ancestorExit: 1,
+          cherryByPair: {
+            'origin/epic/42←origin/story-100': {
+              status: 0,
+              stdout: '- aaaa1111\n',
+            },
+          },
+        }),
+        fs: makeFs([]),
+      });
+      assert.strictEqual(result.phase, RECOVERY_STATES.ALREADY_MERGED);
+      assert.strictEqual(result.detail.via, 'rebased-equivalents');
+      assert.strictEqual(result.detail.remoteStoryRef, 'origin/story-100');
+    },
+  );
+
+  await t.test(
+    'returns pushed-unmerged (not already-merged) when cherry reports any + lines',
+    () => {
+      // At least one commit on the Story branch is NOT patch-equivalent
+      // to any commit on the Epic — the branch has unintegrated work, so
+      // we must not short-circuit to RESUME_FROM_POST_MERGE.
+      const result = detectPriorPhase({
+        cwd: CWD,
+        storyId: 100,
+        epicId: 42,
+        git: makeGit({
+          lsRemote: 'abc123\trefs/heads/story-100\n',
+          localStoryExists: true,
+          ancestorExit: 1,
+          cherryByPair: {
+            'origin/epic/42←story-100': {
+              status: 0,
+              stdout: '- aaaa1111\n+ dddd4444\n',
+            },
+            'origin/epic/42←origin/story-100': {
+              status: 0,
+              stdout: '- aaaa1111\n+ dddd4444\n',
+            },
+          },
+        }),
+        fs: makeFs([]),
+      });
+      assert.strictEqual(result.phase, RECOVERY_STATES.PUSHED_UNMERGED);
+    },
+  );
+
+  await t.test(
+    'rebased-equivalents path is skipped when cherry exits non-zero (e.g. missing ref)',
+    () => {
+      const result = detectPriorPhase({
+        cwd: CWD,
+        storyId: 100,
+        epicId: 42,
+        git: makeGit({
+          lsRemote: 'abc123\trefs/heads/story-100\n',
+          localStoryExists: true,
+          ancestorExit: 1,
+          // cherry adapter returns exit 1 with empty stdout by default
+          // — represents `git cherry` failing because origin/epic/42 is
+          // unreachable. Detection must fall through to PUSHED_UNMERGED.
+        }),
+        fs: makeFs([]),
+      });
+      assert.strictEqual(result.phase, RECOVERY_STATES.PUSHED_UNMERGED);
     },
   );
 

--- a/tests/story-close-state-machine.test.js
+++ b/tests/story-close-state-machine.test.js
@@ -108,7 +108,13 @@ test('assertMergeReachable falls back to merge-commit grep when ancestry fails',
   assert.equal(result.reason, 'merge-commit-reachable');
 });
 
-test('assertMergeReachable throws when neither ancestry nor merge-commit grep matches', () => {
+test('assertMergeReachable falls back to rebased-equivalents when ancestry and merge-commit grep miss but cherry shows all patch-equivalent (Story #3161)', () => {
+  // Recovery scenario from Story #3122: operator manually rebased the
+  // Story's content onto `epic/<id>` so the diff is present as commits
+  // with **different SHAs** and no `(resolves #<id>)` merge commit. The
+  // ancestor check returns 1 (story tip's own commits are not ancestors)
+  // and the grep returns empty, but `git cherry` reports every commit on
+  // the Story branch as patch-equivalent to a commit already on the Epic.
   const { gitSpawn } = makeGitSpawn({
     'rev-parse story-100': {
       status: 0,
@@ -123,6 +129,45 @@ test('assertMergeReachable throws when neither ancestry nor merge-commit grep ma
     'log epic/99 --merges -n 1 --pretty=%H --grep=resolves #100': {
       status: 0,
       stdout: '',
+      stderr: '',
+    },
+    'cherry epic/99 story-100': {
+      status: 0,
+      stdout: '- aaaa1111\n- bbbb2222\n- cccc3333\n',
+      stderr: '',
+    },
+  });
+  const result = assertMergeReachable({
+    cwd: '/repo',
+    storyBranch: 'story-100',
+    epicBranch: 'epic/99',
+    storyId: 100,
+    gitSpawn,
+  });
+  assert.equal(result.reachable, true);
+  assert.equal(result.reason, 'rebased-equivalents');
+});
+
+test('assertMergeReachable throws when ancestry, merge-commit grep, and cherry all miss', () => {
+  const { gitSpawn } = makeGitSpawn({
+    'rev-parse story-100': {
+      status: 0,
+      stdout: `${REACHABLE_HEAD}\n`,
+      stderr: '',
+    },
+    [`merge-base --is-ancestor ${REACHABLE_HEAD} epic/99`]: {
+      status: 1,
+      stdout: '',
+      stderr: '',
+    },
+    'log epic/99 --merges -n 1 --pretty=%H --grep=resolves #100': {
+      status: 0,
+      stdout: '',
+      stderr: '',
+    },
+    'cherry epic/99 story-100': {
+      status: 0,
+      stdout: '+ dddd4444\n',
       stderr: '',
     },
   });
@@ -154,6 +199,11 @@ test('assertMergeReachable error message preserves agent::closing recovery contr
     'log epic/99 --merges -n 1 --pretty=%H --grep=resolves #100': {
       status: 0,
       stdout: '',
+      stderr: '',
+    },
+    'cherry epic/99 story-100': {
+      status: 0,
+      stdout: '+ dddd4444\n',
       stderr: '',
     },
   });


### PR DESCRIPTION
Closes #3161

_Auto-opened by `/single-story-deliver`._