### PR TITLE
ci: add advisory AgentLinter check over agent-config surface

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,6 +125,58 @@ jobs:
       - name: Run check-baselines
         run: node .agents/scripts/check-baselines.js --format text
 
+  agentlinter:
+    # Story #3279 — ADVISORY, NON-BLOCKING dogfooding check.
+    #
+    # This job runs AgentLinter (https://agentlinter.com/, MIT) over Mandrel's
+    # own agent-config surface: the root `CLAUDE.md` / `AGENTS.md` entry points
+    # and the distributed `.agents/` bundle (skills, personas, rules). It
+    # surfaces AgentLinter's Security / Skill-Safety / Structure signal on the
+    # corpus of agent instructions we ship.
+    #
+    # It is INTENTIONALLY advisory and MUST NOT gate merges:
+    #   * `continue-on-error: true` swallows any non-zero exit / red annotation
+    #     so a failing AgentLinter run never fails the build.
+    #   * This job is NOT listed in `.agentrc.json`
+    #     `github.branchProtection.requiredChecks` (which carries the blocking
+    #     gates: `lint`, `test`, `baselines`, `lifecycle-doc-drift`).
+    # Read the report under the job's "Run AgentLinter ..." step logs. See the
+    # "Advisory CI checks" note in `AGENTS.md` for the rationale and the
+    # blocking-vs-advisory distinction.
+    #
+    # The `agentlinter@0.3.3` version is PINNED (not a floating tag) so report
+    # output stays reproducible across runs; bump it deliberately.
+    name: agentlinter (advisory)
+    continue-on-error: true
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Run AgentLinter over root agent configs (advisory)
+        # `--local` keeps output on stdout and skips the report upload.
+        # `|| true` is belt-and-braces over the job-level continue-on-error:
+        # AgentLinter's exit code is swallowed so this step never blocks.
+        # Run from repo root: AgentLinter discovers root CLAUDE.md / AGENTS.md.
+        run: npx --yes agentlinter@0.3.3 --local || true
+
+      - name: Run AgentLinter over .agents bundle (advisory)
+        # AgentLinter combines a single root scan with root configs OR a
+        # subdir scan with that subtree's *.md files, but not both in one
+        # pass — so the distributed `.agents/` skills/personas/rules surface
+        # is scanned in a second, separately-scoped invocation. Same pinned
+        # version, same exit-code swallow.
+        run: npx --yes agentlinter@0.3.3 .agents --local || true
+
   publish:
     name: Publish to Dist
     needs: [validate]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -116,6 +116,32 @@ confidence (lint + full tests + baselines). Pre-push runs only diff-scoped
 quality preview plus coverage/CRAP ratchet; it does not run full lint or
 `npm test`. CI always runs the full `npm test` suite.
 
