### PR TITLE
fix(story-close-recovery): detect already-merged via epic merge-commit when story refs are gone

### DIFF
--- a/.agents/scripts/lib/orchestration/story-close-recovery.js
+++ b/.agents/scripts/lib/orchestration/story-close-recovery.js
@@ -16,7 +16,12 @@
  *                              diff is fully present on `origin/epic/<id>` as
  *                              rebased commits with different SHAs (manual
  *                              recovery path, detected via `git cherry`
- *                              patch-id comparison; Story #3161).
+ *                              patch-id comparison; Story #3161), OR — when
+ *                              both Story refs have already been reaped — the
+ *                              Epic history carries an integration commit
+ *                              referencing the Story (`(resolves #<id>)` /
+ *                              `(refs #<id>)`), found via `git log --grep`
+ *                              (ref-independent path; Story #3327 / Epic #3316).
  *   - `pushed-unmerged`      — the story branch is on origin and not yet merged.
  *   - `fresh`                — no prior close activity detected.
  */
@@ -53,11 +58,44 @@ const DEFAULT_GIT_ADAPTER = {
   cherry(cwd, upstream, head) {
     return gitSpawn(cwd, 'cherry', upstream, head);
   },
+  logGrep(cwd, ref, pattern) {
+    return gitSpawn(cwd, 'log', '-E', `--grep=${pattern}`, '--format=%H', ref);
+  },
 };
 
 const DEFAULT_FS_ADAPTER = {
   existsSync: fs.existsSync,
 };
+
+/**
+ * Scan the Epic branch history for an integration/merge commit whose subject
+ * references this Story via `(resolves #<id>)` or `(refs #<id>)`.
+ *
+ * This is the **ref-independent** already-merged signal: it survives the case
+ * where BOTH the local `story-<id>` branch and the remote `origin/story-<id>`
+ * ref have already been deleted by a prior partial close run, leaving no Story
+ * ref to anchor the ancestor / cherry probes (branches a–c). Because the search
+ * is scoped to the Epic ref's reachable history (`git log <epicRef> --grep`),
+ * any match is by definition already an ancestor of the Epic tip — no separate
+ * ancestor check is required.
+ *
+ * The closing paren in the pattern disambiguates `#<id>` from a longer id that
+ * shares the same prefix (e.g. `#3327` must not match `(resolves #33270)`).
+ *
+ * @returns {{ sha: string, epicRef: string } | null}
+ */
+function findMergeCommitForStory({ cwd, storyId, epicId, git }) {
+  if (!git.logGrep) return null;
+  const pattern = `\\((resolves|refs) #${storyId}\\)`;
+  const epicRefs = [`origin/epic/${epicId}`, `epic/${epicId}`];
+  for (const epicRef of epicRefs) {
+    const res = git.logGrep(cwd, epicRef, pattern);
+    if (!res || res.status !== 0) continue;
+    const sha = (res.stdout ?? '').toString().trim().split('\n')[0]?.trim();
+    if (sha) return { sha, epicRef };
+  }
+  return null;
+}
 
 function storyWorktreePath(cwd, storyId, worktreeRoot) {
   return resolveWorkingPath({
@@ -221,6 +259,27 @@ export function detectPriorPhase({
           };
           break;
         }
+      }
+    }
+
+    // d) Merge-commit-message scan (ref-independent; Story #3327 / Epic #3316).
+    //    Both the local `story-<id>` branch and the remote `origin/story-<id>`
+    //    ref were deleted by a prior partial close run, so branches a–c have no
+    //    ref to anchor on and fall through. Recover the already-merged signal
+    //    from the Epic history itself: locate the integration commit whose
+    //    subject carries `(resolves #<id>)` / `(refs #<id>)`. Without this
+    //    branch, detection falls to FRESH and the resumed close re-enters the
+    //    pre-merge gate chain, which crashes in `format-autofix-scoped.js` on
+    //    `git diff <epicBranch>...story-<id>` because the Story ref is gone.
+    if (!merged) {
+      const mc = findMergeCommitForStory({ cwd, storyId, epicId, git });
+      if (mc) {
+        merged = true;
+        resolvedDetail = {
+          via: 'merge-commit-message',
+          mergeCommit: mc.sha,
+          remoteEpicRef: mc.epicRef,
+        };
       }
     }
 

--- a/baselines/maintainability.json
+++ b/baselines/maintainability.json
@@ -1,7 +1,7 @@
 {
   "$schema": ".agents/schemas/baselines/maintainability.schema.json",
   "kernelVersion": "0.1.0",
-  "generatedAt": "2026-05-29T12:40:09.009Z",
+  "generatedAt": "2026-05-29T13:00:59.422Z",
   "rollup": {
     "*": {
       "min": 61.218,
@@ -1424,7 +1424,7 @@
     },
     {
       "path": ".agents/scripts/lib/orchestration/story-close-recovery.js",
-      "mi": 85.284
+      "mi": 84.213
     },
     {
       "path": ".agents/scripts/lib/orchestration/story-close/auto-refresh-runner.js",
@@ -4828,7 +4828,7 @@
     },
     {
       "path": "tests/story-close-recovery.test.js",
-      "mi": 99.198
+      "mi": 97.837
     },
     {
       "path": "tests/story-close-review.test.js",

--- a/tests/story-close-recovery.test.js
+++ b/tests/story-close-recovery.test.js
@@ -26,6 +26,10 @@ function makeGit({
   // cherry: per-(upstream, head) override. Each value is a `{ status, stdout }`
   // bag, the same shape gitSpawn returns. Default exit 1 (no equivalents).
   cherryByPair = null,
+  // logGrep: per-ref override keyed by the epic ref searched. Each value is a
+  // `{ status, stdout }` bag. Default exit 0 + empty stdout (no match), which
+  // keeps detection falling through to later signals.
+  logGrepByRef = null,
 } = {}) {
   return {
     status(cwd) {
@@ -61,6 +65,10 @@ function makeGit({
         if (key in cherryByPair) return cherryByPair[key];
       }
       return { status: 1, stdout: '' };
+    },
+    logGrep(_cwd, ref, _pattern) {
+      if (logGrepByRef && ref in logGrepByRef) return logGrepByRef[ref];
+      return { status: 0, stdout: '' };
     },
   };
 }
@@ -294,6 +302,63 @@ test('detectPriorPhase', async (t) => {
         fs: makeFs([]),
       });
       assert.strictEqual(result.phase, RECOVERY_STATES.PUSHED_UNMERGED);
+    },
+  );
+
+  await t.test(
+    'returns already-merged via merge-commit-message when both story refs are reaped but the epic carries the integration commit (Story #3327 / Epic #3316)',
+    () => {
+      // Real-world partial-reap recovery: the prior close merged the Story
+      // onto `epic/<id>` and pushed, then deleted BOTH the local `story-<id>`
+      // branch and the remote `origin/story-<id>` ref before dying at
+      // `agent::closing`. With no Story ref left, branches a–c have nothing to
+      // anchor on. The ref-independent scan recovers the signal from the Epic
+      // history's `(resolves #<id>)` integration commit.
+      const result = detectPriorPhase({
+        cwd: CWD,
+        storyId: 100,
+        epicId: 42,
+        git: makeGit({
+          lsRemote: '', // remote story branch reaped
+          localStoryExists: false, // local story branch reaped
+          ancestorExit: 1,
+          logGrepByRef: {
+            'origin/epic/42': { status: 0, stdout: '80aeee34deadbeef\n' },
+          },
+        }),
+        fs: makeFs([]),
+      });
+      assert.strictEqual(result.phase, RECOVERY_STATES.ALREADY_MERGED);
+      assert.strictEqual(result.detail.via, 'merge-commit-message');
+      assert.strictEqual(result.detail.mergeCommit, '80aeee34deadbeef');
+      assert.strictEqual(result.detail.remoteEpicRef, 'origin/epic/42');
+    },
+  );
+
+  await t.test(
+    'merge-commit-message scan falls back to local epic/<id> when origin/epic/<id> yields no match',
+    () => {
+      const result = detectPriorPhase({
+        cwd: CWD,
+        storyId: 100,
+        epicId: 42,
+        git: makeGit({
+          lsRemote: '',
+          localStoryExists: false,
+          ancestorExit: 1,
+          logGrepByRef: {
+            // origin epic ref unreachable / no match...
+            'origin/epic/42': { status: 1, stdout: '' },
+            // ...but the local epic branch carries the integration commit.
+            'epic/42': { status: 0, stdout: 'cafebabe1234\n' },
+          },
+        }),
+        fs: makeFs([]),
+      });
+      assert.strictEqual(result.phase, RECOVERY_STATES.ALREADY_MERGED);
+      assert.strictEqual(result.detail.via, 'merge-commit-message');
+      assert.strictEqual(result.detail.mergeCommit, 'cafebabe1234');
+      assert.strictEqual(result.detail.remoteEpicRef, 'epic/42');
     },
   );
 


### PR DESCRIPTION
## Why

`detectPriorPhase()` in `story-close-recovery.js` could not detect the `already-merged` state when **both** the local `story-<id>` branch and the remote `origin/story-<id>` ref had already been deleted by a prior partial close run. All three existing `already-merged` probes (local-ancestor, remote-ancestor, rebased-equivalents cherry) require a `story-<id>` ref as the comparison anchor. With no ref left, detection fell through to `FRESH`, and re-running `story-close.js --story <id>` re-entered the pre-merge gate chain, which crashes in `format-autofix-scoped.js` on `git diff <epicBranch>...story-<id>` (the story ref is gone → exit 1, fatal).

Real-world repro: Story #3327 / Epic #3316 — the prior run merged the story onto `epic/3316`, deleted both story refs, then died of a transient API error at `agent::closing`; resume crashed until the local `story-3327` branch was manually recreated.

## What

Adds a **ref-independent** `already-merged` signal as detection branch (d): scan the Epic history via `git log -E --grep='\((resolves|refs) #<id>\)'` for the integration commit referencing the Story. Because the search is scoped to the Epic ref's reachable history, any match is by definition an ancestor of the Epic tip — no separate ancestor check needed. Classifies `ALREADY_MERGED` with `{ via: 'merge-commit-message', mergeCommit: <sha>, remoteEpicRef: <ref> }`, which already routes to `RESUME_FROM_POST_MERGE`. Tries `origin/epic/<id>` then local `epic/<id>`. The closing paren in the pattern disambiguates `#3327` from `(resolves #33270)`.

## Tests

Adds a `logGrepByRef` seam to the git mock plus two cases: the no-refs-but-merge-commit-present case (Story #3327 / Epic #3316) and the local-`epic/<id>` fallback. Full suite for the file: 32 pass / 0 fail. Lint clean; `check-baselines.js` exit 0.

## Notes

- A Story #3352 ("refactor detectPriorPhase into a provider") may touch this same file. This change is purely additive (one new detection branch + one adapter method), so it slots in as one more branch rather than conflicting structurally.
- Landed via an isolated git worktree to avoid racing the concurrent `/epic-deliver` that is actively integrating into `epic/3316`.

(refs #3316)

🤖 Generated with [Claude Code](https://claude.com/claude-code)