### PR TITLE
feat: plan: auto-select acceptance::n-a when no BDD runner (avoid manual finalize unblock on node:test repos) (#4145)

### DIFF
--- a/.agents/scripts/lib/orchestration/epic-plan-spec/phases/run-spec-phase.js
+++ b/.agents/scripts/lib/orchestration/epic-plan-spec/phases/run-spec-phase.js
@@ -7,6 +7,7 @@
  */
 
 import path from 'node:path';
+import { verifyBddRunnerPendingTag } from '../../../bdd-runner-detect.js';
 import { Logger } from '../../../Logger.js';
 import { AGENT_LABELS, TYPE_LABELS } from '../../../label-constants.js';
 import { cleanupPhaseTempFiles } from '../../../plan-phase-cleanup.js';
@@ -45,12 +46,20 @@ function buildRiskVerdictCommentBody({ epicId, riskVerdict, planningRisk }) {
     verdict: riskVerdict,
     planningRisk,
   };
+  // Story #4145 — when the disposition was forced to not-applicable because
+  // no BDD runner exists, make the waiver operator-visible in the rendered
+  // comment (not just the fenced JSON record) so a reviewer sees why an
+  // otherwise-required AC table was waived.
+  const waiverNote = planningRisk.acceptanceWaivedReason
+    ? ['', `> ⚠️ **Acceptance waived** — ${planningRisk.acceptanceWaivedReason}`]
+    : [];
   return [
     `### 🧭 Planning Risk Verdict — ${planningRisk.overallLevel} · ${planningRisk.gateDecision}`,
     '',
     riskVerdict.summary,
     '',
     ...axisTable,
+    ...waiverNote,
     '',
     '```json',
     JSON.stringify(record, null, 2),
@@ -99,7 +108,29 @@ export async function runSpecPhase(
       '[epic-plan-spec] risk verdict is required — author risk-verdict.json via the epic-plan-spec-author Skill and pass it with --risk-verdict.',
     );
   }
-  const planningRisk = deriveRiskEnvelope(riskVerdict);
+
+  // Story #4145 — probe the project's BDD runner. When none is detected
+  // (`fallback === true`, e.g. a node:test repo with no tests/features/**),
+  // the acceptance disposition is forced to not-applicable inside
+  // deriveRiskEnvelope: an authored AC table could never be reconciled by
+  // `@epic-<id>-ac-*` feature tags, so /deliver finalize would otherwise
+  // abort and require a manual `acceptance::n-a`. The probe is static and
+  // best-effort — a detection failure degrades to "runner present" (no
+  // forced waiver), preserving the BDD-repo path, and never blocks Phase 7.
+  let bddRunner = null;
+  try {
+    bddRunner = await verifyBddRunnerPendingTag({ cwd: PROJECT_ROOT });
+  } catch (err) {
+    Logger.warn(
+      `[epic-plan-spec] BDD runner probe skipped (${err.message}); acceptance disposition derived from risk axes only.`,
+    );
+  }
+  const planningRisk = deriveRiskEnvelope(riskVerdict, { bddRunner });
+  if (planningRisk.acceptanceWaivedReason) {
+    Logger.info(
+      `[epic-plan-spec] Acceptance disposition forced to not-applicable for Epic #${epicId}: ${planningRisk.acceptanceWaivedReason}`,
+    );
+  }
 
   const epic = await provider.getEpic(epicId);
   if (!epic) {

--- a/.agents/scripts/lib/orchestration/planning-risk.js
+++ b/.agents/scripts/lib/orchestration/planning-risk.js
@@ -37,6 +37,18 @@
  * @property {boolean} requiresReview
  * @property {AcceptanceDisposition} acceptanceDisposition
  * @property {GateDecision} gateDecision
+ * @property {string} [acceptanceWaivedReason] Present only when the
+ *   acceptance disposition was forced to `not-applicable` by a non-axis
+ *   signal (currently: no BDD runner detected). An operator-visible
+ *   rationale so the override is never silent (Story #4145).
+ */
+
+/**
+ * @typedef {Object} BddRunnerProbe
+ * @property {string|null} runner
+ * @property {boolean} fallback `true` when no supported BDD runner was
+ *   detected in the project (`verifyBddRunnerPendingTag`).
+ * @property {string} [reason]
  */
 
 const LEVEL_RANK = Object.freeze({ low: 0, medium: 1, high: 2 });
@@ -129,27 +141,54 @@ function resolveRequiresReview(overallLevel, axes) {
  * (`epic-plan-spec.js`), never here, so a malformed verdict fails closed
  * before this function runs.
  *
+ * **No-BDD-runner waiver (Story #4145).** The acceptance disposition the risk
+ * axes derive presumes a BDD runner exists to satisfy an authored AC table.
+ * When `opts.bddRunner.fallback === true` (no supported runner detected — e.g.
+ * a `node:test` repo with no `tests/features/**`), an authored AC table can
+ * never be reconciled by `@epic-<id>-ac-*` feature tags, so `/deliver`
+ * finalize would abort. In that case the disposition is **forced** to
+ * `not-applicable` regardless of the risk axes, and `acceptanceWaivedReason`
+ * records the override so it is operator-visible, not silent. The
+ * `requiresReview` / `gateDecision` outputs are unaffected — a high-risk
+ * Epic still routes to review; only the acceptance-spec requirement is
+ * waived. Repos that ship a BDD runner (`fallback !== true`) are unaffected.
+ *
  * @param {RiskVerdict} [verdict]
+ * @param {{ bddRunner?: BddRunnerProbe|null }} [opts]
  * @returns {PlanningRiskEnvelope}
  */
-export function deriveRiskEnvelope(verdict = {}) {
+export function deriveRiskEnvelope(verdict = {}, { bddRunner = null } = {}) {
   const axes = (Array.isArray(verdict.axes) ? verdict.axes : []).map(
     ({ axis, level, rationale }) => ({ axis, level, rationale }),
   );
 
   const overallLevel = resolveOverallLevel(axes);
-  const acceptanceDisposition = resolveAcceptanceDisposition(
-    axes,
-    overallLevel,
-  );
+  const axisDisposition = resolveAcceptanceDisposition(axes, overallLevel);
   const requiresReview = resolveRequiresReview(overallLevel, axes);
   const gateDecision = requiresReview ? 'review-required' : 'auto-proceed';
 
-  return {
+  const noBddRunner = bddRunner?.fallback === true;
+  // Force the waiver only when the axes would otherwise have required (or
+  // recommended) an AC table; if the disposition is already not-applicable
+  // there is nothing to override and no waiver rationale to surface.
+  const forceWaiver = noBddRunner && axisDisposition !== 'not-applicable';
+  const acceptanceDisposition = forceWaiver
+    ? 'not-applicable'
+    : axisDisposition;
+
+  /** @type {PlanningRiskEnvelope} */
+  const envelope = {
     axes,
     overallLevel,
     requiresReview,
     acceptanceDisposition,
     gateDecision,
   };
+  if (forceWaiver) {
+    envelope.acceptanceWaivedReason =
+      `no BDD runner detected (${bddRunner?.reason ?? 'no-bdd-runner-detected'}) — ` +
+      `an authored acceptance-spec AC table cannot be reconciled by feature tags, ` +
+      `so the acceptance disposition is waived to not-applicable (was ${axisDisposition}).`;
+  }
+  return envelope;
 }

--- a/tests/epic-plan-spec-acceptance-disposition.test.js
+++ b/tests/epic-plan-spec-acceptance-disposition.test.js
@@ -1,0 +1,145 @@
+/**
+ * tests/epic-plan-spec-acceptance-disposition.test.js — Story #4145.
+ *
+ * Unit contract for the no-BDD-runner acceptance waiver in
+ * `deriveRiskEnvelope`. When the project ships no supported BDD runner
+ * (`bddRunner.fallback === true`, e.g. a node:test repo with no
+ * `tests/features/**`), an authored acceptance-spec AC table can never be
+ * reconciled by `@epic-<id>-ac-*` feature tags, so `/deliver` finalize would
+ * abort and force a manual `acceptance::n-a`. The waiver forces the
+ * acceptance disposition to `not-applicable` for those repos so finalize
+ * succeeds without manual label surgery — while leaving repos WITH a runner
+ * (and the review gate) untouched, and keeping the override operator-visible
+ * via `acceptanceWaivedReason`.
+ */
+
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { deriveRiskEnvelope } from '../.agents/scripts/lib/orchestration/planning-risk.js';
+
+const REQUIRED_AXIS_VERDICT = {
+  axes: [
+    {
+      axis: 'visible-behavior',
+      level: 'high',
+      rationale: 'Changes a user-visible delivery flow.',
+    },
+  ],
+  summary: 'Required-axis change that would normally author an AC table.',
+};
+
+const RECOMMENDED_AXIS_VERDICT = {
+  axes: [
+    {
+      axis: 'internal-refactor',
+      level: 'medium',
+      rationale: 'Medium-blast-radius internal refactor.',
+    },
+  ],
+  summary: 'Recommended disposition under risk axes alone.',
+};
+
+const DOCS_ONLY_VERDICT = {
+  axes: [
+    {
+      axis: 'docs-only',
+      level: 'low',
+      rationale: 'Prose-only updates; no executable surface.',
+    },
+  ],
+  summary: 'Documentation cleanup; already not-applicable.',
+};
+
+const NO_RUNNER = Object.freeze({
+  runner: null,
+  pendingTag: null,
+  supported: false,
+  fallback: true,
+  reason: 'no-bdd-runner-detected',
+});
+
+const BDD_RUNNER_PRESENT = Object.freeze({
+  runner: 'playwright-bdd',
+  pendingTag: '@skip',
+  supported: true,
+  fallback: false,
+});
+
+describe('deriveRiskEnvelope — no-BDD-runner acceptance waiver (Story #4145)', () => {
+  it('forces not-applicable when a required-axis verdict meets no BDD runner', () => {
+    const result = deriveRiskEnvelope(REQUIRED_AXIS_VERDICT, {
+      bddRunner: NO_RUNNER,
+    });
+
+    // Without the waiver this verdict would derive `required`.
+    assert.strictEqual(result.acceptanceDisposition, 'not-applicable');
+  });
+
+  it('records an operator-visible waiver rationale (not silent)', () => {
+    const result = deriveRiskEnvelope(REQUIRED_AXIS_VERDICT, {
+      bddRunner: NO_RUNNER,
+    });
+
+    assert.ok(
+      typeof result.acceptanceWaivedReason === 'string' &&
+        result.acceptanceWaivedReason.length > 0,
+      'expected a non-empty acceptanceWaivedReason',
+    );
+    assert.match(result.acceptanceWaivedReason, /no BDD runner/i);
+    // Surfaces the original axis-derived disposition for the audit trail.
+    assert.match(result.acceptanceWaivedReason, /required/);
+    assert.match(result.acceptanceWaivedReason, /no-bdd-runner-detected/);
+  });
+
+  it('also waives a recommended disposition when no BDD runner exists', () => {
+    const result = deriveRiskEnvelope(RECOMMENDED_AXIS_VERDICT, {
+      bddRunner: NO_RUNNER,
+    });
+
+    assert.strictEqual(result.acceptanceDisposition, 'not-applicable');
+    assert.ok(result.acceptanceWaivedReason);
+    assert.match(result.acceptanceWaivedReason, /recommended/);
+  });
+
+  it('does not stamp a waiver reason when the disposition was already not-applicable', () => {
+    const result = deriveRiskEnvelope(DOCS_ONLY_VERDICT, {
+      bddRunner: NO_RUNNER,
+    });
+
+    assert.strictEqual(result.acceptanceDisposition, 'not-applicable');
+    assert.strictEqual(result.acceptanceWaivedReason, undefined);
+  });
+
+  it('leaves a required disposition intact when a BDD runner is present', () => {
+    const result = deriveRiskEnvelope(REQUIRED_AXIS_VERDICT, {
+      bddRunner: BDD_RUNNER_PRESENT,
+    });
+
+    assert.strictEqual(result.acceptanceDisposition, 'required');
+    assert.strictEqual(result.acceptanceWaivedReason, undefined);
+  });
+
+  it('leaves the disposition intact when no bddRunner probe is supplied (back-compat)', () => {
+    const noOpts = deriveRiskEnvelope(REQUIRED_AXIS_VERDICT);
+    const nullRunner = deriveRiskEnvelope(REQUIRED_AXIS_VERDICT, {
+      bddRunner: null,
+    });
+
+    assert.strictEqual(noOpts.acceptanceDisposition, 'required');
+    assert.strictEqual(noOpts.acceptanceWaivedReason, undefined);
+    assert.strictEqual(nullRunner.acceptanceDisposition, 'required');
+  });
+
+  it('waives acceptance but does NOT relax the review gate for a high-risk Epic', () => {
+    const result = deriveRiskEnvelope(REQUIRED_AXIS_VERDICT, {
+      bddRunner: NO_RUNNER,
+    });
+
+    // The acceptance-spec requirement is waived, but a high-risk Epic still
+    // routes to review — the override touches only the AC disposition.
+    assert.strictEqual(result.acceptanceDisposition, 'not-applicable');
+    assert.strictEqual(result.overallLevel, 'high');
+    assert.strictEqual(result.requiresReview, true);
+    assert.strictEqual(result.gateDecision, 'review-required');
+  });
+});


### PR DESCRIPTION
Closes #4145

_Auto-opened by `/single-story-deliver`._