### PR TITLE
fix(worktree): copy operator local-override files into isolated worktrees

### DIFF
--- a/.agents/scripts/lib/config/worktree-isolation.js
+++ b/.agents/scripts/lib/config/worktree-isolation.js
@@ -18,7 +18,21 @@ export const WORKTREE_ISOLATION_DEFAULTS = Object.freeze({
   allowSymlinkOnWindows: false,
   reapOnSuccess: true,
   reapOnCancel: true,
-  bootstrapFiles: Object.freeze(['.env', '.mcp.json']),
+  // Gitignored workspace files copied into each new worktree. Includes the
+  // operator's local-override files (`.agentrc.local.json`,
+  // `.agents/instructions.local.md`) so a worktree-isolated agent honors the
+  // §1.E local-override contract instead of silently falling back to the
+  // committed `.agentrc.json` placeholders — the gap that left
+  // `github.operatorHandle` unset inside worktrees and broke Story-lease
+  // release at close. Missing sources are skipped by the provisioner, so
+  // listing files that may be absent is safe. Keep in sync with
+  // `DEFAULT_WORKSPACE_FILES` in `../workspace-provisioner.js`.
+  bootstrapFiles: Object.freeze([
+    '.env',
+    '.mcp.json',
+    '.agentrc.local.json',
+    '.agents/instructions.local.md',
+  ]),
 });
 
 /**

--- a/.agents/scripts/lib/workspace-provisioner.js
+++ b/.agents/scripts/lib/workspace-provisioner.js
@@ -2,10 +2,15 @@
  * workspace-provisioner.js
  *
  * Central authority for populating a fresh worktree (or remote-runner checkout)
- * with gitignored workspace files — `.env` and `.mcp.json` by default, plus
- * any other files declared in `.agentrc.json orchestration.workspaceFiles`.
- * Every caller that needs these files in a non-main checkout should go
- * through this module; ad-hoc copy logic elsewhere in the codebase is a bug.
+ * with gitignored workspace files — by default `.env`, `.mcp.json`, and the
+ * operator's local-override files (`.agentrc.local.json`,
+ * `.agents/instructions.local.md`) — plus any other files declared in
+ * `.agentrc.json orchestration.workspaceFiles`. The local-override files are
+ * provisioned so a worktree-isolated agent honors the §1.E local-override
+ * contract (e.g. `github.operatorHandle`) rather than silently falling back to
+ * the committed `.agentrc.json` placeholders. Every caller that needs these
+ * files in a non-main checkout should go through this module; ad-hoc copy
+ * logic elsewhere in the codebase is a bug.
  *
  * Public API:
  *   - `provision({ sourceRoot, targetWorktree, files?, logger? })` — copies
@@ -17,14 +22,25 @@
  *   - `resolveWorkspaceFiles(orchestrationConfig)` — resolves the list honoring
  *     the new `orchestration.workspaceFiles` key, the legacy
  *     `orchestration.worktreeIsolation.bootstrapFiles`, and the default.
- *   - `DEFAULT_WORKSPACE_FILES` — `['.env', '.mcp.json']`.
+ *   - `DEFAULT_WORKSPACE_FILES` — `['.env', '.mcp.json', '.agentrc.local.json',
+ *     '.agents/instructions.local.md']`.
  */
 
 import fs from 'node:fs';
 import path from 'node:path';
 import { NOOP_LOGGER } from './Logger.js';
 
