### PR TITLE
epic-deliver resume: re-running epic-deliver-prepare on a partially-complete Epic desyncs currentWave from the recomputed wave plan (#3358)

### DIFF
--- a/.agents/scripts/epic-deliver-prepare.js
+++ b/.agents/scripts/epic-deliver-prepare.js
@@ -31,6 +31,7 @@ import { getRunners, resolveConfig } from './lib/config-resolver.js';
 import { Logger } from './lib/Logger.js';
 import {
   initialize as initializeEpicRunState,
+  reconcileResumePointer,
   write as writeEpicRunState,
 } from './lib/orchestration/epic-run-state-store.js';
 import {
@@ -180,10 +181,32 @@ export async function runEpicDeliverPrepare({
   // resolve the next wave's stories. Without this write the tick reports
   // every wave as `wave-complete: empty` and the delivery stalls.
   const tickPlan = plan.map((wave) => wave.stories);
+
+  // Story #3358 — reconcile the resume pointer against the recomputed
+  // plan. On a resumed Epic, `build-wave-dag.js` drops the already-merged
+  // (closed) Stories, so the recomputed plan is shorter and re-indexed
+  // from 0. The preserved `currentWave`/`waves[]` reference the *old*
+  // index space; left untouched, `wave-tick.js` would index
+  // `plan[currentWave]` into the new plan and dispatch the wrong wave.
+  // Prepare owns the `plan` field, so it owns the pointer that indexes
+  // into it. When the plan changed, reset the pointer to 0 and drop the
+  // stale history; when it is byte-identical (idempotent re-prepare),
+  // preserve in-flight progress verbatim.
+  const { currentWave, waves } = reconcileResumePointer(
+    checkpointState,
+    checkpointState.plan,
+    tickPlan,
+  );
+
   // Persist the `--ignore-concurrency-hazards` flag on the checkpoint
   // so retro tooling can flag a run that shipped despite an outstanding
   // hazard (the warning above is one-shot; the checkpoint is durable).
-  const checkpointPayload = { ...checkpointState, plan: tickPlan };
+  const checkpointPayload = {
+    ...checkpointState,
+    plan: tickPlan,
+    currentWave,
+    waves,
+  };
   if (gate.bypassed) {
     checkpointPayload.ignoreConcurrencyHazards = true;
   }

--- a/.agents/scripts/lib/orchestration/epic-run-state-store.js
+++ b/.agents/scripts/lib/orchestration/epic-run-state-store.js
@@ -130,6 +130,110 @@ export async function initialize({
 }
 
 /**
+ * Reconcile the resume pointer (`currentWave` + `waves[]` history) against
+ * a freshly-recomputed wave plan.
+ *
+ * Story #3358 — when `/epic-deliver` is resumed on a partially-complete
+ * Epic, `epic-deliver-prepare.js` recomputes the wave DAG over only the
+ * **not-done** Stories (`build-wave-dag.js#discoverOpenStories` drops the
+ * closed/merged Stories). The recomputed plan is therefore *shorter* and
+ * **re-indexed from 0** — `plan[0]` is the next ready wave. The preserved
+ * checkpoint, however, still carries the prior `currentWave` (e.g. `2`)
+ * and a `waves[]` history keyed to the *old* index space. `wave-tick.js`
+ * then indexes `plan[currentWave]` into the new plan and dispatches the
+ * wrong wave — silently skipping the Stories that are actually ready.
+ *
+ * Prepare already owns the `plan` field (it overwrites it on every run),
+ * so it must equally own the pointer that indexes into that plan. This
+ * helper is the single point of reconciliation:
+ *
+ *   - When the recomputed `nextPlan` is **structurally identical** to the
+ *     persisted `priorPlan` (an idempotent re-prepare with no Story
+ *     completed since the last run), the pointer is preserved verbatim so
+ *     in-flight wave progress is not lost.
+ *   - When the recomputed `nextPlan` **differs** (a Story merged → the
+ *     plan got shorter / re-indexed), the pointer is reset: `currentWave`
+ *     to `0` (the new plan's index space starts at the first not-done
+ *     wave) and `waves[]` to `[]` (the prior history references the old
+ *     index space and would mis-key `readGateFailures`).
+ *
+ * Plan equality is compared on the Story-id matrix only — `title` /
+ * `worktree` churn on an otherwise-identical plan must not trip a reset.
+ *
+ * Pure function — no I/O, no provider, no side effects.
+ *
+ * @param {{
+ *   currentWave?: number,
+ *   waves?: Array<unknown>,
+ * }} checkpoint The persisted checkpoint fields to reconcile.
+ * @param {Array<Array<{ id?: number, storyId?: number, number?: number }>>} priorPlan
+ *   The plan currently persisted on the checkpoint (may be undefined on a
+ *   first run).
+ * @param {Array<Array<{ id?: number, storyId?: number, number?: number }>>} nextPlan
+ *   The freshly-recomputed plan prepare is about to persist.
+ * @returns {{ currentWave: number, waves: Array<unknown> }} The reconciled
+ *   pointer fields. Always returns concrete values so the caller can spread
+ *   them onto the checkpoint payload unconditionally.
+ */
+export function reconcileResumePointer(checkpoint, priorPlan, nextPlan) {
+  const safeWaves = Array.isArray(checkpoint?.waves) ? checkpoint.waves : [];
+  const currentWave = Number.isInteger(checkpoint?.currentWave)
+    ? checkpoint.currentWave
+    : 0;
+  if (planStoryMatrixEqual(priorPlan, nextPlan)) {
+    return { currentWave, waves: safeWaves };
+  }
+  // Plan was recomputed (resume after a completed wave): the new plan is
+  // 0-indexed over the remaining not-done waves. Reset the pointer and
+  // drop the stale history so `wave-tick.js` reads `plan[0]`.
+  return { currentWave: 0, waves: [] };
+}
+
+/**
+ * Compare two wave plans on their Story-id matrix only. Each plan is
+ * `Array<Array<{ id|storyId|number }>>`; equality requires the same wave
+ * count, the same per-wave Story count, and the same Story ids in the same
+ * positions. `title` / `worktree` fields are ignored so cosmetic churn on
+ * an otherwise-identical plan does not register as a change.
+ *
+ * Pure helper for {@link reconcileResumePointer}.
+ *
+ * @param {Array<Array<object>>|undefined} a
+ * @param {Array<Array<object>>|undefined} b
+ * @returns {boolean}
+ */
+function planStoryMatrixEqual(a, b) {
+  const left = Array.isArray(a) ? a : [];
+  const right = Array.isArray(b) ? b : [];
+  if (left.length !== right.length) return false;
+  for (let i = 0; i < left.length; i += 1) {
+    const wl = Array.isArray(left[i]) ? left[i] : [];
+    const wr = Array.isArray(right[i]) ? right[i] : [];
+    if (wl.length !== wr.length) return false;
+    for (let j = 0; j < wl.length; j += 1) {
+      if (storyIdOf(wl[j]) !== storyIdOf(wr[j])) return false;
+    }
+  }
+  return true;
+}
+
+/**
+ * Extract the Story id from a plan entry. Mirrors the resolution order
+ * `wave-runner/tick.js#storyIdOf` uses so the equality check keys on the
+ * same identity the tick dispatches against. Returns `null` for shapeless
+ * entries so two `null`s never compare equal by accident.
+ *
+ * @param {object|number|null|undefined} entry
+ * @returns {number|null}
+ */
+function storyIdOf(entry) {
+  if (typeof entry === 'number') return entry;
+  if (!entry || typeof entry !== 'object') return null;
+  const id = entry.id ?? entry.storyId ?? entry.number;
+  return Number.isInteger(id) ? id : null;
+}
+
+/**
  * Append a manual-intervention record to the checkpoint. Out-of-band
  * recovery steps the host LLM performs during a delivery — `AskUserQuestion`
  * calls, `git restore`/`git reset` against the working tree, manual `--no-ff`

--- a/tests/epic-execute/epic-deliver-prepare.test.js
+++ b/tests/epic-execute/epic-deliver-prepare.test.js
@@ -2,7 +2,9 @@ import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 
 import { runEpicDeliverPrepare } from '../../.agents/scripts/epic-deliver-prepare.js';
+import { EPIC_RUN_STATE_TYPE as STORE_TYPE } from '../../.agents/scripts/lib/orchestration/epic-run-state-store.js';
 import { structuredCommentMarker } from '../../.agents/scripts/lib/orchestration/ticketing.js';
+import { tick } from '../../.agents/scripts/lib/wave-runner/tick.js';
 import {
   CHECKPOINT_SCHEMA_VERSION,
   EPIC_RUN_STATE_TYPE,
@@ -42,6 +44,29 @@ function createFakeProvider({ epic, descendants }) {
       }
     },
   };
+}
+
+/** Seed a prior `epic-run-state` checkpoint comment onto the Epic. */
+function seedCheckpoint(provider, epicId, state) {
+  const fenced = JSON.stringify(
+    { version: CHECKPOINT_SCHEMA_VERSION, ...state },
+    null,
+    2,
+  );
+  const body = `${structuredCommentMarker(STORE_TYPE)}\n\`\`\`json\n${fenced}\n\`\`\``;
+  const list = provider._comments.get(epicId) ?? [];
+  list.push({ id: 9000, body });
+  provider._comments.set(epicId, list);
+}
+
+/** Parse the `epic-run-state` checkpoint currently persisted on the Epic. */
+function readPersistedCheckpoint(provider, epicId) {
+  const comments = provider._comments.get(epicId) ?? [];
+  const checkpoint = comments.find((c) =>
+    c.body.includes(structuredCommentMarker(STORE_TYPE)),
+  );
+  const fenced = checkpoint.body.match(/```json\n([\s\S]+?)\n```/);
+  return JSON.parse(fenced[1]);
 }
 
 const baseConfig = {
@@ -336,6 +361,139 @@ describe('runEpicDeliverPrepare', () => {
         ],
       }),
       /Refusing to flip Epic/,
+    );
+  });
+
+  // ---------------------------------------------------------------------
+  // Resume pointer reconciliation (Story #3358)
+  // ---------------------------------------------------------------------
+
+  it('resets currentWave to 0 and re-dispatches wave 0 when resume recomputes a shorter plan', async () => {
+    // Original 3-wave Epic: 201 → 202 → 203. Waves 0 and 1 completed
+    // (201, 202 merged → closed), leaving only 203 open. The recomputed
+    // DAG therefore has a single wave whose plan[0] = [203].
+    const epic = { id: 120, labels: ['type::epic', 'acceptance::n-a'] };
+    const descendants = [
+      {
+        id: 203,
+        number: 203,
+        title: 'Third story',
+        labels: ['type::story'],
+        body: '',
+        state: 'open',
+      },
+    ];
+    const provider = createFakeProvider({ epic, descendants });
+
+    // Prior checkpoint from the parked run: 3-wave plan, currentWave=2.
+    seedCheckpoint(provider, 120, {
+      epicId: 120,
+      startedAt: '2026-05-01T00:00:00.000Z',
+      currentWave: 2,
+      totalWaves: 3,
+      concurrencyCap: 3,
+      phase: 'prepare',
+      waves: [
+        { index: 0, stories: [{ storyId: 201, status: 'done' }] },
+        { index: 1, stories: [{ storyId: 202, status: 'done' }] },
+      ],
+      blockerHistory: [],
+      manualInterventions: [],
+      plan: [[{ storyId: 201 }], [{ storyId: 202 }], [{ storyId: 203 }]],
+    });
+
+    const out = await runEpicDeliverPrepare({
+      epicId: 120,
+      injectedProvider: provider,
+      injectedConfig: baseConfig,
+    });
+
+    // Recomputed plan is a single wave over the only open Story.
+    assert.equal(out.totalWaves, 1, 'recomputed DAG has one not-done wave');
+    assert.deepEqual(
+      out.plan[0].stories.map((s) => s.storyId),
+      [203],
+    );
+
+    // The persisted checkpoint must have its pointer reset into the new
+    // index space — currentWave 2 (the old index) would index past the
+    // 1-wave plan and dispatch nothing.
+    const persisted = readPersistedCheckpoint(provider, 120);
+    assert.equal(persisted.currentWave, 0, 'pointer reset to new index 0');
+    assert.deepEqual(persisted.waves, [], 'stale wave history dropped');
+    assert.deepEqual(
+      persisted.plan.map((w) => w.map((s) => s.storyId ?? s.id)),
+      [[203]],
+    );
+
+    // wave-tick must now dispatch the genuinely-ready Story #203, not
+    // index plan[2] of the recomputed plan (which is undefined → empty).
+    const result = await tick({
+      epic: 120,
+      collaborators: { provider, signalEmit: async () => {} },
+      ctx: { config: baseConfig },
+    });
+    assert.equal(result.currentWave, 0);
+    assert.equal(result.nextAction.kind, 'dispatch');
+    assert.deepEqual(
+      result.nextAction.stories.map((s) => s.id),
+      [203],
+    );
+  });
+
+  it('preserves currentWave on an idempotent re-prepare with no completed waves', async () => {
+    // Same open Story set as the prior run → plan is unchanged. The
+    // in-flight pointer (currentWave=1) must survive a no-op re-prepare.
+    const epic = { id: 121, labels: ['type::epic', 'acceptance::n-a'] };
+    const descendants = [
+      {
+        id: 301,
+        number: 301,
+        title: 'A',
+        labels: ['type::story'],
+        body: '',
+        state: 'open',
+      },
+      {
+        id: 302,
+        number: 302,
+        title: 'B (depends on 301)',
+        labels: ['type::story'],
+        body: 'blocked by #301',
+        state: 'open',
+      },
+    ];
+    const provider = createFakeProvider({ epic, descendants });
+
+    seedCheckpoint(provider, 121, {
+      epicId: 121,
+      startedAt: '2026-05-01T00:00:00.000Z',
+      currentWave: 1,
+      totalWaves: 2,
+      concurrencyCap: 3,
+      phase: 'prepare',
+      waves: [{ index: 0, stories: [{ storyId: 301, status: 'done' }] }],
+      blockerHistory: [],
+      manualInterventions: [],
+      plan: [[{ storyId: 301 }], [{ storyId: 302 }]],
+    });
+
+    await runEpicDeliverPrepare({
+      epicId: 121,
+      injectedProvider: provider,
+      injectedConfig: baseConfig,
+    });
+
+    const persisted = readPersistedCheckpoint(provider, 121);
+    assert.equal(
+      persisted.currentWave,
+      1,
+      'in-flight pointer preserved on idempotent re-prepare',
+    );
+    assert.deepEqual(
+      persisted.waves,
+      [{ index: 0, stories: [{ storyId: 301, status: 'done' }] }],
+      'wave history preserved when the plan is unchanged',
     );
   });
 });

