### PR TITLE
MODULE_TYPELESS_PACKAGE_JSON warning when running bundled .agents/scripts in consumers (no ESM boundary in materialized tree) (#3589)

### DIFF
--- a/.agents/scripts/package.json
+++ b/.agents/scripts/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}


### PR DESCRIPTION
Closes #3589

_Auto-opened by `/single-story-deliver`._