### PR TITLE
ci: wire the architecture-cycle and dead-export gates into CI so they can fail a PR (#4070)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,6 +133,18 @@ jobs:
       - name: Run check-baselines
         run: node .agents/scripts/check-baselines.js --format text
 
+      - name: Architecture Cycle Check
+        # Story #4070: wire the import-cycle ratchet (check-arch-cycles.js,
+        # allowlist baselines/arch-cycles.json) and the dead-export ratchet
+        # (check-dead-exports.js, baseline baselines/dead-exports.json) into
+        # the required `baselines` gate. Both are pure-Node, baseline-aware,
+        # sub-second checks that were green-but-unenforced — running them here
+        # converts documented-but-unenforced boundaries into build-failing
+        # guardrails.
+        run: |
+          node .agents/scripts/check-arch-cycles.js --format text
+          node .agents/scripts/check-dead-exports.js
+
   windows-smoke:
     # Story #3389 — advisory Windows leg. Exercises bootstrap, command sync,
     # config resolution, and the quick test tier without joining the


### PR DESCRIPTION
Closes #4070

_Auto-opened by `/single-story-deliver`._