### PR TITLE
feat(cli): mandrel init banner + Welcome prompt, sync 'Installed' wording

### DIFF
--- a/lib/cli/init.js
+++ b/lib/cli/init.js
@@ -121,11 +121,12 @@ const BOOTSTRAP_SCRIPT = path.join('.agents', 'scripts', 'bootstrap.js');
 const SYNC_BIN = path.join('node_modules', PACKAGE_NAME, 'bin', 'mandrel.js');
 
 const PROMPT_TEXT =
-  'The Mandrel .agents package has been copied to your directory.\n' +
-  'Would you like to begin the interactive process to setup your local and ' +
-  'github environments now? [Y/n]: ';
+  '\n' +
+  'Welcome to Mandrel!\n\n' +
+  'Check .agents/README.md for more quick start instructions, flag options, and documentation.\n\n' +
+  'Begin interactive setup? [Y/n]: ';
 
-const FILES_ONLY_HINT = 'Configure any time with: npx mandrel init\n';
+const FILES_ONLY_HINT = 'Setup any time with: npx mandrel init\n';
 
 // ASCII banner printed once at the very top of `mandrel init`, before any
 // install/sync output streams to the terminal. Paste multi-line ASCII art

--- a/lib/cli/init.js
+++ b/lib/cli/init.js
@@ -127,6 +127,23 @@ const PROMPT_TEXT =
 
 const FILES_ONLY_HINT = 'Configure any time with: npx mandrel init\n';
 
+// ASCII banner printed once at the very top of `mandrel init`, before any
+// install/sync output streams to the terminal. Paste multi-line ASCII art
+// between the fences below. `String.raw` keeps backslashes literal so the art
+// renders exactly as pasted — the only characters to avoid inside are a
+// literal backtick and the `${` sequence. The leading/trailing blank lines
+// frame the art in the terminal.
+const BANNER = String.raw`
+
+   ______  ___             _________           ______
+   ___   |/  /_____ _____________  /______________  /
+   __  /|_/ /_  __ '/_  __ \  __  /__  ___/  _ \_  /
+   _  /  / / / /_/ /_  / / / /_/ / _  /   /  __/  /
+   /_/  /_/  \__,_/ /_/ /_/\__,_/  /_/    \___//_/
+____________________________________________________
+
+`;
+
 // On win32, `npm` resolves to a `.cmd` shim that Node refuses to spawn without
 // a shell after the CVE-2024-27980 hardening; mirror update.js and set
 // `shell: true` only there. Off win32, never shell out — array argv stays
@@ -398,6 +415,10 @@ export default async function run(argv = []) {
     );
     return;
   }
+
+  // Banner is the very first output — before the install + sync steps that
+  // planInit kicks off — so it greets the operator on a cold start.
+  process.stdout.write(BANNER);
 
   const result = await planInit({
     argv,

--- a/lib/cli/sync.js
+++ b/lib/cli/sync.js
@@ -242,7 +242,7 @@ export function runSync({
       write(`would prune ${path.join('.agents', rel)}\n`);
     }
     write(
-      `✅  Dry run: ${payloadFiles.length} file(s) would be materialized, ${stale.length} stale file(s) would be pruned from ./.agents/\n`,
+      `✅  Dry run: ${payloadFiles.length} file(s) would be installed, ${stale.length} stale file(s) would be pruned from ./.agents/\n`,
     );
     return {
       copied: 0,
@@ -275,10 +275,10 @@ export function runSync({
 
   if (staleFiles.length > 0) {
     write(
-      `✅  Materialized ${payloadFiles.length} file(s) into ./.agents/ (pruned ${staleFiles.length} stale file(s))\n`,
+      `✅  Installed ${payloadFiles.length} file(s) into ./.agents/ (pruned ${staleFiles.length} stale file(s))\n`,
     );
   } else {
-    write(`✅  Materialized ${payloadFiles.length} file(s) into ./.agents/\n`);
+    write(`✅  Installed ${payloadFiles.length} file(s) into ./.agents/\n`);
   }
   return {
     copied: payloadFiles.length,

--- a/tests/cli/init.test.js
+++ b/tests/cli/init.test.js
@@ -252,7 +252,7 @@ describe('init — yes/no prompt rendering', () => {
     });
 
     const prompt = out.join('');
-    assert.match(prompt, /begin the interactive process to setup/);
+    assert.match(prompt, /Begin interactive setup\?/);
     assert.match(prompt, /\[Y\/n\]:/);
   });
 });
@@ -315,7 +315,7 @@ describe('init — answering no skips bootstrap and prints the hint', () => {
 
     const bootstrapCall = calls.find((c) => c.cmd === process.execPath);
     assert.equal(bootstrapCall, undefined, 'no bootstrap step on files-only');
-    assert.match(out.join(''), /Configure any time with: npx mandrel init/);
+    assert.match(out.join(''), /Setup any time with: npx mandrel init/);
     assert.equal(result.ranBootstrap, false);
     assert.equal(result.exitCode, 0);
   });
@@ -397,7 +397,7 @@ describe('init — non-TTY stdin defaults to files-only', () => {
     );
     const bootstrapCall = calls.find((c) => c.cmd === process.execPath);
     assert.equal(bootstrapCall, undefined, 'must never provision unattended');
-    assert.match(out.join(''), /Configure any time with: npx mandrel init/);
+    assert.match(out.join(''), /Setup any time with: npx mandrel init/);
     assert.equal(result.ranBootstrap, false);
     assert.equal(result.exitCode, 0);
   });


### PR DESCRIPTION
## Why

Consumer-facing copy polish for the `mandrel` CLI surface.

## What changed

- **lib/cli/init.js**
  - Print a MANDREL ASCII banner as the first output of `mandrel init` (via
    `String.raw` so the art renders verbatim).
  - Reword the prompt from "package has been copied / begin the interactive
    process" to a "Welcome to Mandrel!" message that points at
    `.agents/README.md` for quick-start docs; shorten the files-only hint to
    "Setup any time with: npx mandrel init".
- **lib/cli/sync.js** — reword the materialize-success lines from
  "Materialized" to "Installed" (real run, prune, and dry-run variants).
- **tests/cli/init.test.js** — update the prompt-rendering and files-only-hint
  assertions to the new copy.

Pure copy/UX; no behavioral change. 20/20 init tests pass; biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)