### PR TITLE
Add a soft validator finding when Story acceptance criteria reference a configuration constant without a concrete value (#3855)

### DIFF
--- a/.agents/scripts/lib/orchestration/ticket-validator-sizing.js
+++ b/.agents/scripts/lib/orchestration/ticket-validator-sizing.js
@@ -67,6 +67,93 @@ export const DELIVERABLE_GRANULARITY_GUIDANCE = Object.freeze({
 });
 
 /**
+ * Configuration-constant phrase patterns the `unanchored-constant` heuristic
+ * scans Story acceptance criteria for. Each entry matches the *kind* of
+ * tunable an implementing agent would otherwise have to context-hop to the
+ * Tech Spec (or an ADR) to resolve: a retention window, a rate limit, a
+ * timeout, an age cutoff, a bounded window, a per-unit cap, or a quota.
+ *
+ * The list is the single source of truth for the heuristic and intentionally
+ * narrow — it targets the small set of config constants that recur across
+ * Stories and that an author can almost always inline as a concrete value at
+ * authoring time. Anchored with `\b` word boundaries so substrings inside
+ * unrelated prose ("maximum", "timeouts handled elsewhere") don't over-match.
+ *
+ * Covered phrases (acceptance criterion of Story #3855):
+ *   - `retention window`
+ *   - `rate limit` / `rate-limit`
+ *   - `timeout`
+ *   - `older than`
+ *   - `within N` (a bounded count/duration window)
+ *   - `max ... per ...` (a per-unit cap, e.g. "max requests per second")
+ *   - `quota`
+ */
+const UNANCHORED_CONSTANT_PATTERNS = Object.freeze([
+  /\bretention window\b/i,
+  /\brate[ -]limit\b/i,
+  /\btimeout\b/i,
+  /\bolder than\b/i,
+  /\bwithin\b/i,
+  /\bmax\b[^.]*\bper\b/i,
+  /\bquota\b/i,
+]);
+
+/**
+ * Matches a concrete numeric value anywhere in an acceptance criterion. A
+ * bare digit run is enough to count as "anchored": `"older than 90 days"`,
+ * `"5 req/s"`, `"within 30 minutes"`, and `"max 100 per hour"` all carry a
+ * digit, so they are not flagged. Spelled-out small numbers are intentionally
+ * NOT treated as anchors — the heuristic nudges authors toward an explicit
+ * numeral the implementing agent can copy verbatim.
+ */
+const CONCRETE_VALUE_RE = /\d/;
+
+/**
+ * Soft, advisory `unanchored-constant` finding (Story #3855). Surfaces a
+ * Story acceptance criterion that references a configuration constant
+ * (retention window, rate limit, timeout, threshold) without stating a
+ * concrete numeric value inline — so an implementing agent doesn't have to
+ * context-hop to the Tech Spec or guess. Advisory only: `normalizeTickets`
+ * still returns successfully and the finding rides the advisory nudges array
+ * alongside the sizing soft findings.
+ */
+function makeUnanchoredConstant(slug, criterion) {
+  return {
+    kind: 'unanchored-constant',
+    severity: 'soft',
+    ticketSlug: slug,
+    criterion,
+    message: `Acceptance criterion references a configuration constant without a concrete value: "${criterion}". Specify the value inline (e.g. "90 days", "5 req/s", "30 minutes") so the implementing agent doesn't have to read the Tech Spec or guess.`,
+  };
+}
+
+/**
+ * Scan a single Story's acceptance criteria for unanchored configuration
+ * constants. A criterion trips the finding when it matches one of
+ * `UNANCHORED_CONSTANT_PATTERNS` and carries NO concrete numeric value
+ * (`CONCRETE_VALUE_RE`) — the digit is the signal the author already inlined
+ * the value, so a criterion like `"older than 90 days"` is left alone while
+ * `"older than the retention window"` is flagged. One finding per offending
+ * criterion.
+ */
+function computeUnanchoredConstantFindings(story) {
+  const out = [];
+  const body = story.body && typeof story.body === 'object' ? story.body : null;
+  const acceptance = Array.isArray(body?.acceptance) ? body.acceptance : [];
+  for (const item of acceptance) {
+    const criterion = String(item ?? '');
+    if (CONCRETE_VALUE_RE.test(criterion)) continue;
+    const matches = UNANCHORED_CONSTANT_PATTERNS.some((re) =>
+      re.test(criterion),
+    );
+    if (matches) {
+      out.push(makeUnanchoredConstant(story.slug, criterion));
+    }
+  }
+  return out;
+}
+
+/**
  * Returns true when a `changes[]` entry is a glob pattern. Handles both the
  * canonical PathEntry object form `{ path, assumption }` and legacy strings.
  */
@@ -165,6 +252,11 @@ function computeStorySizingFindings(story, sizing) {
   const acceptance = Array.isArray(body?.acceptance) ? body.acceptance : [];
   const changes = Array.isArray(body?.changes) ? body.changes : [];
   const declaredWide = isDeclaredWide(body?.wide ?? null);
+
+  // Soft, advisory: flag acceptance criteria that reference a configuration
+  // constant without inlining a concrete value (Story #3855). Independent of
+  // the numeric sizing layers below — purely an authoring nudge.
+  out.push(...computeUnanchoredConstantFindings(story));
 
   // Acceptance ceiling + soft warn.
   if (acceptance.length > sizing.maxAcceptance) {

--- a/tests/lib/orchestration/ticket-validator-unanchored-constant.test.js
+++ b/tests/lib/orchestration/ticket-validator-unanchored-constant.test.js
@@ -1,0 +1,191 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { validateAndNormalizeTickets } from '../../../.agents/scripts/lib/orchestration/ticket-validator.js';
+
+/**
+ * `unanchored-constant` soft-finding fixtures (Story #3855).
+ *
+ * The heuristic flags a Story acceptance criterion that references a
+ * configuration constant (retention window, rate limit, timeout, threshold,
+ * quota, bounded window) without stating a concrete numeric value inline. It
+ * is advisory only — `validateAndNormalizeTickets` still returns successfully
+ * and the finding rides the advisory nudges array (`severity === 'soft'`)
+ * alongside the sizing soft findings. It never contributes to `errors[]`.
+ *
+ * Observed gap (Story #3855): a criterion like
+ * `"deletes rows older than the retention window"` forces an implementing
+ * agent to context-hop to the Tech Spec (which itself only references an ADR)
+ * to find the value — a preventable delivery friction point.
+ */
+
+const FEATURE = Object.freeze({
+  type: 'feature',
+  slug: 'f-uc',
+  title: 'Unanchored-constant fixtures',
+});
+
+const SIBLING_FILLER = Object.freeze({
+  type: 'story',
+  slug: 's-uc-filler',
+  parent_slug: 'f-uc',
+  title: 'Unanchored-constant fixtures — filler sibling',
+  acceptance: ['filler observable criterion'],
+  verify: ['npm test (unit)'],
+  body: {
+    goal: 'Filler sibling so the Feature has two Stories.',
+    changes: ['src/_uc-filler.js: edit'],
+    acceptance: ['filler observable criterion'],
+    verify: ['npm test (unit)'],
+  },
+});
+
+function makeStory(slug, acceptance) {
+  return {
+    type: 'story',
+    slug,
+    parent_slug: 'f-uc',
+    title: `Unanchored-constant story ${slug}`,
+    acceptance,
+    verify: ['npm test (unit)'],
+    body: {
+      goal: `Goal for ${slug}.`,
+      changes: ['src/a.js: edit'],
+      acceptance,
+      verify: ['npm test (unit)'],
+    },
+  };
+}
+
+function validateStory(slug, acceptance, opts) {
+  return validateAndNormalizeTickets(
+    [FEATURE, makeStory(slug, acceptance), SIBLING_FILLER],
+    opts,
+  );
+}
+
+function unanchored(result) {
+  return result.findings.filter((f) => f.kind === 'unanchored-constant');
+}
+
+// ---------------------------------------------------------------------------
+// Positive: the canonical observed gap fires
+// ---------------------------------------------------------------------------
+
+test('"older than the retention window" (no numeric value) produces a soft unanchored-constant finding', () => {
+  const result = validateStory('t-retention', [
+    'deletes email_send_log rows older than the retention window',
+  ]);
+  const found = unanchored(result);
+  assert.equal(found.length, 1);
+  assert.equal(found[0].severity, 'soft');
+  assert.equal(found[0].ticketSlug, 't-retention');
+  assert.equal(
+    found[0].criterion,
+    'deletes email_send_log rows older than the retention window',
+  );
+  // Advisory only — the finding never reaches the hard errors[] channel.
+  assert.deepEqual(result.errors, []);
+});
+
+test('the finding rides the advisory nudges array (severity soft, not in errors)', () => {
+  const result = validateStory('t-advisory', [
+    'requests are throttled by the rate limit',
+  ]);
+  const soft = result.findings.filter((f) => f.severity === 'soft');
+  assert.ok(
+    soft.some((f) => f.kind === 'unanchored-constant'),
+    'expected an unanchored-constant finding in the soft nudges array',
+  );
+  assert.equal(result.errors.filter((e) => e.includes('unanchored')).length, 0);
+});
+
+// ---------------------------------------------------------------------------
+// Negative: a concrete numeric value suppresses the finding
+// ---------------------------------------------------------------------------
+
+test('"older than 90 days" does NOT produce the finding', () => {
+  const result = validateStory('t-90days', [
+    'deletes email_send_log rows older than 90 days',
+  ]);
+  assert.deepEqual(unanchored(result), []);
+  assert.deepEqual(result.errors, []);
+});
+
+// ---------------------------------------------------------------------------
+// Message: identifies the criterion and instructs the author
+// ---------------------------------------------------------------------------
+
+test('the finding message names the criterion and tells the author to inline the value', () => {
+  const result = validateStory('t-message', [
+    'each session expires after the timeout',
+  ]);
+  const found = unanchored(result);
+  assert.equal(found.length, 1);
+  assert.match(found[0].message, /each session expires after the timeout/);
+  assert.match(found[0].message, /specify the value inline/i);
+  // Example values appear so the author has a copyable shape.
+  assert.match(found[0].message, /90 days|5 req\/s|30 minutes/);
+});
+
+// ---------------------------------------------------------------------------
+// Pattern coverage: every required phrase trips (Story #3855 AC)
+// ---------------------------------------------------------------------------
+
+const PATTERN_CASES = [
+  ['retention window', 'purges rows beyond the retention window'],
+  ['rate limit', 'inbound calls obey the rate limit'],
+  ['rate-limit', 'the rate-limit policy applies per tenant'],
+  ['timeout', 'the request aborts on timeout'],
+  ['older than', 'rows older than the cutoff are removed'],
+  ['within N', 'retries happen within the configured window'],
+  ['max.*per', 'enforces the max requests per tenant'],
+  ['quota', 'uploads stop once the quota is reached'],
+];
+
+for (const [label, criterion] of PATTERN_CASES) {
+  test(`pattern "${label}" trips unanchored-constant`, () => {
+    const slug = `t-pat-${label.replace(/[^a-z]+/gi, '-')}`;
+    const result = validateStory(slug, [criterion]);
+    const found = unanchored(result);
+    assert.equal(
+      found.length,
+      1,
+      `expected pattern "${label}" to trip on: ${criterion}`,
+    );
+  });
+}
+
+// ---------------------------------------------------------------------------
+// No false positives on benign prose
+// ---------------------------------------------------------------------------
+
+test('benign acceptance criteria with no config-constant phrase produce no finding', () => {
+  const result = validateStory('t-benign', [
+    'the function returns a sorted list',
+    'an invalid input throws a ValidationError',
+    'the parser handles an empty body',
+  ]);
+  assert.deepEqual(unanchored(result), []);
+});
+
+test('a digit anywhere in the criterion suppresses the finding (5 req/s, 30 minutes)', () => {
+  const result = validateStory('t-digits', [
+    'inbound calls obey the rate limit of 5 req/s',
+    'each session expires after a 30 minute timeout',
+    'enforces a max of 100 requests per tenant',
+  ]);
+  assert.deepEqual(unanchored(result), []);
+});
+
+// ---------------------------------------------------------------------------
+// Multiple offending criteria each surface independently
+// ---------------------------------------------------------------------------
+
+test('each offending criterion produces its own finding', () => {
+  const result = validateStory('t-multi', [
+    'purges rows beyond the retention window',
+    'inbound calls obey the rate limit',
+    'the request aborts on timeout',
+  ]);
+  assert.equal(unanchored(result).length, 3);
+});


### PR DESCRIPTION
Closes #3855

_Auto-opened by `/single-story-deliver`._