### PR TITLE
Mandrel: scoped format gate fails on docs-only Stories (no formatter-eligible file in changed set) (#3410)

### DIFF
--- a/.agents/scripts/lib/close-validation.js
+++ b/.agents/scripts/lib/close-validation.js
@@ -172,6 +172,54 @@ function buildChangedFileScope(baseRef) {
   return { baseRef };
 }
 
+/**
+ * File extensions Biome's formatter can process. Used to filter the
+ * changed-file scope down to the formatter-eligible subset (Story #3410):
+ * passing only ineligible paths (e.g. a docs-only Story whose diff is all
+ * markdown) makes `biome format <files>` report "No files were processed"
+ * and exit 1, failing the gate for a Story that has nothing to format.
+ *
+ * The set mirrors Biome's handled languages (JS/TS family + JSON + CSS).
+ * Markdown, YAML, and other unhandled types are intentionally absent — the
+ * default formatter is biome, so the scope is keyed to what biome formats.
+ * Consumers who swap the formatter via `agentSettings.commands.formatCheck`
+ * do not get `changedFileScope` at all (see `buildDefaultGates`), so this
+ * filter only ever runs against the default biome command.
+ */
+const FORMATTER_ELIGIBLE_EXTENSIONS = new Set([
+  'ts',
+  'tsx',
+  'js',
+  'jsx',
+  'mjs',
+  'cjs',
+  'json',
+  'jsonc',
+  'css',
+]);
+
+/**
+ * Whether a changed path is eligible for the default (biome) formatter,
+ * decided purely by file extension. Pure function — no I/O. Exported for
+ * unit coverage (Story #3410).
+ *
+ * @param {string} filePath - A repo-relative path (forward-slash normalized).
+ * @returns {boolean}
+ */
+export function isFormatterEligible(filePath) {
+  if (typeof filePath !== 'string') return false;
+  const lastSlash = Math.max(
+    filePath.lastIndexOf('/'),
+    filePath.lastIndexOf('\\'),
+  );
+  const base = filePath.slice(lastSlash + 1);
+  const dot = base.lastIndexOf('.');
+  // No extension (dotfile-only or extensionless) → not formatter-eligible.
+  if (dot <= 0) return false;
+  const ext = base.slice(dot + 1).toLowerCase();
+  return FORMATTER_ELIGIBLE_EXTENSIONS.has(ext);
+}
+
 function applyChangedFileScope({ gate, spawnCwd, log }) {
   if (!gate.changedFileScope) {
     return { gate, cmd: gate.cmd, args: gate.args, skip: false };
@@ -180,9 +228,15 @@ function applyChangedFileScope({ gate, spawnCwd, log }) {
     cwd: spawnCwd,
     baseRef: gate.changedFileScope.baseRef,
   });
-  if (changedFiles.length === 0) {
+  // Filter to the formatter-eligible subset before deciding to skip. A
+  // non-empty diff that contains zero formatter-eligible files (e.g. a
+  // docs-only Story) must take the skip path, not invoke biome with only
+  // ineligible paths — biome reports "No files were processed" and exits 1
+  // in that case (Story #3410).
+  const eligibleFiles = changedFiles.filter(isFormatterEligible);
+  if (eligibleFiles.length === 0) {
     log(
-      `[close-validation] ⏭ ${gate.name} skipped (no changed files to format)`,
+      `[close-validation] ⏭ ${gate.name} skipped (no formatter-eligible changed files)`,
     );
     return { gate, cmd: gate.cmd, args: gate.args, skip: true };
   }
@@ -191,9 +245,14 @@ function applyChangedFileScope({ gate, spawnCwd, log }) {
       ? gate.args.slice(0, -1)
       : gate.args;
   log(
-    `[close-validation] ↳ ${gate.name} scoped to ${changedFiles.length} changed file(s) from ${gate.changedFileScope.baseRef}...HEAD`,
+    `[close-validation] ↳ ${gate.name} scoped to ${eligibleFiles.length} formatter-eligible changed file(s) from ${gate.changedFileScope.baseRef}...HEAD`,
   );
-  return { gate, cmd: gate.cmd, args: [...args, ...changedFiles], skip: false };
+  return {
+    gate,
+    cmd: gate.cmd,
+    args: [...args, ...eligibleFiles],
+    skip: false,
+  };
 }
 
 /**

--- a/tests/story-close.test.js
+++ b/tests/story-close.test.js
@@ -7,6 +7,7 @@ import { test } from 'node:test';
 import {
   buildDefaultGates,
   DEFAULT_GATES,
+  isFormatterEligible,
   resolveTypecheckCommand,
   runCloseValidation as runCloseValidationOnly,
 } from '../.agents/scripts/lib/close-validation.js';
@@ -339,6 +340,114 @@ test('runCloseValidation', async (t) => {
         ]);
         assert.deepStrictEqual(calls, []);
       }),
+  );
+
+  await t.test(
+    'default biome format gate skips when the diff contains only formatter-ineligible files (docs-only Story)',
+    async () =>
+      withTempGitRepo(async (repoDir) => {
+        runGit(repoDir, ['switch', '-c', 'story-3410']);
+        writeFileSync(
+          path.join(repoDir, 'docs.md'),
+          '# Docs\n\nNew section.\n',
+        );
+        runGit(repoDir, ['add', 'docs.md']);
+        runGit(repoDir, ['commit', '-m', 'docs: add a section']);
+
+        const gate = buildDefaultGates({ epicBranch: 'main' }).find(
+          (g) => g.name === 'format',
+        );
+        const calls = [];
+        const result = await runCloseValidationOnly({
+          cwd: repoDir,
+          gates: [gate],
+          runner: (cmd, args) => {
+            calls.push({ cmd, args });
+            return { status: 0 };
+          },
+          log: () => {},
+        });
+
+        assert.equal(result.ok, true);
+        assert.deepStrictEqual(result.skipped, [
+          { gate, reason: 'no-changed-files' },
+        ]);
+        assert.deepStrictEqual(
+          calls,
+          [],
+          'biome must not be invoked with only ineligible (.md) paths',
+        );
+      }),
+  );
+
+  await t.test(
+    'default biome format gate scopes to the eligible subset when the diff mixes eligible and ineligible files',
+    async () =>
+      withTempGitRepo(async (repoDir) => {
+        runGit(repoDir, ['switch', '-c', 'story-3410']);
+        writeFileSync(path.join(repoDir, 'src.ts'), 'export const x = 1;\n');
+        writeFileSync(path.join(repoDir, 'notes.md'), '# Notes\n');
+        writeFileSync(path.join(repoDir, 'data.json'), '{ "a": 1 }\n');
+        runGit(repoDir, ['add', 'src.ts', 'notes.md', 'data.json']);
+        runGit(repoDir, ['commit', '-m', 'feat: mixed change']);
+
+        const gate = buildDefaultGates({ epicBranch: 'main' }).find(
+          (g) => g.name === 'format',
+        );
+        const calls = [];
+        const result = await runCloseValidationOnly({
+          cwd: repoDir,
+          gates: [gate],
+          runner: (cmd, args) => {
+            calls.push({ cmd, args });
+            return { status: 0 };
+          },
+          log: () => {},
+        });
+
+        assert.equal(result.ok, true);
+        assert.equal(calls.length, 1);
+        assert.equal(calls[0].cmd, 'npx');
+        // Only the biome-eligible paths reach the formatter; .md is dropped.
+        const appended = calls[0].args.slice(2).sort();
+        assert.deepStrictEqual(appended, ['data.json', 'src.ts']);
+      }),
+  );
+
+  await t.test(
+    'isFormatterEligible classifies biome-eligible extensions',
+    () => {
+      for (const p of [
+        'a.ts',
+        'b.tsx',
+        'c.js',
+        'd.jsx',
+        'e.mjs',
+        'f.cjs',
+        'g.json',
+        'h.jsonc',
+        'i.css',
+        'nested/dir/j.ts',
+      ]) {
+        assert.equal(isFormatterEligible(p), true, `${p} should be eligible`);
+      }
+      for (const p of [
+        'README.md',
+        'docs/decisions.md',
+        'config.yaml',
+        'config.yml',
+        'notes.txt',
+        'image.png',
+        'Makefile',
+        'noext',
+      ]) {
+        assert.equal(
+          isFormatterEligible(p),
+          false,
+          `${p} should be ineligible`,
+        );
+      }
+    },
   );
 
   await t.test(


### PR DESCRIPTION
Closes #3410

_Auto-opened by `/single-story-deliver`._