### PR TITLE
Story: Add configurable ignoreGlobs to baseline file discovery (crap/maintainability) (#3217)

### DIFF
--- a/.agents/full-agentrc.json
+++ b/.agents/full-agentrc.json
@@ -167,14 +167,16 @@
           "newMethodCeiling": 30,
           "requireCoverage": true,
           "friction": { "markerKey": "crap-baseline-regression" },
-          "refreshTag": "baseline-refresh:"
+          "refreshTag": "baseline-refresh:",
+          "ignoreGlobs": ["**/fixtures/**", "**/*.generated.ts"]
         },
         "maintainability": {
           "enabled": true,
           "baselinePath": "baselines/maintainability.json",
           "tolerance": { "kind": "absolute", "value": 0.5 },
           "floors": { "*": { "min": 70, "p50": 80 } },
-          "targetDirs": ["src", "tests"]
+          "targetDirs": ["src", "tests"],
+          "ignoreGlobs": ["**/fixtures/**", "**/*.generated.ts"]
         },
         "mutation": {
           "enabled": true,

--- a/.agents/schemas/agentrc.schema.json
+++ b/.agents/schemas/agentrc.schema.json
@@ -502,6 +502,11 @@
           "type": "integer",
           "minimum": 1,
           "description": "Bounded timeout (ms) for `npm run crap:update` spawned by the baseline-attribution refresh path. Mirrors `coverage.timeoutMs`: a SIGKILL fired at the budget boundary maps to exit 124 so the close orchestrator can flip the Story to `agent::blocked`. Default 60000 (Story #2165)."
+        },
+        "ignoreGlobs": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 },
+          "description": "Minimatch glob patterns matched against the canonicalised repo-relative path of each discovered file. Files matching any pattern are excluded from CRAP discovery before scoring. Orthogonal to `components` (grouping) — a file excluded here never appears in any component bucket. Absent or empty preserves the existing IGNORED_DIRS-only behaviour (Story #3217)."
         }
       },
       "additionalProperties": false
@@ -524,6 +529,11 @@
           "type": "integer",
           "minimum": 1,
           "description": "Bounded timeout (ms) for `npm run maintainability:update` spawned by the baseline-attribution refresh path. Mirrors `coverage.timeoutMs`: a SIGKILL fired at the budget boundary maps to exit 124 so the close orchestrator can flip the Story to `agent::blocked`. Default 60000 (Story #2165)."
+        },
+        "ignoreGlobs": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 },
+          "description": "Minimatch glob patterns matched against the canonicalised repo-relative path of each discovered file. Files matching any pattern are excluded from MI discovery before scoring. Orthogonal to `components` (grouping) — a file excluded here never appears in any component bucket. Absent or empty preserves the existing IGNORED_DIRS-only behaviour (Story #3217)."
         }
       },
       "additionalProperties": false

