### PR TITLE
Guard postinstall + scope /.agents/ gitignore so the framework repo doesn't clobber/ignore its own .agents/ source (#3489)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,11 +5,14 @@ dist
 .DS_Store
 *.log
 
-# Regenerated agent payload (npm-distribution model): ./.agents/ is a working
-# copy materialized from node_modules/@mandrel/agents by `mandrel sync` (run by
-# the package postinstall hook). The package tarball is the source of truth, so
-# the regenerated copy is never committed. See Tech Spec #3459 / Feature #3461.
-/.agents/
+# NOTE: This is the Mandrel framework SOURCE repo, where ./.agents/ IS the
+# committed product — so it is deliberately NOT ignored here (Story #3489).
+# A blanket `/.agents/` ignore (correct for a *consumer* project, where
+# ./.agents/ is a working copy materialized from node_modules/@mandrel/agents
+# by `mandrel sync`) would silently hide newly added framework `.agents/**`
+# source files from `git status`/`git add`. Consumer projects add the
+# `/.agents/` ignore to their OWN .gitignore; the framework repo must not.
+# Local overrides under .agents/ are still ignored below.
 
 # Agent Local Overrides
 .agentrc.local.json

--- a/bin/postinstall.js
+++ b/bin/postinstall.js
@@ -16,19 +16,75 @@
  * `mandrel sync` itself does: no network, no shell, no writes outside
  * `./.agents/`.
  *
