### PR TITLE
Audit remediation: SHA-pin GitHub Actions (#3399)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,12 @@
 name: CI / CD
 
+# Action pinning (Story #3399): third-party `uses:` refs are pinned to full
+# 40-char commit SHAs with a `# vX.Y.Z` comment. First-party `actions/*`
+# remain on major-version tags (`@v4`) — Dependabot's `github-actions`
+# ecosystem updates those tags in-place and SHA-pinning would require a
+# manual bump per release with no automated PR surface. Revisit when
+# Dependabot action pinning is enabled repo-wide.
+
 on:
   push:
     branches: [main]
@@ -48,7 +55,7 @@ jobs:
         # third-party action's default branch is a supply-chain risk vector
         # (CWE-1357). Bump deliberately when a new TruffleHog release ships;
         # `npm run audit-security` flags any reversion to `@main` / `@master`.
-        uses: trufflesecurity/trufflehog@v3.95.3
+        uses: trufflesecurity/trufflehog@37b77001d0174ebec2fcca2bd83ff83a6d45a3ab # v3.95.3
         with:
           extra_args: --debug --only-verified
 

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,5 +1,9 @@
 name: Release Please
 
+# Action pinning (Story #3399): third-party `uses:` refs are pinned to full
+# 40-char commit SHAs with a `# vX.Y.Z` comment. First-party `actions/*`
+# remain on major-version tags (`@v4`) — see ci.yml header for rationale.
+
 on:
   push:
     branches: [main]
@@ -38,7 +42,7 @@ jobs:
       # repository secret.
       - name: Run release-please
         id: release
-        uses: googleapis/release-please-action@v5.0.0
+        uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
         with:
           token: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
           config-file: release-please-config.json


### PR DESCRIPTION
Closes #3399

_Auto-opened by `/single-story-deliver`._