### PR TITLE
fix(cli): mandrel update materializes stale .agents/ — re-exec post-install phases from the new bin (#4034)

### DIFF
--- a/lib/cli/__tests__/update-reexec.test.js
+++ b/lib/cli/__tests__/update-reexec.test.js
@@ -1,0 +1,513 @@
+// lib/cli/__tests__/update-reexec.test.js
+/**
+ * Unit tests for the Story #4034 re-exec fix in lib/cli/update.js.
+ *
+ * After `npm-update` lands the new version, the post-install phases
+ * (sync, migrate, doctor) MUST run from the newly-installed binary rather
+ * than in the still-running old process. The `spawnPhase` seam is the
+ * injectable boundary that makes this fully testable without a real npm
+ * install.
+ *
+ * Coverage contract (Story #4034):
+ *   - When `spawnPhase` is injected, post-install phases run through it
+ *     (re-exec path) instead of the in-process runSync/runMigrations/runDoctor.
+ *   - Phases are spawned in the correct order: sync → migrate → doctor.
+ *   - `mandrel migrate` receives `--from <current>` and `--to <target>`.
+ *   - The new bin path passed to `spawnPhase` is resolved from the cwd's
+ *     `node_modules/.bin/mandrel` (the production path).
+ *   - A failing sync phase throws and exits non-zero (never silently continues).
+ *   - A failing migrate phase throws and exits non-zero.
+ *   - A non-zero doctor phase maps to `action: 'doctor-failed'` + exit 1.
+ *   - `resolveNewBinPath` returns the correct platform path.
+ *   - `defaultSpawnPhase` routes stdout/stderr through the write sinks and
+ *     throws on spawn error.
+ *
+ * Tier: unit (testing-standards § Unit). All seams — including `spawnPhase`
+ * — are injected; no real child process, filesystem, or network call occurs.
+ *
+ * Security (security-baseline § 5 — Data Leakage & Logging): fixtures carry
+ * only version strings and paths; no tokens, credentials, or env values.
+ */
+
+import assert from 'node:assert/strict';
+import path from 'node:path';
+import { describe, it } from 'node:test';
+
+import { defaultSpawnPhase, resolveNewBinPath, runUpdate } from '../update.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Capture stdout/stderr writes and the exit code. */
+function makeCapture() {
+  const out = [];
+  const err = [];
+  let exitCode = null;
+  return {
+    out,
+    err,
+    get exitCode() {
+      return exitCode;
+    },
+    write: (s) => out.push(s),
+    writeErr: (s) => err.push(s),
+    exit: (code) => {
+      exitCode = code;
+    },
+  };
+}
+
+/**
+ * Build a minimal seam set for a minor-ahead non-dry-run run.
+ * `spawnPhase` replaces the in-process runSync/runMigrations/runDoctor.
+ */
+function makeReExecSeams({
+  target = '1.44.0',
+  current = '1.43.0',
+  spawnResults = {},
+} = {}) {
+  const calls = [];
+  return {
+    calls,
+    currentVersion: current,
+    resolveTargetVersion: async () => {
+      calls.push('resolve');
+      return target;
+    },
+    npmUpdate: async (version) => {
+      calls.push(`npm-update:${version}`);
+    },
+    spawnPhase: async (phase, args, opts) => {
+      calls.push({ phase, args, binPath: opts.binPath, cwd: opts.cwd });
+      const result = spawnResults[phase] ?? {
+        ok: true,
+        stdout: '',
+        stderr: '',
+      };
+      return result;
+    },
+    surfaceChangelog: async (version) => {
+      calls.push(`changelog:${version}`);
+    },
+    cwd: () => '/fake/consumer',
+  };
+}
+
+// ---------------------------------------------------------------------------
+// AC: spawnPhase is invoked for post-install phases when injected
+// ---------------------------------------------------------------------------
+
+describe('runUpdate — re-exec path via spawnPhase', () => {
+  it('routes post-install phases through spawnPhase, not in-process seams', async () => {
+    const cap = makeCapture();
+    const seams = makeReExecSeams({ target: '1.44.0', current: '1.43.0' });
+
+    const result = await runUpdate({
+      argv: [],
+      ...seams,
+      write: cap.write,
+      writeErr: cap.writeErr,
+      exit: cap.exit,
+    });
+
+    // npm-update ran, then all three phases were spawned via spawnPhase.
+    const phaseNames = seams.calls
+      .filter((c) => typeof c === 'object' && c.phase)
+      .map((c) => c.phase);
+    assert.deepEqual(phaseNames, ['sync', 'migrate', 'doctor']);
+
+    // The in-process runSync/runMigrations/runDoctor were NOT invoked directly
+    // (there are no 'runSync' / 'runMigrations' / 'runDoctor' string entries).
+    assert.ok(
+      !seams.calls.some(
+        (c) => c === 'runSync' || c === 'runMigrations' || c === 'runDoctor',
+      ),
+      'in-process seams must NOT be called when spawnPhase is injected',
+    );
+
+    assert.equal(result.ok, true);
+    assert.equal(result.action, 'updated');
+    assert.deepEqual(result.stepsRun, [
+      'npm-update',
+      'runSync',
+      'runMigrations',
+      'doctor',
+    ]);
+    assert.equal(cap.exitCode, null);
+  });
+
+  it('passes correct ordered argv to each phase: sync→migrate(--from,--to)→doctor', async () => {
+    const cap = makeCapture();
+    const seams = makeReExecSeams({ target: '1.50.0', current: '1.43.0' });
+
+    await runUpdate({
+      argv: [],
+      ...seams,
+      write: cap.write,
+      writeErr: cap.writeErr,
+      exit: cap.exit,
+    });
+
+    const phases = seams.calls.filter((c) => typeof c === 'object' && c.phase);
+    assert.equal(phases.length, 3);
+
+    assert.equal(phases[0].phase, 'sync');
+    assert.deepEqual(phases[0].args, []);
+
+    assert.equal(phases[1].phase, 'migrate');
+    assert.deepEqual(phases[1].args, ['--from', '1.43.0', '--to', '1.50.0']);
+
+    assert.equal(phases[2].phase, 'doctor');
+    assert.deepEqual(phases[2].args, []);
+  });
+
+  it('resolves new bin path from cwd/node_modules/.bin/mandrel', async () => {
+    const cap = makeCapture();
+    const seams = makeReExecSeams({ target: '1.44.0', current: '1.43.0' });
+
+    await runUpdate({
+      argv: [],
+      ...seams,
+      write: cap.write,
+      writeErr: cap.writeErr,
+      exit: cap.exit,
+    });
+
+    const phases = seams.calls.filter((c) => typeof c === 'object' && c.phase);
+    const expectedBin = resolveNewBinPath('/fake/consumer');
+    for (const p of phases) {
+      assert.equal(
+        p.binPath,
+        expectedBin,
+        `phase '${p.phase}' binPath should resolve to new bin`,
+      );
+      assert.equal(p.cwd, '/fake/consumer');
+    }
+  });
+
+  it('throws when sync phase exits non-zero (never silently materialises stale payload)', async () => {
+    const cap = makeCapture();
+    const seams = makeReExecSeams({
+      target: '1.44.0',
+      current: '1.43.0',
+      spawnResults: { sync: { ok: false, stdout: '', stderr: 'sync failed' } },
+    });
+
+    await assert.rejects(
+      () =>
+        runUpdate({
+          argv: [],
+          ...seams,
+          write: cap.write,
+          writeErr: cap.writeErr,
+          exit: cap.exit,
+        }),
+      /mandrel sync.*new binary exited non-zero/,
+    );
+
+    // migrate and doctor must NOT have been called after sync failure.
+    const phases = seams.calls.filter((c) => typeof c === 'object' && c.phase);
+    assert.deepEqual(
+      phases.map((p) => p.phase),
+      ['sync'],
+    );
+  });
+
+  it('throws when migrate phase exits non-zero', async () => {
+    const cap = makeCapture();
+    const seams = makeReExecSeams({
+      target: '1.44.0',
+      current: '1.43.0',
+      spawnResults: {
+        migrate: { ok: false, stdout: '', stderr: 'migrate failed' },
+      },
+    });
+
+    await assert.rejects(
+      () =>
+        runUpdate({
+          argv: [],
+          ...seams,
+          write: cap.write,
+          writeErr: cap.writeErr,
+          exit: cap.exit,
+        }),
+      /mandrel migrate.*new binary exited non-zero/,
+    );
+
+    // doctor must NOT have been called after migrate failure.
+    const phases = seams.calls.filter((c) => typeof c === 'object' && c.phase);
+    assert.deepEqual(
+      phases.map((p) => p.phase),
+      ['sync', 'migrate'],
+    );
+  });
+
+  it('maps non-zero doctor to doctor-failed + exit 1', async () => {
+    const cap = makeCapture();
+    const seams = makeReExecSeams({
+      target: '1.44.0',
+      current: '1.43.0',
+      spawnResults: {
+        doctor: {
+          ok: false,
+          stdout: '',
+          stderr: 'agents-drift: drift detected',
+        },
+      },
+    });
+
+    const result = await runUpdate({
+      argv: [],
+      ...seams,
+      write: cap.write,
+      writeErr: cap.writeErr,
+      exit: cap.exit,
+    });
+
+    assert.equal(result.ok, false);
+    assert.equal(result.action, 'doctor-failed');
+    assert.equal(cap.exitCode, 1);
+    assert.match(cap.err.join(''), /doctor reported failures/);
+  });
+
+  it('still runs the changelog seam after a successful re-exec cycle', async () => {
+    const cap = makeCapture();
+    const seams = makeReExecSeams({ target: '1.44.0', current: '1.43.0' });
+
+    await runUpdate({
+      argv: [],
+      ...seams,
+      write: cap.write,
+      writeErr: cap.writeErr,
+      exit: cap.exit,
+    });
+
+    assert.ok(
+      seams.calls.includes('changelog:1.44.0'),
+      'changelog seam must fire after successful re-exec phases',
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AC: in-process seams still work when spawnPhase is NOT injected
+// (backward compatibility — pre-Story-#4034 tests must stay green)
+// ---------------------------------------------------------------------------
+
+describe('runUpdate — in-process backward-compat path (no spawnPhase)', () => {
+  it('uses injected runSync/runMigrations/runDoctor when spawnPhase is absent', async () => {
+    const calls = [];
+    const cap = makeCapture();
+
+    const result = await runUpdate({
+      argv: [],
+      currentVersion: '1.43.0',
+      resolveTargetVersion: async () => '1.44.0',
+      npmUpdate: async (v) => {
+        calls.push(`npm-update:${v}`);
+      },
+      runSync: (_opts) => {
+        calls.push('runSync');
+        return {};
+      },
+      runMigrations: ({ fromVersion, toVersion }) => {
+        calls.push(`runMigrations:${fromVersion}->${toVersion}`);
+        return { applied: [], skipped: [] };
+      },
+      runDoctor: async () => {
+        calls.push('runDoctor');
+        return { ok: true, results: [] };
+      },
+      surfaceChangelog: async (v) => {
+        calls.push(`changelog:${v}`);
+      },
+      write: cap.write,
+      writeErr: cap.writeErr,
+      exit: cap.exit,
+    });
+
+    assert.deepEqual(calls, [
+      'npm-update:1.44.0',
+      'runSync',
+      'runMigrations:1.43.0->1.44.0',
+      'runDoctor',
+      'changelog:1.44.0',
+    ]);
+    assert.equal(result.ok, true);
+    assert.equal(result.action, 'updated');
+    assert.equal(cap.exitCode, null);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AC: resolveNewBinPath returns the correct platform path
+// ---------------------------------------------------------------------------
+
+describe('resolveNewBinPath', () => {
+  it('returns node_modules/.bin/mandrel on POSIX', () => {
+    // We cannot force-test win32 on non-win32 but we can verify the POSIX shape.
+    if (process.platform !== 'win32') {
+      const p = resolveNewBinPath('/some/project');
+      assert.equal(
+        p,
+        path.join('/some', 'project', 'node_modules', '.bin', 'mandrel'),
+      );
+    }
+  });
+
+  it('returns a path that ends with mandrel or mandrel.cmd', () => {
+    const p = resolveNewBinPath('/project');
+    assert.ok(
+      p.endsWith('mandrel') || p.endsWith('mandrel.cmd'),
+      `expected path to end with mandrel[.cmd], got: ${p}`,
+    );
+  });
+
+  it('contains node_modules/.bin in the path', () => {
+    const p = resolveNewBinPath('/project');
+    assert.ok(
+      p.includes(path.join('node_modules', '.bin')),
+      `expected node_modules/.bin in path, got: ${p}`,
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AC: defaultSpawnPhase routes output through write sinks and throws on error
+// ---------------------------------------------------------------------------
+
+describe('defaultSpawnPhase — output routing and error handling', () => {
+  it('routes child stdout through the write sink', () => {
+    const out = [];
+    const err = [];
+    const fakeSpawn = (_bin, _args, _opts) => ({
+      status: 0,
+      stdout: 'Materialized 832 files\n',
+      stderr: '',
+      error: undefined,
+    });
+
+    defaultSpawnPhase('sync', [], {
+      binPath: '/fake/bin/mandrel',
+      cwd: '/project',
+      write: (s) => out.push(s),
+      writeErr: (s) => err.push(s),
+      spawnFn: fakeSpawn,
+    });
+
+    assert.deepEqual(out, ['Materialized 832 files\n']);
+    assert.deepEqual(err, []);
+  });
+
+  it('routes child stderr through the writeErr sink', () => {
+    const out = [];
+    const err = [];
+    const fakeSpawn = () => ({
+      status: 0,
+      stdout: '',
+      stderr: 'warning: something\n',
+      error: undefined,
+    });
+
+    defaultSpawnPhase('doctor', [], {
+      binPath: '/fake/bin/mandrel',
+      cwd: '/project',
+      write: (s) => out.push(s),
+      writeErr: (s) => err.push(s),
+      spawnFn: fakeSpawn,
+    });
+
+    assert.deepEqual(out, []);
+    assert.deepEqual(err, ['warning: something\n']);
+  });
+
+  it('returns ok:false when child exits non-zero', () => {
+    const fakeSpawn = () => ({
+      status: 1,
+      stdout: '',
+      stderr: 'drift detected',
+      error: undefined,
+    });
+
+    const result = defaultSpawnPhase('doctor', [], {
+      binPath: '/fake/bin/mandrel',
+      cwd: '/project',
+      write: () => {},
+      writeErr: () => {},
+      spawnFn: fakeSpawn,
+    });
+
+    assert.equal(result.ok, false);
+  });
+
+  it('returns ok:true when child exits 0', () => {
+    const fakeSpawn = () => ({
+      status: 0,
+      stdout: 'all good',
+      stderr: '',
+      error: undefined,
+    });
+
+    const result = defaultSpawnPhase('sync', [], {
+      binPath: '/fake/bin/mandrel',
+      cwd: '/project',
+      write: () => {},
+      writeErr: () => {},
+      spawnFn: fakeSpawn,
+    });
+
+    assert.equal(result.ok, true);
+  });
+
+  it('throws a descriptive error when the spawn itself fails (ENOENT)', () => {
+    const fakeSpawn = () => ({
+      status: null,
+      stdout: '',
+      stderr: '',
+      error: new Error('spawnSync mandrel ENOENT'),
+    });
+
+    assert.throws(
+      () =>
+        defaultSpawnPhase('sync', [], {
+          binPath: '/fake/bin/mandrel',
+          cwd: '/project',
+          write: () => {},
+          writeErr: () => {},
+          spawnFn: fakeSpawn,
+        }),
+      /failed to spawn.*mandrel sync.*new binary.*ENOENT/,
+    );
+  });
+
+  it('passes the correct argv vector to the spawn function', () => {
+    const calls = [];
+    const fakeSpawn = (bin, args, opts) => {
+      calls.push({ bin, args, opts });
+      return { status: 0, stdout: '', stderr: '', error: undefined };
+    };
+
+    defaultSpawnPhase('migrate', ['--from', '1.43.0', '--to', '1.44.0'], {
+      binPath: '/nm/.bin/mandrel',
+      cwd: '/proj',
+      write: () => {},
+      writeErr: () => {},
+      spawnFn: fakeSpawn,
+    });
+
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0].bin, '/nm/.bin/mandrel');
+    assert.deepEqual(calls[0].args, [
+      'migrate',
+      '--from',
+      '1.43.0',
+      '--to',
+      '1.44.0',
+    ]);
+    assert.equal(calls[0].opts.cwd, '/proj');
+    // Shell flag is win32-gated: true only on Windows.
+    assert.equal(calls[0].opts.shell, process.platform === 'win32');
+  });
+});

--- a/lib/cli/update.js
+++ b/lib/cli/update.js
@@ -25,10 +25,36 @@
  *      the resolved version so an override can still consume the auto-probed
  *      newest. The registry probe in step 1 always stays on `npm view` (a
  *      PM-agnostic registry query).
- *   5. runSync        — re-materialize ./.agents/ from the new payload
- *   6. runMigrations  — apply version-keyed steps for the crossed range
- *   7. doctor         — run the check registry; success ⇒ all checks pass
+ *   5. runSync        — re-materialize ./.agents/ **from the newly-installed
+ *      binary** so the materialized payload is always the target version's.
+ *   6. runMigrations  — apply version-keyed steps for the crossed range,
+ *      **from the newly-installed binary**.
+ *   7. doctor         — run the check registry **from the newly-installed
+ *      binary** so `agents-drift` is never a false-green against stale payload.
  *   8. surface the changelog for the target version
+ *
+ * ## Re-exec of post-install phases (Story #4034)
+ *
+ * Steps 5–7 execute as **child processes spawned from the newly-installed
+ * binary** (`<cwd>/node_modules/.bin/mandrel`) rather than in the running
+ * process. Node cannot hot-swap a `require`d module mid-process, so without
+ * re-exec, the still-running old binary's `runSync`/`runMigrations`/`runDoctor`
+ * code would materialise the old payload even though the package on disk has
+ * already been updated. This produced the silent stale-`.agents/`
+ * materialization and `doctor` false-green observed in the v1.58.0 → v1.59.0
+ * consumer upgrade.
+ *
+ * The orchestration (progress messages, step tracking, changelog surface, exit
+ * code) stays in the parent process; only the version-sensitive phases run from
+ * the new bin. The `spawnPhase` seam makes the child-process boundary fully
+ * injectable so tests can verify the re-exec path without a real npm install.
+ *
+ * Backward compatibility: when `runSync`, `runMigrations`, or `runDoctor`
+ * are explicitly injected (the historical test-seam pattern) and `spawnPhase`
+ * is NOT injected, the in-process seams are used unchanged (old tests stay
+ * green). When `spawnPhase` IS injected, it takes priority over the in-process
+ * seams for the live phases — so new tests targeting the re-exec boundary can
+ * inject `spawnPhase` without touching the old seam interface.
  *
  * ## No git mutation
  *
@@ -62,12 +88,24 @@
  *   - `resolveTargetVersion`— async, returns the newest published version
  *   - `npmUpdate`           — async, performs the dependency bump (no git);
  *                             receives `(target, { installCmd })`
- *   - `runSync`             — re-materializes ./.agents/ (lib/cli/sync.js)
- *   - `runMigrations`       — version-keyed migration runner (lib/migrations)
- *   - `runDoctor`           — async, returns { ok, results } from the registry
+ *   - `spawnPhase`          — async, spawns a post-install phase from the new
+ *                             binary; receives `(phase, args, { binPath, cwd })`
+ *                             and returns `{ ok, stdout, stderr }`. When
+ *                             injected, it takes priority over `runSync`,
+ *                             `runMigrations`, and `runDoctor` for the live
+ *                             phases. See § Re-exec of post-install phases.
+ *   - `runSync`             — re-materializes ./.agents/ (lib/cli/sync.js).
+ *                             Used when `spawnPhase` is NOT injected (backward
+ *                             compat for tests that pre-date Story #4034).
+ *   - `runMigrations`       — version-keyed migration runner (lib/migrations).
+ *                             Used when `spawnPhase` is NOT injected.
+ *   - `runDoctor`           — async, returns { ok, results } from the registry.
+ *                             Used when `spawnPhase` is NOT injected.
  *   - `surfaceChangelog`    — emits the target changelog section
  *   - `write` / `writeErr`  — stdout / stderr sinks
  *   - `exit`                — process.exit replacement
+ *   - `cwd`                 — process.cwd() replacement (used to resolve the
+ *                             new binary path when `spawnPhase` is absent)
  *
  * Security (security-baseline § 5 — Data Leakage & Logging): logs only version
  * strings, step names, and the runbook path. No tokens, credentials, or env
@@ -86,6 +124,12 @@
  * the install argv is a tokenized list whose only variable segment is a
  * resolved semver string — see `lib/install-cmd-parser.js` for the shared
  * tokenize-and-spawn rationale this module reuses (no duplicated workaround).
+ *
+ * The `spawnPhase` default (Story #4034) similarly uses `shell: true` only on
+ * Windows: the new binary resolves from `node_modules/.bin/mandrel` (a fixed,
+ * non-operator-supplied path) and the per-phase argv vector is a constant
+ * fixed list (e.g. `['sync']`, `['migrate', '--from', v, '--to', v]`,
+ * `['doctor']`) with no injection risk regardless of the shell flag.
  */
 
 import { spawnSync } from 'node:child_process';
@@ -509,6 +553,8 @@ function parseChangelogSections(raw) {
  * report whether all passed. Mirrors lib/cli/doctor.js's pass accounting
  * without the formatted report (the orchestrator owns its own output).
  *
+ * This is used only when `spawnPhase` is NOT injected (backward-compat path).
+ *
  * @param {{ checks?: typeof registry }} [opts]
  * @returns {Promise<{ ok: boolean, results: Array<{ name: string, ok: boolean }> }>}
  */
@@ -519,6 +565,69 @@ async function defaultRunDoctor({ checks = registry } = {}) {
     results.push({ name: check.name, ok: Boolean(r.ok) });
   }
   return { ok: results.every((r) => r.ok), results };
+}
+
+/**
+ * Resolve the path to the `mandrel` binary inside `node_modules/.bin/` for the
+ * given project root. On Windows the binary is a `.cmd` shim; on POSIX it is a
+ * plain executable. The resolved path is used as the target for the post-install
+ * phase re-exec (Story #4034).
+ *
+ * @param {string} projectRoot - Absolute path to the consumer project.
+ * @returns {string} Absolute path to the new binary.
+ */
+export function resolveNewBinPath(projectRoot) {
+  const binName = process.platform === 'win32' ? 'mandrel.cmd' : 'mandrel';
+  return path.join(projectRoot, 'node_modules', '.bin', binName);
+}
+
+/**
+ * Default `spawnPhase` seam (Story #4034): spawn a post-install phase from the
+ * newly-installed `mandrel` binary and stream its stdout/stderr through the
+ * parent's write sinks. Each phase runs as an isolated child process so the
+ * newly-installed module code (not the currently-loaded old module) executes.
+ *
+ * The spawn uses `shell: true` only on Windows where the binary is a `.cmd`
+ * shim (CVE-2024-27980 parity). The argv vector is a fixed constant list
+ * per phase — no operator-supplied data enters the vector, so the shell flag
+ * carries no injection risk (security-baseline § Output & Rendering).
+ *
+ * Throws when the child exits non-zero so the orchestrator can surface the
+ * failure to the operator.
+ *
+ * @param {string} phase - The mandrel sub-command to run (e.g. `'sync'`).
+ * @param {string[]} args - Additional arguments for the sub-command.
+ * @param {{
+ *   binPath: string,
+ *   cwd: string,
+ *   write: (s: string) => void,
+ *   writeErr: (s: string) => void,
+ *   spawnFn?: typeof spawnSync,
+ * }} opts
+ * @returns {{ ok: boolean, stdout: string, stderr: string }}
+ */
+export function defaultSpawnPhase(
+  phase,
+  args,
+  { binPath, cwd, write, writeErr, spawnFn = spawnSync },
+) {
+  const argv = [phase, ...args];
+  const r = spawnFn(binPath, argv, {
+    cwd,
+    encoding: 'utf8',
+    shell: process.platform === 'win32',
+  });
+  const stdout = typeof r.stdout === 'string' ? r.stdout : '';
+  const stderr = typeof r.stderr === 'string' ? r.stderr : '';
+  if (stdout) write(stdout);
+  if (stderr) writeErr(stderr);
+  if (r.error) {
+    throw new Error(
+      `mandrel update: failed to spawn \`mandrel ${phase}\` from new binary: ${r.error.message}`,
+    );
+  }
+  const ok = r.status === 0;
+  return { ok, stdout, stderr };
 }
 
 /**
@@ -576,6 +685,7 @@ function emitMajorRefusal(target, writeErr) {
  *   currentVersion?: string | (() => string),
  *   resolveTargetVersion?: () => (string | Promise<string>),
  *   npmUpdate?: (version: string, opts: { installCmd?: string }) => unknown | Promise<unknown>,
+ *   spawnPhase?: (phase: string, args: string[], opts: { binPath: string, cwd: string, write: (s: string) => void, writeErr: (s: string) => void }) => Promise<{ ok: boolean, stdout: string, stderr: string }> | { ok: boolean, stdout: string, stderr: string },
  *   runSync?: typeof defaultRunSync,
  *   runMigrations?: typeof defaultRunMigrations,
  *   runDoctor?: typeof defaultRunDoctor,
@@ -583,6 +693,7 @@ function emitMajorRefusal(target, writeErr) {
  *   write?: (s: string) => void,
  *   writeErr?: (s: string) => void,
  *   exit?: (code: number) => void,
+ *   cwd?: () => string,
  * }} [opts]
  * @returns {Promise<{
  *   ok: boolean,
@@ -599,6 +710,7 @@ export async function runUpdate({
   currentVersion,
   resolveTargetVersion,
   npmUpdate,
+  spawnPhase,
   runSync = defaultRunSync,
   runMigrations = defaultRunMigrations,
   runDoctor = defaultRunDoctor,
@@ -606,6 +718,7 @@ export async function runUpdate({
   write = (s) => process.stdout.write(s),
   writeErr = (s) => process.stderr.write(s),
   exit = (code) => process.exit(code),
+  cwd = () => process.cwd(),
 } = {}) {
   const dryRun = argv.includes('--dry-run');
   const allowMajor = argv.includes('--major');
@@ -703,40 +816,136 @@ export async function runUpdate({
   await npmUpdate(target, { installCmd });
   stepsRun.push('npm-update');
 
-  // 2. runSync — re-materialize ./.agents/ from the freshly installed payload.
-  runSync({ argv: [] });
-  stepsRun.push('runSync');
+  // Decide whether to use the re-exec path (spawnPhase) or the in-process
+  // backward-compat seams (runSync / runMigrations / runDoctor).
+  //
+  // spawnPhase injected → re-exec path: all post-install phases run from the
+  //   newly-installed binary. This is the production path and is what fixes
+  //   the stale-materialization bug (Story #4034).
+  //
+  // spawnPhase NOT injected → in-process path: the original pre-Story-#4034
+  //   behaviour. Tests that pre-date this change inject runSync/runMigrations/
+  //   runDoctor and rely on the in-process path; they stay green without any
+  //   modification.
+  const useReExec = typeof spawnPhase === 'function';
 
-  // 3. runMigrations — apply version-keyed steps for the crossed range.
-  runMigrations({ fromVersion: current, toVersion: target, ctx: {} });
-  stepsRun.push('runMigrations');
+  if (useReExec) {
+    // Re-exec path: post-install phases run from the new binary.
+    const projectRoot = cwd();
+    const binPath = resolveNewBinPath(projectRoot);
 
-  // 4. doctor — verify the resulting install.
-  const doctor = await runDoctor();
-  stepsRun.push('doctor');
+    // 2. runSync from new bin — re-materialize ./.agents/ from the freshly
+    //    installed payload. Running from the new bin ensures the copied files
+    //    come from the new package's .agents/ tree, not the old loaded module.
+    const syncResult = await spawnPhase('sync', [], {
+      binPath,
+      cwd: projectRoot,
+      write,
+      writeErr,
+    });
+    if (!syncResult.ok) {
+      throw new Error(
+        `mandrel update: \`mandrel sync\` from new binary exited non-zero — ` +
+          'the .agents/ materialization may be incomplete. ' +
+          'Run `mandrel sync` manually to restore.',
+      );
+    }
+    stepsRun.push('runSync');
 
-  // 5. surface the target changelog (best-effort; optional seam).
-  if (typeof surfaceChangelog === 'function') {
-    await surfaceChangelog(target);
-  }
-
-  if (!doctor.ok) {
-    const failed = doctor.results.filter((r) => !r.ok).map((r) => r.name);
-    writeErr(
-      `mandrel update: upgraded to v${target} but doctor reported failures: ` +
-        `${failed.join(', ')}\n` +
-        '   → Run `mandrel doctor` for remedies.\n',
+    // 3. runMigrations from new bin — apply version-keyed steps for the
+    //    crossed range. The new binary's migration registry contains any steps
+    //    added in the target version; the old process's registry does not.
+    const migrateResult = await spawnPhase(
+      'migrate',
+      ['--from', current, '--to', target],
+      { binPath, cwd: projectRoot, write, writeErr },
     );
-    exit(1);
-    return {
-      ok: false,
-      action: 'doctor-failed',
-      currentVersion: current,
-      targetVersion: target,
-      major,
-      stepsRun,
-      dryRun: false,
-    };
+    if (!migrateResult.ok) {
+      throw new Error(
+        `mandrel update: \`mandrel migrate\` from new binary exited non-zero — ` +
+          `some migrations for v${current} → v${target} may not have applied. ` +
+          `Run \`mandrel migrate --from ${current} --to ${target}\` manually to retry.`,
+      );
+    }
+    stepsRun.push('runMigrations');
+
+    // 4. doctor from new bin — verify the resulting install. Running from the
+    //    new bin is critical: the agents-drift check compares the materialized
+    //    .agents/ against the installed package payload. When the old process
+    //    runs this check, it resolves the package root to its own (old) install
+    //    dir, so drift against the new payload is invisible. The new binary
+    //    resolves the package root to the now-installed new version, producing
+    //    an accurate result.
+    const doctorResult = await spawnPhase('doctor', [], {
+      binPath,
+      cwd: projectRoot,
+      write,
+      writeErr,
+    });
+    stepsRun.push('doctor');
+
+    // 5. surface the target changelog (best-effort; optional seam).
+    if (typeof surfaceChangelog === 'function') {
+      await surfaceChangelog(target);
+    }
+
+    if (!doctorResult.ok) {
+      writeErr(
+        `mandrel update: upgraded to v${target} but doctor reported failures.\n` +
+          '   → Run `mandrel doctor` for remedies.\n',
+      );
+      exit(1);
+      return {
+        ok: false,
+        action: 'doctor-failed',
+        currentVersion: current,
+        targetVersion: target,
+        major,
+        stepsRun,
+        dryRun: false,
+      };
+    }
+  } else {
+    // In-process backward-compat path (pre-Story-#4034 behaviour).
+    // Used when no `spawnPhase` seam is injected — preserves full backward
+    // compatibility with existing tests that inject runSync/runMigrations/
+    // runDoctor directly.
+
+    // 2. runSync — re-materialize ./.agents/ from the new payload.
+    runSync({ argv: [] });
+    stepsRun.push('runSync');
+
+    // 3. runMigrations — apply version-keyed steps for the crossed range.
+    runMigrations({ fromVersion: current, toVersion: target, ctx: {} });
+    stepsRun.push('runMigrations');
+
+    // 4. doctor — verify the resulting install.
+    const doctor = await runDoctor();
+    stepsRun.push('doctor');
+
+    // 5. surface the target changelog (best-effort; optional seam).
+    if (typeof surfaceChangelog === 'function') {
+      await surfaceChangelog(target);
+    }
+
+    if (!doctor.ok) {
+      const failed = doctor.results.filter((r) => !r.ok).map((r) => r.name);
+      writeErr(
+        `mandrel update: upgraded to v${target} but doctor reported failures: ` +
+          `${failed.join(', ')}\n` +
+          '   → Run `mandrel doctor` for remedies.\n',
+      );
+      exit(1);
+      return {
+        ok: false,
+        action: 'doctor-failed',
+        currentVersion: current,
+        targetVersion: target,
+        major,
+        stepsRun,
+        dryRun: false,
+      };
+    }
   }
 
   write(`✅  Updated to v${target}. The lockfile bump is staged for review.\n`);
@@ -763,6 +972,12 @@ export async function runUpdate({
  *     lockfile (`pnpm`/`yarn`/`npm`), or the `--install-cmd` override —
  *     through the shared `runInstallCommand` helper — no git mutation;
  *     lockfile left staged.
+ *   - `spawnPhase` is wired to `defaultSpawnPhase`, which spawns each
+ *     post-install phase (sync, migrate, doctor) from the newly-installed
+ *     binary (`node_modules/.bin/mandrel`). This is the Story #4034 fix:
+ *     the new bin loads the new package's module code and resolves paths
+ *     against the new install dir, so sync/migrate/doctor can never observe
+ *     the old payload.
  *   - `surfaceChangelog` prints the relevant `docs/CHANGELOG.md` section(s)
  *     for the applied range, degrading gracefully when the file is absent.
  *
@@ -773,8 +988,9 @@ export async function runUpdate({
  *
  * The second `deps` argument exposes the **process boundaries** the production
  * defaults shell out across (`versionRunner` = `npm view`, `runInstall` =
- * the install spawn) plus `fs` / `cachePath` / `now`, so the entrypoint can be
- * driven end-to-end with the network/npm boundary stubbed and no real I/O.
+ * the install spawn, `spawnFn` = the phase-spawn boundary) plus `fs` /
+ * `cachePath` / `now`, so the entrypoint can be driven end-to-end with the
+ * network/npm boundary stubbed and no real I/O.
  * `bin/mandrel.js` calls `run(argv)` with no `deps`, getting the production
  * wiring; tests pass fakes. The `deps` surface is NOT part of the public
  * subcommand contract — `bin/mandrel.js` only ever supplies `argv`.
@@ -787,6 +1003,7 @@ export async function runUpdate({
  *   now?: Date,
  *   versionRunner?: () => string,
  *   runInstall?: (installCmd: string, cwd: string) => { status: number, stderr: string },
+ *   spawnFn?: typeof spawnSync,
  *   changelogPath?: string,
  *   runUpdate?: typeof runUpdate,
  *   runSync?: typeof defaultRunSync,
@@ -806,6 +1023,7 @@ export default async function run(argv = [], deps = {}) {
     now,
     versionRunner,
     runInstall,
+    spawnFn,
     changelogPath,
     runUpdate: runUpdateImpl = runUpdate,
     runSync,
@@ -818,6 +1036,16 @@ export default async function run(argv = [], deps = {}) {
   } = deps;
 
   const current = deps.currentVersion ?? defaultCurrentVersion(fs);
+
+  // The production spawnPhase default: spawn each post-install phase from
+  // node_modules/.bin/mandrel (the newly-installed binary). spawnFn is
+  // injectable so tests can stub the spawn boundary without running a real
+  // child process.
+  const productionSpawnPhase = (phase, args, opts) =>
+    defaultSpawnPhase(phase, args, {
+      ...opts,
+      ...(spawnFn ? { spawnFn } : {}),
+    });
 
   await runUpdateImpl({
     argv,
@@ -836,6 +1064,18 @@ export default async function run(argv = [], deps = {}) {
         ...(runInstall ? { runInstall } : {}),
         fs,
       }),
+    // In the production default export, always wire spawnPhase unless the
+    // caller injects the old-style in-process seams (runSync/runMigrations/
+    // runDoctor). When any old-style seam is present, fall back to in-process
+    // behavior to preserve the full backward-compat surface that the
+    // entrypoint test (update-entrypoint.test.js) relies on.
+    ...(runSync || runMigrations || runDoctor
+      ? {
+          ...(runSync ? { runSync } : {}),
+          ...(runMigrations ? { runMigrations } : {}),
+          ...(runDoctor ? { runDoctor } : {}),
+        }
+      : { spawnPhase: productionSpawnPhase }),
     surfaceChangelog: (target) =>
       defaultSurfaceChangelog(target, {
         current,
@@ -844,9 +1084,6 @@ export default async function run(argv = [], deps = {}) {
         ...(write ? { write } : {}),
         ...(writeErr ? { writeErr } : {}),
       }),
-    ...(runSync ? { runSync } : {}),
-    ...(runMigrations ? { runMigrations } : {}),
-    ...(runDoctor ? { runDoctor } : {}),
     ...(write ? { write } : {}),
     ...(writeErr ? { writeErr } : {}),
     ...(exit ? { exit } : {}),


### PR DESCRIPTION
Closes #4034

_Auto-opened by `/single-story-deliver`._