### PR TITLE
refactor: signal detectors duplicate their validation preamble (#4077)

### DIFF
--- a/.agents/scripts/lib/signals/detectors/common.js
+++ b/.agents/scripts/lib/signals/detectors/common.js
@@ -34,3 +34,110 @@ export function extractTool(rec) {
   }
   return null;
 }
+
+/**
+ * Validate and normalize the shared detector argument preamble.
+ *
+ * `detectRework`, `detectRetry`, and `detectHotspot` previously shipped a
+ * near-identical guard block: the `args` object-shape `TypeError`, the
+ * `nowFn` function-type `TypeError`, the positive-integer `RangeError`s for
+ * the id fields, the non-empty-string `tracesPath` check, and the
+ * non-negative-integer `threshold` check. Story #4077 hoists that preamble
+ * here so the three detectors share one error-message contract.
+ *
+ * Error wording stays per-detector-accurate by prefixing every message with
+ * `fnName` (e.g. `detectRework: …`). Error *types* are preserved exactly:
+ * the `args`/`tracesPath`/`nowFn` guards throw `TypeError`; the id and
+ * `threshold` guards throw `RangeError`.
+ *
+ * The validated fields are gated by the `require*` flags so the same helper
+ * serves both the Story-scoped detectors (rework/retry — full preamble) and
+ * the Epic-scoped hotspot detector (only `epicId` + `nowFn`). A field that
+ * is not required is neither validated nor read.
+ *
+ * @param {object} args — the detector's raw argument object.
+ * @param {object} opts
+ * @param {string} opts.fnName — the calling detector's name, used verbatim as
+ *   the prefix on every thrown error message (e.g. `'detectRework'`).
+ * @param {boolean} [opts.requireTracesPath=true] — validate + return
+ *   `tracesPath` (non-empty string).
+ * @param {boolean} [opts.requireStoryId=true] — validate + return `storyId`
+ *   (positive integer) and the optional `taskId` (positive integer or null).
+ * @param {boolean} [opts.requireThreshold=true] — validate + return
+ *   `threshold` (non-negative integer).
+ * @returns {{
+ *   tracesPath: string|undefined,
+ *   epicId: number,
+ *   storyId: number|undefined,
+ *   taskId: number|null|undefined,
+ *   threshold: number|undefined,
+ *   nowFn: () => string,
+ * }} the normalized argument set. Fields gated off by a `require*` flag are
+ *   omitted (left `undefined`).
+ */
+export function validateDetectorArgs(args, opts) {
+  const { fnName } = opts;
+  const requireTracesPath = opts.requireTracesPath ?? true;
+  const requireStoryId = opts.requireStoryId ?? true;
+  const requireThreshold = opts.requireThreshold ?? true;
+
+  if (args == null || typeof args !== 'object') {
+    throw new TypeError(
+      `${fnName}: args must be an object with at minimum { tracesPath, epicId, storyId, threshold }; got ${args}`,
+    );
+  }
+
+  const { tracesPath, epicId, storyId, threshold } = args;
+  const taskId = args.taskId ?? null;
+
+  if (args.nowFn != null && typeof args.nowFn !== 'function') {
+    throw new TypeError(
+      `${fnName}: nowFn, when provided, must be a function (got ${typeof args.nowFn})`,
+    );
+  }
+  const nowFn = args.nowFn ?? (() => new Date().toISOString());
+
+  if (requireTracesPath) {
+    if (typeof tracesPath !== 'string' || tracesPath.length === 0) {
+      throw new TypeError(
+        `${fnName}: tracesPath must be a non-empty string (got ${tracesPath})`,
+      );
+    }
+  }
+
+  if (!isPositiveInt(epicId)) {
+    throw new RangeError(
+      `${fnName}: epicId must be a positive integer (got ${epicId})`,
+    );
+  }
+
+  if (requireStoryId) {
+    if (!isPositiveInt(storyId)) {
+      throw new RangeError(
+        `${fnName}: storyId must be a positive integer (got ${storyId})`,
+      );
+    }
+    if (taskId !== null && !isPositiveInt(taskId)) {
+      throw new RangeError(
+        `${fnName}: taskId must be a positive integer or null (got ${taskId})`,
+      );
+    }
+  }
+
+  if (requireThreshold) {
+    if (!Number.isInteger(threshold) || threshold < 0) {
+      throw new RangeError(
+        `${fnName}: threshold must be a non-negative integer (got ${threshold})`,
+      );
+    }
+  }
+
+  return {
+    tracesPath: requireTracesPath ? tracesPath : undefined,
+    epicId,
+    storyId: requireStoryId ? storyId : undefined,
+    taskId: requireStoryId ? taskId : undefined,
+    threshold: requireThreshold ? threshold : undefined,
+    nowFn,
+  };
+}

