### PR TITLE
qa harness: qaPersonas schema mandates per-persona auth material the workflow never reads — no name-only variant for url-template seams (#3306)

### DIFF
--- a/.agents/README.md
+++ b/.agents/README.md
@@ -579,10 +579,7 @@ required at run time by `resolveQaContract`. Copy the reference shape from
     "featureRoot": "tests/features",                 // root the selector resolves .feature files against
     "fixturesManifest": "tests/fixtures/personas.json", // persona → seed-data manifest
     "signInSeam": { "urlTemplate": "/dev/sign-in-as/{persona}" }, // dev seam (see step 3)
-    "personas": {
-      "admin": { "credentialRef": "QA_ADMIN_CREDENTIAL" }, // stored-credential reference, never an inline secret
-      "member": { "signInSkill": "stack/qa/sign-in-member" } // or a per-persona sign-in skill
-    },
+    "personas": ["admin", "member"],                 // name-only array — the honest shape for a url-template seam
     "consoleAllowlist": ["[HMR]"],                   // optional benign-noise filter (default [])
     "designTokens": "src/styles/tokens.css"          // optional visual-check pointer (default null)
   }
@@ -592,6 +589,27 @@ required at run time by `resolveQaContract`. Copy the reference shape from
 `featureRoot`, `fixturesManifest`, `signInSeam`, and `personas` are
 mandatory; omitting any one makes the resolver throw a field-named error.
 `consoleAllowlist` and `designTokens` default to `[]` and `null`.
+
+`personas` accepts **two shapes** (the resolver normalizes both to one
+canonical internal map keyed by persona name):
+
+- **Name-only array** (above) — `["admin", "member"]`. This is the honest
+  shape under a `urlTemplate` dev-impersonation seam, where the persona name
+  is the only input the harness consumes (it is substituted into the URL) and
+  no per-persona auth material is ever read. Do **not** fabricate
+  `credentialRef`/`signInSkill` values a url-template seam ignores.
+- **Object map** — keyed by persona name, each entry carrying per-persona
+  auth material (`{ credentialRef }` or `{ signInSkill }`). Use this only
+  under a `skill` (or credential) seam where that material is genuinely
+  consulted:
+
+  ```jsonc
+  "signInSeam": { "skill": "stack/qa/sign-in" },
+  "personas": {
+    "admin": { "credentialRef": "QA_ADMIN_CREDENTIAL" }, // stored-credential reference, never an inline secret
+    "member": { "signInSkill": "stack/qa/sign-in-member" } // or a per-persona sign-in skill
+  }
+  ```
 
 ### 2. Author the fixtures manifest
 
@@ -613,9 +631,13 @@ credentials are never entered. Expose one of two shapes:
 - **`{ skill }`** — when sign-in is multi-step or non-URL, point at a
   consumer skill whose `SKILL.md` the harness reads and follows.
 
-Per-persona overrides live under `qa.personas`: `{ credentialRef }` points at
-a stored-credential reference (resolved from the environment, never inlined)
-and `{ signInSkill }` points at a per-persona sign-in skill.
+Which seam kinds consult per-persona material: under a `{ urlTemplate }` seam
+the persona **name** is the sole input, so author `personas` as a name-only
+array and supply no auth material. Under a `{ skill }` (or credential) seam,
+author `personas` as the object map and supply per-persona overrides:
+`{ credentialRef }` points at a stored-credential reference (resolved from the
+environment, never inlined) and `{ signInSkill }` points at a per-persona
+sign-in skill.
 
 Once these three are in place, `/run-qa-harness <selector>` resolves the
 contract and sweeps the selected scenarios. The `chrome-devtools` MCP surface

