### PR TITLE
fix(tests): add shell:true to spawnSync for Windows npm.cmd compat

### DIFF
--- a/tests/npm-pack-clean.test.js
+++ b/tests/npm-pack-clean.test.js
@@ -18,6 +18,7 @@ test('npm-pack-clean', async (t) => {
     const result = spawnSync('npm', ['pack', '--dry-run'], {
       cwd: repoRoot,
       encoding: 'utf-8',
+      shell: true,
     });
     assert.strictEqual(
       result.status,


### PR DESCRIPTION
## Summary

- `tests/npm-pack-clean.test.js` used `spawnSync('npm', ...)` without `shell: true`, which returns `null` status on Windows because the npm shim is `npm.cmd`, not a bare `npm` executable. Adding `shell: true` routes through `cmd.exe` which resolves the shim correctly and returns a numeric exit status.

## Context

Follow-up to #4057 (Story #4049). The Windows Smoke CI leg failed in that PR; the two required gate checks passed and the PR merged. This single-commit follow-up resolves the remaining Windows failure.