### PR TITLE
docs: reconcile legacy-submodule distribution refs in .agents/rules and .agents/workflows

### DIFF
--- a/.agents/rules/git-conventions.md
+++ b/.agents/rules/git-conventions.md
@@ -46,8 +46,8 @@ creation via `story-init.js`; agents commit on the active Story branch only.
 
 ## Contract Cutovers — No Shim Layer
 
-Mandrel is a Git-submodule-distributed framework whose consumers pin to
-specific versions; they opt into breaks at upgrade time. Operator policy
+Mandrel ships as the `@mandrel/agents` npm package, whose consumers pin an
+exact lockfile version; they opt into breaks at upgrade time. Operator policy
 for any contract change (config shape, baseline shape, schema, lifecycle
 payload, ticket label, dispatch artifact, public API of a script) is
 therefore:
@@ -58,9 +58,9 @@ therefore:
    feature flag that toggles between the two shapes.
 2. **The PR diff IS the migration.** A consumer upgrading to a release
    with the change adopts the new shape by upgrading the
-   `.agents/` submodule. The PR that lands on `main` already moved
-   every internal call site; consumers move on the same beat by
-   re-pinning.
+   `@mandrel/agents` package (`mandrel update`). The PR that lands on
+   `main` already moved every internal call site; consumers move on the
+   same beat by upgrading.
 3. **No deprecation ledger, no version-windowed sunsets.** The framework
    does not track "to be removed in vX.Y" entries or run two shapes side
    by side for a release window. If a shape changes, the old shape is

--- a/.agents/workflows/agents-update.md
+++ b/.agents/workflows/agents-update.md
@@ -1,15 +1,25 @@
 ---
-description: Bump the `.agents` submodule to its remote HEAD and report the change set.
+description: Legacy submodule-bump upgrade path (superseded by `mandrel update`) — bump the `.agents` submodule to its remote HEAD and report the change set.
 ---
 
 # /agents-update
