### PR TITLE
build: rename npm scope to @mandrelai/agents (@mandrel is unobtainable)

### DIFF
--- a/.agents/README.md
+++ b/.agents/README.md
@@ -1,7 +1,7 @@
 # Mandrel — `.agents/`
 
 This is the framework payload (`.agents/`) consumed by host repos. It ships
-inside the [`@mandrel/agents`](https://www.npmjs.com/package/@mandrel/agents)
+inside the [`@mandrelai/agents`](https://www.npmjs.com/package/@mandrelai/agents)
 npm package and is materialized into a consumer's `./.agents/` directory by
 `mandrel sync`. It carries a system prompt, a baseline rule pack, a
 two-tier skill library, a slash-command workflow set, and the
@@ -29,12 +29,12 @@ From an **empty or existing** project that does not yet have `.agents/`,
 install the package and materialize the framework payload:
 
 ```bash
-npm install @mandrel/agents
-# pnpm add @mandrel/agents
-# yarn add @mandrel/agents
+npm install @mandrelai/agents
+# pnpm add @mandrelai/agents
+# yarn add @mandrelai/agents
 ```
 
-Installing `@mandrel/agents` pins an exact, provenance-signed version in
+Installing `@mandrelai/agents` pins an exact, provenance-signed version in
 your lockfile (the npm publish attaches a Sigstore build-provenance
 statement proving the tarball was built from this repo's CI). The package's
 `postinstall` hook runs `mandrel sync` best-effort, which copies the
@@ -58,12 +58,12 @@ node .agents/scripts/bootstrap.js
 > `.agents/` via `git submodule add -b dist …`. That `dist`-branch channel
 > is retired in favor of the npm package; follow the one-time
 > [`docs/migration-submodule-to-npm.md`](../docs/migration-submodule-to-npm.md)
-> guide to deinit the submodule and switch to `npm install @mandrel/agents`.
+> guide to deinit the submodule and switch to `npm install @mandrelai/agents`.
 
 ### Upgrading and local additions
 
 Once installed, the ongoing upgrade path is **`mandrel update`** — it bumps
-`@mandrel/agents` to the newest non-major version, re-runs `mandrel sync`,
+`@mandrelai/agents` to the newest non-major version, re-runs `mandrel sync`,
 applies version-keyed migrations, and verifies the install with
 `mandrel doctor`. The lockfile bump is left **staged for you to review and
 commit** (the command performs no `git` mutation):

--- a/.agents/rules/git-conventions.md
+++ b/.agents/rules/git-conventions.md
@@ -46,7 +46,7 @@ creation via `story-init.js`; agents commit on the active Story branch only.
 
 ## Contract Cutovers — No Shim Layer
 
-Mandrel ships as the `@mandrel/agents` npm package, whose consumers pin an
+Mandrel ships as the `@mandrelai/agents` npm package, whose consumers pin an
 exact lockfile version; they opt into breaks at upgrade time. Operator policy
 for any contract change (config shape, baseline shape, schema, lifecycle
 payload, ticket label, dispatch artifact, public API of a script) is
@@ -58,7 +58,7 @@ therefore:
    feature flag that toggles between the two shapes.
 2. **The PR diff IS the migration.** A consumer upgrading to a release
    with the change adopts the new shape by upgrading the
-   `@mandrel/agents` package (`mandrel update`). The PR that lands on
+   `@mandrelai/agents` package (`mandrel update`). The PR that lands on
    `main` already moved every internal call site; consumers move on the
    same beat by upgrading.
 3. **No deprecation ledger, no version-windowed sunsets.** The framework

--- a/.agents/scripts/install-matrix-assert.js
+++ b/.agents/scripts/install-matrix-assert.js
@@ -4,7 +4,7 @@
  * Golden-path install assertions for the install matrix (Story #3472).
  *
  * The `.github/workflows/install-matrix.yml` workflow exercises the published
- * package contract — install `@mandrel/agents`, run `mandrel sync`, run
+ * package contract — install `@mandrelai/agents`, run `mandrel sync`, run
  * `mandrel doctor` — across {npm, pnpm, yarn} x {ubuntu-latest,
  * windows-latest}. Rather than spread the per-leg invariants across
  * PowerShell-vs-bash shell snippets (which diverge on quoting, `$?`, and
@@ -19,7 +19,7 @@
  *
  *   2. `manifest-clean` — the consumer's `package.json` was NOT mutated with
  *      the framework's internal runtime dependencies. Installing
- *      `@mandrel/agents` is expected to add exactly that one package to the
+ *      `@mandrelai/agents` is expected to add exactly that one package to the
  *      consumer manifest (npm/pnpm/yarn all record the installed dep); what
  *      MUST NOT happen is the framework's own runtime deps (ajv, js-yaml,
  *      minimatch, …) leaking into the consumer's declared dependencies. Those
@@ -57,7 +57,7 @@ import path from 'node:path';
 /**
  * The framework's internal runtime dependencies. These are declared in
  * `.agents/runtime-deps.json` and provided by the consumer's install of
- * `@mandrel/agents` (npm hoists them into node_modules), but they MUST NOT
+ * `@mandrelai/agents` (npm hoists them into node_modules), but they MUST NOT
  * appear in the consumer's *declared* package.json dependencies. Kept in sync
  * with `.agents/runtime-deps.json` `dependencies` keys.
  */
@@ -84,7 +84,7 @@ const ALL_CHECKS = ['materialized', 'manifest-clean', 'doctor-ready'];
  * @returns {{ consumer?: string, checks: string[], doctorOutput?: string, packageName: string }}
  */
 export function parseArgs(argv) {
-  const opts = { checks: [], packageName: '@mandrel/agents' };
+  const opts = { checks: [], packageName: '@mandrelai/agents' };
   for (let i = 0; i < argv.length; i++) {
     const token = argv[i];
     const eq = token.indexOf('=');
@@ -133,7 +133,7 @@ export function checkMaterialized({ consumer, fs = nodeFs }) {
 
 /**
  * Assert the consumer's package.json was not mutated with framework runtime
- * deps. Installing `@mandrel/agents` itself is expected; the framework's
+ * deps. Installing `@mandrelai/agents` itself is expected; the framework's
  * internal runtime packages are not.
  *
  * @param {{ consumer: string, packageName: string, fs?: typeof nodeFs }} opts

--- a/.agents/scripts/lib/bootstrap/project-bootstrap.js
+++ b/.agents/scripts/lib/bootstrap/project-bootstrap.js
@@ -123,7 +123,7 @@ export function detectPackageManager(projectRoot) {
  * Step 2a/2b/2c — Ensure `package.json` exists and carries the
  * `sync:commands` + `prepare` + `bootstrap` scripts. The consumer manifest
  * is never mutated with framework runtime dependencies: those arrive
- * transitively via the `@mandrel/agents` package, so bootstrap leaves the
+ * transitively via the `@mandrelai/agents` package, so bootstrap leaves the
  * `dependencies` block untouched (Story #3466). Returns the per-key outcome
  * the caller can render.
  */
@@ -178,7 +178,7 @@ export function ensurePackageJson(ctx) {
 /**
  * Step 2d — Install dependencies when the framework's sentinel module is
  * unresolvable. Bootstrap no longer seeds framework deps into the consumer
- * manifest (Story #3466) — they arrive transitively via `@mandrel/agents`
+ * manifest (Story #3466) — they arrive transitively via `@mandrelai/agents`
  * — so the install is triggered purely by an empty/stale `node_modules`.
  * Returns `{ ran, manager, skipped, reason }`.
  */

--- a/.agents/workflows/agents-update.md
+++ b/.agents/workflows/agents-update.md
@@ -9,7 +9,7 @@ description: Legacy submodule-bump upgrade path (superseded by `mandrel update`)
 > CLI** (bump → sync → migrate → doctor) under the npm distribution model
 > (#3436/#3437). They are **retained only for consumer repos that have not yet
 > migrated off the retired `dist`-branch Git submodule**; on the
-> `@mandrel/agents` npm install, upgrade with `mandrel update` instead. The
+> `@mandrelai/agents` npm install, upgrade with `mandrel update` instead. The
 > submodule mechanics described below are accurate for that legacy path and do
 > **not** apply to npm-installed consumers.
 

--- a/.github/workflows/install-matrix.yml
+++ b/.github/workflows/install-matrix.yml
@@ -168,7 +168,7 @@ jobs:
         shell: bash
         working-directory: ${{ env.CONSUMER_DIR }}
         run: |
-          echo "MANDREL_BIN=$CONSUMER_DIR/node_modules/@mandrel/agents/bin/mandrel.js" >> "$GITHUB_ENV"
+          echo "MANDREL_BIN=$CONSUMER_DIR/node_modules/@mandrelai/agents/bin/mandrel.js" >> "$GITHUB_ENV"
 
       - name: Materialize .agents/ (mandrel sync)
         shell: bash

--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,7 @@ dist
 # NOTE: This is the Mandrel framework SOURCE repo, where ./.agents/ IS the
 # committed product — so it is deliberately NOT ignored here (Story #3489).
 # A blanket `/.agents/` ignore (correct for a *consumer* project, where
-# ./.agents/ is a working copy materialized from node_modules/@mandrel/agents
+# ./.agents/ is a working copy materialized from node_modules/@mandrelai/agents
 # by `mandrel sync`) would silently hide newly added framework `.agents/**`
 # source files from `git status`/`git add`. Consumer projects add the
 # `/.agents/` ignore to their OWN .gitignore; the framework repo must not.

--- a/.npmrc
+++ b/.npmrc
@@ -3,7 +3,7 @@
 # --ignore-scripts explicitly in .github/workflows/ci.yml; this file extends
 # the same default to local developer installs (npm install / npm ci).
 #
-# The published @mandrel/agents package ships a `postinstall` hook
+# The published @mandrelai/agents package ships a `postinstall` hook
 # (bin/postinstall.js) that runs `mandrel sync` to materialize ./.agents/ on
 # the *consumer's* machine. That hook is best-effort and exits 0 even when
 # skipped, so this repo-local `ignore-scripts=true` (which suppresses lifecycle

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,7 @@ govern AI coding assistants. The `.claude/` / hook / skill surface
 leans in on Claude Code as the reference runtime, and the dispatcher
 under `.agents/scripts/` treats the dispatch manifest (md + structured
 comment) as the cross-runtime contract. The framework is distributed as
-the [`@mandrel/agents`](https://www.npmjs.com/package/@mandrel/agents) npm
+the [`@mandrelai/agents`](https://www.npmjs.com/package/@mandrelai/agents) npm
 package and materialized into consumer projects' `.agents/` directories by
 `mandrel sync`.
 
@@ -139,7 +139,7 @@ the same machine before and after an optimization. Optional flags:
 2. Make changes inside `.agents/` (the distributed product).
 3. Commit — Husky will auto-lint and format staged `.md` files.
 4. Open a PR against `main`. CI validates the change; once merged,
-   release-please cuts the release that publishes `@mandrel/agents` to npm
+   release-please cuts the release that publishes `@mandrelai/agents` to npm
    (see the Release Checklist below).
 
 ### Release Checklist
@@ -164,10 +164,10 @@ Releases are automated by
    `Validate and Test` passes, GitHub squash-merges the release PR,
    which triggers the workflow to create the GitHub Release, tag
    `main` with `vX.Y.Z`, and run the `npm-publish` job — publishing
-   `@mandrel/agents` to npm with build provenance (Sigstore) once the
+   `@mandrelai/agents` to npm with build provenance (Sigstore) once the
    release is cut. This replaces the retired `dist`-branch mirror:
    consumers now install a versioned, provenance-signed package from npm
-   (`npm install @mandrel/agents`, then `mandrel sync`) instead of pinning
+   (`npm install @mandrelai/agents`, then `mandrel sync`) instead of pinning
    a Git submodule to the `dist` branch. The `npm-publish` job requires the
    `NPM_TOKEN` secret — see [§ npm publish token](#npm-publish-token) below.
 4. **Breaking-change releases** ship a consumer-upgrade runbook under

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -266,8 +266,8 @@ to the npm registry with an automation token (rather than OIDC trusted
 publishing), so it needs a one-time secret:
 
 1. Create an **automation** access token with publish rights on the
-   `@mandrel` scope at <https://www.npmjs.com/settings/~/tokens>. The
-   token owner must be able to publish under `@mandrel`; the first
+   `@mandrelai` scope at <https://www.npmjs.com/settings/~/tokens>. The
+   token owner must be able to publish under `@mandrelai`; the first
    publish of the scoped package relies on `publishConfig.access:
    "public"` (already set in `package.json`) so the public registry
    accepts it.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ natively in GitHub Issues, Labels, and Projects V2.
 ## Prerequisites
 
 Mandrel is installed **into an existing project** from the
-[`@mandrel/agents`](https://www.npmjs.com/package/@mandrel/agents) npm
+[`@mandrelai/agents`](https://www.npmjs.com/package/@mandrelai/agents) npm
 package and wires its orchestration into that project's GitHub repository.
 Before you run `bootstrap.js` you need:
 
@@ -36,7 +36,7 @@ From the root of your existing Git repository (with its GitHub remote
 already configured — see Prerequisites):
 
 ```bash
-npm install @mandrel/agents
+npm install @mandrelai/agents
 npx mandrel sync            # materialize ./.agents/ from the installed package
 node .agents/scripts/bootstrap.js
 # in your agentic IDE:
@@ -44,7 +44,7 @@ node .agents/scripts/bootstrap.js
 /epic-deliver <id>  # wave loop -> validation -> review -> retro -> open PR
 ```
 
-`npm install @mandrel/agents` pins an exact, provenance-signed version in
+`npm install @mandrelai/agents` pins an exact, provenance-signed version in
 your lockfile. The package's `postinstall` hook runs `mandrel sync`
 best-effort, so `./.agents/` is usually materialized automatically; the
 explicit `npx mandrel sync` above is the belt-and-suspenders step for
@@ -100,7 +100,7 @@ mandrel/
 ```
 
 Only `.agents/` is distributed to consumers — it ships inside the
-`@mandrel/agents` npm package and is materialized into a consumer's
+`@mandrelai/agents` npm package and is materialized into a consumer's
 `./.agents/` directory by `mandrel sync`.
 
 ### Install scripts are disabled by default
@@ -119,7 +119,7 @@ for that invocation only.
 CRAP and Maintainability gates fire at every checkpoint (keystroke,
 pre-commit, pre-push, story-close, CI, Epic merge) against the same
 thresholds from `delivery.quality.*` in `.agentrc.json`. Downstream
-projects pull the surface in by upgrading the `@mandrel/agents` package
+projects pull the surface in by upgrading the `@mandrelai/agents` package
 (`mandrel update`).
 
 ### Development
@@ -136,7 +136,7 @@ npm run test:coverage  # tests with coverage gate
 Releases are automated by `release-please`. Land Conventional Commits on
 `main`; release-please opens a single combined `chore: release main` PR
 (two-package manifest mode) that squash-merges itself once CI is green,
-then tags `main` and publishes `@mandrel/agents` to npm. See the
+then tags `main` and publishes `@mandrelai/agents` to npm. See the
 **Contribution Workflow** and **Release Checklist** sections in
 [`AGENTS.md`](AGENTS.md) for the two-package topology, PAT/npm-token setup,
 and major-version policy.

--- a/baselines/maintainability.json
+++ b/baselines/maintainability.json
@@ -2680,7 +2680,7 @@
     },
     {
       "path": "tests/cli/postinstall.test.js",
-      "mi": 130.712
+      "mi": 124.773
     },
     {
       "path": "tests/cli/sync-commands.test.js",

--- a/bin/postinstall.js
+++ b/bin/postinstall.js
@@ -19,12 +19,12 @@
  * **Source-checkout guard (Story #3489).** In the Mandrel framework repo
  * itself, `./.agents/` is not a regenerated working copy — it *is* the
  * committed product, and `mandrel sync` would clobber that source of truth
- * with a copy of `node_modules/@mandrel/agents/.agents/`. Today the repo
+ * with a copy of `node_modules/@mandrelai/agents/.agents/`. Today the repo
  * `.npmrc` (`ignore-scripts=true`) masks this, but a contributor running
  * `npm install --ignore-scripts=false` (or a tool that re-enables scripts)
  * would overwrite the source tree. To make the guard intrinsic rather than
  * config-dependent, the hook detects the source checkout — the repo whose
- * root `package.json#name` is `@mandrel/agents` — and no-ops (exit 0)
+ * root `package.json#name` is `@mandrelai/agents` — and no-ops (exit 0)
  * without invoking the materializer. Consumer installs (where the package is
  * a dependency under a differently-named root `package.json`) are unaffected
  * and still materialize `.agents/` as before.
@@ -41,7 +41,7 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { runSync } from '../lib/cli/sync.js';
 
-const PACKAGE_NAME = '@mandrel/agents';
+const PACKAGE_NAME = '@mandrelai/agents';
 
 const HINT =
   'mandrel: could not materialize ./.agents/ during install — run `mandrel sync` to finish setup.\n';
@@ -51,8 +51,8 @@ const HINT =
  * checkout (as opposed to a consumer project that depends on the package).
  *
  * The signal is the **repo-root** `package.json#name`: in the source repo it
- * is `@mandrel/agents`; in a consumer project it is the consumer's own
- * package name (and `@mandrel/agents` lives under `node_modules/` instead).
+ * is `@mandrelai/agents`; in a consumer project it is the consumer's own
+ * package name (and `@mandrelai/agents` lives under `node_modules/` instead).
  * We resolve the root from this module's own location (`bin/postinstall.js`
  * sits one directory below the repo root), not from `process.cwd()`, so the
  * detection is stable regardless of where npm invokes the hook from.
@@ -62,7 +62,7 @@ const HINT =
  * `package.json` never strands a consumer without their `.agents/` payload.
  *
  * @param {{ fs?: typeof nodeFs, moduleUrl?: string }} [opts]
- * @returns {boolean} `true` when running in the `@mandrel/agents` source repo.
+ * @returns {boolean} `true` when running in the `@mandrelai/agents` source repo.
  */
 export function isSourceCheckout({
   fs = nodeFs,

--- a/create-mandrel/README.md
+++ b/create-mandrel/README.md
@@ -14,13 +14,13 @@ npx create-mandrel [bootstrap flags...]
 The launcher performs the minimum work needed to get Mandrel installed, then
 hands off to the in-tree bootstrap:
 
-1. **Installs `@mandrel/agents` and materializes `.agents` (when absent).** If
+1. **Installs `@mandrelai/agents` and materializes `.agents` (when absent).** If
    your project does not already have an `.agents` directory, the launcher
    installs Mandrel's distributed npm package and then copies the payload into
    `./.agents/`:
 
    ```bash
-   npm install @mandrel/agents
+   npm install @mandrelai/agents
    npx mandrel sync
    ```
 
@@ -56,7 +56,7 @@ npx create-mandrel --assume-yes --owner acme --repo widget
 
 ## Why the package name is hardcoded
 
-The installed package name (`@mandrel/agents`) is a build-time constant. It is
+The installed package name (`@mandrelai/agents`) is a build-time constant. It is
 **never** read from an environment variable, a flag, or any other
 operator-supplied input. The launcher's whole purpose is to make the provenance
 of `.agents/` non-negotiable — accepting an operator-supplied package would let

--- a/create-mandrel/index.js
+++ b/create-mandrel/index.js
@@ -3,14 +3,14 @@
  * create-mandrel — cold-start launcher for Mandrel (Story #3373, #3465).
  *
  * Zero-to-installed entry point for cold-start onboarding. The launcher's
- * single job is to install the distributed `@mandrel/agents` npm package
+ * single job is to install the distributed `@mandrelai/agents` npm package
  * (when `.agents` is absent), materialize it into `./.agents/` via
  * `mandrel sync`, and then hand off to the in-tree bootstrap:
  *
  *   1. If `.agents` is absent →
- *        a. `npm install @mandrel/agents` against a HARDCODED canonical
+ *        a. `npm install @mandrelai/agents` against a HARDCODED canonical
  *           package name, then
- *        b. `npx mandrel sync` to copy `node_modules/@mandrel/agents/` →
+ *        b. `npx mandrel sync` to copy `node_modules/@mandrelai/agents/` →
  *           `./.agents/`.
  *   2. If `.agents` already exists → skip the install/sync and go straight
  *      to bootstrap.
@@ -37,7 +37,7 @@ import path from 'node:path';
  * note in the module header. The package ships the `mandrel` CLI bin and the
  * `.agents/` payload as files (per AGENTS.md § Project Overview / Epic #3436).
  */
-export const CANONICAL_PACKAGE = '@mandrel/agents';
+export const CANONICAL_PACKAGE = '@mandrelai/agents';
 
 /** Path `.agents/` is materialized to, relative to the project root. */
 export const AGENTS_PATH = '.agents';
@@ -48,7 +48,7 @@ export const AGENTS_PATH = '.agents';
  * logic is unit-testable in isolation.
  *
  * When `.agents` is absent the plan is:
- *   npm install @mandrel/agents
+ *   npm install @mandrelai/agents
  *   npx mandrel sync
  *   node .agents/scripts/bootstrap.js [...passthrough]
  *

--- a/create-mandrel/package.json
+++ b/create-mandrel/package.json
@@ -1,7 +1,7 @@
 {
   "name": "create-mandrel",
   "version": "0.2.0",
-  "description": "Cold-start launcher for Mandrel: installs @mandrel/agents, materializes .agents via mandrel sync, then runs bootstrap.",
+  "description": "Cold-start launcher for Mandrel: installs @mandrelai/agents, materializes .agents via mandrel sync, then runs bootstrap.",
   "type": "module",
   "license": "MIT",
   "bin": {

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1038,7 +1038,7 @@ A single GitHub Actions workflow (`ci.yml`) runs on every push and PR:
 
 Distribution is **not** handled by `ci.yml`. A separate `release-please.yml`
 workflow cuts releases and runs the `npm-publish` job that publishes
-`@mandrel/agents` to npm with Sigstore build provenance once a release is
+`@mandrelai/agents` to npm with Sigstore build provenance once a release is
 tagged. The retired `dist`-branch mirror that `ci.yml` once synced no longer
 exists.
 
@@ -1149,7 +1149,7 @@ live LLM metering:
 ## Distribution Model
 
 Mandrel is distributed as the
-[`@mandrel/agents`](https://www.npmjs.com/package/@mandrel/agents) npm package.
+[`@mandrelai/agents`](https://www.npmjs.com/package/@mandrelai/agents) npm package.
 The package payload is materialized into the consumer's `./.agents/` directory
 as plain regular files by `mandrel sync` (run best-effort from the package
 `postinstall`, or invoked directly):
@@ -1157,7 +1157,7 @@ as plain regular files by `mandrel sync` (run best-effort from the package
 ```text
 Consumer Project/
 ├── node_modules/
-│   └── @mandrel/agents/  ← installed package (pinned, provenance-signed)
+│   └── @mandrelai/agents/  ← installed package (pinned, provenance-signed)
 ├── .agents/          ← materialized by `mandrel sync` (copy-only, never a symlink)
 │   ├── instructions.md
 │   ├── personas/
@@ -1170,7 +1170,7 @@ Consumer Project/
 └── ...
 ```
 
-Consumers `npm install @mandrel/agents` (which pins an exact,
+Consumers `npm install @mandrelai/agents` (which pins an exact,
 provenance-signed version in the lockfile), run `mandrel sync` to materialize
 `./.agents/`, copy `starter-agentrc.json` to their project root as
 `.agentrc.json`, and configure their `orchestration` block — see

--- a/docs/compatibility-matrix.md
+++ b/docs/compatibility-matrix.md
@@ -1,7 +1,7 @@
 # Compatibility matrix
 
 This page is the source of truth for the **supported install surface** of the
-[`@mandrel/agents`](https://www.npmjs.com/package/@mandrel/agents) package: the
+[`@mandrelai/agents`](https://www.npmjs.com/package/@mandrelai/agents) package: the
 operating systems, Node.js versions, and package managers that the framework is
 tested and supported against.
 
@@ -36,7 +36,7 @@ The install matrix runs every package manager against every OS:
 `yarn` refers to **classic yarn** (the Corepack default for the `yarn` shim).
 Yarn Berry (PnP) is not exercised by the matrix; if you use Berry, install in
 `node-modules` linker mode so `mandrel sync` can resolve the package root from
-`node_modules/@mandrel/agents`.
+`node_modules/@mandrelai/agents`.
 
 ---
 
@@ -60,14 +60,14 @@ within the declared range but are not separately gated.
 
 ## Package-manager notes
 
-- **npm** — the reference package manager. `npm install @mandrel/agents`
+- **npm** — the reference package manager. `npm install @mandrelai/agents`
   runs the `postinstall` hook (best-effort `mandrel sync`) automatically
   unless `--ignore-scripts` is set.
 - **pnpm** — supported. Enable it via Corepack (`corepack enable`) and use
-  `pnpm add @mandrel/agents`. `mandrel sync` resolves the package root from
+  `pnpm add @mandrelai/agents`. `mandrel sync` resolves the package root from
   pnpm's `node_modules` layout, so it works under pnpm's symlinked store.
 - **yarn (classic)** — supported. Enable via Corepack and use
-  `yarn add @mandrel/agents`.
+  `yarn add @mandrelai/agents`.
 
 In all three cases, if the lifecycle scripts are skipped (`--ignore-scripts`
 or the equivalent), run `npx mandrel sync` afterward to materialize

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -85,7 +85,7 @@ the Epic itself execute on intact 4-tier infrastructure:
   Stories must stay sized for the agent to commit incrementally
   inside one worktree; otherwise rollback windows grow.
 - Breaking change for consumers — published surface flips at F8.
-  Consumers re-pin the `@mandrel/agents` package on upgrade per the
+  Consumers re-pin the `@mandrelai/agents` package on upgrade per the
   [hard-cutover policy](#contract-cutovers-no-shim-layer) (see also
   [`.agents/rules/git-conventions.md`](../.agents/rules/git-conventions.md)).
   (This ADR predates the npm-distribution cutover (#3436); the upgrade unit

--- a/docs/examples/dependabot.yml
+++ b/docs/examples/dependabot.yml
@@ -1,4 +1,4 @@
-# Example consumer .github/dependabot.yml — scoped to the @mandrel/agents
+# Example consumer .github/dependabot.yml — scoped to the @mandrelai/agents
 # framework lifecycle. Drop this into your consumer project's .github/
 # directory (merge the `updates` entry with your existing config). The
 # `mandrel doctor` CI gate and the auto-merge workflow live alongside it; see
@@ -10,7 +10,7 @@ updates:
     schedule:
       interval: "weekly"
     allow:
-      - dependency-name: "@mandrel/agents"
+      - dependency-name: "@mandrelai/agents"
     labels:
       - "mandrel"
       - "dependencies"
@@ -19,5 +19,5 @@ updates:
       include: "scope"
     # Hold the deliberate 1.x -> 2.0 major for manual review (see docs/upgrade-major.md).
     ignore:
-      - dependency-name: "@mandrel/agents"
+      - dependency-name: "@mandrelai/agents"
         update-types: ["version-update:semver-major"]

--- a/docs/examples/renovate.json
+++ b/docs/examples/renovate.json
@@ -4,7 +4,7 @@
   "packageRules": [
     {
       "description": "Mandrel framework: auto-merge minor/patch on the 1.x line once doctor passes in CI",
-      "matchPackageNames": ["@mandrel/agents"],
+      "matchPackageNames": ["@mandrelai/agents"],
       "matchUpdateTypes": ["minor", "patch"],
       "groupName": "mandrel",
       "automerge": true,
@@ -13,7 +13,7 @@
     },
     {
       "description": "Mandrel framework: hold the deliberate 1.x -> 2.0 major for manual review (see docs/upgrade-major.md)",
-      "matchPackageNames": ["@mandrel/agents"],
+      "matchPackageNames": ["@mandrelai/agents"],
       "matchUpdateTypes": ["major"],
       "automerge": false,
       "labels": ["mandrel", "major-update"]

--- a/docs/migration-submodule-to-npm.md
+++ b/docs/migration-submodule-to-npm.md
@@ -4,7 +4,7 @@ Mandrel used to ship as a **Git submodule** pinned to the `dist` branch:
 consumers ran `git submodule add -b dist … .agents` and pulled framework
 updates by advancing the submodule pointer. That distribution channel is
 **retired**. The framework now ships as a versioned, provenance-signed npm
-package, [`@mandrel/agents`](https://www.npmjs.com/package/@mandrel/agents),
+package, [`@mandrelai/agents`](https://www.npmjs.com/package/@mandrelai/agents),
 and the `.agents/` working tree is **materialized from the installed package**
 by `mandrel sync` (a plain file copy — never a symlink).
 
@@ -29,13 +29,13 @@ instead — they never touch a submodule at all.
 If you run a coding agent in your consumer project, paste the **single,
 self-contained prompt** below and let it perform the whole migration. It
 embeds every step, so the agent does not need this file. The only mutations
-are the submodule removal, the `@mandrel/agents` install, and the materialized
+are the submodule removal, the `@mandrelai/agents` install, and the materialized
 `./.agents/` tree — all reviewable in a PR — and the agent stops if
 `mandrel doctor` is not green.
 
 ```text
 You are migrating this project from the retired Mandrel **Git submodule**
-(`.agents/` pinned to the `dist` branch) to the **`@mandrel/agents` npm
+(`.agents/` pinned to the `dist` branch) to the **`@mandrelai/agents` npm
 package**. Work on a NEW branch and open a PR — do not push to the default
 branch, and do not bypass git hooks. If any step fails, or `mandrel doctor` is
 not green at the end, STOP and report it — do not paper over it.
@@ -66,8 +66,8 @@ not green at the end, STOP and report it — do not paper over it.
    error).
 
 6. Install the package, pinning an exact version in the lockfile:
-   `npm install @mandrel/agents` (or `pnpm add @mandrel/agents` /
-   `yarn add @mandrel/agents`). The package `postinstall` runs `mandrel sync`
+   `npm install @mandrelai/agents` (or `pnpm add @mandrelai/agents` /
+   `yarn add @mandrelai/agents`). The package `postinstall` runs `mandrel sync`
    best-effort; if your install used `--ignore-scripts`, the next step runs it
    explicitly.
 
@@ -85,10 +85,10 @@ not green at the end, STOP and report it — do not paper over it.
    `npx mandrel sync-commands`. Leave every other hook untouched.
 
 10. Commit everything on the branch: `git add -A`, then
-    `git commit -m "build: migrate Mandrel from git submodule to @mandrel/agents npm package"`.
+    `git commit -m "build: migrate Mandrel from git submodule to @mandrelai/agents npm package"`.
 
 11. Verify, then open the PR and report results: `git submodule status` shows
-    no `.agents` entry; `npm ls @mandrel/agents` resolves the pinned version;
+    no `.agents` entry; `npm ls @mandrelai/agents` resolves the pinned version;
     `git ls-files -s .agents | head -1` shows mode `100644` (a regular file),
     NOT `160000` (a gitlink); and `npx mandrel doctor` is green.
 ```
@@ -163,13 +163,13 @@ git config --remove-section submodule..agents 2>/dev/null || true
 
 ### 4. Install the npm package
 
-Add `@mandrel/agents` as a regular dependency with your project's package
+Add `@mandrelai/agents` as a regular dependency with your project's package
 manager. This pins an exact version in your lockfile.
 
 ```bash
-npm install @mandrel/agents
-# pnpm add @mandrel/agents
-# yarn add @mandrel/agents
+npm install @mandrelai/agents
+# pnpm add @mandrelai/agents
+# yarn add @mandrelai/agents
 ```
 
 The package ships a `postinstall` hook that runs `mandrel sync` on a
@@ -178,14 +178,14 @@ If you install with `--ignore-scripts` (or your CI does), the postinstall is
 skipped and you run `mandrel sync` yourself in the next step.
 
 > **Pin a specific version** by appending `@<version>` (for example
-> `npm install @mandrel/agents@1.43.0`). Upgrades are then a normal
-> `npm install @mandrel/agents@<newer>` followed by `mandrel sync` — no
+> `npm install @mandrelai/agents@1.43.0`). Upgrades are then a normal
+> `npm install @mandrelai/agents@<newer>` followed by `mandrel sync` — no
 > `git submodule update`.
 
 ### 5. Materialize `./.agents/` with `mandrel sync`
 
 `mandrel sync` copies the package's `.agents/` payload
-(`node_modules/@mandrel/agents/.agents/`) into your project's `./.agents/`
+(`node_modules/@mandrelai/agents/.agents/`) into your project's `./.agents/`
 directory as **plain regular files**. It is idempotent — rerun it any time to
 re-materialize after an upgrade.
 
@@ -234,7 +234,7 @@ Stage the submodule removal, the new dependency, and the materialized
 
 ```bash
 git add -A
-git commit -m "build: migrate Mandrel from git submodule to @mandrel/agents npm package"
+git commit -m "build: migrate Mandrel from git submodule to @mandrelai/agents npm package"
 ```
 
 ---
@@ -245,7 +245,7 @@ git commit -m "build: migrate Mandrel from git submodule to @mandrel/agents npm 
 | ----- | ------- | -------- |
 | Submodule is gone | `git submodule status` | No `.agents` entry |
 | No `.gitmodules` stanza | `grep -c '\.agents' .gitmodules` (if the file still exists) | No `[submodule ".agents"]` block |
-| Package is installed | `npm ls @mandrel/agents` | Resolves to the version you pinned |
+| Package is installed | `npm ls @mandrelai/agents` | Resolves to the version you pinned |
 | `.agents/` is plain files | `git ls-files -s .agents \| head -1` | Mode `100644` (a regular file), **not** `160000` (a gitlink) |
 | Install is healthy | `npx mandrel doctor` | `✅  Ready (N/N checks passed)` |
 
@@ -311,7 +311,7 @@ directly; consumers use the installed package bin via `npx mandrel`.)
 
 Once you are on the package, upgrades no longer involve Git at all. The
 ongoing upgrade path is the **`mandrel update`** orchestrator — a single
-command that advances `@mandrel/agents` to the newest non-major published
+command that advances `@mandrelai/agents` to the newest non-major published
 version and drives the whole post-bump cycle for you:
 
 ```bash
@@ -320,7 +320,7 @@ npx mandrel update
 
 On a routine (non-major) bump, `mandrel update` runs four ordered steps:
 
-1. **`npm update`** — bumps the `@mandrel/agents` dependency to the newest
+1. **`npm update`** — bumps the `@mandrelai/agents` dependency to the newest
    non-major version. The lockfile change is **left staged on disk, never
    committed** — `mandrel update` performs no `git` mutation, so you review
    and commit the bump yourself.

--- a/docs/quality-gates.md
+++ b/docs/quality-gates.md
@@ -300,7 +300,7 @@ produces. No new runtime dependencies. Runs at three sites:
 `.husky/pre-push`.
 
 If you're a consumer repo that installed the framework via the
-`@mandrel/agents` npm package (`mandrel sync`), this is what you need to know.
+`@mandrelai/agents` npm package (`mandrel sync`), this is what you need to know.
 
 ### First-run behavior — bootstrap before the first push
 

--- a/docs/renovate-dependabot.md
+++ b/docs/renovate-dependabot.md
@@ -1,14 +1,14 @@
 # Renovate / Dependabot integration
 
-Mandrel ships as the npm package [`@mandrel/agents`](https://www.npmjs.com/package/@mandrel/agents), and the `.agents/` working tree is materialized from the installed package by `mandrel sync` (see [`migration-submodule-to-npm.md`](migration-submodule-to-npm.md)). Because the framework is a regular versioned dependency pinned in your lockfile, framework upgrades can ride the **same dependency-update PRs** you already use for every other package — Renovate or Dependabot opens the bump, `mandrel doctor` gates it in CI, and you review and merge it like any other dependency PR.
+Mandrel ships as the npm package [`@mandrelai/agents`](https://www.npmjs.com/package/@mandrelai/agents), and the `.agents/` working tree is materialized from the installed package by `mandrel sync` (see [`migration-submodule-to-npm.md`](migration-submodule-to-npm.md)). Because the framework is a regular versioned dependency pinned in your lockfile, framework upgrades can ride the **same dependency-update PRs** you already use for every other package — Renovate or Dependabot opens the bump, `mandrel doctor` gates it in CI, and you review and merge it like any other dependency PR.
 
 This guide gives you a drop-in config for **both** bots. Pick whichever your project already runs — you do not need both. Each config:
 
-- **Scopes to `@mandrel/agents`** so the rules here only govern the framework dependency (your other packages keep their existing update policy).
+- **Scopes to `@mandrelai/agents`** so the rules here only govern the framework dependency (your other packages keep their existing update policy).
 - **Runs `mandrel doctor` as the CI gate** so a bump only goes green when `.agents/` re-materializes cleanly, the consumer manifest is unpolluted, the slash commands are in sync, and `gh` is authenticated.
 - **Respects the versioning model.** Mandrel lives on the **1.x** line and is released by `release-please` with `versioning: always-bump-minor`, so routine releases only advance the **minor** axis. A **major (1.x → 2.0) is a deliberate, manual operator decision** ([AGENTS.md § Major-version policy](../AGENTS.md)) and is the rare, runbook-backed event documented in [`upgrade-major.md`](upgrade-major.md). The bot configs below therefore let minor/patch bumps flow automatically but **always hold a major for manual review**.
 
-> **These are example consumer configs.** They belong in the project that *depends on* `@mandrel/agents`, not in this repository. (This repository is the framework itself; its own root `renovate.json` governs Mandrel's own dependencies and is unrelated to the consumer examples here.) Copy the block for your bot into your consumer project root. The two configs below are also shipped verbatim as parseable example files at [`examples/renovate.json`](examples/renovate.json) and [`examples/dependabot.yml`](examples/dependabot.yml) so you can copy them straight from disk.
+> **These are example consumer configs.** They belong in the project that *depends on* `@mandrelai/agents`, not in this repository. (This repository is the framework itself; its own root `renovate.json` governs Mandrel's own dependencies and is unrelated to the consumer examples here.) Copy the block for your bot into your consumer project root. The two configs below are also shipped verbatim as parseable example files at [`examples/renovate.json`](examples/renovate.json) and [`examples/dependabot.yml`](examples/dependabot.yml) so you can copy them straight from disk.
 
 ---
 
@@ -16,7 +16,7 @@ This guide gives you a drop-in config for **both** bots. Pick whichever your pro
 
 Whichever bot you use, the lifecycle of a Mandrel bump PR is the same:
 
-1. The bot detects a newer `@mandrel/agents` on npm and opens a PR that bumps the version in `package.json` and the lockfile.
+1. The bot detects a newer `@mandrelai/agents` on npm and opens a PR that bumps the version in `package.json` and the lockfile.
 2. CI checks out the PR branch, installs dependencies, and runs `npx mandrel sync` followed by `npx mandrel doctor`.
 3. `mandrel sync` re-materializes `./.agents/` from the new package payload; `mandrel doctor` verifies the result and **exits non-zero** if anything is wrong (drift, unmaterialized tree, stale slash commands).
 4. A green `doctor` means the upgrade is clean — merge the PR. A red `doctor` means the upgrade needs attention before it lands.
@@ -29,7 +29,7 @@ A **major** bump (1.x → 2.0) is held for manual review by both configs below. 
 
 ## Renovate
 
-Add a `renovate.json` (or a `renovate` key in `package.json`) to your consumer project root. This config isolates `@mandrel/agents` into its own package rule, auto-merges minor/patch once CI is green, and pins a major for manual review.
+Add a `renovate.json` (or a `renovate` key in `package.json`) to your consumer project root. This config isolates `@mandrelai/agents` into its own package rule, auto-merges minor/patch once CI is green, and pins a major for manual review.
 
 ```json
 {
@@ -38,7 +38,7 @@ Add a `renovate.json` (or a `renovate` key in `package.json`) to your consumer p
   "packageRules": [
     {
       "description": "Mandrel framework: auto-merge minor/patch on the 1.x line once doctor passes in CI",
-      "matchPackageNames": ["@mandrel/agents"],
+      "matchPackageNames": ["@mandrelai/agents"],
       "matchUpdateTypes": ["minor", "patch"],
       "groupName": "mandrel",
       "automerge": true,
@@ -47,7 +47,7 @@ Add a `renovate.json` (or a `renovate` key in `package.json`) to your consumer p
     },
     {
       "description": "Mandrel framework: hold the deliberate 1.x -> 2.0 major for manual review (see docs/upgrade-major.md)",
-      "matchPackageNames": ["@mandrel/agents"],
+      "matchPackageNames": ["@mandrelai/agents"],
       "matchUpdateTypes": ["major"],
       "automerge": false,
       "labels": ["mandrel", "major-update"]
@@ -85,7 +85,7 @@ With this in place a minor/patch Mandrel bump opens, runs `mandrel doctor`, and 
 
 ## Dependabot
 
-Add a `.github/dependabot.yml` to your consumer project root. Dependabot has no per-package auto-merge knob in the config file, so the policy split (auto-merge minor/patch, hold majors) is expressed with `ignore` + a companion auto-merge workflow. The config below limits Dependabot to `@mandrel/agents` updates for the framework lifecycle (keep your existing entries for the rest of your dependencies):
+Add a `.github/dependabot.yml` to your consumer project root. Dependabot has no per-package auto-merge knob in the config file, so the policy split (auto-merge minor/patch, hold majors) is expressed with `ignore` + a companion auto-merge workflow. The config below limits Dependabot to `@mandrelai/agents` updates for the framework lifecycle (keep your existing entries for the rest of your dependencies):
 
 ```yaml
 # .github/dependabot.yml
@@ -96,7 +96,7 @@ updates:
     schedule:
       interval: "weekly"
     allow:
-      - dependency-name: "@mandrel/agents"
+      - dependency-name: "@mandrelai/agents"
     labels:
       - "mandrel"
       - "dependencies"
@@ -105,7 +105,7 @@ updates:
       include: "scope"
     # Hold the deliberate 1.x -> 2.0 major for manual review (see docs/upgrade-major.md).
     ignore:
-      - dependency-name: "@mandrel/agents"
+      - dependency-name: "@mandrelai/agents"
         update-types: ["version-update:semver-major"]
 ```
 
@@ -129,7 +129,7 @@ jobs:
         id: meta
       - name: Enable auto-merge for Mandrel minor/patch
         if: >-
-          steps.meta.outputs.dependency-names == '@mandrel/agents' &&
+          steps.meta.outputs.dependency-names == '@mandrelai/agents' &&
           (steps.meta.outputs.update-type == 'version-update:semver-minor' ||
            steps.meta.outputs.update-type == 'version-update:semver-patch')
         run: gh pr merge --auto --squash "$PR_URL"
@@ -148,6 +148,6 @@ Both example configs are plain JSON / YAML and parse without error. After droppi
 
 - **Renovate:** run `npx --yes renovate-config-validator renovate.json` (or let the Renovate app validate on its first run and post to the Dependency Dashboard).
 - **Dependabot:** push the file; GitHub validates `.github/dependabot.yml` on commit and surfaces parse errors in the repository's **Insights → Dependency graph → Dependabot** tab.
-- **The gate:** open a throwaway PR that bumps `@mandrel/agents` and confirm the `mandrel-doctor` job runs and reports `✅  Ready (N/N checks passed)`.
+- **The gate:** open a throwaway PR that bumps `@mandrelai/agents` and confirm the `mandrel-doctor` job runs and reports `✅  Ready (N/N checks passed)`.
 
 For the supported OS / Node / package-manager combinations the doctor gate runs against, see [`compatibility-matrix.md`](compatibility-matrix.md).

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -708,7 +708,7 @@ produced a leakage map worth recording before any portability work is scoped:
 #### Finding 3 — Distribution is not productized
 
 Evidence (point-in-time, **resolved by #3436** — the framework now ships as
-the `@mandrel/agents` npm package and is no longer distributed via the
+the `@mandrelai/agents` npm package and is no longer distributed via the
 `dist`-branch submodule):
 
 - Root `package.json` had no `bin`, `files`, `publishConfig`, or `workspaces`,
@@ -737,7 +737,7 @@ Deferred remainder:
 - `release-please` manages the root package and `.agents/VERSION`; major bumps
   are intentionally capped (`always-bump-minor`). (The former `dist` sync that
   copied `.agents/` after main merge is retired — #3436 publishes the
-  `@mandrel/agents` npm package instead.)
+  `@mandrelai/agents` npm package instead.)
 - Paid products additionally need: a formal version/support policy, deprecation
   policy, rollback guidance, cross-version config-compatibility tests, automated
   migration checks for breaking changes, and operator-facing release notes
@@ -889,7 +889,7 @@ and compatibility tests across npm/pnpm/yarn and Windows/macOS/Linux.
 #### Finding 16 — Product UX and discoverability are developer-internal
 
 Evidence: the README assumed Git submodules (now reconciled to the
-`@mandrel/agents` npm package + `mandrel sync` model per #3436), GitHub remotes,
+`@mandrelai/agents` npm package + `mandrel sync` model per #3436), GitHub remotes,
 `gh`, and slash commands; `.agents/README.md` is framework-author oriented;
 docs are scattered; there are no screenshots, demo videos, tutorials, sample
 repos, comparison pages, pricing pages, or a "first successful run" path.

--- a/docs/upgrade-major.md
+++ b/docs/upgrade-major.md
@@ -1,6 +1,6 @@
 # Upgrading across a major version (breaking-change runbook)
 
-This is the runbook the `mandrel update` **major gate** points you at. When the newest published `@mandrel/agents` crosses a major boundary (for example `1.x → 2.0`), `mandrel update` **refuses to apply it automatically** — it prints the available version, a pointer to this document, and exits non-zero without mutating anything. You cross the boundary deliberately, with this runbook in hand, by re-running with `--major`.
+This is the runbook the `mandrel update` **major gate** points you at. When the newest published `@mandrelai/agents` crosses a major boundary (for example `1.x → 2.0`), `mandrel update` **refuses to apply it automatically** — it prints the available version, a pointer to this document, and exits non-zero without mutating anything. You cross the boundary deliberately, with this runbook in hand, by re-running with `--major`.
 
 > **Why a major is gated.** Mandrel lives on the **1.x** line and is released by `release-please` with `versioning: always-bump-minor` — routine work only ever advances the **minor** axis, even when a commit carries a `BREAKING CHANGE:` footer. A **major release is a deliberate, manual operator decision** on the framework side ([AGENTS.md § Major-version policy](../AGENTS.md)): an operator sets the version explicitly via a `Release-As: X.0.0` trailer or an in-place version edit on the release PR. The consumer-side major gate is the mirror image of that manual step: just as a major release cannot be cut by reflex, a major upgrade cannot be **adopted** by reflex. Minor and patch bumps within the 1.x line are never gated — only the rare major crossing is.
 
@@ -12,7 +12,7 @@ Mandrel follows a **hard-cutover contract** ([`.agents/rules/git-conventions.md`
 
 In npm terms this means:
 
-- **The package version *is* the contract version.** Your lockfile pins an exact `@mandrel/agents` version, so you are always reading exactly one shape of every artifact — the one that ships in the version you installed. There is no "compatibility mode" to fall back to.
+- **The package version *is* the contract version.** Your lockfile pins an exact `@mandrelai/agents` version, so you are always reading exactly one shape of every artifact — the one that ships in the version you installed. There is no "compatibility mode" to fall back to.
 - **A major bump signals a hard cutover.** A `1.x → 2.0` crossing is the framework telling you that at least one contract shape changed with no backward-compatible reader. You adopt the new shape by upgrading the package; the **PR diff for the version bump is the migration boundary**.
 - **Migrations run forward only.** `mandrel update` runs the version-keyed migration steps for the range you are crossing (each step is idempotent and prints what it changed and why). There is no down-migration: to revert, you pin the previous version in your lockfile and re-`sync`.
 
@@ -50,7 +50,7 @@ npx mandrel update --major
 
 With `--major`, `mandrel update` runs the full cycle and prints the breaking-change notes inline:
 
-1. **npm install.** It installs `@mandrel/agents@<2.0.0>` via npm. The lockfile change is **left staged, never committed** — `mandrel update` performs no `git` mutation, matching the "operator commits the lockfile" contract.
+1. **npm install.** It installs `@mandrelai/agents@<2.0.0>` via npm. The lockfile change is **left staged, never committed** — `mandrel update` performs no `git` mutation, matching the "operator commits the lockfile" contract.
 2. **Re-materialize.** It runs `mandrel sync` so `./.agents/` reflects the new package payload (a plain file copy; your `.agents/local/` zone is never touched).
 3. **Migrate.** It runs every version-keyed migration step in the `installed → target` range, in ascending version order. Each applied step prints an actionable `migrated: <file> — <what changed / why>` line. Migrations are idempotent, so a re-run is a safe no-op.
 4. **Verify with doctor.** It runs `mandrel doctor` and reports success **only when every check passes**. A failing doctor makes `update` exit non-zero so you treat the upgrade as incomplete rather than done.
@@ -71,7 +71,7 @@ Once doctor is green, stage and commit the lockfile bump, the re-materialized `.
 
 ```bash
 git add -A
-git commit -m "build: upgrade @mandrel/agents to 2.0.0"
+git commit -m "build: upgrade @mandrelai/agents to 2.0.0"
 ```
 
 Open a PR so the breaking diff is reviewed before it lands on your default branch.
@@ -93,7 +93,7 @@ Renovate and Dependabot are configured to **hold** the `1.x → 2.0` major for m
 There is no down-migration. To roll back a major you adopted:
 
 ```bash
-npm install @mandrel/agents@<previous-1.x-version>
+npm install @mandrelai/agents@<previous-1.x-version>
 npx mandrel sync
 npx mandrel doctor
 ```

--- a/lib/cli/__tests__/sync-local-zone.test.js
+++ b/lib/cli/__tests__/sync-local-zone.test.js
@@ -105,7 +105,7 @@ function makeCapture() {
 }
 
 const PROJECT = path.join(path.sep, 'proj');
-const PKG_ROOT = path.join(PROJECT, 'node_modules', '@mandrel', 'agents');
+const PKG_ROOT = path.join(PROJECT, 'node_modules', '@mandrelai', 'agents');
 const SRC_AGENTS = path.join(PKG_ROOT, '.agents');
 const resolveToPkg = () => PKG_ROOT;
 

--- a/lib/cli/__tests__/sync.test.js
+++ b/lib/cli/__tests__/sync.test.js
@@ -12,7 +12,7 @@
  *      (no symlinks created — symlinkSync is never called).
  *   2. Re-running is idempotent — a second run leaves ./.agents/
  *      byte-identical.
- *   3. Exits non-zero with an actionable message when @mandrel/agents is
+ *   3. Exits non-zero with an actionable message when @mandrelai/agents is
  *      not resolvable in node_modules.
  *   4. --dry-run reports planned copies and writes nothing.
  *   5. Module shape: runSync named export + default function export.
@@ -233,9 +233,11 @@ describe('runSync — idempotent re-run', () => {
 // AC3 — missing package → non-zero exit with actionable message
 // ---------------------------------------------------------------------------
 
-describe('runSync — @mandrel/agents not resolvable', () => {
+describe('runSync — @mandrelai/agents not resolvable', () => {
   function resolveThrows() {
-    const err = new Error("Cannot find module '@mandrel/agents/package.json'");
+    const err = new Error(
+      "Cannot find module '@mandrelai/agents/package.json'",
+    );
     err.code = 'MODULE_NOT_FOUND';
     throw err;
   }

--- a/lib/cli/__tests__/sync.test.js
+++ b/lib/cli/__tests__/sync.test.js
@@ -107,7 +107,7 @@ function makeCapture() {
 }
 
 const PROJECT = path.join(path.sep, 'proj');
-const PKG_ROOT = path.join(PROJECT, 'node_modules', '@mandrel', 'agents');
+const PKG_ROOT = path.join(PROJECT, 'node_modules', '@mandrelai', 'agents');
 
 /** Seed a package payload of two files under <pkg>/.agents/. */
 function seedPackagePayload() {
@@ -270,8 +270,8 @@ describe('runSync — @mandrelai/agents not resolvable', () => {
       exit: cap.exit,
     });
     const joined = cap.err.join('');
-    assert.match(joined, /@mandrel\/agents/);
-    assert.match(joined, /npm install @mandrel\/agents/);
+    assert.match(joined, /@mandrelai\/agents/);
+    assert.match(joined, /npm install @mandrelai\/agents/);
   });
 
   it('writes nothing to the destination', () => {

--- a/lib/cli/registry.js
+++ b/lib/cli/registry.js
@@ -341,7 +341,7 @@ function runRuntimeDeps({
 /**
  * Verify that the `.agents/` payload has been materialized into the consumer
  * project (`./.agents/instructions.md` exists). When it is absent but the
- * `@mandrel/agents` package *is* installed in node_modules, the project is in
+ * `@mandrelai/agents` package *is* installed in node_modules, the project is in
  * the "postinstall-skipped" state — the package was installed with scripts
  * disabled (e.g. `npm ci --ignore-scripts`, a sandboxed CI, or a package
  * manager that skips lifecycle scripts), so the materializer never ran. The
@@ -350,13 +350,13 @@ function runRuntimeDeps({
  * Resolution anchors:
  * - `./.agents/instructions.md` is resolved against `cwd` (the consumer
  *   project root), matching where `mandrel sync` writes the materialized tree.
- * - `@mandrel/agents` is resolved from `cwd` so we detect *their* install, not
+ * - `@mandrelai/agents` is resolved from `cwd` so we detect *their* install, not
  *   a copy hoisted next to this CLI module — mirroring sync.js's resolver.
  *
  * Injectable seams (used by tests so no real filesystem or package is needed):
  * - `cwd()` — replaces `process.cwd`.
  * - `existsSync(p)` — replaces `fs.existsSync`.
- * - `resolvePackage(fromDir)` — replaces `@mandrel/agents` resolution; throws
+ * - `resolvePackage(fromDir)` — replaces `@mandrelai/agents` resolution; throws
  *   when the package is not installed.
  *
  * @param {{
@@ -380,7 +380,7 @@ function runAgentsMaterialized({ cwd, existsSync, resolvePackage } = {}) {
     resolvePackage ??
     ((fromDir) => {
       const requireFrom = createRequire(path.join(fromDir, 'noop.js'));
-      return requireFrom.resolve('@mandrel/agents/package.json');
+      return requireFrom.resolve('@mandrelai/agents/package.json');
     });
 
   let packageInstalled = false;
@@ -394,7 +394,7 @@ function runAgentsMaterialized({ cwd, existsSync, resolvePackage } = {}) {
   if (packageInstalled) {
     return {
       ok: false,
-      detail: '@mandrel/agents installed but ./.agents/ not materialized',
+      detail: '@mandrelai/agents installed but ./.agents/ not materialized',
       remedy:
         'Run `mandrel sync` to materialize the .agents/ payload (postinstall was skipped).',
     };
@@ -402,9 +402,9 @@ function runAgentsMaterialized({ cwd, existsSync, resolvePackage } = {}) {
 
   return {
     ok: false,
-    detail: '@mandrel/agents not installed and ./.agents/ absent',
+    detail: '@mandrelai/agents not installed and ./.agents/ absent',
     remedy:
-      'Install the framework (`npm install @mandrel/agents`), then run `mandrel sync`.',
+      'Install the framework (`npm install @mandrelai/agents`), then run `mandrel sync`.',
   };
 }
 
@@ -416,7 +416,7 @@ function runAgentsMaterialized({ cwd, existsSync, resolvePackage } = {}) {
  * Package name whose `.agents/` payload is the drift baseline. Mirrors
  * `lib/cli/sync.js#PACKAGE_NAME`.
  */
-const PACKAGE_NAME = '@mandrel/agents';
+const PACKAGE_NAME = '@mandrelai/agents';
 
 /**
  * Top-level directory name (relative to `.agents/`) reserved as the
@@ -430,7 +430,7 @@ const PACKAGE_NAME = '@mandrel/agents';
 const LOCAL_ZONE_DIR = 'local';
 
 /**
- * Default resolver: locate the installed `@mandrel/agents` package root by
+ * Default resolver: locate the installed `@mandrelai/agents` package root by
  * resolving its `package.json` and returning the directory that contains it.
  * Mirrors `lib/cli/sync.js#defaultResolvePackageRoot` so the drift baseline
  * is exactly the payload that `mandrel sync` would copy.
@@ -477,7 +477,7 @@ function listPayloadFiles(dir, fsImpl, prefix = '') {
 
 /**
  * Compare the consumer's materialized `./.agents/<f>` bytes against the
- * installed package payload (`node_modules/@mandrel/agents/.agents/<f>`),
+ * installed package payload (`node_modules/@mandrelai/agents/.agents/<f>`),
  * excluding the `.agents/local/` zone. Reports the first drifted (or
  * missing) materialized file so the operator can re-sync or move local edits
  * into `.agents/local/`.
@@ -491,7 +491,7 @@ function listPayloadFiles(dir, fsImpl, prefix = '') {
  * - `cwd()` — replaces `process.cwd`.
  * - `fsImpl` — replaces the `node:fs` surface (`existsSync`, `readdirSync`,
  *   `readFileSync`).
- * - `resolvePackageRoot(fromDir)` — replaces `@mandrel/agents` resolution;
+ * - `resolvePackageRoot(fromDir)` — replaces `@mandrelai/agents` resolution;
  *   throws when the package is not installed.
  *
  * @param {{
@@ -515,7 +515,7 @@ function runAgentsDrift({ cwd, fsImpl = fs, resolvePackageRoot } = {}) {
     // a no-op success rather than a false drift signal.
     return {
       ok: true,
-      detail: '@mandrel/agents not installed — drift skipped',
+      detail: '@mandrelai/agents not installed — drift skipped',
     };
   }
 
@@ -523,7 +523,7 @@ function runAgentsDrift({ cwd, fsImpl = fs, resolvePackageRoot } = {}) {
   if (!fsImpl.existsSync(sourceRoot)) {
     return {
       ok: true,
-      detail: '@mandrel/agents ships no .agents/ payload — drift skipped',
+      detail: '@mandrelai/agents ships no .agents/ payload — drift skipped',
     };
   }
 
@@ -610,7 +610,7 @@ function compareSemver(a, b) {
 }
 
 /**
- * Resolve the installed `@mandrel/agents` version from this package's own
+ * Resolve the installed `@mandrelai/agents` version from this package's own
  * `package.json`. This module lives at `<root>/lib/cli/registry.js`, so the
  * manifest is two directories up. Mirrors `lib/cli/update.js#defaultCurrentVersion`.
  *

--- a/lib/cli/sync.js
+++ b/lib/cli/sync.js
@@ -3,7 +3,7 @@
  * `mandrel sync` subcommand — the .agents/ materializer.
  *
  * Copies the published package payload
- * (`node_modules/@mandrel/agents/.agents/`) into the consumer project's
+ * (`node_modules/@mandrelai/agents/.agents/`) into the consumer project's
  * `./.agents/` directory by **plain file copy** — never a symlink — so
  * Windows and POSIX behave identically (Tech Spec #3459, Feature #3461).
  *
@@ -12,9 +12,9 @@
  *   - Idempotent. A second run overwrites in place and leaves ./.agents/
  *     byte-identical to the package payload.
  *   - Self-locating. The package root is resolved from the installed
- *     `@mandrel/agents` package metadata, not from the current working
+ *     `@mandrelai/agents` package metadata, not from the current working
  *     directory, so it works regardless of where `mandrel` is invoked.
- *   - Exits non-zero with an actionable message when `@mandrel/agents` is
+ *   - Exits non-zero with an actionable message when `@mandrelai/agents` is
  *     not resolvable in node_modules.
  *   - `--dry-run` reports the planned copies and writes nothing.
  *   - `--force` is accepted; the copy is overwrite-in-place either way, so
@@ -30,7 +30,7 @@
  *   - Logs only paths and counts, never file contents or environment values.
  *
  * Injectable seams (used by lib/cli/__tests__/sync.test.js):
- *   - `resolvePackageRoot` — replaces real `@mandrel/agents` resolution
+ *   - `resolvePackageRoot` — replaces real `@mandrelai/agents` resolution
  *   - `fs`                 — replaces the node:fs surface used here
  *   - `cwd`                — replaces process.cwd()
  *   - `write`              — replaces process.stdout.write
@@ -42,7 +42,7 @@ import nodeFs from 'node:fs';
 import { createRequire } from 'node:module';
 import path from 'node:path';
 
-const PACKAGE_NAME = '@mandrel/agents';
+const PACKAGE_NAME = '@mandrelai/agents';
 
 /**
  * Top-level directory name (relative to `.agents/`) reserved as the
@@ -59,7 +59,7 @@ const PACKAGE_NAME = '@mandrel/agents';
 const LOCAL_ZONE_DIR = 'local';
 
 /**
- * Default resolver: locate the installed `@mandrel/agents` package root by
+ * Default resolver: locate the installed `@mandrelai/agents` package root by
  * resolving its `package.json` and returning the directory that contains it.
  *
  * Throws an Error with `code: 'MODULE_NOT_FOUND'` when the package is not

--- a/lib/cli/update.js
+++ b/lib/cli/update.js
@@ -3,7 +3,7 @@
  * `mandrel update` subcommand — the auto-update orchestrator (f-update-command,
  * Story #3503, Epic #3437 — Auto-Update & Version Lifecycle).
  *
- * Advances `@mandrel/agents` to the newest **non-major** published version,
+ * Advances `@mandrelai/agents` to the newest **non-major** published version,
  * re-materializes `.agents/`, runs applicable version-keyed migrations,
  * surfaces the target changelog, and verifies the result via the doctor
  * registry. A **major** crossing (e.g. `1.x → 2.0`) is gated: the orchestrator
@@ -50,7 +50,7 @@
  * ## Injectable seams (used by lib/cli/__tests__/update*.test.js)
  *
  *   - `argv`                — subcommand args (after `mandrel update`)
- *   - `currentVersion`      — the installed `@mandrel/agents` version string
+ *   - `currentVersion`      — the installed `@mandrelai/agents` version string
  *   - `resolveTargetVersion`— async, returns the newest published version
  *   - `npmUpdate`           — async, performs the dependency bump (no git)
  *   - `runSync`             — re-materializes ./.agents/ (lib/cli/sync.js)
@@ -80,7 +80,7 @@ import { isStale } from './version-check.js';
 const RUNBOOK_PATH = 'docs/upgrade-major.md';
 
 /** The published package whose newest version `mandrel update` advances to. */
-const PACKAGE_NAME = '@mandrel/agents';
+const PACKAGE_NAME = '@mandrelai/agents';
 
 /** Default freshness-cache filename — mirrors version-check.js. */
 const DEFAULT_CACHE_FILENAME = 'version-check.json';
@@ -131,7 +131,7 @@ function crossesMajor(current, target) {
 }
 
 /**
- * Resolve the installed `@mandrel/agents` version from this package's own
+ * Resolve the installed `@mandrelai/agents` version from this package's own
  * `package.json`. The module lives at `<root>/lib/cli/update.js`, so the
  * manifest is two directories up.
  *
@@ -158,12 +158,12 @@ function resolveProjectRoot() {
 
 /**
  * Default `resolveTargetVersion` seam: determine the newest published
- * `@mandrel/agents` version via the daily freshness cache (`version-check.js`).
+ * `@mandrelai/agents` version via the daily freshness cache (`version-check.js`).
  *
  * This delegates to `isStale`, which honours the 24h-cache semantics: a fresh
  * cache returns the cached version with **zero** network I/O, while a missing,
  * corrupt, or stale cache triggers exactly one network probe (`npm view
- * @mandrel/agents version`) and refreshes `temp/version-check.json`. Wiring the
+ * @mandrelai/agents version`) and refreshes `temp/version-check.json`. Wiring the
  * production update path through `isStale` is precisely what populates that
  * daily cache, which the `version-current` doctor advisory reads.
  *
@@ -193,7 +193,7 @@ async function defaultResolveTargetVersion({
 
 /**
  * Default network `runner` for the freshness probe: shells
- * `npm view @mandrel/agents version` synchronously and returns the trimmed
+ * `npm view @mandrelai/agents version` synchronously and returns the trimmed
  * stdout. Fixed argv (no shell), so no interpolation of untrusted input.
  *
  * @returns {string} The newest published version string.
@@ -224,7 +224,7 @@ function defaultVersionRunner() {
 
 /**
  * Default `npmUpdate` seam: install the resolved target version via
- * `npm install @mandrel/agents@<target>`. The install rewrites
+ * `npm install @mandrelai/agents@<target>`. The install rewrites
  * `package.json` / `package-lock.json` on disk (left staged for the operator);
  * this performs no git mutation. Fixed argv — the `@<target>` spec is a
  * resolved semver string, never operator free-text.
@@ -586,11 +586,11 @@ export async function runUpdate({
  * Default export consumed by `bin/mandrel.js`.
  *
  * Wires the production-default seams that `runUpdate` leaves injectable:
- *   - `resolveTargetVersion` probes the newest published `@mandrel/agents`
+ *   - `resolveTargetVersion` probes the newest published `@mandrelai/agents`
  *     version through the daily freshness cache (`version-check.js#isStale`),
  *     which ALSO populates `temp/version-check.json` — the cache the
  *     `version-current` doctor advisory reads.
- *   - `npmUpdate` shells `npm install @mandrel/agents@<target>` (no git
+ *   - `npmUpdate` shells `npm install @mandrelai/agents@<target>` (no git
  *     mutation; lockfile left staged).
  *   - `surfaceChangelog` prints the relevant `docs/CHANGELOG.md` section(s)
  *     for the applied range, degrading gracefully when the file is absent.

--- a/lib/migrations/README.md
+++ b/lib/migrations/README.md
@@ -1,7 +1,7 @@
 # Version-keyed migrations
 
 The migration runner applies one-time, version-gated transformations to a
-consumer project's on-disk state when they upgrade `@mandrel/agents` across a
+consumer project's on-disk state when they upgrade `@mandrelai/agents` across a
 version boundary that changed a contract.
 
 The engine lives in [`index.js`](./index.js). It owns ordering, version

--- a/lib/migrations/index.js
+++ b/lib/migrations/index.js
@@ -4,7 +4,7 @@
  *
  * A migration is a one-time, version-gated transformation of a consumer
  * project's on-disk state (config shape, baseline layout, materialized
- * `.agents/` tree, …). When a consumer upgrades `@mandrel/agents` across a
+ * `.agents/` tree, …). When a consumer upgrades `@mandrelai/agents` across a
  * version boundary that changed a contract (see
  * `.agents/rules/git-conventions.md` § Contract Cutovers), the upgrade path
  * runs every migration whose `version` falls inside the upgrade range so the

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@mandrel/agents",
+  "name": "@mandrelai/agents",
   "version": "1.44.0",
   "description": "Claude Code-first opinionated workflow framework: instructions, personas, skills, and SDLC workflows that govern AI coding assistants.",
   "main": "index.js",

--- a/tests/bootstrap/project-bootstrap.test.js
+++ b/tests/bootstrap/project-bootstrap.test.js
@@ -101,7 +101,7 @@ describe('ensurePackageJson', () => {
 
   it('never seeds framework runtime deps into the consumer manifest', () => {
     // Story #3466: the dependency-merge loop was removed — framework deps
-    // arrive transitively via @mandrel/agents, so bootstrap must leave the
+    // arrive transitively via @mandrelai/agents, so bootstrap must leave the
     // consumer manifest's dependency surface entirely untouched.
     const outcome = ensurePackageJson({ projectRoot: tmpRoot });
     assert.equal(Object.hasOwn(outcome, 'deps'), false);

--- a/tests/cli/postinstall.test.js
+++ b/tests/cli/postinstall.test.js
@@ -8,7 +8,7 @@
  *
  * The source-checkout guard (Story #3489) adds a no-op short-circuit: when the
  * hook runs inside the Mandrel framework source repo (root
- * `package.json#name === "@mandrel/agents"`), it MUST skip the materializer
+ * `package.json#name === "@mandrelai/agents"`), it MUST skip the materializer
  * entirely so `mandrel sync` never clobbers the committed `.agents/` source —
  * even under `npm install --ignore-scripts=false`.
  *
@@ -197,8 +197,8 @@ describe('isSourceCheckout — repo-root package.json#name detection', () => {
     },
   });
 
-  it('returns true when root package.json#name is @mandrel/agents', () => {
-    const fs = makeFs(JSON.stringify({ name: '@mandrel/agents' }));
+  it('returns true when root package.json#name is @mandrelai/agents', () => {
+    const fs = makeFs(JSON.stringify({ name: '@mandrelai/agents' }));
     assert.equal(isSourceCheckout({ fs, moduleUrl }), true);
   });
 

--- a/tests/cli/registry-drift.test.js
+++ b/tests/cli/registry-drift.test.js
@@ -3,7 +3,7 @@
  * Unit tests for the `agents-drift` doctor check in lib/cli/registry.js.
  *
  * The check compares the consumer's materialized `./.agents/<f>` bytes against
- * the installed `@mandrel/agents` package payload, excluding the
+ * the installed `@mandrelai/agents` package payload, excluding the
  * `.agents/local/` zone (Story #3498). Every branch is driven through
  * injectable seams (`cwd`, `fsImpl`, `resolvePackageRoot`) so no real
  * filesystem or package is touched — matching the seam style of the other
@@ -142,7 +142,7 @@ function parentOf(p) {
   return idx <= 0 ? '' : p.slice(0, idx);
 }
 
-const PKG_ROOT = '/fake/project/node_modules/@mandrel/agents';
+const PKG_ROOT = '/fake/project/node_modules/@mandrelai/agents';
 const PROJECT = '/fake/project';
 
 // ---------------------------------------------------------------------------
@@ -248,7 +248,7 @@ describe('agents-drift check', () => {
     assert.match(result.remedy, /mandrel sync/);
   });
 
-  it('is a no-op success when @mandrel/agents is not installed', () => {
+  it('is a no-op success when @mandrelai/agents is not installed', () => {
     const fsImpl = makeFs({
       [`${PROJECT}/.agents/instructions.md`]: 'body',
     });

--- a/tests/cli/registry.test.js
+++ b/tests/cli/registry.test.js
@@ -451,7 +451,7 @@ describe('agents-materialized check', () => {
       },
     });
     assertResultShape(result, { expectOk: false });
-    assert.match(result.remedy, /npm install @mandrel\/agents/);
+    assert.match(result.remedy, /npm install @mandrelai\/agents/);
   });
 
   it('does not echo file contents — detail and remedy are path/instruction only', () => {

--- a/tests/cli/registry.test.js
+++ b/tests/cli/registry.test.js
@@ -433,7 +433,7 @@ describe('agents-materialized check', () => {
       cwd: () => '/fake/project',
       existsSync: () => false,
       resolvePackage: () =>
-        '/fake/project/node_modules/@mandrel/agents/package.json',
+        '/fake/project/node_modules/@mandrelai/agents/package.json',
     });
     assertResultShape(result, { expectOk: false });
     assert.match(result.remedy, /mandrel sync/);
@@ -460,7 +460,7 @@ describe('agents-materialized check', () => {
       cwd: () => '/fake/project',
       existsSync: () => false,
       resolvePackage: () =>
-        '/fake/project/node_modules/@mandrel/agents/package.json',
+        '/fake/project/node_modules/@mandrelai/agents/package.json',
     });
     assert.doesNotMatch(result.detail, /\n/);
   });

--- a/tests/cli/update-entrypoint.test.js
+++ b/tests/cli/update-entrypoint.test.js
@@ -146,7 +146,7 @@ function makeDeps(fsFake, cap, { onNpmView, onNpmInstall } = {}) {
       },
       // Downstream materialize/migrate/verify seams are stubbed: the boundary
       // under test is the entrypoint ↔ npm/network/fs wiring, not sync.js's
-      // real @mandrel/agents resolution (absent in this dev repo).
+      // real @mandrelai/agents resolution (absent in this dev repo).
       runSync: () => {
         calls.push('runSync');
         return { copied: 0, planned: 0, dryRun: false };
@@ -191,7 +191,7 @@ describe('mandrel update entrypoint — production wiring', () => {
     // install → sync → migrate → doctor (changelog is surfaced via the fs).
     assert.deepEqual(calls, [
       'npm-view',
-      `npm install @mandrel/agents@${TARGET_VERSION}`,
+      `npm install @mandrelai/agents@${TARGET_VERSION}`,
       'runSync',
       `runMigrations:${CURRENT_VERSION}->${TARGET_VERSION}`,
       'runDoctor',
@@ -252,7 +252,7 @@ describe('mandrel update entrypoint — freshness-cache population', () => {
     assert.ok(!calls.includes('npm-view'), 'fresh cache must skip the probe');
     // The install still ran at the cached target.
     assert.ok(
-      calls.includes(`npm install @mandrel/agents@${TARGET_VERSION}`),
+      calls.includes(`npm install @mandrelai/agents@${TARGET_VERSION}`),
       'expected install at the cached target',
     );
   });

--- a/tests/codebase-snapshot.test.js
+++ b/tests/codebase-snapshot.test.js
@@ -62,7 +62,7 @@ describe('buildCodebaseSnapshot — skinny tier (this repo)', () => {
     assert.ok(Array.isArray(snapshot.files));
     assert.ok(snapshot.files.length > 0);
     assert.equal(snapshot.signatures, null);
-    assert.ok(snapshot.pkg.name === '@mandrel/agents');
+    assert.ok(snapshot.pkg.name === '@mandrelai/agents');
     assert.ok(Array.isArray(snapshot.pkg.scripts));
     assert.ok(snapshot.pkg.scripts.includes('test'));
   });

--- a/tests/scripts/create-mandrel-launcher.test.js
+++ b/tests/scripts/create-mandrel-launcher.test.js
@@ -39,7 +39,7 @@ describe('planLaunch', () => {
   it('targets the canonical Mandrel package (never operator-supplied)', () => {
     // The package name is a build-time constant; assert its exact value so a
     // refactor that accidentally parameterizes it fails loudly.
-    assert.equal(CANONICAL_PACKAGE, '@mandrel/agents');
+    assert.equal(CANONICAL_PACKAGE, '@mandrelai/agents');
     assert.equal(AGENTS_PATH, '.agents');
   });
 

--- a/tests/scripts/install-matrix-assert.test.js
+++ b/tests/scripts/install-matrix-assert.test.js
@@ -78,9 +78,9 @@ describe('parseArgs', () => {
     ]);
   });
 
-  it('defaults the package name to @mandrel/agents', () => {
+  it('defaults the package name to @mandrelai/agents', () => {
     const opts = parseArgs(['--consumer', '/c']);
-    assert.equal(opts.packageName, '@mandrel/agents');
+    assert.equal(opts.packageName, '@mandrelai/agents');
   });
 });
 
@@ -112,12 +112,15 @@ describe('checkManifestClean', () => {
   it('passes when only the framework package and own deps are declared', () => {
     const fs = makeFs({
       '/c/package.json': JSON.stringify({
-        dependencies: { '@mandrel/agents': 'file:../x.tgz', 'left-pad': '^1' },
+        dependencies: {
+          '@mandrelai/agents': 'file:../x.tgz',
+          'left-pad': '^1',
+        },
       }),
     });
     const r = checkManifestClean({
       consumer: '/c',
-      packageName: '@mandrel/agents',
+      packageName: '@mandrelai/agents',
       fs,
     });
     assert.equal(r.ok, true);
@@ -130,7 +133,7 @@ describe('checkManifestClean', () => {
     });
     const r = checkManifestClean({
       consumer: '/c',
-      packageName: '@mandrel/agents',
+      packageName: '@mandrelai/agents',
       fs,
     });
     assert.equal(r.ok, true);
@@ -139,12 +142,12 @@ describe('checkManifestClean', () => {
   it('fails when a framework runtime dep leaked into the manifest', () => {
     const fs = makeFs({
       '/c/package.json': JSON.stringify({
-        dependencies: { '@mandrel/agents': 'file:../x.tgz', 'js-yaml': '^4' },
+        dependencies: { '@mandrelai/agents': 'file:../x.tgz', 'js-yaml': '^4' },
       }),
     });
     const r = checkManifestClean({
       consumer: '/c',
-      packageName: '@mandrel/agents',
+      packageName: '@mandrelai/agents',
       fs,
     });
     assert.equal(r.ok, false);
@@ -160,7 +163,7 @@ describe('checkManifestClean', () => {
     });
     const r = checkManifestClean({
       consumer: '/c',
-      packageName: '@mandrel/agents',
+      packageName: '@mandrelai/agents',
       fs,
     });
     assert.equal(r.ok, false);
@@ -171,7 +174,7 @@ describe('checkManifestClean', () => {
     const fs = makeFs({ '/c/other.json': '{}' });
     const r = checkManifestClean({
       consumer: '/c',
-      packageName: '@mandrel/agents',
+      packageName: '@mandrelai/agents',
       fs,
     });
     assert.equal(r.ok, false);
@@ -226,7 +229,7 @@ describe('runAssertions', () => {
     const fs = makeFs({
       '/c/.agents/instructions.md': '# hi',
       '/c/package.json': JSON.stringify({
-        dependencies: { '@mandrel/agents': 'file:../x.tgz' },
+        dependencies: { '@mandrelai/agents': 'file:../x.tgz' },
       }),
     });
     const lines = [];


### PR DESCRIPTION
## Why

`@mandrel/agents` **cannot be published**: the unscoped `mandrel` package on npm
is an abandoned 2019 tombstone (no maintainers, no versions), and npm refuses to
let anyone create a `mandrel` org while that name exists — so the `@mandrel`
scope is unobtainable. This renames the package to the operator-owned
**`@mandrelai`** org → `@mandrelai/agents`.

## What

Mechanical `@mandrel/` → `@mandrelai/` across **39 files** (the `@` sigil makes
it unambiguously the npm scope — there are no bare `@mandrel` refs):

- `package.json` name, the `PACKAGE_NAME` constants + path logic in `lib/cli/*`
  and `bin/postinstall.js` (incl. the Story #3489 source-checkout guard), the
  `create-mandrel` bootstrap, all docs, and the tests.
- Re-ran `biome format` to rewrap two test lines that crossed 80 cols.
- Bumped **one** maintainability baseline entry (`tests/cli/postinstall.test.js`,
  130.712 → 124.773 — the longer literal lowers MI ~6 pts, still far above the
  floor). Surgical one-line update, not a full-scope refresh.

## Deliberately unchanged

- **CLI bin stays `mandrel`** — bin names are independent of the package name, so
  `npx mandrel sync/doctor/update` is unaffected. Only the *install* name changes.
- **Git release tags stay `mandrel-v*`** — they track the "Mandrel" project name,
  not the npm scope, so the AGENTS.md tag doc in #3550 stays correct.
- `package-lock.json` (root name was already unscoped `mandrel`).

## Verification

- `npm run lint` clean; `npm run test:quick` 357/357 pass.

## Follow-ups (not in this PR)

1. The **`NPM_TOKEN`** secret must be scoped to the **`@mandrelai`** org (not
   `@dsj1984`) for the publish job to authenticate.
2. Publishing `@mandrelai/agents` will need a release to be cut **after** this
   merges (the prior `mandrel-v1.44.0` publish was for the old name). Re-running
   that old failed job would republish the old `@mandrel/agents` name and is no
   longer the path.
