### PR TITLE
fix(release): gate root npm publish on un-prefixed release_created output

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -18,16 +18,24 @@ jobs:
   release-please:
     name: Run release-please
     runs-on: ubuntu-latest
-    # Multi-package (manifest) mode emits per-path outputs prefixed with the
-    # package path: `.` for the root `mandrel` package and `create-mandrel`
-    # for the launcher. The top-level `release_created` is true if *either*
-    # package released, so each publish job must key off its OWN package's
-    # per-path output — otherwise a launcher-only release would re-run the
-    # root `npm publish` on an already-published version (and fail), and vice
-    # versa. See release-please-action multi-package outputs.
+    # Multi-package (manifest) output naming — verified against
+    # release-please-action v5.0.0 `src/index.ts#setPathOutput`:
+    #
+    #   if (path === '.') core.setOutput(key, value)           // root: UN-prefixed
+    #   else              core.setOutput(`${path}--${key}`, …)  // non-root: prefixed
+    #
+    # The root `mandrel` package has manifest path `.`, so its outputs are the
+    # **un-prefixed** `release_created` / `tag_name`. Only **non-root** packages
+    # (the launcher, path `create-mandrel`) get the `${path}--${key}` prefix.
+    # There is therefore no `.--release_created` output — keying off it (as the
+    # initial Story #3891 wiring did) silently skips the root publish on every
+    # release. The singular `release_created` is **root-specific** (set only
+    # when the root path releases, never on a launcher-only release), so it is
+    # the correct, drift-proof gate for the root publish; `releases_created`
+    # (plural) is the "any package released" boolean and is NOT used here.
     outputs:
-      root_release_created: ${{ steps.release.outputs['.--release_created'] }}
-      root_tag_name: ${{ steps.release.outputs['.--tag_name'] }}
+      root_release_created: ${{ steps.release.outputs.release_created }}
+      root_tag_name: ${{ steps.release.outputs.tag_name }}
       launcher_release_created: ${{ steps.release.outputs['create-mandrel--release_created'] }}
       launcher_tag_name: ${{ steps.release.outputs['create-mandrel--tag_name'] }}
     steps:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -258,25 +258,32 @@ operator-visible consequences:
     is namespaced as `create-mandrel-vX.Y.Z` (e.g. `create-mandrel-v0.2.0`).
 
   [`release-please.yml`](.github/workflows/release-please.yml) carries **two
-  independent publish jobs**, each gated on its own package's **per-path**
-  release output (`steps.release.outputs['<path>--release_created']`), not the
-  top-level `release_created`:
+  independent publish jobs**, each gated on its own package's release output.
+  The output naming follows release-please-action's `setPathOutput` rule
+  (verified against v5.0.0 `src/index.ts`): the **root** package (manifest path
+  `.`) emits **un-prefixed** outputs (`release_created`, `tag_name`), while
+  **non-root** packages emit `${path}--${key}` (e.g.
+  `create-mandrel--release_created`). There is **no** `.--release_created`
+  output — gating the root publish on that string silently skips it on every
+  release (the bug Story #3891's initial wiring shipped; fixed by reverting the
+  root gate to the un-prefixed `release_created`).
   - **`npm-publish`** checks out the repository root and runs `npm publish`
     against the root `package.json`, publishing **`@mandrelai/agents`**. It is
-    gated on the root component's output (path `.`).
+    gated on the root package's `steps.release.outputs.release_created`.
   - **`npm-publish-launcher`** runs `npm publish` with
     `working-directory: create-mandrel`, publishing the unscoped
-    **`create-mandrel`** launcher. It is gated on the launcher component's
-    output (path `create-mandrel`).
+    **`create-mandrel`** launcher. It is gated on the launcher's
+    `steps.release.outputs['create-mandrel--release_created']`.
 
