### PR TITLE
fix(bootstrap): relax owner/repo under --skip-github so non-interactive init works in a fresh dir

### DIFF
--- a/.agents/scripts/bootstrap.js
+++ b/.agents/scripts/bootstrap.js
@@ -534,6 +534,13 @@ export function buildQuestions(defaults, flags, env = process.env, lists = {}) {
   const reposList = lists.reposList;
   const projectsList = lists.projectsList;
   const pickerOwner = (answers) => answers?.owner || owner;
+  // `owner` / `repo` are GitHub-side answers. When `--skip-github` suppresses
+  // the entire GitHub bootstrap, they are not required — this lets a
+  // non-interactive `--assume-yes --skip-github` run materialize and configure
+  // a fresh non-git directory (no inferable remote) without hard-failing on
+  // `missing required answers: owner, repo`. With GitHub bootstrap active they
+  // remain required (the target repo must be resolvable).
+  const skipGithub = Boolean(flags?.['skip-github']);
   return [
     {
       key: 'owner',
@@ -541,7 +548,7 @@ export function buildQuestions(defaults, flags, env = process.env, lists = {}) {
       env: 'GH_OWNER',
       message: '\n\nGitHub repo owner',
       default: defaults.owner,
-      required: true,
+      required: !skipGithub,
       validate: (v) =>
         /^[A-Za-z0-9][A-Za-z0-9-]*$/.test(v) ? null : 'Invalid GitHub owner',
     },
@@ -567,7 +574,7 @@ export function buildQuestions(defaults, flags, env = process.env, lists = {}) {
       pickerMessage:
         'GitHub repo name  - Select existing or press ENTER to create',
       default: defaults.repo,
-      required: true,
+      required: !skipGithub,
       picker: {
         list: (answers) => {
           if (Array.isArray(reposList) && reposList.length > 0)
@@ -957,7 +964,10 @@ export async function collectAndConfirm(state) {
     });
     if (missing.length > 0) {
       Logger.error(
-        `[Bootstrap] missing required answers: ${missing.join(', ')}`,
+        `[Bootstrap] missing required answers: ${missing.join(', ')}. ` +
+          'Pass them as flags (e.g. `--owner <name> --repo <name>`), or run ' +
+          'with `--skip-github` to configure the files/local setup only and ' +
+          'wire GitHub later.',
       );
       return { ok: false, exit: 1 };
     }

--- a/.github/workflows/install-matrix.yml
+++ b/.github/workflows/install-matrix.yml
@@ -428,20 +428,30 @@ jobs:
 
       # ── Leg: cold-start ───────────────────────────────────────────────────────
       # Exercises the Story #4045 single-command path end-to-end:
-      #   npm install --ignore-scripts → mandrel init --assume-yes → doctor ready.
+      #   npm install --ignore-scripts → mandrel init --assume-yes --skip-github
+      #   → doctor ready.
+      # `--skip-github` is required here: the throwaway consumer is not a git
+      # repo and has no remote, so owner/repo are uninferrable. Without
+      # --skip-github, `--assume-yes` (which means "configure now, incl. GitHub
+      # provisioning") hard-fails on `missing required answers: owner, repo`.
+      # The GitHub side effects (repo/labels/project creation) cannot be
+      # exercised against a throwaway repo anyway; this leg validates the
+      # single-command materialize + local-configure → doctor-ready path.
       - name: "[cold-start] Install npm with --ignore-scripts"
         if: matrix.leg == 'cold-start'
         shell: bash
         working-directory: ${{ env.CONSUMER_DIR }}
         run: npm install --ignore-scripts "$TARBALL_PATH"
 
-      - name: "[cold-start] Run mandrel init --assume-yes (cold-start bootstrap)"
+      - name: "[cold-start] Run mandrel init --assume-yes --skip-github (cold-start bootstrap)"
         if: matrix.leg == 'cold-start'
         shell: bash
         working-directory: ${{ env.CONSUMER_DIR }}
-        # --assume-yes accepts all prompts non-interactively, exercising the full
-        # single-command bootstrap path introduced in Story #4045.
-        run: node "$MANDREL_BIN" init --assume-yes
+        # --assume-yes accepts all prompts non-interactively; --skip-github
+        # scopes the run to the files + local configuration (no GitHub
+        # provisioning, no inferable owner/repo needed). Together they exercise
+        # the single-command bootstrap path introduced in Story #4045.
+        run: node "$MANDREL_BIN" init --assume-yes --skip-github
 
       - name: "[cold-start] Assert materialization after mandrel init"
         if: matrix.leg == 'cold-start'

--- a/tests/scripts/bootstrap-main-phases.test.js
+++ b/tests/scripts/bootstrap-main-phases.test.js
@@ -331,12 +331,14 @@ describe('runPipeline', () => {
 });
 
 describe('collectAndConfirm', () => {
-  it('halts with exit 1 when required answers are missing under --assume-yes', async () => {
+  it('halts with exit 1 when required answers are missing under --assume-yes (GitHub active)', async () => {
     const { collectAndConfirm } = await import(
       '../../.agents/scripts/bootstrap.js'
     );
+    // GitHub bootstrap is active (no --skip-github), so owner/repo are
+    // required; non-interactive --assume-yes with no inferable values halts.
     const res = await collectAndConfirm({
-      flags: { 'assume-yes': true, 'skip-github': true },
+      flags: { 'assume-yes': true },
       interactive: false,
       assumeYes: true,
       defaults: { owner: null, repo: null, baseBranch: null },
@@ -345,6 +347,25 @@ describe('collectAndConfirm', () => {
     });
     assert.equal(res.ok, false);
     assert.equal(res.exit, 1);
+  });
+
+  it('advances under --assume-yes --skip-github with no inferable owner/repo (cold-start path)', async () => {
+    const { collectAndConfirm } = await import(
+      '../../.agents/scripts/bootstrap.js'
+    );
+    // --skip-github relaxes the GitHub-side answers, so a fresh non-git dir
+    // (null owner/repo) configures the files/local setup instead of hard-
+    // failing on `missing required answers: owner, repo` — the install-matrix
+    // cold-start leg's contract.
+    const res = await collectAndConfirm({
+      flags: { 'assume-yes': true, 'skip-github': true },
+      interactive: false,
+      assumeYes: true,
+      defaults: { owner: null, repo: null, baseBranch: null },
+      silentAccept: [],
+      gitInitialized: true,
+    });
+    assert.equal(res.ok, true);
   });
 
   it('advances with the resolved answers when flags satisfy every required field', async () => {

--- a/tests/scripts/bootstrap-question-pickers.test.js
+++ b/tests/scripts/bootstrap-question-pickers.test.js
@@ -289,3 +289,49 @@ describe('picker precedence in collectAnswers', () => {
     assert.deepEqual(await resolveFromPicker(ctx), { kind: 'skip' });
   });
 });
+
+// ---------------------------------------------------------------------------
+// buildQuestions — owner/repo required-ness tracks --skip-github
+// ---------------------------------------------------------------------------
+
+describe('buildQuestions owner/repo requiredness under --skip-github', () => {
+  const EMPTY = Object.freeze({}); // no inferable defaults (fresh non-git dir)
+
+  it('marks owner and repo required when GitHub bootstrap is active', () => {
+    const questions = buildQuestions(EMPTY, {}, {}, {});
+    assert.equal(findQuestion(questions, 'owner').required, true);
+    assert.equal(findQuestion(questions, 'repo').required, true);
+  });
+
+  it('relaxes owner and repo when --skip-github is set', () => {
+    const questions = buildQuestions(EMPTY, { 'skip-github': true }, {}, {});
+    assert.equal(findQuestion(questions, 'owner').required, false);
+    assert.equal(findQuestion(questions, 'repo').required, false);
+  });
+
+  it('non-interactive --assume-yes hard-fails on missing owner/repo when GitHub is active', async () => {
+    const questions = buildQuestions(EMPTY, {}, {}, {});
+    const { missing } = await collectAnswers({
+      questions,
+      flags: {},
+      interactive: false,
+      assumeYes: true,
+    });
+    assert.ok(missing.includes('owner'), 'owner should be missing');
+    assert.ok(missing.includes('repo'), 'repo should be missing');
+  });
+
+  it('non-interactive --assume-yes --skip-github resolves with no missing owner/repo (cold-start path)', async () => {
+    const questions = buildQuestions(EMPTY, { 'skip-github': true }, {}, {});
+    const { missing } = await collectAnswers({
+      questions,
+      flags: { 'skip-github': true },
+      interactive: false,
+      assumeYes: true,
+    });
+    assert.ok(
+      !missing.includes('owner') && !missing.includes('repo'),
+      `owner/repo must not be required under --skip-github; got missing=[${missing.join(', ')}]`,
+    );
+  });
+});


### PR DESCRIPTION
## Why

The nightly install-matrix **`cold-start`** leg fails at `mandrel init --assume-yes`:

```
[Bootstrap] ❌ missing required answers: owner, repo
Process completed with exit code 1
```

(confirmed on scheduled run [27547129327](https://github.com/dsj1984/mandrel/actions/runs/27547129327), job `cold-start`). This is **orthogonal** to the pnpm/runtime-deps issue in [#4180](https://github.com/dsj1984/mandrel/pull/4180) — a different leg, a different root cause. npm hoists fine here; the failure is earlier, in bootstrap.

## Root cause

The throwaway consumer dir is not a git repo and has no remote, so owner/repo are uninferrable, and `--assume-yes` (non-interactive) can't prompt. `buildQuestions` marked `owner`/`repo` `required: true` **unconditionally** — even though `--skip-github` already suppresses every GitHub-side step (provisioning, listing, creation detection). So the explicit "files + local configuration only" path couldn't run non-interactively in a fresh directory.

## Fix

`owner`/`repo` are `required` only when GitHub bootstrap is **active** (`!--skip-github`). With `--skip-github` they're optional, so `mandrel init --assume-yes --skip-github` materializes + configures a fresh non-git dir instead of hard-failing. This matches the documented contract (README: `--skip-github` is the files/local-only path; init is meant to run in a non-git dir).

- **`.agents/scripts/bootstrap.js`** — `required: !skipGithub` for owner/repo; the missing-answers error now names the fix (`--owner/--repo`, or `--skip-github`).
- **`.github/workflows/install-matrix.yml`** — cold-start leg uses `init --assume-yes --skip-github`. GitHub provisioning can't run against a throwaway repo anyway; the leg validates the single-command materialize + local-configure → doctor-ready path.
- **tests** — owner/repo requiredness tracks `--skip-github` at three levels (`buildQuestions`, `collectAnswers`, `collectAndConfirm`); the existing halt-on-missing test now asserts the GitHub-active path, plus a new skip-github success-path test.

## Verification

- New + existing bootstrap/init suites green (377 tests via `node --experimental-test-module-mocks --test`).
- Deterministic proof of the contract:
  - GitHub active + missing owner/repo → `missing: [owner, repo]`, halts (the bug, preserved for the GitHub path).
  - `--skip-github` + null owner/repo → no missing, `collectAndConfirm` returns `ok: true` (the fix).
- The end-to-end pack→install→init repro was sandbox-blocked locally; the cold-start CI leg now exercises it on the next nightly / `workflow_dispatch`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)