### PR TITLE
perf: baseline regeneration parses every file with escomplex twice (MI + CRAP passes) (#4192)

### DIFF
--- a/.agents/scripts/lib/baseline-snapshot.js
+++ b/.agents/scripts/lib/baseline-snapshot.js
@@ -20,6 +20,7 @@ import {
   resolveEscomplexVersion,
   resolveTsTranspilerVersion,
   scanAndScore,
+  scanAndScoreCombined,
 } from './crap-utils.js';
 import { ensureEpicBranchRef as defaultEnsureEpicBranchRef } from './git-branch-lifecycle.js';
 import { calculateAll, scanDirectory } from './maintainability-utils.js';
@@ -563,6 +564,126 @@ function crapDirsMatchMi({
 }
 
 /**
+ * Config-only sibling of `crapDirsMatchMi` (Story #4192): decide — before any
+ * tree scan — whether the MI and CRAP passes target the same dirs with the
+ * same ignore globs. When true, `regenerateMainFromTree` collapses the two
+ * escomplex passes into a single combined `analyzeOnce` scan; when false it
+ * falls back to the independent two-pass path. Pure array compare, no scan
+ * list required.
+ */
+function crapConfigMatchesMi({
+  crapTargetDirs,
+  crapIgnoreGlobs,
+  miTargetDirs,
+  miIgnoreGlobs,
+}) {
+  return (
+    crapTargetDirs.length === miTargetDirs.length &&
+    crapTargetDirs.every((d, i) => d === miTargetDirs[i]) &&
+    crapIgnoreGlobs.length === miIgnoreGlobs.length &&
+    crapIgnoreGlobs.every((g, i) => g === miIgnoreGlobs[i])
+  );
+}
+
+/**
+ * Run the combined MI + CRAP single-pass scan once and project it into the
+ * `{ calculateAllFn, scanDirectoryFn, scanAndScoreFn, loadCoverageFn }`
+ * injection seams that `regenerateMaintainability` / `regenerateCrap` already
+ * consume. Returns `null` when the combined path is NOT eligible (either
+ * baseline unconfigured, dirs/globs differ, or coverage is required but
+ * missing) — the caller then falls back to the two independent passes.
+ *
+ * Eligibility deliberately requires coverage to be present under
+ * `requireCoverage`: when coverage is missing, the two-pass path takes a
+ * dedicated `no-coverage` short-circuit for CRAP (no scan at all), and
+ * reproducing that precise envelope is cleaner by deferring to the existing
+ * `regenerateCrap` branch than by routing through the combined scanner.
+ *
+ * Story #4192 — collapses the duplicate escomplex AST parse on the full-tree
+ * baseline path (2 parses/file → 1 parse/file). Byte-for-byte equivalent to
+ * the two-pass path: the combined scan returns the same MI score map and the
+ * same CRAP rows the separate passes would, and the downstream projection +
+ * writer logic is shared verbatim.
+ *
+ * @returns {Promise<null | {
+ *   calculateAllFn: () => Promise<Record<string, number>>,
+ *   scanDirectoryFn: (dir: string, list: string[]) => string[],
+ *   scanAndScoreFn: () => Promise<{ rows: Array<object> }>,
+ *   loadCoverageFn: () => object,
+ * }>}
+ */
+async function buildCombinedScanSeams({
+  cwd,
+  baselines,
+  quality,
+  loadCoverageFn,
+  scanAndScoreCombinedFn,
+}) {
+  const miPath = baselines?.maintainability?.path;
+  const crapPath = baselines?.crap?.path;
+  if (
+    typeof miPath !== 'string' ||
+    miPath.length === 0 ||
+    typeof crapPath !== 'string' ||
+    crapPath.length === 0
+  ) {
+    return null; // both baselines must be configured to combine
+  }
+
+  const miTargetDirs = quality?.maintainability?.targetDirs ?? [];
+  const miIgnoreGlobs = quality?.maintainability?.ignoreGlobs ?? [];
+  const crapCfg = quality?.crap ?? {};
+  const crapTargetDirs = Array.isArray(crapCfg.targetDirs)
+    ? crapCfg.targetDirs
+    : [];
+  const crapIgnoreGlobs = Array.isArray(crapCfg.ignoreGlobs)
+    ? crapCfg.ignoreGlobs
+    : [];
+
+  if (
+    !crapConfigMatchesMi({
+      crapTargetDirs,
+      crapIgnoreGlobs,
+      miTargetDirs,
+      miIgnoreGlobs,
+    })
+  ) {
+    return null; // dirs/globs differ → two-pass fallback
+  }
+
+  const requireCoverage = crapCfg.requireCoverage !== false;
+  const coveragePath = crapCfg.coveragePath ?? 'coverage/coverage-final.json';
+  const coverageAbs = path.isAbsolute(coveragePath)
+    ? coveragePath
+    : path.resolve(cwd, coveragePath);
+  const coverage = loadCoverageFn(coverageAbs);
+
+  if (!coverage && requireCoverage) {
+    return null; // no coverage → let the two-pass CRAP short-circuit run
+  }
+
+  const { miScores, crap } = await scanAndScoreCombinedFn({
+    targetDirs: miTargetDirs,
+    coverage,
+    requireCoverage,
+    cwd,
+    ignoreGlobs: miIgnoreGlobs,
+  });
+
+  return {
+    // MI consumes the precomputed score map directly; the scanDirectory seam
+    // is short-circuited to a no-op list (the combined scan already walked
+    // the tree), so regenerateMaintainability's projection runs unchanged.
+    calculateAllFn: async () => miScores,
+    scanDirectoryFn: (_dir, list = []) => list,
+    // CRAP consumes the precomputed scan result; coverage is already loaded
+    // so its loadCoverage seam returns the same object without re-reading.
+    scanAndScoreFn: async () => crap,
+    loadCoverageFn: () => coverage,
+  };
+}
+
+/**
  * Regenerate the CRAP baseline from a fresh tree scan + coverage map.
  * Returns `null` when no CRAP baseline path is configured. Story #4075 —
  * extracted from `regenerateMainFromTree`.
@@ -675,6 +796,7 @@ export async function regenerateMainFromTree({
   scanDirectoryFn = scanDirectory,
   calculateAllFn = calculateAll,
   scanAndScoreFn = scanAndScore,
+  scanAndScoreCombinedFn = scanAndScoreCombined,
   loadCoverageFn = loadCoverage,
   resolveEscomplexVersionFn = resolveEscomplexVersion,
   resolveTsTranspilerVersionFn = resolveTsTranspilerVersion,
@@ -689,12 +811,49 @@ export async function regenerateMainFromTree({
   const files = [];
   let didChange = false;
 
+  // Story #4192 — when MI and CRAP target the same dirs/globs (and coverage
+  // is present), collapse the two escomplex passes into a single combined
+  // `analyzeOnce` scan. The combined scan is projected into the same scan
+  // seams the two passes consume, so the MI/CRAP envelope projection + writer
+  // logic below runs byte-for-byte identically either way. When the combined
+  // path is not eligible, `combined` is `null` and the original two
+  // independent passes run.
+  //
+  // The combined path is an internal optimization of the *production-default*
+  // scan seams. A caller that injects its own `calculateAllFn` or
+  // `scanAndScoreFn` is explicitly opting into the two independent passes
+  // (the DI contract: "use my seam"), so the combined path defers to those
+  // injected seams rather than silently bypassing them. In production neither
+  // seam is overridden, so the optimization is always taken.
+  const usingDefaultScanSeams =
+    calculateAllFn === calculateAll && scanAndScoreFn === scanAndScore;
+  const combined = usingDefaultScanSeams
+    ? await buildCombinedScanSeams({
+        cwd,
+        baselines,
+        quality,
+        loadCoverageFn,
+        scanAndScoreCombinedFn,
+      })
+    : null;
+
+  const miCalculateAllFn = combined ? combined.calculateAllFn : calculateAllFn;
+  const miScanDirectoryFn = combined
+    ? combined.scanDirectoryFn
+    : scanDirectoryFn;
+  const crapScanAndScoreFn = combined
+    ? combined.scanAndScoreFn
+    : scanAndScoreFn;
+  const crapLoadCoverageFn = combined
+    ? combined.loadCoverageFn
+    : loadCoverageFn;
+
   const miScan = await regenerateMaintainability({
     cwd,
     baselines,
     quality,
-    scanDirectoryFn,
-    calculateAllFn,
+    scanDirectoryFn: miScanDirectoryFn,
+    calculateAllFn: miCalculateAllFn,
     writeFn,
     writeFileFn,
     loadPriorFn,
@@ -711,8 +870,8 @@ export async function regenerateMainFromTree({
     quality,
     logger,
     miScan,
-    scanAndScoreFn,
-    loadCoverageFn,
+    scanAndScoreFn: crapScanAndScoreFn,
+    loadCoverageFn: crapLoadCoverageFn,
     resolveEscomplexVersionFn,
     resolveTsTranspilerVersionFn,
     writeFn,

--- a/.agents/scripts/lib/crap-utils.js
+++ b/.agents/scripts/lib/crap-utils.js
@@ -13,6 +13,10 @@ import { scanDirectory } from './maintainability-utils.js';
 import { resolveTsTranspilerVersion, transpileIfNeeded } from './transpile.js';
 
 const CRAP_WORKER_URL = new URL('./workers/crap-worker.js', import.meta.url);
+const COMBINED_MI_CRAP_WORKER_URL = new URL(
+  './workers/combined-mi-crap-worker.js',
+  import.meta.url,
+);
 
 // Pool-vs-serial cutover — single-sourced in cpu-pool.js (see the
 // POOL_SERIAL_THRESHOLD docstring for the tuning rationale).
@@ -471,4 +475,281 @@ async function scoreFilesViaPool(queue, coverage) {
     }
     return { item, result: r };
   });
+}
+
+/**
+ * In-process combined scorer: parse `abs` exactly once via `analyzeOnce` and
+ * derive BOTH the module MI score and the per-method CRAP rows. The reference
+ * implementation for the combined worker, used directly below
+ * `SERIAL_THRESHOLD` (matching the serial fast paths of `calculateAll` and
+ * `scanAndScore`).
+ *
+ * Return shape mirrors `combined-mi-crap-worker.js`:
+ *   - `miScore` — `null` on read failure (MI dropped by the host), `0` on
+ *     transpile-null / parse-error (parity with `calculateForFile` /
+ *     `calculateForSource`), otherwise the module maintainability index.
+ *   - `crapRows` — `null` on read/transpile/parse failure (CRAP drops the
+ *     file), `[]` when coverage-skipped, otherwise the scored method rows.
+ *   - `skippedFileNoCoverage` / `skippedMethodsNoCoverage` — CRAP counters.
+ */
+function scoreFileCombinedSerial({ abs, relPath, requireCoverage }, coverage) {
+  const entry = findCoverageEntry(coverage, relPath);
+  let source;
+  try {
+    source = fs.readFileSync(abs, 'utf-8');
+  } catch {
+    return {
+      relPath,
+      miScore: null,
+      skippedFileNoCoverage: false,
+      crapRows: null,
+      skippedMethodsNoCoverage: 0,
+    };
+  }
+  const prepared = transpileIfNeeded(abs, source);
+  if (prepared === null) {
+    return {
+      relPath,
+      miScore: 0,
+      skippedFileNoCoverage: false,
+      crapRows: null,
+      skippedMethodsNoCoverage: 0,
+    };
+  }
+  const {
+    miScore,
+    crapRows: rawCrapRows,
+    parseError,
+  } = analyzeOnce(prepared, entry);
+  if (parseError) {
+    return {
+      relPath,
+      miScore: 0,
+      skippedFileNoCoverage: false,
+      crapRows: null,
+      skippedMethodsNoCoverage: 0,
+    };
+  }
+  if (requireCoverage && entry === null) {
+    return {
+      relPath,
+      miScore,
+      skippedFileNoCoverage: true,
+      crapRows: [],
+      skippedMethodsNoCoverage: 0,
+    };
+  }
+  const crapRows = [];
+  let skippedMethodsNoCoverage = 0;
+  for (const mr of rawCrapRows) {
+    if (mr.crap === null || mr.coverage === null) {
+      skippedMethodsNoCoverage += 1;
+      continue;
+    }
+    crapRows.push({
+      method: mr.method,
+      startLine: mr.startLine,
+      cyclomatic: mr.cyclomatic,
+      coverage: mr.coverage,
+      crap: mr.crap,
+    });
+  }
+  return {
+    relPath,
+    miScore,
+    skippedFileNoCoverage: false,
+    crapRows,
+    skippedMethodsNoCoverage,
+  };
+}
+
+async function scoreFilesCombinedViaPool(queue, coverage) {
+  const enrichedQueue = queue.map((item) => ({
+    ...item,
+    coverageEntry: findCoverageEntry(coverage, item.relPath),
+  }));
+  const results = await runOnPool(COMBINED_MI_CRAP_WORKER_URL, enrichedQueue, {
+    workerData: {},
+  });
+  return results.map((r, i) => {
+    const item = queue[i];
+    if (!r || r.__cpuPoolError) {
+      Logger.warn(
+        `[crap-utils] combined worker pool error for ${item.relPath}: ${r?.message ?? 'unknown'}`,
+      );
+      return { item, result: null };
+    }
+    return { item, result: r };
+  });
+}
+
+/**
+ * Combined MI + CRAP single-pass scan. Walks the shared `targetDirs` once (or
+ * reuses `preScannedFiles`), dispatches every file through ONE worker that
+ * calls `analyzeOnce` a single time, and returns BOTH the maintainability
+ * score map and the CRAP scan result.
+ *
+ * This collapses the two independent escomplex passes the full-tree baseline
+ * regenerator used to run (`calculateAll` → maintainability worker, then
+ * `scanAndScore` → CRAP worker) into one parse per file. The outputs are
+ * shaped to be drop-in equivalents of the two passes they replace, so the
+ * downstream envelope projection + writer logic stays byte-identical:
+ *
+ *   - `miScores` — `Record<relPath, number>` keyed exactly as `calculateAll`
+ *     keys its result (`path.relative(cwd, abs)`, POSIX-normalised), with
+ *     read-failure files (`miScore === null`) dropped. Parity target:
+ *     `calculateAll(files)`.
+ *   - `crap` — `{ rows, scannedFiles, skippedFilesNoCoverage,
+ *     skippedMethodsNoCoverage }`, identical in shape and content to
+ *     `scanAndScore({ targetDirs, coverage, ... })`. The rows are
+ *     CRAP-sorted (file → startLine → method) so the result matches
+ *     `scanAndScore` even before the writer re-sorts.
+ *
+ * The `requireCoverage`, `scopeFiles`, `ignoreGlobs`, and `preScannedFiles`
+ * semantics match `scanAndScore` exactly — coverage gating, scope filtering,
+ * and the single-walk reuse path behave the same. Files dropped from CRAP by
+ * the coverage gate STILL contribute their MI score (the MI pass never
+ * required coverage), preserving the two-pass behaviour where MI scores every
+ * file in the target dirs.
+ *
+ * @param {{
+ *   targetDirs: string[],
+ *   coverage: object|null,
+ *   requireCoverage?: boolean,
+ *   cwd?: string,
+ *   scopeFiles?: Set<string>|string[]|null,
+ *   ignoreGlobs?: string[],
+ *   preScannedFiles?: string[]|null,
+ * }} params
+ * @returns {Promise<{
+ *   miScores: Record<string, number>,
+ *   crap: {
+ *     rows: Array<{
+ *       file: string, method: string, startLine: number,
+ *       cyclomatic: number, coverage: number, crap: number,
+ *     }>,
+ *     scannedFiles: number,
+ *     skippedFilesNoCoverage: number,
+ *     skippedMethodsNoCoverage: number,
+ *   },
+ * }>}
+ */
+export async function scanAndScoreCombined({
+  targetDirs,
+  coverage,
+  requireCoverage = true,
+  cwd = process.cwd(),
+  scopeFiles = null,
+  ignoreGlobs = [],
+  preScannedFiles = null,
+}) {
+  if (!Array.isArray(targetDirs)) {
+    throw new TypeError('scanAndScoreCombined: targetDirs must be an array');
+  }
+  const scopeSet =
+    scopeFiles == null
+      ? null
+      : scopeFiles instanceof Set
+        ? scopeFiles
+        : new Set(scopeFiles);
+
+  // Single directory walk (or reuse the caller's pre-walked list), mirroring
+  // scanAndScore so the file discovery is byte-identical between paths.
+  const files = preScannedFiles != null ? [...preScannedFiles] : [];
+  if (preScannedFiles == null) {
+    for (const dir of targetDirs) {
+      const abs = path.isAbsolute(dir) ? dir : path.resolve(cwd, dir);
+      scanDirectory(abs, files, { cwd, ignoreGlobs });
+    }
+  }
+  files.sort();
+
+  // Build the work queue. Each item carries both the canonicalised relPath
+  // (CRAP's key + scope filter, matching scanAndScore) and the raw relPath
+  // (MI's key, matching calculateAll's `path.relative(cwd, p)` shape).
+  const queue = [];
+  for (const abs of files) {
+    const rawRel = path.relative(cwd, abs).replace(/\\/g, '/');
+    const relPath = canonicalisePath(rawRel);
+    if (scopeSet && !scopeSet.has(relPath)) continue;
+    queue.push({ abs, relPath, miRel: rawRel, requireCoverage });
+  }
+  const scannedFiles = queue.length;
+
+  const perFile =
+    queue.length < SERIAL_THRESHOLD
+      ? queue.map((item) => ({
+          item,
+          result: scoreFileCombinedSerial(item, coverage),
+        }))
+      : await scoreFilesCombinedViaPool(queue, coverage);
+
+  // MI assembly — mirror calculateAll: drop read-failure files (miScore
+  // null), key by the raw relative path, then sort ascending so the returned
+  // object is insertion-order-stable.
+  const miEntries = [];
+  // CRAP assembly — mirror scanAndScore: file-level skip counter, drop
+  // read/transpile/parse failures, accumulate method rows.
+  const crapRows = [];
+  let skippedFilesNoCoverage = 0;
+  let skippedMethodsNoCoverage = 0;
+
+  for (const { item, result } of perFile) {
+    if (!result) continue; // unrecoverable per-file failure: drop silently
+
+    // MI side.
+    if (result.miScore !== null) {
+      miEntries.push({ relPath: item.miRel, score: result.miScore });
+    }
+
+    // CRAP side.
+    if (result.skippedFileNoCoverage) {
+      skippedFilesNoCoverage += 1;
+      continue;
+    }
+    if (result.crapRows === null) {
+      if (result.error) {
+        Logger.warn(
+          `[crap-utils] failed to score ${item.relPath}: ${result.error}`,
+        );
+      }
+      continue;
+    }
+    skippedMethodsNoCoverage += result.skippedMethodsNoCoverage ?? 0;
+    for (const mr of result.crapRows) {
+      crapRows.push({
+        file: item.relPath,
+        method: mr.method,
+        startLine: mr.startLine,
+        cyclomatic: mr.cyclomatic,
+        coverage: mr.coverage,
+        crap: mr.crap,
+      });
+    }
+  }
+
+  miEntries.sort((a, b) =>
+    a.relPath < b.relPath ? -1 : a.relPath > b.relPath ? 1 : 0,
+  );
+  const miScores = {};
+  for (const { relPath, score } of miEntries) {
+    miScores[relPath] = score;
+  }
+
+  crapRows.sort((a, b) => {
+    if (a.file !== b.file) return a.file < b.file ? -1 : 1;
+    if (a.startLine !== b.startLine) return a.startLine - b.startLine;
+    if (a.method !== b.method) return a.method < b.method ? -1 : 1;
+    return 0;
+  });
+
+  return {
+    miScores,
+    crap: {
+      rows: crapRows,
+      scannedFiles,
+      skippedFilesNoCoverage,
+      skippedMethodsNoCoverage,
+    },
+  };
 }

--- a/.agents/scripts/lib/workers/combined-mi-crap-worker.js
+++ b/.agents/scripts/lib/workers/combined-mi-crap-worker.js
@@ -1,0 +1,226 @@
+/**
+ * lib/workers/combined-mi-crap-worker.js — CPU-pool worker entry for the
+ * combined MI + CRAP single-pass scan (`scanAndScoreCombined`).
+ *
+ * One file in, BOTH the maintainability score and the per-method CRAP rows
+ * out — derived from a SINGLE `escomplex.analyzeModule` parse via
+ * `analyzeOnce`. This collapses the two independent worker-pool passes the
+ * full-tree baseline regenerator used to run (the MI worker parsed the AST
+ * once for the module score, the CRAP worker parsed the same file's AST
+ * again for the method rows) into one parse per file.
+ *
+ * The MI score and the CRAP rows have independent skip policies, mirroring
+ * the two separate passes this worker replaces:
+ *   - **MI** never requires coverage. The module score is emitted for every
+ *     file that reads + transpiles + parses. A read failure yields
+ *     `miScore: null` (the host drops the file from the MI map, matching
+ *     `calculateAll`'s `score === null` filter). A transpile failure or a
+ *     parse error yields `miScore: 0` (matching `calculateForFile` /
+ *     `calculateForSource`, which return 0 on transpile-null / parse-error).
+ *   - **CRAP** honours `requireCoverage`. A file with no coverage entry is
+ *     reported as `skippedFileNoCoverage: true` (the host increments its own
+ *     counter and emits no CRAP rows for it) — but the MI score is STILL
+ *     computed and returned, because the MI pass would have scored it.
+ *
+ * Message contract — see lib/cpu-pool.js:
+ *   IN  : { item: { abs: string, relPath: string, requireCoverage: boolean,
+ *                   coverageEntry: object | null } }
+ *         { exit: true }
+ *   OUT : { ok: true, result: {
+ *           relPath,
+ *           miScore: number | null,
+ *           skippedFileNoCoverage: boolean,
+ *           crapRows: Array<{ method, startLine, cyclomatic, coverage, crap }> | null,
+ *           skippedMethodsNoCoverage: number,
+ *         } }
+ *
+ * A read/transpile/parse failure surfaces as `crapRows: null` so the host
+ * loop drops the file's CRAP contribution (matching the crap-worker's
+ * `rows: null` contract) — never aborts the whole scan. On a read failure
+ * `miScore` is `null`; on a transpile/parse failure `miScore` is `0`.
+ */
+
+import fs from 'node:fs';
+import { parentPort } from 'node:worker_threads';
+import { analyzeOnce } from '../crap-utils.js';
+import { transpileIfNeeded } from '../transpile.js';
+
+/**
+ * Pure handler for a single inbound worker message. Exported so unit tests
+ * can exercise every branch (bad-shape rejection, coverage gate, read /
+ * transpile / parse failures, success rows, skipped methods, and the
+ * MI-computed-even-when-coverage-skipped invariant) without spawning a real
+ * `Worker` thread.
+ *
+ * Side effects (fs, transpile, analyzeOnce) are wired through `deps` so
+ * tests pass deterministic stubs.
+ *
+ * @param {unknown} msg
+ * @param {{
+ *   readFile?: (abs: string) => string,
+ *   transpile?: (abs: string, source: string) => string | null,
+ *   analyze?: (source: string, entry: object|null) => {
+ *     miScore: number,
+ *     crapRows: Array<object>,
+ *     parseError: boolean,
+ *   },
+ * }} [deps]
+ * @returns {{kind: 'exit'} | {kind: 'reply', message: object}}
+ */
+export function handleCombinedMiCrapWorkerMessage(msg, deps = {}) {
+  if (msg && msg.exit === true) return { kind: 'exit' };
+
+  const item = msg?.item;
+  if (
+    !item ||
+    typeof item.abs !== 'string' ||
+    typeof item.relPath !== 'string'
+  ) {
+    return {
+      kind: 'reply',
+      message: {
+        ok: false,
+        error: `bad worker message: ${JSON.stringify(msg)}`,
+      },
+    };
+  }
+  const { abs, relPath, requireCoverage } = item;
+  const readFile = deps.readFile ?? ((p) => fs.readFileSync(p, 'utf-8'));
+  const transpile = deps.transpile ?? transpileIfNeeded;
+  const analyze = deps.analyze ?? analyzeOnce;
+
+  // Coverage entry is pre-resolved on the host and attached to the item.
+  // `item.coverageEntry` may be explicitly `null` when the file has no
+  // coverage, or `undefined` when the caller did not supply it (treat as null).
+  const entry = item.coverageEntry ?? null;
+
+  // Read the source once. A read failure means neither MI nor CRAP can be
+  // computed — MI drops (null), CRAP drops (rows null) — matching the two
+  // passes' read-failure contracts (calculateAll → score null; crap worker
+  // → rows null).
+  let source;
+  try {
+    source = readFile(abs);
+  } catch {
+    return {
+      kind: 'reply',
+      message: {
+        ok: true,
+        result: {
+          relPath,
+          miScore: null,
+          skippedFileNoCoverage: false,
+          crapRows: null,
+          skippedMethodsNoCoverage: 0,
+        },
+      },
+    };
+  }
+
+  // TS/TSX → strip-then-analyze. A transpile failure yields miScore 0
+  // (calculateForFile returns 0 when transpileIfNeeded returns null) and a
+  // null CRAP contribution (crap worker returns rows: null).
+  const prepared = transpile(abs, source);
+  if (prepared === null) {
+    return {
+      kind: 'reply',
+      message: {
+        ok: true,
+        result: {
+          relPath,
+          miScore: 0,
+          skippedFileNoCoverage: false,
+          crapRows: null,
+          skippedMethodsNoCoverage: 0,
+        },
+      },
+    };
+  }
+
+  // ONE parse: analyzeOnce derives both the module MI score and the raw
+  // per-method CRAP rows from a single escomplex report. On a parse error it
+  // returns miScore 0 and an empty crapRows with parseError true.
+  const {
+    miScore,
+    crapRows: rawCrapRows,
+    parseError,
+  } = analyze(prepared, entry);
+  if (parseError) {
+    // Parse error: MI scores 0 (parity with calculateForSource's catch →
+    // returns 0), CRAP drops the file (rows null, parity with the crap
+    // worker's calculateCrap-throw branch).
+    return {
+      kind: 'reply',
+      message: {
+        ok: true,
+        result: {
+          relPath,
+          miScore: 0,
+          skippedFileNoCoverage: false,
+          crapRows: null,
+          skippedMethodsNoCoverage: 0,
+        },
+      },
+    };
+  }
+
+  // CRAP coverage gate runs AFTER the parse so the MI score is always
+  // available. When the file has no coverage under requireCoverage, the CRAP
+  // pass would have skipped it at the file level (no rows, counted) — but the
+  // MI pass would still have scored it, so miScore is returned regardless.
+  if (requireCoverage && entry === null) {
+    return {
+      kind: 'reply',
+      message: {
+        ok: true,
+        result: {
+          relPath,
+          miScore,
+          skippedFileNoCoverage: true,
+          crapRows: [],
+          skippedMethodsNoCoverage: 0,
+        },
+      },
+    };
+  }
+
+  const crapRows = [];
+  let skippedMethodsNoCoverage = 0;
+  for (const mr of rawCrapRows) {
+    if (mr.crap === null || mr.coverage === null) {
+      skippedMethodsNoCoverage += 1;
+      continue;
+    }
+    crapRows.push({
+      method: mr.method,
+      startLine: mr.startLine,
+      cyclomatic: mr.cyclomatic,
+      coverage: mr.coverage,
+      crap: mr.crap,
+    });
+  }
+  return {
+    kind: 'reply',
+    message: {
+      ok: true,
+      result: {
+        relPath,
+        miScore,
+        skippedFileNoCoverage: false,
+        crapRows,
+        skippedMethodsNoCoverage,
+      },
+    },
+  };
+}
+
+if (parentPort) {
+  parentPort.on('message', (msg) => {
+    const out = handleCombinedMiCrapWorkerMessage(msg);
+    if (out.kind === 'exit') {
+      parentPort.close();
+      return;
+    }
+    parentPort.postMessage(out.message);
+  });
+}

--- a/tests/lib/baseline-snapshot.combined-parity.test.js
+++ b/tests/lib/baseline-snapshot.combined-parity.test.js
@@ -1,0 +1,263 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, it } from 'node:test';
+
+import { regenerateMainFromTree } from '../../.agents/scripts/lib/baseline-snapshot.js';
+import {
+  scanAndScore,
+  scanAndScoreCombined,
+} from '../../.agents/scripts/lib/crap-utils.js';
+import { calculateAll } from '../../.agents/scripts/lib/maintainability-utils.js';
+
+/**
+ * Story #4192 — end-to-end envelope parity for the combined single-pass path.
+ *
+ * This is the load-bearing baseline-invariance proof: it runs the REAL
+ * `regenerateMainFromTree` over a real fixture tree with real coverage TWICE —
+ * once with the production-default scan seams (so the combined `analyzeOnce`
+ * single-pass path is taken) and once with the two independent passes forced
+ * on (real `calculateAll` + `scanAndScore`, wrapped so the seam-injection
+ * guard routes to the two-pass branch) — and asserts the envelopes handed to
+ * the writer are byte-for-byte identical (same `rows`, in the same order,
+ * with the same scores). If the single-parse refactor shifted any MI or CRAP
+ * number, this test fails.
+ */
+
+const FIXTURES = {
+  'src/branchy.js': `export function branchy(n) {
+  if (n > 10) {
+    return 'big';
+  }
+  if (n > 5) {
+    return 'mid';
+  }
+  for (let i = 0; i < n; i += 1) {
+    if (i % 2 === 0) {
+      continue;
+    }
+  }
+  return 'small';
+}
+
+export function trivial() {
+  return 42;
+}
+`,
+  'src/nested/deep.js': `export function deep(items) {
+  let total = 0;
+  for (const item of items) {
+    if (item.active) {
+      total += item.value;
+    } else if (item.pending) {
+      total -= item.value;
+    }
+  }
+  return total;
+}
+`,
+  'src/plain.mjs': `export const add = (a, b) => a + b;
+
+export function classify(x) {
+  switch (x) {
+    case 1:
+      return 'one';
+    case 2:
+      return 'two';
+    default:
+      return 'many';
+  }
+}
+`,
+};
+
+function fullCoverageEntry(lineCount) {
+  const fnMap = {};
+  const statementMap = {};
+  const s = {};
+  for (let line = 1; line <= lineCount; line += 1) {
+    fnMap[String(line)] = {
+      name: `fn${line}`,
+      decl: { start: { line }, end: { line } },
+      loc: { start: { line }, end: { line: lineCount } },
+    };
+    statementMap[String(line)] = { start: { line }, end: { line } };
+    s[String(line)] = 1;
+  }
+  return { fnMap, statementMap, s };
+}
+
+describe('regenerateMainFromTree — combined vs two-pass envelope parity (#4192)', () => {
+  let tmpDir;
+
+  beforeEach(() => {
+    // Root the fixture under the repo's gitignored `tmp/` (NOT `temp/`, which
+    // scanDirectory's IGNORED_DIRS skips) so the scan walks it AND so paths
+    // relative to `process.cwd()` carry no `..` segments — `calculateAll`
+    // keys by `process.cwd()`, and the baseline path-canon forbids `..`.
+    // Running with `cwd === process.cwd()` makes both the combined and the
+    // two-pass paths key files identically, which is exactly the production
+    // invariant (the regenerator always runs at the repo root).
+    const tmpRoot = path.join(process.cwd(), 'tmp');
+    fs.mkdirSync(tmpRoot, { recursive: true });
+    tmpDir = fs.mkdtempSync(path.join(tmpRoot, 'bsnap-combined-parity-'));
+    for (const [rel, contents] of Object.entries(FIXTURES)) {
+      const abs = path.join(tmpDir, rel);
+      fs.mkdirSync(path.dirname(abs), { recursive: true });
+      fs.writeFileSync(abs, contents, 'utf-8');
+    }
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function coverageMap() {
+    const coverage = {};
+    for (const rel of Object.keys(FIXTURES)) {
+      coverage[path.join(tmpDir, rel)] = fullCoverageEntry(
+        FIXTURES[rel].split('\n').length,
+      );
+    }
+    return coverage;
+  }
+
+  // A minimal writer seam that records every `{ kind, rows }` it is asked to
+  // assemble and echoes a deterministic envelope. We never touch disk
+  // (writeFileFn is a no-op) — the assertion is purely on the captured rows.
+  function recordingWriter() {
+    const calls = [];
+    return {
+      calls,
+      writeFn: ({ kind, rows }) => {
+        calls.push({ kind, rows });
+        return {
+          $schema: `.agents/schemas/baselines/${kind}.schema.json`,
+          kernelVersion: '0.1.0',
+          generatedAt: 'fixed',
+          rollup: { '*': {} },
+          rows,
+        };
+      },
+      writeFileFn: () => {},
+    };
+  }
+
+  const baselinesResolved = () => ({
+    maintainability: { path: 'baselines/maintainability.json' },
+    crap: { path: 'baselines/crap.json' },
+  });
+
+  function qualityResolved(tmp) {
+    return {
+      maintainability: { targetDirs: [path.join(tmp, 'src')], ignoreGlobs: [] },
+      crap: {
+        targetDirs: [path.join(tmp, 'src')],
+        ignoreGlobs: [],
+        requireCoverage: true,
+        coveragePath: 'coverage/coverage-final.json',
+      },
+    };
+  }
+
+  async function runRegen({ forceTwoPass }) {
+    const writer = recordingWriter();
+    const cov = coverageMap();
+    // Forcing two-pass: inject WRAPPED real scorers so their reference differs
+    // from the module defaults, which flips the seam-injection guard to the
+    // independent-passes branch while still scoring with the real engines.
+    const twoPassSeams = forceTwoPass
+      ? {
+          calculateAllFn: (paths) => calculateAll(paths),
+          scanAndScoreFn: (opts) => scanAndScore(opts),
+        }
+      : {};
+    await regenerateMainFromTree({
+      // Run at the repo root (production invariant) so `calculateAll`'s
+      // process.cwd()-relative keys and the combined scan's cwd-relative keys
+      // coincide and canonicalise cleanly.
+      cwd: process.cwd(),
+      resolveConfig: () => ({ agentSettings: {} }),
+      getBaselines: baselinesResolved,
+      getQuality: () => qualityResolved(tmpDir),
+      logger: { info: () => {}, warn: () => {} },
+      // Coverage is loaded by both the combined eligibility check and the
+      // CRAP pass; return the fixture map regardless of the resolved path.
+      loadCoverageFn: () => cov,
+      resolveEscomplexVersionFn: () => '0.1.0',
+      resolveTsTranspilerVersionFn: () => '5.9.3',
+      writeFn: writer.writeFn,
+      writeFileFn: writer.writeFileFn,
+      loadPriorFn: () => null,
+      ...twoPassSeams,
+    });
+    return writer.calls;
+  }
+
+  it('combined and two-pass hand the writer identical MI and CRAP rows', async () => {
+    const combinedCalls = await runRegen({ forceTwoPass: false });
+    const twoPassCalls = await runRegen({ forceTwoPass: true });
+
+    const pick = (calls, kind) =>
+      calls.find((c) => c.kind === kind)?.rows ?? null;
+
+    const combinedMi = pick(combinedCalls, 'maintainability');
+    const twoPassMi = pick(twoPassCalls, 'maintainability');
+    const combinedCrap = pick(combinedCalls, 'crap');
+    const twoPassCrap = pick(twoPassCalls, 'crap');
+
+    assert.ok(combinedMi, 'combined path must produce MI rows');
+    assert.ok(twoPassMi, 'two-pass path must produce MI rows');
+    assert.ok(combinedCrap, 'combined path must produce CRAP rows');
+    assert.ok(twoPassCrap, 'two-pass path must produce CRAP rows');
+
+    // The byte-identity contract: identical rows, identical order, identical
+    // scores — exactly what the on-disk envelope serialises.
+    assert.deepEqual(
+      combinedMi,
+      twoPassMi,
+      'MI rows must be byte-identical between combined and two-pass paths',
+    );
+    assert.deepEqual(
+      combinedCrap,
+      twoPassCrap,
+      'CRAP rows must be byte-identical between combined and two-pass paths',
+    );
+
+    // Sanity guards so an empty-vs-empty match cannot mask a broken scan.
+    assert.equal(combinedMi.length, 3, 'three source files → three MI rows');
+    assert.ok(combinedCrap.length >= 1, 'real CRAP rows were produced');
+  });
+
+  it('combined path is actually taken by default (guard wiring sanity)', async () => {
+    // Prove the default run routes through the COMBINED scanner, not the
+    // two-pass one, by spying on `scanAndScoreCombined` via a wrapped seam.
+    // (We inject the combined fn explicitly; injecting it does NOT flip the
+    // two-pass guard — only overriding calculateAllFn/scanAndScoreFn does.)
+    let combinedCalled = 0;
+    const cov = coverageMap();
+    const writer = recordingWriter();
+    await regenerateMainFromTree({
+      cwd: process.cwd(),
+      resolveConfig: () => ({ agentSettings: {} }),
+      getBaselines: baselinesResolved,
+      getQuality: () => qualityResolved(tmpDir),
+      logger: { info: () => {}, warn: () => {} },
+      loadCoverageFn: () => cov,
+      scanAndScoreCombinedFn: async (opts) => {
+        combinedCalled += 1;
+        return scanAndScoreCombined(opts);
+      },
+      resolveEscomplexVersionFn: () => '0.1.0',
+      resolveTsTranspilerVersionFn: () => '5.9.3',
+      writeFn: writer.writeFn,
+      writeFileFn: writer.writeFileFn,
+      loadPriorFn: () => null,
+    });
+    assert.equal(
+      combinedCalled,
+      1,
+      'the combined single-pass scanner must run exactly once on the default path',
+    );
+  });
+});

--- a/tests/lib/crap-utils.combined-parity.test.js
+++ b/tests/lib/crap-utils.combined-parity.test.js
@@ -1,0 +1,302 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, it } from 'node:test';
+
+import {
+  scanAndScore,
+  scanAndScoreCombined,
+} from '../../.agents/scripts/lib/crap-utils.js';
+import { calculateAll } from '../../.agents/scripts/lib/maintainability-utils.js';
+
+/**
+ * Story #4192 — byte-identical parity proof for the combined single-pass
+ * MI + CRAP scan.
+ *
+ * The whole point of `scanAndScoreCombined` is that collapsing the two
+ * escomplex passes (one for the MI module score, one for the CRAP method
+ * rows) into a single `analyzeOnce` parse per file produces the EXACT same
+ * numbers the two separate passes did. These tests run the real production
+ * scorers — `calculateAll` (MI two-pass), `scanAndScore` (CRAP two-pass), and
+ * `scanAndScoreCombined` (the new single-pass) — over the same real fixture
+ * tree with the same coverage map, and assert deep equality of:
+ *
+ *   - the MI score map (`scanAndScoreCombined().miScores` === `calculateAll()`)
+ *   - the CRAP scan result (`scanAndScoreCombined().crap` === `scanAndScore()`)
+ *
+ * No mocks of escomplex: the AST parse is real on both sides, so a parity
+ * pass means the single-parse path yields identical scores.
+ */
+
+function mkFixtureFile(dir, rel, contents) {
+  const abs = path.join(dir, rel);
+  fs.mkdirSync(path.dirname(abs), { recursive: true });
+  fs.writeFileSync(abs, contents, 'utf-8');
+  return abs;
+}
+
+/**
+ * Re-key a `{ relOrAbsPath: score }` map (as produced by `calculateAll`,
+ * whose keys are relative to `process.cwd()`) to keys relative to `cwd`.
+ * `calculateAll` ignores any explicit cwd and always relativises against
+ * `process.cwd()`; `scanAndScoreCombined` relativises against the `cwd` it
+ * is handed. In production both run with `cwd === process.cwd()` so the keys
+ * coincide — this re-key makes the cross-cwd unit comparison faithful.
+ */
+function reKeyToCwd(scoreMap, cwd) {
+  const out = {};
+  for (const [key, score] of Object.entries(scoreMap)) {
+    const abs = path.isAbsolute(key) ? key : path.resolve(process.cwd(), key);
+    out[path.relative(cwd, abs).replace(/\\/g, '/')] = score;
+  }
+  return out;
+}
+
+/**
+ * Build a synthetic istanbul-shaped coverage entry that marks every line in
+ * `[1, lineCount]` as a function start AND a covered statement. This makes
+ * `coverageForMethodInEntry` resolve a real (1.0) ratio for whatever method
+ * lineStart escomplex reports, so the CRAP row-emission path is exercised on
+ * both the two-pass and combined sides identically.
+ */
+function fullCoverageEntry(lineCount) {
+  const fnMap = {};
+  const statementMap = {};
+  const s = {};
+  for (let line = 1; line <= lineCount; line += 1) {
+    fnMap[String(line)] = {
+      name: `fn${line}`,
+      decl: { start: { line }, end: { line } },
+      loc: { start: { line }, end: { line: lineCount } },
+    };
+    statementMap[String(line)] = {
+      start: { line },
+      end: { line },
+    };
+    s[String(line)] = 1;
+  }
+  return { fnMap, statementMap, s };
+}
+
+describe('scanAndScoreCombined — byte-identical parity with the two-pass path', () => {
+  let tmpDir;
+
+  const FIXTURES = {
+    'src/branchy.js': `export function branchy(n) {
+  if (n > 10) {
+    return 'big';
+  }
+  if (n > 5) {
+    return 'mid';
+  }
+  for (let i = 0; i < n; i += 1) {
+    if (i % 2 === 0) {
+      continue;
+    }
+  }
+  return 'small';
+}
+
+export function trivial() {
+  return 42;
+}
+`,
+    'src/nested/deep.js': `export function deep(items) {
+  let total = 0;
+  for (const item of items) {
+    if (item.active) {
+      total += item.value;
+    } else if (item.pending) {
+      total -= item.value;
+    }
+  }
+  return total;
+}
+`,
+    'src/plain.mjs': `export const add = (a, b) => a + b;
+
+export function classify(x) {
+  switch (x) {
+    case 1:
+      return 'one';
+    case 2:
+      return 'two';
+    default:
+      return 'many';
+  }
+}
+`,
+  };
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'crap-combined-parity-'));
+    for (const [rel, contents] of Object.entries(FIXTURES)) {
+      mkFixtureFile(tmpDir, rel, contents);
+    }
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function buildCoverageMap() {
+    const coverage = {};
+    for (const rel of Object.keys(FIXTURES)) {
+      const abs = path.join(tmpDir, rel);
+      const lineCount = FIXTURES[rel].split('\n').length;
+      // coverage-final.json keys on absolute paths.
+      coverage[abs] = fullCoverageEntry(lineCount);
+    }
+    return coverage;
+  }
+
+  it('miScores deep-equals calculateAll over the same tree', async () => {
+    const targetDirs = [path.join(tmpDir, 'src')];
+    // calculateAll takes an explicit file list; build it the way the MI
+    // regenerator does (scanDirectory walk), so the inputs are identical.
+    const { scanDirectory } = await import(
+      '../../.agents/scripts/lib/maintainability-utils.js'
+    );
+    const miFiles = [];
+    for (const dir of targetDirs) scanDirectory(dir, miFiles, { cwd: tmpDir });
+
+    // `calculateAll` keys its result by `path.relative(process.cwd(), abs)`
+    // (it ignores any passed cwd). `scanAndScoreCombined` keys by the
+    // explicit `cwd` it is given. Re-key the two-pass output to the same
+    // cwd-relative shape so the comparison is apples-to-apples — in
+    // production both collapse to the same key because the regenerator runs
+    // with `cwd === process.cwd()` and re-derives `path.relative(cwd, key)`
+    // before the writer canonicalises identically for either source.
+    const twoPassRaw = await calculateAll(miFiles);
+    const twoPassMi = reKeyToCwd(twoPassRaw, tmpDir);
+    const { miScores } = await scanAndScoreCombined({
+      targetDirs,
+      coverage: buildCoverageMap(),
+      requireCoverage: true,
+      cwd: tmpDir,
+    });
+
+    assert.deepEqual(miScores, twoPassMi);
+    // Sanity: the fixture actually produced scores (guards against an empty
+    // both-sides match masking a broken walk).
+    assert.ok(Object.keys(miScores).length >= 3);
+  });
+
+  it('crap result deep-equals scanAndScore over the same tree (requireCoverage)', async () => {
+    const targetDirs = [path.join(tmpDir, 'src')];
+    const coverage = buildCoverageMap();
+
+    const twoPassCrap = await scanAndScore({
+      targetDirs,
+      coverage,
+      requireCoverage: true,
+      cwd: tmpDir,
+    });
+    const { crap } = await scanAndScoreCombined({
+      targetDirs,
+      coverage,
+      requireCoverage: true,
+      cwd: tmpDir,
+    });
+
+    assert.deepEqual(crap, twoPassCrap);
+    // Sanity: real CRAP rows were produced.
+    assert.ok(crap.rows.length >= 1);
+    assert.ok(crap.scannedFiles >= 3);
+  });
+
+  it('crap result deep-equals scanAndScore when coverage is partial (files skipped)', async () => {
+    const targetDirs = [path.join(tmpDir, 'src')];
+    // Cover only ONE file so the other two trip the requireCoverage
+    // file-level skip on both paths.
+    const onlyOne = path.join(tmpDir, 'src/branchy.js');
+    const coverage = {
+      [onlyOne]: fullCoverageEntry(
+        FIXTURES['src/branchy.js'].split('\n').length,
+      ),
+    };
+
+    const twoPassCrap = await scanAndScore({
+      targetDirs,
+      coverage,
+      requireCoverage: true,
+      cwd: tmpDir,
+    });
+    const { crap, miScores } = await scanAndScoreCombined({
+      targetDirs,
+      coverage,
+      requireCoverage: true,
+      cwd: tmpDir,
+    });
+
+    // CRAP parity: same rows, same skip counters.
+    assert.deepEqual(crap, twoPassCrap);
+    assert.ok(crap.skippedFilesNoCoverage >= 2);
+    // MI parity invariant: MI scores EVERY file regardless of coverage, so the
+    // two coverage-skipped files still appear in miScores (the combined worker
+    // computes MI before the coverage gate). Compare against the standalone MI
+    // pass to prove it.
+    const miFiles = [];
+    const { scanDirectory } = await import(
+      '../../.agents/scripts/lib/maintainability-utils.js'
+    );
+    for (const dir of targetDirs) scanDirectory(dir, miFiles, { cwd: tmpDir });
+    const twoPassMi = reKeyToCwd(await calculateAll(miFiles), tmpDir);
+    assert.deepEqual(miScores, twoPassMi);
+    assert.equal(Object.keys(miScores).length, 3);
+  });
+
+  it('crap result deep-equals scanAndScore with requireCoverage:false', async () => {
+    const targetDirs = [path.join(tmpDir, 'src')];
+    // No coverage at all; requireCoverage false means methods resolve
+    // coverage null → crap null → skipped methods, on both paths.
+    const twoPassCrap = await scanAndScore({
+      targetDirs,
+      coverage: null,
+      requireCoverage: false,
+      cwd: tmpDir,
+    });
+    const { crap } = await scanAndScoreCombined({
+      targetDirs,
+      coverage: null,
+      requireCoverage: false,
+      cwd: tmpDir,
+    });
+    assert.deepEqual(crap, twoPassCrap);
+  });
+
+  it('honours preScannedFiles identically to scanAndScore', async () => {
+    const targetDirs = [path.join(tmpDir, 'src')];
+    const coverage = buildCoverageMap();
+    const { scanDirectory } = await import(
+      '../../.agents/scripts/lib/maintainability-utils.js'
+    );
+    const preScanned = [];
+    for (const dir of targetDirs)
+      scanDirectory(dir, preScanned, { cwd: tmpDir });
+
+    const twoPassCrap = await scanAndScore({
+      targetDirs,
+      coverage,
+      requireCoverage: true,
+      cwd: tmpDir,
+      preScannedFiles: preScanned,
+    });
+    const { crap } = await scanAndScoreCombined({
+      targetDirs,
+      coverage,
+      requireCoverage: true,
+      cwd: tmpDir,
+      preScannedFiles: preScanned,
+    });
+    assert.deepEqual(crap, twoPassCrap);
+  });
+
+  it('rejects a non-array targetDirs (parity with scanAndScore guard)', async () => {
+    await assert.rejects(
+      () => scanAndScoreCombined({ targetDirs: 'nope', coverage: null }),
+      /targetDirs must be an array/,
+    );
+  });
+});

