### PR TITLE
Framework scripts free-ride on consumer node_modules — declare + verify runtime deps (.agents has no manifest; minimatch undeclared) (#3432)

### DIFF
--- a/.agents/README.md
+++ b/.agents/README.md
@@ -138,6 +138,39 @@ Epic; standalone Stories pair [`/single-story-plan`](workflows/single-story-plan
 (idea → drafted Story Issue) with [`/story-deliver`](workflows/story-deliver.md)
 (Story Issue → merged PR).
 
+### Runtime dependencies
+
+The framework scripts under `.agents/scripts/` import a small set of
+third-party npm packages at runtime. Because `.agents/` is distributed as
+a Git submodule, it carries **no `node_modules` of its own** — the scripts
+resolve their dependencies from the **consuming repository's** install
+(Node walks `node_modules` upward from the script's location to your repo
+root). The required set is enumerated in a single vendored manifest that
+ships inside the submodule:
+
+- **[`runtime-deps.json`](runtime-deps.json)** — the single source of
+  truth. Its `dependencies` block lists the **required** packages (`ajv`,
+  `ajv-formats`, `js-yaml`, `minimatch`, `picomatch`, `string-argv`,
+  `typescript`, `typhonjs-escomplex`); its `optionalDependencies` block
+  lists packages used only behind graceful-degradation paths (`chokidar`
+  for `quality:watch`, `@commitlint/load` for commit-subject sizing).
+
+**How a consumer satisfies them:** `bootstrap` (above) merges the required
+set into your `package.json` `dependencies` and runs your package manager's
+install — so a freshly bootstrapped repo already has them. If you adopt
+`.agents/` without the bootstrap, add the `runtime-deps.json` `dependencies`
+to your own `package.json` (any compatible versions) and install.
+
+**Fail-fast guard.** The dependency-dependent entry points
+(`epic-plan-spec.js`, `epic-plan-decompose.js`, and the baseline scorers)
+run a presence check on their required deps before doing any work. When the
+install is missing, empty, or stale, they exit non-zero with an actionable
+message naming the missing packages and your install command — instead of a
+raw `ERR_MODULE_NOT_FOUND` deep inside a workflow. A drift test
+(`tests/scripts/runtime-deps-drift.test.js`) keeps the manifest honest: it
+fails if any third-party import under `.agents/scripts/**` is not declared
+in `runtime-deps.json`.
+
 ---
 
 ## Contents

--- a/.agents/runtime-deps.json
+++ b/.agents/runtime-deps.json
@@ -1,0 +1,17 @@
+{
+  "description": "Single source of truth for the third-party npm packages the .agents/ framework scripts import at runtime. This manifest ships *inside* .agents/ so it travels with the Git submodule into consumer projects. Consumers must provide these packages in the node_modules resolvable from their repository root (the framework scripts free-ride on the consumer's install). The `dependencies` block is fail-fast enforced by the preflight guard (.agents/scripts/lib/runtime-deps/ensure-installed.js); the `optionalDependencies` block lists packages that are imported behind graceful-degradation paths (try/catch or dev-only watch tooling) and are therefore declared but never preflight-blocked. A drift test (tests/scripts/runtime-deps-drift.test.js) asserts every third-party import under .agents/scripts/** is declared here. Version ranges mirror the framework's own root package.json.",
+  "dependencies": {
+    "ajv": "^8.20.0",
+    "ajv-formats": "^3.0.1",
+    "js-yaml": "^4.1.1",
+    "minimatch": "^10.0.0",
+    "picomatch": "^4.0.4",
+    "string-argv": "^0.3.2",
+    "typescript": ">=5.0.0",
+    "typhonjs-escomplex": "^0.1.0"
+  },
+  "optionalDependencies": {
+    "@commitlint/load": "^21.0.0",
+    "chokidar": "^5.0.0"
+  }
+}

--- a/.agents/scripts/check-baselines.js
+++ b/.agents/scripts/check-baselines.js
@@ -32,6 +32,10 @@
 //   3 EXIT_CONFIG      — config resolution failure (mapped by main()).
 //   4 EXIT_REGRESSION  — at least one head-vs-base regression.
 
+// Fail-fast if the framework's runtime deps are not installed — must be the
+// first import so the check runs before any third-party-importing sibling
+// module is evaluated (Story #3432).
+import './lib/runtime-deps/ensure-installed.js';
 import { EXIT_CONFIG } from './lib/baselines/exit-codes.js';
 import { runAsCli } from './lib/cli-utils.js';
 import {

--- a/.agents/scripts/epic-plan-decompose.js
+++ b/.agents/scripts/epic-plan-decompose.js
@@ -44,6 +44,10 @@
  * refactor implementation.
  */
 
+// Fail-fast if the framework's runtime deps are not installed — must be the
+// first import so the check runs before any third-party-importing sibling
+// module is evaluated (Story #3432).
+import './lib/runtime-deps/ensure-installed.js';
 import { runAsCli } from './lib/cli-utils.js';
 import { main } from './lib/orchestration/epic-plan-decompose/phases/cli.js';
 import {

--- a/.agents/scripts/epic-plan-spec.js
+++ b/.agents/scripts/epic-plan-spec.js
@@ -29,6 +29,10 @@
  * entry that wires argv → phases.
  */
 
+// Fail-fast if the framework's runtime deps are not installed — must be the
+// first import so the check runs before any third-party-importing sibling
+// module is evaluated (Story #3432).
+import './lib/runtime-deps/ensure-installed.js';
 import { readFile } from 'node:fs/promises';
 import { parseArgs } from 'node:util';
 import {

--- a/.agents/scripts/lib/bootstrap/project-bootstrap.js
+++ b/.agents/scripts/lib/bootstrap/project-bootstrap.js
@@ -14,15 +14,19 @@ import { spawnSync } from 'node:child_process';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
+import { loadRuntimeDepsManifest } from '../runtime-deps/manifest.js';
 import { applyQualityBootstrap } from './quality-bootstrap.js';
 
+/**
+ * The framework's required runtime dependencies, seeded into a consumer's
+ * `package.json` during bootstrap. Derived from the vendored SSOT manifest
+ * (`.agents/runtime-deps.json`) so there is exactly one place the list lives
+ * — the same manifest the preflight guard and drift test read (Story #3432).
+ * `optionalDependencies` are intentionally not seeded: they sit behind
+ * graceful-degradation paths and consumers opt into them only if needed.
+ */
 export const REQUIRED_RUNTIME_DEPS = Object.freeze({
-  ajv: '^8.20.0',
-  'ajv-formats': '^3.0.1',
-  'js-yaml': '^4.1.1',
-  picomatch: '^4.0.4',
-  'string-argv': '^0.3.2',
-  'typhonjs-escomplex': '^0.1.0',
+  ...loadRuntimeDepsManifest().dependencies,
 });
 
 export const SYNC_COMMAND = 'node .agents/scripts/sync-claude-commands.js';

--- a/.agents/scripts/lib/runtime-deps/ensure-installed.js
+++ b/.agents/scripts/lib/runtime-deps/ensure-installed.js
@@ -1,0 +1,100 @@
+/**
+ * runtime-deps/ensure-installed — fail-fast guard for framework runtime deps.
+ *
+ * Importing this module runs the dependency-presence check as a side effect:
+ * if any package in `.agents/runtime-deps.json`'s `dependencies` block cannot
+ * be resolved from the framework's `node_modules` (i.e. the consumer's
+ * install is missing, empty, or stale), it prints an actionable remediation
+ * message and exits non-zero — *before* the entry point's heavier imports
+ * reach the first `import 'ajv'` and throw an opaque `ERR_MODULE_NOT_FOUND`
+ * (Story #3432).
+ *
+ * Why a side-effect-on-import (rather than a function the entry point calls):
+ * ESM evaluates a module's imports in source order, depth-first, *before* the
+ * module body runs. A function call in `main()` would therefore execute only
+ * after the third-party-importing sibling modules had already been evaluated
+ * (and already thrown). By making each target entry point's *first* import a
+ * side-effect import of this module, the check runs first and short-circuits a
+ * broken install with a clear message.
+ *
+ * The guard only ever exits when a *required* dependency is genuinely
+ * missing. With a healthy install (CI, tests, normal runs) it is a no-op, so
+ * it is safe for entry points imported by the test suite. `optionalDependencies`
+ * are intentionally not checked — they sit behind graceful-degradation paths.
+ *
+ * Set `MANDREL_SKIP_DEP_PREFLIGHT=1` to disable the side effect (escape hatch
+ * for tooling that imports an entry point in an environment that deliberately
+ * lacks the framework deps).
+ */
+
+import { createRequire } from 'node:module';
+import { loadRuntimeDepsManifest } from './manifest.js';
+import {
+  checkRuntimeDeps,
+  detectPackageManager,
+  formatMissingDepsMessage,
+} from './preflight.js';
+
+// `require.resolve` bound to this module's location walks `node_modules`
+// upward from `.agents/scripts/lib/runtime-deps/` to the consumer root —
+// exactly the resolution path the framework's third-party imports follow.
+const frameworkRequire = createRequire(import.meta.url);
+
+/**
+ * Run the dependency-presence check and, on failure, write the remediation
+ * message and exit. Seams (`requireResolve`, `cwd`, `stderr`, `exit`,
+ * `manifest`) make it fully testable without touching the real process.
+ *
+ * @param {{
+ *   requireResolve?: (specifier: string) => string,
+ *   cwd?: string,
+ *   stderr?: { write: (s: string) => void },
+ *   exit?: (code: number) => void,
+ *   manifest?: { required: string[] },
+ * }} [opts]
+ * @returns {{ ok: boolean, missing: string[] }}
+ */
+export function ensureRuntimeDepsInstalled(opts = {}) {
+  const {
+    requireResolve = (s) => frameworkRequire.resolve(s),
+    cwd = process.cwd(),
+    stderr = process.stderr,
+    exit = process.exit,
+    manifest = safeLoadManifest(),
+  } = opts;
+
+  // A manifest we cannot read is a packaging defect the drift test owns —
+  // never let the guard kill an otherwise-healthy process over it.
+  if (!manifest) return { ok: true, missing: [] };
+
+  const result = checkRuntimeDeps({
+    required: manifest.required,
+    resolve: requireResolve,
+  });
+  if (result.ok) return result;
+
+  const packageManager = detectPackageManager(cwd);
+  stderr.write(
+    `${formatMissingDepsMessage(result.missing, { root: cwd, packageManager })}\n`,
+  );
+  exit(1);
+  return result;
+}
+
+/**
+ * Load the manifest, swallowing a read/parse failure to `null` so the guard
+ * stays inert on a packaging defect (see `ensureRuntimeDepsInstalled`).
+ *
+ * @returns {{ required: string[] } | null}
+ */
+function safeLoadManifest() {
+  try {
+    return loadRuntimeDepsManifest();
+  } catch {
+    return null;
+  }
+}
+
+if (process.env.MANDREL_SKIP_DEP_PREFLIGHT !== '1') {
+  ensureRuntimeDepsInstalled();
+}

--- a/.agents/scripts/lib/runtime-deps/manifest.js
+++ b/.agents/scripts/lib/runtime-deps/manifest.js
@@ -1,0 +1,96 @@
+/**
+ * runtime-deps/manifest — loader for the framework's vendored runtime-dep SSOT.
+ *
+ * `.agents/runtime-deps.json` is the single source of truth for the
+ * third-party npm packages the framework scripts import at runtime
+ * (Story #3432). It ships *inside* `.agents/` so it travels with the Git
+ * submodule into consumer projects. This module is the only reader of that
+ * file — the bootstrap seeder (`project-bootstrap.js`), the preflight guard
+ * (`ensure-installed.js`), and the import-vs-manifest drift test all derive
+ * their dependency lists from `loadRuntimeDepsManifest()` so there is exactly
+ * one place the list lives.
+ *
+ * The loader stays on Node builtins only (`node:fs`, `node:path`,
+ * `node:url`) so it can run inside the preflight guard *before* any
+ * third-party package is imported — that is the whole point of the guard.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+
+/**
+ * Absolute path to the vendored manifest. `HERE` is
+ * `.agents/scripts/lib/runtime-deps/`; the manifest sits at the `.agents/`
+ * root, three directories up.
+ */
+export const MANIFEST_PATH = path.resolve(
+  HERE,
+  '..',
+  '..',
+  '..',
+  'runtime-deps.json',
+);
+
+/**
+ * @typedef {object} RuntimeDepsManifest
+ * @property {Record<string,string>} dependencies        — required runtime
+ *   packages (name → semver range). Fail-fast enforced by the preflight.
+ * @property {Record<string,string>} optionalDependencies — packages imported
+ *   behind graceful-degradation paths; declared but never preflight-blocked.
+ * @property {string[]} required — `Object.keys(dependencies)`.
+ * @property {string[]} optional — `Object.keys(optionalDependencies)`.
+ * @property {Set<string>} declared — union of required + optional names.
+ */
+
+/**
+ * Read, parse, and structurally validate the runtime-deps manifest.
+ *
+ * Throws a clear `Error` when the file is missing or malformed so the
+ * drift test and bootstrap seeder fail loudly on a packaging regression,
+ * rather than silently treating the dependency set as empty.
+ *
+ * @param {string} [manifestPath=MANIFEST_PATH]
+ * @returns {RuntimeDepsManifest}
+ */
+export function loadRuntimeDepsManifest(manifestPath = MANIFEST_PATH) {
+  let raw;
+  try {
+    raw = fs.readFileSync(manifestPath, 'utf8');
+  } catch (err) {
+    throw new Error(
+      `runtime-deps manifest not found at ${manifestPath}: ${err?.message ?? err}`,
+    );
+  }
+  let parsed;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (err) {
+    throw new Error(
+      `runtime-deps manifest at ${manifestPath} is not valid JSON: ${err?.message ?? err}`,
+    );
+  }
+  const dependencies = parsed.dependencies;
+  if (!dependencies || typeof dependencies !== 'object') {
+    throw new Error(
+      `runtime-deps manifest at ${manifestPath} is missing a "dependencies" object`,
+    );
+  }
+  const optionalDependencies =
+    parsed.optionalDependencies &&
+    typeof parsed.optionalDependencies === 'object'
+      ? parsed.optionalDependencies
+      : {};
+  return {
+    dependencies,
+    optionalDependencies,
+    required: Object.keys(dependencies),
+    optional: Object.keys(optionalDependencies),
+    declared: new Set([
+      ...Object.keys(dependencies),
+      ...Object.keys(optionalDependencies),
+    ]),
+  };
+}

--- a/.agents/scripts/lib/runtime-deps/preflight.js
+++ b/.agents/scripts/lib/runtime-deps/preflight.js
@@ -1,0 +1,78 @@
+/**
+ * runtime-deps/preflight — pure helpers for the dependency-presence check.
+ *
+ * These functions hold no side effects so they are unit-testable in
+ * isolation: `checkRuntimeDeps` takes an injected `resolve` seam,
+ * `detectPackageManager` takes an injected `exists` seam, and
+ * `formatMissingDepsMessage` is a pure string builder. The side-effecting
+ * guard that wires them to the real process lives in `ensure-installed.js`.
+ *
+ * Builtins only — this module runs *before* any third-party package is
+ * imported, so importing a third-party here would defeat its own purpose.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+
+/**
+ * Resolve each required package via the injected `resolve` seam and collect
+ * the ones that fail. `resolve` is typically `require.resolve` bound to the
+ * framework module location; it throws `MODULE_NOT_FOUND` when a package is
+ * absent from the resolvable `node_modules`.
+ *
+ * @param {{ required: string[], resolve: (specifier: string) => string }} opts
+ * @returns {{ ok: boolean, missing: string[] }}
+ */
+export function checkRuntimeDeps({ required, resolve }) {
+  const missing = [];
+  for (const dep of required) {
+    try {
+      resolve(dep);
+    } catch {
+      missing.push(dep);
+    }
+  }
+  return { ok: missing.length === 0, missing };
+}
+
+/**
+ * Detect the consumer's package manager from lockfile presence so the
+ * remediation message names the right install command. Defaults to `npm`.
+ * Mirrors `bootstrap/project-bootstrap.js#detectPackageManager` but stays
+ * decoupled (and seam-injectable) so the preflight imports nothing heavy.
+ *
+ * @param {string} root
+ * @param {(p: string) => boolean} [exists=fs.existsSync]
+ * @returns {'pnpm'|'yarn'|'npm'}
+ */
+export function detectPackageManager(root, exists = fs.existsSync) {
+  if (exists(path.join(root, 'pnpm-lock.yaml'))) return 'pnpm';
+  if (exists(path.join(root, 'yarn.lock'))) return 'yarn';
+  return 'npm';
+}
+
+/** Map a detected package manager to its install command. */
+function installCommand(packageManager) {
+  if (packageManager === 'pnpm') return 'pnpm install';
+  if (packageManager === 'yarn') return 'yarn install';
+  return 'npm install';
+}
+
+/**
+ * Build the actionable remediation message naming the missing packages and
+ * the consumer's install command. This is what replaces the opaque raw
+ * `ERR_MODULE_NOT_FOUND` stack trace.
+ *
+ * @param {string[]} missing
+ * @param {{ root: string, packageManager: 'pnpm'|'yarn'|'npm' }} opts
+ * @returns {string}
+ */
+export function formatMissingDepsMessage(missing, { root, packageManager }) {
+  return [
+    'Framework runtime dependencies are not installed.',
+    `Missing from node_modules/: ${missing.join(', ')}.`,
+    `The .agents/ framework scripts require these packages (declared in ` +
+      `.agents/runtime-deps.json) to be installed in this repository.`,
+    `Run \`${installCommand(packageManager)}\` in ${root}, then re-run this command.`,
+  ].join('\n');
+}

--- a/.agents/scripts/lib/runtime-deps/scan-imports.js
+++ b/.agents/scripts/lib/runtime-deps/scan-imports.js
@@ -1,0 +1,202 @@
+/**
+ * runtime-deps/scan-imports — extract third-party package imports from source.
+ *
+ * Powers the import-vs-manifest drift test (Story #3432): it walks
+ * `.agents/scripts/**` and reports every third-party (non-builtin,
+ * non-relative) top-level package the framework imports, so the test can
+ * assert each one is declared in `.agents/runtime-deps.json`.
+ *
+ * Robustness is the whole game here. A naive `from ['"]...['"]` regex also
+ * matches prose inside strings and comments (e.g. a log line containing the
+ * word "from 'x'"), which would invent phantom dependencies. Two guards
+ * prevent that:
+ *
+ *   1. Static `import` / `export … from` matches are anchored to the start
+ *      of a line — a real import statement begins the line; prose inside a
+ *      template literal does not.
+ *   2. Every extracted specifier's *top-level* package name is validated
+ *      against the npm package-name grammar. Names with spaces, uppercase,
+ *      or stray punctuation (i.e. accidental prose captures) are rejected.
+ *
+ * Node builtins (`node:fs`, `path`, …) and relative/absolute specifiers are
+ * excluded. Subpath specifiers (`ajv/dist/2020.js`, `@scope/pkg/sub`) are
+ * collapsed to their installable top-level name (`ajv`, `@scope/pkg`).
+ */
+
+import fs from 'node:fs';
+import { builtinModules } from 'node:module';
+import path from 'node:path';
+
+/** Node builtins, with and without the `node:` prefix. */
+export const BUILTIN_MODULES = new Set([
+  ...builtinModules,
+  ...builtinModules.map((m) => `node:${m}`),
+]);
+
+/**
+ * npm package-name grammar (top-level, optionally scoped). Lowercase,
+ * digits, and a small punctuation set only — deliberately strict so that
+ * accidental prose captures are rejected.
+ */
+const PACKAGE_NAME = /^(?:@[a-z0-9-~][a-z0-9-._~]*\/)?[a-z0-9-~][a-z0-9-._~]*$/;
+
+/**
+ * Collapse an import specifier to its installable top-level package name.
+ * `@scope/pkg/sub` → `@scope/pkg`; `pkg/sub` → `pkg`.
+ *
+ * @param {string} specifier
+ * @returns {string}
+ */
+export function toTopLevelPackage(specifier) {
+  const segments = specifier.split('/');
+  if (specifier.startsWith('@')) return segments.slice(0, 2).join('/');
+  return segments[0];
+}
+
+/**
+ * True when `name` is a syntactically valid npm package name.
+ *
+ * @param {string} name
+ * @returns {boolean}
+ */
+export function isValidPackageName(name) {
+  return typeof name === 'string' && PACKAGE_NAME.test(name);
+}
+
+// Anchored static import / re-export: the statement must start the line.
+const STATIC_FROM =
+  /^\s*(?:import|export)\b[^\n;]*?\bfrom\s*['"]([^'"]+)['"]/gm;
+// Anchored side-effect import at line start.
+const SIDE_EFFECT = /^\s*import\s*['"]([^'"]+)['"]/gm;
+// `require(...)` and dynamic `import(...)` may appear mid-expression.
+const CALL_FORM = /\b(?:require|import)\s*\(\s*['"]([^'"]+)['"]/g;
+
+/**
+ * Remove `//` line comments and block comments while preserving string and
+ * template literals (which carry the import specifiers we extract). A
+ * char-by-char state machine is used rather than a regex so that comment
+ * markers inside string literals (e.g. a `https://` URL) are not mistaken
+ * for comments, and example import syntax inside *comments* (e.g. a
+ * `// require('x')` doc line) does not register as a phantom dependency.
+ *
+ * @param {string} source
+ * @returns {string}
+ */
+export function stripComments(source) {
+  let out = '';
+  let i = 0;
+  const n = source.length;
+  while (i < n) {
+    const ch = source[i];
+    const next = source[i + 1];
+    // Enter a string / template literal — copy verbatim until it closes.
+    if (ch === '"' || ch === "'" || ch === '`') {
+      const quote = ch;
+      out += ch;
+      i += 1;
+      while (i < n) {
+        const c = source[i];
+        out += c;
+        if (c === '\\') {
+          // Copy the escaped char too, then continue.
+          if (i + 1 < n) out += source[i + 1];
+          i += 2;
+          continue;
+        }
+        i += 1;
+        if (c === quote) break;
+      }
+      continue;
+    }
+    // Line comment — drop to end of line (keep the newline).
+    if (ch === '/' && next === '/') {
+      i += 2;
+      while (i < n && source[i] !== '\n') i += 1;
+      continue;
+    }
+    // Block comment — drop until the closing `*/`.
+    if (ch === '/' && next === '*') {
+      i += 2;
+      while (i < n && !(source[i] === '*' && source[i + 1] === '/')) i += 1;
+      i += 2;
+      continue;
+    }
+    out += ch;
+    i += 1;
+  }
+  return out;
+}
+
+/**
+ * Extract the set of third-party top-level package names imported by a
+ * single source string.
+ *
+ * @param {string} source
+ * @returns {Set<string>}
+ */
+export function extractThirdPartyImports(source) {
+  const found = new Set();
+  const cleaned = stripComments(source);
+  for (const re of [STATIC_FROM, SIDE_EFFECT, CALL_FORM]) {
+    re.lastIndex = 0;
+    let match = re.exec(cleaned);
+    while (match !== null) {
+      const specifier = match[1];
+      // Advance the iterator up front so every `continue` below is safe.
+      match = re.exec(cleaned);
+      if (
+        specifier.startsWith('.') ||
+        specifier.startsWith('/') ||
+        specifier.startsWith('node:') ||
+        specifier.startsWith('#')
+      ) {
+        continue;
+      }
+      const top = toTopLevelPackage(specifier);
+      if (!isValidPackageName(top)) continue;
+      if (BUILTIN_MODULES.has(top)) continue;
+      found.add(top);
+    }
+  }
+  return found;
+}
+
+/**
+ * Recursively collect every `.js` file under `dir`.
+ *
+ * @param {string} dir
+ * @returns {string[]}
+ */
+export function listJsFiles(dir) {
+  const out = [];
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      out.push(...listJsFiles(full));
+    } else if (entry.isFile() && entry.name.endsWith('.js')) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+/**
+ * Scan every `.js` file under `dir` and map each third-party top-level
+ * package to the (relative) files that import it.
+ *
+ * @param {string} dir — directory root to scan (e.g. `.agents/scripts`).
+ * @returns {{ packages: Set<string>, byPackage: Map<string, string[]> }}
+ */
+export function scanThirdPartyImports(dir) {
+  const byPackage = new Map();
+  for (const file of listJsFiles(dir)) {
+    const source = fs.readFileSync(file, 'utf8');
+    const rel = path.relative(dir, file);
+    for (const pkg of extractThirdPartyImports(source)) {
+      const files = byPackage.get(pkg) ?? [];
+      files.push(rel);
+      byPackage.set(pkg, files);
+    }
+  }
+  return { packages: new Set(byPackage.keys()), byPackage };
+}

--- a/.agents/scripts/update-crap-baseline.js
+++ b/.agents/scripts/update-crap-baseline.js
@@ -1,3 +1,7 @@
+// Fail-fast if the framework's runtime deps are not installed — must be the
+// first import so the check runs before any third-party-importing sibling
+// module is evaluated (Story #3432).
+import './lib/runtime-deps/ensure-installed.js';
 import path from 'node:path';
 import { buildWriterScopeArgs } from './lib/baselines/diff-scope-cli.js';
 import { write, writeFile } from './lib/baselines/writer.js';

--- a/.agents/scripts/update-maintainability-baseline.js
+++ b/.agents/scripts/update-maintainability-baseline.js
@@ -27,6 +27,10 @@
  * story-close would have produced for the same scope.
  */
 
+// Fail-fast if the framework's runtime deps are not installed — must be the
+// first import so the check runs before any third-party-importing sibling
+// module is evaluated (Story #3432).
+import './lib/runtime-deps/ensure-installed.js';
 import path from 'node:path';
 import { parseDiffScopeFlag } from './lib/baselines/diff-scope-cli.js';
 import { filterExcludedRows } from './lib/baselines/kinds/maintainability.js';

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
     "": {
       "name": "mandrel",
       "version": "1.42.0",
-      "license": "MIT",
+      "license": "ISC",
       "dependencies": {
         "ajv": "^8.20.0",
         "ajv-formats": "^3.0.1",
@@ -637,6 +637,31 @@
         "conventional-commits-parser": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/wasi-threads": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,11 +7,12 @@
     "": {
       "name": "mandrel",
       "version": "1.42.0",
-      "license": "ISC",
+      "license": "MIT",
       "dependencies": {
         "ajv": "^8.20.0",
         "ajv-formats": "^3.0.1",
         "js-yaml": "^4.1.1",
+        "minimatch": "^10.0.0",
         "picomatch": "^4.0.4",
         "string-argv": "^0.3.2",
         "typescript": ">=5.0.0",
@@ -636,31 +637,6 @@
         "conventional-commits-parser": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@emnapi/core": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
-      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
-      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/wasi-threads": {
@@ -2057,7 +2033,6 @@
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
       "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "18 || 20 || >=22"
@@ -2067,7 +2042,6 @@
       "version": "5.0.6",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
       "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
@@ -4229,7 +4203,6 @@
       "version": "10.2.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
       "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
-      "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "brace-expansion": "^5.0.5"

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "ajv": "^8.20.0",
     "ajv-formats": "^3.0.1",
     "js-yaml": "^4.1.1",
+    "minimatch": "^10.0.0",
     "picomatch": "^4.0.4",
     "string-argv": "^0.3.2",
     "typescript": ">=5.0.0",

--- a/tests/scripts/runtime-deps-drift.test.js
+++ b/tests/scripts/runtime-deps-drift.test.js
@@ -1,0 +1,90 @@
+/**
+ * runtime-deps-drift.test — Story #3432
+ *
+ * Asserts the framework's vendored runtime-dependency manifest
+ * (`.agents/runtime-deps.json`) stays honest against the actual third-party
+ * imports under `.agents/scripts/**`:
+ *
+ *   1. Every third-party package imported by the framework scripts is
+ *      declared in the manifest (the import-vs-manifest drift guard). If a
+ *      new import is added without declaring it — or a declaration is
+ *      removed while the import remains — this test fails.
+ *   2. The manifest covers (at least) the eight required runtime packages
+ *      named in the Story, and `minimatch` specifically is declared (the
+ *      historical gap this Story closes).
+ *   3. A negative control proves the drift comparison actually fails when a
+ *      declaration is removed — i.e. the test is not vacuously green.
+ */
+
+import assert from 'node:assert/strict';
+import path from 'node:path';
+import { describe, it } from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+import { loadRuntimeDepsManifest } from '../../.agents/scripts/lib/runtime-deps/manifest.js';
+import { scanThirdPartyImports } from '../../.agents/scripts/lib/runtime-deps/scan-imports.js';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(HERE, '..', '..');
+const SCRIPTS_DIR = path.join(REPO_ROOT, '.agents', 'scripts');
+
+// The required runtime packages the Story enumerates explicitly.
+const REQUIRED_NAMED = [
+  'ajv',
+  'ajv-formats',
+  'js-yaml',
+  'minimatch',
+  'picomatch',
+  'string-argv',
+  'typescript',
+  'typhonjs-escomplex',
+];
+
+describe('runtime-deps drift', () => {
+  it('declares every third-party import under .agents/scripts/**', () => {
+    const { declared } = loadRuntimeDepsManifest();
+    const { packages, byPackage } = scanThirdPartyImports(SCRIPTS_DIR);
+
+    const undeclared = [...packages]
+      .filter((pkg) => !declared.has(pkg))
+      .map((pkg) => `${pkg} (imported by ${byPackage.get(pkg).join(', ')})`);
+
+    assert.deepEqual(
+      undeclared,
+      [],
+      `Undeclared third-party imports found. Add them to .agents/runtime-deps.json:\n${undeclared.join('\n')}`,
+    );
+  });
+
+  it('covers the required runtime packages, including minimatch', () => {
+    const { dependencies } = loadRuntimeDepsManifest();
+    for (const pkg of REQUIRED_NAMED) {
+      assert.ok(
+        Object.hasOwn(dependencies, pkg),
+        `expected ${pkg} in runtime-deps.json "dependencies"`,
+      );
+    }
+    // The historical gap: minimatch was imported but never declared.
+    assert.ok(dependencies.minimatch, 'minimatch must be declared');
+  });
+
+  it('fails the drift check when a declaration is removed (negative control)', () => {
+    const { packages } = scanThirdPartyImports(SCRIPTS_DIR);
+    assert.ok(packages.has('minimatch'), 'precondition: minimatch is imported');
+
+    // Simulate a manifest that dropped `minimatch` while the import remains.
+    const { declared } = loadRuntimeDepsManifest();
+    const declaredWithoutMinimatch = new Set(
+      [...declared].filter((pkg) => pkg !== 'minimatch'),
+    );
+    const undeclared = [...packages].filter(
+      (pkg) => !declaredWithoutMinimatch.has(pkg),
+    );
+
+    assert.deepEqual(
+      undeclared,
+      ['minimatch'],
+      'drift comparison must flag an imported-but-undeclared package',
+    );
+  });
+});

--- a/tests/scripts/runtime-deps-preflight.test.js
+++ b/tests/scripts/runtime-deps-preflight.test.js
@@ -1,0 +1,231 @@
+/**
+ * runtime-deps-preflight.test — Story #3432
+ *
+ * Exercises the dependency-presence preflight and its supporting pieces:
+ *
+ *   1. loadRuntimeDepsManifest — parses the SSOT, throws on missing/malformed.
+ *   2. checkRuntimeDeps        — collects unresolvable required packages.
+ *   3. detectPackageManager    — lockfile-driven manager detection.
+ *   4. formatMissingDepsMessage— actionable remediation string.
+ *   5. ensureRuntimeDepsInstalled — no-op on a healthy install; on a missing
+ *      dep it writes the remediation message and exits non-zero (the
+ *      fail-fast behaviour that replaces a raw ERR_MODULE_NOT_FOUND).
+ *   6. scan-imports            — robust third-party import extraction, incl.
+ *      comment stripping, scope/subpath collapse, and name validation.
+ */
+
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { describe, it } from 'node:test';
+import { ensureRuntimeDepsInstalled } from '../../.agents/scripts/lib/runtime-deps/ensure-installed.js';
+import { loadRuntimeDepsManifest } from '../../.agents/scripts/lib/runtime-deps/manifest.js';
+import {
+  checkRuntimeDeps,
+  detectPackageManager,
+  formatMissingDepsMessage,
+} from '../../.agents/scripts/lib/runtime-deps/preflight.js';
+import {
+  extractThirdPartyImports,
+  isValidPackageName,
+  stripComments,
+  toTopLevelPackage,
+} from '../../.agents/scripts/lib/runtime-deps/scan-imports.js';
+
+function tmpFile(name, body) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'mandrel-rtdeps-'));
+  const file = path.join(dir, name);
+  fs.writeFileSync(file, body, 'utf8');
+  return file;
+}
+
+describe('loadRuntimeDepsManifest', () => {
+  it('parses the vendored manifest with required + optional sets', () => {
+    const m = loadRuntimeDepsManifest();
+    assert.ok(m.required.includes('ajv'));
+    assert.ok(m.required.includes('minimatch'));
+    assert.ok(m.declared.has('ajv'));
+    // optional deps are declared but kept out of the required (preflight) set.
+    assert.ok(m.optional.includes('chokidar'));
+    assert.ok(!m.required.includes('chokidar'));
+    assert.ok(m.declared.has('chokidar'));
+  });
+
+  it('throws when the manifest file is missing', () => {
+    assert.throws(
+      () => loadRuntimeDepsManifest('/no/such/runtime-deps.json'),
+      /not found/,
+    );
+  });
+
+  it('throws when the manifest JSON is malformed', () => {
+    const file = tmpFile('runtime-deps.json', '{ not json');
+    assert.throws(() => loadRuntimeDepsManifest(file), /not valid JSON/);
+  });
+
+  it('throws when the dependencies object is absent', () => {
+    const file = tmpFile('runtime-deps.json', '{"optionalDependencies":{}}');
+    assert.throws(
+      () => loadRuntimeDepsManifest(file),
+      /missing a "dependencies"/,
+    );
+  });
+});
+
+describe('checkRuntimeDeps', () => {
+  it('is ok when every required package resolves', () => {
+    const result = checkRuntimeDeps({
+      required: ['ajv', 'minimatch'],
+      resolve: (s) => `/resolved/${s}`,
+    });
+    assert.deepEqual(result, { ok: true, missing: [] });
+  });
+
+  it('collects the packages that fail to resolve', () => {
+    const result = checkRuntimeDeps({
+      required: ['ajv', 'minimatch', 'js-yaml'],
+      resolve: (s) => {
+        if (s === 'minimatch') throw new Error('MODULE_NOT_FOUND');
+        return `/resolved/${s}`;
+      },
+    });
+    assert.equal(result.ok, false);
+    assert.deepEqual(result.missing, ['minimatch']);
+  });
+});
+
+describe('detectPackageManager', () => {
+  it('prefers pnpm, then yarn, then npm', () => {
+    assert.equal(
+      detectPackageManager('/r', (p) => p.endsWith('pnpm-lock.yaml')),
+      'pnpm',
+    );
+    assert.equal(
+      detectPackageManager('/r', (p) => p.endsWith('yarn.lock')),
+      'yarn',
+    );
+    assert.equal(
+      detectPackageManager('/r', () => false),
+      'npm',
+    );
+  });
+});
+
+describe('formatMissingDepsMessage', () => {
+  it('names the missing packages, root, and install command', () => {
+    const msg = formatMissingDepsMessage(['ajv', 'minimatch'], {
+      root: '/consumer',
+      packageManager: 'pnpm',
+    });
+    assert.match(msg, /not installed/);
+    assert.match(msg, /ajv, minimatch/);
+    assert.match(msg, /pnpm install/);
+    assert.match(msg, /\/consumer/);
+    assert.match(msg, /runtime-deps\.json/);
+  });
+});
+
+describe('ensureRuntimeDepsInstalled', () => {
+  it('no-ops when all required deps resolve', () => {
+    let exited = null;
+    let written = '';
+    const result = ensureRuntimeDepsInstalled({
+      requireResolve: (s) => `/resolved/${s}`,
+      cwd: '/consumer',
+      stderr: { write: (s) => (written += s) },
+      exit: (c) => (exited = c),
+      manifest: { required: ['ajv', 'minimatch'] },
+    });
+    assert.deepEqual(result, { ok: true, missing: [] });
+    assert.equal(exited, null);
+    assert.equal(written, '');
+  });
+
+  it('writes a remediation message and exits 1 on a missing dep', () => {
+    let exited = null;
+    let written = '';
+    ensureRuntimeDepsInstalled({
+      requireResolve: (s) => {
+        if (s === 'ajv') throw new Error('MODULE_NOT_FOUND');
+        return `/resolved/${s}`;
+      },
+      cwd: '/consumer',
+      stderr: { write: (s) => (written += s) },
+      exit: (c) => (exited = c),
+      manifest: { required: ['ajv', 'minimatch'] },
+    });
+    assert.equal(exited, 1);
+    assert.match(written, /Framework runtime dependencies are not installed/);
+    assert.match(written, /ajv/);
+  });
+
+  it('stays inert (ok, no exit) when the manifest cannot be loaded', () => {
+    let exited = null;
+    const result = ensureRuntimeDepsInstalled({
+      requireResolve: () => {
+        throw new Error('should not be called');
+      },
+      exit: (c) => (exited = c),
+      manifest: null,
+    });
+    assert.deepEqual(result, { ok: true, missing: [] });
+    assert.equal(exited, null);
+  });
+});
+
+describe('scan-imports extraction', () => {
+  it('detects static, side-effect, require, and dynamic-import forms', () => {
+    const src = [
+      "import ajv from 'ajv';",
+      "export { x } from 'ajv-formats';",
+      "import 'string-argv';",
+      "const y = require('js-yaml');",
+      "const z = await import('picomatch');",
+    ].join('\n');
+    const found = extractThirdPartyImports(src);
+    assert.deepEqual([...found].sort(), [
+      'ajv',
+      'ajv-formats',
+      'js-yaml',
+      'picomatch',
+      'string-argv',
+    ]);
+  });
+
+  it('ignores builtins, relative, and subpath-imports collapse to top-level', () => {
+    const src = [
+      "import fs from 'node:fs';",
+      "import path from 'path';",
+      "import local from './local.js';",
+      "import sub from 'ajv/dist/2020.js';",
+      "import scoped from '@commitlint/load';",
+    ].join('\n');
+    const found = extractThirdPartyImports(src);
+    assert.deepEqual([...found].sort(), ['@commitlint/load', 'ajv']);
+  });
+
+  it('does not register import syntax that appears inside comments', () => {
+    const src = [
+      "// require('phantom-pkg') is just an example in a comment",
+      "/* import x from 'another-phantom'; */",
+      "import real from 'minimatch';",
+    ].join('\n');
+    const found = extractThirdPartyImports(src);
+    assert.deepEqual([...found], ['minimatch']);
+  });
+
+  it('preserves string literals (URLs with //) while stripping comments', () => {
+    const src = "const url = 'https://example.com'; // trailing comment";
+    assert.match(stripComments(src), /https:\/\/example\.com/);
+    assert.doesNotMatch(stripComments(src), /trailing comment/);
+  });
+
+  it('rejects invalid package names and collapses scopes', () => {
+    assert.equal(isValidPackageName('ajv'), true);
+    assert.equal(isValidPackageName('@scope/pkg'), true);
+    assert.equal(isValidPackageName('Not A Package'), false);
+    assert.equal(toTopLevelPackage('ajv/dist/2020.js'), 'ajv');
+    assert.equal(toTopLevelPackage('@scope/pkg/sub'), '@scope/pkg');
+  });
+});


### PR DESCRIPTION
Closes #3432

_Auto-opened by `/single-story-deliver`._