### PR TITLE
fix(lifecycle): allow epicId in epic.automerge.end schema so the CLI can emit it

### DIFF
--- a/.agents/schemas/lifecycle/epic.automerge.end.schema.json
+++ b/.agents/schemas/lifecycle/epic.automerge.end.schema.json
@@ -8,7 +8,8 @@
   "properties": {
     "prUrl": { "type": "string", "format": "uri", "minLength": 1 },
     "merged": { "type": "boolean" },
-    "reason": { "type": "string" }
+    "reason": { "type": "string" },
+    "epicId": { "type": "integer", "minimum": 1 }
   },
   "additionalProperties": false
 }

--- a/tests/scripts/lifecycle-emit.test.js
+++ b/tests/scripts/lifecycle-emit.test.js
@@ -215,6 +215,32 @@ describe('lifecycle-emit ↔ epic.automerge.start schema (Story #2855)', () => {
   });
 });
 
+// `epic.automerge.end` had the same outlier shape as the #2855
+// `epic.automerge.start` schema: `additionalProperties: false` with no
+// `epicId` property. Because `lifecycle-emit.js#buildPayload` always maps
+// `--epic <id>` → `payload.epicId`, the documented `/deliver` Phase 8.5
+// ledger close-out invocation
+// `lifecycle-emit --epic <id> --event epic.automerge.end --pr-url <url>
+// --merged <true|false>` failed schema validation every time. The schema now
+// accepts `epicId` as an optional integer, matching its sibling
+// `epic.automerge.start`. This test pins the relaxation against future
+// re-tightening.
+describe('lifecycle-emit ↔ epic.automerge.end schema', () => {
+  it('epic.automerge.end accepts the injected epicId alongside prUrl + merged', async () => {
+    const out = await runLifecycleEmit({
+      event: 'epic.automerge.end',
+      payload: {
+        epicId: 90046,
+        prUrl: 'https://github.com/dsj1984/mandrel/pull/90046',
+        merged: false,
+      },
+      bus: new Bus(),
+    });
+    assert.equal(out.event, 'epic.automerge.end');
+    assert.equal(typeof out.seqId, 'number');
+  });
+});
+
 // Story #3904 — `runLifecycleEmit` previously returned `{ event, payload,
 // seqId }` and the CLI always exited 0, even when a listener (e.g. the
 // Finalizer on a `closePlanningTickets` throw, or the AcceptanceReconciler


### PR DESCRIPTION
## Root cause

`lifecycle-emit.js#buildPayload` always maps `--epic <id>` → `payload.epicId`. But `.agents/schemas/lifecycle/epic.automerge.end.schema.json` omitted `epicId` from `properties` while keeping `additionalProperties: false`. It was the lone outlier in the `epic.*` family — every sibling event (e.g. `epic.automerge.start`, `epic.merge.*`) declares `epicId` as a **non-required** optional integer.

As a result the documented `/deliver` **Phase 8.5 ledger close-out** invocation:

```
lifecycle-emit --epic <id> --event epic.automerge.end --pr-url <url> --merged <true|false>
```

failed schema validation on **every** run with:

```
Bus.emit: schema validation failed for "epic.automerge.end": / must NOT have additional properties
```

(Observed while delivering Epic #4158.)

## Fix

Match the sibling contract — add `epicId` to `properties`, copied verbatim from `epic.automerge.start`:

```json
"epicId": { "type": "integer", "minimum": 1 }
```

- `required` stays `["prUrl", "merged"]` (epicId optional, exactly like `epic.automerge.start`).
- `additionalProperties: false` is unchanged.
- `lifecycle-emit.js` is **not** touched — the injection was already correct; the schema was wrong.

## Test

Added a fail-before/pass-after test in `tests/scripts/lifecycle-emit.test.js` that drives the real emit path for `epic.automerge.end` with `{ epicId, prUrl, merged }` and asserts it validates and emits, mirroring the existing `epic.automerge.start` (Story #2855) test.

- **Fail-before:** against the unfixed schema the test fails with the exact reported error (`/ must NOT have additional properties`).
- **Pass-after:** validates cleanly with the one-line schema addition.
- `tests/lifecycle/schema-registry.test.js` still passes (11/11).

## Verification

- `npm run lint` → exit 0
- `npm test` → exit 0 (9244 pass, 0 fail)

🤖 Generated with [Claude Code](https://claude.com/claude-code)