### PR TITLE
fix(quality): preview gate honors the configured maintainability tolerance

### DIFF
--- a/.agents/scripts/lib/baselines/preview-gates.js
+++ b/.agents/scripts/lib/baselines/preview-gates.js
@@ -42,6 +42,35 @@ import {
 } from './kinds/maintainability.js';
 
 /**
+ * Framework default MI preview tolerance, used only when neither an explicit
+ * override nor a configured `quality.maintainability.tolerance` is present.
+ * Mirrors the historical preview default.
+ */
+export const MI_PREVIEW_DEFAULT_TOLERANCE = 0.5;
+
+/**
+ * Resolve the effective maintainability tolerance for the preview gate so it
+ * agrees with the authoritative `check-baselines` gate. Precedence: an explicit
+ * caller override → the configured `quality.maintainability.tolerance` (already
+ * resolved to a scalar by `getQuality`) → the framework default. Previously the
+ * preview hardcoded the default and ignored the configured value, so a project
+ * that raised its tolerance (e.g. to 12) still saw the local pre-commit/pre-push
+ * gate flag sub-tolerance drops that `check-baselines` accepted.
+ *
+ * @param {{ explicit?: number | null, configured?: number, fallback?: number }} opts
+ * @returns {number}
+ */
+export function resolvePreviewTolerance({
+  explicit = null,
+  configured,
+  fallback = MI_PREVIEW_DEFAULT_TOLERANCE,
+} = {}) {
+  if (Number.isFinite(explicit)) return explicit;
+  if (Number.isFinite(configured)) return configured;
+  return fallback;
+}
+
+/**
  * Pure: replicate the legacy `check-maintainability.js compareScores`
  * behavior so the preview runner can build the stats block the report
  * builder expects.
@@ -130,7 +159,7 @@ export async function runMaintainabilityPreview({
   cwd = process.cwd(),
   changedSinceRef = null,
   staged = false,
-  tolerance = 0.5,
+  tolerance = null,
 } = {}) {
   const config = resolveConfig({ cwd });
   const baselinePath = getBaselines(config).maintainability.path;
@@ -142,6 +171,10 @@ export async function runMaintainabilityPreview({
   });
 
   const miQuality = getQuality(config).maintainability;
+  const effectiveTolerance = resolvePreviewTolerance({
+    explicit: tolerance,
+    configured: miQuality.tolerance,
+  });
   const targetDirs = miQuality.targetDirs;
   const ignoreGlobs = miQuality.ignoreGlobs ?? [];
   const files = [];
@@ -170,7 +203,7 @@ export async function runMaintainabilityPreview({
     const posixRel = rel.split(path.sep).join('/');
     if (!MAINTAINABILITY_EXCLUSIONS.has(posixRel)) scores[key] = mi;
   }
-  const stats = compareScores(scores, scopedBaseline, tolerance);
+  const stats = compareScores(scores, scopedBaseline, effectiveTolerance);
   const envelope = buildMaintainabilityReport(scores, stats, {
     scope,
     diffRef,

--- a/tests/lib/baselines/preview-tolerance.test.js
+++ b/tests/lib/baselines/preview-tolerance.test.js
@@ -1,0 +1,41 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  MI_PREVIEW_DEFAULT_TOLERANCE,
+  resolvePreviewTolerance,
+} from '../../../.agents/scripts/lib/baselines/preview-gates.js';
+
+// The preview gate must use the SAME maintainability tolerance the
+// authoritative `check-baselines` gate uses (the resolved
+// `quality.maintainability.tolerance` scalar). Previously the preview ignored
+// it and hardcoded the default, so a project that raised its tolerance still
+// saw the local pre-commit/pre-push gate flag sub-tolerance drops that CI
+// accepted.
+
+test('resolvePreviewTolerance: prefers an explicit override', () => {
+  assert.equal(resolvePreviewTolerance({ explicit: 3, configured: 12 }), 3);
+});
+
+test('resolvePreviewTolerance: falls back to the configured tolerance', () => {
+  // The case this fix exists for: configured 12 must win over the default.
+  assert.equal(resolvePreviewTolerance({ explicit: null, configured: 12 }), 12);
+  assert.equal(resolvePreviewTolerance({ configured: 12 }), 12);
+});
+
+test('resolvePreviewTolerance: uses the framework default when nothing is set', () => {
+  assert.equal(resolvePreviewTolerance({}), MI_PREVIEW_DEFAULT_TOLERANCE);
+  assert.equal(
+    resolvePreviewTolerance({ explicit: null, configured: undefined }),
+    MI_PREVIEW_DEFAULT_TOLERANCE,
+  );
+});
+
+test('resolvePreviewTolerance: ignores non-finite or negative-sentinel inputs', () => {
+  assert.equal(
+    resolvePreviewTolerance({ explicit: Number.NaN, configured: 12 }),
+    12,
+  );
+  // A configured 0 is a valid, intentional zero-tolerance setting.
+  assert.equal(resolvePreviewTolerance({ configured: 0 }), 0);
+});


### PR DESCRIPTION
## Why

The local maintainability **preview** gate (`quality-preview --staged` in `.husky/pre-commit`, `--changed-since` in `.husky/pre-push`) hardcoded `tolerance = 0.5` and ignored the already-resolved `quality.maintainability.tolerance`. The authoritative `check-baselines` gate (CI) uses the configured value, so a project that raised its tolerance — this repo: `{ kind: 'absolute', value: 12 }` — had the local hook flag sub-tolerance MI drops that CI accepted.

Symptom (hit repeatedly this session): legitimate changes that pass `check-baselines` (and `quality-preview --changed-since origin/main` → 0 regressions) were blocked at commit/push by the stricter `--staged` preview, e.g. `tests/...: MI delta -10.99` on a change well within the configured ±12.

## What

- `runMaintainabilityPreview` resolves the effective tolerance via a new pure `resolvePreviewTolerance()` helper: **explicit override → configured scalar (`getQuality(config).maintainability.tolerance`) → framework default (0.5)**. The local preview now agrees with `check-baselines`.
- Unit tests for the resolver (override / configured / default / zero-tolerance / non-finite).

## Verification

Self-consistent: this change's own diff to `preview-gates.js` reports **0 regressions under the fixed gate** — it would have tripped the old hardcoded 0.5 default. Both pre-commit and pre-push hooks passed on this very commit.

Surfaced while delivering #3588. Unblocks landing other in-flight fixes (frontmatter/plugin work) under the project's actual configured tolerance.