### PR TITLE
docs: add epic-lifecycle and install-bootstrap review reports

### DIFF
--- a/docs/epic-lifecycle-review.md
+++ b/docs/epic-lifecycle-review.md
@@ -1,0 +1,347 @@
+# Epic lifecycle code review — `/epic-plan` + `/epic-deliver`
+
+> **Date:** 2026-06-10
+> **Scope:** ~4,600 lines of workflow prose, ~23k LOC of entry-point scripts,
+> ~102k LOC under `.agents/scripts/lib/` (48k in `lib/orchestration` alone).
+> Reviewed by five parallel deep-dives (planning, wave loop, story lifecycle,
+> close-tail / lifecycle bus, prose layer). The highest-severity claims were
+> independently verified in source.
+>
+> **Remediation tracking:** GitHub Stories #3900–#3911 (see
+> [§6 Recommended sequence](#6-recommended-sequence)). All carry
+> `type::story` + `meta::framework-gap`.
+
+## TL;DR
+
+The pipeline's deterministic core — DAG/wave planning, git-probe validation,
+lease/checkout guards, the merge-recovery state machine, `evidence-gate` — is
+genuinely good. But the codebase is carrying a **dead second architecture**: an
+in-process epic-runner (bus + `WaveSession` + 19 listeners) was superseded by
+the "host LLM drives CLIs" model, and roughly **10–15k LOC of the old stratum
+is still wired in but unreachable**. Worse, **four load-bearing features
+silently died in that migration** while the docs still describe them as live.
+
+- **Deletable with zero capability loss:** ~12–15k LOC of JS and ~28% of the
+  prose layer.
+- **New code needed to make the surviving features actually work:** ~100 LOC.
+
+The framework lints itself (781 LOC across `check-lifecycle-lint.js` /
+`check-lifecycle-doc-drift.js`, a required CI check) yet none of the broken
+features below were caught, because those gates police listener-table
+**formatting** rather than **connectivity**. One contract test — *every
+schema'd event has ≥1 production emitter and ≥1 production subscriber* — would
+have caught most of §1.
+
+---
+
+## 1. Verified broken-by-construction defects
+
+Each was confirmed in source; each is also documented as working in the
+workflow prose. (Fix or delete — do not leave half-dead.)
+
+### 1.1 Auto-merge can never fire → Story #3901
+
+`epic.automerge.start` has **zero subscribers** in the chain `lifecycle-emit.js`
+builds; `lib/orchestration/lifecycle/listeners/automerge-predicate.js:342`
+subscribes only to `epic.watch.end`, which only the test-only `Watcher` emits.
+Phase 8.5 of `epic-deliver.md` — the flagship "conditional auto-merge" in the
+skill description — is a dead wire. The real run ledger for Epic #3823 confirms
+no `epic.watch.*` / `epic.merge.*` / `epic.cleanup.*` event has ever been
+emitted in production (so Phase 9 auto-cleanup never runs either).
+
+### 1.2 Phase 8 "watch until green" watches nothing → Story #3902
+
+`pr-watch-with-update.js` was collapsed (Story #2327, "<50 lines, exactly one
+bus.emit") into a shim that emits `pr.created` into a **freshly created bus
+with no listeners**, then exits 0. The fully implemented 557-line `Watcher`
+(poll loop + `mergeStateStatus: BEHIND` recovery + update-branch cap) is
+unreachable. The workflow then says "Exit 0 → proceed to Phase 8.5" — i.e. the
+pipeline advances to (attempted) auto-merge with CI red or still running.
+
+### 1.3 The idle-watchdog/heartbeat system cannot work, and actively harms → Story #3900
+
+Three independent breaks compound:
+
+- **(a)** `story.dispatch.end` is emitted only by
+  `lib/orchestration/wave-session.js`, which nothing imports except tests — so
+  every dispatched Story is "in-flight" forever and `--check-idle` flags
+  completed Stories as stalled.
+- **(b)** Heartbeats are appended via a **relative** `temp/` path
+  (`lib/config/temp-paths.js` joins `'temp'`; `appendFileSync` resolves against
+  `process.cwd()`). The story child `cd`s into `.worktrees/story-<id>/` before
+  calling `story-phase.js` (no `--cwd`), so `story.heartbeat` records land in
+  `<worktree>/temp/epic-N/lifecycle.ndjson` while the host reads the
+  main-checkout copy.
+- **(c)** Heartbeats fire only at phase transitions; `implementing → closing`
+  routinely exceeds the 10-minute threshold.
+
+Net: every healthy long-running Story trips the watchdog, whose prescribed
+remediation is **re-dispatch** — and there is no per-Story lease, so that
+yields two concurrent agents on one `story-<id>` branch (the worst failure mode
+in the system, manufactured by its own safety mechanism). The same broken
+heartbeat lookup also makes the Epic lease guard **silently reclaim live
+foreign claims** (the exact audit-#3513 bug it was built to fix).
+
+### 1.4 Phase 6 retro has no runner → Story #3903
+
+`epic-deliver.md:484` says the retro is "driven by `epic-deliver.js`" — **that
+file does not exist**. `runRetro` (`retro-runner.js`) has no CLI wrapper and
+hard-requires `bus`+`provider`; the most recent real delivery shows the host
+LLM hand-improvising a `run-retro.mjs` with a bare bus (so `retro.start/end`
+never reached the ledger). The retro body then feeds the auto-merge predicate
+via an emoji string-match (`'🟢 Clean sprint'.includes()`).
+
+### 1.5 Planning `--force` re-plan and `--resume` idempotency are broken → Story #3905
+
+- `spawnReconcilerApply`
+  (`lib/orchestration/epic-plan-decompose/phases/reconcile-spawn.js`) invokes
+  `epic-reconcile.js --apply --yes` **without `--explicit-delete`**, and
+  `epic-reconcile.js` hard-exits 2 whenever the plan carries close ops. So the
+  documented close-and-recreate `--force` re-plan fails on any changed ticket
+  set — *after* the spec was already overwritten.
+- `--resume`'s idempotency rests entirely on the gitignored
+  `temp/epic-N/state.json` slug→issue map; if it's missing, the reconciler
+  degrades to an empty mapping and **recreates the full Feature/Story tree on
+  top of the existing one** — and `--resume` is precisely the documented
+  recovery for that situation. The "title-matching resume" described in
+  `epic-plan.md:833` no longer exists in code.
+
+### 1.6 A believed-enforced planning validator validates nothing → Story #3906
+
+`lib/orchestration/task-body-validator.js` skips any Story whose body is a
+string; the decompose-author skill **mandates** string bodies (object bodies
+throw in `createOp`). So the verify-tier suffix rule, vague-verb check, and
+non-empty-goal check — which the skill tells the model are machine-checked —
+never run on any canonical decomposition. Same genus: the story-init
+`dependency-guard` (300 LOC) can never block under 3-tier
+(`tasks.length === 0 → continue`) and has a destructuring bug (`config` passed
+where `orchestration` expected) proving it never ran in anger; the dispatch
+concurrency-gate has "no default loader wired" so it trivially passes; the
+focus-overlap engine always produces zero edges since Task deletion.
+
+### 1.7 Silent failure at finalize → Story #3904
+
+`lifecycle-emit.js` exits 0 with success-shaped JSON even when the acceptance
+reconciler fails or `closePlanningTickets` throws — listener classifications
+are collected in memory and discarded; `epic.blocked` has no subscriber in the
+CLI chain (no label flip, no comment, no notification). The workflow's promise
+that "a non-OK reconciliation throws, aborting finalize" is false at the CLI
+boundary.
+
+---
+
+## 2. Streamlining — what to delete
+
+### 2.1 The dead runner stratum (~6–8k LOC + tests) → Story #3908
+
+`wave-session.js`, `wave-scheduler.js`, `StoryLauncher.launchWave`,
+`wave-gate.js`, `epic-deliver-close-tail.js` (547 LOC duplicate orchestrator
+whose phase order already disagrees with the markdown), `commit-assertion.js`,
+`blocker-wait.js`, the tick spec-path, `CheckpointPointerWriter` (writes a
+checkpoint nothing reads), and the ~11 listeners + `factory.js` + `TraceLogger`
+with no production activation path. **Note:** `commit-assertion.js` was the
+**only** defense against a Story marked done with zero commits — decide
+consciously: rewire it into `verifySingleResult` (one `git rev-list` per
+done-claim) or accept label-trust and delete. Several of these violate the
+repo's own hard-cutover doctrine (one even hides from the doctrine's grep via
+`'orches' + 'tration'` string-splitting).
+
+### 2.2 State-surface sprawl → Story #3909
+
+An Epic run currently writes to five overlapping surfaces (`epic-run-state`
+checkpoint, `dispatch-manifest` comment + 2 temp mirrors, `lifecycle.ndjson`,
+`signals.ndjson` wave events, `epic-run-progress` + per-Story
+`story-run-progress` comments at five phase transitions each). The per-wave
+manifest refresh re-runs a **full dispatch pipeline** (re-fetch all tickets,
+recompute waves) to update a cosmetic comment nothing reads. In planning, the
+`epic-plan-state` comment's `phase` field is write-only telemetry duplicating
+the labels at ~8 GitHub round-trips per plan. Keep three: checkpoint (resume),
+ledger (forensics), one operator-facing progress comment.
+
+### 2.3 Story-close redundancy → Story #3907 / Story #3909
+
+Two parallel baseline-refresh subsystems (~1,800 LOC) score MI/CRAP up to three
+times per clean close and emit the identical `chore(baselines):` commit; three
+format-autofix modules for "format, commit if dirty"; cascade machinery sized
+for a tree with fan-out >1 that can no longer exist; `story-deliver-prepare.js`
+is a whole process that re-reads the comment `story-init` wrote seconds earlier.
+
+### 2.4 Duplicated graph computation → Story #3909
+
+Three-and-a-half wave/DAG implementations (prepare's `build-wave-dag`,
+dispatcher's `dispatch-pipeline`, `stories-wave-tick`, plus the dead tick
+spec-path) that can disagree on wave numbering. One function, two
+presentations.
+
+### 2.5 Prose layer (~28% cuttable) → Story #3910
+
+`epic-plan.md` restates 346 lines of its two helpers nearly in full, and the
+copies have **already diverged** — the wrapper calls `maxTickets` "the hard
+ceiling" while helper+skill+script implement a soft budget with
+`--allow-over-budget`; `helpers/epic-plan-spec.md` is a stale generation that
+omits the Acceptance Spec entirely (a model loading only it produces a plan
+that hard-fails `/epic-deliver`'s start gate). The acceptance self-eval loop
+exists in triplicate; `single-story-deliver.md`'s routing table describes the
+pre-rename `/story-deliver` and routes Epic-attached Stories to a command that
+refuses them; Task-era debris (`tasksDone/tasksTotal` in the parent's demanded
+return contract, "Bookend Lifecycle", troubleshooting "a Story with no child
+Tasks") and an unfilled template token survive throughout.
+
+---
+
+## 3. Resilience & idempotence gaps (beyond §1) → Story #3907
+
+- **story-close "merged locally, push failed":** the recovery probe greps the
+  **local** `epic/<id>` ref, so a re-run classifies the unpushed merge as
+  `ALREADY_MERGED`, skips the push, flips the ticket done, and deletes the
+  branch local+remote — the work then exists only in one clone, and a sibling's
+  `pull --rebase` can linearize away the `(resolves #N)` merge commit four
+  subsystems depend on. Restrict probe (d) to `origin/…` or make
+  resume-from-post-merge unconditionally re-push.
+- **Scoped format-autofix runs in the wrong tree** (`story-close/phases/gates.js:239`
+  gets main-checkout `cwd`, not `worktreePath`) and can land an unreviewed
+  `fix(story-close):` commit on whatever branch the main checkout has out,
+  including `main`. Pass `worktreePath`; assert branch identity before
+  committing.
+- **Wave-complete livelock:** only `record-wave` advances `currentWave`; if the
+  host crashes after children finish but before recording, every re-tick
+  returns `wave-complete` for the same index forever and the workflow says
+  "loop". Let mode B accept "reconcile every Story in `plan[N]` from GitHub"
+  with no returns.
+- **Mode-B reconcile erases `blocked`:** a garbled return from a genuinely
+  blocked child is recorded `failed`, losing `blockerCommentId` and steering
+  the operator to the wrong remediation. Add the `agent::blocked` branch.
+- **A manually closed Story is re-dispatched:** tick classifies by labels only;
+  three different done-predicates exist across the codebase. Align on one
+  `isStoryDone(ticket)` that respects `state === 'closed'`.
+- **Spec-phase rerun demotes the Epic** (Story #3905-adjacent): re-running
+  `epic-plan-spec.js` on a fully decomposed Epic unconditionally flips
+  `agent::ready` → `agent::review-spec` and re-takes the lease; the plan lease
+  also has no recorded claim-time, making the documented "`--steal` once you
+  confirmed the other run is dead" undecidable.
+- **Smaller but real:** worktree reuse rewrites `dependenciesInstalled: 'false'`
+  to `'skipped'`, defeating the retry exactly when it matters; the
+  acceptance-eval round cap trusts a self-reported `round` in a scratch file
+  and doesn't survive a subagent restart (derive it from the `acceptance-eval`
+  signals already appended to `signals.ndjson`); Windows `force-drain` matches
+  holders by command-line substring and can `taskkill` its own ancestor shell
+  mid-close; the preflight cache fingerprints only the Epic ticket, so
+  Story-dependency edits don't invalidate it; partial-recovery reruns append a
+  duplicate `## Planning Artifacts` section to the Epic body.
+
+---
+
+## 4. Overengineering vs. native frontier-model capability → Story #3910 (planning), Story #3911 (structural)
+
+The clearest pattern in planning is **deterministic keyword/regex/Jaccard
+proxies for judgment the host model is already making**:
+
+| Mechanism | Verdict |
+|---|---|
+| Ticket structural validation (hierarchy, cycles, dep resolution), file-assumption git probes, `maxTickets` hard gate | **Keep** — cheap, hard, catches real hallucinations; highest-value determinism in the pipeline |
+| Epic lease + checkout guards, evidence-gate skip-cache, PR open/locate probes, merge-reachability gating | **Keep** |
+| Clarity gate (heading-presence ≥4/5 — passes an Epic with *no* Acceptance Criteria) | Replace scorer with one prompt sentence; keep the idempotent persist CLI |
+| Spec-freshness "net-new cue" keyword classifier (18 keywords / 80-char window) | Delete the cue classifier; the decompose-side git probes are the real gate |
+| BDD `findBestScenarioMatch` Jaccard the *skill asks the LLM to run* | Keep the scanner index, delete the matcher — the model authors the Disposition column either way |
+| `duplicate-search` token-Jaccard | Replaceable by "fetch open Epic titles, ask the model"; harmless but 2023-era |
+| Risk verdict: schema → axis-derivation → routing → one boolean | Keep schema + audit comment; collapse derivation/routing (~180 LOC) — the model authors the axes, so it already controls the gate |
+| Phase 7.5 section gate (standalone CLI + module + manual phase validating a file the previous phase deletes) | Right check, wrong altitude — move the one-line call inside `runSpecPhase`, delete the CLI and the phase |
+| Consolidate critic (fresh-context pass) | Keep the pattern; but its central "scope-preserving" claim has **no runtime check** — add a 30-line acceptance-union diff or drop the claim |
+| Retro compactness heuristics, perf-signal classification, emoji string-match for "clean" | LLM judgment + a machine-readable JSON trailer on the comment; keep the deterministic intervention/wave-status inputs |
+
+On the prose side, the fossil guardrails worth deleting: mode-B
+return-parsing scaffolding (the repo's own Story #3864 measured **zero**
+malformed terminal returns and deleted the parser — but kept the prompt
+ceremony), the mid-run persona re-read, per-commit `git branch --show-current`
+ritual (worktrees pin the branch), the literal "Heartbeat or block." magic
+phrase, and Windows reap-taxonomy education in every story subagent's prompt.
+The HITL pile-up in `/epic-plan`'s ideation path (up to 6 sequential
+confirmations, including a duplicate of the skill's own gate) trains
+rubber-stamping that dilutes the two gates that matter (risk review, re-plan
+overwrite).
+
+**Guardrails worth keeping** (encode non-obvious harness truths): synchronous
+`Bash(timeout)` for story-init (never `Monitor`), "Edit tools ignore shell
+cwd", ledger-before-dispatch ordering, "audit `findings: []` is intentional",
+the `--base main` prohibition, one Agent call per Story for context isolation.
+
+---
+
+## 5. Calibration — what is genuinely good
+
+`evidence-gate.js` (SHA + config-hash keyed skip cache, worktree-aware, fails
+open on evidence-write errors) — the best cost/value ratio in the layer. Also
+sound: `openOrLocatePr`'s probe/create split, `AutomergeArmer`'s
+`autoMergeRequest` probe, `Cleaner`'s atomic rename + archive probe,
+`epic-cleanup`'s fail-closed open-PR guard, `LedgerWriter`'s secret strip, the
+PID-liveness + age-based steal in `epic-merge-lock.js`, the merge-recovery state
+machine, `sync-branch-from-base`'s branch guard, and the DAG/wave planner. The
+problem is not the parts; it is that the wiring between several of them exists
+only in tests and prose.
+
+---
+
+## 6. Recommended sequence
+
+| Step | Work | Stories |
+|---|---|---|
+| **1. Repair (~100 LOC)** | Make the four silently-dead features work again and close the correctness gaps. | #3900, #3901, #3902, #3903, #3904, #3905, #3906, #3907 |
+| **2. Delete the dead stratum** | Remove the unreachable in-process runner + listeners (~10k LOC), consistent with the hard-cutover doctrine. | #3908 |
+| **3. Collapse state surfaces** | Keep checkpoint + ledger + one progress comment; drop the rest. | #3909 |
+| **4. Simplify planning + sweep prose** | Trim deterministic proxies; single-home each procedure; remove Task-era / stale-rename references. | #3910 |
+| **5. Structural (directional)** | Replace the bus with direct calls; collapse the steady-state wave loop. **Depends on steps 1–2.** | #3911 |
+
+### Step 1 — repair stories
+
+| Story | Title |
+|---|---|
+| [#3900](https://github.com/dsj1984/mandrel/issues/3900) | repair idle-watchdog + Epic-lease via main-checkout ledger path and dispatch-end emission |
+| [#3901](https://github.com/dsj1984/mandrel/issues/3901) | make the Phase 8.5 auto-merge gate reachable + add event-connectivity contract test |
+| [#3902](https://github.com/dsj1984/mandrel/issues/3902) | make Phase 8 pr-watch actually poll CI to green instead of emitting into an empty bus |
+| [#3903](https://github.com/dsj1984/mandrel/issues/3903) | ship `retro-run.js` CLI so Phase 6 retro is executable (remove phantom `epic-deliver.js`) |
+| [#3904](https://github.com/dsj1984/mandrel/issues/3904) | propagate finalize/listener failures to `lifecycle-emit` exit code and ledger |
+| [#3905](https://github.com/dsj1984/mandrel/issues/3905) | repair `--force` re-plan (`--explicit-delete`) and `--resume` idempotency on missing `state.json` |
+| [#3906](https://github.com/dsj1984/mandrel/issues/3906) | re-point or remove vacated validators and dead init guards |
+| [#3907](https://github.com/dsj1984/mandrel/issues/3907) | correct story-close push-failure recovery + format-autofix cwd, and close wave-loop resilience gaps |
+
+### Steps 2–5
+
+| Story | Title |
+|---|---|
+| [#3908](https://github.com/dsj1984/mandrel/issues/3908) | delete the dead in-process epic-runner stratum (bus/listeners/wave-session) |
+| [#3909](https://github.com/dsj1984/mandrel/issues/3909) | collapse overlapping run-state/progress surfaces to checkpoint+ledger+one comment |
+| [#3910](https://github.com/dsj1984/mandrel/issues/3910) | simplify deterministic planning proxies and sweep stale/duplicated workflow prose |
+| [#3911](https://github.com/dsj1984/mandrel/issues/3911) | replace lifecycle bus with direct calls + collapse steady-state wave loop |
+
+> **Sequencing note:** do steps 1–2 before step 5. Story #3911 (structural) is
+> intentionally last — it should not start until the surviving features work
+> (#3900–#3907) and the dead stratum is removed (#3908), or it will be
+> reimplementing code that is about to be deleted.
+
+### Dependencies (encoded in GitHub)
+
+Logical "blocked by" dependencies are encoded in each dependent issue body
+using Mandrel's canonical `blocked by #N` token (parsed by
+[`lib/dependency-parser.js`](../.agents/scripts/lib/dependency-parser.js) and
+consumed by `stories-wave-tick.js` / `epic-deliver-prepare.js`). Only true
+logical dependencies are encoded — "B cannot be correct or possible until A
+lands" — not mere same-file edit collisions.
+
+| Story | Blocked by | Why |
+|---|---|---|
+| #3907 | #3900 | Needs the corrected in-flight signal (dispatch-end + ledger path) before it can subtract in-flight from the dispatch set. |
+| #3901 | #3903 | The auto-merge predicate must read the machine-readable retro trailer that #3903 introduces (replacing the emoji string-match). |
+| #3908 | #3900, #3901, #3902, #3907 | What is "dead" cannot be determined until the repairs decide which listeners/modules get rescued vs. deleted. |
+| #3909 | #3908 | Don't collapse state surfaces whose writers are mid-deletion. |
+| #3910 | #3906 | Planning-proxy simplification layers on the vacated-validator cleanup. |
+| #3911 | #3908, #3909 | Bus replacement + wave-loop collapse must follow dead-listener removal and state-surface collapse. |
+
+Resulting dependency-aware wave plan (`stories-wave-tick.js`, acyclic):
+
+| Wave | Stories |
+|---|---|
+| 0 | #3900, #3902, #3903, #3904, #3905, #3906 |
+| 1 | #3901, #3907, #3910 |
+| 2 | #3908 |
+| 3 | #3909 |
+| 4 | #3911 |

--- a/docs/install-bootstrap-review.md
+++ b/docs/install-bootstrap-review.md
@@ -1,0 +1,120 @@
+# Install & Bootstrap Review
+
+- **Date:** 2026-06-10
+- **Reviewed at:** `@mandrelai/agents` v1.54.0, `create-mandrel` v0.3.0 (commit `a7ff890e`)
+- **Scope:** the full install/bootstrap surface — `create-mandrel` launcher, `bin/mandrel.js` + `bin/postinstall.js`, `lib/cli/*` (sync / update / doctor / uninstall / migrate / explain / sync-commands), the `.agents/scripts/bootstrap.js` pipeline and its `lib/bootstrap/` helpers, `agents-bootstrap-github.js`, npm packaging, the Install Matrix CI, and every document that describes getting started (`README.md`, `.agents/README.md`, `create-mandrel/README.md`, `AGENTS.md`, `.agents/docs/SDLC.md`, `.agents/workflows/onboard.md`, `.agents/docs/configuration.md`).
+- **Method:** five parallel deep-dive code/doc reviews (CLI internals, bootstrap pipeline, documentation consistency, packaging + CI, end-to-end new-user UX trace), with the highest-impact claims independently re-verified against the live npm registry and the workflow YAML.
+
+## Verdict
+
+The individual pieces are well-engineered — small entry points, injectable seams, ~2,800 lines of bootstrap tests, honest doc-comments — but the install story as a whole is broken at the front door and inconsistent behind it. `@mandrelai/agents` is published and healthy; the advertised cold-start command `npx create-mandrel` is not usable because the launcher package has never been published under any name, and the unscoped name it advertises is currently squattable. The docs describe four different install paths, two of which are stale, and a new user following the guided path hits two *guaranteed* failures (gh `project` scope, doctor's `github-token` check). Below that sit a handful of real bugs (one data-loss, one secret-push hazard, one duplicate-resource-creation), a recurring package-root-vs-consumer-root anchoring bug family, and a vestigial consent layer left behind by recent cutovers.
+
+## High-priority story tracker
+
+Stories were filed for every P0 and P1 recommendation:
+
+| Story | Priority | Finding | Summary |
+| --- | --- | --- | --- |
+| [#3891](https://github.com/dsj1984/mandrel/issues/3891) | P0 | A.1 | Publish the `create-mandrel` launcher and resolve its package name |
+| [#3892](https://github.com/dsj1984/mandrel/issues/3892) | P0 | A.2, A.3 | Rewrite install quickstart + SDLC Phase 0 around the canonical path |
+| [#3893](https://github.com/dsj1984/mandrel/issues/3893) | P0 | A.4, A.5 | Stop doctor + bootstrap preflight from false-blocking on auth |
+| [#3894](https://github.com/dsj1984/mandrel/issues/3894) | P1 | B.1 | Fix the cold-start secret-push hazard (gitignore before staging) |
+| [#3895](https://github.com/dsj1984/mandrel/issues/3895) | P1 | B.2 | Make `mandrel uninstall` preserve a pre-existing `.agentrc.json` |
+| [#3896](https://github.com/dsj1984/mandrel/issues/3896) | P1 | B.3 | Dedupe Projects V2 board creation on bootstrap re-run |
+| [#3897](https://github.com/dsj1984/mandrel/issues/3897) | P1 | B.4 | Thread a real GitHub-admin consent signal |
+| [#3898](https://github.com/dsj1984/mandrel/issues/3898) | P1 | B.5 | Exit non-zero when the GitHub-side bootstrap fails |
+| [#3899](https://github.com/dsj1984/mandrel/issues/3899) | P0/P1 | A.6 | End bootstrap with an offered commit + push of the wiring |
+
+## npm publication status (verified)
+
+| Package | Declared name | Registry status |
+| --- | --- | --- |
+| Framework | `@mandrelai/agents` | **Published** — 1.54.0 is `latest`; the only package in the `mandrelai` org (`npm access list packages mandrelai`) |
+| Launcher | `create-mandrel` (unscoped) | **Not published** — E404 for both `create-mandrel` and `@mandrelai/create-mandrel` |
+
+Two consequences for the launcher:
+
+1. **`npx create-mandrel` fails for every user today**, despite being advertised by `create-mandrel/README.md`, `onboard.md`, and the bootstrap docs. [release-please.yml](../.github/workflows/release-please.yml) has exactly one `npm publish` step (repo root → `@mandrelai/agents`); release-please has tagged `create-mandrel-v0.2.0`/`v0.3.0`, but no job publishes the launcher.
+2. **The unscoped name is a squatting risk.** Because the docs advertise an unregistered name, anyone could publish a malicious `create-mandrel` to the public registry and every user following the docs would execute it. A naming decision is needed before (or as part of) first publish:
+   - Keep the unscoped `create-mandrel` name (required for the `npm create mandrel` convention and the `npx create-mandrel` command as documented) and publish it promptly to claim the name; or
+   - Move it under the org as `@mandrelai/create-mandrel` for scope consistency — in which case the documented command must change to `npm create @mandrelai/mandrel` (or `npx @mandrelai/create-mandrel`).
+
+Also latent in the release workflow: `release_created` fires if *either* package releases, so a launcher-only release would re-run `npm publish` on an already-published root version and fail.
+
+## A. The front door is broken or misdocumented (highest priority)
+
+1. **The launcher is unpublished and its name unclaimed.** See "npm publication status" above. **→ Story [#3891](https://github.com/dsj1984/mandrel/issues/3891)**
+2. **The root [README.md](../README.md) tells a pre-v1.54 story.** It requires a pre-existing git repo and GitHub remote ("Create the empty GitHub repo first") — false since cold-start provisioning landed (`git init` → `gh repo create --push` → `gh project create` in [bootstrap.js](../.agents/scripts/bootstrap.js)). It never mentions `npx create-mandrel` or `/onboard`. Neither does [.agents/README.md](../.agents/README.md). **→ Story [#3892](https://github.com/dsj1984/mandrel/issues/3892)**
+3. **[SDLC.md](../.agents/docs/SDLC.md) Phase 0 is dead.** It instructs `cp starter-agentrc.json`, filling in an `orchestration` block (no such schema key — it's `github`), then running `/agents-bootstrap-github` — a command in the lint `RETIRED_COMMANDS` blocklist that survives only because it's backticked. The canonical narrative document starts new users with a command that doesn't exist. **→ Story [#3892](https://github.com/dsj1984/mandrel/issues/3892)**
+4. **First run fails on gh scope, undocumented.** A vanilla `gh auth login` token lacks the `project` scope, so the preflight in [gh-preflight.js](../.agents/scripts/lib/bootstrap/gh-preflight.js) hard-fails the very first bootstrap → browser → re-run loop. No README mentions `gh auth refresh -s project` — and the GitHub-side code already knows how to degrade gracefully for the same condition, so preflight is stricter than the code it guards. **→ Story [#3893](https://github.com/dsj1984/mandrel/issues/3893)**
+5. **The doctor `github-token` check is a false-blocking gate.** `runGithubToken` ([registry.js:150](../lib/cli/registry.js)) reads only `process.env`; the `mandrel` CLI never loads `.env` (verified — no env-loader anywhere under `bin/` or `lib/`), yet the printed remedy says "(or add to .env)" and `/onboard` both instructs exactly that and treats red doctor as a hard stop. The actual runtime falls back to `gh auth token`, so doctor blocks on a variable the framework doesn't need locally. **→ Story [#3893](https://github.com/dsj1984/mandrel/issues/3893)**
+6. **Nobody tells the user to commit and push the wiring.** Story delivery runs in worktrees that contain only *tracked* files, so an uncommitted `.agents/`/`.agentrc.json` breaks every sub-agent. This mandatory step appears in no README and no bootstrap output — the most likely "worked in my checkout, broke in delivery" trap. **→ Story [#3899](https://github.com/dsj1984/mandrel/issues/3899)**
+
+## B. Correctness and safety bugs
+
+1. **Secret-push hazard (High).** Cold-start provisioning runs `git add -A` + initial commit, then `gh repo create --push` — and the `.gitignore` seeding runs **two phases later**. A folder containing `.env` or `.mcp.json` gets them pushed to the brand-new repo with no per-file consent. `GITIGNORE_BLOCKS` in [project-bootstrap.js](../.agents/scripts/lib/bootstrap/project-bootstrap.js) also omits `.env` entirely, while `/onboard` tells users to put `GITHUB_TOKEN` in `.env`. This violates the repo's own security baseline. Fix: empty initial commit (no `add -A`) or reorder gitignore before staging, and add `.env` + the install ledger to the blocks. **→ Story [#3894](https://github.com/dsj1984/mandrel/issues/3894)**
+2. **`mandrel uninstall` can delete a hand-authored `.agentrc.json` (High, data loss).** `revertAgentrc` ([uninstall.js:442](../lib/cli/uninstall.js)) deletes unconditionally, but the ledger records the *full manifest filtered by phase group*, never the execution-time "already-present" no-op — so a pre-existing operator config gets ledgered as install-created and later removed. **→ Story [#3895](https://github.com/dsj1984/mandrel/issues/3895)**
+3. **Re-running bootstrap with `--assume-yes` creates a duplicate Projects V2 board every run** and re-points `.agentrc.json` at it. The project question defaults to the repo *name* (never the stored `projectNumber`), any non-numeric answer is classified "create new," and `gh project create` is never deduped against existing titles — directly contradicting the docstring's "a re-run is a no-op." The repo side got exactly this fix; the project side didn't. **→ Story [#3896](https://github.com/dsj1984/mandrel/issues/3896)**
+4. **Consent is hardcoded.** [bootstrap.js](../.agents/scripts/bootstrap.js) passes `githubAdminApproved: true` into the GitHub bootstrap, and a non-TTY run with just `--owner/--repo` (no `--assume-yes`, despite help text claiming it's required) auto-approves repo/board/label creation. Only branch protection and merge methods stay HITL-gated. **→ Story [#3897](https://github.com/dsj1984/mandrel/issues/3897)**
+5. **GitHub-side bootstrap failure exits 0.** `executeGithubBootstrap` catches the error into the report and `main()` prints `Done.` — invisible to `create-mandrel` and CI, while preflight/provisioning failures correctly exit 1. **→ Story [#3898](https://github.com/dsj1984/mandrel/issues/3898)**
+6. **`mandrel update` ends with three quiet failures:** changelog surfacing can never work in a consumer (default path is `docs/CHANGELOG.md`, which isn't in the npm `files` allowlist — every real update logs "skipping"); the explicit update resolves through the 24h cache, so it can report "already up to date" without ever hitting the registry; and it never runs `sync-commands` yet gates on the `commands-in-sync` doctor check it didn't establish.
+7. **Anchoring bug family (the recurring root cause).** Three places confuse package root with consumer root, the exact bug class Story #3588 fixed once: the `runtime-deps` doctor check resolves from inside `node_modules/@mandrelai/agents` so it *can never fail* where it matters (and is currently masking an analytically real pnpm isolated-layout breakage of the "scripts free-ride on consumer node_modules" contract); the version cache writes to `node_modules/@mandrelai/agents/temp/`, wiped by every reinstall. Anchor all of them at `process.cwd()` like `agents-materialized`/`agents-drift` already do.
+8. **`mandrel sync` never prunes and `agents-drift` only checks payload files**, so a file deleted upstream lingers (and keeps projecting its slash command) in consumer `.agents/` forever, doctor all-green — contradicting both sync's "byte-identical" claim and the hard-cutover doctrine.
+9. **Prompt polarity trap:** four `[Y/n]` prompts, then the final merge-methods gate flips to `[y/N]` — and drift is guaranteed on fresh repos, so Enter-through silently disables the auto-merge half of the pipeline, surfacing weeks later as `/epic-deliver` warn-only failures.
+
+## C. Unnecessary complexity and dead code
+
+1. **The consent/preview machinery is vestigial.** Since Story #3690 removed phased approval, the phase-group gate always passes, `previewMutationManifest` has zero production callers, `--dry-run` doesn't render the manifest its docstring promises, and the manifest omits the *most* irreversible mutations (git init, repo/board creation) — so uninstall's ledger never hears about them either. Either wire it into `--dry-run` + ledger fully, or collapse it.
+2. **Confirmed dead code:** `--install-workflows` (parsed, never read), `ensureCiWorkflow` (zero production callers — which also means the advertised branch-protection/CI story is unreachable on a default install), `ensureMainBranchProtection` (kept only for legacy contract tests, duplicates `applyBranchProtection`), `mandrel sync --force` (documented no-op), `__filenameForTests` (unimported), an unreachable `--skip-github` notice, and a stale remediation hint pointing at retired `/agents-bootstrap-project`.
+3. **Quadruplicated helpers:** four independent lockfile-probe implementations, four `parseVersion`/`compareVersions` copies, and [registry.js](../lib/cli/registry.js) maintaining verbatim mirrors of sync.js's resolver/walker via "Mirrors lib/cli/sync.js" comments instead of imports. [update.js](../lib/cli/update.js) also carries a redundant second DI layer and a "no-drift" `STEP_PLAN` whose live and dry-run paths have already drifted.
+4. **TypeScript is declared three incompatible ways:** hard runtime dep (`>=5.0.0`, unbounded), non-optional peer, and gracefully-degrading optional in the one real consumer (the maintainability gate). Every pure-JS consumer downloads the TS compiler; any TS4 consumer gets ERESOLVE. Make it a truly optional peer.
+5. **`engines: ">=22.22.1 <25"`** — patch-specific floor introduced wholesale in the v6 cutover with no recorded rationale, duplicated in four places, and a hard install error under pnpm/yarn for consumers on earlier 22.x.
+6. **CLI surface gaps:** bare `mandrel` prints no subcommand list; no `--help`/`--version`; `registry.js`/`version-check.js` sit in the convention-dispatched directory but crash via the dispatcher; `uninstall`, `explain`, and `sync-commands` are documented nowhere consumer-facing; the most destructive command (`uninstall`) is the only mutating one without `--dry-run`; no subcommand rejects unknown flags, so `mandrel update --dryrun` (typo) performs a live install.
+
+## D. Packaging & CI gaps
+
+1. **Tarball is healthy** (1.9 MB, 856 files, everything sync needs) except: 7 `__tests__` files ship in `lib/`, and `"main": "index.js"` dangles (no such file). `.npmrc ignore-scripts=true` and the postinstall source-checkout guard are both sound.
+2. **The Install Matrix never exercises:** postinstall materialization (every leg uses `--ignore-scripts` — exactly the path that already shipped the Story #3584 regression), the create-mandrel cold start (one pure-function unit test), or running a single materialized script from the consumer root (which would immediately expose the pnpm free-ride breakage that finding B.7 is masking).
+3. **`create-mandrel` installs floating `latest`** with lifecycle scripts enabled, then runs the sync the postinstall already did — pin the framework version per release and pass `--ignore-scripts`. The version-sync pre-commit guard also only checks the root manifest entry, and the launcher's changelog shows it being version-bumped by unrelated root work.
+4. **`knip` never scans `bin/`, `lib/`, or `create-mandrel/`** — the entire npm distribution surface is invisible to the dead-code gate; it already flags ~10 bootstrap-refactor leftovers in the areas it does scan.
+5. **Doc nits:** `@mandrel/agents` (missing `ai`) typos in two places, `AGENTS.md` says "License: ISC" vs MIT everywhere else, and the three-agentrc-files table is maintained in two places that have already drifted from each other.
+
+## What's healthy
+
+`create-mandrel/index.js`, `bin/mandrel.js`, and `bin/postinstall.js` are exemplary — small, pure-planned, seam-injected, honestly documented. The bootstrap pipeline is a single readable 10-phase array; file-side idempotency (markers, minimal writes, operator-wins `.agentrc.json`) is genuinely hardened and tested; no prompt can hang in CI; `/onboard` vs `bootstrap.js` division of labor is explicit and clean; `create-mandrel/README.md` and `onboard.md` match their code exactly; `@mandrelai/agents` publishing (provenance, `publishConfig.access`, source-checkout guard) is correctly set up.
+
+## Prioritized recommendations
+
+**P0 — unbreak the front door:**
+
+- Decide the launcher's name (unscoped `create-mandrel` for the `npm create mandrel` convention vs `@mandrelai/create-mandrel` for org consistency), publish it, and add the second publish step to `release-please.yml` gated on the launcher's own release output. Until it ships, stop advertising `npx create-mandrel`. — Story [#3891](https://github.com/dsj1984/mandrel/issues/3891)
+- Rewrite the README quickstart + SDLC Phase 0 around the one canonical path (`npx create-mandrel` → `/onboard`). — Story [#3892](https://github.com/dsj1984/mandrel/issues/3892)
+- Make the `github-token` doctor check accept the `gh auth token` fallback (or load `.env`); document or soften the `project`-scope preflight. — Story [#3893](https://github.com/dsj1984/mandrel/issues/3893)
+
+**P1 — safety:**
+
+- Gitignore-before-stage ordering plus `.env` in `GITIGNORE_BLOCKS`. — Story [#3894](https://github.com/dsj1984/mandrel/issues/3894)
+- Content-aware `.agentrc.json` reversal in uninstall (or outcome-aware ledger). — Story [#3895](https://github.com/dsj1984/mandrel/issues/3895)
+- Dedupe project-board creation on re-run. — Story [#3896](https://github.com/dsj1984/mandrel/issues/3896)
+- Real consent signal instead of `githubAdminApproved: true`. — Story [#3897](https://github.com/dsj1984/mandrel/issues/3897)
+- Non-zero exit on GitHub-side failure. — Story [#3898](https://github.com/dsj1984/mandrel/issues/3898)
+- End bootstrap with an offered "commit + push the wiring" step. — Story [#3899](https://github.com/dsj1984/mandrel/issues/3899)
+
+**P2 — consistency & weight:**
+
+- Fix the three `process.cwd()` anchoring bugs; add prune-or-flag-extras to sync/drift.
+- Insert `sync-commands` into the update cycle and ship the changelog.
+- Collapse or fully wire the consent/preview layer; delete the confirmed dead code; unify the version/lockfile helpers.
+- TypeScript → optional peer; justify or lower the engines floor.
+- Add a subcommand list + unknown-flag rejection + `uninstall --dry-run`; document `uninstall`/`explain`/`sync-commands`.
+
+**P3 — CI:**
+
+- One scripts-enabled npm leg asserting postinstall materialization.
+- A registry-backed (e.g. verdaccio) create-mandrel cold-start leg.
+- Run one materialized script from the consumer dir per leg.
+- Extend knip to `bin/`/`lib/`/`create-mandrel/`; extend the version-sync guard to both manifest entries.
+
+## UX bottom line
+
+Today a careful new user needs **~12–18 operator actions with two guaranteed failures** to reach a deliverable Epic, and the "15 minutes" claim only covers the slice `/onboard` measures — realistically 30–60 minutes. The P0+P1 items collapse that to: `npx create-mandrel` → ~4 answers → "commit & push? [Y]" → `/onboard` → green doctor.


### PR DESCRIPTION
## Why

Two code-review reports produced this session, with their remediation work already filed as GitHub Stories. Landing the docs so the findings and the story tracker live in-repo alongside the code they describe.

## What

- **`docs/epic-lifecycle-review.md`** — full review of the `/epic-plan` + `/epic-deliver` pipelines (workflow prose, helpers, and `.agents/scripts`). Covers verified broken-by-construction defects, deletion targets, resilience/idempotence gaps, and the overengineering-vs-frontier-capability analysis. Recommended sequence is mapped to Stories #3900–#3911, including the `blocked by #N` dependency graph and the computed `stories-wave-tick.js` wave plan.
- **`docs/install-bootstrap-review.md`** — review of the install/bootstrap surface (`create-mandrel`, `bin/`, `lib/cli/*`, `bootstrap.js`, packaging, Install Matrix CI, getting-started docs). P0/P1 findings tracked as Stories #3891–#3898.

Docs-only change — no code or workflow behavior is modified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)