+### Advisory CI checks (non-blocking)
+
+CI runs **blocking** required checks and **advisory** non-blocking ones.
+The blocking gates are the ones listed in
+[`.agentrc.json`](.agentrc.json) under
+`github.branchProtection.requiredChecks` (`lint`, `test`, `baselines`,
+`lifecycle-doc-drift`) — a red one of those stops the merge.
+
+Advisory checks surface signal without gating merges:
+
+| Check                 | Tool                                                | What it covers                                                                       | Where to read output                                                       |
+| --------------------- | --------------------------------------------------- | ------------------------------------------------------------------------------------ | -------------------------------------------------------------------------- |
+| `agentlinter (advisory)` | [AgentLinter](https://agentlinter.com/) (`npx agentlinter`, pinned `@0.3.3`, MIT) | Mandrel's own agent-config surface: root `CLAUDE.md` / `AGENTS.md` plus the distributed `.agents/` bundle (skills, personas, rules) | The `agentlinter (advisory)` job logs in the `CI / CD` workflow run — read the two "Run AgentLinter ..." step outputs |
+
+The `agentlinter (advisory)` job is **advisory-only** by design
+(`continue-on-error: true` in [`ci.yml`](.github/workflows/ci.yml) plus an
+exit-code swallow on each step), so a failing AgentLinter run never blocks a
+merge. It is deliberately **not** in `requiredChecks`. The intent is to
+gather signal — its Security and Skill-Safety dimensions are the high-value
+ones for an agent-instruction corpus — and decide later whether any
+dimension is trustworthy enough to promote toward a gate. The generic
+Clarity / Consistency / Completeness scoring is expected to be noisy on
+Mandrel's deliberately verbose, cross-referential instruction files, which
+is exactly why the check stays advisory. The pinned version keeps report
+output reproducible across runs.
+
 ### Slow-test profiling
 
 `npm run test:profile` runs the full suite with the TAP reporter, writes

--- a/docs/agentlinter-baseline.md
+++ b/docs/agentlinter-baseline.md
@@ -1,0 +1,112 @@
+# AgentLinter Baseline Report
+
+This is the **first baseline** capture of what
+[AgentLinter](https://agentlinter.com/) (`npx agentlinter`, MIT) flags on
+Mandrel's own agent-config surface, recorded when the advisory CI check was
+wired in (Story #3279).
+
+- **Tool version:** `agentlinter@0.3.3` (pinned)
+- **Captured:** 2026-05-28, against the `story-3279` tree
+- **How to reproduce:** the same two invocations the `agentlinter (advisory)`
+  CI job runs (see [`.github/workflows/ci.yml`](../.github/workflows/ci.yml)):
+
+  ```bash
+  npx --yes agentlinter@0.3.3 --local        # root CLAUDE.md / AGENTS.md
+  npx --yes agentlinter@0.3.3 .agents --local # distributed .agents/ bundle
+  ```
+
+> **Status:** advisory only. This report is a snapshot for triage, **not** a
+> to-do list scoped to Story #3279. Acting on / remediating any finding below
+> is explicit follow-up work (out of scope per the Story). The check is
+> non-blocking; see the "Advisory CI checks" note in
+> [`AGENTS.md`](../AGENTS.md) for the blocking-vs-advisory distinction.
+
+## Why two scans
+
+AgentLinter combines either a single root scan (which discovers root
+`CLAUDE.md` / `AGENTS.md`) **or** a subdirectory scan (which recurses that
+subtree's `*.md` files), but not both in one pass. To cover the whole
+agent-config surface the CI job runs it twice — once at repo root and once
+scoped to `.agents/`. The two runs therefore report independently (e.g. the
+`.agents/` run flags "No CLAUDE.md found" because that file lives at the root,
+outside the scoped subtree).
+
+## Scan 1 — root agent configs (`CLAUDE.md`, `AGENTS.md`)
+
+**Overall: 85/100 (B+)** — 1 critical, 10 warnings, 13 suggestions.
+
+| Dimension    | Score |
+| ------------ | ----- |
+| Structure    | 99 (S) |
+| Clarity      | 34 (F) |
+| Completeness | 95 (A) |
+| Security     | 95 (A) |
+| Consistency  | 100 (S) |
+| Memory       | 100 (S) |
+| Runtime      | 99 (S) |
+| SkillSafety  | 100 (S) |
+
+Headline findings:
+
+- **Critical** — `AGENTS.md`: a "vague conditional" in the release-please PAT
+  section ("update workflow files when needed)").
+- **Warnings** — "no prompt-injection defense found" (workspace-level);
+  several "absolute rule without escape hatch" hits on Markdown headings and
+  `MUST` statements; "compound instruction" and "vague instruction" hits;
+  "no tool documentation found" on `CLAUDE.md`.
+- **Suggestions** — undefined-acronym tips (`MUST`, `SDLC`, `ISC`, `TDD`,
+  `CRAP`, `MIT`, `TAP`, `PAT`, `OR`), "no version/update date", "no examples"
+  on `CLAUDE.md`, and "no runtime config".
+
+The Clarity score (34/F) reflects AgentLinter's heuristic flagging of
+Mandrel's deliberately absolute, cross-referential instruction style — exactly
+the noise this Story anticipated, and the reason the check stays advisory.
+The high-value Security (95/A) and SkillSafety (100/S) dimensions are clean.
+
+## Scan 2 — distributed `.agents/` bundle (skills, personas, rules)
+
+**Overall: 91/100 (A-)** — 1 critical, 5 warnings, 50 suggestions.
+
+| Dimension    | Score |
+| ------------ | ----- |
+| Structure    | 90 (A-) |
+| Clarity      | 100 (S) |
+| Completeness | 81 (B) |
+| Security     | 100 (S) |
+| Consistency  | 100 (S) |
+| Memory       | 100 (S) |
+| Runtime      | 99 (S) |
+| SkillSafety  | 50 (D) |
+
+Headline findings:
+
+- **Critical** — "No CLAUDE.md or AGENTS.md found": an artifact of scoping the
+  scan to the `.agents/` subtree (those entry points live at the repo root,
+  covered by Scan 1). Not a real gap.
+- **SkillSafety 50/D** — driven by two "potential injection vector in skill"
+  tips on
+  `skills/core/browser-testing-with-devtools/SKILL.md`, which fire on the
+  skill's own text **defending against** prompt injection (e.g. lines that
+  quote `"Ignore previous instructions..."` as an example of input to treat as
+  data). These are false positives on defensive guidance, worth confirming
+  during triage.
+- **Warnings** — workspace-level "no identity/persona", "no tool
+  documentation", "no boundaries", "no prompt-injection defense" (again,
+  scoping artifacts since these live in root/other files), plus a "dangerous
+  command: dynamic eval execution" hit on
+  `skills/core/security-and-hardening/SKILL.md:19` that fires on prose telling
+  authors **not** to use `eval()` — another defensive-text false positive.
+- **Suggestions** — the bulk (≈45) are "Skill missing author field" frontmatter
+  tips across every `SKILL.md`, plus workspace-level "no error handling / output
+  format / workflow / priority guidance" and "no runtime config" tips.
+
+## Triage notes for follow-up (not in scope here)
+
+- Several high-severity-looking findings (injection vectors, "dangerous
+  command: eval") are **false positives on defensive text** — the linter
+  matches the attack patterns the docs explicitly warn against. Confirm before
+  acting.
+- The "missing author field" frontmatter tip is a consistent, low-risk
+  candidate if the team wants to attribute skills.
+- The scoping artifacts ("no CLAUDE.md", "no persona/boundaries/tools" in the
+  `.agents/` scan) are expected given the two-pass approach and need no action.


### PR DESCRIPTION
## Summary

Wires [AgentLinter](https://agentlinter.com/) (`npx agentlinter`, MIT) into
this repo's CI as a **non-blocking, advisory** dogfooding check over
Mandrel's own agent-config surface — root `CLAUDE.md` / `AGENTS.md` plus the
distributed `.agents/` bundle (skills, personas, rules).

- New `agentlinter (advisory)` job in `.github/workflows/ci.yml`. It runs
  AgentLinter twice (root configs + `.agents/` subtree, since the CLI scans
  one OR the other per pass), pinned to `agentlinter@0.3.3` for reproducible
  reports. It is **advisory-only**: `continue-on-error: true` plus a per-step
  exit-code swallow means a red run never gates a merge, and it is
  deliberately **not** in `.agentrc.json` `requiredChecks`.
- `AGENTS.md` gains an "Advisory CI checks (non-blocking)" note recording the
  check, its advisory-only intent, where to read its output, and the
  blocking-vs-advisory distinction.
- First baseline report captured at
  [`docs/agentlinter-baseline.md`](docs/agentlinter-baseline.md) — root scan
  85/100 (B+), `.agents/` scan 91/100 (A-). Security/SkillSafety are clean on
  the root configs; the `.agents/` SkillSafety dip is false positives on
  defensive anti-injection text. Triage is out of scope for this Story.

## Why

Mandrel is itself a large corpus of agent instructions; AgentLinter's
Security / Skill-Safety dimensions are directly relevant. Starting
non-blocking gathers signal without gating, so the noisy generic
Clarity/Consistency scoring on Mandrel's deliberately verbose docs never
blocks a merge.

## Out of scope

Making the check blocking, remediating findings, and any consumer-facing
distribution of AgentLinter.

## Test plan

- [x] `ci.yml` parses as valid YAML.
- [x] `markdownlint-cli2` clean on `AGENTS.md` and `docs/agentlinter-baseline.md`.
- [x] Both AgentLinter invocations run cleanly against the current tree
      (baseline captured).
- [ ] CI: the new `agentlinter (advisory)` job runs and never blocks the merge.

Closes #3279

🤖 Generated with [Claude Code](https://claude.com/claude-code)