### PR TITLE
fix(install-matrix): hoist mandrel runtime deps in pnpm legs so doctor is honest

### DIFF
--- a/.github/workflows/install-matrix.yml
+++ b/.github/workflows/install-matrix.yml
@@ -255,7 +255,15 @@ jobs:
               npm install --ignore-scripts "$TARBALL_PATH"
               ;;
             pnpm)
-              pnpm add --ignore-scripts "$TARBALL_PATH"
+              # `--shamefully-hoist` lifts mandrel's transitive runtime deps
+              # (ajv, js-yaml, …) to the consumer's top-level node_modules.
+              # pnpm's default isolated layout only hoists them into the `.pnpm`
+              # virtual store, which the materialized `.agents/scripts/*.js`
+              # (run from the consumer root, free-riding on consumer
+              # node_modules) cannot reach — so without this flag doctor
+              # honestly fails `runtime-deps`. This mirrors the supported pnpm
+              # consumer contract documented in .agents/README.md.
+              pnpm add --ignore-scripts --shamefully-hoist "$TARBALL_PATH"
               ;;
             yarn)
               # Classic yarn (corepack default for `yarn`) installs the tarball
@@ -464,16 +472,24 @@ jobs:
             --doctor-output "$RUNNER_TEMP/doctor-output.txt"
 
       # ── Leg: materialized-script-run (pnpm) ──────────────────────────────────
-      # Installs with pnpm (isolated layout), mandrel sync, then runs a
-      # materialized .agents/scripts/*.js from the consumer root. pnpm's
-      # isolated node_modules cannot satisfy transitive deps via free-riding
-      # on consumer node_modules — this leg exposes the anchoring fix
-      # from Story #4046 (scripts must resolve deps from the package root).
-      - name: "[script-run] Install pnpm with --ignore-scripts"
+      # Installs with pnpm, mandrel sync, then runs a materialized
+      # .agents/scripts/*.js from the consumer root. The materialized scripts
+      # use bare imports (`import Ajv from 'ajv'`) resolved from their own
+      # location, which walks up to the consumer's top-level node_modules.
+      # pnpm's default isolated layout hoists mandrel's transitive deps only
+      # into the `.pnpm` virtual store — never to the top level — so the
+      # materialized scripts (and the doctor `runtime-deps` check anchored at
+      # the consumer root, Story #4046 A2) genuinely cannot resolve them.
+      # `--shamefully-hoist` lifts them to the top level, which IS the supported
+      # pnpm consumer contract (see .agents/README.md). This leg therefore
+      # exercises the supported configuration end to end; a pnpm-without-hoist
+      # install is intentionally NOT supported (doctor correctly reports it
+      # unready).
+      - name: "[script-run] Install pnpm (--shamefully-hoist, --ignore-scripts)"
         if: matrix.leg == 'materialized-script-run'
         shell: bash
         working-directory: ${{ env.CONSUMER_DIR }}
-        run: pnpm add --ignore-scripts "$TARBALL_PATH"
+        run: pnpm add --ignore-scripts --shamefully-hoist "$TARBALL_PATH"
 
       - name: "[script-run] Materialize .agents/ (mandrel sync)"
         if: matrix.leg == 'materialized-script-run'
@@ -491,9 +507,11 @@ jobs:
         if: matrix.leg == 'materialized-script-run'
         shell: bash
         working-directory: ${{ env.CONSUMER_DIR }}
-        # mandrel doctor resolves through .agents/scripts/ which in turn
-        # must load its own deps from the package root (Story #4046 anchoring).
-        # A free-ride breakage would surface here as MODULE_NOT_FOUND.
+        # The materialized .agents/scripts/ free-ride on the consumer's
+        # top-level node_modules (Story #4046 A2 anchors the doctor runtime-deps
+        # check there to mirror that). With --shamefully-hoist applied above the
+        # deps are present at the top level; a free-ride breakage (e.g. a
+        # missing-hoist regression) would surface here as MODULE_NOT_FOUND.
         run: |
           set -o pipefail
           node "$MANDREL_BIN" doctor 2>&1 | tee "$RUNNER_TEMP/doctor-output.txt"

--- a/README.md
+++ b/README.md
@@ -69,6 +69,26 @@ explicit `npx mandrel sync` above is the belt-and-suspenders step for
 `--ignore-scripts` or sandboxed-CI installs. Run `npx mandrel doctor` any
 time to confirm the install is healthy.
 
