### PR TITLE
fix(test-runner): chunk node --test spawns to avoid Windows ENAMETOOLONG

### DIFF
--- a/.agents/scripts/run-tests.js
+++ b/.agents/scripts/run-tests.js
@@ -15,6 +15,17 @@
  * `notify()` POSTs to the live endpoint. Set `MANDREL_ALLOW_TEST_WEBHOOKS=1`
  * to opt back in for the rare case where a contract test deliberately
  * exercises a sandbox endpoint.
+ *
+ * Windows arg-length safety: the `quick` / `integration` tiers enumerate
+ * explicit test-file targets (they exclude specific slow suites, so a single
+ * glob will not do). With ~700+ targets the joined command line crosses the
+ * Windows `CreateProcess` ~32 767-char `lpCommandLine` ceiling, and
+ * `spawnSync` throws `ENAMETOOLONG` before a single test runs. To stay safe
+ * on every platform the runner partitions the targets into chunks whose
+ * joined length stays well under that ceiling (`MAX_TARGET_CHARS`) and spawns
+ * one `node --test` process per chunk, aggregating the exit codes. The
+ * `full` tier (a single recursive `tests` glob) yields exactly one chunk, so
+ * its behaviour is unchanged.
  */
 
 import { spawnSync } from 'node:child_process';
