### PR TITLE
fix(baselines): refreshBaseline default CRAP scorer is built without config and silently drops rows (#3694)

### DIFF
--- a/.agents/scripts/lib/baselines/refresh-service.js
+++ b/.agents/scripts/lib/baselines/refresh-service.js
@@ -10,9 +10,10 @@
  *
  * The service is **scoring-agnostic**: it does not itself walk the
  * filesystem to compute MI / CRAP / coverage scores. Scoring is provided
- * by the per-kind scorer functions registered in the internal
- * `KIND_SCORERS` table (and, in tests, injected via the `scorers` option
- * for hermetic determinism). The service is the policy layer:
+ * by the per-kind default scorers resolved lazily via `resolveDefaultScorer`
+ * (built with the project config resolved against `cwd`) and, in tests or
+ * production wiring, injected via the `scorer` option for hermetic
+ * determinism. The service is the policy layer:
  *
  *   1. Validate the input contract.
  *   2. Resolve the scope (explicit list / diff-derived / full).
@@ -76,6 +77,7 @@ import nodeFs from 'node:fs';
 import { createRequire } from 'node:module';
 import path from 'node:path';
 import { promisify } from 'node:util';
+import { getQuality, resolveConfig } from '../config-resolver.js';
 import {
   buildScopePredicate,
   scoreCoverageFinal,
@@ -125,19 +127,45 @@ const KIND_FILE_PREDICATES = Object.freeze({
 });
 
 /**
+ * Resolve the normalized quality block for a kind from a `config` /
+ * `quality` pair. The default scorers MUST read the same canonical,
+ * defaulted shape that the production scorers (`refresh-commit.js#buildKindScorer`,
+ * `update-crap-baseline.js`) consume — i.e. the `getQuality(config)` output,
+ * not the raw `config.delivery.quality.gates.<kind>` path. The raw path is
+ * un-defaulted (e.g. it lacks `requireCoverage` / `coveragePath`), so reading
+ * it directly is exactly the construction inconsistency Story #3694 fixes.
+ *
+ * Precedence: an explicitly supplied `quality` block wins; otherwise derive
+ * it from `config` via `getQuality`; otherwise fall back to `{}`.
+ *
+ * @param {{ quality?: object, config?: object }} opts
+ * @returns {object}
+ */
+function resolveQualityBlock({ quality, config } = {}) {
+  if (quality && typeof quality === 'object') return quality;
+  if (config && typeof config === 'object') return getQuality(config) ?? {};
+  return {};
+}
+
+/**
  * Build the default CRAP scorer. Scans configured target directories
  * (full-scope) or the diff-derived file list, loads coverage-final.json,
  * and runs `scanAndScore` to produce row-shape objects ready for the writer.
  *
- * Exposed for unit tests that need to inspect the built scorer shape; the
- * production caller is the internal `KIND_SCORERS` registry below.
+ * Reads its `targetDirs` / `ignoreGlobs` / `requireCoverage` / `coveragePath`
+ * from the normalized quality block (Story #3694). The lazy default resolver
+ * (`resolveDefaultScorer`) passes the resolved project quality block so the
+ * config-less default no longer silently drops rows.
  *
- * @param {{ cwd: string, config?: object }} opts
+ * Exposed for unit tests that need to inspect the built scorer shape; the
+ * production caller is the internal `resolveDefaultScorer` resolver below.
+ *
+ * @param {{ cwd: string, config?: object, quality?: object }} opts
  * @returns {(files: string[], opts: object) => Promise<object[]>}
  */
-function buildDefaultCrapScorer({ cwd, config } = {}) {
+function buildDefaultCrapScorer({ cwd, config, quality } = {}) {
   // Config is optional: callers that don't pass it get reasonable defaults.
-  const crapCfg = config?.delivery?.quality?.gates?.crap ?? {};
+  const crapCfg = resolveQualityBlock({ quality, config })?.crap ?? {};
   const targetDirs = Array.isArray(crapCfg.targetDirs)
     ? crapCfg.targetDirs
     : [];
@@ -234,11 +262,15 @@ function buildDefaultCoverageScorer({ cwd } = {}) {
  * Build the default maintainability scorer. Full-scope walks all configured
  * target directories; diff-scope resolves just the in-scope files.
  *
- * @param {{ cwd: string, config?: object }} opts
+ * Reads its `targetDirs` / `ignoreGlobs` from the normalized quality block
+ * (Story #3694), mirroring `buildDefaultCrapScorer` and the production
+ * `refresh-commit.js#buildKindScorer`.
+ *
+ * @param {{ cwd: string, config?: object, quality?: object }} opts
  * @returns {(files: string[], opts: object) => Promise<object[]>}
  */
-function buildDefaultMaintainabilityScorer({ cwd, config } = {}) {
-  const miCfg = config?.delivery?.quality?.gates?.maintainability ?? {};
+function buildDefaultMaintainabilityScorer({ cwd, config, quality } = {}) {
+  const miCfg = resolveQualityBlock({ quality, config })?.maintainability ?? {};
   const targetDirs = Array.isArray(miCfg.targetDirs) ? miCfg.targetDirs : [];
   const ignoreGlobs = Array.isArray(miCfg.ignoreGlobs) ? miCfg.ignoreGlobs : [];
   return async (files, opts) => {
@@ -273,20 +305,60 @@ function buildDefaultMaintainabilityScorer({ cwd, config } = {}) {
 }
 
 /**
- * Per-kind scorer registry. Each scorer accepts `(files, opts)` and returns
- * an array of rows in the kind's row shape. Story #3658 completes the Epic
- * #2173 migration by wiring real default scorers for all three kinds so the
- * service is self-contained: callers may still inject a `scorer` via the
- * options bag (used by auto-refresh-runner and tests), but no scorer injection
- * is required for production invocations.
+ * Per-kind default-scorer builders. Story #3658 completes the Epic #2173
+ * migration by wiring real default scorers for all three kinds so the service
+ * is self-contained: callers may still inject a `scorer` via the options bag
+ * (used by auto-refresh-runner and tests), but no scorer injection is required
+ * for production invocations.
  *
- * @type {Record<string, ((files: string[], opts: object) => Promise<object[]> | object[])>}
+ * Story #3694: the builders are invoked **lazily** by `resolveDefaultScorer`
+ * with the project config resolved against the call's `cwd`, rather than being
+ * frozen once at module-load with `{ cwd: process.cwd() }` and no `config`.
+ * The previous eager table built every scorer with no config, so the crap and
+ * maintainability scorers ran with empty `targetDirs`/`ignoreGlobs` and
+ * silently dropped valid rows. Lazy resolution honours both the call's `cwd`
+ * and the resolved `crap.targetDirs`/`ignoreGlobs`/`requireCoverage` (and the
+ * maintainability equivalents).
+ *
+ * @type {Record<string, (input: { cwd: string, config?: object, quality?: object }) => ((files: string[], opts: object) => Promise<object[]> | object[])>}
  */
-const KIND_SCORERS = Object.freeze({
-  maintainability: buildDefaultMaintainabilityScorer({ cwd: process.cwd() }),
-  crap: buildDefaultCrapScorer({ cwd: process.cwd() }),
-  coverage: buildDefaultCoverageScorer({ cwd: process.cwd() }),
+const KIND_SCORER_BUILDERS = Object.freeze({
+  maintainability: buildDefaultMaintainabilityScorer,
+  crap: buildDefaultCrapScorer,
+  coverage: buildDefaultCoverageScorer,
 });
+
+/**
+ * Resolve the default scorer for `kind`, building it with the project config
+ * resolved against `cwd` (Story #3694). This is the production replacement for
+ * the old eager `KIND_SCORERS` table: it guarantees the crap and
+ * maintainability defaults are constructed with the resolved
+ * `targetDirs`/`ignoreGlobs`/`requireCoverage`, so a config-less
+ * `refreshBaseline({ kind: 'crap', ... })` call produces the same rows as the
+ * `update-crap-baseline.js` CLI rather than silently dropping them.
+ *
+ * Config resolution is best-effort: if `resolveConfig` throws (e.g. a
+ * malformed `.agentrc.json` under a tmp `cwd` in tests), we fall back to a
+ * config-less builder so the service still produces a valid (empty) envelope
+ * rather than crashing the refresh. The production crap/maintainability paths
+ * never rely on this fallback — they inject an explicit, configured scorer.
+ *
+ * @param {string} kind
+ * @param {{ cwd: string }} opts
+ * @returns {((files: string[], opts: object) => Promise<object[]> | object[]) | undefined}
+ */
+function resolveDefaultScorer(kind, { cwd } = {}) {
+  const builder = KIND_SCORER_BUILDERS[kind];
+  if (typeof builder !== 'function') return undefined;
+  const effectiveCwd = cwd ?? process.cwd();
+  let quality;
+  try {
+    quality = getQuality(resolveConfig({ cwd: effectiveCwd })) ?? undefined;
+  } catch {
+    quality = undefined;
+  }
+  return builder({ cwd: effectiveCwd, quality });
+}
 
 /**
  * Refresh the on-disk baseline for `kind`. See module preamble for the
@@ -337,12 +409,14 @@ export async function refreshBaseline(opts = {}) {
 
   validateOptions({ kind, scopeFiles, fullScope, writePath });
 
-  // Resolve the kind's scorer. Production defaults are wired by later
-  // Stories; tests inject via `opts.scorer`.
-  const resolvedScorer = scorer ?? KIND_SCORERS[kind];
+  // Resolve the kind's scorer. Tests / production wiring inject via
+  // `opts.scorer`; otherwise build the default scorer lazily with the project
+  // config resolved against `cwd` (Story #3694) so the crap/maintainability
+  // defaults honour the configured targetDirs/ignoreGlobs.
+  const resolvedScorer = scorer ?? resolveDefaultScorer(kind, { cwd });
   if (typeof resolvedScorer !== 'function') {
     throw new Error(
-      `refreshBaseline: no scorer registered for kind "${kind}" (inject one via opts.scorer until Stories 3/4/5 wire defaults)`,
+      `refreshBaseline: no scorer registered for kind "${kind}" (inject one via opts.scorer)`,
     );
   }
 

--- a/tests/baselines/refresh-service.default-crap-scorer.test.js
+++ b/tests/baselines/refresh-service.default-crap-scorer.test.js
@@ -1,0 +1,171 @@
+/**
+ * refresh-service.default-crap-scorer.test.js — Story #3694.
+ *
+ * Regression contract: a config-less `refreshBaseline({ kind: 'crap',
+ * scopeFiles, writePath, cwd })` call (no explicit `opts.scorer`) MUST
+ * produce the **same** row set as a direct `scanAndScore` run over the same
+ * scope, honouring the resolved project `crap.targetDirs` / `crap.ignoreGlobs`
+ * / `crap.requireCoverage`.
+ *
+ * The bug (discovered during Story #3685 / PR #3692): the default CRAP scorer
+ * was built once at module-load via a frozen `KIND_SCORERS` table with no
+ * `config`, so it ran with empty `targetDirs` / `ignoreGlobs` and `scanAndScore`
+ * silently dropped every valid method row. The fix builds the default scorer
+ * **lazily** with the project config resolved against the call's `cwd`
+ * (`resolveDefaultScorer`), so the default and the explicit
+ * `update-crap-baseline.js` scorer agree.
+ *
+ * Hermetic by construction: the test materializes a tiny standalone project
+ * (its own schema-valid `.agentrc.json`, source tree, and Istanbul
+ * `coverage-final.json`) under a tmp dir, then drives the service against that
+ * `cwd`. No mocking of the boundary under test — the config resolver and the
+ * crap scorer both run for real.
+ */
+
+import assert from 'node:assert/strict';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, it } from 'node:test';
+
+import { refreshBaseline } from '../../.agents/scripts/lib/baselines/refresh-service.js';
+import { loadCoverage } from '../../.agents/scripts/lib/coverage-utils.js';
+import { scanAndScore } from '../../.agents/scripts/lib/crap-utils.js';
+
+// A function with a single decision point so escomplex yields a cyclomatic
+// complexity > 1 and `scanAndScore` produces a deterministic CRAP row.
+const SOURCE =
+  'export function f(x) {\n  if (x > 1) {\n    return x;\n  }\n  return 0;\n}\n';
+
+// Minimal-but-valid Istanbul coverage entry whose fnMap.loc.start.line (1)
+// matches the escomplex method lineStart, so per-method coverage resolves.
+function makeCoverageEntry(absPath) {
+  return {
+    path: absPath,
+    statementMap: {
+      0: { start: { line: 2, column: 0 }, end: { line: 2, column: 10 } },
+      1: { start: { line: 3, column: 0 }, end: { line: 3, column: 12 } },
+      2: { start: { line: 5, column: 0 }, end: { line: 5, column: 10 } },
+    },
+    s: { 0: 1, 1: 1, 2: 0 },
+    fnMap: {
+      0: {
+        name: 'f',
+        decl: { start: { line: 1, column: 16 }, end: { line: 1, column: 17 } },
+        loc: { start: { line: 1, column: 0 }, end: { line: 6, column: 1 } },
+      },
+    },
+    f: { 0: 1 },
+    branchMap: {},
+    b: {},
+  };
+}
+
+function rowKey(row) {
+  return `${row.file ?? row.path}::${row.method}@${row.startLine}`;
+}
+
+describe('refreshBaseline — default CRAP scorer honours config (Story #3694)', () => {
+  let projectDir;
+  let writePath;
+  const scopeFiles = ['src/a.js', 'src/ignored.js'];
+
+  beforeEach(() => {
+    projectDir = mkdtempSync(path.join(tmpdir(), 'mandrel-3694-crap-'));
+    mkdirSync(path.join(projectDir, 'src'), { recursive: true });
+    mkdirSync(path.join(projectDir, 'coverage'), { recursive: true });
+    mkdirSync(path.join(projectDir, 'baselines'), { recursive: true });
+
+    // Two scored files; `src/ignored.js` is excluded via crap.ignoreGlobs so
+    // it must NOT appear in either the default-scorer rows or the source-of-
+    // truth scanAndScore rows.
+    writeFileSync(path.join(projectDir, 'src', 'a.js'), SOURCE);
+    writeFileSync(path.join(projectDir, 'src', 'ignored.js'), SOURCE);
+
+    const absA = path.join(projectDir, 'src', 'a.js').split(path.sep).join('/');
+    const absIgnored = path
+      .join(projectDir, 'src', 'ignored.js')
+      .split(path.sep)
+      .join('/');
+    writeFileSync(
+      path.join(projectDir, 'coverage', 'coverage-final.json'),
+      JSON.stringify({
+        [absA]: makeCoverageEntry(absA),
+        [absIgnored]: makeCoverageEntry(absIgnored),
+      }),
+    );
+
+    // Schema-valid .agentrc.json scoping crap to `src` and ignoring one file.
+    writeFileSync(
+      path.join(projectDir, '.agentrc.json'),
+      JSON.stringify({
+        project: {
+          paths: { agentRoot: '.agents', docsRoot: 'docs', tempRoot: 'temp' },
+        },
+        github: { owner: 'o', repo: 'r', operatorHandle: '@x' },
+        delivery: {
+          quality: {
+            gates: {
+              crap: { targetDirs: ['src'], ignoreGlobs: ['src/ignored.js'] },
+            },
+          },
+        },
+      }),
+    );
+
+    writePath = path.join(projectDir, 'baselines', 'crap.json');
+  });
+
+  afterEach(() => {
+    rmSync(projectDir, { recursive: true, force: true });
+  });
+
+  it('AC: config-less default scorer matches a direct scanAndScore over the same scope', async () => {
+    // Act — drive the service with NO explicit scorer. The default scorer must
+    // resolve the project config from `cwd` and score the same rows the CLI
+    // would. Pre-fix this returned an empty row set (the footgun).
+    const result = await refreshBaseline({
+      kind: 'crap',
+      scopeFiles,
+      writePath,
+      cwd: projectDir,
+    });
+
+    // Source of truth — the exact scorer shape update-crap-baseline.js builds.
+    const coverage = loadCoverage(
+      path.join(projectDir, 'coverage', 'coverage-final.json'),
+    );
+    const { rows: expectedRows } = await scanAndScore({
+      targetDirs: ['src'],
+      coverage,
+      requireCoverage: true,
+      cwd: projectDir,
+      ignoreGlobs: ['src/ignored.js'],
+      scopeFiles,
+    });
+
+    // The default scorer must produce a non-empty row set (the regression
+    // signal: an empty set means the config-less default dropped the rows).
+    assert.ok(
+      result.envelope.rows.length > 0,
+      'default crap scorer produced zero rows — config (targetDirs) was not honoured',
+    );
+    assert.ok(
+      expectedRows.length > 0,
+      'fixture sanity: scanAndScore must produce at least one row',
+    );
+
+    // Row sets must match by (file, method, startLine) — no silently dropped
+    // methods, no extra rows.
+    const actualKeys = result.envelope.rows.map(rowKey).sort();
+    const expectedKeys = expectedRows.map(rowKey).sort();
+    assert.deepEqual(actualKeys, expectedKeys);
+
+    // ignoreGlobs honoured: the excluded file never appears.
+    assert.equal(
+      result.envelope.rows.some((r) => (r.file ?? r.path) === 'src/ignored.js'),
+      false,
+      'crap.ignoreGlobs was not honoured — src/ignored.js leaked into the baseline',
+    );
+  });
+});


### PR DESCRIPTION
Closes #3694

_Auto-opened by `/single-story-deliver`._