--- a/.agents/scripts/lib/signals/detectors/hotspot.js
+++ b/.agents/scripts/lib/signals/detectors/hotspot.js
@@ -73,7 +73,7 @@ import path from 'node:path';
 import { createInterface } from 'node:readline';
 import { epicTempDir } from '../../config/temp-paths.js';
 import { parseStoryBranch } from '../../git-utils.js';
-import { extractTool, isPositiveInt } from './common.js';
+import { extractTool, validateDetectorArgs } from './common.js';
 
 /**
  * Tools that mutate files. Only these contribute to the per-target edit
@@ -207,24 +207,18 @@ export function nearestRankP95(values) {
  *   p95Threshold, multiplier }`.
  */
 export async function detectHotspot(args) {
-  if (args == null || typeof args !== 'object') {
-    throw new TypeError(
-      `detectHotspot: args must be an object with at minimum { epicId, multiplier }; got ${args}`,
-    );
-  }
-  const { epicId, multiplier, tempRoot } = args;
-  if (args.nowFn != null && typeof args.nowFn !== 'function') {
-    throw new TypeError(
-      `detectHotspot: nowFn, when provided, must be a function (got ${typeof args.nowFn})`,
-    );
-  }
-  const nowFn = args.nowFn ?? (() => new Date().toISOString());
+  // Hotspot shares only the args-shape, nowFn, and epicId guards with the
+  // Story-scoped detectors — it has no tracesPath/storyId/taskId/threshold.
+  // Gate those three off and validate multiplier/tempRoot (hotspot-specific)
+  // inline below.
+  const { epicId, nowFn } = validateDetectorArgs(args, {
+    fnName: 'detectHotspot',
+    requireTracesPath: false,
+    requireStoryId: false,
+    requireThreshold: false,
+  });
+  const { multiplier, tempRoot } = args;
 
-  if (!isPositiveInt(epicId)) {
-    throw new RangeError(
-      `detectHotspot: epicId must be a positive integer (got ${epicId})`,
-    );
-  }
   if (!isPositiveNumber(multiplier)) {
     throw new RangeError(
       `detectHotspot: multiplier must be a positive number (got ${multiplier})`,

--- a/.agents/scripts/lib/signals/detectors/retry.js
+++ b/.agents/scripts/lib/signals/detectors/retry.js
@@ -82,7 +82,7 @@ import { createReadStream } from 'node:fs';
 import fs from 'node:fs/promises';
 import { createInterface } from 'node:readline';
 
-import { extractTool, isPositiveInt } from './common.js';
+import { extractTool, validateDetectorArgs } from './common.js';
 
 /**
  * Documented argv-normalisation rules — emitted verbatim onto every
@@ -220,45 +220,8 @@ async function tallyFailuresByIdentity(tracesPath) {
  *   to `.agents/schemas/signal-event.schema.json`.
  */
 export async function detectRetry(args) {
-  if (args == null || typeof args !== 'object') {
-    throw new TypeError(
-      `detectRetry: args must be an object with at minimum { tracesPath, epicId, storyId, threshold }; got ${args}`,
-    );
-  }
-  const { tracesPath, epicId, storyId, threshold } = args;
-  const taskId = args.taskId ?? null;
-  if (args.nowFn != null && typeof args.nowFn !== 'function') {
-    throw new TypeError(
-      `detectRetry: nowFn, when provided, must be a function (got ${typeof args.nowFn})`,
-    );
-  }
-  const nowFn = args.nowFn ?? (() => new Date().toISOString());
-
-  if (typeof tracesPath !== 'string' || tracesPath.length === 0) {
-    throw new TypeError(
-      `detectRetry: tracesPath must be a non-empty string (got ${tracesPath})`,
-    );
-  }
-  if (!isPositiveInt(epicId)) {
-    throw new RangeError(
-      `detectRetry: epicId must be a positive integer (got ${epicId})`,
-    );
-  }
-  if (!isPositiveInt(storyId)) {
-    throw new RangeError(
-      `detectRetry: storyId must be a positive integer (got ${storyId})`,
-    );
-  }
-  if (taskId !== null && !isPositiveInt(taskId)) {
-    throw new RangeError(
-      `detectRetry: taskId must be a positive integer or null (got ${taskId})`,
-    );
-  }
-  if (!Number.isInteger(threshold) || threshold < 0) {
-    throw new RangeError(
-      `detectRetry: threshold must be a non-negative integer (got ${threshold})`,
-    );
-  }
+  const { tracesPath, epicId, storyId, taskId, threshold, nowFn } =
+    validateDetectorArgs(args, { fnName: 'detectRetry' });
 
   const counts = await tallyFailuresByIdentity(tracesPath);
 

--- a/.agents/scripts/lib/signals/detectors/rework.js
+++ b/.agents/scripts/lib/signals/detectors/rework.js
@@ -52,7 +52,7 @@ import { createReadStream } from 'node:fs';
 import fs from 'node:fs/promises';
 import { createInterface } from 'node:readline';
 
-import { extractTool, isPositiveInt } from './common.js';
+import { extractTool, validateDetectorArgs } from './common.js';
 
 /**
  * Tools that mutate files. Only these contribute to the per-target edit
@@ -140,45 +140,8 @@ async function tallyEditsByTarget(tracesPath) {
  *   conforming to `.agents/schemas/signal-event.schema.json`.
  */
 export async function detectRework(args) {
-  if (args == null || typeof args !== 'object') {
-    throw new TypeError(
-      `detectRework: args must be an object with at minimum { tracesPath, epicId, storyId, threshold }; got ${args}`,
-    );
-  }
-  const { tracesPath, epicId, storyId, threshold } = args;
-  const taskId = args.taskId ?? null;
-  if (args.nowFn != null && typeof args.nowFn !== 'function') {
-    throw new TypeError(
-      `detectRework: nowFn, when provided, must be a function (got ${typeof args.nowFn})`,
-    );
-  }
-  const nowFn = args.nowFn ?? (() => new Date().toISOString());
-
-  if (typeof tracesPath !== 'string' || tracesPath.length === 0) {
-    throw new TypeError(
-      `detectRework: tracesPath must be a non-empty string (got ${tracesPath})`,
-    );
-  }
-  if (!isPositiveInt(epicId)) {
-    throw new RangeError(
-      `detectRework: epicId must be a positive integer (got ${epicId})`,
-    );
-  }
-  if (!isPositiveInt(storyId)) {
-    throw new RangeError(
-      `detectRework: storyId must be a positive integer (got ${storyId})`,
-    );
-  }
-  if (taskId !== null && !isPositiveInt(taskId)) {
-    throw new RangeError(
-      `detectRework: taskId must be a positive integer or null (got ${taskId})`,
-    );
-  }
-  if (!Number.isInteger(threshold) || threshold < 0) {
-    throw new RangeError(
-      `detectRework: threshold must be a non-negative integer (got ${threshold})`,
-    );
-  }
+  const { tracesPath, epicId, storyId, taskId, threshold, nowFn } =
+    validateDetectorArgs(args, { fnName: 'detectRework' });
 
   const counts = await tallyEditsByTarget(tracesPath);
 

--- a/tests/lib/signals/detectors/common.test.js
+++ b/tests/lib/signals/detectors/common.test.js
@@ -3,6 +3,7 @@ import { describe, it } from 'node:test';
 import {
   extractTool,
   isPositiveInt,
+  validateDetectorArgs,
 } from '../../../../.agents/scripts/lib/signals/detectors/common.js';
 
 // ---------------------------------------------------------------------------
@@ -87,5 +88,206 @@ describe('extractTool()', () => {
   it('returns null for null/undefined records (no throw)', () => {
     assert.equal(extractTool(null), null);
     assert.equal(extractTool(undefined), null);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// validateDetectorArgs() — the shared argument-validation preamble hoisted
+// out of detectRework / detectRetry / detectHotspot in Story #4077. The three
+// detectors previously shipped a near-identical guard block; this helper owns
+// the error-message contract so they stay consistent.
+// ---------------------------------------------------------------------------
+
+describe('validateDetectorArgs() — full preamble (rework/retry shape)', () => {
+  const baseArgs = () => ({
+    tracesPath: '/tmp/traces.ndjson',
+    epicId: 10,
+    storyId: 20,
+    taskId: 30,
+    threshold: 2,
+  });
+
+  it('returns the normalized arg set for a valid full argument object', () => {
+    const out = validateDetectorArgs(baseArgs(), { fnName: 'detectRework' });
+    assert.equal(out.tracesPath, '/tmp/traces.ndjson');
+    assert.equal(out.epicId, 10);
+    assert.equal(out.storyId, 20);
+    assert.equal(out.taskId, 30);
+    assert.equal(out.threshold, 2);
+    assert.equal(typeof out.nowFn, 'function');
+  });
+
+  it('defaults taskId to null when omitted', () => {
+    const { taskId, ...rest } = baseArgs();
+    const out = validateDetectorArgs(rest, { fnName: 'detectRework' });
+    assert.equal(out.taskId, null);
+  });
+
+  it('defaults nowFn to a real ISO clock when omitted', () => {
+    const out = validateDetectorArgs(baseArgs(), { fnName: 'detectRetry' });
+    assert.match(out.nowFn(), /^\d{4}-\d{2}-\d{2}T/);
+  });
+
+  it('returns the injected nowFn unchanged when provided', () => {
+    const FIXED = '2026-01-02T03:04:05.678Z';
+    const out = validateDetectorArgs(
+      { ...baseArgs(), nowFn: () => FIXED },
+      { fnName: 'detectRetry' },
+    );
+    assert.equal(out.nowFn(), FIXED);
+  });
+
+  it('throws TypeError when args is null or not an object', () => {
+    assert.throws(
+      () => validateDetectorArgs(null, { fnName: 'detectRework' }),
+      TypeError,
+    );
+    assert.throws(
+      () => validateDetectorArgs(undefined, { fnName: 'detectRework' }),
+      TypeError,
+    );
+    assert.throws(
+      () => validateDetectorArgs(42, { fnName: 'detectRework' }),
+      TypeError,
+    );
+  });
+
+  it('throws TypeError when tracesPath is missing or empty', () => {
+    assert.throws(
+      () =>
+        validateDetectorArgs(
+          { ...baseArgs(), tracesPath: '' },
+          { fnName: 'detectRework' },
+        ),
+      TypeError,
+    );
+    assert.throws(
+      () =>
+        validateDetectorArgs(
+          { ...baseArgs(), tracesPath: 42 },
+          { fnName: 'detectRework' },
+        ),
+      TypeError,
+    );
+  });
+
+  it('throws RangeError for a non-positive epicId', () => {
+    assert.throws(
+      () =>
+        validateDetectorArgs(
+          { ...baseArgs(), epicId: 0 },
+          { fnName: 'detectRework' },
+        ),
+      RangeError,
+    );
+  });
+
+  it('throws RangeError for a non-positive storyId', () => {
+    assert.throws(
+      () =>
+        validateDetectorArgs(
+          { ...baseArgs(), storyId: -1 },
+          { fnName: 'detectRework' },
+        ),
+      RangeError,
+    );
+  });
+
+  it('throws RangeError for a non-positive taskId (when not null)', () => {
+    assert.throws(
+      () =>
+        validateDetectorArgs(
+          { ...baseArgs(), taskId: 0 },
+          { fnName: 'detectRework' },
+        ),
+      RangeError,
+    );
+  });
+
+  it('throws RangeError for a negative threshold', () => {
+    assert.throws(
+      () =>
+        validateDetectorArgs(
+          { ...baseArgs(), threshold: -1 },
+          { fnName: 'detectRework' },
+        ),
+      RangeError,
+    );
+  });
+
+  it('throws TypeError when nowFn is provided but not a function', () => {
+    assert.throws(
+      () =>
+        validateDetectorArgs(
+          { ...baseArgs(), nowFn: 42 },
+          { fnName: 'detectRework' },
+        ),
+      TypeError,
+    );
+  });
+
+  it('prefixes every thrown message with the supplied fnName', () => {
+    assert.throws(
+      () => validateDetectorArgs(null, { fnName: 'detectRetry' }),
+      /^TypeError: detectRetry: /,
+    );
+    assert.throws(
+      () =>
+        validateDetectorArgs(
+          { ...baseArgs(), epicId: 0 },
+          { fnName: 'detectRetry' },
+        ),
+      /^RangeError: detectRetry: epicId/,
+    );
+  });
+});
+
+describe('validateDetectorArgs() — gated preamble (hotspot shape)', () => {
+  it('validates only args/nowFn/epicId when the require flags are off', () => {
+    const out = validateDetectorArgs(
+      { epicId: 7 },
+      {
+        fnName: 'detectHotspot',
+        requireTracesPath: false,
+        requireStoryId: false,
+        requireThreshold: false,
+      },
+    );
+    assert.equal(out.epicId, 7);
+    assert.equal(out.tracesPath, undefined);
+    assert.equal(out.storyId, undefined);
+    assert.equal(out.taskId, undefined);
+    assert.equal(out.threshold, undefined);
+    assert.equal(typeof out.nowFn, 'function');
+  });
+
+  it('still throws RangeError for a non-positive epicId', () => {
+    assert.throws(
+      () =>
+        validateDetectorArgs(
+          { epicId: 0 },
+          {
+            fnName: 'detectHotspot',
+            requireTracesPath: false,
+            requireStoryId: false,
+            requireThreshold: false,
+          },
+        ),
+      RangeError,
+    );
+  });
+
+  it('does not require tracesPath/storyId/threshold when gated off', () => {
+    assert.doesNotThrow(() =>
+      validateDetectorArgs(
+        { epicId: 1 },
+        {
+          fnName: 'detectHotspot',
+          requireTracesPath: false,
+          requireStoryId: false,
+          requireThreshold: false,
+        },
+      ),
+    );
   });
 });


### PR DESCRIPTION
Closes #4077

_Auto-opened by `/single-story-deliver`._