### PR TITLE
chore(bootstrap): GitHub capitalization in prompts + drop stale detect-stack refs

### DIFF
--- a/.agents/scripts/bootstrap.js
+++ b/.agents/scripts/bootstrap.js
@@ -539,7 +539,7 @@ export function buildQuestions(defaults, flags, env = process.env, lists = {}) {
       key: 'owner',
       flag: 'owner',
       env: 'GH_OWNER',
-      message: '\n\nGithub repo owner',
+      message: '\n\nGitHub repo owner',
       default: defaults.owner,
       required: true,
       validate: (v) =>
@@ -550,7 +550,7 @@ export function buildQuestions(defaults, flags, env = process.env, lists = {}) {
       flag: 'operator-handle',
       env: 'GH_OPERATOR_HANDLE',
       message:
-        'Github username/handle without preceding@ (default: same as owner)',
+        'GitHub username/handle without preceding@ (default: same as owner)',
       // Default tracks the repo owner; resolved post-collect if left blank.
       default: defaults.owner,
       required: false,

--- a/.agents/scripts/lib/detect-package-manager.js
+++ b/.agents/scripts/lib/detect-package-manager.js
@@ -1,11 +1,11 @@
 /**
  * detect-package-manager — shared lockfile-probe helper (Story #4048 B3).
  *
- * Five independent copies of this lockfile probe existed across the codebase:
+ * Several independent copies of this lockfile probe existed across the
+ * codebase before this consolidation:
  *   - `lib/cli/update.js#detectPackageManager`
  *   - `lib/bootstrap/project-bootstrap.js#detectPackageManager`
  *   - `lib/runtime-deps/preflight.js#detectPackageManager`
- *   - `lib/onboard/detect-stack.js#detectPackageManager`
  *   - `lib/worktree/node-modules-strategy.js#selectInstallCommand` (inline)
  *
  * This module is the single authoritative implementation. It uses the

--- a/tests/scripts/detect-package-manager.test.js
+++ b/tests/scripts/detect-package-manager.test.js
@@ -1,23 +1,21 @@
 /**
  * Unit tests for the shared lockfile-probe helper (Story #4048 B3).
  *
- * Prior to this story, five independent `detectPackageManager` implementations
- * existed across the codebase with subtly different semantics:
+ * Prior to this story, several independent `detectPackageManager`
+ * implementations existed across the codebase with subtly different semantics:
  *
  *   - `lib/cli/update.js`              → returns { packageManager, workspaceRoot }
  *   - `lib/bootstrap/project-bootstrap.js` → returns 'pnpm'|'yarn'|'npm'
  *   - `lib/runtime-deps/preflight.js`  → returns 'pnpm'|'yarn'|'npm'
- *   - `lib/onboard/detect-stack.js`    → returns 'pnpm'|'yarn'|'bun'|'npm'|null
  *   - `lib/worktree/node-modules-strategy.js` (inline probe)
  *
  * This suite exercises the unified `detectPackageManager` and
  * `detectPackageManagerWithWorkspace` functions and covers the edge cases that
  * previously diverged:
  *
- *   - `detect-stack.js` returned `null` when no manifest existed at all;
- *     the other copies defaulted to `'npm'`. The shared helper returns `null`.
- *   - `detect-stack.js` detected `bun` from `bun.lockb`; the other copies
- *     did not. The shared helper detects `bun`.
+ *   - When no manifest exists at all, some copies defaulted to `'npm'`; the
+ *     shared helper returns `null`.
+ *   - The shared helper detects `bun` from `bun.lockb` (some copies did not).
  *   - `update.js` needed `workspaceRoot`; the others did not.
  *     `detectPackageManagerWithWorkspace` provides that.
  */
@@ -61,7 +59,7 @@ describe('detectPackageManager', () => {
     );
   });
 
-  it('detects bun from bun.lockb (strictest semantics from detect-stack.js)', () => {
+  it('detects bun from bun.lockb (strictest unified semantics)', () => {
     assert.equal(
       detectPackageManager('/root', makeExists(['bun.lockb'])),
       'bun',


### PR DESCRIPTION
## Why

Two small follow-ups to the bootstrap/init copy cleanup:

1. **Brand capitalization** — the two user-facing bootstrap prompts said "Github"; corrected to "GitHub". (Only the displayed prompt labels are touched — internal identifiers like `skipGithub`/`createGithubRepo` are intentionally left alone.)
2. **Stale references** — the historical lineage comments in `detect-package-manager.js` and its test pointed at `lib/onboard/detect-stack.js`, which was removed in #4113. Updated the prose to keep the semantic notes (null-on-no-manifest, `bun` detection) without naming the deleted file.

Pure copy/comment changes; no behavioral change. Syntax + biome clean; affected suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)