### PR TITLE
fix(story-close): cd-out guard false-negatives on symlinked paths (macOS) — realpath both sides before comparing (#3672)

### DIFF
--- a/.agents/scripts/lib/orchestration/story-close/cd-out-guard.js
+++ b/.agents/scripts/lib/orchestration/story-close/cd-out-guard.js
@@ -14,11 +14,41 @@
  * `workCwd` to the main repo, so the equality check is a tautology there
  * and we don't reject those.
  *
+ * Both operands are canonicalized through `fs.realpathSync` before the
+ * equality check (Story #3672). `path.resolve` normalizes `.`/`..` and makes
+ * a path absolute but does NOT resolve symlinks, while `process.cwd()` is
+ * returned fully canonicalized by the OS. On hosts where the working path
+ * contains a symlinked component — most notably macOS, where `/tmp` →
+ * `/private/tmp` and `/var` → `/private/var` — the two strings would never
+ * match, so the guard silently no-opped and failed to fire. Realpath'ing
+ * both sides closes that false-negative.
+ *
  * Pure: takes inputs, returns a verdict. Exported so the rejection path is
- * unit-testable without spawning the script.
+ * unit-testable without spawning the script. The `realpath` seam is injected
+ * (default `fs.realpathSync`) so tests can drive the symlinked and
+ * non-symlinked cases without touching the filesystem.
  */
 
+import fs from 'node:fs';
 import path from 'node:path';
+
+/**
+ * Canonicalize a path: resolve symlinks via `realpath`, falling back to
+ * `path.resolve` when the path does not exist yet (`realpathSync` throws on
+ * missing paths). The fallback keeps the comparison correct for
+ * not-yet-created worktree directories.
+ *
+ * @param {string} p
+ * @param {(p: string) => string} realpath
+ * @returns {string}
+ */
+function canonical(p, realpath) {
+  try {
+    return realpath(p);
+  } catch {
+    return path.resolve(p);
+  }
+}
 
 /**
  * @param {object} opts
@@ -27,6 +57,7 @@ import path from 'node:path';
  * @param {number|string} opts.storyId
  * @param {string} [opts.worktreeRoot]     `delivery.worktreeIsolation.root` (defaults to `.worktrees`).
  * @param {string} [opts.currentCwd]       Defaults to `process.cwd()`.
+ * @param {(p: string) => string} [opts.realpath]  Symlink-resolution seam (defaults to `fs.realpathSync`).
  * @returns {{ ok: true } | { ok: false, message: string }}
  */
 export function checkCdOutGuard({
@@ -35,10 +66,14 @@ export function checkCdOutGuard({
   storyId,
   worktreeRoot = '.worktrees',
   currentCwd = process.cwd(),
+  realpath = fs.realpathSync,
 }) {
   if (!cwdExplicit) return { ok: true };
-  const workCwd = path.resolve(mainCwd, worktreeRoot, `story-${storyId}`);
-  const cwd = path.resolve(currentCwd);
+  const workCwd = canonical(
+    path.resolve(mainCwd, worktreeRoot, `story-${storyId}`),
+    realpath,
+  );
+  const cwd = canonical(currentCwd, realpath);
   if (cwd !== workCwd) return { ok: true };
   return {
     ok: false,

--- a/tests/story-close-cd-out-guard.test.js
+++ b/tests/story-close-cd-out-guard.test.js
@@ -131,6 +131,80 @@ test('checkCdOutGuard pure helper', async (t) => {
     assert.equal(result.ok, false);
     assert.match(result.message, /story-42/);
   });
+
+  await t.test(
+    'fires when currentCwd and mainCwd differ only by a symlinked prefix (Story #3672)',
+    () => {
+      // Regression for the macOS false-negative: the derived `workCwd`
+      // (built from the verbatim `--cwd` arg via path.resolve, symlinks NOT
+      // resolved) and `process.cwd()` (OS-canonicalized) point at the same
+      // worktree but carry different string prefixes (`/tmp` vs
+      // `/private/tmp`). Inject a realpath seam that canonicalizes both
+      // operands to one fixed string per story segment, proving the guard
+      // realpath's BOTH sides before comparing — platform-independently
+      // (the seam keys off the trailing `story-<id>` segment, so it does not
+      // care whether the host's path.resolve produced POSIX or Windows
+      // separators on the way in).
+      const realpath = (p) =>
+        /story-746$/.test(p) ? '/private/tmp/repo/.worktrees/story-746' : p;
+      const result = checkCdOutGuard({
+        cwdExplicit: true,
+        mainCwd: '/tmp/repo',
+        storyId: 746,
+        currentCwd: '/private/tmp/repo/.worktrees/story-746',
+        realpath,
+      });
+      assert.equal(result.ok, false);
+      assert.match(result.message, /Refusing to close/);
+      assert.match(result.message, /story-746/);
+    },
+  );
+
+  await t.test(
+    'stays ok for a sibling worktree even after symlink canonicalization (Story #3672)',
+    () => {
+      // The canonicalized worktree prefix matches, but the story segment
+      // differs — the guard must still let a sibling worktree through.
+      // Canonicalize the two distinct story segments to two distinct strings.
+      const realpath = (p) => {
+        if (/story-746$/.test(p))
+          return '/private/tmp/repo/.worktrees/story-746';
+        if (/story-999$/.test(p))
+          return '/private/tmp/repo/.worktrees/story-999';
+        return p;
+      };
+      const result = checkCdOutGuard({
+        cwdExplicit: true,
+        mainCwd: '/tmp/repo',
+        storyId: 746,
+        currentCwd: '/private/tmp/repo/.worktrees/story-999',
+        realpath,
+      });
+      assert.deepStrictEqual(result, { ok: true });
+    },
+  );
+
+  await t.test(
+    'falls back to path.resolve when realpath throws on a missing path (Story #3672)',
+    () => {
+      // realpathSync throws on not-yet-existing paths; the guard must fall
+      // back to path.resolve so a worktree dir that does not exist yet still
+      // compares correctly. Both operands resolve to the same worktree, so
+      // the fallback must still produce matching strings and the guard fires.
+      const realpath = () => {
+        throw new Error('ENOENT');
+      };
+      const result = checkCdOutGuard({
+        cwdExplicit: true,
+        mainCwd: '/repo',
+        storyId: 746,
+        currentCwd: '/repo/.worktrees/story-746',
+        realpath,
+      });
+      assert.equal(result.ok, false);
+      assert.match(result.message, /Refusing to close/);
+    },
+  );
 });
 
 test('story-close cd-out guard (subprocess)', async (t) => {


### PR DESCRIPTION
Closes #3672

_Auto-opened by `/single-story-deliver`._