### PR TITLE
fix: close the 9 post-merge review findings on the install/bootstrap batch

### DIFF
--- a/.agents/README.md
+++ b/.agents/README.md
@@ -151,7 +151,7 @@ Run `mandrel --help` for a subcommand list. Each subcommand supports
 | Subcommand | Purpose | Key flags |
 | ---------- | ------- | --------- |
 | `init` | Install + configure mandrel in the current project (cold-start). | `--assume-yes`, `--skip-github`, `--dry-run` |
-| `sync` | Re-materialize `.agents/` from the installed package payload. | `--dry-run`, `--force` |
+| `sync` | Re-materialize `.agents/` from the installed package payload. | `--dry-run` |
 | `sync-commands` | Regenerate `.claude/commands/` from `.agents/workflows/`. | — |
 | `doctor` | Run readiness checks and print per-check remedies. | — |
 | `update` | Upgrade mandrel to the newest non-major version. | `--dry-run`, `--major`, `--install-cmd` |

--- a/.agents/scripts/agents-bootstrap-github.js
+++ b/.agents/scripts/agents-bootstrap-github.js
@@ -291,6 +291,7 @@ async function ensureProjectFields(provider, project, log) {
  *   github?: object,
  *   baseBranch?: string,
  *   githubAdminApproved?: boolean,
+ *   isTTY?: boolean,
  * }} [opts] - `githubAdminApproved` MUST be `true` for any GitHub mutation to
  *   occur; any other value (absent / `false`) is treated as "not approved"
  *   and the run is a verified no-op.
@@ -357,8 +358,11 @@ export async function runBootstrap(config, opts = {}) {
   // Consumer-facing bootstrap promotes the framework's CI-gates-only
   // stance: branch protection with enforce_admins + 0-approval-count and
   // the squash-only merge-method allowlist. Behavior-shifting drift on
-  // either step routes through the HITL confirm gate — non-TTY runs abort
-  // with a clear stderr message rather than silently apply.
+  // branch protection routes through the HITL confirm gate — non-TTY runs
+  // abort with a clear stderr message rather than silently apply. The
+  // merge-method step differs by design (Story #4045 A4): non-TTY without an
+  // assume override default-applies the framework stance with an explicit
+  // log line (see mergeMethodsHitlConfirm below).
   //
   // Post-reshape: bootstrap reads from the new `project` + `github` blocks
   // exclusively. The legacy "agent settings" opt was removed in Epic #2880.
@@ -384,10 +388,22 @@ export async function runBootstrap(config, opts = {}) {
     hitlConfirm,
     log,
   });
+
+  // Merge-methods gate (Story #4045 A4): under non-TTY without an explicit
+  // assume override there is no operator to consult, and the default HITL
+  // gate declines every non-TTY prompt — which would make applyMergeMethods'
+  // documented non-TTY default-apply branch unreachable. Skip the gate in
+  // that case so the merge-method stance default-applies with its explicit
+  // log line. Interactive runs (and explicit --assume-yes/--assume-no, and
+  // injected gates) keep the loud confirm/decline behaviour.
+  const stdoutIsTTY = opts.isTTY ?? Boolean(process.stdout.isTTY);
+  const mergeMethodsHitlConfirm =
+    opts.hitlConfirm ??
+    (stdoutIsTTY || opts.assumeYes || opts.assumeNo ? hitlConfirm : undefined);
   const mergeMethods = await applyMergeMethods({
     provider,
     settings,
-    hitlConfirm,
+    hitlConfirm: mergeMethodsHitlConfirm,
     log,
   });
 

--- a/.agents/scripts/lib/bootstrap/merge-methods.js
+++ b/.agents/scripts/lib/bootstrap/merge-methods.js
@@ -17,10 +17,13 @@
  * No drift (live settings already match the target): no-op, returns
  * `{ status: 'unchanged' }`.
  *
