### PR TITLE
fix: scope epic child-ticket fetch so reconciliation stops scanning every repo issue (#3455)

### DIFF
--- a/.agents/scripts/epic-reconcile.js
+++ b/.agents/scripts/epic-reconcile.js
@@ -171,10 +171,19 @@ export function parseCli(argv) {
  * Project the GH state observation into the shape the diff engine
  * expects: `{ [issueNumber]: { title, body?, labels?, state } }`.
  *
- * Pulls every ticket under the Epic via `getTickets` (matches the
- * decomposer's "fetch all children" call shape) plus the Epic itself.
- * The provider's returned issues come back with `id, title, body?,
- * labels[], state`; the diff engine ignores fields it doesn't use.
+ * Enumerates the Epic's children via the **server-side-scoped**
+ * `getSubTickets(epicId)` (native sub-issue GraphQL graph → checklist
+ * links → reverse-search) rather than `getTickets(epicId)`'s repo-wide
+ * `state=all` scan-and-filter (Story #3455). The structural diff engine
+ * never branches on `obs.state` — Close detection is driven by
+ * spec-vs-mapping, `fieldChanges` compares only `title/body/labels/wave`,
+ * and `ghState` is consulted only to look up an issue by the number
+ * already in the state-file mapping — so dropping the repo-wide
+ * closed-issue over-fetch changes nothing but cost (and removes the
+ * latent spurious-Update risk on a re-plan of a partially-delivered
+ * Epic). The provider's returned children come back as full ticket
+ * objects (`id, title, body, labels, state`); the diff engine ignores
+ * fields it doesn't use.
  *
  * @param {object} provider
  * @param {number} epicId
@@ -200,8 +209,8 @@ export async function fetchGhState(provider, epicId) {
     /* swallow — epic body observation is non-fatal for diff */
   }
 
-  if (typeof provider.getTickets === 'function') {
-    const tickets = await provider.getTickets(epicId);
+  if (typeof provider.getSubTickets === 'function') {
+    const tickets = await provider.getSubTickets(epicId);
     for (const t of tickets ?? []) {
       if (typeof t.id !== 'number') continue;
       ghState[t.id] = {

--- a/.agents/scripts/lib/orchestration/epic-deliver-reconcile.js
+++ b/.agents/scripts/lib/orchestration/epic-deliver-reconcile.js
@@ -162,9 +162,9 @@ export async function reconcileEpicAgentLabels({
       `[epic-deliver-reconcile] epicId must be a positive integer (got ${epicId}).`,
     );
   }
-  if (!provider || typeof provider.getTickets !== 'function') {
+  if (!provider || typeof provider.getSubTickets !== 'function') {
     throw new Error(
-      '[epic-deliver-reconcile] provider must implement getTickets(parentId).',
+      '[epic-deliver-reconcile] provider must implement getSubTickets(parentId).',
     );
   }
   if (typeof repoRoot !== 'string' || repoRoot.length === 0) {
@@ -173,7 +173,12 @@ export async function reconcileEpicAgentLabels({
     );
   }
 
-  const children = await provider.getTickets(epicId);
+  // Story #3455 — scope child enumeration to the Epic's sub-issue graph
+  // (server-side) instead of `getTickets`'s repo-wide `state=all` scan.
+  // The watchdog only classifies children that carry a reconcile label
+  // (executing/closing → open issues), so the scoped fetch yields the
+  // same candidate set without paging every issue in the repo.
+  const children = await provider.getSubTickets(epicId);
   const candidates = (children ?? []).filter(hasReconcileLabel);
 
   const live = [];

--- a/.agents/scripts/lib/orchestration/epic-plan-decompose/phases/creation.js
+++ b/.agents/scripts/lib/orchestration/epic-plan-decompose/phases/creation.js
@@ -88,9 +88,14 @@ export async function setEpicLabel(provider, epicId, targetLabel) {
 }
 
 async function loadExistingChildren(provider, epicId) {
+  // Story #3455 — scope resume-indexing to the Epic's sub-issue graph
+  // (`getSubTickets`) instead of `getTickets`'s repo-wide `state=all`
+  // scan. The downstream filter keeps only Feature/Story children, so the
+  // scoped fetch surfaces the same set without paging every issue in the
+  // repo.
   const existing =
-    typeof provider.getTickets === 'function'
-      ? await provider.getTickets(epicId)
+    typeof provider.getSubTickets === 'function'
+      ? await provider.getSubTickets(epicId)
       : [];
   if (existing.length > 0 && typeof provider.primeTicketCache === 'function') {
     provider.primeTicketCache(existing);

--- a/.agents/scripts/lib/orchestration/epic-plan-decompose/phases/diagnostics.js
+++ b/.agents/scripts/lib/orchestration/epic-plan-decompose/phases/diagnostics.js
@@ -20,8 +20,13 @@ import { TYPE_LABELS } from '../../../label-constants.js';
  * tickets are always Feature or Story.
  */
 async function emitOpenChildrenDiagnostic(provider, epicId) {
-  if (typeof provider.getTickets !== 'function') return;
-  const existing = await provider.getTickets(epicId);
+  if (typeof provider.getSubTickets !== 'function') return;
+  // Story #3455 — scope to the Epic's sub-issue graph instead of
+  // `getTickets`'s repo-wide `state=all` scan. The diagnostic explicitly
+  // counts `state !== 'closed'`, so the scoped fetch (which still surfaces
+  // closed children) yields the same open-child count without paging
+  // every issue in the repo.
+  const existing = await provider.getSubTickets(epicId);
   const childTypes = [TYPE_LABELS.FEATURE, TYPE_LABELS.STORY];
   const created = (existing || []).filter(
     (t) =>

--- a/.agents/scripts/wave-gate.js
+++ b/.agents/scripts/wave-gate.js
@@ -92,8 +92,14 @@ export async function runWaveGate({
   // paying a wire round-trip each. `primeTicketCache` is a no-op on
   // providers without a cache (manual adapter, test stubs), so the call
   // is unconditional.
+  //
+  // Story #3455 — scope the prime to the Epic's sub-issue graph
+  // (`getSubTickets`) instead of `getTickets`'s repo-wide `state=all`
+  // scan. This is a best-effort warm cache, so the scoped child set is
+  // observably equivalent for the per-Story reads that follow while
+  // dropping the whole-repo pagination.
   try {
-    const allTickets = await provider.getTickets(epicId);
+    const allTickets = await provider.getSubTickets(epicId);
     if (Array.isArray(allTickets)) {
       provider.primeTicketCache(allTickets);
     }

--- a/tests/scripts/epic-deliver-reconcile.dead-classification.test.js
+++ b/tests/scripts/epic-deliver-reconcile.dead-classification.test.js
@@ -54,7 +54,7 @@ function fixtureStory(id, title, label = 'agent::executing') {
 
 function fakeProvider(children) {
   return {
-    getTickets: async () => children,
+    getSubTickets: async () => children,
   };
 }
 

--- a/tests/scripts/epic-deliver-reconcile.test.js
+++ b/tests/scripts/epic-deliver-reconcile.test.js
@@ -47,10 +47,10 @@ function fixtureStory(id, title, label = 'agent::executing') {
   };
 }
 
-/** In-memory provider stub exposing `getTickets(parentId)`. */
+/** In-memory provider stub exposing `getSubTickets(parentId)`. */
 function fakeProvider(children) {
   return {
-    getTickets: async () => children,
+    getSubTickets: async () => children,
   };
 }
 

--- a/tests/scripts/epic-plan-decompose-pipeline.test.js
+++ b/tests/scripts/epic-plan-decompose-pipeline.test.js
@@ -186,7 +186,7 @@ describe('epic-plan-decompose pipeline — runDecomposePhase over-budget gate (S
     async createTicket() {
       return { id: 999, url: 'u' };
     },
-    async getTickets() {
+    async getSubTickets() {
       return [];
     },
   });

--- a/tests/scripts/epic-plan-decompose.3tier-creation-diagnostics.test.js
+++ b/tests/scripts/epic-plan-decompose.3tier-creation-diagnostics.test.js
@@ -132,7 +132,7 @@ describe('reportPartialFailure — 3-tier no "missing Tasks" warning (Story #312
       async getEpic() {
         return { id: EPIC_ID, labels: ['type::epic', 'agent::executing'] };
       },
-      async getTickets() {
+      async getSubTickets() {
         // 3-tier: Feature + Story only, no Task children.
         return [
           { id: 9121, title: 'F1', labels: ['type::feature'], state: 'open' },

--- a/tests/scripts/epic-plan-decompose.body-preservation.test.js
+++ b/tests/scripts/epic-plan-decompose.body-preservation.test.js
@@ -103,6 +103,11 @@ function buildStubProvider({ epicId, epicBody }) {
     async getTickets() {
       return Array.from(issues.values()).filter((t) => t.id !== epicId);
     },
+    // Story #3455 — decompose's resume-indexing path enumerates children
+    // via the scoped getSubTickets; mirror the same child set.
+    async getSubTickets() {
+      return Array.from(issues.values()).filter((t) => t.id !== epicId);
+    },
     async createTicket(_parentId, payload) {
       const id = nextId++;
       issues.set(id, {

--- a/tests/scripts/epic-plan.spec-flow.test.js
+++ b/tests/scripts/epic-plan.spec-flow.test.js
@@ -103,6 +103,13 @@ function buildStubProvider({ epicId, epicTitle }) {
       calls.getTickets += 1;
       return Array.from(issues.values()).filter((t) => t.id !== epicId);
     },
+    // Story #3455 — the reconciler's `fetchGhState` now enumerates the
+    // Epic's children via the scoped `getSubTickets` rather than the
+    // repo-wide `getTickets`. Mirror the same child set so the apply
+    // path observes the live tickets it always did.
+    async getSubTickets(_parentId) {
+      return Array.from(issues.values()).filter((t) => t.id !== epicId);
+    },
     async createTicket(parentId, payload) {
       calls.createTicket += 1;
       const id = nextId++;

--- a/tests/scripts/epic-reconcile.cli.test.js
+++ b/tests/scripts/epic-reconcile.cli.test.js
@@ -27,11 +27,13 @@ import { describe, it } from 'node:test';
 
 import {
   EXIT_CODES,
+  fetchGhState,
   parseCli,
   planHasCloses,
   renderExplicitDeleteMessage,
   runReconcile,
 } from '../../.agents/scripts/epic-reconcile.js';
+import { diff as realDiff } from '../../.agents/scripts/lib/orchestration/epic-spec-reconciler-diff.js';
 import {
   closeOp,
   createOp,
@@ -611,5 +613,174 @@ describe('runReconcile — bootstrap state.mapping.epic', () => {
       0,
       'diff must not emit a Create op for the epic entity once the CLI has seeded mapping.epic',
     );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// fetchGhState — scoped child enumeration (Story #3455)
+// ---------------------------------------------------------------------------
+
+describe('fetchGhState — scoped child enumeration (Story #3455)', () => {
+  /**
+   * Build a provider stub that records which enumeration surface the
+   * reconciler reaches for. `getTickets` is the legacy repo-wide
+   * scan-and-filter; `getSubTickets` is the server-side-scoped sub-issue
+   * graph. Story #3455 routes `fetchGhState` through the latter.
+   */
+  function buildEnumProvider({ epic, children }) {
+    const calls = { getTickets: 0, getSubTickets: 0, getEpic: 0 };
+    return {
+      calls,
+      async getEpic(id) {
+        calls.getEpic += 1;
+        return epic && epic.id === id ? epic : null;
+      },
+      async getTickets() {
+        calls.getTickets += 1;
+        return children;
+      },
+      async getSubTickets() {
+        calls.getSubTickets += 1;
+        return children;
+      },
+    };
+  }
+
+  it('sources the Epic observation from getSubTickets, never the repo-wide getTickets', async () => {
+    const provider = buildEnumProvider({
+      epic: { id: 700, title: 'Epic', body: '', labels: ['type::epic'] },
+      children: [
+        { id: 701, title: 'Story one', body: 'b1', labels: [], state: 'open' },
+      ],
+    });
+
+    const ghState = await fetchGhState(provider, 700);
+
+    // AC: scoped path is used (so unrelated issues in other Epics do not
+    // enlarge the fetch); the repo-wide scan-and-filter is never reached.
+    assert.equal(provider.calls.getSubTickets, 1);
+    assert.equal(provider.calls.getTickets, 0);
+    // The observation projects the scoped child set + the epic itself.
+    assert.deepEqual(Object.keys(ghState).sort(), ['700', '701']);
+  });
+
+  it('keeps closed/delivered children visible in the observation', async () => {
+    const provider = buildEnumProvider({
+      epic: { id: 800, title: 'Epic', body: '', labels: ['type::epic'] },
+      children: [
+        { id: 801, title: 'Open story', body: '', labels: [], state: 'open' },
+        {
+          id: 802,
+          title: 'Delivered story',
+          body: '',
+          labels: [],
+          state: 'closed',
+        },
+      ],
+    });
+
+    const ghState = await fetchGhState(provider, 800);
+
+    // AC: load-bearing visibility — the scoped fetch still surfaces the
+    // closed child (getSubTickets walks the full sub-issue graph; only the
+    // diff engine, which ignores obs.state, declines to act on it).
+    assert.equal(ghState[802].state, 'closed');
+    assert.equal(ghState[801].state, 'open');
+  });
+
+  it('re-reconcile with a closed/delivered child emits no spurious Update/Close op', async () => {
+    // A partially-delivered Epic: feature-a + story-one already mapped and
+    // delivered (story-one closed on GH). The structural fields the diff
+    // engine is authoritative over (title/body/labels) match the spec; the
+    // only "drift" is the closed GH state — exactly the over-fetch the
+    // legacy repo-wide `getTickets` pulled in and the scoped `getSubTickets`
+    // still surfaces. Because the diff engine never branches on `obs.state`,
+    // the closed child must produce neither an Update nor a Close op.
+    const epicId = 900;
+    const epicIssue = 900;
+    const featureIssue = 910;
+    const storyIssue = 911;
+
+    // Compose the canonical orchestrator footer the diff engine expects on
+    // non-epic bodies so the body comparison is a no-op.
+    const storyBody = `A delivered story.\n\n---\nparent: #${featureIssue}\nEpic: #${epicId}`;
+    const featureBody = `A feature.\n\n---\nparent: #${epicIssue}`;
+
+    const spec = {
+      epic: { id: epicId, title: 'Partially Delivered Epic', body: '' },
+      features: [
+        {
+          slug: 'feature-a',
+          title: 'Feature A',
+          body: 'A feature.',
+          labels: ['type::feature'],
+          stories: [
+            {
+              slug: 'story-one',
+              title: 'Story One',
+              body: 'A delivered story.',
+              labels: ['type::story'],
+            },
+          ],
+        },
+      ],
+    };
+
+    const state = {
+      epicId,
+      mapping: {
+        epic: { issueNumber: epicIssue, entity: 'epic', parentSlug: null },
+        'feature-a': {
+          issueNumber: featureIssue,
+          entity: 'feature',
+          parentSlug: 'epic',
+        },
+        'story-one': {
+          issueNumber: storyIssue,
+          entity: 'story',
+          parentSlug: 'feature-a',
+        },
+      },
+    };
+
+    // The scoped enumeration surfaces the closed/delivered story — exactly
+    // the over-fetch the legacy repo-wide getTickets would also have
+    // pulled. The diff must ignore its closed state.
+    const provider = buildEnumProvider({
+      epic: {
+        id: epicIssue,
+        title: 'Partially Delivered Epic',
+        body: '',
+        labels: ['type::epic'],
+      },
+      children: [
+        {
+          id: featureIssue,
+          title: 'Feature A',
+          body: featureBody,
+          labels: ['type::feature'],
+          state: 'open',
+        },
+        {
+          id: storyIssue,
+          title: 'Story One',
+          body: storyBody,
+          labels: ['type::story'],
+          state: 'closed',
+        },
+      ],
+    });
+
+    const ghState = await fetchGhState(provider, epicId);
+    const plan = realDiff({ spec, state, ghState });
+
+    assert.equal(provider.calls.getSubTickets, 1);
+    assert.equal(provider.calls.getTickets, 0);
+    // No close: the slug is still in the spec.
+    assert.equal(plan.closes.length, 0, 'no spurious Close op');
+    // No update against the closed/delivered child whose structural
+    // fields match the spec (the closed state is not structural).
+    const storyUpdate = plan.updates.find((op) => op.slug === 'story-one');
+    assert.equal(storyUpdate, undefined, 'no spurious Update op for story-one');
   });
 });