--- a/.agents/full-agentrc.json
+++ b/.agents/full-agentrc.json
@@ -262,7 +262,7 @@
     "featureRoot": "tests/features",
     "fixturesManifest": "tests/fixtures/personas.json",
     "signInSeam": {
-      "urlTemplate": "/dev/sign-in-as/{persona}"
+      "skill": "stack/qa/sign-in"
     },
     "personas": {
       "admin": { "credentialRef": "QA_ADMIN_CREDENTIAL" },

--- a/.agents/schemas/agentrc.schema.json
+++ b/.agents/schemas/agentrc.schema.json
@@ -900,31 +900,50 @@
       ]
     },
     "qaPersonas": {
-      "type": "object",
-      "additionalProperties": {
-        "oneOf": [
-          {
-            "type": "object",
-            "required": ["credentialRef"],
-            "additionalProperties": false,
-            "properties": {
-              "credentialRef": {
-                "allOf": [{ "$ref": "#/$defs/safeString" }, { "minLength": 1 }]
-              }
-            }
-          },
-          {
-            "type": "object",
-            "required": ["signInSkill"],
-            "additionalProperties": false,
-            "properties": {
-              "signInSkill": {
-                "allOf": [{ "$ref": "#/$defs/safeString" }, { "minLength": 1 }]
-              }
-            }
+      "description": "Personas the QA-harness sign-in seam accepts. Two accepted shapes: (1) a plain array of persona names — the honest shape for a `urlTemplate` dev-impersonation seam, where the persona name is the sole input the workflow consumes; (2) the object-map form keyed by persona name, where each entry carries per-persona auth material (`credentialRef` or `signInSkill`) consulted only under a `skill`/credential seam.",
+      "oneOf": [
+        {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "allOf": [{ "$ref": "#/$defs/safeString" }, { "minLength": 1 }]
           }
-        ]
-      }
+        },
+        {
+          "type": "object",
+          "minProperties": 1,
+          "additionalProperties": {
+            "oneOf": [
+              {
+                "type": "object",
+                "required": ["credentialRef"],
+                "additionalProperties": false,
+                "properties": {
+                  "credentialRef": {
+                    "allOf": [
+                      { "$ref": "#/$defs/safeString" },
+                      { "minLength": 1 }
+                    ]
+                  }
+                }
+              },
+              {
+                "type": "object",
+                "required": ["signInSkill"],
+                "additionalProperties": false,
+                "properties": {
+                  "signInSkill": {
+                    "allOf": [
+                      { "$ref": "#/$defs/safeString" },
+                      { "minLength": 1 }
+                    ]
+                  }
+                }
+              }
+            ]
+          }
+        }
+      ]
     },
     "qa": {
       "type": "object",

--- a/.agents/scripts/lib/config-settings-schema.js
+++ b/.agents/scripts/lib/config-settings-schema.js
@@ -845,28 +845,45 @@ const QA_SIGN_IN_SEAM_SCHEMA = {
   ],
 };
 