-export const DEFAULT_WORKSPACE_FILES = ['.env', '.mcp.json'];
+// Keep in sync with `WORKTREE_ISOLATION_DEFAULTS.bootstrapFiles` in
+// `./config/worktree-isolation.js`. The local-override files are listed even
+// though they are frequently absent — `provision()` skips missing sources and
+// `verify()` callers filter to files present at the source first, so a missing
+// override never fails a worktree create.
+export const DEFAULT_WORKSPACE_FILES = [
+  '.env',
+  '.mcp.json',
+  '.agentrc.local.json',
+  '.agents/instructions.local.md',
+];
 
 /**
  * Resolve the list of workspace files to provision.

--- a/tests/lib/workspace-provisioner-local-overrides.test.js
+++ b/tests/lib/workspace-provisioner-local-overrides.test.js
@@ -1,0 +1,94 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+import {
+  DEFAULT_WORKSPACE_FILES,
+  provision,
+} from '../../.agents/scripts/lib/workspace-provisioner.js';
+
+// Worktree-isolated delivery must inherit the operator's gitignored
+// local-override files so the config resolver sees the real
+// `github.operatorHandle` (and local instruction overrides) inside the
+// worktree, not the committed `.agentrc.json` `@[USERNAME]` placeholder. The
+// missing override previously broke single-story Story-lease release at close.
+
+function makeRoots() {
+  const src = fs.mkdtempSync(path.join(os.tmpdir(), 'wsp-lo-src-'));
+  const dst = fs.mkdtempSync(path.join(os.tmpdir(), 'wsp-lo-dst-'));
+  return { src, dst };
+}
+
+test('DEFAULT_WORKSPACE_FILES carries the local-override files', () => {
+  assert.deepEqual(DEFAULT_WORKSPACE_FILES, [
+    '.env',
+    '.mcp.json',
+    '.agentrc.local.json',
+    '.agents/instructions.local.md',
+  ]);
+});
+
+test('provision: copies the default workspace files into a fresh worktree', () => {
+  const { src, dst } = makeRoots();
+  fs.writeFileSync(path.join(src, '.env'), 'TOKEN=1\n');
+  fs.writeFileSync(path.join(src, '.mcp.json'), '{"mcpServers":{}}\n');
+
+  const result = provision({
+    sourceRoot: src,
+    targetWorktree: dst,
+    files: ['.env', '.mcp.json'],
+  });
+
+  assert.deepEqual(result.copied.sort(), ['.env', '.mcp.json']);
+  assert.equal(result.skipped.length, 0);
+  assert.equal(result.missing.length, 0);
+  assert.equal(fs.readFileSync(path.join(dst, '.env'), 'utf8'), 'TOKEN=1\n');
+  assert.equal(
+    fs.readFileSync(path.join(dst, '.mcp.json'), 'utf8'),
+    '{"mcpServers":{}}\n',
+  );
+});
+
+test('provision: copies local-override files into the worktree when present at source', () => {
+  const { src, dst } = makeRoots();
+  fs.writeFileSync(
+    path.join(src, '.agentrc.local.json'),
+    '{"github":{"operatorHandle":"@dsj1984"}}\n',
+  );
+  fs.mkdirSync(path.join(src, '.agents'), { recursive: true });
+  fs.writeFileSync(path.join(src, '.agents', 'instructions.local.md'), '# x\n');
+
+  const result = provision({
+    sourceRoot: src,
+    targetWorktree: dst,
+    files: DEFAULT_WORKSPACE_FILES,
+  });
+
+  assert.ok(result.copied.includes('.agentrc.local.json'));
+  assert.ok(
+    result.copied.includes(path.normalize('.agents/instructions.local.md')),
+  );
+  assert.equal(
+    fs.readFileSync(path.join(dst, '.agentrc.local.json'), 'utf8'),
+    '{"github":{"operatorHandle":"@dsj1984"}}\n',
+  );
+});
+
+test('provision: absent local-override files are reported missing, never fatal', () => {
+  const { src, dst } = makeRoots();
+  fs.writeFileSync(path.join(src, '.env'), 'TOKEN=1\n');
+
+  const result = provision({
+    sourceRoot: src,
+    targetWorktree: dst,
+    files: DEFAULT_WORKSPACE_FILES,
+  });
+
+  assert.deepEqual(result.copied, ['.env']);
+  assert.deepEqual(result.missing.sort(), [
+    '.agentrc.local.json',
+    path.normalize('.agents/instructions.local.md'),
+    '.mcp.json',
+  ]);
+});

--- a/tests/lib/workspace-provisioner.test.js
+++ b/tests/lib/workspace-provisioner.test.js
@@ -28,10 +28,6 @@ function quietLogger() {
   };
 }
 
-test('DEFAULT_WORKSPACE_FILES is [.env, .mcp.json]', () => {
-  assert.deepEqual(DEFAULT_WORKSPACE_FILES, ['.env', '.mcp.json']);
-});
-
 test('resolveWorkspaceFiles: prefers workspaceFiles', () => {
   const files = resolveWorkspaceFiles({
     workspaceFiles: ['.env', '.custom'],
@@ -50,28 +46,6 @@ test('resolveWorkspaceFiles: falls back to legacy bootstrapFiles', () => {
 test('resolveWorkspaceFiles: defaults when unset', () => {
   assert.deepEqual(resolveWorkspaceFiles(undefined), DEFAULT_WORKSPACE_FILES);
   assert.deepEqual(resolveWorkspaceFiles({}), DEFAULT_WORKSPACE_FILES);
-});
-
-test('provision: copies .env and .mcp.json into a fresh worktree by default', () => {
-  const { src, dst } = makeRoots();
-  fs.writeFileSync(path.join(src, '.env'), 'TOKEN=1\n');
-  fs.writeFileSync(path.join(src, '.mcp.json'), '{"mcpServers":{}}\n');
-  const { logger } = quietLogger();
-
-  const result = provision({
-    sourceRoot: src,
-    targetWorktree: dst,
-    logger,
-  });
-
-  assert.deepEqual(result.copied.sort(), ['.env', '.mcp.json']);
-  assert.equal(result.skipped.length, 0);
-  assert.equal(result.missing.length, 0);
-  assert.equal(fs.readFileSync(path.join(dst, '.env'), 'utf8'), 'TOKEN=1\n');
-  assert.equal(
-    fs.readFileSync(path.join(dst, '.mcp.json'), 'utf8'),
-    '{"mcpServers":{}}\n',
-  );
 });
 
 test('provision: preserves existing target files (no overwrite)', () => {


### PR DESCRIPTION
## Why

Worktree-isolated delivery (`single-story-init` / `epic-deliver-story`) copied only `.env` and `.mcp.json` into each new worktree, silently dropping the operator's gitignored **local-override** files:

- `.agentrc.local.json`
- `.agents/instructions.local.md`

Inside the worktree the config resolver then saw only the committed `.agentrc.json`, whose `github.operatorHandle` ships as the `@[USERNAME]` placeholder. That violates the `instructions.md` §1.E local-override contract.

**Concrete symptom (observed this session):** `single-story-close` for a standalone Story failed to release the Story lease —

> ⚠️ lease release failed (close continues): single-story lease: no operator identity is configured. `github.operatorHandle` is unset or still the shipped `@[USERNAME]` placeholder

— even though the main checkout had a real handle in `.agentrc.local.json`. The override simply never reached the worktree.

## What

- Add both local-override files to the default workspace/bootstrap lists, kept in sync:
  - `DEFAULT_WORKSPACE_FILES` in `lib/workspace-provisioner.js`
  - `WORKTREE_ISOLATION_DEFAULTS.bootstrapFiles` in `lib/config/worktree-isolation.js`
- `provision()` skips missing sources and `verify()` callers filter to files present at the source first, so listing a frequently-absent override **never fails a worktree create**.

## Tests

- New `tests/lib/workspace-provisioner-local-overrides.test.js`: default list carries the overrides; overrides copied when present; absent overrides reported `missing`, not fatal.
- Existing provisioner suite trimmed (the default-list assertions moved to the new file).

Surfaced while delivering #3588. This is a framework-gap fix (`meta::framework-gap`).