### PR TITLE
config-resolver drops the top-level qa block — /run-qa-harness Step 0 throws 'not bound' despite a valid qa contract (#3312)

### DIFF
--- a/.agents/scripts/lib/config-resolver.js
+++ b/.agents/scripts/lib/config-resolver.js
@@ -169,6 +169,12 @@ function applyDefaults(raw) {
     github: applyGithubDefaults(raw.github),
     planning: raw.planning ?? {},
     delivery: applyDeliveryDefaults(raw.delivery),
+    // `qa` is an optional top-level block (agentrc.schema.json
+    // `#/$defs/qa`). It needs no default-layering — the harness resolver
+    // (`resolveQaContract`) owns normalization and required-field
+    // enforcement — it only needs to survive the reshape so
+    // `/run-qa-harness` Step 0 can read it off the resolved wrapper.
+    ...(raw.qa !== undefined ? { qa: raw.qa } : {}),
   };
 }
 
@@ -178,6 +184,7 @@ function applyDefaults(raw) {
  * Returned shape:
  *   {
  *     project, github, planning, delivery,  // post-reshape canonical blocks
+ *     qa,                                    // optional QA-harness block (present iff authored)
  *     raw, source,
  *   }
  *

--- a/tests/lib/config-resolver.test.js
+++ b/tests/lib/config-resolver.test.js
@@ -20,6 +20,7 @@ import {
   resolveMaintainabilityCrap,
   resolveQuality,
 } from '../../.agents/scripts/lib/config-resolver.js';
+import { resolveQaContract } from '../../.agents/scripts/lib/qa/resolve-qa-contract.js';
 import { setupFsMock } from './fs-mock.js';
 
 /**
@@ -104,6 +105,68 @@ describe('config-resolver — loading + legacy shim', () => {
     const first = resolveConfig({ bustCache: true });
     const second = resolveConfig({});
     assert.equal(first, second);
+  });
+});
+
+/**
+ * Story #3312 — `resolveConfig` must carry the optional top-level `qa`
+ * block through `applyDefaults` so `/run-qa-harness` Step 0 can read it
+ * off the resolved wrapper. Before the fix, `applyDefaults` returned a
+ * fixed `{ project, github, planning, delivery }` reshape that silently
+ * discarded `raw.qa`, so the harness resolver fell back to treating the
+ * whole wrapper as the bare block and threw "not bound".
+ */
+describe('config-resolver — qa block round-trip (Story #3312)', () => {
+  let vol;
+
+  // A complete, schema-valid `qa` contract for a bound consumer: the four
+  // harness-required fields plus a url-template sign-in seam and a
+  // name-only persona list.
+  const BOUND_QA = Object.freeze({
+    featureRoot: 'tests/features',
+    fixturesManifest: 'tests/fixtures/manifest.json',
+    signInSeam: { urlTemplate: 'https://app.example.test/impersonate/{persona}' },
+    personas: ['coach', 'admin'],
+  });
+
+  beforeEach((t) => {
+    vol = new Volume();
+    setupFsMock(t, vol);
+    resolveConfig({ bustCache: true });
+  });
+
+  function writeAgentrc(extra) {
+    const agentrcPath = path.join(PROJECT_ROOT, '.agentrc.json');
+    vol.mkdirSync(PROJECT_ROOT, { recursive: true });
+    vol.writeFileSync(
+      agentrcPath,
+      JSON.stringify({ project: { ...REQ.project }, ...extra }),
+    );
+  }
+
+  it('round-trips a top-level qa block onto the resolved wrapper', () => {
+    writeAgentrc({ qa: BOUND_QA });
+    const config = resolveConfig({ bustCache: true });
+    assert.deepEqual(config.qa, BOUND_QA);
+  });
+
+  it('omits qa from the wrapper when no qa block is authored', () => {
+    writeAgentrc({});
+    const config = resolveConfig({ bustCache: true });
+    assert.ok(
+      !Object.hasOwn(config, 'qa'),
+      'qa key should be absent when .agentrc.json omits the block',
+    );
+  });
+
+  it('resolveQaContract(resolveConfig()) resolves cleanly for a bound consumer', () => {
+    writeAgentrc({ qa: BOUND_QA });
+    const config = resolveConfig({ bustCache: true });
+    const contract = resolveQaContract(config);
+    assert.equal(contract.featureRoot, BOUND_QA.featureRoot);
+    assert.equal(contract.fixturesManifest, BOUND_QA.fixturesManifest);
+    assert.deepEqual(contract.signInSeam, BOUND_QA.signInSeam);
+    assert.deepEqual(contract.personaNames, ['coach', 'admin']);
   });
 });
 

--- a/tests/lib/config-resolver.test.js
+++ b/tests/lib/config-resolver.test.js
@@ -125,7 +125,9 @@ describe('config-resolver — qa block round-trip (Story #3312)', () => {
   const BOUND_QA = Object.freeze({
     featureRoot: 'tests/features',
     fixturesManifest: 'tests/fixtures/manifest.json',
-    signInSeam: { urlTemplate: 'https://app.example.test/impersonate/{persona}' },
+    signInSeam: {
+      urlTemplate: 'https://app.example.test/impersonate/{persona}',
+    },
     personas: ['coach', 'admin'],
   });
 


### PR DESCRIPTION
Closes #3312

_Auto-opened by `/single-story-deliver`._