### PR TITLE
fix: `mandrel update` no-op short-circuit leaves a stale `.agents/` unhealed (gates on installed version, not materialized drift) (#4065)

### DIFF
--- a/lib/cli/__tests__/update-drift.test.js
+++ b/lib/cli/__tests__/update-drift.test.js
@@ -1,0 +1,360 @@
+// lib/cli/__tests__/update-drift.test.js
+/**
+ * Unit tests for Story #4065: drift-aware no-op short-circuit in
+ * lib/cli/update.js.
+ *
+ * The no-op short-circuit previously gated only on the installed package
+ * version. When `installedVersion === newestPublished` it returned immediately,
+ * leaving a drifted `.agents/` unhealed. This file verifies the new behaviour:
+ *
+ *   1. Version current + drift detected  → runUpdate invokes sync phase(s) and
+ *      returns `action: 'resynced'` (or `action: 'dry-run'` under --dry-run).
+ *   2. Version current + no drift        → runUpdate still returns
+ *      `action: 'up-to-date'` with `stepsRun: []` (true no-op preserved).
+ *   3. --dry-run + drift                 → reports that a heal will run;
+ *      emits no "Already up to date" message; writes nothing.
+ *
+ * Tier: unit (testing-standards § Unit). All seams including `checkDrift` are
+ * injected; no real filesystem, package, or network call occurs.
+ *
+ * Security (security-baseline § 5): fixtures contain only version strings and
+ * boolean drift signals; no credentials, tokens, or env values.
+ */
+
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import { runUpdate } from '../update.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Capture stdout/stderr writes and exit code. */
+function makeCapture() {
+  const out = [];
+  const err = [];
+  let exitCode = null;
+  return {
+    out,
+    err,
+    get exitCode() {
+      return exitCode;
+    },
+    write: (s) => out.push(s),
+    writeErr: (s) => err.push(s),
+    exit: (code) => {
+      exitCode = code;
+    },
+  };
+}
+
+/**
+ * Minimal seam set for a "version already current" scenario. The injected
+ * `checkDrift` toggle lets us probe both the drifted and non-drifted branches
+ * without touching the real filesystem.
+ *
+ * @param {{ drifted?: boolean }} [opts]
+ */
+function makeUpToDateSeams({ drifted = false } = {}) {
+  const calls = [];
+  return {
+    calls,
+    currentVersion: '1.61.0',
+    resolveTargetVersion: async () => {
+      calls.push('resolveTargetVersion');
+      return '1.61.0'; // same as current — no-op path
+    },
+    checkDrift: async () => {
+      calls.push(`checkDrift:${drifted}`);
+      return drifted;
+    },
+    // npmUpdate, runSync, etc. must NOT be called on the up-to-date/resync path —
+    // inject them as call-recording stubs so we can assert they were never invoked.
+    npmUpdate: async (v) => {
+      calls.push(`npmUpdate:${v}`);
+    },
+    runSync: (_opts) => {
+      calls.push('runSync');
+      return {};
+    },
+    runMigrations: ({ fromVersion, toVersion }) => {
+      calls.push(`runMigrations:${fromVersion}->${toVersion}`);
+      return {};
+    },
+    runDoctor: async () => {
+      calls.push('runDoctor');
+      return { ok: true, results: [] };
+    },
+    surfaceChangelog: async (v) => {
+      calls.push(`surfaceChangelog:${v}`);
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// AC: version current + drift → sync phases run, action: 'resynced'
+// ---------------------------------------------------------------------------
+
+describe('runUpdate — drift-aware no-op (Story #4065)', () => {
+  it('invokes the sync phase(s) and returns resynced when version is current but drift detected (in-process path)', async () => {
+    const seams = makeUpToDateSeams({ drifted: true });
+    const cap = makeCapture();
+
+    const result = await runUpdate({
+      argv: [],
+      ...seams,
+      write: cap.write,
+      writeErr: cap.writeErr,
+      exit: cap.exit,
+    });
+
+    // checkDrift must have been called.
+    assert.ok(
+      seams.calls.includes('checkDrift:true'),
+      'checkDrift should be called on the up-to-date path',
+    );
+
+    // npm-update and migrations must NOT run — version is already current.
+    assert.ok(
+      !seams.calls.some((c) => String(c).startsWith('npmUpdate:')),
+      'npmUpdate must NOT be called when version is already current',
+    );
+    assert.ok(
+      !seams.calls.some((c) => String(c).startsWith('runMigrations:')),
+      'runMigrations must NOT be called when version is already current',
+    );
+    assert.ok(
+      !seams.calls.includes('runDoctor'),
+      'runDoctor must NOT be called on the resync path (in-process)',
+    );
+
+    // runSync must have been called (in-process path; no spawnPhase injected).
+    assert.ok(
+      seams.calls.includes('runSync'),
+      'runSync should be called to heal the drift',
+    );
+
+    assert.equal(result.ok, true);
+    assert.equal(result.action, 'resynced');
+    assert.deepEqual(result.stepsRun, ['runSync']);
+    assert.equal(cap.exitCode, null);
+
+    // Output should mention drift healing, not "Already up to date".
+    const stdout = cap.out.join('');
+    assert.ok(
+      !stdout.includes('Already up to date'),
+      'should NOT print "Already up to date" when drift is detected',
+    );
+    assert.match(stdout, /[Hh]eal/);
+  });
+
+  it('returns up-to-date when version is current AND no drift (true no-op preserved)', async () => {
+    const seams = makeUpToDateSeams({ drifted: false });
+    const cap = makeCapture();
+
+    const result = await runUpdate({
+      argv: [],
+      ...seams,
+      write: cap.write,
+      writeErr: cap.writeErr,
+      exit: cap.exit,
+    });
+
+    assert.equal(result.ok, true);
+    assert.equal(result.action, 'up-to-date');
+    assert.deepEqual(result.stepsRun, []);
+    assert.equal(cap.exitCode, null);
+
+    // The "Already up to date" message must still appear for the true no-op.
+    assert.match(cap.out.join(''), /Already up to date/);
+
+    // npmUpdate, runSync, runMigrations, runDoctor must NOT be called.
+    assert.ok(
+      !seams.calls.some((c) => String(c).startsWith('npmUpdate:')),
+      'npmUpdate must not be called',
+    );
+    assert.ok(!seams.calls.includes('runSync'), 'runSync must not be called');
+    assert.ok(
+      !seams.calls.some((c) => String(c).startsWith('runMigrations:')),
+      'runMigrations must not be called',
+    );
+    assert.ok(
+      !seams.calls.includes('runDoctor'),
+      'runDoctor must not be called',
+    );
+  });
+
+  it('invokes spawnPhase for sync + sync-commands on the re-exec drift-heal path', async () => {
+    const spawnCalls = [];
+    const cap = makeCapture();
+
+    const result = await runUpdate({
+      argv: [],
+      currentVersion: '1.61.0',
+      resolveTargetVersion: async () => '1.61.0',
+      checkDrift: async () => true, // drift present
+      npmUpdate: async () => {},
+      spawnPhase: async (phase, args, opts) => {
+        spawnCalls.push({ phase, args, cwd: opts.cwd });
+        return { ok: true, stdout: '', stderr: '' };
+      },
+      surfaceChangelog: async () => {},
+      write: cap.write,
+      writeErr: cap.writeErr,
+      exit: cap.exit,
+      cwd: () => '/fake/consumer',
+    });
+
+    // Exactly sync + sync-commands, no migrate, no doctor on the heal path.
+    const phaseNames = spawnCalls.map((c) => c.phase);
+    assert.deepEqual(phaseNames, ['sync', 'sync-commands']);
+
+    assert.equal(result.ok, true);
+    assert.equal(result.action, 'resynced');
+    assert.deepEqual(result.stepsRun, ['runSync', 'sync-commands']);
+    assert.equal(cap.exitCode, null);
+  });
+
+  it('throws when spawnPhase sync exits non-zero on the drift-heal path', async () => {
+    const cap = makeCapture();
+
+    await assert.rejects(
+      () =>
+        runUpdate({
+          argv: [],
+          currentVersion: '1.61.0',
+          resolveTargetVersion: async () => '1.61.0',
+          checkDrift: async () => true,
+          npmUpdate: async () => {},
+          spawnPhase: async (phase) => {
+            if (phase === 'sync')
+              return { ok: false, stdout: '', stderr: 'boom' };
+            return { ok: true, stdout: '', stderr: '' };
+          },
+          write: cap.write,
+          writeErr: cap.writeErr,
+          exit: cap.exit,
+          cwd: () => '/fake/consumer',
+        }),
+      /mandrel sync.*installed binary exited non-zero/,
+    );
+  });
+
+  it('throws when spawnPhase sync-commands exits non-zero on the drift-heal path', async () => {
+    const cap = makeCapture();
+
+    await assert.rejects(
+      () =>
+        runUpdate({
+          argv: [],
+          currentVersion: '1.61.0',
+          resolveTargetVersion: async () => '1.61.0',
+          checkDrift: async () => true,
+          npmUpdate: async () => {},
+          spawnPhase: async (phase) => {
+            if (phase === 'sync-commands')
+              return { ok: false, stdout: '', stderr: 'commands failed' };
+            return { ok: true, stdout: '', stderr: '' };
+          },
+          write: cap.write,
+          writeErr: cap.writeErr,
+          exit: cap.exit,
+          cwd: () => '/fake/consumer',
+        }),
+      /mandrel sync-commands.*installed binary exited non-zero/,
+    );
+  });
+
+  // ---
+  // AC: --dry-run + drift → reports heal will run (not "Already up to date")
+  // ---
+
+  it('--dry-run with drift: reports sync heal planned (not "Already up to date"), writes nothing', async () => {
+    const seams = makeUpToDateSeams({ drifted: true });
+    const cap = makeCapture();
+
+    const result = await runUpdate({
+      argv: ['--dry-run'],
+      ...seams,
+      write: cap.write,
+      writeErr: cap.writeErr,
+      exit: cap.exit,
+    });
+
+    assert.equal(result.action, 'dry-run');
+    assert.equal(result.dryRun, true);
+    assert.deepEqual(result.stepsRun, []);
+    assert.equal(cap.exitCode, null);
+
+    const stdout = cap.out.join('');
+    // Must NOT say "Already up to date" when drift is detected.
+    assert.ok(
+      !stdout.includes('Already up to date'),
+      'should NOT print "Already up to date" on dry-run with drift',
+    );
+    // Must mention the heal plan.
+    assert.match(stdout, /drift/i);
+    assert.match(stdout, /[Dd]ry run/);
+
+    // No effectful seams called.
+    assert.ok(
+      !seams.calls.some((c) => String(c).startsWith('npmUpdate:')),
+      'npmUpdate must not be called on dry-run',
+    );
+    assert.ok(
+      !seams.calls.includes('runSync'),
+      'runSync must not be called on dry-run',
+    );
+  });
+
+  it('--dry-run without drift: still prints "Already up to date"', async () => {
+    const seams = makeUpToDateSeams({ drifted: false });
+    const cap = makeCapture();
+
+    const result = await runUpdate({
+      argv: ['--dry-run'],
+      ...seams,
+      write: cap.write,
+      writeErr: cap.writeErr,
+      exit: cap.exit,
+    });
+
+    assert.equal(result.action, 'up-to-date');
+    assert.match(cap.out.join(''), /Already up to date/);
+    assert.deepEqual(result.stepsRun, []);
+  });
+
+  // ---
+  // AC: checkDrift is only called on the up-to-date path (not on version bump)
+  // ---
+
+  it('does NOT call checkDrift when a real version bump is needed', async () => {
+    const driftCalls = [];
+    const cap = makeCapture();
+
+    await runUpdate({
+      argv: [],
+      currentVersion: '1.60.0',
+      resolveTargetVersion: async () => '1.61.0', // newer → take bump path
+      checkDrift: async () => {
+        driftCalls.push('called');
+        return true;
+      },
+      npmUpdate: async () => {},
+      runSync: () => ({}),
+      runMigrations: () => ({}),
+      runDoctor: async () => ({ ok: true, results: [] }),
+      surfaceChangelog: async () => {},
+      write: cap.write,
+      writeErr: cap.writeErr,
+      exit: cap.exit,
+    });
+
+    assert.deepEqual(
+      driftCalls,
+      [],
+      'checkDrift must NOT be called when a version bump is available',
+    );
+  });
+});

--- a/lib/cli/registry.js
+++ b/lib/cli/registry.js
@@ -483,7 +483,7 @@ function runAgentsMaterialized({ cwd, existsSync, resolvePackage } = {}) {
  * }} [opts]
  * @returns {{ ok: boolean, detail: string, remedy?: string }}
  */
-function runAgentsDrift({ cwd, fsImpl = fs, resolvePackageRoot } = {}) {
+export function runAgentsDrift({ cwd, fsImpl = fs, resolvePackageRoot } = {}) {
   const getCwd = cwd ?? (() => process.cwd());
   const resolveRoot = resolvePackageRoot ?? defaultResolvePackageRoot;
   const projectRoot = getCwd();

--- a/lib/cli/update.js
+++ b/lib/cli/update.js
@@ -12,7 +12,10 @@
  * ## Ordered cycle (happy path)
  *
  *   1. resolve target version (newest published) and the current version
- *   2. no-op short-circuit — already on the newest version ⇒ nothing to do
+ *   2. drift-aware short-circuit — version check gates on installed version AND
+ *      materialized `.agents/` state (Story #4065). When already on newest AND
+ *      no drift: nothing to do (true no-op). When already on newest BUT drift
+ *      detected: skip npm-update/migrations, run sync + sync-commands to heal.
  *   3. install        — bump the dependency (lockfile bump left STAGED).
  *      The package manager is auto-detected from the lockfile in the project
  *      root: `pnpm-lock.yaml` ⇒ `pnpm add -D …` (with `-w` at a
@@ -85,6 +88,11 @@
  *   - `argv`                — subcommand args (after `mandrel update`)
  *   - `currentVersion`      — the installed `mandrel` version string
  *   - `resolveTargetVersion`— async, returns the newest published version
+ *   - `checkDrift`          — sync or async, returns `true` when `.agents/`
+ *                             differs from the installed payload. Used by the
+ *                             drift-aware no-op short-circuit (Story #4065).
+ *                             Defaults to `() => !runAgentsDrift().ok`, which
+ *                             reuses the same `agents-drift` doctor signal.
  *   - `npmUpdate`           — async, performs the dependency bump (no git);
  *                             receives `(target, { installCmd })`
  *   - `spawnPhase`          — async, spawns a post-install phase from the new
@@ -140,7 +148,7 @@ import { fileURLToPath } from 'node:url';
 import { detectPackageManagerWithWorkspace } from '../../.agents/scripts/lib/detect-package-manager.js';
 import { runInstallCommand } from '../../.agents/scripts/lib/install-cmd-parser.js';
 import { runMigrations as defaultRunMigrations } from '../migrations/index.js';
-import { registry } from './registry.js';
+import { registry, runAgentsDrift } from './registry.js';
 import { runSync as defaultRunSync } from './sync.js';
 import { isStale } from './version-check.js';
 import { compareVersions } from './version-helpers.js';
@@ -761,6 +769,7 @@ function parseInstallCmdFlag(argv) {
  *   currentVersion?: string | (() => string),
  *   resolveTargetVersion?: () => (string | Promise<string>),
  *   npmUpdate?: (version: string, opts: { installCmd?: string }) => unknown | Promise<unknown>,
+ *   checkDrift?: () => (boolean | Promise<boolean>),
  *   spawnPhase?: (phase: string, args: string[], opts: { binPath: string, cwd: string, write: (s: string) => void, writeErr: (s: string) => void }) => Promise<{ ok: boolean, stdout: string, stderr: string }> | { ok: boolean, stdout: string, stderr: string },
  *   runSync?: typeof defaultRunSync,
  *   runMigrations?: typeof defaultRunMigrations,
@@ -773,7 +782,7 @@ function parseInstallCmdFlag(argv) {
  * }} [opts]
  * @returns {Promise<{
  *   ok: boolean,
- *   action: 'updated' | 'dry-run' | 'up-to-date' | 'doctor-failed',
+ *   action: 'updated' | 'resynced' | 'dry-run' | 'up-to-date' | 'doctor-failed',
  *   currentVersion: string,
  *   targetVersion: string | null,
  *   stepsRun: string[],
@@ -785,6 +794,7 @@ export async function runUpdate({
   currentVersion,
   resolveTargetVersion,
   npmUpdate,
+  checkDrift,
   spawnPhase,
   runSync = defaultRunSync,
   runMigrations = defaultRunMigrations,
@@ -811,16 +821,112 @@ export async function runUpdate({
   const target = String(await resolveTargetVersion());
 
   // --- No-op short-circuit --------------------------------------------------
-  // Already on (or ahead of) the newest version: nothing to apply.
+  // Already on (or ahead of) the newest version: check whether .agents/ is
+  // actually materialized to the installed payload (agents-drift). When drift
+  // is present, fall through to a sync-only heal path even though the package
+  // version is unchanged. Only emit "Already up to date" when the version is
+  // current AND the payload matches (Story #4065).
   if (compareVersions(target, current) <= 0) {
-    write(`✅  Already up to date (v${current} is the newest version).\n`);
+    // Resolve the drift probe: prefer the injected checkDrift seam (unit-test
+    // friendly); fall back to the production runAgentsDrift helper.
+    const driftProbe =
+      typeof checkDrift === 'function'
+        ? checkDrift
+        : () => !runAgentsDrift().ok;
+    const hasDrift = await driftProbe();
+
+    if (!hasDrift) {
+      write(`✅  Already up to date (v${current} is the newest version).\n`);
+      return {
+        ok: true,
+        action: 'up-to-date',
+        currentVersion: current,
+        targetVersion: target,
+        stepsRun: [],
+        dryRun,
+      };
+    }
+
+    // Drift detected while version is already current — heal by re-syncing
+    // without bumping the package (no npm-update, no migrations needed since
+    // the installed version did not change).
+    if (dryRun) {
+      write(
+        `mandrel update — drift detected, sync heal planned (v${current} is already current)\n`,
+      );
+      write(
+        '  1. runSync        — re-materialize .agents/ from installed payload\n',
+      );
+      write(
+        '  2. sync-commands  — regenerate .claude/commands/ from .agents/workflows/\n',
+      );
+      write('Dry run: no files written.\n');
+      return {
+        ok: true,
+        action: 'dry-run',
+        currentVersion: current,
+        targetVersion: target,
+        stepsRun: [],
+        dryRun: true,
+      };
+    }
+
+    write(
+      `Healing .agents/ drift (v${current} is already current, but .agents/ is stale)…\n`,
+    );
+    const stepsRun = [];
+
+    const useReExec = typeof spawnPhase === 'function';
+
+    if (useReExec) {
+      const projectRoot = cwd();
+      const binPath = resolveNewBinPath(projectRoot);
+
+      const syncResult = await spawnPhase('sync', [], {
+        binPath,
+        cwd: projectRoot,
+        write,
+        writeErr,
+      });
+      if (!syncResult.ok) {
+        throw new Error(
+          `mandrel update: \`mandrel sync\` from installed binary exited non-zero — ` +
+            'the .agents/ materialization may be incomplete. ' +
+            'Run `mandrel sync` manually to restore.',
+        );
+      }
+      stepsRun.push('runSync');
+
+      const syncCommandsResult = await spawnPhase('sync-commands', [], {
+        binPath,
+        cwd: projectRoot,
+        write,
+        writeErr,
+      });
+      if (!syncCommandsResult.ok) {
+        throw new Error(
+          `mandrel update: \`mandrel sync-commands\` from installed binary exited non-zero — ` +
+            'the .claude/commands/ tree may be out of sync. ' +
+            'Run `npm run sync:commands` manually to restore.',
+        );
+      }
+      stepsRun.push('sync-commands');
+    } else {
+      // In-process backward-compat path.
+      runSync({ argv: [] });
+      stepsRun.push('runSync');
+    }
+
+    write(
+      `✅  Healed .agents/ drift (v${current}). The materialized payload is now current.\n`,
+    );
     return {
       ok: true,
-      action: 'up-to-date',
+      action: 'resynced',
       currentVersion: current,
       targetVersion: target,
-      stepsRun: [],
-      dryRun,
+      stepsRun,
+      dryRun: false,
     };
   }
 


### PR DESCRIPTION
Closes #4065

_Auto-opened by `/single-story-deliver`._