### PR TITLE
docs(roadmap): frontier-model review — restructure, calibrate, reconcile shipped cutovers

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,7 +1,7 @@
 # Mandrel Roadmap
 
-> **Not a scheduled roadmap.** This file consolidates Mandrel's two standing
-> forward-looking analyses into one place. Neither is a committed plan — both
+> **Not a scheduled roadmap.** This file consolidates Mandrel's standing
+> forward-looking analyses into one place. None is a committed plan — all
 > are deferred-work catalogs, preserved so the analysis is not lost. Work
 > graduates out of here when it is filed as an epic.
 >
@@ -10,10 +10,17 @@
 > - **Part 2 — Product-Readiness Backlog** catalogs what would be required *if
 >   and when* Mandrel is productized for external customers; it is gated on a
 >   "productize or stay internal?" decision and blocks no internal use today.
+> - **Part 3 — Dynamic-Workflow Orchestration** is the durable home for the
+>   orchestrated-audit evidence and the per-lens cost/precision gate verdicts.
+> - **Part 4 — Frontier-Model Calibration (2026-06-09)** re-prices Part 1's
+>   🔭 Monitor items now that a frontier-tier model is the daily driver, and
+>   scopes the **story-size recalibration** for epic planning/decomposition —
+>   the highest-leverage "tackle now" cluster.
 
 ## Part 1 — Model-Evolution Audit: Mandrel Under a 10x Coding Model
 
