### PR TITLE
doctor `commands-in-sync` false-positive in npm-installed consumers (resolveProjectRoot lands on the package dir) (#3588)

### DIFF
--- a/.agents/scripts/sync-claude-commands.js
+++ b/.agents/scripts/sync-claude-commands.js
@@ -37,12 +37,22 @@
 // cli-opt-out: top-level-await script with no main() function — runAsCli wraps an async main, which doesn't apply here.
 import fs from 'node:fs';
 import path from 'node:path';
-import { fileURLToPath } from 'node:url';
 
 import { Logger } from './lib/Logger.js';
 
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
-const PROJECT_ROOT = path.resolve(__dirname, '../..');
+// Resolve the project root from the invocation cwd — the consumer project where
+// `.agents/` is materialized and where Claude Code loads the plugin from
+// `<root>/.claude/plugins/mandrel/`. It MUST NOT use `__dirname/../..`: in an
+// npm-installed consumer this script runs from
+// `node_modules/@mandrelai/agents/.agents/scripts/`, so that climb lands on the
+// package dir and the plugin tree would be written *inside node_modules* rather
+// than the consumer — leaving `/mandrel:*` commands unloadable and the
+// `commands-in-sync` doctor check (which resolves the same consumer root via
+// cwd — Story #3588) reporting "N not synced". Every real invocation runs with
+// cwd at the project root: `npm run sync:commands`, the UserPromptSubmit hook,
+// and `mandrel sync-commands` (which inherits the caller's cwd). Tests drive
+// fixture trees via the SYNC_CLAUDE_COMMANDS_SRC/DEST overrides below.
+const PROJECT_ROOT = process.cwd();
 
 /** Plugin manifest name — the `mandrel:` namespace every command gets. */
 export const PLUGIN_NAME = 'mandrel';

--- a/lib/cli/registry.js
+++ b/lib/cli/registry.js
@@ -214,14 +214,26 @@ function resolveProjectRoot() {
  * `.claude/plugins/mandrel/commands/*.md` destinations and report parity
  * (Story #3576 — the projection is now a Claude Code plugin, /mandrel:<name>).
  *
- * Injectable seam: `readDir` replaces `fs.readdirSync` so tests can
- * exercise without touching the real filesystem.
+ * Resolution anchor (Story #3588): the root defaults to `process.cwd()` —
+ * the consumer project directory where `mandrel sync` materializes both
+ * `.agents/` and the plugin command tree — mirroring the `agents-materialized`
+ * and `agents-drift` checks. It MUST NOT fall back to `resolveProjectRoot()`:
+ * that walks up from this module's own location and lands on the *package*
+ * directory in an npm-installed consumer
+ * (`node_modules/@mandrelai/agents/`), where the generated plugin tree never
+ * exists — yielding a permanent `N not synced` false positive whose
+ * `npm run sync:commands` remedy can never clear it.
  *
- * @param {{ projectRoot?: string, readDir?: (dir: string) => string[] }} [opts]
+ * Injectable seams (used by tests so no real filesystem is touched):
+ * - `cwd()` replaces `process.cwd` so tests can pin the consumer root.
+ * - `readDir` replaces `fs.readdirSync`.
+ *
+ * @param {{ projectRoot?: string, cwd?: () => string, readDir?: (dir: string) => string[] }} [opts]
  * @returns {{ ok: boolean, detail: string, remedy?: string }}
  */
-function runCommandsInSync({ projectRoot, readDir } = {}) {
-  const root = projectRoot ?? resolveProjectRoot();
+function runCommandsInSync({ projectRoot, cwd, readDir } = {}) {
+  const getCwd = cwd ?? (() => process.cwd());
+  const root = projectRoot ?? getCwd();
   const listDir =
     readDir ??
     ((dir) => {

--- a/tests/cli/registry.test.js
+++ b/tests/cli/registry.test.js
@@ -14,6 +14,7 @@
  */
 
 import assert from 'node:assert/strict';
+import path from 'node:path';
 import { describe, it } from 'node:test';
 
 import { registry } from '../../lib/cli/registry.js';
@@ -342,6 +343,31 @@ describe('commands-in-sync check', () => {
     });
     assertResultShape(result, { expectOk: false });
     assert.match(result.detail, /1 stale/);
+  });
+
+  // Story #3588 — regression: without an explicit projectRoot the check MUST
+  // anchor on the consumer dir (cwd()), not the package-relative
+  // resolveProjectRoot() climb that lands in node_modules in a real install.
+  it('defaults the root to cwd() (the consumer dir), not the package-relative climb', () => {
+    const check = findCheck('commands-in-sync');
+    const consumerRoot = path.join('/fake', 'consumer');
+    const dirsRead = [];
+    const result = check.run({
+      // projectRoot intentionally omitted — exercise the default resolution.
+      cwd: () => consumerRoot,
+      readDir: (dir) => {
+        dirsRead.push(dir);
+        // Both src and dest in sync so the assertion is purely about roots.
+        return ['epic-deliver.md', 'story-deliver.md'];
+      },
+    });
+    assertResultShape(result, { expectOk: true });
+    // The check must read the src/dest dirs anchored on the cwd() consumer
+    // root — not a package-relative path under node_modules.
+    assert.deepEqual(dirsRead, [
+      path.join(consumerRoot, '.agents', 'workflows'),
+      path.join(consumerRoot, '.claude', 'plugins', 'mandrel', 'commands'),
+    ]);
   });
 });
 


### PR DESCRIPTION
Closes #3588

_Auto-opened by `/single-story-deliver`._