### PR TITLE
docs: Epic #3163 producer-rewrite closeout (upgrade-guide note + #3078 AC flip)

### DIFF
--- a/docs/upgrade-guide-3-tier.md
+++ b/docs/upgrade-guide-3-tier.md
@@ -201,6 +201,15 @@ issues are created, `/story-deliver` runs a single phase) — the
 deferred work is internal cleanup that does not change the runtime
 contract.
 
+> **Resolved.** The deferred producer rewrite landed via Epic #3163's
+> closing PR [#3216](https://github.com/dsj1984/mandrel/pull/3216):
+> `story-grouper.js` and `task-body-renderer.js` are deleted, every
+> producer/presentation/CLI import site is rewritten for the 3-tier
+> hierarchy, and the parked producer-side tests are reinstated. A
+> repo-wide grep for the canonical Task-tier symbols now returns zero
+> structural hits outside the `cleanup-type-task-label.js` consumer
+> utility and this historical note.
+
 ---
 
 ## References


### PR DESCRIPTION
## Summary

Completes the closeout deliverables for **Epic #3163** (Task-tier producer rewrite) that were left undone when the epic auto-merged via PR #3216 before its final closeout story ran.

- Appends a **Resolved** note to the "Known follow-on" section of `docs/upgrade-guide-3-tier.md` referencing Epic #3163's closing PR #3216.
- Re-checks Epic #3078's two previously-deferred acceptance criteria (repo-wide structural-grep AC + import-site deletion AC) and cross-links PR #3216 — done directly on issue #3078 (body + comment), not in this diff.

This is the work scoped by Story #3210 under Feature #3184.

## Notes

- Epic #3163's implementation (incl. the deleted helpers, rewritten import sites, and reinstated tests) already landed on `main` via PR #3216.
- The full suite was green on the epic branch before that merge (7156 pass / 0 fail), and `main` carries it.

Resolves #3210
Resolves #3184

🤖 Generated with [Claude Code](https://claude.com/claude-code)