### PR TITLE
fix(retro): low-utilisation heuristic false-positives on serialized/narrow waves + missing timing (#3850)

### DIFF
--- a/.agents/schemas/epic-perf-report.schema.json
+++ b/.agents/schemas/epic-perf-report.schema.json
@@ -33,7 +33,7 @@
     },
     "waveParallelism": {
       "type": "array",
-      "description": "Per-wave parallelism utilisation. utilisation = summedStoryMs / (wallClockMs * concurrencyCap), clamped to [0,1] (Epic #3019 / Story #3025).",
+      "description": "Per-wave parallelism utilisation. utilisation = summedStoryMs / (wallClockMs * min(storyCount, concurrencyCap)), clamped to [0,1] (Epic #3019 / Story #3025; effective-cap denominator Story #3850).",
       "items": {
         "type": "object",
         "additionalProperties": false,
@@ -47,6 +47,11 @@
         ],
         "properties": {
           "waveIndex": { "type": "integer", "minimum": 0 },
+          "storyCount": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "Number of Stories in the wave (from wave-start.stories). Added Story #3850."
+          },
           "wallClockMs": { "type": "integer", "minimum": 0 },
           "summedStoryMs": { "type": "integer", "minimum": 0 },
           "utilisation": { "type": "number", "minimum": 0, "maximum": 1 },

--- a/.agents/scripts/lib/observability/perf-aggregator.js
+++ b/.agents/scripts/lib/observability/perf-aggregator.js
@@ -573,13 +573,20 @@ function fillMissingWaveEnds(orderedWaves, timedEvents) {
  *
  * Field contract (per the extended `epic-perf-report.schema.json`):
  *   - `waveIndex`: integer ≥ 0, from `wave-start.index`
+ *   - `storyCount`: integer ≥ 0, number of Stories in the wave (from
+ *     `wave-start.stories`). Added under Story #3850.
  *   - `wallClockMs`: integer ≥ 0, `(waveEnd - waveStart)` in ms
  *   - `summedStoryMs`: integer ≥ 0, Σ per-Story `(end - start)`
- *   - `utilisation`: `summedStoryMs / (wallClockMs * concurrencyCap)`,
- *     clamped to `[0, 1]`. Zero when `wallClockMs === 0` or cap is 0.
+ *   - `utilisation`: `summedStoryMs / (wallClockMs * effectiveCap)`,
+ *     where `effectiveCap = min(storyCount, concurrencyCap)`, clamped
+ *     to `[0, 1]`. Zero when `wallClockMs === 0` or effectiveCap is 0.
+ *     Using the effective (not raw) cap means a fully-busy 1-Story wave
+ *     scores 1.0 rather than `1/cap`, eliminating false-positive
+ *     `low-utilisation` signals on serialized/narrow waves (Story #3850).
  *   - `capBinding`: true when `summedStoryMs / wallClockMs >=
  *     concurrencyCap`, false otherwise (and false when wallClockMs
- *     is 0).
+ *     is 0). Still uses the raw cap so the signal fires when the
+ *     configured parallelism ceiling is actually saturated.
  *   - `verifyConcurrencyCap`: forwarded from `opts.verifyConcurrencyCap`
  *     (or the project default 4) so the post-merge close comment can
  *     attribute saturation back to the cap value in force at the time.
@@ -591,6 +598,7 @@ function fillMissingWaveEnds(orderedWaves, timedEvents) {
  * }} [opts]
  * @returns {Array<{
  *   waveIndex: number,
+ *   storyCount: number,
  *   wallClockMs: number,
  *   summedStoryMs: number,
  *   utilisation: number,
@@ -633,6 +641,7 @@ export function computeWaveParallelismRows(events, opts = {}) {
       0,
       Math.floor((rec.endMs ?? rec.startMs) - rec.startMs),
     );
+    const storyCount = rec.stories.length;
     let summedStoryMs = 0;
     for (const sid of rec.stories) {
       const w = storyWindows.get(sid);
@@ -640,14 +649,24 @@ export function computeWaveParallelismRows(events, opts = {}) {
       const dur = w.endMs - w.startMs;
       if (Number.isFinite(dur) && dur > 0) summedStoryMs += Math.floor(dur);
     }
+    // Use the effective cap — min(storyCount, concurrencyCap) — as the
+    // utilisation denominator so a fully-busy 1-Story wave scores 1.0
+    // instead of 1/cap. This eliminates false-positive `low-utilisation`
+    // signals on serialized / narrow-wave Epics (Story #3850).
+    // capBinding still uses the raw concurrencyCap because it signals that
+    // the configured parallelism ceiling is genuinely saturated.
+    const effectiveCap = Math.min(storyCount, concurrencyCap);
     let utilisation = 0;
     let capBinding = false;
+    if (wallClockMs > 0 && effectiveCap > 0) {
+      utilisation = clamp(summedStoryMs / (wallClockMs * effectiveCap), 0, 1);
+    }
     if (wallClockMs > 0 && concurrencyCap > 0) {
-      utilisation = clamp(summedStoryMs / (wallClockMs * concurrencyCap), 0, 1);
       capBinding = summedStoryMs / wallClockMs >= concurrencyCap;
     }
     rows.push({
       waveIndex: idx,
+      storyCount,
       wallClockMs,
       summedStoryMs,
       utilisation,
@@ -677,8 +696,9 @@ function clamp(n, lo, hi) {
 
 /**
  * Coerce a single waveParallelism input row into the schema-canonical
- * shape `{ waveIndex, wallClockMs, summedStoryMs, utilisation,
- * capBinding, verifyConcurrencyCap }` (Story #3025).
+ * shape `{ waveIndex, storyCount, wallClockMs, summedStoryMs, utilisation,
+ * capBinding, verifyConcurrencyCap }` (Story #3025; storyCount added
+ * Story #3850).
  *
  * - Numeric fields are floored to non-negative integers (or clamped
  *   numbers for utilisation) so the JSON-schema `integer` / `minimum: 0`
@@ -689,11 +709,13 @@ function clamp(n, lo, hi) {
  * - `verifyConcurrencyCap` falls back to the project default (4) when the
  *   caller omits it or supplies a non-positive integer; the schema
  *   requires `minimum: 1` so 0 is not a valid carrier value.
+ * - `storyCount` falls back to 0 when absent (older payloads predating
+ *   Story #3850 do not carry the field).
  *
  * Exported for unit-testing the coercer in isolation.
  *
  * @param {object | null | undefined} row
- * @returns {{ waveIndex: number, wallClockMs: number, summedStoryMs: number, utilisation: number, capBinding: boolean, verifyConcurrencyCap: number }}
+ * @returns {{ waveIndex: number, storyCount: number, wallClockMs: number, summedStoryMs: number, utilisation: number, capBinding: boolean, verifyConcurrencyCap: number }}
  */
 export function coerceWaveParallelismRow(row) {
   const src = isObject(row) ? row : {};
@@ -702,6 +724,7 @@ export function coerceWaveParallelismRow(row) {
     Number.isInteger(cap) && cap >= 1 ? cap : DEFAULT_VERIFY_CONCURRENCY_CAP;
   return {
     waveIndex: nonNegativeInt(src.waveIndex),
+    storyCount: nonNegativeInt(src.storyCount),
     wallClockMs: nonNegativeInt(src.wallClockMs),
     summedStoryMs: nonNegativeInt(src.summedStoryMs),
     utilisation: clamp(nonNegativeNumber(src.utilisation), 0, 1),

--- a/.agents/scripts/lib/orchestration/retro-perf-heuristics.js
+++ b/.agents/scripts/lib/orchestration/retro-perf-heuristics.js
@@ -134,10 +134,18 @@ function extractRows(report) {
 /**
  * Build the `low-utilisation` signals — one per wave whose `utilisation` is
  * strictly below the threshold. Returns `[]` when no row crosses the gate.
+ *
+ * Waves with `summedStoryMs <= 0` are skipped unconditionally: when no
+ * per-Story timing windows are present the computed utilisation is 0.0%
+ * because the numerator is 0, not because the wave was genuinely idle.
+ * Scoring unknown timing as low would flood the retro with non-actionable
+ * follow-ons (Story #3850).
  */
 function detectLowUtilisation(rows, threshold) {
   const out = [];
   for (const row of rows) {
+    // Skip waves with no timing data — utilisation is unknown, not low.
+    if (row.summedStoryMs <= 0) continue;
     if (row.utilisation < threshold) {
       out.push({
         kind: 'low-utilisation',

--- a/tests/lib/observability/perf-aggregator.test.js
+++ b/tests/lib/observability/perf-aggregator.test.js
@@ -8,9 +8,11 @@ import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 
 import {
+  coerceWaveParallelismRow,
   collectValidStorySamples,
   computeEpicPerfReport,
   computeStoryPerfSummary,
+  computeWaveParallelismRows,
 } from '../../../.agents/scripts/lib/observability/perf-aggregator.js';
 
 describe('computeStoryPerfSummary', () => {
@@ -253,6 +255,7 @@ describe('computeEpicPerfReport', () => {
       waveParallelism: [
         {
           waveIndex: 1,
+          storyCount: 3,
           wallClockMs: 1000,
           summedStoryMs: 4000,
           utilisation: 0.25,
@@ -272,10 +275,12 @@ describe('computeEpicPerfReport', () => {
     assert.equal(out.waveParallelism.length, 2);
     // First row passes through (already canonical).
     assert.equal(out.waveParallelism[0].waveIndex, 1);
+    assert.equal(out.waveParallelism[0].storyCount, 3);
     assert.equal(out.waveParallelism[0].capBinding, true);
     assert.equal(out.waveParallelism[0].verifyConcurrencyCap, 4);
     // Second row coerces garbage to safe defaults.
     assert.equal(out.waveParallelism[1].waveIndex, 0);
+    assert.equal(out.waveParallelism[1].storyCount, 0);
     assert.equal(out.waveParallelism[1].wallClockMs, 0);
     assert.equal(out.waveParallelism[1].summedStoryMs, 0);
     assert.equal(out.waveParallelism[1].utilisation, 0);
@@ -286,6 +291,175 @@ describe('computeEpicPerfReport', () => {
 
   it('rejects bad epicId', () => {
     assert.throws(() => computeEpicPerfReport([], { epicId: 0 }), /epicId/);
+  });
+});
+
+describe('computeWaveParallelismRows (Story #3850 fixes)', () => {
+  // Helper to build a minimal lifecycle event stream.
+  function makeEvents({ waves = [], transitions = [] } = {}) {
+    const events = [];
+    const base = Date.parse('2026-06-01T00:00:00.000Z');
+    for (const w of waves) {
+      events.push({
+        kind: 'wave-start',
+        index: w.index,
+        stories: w.stories.map((id) => ({ id })),
+        ts: new Date(base + w.startOffset).toISOString(),
+      });
+      if (w.endOffset != null) {
+        events.push({
+          kind: 'wave-complete',
+          index: w.index,
+          ts: new Date(base + w.endOffset).toISOString(),
+        });
+      }
+    }
+    for (const t of transitions) {
+      events.push({
+        kind: 'state-transition',
+        story: t.storyId,
+        details: { to: t.to },
+        ts: new Date(base + t.offset).toISOString(),
+      });
+    }
+    return events;
+  }
+
+  it('emits storyCount matching the wave-start stories array', () => {
+    const events = makeEvents({
+      waves: [
+        { index: 0, stories: [1, 2, 3], startOffset: 0, endOffset: 5000 },
+      ],
+      transitions: [
+        { storyId: 1, to: 'agent::executing', offset: 100 },
+        { storyId: 1, to: 'agent::done', offset: 2000 },
+        { storyId: 2, to: 'agent::executing', offset: 100 },
+        { storyId: 2, to: 'agent::done', offset: 2000 },
+        { storyId: 3, to: 'agent::executing', offset: 100 },
+        { storyId: 3, to: 'agent::done', offset: 2000 },
+      ],
+    });
+    const rows = computeWaveParallelismRows(events, { concurrencyCap: 4 });
+    assert.equal(rows.length, 1);
+    assert.equal(rows[0].storyCount, 3);
+  });
+
+  it('Fix C: 1-Story wave with cap=3 scores utilisation 1.0, not 0.33', () => {
+    // Wall=5000ms, story active for 5000ms, storyCount=1, cap=3.
+    // Old formula: 5000 / (5000 * 3) = 0.33.
+    // New formula: 5000 / (5000 * min(1, 3)) = 1.0.
+    const events = makeEvents({
+      waves: [
+        { index: 0, stories: [1], startOffset: 0, endOffset: 5000 },
+      ],
+      transitions: [
+        { storyId: 1, to: 'agent::executing', offset: 0 },
+        { storyId: 1, to: 'agent::done', offset: 5000 },
+      ],
+    });
+    const rows = computeWaveParallelismRows(events, { concurrencyCap: 3 });
+    assert.equal(rows.length, 1);
+    assert.equal(rows[0].storyCount, 1);
+    // Utilisation should be clamped to 1.0 for a fully-busy single-story wave.
+    assert.ok(
+      rows[0].utilisation >= 0.99,
+      `expected utilisation ≈ 1.0 but got ${rows[0].utilisation}`,
+    );
+  });
+
+  it('Fix C: 2-Story wave at cap=3 uses min(2,3)=2 as denominator', () => {
+    // Both stories run from 0 to 5000ms (wallClock=5000). summedStoryMs=10000.
+    // Old formula: 10000 / (5000 * 3) = 0.67.
+    // New formula: 10000 / (5000 * min(2,3)) = 10000 / 10000 = 1.0.
+    const events = makeEvents({
+      waves: [
+        { index: 0, stories: [1, 2], startOffset: 0, endOffset: 5000 },
+      ],
+      transitions: [
+        { storyId: 1, to: 'agent::executing', offset: 0 },
+        { storyId: 1, to: 'agent::done', offset: 5000 },
+        { storyId: 2, to: 'agent::executing', offset: 0 },
+        { storyId: 2, to: 'agent::done', offset: 5000 },
+      ],
+    });
+    const rows = computeWaveParallelismRows(events, { concurrencyCap: 3 });
+    assert.equal(rows[0].storyCount, 2);
+    assert.ok(
+      rows[0].utilisation >= 0.99,
+      `expected utilisation ≈ 1.0 but got ${rows[0].utilisation}`,
+    );
+  });
+
+  it('Fix C: wide wave (storyCount >= cap) uses concurrencyCap denominator', () => {
+    // 4 stories, cap=2. effectiveCap = min(4, 2) = 2.
+    // summedStoryMs=4000 (each story 1000ms), wallClock=1000.
+    // utilisation = 4000 / (1000 * 2) = 2.0, clamped to 1.0.
+    const events = makeEvents({
+      waves: [
+        { index: 0, stories: [1, 2, 3, 4], startOffset: 0, endOffset: 1000 },
+      ],
+      transitions: [
+        { storyId: 1, to: 'agent::executing', offset: 0 },
+        { storyId: 1, to: 'agent::done', offset: 1000 },
+        { storyId: 2, to: 'agent::executing', offset: 0 },
+        { storyId: 2, to: 'agent::done', offset: 1000 },
+        { storyId: 3, to: 'agent::executing', offset: 0 },
+        { storyId: 3, to: 'agent::done', offset: 1000 },
+        { storyId: 4, to: 'agent::executing', offset: 0 },
+        { storyId: 4, to: 'agent::done', offset: 1000 },
+      ],
+    });
+    const rows = computeWaveParallelismRows(events, { concurrencyCap: 2 });
+    assert.equal(rows[0].storyCount, 4);
+    // capBinding: summedStoryMs/wallClock = 4000/1000 = 4 >= cap(2) → true.
+    assert.equal(rows[0].capBinding, true);
+    // utilisation clamped to 1.0 (4000 / (1000 * 2) = 2.0).
+    assert.equal(rows[0].utilisation, 1);
+  });
+
+  it('returns empty array on empty event stream', () => {
+    const rows = computeWaveParallelismRows([], { concurrencyCap: 2 });
+    assert.deepEqual(rows, []);
+  });
+});
+
+describe('coerceWaveParallelismRow (Story #3850: storyCount field)', () => {
+  it('passes storyCount through when present', () => {
+    const row = coerceWaveParallelismRow({
+      waveIndex: 0,
+      storyCount: 2,
+      wallClockMs: 1000,
+      summedStoryMs: 2000,
+      utilisation: 0.5,
+      capBinding: false,
+      verifyConcurrencyCap: 4,
+    });
+    assert.equal(row.storyCount, 2);
+  });
+
+  it('defaults storyCount to 0 when absent (older payloads)', () => {
+    const row = coerceWaveParallelismRow({
+      waveIndex: 0,
+      wallClockMs: 1000,
+      summedStoryMs: 2000,
+      utilisation: 0.5,
+      capBinding: false,
+      verifyConcurrencyCap: 4,
+    });
+    assert.equal(row.storyCount, 0);
+  });
+
+  it('coerces negative storyCount to 0', () => {
+    const row = coerceWaveParallelismRow({
+      waveIndex: 0,
+      storyCount: -5,
+      wallClockMs: 0,
+      summedStoryMs: 0,
+      utilisation: 0,
+      capBinding: false,
+      verifyConcurrencyCap: 4,
+    });
+    assert.equal(row.storyCount, 0);
   });
 });
 

--- a/tests/lib/observability/perf-aggregator.test.js
+++ b/tests/lib/observability/perf-aggregator.test.js
@@ -349,9 +349,7 @@ describe('computeWaveParallelismRows (Story #3850 fixes)', () => {
     // Old formula: 5000 / (5000 * 3) = 0.33.
     // New formula: 5000 / (5000 * min(1, 3)) = 1.0.
     const events = makeEvents({
-      waves: [
-        { index: 0, stories: [1], startOffset: 0, endOffset: 5000 },
-      ],
+      waves: [{ index: 0, stories: [1], startOffset: 0, endOffset: 5000 }],
       transitions: [
         { storyId: 1, to: 'agent::executing', offset: 0 },
         { storyId: 1, to: 'agent::done', offset: 5000 },
@@ -372,9 +370,7 @@ describe('computeWaveParallelismRows (Story #3850 fixes)', () => {
     // Old formula: 10000 / (5000 * 3) = 0.67.
     // New formula: 10000 / (5000 * min(2,3)) = 10000 / 10000 = 1.0.
     const events = makeEvents({
-      waves: [
-        { index: 0, stories: [1, 2], startOffset: 0, endOffset: 5000 },
-      ],
+      waves: [{ index: 0, stories: [1, 2], startOffset: 0, endOffset: 5000 }],
       transitions: [
         { storyId: 1, to: 'agent::executing', offset: 0 },
         { storyId: 1, to: 'agent::done', offset: 5000 },

--- a/tests/perf-aggregator-wave-parallelism.test.js
+++ b/tests/perf-aggregator-wave-parallelism.test.js
@@ -297,18 +297,23 @@ function refComputeWaveParallelismRows(events, opts = {}) {
       const dur = w.endMs - w.startMs;
       if (Number.isFinite(dur) && dur > 0) summedStoryMs += Math.floor(dur);
     }
+    const storyCount = rec.stories.length;
+    const effectiveCap = Math.min(storyCount, concurrencyCap);
     let utilisation = 0;
     let capBinding = false;
-    if (wallClockMs > 0 && concurrencyCap > 0) {
+    if (wallClockMs > 0 && effectiveCap > 0) {
       utilisation = refClamp(
-        summedStoryMs / (wallClockMs * concurrencyCap),
+        summedStoryMs / (wallClockMs * effectiveCap),
         0,
         1,
       );
+    }
+    if (wallClockMs > 0 && concurrencyCap > 0) {
       capBinding = summedStoryMs / wallClockMs >= concurrencyCap;
     }
     rows.push({
       waveIndex: idx,
+      storyCount,
       wallClockMs,
       summedStoryMs,
       utilisation,

--- a/tests/retro-perf-heuristics.test.js
+++ b/tests/retro-perf-heuristics.test.js
@@ -242,6 +242,70 @@ describe('classifyPerfSignals (Story #3045)', () => {
     assert.equal(signals.filter((s) => s.kind === 'cap-binding-run').length, 1);
   });
 
+  it('Fix A: does not emit low-utilisation for waves with no timing data', () => {
+    // summedStoryMs=0 means timing is unknown, not that the wave was idle.
+    // A run with no per-Story dispatch windows should produce zero signals.
+    const report = makeReport({
+      waveParallelism: [
+        {
+          waveIndex: 0,
+          wallClockMs: 5000,
+          summedStoryMs: 0,
+          utilisation: 0,
+          capBinding: false,
+        },
+        {
+          waveIndex: 1,
+          wallClockMs: 5000,
+          summedStoryMs: 0,
+          utilisation: 0,
+          capBinding: false,
+        },
+      ],
+    });
+    const signals = classifyPerfSignals(report);
+    assert.equal(
+      signals.filter((s) => s.kind === 'low-utilisation').length,
+      0,
+      'expected zero low-utilisation signals for waves with unknown timing',
+    );
+  });
+
+  it('Fix A: emits low-utilisation only for waves that have timing and are genuinely low', () => {
+    // Wave 0: timing present, genuinely low (0.2 < 0.6 threshold).
+    // Wave 1: timing absent (summedStoryMs=0) — should be suppressed.
+    // Wave 2: timing present, above threshold (0.75 >= 0.6) — no signal.
+    const report = makeReport({
+      waveParallelism: [
+        {
+          waveIndex: 0,
+          wallClockMs: 5000,
+          summedStoryMs: 1000,
+          utilisation: 0.2,
+          capBinding: false,
+        },
+        {
+          waveIndex: 1,
+          wallClockMs: 5000,
+          summedStoryMs: 0,
+          utilisation: 0,
+          capBinding: false,
+        },
+        {
+          waveIndex: 2,
+          wallClockMs: 5000,
+          summedStoryMs: 3750,
+          utilisation: 0.75,
+          capBinding: false,
+        },
+      ],
+    });
+    const signals = classifyPerfSignals(report);
+    const lows = signals.filter((s) => s.kind === 'low-utilisation');
+    assert.equal(lows.length, 1);
+    assert.equal(lows[0].waveIndex, 0);
+  });
+
   it('resolvePerfThresholds falls back to documented defaults', () => {
     assert.deepEqual(
       resolvePerfThresholds(undefined),


### PR DESCRIPTION
Closes #3850

_Auto-opened by `/single-story-deliver`._