### PR TITLE
Make epic code-review depth a real, consumed signal (#3937)

### DIFF
--- a/.agents/scripts/lib/orchestration/code-review.js
+++ b/.agents/scripts/lib/orchestration/code-review.js
@@ -34,6 +34,7 @@
 
 import { resolveConfig } from '../config-resolver.js';
 import { selectAuditStrategy } from '../dynamic-workflow/capability.js';
+import { read as readPlanState } from './epic-plan-state-store.js';
 import {
   countBySeverity,
   renderFindings,
@@ -70,6 +71,44 @@ export function resolveReviewDepth(overallLevel) {
     default:
       return 'standard';
   }
+}
+
+/**
+ * Producer-side resolver (Story #3937): read an Epic's judged `planningRisk`
+ * envelope off its `epic-plan-state` checkpoint and resolve the review depth.
+ * This is the live epic-scope counterpart to `resolveRiskRoutedLenses` in
+ * `epic-audit-prepare.js` — it reuses the same best-effort `readPlanState`
+ * pattern so the producer never aborts the review on a risk-read failure.
+ *
+ * Best-effort and total: a missing/unparseable checkpoint, an absent
+ * `planningRisk` field, a read failure, or a malformed `overallLevel` all
+ * degrade to `standard` (never throws). So an Epic that skipped `/epic-plan`
+ * (no checkpoint) still gets a passing `standard` review with no new failure
+ * mode. The resolved depth is what the `/epic-deliver` Phase 5 review then
+ * threads into `runCodeReview` via the `planningRisk` opt so a high-risk Epic
+ * gets a `deep` provider pass and a low-risk one a `light` pass.
+ *
+ * @param {{
+ *   epicId: number,
+ *   provider: object,
+ *   readPlanState?: typeof readPlanState,
+ * }} params
+ * @returns {Promise<ReviewDepth>}
+ */
+export async function resolveReviewDepthForEpic({
+  epicId,
+  provider,
+  readPlanState: readPlanStateFn = readPlanState,
+}) {
+  let state = null;
+  try {
+    state = await readPlanStateFn({ provider, epicId });
+  } catch {
+    // A read failure (provider error, malformed comment) must not abort the
+    // review. Degrade to the neutral `standard` depth.
+    return 'standard';
+  }
+  return resolveReviewDepth(state?.planningRisk?.overallLevel);
 }
 
 /**

--- a/.agents/scripts/lib/orchestration/review-providers/codex.js
+++ b/.agents/scripts/lib/orchestration/review-providers/codex.js
@@ -31,6 +31,7 @@ import { spawnSync } from 'node:child_process';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
+import { renderDepthDirective } from './review-depth.js';
 
 /**
  * Canonical install/remediation guidance baked into every probe failure.
@@ -235,6 +236,27 @@ export function parseCodexFindings(rawStdout) {
 }
 
 /**
+ * Build the `claude --print` prompt that invokes the `/codex:review` slash
+ * command for a review input. The risk-derived `depth` lever (Story #3937) is
+ * appended via `renderDepthDirective` so a high-risk Epic instructs Codex
+ * toward a deeper second-pass review while a low-risk one keeps it light; an
+ * absent depth renders the `standard` directive. The `/codex:review` slash
+ * command and its `--wait` flag are unchanged — the directive rides as
+ * trailing prompt prose the plugin's wrapping model reads.
+ *
+ * Pure. Exported for testing.
+ *
+ * @param {{ baseRef: string, headRef: string, depth?: import('./types.js').ReviewDepth }} args
+ * @returns {string}
+ */
+export function buildCodexReviewPrompt({ baseRef, headRef, depth }) {
+  return (
+    `/codex:review --base ${baseRef} --head ${headRef} --wait ` +
+    `${renderDepthDirective(depth)}`
+  );
+}
+
+/**
  * Default invoker: shell out to the host's `claude` CLI to run the
  * `/codex:review` slash command. The plugin is expected to print a
  * JSON document to stdout when `--wait` is passed; non-zero exits
@@ -244,13 +266,13 @@ export function parseCodexFindings(rawStdout) {
  * Exported for testing — the production adapter accepts an
  * `invokeFn` override so tests never spawn a real process.
  *
- * @param {{ baseRef: string, headRef: string }} args
+ * @param {{ baseRef: string, headRef: string, depth?: import('./types.js').ReviewDepth }} args
  * @returns {{ status: number, stdout: string, stderr: string }}
  */
-export function defaultInvokeCodexReview({ baseRef, headRef }) {
+export function defaultInvokeCodexReview({ baseRef, headRef, depth }) {
   const cliArgs = [
     '--print',
-    `/codex:review --base ${baseRef} --head ${headRef} --wait`,
+    buildCodexReviewPrompt({ baseRef, headRef, depth }),
   ];
   const result = spawnSync('claude', cliArgs, {
     encoding: 'utf-8',
@@ -274,7 +296,7 @@ export function defaultInvokeCodexReview({ baseRef, headRef }) {
  *
  * @param {{
  *   probeFn?: () => boolean,
- *   invokeFn?: (args: { baseRef: string, headRef: string, scope: string, ticketId: number }) => { status: number, stdout: string, stderr: string },
+ *   invokeFn?: (args: { baseRef: string, headRef: string, scope: string, ticketId: number, depth?: import('./types.js').ReviewDepth }) => { status: number, stdout: string, stderr: string },
  *   logger?: { info?: Function, warn?: Function, error?: Function },
  * }} [deps]
  * @returns {ReviewProvider}
@@ -294,7 +316,7 @@ export function createCodexProvider(deps = {}) {
      * @returns {Promise<Finding[]>}
      */
     async runReview(input) {
-      const { scope, ticketId, baseRef, headRef } = input ?? {};
+      const { scope, ticketId, baseRef, headRef, depth } = input ?? {};
       if (!baseRef || !headRef) {
         throw new TypeError(
           '[codex-review] runReview requires baseRef and headRef.',
@@ -311,7 +333,7 @@ export function createCodexProvider(deps = {}) {
           `for ${scope} #${ticketId}...`,
       );
 
-      const result = invokeFn({ baseRef, headRef, scope, ticketId });
+      const result = invokeFn({ baseRef, headRef, scope, ticketId, depth });
       if (result.status !== 0) {
         throw new Error(
           `[codex-review] /codex:review exited with status ${result.status}: ${

--- a/.agents/scripts/lib/orchestration/review-providers/native.js
+++ b/.agents/scripts/lib/orchestration/review-providers/native.js
@@ -21,6 +21,20 @@
  * (paths, runners, evidence store) is injected via the `runReview` arg or
  * the `createNativeProvider({ deps })` overload used by tests.
  *
+ * **Depth is deliberately ignored here (Story #3937).** The pluggable review
+ * contract threads a risk-derived `depth` lever (`light` / `standard` /
+ * `deep`) on `ReviewInput` so LLM-backed providers can dial their thoroughness
+ * up or down with the Epic's judged risk. This native adapter does not read
+ * `input.depth` and does not branch on it: its work is a *mechanical* lint +
+ * maintainability sweep whose cost already scales with the diff — every
+ * changed file is linted once and every changed JS file is scored once,
+ * regardless of risk tier. There is no "review harder" knob a deterministic
+ * scorer can turn: a high-risk diff and a low-risk diff of the same size do
+ * exactly the same amount of work. The contract is therefore explicit rather
+ * than silently dropping the field — `depth` is a no-op for this provider by
+ * design, and the LLM-backed providers (codex, security-review, ultrareview)
+ * are where the lever actually changes behaviour.
+ *
  * @typedef {import('./types.js').Finding} Finding
  * @typedef {import('./types.js').ReviewInput} ReviewInput
  * @typedef {import('./types.js').ReviewProvider} ReviewProvider

--- a/.agents/scripts/lib/orchestration/review-providers/review-depth.js
+++ b/.agents/scripts/lib/orchestration/review-providers/review-depth.js
@@ -1,0 +1,72 @@
+/**
+ * review-providers/review-depth.js — Shared depth-prompt vocabulary for the
+ * LLM-backed review providers.
+ *
+ * Story #3937 — the risk-derived `depth` lever (`light` / `standard` / `deep`,
+ * resolved by `resolveReviewDepth` in `code-review.js`) is threaded into every
+ * provider's `runReview` input. LLM-backed providers (codex, security-review,
+ * ultrareview) must render that lever into the prompt/instructions they emit so
+ * the model actually changes its thoroughness; the native (mechanical) provider
+ * documents in its own JSDoc why depth does not change its lint +
+ * maintainability sweep. This module is the single home for the depth → prose
+ * mapping so the three LLM providers share one wording rather than each
+ * re-spelling the semantics (which would cross the duplication gate).
+ *
+ * The mapping is intentionally model-agnostic: it describes *how thorough* the
+ * review should be, not which tool runs it. A provider appends
+ * `renderDepthDirective(depth)` to its prompt to instruct the model.
+ *
+ * @typedef {import('./types.js').ReviewDepth} ReviewDepth
+ */
+
+/**
+ * Canonical per-depth review directive sentences. Keyed by the canonical
+ * `ReviewDepth` enum. Exported so tests and doc tooling can assert against the
+ * exact wording rather than free-text matching.
+ *
+ * @type {Readonly<Record<ReviewDepth, string>>}
+ */
+export const DEPTH_DIRECTIVES = Object.freeze({
+  light:
+    'Review depth: LIGHT. Run a single pass focused on spec adherence over the ' +
+    'changed surface — confirm the change matches its stated intent. Reduce the ' +
+    'integration and quality sweeps to a quick scan for obvious breakage; do not ' +
+    'exhaustively re-walk them.',
+  standard:
+    'Review depth: STANDARD. Cover all review pillars (spec adherence, ' +
+    'integration, documentation/quality) at normal thoroughness.',
+  deep:
+    'Review depth: DEEP. Cover all review pillars at full thoroughness, then ' +
+    'make a second adversarial pass over the diff specifically hunting for ' +
+    'integration regressions and security-relevant edges before finalizing ' +
+    'findings.',
+});
+
+/**
+ * Normalize an arbitrary depth value to the canonical enum, defaulting to
+ * `standard` for anything unrecognised (including `undefined` — providers may
+ * receive an input without a depth from a caller that did not resolve one).
+ *
+ * Pure. Exported for testing.
+ *
+ * @param {unknown} depth
+ * @returns {ReviewDepth}
+ */
+export function normalizeDepth(depth) {
+  return depth === 'light' || depth === 'deep' ? depth : 'standard';
+}
+
+/**
+ * Render the depth directive sentence(s) for a given depth value, ready to
+ * append to a provider's prompt. Always returns a non-empty string carrying a
+ * `Review depth:` marker so connectivity tests can assert the lever reached the
+ * prompt regardless of which tier resolved.
+ *
+ * Pure. Exported for testing.
+ *
+ * @param {ReviewDepth|undefined} depth
+ * @returns {string}
+ */
+export function renderDepthDirective(depth) {
+  return DEPTH_DIRECTIVES[normalizeDepth(depth)];
+}

--- a/.agents/scripts/lib/orchestration/review-providers/security-review.js
+++ b/.agents/scripts/lib/orchestration/review-providers/security-review.js
@@ -32,6 +32,7 @@
  */
 
 import { spawnSync } from 'node:child_process';
+import { renderDepthDirective } from './review-depth.js';
 
 /**
  * Canonical install/remediation guidance baked into every probe
@@ -208,11 +209,15 @@ export function parseSecurityReviewFindings(rawStdout) {
  * array. Any prose preface or trailing commentary is parseable as
  * "garbage before/after JSON" — `parseSecurityReviewFindings` uses
  * the first JSON-shaped substring rather than the whole stdout.
+ *
+ * The `{depthDirective}` slot renders the risk-derived thoroughness lever
+ * (Story #3937) so a high-risk Epic instructs the model toward a deeper
+ * second-pass review while a low-risk one keeps it light.
  */
 export const SECURITY_REVIEW_INVOKE_PROMPT =
   'Run /security-review against the diff `{baseRef}`...`{headRef}` ' +
-  'for {scopeLabel} #{ticketId}. After the review, emit ONLY a JSON ' +
-  'array of findings on stdout with this exact shape:\n\n' +
+  'for {scopeLabel} #{ticketId}. {depthDirective} After the review, emit ' +
+  'ONLY a JSON array of findings on stdout with this exact shape:\n\n' +
   '```\n[{"severity":"critical|high|medium|suggestion","title":"...",' +
   '"body":"...","file":"...","line":1,"category":"security"}]\n```\n\n' +
   'Use severity "critical" for blockers (must fix before merge), ' +
@@ -221,7 +226,11 @@ export const SECURITY_REVIEW_INVOKE_PROMPT =
   'No prose around the JSON.';
 
 /**
- * Build the `claude --print` prompt for a specific review input.
+ * Build the `claude --print` prompt for a specific review input. The
+ * risk-derived `depth` lever (Story #3937) is rendered into the prompt via
+ * `renderDepthDirective` so the model's thoroughness tracks the Epic's judged
+ * risk; an absent depth renders the `standard` directive.
+ *
  * Exported for testing.
  *
  * @param {ReviewInput} input
@@ -238,7 +247,8 @@ export function buildSecurityReviewPrompt(input) {
   return SECURITY_REVIEW_INVOKE_PROMPT.replace('{baseRef}', baseRef)
     .replace('{headRef}', headRef)
     .replace('{scopeLabel}', scopeLabel)
-    .replace('{ticketId}', ticketId);
+    .replace('{ticketId}', ticketId)
+    .replace('{depthDirective}', renderDepthDirective(input?.depth));
 }
 
 /**

--- a/.agents/scripts/lib/orchestration/review-providers/types.js
+++ b/.agents/scripts/lib/orchestration/review-providers/types.js
@@ -28,11 +28,22 @@
  *
  * @typedef {'story'|'epic'} ReviewScope
  *
+ * @typedef {'light'|'standard'|'deep'} ReviewDepth
+ *
  * @typedef {object} ReviewInput
  * @property {ReviewScope} scope     - Which close boundary is invoking the review.
  * @property {number}      ticketId  - Story or Epic issue number.
  * @property {string}      baseRef   - Git ref to diff against (e.g. 'main', 'epic/2815').
  * @property {string}      headRef   - Git ref under review (e.g. 'story-2820', 'epic/2815').
+ * @property {ReviewDepth=} depth    - Risk-derived review thoroughness lever
+ *   (Story #3876/#3937). `light` → single-pass review focused on Pillar 1
+ *   (spec adherence) with Pillars 2–3 reduced to a quick scan; `standard` →
+ *   all pillars at baseline depth; `deep` → all pillars plus a second
+ *   adversarial pass over the diff. Resolved from the Epic's judged risk
+ *   envelope by `resolveReviewDepth` and threaded into `runReview`. LLM-backed
+ *   providers MUST render this into the prompt/instructions they emit; the
+ *   native provider documents why its mechanical sweep ignores it. Absent →
+ *   providers treat the review as `standard`.
  *
  * @typedef {object} ReviewProvider
  * @property {(input: ReviewInput) => Promise<Finding[]>} runReview

--- a/.agents/scripts/lib/orchestration/review-providers/ultrareview.js
+++ b/.agents/scripts/lib/orchestration/review-providers/ultrareview.js
@@ -24,21 +24,30 @@
  * @typedef {import('./types.js').ReviewInput}          ReviewInput
  */
 
+import { renderDepthDirective } from './review-depth.js';
+
 /**
  * Canonical suggestion string. Exported so tests can assert against
  * the exact wording rather than free-text matching, and so doc
  * tooling can lift the line without spawning a fake review.
+ *
+ * The `{depthDirective}` slot renders the risk-derived thoroughness lever
+ * (Story #3937) so the operator nudge tells the human reviewer how deep to go
+ * when they trigger `/ultrareview` — a high-risk Epic asks for a deep
+ * second-pass review, a low-risk one keeps it light.
  */
 export const ULTRAREVIEW_PROMPT_TEMPLATE =
   '💡 **Suggested:** Consider running `/ultrareview` on this ' +
   '{scopeLabel} (`{baseRef}`…`{headRef}`) before merging — ' +
   "Anthropic's multi-agent cloud review surfaces issues that " +
   'single-pass review can miss. This is operator-triggered ' +
-  '(billed by Anthropic); not a blocker.';
+  '(billed by Anthropic); not a blocker. {depthDirective}';
 
 /**
  * Render the canonical suggestion string with the live scope/baseRef/
- * headRef substituted.
+ * headRef substituted, and the risk-derived `depth` lever (Story #3937)
+ * rendered into the nudge via `renderDepthDirective` (absent depth → the
+ * `standard` directive).
  *
  * Pure — exported for testing.
  *
@@ -51,7 +60,8 @@ export function buildUltrareviewMessage(input) {
   const headRef = typeof input?.headRef === 'string' ? input.headRef : '?';
   return ULTRAREVIEW_PROMPT_TEMPLATE.replace('{scopeLabel}', scopeLabel)
     .replace('{baseRef}', baseRef)
-    .replace('{headRef}', headRef);
+    .replace('{headRef}', headRef)
+    .replace('{depthDirective}', renderDepthDirective(input?.depth));
 }
 
 /**

--- a/.agents/workflows/epic-deliver.md
+++ b/.agents/workflows/epic-deliver.md
@@ -490,11 +490,26 @@ structured comment on the Epic.
 
 ## Phase 5 — Code review
 
-Skip when `--skip-code-review`. Otherwise auto-invoke
+Skip when `--skip-code-review`. Otherwise resolve the **risk-derived review
+depth** for this Epic, then auto-invoke
 [`helpers/code-review.md`](helpers/code-review.md) inline (read-only audit)
 with the argument envelope `{ scope: 'epic', ticketId: <epicId>, baseRef:
-'main', headRef: 'epic/<epicId>' }`. The helper persists findings as a
-`code-review` structured comment on the Epic.
+'main', headRef: 'epic/<epicId>', depth: <reviewDepth> }`. The helper
+persists findings as a `code-review` structured comment on the Epic.
+
+The `depth` is the live epic-scope producer for Story #3876's review-depth
+lever (Story #3937). Resolve it from the Epic's judged risk envelope the same
+best-effort way Phase 4 routes audit lenses — via
+[`resolveReviewDepthForEpic`](../scripts/lib/orchestration/code-review.js),
+which reads `planningRisk.overallLevel` off the Epic's `epic-plan-state`
+checkpoint and maps it: `high` → `deep`, `low` → `light`, everything else
+(including a missing/unparseable checkpoint, or an Epic that skipped
+`/epic-plan`) → `standard`. The helper threads `depth` into `runCodeReview`,
+which forwards it to every provider's `runReview` input; the LLM-backed
+providers (codex, security-review, ultrareview) render it into the prompt they
+emit so a high-risk Epic gets a deeper adversarial pass and a low-risk one a
+lighter one. Depth is **input-only** — it never changes the findings envelope
+or the posted comment shape.
 
 - **Any 🔴 Critical Blocker** — STOP. Relay to the operator.
 - **Only 🟠/🟡/🟢** — log as non-blocking and continue.

--- a/.agents/workflows/helpers/code-review.md
+++ b/.agents/workflows/helpers/code-review.md
@@ -27,16 +27,53 @@ is merged upstream. It runs in two scopes:
 The caller passes the following arguments (Story workflows pass
 `scope: story`; Epic workflows pass `scope: epic`):
 
-| Argument    | Type                  | Required | Meaning                                                                                          |
-| ----------- | --------------------- | -------- | ------------------------------------------------------------------------------------------------ |
-| `scope`     | `"story"` \| `"epic"` | yes      | Selects the integration-pillar diff base and the structured-comment target ticket.               |
-| `ticketId`  | integer               | yes      | GitHub issue number of the Story (when `scope === 'story'`) or Epic (when `scope === 'epic'`).   |
-| `baseRef`   | string (git ref)      | yes      | The diff base. Story scope: `epic/<epicId>`. Epic scope: `main` (or `project.baseBranch`).       |
-| `headRef`   | string (git ref)      | yes      | The branch tip under review. Story scope: `story-<storyId>`. Epic scope: `epic/<epicId>`.        |
+| Argument    | Type                                  | Required | Meaning                                                                                          |
+| ----------- | ------------------------------------- | -------- | ------------------------------------------------------------------------------------------------ |
+| `scope`     | `"story"` \| `"epic"`                 | yes      | Selects the integration-pillar diff base and the structured-comment target ticket.               |
+| `ticketId`  | integer                               | yes      | GitHub issue number of the Story (when `scope === 'story'`) or Epic (when `scope === 'epic'`).   |
+| `baseRef`   | string (git ref)                      | yes      | The diff base. Story scope: `epic/<epicId>`. Epic scope: `main` (or `project.baseBranch`).       |
+| `headRef`   | string (git ref)                      | yes      | The branch tip under review. Story scope: `story-<storyId>`. Epic scope: `epic/<epicId>`.        |
+| `depth`     | `"light"` \| `"standard"` \| `"deep"` | no       | Risk-derived review thoroughness lever. Absent → `standard`. See **Review depth** below.         |
 
-All scope-dependent behavior in this helper branches off these four
+All scope-dependent behavior in this helper branches off the first four
 arguments. Do not hard-code branch names or ticket types — read them from
 the argument envelope.
+
+### Review depth (`depth`)
+
+`depth` is the risk-derived thoroughness lever introduced by Story #3876 and
+made a live consumed signal end to end by Story #3937. The Epic caller
+(`/epic-deliver` Phase 5) resolves it from the Epic's judged `planningRisk`
+envelope via
+[`resolveReviewDepthForEpic`](../../scripts/lib/orchestration/code-review.js)
+(`high` → `deep`, `low` → `light`, everything else — including a missing
+`epic-plan-state` checkpoint — → `standard`) and passes it in this envelope.
+`runCodeReview` forwards `depth` to every provider's `runReview` input.
+
+It is an **input-only** signal: it changes *how thorough* the review is, never
+the findings envelope (`{ status, severity, posted, report, halted,
+blockerReason }`) nor the posted `code-review` structured-comment body. An
+absent or malformed `depth` is treated as `standard`, so an Epic that skipped
+`/epic-plan` still gets a passing review with no new failure mode.
+
+How each tier changes the review protocol:
+
+- **`light`** — single-pass review focused on Pillar 1 (Spec Adherence) over
+  the changed surface; Pillars 2–3 (Integration, Documentation Integrity) are
+  reduced to a quick scan for obvious breakage rather than exhaustively
+  re-walked.
+- **`standard`** — the default: all three pillars at today's depth.
+- **`deep`** — all three pillars at full depth, **plus** an explicit second
+  adversarial pass over the diff hunting for integration regressions and
+  security-relevant edges before findings are finalized.
+
+The LLM-backed review providers (codex, security-review, ultrareview) render
+the resolved `depth` into the prompt/instructions they emit so the underlying
+model actually changes thoroughness. The native provider deliberately ignores
+`depth` — its mechanical lint + maintainability sweep already scales with diff
+size, and there is no "review harder" knob a deterministic scorer can turn (its
+module JSDoc documents this). When you (the host LLM) perform the Step 2 pillar
+review yourself, honor the `depth` semantics above directly.
 
 ## Step 0 — Resolve Context
 
@@ -54,9 +91,11 @@ the argument envelope.
 
 The caller invokes the in-process code-review pipeline
 (`runCodeReview` in `.agents/scripts/lib/orchestration/code-review.js`)
-with the resolved `{ scope, ticketId, baseRef, headRef }` envelope. The
+with the resolved `{ scope, ticketId, baseRef, headRef, depth }` envelope
+(`depth` defaults to `standard` when the caller omits it). The
 pluggable `ReviewProvider` adapter chain (Epic #2815) runs against the
-diff `baseRef..headRef` and posts a structured summary to `[TICKET_ID]`.
+diff `baseRef..headRef`, with the LLM-backed providers honoring `depth`
+(see **Review depth** above), and posts a structured summary to `[TICKET_ID]`.
 The pipeline will:
 
 - Generate a `git diff baseRef..headRef`.
@@ -71,6 +110,13 @@ middle pillar (**Integration Review**) deliberately defers the security /
 performance / quality / coverage sweeps to the change-set-scoped audits
 that already ran upstream — re-walking them here is duplication, not
 defense-in-depth.
+
+**Apply the `depth` lever** (see **Review depth** above) to how hard you walk
+these pillars: at `light`, focus on Pillar 1 and reduce Pillars 2–3 to a quick
+scan for obvious breakage; at `standard`, cover all three at today's depth; at
+`deep`, cover all three at full depth and then make a second adversarial pass
+over the diff hunting for integration regressions and security-relevant edges
+before finalizing findings.
 
 ### Pillar 1: Spec Adherence
 
@@ -132,7 +178,7 @@ Verify documentation stays synchronized with code:
 - All new public APIs have JSDoc/TSDoc comments.
 - Updated interfaces have updated documentation.
 - README and CHANGELOG reflect the changes if applicable.
-- Inline comments explain _why_, not _what_.
+- Inline comments explain *why*, not *what*.
 
 ## Step 3 — Maintainability Ratchet
 
@@ -188,7 +234,7 @@ paths and keep the `code-review` structured comment authoritative for
 anything not fixed in-place.
 
 1. **Apply a focused fix on `[HEAD_REF]`.** Permitted only when the
-   finding is unambiguously _fixable_ (clean remediation, no scope
+   finding is unambiguously *fixable* (clean remediation, no scope
    creep, no spec deviation, no secret exposure):
    - Call [`assert-branch.js`](../../scripts/assert-branch.js) with
      `--expected [HEAD_REF]` before touching the working tree.
@@ -215,8 +261,8 @@ anything not fixed in-place.
      attempt (the equivalent of the prior loop's
      `validation-regression` / `thrash-detected` exits).
 
-Do not invent a programmatic retry budget. The host LLM applies _at most
-one_ focused-fix attempt per finding before escalating to the operator.
+Do not invent a programmatic retry budget. The host LLM applies *at most
+one* focused-fix attempt per finding before escalating to the operator.
 Escalated findings remain on the `code-review` structured comment with
 their reason recorded, so Step 5 (and downstream consumers) see exactly
 why each one was not auto-remediated.

--- a/tests/contract/orchestration/review-depth-connectivity.test.js
+++ b/tests/contract/orchestration/review-depth-connectivity.test.js
@@ -1,0 +1,270 @@
+// tests/contract/orchestration/review-depth-connectivity.test.js
+//
+// Contract tier (Story #3937): proves the epic code-review `depth` signal is a
+// real, consumed wire from producer to provider — the boundary the prior
+// "dead wiring" complexity-review flagged.
+//
+// The wire has three segments, each asserted here:
+//   1. Producer — `resolveReviewDepthForEpic` reads the Epic's `planningRisk`
+//      envelope off the `epic-plan-state` checkpoint (best-effort `readPlanState`)
+//      and resolves the depth: high → deep, low → light, absent/malformed →
+//      standard (the no-new-failure-mode default).
+//   2. Pipeline — feeding that depth into `runCodeReview` (via `planningRisk`)
+//      threads it into the provider's `runReview` input. high → 'deep',
+//      low → 'light', absent → 'standard'.
+//   3. Consumer — the LLM-backed providers render the depth marker into the
+//      prompt/instructions they emit. The suite FAILS if any of them omits it.
+//
+// All I/O is injected: `readPlanState`, the review provider, the GitHub
+// upserter, and the renderer are stubbed. No network, git, or filesystem.
+
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+  resolveReviewDepthForEpic,
+  runCodeReview,
+} from '../../../.agents/scripts/lib/orchestration/code-review.js';
+import { buildCodexReviewPrompt } from '../../../.agents/scripts/lib/orchestration/review-providers/codex.js';
+import {
+  DEPTH_DIRECTIVES,
+  renderDepthDirective,
+} from '../../../.agents/scripts/lib/orchestration/review-providers/review-depth.js';
+import { buildSecurityReviewPrompt } from '../../../.agents/scripts/lib/orchestration/review-providers/security-review.js';
+import { buildUltrareviewMessage } from '../../../.agents/scripts/lib/orchestration/review-providers/ultrareview.js';
+
+// --- Producer segment: checkpoint → depth ---------------------------------
+
+/**
+ * Fake `readPlanState` mirroring the epic-audit-prepare test seam: returns a
+ * checkpoint whose `planningRisk` is the supplied envelope, or `null` for a
+ * missing checkpoint.
+ */
+function makeFakeReadPlanState(planningRisk) {
+  return async () => (planningRisk === null ? null : { planningRisk });
+}
+
+test('producer: high-risk checkpoint → deep', async () => {
+  const depth = await resolveReviewDepthForEpic({
+    epicId: 100,
+    provider: {},
+    readPlanState: makeFakeReadPlanState({ overallLevel: 'high' }),
+  });
+  assert.equal(depth, 'deep');
+});
+
+test('producer: low-risk checkpoint → light', async () => {
+  const depth = await resolveReviewDepthForEpic({
+    epicId: 100,
+    provider: {},
+    readPlanState: makeFakeReadPlanState({ overallLevel: 'low' }),
+  });
+  assert.equal(depth, 'light');
+});
+
+test('producer: medium-risk checkpoint → standard', async () => {
+  const depth = await resolveReviewDepthForEpic({
+    epicId: 100,
+    provider: {},
+    readPlanState: makeFakeReadPlanState({ overallLevel: 'medium' }),
+  });
+  assert.equal(depth, 'standard');
+});
+
+test('producer: missing checkpoint → standard (Epic skipped /epic-plan)', async () => {
+  const depth = await resolveReviewDepthForEpic({
+    epicId: 100,
+    provider: {},
+    readPlanState: makeFakeReadPlanState(null),
+  });
+  assert.equal(depth, 'standard');
+});
+
+test('producer: malformed planningRisk → standard', async () => {
+  const depth = await resolveReviewDepthForEpic({
+    epicId: 100,
+    provider: {},
+    readPlanState: makeFakeReadPlanState({ overallLevel: 'bogus' }),
+  });
+  assert.equal(depth, 'standard');
+});
+
+test('producer: read failure degrades to standard, never throws', async () => {
+  const depth = await resolveReviewDepthForEpic({
+    epicId: 100,
+    provider: {},
+    readPlanState: async () => {
+      throw new Error('provider exploded');
+    },
+  });
+  assert.equal(depth, 'standard');
+});
+
+// --- Pipeline segment: depth reaches the provider -------------------------
+
+function fakeResolveConfig() {
+  return { project: { baseBranch: 'main' }, delivery: { codeReview: null } };
+}
+
+/**
+ * Drive an epic-scope `runCodeReview` with a checkpoint-resolved depth and
+ * capture the `runReview` input the provider receives. Mirrors the producer →
+ * pipeline handoff: the depth resolved in segment 1 is what the Phase 5 helper
+ * forwards as `planningRisk` to `runCodeReview`.
+ */
+async function captureProviderDepth(planningRisk) {
+  const captured = {};
+  const bus = { emit: async () => {} };
+  await runCodeReview({
+    epicId: 100,
+    provider: {},
+    bus,
+    planningRisk,
+    reviewProvider: {
+      runReview: async (input) => {
+        captured.input = input;
+        return [];
+      },
+    },
+    resolveConfigFn: fakeResolveConfig,
+    upsertCommentFn: async () => ({ commentId: 1 }),
+    renderFindingsFn: () => '## Code Review\n',
+  });
+  return captured.input;
+}
+
+test('pipeline: high → deep reaches the provider runReview input', async () => {
+  const input = await captureProviderDepth({ overallLevel: 'high' });
+  assert.equal(input.depth, 'deep');
+});
+
+test('pipeline: low → light reaches the provider runReview input', async () => {
+  const input = await captureProviderDepth({ overallLevel: 'low' });
+  assert.equal(input.depth, 'light');
+});
+
+test('pipeline: absent risk → standard reaches the provider runReview input', async () => {
+  const input = await captureProviderDepth(undefined);
+  assert.equal(input.depth, 'standard');
+});
+
+test('pipeline: end-to-end, a high-risk checkpoint resolves and reaches the provider as deep', async () => {
+  // Compose the two segments the way Phase 5 does: the producer resolves the
+  // depth from the checkpoint, and the pipeline maps the same `planningRisk`
+  // envelope into the provider input. Both must agree on `deep`.
+  const planningRisk = { overallLevel: 'high' };
+  const resolvedDepth = await resolveReviewDepthForEpic({
+    epicId: 100,
+    provider: {},
+    readPlanState: makeFakeReadPlanState(planningRisk),
+  });
+  assert.equal(resolvedDepth, 'deep');
+  const providerInput = await captureProviderDepth(planningRisk);
+  assert.equal(providerInput.depth, resolvedDepth);
+});
+
+// --- Consumer segment: LLM providers render the depth marker --------------
+
+const DEPTH_MARKER = 'Review depth:';
+
+test('consumer: renderDepthDirective always carries the depth marker', () => {
+  for (const depth of ['light', 'standard', 'deep', undefined, 'bogus']) {
+    assert.ok(
+      renderDepthDirective(depth).includes(DEPTH_MARKER),
+      `directive for ${String(depth)} omits the depth marker`,
+    );
+  }
+});
+
+test('consumer: security-review prompt embeds the resolved depth directive', () => {
+  const prompt = buildSecurityReviewPrompt({
+    scope: 'epic',
+    ticketId: 100,
+    baseRef: 'main',
+    headRef: 'epic/100',
+    depth: 'deep',
+  });
+  assert.ok(
+    prompt.includes(DEPTH_MARKER),
+    'security-review prompt omits the depth marker',
+  );
+  assert.ok(
+    prompt.includes(DEPTH_DIRECTIVES.deep),
+    'security-review prompt omits the deep directive text',
+  );
+});
+
+test('consumer: ultrareview suggestion embeds the resolved depth directive', () => {
+  const message = buildUltrareviewMessage({
+    scope: 'epic',
+    ticketId: 100,
+    baseRef: 'main',
+    headRef: 'epic/100',
+    depth: 'light',
+  });
+  assert.ok(
+    message.includes(DEPTH_MARKER),
+    'ultrareview suggestion omits the depth marker',
+  );
+  assert.ok(
+    message.includes(DEPTH_DIRECTIVES.light),
+    'ultrareview suggestion omits the light directive text',
+  );
+});
+
+test('consumer: codex prompt embeds the resolved depth directive', () => {
+  const prompt = buildCodexReviewPrompt({
+    baseRef: 'main',
+    headRef: 'epic/100',
+    depth: 'deep',
+  });
+  assert.ok(
+    prompt.includes(DEPTH_MARKER),
+    'codex prompt omits the depth marker',
+  );
+  assert.ok(
+    prompt.includes(DEPTH_DIRECTIVES.deep),
+    'codex prompt omits the deep directive text',
+  );
+  // The slash command and --wait flag must survive the depth append.
+  assert.ok(
+    prompt.includes('/codex:review --base main --head epic/100 --wait'),
+    'codex prompt dropped the slash-command invocation',
+  );
+});
+
+test('consumer: an omitted depth still renders the standard marker (no silent drop)', () => {
+  const prompt = buildSecurityReviewPrompt({
+    scope: 'epic',
+    ticketId: 100,
+    baseRef: 'main',
+    headRef: 'epic/100',
+  });
+  assert.ok(
+    prompt.includes(DEPTH_DIRECTIVES.standard),
+    'security-review prompt dropped the standard directive when depth was absent',
+  );
+});
+
+// --- No new failure mode for absent/malformed risk ------------------------
+
+test('absent planningRisk yields a passing review run (status ok, standard depth)', async () => {
+  const captured = {};
+  const result = await runCodeReview({
+    epicId: 100,
+    provider: {},
+    bus: { emit: async () => {} },
+    // no planningRisk at all
+    reviewProvider: {
+      runReview: async (input) => {
+        captured.input = input;
+        return [];
+      },
+    },
+    resolveConfigFn: fakeResolveConfig,
+    upsertCommentFn: async () => ({ commentId: 1 }),
+    renderFindingsFn: () => '## Code Review\n',
+  });
+  assert.equal(result.status, 'ok');
+  assert.equal(result.halted, false);
+  assert.equal(captured.input.depth, 'standard');
+});

--- a/tests/lib/orchestration/review-providers/codex.test.js
+++ b/tests/lib/orchestration/review-providers/codex.test.js
@@ -260,7 +260,7 @@ test('runReview: returns parsed Finding[] with canonical severities', async () =
   }
 });
 
-test('runReview: invokeFn receives baseRef + headRef + scope + ticketId', async () => {
+test('runReview: invokeFn receives baseRef + headRef + scope + ticketId + depth', async () => {
   let captured = null;
   const provider = createCodexProvider({
     probeFn: presentProbe,
@@ -274,12 +274,14 @@ test('runReview: invokeFn receives baseRef + headRef + scope + ticketId', async 
     ticketId: 2830,
     baseRef: 'epic/2815',
     headRef: 'story-2830',
+    depth: 'deep',
   });
   assert.deepEqual(captured, {
     baseRef: 'epic/2815',
     headRef: 'story-2830',
     scope: 'story',
     ticketId: 2830,
+    depth: 'deep',
   });
 });
 


### PR DESCRIPTION
Closes #3937

_Auto-opened by `/single-story-deliver`._