### PR TITLE
confirm-merge short-circuits agent::done flip when Closes-footer already closed the issue (#3415)

### DIFF
--- a/.agents/scripts/lib/single-story/confirm-merge.js
+++ b/.agents/scripts/lib/single-story/confirm-merge.js
@@ -18,7 +18,11 @@
  *   - `{ action: 'done', merged: true }`
  *       PR merged → flipped `agent::done`, issue closed.
  *   - `{ action: 'noop', reason: 'already-done' }`
- *       Story already carries `agent::done` / issue already closed.
+ *       Story already carries `agent::done`. A closed issue *alone* does
+ *       NOT short-circuit — GitHub's `Closes #<id>` footer closes the issue
+ *       on auto-merge before this step runs, so a closed issue whose label
+ *       is still `agent::closing` must still drive the `agent::done` flip
+ *       (Story #3415).
  *   - `{ action: 'pending', reason: 'pr-open' | 'pr-not-merged' }`
  *       PR is still open (or closed-without-merge); the Story is left at
  *       `agent::closing` and the issue stays OPEN. Recoverable — re-run
@@ -93,12 +97,22 @@ export async function confirmStoryMerged({
 
   const story = await provider.getTicket(storyId);
 
-  // Idempotence: a prior confirm-merge run (or the GitHub `Closes #<id>`
-  // auto-close) may already have closed the issue / flipped agent::done.
-  if (story.state === 'closed' || story.labels?.includes(STATE_LABELS.DONE)) {
+  // Idempotence: short-circuit only when the Story already carries
+  // `agent::done`. A *closed issue alone* is NOT sufficient — GitHub
+  // auto-merge closes the issue via the `Closes #<id>` PR footer *before*
+  // this confirm step runs, so a Story whose label is still `agent::closing`
+  // routinely arrives here with `state === 'closed'`. Gating the noop on
+  // `state === 'closed'` mistook that for already-done and skipped the
+  // `agent::closing → agent::done` flip, stranding the label and the
+  // Projects board at "In Progress" (reproduced on Story #3413 / PR #3414).
+  // Requiring the `agent::done` label preserves idempotence for a genuinely
+  // finished Story while still driving the flip for the closed-by-footer
+  // case below (`transitionTicketState` is idempotent against an
+  // already-closed issue).
+  if (story.labels?.includes(STATE_LABELS.DONE)) {
     progress?.(
       'CONFIRM',
-      `⏭  Story #${storyId} already done/closed — nothing to confirm.`,
+      `⏭  Story #${storyId} already agent::done — nothing to confirm.`,
     );
     return { storyId, action: 'noop', reason: 'already-done', merged: true };
   }

--- a/tests/single-story-confirm-merge.test.js
+++ b/tests/single-story-confirm-merge.test.js
@@ -184,13 +184,13 @@ describe('confirmStoryMerged', () => {
     assert.equal(prRead, 0, 'PR state is not even read once already done');
   });
 
-  it('is idempotent: noop when the issue is already closed (GitHub Closes # auto-close raced us)', async () => {
+  it('is idempotent: noop when a closed issue also carries agent::done', async () => {
     const provider = makeFakeProvider({
       initialStory: {
         id: 3385,
         state: 'closed',
-        title: 'Auto-closed',
-        labels: ['agent::closing'],
+        title: 'Already done and closed',
+        labels: ['agent::done'],
       },
     });
     const result = await confirmStoryMerged({
@@ -203,6 +203,47 @@ describe('confirmStoryMerged', () => {
     });
     assert.equal(result.action, 'noop');
     assert.equal(result.reason, 'already-done');
+    assert.equal(provider._updates().length, 0, 'no re-flip on noop');
+  });
+
+  it('still flips to agent::done when the Closes-footer already closed the issue but the label is agent::closing (Story #3415)', async () => {
+    // Reproduces Story #3413 / PR #3414: GitHub auto-merge closes the issue
+    // via the `Closes #<id>` footer *before* confirm-merge runs, so the
+    // story arrives here with `state: 'closed'` while the label is still
+    // `agent::closing`. A closed issue alone must NOT short-circuit — the
+    // `agent::closing → agent::done` flip must still fire.
+    const provider = makeFakeProvider({
+      initialStory: {
+        id: 3385,
+        state: 'closed',
+        title: 'Auto-closed by Closes-footer',
+        labels: ['agent::closing'],
+      },
+    });
+    const notifyCalls = [];
+    const result = await confirmStoryMerged({
+      provider,
+      storyId: 3385,
+      prNumber: 42,
+      prUrl: 'https://github.com/o/r/pull/42',
+      cwd: '/repo',
+      injectedNotify: async (ticketId, payload) =>
+        notifyCalls.push({ ticketId, payload }),
+      readPrMergeStateFn: fakeMergeState('MERGED', 'x'),
+    });
+
+    // The flip fires (NOT a noop) even though the issue was already closed.
+    assert.equal(result.action, 'done');
+    assert.equal(result.merged, true);
+
+    // transitionTicketState was invoked and applied the agent::done flip.
+    const [{ patch }] = provider._updates();
+    assert.deepEqual(patch.labels.add, ['agent::done']);
+    assert.ok(patch.labels.remove.includes('agent::closing'));
+
+    // story-merged notify fires exactly once.
+    assert.equal(notifyCalls.length, 1);
+    assert.equal(notifyCalls[0].payload.event, 'story-merged');
   });
 
   it('reports flip-failed and skips the notify when the done transition throws', async () => {


### PR DESCRIPTION
Closes #3415

_Auto-opened by `/single-story-deliver`._