+// `personas` accepts two shapes (Story #3306). The plain `string[]` of
+// persona names is the honest shape for a `urlTemplate` dev-impersonation
+// seam, where the workflow substitutes only the persona name into the URL
+// and never reads per-persona auth material. The object-map form (keyed by
+// persona name, each entry carrying `credentialRef` or `signInSkill`) is
+// for `skill`/credential seams where per-persona material is genuinely
+// consulted. The resolver normalizes both to one canonical internal form.
 const QA_PERSONAS_SCHEMA = {
-  type: 'object',
-  additionalProperties: {
-    oneOf: [
-      {
-        type: 'object',
-        properties: {
-          credentialRef: { ...SAFE_STRING, minLength: 1 },
-        },
-        required: ['credentialRef'],
-        additionalProperties: false,
+  oneOf: [
+    {
+      type: 'array',
+      minItems: 1,
+      items: { ...SAFE_STRING, minLength: 1 },
+    },
+    {
+      type: 'object',
+      minProperties: 1,
+      additionalProperties: {
+        oneOf: [
+          {
+            type: 'object',
+            properties: {
+              credentialRef: { ...SAFE_STRING, minLength: 1 },
+            },
+            required: ['credentialRef'],
+            additionalProperties: false,
+          },
+          {
+            type: 'object',
+            properties: {
+              signInSkill: { ...SAFE_STRING, minLength: 1 },
+            },
+            required: ['signInSkill'],
+            additionalProperties: false,
+          },
+        ],
       },
-      {
-        type: 'object',
-        properties: {
-          signInSkill: { ...SAFE_STRING, minLength: 1 },
-        },
-        required: ['signInSkill'],
-        additionalProperties: false,
-      },
-    ],
-  },
+    },
+  ],
 };
 
 export const QA_SCHEMA = {

--- a/.agents/scripts/lib/qa/resolve-qa-contract.js
+++ b/.agents/scripts/lib/qa/resolve-qa-contract.js
@@ -62,6 +62,37 @@ function getQaValidator() {
 }
 
 /**
+ * Normalize the two accepted `personas` shapes to one canonical internal
+ * form (Story #3306).
+ *
+ * The schema accepts either a plain `string[]` of persona names (the honest
+ * shape for a `urlTemplate` dev-impersonation seam, where the workflow reads
+ * only the persona name) or the object-map form keyed by persona name (each
+ * entry carrying `credentialRef` / `signInSkill` for a `skill`/credential
+ * seam). Downstream the workflow consumes only the persona *names*, so the
+ * canonical internal form is an object map keyed by persona name. A name-only
+ * persona maps to an empty record — it carries no fabricated auth material.
+ *
+ * @param {string[] | Record<string, object>} personas Either accepted shape.
+ * @returns {{ personas: Record<string, object>, personaNames: string[] }}
+ */
+function normalizePersonas(personas) {
+  if (Array.isArray(personas)) {
+    const map = {};
+    for (const name of personas) {
+      map[name] = {};
+    }
+    return { personas: map, personaNames: [...personas] };
+  }
+  // Object-map form: clone each entry so callers cannot mutate the input.
+  const map = {};
+  for (const [name, material] of Object.entries(personas)) {
+    map[name] = { ...material };
+  }
+  return { personas: map, personaNames: Object.keys(personas) };
+}
+
+/**
  * Render an AJV error into an actionable, field-named sentence.
  *
  * @param {import('ajv').ErrorObject} err
@@ -87,12 +118,18 @@ function describeError(err) {
  * or the bare `qa` bag. Returns a fresh normalized object — callers must not
  * mutate the input.
  *
+ * `personas` is accepted in either shape (a `string[]` of names or the
+ * object-map form) and normalized to one canonical internal form: an object
+ * map keyed by persona name. A `personaNames` array is also returned for the
+ * common case (url-template seam) where only the names are consumed.
+ *
  * @param {object | null | undefined} config Full resolved config or bare qa block.
  * @returns {{
  *   featureRoot: string,
  *   fixturesManifest: string,
  *   signInSeam: object,
- *   personas: object,
+ *   personas: Record<string, object>,
+ *   personaNames: string[],
  *   consoleAllowlist: string[],
  *   designTokens: string | null,
  * }}
@@ -134,11 +171,14 @@ export function resolveQaContract(config) {
     );
   }
 
+  const { personas, personaNames } = normalizePersonas(qa.personas);
+
   return {
     featureRoot: qa.featureRoot,
     fixturesManifest: qa.fixturesManifest,
     signInSeam: qa.signInSeam,
-    personas: qa.personas,
+    personas,
+    personaNames,
     consoleAllowlist: Array.isArray(qa.consoleAllowlist)
       ? [...qa.consoleAllowlist]
       : [...QA_CONTRACT_DEFAULTS.consoleAllowlist],

--- a/.agents/workflows/run-qa-harness.md
+++ b/.agents/workflows/run-qa-harness.md
@@ -88,7 +88,7 @@ contract:
 | `featureRoot`      | Root passed to `resolve-selection.js` for scenario discovery.             |
 | `fixturesManifest` | Persona → seed binding loaded before sign-in.                             |
 | `signInSeam`       | `{ kind: 'url', template }` **or** `{ kind: 'skill', skill }` — see Step 2. |
-| `personas`         | Persona names the seam accepts.                                           |
+| `personas`         | Canonical object map keyed by persona name (`personaNames` lists the names). Authored as a plain name array under a `urlTemplate` seam, or as a per-persona credential/skill map under a `skill` (or credential) seam — see Step 2. |
 | `consoleAllowlist` | Inline benign-console patterns (default `[]`) — see Step 4.               |
 | `designTokens`     | Pointer to the token/style source for visual inspection (default `null`). |
 
@@ -145,9 +145,24 @@ the contract's discriminated-union seam:
 - **`kind: 'url'`** — substitute `{persona}` into `template` (e.g.
   `/dev/sign-in-as/{persona}` → `/dev/sign-in-as/admin`) and `navigate_page`
   to the resulting dev seam URL. This is a dev-only seam; **no real
-  credentials** are ever entered.
+  credentials** are ever entered. The persona **name** (a `personaNames`
+  entry) is the **sole input** the seam consumes — per-persona auth material
+  is neither needed nor read here, so under a `urlTemplate` seam the contract
+  is authored as a plain name array (`personas: ["athlete", "coach"]`).
 - **`kind: 'skill'`** — invoke the named consumer skill for procedural
   (multi-step or non-URL) sign-in. Read the skill's `SKILL.md` and follow it.
+
+### Which seam kinds consult per-persona material
+
+Per-persona auth material (`credentialRef` / `signInSkill`, authored via the
+object-map `personas` shape) is consulted **only** under a `skill` or
+credential seam, where the sign-in procedure needs a stored credential
+reference or a per-persona sign-in skill. Under a `urlTemplate`
+dev-impersonation seam the persona name is the only input, so the material is
+never read — author name-only personas there rather than fabricating
+`credentialRef`/`signInSkill` values the harness ignores. The resolver
+normalizes both authored shapes to one canonical object map keyed by persona
+name; a name-only persona resolves to an empty record (no auth material).
 
 After sign-in, confirm the authenticated state with a `take_snapshot`
 (e.g. the user menu or persona badge is present) before driving any scenario.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1223,7 +1223,7 @@ in [`.agents/full-agentrc.json`](../.agents/full-agentrc.json). Fields:
 | `featureRoot`      | yes      | Filesystem root the selector resolves `.feature` files against.                                                                                               |
 | `fixturesManifest` | yes      | Path to the persona → seed-data manifest loaded before sign-in.                                                                                               |
 | `signInSeam`       | yes      | Discriminated union: `{ urlTemplate }` (substitute `{persona}` into a dev sign-in URL) **or** `{ skill }` (invoke a named consumer skill for procedural sign-in). |
-| `personas`         | yes      | Map of persona name → `{ credentialRef }` (stored-credential reference) or `{ signInSkill }` (per-persona sign-in skill). Never an inline secret.             |
+| `personas`         | yes      | Either a name-only `string[]` (the honest shape under a `{ urlTemplate }` seam, where the persona name is the sole input) **or** a map of persona name → `{ credentialRef }` / `{ signInSkill }` (per-persona auth material, consulted only under a `{ skill }` or credential seam). Never an inline secret. The resolver normalizes both to one canonical map keyed by persona name. |
 | `consoleAllowlist` | no       | Benign-console substring patterns to suppress (default `[]`). A noise filter, **not** a security control — never expand it to silence a genuine error.        |
 | `designTokens`     | no       | Pointer to the token/style source for visual spot-checks (default `null`). When `null`, the design-token check is skipped entirely.                            |
 

--- a/tests/config-schema-mirror-drift.test.js
+++ b/tests/config-schema-mirror-drift.test.js
@@ -502,6 +502,77 @@ describe('agentrc.schema.json mirror — drift vs runtime AJV schema', () => {
       'unknown key in qa block',
     );
   });
+
+  it('accepts a name-only personas array on both sides (Story #3306)', () => {
+    assertAgree(
+      {
+        ...REQ,
+        qa: {
+          featureRoot: 'tests/features',
+          fixturesManifest: 'tests/fixtures/manifest.json',
+          signInSeam: { urlTemplate: '/dev/sign-in-as/{persona}' },
+          personas: ['athlete', 'coach', 'org-admin'],
+        },
+      },
+      'qa block with name-only personas array',
+    );
+  });
+
+  it('accepts the object-map personas form on both sides (Story #3306)', () => {
+    assertAgree(
+      {
+        ...REQ,
+        qa: {
+          signInSeam: { skill: 'stack/qa/sign-in' },
+          personas: {
+            admin: { credentialRef: 'env:ADMIN_CREDS' },
+            member: { signInSkill: 'stack/qa/sign-in-member' },
+          },
+        },
+      },
+      'qa block with object-map personas',
+    );
+  });
+
+  it('rejects an empty personas array on both sides (Story #3306)', () => {
+    assertAgree(
+      {
+        ...REQ,
+        qa: { personas: [] },
+      },
+      'empty personas array (minItems)',
+    );
+  });
+
+  it('rejects an empty personas object-map on both sides (Story #3306)', () => {
+    assertAgree(
+      {
+        ...REQ,
+        qa: { personas: { admin: {} } },
+      },
+      'object-map persona without auth material',
+    );
+  });
+
+  it('rejects a blank persona name in the array on both sides (Story #3306)', () => {
+    assertAgree(
+      {
+        ...REQ,
+        qa: { personas: [''] },
+      },
+      'blank persona name (minLength)',
+    );
+  });
+
+  it('rejects shell-injection in a name-only persona on both sides (Story #3306)', () => {
+    assertAgree(
+      {
+        ...REQ,
+        qa: { personas: ['admin; rm -rf /'] },
+      },
+      'shell injection in name-only persona',
+    );
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/tests/qa-contract-validation.test.js
+++ b/tests/qa-contract-validation.test.js
@@ -26,6 +26,7 @@ describe('resolveQaContract — present (well-formed)', () => {
     assert.deepEqual(out.personas, {
       admin: { credentialRef: 'QA_ADMIN_CREDS' },
     });
+    assert.deepEqual(out.personaNames, ['admin']);
   });
 
   it('accepts a bare qa bag (not wrapped in config)', () => {
@@ -66,6 +67,93 @@ describe('resolveQaContract — present (well-formed)', () => {
       qa: { ...WELL_FORMED, signInSeam: { skill: 'consumer-sign-in' } },
     });
     assert.deepEqual(out.signInSeam, { skill: 'consumer-sign-in' });
+  });
+});
+
+describe('resolveQaContract — personas normalization (Story #3306)', () => {
+  /** Base block carrying a url-template dev-impersonation seam. */
+  const URL_SEAM_BASE = Object.freeze({
+    featureRoot: 'tests/features',
+    fixturesManifest: 'tests/fixtures/personas.json',
+    signInSeam: { urlTemplate: '/dev/sign-in-as/{persona}' },
+  });
+
+  it('accepts a name-only string[] under a urlTemplate seam', () => {
+    const out = resolveQaContract({
+      qa: { ...URL_SEAM_BASE, personas: ['athlete', 'coach', 'org-admin'] },
+    });
+    // Acceptance: resolves cleanly with no fabricated credentialRef/signInSkill.
+    assert.deepEqual(out.personas, {
+      athlete: {},
+      coach: {},
+      'org-admin': {},
+    });
+    assert.deepEqual(out.personaNames, ['athlete', 'coach', 'org-admin']);
+  });
+
+  it('normalizes the name-only array to an empty-record canonical map', () => {
+    const out = resolveQaContract({
+      qa: { ...URL_SEAM_BASE, personas: ['athlete'] },
+    });
+    assert.deepEqual(out.personas.athlete, {});
+  });
+
+  it('keeps the object-map form for credential/skill seams', () => {
+    const out = resolveQaContract({
+      qa: {
+        ...URL_SEAM_BASE,
+        signInSeam: { skill: 'stack/qa/sign-in' },
+        personas: {
+          admin: { credentialRef: 'QA_ADMIN_CREDENTIAL' },
+          member: { signInSkill: 'stack/qa/sign-in-member' },
+        },
+      },
+    });
+    assert.deepEqual(out.personas, {
+      admin: { credentialRef: 'QA_ADMIN_CREDENTIAL' },
+      member: { signInSkill: 'stack/qa/sign-in-member' },
+    });
+    assert.deepEqual(out.personaNames, ['admin', 'member']);
+  });
+
+  it('does not mutate an object-map personas input', () => {
+    const input = {
+      qa: {
+        ...URL_SEAM_BASE,
+        personas: { admin: { credentialRef: 'QA_ADMIN_CREDENTIAL' } },
+      },
+    };
+    const out = resolveQaContract(input);
+    out.personas.admin.credentialRef = 'mutated';
+    assert.equal(input.qa.personas.admin.credentialRef, 'QA_ADMIN_CREDENTIAL');
+  });
+
+  it('does not mutate a name-only personas input', () => {
+    const personas = ['athlete', 'coach'];
+    const input = { qa: { ...URL_SEAM_BASE, personas } };
+    resolveQaContract(input);
+    assert.deepEqual(personas, ['athlete', 'coach']);
+  });
+
+  it('rejects an empty name-only array (personas is required)', () => {
+    assert.throws(
+      () => resolveQaContract({ qa: { ...URL_SEAM_BASE, personas: [] } }),
+      /qa\.personas/,
+    );
+  });
+
+  it('rejects an empty object-map (personas is required)', () => {
+    assert.throws(
+      () => resolveQaContract({ qa: { ...URL_SEAM_BASE, personas: {} } }),
+      /qa\.personas/,
+    );
+  });
+
+  it('rejects a name-only array with a blank persona name', () => {
+    assert.throws(
+      () => resolveQaContract({ qa: { ...URL_SEAM_BASE, personas: [''] } }),
+      /qa\.personas/,
+    );
   });
 });
 


### PR DESCRIPTION
Closes #3306

_Auto-opened by `/single-story-deliver`._