### PR TITLE
fix(transpile): add typescript to devDependencies so Windows CI finds it

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,6 @@
         "minimatch": "^10.0.0",
         "picomatch": "^4.0.4",
         "string-argv": "^0.3.2",
-        "typescript": ">=5.0.0",
         "typhonjs-escomplex": "^0.1.0"
       },
       "bin": {
@@ -33,7 +32,8 @@
         "knip": "^6.14.0",
         "lint-staged": "^17.0.4",
         "markdownlint-cli2": "^0.18.1",
-        "memfs": "^4.57.2"
+        "memfs": "^4.57.2",
+        "typescript": ">=5.0.0"
       },
       "engines": {
         "node": ">=22.22.1 <25"
@@ -43,7 +43,7 @@
       },
       "peerDependenciesMeta": {
         "typescript": {
-          "optional": false
+          "optional": true
         }
       }
     },
@@ -5920,6 +5920,7 @@
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",

--- a/package.json
+++ b/package.json
@@ -84,7 +84,8 @@
     "knip": "^6.14.0",
     "lint-staged": "^17.0.4",
     "markdownlint-cli2": "^0.18.1",
-    "memfs": "^4.57.2"
+    "memfs": "^4.57.2",
+    "typescript": ">=5.0.0"
   },
   "dependencies": {
     "ajv": "^8.20.0",


### PR DESCRIPTION
## Summary

- Story #4047 moved `typescript` from `dependencies` to optional peer (`peerDependenciesMeta.typescript.optional: true`) but did not add it to `devDependencies`
- The Windows Smoke CI runner runs `npm ci` without installing optional peers, so TypeScript was never present and the three *"transpile.js — real TS present"* tests failed
- This fix adds `typescript: >=5.0.0` to `devDependencies` so `npm ci` always installs it in test environments while consumer projects continue to receive it only as an optional peer

Fixes the failing Windows Smoke check across commits #4047, #4045, #4048 on `main`.

## Test plan
- [ ] Windows Smoke: `transpile.js — real TS present` (3 tests) passes
- [ ] All other checks remain green

🤖 Generated with [Claude Code](https://claude.com/claude-code)