### PR TITLE
single-story-deliver: worktree-isolated edits can silently land in the main checkout (no wrong-tree guard) (#3364)

### DIFF
--- a/.agents/scripts/lib/orchestration/single-story-close/phases/wrong-tree-guard.js
+++ b/.agents/scripts/lib/orchestration/single-story-close/phases/wrong-tree-guard.js
@@ -1,0 +1,225 @@
+/**
+ * phases/wrong-tree-guard.js — detect worktree/main-checkout edit divergence.
+ *
+ * Story #3364 — `/single-story-deliver` (and `/story-deliver`) materializes a
+ * per-Story worktree and instructs the agent to `cd` into it before editing.
+ * On Windows that guidance is silently insufficient: `cd <workCwd>` steers the
+ * Bash tool's working directory, but the path-based Edit/Write tools operate on
+ * absolute paths and ignore cwd. An agent whose shell is correctly inside the
+ * worktree can still resolve a main-checkout absolute path and edit the wrong
+ * tree — the two surfaces disagree and nothing detects it.
+ *
+ * Failure mode this guards: the worktree is the intended work tree, but the
+ * agent's edits landed under the main checkout instead. `single-story-close.js`
+ * runs its gates against the worktree only, so it would commit an unchanged /
+ * partial worktree (gates pass on the clean tree) while leaving the main
+ * checkout dirty — a silent empty-diff PR.
+ *
+ * Detection: when a worktree is the active work tree (it exists on disk and is
+ * distinct from `cwd`), inspect `git -C <mainCheckout> status --porcelain`. Any
+ * **tracked-path** change (modified, staged, deleted, renamed) in the main
+ * checkout is the wrong-tree signal. Untracked files (`??`) are ignored — they
+ * are scratch artifacts, not relocated Story work, and flagging them would
+ * produce false positives on every run.
+ *
+ * The guard runs before the gate chain. On detection it posts a `friction`
+ * structured comment naming the stray files and throws, so the operator/agent
+ * relocates the edits into the worktree before close proceeds. This is the
+ * load-bearing, detection-based fix: it fires regardless of whether the agent
+ * ever realized it edited the wrong tree.
+ */
+
+import path from 'node:path';
+import { postStructuredComment } from '../../ticketing/state.js';
+
+/**
+ * Parse `git status --porcelain` output into structured status entries.
+ *
+ * Porcelain v1 format: a two-character status field, a space, then the path
+ * (renames use `orig -> dest`, which we collapse to the destination path).
+ * Untracked entries carry the `??` status field.
+ *
+ * @param {string} raw - Raw `git status --porcelain` stdout (may be empty).
+ * @returns {Array<{ status: string, path: string, untracked: boolean }>}
+ */
+export function parsePorcelainStatus(raw) {
+  if (typeof raw !== 'string' || raw.trim() === '') return [];
+  return raw
+    .split('\n')
+    .map((line) => line.replace(/\r$/, ''))
+    .filter((line) => line.length > 0)
+    .map((line) => {
+      // First two chars are the status code; path begins at column 3.
+      const status = line.slice(0, 2);
+      let filePath = line.slice(3).trim();
+      // Renames/copies render as "orig -> dest"; keep the destination.
+      const arrowIdx = filePath.indexOf(' -> ');
+      if (arrowIdx !== -1) {
+        filePath = filePath.slice(arrowIdx + 4).trim();
+      }
+      // Porcelain may quote paths containing special chars; strip the quotes.
+      if (filePath.startsWith('"') && filePath.endsWith('"')) {
+        filePath = filePath.slice(1, -1);
+      }
+      return { status, path: filePath, untracked: status === '??' };
+    });
+}
+
+/**
+ * Filter porcelain status entries down to the tracked-path changes that
+ * indicate stray Story work landed in the main checkout.
+ *
+ * Untracked files (`??`) are excluded — they are scratch artifacts, not
+ * relocated tracked-file edits, and the issue's contract scopes the signal to
+ * "uncommitted changes under tracked paths".
+ *
+ * @param {Array<{ status: string, path: string, untracked: boolean }>} entries
+ * @returns {string[]} sorted list of stray tracked-file paths.
+ */
+export function collectStrayTrackedPaths(entries) {
+  return entries
+    .filter((e) => !e.untracked)
+    .map((e) => e.path)
+    .filter(Boolean)
+    .sort();
+}
+
+/**
+ * Decide whether the wrong-tree guard applies for this close.
+ *
+ * The guard only makes sense when a worktree is the active work tree: it must
+ * exist on disk (`worktreePath` is non-null) and be a distinct directory from
+ * the main checkout (`cwd`). In single-tree mode the worktree IS the main
+ * checkout, so there is no divergence to detect.
+ *
+ * @param {{ cwd: string, worktreePath: string|null }} opts
+ * @returns {boolean}
+ */
+export function guardApplies({ cwd, worktreePath }) {
+  if (!worktreePath) return false;
+  return path.resolve(cwd) !== path.resolve(worktreePath);
+}
+
+/**
+ * Format the `friction` finding body naming the stray files.
+ *
+ * @param {{ storyId: number, strayFiles: string[], worktreePath: string }} opts
+ * @returns {string}
+ */
+export function formatWrongTreeFinding({ storyId, strayFiles, worktreePath }) {
+  const list = strayFiles.map((f) => `- \`${f}\``).join('\n');
+  return (
+    `### wrong-tree edit detected (close aborted)\n\n` +
+    `Story #${storyId}: the main checkout has uncommitted changes under ` +
+    `tracked paths while the active work tree is the per-Story worktree:\n\n` +
+    `\`${worktreePath}\`\n\n` +
+    `This is the wrong-tree failure mode: edits intended for the worktree ` +
+    `landed in the main checkout instead (on Windows, \`cd\` steers the Bash ` +
+    `cwd but path-based Edit/Write tools resolve absolute paths and ignore ` +
+    `it). Close was **aborted** to prevent committing an unchanged worktree ` +
+    `and opening an empty-diff PR.\n\n` +
+    `**Stray files in the main checkout:**\n\n${list}\n\n` +
+    `**Recovery:** relocate these edits into the worktree (re-apply them under ` +
+    `\`${worktreePath}\`), restore the main checkout ` +
+    `(\`git -C <main-repo> checkout -- <files>\`), then re-run ` +
+    `\`/single-story-deliver\`.`
+  );
+}
+
+/**
+ * Run the wrong-tree detection guard for `single-story-close`.
+ *
+ * When a worktree is the active work tree and the main checkout has uncommitted
+ * tracked-path changes, posts a `friction` comment naming the stray files and
+ * throws to abort close. Otherwise returns a clean result.
+ *
+ * Unlike the soft drift-detection phase, this guard is **load-bearing**: a
+ * positive detection aborts close (throws). Failures to run git, however, are
+ * swallowed as warnings — a probe failure must not block an otherwise valid
+ * close (fail-open on the probe, fail-closed on a confirmed positive).
+ *
+ * @param {{
+ *   cwd: string,
+ *   worktreePath: string|null,
+ *   storyId: number,
+ *   provider: object,
+ *   progress: (tag: string, msg: string) => void,
+ *   gitSpawn?: Function,
+ * }} args
+ * @returns {Promise<{ applied: boolean, strayFiles: string[] }>}
+ * @throws {Error} when stray tracked-path edits are detected in the main checkout.
+ */
+export async function runWrongTreeGuardPhase({
+  cwd,
+  worktreePath,
+  storyId,
+  provider,
+  progress,
+  gitSpawn: injectedGitSpawn,
+}) {
+  if (!guardApplies({ cwd, worktreePath })) {
+    return { applied: false, strayFiles: [] };
+  }
+
+  // Dynamic import keeps the default git binding out of the module top-level so
+  // unit tests can inject a fake without module-URL mocking.
+  const { gitSpawn: defaultGitSpawn } = await import('../../../git-utils.js');
+  const gitSpawnFn = injectedGitSpawn ?? defaultGitSpawn;
+
+  progress(
+    'WRONG-TREE',
+    `Checking main checkout for stray edits (worktree-isolated Story #${storyId})...`,
+  );
+
+  let result;
+  try {
+    result = gitSpawnFn(cwd, 'status', '--porcelain');
+  } catch (err) {
+    // Probe failure is non-fatal — never block a valid close on a git hiccup.
+    progress(
+      'WRONG-TREE',
+      `⚠️ Could not probe main checkout status: ${err?.message ?? err}. Skipping guard.`,
+    );
+    return { applied: false, strayFiles: [] };
+  }
+
+  if (!result || result.status !== 0) {
+    progress(
+      'WRONG-TREE',
+      `⚠️ git status probe exited non-zero: ${result?.stderr || '(no stderr)'}. Skipping guard.`,
+    );
+    return { applied: false, strayFiles: [] };
+  }
+
+  const strayFiles = collectStrayTrackedPaths(
+    parsePorcelainStatus(result.stdout ?? ''),
+  );
+
+  if (strayFiles.length === 0) {
+    progress('WRONG-TREE', '✅ Main checkout clean — no wrong-tree edits.');
+    return { applied: true, strayFiles: [] };
+  }
+
+  // Confirmed positive: post a friction comment and abort close.
+  const body = formatWrongTreeFinding({ storyId, strayFiles, worktreePath });
+  try {
+    await postStructuredComment(provider, storyId, 'friction', body);
+    progress(
+      'WRONG-TREE',
+      `🛑 Wrong-tree edits detected: ${strayFiles.length} stray file(s). Posted friction comment to Story #${storyId}.`,
+    );
+  } catch (err) {
+    progress(
+      'WRONG-TREE',
+      `⚠️ Failed to post wrong-tree friction comment: ${err?.message ?? err}`,
+    );
+  }
+
+  throw new Error(
+    `[single-story-close] Wrong-tree edits detected: the main checkout has ` +
+      `uncommitted tracked-path changes while the worktree (${worktreePath}) is ` +
+      `the active work tree. Close aborted to avoid an empty-diff PR. Stray ` +
+      `files: ${strayFiles.join(', ')}. Relocate the edits into the worktree, ` +
+      `restore the main checkout, then re-run /single-story-deliver.`,
+  );
+}

--- a/.agents/scripts/single-story-close.js
+++ b/.agents/scripts/single-story-close.js
@@ -64,6 +64,7 @@ import { parseCloseOptions } from './lib/orchestration/single-story-close/phases
 import { ensurePullRequestWith } from './lib/orchestration/single-story-close/phases/pull-request.js';
 import { pushStoryBranch } from './lib/orchestration/single-story-close/phases/push.js';
 import { reapWorktreePhase } from './lib/orchestration/single-story-close/phases/worktree-reap.js';
+import { runWrongTreeGuardPhase } from './lib/orchestration/single-story-close/phases/wrong-tree-guard.js';
 import { buildGatesFromConfig } from './lib/orchestration/story-close/legacy-settings-bag.js';
 import { createProvider } from './lib/provider-factory.js';
 import { flipLabelAndNotify } from './lib/single-story/story-merged-notify.js';
@@ -111,6 +112,8 @@ export async function runSingleStoryClose({
   // Story #3260: lets tests inject fakes for plan-vs-actual drift detection.
   injectedFindStructuredComment,
   injectedGitSync,
+  // Story #3364: lets tests inject a fake `gitSpawn` for the wrong-tree guard.
+  injectedGitSpawn,
 } = {}) {
   const {
     storyId,
@@ -166,6 +169,20 @@ export async function runSingleStoryClose({
   const worktreePath = nodeFs.existsSync(worktreePathCandidate)
     ? worktreePathCandidate
     : null;
+
+  // Step 0.4: wrong-tree guard (Story #3364). When the worktree is the active
+  // work tree, abort if stray tracked-path edits are sitting in the main
+  // checkout — they signal that path-based Edit/Write tools wrote to the wrong
+  // tree (the Bash `cd` only steers the shell). Runs before any gate so a
+  // false-clean worktree never reaches commit. Throws on a confirmed positive.
+  await runWrongTreeGuardPhase({
+    cwd,
+    worktreePath,
+    storyId,
+    provider,
+    progress,
+    gitSpawn: injectedGitSpawn,
+  });
 
   // Step 0.5: plan-vs-actual drift detection (non-blocking soft findings).
   await runDriftDetectionPhase({

--- a/.agents/workflows/helpers/single-story-deliver.md
+++ b/.agents/workflows/helpers/single-story-deliver.md
@@ -116,6 +116,20 @@ cd "<workCwd from Step 0 result>"
 
 All subsequent commands run from this directory.
 
+> **Worktree scope is not just the Bash cwd.** `cd <workCwd>` steers the
+> **Bash** tool's working directory, but it does **not** scope the
+> path-based **Edit/Write/Read** tools — those resolve **absolute paths**
+> and ignore the shell cwd. On Windows especially, an agent whose shell
+> sits in the worktree can still silently edit the **main checkout** if it
+> resolves a main-checkout absolute path. To stay in the worktree you MUST
+> prefix **every Edit/Write/Read path with the absolute worktree root**
+> (the `workCwd` value from Step 0), not merely `cd` into it. Never edit
+> files under the bare main-checkout root. `single-story-close.js` runs a
+> **wrong-tree guard** (Story #3364) that aborts close and posts a
+> `friction` comment if it finds uncommitted tracked-path edits in the main
+> checkout while the worktree is the active work tree — but that is a
+> backstop, not a substitute for prefixing paths correctly.
+
 ### Step 0.6 — Story-plan checkpoint (non-trivial Stories only)
 
 Before authoring any commit, evaluate the **always-emit triggering predicate**
@@ -541,7 +555,11 @@ safe.
 
 - **Never** push the Story branch directly to `main`. The PR is the only
   merge surface.
-- **Always** `cd` into the `workCwd` returned by Step 0 before editing.
+- **Always** `cd` into the `workCwd` returned by Step 0 before editing,
+  **and** prefix every path-based Edit/Write/Read with that absolute
+  `workCwd` root — the `cd` alone does not scope the path-based tools (see
+  Step 0.5). Editing a bare main-checkout path lands the change in the wrong
+  tree; close's wrong-tree guard (Story #3364) aborts when it detects this.
 - **Always** pass `--cwd <main-repo>` to `single-story-close.js` when
   invoking from inside a worktree (worktree-local branch deletion fails
   when run from inside the worktree).

--- a/tests/single-story-close-wrong-tree-guard.test.js
+++ b/tests/single-story-close-wrong-tree-guard.test.js
@@ -1,0 +1,360 @@
+/**
+ * Regression tests for the wrong-tree guard in `single-story-close.js`.
+ *
+ * Story #3364 — `/single-story-deliver` materializes a per-Story worktree, but
+ * on Windows `cd <workCwd>` only steers the Bash tool's cwd: the path-based
+ * Edit/Write tools resolve absolute paths and ignore it. An agent can silently
+ * edit the MAIN CHECKOUT while its shell sits in the worktree, and nothing in
+ * the close path detected it — close would commit an unchanged worktree and
+ * open an empty-diff PR.
+ *
+ * Asserts:
+ *   AC-1: when the worktree is the active work tree and the main checkout has
+ *         uncommitted tracked-path changes, the guard throws (close aborts)
+ *         and posts a `friction` comment naming the stray files.
+ *   AC-2: the helper workflow doc states the worktree-scope requirement for
+ *         the path-based edit tools, not only for the Bash cwd (asserted in a
+ *         sibling doc-contract assertion at the bottom of this file).
+ *   - The guard does not fire in single-tree mode (worktree === main checkout).
+ *   - The guard does not fire when no worktree exists.
+ *   - The guard ignores untracked (`??`) files — only tracked-path edits count.
+ *   - The guard fails open on a git probe error (never blocks a valid close).
+ *
+ * Tests exercise the pure helpers directly (`parsePorcelainStatus`,
+ * `collectStrayTrackedPaths`, `guardApplies`, `formatWrongTreeFinding`) and the
+ * orchestration wrapper (`runWrongTreeGuardPhase`) with an in-memory provider
+ * and an injected fake `gitSpawn` so no real git or GitHub call is made.
+ */
+
+import assert from 'node:assert/strict';
+import nodeFs from 'node:fs';
+import path from 'node:path';
+import { describe, it } from 'node:test';
+import { fileURLToPath } from 'node:url';
+import {
+  collectStrayTrackedPaths,
+  formatWrongTreeFinding,
+  guardApplies,
+  parsePorcelainStatus,
+  runWrongTreeGuardPhase,
+} from '../.agents/scripts/lib/orchestration/single-story-close/phases/wrong-tree-guard.js';
+
+const REPO_ROOT = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '..',
+);
+
+/**
+ * Minimal in-memory provider. The guard only calls `postComment`.
+ */
+function makeProvider() {
+  const comments = [];
+  let nextId = 1;
+  return {
+    comments,
+    async postComment(ticketId, { type, body }) {
+      const id = nextId++;
+      comments.push({ id, ticketId, type, body });
+      return { commentId: id };
+    },
+    async getTicketComments(ticketId) {
+      return comments.filter((c) => c.ticketId === ticketId);
+    },
+  };
+}
+
+/** Build a fake `gitSpawn` result envelope. */
+function spawnResult(stdout, { status = 0, stderr = '' } = {}) {
+  return () => ({ status, stdout, stderr });
+}
+
+function noop() {}
+
+// ---------------------------------------------------------------------------
+// parsePorcelainStatus — pure unit
+// ---------------------------------------------------------------------------
+
+describe('parsePorcelainStatus — pure unit', () => {
+  it('returns empty array for empty input', () => {
+    assert.deepEqual(parsePorcelainStatus(''), []);
+    assert.deepEqual(parsePorcelainStatus('   '), []);
+    assert.deepEqual(parsePorcelainStatus(undefined), []);
+  });
+
+  it('parses modified tracked file', () => {
+    const entries = parsePorcelainStatus(' M src/a.js');
+    assert.equal(entries.length, 1);
+    assert.equal(entries[0].path, 'src/a.js');
+    assert.equal(entries[0].untracked, false);
+  });
+
+  it('parses staged + modified tracked files', () => {
+    const entries = parsePorcelainStatus('M  src/a.js\n M src/b.js');
+    assert.deepEqual(
+      entries.map((e) => e.path),
+      ['src/a.js', 'src/b.js'],
+    );
+    assert.ok(entries.every((e) => e.untracked === false));
+  });
+
+  it('flags untracked files via the ?? status', () => {
+    const entries = parsePorcelainStatus('?? scratch.txt');
+    assert.equal(entries[0].untracked, true);
+  });
+
+  it('collapses a rename to its destination path', () => {
+    const entries = parsePorcelainStatus('R  old.js -> new.js');
+    assert.equal(entries[0].path, 'new.js');
+    assert.equal(entries[0].untracked, false);
+  });
+
+  it('strips surrounding quotes from special-char paths', () => {
+    const entries = parsePorcelainStatus(' M "src/with space.js"');
+    assert.equal(entries[0].path, 'src/with space.js');
+  });
+
+  it('tolerates carriage returns (Windows CRLF git output)', () => {
+    const entries = parsePorcelainStatus(' M src/a.js\r\n M src/b.js\r');
+    assert.deepEqual(
+      entries.map((e) => e.path),
+      ['src/a.js', 'src/b.js'],
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// collectStrayTrackedPaths — pure unit
+// ---------------------------------------------------------------------------
+
+describe('collectStrayTrackedPaths — pure unit', () => {
+  it('returns tracked-path changes only, sorted', () => {
+    const entries = parsePorcelainStatus(' M src/z.js\nM  src/a.js');
+    assert.deepEqual(collectStrayTrackedPaths(entries), [
+      'src/a.js',
+      'src/z.js',
+    ]);
+  });
+
+  it('excludes untracked files', () => {
+    const entries = parsePorcelainStatus(' M src/a.js\n?? scratch.txt');
+    assert.deepEqual(collectStrayTrackedPaths(entries), ['src/a.js']);
+  });
+
+  it('returns empty when only untracked files are present', () => {
+    const entries = parsePorcelainStatus('?? a.txt\n?? b.txt');
+    assert.deepEqual(collectStrayTrackedPaths(entries), []);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// guardApplies — pure unit
+// ---------------------------------------------------------------------------
+
+describe('guardApplies — pure unit', () => {
+  it('is false when no worktree exists', () => {
+    assert.equal(guardApplies({ cwd: '/repo', worktreePath: null }), false);
+  });
+
+  it('is false in single-tree mode (worktree === main checkout)', () => {
+    assert.equal(guardApplies({ cwd: '/repo', worktreePath: '/repo' }), false);
+  });
+
+  it('is true when the worktree is a distinct directory', () => {
+    assert.equal(
+      guardApplies({
+        cwd: '/repo',
+        worktreePath: '/repo/.worktrees/story-1',
+      }),
+      true,
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// formatWrongTreeFinding — pure unit
+// ---------------------------------------------------------------------------
+
+describe('formatWrongTreeFinding — pure unit', () => {
+  it('names each stray file and the story id', () => {
+    const body = formatWrongTreeFinding({
+      storyId: 42,
+      strayFiles: ['src/a.js', 'src/b.js'],
+      worktreePath: '/repo/.worktrees/story-42',
+    });
+    assert.match(body, /#42/);
+    assert.match(body, /`src\/a\.js`/);
+    assert.match(body, /`src\/b\.js`/);
+  });
+
+  it('states close was aborted', () => {
+    const body = formatWrongTreeFinding({
+      storyId: 1,
+      strayFiles: ['x.js'],
+      worktreePath: '/wt',
+    });
+    assert.match(body, /aborted/i);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// runWrongTreeGuardPhase — orchestration contract tests
+// ---------------------------------------------------------------------------
+
+describe('runWrongTreeGuardPhase — AC-1: aborts on stray main-checkout edits', () => {
+  it('throws and posts a friction comment naming the stray files', async () => {
+    const storyId = 200;
+    const provider = makeProvider();
+
+    await assert.rejects(
+      () =>
+        runWrongTreeGuardPhase({
+          cwd: '/repo',
+          worktreePath: '/repo/.worktrees/story-200',
+          storyId,
+          provider,
+          progress: noop,
+          gitSpawn: spawnResult(' M .agents/scripts/foo.js\nM  docs/bar.md'),
+        }),
+      /Wrong-tree edits detected/,
+    );
+
+    const comments = await provider.getTicketComments(storyId);
+    assert.equal(comments.length, 1, 'expected one friction comment');
+    assert.equal(comments[0].type, 'friction');
+    assert.match(comments[0].body, /`\.agents\/scripts\/foo\.js`/);
+    assert.match(comments[0].body, /`docs\/bar\.md`/);
+  });
+
+  it('error message lists the stray files for the operator', async () => {
+    const provider = makeProvider();
+    await assert.rejects(
+      () =>
+        runWrongTreeGuardPhase({
+          cwd: '/repo',
+          worktreePath: '/repo/.worktrees/story-201',
+          storyId: 201,
+          provider,
+          progress: noop,
+          gitSpawn: spawnResult(' M src/leaked.js'),
+        }),
+      /src\/leaked\.js/,
+    );
+  });
+});
+
+describe('runWrongTreeGuardPhase — clean main checkout proceeds', () => {
+  it('returns applied:true and does not throw when main checkout is clean', async () => {
+    const provider = makeProvider();
+    const result = await runWrongTreeGuardPhase({
+      cwd: '/repo',
+      worktreePath: '/repo/.worktrees/story-202',
+      storyId: 202,
+      provider,
+      progress: noop,
+      gitSpawn: spawnResult(''),
+    });
+    assert.equal(result.applied, true);
+    assert.deepEqual(result.strayFiles, []);
+    const comments = await provider.getTicketComments(202);
+    assert.equal(comments.length, 0);
+  });
+
+  it('ignores untracked-only changes (scratch files are not wrong-tree edits)', async () => {
+    const provider = makeProvider();
+    const result = await runWrongTreeGuardPhase({
+      cwd: '/repo',
+      worktreePath: '/repo/.worktrees/story-203',
+      storyId: 203,
+      provider,
+      progress: noop,
+      gitSpawn: spawnResult('?? temp/scratch.json\n?? notes.txt'),
+    });
+    assert.equal(result.applied, true);
+    assert.deepEqual(result.strayFiles, []);
+    const comments = await provider.getTicketComments(203);
+    assert.equal(comments.length, 0);
+  });
+});
+
+describe('runWrongTreeGuardPhase — guard does not apply', () => {
+  it('no-ops in single-tree mode (worktree === main checkout)', async () => {
+    let probed = false;
+    const result = await runWrongTreeGuardPhase({
+      cwd: '/repo',
+      worktreePath: '/repo',
+      storyId: 204,
+      provider: makeProvider(),
+      progress: noop,
+      gitSpawn: () => {
+        probed = true;
+        return { status: 0, stdout: ' M src/a.js', stderr: '' };
+      },
+    });
+    assert.equal(result.applied, false);
+    assert.equal(probed, false, 'must not probe git when guard does not apply');
+  });
+
+  it('no-ops when no worktree exists', async () => {
+    const result = await runWrongTreeGuardPhase({
+      cwd: '/repo',
+      worktreePath: null,
+      storyId: 205,
+      provider: makeProvider(),
+      progress: noop,
+      gitSpawn: spawnResult(' M src/a.js'),
+    });
+    assert.equal(result.applied, false);
+  });
+});
+
+describe('runWrongTreeGuardPhase — fail-open on probe error', () => {
+  it('does not throw when gitSpawn throws (probe hiccup never blocks close)', async () => {
+    const result = await runWrongTreeGuardPhase({
+      cwd: '/repo',
+      worktreePath: '/repo/.worktrees/story-206',
+      storyId: 206,
+      provider: makeProvider(),
+      progress: noop,
+      gitSpawn: () => {
+        throw new Error('git not found');
+      },
+    });
+    assert.equal(result.applied, false);
+  });
+
+  it('does not throw when git status exits non-zero', async () => {
+    const result = await runWrongTreeGuardPhase({
+      cwd: '/repo',
+      worktreePath: '/repo/.worktrees/story-207',
+      storyId: 207,
+      provider: makeProvider(),
+      progress: noop,
+      gitSpawn: spawnResult('', { status: 128, stderr: 'fatal: not a repo' }),
+    });
+    assert.equal(result.applied, false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AC-2: helper workflow doc states the path-based edit-tool scope requirement.
+// ---------------------------------------------------------------------------
+
+describe('AC-2: single-story-deliver doc clarifies path-based edit scope', () => {
+  it('Step 0.5 instructs prefixing Edit/Write paths with the worktree root', () => {
+    const docPath = path.join(
+      REPO_ROOT,
+      '.agents',
+      'workflows',
+      'helpers',
+      'single-story-deliver.md',
+    );
+    const doc = nodeFs.readFileSync(docPath, 'utf8');
+    // The doc must mention the path-based Edit/Write tools (not only Bash cwd).
+    assert.match(doc, /Edit\/Write/);
+    // And it must say those paths are prefixed/scoped with the worktree root.
+    assert.match(
+      doc,
+      /absolute worktree root|prefix[^\n]*workCwd|worktree root/i,
+    );
+  });
+});


### PR DESCRIPTION
Closes #3364

_Auto-opened by `/single-story-deliver`._