### PR TITLE
fix(doctor): degrade gh-auth check to warn-and-skip when an env token is present

### DIFF
--- a/.github/workflows/install-matrix.yml
+++ b/.github/workflows/install-matrix.yml
@@ -19,9 +19,12 @@ name: Install Matrix
 #   2. The consumer package.json is not mutated with framework runtime deps.
 #   3. `mandrel doctor` returns a ready verdict.
 #
-# `mandrel doctor` requires an authenticated GitHub CLI (its `gh-auth` check),
-# so each leg exports the workflow's GITHUB_TOKEN as GH_TOKEN — on GitHub-hosted
-# runners `gh` is preinstalled and `gh auth status` authenticates against it.
+# `mandrel doctor`'s `gh-auth` check confirms the GitHub CLI can authenticate,
+# so each leg exports the workflow's GITHUB_TOKEN as GH_TOKEN. `gh auth status`
+# performs live token validation that an Actions installation token cannot pass
+# (`GET /user` → 403 for integration tokens), so the check degrades to
+# warn-and-skip when a token is present in the environment — the runtime
+# authenticates non-interactively with that token regardless.
 # Doctor's `commands-in-sync` check compares `.agents/workflows/` to
 # `.claude/commands/` relative to the installed package, so the leg also runs
 # `mandrel sync-commands` (the same step the bootstrap/postinstall flow runs)

--- a/lib/cli/registry.js
+++ b/lib/cli/registry.js
@@ -181,10 +181,25 @@ function runGithubToken({ env = process.env, runner = spawn } = {}) {
 // ---------------------------------------------------------------------------
 
 /**
- * @param {{ runner?: (cmd: string, args: string[]) => { status: number|null, stdout: string, stderr: string, error?: NodeJS.ErrnoException } }} [opts]
+ * Verify the GitHub CLI can authenticate.
+ *
+ * `gh auth status` performs **live token validation** (it probes the API for
+ * the active token). A GitHub Actions installation token — and some
+ * fine-grained tokens — cannot pass that probe (`GET /user` returns 403
+ * "Resource not accessible by integration") even though the token works for
+ * every git/API operation mandrel actually performs. The non-interactive
+ * runtime never consults `gh auth status`: it resolves auth via the env token
+ * or `gh auth token` (`.agents/scripts/providers/github/auth.js#resolveToken`,
+ * mirrored by the `github-token` check above). So when `gh auth status` fails
+ * but a token is present in the environment, degrade to **warn-and-skip**
+ * (ok=true) rather than false-blocking the ready verdict — the same
+ * warn-and-skip resolution #3915 applied to the project-scope preflight.
+ * A genuine "no token anywhere and not logged in" condition still fails.
+ *
+ * @param {{ runner?: (cmd: string, args: string[]) => { status: number|null, stdout: string, stderr: string, error?: NodeJS.ErrnoException }, env?: Record<string,string|undefined> }} [opts]
  * @returns {{ ok: boolean, detail: string, remedy?: string }}
  */
-function runGhAuth({ runner = spawn } = {}) {
+function runGhAuth({ runner = spawn, env = process.env } = {}) {
   const r = runner('gh', ['auth', 'status']);
   if (r.error?.code === 'ENOENT') {
     return {
@@ -194,6 +209,14 @@ function runGhAuth({ runner = spawn } = {}) {
     };
   }
   if (r.status !== 0) {
+    const envToken = env.GITHUB_TOKEN || env.GH_TOKEN;
+    if (envToken && envToken.length > 0) {
+      return {
+        ok: true,
+        detail:
+          '`gh auth status` could not validate the active token, but GITHUB_TOKEN/GH_TOKEN is set (the runtime authenticates non-interactively with it)',
+      };
+    }
     return {
       ok: false,
       detail: 'not logged in',

--- a/tests/cli/registry.test.js
+++ b/tests/cli/registry.test.js
@@ -359,13 +359,38 @@ describe('gh-auth check', () => {
     assert.equal(result.detail, 'logged in');
   });
 
-  it('returns ok=false when gh auth status exits non-zero', () => {
+  it('returns ok=false when gh auth status exits non-zero and no env token is present', () => {
     const check = findCheck('gh-auth');
     const result = check.run({
       runner: () => ({ status: 1, stdout: '', stderr: 'not logged in' }),
+      env: {},
     });
     assertResultShape(result, { expectOk: false });
     assert.match(result.remedy, /gh auth login/);
+  });
+
+  it('degrades to ok=true when gh auth status fails but GITHUB_TOKEN is set (CI installation token)', () => {
+    const check = findCheck('gh-auth');
+    const result = check.run({
+      runner: () => ({
+        status: 1,
+        stdout: '',
+        stderr: 'The token in GH_TOKEN is invalid.',
+      }),
+      env: { GITHUB_TOKEN: 'ghs_actions_installation_token' },
+    });
+    assertResultShape(result, { expectOk: true });
+    assert.match(result.detail, /GITHUB_TOKEN\/GH_TOKEN is set/);
+    assert.equal(result.remedy, undefined);
+  });
+
+  it('degrades to ok=true when gh auth status fails but GH_TOKEN is set', () => {
+    const check = findCheck('gh-auth');
+    const result = check.run({
+      runner: () => ({ status: 1, stdout: '', stderr: 'not logged in' }),
+      env: { GH_TOKEN: 'gho_some_token' },
+    });
+    assertResultShape(result, { expectOk: true });
   });
 });
 


### PR DESCRIPTION
## Why

The **Install Matrix** required check (`install (yarn / windows-latest)`, `install (npm / ubuntu-latest)`) started failing on `main` and on every PR — the `mandrel doctor` `gh-auth` check reports `✘ gh-auth: not logged in` → `❌ Not ready (1/10 checks failed)`, even though the workflow exports a valid `GITHUB_TOKEN`/`GH_TOKEN`.

**Root cause:** `gh auth status` performs *live token validation*. The GitHub Actions `GITHUB_TOKEN` is an App installation token that cannot pass that probe (`GET /user` → 403 "Resource not accessible by integration"), even though it works for every git/API operation. When the hosted-runner `gh` version began validating the active token, the `gh-auth` check — which hard-gates on `gh auth status`'s exit code — started false-blocking the `doctor-ready` gate. This is unrelated to any product diff (confirmed red on `main`, e.g. run 27287470247).

## What

When `gh auth status` exits non-zero **but a token is present in the environment** (`GITHUB_TOKEN`/`GH_TOKEN`), the `gh-auth` check now degrades to **warn-and-skip** (`ok=true`) — the runtime authenticates non-interactively with that token via `providers/github/auth.js#resolveToken` and never consults `gh auth status`. This mirrors the warn-and-skip resolution #3915 applied to the project-scope preflight. A genuine "no token anywhere and not logged in" condition still fails with the `gh auth login` remedy.

- `lib/cli/registry.js` — `runGhAuth` gains an injectable `env` seam and the degrade branch.
- `tests/cli/registry.test.js` — the existing non-zero case now pins `env: {}` (deterministic genuine-failure); two new cases cover the CI installation-token degrade path.
- `.github/workflows/install-matrix.yml` — header comment corrected to describe the new behavior.

## Self-validating

This PR's own Install Matrix run exercises the patched check (the doctor step runs this branch's `registry.js`), so a green Install Matrix here *is* the proof.

## Verification

- `node --test tests/cli/registry.test.js tests/scripts/install-matrix-assert.test.js` → 58 pass
- `npm run lint` → clean
- `npm run test:quick` → 358 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)