### PR TITLE
feat(finalize): embed a run-trace digest in the epic-handoff comment (#3669)

### DIFF
--- a/.agents/scripts/lib/orchestration/finalize/post-handoff-comment.js
+++ b/.agents/scripts/lib/orchestration/finalize/post-handoff-comment.js
@@ -18,11 +18,25 @@
 
 import fs from 'node:fs/promises';
 import path from 'node:path';
-import { epicPerfReportJsonPath } from '../../config/temp-paths.js';
+import {
+  epicLedgerPath,
+  epicPerfReportJsonPath,
+} from '../../config/temp-paths.js';
 import { Logger } from '../../Logger.js';
+import { render as renderLifecycleTrace } from '../lifecycle/trace-logger.js';
 import { upsertStructuredComment as defaultUpsertStructuredComment } from '../ticketing.js';
 
 export const EPIC_HANDOFF_MARKER = 'epic-handoff';
+
+/**
+ * Byte budget for the embedded run-trace digest. The digest is the
+ * `TraceLogger` Summary block only (phase list + per-phase durations +
+ * event/completed/failed counts), so it is small by construction — but we
+ * cap it well under GitHub's ~64KB comment limit so a pathological ledger
+ * with a huge phase list still degrades to a truncated note + the
+ * relative-path link rather than blowing the comment budget. Story #3669.
+ */
+export const RUN_TRACE_MAX_BYTES = 8000;
 
 /**
  * Format a millisecond duration as a compact wall-clock string for the
@@ -91,6 +105,176 @@ export function renderPerfReportSection(perfReport) {
 }
 
 /**
+ * Slice the `## Summary` block out of the full `lifecycle.md` projection.
+ * The TraceLogger `render()` output ends with a `## Summary` section (phase
+ * list, per-phase durations, event/completed/failed counts); everything
+ * before it is the per-event trace, which the Story explicitly excludes
+ * from the embedded digest. Returns the Summary body (the lines *after* the
+ * `## Summary` heading, trimmed) or `''` when no Summary heading is present.
+ *
+ * @param {string} fullMarkdown
+ * @returns {string}
+ */
+function summaryBlockFrom(fullMarkdown) {
+  const marker = '## Summary';
+  const idx = fullMarkdown.indexOf(marker);
+  if (idx < 0) return '';
+  return fullMarkdown.slice(idx + marker.length).trim();
+}
+
+/**
+ * Project the canonical lifecycle ledger NDJSON into the compact run-trace
+ * digest embedded in the handoff comment. Reuses the pure `TraceLogger`
+ * `render()` projection and keeps only its Summary rollup — never the full
+ * per-event trace (Story #3669 acceptance).
+ *
+ * Pure + read-only: it parses the supplied ledger text and never touches
+ * the filesystem or mutates the ledger. Returns `null` on:
+ *   - a missing / empty ledger (no emitted records → empty Summary), or
+ *   - a malformed ledger (the underlying `render` throws on bad JSON; we
+ *     swallow it so the section degrades gracefully instead of blocking
+ *     the PR open).
+ *
+ * When the projected Summary exceeds `maxBytes`, the digest is truncated on
+ * a UTF-8-safe boundary and `truncated: true` is set so the renderer can
+ * append a note and keep the relative-path link to the full `lifecycle.md`.
+ *
+ * @param {{
+ *   ledgerText: string,
+ *   epicId: number,
+ *   relativePath: string,
+ *   maxBytes?: number,
+ * }} args
+ * @returns {{ digest: string, relativePath: string, truncated: boolean } | null}
+ */
+export function extractRunTraceDigest({
+  ledgerText,
+  epicId,
+  relativePath,
+  maxBytes = RUN_TRACE_MAX_BYTES,
+} = {}) {
+  if (typeof ledgerText !== 'string' || ledgerText.trim().length === 0) {
+    return null;
+  }
+  let fullMarkdown;
+  try {
+    fullMarkdown = renderLifecycleTrace(ledgerText, { epicId });
+  } catch {
+    // Malformed ledger (parseLedger throws on bad JSON). Degrade to no
+    // section rather than propagating and blocking the handoff comment.
+    return null;
+  }
+  const summary = summaryBlockFrom(fullMarkdown);
+  if (summary.length === 0) return null;
+
+  const budget =
+    Number.isInteger(maxBytes) && maxBytes > 0 ? maxBytes : RUN_TRACE_MAX_BYTES;
+  if (Buffer.byteLength(summary, 'utf8') <= budget) {
+    return { digest: summary, relativePath, truncated: false };
+  }
+  // Truncate on a UTF-8-safe boundary: take a byte slice, then drop any
+  // trailing partial multibyte sequence by decoding with replacement and
+  // stripping the U+FFFD tail.
+  const sliced = Buffer.from(summary, 'utf8')
+    .subarray(0, budget)
+    .toString('utf8')
+    .replace(/�+$/u, '');
+  return { digest: sliced, relativePath, truncated: true };
+}
+
+/**
+ * Render the "Run trace" digest section appended to the `epic-handoff`
+ * comment. Returns `''` when `runTrace` is null / malformed so callers can
+ * splice the result in unconditionally — mirrors `renderPerfReportSection`.
+ *
+ * Output contract (Story #3669):
+ *   - `## Run trace` heading
+ *   - One relative link line to `temp/epic-<id>/lifecycle.md`
+ *   - The TraceLogger Summary rollup (phase durations + counts)
+ *   - A truncation note when the projection overflowed the byte budget
+ *
+ * @param {{ digest: string, relativePath: string, truncated?: boolean } | null | undefined} runTrace
+ * @returns {string}
+ */
+export function renderRunTraceSection(runTrace) {
+  if (
+    !runTrace ||
+    typeof runTrace.digest !== 'string' ||
+    runTrace.digest.length === 0 ||
+    typeof runTrace.relativePath !== 'string'
+  ) {
+    return '';
+  }
+  const lines = [];
+  lines.push('');
+  lines.push('## Run trace');
+  lines.push('');
+  lines.push(
+    `Full lifecycle companion: [\`${runTrace.relativePath}\`](${runTrace.relativePath}).`,
+  );
+  lines.push('');
+  lines.push(runTrace.digest);
+  if (runTrace.truncated) {
+    lines.push('');
+    lines.push(
+      `_Digest truncated to fit the comment budget — see [\`${runTrace.relativePath}\`](${runTrace.relativePath}) for the full trace._`,
+    );
+  }
+  return lines.join('\n');
+}
+
+/**
+ * Default loader: read the canonical `temp/epic-<id>/lifecycle.ndjson`
+ * ledger from disk and project it into the run-trace digest envelope
+ * `renderRunTraceSection` expects. Returns `null` on any failure (missing
+ * file, malformed JSON, empty ledger) so the handoff comment degrades
+ * gracefully — mirrors `loadPerfReportFromDisk`.
+ *
+ * `relativePath` points at the rendered `lifecycle.md` companion (the same
+ * directory as the ledger), computed relative to `cwd` so consumers can
+ * follow the link from the rendered comment. Falls back to the absolute
+ * path when the companion resolves outside `cwd`.
+ *
+ * @param {{ epicId: number, config?: object, cwd?: string }} args
+ * @returns {Promise<{ digest: string, relativePath: string, truncated: boolean } | null>}
+ */
+export async function loadRunTraceFromDisk({
+  epicId,
+  config,
+  cwd = process.cwd(),
+} = {}) {
+  if (!Number.isInteger(epicId) || epicId < 1) return null;
+  let ledgerAbsPath;
+  try {
+    ledgerAbsPath = epicLedgerPath(epicId, config);
+  } catch {
+    return null;
+  }
+  let ledgerText;
+  try {
+    ledgerText = await fs.readFile(ledgerAbsPath, 'utf8');
+  } catch {
+    return null;
+  }
+  const companionAbsPath = path.join(
+    path.dirname(ledgerAbsPath),
+    'lifecycle.md',
+  );
+  let relativePath;
+  try {
+    const rel = path.relative(cwd, companionAbsPath);
+    relativePath =
+      rel && !rel.startsWith('..') && !path.isAbsolute(rel)
+        ? rel
+        : companionAbsPath;
+    relativePath = relativePath.split(path.sep).join('/');
+  } catch {
+    relativePath = companionAbsPath;
+  }
+  return extractRunTraceDigest({ ledgerText, epicId, relativePath });
+}
+
+/**
  * Render the `epic-handoff` comment body. Pure helper — exported so the
  * contract tests can assert the rendered shape without standing up a
  * provider.
@@ -104,6 +288,7 @@ export function renderHandoffBody({
   prNumber,
   prUrl = null,
   perfReport = null,
+  runTrace = null,
 } = {}) {
   const lines = [];
   lines.push('### 🤝 Epic handoff — PR opened');
@@ -125,6 +310,14 @@ export function renderHandoffBody({
   const perfSection = renderPerfReportSection(perfReport);
   if (perfSection.length > 0) {
     lines.push(perfSection);
+  }
+  // Story #3669 — Run trace digest section. Empty string is returned when
+  // no ledger digest is available (missing/malformed ledger → section
+  // omitted), so the body shape is preserved for handoffs that fire before
+  // a ledger exists.
+  const runTraceSection = renderRunTraceSection(runTrace);
+  if (runTraceSection.length > 0) {
+    lines.push(runTraceSection);
   }
   lines.push('');
   lines.push('```json');
@@ -221,7 +414,9 @@ export async function postHandoffComment({
   config,
   cwd,
   perfReport,
+  runTrace,
   loadPerfReportFn = loadPerfReportFromDisk,
+  loadRunTraceFn = loadRunTraceFromDisk,
   upsertStructuredCommentFn = defaultUpsertStructuredComment,
   logger = Logger,
 } = {}) {
@@ -253,11 +448,27 @@ export async function postHandoffComment({
       resolvedPerfReport = null;
     }
   }
+  // Story #3669 — if an explicit `runTrace` envelope is not supplied, fall
+  // back to projecting the canonical lifecycle ledger from disk. Any loader
+  // failure resolves to `null` and the Run trace section is silently
+  // omitted, never blocking the handoff comment / PR open.
+  let resolvedRunTrace = runTrace;
+  if (resolvedRunTrace === undefined) {
+    try {
+      resolvedRunTrace = await loadRunTraceFn({ epicId, config, cwd });
+    } catch (err) {
+      logger.warn?.(
+        `[finalize/post-handoff-comment] run-trace load failed for Epic #${epicId} (non-fatal): ${err?.message ?? err}`,
+      );
+      resolvedRunTrace = null;
+    }
+  }
   const body = renderHandoffBody({
     epicId,
     prNumber,
     prUrl: prUrl ?? null,
     perfReport: resolvedPerfReport,
+    runTrace: resolvedRunTrace,
   });
   try {
     const result = await upsertStructuredCommentFn(

--- a/tests/contract/finalize/post-handoff-comment.test.js
+++ b/tests/contract/finalize/post-handoff-comment.test.js
@@ -19,16 +19,59 @@
  */
 
 import { strict as assert } from 'node:assert';
+import fsp from 'node:fs/promises';
+import os from 'node:os';
+import nodePath from 'node:path';
 import { describe, it } from 'node:test';
 
 import {
   EPIC_HANDOFF_MARKER,
+  extractRunTraceDigest,
+  loadRunTraceFromDisk,
   postHandoffComment,
   renderHandoffBody,
+  renderRunTraceSection,
 } from '../../../.agents/scripts/lib/orchestration/finalize/post-handoff-comment.js';
 
 function quietLogger() {
   return { info: () => {}, warn: () => {}, debug: () => {} };
+}
+
+/**
+ * Build a small, valid NDJSON ledger string with two phases so the
+ * TraceLogger Summary projection has phase durations to roll up and one
+ * failed terminal to exercise the failed-count line.
+ */
+function sampleLedger() {
+  const recs = [
+    {
+      kind: 'emitted',
+      seqId: 1,
+      event: 'epic.snapshot.start',
+      ts: '2026-06-05T10:00:00.000Z',
+      payload: { epicId: 42 },
+    },
+    {
+      kind: 'completed',
+      seqId: 1,
+      event: 'epic.snapshot.start',
+      ts: '2026-06-05T10:00:02.000Z',
+    },
+    {
+      kind: 'emitted',
+      seqId: 2,
+      event: 'wave.start',
+      ts: '2026-06-05T10:00:05.000Z',
+      payload: { waveIndex: 0 },
+    },
+    {
+      kind: 'failed',
+      seqId: 2,
+      event: 'wave.start',
+      ts: '2026-06-05T10:00:09.000Z',
+    },
+  ];
+  return `${recs.map((r) => JSON.stringify(r)).join('\n')}\n`;
 }
 
 describe('renderHandoffBody', () => {
@@ -50,6 +93,168 @@ describe('renderHandoffBody', () => {
     const body = renderHandoffBody({ epicId: 1, prNumber: 7 });
     assert.match(body, /Pull request: #7$/m);
     assert.doesNotMatch(body, /\(http/);
+  });
+
+  it('embeds the Run trace digest section when a runTrace envelope is supplied', () => {
+    const runTrace = renderRunTraceSection({
+      digest: '- Events: 2\n- Completed: 1\n- Failed: 1',
+      relativePath: 'temp/epic-42/lifecycle.md',
+      truncated: false,
+    });
+    const body = renderHandoffBody({
+      epicId: 42,
+      prNumber: 9,
+      runTrace: {
+        digest: '- Events: 2\n- Completed: 1\n- Failed: 1',
+        relativePath: 'temp/epic-42/lifecycle.md',
+        truncated: false,
+      },
+    });
+    assert.ok(runTrace.length > 0);
+    assert.match(body, /## Run trace/);
+    assert.match(body, /- Events: 2/);
+    assert.match(body, /- Failed: 1/);
+  });
+
+  it('omits the Run trace section when no runTrace envelope is supplied', () => {
+    const body = renderHandoffBody({ epicId: 42, prNumber: 9 });
+    assert.doesNotMatch(body, /## Run trace/);
+  });
+});
+
+describe('renderRunTraceSection', () => {
+  it('returns empty string for null / malformed envelope', () => {
+    assert.equal(renderRunTraceSection(null), '');
+    assert.equal(renderRunTraceSection(undefined), '');
+    assert.equal(renderRunTraceSection({}), '');
+    assert.equal(renderRunTraceSection({ digest: 42 }), '');
+  });
+
+  it('renders the heading, the digest body, and the lifecycle.md link', () => {
+    const section = renderRunTraceSection({
+      digest: '- Events: 5\n- Completed: 4\n- Failed: 1',
+      relativePath: 'temp/epic-7/lifecycle.md',
+      truncated: false,
+    });
+    assert.match(section, /## Run trace/);
+    assert.match(section, /- Events: 5/);
+    assert.match(
+      section,
+      /\[`temp\/epic-7\/lifecycle\.md`\]\(temp\/epic-7\/lifecycle\.md\)/,
+    );
+    assert.doesNotMatch(section, /truncated/i);
+  });
+
+  it('emits a truncation note when truncated is true', () => {
+    const section = renderRunTraceSection({
+      digest: '- Events: 9999',
+      relativePath: 'temp/epic-7/lifecycle.md',
+      truncated: true,
+    });
+    assert.match(section, /truncated/i);
+    // The relative-path link to the full lifecycle.md is retained.
+    assert.match(section, /lifecycle\.md/);
+  });
+});
+
+describe('extractRunTraceDigest', () => {
+  it('projects the Summary block from a valid ledger string', () => {
+    const out = extractRunTraceDigest({
+      ledgerText: sampleLedger(),
+      epicId: 42,
+      relativePath: 'temp/epic-42/lifecycle.md',
+    });
+    assert.ok(out, 'expected a digest envelope');
+    assert.equal(out.truncated, false);
+    assert.equal(out.relativePath, 'temp/epic-42/lifecycle.md');
+    // The digest carries the Summary rollup, not the per-event trace.
+    assert.match(out.digest, /Events: 2/);
+    assert.match(out.digest, /Completed: 1/);
+    assert.match(out.digest, /Failed: 1/);
+    assert.match(out.digest, /Phase durations:/);
+    // The full per-event trace lines (HH:MM:SS event.name) are NOT carried.
+    assert.doesNotMatch(out.digest, /epic\.snapshot\.start/);
+  });
+
+  it('returns null for an empty ledger (no emitted records)', () => {
+    assert.equal(
+      extractRunTraceDigest({
+        ledgerText: '',
+        epicId: 1,
+        relativePath: 'temp/epic-1/lifecycle.md',
+      }),
+      null,
+    );
+  });
+
+  it('returns null for a malformed ledger rather than throwing', () => {
+    assert.equal(
+      extractRunTraceDigest({
+        ledgerText: '{not json}\n',
+        epicId: 1,
+        relativePath: 'temp/epic-1/lifecycle.md',
+      }),
+      null,
+    );
+  });
+
+  it('truncates and flags when the projected digest exceeds the byte budget', () => {
+    const out = extractRunTraceDigest({
+      ledgerText: sampleLedger(),
+      epicId: 42,
+      relativePath: 'temp/epic-42/lifecycle.md',
+      maxBytes: 20,
+    });
+    assert.ok(out);
+    assert.equal(out.truncated, true);
+    assert.ok(
+      Buffer.byteLength(out.digest, 'utf8') <= 20,
+      'truncated digest must fit the byte budget',
+    );
+  });
+});
+
+describe('loadRunTraceFromDisk', () => {
+  it('returns null when the ledger file is absent', async () => {
+    const dir = await fsp.mkdtemp(nodePath.join(os.tmpdir(), 'runtrace-'));
+    try {
+      const out = await loadRunTraceFromDisk({
+        epicId: 999999,
+        config: { project: { paths: { tempRoot: dir } } },
+        cwd: dir,
+      });
+      assert.equal(out, null);
+    } finally {
+      await fsp.rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('returns null for a non-positive epicId', async () => {
+    assert.equal(await loadRunTraceFromDisk({ epicId: 0 }), null);
+    assert.equal(await loadRunTraceFromDisk({ epicId: -1 }), null);
+  });
+
+  it('projects the digest from an on-disk ledger', async () => {
+    const dir = await fsp.mkdtemp(nodePath.join(os.tmpdir(), 'runtrace-'));
+    try {
+      const epicDir = nodePath.join(dir, 'epic-77');
+      await fsp.mkdir(epicDir, { recursive: true });
+      await fsp.writeFile(
+        nodePath.join(epicDir, 'lifecycle.ndjson'),
+        sampleLedger(),
+        'utf8',
+      );
+      const out = await loadRunTraceFromDisk({
+        epicId: 77,
+        config: { project: { paths: { tempRoot: dir } } },
+        cwd: dir,
+      });
+      assert.ok(out, 'expected a digest envelope');
+      assert.match(out.digest, /Events: 2/);
+      assert.equal(out.relativePath, 'epic-77/lifecycle.md');
+    } finally {
+      await fsp.rm(dir, { recursive: true, force: true });
+    }
   });
 });
 


### PR DESCRIPTION
Closes #3669

_Auto-opened by `/single-story-deliver`._