--- a/tests/lib/orchestration/epic-run-state-store.test.js
+++ b/tests/lib/orchestration/epic-run-state-store.test.js
@@ -402,7 +402,11 @@ describe('epic-run-state-store', () => {
       ];
       const next = [[{ id: 3 }], [{ id: 4 }], [{ id: 5 }], [{ id: 6 }]];
       const out = reconcileResumePointer(checkpoint, prior, next);
-      assert.equal(out.currentWave, 0, 'pointer reset into the new index space');
+      assert.equal(
+        out.currentWave,
+        0,
+        'pointer reset into the new index space',
+      );
       assert.deepEqual(out.waves, [], 'stale history dropped');
     });
 

--- a/tests/lib/orchestration/epic-run-state-store.test.js
+++ b/tests/lib/orchestration/epic-run-state-store.test.js
@@ -6,6 +6,7 @@ import {
   EPIC_RUN_STATE_TYPE,
   initialize,
   read,
+  reconcileResumePointer,
   setPhase,
   write,
 } from '../../../.agents/scripts/lib/orchestration/epic-run-state-store.js';
@@ -358,5 +359,86 @@ describe('epic-run-state-store', () => {
     const written = await write({ provider, epicId: 321, state: seed });
     const got = await read({ provider, epicId: 321 });
     assert.deepEqual(got, written);
+  });
+
+  // -------------------------------------------------------------------
+  // reconcileResumePointer (Story #3358)
+  // -------------------------------------------------------------------
+  describe('reconcileResumePointer', () => {
+    it('preserves currentWave + waves when the plan is unchanged', () => {
+      const checkpoint = {
+        currentWave: 2,
+        waves: [{ index: 0 }, { index: 1 }],
+      };
+      const plan = [[{ id: 10 }], [{ id: 20 }], [{ id: 30 }]];
+      const out = reconcileResumePointer(checkpoint, plan, plan);
+      assert.equal(out.currentWave, 2);
+      assert.deepEqual(out.waves, [{ index: 0 }, { index: 1 }]);
+    });
+
+    it('ignores title/worktree churn when comparing plans', () => {
+      const checkpoint = { currentWave: 1, waves: [{ index: 0 }] };
+      const prior = [[{ id: 10, title: 'old', worktree: 'a' }], [{ id: 20 }]];
+      const next = [[{ id: 10, title: 'new', worktree: 'b' }], [{ id: 20 }]];
+      const out = reconcileResumePointer(checkpoint, prior, next);
+      assert.equal(out.currentWave, 1, 'cosmetic churn must not trip a reset');
+      assert.deepEqual(out.waves, [{ index: 0 }]);
+    });
+
+    it('resets currentWave to 0 and clears waves when the plan shrank', () => {
+      const checkpoint = {
+        currentWave: 2,
+        waves: [{ index: 0 }, { index: 1 }],
+      };
+      // Prior plan had 6 waves; resume recomputed a 4-wave plan over the
+      // not-done Stories, re-indexed from 0.
+      const prior = [
+        [{ id: 1 }],
+        [{ id: 2 }],
+        [{ id: 3 }],
+        [{ id: 4 }],
+        [{ id: 5 }],
+        [{ id: 6 }],
+      ];
+      const next = [[{ id: 3 }], [{ id: 4 }], [{ id: 5 }], [{ id: 6 }]];
+      const out = reconcileResumePointer(checkpoint, prior, next);
+      assert.equal(out.currentWave, 0, 'pointer reset into the new index space');
+      assert.deepEqual(out.waves, [], 'stale history dropped');
+    });
+
+    it('resets when wave membership changes but length is identical', () => {
+      const checkpoint = { currentWave: 1, waves: [{ index: 0 }] };
+      const prior = [[{ id: 1 }], [{ id: 2 }]];
+      const next = [[{ id: 1 }], [{ id: 99 }]];
+      const out = reconcileResumePointer(checkpoint, prior, next);
+      assert.equal(out.currentWave, 0);
+      assert.deepEqual(out.waves, []);
+    });
+
+    it('treats an absent prior plan as a fresh-run no-reset baseline', () => {
+      const checkpoint = { currentWave: 0, waves: [] };
+      const next = [[{ id: 1 }]];
+      // undefined prior !== next → reset, but currentWave is already 0 and
+      // waves already empty, so the reconciled output is a clean fresh start.
+      const out = reconcileResumePointer(checkpoint, undefined, next);
+      assert.equal(out.currentWave, 0);
+      assert.deepEqual(out.waves, []);
+    });
+
+    it('coerces non-integer currentWave / non-array waves to safe defaults', () => {
+      const checkpoint = { currentWave: 'nope', waves: 'nope' };
+      const plan = [[{ id: 1 }]];
+      const out = reconcileResumePointer(checkpoint, plan, plan);
+      assert.equal(out.currentWave, 0);
+      assert.deepEqual(out.waves, []);
+    });
+
+    it('keys equality on storyId / number entry shapes too', () => {
+      const checkpoint = { currentWave: 1, waves: [{ index: 0 }] };
+      const prior = [[{ storyId: 5 }], [{ number: 6 }]];
+      const next = [[{ id: 5 }], [{ id: 6 }]];
+      const out = reconcileResumePointer(checkpoint, prior, next);
+      assert.equal(out.currentWave, 1, 'mixed id keys still compare equal');
+    });
   });
 });


### PR DESCRIPTION
Closes #3358

_Auto-opened by `/single-story-deliver`._