--- a/tests/lib/workers/combined-mi-crap-worker.test.js
+++ b/tests/lib/workers/combined-mi-crap-worker.test.js
@@ -1,0 +1,176 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import { handleCombinedMiCrapWorkerMessage } from '../../../.agents/scripts/lib/workers/combined-mi-crap-worker.js';
+
+/**
+ * Story #4192 — unit coverage for the combined MI + CRAP worker handler. The
+ * handler derives BOTH the maintainability score and the CRAP method rows from
+ * a single `analyzeOnce` parse. These tests pin every branch (bad-shape
+ * rejection, read/transpile/parse failures, the coverage gate, success rows,
+ * skipped methods) and — crucially — the invariant that the MI score is always
+ * computed even when the CRAP coverage gate skips the file.
+ */
+
+const STUB_ENTRY = { fnMap: {}, statementMap: {}, s: {} };
+
+const okItem = {
+  abs: '/abs/file.js',
+  relPath: 'src/file.js',
+  requireCoverage: false,
+  coverageEntry: STUB_ENTRY,
+};
+
+function stubDeps({
+  readFile = () => 'export const x = 1;',
+  transpile = (_abs, src) => src,
+  analyze = () => ({ miScore: 80, crapRows: [], parseError: false }),
+} = {}) {
+  return { readFile, transpile, analyze };
+}
+
+describe('handleCombinedMiCrapWorkerMessage — control messages', () => {
+  it('exit:true returns kind=exit', () => {
+    assert.deepEqual(handleCombinedMiCrapWorkerMessage({ exit: true }), {
+      kind: 'exit',
+    });
+  });
+
+  it('rejects messages with no item', () => {
+    const out = handleCombinedMiCrapWorkerMessage({}, stubDeps());
+    assert.equal(out.kind, 'reply');
+    assert.equal(out.message.ok, false);
+    assert.match(out.message.error, /bad worker message/);
+  });
+
+  it('rejects messages with non-string abs', () => {
+    const out = handleCombinedMiCrapWorkerMessage(
+      { item: { abs: 5, relPath: 'a' } },
+      stubDeps(),
+    );
+    assert.equal(out.message.ok, false);
+  });
+
+  it('rejects messages with non-string relPath', () => {
+    const out = handleCombinedMiCrapWorkerMessage(
+      { item: { abs: 'a', relPath: null } },
+      stubDeps(),
+    );
+    assert.equal(out.message.ok, false);
+  });
+});
+
+describe('handleCombinedMiCrapWorkerMessage — failure isolation', () => {
+  it('readFile throws → miScore null AND crapRows null', () => {
+    const out = handleCombinedMiCrapWorkerMessage(
+      { item: okItem },
+      stubDeps({
+        readFile: () => {
+          throw new Error('ENOENT');
+        },
+      }),
+    );
+    assert.equal(out.message.ok, true);
+    assert.equal(out.message.result.miScore, null);
+    assert.equal(out.message.result.crapRows, null);
+  });
+
+  it('transpile returns null → miScore 0 AND crapRows null', () => {
+    const out = handleCombinedMiCrapWorkerMessage(
+      { item: okItem },
+      stubDeps({ transpile: () => null }),
+    );
+    assert.equal(out.message.result.miScore, 0);
+    assert.equal(out.message.result.crapRows, null);
+  });
+
+  it('parse error → miScore 0 AND crapRows null', () => {
+    const out = handleCombinedMiCrapWorkerMessage(
+      { item: okItem },
+      stubDeps({
+        analyze: () => ({ miScore: 0, crapRows: [], parseError: true }),
+      }),
+    );
+    assert.equal(out.message.result.miScore, 0);
+    assert.equal(out.message.result.crapRows, null);
+  });
+});
+
+describe('handleCombinedMiCrapWorkerMessage — coverage gate', () => {
+  it('requireCoverage + null entry → skippedFileNoCoverage but MI STILL computed', () => {
+    const out = handleCombinedMiCrapWorkerMessage(
+      {
+        item: { ...okItem, requireCoverage: true, coverageEntry: null },
+      },
+      stubDeps({
+        analyze: () => ({ miScore: 73.5, crapRows: [], parseError: false }),
+      }),
+    );
+    assert.equal(out.message.ok, true);
+    assert.equal(out.message.result.skippedFileNoCoverage, true);
+    assert.deepEqual(out.message.result.crapRows, []);
+    // The load-bearing MI invariant: the module score is returned even though
+    // CRAP skipped the file — MI never required coverage.
+    assert.equal(out.message.result.miScore, 73.5);
+  });
+
+  it('requireCoverage + undefined entry → skippedFileNoCoverage, MI computed', () => {
+    const { coverageEntry: _drop, ...itemNoCov } = okItem;
+    const out = handleCombinedMiCrapWorkerMessage(
+      { item: { ...itemNoCov, requireCoverage: true } },
+      stubDeps({
+        analyze: () => ({ miScore: 90, crapRows: [], parseError: false }),
+      }),
+    );
+    assert.equal(out.message.result.skippedFileNoCoverage, true);
+    assert.equal(out.message.result.miScore, 90);
+  });
+
+  it('requireCoverage:false continues even when coverageEntry is null', () => {
+    const out = handleCombinedMiCrapWorkerMessage(
+      { item: { ...okItem, coverageEntry: null } },
+      stubDeps(),
+    );
+    assert.equal(out.message.result.skippedFileNoCoverage, false);
+    assert.deepEqual(out.message.result.crapRows, []);
+  });
+});
+
+describe('handleCombinedMiCrapWorkerMessage — success rows', () => {
+  it('returns miScore and CRAP rows for fully-covered methods', () => {
+    const rawRows = [
+      { method: 'a', startLine: 5, cyclomatic: 2, coverage: 1, crap: 2 },
+      { method: 'b', startLine: 9, cyclomatic: 4, coverage: 0.5, crap: 6 },
+    ];
+    const out = handleCombinedMiCrapWorkerMessage(
+      { item: okItem },
+      stubDeps({
+        analyze: () => ({
+          miScore: 65.25,
+          crapRows: rawRows,
+          parseError: false,
+        }),
+      }),
+    );
+    assert.equal(out.message.result.miScore, 65.25);
+    assert.equal(out.message.result.crapRows.length, 2);
+    assert.equal(out.message.result.skippedMethodsNoCoverage, 0);
+  });
+
+  it('skips methods with null crap or null coverage and counts them', () => {
+    const rawRows = [
+      { method: 'a', startLine: 5, cyclomatic: 2, coverage: 1, crap: 2 },
+      { method: 'b', startLine: 9, cyclomatic: 1, coverage: null, crap: null },
+      { method: 'c', startLine: 12, cyclomatic: 3, coverage: 0.8, crap: null },
+    ];
+    const out = handleCombinedMiCrapWorkerMessage(
+      { item: okItem },
+      stubDeps({
+        analyze: () => ({ miScore: 50, crapRows: rawRows, parseError: false }),
+      }),
+    );
+    assert.equal(out.message.result.crapRows.length, 1);
+    assert.equal(out.message.result.skippedMethodsNoCoverage, 2);
+    assert.equal(out.message.result.miScore, 50);
+  });
+});


### PR DESCRIPTION
Closes #4192

_Auto-opened by `/single-story-deliver`._