### PR TITLE
fix(transpile): use pathToFileURL for ESM import on Windows

### DIFF
--- a/tests/lib/transpile-degradation.test.js
+++ b/tests/lib/transpile-degradation.test.js
@@ -26,14 +26,18 @@ const TRANSPILE_PATH = path.resolve(
 
 describe('transpile.js — real TS present', () => {
   it('transpileIfNeeded returns the original source for .js files (no-op)', async () => {
-    const { transpileIfNeeded } = await import(pathToFileURL(TRANSPILE_PATH).href);
+    const { transpileIfNeeded } = await import(
+      pathToFileURL(TRANSPILE_PATH).href
+    );
     const src = 'const x = 1;';
     const result = transpileIfNeeded('foo.js', src);
     assert.equal(result, src, '.js files must pass through unchanged');
   });
 
   it('transpileIfNeeded transpiles a .ts source to JS', async () => {
-    const { transpileIfNeeded } = await import(pathToFileURL(TRANSPILE_PATH).href);
+    const { transpileIfNeeded } = await import(
+      pathToFileURL(TRANSPILE_PATH).href
+    );
     const tsSrc = 'const x: number = 1;\nexport default x;\n';
     const result = transpileIfNeeded('foo.ts', tsSrc);
     assert.notEqual(result, null, 'must produce output when TS is present');
@@ -43,7 +47,9 @@ describe('transpile.js — real TS present', () => {
   });
 
   it('resolveTsTranspilerVersion returns a semver string when TS is present', async () => {
-    const { resolveTsTranspilerVersion } = await import(pathToFileURL(TRANSPILE_PATH).href);
+    const { resolveTsTranspilerVersion } = await import(
+      pathToFileURL(TRANSPILE_PATH).href
+    );
     const v = resolveTsTranspilerVersion();
     assert.match(
       v,

--- a/tests/lib/transpile-degradation.test.js
+++ b/tests/lib/transpile-degradation.test.js
@@ -12,7 +12,7 @@
 import assert from 'node:assert/strict';
 import path from 'node:path';
 import { describe, it } from 'node:test';
-import { fileURLToPath } from 'node:url';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const TRANSPILE_PATH = path.resolve(
@@ -26,14 +26,14 @@ const TRANSPILE_PATH = path.resolve(
 
 describe('transpile.js — real TS present', () => {
   it('transpileIfNeeded returns the original source for .js files (no-op)', async () => {
-    const { transpileIfNeeded } = await import(TRANSPILE_PATH);
+    const { transpileIfNeeded } = await import(pathToFileURL(TRANSPILE_PATH).href);
     const src = 'const x = 1;';
     const result = transpileIfNeeded('foo.js', src);
     assert.equal(result, src, '.js files must pass through unchanged');
   });
 
   it('transpileIfNeeded transpiles a .ts source to JS', async () => {
-    const { transpileIfNeeded } = await import(TRANSPILE_PATH);
+    const { transpileIfNeeded } = await import(pathToFileURL(TRANSPILE_PATH).href);
     const tsSrc = 'const x: number = 1;\nexport default x;\n';
     const result = transpileIfNeeded('foo.ts', tsSrc);
     assert.notEqual(result, null, 'must produce output when TS is present');
@@ -43,7 +43,7 @@ describe('transpile.js — real TS present', () => {
   });
 
   it('resolveTsTranspilerVersion returns a semver string when TS is present', async () => {
-    const { resolveTsTranspilerVersion } = await import(TRANSPILE_PATH);
+    const { resolveTsTranspilerVersion } = await import(pathToFileURL(TRANSPILE_PATH).href);
     const v = resolveTsTranspilerVersion();
     assert.match(
       v,


### PR DESCRIPTION
## Summary

- `transpile-degradation.test.js` uses `await import(absolutePath)` to dynamically load `transpile.js`
- On Windows the ESM loader requires a `file://` URL — a raw `D:\...` path throws `ERR_UNSUPPORTED_ESM_URL_SCHEME`
- Wraps `TRANSPILE_PATH` with `pathToFileURL(TRANSPILE_PATH).href` in all three dynamic import calls

This is the root cause of the Windows Smoke CI failures across the wave 1 stories. The previous PR #4055 added `typescript` to devDependencies (also needed) but this is the actual fix.

## Test plan
- [ ] Windows Smoke: all 6 `transpile-degradation` tests pass (3 "TS present" + 3 "TS absent")
- [ ] All other checks remain green

🤖 Generated with [Claude Code](https://claude.com/claude-code)