### PR TITLE
fix(init): set terminal:false on readline confirms so the prompt is not erased

### DIFF
--- a/.agents/scripts/lib/onboard/init-tail.js
+++ b/.agents/scripts/lib/onboard/init-tail.js
@@ -92,12 +92,24 @@ const SCAFFOLD_PROMPT = '\nScaffold stubs now? [y/N]: ';
  * something other than `y` / `yes`. The prompt text is written by the caller
  * via `stdout`, so the question string passed here is empty.
  *
+ * `terminal: false` is **load-bearing**: with terminal mode on (the default
+ * when stdout is a TTY) readline emits cursor-control escapes
+ * (`\x1b[1G\x1b[0J`) that erase the `Scaffold stubs now? [y/N]:` prompt already
+ * written via the caller's `stdout`, leaving the operator staring at a blank,
+ * dead-looking line. Disabling terminal mode preserves the pre-written prompt
+ * and reads the line via the TTY's cooked-mode echo. `createInterface` is
+ * injectable so a test can assert this option is set (regression guard).
+ *
+ * @param {{ createInterface?: typeof readline.createInterface }} [opts]
  * @returns {Promise<boolean>}
  */
-async function readConfirm() {
-  const rl = readline.createInterface({
+export async function readConfirm({
+  createInterface = readline.createInterface,
+} = {}) {
+  const rl = createInterface({
     input: process.stdin,
     output: process.stdout,
+    terminal: false,
   });
   try {
     const answer = (await rl.question('')).trim().toLowerCase();

--- a/lib/cli/init.js
+++ b/lib/cli/init.js
@@ -349,12 +349,25 @@ function defaultRunStep(cmd, args) {
  * prompt text is written by `planInit` via `stdout`, so the question string
  * passed here is empty.
  *
+ * `terminal: false` is **load-bearing**, not cosmetic: with terminal mode on
+ * (the default when stdout is a TTY) readline emits cursor-control escapes
+ * (`\x1b[1G\x1b[0J` — column-1 + erase-to-end-of-screen) when it takes over the
+ * line, which **erases the `[Y/n]:` prompt already written via `stdout`** — the
+ * operator then sees only the first prompt line and a dead-looking cursor.
+ * Disabling terminal mode leaves the pre-written prompt intact and reads the
+ * line via the TTY's own cooked-mode echo. `createInterface` is injectable so a
+ * test can assert this option is set (regression guard).
+ *
+ * @param {{ createInterface?: typeof readline.createInterface }} [opts]
  * @returns {Promise<boolean>}
  */
-async function defaultConfirm() {
-  const rl = readline.createInterface({
+export async function defaultConfirm({
+  createInterface = readline.createInterface,
+} = {}) {
+  const rl = createInterface({
     input: process.stdin,
     output: process.stdout,
+    terminal: false,
   });
   try {
     const answer = (await rl.question('')).trim().toLowerCase();

--- a/tests/cli/init.test.js
+++ b/tests/cli/init.test.js
@@ -27,7 +27,7 @@ import path from 'node:path';
 import { describe, it } from 'node:test';
 import { fileURLToPath } from 'node:url';
 
-import init, { planInit } from '../../lib/cli/init.js';
+import init, { defaultConfirm, planInit } from '../../lib/cli/init.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = path.resolve(__dirname, '..', '..');
@@ -549,5 +549,41 @@ describe('mandrel init — bin dispatch integration', () => {
       `mandrel init --help exited ${result.status}\nstdout: ${result.stdout}\nstderr: ${result.stderr}`,
     );
     assert.match(result.stdout, /Usage: mandrel init/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// defaultConfirm — prompt-erase regression guard
+// ---------------------------------------------------------------------------
+
+describe('init — defaultConfirm readline options', () => {
+  it('creates the readline interface with terminal:false so the pre-written prompt is not erased', async () => {
+    let captured;
+    const createInterface = (opts) => {
+      captured = opts;
+      return { question: async () => 'y', close: () => {} };
+    };
+    const result = await defaultConfirm({ createInterface });
+    // The load-bearing guard: terminal mode must be off. With it on, readline
+    // emits cursor-erase escapes that wipe the `[Y/n]:` prompt line.
+    assert.equal(
+      captured.terminal,
+      false,
+      'defaultConfirm must pass terminal:false to readline.createInterface',
+    );
+    assert.equal(result, true, 'a "y" answer resolves to true (configure)');
+  });
+
+  it('treats an explicit "no" as decline and bare Enter as the yes default', async () => {
+    const make = (answer) => ({
+      createInterface: () => ({
+        question: async () => answer,
+        close: () => {},
+      }),
+    });
+    assert.equal(await defaultConfirm(make('n')), false);
+    assert.equal(await defaultConfirm(make('no')), false);
+    assert.equal(await defaultConfirm(make('')), true);
+    assert.equal(await defaultConfirm(make('y')), true);
   });
 });

--- a/tests/onboard/onboard-workflow.test.js
+++ b/tests/onboard/onboard-workflow.test.js
@@ -26,7 +26,7 @@ import { fileURLToPath, pathToFileURL } from 'node:url';
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = path.resolve(__dirname, '..', '..');
 
-const { runInitTail, PLAN_HANDOFF_TEXT } = await import(
+const { runInitTail, readConfirm, PLAN_HANDOFF_TEXT } = await import(
   pathToFileURL(
     path.resolve(REPO_ROOT, '.agents/scripts/lib/onboard/init-tail.js'),
   ).href
@@ -258,5 +258,39 @@ describe('/onboard retirement', async () => {
       false,
       'onboard.md must be removed — /onboard is retired',
     );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// readConfirm — scaffold-prompt erase regression guard
+// ---------------------------------------------------------------------------
+
+describe('init tail — readConfirm readline options', () => {
+  it('creates the readline interface with terminal:false so the scaffold prompt is not erased', async () => {
+    let captured;
+    const createInterface = (opts) => {
+      captured = opts;
+      return { question: async () => 'y', close: () => {} };
+    };
+    const result = await readConfirm({ createInterface });
+    assert.equal(
+      captured.terminal,
+      false,
+      'readConfirm must pass terminal:false to readline.createInterface',
+    );
+    assert.equal(result, true, 'a "y" answer resolves to true (scaffold)');
+  });
+
+  it('treats anything but y/yes as decline (default-false for the scaffold offer)', async () => {
+    const make = (answer) => ({
+      createInterface: () => ({
+        question: async () => answer,
+        close: () => {},
+      }),
+    });
+    assert.equal(await readConfirm(make('y')), true);
+    assert.equal(await readConfirm(make('yes')), true);
+    assert.equal(await readConfirm(make('')), false);
+    assert.equal(await readConfirm(make('n')), false);
   });
 });


### PR DESCRIPTION
## Why

Follow-up to #4106 / PR #4107. That PR replaced the EOF-blocking
`fs.readFileSync(0)` confirm reads with `node:readline` — fixing the hang —
but created the readline interface with **terminal mode on** (the default when
stdout is a TTY). On a real terminal readline then emits cursor-control escapes
(`\x1b[1G\x1b[0J` — column-1 + erase-to-end-of-screen) when it takes over the
line, which **erases the `[Y/n]:` prompt already written via `stdout`**. The
operator saw only the first prompt line (`The Mandrel .agents package has been
copied to your directory.`) and a dead-looking cursor — looked like the same
hang.

It passed CI because the unit tests inject the `confirm` seam (never exercise
readline) and a byte-capture pty check still *contains* the prompt (the erase
only matters at render time).

## What changed

- **lib/cli/init.js** (`defaultConfirm`) and
  **.agents/scripts/lib/onboard/init-tail.js** (`readConfirm`): pass
  `terminal: false` to `readline.createInterface`, so readline does not
  manipulate the line; the pre-written prompt stays visible and input is read
  via the TTY's cooked-mode echo.
- Both functions now take an injectable `createInterface` factory and are
  exported.
- **Regression guard:** new hermetic tests in `tests/cli/init.test.js` and
  `tests/onboard/onboard-workflow.test.js` assert `terminal: false` is passed
  (the gap that let this through), plus the y/n/default answer mapping.

Reproduced under a real pseudo-terminal: before, raw output contained
`\x1b[0J`; after, it does not, and the full prompt renders. 34/34 tests in the
two affected suites pass; biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)