- * Injectable seams (used by bin/__tests__/postinstall.test.js):
- *   - `sync`      — replaces the real `runSync` from lib/cli/sync.js
- *   - `writeErr`  — replaces process.stderr.write
- *   - `exit`      — replaces process.exit
+ * **Source-checkout guard (Story #3489).** In the Mandrel framework repo
+ * itself, `./.agents/` is not a regenerated working copy — it *is* the
+ * committed product, and `mandrel sync` would clobber that source of truth
+ * with a copy of `node_modules/@mandrel/agents/.agents/`. Today the repo
+ * `.npmrc` (`ignore-scripts=true`) masks this, but a contributor running
+ * `npm install --ignore-scripts=false` (or a tool that re-enables scripts)
+ * would overwrite the source tree. To make the guard intrinsic rather than
+ * config-dependent, the hook detects the source checkout — the repo whose
+ * root `package.json#name` is `@mandrel/agents` — and no-ops (exit 0)
+ * without invoking the materializer. Consumer installs (where the package is
+ * a dependency under a differently-named root `package.json`) are unaffected
+ * and still materialize `.agents/` as before.
+ *
+ * Injectable seams (used by tests/cli/postinstall.test.js):
+ *   - `sync`             — replaces the real `runSync` from lib/cli/sync.js
+ *   - `isSourceCheckout` — replaces the source-checkout detector
+ *   - `writeErr`         — replaces process.stderr.write
+ *   - `exit`             — replaces process.exit
  */
 
+import nodeFs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { runSync } from '../lib/cli/sync.js';
+
+const PACKAGE_NAME = '@mandrel/agents';
 
 const HINT =
   'mandrel: could not materialize ./.agents/ during install — run `mandrel sync` to finish setup.\n';
 
 /**
+ * Detect whether this hook is running inside the Mandrel framework source
+ * checkout (as opposed to a consumer project that depends on the package).
+ *
+ * The signal is the **repo-root** `package.json#name`: in the source repo it
+ * is `@mandrel/agents`; in a consumer project it is the consumer's own
+ * package name (and `@mandrel/agents` lives under `node_modules/` instead).
+ * We resolve the root from this module's own location (`bin/postinstall.js`
+ * sits one directory below the repo root), not from `process.cwd()`, so the
+ * detection is stable regardless of where npm invokes the hook from.
+ *
+ * Fails safe: any read/parse error returns `false` (treat as a consumer
+ * install and let the best-effort sync run), so a malformed or missing
+ * `package.json` never strands a consumer without their `.agents/` payload.
+ *
+ * @param {{ fs?: typeof nodeFs, moduleUrl?: string }} [opts]
+ * @returns {boolean} `true` when running in the `@mandrel/agents` source repo.
+ */
+export function isSourceCheckout({
+  fs = nodeFs,
+  moduleUrl = import.meta.url,
+} = {}) {
+  try {
+    const here = path.dirname(fileURLToPath(moduleUrl));
+    const pkgPath = path.join(here, '..', 'package.json');
+    const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8'));
+    return pkg?.name === PACKAGE_NAME;
+  } catch {
+    return false;
+  }
+}
+
+/**
  * Run the materializer, swallowing any failure into an exit-0 hint.
+ *
+ * When invoked inside the framework source checkout the hook short-circuits
+ * to a clean exit 0 *before* touching the materializer (Story #3489), so the
+ * committed `.agents/` source is never overwritten — even under
+ * `--ignore-scripts=false`.
  *
  * `runSync` calls its injected `exit` with a non-zero code when the package
  * is not resolvable (the common `--ignore-scripts`-adjacent failure). We
@@ -38,17 +94,27 @@ const HINT =
  *
  * @param {{
  *   sync?: typeof runSync,
+ *   isSourceCheckout?: typeof isSourceCheckout,
  *   writeErr?: (s: string) => void,
  *   exit?: (code: number) => void,
  * }} [opts]
- * @returns {{ exitCode: number, hinted: boolean }} Outcome (also returned for
- *   testability; the process always exits 0).
+ * @returns {{ exitCode: number, hinted: boolean, skipped: boolean }} Outcome
+ *   (also returned for testability; the process always exits 0).
  */
 export function runPostinstall({
   sync = runSync,
+  isSourceCheckout: detectSource = isSourceCheckout,
   writeErr = (s) => process.stderr.write(s),
   exit = (code) => process.exit(code),
 } = {}) {
+  // Source-checkout guard (Story #3489): never materialize over the
+  // framework's own committed `.agents/` source. No hint — this is the
+  // expected, correct no-op in the framework repo, not a degraded state.
+  if (detectSource()) {
+    exit(0);
+    return { exitCode: 0, hinted: false, skipped: true };
+  }
+
   let syncFailed = false;
   try {
     // No argv is forwarded: the install-time materialization is a plain,
@@ -72,7 +138,7 @@ export function runPostinstall({
 
   // Always succeed: the install must not fail on a best-effort sync.
   exit(0);
-  return { exitCode: 0, hinted: syncFailed };
+  return { exitCode: 0, hinted: syncFailed, skipped: false };
 }
 
 // Run when invoked directly as the postinstall hook (not when imported by a

--- a/tests/cli/postinstall.test.js
+++ b/tests/cli/postinstall.test.js
@@ -6,20 +6,34 @@
  * "run `mandrel sync`" hint so `--ignore-scripts` / sandboxed installs degrade
  * to the doctor-detected state instead of failing the consumer's install.
  *
+ * The source-checkout guard (Story #3489) adds a no-op short-circuit: when the
+ * hook runs inside the Mandrel framework source repo (root
+ * `package.json#name === "@mandrel/agents"`), it MUST skip the materializer
+ * entirely so `mandrel sync` never clobbers the committed `.agents/` source —
+ * even under `npm install --ignore-scripts=false`.
+ *
  * Tests drive `runPostinstall` through its injectable seams (`sync`,
- * `writeErr`, `exit`) so no real package resolution, filesystem I/O, or
- * process exit occurs (testing-standards § Unit).
+ * `isSourceCheckout`, `writeErr`, `exit`) and `isSourceCheckout` through its
+ * `fs` / `moduleUrl` seams, so no real package resolution, filesystem I/O, or
+ * process exit occurs (testing-standards § Unit). The consumer-path suites
+ * inject `isSourceCheckout: () => false` to isolate the materializer behaviour
+ * from the source-checkout guard.
  */
 
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 
-import { runPostinstall } from '../../bin/postinstall.js';
+import { isSourceCheckout, runPostinstall } from '../../bin/postinstall.js';
+
+// Consumer install: force the source-checkout guard off so these suites
+// exercise the materializer path in isolation.
+const consumer = { isSourceCheckout: () => false };
 
 describe('postinstall hook — success path', () => {
   it('invokes the sync materializer', () => {
     let called = false;
     runPostinstall({
+      ...consumer,
       sync: () => {
         called = true;
       },
@@ -32,6 +46,7 @@ describe('postinstall hook — success path', () => {
   it('exits 0 when sync succeeds', () => {
     let exitCode;
     runPostinstall({
+      ...consumer,
       sync: () => {},
       writeErr: () => {},
       exit: (code) => {
@@ -44,6 +59,7 @@ describe('postinstall hook — success path', () => {
   it('does not log a hint when sync succeeds', () => {
     let hint = '';
     runPostinstall({
+      ...consumer,
       sync: () => {},
       writeErr: (s) => {
         hint += s;
@@ -58,6 +74,7 @@ describe('postinstall hook — sync reports non-zero exit (e.g. package missing)
   it('still exits 0 (best-effort: never fail the install)', () => {
     let exitCode;
     runPostinstall({
+      ...consumer,
       // Mimic runSync's missing-package path, which calls its injected exit(1).
       sync: ({ exit }) => exit(1),
       writeErr: () => {},
@@ -71,6 +88,7 @@ describe('postinstall hook — sync reports non-zero exit (e.g. package missing)
   it('logs a "run `mandrel sync`" hint', () => {
     let hint = '';
     runPostinstall({
+      ...consumer,
       sync: ({ exit }) => exit(1),
       writeErr: (s) => {
         hint += s;
@@ -85,6 +103,7 @@ describe('postinstall hook — sync throws (e.g. mid-copy fault)', () => {
   it('swallows the throw and exits 0', () => {
     let exitCode;
     runPostinstall({
+      ...consumer,
       sync: () => {
         throw new Error('boom');
       },
@@ -99,6 +118,7 @@ describe('postinstall hook — sync throws (e.g. mid-copy fault)', () => {
   it('logs the remediation hint after a thrown error', () => {
     let hint = '';
     runPostinstall({
+      ...consumer,
       sync: () => {
         throw new Error('boom');
       },
@@ -108,5 +128,92 @@ describe('postinstall hook — sync throws (e.g. mid-copy fault)', () => {
       exit: () => {},
     });
     assert.match(hint, /mandrel sync/);
+  });
+});
+
+describe('postinstall hook — source-checkout guard (Story #3489)', () => {
+  it('does NOT invoke the materializer in the framework source checkout', () => {
+    let called = false;
+    runPostinstall({
+      isSourceCheckout: () => true,
+      sync: () => {
+        called = true;
+      },
+      writeErr: () => {},
+      exit: () => {},
+    });
+    assert.equal(called, false);
+  });
+
+  it('exits 0 (clean no-op, never fails the install)', () => {
+    let exitCode;
+    runPostinstall({
+      isSourceCheckout: () => true,
+      sync: () => {},
+      writeErr: () => {},
+      exit: (code) => {
+        exitCode = code;
+      },
+    });
+    assert.equal(exitCode, 0);
+  });
+
+  it('does not log the degraded-state hint (the no-op is expected, not a failure)', () => {
+    let hint = '';
+    runPostinstall({
+      isSourceCheckout: () => true,
+      sync: () => {},
+      writeErr: (s) => {
+        hint += s;
+      },
+      exit: () => {},
+    });
+    assert.equal(hint, '');
+  });
+
+  it('reports skipped: true in the returned outcome', () => {
+    const outcome = runPostinstall({
+      isSourceCheckout: () => true,
+      sync: () => {},
+      writeErr: () => {},
+      exit: () => {},
+    });
+    assert.deepEqual(outcome, { exitCode: 0, hinted: false, skipped: true });
+  });
+});
+
+describe('isSourceCheckout — repo-root package.json#name detection', () => {
+  // The SUT resolves the probed file as dirname(fileURLToPath(moduleUrl))
+  // joined with '..'. We point moduleUrl at this test file's own URL so
+  // `fileURLToPath` produces a valid path on every platform; the fake fs keys
+  // off the package.json basename rather than the exact directory.
+  const moduleUrl = import.meta.url;
+
+  const makeFs = (contents) => ({
+    readFileSync: (p) => {
+      const norm = String(p).replace(/\\/g, '/');
+      if (norm.endsWith('package.json') && contents !== null) return contents;
+      throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+    },
+  });
+
+  it('returns true when root package.json#name is @mandrel/agents', () => {
+    const fs = makeFs(JSON.stringify({ name: '@mandrel/agents' }));
+    assert.equal(isSourceCheckout({ fs, moduleUrl }), true);
+  });
+
+  it('returns false when root package.json#name is a consumer project', () => {
+    const fs = makeFs(JSON.stringify({ name: 'my-consumer-app' }));
+    assert.equal(isSourceCheckout({ fs, moduleUrl }), false);
+  });
+
+  it('fails safe (false) when package.json is unreadable', () => {
+    const fs = makeFs(null);
+    assert.equal(isSourceCheckout({ fs, moduleUrl }), false);
+  });
+
+  it('fails safe (false) when package.json is malformed JSON', () => {
+    const fs = makeFs('{ not valid json');
+    assert.equal(isSourceCheckout({ fs, moduleUrl }), false);
   });
 });


### PR DESCRIPTION
Closes #3489

_Auto-opened by `/single-story-deliver`._