### PR TITLE
feat(orchestration): require per-contributor operatorHandle and fail closed in lease guards

### DIFF
--- a/.agentrc.json
+++ b/.agentrc.json
@@ -15,8 +15,7 @@
     "owner": "dsj1984",
     "repo": "mandrel",
     "projectNumber": 1,
-    "projectOwner": "dsj1984",
-    "operatorHandle": "@dsj1984",
+    "operatorHandle": "@[USERNAME]",
     "branchProtection": {
       "requiredChecks": [
         { "name": "lint", "cmd": ["npm", "run", "lint"] },

--- a/.agents/schemas/agentrc.schema.json
+++ b/.agents/schemas/agentrc.schema.json
@@ -153,7 +153,7 @@
     },
     "github": {
       "type": "object",
-      "required": ["owner", "repo"],
+      "required": ["owner", "repo", "operatorHandle"],
       "properties": {
         "owner": { "type": "string", "minLength": 1 },
         "repo": { "type": "string", "minLength": 1 },

--- a/.agents/scripts/lib/config-settings-schema.js
+++ b/.agents/scripts/lib/config-settings-schema.js
@@ -189,7 +189,7 @@ const MERGE_METHODS_SCHEMA = {
 
 const GITHUB_SCHEMA = {
   type: 'object',
-  required: ['owner', 'repo'],
+  required: ['owner', 'repo', 'operatorHandle'],
   properties: {
     owner: { type: 'string', minLength: 1 },
     repo: { type: 'string', minLength: 1 },

--- a/.agents/scripts/lib/orchestration/epic-deliver-lease-guard.js
+++ b/.agents/scripts/lib/orchestration/epic-deliver-lease-guard.js
@@ -228,18 +228,20 @@ export async function acquireEpicLease({
  * checkout-safety check first (cheap, local, no network), then the Epic-lease
  * acquisition (a GitHub round-trip). Both fail closed by throwing.
  *
- * When `operator` cannot be resolved the lease step is skipped with a warning
- * rather than throwing — a clone with no operator identity configured (e.g. a
- * fresh CI checkout with no `git config user.email`) should still be able to
- * run the checkout-safety guard; the lease is the cross-clone coordination
- * layer and degrades to a no-op without an identity.
+ * The checkout-safety guard runs first (cheap, local) and always executes. The
+ * Epic-lease step then **fails closed**: when `operator` cannot be resolved
+ * (null — `--as`, `github.operatorHandle`, and `git user.email` all empty, with
+ * the shipped `@[USERNAME]` placeholder normalised to null), this throws rather
+ * than running an ownerless, unguarded delivery. The lease is the cross-clone
+ * coordination layer; without an identity it cannot serialise concurrent runs,
+ * so silently skipping it would defeat the guard.
  *
  * @param {object} args
  * @param {number} args.epicId
  * @param {string|string[]} args.expectedBranch  Branch(es) prepare expects HEAD on.
  * @param {object} args.git                   Injected git shim (statusPorcelain/currentBranch).
  * @param {object} args.provider              Ticketing provider for the lease.
- * @param {string|null} args.operator         Resolved operator handle (null skips the lease).
+ * @param {string|null} args.operator         Resolved operator handle (null fails closed → throw).
  * @param {number|null} [args.heartbeatAt]    Current owner's last heartbeat (epoch ms).
  * @param {boolean} [args.steal=false]        Transfer a live foreign claim.
  * @param {object} [args.config]              Resolved config.
@@ -247,9 +249,10 @@ export async function acquireEpicLease({
  * @param {object} [args.logger]              Logger with info/warn.
  * @returns {Promise<{
  *   checkout: ReturnType<typeof checkCheckoutSafety>,
- *   lease: { acquired: boolean, owner: string, reason: string }|null,
+ *   lease: { acquired: boolean, owner: string, reason: string },
  * }>}
- * @throws {Error} on a dirty/wrong-branch tree or a refused live foreign lease.
+ * @throws {Error} on a dirty/wrong-branch tree, an unresolvable operator
+ *   identity, or a refused live foreign lease.
  */
 export async function runPrepareGuards({
   epicId,
@@ -274,10 +277,15 @@ export async function runPrepareGuards({
   );
 
   if (!operator) {
-    log.warn?.(
-      '[epic-deliver] ⚠️  No operator identity resolved (--as / github.operatorHandle / git user.email all empty); skipping Epic-lease preflight.',
+    throw new Error(
+      '[epic-deliver] Refusing to start: no operator identity could be ' +
+        'resolved. --as, github.operatorHandle (unset or still the shipped ' +
+        '`@[USERNAME]` placeholder), and git user.email are all empty, so the ' +
+        'Epic-lease has no owner and concurrent /epic-deliver runs cannot be ' +
+        'serialised. Set your own handle in .agentrc.local.json (e.g. ' +
+        '{ "github": { "operatorHandle": "@your-login" } }), pass --as <handle>, ' +
+        'or configure git user.email, then re-run.',
     );
-    return { checkout, lease: null };
   }
 
   const lease = await acquireEpicLease({

--- a/.agents/scripts/lib/orchestration/epic-plan-lease-guard.js
+++ b/.agents/scripts/lib/orchestration/epic-plan-lease-guard.js
@@ -46,9 +46,11 @@ import {
 /**
  * Resolve the operator handle that owns this `/epic-plan` run from
  * `github.operatorHandle`. The assignee-as-lease primitive is single-holder
- * keyed on a non-empty string; when no operator is configured the lease cannot
- * be keyed, so this returns `null` and the preflight degrades to a no-op rather
- * than wedging every plan run in a repo that has not set the handle.
+ * keyed on a non-empty string; when no operator is configured (unset, or the
+ * shipped `@[USERNAME]` placeholder, both of which `normalizeOperatorHandle`
+ * maps to `null`) the lease cannot be keyed. This returns `null`; the caller
+ * (`acquireEpicPlanLease`) then fails closed by throwing rather than running an
+ * ownerless, unguarded plan.
  *
  * The `@`-prefix some operators carry on `operatorHandle` is stripped so the
  * value matches the bare login GitHub writes to (and returns from) a ticket's
@@ -96,16 +98,14 @@ export async function acquireEpicPlanLease({
 }) {
   const operator = resolveOperator(config);
   if (operator === null) {
-    Logger.warn(
-      `[epic-plan] Epic-lease preflight skipped for #${epicId}: ` +
-        'github.operatorHandle is unset in .agentrc.json (no lease key).',
+    throw new Error(
+      `[epic-plan] Refusing to plan Epic #${epicId}: no operator identity is ` +
+        'configured. github.operatorHandle is unset or still the shipped ' +
+        '`@[USERNAME]` placeholder, so the Epic-lease has no owner and ' +
+        'concurrent /epic-plan runs cannot be serialised. Set your own handle ' +
+        'in .agentrc.local.json (e.g. { "github": { "operatorHandle": ' +
+        '"@your-login" } }) and re-run.',
     );
-    return {
-      acquired: true,
-      owner: null,
-      previousOwner: null,
-      reason: 'no-operator',
-    };
   }
 
   // Fail closed: with no live-heartbeat source on the plan path, treat any

--- a/.agents/scripts/lib/orchestration/single-story-lease-guard.js
+++ b/.agents/scripts/lib/orchestration/single-story-lease-guard.js
@@ -52,7 +52,8 @@ import {
  *
  * @param {object} config Resolved `.agentrc.json` config.
  * @returns {string} Bare operator handle.
- * @throws {Error} When no `github.operatorHandle` is configured — without an
+ * @throws {Error} When no `github.operatorHandle` resolves — unset, or still the
+ *   shipped `@[USERNAME]` placeholder (both normalise to `null`). Without an
  *   operator identity the lease has no owner to record, so the standalone
  *   path cannot safely serialise concurrent runs.
  */
@@ -60,8 +61,11 @@ export function resolveOperator(config) {
   const handle = normalizeOperatorHandle(config?.github?.operatorHandle);
   if (handle === null) {
     throw new Error(
-      'single-story lease: github.operatorHandle is not configured. ' +
-        'Set it in .agentrc.json so the standalone Story lease has an owner.',
+      'single-story lease: no operator identity is configured. ' +
+        'github.operatorHandle is unset or still the shipped `@[USERNAME]` ' +
+        'placeholder, so the standalone Story lease has no owner. Set your own ' +
+        'handle in .agentrc.local.json (e.g. { "github": { "operatorHandle": ' +
+        '"@your-login" } }) and re-run.',
     );
   }
   return handle;

--- a/.agents/scripts/lib/orchestration/ticket-lease.js
+++ b/.agents/scripts/lib/orchestration/ticket-lease.js
@@ -46,14 +46,31 @@ import { epicLedgerPath } from '../config/temp-paths.js';
 import { parseLedger } from './lifecycle/trace-logger.js';
 
 /**
+ * The shipped, non-personal operator-identity placeholder (and its bare,
+ * post-normalise form). The committed `.agentrc.json` and the distributed
+ * templates carry this sentinel so `github.operatorHandle` is schema-present
+ * without naming a real person; each contributor overrides it with their own
+ * handle in the gitignored `.agentrc.local.json`. It is NOT a usable lease
+ * owner: `normalizeOperatorHandle` maps it to `null` so the guards fail closed
+ * (a contributor who never set their handle is loudly refused, never silently
+ * coordinated under a shared identity) and no assignee PATCH ever writes a
+ * literal `[USERNAME]` (HTTP 422).
+ */
+export const OPERATOR_HANDLE_PLACEHOLDER = '@[USERNAME]';
+const OPERATOR_HANDLE_PLACEHOLDER_BARE = '[USERNAME]';
+
+/**
  * Normalise an operator handle into the bare login GitHub writes to (and
  * returns from) a ticket's `assignees`. Trims surrounding whitespace and
  * strips a single leading `@` so an `@`-prefixed `operatorHandle` matches a
  * bare assignee login (otherwise the assignee PATCH is rejected HTTP 422 and
  * the self-held-claim comparison `owner === operator` never matches).
  *
- * Returns `null` for a non-string, empty, or whitespace-only handle so each
- * caller can apply its own absent-handling (degrade to a no-op, or throw).
+ * Returns `null` for a non-string, empty, whitespace-only, or placeholder
+ * handle (`@[USERNAME]`) so each caller can apply its own absent-handling
+ * (degrade to a no-op, or throw). Treating the placeholder as unset is what
+ * makes the shipped sentinel safe: a contributor who never overrode it is
+ * indistinguishable from one who set nothing, so the guards fail closed.
  *
  * @param {unknown} raw
  * @returns {string|null}
@@ -61,7 +78,10 @@ import { parseLedger } from './lifecycle/trace-logger.js';
 export function normalizeOperatorHandle(raw) {
   if (typeof raw !== 'string') return null;
   const trimmed = raw.trim().replace(/^@/, '');
-  return trimmed.length > 0 ? trimmed : null;
+  if (trimmed.length === 0 || trimmed === OPERATOR_HANDLE_PLACEHOLDER_BARE) {
+    return null;
+  }
+  return trimmed;
 }
 
 /**

--- a/.agents/workflows/epic-deliver.md
+++ b/.agents/workflows/epic-deliver.md
@@ -172,9 +172,13 @@ and upserts the `epic-run-state` checkpoint. Treat the printed JSON as
 >    a **stale** claim is silently reclaimed. The operator identity is
 >    resolved from `--as <handle>` → `github.operatorHandle` →
 >    `git config user.email`. Pass `--steal` to forcibly transfer a live
->    foreign claim (the takeover is logged for auditability). A clone with
->    no resolvable identity skips the lease step (the checkout guard still
->    runs); the lease is the cross-clone coordination layer, while
+>    foreign claim (the takeover is logged for auditability). The committed
+>    `github.operatorHandle` is the non-personal `@[USERNAME]` placeholder,
+>    which resolves to null — so when none of the three sources yields a real
+>    identity the guard **fails closed** (throws after the checkout guard
+>    runs) rather than driving an ownerless, unguarded delivery. Set your own
+>    handle in `.agentrc.local.json`, pass `--as <handle>`, or configure
+>    `git user.email`. The lease is the cross-clone coordination layer, while
 >    `epic-merge-lock.js` continues to serialize same-machine sessions.
 >
 > Both guards throw on failure, which `runAsCli` maps to `process.exit(1)`

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -76,7 +76,7 @@ top-level keys are validation errors.
 | `repo` | Yes | `string` | — | — |
 | `projectNumber` | No | `integer` \| `null` | — | — |
 | `projectOwner` | No | `string` \| `null` | — | — |
-| `operatorHandle` | No | `string` | — | — |
+| `operatorHandle` | Yes | `string` | — | — |
 | `defaultTimeoutMs` | No | `integer` | — | Default `timeoutMs` (in milliseconds) applied to every `gh` subprocess spawned by the GitHub provider facade. Caps any single `gh api` / `gh issue ...` / `gh pr ...` invocation so a stalled TCP socket or long-poll cannot hang an orchestration indefinitely. A `GhExecTimeoutError` from a hit ceiling is classified `transient` and retried by `withTransientRetry`. Recommended floor 1000ms; recommended default 60000 (60s). Omit to use the in-code default of 60000. Story #2860. |
 | `branchProtection` | No | `object` | — | Nested configuration block. |
 | `branchProtection.enforce` | No | `boolean` | — | — |
@@ -764,7 +764,8 @@ number of keys.
 | `project.commands.lintBaseline`                      | `npm run lint`                        | `npx eslint . --format json`               | Root piggybacks on the repo's existing lint script; consumer template assumes a generic ESLint setup with structured output.     |
 | `delivery.quality.gates.maintainability.targetDirs`  | `[".agents/scripts", "tests"]`        | `["src"]`                                  | Root scans the framework's own source tree; consumer template scans the conventional `src/`.                                     |
 | `delivery.quality.gates.crap.targetDirs`             | `[".agents/scripts"]`                 | `["src"]`                                  | Same reason as maintainability above.                                                                                            |
-| `github.owner` / `.repo` / `.projectNumber` / `.projectOwner` / `.operatorHandle` | Populated for `dsj1984/mandrel` | `[OWNER]` / `[REPO]` / `null` / `null` / `@[USERNAME]` | Repo-specific identifiers; placeholders in the template are replaced by `node .agents/scripts/bootstrap.js` (or by hand). |
+| `github.owner` / `.repo` / `.projectNumber` | Populated for `dsj1984/mandrel` | `[OWNER]` / `[REPO]` / `null` | Shared repo identifiers; placeholders in the template are replaced by `node .agents/scripts/bootstrap.js` (or by hand). |
+| `github.operatorHandle` | Committed as the `@[USERNAME]` placeholder; each contributor overrides it in gitignored `.agentrc.local.json` | `@[USERNAME]` | Schema-required, but per-contributor: the committed placeholder resolves to null and the lease guards fail closed until you set your own handle locally (see [Per-machine local overrides](#per-machine-local-overrides)). |
 | `delivery.worktreeIsolation.nodeModulesStrategy`     | `per-worktree`                        | `per-worktree`                             | npm-only repo (`package-lock.json`); worktree init runs `npm ci` per tree.                                                       |
 
 When a consumer runs `/agents-update`, the
@@ -878,6 +879,33 @@ nested field without restating sibling keys; absent local file is a no-op. Use
 it for machine-specific tuning (e.g. lower
 `delivery.deliverRunner.concurrencyCap` on a laptop) that should never reach
 git.
+
+**Per-contributor identity (required).** `github.operatorHandle` is a personal,
+per-contributor value with two jobs: the `@`-handle the framework @mentions on
+friction comments, **and** the lease owner the workflow guards
+([`ticket-lease.js`](../.agents/scripts/lib/orchestration/ticket-lease.js))
+assign to a ticket so two contributors cannot drive the same Epic/Story
+concurrently. Because the lease must distinguish *your* run from *another
+person's*, a shared committed handle would defeat it — everyone would coordinate
+under one identity. So each contributor sets their own in `.agentrc.local.json`:
+
+```json
+{
+  "github": { "operatorHandle": "@your-handle" }
+}
+```
+
+`operatorHandle` is **required** by the schema, but the committed `.agentrc.json`
+carries only the non-personal placeholder `@[USERNAME]` (so CI and fresh clones
+validate without naming a real person). The placeholder is **not** a usable
+identity: [`normalizeOperatorHandle`](../.agents/scripts/lib/orchestration/ticket-lease.js)
+resolves `@[USERNAME]` to `null`, and the lease guards (`/epic-plan`,
+`/epic-deliver`, `/story-deliver`) **fail closed** — they throw with a
+"set your own handle in `.agentrc.local.json`" message rather than running an
+ownerless, unguarded workflow. Your local overlay replaces the placeholder with
+your real handle, and the guards proceed. By contrast, `github.owner` / `repo`
+are **shared** repo identifiers (everyone targets the same `dsj1984/mandrel`)
+and stay committed with real values.
 
 ### Adding a new top-level key (framework change)
 

--- a/tests/check-baselines-dispatch-pipeline.test.js
+++ b/tests/check-baselines-dispatch-pipeline.test.js
@@ -70,7 +70,7 @@ function setupTmpRepo() {
       docsContextFiles: [],
       commands: { lintBaseline: 'echo', test: 'echo', typecheck: 'echo' },
     },
-    github: { owner: 'x', repo: 'y' },
+    github: { owner: 'x', repo: 'y', operatorHandle: '@ci' },
     delivery: {
       quality: {
         gates: {

--- a/tests/check-baselines-exit-codes.test.js
+++ b/tests/check-baselines-exit-codes.test.js
@@ -51,7 +51,7 @@ function setupTmpRepo() {
       docsContextFiles: [],
       commands: { lintBaseline: 'echo', test: 'echo', typecheck: 'echo' },
     },
-    github: { owner: 'x', repo: 'y' },
+    github: { owner: 'x', repo: 'y', operatorHandle: '@ci' },
     delivery: {
       quality: {
         gateScoping: { scope: 'diff', diffRef: 'main' },

--- a/tests/check-baselines-friction.test.js
+++ b/tests/check-baselines-friction.test.js
@@ -62,7 +62,7 @@ function setupTmpRepo() {
       docsContextFiles: [],
       commands: { lintBaseline: 'echo', test: 'echo', typecheck: 'echo' },
     },
-    github: { owner: 'x', repo: 'y' },
+    github: { owner: 'x', repo: 'y', operatorHandle: '@ci' },
     delivery: {
       quality: {
         gateScoping: { scope: 'diff', diffRef: 'main' },

--- a/tests/contract/check-baselines-kernel-mismatch.test.js
+++ b/tests/contract/check-baselines-kernel-mismatch.test.js
@@ -78,7 +78,7 @@ function setupRepo() {
       docsContextFiles: [],
       commands: { lintBaseline: 'echo', test: 'echo', typecheck: 'echo' },
     },
-    github: { owner: 'x', repo: 'y' },
+    github: { owner: 'x', repo: 'y', operatorHandle: '@ci' },
     delivery: {
       quality: {
         gateScoping: { scope: 'diff', diffRef: 'main' },

--- a/tests/contract/check-baselines-regression.test.js
+++ b/tests/contract/check-baselines-regression.test.js
@@ -72,7 +72,7 @@ function setupRepo({ baseRollup, baseRows } = {}) {
       docsContextFiles: [],
       commands: { lintBaseline: 'echo', test: 'echo', typecheck: 'echo' },
     },
-    github: { owner: 'x', repo: 'y' },
+    github: { owner: 'x', repo: 'y', operatorHandle: '@ci' },
     delivery: {
       quality: {
         gateScoping: { scope: 'diff', diffRef: 'main' },

--- a/tests/lib/orchestration/epic-deliver-lease-guard.test.js
+++ b/tests/lib/orchestration/epic-deliver-lease-guard.test.js
@@ -239,18 +239,22 @@ describe('epic-deliver-lease-guard — runPrepareGuards', () => {
     assert.deepEqual(provider.state.assignees, ['alice']);
   });
 
-  it('skips the lease (no throw) when no operator identity resolves', async () => {
+  it('fails closed (throws) when no operator identity resolves', async () => {
     const provider = makeProvider([]);
-    const { lease } = await runPrepareGuards({
-      epicId: EPIC_ID,
-      expectedBranch: [EPIC_BRANCH, 'main'],
-      git: makeGit({ branch: 'main' }),
-      provider,
-      operator: null,
-      now: NOW,
-      logger: SILENT_LOGGER,
-    });
-    assert.equal(lease, null);
+    await assert.rejects(
+      runPrepareGuards({
+        epicId: EPIC_ID,
+        expectedBranch: [EPIC_BRANCH, 'main'],
+        git: makeGit({ branch: 'main' }),
+        provider,
+        operator: null,
+        now: NOW,
+        logger: SILENT_LOGGER,
+      }),
+      /no operator identity could be resolved/,
+    );
+    // checkout-safety runs first (cheap, local); the lease never writes an
+    // assignee because the run is refused before the GitHub round-trip.
     assert.equal(provider.updateCalls.length, 0);
   });
 });

--- a/tests/lib/orchestration/epic-plan-lease-guard.test.js
+++ b/tests/lib/orchestration/epic-plan-lease-guard.test.js
@@ -143,19 +143,34 @@ describe('epic-plan-lease-guard — acquireEpicPlanLease (fail-closed)', () => {
     assert.deepEqual(provider.state.assignees, [OPERATOR]);
   });
 
-  it('degrades to a no-op when no operator is configured', async () => {
+  it('fails closed (throws) when no operator is configured', async () => {
     const provider = makeProvider({ assignees: [FOREIGN] });
 
-    const result = await acquireEpicPlanLease({
-      provider,
-      epicId: 9,
-      config: { github: {} },
-      now: NOW,
-    });
-
-    assert.equal(result.acquired, true);
-    assert.equal(result.reason, 'no-operator');
+    await assert.rejects(
+      acquireEpicPlanLease({
+        provider,
+        epicId: 9,
+        config: { github: {} },
+        now: NOW,
+      }),
+      /no operator identity is configured/,
+    );
     // no assignee mutation when the lease cannot be keyed
+    assert.equal(provider.updateCalls.length, 0);
+  });
+
+  it('fails closed when operatorHandle is still the @[USERNAME] placeholder', async () => {
+    const provider = makeProvider({ assignees: [FOREIGN] });
+
+    await assert.rejects(
+      acquireEpicPlanLease({
+        provider,
+        epicId: 9,
+        config: { github: { operatorHandle: '@[USERNAME]' } },
+        now: NOW,
+      }),
+      /placeholder/,
+    );
     assert.equal(provider.updateCalls.length, 0);
   });
 

--- a/tests/lib/orchestration/single-story-lease-guard.test.js
+++ b/tests/lib/orchestration/single-story-lease-guard.test.js
@@ -52,11 +52,18 @@ describe('single-story-lease-guard — resolveOperator', () => {
   it('throws when no operator handle is configured', () => {
     assert.throws(
       () => resolveOperator({ github: {} }),
-      /github.operatorHandle is not configured/,
+      /no operator identity is configured/,
     );
     assert.throws(
       () => resolveOperator({}),
-      /operatorHandle is not configured/,
+      /no operator identity is configured/,
+    );
+  });
+
+  it('throws when operatorHandle is still the shipped @[USERNAME] placeholder', () => {
+    assert.throws(
+      () => resolveOperator({ github: { operatorHandle: '@[USERNAME]' } }),
+      /placeholder/,
     );
   });
 });

--- a/tests/scripts/check-baselines-pipeline.test.js
+++ b/tests/scripts/check-baselines-pipeline.test.js
@@ -63,7 +63,7 @@ function setupTmpRepo({ coverageRollup } = {}) {
       docsContextFiles: [],
       commands: { lintBaseline: 'echo', test: 'echo', typecheck: 'echo' },
     },
-    github: { owner: 'x', repo: 'y' },
+    github: { owner: 'x', repo: 'y', operatorHandle: '@ci' },
     delivery: {
       quality: {
         gates: {

--- a/tests/scripts/check-baselines.min-floor.test.js
+++ b/tests/scripts/check-baselines.min-floor.test.js
@@ -55,7 +55,7 @@ function setupRepo({ floors } = {}) {
       docsContextFiles: [],
       commands: { lintBaseline: 'echo', test: 'echo', typecheck: 'echo' },
     },
-    github: { owner: 'x', repo: 'y' },
+    github: { owner: 'x', repo: 'y', operatorHandle: '@ci' },
     delivery: {
       quality: {
         gates: {

--- a/tests/scripts/check-baselines.test.js
+++ b/tests/scripts/check-baselines.test.js
@@ -47,7 +47,7 @@ function setupTmpRepo(extraConfig = {}) {
       docsContextFiles: [],
       commands: { lintBaseline: 'echo', test: 'echo', typecheck: 'echo' },
     },
-    github: { owner: 'x', repo: 'y' },
+    github: { owner: 'x', repo: 'y', operatorHandle: '@ci' },
     delivery: {
       quality: {
         gates: {

--- a/tests/scripts/check-baselines.unknown-axis.test.js
+++ b/tests/scripts/check-baselines.unknown-axis.test.js
@@ -47,7 +47,7 @@ function setupRepoWithBadFloor() {
       docsContextFiles: [],
       commands: { lintBaseline: 'echo', test: 'echo', typecheck: 'echo' },
     },
-    github: { owner: 'x', repo: 'y' },
+    github: { owner: 'x', repo: 'y', operatorHandle: '@ci' },
     delivery: {
       quality: {
         gates: {

--- a/tests/scripts/epic-plan.spec-flow.test.js
+++ b/tests/scripts/epic-plan.spec-flow.test.js
@@ -458,6 +458,12 @@ function buildRunSpecPhaseProvider(epicShape = {}) {
 
   return {
     ...base,
+    // The Epic-plan lease (acquireEpicPlanLease) reads/writes the assignee via
+    // getTicket/updateTicket. The epic starts unassigned, so the lease takes an
+    // unclaimed claim cleanly.
+    async getTicket(id) {
+      return { ...base.epic, id, assignees: base.epic.assignees ?? [] };
+    },
     async getTicketComments(ticketId) {
       return comments.get(ticketId) ?? [];
     },
@@ -477,6 +483,13 @@ function buildRunSpecPhaseProvider(epicShape = {}) {
   };
 }
 
+// Shared opts.config carrying an operator handle so the Epic-plan lease can
+// acquire (the guard fails closed without one). Reused across the runSpecPhase
+// cases below.
+const SPEC_LEASE_CFG = {
+  github: { owner: 'o', repo: 'r', operatorHandle: '@ci' },
+};
+
 describe('review routing — Story #2795', () => {
   it('high-risk runSpecPhase records review-required routing in checkpoint', async () => {
     const provider = buildRunSpecPhaseProvider({
@@ -492,6 +505,7 @@ describe('review routing — Story #2795', () => {
         techSpecContent: '## Technical Overview\nNo stale paths here.',
       },
       { baseBranch: 'main', paths: { tempRoot: sandbox } },
+      { config: SPEC_LEASE_CFG },
     );
 
     assert.equal(result.planningRisk.requiresReview, true);
@@ -516,6 +530,7 @@ describe('review routing — Story #2795', () => {
         techSpecContent: '## Technical Overview\nNo stale paths here.',
       },
       { baseBranch: 'main', paths: { tempRoot: sandbox } },
+      { config: SPEC_LEASE_CFG },
     );
 
     assert.equal(result.planningRisk.requiresReview, false);
@@ -548,7 +563,7 @@ describe('review routing — Story #2795', () => {
         techSpecContent: '## Technical Overview\nNo stale paths here.',
       },
       { baseBranch: 'main', paths: { tempRoot: sandbox } },
-      { forceReview: true },
+      { forceReview: true, config: SPEC_LEASE_CFG },
     );
 
     assert.equal(result.reviewRouting.decision, 'operator-override-review');

--- a/tests/story-orchestration.test.js
+++ b/tests/story-orchestration.test.js
@@ -412,7 +412,7 @@ test('story-close: successful merge and closure', async () => {
           tempRoot: path.join(sandboxCwd, 'temp'),
         },
       },
-      github: { owner: 'o', repo: 'r' },
+      github: { owner: 'o', repo: 'r', operatorHandle: '@ci' },
       delivery: { worktreeIsolation: { enabled: false } },
     }),
   );
@@ -476,7 +476,7 @@ test('story-close: reaps worktree using resolved --cwd repo root', async () => {
           tempRoot: path.join(explicitMainRepo, 'temp'),
         },
       },
-      github: { owner: 'o', repo: 'r' },
+      github: { owner: 'o', repo: 'r', operatorHandle: '@ci' },
       delivery: {
         worktreeIsolation: {
           enabled: true,
@@ -543,7 +543,7 @@ test('story-close: resolves config from runtime --cwd (can disable reap)', async
           tempRoot: path.join(tmp, 'temp'),
         },
       },
-      github: { owner: 'o', repo: 'r' },
+      github: { owner: 'o', repo: 'r', operatorHandle: '@ci' },
       delivery: { worktreeIsolation: { enabled: false } },
     }),
   );
@@ -603,7 +603,7 @@ test('story-init: resolves config from runtime --cwd for worktree mode', async (
           tempRoot: path.join(tmp, 'temp'),
         },
       },
-      github: { owner: 'o', repo: 'r' },
+      github: { owner: 'o', repo: 'r', operatorHandle: '@ci' },
       delivery: { worktreeIsolation: { enabled: false } },
     }),
   );


### PR DESCRIPTION
## Why

`github.operatorHandle` is the **lease owner** the workflow guards ([`ticket-lease.js`](.agents/scripts/lib/orchestration/ticket-lease.js)) assign to a ticket so two runs can't drive the same Epic/Story concurrently. Previously it was a single shared value committed in `.agentrc.json` (`@dsj1984`), which meant **every contributor resolved to the same lease owner** — so the lease couldn't tell one person's run from another's, defeating the guard. On top of that, the `/epic-plan` and `/epic-deliver` guards **silently skipped** the lease when no handle resolved.

This makes the handle per-contributor and enforces it.

## What changed

- **Schema — `operatorHandle` is now required** under `github` (`agentrc.schema.json` + the JS mirror `config-settings-schema.js`).
- **Committed `.agentrc.json`** carries the non-personal `@[USERNAME]` placeholder (so CI and fresh clones validate without naming a real person) and **drops the redundant `projectOwner`** (it falls back to `owner`). Each contributor sets their real handle in the gitignored `.agentrc.local.json`.
- **`normalizeOperatorHandle` maps `@[USERNAME]` → `null`**, so the placeholder is never a usable lease owner and an assignee PATCH never writes a literal `[USERNAME]` (HTTP 422).
- **All three lease guards fail closed (throw)** when no real operator resolves, with a "set your handle in `.agentrc.local.json`" message: `epic-plan` and `epic-deliver` previously skipped silently; `single-story` already threw and now also catches the placeholder.
- Docs ([`configuration.md`](docs/configuration.md), [`epic-deliver.md`](.agents/workflows/epic-deliver.md)) updated to the required-placeholder model; test fixtures carrying a `github` block updated for the new required field.

## Behavior

| Path | `operatorHandle` resolves to | Result |
|---|---|---|
| Contributor with local override | their login | Guards proceed under their identity |
| Contributor who forgot to set it | `@[USERNAME]` → `null` | Guards **throw** loudly |
| CI / fresh clone (no local file) | `@[USERNAME]` | Schema validates (CI green); CI doesn't run guards |

## Verification

- Full suite: **8253 pass, 0 fail**. Lint clean; config-docs/lifecycle/doc-drift/link checks clean; maintainability baseline 0 breaches/regressions. Pre-commit and pre-push quality ratchets pass with **0 MI regressions** (no `--no-verify`).

> [!WARNING]
> **BREAKING CHANGE:** `.agentrc.json` documents with a `github` block must now include `github.operatorHandle`. Shipped templates already carry the `@[USERNAME]` placeholder, so consumers upgrading via `mandrel sync` get it automatically; a hand-written config without it will fail schema validation until the key is added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)