--- a/.agents/scripts/lib/baseline-snapshot.js
+++ b/.agents/scripts/lib/baseline-snapshot.js
@@ -479,12 +479,13 @@ export async function regenerateMainFromTree({
   // ── maintainability ──────────────────────────────────────────────────────
   const miPath = baselines?.maintainability?.path;
   const miTargetDirs = quality?.maintainability?.targetDirs ?? [];
+  const miIgnoreGlobs = quality?.maintainability?.ignoreGlobs ?? [];
   if (typeof miPath === 'string' && miPath.length > 0) {
     const miAbs = path.isAbsolute(miPath) ? miPath : path.resolve(cwd, miPath);
     const sourceList = [];
     for (const dir of miTargetDirs) {
       const abs = path.isAbsolute(dir) ? dir : path.resolve(cwd, dir);
-      scanDirectoryFn(abs, sourceList);
+      scanDirectoryFn(abs, sourceList, { cwd, ignoreGlobs: miIgnoreGlobs });
     }
     const scores = await calculateAllFn(sourceList);
 
@@ -533,6 +534,9 @@ export async function regenerateMainFromTree({
   const crapTargetDirs = Array.isArray(crapCfg.targetDirs)
     ? crapCfg.targetDirs
     : [];
+  const crapIgnoreGlobs = Array.isArray(crapCfg.ignoreGlobs)
+    ? crapCfg.ignoreGlobs
+    : [];
   const requireCoverage = crapCfg.requireCoverage !== false;
   const coveragePath = crapCfg.coveragePath ?? 'coverage/coverage-final.json';
   if (typeof crapPath === 'string' && crapPath.length > 0) {
@@ -559,6 +563,7 @@ export async function regenerateMainFromTree({
         coverage,
         requireCoverage,
         cwd,
+        ignoreGlobs: crapIgnoreGlobs,
       });
       // scanAndScore yields rows keyed by `file:`; the per-kind crap module's
       // `projectRow` handles `path ?? file`, so the writer takes either.

--- a/.agents/scripts/lib/baselines/preview-gates.js
+++ b/.agents/scripts/lib/baselines/preview-gates.js
@@ -224,7 +224,9 @@ export async function runCrapPreview({
   }
 
   const targetDirs = Array.isArray(crap.targetDirs) ? crap.targetDirs : [];
-  const crapIgnoreGlobs = Array.isArray(crap.ignoreGlobs) ? crap.ignoreGlobs : [];
+  const crapIgnoreGlobs = Array.isArray(crap.ignoreGlobs)
+    ? crap.ignoreGlobs
+    : [];
   const requireCoverage = crap.requireCoverage !== false;
   const coveragePath = crap.coveragePath ?? 'coverage/coverage-final.json';
   const coverage = loadCoverage(path.resolve(cwd, coveragePath));

--- a/.agents/scripts/lib/baselines/preview-gates.js
+++ b/.agents/scripts/lib/baselines/preview-gates.js
@@ -141,10 +141,13 @@ export async function runMaintainabilityPreview({
     epicRef: null,
   });
 
-  const targetDirs = getQuality(config).maintainability.targetDirs;
+  const miQuality = getQuality(config).maintainability;
+  const targetDirs = miQuality.targetDirs;
+  const ignoreGlobs = miQuality.ignoreGlobs ?? [];
   const files = [];
   for (const dir of targetDirs) {
-    scanDirectory(dir, files);
+    const abs = path.isAbsolute(dir) ? dir : path.resolve(cwd, dir);
+    scanDirectory(abs, files, { cwd, ignoreGlobs });
   }
   const { scopeSet, scope, diffRef } = resolvePreviewScope({
     staged,
@@ -221,6 +224,7 @@ export async function runCrapPreview({
   }
 
   const targetDirs = Array.isArray(crap.targetDirs) ? crap.targetDirs : [];
+  const crapIgnoreGlobs = Array.isArray(crap.ignoreGlobs) ? crap.ignoreGlobs : [];
   const requireCoverage = crap.requireCoverage !== false;
   const coveragePath = crap.coveragePath ?? 'coverage/coverage-final.json';
   const coverage = loadCoverage(path.resolve(cwd, coveragePath));
@@ -234,6 +238,7 @@ export async function runCrapPreview({
     requireCoverage,
     cwd,
     scopeFiles: scopeSet,
+    ignoreGlobs: crapIgnoreGlobs,
   });
   const baselineRows = resolveBaselineRows(baseline, scopeSet);
   const result = compareCrap({

--- a/.agents/scripts/lib/config/gates/crap.schema.js
+++ b/.agents/scripts/lib/config/gates/crap.schema.js
@@ -24,6 +24,10 @@ export const CRAP_GATE = {
     // #2142): a SIGKILL fired at the budget boundary maps to exit code 124
     // so the close orchestrator can flip the Story to `agent::blocked`.
     refreshTimeoutMs: { type: 'integer', minimum: 1 },
+    // Story #3217 — glob patterns matched against canonicalised repo-relative
+    // paths to exclude files from CRAP discovery before scoring. Orthogonal
+    // to `components` (grouping). Absent/empty preserves existing behaviour.
+    ignoreGlobs: { type: 'array', items: { type: 'string', minLength: 1 } },
   },
   additionalProperties: false,
 };

--- a/.agents/scripts/lib/config/gates/maintainability.schema.js
+++ b/.agents/scripts/lib/config/gates/maintainability.schema.js
@@ -11,6 +11,10 @@ export const MAINTAINABILITY_GATE = {
     // spawned by the baseline-attribution refresh path. Mirrors
     // `coverage.timeoutMs` (Story #2142).
     refreshTimeoutMs: { type: 'integer', minimum: 1 },
+    // Story #3217 — glob patterns matched against canonicalised repo-relative
+    // paths to exclude files from MI discovery before scoring. Orthogonal to
+    // `components` (grouping). Absent/empty preserves existing behaviour.
+    ignoreGlobs: { type: 'array', items: { type: 'string', minLength: 1 } },
   },
   additionalProperties: false,
 };

--- a/.agents/scripts/lib/config/quality.js
+++ b/.agents/scripts/lib/config/quality.js
@@ -87,6 +87,7 @@ export const CRAP_GATE_DEFAULTS = Object.freeze({
   // `gates.coverage.timeoutMs` (Story #2142) for shape and SIGKILL → 124
   // semantics.
   refreshTimeoutMs: 60_000,
+  ignoreGlobs: Object.freeze([]),
 });
 
 /** Framework defaults for the coverage gate. */
@@ -112,6 +113,7 @@ export const MAINTAINABILITY_GATE_DEFAULTS = Object.freeze({
   // Story #2165 — bounded timeout (ms) for `npm run maintainability:update`
   // spawned by the baseline-attribution refresh path. Defaults to 60 s.
   refreshTimeoutMs: 60_000,
+  ignoreGlobs: Object.freeze([]),
 });
 
 /**
@@ -161,6 +163,7 @@ const CRAP_GATE_KEYS = new Set([
   'friction',
   'refreshTag',
   'refreshTimeoutMs',
+  'ignoreGlobs',
 ]);
 
 const COVERAGE_GATE_KEYS = new Set([
@@ -179,6 +182,7 @@ const MI_GATE_KEYS = new Set([
   'floors',
   'targetDirs',
   'refreshTimeoutMs',
+  'ignoreGlobs',
 ]);
 
 /**
@@ -245,6 +249,7 @@ export function resolveMaintainabilityCrap(
       friction: { ...defaults.friction },
       refreshTag: defaults.refreshTag,
       refreshTimeoutMs: defaults.refreshTimeoutMs,
+      ignoreGlobs: [...defaults.ignoreGlobs],
       defaultScope: scoping.defaultScope,
       diffRef: scoping.diffRef,
     };
@@ -268,6 +273,9 @@ export function resolveMaintainabilityCrap(
       userCrap.refreshTimeoutMs,
       defaults.refreshTimeoutMs,
     ),
+    ignoreGlobs: Array.isArray(userCrap.ignoreGlobs)
+      ? userCrap.ignoreGlobs.slice()
+      : [...defaults.ignoreGlobs],
     defaultScope: scoping.defaultScope,
     diffRef: scoping.diffRef,
   };
@@ -288,6 +296,7 @@ export function resolveMaintainabilityQuality(userBlock, gateScoping) {
     return {
       targetDirs: [...defaults.targetDirs],
       refreshTimeoutMs: defaults.refreshTimeoutMs,
+      ignoreGlobs: [...defaults.ignoreGlobs],
       defaultScope: scoping.defaultScope,
       diffRef: scoping.diffRef,
     };
@@ -299,6 +308,9 @@ export function resolveMaintainabilityQuality(userBlock, gateScoping) {
       userBlock.refreshTimeoutMs,
       defaults.refreshTimeoutMs,
     ),
+    ignoreGlobs: Array.isArray(userBlock.ignoreGlobs)
+      ? userBlock.ignoreGlobs.slice()
+      : [...defaults.ignoreGlobs],
     defaultScope: scoping.defaultScope,
     diffRef: scoping.diffRef,
   };

--- a/.agents/scripts/lib/crap-utils.js
+++ b/.agents/scripts/lib/crap-utils.js
@@ -239,6 +239,7 @@ export async function scanAndScore({
   requireCoverage = true,
   cwd = process.cwd(),
   scopeFiles = null,
+  ignoreGlobs = [],
 }) {
   if (!Array.isArray(targetDirs)) {
     throw new TypeError('scanAndScore: targetDirs must be an array');
@@ -252,7 +253,7 @@ export async function scanAndScore({
   const files = [];
   for (const dir of targetDirs) {
     const abs = path.isAbsolute(dir) ? dir : path.resolve(cwd, dir);
-    scanDirectory(abs, files);
+    scanDirectory(abs, files, { cwd, ignoreGlobs });
   }
   files.sort();
 

--- a/.agents/scripts/lib/maintainability-utils.js
+++ b/.agents/scripts/lib/maintainability-utils.js
@@ -1,6 +1,8 @@
 import fs from 'node:fs';
 import { createRequire } from 'node:module';
 import path from 'node:path';
+import { minimatch } from 'minimatch';
+import { canonicalise as canonicalisePath } from './baselines/path-canon.js';
 import {
   write as writeBaselineEnvelope,
   writeFile as writeBaselineFile,
@@ -223,11 +225,20 @@ const IGNORED_DIRS = new Set([
  * in `IGNORED_DIRS` (including `coverage` and `.next`, added in 5.29.0
  * to skip vitest's istanbul HTML scaffolding and Next.js build output)
  * are skipped.
+ *
  * @param {string} dir
  * @param {string[]} fileList
+ * @param {{ ignoreGlobs?: string[], cwd?: string }} [opts]
+ *   `ignoreGlobs` — minimatch patterns matched against the canonicalised
+ *   repo-relative path of each discovered file. Files whose path matches
+ *   any pattern are excluded before scoring. Absent/empty is a no-op.
+ *   `cwd` — root used to compute repo-relative paths for glob matching;
+ *   defaults to `process.cwd()` when omitted.
  * @returns {string[]}
  */
-export function scanDirectory(dir, fileList = []) {
+export function scanDirectory(dir, fileList = [], opts = {}) {
+  const { ignoreGlobs = [], cwd: optsCwd } = opts;
+  const matchCwd = optsCwd ?? process.cwd();
   let entries;
   try {
     entries = fs.readdirSync(dir, { withFileTypes: true });
@@ -240,9 +251,19 @@ export function scanDirectory(dir, fileList = []) {
     const filePath = path.join(dir, entry.name);
     if (entry.isDirectory()) {
       if (!IGNORED_DIRS.has(entry.name)) {
-        scanDirectory(filePath, fileList);
+        scanDirectory(filePath, fileList, opts);
       }
     } else if (entry.isFile() && isSupportedSourceFile(entry.name)) {
+      if (ignoreGlobs.length > 0) {
+        const absFilePath = path.isAbsolute(filePath)
+          ? filePath
+          : path.resolve(filePath);
+        const rawRel = path.relative(matchCwd, absFilePath).replace(/\\/g, '/');
+        const relPath = canonicalisePath(rawRel);
+        if (ignoreGlobs.some((g) => minimatch(relPath, g, { dot: true }))) {
+          continue;
+        }
+      }
       fileList.push(filePath);
     }
   }

--- a/.agents/scripts/lib/orchestration/story-close/baseline-attribution/phases/refresh-commit.js
+++ b/.agents/scripts/lib/orchestration/story-close/baseline-attribution/phases/refresh-commit.js
@@ -72,11 +72,12 @@ export function buildKindScorer({
   const quality = getQuality(config) ?? {};
   if (kind === 'maintainability') {
     const targetDirs = quality?.maintainability?.targetDirs ?? [];
+    const miIgnoreGlobs = quality?.maintainability?.ignoreGlobs ?? [];
     return async () => {
       const sourceList = [];
       for (const dir of targetDirs) {
         const abs = path.isAbsolute(dir) ? dir : path.resolve(cwd, dir);
-        scanDirectory(abs, sourceList);
+        scanDirectory(abs, sourceList, { cwd, ignoreGlobs: miIgnoreGlobs });
       }
       const scores = await calculateAll(sourceList);
       return filterExcludedRows(
@@ -93,6 +94,9 @@ export function buildKindScorer({
     const targetDirs = Array.isArray(crapCfg.targetDirs)
       ? crapCfg.targetDirs
       : [];
+    const crapIgnoreGlobs = Array.isArray(crapCfg.ignoreGlobs)
+      ? crapCfg.ignoreGlobs
+      : [];
     const requireCoverage = crapCfg.requireCoverage !== false;
     const coveragePath = crapCfg.coveragePath ?? 'coverage/coverage-final.json';
     return async () => {
@@ -106,6 +110,7 @@ export function buildKindScorer({
         coverage,
         requireCoverage,
         cwd,
+        ignoreGlobs: crapIgnoreGlobs,
       });
       // Stamp kernel versions so downstream gates can reason about the
       // scoring environment. The writer keeps `kernelVersion`; the others

--- a/.agents/scripts/update-maintainability-baseline.js
+++ b/.agents/scripts/update-maintainability-baseline.js
@@ -64,7 +64,7 @@ function parseFullScopeFlag(argv = []) {
  * The scorer is `cwd`-aware: the service passes its `cwd` through so all
  * path normalisation stays consistent with diff-scope derivation.
  */
-function buildMaintainabilityScorer({ targetDirs, logger }) {
+function buildMaintainabilityScorer({ targetDirs, ignoreGlobs = [], logger }) {
   return async function maintainabilityScorer(files, opts) {
     const cwd = opts?.cwd ?? process.cwd();
     let absPaths;
@@ -73,7 +73,7 @@ function buildMaintainabilityScorer({ targetDirs, logger }) {
       for (const dir of targetDirs) {
         const abs = path.isAbsolute(dir) ? dir : path.resolve(cwd, dir);
         logger.info(`[Maintainability] Scanning ${dir}...`);
-        scanDirectory(abs, absPaths);
+        scanDirectory(abs, absPaths, { cwd, ignoreGlobs });
       }
     } else {
       // Files come in as canonical POSIX repo-relative paths from the
@@ -116,7 +116,9 @@ async function main() {
   }
 
   const config = resolveConfig();
-  const targetDirs = getQuality(config).maintainability.targetDirs;
+  const miQuality = getQuality(config).maintainability;
+  const targetDirs = miQuality.targetDirs;
+  const ignoreGlobs = miQuality.ignoreGlobs ?? [];
   const baselinePath = getBaselines(config).maintainability.path;
   const absBaselinePath = path.isAbsolute(baselinePath)
     ? baselinePath
@@ -134,7 +136,7 @@ async function main() {
     );
   }
 
-  const scorer = buildMaintainabilityScorer({ targetDirs, logger: Logger });
+  const scorer = buildMaintainabilityScorer({ targetDirs, ignoreGlobs, logger: Logger });
 
   // Task #2214 (Epic #2173, AC-2): flag-omission now defaults to
   // diff-scope. The pre-migration default was a full regenerate; operators

--- a/.agents/scripts/update-maintainability-baseline.js
+++ b/.agents/scripts/update-maintainability-baseline.js
@@ -136,7 +136,11 @@ async function main() {
     );
   }
 
-  const scorer = buildMaintainabilityScorer({ targetDirs, ignoreGlobs, logger: Logger });
+  const scorer = buildMaintainabilityScorer({
+    targetDirs,
+    ignoreGlobs,
+    logger: Logger,
+  });
 
   // Task #2214 (Epic #2173, AC-2): flag-omission now defaults to
   // diff-scope. The pre-migration default was a full regenerate; operators

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -182,6 +182,7 @@ top-level keys are validation errors.
 | `quality.gates.crap.friction.markerKey` | No | `string` | — | — |
 | `quality.gates.crap.refreshTag` | No | `string` | — | — |
 | `quality.gates.crap.refreshTimeoutMs` | No | `integer` | — | Bounded timeout (ms) for `npm run crap:update` spawned by the baseline-attribution refresh path. Mirrors `coverage.timeoutMs`: a SIGKILL fired at the budget boundary maps to exit 124 so the close orchestrator can flip the Story to `agent::blocked`. Default 60000 (Story #2165). |
+| `quality.gates.crap.ignoreGlobs` | No | `array<string>` | — | Minimatch glob patterns matched against the canonicalised repo-relative path of each discovered file. Files matching any pattern are excluded from CRAP discovery before scoring. Orthogonal to `components` (grouping) — a file excluded here never appears in any component bucket. Absent or empty preserves the existing IGNORED_DIRS-only behaviour (Story #3217). |
 | `quality.gates.maintainability` | No | `object` | — | Nested configuration block. |
 | `quality.gates.maintainability.enabled` | No | `boolean` | — | — |
 | `quality.gates.maintainability.baselinePath` | No | `string` | — | — |
@@ -192,6 +193,7 @@ top-level keys are validation errors.
 | `quality.gates.maintainability.components` | No | `object<map>` | — | — |
 | `quality.gates.maintainability.targetDirs` | No | `string[]` or `{ append?, prepend? }` | — | Directories whose JS sources the maintainability gate scores. Mandrel ships a `src/`-centric default; projects whose executable code lives elsewhere (e.g. this repo's `.agents/scripts/` plus `tests/`) override here. The framework default is intentionally not auto-discovered, so an override is the explicit, auditable signal. |
 | `quality.gates.maintainability.refreshTimeoutMs` | No | `integer` | — | Bounded timeout (ms) for `npm run maintainability:update` spawned by the baseline-attribution refresh path. Mirrors `coverage.timeoutMs`: a SIGKILL fired at the budget boundary maps to exit 124 so the close orchestrator can flip the Story to `agent::blocked`. Default 60000 (Story #2165). |
+| `quality.gates.maintainability.ignoreGlobs` | No | `array<string>` | — | Minimatch glob patterns matched against the canonicalised repo-relative path of each discovered file. Files matching any pattern are excluded from MI discovery before scoring. Orthogonal to `components` (grouping) — a file excluded here never appears in any component bucket. Absent or empty preserves the existing IGNORED_DIRS-only behaviour (Story #3217). |
 | `quality.gates.mutation` | No | `object` | — | Nested configuration block. |
 | `quality.gates.mutation.enabled` | No | `boolean` | — | — |
 | `quality.gates.mutation.baselinePath` | No | `string` | — | — |

--- a/tests/maintainability-utils.ignore-globs.test.js
+++ b/tests/maintainability-utils.ignore-globs.test.js
@@ -1,0 +1,224 @@
+import assert from 'node:assert';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { test } from 'node:test';
+import { scanDirectory } from '../.agents/scripts/lib/maintainability-utils.js';
+
+/**
+ * Story #3217 — configurable `ignoreGlobs` for CRAP/MI baseline file
+ * discovery. `scanDirectory` accepts an optional `opts` bag with
+ * `ignoreGlobs` (minimatch patterns) and `cwd` (root for relative-path
+ * computation). Files whose canonicalised relative path matches any glob
+ * are excluded before scoring.
+ */
+
+function mkTmp() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'mi_ignore_globs_'));
+}
+
+function rmTmp(dir) {
+  try {
+    fs.rmSync(dir, { recursive: true, force: true });
+  } catch {
+    /* noop */
+  }
+}
+
+function rels(found, base) {
+  return found
+    .map((p) => path.relative(base, p).replace(/\\/g, '/'))
+    .sort();
+}
+
+// ── empty / missing ignoreGlobs is a no-op ────────────────────────────────
+
+test('scanDirectory — absent opts produces same result as no opts', () => {
+  const dir = mkTmp();
+  try {
+    fs.writeFileSync(path.join(dir, 'a.js'), '// a');
+    fs.writeFileSync(path.join(dir, 'b.ts'), '// b');
+    const withoutOpts = scanDirectory(dir).map((p) => path.relative(dir, p)).sort();
+    const withEmptyOpts = scanDirectory(dir, [], {}).map((p) => path.relative(dir, p)).sort();
+    assert.deepStrictEqual(withEmptyOpts, withoutOpts);
+  } finally {
+    rmTmp(dir);
+  }
+});
+
+test('scanDirectory — empty ignoreGlobs is a no-op', () => {
+  const dir = mkTmp();
+  try {
+    fs.writeFileSync(path.join(dir, 'a.js'), '// a');
+    const baseline = scanDirectory(dir).map((p) => path.relative(dir, p)).sort();
+    const withEmpty = scanDirectory(dir, [], { ignoreGlobs: [], cwd: dir })
+      .map((p) => path.relative(dir, p))
+      .sort();
+    assert.deepStrictEqual(withEmpty, baseline);
+  } finally {
+    rmTmp(dir);
+  }
+});
+
+// ── single glob excludes matching files ───────────────────────────────────
+
+test('scanDirectory — single glob excludes matching files', () => {
+  const dir = mkTmp();
+  try {
+    fs.mkdirSync(path.join(dir, 'src'));
+    fs.mkdirSync(path.join(dir, 'fixtures'));
+    fs.writeFileSync(path.join(dir, 'src', 'app.js'), '// app');
+    fs.writeFileSync(path.join(dir, 'fixtures', 'mock.js'), '// mock');
+
+    const found = scanDirectory(dir, [], { cwd: dir, ignoreGlobs: ['fixtures/**'] });
+    assert.deepStrictEqual(rels(found, dir), ['src/app.js']);
+  } finally {
+    rmTmp(dir);
+  }
+});
+
+test('scanDirectory — single glob with ** prefix excludes deeply nested files', () => {
+  const dir = mkTmp();
+  try {
+    fs.mkdirSync(path.join(dir, 'src'));
+    fs.mkdirSync(path.join(dir, 'src', '__fixtures__'), { recursive: true });
+    fs.mkdirSync(path.join(dir, 'src', 'utils', '__fixtures__'), { recursive: true });
+    fs.writeFileSync(path.join(dir, 'src', 'a.js'), '// a');
+    fs.writeFileSync(path.join(dir, 'src', '__fixtures__', 'fake.js'), '// fake1');
+    fs.writeFileSync(path.join(dir, 'src', 'utils', '__fixtures__', 'fake2.js'), '// fake2');
+
+    const found = scanDirectory(dir, [], { cwd: dir, ignoreGlobs: ['**/__fixtures__/**'] });
+    assert.deepStrictEqual(rels(found, dir), ['src/a.js']);
+  } finally {
+    rmTmp(dir);
+  }
+});
+
+// ── multiple globs ────────────────────────────────────────────────────────
+
+test('scanDirectory — multiple globs each exclude their matching files', () => {
+  const dir = mkTmp();
+  try {
+    fs.mkdirSync(path.join(dir, 'src'));
+    fs.mkdirSync(path.join(dir, 'gen'));
+    fs.mkdirSync(path.join(dir, 'fixtures'));
+    fs.writeFileSync(path.join(dir, 'src', 'a.js'), '// a');
+    fs.writeFileSync(path.join(dir, 'gen', 'auto.generated.ts'), '// gen');
+    fs.writeFileSync(path.join(dir, 'fixtures', 'fake.js'), '// fake');
+
+    const found = scanDirectory(dir, [], {
+      cwd: dir,
+      ignoreGlobs: ['gen/**', 'fixtures/**'],
+    });
+    assert.deepStrictEqual(rels(found, dir), ['src/a.js']);
+  } finally {
+    rmTmp(dir);
+  }
+});
+
+test('scanDirectory — glob matching *.generated.ts excludes generated files', () => {
+  const dir = mkTmp();
+  try {
+    fs.mkdirSync(path.join(dir, 'src'));
+    fs.writeFileSync(path.join(dir, 'src', 'app.ts'), '// app');
+    fs.writeFileSync(path.join(dir, 'src', 'schema.generated.ts'), '// gen');
+
+    const found = scanDirectory(dir, [], {
+      cwd: dir,
+      ignoreGlobs: ['**/*.generated.ts'],
+    });
+    assert.deepStrictEqual(rels(found, dir), ['src/app.ts']);
+  } finally {
+    rmTmp(dir);
+  }
+});
+
+// ── interaction with targetDirs (scoped exclusion) ────────────────────────
+
+test('scanDirectory — exclusion is scoped within the targetDir root', () => {
+  const root = mkTmp();
+  try {
+    // Simulate a monorepo: app/ and packages/ as separate targetDirs.
+    // fixtures/ inside app/ is excluded; fixtures/ inside packages/ is NOT.
+    fs.mkdirSync(path.join(root, 'app', 'src'), { recursive: true });
+    fs.mkdirSync(path.join(root, 'app', 'fixtures'), { recursive: true });
+    fs.mkdirSync(path.join(root, 'packages', 'lib', 'src'), { recursive: true });
+    fs.mkdirSync(path.join(root, 'packages', 'lib', 'fixtures'), { recursive: true });
+    fs.writeFileSync(path.join(root, 'app', 'src', 'main.js'), '// main');
+    fs.writeFileSync(path.join(root, 'app', 'fixtures', 'fix.js'), '// fix');
+    fs.writeFileSync(path.join(root, 'packages', 'lib', 'src', 'util.js'), '// util');
+    fs.writeFileSync(path.join(root, 'packages', 'lib', 'fixtures', 'fix2.js'), '// fix2');
+
+    // Both targetDirs share the same cwd (repo root) and ignoreGlobs.
+    const globs = ['app/fixtures/**'];
+    const files = [];
+    for (const dir of ['app', 'packages']) {
+      const abs = path.resolve(root, dir);
+      scanDirectory(abs, files, { cwd: root, ignoreGlobs: globs });
+    }
+    const found = rels(files, root);
+    // app/fixtures/fix.js is excluded; packages/**  is kept.
+    assert.ok(!found.includes('app/fixtures/fix.js'), 'app fixture should be excluded');
+    assert.ok(found.includes('app/src/main.js'), 'app/src/main.js should be present');
+    assert.ok(found.includes('packages/lib/src/util.js'), 'packages util should be present');
+    assert.ok(found.includes('packages/lib/fixtures/fix2.js'), 'packages fixture is NOT excluded');
+  } finally {
+    rmTmp(root);
+  }
+});
+
+// ── interaction with components (excluded row never in any bucket) ────────
+
+test('scanDirectory — excluded file is absent from calculateAll result', async () => {
+  const { calculateAll } = await import('../.agents/scripts/lib/maintainability-utils.js');
+  const { groupRows } = await import('../.agents/scripts/lib/baselines/components.js');
+  const dir = mkTmp();
+  try {
+    fs.mkdirSync(path.join(dir, 'src'));
+    fs.mkdirSync(path.join(dir, 'fixtures'));
+    fs.writeFileSync(
+      path.join(dir, 'src', 'a.js'),
+      'export function add(x, y) { return x + y; }\n',
+    );
+    fs.writeFileSync(
+      path.join(dir, 'fixtures', 'stub.js'),
+      'export const stub = () => {};\n',
+    );
+
+    const files = scanDirectory(dir, [], { cwd: dir, ignoreGlobs: ['fixtures/**'] });
+    const scores = await calculateAll(files);
+
+    // 'fixtures/stub.js' must not appear in scores at all.
+    assert.ok(!Object.keys(scores).some((k) => k.includes('fixtures')),
+      'fixtures/stub.js should not appear in scores');
+
+    // Also verify components grouper sees nothing for fixtures.
+    const rows = Object.entries(scores).map(([p, mi]) => ({ path: p, mi }));
+    const components = { all: ['**'] };
+    const grouped = groupRows(rows, components, 'path');
+    const allPaths = grouped.all?.map((r) => r.path) ?? [];
+    assert.ok(!allPaths.some((p) => p.includes('fixtures')),
+      'fixtures/stub.js should not appear in any component bucket');
+  } finally {
+    rmTmp(dir);
+  }
+});
+
+// ── canonical path matching (Windows separators, worktree prefix) ─────────
+
+test('scanDirectory — worktree-prefix paths canonicalise correctly', () => {
+  const dir = mkTmp();
+  try {
+    fs.mkdirSync(path.join(dir, '.worktrees', 'story-999', 'src'), { recursive: true });
+    fs.mkdirSync(path.join(dir, 'src'));
+    fs.writeFileSync(path.join(dir, 'src', 'a.js'), '// a');
+    // The worktree-prefixed dir is inside IGNORED_DIRS (.worktrees), so it won't
+    // be walked at all. This test verifies the no-op case where IGNORED_DIRS
+    // handles that — ignoreGlobs is orthogonal.
+    const found = scanDirectory(dir, [], { cwd: dir, ignoreGlobs: ['src/**'] });
+    // src/** should exclude src/a.js.
+    assert.deepStrictEqual(rels(found, dir), []);
+  } finally {
+    rmTmp(dir);
+  }
+});

--- a/tests/maintainability-utils.ignore-globs.test.js
+++ b/tests/maintainability-utils.ignore-globs.test.js
@@ -26,9 +26,7 @@ function rmTmp(dir) {
 }
 
 function rels(found, base) {
-  return found
-    .map((p) => path.relative(base, p).replace(/\\/g, '/'))
-    .sort();
+  return found.map((p) => path.relative(base, p).replace(/\\/g, '/')).sort();
 }
 
 // ── empty / missing ignoreGlobs is a no-op ────────────────────────────────
@@ -38,8 +36,12 @@ test('scanDirectory — absent opts produces same result as no opts', () => {
   try {
     fs.writeFileSync(path.join(dir, 'a.js'), '// a');
     fs.writeFileSync(path.join(dir, 'b.ts'), '// b');
-    const withoutOpts = scanDirectory(dir).map((p) => path.relative(dir, p)).sort();
-    const withEmptyOpts = scanDirectory(dir, [], {}).map((p) => path.relative(dir, p)).sort();
+    const withoutOpts = scanDirectory(dir)
+      .map((p) => path.relative(dir, p))
+      .sort();
+    const withEmptyOpts = scanDirectory(dir, [], {})
+      .map((p) => path.relative(dir, p))
+      .sort();
     assert.deepStrictEqual(withEmptyOpts, withoutOpts);
   } finally {
     rmTmp(dir);
@@ -50,7 +52,9 @@ test('scanDirectory — empty ignoreGlobs is a no-op', () => {
   const dir = mkTmp();
   try {
     fs.writeFileSync(path.join(dir, 'a.js'), '// a');
-    const baseline = scanDirectory(dir).map((p) => path.relative(dir, p)).sort();
+    const baseline = scanDirectory(dir)
+      .map((p) => path.relative(dir, p))
+      .sort();
     const withEmpty = scanDirectory(dir, [], { ignoreGlobs: [], cwd: dir })
       .map((p) => path.relative(dir, p))
       .sort();
@@ -70,7 +74,10 @@ test('scanDirectory — single glob excludes matching files', () => {
     fs.writeFileSync(path.join(dir, 'src', 'app.js'), '// app');
     fs.writeFileSync(path.join(dir, 'fixtures', 'mock.js'), '// mock');
 
-    const found = scanDirectory(dir, [], { cwd: dir, ignoreGlobs: ['fixtures/**'] });
+    const found = scanDirectory(dir, [], {
+      cwd: dir,
+      ignoreGlobs: ['fixtures/**'],
+    });
     assert.deepStrictEqual(rels(found, dir), ['src/app.js']);
   } finally {
     rmTmp(dir);
@@ -82,12 +89,23 @@ test('scanDirectory — single glob with ** prefix excludes deeply nested files'
   try {
     fs.mkdirSync(path.join(dir, 'src'));
     fs.mkdirSync(path.join(dir, 'src', '__fixtures__'), { recursive: true });
-    fs.mkdirSync(path.join(dir, 'src', 'utils', '__fixtures__'), { recursive: true });
+    fs.mkdirSync(path.join(dir, 'src', 'utils', '__fixtures__'), {
+      recursive: true,
+    });
     fs.writeFileSync(path.join(dir, 'src', 'a.js'), '// a');
-    fs.writeFileSync(path.join(dir, 'src', '__fixtures__', 'fake.js'), '// fake1');
-    fs.writeFileSync(path.join(dir, 'src', 'utils', '__fixtures__', 'fake2.js'), '// fake2');
+    fs.writeFileSync(
+      path.join(dir, 'src', '__fixtures__', 'fake.js'),
+      '// fake1',
+    );
+    fs.writeFileSync(
+      path.join(dir, 'src', 'utils', '__fixtures__', 'fake2.js'),
+      '// fake2',
+    );
 
-    const found = scanDirectory(dir, [], { cwd: dir, ignoreGlobs: ['**/__fixtures__/**'] });
+    const found = scanDirectory(dir, [], {
+      cwd: dir,
+      ignoreGlobs: ['**/__fixtures__/**'],
+    });
     assert.deepStrictEqual(rels(found, dir), ['src/a.js']);
   } finally {
     rmTmp(dir);
@@ -142,12 +160,22 @@ test('scanDirectory — exclusion is scoped within the targetDir root', () => {
     // fixtures/ inside app/ is excluded; fixtures/ inside packages/ is NOT.
     fs.mkdirSync(path.join(root, 'app', 'src'), { recursive: true });
     fs.mkdirSync(path.join(root, 'app', 'fixtures'), { recursive: true });
-    fs.mkdirSync(path.join(root, 'packages', 'lib', 'src'), { recursive: true });
-    fs.mkdirSync(path.join(root, 'packages', 'lib', 'fixtures'), { recursive: true });
+    fs.mkdirSync(path.join(root, 'packages', 'lib', 'src'), {
+      recursive: true,
+    });
+    fs.mkdirSync(path.join(root, 'packages', 'lib', 'fixtures'), {
+      recursive: true,
+    });
     fs.writeFileSync(path.join(root, 'app', 'src', 'main.js'), '// main');
     fs.writeFileSync(path.join(root, 'app', 'fixtures', 'fix.js'), '// fix');
-    fs.writeFileSync(path.join(root, 'packages', 'lib', 'src', 'util.js'), '// util');
-    fs.writeFileSync(path.join(root, 'packages', 'lib', 'fixtures', 'fix2.js'), '// fix2');
+    fs.writeFileSync(
+      path.join(root, 'packages', 'lib', 'src', 'util.js'),
+      '// util',
+    );
+    fs.writeFileSync(
+      path.join(root, 'packages', 'lib', 'fixtures', 'fix2.js'),
+      '// fix2',
+    );
 
     // Both targetDirs share the same cwd (repo root) and ignoreGlobs.
     const globs = ['app/fixtures/**'];
@@ -158,10 +186,22 @@ test('scanDirectory — exclusion is scoped within the targetDir root', () => {
     }
     const found = rels(files, root);
     // app/fixtures/fix.js is excluded; packages/**  is kept.
-    assert.ok(!found.includes('app/fixtures/fix.js'), 'app fixture should be excluded');
-    assert.ok(found.includes('app/src/main.js'), 'app/src/main.js should be present');
-    assert.ok(found.includes('packages/lib/src/util.js'), 'packages util should be present');
-    assert.ok(found.includes('packages/lib/fixtures/fix2.js'), 'packages fixture is NOT excluded');
+    assert.ok(
+      !found.includes('app/fixtures/fix.js'),
+      'app fixture should be excluded',
+    );
+    assert.ok(
+      found.includes('app/src/main.js'),
+      'app/src/main.js should be present',
+    );
+    assert.ok(
+      found.includes('packages/lib/src/util.js'),
+      'packages util should be present',
+    );
+    assert.ok(
+      found.includes('packages/lib/fixtures/fix2.js'),
+      'packages fixture is NOT excluded',
+    );
   } finally {
     rmTmp(root);
   }
@@ -170,8 +210,12 @@ test('scanDirectory — exclusion is scoped within the targetDir root', () => {
 // ── interaction with components (excluded row never in any bucket) ────────
 
 test('scanDirectory — excluded file is absent from calculateAll result', async () => {
-  const { calculateAll } = await import('../.agents/scripts/lib/maintainability-utils.js');
-  const { groupRows } = await import('../.agents/scripts/lib/baselines/components.js');
+  const { calculateAll } = await import(
+    '../.agents/scripts/lib/maintainability-utils.js'
+  );
+  const { groupRows } = await import(
+    '../.agents/scripts/lib/baselines/components.js'
+  );
   const dir = mkTmp();
   try {
     fs.mkdirSync(path.join(dir, 'src'));
@@ -185,20 +229,27 @@ test('scanDirectory — excluded file is absent from calculateAll result', async
       'export const stub = () => {};\n',
     );
 
-    const files = scanDirectory(dir, [], { cwd: dir, ignoreGlobs: ['fixtures/**'] });
+    const files = scanDirectory(dir, [], {
+      cwd: dir,
+      ignoreGlobs: ['fixtures/**'],
+    });
     const scores = await calculateAll(files);
 
     // 'fixtures/stub.js' must not appear in scores at all.
-    assert.ok(!Object.keys(scores).some((k) => k.includes('fixtures')),
-      'fixtures/stub.js should not appear in scores');
+    assert.ok(
+      !Object.keys(scores).some((k) => k.includes('fixtures')),
+      'fixtures/stub.js should not appear in scores',
+    );
 
     // Also verify components grouper sees nothing for fixtures.
     const rows = Object.entries(scores).map(([p, mi]) => ({ path: p, mi }));
     const components = { all: ['**'] };
     const grouped = groupRows(rows, components, 'path');
     const allPaths = grouped.all?.map((r) => r.path) ?? [];
-    assert.ok(!allPaths.some((p) => p.includes('fixtures')),
-      'fixtures/stub.js should not appear in any component bucket');
+    assert.ok(
+      !allPaths.some((p) => p.includes('fixtures')),
+      'fixtures/stub.js should not appear in any component bucket',
+    );
   } finally {
     rmTmp(dir);
   }
@@ -209,7 +260,9 @@ test('scanDirectory — excluded file is absent from calculateAll result', async
 test('scanDirectory — worktree-prefix paths canonicalise correctly', () => {
   const dir = mkTmp();
   try {
-    fs.mkdirSync(path.join(dir, '.worktrees', 'story-999', 'src'), { recursive: true });
+    fs.mkdirSync(path.join(dir, '.worktrees', 'story-999', 'src'), {
+      recursive: true,
+    });
     fs.mkdirSync(path.join(dir, 'src'));
     fs.writeFileSync(path.join(dir, 'src', 'a.js'), '// a');
     // The worktree-prefixed dir is inside IGNORED_DIRS (.worktrees), so it won't


### PR DESCRIPTION
Closes #3217

_Auto-opened by `/single-story-deliver`._