### PR TITLE
feat: route `/qa-assist` and `/qa-explore` triage into `/plan` and harden both QA loops (#4115)

### DIFF
--- a/.agents/workflows/qa-assist.md
+++ b/.agents/workflows/qa-assist.md
@@ -239,24 +239,61 @@ and optionally route or promote it — with the operator deciding each write.
    `regression-of-closed`. Stamp the `fingerprintFooter(sha)` marker into any
    Issue body so future runs dedup against it.
 
-3. **Optionally promote** the finding to a follow-up ticket via
+3. **Promote `file`-dispositioned findings through `/plan`** (never a raw
+   GitHub Issue) via
    [`promote-finding.js`](../scripts/lib/findings/promote-finding.js), which
-   clusters, routes, and files through the same ports — never hand-roll the
-   promotion:
+   clusters, sizes, routes, and files through the same ports `/qa-explore` and
+   `/audit-to-stories` consume — never hand-roll the promotion, the clustering,
+   or the sizing:
 
    ```js
    import { promoteFindings } from '../scripts/lib/findings/promote-finding.js';
-   const promotions = await promoteFindings(ledgerItems, { searchIssues, createStory });
+   const { promotions } = await promoteFindings(ledgerItems, {
+     searchIssues, // GitHub provider, open + closed
+     createStory, // tight cluster (≤2 surfaces): render seed → /plan --from-notes
+     createEpic, // broad cluster (>2 surfaces): render seed → /plan --idea
+   });
    ```
 
-4. **Gate:** any ledger append, ticket-filing, or label mutation is a write —
-   confirm **each one** with the operator before it happens. Redaction has
-   already run, so nothing unredacted reaches disk or GitHub.
+   - **Sizing is delegated, not decided in prose.** `promoteFindings` runs
+     `clusterLedgerItems` + `targetForCluster`: a cluster spanning **≤2**
+     distinct coverage surfaces routes to `createStory`; **>2** routes to
+     `createEpic`. Do not re-cluster, re-size, or re-dedup in the workflow —
+     [`route-finding.js`](../scripts/lib/findings/route-finding.js) /
+     [`promote-finding.js`](../scripts/lib/findings/promote-finding.js) are the
+     single implementation.
+   - **`createStory` (`/plan --from-notes`)** — render a **redacted**
+     `--from-notes` seed from the cluster (reuse the `/audit-to-stories`
+     Phase 5b notes shape; redaction already ran in Phase 2), **stamp the
+     cluster's `fingerprintFooter(sha)` verbatim into the seed body**, then
+     chain `/plan --from-notes <seed>`. The footer must survive into the issue
+     body the Story create path writes — it round-trips through
+     `story-plan.js --body <file> --dry-run` unchanged (asserted by the
+     deterministic round-trip test under `tests/`) so a later `routeFinding`
+     dedups the same finding instead of re-filing it.
+   - **`createEpic` (`/plan --idea`)** — carry the cluster's
+     `fingerprintFooter(sha)` into the `/plan --idea` seed, then chain
+     `/plan --idea <seed>`. **Known limitation (not solved here):**
+     per-child-Story fingerprint propagation through full Epic decomposition is
+     *not* guaranteed — the fingerprint is carried in the Epic seed only; the
+     child Stories `/plan` spawns from that seed are not individually
+     footer-stamped.
+   - **A `file` disposition never opens a raw GitHub Issue.** Every `file`
+     finding flows through `promoteFindings` → `/plan`; only `defer` (carry
+     forward as backlog) and `dismiss` (non-actionable) skip the `/plan`
+     handoff.
+
+4. **Gate:** any ledger append, seed write, `/plan` invocation, ticket-filing,
+   or label mutation is a write — confirm **each one** with the operator before
+   it happens. The plan→deliver hard stop is preserved: each `/plan` chain
+   pauses at its own HITL gates and never auto-delivers. Redaction has already
+   run, so nothing unredacted reaches disk or GitHub.
 
 After recording, summarize: the finding recorded, its coverage verdict and
 `missingTest`, any route/promotion decision
-(`new`/`update-existing`/`duplicate`/`regression-of-closed`), and the rolling
-backlog a resumed session will pick up.
+(`new`/`update-existing`/`duplicate`/`regression-of-closed`) and whether it was
+promoted to a Story (`/plan --from-notes`) or Epic (`/plan --idea`), and the
+rolling backlog a resumed session will pick up.
 
 ---
 
@@ -291,3 +328,24 @@ backlog a resumed session will pick up.
   promotion ([`promote-finding.js`](../scripts/lib/findings/promote-finding.js)),
   and session resolution ([`qa-session.js`](../scripts/lib/qa/qa-session.js))
   are deterministic — never re-derive them in prose.
+- **Promote through `/plan`, never a raw Issue.** A `file`-dispositioned
+  finding is promoted via `promoteFindings`, which chains into
+  [`/plan`](plan.md) (`--from-notes` for a tight cluster, `--idea` for a broad
+  one) — mirroring [`/audit-to-stories`](audit-to-stories.md). `/qa-assist`
+  never opens a bare GitHub Issue for a `file` finding. The cluster's
+  `fingerprintFooter(sha)` is stamped verbatim into the seed so a future
+  `routeFinding` dedups it.
+
+## See also
+
+- [`/plan`](plan.md) — the planning pipeline `/qa-assist` chains into when an
+  operator dispositions a finding `file` (`--from-notes` for a Story, `--idea`
+  for an Epic). The plan→deliver hard stop is preserved across the handoff.
+- [`/qa-explore`](qa-explore.md) — the agent-led sibling that drives a named
+  surface and triages through the same `/plan` handoff.
+- [`/audit-to-stories`](audit-to-stories.md) — the precedent for the
+  findings → `/plan` handoff and the shared fingerprint-footer dedup contract.
+- [`promote-finding.js`](../scripts/lib/findings/promote-finding.js) /
+  [`route-finding.js`](../scripts/lib/findings/route-finding.js) — the shared
+  cluster/size/promote and dedup/route/fingerprint-footer helpers. There is no
+  second clustering, sizing, or dedup implementation.

--- a/.agents/workflows/qa-explore.md
+++ b/.agents/workflows/qa-explore.md
@@ -296,19 +296,62 @@ For each untriaged ledger item:
    `searchIssues` port to the GitHub provider (querying both open and closed
    Issues).
 
-3. **Decide the disposition** with the operator: `file` (promote to a
-   follow-up ticket with the classified labels + fingerprint footer), `defer`
-   (carry forward to a later session as backlog), or `dismiss` (non-actionable).
-   Record the chosen `disposition` back onto the ledger item.
+3. **Decide the disposition** with the operator: `file` (promote through
+   `/plan` — never a raw GitHub Issue), `defer` (carry forward to a later
+   session as backlog), or `dismiss` (non-actionable). Record the chosen
+   `disposition` back onto the ledger item.
 
-4. **Gate:** any ticket-filing or label mutation is a write — confirm each one
-   with the operator before it happens. Capture stayed read-only precisely so
-   that every state change lands here, deliberately and confirmed.
+4. **Promote the `file`-dispositioned findings through `/plan`** via
+   [`promote-finding.js`](../scripts/lib/findings/promote-finding.js) — the
+   same cluster/size/route/file path `/qa-assist` and `/audit-to-stories`
+   consume. Never hand-roll the clustering, sizing, or promotion in prose:
+
+   ```js
+   import { promoteFindings } from '../scripts/lib/findings/promote-finding.js';
+   const { promotions } = await promoteFindings(ledgerItems, {
+     searchIssues, // GitHub provider, open + closed
+     createStory, // tight cluster (≤2 surfaces): render seed → /plan --from-notes
+     createEpic, // broad cluster (>2 surfaces): render seed → /plan --idea
+   });
+   ```
+
+   - **Sizing is delegated, not decided in prose.** `promoteFindings` runs
+     `clusterLedgerItems` + `targetForCluster`: a cluster spanning **≤2**
+     distinct coverage surfaces routes to `createStory`; **>2** routes to
+     `createEpic`. The workflow introduces no new sizing, clustering, or dedup
+     logic — `route-finding.js` / `promote-finding.js` remain the single
+     implementation.
+   - **`createStory` (`/plan --from-notes`)** — render a **redacted**
+     `--from-notes` seed from the cluster (reuse the `/audit-to-stories`
+     Phase 5b notes shape; redaction already ran in Capture), **stamp the
+     cluster's `fingerprintFooter(sha)` verbatim into the seed body**, then
+     chain `/plan --from-notes <seed>`. The footer must survive into the issue
+     body the Story create path writes — it round-trips through
+     `story-plan.js --body <file> --dry-run` unchanged (asserted by the
+     deterministic round-trip test under `tests/`) so a later `routeFinding`
+     dedups the same finding instead of re-filing it.
+   - **`createEpic` (`/plan --idea`)** — carry the cluster's
+     `fingerprintFooter(sha)` into the `/plan --idea` seed, then chain
+     `/plan --idea <seed>`. **Known limitation (not solved here):**
+     per-child-Story fingerprint propagation through full Epic decomposition is
+     *not* guaranteed — the fingerprint is carried in the Epic seed only; the
+     child Stories `/plan` spawns from that seed are not individually
+     footer-stamped.
+   - **A `file` disposition never opens a raw GitHub Issue.** Every `file`
+     finding flows through `promoteFindings` → `/plan`; only `defer` and
+     `dismiss` skip the `/plan` handoff.
+
+5. **Gate:** any ticket-filing, seed write, `/plan` invocation, or label
+   mutation is a write — confirm each one with the operator before it happens.
+   Capture stayed read-only precisely so that every state change lands here,
+   deliberately and confirmed. The plan→deliver hard stop is preserved: each
+   `/plan` chain pauses at its own HITL gates and never auto-delivers.
 
 After triage, write the updated dispositions back to the ledger (still under
 `temp/qa/`), and summarize: items captured, the driving method used, classes,
-routes (`new`/`update-existing`/`duplicate`/`regression-of-closed`), filed
-tickets, and the deferred rolling backlog that a resumed session will pick up.
+routes (`new`/`update-existing`/`duplicate`/`regression-of-closed`), the
+Stories (`/plan --from-notes`) and Epics (`/plan --idea`) promoted, and the
+deferred rolling backlog that a resumed session will pick up.
 
 ---
 
@@ -343,8 +386,31 @@ tickets, and the deferred rolling backlog that a resumed session will pick up.
   ([`coverage-verdict.js`](../scripts/lib/qa/coverage-verdict.js)),
   missing-test ([`propose-missing-test.js`](../scripts/lib/qa/propose-missing-test.js)),
   classification ([`classify-finding.js`](../scripts/lib/findings/classify-finding.js)),
-  and dedup/route ([`route-finding.js`](../scripts/lib/findings/route-finding.js))
-  are deterministic — never re-derive them in prose.
+  dedup/route ([`route-finding.js`](../scripts/lib/findings/route-finding.js)),
+  and cluster/size/promote
+  ([`promote-finding.js`](../scripts/lib/findings/promote-finding.js)) are
+  deterministic — never re-derive them in prose.
+- **Promote through `/plan`, never a raw Issue.** A `file`-dispositioned
+  finding is promoted via `promoteFindings`, which chains into
+  [`/plan`](plan.md) (`--from-notes` for a tight cluster, `--idea` for a broad
+  one) — mirroring [`/audit-to-stories`](audit-to-stories.md). `/qa-explore`
+  never opens a bare GitHub Issue for a `file` finding. The cluster's
+  `fingerprintFooter(sha)` is stamped verbatim into the seed so a future
+  `routeFinding` dedups it.
 - **Resume safely.** A reused session appends and carries the un-triaged
   backlog forward via [`qa-session.js`](../scripts/lib/qa/qa-session.js); it
   never overwrites a prior ledger.
+
+## See also
+
+- [`/plan`](plan.md) — the planning pipeline `/qa-explore` Triage chains into
+  for a `file`-dispositioned finding (`--from-notes` for a Story, `--idea` for
+  an Epic). The plan→deliver hard stop is preserved across the handoff.
+- [`/qa-assist`](qa-assist.md) — the human-led sibling that enriches a single
+  operator observation and triages through the same `/plan` handoff.
+- [`/audit-to-stories`](audit-to-stories.md) — the precedent for the
+  findings → `/plan` handoff and the shared fingerprint-footer dedup contract.
+- [`promote-finding.js`](../scripts/lib/findings/promote-finding.js) /
+  [`route-finding.js`](../scripts/lib/findings/route-finding.js) — the shared
+  cluster/size/promote and dedup/route/fingerprint-footer helpers. There is no
+  second clustering, sizing, or dedup implementation.

--- a/tests/qa-promote-footer-roundtrip.test.js
+++ b/tests/qa-promote-footer-roundtrip.test.js
@@ -1,0 +1,151 @@
+/**
+ * tests/qa-promote-footer-roundtrip.test.js — Story #4115.
+ *
+ * The `/qa-assist` and `/qa-explore` Triage paths promote a
+ * `file`-dispositioned finding through `/plan` (never a raw GitHub Issue).
+ * For a tight cluster the seam is `createStory` → `/plan --from-notes`, which
+ * persists through `story-plan.js --body <file>`. The dedup contract
+ * (`route-finding.js`) only works on a *re*-run if the cluster's
+ * `fingerprintFooter(sha)` survives verbatim into the issue body that the
+ * Story create path writes — otherwise a future `routeFinding` re-files the
+ * same finding instead of recognising it.
+ *
+ * This is a **contract** test of that round-trip: it does NOT add a new
+ * `--fingerprint` flag (per the operator's decision); it asserts that the
+ * existing `story-plan.js --body <file> --dry-run` resolved body carries the
+ * footer unchanged, and that `parseFingerprintFooter` recovers the exact sha a
+ * subsequent `routeFinding` would key off. The dry-run path is deterministic
+ * and touches no network, so the assertion is hermetic.
+ *
+ * Three legs:
+ *   (a) The resolved body the Story create path would send carries the footer
+ *       byte-for-byte, and `parseFingerprintFooter` recovers the same sha.
+ *   (b) The `--body-file` argv points at the unmodified seed file, so the
+ *       footer the seam wrote is the footer GitHub receives.
+ *   (c) The full promote → fingerprint identity is stable end to end: the sha
+ *       a cluster fingerprints to is exactly the sha that survives the
+ *       round-trip, closing the dedup loop.
+ */
+
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, it } from 'node:test';
+import { fileURLToPath } from 'node:url';
+import { __testing as promoteTesting } from '../.agents/scripts/lib/findings/promote-finding.js';
+import {
+  fingerprintFinding,
+  fingerprintFooter,
+  parseFingerprintFooter,
+} from '../.agents/scripts/lib/findings/route-finding.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const PROJECT_ROOT = path.resolve(__dirname, '..');
+const CLI = path.join(PROJECT_ROOT, '.agents', 'scripts', 'story-plan.js');
+
+const { clusterToFinding } = promoteTesting;
+
+/**
+ * Render a minimal but schema-valid standalone Story seed body (the shape
+ * `/plan --from-notes` produces) carrying the fingerprint footer the
+ * `createStory` promotion seam stamps in.
+ */
+function renderSeedBody(sha) {
+  return `# Address qa-coverage findings in feature:login
+
+## Context
+
+A clustered QA finding promoted from a /qa-explore session.
+
+## Acceptance Criteria
+
+- [ ] Close the coverage gap the finding surfaced.
+
+## Out of Scope
+
+Anything beyond the named surface.
+
+## Notes
+
+Promoted via promoteFindings → /plan --from-notes.
+
+${fingerprintFooter(sha)}
+`;
+}
+
+describe('qa promote → /plan footer round-trip (Story #4115)', () => {
+  let tmp;
+  // A representative cluster, shaped exactly as `clusterToFinding` emits so the
+  // fingerprint matches what production routing computes.
+  const cluster = {
+    title: 'Address 2 test-gap findings in feature:login',
+    coverages: ['feature:login'],
+    class: 'test-gap',
+    severity: 'high',
+  };
+  const finding = clusterToFinding(cluster);
+  const { full: sha } = fingerprintFinding(finding);
+
+  beforeEach(() => {
+    tmp = mkdtempSync(path.join(os.tmpdir(), 'qa-footer-'));
+  });
+  afterEach(() => {
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it('preserves the fingerprint footer verbatim in the resolved --from-notes body', () => {
+    const seedPath = path.join(tmp, 'seed.md');
+    writeFileSync(seedPath, renderSeedBody(sha));
+
+    const r = spawnSync('node', [CLI, '--body', seedPath, '--dry-run'], {
+      cwd: PROJECT_ROOT,
+      encoding: 'utf8',
+    });
+    assert.equal(r.status, 0, `stderr: ${r.stderr}`);
+
+    // The resolved body the Story create path would send is echoed under the
+    // `--- BODY ---` marker. The footer must survive byte-for-byte.
+    const combined = `${r.stdout}\n${r.stderr}`;
+    const expectedFooter = fingerprintFooter(sha);
+    assert.ok(
+      combined.includes(expectedFooter),
+      `expected the resolved body to carry "${expectedFooter}" verbatim`,
+    );
+
+    // And a future routeFinding must recover the exact same sha from it.
+    const recovered = parseFingerprintFooter(combined);
+    assert.deepEqual(recovered, [sha]);
+  });
+
+  it('points the gh --body-file argv at the unmodified seed file', () => {
+    const seedPath = path.join(tmp, 'seed.md');
+    writeFileSync(seedPath, renderSeedBody(sha));
+
+    const r = spawnSync('node', [CLI, '--body', seedPath, '--dry-run'], {
+      cwd: PROJECT_ROOT,
+      encoding: 'utf8',
+    });
+    assert.equal(r.status, 0, `stderr: ${r.stderr}`);
+
+    const parsed = JSON.parse(r.stdout.slice(r.stdout.indexOf('{')));
+    assert.equal(parsed.dryRun, true);
+    // The body GitHub receives IS the on-disk seed (which carries the footer);
+    // the create path never rewrites it.
+    const bodyFileIdx = parsed.argv.indexOf('--body-file');
+    assert.notEqual(bodyFileIdx, -1, 'argv must carry --body-file');
+    assert.equal(parsed.argv[bodyFileIdx + 1], seedPath);
+  });
+
+  it('keeps the cluster fingerprint stable end to end (dedup loop closes)', () => {
+    // The sha a cluster fingerprints to is exactly the sha the footer carries,
+    // so a re-promotion of the same cluster routes against the same identity.
+    const reFinding = clusterToFinding(cluster);
+    const { full: reSha } = fingerprintFinding(reFinding);
+    assert.equal(reSha, sha);
+
+    const body = renderSeedBody(sha);
+    assert.deepEqual(parseFingerprintFooter(body), [reSha]);
+  });
+});


### PR DESCRIPTION
Closes #4115

_Auto-opened by `/single-story-deliver`._