### PR TITLE
Thread a real GitHub-admin consent signal instead of hardcoding approval (#3897)

### DIFF
--- a/.agents/scripts/agents-bootstrap-github.js
+++ b/.agents/scripts/agents-bootstrap-github.js
@@ -379,10 +379,12 @@ export function ensureCiWorkflow(args) {
  * mutation manifest. The whole sequence is now **explicit opt-in**: unless
  * `opts.githubAdminApproved === true`, `runBootstrap` short-circuits before
  * touching the provider and issues **zero** GitHub mutations. This is the
- * boundary-level enforcement of the consent gate the `bootstrap.js`
- * orchestrator already collects (`approvePhases` → `executeGithubBootstrap`):
- * a direct caller cannot silently reconfigure a repo by skipping the phased
- * approval flow. Even additive branch-protection / merge-method changes that
+ * boundary-level enforcement of the consent signal the `bootstrap.js`
+ * orchestrator threads from `parseAndValidate` (interactive operator
+ * confirmation, `--assume-yes`, or `--approve-github-admin`) down through
+ * `executeGithubBootstrap`: a direct caller cannot silently reconfigure a
+ * repo by skipping that consent. Even additive branch-protection /
+ * merge-method changes that
  * previously applied without a prompt are gated — they are enumerated in the
  * manifest's `github-admin` group and only land once that group is approved.
  *

--- a/.agents/scripts/bootstrap.js
+++ b/.agents/scripts/bootstrap.js
@@ -717,7 +717,6 @@ function resolveAppliedGroups(approvedGroups, report) {
  */
 export function parseAndValidate(argv, opts = {}) {
   const stdout = opts.stdout ?? process.stdout;
-  const env = opts.env ?? process.env;
   const stdin = opts.stdin ?? process.stdin;
   const flags = parseFlags(argv);
   if (flags.help) {
@@ -730,26 +729,15 @@ export function parseAndValidate(argv, opts = {}) {
   // A non-TTY run cannot collect operator consent interactively, so it MUST
   // carry an explicit consent signal. This restores parity with the --help
   // text, which has always claimed --assume-yes is required for non-TTY runs.
+  // (owner/repo are resolved from flags/env/git-remote downstream — a consent
+  // signal alone is sufficient to advance, exactly as the pre-Story #3897
+  // `--assume-yes` path did.)
   if (!interactive && !assumeYes && !approveGithubAdmin) {
     Logger.error(
       '[bootstrap] non-TTY run requires --assume-yes or --approve-github-admin ' +
         '(no operator is present to confirm the GitHub-admin mutations).',
     );
     return { ok: false, exit: 1 };
-  }
-  if (!interactive) {
-    const required = ['owner', 'repo'];
-    const missing = required.filter(
-      (k) =>
-        typeof flags[k] !== 'string' &&
-        typeof env[`GH_${k.toUpperCase()}`] !== 'string',
-    );
-    if (missing.length > 0) {
-      Logger.error(
-        `[bootstrap] non-TTY run requires --owner and --repo (or GH_OWNER / GH_REPO). Missing: ${missing.join(', ')}`,
-      );
-      return { ok: false, exit: 1 };
-    }
   }
   // Real GitHub-admin consent: an interactive run confirms it in
   // `collectAndConfirm`; a non-TTY run signals it via flag (above).

--- a/.agents/scripts/bootstrap.js
+++ b/.agents/scripts/bootstrap.js
@@ -29,7 +29,13 @@
  *   --operator-handle <name>  GitHub handle for github.operatorHandle
  *   --base-branch <name>      Base branch (default: origin/HEAD or 'main')
  *   --project-number <n>      Projects V2 number/name (optional)
- *   --assume-yes              Accept every default; required for non-TTY runs
+ *   --assume-yes              Accept every default + approve GitHub-admin
+ *                             mutations. A non-TTY run requires this (or
+ *                             --approve-github-admin) — there is no operator
+ *                             to confirm the summary.
+ *   --approve-github-admin    Consent to the irreversible GitHub-admin phase
+ *                             (labels, Projects V2, branch protection, merge
+ *                             methods) without accepting every other default.
  *   --skip-github             Skip the GitHub-side bootstrap entirely
  *   --skip-quality            Skip the quality-gates bootstrap
  *   --dry-run                 Collect info and print the plan; change nothing
@@ -77,7 +83,13 @@ Flags:
   --operator-handle <name>  GitHub handle for github.operatorHandle
   --base-branch <name>      Base branch (default: origin/HEAD or 'main')
   --project-number <n>      Projects V2 number/name (optional)
-  --assume-yes              Accept every default; required for non-TTY runs
+  --assume-yes              Accept every default + approve GitHub-admin
+                            mutations. A non-TTY run requires this (or
+                            --approve-github-admin) — there is no operator
+                            to confirm the summary.
+  --approve-github-admin    Consent to the irreversible GitHub-admin phase
+                            (labels, Projects V2, branch protection, merge
+                            methods) without accepting every other default.
   --skip-github             Skip the GitHub-side bootstrap entirely
   --skip-quality            Skip the quality-gates bootstrap
   --dry-run                 Collect info and print the plan; change nothing
@@ -584,7 +596,10 @@ async function runGithubBootstrap(answers, opts) {
     github: config.github,
     assumeYes: opts.assumeYes,
     baseBranch: answers.baseBranch,
-    githubAdminApproved: true,
+    // Real consent signal threaded from `parseAndValidate` (Story #3897):
+    // interactive operator confirmation, `--assume-yes`, or
+    // `--approve-github-admin`. Default-deny at the boundary gate when absent.
+    githubAdminApproved: opts.githubAdminApproved === true,
     // Opt-in: delete the Projects V2 built-in workflows that race against the
     // orchestrator's ColumnSync (e.g. "Pull request merged"). Off by default.
     reapConflictingWorkflows: Boolean(opts.reapConflictingWorkflows),
@@ -619,8 +634,24 @@ function resolveAppliedGroups(approvedGroups, report) {
 // ---------------------------------------------------------------------------
 
 /**
- * Step 1 — Parse argv, handle `--help`, and enforce the non-TTY contract
- * (`--owner`/`--repo` or env equivalents + `--assume-yes`).
+ * Step 1 — Parse argv, handle `--help`, and enforce the non-TTY contract.
+ *
+ * Consent contract (Story #3897). A non-TTY run has no operator to confirm
+ * the summary loop in `collectAndConfirm`, so the irreversible GitHub-admin
+ * mutations cannot ride on a real confirmation — they need an explicit
+ * up-front signal. The gate therefore requires **either** `--assume-yes`
+ * **or** `--approve-github-admin` on any non-TTY run (matching the
+ * `--help` text), and computes `githubAdminApproved` once for the whole run:
+ *
+ *   - **interactive (TTY)** → consent is the operator's `Is this correct?`
+ *     confirmation in `collectAndConfirm`, so the run is approved.
+ *   - **non-TTY** → consent is `--assume-yes` or `--approve-github-admin`;
+ *     without one of those the run halts before any mutation.
+ *
+ * `githubAdminApproved` flows down to `runGithubBootstrap`, which forwards it
+ * to the boundary gate in `agents-bootstrap-github.js#runBootstrap`. That
+ * gate is default-deny, so a non-approved value makes the GitHub-admin phase
+ * a verified no-op instead of a silent mutation.
  */
 export function parseAndValidate(argv, opts = {}) {
   const stdout = opts.stdout ?? process.stdout;
@@ -633,7 +664,18 @@ export function parseAndValidate(argv, opts = {}) {
   }
   const interactive = Boolean(stdin.isTTY) && !flags['assume-yes'];
   const assumeYes = Boolean(flags['assume-yes']);
-  if (!interactive && !assumeYes) {
+  const approveGithubAdmin = Boolean(flags['approve-github-admin']);
+  // A non-TTY run cannot collect operator consent interactively, so it MUST
+  // carry an explicit consent signal. This restores parity with the --help
+  // text, which has always claimed --assume-yes is required for non-TTY runs.
+  if (!interactive && !assumeYes && !approveGithubAdmin) {
+    Logger.error(
+      '[bootstrap] non-TTY run requires --assume-yes or --approve-github-admin ' +
+        '(no operator is present to confirm the GitHub-admin mutations).',
+    );
+    return { ok: false, exit: 1 };
+  }
+  if (!interactive) {
     const required = ['owner', 'repo'];
     const missing = required.filter(
       (k) =>
@@ -642,11 +684,14 @@ export function parseAndValidate(argv, opts = {}) {
     );
     if (missing.length > 0) {
       Logger.error(
-        `[bootstrap] non-TTY run requires --owner and --repo (or GH_OWNER / GH_REPO) and --assume-yes. Missing: ${missing.join(', ')}`,
+        `[bootstrap] non-TTY run requires --owner and --repo (or GH_OWNER / GH_REPO). Missing: ${missing.join(', ')}`,
       );
       return { ok: false, exit: 1 };
     }
   }
+  // Real GitHub-admin consent: an interactive run confirms it in
+  // `collectAndConfirm`; a non-TTY run signals it via flag (above).
+  const githubAdminApproved = interactive || assumeYes || approveGithubAdmin;
   if (resolveRepoVisibility(flags) === null) {
     Logger.error(
       `[bootstrap] invalid --visibility "${flags.visibility}". ` +
@@ -654,7 +699,10 @@ export function parseAndValidate(argv, opts = {}) {
     );
     return { ok: false, exit: 1 };
   }
-  return { ok: true, payload: { flags, interactive, assumeYes } };
+  return {
+    ok: true,
+    payload: { flags, interactive, assumeYes, githubAdminApproved },
+  };
 }
 
 /**
@@ -1071,6 +1119,7 @@ export async function executeGithubBootstrap(state) {
   try {
     state.report.github = await runGithubBootstrap(state.answers, {
       assumeYes: state.assumeYes,
+      githubAdminApproved: state.githubAdminApproved === true,
       reapConflictingWorkflows: Boolean(
         state.flags['reap-conflicting-workflows'],
       ),

--- a/.agents/scripts/lib/bootstrap/prompt.js
+++ b/.agents/scripts/lib/bootstrap/prompt.js
@@ -37,6 +37,7 @@ export const KNOWN_FLAGS = Object.freeze({
   ],
   boolean: [
     'assume-yes',
+    'approve-github-admin',
     'skip-github',
     'skip-quality',
     'help',

--- a/tests/scripts/bootstrap-main-phases.test.js
+++ b/tests/scripts/bootstrap-main-phases.test.js
@@ -55,9 +55,12 @@ describe('parseAndValidate', () => {
     assert.equal(res.ok, true);
     assert.equal(res.payload.interactive, true);
     assert.equal(res.payload.assumeYes, false);
+    // An interactive run consents via the summary confirm loop, so the
+    // GitHub-admin phase is approved (Story #3897).
+    assert.equal(res.payload.githubAdminApproved, true);
   });
 
-  it('halts with exit 1 in non-TTY mode without --assume-yes when owner/repo are missing', () => {
+  it('halts with exit 1 in non-TTY mode without a consent signal when owner/repo are missing', () => {
     const res = parseAndValidate([], {
       stdout: { write: () => {} },
       env: {},
@@ -67,13 +70,16 @@ describe('parseAndValidate', () => {
     assert.equal(res.exit, 1);
   });
 
-  it('advances in non-TTY mode without --assume-yes when owner+repo flags are supplied', () => {
+  it('halts in non-TTY mode without a consent signal even when owner+repo flags are supplied (Story #3897)', () => {
+    // Previously this advanced and silently applied GitHub-admin mutations
+    // with no consent flag, contradicting the --help contract.
     const res = parseAndValidate(['--owner', 'acme', '--repo', 'widget'], {
       stdout: { write: () => {} },
       env: {},
       stdin: { isTTY: false },
     });
-    assert.equal(res.ok, true);
+    assert.equal(res.ok, false);
+    assert.equal(res.exit, 1);
   });
 
   it('advances in non-TTY mode when --assume-yes plus owner/repo are present', () => {
@@ -88,6 +94,33 @@ describe('parseAndValidate', () => {
     assert.equal(res.ok, true);
     assert.equal(res.payload.assumeYes, true);
     assert.equal(res.payload.interactive, false);
+    assert.equal(res.payload.githubAdminApproved, true);
+  });
+
+  it('advances in non-TTY mode when --approve-github-admin (without --assume-yes) plus owner/repo are present (Story #3897)', () => {
+    const res = parseAndValidate(
+      ['--approve-github-admin', '--owner', 'acme', '--repo', 'widget'],
+      {
+        stdout: { write: () => {} },
+        env: {},
+        stdin: { isTTY: false },
+      },
+    );
+    assert.equal(res.ok, true);
+    assert.equal(res.payload.assumeYes, false);
+    assert.equal(res.payload.interactive, false);
+    // The dedicated consent flag approves the GitHub-admin phase.
+    assert.equal(res.payload.githubAdminApproved, true);
+  });
+
+  it('halts in non-TTY mode with a consent signal but missing owner/repo (Story #3897)', () => {
+    const res = parseAndValidate(['--approve-github-admin'], {
+      stdout: { write: () => {} },
+      env: {},
+      stdin: { isTTY: false },
+    });
+    assert.equal(res.ok, false);
+    assert.equal(res.exit, 1);
   });
 
   it('honours GH_OWNER / GH_REPO env vars as a substitute for the flags', () => {

--- a/tests/scripts/bootstrap-main-phases.test.js
+++ b/tests/scripts/bootstrap-main-phases.test.js
@@ -113,23 +113,27 @@ describe('parseAndValidate', () => {
     assert.equal(res.payload.githubAdminApproved, true);
   });
 
-  it('halts in non-TTY mode with a consent signal but missing owner/repo (Story #3897)', () => {
-    const res = parseAndValidate(['--approve-github-admin'], {
+  it('advances in non-TTY mode with a consent signal even when owner/repo are absent — they resolve downstream (Story #3897)', () => {
+    // A consent signal alone advances; owner/repo are inferred from the git
+    // remote (or flags/env) by the later phases, matching the pre-Story #3897
+    // `--assume-yes` behaviour the Windows Smoke dry-run relies on.
+    const res = parseAndValidate(['--assume-yes', '--skip-github'], {
       stdout: { write: () => {} },
       env: {},
       stdin: { isTTY: false },
     });
-    assert.equal(res.ok, false);
-    assert.equal(res.exit, 1);
+    assert.equal(res.ok, true);
+    assert.equal(res.payload.githubAdminApproved, true);
   });
 
-  it('honours GH_OWNER / GH_REPO env vars as a substitute for the flags', () => {
+  it('advances with --assume-yes alone; owner/repo (here via GH_OWNER/GH_REPO) are resolved downstream, not at the gate', () => {
     const res = parseAndValidate(['--assume-yes'], {
       stdout: { write: () => {} },
       env: { GH_OWNER: 'acme', GH_REPO: 'widget' },
       stdin: { isTTY: false },
     });
     assert.equal(res.ok, true);
+    assert.equal(res.payload.githubAdminApproved, true);
   });
 
   it('halts with exit 1 on an unrecognized --visibility value', () => {

--- a/tests/scripts/bootstrap-phases-coverage.test.js
+++ b/tests/scripts/bootstrap-phases-coverage.test.js
@@ -80,6 +80,11 @@ const GH_BOOTSTRAP_PATH = path.resolve(
   '.agents/scripts/agents-bootstrap-github.js',
 );
 const GH_BOOTSTRAP_URL = pathToFileURL(GH_BOOTSTRAP_PATH).href;
+const CONFIG_RESOLVER_PATH = path.resolve(
+  ROOT,
+  '.agents/scripts/lib/config-resolver.js',
+);
+const CONFIG_RESOLVER_URL = pathToFileURL(CONFIG_RESOLVER_PATH).href;
 
 /** Track scratch dirs so afterEach can reap them. */
 const scratchDirs = [];
@@ -570,6 +575,78 @@ describe('executeGithubBootstrap — GhExecError surfacing', () => {
     });
     assert.equal(res.ok, true);
     assert.equal(report.github, undefined);
+  });
+
+  // -------------------------------------------------------------------------
+  // Story #3897 — the consent signal (no longer a hardcoded `true`) is threaded
+  // verbatim into the boundary gate. Mock every seam runGithubBootstrap pulls
+  // in so we capture the exact `githubAdminApproved` opt the orchestrator
+  // forwards to `runBootstrap` — no real gh call, no real config read.
+  // -------------------------------------------------------------------------
+  async function loadSutWithCapturedRunBootstrap(t, tag) {
+    const realGhBootstrap = await import(GH_BOOTSTRAP_URL);
+    const realResolver = await import(CONFIG_RESOLVER_URL);
+    const captured = {};
+    t.mock.module(GH_BOOTSTRAP_URL, {
+      namedExports: {
+        ...namedOnly(realGhBootstrap),
+        preflightGh: async () => {},
+        preflightRuntimeDeps: async () => {},
+        runBootstrap: async (_config, opts) => {
+          captured.opts = opts;
+          return { skipped: opts.githubAdminApproved !== true };
+        },
+      },
+    });
+    t.mock.module(CONFIG_RESOLVER_URL, {
+      namedExports: {
+        ...namedOnly(realResolver),
+        resolveConfig: () => ({ project: {}, github: {} }),
+        validateOrchestrationConfig: () => {},
+      },
+    });
+    const mod = await import(`${SUT_URL}?t=${tag}`);
+    return { mod, captured };
+  }
+
+  it('threads githubAdminApproved=true into runBootstrap when consent is present (Story #3897)', async (t) => {
+    captureInfo(t);
+    const { mod, captured } = await loadSutWithCapturedRunBootstrap(
+      t,
+      'egb-consent-yes',
+    );
+    const report = {};
+    const res = await mod.executeGithubBootstrap({
+      report,
+      answers: { owner: 'acme', repo: 'widget', baseBranch: 'main' },
+      flags: {},
+      assumeYes: true,
+      githubAdminApproved: true,
+    });
+    assert.equal(res.ok, true);
+    assert.equal(captured.opts.githubAdminApproved, true);
+    assert.equal(report.github.skipped, false);
+  });
+
+  it('threads githubAdminApproved=false into runBootstrap so the GitHub-admin phase is a verified no-op without consent (Story #3897)', async (t) => {
+    captureInfo(t);
+    const { mod, captured } = await loadSutWithCapturedRunBootstrap(
+      t,
+      'egb-consent-no',
+    );
+    const report = {};
+    const res = await mod.executeGithubBootstrap({
+      report,
+      answers: { owner: 'acme', repo: 'widget', baseBranch: 'main' },
+      flags: {},
+      assumeYes: false,
+      // No consent signal computed by parseAndValidate → not approved.
+      githubAdminApproved: false,
+    });
+    assert.equal(res.ok, true);
+    // The boundary received a strict `false`, never a hardcoded `true`.
+    assert.equal(captured.opts.githubAdminApproved, false);
+    assert.equal(report.github.skipped, true);
   });
 });
 


### PR DESCRIPTION
Closes #3897

_Auto-opened by `/single-story-deliver`._