### PR TITLE
fix(baselines): scoped maintainability refresh drops the change set's own new files from the baseline (#3695)

### DIFF
--- a/.agents/scripts/lib/baselines/path-canon.js
+++ b/.agents/scripts/lib/baselines/path-canon.js
@@ -208,8 +208,17 @@ export function assertCanonical(input) {
  *      equivalent Linux path.
  *   5. Strip a single leading `/` so a path that was absolute after
  *      drive-letter stripping becomes repo-relative.
- *   6. Strip a leading `./` for cosmetic stability.
- *   7. Collapse any `/{2,}` run to a single `/`.
+ *   6. Strip a leading `.worktrees/<workspace>/` prefix so a refresh run
+ *      from inside a worktree produces the same key as a refresh from the
+ *      main checkout. This MUST match the equivalent step in
+ *      `canonicalise()` (Story #3695): the strict canonicaliser used by the
+ *      per-kind `projectRow` strips this prefix, so the permissive coercer
+ *      that builds the diff-scope `scope.files` set MUST strip it too —
+ *      otherwise a scored row's path (`src/new.js`) never matches its
+ *      worktree-prefixed scope entry (`.worktrees/story-1/src/new.js`) and
+ *      a brand-new file's row is silently dropped from the scoped baseline.
+ *   7. Strip a leading `./` for cosmetic stability.
+ *   8. Collapse any `/{2,}` run to a single `/`.
  *
  * The function is **idempotent**: feeding its own output back in produces
  * the same string. Downstream consumers (the refresh service and the gate
@@ -249,12 +258,21 @@ export function canonicalizeBaselinePath(input) {
     working = working.replace(/^\/+/, '');
   }
 
-  // 5. Strip a leading `./`.
+  // 5. Strip a leading `.worktrees/<workspace>/` prefix (Story #3695) so a
+  //    worktree-rooted path collapses to the same repo-relative key the
+  //    strict `canonicalise()` produces. Without this, a scored row path and
+  //    its diff-scope `scope.files` entry diverge inside a worktree and the
+  //    scope-aware merge drops brand-new files. Only a single leading
+  //    segment is stripped — a legitimate inner `.worktrees/` directory the
+  //    user named themselves is preserved (mirrors `canonicalise`).
+  working = working.replace(WORKTREE_PREFIX, '');
+
+  // 6. Strip a leading `./`.
   if (working.startsWith('./')) {
     working = working.slice(2);
   }
 
-  // 6. Collapse redundant separators.
+  // 7. Collapse redundant separators.
   working = working.replace(/\/{2,}/g, '/');
 
   return working;

--- a/tests/baselines/canonicalize-path.test.js
+++ b/tests/baselines/canonicalize-path.test.js
@@ -1,6 +1,9 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
-import { canonicalizeBaselinePath } from '../../.agents/scripts/lib/baselines/path-canon.js';
+import {
+  canonicalise,
+  canonicalizeBaselinePath,
+} from '../../.agents/scripts/lib/baselines/path-canon.js';
 
 // ---------------------------------------------------------------------------
 // canonicalize-path.test.js — pin every rule in the
@@ -85,6 +88,62 @@ describe('canonicalizeBaselinePath()', () => {
     });
   });
 
+  // -------------------------------------------------------------------------
+  // Story #3695 — worktree-prefix stripping must match canonicalise().
+  //
+  // The strict canonicaliser (used by the per-kind projectRow) strips the
+  // `.worktrees/<workspace>/` prefix. The permissive coercer builds the
+  // diff-scope `scope.files` membership set, so it MUST strip the prefix too —
+  // otherwise a worktree-rooted run can never match a scored row's path
+  // against its scope entry and a brand-new file's row is dropped.
+  // -------------------------------------------------------------------------
+  describe('worktree-prefix stripping (Story #3695)', () => {
+    it("strips a leading '.worktrees/<workspace>/' prefix", () => {
+      assert.equal(
+        canonicalizeBaselinePath('.worktrees/story-3695/src/foo.js'),
+        'src/foo.js',
+      );
+    });
+
+    it('strips the prefix when the workspace name carries hyphens and digits', () => {
+      assert.equal(
+        canonicalizeBaselinePath(
+          '.worktrees/story-3695-abc/.agents/scripts/x.js',
+        ),
+        '.agents/scripts/x.js',
+      );
+    });
+
+    it('strips a mixed-separator worktree-prefixed path', () => {
+      assert.equal(
+        canonicalizeBaselinePath('.worktrees\\story-3695\\src\\foo.js'),
+        'src/foo.js',
+      );
+    });
+
+    it('only strips a single leading worktree segment (never recursive)', () => {
+      assert.equal(
+        canonicalizeBaselinePath('.worktrees/story-1/.worktrees/inner/foo.js'),
+        '.worktrees/inner/foo.js',
+      );
+    });
+
+    it('does not strip when .worktrees appears mid-stream', () => {
+      assert.equal(
+        canonicalizeBaselinePath('src/.worktrees/story-1/foo.js'),
+        'src/.worktrees/story-1/foo.js',
+      );
+    });
+
+    it('agrees with canonicalise() on a worktree-rooted path', () => {
+      // The two canonicalisers MUST converge on the same repo-relative key —
+      // this is the load-bearing invariant the scope-aware merge relies on.
+      const wt = '.worktrees/story-3695/.agents/scripts/new.js';
+      assert.equal(canonicalizeBaselinePath(wt), canonicalise(wt));
+      assert.equal(canonicalizeBaselinePath(wt), '.agents/scripts/new.js');
+    });
+  });
+
   describe('non-string rejection', () => {
     it('throws TypeError on null', () => {
       assert.throws(() => canonicalizeBaselinePath(null), TypeError);
@@ -114,6 +173,8 @@ describe('canonicalizeBaselinePath()', () => {
       '//server/share/repo/src/foo.js',
       'D:\\proj\\src\\baselines\\foo.js',
       '/abs/path/foo.js',
+      '.worktrees/story-3695/src/foo.js',
+      '.worktrees\\story-3695\\src\\foo.js',
     ];
 
     for (const input of inputs) {

--- a/tests/baselines/refresh-service.row-preservation.test.js
+++ b/tests/baselines/refresh-service.row-preservation.test.js
@@ -265,3 +265,180 @@ describe('refreshBaseline — out-of-scope row preservation (Task #2209, AC-4)',
     assert.equal(byPath.get('src/a.js').mi, 99);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Story #3695 — scoped refresh must INCLUDE the change set's own new files.
+//
+// Regression class: when a scoped refresh (explicit `scopeFiles` or
+// diff-scope `baseRef..headRef`) includes a brand-new file (no prior baseline
+// row), the scorer scores it but the scope-aware merge dropped it — the new
+// file never got a row. The root cause was a path-format mismatch between the
+// scored row path (`canonicalise()` strips the `.worktrees/<workspace>/`
+// prefix) and the `scope.files` membership set (the permissive coercer
+// `canonicalizeBaselinePath()` did NOT strip it), so a worktree-rooted run
+// could never match a new file's row against its scope entry. The fix makes
+// both canonicalisers strip the prefix consistently.
+// ---------------------------------------------------------------------------
+
+describe('refreshBaseline — scoped refresh includes new files (Story #3695)', () => {
+  let workDir;
+
+  beforeEach(() => {
+    workDir = mkdtempSync(path.join(tmpdir(), 'mandrel-refresh-new-'));
+  });
+
+  afterEach(() => {
+    rmSync(workDir, { recursive: true, force: true });
+  });
+
+  it('AC-1 (explicit scope, maintainability): a new file in scope lands in the baseline; out-of-scope rows untouched', async () => {
+    const writePath = path.join(workDir, 'baselines', 'maintainability.json');
+    // Prior has one existing in-scope file and one out-of-scope file.
+    const priorEnvelope = seedPriorBaseline(
+      writePath,
+      [
+        { path: 'src/existing.js', mi: 50 },
+        { path: 'src/untouched.js', mi: 72 },
+      ],
+      FIXED_PRIOR,
+    );
+    const priorByPath = new Map(priorEnvelope.rows.map((r) => [r.path, r]));
+
+    // Scope = [existing.js, brandNew.js]; the scorer scores both, but
+    // brandNew.js has no prior row.
+    await refreshBaseline({
+      kind: 'maintainability',
+      writePath,
+      scopeFiles: ['src/existing.js', 'src/brandNew.js'],
+      generatedAt: FIXED_NOW,
+      scorer: makeScorer([
+        { path: 'src/existing.js', mi: 61 },
+        { path: 'src/brandNew.js', mi: 83 },
+      ]),
+    });
+
+    const parsed = JSON.parse(readFileSync(writePath, 'utf8'));
+    const byPath = new Map(parsed.rows.map((r) => [r.path, r]));
+
+    // The new file's row is present (this is the bug fix).
+    assert.ok(
+      byPath.has('src/brandNew.js'),
+      "new in-scope file 'src/brandNew.js' must get a baseline row",
+    );
+    assert.equal(byPath.get('src/brandNew.js').mi, 83);
+    // The existing in-scope file reflects the fresh score.
+    assert.equal(byPath.get('src/existing.js').mi, 61);
+    // The out-of-scope row is preserved verbatim.
+    assert.deepEqual(
+      byPath.get('src/untouched.js'),
+      priorByPath.get('src/untouched.js'),
+    );
+  });
+
+  it('AC-2 (explicit scope, crap): a new covered file in scope lands in the CRAP baseline', async () => {
+    const writePath = path.join(workDir, 'baselines', 'crap.json');
+    const priorEnvelope = (() => {
+      mkdirSync(path.dirname(writePath), { recursive: true });
+      const env = writeEnvelope({
+        kind: 'crap',
+        rows: [
+          { path: 'src/existing.js', method: 'f', startLine: 1, crap: 5 },
+          { path: 'src/untouched.js', method: 'g', startLine: 9, crap: 7 },
+        ],
+        generatedAt: FIXED_PRIOR,
+      });
+      writeEnvelopeFile(writePath, env);
+      return env;
+    })();
+    const priorByKey = new Map(
+      priorEnvelope.rows.map((r) => [
+        `${r.path}::${r.method}@${r.startLine}`,
+        r,
+      ]),
+    );
+
+    await refreshBaseline({
+      kind: 'crap',
+      writePath,
+      scopeFiles: ['src/existing.js', 'src/brandNew.js'],
+      generatedAt: FIXED_NOW,
+      scorer: makeScorer([
+        { path: 'src/existing.js', method: 'f', startLine: 1, crap: 6 },
+        { path: 'src/brandNew.js', method: 'h', startLine: 3, crap: 8 },
+      ]),
+    });
+
+    const parsed = JSON.parse(readFileSync(writePath, 'utf8'));
+    const paths = parsed.rows.map((r) => r.path);
+    // The new file's method row is present.
+    assert.ok(
+      paths.includes('src/brandNew.js'),
+      "new in-scope file 'src/brandNew.js' must get a CRAP row",
+    );
+    const newRow = parsed.rows.find((r) => r.path === 'src/brandNew.js');
+    assert.equal(newRow.crap, 8);
+    assert.equal(newRow.method, 'h');
+    // The out-of-scope row survives verbatim.
+    const untouched = parsed.rows.find((r) => r.path === 'src/untouched.js');
+    assert.deepEqual(untouched, priorByKey.get('src/untouched.js::g@9'));
+  });
+
+  it('AC-1+AC-4 (diff-scope, worktree-rooted): new file lands and out-of-scope rows are preserved', async () => {
+    // The exact #3685 reproduction shape: the diff and the scorer both emit
+    // `.worktrees/<workspace>/...` paths (a refresh run from inside a
+    // worktree). Before the fix, the new file's row was dropped because its
+    // canonicalised row path (`src/brandNew.js`) never matched its
+    // worktree-prefixed scope entry, AND the existing file kept its STALE
+    // prior score because the in-scope regen row was discarded.
+    const writePath = path.join(workDir, 'baselines', 'maintainability.json');
+    const priorEnvelope = seedPriorBaseline(
+      writePath,
+      [
+        { path: 'src/existing.js', mi: 50 },
+        { path: 'src/untouched.js', mi: 88 },
+      ],
+      FIXED_PRIOR,
+    );
+    const priorByPath = new Map(priorEnvelope.rows.map((r) => [r.path, r]));
+
+    await refreshBaseline({
+      kind: 'maintainability',
+      writePath,
+      scopeFiles: null,
+      fullScope: false,
+      baseRef: 'origin/main',
+      headRef: 'HEAD',
+      generatedAt: FIXED_NOW,
+      gitDiff: async () => [
+        '.worktrees/story-3695/src/existing.js',
+        '.worktrees/story-3695/src/brandNew.js',
+      ],
+      scorer: makeScorer([
+        { path: '.worktrees/story-3695/src/existing.js', mi: 60 },
+        { path: '.worktrees/story-3695/src/brandNew.js', mi: 80 },
+      ]),
+    });
+
+    const parsed = JSON.parse(readFileSync(writePath, 'utf8'));
+    const byPath = new Map(parsed.rows.map((r) => [r.path, r]));
+
+    // New file lands under its repo-relative key (prefix stripped).
+    assert.ok(
+      byPath.has('src/brandNew.js'),
+      'worktree-rooted new file must land under its repo-relative key',
+    );
+    assert.equal(byPath.get('src/brandNew.js').mi, 80);
+    // Existing in-scope file reflects the FRESH score, not the stale prior.
+    assert.equal(byPath.get('src/existing.js').mi, 60);
+    // Out-of-scope row preserved verbatim.
+    assert.deepEqual(
+      byPath.get('src/untouched.js'),
+      priorByPath.get('src/untouched.js'),
+    );
+    // No worktree-prefixed key leaked into the baseline.
+    assert.ok(
+      !parsed.rows.some((r) => r.path.startsWith('.worktrees/')),
+      'no row may carry a .worktrees/ prefix',
+    );
+  });
+});


### PR DESCRIPTION
Closes #3695

_Auto-opened by `/single-story-deliver`._