### PR TITLE
feat: add a `mandrel init` subcommand: one-command cold start (install-if-absent → two-option prompt → bootstrap.js) (#3975)

### DIFF
--- a/.agents/docs/SDLC.md
+++ b/.agents/docs/SDLC.md
@@ -225,7 +225,7 @@ graph LR
 
     subgraph Phase0 ["Phase 0: Bootstrap"]
         direction TB
-        Z["👤 npx create-mandrel<br/>(install → sync → bootstrap.js)"]:::manual
+        Z["👤 npx mandrel init<br/>(install → sync → prompt → bootstrap.js)"]:::manual
         Z2["👤 /onboard (guided first run)"]:::manual
         Z --> Z2
     end
@@ -272,15 +272,19 @@ wire the framework system prompt, and create the GitHub labels, Projects V2
 fields, and (when enabled) main-branch protection the orchestration engine
 depends on.
 
-The canonical cold-start path is a single launcher command:
+The canonical cold-start path is a single command:
 
 ```bash
-npx create-mandrel
+npx mandrel init
 ```
 
-`create-mandrel` installs `mandrel`, materializes `./.agents/` via
-`mandrel sync`, and runs `node .agents/scripts/bootstrap.js`, forwarding any
-flags you pass. `bootstrap.js`:
+`mandrel init` installs `mandrel` (when `./.agents/` is absent), materializes
+`./.agents/` via `mandrel sync`, then presents a two-option prompt: **configure
+now** (option 1 → runs `node .agents/scripts/bootstrap.js`, forwarding any flags
+you pass) or **just the files** (option 2 → re-run `mandrel init` any time to
+configure later). `--assume-yes` skips the prompt and proceeds straight to
+configure (and is forwarded to bootstrap); a non-TTY run without it defaults to
+files-only so the GitHub provisioning never runs unattended. `bootstrap.js`:
 
 1. **Provisions a cold start.** Initializes the local git repo (with a first
    commit) when absent, creates the GitHub repo (`gh repo create --source=.
@@ -1404,7 +1408,7 @@ For Stories already in flight, use one of the three options above.
 
 | Command                                          | Purpose                                                                                                                                                                      |
 | ------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `npx create-mandrel`                             | Cold-start launcher — install `mandrel`, `mandrel sync`, then run `bootstrap.js` (provisions repo + Projects V2 board, labels, branch protection).                  |
+| `npx mandrel init`                               | Cold-start command — install `mandrel` (if absent), `mandrel sync`, then prompt to run `bootstrap.js` (provisions repo + Projects V2 board, labels, branch protection).        |
 | `/onboard`                                       | Guided first run after bootstrap — stack detection, docs scaffolding, `mandrel doctor` readiness gate, started `/epic-plan` handoff.                                          |
 | `/epic-plan`                                     | Ideation entry — sharpen idea, search duplicates, open Epic, then PRD + Tech Spec + decomposition.                                                                            |
 | `/epic-plan --idea "<seed>"`                     | Same ideation entry with pre-supplied seed.                                                                                                                                   |

--- a/.agents/workflows/onboard.md
+++ b/.agents/workflows/onboard.md
@@ -46,9 +46,10 @@ genuinely missing, and `mandrel doctor` is read-only).
 ## Prerequisites
 
 1. Mandrel installed and bootstrapped into the project. The zero-to-installed
-   path is `npx create-mandrel`, which installs the `mandrel`
-   package, runs `mandrel sync` to materialize the `.agents/` bundle, and then
-   execs `.agents/scripts/bootstrap.js` to provision the project (labels,
+   path is `npx mandrel init`, which installs the `mandrel`
+   package (when absent), runs `mandrel sync` to materialize the `.agents/`
+   bundle, and then — on the **configure now** prompt option — execs
+   `.agents/scripts/bootstrap.js` to provision the project (labels,
    board, `.agentrc.json` seed). `/onboard` runs **after** that bootstrap
    completes — it does not invoke `bootstrap.js` itself, so the coupling is
    indirect: bootstrap owns first-time provisioning, `/onboard` owns the

--- a/README.md
+++ b/README.md
@@ -31,11 +31,11 @@ package-manager combinations.
 
 ## Quickstart
 
-The canonical cold-start path is one launcher command, then two slash
+The canonical cold-start path is one command, then two slash
 commands inside Claude Code:
 
 ```bash
-npx create-mandrel        # install mandrel → sync → bootstrap
+npx mandrel init        # install mandrel → sync → prompt → bootstrap
 ```
 
 ```text
@@ -44,18 +44,23 @@ npx create-mandrel        # install mandrel → sync → bootstrap
 /epic-plan          # ideation -> PRD/Tech Spec -> Epic/Feature/Story hierarchy
 ```
 
-`create-mandrel` installs `mandrel`, materializes `./.agents/` via
-`mandrel sync`, and runs `node .agents/scripts/bootstrap.js` for you,
-forwarding any flags you pass. `/onboard` then walks you from a clean
-checkout to a planned Epic (stack detection, docs scaffolding, a
+`npx mandrel init` installs `mandrel` (when `./.agents/` is absent),
+materializes it via `mandrel sync`, then asks whether to **configure now**
+(option 1 → runs `node .agents/scripts/bootstrap.js`, forwarding any flags you
+pass) or stop at **just the files** (option 2 → re-run `mandrel init` any time
+to configure). Pass `--assume-yes` for a non-interactive run that proceeds
+straight to configure (and forwards the flag to bootstrap). When `./.agents/`
+is already present (you ran `npm install mandrel` first), `init` skips the
+install/sync and goes straight to the prompt. `/onboard` then walks you from a
+clean checkout to a planned Epic (stack detection, docs scaffolding, a
 `mandrel doctor` readiness gate, and a started `/epic-plan`). Once you have a
 planned Epic, deliver it with `/epic-deliver <id>` (wave loop → validation →
 review → retro → open PR).
 
 ### Manual equivalent
 
-If you prefer to drive the three steps `create-mandrel` wraps by hand, run
-them from your project root:
+If you prefer to drive the steps `mandrel init` wraps by hand, run them from
+your project root:
 
 ```bash
 npm install mandrel   # pin an exact, provenance-signed version

--- a/docs/migrate-mandrelai-to-mandrel.md
+++ b/docs/migrate-mandrelai-to-mandrel.md
@@ -43,32 +43,37 @@ a deliberate, documented manual hop you make **once** — after this, ordinary
 Run these from your consumer project root, on a branch with a clean working
 tree so the whole migration lands as one reviewable commit.
 
-### 1. Swap the dependency
+### 1. Drop the old scoped package, then install + configure in one command
 
 ```bash
 npm rm @mandrelai/agents
-npm install mandrel
+npx mandrel init
 ```
 
-`npm rm` drops the old scoped dependency from `package.json` and the lockfile;
-`npm install mandrel` adds the new unscoped package, resolving to the newest
-published version (currently `mandrel@1.57.0`). Pin an exact version if your
-policy requires it — the install is provenance-signed either way.
+`npm rm` drops the old scoped dependency from `package.json` and the lockfile.
+`npx mandrel init` then installs the new unscoped `mandrel` package (resolving
+to the newest published version), re-materializes `./.agents/` via
+`mandrel sync`, and prompts whether to configure now (runs
+`node .agents/scripts/bootstrap.js`) or stop at just the files. Pass
+`--assume-yes` for a non-interactive run that proceeds straight to configure.
+This folds the former two-step install + bootstrap into a single command; pin
+an exact version if your policy requires it — the install is provenance-signed
+either way.
 
-> Using pnpm or yarn? Substitute the equivalent remove/add pair —
-> `pnpm remove @mandrelai/agents && pnpm add -D mandrel`, or
-> `yarn remove @mandrelai/agents && yarn add -D mandrel`.
+> Using pnpm or yarn? Run the remove with your package manager —
+> `pnpm remove @mandrelai/agents` or `yarn remove @mandrelai/agents` — then
+> `npx mandrel init` to install and configure the new package.
 
-### 2. Re-materialize `./.agents/`
+### 2. Re-materialize `./.agents/` (only if you skipped `mandrel init`)
 
 ```bash
 npx mandrel sync
 ```
 
-`mandrel sync` re-materializes `./.agents/` from the freshly installed
-`mandrel` payload. The package's `postinstall` hook usually runs this for you,
-but run it explicitly so the materialization is unambiguous (and to cover
-`--ignore-scripts` / sandboxed-CI installs).
+`mandrel init` in step 1 already runs `mandrel sync` for you. Run `sync`
+explicitly only when you installed `mandrel` by hand instead — it
+re-materializes `./.agents/` from the freshly installed `mandrel` payload (and
+covers `--ignore-scripts` / sandboxed-CI installs).
 
 ### 3. Verify and commit
 

--- a/lib/cli/init.js
+++ b/lib/cli/init.js
@@ -1,0 +1,316 @@
+// lib/cli/init.js
+/**
+ * `mandrel init` subcommand — one-command cold start (Story #3975).
+ *
+ * Folds the former `create-mandrel` launcher logic into a subcommand of the
+ * single published `mandrel` package. `npx mandrel init` (≡ `npm exec --
+ * mandrel init`, or `mandrel init` once installed) takes a project from a
+ * blank folder to a configured Mandrel environment in one command:
+ *
+ *   1. **Install-if-absent.** When `./.agents/` is missing in the cwd, install
+ *      the framework deterministically — `npm install mandrel --ignore-scripts`
+ *      followed by an explicit `mandrel sync`. The `--ignore-scripts` install
+ *      skips the package's best-effort `postinstall` sync so the explicit
+ *      `sync` is the single, deterministic materialization (review rec D.3 —
+ *      no postinstall-then-init double-sync, and no arbitrary install
+ *      lifecycle scripts during cold start). When `./.agents/` already exists
+ *      (the operator ran `npm install mandrel` first), step 1 is skipped and
+ *      `init` goes straight to the prompt — the one subcommand is idempotent
+ *      across both the cold-start and post-install entry points.
+ *
+ *   2. **Two-option prompt.** Ask whether to configure now (option 1 → run
+ *      `node .agents/scripts/bootstrap.js`, forwarding every passthrough flag
+ *      unchanged) or stop at "just the files" (option 2 → print a re-run hint
+ *      and exit 0). `--assume-yes` skips the prompt and configures (the flag is
+ *      also forwarded to bootstrap for its own non-interactive run). A non-TTY
+ *      stdin without `--assume-yes` defaults to option 2 (files-only) so the
+ *      side-effecting GitHub provisioning never runs unattended.
+ *
+ * ## Cold-start provenance
+ *
+ * The installed package name is the **hardcoded build-time constant**
+ * `PACKAGE_NAME` below — it is NEVER read from argv or the environment. A
+ * cold start fetches `mandrel` from npx's temp cache and runs this bin; the
+ * package it then installs into the project must be the same `mandrel`, not an
+ * attacker-influenced name supplied on the command line. The forwarded
+ * passthrough flags reach `bootstrap.js` (the sole bootstrap orchestrator),
+ * which owns its own summary + confirm loop and validates its own inputs.
+ *
+ * ## Injectable seams (used by tests/cli/init.test.js)
+ *
+ * The plan/decision logic is a pure function (`planInit`) over injected
+ * boundaries so the suite is hermetic — no real TTY, npm, or network:
+ *
+ *   - `argv`     — subcommand args (after `mandrel init`)
+ *   - `exists`   — `(path) => boolean`; defaults to an `fs.existsSync` probe
+ *                  for `./.agents/` in the cwd
+ *   - `runStep`  — `(cmd, args) => { status }`; runs one install/sync/bootstrap
+ *                  step. Defaults to a `spawnSync` runner with `stdio: inherit`.
+ *   - `confirm`  — `() => '1' | '2'`; reads the operator's numbered choice.
+ *                  Defaults to a synchronous stdin readline prompt.
+ *   - `stdout`   — `(s) => void`; defaults to `process.stdout.write`.
+ *   - `isTTY`    — boolean; defaults to `process.stdin.isTTY`.
+ *   - `exit`     — `(code) => void`; defaults to `process.exit`.
+ *
+ * Security (security-baseline § 5/6): logs only flag/step descriptions and
+ * never reads or echoes tokens, credentials, or env values. The package name
+ * is a hardcoded constant rather than interpolated input, and the step runner
+ * passes argv as an array (no shell-string concatenation of user input).
+ */
+
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+
+/**
+ * Hardcoded build-time package name. NEVER read from argv or env — cold-start
+ * provenance requires the install target to be the same package this bin
+ * shipped from. See the module header.
+ */
+const PACKAGE_NAME = 'mandrel';
+
+// The `mandrel sync` and `node .agents/scripts/bootstrap.js` invocations both
+// resolve relative to the consumer's cwd at run time (the materialized
+// `.agents/` lives there), so they are expressed as cwd-relative steps rather
+// than against PROJECT_ROOT (which, under npx, is npx's throwaway cache).
+const BOOTSTRAP_SCRIPT = path.join('.agents', 'scripts', 'bootstrap.js');
+
+const PROMPT_TEXT =
+  'Mandrel is installed. What next?\n' +
+  '  1) Configure my environment now (creates the GitHub repo + Projects board)\n' +
+  "  2) Just the files — I'll configure later\n" +
+  'Choice [1/2]: ';
+
+const FILES_ONLY_HINT = 'Configure any time with: mandrel init\n';
+
+// On win32, `npm`/`mandrel` resolve to `.cmd` shims that Node refuses to spawn
+// without a shell after the CVE-2024-27980 hardening; mirror update.js and set
+// `shell: true` only there. Off win32, never shell out — array argv stays
+// injection-proof.
+const NEEDS_SHELL = process.platform === 'win32';
+
+/**
+ * Strip the `--assume-yes` flag from a passthrough argv, returning the
+ * remaining flags. `--assume-yes` is consumed by `init` to skip the prompt but
+ * is ALSO forwarded to bootstrap (see `buildBootstrapArgs`), so this helper
+ * exists only to detect its presence, not to drop it from the forward set.
+ *
+ * @param {string[]} argv
+ * @returns {boolean} whether `--assume-yes` is present
+ */
+function hasAssumeYes(argv) {
+  return argv.includes('--assume-yes');
+}
+
+/**
+ * Build the forwarded argv for the bootstrap step. Every passthrough flag is
+ * forwarded unchanged; `--assume-yes` is appended when chosen but absent so
+ * bootstrap runs non-interactively without the operator having typed it.
+ *
+ * @param {string[]} argv
+ * @param {boolean} assumeYes
+ * @returns {string[]}
+ */
+function buildBootstrapArgs(argv, assumeYes) {
+  if (assumeYes && !argv.includes('--assume-yes')) {
+    return [...argv, '--assume-yes'];
+  }
+  return [...argv];
+}
+
+/**
+ * Decide and execute the cold-start plan over injected boundaries.
+ *
+ * This is the testable core: it consults `exists` to decide whether to run the
+ * install + sync steps, resolves the prompt outcome from `isTTY` / `--assume-yes`
+ * / `confirm`, and either runs the bootstrap step or prints the files-only hint.
+ * Every effectful boundary is injected so the suite never touches a real TTY,
+ * npm, or the network.
+ *
+ * @param {{
+ *   argv?: string[],
+ *   exists?: (relPath: string) => boolean,
+ *   runStep?: (cmd: string, args: string[]) => { status: number | null },
+ *   confirm?: () => '1' | '2',
+ *   stdout?: (s: string) => void,
+ *   isTTY?: boolean,
+ * }} [opts]
+ * @returns {{
+ *   installed: boolean,
+ *   ranBootstrap: boolean,
+ *   steps: Array<{ cmd: string, args: string[] }>,
+ *   exitCode: number,
+ * }}
+ */
+export function planInit({
+  argv = [],
+  exists,
+  runStep,
+  confirm,
+  stdout = (s) => process.stdout.write(s),
+  isTTY,
+} = {}) {
+  const steps = [];
+
+  /**
+   * Run one step through the injected runner and record it. A non-zero status
+   * short-circuits the plan with that exit code (the runner inherits stdio, so
+   * the failing tool's own output already reached the terminal).
+   *
+   * @param {string} cmd
+   * @param {string[]} args
+   * @returns {number} the step's exit code (0 on success)
+   */
+  const step = (cmd, args) => {
+    steps.push({ cmd, args });
+    const result = runStep(cmd, args);
+    return result?.status ?? 1;
+  };
+
+  // --- Step 1: install-if-absent ------------------------------------------
+  // When `./.agents/` is missing, materialize the framework deterministically:
+  // `npm install <pkg> --ignore-scripts` then explicit `mandrel sync`. When it
+  // is present, skip straight to the prompt (idempotent post-install path).
+  const agentsPresent = exists('.agents');
+  if (!agentsPresent) {
+    const installStatus = step('npm', [
+      'install',
+      PACKAGE_NAME,
+      '--ignore-scripts',
+    ]);
+    if (installStatus !== 0) {
+      return {
+        installed: false,
+        ranBootstrap: false,
+        steps,
+        exitCode: installStatus,
+      };
+    }
+
+    const syncStatus = step('mandrel', ['sync']);
+    if (syncStatus !== 0) {
+      return {
+        installed: true,
+        ranBootstrap: false,
+        steps,
+        exitCode: syncStatus,
+      };
+    }
+  }
+
+  const installed = !agentsPresent;
+
+  // --- Step 2: configure-or-files prompt ----------------------------------
+  const assumeYes = hasAssumeYes(argv);
+
+  // Decide the outcome: configure (run bootstrap) vs. files-only.
+  // - `--assume-yes` → configure, prompt skipped entirely.
+  // - non-TTY without `--assume-yes` → files-only (never provision unattended).
+  // - TTY → consult the confirm seam for the numbered choice.
+  let choice;
+  if (assumeYes) {
+    choice = '1';
+  } else if (!isTTY) {
+    choice = '2';
+  } else {
+    stdout(PROMPT_TEXT);
+    choice = confirm();
+  }
+
+  if (choice === '1') {
+    const bootstrapArgs = buildBootstrapArgs(argv, assumeYes);
+    const bootstrapStatus = step(process.execPath, [
+      BOOTSTRAP_SCRIPT,
+      ...bootstrapArgs,
+    ]);
+    return {
+      installed,
+      ranBootstrap: true,
+      steps,
+      exitCode: bootstrapStatus,
+    };
+  }
+
+  // Option 2 (files-only): print the re-run hint and exit cleanly.
+  stdout(FILES_ONLY_HINT);
+  return { installed, ranBootstrap: false, steps, exitCode: 0 };
+}
+
+/**
+ * Default `exists` seam — probe for `./.agents/` in the consumer's cwd.
+ *
+ * @param {string} relPath
+ * @returns {boolean}
+ */
+function defaultExists(relPath) {
+  return fs.existsSync(path.resolve(process.cwd(), relPath));
+}
+
+/**
+ * Default step runner — spawn the tool synchronously, inheriting stdio so its
+ * output streams to the terminal. Sets `shell: true` only on win32 so `.cmd`
+ * shims (`npm.cmd`, `mandrel.cmd`) resolve under CVE-2024-27980 hardening.
+ *
+ * @param {string} cmd
+ * @param {string[]} args
+ * @returns {{ status: number | null }}
+ */
+function defaultRunStep(cmd, args) {
+  return spawnSync(cmd, args, {
+    stdio: 'inherit',
+    env: process.env,
+    shell: NEEDS_SHELL,
+  });
+}
+
+/**
+ * Default `confirm` seam — synchronous numbered-choice prompt. Reads one line
+ * from stdin and normalizes it to `'1'` or `'2'`; any input other than `'2'`
+ * (including bare Enter) defaults to `'1'` (configure), matching the
+ * `Choice [1/2]:` convention where the first option is the default.
+ *
+ * @returns {'1' | '2'}
+ */
+function defaultConfirm() {
+  let answer = '';
+  try {
+    const buf = fs.readFileSync(0, 'utf8');
+    answer = buf.split('\n', 1)[0].trim();
+  } catch {
+    // No readable line (e.g. stdin closed) → fall through to the default.
+    answer = '';
+  }
+  return answer === '2' ? '2' : '1';
+}
+
+/**
+ * Default export consumed by `bin/mandrel.js`.
+ *
+ * @param {string[]} [argv] - Subcommand arguments (after `mandrel init`).
+ * @returns {void}
+ */
+export default function run(argv = []) {
+  if (argv.includes('--help') || argv.includes('-h')) {
+    process.stdout.write(
+      'Usage: mandrel init [bootstrap flags]\n\n' +
+        '  One-command cold start: install Mandrel (if absent), then prompt to\n' +
+        '  configure now or stop at the files.\n\n' +
+        '  --assume-yes   Skip the prompt and configure non-interactively\n' +
+        '                 (forwarded to bootstrap.js). All other flags are\n' +
+        '                 forwarded to bootstrap.js unchanged.\n',
+    );
+    return;
+  }
+
+  const result = planInit({
+    argv,
+    exists: defaultExists,
+    runStep: defaultRunStep,
+    confirm: defaultConfirm,
+    isTTY: Boolean(process.stdin.isTTY),
+  });
+
+  if (result.exitCode !== 0) {
+    process.exit(result.exitCode);
+  }
+}

--- a/tests/cli/init.test.js
+++ b/tests/cli/init.test.js
@@ -1,0 +1,367 @@
+// tests/cli/init.test.js
+/**
+ * Unit tests for lib/cli/init.js — the `mandrel init` one-command cold start
+ * (Story #3975).
+ *
+ * Every test drives `planInit` through its injectable seams (argv, exists,
+ * runStep, confirm, stdout, isTTY). The suite is hermetic: no real TTY, no real
+ * npm install, no network, and no filesystem writes occur (testing-standards
+ * § Unit — all external I/O MUST be mocked; pure-logic assertions only).
+ *
+ * Coverage contract (Story #3975 AC):
+ *   - Module shape: `planInit` named export + default function export.
+ *   - `.agents/` absent → install `mandrel --ignore-scripts` then `sync`, in
+ *     that order, against the hardcoded `mandrel` package name.
+ *   - `.agents/` present → no install/sync steps run.
+ *   - The two-option numbered prompt renders both options.
+ *   - Choosing 1 → bootstrap step is execPath + bootstrap.js + forwarded argv.
+ *   - Choosing 2 → no bootstrap, hint printed, ranBootstrap false, exit 0.
+ *   - `--assume-yes` → confirm seam not consulted, bootstrap carries the flag.
+ *   - Non-TTY without `--assume-yes` → files-only, exit 0.
+ *   - Bin dispatch: `mandrel init --help` reaches the module (integration).
+ */
+
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import path from 'node:path';
+import { describe, it } from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+import init, { planInit } from '../../lib/cli/init.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+const BIN = path.join(REPO_ROOT, 'bin', 'mandrel.js');
+
+// ---------------------------------------------------------------------------
+// Seam helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a recording `runStep` seam. Every invocation is captured; the status
+ * defaults to 0 (success) unless `statuses` supplies a per-call override.
+ */
+function makeRunStep({ statuses = [] } = {}) {
+  const calls = [];
+  const runStep = (cmd, args) => {
+    calls.push({ cmd, args });
+    const status = statuses.length ? statuses.shift() : 0;
+    return { status };
+  };
+  return { calls, runStep };
+}
+
+/** Capture stdout writes into an array. */
+function makeStdout() {
+  const out = [];
+  return { out, write: (s) => out.push(s) };
+}
+
+/** A `confirm` seam that records whether it was consulted and returns `choice`. */
+function makeConfirm(choice) {
+  const state = { consulted: false };
+  const confirm = () => {
+    state.consulted = true;
+    return choice;
+  };
+  return { state, confirm };
+}
+
+// ---------------------------------------------------------------------------
+// Module shape
+// ---------------------------------------------------------------------------
+
+describe('init — module shape', () => {
+  it('exports planInit (named) and a default run function', () => {
+    assert.equal(typeof planInit, 'function');
+    assert.equal(typeof init, 'function');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Step 1 — install-if-absent
+// ---------------------------------------------------------------------------
+
+describe('init — install when .agents/ is absent', () => {
+  it('installs the hardcoded `mandrel` with --ignore-scripts, then syncs, in order', () => {
+    const { calls, runStep } = makeRunStep();
+    const { confirm } = makeConfirm('2');
+    const { write } = makeStdout();
+
+    const result = planInit({
+      argv: [],
+      exists: () => false, // .agents/ absent
+      runStep,
+      confirm,
+      stdout: write,
+      isTTY: true,
+    });
+
+    // First two steps are install then sync, in that order.
+    assert.equal(calls[0].cmd, 'npm');
+    assert.deepEqual(calls[0].args, ['install', 'mandrel', '--ignore-scripts']);
+    assert.equal(calls[1].cmd, 'mandrel');
+    assert.deepEqual(calls[1].args, ['sync']);
+    assert.equal(result.installed, true);
+  });
+
+  it('targets the hardcoded package name even when argv supplies a different name', () => {
+    const { calls, runStep } = makeRunStep();
+    const { confirm } = makeConfirm('2');
+    const { write } = makeStdout();
+
+    planInit({
+      // An attacker-influenced flag must NOT redirect the install target.
+      argv: ['--package', 'evil-pkg', 'evil-pkg'],
+      exists: () => false,
+      runStep,
+      confirm,
+      stdout: write,
+      isTTY: true,
+    });
+
+    assert.deepEqual(calls[0].args, ['install', 'mandrel', '--ignore-scripts']);
+  });
+
+  it('short-circuits with the install exit code when install fails', () => {
+    const { calls, runStep } = makeRunStep({ statuses: [7] });
+    const { confirm, state } = makeConfirm('1');
+    const { write } = makeStdout();
+
+    const result = planInit({
+      argv: [],
+      exists: () => false,
+      runStep,
+      confirm,
+      stdout: write,
+      isTTY: true,
+    });
+
+    assert.equal(result.exitCode, 7);
+    assert.equal(result.ranBootstrap, false);
+    assert.equal(calls.length, 1, 'sync must not run after a failed install');
+    assert.equal(
+      state.consulted,
+      false,
+      'prompt must not run after a failed install',
+    );
+  });
+});
+
+describe('init — skip install when .agents/ is present', () => {
+  it('runs no install/sync steps and goes straight to the prompt', () => {
+    const { calls, runStep } = makeRunStep();
+    const { confirm } = makeConfirm('2');
+    const { write } = makeStdout();
+
+    const result = planInit({
+      argv: [],
+      exists: () => true, // .agents/ present
+      runStep,
+      confirm,
+      stdout: write,
+      isTTY: true,
+    });
+
+    const installOrSync = calls.filter(
+      (c) => c.cmd === 'npm' || (c.cmd === 'mandrel' && c.args[0] === 'sync'),
+    );
+    assert.equal(
+      installOrSync.length,
+      0,
+      'no install/sync when .agents/ exists',
+    );
+    assert.equal(result.installed, false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Step 2 — two-option prompt
+// ---------------------------------------------------------------------------
+
+describe('init — two-option prompt rendering', () => {
+  it('renders both numbered options on a TTY without --assume-yes', () => {
+    const { runStep } = makeRunStep();
+    const { confirm } = makeConfirm('2');
+    const { out, write } = makeStdout();
+
+    planInit({
+      argv: [],
+      exists: () => true,
+      runStep,
+      confirm,
+      stdout: write,
+      isTTY: true,
+    });
+
+    const prompt = out.join('');
+    assert.match(prompt, /1\) Configure my environment now/);
+    assert.match(prompt, /2\) Just the files/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Option 1 — configure (run bootstrap)
+// ---------------------------------------------------------------------------
+
+describe('init — option 1 runs bootstrap.js with forwarded argv', () => {
+  it('invokes process.execPath + bootstrap.js + forwarded flags', () => {
+    const { calls, runStep } = makeRunStep();
+    const { confirm } = makeConfirm('1');
+    const { write } = makeStdout();
+
+    const result = planInit({
+      argv: ['--owner', 'acme', '--repo', 'widgets'],
+      exists: () => true,
+      runStep,
+      confirm,
+      stdout: write,
+      isTTY: true,
+    });
+
+    const bootstrapCall = calls.find((c) => c.cmd === process.execPath);
+    assert.ok(bootstrapCall, 'expected a process.execPath bootstrap step');
+    assert.ok(
+      bootstrapCall.args[0].endsWith(
+        path.join('.agents', 'scripts', 'bootstrap.js'),
+      ),
+      `expected bootstrap.js path, got ${bootstrapCall.args[0]}`,
+    );
+    assert.deepEqual(bootstrapCall.args.slice(1), [
+      '--owner',
+      'acme',
+      '--repo',
+      'widgets',
+    ]);
+    assert.equal(result.ranBootstrap, true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Option 2 — files-only
+// ---------------------------------------------------------------------------
+
+describe('init — option 2 skips bootstrap and prints the hint', () => {
+  it('runs no bootstrap step, prints the re-run hint, sets ranBootstrap false, exits 0', () => {
+    const { calls, runStep } = makeRunStep();
+    const { confirm } = makeConfirm('2');
+    const { out, write } = makeStdout();
+
+    const result = planInit({
+      argv: [],
+      exists: () => true,
+      runStep,
+      confirm,
+      stdout: write,
+      isTTY: true,
+    });
+
+    const bootstrapCall = calls.find((c) => c.cmd === process.execPath);
+    assert.equal(bootstrapCall, undefined, 'no bootstrap step on files-only');
+    assert.match(out.join(''), /Configure any time with: mandrel init/);
+    assert.equal(result.ranBootstrap, false);
+    assert.equal(result.exitCode, 0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// --assume-yes
+// ---------------------------------------------------------------------------
+
+describe('init — --assume-yes skips the prompt and forwards the flag', () => {
+  it('does not consult confirm and forwards --assume-yes to bootstrap', () => {
+    const { calls, runStep } = makeRunStep();
+    const { confirm, state } = makeConfirm('2'); // would choose files-only if consulted
+    const { write } = makeStdout();
+
+    const result = planInit({
+      argv: ['--assume-yes', '--owner', 'acme'],
+      exists: () => true,
+      runStep,
+      confirm,
+      stdout: write,
+      isTTY: true,
+    });
+
+    assert.equal(state.consulted, false, 'confirm seam must not be consulted');
+    const bootstrapCall = calls.find((c) => c.cmd === process.execPath);
+    assert.ok(
+      bootstrapCall.args.includes('--assume-yes'),
+      'bootstrap must carry --assume-yes',
+    );
+    assert.equal(result.ranBootstrap, true);
+  });
+
+  it('does not duplicate --assume-yes when argv already carries it once', () => {
+    const { calls, runStep } = makeRunStep();
+    const { confirm } = makeConfirm('1');
+    const { write } = makeStdout();
+
+    planInit({
+      argv: ['--assume-yes'],
+      exists: () => true,
+      runStep,
+      confirm,
+      stdout: write,
+      isTTY: true,
+    });
+
+    const bootstrapCall = calls.find((c) => c.cmd === process.execPath);
+    const yesCount = bootstrapCall.args.filter(
+      (a) => a === '--assume-yes',
+    ).length;
+    assert.equal(yesCount, 1, '--assume-yes must be forwarded exactly once');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Non-TTY default
+// ---------------------------------------------------------------------------
+
+describe('init — non-TTY stdin defaults to files-only', () => {
+  it('chooses files-only (no bootstrap) and exits 0 when stdin is not a TTY', () => {
+    const { calls, runStep } = makeRunStep();
+    const { confirm, state } = makeConfirm('1'); // would configure if consulted
+    const { out, write } = makeStdout();
+
+    const result = planInit({
+      argv: [],
+      exists: () => true,
+      runStep,
+      confirm,
+      stdout: write,
+      isTTY: false, // non-TTY
+    });
+
+    assert.equal(
+      state.consulted,
+      false,
+      'confirm seam must not run in non-TTY mode',
+    );
+    const bootstrapCall = calls.find((c) => c.cmd === process.execPath);
+    assert.equal(bootstrapCall, undefined, 'must never provision unattended');
+    assert.match(out.join(''), /Configure any time with: mandrel init/);
+    assert.equal(result.ranBootstrap, false);
+    assert.equal(result.exitCode, 0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Bin dispatch integration — mandrel init --help reaches the module
+// ---------------------------------------------------------------------------
+
+describe('mandrel init — bin dispatch integration', () => {
+  it('dispatches `mandrel init --help` to the module and exits 0', () => {
+    const result = spawnSync(process.execPath, [BIN, 'init', '--help'], {
+      cwd: REPO_ROOT,
+      encoding: 'utf8',
+      env: process.env,
+    });
+    assert.equal(
+      result.status,
+      0,
+      `mandrel init --help exited ${result.status}\nstdout: ${result.stdout}\nstderr: ${result.stderr}`,
+    );
+    assert.match(result.stdout, /Usage: mandrel init/);
+  });
+});


### PR DESCRIPTION
Closes #3975

_Auto-opened by `/single-story-deliver`._