### PR TITLE
fix(cli): resolve `mandrel init` sync step to the local bin instead of relying on PATH (#4016)

### DIFF
--- a/lib/cli/init.js
+++ b/lib/cli/init.js
@@ -9,7 +9,9 @@
  *
  *   1. **Install-if-absent.** When `./.agents/` is missing in the cwd, install
  *      the framework deterministically — `npm install mandrel --ignore-scripts`
- *      followed by an explicit `mandrel sync`. The `--ignore-scripts` install
+ *      followed by an explicit sync run against the freshly installed bin
+ *      (`node ./node_modules/mandrel/bin/mandrel.js sync`, NOT a bare `mandrel`
+ *      on `PATH` — see `SYNC_BIN` below). The `--ignore-scripts` install
  *      skips the package's best-effort `postinstall` sync so the explicit
  *      `sync` is the single, deterministic materialization (review rec D.3 —
  *      no postinstall-then-init double-sync, and no arbitrary install
@@ -75,6 +77,20 @@ const PACKAGE_NAME = 'mandrel';
 // than against PROJECT_ROOT (which, under npx, is npx's throwaway cache).
 const BOOTSTRAP_SCRIPT = path.join('.agents', 'scripts', 'bootstrap.js');
 
+// The `sync` step is dispatched against the **locally installed** Mandrel bin
+// rather than a bare `mandrel` on `PATH`. A bare `spawnSync('mandrel', …)` only
+// resolves while npx keeps its throwaway `.bin` on `PATH`; reached any other
+// way (a documented `npm install mandrel` then `mandrel init`, or a plain
+// `node bin/mandrel.js init`), the freshly installed binary lives at
+// `./node_modules/mandrel/bin/mandrel.js` — off `PATH` — and a bare spawn dies
+// with ENOENT, leaving `.agents/` un-materialized. Spawning `process.execPath`
+// against the package entrypoint resolves identically under npx, under a
+// post-install invocation, and in tests — and, by going through `node`, also
+// sidesteps the win32 `.cmd`-shim concern entirely (no `shell: true` needed for
+// this step). The path is cwd-relative because the package is installed into
+// the consumer's cwd (the same reason BOOTSTRAP_SCRIPT is cwd-relative).
+const SYNC_BIN = path.join('node_modules', PACKAGE_NAME, 'bin', 'mandrel.js');
+
 const PROMPT_TEXT =
   'Mandrel is installed. What next?\n' +
   '  1) Configure my environment now (creates the GitHub repo + Projects board)\n' +
@@ -83,10 +99,12 @@ const PROMPT_TEXT =
 
 const FILES_ONLY_HINT = 'Configure any time with: mandrel init\n';
 
-// On win32, `npm`/`mandrel` resolve to `.cmd` shims that Node refuses to spawn
-// without a shell after the CVE-2024-27980 hardening; mirror update.js and set
+// On win32, `npm` resolves to a `.cmd` shim that Node refuses to spawn without
+// a shell after the CVE-2024-27980 hardening; mirror update.js and set
 // `shell: true` only there. Off win32, never shell out — array argv stays
-// injection-proof.
+// injection-proof. (The `sync` step no longer hits a `.cmd` shim at all: it is
+// dispatched as `process.execPath` + `SYNC_BIN`, a plain `node` spawn — but the
+// `npm install` step still needs the shim handling, so `NEEDS_SHELL` stays.)
 const NEEDS_SHELL = process.platform === 'win32';
 
 /**
@@ -187,7 +205,7 @@ export function planInit({
       };
     }
 
-    const syncStatus = step('mandrel', ['sync']);
+    const syncStatus = step(process.execPath, [SYNC_BIN, 'sync']);
     if (syncStatus !== 0) {
       return {
         installed: true,
@@ -248,8 +266,10 @@ function defaultExists(relPath) {
 
 /**
  * Default step runner — spawn the tool synchronously, inheriting stdio so its
- * output streams to the terminal. Sets `shell: true` only on win32 so `.cmd`
- * shims (`npm.cmd`, `mandrel.cmd`) resolve under CVE-2024-27980 hardening.
+ * output streams to the terminal. Sets `shell: true` only on win32 so the
+ * `npm.cmd` shim resolves under CVE-2024-27980 hardening. The `sync` and
+ * bootstrap steps spawn `process.execPath` (a plain `node`), which needs no
+ * shell on any platform.
  *
  * @param {string} cmd
  * @param {string[]} args

--- a/tests/cli/init.test.js
+++ b/tests/cli/init.test.js
@@ -97,12 +97,66 @@ describe('init — install when .agents/ is absent', () => {
       isTTY: true,
     });
 
-    // First two steps are install then sync, in that order.
+    // First two steps are install then sync, in that order. The sync step is
+    // dispatched against the locally installed bin via process.execPath, NOT a
+    // bare `mandrel` on PATH (Story #4016).
     assert.equal(calls[0].cmd, 'npm');
     assert.deepEqual(calls[0].args, ['install', 'mandrel', '--ignore-scripts']);
-    assert.equal(calls[1].cmd, 'mandrel');
-    assert.deepEqual(calls[1].args, ['sync']);
+    assert.equal(calls[1].cmd, process.execPath);
+    assert.equal(calls[1].args.length, 2);
+    assert.ok(
+      calls[1].args[0].endsWith(
+        path.join('node_modules', 'mandrel', 'bin', 'mandrel.js'),
+      ),
+      `expected the resolved local bin path, got ${calls[1].args[0]}`,
+    );
+    assert.equal(calls[1].args[1], 'sync');
     assert.equal(result.installed, true);
+  });
+
+  it('resolves the sync step to the local bin, never a bare `mandrel` on PATH (Story #4016)', () => {
+    // Regression guard for the post-install (non-npx) cold start: reached via a
+    // documented `npm install mandrel` then `mandrel init`, or a plain
+    // `node bin/mandrel.js init`, the freshly installed binary lives at
+    // ./node_modules/mandrel/bin/mandrel.js and is NOT on PATH. A bare
+    // spawnSync('mandrel', ['sync']) dies with ENOENT and leaves .agents/
+    // un-materialized. The sync step must instead spawn process.execPath against
+    // the resolved local entrypoint.
+    const { calls, runStep } = makeRunStep();
+    const { confirm } = makeConfirm('2');
+    const { write } = makeStdout();
+
+    planInit({
+      argv: [],
+      exists: () => false, // .agents/ absent → install + sync path
+      runStep,
+      confirm,
+      stdout: write,
+      isTTY: true,
+    });
+
+    // No step may invoke a bare `mandrel` (the PATH-dependent shape).
+    const bareMandrel = calls.find((c) => c.cmd === 'mandrel');
+    assert.equal(
+      bareMandrel,
+      undefined,
+      'sync must not spawn a bare `mandrel` on PATH',
+    );
+
+    // The sync step is process.execPath + the cwd-relative local bin + `sync`.
+    const syncCall = calls.find((c) => c.args.includes('sync'));
+    assert.ok(syncCall, 'expected a sync step');
+    assert.equal(
+      syncCall.cmd,
+      process.execPath,
+      'sync must be dispatched through process.execPath (node)',
+    );
+    assert.equal(
+      syncCall.args[0],
+      path.join('node_modules', 'mandrel', 'bin', 'mandrel.js'),
+      'sync must target the resolved local Mandrel entrypoint',
+    );
+    assert.equal(syncCall.args[1], 'sync');
   });
 
   it('targets the hardcoded package name even when argv supplies a different name', () => {
@@ -164,7 +218,7 @@ describe('init — skip install when .agents/ is present', () => {
     });
 
     const installOrSync = calls.filter(
-      (c) => c.cmd === 'npm' || (c.cmd === 'mandrel' && c.args[0] === 'sync'),
+      (c) => c.cmd === 'npm' || c.args.includes('sync'),
     );
     assert.equal(
       installOrSync.length,


### PR DESCRIPTION
Closes #4016

_Auto-opened by `/single-story-deliver`._