### PR TITLE
fix(uninstall): guard per-target JSON.parse so a bad operator file can't abort uninstall (#3544)

### DIFF
--- a/lib/cli/uninstall.js
+++ b/lib/cli/uninstall.js
@@ -547,7 +547,7 @@ function formatOutcome(outcome) {
  *   exit?: (code: number) => void,
  *   includeGithub?: boolean,
  * }} [opts]
- * @returns {{ revertedCount: number, manualCount: number, ledgerFound: boolean }}
+ * @returns {{ revertedCount: number, manualCount: number, ledgerFound: boolean, parseErrorCount: number }}
  */
 export function runUninstall({
   projectRoot,
@@ -565,7 +565,12 @@ export function runUninstall({
   } catch (err) {
     write(`❌  Install ledger is unreadable: ${err.message}\n`);
     exit(1);
-    return { revertedCount: 0, manualCount: 0, ledgerFound: false };
+    return {
+      revertedCount: 0,
+      manualCount: 0,
+      ledgerFound: false,
+      parseErrorCount: 0,
+    };
   }
 
   if (!ledger) {
@@ -573,7 +578,12 @@ export function runUninstall({
     // A missing ledger is a benign no-op (never installed, or already
     // uninstalled), so this is success, not an error.
     exit(0);
-    return { revertedCount: 0, manualCount: 0, ledgerFound: false };
+    return {
+      revertedCount: 0,
+      manualCount: 0,
+      ledgerFound: false,
+      parseErrorCount: 0,
+    };
   }
 
   if (ledger.schemaVersion !== LEDGER_SCHEMA_VERSION) {
@@ -581,14 +591,36 @@ export function runUninstall({
       `❌  Install ledger schema v${ledger.schemaVersion} is not supported by this mandrel (expected v${LEDGER_SCHEMA_VERSION}). Upgrade/downgrade mandrel to match, then re-run.\n`,
     );
     exit(1);
-    return { revertedCount: 0, manualCount: 0, ledgerFound: true };
+    return {
+      revertedCount: 0,
+      manualCount: 0,
+      ledgerFound: true,
+      parseErrorCount: 0,
+    };
   }
 
   const { fileTargets, manual } = planUninstall(ledger);
 
   let revertedCount = 0;
+  let parseErrorCount = 0;
   for (const target of fileTargets) {
-    const outcome = REVERSAL_BY_TARGET[target](root, fsImpl);
+    let outcome;
+    try {
+      outcome = REVERSAL_BY_TARGET[target](root, fsImpl);
+    } catch (err) {
+      // An operator-edited file that contains invalid JSON (or any other
+      // unexpected throw from the reversal helper) must not abort the whole
+      // uninstall and leave earlier targets reverted while later ones are not.
+      // Emit a `skipped` outcome so the operator knows they must revert this
+      // target by hand, and leave the install ledger intact so a re-run after
+      // the file is fixed can resume cleanly.
+      outcome = {
+        kind: 'skipped',
+        target,
+        detail: `unparseable — revert manually (${err.message})`,
+      };
+      parseErrorCount += 1;
+    }
     if (outcome.kind === 'reverted') revertedCount += 1;
     write(formatOutcome(outcome));
   }
@@ -608,9 +640,11 @@ export function runUninstall({
   }
 
   // Remove the ledger last so a re-run is a clean no-op and a partial failure
-  // mid-reversal still leaves the ledger for a resume.
+  // mid-reversal still leaves the ledger for a resume. When any target was
+  // skipped due to a parse error, leave the ledger in place so the operator
+  // can fix the corrupt file and re-run to complete the uninstall.
   const lp = ledgerPath(root);
-  if (fsImpl.existsSync(lp)) {
+  if (fsImpl.existsSync(lp) && parseErrorCount === 0) {
     fsImpl.rmSync(lp, { force: true });
     write(
       formatOutcome({
@@ -620,6 +654,14 @@ export function runUninstall({
       }),
     );
     revertedCount += 1;
+  } else if (parseErrorCount > 0 && fsImpl.existsSync(lp)) {
+    write(
+      formatOutcome({
+        kind: 'skipped',
+        target: '.agents/.install-manifest.json',
+        detail: 'ledger retained — re-run after fixing unparseable file(s)',
+      }),
+    );
   }
 
   write(
@@ -628,7 +670,7 @@ export function runUninstall({
     })\n`,
   );
   exit(0);
-  return { revertedCount, manualCount, ledgerFound: true };
+  return { revertedCount, manualCount, ledgerFound: true, parseErrorCount };
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/cli/uninstall.test.js
+++ b/tests/cli/uninstall.test.js
@@ -779,3 +779,134 @@ describe('runUninstall — edge cases', () => {
     assert.match(cap.text, /unreadable/);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Story #3544 — per-target JSON.parse guard (corrupt operator file)
+// ---------------------------------------------------------------------------
+
+describe('runUninstall — corrupt target file guard (Story #3544)', () => {
+  it('yields a skipped outcome (not an uncaught throw) when settings.json is invalid JSON', () => {
+    // Arrange: an operator-edited .claude/settings.json that is invalid JSON.
+    fs.mkdirSync(path.join(tmpRoot, '.claude'), { recursive: true });
+    fs.writeFileSync(
+      path.join(tmpRoot, '.claude', 'settings.json'),
+      '{ not valid json at all',
+      'utf8',
+    );
+    writeLedger(tmpRoot, {
+      entries: [{ target: '.claude/settings.json', reversible: true }],
+    });
+
+    const cap = makeCapture();
+    // Must not throw — the per-target guard must catch the JSON.parse error.
+    let result;
+    assert.doesNotThrow(() => {
+      result = runUninstall({
+        projectRoot: tmpRoot,
+        write: cap.write,
+        exit: cap.exit,
+      });
+    });
+
+    // AC2: yields a skipped outcome rather than an uncaught throw
+    assert.equal(cap.exitCode, 0);
+    assert.match(cap.text, /skipped/);
+    assert.match(cap.text, /unparseable/);
+    assert.equal(result.parseErrorCount, 1);
+  });
+
+  it('yields a skipped outcome (not an uncaught throw) when package.json is invalid JSON', () => {
+    // Arrange: an operator-edited package.json that is invalid JSON.
+    fs.mkdirSync(tmpRoot, { recursive: true });
+    fs.writeFileSync(
+      path.join(tmpRoot, 'package.json'),
+      '{ broken json',
+      'utf8',
+    );
+    writeLedger(tmpRoot, {
+      entries: [{ target: 'package.json', reversible: true }],
+    });
+
+    const cap = makeCapture();
+    let result;
+    assert.doesNotThrow(() => {
+      result = runUninstall({
+        projectRoot: tmpRoot,
+        write: cap.write,
+        exit: cap.exit,
+      });
+    });
+
+    assert.equal(cap.exitCode, 0);
+    assert.match(cap.text, /skipped/);
+    assert.match(cap.text, /unparseable/);
+    assert.equal(result.parseErrorCount, 1);
+  });
+
+  it('continues reverting other targets after a corrupt file (AC3 — one bad file does not abort)', () => {
+    // Arrange: settings.json is corrupt; CLAUDE.md and .agentrc.json are valid.
+    fs.mkdirSync(path.join(tmpRoot, '.claude'), { recursive: true });
+    fs.writeFileSync(
+      path.join(tmpRoot, '.claude', 'settings.json'),
+      '{ not valid json',
+      'utf8',
+    );
+    fs.writeFileSync(
+      path.join(tmpRoot, 'CLAUDE.md'),
+      SYSTEM_PROMPT_CLAUDE_MD,
+      'utf8',
+    );
+    writeJson(path.join(tmpRoot, '.agentrc.json'), {
+      $schema: './.agents/schemas/agentrc.schema.json',
+    });
+    writeLedger(tmpRoot, {
+      entries: [
+        { target: '.claude/settings.json', reversible: true },
+        { target: 'CLAUDE.md', reversible: true },
+        { target: '.agentrc.json', reversible: true },
+      ],
+    });
+
+    const cap = makeCapture();
+    runUninstall({ projectRoot: tmpRoot, write: cap.write, exit: cap.exit });
+
+    // The corrupt settings.json is skipped, but CLAUDE.md and .agentrc.json
+    // are still reverted.
+    assert.equal(cap.exitCode, 0);
+    assert.equal(
+      fs.existsSync(path.join(tmpRoot, 'CLAUDE.md')),
+      false,
+      'CLAUDE.md must be reverted even though settings.json was corrupt',
+    );
+    assert.equal(
+      fs.existsSync(path.join(tmpRoot, '.agentrc.json')),
+      false,
+      '.agentrc.json must be reverted even though settings.json was corrupt',
+    );
+    // The corrupt target is reported as skipped.
+    assert.match(cap.text, /skipped/);
+    assert.match(cap.text, /unparseable/);
+  });
+
+  it('leaves the install ledger intact when a target is skipped due to parse error (AC4 — resume possible)', () => {
+    // Arrange: settings.json is corrupt; only this one entry in ledger.
+    fs.mkdirSync(path.join(tmpRoot, '.claude'), { recursive: true });
+    fs.writeFileSync(
+      path.join(tmpRoot, '.claude', 'settings.json'),
+      '{ corrupt',
+      'utf8',
+    );
+    writeLedger(tmpRoot, {
+      entries: [{ target: '.claude/settings.json', reversible: true }],
+    });
+
+    runUninstall({ projectRoot: tmpRoot, write: () => {}, exit: () => {} });
+
+    // Ledger must still exist so operator can fix the file and re-run.
+    assert.equal(
+      fs.existsSync(ledgerPath(tmpRoot)),
+      true,
+      'install ledger must be retained when a target was skipped due to parse error',
+    );
+  });
+});


### PR DESCRIPTION
Closes #3544

_Auto-opened by `/single-story-deliver`._