### PR TITLE
fix(planning): issue-link-parser matches spec references in Epic body prose, dropping authored acceptance specs (#3848)

### DIFF
--- a/.agents/scripts/lib/issue-link-parser.js
+++ b/.agents/scripts/lib/issue-link-parser.js
@@ -14,6 +14,11 @@
  * `closePlanningArtifacts()` cascade in `epic-deliver-finalize.js` can close
  * the `context::acceptance-spec` ticket Epic #2001 introduces alongside the
  * existing PRD / Tech-Spec pair.
+ *
+ * Story #3848: regexes are now scoped to the `## Planning Artifacts` section
+ * only. Prose elsewhere in the body (e.g. bundled-follow-up notes that
+ * mention a foreign Epic's spec ticket by number) can no longer collide with
+ * the machine-managed list items.
  */
 
 const PRD_RE = /(?:PRD|prd)[:\s]+#(\d+)/;
@@ -22,17 +27,46 @@ const ACCEPTANCE_SPEC_RE =
   /(?:Acceptance Spec|acceptance.?spec|accept.?spec)[:\s]+#(\d+)/i;
 
 /**
+ * Extract the `## Planning Artifacts` section text from an Epic body.
+ * Returns the slice from just after the heading line to the next `##`-level
+ * heading (exclusive), or to end-of-string when no following heading is
+ * present. Returns an empty string when the section is absent.
+ *
+ * @param {string} body
+ * @returns {string}
+ */
+function extractPlanningArtifactsSection(body) {
+  // Step 1: locate the heading.
+  const startMatch = body.match(/^##\s+Planning Artifacts[^\n]*/m);
+  if (!startMatch) return '';
+  // Step 2: slice from just after the heading to the next ## heading (or EOB).
+  const afterHeading = body.slice(startMatch.index + startMatch[0].length);
+  const nextHeadingMatch = afterHeading.match(/\n##\s/);
+  return nextHeadingMatch
+    ? afterHeading.slice(0, nextHeadingMatch.index)
+    : afterHeading;
+}
+
+/**
  * @param {string|null|undefined} body
  * @returns {{ prd: number|null, techSpec: number|null, acceptanceSpec: number|null }}
  */
 export function parseLinkedIssues(body) {
   const result = { prd: null, techSpec: null, acceptanceSpec: null };
   if (typeof body !== 'string' || body.length === 0) return result;
-  const prdMatch = body.match(PRD_RE);
+
+  // Scope all regex matching to the canonical Planning Artifacts section so
+  // prose references elsewhere in the body do not shadow the machine-managed
+  // list items. When the section is absent every slot stays null — the caller
+  // (plan-epic.js) treats null as "not yet linked" and creates fresh tickets.
+  const section = extractPlanningArtifactsSection(body);
+  if (section.length === 0) return result;
+
+  const prdMatch = section.match(PRD_RE);
   if (prdMatch) result.prd = Number.parseInt(prdMatch[1], 10);
-  const specMatch = body.match(TECH_SPEC_RE);
+  const specMatch = section.match(TECH_SPEC_RE);
   if (specMatch) result.techSpec = Number.parseInt(specMatch[1], 10);
-  const acceptanceMatch = body.match(ACCEPTANCE_SPEC_RE);
+  const acceptanceMatch = section.match(ACCEPTANCE_SPEC_RE);
   if (acceptanceMatch) {
     result.acceptanceSpec = Number.parseInt(acceptanceMatch[1], 10);
   }

--- a/tests/issue-link-parser.test.js
+++ b/tests/issue-link-parser.test.js
@@ -84,7 +84,7 @@ describe('parseLinkedIssues — Story #2091 contract', () => {
       'tech spec: #5003',
     ];
     for (const line of techSpecVariants) {
-      const parsed = parseLinkedIssues(`- [ ] ${line}\n`);
+      const parsed = parseLinkedIssues(planningArtifactsBody([line]));
       assert.match(line, /#(\d+)/);
       const expected = Number.parseInt(line.match(/#(\d+)/)[1], 10);
       assert.equal(parsed.techSpec, expected, `failed: ${line}`);
@@ -95,10 +95,67 @@ describe('parseLinkedIssues — Story #2091 contract', () => {
       'accept-spec: #6003',
     ];
     for (const line of acceptanceVariants) {
-      const parsed = parseLinkedIssues(`- [ ] ${line}\n`);
+      const parsed = parseLinkedIssues(planningArtifactsBody([line]));
       assert.match(line, /#(\d+)/);
       const expected = Number.parseInt(line.match(/#(\d+)/)[1], 10);
       assert.equal(parsed.acceptanceSpec, expected, `failed: ${line}`);
     }
+  });
+
+  // Story #3848 — regression guard: prose references in the body must not
+  // shadow the canonical Planning Artifacts section links.
+  it('ignores prose spec references outside the Planning Artifacts section (Story #3848)', () => {
+    // Simulate the live reproduction case: body prose mentions a foreign
+    // Epic's Acceptance Spec #907, but the Planning Artifacts section links
+    // the correct ticket #1442.
+    const body = [
+      '## Summary',
+      '',
+      'Bundled follow-up: AC-8..AC-12 on Acceptance Spec #907 from Epic #11.',
+      'Also references PRD #42 and Tech Spec #43 in passing prose.',
+      '',
+      '## Planning Artifacts',
+      '- [ ] PRD: #100',
+      '- [ ] Tech Spec: #200',
+      '- [ ] Acceptance Spec: #1442',
+      '',
+      '## Other Section',
+      'Some more content referencing Acceptance Spec #999.',
+    ].join('\n');
+
+    const parsed = parseLinkedIssues(body);
+
+    // Must resolve to the Planning Artifacts values, not the prose values.
+    assert.equal(
+      parsed.prd,
+      100,
+      'prd should be 100 from Planning Artifacts, not 42 from prose',
+    );
+    assert.equal(
+      parsed.techSpec,
+      200,
+      'techSpec should be 200 from Planning Artifacts, not 43 from prose',
+    );
+    assert.equal(
+      parsed.acceptanceSpec,
+      1442,
+      'acceptanceSpec should be 1442 from Planning Artifacts, not 907 from prose',
+    );
+  });
+
+  it('returns all-null slots when there is no Planning Artifacts section at all', () => {
+    // Prose references without a Planning Artifacts section must return null
+    // (not the prose value) — plan-epic.js treats null as "not yet linked"
+    // and will create fresh tickets rather than linking foreign ones.
+    const body = [
+      '## Summary',
+      '',
+      'See PRD #42, Tech Spec #43, Acceptance Spec #907 for prior art.',
+    ].join('\n');
+
+    const parsed = parseLinkedIssues(body);
+    assert.equal(parsed.prd, null);
+    assert.equal(parsed.techSpec, null);
+    assert.equal(parsed.acceptanceSpec, null);
   });
 });

--- a/tests/lib/github-provider.test.js
+++ b/tests/lib/github-provider.test.js
@@ -82,7 +82,7 @@ test('GitHubProvider: getEpic parses PRD/TechSpec links', async () => {
         id: 111,
         node_id: 'node_1',
         title: 'Epic Title',
-        body: 'PRD: #2\nTech Spec: #3',
+        body: '## Planning Artifacts\n- [ ] PRD: #2\n- [ ] Tech Spec: #3\n',
         labels: [{ name: 'type::epic' }],
       },
     },

--- a/tests/providers-github.test.js
+++ b/tests/providers-github.test.js
@@ -265,7 +265,7 @@ describe('GitHubProvider — getEpic()', () => {
         json: {
           number: 10,
           title: 'Epic: Build v5',
-          body: 'Goal description\n\nPRD: #11\nTech Spec: #12',
+          body: 'Goal description\n\n## Planning Artifacts\n- [ ] PRD: #11\n- [ ] Tech Spec: #12\n',
           labels: [{ name: 'type::epic' }],
         },
       },

--- a/tests/providers/github/mappers.test.js
+++ b/tests/providers/github/mappers.test.js
@@ -86,7 +86,7 @@ describe('providers/github/mappers.js — REST payload shapes', () => {
       id: 9999,
       node_id: 'EPIC_NODE',
       title: 'Epic title',
-      body: 'PRD: #200\nTech Spec: #201',
+      body: '## Planning Artifacts\n- [ ] PRD: #200\n- [ ] Tech Spec: #201\n',
       labels: [{ name: 'type::epic' }],
     });
     assert.strictEqual(epic.id, 100);


### PR DESCRIPTION
Closes #3848

_Auto-opened by `/single-story-deliver`._