- * Drift (any field differs from the target stance): routes the proposed
- * payload through `hitlConfirm`. On approval, PATCH is issued. On
- * decline or non-TTY (the gate returns false), the module returns
- * `{ status: 'skipped', reason: 'hitl-declined' }` without writing.
+ * Drift (any field differs from the target stance): when a `hitlConfirm`
+ * gate is supplied, the proposed payload routes through it — on approval
+ * the PATCH is issued; on decline the module returns
+ * `{ status: 'skipped', reason: 'hitl-declined' }` without writing (a loud
+ * decline, never silent). When NO gate is supplied (non-TTY, no operator
+ * present — Story #4045 A4), the framework stance is default-applied with
+ * an explicit log line.
  */
 
 export const TARGET_MERGE_METHODS = Object.freeze({

--- a/.agents/scripts/lib/bootstrap/project-bootstrap.js
+++ b/.agents/scripts/lib/bootstrap/project-bootstrap.js
@@ -15,6 +15,7 @@ import { spawnSync as defaultSpawnSync } from 'node:child_process';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
+import { pathToFileURL } from 'node:url';
 import { detectPackageManager as detectPm } from '../detect-package-manager.js';
 import { LEDGER_RELATIVE_PATH } from './install-ledger.js';
 import { PHASE_GROUPS, previewMutationManifest } from './manifest.js';
@@ -346,7 +347,9 @@ export async function validateAgentrc(ctx) {
   if (!fsImpl.existsSync(schemaModule)) {
     return { ok: false, errors: ['config-settings-schema.js not found'] };
   }
-  const mod = await import(`file://${schemaModule.replace(/\\/g, '/')}`);
+  // pathToFileURL handles Windows drive letters and percent-encoding
+  // correctly (same fix as commit 2e3d210b in lib/transpile.js).
+  const mod = await import(pathToFileURL(schemaModule).href);
   const validate = mod.getAgentrcValidator();
   const data = readJsonIfExists(
     path.join(ctx.projectRoot, '.agentrc.json'),

--- a/.agents/workflows/plan.md
+++ b/.agents/workflows/plan.md
@@ -71,8 +71,10 @@ The preflight runs when **any** of these is true:
    configured `docsRoot`.
 2. One or more present `docsContextFiles` still carry the
    `<!-- MANDREL:STUB -->` marker (i.e. they are un-edited scaffolded stubs).
-3. The last `mandrel doctor` verdict cached in `.agents/doctor-result.json`
-   is non-ready (or the file is absent, implying the gate was never run).
+3. The last `mandrel doctor` verdict cached in `temp/doctor-result.json`
+   records `"verdict": "unready"`. An **absent** cache file is no signal —
+   doctor may simply never have run; only an explicit recorded unready
+   verdict fires this signal.
 
 ### Preflight procedure
 

--- a/.github/workflows/install-matrix.yml
+++ b/.github/workflows/install-matrix.yml
@@ -65,7 +65,7 @@ name: Install Matrix
 #      install time. Asserts .agents/ is materialized and doctor is ready
 #      WITHOUT a manual `mandrel sync` step.
 #   2. cold-start — exercises the Story #4045 `mandrel init` single-command
-#      path end-to-end: npm install → mandrel init --yes (non-interactive)
+#      path end-to-end: npm install → mandrel init --assume-yes (non-interactive)
 #      → doctor ready.
 #   3. materialized-script-run (pnpm) — installs with pnpm (isolated
 #      layout), mandrel sync, then runs a materialized .agents/scripts/*.js
@@ -386,20 +386,20 @@ jobs:
 
       # ── Leg: cold-start ───────────────────────────────────────────────────────
       # Exercises the Story #4045 single-command path end-to-end:
-      #   npm install --ignore-scripts → mandrel init --yes → doctor ready.
+      #   npm install --ignore-scripts → mandrel init --assume-yes → doctor ready.
       - name: "[cold-start] Install npm with --ignore-scripts"
         if: matrix.leg == 'cold-start'
         shell: bash
         working-directory: ${{ env.CONSUMER_DIR }}
         run: npm install --ignore-scripts "$TARBALL_PATH"
 
-      - name: "[cold-start] Run mandrel init --yes (cold-start bootstrap)"
+      - name: "[cold-start] Run mandrel init --assume-yes (cold-start bootstrap)"
         if: matrix.leg == 'cold-start'
         shell: bash
         working-directory: ${{ env.CONSUMER_DIR }}
-        # --yes accepts all prompts non-interactively, exercising the full
+        # --assume-yes accepts all prompts non-interactively, exercising the full
         # single-command bootstrap path introduced in Story #4045.
-        run: node "$MANDREL_BIN" init --yes
+        run: node "$MANDREL_BIN" init --assume-yes
 
       - name: "[cold-start] Assert materialization after mandrel init"
         if: matrix.leg == 'cold-start'
@@ -459,3 +459,18 @@ jobs:
             --consumer "$CONSUMER_DIR" \
             --check doctor-ready \
             --doctor-output "$RUNNER_TEMP/doctor-output.txt"
+
+      - name: "[script-run] Execute a materialized consumer script (pnpm free-ride guard)"
+        if: matrix.leg == 'materialized-script-run'
+        shell: bash
+        working-directory: ${{ env.CONSUMER_DIR }}
+        # Regression class: pnpm free-ride / dependency anchoring (Story #4046).
+        # The previous step runs the *packaged* doctor bin; this step executes
+        # a file genuinely materialized under $CONSUMER_DIR/.agents/scripts/
+        # with cwd=$CONSUMER_DIR. validate-skills.js imports third-party deps
+        # (ajv, ajv-formats) at module top, so even its read-only `--help` run
+        # (exits 0) proves materialized scripts resolve runtime deps through
+        # the package-root anchoring rather than free-riding on the consumer's
+        # node_modules layout — under pnpm's isolated layout a free-ride
+        # regression dies here with ERR_MODULE_NOT_FOUND.
+        run: node ./.agents/scripts/validate-skills.js --help

--- a/bin/mandrel.js
+++ b/bin/mandrel.js
@@ -50,7 +50,7 @@ const SUBCOMMANDS = new Map([
     'sync',
     {
       description: 'materialize .agents/ payload from installed package',
-      knownFlags: new Set(['--dry-run', '--force']),
+      knownFlags: new Set(['--dry-run']),
     },
   ],
   [

--- a/lib/cli/__tests__/sync-prune.test.js
+++ b/lib/cli/__tests__/sync-prune.test.js
@@ -272,6 +272,67 @@ describe('runSync — .agents/local/ consumer additions are never pruned (A3)', 
 });
 
 // ---------------------------------------------------------------------------
+// Local-override files (*.local.*) are never pruned (instructions.md § 1.E)
+// ---------------------------------------------------------------------------
+
+describe('runSync — *.local.* consumer overrides are never pruned', () => {
+  it('does not delete .agents/instructions.local.md', () => {
+    const localOverride = path.join(DEST_AGENTS, 'instructions.local.md');
+    const fs = makeFs({
+      ...seedPayload(),
+      [localOverride]: '# my overrides\n',
+    });
+    const cap = makeCapture();
+
+    const result = runSync({
+      argv: [],
+      resolvePackageRoot: resolveToPkg,
+      fs,
+      cwd: () => PROJECT,
+      write: cap.write,
+      writeErr: cap.writeErr,
+      exit: cap.exit,
+    });
+
+    assert.equal(
+      fs.files.get(localOverride),
+      '# my overrides\n',
+      'instructions.local.md must survive sync',
+    );
+    assert.equal(result.pruned, 0);
+  });
+
+  it('does not delete a nested *.local.* file but still prunes a stale sibling', () => {
+    const nestedLocal = path.join(DEST_AGENTS, 'rules', 'foo.local.json');
+    const staleFile = path.join(DEST_AGENTS, 'rules', 'stale.md');
+    const fs = makeFs({
+      ...seedPayload(),
+      [nestedLocal]: '{"mine":true}\n',
+      [staleFile]: '# stale\n',
+    });
+    const cap = makeCapture();
+
+    const result = runSync({
+      argv: [],
+      resolvePackageRoot: resolveToPkg,
+      fs,
+      cwd: () => PROJECT,
+      write: cap.write,
+      writeErr: cap.writeErr,
+      exit: cap.exit,
+    });
+
+    assert.equal(
+      fs.files.get(nestedLocal),
+      '{"mine":true}\n',
+      'nested *.local.* file must survive sync',
+    );
+    assert.equal(fs.files.has(staleFile), false, 'stale sibling still pruned');
+    assert.equal(result.pruned, 1);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // AC4 — --dry-run reports stale files, deletes nothing
 // ---------------------------------------------------------------------------
 

--- a/lib/cli/doctor.js
+++ b/lib/cli/doctor.js
@@ -17,10 +17,14 @@
  * Exit code 0 = all pass, 1 = any fail.
  *
  * Injectable seams (used by tests):
- *   - `checks`  — replaces the default registry array
- *   - `write`   — replaces process.stdout.write
- *   - `exit`    — replaces process.exit
+ *   - `checks`           — replaces the default registry array
+ *   - `write`            — replaces process.stdout.write
+ *   - `exit`             — replaces process.exit
+ *   - `writeResultCache` — replaces the temp/doctor-result.json writer
  */
+
+import nodeFs from 'node:fs';
+import path from 'node:path';
 
 import { registry } from './registry.js';
 
@@ -75,6 +79,40 @@ function formatSummary(passed, total) {
 }
 
 // ---------------------------------------------------------------------------
+// Result cache
+// ---------------------------------------------------------------------------
+
+/**
+ * Best-effort write of the doctor verdict to `temp/doctor-result.json` under
+ * the consumer root so downstream workflows (e.g. the `/plan` first-run
+ * preflight) can read the last recorded verdict without re-running doctor.
+ * `temp/` is the gitignored scratch root, so neither git nor the sync prune
+ * pass ever sees the cache. Any write failure is swallowed — the cache is
+ * advisory, never a gate.
+ *
+ * Exported for testing.
+ *
+ * @param {'ready'|'unready'} verdict
+ * @param {{ fs?: typeof nodeFs, cwd?: () => string }} [opts]
+ * @returns {void}
+ */
+export function writeDoctorResultCache(
+  verdict,
+  { fs = nodeFs, cwd = process.cwd } = {},
+) {
+  try {
+    const dir = path.join(cwd(), 'temp');
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(
+      path.join(dir, 'doctor-result.json'),
+      `${JSON.stringify({ verdict, checkedAt: new Date().toISOString() }, null, 2)}\n`,
+    );
+  } catch {
+    // Best-effort only — an unwritable temp/ must never fail the doctor run.
+  }
+}
+
+// ---------------------------------------------------------------------------
 // Doctor runner (exported for testing)
 // ---------------------------------------------------------------------------
 
@@ -85,6 +123,7 @@ function formatSummary(passed, total) {
  *   checks?: Array<{ name: string, run(opts?: unknown): { ok: boolean, detail: string, remedy?: string } }>,
  *   write?: (s: string) => void,
  *   exit?: (code: number) => void,
+ *   writeResultCache?: (verdict: 'ready'|'unready') => void,
  * }} [opts]
  * @returns {void}
  */
@@ -92,6 +131,7 @@ export async function runDoctor({
   checks = registry,
   write = (s) => process.stdout.write(s),
   exit = (code) => process.exit(code),
+  writeResultCache = writeDoctorResultCache,
 } = {}) {
   let passed = 0;
 
@@ -103,6 +143,8 @@ export async function runDoctor({
 
   const total = checks.length;
   write(formatSummary(passed, total));
+
+  writeResultCache(passed === total ? 'ready' : 'unready');
 
   if (passed < total) {
     exit(1);

--- a/lib/cli/init.js
+++ b/lib/cli/init.js
@@ -66,6 +66,7 @@
 import { spawnSync } from 'node:child_process';
 import fs from 'node:fs';
 import path from 'node:path';
+import { pathToFileURL } from 'node:url';
 
 // Lazily resolved at runtime so cold-start `npx mandrel init` (where
 // `.agents/` is absent) does not try to import from a directory that does not
@@ -82,7 +83,10 @@ async function getRunInitTail(projectRoot) {
     'onboard',
     'init-tail.js',
   );
-  const mod = await import(`file://${tailPath}`);
+  // pathToFileURL handles Windows drive letters correctly (a raw
+  // `file://C:\…` template treats the drive letter as a URL host — same
+  // fix as commit 2e3d210b in lib/transpile.js).
+  const mod = await import(pathToFileURL(tailPath).href);
   _runInitTail = mod.runInitTail;
   return _runInitTail;
 }
@@ -174,7 +178,7 @@ function buildBootstrapArgs(argv, assumeYes) {
  *   confirm?: () => boolean,
  *   stdout?: (s: string) => void,
  *   isTTY?: boolean,
- *   afterBootstrap?: (root: string) => Promise<void> | void,
+ *   afterBootstrap?: (root: string) => Promise<{ ok?: boolean } | void> | { ok?: boolean } | void,
  * }} [opts]
  * @returns {Promise<{
  *   installed: boolean,
@@ -275,9 +279,20 @@ export async function planInit({
     }
 
     // Bootstrap succeeded — run the onboarding tail: stack detection, docs
-    // scaffolding offer, doctor gate, and /plan handoff.
+    // scaffolding offer, doctor gate, and /plan handoff. A tail that reports
+    // `ok: false` (the doctor gate failed) makes the whole init exit
+    // non-zero; the tail already printed its own remediation message, and the
+    // earlier install/sync/bootstrap phases' results stand as completed.
     if (afterBootstrap) {
-      await afterBootstrap(process.cwd());
+      const tail = await afterBootstrap(process.cwd());
+      if (tail && tail.ok === false) {
+        return {
+          installed,
+          ranBootstrap: true,
+          steps,
+          exitCode: 1,
+        };
+      }
     }
 
     return {
@@ -369,7 +384,10 @@ export default async function run(argv = []) {
     isTTY: Boolean(process.stdin.isTTY),
     afterBootstrap: async (projectRoot) => {
       const runInitTail = await getRunInitTail(projectRoot);
-      runInitTail({ root: projectRoot, isTTY: Boolean(process.stdin.isTTY) });
+      return runInitTail({
+        root: projectRoot,
+        isTTY: Boolean(process.stdin.isTTY),
+      });
     },
   });
 

--- a/lib/cli/registry.js
+++ b/lib/cli/registry.js
@@ -29,6 +29,7 @@ import { fileURLToPath } from 'node:url';
 import {
   REQUIRED_NODE_CEILING_MAJOR,
   REQUIRED_NODE_FLOOR,
+  satisfiesNodeEngine,
 } from '../../.agents/scripts/lib/bootstrap/project-bootstrap.js';
 import {
   defaultResolvePackageRoot,
@@ -61,25 +62,6 @@ function spawn(cmd, args) {
 // ---------------------------------------------------------------------------
 // check: node-version
 // ---------------------------------------------------------------------------
-
-/**
- * Return true when `version` satisfies `>=22.22.1 <25`.
- *
- * @param {string} version
- * @returns {boolean}
- */
-function satisfiesNodeEngine(version) {
-  const [majorRaw, minorRaw, patchRaw] = String(version).split('.');
-  const major = Number.parseInt(majorRaw, 10) || 0;
-  const minor = Number.parseInt(minorRaw, 10) || 0;
-  const patch = Number.parseInt(patchRaw, 10) || 0;
-  if (major >= REQUIRED_NODE_CEILING_MAJOR) return false;
-  if (major > 22) return true;
-  if (major < 22) return false;
-  if (minor > 22) return true;
-  if (minor < 22) return false;
-  return patch >= 1;
-}
 
 /**
  * @param {{ nodeVersion?: string }} [opts]

--- a/lib/cli/sync.js
+++ b/lib/cli/sync.js
@@ -62,6 +62,15 @@ export const PACKAGE_NAME = 'mandrel';
 export const LOCAL_ZONE_DIR = 'local';
 
 /**
+ * Basename pattern for consumer local-override files (`*.local.<ext>`,
+ * e.g. `instructions.local.md`, `foo.local.json`). Matches the gitignore
+ * convention (`.agents/*.local.md`, `.agentrc.local.json`) and the override
+ * mechanism documented in `.agents/instructions.md` § 1.E. These files never
+ * ship in the payload and are exempt from the sync prune pass.
+ */
+export const LOCAL_OVERRIDE_RE = /\.local\.[^.]+$/;
+
+/**
  * Default resolver: locate the installed `mandrel` package root by
  * resolving its `package.json` and returning the directory that contains it.
  *
@@ -119,7 +128,10 @@ export function listFiles(dir, fsImpl, prefix = '') {
  * Recursively enumerate every regular file under `dir`, returning paths
  * relative to `dir` using OS separators. The top-level `local/` subtree is
  * skipped so consumer additions inside `.agents/local/` are never pruned
- * (Story #3498).
+ * (Story #3498). Files following the `*.local.*` naming convention (e.g.
+ * `.agents/instructions.local.md` — the documented consumer override
+ * mechanism, instructions.md § 1.E) are also skipped: they never ship in
+ * the payload and must survive every sync.
  *
  * Mirrors `listFiles` but operates on the destination tree so we can
  * identify stale files that have no payload counterpart (Story #4046 A3).
@@ -141,6 +153,12 @@ function listDestFiles(dir, fsImpl, prefix = '') {
   for (const ent of entries) {
     // The local-additions zone is never pruned; skip it at the top level.
     if (prefix === '' && ent.name === LOCAL_ZONE_DIR && ent.isDirectory()) {
+      continue;
+    }
+    // Consumer local-override files (`*.local.*`, e.g. instructions.local.md,
+    // foo.local.json) are gitignored, never shipped in the payload, and a
+    // documented override mechanism (instructions.md § 1.E) — never prune.
+    if (!ent.isDirectory() && LOCAL_OVERRIDE_RE.test(ent.name)) {
       continue;
     }
     const rel = prefix ? path.join(prefix, ent.name) : ent.name;

--- a/tests/bootstrap/agents-bootstrap-github.integration.test.js
+++ b/tests/bootstrap/agents-bootstrap-github.integration.test.js
@@ -198,6 +198,42 @@ describe('agents-bootstrap-github — end-to-end integration', () => {
   it('(d) drifted with --assume-yes → every step applies', async () => {
     /* placeholder */
   });
+
+  it('(e) drifted, non-TTY, no assume flags → merge methods default-apply; branch protection declines loudly', async () => {
+    // Story #4045 A4: with no operator present (non-TTY) and no explicit
+    // assume override, the merge-method step must reach applyMergeMethods'
+    // default-apply branch — not be silently declined by the non-TTY HITL
+    // gate. Branch protection keeps the abort-on-non-TTY stance.
+    const provider = makeMockProvider({
+      protection: {
+        required_status_checks: {
+          strict: true,
+          contexts: ['lint'],
+        },
+        enforce_admins: { enabled: false }, // diverges
+        required_pull_request_reviews: {
+          required_approving_review_count: 2, // diverges
+        },
+        restrictions: null,
+      },
+      mergeState: { ...TARGET_MERGE_METHODS, allow_merge_commit: true },
+    });
+
+    const result = await runBootstrap(ORCHESTRATION, {
+      providerOverride: provider,
+      project: PROJECT_BLOCK,
+      githubAdminApproved: true,
+      isTTY: false,
+      quiet: true,
+    });
+
+    assert.equal(result.mergeMethods.status, 'patched');
+    assert.equal(provider.calls.setMergeMethods.length, 1);
+    // Branch protection still declines loudly under non-TTY.
+    assert.equal(result.branchProtection.status, 'skipped');
+    assert.equal(result.branchProtection.reason, 'hitl-declined');
+    assert.equal(provider.calls.setBranchProtection.length, 0);
+  });
 });
 
 describe('agents-bootstrap-github — CI workflow template (Story #1401)', () => {

--- a/tests/cli/doctor.test.js
+++ b/tests/cli/doctor.test.js
@@ -17,7 +17,10 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 
-import doctor, { runDoctor } from '../../lib/cli/doctor.js';
+import doctor, {
+  runDoctor,
+  writeDoctorResultCache,
+} from '../../lib/cli/doctor.js';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -89,13 +92,23 @@ describe('runDoctor — all checks pass', () => {
 
   it('does not call exit when all checks pass', async () => {
     const cap = makeCapture();
-    await runDoctor({ checks, write: cap.write, exit: cap.exit });
+    await runDoctor({
+      checks,
+      write: cap.write,
+      exit: cap.exit,
+      writeResultCache: () => {},
+    });
     assert.equal(cap.exitCode, null);
   });
 
   it('emits a ✔ line for each passing check', async () => {
     const cap = makeCapture();
-    await runDoctor({ checks, write: cap.write, exit: cap.exit });
+    await runDoctor({
+      checks,
+      write: cap.write,
+      exit: cap.exit,
+      writeResultCache: () => {},
+    });
     const joined = cap.lines.join('');
     assert.match(joined, /✔/);
     for (const check of checks) {
@@ -105,21 +118,36 @@ describe('runDoctor — all checks pass', () => {
 
   it('does not emit any ✘ lines', async () => {
     const cap = makeCapture();
-    await runDoctor({ checks, write: cap.write, exit: cap.exit });
+    await runDoctor({
+      checks,
+      write: cap.write,
+      exit: cap.exit,
+      writeResultCache: () => {},
+    });
     const joined = cap.lines.join('');
     assert.doesNotMatch(joined, /✘/);
   });
 
   it('emits the ✅ Ready summary line', async () => {
     const cap = makeCapture();
-    await runDoctor({ checks, write: cap.write, exit: cap.exit });
+    await runDoctor({
+      checks,
+      write: cap.write,
+      exit: cap.exit,
+      writeResultCache: () => {},
+    });
     const joined = cap.lines.join('');
     assert.match(joined, /✅\s+Ready \(7\/7 checks passed\)/);
   });
 
   it('includes the detail string in each ✔ line', async () => {
     const cap = makeCapture();
-    await runDoctor({ checks, write: cap.write, exit: cap.exit });
+    await runDoctor({
+      checks,
+      write: cap.write,
+      exit: cap.exit,
+      writeResultCache: () => {},
+    });
     const joined = cap.lines.join('');
     assert.match(joined, /v22\.22\.1/);
     assert.match(joined, /git version 2\.49\.0/);
@@ -150,13 +178,23 @@ describe('runDoctor — github-token fails', () => {
 
   it('calls exit(1) when github-token fails', async () => {
     const cap = makeCapture();
-    await runDoctor({ checks, write: cap.write, exit: cap.exit });
+    await runDoctor({
+      checks,
+      write: cap.write,
+      exit: cap.exit,
+      writeResultCache: () => {},
+    });
     assert.equal(cap.exitCode, 1);
   });
 
   it('emits a ✘ line for github-token', async () => {
     const cap = makeCapture();
-    await runDoctor({ checks, write: cap.write, exit: cap.exit });
+    await runDoctor({
+      checks,
+      write: cap.write,
+      exit: cap.exit,
+      writeResultCache: () => {},
+    });
     const joined = cap.lines.join('');
     assert.match(joined, /✘/);
     assert.match(joined, /github-token/);
@@ -165,14 +203,24 @@ describe('runDoctor — github-token fails', () => {
 
   it('emits the remedy line for github-token', async () => {
     const cap = makeCapture();
-    await runDoctor({ checks, write: cap.write, exit: cap.exit });
+    await runDoctor({
+      checks,
+      write: cap.write,
+      exit: cap.exit,
+      writeResultCache: () => {},
+    });
     const joined = cap.lines.join('');
     assert.match(joined, /→.*GITHUB_TOKEN/);
   });
 
   it('emits the ❌ Not ready summary line with correct counts', async () => {
     const cap = makeCapture();
-    await runDoctor({ checks, write: cap.write, exit: cap.exit });
+    await runDoctor({
+      checks,
+      write: cap.write,
+      exit: cap.exit,
+      writeResultCache: () => {},
+    });
     const joined = cap.lines.join('');
     assert.match(joined, /❌\s+Not ready \(1\/7 checks failed\)/);
   });
@@ -204,13 +252,23 @@ describe('runDoctor — gh-available fails', () => {
 
   it('calls exit(1) when gh-available fails', async () => {
     const cap = makeCapture();
-    await runDoctor({ checks, write: cap.write, exit: cap.exit });
+    await runDoctor({
+      checks,
+      write: cap.write,
+      exit: cap.exit,
+      writeResultCache: () => {},
+    });
     assert.equal(cap.exitCode, 1);
   });
 
   it('emits a ✘ line for gh-available with detail', async () => {
     const cap = makeCapture();
-    await runDoctor({ checks, write: cap.write, exit: cap.exit });
+    await runDoctor({
+      checks,
+      write: cap.write,
+      exit: cap.exit,
+      writeResultCache: () => {},
+    });
     const joined = cap.lines.join('');
     assert.match(joined, /✘/);
     assert.match(joined, /gh-available/);
@@ -219,14 +277,24 @@ describe('runDoctor — gh-available fails', () => {
 
   it('emits the remedy line for gh-available', async () => {
     const cap = makeCapture();
-    await runDoctor({ checks, write: cap.write, exit: cap.exit });
+    await runDoctor({
+      checks,
+      write: cap.write,
+      exit: cap.exit,
+      writeResultCache: () => {},
+    });
     const joined = cap.lines.join('');
     assert.match(joined, /→.*cli\.github\.com/);
   });
 
   it('emits the ❌ Not ready summary with 1/7 failed', async () => {
     const cap = makeCapture();
-    await runDoctor({ checks, write: cap.write, exit: cap.exit });
+    await runDoctor({
+      checks,
+      write: cap.write,
+      exit: cap.exit,
+      writeResultCache: () => {},
+    });
     const joined = cap.lines.join('');
     assert.match(joined, /❌\s+Not ready \(1\/7 checks failed\)/);
   });
@@ -253,20 +321,35 @@ describe('runDoctor — multiple checks fail', () => {
 
   it('calls exit(1)', async () => {
     const cap = makeCapture();
-    await runDoctor({ checks, write: cap.write, exit: cap.exit });
+    await runDoctor({
+      checks,
+      write: cap.write,
+      exit: cap.exit,
+      writeResultCache: () => {},
+    });
     assert.equal(cap.exitCode, 1);
   });
 
   it('emits the ❌ Not ready summary with 2/3 failed', async () => {
     const cap = makeCapture();
-    await runDoctor({ checks, write: cap.write, exit: cap.exit });
+    await runDoctor({
+      checks,
+      write: cap.write,
+      exit: cap.exit,
+      writeResultCache: () => {},
+    });
     const joined = cap.lines.join('');
     assert.match(joined, /❌\s+Not ready \(2\/3 checks failed\)/);
   });
 
   it('emits remedy lines for each failed check', async () => {
     const cap = makeCapture();
-    await runDoctor({ checks, write: cap.write, exit: cap.exit });
+    await runDoctor({
+      checks,
+      write: cap.write,
+      exit: cap.exit,
+      writeResultCache: () => {},
+    });
     const joined = cap.lines.join('');
     assert.match(joined, /→.*fix a/);
     assert.match(joined, /→.*fix c/);
@@ -284,13 +367,23 @@ describe('runDoctor — failed check with no remedy', () => {
 
   it('calls exit(1)', async () => {
     const cap = makeCapture();
-    await runDoctor({ checks, write: cap.write, exit: cap.exit });
+    await runDoctor({
+      checks,
+      write: cap.write,
+      exit: cap.exit,
+      writeResultCache: () => {},
+    });
     assert.equal(cap.exitCode, 1);
   });
 
   it('does not emit a → line when remedy is absent', async () => {
     const cap = makeCapture();
-    await runDoctor({ checks, write: cap.write, exit: cap.exit });
+    await runDoctor({
+      checks,
+      write: cap.write,
+      exit: cap.exit,
+      writeResultCache: () => {},
+    });
     const joined = cap.lines.join('');
     assert.doesNotMatch(joined, /→/);
   });
@@ -308,7 +401,12 @@ describe('runDoctor — summary N/N counts', () => {
       fakeCheck('c', { ok: false, detail: 'fail', remedy: 'r' }),
     ];
     const cap = makeCapture();
-    await runDoctor({ checks, write: cap.write, exit: cap.exit });
+    await runDoctor({
+      checks,
+      write: cap.write,
+      exit: cap.exit,
+      writeResultCache: () => {},
+    });
     assert.match(cap.lines.join(''), /❌\s+Not ready \(3\/3 checks failed\)/);
   });
 
@@ -319,7 +417,12 @@ describe('runDoctor — summary N/N counts', () => {
       fakeCheck('c', { ok: true, detail: 'ok' }),
     ];
     const cap = makeCapture();
-    await runDoctor({ checks, write: cap.write, exit: cap.exit });
+    await runDoctor({
+      checks,
+      write: cap.write,
+      exit: cap.exit,
+      writeResultCache: () => {},
+    });
     assert.match(cap.lines.join(''), /✅\s+Ready \(3\/3 checks passed\)/);
   });
 
@@ -330,7 +433,101 @@ describe('runDoctor — summary N/N counts', () => {
       fakeCheck('c', { ok: true, detail: 'ok' }),
     ];
     const cap = makeCapture();
-    await runDoctor({ checks, write: cap.write, exit: cap.exit });
+    await runDoctor({
+      checks,
+      write: cap.write,
+      exit: cap.exit,
+      writeResultCache: () => {},
+    });
     assert.match(cap.lines.join(''), /❌\s+Not ready \(1\/3 checks failed\)/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Result cache (temp/doctor-result.json)
+// ---------------------------------------------------------------------------
+
+describe('runDoctor — result cache verdict', () => {
+  it('records "ready" when all checks pass', async () => {
+    const checks = [fakeCheck('a', { ok: true, detail: 'ok' })];
+    const cap = makeCapture();
+    let recorded = null;
+    await runDoctor({
+      checks,
+      write: cap.write,
+      exit: cap.exit,
+      writeResultCache: (verdict) => {
+        recorded = verdict;
+      },
+    });
+    assert.equal(recorded, 'ready');
+  });
+
+  it('records "unready" when any check fails', async () => {
+    const checks = [
+      fakeCheck('a', { ok: true, detail: 'ok' }),
+      fakeCheck('b', { ok: false, detail: 'fail', remedy: 'r' }),
+    ];
+    const cap = makeCapture();
+    let recorded = null;
+    await runDoctor({
+      checks,
+      write: cap.write,
+      exit: cap.exit,
+      writeResultCache: (verdict) => {
+        recorded = verdict;
+      },
+    });
+    assert.equal(recorded, 'unready');
+  });
+});
+
+describe('writeDoctorResultCache', () => {
+  /** In-memory fs fake covering mkdirSync + writeFileSync. */
+  function makeFakeFs() {
+    const writes = new Map();
+    const dirs = [];
+    return {
+      writes,
+      dirs,
+      mkdirSync(dir, opts) {
+        dirs.push({ dir, opts });
+      },
+      writeFileSync(p, content) {
+        writes.set(p, content);
+      },
+    };
+  }
+
+  it('writes { verdict, checkedAt } to <cwd>/temp/doctor-result.json', () => {
+    const fakeFs = makeFakeFs();
+    writeDoctorResultCache('ready', { fs: fakeFs, cwd: () => '/proj' });
+
+    const [dir] = fakeFs.dirs;
+    assert.ok(dir.dir.endsWith('temp'), 'creates the temp/ scratch dir');
+    assert.deepEqual(dir.opts, { recursive: true });
+
+    const [[file, content]] = [...fakeFs.writes.entries()];
+    assert.ok(file.endsWith('doctor-result.json'));
+    const parsed = JSON.parse(content);
+    assert.equal(parsed.verdict, 'ready');
+    assert.ok(
+      !Number.isNaN(Date.parse(parsed.checkedAt)),
+      'checkedAt is a parseable ISO timestamp',
+    );
+  });
+
+  it('swallows write failures (best-effort, never throws)', () => {
+    const throwingFs = {
+      mkdirSync() {
+        throw new Error('EACCES');
+      },
+      writeFileSync() {
+        throw new Error('EACCES');
+      },
+    };
+    assert.doesNotThrow(() =>
+      writeDoctorResultCache('unready', { fs: throwingFs, cwd: () => '/x' }),
+    );
   });
 });

--- a/tests/cli/init.test.js
+++ b/tests/cli/init.test.js
@@ -489,6 +489,47 @@ describe('init — afterBootstrap seam called after successful bootstrap', () =>
       'afterBootstrap must not run on the files-only path',
     );
   });
+
+  it('exits 1 when the init tail reports ok: false (doctor gate failed)', async () => {
+    const { runStep } = makeRunStep({ statuses: [0] }); // bootstrap exits 0
+    const { confirm } = makeConfirm(true);
+    const { write } = makeStdout();
+
+    const result = await planInit({
+      argv: [],
+      exists: () => true,
+      runStep,
+      confirm,
+      stdout: write,
+      isTTY: true,
+      afterBootstrap: async () => ({ ok: false }),
+    });
+
+    assert.equal(result.ranBootstrap, true);
+    assert.equal(
+      result.exitCode,
+      1,
+      'a failed init tail must propagate a non-zero exit code',
+    );
+  });
+
+  it('exits 0 when the init tail reports ok: true', async () => {
+    const { runStep } = makeRunStep({ statuses: [0] });
+    const { confirm } = makeConfirm(true);
+    const { write } = makeStdout();
+
+    const result = await planInit({
+      argv: [],
+      exists: () => true,
+      runStep,
+      confirm,
+      stdout: write,
+      isTTY: true,
+      afterBootstrap: async () => ({ ok: true }),
+    });
+
+    assert.equal(result.exitCode, 0);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/tests/cli/mandrel.test.js
+++ b/tests/cli/mandrel.test.js
@@ -149,6 +149,13 @@ describe('mandrel CLI — unknown-flag rejection', () => {
     assert.match(stderr, /unknown flag/);
   });
 
+  it('rejects "--force" for "sync" (no longer a known flag — sync never read it)', () => {
+    const { status, stderr } = runMandrel(['sync', '--force']);
+    assert.equal(status, 1);
+    assert.match(stderr, /unknown flag/);
+    assert.match(stderr, /--force/);
+  });
+
   it('rejects unknown flags for "doctor" and exits 1', () => {
     const { status, stderr } = runMandrel(['doctor', '--verbose']);
     assert.equal(status, 1);


### PR DESCRIPTION
## Why

A quick post-merge code review of the #4045–#4049 install & bootstrap batch (range `01a68497..f5abcd55`) surfaced 9 verified findings — 3 high, 4 medium, 2 low. This PR closes all of them.

## What

| # | Severity | Fix |
|---|----------|-----|
| 1 | 🔴 High | **sync prune no longer deletes consumer local overrides** — `*.local.*` files (`.agents/instructions.local.md`, `.agentrc.local.json` convention per § 1.E) are exempt from the prune pass; previously every `mandrel sync` deleted them |
| 2 | 🔴 High | **`/plan` first-run preflight no longer fires forever** — `mandrel doctor` now writes a best-effort verdict cache to `temp/doctor-result.json`, and the preflight treats an absent cache as *no signal* (the file it read before was never written by anything) |
| 3 | 🔴 High | **cold-start Install Matrix leg un-broken** — `mandrel init --yes` → `--assume-yes` (the dispatcher's flag rejection made the nightly leg exit 1 on every run) |
| 4 | 🟠 Med-High | **Windows `mandrel init` fixed** — remaining raw `file://` dynamic imports in `lib/cli/init.js` + `project-bootstrap.js` → `pathToFileURL` (same class as 2e3d210b) |
| 5 | 🟡 Medium | `mandrel init` exits 1 when the doctor readiness gate fails (result was printed but discarded; exit was always 0) |
| 6 | 🟡 Medium | the materialized-script-run CI leg now actually executes a materialized `.agents/scripts` file from the consumer root, guarding the pnpm free-ride/anchoring regression class |
| 7 | 🟡 Medium | merge-methods **non-TTY default-applies with an explicit log line** (operator decision per the original A4 acceptance — the default-apply branch was unreachable in production); contradictory module header fixed |
| 8 | 🟢 Low | `sync --force` removed from the dispatcher's known flags (was a silent no-op) |
| 9 | 🟢 Low | `registry.js` imports `satisfiesNodeEngine` instead of re-implementing the node floor with hardcoded values |

## Verification

- `npm run verify` green (full suite + baselines), `npm run test:quick` 8,581 pass / 0 fail
- `npx biome ci` clean on all 13 touched JS files; markdownlint clean on touched docs
- New/extended tests for every behavior change: prune exemptions, doctor cache write + absent-cache semantics, init exit codes, non-TTY merge-methods apply, dispatcher flag rejection

🤖 Generated with [Claude Code](https://claude.com/claude-code)