-  Gating each job on its own package's per-path output is load-bearing: the
-  top-level `release_created` is `true` if **either** package releases, so a
-  launcher-only release would otherwise re-run the root `npm publish` on an
-  already-published version (and fail), and vice versa. Neither job keys off a
-  tag pattern, so neither the `mandrel-*` nor the `create-mandrel-*` tag series
-  triggers a publish by tag. `ci.yml` triggers only on branch `push` /
-  `pull_request` / `workflow_dispatch` events (it has **no** tag-driven step),
-  so neither tag series triggers CI directly.
+  This split is load-bearing: the singular `release_created` is **root-specific**
+  (set only when the root path releases — never on a launcher-only release), so
+  a launcher-only release does not re-run the root `npm publish` on an
+  already-published version, and vice versa. (The "any package released" boolean
+  is the *plural* `releases_created`, which is intentionally **not** used as a
+  gate here.) Neither job keys off a tag pattern, so neither the `mandrel-*` nor
+  the `create-mandrel-*` tag series triggers a publish by tag. `ci.yml` triggers
+  only on branch `push` / `pull_request` / `workflow_dispatch` events (it has
+  **no** tag-driven step), so neither tag series triggers CI directly.
 
 #### One-time PAT setup
 


### PR DESCRIPTION
## Problem

`@mandrelai/agents` **v1.55.0** was tagged and GitHub-released on 2026-06-10
([run](https://github.com/dsj1984/mandrel/actions/runs/27294674717)) but the
**Publish to npm** job was *skipped*, so npm `latest` is still **1.54.0**. The
1.55.0 release bundles all 23 Stories (#3889–#3911) of framework fixes, which
consumers cannot get via `mandrel update` until it publishes.

## Root cause

PR [#3914](https://github.com/dsj1984/mandrel/pull/3914) (Story #3891) changed
the root publish gate to `steps.release.outputs['.--release_created']`. That
output **never exists**. Verified against `release-please-action` v5.0.0
`src/index.ts`:

```js
function setPathOutput(path, key, value) {
  if (path === '.') core.setOutput(key, value);            // root → UN-prefixed
  else              core.setOutput(`${path}--${key}`, value); // non-root → prefixed
}
```

The root `mandrel` package has manifest path `.`, so it emits the **un-prefixed**
`release_created` / `tag_name`. Only non-root packages (the launcher, path
`create-mandrel`) get the `${path}--${key}` prefix. The new gate was therefore
never `true`, and the root publish skipped on the first release after #3891.

Evidence:

| Run | Release | Root gate | Publish to npm |
| --- | --- | --- | --- |
| [27163973205](https://github.com/dsj1984/mandrel/actions/runs/27163973205) | v1.54.0 (Jun 8) | old `release_created` | ✅ success |
| [27294674717](https://github.com/dsj1984/mandrel/actions/runs/27294674717) | v1.55.0 (Jun 10) | `['.--release_created']` (#3891) | ❌ skipped |

## Fix

- Revert the root outputs to the un-prefixed `release_created` / `tag_name`.
- Keep the launcher gate (`create-mandrel--release_created`) — correct, as it's
  a non-root path.
- The singular `release_created` is root-specific (set only when the root path
  releases, never on a launcher-only release), so it still prevents a
  launcher-only release from re-running the root publish — the property #3891
  meant to preserve. (The "any package" boolean is the *plural*
  `releases_created`, intentionally unused as a gate.)
- Correct the matching AGENTS.md release-topology description.

## Follow-up (not in this PR)

v1.55.0 is already tagged/released but absent from npm. After this merges it
will **not** auto-publish (release-please won't re-cut an existing release).
1.55.0 needs a one-off manual `npm publish` (or a `workflow_dispatch` publish
path); the next normal release (1.56.0) will publish correctly under this fix.

## Verification

- `npm run lint` — clean.
- Confirmed the active output expressions: root → `release_created` /
  `tag_name`; launcher → `create-mandrel--release_created` / `...tag_name`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)