### PR TITLE
ci: cI comments reference a non-existent `npm run audit-security` gate (#4079)

### DIFF
--- a/.agents/scripts/check-action-pinning.js
+++ b/.agents/scripts/check-action-pinning.js
@@ -1,0 +1,260 @@
+/**
+ * CLI: third-party GitHub Action pinning gate.
+ *
+ * Story #4079 (audit::devops). Closes a supply-chain regression window the
+ * `ci.yml` / `release-please.yml` comments *claimed* was guarded by a
+ * nonexistent `npm run audit-security` gate. There is no such npm script;
+ * `audit-security` is only a manual `/audit-security` slash-command lens.
+ * Nothing actually enforced that third-party `uses:` refs stay SHA-pinned,
+ * so a future edit reverting `trufflehog@<sha>` to `@main` would pass CI
+ * silently.
+ *
+ * This script scans `.github/workflows/*.yml` (and `*.yaml`), extracts every
+ * `uses:` ref, and fails the build when a **third-party** action (anything
+ * not under the first-party `actions/*` org) is pinned to a floating ref
+ * instead of a full 40-char commit SHA. First-party `actions/*` refs are
+ * allowed on major-version tags (`@v4`) — Dependabot's `github-actions`
+ * ecosystem bumps those in-place, matching the rationale in the workflow
+ * file headers.
+ *
+ * A "floating ref" is any of:
+ *   - a branch head: `@main`, `@master`
+ *   - a tag / partial-SHA that is not a full 40-hex-char commit SHA
+ *     (`@v5`, `@v3.95.3`, `@release`, a 7-char short SHA, …)
+ *
+ * Contract:
+ *   - Scans the workflows directory (default `.github/workflows`, override
+ *     with `--dir <path>`).
+ *   - Prints `<file>:<lineNo> <ref> — <reason>` for each violation, then a
+ *     one-line summary even on a clean scan so operators see the "ok" signal.
+ *   - With `--json`: writes a structured envelope to stdout and skips the
+ *     human summary.
+ *   - Exit codes: 0 = no violations; 1 = at least one floating third-party
+ *     ref. A missing / empty workflows directory exits 0 (nothing to gate).
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import process from 'node:process';
+import { runAsCli } from './lib/cli-utils.js';
+
+/**
+ * Parse argv for `--dir <path>` and `--json`. Exported so unit tests can pin
+ * the parser.
+ *
+ * @param {string[]} argv
+ * @returns {{ dir: string | null, json: boolean }}
+ */
+export function parseArgv(argv = []) {
+  let dir = null;
+  let json = false;
+  for (let i = 0; i < argv.length; i += 1) {
+    const a = argv[i];
+    if (a === '--dir') {
+      const next = argv[i + 1];
+      if (next && !next.startsWith('--')) {
+        dir = next;
+        i += 1;
+      }
+    } else if (a === '--json') {
+      json = true;
+    }
+  }
+  return { dir, json };
+}
+
+/**
+ * Is the given ref suffix a full 40-char hex commit SHA?
+ *
+ * @param {string} ref The portion after the `@` in a `uses:` value.
+ * @returns {boolean}
+ */
+export function isFullSha(ref) {
+  return /^[0-9a-f]{40}$/i.test(ref);
+}
+
+/**
+ * Is the action a first-party `actions/*` action (e.g. `actions/checkout`)?
+ * First-party refs are allowed to float on major-version tags because
+ * Dependabot's `github-actions` ecosystem bumps them in-place.
+ *
+ * Local (`./…`) and reusable-workflow (`owner/repo/.github/workflows/x.yml`)
+ * refs and Docker refs (`docker://…`) are out of scope for the SHA-pin gate;
+ * `isFirstParty` only matters for `owner/repo[@ref]` registry actions.
+ *
+ * @param {string} action The portion before the `@` in a `uses:` value.
+ * @returns {boolean}
+ */
+export function isFirstParty(action) {
+  return /^actions\//.test(action);
+}
+
+/**
+ * Pure helper: scan a single workflow file's text for `uses:` refs and return
+ * the violations. A violation is a third-party `owner/repo@ref` where `ref`
+ * is not a full 40-char SHA.
+ *
+ * Skips:
+ *   - local actions (`uses: ./path`)
+ *   - Docker refs (`uses: docker://…`)
+ *   - first-party `actions/*` refs (allowed on major-version tags)
+ *   - refs with no `@` (pinned by default branch implicitly — flagged as a
+ *     violation: an unpinned third-party ref floats on the default branch)
+ *
+ * @param {string} file Relative file label used in violation rows.
+ * @param {string} text The file contents.
+ * @returns {Array<{ file: string, line: number, action: string, ref: string | null, reason: string }>}
+ */
+export function scanWorkflowText(file, text) {
+  const violations = [];
+  const lines = text.split(/\r?\n/);
+  // Match `uses:` values, optionally quoted. The value runs until whitespace
+  // or a `#` comment. Capture the raw value for downstream parsing.
+  const usesRe = /^\s*(?:-\s*)?uses:\s*['"]?([^'"#\s]+)['"]?/;
+  for (let i = 0; i < lines.length; i += 1) {
+    const m = usesRe.exec(lines[i]);
+    if (!m) continue;
+    const value = m[1];
+    const lineNo = i + 1;
+    // Local actions and Docker refs are out of scope for the SHA-pin gate.
+    if (value.startsWith('./') || value.startsWith('docker://')) continue;
+    const atIndex = value.indexOf('@');
+    const action = atIndex === -1 ? value : value.slice(0, atIndex);
+    const ref = atIndex === -1 ? null : value.slice(atIndex + 1);
+    // First-party actions/* may float on major-version tags.
+    if (isFirstParty(action)) continue;
+    if (ref === null) {
+      violations.push({
+        file,
+        line: lineNo,
+        action,
+        ref: null,
+        reason: 'third-party action with no ref floats on the default branch',
+      });
+      continue;
+    }
+    if (!isFullSha(ref)) {
+      const floating = ref === 'main' || ref === 'master';
+      violations.push({
+        file,
+        line: lineNo,
+        action,
+        ref,
+        reason: floating
+          ? `third-party action pinned to branch head @${ref} (CWE-1357)`
+          : `third-party action @${ref} is not a full 40-char commit SHA`,
+      });
+    }
+  }
+  return violations;
+}
+
+/**
+ * Enumerate workflow files (`*.yml` / `*.yaml`) directly under `dir`.
+ * Returns absolute paths sorted for deterministic output. A missing directory
+ * yields an empty list.
+ *
+ * @param {string} dir Absolute workflows directory.
+ * @returns {string[]}
+ */
+export function listWorkflowFiles(dir) {
+  let entries;
+  try {
+    entries = fs.readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+  return entries
+    .filter((e) => e.isFile() && /\.ya?ml$/i.test(e.name))
+    .map((e) => path.join(dir, e.name))
+    .sort();
+}
+
+/**
+ * Pure helper: render the human-readable report. One line per violation
+ * followed by a one-line summary. The summary carries a `(gate fail)` /
+ * `(ok)` marker so the result is visible in CI output.
+ *
+ * @param {Array<{ file: string, line: number, action: string, ref: string | null, reason: string }>} violations
+ * @returns {string}
+ */
+export function renderReport(violations) {
+  const lines = [];
+  for (const v of violations) {
+    const refLabel = v.ref === null ? '(no ref)' : `@${v.ref}`;
+    lines.push(`${v.file}:${v.line} ${v.action}${refLabel} — ${v.reason}`);
+  }
+  const tag = violations.length > 0 ? '(gate fail)' : '(ok)';
+  lines.push(`[action-pinning] violations=${violations.length} ${tag}`);
+  return lines.join('\n');
+}
+
+/**
+ * Top-level CLI entry. Exported so tests can drive the full pipeline against a
+ * fixture workflows directory without touching the repo's real workflows.
+ *
+ * @param {{
+ *   argv?: string[],
+ *   cwd?: string,
+ *   stdout?: { write: (s: string) => void },
+ *   stderr?: { write: (s: string) => void },
+ * }} [opts]
+ * @returns {Promise<number>} exit code: 0 = clean; 1 = floating third-party ref
+ */
+export async function runCli({
+  argv = process.argv.slice(2),
+  cwd = process.cwd(),
+  stdout = process.stdout,
+  stderr = process.stderr,
+} = {}) {
+  const { dir, json } = parseArgv(argv);
+  const resolvedDir = path.resolve(
+    cwd,
+    dir ?? path.join('.github', 'workflows'),
+  );
+
+  const files = listWorkflowFiles(resolvedDir);
+  const violations = [];
+  for (const file of files) {
+    let text;
+    try {
+      text = fs.readFileSync(file, 'utf-8');
+    } catch {
+      continue;
+    }
+    violations.push(...scanWorkflowText(path.relative(cwd, file), text));
+  }
+
+  const exitCode = violations.length > 0 ? 1 : 0;
+
+  if (json) {
+    const envelope = {
+      kind: 'action-pinning-report',
+      dir: resolvedDir,
+      filesScanned: files.length,
+      violations,
+      exitCode,
+    };
+    stdout.write(`${JSON.stringify(envelope, null, 2)}\n`);
+  } else {
+    if (files.length === 0) {
+      stderr.write(
+        `[action-pinning] ⚠ no workflow files found under ${resolvedDir}\n`,
+      );
+    }
+    stdout.write(`\n--- action-pinning scan ---\n`);
+    stdout.write(`${renderReport(violations)}\n`);
+  }
+
+  return exitCode;
+}
+
+async function main() {
+  return runCli();
+}
+
+runAsCli(import.meta.url, main, {
+  source: 'action-pinning',
+  propagateExitCode: true,
+  errorPrefix: '[action-pinning] ❌ Fatal error',
+});

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,11 +50,23 @@ jobs:
       - name: Dependency Vulnerability Audit (SCA)
         run: npm audit --audit-level=high
 
+      - name: Action Pinning Guard
+        # Story #4079: fail the build if any third-party `uses:` ref drifts off
+        # a full 40-char commit SHA onto a branch head (`@main`/`@master`) or a
+        # floating tag (`@v5`). First-party `actions/*` refs may stay on
+        # major-version tags (Dependabot bumps those in-place). This is the
+        # real, automated gate the comments below reference — there is no
+        # `npm run audit-security` script (that name is only the manual
+        # `/audit-security` slash-command lens).
+        run: node .agents/scripts/check-action-pinning.js
+
       - name: Secret Scanning (TruffleHog)
         # Pinned to a released tag rather than the moving `@main` head — a
         # third-party action's default branch is a supply-chain risk vector
         # (CWE-1357). Bump deliberately when a new TruffleHog release ships;
-        # `npm run audit-security` flags any reversion to `@main` / `@master`.
+        # the `Action Pinning Guard` step above (check-action-pinning.js)
+        # fails the build on any reversion to `@main` / `@master` / a
+        # floating tag.
         uses: trufflesecurity/trufflehog@37b77001d0174ebec2fcca2bd83ff83a6d45a3ab # v3.95.3
         with:
           extra_args: --debug --only-verified

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -38,8 +38,10 @@ jobs:
       # Pinned to an exact release tag rather than a floating major (`@v5`)
       # or the moving `@main` ref — a third-party action's default branch
       # is a supply-chain risk vector (CWE-1357). Bump deliberately when a
-      # new release-please-action ships; `npm run audit-security` flags
-      # any reversion to `@main` / `@master`.
+      # new release-please-action ships; the `Action Pinning Guard` step in
+      # ci.yml (.agents/scripts/check-action-pinning.js) scans every
+      # workflow — including this one — and fails the build on any reversion
+      # to `@main` / `@master` / a floating tag.
       #
       # Token preference: RELEASE_PLEASE_TOKEN (operator-managed PAT or
       # GitHub App installation token) first, default GITHUB_TOKEN as

--- a/tests/check-action-pinning.test.js
+++ b/tests/check-action-pinning.test.js
@@ -1,0 +1,258 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { test } from 'node:test';
+import {
+  isFirstParty,
+  isFullSha,
+  listWorkflowFiles,
+  parseArgv,
+  renderReport,
+  runCli,
+  scanWorkflowText,
+} from '../.agents/scripts/check-action-pinning.js';
+
+/**
+ * Unit coverage for the third-party action-pinning gate (Story #4079).
+ *
+ * Modeled on the sibling `check-dead-exports.test.js`: exercise the pure
+ * helpers directly, then drive `runCli` end-to-end against a fixture
+ * workflows directory.
+ */
+
+test('parseArgv: returns defaults when no flags supplied', () => {
+  const out = parseArgv([]);
+  assert.equal(out.dir, null);
+  assert.equal(out.json, false);
+});
+
+test('parseArgv: --dir takes the next non-flag token, --json sets json', () => {
+  const out = parseArgv(['--dir', 'tmp/wf', '--json']);
+  assert.equal(out.dir, 'tmp/wf');
+  assert.equal(out.json, true);
+});
+
+test('parseArgv: --dir without a value falls back to null', () => {
+  const out = parseArgv(['--dir', '--json']);
+  assert.equal(out.dir, null);
+  assert.equal(out.json, true);
+});
+
+test('isFullSha: accepts a 40-char hex SHA, rejects everything else', () => {
+  assert.equal(isFullSha('37b77001d0174ebec2fcca2bd83ff83a6d45a3ab'), true);
+  assert.equal(isFullSha('37B77001D0174EBEC2FCCA2BD83FF83A6D45A3AB'), true);
+  assert.equal(isFullSha('v5'), false);
+  assert.equal(isFullSha('v3.95.3'), false);
+  assert.equal(isFullSha('main'), false);
+  // 7-char short SHA is not a full pin.
+  assert.equal(isFullSha('37b7700'), false);
+  // 41 chars is not a valid SHA.
+  assert.equal(isFullSha('37b77001d0174ebec2fcca2bd83ff83a6d45a3abc'), false);
+});
+
+test('isFirstParty: actions/* is first-party, others are not', () => {
+  assert.equal(isFirstParty('actions/checkout'), true);
+  assert.equal(isFirstParty('actions/setup-node'), true);
+  assert.equal(isFirstParty('trufflesecurity/trufflehog'), false);
+  assert.equal(isFirstParty('googleapis/release-please-action'), false);
+});
+
+test('scanWorkflowText: flags a third-party action pinned to @main', () => {
+  const text = [
+    'jobs:',
+    '  x:',
+    '    steps:',
+    '      - uses: foo/bar@main',
+  ].join('\n');
+  const v = scanWorkflowText('ci.yml', text);
+  assert.equal(v.length, 1);
+  assert.equal(v[0].action, 'foo/bar');
+  assert.equal(v[0].ref, 'main');
+  assert.equal(v[0].line, 4);
+  assert.match(v[0].reason, /branch head/);
+});
+
+test('scanWorkflowText: flags a third-party action pinned to a version tag', () => {
+  const text = '      - uses: googleapis/release-please-action@v5';
+  const v = scanWorkflowText('release.yml', text);
+  assert.equal(v.length, 1);
+  assert.equal(v[0].ref, 'v5');
+  assert.match(v[0].reason, /not a full 40-char commit SHA/);
+});
+
+test('scanWorkflowText: allows a third-party action pinned to a full SHA', () => {
+  const text =
+    '      - uses: trufflesecurity/trufflehog@37b77001d0174ebec2fcca2bd83ff83a6d45a3ab # v3.95.3';
+  const v = scanWorkflowText('ci.yml', text);
+  assert.deepEqual(v, []);
+});
+
+test('scanWorkflowText: allows first-party actions/* on a major-version tag', () => {
+  const text = [
+    '      - uses: actions/checkout@v4',
+    '      - uses: actions/setup-node@v4',
+  ].join('\n');
+  const v = scanWorkflowText('ci.yml', text);
+  assert.deepEqual(v, []);
+});
+
+test('scanWorkflowText: skips local and docker refs', () => {
+  const text = [
+    '      - uses: ./.github/actions/local',
+    '      - uses: docker://alpine:3.19',
+  ].join('\n');
+  const v = scanWorkflowText('ci.yml', text);
+  assert.deepEqual(v, []);
+});
+
+test('scanWorkflowText: flags a third-party action with no ref (floats on default branch)', () => {
+  const text = '      - uses: foo/bar';
+  const v = scanWorkflowText('ci.yml', text);
+  assert.equal(v.length, 1);
+  assert.equal(v[0].ref, null);
+  assert.match(v[0].reason, /no ref/);
+});
+
+test('scanWorkflowText: handles quoted uses values', () => {
+  const text = "      - uses: 'foo/bar@master'";
+  const v = scanWorkflowText('ci.yml', text);
+  assert.equal(v.length, 1);
+  assert.equal(v[0].ref, 'master');
+});
+
+test('listWorkflowFiles: returns empty list for a missing directory', () => {
+  assert.deepEqual(listWorkflowFiles('/does/not/exist/anywhere'), []);
+});
+
+test('listWorkflowFiles: lists yml and yaml files sorted', () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'action-pin-'));
+  fs.writeFileSync(path.join(tmp, 'b.yml'), '');
+  fs.writeFileSync(path.join(tmp, 'a.yaml'), '');
+  fs.writeFileSync(path.join(tmp, 'ignore.txt'), '');
+  const files = listWorkflowFiles(tmp).map((f) => path.basename(f));
+  assert.deepEqual(files, ['a.yaml', 'b.yml']);
+});
+
+test('renderReport: lines + (gate fail) summary on violations', () => {
+  const out = renderReport([
+    { file: 'ci.yml', line: 4, action: 'foo/bar', ref: 'main', reason: 'r' },
+  ]);
+  assert.match(out, /ci\.yml:4 foo\/bar@main — r/);
+  assert.match(out, /violations=1 \(gate fail\)/);
+});
+
+test('renderReport: (ok) summary on a clean scan', () => {
+  const out = renderReport([]);
+  assert.match(out, /violations=0 \(ok\)/);
+});
+
+function captureStream() {
+  const chunks = [];
+  return {
+    stream: { write: (s) => chunks.push(s) },
+    text: () => chunks.join(''),
+  };
+}
+
+function seedWorkflowsDir(files) {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'action-pin-cli-'));
+  const wfDir = path.join(tmp, '.github', 'workflows');
+  fs.mkdirSync(wfDir, { recursive: true });
+  for (const [name, content] of Object.entries(files)) {
+    fs.writeFileSync(path.join(wfDir, name), content);
+  }
+  return { cwd: tmp, wfDir };
+}
+
+test('runCli: exits 0 on a clean scan and emits JSON envelope', async () => {
+  const { cwd } = seedWorkflowsDir({
+    'ci.yml':
+      '      - uses: actions/checkout@v4\n      - uses: foo/bar@37b77001d0174ebec2fcca2bd83ff83a6d45a3ab\n',
+  });
+  const stdout = captureStream();
+  const stderr = captureStream();
+  const exit = await runCli({
+    argv: ['--json'],
+    cwd,
+    stdout: stdout.stream,
+    stderr: stderr.stream,
+  });
+  assert.equal(exit, 0);
+  const envelope = JSON.parse(stdout.text());
+  assert.equal(envelope.kind, 'action-pinning-report');
+  assert.equal(envelope.filesScanned, 1);
+  assert.deepEqual(envelope.violations, []);
+  assert.equal(envelope.exitCode, 0);
+});
+
+test('runCli: exits 1 when a third-party action floats on @main', async () => {
+  const { cwd } = seedWorkflowsDir({
+    'ci.yml': '      - uses: foo/bar@main\n',
+  });
+  const stdout = captureStream();
+  const stderr = captureStream();
+  const exit = await runCli({
+    argv: ['--json'],
+    cwd,
+    stdout: stdout.stream,
+    stderr: stderr.stream,
+  });
+  assert.equal(exit, 1);
+  const envelope = JSON.parse(stdout.text());
+  assert.equal(envelope.violations.length, 1);
+  assert.equal(envelope.violations[0].ref, 'main');
+  assert.equal(envelope.exitCode, 1);
+});
+
+test('runCli: human output prints violation rows and the gate-fail marker', async () => {
+  const { cwd } = seedWorkflowsDir({
+    'release.yml': '      - uses: googleapis/release-please-action@v5\n',
+  });
+  const stdout = captureStream();
+  const stderr = captureStream();
+  const exit = await runCli({
+    argv: [],
+    cwd,
+    stdout: stdout.stream,
+    stderr: stderr.stream,
+  });
+  assert.equal(exit, 1);
+  const out = stdout.text();
+  assert.match(out, /release\.yml:1 googleapis\/release-please-action@v5/);
+  assert.match(out, /\(gate fail\)/);
+});
+
+test('runCli: exits 0 and warns when the workflows directory is missing', async () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'action-pin-empty-'));
+  const stdout = captureStream();
+  const stderr = captureStream();
+  const exit = await runCli({
+    argv: [],
+    cwd: tmp,
+    stdout: stdout.stream,
+    stderr: stderr.stream,
+  });
+  assert.equal(exit, 0);
+  assert.match(stderr.text(), /no workflow files found/);
+});
+
+test('runCli: scans the repo workflows and finds no violations (self-check)', async () => {
+  // The repo's own .github/workflows must stay clean — this doubles as a
+  // regression guard against a future @main reversion landing in-tree.
+  const repoRoot = path.resolve(import.meta.dirname, '..');
+  const stdout = captureStream();
+  const stderr = captureStream();
+  const exit = await runCli({
+    argv: ['--json'],
+    cwd: repoRoot,
+    stdout: stdout.stream,
+    stderr: stderr.stream,
+  });
+  const envelope = JSON.parse(stdout.text());
+  assert.equal(
+    exit,
+    0,
+    `repo workflows have pinning violations: ${JSON.stringify(envelope.violations, null, 2)}`,
+  );
+});


### PR DESCRIPTION
Closes #4079

_Auto-opened by `/single-story-deliver`._