### PR TITLE
docs: fix stale docs/architecture.md refs (phantom wave-dispatcher.js + scripts/adapters/ dir) (#4190)

### DIFF
--- a/.agents/README.md
+++ b/.agents/README.md
@@ -466,7 +466,7 @@ ticketing provider is GitHub, resolved by `provider-factory.js` from the
 `orchestration.provider` config key. CLI scripts receive provider
 instances from the SDK surface rather than importing provider
 implementations directly. Execution is Claude-Code-in-session — there is
-no separate adapter abstraction; `wave-dispatcher.js` synthesizes the
+no separate adapter abstraction; `manifest-builder.js` synthesizes the
 dispatch record inline and the dispatch manifest (md + structured
 comment) is the cross-runtime contract.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -91,8 +91,7 @@ mandrel/
 │   ├── workflows/            ← Slash-command workflows
 │   ├── scripts/              ← Deterministic JavaScript tooling
 │   │   ├── lib/              ←   Shared modules & interfaces
-│   │   ├── providers/        ←   Ticketing provider implementations
-│   │   └── adapters/         ←   Execution adapter implementations
+│   │   └── providers/        ←   Ticketing provider implementations
 │   ├── schemas/              ← JSON Schema for structured output
 │   ├── templates/            ← Prompt and planning templates
 │   └── docs/                 ← Shipped consumer reference docs
@@ -484,8 +483,8 @@ façade.
 Mandrel runs Claude-Code-in-session: `/deliver` fans out via the
 `Agent` tool over a wave of Story sub-agents, each driving the per-Story
 implementation loop directly from the Story worktree. There is no separate
-adapter abstraction — `wave-dispatcher.js` synthesizes the
-`{ taskId, dispatchId, status }` record inline at the dispatch site,
+adapter abstraction — `lib/orchestration/manifest-builder.js` synthesizes
+the `{ taskId, dispatchId, status }` record inline at the dispatch site,
 and the **dispatch manifest** (md + structured comment, schema
 [`dispatch-manifest.json`](../.agents/schemas/dispatch-manifest.json))
 is the load-bearing artifact downstream tooling (and operators) read.
@@ -1357,7 +1356,7 @@ conventions to follow.
 - **Ticketing provider abstraction:** `.agents/scripts/lib/ITicketingProvider.js`
   with a shipped GitHub implementation in `.agents/scripts/providers/github.js`
 - **Execution path:** Claude-Code-in-session; the dispatch record is
-  synthesized inline at `wave-dispatcher.js` and the
+  synthesized inline at `lib/orchestration/manifest-builder.js` and the
   [dispatch manifest](../.agents/schemas/dispatch-manifest.json) is the
   cross-runtime contract. Epic #2646 removed the previous
   `IExecutionAdapter` abstraction as a hard cutover.

--- a/docs/data-dictionary.md
+++ b/docs/data-dictionary.md
@@ -187,8 +187,8 @@ any prior comment of the same type.
 | ------------------- | --------------------------------------------------- | ------------------------------------------------------------------------ |
 | `epic-run-state`    | `Checkpointer`                                      | JSON checkpoint of wave progress and resume state.                       |
 | `epic-run-progress` | `ProgressReporter`                                  | Periodic operator-facing wave roll-up.                                   |
-| `wave-<N>-start`    | `WaveObserver.waveStart`                            | Per-wave start manifest + timestamp.                                     |
-| `wave-<N>-end`      | `WaveObserver.waveEnd`                              | Per-wave outcomes + duration.                                            |
+| `wave-<N>-start`    | `/deliver` wave loop (`lib/orchestration/wave-marker.js`) | Per-wave start manifest + timestamp.                                |
+| `wave-<N>-end`      | `/deliver` wave loop (`lib/orchestration/wave-marker.js`) | Per-wave outcomes + duration.                                       |
 | `epic-plan-state`   | `/plan` checkpoint                             | Phase 1/2 progress so re-plans resume cleanly.                           |
 | `dispatch-manifest` | `/plan` / dispatcher                           | Frozen Story manifest for the wave-gate.                                 |
 | `parked-follow-ons` | dispatcher                                          | Out-of-manifest Stories surfaced at the deliver-tail gate (recuts + parked). |
@@ -283,8 +283,8 @@ the Epic is the SSOT; the on-disk file is a renderer cache regenerable via
 
 The wave structured-comment marker regex is
 `/^wave-([0-9]{1,3})-(start|end)$/` — up to 999 waves. `wave-1000-start` is
-rejected; downstream wave-index consumers (`manifest-builder`,
-`wave-dispatcher`) tolerate rejected indices gracefully.
+rejected; downstream wave-index consumers (`manifest-builder`) tolerate
+rejected indices gracefully.
 
 ---
 


### PR DESCRIPTION
Closes #4190

_Auto-opened by `/single-story-deliver`._