### PR TITLE
Retire .agents/VERSION — package.json is the single source of truth under npm distribution (#3549)

### DIFF
--- a/.agents/README.md
+++ b/.agents/README.md
@@ -6,8 +6,10 @@ npm package and is materialized into a consumer's `./.agents/` directory by
 `mandrel sync`. It carries a system prompt, a baseline rule pack, a
 two-tier skill library, a slash-command workflow set, and the
 orchestration engine that runs Epic → Feature → Story plans on
-GitHub. The framework version lives at [`VERSION`](VERSION) — read that
-file, not a count here.
+GitHub. The framework version is the version of the installed
+[`@mandrel/agents`](https://www.npmjs.com/package/@mandrel/agents) npm
+package — run `npm ls @mandrel/agents` (or read `package.json`), not a
+count here.
 
 > **Ticket hierarchy.** Mandrel uses a **3-tier hierarchy**
 > (Epic → Feature → Story) with inline `acceptance[]` / `verify[]` on
@@ -224,7 +226,6 @@ in `runtime-deps.json`.
 | Path | Purpose |
 | ---- | ------- |
 | [`instructions.md`](instructions.md) | Primary system prompt loaded by the host AI tool. |
-| [`VERSION`](VERSION) | Framework version shipped by this `.agents/` bundle. |
 | [`SDLC.md`](SDLC.md) | Operator process for `/epic-plan` and `/epic-deliver`. |
 | [`starter-agentrc.json`](starter-agentrc.json) | Bootstrap delta-seed copied to the consumer repo root as `.agentrc.json`. |
 | [`full-agentrc.json`](full-agentrc.json) | Exhaustive editor reference enumerating every schema key with its framework default. |

--- a/.agents/VERSION
+++ b/.agents/VERSION
@@ -1,1 +1,0 @@
-1.44.0 # x-release-please-version

--- a/.agents/scripts/lib/orchestration/context-hydration-engine.js
+++ b/.agents/scripts/lib/orchestration/context-hydration-engine.js
@@ -19,6 +19,7 @@
 import crypto from 'node:crypto';
 import fs from 'node:fs';
 import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { getCommands } from '../config/commands.js';
 import {
   getLimits,
@@ -126,15 +127,28 @@ export function formatSkillCapsulesSection(entries) {
 // ---------------------------------------------------------------------------
 
 /**
- * Read the framework VERSION file.
+ * Resolve the framework version from the installed package's `package.json`.
+ *
+ * Under npm distribution `package.json` is the single source of truth for the
+ * framework version (the legacy plaintext version marker is retired). This
+ * module ships inside the `@mandrelai/agents` package at
+ * `<pkgRoot>/.agents/scripts/lib/orchestration/context-hydration-engine.js`,
+ * so the package manifest sits four directories up — the same layout in the
+ * dev repo and in the published tarball. Read that manifest's `version`.
+ *
+ * Falls back to `'unknown'` when the manifest is absent or unreadable so a
+ * missing package.json never crashes hydration.
  *
  * @returns {string}
  */
 function getVersion() {
   try {
-    return fs
-      .readFileSync(path.join(PROJECT_ROOT, '.agents', 'VERSION'), 'utf8')
-      .trim();
+    const moduleDir = path.dirname(fileURLToPath(import.meta.url));
+    const pkgPath = path.resolve(moduleDir, '../../../..', 'package.json');
+    const parsed = JSON.parse(fs.readFileSync(pkgPath, 'utf8'));
+    return typeof parsed.version === 'string' && parsed.version.trim()
+      ? parsed.version.trim()
+      : 'unknown';
   } catch {
     return 'unknown';
   }

--- a/.agents/skills/core/baseline-refresh/SKILL.md
+++ b/.agents/skills/core/baseline-refresh/SKILL.md
@@ -76,9 +76,9 @@ Epic: #<epic-id>
    [`.agents/rules/git-conventions.md`](../../../rules/git-conventions.md),
    so the subject must conform.
 2. `release-please` consumes Conventional-Commits subjects on `main` to
-   generate `docs/CHANGELOG.md` and bump `package.json` /
-   `.agents/VERSION`. A non-conventional subject parses as "no changelog
-   entry" and the refresh disappears from the release record.
+   generate `docs/CHANGELOG.md` and bump `package.json`. A
+   non-conventional subject parses as "no changelog entry" and the
+   refresh disappears from the release record.
 3. `chore(baselines):` keeps the refresh out of the user-facing changelog
    (which is correct — a baseline refresh is internal hygiene, not a
    feature or fix) while still being machine-parseable.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,7 +20,9 @@ the [`@mandrel/agents`](https://www.npmjs.com/package/@mandrel/agents) npm
 package and materialized into consumer projects' `.agents/` directories by
 `mandrel sync`.
 
-- **Current Version:** See [`.agents/VERSION`](.agents/VERSION)
+- **Current Version:** the `version` field of the root
+  [`package.json`](package.json) (run `npm ls @mandrel/agents` in a
+  consumer project)
 - **License:** ISC
 
 > **Ticket hierarchy.** Mandrel ships a **3-tier ticket hierarchy**
@@ -153,8 +155,8 @@ Releases are automated by
    already enforce the commit-message contract).
 2. release-please opens a **single combined** release PR with
    auto-merge enabled (squash). Review the auto-generated entry in
-   `docs/CHANGELOG.md` and the bumps to `package.json` and
-   `.agents/VERSION` if you want; otherwise no operator action is
+   `docs/CHANGELOG.md` and the bump to `package.json` (the framework
+   version SSOT) if you want; otherwise no operator action is
    needed. See [§ Two-package release topology](#two-package-release-topology)
    below for the combined-PR title/branch shape and the tag namespace
    each package uses.
@@ -290,9 +292,10 @@ which caps automatic bumps at the minor axis even when commits carry
 
 1. Land the breaking work on `main` as usual (Conventional Commits).
 2. On the release PR that release-please opens, either:
-   - **Edit `package.json`, `.agents/VERSION`, and `docs/CHANGELOG.md`
-     in-place** on the release branch to set the major version
-     (release-please will respect the edits and tag accordingly), OR
+   - **Edit `package.json`, `.release-please-manifest.json`, and
+     `docs/CHANGELOG.md` in-place** on the release branch to set the
+     major version (release-please will respect the edits and tag
+     accordingly), OR
    - **Add a one-shot commit on `main`** with `Release-As: X.0.0` in
      the trailer — release-please will adopt that as the proposed
      version on its next run.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -80,7 +80,6 @@ The repository has a clear separation between the **distributed product**
 mandrel/
 ├── .agents/                  ← Distributed bundle (the "product")
 │   ├── instructions.md       ← Primary system prompt (all agent rules)
-│   ├── VERSION               ← Semantic version
 │   ├── SDLC.md               ← End-to-end workflow guide
 │   ├── README.md             ← Consumer documentation
 │   ├── starter-agentrc.json ← Bootstrap delta-seed (copy to .agentrc.json)

--- a/docs/migration-submodule-to-npm.md
+++ b/docs/migration-submodule-to-npm.md
@@ -104,8 +104,10 @@ The manual, step-by-step version of the same migration follows below.
   overwrites `./.agents/` in place from the package payload, so anything you
   customized there must be migrated into your own project layer (root
   `.agentrc.json`, project skills, etc.) first.
-- Note the framework version you are currently pinned to (read
-  `.agents/VERSION`) so you can pick a target package version deliberately.
+- Note the framework version you are currently pinned to (read the
+  `version` field of the submodule's `package.json`) so you can pick a
+  target package version deliberately. After migrating, the installed
+  version is whatever `npm ls @mandrel/agents` reports.
 - Make sure your `gh` CLI is still authenticated — orchestration scripts and
   `mandrel doctor`'s `gh-auth` check read your token exactly as before.
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -523,7 +523,7 @@ theoretical. Until then, the static lint is the supported surface.
 ## Part 2 — Product-Readiness Backlog (If/When Mandrel Is Productized)
 
 Last triaged: 2026-06-02 (distribution & onboarding slice filed — see below;
-prior triage 2026-05-30 against `.agents/VERSION` 1.40.0).
+prior triage 2026-05-30 against framework version 1.40.0).
 
 Scope: this document is the **standing backlog** of product-readiness gaps that
 Mandrel would need to close *if and when it is productized* (sold or distributed
@@ -734,7 +734,8 @@ Filed slice: the dangling `docs/upgrade-guide-3-tier.md` reference → #3386.
 
 Deferred remainder:
 
-- `release-please` manages the root package and `.agents/VERSION`; major bumps
+- `release-please` manages the root package version (`package.json` +
+  `.release-please-manifest.json`); major bumps
   are intentionally capped (`always-bump-minor`). (The former `dist` sync that
   copied `.agents/` after main merge is retired — #3436 publishes the
   `@mandrel/agents` npm package instead.)

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -12,12 +12,6 @@
       "component": "",
       "changelog-path": "docs/CHANGELOG.md",
       "versioning": "always-bump-minor",
-      "extra-files": [
-        {
-          "type": "generic",
-          "path": ".agents/VERSION"
-        }
-      ],
       "changelog-sections": [
         { "type": "feat", "section": "Added" },
         { "type": "fix", "section": "Fixed" },

--- a/scripts/check-version-sync.js
+++ b/scripts/check-version-sync.js
@@ -3,26 +3,30 @@
 /**
  * scripts/check-version-sync.js — Version Consistency Guard
  *
- * Verifies that the version is identical across three sources of truth:
+ * Verifies that the framework version is identical across the two release
+ * sources of truth:
  *   - package.json → `version`
- *   - .agents/VERSION (plain text)
- *   - docs/CHANGELOG.md → latest `## [X.Y.Z]` heading
+ *   - .release-please-manifest.json → the root package entry (`"."`)
  *
- * Invoked from the pre-commit hook. Exits non-zero with a diagnostic if any
- * pair diverges. Released versions should always move together; catching
- * drift at commit time prevents shipping a `package.json` bump with a stale
- * VERSION file or an undocumented CHANGELOG.
+ * Invoked from the pre-commit hook. Exits non-zero with a diagnostic if the
+ * pair diverges. release-please writes both in lockstep on every release, so
+ * catching drift at commit time prevents shipping a `package.json` bump with
+ * a stale manifest entry.
+ *
+ * Under npm distribution `package.json` is the single source of truth for the
+ * framework version; the legacy plaintext version marker is retired, so this
+ * gate no longer cross-checks it.
  *
  * This script intentionally lives outside `.agents/` because it is specific
  * to this repository's release process — the `.agents/` tree is distributed
- * to consumer projects as a submodule and should only contain protocol
- * tooling that is generally useful.
+ * to consumer projects and should only contain protocol tooling that is
+ * generally useful.
  *
  * Usage:
  *   node scripts/check-version-sync.js
  *
  * Exit codes:
- *   0 — All three sources match.
+ *   0 — Both sources match.
  *   1 — Mismatch or unreadable source (details on stderr).
  */
 
@@ -33,8 +37,9 @@ import { fileURLToPath } from 'node:url';
 const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
 const DEFAULT_ROOT = resolve(SCRIPT_DIR, '..');
 
-const CHANGELOG_HEADING_RE = /^##\s*\[(\d+\.\d+\.\d+)\]/m;
-const CHANGELOG_UNRELEASED_RE = /^##\s*\[Unreleased\]/m;
+// The root package is keyed under `"."` in the release-please manifest
+// (see release-please-config.json → `packages["."]`).
+const ROOT_PACKAGE_KEY = '.';
 
 export function readPackageVersion(root = DEFAULT_ROOT) {
   const raw = readFileSync(resolve(root, 'package.json'), 'utf8');
@@ -45,55 +50,34 @@ export function readPackageVersion(root = DEFAULT_ROOT) {
   return parsed.version.trim();
 }
 
-export function readVersionFile(root = DEFAULT_ROOT) {
-  const raw = readFileSync(resolve(root, '.agents/VERSION'), 'utf8');
-  // The file may carry an `# x-release-please-version` marker comment so
-  // release-please's generic updater can find it. Strip the comment tail
-  // and any whitespace before comparing.
-  return raw.split('\n')[0].split('#')[0].trim();
-}
-
-export function readChangelogVersion(root = DEFAULT_ROOT) {
-  const raw = readFileSync(resolve(root, 'docs/CHANGELOG.md'), 'utf8');
-  const match = raw.match(CHANGELOG_HEADING_RE);
-  if (match) {
-    return match[1];
-  }
-  // No `## [X.Y.Z]` heading yet — release-please opens the next release
-  // PR with an `## [Unreleased]` anchor that gets rewritten to the
-  // concrete version on merge. Treat the anchor as a wildcard that
-  // matches whatever version the other two sources agree on.
-  if (CHANGELOG_UNRELEASED_RE.test(raw)) {
-    return null;
-  }
-  throw new Error(
-    'docs/CHANGELOG.md has no "## [X.Y.Z]" heading or "## [Unreleased]" anchor — cannot determine latest version',
+export function readManifestVersion(root = DEFAULT_ROOT) {
+  const raw = readFileSync(
+    resolve(root, '.release-please-manifest.json'),
+    'utf8',
   );
+  const parsed = JSON.parse(raw);
+  const version = parsed[ROOT_PACKAGE_KEY];
+  if (typeof version !== 'string') {
+    throw new Error(
+      `.release-please-manifest.json has no "${ROOT_PACKAGE_KEY}" root-package entry`,
+    );
+  }
+  return version.trim();
 }
 
 export function checkVersionSync(root = DEFAULT_ROOT) {
   const sources = {
     'package.json': readPackageVersion(root),
-    '.agents/VERSION': readVersionFile(root),
-    'docs/CHANGELOG.md': readChangelogVersion(root),
+    '.release-please-manifest.json': readManifestVersion(root),
   };
 
-  // The CHANGELOG may legitimately return `null` while sitting on a bare
-  // `## [Unreleased]` anchor (release-please's pre-cut window). When
-  // that happens, the changelog source is a wildcard — drop it from
-  // the equality check.
-  const concreteSources = Object.fromEntries(
-    Object.entries(sources).filter(([, version]) => version != null),
-  );
-
-  const versions = new Set(Object.values(concreteSources));
+  const versions = new Set(Object.values(sources));
   if (versions.size === 1) {
     return { ok: true, version: [...versions][0], sources };
   }
 
   const lines = Object.entries(sources).map(
-    ([file, version]) =>
-      `  ${file.padEnd(22)} → ${version ?? '[Unreleased] (wildcard)'}`,
+    ([file, version]) => `  ${file.padEnd(30)} → ${version}`,
   );
   return {
     ok: false,

--- a/tests/check-version-sync.test.js
+++ b/tests/check-version-sync.test.js
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { test } from 'node:test';
@@ -8,86 +8,31 @@ import { checkVersionSync } from '../scripts/check-version-sync.js';
 
 function makeFixture({
   pkgVersion = '1.2.3',
-  fileVersion = '1.2.3',
-  changelogVersion = '1.2.3',
-  changelogPrefix = '# Changelog\n\n',
+  manifestVersion = '1.2.3',
+  manifestEntries,
 } = {}) {
   const root = mkdtempSync(join(tmpdir(), 'version-sync-'));
-  mkdirSync(join(root, '.agents'), { recursive: true });
-  mkdirSync(join(root, 'docs'), { recursive: true });
   writeFileSync(
     join(root, 'package.json'),
     JSON.stringify({ name: 'x', version: pkgVersion }),
   );
-  writeFileSync(join(root, '.agents/VERSION'), `${fileVersion}\n`);
+  const manifest = manifestEntries ?? {
+    '.': manifestVersion,
+    'create-mandrel': '0.2.0',
+  };
   writeFileSync(
-    join(root, 'docs/CHANGELOG.md'),
-    `${changelogPrefix}## [${changelogVersion}] - 2026-04-14\n\nNotes.\n`,
+    join(root, '.release-please-manifest.json'),
+    JSON.stringify(manifest),
   );
   return root;
 }
 
 test('checkVersionSync', async (t) => {
-  await t.test('passes when all three sources match', () => {
+  await t.test('passes when both sources match', () => {
     const root = makeFixture({
       pkgVersion: '5.5.1',
-      fileVersion: '5.5.1',
-      changelogVersion: '5.5.1',
+      manifestVersion: '5.5.1',
     });
-    try {
-      const result = checkVersionSync(root);
-      assert.strictEqual(result.ok, true);
-      assert.strictEqual(result.version, '5.5.1');
-    } finally {
-      rmSync(root, { recursive: true, force: true });
-    }
-  });
-
-  await t.test('fails when package.json drifts from VERSION file', () => {
-    const root = makeFixture({
-      pkgVersion: '5.5.2',
-      fileVersion: '5.5.1',
-      changelogVersion: '5.5.2',
-    });
-    try {
-      const result = checkVersionSync(root);
-      assert.strictEqual(result.ok, false);
-      assert.match(result.reason, /Version drift/);
-      assert.match(result.reason, /\.agents\/VERSION.*5\.5\.1/);
-    } finally {
-      rmSync(root, { recursive: true, force: true });
-    }
-  });
-
-  await t.test('fails when CHANGELOG latest entry lags', () => {
-    const root = makeFixture({
-      pkgVersion: '5.5.1',
-      fileVersion: '5.5.1',
-      changelogVersion: '5.5.0',
-    });
-    try {
-      const result = checkVersionSync(root);
-      assert.strictEqual(result.ok, false);
-      assert.match(result.reason, /docs\/CHANGELOG\.md.*5\.5\.0/);
-    } finally {
-      rmSync(root, { recursive: true, force: true });
-    }
-  });
-
-  await t.test('reads the FIRST ## [X.Y.Z] heading (latest entry)', () => {
-    // Real-world CHANGELOG has multiple version headings; we want the topmost one.
-    const root = mkdtempSync(join(tmpdir(), 'version-sync-'));
-    mkdirSync(join(root, '.agents'), { recursive: true });
-    mkdirSync(join(root, 'docs'), { recursive: true });
-    writeFileSync(
-      join(root, 'package.json'),
-      JSON.stringify({ version: '5.5.1' }),
-    );
-    writeFileSync(join(root, '.agents/VERSION'), '5.5.1\n');
-    writeFileSync(
-      join(root, 'docs/CHANGELOG.md'),
-      '# Changelog\n\n## [5.5.1] - 2026-04-14\n\nNew.\n\n## [5.5.0] - 2026-04-14\n\nOld.\n',
-    );
     try {
       const result = checkVersionSync(root);
       assert.strictEqual(result.ok, true);
@@ -98,53 +43,44 @@ test('checkVersionSync', async (t) => {
   });
 
   await t.test(
-    'treats a bare ## [Unreleased] anchor as a wildcard (v6 pre-cut window)',
+    'reads the root package entry ("."), ignoring sibling packages',
     () => {
-      // After Story #1605 (Epic #1184) consolidates the 5.x history out of
-      // docs/CHANGELOG.md but before the v6.0.0 cut, the live changelog
-      // carries only a `## [Unreleased]` anchor. package.json + VERSION
-      // still read 5.41.0 in that window; the gate must not trip.
-      const root = mkdtempSync(join(tmpdir(), 'version-sync-'));
-      mkdirSync(join(root, '.agents'), { recursive: true });
-      mkdirSync(join(root, 'docs'), { recursive: true });
-      writeFileSync(
-        join(root, 'package.json'),
-        JSON.stringify({ version: '5.41.0' }),
-      );
-      writeFileSync(join(root, '.agents/VERSION'), '5.41.0\n');
-      writeFileSync(
-        join(root, 'docs/CHANGELOG.md'),
-        '# Changelog\n\n## [Unreleased]\n\nv6 work in flight.\n',
-      );
+      const root = makeFixture({
+        pkgVersion: '5.5.1',
+        manifestEntries: { '.': '5.5.1', 'create-mandrel': '9.9.9' },
+      });
       try {
         const result = checkVersionSync(root);
         assert.strictEqual(result.ok, true);
-        assert.strictEqual(result.version, '5.41.0');
-        assert.strictEqual(result.sources['docs/CHANGELOG.md'], null);
+        assert.strictEqual(result.version, '5.5.1');
       } finally {
         rmSync(root, { recursive: true, force: true });
       }
     },
   );
 
-  await t.test('throws when CHANGELOG has no version heading', () => {
-    const root = mkdtempSync(join(tmpdir(), 'version-sync-'));
-    mkdirSync(join(root, '.agents'), { recursive: true });
-    mkdirSync(join(root, 'docs'), { recursive: true });
-    writeFileSync(
-      join(root, 'package.json'),
-      JSON.stringify({ version: '1.0.0' }),
-    );
-    writeFileSync(join(root, '.agents/VERSION'), '1.0.0\n');
-    writeFileSync(
-      join(root, 'docs/CHANGELOG.md'),
-      '# Changelog\n\nNo entries yet.\n',
-    );
+  await t.test('fails when package.json drifts from the manifest', () => {
+    const root = makeFixture({
+      pkgVersion: '5.5.2',
+      manifestVersion: '5.5.1',
+    });
     try {
-      assert.throws(
-        () => checkVersionSync(root),
-        /no "## \[X\.Y\.Z\]" heading/,
-      );
+      const result = checkVersionSync(root);
+      assert.strictEqual(result.ok, false);
+      assert.match(result.reason, /Version drift/);
+      assert.match(result.reason, /\.release-please-manifest\.json.*5\.5\.1/);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  await t.test('throws when the manifest has no root-package entry', () => {
+    const root = makeFixture({
+      pkgVersion: '1.0.0',
+      manifestEntries: { 'create-mandrel': '0.2.0' },
+    });
+    try {
+      assert.throws(() => checkVersionSync(root), /no "\." root-package entry/);
     } finally {
       rmSync(root, { recursive: true, force: true });
     }

--- a/tests/cli/update-golden-path.test.js
+++ b/tests/cli/update-golden-path.test.js
@@ -49,6 +49,7 @@ import { runUpdate } from '../../lib/cli/update.js';
 const CURRENT_VERSION = '1.43.0';
 const TARGET_VERSION = '1.44.0';
 const LOCKFILE = 'package-lock.json';
+const PACKAGE_JSON = 'package.json';
 
 /**
  * A faithful in-memory model of the consumer working tree across the update
@@ -66,7 +67,7 @@ const LOCKFILE = 'package-lock.json';
 function makeWorkingTree() {
   const committed = new Map([
     [LOCKFILE, `{"version":"${CURRENT_VERSION}"}`],
-    ['.agents/VERSION', CURRENT_VERSION],
+    [PACKAGE_JSON, `{"version":"${CURRENT_VERSION}"}`],
   ]);
   const workingTree = new Map(committed);
   const index = new Set();
@@ -106,9 +107,11 @@ function makeWorkingTree() {
 /**
  * Wire the full golden-path seam set against a shared working-tree fixture.
  * Each seam mutates / reads the same `tree` so the steps compose the way the
- * live cycle does: `npmUpdate` bumps + stages the lockfile, `runSync`
- * re-materializes `.agents/VERSION`, `runMigrations` is a no-op (empty
- * registry on the 1.x line), and `runDoctor` inspects the resulting tree.
+ * live cycle does: `npmUpdate` bumps + stages the lockfile and the
+ * installed `package.json` version (the framework version SSOT under npm
+ * distribution), `runSync` re-materializes the `.agents/` payload,
+ * `runMigrations` is a no-op (empty registry on the 1.x line), and
+ * `runDoctor` inspects the resulting tree.
  */
 function makeGoldenPathSeams(tree) {
   const calls = [];
@@ -121,15 +124,16 @@ function makeGoldenPathSeams(tree) {
     },
     npmUpdate: async (version) => {
       calls.push(`npm-update:${version}`);
-      // npm rewrites the lockfile on disk and stages it — but never commits.
+      // npm rewrites the lockfile + package.json on disk and stages them —
+      // but never commits. package.json is the framework version SSOT.
       tree.write(LOCKFILE, `{"version":"${version}"}`);
       tree.add(LOCKFILE);
+      tree.write(PACKAGE_JSON, `{"version":"${version}"}`);
+      tree.add(PACKAGE_JSON);
     },
     runSync: (_opts) => {
       calls.push('sync');
-      // Re-materialize the pinned VERSION marker from the new payload.
-      tree.write('.agents/VERSION', TARGET_VERSION);
-      tree.add('.agents/VERSION');
+      // Re-materialize the `.agents/` payload from the new package version.
       return { copied: 1, planned: 1, dryRun: false };
     },
     runMigrations: ({ fromVersion, toVersion }) => {
@@ -140,9 +144,11 @@ function makeGoldenPathSeams(tree) {
     runDoctor: async () => {
       calls.push('doctor');
       // Doctor reads the post-sync state the earlier steps produced and
-      // verifies it is healthy: the materialized VERSION matches the target
-      // and the lockfile bump is staged (the expected pre-commit shape).
-      const versionOk = tree.read('.agents/VERSION') === TARGET_VERSION;
+      // verifies it is healthy: the bumped package.json version matches the
+      // target and the lockfile bump is staged (the expected pre-commit
+      // shape).
+      const versionOk =
+        tree.read(PACKAGE_JSON) === `{"version":"${TARGET_VERSION}"}`;
       const lockStaged = tree.isStaged(LOCKFILE);
       return {
         ok: versionOk && lockStaged,

--- a/tests/enforcement/inventory-freshness.test.js
+++ b/tests/enforcement/inventory-freshness.test.js
@@ -8,11 +8,6 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = path.resolve(__dirname, '..', '..');
 const AGENTS_DIR = path.join(REPO_ROOT, '.agents');
 const README_PATH = path.join(AGENTS_DIR, 'README.md');
-const VERSION_PATH = path.join(AGENTS_DIR, 'VERSION');
-
-function readVersion() {
-  return fs.readFileSync(VERSION_PATH, 'utf8').trim();
-}
 
 function countMarkdownFiles(dir) {
   return fs
@@ -75,19 +70,6 @@ test('scanReadmeVersionClaims: no literal next to VERSION passes', () => {
     '5.29.0',
   );
   assert.deepStrictEqual(offenses, []);
-});
-
-test('.agents/README.md inline VERSION literal matches .agents/VERSION', () => {
-  const content = fs.readFileSync(README_PATH, 'utf8');
-  const actual = readVersion();
-  const offenses = scanReadmeVersionClaims(content, actual);
-  assert.deepStrictEqual(
-    offenses,
-    [],
-    `README inline VERSION literal is stale. ` +
-      `Either remove the parenthetical or sync it with .agents/VERSION (${actual}). ` +
-      `Offenses: ${JSON.stringify(offenses)}`,
-  );
 });
 
 // The post-slim README (Story #1007) no longer enumerates persona / rule /

--- a/tests/lib/worktree-manager.test.js
+++ b/tests/lib/worktree-manager.test.js
@@ -1184,7 +1184,7 @@ test('copyAgentsFromRoot: recursively copies root .agents into the worktree', ()
     );
     const rootAgents = path.join(tmp, '.agents');
     fs.mkdirSync(path.join(rootAgents, 'workflows'), { recursive: true });
-    fs.writeFileSync(path.join(rootAgents, 'VERSION'), 'v1\n');
+    fs.writeFileSync(path.join(rootAgents, 'instructions.md'), '# protocol\n');
     fs.writeFileSync(
       path.join(rootAgents, 'workflows', 'story-deliver.md'),
       '# run\n',
@@ -1209,8 +1209,8 @@ test('copyAgentsFromRoot: recursively copies root .agents into the worktree', ()
     );
 
     assert.equal(
-      fs.readFileSync(path.join(wtAgents, 'VERSION'), 'utf8'),
-      'v1\n',
+      fs.readFileSync(path.join(wtAgents, 'instructions.md'), 'utf8'),
+      '# protocol\n',
     );
     assert.equal(
       fs.readFileSync(


### PR DESCRIPTION
Closes #3549

_Auto-opened by `/single-story-deliver`._