### PR TITLE
docs: mark epic-lifecycle and install-bootstrap reviews as resolved

### DIFF
--- a/docs/epic-lifecycle-review.md
+++ b/docs/epic-lifecycle-review.md
@@ -10,6 +10,16 @@
 > **Remediation tracking:** GitHub Stories #3900–#3911 (see
 > [§6 Recommended sequence](#6-recommended-sequence)). All carry
 > `type::story` + `meta::framework-gap`.
+>
+> **✅ Status: RESOLVED (2026-06-10).** All twelve remediation Stories
+> (#3900–#3911) have been delivered and merged to `main` across a
+> dependency-aware 5-wave `/story-deliver` run. Every §1 defect is repaired,
+> the dead runner stratum (§2.1) is deleted, the state surfaces (§2.2) are
+> collapsed, the resilience gaps (§3) are closed, and the planning/structural
+> simplifications (§4) are landed. Per-Story merge commits are listed in
+> [§6 Recommended sequence](#6-recommended-sequence). The findings below are
+> retained as the historical review record; each is annotated with its
+> resolving Story.
 
 ## TL;DR
 
@@ -283,40 +293,45 @@ only in tests and prose.
 
 ## 6. Recommended sequence
 
-| Step | Work | Stories |
-|---|---|---|
-| **1. Repair (~100 LOC)** | Make the four silently-dead features work again and close the correctness gaps. | #3900, #3901, #3902, #3903, #3904, #3905, #3906, #3907 |
-| **2. Delete the dead stratum** | Remove the unreachable in-process runner + listeners (~10k LOC), consistent with the hard-cutover doctrine. | #3908 |
-| **3. Collapse state surfaces** | Keep checkpoint + ledger + one progress comment; drop the rest. | #3909 |
-| **4. Simplify planning + sweep prose** | Trim deterministic proxies; single-home each procedure; remove Task-era / stale-rename references. | #3910 |
-| **5. Structural (directional)** | Replace the bus with direct calls; collapse the steady-state wave loop. **Depends on steps 1–2.** | #3911 |
+| Step | Work | Stories | Status |
+|---|---|---|---|
+| **1. Repair (~100 LOC)** | Make the four silently-dead features work again and close the correctness gaps. | #3900, #3901, #3902, #3903, #3904, #3905, #3906, #3907 | ✅ Done |
+| **2. Delete the dead stratum** | Remove the unreachable in-process runner + listeners (~10k LOC), consistent with the hard-cutover doctrine. | #3908 | ✅ Done |
+| **3. Collapse state surfaces** | Keep checkpoint + ledger + one progress comment; drop the rest. | #3909 | ✅ Done |
+| **4. Simplify planning + sweep prose** | Trim deterministic proxies; single-home each procedure; remove Task-era / stale-rename references. | #3910 | ✅ Done |
+| **5. Structural (directional)** | Replace the bus with direct calls; collapse the steady-state wave loop. **Depends on steps 1–2.** | #3911 | ✅ Done |
+
+All steps delivered and merged to `main` on 2026-06-10.
 
 ### Step 1 — repair stories
 
-| Story | Title |
-|---|---|
-| [#3900](https://github.com/dsj1984/mandrel/issues/3900) | repair idle-watchdog + Epic-lease via main-checkout ledger path and dispatch-end emission |
-| [#3901](https://github.com/dsj1984/mandrel/issues/3901) | make the Phase 8.5 auto-merge gate reachable + add event-connectivity contract test |
-| [#3902](https://github.com/dsj1984/mandrel/issues/3902) | make Phase 8 pr-watch actually poll CI to green instead of emitting into an empty bus |
-| [#3903](https://github.com/dsj1984/mandrel/issues/3903) | ship `retro-run.js` CLI so Phase 6 retro is executable (remove phantom `epic-deliver.js`) |
-| [#3904](https://github.com/dsj1984/mandrel/issues/3904) | propagate finalize/listener failures to `lifecycle-emit` exit code and ledger |
-| [#3905](https://github.com/dsj1984/mandrel/issues/3905) | repair `--force` re-plan (`--explicit-delete`) and `--resume` idempotency on missing `state.json` |
-| [#3906](https://github.com/dsj1984/mandrel/issues/3906) | re-point or remove vacated validators and dead init guards |
-| [#3907](https://github.com/dsj1984/mandrel/issues/3907) | correct story-close push-failure recovery + format-autofix cwd, and close wave-loop resilience gaps |
+| Story | Title | Resolution |
+|---|---|---|
+| [#3900](https://github.com/dsj1984/mandrel/issues/3900) | repair idle-watchdog + Epic-lease via main-checkout ledger path and dispatch-end emission | ✅ [PR #3926](https://github.com/dsj1984/mandrel/pull/3926) (`9bd172bc`) |
+| [#3901](https://github.com/dsj1984/mandrel/issues/3901) | make the Phase 8.5 auto-merge gate reachable + add event-connectivity contract test | ✅ [PR #3932](https://github.com/dsj1984/mandrel/pull/3932) (`509e0af2`) |
+| [#3902](https://github.com/dsj1984/mandrel/issues/3902) | make Phase 8 pr-watch actually poll CI to green instead of emitting into an empty bus | ✅ [PR #3925](https://github.com/dsj1984/mandrel/pull/3925) (`078a891`) |
+| [#3903](https://github.com/dsj1984/mandrel/issues/3903) | ship `retro-run.js` CLI so Phase 6 retro is executable (remove phantom `epic-deliver.js`) | ✅ [PR #3924](https://github.com/dsj1984/mandrel/pull/3924) (`b663840`) |
+| [#3904](https://github.com/dsj1984/mandrel/issues/3904) | propagate finalize/listener failures to `lifecycle-emit` exit code and ledger | ✅ [PR #3927](https://github.com/dsj1984/mandrel/pull/3927) (`588f0ba3`) |
+| [#3905](https://github.com/dsj1984/mandrel/issues/3905) | repair `--force` re-plan (`--explicit-delete`) and `--resume` idempotency on missing `state.json` | ✅ [PR #3928](https://github.com/dsj1984/mandrel/pull/3928) (`617a1215`) |
+| [#3906](https://github.com/dsj1984/mandrel/issues/3906) | re-point or remove vacated validators and dead init guards | ✅ [PR #3929](https://github.com/dsj1984/mandrel/pull/3929) (`15caad90`) |
+| [#3907](https://github.com/dsj1984/mandrel/issues/3907) | correct story-close push-failure recovery + format-autofix cwd, and close wave-loop resilience gaps | ✅ [PR #3930](https://github.com/dsj1984/mandrel/pull/3930) (`7ac053a9`) |
 
 ### Steps 2–5
 
-| Story | Title |
-|---|---|
-| [#3908](https://github.com/dsj1984/mandrel/issues/3908) | delete the dead in-process epic-runner stratum (bus/listeners/wave-session) |
-| [#3909](https://github.com/dsj1984/mandrel/issues/3909) | collapse overlapping run-state/progress surfaces to checkpoint+ledger+one comment |
-| [#3910](https://github.com/dsj1984/mandrel/issues/3910) | simplify deterministic planning proxies and sweep stale/duplicated workflow prose |
-| [#3911](https://github.com/dsj1984/mandrel/issues/3911) | replace lifecycle bus with direct calls + collapse steady-state wave loop |
+| Story | Title | Resolution |
+|---|---|---|
+| [#3908](https://github.com/dsj1984/mandrel/issues/3908) | delete the dead in-process epic-runner stratum (bus/listeners/wave-session) | ✅ [PR #3936](https://github.com/dsj1984/mandrel/pull/3936) (`fcea7170`; 225 ins / 12,810 del) |
+| [#3909](https://github.com/dsj1984/mandrel/issues/3909) | collapse overlapping run-state/progress surfaces to checkpoint+ledger+one comment | ✅ [PR #3945](https://github.com/dsj1984/mandrel/pull/3945) (`80b598c3`) |
+| [#3910](https://github.com/dsj1984/mandrel/issues/3910) | simplify deterministic planning proxies and sweep stale/duplicated workflow prose | ✅ [PR #3931](https://github.com/dsj1984/mandrel/pull/3931) (`6b53fa80`) |
+| [#3911](https://github.com/dsj1984/mandrel/issues/3911) | replace lifecycle bus with direct calls + collapse steady-state wave loop | ✅ [PR #3948](https://github.com/dsj1984/mandrel/pull/3948) (`037afdec`) — ADR `20260610-lifecycle-bus-retained`: bus **retained** (its schema-validate / ledger-ordering / seqId / secret-strip guarantees are load-bearing for the resume contract; the hot path already uses direct ledger-appends per #3900, and #3901's event-connectivity contract test meets the wrong-emit motive); wave-loop collapse already completed via #3909/#3907/#3900. |
 
-> **Sequencing note:** do steps 1–2 before step 5. Story #3911 (structural) is
-> intentionally last — it should not start until the surviving features work
-> (#3900–#3907) and the dead stratum is removed (#3908), or it will be
-> reimplementing code that is about to be deleted.
+> **Sequencing note (historical):** steps 1–2 ran before step 5. Story #3911
+> (structural) was intentionally last — it did not start until the surviving
+> features worked (#3900–#3907) and the dead stratum was removed (#3908). In
+> delivery, #3911's architect pass concluded the bus should be **kept** (see
+> the resolution note above) rather than replaced, since the wave-loop
+> collapse was already achieved by the earlier repairs and the bus's
+> invariants are load-bearing.
 
 ### Dependencies (encoded in GitHub)
 

--- a/docs/install-bootstrap-review.md
+++ b/docs/install-bootstrap-review.md
@@ -11,26 +11,33 @@ The individual pieces are well-engineered — small entry points, injectable sea
 
 ## High-priority story tracker
 
-Stories were filed for every P0 and P1 recommendation:
+Stories were filed for every P0 and P1 recommendation.
 
-| Story | Priority | Finding | Summary |
-| --- | --- | --- | --- |
-| [#3891](https://github.com/dsj1984/mandrel/issues/3891) | P0 | A.1 | Publish the `create-mandrel` launcher and resolve its package name |
-| [#3892](https://github.com/dsj1984/mandrel/issues/3892) | P0 | A.2, A.3 | Rewrite install quickstart + SDLC Phase 0 around the canonical path |
-| [#3893](https://github.com/dsj1984/mandrel/issues/3893) | P0 | A.4, A.5 | Stop doctor + bootstrap preflight from false-blocking on auth |
-| [#3894](https://github.com/dsj1984/mandrel/issues/3894) | P1 | B.1 | Fix the cold-start secret-push hazard (gitignore before staging) |
-| [#3895](https://github.com/dsj1984/mandrel/issues/3895) | P1 | B.2 | Make `mandrel uninstall` preserve a pre-existing `.agentrc.json` |
-| [#3896](https://github.com/dsj1984/mandrel/issues/3896) | P1 | B.3 | Dedupe Projects V2 board creation on bootstrap re-run |
-| [#3897](https://github.com/dsj1984/mandrel/issues/3897) | P1 | B.4 | Thread a real GitHub-admin consent signal |
-| [#3898](https://github.com/dsj1984/mandrel/issues/3898) | P1 | B.5 | Exit non-zero when the GitHub-side bootstrap fails |
-| [#3899](https://github.com/dsj1984/mandrel/issues/3899) | P0/P1 | A.6 | End bootstrap with an offered commit + push of the wiring |
+**✅ Status: RESOLVED (2026-06-10).** All nine high-priority Stories
+(#3891–#3899) have been delivered and merged to `main`. Every P0 front-door
+break (§A) and every P1 correctness/safety bug (§B.1–B.5) below that carried a
+Story is fixed. The remaining un-storied findings (§B.6–B.9, §C, §D) are P2/P3
+and remain open as future work. The findings text below is retained as the
+historical review record.
+
+| Story | Priority | Finding | Summary | Resolution |
+| --- | --- | --- | --- | --- |
+| [#3891](https://github.com/dsj1984/mandrel/issues/3891) | P0 | A.1 | Publish the `create-mandrel` launcher and resolve its package name | ✅ [PR #3914](https://github.com/dsj1984/mandrel/pull/3914) (`ed46c9e3`) |
+| [#3892](https://github.com/dsj1984/mandrel/issues/3892) | P0 | A.2, A.3 | Rewrite install quickstart + SDLC Phase 0 around the canonical path | ✅ [PR #3913](https://github.com/dsj1984/mandrel/pull/3913) (`cd128d97`) |
+| [#3893](https://github.com/dsj1984/mandrel/issues/3893) | P0 | A.4, A.5 | Stop doctor + bootstrap preflight from false-blocking on auth | ✅ [PR #3915](https://github.com/dsj1984/mandrel/pull/3915) (`e7f12c8`) |
+| [#3894](https://github.com/dsj1984/mandrel/issues/3894) | P1 | B.1 | Fix the cold-start secret-push hazard (gitignore before staging) | ✅ [PR #3918](https://github.com/dsj1984/mandrel/pull/3918) (`37358d2d`) |
+| [#3895](https://github.com/dsj1984/mandrel/issues/3895) | P1 | B.2 | Make `mandrel uninstall` preserve a pre-existing `.agentrc.json` | ✅ [PR #3919](https://github.com/dsj1984/mandrel/pull/3919) (`ebdfd37`) |
+| [#3896](https://github.com/dsj1984/mandrel/issues/3896) | P1 | B.3 | Dedupe Projects V2 board creation on bootstrap re-run | ✅ [PR #3920](https://github.com/dsj1984/mandrel/pull/3920) (`84e6e20`) |
+| [#3897](https://github.com/dsj1984/mandrel/issues/3897) | P1 | B.4 | Thread a real GitHub-admin consent signal | ✅ [PR #3921](https://github.com/dsj1984/mandrel/pull/3921) |
+| [#3898](https://github.com/dsj1984/mandrel/issues/3898) | P1 | B.5 | Exit non-zero when the GitHub-side bootstrap fails | ✅ [PR #3922](https://github.com/dsj1984/mandrel/pull/3922) (`06296213`) |
+| [#3899](https://github.com/dsj1984/mandrel/issues/3899) | P0/P1 | A.6 | End bootstrap with an offered commit + push of the wiring | ✅ [PR #3923](https://github.com/dsj1984/mandrel/pull/3923) |
 
 ## npm publication status (verified)
 
 | Package | Declared name | Registry status |
 | --- | --- | --- |
 | Framework | `@mandrelai/agents` | **Published** — 1.54.0 is `latest`; the only package in the `mandrelai` org (`npm access list packages mandrelai`) |
-| Launcher | `create-mandrel` (unscoped) | **Not published** — E404 for both `create-mandrel` and `@mandrelai/create-mandrel` |
+| Launcher | `create-mandrel` (unscoped) | **Publish wired (Story #3891)** — at review time E404 for both `create-mandrel` and `@mandrelai/create-mandrel`. [PR #3914](https://github.com/dsj1984/mandrel/pull/3914) added the `npm-publish-launcher` job (gated on the launcher's own per-path `release_created`) and set `publishConfig.access: public` + `provenance: true`; the name is claimed on the next release that bumps the launcher version. |
 
 Two consequences for the launcher:
 


### PR DESCRIPTION
## Why

Both review reports drove a full remediation pass that has now completed. This
updates the two docs to reflect that all tracked Stories are delivered and
merged, so a future reader sees resolution status (and the resolving PR/commit)
rather than an open backlog.

## What changed

- **docs/epic-lifecycle-review.md** — added a RESOLVED banner; annotated the
  §6 recommended-sequence tables with ✅ + merged PR/commit per Story
  (#3900–#3911). Noted #3911's architect ADR (`20260610-lifecycle-bus-retained`)
  concluded the lifecycle bus should be **kept**, not replaced.
- **docs/install-bootstrap-review.md** — added a RESOLVED banner; annotated the
  high-priority tracker with ✅ + merged PR/commit per Story (#3891–#3899);
  updated the npm publication-status row for the launcher to reflect #3891's
  `npm-publish-launcher` job. Un-storied P2/P3 findings (§B.6–B.9, §C, §D) are
  explicitly marked as still-open future work.

All 23 Stories (#3889–#3911) were delivered end-to-end via `/story-deliver`
across 5 dependency-aware waves; each merged to `main` with green CI.

## Verification

- `npm run lint` — 0 errors (markdownlint + check-doc-links clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)