### PR TITLE
refactor: direct subprocess use in single-story-init.js bypasses the gh-exec façade (#4073)

### DIFF
--- a/.agents/scripts/single-story-init.js
+++ b/.agents/scripts/single-story-init.js
@@ -36,7 +36,7 @@
  * @see .agents/workflows/helpers/single-story-deliver.md
  */
 
-import { spawnSync } from 'node:child_process';
+import { spawnSync as defaultSpawnSync } from 'node:child_process';
 import { existsSync } from 'node:fs';
 import path from 'node:path';
 import { parseSprintArgs } from './lib/cli-args.js';
@@ -109,12 +109,25 @@ const progress = Logger.createProgress('single-story-init', { stderr: true });
  * ripple into the single-story-sweep planner, which is intentionally out
  * of scope for the callers-only provider migration.
  *
+ * Story #4073: the `spawnImpl` seam injects the `spawnSync` boundary so the
+ * runner's success/error handling can be unit-tested without a live `gh`
+ * binary. It defaults to `child_process.spawnSync` (mirroring the
+ * `spawnImpl` seam in `lib/gh-exec.js` and the `runner` seam in
+ * `lib/bootstrap/gh-preflight.js`), so the production CLI path is unchanged.
+ * The synchronous `spawnSync` shape is preserved deliberately — the
+ * candidate-filter loop in `executeCleanup` is synchronous, so converting
+ * this to the async `lib/gh-exec.js` facade would ripple into the
+ * single-story-sweep planner.
+ *
  * @param {string} cwd Repo root used as the default spawn cwd.
+ * @param {typeof defaultSpawnSync} [spawnImpl] Injectable spawn boundary —
+ *   defaults to `child_process.spawnSync`. Tests pass a fake to assert the
+ *   error/exit-code handling without spawning a real child process.
  * @returns {(args: string[], opts?: { cwd?: string }) => string}
  */
-export function makeGhRunner(cwd) {
+export function makeGhRunner(cwd, spawnImpl = defaultSpawnSync) {
   return (args, opts) => {
-    const result = spawnSync('gh', args, {
+    const result = spawnImpl('gh', args, {
       cwd: opts?.cwd ?? cwd,
       encoding: 'utf-8',
       shell: false,

--- a/tests/scripts/single-story-init-gh-runner.test.js
+++ b/tests/scripts/single-story-init-gh-runner.test.js
@@ -1,0 +1,120 @@
+/**
+ * tests/scripts/single-story-init-gh-runner.test.js — Story #4073
+ *
+ * Verifies that `makeGhRunner` accepts an injectable `spawnImpl` boundary so
+ * its success/error handling can be unit-tested without a live `gh` binary.
+ *
+ * Before #4073 the runner called `spawnSync('gh', …)` directly, leaving its
+ * error/exit-code path exercisable only on the slow integration-test path.
+ * The injected spawn function is mocked at the subprocess boundary here, per
+ * testing-standards § Unit (mock all I/O).
+ */
+
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import { makeGhRunner } from '../../.agents/scripts/single-story-init.js';
+
+/**
+ * Build a fake `spawnSync` that records its calls and returns a canned
+ * `{ status, stdout, stderr }` envelope.
+ *
+ * @param {{ status?: number|null, stdout?: string, stderr?: string }} result
+ */
+function makeFakeSpawn(result) {
+  const calls = [];
+  const fn = (cmd, args, opts) => {
+    calls.push({ cmd, args, opts });
+    return {
+      status: result.status ?? 0,
+      stdout: result.stdout,
+      stderr: result.stderr,
+    };
+  };
+  fn.calls = calls;
+  return fn;
+}
+
+describe('single-story-init — makeGhRunner', () => {
+  it('returns stdout on a zero exit status', () => {
+    // Arrange
+    const spawn = makeFakeSpawn({ status: 0, stdout: 'ok-output' });
+    const run = makeGhRunner('/repo', spawn);
+
+    // Act
+    const out = run(['pr', 'view', '7']);
+
+    // Assert
+    assert.equal(out, 'ok-output');
+  });
+
+  it('invokes the injected spawn with `gh`, the args, and a shell-free opts bag', () => {
+    // Arrange
+    const spawn = makeFakeSpawn({ status: 0, stdout: '' });
+    const run = makeGhRunner('/repo', spawn);
+
+    // Act
+    run(['issue', 'view', '4073']);
+
+    // Assert — the boundary is exercised without a real child process.
+    assert.equal(spawn.calls.length, 1);
+    assert.equal(spawn.calls[0].cmd, 'gh');
+    assert.deepEqual(spawn.calls[0].args, ['issue', 'view', '4073']);
+    assert.equal(spawn.calls[0].opts.shell, false);
+    assert.equal(spawn.calls[0].opts.encoding, 'utf-8');
+  });
+
+  it('defaults the spawn cwd to the runner cwd', () => {
+    // Arrange
+    const spawn = makeFakeSpawn({ status: 0, stdout: '' });
+    const run = makeGhRunner('/repo-root', spawn);
+
+    // Act
+    run(['pr', 'list']);
+
+    // Assert
+    assert.equal(spawn.calls[0].opts.cwd, '/repo-root');
+  });
+
+  it('honours a per-call cwd override', () => {
+    // Arrange
+    const spawn = makeFakeSpawn({ status: 0, stdout: '' });
+    const run = makeGhRunner('/repo-root', spawn);
+
+    // Act
+    run(['pr', 'list'], { cwd: '/elsewhere' });
+
+    // Assert
+    assert.equal(spawn.calls[0].opts.cwd, '/elsewhere');
+  });
+
+  it('returns an empty string when stdout is undefined on success', () => {
+    // Arrange
+    const spawn = makeFakeSpawn({ status: 0, stdout: undefined });
+    const run = makeGhRunner('/repo', spawn);
+
+    // Act
+    const out = run(['pr', 'list']);
+
+    // Assert
+    assert.equal(out, '');
+  });
+
+  it('throws with the args, exit code, and stderr on a non-zero status', () => {
+    // Arrange
+    const spawn = makeFakeSpawn({ status: 1, stderr: 'boom' });
+    const run = makeGhRunner('/repo', spawn);
+
+    // Act + Assert
+    assert.throws(() => run(['pr', 'view', '7']), /gh pr view 7 exit 1: boom/);
+  });
+
+  it('tolerates a missing stderr on the error path', () => {
+    // Arrange — non-zero status with undefined stderr must not crash.
+    const spawn = makeFakeSpawn({ status: 2, stderr: undefined });
+    const run = makeGhRunner('/repo', spawn);
+
+    // Act + Assert
+    assert.throws(() => run(['repo', 'view']), /gh repo view exit 2: /);
+  });
+});


### PR DESCRIPTION
Closes #4073

_Auto-opened by `/single-story-deliver`._