### PR TITLE
Move single-story-deliver into workflows/helpers (#3228)

### DIFF
--- a/.agents/README.md
+++ b/.agents/README.md
@@ -47,7 +47,7 @@ After bootstrap you can run any slash command — `/epic-plan`,
 `/single-story-plan`, `/single-story-deliver`, `/audit-security`,
 `/agents-update`, etc. The [SDLC guide](SDLC.md) walks an end-to-end
 Epic; standalone Stories pair [`/single-story-plan`](workflows/single-story-plan.md)
-(idea → drafted Story Issue) with [`/single-story-deliver`](workflows/single-story-deliver.md)
+(idea → drafted Story Issue) with [`/single-story-deliver`](workflows/helpers/single-story-deliver.md)
 (Story Issue → merged PR).
 
 ---

--- a/.agents/scripts/check-doc-links.js
+++ b/.agents/scripts/check-doc-links.js
@@ -318,12 +318,16 @@ export function checkFile(absPath, repoRoot) {
   }
 
   // 3. Slash-command resolution. Skip retired hits (already reported) and
-  //    allowlisted tokens.
+  //    allowlisted tokens. A command is valid if it resolves to a top-level
+  //    workflow file OR to a helpers/ module (helpers are not exposed as slash
+  //    commands in .claude/commands/ but are still legitimate named workflows
+  //    that parent workflows invoke by prose reference).
   for (const { token, line } of extractSlashTokens(masked)) {
     if (RETIRED_COMMANDS.has(token)) continue;
     if (SLASH_ALLOWLIST.has(token)) continue;
     const workflowFile = path.join(workflowsDir, `${token}.md`);
-    if (!fs.existsSync(workflowFile)) {
+    const helperFile = path.join(workflowsDir, 'helpers', `${token}.md`);
+    if (!fs.existsSync(workflowFile) && !fs.existsSync(helperFile)) {
       violations.push({
         file: relFile,
         line,

--- a/.agents/workflows/helpers/single-story-deliver.md
+++ b/.agents/workflows/helpers/single-story-deliver.md
@@ -10,7 +10,7 @@ description:
 ## Overview
 
 `/single-story-deliver` is the standalone counterpart to
-[`/story-deliver`](story-deliver.md). Use it for a Story that is **not**
+[`/story-deliver`](../story-deliver.md). Use it for a Story that is **not**
 attached to an Epic — refactors carved out of closed Epics, framework
 maintenance, or any work small enough that the Epic-Centric ceremony
 (PRD + Tech Spec + decomposition + dispatch manifest + cascade) would be

--- a/.agents/workflows/helpers/single-story-deliver.md
+++ b/.agents/workflows/helpers/single-story-deliver.md
@@ -483,5 +483,5 @@ safe.
 
 ## See also
 
-- [`/story-deliver`](story-deliver.md) — Epic-attached Story execution.
-- [`/epic-deliver`](epic-deliver.md) — full Epic wave loop.
+- [`/story-deliver`](../story-deliver.md) — Epic-attached Story execution.
+- [`/epic-deliver`](../epic-deliver.md) — full Epic wave loop.

--- a/.agents/workflows/single-story-plan.md
+++ b/.agents/workflows/single-story-plan.md
@@ -13,7 +13,7 @@ description:
 `/single-story-plan` is the standalone counterpart to
 [`/epic-plan`](epic-plan.md) for Stories that are **not** attached to an
 Epic. It closes the gap between "one-line idea" and "well-formed
-standalone Story body ready for [`/single-story-deliver`](single-story-deliver.md)"
+standalone Story body ready for [`/single-story-deliver`](helpers/single-story-deliver.md)"
 using the same `host LLM authors + Node wrapper persists` split as
 `/epic-plan`.
 
@@ -157,11 +157,11 @@ exact `gh issue create` shape that would run.
   `--body` opens a new Issue (it is not aware of prior runs); use
   `--dry-run` first when iterating on the draft.
 - **No child Task creation.** Standalone Stories are atomic by contract
-  ([`single-story-deliver.md`](single-story-deliver.md)).
+  ([`single-story-deliver.md`](helpers/single-story-deliver.md)).
 
 ## See also
 
-- [`/single-story-deliver`](single-story-deliver.md) — the consumer
+- [`/single-story-deliver`](helpers/single-story-deliver.md) — the consumer
   workflow that picks the Story up after this one creates it.
 - [`/epic-plan`](epic-plan.md) — the Epic-tier equivalent. Phases 1–4
   inspired the seed-capture + envelope-emit pattern used here.

--- a/.agents/workflows/story-deliver.md
+++ b/.agents/workflows/story-deliver.md
@@ -30,7 +30,7 @@ The argument is always a **Story ID** (`type::story`). Epic IDs go through
 [`/epic-deliver`](epic-deliver.md).
 
 **Standalone Stories** (no `Epic: #N` in body) use
-[`/single-story-deliver`](single-story-deliver.md) instead — that workflow
+[`/single-story-deliver`](helpers/single-story-deliver.md) instead — that workflow
 branches from `main`, opens its PR directly to `main`, and skips the
 Epic-scoped machinery (cascade, dispatch manifest, dashboard regen).
 `/story-deliver` requires a parent Epic and will refuse to initialize a


### PR DESCRIPTION
Closes #3228

_Auto-opened by `/single-story-deliver`._