+> **pnpm users — hoist mandrel's runtime deps.** The materialized
+> `./.agents/scripts/*.js` run from your project root and resolve their
+> third-party deps (ajv, js-yaml, …) from your top-level `node_modules`.
+> npm and yarn hoist transitive deps there automatically; pnpm's default
+> isolated layout does **not** — it keeps them in the `.pnpm` virtual store,
+> so the framework scripts (and `mandrel doctor`'s `runtime-deps` check)
+> cannot see them. Add the following to your `.npmrc` before installing:
+>
+> ```ini
+> # Lift mandrel's runtime deps to the top-level node_modules so the
+> # materialized .agents/scripts can resolve them.
+> shamefully-hoist=true
+> ```
+>
+> Prefer a surgical alternative? Replace `shamefully-hoist` with a scoped
+> `public-hoist-pattern[]=` line per package listed in
+> `.agents/runtime-deps.json` (`ajv`, `ajv-formats`, `js-yaml`, `minimatch`,
+> `picomatch`, `string-argv`, `typhonjs-escomplex`). If `mandrel doctor`
+> reports `runtime-deps missing: …`, this is the fix.
+
 `bootstrap.js` is interactive on a TTY and auto-accepts the
 owner/repo/base branch/operator handle it can infer from your local
 `git remote` and `git config user.name` — you only get prompted for

--- a/lib/cli/__tests__/registry-cwd.test.js
+++ b/lib/cli/__tests__/registry-cwd.test.js
@@ -95,6 +95,15 @@ describe('runtime-deps check — anchors at consumer project root (A2)', () => {
     assert.equal(result.ok, false);
     assert.match(result.detail, /missing-pkg/);
     assert.ok(result.remedy, 'remedy should be present');
+    // The remedy must name the real (pnpm-isolated) cause and its fix, so the
+    // operator who actually hits this — a pnpm consumer — gets actionable
+    // guidance rather than the unhelpful "run npm install" of old.
+    assert.match(result.remedy, /pnpm/i, 'remedy should mention pnpm');
+    assert.match(
+      result.remedy,
+      /hoist/i,
+      'remedy should mention the hoist fix',
+    );
   });
 
   it('is ok with no required deps', () => {

--- a/lib/cli/registry.js
+++ b/lib/cli/registry.js
@@ -371,7 +371,14 @@ function runRuntimeDeps({
   return {
     ok: false,
     detail: `missing: ${missing.join(', ')}`,
-    remedy: `Run \`npm install\` in the repository root to install missing packages: ${missing.join(', ')}`,
+    remedy:
+      'The framework runtime deps are not resolvable from the consumer root, ' +
+      'where the materialized .agents/scripts/*.js run. npm and yarn hoist ' +
+      "them automatically — run the installer if you haven't. pnpm's default " +
+      'isolated layout does NOT hoist transitive deps to the top level: add ' +
+      '`shamefully-hoist=true` (or a scoped `public-hoist-pattern[]` for ' +
+      'each dep) to your `.npmrc` and reinstall. ' +
+      `Missing: ${missing.join(', ')}`,
   };
 }
 

--- a/tests/cli/registry.test.js
+++ b/tests/cli/registry.test.js
@@ -494,7 +494,10 @@ describe('runtime-deps check', () => {
     });
     assertResultShape(result, { expectOk: false });
     assert.match(result.detail, /missing-pkg/);
-    assert.match(result.remedy, /npm install/);
+    // Remedy names the real cause (consumer-root resolution) and the pnpm
+    // hoist fix that operators who hit this actually need.
+    assert.match(result.remedy, /pnpm/i);
+    assert.match(result.remedy, /hoist/i);
   });
 
   it('returns ok=true for an empty manifest', () => {


### PR DESCRIPTION
## Why

The nightly install-matrix pnpm legs (`materialized-script-run`, `install (pnpm/*)`) fail `mandrel doctor`:
`✘ runtime-deps missing: ajv, ajv-formats, js-yaml, minimatch, picomatch, string-argv, typhonjs-escomplex`
(confirmed on scheduled run [27547129327](https://github.com/dsj1984/mandrel/actions/runs/27547129327)).

## Root cause — and why doctor is right

The materialized `.agents/scripts/*.js` run from the **consumer root** and resolve their deps via bare `import 'ajv'`, which walks `node_modules` up to the consumer top-level. npm/yarn hoist transitive deps there; **pnpm's default isolated layout keeps them in the `.pnpm` virtual store**, so the framework scripts genuinely cannot load them. `runRuntimeDeps` anchors at the consumer root (Story #4046 A2) precisely to mirror that runtime context — so the failure is **honest**, not a false negative.

Making the check resolve from `node_modules/mandrel` instead (the tempting "fix") would flip doctor to Ready while every `node .agents/scripts/*.js` invocation still crashed with `ERR_MODULE_NOT_FOUND` under pnpm isolated. That was explicitly rejected.

## Fix

- **`.github/workflows/install-matrix.yml`** — install the pnpm legs with `--shamefully-hoist` (the supported pnpm consumer contract, already used by the `update-reexec-pnpm` leg from #4173). Corrected the two backwards "resolve from the package root" comments to match #4046 A2.
- **`lib/cli/registry.js`** — runtime-deps remedy now names the real (pnpm-isolated) cause and the hoist fix, instead of the unhelpful "run `npm install`". **Anchor unchanged** (stays consumer-root / honest).
- **`README.md`** — document the pnpm hoisting requirement (`shamefully-hoist=true`, or scoped `public-hoist-pattern[]`).
- **tests** — lock the pnpm/hoist remedy guidance.

## Verification

Local pnpm 11.5.2 A/B (pack → `pnpm add` → `mandrel sync` → `mandrel doctor`):

| install | runtime-deps |
| --- | --- |
| `pnpm add` (isolated, no hoist) | `✘ missing: ajv, …` — honest fail |
| `pnpm add --shamefully-hoist` | `✔ all dependencies found` |

Registry/CLI suites green (66 tests).

## Out of scope (separate follow-up)

The `cold-start` leg also fails, but for an **orthogonal** reason: `mandrel init --assume-yes` errors with `[Bootstrap] missing required answers: owner, repo` in a throwaway non-GitHub consumer dir. Not a deps problem — tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)