+
+> **Legacy upgrade path.** `/agents-update` and its `update-self.js` script are
+> the **legacy Git-submodule-bump** path, **superseded by the `mandrel update`
+> CLI** (bump → sync → migrate → doctor) under the npm distribution model
+> (#3436/#3437). They are **retained only for consumer repos that have not yet
+> migrated off the retired `dist`-branch Git submodule**; on the
+> `@mandrel/agents` npm install, upgrade with `mandrel update` instead. The
+> submodule mechanics described below are accurate for that legacy path and do
+> **not** apply to npm-installed consumers.
 
 ## Overview
 
 `/agents-update` advances the consumer repo's `.agents/` submodule pointer to
 the latest commit on its tracked branch, then regenerates
-`.claude/commands/` against the new workflow set. It is the **only**
-supported way to upgrade the framework inside a consumer project.
+`.claude/commands/` against the new workflow set. It is the legacy upgrade
+path for consumer repos still vendoring `.agents/` as a Git submodule;
+npm-installed consumers upgrade with `mandrel update` instead.
 
 The upgrade contract:
 
@@ -241,11 +251,11 @@ the right moment to reconcile those, while the diff is in front of the
 operator.
 
 The framework CHANGELOG is **not shipped inside the `.agents/`
-submodule** — the distributed bundle (the `dist` branch) carries only
-the *contents* of `.agents/`, and `docs/CHANGELOG.md` lives at the
-framework repo root, outside that tree. So there is no
-`.agents/docs/CHANGELOG.md` to read in a consumer project; reaching for
-one yields "No tracked CHANGELOG in the submodule."
+bundle** — the distributed bundle carries only the *contents* of
+`.agents/`, and `docs/CHANGELOG.md` lives at the framework repo root,
+outside that tree. So there is no `.agents/docs/CHANGELOG.md` to read in
+a consumer project; reaching for one yields "No tracked CHANGELOG in the
+submodule."
 
 Source the change set from the framework remote instead. The submodule's
 `origin` points at the framework repo, so fetch its default branch and

--- a/.agents/workflows/helpers/agents-sync-config.md
+++ b/.agents/workflows/helpers/agents-sync-config.md
@@ -12,8 +12,10 @@ description: >-
 
 > **Not a slash command.** Lives under `.agents/workflows/helpers/` so it is
 > not synced into `.claude/commands/`. Invoked by reference from
-> [`/agents-update`](../agents-update.md) after the submodule pointer moves;
-> previously shipped as `/agents-sync-config`.
+> [`/agents-update`](../agents-update.md) (the legacy submodule-bump path)
+> after a framework update; previously shipped as `/agents-sync-config`. The
+> reconciliation is distribution-agnostic — under the npm model the same
+> `.agentrc.json` validation runs as part of `mandrel update`.
 >
 > **Configuration reference.** The full set of configurable keys, defaults,
 > and required-vs-optional flags lives in

--- a/.agents/workflows/helpers/worktree-lifecycle.md
+++ b/.agents/workflows/helpers/worktree-lifecycle.md
@@ -100,7 +100,8 @@ or stale locks.
 
 ## `.agents` copy (consumer projects)
 
-In consumer projects `.agents/` is declared as a git submodule in `.gitmodules`.
+In consumer projects **on the legacy Git-submodule install**, `.agents/` is
+declared as a git submodule in `.gitmodules`.
 When `git worktree add` creates `.worktrees/story-<id>/`, the worktree carries
 its own gitlink entry for `.agents`, and `git worktree remove` then refuses to
 reap it on the grounds that "there is a submodule inside the worktree."
@@ -117,8 +118,9 @@ length worktrees this is acceptable; if the root `.agents/` changes during an
 epic, those updates do not propagate into existing worktrees. Recreate the
 worktree (or add an explicit refresh step) if you need the update mid-epic.
 
-The framework repo itself (where `.agents` is a regular tracked directory, not a
-submodule) skips this behavior. Detection is automatic — keyed off whether
+The framework repo itself — and any npm-installed consumer, where `mandrel sync`
+materializes `.agents/` as a regular tracked directory rather than a submodule —
+skips this behavior. Detection is automatic — keyed off whether
 `.gitmodules` at repo root declares `.agents` as a submodule path.
 
 > **Why copy instead of symlink:** the previous symlink/junction approach caused


### PR DESCRIPTION
## What

Follow-up to #3490 (the npm-distribution repo-wide docs pass). #3490 was scoped
to root `README.md` / `AGENTS.md`, `.agents/README.md`, `.agents/SDLC.md`, and
`docs/*`, and **deliberately did not touch `.agents/rules/` or
`.agents/workflows/`**. Those surfaces still carried stale Git-submodule /
`dist`-branch *distribution* references. This PR reconciles them to the shipped
npm + `mandrel sync` model.

Context: Epics #3436 (npm distribution), #3437 (auto-update), #3438
(consent-first onboarding) are merged; the `dist` branch + Git-submodule
distribution channel is **retired**.

## Changes

- **`.agents/rules/git-conventions.md`** — "Git-submodule-distributed framework
  whose consumers pin to specific versions" → ships as the `@mandrel/agents`
  npm package; consumers pin a lockfile version and upgrade via `mandrel
  update`. The **Contract Cutovers / No-Shim-Layer policy is unchanged** — only
  the distribution-mechanism wording moved.
- **`.agents/workflows/agents-update.md`** — added a **legacy banner** marking
  `/agents-update` + `update-self.js` as the legacy submodule-bump path
  **superseded by `mandrel update`** (matching how `docs/architecture.md` and
  `docs/workflows.md` were reconciled in #3490). Fixed the false "the only
  supported way to upgrade" claim and dropped the retired `dist`-branch
  reference. The legacy submodule mechanics themselves are left intact and
  accurate for that path.
- **`.agents/workflows/helpers/agents-sync-config.md`** — qualified the
  `/agents-update` reference as the legacy path; noted the npm equivalent runs
  as part of `mandrel update`.
- **`.agents/workflows/helpers/worktree-lifecycle.md`** — qualified "consumer
  projects declare `.agents/` as a submodule" as the **legacy install**, and
  noted npm-installed consumers get `.agents/` as a regular `mandrel sync`
  directory. The gitlink-scrub behavior description is unchanged.

## Carve-outs (intentional, matching #3490)

- **Code-sense `submodule` left untouched** — `isAgentsSubmodule` detection,
  gitlink / skip-worktree scrub, and the legacy-path mechanics in
  `agents-update.md` are not the distribution submodule.
- **`changelog-style.md` unchanged** — its `submodule` mentions are
  illustrative *historical changelog examples*; there is **no** `dist`
  reference in it (the one suspected in the hand-off was not present).
- Deliberate migration-guide references (how to move *off* the retired
  submodule) kept intact.

## Out of scope — separate code Epic

`update-self.js` and `/agents-update` still **physically** run
`git submodule update --remote .agents`, which is dead under the npm model.
Retiring that code path (not just its docs) is a code-migration task and is
**not** attempted here — flagged for a follow-up Epic.

## Verification

- `npm run lint` — **0 errors** (markdownlint, `docs:check`, `check-doc-links`,
  `skills:check` all clean).
- Pre-push quality ratchet — 0 breaches / 0 regressions (docs-only).
- Repo-wide grep confirms the remaining `submodule` hits in
  `.agents/{rules,workflows}` are all legacy-path mechanics or code-sense.

Docs-only: no code, `package.json`, or `package-lock.json` changes.

Refs #3490
