### PR TITLE
perf: `analyze-execution` retro reader fetches Story comments N+1 and serially (#3990)

### DIFF
--- a/.agents/scripts/lib/observability/perf-report-readers.js
+++ b/.agents/scripts/lib/observability/perf-report-readers.js
@@ -16,6 +16,7 @@ import { storyArtifactPath } from '../config/temp-paths.js';
 import { gitSpawn } from '../git-utils.js';
 import { Logger } from '../Logger.js';
 import { read as readSignals } from '../signals/read.js';
+import { concurrentMap } from '../util/concurrent-map.js';
 import { extractStoryPerfSummaryFromComment } from './perf-report-render.js';
 import { forEachLine } from './signals-writer.js';
 
@@ -154,30 +155,38 @@ export async function collectStorySummaries(provider, epicId, logger) {
       ),
   );
 
-  const summaries = [];
-  for (const ticket of storyTickets) {
-    const id = Number(ticket.id ?? ticket.number);
-    if (!Number.isInteger(id) || id < 1) continue;
-    let comments;
-    try {
-      comments = (await provider.getTicketComments(id)) ?? [];
-    } catch (err) {
-      logger.warn?.(
-        `[analyze-execution] getTicketComments(${id}) failed: ${
-          err instanceof Error ? err.message : String(err)
-        }`,
-      );
-      continue;
-    }
-    for (const c of comments) {
-      const parsed = extractStoryPerfSummaryFromComment(c?.body);
-      if (parsed) {
-        summaries.push(parsed);
-        break;
+  // Bounded-parallel comment fetch (Story #3990). Each Story's comment
+  // thread is an independent paginated REST read through a fresh `gh`
+  // spawn, so a serial loop pays N sequential round-trips. concurrentMap
+  // preserves input→output index, keeping summaries in Story order; the
+  // per-Story try/catch stays inside the mapper so one failed fetch
+  // degrades to warn-and-skip without aborting the batch (mirrors
+  // verifySingleResult in lib/orchestration/wave-record-io.js, #3024).
+  const perStory = await concurrentMap(
+    storyTickets,
+    async (ticket) => {
+      const id = Number(ticket.id ?? ticket.number);
+      if (!Number.isInteger(id) || id < 1) return null;
+      let comments;
+      try {
+        comments = (await provider.getTicketComments(id)) ?? [];
+      } catch (err) {
+        logger.warn?.(
+          `[analyze-execution] getTicketComments(${id}) failed: ${
+            err instanceof Error ? err.message : String(err)
+          }`,
+        );
+        return null;
       }
-    }
-  }
-  return summaries;
+      for (const c of comments) {
+        const parsed = extractStoryPerfSummaryFromComment(c?.body);
+        if (parsed) return parsed;
+      }
+      return null;
+    },
+    { concurrency: 4 },
+  );
+  return perStory.filter((s) => s !== null);
 }
 
 /**

--- a/tests/analyze-execution.test.js
+++ b/tests/analyze-execution.test.js
@@ -623,9 +623,7 @@ describe('collectStorySummaries — bounded-parallel fetch (Story #3990)', () =>
         return new Promise((resolve) => {
           setTimeout(
             () =>
-              resolve([
-                { id: ticketId, body: summaryBody(Number(ticketId)) },
-              ]),
+              resolve([{ id: ticketId, body: summaryBody(Number(ticketId)) }]),
             (206 - Number(ticketId)) * 5,
           );
         });

--- a/tests/analyze-execution.test.js
+++ b/tests/analyze-execution.test.js
@@ -21,6 +21,7 @@ import {
   runEpicMode,
   runStoryMode,
 } from '../.agents/scripts/analyze-execution.js';
+import { collectStorySummaries } from '../.agents/scripts/lib/observability/perf-report-readers.js';
 
 // In-memory ticketing provider that satisfies the slice of the
 // ITicketingProvider surface analyze-execution touches. Comments are
@@ -595,6 +596,90 @@ describe('runStoryMode — back-compat with source-tagged streams (Story #2553)'
     assert.equal(result.payload.phaseTimingsMs.install, 1500);
     assert.equal(result.payload.phaseTimingsMs.test, 3500);
     assert.equal(result.payload.retryDensity.retries, 1);
+  });
+});
+
+describe('collectStorySummaries — bounded-parallel fetch (Story #3990)', () => {
+  const summaryBody = (storyId) =>
+    [
+      '<!-- ap:structured-comment type="story-perf-summary" -->',
+      '',
+      '```json',
+      JSON.stringify({ kind: 'story-perf-summary', storyId }, null, 2),
+      '```',
+    ].join('\n');
+
+  const storyTicket = (id) => ({ id, labels: ['type::story'] });
+
+  it('keeps summaries in input Story order even when later fetches resolve first', async () => {
+    const ids = [201, 202, 203, 204, 205, 206];
+    const provider = {
+      async getSubTickets() {
+        return ids.map(storyTicket);
+      },
+      getTicketComments(ticketId) {
+        // Later inputs resolve before earlier ones — output must still
+        // follow input order, not completion order.
+        return new Promise((resolve) => {
+          setTimeout(
+            () =>
+              resolve([
+                { id: ticketId, body: summaryBody(Number(ticketId)) },
+              ]),
+            (206 - Number(ticketId)) * 5,
+          );
+        });
+      },
+    };
+    const out = await collectStorySummaries(provider, 1, { warn() {} });
+    assert.deepEqual(
+      out.map((s) => s.storyId),
+      ids,
+    );
+  });
+
+  it('caps in-flight getTicketComments calls at 4', async () => {
+    const ids = Array.from({ length: 10 }, (_, i) => 300 + i);
+    let inFlight = 0;
+    let maxInFlight = 0;
+    const provider = {
+      async getSubTickets() {
+        return ids.map(storyTicket);
+      },
+      async getTicketComments(ticketId) {
+        inFlight++;
+        maxInFlight = Math.max(maxInFlight, inFlight);
+        await new Promise((resolve) => setTimeout(resolve, 5));
+        inFlight--;
+        return [{ id: ticketId, body: summaryBody(Number(ticketId)) }];
+      },
+    };
+    const out = await collectStorySummaries(provider, 1, { warn() {} });
+    assert.equal(out.length, 10);
+    assert.ok(maxInFlight <= 4, `maxInFlight=${maxInFlight} exceeds cap 4`);
+    assert.ok(maxInFlight > 1, 'expected parallel fetches');
+  });
+
+  it('warns and skips a rejecting getTicketComments without aborting the batch', async () => {
+    const warned = [];
+    const provider = {
+      async getSubTickets() {
+        return [storyTicket(401), storyTicket(402), storyTicket(403)];
+      },
+      async getTicketComments(ticketId) {
+        if (Number(ticketId) === 402) throw new Error('boom 402');
+        return [{ id: ticketId, body: summaryBody(Number(ticketId)) }];
+      },
+    };
+    const out = await collectStorySummaries(provider, 1, {
+      warn: (msg) => warned.push(msg),
+    });
+    assert.deepEqual(
+      out.map((s) => s.storyId),
+      [401, 403],
+    );
+    assert.equal(warned.length, 1);
+    assert.match(warned[0], /getTicketComments\(402\) failed: boom 402/);
   });
 });
 


### PR DESCRIPTION
Closes #3990

_Auto-opened by `/single-story-deliver`._