@@ -29,6 +40,62 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '..', '..');
 
 /**
+ * Fixed `node --test` flags applied to every spawn (every chunk).
+ */
+export const TEST_RUNNER_FLAGS = Object.freeze([
+  '--experimental-test-module-mocks',
+  '--test',
+  '--test-concurrency=8',
+]);
+
+/**
+ * Per-spawn character budget for the joined *targets* portion of the argv.
+ *
+ * The Windows `CreateProcess` command-line ceiling is 32 767 chars for the
+ * whole `lpCommandLine` (node exe path + flags + targets + extra args +
+ * quoting). Budgeting the targets to 8 000 chars keeps every spawn's full
+ * command line at roughly a quarter of the ceiling — ample headroom for the
+ * exe path and any pass-through `--test-name-pattern` args — while keeping
+ * the chunk count (and thus the extra `node` start-ups) low. POSIX limits are
+ * far higher, so this only ever splits work that would otherwise fail on
+ * Windows.
+ */
+export const MAX_TARGET_CHARS = 8000;
+
+/**
+ * Partition an ordered list of test-file targets into chunks whose joined
+ * length (targets + single-space separators) stays at or below `maxChars`.
+ * Order is preserved. A single target longer than the budget still lands in
+ * its own chunk rather than being dropped. An empty target list yields a
+ * single empty chunk so the caller still issues exactly one spawn (matching
+ * the historical single-spawn behaviour, e.g. the `full`-tier glob path).
+ *
+ * @param {string[]} targets
+ * @param {number} [maxChars]
+ * @returns {string[][]}
+ */
+export function chunkTestTargets(targets, maxChars = MAX_TARGET_CHARS) {
+  const chunks = [];
+  let current = [];
+  let currentLen = 0;
+
+  for (const target of targets) {
+    // +1 for the separator that would join this target to the previous one.
+    const addition = target.length + (current.length > 0 ? 1 : 0);
+    if (current.length > 0 && currentLen + addition > maxChars) {
+      chunks.push(current);
+      current = [];
+      currentLen = 0;
+    }
+    current.push(target);
+    currentLen += target.length + (current.length > 1 ? 1 : 0);
+  }
+
+  if (current.length > 0) chunks.push(current);
+  return chunks.length > 0 ? chunks : [[]];
+}
+
+/**
  * @param {object} [opts]
  * @param {string[]} [opts.extraArgs]
  * @param {'full' | 'quick' | 'integration'} [opts.tier]
@@ -40,13 +107,7 @@ export function buildNodeTestArgs({
   repoRoot = ROOT,
 } = {}) {
   const targets = listTestFilesForTier(tier, repoRoot);
-  return [
-    '--experimental-test-module-mocks',
-    '--test',
-    '--test-concurrency=8',
-    ...targets,
-    ...extraArgs,
-  ];
+  return [...TEST_RUNNER_FLAGS, ...targets, ...extraArgs];
 }
 
 export function runTestSuite({
@@ -54,25 +115,40 @@ export function runTestSuite({
   cwd = ROOT,
   spawn = spawnSync,
   cleanup = cleanupRepoTestTempArtifacts,
+  listTargets = listTestFilesForTier,
+  maxTargetChars = MAX_TARGET_CHARS,
 } = {}) {
   const { tier, rest } = parseTierArgv(argv);
-  const testRun = spawn(
-    process.execPath,
-    buildNodeTestArgs({ extraArgs: rest, tier, repoRoot: cwd }),
-    {
-      cwd,
-      stdio: 'inherit',
-      env: buildWebhookSafeTestEnv(process.env),
-    },
-  );
+  const targets = listTargets(tier, cwd);
+  const chunks = chunkTestTargets(targets, maxTargetChars);
+
+  const env = buildWebhookSafeTestEnv(process.env);
+  let status = 0;
+  let spawnError = null;
+
+  for (const chunk of chunks) {
+    const testRun = spawn(
+      process.execPath,
+      [...TEST_RUNNER_FLAGS, ...chunk, ...rest],
+      { cwd, stdio: 'inherit', env },
+    );
+    if (testRun.error) {
+      spawnError = testRun.error;
+      break;
+    }
+    const chunkStatus = testRun.status ?? 1;
+    // First non-zero exit code wins; later chunks still run so the full
+    // failure surface is reported in one CI pass.
+    if (chunkStatus !== 0 && status === 0) status = chunkStatus;
+  }
 
   cleanup({ repoRoot: cwd });
 
-  if (testRun.error) {
-    throw testRun.error;
+  if (spawnError) {
+    throw spawnError;
   }
 
-  return testRun.status ?? 1;
+  return status;
 }
 
 runAsCli(import.meta.url, async () => runTestSuite(), {

--- a/baselines/maintainability.json
+++ b/baselines/maintainability.json
@@ -1,11 +1,11 @@
 {
   "$schema": ".agents/schemas/baselines/maintainability.schema.json",
   "kernelVersion": "0.1.0",
-  "generatedAt": "2026-06-03T15:13:20.331Z",
+  "generatedAt": "2026-06-03T16:42:54.244Z",
   "rollup": {
     "*": {
       "min": 45.044,
-      "p50": 103.85,
+      "p50": 103.836,
       "p95": 121.586
     }
   },
@@ -2172,7 +2172,7 @@
     },
     {
       "path": ".agents/scripts/run-tests.js",
-      "mi": 108.005
+      "mi": 96.362
     },
     {
       "path": ".agents/scripts/run-verify.js",
@@ -4912,7 +4912,7 @@
     },
     {
       "path": "tests/scripts/run-tests.test.js",
-      "mi": 113.128
+      "mi": 112.354
     },
     {
       "path": "tests/scripts/run-verify.test.js",

--- a/tests/scripts/run-tests.test.js
+++ b/tests/scripts/run-tests.test.js
@@ -1,9 +1,12 @@
 import assert from 'node:assert/strict';
 import { test } from 'node:test';
-
+import { listTestFilesForTier } from '../../.agents/scripts/lib/test-tiers.js';
 import {
   buildNodeTestArgs,
+  chunkTestTargets,
+  MAX_TARGET_CHARS,
   runTestSuite,
+  TEST_RUNNER_FLAGS,
 } from '../../.agents/scripts/run-tests.js';
 
 test('buildNodeTestArgs preserves the default test glob and appends extra args', () => {
@@ -46,4 +49,144 @@ test('runTestSuite cleans reserved temp even when the test process fails', () =>
   assert.equal(calls[0].kind, 'spawn');
   assert.equal(calls[1].kind, 'cleanup');
   assert.deepEqual(calls[1].opts, { repoRoot: '/repo' });
+});
+
+// ---------------------------------------------------------------------------
+// chunkTestTargets — Windows arg-length guard (the run-tests.js spawnSync
+// ENAMETOOLONG regression: the `quick` tier crossed the Windows ~32 767-char
+// CreateProcess ceiling once the enumerated target list grew past it).
+// ---------------------------------------------------------------------------
+
+test('chunkTestTargets keeps a short list in a single chunk', () => {
+  const targets = ['tests/a.test.js', 'tests/b.test.js'];
+  assert.deepEqual(chunkTestTargets(targets, 8000), [targets]);
+});
+
+test('chunkTestTargets yields one empty chunk for an empty list (single spawn)', () => {
+  assert.deepEqual(chunkTestTargets([], 8000), [[]]);
+});
+
+test('chunkTestTargets splits a large list into chunks bounded by maxChars, preserving order', () => {
+  // 729-ish realistic paths well past the Windows ceiling.
+  const targets = Array.from(
+    { length: 800 },
+    (_, i) =>
+      `tests/some/nested/dir/file-${String(i).padStart(4, '0')}.test.js`,
+  );
+  const maxChars = 8000;
+  const chunks = chunkTestTargets(targets, maxChars);
+
+  assert.ok(chunks.length > 1, 'a large list must split into multiple chunks');
+
+  // Every chunk's joined length stays within budget.
+  for (const chunk of chunks) {
+    const joinedLen = chunk.join(' ').length;
+    assert.ok(
+      joinedLen <= maxChars,
+      `chunk joined length ${joinedLen} exceeds budget ${maxChars}`,
+    );
+  }
+
+  // Order and completeness preserved across chunks.
+  assert.deepEqual(chunks.flat(), targets);
+});
+
+test('chunkTestTargets places an over-budget single target in its own chunk', () => {
+  const huge = `tests/${'x'.repeat(50)}.test.js`;
+  const chunks = chunkTestTargets([huge], 10);
+  assert.deepEqual(chunks, [[huge]]);
+});
+
+test('the real quick tier never exceeds the Windows arg budget per chunk', () => {
+  // Regression guard: with the live quick-tier file set, every spawned chunk
+  // must stay under MAX_TARGET_CHARS so spawnSync cannot throw ENAMETOOLONG
+  // on Windows. (This is the exact failure that reddened the Windows Smoke
+  // CI job — see run-tests.js header.)
+  const targets = listTestFilesForTier('quick', process.cwd());
+  const chunks = chunkTestTargets(targets, MAX_TARGET_CHARS);
+  for (const chunk of chunks) {
+    assert.ok(
+      chunk.join(' ').length <= MAX_TARGET_CHARS,
+      'a quick-tier chunk exceeded the Windows arg budget',
+    );
+  }
+  // Sanity: all live targets are still covered.
+  assert.equal(chunks.flat().length, targets.length);
+});
+
+test('runTestSuite issues one spawn per chunk and never builds an unbounded argv', () => {
+  // Inject a target list that spans multiple chunks.
+  const targets = Array.from(
+    { length: 600 },
+    (_, i) => `tests/dir/file-${String(i).padStart(4, '0')}.test.js`,
+  );
+  const spawns = [];
+  const status = runTestSuite({
+    argv: [], // full tier — but listTargets is injected below
+    cwd: '/repo',
+    listTargets: () => targets,
+    maxTargetChars: 8000,
+    spawn: (_cmd, args) => {
+      spawns.push(args);
+      return { status: 0 };
+    },
+    cleanup: () => {},
+  });
+
+  assert.equal(status, 0);
+  assert.ok(spawns.length > 1, 'large target set must fan out across spawns');
+
+  for (const args of spawns) {
+    // Fixed flags lead every spawn.
+    for (const flag of TEST_RUNNER_FLAGS) assert.ok(args.includes(flag));
+    // The target portion (args minus the fixed flags) stays bounded.
+    const targetPortion = args.filter((a) => a.startsWith('tests/'));
+    assert.ok(
+      targetPortion.join(' ').length <= 8000,
+      'a spawn argv exceeded the target char budget',
+    );
+  }
+  // Completeness: union of all spawned targets equals the input set.
+  const spawnedTargets = spawns.flatMap((a) =>
+    a.filter((x) => x.startsWith('tests/')),
+  );
+  assert.deepEqual(spawnedTargets, targets);
+});
+
+test('runTestSuite returns the first non-zero chunk exit code', () => {
+  const targets = Array.from(
+    { length: 600 },
+    (_, i) => `tests/dir/file-${String(i).padStart(4, '0')}.test.js`,
+  );
+  let call = 0;
+  const status = runTestSuite({
+    argv: [],
+    cwd: '/repo',
+    listTargets: () => targets,
+    maxTargetChars: 8000,
+    spawn: () => {
+      call += 1;
+      return { status: call === 2 ? 7 : 0 };
+    },
+    cleanup: () => {},
+  });
+  assert.equal(status, 7);
+});
+
+test('runTestSuite cleans up then throws on a spawn error', () => {
+  let cleaned = false;
+  assert.throws(
+    () =>
+      runTestSuite({
+        argv: ['tests/x.test.js'],
+        cwd: '/repo',
+        listTargets: () => ['tests/x.test.js'],
+        spawn: () => ({ error: new Error('ENOENT') }),
+        cleanup: () => {
+          cleaned = true;
+        },
+      }),
+    /ENOENT/,
+  );
+  assert.ok(cleaned, 'cleanup must run before the throw');
 });


### PR DESCRIPTION
## Why

`main` and the release PR #3488 are red on the **Windows Smoke** CI job. Root cause: `.agents/scripts/run-tests.js` enumerates every test-file target into the `node --test` argv. The `quick` tier's joined target list reached **32,805 chars** — just past the Windows `CreateProcess` ~32,767-char `lpCommandLine` ceiling — so `spawnSync` throws `ENAMETOOLONG` and `npm run test:quick` dies before a single test runs. Epic #3438 added ~12 test files, which tipped the list over the boundary. The code is correct (the Ubuntu `Validate and Test` full-suite leg passes; `full` uses a single glob, `integration` is small) — this is purely a Windows arg-packing bug in the test runner.

## What

- Partition targets into chunks bounded by `MAX_TARGET_CHARS` (8000) and spawn one `node --test` per chunk, aggregating exit codes (first non-zero wins). Cleanup runs once; a spawn error still cleans up then throws (unchanged).
- The `full` tier (single recursive glob) yields exactly one chunk, so its behaviour is unchanged. POSIX limits are far higher, so this only ever splits work that would otherwise fail on Windows.
- New `chunkTestTargets` helper + a **live quick-tier regression guard** asserting no chunk's joined length exceeds the budget, so an unbounded argv cannot silently return.
- Refresh the maintainability baseline for the two touched files (the runner gained chunking logic; the −11.6 MI drift is justified and well under the CI tolerance of 12).

## Verification

- `npm run test:quick` now runs as 5 sequential chunks and exits 0 (no `ENAMETOOLONG`).
- `tests/scripts/run-tests.test.js`: 11/11 pass (chunking, ordering, exit-code aggregation, spawn-error path, live quick-tier budget guard).
- Pre-push gates green (quality-preview, crap, maintainability, coverage incl. the shipped-baselines round-trip).

Greens `main` CI and unblocks the release PR #3488 (both fail solely on this).