--- a/tests/ticket-decomposer.test.js
+++ b/tests/ticket-decomposer.test.js
@@ -346,7 +346,7 @@ describe('ticket-decomposer orchestration (v5.6+)', () => {
     // never created. Resume must skip the Feature and create only Story One
     // + Story Two, wiring Story Two's dep to the id of the freshly-created
     // Story One (NOT to the pre-existing Feature).
-    mockProvider.getTickets = async () => [
+    mockProvider.getSubTickets = async () => [
       {
         id: 500,
         title: 'Feature One',
@@ -379,7 +379,7 @@ describe('ticket-decomposer orchestration (v5.6+)', () => {
   });
 
   it('resume mode: errors when the Epic has no existing children', async () => {
-    mockProvider.getTickets = async () => [];
+    mockProvider.getSubTickets = async () => [];
     await assert.rejects(
       () =>
         decomposeEpic(
@@ -415,7 +415,7 @@ describe('ticket-decomposer orchestration (v5.6+)', () => {
     let firedRL = false;
     // Fake http client surface — just enough for the adaptive hook to bind.
     mockProvider._http = { onTransientFailure: null };
-    mockProvider.getTickets = async () => [];
+    mockProvider.getSubTickets = async () => [];
     mockProvider.createTicket = async (parentId, ticketData) => {
       inFlight++;
       const labels = ticketData.labels || [];

--- a/tests/wave-gate.test.js
+++ b/tests/wave-gate.test.js
@@ -82,10 +82,10 @@ class TimingProvider {
     return this.comments;
   }
 
-  async getTickets(epicId, _filters = {}) {
+  async getSubTickets(epicId) {
     this.getTicketsCalls.push(epicId);
     if (this.getTicketsThrows) {
-      throw new Error('getTickets failed');
+      throw new Error('getSubTickets failed');
     }
     return Object.values(this.tickets).map((t) => ({ ...t }));
   }
@@ -331,7 +331,7 @@ describe('wave-gate — pass/fail/fetch-error contract', () => {
 });
 
 describe('wave-gate — ticket-cache prime (Story #2465)', () => {
-  it('calls provider.getTickets exactly once per runWaveGate invocation', async () => {
+  it('calls provider.getSubTickets exactly once per runWaveGate invocation', async () => {
     const provider = new TimingProvider({
       tickets: {
         10: { id: 10, state: 'closed' },


### PR DESCRIPTION
Closes #3455

_Auto-opened by `/single-story-deliver`._