-Date: 2026-05-21 (last reviewed 2026-05-21)
+Date: 2026-05-21 (last reviewed 2026-06-09 — frontier-model review; action
+tags below were re-priced, see [Part 4 § 4.1](#41-re-priced-action-tags-for-part-1-findings))
 
 > **Action legend.** Each finding below carries one of two action tags:
 >
@@ -183,27 +190,7 @@ Remaining recommendation (Monitor):
   feasible (the capsules already carry the non-negotiables; building new
   validators is the deliberate non-scope tail of this finding).
 
-#### 4. Per-Task Ritual and Commit Strategy Can Relax
-
-**Status:** Resolved — Epic #3078
-**Action:** ✅ Closed — Epic #3078 collapsed the Task layer into a
-single Story-implementation phase
-(Epic → Feature → Story with inline `acceptance[]` / `verify[]` on the
-Story body). `task-commit.js`, the per-Task `agent::*` lifecycle, the
-`(resolves #<taskId>)` commit convention, and the per-Task sub-loop in
-`/story-deliver` are gone. See
-[`decisions.md` § ADR 20260527-three-tier-hierarchy](decisions.md) for
-the rationale and Consequences.
-
-The original finding (one-commit-per-Task multiplies churn; stronger
-holistic editing justifies fewer commits per Story while keeping
-Story-level boundaries and close validation) is now structurally
-enforced: Stories are the unit of commit boundaries, branch assertions,
-conventional-commit checks, and close validation all operate at the
-Story tier, and `quality:preview` runs once before commit rather than
-per-Task.
-
-#### 5. Sub-Agent Return Repair Can Shrink Substantially
+#### 4. Sub-Agent Return Repair Can Shrink Substantially
 
 **Status:** Simplify
 **Action:** ✅ **Shipped (free-form extraction deleted)** — Story
@@ -255,12 +242,19 @@ Shipped (this finding's deletion):
 - Malformed terminal returns are now treated as rare protocol errors routed
   to reconciliation, not a normal recovery path.
 
-#### 6. Code Review Should Become Evidence-First, Not Ritual-First
+#### 5. Code Review Should Become Evidence-First, Not Ritual-First
 
 **Status:** Reframe
-**Action:** 🔭 Monitor — adaptive review-depth selection is most valuable
-once the model can reliably judge "this diff is risky." Keep the structured
-`code-review` comment contract as-is until then.
+**Action:** 🚀 **Implement now** (re-priced 2026-06-09, was 🔭 Monitor) —
+the model-capability gate is met, and the harness side is cheaper than this
+finding originally assumed: the planner-side risk classifier
+(`lib/orchestration/planning-risk.js`, Epic #2649) already computes a
+per-Epic risk envelope (`axes`, `overallLevel`, `requiresReview`) that
+`code-review.js` does not consult. Reuse it to select review depth rather
+than building a new classifier. This lands naturally **together with** the
+story-size recalibration (Part 4): larger Stories mean larger diffs, which
+is exactly when adaptive depth pays for itself. Keep the structured
+`code-review` comment contract unchanged.
 
 **Primary paths:**
 
@@ -281,7 +275,7 @@ Recommendation:
 - Let the future model perform review directly, then validate that required
   sections, severities, and changed-file coverage exist.
 
-#### 7. Worktree and Branch Isolation Still Matter
+#### 6. Worktree and Branch Isolation Still Matter
 
 **Status:** Keep
 **Action:** 🔭 Monitor — the "Simplify" sublist (demote local worktrees to
@@ -314,7 +308,7 @@ Simplify:
   local worktrees an implementation option rather than the default mental model.
 - Keep the abstraction but reduce operator-facing worktree prose.
 
-#### 8. Anti-Thrashing and FinOps Should Be Softer
+#### 7. Anti-Thrashing and FinOps Should Be Softer
 
 **Status:** Simplify
 **Action:** 🔭 Monitor — further relaxation of per-turn FinOps rituals
@@ -366,9 +360,9 @@ These remain useful but should become smaller:
 3. **Code review**: adaptive evidence-first review with structured findings,
    not a mandatory identical six-pillar ritual every time.
 4. **Telemetry**: keep aggregate signals; reduce control-flow dependence on
-   friction counters.
-5. **Per-Task execution**: preserve close-validation and state tracking, but
-   allow Story-level batching when Tasks are tightly coupled.
+   friction counters. (Numeric step limits and `friction.*` thresholds are
+   already gone from `lib/config/limits.js`; the remainder is keeping it
+   that way as new signals land.)
 
 ### Functionality That Should Stay
 
@@ -453,12 +447,9 @@ every reasoning step.
 
 ### Migration Roadmap
 
-The audit's original five-phase roadmap is largely complete: adaptive
-planning (Epic #2649), structured context envelopes (Epic #2648), skill
-index + policy capsules (Epic #2647), schema-backed docs (Epic #2645),
-hard-cutover compatibility cleanup (Epic #2646), and adaptive audit
-selection (Epic #2586) have all shipped. The remaining forward-looking
-work clusters into two areas:
+The audit's original five-phase roadmap has shipped (Epics #2649, #2648,
+#2647, #2646, #2645, #2586). The remaining forward-looking work clusters
+into three areas:
 
 #### Reduce Prompt Weight Further
 
@@ -480,7 +471,14 @@ work clusters into two areas:
   chat-relay-instruction trim is still open.
 - Make code-review depth adaptive to diff risk (Finding #6).
 - Treat anti-thrashing / FinOps as observability rather than control
-  flow when inference economics permit (Finding #8).
+  flow when inference economics permit (Finding #7).
+
+#### Recalibrate Decomposition Scope (added 2026-06-09)
+
+- Raise the per-Story sizing ceilings and make them risk-adaptive so a
+  frontier-tier model can deliver capability-sized Stories instead of
+  module-sized ones — see [Part 4 § 4.2–4.4](#42-where-the-small-story-bias-comes-from-measured-2026-06-09)
+  for the measured bias map and the candidate epic.
 
 ### Priority Recommendations
 
@@ -546,8 +544,10 @@ theoretical. Until then, the static lint is the supported surface.
 
 ## Part 2 — Product-Readiness Backlog (If/When Mandrel Is Productized)
 
-Last triaged: 2026-06-02 (distribution & onboarding slice filed — see below;
-prior triage 2026-05-30 against framework version 1.40.0).
+Last triaged: 2026-06-09 against framework version 1.54.0 (status refresh:
+all filed epics from the 2026-05-30 and 2026-06-02 triages have **delivered**
+except [#3439](https://github.com/dsj1984/mandrel/issues/3439), which remains
+the sole open in-flight item; prior triages 2026-06-02 and 2026-05-30).
 
 Scope: this document is the **standing backlog** of product-readiness gaps that
 Mandrel would need to close *if and when it is productized* (sold or distributed
@@ -562,37 +562,23 @@ GitHub-first** framework that is dogfooded. Everything below is **deferred until
 a "productize" decision** — none of it blocks internal use. Each item is
 grouped under the candidate epic that would carry it.
 
-### Already filed (do not re-scope here)
+### Already delivered (do not re-scope here)
 
-A 2026-05-30 triage carved the immediately-actionable, internally-valuable work
-into four epics. The slices noted as "filed" below live there:
+Two triages (2026-05-30 and 2026-06-02) carved the immediately-actionable,
+internally-valuable slices into nine epics. **Eight have delivered**
+(all closed 2026-06-05): #3386 (truth & correctness), #3387 (3-tier doc
+cutover), #3388 (config integrity), #3389 (dev-hygiene), #3435
+(`mandrel doctor` + installer/content partition), #3436 (npm distribution —
+supersedes E-B's core), #3437 (auto-update & version lifecycle), #3438
+(consent-first install & onboarding). The sole open filed epic is
+[#3439](https://github.com/dsj1984/mandrel/issues/3439) — GitHub-optional /
+no-mutation (lite) profile, re-scoped 2026-06-03 to include the
+provider-interface segregation slice.
 
-| Epic | Covers | Filed from findings |
-|------|--------|---------------------|
-| [#3386](https://github.com/dsj1984/mandrel/issues/3386) — truth & correctness | license → MIT, Node floor, dangling CHANGELOG ref | 4, 8, 18 (ref) |
-| [#3387](https://github.com/dsj1984/mandrel/issues/3387) — 3-tier doc cutover | scrub stale "Task" concepts | 7 |
-| [#3388](https://github.com/dsj1984/mandrel/issues/3388) — config integrity | `.agentrc.local.json` layer, token-budget honesty | 6 (core) |
-| [#3389](https://github.com/dsj1984/mandrel/issues/3389) — dev-hygiene | Windows CI smoke, SHA-pin Actions | 9 (Windows), 14 (SHA-pin) |
-
-Findings 4, 7, 8 are fully resolved by the above and are **not** repeated below.
-Findings 6, 9, 14, 18 were partially filed; only their deferred remainders
-appear here.
-
-A 2026-06-02 triage filed the **distribution-and-onboarding slice** — the
-internally-valuable remainder of E-B plus the install-experience findings —
-into five epics:
-
-| Epic | Covers | Filed from findings |
-|------|--------|---------------------|
-| [#3435](https://github.com/dsj1984/mandrel/issues/3435) — installer/content partition + `mandrel doctor` | lifecycle/runtime split, readiness command, config-explain seed | 11 (doctor) |
-| [#3436](https://github.com/dsj1984/mandrel/issues/3436) — npm distribution + dep simplification | **supersedes E-B**: npm package, `mandrel sync`, kill the dep-merge hack, release integrity, compat matrix | 3, 18 (remainder) |
-| [#3437](https://github.com/dsj1984/mandrel/issues/3437) — auto-update & version lifecycle | `mandrel update`, migration runner, notify-on-stale, Renovate/Dependabot, config-compat tests | 11 (config migrations), 18 (remainder) |
-| [#3438](https://github.com/dsj1984/mandrel/issues/3438) — consent-first install & onboarding | dry-run manifest, phased approval, uninstall/rollback, config profiles, `/onboard` first-run path | 10, 11 (profiles), 16 |
-| [#3439](https://github.com/dsj1984/mandrel/issues/3439) — GitHub-optional / no-mutation profile | Issues-only lite mode; no Projects/branch-protection mutation | 10 (no-mutation), 2 (partial) |
-
-**E-B is fully filed** (see #3436/#3437). Findings 10, 11, 16 and the
-Projects/branch-protection slice of Finding 2 were partially filed; their
-deferred remainders appear under E-A/E-D/E-F below.
+Findings 3, 4, 7, 8 are fully resolved by the delivered epics and do not
+appear below. Findings 2, 6, 9, 10, 11, 14, 16, 18 were partially filed;
+only their **deferred remainders** appear below — the "filed slice" notes
+on each finding record where the delivered portion went.
 
 ---
 
@@ -715,58 +701,19 @@ produced a leakage map worth recording before any portability work is scoped:
 
 ### Candidate epic E-B — Distribution & release productization
 
-**Findings:** 3, 18 (remainder).
-
-> **Status: filed (2026-06-02).** The internally-valuable core graduated to
-> [#3436](https://github.com/dsj1984/mandrel/issues/3436) (npm distribution +
-> dependency simplification — supersedes Finding 3 and the
-> create-mandrel-versioning / release-integrity / compat-matrix direction) and
-> [#3437](https://github.com/dsj1984/mandrel/issues/3437) (auto-update
-> lifecycle — migration runner, cross-version config-compat tests, rollback /
-> upgrade messaging from the Finding 18 remainder). The detail below is
-> retained as the filed work's source analysis. Still gated on the productize
-> decision (paid-support remainder of Finding 18): a formal version/support
-> policy, deprecation policy, and operator-facing release notes beyond
-> commit-derived changelog entries.
-
-#### Finding 3 — Distribution is not productized
-
-Evidence (point-in-time, **resolved by #3436** — the framework now ships as
-the `@mandrelai/agents` npm package and is no longer distributed via the
-`dist`-branch submodule):
-
-- Root `package.json` had no `bin`, `files`, `publishConfig`, or `workspaces`,
-  and empty `description`/`keywords`/`author` (at the time the framework repo
-  was distributed via the `dist`-branch submodule, not a published package).
-- `create-mandrel/package.json` is version `0.0.0` and is not a root workspace.
-- `create-mandrel/index.js` hardcodes `https://github.com/dsj1984/mandrel.git`.
-- `.github/workflows/ci.yml` then "published" only by copying `.agents/` to the
-  `dist` branch; it did not publish npm packages.
-
-Remediation direction:
-
-- Choose a productized channel: npm package(s), signed release archives,
-  Homebrew/winget, or a hosted CLI updater.
-- Bring `create-mandrel` into the release/versioning model (non-zero version).
-- Add root package metadata + documented install/update/uninstall flows.
-- Provide release integrity: checksums, provenance/SLSA, signed tags, a
-  compatibility matrix.
+**Finding:** 18 (remainder). Finding 3 (distribution not productized) is
+fully resolved — #3436 ships the framework as the `@mandrelai/agents` npm
+package and #3437 covers the update lifecycle.
 
 #### Finding 18 (remainder) — Release process is not ready for paid support
 
-Filed slice: the dangling `docs/upgrade-guide-3-tier.md` reference → #3386.
+Context: `release-please` manages the root package version, and major bumps
+are intentionally capped (`always-bump-minor`).
 
-Deferred remainder:
-
-- `release-please` manages the root package version (`package.json` +
-  `.release-please-manifest.json`); major bumps
-  are intentionally capped (`always-bump-minor`). (The former `dist` sync that
-  copied `.agents/` after main merge is retired — #3436 publishes the
-  `@mandrelai/agents` npm package instead.)
-- Paid products additionally need: a formal version/support policy, deprecation
-  policy, rollback guidance, cross-version config-compatibility tests, automated
-  migration checks for breaking changes, and operator-facing release notes
-  (beyond commit-derived changelog entries).
+Deferred remainder (productize-gated): a formal version/support policy,
+deprecation policy, rollback guidance, and operator-facing release notes
+beyond commit-derived changelog entries. (Cross-version config-compat tests
+and automated migration checks shipped with #3437.)
 
 ---
 
@@ -863,11 +810,12 @@ actuals; policy controls for model selection, concurrency, retry ceilings.
 Filed slice: SHA-pinning GitHub Actions → #3389.
 
 Existing positives: CI runs `npm audit` + TruffleHog; `.npmrc` sets
-`ignore-scripts=true`.
+`ignore-scripts=true`; npm releases publish with signed Sigstore provenance
+(`publishConfig.provenance: true`, via #3436).
 
 Deferred remainder (procurement gates): no `SECURITY.md`, vulnerability-
-disclosure process, SBOM, dependency-license report, signed releases/provenance,
-or enterprise data-handling documentation. Add these plus a hardening guide and
+disclosure process, SBOM, dependency-license report, or enterprise
+data-handling documentation. Add these plus a hardening guide and
 documented data flows / token scopes / retention / redaction.
 
 #### Finding 15 — No hosted or multi-user control plane
@@ -949,8 +897,9 @@ tests.
    narrow" tension.
 2. **E-A portability** — the biggest scope multiplier; decide runtime/ticketing
    neutrality early because it shapes everything else.
-3. **E-C QA harness** — parallel product build. (**E-B distribution is now
-   filed** — see #3436 / #3437.)
+3. **E-C QA harness** — parallel product build. (**E-B distribution
+   delivered** — #3436 / #3437; only the Finding 18 paid-support remainder
+   is left under E-B.)
 4. **E-D enterprise** and **E-E platform matrix** — gate on first enterprise
    prospect.
 
@@ -1093,3 +1042,159 @@ on a host below the 2.1.154 floor, `selectAuditStrategy` returns `sequential`
 and the lens markdown runs turn-by-turn against the identical report
 contract. This is verified by `tests/dynamic-workflow-capability.test.js` and
 the per-lens report-contract conformance tests under `tests/contract/`.
+
+### 3.3 Remaining orchestration surface (added 2026-06-09)
+
+Seven audit lenses are still **sequential-only** with no
+`.claude/workflows/*.workflow.js` artifact: `audit-dependencies`,
+`audit-devops`, `audit-sre`, `audit-privacy`, `audit-seo`, `audit-ux-ui`,
+`audit-lighthouse`. That is not a backlog by default — several are
+externally bound (`audit-lighthouse` drives a browser; `audit-seo` /
+`audit-ux-ui` are page-walk-shaped) or not cleanly dimensionally
+decomposable, so sequential may stay the *correct* default. Any
+generalization must clear the same § 3.2 per-lens cost/precision gate, lens
+by lens; do not batch-convert.
+
+Beyond audits, `runAuditOrchestration`'s fan-out → adversarial cross-check →
+synthesis shape has one obvious next application: **epic-plan
+decomposition** (parallel per-Feature Story drafting + an adversarial
+consolidation pass). That candidate is scoped in
+[Part 4 § 4.5](#45-orchestration-beyond-audits-spike-candidate) rather than
+here, because its payoff is coupled to the story-size recalibration.
+
+## Part 4 — Frontier-Model Calibration: Story Scope & Decomposition
+
+Recorded: 2026-06-09, against framework version 1.54.0.
+
+Part 1 was written against a hypothetical: "what changes when the model is
+~10x stronger?" This part records the first review run **on** a
+frontier-tier model rather than in anticipation of one. Two outputs:
+
+1. A re-pricing of Part 1's 🔭 Monitor tags whose stated gate ("a materially
+   stronger model") is now met (§ 4.1).
+2. A measured map of why Stories come out small in scope today, and a
+   candidate epic to recalibrate decomposition so the planner emits
+   **capability-sized** Stories a frontier model can deliver in one pass
+   (§ 4.2–4.4). This is the operator-reported pain point and the
+   highest-leverage cluster in this part.
+
+### 4.1 Re-priced action tags for Part 1 findings
+
+| Finding | Old tag | New tag (2026-06-09) | Rationale |
+| ------- | ------- | -------------------- | --------- |
+| #3 — hydrator default flip (skill bodies) | 🔭 Monitor | 🚀 **Filed** — Story [#3863](https://github.com/dsj1984/mandrel/issues/3863) | Gate ("model can self-select context") is met; capsules + `skills.index.json` shipped under Epic #2647. Sized as **one standalone Story**: hard cutover, no opt-in flag, no new validators. |
+| #4 — sub-agent return repair shrink | 🔭 Monitor | 🚀 **Filed** — Story [#3864](https://github.com/dsj1984/mandrel/issues/3864) | Sized as **one standalone Story**, evidence-gated with no staging flag: measure malformed-return rate from existing friction records, then hard-cutover delete (reconciliation already backstops) or documented no-go. |
+| #5 — adaptive code-review depth | 🔭 Monitor | 🚀 **Implement now** | Reuse the existing `planning-risk.js` envelope instead of a new classifier; pairs with the story-size recalibration (bigger diffs need depth selection) — carried inside the § 4.3 candidate epic. |
+| #2 — personas → review checklists | 🔭 Monitor | 🔭 Monitor (**next up**) | Sequence after #3: the hydrator flip changes how much persona prose matters; measure role drift on the frontier tier before converting. |
+| #1 — instruction-surface compression | 🔭 Monitor | 🔭 Monitor | Compress opportunistically as #2/#3 land; a standalone rewrite epic is still premature. |
+| #6 — worktree/branch isolation | 🔭 Monitor | 🔭 Monitor (Keep) | Unchanged — concurrency physics, not model capability. |
+| #7 — anti-thrashing / FinOps | 🔭 Monitor | 🔭 Monitor (remainder only) | Numeric step limits already dropped from `lib/config/limits.js`; remainder waits on inference economics. |
+
+### 4.2 Where the small-story bias comes from (measured 2026-06-09)
+
+The "Stories are typically small in scope" effect is not one knob — it is
+eight mechanisms, all verified against current code. The first five are the
+primary drivers:
+
+| # | Mechanism | Kind | Where | Effect |
+| - | --------- | ---- | ----- | ------ |
+| 1 | `DEFAULT_TASK_SIZING.hardFiles: 15` — Story touching >15 files **rejected** unless it declares `wide: { reason }` | Deterministic validator | `lib/orchestration/ticket-validator-sizing.js` | Hard scope ceiling per Story |
+| 2 | `DEFAULT_TASK_SIZING.maxAcceptance: 8` — >8 acceptance criteria **rejected**, no escape hatch (soft warn at 6) | Deterministic validator | same | Hard AC ceiling per Story |
+| 3 | Feature MUST decompose into 2–5 Stories; >5 forces a sibling Feature | Deterministic validator + prompt | `ticket-validator.js`, `lib/templates/decomposer-prompts.js` | Caps Stories per Feature; widens hierarchy instead of deepening Stories |
+| 4 | `softFiles: 5` advisory width finding + the §7 "5-file rule" prose in `instructions.md` | Validator (soft) + prompt prose | `ticket-validator-sizing.js`, `.agents/instructions.md` §7 | Anchors the planner's mental model at ~5 files/Story |
+| 5 | `DELIVERABLE_GRANULARITY_GUIDANCE` — "a shippable slice a reviewer would accept as a single PR" + single-consumer merge rule | Prompt prose (SSOT constant) | `ticket-validator-sizing.js`, interpolated into decomposer prompt | Conceptual definition sized for *today's* review comfort, not frontier delivery capacity |
+| 6 | `maxTickets: 60` reviewability budget — "combine atomic stories into larger, cohesive stories before splitting" | Prompt prose (soft) | `lib/config/limits.js` + decomposer prompt | Attacks story *count*, already aligned with larger stories |
+| 7 | Planning-context budget (`maxBytes: 50000`) summarizes PRD/Tech Spec before decomposition | Deterministic | `lib/orchestration/planning-context-budget.js` | Less spec detail → more conservative slicing |
+| 8 | `delivery.maxTokenBudget: 200000` hydration cap per Story | Deterministic | `lib/config/limits.js` | Large Story bodies risk section elision at delivery time |
+
+Two structural facts make the recalibration cheap:
+
+- **The constants are SSOT and prompt-synced.** The decomposer prompt
+  interpolates `DEFAULT_TASK_SIZING` values rather than hardcoding them, so
+  raising a ceiling automatically updates the guidance the planner reads.
+- **The risk classifier already exists but is not consulted for sizing.**
+  `planning-risk.js` computes the per-Epic envelope and it is already
+  threaded into decomposition context — the decomposer just never reads it
+  when sizing Stories.
+
+**Recent work already moved the count axis.** v1.54.0 shipped a cluster
+that recognized the over-slicing problem: #3764 collapsed the
+decomposition-sizing profile matrix, #3781 forbade single-Story Features
+and anchored "deliverable granularity," #3799 added a holistic
+consolidation pass to Phase 8 decompose, and #3858 grouped Stories by
+capability rather than execution shape. Those reduce story *count*; the
+per-Story *scope* ceilings (#1–#4 above) are untouched and are now the
+binding constraint.
+
+### 4.3 Candidate epic — risk-adaptive story sizing (🚀 Implement now)
+
+One coordinated change, in decomposer + validator + delivery envelope, with
+one dogfood epic as the calibration fixture:
+
+1. **Raise the per-Story ceilings.** Suggested starting points (calibrate
+   during epic planning, don't copy blindly): `softFiles` 5 → 8,
+   `hardFiles` 15 → 30, `softAcceptanceCount` 6 → 10, `maxAcceptance`
+   8 → 14, Feature max Stories 5 → 7. Keep `wide` as the beyond-ceiling
+   escape hatch. Because the constants are SSOT, this is a small diff —
+   the work is calibration, not plumbing.
+2. **Make sizing risk-adaptive.** Have the decomposer read the
+   already-present `planningRisk` envelope: high-risk axes (security,
+   data-migration, destructive-mutation, billing, public-api) keep today's
+   tight thresholds (smaller, more reviewable Stories); low-risk axes
+   (internal-refactor, test-harness, docs-only) get the relaxed profile.
+   This preserves the original rationale for small stories — review safety
+   — exactly where it matters, instead of everywhere.
+3. **Re-anchor the granularity prose.** Rewrite
+   `DELIVERABLE_GRANULARITY_GUIDANCE` and the §7 "5-file rule" framing in
+   `instructions.md` around the capability tier: a Story is a coherent
+   capability slice the model delivers and self-verifies in one pass; the
+   *Feature* is the review conversation unit. Drop the implicit
+   "atomic = good" framing.
+4. **Thread delivery constraints into planning.** Pass
+   `delivery.maxTokenBudget` and any `delivery.preflight.*` ceilings into
+   decomposer context so the planner sizes Stories against the actual
+   delivery envelope instead of discovering breaches post-hoc at preflight.
+5. **Scale the delivery envelope to match.** Larger Stories must not be
+   silently clipped: raise `maxTokenBudget` for relaxed-profile Stories (or
+   scale it off the sizing profile), and lean on the bounded per-Story
+   acceptance self-eval loop (#3820) — it becomes more load-bearing as
+   ACs-per-Story rise.
+
+**Verification fixture.** Plan the same Epic body under old and new
+profiles and compare: Stories emitted, files/Story, ACs/Story, wave count,
+and (after delivery) rework signals and review findings per Story. The
+hypothesis to confirm: fewer waves and less cross-Story coordination
+overhead at equal-or-better review outcomes.
+
+### 4.4 Guardrails that must NOT relax
+
+- **Worktree/branch isolation and the wave model stay as-is** (Part 1
+  Finding #6) — larger Stories increase per-Story wall-clock, which the
+  existing concurrency cap already governs.
+- **Hard ceilings stay hard** — they move up; they do not become advisory.
+  `wide` remains the only beyond-ceiling path and keeps requiring a reason.
+- **Adaptive review depth lands with, not after, larger stories** (Finding
+  #5) — a 30-file Story with fixed-depth review is strictly worse than
+  today; the two changes are one logical unit.
+- **High-risk axes keep small stories.** The recalibration is conditional
+  relaxation, not a global loosening; `rules/security-baseline.md`
+  inviolability is untouched.
+
+### 4.5 Orchestration beyond audits (spike candidate)
+
+**Status:** 🔭 Monitor — spike-sized, sequenced after § 4.3.
+
+The Part 3 pattern (parallel fan-out → adversarial cross-check →
+synthesis) maps onto **epic-plan decomposition**: draft Stories per Feature
+in parallel sub-agents, then run an adversarial consolidation pass that
+applies the single-consumer merge rule, capability grouping (#3858), and
+the holistic consolidation checks (#3799) across the whole plan at once.
+Today's Phase-8 consolidation runs in one context; a fan-out version would
+trade tokens for plan quality the same way the audit lenses do.
+
+Hold it to the same discipline as Part 3: a measured cost/precision gate
+(plan-quality delta vs token multiple) before it becomes a default, and the
+sequential path remains the capability-degraded fallback. Do **not** start
+this before § 4.3 lands — decomposition quality should be re-baselined on
+the new sizing profile first, since over-slicing is currently the dominant
+plan defect and may disappear without orchestration.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -14,8 +14,9 @@
 >   orchestrated-audit evidence and the per-lens cost/precision gate verdicts.
 > - **Part 4 — Frontier-Model Calibration (2026-06-09)** re-prices Part 1's
 >   🔭 Monitor items now that a frontier-tier model is the daily driver, and
->   scopes the **story-size recalibration** for epic planning/decomposition —
->   the highest-leverage "tackle now" cluster.
+>   scopes the **story-size recalibration** for epic planning/decomposition.
+>   Its "tackle now" cluster has graduated: Stories #3863/#3864 shipped and
+>   the recalibration is filed as Epic #3865 (§ 4.3).
 
 ## Part 1 — Model-Evolution Audit: Mandrel Under a 10x Coding Model
 
@@ -129,6 +130,17 @@ Specific simplifications:
 - Keep security and destructive-action constraints strict; these represent
   operator risk appetite, not model capability.
 
+Carried tails (open remainders of findings that shipped and were deleted
+per the numbering convention):
+
+- Push remaining stack-specific non-negotiables into validators or lint
+  checks rather than skill prose — the capsule-only hydration cutover
+  (Story #3863) deliberately did not build new validators; capsules carry
+  the non-negotiables for now.
+- Trim chat-relay instructions in `epic-deliver.md` / `story-deliver.md`
+  now that the canonical progress surface is a structured comment — the
+  open remainder of the return-extraction deletion (Story #3864).
+
 #### 2. Persona Files Become Advisory, Not Routing-Critical
 
 **Status:** Simplify
@@ -157,104 +169,18 @@ Recommendation:
   implementation task.
 - Preserve security and release personas as optional high-risk review modes.
 
-#### 3. Skill Library — Stop Hydrating Full Bodies by Default
-
-**Status:** Shipped (capsule-only cutover) — Story #3863
-**Action:** ✅ **Done (skill-loading half)** — the hydrator now emits only
-the Policy Capsule per selected skill (non-negotiables + a `Read <path>`
-pointer to the full `SKILL.md`); no full skill body is ever inlined into a
-task prompt. Per the hard-cutover policy in
-[`git-conventions.md`](../.agents/rules/git-conventions.md), Story #3863
-**deleted** the full-body injection branch, the `fullSkillBodies` config
-flag (schema + resolver), and the `skill::full` label handling in one pass —
-there is no compatibility flag, label, or dual path. The remaining
-validator-coverage tail (push stack-specific non-negotiables into validators
-/ lint checks) stays 🔭 **Monitor**.
-
-**Primary paths:**
-
-- `.agents/scripts/lib/orchestration/context-hydration-engine.js`
-- `.agents/scripts/lib/orchestration/skill-capsule-loader.js`
-- `.agents/skills/skills.index.json`
-- `.agents/skills/stack/`
-
-The skill library ships a generated manifest (`skills.index.json`) and a
-Policy Capsule per skill, so selection is cheap; the behavioral cut-over
-inside the hydrator landed in Story #3863. The only residual full-body
-emission is the defensive fallback when a `SKILL.md` is missing its capsule
-marker (a malformed manifest), which also logs a warning.
-
-Remaining recommendation (Monitor):
-
-- Move stack-specific non-negotiables into validators or lint checks where
-  feasible (the capsules already carry the non-negotiables; building new
-  validators is the deliberate non-scope tail of this finding).
-
-#### 4. Sub-Agent Return Repair Can Shrink Substantially
-
-**Status:** Simplify
-**Action:** ✅ **Shipped (free-form extraction deleted)** — Story
-[#3864](https://github.com/dsj1984/mandrel/issues/3864) (2026-06-09).
-Evidence-gated hard cutover: the malformed-terminal-return rate measured
-from existing friction records (`renderMalformedReturnsFriction` per-wave
-occurrences + `friction` structured comments) across the last delivered
-Epics (#3823, #3798, #3780/#3763/#3744, #3686) was **zero** —
-`malformed-subagent-return` was never posted, and the friction signals that
-did fire were unrelated categories (e.g. `reap-failure`). With the rate at
-~zero, the four free-form extraction candidates (`starts-with-{`, fenced
-```json``` block, balanced-`{...}`-substring scan) and their dedicated tests
-were deleted in one cutover (no flag, no staged legacy path). Schema
-validation and GitHub-state reconciliation are retained unchanged; a
-malformed terminal return now routes directly to reconciliation plus a
-friction record — the stronger backstop that already caught everything the
-heuristics caught.
-
-Still open (separate Finding #4 sub-item, **not** shipped by #3864):
-reduce chat-relay instructions in `epic-deliver.md` / `story-deliver.md`
-now that the canonical progress surface is a structured comment.
-
-**Primary paths:**
-
-- `.agents/scripts/lib/orchestration/epic-runner/sub-agent-return.js`
-- `.agents/scripts/lib/orchestration/wave-record-projection.js`
-- `.agents/scripts/epic-execute-record-wave.js`
-- `.agents/workflows/epic-deliver.md`
-- `.agents/workflows/story-deliver.md`
-
-The sub-agent return parser existed because earlier sub-agents sometimes
-returned plain prose, partial status, or malformed JSON after doing real
-work. On the current model tier, structured-output compliance is reliable
-enough that the prose-wrapped extraction layer never fired across the
-sampled Epics, so it was removed.
-
-Kept (permanent):
-
-- Schema validation of returned envelopes.
-- Conservative reconciliation from GitHub state when a child result is missing
-  or inconsistent.
-- Friction reporting when a child violates the contract.
-
-Shipped (this finding's deletion):
-
-- Replaced the free-form JSON extraction heuristics with a single
-  structured-output contract: `parseStoryAgentReturn` now accepts only an
-  already-parsed object or a return string that is pure JSON.
-- Malformed terminal returns are now treated as rare protocol errors routed
-  to reconciliation, not a normal recovery path.
-
-#### 5. Code Review Should Become Evidence-First, Not Ritual-First
+#### 3. Code Review Should Become Evidence-First, Not Ritual-First
 
 **Status:** Reframe
-**Action:** 🚀 **Implement now** (re-priced 2026-06-09, was 🔭 Monitor) —
-the model-capability gate is met, and the harness side is cheaper than this
-finding originally assumed: the planner-side risk classifier
-(`lib/orchestration/planning-risk.js`, Epic #2649) already computes a
-per-Epic risk envelope (`axes`, `overallLevel`, `requiresReview`) that
-`code-review.js` does not consult. Reuse it to select review depth rather
-than building a new classifier. This lands naturally **together with** the
-story-size recalibration (Part 4): larger Stories mean larger diffs, which
-is exactly when adaptive depth pays for itself. Keep the structured
-`code-review` comment contract unchanged.
+**Action:** 🚀 **Filed** — carried inside Epic
+[#3865](https://github.com/dsj1984/mandrel/issues/3865) (Story
+`s-risk-rigor`, 2026-06-09). Review depth is selected from the per-Epic
+risk envelope — which #3865 also reworks from regex keyword-matching to a
+planner-supplied, schema-validated verdict (`planning-risk.js`'s
+`AXIS_RULES` regex is deleted; the pure gate-derivation helpers stay).
+The judged envelope routes code-review depth AND post-delivery audit
+lenses. The structured `code-review` comment contract is unchanged.
+This finding is updated to shipped-state when #3865 closes.
 
 **Primary paths:**
 
@@ -275,7 +201,7 @@ Recommendation:
 - Let the future model perform review directly, then validate that required
   sections, severities, and changed-file coverage exist.
 
-#### 6. Worktree and Branch Isolation Still Matter
+#### 4. Worktree and Branch Isolation Still Matter
 
 **Status:** Keep
 **Action:** 🔭 Monitor — the "Simplify" sublist (demote local worktrees to
@@ -308,7 +234,7 @@ Simplify:
   local worktrees an implementation option rather than the default mental model.
 - Keep the abstraction but reduce operator-facing worktree prose.
 
-#### 7. Anti-Thrashing and FinOps Should Be Softer
+#### 5. Anti-Thrashing and FinOps Should Be Softer
 
 **Status:** Simplify
 **Action:** 🔭 Monitor — further relaxation of per-turn FinOps rituals
@@ -338,15 +264,13 @@ Recommendation:
 
 ### Functionality Likely Obsolete With a 10x Model
 
-These should be removed or made opt-in once future-model assumptions hold:
+These should be removed or made opt-in once future-model assumptions hold
+(the skill-hydration and return-extraction entries that used to live here
+shipped — Stories #3863 / #3864 — and were removed):
 
-1. **Mandatory full skill/persona hydration** for common tasks. Replace with
-   compact policy capsules and on-demand deep docs. (Skill hydration is now
-   capsule-only with a `Read <path>` pointer — Story #3863 shipped that flip;
-   the parallel persona-hydration cut is Finding #2.)
-2. **Free-form sub-agent JSON extraction heuristics.** Keep schema validation
-   and GitHub reconciliation; drop the assumption that malformed returns are
-   common.
+1. **Mandatory full persona hydration** for common tasks. Replace with
+   concise role lenses and on-demand deep docs — the persona-side parallel
+   of the shipped capsule-only skill cutover (Finding #2).
 
 ### Functionality Greatly Simplified
 
@@ -453,32 +377,27 @@ into three areas:
 
 #### Reduce Prompt Weight Further
 
-- ✅ **Shipped (Story #3863).** The hydrator now loads capsule-only:
-  manifest-driven skill selection emits the Policy Capsule plus a
-  `Read <path>` pointer, and the full-body path / `fullSkillBodies` flag /
-  `skill::full` label were deleted in a hard cutover (Finding #3).
 - Push remaining stack-specific non-negotiables into validators or lint
-  checks rather than skill prose (Finding #3, validator-coverage tail).
+  checks rather than skill prose (carried tail of the shipped capsule-only
+  cutover, Story #3863 — see Finding #1).
+- Trim chat-relay instructions in `epic-deliver.md` / `story-deliver.md`
+  now that the canonical progress surface is a structured comment (carried
+  tail of Story #3864 — see Finding #1).
 
 #### Soften Procedural Defaults
 
 - Convert persona prose into concise review checklists (Finding #2).
-- Reduce per-Task commit ritual when Tasks are tightly coupled
-  (Finding #4).
-- ✅ Dropped the free-form sub-agent return extraction heuristics now that
-  structured-output compliance is reliable (Finding #5, Story #3864). Schema
-  validation and GitHub-state reconciliation are retained; the remaining
-  chat-relay-instruction trim is still open.
-- Make code-review depth adaptive to diff risk (Finding #6).
+- Make code-review depth adaptive to judged risk (Finding #3 — filed,
+  carried inside Epic #3865).
 - Treat anti-thrashing / FinOps as observability rather than control
-  flow when inference economics permit (Finding #7).
+  flow when inference economics permit (Finding #5).
 
 #### Recalibrate Decomposition Scope (added 2026-06-09)
 
-- Raise the per-Story sizing ceilings and make them risk-adaptive so a
-  frontier-tier model can deliver capability-sized Stories instead of
-  module-sized ones — see [Part 4 § 4.2–4.4](#42-where-the-small-story-bias-comes-from-measured-2026-06-09)
-  for the measured bias map and the candidate epic.
+- 🚀 **Filed — Epic [#3865](https://github.com/dsj1984/mandrel/issues/3865)**
+  (capability-sized Stories + model-judged risk routing). The measured bias
+  map stays in [Part 4 § 4.2](#42-where-the-small-story-bias-comes-from-measured-2026-06-09);
+  the filed scope and its two planning-time reframes are recorded in § 4.3.
 
 ### Priority Recommendations
 
@@ -1076,17 +995,23 @@ frontier-tier model rather than in anticipation of one. Two outputs:
    candidate epic to recalibrate decomposition so the planner emits
    **capability-sized** Stories a frontier model can deliver in one pass
    (§ 4.2–4.4). This is the operator-reported pain point and the
-   highest-leverage cluster in this part.
+   highest-leverage cluster in this part — since filed as Epic #3865
+   (§ 4.3).
 
 ### 4.1 Re-priced action tags for Part 1 findings
 
-| Finding | Old tag | New tag (2026-06-09) | Rationale |
-| ------- | ------- | -------------------- | --------- |
-| #3 — hydrator default flip (skill bodies) | 🔭 Monitor | 🚀 **Filed** — Story [#3863](https://github.com/dsj1984/mandrel/issues/3863) | Gate ("model can self-select context") is met; capsules + `skills.index.json` shipped under Epic #2647. Sized as **one standalone Story**: hard cutover, no opt-in flag, no new validators. |
-| #4 — sub-agent return repair shrink | 🔭 Monitor | 🚀 **Filed** — Story [#3864](https://github.com/dsj1984/mandrel/issues/3864) | Sized as **one standalone Story**, evidence-gated with no staging flag: measure malformed-return rate from existing friction records, then hard-cutover delete (reconciliation already backstops) or documented no-go. |
-| #5 — adaptive code-review depth | 🔭 Monitor | 🚀 **Implement now** | Reuse the existing `planning-risk.js` envelope instead of a new classifier; pairs with the story-size recalibration (bigger diffs need depth selection) — carried inside the § 4.3 candidate epic. |
-| #2 — personas → review checklists | 🔭 Monitor | 🔭 Monitor (**next up**) | Sequence after #3: the hydrator flip changes how much persona prose matters; measure role drift on the frontier tier before converting. |
-| #1 — instruction-surface compression | 🔭 Monitor | 🔭 Monitor | Compress opportunistically as #2/#3 land; a standalone rewrite epic is still premature. |
+> Finding numbers in this table are **point-in-time** against the audit as
+> of 2026-06-09, per the Part 1 numbering convention. The two shipped rows
+> have since been deleted from Part 1 and the survivors renumbered
+> (code review is now Finding #3, worktree #4, anti-thrashing #5).
+
+| Finding | Old tag | Outcome (as of this branch) | Rationale |
+| ------- | ------- | --------------------------- | --------- |
+| #3 — hydrator default flip (skill bodies) | 🔭 Monitor | ✅ **Shipped** — Story [#3863](https://github.com/dsj1984/mandrel/issues/3863) ([PR #3869](https://github.com/dsj1984/mandrel/pull/3869), 2026-06-09) | Gate ("model can self-select context") was met; capsule-only hard cutover landed — full-body path, `fullSkillBodies` flag, and `skill::full` label deleted in one pass. Validator-coverage tail carried in Finding #1. |
+| #4 — sub-agent return repair shrink | 🔭 Monitor | ✅ **Shipped** — Story [#3864](https://github.com/dsj1984/mandrel/issues/3864) ([PR #3868](https://github.com/dsj1984/mandrel/pull/3868), 2026-06-09) | Evidence gate passed: measured malformed-return rate across recent delivered Epics was **zero**, so the four free-form extraction candidates and their tests were deleted; schema validation + GitHub reconciliation retained. Chat-relay trim carried in Finding #1. |
+| #5 — adaptive code-review depth | 🔭 Monitor | 🚀 **Filed** — Epic [#3865](https://github.com/dsj1984/mandrel/issues/3865) (`s-risk-rigor`) | Depth selects off the risk envelope — which #3865 also reworks to a model-judged, schema-validated verdict (see § 4.3). |
+| #2 — personas → review checklists | 🔭 Monitor | 🔭 Monitor (**next up**) | Sequence after the hydrator flip's effect is measured: capsule-only hydration changes how much persona prose matters; measure role drift on the frontier tier before converting. |
+| #1 — instruction-surface compression | 🔭 Monitor | 🔭 Monitor | Compress opportunistically as #2 lands; a standalone rewrite epic is still premature. |
 | #6 — worktree/branch isolation | 🔭 Monitor | 🔭 Monitor (Keep) | Unchanged — concurrency physics, not model capability. |
 | #7 — anti-thrashing / FinOps | 🔭 Monitor | 🔭 Monitor (remainder only) | Numeric step limits already dropped from `lib/config/limits.js`; remainder waits on inference economics. |
 
@@ -1126,59 +1051,60 @@ capability rather than execution shape. Those reduce story *count*; the
 per-Story *scope* ceilings (#1–#4 above) are untouched and are now the
 binding constraint.
 
-### 4.3 Candidate epic — risk-adaptive story sizing (🚀 Implement now)
+### 4.3 Story-scope recalibration — filed as Epic #3865
 
-One coordinated change, in decomposer + validator + delivery envelope, with
-one dogfood epic as the calibration fixture:
+**Status:** 🚀 **Filed** — Epic
+[#3865](https://github.com/dsj1984/mandrel/issues/3865) "Capability-Sized
+Stories & Model-Judged Risk Routing" (2026-06-09; PRD #3866, Tech Spec
+#3867, `acceptance::n-a`; 3 Features / 6 Stories), in flight. The Epic body
+is the SSOT for scope; this section records the two operator decisions that
+**reframed** the originally-sketched candidate during planning:
 
-1. **Raise the per-Story ceilings.** Suggested starting points (calibrate
-   during epic planning, don't copy blindly): `softFiles` 5 → 8,
-   `hardFiles` 15 → 30, `softAcceptanceCount` 6 → 10, `maxAcceptance`
-   8 → 14, Feature max Stories 5 → 7. Keep `wide` as the beyond-ceiling
-   escape hatch. Because the constants are SSOT, this is a small diff —
-   the work is calibration, not plumbing.
-2. **Make sizing risk-adaptive.** Have the decomposer read the
-   already-present `planningRisk` envelope: high-risk axes (security,
-   data-migration, destructive-mutation, billing, public-api) keep today's
-   tight thresholds (smaller, more reviewable Stories); low-risk axes
-   (internal-refactor, test-harness, docs-only) get the relaxed profile.
-   This preserves the original rationale for small stories — review safety
-   — exactly where it matters, instead of everywhere.
-3. **Re-anchor the granularity prose.** Rewrite
-   `DELIVERABLE_GRANULARITY_GUIDANCE` and the §7 "5-file rule" framing in
-   `instructions.md` around the capability tier: a Story is a coherent
-   capability slice the model delivers and self-verifies in one pass; the
-   *Feature* is the review conversation unit. Drop the implicit
-   "atomic = good" framing.
-4. **Thread delivery constraints into planning.** Pass
-   `delivery.maxTokenBudget` and any `delivery.preflight.*` ceilings into
-   decomposer context so the planner sizes Stories against the actual
-   delivery envelope instead of discovering breaches post-hoc at preflight.
-5. **Scale the delivery envelope to match.** Larger Stories must not be
-   silently clipped: raise `maxTokenBudget` for relaxed-profile Stories (or
-   scale it off the sizing profile), and lean on the bounded per-Story
-   acceptance self-eval loop (#3820) — it becomes more load-bearing as
-   ACs-per-Story rise.
+- **Sizing decoupled from risk.** The original sketch had two sizing
+  profiles selected by Epic risk. Dropped: **every** Epic plans under one
+  relaxed `DEFAULT_TASK_SIZING` (suggested starting points: `softFiles`
+  5 → 8, `hardFiles` 15 → 30, `softAcceptanceCount` 6 → 10, `maxAcceptance`
+  8 → 14; Feature-count prose ≤5 → ≤7; `wide` unchanged), calibrated by an
+  A/B re-plan fixture. Story size measures uniform delivery capacity —
+  risk routes *rigor* instead. Rationale: the real promotion unit is the
+  Epic→main PR (Story size doesn't change rollback granularity at `main`),
+  and fragmenting risky work can hide cross-cutting issues a holistic
+  review would catch.
+- **Risk is model-judged; the regex is deleted.** An empirical probe showed
+  `planning-risk.js`'s keyword regex is presence-detection, not risk
+  assessment: it flags an Epic that merely *names* "billing"/"security" in
+  an Out-of-Scope line (false positive) and rates "rotate the customer
+  credential vault and re-issue all active session cookies" **low / no
+  review** (false negative — the dangerous direction). #3865 deletes
+  `AXIS_RULES` and replaces axis *production* with a planner-supplied,
+  schema-validated risk verdict recorded as a structured artifact; the
+  retained pure helpers still derive gate routing deterministically. The
+  judged envelope routes code-review depth **and** post-delivery audit
+  lenses — high-risk work gets enhanced reviews and audits, not smaller
+  Stories. Both probe control cases are locked in as a regression AC.
 
-**Verification fixture.** Plan the same Epic body under old and new
-profiles and compare: Stories emitted, files/Story, ACs/Story, wave count,
-and (after delivery) rework signals and review findings per Story. The
-hypothesis to confirm: fewer waves and less cross-Story coordination
-overhead at equal-or-better review outcomes.
+Delivery evidence (the A/B sizing fixture + the risk-verdict regression)
+lands on the Epic; this section and Part 1 Finding #3 are updated to
+shipped-state when #3865 closes.
 
 ### 4.4 Guardrails that must NOT relax
 
-- **Worktree/branch isolation and the wave model stay as-is** (Part 1
-  Finding #6) — larger Stories increase per-Story wall-clock, which the
-  existing concurrency cap already governs.
+- **Worktree/branch isolation and the wave model stay as-is** (Part 1's
+  worktree finding) — larger Stories increase per-Story wall-clock, which
+  the existing concurrency cap already governs.
 - **Hard ceilings stay hard** — they move up; they do not become advisory.
   `wide` remains the only beyond-ceiling path and keeps requiring a reason.
-- **Adaptive review depth lands with, not after, larger stories** (Finding
-  #5) — a 30-file Story with fixed-depth review is strictly worse than
-  today; the two changes are one logical unit.
-- **High-risk axes keep small stories.** The recalibration is conditional
-  relaxation, not a global loosening; `rules/security-baseline.md`
-  inviolability is untouched.
+- **Adaptive review depth lands with, not after, larger stories** (carried
+  as Story `s-risk-rigor` inside Epic #3865) — a 30-file Story with
+  fixed-depth review is strictly worse than today; the two changes are one
+  logical unit, expressed as a `depends_on` edge in the Epic's wave plan.
+- **Rigor follows risk.** *(Superseded wording — this bullet originally
+  read "high-risk axes keep small stories"; the § 4.3 decoupling decision
+  replaced conditional sizing with risk-routed rigor.)* High-risk work gets
+  deeper review and auto-run audit lenses, never silently lighter
+  treatment; the model-judged verdict is schema-validated and the harness
+  still owns the gate decision deterministically.
+  `rules/security-baseline.md` inviolability is untouched.
 
 ### 4.5 Orchestration beyond audits (spike candidate)
 
@@ -1195,6 +1121,6 @@ trade tokens for plan quality the same way the audit lenses do.
 Hold it to the same discipline as Part 3: a measured cost/precision gate
 (plan-quality delta vs token multiple) before it becomes a default, and the
 sequential path remains the capability-degraded fallback. Do **not** start
-this before § 4.3 lands — decomposition quality should be re-baselined on
-the new sizing profile first, since over-slicing is currently the dominant
-plan defect and may disappear without orchestration.
+this before § 4.3 (Epic #3865) delivers — decomposition quality should be
+re-baselined on the new sizing profile first, since over-slicing is
+currently the dominant plan defect and may disappear without orchestration.


### PR DESCRIPTION
## Why

First roadmap review run on a frontier-tier model. The doc had drifted from reality on three axes: Part 2 listed delivered epics as pending, Part 1 carried findings whose model-capability gate has now been met, and the operator-reported pain point (Stories too small in scope) had no measured analysis.

## What

- **Restructure:** intro now indexes all four parts; stale two-analyses framing fixed.
- **Part 1:** re-priced action tags for the frontier tier; deleted the findings shipped by #3863 (capsule-only skill hydration) and #3864 (free-form return-extraction deletion) per the renumbering convention, carrying their open tails into Finding #1; scrubbed resolved per-Task references.
- **Part 2:** status refresh against v1.54.0 — all filed epics delivered except #3439.
- **Part 3:** added §3.3 (remaining sequential-only lenses + the beyond-audits candidate).
- **New Part 4 — Frontier-Model Calibration:** the measured eight-mechanism map of the small-story bias (§4.2), the story-scope recalibration filed as Epic #3865 with its two planning-time reframes recorded (§4.3: sizing decoupled from risk — one uniform relaxed profile; model-judged risk verdict replacing the regex classifier, routing review depth + audit lenses), guardrails (§4.4), and the orchestration spike candidate (§4.5).

Closes the loop with: Stories #3863/#3864 (shipped), Epic #3865 (filed, in flight — its closeout Story #3878 updates this doc to shipped-state).

🤖 Generated with [Claude Code](https://claude.com/claude-code)