### PR TITLE
story-close baseline refresh silently drops a change set's own new files from quality baselines (#3682)

### DIFF
--- a/.agents/scripts/lib/baselines/refresh-service.js
+++ b/.agents/scripts/lib/baselines/refresh-service.js
@@ -52,6 +52,8 @@
  *     cwd,         // working directory for git diff; default process.cwd()
  *     generatedAt, // optional pinned timestamp (test determinism); falls
  *                  // back to MANDREL_BASELINE_GENERATED_AT, then now().
+ *     requireRowsForScopeFiles, // optional fail-loud guard for Story-close
+ *     requiredScopeFilePredicate, // optional predicate to narrow guarded files
  *   }) -> Promise<{
  *     kind, writePath, scope: { mode, ref?, files: string[] },
  *     envelope, wrote: boolean
@@ -304,6 +306,8 @@ const KIND_SCORERS = Object.freeze({
  *   gitDiff?: (args: { baseRef: string, headRef: string, cwd: string }) => Iterable<string> | Promise<Iterable<string>>,
  *   cwd?: string,
  *   generatedAt?: string,
+ *   requireRowsForScopeFiles?: boolean,
+ *   requiredScopeFilePredicate?: (file: string) => boolean,
  * }} opts
  * @returns {Promise<{
  *   kind: string,
@@ -327,6 +331,8 @@ export async function refreshBaseline(opts = {}) {
     gitDiff = defaultGitDiff,
     cwd = process.cwd(),
     generatedAt,
+    requireRowsForScopeFiles = false,
+    requiredScopeFilePredicate,
   } = opts;
 
   validateOptions({ kind, scopeFiles, fullScope, writePath });
@@ -379,6 +385,14 @@ export async function refreshBaseline(opts = {}) {
     path: canonicalizeBaselinePath(row.path ?? row.file),
   }));
 
+  assertRequiredScopeRows({
+    kind,
+    scope,
+    canonicalRows,
+    requireRowsForScopeFiles,
+    requiredScopeFilePredicate,
+  });
+
   // Read the prior envelope so out-of-scope rows survive (Task #2209) and
   // the structural-equality short-circuit can fire.
   const priorEnvelope = readPriorEnvelope(writePath, fs);
@@ -419,6 +433,35 @@ export async function refreshBaseline(opts = {}) {
     envelope,
     wrote,
   };
+}
+
+function assertRequiredScopeRows({
+  kind,
+  scope,
+  canonicalRows,
+  requireRowsForScopeFiles,
+  requiredScopeFilePredicate,
+}) {
+  if (!requireRowsForScopeFiles || scope.mode === 'full') return;
+  const predicate =
+    typeof requiredScopeFilePredicate === 'function'
+      ? requiredScopeFilePredicate
+      : () => true;
+  const requiredFiles = scope.files.filter(predicate);
+  if (requiredFiles.length === 0) return;
+
+  const rowPaths = new Set(
+    canonicalRows
+      .map((row) => row?.path)
+      .filter((rowPath) => typeof rowPath === 'string' && rowPath.length > 0),
+  );
+  const missing = requiredFiles.filter((file) => !rowPaths.has(file));
+  if (missing.length === 0) return;
+
+  throw new Error(
+    `refreshBaseline(${kind}): scoped file(s) produced no baseline rows: ${missing.join(', ')}. ` +
+      'Run coverage/scoring for the changed files or use full-scope refresh; refusing to write a baseline that would silently drop Story-owned files.',
+  );
 }
 
 /**

--- a/.agents/scripts/lib/orchestration/story-close/auto-refresh-runner.js
+++ b/.agents/scripts/lib/orchestration/story-close/auto-refresh-runner.js
@@ -142,6 +142,25 @@ function filterToStoryDiff({ miRows, crapRows, storyDiffPaths }) {
   return { mi, crap };
 }
 
+function normalizeTargetDir(dir) {
+  if (typeof dir !== 'string' || dir.length === 0) return null;
+  return dir.replace(/\\/g, '/').replace(/^\.\//, '').replace(/\/+$/, '');
+}
+
+function buildRequiredScopeFilePredicate({
+  kind,
+  config,
+  getQuality = defaultGetQuality,
+}) {
+  const quality = getQuality(config) ?? {};
+  const targetDirs = Array.isArray(quality?.[kind]?.targetDirs)
+    ? quality[kind].targetDirs.map(normalizeTargetDir).filter(Boolean)
+    : [];
+  if (targetDirs.length === 0) return () => true;
+  return (file) =>
+    targetDirs.some((dir) => file === dir || file.startsWith(`${dir}/`));
+}
+
 /**
  * Check whether a `baseline-refresh-regression` signal tagged with the
  * runner's `source.tool === 'auto-refresh-runner'` already exists in the
@@ -316,6 +335,8 @@ async function runRefreshForKind({
   epicBranch,
   storyBranch,
   writePath,
+  config,
+  getQuality,
   refreshBaseline,
   scorer,
   fsImpl,
@@ -333,6 +354,12 @@ async function runRefreshForKind({
     scorer,
     fs: fsImpl,
     cwd,
+    requireRowsForScopeFiles: true,
+    requiredScopeFilePredicate: buildRequiredScopeFilePredicate({
+      kind,
+      config,
+      getQuality,
+    }),
   });
   return { writePath, wrote: result?.wrote === true };
 }
@@ -422,6 +449,7 @@ async function stageRefreshArtifacts({
   epicBranch,
   storyBranch,
   config,
+  getQuality,
   getBaselines,
   refreshBaseline,
   scorerBuilder,
@@ -466,6 +494,8 @@ async function stageRefreshArtifacts({
         epicBranch,
         storyBranch,
         writePath: miAbs,
+        config,
+        getQuality,
         refreshBaseline,
         scorer,
         fsImpl,
@@ -479,6 +509,8 @@ async function stageRefreshArtifacts({
         epicBranch,
         storyBranch,
         writePath: crapAbs,
+        config,
+        getQuality,
         refreshBaseline,
         scorer,
         fsImpl,
@@ -705,6 +737,7 @@ export async function runAutoRefresh({
     epicBranch,
     storyBranch,
     config,
+    getQuality,
     getBaselines,
     refreshBaseline,
     scorerBuilder,

--- a/.agents/scripts/lib/orchestration/story-close/baseline-attribution/phases/refresh-commit.js
+++ b/.agents/scripts/lib/orchestration/story-close/baseline-attribution/phases/refresh-commit.js
@@ -179,6 +179,25 @@ function resolveBaselineWritePath({
   return path.isAbsolute(rel) ? rel : path.resolve(cwd, rel);
 }
 
+function normalizeTargetDir(dir) {
+  if (typeof dir !== 'string' || dir.length === 0) return null;
+  return dir.replace(/\\/g, '/').replace(/^\.\//, '').replace(/\/+$/, '');
+}
+
+function buildRequiredScopeFilePredicate({
+  kind,
+  config,
+  getQuality = defaultGetQuality,
+}) {
+  const quality = getQuality(config) ?? {};
+  const targetDirs = Array.isArray(quality?.[kind]?.targetDirs)
+    ? quality[kind].targetDirs.map(normalizeTargetDir).filter(Boolean)
+    : [];
+  if (targetDirs.length === 0) return () => true;
+  return (file) =>
+    targetDirs.some((dir) => file === dir || file.startsWith(`${dir}/`));
+}
+
 /**
  * Stage the baseline file, then check whether the staged tree differs
  * from HEAD via `git diff --cached --exit-code`. Returns one of:
@@ -318,6 +337,11 @@ export async function runRefreshCommit({
       scorer,
       fs: fsImpl,
       cwd,
+      requireRowsForScopeFiles: true,
+      requiredScopeFilePredicate: buildRequiredScopeFilePredicate({
+        kind,
+        config,
+      }),
     });
   } catch (err) {
     return {

--- a/tests/baselines/refresh-service.diff-scope.test.js
+++ b/tests/baselines/refresh-service.diff-scope.test.js
@@ -179,6 +179,64 @@ describe('refreshBaseline — diff-scope default (Task #2207)', () => {
       scorer: makeRecordingScorer([]),
     });
   });
+
+  it('keeps Story-owned new files in refreshed maintainability and CRAP baselines', async () => {
+    const newFile = '.agents/scripts/lib/new-story-owned-file.js';
+    const cases = [
+      {
+        kind: 'maintainability',
+        rows: [{ path: newFile, mi: 88 }],
+      },
+      {
+        kind: 'crap',
+        rows: [
+          { path: newFile, method: 'newStoryOwnedFile', startLine: 1, crap: 2 },
+        ],
+      },
+    ];
+
+    for (const { kind, rows } of cases) {
+      const result = await refreshBaseline({
+        kind,
+        writePath: path.join(workDir, `${kind}.json`),
+        scopeFiles: null,
+        fullScope: false,
+        generatedAt: FIXED,
+        gitDiff: makeRecordingGitDiff([newFile]),
+        scorer: makeRecordingScorer(rows),
+        requireRowsForScopeFiles: true,
+        requiredScopeFilePredicate: (file) =>
+          file.startsWith('.agents/scripts/'),
+      });
+
+      assert.equal(result.scope.mode, 'diff');
+      assert.equal(
+        result.envelope.rows.some((row) => row.path === newFile),
+        true,
+      );
+    }
+  });
+
+  it('fails loudly when a required Story-owned scoped file produces no baseline row', async () => {
+    const newFile = '.agents/scripts/lib/unscored-story-owned-file.js';
+
+    await assert.rejects(
+      () =>
+        refreshBaseline({
+          kind: 'maintainability',
+          writePath: path.join(workDir, 'maintainability-missing.json'),
+          scopeFiles: null,
+          fullScope: false,
+          generatedAt: FIXED,
+          gitDiff: makeRecordingGitDiff([newFile]),
+          scorer: makeRecordingScorer([]),
+          requireRowsForScopeFiles: true,
+          requiredScopeFilePredicate: (file) =>
+            file.startsWith('.agents/scripts/'),
+        }),
+      /produced no baseline rows: \.agents\/scripts\/lib\/unscored-story-owned-file\.js/,
+    );
+  });
 });
 
 describe('deriveScopeFromDiff — direct invocation', () => {

--- a/tests/lib/orchestration/story-close/auto-refresh-runner.test.js
+++ b/tests/lib/orchestration/story-close/auto-refresh-runner.test.js
@@ -30,6 +30,8 @@ const AGENT_SETTINGS_FIXTURE = {
       maintainability: { path: 'baselines/maintainability.json' },
       crap: { path: 'baselines/crap.json' },
     },
+    maintainability: { targetDirs: ['.agents/scripts', 'tests'] },
+    crap: { targetDirs: ['.agents/scripts'] },
   },
 };
 
@@ -214,7 +216,23 @@ describe('runAutoRefresh — Story #2205 routing through refreshBaseline()', () 
       assert.equal(typeof call.writePath, 'string');
       assert.equal(call.baseRef, 'origin/epic/2173');
       assert.equal(call.headRef, 'story-2205');
+      assert.equal(call.requireRowsForScopeFiles, true);
+      assert.equal(typeof call.requiredScopeFilePredicate, 'function');
     }
+    const miCall = calls.find((c) => c.kind === 'maintainability');
+    const crapCall = calls.find((c) => c.kind === 'crap');
+    assert.equal(
+      miCall.requiredScopeFilePredicate('tests/new-baseline.test.js'),
+      true,
+    );
+    assert.equal(
+      crapCall.requiredScopeFilePredicate('tests/new-baseline.test.js'),
+      false,
+    );
+    assert.equal(
+      crapCall.requiredScopeFilePredicate('.agents/scripts/new-baseline.js'),
+      true,
+    );
 
     // AC: only the kind that actually drifted produces a commit. The
     // crap kind reported `wrote:false` so the runner never staged it.


### PR DESCRIPTION
Closes #3682

_Auto-opened by `/single-story-deliver`._