### PR TITLE
fix(update): auto-detect the package manager in `mandrel update` — hardcoded `npm install` breaks & corrupts pnpm/yarn workspaces (#3575)

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,9 +87,12 @@ npx mandrel update
    [`docs/upgrade-major.md`](docs/upgrade-major.md), and exits non-zero
    without touching anything. Re-run with `--major` to apply it.
 3. **No-op short-circuit** — already on the newest version ⇒ nothing to do.
-4. **Install** the target version (the dependency bump is left **staged**
-   on disk — `mandrel update` performs no `git add` / `git commit`, so you
-   review and commit the lockfile change yourself).
+4. **Install** the target version with the project's package manager —
+   auto-detected from the lockfile (`pnpm-lock.yaml` ⇒ pnpm, `yarn.lock` ⇒
+   yarn, otherwise npm) so the bump lands in your real lockfile. The
+   dependency bump is left **staged** on disk — `mandrel update` performs no
+   `git add` / `git commit`, so you review and commit the lockfile change
+   yourself.
 5. **Sync** — re-materialize `./.agents/` from the freshly installed payload.
 6. **Migrate** — apply version-keyed migration steps for the crossed range.
 7. **Doctor** — run the check registry to verify the resulting install.
@@ -102,12 +105,14 @@ npx mandrel update
   runs.
 - `--major` — apply a major-version crossing that the gate would otherwise
   refuse. Review [`docs/upgrade-major.md`](docs/upgrade-major.md) first.
-- `--install-cmd "<cmd>"` — override the install command for pnpm/yarn
-  workspaces. The default is `npm install @mandrelai/agents@<target>`; pass
-  e.g. `--install-cmd "pnpm add @mandrelai/agents@<target>"` so the bump
-  lands in your real lockfile rather than writing a stray
-  `package-lock.json`. The registry probe always stays on `npm view` (it is
-  a PM-agnostic registry query).
+- `--install-cmd "<cmd>"` — override the auto-detected install command. The
+  package manager is normally detected from your lockfile
+  (`pnpm-lock.yaml` ⇒ `pnpm add -D …`, `yarn.lock` ⇒ `yarn add -D …`,
+  otherwise `npm install …`), so an override is rarely needed. When you do
+  pass one, a `{target}` placeholder is substituted with the resolved newest
+  version — e.g. `--install-cmd "pnpm add -D @mandrelai/agents@{target} -w"` —
+  so the override can still consume the auto-probed version. The registry
+  probe always stays on `npm view` (it is a PM-agnostic registry query).
 
 ### Manual equivalent
 

--- a/lib/cli/__tests__/update.test.js
+++ b/lib/cli/__tests__/update.test.js
@@ -23,15 +23,30 @@
  */
 
 import assert from 'node:assert/strict';
+import path from 'node:path';
 import { describe, it } from 'node:test';
 
 import { runInstallCommand } from '../../../.agents/scripts/lib/install-cmd-parser.js';
 import update, {
   defaultNpmUpdate,
   defaultVersionRunner,
+  detectPackageManager,
   resolveInstallCmd,
   runUpdate,
 } from '../update.js';
+
+/**
+ * Build an in-memory `node:fs` fake whose `existsSync` reports the given
+ * basenames as present — enough surface for `detectPackageManager` to probe
+ * lockfiles without touching the real filesystem (testing-standards § Unit:
+ * mock all filesystem I/O).
+ *
+ * @param {string[]} present - lockfile basenames to report as present.
+ */
+function makeLockFs(present = []) {
+  const set = new Set(present);
+  return { existsSync: (p) => set.has(path.basename(String(p))) };
+}
 
 // ---------------------------------------------------------------------------
 // Capture + seam helpers
@@ -385,6 +400,174 @@ describe('resolveInstallCmd — default vs override', () => {
     assert.equal(
       resolveInstallCmd('1.46.0', '   '),
       'npm install @mandrelai/agents@1.46.0',
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AC-1/AC-2 — package-manager detection from the project lockfile
+// ---------------------------------------------------------------------------
+
+describe('detectPackageManager — lockfile probe', () => {
+  it('detects pnpm and the workspace root from pnpm-lock.yaml + pnpm-workspace.yaml', () => {
+    const fs = makeLockFs(['pnpm-lock.yaml', 'pnpm-workspace.yaml']);
+    assert.deepEqual(detectPackageManager('/ws', fs), {
+      packageManager: 'pnpm',
+      workspaceRoot: true,
+    });
+  });
+
+  it('detects pnpm without -w when no pnpm-workspace.yaml is present', () => {
+    const fs = makeLockFs(['pnpm-lock.yaml']);
+    assert.deepEqual(detectPackageManager('/proj', fs), {
+      packageManager: 'pnpm',
+      workspaceRoot: false,
+    });
+  });
+
+  it('detects yarn from yarn.lock', () => {
+    const fs = makeLockFs(['yarn.lock']);
+    assert.deepEqual(detectPackageManager('/proj', fs), {
+      packageManager: 'yarn',
+      workspaceRoot: false,
+    });
+  });
+
+  it('falls back to npm when only package-lock.json (or nothing) is present', () => {
+    assert.deepEqual(
+      detectPackageManager('/proj', makeLockFs(['package-lock.json'])),
+      {
+        packageManager: 'npm',
+        workspaceRoot: false,
+      },
+    );
+    assert.deepEqual(detectPackageManager('/proj', makeLockFs([])), {
+      packageManager: 'npm',
+      workspaceRoot: false,
+    });
+  });
+
+  it('prefers pnpm over yarn when both lockfiles exist', () => {
+    const fs = makeLockFs(['pnpm-lock.yaml', 'yarn.lock']);
+    assert.equal(detectPackageManager('/proj', fs).packageManager, 'pnpm');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AC-1/AC-2/AC-3 — resolveInstallCmd builds the PM-aware command
+// ---------------------------------------------------------------------------
+
+describe('resolveInstallCmd — package-manager aware', () => {
+  it('builds `pnpm add -D … -w` at a workspace root (AC-1)', () => {
+    assert.equal(
+      resolveInstallCmd('1.48.0', undefined, {
+        packageManager: 'pnpm',
+        workspaceRoot: true,
+      }),
+      'pnpm add -D @mandrelai/agents@1.48.0 -w',
+    );
+  });
+
+  it('omits -w for a non-root pnpm project', () => {
+    assert.equal(
+      resolveInstallCmd('1.48.0', undefined, { packageManager: 'pnpm' }),
+      'pnpm add -D @mandrelai/agents@1.48.0',
+    );
+  });
+
+  it('builds `yarn add -D …` for a yarn project (AC-2)', () => {
+    assert.equal(
+      resolveInstallCmd('1.48.0', undefined, { packageManager: 'yarn' }),
+      'yarn add -D @mandrelai/agents@1.48.0',
+    );
+  });
+
+  it('substitutes a {target} placeholder in an override (AC-3)', () => {
+    assert.equal(
+      resolveInstallCmd('1.48.0', 'pnpm add -D @mandrelai/agents@{target} -w'),
+      'pnpm add -D @mandrelai/agents@1.48.0 -w',
+    );
+  });
+
+  it('uses a placeholder-free override verbatim', () => {
+    assert.equal(
+      resolveInstallCmd('1.48.0', 'pnpm add @mandrelai/agents@latest'),
+      'pnpm add @mandrelai/agents@latest',
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AC-1/AC-2 — defaultNpmUpdate resolves the command from the detected PM
+// ---------------------------------------------------------------------------
+
+describe('defaultNpmUpdate — package-manager detection', () => {
+  it('runs `pnpm add -D … -w` in a pnpm workspace root (AC-1)', () => {
+    const fs = makeLockFs(['pnpm-lock.yaml', 'pnpm-workspace.yaml']);
+    const calls = [];
+    const runInstall = (cmd, cwd) => {
+      calls.push({ cmd, cwd });
+      return { status: 0, stderr: '' };
+    };
+
+    defaultNpmUpdate('1.48.0', { runInstall, cwd: '/ws', fs });
+
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0].cmd, 'pnpm add -D @mandrelai/agents@1.48.0 -w');
+    assert.equal(calls[0].cwd, '/ws');
+  });
+
+  it('runs `yarn add -D …` when yarn.lock is present (AC-2)', () => {
+    const fs = makeLockFs(['yarn.lock']);
+    const calls = [];
+    const runInstall = (cmd) => {
+      calls.push(cmd);
+      return { status: 0, stderr: '' };
+    };
+
+    defaultNpmUpdate('1.48.0', { runInstall, cwd: '/proj', fs });
+
+    assert.deepEqual(calls, ['yarn add -D @mandrelai/agents@1.48.0']);
+  });
+
+  it('keeps `npm install …` unchanged for an npm repo (AC-2)', () => {
+    const fs = makeLockFs(['package-lock.json']);
+    const calls = [];
+    const runInstall = (cmd) => {
+      calls.push(cmd);
+      return { status: 0, stderr: '' };
+    };
+
+    defaultNpmUpdate('1.48.0', { runInstall, cwd: '/proj', fs });
+
+    assert.deepEqual(calls, ['npm install @mandrelai/agents@1.48.0']);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AC-4 — install failure surfaces a PM-specific node_modules repair hint
+// ---------------------------------------------------------------------------
+
+describe('defaultNpmUpdate — repair hint on failure (AC-4)', () => {
+  it('names the detected package manager when the install exits non-zero', () => {
+    const fs = makeLockFs(['pnpm-lock.yaml']);
+    const runInstall = () => ({ status: 1, stderr: 'boom' });
+
+    assert.throws(
+      () => defaultNpmUpdate('1.48.0', { runInstall, cwd: '/ws', fs }),
+      /exited 1: boom[\s\S]*run `pnpm install`/,
+    );
+  });
+
+  it('includes the repair hint when the install spawn throws', () => {
+    const fs = makeLockFs(['yarn.lock']);
+    const runInstall = () => {
+      throw new Error('ENOENT');
+    };
+
+    assert.throws(
+      () => defaultNpmUpdate('1.48.0', { runInstall, cwd: '/ws', fs }),
+      /failed to spawn: ENOENT[\s\S]*run `yarn install`/,
     );
   });
 });

--- a/lib/cli/update.js
+++ b/lib/cli/update.js
@@ -17,10 +17,14 @@
  *      major boundary and `--major` is absent
  *   3. no-op short-circuit — already on the newest version ⇒ nothing to do
  *   4. install        — bump the dependency (lockfile bump left STAGED).
- *      Defaults to `npm install @mandrelai/agents@<target>`; an explicit
- *      `--install-cmd "<pm> <args>"` overrides the package manager for
- *      pnpm/yarn workspaces. The registry probe in step 1 always stays on
- *      `npm view` (a PM-agnostic registry query).
+ *      The package manager is auto-detected from the lockfile in the project
+ *      root: `pnpm-lock.yaml` ⇒ `pnpm add -D …` (with `-w` at a
+ *      `pnpm-workspace.yaml` root), `yarn.lock` ⇒ `yarn add -D …`, otherwise
+ *      `npm install …`. An explicit `--install-cmd "<pm> <args>"` overrides
+ *      detection; a `{target}` placeholder in the override is substituted with
+ *      the resolved version so an override can still consume the auto-probed
+ *      newest. The registry probe in step 1 always stays on `npm view` (a
+ *      PM-agnostic registry query).
  *   5. runSync        — re-materialize ./.agents/ from the new payload
  *   6. runMigrations  — apply version-keyed steps for the crossed range
  *   7. doctor         — run the check registry; success ⇒ all checks pass
@@ -250,19 +254,99 @@ export function defaultVersionRunner({ spawnSync: spawn = spawnSync } = {}) {
 }
 
 /**
- * Resolve the install command string `defaultNpmUpdate` runs. With no override
- * it is `npm install @mandrelai/agents@<target>` (the unchanged default); an
- * explicit `--install-cmd "<pm> <args>"` substitutes a pnpm/yarn invocation.
- * The override is the operator's full command verbatim — the resolved semver
- * `target` is appended only when no override is supplied.
+ * Map a detected package manager to the command that re-runs a full install.
+ * Surfaced in the repair hint when an install fails so the operator can restore
+ * `node_modules` to a consistent state (Story #3575 AC-4).
+ *
+ * @param {'pnpm' | 'yarn' | 'npm'} packageManager
+ * @returns {string}
+ */
+function repairInstallCommand(packageManager) {
+  if (packageManager === 'pnpm') return 'pnpm install';
+  if (packageManager === 'yarn') return 'yarn install';
+  return 'npm install';
+}
+
+/**
+ * Detect the project's package manager by probing for a lockfile in `cwd`.
+ * Precedence mirrors the ecosystem norm: a `pnpm-lock.yaml` wins over a
+ * `yarn.lock`, which wins over the npm default. `workspaceRoot` is true only
+ * for pnpm when a `pnpm-workspace.yaml` sits alongside the lockfile — the
+ * signal that `pnpm add` must carry `-w` to target the workspace-root manifest.
+ *
+ * Running the wrong package manager (e.g. `npm install` in a pnpm workspace) is
+ * the root cause this resolves (Story #3575): npm chokes on the pnpm-managed
+ * tree, exits non-zero, and can flip `node_modules` to a stale store entry.
+ * Detecting the lockfile keeps the bump on the operator's real package manager
+ * so the change lands in the matching lockfile.
+ *
+ * @param {string} [cwd] - Project root to probe (default `process.cwd()`).
+ * @param {typeof nodeFs} [fs]
+ * @returns {{ packageManager: 'pnpm' | 'yarn' | 'npm', workspaceRoot: boolean }}
+ */
+export function detectPackageManager(cwd = process.cwd(), fs = nodeFs) {
+  const has = (file) => {
+    try {
+      return fs.existsSync(path.join(cwd, file));
+    } catch {
+      return false;
+    }
+  };
+  if (has('pnpm-lock.yaml')) {
+    return {
+      packageManager: 'pnpm',
+      workspaceRoot: has('pnpm-workspace.yaml'),
+    };
+  }
+  if (has('yarn.lock')) {
+    return { packageManager: 'yarn', workspaceRoot: false };
+  }
+  return { packageManager: 'npm', workspaceRoot: false };
+}
+
+/**
+ * Resolve the install command string `defaultNpmUpdate` runs.
+ *
+ * With no override the command is built from the detected package manager:
+ *   - `pnpm` ⇒ `pnpm add -D @mandrelai/agents@<target>` (plus ` -w` at a pnpm
+ *     workspace root)
+ *   - `yarn` ⇒ `yarn add -D @mandrelai/agents@<target>`
+ *   - `npm`  ⇒ `npm install @mandrelai/agents@<target>` (the unchanged default)
+ *
+ * An explicit `--install-cmd` override is used verbatim, except that a
+ * `{target}` placeholder is substituted with the resolved semver so an override
+ * can still consume the auto-probed newest version (Story #3575 AC-3).
+ *
+ * This function is pure: package-manager detection happens in
+ * `detectPackageManager` (the only filesystem seam) and is passed in as
+ * `detected`, keeping the command-string assembly trivially unit-testable.
  *
  * @param {string} target - The resolved semver to install.
  * @param {string} [override] - Operator-supplied `--install-cmd` value.
+ * @param {{
+ *   packageManager?: 'pnpm' | 'yarn' | 'npm',
+ *   workspaceRoot?: boolean,
+ * }} [detected]
  * @returns {string}
  */
-export function resolveInstallCmd(target, override) {
+export function resolveInstallCmd(
+  target,
+  override,
+  { packageManager = 'npm', workspaceRoot = false } = {},
+) {
   const trimmed = String(override ?? '').trim();
-  return trimmed.length > 0 ? trimmed : `npm install ${PACKAGE_NAME}@${target}`;
+  if (trimmed.length > 0) {
+    return trimmed.includes('{target}')
+      ? trimmed.replaceAll('{target}', target)
+      : trimmed;
+  }
+  if (packageManager === 'pnpm') {
+    return `pnpm add -D ${PACKAGE_NAME}@${target}${workspaceRoot ? ' -w' : ''}`;
+  }
+  if (packageManager === 'yarn') {
+    return `yarn add -D ${PACKAGE_NAME}@${target}`;
+  }
+  return `npm install ${PACKAGE_NAME}@${target}`;
 }
 
 /**
@@ -270,39 +354,56 @@ export function resolveInstallCmd(target, override) {
  * rewrites `package.json` / the lockfile on disk (left staged for the
  * operator); this performs no git mutation.
  *
- * The install routes through the shared `runInstallCommand` helper from
- * `lib/install-cmd-parser.js`, which tokenizes the command and spawns with
- * `shell: process.platform === 'win32'` so the Windows `.cmd` shim resolves
- * under CVE-2024-27980 — the win32 shell handling and tokenization are reused,
- * not re-implemented here. The default argv (`npm install @mandrelai/agents@<target>`)
- * is a fixed vector; an `--install-cmd` override is tokenized and escaped
+ * The package manager is auto-detected from `cwd`'s lockfile (Story #3575) so
+ * the bump lands in the operator's real lockfile rather than running
+ * `npm install` against a pnpm/yarn-managed tree. The install routes through
+ * the shared `runInstallCommand` helper from `lib/install-cmd-parser.js`, which
+ * tokenizes the command and spawns with `shell: process.platform === 'win32'`
+ * so the Windows `.cmd` shim resolves under CVE-2024-27980 — the win32 shell
+ * handling and tokenization are reused, not re-implemented here. The resolved
+ * argv is a fixed vector; an `--install-cmd` override is tokenized and escaped
  * per-arg by the parser even when the win32 shell flag is required.
+ *
+ * On any install failure the thrown error names the detected package manager's
+ * own `install` command so the operator can restore `node_modules` to a
+ * consistent state — `mandrel update` never silently leaves a half-mutated
+ * tree (Story #3575 AC-4).
  *
  * @param {string} target - The version to install.
  * @param {{
  *   installCmd?: string,
  *   runInstall?: typeof runInstallCommand,
  *   cwd?: string,
+ *   fs?: typeof nodeFs,
  * }} [opts]
  * @returns {void}
  */
 export function defaultNpmUpdate(
   target,
-  { installCmd, runInstall = runInstallCommand, cwd = process.cwd() } = {},
+  {
+    installCmd,
+    runInstall = runInstallCommand,
+    cwd = process.cwd(),
+    fs = nodeFs,
+  } = {},
 ) {
-  const cmd = resolveInstallCmd(target, installCmd);
+  const detected = detectPackageManager(cwd, fs);
+  const cmd = resolveInstallCmd(target, installCmd, detected);
+  const repairHint =
+    `\n   → If node_modules looks wrong, run \`${repairInstallCommand(detected.packageManager)}\`` +
+    ' to restore it to a consistent state.';
   let r;
   try {
     r = runInstall(cmd, cwd);
   } catch (err) {
     throw new Error(
-      `mandrel update: install command \`${cmd}\` failed to spawn: ${err.message}`,
+      `mandrel update: install command \`${cmd}\` failed to spawn: ${err.message}${repairHint}`,
     );
   }
   if (r.status !== 0) {
     const snippet = (r.stderr || '').trim().slice(0, 200);
     throw new Error(
-      `mandrel update: install command \`${cmd}\` exited ${r.status}: ${snippet}`,
+      `mandrel update: install command \`${cmd}\` exited ${r.status}: ${snippet}${repairHint}`,
     );
   }
 }
@@ -658,10 +759,10 @@ export async function runUpdate({
  *     version through the daily freshness cache (`version-check.js#isStale`),
  *     which ALSO populates `temp/version-check.json` — the cache the
  *     `version-current` doctor advisory reads.
- *   - `npmUpdate` runs the install command (default
- *     `npm install @mandrelai/agents@<target>`, or the `--install-cmd`
- *     override) through the shared `runInstallCommand` helper — no git
- *     mutation; lockfile left staged.
+ *   - `npmUpdate` runs the install command — auto-detected from the project
+ *     lockfile (`pnpm`/`yarn`/`npm`), or the `--install-cmd` override —
+ *     through the shared `runInstallCommand` helper — no git mutation;
+ *     lockfile left staged.
  *   - `surfaceChangelog` prints the relevant `docs/CHANGELOG.md` section(s)
  *     for the applied range, degrading gracefully when the file is absent.
  *
@@ -733,6 +834,7 @@ export default async function run(argv = [], deps = {}) {
       defaultNpmUpdate(target, {
         ...(installCmd ? { installCmd } : {}),
         ...(runInstall ? { runInstall } : {}),
+        fs,
       }),
     surfaceChangelog: (target) =>
       defaultSurfaceChangelog(target, {


### PR DESCRIPTION
Closes #3575

_Auto-opened by `/single-story-deliver`._