### PR TITLE
Per-epic isolation failures under concurrent /epic-deliver: audit selector and acceptance reconciler both leak across epics (#3362)

### DIFF
--- a/.agents/scripts/acceptance-spec-reconciler.js
+++ b/.agents/scripts/acceptance-spec-reconciler.js
@@ -3,8 +3,12 @@
  * acceptance-spec-reconciler.js — Story #2106 / Task #2113 (Epic #2001).
  *
  * Diffs the AC IDs declared in an Epic's linked `context::acceptance-spec`
- * body against the `@ac-*` / `@pending` tags emitted by scenarios under
- * `tests/features/**`. Surfaces three categories:
+ * body against the **per-Epic-namespaced** `@epic-<id>-ac-*` / `@pending`
+ * tags emitted by scenarios under `tests/features/**`. The namespace is
+ * load-bearing (Story #3362): `tests/features` is a single global tree
+ * shared by every Epic, so a bare `@ac-N` tag authored under an unrelated
+ * Epic's scenarios must not count as coverage for this Epic. Surfaces three
+ * categories:
  *
  *   - `satisfied[]` — AC IDs covered by at least one non-pending scenario.
  *   - `pending[]`   — AC IDs covered only by scenarios tagged `@pending`.
@@ -212,25 +216,46 @@ export function enumerateFeatureFiles(dir) {
 }
 
 /**
+ * Pure: derive the scenario tag token that satisfies an AC ID for a given
+ * Epic. When `epicId` is supplied the token is **namespaced per Epic** —
+ * `epic-<id>-ac-<n>` — so a bare `@ac-N` tag authored under an *unrelated*
+ * Epic's feature scenarios can never count as coverage for this Epic
+ * (Story #3362). When `epicId` is absent the legacy bare `ac-<n>` token is
+ * used so non-Epic callers keep their behaviour.
+ *
+ * @param {string} acId  e.g. `AC-7`
+ * @param {number|null} [epicId]
+ * @returns {string} lower-cased tag token (no `@` prefix)
+ */
+export function acTagToken(acId, epicId = null) {
+  const bare = acId.toLowerCase(); // e.g. "ac-7"
+  if (Number.isInteger(epicId) && epicId > 0) {
+    return `epic-${epicId}-${bare}`; // e.g. "epic-1241-ac-7"
+  }
+  return bare;
+}
+
+/**
  * Pure: classify each declared AC ID against the union of scenario tag
  * sets observed across every feature file.
  *
- * Coverage rule:
- *   - `ac-N` token present on at least one scenario with no `pending` tag
+ * Coverage rule (with `epicId`, the matched token is the per-Epic
+ * namespaced `epic-<id>-ac-<n>` — see {@link acTagToken}):
+ *   - matched token present on at least one scenario with no `pending` tag
  *     on the same scenario → satisfied.
- *   - `ac-N` token present only on scenarios that *also* carry `pending`
+ *   - matched token present only on scenarios that *also* carry `pending`
  *     → pending.
- *   - `ac-N` token absent from every scenario → missing.
+ *   - matched token absent from every scenario → missing.
  *
- * @param {{ acIds: string[], tagSets: Set<string>[] }} args
+ * @param {{ acIds: string[], tagSets: Set<string>[], epicId?: number|null }} args
  * @returns {{ satisfied: string[], pending: string[], missing: string[] }}
  */
-export function classifyCoverage({ acIds, tagSets }) {
+export function classifyCoverage({ acIds, tagSets, epicId = null }) {
   const satisfied = [];
   const pending = [];
   const missing = [];
   for (const acId of acIds) {
-    const tagToken = acId.toLowerCase(); // e.g. "ac-7"
+    const tagToken = acTagToken(acId, epicId);
     let sawSatisfied = false;
     let sawPending = false;
     for (const set of tagSets) {
@@ -269,14 +294,14 @@ export function renderBlockerMessage({
   ];
   if (missing.length > 0) {
     lines.push(
-      `  Missing (no @ac-* tag in tests/features): ${missing.join(', ')}`,
+      `  Missing (no @epic-${epicId}-ac-* tag in tests/features): ${missing.join(', ')}`,
     );
   }
   if (pending.length > 0) {
     lines.push(`  Pending (@pending-only coverage): ${pending.join(', ')}`);
   }
   lines.push(
-    'Author or de-pend the missing scenarios under tests/features/** so every AC ID is satisfied, then re-run /epic-deliver.',
+    `Author or de-pend scenarios under tests/features/** tagged @epic-${epicId}-ac-<n> so every AC ID is satisfied, then re-run /epic-deliver.`,
   );
   return lines.join('\n');
 }
@@ -443,7 +468,11 @@ export async function reconcileAcceptanceSpec({
     };
   }
 
-  const { satisfied, pending, missing } = classifyCoverage({ acIds, tagSets });
+  const { satisfied, pending, missing } = classifyCoverage({
+    acIds,
+    tagSets,
+    epicId,
+  });
   const ok = missing.length === 0 && pending.length === 0;
 
   return {

--- a/.agents/scripts/epic-audit-prepare.js
+++ b/.agents/scripts/epic-audit-prepare.js
@@ -111,18 +111,27 @@ export async function runEpicAuditPrepare(values, deps = {}) {
     : createProvider(cfg);
   const runner = deps.selectAudits ?? selectAudits;
 
+  // Pin the change set to the requested Epic's own branch rather than the
+  // shared checkout's HEAD (Story #3362). Under two concurrent /epic-deliver
+  // runs sharing one working copy, a HEAD-relative diff silently reports the
+  // *other* Epic's change set; `refs/heads/epic/<id>` is unambiguous.
+  const epicBranch = `epic/${epicId}`;
+  const epicRef = `refs/heads/${epicBranch}`;
+
   const envelope = await runner({
     ticketId: epicId,
     gate: gate ?? DEFAULT_GATE,
     provider,
     baseBranch,
+    headRef: epicRef,
   });
 
   // Degraded envelopes from selectAudits short-circuit through the
   // same surface so callers can branch on `degraded: true`. The
   // helper treats a degraded envelope as a Phase 4 abort — propagate
   // it verbatim with a non-zero exit code so shell pipelines see the
-  // failure.
+  // failure. An unresolved Epic ref (HEAD_REF_UNRESOLVED) flows through
+  // here too: better to abort Phase 4 than audit a phantom change set.
   if (envelope?.degraded) {
     return {
       exitCode: 1,
@@ -130,8 +139,30 @@ export async function runEpicAuditPrepare(values, deps = {}) {
         kind: 'envelope',
         envelope: {
           epicId,
-          epicBranch: `epic/${epicId}`,
+          epicBranch,
           ...envelope,
+        },
+      },
+    };
+  }
+
+  // Defence in depth: assert the selector diffed the ref we asked for. If a
+  // future selector change drops the pin, fail closed with an explicit
+  // degraded envelope rather than emitting an audit selection silently
+  // derived from the wrong branch.
+  const resolvedRef = envelope?.context?.resolvedRef;
+  if (resolvedRef !== epicRef) {
+    return {
+      exitCode: 1,
+      result: {
+        kind: 'envelope',
+        envelope: {
+          epicId,
+          epicBranch,
+          ok: false,
+          degraded: true,
+          reason: 'EPIC_REF_MISMATCH',
+          detail: `epic-audit-prepare: selector diffed '${resolvedRef ?? '(unset)'}' but Epic #${epicId} requested '${epicRef}'`,
         },
       },
     };
@@ -146,7 +177,7 @@ export async function runEpicAuditPrepare(values, deps = {}) {
       kind: 'envelope',
       envelope: {
         epicId,
-        epicBranch: `epic/${epicId}`,
+        epicBranch,
         selectedAudits,
         changedFiles,
         changedFilesCount: changedFiles.length,

--- a/.agents/scripts/lib/audit-suite/selector.js
+++ b/.agents/scripts/lib/audit-suite/selector.js
@@ -54,6 +54,17 @@ export function matchesAnyFilePattern(patterns, files) {
  * @param {string} params.gate
  * @param {import('../ITicketingProvider.js').ITicketingProvider} params.provider
  * @param {string} [params.baseBranch]
+ * @param {string} [params.headRef]
+ *   Git ref whose diff-against-`baseBranch` defines the change set. Defaults
+ *   to `HEAD` (the working-copy tip) for ticket-scoped callers. Epic-mode
+ *   callers MUST pass the requested Epic's own branch ref (e.g.
+ *   `refs/heads/epic/<id>`) so the change set is pinned to that Epic's branch
+ *   rather than whatever HEAD the shared checkout happens to sit on. Under two
+ *   concurrent `/epic-deliver` runs sharing one checkout, diffing against
+ *   `HEAD` silently resolves the *other* Epic's change set (Story #3362). When
+ *   `headRef` cannot be resolved in the repo, the selector returns a
+ *   `degraded: true` envelope (or hard-fails in gate-mode) instead of diffing
+ *   the wrong tree.
  * @param {(cwd: string, ...args: string[]) => Promise<{status:number, stdout:string, stderr:string}>} [params.injectedGitSpawn]
  *   Test-only seam. Production callers leave unset; the real (synchronous) `gitSpawn`
  *   is wrapped in `Promise.resolve` so `withTimeout` can still race it. Tests can
@@ -68,14 +79,15 @@ export function matchesAnyFilePattern(patterns, files) {
  *
  * Returns either the success envelope (`{ selectedAudits, ticketId, gate, context }`)
  * OR the degraded envelope (`{ ok: false, degraded: true, reason, detail }`)
- * when the git-diff probe times out and gate-mode is unset. In gate-mode,
- * the same condition throws.
+ * when the git-diff probe times out OR `headRef` cannot be resolved and
+ * gate-mode is unset. In gate-mode, the same conditions throw.
  */
 export async function selectAudits({
   ticketId,
   gate,
   provider,
   baseBranch = 'main',
+  headRef = 'HEAD',
   injectedGitSpawn,
   gitTimeoutMsOverride,
   gateModeOpts,
@@ -103,10 +115,50 @@ export async function selectAudits({
 
   const runGit = injectedGitSpawn ?? (async (...args) => gitSpawn(...args));
 
+  // Resolve `headRef` to a commit before diffing. A non-default `headRef`
+  // (Epic-mode callers pass `refs/heads/epic/<id>`) that the repo can't
+  // resolve means the requested Epic's branch is not present in this
+  // checkout — diffing `baseBranch...HEAD` would silently report a
+  // *different* Epic's change set (Story #3362). Surface that as an explicit
+  // degraded signal instead of leaking the wrong scope. `HEAD` is always
+  // resolvable in a valid repo, so the default-path callers skip the probe
+  // cost on the common case.
+  if (headRef !== 'HEAD') {
+    let resolved;
+    try {
+      resolved = await withTimeout(
+        runGit(process.cwd(), 'rev-parse', '--verify', '--quiet', headRef),
+        timeoutMs,
+        { label: 'select-audits rev-parse headRef' },
+      );
+    } catch (err) {
+      if (err?.code === 'ETIMEDOUT') {
+        return softFailOrThrow(
+          'GIT_DIFF_TIMEOUT',
+          `select-audits: git rev-parse ${headRef} timed out after ${timeoutMs} ms`,
+          gateModeOpts,
+        );
+      }
+      throw err;
+    }
+    if (resolved?.status !== 0 || !resolved.stdout.trim()) {
+      return softFailOrThrow(
+        'HEAD_REF_UNRESOLVED',
+        `select-audits: requested ref '${headRef}' could not be resolved in this checkout; refusing to diff against a phantom change set`,
+        gateModeOpts,
+      );
+    }
+  }
+
   let changedFiles = [];
   try {
     const diff = await withTimeout(
-      runGit(process.cwd(), 'diff', '--name-only', `${baseBranch}...HEAD`),
+      runGit(
+        process.cwd(),
+        'diff',
+        '--name-only',
+        `${baseBranch}...${headRef}`,
+      ),
       timeoutMs,
       { label: 'select-audits git diff' },
     );
@@ -173,6 +225,10 @@ export async function selectAudits({
       // callers that read only `changedFilesCount` remain unaffected.
       changedFiles,
       changedFilesCount: changedFiles.length,
+      // The ref the change set was actually diffed against. Epic-mode callers
+      // assert this matches the requested Epic branch (Story #3362) so a
+      // mis-pinned diff never reaches the audit-lens selector silently.
+      resolvedRef: headRef,
       ticketTitle: ticket.title,
     },
   };

--- a/.agents/scripts/lib/orchestration/planning-risk.js
+++ b/.agents/scripts/lib/orchestration/planning-risk.js
@@ -140,6 +140,18 @@ const AXIS_RULES = [
 const CLEANUP_PATTERN = /\b(?:cleanup|chore-only|housekeeping)\b/i;
 
 /**
+ * Signals that the deliverable has no browser/UI surface — a CLI, tooling,
+ * script, or library Epic. BDD `.feature` acceptance scenarios run through a
+ * browser/automation runner, so when there is no visible-behavior axis these
+ * Epics cannot satisfy a `required` Acceptance Spec by `.feature` files;
+ * their acceptance is contract-tier (unit/contract tests), not e2e. The
+ * disposition should therefore not be forced to `required` off a keyword like
+ * "security" alone (Story #3362).
+ */
+const CLI_TOOLING_PATTERN =
+  /\b(?:cli|command[- ]line|tooling|script(?:s|ing)?|library|sdk|no[- ]ui|headless|backend[- ]only)\b/i;
+
+/**
  * @param {string} text
  * @returns {string}
  */
@@ -178,10 +190,30 @@ function resolveOverallLevel(axes) {
 /**
  * @param {PlanningRiskAxis[]} axes
  * @param {RiskLevel} overallLevel
+ * @param {boolean} [cliTooling]
+ *   True when the Epic scope carries a CLI/tooling/no-UI signal (see
+ *   {@link CLI_TOOLING_PATTERN}). When set and there is no `visible-behavior`
+ *   axis, a REQUIRED axis that is *not* itself visible-behavior (e.g.
+ *   `security` on a CLI epic) is weighted down to `recommended` rather than
+ *   forcing a BDD `.feature` Acceptance Spec the deliverable cannot satisfy
+ *   (Story #3362). Genuinely user-facing risk (`visible-behavior`) still
+ *   forces `required`.
  * @returns {AcceptanceDisposition}
  */
-function resolveAcceptanceDisposition(axes, overallLevel) {
-  if (axes.some((entry) => REQUIRED_AXES.has(entry.axis))) {
+function resolveAcceptanceDisposition(axes, overallLevel, cliTooling = false) {
+  const hasVisibleBehavior = axes.some(
+    (entry) => entry.axis === 'visible-behavior',
+  );
+  const requiredAxes = axes.filter((entry) => REQUIRED_AXES.has(entry.axis));
+  if (requiredAxes.length > 0) {
+    // CLI/tooling/no-UI epic with no user-visible surface: BDD `.feature`
+    // scenarios can't satisfy a required Acceptance Spec, so weight the
+    // non-visible required axes down to `recommended` (acceptance is
+    // contract-tier here). A visible-behavior axis overrides this and keeps
+    // the hard requirement.
+    if (cliTooling && !hasVisibleBehavior) {
+      return 'recommended';
+    }
     return 'required';
   }
   if (
@@ -254,10 +286,13 @@ export function classifyPlanningRisk(input = {}) {
     });
   }
 
+  const cliTooling = CLI_TOOLING_PATTERN.test(haystack);
+
   const overallLevel = resolveOverallLevel(axes);
   const acceptanceDisposition = resolveAcceptanceDisposition(
     axes,
     overallLevel,
+    cliTooling,
   );
   const requiresReview = resolveRequiresReview(overallLevel, axes);
   const gateDecision = requiresReview ? 'review-required' : 'auto-proceed';

--- a/.agents/workflows/helpers/epic-audit.md
+++ b/.agents/workflows/helpers/epic-audit.md
@@ -71,10 +71,15 @@ envelope:
 - **`selectedAudits` is non-empty** — continue to Step 2.
 - **`selectedAudits` is empty** (docs-only or no-lens change set) — skip
   Step 2 and write the docs-only marker described in Step 4.
-- **`degraded: true`** — the selector aborted (typically a git-diff
-  timeout). Surface the `reason`/`detail` fields to the operator, post a
-  friction comment on the Epic, and STOP. Do not fall back to running the
-  full lens roster — that defeats the change-set scoping.
+- **`degraded: true`** — the selector aborted. Possible `reason` codes:
+  `GIT_DIFF_TIMEOUT` (git-diff timed out), `HEAD_REF_UNRESOLVED` (the
+  Epic's branch `refs/heads/epic/<id>` is not present in this checkout),
+  or `EPIC_REF_MISMATCH` (the selector diffed a ref other than the
+  requested Epic's branch — the cross-epic-leak guard from Story #3362).
+  Surface the `reason`/`detail` fields to the operator, post a friction
+  comment on the Epic, and STOP. Do not fall back to running the full lens
+  roster — that defeats the change-set scoping, and an unresolved/mismatched
+  ref means the change set would belong to the wrong Epic.
 
 ## Step 2 — Walk Selected Lenses (`runAuditSuite`)
 

--- a/tests/acceptance-spec-reconciler.test.js
+++ b/tests/acceptance-spec-reconciler.test.js
@@ -14,6 +14,7 @@ import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 
 import {
+  acTagToken,
   classifyCoverage,
   classifyReconcilerInvocation,
   collectScenarioTagSets,
@@ -156,6 +157,40 @@ describe('classifyCoverage', () => {
     assert.deepEqual(out.pending, ['AC-2']);
     assert.deepEqual(out.missing, ['AC-3']);
   });
+
+  it('with epicId, matches only the per-epic namespaced tag (Story #3362)', () => {
+    // Scenario carries the namespaced tag for THIS epic → satisfied.
+    const tagSets = [new Set(['epic-1241-ac-1'])];
+    const out = classifyCoverage({ acIds: ['AC-1'], tagSets, epicId: 1241 });
+    assert.deepEqual(out, { satisfied: ['AC-1'], pending: [], missing: [] });
+  });
+
+  it('with epicId, ignores a bare @ac-N tag from an unrelated epic (Story #3362)', () => {
+    // This is the cross-epic leak: a bare `ac-1` (and another epic's
+    // namespaced tag) must NOT count as coverage for epic 1241.
+    const tagSets = [new Set(['ac-1']), new Set(['epic-9999-ac-1'])];
+    const out = classifyCoverage({ acIds: ['AC-1'], tagSets, epicId: 1241 });
+    assert.deepEqual(out, { satisfied: [], pending: [], missing: ['AC-1'] });
+  });
+
+  it('with epicId, a foreign @skip @ac-N does not count as pending (Story #3362)', () => {
+    // The reported symptom: AC-10 read off a `@skip @ac-10` in another
+    // epic's deploy/emergency-hotfix.feature → false pending block.
+    const tagSets = [new Set(['ac-10', 'skip'])];
+    const out = classifyCoverage({ acIds: ['AC-10'], tagSets, epicId: 1241 });
+    assert.deepEqual(out, { satisfied: [], pending: [], missing: ['AC-10'] });
+  });
+});
+
+describe('acTagToken', () => {
+  it('namespaces the token per epic when epicId is a positive integer', () => {
+    assert.equal(acTagToken('AC-7', 1241), 'epic-1241-ac-7');
+  });
+  it('falls back to the bare lower-cased token without an epicId', () => {
+    assert.equal(acTagToken('AC-7'), 'ac-7');
+    assert.equal(acTagToken('AC-7', null), 'ac-7');
+    assert.equal(acTagToken('AC-7', 0), 'ac-7');
+  });
 });
 
 describe('classifyReconcilerInvocation', () => {
@@ -272,11 +307,11 @@ describe('reconcileAcceptanceSpec', () => {
     ]);
     const featureContent = [
       'Feature: Sample',
-      '@ac-1',
+      '@epic-7002-ac-1',
       'Scenario: first',
       '  Given x',
       '',
-      '@ac-2',
+      '@epic-7002-ac-2',
       'Scenario: second',
       '  Given y',
     ].join('\n');
@@ -312,7 +347,7 @@ describe('reconcileAcceptanceSpec', () => {
     ]);
     const featureContent = [
       'Feature: Sample',
-      '@ac-1',
+      '@epic-7003-ac-1',
       'Scenario: only one',
       '  Given x',
     ].join('\n');
@@ -347,11 +382,11 @@ describe('reconcileAcceptanceSpec', () => {
     ]);
     const featureContent = [
       'Feature: Sample',
-      '@ac-1',
+      '@epic-7004-ac-1',
       'Scenario: first',
       '  Given x',
       '',
-      '@ac-2 @pending',
+      '@epic-7004-ac-2 @pending',
       'Scenario: pending one',
       '  Given y',
     ].join('\n');
@@ -394,6 +429,48 @@ describe('reconcileAcceptanceSpec', () => {
     });
     assert.equal(out.status, 'empty-spec');
     assert.equal(out.ok, true);
+  });
+
+  it("does not satisfy AC IDs from another epic's bare @ac-N scenarios (Story #3362)", async () => {
+    // Reproduces the #1241 leak: a CLI epic declares AC-1..AC-2 but authored
+    // zero of its OWN scenarios; unrelated epics' feature files carry bare
+    // @ac-1 / @skip @ac-2. With per-epic namespacing those must NOT count.
+    const provider = buildProvider([
+      {
+        id: 1241,
+        labels: ['type::epic'],
+        body: '## Planning Artifacts\n- [x] Acceptance Spec: #1500\n',
+      },
+      {
+        id: 1500,
+        labels: ['context::acceptance-spec'],
+        body: '| AC-1 | a |\n| AC-2 | b |\n',
+        state: 'closed',
+      },
+    ]);
+    const foreignFeature = [
+      'Feature: analytics (epic 1242)',
+      '@ac-1',
+      'Scenario: unrelated',
+      '  Given x',
+      '',
+      '@skip @ac-2',
+      'Scenario: skipped unrelated',
+      '  Given y',
+    ].join('\n');
+    const out = await reconcileAcceptanceSpec({
+      epicId: 1241,
+      cwd: process.cwd(),
+      injectedProvider: provider,
+      injectedConfig: {},
+      loggerImpl: SILENT_LOGGER,
+      listFeatureFiles: () => ['/fake/analytics.feature'],
+      readFeatureFile: () => foreignFeature,
+    });
+    assert.equal(out.ok, false);
+    assert.equal(out.status, 'gap');
+    assert.deepEqual(out.satisfied, []);
+    assert.deepEqual(out.missing, ['AC-1', 'AC-2']);
   });
 
   it('honours pre-populated linkedIssues.acceptanceSpec on the epic', async () => {

--- a/tests/audit-suite/epic-audit-helper.test.js
+++ b/tests/audit-suite/epic-audit-helper.test.js
@@ -56,13 +56,17 @@ const noopConfig = () => ({});
 const noopProviderFactory = (provider) => () => provider;
 
 function makeFakeSelectAudits({ selectedAudits, changedFiles, ticketTitle }) {
-  return async ({ ticketId, gate }) => ({
+  // Mirror the real selector: echo the `headRef` it was pinned to back as
+  // `context.resolvedRef`, so epic-audit-prepare's per-epic ref assertion
+  // (Story #3362) passes end-to-end.
+  return async ({ ticketId, gate, headRef }) => ({
     selectedAudits,
     ticketId,
     gate,
     context: {
       changedFiles,
       changedFilesCount: changedFiles.length,
+      resolvedRef: headRef,
       ticketTitle,
     },
   });

--- a/tests/audit-suite/epic-audit-prepare.test.js
+++ b/tests/audit-suite/epic-audit-prepare.test.js
@@ -47,13 +47,17 @@ function makeProvider() {
  * touching the filesystem or git.
  */
 function makeFakeSelectAudits({ selectedAudits, changedFiles, ticketTitle }) {
-  return async ({ ticketId, gate }) => ({
+  // Mirror the real selector: echo the `headRef` it was pinned to back as
+  // `context.resolvedRef`, so epic-audit-prepare's per-epic ref assertion
+  // (Story #3362) sees the same value it requested.
+  return async ({ ticketId, gate, headRef }) => ({
     selectedAudits,
     ticketId,
     gate,
     context: {
       changedFiles,
       changedFilesCount: changedFiles.length,
+      resolvedRef: headRef,
       ticketTitle,
     },
   });
@@ -177,6 +181,77 @@ test('runEpicAuditPrepare: degraded selectAudits envelope propagates with non-ze
   assert.equal(result.kind, 'envelope');
   assert.equal(result.envelope.degraded, true);
   assert.equal(result.envelope.reason, 'GIT_DIFF_TIMEOUT');
+  assert.equal(result.envelope.epicId, EPIC_ID);
+  assert.equal(result.envelope.epicBranch, `epic/${EPIC_ID}`);
+});
+
+test('runEpicAuditPrepare: pins selectAudits to the requested Epic branch ref (Story #3362)', async () => {
+  const provider = makeProvider();
+  let capturedArgs = null;
+
+  const capturingRunner = async (args) => {
+    capturedArgs = args;
+    return {
+      selectedAudits: ['audit-security'],
+      ticketId: args.ticketId,
+      gate: args.gate,
+      context: {
+        changedFiles: ['src/a.ts'],
+        changedFilesCount: 1,
+        resolvedRef: args.headRef,
+        ticketTitle: 'x',
+      },
+    };
+  };
+
+  const { exitCode, result } = await runEpicAuditPrepare(
+    { epicId: EPIC_ID, baseBranch: 'main', gate: 'gate3' },
+    {
+      resolveConfig: noopConfig,
+      createProvider: noopProviderFactory(provider),
+      selectAudits: capturingRunner,
+    },
+  );
+
+  assert.equal(exitCode, 0);
+  assert.equal(result.kind, 'envelope');
+  // The selector must be pinned to refs/heads/epic/<id>, NOT the shared
+  // checkout's HEAD — that is the whole point of the cross-epic isolation fix.
+  assert.equal(capturedArgs.headRef, `refs/heads/epic/${EPIC_ID}`);
+  assert.deepEqual(result.envelope.changedFiles, ['src/a.ts']);
+});
+
+test('runEpicAuditPrepare: degrades when selector resolves a different ref than requested (Story #3362)', async () => {
+  const provider = makeProvider();
+
+  // Selector reports it diffed a DIFFERENT epic's branch — exactly the
+  // cross-epic leak symptom. Prepare must fail closed rather than emit the
+  // wrong audit selection.
+  const mismatchedRunner = async ({ ticketId, gate }) => ({
+    selectedAudits: ['audit-seo'],
+    ticketId,
+    gate,
+    context: {
+      changedFiles: ['robots.txt', 'Schema.astro'],
+      changedFilesCount: 2,
+      resolvedRef: 'refs/heads/epic/9999',
+      ticketTitle: 'x',
+    },
+  });
+
+  const { exitCode, result } = await runEpicAuditPrepare(
+    { epicId: EPIC_ID, baseBranch: 'main', gate: 'gate3' },
+    {
+      resolveConfig: noopConfig,
+      createProvider: noopProviderFactory(provider),
+      selectAudits: mismatchedRunner,
+    },
+  );
+
+  assert.equal(exitCode, 1);
+  assert.equal(result.kind, 'envelope');
+  assert.equal(result.envelope.degraded, true);
+  assert.equal(result.envelope.reason, 'EPIC_REF_MISMATCH');
   assert.equal(result.envelope.epicId, EPIC_ID);
   assert.equal(result.envelope.epicBranch, `epic/${EPIC_ID}`);
 });

--- a/tests/audit-suite/selector-changedfiles.test.js
+++ b/tests/audit-suite/selector-changedfiles.test.js
@@ -91,3 +91,78 @@ test('selector: empty diff yields empty changedFiles array (not undefined)', asy
   assert.deepEqual(result.context.changedFiles, []);
   assert.equal(result.context.changedFilesCount, 0);
 });
+
+test('selector: headRef pins the diff to the requested ref (Story #3362)', async () => {
+  const epicRef = 'refs/heads/epic/1241';
+  const seen = [];
+  // Distinguish the rev-parse probe (resolves the ref) from the diff.
+  const fakeGitSpawn = async (_cwd, ...args) => {
+    seen.push(args);
+    if (args[0] === 'rev-parse') {
+      return { status: 0, stdout: 'abc123\n', stderr: '' };
+    }
+    // args: ['diff', '--name-only', '<base>...<headRef>']
+    return { status: 0, stdout: 'env/doctor.js\nenv/fix.js\n', stderr: '' };
+  };
+
+  const result = await selectAudits({
+    ticketId: 500,
+    gate: 'gate1',
+    provider: makeProvider(),
+    headRef: epicRef,
+    injectedGitSpawn: fakeGitSpawn,
+  });
+
+  // The diff range must terminate at the requested ref, not HEAD.
+  const diffCall = seen.find((a) => a[0] === 'diff');
+  assert.equal(diffCall[2], `main...${epicRef}`);
+  assert.equal(result.context.resolvedRef, epicRef);
+  assert.deepEqual(result.context.changedFiles, [
+    'env/doctor.js',
+    'env/fix.js',
+  ]);
+});
+
+test('selector: unresolvable headRef returns a degraded envelope (Story #3362)', async () => {
+  // rev-parse --verify --quiet returns non-zero + empty stdout when the ref
+  // does not exist in this checkout — the concurrent-epic leak symptom.
+  const fakeGitSpawn = async (_cwd, ...args) => {
+    if (args[0] === 'rev-parse') {
+      return { status: 1, stdout: '', stderr: '' };
+    }
+    throw new Error('diff should not run when the ref is unresolved');
+  };
+
+  const result = await selectAudits({
+    ticketId: 500,
+    gate: 'gate1',
+    provider: makeProvider(),
+    headRef: 'refs/heads/epic/9999',
+    injectedGitSpawn: fakeGitSpawn,
+  });
+
+  assert.equal(result.ok, false);
+  assert.equal(result.degraded, true);
+  assert.equal(result.reason, 'HEAD_REF_UNRESOLVED');
+});
+
+test('selector: default headRef (HEAD) skips the rev-parse probe and diffs HEAD', async () => {
+  const seen = [];
+  const fakeGitSpawn = async (_cwd, ...args) => {
+    seen.push(args);
+    return { status: 0, stdout: 'a.js\n', stderr: '' };
+  };
+
+  const result = await selectAudits({
+    ticketId: 500,
+    gate: 'gate1',
+    provider: makeProvider(),
+    injectedGitSpawn: fakeGitSpawn,
+  });
+
+  // No rev-parse probe for the default path; the diff terminates at HEAD.
+  assert.ok(!seen.some((a) => a[0] === 'rev-parse'));
+  const diffCall = seen.find((a) => a[0] === 'diff');
+  assert.equal(diffCall[2], 'main...HEAD');
+  assert.equal(result.context.resolvedRef, 'HEAD');
+});

--- a/tests/lib/orchestration/planning-risk.test.js
+++ b/tests/lib/orchestration/planning-risk.test.js
@@ -27,6 +27,24 @@ const MIXED_SIGNAL_EPIC = {
   labels: ['type::epic'],
 };
 
+const CLI_SECURITY_EPIC = {
+  title: 'Env-tooling CLI: doctor, fix, lint commands',
+  body: `## Scope
+
+A command-line tooling epic. Includes security hardening of the secret-loading
+path. No browser surface — headless CLI scripts only.`,
+  labels: ['type::epic'],
+};
+
+const UI_SECURITY_EPIC = {
+  title: 'Secure the account settings page',
+  body: `## Scope
+
+User-facing security hardening for the authentication UI change on the settings
+screen.`,
+  labels: ['type::epic'],
+};
+
 describe('classifyPlanningRisk', () => {
   it('classifies a critical-workflow Epic as high risk requiring review', () => {
     const result = classifyPlanningRisk(HIGH_RISK_CRITICAL_WORKFLOW);
@@ -70,6 +88,31 @@ describe('classifyPlanningRisk', () => {
     assert.match(String(docsOnly.evidence), /docs/i);
     assert.ok(security.evidence.length <= 120);
     assert.ok(docsOnly.evidence.length <= 120);
+  });
+
+  it('weights a CLI/tooling security Epic with no UI surface away from required acceptance (Story #3362)', () => {
+    const result = classifyPlanningRisk(CLI_SECURITY_EPIC);
+
+    // The security keyword still raises the axis...
+    assert.ok(
+      result.axes.some((entry) => entry.axis === 'security'),
+      'expected security axis',
+    );
+    // ...but a headless CLI epic cannot satisfy a BDD `.feature` Acceptance
+    // Spec, so the disposition must not be forced to `required`.
+    assert.strictEqual(result.acceptanceDisposition, 'recommended');
+  });
+
+  it('keeps required acceptance when a security Epic IS user-facing (Story #3362)', () => {
+    const result = classifyPlanningRisk(UI_SECURITY_EPIC);
+
+    assert.ok(
+      result.axes.some((entry) => entry.axis === 'visible-behavior'),
+      'expected visible-behavior axis',
+    );
+    // A user-facing surface overrides the CLI weighting — acceptance stays
+    // required.
+    assert.strictEqual(result.acceptanceDisposition, 'required');
   });
 
   it('returns the stable planning risk envelope shape', () => {


### PR DESCRIPTION
Closes #3362

_Auto-opened by `/single-story-deliver`._