### PR TITLE
feat(bench): add Mandrel self-benchmark harness (Epic #4211)

### DIFF
--- a/bench/collect/normalize.js
+++ b/bench/collect/normalize.js
@@ -1,0 +1,542 @@
+// bench/collect/normalize.js
+//
+// Telemetry normalizer for the Mandrel self-benchmark harness (Epic #4211,
+// Story #4217). Internal tooling only — never shipped in the distributed
+// `.agents/` bundle, never run against the live repo.
+//
+// This module is the join point of the harness: it reads the raw artifacts a
+// single (scenario × arm × run) produced —
+//
+//   1. the run's lifecycle NDJSON ledger (temp/epic-<id>/lifecycle.ndjson),
+//   2. the per-Story signals NDJSON files,
+//   3. the `claude -p --output-format json` usage/cost envelope (parsed by
+//      bench/driver/run-session.js#parseSessionEnvelope),
+//   4. the scenario's frozen acceptance-suite result + the acceptance-eval
+//      cross-check verdict (the Quality inputs), and
+//   5. the plan-vs-actual counts (planned/delivered Story counts, planned vs
+//      touched file footprints)
+//
+// — and folds them into ONE per-run record that conforms to
+// bench/schemas/scorecard.schema.json. The dimension math is delegated to
+// bench/score/dimensions.js; this module owns the *extraction* of the raw
+// sub-signals from the lifecycle ledger (timings, dispatch count, autonomy
+// counters, and the ceremony/codegen token split) and the assembly of the
+// surrounding scorecard envelope.
+//
+// Determinism: pure functions plus a thin file-reading shell. The NDJSON
+// parser and every derivation are pure; only `normalizeRunFromPaths` touches
+// the filesystem (and only to read the three artifact kinds), so the core is
+// unit-testable from in-memory inputs with no I/O.
+
+import { readFileSync } from 'node:fs';
+
+import { computeDimensions } from '../score/dimensions.js';
+
+/** Scorecard-record schema version this normalizer emits. */
+export const SCORECARD_SCHEMA_VERSION = 1;
+
+/**
+ * Lifecycle events that bound the *codegen* spans (shippable
+ * Story-implementation work). Tokens spent inside a
+ * `story.dispatch.start` → `story.dispatch.end` window are codegen; everything
+ * else in the session (planning between `epic.plan.start`/`epic.plan.end`,
+ * orchestration, gate/close machinery) is attributed to ceremony as the
+ * `total − codegen` remainder (see `deriveTokenSplit`).
+ */
+const STORY_DISPATCH_START = 'story.dispatch.start';
+const STORY_DISPATCH_END = 'story.dispatch.end';
+
+/** Lifecycle events that count toward the autonomy intervention tally. */
+const EPIC_BLOCKED = 'epic.blocked';
+const STORY_BLOCKED = 'story.blocked';
+const INTERVENTION_RECORDED = 'intervention.recorded';
+
+/**
+ * Parse an NDJSON string into an array of records. Blank lines are skipped;
+ * a malformed line throws with its 1-based line number so a corrupt ledger
+ * fails loudly rather than silently dropping telemetry.
+ *
+ * Each lifecycle record has the shape written by the LedgerWriter / the thin
+ * emit helpers: `{ kind, ts, seqId?, event, payload }`.
+ *
+ * @param {string} text
+ * @returns {Array<object>}
+ * @throws {SyntaxError} on a non-blank line that is not valid JSON.
+ */
+export function parseNdjson(text) {
+  if (typeof text !== 'string') {
+    throw new TypeError('parseNdjson: input must be a string');
+  }
+  const out = [];
+  const lines = text.split('\n');
+  for (let i = 0; i < lines.length; i += 1) {
+    const line = lines[i].trim();
+    if (line.length === 0) continue;
+    try {
+      out.push(JSON.parse(line));
+    } catch (cause) {
+      throw new SyntaxError(
+        `parseNdjson: invalid JSON on line ${i + 1}: ${cause.message}`,
+      );
+    }
+  }
+  return out;
+}
+
+/**
+ * The `emitted` records are the canonical lifecycle signal; the LedgerWriter
+ * also writes `completed`/`failed` bookkeeping records that repeat an event
+ * name without a payload. For deriving run telemetry we only ever want the
+ * `emitted` records (every emit produces exactly one). Records written by the
+ * thin direct-append helpers (heartbeat, dispatch-end) are already
+ * `kind: 'emitted'`, so this filter unifies both producers.
+ *
+ * @param {Array<object>} records
+ * @returns {Array<object>}
+ */
+function emittedRecords(records) {
+  return records.filter(
+    (r) => r?.event && r.kind !== 'completed' && r.kind !== 'failed',
+  );
+}
+
+/**
+ * Parse an ISO-8601 timestamp into epoch ms, or NaN when absent/malformed.
+ *
+ * @param {unknown} ts
+ * @returns {number}
+ */
+function tsMs(ts) {
+  if (typeof ts !== 'string') return Number.NaN;
+  const ms = Date.parse(ts);
+  return Number.isFinite(ms) ? ms : Number.NaN;
+}
+
+/**
+ * Derive the wall-clock duration of a run from the span of its lifecycle
+ * records: `last.ts − first.ts`, in milliseconds. Records are NOT assumed to
+ * be sorted, so we scan for the min and max parseable timestamp. Returns 0
+ * when fewer than two timestamps are present.
+ *
+ * GitHub round-trip latency is intentionally inside this window — it is part
+ * of Mandrel's real overhead (README § 4).
+ *
+ * @param {Array<object>} records  Lifecycle records.
+ * @returns {number}
+ */
+export function deriveWallClockMs(records) {
+  let min = Number.POSITIVE_INFINITY;
+  let max = Number.NEGATIVE_INFINITY;
+  let count = 0;
+  for (const r of records) {
+    const ms = tsMs(r?.ts);
+    if (!Number.isFinite(ms)) continue;
+    count += 1;
+    if (ms < min) min = ms;
+    if (ms > max) max = ms;
+  }
+  if (count < 2) return 0;
+  return Math.max(0, max - min);
+}
+
+/**
+ * Count Story dispatches (sub-agent launches) — one per
+ * `story.dispatch.start` record.
+ *
+ * @param {Array<object>} records  Emitted lifecycle records.
+ * @returns {number}
+ */
+export function deriveDispatchCount(records) {
+  let n = 0;
+  for (const r of records) {
+    if (r.event === STORY_DISPATCH_START) n += 1;
+  }
+  return n;
+}
+
+/**
+ * Derive the autonomy counters from the lifecycle ledger plus the per-Story
+ * signals.
+ *
+ *   blockedEvents — `epic.blocked` + `story.blocked` records.
+ *   manualRescues — `intervention.recorded` records.
+ *   hitlStops     — STOP gates the run actually halted at. In a correctly
+ *                   configured unattended run these auto-proceed (count 0); a
+ *                   non-zero value is a finding. They are sourced from
+ *                   explicit signal records (`kind: 'hitl-stop'` or
+ *                   `signal: 'hitl-stop'`) in the per-Story signals, since the
+ *                   lifecycle bus has no dedicated HITL-stop event — an
+ *                   auto-proceeding gate emits nothing.
+ *
+ * @param {object} args
+ * @param {Array<object>} args.lifecycle  Emitted lifecycle records.
+ * @param {Array<object>} [args.signals]  Flattened per-Story signal records.
+ * @returns {{ hitlStops: number, blockedEvents: number, manualRescues: number }}
+ */
+export function deriveAutonomyCounters({ lifecycle, signals = [] }) {
+  let blockedEvents = 0;
+  let manualRescues = 0;
+  for (const r of lifecycle) {
+    if (r.event === EPIC_BLOCKED || r.event === STORY_BLOCKED)
+      blockedEvents += 1;
+    else if (r.event === INTERVENTION_RECORDED) manualRescues += 1;
+  }
+  let hitlStops = 0;
+  for (const s of signals) {
+    if (s?.kind === 'hitl-stop' || s?.signal === 'hitl-stop') hitlStops += 1;
+  }
+  return { hitlStops, blockedEvents, manualRescues };
+}
+
+/**
+ * Split the run's total tokens into a ceremony bucket and a codegen bucket
+ * using the lifecycle phase boundaries (README § 5, "Token attribution").
+ *
+ * Mandrel records no per-phase token actuals — the only cost source is the
+ * single session-level `claude -p` envelope (`totalTokens`). So we attribute
+ * the *session total* across the two buckets in proportion to the wall-clock
+ * time each bucket occupied:
+ *
+ *   codegenMs  = Σ (story.dispatch.end.ts − matching story.dispatch.start.ts)
+ *   ceremonyMs = wallClockMs − codegenMs
+ *   codegenTokens  = round(totalTokens · codegenMs / wallClockMs)
+ *   ceremonyTokens = totalTokens − codegenTokens   (so the two always sum to total)
+ *
+ * Time-proportional attribution is the honest derivation available from the
+ * recorded inputs: the implementation phases that produce shippable artifacts
+ * are exactly the dispatch windows, and everything else in the session
+ * (planning, orchestration, gate/close machinery) is ceremony. The per-Story
+ * dispatch windows are matched start→end by `storyId`; an unclosed dispatch
+ * (start with no end) contributes nothing to codegen time (it never produced a
+ * settled shippable result within the recorded window).
+ *
+ * Edge cases:
+ *   - `wallClockMs === 0` (single-timestamp ledger): the whole session total
+ *     is ceremony (no measurable codegen window).
+ *   - `totalTokens === 0`: both buckets are 0.
+ *   - control arm: typically no dispatch windows, so codegen ≈ the bare run
+ *     and ceremony ≈ 0 — matching the README's "control arm sits near the
+ *     floor".
+ *
+ * @param {object} args
+ * @param {Array<object>} args.lifecycle    Emitted lifecycle records.
+ * @param {number} args.totalTokens         Session total tokens (from envelope).
+ * @param {number} args.wallClockMs         Derived run wall-clock.
+ * @returns {{
+ *   ceremonyTokens: number,
+ *   codegenTokens: number,
+ *   ceremonyMs: number,
+ *   codegenMs: number
+ * }}
+ */
+export function deriveTokenSplit({ lifecycle, totalTokens, wallClockMs }) {
+  const total =
+    typeof totalTokens === 'number' && totalTokens >= 0
+      ? Math.trunc(totalTokens)
+      : 0;
+  const wall =
+    typeof wallClockMs === 'number' && wallClockMs > 0 ? wallClockMs : 0;
+
+  // Sum the matched dispatch windows. Match start→end per storyId; a start
+  // with no matching end contributes no codegen time.
+  const openStartMsByStory = new Map();
+  let codegenMs = 0;
+  for (const r of lifecycle) {
+    const storyId = r?.payload?.storyId;
+    const ms = tsMs(r.ts);
+    if (r.event === STORY_DISPATCH_START && Number.isFinite(ms)) {
+      openStartMsByStory.set(storyId, ms);
+    } else if (r.event === STORY_DISPATCH_END && Number.isFinite(ms)) {
+      const startMs = openStartMsByStory.get(storyId);
+      if (Number.isFinite(startMs) && ms >= startMs) {
+        codegenMs += ms - startMs;
+        openStartMsByStory.delete(storyId);
+      }
+    }
+  }
+  // Codegen time can never exceed the run's wall-clock (overlapping parallel
+  // dispatches could otherwise sum past it); clamp so the proportion is valid.
+  if (wall > 0 && codegenMs > wall) codegenMs = wall;
+  const ceremonyMs = wall > 0 ? Math.max(0, wall - codegenMs) : 0;
+
+  let codegenTokens = 0;
+  if (total > 0 && wall > 0) {
+    codegenTokens = Math.round((total * codegenMs) / wall);
+    if (codegenTokens > total) codegenTokens = total;
+  }
+  const ceremonyTokens = total - codegenTokens;
+
+  return { ceremonyTokens, codegenTokens, ceremonyMs, codegenMs };
+}
+
+/**
+ * Extract the usage/cost fields the scorecard needs from a parsed `claude -p`
+ * envelope. Accepts either the normalized shape returned by
+ * `run-session.js#parseSessionEnvelope` (`{ usage: { totalTokens, … }, cost:
+ * { totalUsd } }`) or a raw envelope (`{ usage: { input_tokens, … },
+ * total_cost_usd }`), so the normalizer is robust to being handed either.
+ *
+ * @param {object} envelope
+ * @returns {{
+ *   totalTokens: number,
+ *   inputTokens: number,
+ *   outputTokens: number,
+ *   costUsd: number|null
+ * }}
+ */
+export function extractUsage(envelope) {
+  if (!envelope || typeof envelope !== 'object') {
+    return { totalTokens: 0, inputTokens: 0, outputTokens: 0, costUsd: null };
+  }
+  const usage =
+    envelope.usage && typeof envelope.usage === 'object' ? envelope.usage : {};
+
+  // Normalized shape (from parseSessionEnvelope).
+  if (typeof usage.totalTokens === 'number') {
+    const totalUsd =
+      envelope.cost && typeof envelope.cost === 'object'
+        ? envelope.cost.totalUsd
+        : null;
+    return {
+      totalTokens: nonNeg(usage.totalTokens),
+      inputTokens: nonNeg(usage.inputTokens),
+      outputTokens: nonNeg(usage.outputTokens),
+      costUsd: typeof totalUsd === 'number' && totalUsd >= 0 ? totalUsd : null,
+    };
+  }
+
+  // Raw envelope shape.
+  const inputTokens = nonNeg(usage.input_tokens);
+  const outputTokens = nonNeg(usage.output_tokens);
+  const cacheCreate = nonNeg(usage.cache_creation_input_tokens);
+  const cacheRead = nonNeg(usage.cache_read_input_tokens);
+  const totalUsd =
+    typeof envelope.total_cost_usd === 'number' && envelope.total_cost_usd >= 0
+      ? envelope.total_cost_usd
+      : null;
+  return {
+    totalTokens: inputTokens + outputTokens + cacheCreate + cacheRead,
+    inputTokens,
+    outputTokens,
+    costUsd: totalUsd,
+  };
+}
+
+/**
+ * Coerce to a non-negative integer (0 on miss).
+ * @param {unknown} v
+ * @returns {number}
+ */
+function nonNeg(v) {
+  return typeof v === 'number' && Number.isFinite(v) && v >= 0
+    ? Math.trunc(v)
+    : 0;
+}
+
+/**
+ * Build one per-run scorecard record from already-parsed in-memory inputs.
+ * This is the pure core — no filesystem access — so it is fully unit-testable.
+ *
+ * @param {object} args
+ * @param {object} args.run             Run identity / stamp.
+ * @param {string} args.run.runId
+ * @param {string} args.run.timestamp   ISO-8601 run-complete time.
+ * @param {{ id: string, displayName?: string }} args.run.model
+ * @param {string} args.run.frameworkVersion
+ * @param {{ node: string, os: string, host?: string }} args.run.env
+ * @param {'hello-world'|'crud-db'} args.run.scenario
+ * @param {'mandrel'|'control'} args.run.arm
+ * @param {Array<object>} args.lifecycle   Parsed lifecycle NDJSON records.
+ * @param {Array<object>} [args.signals]   Flattened per-Story signal records.
+ * @param {object} args.envelope           Parsed `claude -p` usage envelope.
+ * @param {object} args.quality            Frozen-suite + judge inputs:
+ *   `{ frozenSuitePassed, frozenSuiteTotal, acceptanceEvalScore? }`.
+ * @param {object} [args.planning]         Plan-vs-actual inputs:
+ *   `{ rePlanCount?, plannedStoryCount?, deliveredStoryCount?,
+ *      fileFootprintDrift?|{plannedPaths, actualPaths} }`. Ignored for control.
+ * @param {object} [args.rawRefs]          Provenance breadcrumbs for `rawRefs`.
+ * @returns {object} A scorecard record conforming to scorecard.schema.json.
+ */
+export function buildScorecard({
+  run,
+  lifecycle = [],
+  signals = [],
+  envelope,
+  quality,
+  planning = {},
+  rawRefs,
+}) {
+  if (!run || typeof run !== 'object') {
+    throw new TypeError('buildScorecard: run identity is required');
+  }
+  const required = [
+    'runId',
+    'timestamp',
+    'model',
+    'frameworkVersion',
+    'env',
+    'scenario',
+    'arm',
+  ];
+  for (const key of required) {
+    if (run[key] === undefined || run[key] === null) {
+      throw new TypeError(`buildScorecard: run.${key} is required`);
+    }
+  }
+  if (run.arm !== 'mandrel' && run.arm !== 'control') {
+    throw new TypeError(
+      `buildScorecard: run.arm must be "mandrel" or "control", got ${String(run.arm)}`,
+    );
+  }
+  if (!quality || typeof quality !== 'object') {
+    throw new TypeError('buildScorecard: quality inputs are required');
+  }
+
+  const emitted = emittedRecords(lifecycle);
+
+  // ---- Lifecycle-derived raw sub-signals -------------------------------
+  const wallClockMs = deriveWallClockMs(emitted);
+  const dispatches = deriveDispatchCount(emitted);
+  const autonomy = deriveAutonomyCounters({ lifecycle: emitted, signals });
+  const usage = extractUsage(envelope);
+  const split = deriveTokenSplit({
+    lifecycle: emitted,
+    totalTokens: usage.totalTokens,
+    wallClockMs,
+  });
+
+  // ---- Dimension math (delegated to the scorer) ------------------------
+  const dimensions = computeDimensions({
+    arm: run.arm,
+    quality: {
+      frozenSuitePassed: quality.frozenSuitePassed,
+      frozenSuiteTotal: quality.frozenSuiteTotal,
+      acceptanceEvalScore:
+        run.arm === 'control' && quality.acceptanceEvalScore === undefined
+          ? null
+          : (quality.acceptanceEvalScore ?? null),
+    },
+    planningFidelity: {
+      rePlanCount: planning.rePlanCount,
+      plannedStoryCount: planning.plannedStoryCount,
+      deliveredStoryCount: planning.deliveredStoryCount,
+      fileFootprintDrift: planning.fileFootprintDrift,
+      plannedPaths: planning.plannedPaths,
+      actualPaths: planning.actualPaths,
+    },
+    autonomy,
+    efficiency: {
+      wallClockMs,
+      totalTokens: usage.totalTokens,
+      inputTokens: usage.inputTokens,
+      outputTokens: usage.outputTokens,
+      dispatches,
+      costUsd: usage.costUsd,
+    },
+    overheadRatio: {
+      ceremonyTokens: split.ceremonyTokens,
+      codegenTokens: split.codegenTokens,
+      ceremonyMs: split.ceremonyMs,
+      codegenMs: split.codegenMs,
+    },
+  });
+
+  const scorecard = {
+    schemaVersion: SCORECARD_SCHEMA_VERSION,
+    runId: run.runId,
+    timestamp: run.timestamp,
+    model:
+      typeof run.model === 'string'
+        ? { id: run.model }
+        : {
+            id: run.model.id,
+            ...(run.model.displayName
+              ? { displayName: run.model.displayName }
+              : {}),
+          },
+    frameworkVersion: run.frameworkVersion,
+    env: {
+      node: run.env.node,
+      os: run.env.os,
+      ...(run.env.host ? { host: run.env.host } : {}),
+    },
+    scenario: run.scenario,
+    arm: run.arm,
+    dimensions,
+  };
+
+  if (rawRefs && typeof rawRefs === 'object') {
+    scorecard.rawRefs = rawRefs;
+  }
+
+  return scorecard;
+}
+
+/**
+ * Filesystem shell over `buildScorecard`: read the lifecycle NDJSON, the
+ * per-Story signals NDJSON files, and the `claude -p` envelope JSON from disk,
+ * then assemble the scorecard. The Quality and planning inputs are passed
+ * in-memory by the caller (they come from the frozen-suite/judge run and the
+ * decomposer output, not from a single artifact file on disk).
+ *
+ * @param {object} args
+ * @param {object} args.run                 Run identity (see buildScorecard).
+ * @param {string} args.lifecyclePath       Path to lifecycle.ndjson.
+ * @param {string[]} [args.signalsPaths]    Paths to per-Story signals.ndjson.
+ * @param {string} args.costEnvelopePath    Path to the captured envelope JSON.
+ * @param {object} args.quality             Quality inputs.
+ * @param {object} [args.planning]          Plan-vs-actual inputs.
+ * @param {object} [args.rawRefs]           Provenance overrides; when omitted,
+ *   the supplied paths are recorded.
+ * @param {object} [deps]
+ * @param {(p: string, enc: string) => string} [deps.readFileImpl]  Injectable
+ *   reader (tests).
+ * @returns {object} A scorecard record.
+ */
+export function normalizeRunFromPaths(
+  {
+    run,
+    lifecyclePath,
+    signalsPaths = [],
+    costEnvelopePath,
+    quality,
+    planning = {},
+    rawRefs,
+  },
+  deps = {},
+) {
+  const read = deps.readFileImpl ?? readFileSync;
+
+  if (typeof lifecyclePath !== 'string' || lifecyclePath.length === 0) {
+    throw new TypeError('normalizeRunFromPaths: lifecyclePath is required');
+  }
+  if (typeof costEnvelopePath !== 'string' || costEnvelopePath.length === 0) {
+    throw new TypeError('normalizeRunFromPaths: costEnvelopePath is required');
+  }
+
+  const lifecycle = parseNdjson(read(lifecyclePath, 'utf8'));
+
+  const signals = [];
+  for (const p of signalsPaths) {
+    const recs = parseNdjson(read(p, 'utf8'));
+    for (const r of recs) signals.push(r);
+  }
+
+  const envelope = JSON.parse(read(costEnvelopePath, 'utf8'));
+
+  const resolvedRawRefs = rawRefs ?? {
+    lifecycleNdjson: lifecyclePath,
+    ...(signalsPaths.length > 0 ? { signalsNdjson: [...signalsPaths] } : {}),
+    costEnvelope: costEnvelopePath,
+  };
+
+  return buildScorecard({
+    run,
+    lifecycle,
+    signals,
+    envelope,
+    quality,
+    planning,
+    rawRefs: resolvedRawRefs,
+  });
+}

--- a/bench/driver/run-session.js
+++ b/bench/driver/run-session.js
@@ -1,0 +1,452 @@
+// bench/driver/run-session.js
+/**
+ * Headless run driver for the Mandrel self-benchmark harness.
+ *
+ * A "run" is one headless Claude Code session driving one arm over one
+ * scenario. The driver shells out to `claude -p --output-format json`, which
+ * runs the agent non-interactively and emits a single JSON result envelope on
+ * stdout carrying the real usage/cost actuals (`total_cost_usd`, `usage`,
+ * `modelUsage`, timings). This is the ONLY cost source in the harness — Mandrel
+ * itself records no token actuals — and it is measured identically for both
+ * arms, so the value/cost comparison is apples-to-apples by construction
+ * (Epic #4211, Tech Spec #4213).
+ *
+ * Precedent: `.agents/scripts/lib/orchestration/review-providers/security-review.js`
+ * (`defaultInvokeSecurityReview`) already shells `claude --print` and parses
+ * its stdout. This module follows the same shape — a default `spawnSync`-based
+ * invoker that is **injectable** (`invokeFn`) so unit tests never spawn a real
+ * process — but targets the `-p --output-format json` envelope rather than the
+ * free-text `--print` mode.
+ *
+ * The driver does NOT score, persist, or read lifecycle telemetry — those are
+ * downstream slices. It launches the session, parses the envelope, and returns
+ * a normalized `{ usage, cost, raw, ... }` record plus the per-run prompt that
+ * was sent.
+ */
+
+import { spawnSync } from 'node:child_process';
+
+/**
+ * Pinned default model id. The harness records the exact model on every
+ * scorecard and only ever compares like-model to like-model (Epic Non-Goal:
+ * "A model benchmark — the model is pinned and recorded"). Overridable per run.
+ */
+export const DEFAULT_BENCH_MODEL = 'claude-opus-4-8';
+
+/**
+ * Hard ceiling for a single headless session. Long agentic `/deliver` runs are
+ * the expensive case; default to one hour and let callers override.
+ */
+export const DEFAULT_SESSION_TIMEOUT_MS = 60 * 60 * 1000;
+
+/**
+ * Compose the prompt sent to `claude -p` for a given arm + scenario.
+ *
+ * - **mandrel** arm: drive the real Mandrel pipeline (`/plan` then `/deliver`)
+ *   so planning fidelity is genuinely measured rather than pre-staged
+ *   (Epic Non-Goal: "Pre-staged plans … would grade our own homework").
+ * - **control** arm: hand the bare task straight to the model with no
+ *   scaffolding.
+ *
+ * The unattended-mode preamble (auto-proceed through HITL gates) is documented
+ * in `bench/driver/unattended.md` and injected here so every Mandrel-arm run
+ * carries it. Exported so docs tooling and tests reference one canonical
+ * builder.
+ *
+ * @param {object} input
+ * @param {'mandrel'|'control'} input.arm
+ * @param {{ id: string, taskPrompt: string, epicId?: number|string }} input.scenario
+ * @returns {string}
+ */
+export function buildArmPrompt(input) {
+  const { arm, scenario } = input ?? {};
+  if (!scenario || typeof scenario.id !== 'string') {
+    throw new TypeError('buildArmPrompt requires a scenario with a string id');
+  }
+  if (
+    typeof scenario.taskPrompt !== 'string' ||
+    scenario.taskPrompt.length === 0
+  ) {
+    throw new TypeError('buildArmPrompt requires scenario.taskPrompt');
+  }
+
+  if (arm === 'control') {
+    // Bare-model baseline: no Mandrel scaffolding, no pipeline ceremony.
+    return (
+      `You are working in a fresh git checkout. Complete the following task ` +
+      `end to end, committing your work. Do not ask for confirmation — proceed ` +
+      `autonomously to completion.\n\nTask (${scenario.id}):\n${scenario.taskPrompt}`
+    );
+  }
+
+  if (arm === 'mandrel') {
+    // Mandrel pipeline arm. Auto-proceed directive keeps the HITL STOP gates
+    // from stalling the headless session (see unattended.md).
+    return (
+      `You are operating Mandrel's pipeline non-interactively under a headless ` +
+      `benchmark driver. There is no human at the keyboard. At every ` +
+      `human-in-the-loop STOP / confirmation gate (one-pager confirm, spec ` +
+      `review, decomposition diff gate, and the auto-merge-else-operator-merge ` +
+      `step), treat the absence of an operator as implicit approval and proceed ` +
+      `with the best available interpretation — never block waiting for input. ` +
+      `Author the plan with /plan and then deliver it with /deliver; do not ` +
+      `pre-stage any planning artifact.\n\nTask (${scenario.id}):\n${scenario.taskPrompt}`
+    );
+  }
+
+  throw new TypeError(
+    `buildArmPrompt arm must be "mandrel" or "control", got: ${String(arm)}`,
+  );
+}
+
+/**
+ * Build the argv passed to the `claude` binary for a headless JSON run.
+ * Exported so tests assert the exact invocation shape (notably
+ * `--output-format json`, which is what makes the usage/cost envelope appear).
+ *
+ * `--permission-mode bypassPermissions` and `--dangerously-skip-permissions`
+ * are intentionally NOT added here by default — the harness runs inside a
+ * throwaway sandbox clone (see `sandbox.js`); callers that need a broader
+ * autorun posture pass `extraArgs`. We keep the default surface minimal.
+ *
+ * @param {object} input
+ * @param {string} input.prompt
+ * @param {string} input.model
+ * @param {string[]} [input.extraArgs]
+ * @returns {string[]}
+ */
+export function buildClaudeArgs(input) {
+  const { prompt, model, extraArgs = [] } = input ?? {};
+  if (typeof prompt !== 'string' || prompt.length === 0) {
+    throw new TypeError('buildClaudeArgs requires a non-empty prompt');
+  }
+  if (typeof model !== 'string' || model.length === 0) {
+    throw new TypeError('buildClaudeArgs requires a non-empty model');
+  }
+  if (!Array.isArray(extraArgs)) {
+    throw new TypeError('buildClaudeArgs extraArgs must be an array');
+  }
+  return [
+    '-p',
+    '--output-format',
+    'json',
+    '--model',
+    model,
+    ...extraArgs,
+    prompt,
+  ];
+}
+
+/**
+ * Default invoker: shell out to the host's `claude` CLI in headless JSON mode.
+ * Exported and injectable — the production caller accepts an `invokeFn`
+ * override so tests never spawn a real process.
+ *
+ * Mirrors `defaultInvokeSecurityReview`'s contract: returns
+ * `{ status, stdout, stderr }`. The `cwd` is the ephemeral sandbox clone, so
+ * all churn lands there and never in the live repo.
+ *
+ * @param {object} input
+ * @param {string} input.prompt
+ * @param {string} input.model
+ * @param {string} input.cwd       Absolute path of the sandbox clone to run in.
+ * @param {string[]} [input.extraArgs]
+ * @param {number} [input.timeoutMs]
+ * @returns {{ status: number, stdout: string, stderr: string }}
+ */
+export function defaultInvokeClaudeSession(input) {
+  const { prompt, model, cwd, extraArgs, timeoutMs } = input ?? {};
+  const args = buildClaudeArgs({ prompt, model, extraArgs });
+  const result = spawnSync('claude', args, {
+    cwd,
+    encoding: 'utf-8',
+    shell: process.platform === 'win32',
+    timeout: timeoutMs ?? DEFAULT_SESSION_TIMEOUT_MS,
+    maxBuffer: 64 * 1024 * 1024,
+  });
+  return {
+    status: result.status ?? 1,
+    stdout: result.stdout ?? '',
+    stderr: result.stderr ?? '',
+  };
+}
+
+/**
+ * Parse the `claude -p --output-format json` envelope into the fields the
+ * harness needs. The envelope is a single JSON object on stdout; we tolerate
+ * leading/trailing whitespace and a possible prose preface by extracting the
+ * first balanced top-level object.
+ *
+ * Verified against a live run on `claude` 2.1.178: the envelope carries
+ * `type:"result"`, `subtype`, `is_error`, `result`, `total_cost_usd`,
+ * `usage:{ input_tokens, output_tokens, cache_creation_input_tokens,
+ * cache_read_input_tokens, ... }`, `modelUsage`, `duration_ms`, `num_turns`,
+ * `session_id`, `permission_denials`, and `terminal_reason`.
+ *
+ * Exported for testing.
+ *
+ * @param {string} rawStdout
+ * @returns {{
+ *   type: string|undefined,
+ *   subtype: string|undefined,
+ *   isError: boolean,
+ *   result: string|undefined,
+ *   sessionId: string|undefined,
+ *   numTurns: number|undefined,
+ *   durationMs: number|undefined,
+ *   cost: { totalUsd: number|null },
+ *   usage: {
+ *     inputTokens: number,
+ *     outputTokens: number,
+ *     cacheCreationInputTokens: number,
+ *     cacheReadInputTokens: number,
+ *     totalTokens: number
+ *   },
+ *   modelUsage: Record<string, unknown>,
+ *   permissionDenials: unknown[],
+ *   terminalReason: string|undefined,
+ *   raw: object
+ * }}
+ * @throws {Error} when stdout contains no parseable JSON object.
+ */
+export function parseSessionEnvelope(rawStdout) {
+  const obj = extractFirstJsonObject(rawStdout);
+  if (obj === null) {
+    throw new Error(
+      '[run-session] Failed to parse claude --output-format json stdout as a JSON object.',
+    );
+  }
+
+  const usage = obj.usage && typeof obj.usage === 'object' ? obj.usage : {};
+  const inputTokens = toNonNegInt(usage.input_tokens);
+  const outputTokens = toNonNegInt(usage.output_tokens);
+  const cacheCreationInputTokens = toNonNegInt(
+    usage.cache_creation_input_tokens,
+  );
+  const cacheReadInputTokens = toNonNegInt(usage.cache_read_input_tokens);
+
+  const totalCost =
+    typeof obj.total_cost_usd === 'number' &&
+    Number.isFinite(obj.total_cost_usd)
+      ? obj.total_cost_usd
+      : null;
+
+  return {
+    type: typeof obj.type === 'string' ? obj.type : undefined,
+    subtype: typeof obj.subtype === 'string' ? obj.subtype : undefined,
+    isError: obj.is_error === true,
+    result: typeof obj.result === 'string' ? obj.result : undefined,
+    sessionId: typeof obj.session_id === 'string' ? obj.session_id : undefined,
+    numTurns: Number.isFinite(obj.num_turns) ? obj.num_turns : undefined,
+    durationMs: Number.isFinite(obj.duration_ms) ? obj.duration_ms : undefined,
+    cost: { totalUsd: totalCost },
+    usage: {
+      inputTokens,
+      outputTokens,
+      cacheCreationInputTokens,
+      cacheReadInputTokens,
+      totalTokens:
+        inputTokens +
+        outputTokens +
+        cacheCreationInputTokens +
+        cacheReadInputTokens,
+    },
+    modelUsage:
+      obj.modelUsage && typeof obj.modelUsage === 'object'
+        ? obj.modelUsage
+        : {},
+    permissionDenials: Array.isArray(obj.permission_denials)
+      ? obj.permission_denials
+      : [],
+    terminalReason:
+      typeof obj.terminal_reason === 'string' ? obj.terminal_reason : undefined,
+    raw: obj,
+  };
+}
+
+/**
+ * Launch a headless `claude -p --output-format json` session for one arm and
+ * scenario and return the parsed usage/cost envelope.
+ *
+ * @param {object} opts
+ * @param {'mandrel'|'control'} opts.arm
+ * @param {{ id: string, taskPrompt: string, epicId?: number|string }} opts.scenario
+ * @param {string} opts.cwd  Absolute path of the ephemeral sandbox clone.
+ * @param {string} [opts.model=DEFAULT_BENCH_MODEL]
+ * @param {string[]} [opts.extraArgs]
+ * @param {number} [opts.timeoutMs=DEFAULT_SESSION_TIMEOUT_MS]
+ * @param {object} [deps]
+ * @param {(input: object) => { status: number, stdout: string, stderr: string }} [deps.invokeFn]
+ *   Injected session invoker. Defaults to `defaultInvokeClaudeSession`. Tests
+ *   override this so no real `claude` process is spawned.
+ * @param {{ info?: Function, warn?: Function, error?: Function }} [deps.logger]
+ * @returns {{
+ *   arm: 'mandrel'|'control',
+ *   scenarioId: string,
+ *   model: string,
+ *   prompt: string,
+ *   status: number,
+ *   envelope: ReturnType<typeof parseSessionEnvelope>
+ * }}
+ */
+export function runSession(opts = {}, deps = {}) {
+  const {
+    arm,
+    scenario,
+    cwd,
+    model = DEFAULT_BENCH_MODEL,
+    extraArgs = [],
+    timeoutMs = DEFAULT_SESSION_TIMEOUT_MS,
+  } = opts;
+
+  if (arm !== 'mandrel' && arm !== 'control') {
+    throw new TypeError(
+      `runSession arm must be "mandrel" or "control", got: ${String(arm)}`,
+    );
+  }
+  if (typeof cwd !== 'string' || cwd.length === 0) {
+    throw new TypeError(
+      'runSession requires a non-empty cwd (sandbox clone path)',
+    );
+  }
+
+  const invokeFn = deps.invokeFn ?? defaultInvokeClaudeSession;
+  const logger = deps.logger;
+
+  const prompt = buildArmPrompt({ arm, scenario });
+
+  logger?.info?.(
+    `[run-session] Launching headless session: arm=${arm} scenario=${scenario.id} model=${model}`,
+  );
+
+  const { status, stdout, stderr } = invokeFn({
+    prompt,
+    model,
+    cwd,
+    extraArgs,
+    timeoutMs,
+  });
+
+  if (status !== 0) {
+    throw new Error(
+      `[run-session] claude -p exited with status ${status} ` +
+        `(arm=${arm}, scenario=${scenario.id}): ${
+          stderr || stdout || '<no output>'
+        }`,
+    );
+  }
+
+  const envelope = parseSessionEnvelope(stdout);
+
+  // A clean exit code with an error envelope is still a failed run — surface it
+  // rather than silently returning a zero-cost record the scorer would trust.
+  if (envelope.isError) {
+    logger?.warn?.(
+      `[run-session] Session reported is_error=true (arm=${arm}, scenario=${scenario.id}): ${
+        envelope.result ?? '<no result text>'
+      }`,
+    );
+  }
+
+  logger?.info?.(
+    `[run-session] Session complete: arm=${arm} scenario=${scenario.id} ` +
+      `cost=$${envelope.cost.totalUsd ?? '?'} tokens=${envelope.usage.totalTokens} turns=${
+        envelope.numTurns ?? '?'
+      }`,
+  );
+
+  return {
+    arm,
+    scenarioId: scenario.id,
+    model,
+    prompt,
+    status,
+    envelope,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Coerce a value to a non-negative integer, defaulting to 0. Token-count
+ * fields in the envelope are always non-negative integers; a missing or
+ * malformed field collapses to 0 rather than NaN so downstream sums stay valid.
+ *
+ * @param {unknown} v
+ * @returns {number}
+ */
+function toNonNegInt(v) {
+  if (typeof v === 'number' && Number.isFinite(v) && v >= 0) {
+    return Math.trunc(v);
+  }
+  return 0;
+}
+
+/**
+ * Extract the first balanced top-level JSON object from a string, tolerating a
+ * prose preface or trailing text around it. Returns the parsed object, or
+ * `null` when no parseable object is present.
+ *
+ * Brace-counting is done outside string literals (with escape handling) so a
+ * `}` inside a JSON string value does not prematurely close the scan.
+ *
+ * @param {string} raw
+ * @returns {object|null}
+ */
+function extractFirstJsonObject(raw) {
+  if (typeof raw !== 'string') return null;
+  const trimmed = raw.trim();
+  if (trimmed.length === 0) return null;
+
+  // Fast path: the whole stdout is one JSON object.
+  try {
+    const direct = JSON.parse(trimmed);
+    if (direct && typeof direct === 'object' && !Array.isArray(direct)) {
+      return direct;
+    }
+  } catch {
+    // Fall through to the scanning path.
+  }
+
+  const start = trimmed.indexOf('{');
+  if (start === -1) return null;
+
+  let depth = 0;
+  let inString = false;
+  let escaped = false;
+  for (let i = start; i < trimmed.length; i += 1) {
+    const ch = trimmed[i];
+    if (inString) {
+      if (escaped) {
+        escaped = false;
+      } else if (ch === '\\') {
+        escaped = true;
+      } else if (ch === '"') {
+        inString = false;
+      }
+      continue;
+    }
+    if (ch === '"') {
+      inString = true;
+    } else if (ch === '{') {
+      depth += 1;
+    } else if (ch === '}') {
+      depth -= 1;
+      if (depth === 0) {
+        const candidate = trimmed.slice(start, i + 1);
+        try {
+          const parsed = JSON.parse(candidate);
+          if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+            return parsed;
+          }
+        } catch {
+          return null;
+        }
+        return null;
+      }
+    }
+  }
+  return null;
+}

--- a/bench/driver/sandbox.js
+++ b/bench/driver/sandbox.js
@@ -1,0 +1,305 @@
+// bench/driver/sandbox.js
+/**
+ * Ephemeral sandbox-repo lifecycle for the Mandrel self-benchmark harness.
+ *
+ * The harness must never mutate the live `mandrel` repo (Epic #4211 Non-Goal:
+ * "Running against the live `mandrel` repo"). Every benchmark run executes in a
+ * throwaway clone of a dedicated sandbox GitHub repo, created under the OS temp
+ * directory and torn down when the run finishes.
+ *
+ * Two operations:
+ *   - `provisionSandbox(opts)` — `git clone` the configured sandbox repo into a
+ *     fresh `mkdtemp` workspace and return a handle describing it. For the
+ *     control arm the materialized `.agents/` bundle is stripped so the bare
+ *     model receives no Mandrel scaffolding (Tech Spec #4213: "The control arm
+ *     clone has **no** `.agents/` scaffolding").
+ *   - `teardownSandbox(handle)` — recursively remove the workspace, with the
+ *     removal path asserted to live strictly inside the configured ephemeral
+ *     root before a single byte is deleted.
+ *
+ * SECURITY (security-baseline + Story #4216 binding contract): teardown is
+ * scoped strictly to the ephemeral workspace path. `assertInsideRoot` rejects
+ * any path that is not a proper descendant of the ephemeral root, so a
+ * malformed or adversarial handle can never escalate into an `rm -rf` of a real
+ * repository, the home directory, or `/`. The git binary is invoked via
+ * `execFileSync` with an argument array — never a shell string — so a
+ * repo-URL or path value can never be interpreted as a shell command.
+ *
+ * All external effects (`git`, `mkdtemp`, `rm`, `existsSync`) are injectable so
+ * the unit tests exercise the full provision/teardown contract — including the
+ * path-containment guard — without cloning a real repository or deleting real
+ * files.
+ */
+
+import { execFileSync } from 'node:child_process';
+import { existsSync, mkdtempSync, rmSync, statSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+/**
+ * Canonical prefix for every ephemeral sandbox workspace directory. Exported so
+ * tests and teardown share one constant rather than a magic string.
+ */
+export const SANDBOX_DIR_PREFIX = 'mandrel-bench-sandbox-';
+
+/**
+ * Default ephemeral root under which all sandbox workspaces are created. Kept
+ * as a function (not a const) so each call re-reads `tmpdir()` — the value is
+ * environment-dependent and tests override it explicitly.
+ *
+ * @returns {string}
+ */
+export function defaultEphemeralRoot() {
+  return tmpdir();
+}
+
+/**
+ * Assert that `target` is a path strictly *inside* `root` (a proper
+ * descendant, never `root` itself and never an escape via `..` or an absolute
+ * re-root). Returns the resolved absolute target on success.
+ *
+ * This is the load-bearing safety check for teardown: it runs before any
+ * filesystem removal and converts a bad path into a thrown Error rather than a
+ * destructive delete. Mirrors `.agents/scripts/lib/path-security.js` but is
+ * inlined so the bench tree carries no dependency on the distributed bundle.
+ *
+ * @param {string} root    Absolute path of the containing ephemeral root.
+ * @param {string} target  Path to validate (resolved against `root`).
+ * @param {string} label   Human-readable identifier for the error message.
+ * @returns {string} The resolved absolute `target`.
+ * @throws {Error} when `target` is not strictly inside `root`.
+ */
+export function assertInsideRoot(root, target, label = 'path') {
+  if (typeof root !== 'string' || root.length === 0) {
+    throw new TypeError('assertInsideRoot requires a non-empty root');
+  }
+  if (typeof target !== 'string' || target.length === 0) {
+    throw new TypeError('assertInsideRoot requires a non-empty target');
+  }
+  const resolvedRoot = path.resolve(root);
+  const resolvedTarget = path.resolve(resolvedRoot, target);
+  const rel = path.relative(resolvedRoot, resolvedTarget);
+  const escapes = rel === '' || rel.startsWith('..') || path.isAbsolute(rel);
+  if (escapes) {
+    throw new Error(
+      `${label} resolves outside the ephemeral sandbox root ${resolvedRoot}: ${resolvedTarget}`,
+    );
+  }
+  return resolvedTarget;
+}
+
+/**
+ * @typedef {object} SandboxHandle
+ * @property {string} workspacePath  Absolute path to the ephemeral clone root.
+ * @property {string} ephemeralRoot  Absolute path of the temp root the clone lives under.
+ * @property {string} repoUrl        The sandbox repo URL that was cloned.
+ * @property {'mandrel'|'control'} arm  Which benchmark arm this workspace serves.
+ * @property {string|null} ref       The branch/ref checked out, or null for default.
+ * @property {boolean} agentsStripped Whether `.agents/` was removed (true for the control arm).
+ */
+
+/**
+ * @typedef {object} ProvisionDeps
+ * @property {(cmd: string, args: string[], opts: object) => unknown} [execFileFn]
+ *   Injected `execFileSync`. Defaults to the real one. Tests stub this so no
+ *   real `git clone` runs.
+ * @property {(prefix: string) => string} [mkdtempFn]
+ *   Injected directory factory. Receives the full `<root>/<prefix>` argument
+ *   and returns the created absolute path. Defaults to `mkdtempSync`.
+ * @property {(p: string) => boolean} [existsFn]  Injected `existsSync`.
+ * @property {(p: string, opts: object) => void} [rmFn]  Injected `rmSync`.
+ * @property {{ info?: Function, warn?: Function }} [logger]
+ */
+
+/**
+ * Provision a fresh ephemeral clone of the configured sandbox repo.
+ *
+ * @param {object} opts
+ * @param {string} opts.repoUrl  Sandbox repo URL or local path to clone.
+ * @param {'mandrel'|'control'} [opts.arm='mandrel']  Benchmark arm.
+ * @param {string|null} [opts.ref=null]  Branch / ref to check out (default branch when null).
+ * @param {string} [opts.ephemeralRoot]  Temp root to clone under. Defaults to `tmpdir()`.
+ * @param {number} [opts.depth=1]  `git clone --depth` value (shallow by default).
+ * @param {ProvisionDeps} [deps]
+ * @returns {SandboxHandle}
+ */
+export function provisionSandbox(opts = {}, deps = {}) {
+  const {
+    repoUrl,
+    arm = 'mandrel',
+    ref = null,
+    ephemeralRoot = defaultEphemeralRoot(),
+    depth = 1,
+  } = opts;
+
+  if (typeof repoUrl !== 'string' || repoUrl.length === 0) {
+    throw new TypeError('provisionSandbox requires a non-empty repoUrl');
+  }
+  if (arm !== 'mandrel' && arm !== 'control') {
+    throw new TypeError(
+      `provisionSandbox arm must be "mandrel" or "control", got: ${String(arm)}`,
+    );
+  }
+
+  const execFileFn = deps.execFileFn ?? execFileSync;
+  const mkdtempFn = deps.mkdtempFn ?? mkdtempSync;
+  const existsFn = deps.existsFn ?? existsSync;
+  const rmFn = deps.rmFn ?? rmSync;
+  const logger = deps.logger;
+
+  const resolvedRoot = path.resolve(ephemeralRoot);
+  // mkdtemp appends random chars to the prefix; we pass the full root+prefix.
+  const workspacePath = path.resolve(
+    mkdtempFn(path.join(resolvedRoot, SANDBOX_DIR_PREFIX)),
+  );
+  // Defense in depth: the freshly minted workspace must itself sit inside root.
+  assertInsideRoot(resolvedRoot, workspacePath, 'sandbox workspace');
+
+  logger?.info?.(
+    `[sandbox] Cloning ${repoUrl} → ${workspacePath} (arm=${arm}, depth=${depth})`,
+  );
+
+  const cloneArgs = ['clone', '--depth', String(depth)];
+  if (ref) {
+    cloneArgs.push('--branch', ref);
+  }
+  cloneArgs.push('--', repoUrl, workspacePath);
+
+  try {
+    execFileFn('git', cloneArgs, {
+      encoding: 'utf-8',
+      stdio: 'pipe',
+      timeout: 5 * 60 * 1000,
+    });
+  } catch (err) {
+    // Clone failed — best-effort clean up the (possibly partial) workspace so a
+    // failed provision never leaks a temp directory, then rethrow.
+    try {
+      const safe = assertInsideRoot(
+        resolvedRoot,
+        workspacePath,
+        'sandbox workspace (failed-clone cleanup)',
+      );
+      if (existsFn(safe)) {
+        rmFn(safe, { recursive: true, force: true });
+      }
+    } catch {
+      // Swallow cleanup errors — the original clone error is what matters.
+    }
+    throw new Error(
+      `[sandbox] git clone failed for ${repoUrl}: ${err?.message ?? err}`,
+    );
+  }
+
+  let agentsStripped = false;
+  if (arm === 'control') {
+    // The control arm is the bare-model baseline: it must carry NO Mandrel
+    // scaffolding so the overhead ratio is apples-to-apples by construction.
+    const agentsPath = assertInsideRoot(
+      workspacePath,
+      path.join(workspacePath, '.agents'),
+      'control-arm .agents bundle',
+    );
+    if (existsFn(agentsPath)) {
+      rmFn(agentsPath, { recursive: true, force: true });
+      agentsStripped = true;
+      logger?.info?.(
+        `[sandbox] Stripped .agents/ for control arm: ${agentsPath}`,
+      );
+    }
+  }
+
+  return {
+    workspacePath,
+    ephemeralRoot: resolvedRoot,
+    repoUrl,
+    arm,
+    ref,
+    agentsStripped,
+  };
+}
+
+/**
+ * @typedef {object} TeardownDeps
+ * @property {(p: string) => boolean} [existsFn]  Injected `existsSync`.
+ * @property {(p: string) => { isDirectory: () => boolean }} [statFn]  Injected `statSync`.
+ * @property {(p: string, opts: object) => void} [rmFn]  Injected `rmSync`.
+ * @property {{ info?: Function, warn?: Function }} [logger]
+ */
+
+/**
+ * Tear down an ephemeral sandbox workspace. The removal target is asserted to
+ * live strictly inside the handle's `ephemeralRoot` *before* any deletion — a
+ * handle whose `workspacePath` is not a descendant of its `ephemeralRoot`
+ * throws and removes nothing. This is the strict-scoping guarantee in the
+ * Story #4216 binding contract: teardown can only ever delete the throwaway
+ * workspace, never a real repo.
+ *
+ * Idempotent: tearing down an already-removed workspace is a no-op.
+ *
+ * @param {SandboxHandle} handle
+ * @param {TeardownDeps} [deps]
+ * @returns {{ removed: boolean, workspacePath: string }}
+ */
+export function teardownSandbox(handle, deps = {}) {
+  if (!handle || typeof handle !== 'object') {
+    throw new TypeError('teardownSandbox requires a sandbox handle');
+  }
+  const { workspacePath, ephemeralRoot } = handle;
+  if (typeof workspacePath !== 'string' || workspacePath.length === 0) {
+    throw new TypeError('teardownSandbox handle requires workspacePath');
+  }
+  if (typeof ephemeralRoot !== 'string' || ephemeralRoot.length === 0) {
+    throw new TypeError('teardownSandbox handle requires ephemeralRoot');
+  }
+
+  const existsFn = deps.existsFn ?? existsSync;
+  const statFn = deps.statFn ?? statSync;
+  const rmFn = deps.rmFn ?? rmSync;
+  const logger = deps.logger;
+
+  // The single safety gate: assert containment before touching the filesystem.
+  const safeTarget = assertInsideRoot(
+    ephemeralRoot,
+    workspacePath,
+    'sandbox teardown target',
+  );
+
+  if (!existsFn(safeTarget)) {
+    logger?.info?.(`[sandbox] Teardown no-op (already gone): ${safeTarget}`);
+    return { removed: false, workspacePath: safeTarget };
+  }
+
+  // Guard against pointing teardown at a file or a symlink masquerading as the
+  // workspace — only ever recursively remove an actual directory.
+  const stat = statFn(safeTarget);
+  if (!stat.isDirectory()) {
+    throw new Error(
+      `[sandbox] teardown target is not a directory, refusing to remove: ${safeTarget}`,
+    );
+  }
+
+  logger?.info?.(`[sandbox] Removing ephemeral workspace: ${safeTarget}`);
+  rmFn(safeTarget, { recursive: true, force: true });
+  return { removed: true, workspacePath: safeTarget };
+}
+
+/**
+ * Convenience wrapper: provision a sandbox, run `fn(handle)`, and guarantee
+ * teardown even when `fn` throws. The harness uses this so a crashed run can
+ * never leak a workspace (Epic AC: "tears down each workspace").
+ *
+ * @template T
+ * @param {object} provisionOpts  Forwarded to `provisionSandbox`.
+ * @param {(handle: SandboxHandle) => Promise<T> | T} fn
+ * @param {{ provision?: ProvisionDeps, teardown?: TeardownDeps }} [deps]
+ * @returns {Promise<T>}
+ */
+export async function withSandbox(provisionOpts, fn, deps = {}) {
+  const handle = provisionSandbox(provisionOpts, deps.provision);
+  try {
+    return await fn(handle);
+  } finally {
+    teardownSandbox(handle, deps.teardown);
+  }
+}

--- a/bench/driver/unattended.md
+++ b/bench/driver/unattended.md
@@ -1,0 +1,162 @@
+# Unattended headless drive — how the pipeline's HITL gates auto-proceed
+
+> **Scope.** This document satisfies the Story #4216 acceptance item: *document
+> the mechanism by which the pipeline HITL stop gates auto-proceed under
+> headless drive, or record the blocker when they cannot.* It is the
+> make-or-break risk for the whole harness (Epic #4211): a headless
+> `claude -p` orchestrator has no human at the keyboard, so if Mandrel's
+> `/plan` → `/deliver` pipeline blocks at its first STOP gate, every
+> downstream slice stalls.
+>
+> The answer is **mixed**: `/deliver` has a real, first-class non-interactive
+> path; `/plan` does **not** ship an equivalent flag, and that residual gap is
+> recorded here as a known blocker with the behavioral mitigation the driver
+> applies. This is intentionally honest — the harness measures *Autonomy* as a
+> scored dimension, so a gate the driver had to paper over is itself a finding.
+
+The driver in [`run-session.js`](./run-session.js) launches the pipeline via
+`claude -p --output-format json` (see `buildArmPrompt` / `buildClaudeArgs`).
+Two complementary mechanisms keep the run unattended: **per-command
+non-interactive flags** (deterministic, where they exist) and a **prompt-level
+auto-proceed directive** (behavioral, covering the rest).
+
+---
+
+## Inventory of HITL STOP gates in the pipeline
+
+Sourced from the live workflow definitions in the materialized bundle
+(`.agents/workflows/plan.md`, `.agents/workflows/deliver.md`,
+`.agents/workflows/helpers/deliver-epic.md`) as of `mandrel` 1.70.x.
+
+| # | Gate | Where | Native unattended control | Verdict |
+| - | ---- | ----- | ------------------------- | ------- |
+| 1 | One-pager / scope-triage confirm | `/plan` ideation path (`--idea`) | none | **blocker — mitigated by prompt** |
+| 2 | Epic operator review gate | `/plan` Epic path, Phase 7 | risk-routed skip; `--force-review` only *forces* it | **auto-skips when risk routing allows; else blocker** |
+| 3 | First-run docs preflight | `/plan` router | "never a hard stop" (declining continues) | **not blocking** |
+| 4 | Segment-plan confirmation | `/deliver` router | **`--yes`** suppresses it | **solved (flag)** |
+| 5 | Decomposition diff / `maxTickets` budget | `/plan` Epic decomposition | `--allow-over-budget` | **solved (flag)** |
+| 6 | Auto-merge-else-operator-merge | `/deliver` Epic Phase 8.5 | `AutomergePredicate` auto-merges a clean run; else operator merges | **auto-proceeds on a clean run** |
+
+---
+
+## Mechanism 1 — native non-interactive flags (deterministic)
+
+These gates have first-class flags the driver passes; no behavioral coaxing
+needed.
+
+### `/deliver --yes` (gate #4)
+
+`/deliver` presents a segment plan and *waits for confirmation*; `--yes`
+suppresses that gate (`.agents/workflows/deliver.md`: *"present it and wait for
+operator confirmation (`--yes` suppresses)"*). The driver passes `--yes` for
+the Mandrel arm via `extraArgs` when it wants the deterministic path:
+
+```js
+runSession(
+  { arm: 'mandrel', scenario, cwd: sandbox.workspacePath,
+    extraArgs: ['--yes'] },
+  { invokeFn },
+);
+```
+
+> The driver does **not** hard-code `--yes` inside `buildClaudeArgs` — it is a
+> caller-supplied `extraArgs` entry, so a harness run that wants to *measure*
+> the confirmation gate (rather than skip it) can omit it.
+
+### `/deliver` Epic auto-merge (gate #6)
+
+The Epic delivery path ends in a **conditional auto-merge gate** (Phase 8.5).
+An `AutomergePredicate` evaluates every run signal; when all certify a clean
+run it auto-merges via `gh pr merge --squash --delete-branch` and Phase 9
+cleanup fires automatically inside the lifecycle bus — **no operator step on
+the auto-merge path** (`deliver-epic.md` Phase 8.5/9). When any signal
+disqualifies (critical blocker, degraded selector, failed gate), it emits
+`epic.merge.blocked` and leaves the PR for the operator. For the benchmark this
+is the desired shape: a clean run completes fully unattended, and a run that
+*would* need a human is exactly the Autonomy signal we want to record (it shows
+up as an un-merged PR + `epic.merge.blocked` in `lifecycle.ndjson`).
+
+### `/plan --allow-over-budget` (gate #5)
+
+A decomposition that exceeds the framework `maxTickets` reviewability budget
+otherwise stops; `--allow-over-budget` permits it
+(`.agents/workflows/plan.md` flag table). Pass it on the Mandrel arm when the
+scenario is expected to decompose wide (the CRUD+DB scenario can).
+
+---
+
+## Mechanism 2 — prompt-level auto-proceed directive (behavioral)
+
+Gates #1 and #2 (and #2 when risk routing forces the review) have **no native
+non-interactive flag**. For these the driver relies on a behavioral directive
+baked into the Mandrel-arm prompt (`buildArmPrompt` in `run-session.js`):
+
+> *You are operating Mandrel's pipeline non-interactively under a headless
+> benchmark driver. There is no human at the keyboard. At every
+> human-in-the-loop STOP / confirmation gate (one-pager confirm, spec review,
+> decomposition diff gate, and the auto-merge-else-operator-merge step), treat
+> the absence of an operator as implicit approval and proceed with the best
+> available interpretation — never block waiting for input.*
+
+This works because each gate is executed by the host LLM following the
+workflow prose, not by a hard `read()` from a TTY. The framework's own
+non-interactive sub-agent contract already establishes this pattern: Story
+delivery sub-agents run with *"no input channel mid-run"* and are instructed to
+*"pick the narrowest reasonable interpretation"* rather than ask
+(`epic-deliver-story.md` → *Non-interactive execution contract*;
+`deliver-epic.md` line ~340 → *the non-interactive contract (no clarifying
+questions)*). The driver's directive extends that same contract up to the
+top-level `/plan` and `/deliver` gates.
+
+### Why this is a directive and not a flag
+
+`/plan` ships **no** `--yes`, `--non-interactive`, `--ci`, or `--headless`
+flag (verified against `plan.md`'s flag table — only `--idea`, `--from-notes`,
+`--force`, `--force-review`, `--allow-over-budget`, `--steal`, `--dry-run`,
+`--body`, `--persona`, `--refine`/`--no-refine` exist). The one-pager confirm
+on the ideation path and the Phase 7 review gate when risk-forced therefore
+have no deterministic suppression. The prompt directive is the only lever
+available without a framework change.
+
+---
+
+## Recorded blocker (residual risk)
+
+The behavioral directive is **best-effort, not guaranteed**. The honest
+residual risks, recorded here per the acceptance contract:
+
+1. **No deterministic `/plan` headless flag.** Gate #1 (ideation one-pager) and
+   gate #2 (forced Epic review) depend on the host LLM honoring the prompt
+   directive. A future workflow revision that turns one of these into a true
+   blocking primitive (e.g. an `AskUserQuestion` the harness cannot answer)
+   would stall the run with no flag to fall back on. **Mitigation today:**
+   prefer driving the Mandrel arm from an **existing Epic id** (`/plan
+   <epicId>` / `/deliver <epicId>`) rather than `--idea`, which routes around
+   the ideation one-pager entirely; and rely on risk routing to skip the Phase
+   7 review for the two low-risk v1 scenarios (`hello-world`, `CRUD+DB`).
+2. **Tool-permission prompts are not auto-approved by the prompt.** A blocking
+   permission prompt is a harness condition, not a gate the directive covers.
+   Because every run executes inside a throwaway sandbox clone
+   ([`sandbox.js`](./sandbox.js)), callers that need a broader autorun posture
+   should pass `extraArgs: ['--permission-mode', 'bypassPermissions']` (or the
+   equivalent the host CLI exposes) explicitly. The driver deliberately leaves
+   the default permission surface minimal rather than baking in a dangerous
+   default.
+3. **A stalled run must be detected, not assumed.** `claude -p` runs under a
+   hard `timeoutMs` ceiling (default 1h, `DEFAULT_SESSION_TIMEOUT_MS`). A run
+   that blocks on an un-mitigated gate exhausts the timeout and surfaces as a
+   non-zero exit / empty envelope — `runSession` throws rather than returning a
+   silent zero-cost record. The downstream telemetry slice additionally reads
+   `lifecycle.ndjson` heartbeats to distinguish a live-but-slow run from a dead
+   one.
+
+### Follow-up framework ask (out of scope for #4216)
+
+The clean fix is a first-class `--yes` / `--non-interactive` flag on `/plan`
+that suppresses the ideation one-pager and the Phase 7 review gate the same way
+`/deliver --yes` suppresses the segment-plan gate. That is a framework change
+(it lives in `.agents/`, the distributed bundle) and is **explicitly out of
+scope** for this internal-tooling Story. It should be filed against the
+framework with the `meta::framework-gap` label so `/plan` Phase 0 surfaces it
+to the planner. Until then, the prompt directive + the existing-Epic routing in
+risk #1 keep the harness unattended for v1's two low-risk scenarios.

--- a/bench/fixtures/lifecycle.sample.ndjson
+++ b/bench/fixtures/lifecycle.sample.ndjson
@@ -1,0 +1,17 @@
+{"kind":"emitted","seqId":1,"ts":"2026-06-16T19:32:00.000Z","event":"epic.plan.start","payload":{"epicId":9001}}
+{"kind":"completed","seqId":1,"ts":"2026-06-16T19:32:00.000Z","event":"epic.plan.start"}
+{"kind":"emitted","seqId":2,"ts":"2026-06-16T19:34:30.000Z","event":"epic.plan.end","payload":{"waves":[[9101,9102]]}}
+{"kind":"completed","seqId":2,"ts":"2026-06-16T19:34:30.000Z","event":"epic.plan.end"}
+{"kind":"emitted","seqId":3,"ts":"2026-06-16T19:34:40.000Z","event":"story.dispatch.start","payload":{"storyId":9101,"waveIndex":0,"dispatchedAt":"2026-06-16T19:34:40.000Z","attempt":1}}
+{"kind":"completed","seqId":3,"ts":"2026-06-16T19:34:40.000Z","event":"story.dispatch.start"}
+{"kind":"emitted","ts":"2026-06-16T19:35:10.000Z","event":"story.heartbeat","payload":{"event":"story.heartbeat","storyId":9101,"epicId":9001,"phase":"implementing","timestamp":"2026-06-16T19:35:10.000Z"}}
+{"kind":"emitted","seqId":4,"ts":"2026-06-16T19:34:45.000Z","event":"story.dispatch.start","payload":{"storyId":9102,"waveIndex":0,"dispatchedAt":"2026-06-16T19:34:45.000Z","attempt":1}}
+{"kind":"completed","seqId":4,"ts":"2026-06-16T19:34:45.000Z","event":"story.dispatch.start"}
+{"kind":"emitted","ts":"2026-06-16T19:38:00.000Z","event":"story.dispatch.end","payload":{"storyId":9101,"outcome":"done","durationMs":200000}}
+{"kind":"emitted","ts":"2026-06-16T19:38:20.000Z","event":"story.dispatch.end","payload":{"storyId":9102,"outcome":"done","durationMs":215000}}
+{"kind":"emitted","seqId":5,"ts":"2026-06-16T19:38:30.000Z","event":"story.merged","payload":{"storyId":9101,"sha":"a1b2c3d4e5f6"}}
+{"kind":"completed","seqId":5,"ts":"2026-06-16T19:38:30.000Z","event":"story.merged"}
+{"kind":"emitted","seqId":6,"ts":"2026-06-16T19:38:40.000Z","event":"story.merged","payload":{"storyId":9102,"sha":"f6e5d4c3b2a1"}}
+{"kind":"completed","seqId":6,"ts":"2026-06-16T19:38:40.000Z","event":"story.merged"}
+{"kind":"emitted","seqId":7,"ts":"2026-06-16T19:42:11.000Z","event":"epic.complete","payload":{"epicId":9001,"prUrl":"https://github.com/dsj1984/mandrel/pull/9123"}}
+{"kind":"completed","seqId":7,"ts":"2026-06-16T19:42:11.000Z","event":"epic.complete"}

--- a/bench/fixtures/sample-scorecard.json
+++ b/bench/fixtures/sample-scorecard.json
@@ -1,0 +1,62 @@
+{
+  "schemaVersion": 1,
+  "runId": "hello-world-mandrel-2026-06-16-r03",
+  "timestamp": "2026-06-16T19:42:11.000Z",
+  "model": {
+    "id": "claude-opus-4-8[1m]",
+    "displayName": "Claude Opus 4.8 (1M context)"
+  },
+  "frameworkVersion": "1.70.0",
+  "env": {
+    "node": "v24.16.0",
+    "os": "darwin",
+    "host": "bench-runner-01"
+  },
+  "scenario": "hello-world",
+  "arm": "mandrel",
+  "dimensions": {
+    "quality": {
+      "score": 1,
+      "frozenSuitePassRate": 1,
+      "frozenSuitePassed": 6,
+      "frozenSuiteTotal": 6,
+      "acceptanceEvalScore": 1
+    },
+    "planningFidelity": {
+      "score": 0.92,
+      "rePlanCount": 0,
+      "plannedStoryCount": 2,
+      "deliveredStoryCount": 2,
+      "fileFootprintDrift": 0.08
+    },
+    "autonomy": {
+      "score": 1,
+      "hitlStops": 0,
+      "blockedEvents": 0,
+      "manualRescues": 0
+    },
+    "efficiency": {
+      "wallClockMs": 612000,
+      "totalTokens": 184320,
+      "inputTokens": 151200,
+      "outputTokens": 33120,
+      "dispatches": 2,
+      "costUsd": 1.47
+    },
+    "overheadRatio": {
+      "tokenRatio": 4.2,
+      "timeRatio": 3.6,
+      "ceremonyTokens": 148800,
+      "codegenTokens": 35520
+    }
+  },
+  "rawRefs": {
+    "lifecycleNdjson": "temp/epic-9001/lifecycle.ndjson",
+    "signalsNdjson": [
+      "temp/epic-9001/story-9101/signals.ndjson",
+      "temp/epic-9001/story-9102/signals.ndjson"
+    ],
+    "costEnvelope": "temp/bench/hello-world-mandrel-2026-06-16-r03/cost-envelope.json",
+    "acceptanceEvalVerdict": "temp/bench/hello-world-mandrel-2026-06-16-r03/acceptance-eval-verdict.json"
+  }
+}

--- a/bench/metrics/README.md
+++ b/bench/metrics/README.md
@@ -1,0 +1,330 @@
+# Mandrel Self-Benchmark — Metrics Model
+
+> **Internal tooling.** Everything under `bench/` is development tooling, like
+> `tests/` and `docs/`. It is **never** shipped in the distributed `.agents/`
+> bundle and **never** runs against the live `mandrel` repo — all churn lands
+> in a dedicated sandbox repo on ephemeral clones (Epic
+> [#4211](https://github.com/dsj1984/mandrel/issues/4211), Story
+> [#4215](https://github.com/dsj1984/mandrel/issues/4215)).
+
+This document is the **measurement contract** the whole harness conforms to.
+It defines, with explicit reproducible formulas:
+
+1. The **five dimensions** — three on the value side (what scaffolding
+   _buys_) and two on the cost side (what it _charges_).
+2. The **variance / noise-band method** — how every dimension is reported as a
+   distribution across N runs, and the rule for when a Mandrel-vs-control delta
+   is called _real_.
+3. Two **cross-scenario derived metrics** — the difficulty-monotonicity check
+   and the overhead-floor estimate — that are computed by comparing scenarios,
+   not scored per run.
+
+The scorecard JSON contract is
+[`../schemas/scorecard.schema.json`](../schemas/scorecard.schema.json); a
+worked example is [`../fixtures/sample-scorecard.json`](../fixtures/sample-scorecard.json).
+The noise-band is implemented in [`variance.js`](./variance.js).
+
+---
+
+## Design principles (binding)
+
+- **No single composite score.** We report the value/cost frontier; we never
+  collapse the five dimensions into one scalar that would get gamed
+  (Goodhart's law — see Epic #4211 Non-Goals). Each dimension stands alone.
+- **Every score is a distribution, never a point.** Each `(scenario × arm)`
+  cell runs at **N≈8–10**. A dimension's headline number is always reported
+  with its noise-band; a bare point estimate is a reporting bug.
+- **Apples-to-apples by construction.** Both arms — the **Mandrel arm**
+  (clone carries `.agents/`, runs `/plan`→`/deliver`) and the **control arm**
+  (no scaffolding, bare task prompt) — are driven by the same `claude -p
+  --output-format json` launcher and costed by the same usage envelope. The
+  overhead ratio is therefore a like-for-like comparison, not an estimate.
+- **Like model to like.** Every scorecard is stamped with the exact pinned
+  model id, framework version, and environment. A cross-version comparison
+  only ever compares cells with the same `(model, frameworkVersion, env)`.
+- **Reproducible formulas only.** Every dimension below reduces to a
+  deterministic function of recorded inputs (lifecycle NDJSON fields, the
+  `claude -p` envelope, frozen-suite results, the acceptance-eval verdict). No
+  formula depends on a wall-clock read at scoring time, a random draw, or an
+  un-recorded judgment.
+
+### Inputs (recorded per run)
+
+| Input                  | Source                                                                 |
+| ---------------------- | ---------------------------------------------------------------------- |
+| Timings, dispatches    | `temp/epic-<id>/lifecycle.ndjson` (append-only NDJSON)                 |
+| Autonomy events        | `lifecycle.ndjson` (`agent::blocked`, HITL stops) + per-Story `signals.ndjson` |
+| Cost (tokens, USD)     | `claude -p --output-format json` usage/cost envelope                   |
+| Quality (objective)    | Scenario's **frozen acceptance suite** (deterministic HTTP/Playwright) |
+| Quality (cross-check)  | `acceptance-eval.js` LLM-judge verdict                                 |
+| Plan vs. actual        | Decomposer output (planned Stories / `changes[]`) vs. delivered Stories / touched files |
+
+All inputs are persisted onto the scorecard's `rawRefs` for traceability, even
+though the ephemeral workspace is torn down after each run.
+
+---
+
+## The five dimensions
+
+Each formula yields a value in a stated range. Per-run values land on the
+scorecard under `dimensions.<name>`; the distribution and band are computed
+across the N per-run values by the scoring slice (see
+[§ Variance](#variance--noise-band-method)).
+
+### 1. Quality — _is the output correct & on-intent?_ (value side)
+
+The objective spine is the scenario's **frozen acceptance suite** — a fixed
+set of deterministic assertions (HTTP status/body, Playwright steps) run
+against the delivered app. The LLM-judge (`acceptance-eval.js`) is a
+**cross-check**, never the spine, so Quality cannot be gamed by persuading the
+judge.
+
+```text
+frozenSuitePassRate = frozenSuitePassed / frozenSuiteTotal           ∈ [0, 1]
+
+quality.score =
+    w_suite · frozenSuitePassRate  +  w_judge · acceptanceEvalScore
+  with w_suite = 0.7, w_judge = 0.3, and w_judge folded into w_suite
+  (renormalized to w_suite = 1.0) when acceptanceEvalScore is null
+                                                                     ∈ [0, 1]
+```
+
+- The frozen suite is **frozen**: its assertions are authored once per
+  scenario and never edited to match a particular run's output.
+- `acceptanceEvalScore` is the fraction of acceptance criteria the judge marks
+  satisfied. It is `null` for the control arm when no acceptance criteria were
+  authored; the weight then collapses entirely onto the frozen suite.
+- A run that fails to deliver a runnable app scores `frozenSuitePassRate = 0`
+  (every assertion fails), i.e. `quality.score = 0` — not "no data".
+
+### 2. Planning fidelity — _did the plan match reality?_ (value side)
+
+Measures how well the authored plan predicted the delivered work. Three
+recorded sub-signals combine into a `[0, 1]` score; **`null` for the control
+arm** (it authors no plan).
+
+```text
+storyAccuracy   = 1 − |plannedStoryCount − deliveredStoryCount|
+                       / max(plannedStoryCount, deliveredStoryCount, 1)   ∈ [0, 1]
+
+rePlanPenalty   = 1 / (1 + rePlanCount)                                   ∈ (0, 1]
+
+footprintAccuracy = 1 − fileFootprintDrift                                ∈ [0, 1]
+  where fileFootprintDrift = Jaccard distance between the planned changes[]
+  path set P and the actually-touched path set A:
+    fileFootprintDrift = 1 − |P ∩ A| / |P ∪ A|         (0 when both empty)
+
+planningFidelity.score =
+    (storyAccuracy + rePlanPenalty + footprintAccuracy) / 3               ∈ [0, 1]
+```
+
+- `rePlanCount` counts decomposition-revision / re-plan events observed during
+  the run (a high count means the plan needed reshaping mid-flight).
+- `fileFootprintDrift` is the symmetric set distance; recall that under the
+  Engineer persona's _logged-deviation_ latitude, `changes[]` is an advisory
+  sketch — so modest drift is expected and only a large drift dents fidelity.
+
+### 3. Autonomy — _how little human intervention?_ (value side)
+
+How close the run came to fully unattended. Counts every point a human had to
+step in. The harness's whole make-or-break risk is that the pipeline runs
+**unattended**, so this is the dimension that proves it.
+
+```text
+interventions = hitlStops + blockedEvents + manualRescues
+
+autonomy.score = 1 / (1 + interventions)                                  ∈ (0, 1]
+```
+
+- `autonomy.score = 1.0` ⇒ zero interventions: the run completed end-to-end
+  with no human in the loop.
+- `hitlStops` — STOP gates the run actually halted at (one-pager confirm, spec
+  review, decomposition diff gate, the auto-merge-else-operator-merge step).
+  In a correctly-configured unattended run these auto-proceed and the count is
+  0; any non-zero value is a finding.
+- `blockedEvents` — `agent::blocked` transitions in `lifecycle.ndjson`.
+- `manualRescues` — operator interventions that unblocked or restarted the run.
+
+### 4. Efficiency — _what did it cost absolutely?_ (cost side)
+
+Absolute cost as a **vector**, never collapsed to one number. The three
+components are reported independently (each gets its own distribution + band):
+
+```text
+efficiency.wallClockMs  = run end − run start, from lifecycle.ndjson    (ms, ≥ 0)
+efficiency.totalTokens  = Σ (inputTokens + outputTokens) over the
+                          claude -p usage envelope                      (≥ 0)
+efficiency.dispatches   = count of Story sub-agent launches in
+                          lifecycle.ndjson                              (≥ 0)
+efficiency.costUsd      = total USD from the envelope when reported,
+                          else null
+```
+
+- Tokens and USD come **only** from the `claude -p` envelope — Mandrel records
+  no token actuals of its own (`epic-deliver-preflight.js` merely _estimates_).
+  Measuring both arms from the same envelope is what makes the comparison
+  honest.
+- GitHub round-trip latency is intentionally **inside** `wallClockMs` — it is
+  part of Mandrel's real overhead.
+
+### 5. Overhead ratio — _ceremony tax vs. shippable output?_ (cost side)
+
+The framework's _tax_: how much ceremony (planning, decomposition,
+orchestration, gate machinery) it spends per unit of shippable codegen.
+
+```text
+overheadRatio.tokenRatio = ceremonyTokens / codegenTokens               (≥ 0)
+overheadRatio.timeRatio  = ceremonyMs    / codegenMs   (null if unavailable)
+```
+
+- **Token attribution.** `codegenTokens` are the tokens spent inside the
+  Story-implementation phases that produce shippable artifacts (the
+  delivery sub-agents' edit/commit work). `ceremonyTokens` are everything
+  else in the session: `/plan` authoring (PRD, Tech Spec, decomposition),
+  orchestration overhead, and the gate/close machinery. The split is derived
+  from the lifecycle phase boundaries; `ceremonyTokens + codegenTokens` equals
+  `efficiency.totalTokens`.
+- A `tokenRatio` of `4.0` means four tokens of ceremony per token of shippable
+  output. For the **control arm** there is effectively no ceremony, so its
+  ratio sits near the floor (~0) — the gap between the arms _is_ the tax.
+- This dimension is the most direct lever for the "ceremony-lite path for
+  trivial scopes" recommendation when `hello-world` shows a high ratio with no
+  quality gain.
+
+---
+
+## Variance / noise-band method
+
+Every dimension above is reported as a **distribution** across the N≈8–10
+per-run values, summarized by a **noise-band**. The band is the spread a
+Mandrel-vs-control delta must clear before we call it real. The canonical
+implementation is [`variance.js`](./variance.js); this section is its
+specification.
+
+`noiseBand(values, { method })` accepts an array of per-run values for one
+dimension (non-finite entries — a run that produced no value — are filtered
+out first) and returns:
+
+```text
+{ method, n, center, low, high, spread, detail }
+```
+
+Two methods, both robust for tiny samples:
+
+### `iqr` — median + inter-quartile range (default)
+
+```text
+center = median(values)
+Q1     = 25th percentile          (linear-interpolation / type-7 estimator)
+Q3     = 75th percentile
+IQR    = Q3 − Q1
+low    = max(min(values), Q1 − 1.5·IQR)      (Tukey inner fence, clamped)
+high   = min(max(values), Q3 + 1.5·IQR)      (Tukey inner fence, clamped)
+spread = high − low
+```
+
+The default. Resistant to the heavy-tailed outliers an agent run produces (one
+stalled 40-minute wall-clock run must not blow out the band). Fences are
+clamped to the observed range so the band never claims an unobserved value.
+
+### `ci` — mean + 95% confidence interval of the mean
+
+```text
+center = mean(values)
+sd     = sample standard deviation (Bessel-corrected, n − 1 denominator)
+sem    = sd / √n
+margin = t₀.₉₇₅(n − 1) · sem        (Student's t critical value, df = n − 1)
+low    = mean − margin
+high   = mean + margin
+spread = 2 · margin
+```
+
+A parametric band on the **mean**, for roughly-symmetric dimensions. The
+Student's _t_ critical value (not the normal 1.96) is used because the samples
+are tiny — at df ≈ 7–9 the difference is material.
+
+### Real-delta rule (consumed by the scoring slice)
+
+A Mandrel-vs-control difference on a dimension is only reported as **real** when
+the absolute difference of the two arms' band centers exceeds the larger of the
+two arms' `spread`:
+
+```text
+deltaIsReal = |centerMandrel − centerControl| > max(spreadMandrel, spreadControl)
+```
+
+Otherwise the delta is **within noise** and reported as "no significant
+difference." This module produces the bands; the comparison itself lives in the
+scoring slice.
+
+---
+
+## Cross-scenario derived metrics
+
+These two relationships are computed by **comparing scenarios** and reported as
+calibration guardrails plus framework findings — they are **not** scored
+per-run dimensions and never appear on a single scorecard. With v1's two
+scenarios (`hello-world`, `crud-db`) they yield a monotonicity check and a
+floor estimate; the full scaling curve needs ≥ 3 ladder rungs and rides the
+deferred ladder.
+
+### A. Difficulty monotonicity (calibration guardrail)
+
+As scenario difficulty rises along the ladder, two things **must** hold for the
+Mandrel arm:
+
+- **Efficiency rises** — absolute cost / time / dispatches increase
+  (`hello-world` < `crud-db`). Harder work costs more in absolute terms.
+- **Overhead ratio falls** — ceremony amortizes over more shippable output as
+  the task grows, so `overheadRatio.tokenRatio` _decreases_ down the ladder
+  (`hello-world` > `crud-db`).
+
+Formally, over the difficulty-ordered scenario list `s₁ … s_k` (easy → hard),
+comparing the band centers:
+
+```text
+monotonicityHolds =
+      center(efficiency.totalTokens, sᵢ)   < center(efficiency.totalTokens, sᵢ₊₁)
+  AND center(overheadRatio.tokenRatio, sᵢ) > center(overheadRatio.tokenRatio, sᵢ₊₁)
+  for every adjacent pair (sᵢ, sᵢ₊₁)
+```
+
+A **violation is a calibration warning**, not a silent pass: it means either
+the instrument is insensitive or a scenario is mis-graded for difficulty. The
+report surfaces the violation explicitly rather than trusting the numbers.
+
+### B. Overhead floor (framework finding)
+
+The fixed ceremony tax Mandrel pays on **near-zero work** — the most direct
+"is the scaffolding worth it for trivial scopes?" signal. Estimated from the
+`hello-world` rung as the cost the Mandrel arm pays _above_ the control arm:
+
+```text
+overheadFloorTokens = center(efficiency.totalTokens, hello-world, mandrel)
+                     − center(efficiency.totalTokens, hello-world, control)
+
+overheadFloorUsd    = center(efficiency.costUsd,     hello-world, mandrel)
+                     − center(efficiency.costUsd,     hello-world, control)
+```
+
+- Computed on the **band centers** so it inherits the distribution method, and
+  reported with its own band derived from the per-run differences.
+- A large floor with **no** corresponding `quality.score` gain on `hello-world`
+  is the canonical evidence feeding the report's **Recommended improvements**
+  section (e.g. _"hello-world overhead ratio is 4.2× with no quality gain →
+  consider a ceremony-lite path for trivial scopes"_).
+- It is a **floor**, not the full curve: characterizing whether ceremony is a
+  flat fixed cost or scales with task size needs at least three ladder rungs
+  (deferred beyond v1).
+
+---
+
+## Why these and not a composite
+
+The split — three value dimensions, two cost dimensions, reported as
+distributions with an explicit real-delta rule — is deliberate. Collapsing them
+into one number would let a regression on one axis hide behind a gain on
+another, and would invite gaming the scalar. The harness's job is to show the
+**value/cost frontier at a fixed model**, so a human can decide whether
+Mandrel still earns its tax at the current frontier — not to declare a single
+winner.

--- a/bench/metrics/variance.js
+++ b/bench/metrics/variance.js
@@ -1,0 +1,290 @@
+// bench/metrics/variance.js
+//
+// Variance / noise-band method for the Mandrel self-benchmark harness
+// (Epic #4211, Story #4215). Internal tooling only — never shipped in the
+// distributed `.agents/` bundle.
+//
+// Every benchmark dimension is reported as a *distribution* across N≈8–10
+// runs, never a single point (see Non-Goals in Epic #4211: no composite
+// scalar, no point estimates). This module is the single source of truth for
+// turning a raw array of per-run dimension values into a noise-band, so the
+// scoring and report slices can decide whether a Mandrel-vs-control delta is
+// real (clears the band) or indistinguishable from run-to-run noise.
+//
+// Two band methods are supported, both robust enough for low-N benchmark
+// samples:
+//
+//   - 'iqr'  — median + inter-quartile range (Tukey). The default. Resistant
+//              to the heavy-tailed outliers a stalled agent run produces
+//              (a single 40-minute wall-clock outlier should not blow out the
+//              band). `low`/`high` are the Tukey inner fences
+//              (Q1 − 1.5·IQR, Q3 + 1.5·IQR), clamped so the band never
+//              extends past the observed min/max.
+//   - 'ci'   — mean + 95% confidence interval of the mean, using a Student's
+//              t critical value for (n − 1) degrees of freedom. Appropriate
+//              when values are roughly symmetric and you want a parametric
+//              band on the *mean* rather than a spread descriptor.
+//
+// Determinism: pure functions, no I/O, no clock, no randomness. The same
+// input array always yields the same band, so a persisted scorecard is
+// reproducible.
+
+/**
+ * @typedef {Object} NoiseBand
+ * @property {'iqr' | 'ci'} method      Band method used.
+ * @property {number}       n           Number of finite values summarized.
+ * @property {number}       center      Point estimate (median for 'iqr',
+ *                                       arithmetic mean for 'ci').
+ * @property {number}       low         Lower edge of the noise-band.
+ * @property {number}       high        Upper edge of the noise-band.
+ * @property {number}       spread      Band width (`high - low`), the noise
+ *                                       floor a delta must clear to be real.
+ * @property {Object}       detail      Method-specific descriptors (see below).
+ */
+
+/**
+ * Sort a copy of `values` ascending. Never mutates the caller's array.
+ *
+ * @param {number[]} values
+ * @returns {number[]}
+ */
+function sortedCopy(values) {
+  return values.slice().sort((a, b) => a - b);
+}
+
+/**
+ * Linear-interpolation percentile (the "type 7" / R-default estimator, also
+ * what NumPy uses by default). `p` is a fraction in [0, 1].
+ *
+ * @param {number[]} sorted  Ascending-sorted finite values (length ≥ 1).
+ * @param {number}   p       Percentile as a fraction in [0, 1].
+ * @returns {number}
+ */
+function percentile(sorted, p) {
+  if (sorted.length === 1) return sorted[0];
+  const rank = p * (sorted.length - 1);
+  const lo = Math.floor(rank);
+  const hi = Math.ceil(rank);
+  if (lo === hi) return sorted[lo];
+  const frac = rank - lo;
+  return sorted[lo] + (sorted[hi] - sorted[lo]) * frac;
+}
+
+/**
+ * Median of an ascending-sorted array (length ≥ 1).
+ *
+ * @param {number[]} sorted
+ * @returns {number}
+ */
+function median(sorted) {
+  return percentile(sorted, 0.5);
+}
+
+/**
+ * Arithmetic mean of a finite array (length ≥ 1).
+ *
+ * @param {number[]} values
+ * @returns {number}
+ */
+function mean(values) {
+  let sum = 0;
+  for (const v of values) sum += v;
+  return sum / values.length;
+}
+
+/**
+ * Sample standard deviation (Bessel-corrected, n − 1 denominator). Returns 0
+ * for a single value (no spread is observable from one sample).
+ *
+ * @param {number[]} values  Finite values (length ≥ 1).
+ * @param {number}   m       Precomputed mean of `values`.
+ * @returns {number}
+ */
+function sampleStdDev(values, m) {
+  if (values.length < 2) return 0;
+  let ss = 0;
+  for (const v of values) {
+    const d = v - m;
+    ss += d * d;
+  }
+  return Math.sqrt(ss / (values.length - 1));
+}
+
+/**
+ * Two-sided 95% Student's t critical value for `df` degrees of freedom.
+ *
+ * Benchmark samples are tiny (N≈8–10 ⇒ df≈7–9), where the normal-approx 1.96
+ * understates the interval materially. We use a small lookup table for the
+ * common small-df cases and the well-known asymptotic Cornish–Fisher expansion
+ * (Abramowitz & Stegun 26.2.23) for larger df, falling back to the normal
+ * quantile in the limit. Values match standard t-tables to 2–3 decimals.
+ *
+ * @param {number} df  Degrees of freedom (n − 1), an integer ≥ 1.
+ * @returns {number}   Two-sided 95% (i.e. 0.975 one-sided) t critical value.
+ */
+function tCritical95(df) {
+  // Exact-enough table for the small-sample regime this harness lives in.
+  const table = {
+    1: 12.706,
+    2: 4.303,
+    3: 3.182,
+    4: 2.776,
+    5: 2.571,
+    6: 2.447,
+    7: 2.365,
+    8: 2.306,
+    9: 2.262,
+    10: 2.228,
+    11: 2.201,
+    12: 2.179,
+    13: 2.16,
+    14: 2.145,
+    15: 2.131,
+    16: 2.12,
+    17: 2.11,
+    18: 2.101,
+    19: 2.093,
+    20: 2.086,
+    25: 2.06,
+    30: 2.042,
+    40: 2.021,
+    60: 2.0,
+    120: 1.98,
+  };
+  if (table[df] !== undefined) return table[df];
+  if (df < 1) return Number.POSITIVE_INFINITY;
+
+  // Cornish–Fisher expansion around the normal 0.975 quantile for df not in
+  // the table. z = 1.959964 is the standard-normal 97.5th percentile.
+  const z = 1.959963984540054;
+  const g1 = (z ** 3 + z) / 4;
+  const g2 = (5 * z ** 5 + 16 * z ** 3 + 3 * z) / 96;
+  const g3 = (3 * z ** 7 + 19 * z ** 5 + 17 * z ** 3 - 15 * z) / 384;
+  return z + g1 / df + g2 / df ** 2 + g3 / df ** 3;
+}
+
+/**
+ * Keep only finite numeric entries. Strings, `null`, `undefined`, `NaN`,
+ * `±Infinity`, and non-number types are dropped — the band is computed over
+ * the runs that actually produced a value.
+ *
+ * @param {unknown[]} values
+ * @returns {number[]}
+ */
+function finiteNumbers(values) {
+  const out = [];
+  for (const v of values) {
+    if (typeof v === 'number' && Number.isFinite(v)) out.push(v);
+  }
+  return out;
+}
+
+/**
+ * Compute a noise-band from an array of per-run dimension values.
+ *
+ * This is the function the Story's acceptance item names: *"given an array of
+ * per-run dimension values, returns a noise-band (e.g. median + IQR or
+ * mean + 95% CI)."* Both methods are implemented; `method` selects which.
+ *
+ * A delta between two arms is only considered **real** when the difference of
+ * their centers exceeds the relevant `spread` — that comparison lives in the
+ * scoring slice; here we only produce the band.
+ *
+ * @param {number[]} values            Per-run values for one dimension. Non-
+ *                                      finite entries are filtered out first.
+ * @param {Object}   [options]
+ * @param {'iqr' | 'ci'} [options.method='iqr']  Band method.
+ * @returns {NoiseBand}
+ * @throws {TypeError}  When `values` is not an array.
+ * @throws {RangeError} When no finite values remain, or `method` is unknown.
+ */
+function noiseBand(values, options = {}) {
+  if (!Array.isArray(values)) {
+    throw new TypeError(
+      `noiseBand: values must be an array, received ${typeof values}`,
+    );
+  }
+  const method = options.method ?? 'iqr';
+  if (method !== 'iqr' && method !== 'ci') {
+    throw new RangeError(
+      `noiseBand: unknown method ${JSON.stringify(method)} (expected 'iqr' or 'ci')`,
+    );
+  }
+
+  const finite = finiteNumbers(values);
+  if (finite.length === 0) {
+    throw new RangeError('noiseBand: no finite numeric values to summarize');
+  }
+
+  const n = finite.length;
+  const min = Math.min(...finite);
+  const max = Math.max(...finite);
+
+  if (method === 'ci') {
+    const m = mean(finite);
+    const sd = sampleStdDev(finite, m);
+    // Standard error of the mean; df = n − 1.
+    const sem = n > 1 ? sd / Math.sqrt(n) : 0;
+    const t = n > 1 ? tCritical95(n - 1) : 0;
+    const margin = t * sem;
+    return Object.freeze({
+      method: 'ci',
+      n,
+      center: m,
+      low: m - margin,
+      high: m + margin,
+      spread: 2 * margin,
+      detail: Object.freeze({
+        mean: m,
+        stdDev: sd,
+        stdError: sem,
+        tCritical: t,
+        margin,
+        confidence: 0.95,
+        min,
+        max,
+      }),
+    });
+  }
+
+  // method === 'iqr'
+  const sorted = sortedCopy(finite);
+  const med = median(sorted);
+  const q1 = percentile(sorted, 0.25);
+  const q3 = percentile(sorted, 0.75);
+  const iqr = q3 - q1;
+  // Tukey inner fences, clamped to the observed range so the band never
+  // claims values that were not observed.
+  const fenceLow = Math.max(min, q1 - 1.5 * iqr);
+  const fenceHigh = Math.min(max, q3 + 1.5 * iqr);
+  return Object.freeze({
+    method: 'iqr',
+    n,
+    center: med,
+    low: fenceLow,
+    high: fenceHigh,
+    spread: fenceHigh - fenceLow,
+    detail: Object.freeze({
+      median: med,
+      q1,
+      q3,
+      iqr,
+      lowerFence: fenceLow,
+      upperFence: fenceHigh,
+      min,
+      max,
+    }),
+  });
+}
+
+export {
+  finiteNumbers,
+  mean,
+  median,
+  noiseBand,
+  // Exported for reuse by the scoring slice and for unit testing the
+  // statistical primitives in isolation.
+  percentile,
+  sampleStdDev,
+  tCritical95,
+};

--- a/bench/report/README.md
+++ b/bench/report/README.md
@@ -1,0 +1,106 @@
+# Mandrel Self-Benchmark — Report, Persistence & Comparison
+
+> **Internal tooling.** Everything under `bench/` is development tooling, like
+> `tests/` and `docs/`. It is **never** shipped in the distributed `.agents/`
+> bundle and **never** runs against the live `mandrel` repo — all churn lands
+> in a dedicated sandbox repo on ephemeral clones (Epic
+> [#4211](https://github.com/dsj1984/mandrel/issues/4211), Story
+> [#4218](https://github.com/dsj1984/mandrel/issues/4218)).
+
+This slice is the **operator-facing deliverable** of the harness. It turns the
+per-run scorecards the scoring layer produces into a readable value-add report,
+persists them to a durable store, and compares two stored runs so the value-add
+can be tracked over time. It adds **no new statistics**: every number it prints
+is sourced from [`../score/differential.js`](../score/differential.js) and
+[`../metrics/variance.js`](../metrics/variance.js), so the report is a faithful
+rendering of the measurement contract
+([`../metrics/README.md`](../metrics/README.md)), not a second interpretation of
+it.
+
+## Modules
+
+| Module          | Responsibility                                                                                       |
+| --------------- | ---------------------------------------------------------------------------------------------------- |
+| `render.js`     | Render the value-add report (Markdown) from a corpus of per-run scorecards.                          |
+| `persist.js`    | Append-only, stamped scorecard store (NDJSON) — the durable substrate for over-time tracking.        |
+| `compare.js`    | Surface the per-dimension deltas between two stored runs, with the real-delta rule and cohort safety. |
+
+## `render.js` — the value-add report
+
+`renderReport({ scorecards, method })` takes a flat list of scorecards (all
+`scenario × arm × run` for **one cohort**) and returns the full Markdown report:
+
+1. **Cohort header** — the pinned model, framework version, and environment the
+   corpus was measured at, so a reader only ever compares like-to-like. A corpus
+   that mixes cohorts is flagged, never silently averaged.
+2. **Dimension distributions** — for every scenario, each of the five dimensions
+   (Quality, Planning fidelity, Autonomy, plus the Efficiency vector components
+   and Overhead ratio) is rendered as a **noise-band per arm** (`center [low,
+   high]`), never a bare point estimate, alongside the **Mandrel-vs-bare delta**
+   and its **verdict** against the noise floor (`real` / `within noise` /
+   `n/a`). Planning fidelity is `n/a` for the control arm (it authors no plan).
+3. **Per-difficulty scaling view** — Efficiency (absolute tokens) and Overhead
+   ratio across the difficulty ladder for **both arms**, with the
+   **monotonicity** verdict. A violation (efficiency that does not rise, or an
+   overhead ratio that does not fall, as difficulty increases) is surfaced as an
+   explicit **calibration warning**.
+4. **Recommended improvements** — a clearly-delineated section of actionable,
+   evidence-linked findings:
+   - the **overhead-floor estimate** (always surfaced), with a **ceremony-lite**
+     recommendation when a positive floor on `hello-world` buys no quality gain;
+   - **monotonicity violations** routed to a recalibration action;
+   - any **real value-dimension regression** where the bare control arm beats
+     Mandrel (a regression the scaffolding should not cause).
+
+`buildReportModel(...)` returns the same data in structured form for callers
+that want the findings programmatically rather than by parsing Markdown.
+
+The renderer is **pure and deterministic**: the same corpus renders
+byte-for-byte identically, so a persisted report is diffable across runs.
+
+## `persist.js` — the append-only store
+
+A benchmark store is a historical ledger. `appendScorecards({ storePath,
+scorecards })` validates every scorecard's **stamp** (`runId`, `model.id`,
+`frameworkVersion`, `env.node`, `env.os`, `scenario`, `arm`) and **schema
+version**, then appends them as NDJSON — one JSON object per line, never
+rewriting existing records. A batch with any un-stamped record is rejected
+**atomically** (nothing is written), because the store's whole point is that a
+later comparison only compares like-to-like, which is impossible without a
+complete stamp.
+
+NDJSON + append-only matches the harness's other ledgers
+(`lifecycle.ndjson`, `signals.ndjson`): crash-safe (a torn final line never
+corrupts earlier records), greppable, and diffable.
+
+- `readStore({ storePath })` reads every persisted scorecard back (a
+  never-written store reads as empty, not an error).
+- `groupByCohort(scorecards)` buckets the store by `cohortKey` so a caller can
+  pull "all runs for this (model, framework version, env)" out of a mixed store.
+
+The validation + serialization core is pure; only `appendScorecards` /
+`readStore` touch the filesystem, and both accept injectable I/O shims so the
+core is unit-testable with no real disk.
+
+## `compare.js` — over-time comparison
+
+`compareRuns({ baseline, candidate, method })` surfaces the **per-dimension
+deltas** between two stored runs (each a scorecard array, typically read from
+the store and filtered to one cohort). For every shared scenario and every
+comparable metric it reports the per-arm centers and the **Mandrel-arm cross-run
+shift**, applying the **same real-delta rule** the single-run differential uses
+(`|shift| > max(spread_baseline, spread_candidate)`) so a center that wobbled
+inside the band is `within-noise`, not a spurious `improved` / `regressed`.
+
+It refuses to silently compare across cohorts: a baseline and candidate stamped
+with a different `(model, framework version, env)` set `cohortMatch: false` and
+carry a `cohortMismatchWarning` — the deltas are still computed (a deliberate
+cross-version diff is a legitimate operator action) but the mismatch is always
+labelled. `renderComparison(comparison, { baselineLabel, candidateLabel })`
+renders it as Markdown.
+
+## Determinism
+
+Every module is pure (modulo the thin FS shell in `persist.js`): no clock, no
+randomness, no hidden state. The report and comparison are functions of their
+inputs alone, so they are reproducible and safe to snapshot.

--- a/bench/report/compare.js
+++ b/bench/report/compare.js
@@ -1,0 +1,356 @@
+// bench/report/compare.js
+//
+// Cross-run comparison for the Mandrel self-benchmark harness (Epic #4211,
+// Story #4218). Internal tooling only — never shipped in the distributed
+// `.agents/` bundle, never run against the live repo.
+//
+// This module surfaces the per-dimension deltas between TWO stored runs — the
+// "is the value-add moving over time?" question the persistence ledger
+// (bench/report/persist.js) exists to answer. A "run" is a labelled set of
+// per-run scorecards (e.g. everything one nightly benchmark execution
+// appended). Given a baseline run and a candidate run, for every
+// scenario × dimension it reports:
+//
+//   - the baseline and candidate band centers (per arm: mandrel and control),
+//   - the cross-run shift of the Mandrel arm's center (candidate − baseline),
+//   - and, reusing the SAME real-delta rule the single-run differential uses
+//     (bench/metrics/README.md § Real-delta rule), whether that shift CLEARS
+//     the combined run-to-run noise — so a center that wobbled inside the band
+//     is reported as "within noise", not a spurious regression/improvement.
+//
+// It refuses to compare across cohorts: a baseline and candidate stamped with a
+// different (model, framework version, env) are NOT like-to-like, and silently
+// differencing them would be exactly the apples-to-oranges error the stamp
+// exists to prevent. A cohort mismatch is surfaced as a flag, never hidden.
+//
+// Determinism: pure functions, no I/O, no clock, no randomness. Reads of the
+// persisted store live in persist.js; this module operates on the in-memory
+// scorecard arrays that reader returns.
+
+import { noiseBand } from '../metrics/variance.js';
+import {
+  EFFICIENCY_COMPONENTS,
+  SCALAR_DIMENSIONS,
+} from '../score/differential.js';
+import { cohortKey } from './persist.js';
+
+/**
+ * All comparable per-run scalars, in render order: the four scalar dimensions
+ * plus the efficiency-vector components, each keyed by the metric name the
+ * report uses and tagged with its scorecard accessor and "higher is better"
+ * polarity (used only to label a shift as improvement vs regression).
+ */
+const COMPARABLE_METRICS = Object.freeze([
+  ...SCALAR_DIMENSIONS.map((d) => ({
+    metric: d.name,
+    accessor: d.accessor,
+    // quality / planningFidelity / autonomy: higher is better.
+    // overheadRatio: lower is better.
+    higherIsBetter: d.name !== 'overheadRatio',
+  })),
+  ...EFFICIENCY_COMPONENTS.map((c) => ({
+    metric: `efficiency.${c.name}`,
+    accessor: c.accessor,
+    // Efficiency cost components: lower is better (fewer tokens / ms / $).
+    higherIsBetter: false,
+  })),
+]);
+
+/**
+ * Build a noise-band over one run's per-run values for an accessor, or null
+ * when no finite values are present. Mirrors the scoring slice's band helper so
+ * the comparison's centers/spreads are the identical statistic used elsewhere.
+ *
+ * @param {Array<object>} scorecards
+ * @param {(d: object) => number|null} accessor
+ * @param {'iqr'|'ci'} method
+ * @returns {import('../metrics/variance.js').NoiseBand|null}
+ */
+function bandOrNull(scorecards, accessor, method) {
+  try {
+    return noiseBand(
+      scorecards.map((sc) => accessor(sc?.dimensions)),
+      { method },
+    );
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Split a run's scorecards into (scenario → { mandrel, control }) cells.
+ *
+ * @param {Array<object>} run
+ * @returns {Map<string, { mandrel: Array<object>, control: Array<object> }>}
+ */
+function cellsByScenario(run) {
+  const byScenario = new Map();
+  for (const sc of run) {
+    const scenario = sc?.scenario;
+    if (typeof scenario !== 'string') continue;
+    if (!byScenario.has(scenario)) {
+      byScenario.set(scenario, { mandrel: [], control: [] });
+    }
+    const cell = byScenario.get(scenario);
+    if (sc.arm === 'mandrel') cell.mandrel.push(sc);
+    else if (sc.arm === 'control') cell.control.push(sc);
+  }
+  return byScenario;
+}
+
+/**
+ * The distinct cohort keys present in a run.
+ *
+ * @param {Array<object>} run
+ * @returns {string[]}
+ */
+function cohortKeysOf(run) {
+  const keys = new Set();
+  for (const sc of run) keys.add(cohortKey(sc));
+  return [...keys];
+}
+
+/**
+ * Compare the Mandrel arm's center of one metric between two runs, applying the
+ * real-delta rule against the combined run-to-run noise (the larger of the two
+ * runs' band spreads — the same `max(spread)` floor the single-run differential
+ * uses). Returns a structured verdict.
+ *
+ * @param {object} args
+ * @param {import('../metrics/variance.js').NoiseBand|null} args.baselineBand
+ * @param {import('../metrics/variance.js').NoiseBand|null} args.candidateBand
+ * @param {boolean} args.higherIsBetter
+ * @returns {{
+ *   comparable: boolean,
+ *   baselineCenter: number|null,
+ *   candidateCenter: number|null,
+ *   shift: number|null,
+ *   noiseFloor: number|null,
+ *   shiftIsReal: boolean,
+ *   verdict: 'improved'|'regressed'|'within-noise'|'incomparable'
+ * }}
+ */
+function compareCenters({ baselineBand, candidateBand, higherIsBetter }) {
+  if (baselineBand === null || candidateBand === null) {
+    return {
+      comparable: false,
+      baselineCenter: baselineBand ? baselineBand.center : null,
+      candidateCenter: candidateBand ? candidateBand.center : null,
+      shift: null,
+      noiseFloor: null,
+      shiftIsReal: false,
+      verdict: 'incomparable',
+    };
+  }
+  const shift = candidateBand.center - baselineBand.center;
+  const noiseFloor = Math.max(baselineBand.spread, candidateBand.spread);
+  const shiftIsReal = Math.abs(shift) > noiseFloor;
+  let verdict;
+  if (!shiftIsReal) {
+    verdict = 'within-noise';
+  } else {
+    const improved = higherIsBetter ? shift > 0 : shift < 0;
+    verdict = improved ? 'improved' : 'regressed';
+  }
+  return {
+    comparable: true,
+    baselineCenter: baselineBand.center,
+    candidateCenter: candidateBand.center,
+    shift,
+    noiseFloor,
+    shiftIsReal,
+    verdict,
+  };
+}
+
+/**
+ * Compare two stored runs and surface the per-dimension deltas between them.
+ *
+ * Both runs are flat scorecard arrays (typically read from the persist store
+ * and filtered to one cohort each). For every scenario shared by the two runs
+ * and every comparable metric, the result carries the per-arm centers and the
+ * Mandrel-arm cross-run shift with its real/within-noise verdict.
+ *
+ * @param {object} args
+ * @param {Array<object>} args.baseline   Baseline run's scorecards (the "from").
+ * @param {Array<object>} args.candidate  Candidate run's scorecards (the "to").
+ * @param {'iqr'|'ci'} [args.method='iqr']
+ * @param {boolean} [args.requireSameCohort=true]  When true, a cohort mismatch
+ *   sets `cohortMatch: false` and still computes the deltas (flagged), so the
+ *   caller decides whether to trust them. (We never silently drop the flag.)
+ * @returns {{
+ *   method: 'iqr'|'ci',
+ *   cohortMatch: boolean,
+ *   baselineCohorts: string[],
+ *   candidateCohorts: string[],
+ *   scenarios: Array<{
+ *     scenario: string,
+ *     inBaseline: boolean,
+ *     inCandidate: boolean,
+ *     metrics: Array<{
+ *       metric: string,
+ *       mandrel: ReturnType<typeof compareCenters>,
+ *       controlBaselineCenter: number|null,
+ *       controlCandidateCenter: number|null
+ *     }>
+ *   }>
+ * }}
+ */
+export function compareRuns({
+  baseline,
+  candidate,
+  method = 'iqr',
+  requireSameCohort = true,
+} = {}) {
+  if (!Array.isArray(baseline) || !Array.isArray(candidate)) {
+    throw new TypeError('compareRuns: baseline and candidate must be arrays');
+  }
+
+  const baselineCohorts = cohortKeysOf(baseline);
+  const candidateCohorts = cohortKeysOf(candidate);
+  // Cohorts match when each run is internally single-cohort AND the two runs
+  // share that one cohort.
+  const cohortMatch =
+    baselineCohorts.length === 1 &&
+    candidateCohorts.length === 1 &&
+    baselineCohorts[0] === candidateCohorts[0];
+
+  const baseCells = cellsByScenario(baseline);
+  const candCells = cellsByScenario(candidate);
+  const scenarioNames = new Set([...baseCells.keys(), ...candCells.keys()]);
+
+  const scenarios = [...scenarioNames].sort().map((scenario) => {
+    const baseCell = baseCells.get(scenario) ?? { mandrel: [], control: [] };
+    const candCell = candCells.get(scenario) ?? { mandrel: [], control: [] };
+    const metrics = COMPARABLE_METRICS.map(
+      ({ metric, accessor, higherIsBetter }) => {
+        const mandrel = compareCenters({
+          baselineBand: bandOrNull(baseCell.mandrel, accessor, method),
+          candidateBand: bandOrNull(candCell.mandrel, accessor, method),
+          higherIsBetter,
+        });
+        const controlBaseBand = bandOrNull(baseCell.control, accessor, method);
+        const controlCandBand = bandOrNull(candCell.control, accessor, method);
+        return {
+          metric,
+          mandrel,
+          controlBaselineCenter: controlBaseBand
+            ? controlBaseBand.center
+            : null,
+          controlCandidateCenter: controlCandBand
+            ? controlCandBand.center
+            : null,
+        };
+      },
+    );
+    return {
+      scenario,
+      inBaseline: baseCells.has(scenario),
+      inCandidate: candCells.has(scenario),
+      metrics,
+    };
+  });
+
+  const result = {
+    method,
+    cohortMatch,
+    baselineCohorts,
+    candidateCohorts,
+    scenarios,
+  };
+
+  if (requireSameCohort && !cohortMatch) {
+    // Surface the mismatch as a first-class field; the caller / renderer must
+    // show it. We do NOT throw — a deliberate cross-cohort diff (e.g. to see a
+    // version bump's effect) is a legitimate operator action, but it must be
+    // labelled, never silent.
+    result.cohortMismatchWarning =
+      'Baseline and candidate are not a single shared cohort ' +
+      `(baseline: ${baselineCohorts.join(' / ') || 'none'}; ` +
+      `candidate: ${candidateCohorts.join(' / ') || 'none'}). ` +
+      'Cross-run deltas are not strictly like-to-like.';
+  }
+
+  return result;
+}
+
+const VERDICT_BADGE = Object.freeze({
+  improved: '🟢 improved',
+  regressed: '🔴 regressed',
+  'within-noise': '≈ within noise',
+  incomparable: '— n/a',
+});
+
+/**
+ * Render a cross-run comparison as a compact Markdown report. Pure.
+ *
+ * @param {ReturnType<typeof compareRuns>} comparison
+ * @param {object} [labels]
+ * @param {string} [labels.baselineLabel='baseline']
+ * @param {string} [labels.candidateLabel='candidate']
+ * @returns {string}  Markdown.
+ */
+export function renderComparison(
+  comparison,
+  { baselineLabel = 'baseline', candidateLabel = 'candidate' } = {},
+) {
+  const fmt = (v, digits = 3) => {
+    if (typeof v !== 'number' || !Number.isFinite(v)) return '—';
+    const rounded = Number(v.toFixed(digits));
+    return Object.is(rounded, -0) ? '0' : String(rounded);
+  };
+
+  const lines = [
+    '# Mandrel Self-Benchmark — Cross-run comparison',
+    '',
+    `Baseline: **${baselineLabel}** → Candidate: **${candidateLabel}** · band = ${comparison.method}`,
+    '',
+  ];
+
+  if (comparison.cohortMatch) {
+    lines.push(`Cohort: \`${comparison.baselineCohorts[0]}\` (matched).`, '');
+  } else {
+    lines.push(
+      '> ⚠️ **Cohort mismatch.** ' +
+        (comparison.cohortMismatchWarning ??
+          'Baseline and candidate are not a single shared cohort.'),
+      '',
+    );
+  }
+
+  if (comparison.scenarios.length === 0) {
+    lines.push('No shared scenarios to compare.');
+    return `${lines.join('\n')}\n`;
+  }
+
+  for (const s of comparison.scenarios) {
+    lines.push(`## Scenario: \`${s.scenario}\``);
+    if (!s.inBaseline || !s.inCandidate) {
+      lines.push(
+        '',
+        `> Present only in ${s.inBaseline ? baselineLabel : candidateLabel}; ` +
+          'no cross-run delta computable.',
+        '',
+      );
+    } else {
+      lines.push(
+        '',
+        `| Metric (Mandrel arm) | ${baselineLabel} | ${candidateLabel} | Shift | Noise floor | Verdict |`,
+        '| --- | --- | --- | --- | --- | --- |',
+      );
+      for (const m of s.metrics) {
+        const digits = m.metric === 'efficiency.wallClockMs' ? 0 : 3;
+        const c = m.mandrel;
+        lines.push(
+          `| ${m.metric} | ${fmt(c.baselineCenter, digits)} | ${fmt(c.candidateCenter, digits)} | ${fmt(c.shift, digits)} | ${fmt(c.noiseFloor, digits)} | ${VERDICT_BADGE[c.verdict]} |`,
+        );
+      }
+      lines.push('');
+    }
+  }
+
+  return `${lines
+    .join('\n')
+    .replace(/\n{3,}/g, '\n\n')
+    .trimEnd()}\n`;
+}

--- a/bench/report/persist.js
+++ b/bench/report/persist.js
@@ -1,0 +1,249 @@
+// bench/report/persist.js
+//
+// Append-only scorecard store for the Mandrel self-benchmark harness
+// (Epic #4211, Story #4218). Internal tooling only — never shipped in the
+// distributed `.agents/` bundle, never run against the live repo.
+//
+// The store is the durable substrate that makes "track the value-add over
+// time" real: each run's per-run scorecards are appended — stamped with the
+// pinned model, the framework version under test, and the execution
+// environment — to a stable NDJSON ledger, so a later run can read them back
+// and compare cohorts (bench/report/compare.js) without re-executing the
+// expensive `claude -p` sessions.
+//
+// Why NDJSON and append-only:
+//   - Append-only matches the harness's other ledgers (lifecycle.ndjson,
+//     signals.ndjson) and is crash-safe: a partially-written final line never
+//     corrupts the records before it.
+//   - One JSON object per line is greppable, diffable, and streamable, and a
+//     new run never has to rewrite history — it only appends.
+//
+// Every appended record is REQUIRED to carry the stamp fields (model.id,
+// frameworkVersion, env.node, env.os) so the store can never hold an
+// un-attributable scorecard that would later be compared across mismatched
+// cohorts. A scorecard missing a stamp field is rejected at the boundary
+// (fail loud, never persist silently-incomparable data).
+//
+// Determinism: the validation + serialization core is pure; only the public
+// `appendScorecards` / `readStore` touch the filesystem, and both accept an
+// injectable I/O shim so the core is unit-testable with no real disk.
+
+import { appendFileSync, existsSync, mkdirSync, readFileSync } from 'node:fs';
+import { dirname } from 'node:path';
+
+import { SCORECARD_SCHEMA_VERSION } from '../collect/normalize.js';
+
+/**
+ * The stamp fields every persisted scorecard MUST carry, each with an accessor
+ * that pulls the value off a scorecard. A record missing any of these is
+ * rejected — the store's whole point is that a later cross-run comparison only
+ * compares like-to-like, which is impossible without a complete stamp.
+ */
+const REQUIRED_STAMP = Object.freeze([
+  { key: 'runId', get: (sc) => sc?.runId },
+  { key: 'model.id', get: (sc) => sc?.model?.id },
+  { key: 'frameworkVersion', get: (sc) => sc?.frameworkVersion },
+  { key: 'env.node', get: (sc) => sc?.env?.node },
+  { key: 'env.os', get: (sc) => sc?.env?.os },
+  { key: 'scenario', get: (sc) => sc?.scenario },
+  { key: 'arm', get: (sc) => sc?.arm },
+]);
+
+/**
+ * Validate that a scorecard carries the full stamp required to persist it.
+ * Returns the list of missing field paths (empty ⇒ valid). Pure.
+ *
+ * @param {object} scorecard
+ * @returns {string[]}  Missing stamp field paths.
+ */
+export function missingStampFields(scorecard) {
+  if (!scorecard || typeof scorecard !== 'object') {
+    return REQUIRED_STAMP.map((f) => f.key);
+  }
+  const missing = [];
+  for (const { key, get } of REQUIRED_STAMP) {
+    const v = get(scorecard);
+    if (typeof v !== 'string' || v.length === 0) missing.push(key);
+  }
+  return missing;
+}
+
+/**
+ * Derive the cohort key a scorecard belongs to — the tuple a cross-run
+ * comparison groups by so it only ever compares like-to-like. Stable, so two
+ * runs in the same cohort produce the identical key string.
+ *
+ * @param {object} scorecard
+ * @returns {string}  `<model.id>|<frameworkVersion>|<env.node>|<env.os>`
+ */
+export function cohortKey(scorecard) {
+  const model = scorecard?.model?.id ?? '';
+  const fw = scorecard?.frameworkVersion ?? '';
+  const node = scorecard?.env?.node ?? '';
+  const os = scorecard?.env?.os ?? '';
+  return `${model}|${fw}|${node}|${os}`;
+}
+
+/**
+ * Serialize a list of scorecards to the NDJSON block that gets appended to the
+ * store. Each record is validated for its stamp and schema version first; an
+ * invalid record throws (the whole append is rejected — never persist a
+ * partial, silently-incomparable batch). Pure — returns the string to append,
+ * does no I/O.
+ *
+ * @param {Array<object>} scorecards
+ * @returns {string}  NDJSON text ending in a single trailing newline.
+ * @throws {TypeError}  When the input is not an array.
+ * @throws {Error}      When any scorecard is missing stamp fields or carries an
+ *                      unexpected schemaVersion.
+ */
+export function serializeScorecards(scorecards) {
+  if (!Array.isArray(scorecards)) {
+    throw new TypeError('serializeScorecards: scorecards must be an array');
+  }
+  const lines = [];
+  for (let i = 0; i < scorecards.length; i += 1) {
+    const sc = scorecards[i];
+    const missing = missingStampFields(sc);
+    if (missing.length > 0) {
+      throw new Error(
+        `serializeScorecards: scorecard[${i}] (runId=${sc?.runId ?? '?'}) is missing required stamp field(s): ${missing.join(', ')}`,
+      );
+    }
+    if (
+      sc.schemaVersion !== undefined &&
+      sc.schemaVersion !== SCORECARD_SCHEMA_VERSION
+    ) {
+      throw new Error(
+        `serializeScorecards: scorecard[${i}] (runId=${sc.runId}) has schemaVersion ${sc.schemaVersion}, expected ${SCORECARD_SCHEMA_VERSION}`,
+      );
+    }
+    // Stamp the schema version on if the caller omitted it, so every persisted
+    // record is self-describing.
+    const record =
+      sc.schemaVersion === undefined
+        ? { schemaVersion: SCORECARD_SCHEMA_VERSION, ...sc }
+        : sc;
+    lines.push(JSON.stringify(record));
+  }
+  return lines.length > 0 ? `${lines.join('\n')}\n` : '';
+}
+
+/**
+ * Parse the NDJSON store text back into scorecard records. Blank lines are
+ * skipped; a malformed line throws with its 1-based line number so a corrupt
+ * store fails loudly. Pure.
+ *
+ * @param {string} text
+ * @returns {Array<object>}
+ * @throws {SyntaxError}  On a non-blank line that is not valid JSON.
+ */
+export function parseStore(text) {
+  if (typeof text !== 'string') {
+    throw new TypeError('parseStore: input must be a string');
+  }
+  const out = [];
+  const lines = text.split('\n');
+  for (let i = 0; i < lines.length; i += 1) {
+    const line = lines[i].trim();
+    if (line.length === 0) continue;
+    try {
+      out.push(JSON.parse(line));
+    } catch (cause) {
+      throw new SyntaxError(
+        `parseStore: invalid JSON on line ${i + 1}: ${cause.message}`,
+      );
+    }
+  }
+  return out;
+}
+
+/**
+ * Append a batch of scorecards to the append-only store at `storePath`. Creates
+ * the parent directory and the file on first write; never rewrites existing
+ * records. Each scorecard is validated (full stamp + schema version) before any
+ * byte is written, so a bad batch is rejected atomically rather than appending
+ * a partial run.
+ *
+ * Idempotency note: appending is additive by design (a benchmark store is a
+ * historical ledger — the same run re-appended is a duplicate the reader can
+ * de-dup by `runId`, not an error). Callers that must avoid duplicates should
+ * read the store and filter by `runId` first.
+ *
+ * @param {object} args
+ * @param {string} args.storePath          Path to the NDJSON store file.
+ * @param {Array<object>} args.scorecards  Scorecards to append.
+ * @param {object} [deps]
+ * @param {(p: string, data: string) => void} [deps.appendFileImpl]
+ * @param {(p: string) => boolean} [deps.existsImpl]
+ * @param {(p: string, opts: object) => void} [deps.mkdirImpl]
+ * @returns {{ storePath: string, appended: number, bytesAppended: number }}
+ */
+export function appendScorecards({ storePath, scorecards }, deps = {}) {
+  if (typeof storePath !== 'string' || storePath.length === 0) {
+    throw new TypeError('appendScorecards: storePath is required');
+  }
+  const append = deps.appendFileImpl ?? appendFileSync;
+  const exists = deps.existsImpl ?? existsSync;
+  const mkdir = deps.mkdirImpl ?? mkdirSync;
+
+  // Validate + serialize first; this throws before any I/O on a bad batch.
+  const block = serializeScorecards(scorecards);
+  if (block.length === 0) {
+    return { storePath, appended: 0, bytesAppended: 0 };
+  }
+
+  const dir = dirname(storePath);
+  if (dir && dir !== '.' && !exists(dir)) {
+    mkdir(dir, { recursive: true });
+  }
+
+  append(storePath, block);
+  return {
+    storePath,
+    appended: scorecards.length,
+    bytesAppended: Buffer.byteLength(block, 'utf8'),
+  };
+}
+
+/**
+ * Read every scorecard from the store. A non-existent store reads as an empty
+ * list (a store that was never written is simply empty, not an error).
+ *
+ * @param {object} args
+ * @param {string} args.storePath
+ * @param {object} [deps]
+ * @param {(p: string) => boolean} [deps.existsImpl]
+ * @param {(p: string, enc: string) => string} [deps.readFileImpl]
+ * @returns {Array<object>}
+ */
+export function readStore({ storePath }, deps = {}) {
+  if (typeof storePath !== 'string' || storePath.length === 0) {
+    throw new TypeError('readStore: storePath is required');
+  }
+  const exists = deps.existsImpl ?? existsSync;
+  const read = deps.readFileImpl ?? readFileSync;
+  if (!exists(storePath)) return [];
+  return parseStore(read(storePath, 'utf8'));
+}
+
+/**
+ * Group the store's records by cohort key, preserving append order within each
+ * cohort. The reader for the cross-run comparison slice — it lets a caller pull
+ * "all runs for this (model, framework version, env)" out of a mixed store.
+ *
+ * @param {Array<object>} scorecards  Records read from the store.
+ * @returns {Map<string, Array<object>>}
+ */
+export function groupByCohort(scorecards) {
+  if (!Array.isArray(scorecards)) {
+    throw new TypeError('groupByCohort: scorecards must be an array');
+  }
+  const byCohort = new Map();
+  for (const sc of scorecards) {
+    const key = cohortKey(sc);
+    if (!byCohort.has(key)) byCohort.set(key, []);
+    byCohort.get(key).push(sc);
+  }
+  return byCohort;
+}

--- a/bench/report/render.js
+++ b/bench/report/render.js
@@ -1,0 +1,610 @@
+// bench/report/render.js
+//
+// The operator-facing value-add report for the Mandrel self-benchmark harness
+// (Epic #4211, Story #4218). Internal tooling only — never shipped in the
+// distributed `.agents/` bundle, never run against the live repo.
+//
+// This module turns a corpus of per-run scorecards (one per scenario × arm ×
+// run, conforming to bench/schemas/scorecard.schema.json) into a single
+// Markdown report. It sits on top of the scoring slice
+// (bench/score/differential.js) and the noise-band primitive
+// (bench/metrics/variance.js); it adds NO new statistics of its own — every
+// number it prints is sourced from those modules so the report is a faithful
+// rendering of the measurement contract (bench/metrics/README.md), not a
+// second, divergent interpretation of it.
+//
+// The report renders, in order:
+//
+//   1. A header stamped with the cohort (model, framework version, env) so a
+//      reader only ever compares like-to-like.
+//   2. Per-scenario, per-dimension DISTRIBUTIONS — each dimension reported as a
+//      noise-band for BOTH arms (never a bare point estimate), plus the
+//      Mandrel-vs-bare delta and its real/within-noise verdict against the
+//      noise floor (README § "Real-delta rule").
+//   3. The per-difficulty SCALING VIEW — Efficiency (totalTokens) and Overhead
+//      ratio across the difficulty ladder for both arms, with any monotonicity
+//      violation surfaced as an explicit calibration warning (never a silent
+//      pass).
+//   4. A clearly-delineated "Recommended improvements" section of actionable,
+//      evidence-linked recommendations — including the overhead-floor estimate
+//      and the ceremony-lite recommendation when a positive floor buys no
+//      quality gain.
+//
+// Determinism: pure functions, no I/O, no clock, no randomness. The same corpus
+// always renders byte-for-byte the same report, so a persisted report is
+// reproducible and diffable across runs.
+
+import { noiseBand } from '../metrics/variance.js';
+import {
+  EFFICIENCY_COMPONENTS,
+  SCALAR_DIMENSIONS,
+  scoreCorpus,
+} from '../score/differential.js';
+
+/** Difficulty ladder order (easy → hard). v1 ships two rungs. */
+const DIFFICULTY_BY_SCENARIO = Object.freeze({
+  'hello-world': 1,
+  'crud-db': 2,
+});
+
+/**
+ * Human-readable labels for the dimensions and efficiency components, used in
+ * report headings. Keyed by the same `name` the scoring slice emits.
+ */
+const DIMENSION_LABELS = Object.freeze({
+  quality: 'Quality',
+  planningFidelity: 'Planning fidelity',
+  autonomy: 'Autonomy',
+  overheadRatio: 'Overhead ratio (tokens)',
+  'efficiency.wallClockMs': 'Efficiency · wall-clock (ms)',
+  'efficiency.totalTokens': 'Efficiency · total tokens',
+  'efficiency.dispatches': 'Efficiency · dispatches',
+  'efficiency.costUsd': 'Efficiency · cost (USD)',
+});
+
+/**
+ * Round a finite number to a fixed precision for display, leaving non-finite /
+ * null values as an em-dash. Never throws.
+ *
+ * @param {unknown} v
+ * @param {number} [digits=3]
+ * @returns {string}
+ */
+function fmt(v, digits = 3) {
+  if (typeof v !== 'number' || !Number.isFinite(v)) return '—';
+  // Avoid "-0" and trailing-zero noise while keeping integers clean.
+  const rounded = Number(v.toFixed(digits));
+  return Object.is(rounded, -0) ? '0' : String(rounded);
+}
+
+/**
+ * Render a noise-band as a compact `center [low, high]` cell, or an em-dash
+ * when the band is null (the metric was null for that arm across all runs).
+ *
+ * @param {import('../metrics/variance.js').NoiseBand|null} band
+ * @param {number} [digits=3]
+ * @returns {string}
+ */
+function fmtBand(band, digits = 3) {
+  if (!band) return '—';
+  return `${fmt(band.center, digits)} [${fmt(band.low, digits)}, ${fmt(band.high, digits)}]`;
+}
+
+/**
+ * Build a noise-band over one arm's per-run values for a given accessor, or
+ * null when no finite values are present (so a dimension that is null for an
+ * arm — planningFidelity on control — renders as an em-dash rather than
+ * throwing). Mirrors the private helper in the scoring slice so the report's
+ * per-arm distributions use the identical band the delta was computed from.
+ *
+ * @param {Array<object>} scorecards
+ * @param {(d: object) => number|null} accessor
+ * @param {'iqr'|'ci'} method
+ * @returns {import('../metrics/variance.js').NoiseBand|null}
+ */
+function armBand(scorecards, accessor, method) {
+  try {
+    return noiseBand(
+      scorecards.map((sc) => accessor(sc?.dimensions)),
+      { method },
+    );
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Group a flat list of scorecards into difficulty-ordered scenario cells, each
+ * carrying the Mandrel and control arms separately. Scenarios are ordered by
+ * the difficulty ladder; an unknown scenario sorts last (and is still
+ * rendered, so an out-of-ladder scenario is never silently dropped).
+ *
+ * @param {Array<object>} scorecards
+ * @returns {Array<{
+ *   scenario: string,
+ *   difficulty: number,
+ *   mandrelRuns: Array<object>,
+ *   controlRuns: Array<object>
+ * }>}
+ */
+export function groupCells(scorecards) {
+  if (!Array.isArray(scorecards)) {
+    throw new TypeError('groupCells: scorecards must be an array');
+  }
+  const byScenario = new Map();
+  for (const sc of scorecards) {
+    const scenario = sc?.scenario;
+    if (typeof scenario !== 'string') continue;
+    if (!byScenario.has(scenario)) {
+      byScenario.set(scenario, { mandrelRuns: [], controlRuns: [] });
+    }
+    const cell = byScenario.get(scenario);
+    if (sc.arm === 'mandrel') cell.mandrelRuns.push(sc);
+    else if (sc.arm === 'control') cell.controlRuns.push(sc);
+  }
+
+  const cells = [];
+  for (const [scenario, arms] of byScenario) {
+    cells.push({
+      scenario,
+      difficulty: DIFFICULTY_BY_SCENARIO[scenario] ?? Number.POSITIVE_INFINITY,
+      mandrelRuns: arms.mandrelRuns,
+      controlRuns: arms.controlRuns,
+    });
+  }
+  cells.sort((a, b) => {
+    if (a.difficulty !== b.difficulty) return a.difficulty - b.difficulty;
+    return a.scenario.localeCompare(b.scenario);
+  });
+  return cells;
+}
+
+/**
+ * Derive the cohort stamp (model, framework version, env) from the corpus. The
+ * harness only ever compares like-to-like, so every scorecard in a corpus is
+ * expected to share one cohort; if more than one distinct value is present for
+ * a field, that is itself a finding — we record every distinct value and flag
+ * the mix so the report never silently averages across cohorts.
+ *
+ * @param {Array<object>} scorecards
+ * @returns {{
+ *   models: string[],
+ *   frameworkVersions: string[],
+ *   nodes: string[],
+ *   oses: string[],
+ *   mixed: boolean
+ * }}
+ */
+export function deriveCohort(scorecards) {
+  const models = new Set();
+  const frameworkVersions = new Set();
+  const nodes = new Set();
+  const oses = new Set();
+  for (const sc of scorecards) {
+    if (sc?.model?.id) models.add(sc.model.id);
+    if (sc?.frameworkVersion) frameworkVersions.add(sc.frameworkVersion);
+    if (sc?.env?.node) nodes.add(sc.env.node);
+    if (sc?.env?.os) oses.add(sc.env.os);
+  }
+  const mixed =
+    models.size > 1 ||
+    frameworkVersions.size > 1 ||
+    nodes.size > 1 ||
+    oses.size > 1;
+  return {
+    models: [...models],
+    frameworkVersions: [...frameworkVersions],
+    nodes: [...nodes],
+    oses: [...oses],
+    mixed,
+  };
+}
+
+/**
+ * Render the cohort-stamp header block.
+ *
+ * @param {ReturnType<typeof deriveCohort>} cohort
+ * @param {'iqr'|'ci'} method
+ * @returns {string}
+ */
+function renderHeader(cohort, method) {
+  const lines = [
+    '# Mandrel Self-Benchmark — Value-Add Report',
+    '',
+    '> Internal tooling (Epic #4211). Each dimension is reported as a',
+    '> distribution across N runs, never a point estimate. A Mandrel-vs-bare',
+    '> delta is only called **real** when it clears the larger of the two arms’',
+    '> noise-band spreads (see `bench/metrics/README.md` § Real-delta rule).',
+    '',
+    '## Cohort',
+    '',
+    `- **Model:** ${cohort.models.length ? cohort.models.join(', ') : '—'}`,
+    `- **Framework version:** ${cohort.frameworkVersions.length ? cohort.frameworkVersions.join(', ') : '—'}`,
+    `- **Node:** ${cohort.nodes.length ? cohort.nodes.join(', ') : '—'}`,
+    `- **OS:** ${cohort.oses.length ? cohort.oses.join(', ') : '—'}`,
+    `- **Band method:** ${method}`,
+  ];
+  if (cohort.mixed) {
+    lines.push(
+      '',
+      '> ⚠️ **Mixed cohort:** this corpus mixes more than one',
+      '> (model, framework version, env) — comparisons below are NOT',
+      '> strictly like-to-like. Re-run within a single cohort for a clean',
+      '> verdict.',
+    );
+  }
+  return lines.join('\n');
+}
+
+/**
+ * Build the per-arm distribution rows + the differential verdict for every
+ * dimension of one scenario cell. Returns a structured object the renderer
+ * formats into a table; separated so it is unit-testable independent of the
+ * Markdown shape.
+ *
+ * @param {object} cell  A `groupCells` entry.
+ * @param {ReturnType<typeof computeDifferential>} diff  The scenario's
+ *   differential from `scoreCorpus`.
+ * @param {'iqr'|'ci'} method
+ * @returns {Array<{
+ *   metric: string,
+ *   label: string,
+ *   mandrelBand: object|null,
+ *   controlBand: object|null,
+ *   delta: number|null,
+ *   noiseFloor: number|null,
+ *   verdict: 'real'|'within-noise'|'incomparable'
+ * }>}
+ */
+export function dimensionRows(cell, diff, method) {
+  const rows = [];
+  for (const { name, accessor } of SCALAR_DIMENSIONS) {
+    const cmp = diff.dimensions[name];
+    rows.push({
+      metric: name,
+      label: DIMENSION_LABELS[name] ?? name,
+      mandrelBand: armBand(cell.mandrelRuns, accessor, method),
+      controlBand: armBand(cell.controlRuns, accessor, method),
+      delta: cmp?.delta ?? null,
+      noiseFloor: cmp?.noiseFloor ?? null,
+      verdict: cmp?.verdict ?? 'incomparable',
+    });
+  }
+  for (const { name, accessor } of EFFICIENCY_COMPONENTS) {
+    const key = `efficiency.${name}`;
+    const cmp = diff.efficiency[name];
+    rows.push({
+      metric: key,
+      label: DIMENSION_LABELS[key] ?? key,
+      mandrelBand: armBand(cell.mandrelRuns, accessor, method),
+      controlBand: armBand(cell.controlRuns, accessor, method),
+      delta: cmp?.delta ?? null,
+      noiseFloor: cmp?.noiseFloor ?? null,
+      verdict: cmp?.verdict ?? 'incomparable',
+    });
+  }
+  return rows;
+}
+
+const VERDICT_BADGE = Object.freeze({
+  real: '✅ real',
+  'within-noise': '≈ within noise',
+  incomparable: '— n/a',
+});
+
+/**
+ * Render one scenario's distribution table (every dimension, both arms, delta
+ * + verdict).
+ *
+ * @param {object} cell
+ * @param {ReturnType<typeof computeDifferential>} diff
+ * @param {'iqr'|'ci'} method
+ * @returns {string}
+ */
+function renderScenarioSection(cell, diff, method) {
+  const rows = dimensionRows(cell, diff, method);
+  const header = [
+    `### Scenario: \`${cell.scenario}\` (difficulty ${Number.isFinite(cell.difficulty) ? cell.difficulty : '?'})`,
+    '',
+    `n = ${cell.mandrelRuns.length} mandrel / ${cell.controlRuns.length} control · band = ${method} (\`center [low, high]\`)`,
+    '',
+    '| Dimension | Mandrel | Control | Δ (M−C) | Noise floor | Verdict |',
+    '| --- | --- | --- | --- | --- | --- |',
+  ];
+  const body = rows.map((r) => {
+    const digits = r.metric === 'efficiency.wallClockMs' ? 0 : 3;
+    return `| ${r.label} | ${fmtBand(r.mandrelBand, digits)} | ${fmtBand(r.controlBand, digits)} | ${fmt(r.delta, digits)} | ${fmt(r.noiseFloor, digits)} | ${VERDICT_BADGE[r.verdict]} |`;
+  });
+  return [...header, ...body].join('\n');
+}
+
+/**
+ * Render the per-difficulty scaling view: Efficiency (totalTokens) and Overhead
+ * ratio (tokenRatio) across the difficulty ladder for BOTH arms, with the
+ * monotonicity verdict and any calibration warnings surfaced explicitly.
+ *
+ * @param {Array<object>} cells  Difficulty-ordered scenario cells.
+ * @param {ReturnType<typeof scoreCorpus>} corpus  The scored corpus.
+ * @param {'iqr'|'ci'} method
+ * @returns {string}
+ */
+export function renderScalingView(cells, corpus, method) {
+  const tokenAcc = (d) => d?.efficiency?.totalTokens ?? null;
+  const ratioAcc = (d) => d?.overheadRatio?.tokenRatio ?? null;
+
+  const lines = [
+    '## Per-difficulty scaling view',
+    '',
+    'As difficulty rises, Efficiency (absolute tokens) must **rise** and the',
+    'Overhead ratio must **fall** as ceremony amortizes over more output. A',
+    'violation is a calibration warning, not a silent pass.',
+    '',
+    '| Scenario | Difficulty | Tokens (mandrel) | Tokens (control) | Overhead ratio (mandrel) | Overhead ratio (control) |',
+    '| --- | --- | --- | --- | --- | --- |',
+  ];
+  for (const cell of cells) {
+    const mTokens = armBand(cell.mandrelRuns, tokenAcc, method);
+    const cTokens = armBand(cell.controlRuns, tokenAcc, method);
+    const mRatio = armBand(cell.mandrelRuns, ratioAcc, method);
+    const cRatio = armBand(cell.controlRuns, ratioAcc, method);
+    lines.push(
+      `| \`${cell.scenario}\` | ${Number.isFinite(cell.difficulty) ? cell.difficulty : '?'} | ${fmtBand(mTokens, 0)} | ${fmtBand(cTokens, 0)} | ${fmtBand(mRatio)} | ${fmtBand(cRatio)} |`,
+    );
+  }
+
+  const mono = corpus.difficultyMonotonicity;
+  lines.push('', '### Monotonicity (Mandrel arm, calibration guardrail)', '');
+  if (mono.ordered.length < 2) {
+    lines.push(
+      '- Not enough ladder rungs to evaluate monotonicity (needs ≥ 2 scenarios).',
+    );
+  } else if (mono.monotonicityHolds) {
+    lines.push(
+      '- ✅ Monotonicity holds across every adjacent rung (efficiency rises, overhead ratio falls).',
+    );
+  } else {
+    lines.push(
+      '- ⚠️ **Calibration warning — monotonicity violated.** The instrument may be',
+      '  insensitive or a scenario mis-graded for difficulty:',
+    );
+    for (const w of mono.warnings) {
+      lines.push(`  - ${w}`);
+    }
+  }
+  return lines.join('\n');
+}
+
+/**
+ * Build the structured "Recommended improvements" findings list from the scored
+ * corpus. Each finding is actionable and evidence-linked (it cites the metric
+ * and the number that triggered it). Returned as data so the renderer formats
+ * it and tests can assert on the findings without parsing Markdown.
+ *
+ * Findings, in priority order:
+ *   1. Overhead floor with no quality gain → ceremony-lite path (the canonical
+ *      README § "Overhead floor" recommendation). Always reports the floor
+ *      estimate even when it does NOT trigger a recommendation, so the section
+ *      surfaces the overhead-floor estimate unconditionally.
+ *   2. Monotonicity violations → recalibrate the difficulty ladder / instrument.
+ *   3. Per-scenario dimensions where the bare control arm beats Mandrel by a
+ *      REAL margin on a value dimension (a regression the scaffolding should
+ *      not be causing).
+ *
+ * @param {ReturnType<typeof scoreCorpus>} corpus
+ * @returns {Array<{
+ *   id: string,
+ *   severity: 'high'|'medium'|'info',
+ *   title: string,
+ *   evidence: string,
+ *   action: string
+ * }>}
+ */
+export function recommendImprovements(corpus) {
+  const findings = [];
+
+  // 1. Overhead floor — always surfaced; recommendation fires conditionally.
+  const floor = corpus.overheadFloor;
+  if (floor) {
+    const tok = floor.overheadFloorTokens;
+    const usd = floor.overheadFloorUsd;
+    const floorEvidence =
+      `hello-world overhead floor ≈ ${fmt(tok, 0)} tokens` +
+      (typeof usd === 'number' ? ` / $${fmt(usd, 4)}` : '') +
+      ` above control (quality gain ${fmt(floor.qualityGain)})`;
+    if (floor.recommendCeremonyLite) {
+      findings.push({
+        id: 'overhead-floor-ceremony-lite',
+        severity: 'high',
+        title: 'Add a ceremony-lite path for trivial scopes',
+        evidence: `${floorEvidence} — a positive floor with no matching quality gain.`,
+        action:
+          'Gate the full /plan→/deliver ceremony behind a complexity threshold so ' +
+          'trivial scopes skip the planning/decomposition tax that buys no quality here.',
+      });
+    } else {
+      findings.push({
+        id: 'overhead-floor-estimate',
+        severity: 'info',
+        title: 'Overhead-floor estimate (fixed ceremony tax on near-zero work)',
+        evidence: floorEvidence,
+        action:
+          floor.noQualityGain === false && typeof floor.qualityGain === 'number'
+            ? 'The floor is currently justified by a quality gain on hello-world; keep monitoring as the ladder grows.'
+            : 'No actionable floor finding for this cohort; recorded for tracking.',
+      });
+    }
+  }
+
+  // 2. Monotonicity violations.
+  const mono = corpus.difficultyMonotonicity;
+  if (mono && !mono.monotonicityHolds && mono.ordered.length >= 2) {
+    findings.push({
+      id: 'monotonicity-violation',
+      severity: 'high',
+      title: 'Recalibrate the difficulty ladder or the instrument',
+      evidence: mono.warnings.join('; '),
+      action:
+        'Efficiency did not rise and/or overhead ratio did not fall across the ' +
+        'ladder. Re-grade the scenario difficulties or widen the gap between rungs ' +
+        'so the instrument is sensitive to scaling.',
+    });
+  }
+
+  // 3. Real regressions on a value dimension (control beats mandrel).
+  //    Higher-is-better for quality/planningFidelity/autonomy ⇒ a positive
+  //    (control − mandrel) gap that clears the noise floor is a regression.
+  const valueDimensions = new Set(['quality', 'planningFidelity', 'autonomy']);
+  for (const scenarioDiff of corpus.perScenario) {
+    for (const name of valueDimensions) {
+      const cmp = scenarioDiff.dimensions[name];
+      if (!cmp?.comparable || !cmp.deltaIsReal) continue;
+      // delta is (mandrel − control); a value dimension regresses when it is
+      // negative AND real.
+      if (cmp.delta < 0) {
+        findings.push({
+          id: `regression-${scenarioDiff.scenario}-${name}`,
+          severity: 'medium',
+          title: `Investigate the ${DIMENSION_LABELS[name] ?? name} regression on \`${scenarioDiff.scenario}\``,
+          evidence: `Mandrel ${fmt(cmp.mandrelCenter)} vs control ${fmt(cmp.controlCenter)} (Δ ${fmt(cmp.delta)}, noise floor ${fmt(cmp.noiseFloor)}) — a real gap in the bare arm’s favour.`,
+          action:
+            'The scaffolding is costing a value dimension it should protect. ' +
+            'Trace the lifecycle for this scenario to find where the regression enters.',
+        });
+      }
+    }
+  }
+
+  return findings;
+}
+
+const SEVERITY_BADGE = Object.freeze({
+  high: '🔴 High',
+  medium: '🟠 Medium',
+  info: '🔵 Info',
+});
+
+/**
+ * Render the "Recommended improvements" section from the structured findings.
+ *
+ * @param {ReturnType<typeof recommendImprovements>} findings
+ * @returns {string}
+ */
+function renderRecommendations(findings) {
+  const lines = ['## Recommended improvements', ''];
+  if (findings.length === 0) {
+    lines.push(
+      'No actionable findings for this cohort: no overhead-floor recommendation,',
+      'no monotonicity violation, and no real value-dimension regression. The',
+      'scaffolding is earning its tax at this frontier.',
+    );
+    return lines.join('\n');
+  }
+  for (const f of findings) {
+    lines.push(
+      `### ${SEVERITY_BADGE[f.severity] ?? f.severity} — ${f.title}`,
+      '',
+      `- **Evidence:** ${f.evidence}`,
+      `- **Action:** ${f.action}`,
+      '',
+    );
+  }
+  // Drop the trailing blank line for a stable tail.
+  while (lines.length > 0 && lines[lines.length - 1] === '') lines.pop();
+  return lines.join('\n');
+}
+
+/**
+ * Render the full value-add report from a corpus of per-run scorecards.
+ *
+ * @param {object} args
+ * @param {Array<object>} args.scorecards  Flat list of scorecards (all
+ *   scenarios × arms × runs) for ONE cohort.
+ * @param {'iqr'|'ci'} [args.method='iqr']  Band method.
+ * @returns {string}  The Markdown report.
+ */
+export function renderReport({ scorecards, method = 'iqr' } = {}) {
+  if (!Array.isArray(scorecards)) {
+    throw new TypeError('renderReport: scorecards must be an array');
+  }
+
+  const cohort = deriveCohort(scorecards);
+  const cells = groupCells(scorecards);
+  const corpus = scoreCorpus({
+    cells: cells.map((c) => ({
+      scenario: c.scenario,
+      difficulty: c.difficulty,
+      mandrelRuns: c.mandrelRuns,
+      controlRuns: c.controlRuns,
+    })),
+    method,
+  });
+
+  const sections = [renderHeader(cohort, method), ''];
+
+  sections.push('## Dimension distributions (Mandrel vs bare control)', '');
+  if (cells.length === 0) {
+    sections.push('No scorecards supplied — nothing to render.', '');
+  } else {
+    for (let i = 0; i < cells.length; i += 1) {
+      const cell = cells[i];
+      const diff = corpus.perScenario[i];
+      sections.push(renderScenarioSection(cell, diff, method), '');
+    }
+  }
+
+  sections.push(renderScalingView(cells, corpus, method), '');
+
+  const findings = recommendImprovements(corpus);
+  sections.push(renderRecommendations(findings));
+
+  return `${sections
+    .join('\n')
+    .replace(/\n{3,}/g, '\n\n')
+    .trimEnd()}\n`;
+}
+
+/**
+ * Convenience structured form of the report (the same data the Markdown is
+ * rendered from) for callers that want to consume the findings programmatically
+ * rather than parse the Markdown. Pure; shares the corpus computation.
+ *
+ * @param {object} args
+ * @param {Array<object>} args.scorecards
+ * @param {'iqr'|'ci'} [args.method='iqr']
+ * @returns {{
+ *   cohort: ReturnType<typeof deriveCohort>,
+ *   method: 'iqr'|'ci',
+ *   scenarios: Array<{ scenario: string, difficulty: number, rows: ReturnType<typeof dimensionRows> }>,
+ *   monotonicity: ReturnType<typeof scoreCorpus>['difficultyMonotonicity'],
+ *   overheadFloor: ReturnType<typeof scoreCorpus>['overheadFloor'],
+ *   recommendations: ReturnType<typeof recommendImprovements>
+ * }}
+ */
+export function buildReportModel({ scorecards, method = 'iqr' } = {}) {
+  if (!Array.isArray(scorecards)) {
+    throw new TypeError('buildReportModel: scorecards must be an array');
+  }
+  const cohort = deriveCohort(scorecards);
+  const cells = groupCells(scorecards);
+  const corpus = scoreCorpus({
+    cells: cells.map((c) => ({
+      scenario: c.scenario,
+      difficulty: c.difficulty,
+      mandrelRuns: c.mandrelRuns,
+      controlRuns: c.controlRuns,
+    })),
+    method,
+  });
+  return {
+    cohort,
+    method,
+    scenarios: cells.map((cell, i) => ({
+      scenario: cell.scenario,
+      difficulty: cell.difficulty,
+      rows: dimensionRows(cell, corpus.perScenario[i], method),
+    })),
+    monotonicity: corpus.difficultyMonotonicity,
+    overheadFloor: corpus.overheadFloor,
+    recommendations: recommendImprovements(corpus),
+  };
+}

--- a/bench/scenarios/acceptance-eval-adapter.js
+++ b/bench/scenarios/acceptance-eval-adapter.js
@@ -1,0 +1,319 @@
+/**
+ * acceptance-eval-adapter.js — bridge a scenario's FROZEN acceptance oracle
+ * to Mandrel's existing acceptance-eval cross-check (Story #4214).
+ *
+ * The benchmark's Quality dimension is scored two ways (Epic #4211):
+ *
+ *   1. The **frozen acceptance suite** is the objective spine — a fixed,
+ *      deterministic oracle that probes the delivered app's user-visible
+ *      HTTP behavior and returns one verdict per acceptance criterion
+ *      (`bench/scenarios/<id>/acceptance.test.js#evaluate`).
+ *   2. The **acceptance-eval cross-check** is the LLM-judge second opinion
+ *      — the in-repo gate at `.agents/scripts/acceptance-eval.js`, whose
+ *      verdict shape is fixed by
+ *      `.agents/schemas/acceptance-eval-verdict.schema.json`.
+ *
+ * This adapter runs the frozen suite, lifts its per-criterion pass/fail
+ * into a schema-valid acceptance-eval verdict, feeds that verdict through
+ * the **existing** cross-check, and returns the cross-check decision
+ * **alongside** the frozen-suite result in one combined object. It owns no
+ * scoring policy of its own — the frozen suite owns the assertions and
+ * `acceptance-eval.js` owns the proceed/redraft/block decision; the adapter
+ * is pure plumbing between them.
+ *
+ * Two cross-check transports are supported, selected by the caller:
+ *
+ *   - **in-process** (default): import and call the gate's `runAcceptanceEval`
+ *     export directly. Fast, no child process, signal-emit suppressed by
+ *     default so a benchmark probe never writes to a live signals ledger.
+ *   - **CLI**: spawn `node .agents/scripts/acceptance-eval.js --verdict …`
+ *     exactly as a Story-delivery run would, parsing its JSON envelope.
+ *     Used when the cross-check must run against another checkout's gate
+ *     (e.g. the sandbox clone) rather than this process's import graph.
+ *
+ * @module bench/scenarios/acceptance-eval-adapter
+ */
+
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+// The cross-check decision lives on the gate module; `runAcceptanceEval`
+// is the programmatic (no-process) entry point the CLI also wraps.
+import { runAcceptanceEval as runGate } from '../../.agents/scripts/acceptance-eval.js';
+import { resolveConfig } from '../../.agents/scripts/lib/config-resolver.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+/** Absolute path to the in-repo acceptance-eval CLI. */
+export const ACCEPTANCE_EVAL_CLI = path.resolve(
+  __dirname,
+  '..',
+  '..',
+  '.agents',
+  'scripts',
+  'acceptance-eval.js',
+);
+
+/**
+ * Lift a frozen-suite result into an acceptance-eval verdict object that
+ * conforms to `acceptance-eval-verdict.schema.json`. A frozen criterion
+ * that the oracle marked `met` becomes verdict `met`; a failed one becomes
+ * `unmet`, with the oracle's evidence string carried through verbatim so
+ * the cross-check (and any signal it emits) can see *why*.
+ *
+ * @param {object} args
+ * @param {{ criteria: Array<{ index: number, criterion: string, met: boolean, evidence: string }> }} args.frozenResult
+ * @param {number} args.storyId
+ * @param {number | null} [args.epicId]
+ * @param {number} [args.round] — defaults to 1 (a single frozen probe).
+ * @param {string | null} [args.commitSha]
+ * @returns {object} A verdict object (schema-valid when the frozen result
+ *   carries at least one criterion).
+ */
+export function buildVerdictFromFrozenResult({
+  frozenResult,
+  storyId,
+  epicId = null,
+  round = 1,
+  commitSha = null,
+}) {
+  if (!frozenResult || !Array.isArray(frozenResult.criteria)) {
+    throw new TypeError(
+      'buildVerdictFromFrozenResult: frozenResult.criteria must be an array',
+    );
+  }
+  if (!Number.isInteger(storyId) || storyId < 1) {
+    throw new TypeError(
+      'buildVerdictFromFrozenResult: storyId must be a positive integer',
+    );
+  }
+
+  const verdict = {
+    storyId,
+    epicId: epicId ?? null,
+    schemaVersion: 1,
+    round: Number.isInteger(round) && round >= 1 ? round : 1,
+    criteria: frozenResult.criteria.map((c) => ({
+      index: c.index,
+      criterion: c.criterion,
+      verdict: c.met ? 'met' : 'unmet',
+      evidence:
+        c.evidence || (c.met ? 'frozen oracle: met' : 'frozen oracle: unmet'),
+      verifyEvidence: [
+        {
+          command: 'frozen acceptance oracle (HTTP probe of delivered app)',
+          outcome: c.met ? 'pass' : 'fail',
+          detail: c.evidence ?? null,
+        },
+      ],
+    })),
+  };
+  if (commitSha) verdict.commitSha = commitSha;
+  return verdict;
+}
+
+/**
+ * Run the acceptance-eval cross-check **in-process** against a verdict.
+ *
+ * @param {object} args
+ * @param {object} args.verdict — a schema-valid verdict object.
+ * @param {number} args.storyId
+ * @param {number | null} [args.epicId]
+ * @param {object} [args.config] — resolved `.agentrc.json`; defaults to
+ *   `resolveConfig()` (built-in defaults are fine — the gate only needs
+ *   `delivery.acceptanceEval.maxRounds`).
+ * @param {boolean} [args.emitSignal] — default `false`; a benchmark probe
+ *   must not pollute a live signals ledger.
+ * @param {number} [args.round] — explicit round override forwarded to the
+ *   gate (defaults to the verdict's `round`).
+ * @param {object} [deps]
+ * @param {typeof runGate} [deps.runGateFn] — injectable gate (tests).
+ * @returns {Promise<{ decision: string, envelope: object, exitCode: number }>}
+ */
+export async function runCrossCheckInProcess({
+  verdict,
+  storyId,
+  epicId = null,
+  config,
+  emitSignal = false,
+  round,
+  ...deps
+}) {
+  const runGateFn = deps.runGateFn ?? runGate;
+  const resolved = config ?? resolveConfig();
+  const { envelope, exitCode } = await runGateFn({
+    storyId,
+    epicId: epicId ?? null,
+    verdict,
+    config: resolved,
+    emitSignal,
+    round: round ?? verdict.round,
+  });
+  return { decision: envelope.decision, envelope, exitCode };
+}
+
+/**
+ * Run the acceptance-eval cross-check via the **CLI**, writing the verdict
+ * to a temp file and spawning `node acceptance-eval.js --verdict …`. The
+ * `--no-signal` flag is always passed so a benchmark probe is side-effect
+ * free. Parses the gate's JSON envelope from stdout.
+ *
+ * @param {object} args
+ * @param {object} args.verdict — a schema-valid verdict object.
+ * @param {number} args.storyId
+ * @param {number | null} [args.epicId]
+ * @param {string} [args.cli] — path to the acceptance-eval CLI (defaults
+ *   to the in-repo one; pass a sandbox clone's path to cross-check there).
+ * @param {object} [deps]
+ * @param {typeof spawnSync} [deps.spawnFn] — injectable spawn (tests).
+ * @returns {{ decision: string, envelope: object, exitCode: number }}
+ */
+export function runCrossCheckViaCli({
+  verdict,
+  storyId,
+  epicId = null,
+  cli = ACCEPTANCE_EVAL_CLI,
+  ...deps
+}) {
+  const spawnFn = deps.spawnFn ?? spawnSync;
+  const dir = mkdtempSync(path.join(tmpdir(), 'bench-accept-eval-'));
+  const verdictPath = path.join(dir, 'verdict.json');
+  try {
+    writeFileSync(verdictPath, JSON.stringify(verdict), 'utf8');
+    const args = [
+      cli,
+      '--story',
+      String(storyId),
+      '--verdict',
+      verdictPath,
+      '--no-signal',
+    ];
+    if (Number.isInteger(epicId) && epicId !== null) {
+      args.push('--epic', String(epicId));
+    }
+    const result = spawnFn(process.execPath, args, { encoding: 'utf8' });
+    const envelope = parseGateEnvelope(result.stdout ?? '');
+    return {
+      decision: envelope?.decision ?? null,
+      envelope,
+      exitCode: typeof result.status === 'number' ? result.status : 1,
+    };
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+/**
+ * Extract the gate's JSON envelope from a stdout blob. The CLI prints the
+ * envelope via `Logger.info(JSON.stringify(envelope, null, 2))`, possibly
+ * preceded by log lines, so scan for the last balanced JSON object.
+ *
+ * @param {string} stdout
+ * @returns {object | null}
+ */
+export function parseGateEnvelope(stdout) {
+  if (typeof stdout !== 'string' || stdout.length === 0) return null;
+  // The pretty-printed envelope is the final top-level JSON object. Find
+  // the last line that starts an object and parse from there.
+  const start = stdout.lastIndexOf('\n{');
+  const candidate = start >= 0 ? stdout.slice(start + 1) : stdout;
+  try {
+    return JSON.parse(candidate);
+  } catch {
+    // Fall back to a forgiving scan: the first `{` to the matching final
+    // `}` in the whole blob.
+    const open = stdout.indexOf('{');
+    const close = stdout.lastIndexOf('}');
+    if (open >= 0 && close > open) {
+      try {
+        return JSON.parse(stdout.slice(open, close + 1));
+      } catch {
+        return null;
+      }
+    }
+    return null;
+  }
+}
+
+/**
+ * Score a scenario's Quality: run the FROZEN acceptance oracle against the
+ * delivered app, then run the existing acceptance-eval cross-check over the
+ * verdict the oracle produced, and return both.
+ *
+ * This is the function the benchmark harness calls per `(scenario × arm ×
+ * run)` to obtain the Quality signal.
+ *
+ * @param {object} args
+ * @param {(baseUrl: string, deps?: object) => Promise<{ scenario: string, passed: boolean, criteria: Array<object> }>} args.evaluate
+ *   — the scenario's frozen oracle `evaluate` export.
+ * @param {string} args.baseUrl — base URL of the delivered app.
+ * @param {number} args.storyId
+ * @param {number | null} [args.epicId]
+ * @param {'in-process' | 'cli'} [args.transport] — cross-check transport
+ *   (default `'in-process'`).
+ * @param {string | null} [args.commitSha]
+ * @param {object} [args.config] — resolved config for the in-process path.
+ * @param {object} [args.evaluateDeps] — forwarded to the frozen oracle
+ *   (e.g. `{ fetchImpl }`).
+ * @param {object} [deps] — cross-check injection (`runGateFn`, `spawnFn`,
+ *   `cli`).
+ * @returns {Promise<{
+ *   scenario: string,
+ *   frozen: { passed: boolean, criteria: Array<object> },
+ *   crossCheck: { decision: string, envelope: object, exitCode: number },
+ *   agree: boolean,
+ * }>}
+ */
+export async function scoreScenarioQuality({
+  evaluate,
+  baseUrl,
+  storyId,
+  epicId = null,
+  transport = 'in-process',
+  commitSha = null,
+  config,
+  evaluateDeps = {},
+  ...deps
+}) {
+  if (typeof evaluate !== 'function') {
+    throw new TypeError('scoreScenarioQuality: evaluate must be a function');
+  }
+  const frozenResult = await evaluate(baseUrl, evaluateDeps);
+  const verdict = buildVerdictFromFrozenResult({
+    frozenResult,
+    storyId,
+    epicId,
+    commitSha,
+  });
+
+  const crossCheck =
+    transport === 'cli'
+      ? runCrossCheckViaCli({
+          verdict,
+          storyId,
+          epicId,
+          cli: deps.cli,
+          spawnFn: deps.spawnFn,
+        })
+      : await runCrossCheckInProcess({
+          verdict,
+          storyId,
+          epicId,
+          config,
+          runGateFn: deps.runGateFn,
+        });
+
+  // The two oracles "agree" when the frozen pass/fail and the cross-check
+  // decision point the same way: a fully-passing frozen suite should yield
+  // a `proceed` cross-check; any frozen failure should not.
+  const agree = frozenResult.passed === (crossCheck.decision === 'proceed');
+
+  return {
+    scenario: frozenResult.scenario,
+    frozen: { passed: frozenResult.passed, criteria: frozenResult.criteria },
+    crossCheck,
+    agree,
+  };
+}

--- a/bench/scenarios/crud-db/acceptance.test.js
+++ b/bench/scenarios/crud-db/acceptance.test.js
@@ -1,0 +1,326 @@
+/**
+ * FROZEN acceptance oracle — `crud-db` scenario (Story #4214).
+ *
+ * The objective Quality spine for the CRUD+DB benchmark scenario. Like the
+ * hello-world oracle it is **frozen**: it exercises only the delivered
+ * app's user-visible HTTP contract (the notes REST surface) and imports
+ * nothing from the delivered source — it has no knowledge of the app's
+ * storage engine, routing, or file layout. It drives a full create → read
+ * → update → delete round-trip over HTTP and derives one verdict per
+ * acceptance criterion, so the same oracle scores every run of every arm
+ * identically (Epic #4211).
+ *
+ * Determinism notes:
+ *   - Created notes carry a unique, run-stamped title so the GET-list
+ *     assertion never collides with notes left by a prior run against a
+ *     reused store.
+ *   - The round-trip is sequential and self-contained; no criterion
+ *     depends on wall-clock timing or external state beyond the resource
+ *     it just created.
+ *
+ * Two faces, mirroring the hello-world oracle: a pure {@link evaluate}
+ * the harness calls directly, and skip-unless-`BENCH_APP_BASE_URL`
+ * `node --test` cases for standalone runs against a live app.
+ *
+ * @module bench/scenarios/crud-db/acceptance.test
+ */
+
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+/** Stable scenario identifier this oracle scores. */
+export const SCENARIO_ID = 'crud-db';
+
+/**
+ * Frozen acceptance criteria, in scenario-seed order.
+ *
+ * @type {ReadonlyArray<string>}
+ */
+export const CRITERIA = Object.freeze([
+  'POST /notes with a valid body creates a note and returns 201 with the created note (including a server-assigned id) as JSON',
+  'GET /notes returns 200 with a JSON array containing previously created notes',
+  'GET /notes/:id returns the matching note, and 404 for an unknown id',
+  'PUT /notes/:id updates the persisted note and returns the updated representation',
+  'DELETE /notes/:id removes the note (returns 204) and a subsequent GET for that id returns 404',
+  'POST /notes with an invalid body (missing or empty title/body) returns 400',
+]);
+
+/**
+ * Join a base URL and a path without producing a double slash.
+ *
+ * @param {string} baseUrl
+ * @param {string} path
+ * @returns {string}
+ */
+function joinUrl(baseUrl, path) {
+  return `${baseUrl.replace(/\/+$/, '')}/${path.replace(/^\/+/, '')}`;
+}
+
+/**
+ * A small result accumulator that records one criterion verdict and keeps
+ * the criteria in scenario order regardless of probe ordering.
+ */
+class CriteriaLedger {
+  constructor() {
+    /** @type {Map<number, { index: number, criterion: string, met: boolean, evidence: string }>} */
+    this.byIndex = new Map();
+  }
+
+  /**
+   * @param {number} index
+   * @param {boolean} met
+   * @param {string} evidence
+   */
+  record(index, met, evidence) {
+    this.byIndex.set(index, {
+      index,
+      criterion: CRITERIA[index],
+      met: Boolean(met),
+      evidence,
+    });
+  }
+
+  /**
+   * Any criterion never explicitly recorded (e.g. a probe threw before it
+   * could run) is reported as unmet with the supplied reason, so the
+   * harness always receives a complete, ordered criteria list.
+   *
+   * @param {string} reason
+   * @returns {Array<{ index: number, criterion: string, met: boolean, evidence: string }>}
+   */
+  finalize(reason) {
+    const out = [];
+    for (let i = 0; i < CRITERIA.length; i += 1) {
+      out.push(
+        this.byIndex.get(i) ?? {
+          index: i,
+          criterion: CRITERIA[i],
+          met: false,
+          evidence: reason,
+        },
+      );
+    }
+    return out;
+  }
+}
+
+/**
+ * Best-effort JSON parse that never throws.
+ *
+ * @param {Response} res
+ * @returns {Promise<unknown>}
+ */
+async function safeJson(res) {
+  try {
+    return await res.json();
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Run the frozen CRUD+DB oracle against a running app instance.
+ *
+ * Performs a sequential create → list → read → update → delete round-trip
+ * plus an invalid-payload probe. Never throws on an assertion failure: a
+ * failed or unreachable endpoint becomes a `met: false` criterion with
+ * concrete evidence.
+ *
+ * @param {string} baseUrl — base URL of the delivered app.
+ * @param {object} [deps]
+ * @param {typeof fetch} [deps.fetchImpl] — injectable fetch (tests).
+ * @param {() => string} [deps.uniqueSuffix] — injectable unique-title
+ *   source (tests); defaults to a timestamp+random token.
+ * @returns {Promise<{
+ *   scenario: string,
+ *   passed: boolean,
+ *   criteria: Array<{ index: number, criterion: string, met: boolean, evidence: string }>,
+ * }>}
+ */
+export async function evaluate(
+  baseUrl,
+  {
+    fetchImpl = fetch,
+    uniqueSuffix = () =>
+      `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+  } = {},
+) {
+  if (typeof baseUrl !== 'string' || baseUrl.length === 0) {
+    throw new TypeError(
+      'evaluate(baseUrl): baseUrl must be a non-empty string',
+    );
+  }
+
+  const ledger = new CriteriaLedger();
+  const title = `bench-note-${uniqueSuffix()}`;
+  const notesUrl = joinUrl(baseUrl, '/notes');
+
+  const json = (body) => ({
+    method: undefined,
+    headers: { 'content-type': 'application/json', accept: 'application/json' },
+    body: JSON.stringify(body),
+  });
+
+  try {
+    // --- Criterion 0 — POST /notes (valid) → 201 + created note ---------
+    let createdId;
+    {
+      const res = await fetchImpl(notesUrl, {
+        ...json({ title, body: 'first body' }),
+        method: 'POST',
+      });
+      const payload = await safeJson(res);
+      const hasId =
+        payload != null &&
+        typeof payload === 'object' &&
+        'id' in payload &&
+        payload.id !== undefined &&
+        payload.id !== null;
+      const met = res.status === 201 && hasId;
+      if (hasId) createdId = payload.id;
+      ledger.record(
+        0,
+        met,
+        `POST /notes → HTTP ${res.status}; created note id=${
+          hasId ? JSON.stringify(payload.id) : '(missing)'
+        }`,
+      );
+    }
+
+    // --- Criterion 1 — GET /notes → 200 array containing the note -------
+    {
+      const res = await fetchImpl(notesUrl, {
+        method: 'GET',
+        headers: { accept: 'application/json' },
+      });
+      const payload = await safeJson(res);
+      const isArray = Array.isArray(payload);
+      const contains =
+        isArray &&
+        payload.some(
+          (n) => n != null && typeof n === 'object' && n.title === title,
+        );
+      ledger.record(
+        1,
+        res.status === 200 && contains,
+        `GET /notes → HTTP ${res.status}; array=${isArray}; contains created title=${contains}`,
+      );
+    }
+
+    // --- Criterion 2 — GET /notes/:id (hit) + unknown id → 404 ----------
+    {
+      let hitOk = false;
+      let hitEvidence = 'no note id was created, so the read probe was skipped';
+      if (createdId !== undefined) {
+        const res = await fetchImpl(
+          joinUrl(baseUrl, `/notes/${encodeURIComponent(String(createdId))}`),
+          { method: 'GET', headers: { accept: 'application/json' } },
+        );
+        const payload = await safeJson(res);
+        hitOk =
+          res.status === 200 &&
+          payload != null &&
+          typeof payload === 'object' &&
+          payload.title === title;
+        hitEvidence = `GET /notes/${createdId} → HTTP ${res.status}`;
+      }
+      const missRes = await fetchImpl(
+        joinUrl(baseUrl, '/notes/00000000-0000-0000-0000-000000000000'),
+        { method: 'GET', headers: { accept: 'application/json' } },
+      );
+      const missOk = missRes.status === 404;
+      ledger.record(
+        2,
+        hitOk && missOk,
+        `${hitEvidence}; GET unknown id → HTTP ${missRes.status} (expected 404)`,
+      );
+    }
+    if (createdId === undefined) {
+      ledger.record(
+        3,
+        false,
+        'no note id was created, so the update probe was skipped',
+      );
+    } else {
+      const res = await fetchImpl(
+        joinUrl(baseUrl, `/notes/${encodeURIComponent(String(createdId))}`),
+        { ...json({ title, body: 'updated body' }), method: 'PUT' },
+      );
+      const payload = await safeJson(res);
+      const updated =
+        res.status === 200 &&
+        payload != null &&
+        typeof payload === 'object' &&
+        payload.body === 'updated body';
+      ledger.record(
+        3,
+        updated,
+        `PUT /notes/${createdId} → HTTP ${res.status}; body reflected updated value=${updated}`,
+      );
+    }
+    if (createdId === undefined) {
+      ledger.record(
+        4,
+        false,
+        'no note id was created, so the delete probe was skipped',
+      );
+    } else {
+      const delRes = await fetchImpl(
+        joinUrl(baseUrl, `/notes/${encodeURIComponent(String(createdId))}`),
+        { method: 'DELETE' },
+      );
+      const afterRes = await fetchImpl(
+        joinUrl(baseUrl, `/notes/${encodeURIComponent(String(createdId))}`),
+        { method: 'GET', headers: { accept: 'application/json' } },
+      );
+      ledger.record(
+        4,
+        delRes.status === 204 && afterRes.status === 404,
+        `DELETE /notes/${createdId} → HTTP ${delRes.status} (expected 204); subsequent GET → HTTP ${afterRes.status} (expected 404)`,
+      );
+    }
+
+    // --- Criterion 5 — POST /notes (invalid) → 400 ----------------------
+    {
+      const res = await fetchImpl(notesUrl, {
+        ...json({ title: '', body: '' }),
+        method: 'POST',
+      });
+      ledger.record(
+        5,
+        res.status === 400,
+        `POST /notes with empty title/body → HTTP ${res.status} (expected 400)`,
+      );
+    }
+  } catch (err) {
+    const reason = `frozen oracle aborted: ${
+      err instanceof Error ? err.message : String(err)
+    }`;
+    const criteria = ledger.finalize(reason);
+    return { scenario: SCENARIO_ID, passed: false, criteria };
+  }
+
+  const criteria = ledger.finalize('criterion probe did not run');
+  return {
+    scenario: SCENARIO_ID,
+    passed: criteria.every((c) => c.met),
+    criteria,
+  };
+}
+
+// --- Standalone `node --test` face -------------------------------------
+
+const BASE_URL = process.env.BENCH_APP_BASE_URL;
+
+describe('crud-db frozen acceptance oracle', { skip: !BASE_URL }, () => {
+  it('every frozen criterion is met by the delivered app', async () => {
+    const result = await evaluate(/** @type {string} */ (BASE_URL));
+    const failed = result.criteria.filter((c) => !c.met);
+    assert.equal(
+      failed.length,
+      0,
+      `unmet criteria: ${failed.map((c) => `${c.criterion} — ${c.evidence}`).join('; ')}`,
+    );
+    assert.equal(result.passed, true);
+  });
+});

--- a/bench/scenarios/crud-db/scenario.json
+++ b/bench/scenarios/crud-db/scenario.json
@@ -1,0 +1,26 @@
+{
+  "id": "crud-db",
+  "title": "CRUD + DB notes API",
+  "difficulty": 2,
+  "rung": "depth",
+  "description": "The depth scenario. A persisted CRUD resource exercises decomposition, multi-wave delivery, planning fidelity, and autonomy at depth — enough surface to need a real plan, not just a single file.",
+  "seed": {
+    "title": "Notes CRUD API with persistent storage",
+    "prompt": "Build a JSON REST API in Node.js (ESM) for a \"notes\" resource backed by a persistent store (an embedded SQLite database file, or an equivalent on-disk store — not in-memory). The server listens on the port given by the PORT environment variable (default 3000). It must expose: POST /notes (accepts a JSON body {\"title\": string, \"body\": string}, validates that both fields are non-empty strings, persists the note with a server-assigned id and createdAt timestamp, and returns 201 with the created note as JSON); GET /notes (returns 200 with a JSON array of all notes); GET /notes/:id (returns 200 with the note JSON, or 404 if no such note exists); PUT /notes/:id (accepts a JSON body with title and/or body, updates the persisted note, returns 200 with the updated note, or 404 if absent); DELETE /notes/:id (deletes the persisted note, returns 204, or 404 if absent). Invalid create/update payloads must return 400. Persisted notes must survive a server restart. Add an npm \"start\" script.",
+    "acceptance": [
+      "POST /notes with a valid body creates a note and returns 201 with the created note (including a server-assigned id) as JSON",
+      "GET /notes returns 200 with a JSON array containing previously created notes",
+      "GET /notes/:id returns the matching note, and 404 for an unknown id",
+      "PUT /notes/:id updates the persisted note and returns the updated representation",
+      "DELETE /notes/:id removes the note (returns 204) and a subsequent GET for that id returns 404",
+      "POST /notes with an invalid body (missing or empty title/body) returns 400"
+    ]
+  },
+  "app": {
+    "startCommand": "npm start",
+    "readinessPath": "/notes",
+    "defaultPort": 3000,
+    "portEnvVar": "PORT"
+  },
+  "acceptanceSuite": "./acceptance.test.js"
+}

--- a/bench/scenarios/hello-world/acceptance.test.js
+++ b/bench/scenarios/hello-world/acceptance.test.js
@@ -1,0 +1,179 @@
+/**
+ * FROZEN acceptance oracle — `hello-world` scenario (Story #4214).
+ *
+ * This suite is the objective Quality spine for the hello-world benchmark
+ * scenario. It is **frozen**: it asserts only the delivered app's
+ * user-visible HTTP behavior and depends on **nothing** from the app's
+ * internals — no imports of the delivered source, no knowledge of its file
+ * layout, framework, or storage. It probes a running instance over HTTP
+ * exactly the way a user (or the harness) would. Because the contract is
+ * fixed, the same oracle scores every run of every arm identically, which
+ * is what makes the Mandrel-vs-control delta meaningful (Epic #4211).
+ *
+ * The suite has two faces:
+ *
+ *   1. {@link evaluate} — a pure async function the benchmark harness calls
+ *      directly. Given the delivered app's base URL it runs every frozen
+ *      assertion and returns a structured, deterministic result (one
+ *      entry per acceptance criterion, in scenario-body order). The
+ *      adapter (`bench/scenarios/acceptance-eval-adapter.js`) turns this
+ *      into an acceptance-eval verdict and reports it alongside the
+ *      cross-check.
+ *   2. `node --test` `describe`/`it` cases — so the oracle can be run
+ *      standalone against a live app (`BENCH_APP_BASE_URL=… node --test
+ *      bench/scenarios/hello-world/acceptance.test.js`). When the base URL
+ *      is not set the cases skip rather than fail, because there is no app
+ *      to probe outside a benchmark run.
+ *
+ * @module bench/scenarios/hello-world/acceptance.test
+ */
+
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+/** Stable scenario identifier this oracle scores. */
+export const SCENARIO_ID = 'hello-world';
+
+/**
+ * The frozen acceptance criteria, in the exact order they appear on the
+ * scenario seed's `acceptance[]`. The text is kept in lock-step with
+ * `scenario.json` so the verdict the adapter builds lines up criterion for
+ * criterion.
+ *
+ * @type {ReadonlyArray<string>}
+ */
+export const CRITERIA = Object.freeze([
+  'GET / returns HTTP 200',
+  'The response Content-Type is text/html',
+  'The response body contains the text "Hello, World!"',
+]);
+
+/**
+ * The exact user-visible text the delivered page must contain. Frozen.
+ *
+ * @type {string}
+ */
+export const EXPECTED_BODY_TEXT = 'Hello, World!';
+
+/**
+ * Join a base URL and a path without producing a double slash.
+ *
+ * @param {string} baseUrl
+ * @param {string} path
+ * @returns {string}
+ */
+function joinUrl(baseUrl, path) {
+  return `${baseUrl.replace(/\/+$/, '')}/${path.replace(/^\/+/, '')}`;
+}
+
+/**
+ * Run the frozen hello-world oracle against a running app instance.
+ *
+ * Pure with respect to the app: it performs exactly one HTTP GET to `/`
+ * and derives every criterion verdict from the user-visible response. It
+ * never throws on an assertion failure — a failed probe becomes a
+ * `met: false` criterion with concrete evidence, so the harness gets a
+ * structured result for every run (including runs where the app never came
+ * up).
+ *
+ * @param {string} baseUrl — base URL of the delivered app (e.g.
+ *   `http://127.0.0.1:3000`).
+ * @param {object} [deps]
+ * @param {typeof fetch} [deps.fetchImpl] — injectable fetch (tests).
+ * @returns {Promise<{
+ *   scenario: string,
+ *   passed: boolean,
+ *   criteria: Array<{ index: number, criterion: string, met: boolean, evidence: string }>,
+ * }>}
+ */
+export async function evaluate(baseUrl, { fetchImpl = fetch } = {}) {
+  if (typeof baseUrl !== 'string' || baseUrl.length === 0) {
+    throw new TypeError(
+      'evaluate(baseUrl): baseUrl must be a non-empty string',
+    );
+  }
+
+  const criteria = [];
+  let status = null;
+  let contentType = null;
+  let bodyText = null;
+  let transportError = null;
+
+  try {
+    const res = await fetchImpl(joinUrl(baseUrl, '/'), {
+      method: 'GET',
+      headers: { accept: 'text/html' },
+    });
+    status = res.status;
+    contentType = res.headers.get('content-type');
+    bodyText = await res.text();
+  } catch (err) {
+    transportError = err instanceof Error ? err.message : String(err);
+  }
+
+  // Criterion 0 — HTTP 200.
+  criteria.push({
+    index: 0,
+    criterion: CRITERIA[0],
+    met: status === 200,
+    evidence: transportError
+      ? `GET / failed at the transport layer: ${transportError}`
+      : `GET / responded with HTTP ${status}`,
+  });
+
+  // Criterion 1 — Content-Type is text/html.
+  const isHtml =
+    typeof contentType === 'string' &&
+    contentType.toLowerCase().includes('text/html');
+  criteria.push({
+    index: 1,
+    criterion: CRITERIA[1],
+    met: isHtml,
+    evidence: transportError
+      ? `no response received: ${transportError}`
+      : `Content-Type header was ${JSON.stringify(contentType)}`,
+  });
+
+  // Criterion 2 — body contains the expected text.
+  const containsText =
+    typeof bodyText === 'string' && bodyText.includes(EXPECTED_BODY_TEXT);
+  criteria.push({
+    index: 2,
+    criterion: CRITERIA[2],
+    met: containsText,
+    evidence: transportError
+      ? `no body received: ${transportError}`
+      : containsText
+        ? `response body contained ${JSON.stringify(EXPECTED_BODY_TEXT)}`
+        : `response body did not contain ${JSON.stringify(
+            EXPECTED_BODY_TEXT,
+          )} (received ${JSON.stringify((bodyText ?? '').slice(0, 120))})`,
+  });
+
+  return {
+    scenario: SCENARIO_ID,
+    passed: criteria.every((c) => c.met),
+    criteria,
+  };
+}
+
+// --- Standalone `node --test` face -------------------------------------
+//
+// Only runs against a live app the harness (or an operator) has already
+// started and pointed at via BENCH_APP_BASE_URL. Outside a benchmark run
+// there is no app to probe, so the cases skip rather than fail.
+
+const BASE_URL = process.env.BENCH_APP_BASE_URL;
+
+describe('hello-world frozen acceptance oracle', { skip: !BASE_URL }, () => {
+  it('every frozen criterion is met by the delivered app', async () => {
+    const result = await evaluate(/** @type {string} */ (BASE_URL));
+    const failed = result.criteria.filter((c) => !c.met);
+    assert.equal(
+      failed.length,
+      0,
+      `unmet criteria: ${failed.map((c) => `${c.criterion} — ${c.evidence}`).join('; ')}`,
+    );
+    assert.equal(result.passed, true);
+  });
+});

--- a/bench/scenarios/hello-world/scenario.json
+++ b/bench/scenarios/hello-world/scenario.json
@@ -1,0 +1,23 @@
+{
+  "id": "hello-world",
+  "title": "Hello-world HTTP server",
+  "difficulty": 1,
+  "rung": "floor",
+  "description": "The overhead floor and end-to-end smoke scenario. A single tiny capability with no decomposition surface — its only job is to expose Mandrel's fixed ceremony tax on near-zero work versus the bare-model control.",
+  "seed": {
+    "title": "Hello-world HTTP server",
+    "prompt": "Build a minimal HTTP server in Node.js (ESM, no external web framework) that listens on the port given by the PORT environment variable (default 3000). A GET request to the path \"/\" must return HTTP 200 with a Content-Type of text/html and a response body containing the exact text \"Hello, World!\". Add an npm \"start\" script that launches the server. Keep the implementation to a single source file plus package.json.",
+    "acceptance": [
+      "GET / returns HTTP 200",
+      "The response Content-Type is text/html",
+      "The response body contains the text \"Hello, World!\""
+    ]
+  },
+  "app": {
+    "startCommand": "npm start",
+    "readinessPath": "/",
+    "defaultPort": 3000,
+    "portEnvVar": "PORT"
+  },
+  "acceptanceSuite": "./acceptance.test.js"
+}

--- a/bench/schemas/scorecard.schema.json
+++ b/bench/schemas/scorecard.schema.json
@@ -1,0 +1,311 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "mandrel-bench-scorecard",
+  "title": "Mandrel Self-Benchmark Scorecard",
+  "description": "One persisted, schema-validated scorecard for a single (scenario × arm × run) of the Mandrel Self-Benchmark Harness (Epic #4211). Each scorecard captures the five measured dimensions for one headless `claude -p` session, stamped with the pinned model id, the framework version under test, and the execution environment so that cross-version / cross-model comparisons only ever compare like to like. Internal tooling only — never shipped in the distributed `.agents/` bundle. Per-run scorecards aggregate into distributions across N≈8–10 runs (see bench/metrics/variance.js for the noise-band method). Authored by Story #4215; consumed by the scoring, report, and persistence slices.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schemaVersion",
+    "runId",
+    "timestamp",
+    "model",
+    "frameworkVersion",
+    "env",
+    "scenario",
+    "arm",
+    "dimensions"
+  ],
+  "properties": {
+    "schemaVersion": {
+      "type": "integer",
+      "const": 1,
+      "description": "Scorecard-record schema version. Bumped on any breaking change to this record shape (hard cutover — see .agents/rules/git-conventions.md § Contract Cutovers)."
+    },
+    "runId": {
+      "type": "string",
+      "minLength": 1,
+      "pattern": "^[A-Za-z0-9._-]+$",
+      "description": "Unique identifier for this single (scenario × arm × run). Stable across re-reads of the same persisted scorecard."
+    },
+    "timestamp": {
+      "type": "string",
+      "format": "date-time",
+      "description": "RFC 3339 / ISO 8601 timestamp at which the run completed and the scorecard was emitted."
+    },
+    "model": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id"],
+      "description": "The pinned model under measurement. The harness measures the framework's value-add at a fixed model — the exact id is recorded so a cross-version comparison only compares like model to like.",
+      "properties": {
+        "id": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Exact model id as reported by the `claude -p` envelope (e.g. 'claude-opus-4-8[1m]')."
+        },
+        "displayName": {
+          "type": "string",
+          "description": "Human-readable model name, when available."
+        }
+      }
+    },
+    "frameworkVersion": {
+      "type": "string",
+      "minLength": 1,
+      "description": "The Mandrel framework version under test (the `version` field of the repo's root package.json) for the Mandrel arm. For the control arm this records the framework version the comparison is anchored to, even though the control clone carries no .agents/ scaffolding."
+    },
+    "env": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": ["node", "os"],
+      "description": "Execution environment stamp. Comparisons across environments are advisory only; a band is computed per (model, frameworkVersion, env) cohort.",
+      "properties": {
+        "node": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Node.js version the harness ran under (e.g. 'v24.16.0')."
+        },
+        "os": {
+          "type": "string",
+          "minLength": 1,
+          "description": "OS platform identifier (e.g. 'darwin', 'linux')."
+        },
+        "host": {
+          "type": "string",
+          "description": "Optional host/runner identifier."
+        }
+      }
+    },
+    "scenario": {
+      "type": "string",
+      "enum": ["hello-world", "crud-db"],
+      "description": "Scenario this run exercised. v1 ships two rungs: 'hello-world' (the overhead floor + end-to-end smoke) and 'crud-db' (decomposition, multi-wave delivery, planning fidelity, autonomy at depth)."
+    },
+    "arm": {
+      "type": "string",
+      "enum": ["mandrel", "control"],
+      "description": "Which arm produced this run. 'mandrel' clones carry .agents/ and run the /plan→/deliver pipeline; 'control' clones have no scaffolding and receive the bare task prompt. Both arms are costed by the same `claude -p` envelope (apples-to-apples by construction)."
+    },
+    "dimensions": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "quality",
+        "planningFidelity",
+        "autonomy",
+        "efficiency",
+        "overheadRatio"
+      ],
+      "description": "The five measured dimensions for this run. Value side: quality, planningFidelity, autonomy. Cost side: efficiency, overheadRatio. Each is a single per-run value; the distribution/noise-band is computed across N runs by the scoring slice, never stored here. Formulas are defined in bench/metrics/README.md.",
+      "properties": {
+        "quality": {
+          "$ref": "#/$defs/qualityDimension"
+        },
+        "planningFidelity": {
+          "$ref": "#/$defs/planningFidelityDimension"
+        },
+        "autonomy": {
+          "$ref": "#/$defs/autonomyDimension"
+        },
+        "efficiency": {
+          "$ref": "#/$defs/efficiencyDimension"
+        },
+        "overheadRatio": {
+          "$ref": "#/$defs/overheadRatioDimension"
+        }
+      }
+    },
+    "rawRefs": {
+      "type": "object",
+      "additionalProperties": true,
+      "description": "Pointers to the on-disk raw artifacts this scorecard was derived from, for traceability and re-scoring. Paths are workspace-relative; the underlying ephemeral workspace is torn down after the run, so these are provenance breadcrumbs, not live handles.",
+      "properties": {
+        "lifecycleNdjson": {
+          "type": "string",
+          "description": "Path to the run's temp/epic-<id>/lifecycle.ndjson (timings/autonomy source)."
+        },
+        "signalsNdjson": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Paths to per-Story signals.ndjson files."
+        },
+        "costEnvelope": {
+          "type": "string",
+          "description": "Path to the captured `claude -p --output-format json` usage/cost envelope."
+        },
+        "acceptanceEvalVerdict": {
+          "type": "string",
+          "description": "Path to the acceptance-eval LLM-judge verdict JSON, validated against .agents/schemas/acceptance-eval-verdict.schema.json."
+        }
+      }
+    }
+  },
+  "$defs": {
+    "qualityDimension": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["score", "frozenSuitePassRate"],
+      "description": "Quality — is the output correct & on-intent? Spine: the scenario's frozen acceptance suite pass rate; cross-checked by the acceptance-eval LLM judge.",
+      "properties": {
+        "score": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 1,
+          "description": "Composite quality in [0,1]. Formula in README; the frozen-suite pass rate is the objective spine."
+        },
+        "frozenSuitePassRate": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 1,
+          "description": "Fraction of the scenario's frozen acceptance-suite assertions that passed against the delivered app."
+        },
+        "frozenSuitePassed": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Count of passing frozen-suite assertions."
+        },
+        "frozenSuiteTotal": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Total frozen-suite assertions."
+        },
+        "acceptanceEvalScore": {
+          "type": ["number", "null"],
+          "minimum": 0,
+          "maximum": 1,
+          "description": "LLM-judge cross-check score in [0,1], or null when the judge did not run (e.g. control arm with no acceptance criteria)."
+        }
+      }
+    },
+    "planningFidelityDimension": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["score"],
+      "description": "Planning fidelity — did the plan match reality? Decomposition accuracy, re-plan count, plan-vs-actual drift. For the control arm (no plan authored) this is null.",
+      "properties": {
+        "score": {
+          "type": ["number", "null"],
+          "minimum": 0,
+          "maximum": 1,
+          "description": "Planning fidelity in [0,1], or null when no plan was authored (control arm)."
+        },
+        "rePlanCount": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Number of re-plan / decomposition-revision events observed."
+        },
+        "plannedStoryCount": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Number of Stories the decomposer emitted."
+        },
+        "deliveredStoryCount": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Number of Stories actually delivered (closed)."
+        },
+        "fileFootprintDrift": {
+          "type": "number",
+          "minimum": 0,
+          "description": "Symmetric drift between the planned changes[] footprint and the files actually touched (Jaccard distance in [0,1])."
+        }
+      }
+    },
+    "autonomyDimension": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["score", "hitlStops", "blockedEvents", "manualRescues"],
+      "description": "Autonomy — how little human intervention? Counts of HITL stops, agent::blocked transitions, and manual rescues, collapsed to a [0,1] score where 1 = fully unattended.",
+      "properties": {
+        "score": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 1,
+          "description": "Autonomy in [0,1]; 1 means the run completed with zero human intervention."
+        },
+        "hitlStops": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Count of human-in-the-loop STOP gates the run halted at."
+        },
+        "blockedEvents": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Count of agent::blocked transitions observed in lifecycle.ndjson."
+        },
+        "manualRescues": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Count of operator interventions that unblocked or restarted the run."
+        }
+      }
+    },
+    "efficiencyDimension": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["wallClockMs", "totalTokens", "dispatches"],
+      "description": "Efficiency — what did it cost absolutely? Wall-clock, tokens, and dispatch count. Cost (tokens) comes from the `claude -p` envelope; timings/dispatches from lifecycle.ndjson. No composite is required — the three are reported as a vector; an optional `costUsd` is included when the envelope reports it.",
+      "properties": {
+        "wallClockMs": {
+          "type": "number",
+          "minimum": 0,
+          "description": "End-to-end wall-clock duration of the run in milliseconds."
+        },
+        "totalTokens": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Total tokens (input + output) from the `claude -p` usage envelope, summed across the session."
+        },
+        "inputTokens": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Input tokens from the usage envelope."
+        },
+        "outputTokens": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Output tokens from the usage envelope."
+        },
+        "dispatches": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Number of agent dispatches (Story sub-agent launches) recorded in lifecycle.ndjson."
+        },
+        "costUsd": {
+          "type": ["number", "null"],
+          "minimum": 0,
+          "description": "Total USD cost from the `claude -p` envelope when reported, else null."
+        }
+      }
+    },
+    "overheadRatioDimension": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["tokenRatio"],
+      "description": "Overhead ratio — ceremony tax vs. shippable output. Ceremony cost (planning, decomposition, orchestration, gate ceremony) divided by codegen cost (tokens/time spent producing shippable artifacts). For the control arm there is effectively no ceremony, so tokenRatio approaches its floor.",
+      "properties": {
+        "tokenRatio": {
+          "type": "number",
+          "minimum": 0,
+          "description": "ceremonyTokens ÷ codegenTokens. A ratio of 4.0 means 4 tokens of ceremony per token of shippable codegen."
+        },
+        "timeRatio": {
+          "type": ["number", "null"],
+          "minimum": 0,
+          "description": "ceremonyMs ÷ codegenMs, or null when the time split is not available."
+        },
+        "ceremonyTokens": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Tokens attributed to ceremony (planning + orchestration + gates)."
+        },
+        "codegenTokens": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Tokens attributed to producing shippable code/artifacts."
+        }
+      }
+    }
+  }
+}

--- a/bench/score/differential.js
+++ b/bench/score/differential.js
@@ -1,0 +1,509 @@
+// bench/score/differential.js
+//
+// The Mandrel-vs-control differential + cross-scenario calibration metrics for
+// the Mandrel self-benchmark harness (Epic #4211, Story #4217). Internal
+// tooling only — never shipped in the distributed `.agents/` bundle.
+//
+// This module sits on top of the per-run scorecards (bench/collect/normalize.js)
+// and the noise-band primitive (bench/metrics/variance.js). It computes:
+//
+//   1. The per-dimension Mandrel-vs-control delta across the N runs of one
+//      (scenario) cell, with the binding "real-delta" rule from
+//      bench/metrics/README.md § "Real-delta rule":
+//
+//        deltaIsReal = |centerMandrel − centerControl|
+//                        > max(spreadMandrel, spreadControl)
+//
+//      A delta that does not clear the larger of the two arms' noise-band
+//      spreads is reported as "within noise" (no significant difference).
+//
+//   2. The two cross-scenario derived metrics (README § "Cross-scenario
+//      derived metrics") — computed by comparing scenarios, never scored
+//      per-run:
+//        A. Difficulty monotonicity — Efficiency must RISE and Overhead ratio
+//           must FALL as difficulty increases; a violation is a calibration
+//           warning, surfaced explicitly.
+//        B. Overhead floor — the fixed ceremony tax Mandrel pays above control
+//           on the near-zero `hello-world` rung, with its own band over the
+//           per-run differences.
+//
+// Determinism: pure functions, no I/O, no clock, no randomness.
+
+import { noiseBand } from '../metrics/variance.js';
+
+/**
+ * The five scorecard dimensions, in canonical order, each tagged with the
+ * single per-run scalar that represents it for differential purposes.
+ * `quality`, `planningFidelity`, `autonomy` and `overheadRatio` each have a
+ * natural headline scalar. `efficiency` is a vector (README § 4 — "never
+ * collapsed to one number"), so it is differenced per-component rather than as
+ * a single dimension; see `EFFICIENCY_COMPONENTS`.
+ *
+ * The accessor pulls the scalar out of a scorecard's `dimensions.<name>`
+ * sub-object, returning `null` when the value is null (e.g. planningFidelity on
+ * the control arm) so it is filtered out of the band by `noiseBand`.
+ */
+export const SCALAR_DIMENSIONS = Object.freeze([
+  { name: 'quality', accessor: (d) => d?.quality?.score ?? null },
+  {
+    name: 'planningFidelity',
+    accessor: (d) => d?.planningFidelity?.score ?? null,
+  },
+  { name: 'autonomy', accessor: (d) => d?.autonomy?.score ?? null },
+  {
+    name: 'overheadRatio',
+    accessor: (d) => d?.overheadRatio?.tokenRatio ?? null,
+  },
+]);
+
+/**
+ * The Efficiency vector components, each differenced independently (each gets
+ * its own distribution + band, per README § 4).
+ */
+export const EFFICIENCY_COMPONENTS = Object.freeze([
+  { name: 'wallClockMs', accessor: (d) => d?.efficiency?.wallClockMs ?? null },
+  { name: 'totalTokens', accessor: (d) => d?.efficiency?.totalTokens ?? null },
+  { name: 'dispatches', accessor: (d) => d?.efficiency?.dispatches ?? null },
+  { name: 'costUsd', accessor: (d) => d?.efficiency?.costUsd ?? null },
+]);
+
+/**
+ * Pull the per-run scalar values for one (dimension accessor) across a set of
+ * scorecards. Non-finite / null entries are left in place; `noiseBand` filters
+ * them, so a metric that is null for one arm (planningFidelity on control)
+ * simply yields an empty band.
+ *
+ * @param {Array<object>} scorecards
+ * @param {(dimensions: object) => number|null} accessor
+ * @returns {Array<number|null>}
+ */
+function valuesFor(scorecards, accessor) {
+  return scorecards.map((sc) => accessor(sc?.dimensions));
+}
+
+/**
+ * Compute a noise-band, or `null` when no finite values are present (so a
+ * dimension that is null for an arm — planningFidelity on control — does not
+ * throw, it simply has no band).
+ *
+ * @param {Array<number|null>} values
+ * @param {'iqr'|'ci'} method
+ * @returns {import('../metrics/variance.js').NoiseBand|null}
+ */
+function bandOrNull(values, method) {
+  try {
+    return noiseBand(values, { method });
+  } catch {
+    // RangeError: no finite values to summarize.
+    return null;
+  }
+}
+
+/**
+ * Apply the binding real-delta rule to two arms' bands for one metric.
+ *
+ *   deltaIsReal = |centerMandrel − centerControl| > max(spreadMandrel, spreadControl)
+ *
+ * When either band is null (the metric was null for that arm across all its
+ * runs — e.g. planningFidelity on control), the delta cannot be computed and
+ * is reported with `deltaIsReal: false` and `comparable: false`.
+ *
+ * @param {object} args
+ * @param {string} args.name
+ * @param {import('../metrics/variance.js').NoiseBand|null} args.mandrelBand
+ * @param {import('../metrics/variance.js').NoiseBand|null} args.controlBand
+ * @returns {{
+ *   metric: string,
+ *   comparable: boolean,
+ *   mandrelCenter: number|null,
+ *   controlCenter: number|null,
+ *   delta: number|null,
+ *   noiseFloor: number|null,
+ *   deltaIsReal: boolean,
+ *   verdict: 'real'|'within-noise'|'incomparable',
+ *   mandrelBand: object|null,
+ *   controlBand: object|null
+ * }}
+ */
+function compareBands({ name, mandrelBand, controlBand }) {
+  if (mandrelBand === null || controlBand === null) {
+    return {
+      metric: name,
+      comparable: false,
+      mandrelCenter: mandrelBand ? mandrelBand.center : null,
+      controlCenter: controlBand ? controlBand.center : null,
+      delta: null,
+      noiseFloor: null,
+      deltaIsReal: false,
+      verdict: 'incomparable',
+      mandrelBand,
+      controlBand,
+    };
+  }
+  const delta = mandrelBand.center - controlBand.center;
+  const noiseFloor = Math.max(mandrelBand.spread, controlBand.spread);
+  const deltaIsReal = Math.abs(delta) > noiseFloor;
+  return {
+    metric: name,
+    comparable: true,
+    mandrelCenter: mandrelBand.center,
+    controlCenter: controlBand.center,
+    delta,
+    noiseFloor,
+    deltaIsReal,
+    verdict: deltaIsReal ? 'real' : 'within-noise',
+    mandrelBand,
+    controlBand,
+  };
+}
+
+/**
+ * Compute the full Mandrel-vs-control differential for ONE scenario cell.
+ *
+ * @param {object} args
+ * @param {Array<object>} args.mandrelRuns  Scorecards for the Mandrel arm.
+ * @param {Array<object>} args.controlRuns  Scorecards for the control arm.
+ * @param {'iqr'|'ci'} [args.method='iqr']  Band method passed to noiseBand.
+ * @param {string} [args.scenario]          Optional scenario id for labelling.
+ * @returns {{
+ *   scenario: string|undefined,
+ *   method: 'iqr'|'ci',
+ *   n: { mandrel: number, control: number },
+ *   dimensions: Record<string, object>,
+ *   efficiency: Record<string, object>
+ * }}
+ */
+export function computeDifferential({
+  mandrelRuns,
+  controlRuns,
+  method = 'iqr',
+  scenario,
+}) {
+  if (!Array.isArray(mandrelRuns) || !Array.isArray(controlRuns)) {
+    throw new TypeError(
+      'computeDifferential: mandrelRuns and controlRuns must be arrays',
+    );
+  }
+
+  const dimensions = {};
+  for (const { name, accessor } of SCALAR_DIMENSIONS) {
+    const mandrelBand = bandOrNull(valuesFor(mandrelRuns, accessor), method);
+    const controlBand = bandOrNull(valuesFor(controlRuns, accessor), method);
+    dimensions[name] = compareBands({ name, mandrelBand, controlBand });
+  }
+
+  const efficiency = {};
+  for (const { name, accessor } of EFFICIENCY_COMPONENTS) {
+    const mandrelBand = bandOrNull(valuesFor(mandrelRuns, accessor), method);
+    const controlBand = bandOrNull(valuesFor(controlRuns, accessor), method);
+    efficiency[name] = compareBands({
+      name: `efficiency.${name}`,
+      mandrelBand,
+      controlBand,
+    });
+  }
+
+  return {
+    scenario,
+    method,
+    n: { mandrel: mandrelRuns.length, control: controlRuns.length },
+    dimensions,
+    efficiency,
+  };
+}
+
+/**
+ * Center of a band over the Mandrel arm's per-run values for one metric in one
+ * scenario cell — the building block of the cross-scenario metrics. Returns
+ * `null` when the cell has no finite values.
+ *
+ * @param {Array<object>} scorecards
+ * @param {(d: object) => number|null} accessor
+ * @param {'iqr'|'ci'} method
+ * @returns {number|null}
+ */
+function centerOf(scorecards, accessor, method) {
+  const band = bandOrNull(valuesFor(scorecards, accessor), method);
+  return band ? band.center : null;
+}
+
+/**
+ * Cross-scenario metric A — **difficulty monotonicity** (calibration guardrail).
+ *
+ * Over the difficulty-ordered scenario list (easy → hard), comparing the
+ * Mandrel arm's band centers, two things MUST hold for every adjacent pair:
+ *
+ *   - Efficiency (totalTokens) RISES:   center(tokens, sᵢ) < center(tokens, sᵢ₊₁)
+ *   - Overhead ratio FALLS:             center(ratio,  sᵢ) > center(ratio,  sᵢ₊₁)
+ *
+ * A violation is a **calibration warning**, surfaced explicitly (never a silent
+ * pass): it means the instrument is insensitive or a scenario is mis-graded.
+ *
+ * @param {object} args
+ * @param {Array<{ scenario: string, difficulty: number, mandrelRuns: Array<object> }>} args.cells
+ *   One entry per scenario, each carrying the scenario id, its numeric
+ *   difficulty (from scenario.json), and the Mandrel arm's scorecards.
+ * @param {'iqr'|'ci'} [args.method='iqr']
+ * @returns {{
+ *   ordered: Array<{ scenario: string, difficulty: number, totalTokens: number|null, tokenRatio: number|null }>,
+ *   pairs: Array<{
+ *     from: string, to: string,
+ *     efficiencyRises: boolean, overheadFalls: boolean,
+ *     holds: boolean,
+ *     violations: string[]
+ *   }>,
+ *   monotonicityHolds: boolean,
+ *   warnings: string[]
+ * }}
+ */
+export function difficultyMonotonicity({ cells, method = 'iqr' }) {
+  if (!Array.isArray(cells)) {
+    throw new TypeError('difficultyMonotonicity: cells must be an array');
+  }
+
+  const ordered = cells
+    .map((c) => ({
+      scenario: c.scenario,
+      difficulty: c.difficulty,
+      totalTokens: centerOf(
+        c.mandrelRuns ?? [],
+        (d) => d?.efficiency?.totalTokens ?? null,
+        method,
+      ),
+      tokenRatio: centerOf(
+        c.mandrelRuns ?? [],
+        (d) => d?.overheadRatio?.tokenRatio ?? null,
+        method,
+      ),
+    }))
+    .sort((a, b) => a.difficulty - b.difficulty);
+
+  const pairs = [];
+  const warnings = [];
+  let monotonicityHolds = true;
+
+  for (let i = 0; i < ordered.length - 1; i += 1) {
+    const lo = ordered[i];
+    const hi = ordered[i + 1];
+    const violations = [];
+
+    // Efficiency must rise (harder work costs more in absolute terms).
+    const efficiencyRises =
+      lo.totalTokens !== null &&
+      hi.totalTokens !== null &&
+      hi.totalTokens > lo.totalTokens;
+    if (lo.totalTokens === null || hi.totalTokens === null) {
+      violations.push(
+        `efficiency.totalTokens not comparable between ${lo.scenario} and ${hi.scenario} (missing band center)`,
+      );
+    } else if (!efficiencyRises) {
+      violations.push(
+        `efficiency.totalTokens did not rise: ${lo.scenario}=${lo.totalTokens} ≥ ${hi.scenario}=${hi.totalTokens}`,
+      );
+    }
+
+    // Overhead ratio must fall (ceremony amortizes over more output).
+    const overheadFalls =
+      lo.tokenRatio !== null &&
+      hi.tokenRatio !== null &&
+      hi.tokenRatio < lo.tokenRatio;
+    if (lo.tokenRatio === null || hi.tokenRatio === null) {
+      violations.push(
+        `overheadRatio.tokenRatio not comparable between ${lo.scenario} and ${hi.scenario} (missing band center)`,
+      );
+    } else if (!overheadFalls) {
+      violations.push(
+        `overheadRatio.tokenRatio did not fall: ${lo.scenario}=${lo.tokenRatio} ≤ ${hi.scenario}=${hi.tokenRatio}`,
+      );
+    }
+
+    const holds = violations.length === 0;
+    if (!holds) {
+      monotonicityHolds = false;
+      for (const v of violations) {
+        warnings.push(`[calibration] ${v}`);
+      }
+    }
+    pairs.push({
+      from: lo.scenario,
+      to: hi.scenario,
+      efficiencyRises,
+      overheadFalls,
+      holds,
+      violations,
+    });
+  }
+
+  return { ordered, pairs, monotonicityHolds, warnings };
+}
+
+/**
+ * Cross-scenario metric B — **overhead floor** (framework finding).
+ *
+ * The fixed ceremony tax Mandrel pays on near-zero work, estimated from the
+ * `hello-world` rung as the cost the Mandrel arm pays ABOVE the control arm:
+ *
+ *   overheadFloorTokens = center(totalTokens, hello-world, mandrel)
+ *                        − center(totalTokens, hello-world, control)
+ *   overheadFloorUsd    = center(costUsd,     hello-world, mandrel)
+ *                        − center(costUsd,     hello-world, control)
+ *
+ * Computed on the band centers (so it inherits the distribution method) AND
+ * reported with its own band derived from the per-run differences (paired
+ * across the run index, which is what the README's "reported with its own band
+ * derived from the per-run differences" calls for).
+ *
+ * A large floor with NO corresponding `quality.score` gain on `hello-world` is
+ * the canonical evidence for the report's "ceremony-lite path for trivial
+ * scopes" recommendation; this function surfaces that condition as a flag.
+ *
+ * @param {object} args
+ * @param {Array<object>} args.mandrelRuns  hello-world Mandrel scorecards.
+ * @param {Array<object>} args.controlRuns  hello-world control scorecards.
+ * @param {'iqr'|'ci'} [args.method='iqr']
+ * @param {number} [args.qualityGainEpsilon=0.05]  A Mandrel quality center
+ *   that exceeds control by less than this is treated as "no quality gain".
+ * @returns {{
+ *   scenario: 'hello-world',
+ *   overheadFloorTokens: number|null,
+ *   overheadFloorUsd: number|null,
+ *   tokenDiffBand: object|null,
+ *   usdDiffBand: object|null,
+ *   qualityGain: number|null,
+ *   noQualityGain: boolean,
+ *   recommendCeremonyLite: boolean
+ * }}
+ */
+export function overheadFloor({
+  mandrelRuns,
+  controlRuns,
+  method = 'iqr',
+  qualityGainEpsilon = 0.05,
+}) {
+  if (!Array.isArray(mandrelRuns) || !Array.isArray(controlRuns)) {
+    throw new TypeError(
+      'overheadFloor: mandrelRuns and controlRuns must be arrays',
+    );
+  }
+
+  const tokenAccessor = (d) => d?.efficiency?.totalTokens ?? null;
+  const usdAccessor = (d) => d?.efficiency?.costUsd ?? null;
+  const qualityAccessor = (d) => d?.quality?.score ?? null;
+
+  const mandrelTokens = centerOf(mandrelRuns, tokenAccessor, method);
+  const controlTokens = centerOf(controlRuns, tokenAccessor, method);
+  const overheadFloorTokens =
+    mandrelTokens !== null && controlTokens !== null
+      ? mandrelTokens - controlTokens
+      : null;
+
+  const mandrelUsd = centerOf(mandrelRuns, usdAccessor, method);
+  const controlUsd = centerOf(controlRuns, usdAccessor, method);
+  const overheadFloorUsd =
+    mandrelUsd !== null && controlUsd !== null ? mandrelUsd - controlUsd : null;
+
+  // Per-run paired differences (index-aligned over the shorter arm) give the
+  // floor its own band.
+  const pairCount = Math.min(mandrelRuns.length, controlRuns.length);
+  const tokenDiffs = [];
+  const usdDiffs = [];
+  for (let i = 0; i < pairCount; i += 1) {
+    const mt = tokenAccessor(mandrelRuns[i]?.dimensions);
+    const ct = tokenAccessor(controlRuns[i]?.dimensions);
+    if (typeof mt === 'number' && typeof ct === 'number') {
+      tokenDiffs.push(mt - ct);
+    }
+    const mu = usdAccessor(mandrelRuns[i]?.dimensions);
+    const cu = usdAccessor(controlRuns[i]?.dimensions);
+    if (typeof mu === 'number' && typeof cu === 'number') {
+      usdDiffs.push(mu - cu);
+    }
+  }
+  const tokenDiffBand = bandOrNull(tokenDiffs, method);
+  const usdDiffBand = bandOrNull(usdDiffs, method);
+
+  const mandrelQuality = centerOf(mandrelRuns, qualityAccessor, method);
+  const controlQuality = centerOf(controlRuns, qualityAccessor, method);
+  const qualityGain =
+    mandrelQuality !== null && controlQuality !== null
+      ? mandrelQuality - controlQuality
+      : null;
+  const noQualityGain =
+    qualityGain !== null && qualityGain < qualityGainEpsilon;
+
+  // The recommendation fires when there IS a positive overhead floor AND no
+  // matching quality gain to justify it.
+  const recommendCeremonyLite =
+    overheadFloorTokens !== null && overheadFloorTokens > 0 && noQualityGain;
+
+  return {
+    scenario: 'hello-world',
+    overheadFloorTokens,
+    overheadFloorUsd,
+    tokenDiffBand,
+    usdDiffBand,
+    qualityGain,
+    noQualityGain,
+    recommendCeremonyLite,
+  };
+}
+
+/**
+ * Convenience top-level: compute the per-scenario differentials AND both
+ * cross-scenario metrics from a full corpus of scorecards keyed by scenario
+ * and arm. This is the function a report slice calls with everything it has.
+ *
+ * @param {object} args
+ * @param {Array<{
+ *   scenario: string,
+ *   difficulty: number,
+ *   mandrelRuns: Array<object>,
+ *   controlRuns: Array<object>
+ * }>} args.cells
+ * @param {'iqr'|'ci'} [args.method='iqr']
+ * @returns {{
+ *   method: 'iqr'|'ci',
+ *   perScenario: Array<ReturnType<typeof computeDifferential>>,
+ *   difficultyMonotonicity: ReturnType<typeof difficultyMonotonicity>,
+ *   overheadFloor: ReturnType<typeof overheadFloor>|null
+ * }}
+ */
+export function scoreCorpus({ cells, method = 'iqr' }) {
+  if (!Array.isArray(cells)) {
+    throw new TypeError('scoreCorpus: cells must be an array');
+  }
+
+  const perScenario = cells.map((c) =>
+    computeDifferential({
+      scenario: c.scenario,
+      mandrelRuns: c.mandrelRuns ?? [],
+      controlRuns: c.controlRuns ?? [],
+      method,
+    }),
+  );
+
+  const mono = difficultyMonotonicity({
+    cells: cells.map((c) => ({
+      scenario: c.scenario,
+      difficulty: c.difficulty,
+      mandrelRuns: c.mandrelRuns ?? [],
+    })),
+    method,
+  });
+
+  const floorCell = cells.find((c) => c.scenario === 'hello-world');
+  const floor = floorCell
+    ? overheadFloor({
+        mandrelRuns: floorCell.mandrelRuns ?? [],
+        controlRuns: floorCell.controlRuns ?? [],
+        method,
+      })
+    : null;
+
+  return {
+    method,
+    perScenario,
+    difficultyMonotonicity: mono,
+    overheadFloor: floor,
+  };
+}

--- a/bench/score/dimensions.js
+++ b/bench/score/dimensions.js
@@ -1,0 +1,393 @@
+// bench/score/dimensions.js
+//
+// The five-dimension scorer for the Mandrel self-benchmark harness
+// (Epic #4211, Story #4217). Internal tooling only — never shipped in the
+// distributed `.agents/` bundle, never run against the live repo.
+//
+// This module is the single source of truth for turning the raw inputs a
+// single run recorded (frozen-suite results, the acceptance-eval verdict,
+// plan-vs-actual counts, lifecycle timings/autonomy counters, the `claude -p`
+// usage envelope, and the ceremony/codegen token split) into the five
+// per-run dimension values that land on a scorecard under `dimensions.<name>`.
+//
+// Every formula is the verbatim, reproducible definition from the binding
+// measurement contract at bench/metrics/README.md § "The five dimensions":
+//
+//   value side: quality, planningFidelity, autonomy
+//   cost side:  efficiency, overheadRatio
+//
+// Determinism: pure functions, no I/O, no clock, no randomness. The same
+// inputs always yield the same dimension object, so a persisted scorecard is
+// reproducible and re-scorable from its rawRefs.
+//
+// The distribution / noise-band across N runs is NOT computed here — that is
+// the job of bench/metrics/variance.js (consumed by bench/score/differential.js).
+// This module produces the single per-run point that feeds those bands.
+
+/**
+ * Quality weights (README § 1). The frozen acceptance suite is the objective
+ * spine (`w_suite`); the acceptance-eval LLM judge is a cross-check
+ * (`w_judge`). When the judge did not run (`acceptanceEvalScore == null`,
+ * e.g. the control arm with no acceptance criteria) the judge weight folds
+ * into the suite weight, renormalizing `w_suite` to 1.0.
+ */
+export const QUALITY_WEIGHTS = Object.freeze({ suite: 0.7, judge: 0.3 });
+
+/**
+ * Coerce a value to a finite number, or return `fallback`. Used to keep a
+ * malformed recorded input from poisoning a formula with NaN.
+ *
+ * @param {unknown} v
+ * @param {number} fallback
+ * @returns {number}
+ */
+function finiteOr(v, fallback) {
+  return typeof v === 'number' && Number.isFinite(v) ? v : fallback;
+}
+
+/**
+ * Coerce a value to a non-negative integer, defaulting to 0. Count inputs
+ * (dispatches, blocked events, story counts) are always non-negative integers;
+ * a missing or malformed field collapses to 0 rather than NaN.
+ *
+ * @param {unknown} v
+ * @returns {number}
+ */
+function nonNegInt(v) {
+  if (typeof v === 'number' && Number.isFinite(v) && v >= 0) {
+    return Math.trunc(v);
+  }
+  return 0;
+}
+
+/**
+ * Clamp a number into the closed interval [lo, hi].
+ *
+ * @param {number} v
+ * @param {number} [lo=0]
+ * @param {number} [hi=1]
+ * @returns {number}
+ */
+function clamp(v, lo = 0, hi = 1) {
+  if (v < lo) return lo;
+  if (v > hi) return hi;
+  return v;
+}
+
+/**
+ * Jaccard distance between two path sets — the symmetric file-footprint drift
+ * between a plan's `changes[]` paths (P) and the files actually touched (A):
+ *
+ *   drift = 1 − |P ∩ A| / |P ∪ A|        (0 when both sets are empty)
+ *
+ * @param {Iterable<string>} planned  Planned `changes[]` paths.
+ * @param {Iterable<string>} actual   Actually-touched paths.
+ * @returns {number} Jaccard distance in [0, 1].
+ */
+export function fileFootprintDrift(planned, actual) {
+  const P = new Set(planned ?? []);
+  const A = new Set(actual ?? []);
+  if (P.size === 0 && A.size === 0) return 0;
+  let intersection = 0;
+  for (const p of P) {
+    if (A.has(p)) intersection += 1;
+  }
+  const union = P.size + A.size - intersection;
+  if (union === 0) return 0;
+  return 1 - intersection / union;
+}
+
+/**
+ * Quality — *is the output correct & on-intent?* (value side)
+ *
+ *   frozenSuitePassRate = frozenSuitePassed / frozenSuiteTotal      ∈ [0, 1]
+ *   quality.score = w_suite·passRate + w_judge·acceptanceEvalScore  ∈ [0, 1]
+ *     with w_judge folded into w_suite (→ 1.0) when acceptanceEvalScore null.
+ *
+ * A run that delivered no runnable app passes zero of its frozen assertions
+ * (`frozenSuiteTotal === 0` is treated as pass-rate 0, NOT "no data"), so its
+ * quality is 0 — exactly the README's stated behaviour.
+ *
+ * @param {object} input
+ * @param {number} input.frozenSuitePassed   Count of passing frozen assertions.
+ * @param {number} input.frozenSuiteTotal    Total frozen assertions.
+ * @param {number|null} [input.acceptanceEvalScore]  LLM-judge cross-check in
+ *   [0,1], or null when the judge did not run.
+ * @returns {{
+ *   score: number,
+ *   frozenSuitePassRate: number,
+ *   frozenSuitePassed: number,
+ *   frozenSuiteTotal: number,
+ *   acceptanceEvalScore: number|null
+ * }}
+ */
+export function computeQuality(input = {}) {
+  const passed = nonNegInt(input.frozenSuitePassed);
+  const total = nonNegInt(input.frozenSuiteTotal);
+  // A delivered-but-empty suite (total 0) scores 0, never a divide-by-zero.
+  const passRate = total > 0 ? clamp(passed / total) : 0;
+
+  const judgeRaw = input.acceptanceEvalScore;
+  const judgePresent =
+    typeof judgeRaw === 'number' && Number.isFinite(judgeRaw);
+  const acceptanceEvalScore = judgePresent ? clamp(judgeRaw) : null;
+
+  let score;
+  if (acceptanceEvalScore === null) {
+    // Judge weight folds entirely onto the frozen suite.
+    score = passRate;
+  } else {
+    score =
+      QUALITY_WEIGHTS.suite * passRate +
+      QUALITY_WEIGHTS.judge * acceptanceEvalScore;
+  }
+
+  return {
+    score: clamp(score),
+    frozenSuitePassRate: passRate,
+    frozenSuitePassed: passed,
+    frozenSuiteTotal: total,
+    acceptanceEvalScore,
+  };
+}
+
+/**
+ * Planning fidelity — *did the plan match reality?* (value side)
+ *
+ *   storyAccuracy     = 1 − |planned − delivered| / max(planned, delivered, 1)
+ *   rePlanPenalty     = 1 / (1 + rePlanCount)
+ *   footprintAccuracy = 1 − fileFootprintDrift
+ *   score = (storyAccuracy + rePlanPenalty + footprintAccuracy) / 3   ∈ [0, 1]
+ *
+ * **`null` for the control arm** — it authors no plan. The caller signals this
+ * with `arm: 'control'` (or `planAuthored: false`); the score is then null and
+ * the sub-signals are reported as zeros for shape stability.
+ *
+ * `fileFootprintDrift` may be supplied directly, or derived from
+ * `plannedPaths` / `actualPaths` when both arrays are present.
+ *
+ * @param {object} input
+ * @param {'mandrel'|'control'} [input.arm]
+ * @param {boolean} [input.planAuthored]   Explicit override; defaults to
+ *   `arm !== 'control'`.
+ * @param {number} [input.rePlanCount]
+ * @param {number} [input.plannedStoryCount]
+ * @param {number} [input.deliveredStoryCount]
+ * @param {number} [input.fileFootprintDrift]  Precomputed Jaccard distance.
+ * @param {Iterable<string>} [input.plannedPaths]  Used iff fileFootprintDrift
+ *   is not supplied and actualPaths is present.
+ * @param {Iterable<string>} [input.actualPaths]
+ * @returns {{
+ *   score: number|null,
+ *   rePlanCount: number,
+ *   plannedStoryCount: number,
+ *   deliveredStoryCount: number,
+ *   fileFootprintDrift: number
+ * }}
+ */
+export function computePlanningFidelity(input = {}) {
+  const rePlanCount = nonNegInt(input.rePlanCount);
+  const plannedStoryCount = nonNegInt(input.plannedStoryCount);
+  const deliveredStoryCount = nonNegInt(input.deliveredStoryCount);
+
+  let drift;
+  if (typeof input.fileFootprintDrift === 'number') {
+    drift = clamp(finiteOr(input.fileFootprintDrift, 0));
+  } else if (input.plannedPaths || input.actualPaths) {
+    drift = fileFootprintDrift(input.plannedPaths, input.actualPaths);
+  } else {
+    drift = 0;
+  }
+
+  const planAuthored =
+    typeof input.planAuthored === 'boolean'
+      ? input.planAuthored
+      : input.arm !== 'control';
+
+  if (!planAuthored) {
+    return {
+      score: null,
+      rePlanCount,
+      plannedStoryCount,
+      deliveredStoryCount,
+      fileFootprintDrift: drift,
+    };
+  }
+
+  const storyAccuracy =
+    1 -
+    Math.abs(plannedStoryCount - deliveredStoryCount) /
+      Math.max(plannedStoryCount, deliveredStoryCount, 1);
+  const rePlanPenalty = 1 / (1 + rePlanCount);
+  const footprintAccuracy = 1 - drift;
+
+  const score = (storyAccuracy + rePlanPenalty + footprintAccuracy) / 3;
+
+  return {
+    score: clamp(score),
+    rePlanCount,
+    plannedStoryCount,
+    deliveredStoryCount,
+    fileFootprintDrift: drift,
+  };
+}
+
+/**
+ * Autonomy — *how little human intervention?* (value side)
+ *
+ *   interventions = hitlStops + blockedEvents + manualRescues
+ *   score = 1 / (1 + interventions)                                  ∈ (0, 1]
+ *
+ * `score === 1.0` ⇔ zero interventions (fully unattended).
+ *
+ * @param {object} input
+ * @param {number} [input.hitlStops]
+ * @param {number} [input.blockedEvents]
+ * @param {number} [input.manualRescues]
+ * @returns {{
+ *   score: number,
+ *   hitlStops: number,
+ *   blockedEvents: number,
+ *   manualRescues: number
+ * }}
+ */
+export function computeAutonomy(input = {}) {
+  const hitlStops = nonNegInt(input.hitlStops);
+  const blockedEvents = nonNegInt(input.blockedEvents);
+  const manualRescues = nonNegInt(input.manualRescues);
+  const interventions = hitlStops + blockedEvents + manualRescues;
+  return {
+    score: 1 / (1 + interventions),
+    hitlStops,
+    blockedEvents,
+    manualRescues,
+  };
+}
+
+/**
+ * Efficiency — *what did it cost absolutely?* (cost side)
+ *
+ * A vector, never collapsed to a scalar: wall-clock, tokens, dispatches, plus
+ * the input/output token split and an optional USD cost. Tokens and USD come
+ * ONLY from the `claude -p` envelope; timings/dispatches from lifecycle.ndjson.
+ *
+ *   wallClockMs = run end − run start
+ *   totalTokens = Σ (inputTokens + outputTokens) over the usage envelope
+ *   dispatches  = count of Story sub-agent launches
+ *   costUsd     = total USD from the envelope when reported, else null
+ *
+ * @param {object} input
+ * @param {number} input.wallClockMs
+ * @param {number} input.totalTokens
+ * @param {number} input.dispatches
+ * @param {number} [input.inputTokens]
+ * @param {number} [input.outputTokens]
+ * @param {number|null} [input.costUsd]
+ * @returns {{
+ *   wallClockMs: number,
+ *   totalTokens: number,
+ *   inputTokens: number,
+ *   outputTokens: number,
+ *   dispatches: number,
+ *   costUsd: number|null
+ * }}
+ */
+export function computeEfficiency(input = {}) {
+  const wallClockMs = Math.max(0, finiteOr(input.wallClockMs, 0));
+  const totalTokens = nonNegInt(input.totalTokens);
+  const inputTokens = nonNegInt(input.inputTokens);
+  const outputTokens = nonNegInt(input.outputTokens);
+  const dispatches = nonNegInt(input.dispatches);
+  const costUsd =
+    typeof input.costUsd === 'number' &&
+    Number.isFinite(input.costUsd) &&
+    input.costUsd >= 0
+      ? input.costUsd
+      : null;
+  return {
+    wallClockMs,
+    totalTokens,
+    inputTokens,
+    outputTokens,
+    dispatches,
+    costUsd,
+  };
+}
+
+/**
+ * Overhead ratio — *ceremony tax vs. shippable output?* (cost side)
+ *
+ *   tokenRatio = ceremonyTokens / codegenTokens                      (≥ 0)
+ *   timeRatio  = ceremonyMs    / codegenMs   (null when unavailable)
+ *
+ * `ceremonyTokens + codegenTokens` equals `efficiency.totalTokens` by
+ * construction of the lifecycle phase split (see the normalize slice). When
+ * `codegenTokens === 0` (no shippable codegen recorded — e.g. a run that never
+ * reached a Story-implementation phase) the ratio is reported as 0 rather than
+ * Infinity: the schema constrains it to a finite `minimum: 0`, and a run that
+ * shipped nothing has no meaningful per-unit-output tax. The control arm has
+ * effectively no ceremony, so its ratio sits near the floor.
+ *
+ * @param {object} input
+ * @param {number} input.ceremonyTokens
+ * @param {number} input.codegenTokens
+ * @param {number|null} [input.ceremonyMs]
+ * @param {number|null} [input.codegenMs]
+ * @returns {{
+ *   tokenRatio: number,
+ *   timeRatio: number|null,
+ *   ceremonyTokens: number,
+ *   codegenTokens: number
+ * }}
+ */
+export function computeOverheadRatio(input = {}) {
+  const ceremonyTokens = nonNegInt(input.ceremonyTokens);
+  const codegenTokens = nonNegInt(input.codegenTokens);
+  const tokenRatio = codegenTokens > 0 ? ceremonyTokens / codegenTokens : 0;
+
+  const ceremonyMs = finiteOr(input.ceremonyMs, Number.NaN);
+  const codegenMs = finiteOr(input.codegenMs, Number.NaN);
+  let timeRatio = null;
+  if (
+    Number.isFinite(ceremonyMs) &&
+    Number.isFinite(codegenMs) &&
+    codegenMs > 0
+  ) {
+    timeRatio = ceremonyMs / codegenMs;
+  }
+
+  return { tokenRatio, timeRatio, ceremonyTokens, codegenTokens };
+}
+
+/**
+ * Compute all five dimensions from one run's recorded inputs and return the
+ * `dimensions` sub-object exactly as it appears on a scorecard
+ * (`bench/schemas/scorecard.schema.json#/properties/dimensions`).
+ *
+ * The caller (the normalize slice) assembles the rest of the scorecard
+ * (`runId`, `model`, `env`, `rawRefs`, …) around this object.
+ *
+ * @param {object} run  The per-run inputs. Fields are grouped by dimension
+ *   but passed flat for the convenience of the normalize slice, which already
+ *   holds them all.
+ * @param {'mandrel'|'control'} [run.arm]  Drives the planning-fidelity null.
+ * @returns {{
+ *   quality: ReturnType<typeof computeQuality>,
+ *   planningFidelity: ReturnType<typeof computePlanningFidelity>,
+ *   autonomy: ReturnType<typeof computeAutonomy>,
+ *   efficiency: ReturnType<typeof computeEfficiency>,
+ *   overheadRatio: ReturnType<typeof computeOverheadRatio>
+ * }}
+ */
+export function computeDimensions(run = {}) {
+  return {
+    quality: computeQuality(run.quality ?? run),
+    planningFidelity: computePlanningFidelity({
+      arm: run.arm,
+      ...(run.planningFidelity ?? run),
+    }),
+    autonomy: computeAutonomy(run.autonomy ?? run),
+    efficiency: computeEfficiency(run.efficiency ?? run),
+    overheadRatio: computeOverheadRatio(run.overheadRatio ?? run),
+  };
+}

--- a/tests/bench/collect/normalize.test.js
+++ b/tests/bench/collect/normalize.test.js
@@ -1,0 +1,478 @@
+// tests/bench/collect/normalize.test.js
+//
+// Unit + contract tier for the telemetry normalizer (Epic #4211, Story #4217).
+// Exercises bench/collect/normalize.js:
+//   - NDJSON parsing (blank-line tolerance, malformed-line failure),
+//   - lifecycle-derived raw sub-signals (wall-clock, dispatch count, autonomy
+//     counters, the ceremony/codegen token split),
+//   - usage extraction from both the normalized and raw `claude -p` envelope
+//     shapes,
+//   - the binding acceptance item: the assembled per-run record CONFORMS to
+//     bench/schemas/scorecard.schema.json (validated with the same Ajv 2020
+//     strict setup the schema's own contract test uses),
+//   - the file-reading shell via an injected reader, including reading the
+//     committed bench/fixtures/lifecycle.sample.ndjson.
+
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { describe, it } from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+import Ajv2020 from 'ajv/dist/2020.js';
+import addFormats from 'ajv-formats';
+
+import {
+  buildScorecard,
+  deriveAutonomyCounters,
+  deriveDispatchCount,
+  deriveTokenSplit,
+  deriveWallClockMs,
+  extractUsage,
+  normalizeRunFromPaths,
+  parseNdjson,
+  SCORECARD_SCHEMA_VERSION,
+} from '../../../bench/collect/normalize.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+// tests/bench/collect/ → repo root is three levels up.
+const REPO_ROOT = path.resolve(__dirname, '..', '..', '..');
+const SCHEMA_PATH = path.join(
+  REPO_ROOT,
+  'bench',
+  'schemas',
+  'scorecard.schema.json',
+);
+const LIFECYCLE_FIXTURE = path.join(
+  REPO_ROOT,
+  'bench',
+  'fixtures',
+  'lifecycle.sample.ndjson',
+);
+
+const schema = JSON.parse(readFileSync(SCHEMA_PATH, 'utf8'));
+
+/** A validator built exactly like the schema's own contract test. */
+function buildValidator() {
+  const ajv = new Ajv2020({ allErrors: true, strict: true });
+  addFormats(ajv);
+  return ajv.compile(schema);
+}
+
+/** A canonical run-identity stamp (hello-world / mandrel). */
+function runStamp(overrides = {}) {
+  return {
+    runId: 'hello-world-mandrel-2026-06-16-r01',
+    timestamp: '2026-06-16T19:42:11.000Z',
+    model: {
+      id: 'claude-opus-4-8[1m]',
+      displayName: 'Claude Opus 4.8 (1M context)',
+    },
+    frameworkVersion: '1.70.0',
+    env: { node: 'v24.16.0', os: 'darwin', host: 'bench-runner-01' },
+    scenario: 'hello-world',
+    arm: 'mandrel',
+    ...overrides,
+  };
+}
+
+/** A normalized envelope (the shape parseSessionEnvelope returns). */
+function normalizedEnvelope(overrides = {}) {
+  return {
+    usage: {
+      inputTokens: 151200,
+      outputTokens: 33120,
+      cacheCreationInputTokens: 0,
+      cacheReadInputTokens: 0,
+      totalTokens: 184320,
+    },
+    cost: { totalUsd: 1.47 },
+    ...overrides,
+  };
+}
+
+describe('parseNdjson', () => {
+  it('parses non-blank lines and skips blanks', () => {
+    const recs = parseNdjson('{"a":1}\n\n  \n{"b":2}\n');
+    assert.deepEqual(recs, [{ a: 1 }, { b: 2 }]);
+  });
+
+  it('throws with the 1-based line number on a malformed line', () => {
+    assert.throws(() => parseNdjson('{"a":1}\nnot json\n'), /line 2/);
+  });
+
+  it('rejects a non-string input', () => {
+    assert.throws(() => parseNdjson(null), TypeError);
+  });
+});
+
+describe('deriveWallClockMs', () => {
+  it('is the span between the earliest and latest timestamp', () => {
+    const recs = [
+      { ts: '2026-06-16T19:32:00.000Z' },
+      { ts: '2026-06-16T19:42:11.000Z' },
+      { ts: '2026-06-16T19:34:30.000Z' },
+    ];
+    // 19:42:11 − 19:32:00 = 611 s = 611000 ms
+    assert.equal(deriveWallClockMs(recs), 611000);
+  });
+
+  it('is 0 when fewer than two timestamps are parseable', () => {
+    assert.equal(deriveWallClockMs([{ ts: '2026-06-16T19:32:00.000Z' }]), 0);
+    assert.equal(deriveWallClockMs([{ ts: 'nope' }, { ts: 'also nope' }]), 0);
+  });
+});
+
+describe('deriveDispatchCount', () => {
+  it('counts story.dispatch.start records', () => {
+    const recs = [
+      { event: 'story.dispatch.start', payload: { storyId: 1 } },
+      { event: 'story.dispatch.start', payload: { storyId: 2 } },
+      { event: 'story.dispatch.end', payload: { storyId: 1 } },
+      { event: 'epic.plan.start' },
+    ];
+    assert.equal(deriveDispatchCount(recs), 2);
+  });
+});
+
+describe('deriveAutonomyCounters', () => {
+  it('counts blocked events, manual rescues, and hitl stops', () => {
+    const lifecycle = [
+      { event: 'epic.blocked', payload: { reason: 'x' } },
+      { event: 'story.blocked', payload: { storyId: 1, reason: 'y' } },
+      { event: 'intervention.recorded', payload: { epicId: 1, reason: 'z' } },
+      { event: 'story.dispatch.start', payload: { storyId: 1 } },
+    ];
+    const signals = [
+      { kind: 'hitl-stop' },
+      { signal: 'hitl-stop' },
+      { kind: 'other' },
+    ];
+    const counters = deriveAutonomyCounters({ lifecycle, signals });
+    assert.deepEqual(counters, {
+      hitlStops: 2,
+      blockedEvents: 2,
+      manualRescues: 1,
+    });
+  });
+
+  it('is all zeros for a clean unattended run', () => {
+    const counters = deriveAutonomyCounters({
+      lifecycle: [{ event: 'story.dispatch.start', payload: { storyId: 1 } }],
+      signals: [],
+    });
+    assert.deepEqual(counters, {
+      hitlStops: 0,
+      blockedEvents: 0,
+      manualRescues: 0,
+    });
+  });
+});
+
+describe('deriveTokenSplit', () => {
+  it('attributes tokens to codegen in proportion to dispatch wall-clock', () => {
+    // One dispatch window of 100s inside a 200s run ⇒ 50% codegen.
+    const lifecycle = [
+      { event: 'epic.plan.start', ts: '2026-06-16T19:00:00.000Z' },
+      {
+        event: 'story.dispatch.start',
+        ts: '2026-06-16T19:01:00.000Z',
+        payload: { storyId: 1 },
+      },
+      {
+        event: 'story.dispatch.end',
+        ts: '2026-06-16T19:02:40.000Z',
+        payload: { storyId: 1 },
+      },
+      { event: 'epic.complete', ts: '2026-06-16T19:03:20.000Z' },
+    ];
+    // wall = 200s, codegen window = 100s
+    const split = deriveTokenSplit({
+      lifecycle,
+      totalTokens: 1000,
+      wallClockMs: 200000,
+    });
+    assert.equal(split.codegenMs, 100000);
+    assert.equal(split.ceremonyMs, 100000);
+    assert.equal(split.codegenTokens, 500);
+    assert.equal(split.ceremonyTokens, 500);
+  });
+
+  it('keeps ceremonyTokens + codegenTokens === totalTokens', () => {
+    const lifecycle = [
+      {
+        event: 'story.dispatch.start',
+        ts: '2026-06-16T19:01:00.000Z',
+        payload: { storyId: 1 },
+      },
+      {
+        event: 'story.dispatch.end',
+        ts: '2026-06-16T19:01:33.000Z',
+        payload: { storyId: 1 },
+      },
+    ];
+    const split = deriveTokenSplit({
+      lifecycle,
+      totalTokens: 999,
+      wallClockMs: 90000,
+    });
+    assert.equal(split.codegenTokens + split.ceremonyTokens, 999);
+  });
+
+  it('attributes everything to ceremony when there is no measurable codegen window', () => {
+    const split = deriveTokenSplit({
+      lifecycle: [{ event: 'epic.plan.start', ts: '2026-06-16T19:00:00.000Z' }],
+      totalTokens: 500,
+      wallClockMs: 0,
+    });
+    assert.equal(split.codegenTokens, 0);
+    assert.equal(split.ceremonyTokens, 500);
+  });
+
+  it('clamps codegen time that would exceed wall-clock (overlapping dispatches)', () => {
+    // Two fully-overlapping 200s windows inside a 200s run: summed = 400s,
+    // clamped to 200s ⇒ all tokens are codegen.
+    const lifecycle = [
+      {
+        event: 'story.dispatch.start',
+        ts: '2026-06-16T19:00:00.000Z',
+        payload: { storyId: 1 },
+      },
+      {
+        event: 'story.dispatch.start',
+        ts: '2026-06-16T19:00:00.000Z',
+        payload: { storyId: 2 },
+      },
+      {
+        event: 'story.dispatch.end',
+        ts: '2026-06-16T19:03:20.000Z',
+        payload: { storyId: 1 },
+      },
+      {
+        event: 'story.dispatch.end',
+        ts: '2026-06-16T19:03:20.000Z',
+        payload: { storyId: 2 },
+      },
+    ];
+    const split = deriveTokenSplit({
+      lifecycle,
+      totalTokens: 800,
+      wallClockMs: 200000,
+    });
+    assert.equal(split.codegenMs, 200000);
+    assert.equal(split.codegenTokens, 800);
+    assert.equal(split.ceremonyTokens, 0);
+  });
+});
+
+describe('extractUsage', () => {
+  it('reads the normalized envelope shape', () => {
+    const u = extractUsage(normalizedEnvelope());
+    assert.deepEqual(u, {
+      totalTokens: 184320,
+      inputTokens: 151200,
+      outputTokens: 33120,
+      costUsd: 1.47,
+    });
+  });
+
+  it('reads the raw `claude -p` envelope shape and sums cache tokens', () => {
+    const u = extractUsage({
+      total_cost_usd: 0.35,
+      usage: {
+        input_tokens: 4942,
+        output_tokens: 100,
+        cache_creation_input_tokens: 31340,
+        cache_read_input_tokens: 1000,
+      },
+    });
+    assert.equal(u.totalTokens, 4942 + 100 + 31340 + 1000);
+    assert.equal(u.inputTokens, 4942);
+    assert.equal(u.outputTokens, 100);
+    assert.equal(u.costUsd, 0.35);
+  });
+
+  it('returns zeros / null for a missing envelope', () => {
+    assert.deepEqual(extractUsage(null), {
+      totalTokens: 0,
+      inputTokens: 0,
+      outputTokens: 0,
+      costUsd: null,
+    });
+  });
+});
+
+describe('buildScorecard — schema conformance (binding acceptance)', () => {
+  it('assembles a per-run record that validates against scorecard.schema.json', () => {
+    const lifecycle = parseNdjson(readFileSync(LIFECYCLE_FIXTURE, 'utf8'));
+    const scorecard = buildScorecard({
+      run: runStamp(),
+      lifecycle,
+      signals: [],
+      envelope: normalizedEnvelope(),
+      quality: {
+        frozenSuitePassed: 3,
+        frozenSuiteTotal: 3,
+        acceptanceEvalScore: 1,
+      },
+      planning: {
+        rePlanCount: 0,
+        plannedStoryCount: 2,
+        deliveredStoryCount: 2,
+        plannedPaths: ['server.js', 'package.json'],
+        actualPaths: ['server.js', 'package.json'],
+      },
+    });
+
+    const validate = buildValidator();
+    const ok = validate(scorecard);
+    assert.ok(
+      ok,
+      `scorecard failed schema validation: ${JSON.stringify(validate.errors, null, 2)}`,
+    );
+
+    assert.equal(scorecard.schemaVersion, SCORECARD_SCHEMA_VERSION);
+    assert.equal(scorecard.scenario, 'hello-world');
+    assert.equal(scorecard.arm, 'mandrel');
+    // Five dimensions present.
+    assert.deepEqual(Object.keys(scorecard.dimensions).sort(), [
+      'autonomy',
+      'efficiency',
+      'overheadRatio',
+      'planningFidelity',
+      'quality',
+    ]);
+    // Wall-clock derived from the fixture span (19:32:00 → 19:42:11 = 611000ms).
+    assert.equal(scorecard.dimensions.efficiency.wallClockMs, 611000);
+    // Two dispatch.start records in the fixture.
+    assert.equal(scorecard.dimensions.efficiency.dispatches, 2);
+    // Clean autonomy.
+    assert.equal(scorecard.dimensions.autonomy.score, 1);
+    // Token split sums to the envelope total.
+    assert.equal(
+      scorecard.dimensions.overheadRatio.ceremonyTokens +
+        scorecard.dimensions.overheadRatio.codegenTokens,
+      scorecard.dimensions.efficiency.totalTokens,
+    );
+  });
+
+  it('produces a schema-valid control-arm record (planningFidelity null)', () => {
+    const scorecard = buildScorecard({
+      run: runStamp({ runId: 'hw-control-r01', arm: 'control' }),
+      lifecycle: [
+        {
+          kind: 'emitted',
+          event: 'epic.plan.start',
+          ts: '2026-06-16T19:00:00.000Z',
+          payload: { epicId: 1 },
+        },
+        {
+          kind: 'emitted',
+          event: 'epic.complete',
+          ts: '2026-06-16T19:01:40.000Z',
+          payload: { epicId: 1, prUrl: 'https://x/y' },
+        },
+      ],
+      envelope: normalizedEnvelope({ cost: { totalUsd: 0.2 } }),
+      quality: { frozenSuitePassed: 3, frozenSuiteTotal: 3 },
+    });
+    const validate = buildValidator();
+    assert.ok(
+      validate(scorecard),
+      `control scorecard failed: ${JSON.stringify(validate.errors, null, 2)}`,
+    );
+    assert.equal(scorecard.dimensions.planningFidelity.score, null);
+    // No judge ⇒ quality is the frozen pass rate.
+    assert.equal(scorecard.dimensions.quality.score, 1);
+  });
+
+  it('rejects an unknown arm', () => {
+    assert.throws(
+      () =>
+        buildScorecard({
+          run: runStamp({ arm: 'bogus' }),
+          lifecycle: [],
+          envelope: normalizedEnvelope(),
+          quality: { frozenSuitePassed: 0, frozenSuiteTotal: 0 },
+        }),
+      /arm must be/,
+    );
+  });
+
+  it('requires the run identity fields', () => {
+    assert.throws(
+      () =>
+        buildScorecard({
+          run: { runId: 'x' },
+          lifecycle: [],
+          envelope: normalizedEnvelope(),
+          quality: {},
+        }),
+      /required/,
+    );
+  });
+});
+
+describe('normalizeRunFromPaths — file-reading shell', () => {
+  it('reads lifecycle, signals, and envelope from disk via an injected reader', () => {
+    const lifecycleText = readFileSync(LIFECYCLE_FIXTURE, 'utf8');
+    const signalsText = '{"kind":"hitl-stop"}\n';
+    const envelopeText = JSON.stringify(normalizedEnvelope());
+
+    const files = {
+      '/run/lifecycle.ndjson': lifecycleText,
+      '/run/story-1/signals.ndjson': signalsText,
+      '/run/cost-envelope.json': envelopeText,
+    };
+    const readFileImpl = (p) => {
+      if (!(p in files)) throw new Error(`unexpected read: ${p}`);
+      return files[p];
+    };
+
+    const scorecard = normalizeRunFromPaths(
+      {
+        run: runStamp(),
+        lifecyclePath: '/run/lifecycle.ndjson',
+        signalsPaths: ['/run/story-1/signals.ndjson'],
+        costEnvelopePath: '/run/cost-envelope.json',
+        quality: {
+          frozenSuitePassed: 3,
+          frozenSuiteTotal: 3,
+          acceptanceEvalScore: 1,
+        },
+        planning: {
+          rePlanCount: 0,
+          plannedStoryCount: 2,
+          deliveredStoryCount: 2,
+        },
+      },
+      { readFileImpl },
+    );
+
+    const validate = buildValidator();
+    assert.ok(
+      validate(scorecard),
+      `scorecard failed schema validation: ${JSON.stringify(validate.errors, null, 2)}`,
+    );
+    // The injected signals file carried one hitl-stop ⇒ one intervention.
+    assert.equal(scorecard.dimensions.autonomy.hitlStops, 1);
+    // rawRefs default to the supplied paths.
+    assert.equal(scorecard.rawRefs.lifecycleNdjson, '/run/lifecycle.ndjson');
+    assert.deepEqual(scorecard.rawRefs.signalsNdjson, [
+      '/run/story-1/signals.ndjson',
+    ]);
+    assert.equal(scorecard.rawRefs.costEnvelope, '/run/cost-envelope.json');
+  });
+
+  it('requires lifecyclePath and costEnvelopePath', () => {
+    assert.throws(
+      () =>
+        normalizeRunFromPaths({
+          run: runStamp(),
+          costEnvelopePath: '/x.json',
+          quality: {},
+        }),
+      /lifecyclePath is required/,
+    );
+  });
+});

--- a/tests/bench/driver/run-session.test.js
+++ b/tests/bench/driver/run-session.test.js
@@ -1,0 +1,320 @@
+// tests/bench/driver/run-session.test.js
+/**
+ * Unit tests for bench/driver/run-session.js — Story #4216.
+ *
+ * Verifies the headless `claude -p --output-format json` launcher:
+ *   - builds the correct argv (including `--output-format json`),
+ *   - composes distinct Mandrel-arm vs control-arm prompts,
+ *   - parses the real session envelope into usage/cost,
+ *   - drives entirely through an INJECTED invoke function (no real process),
+ *   - surfaces a non-zero exit and unparseable stdout as errors.
+ *
+ * The envelope fixture below is a verbatim shape captured from a live
+ * `claude 2.1.178 -p --output-format json` run.
+ */
+
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  buildArmPrompt,
+  buildClaudeArgs,
+  DEFAULT_BENCH_MODEL,
+  parseSessionEnvelope,
+  runSession,
+} from '../../../bench/driver/run-session.js';
+
+const SCENARIO = {
+  id: 'hello-world',
+  taskPrompt: 'Create a hello-world HTTP server with a GET / route.',
+};
+
+/** A real-shape `claude -p --output-format json` envelope (trimmed). */
+function realEnvelope(overrides = {}) {
+  return {
+    type: 'result',
+    subtype: 'success',
+    is_error: false,
+    duration_ms: 4952,
+    num_turns: 1,
+    result: 'ok',
+    session_id: '56d0b069-56c7-4d2b-bf76-b0cc4c5b388a',
+    total_cost_usd: 0.346588,
+    usage: {
+      input_tokens: 4942,
+      cache_creation_input_tokens: 31340,
+      cache_read_input_tokens: 15626,
+      output_tokens: 4,
+      service_tier: 'standard',
+    },
+    modelUsage: {
+      'claude-opus-4-8[1m]': { inputTokens: 4942, costUSD: 0.346023 },
+    },
+    permission_denials: [],
+    terminal_reason: 'completed',
+    uuid: '9d7dd296-f5c4-4156-9b50-f0cb4c0d053a',
+    ...overrides,
+  };
+}
+
+/**
+ * Build an injected invoke that records its input and returns a fixed result.
+ * @param {{ status?: number, stdout?: string, stderr?: string }} result
+ */
+function fakeInvoke(result = {}) {
+  const calls = [];
+  const fn = (input) => {
+    calls.push(input);
+    return {
+      status: result.status ?? 0,
+      stdout: result.stdout ?? JSON.stringify(realEnvelope()),
+      stderr: result.stderr ?? '',
+    };
+  };
+  fn.calls = calls;
+  return fn;
+}
+
+// ---------------------------------------------------------------------------
+// buildClaudeArgs
+// ---------------------------------------------------------------------------
+
+test('buildClaudeArgs: emits -p and --output-format json with the model', () => {
+  const args = buildClaudeArgs({
+    prompt: 'do the thing',
+    model: 'claude-opus-4-8',
+  });
+  assert.deepEqual(args, [
+    '-p',
+    '--output-format',
+    'json',
+    '--model',
+    'claude-opus-4-8',
+    'do the thing',
+  ]);
+});
+
+test('buildClaudeArgs: places the prompt last, after extraArgs', () => {
+  const args = buildClaudeArgs({
+    prompt: 'PROMPT',
+    model: 'm',
+    extraArgs: ['--yes', '--permission-mode', 'bypassPermissions'],
+  });
+  assert.equal(args[args.length - 1], 'PROMPT');
+  assert.ok(args.includes('--yes'));
+  // --output-format json is non-negotiable: it is what surfaces the envelope.
+  assert.equal(args[1], '--output-format');
+  assert.equal(args[2], 'json');
+});
+
+test('buildClaudeArgs: rejects empty prompt / model / non-array extraArgs', () => {
+  assert.throws(
+    () => buildClaudeArgs({ prompt: '', model: 'm' }),
+    /non-empty prompt/,
+  );
+  assert.throws(
+    () => buildClaudeArgs({ prompt: 'p', model: '' }),
+    /non-empty model/,
+  );
+  assert.throws(
+    () => buildClaudeArgs({ prompt: 'p', model: 'm', extraArgs: 'nope' }),
+    /extraArgs must be an array/,
+  );
+});
+
+// ---------------------------------------------------------------------------
+// buildArmPrompt
+// ---------------------------------------------------------------------------
+
+test('buildArmPrompt: mandrel arm drives /plan then /deliver with auto-proceed', () => {
+  const prompt = buildArmPrompt({ arm: 'mandrel', scenario: SCENARIO });
+  assert.match(prompt, /\/plan/);
+  assert.match(prompt, /\/deliver/);
+  assert.match(prompt, /headless/i);
+  assert.match(prompt, /implicit approval|never block/i);
+  assert.match(prompt, /hello-world/);
+});
+
+test('buildArmPrompt: control arm is bare — no Mandrel pipeline', () => {
+  const prompt = buildArmPrompt({ arm: 'control', scenario: SCENARIO });
+  assert.doesNotMatch(prompt, /\/plan|\/deliver/);
+  assert.match(prompt, /autonomously/i);
+  assert.match(prompt, /hello-world/);
+});
+
+test('buildArmPrompt: rejects bad arm and missing scenario fields', () => {
+  assert.throws(
+    () => buildArmPrompt({ arm: 'nope', scenario: SCENARIO }),
+    /must be "mandrel" or "control"/,
+  );
+  assert.throws(
+    () => buildArmPrompt({ arm: 'mandrel', scenario: {} }),
+    /string id/,
+  );
+  assert.throws(
+    () => buildArmPrompt({ arm: 'mandrel', scenario: { id: 'x' } }),
+    /taskPrompt/,
+  );
+});
+
+// ---------------------------------------------------------------------------
+// parseSessionEnvelope
+// ---------------------------------------------------------------------------
+
+test('parseSessionEnvelope: extracts usage + cost from the real envelope', () => {
+  const parsed = parseSessionEnvelope(JSON.stringify(realEnvelope()));
+  assert.equal(parsed.type, 'result');
+  assert.equal(parsed.subtype, 'success');
+  assert.equal(parsed.isError, false);
+  assert.equal(parsed.result, 'ok');
+  assert.equal(parsed.sessionId, '56d0b069-56c7-4d2b-bf76-b0cc4c5b388a');
+  assert.equal(parsed.numTurns, 1);
+  assert.equal(parsed.durationMs, 4952);
+  assert.equal(parsed.cost.totalUsd, 0.346588);
+  assert.equal(parsed.usage.inputTokens, 4942);
+  assert.equal(parsed.usage.outputTokens, 4);
+  assert.equal(parsed.usage.cacheCreationInputTokens, 31340);
+  assert.equal(parsed.usage.cacheReadInputTokens, 15626);
+  assert.equal(parsed.usage.totalTokens, 4942 + 4 + 31340 + 15626);
+  assert.equal(parsed.terminalReason, 'completed');
+  assert.deepEqual(parsed.permissionDenials, []);
+  assert.equal(parsed.raw.uuid, '9d7dd296-f5c4-4156-9b50-f0cb4c0d053a');
+});
+
+test('parseSessionEnvelope: missing/malformed usage fields collapse to 0', () => {
+  const parsed = parseSessionEnvelope(
+    JSON.stringify({
+      type: 'result',
+      is_error: false,
+      usage: { input_tokens: 'x' },
+    }),
+  );
+  assert.equal(parsed.usage.inputTokens, 0);
+  assert.equal(parsed.usage.outputTokens, 0);
+  assert.equal(parsed.usage.totalTokens, 0);
+  assert.equal(parsed.cost.totalUsd, null);
+});
+
+test('parseSessionEnvelope: tolerates a prose preface around the JSON', () => {
+  const noisy = `Some banner line\n${JSON.stringify(realEnvelope())}\ntrailing note`;
+  const parsed = parseSessionEnvelope(noisy);
+  assert.equal(parsed.cost.totalUsd, 0.346588);
+  assert.equal(parsed.usage.inputTokens, 4942);
+});
+
+test('parseSessionEnvelope: a brace inside a string value does not close the scan', () => {
+  const env = realEnvelope({ result: 'done }{ ok' });
+  const parsed = parseSessionEnvelope(`prefix ${JSON.stringify(env)}`);
+  assert.equal(parsed.result, 'done }{ ok');
+  assert.equal(parsed.cost.totalUsd, 0.346588);
+});
+
+test('parseSessionEnvelope: throws on non-JSON stdout', () => {
+  assert.throws(
+    () => parseSessionEnvelope('not json at all'),
+    /Failed to parse/,
+  );
+  assert.throws(() => parseSessionEnvelope(''), /Failed to parse/);
+});
+
+// ---------------------------------------------------------------------------
+// runSession (injected invoke — NEVER spawns a real process)
+// ---------------------------------------------------------------------------
+
+test('runSession: drives the injected invokeFn and returns the parsed envelope', () => {
+  const invoke = fakeInvoke();
+  const out = runSession(
+    { arm: 'mandrel', scenario: SCENARIO, cwd: '/tmp/sandbox-xyz' },
+    { invokeFn: invoke },
+  );
+
+  assert.equal(invoke.calls.length, 1);
+  assert.equal(invoke.calls[0].cwd, '/tmp/sandbox-xyz');
+  assert.equal(invoke.calls[0].model, DEFAULT_BENCH_MODEL);
+  assert.match(invoke.calls[0].prompt, /\/deliver/);
+
+  assert.equal(out.arm, 'mandrel');
+  assert.equal(out.scenarioId, 'hello-world');
+  assert.equal(out.model, DEFAULT_BENCH_MODEL);
+  assert.equal(out.status, 0);
+  assert.equal(out.envelope.cost.totalUsd, 0.346588);
+  assert.equal(out.envelope.usage.totalTokens, 4942 + 4 + 31340 + 15626);
+});
+
+test('runSession: forwards model, extraArgs, and timeoutMs to the invoker', () => {
+  const invoke = fakeInvoke();
+  runSession(
+    {
+      arm: 'control',
+      scenario: SCENARIO,
+      cwd: '/tmp/s',
+      model: 'claude-sonnet-4-6',
+      extraArgs: ['--yes'],
+      timeoutMs: 123,
+    },
+    { invokeFn: invoke },
+  );
+  const call = invoke.calls[0];
+  assert.equal(call.model, 'claude-sonnet-4-6');
+  assert.deepEqual(call.extraArgs, ['--yes']);
+  assert.equal(call.timeoutMs, 123);
+  // control arm prompt must not carry pipeline commands
+  assert.doesNotMatch(call.prompt, /\/plan|\/deliver/);
+});
+
+test('runSession: non-zero exit throws with stderr context', () => {
+  const invoke = fakeInvoke({ status: 137, stderr: 'killed: timeout' });
+  assert.throws(
+    () =>
+      runSession(
+        { arm: 'mandrel', scenario: SCENARIO, cwd: '/tmp/s' },
+        { invokeFn: invoke },
+      ),
+    /exited with status 137.*killed: timeout/s,
+  );
+});
+
+test('runSession: clean exit + is_error envelope warns but still returns the record', () => {
+  const warnings = [];
+  const invoke = fakeInvoke({
+    status: 0,
+    stdout: JSON.stringify(
+      realEnvelope({
+        is_error: true,
+        subtype: 'error_during_execution',
+        result: 'boom',
+      }),
+    ),
+  });
+  const out = runSession(
+    { arm: 'mandrel', scenario: SCENARIO, cwd: '/tmp/s' },
+    { invokeFn: invoke, logger: { warn: (m) => warnings.push(m), info() {} } },
+  );
+  assert.equal(out.envelope.isError, true);
+  assert.equal(out.envelope.result, 'boom');
+  assert.equal(warnings.length, 1);
+  assert.match(warnings[0], /is_error=true/);
+});
+
+test('runSession: rejects bad arm and empty cwd', () => {
+  assert.throws(
+    () => runSession({ arm: 'nope', scenario: SCENARIO, cwd: '/tmp/s' }, {}),
+    /must be "mandrel" or "control"/,
+  );
+  assert.throws(
+    () => runSession({ arm: 'mandrel', scenario: SCENARIO, cwd: '' }, {}),
+    /non-empty cwd/,
+  );
+});
+
+test('runSession: throws when the injected invoke returns unparseable stdout', () => {
+  const invoke = fakeInvoke({ status: 0, stdout: 'totally not json' });
+  assert.throws(
+    () =>
+      runSession(
+        { arm: 'control', scenario: SCENARIO, cwd: '/tmp/s' },
+        { invokeFn: invoke },
+      ),
+    /Failed to parse/,
+  );
+});

--- a/tests/bench/driver/sandbox.test.js
+++ b/tests/bench/driver/sandbox.test.js
@@ -1,0 +1,324 @@
+// tests/bench/driver/sandbox.test.js
+/**
+ * Unit tests for bench/driver/sandbox.js — Story #4216.
+ *
+ * Verifies the ephemeral sandbox lifecycle:
+ *   - provision clones the configured repo into a fresh temp workspace,
+ *   - the control arm strips the materialized `.agents/` bundle,
+ *   - teardown removes ONLY the ephemeral workspace,
+ *   - the path-containment guard refuses to delete anything outside the
+ *     ephemeral root (the strict-scoping safety contract),
+ *   - withSandbox guarantees teardown even when the body throws.
+ *
+ * Every filesystem and git effect is INJECTED — no real clone, no real rm.
+ */
+
+import assert from 'node:assert/strict';
+import path from 'node:path';
+import test from 'node:test';
+
+import {
+  assertInsideRoot,
+  provisionSandbox,
+  SANDBOX_DIR_PREFIX,
+  teardownSandbox,
+  withSandbox,
+} from '../../../bench/driver/sandbox.js';
+
+const ROOT = path.resolve('/tmp/ephemeral-root');
+
+/**
+ * Build an injected dep bundle with recording fakes. By default the workspace
+ * is created under ROOT and every path "exists".
+ */
+function fakes(opts = {}) {
+  const execCalls = [];
+  const rmCalls = [];
+  const existing = new Set(opts.existing ?? []);
+  const created =
+    opts.workspacePath ?? path.join(ROOT, `${SANDBOX_DIR_PREFIX}abc123`);
+
+  const deps = {
+    execFileFn: (cmd, args) => {
+      execCalls.push({ cmd, args });
+      if (opts.cloneThrows) {
+        throw new Error('fatal: clone failed');
+      }
+      return '';
+    },
+    mkdtempFn: (prefixArg) => {
+      // Real mkdtemp appends random chars; our fake returns a fixed path but
+      // asserts the caller passed the expected <root>/<prefix> argument.
+      assert.ok(prefixArg.startsWith(path.join(ROOT, SANDBOX_DIR_PREFIX)));
+      return created;
+    },
+    existsFn: (p) => existing.has(path.resolve(p)),
+    rmFn: (p, o) => {
+      rmCalls.push({ path: path.resolve(p), opts: o });
+    },
+    statFn: () => ({ isDirectory: () => !opts.notADir }),
+    logger: { info() {}, warn() {} },
+  };
+  return { deps, execCalls, rmCalls, created };
+}
+
+// ---------------------------------------------------------------------------
+// assertInsideRoot — the load-bearing safety primitive
+// ---------------------------------------------------------------------------
+
+test('assertInsideRoot: accepts a proper descendant', () => {
+  const ok = assertInsideRoot(ROOT, path.join(ROOT, 'ws-1'), 'ws');
+  assert.equal(ok, path.join(ROOT, 'ws-1'));
+});
+
+test('assertInsideRoot: rejects the root itself', () => {
+  assert.throws(() => assertInsideRoot(ROOT, ROOT, 'ws'), /resolves outside/);
+});
+
+test('assertInsideRoot: rejects ../ traversal escapes', () => {
+  assert.throws(
+    () => assertInsideRoot(ROOT, path.join(ROOT, '..', 'evil'), 'ws'),
+    /resolves outside/,
+  );
+});
+
+test('assertInsideRoot: rejects an absolute re-root to a real path', () => {
+  assert.throws(
+    () => assertInsideRoot(ROOT, '/Users/someone/real-repo', 'ws'),
+    /resolves outside/,
+  );
+  assert.throws(() => assertInsideRoot(ROOT, '/', 'ws'), /resolves outside/);
+});
+
+test('assertInsideRoot: rejects empty root / target', () => {
+  assert.throws(() => assertInsideRoot('', '/tmp/x', 'ws'), /non-empty root/);
+  assert.throws(() => assertInsideRoot(ROOT, '', 'ws'), /non-empty target/);
+});
+
+// ---------------------------------------------------------------------------
+// provisionSandbox
+// ---------------------------------------------------------------------------
+
+test('provisionSandbox: clones into a fresh temp workspace under the root', () => {
+  const { deps, execCalls, created } = fakes();
+  const handle = provisionSandbox(
+    { repoUrl: 'https://github.com/acme/sandbox.git', ephemeralRoot: ROOT },
+    deps,
+  );
+
+  assert.equal(handle.workspacePath, created);
+  assert.equal(handle.ephemeralRoot, ROOT);
+  assert.equal(handle.arm, 'mandrel');
+  assert.equal(handle.agentsStripped, false);
+
+  assert.equal(execCalls.length, 1);
+  assert.equal(execCalls[0].cmd, 'git');
+  assert.deepEqual(execCalls[0].args, [
+    'clone',
+    '--depth',
+    '1',
+    '--',
+    'https://github.com/acme/sandbox.git',
+    created,
+  ]);
+});
+
+test('provisionSandbox: passes --branch when a ref is supplied', () => {
+  const { deps, execCalls } = fakes();
+  provisionSandbox(
+    { repoUrl: 'u', ref: 'release/v2', ephemeralRoot: ROOT, depth: 3 },
+    deps,
+  );
+  assert.deepEqual(execCalls[0].args.slice(0, 6), [
+    'clone',
+    '--depth',
+    '3',
+    '--branch',
+    'release/v2',
+    '--',
+  ]);
+});
+
+test('provisionSandbox: control arm strips a present .agents/ bundle', () => {
+  const created = path.join(ROOT, `${SANDBOX_DIR_PREFIX}ctrl`);
+  const { deps, rmCalls } = fakes({
+    workspacePath: created,
+    existing: [path.join(created, '.agents')],
+  });
+  const handle = provisionSandbox(
+    { repoUrl: 'u', arm: 'control', ephemeralRoot: ROOT },
+    deps,
+  );
+  assert.equal(handle.arm, 'control');
+  assert.equal(handle.agentsStripped, true);
+  assert.equal(rmCalls.length, 1);
+  assert.equal(rmCalls[0].path, path.join(created, '.agents'));
+  assert.equal(rmCalls[0].opts.recursive, true);
+});
+
+test('provisionSandbox: control arm with no .agents/ present is a no-op strip', () => {
+  const { deps, rmCalls } = fakes({ existing: [] });
+  const handle = provisionSandbox(
+    { repoUrl: 'u', arm: 'control', ephemeralRoot: ROOT },
+    deps,
+  );
+  assert.equal(handle.agentsStripped, false);
+  assert.equal(rmCalls.length, 0);
+});
+
+test('provisionSandbox: a failed clone cleans up the partial workspace and rethrows', () => {
+  const created = path.join(ROOT, `${SANDBOX_DIR_PREFIX}fail`);
+  const { deps, rmCalls } = fakes({
+    workspacePath: created,
+    cloneThrows: true,
+    existing: [created], // the partial dir exists and must be swept
+  });
+  assert.throws(
+    () => provisionSandbox({ repoUrl: 'u', ephemeralRoot: ROOT }, deps),
+    /git clone failed/,
+  );
+  // Cleanup must target only the (contained) partial workspace.
+  assert.equal(rmCalls.length, 1);
+  assert.equal(rmCalls[0].path, created);
+});
+
+test('provisionSandbox: rejects empty repoUrl and bad arm', () => {
+  const { deps } = fakes();
+  assert.throws(
+    () => provisionSandbox({ repoUrl: '', ephemeralRoot: ROOT }, deps),
+    /non-empty repoUrl/,
+  );
+  assert.throws(
+    () =>
+      provisionSandbox(
+        { repoUrl: 'u', arm: 'nope', ephemeralRoot: ROOT },
+        deps,
+      ),
+    /must be "mandrel" or "control"/,
+  );
+});
+
+// ---------------------------------------------------------------------------
+// teardownSandbox — strict-scoping safety
+// ---------------------------------------------------------------------------
+
+test('teardownSandbox: removes the workspace when it is inside the root', () => {
+  const ws = path.join(ROOT, `${SANDBOX_DIR_PREFIX}live`);
+  const { deps, rmCalls } = fakes({ existing: [ws] });
+  const res = teardownSandbox({ workspacePath: ws, ephemeralRoot: ROOT }, deps);
+  assert.equal(res.removed, true);
+  assert.equal(res.workspacePath, ws);
+  assert.equal(rmCalls.length, 1);
+  assert.equal(rmCalls[0].path, ws);
+  assert.equal(rmCalls[0].opts.recursive, true);
+});
+
+test('teardownSandbox: REFUSES to remove a path outside the ephemeral root', () => {
+  const { deps, rmCalls } = fakes({ existing: ['/Users/me/real-mandrel'] });
+  assert.throws(
+    () =>
+      teardownSandbox(
+        { workspacePath: '/Users/me/real-mandrel', ephemeralRoot: ROOT },
+        deps,
+      ),
+    /resolves outside the ephemeral sandbox root/,
+  );
+  // Critically: nothing was deleted.
+  assert.equal(rmCalls.length, 0);
+});
+
+test('teardownSandbox: REFUSES when workspace equals the root (would nuke the root)', () => {
+  const { deps, rmCalls } = fakes({ existing: [ROOT] });
+  assert.throws(
+    () => teardownSandbox({ workspacePath: ROOT, ephemeralRoot: ROOT }, deps),
+    /resolves outside/,
+  );
+  assert.equal(rmCalls.length, 0);
+});
+
+test('teardownSandbox: REFUSES a ../ escape even if the path "exists"', () => {
+  const escapePath = path.join(ROOT, '..', '..', 'etc');
+  const { deps, rmCalls } = fakes({ existing: [path.resolve(escapePath)] });
+  assert.throws(
+    () =>
+      teardownSandbox({ workspacePath: escapePath, ephemeralRoot: ROOT }, deps),
+    /resolves outside/,
+  );
+  assert.equal(rmCalls.length, 0);
+});
+
+test('teardownSandbox: no-op when the workspace is already gone', () => {
+  const ws = path.join(ROOT, `${SANDBOX_DIR_PREFIX}gone`);
+  const { deps, rmCalls } = fakes({ existing: [] });
+  const res = teardownSandbox({ workspacePath: ws, ephemeralRoot: ROOT }, deps);
+  assert.equal(res.removed, false);
+  assert.equal(rmCalls.length, 0);
+});
+
+test('teardownSandbox: refuses to remove a non-directory target', () => {
+  const ws = path.join(ROOT, `${SANDBOX_DIR_PREFIX}file`);
+  const { deps, rmCalls } = fakes({ existing: [ws], notADir: true });
+  assert.throws(
+    () => teardownSandbox({ workspacePath: ws, ephemeralRoot: ROOT }, deps),
+    /not a directory/,
+  );
+  assert.equal(rmCalls.length, 0);
+});
+
+test('teardownSandbox: rejects a malformed handle', () => {
+  assert.throws(() => teardownSandbox(null, {}), /requires a sandbox handle/);
+  assert.throws(
+    () => teardownSandbox({ ephemeralRoot: ROOT }, {}),
+    /requires workspacePath/,
+  );
+  assert.throws(
+    () => teardownSandbox({ workspacePath: '/tmp/x' }, {}),
+    /requires ephemeralRoot/,
+  );
+});
+
+// ---------------------------------------------------------------------------
+// withSandbox — teardown is guaranteed
+// ---------------------------------------------------------------------------
+
+test('withSandbox: runs the body then tears down', async () => {
+  const created = path.join(ROOT, `${SANDBOX_DIR_PREFIX}with`);
+  const { deps, rmCalls } = fakes({
+    workspacePath: created,
+    existing: [created],
+  });
+  let sawHandle = null;
+  const result = await withSandbox(
+    { repoUrl: 'u', ephemeralRoot: ROOT },
+    (handle) => {
+      sawHandle = handle;
+      return 'body-result';
+    },
+    { provision: deps, teardown: deps },
+  );
+  assert.equal(result, 'body-result');
+  assert.equal(sawHandle.workspacePath, created);
+  assert.equal(rmCalls.length, 1);
+  assert.equal(rmCalls[0].path, created);
+});
+
+test('withSandbox: tears down even when the body throws', async () => {
+  const created = path.join(ROOT, `${SANDBOX_DIR_PREFIX}boom`);
+  const { deps, rmCalls } = fakes({
+    workspacePath: created,
+    existing: [created],
+  });
+  await assert.rejects(
+    withSandbox(
+      { repoUrl: 'u', ephemeralRoot: ROOT },
+      () => {
+        throw new Error('body exploded');
+      },
+      { provision: deps, teardown: deps },
+    ),
+    /body exploded/,
+  );
+  // Teardown still happened.
+  assert.equal(rmCalls.length, 1);
+  assert.equal(rmCalls[0].path, created);
+});

--- a/tests/bench/metrics/variance.test.js
+++ b/tests/bench/metrics/variance.test.js
@@ -1,0 +1,226 @@
+// tests/bench/metrics/variance.test.js
+//
+// Unit tier (pure logic, no I/O) for the benchmark noise-band method
+// (Epic #4211, Story #4215). Exercises bench/metrics/variance.js: both band
+// methods (median+IQR and mean+95%CI), the statistical primitives, input
+// filtering, immutability, and error handling.
+
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import {
+  finiteNumbers,
+  mean,
+  median,
+  noiseBand,
+  percentile,
+  sampleStdDev,
+  tCritical95,
+} from '../../../bench/metrics/variance.js';
+
+const approx = (actual, expected, eps = 1e-9) =>
+  assert.ok(
+    Math.abs(actual - expected) <= eps,
+    `expected ${actual} ≈ ${expected} (±${eps})`,
+  );
+
+describe('variance primitives', () => {
+  it('percentile uses linear interpolation (type-7 estimator)', () => {
+    const sorted = [1, 2, 3, 4]; // already sorted
+    approx(percentile(sorted, 0), 1);
+    approx(percentile(sorted, 1), 4);
+    approx(percentile(sorted, 0.5), 2.5);
+    // rank = 0.25 * 3 = 0.75 → 1 + (2-1)*0.75 = 1.75
+    approx(percentile(sorted, 0.25), 1.75);
+    // rank = 0.75 * 3 = 2.25 → 3 + (4-3)*0.25 = 3.25
+    approx(percentile(sorted, 0.75), 3.25);
+  });
+
+  it('percentile of a single value returns that value', () => {
+    approx(percentile([42], 0.5), 42);
+    approx(percentile([42], 0), 42);
+    approx(percentile([42], 1), 42);
+  });
+
+  it('median handles odd and even lengths', () => {
+    approx(median([1, 2, 3]), 2);
+    approx(median([1, 2, 3, 4]), 2.5);
+  });
+
+  it('mean is the arithmetic average', () => {
+    approx(mean([2, 4, 6]), 4);
+    approx(mean([5]), 5);
+  });
+
+  it('sampleStdDev is Bessel-corrected and 0 for a single value', () => {
+    // values [2,4,4,4,5,5,7,9], known sample sd = 2.13808...
+    const vals = [2, 4, 4, 4, 5, 5, 7, 9];
+    const m = mean(vals);
+    approx(sampleStdDev(vals, m), 2.138089935299395, 1e-9);
+    approx(sampleStdDev([5], 5), 0);
+  });
+
+  it('tCritical95 matches standard t-table values', () => {
+    approx(tCritical95(1), 12.706, 1e-3);
+    approx(tCritical95(7), 2.365, 1e-3);
+    approx(tCritical95(9), 2.262, 1e-3);
+    approx(tCritical95(30), 2.042, 1e-3);
+  });
+
+  it('tCritical95 falls back to the asymptotic expansion off-table', () => {
+    // df=50 is not in the table; should sit between the df=40 and df=60
+    // table entries (2.021 and 2.000) and near the true ~2.009.
+    const t50 = tCritical95(50);
+    assert.ok(t50 < 2.021 && t50 > 2.0, `t(50)=${t50} should be ~2.009`);
+    approx(t50, 2.009, 5e-3);
+  });
+
+  it('finiteNumbers drops non-finite and non-number entries', () => {
+    const input = [
+      1,
+      '2',
+      null,
+      undefined,
+      Number.NaN,
+      Number.POSITIVE_INFINITY,
+      Number.NEGATIVE_INFINITY,
+      3.5,
+      0,
+    ];
+    assert.deepEqual(finiteNumbers(input), [1, 3.5, 0]);
+  });
+});
+
+describe('noiseBand — iqr (default)', () => {
+  it('defaults to the iqr method', () => {
+    const band = noiseBand([1, 2, 3, 4, 5]);
+    assert.equal(band.method, 'iqr');
+  });
+
+  it('reports median center, quartiles, and clamped Tukey fences', () => {
+    const values = [10, 12, 14, 16, 18, 20, 22, 24];
+    const band = noiseBand(values, { method: 'iqr' });
+    assert.equal(band.n, 8);
+    approx(band.center, 17); // median of 8 symmetric values
+    // Q1 (p=.25, rank=1.75) = 12 + (14-12)*.75 = 13.5
+    // Q3 (p=.75, rank=5.25) = 20 + (22-20)*.25 = 20.5
+    approx(band.detail.q1, 13.5);
+    approx(band.detail.q3, 20.5);
+    approx(band.detail.iqr, 7);
+    // fences: Q1-1.5*7 = 3 (clamp to min 10), Q3+1.5*7 = 31 (clamp to max 24)
+    approx(band.low, 10);
+    approx(band.high, 24);
+    approx(band.spread, 14);
+    approx(band.detail.min, 10);
+    approx(band.detail.max, 24);
+  });
+
+  it('does not clamp when an outlier pushes a fence past the inner quartiles but within range', () => {
+    // tightly clustered with one high outlier; the upper fence stays below
+    // the outlier so it is flagged as out-of-band.
+    const values = [10, 10, 11, 11, 12, 12, 13, 100];
+    const band = noiseBand(values, { method: 'iqr' });
+    assert.ok(
+      band.high < 100,
+      `upper fence ${band.high} should exclude the 100 outlier`,
+    );
+    assert.ok(band.center >= 10 && band.center <= 13);
+  });
+
+  it('handles a single value with a zero-width band', () => {
+    const band = noiseBand([7]);
+    assert.equal(band.n, 1);
+    approx(band.center, 7);
+    approx(band.low, 7);
+    approx(band.high, 7);
+    approx(band.spread, 0);
+  });
+
+  it('filters non-finite values before computing', () => {
+    const band = noiseBand([5, Number.NaN, '99', null, 5, 5]);
+    assert.equal(band.n, 3);
+    approx(band.center, 5);
+    approx(band.spread, 0);
+  });
+});
+
+describe('noiseBand — ci', () => {
+  it('reports mean center and a symmetric t-based interval', () => {
+    const values = [2, 4, 4, 4, 5, 5, 7, 9];
+    const band = noiseBand(values, { method: 'ci' });
+    assert.equal(band.method, 'ci');
+    assert.equal(band.n, 8);
+    approx(band.center, 5); // mean
+    approx(band.detail.mean, 5);
+    approx(band.detail.stdDev, 2.138089935299395, 1e-9);
+    // sem = sd/sqrt(8) = 0.755928...; t(7)=2.365; margin = 1.78777...
+    approx(band.detail.stdError, 0.7559289460184544, 1e-9);
+    approx(band.detail.tCritical, 2.365, 1e-3);
+    approx(band.detail.margin, 1.78777, 1e-3);
+    approx(band.low, 5 - 1.78777, 1e-3);
+    approx(band.high, 5 + 1.78777, 1e-3);
+    approx(band.spread, 2 * 1.78777, 1e-3);
+    assert.equal(band.detail.confidence, 0.95);
+  });
+
+  it('is symmetric about the mean', () => {
+    const band = noiseBand([10, 20, 30, 40, 50], { method: 'ci' });
+    approx(band.center, 30);
+    approx((band.low + band.high) / 2, band.center, 1e-9);
+  });
+
+  it('yields a zero-width band for a single value', () => {
+    const band = noiseBand([42], { method: 'ci' });
+    assert.equal(band.n, 1);
+    approx(band.center, 42);
+    approx(band.spread, 0);
+    approx(band.detail.stdError, 0);
+    approx(band.detail.tCritical, 0);
+  });
+});
+
+describe('noiseBand — immutability and contract', () => {
+  it('never mutates the caller array', () => {
+    const values = [5, 3, 1, 4, 2];
+    const snapshot = values.slice();
+    noiseBand(values, { method: 'iqr' });
+    noiseBand(values, { method: 'ci' });
+    assert.deepEqual(values, snapshot);
+  });
+
+  it('returns a frozen band object', () => {
+    const band = noiseBand([1, 2, 3]);
+    assert.ok(Object.isFrozen(band));
+    assert.ok(Object.isFrozen(band.detail));
+  });
+
+  it('always reports low <= center <= high', () => {
+    for (const method of ['iqr', 'ci']) {
+      const band = noiseBand([3, 1, 9, 4, 2, 8, 5], { method });
+      assert.ok(
+        band.low <= band.center && band.center <= band.high,
+        `${method}: ${band.low} <= ${band.center} <= ${band.high}`,
+      );
+      approx(band.spread, band.high - band.low, 1e-9);
+    }
+  });
+});
+
+describe('noiseBand — error handling', () => {
+  it('throws TypeError when values is not an array', () => {
+    assert.throws(() => noiseBand('nope'), TypeError);
+    assert.throws(() => noiseBand(undefined), TypeError);
+    assert.throws(() => noiseBand({ length: 3 }), TypeError);
+  });
+
+  it('throws RangeError when no finite values remain', () => {
+    assert.throws(() => noiseBand([]), RangeError);
+    assert.throws(
+      () => noiseBand([Number.NaN, '1', null, Number.POSITIVE_INFINITY]),
+      RangeError,
+    );
+  });
+
+  it('throws RangeError on an unknown method', () => {
+    assert.throws(() => noiseBand([1, 2, 3], { method: 'stddev' }), RangeError);
+  });
+});

--- a/tests/bench/report/compare.test.js
+++ b/tests/bench/report/compare.test.js
@@ -1,0 +1,258 @@
+// tests/bench/report/compare.test.js
+//
+// Unit tier (pure logic, no I/O) for the cross-run comparison
+// (Epic #4211, Story #4218). Exercises bench/report/compare.js against the
+// Story's binding acceptance item:
+//   "surfaces the per-dimension deltas between two stored runs."
+// Covers: per-dimension Mandrel-arm shift with the real-delta rule
+// (improved / regressed / within-noise / incomparable), cohort-mismatch
+// flagging, scenario presence in only one run, and the Markdown rendering.
+
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import {
+  compareRuns,
+  renderComparison,
+} from '../../../bench/report/compare.js';
+
+const MODEL = { id: 'claude-opus-4-8[1m]' };
+const ENV = { node: 'v24.16.0', os: 'darwin' };
+
+function card({
+  scenario = 'hello-world',
+  arm = 'mandrel',
+  runId = `${scenario}-${arm}-r1`,
+  quality = 1,
+  planningFidelity = 0.9,
+  autonomy = 1,
+  tokenRatio = 4,
+  wallClockMs = 600000,
+  totalTokens = 180000,
+  dispatches = 2,
+  costUsd = 1.4,
+  frameworkVersion = '1.70.0',
+  model = MODEL,
+  env = ENV,
+} = {}) {
+  return {
+    schemaVersion: 1,
+    runId,
+    timestamp: '2026-06-16T19:42:11.000Z',
+    model,
+    frameworkVersion,
+    env,
+    scenario,
+    arm,
+    dimensions: {
+      quality: { score: quality, frozenSuitePassRate: quality },
+      planningFidelity: { score: arm === 'control' ? null : planningFidelity },
+      autonomy: {
+        score: autonomy,
+        hitlStops: 0,
+        blockedEvents: 0,
+        manualRescues: 0,
+      },
+      overheadRatio: { tokenRatio },
+      efficiency: { wallClockMs, totalTokens, dispatches, costUsd },
+    },
+  };
+}
+
+/** A run of N mandrel hello-world cards at a given quality center. */
+function run({ quality, totalTokens = 180000, fw = '1.70.0', n = 4 } = {}) {
+  const cards = [];
+  for (let i = 0; i < n; i += 1) {
+    cards.push(
+      card({
+        scenario: 'hello-world',
+        arm: 'mandrel',
+        runId: `hw-m-${fw}-${i}`,
+        quality: quality + (i % 2 === 0 ? 0.002 : -0.002),
+        totalTokens: totalTokens + i * 100,
+        frameworkVersion: fw,
+      }),
+    );
+    cards.push(
+      card({
+        scenario: 'hello-world',
+        arm: 'control',
+        runId: `hw-c-${fw}-${i}`,
+        quality: 0.5,
+        totalTokens: 40000,
+        tokenRatio: 0.1,
+        frameworkVersion: fw,
+      }),
+    );
+  }
+  return cards;
+}
+
+describe('compareRuns — per-dimension cross-run deltas', () => {
+  it('flags a real quality improvement when the candidate center clears the noise', () => {
+    const baseline = run({ quality: 0.6 });
+    const candidate = run({ quality: 0.95 });
+    const cmp = compareRuns({ baseline, candidate });
+    const hw = cmp.scenarios.find((s) => s.scenario === 'hello-world');
+    const quality = hw.metrics.find((m) => m.metric === 'quality');
+    assert.equal(quality.mandrel.comparable, true);
+    assert.equal(quality.mandrel.verdict, 'improved');
+    assert.ok(quality.mandrel.shift > 0);
+    assert.ok(Math.abs(quality.mandrel.shift) > quality.mandrel.noiseFloor);
+  });
+
+  it('flags a real regression when the candidate quality center drops', () => {
+    const baseline = run({ quality: 0.95 });
+    const candidate = run({ quality: 0.6 });
+    const cmp = compareRuns({ baseline, candidate });
+    const quality = cmp.scenarios[0].metrics.find(
+      (m) => m.metric === 'quality',
+    );
+    assert.equal(quality.mandrel.verdict, 'regressed');
+    assert.ok(quality.mandrel.shift < 0);
+  });
+
+  it('treats overheadRatio as lower-is-better (a drop is an improvement)', () => {
+    const baseline = [];
+    const candidate = [];
+    for (let i = 0; i < 4; i += 1) {
+      baseline.push(
+        card({ runId: `b-${i}`, tokenRatio: 4.0 + (i % 2 ? 0.01 : -0.01) }),
+      );
+      candidate.push(
+        card({ runId: `c-${i}`, tokenRatio: 1.0 + (i % 2 ? 0.01 : -0.01) }),
+      );
+    }
+    const cmp = compareRuns({ baseline, candidate });
+    const overhead = cmp.scenarios[0].metrics.find(
+      (m) => m.metric === 'overheadRatio',
+    );
+    assert.equal(overhead.mandrel.verdict, 'improved'); // ratio fell
+    assert.ok(overhead.mandrel.shift < 0);
+  });
+
+  it('reports a hair-thin shift inside the band as within-noise', () => {
+    // Wide spread, nearly-identical centers ⇒ within noise.
+    const wide = (rid, fw) => [
+      card({ runId: `${rid}-0`, quality: 0.4, frameworkVersion: fw }),
+      card({ runId: `${rid}-1`, quality: 1.0, frameworkVersion: fw }),
+      card({ runId: `${rid}-2`, quality: 0.5, frameworkVersion: fw }),
+      card({ runId: `${rid}-3`, quality: 0.95, frameworkVersion: fw }),
+    ];
+    const cmp = compareRuns({
+      baseline: wide('b', '1.70.0'),
+      candidate: wide('c', '1.70.0'),
+    });
+    const quality = cmp.scenarios[0].metrics.find(
+      (m) => m.metric === 'quality',
+    );
+    assert.equal(quality.mandrel.verdict, 'within-noise');
+    assert.equal(quality.mandrel.shiftIsReal, false);
+  });
+
+  it('surfaces both arms’ centers for traceability', () => {
+    const cmp = compareRuns({
+      baseline: run({ quality: 0.6 }),
+      candidate: run({ quality: 0.9 }),
+    });
+    const quality = cmp.scenarios[0].metrics.find(
+      (m) => m.metric === 'quality',
+    );
+    assert.ok(typeof quality.controlBaselineCenter === 'number');
+    assert.ok(typeof quality.controlCandidateCenter === 'number');
+  });
+
+  it('includes every comparable metric (4 dimensions + 4 efficiency components)', () => {
+    const cmp = compareRuns({
+      baseline: run({ quality: 0.9 }),
+      candidate: run({ quality: 0.9 }),
+    });
+    const metricNames = cmp.scenarios[0].metrics.map((m) => m.metric);
+    assert.equal(metricNames.length, 8);
+    assert.ok(metricNames.includes('quality'));
+    assert.ok(metricNames.includes('efficiency.totalTokens'));
+    assert.ok(metricNames.includes('efficiency.costUsd'));
+  });
+});
+
+describe('compareRuns — cohort safety', () => {
+  it('matches cohorts when both runs share one (model, fw, env)', () => {
+    const cmp = compareRuns({
+      baseline: run({ quality: 0.9, fw: '1.70.0' }),
+      candidate: run({ quality: 0.9, fw: '1.70.0' }),
+    });
+    assert.equal(cmp.cohortMatch, true);
+    assert.equal(cmp.cohortMismatchWarning, undefined);
+  });
+
+  it('flags (does not throw on) a cross-cohort comparison', () => {
+    const cmp = compareRuns({
+      baseline: run({ quality: 0.9, fw: '1.70.0' }),
+      candidate: run({ quality: 0.9, fw: '1.71.0' }),
+    });
+    assert.equal(cmp.cohortMatch, false);
+    assert.match(cmp.cohortMismatchWarning, /not strictly like-to-like/);
+  });
+
+  it('throws on non-array inputs', () => {
+    assert.throws(
+      () => compareRuns({ baseline: null, candidate: [] }),
+      TypeError,
+    );
+  });
+});
+
+describe('compareRuns — scenario presence', () => {
+  it('marks a scenario present in only one run as not cross-comparable', () => {
+    const baseline = run({ quality: 0.9 }); // hello-world only
+    const candidate = [
+      ...run({ quality: 0.9 }),
+      card({
+        scenario: 'crud-db',
+        arm: 'mandrel',
+        runId: 'crud-m',
+        quality: 0.8,
+      }),
+    ];
+    const cmp = compareRuns({ baseline, candidate });
+    const crud = cmp.scenarios.find((s) => s.scenario === 'crud-db');
+    assert.equal(crud.inBaseline, false);
+    assert.equal(crud.inCandidate, true);
+  });
+});
+
+describe('renderComparison — Markdown', () => {
+  it('renders the cohort line and a per-scenario delta table', () => {
+    const cmp = compareRuns({
+      baseline: run({ quality: 0.6 }),
+      candidate: run({ quality: 0.95 }),
+    });
+    const md = renderComparison(cmp, {
+      baselineLabel: 'v1.70.0',
+      candidateLabel: 'v1.71.0',
+    });
+    assert.match(md, /Cross-run comparison/);
+    assert.match(md, /v1\.70\.0/);
+    assert.match(md, /v1\.71\.0/);
+    assert.match(md, /Scenario: `hello-world`/);
+    assert.match(md, /improved/);
+    assert.match(md, /Cohort:.*matched/);
+  });
+
+  it('renders the cohort-mismatch warning in the Markdown', () => {
+    const cmp = compareRuns({
+      baseline: run({ quality: 0.9, fw: '1.70.0' }),
+      candidate: run({ quality: 0.9, fw: '1.71.0' }),
+    });
+    const md = renderComparison(cmp);
+    assert.match(md, /Cohort mismatch/);
+  });
+
+  it('is deterministic', () => {
+    const cmp = compareRuns({
+      baseline: run({ quality: 0.6 }),
+      candidate: run({ quality: 0.95 }),
+    });
+    assert.equal(renderComparison(cmp), renderComparison(cmp));
+  });
+});

--- a/tests/bench/report/persist.test.js
+++ b/tests/bench/report/persist.test.js
@@ -1,0 +1,294 @@
+// tests/bench/report/persist.test.js
+//
+// Unit tier (pure logic + injected I/O, no real disk) for the append-only
+// scorecard store (Epic #4211, Story #4218). Exercises bench/report/persist.js
+// against the Story's binding acceptance item:
+//   "writes each scorecard stamped with model, framework-version, and env to a
+//    stable append-only store."
+// Covers: stamp validation, NDJSON serialization round-trip, append-only
+// semantics (never rewrites), directory creation, cohort grouping, and the
+// rejection of un-stamped / wrong-version records.
+
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import {
+  appendScorecards,
+  cohortKey,
+  groupByCohort,
+  missingStampFields,
+  parseStore,
+  readStore,
+  serializeScorecards,
+} from '../../../bench/report/persist.js';
+
+const MODEL = { id: 'claude-opus-4-8[1m]' };
+const ENV = { node: 'v24.16.0', os: 'darwin' };
+
+function card(overrides = {}) {
+  return {
+    schemaVersion: 1,
+    runId: 'hw-m-r1',
+    timestamp: '2026-06-16T19:42:11.000Z',
+    model: MODEL,
+    frameworkVersion: '1.70.0',
+    env: ENV,
+    scenario: 'hello-world',
+    arm: 'mandrel',
+    dimensions: {
+      quality: { score: 1, frozenSuitePassRate: 1 },
+      planningFidelity: { score: 0.9 },
+      autonomy: { score: 1, hitlStops: 0, blockedEvents: 0, manualRescues: 0 },
+      efficiency: { wallClockMs: 600000, totalTokens: 180000, dispatches: 2 },
+      overheadRatio: { tokenRatio: 4.2 },
+    },
+    ...overrides,
+  };
+}
+
+/**
+ * In-memory filesystem double: a Map of path → contents, with append/read/
+ * exists/mkdir shims that record what was written.
+ */
+function fakeFs(initial = {}) {
+  const files = new Map(Object.entries(initial));
+  const dirs = new Set();
+  return {
+    files,
+    dirs,
+    appendFileImpl(path, data) {
+      files.set(path, (files.get(path) ?? '') + data);
+    },
+    existsImpl(path) {
+      return files.has(path) || dirs.has(path);
+    },
+    mkdirImpl(path) {
+      dirs.add(path);
+    },
+    readFileImpl(path) {
+      if (!files.has(path)) throw new Error(`ENOENT: ${path}`);
+      return files.get(path);
+    },
+  };
+}
+
+describe('missingStampFields', () => {
+  it('returns empty for a fully-stamped scorecard', () => {
+    assert.deepEqual(missingStampFields(card()), []);
+  });
+
+  it('lists every missing stamp field', () => {
+    const bare = { dimensions: {} };
+    const missing = missingStampFields(bare);
+    assert.ok(missing.includes('model.id'));
+    assert.ok(missing.includes('frameworkVersion'));
+    assert.ok(missing.includes('env.node'));
+    assert.ok(missing.includes('env.os'));
+    assert.ok(missing.includes('runId'));
+  });
+
+  it('flags a partial stamp (missing env.os only)', () => {
+    const sc = card({ env: { node: 'v24.16.0' } });
+    assert.deepEqual(missingStampFields(sc), ['env.os']);
+  });
+});
+
+describe('cohortKey', () => {
+  it('builds a stable model|fw|node|os key', () => {
+    assert.equal(
+      cohortKey(card()),
+      'claude-opus-4-8[1m]|1.70.0|v24.16.0|darwin',
+    );
+  });
+
+  it('keys differ when the framework version differs', () => {
+    assert.notEqual(
+      cohortKey(card({ frameworkVersion: '1.70.0' })),
+      cohortKey(card({ frameworkVersion: '1.71.0' })),
+    );
+  });
+});
+
+describe('serializeScorecards', () => {
+  it('serializes one record per line ending in a single newline', () => {
+    const block = serializeScorecards([
+      card({ runId: 'a' }),
+      card({ runId: 'b' }),
+    ]);
+    const lines = block.split('\n').filter((l) => l.length > 0);
+    assert.equal(lines.length, 2);
+    assert.ok(block.endsWith('\n'));
+    assert.equal(JSON.parse(lines[0]).runId, 'a');
+  });
+
+  it('stamps schemaVersion when the caller omitted it', () => {
+    const { schemaVersion, ...noVersion } = card();
+    void schemaVersion;
+    const block = serializeScorecards([noVersion]);
+    assert.equal(JSON.parse(block.trim()).schemaVersion, 1);
+  });
+
+  it('rejects an un-stamped scorecard (never persists incomparable data)', () => {
+    assert.throws(
+      () => serializeScorecards([{ dimensions: {} }]),
+      /missing required stamp field/,
+    );
+  });
+
+  it('rejects a scorecard with an unexpected schemaVersion', () => {
+    assert.throws(
+      () => serializeScorecards([card({ schemaVersion: 2 })]),
+      /schemaVersion 2, expected 1/,
+    );
+  });
+
+  it('returns an empty string for an empty batch', () => {
+    assert.equal(serializeScorecards([]), '');
+  });
+
+  it('throws on a non-array', () => {
+    assert.throws(() => serializeScorecards(null), TypeError);
+  });
+});
+
+describe('parseStore', () => {
+  it('round-trips serialized records', () => {
+    const block = serializeScorecards([
+      card({ runId: 'a' }),
+      card({ runId: 'b' }),
+    ]);
+    const parsed = parseStore(block);
+    assert.equal(parsed.length, 2);
+    assert.equal(parsed[1].runId, 'b');
+  });
+
+  it('skips blank lines', () => {
+    assert.equal(parseStore('\n\n').length, 0);
+  });
+
+  it('throws with a line number on malformed JSON', () => {
+    assert.throws(() => parseStore('{ok:1}'), /line 1/);
+  });
+});
+
+describe('appendScorecards — append-only store', () => {
+  it('writes a batch and reports the count + bytes', () => {
+    const fs = fakeFs();
+    const res = appendScorecards(
+      {
+        storePath: 'temp/bench/store.ndjson',
+        scorecards: [card({ runId: 'a' })],
+      },
+      fs,
+    );
+    assert.equal(res.appended, 1);
+    assert.ok(res.bytesAppended > 0);
+    assert.equal(parseStore(fs.files.get('temp/bench/store.ndjson')).length, 1);
+  });
+
+  it('creates the parent directory on first write', () => {
+    const fs = fakeFs();
+    appendScorecards(
+      { storePath: 'temp/bench/nested/store.ndjson', scorecards: [card()] },
+      fs,
+    );
+    assert.ok(fs.dirs.has('temp/bench/nested'));
+  });
+
+  it('APPENDS to an existing store rather than rewriting it', () => {
+    const fs = fakeFs();
+    appendScorecards(
+      { storePath: 's.ndjson', scorecards: [card({ runId: 'first' })] },
+      fs,
+    );
+    appendScorecards(
+      { storePath: 's.ndjson', scorecards: [card({ runId: 'second' })] },
+      fs,
+    );
+    const all = parseStore(fs.files.get('s.ndjson'));
+    assert.equal(all.length, 2);
+    assert.deepEqual(
+      all.map((r) => r.runId),
+      ['first', 'second'],
+    );
+  });
+
+  it('rejects the whole batch atomically when one record is un-stamped', () => {
+    const fs = fakeFs();
+    assert.throws(
+      () =>
+        appendScorecards(
+          {
+            storePath: 's.ndjson',
+            scorecards: [card({ runId: 'ok' }), { dimensions: {} }],
+          },
+          fs,
+        ),
+      /missing required stamp field/,
+    );
+    // Nothing was written — the bad batch never touched the file.
+    assert.equal(fs.files.has('s.ndjson'), false);
+  });
+
+  it('is a no-op for an empty batch', () => {
+    const fs = fakeFs();
+    const res = appendScorecards({ storePath: 's.ndjson', scorecards: [] }, fs);
+    assert.equal(res.appended, 0);
+    assert.equal(fs.files.has('s.ndjson'), false);
+  });
+
+  it('throws without a storePath', () => {
+    assert.throws(() => appendScorecards({ scorecards: [] }), TypeError);
+  });
+});
+
+describe('readStore', () => {
+  it('reads every persisted scorecard back', () => {
+    const fs = fakeFs();
+    appendScorecards(
+      {
+        storePath: 's.ndjson',
+        scorecards: [card({ runId: 'a' }), card({ runId: 'b' })],
+      },
+      fs,
+    );
+    const back = readStore({ storePath: 's.ndjson' }, fs);
+    assert.equal(back.length, 2);
+    assert.equal(back[0].model.id, 'claude-opus-4-8[1m]');
+  });
+
+  it('reads a non-existent store as empty', () => {
+    const fs = fakeFs();
+    assert.deepEqual(readStore({ storePath: 'missing.ndjson' }, fs), []);
+  });
+});
+
+describe('groupByCohort', () => {
+  it('groups records by their (model, fw, env) cohort key', () => {
+    const records = [
+      card({ runId: 'a', frameworkVersion: '1.70.0' }),
+      card({ runId: 'b', frameworkVersion: '1.70.0' }),
+      card({ runId: 'c', frameworkVersion: '1.71.0' }),
+    ];
+    const grouped = groupByCohort(records);
+    assert.equal(grouped.size, 2);
+    const v170 = grouped.get('claude-opus-4-8[1m]|1.70.0|v24.16.0|darwin');
+    assert.equal(v170.length, 2);
+  });
+
+  it('preserves append order within a cohort', () => {
+    const grouped = groupByCohort([
+      card({ runId: 'first' }),
+      card({ runId: 'second' }),
+    ]);
+    const only = [...grouped.values()][0];
+    assert.deepEqual(
+      only.map((r) => r.runId),
+      ['first', 'second'],
+    );
+  });
+
+  it('throws on a non-array', () => {
+    assert.throws(() => groupByCohort(null), TypeError);
+  });
+});

--- a/tests/bench/report/render.test.js
+++ b/tests/bench/report/render.test.js
@@ -1,0 +1,466 @@
+// tests/bench/report/render.test.js
+//
+// Unit tier (pure logic, no I/O) for the value-add report renderer
+// (Epic #4211, Story #4218). Exercises bench/report/render.js against the
+// Story's binding acceptance items:
+//   - every dimension rendered as a distribution (a noise-band per arm),
+//   - the Mandrel-vs-bare delta and the noise-band verdict,
+//   - the per-difficulty scaling view (Efficiency + Overhead ratio, both arms),
+//   - monotonicity violations surfaced as explicit calibration warnings,
+//   - the overhead-floor estimate surfaced in Recommended improvements,
+//   - a clearly-delineated, actionable, evidence-linked Recommended
+//     improvements section.
+
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import {
+  buildReportModel,
+  deriveCohort,
+  dimensionRows,
+  groupCells,
+  recommendImprovements,
+  renderReport,
+  renderScalingView,
+} from '../../../bench/report/render.js';
+import { scoreCorpus } from '../../../bench/score/differential.js';
+
+const MODEL = { id: 'claude-opus-4-8[1m]' };
+const ENV = { node: 'v24.16.0', os: 'darwin' };
+const FW = '1.70.0';
+
+/**
+ * Build a full per-run scorecard carrying the stamp + the dimension scalars a
+ * test cares about. Defaults are benign and in-range.
+ */
+function card({
+  scenario = 'hello-world',
+  arm = 'mandrel',
+  runId = `${scenario}-${arm}-r1`,
+  quality = 1,
+  planningFidelity = 0.9,
+  autonomy = 1,
+  tokenRatio = 4,
+  wallClockMs = 600000,
+  totalTokens = 180000,
+  dispatches = 2,
+  costUsd = 1.4,
+  model = MODEL,
+  frameworkVersion = FW,
+  env = ENV,
+} = {}) {
+  return {
+    schemaVersion: 1,
+    runId,
+    timestamp: '2026-06-16T19:42:11.000Z',
+    model,
+    frameworkVersion,
+    env,
+    scenario,
+    arm,
+    dimensions: {
+      quality: { score: quality, frozenSuitePassRate: quality },
+      planningFidelity: { score: arm === 'control' ? null : planningFidelity },
+      autonomy: {
+        score: autonomy,
+        hitlStops: 0,
+        blockedEvents: 0,
+        manualRescues: 0,
+      },
+      overheadRatio: { tokenRatio },
+      efficiency: { wallClockMs, totalTokens, dispatches, costUsd },
+    },
+  };
+}
+
+/**
+ * A small but realistic corpus: two scenarios × two arms × a few runs each,
+ * shaped so monotonicity HOLDS (tokens rise, overhead ratio falls easy→hard)
+ * and Mandrel clearly beats control on quality.
+ */
+function healthyCorpus() {
+  const cards = [];
+  // hello-world: low tokens, high overhead ratio.
+  for (let i = 0; i < 4; i += 1) {
+    cards.push(
+      card({
+        scenario: 'hello-world',
+        arm: 'mandrel',
+        runId: `hw-m-${i}`,
+        quality: 1 - i * 0.005,
+        tokenRatio: 4.2,
+        totalTokens: 180000 + i * 1000,
+        costUsd: 1.4,
+      }),
+    );
+    cards.push(
+      card({
+        scenario: 'hello-world',
+        arm: 'control',
+        runId: `hw-c-${i}`,
+        quality: 0.5 + i * 0.005,
+        tokenRatio: 0.1,
+        totalTokens: 40000 + i * 500,
+        costUsd: 0.3,
+      }),
+    );
+  }
+  // crud-db: higher tokens, lower overhead ratio (amortized).
+  for (let i = 0; i < 4; i += 1) {
+    cards.push(
+      card({
+        scenario: 'crud-db',
+        arm: 'mandrel',
+        runId: `crud-m-${i}`,
+        quality: 0.95 - i * 0.005,
+        tokenRatio: 1.5,
+        totalTokens: 900000 + i * 5000,
+        costUsd: 7.0,
+      }),
+    );
+    cards.push(
+      card({
+        scenario: 'crud-db',
+        arm: 'control',
+        runId: `crud-c-${i}`,
+        quality: 0.4 + i * 0.005,
+        tokenRatio: 0.1,
+        totalTokens: 300000 + i * 2000,
+        costUsd: 2.5,
+      }),
+    );
+  }
+  return cards;
+}
+
+describe('groupCells', () => {
+  it('groups by scenario and arm, ordered by the difficulty ladder', () => {
+    const cells = groupCells(healthyCorpus());
+    assert.equal(cells.length, 2);
+    assert.equal(cells[0].scenario, 'hello-world'); // difficulty 1 first
+    assert.equal(cells[1].scenario, 'crud-db'); // difficulty 2 second
+    assert.equal(cells[0].mandrelRuns.length, 4);
+    assert.equal(cells[0].controlRuns.length, 4);
+  });
+
+  it('sorts an unknown scenario last without dropping it', () => {
+    const cells = groupCells([
+      card({ scenario: 'crud-db', runId: 'a' }),
+      card({ scenario: 'mystery', runId: 'b' }),
+      card({ scenario: 'hello-world', runId: 'c' }),
+    ]);
+    assert.deepEqual(
+      cells.map((c) => c.scenario),
+      ['hello-world', 'crud-db', 'mystery'],
+    );
+  });
+
+  it('throws on a non-array input', () => {
+    assert.throws(() => groupCells(null), TypeError);
+  });
+});
+
+describe('deriveCohort', () => {
+  it('collects the distinct stamp values and flags a single cohort as not mixed', () => {
+    const cohort = deriveCohort(healthyCorpus());
+    assert.deepEqual(cohort.models, ['claude-opus-4-8[1m]']);
+    assert.deepEqual(cohort.frameworkVersions, ['1.70.0']);
+    assert.equal(cohort.mixed, false);
+  });
+
+  it('flags a mixed cohort when stamps diverge', () => {
+    const cohort = deriveCohort([
+      card({ runId: 'a', frameworkVersion: '1.70.0' }),
+      card({ runId: 'b', frameworkVersion: '1.71.0' }),
+    ]);
+    assert.equal(cohort.mixed, true);
+    assert.equal(cohort.frameworkVersions.length, 2);
+  });
+});
+
+describe('dimensionRows — distributions per arm + delta verdict', () => {
+  it('reports a noise-band for both arms on every dimension (no bare points)', () => {
+    const cells = groupCells(healthyCorpus());
+    const corpus = scoreCorpus({
+      cells: cells.map((c) => ({
+        scenario: c.scenario,
+        difficulty: c.difficulty,
+        mandrelRuns: c.mandrelRuns,
+        controlRuns: c.controlRuns,
+      })),
+    });
+    const rows = dimensionRows(cells[0], corpus.perScenario[0], 'iqr');
+    // 4 scalar dimensions + 4 efficiency components = 8 rows.
+    assert.equal(rows.length, 8);
+    const quality = rows.find((r) => r.metric === 'quality');
+    // Both arms have a band (a distribution), not a single number.
+    assert.ok(
+      quality.mandrelBand && typeof quality.mandrelBand.center === 'number',
+    );
+    assert.ok(
+      quality.controlBand && typeof quality.controlBand.center === 'number',
+    );
+    assert.ok('low' in quality.mandrelBand && 'high' in quality.mandrelBand);
+  });
+
+  it('flags the Mandrel-vs-control quality gap as a real delta', () => {
+    const cells = groupCells(healthyCorpus());
+    const corpus = scoreCorpus({
+      cells: cells.map((c) => ({
+        scenario: c.scenario,
+        difficulty: c.difficulty,
+        mandrelRuns: c.mandrelRuns,
+        controlRuns: c.controlRuns,
+      })),
+    });
+    const rows = dimensionRows(cells[0], corpus.perScenario[0], 'iqr');
+    const quality = rows.find((r) => r.metric === 'quality');
+    assert.equal(quality.verdict, 'real');
+    assert.ok(quality.delta > 0); // mandrel − control, mandrel higher
+  });
+
+  it('marks planningFidelity incomparable when the control arm is null', () => {
+    const cells = groupCells(healthyCorpus());
+    const corpus = scoreCorpus({
+      cells: cells.map((c) => ({
+        scenario: c.scenario,
+        difficulty: c.difficulty,
+        mandrelRuns: c.mandrelRuns,
+        controlRuns: c.controlRuns,
+      })),
+    });
+    const rows = dimensionRows(cells[0], corpus.perScenario[0], 'iqr');
+    const pf = rows.find((r) => r.metric === 'planningFidelity');
+    assert.equal(pf.verdict, 'incomparable');
+    assert.equal(pf.controlBand, null); // control authored no plan
+    assert.ok(pf.mandrelBand); // mandrel still has a distribution
+  });
+});
+
+describe('renderScalingView — per-difficulty ladder', () => {
+  it('renders Efficiency + Overhead ratio across the ladder for both arms', () => {
+    const cells = groupCells(healthyCorpus());
+    const corpus = scoreCorpus({
+      cells: cells.map((c) => ({
+        scenario: c.scenario,
+        difficulty: c.difficulty,
+        mandrelRuns: c.mandrelRuns,
+        controlRuns: c.controlRuns,
+      })),
+    });
+    const md = renderScalingView(cells, corpus, 'iqr');
+    assert.match(md, /Per-difficulty scaling view/);
+    assert.match(md, /Tokens \(mandrel\)/);
+    assert.match(md, /Tokens \(control\)/);
+    assert.match(md, /Overhead ratio \(mandrel\)/);
+    assert.match(md, /Overhead ratio \(control\)/);
+    // Both rungs present.
+    assert.match(md, /hello-world/);
+    assert.match(md, /crud-db/);
+  });
+
+  it('reports monotonicity holding on a healthy corpus', () => {
+    const cells = groupCells(healthyCorpus());
+    const corpus = scoreCorpus({
+      cells: cells.map((c) => ({
+        scenario: c.scenario,
+        difficulty: c.difficulty,
+        mandrelRuns: c.mandrelRuns,
+        controlRuns: c.controlRuns,
+      })),
+    });
+    const md = renderScalingView(cells, corpus, 'iqr');
+    assert.match(md, /Monotonicity holds/);
+  });
+
+  it('surfaces a monotonicity violation as an explicit calibration warning', () => {
+    // Invert the ladder: hello-world MORE expensive than crud-db ⇒ efficiency
+    // does not rise ⇒ violation.
+    const broken = [];
+    for (let i = 0; i < 4; i += 1) {
+      broken.push(
+        card({
+          scenario: 'hello-world',
+          arm: 'mandrel',
+          runId: `hw-m-${i}`,
+          totalTokens: 900000,
+          tokenRatio: 1.0,
+        }),
+      );
+      broken.push(
+        card({
+          scenario: 'crud-db',
+          arm: 'mandrel',
+          runId: `crud-m-${i}`,
+          totalTokens: 180000, // LOWER than hello-world → violation
+          tokenRatio: 4.0, // HIGHER than hello-world → violation
+        }),
+      );
+    }
+    const cells = groupCells(broken);
+    const corpus = scoreCorpus({
+      cells: cells.map((c) => ({
+        scenario: c.scenario,
+        difficulty: c.difficulty,
+        mandrelRuns: c.mandrelRuns,
+        controlRuns: c.controlRuns,
+      })),
+    });
+    const md = renderScalingView(cells, corpus, 'iqr');
+    assert.match(md, /Calibration warning/);
+    assert.match(md, /\[calibration\]/);
+    assert.equal(corpus.difficultyMonotonicity.monotonicityHolds, false);
+  });
+});
+
+describe('recommendImprovements — actionable, evidence-linked findings', () => {
+  it('surfaces the overhead-floor estimate even when it does not trigger a recommendation', () => {
+    const corpus = scoreCorpus({
+      cells: groupCells(healthyCorpus()).map((c) => ({
+        scenario: c.scenario,
+        difficulty: c.difficulty,
+        mandrelRuns: c.mandrelRuns,
+        controlRuns: c.controlRuns,
+      })),
+    });
+    const findings = recommendImprovements(corpus);
+    const floorFinding = findings.find((f) =>
+      f.id.startsWith('overhead-floor'),
+    );
+    assert.ok(floorFinding, 'overhead floor must always be surfaced');
+    assert.match(floorFinding.evidence, /overhead floor/i);
+  });
+
+  it('recommends a ceremony-lite path when a positive floor buys no quality gain', () => {
+    // hello-world: Mandrel costs far more tokens than control, SAME quality.
+    const cards = [];
+    for (let i = 0; i < 4; i += 1) {
+      cards.push(
+        card({
+          scenario: 'hello-world',
+          arm: 'mandrel',
+          runId: `hw-m-${i}`,
+          quality: 0.9,
+          totalTokens: 200000,
+          costUsd: 1.6,
+        }),
+      );
+      cards.push(
+        card({
+          scenario: 'hello-world',
+          arm: 'control',
+          runId: `hw-c-${i}`,
+          quality: 0.9, // identical quality → no gain
+          totalTokens: 40000,
+          costUsd: 0.3,
+        }),
+      );
+    }
+    const corpus = scoreCorpus({
+      cells: groupCells(cards).map((c) => ({
+        scenario: c.scenario,
+        difficulty: c.difficulty,
+        mandrelRuns: c.mandrelRuns,
+        controlRuns: c.controlRuns,
+      })),
+    });
+    const findings = recommendImprovements(corpus);
+    const ceremonyLite = findings.find(
+      (f) => f.id === 'overhead-floor-ceremony-lite',
+    );
+    assert.ok(ceremonyLite, 'expected a ceremony-lite recommendation');
+    assert.equal(ceremonyLite.severity, 'high');
+    assert.match(ceremonyLite.action, /ceremony/i);
+  });
+
+  it('flags a real value-dimension regression where control beats mandrel', () => {
+    // crud-db: control quality clearly HIGHER than mandrel (a regression the
+    // scaffolding should not cause).
+    const cards = [];
+    for (let i = 0; i < 4; i += 1) {
+      cards.push(
+        card({
+          scenario: 'crud-db',
+          arm: 'mandrel',
+          runId: `crud-m-${i}`,
+          quality: 0.4 + i * 0.005,
+        }),
+      );
+      cards.push(
+        card({
+          scenario: 'crud-db',
+          arm: 'control',
+          runId: `crud-c-${i}`,
+          quality: 0.9 - i * 0.005,
+        }),
+      );
+    }
+    const corpus = scoreCorpus({
+      cells: groupCells(cards).map((c) => ({
+        scenario: c.scenario,
+        difficulty: c.difficulty,
+        mandrelRuns: c.mandrelRuns,
+        controlRuns: c.controlRuns,
+      })),
+    });
+    const findings = recommendImprovements(corpus);
+    const regression = findings.find((f) =>
+      f.id.startsWith('regression-crud-db-quality'),
+    );
+    assert.ok(regression, 'expected a quality regression finding');
+    assert.equal(regression.severity, 'medium');
+  });
+});
+
+describe('renderReport — full Markdown', () => {
+  it('renders every required section', () => {
+    const md = renderReport({ scorecards: healthyCorpus(), method: 'iqr' });
+    assert.match(md, /# Mandrel Self-Benchmark — Value-Add Report/);
+    assert.match(md, /## Cohort/);
+    assert.match(md, /## Dimension distributions \(Mandrel vs bare control\)/);
+    assert.match(md, /## Per-difficulty scaling view/);
+    assert.match(md, /## Recommended improvements/);
+    // Every dimension label appears.
+    assert.match(md, /Quality/);
+    assert.match(md, /Planning fidelity/);
+    assert.match(md, /Autonomy/);
+    assert.match(md, /Overhead ratio/);
+    assert.match(md, /Efficiency · total tokens/);
+  });
+
+  it('is deterministic — identical corpus renders byte-for-byte identically', () => {
+    const a = renderReport({ scorecards: healthyCorpus() });
+    const b = renderReport({ scorecards: healthyCorpus() });
+    assert.equal(a, b);
+  });
+
+  it('renders a graceful empty report for an empty corpus', () => {
+    const md = renderReport({ scorecards: [] });
+    assert.match(md, /nothing to render/i);
+    assert.match(md, /## Recommended improvements/);
+  });
+
+  it('surfaces the mixed-cohort warning in the header', () => {
+    const md = renderReport({
+      scorecards: [
+        card({ runId: 'a', frameworkVersion: '1.70.0' }),
+        card({ runId: 'b', frameworkVersion: '1.71.0' }),
+      ],
+    });
+    assert.match(md, /Mixed cohort/);
+  });
+
+  it('throws on a non-array corpus', () => {
+    assert.throws(() => renderReport({ scorecards: 'nope' }), TypeError);
+  });
+});
+
+describe('buildReportModel — structured form', () => {
+  it('returns the same findings the Markdown is built from', () => {
+    const model = buildReportModel({ scorecards: healthyCorpus() });
+    assert.equal(model.scenarios.length, 2);
+    assert.ok(Array.isArray(model.recommendations));
+    assert.ok(model.overheadFloor); // hello-world present → floor computed
+    assert.equal(model.monotonicity.monotonicityHolds, true);
+  });
+});

--- a/tests/bench/scenarios/scenario-defs.test.js
+++ b/tests/bench/scenarios/scenario-defs.test.js
@@ -1,0 +1,537 @@
+/**
+ * Contract tests for the benchmark scenario corpus and its frozen quality
+ * oracles (Story #4214).
+ *
+ * Verifies the three acceptance criteria of the Story:
+ *   1. Each scenario seed (`bench/scenarios/<id>/scenario.json`) defines the
+ *      task seed used by both arms (a prompt + the acceptance contract).
+ *   2. Each frozen oracle (`acceptance.test.js#evaluate`) asserts the
+ *      delivered app's user-visible HTTP behavior and is frozen — pure with
+ *      respect to the app (no app-internal imports), deterministic, and
+ *      structured (one verdict per criterion, in seed order).
+ *   3. The adapter (`acceptance-eval-adapter.js`) invokes the existing
+ *      acceptance-eval cross-check and returns its verdict alongside the
+ *      frozen-suite result.
+ *
+ * These are contract-tier checks: they assert the shape of the scenario
+ * assets and the wiring to the cross-check, with the HTTP boundary and the
+ * cross-check gate both injected (no real `claude`, no network, no server).
+ */
+
+import assert from 'node:assert/strict';
+import { readdirSync, readFileSync } from 'node:fs';
+import path from 'node:path';
+import { describe, it } from 'node:test';
+import { fileURLToPath } from 'node:url';
+import {
+  buildVerdictFromFrozenResult,
+  parseGateEnvelope,
+  runCrossCheckViaCli,
+  scoreScenarioQuality,
+} from '../../../bench/scenarios/acceptance-eval-adapter.js';
+import { evaluate as evaluateCrud } from '../../../bench/scenarios/crud-db/acceptance.test.js';
+import { evaluate as evaluateHello } from '../../../bench/scenarios/hello-world/acceptance.test.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const SCENARIOS_DIR = path.resolve(
+  __dirname,
+  '..',
+  '..',
+  '..',
+  'bench',
+  'scenarios',
+);
+const SCENARIO_IDS = ['hello-world', 'crud-db'];
+
+function loadScenario(id) {
+  const raw = readFileSync(
+    path.join(SCENARIOS_DIR, id, 'scenario.json'),
+    'utf8',
+  );
+  return JSON.parse(raw);
+}
+
+/**
+ * Build a stub `fetch` from an ordered list of canned responses keyed by a
+ * matcher predicate, so a frozen oracle can be driven without a server.
+ *
+ * @param {Array<{ when: (url: string, init: object) => boolean, status: number, headers?: Record<string,string>, json?: unknown, text?: string }>} routes
+ */
+function stubFetch(routes) {
+  return async (url, init = {}) => {
+    const route = routes.find((r) => r.when(String(url), init));
+    if (!route) {
+      throw new Error(`stubFetch: no route for ${init.method ?? 'GET'} ${url}`);
+    }
+    const headers = new Map(
+      Object.entries(route.headers ?? {}).map(([k, v]) => [k.toLowerCase(), v]),
+    );
+    return {
+      status: route.status,
+      headers: { get: (k) => headers.get(String(k).toLowerCase()) ?? null },
+      async text() {
+        return (
+          route.text ??
+          (route.json !== undefined ? JSON.stringify(route.json) : '')
+        );
+      },
+      async json() {
+        if (route.json === undefined) throw new Error('no json');
+        return route.json;
+      },
+    };
+  };
+}
+
+describe('scenario seeds (AC1: task seed shared by both arms)', () => {
+  it('exposes exactly the two v1 scenarios on disk', () => {
+    const dirs = readdirSync(SCENARIOS_DIR, { withFileTypes: true })
+      .filter((d) => d.isDirectory())
+      .map((d) => d.name)
+      .sort();
+    assert.deepEqual(dirs, [...SCENARIO_IDS].sort());
+  });
+
+  for (const id of SCENARIO_IDS) {
+    it(`${id}/scenario.json defines a non-empty task seed and acceptance contract`, () => {
+      const s = loadScenario(id);
+      assert.equal(s.id, id, 'id matches its directory');
+      assert.equal(typeof s.title, 'string');
+      assert.ok(s.title.length > 0, 'has a title');
+
+      // The seed is the task both arms receive — a prompt plus the
+      // acceptance contract. It must be present and non-trivial.
+      assert.ok(s.seed && typeof s.seed === 'object', 'has a seed object');
+      assert.equal(typeof s.seed.prompt, 'string');
+      assert.ok(
+        s.seed.prompt.length >= 40,
+        'seed prompt is a real task description',
+      );
+      assert.ok(
+        Array.isArray(s.seed.acceptance) && s.seed.acceptance.length > 0,
+        'seed carries the acceptance contract',
+      );
+      for (const item of s.seed.acceptance) {
+        assert.equal(typeof item, 'string');
+        assert.ok(item.length > 0);
+      }
+
+      // The seed must point at its frozen acceptance suite, and the app
+      // launch contract must be present so the harness can boot it.
+      assert.equal(s.acceptanceSuite, './acceptance.test.js');
+      assert.ok(
+        s.app && typeof s.app === 'object',
+        'declares an app launch contract',
+      );
+      assert.equal(typeof s.app.startCommand, 'string');
+      assert.equal(typeof s.app.portEnvVar, 'string');
+      assert.equal(typeof s.app.readinessPath, 'string');
+    });
+  }
+
+  it('difficulty is monotonic across the ladder (hello-world < crud-db)', () => {
+    const hello = loadScenario('hello-world');
+    const crud = loadScenario('crud-db');
+    assert.ok(
+      Number(hello.difficulty) < Number(crud.difficulty),
+      'crud-db must out-rank hello-world on difficulty for the monotonicity check',
+    );
+  });
+});
+
+describe('frozen oracles are pure w.r.t. the delivered app (AC2: frozen)', () => {
+  for (const id of SCENARIO_IDS) {
+    it(`${id}/acceptance.test.js imports nothing from the delivered app`, () => {
+      const src = readFileSync(
+        path.join(SCENARIOS_DIR, id, 'acceptance.test.js'),
+        'utf8',
+      );
+      const importRe = /^\s*import\s[^;]*from\s+['"]([^'"]+)['"]/gm;
+      const specs = [...src.matchAll(importRe)].map((m) => m[1]);
+      for (const spec of specs) {
+        // A frozen oracle may import node builtins only. Any relative or
+        // bare third-party import would couple it to app or framework
+        // internals and break the freeze.
+        assert.ok(
+          spec.startsWith('node:'),
+          `frozen oracle ${id} must import only node: builtins, found "${spec}"`,
+        );
+      }
+    });
+
+    it(`${id}/acceptance.test.js exports a frozen criteria list and an evaluate()`, async () => {
+      const mod = await import(
+        `../../../bench/scenarios/${id}/acceptance.test.js`
+      );
+      assert.equal(typeof mod.evaluate, 'function');
+      assert.ok(Array.isArray(mod.CRITERIA) && mod.CRITERIA.length > 0);
+      assert.ok(Object.isFrozen(mod.CRITERIA), 'CRITERIA is frozen');
+
+      // The oracle's criteria text matches the scenario seed exactly, so
+      // the verdict the adapter builds lines up criterion for criterion.
+      const seed = loadScenario(id);
+      assert.deepEqual([...mod.CRITERIA], seed.seed.acceptance);
+    });
+  }
+
+  it('rejects a non-string baseUrl', async () => {
+    await assert.rejects(() => evaluateHello(''), TypeError);
+    await assert.rejects(() => evaluateCrud(undefined), TypeError);
+  });
+});
+
+describe('hello-world frozen oracle behavior', () => {
+  it('passes when the delivered page returns 200 text/html with the text', async () => {
+    const fetchImpl = stubFetch([
+      {
+        when: (u) => u.endsWith('/'),
+        status: 200,
+        headers: { 'content-type': 'text/html; charset=utf-8' },
+        text: '<!doctype html><h1>Hello, World!</h1>',
+      },
+    ]);
+    const result = await evaluateHello('http://127.0.0.1:3000', { fetchImpl });
+    assert.equal(result.scenario, 'hello-world');
+    assert.equal(result.passed, true);
+    assert.equal(result.criteria.length, 3);
+    assert.ok(result.criteria.every((c) => c.met));
+    // Criteria are returned in seed order.
+    assert.deepEqual(
+      result.criteria.map((c) => c.index),
+      [0, 1, 2],
+    );
+  });
+
+  it('fails each criterion when the body lacks the text / wrong type / wrong status', async () => {
+    const fetchImpl = stubFetch([
+      {
+        when: (u) => u.endsWith('/'),
+        status: 500,
+        headers: { 'content-type': 'application/json' },
+        text: 'nope',
+      },
+    ]);
+    const result = await evaluateHello('http://127.0.0.1:3000', { fetchImpl });
+    assert.equal(result.passed, false);
+    assert.deepEqual(
+      result.criteria.map((c) => c.met),
+      [false, false, false],
+    );
+  });
+
+  it('does not throw when the app is unreachable; reports a transport failure', async () => {
+    const fetchImpl = async () => {
+      throw new Error('ECONNREFUSED');
+    };
+    const result = await evaluateHello('http://127.0.0.1:3000', { fetchImpl });
+    assert.equal(result.passed, false);
+    assert.ok(result.criteria[0].evidence.includes('ECONNREFUSED'));
+  });
+
+  it('is deterministic — identical inputs yield identical output', async () => {
+    const make = () =>
+      stubFetch([
+        {
+          when: (u) => u.endsWith('/'),
+          status: 200,
+          headers: { 'content-type': 'text/html' },
+          text: 'Hello, World!',
+        },
+      ]);
+    const a = await evaluateHello('http://h', { fetchImpl: make() });
+    const b = await evaluateHello('http://h', { fetchImpl: make() });
+    assert.deepEqual(a, b);
+  });
+});
+
+describe('crud-db frozen oracle behavior', () => {
+  // A dynamic fetch stub modelling a conforming in-memory notes backend,
+  // so the full stateful CRUD round-trip can be driven deterministically
+  // without a real server.
+  function makeCrudFetch() {
+    const store = new Map();
+    let seq = 0;
+    const send = (status, json) => ({
+      status,
+      headers: { get: () => 'application/json' },
+      async text() {
+        return json === undefined ? '' : JSON.stringify(json);
+      },
+      async json() {
+        if (json === undefined) throw new Error('no json');
+        return json;
+      },
+    });
+    return async (url, init = {}) => {
+      const u = new URL(String(url));
+      const parts = u.pathname.split('/').filter(Boolean); // ['notes'] or ['notes', ':id']
+      const method = init.method ?? 'GET';
+      const body = init.body ? JSON.parse(init.body) : undefined;
+
+      if (parts[0] !== 'notes') return send(404);
+
+      // Collection
+      if (parts.length === 1) {
+        if (method === 'POST') {
+          const okTitle =
+            typeof body?.title === 'string' && body.title.length > 0;
+          const okBody = typeof body?.body === 'string' && body.body.length > 0;
+          if (!okTitle || !okBody) return send(400, { error: 'invalid' });
+          const id = `id-${++seq}`;
+          const note = {
+            id,
+            title: body.title,
+            body: body.body,
+            createdAt: '2026-01-01T00:00:00Z',
+          };
+          store.set(id, note);
+          return send(201, note);
+        }
+        if (method === 'GET') return send(200, [...store.values()]);
+        return send(405);
+      }
+
+      // Item
+      const id = decodeURIComponent(parts[1]);
+      const existing = store.get(id);
+      if (method === 'GET')
+        return existing
+          ? send(200, existing)
+          : send(404, { error: 'not found' });
+      if (method === 'PUT') {
+        if (!existing) return send(404, { error: 'not found' });
+        const updated = { ...existing, ...(body ?? {}) };
+        store.set(id, updated);
+        return send(200, updated);
+      }
+      if (method === 'DELETE') {
+        if (!existing) return send(404);
+        store.delete(id);
+        return send(204);
+      }
+      return send(405);
+    };
+  }
+
+  it('passes the full CRUD round-trip against a conforming backend', async () => {
+    const result = await evaluateCrud('http://127.0.0.1:3000', {
+      fetchImpl: makeCrudFetch(),
+      uniqueSuffix: () => 'fixed',
+    });
+    assert.equal(result.scenario, 'crud-db');
+    assert.equal(
+      result.passed,
+      true,
+      `unmet: ${result.criteria
+        .filter((c) => !c.met)
+        .map((c) => c.evidence)
+        .join('; ')}`,
+    );
+    assert.equal(result.criteria.length, 6);
+    assert.deepEqual(
+      result.criteria.map((c) => c.index),
+      [0, 1, 2, 3, 4, 5],
+    );
+  });
+
+  it('flags the invalid-payload criterion when the backend accepts junk', async () => {
+    // A backend that returns 201 for an empty body fails criterion 5.
+    const base = makeCrudFetch();
+    const fetchImpl = async (url, init = {}) => {
+      const u = new URL(String(url));
+      const body = init.body ? JSON.parse(init.body) : undefined;
+      if (
+        u.pathname === '/notes' &&
+        init.method === 'POST' &&
+        (!body?.title || !body?.body)
+      ) {
+        // Wrongly accept invalid input.
+        return {
+          status: 201,
+          headers: { get: () => 'application/json' },
+          async text() {
+            return JSON.stringify({ id: 'x' });
+          },
+          async json() {
+            return { id: 'x' };
+          },
+        };
+      }
+      return base(url, init);
+    };
+    const result = await evaluateCrud('http://127.0.0.1:3000', {
+      fetchImpl,
+      uniqueSuffix: () => 'fixed',
+    });
+    const c5 = result.criteria.find((c) => c.index === 5);
+    assert.equal(c5.met, false);
+    assert.equal(result.passed, false);
+  });
+
+  it('does not throw when the backend is unreachable', async () => {
+    const result = await evaluateCrud('http://127.0.0.1:3000', {
+      fetchImpl: async () => {
+        throw new Error('ECONNREFUSED');
+      },
+    });
+    assert.equal(result.passed, false);
+    assert.equal(result.criteria.length, 6);
+    assert.ok(result.criteria[0].evidence.includes('ECONNREFUSED'));
+  });
+});
+
+describe('acceptance-eval cross-check adapter (AC3)', () => {
+  const frozenPass = {
+    scenario: 'hello-world',
+    passed: true,
+    criteria: [
+      { index: 0, criterion: 'a', met: true, evidence: 'ok-a' },
+      { index: 1, criterion: 'b', met: true, evidence: 'ok-b' },
+    ],
+  };
+  const frozenFail = {
+    scenario: 'hello-world',
+    passed: false,
+    criteria: [
+      { index: 0, criterion: 'a', met: true, evidence: 'ok-a' },
+      { index: 1, criterion: 'b', met: false, evidence: 'bad-b' },
+    ],
+  };
+
+  it('lifts a frozen result into a schema-valid acceptance-eval verdict', () => {
+    const verdict = buildVerdictFromFrozenResult({
+      frozenResult: frozenFail,
+      storyId: 4214,
+      epicId: 4211,
+    });
+    assert.equal(verdict.storyId, 4214);
+    assert.equal(verdict.epicId, 4211);
+    assert.equal(verdict.schemaVersion, 1);
+    assert.equal(verdict.round, 1);
+    assert.equal(verdict.criteria.length, 2);
+    assert.equal(verdict.criteria[0].verdict, 'met');
+    assert.equal(verdict.criteria[1].verdict, 'unmet');
+    assert.equal(verdict.criteria[1].evidence, 'bad-b');
+    // verify[]-as-evidence is carried so the cross-check sees the probe.
+    assert.equal(verdict.criteria[0].verifyEvidence[0].outcome, 'pass');
+    assert.equal(verdict.criteria[1].verifyEvidence[0].outcome, 'fail');
+  });
+
+  it('the lifted verdict actually validates against the real verdict schema', async () => {
+    // Use the same gate validator the production cross-check uses, so this
+    // is a genuine contract assertion, not a re-implementation.
+    const { validateVerdict } = await import(
+      '../../../.agents/scripts/acceptance-eval.js'
+    );
+    const verdict = buildVerdictFromFrozenResult({
+      frozenResult: frozenPass,
+      storyId: 4214,
+      epicId: 4211,
+    });
+    assert.doesNotThrow(() => validateVerdict(verdict));
+  });
+
+  it('invokes the existing cross-check in-process and returns its verdict alongside the frozen result', async () => {
+    // Inject the gate so we assert the wiring (the verdict reaches the
+    // gate; the gate decision reaches the caller) without exercising the
+    // gate's own decision logic here.
+    let received = null;
+    const runGateFn = async (args) => {
+      received = args;
+      return {
+        envelope: { decision: 'proceed', metCount: 2, totalCriteria: 2 },
+        exitCode: 0,
+      };
+    };
+    const out = await scoreScenarioQuality({
+      evaluate: async () => frozenPass,
+      baseUrl: 'http://127.0.0.1:3000',
+      storyId: 4214,
+      epicId: 4211,
+      transport: 'in-process',
+      runGateFn,
+    });
+    // The cross-check received the lifted verdict.
+    assert.ok(received, 'gate was invoked');
+    assert.equal(received.verdict.storyId, 4214);
+    assert.equal(
+      received.emitSignal,
+      false,
+      'benchmark probe suppresses the signal emit',
+    );
+    // The combined result carries BOTH faces of the Quality score.
+    assert.equal(out.scenario, 'hello-world');
+    assert.equal(out.frozen.passed, true);
+    assert.equal(out.crossCheck.decision, 'proceed');
+    assert.equal(out.agree, true);
+  });
+
+  it('reports disagreement when the frozen suite fails but the cross-check would proceed', async () => {
+    const runGateFn = async () => ({
+      envelope: { decision: 'proceed' },
+      exitCode: 0,
+    });
+    const out = await scoreScenarioQuality({
+      evaluate: async () => frozenFail,
+      baseUrl: 'http://127.0.0.1:3000',
+      storyId: 4214,
+      epicId: 4211,
+      transport: 'in-process',
+      runGateFn,
+    });
+    assert.equal(out.frozen.passed, false);
+    assert.equal(out.crossCheck.decision, 'proceed');
+    assert.equal(out.agree, false);
+  });
+
+  it('CLI transport spawns acceptance-eval.js with --no-signal and parses its envelope', () => {
+    let spawnArgs = null;
+    const spawnFn = (exe, args) => {
+      spawnArgs = { exe, args };
+      return {
+        status: 0,
+        stdout:
+          'some log line\n' +
+          JSON.stringify(
+            { storyId: 4214, decision: 'proceed', metCount: 2 },
+            null,
+            2,
+          ),
+      };
+    };
+    const verdict = buildVerdictFromFrozenResult({
+      frozenResult: frozenPass,
+      storyId: 4214,
+      epicId: 4211,
+    });
+    const out = runCrossCheckViaCli({
+      verdict,
+      storyId: 4214,
+      epicId: 4211,
+      spawnFn,
+    });
+    assert.ok(
+      spawnArgs.args.includes('--no-signal'),
+      'CLI probe is side-effect free',
+    );
+    assert.ok(spawnArgs.args.includes('--story'));
+    assert.ok(spawnArgs.args.includes('4214'));
+    assert.ok(spawnArgs.args.includes('--epic'));
+    assert.equal(out.decision, 'proceed');
+    assert.equal(out.exitCode, 0);
+  });
+});
+
+describe('parseGateEnvelope', () => {
+  it('extracts the trailing JSON envelope from mixed stdout', () => {
+    const stdout =
+      '[Orchestrator] noise\n' +
+      JSON.stringify({ decision: 'block', a: 1 }, null, 2);
+    assert.deepEqual(parseGateEnvelope(stdout), { decision: 'block', a: 1 });
+  });
+
+  it('returns null for empty / unparseable stdout', () => {
+    assert.equal(parseGateEnvelope(''), null);
+    assert.equal(parseGateEnvelope('not json at all'), null);
+  });
+});

--- a/tests/bench/schemas/scorecard-schema.test.js
+++ b/tests/bench/schemas/scorecard-schema.test.js
@@ -1,0 +1,170 @@
+// tests/bench/schemas/scorecard-schema.test.js
+//
+// Contract tier for the benchmark scorecard JSON schema (Epic #4211,
+// Story #4215). Proves the schema at bench/schemas/scorecard.schema.json
+// validates the committed fixture (the binding acceptance item) and that it
+// genuinely constrains the record shape — required fields, enums, ranges,
+// and additionalProperties: false all reject malformed scorecards.
+
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { describe, it } from 'node:test';
+import { fileURLToPath } from 'node:url';
+import Ajv2020 from 'ajv/dist/2020.js';
+import addFormats from 'ajv-formats';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+// tests/bench/schemas/ → repo root is three levels up.
+const REPO_ROOT = path.resolve(__dirname, '..', '..', '..');
+const SCHEMA_PATH = path.join(
+  REPO_ROOT,
+  'bench',
+  'schemas',
+  'scorecard.schema.json',
+);
+const FIXTURE_PATH = path.join(
+  REPO_ROOT,
+  'bench',
+  'fixtures',
+  'sample-scorecard.json',
+);
+
+const schema = JSON.parse(readFileSync(SCHEMA_PATH, 'utf8'));
+const fixture = JSON.parse(readFileSync(FIXTURE_PATH, 'utf8'));
+
+function buildValidator() {
+  const ajv = new Ajv2020({ allErrors: true, strict: true });
+  addFormats(ajv);
+  return ajv.compile(schema);
+}
+
+/** Deep clone so each negative case starts from a known-valid record. */
+const clone = (obj) => JSON.parse(JSON.stringify(obj));
+
+describe('scorecard schema — meta', () => {
+  it('compiles under draft 2020-12 in strict mode', () => {
+    assert.doesNotThrow(buildValidator);
+  });
+
+  it('declares the draft 2020-12 meta-schema and an $id', () => {
+    assert.equal(
+      schema.$schema,
+      'https://json-schema.org/draft/2020-12/schema',
+    );
+    assert.equal(schema.$id, 'mandrel-bench-scorecard');
+  });
+});
+
+describe('scorecard schema — validates the committed fixture', () => {
+  it('accepts bench/fixtures/sample-scorecard.json', () => {
+    const validate = buildValidator();
+    const ok = validate(fixture);
+    assert.ok(
+      ok,
+      `fixture failed validation: ${JSON.stringify(validate.errors, null, 2)}`,
+    );
+  });
+
+  it('the fixture exercises all five dimensions', () => {
+    assert.deepEqual(
+      Object.keys(fixture.dimensions).sort(),
+      [
+        'autonomy',
+        'efficiency',
+        'overheadRatio',
+        'planningFidelity',
+        'quality',
+      ].sort(),
+    );
+  });
+});
+
+describe('scorecard schema — rejects malformed records', () => {
+  const validate = buildValidator();
+
+  it('rejects a record missing a top-level required field', () => {
+    const bad = clone(fixture);
+    delete bad.dimensions;
+    assert.equal(validate(bad), false);
+  });
+
+  it('rejects a record missing one of the five dimensions', () => {
+    const bad = clone(fixture);
+    delete bad.dimensions.overheadRatio;
+    assert.equal(validate(bad), false);
+  });
+
+  it('rejects an unknown top-level property (additionalProperties: false)', () => {
+    const bad = clone(fixture);
+    bad.surpriseField = 'nope';
+    assert.equal(validate(bad), false);
+  });
+
+  it('rejects an unknown property inside a dimension', () => {
+    const bad = clone(fixture);
+    bad.dimensions.quality.extra = 1;
+    assert.equal(validate(bad), false);
+  });
+
+  it('rejects a wrong schemaVersion const', () => {
+    const bad = clone(fixture);
+    bad.schemaVersion = 2;
+    assert.equal(validate(bad), false);
+  });
+
+  it('rejects an out-of-enum scenario', () => {
+    const bad = clone(fixture);
+    bad.scenario = 'auth-flow';
+    assert.equal(validate(bad), false);
+  });
+
+  it('rejects an out-of-enum arm', () => {
+    const bad = clone(fixture);
+    bad.arm = 'baseline';
+    assert.equal(validate(bad), false);
+  });
+
+  it('rejects a quality.score above its [0,1] range', () => {
+    const bad = clone(fixture);
+    bad.dimensions.quality.score = 1.5;
+    assert.equal(validate(bad), false);
+  });
+
+  it('rejects a negative efficiency.wallClockMs', () => {
+    const bad = clone(fixture);
+    bad.dimensions.efficiency.wallClockMs = -1;
+    assert.equal(validate(bad), false);
+  });
+
+  it('rejects a non-RFC3339 timestamp', () => {
+    const bad = clone(fixture);
+    bad.timestamp = 'last tuesday';
+    assert.equal(validate(bad), false);
+  });
+
+  it('rejects a runId with whitespace (pattern violation)', () => {
+    const bad = clone(fixture);
+    bad.runId = 'run with spaces';
+    assert.equal(validate(bad), false);
+  });
+});
+
+describe('scorecard schema — control-arm nullable dimensions', () => {
+  const validate = buildValidator();
+
+  it('accepts null planningFidelity.score and null quality.acceptanceEvalScore for the control arm', () => {
+    const control = clone(fixture);
+    control.runId = 'hello-world-control-2026-06-16-r03';
+    control.arm = 'control';
+    control.dimensions.planningFidelity.score = null;
+    control.dimensions.quality.acceptanceEvalScore = null;
+    control.dimensions.efficiency.costUsd = null;
+    control.dimensions.overheadRatio.timeRatio = null;
+    const ok = validate(control);
+    assert.ok(
+      ok,
+      `control-arm record failed: ${JSON.stringify(validate.errors, null, 2)}`,
+    );
+  });
+});

--- a/tests/bench/score/differential.test.js
+++ b/tests/bench/score/differential.test.js
@@ -1,0 +1,319 @@
+// tests/bench/score/differential.test.js
+//
+// Unit tier (pure logic, no I/O) for the Mandrel-vs-control differential +
+// cross-scenario calibration metrics (Epic #4211, Story #4217). Exercises
+// bench/score/differential.js against the binding rules in
+// bench/metrics/README.md § "Real-delta rule" and § "Cross-scenario derived
+// metrics":
+//   - per-dimension delta with the real-delta rule (clears vs within-noise),
+//   - planningFidelity incomparable when control is null,
+//   - difficulty monotonicity (holds, and an explicit warning on a violation),
+//   - overhead floor estimate + the ceremony-lite recommendation flag.
+
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import {
+  computeDifferential,
+  difficultyMonotonicity,
+  overheadFloor,
+  scoreCorpus,
+} from '../../../bench/score/differential.js';
+
+const approx = (actual, expected, eps = 1e-9) =>
+  assert.ok(
+    Math.abs(actual - expected) <= eps,
+    `expected ${actual} ≈ ${expected} (±${eps})`,
+  );
+
+/**
+ * Build a minimal scorecard carrying only the dimension scalars a test needs.
+ * Missing dimensions default to benign values.
+ */
+function card({
+  quality = 1,
+  planningFidelity = 0.9,
+  autonomy = 1,
+  tokenRatio = 4,
+  wallClockMs = 600000,
+  totalTokens = 180000,
+  dispatches = 2,
+  costUsd = 1.4,
+} = {}) {
+  return {
+    dimensions: {
+      quality: { score: quality },
+      planningFidelity: { score: planningFidelity },
+      autonomy: { score: autonomy },
+      overheadRatio: { tokenRatio },
+      efficiency: { wallClockMs, totalTokens, dispatches, costUsd },
+    },
+  };
+}
+
+describe('computeDifferential — real-delta rule', () => {
+  it('flags a delta that clears the larger noise-band spread as real', () => {
+    // Mandrel quality tightly clustered near 1.0; control near 0.5. The gap
+    // (~0.5) dwarfs either arm's spread ⇒ real.
+    const mandrelRuns = [
+      card({ quality: 1.0 }),
+      card({ quality: 0.98 }),
+      card({ quality: 1.0 }),
+      card({ quality: 0.99 }),
+    ];
+    const controlRuns = [
+      card({ quality: 0.5 }),
+      card({ quality: 0.52 }),
+      card({ quality: 0.48 }),
+      card({ quality: 0.5 }),
+    ];
+    const diff = computeDifferential({ mandrelRuns, controlRuns });
+    const q = diff.dimensions.quality;
+    assert.equal(q.comparable, true);
+    assert.equal(q.verdict, 'real');
+    assert.equal(q.deltaIsReal, true);
+    assert.ok(Math.abs(q.delta) > q.noiseFloor);
+  });
+
+  it('reports a delta within the noise-band as within-noise', () => {
+    // Two heavily-overlapping clusters: centers differ by a hair, spreads are
+    // wide ⇒ within noise.
+    const mandrelRuns = [
+      card({ quality: 0.7 }),
+      card({ quality: 0.9 }),
+      card({ quality: 0.6 }),
+      card({ quality: 0.8 }),
+    ];
+    const controlRuns = [
+      card({ quality: 0.68 }),
+      card({ quality: 0.88 }),
+      card({ quality: 0.62 }),
+      card({ quality: 0.82 }),
+    ];
+    const q = computeDifferential({ mandrelRuns, controlRuns }).dimensions
+      .quality;
+    assert.equal(q.verdict, 'within-noise');
+    assert.equal(q.deltaIsReal, false);
+  });
+
+  it('marks planningFidelity incomparable when control is null', () => {
+    const mandrelRuns = [
+      card({ planningFidelity: 0.9 }),
+      card({ planningFidelity: 0.85 }),
+    ];
+    const controlRuns = [
+      card({ planningFidelity: null }),
+      card({ planningFidelity: null }),
+    ];
+    const pf = computeDifferential({ mandrelRuns, controlRuns }).dimensions
+      .planningFidelity;
+    assert.equal(pf.comparable, false);
+    assert.equal(pf.verdict, 'incomparable');
+    assert.equal(pf.deltaIsReal, false);
+    assert.equal(pf.controlCenter, null);
+  });
+
+  it('differences each efficiency component independently', () => {
+    const mandrelRuns = [
+      card({ totalTokens: 180000 }),
+      card({ totalTokens: 182000 }),
+    ];
+    const controlRuns = [
+      card({ totalTokens: 40000 }),
+      card({ totalTokens: 41000 }),
+    ];
+    const diff = computeDifferential({ mandrelRuns, controlRuns });
+    assert.ok('totalTokens' in diff.efficiency);
+    assert.ok('wallClockMs' in diff.efficiency);
+    assert.ok('dispatches' in diff.efficiency);
+    assert.ok('costUsd' in diff.efficiency);
+    assert.equal(diff.efficiency.totalTokens.metric, 'efficiency.totalTokens');
+    // 180k+ vs 40k tokens ⇒ a real gap.
+    assert.equal(diff.efficiency.totalTokens.verdict, 'real');
+  });
+
+  it('carries the band method and arm sample sizes', () => {
+    const diff = computeDifferential({
+      mandrelRuns: [card(), card(), card()],
+      controlRuns: [card(), card()],
+      method: 'ci',
+      scenario: 'crud-db',
+    });
+    assert.equal(diff.method, 'ci');
+    assert.equal(diff.scenario, 'crud-db');
+    assert.deepEqual(diff.n, { mandrel: 3, control: 2 });
+  });
+});
+
+describe('difficultyMonotonicity — calibration guardrail', () => {
+  // hello-world (easy): cheap + high overhead ratio.
+  const helloMandrel = [
+    card({ totalTokens: 180000, tokenRatio: 4.2 }),
+    card({ totalTokens: 184000, tokenRatio: 4.0 }),
+  ];
+  // crud-db (hard): more expensive + lower overhead ratio.
+  const crudMandrel = [
+    card({ totalTokens: 520000, tokenRatio: 2.1 }),
+    card({ totalTokens: 540000, tokenRatio: 2.0 }),
+  ];
+
+  it('holds when efficiency rises and overhead ratio falls down the ladder', () => {
+    const result = difficultyMonotonicity({
+      cells: [
+        { scenario: 'hello-world', difficulty: 1, mandrelRuns: helloMandrel },
+        { scenario: 'crud-db', difficulty: 2, mandrelRuns: crudMandrel },
+      ],
+    });
+    assert.equal(result.monotonicityHolds, true);
+    assert.equal(result.warnings.length, 0);
+    assert.equal(result.pairs.length, 1);
+    assert.equal(result.pairs[0].efficiencyRises, true);
+    assert.equal(result.pairs[0].overheadFalls, true);
+    // Ordered easy → hard regardless of input order.
+    assert.deepEqual(
+      result.ordered.map((o) => o.scenario),
+      ['hello-world', 'crud-db'],
+    );
+  });
+
+  it('sorts by difficulty even when cells are supplied hard-first', () => {
+    const result = difficultyMonotonicity({
+      cells: [
+        { scenario: 'crud-db', difficulty: 2, mandrelRuns: crudMandrel },
+        { scenario: 'hello-world', difficulty: 1, mandrelRuns: helloMandrel },
+      ],
+    });
+    assert.equal(result.monotonicityHolds, true);
+    assert.deepEqual(result.pairs[0], {
+      from: 'hello-world',
+      to: 'crud-db',
+      efficiencyRises: true,
+      overheadFalls: true,
+      holds: true,
+      violations: [],
+    });
+  });
+
+  it('flags a violation when efficiency does NOT rise', () => {
+    // crud-db cheaper than hello-world ⇒ efficiency non-monotonic.
+    const cheapCrud = [card({ totalTokens: 100000, tokenRatio: 2.0 })];
+    const result = difficultyMonotonicity({
+      cells: [
+        { scenario: 'hello-world', difficulty: 1, mandrelRuns: helloMandrel },
+        { scenario: 'crud-db', difficulty: 2, mandrelRuns: cheapCrud },
+      ],
+    });
+    assert.equal(result.monotonicityHolds, false);
+    assert.equal(result.pairs[0].efficiencyRises, false);
+    assert.ok(result.warnings.some((w) => /did not rise/.test(w)));
+    assert.ok(result.warnings.every((w) => w.startsWith('[calibration]')));
+  });
+
+  it('flags a violation when overhead ratio does NOT fall', () => {
+    // crud-db ratio HIGHER than hello-world ⇒ overhead non-monotonic.
+    const highRatioCrud = [card({ totalTokens: 520000, tokenRatio: 5.0 })];
+    const result = difficultyMonotonicity({
+      cells: [
+        { scenario: 'hello-world', difficulty: 1, mandrelRuns: helloMandrel },
+        { scenario: 'crud-db', difficulty: 2, mandrelRuns: highRatioCrud },
+      ],
+    });
+    assert.equal(result.monotonicityHolds, false);
+    assert.equal(result.pairs[0].overheadFalls, false);
+    assert.ok(result.warnings.some((w) => /did not fall/.test(w)));
+  });
+});
+
+describe('overheadFloor — framework finding', () => {
+  it('estimates the token + USD floor as mandrel minus control on hello-world', () => {
+    const mandrelRuns = [
+      card({ totalTokens: 180000, costUsd: 1.4, quality: 1 }),
+      card({ totalTokens: 184000, costUsd: 1.5, quality: 1 }),
+    ];
+    const controlRuns = [
+      card({ totalTokens: 40000, costUsd: 0.3, quality: 1 }),
+      card({ totalTokens: 42000, costUsd: 0.32, quality: 1 }),
+    ];
+    const floor = overheadFloor({ mandrelRuns, controlRuns });
+    assert.equal(floor.scenario, 'hello-world');
+    // median(180k,184k)=182k − median(40k,42k)=41k = 141000
+    approx(floor.overheadFloorTokens, 141000);
+    assert.ok(floor.overheadFloorUsd > 0);
+    assert.ok(floor.tokenDiffBand !== null);
+  });
+
+  it('recommends a ceremony-lite path when the floor buys NO quality gain', () => {
+    // Big token floor, identical quality ⇒ recommend ceremony-lite.
+    const mandrelRuns = [
+      card({ totalTokens: 180000, quality: 1 }),
+      card({ totalTokens: 182000, quality: 1 }),
+    ];
+    const controlRuns = [
+      card({ totalTokens: 40000, quality: 1 }),
+      card({ totalTokens: 41000, quality: 1 }),
+    ];
+    const floor = overheadFloor({ mandrelRuns, controlRuns });
+    assert.equal(floor.noQualityGain, true);
+    assert.equal(floor.recommendCeremonyLite, true);
+    approx(floor.qualityGain, 0);
+  });
+
+  it('does NOT recommend ceremony-lite when the floor buys a quality gain', () => {
+    const mandrelRuns = [
+      card({ totalTokens: 180000, quality: 1.0 }),
+      card({ totalTokens: 182000, quality: 1.0 }),
+    ];
+    const controlRuns = [
+      card({ totalTokens: 40000, quality: 0.4 }),
+      card({ totalTokens: 41000, quality: 0.42 }),
+    ];
+    const floor = overheadFloor({ mandrelRuns, controlRuns });
+    assert.equal(floor.noQualityGain, false);
+    assert.equal(floor.recommendCeremonyLite, false);
+    assert.ok(floor.qualityGain > 0.05);
+  });
+});
+
+describe('scoreCorpus — top-level convenience', () => {
+  it('computes per-scenario differentials plus both cross-scenario metrics', () => {
+    const cells = [
+      {
+        scenario: 'hello-world',
+        difficulty: 1,
+        mandrelRuns: [
+          card({ totalTokens: 180000, tokenRatio: 4.2, quality: 1 }),
+        ],
+        controlRuns: [card({ totalTokens: 40000, tokenRatio: 0, quality: 1 })],
+      },
+      {
+        scenario: 'crud-db',
+        difficulty: 2,
+        mandrelRuns: [
+          card({ totalTokens: 520000, tokenRatio: 2.0, quality: 1 }),
+        ],
+        controlRuns: [
+          card({ totalTokens: 90000, tokenRatio: 0, quality: 0.9 }),
+        ],
+      },
+    ];
+    const result = scoreCorpus({ cells });
+    assert.equal(result.perScenario.length, 2);
+    assert.equal(result.difficultyMonotonicity.monotonicityHolds, true);
+    assert.equal(result.overheadFloor.scenario, 'hello-world');
+    approx(result.overheadFloor.overheadFloorTokens, 140000);
+  });
+
+  it('returns a null overhead floor when no hello-world cell is present', () => {
+    const result = scoreCorpus({
+      cells: [
+        {
+          scenario: 'crud-db',
+          difficulty: 2,
+          mandrelRuns: [card()],
+          controlRuns: [card()],
+        },
+      ],
+    });
+    assert.equal(result.overheadFloor, null);
+  });
+});

--- a/tests/bench/score/dimensions.test.js
+++ b/tests/bench/score/dimensions.test.js
@@ -1,0 +1,296 @@
+// tests/bench/score/dimensions.test.js
+//
+// Unit tier (pure logic, no I/O) for the five-dimension scorer
+// (Epic #4211, Story #4217). Exercises bench/score/dimensions.js against the
+// verbatim formulas in bench/metrics/README.md § "The five dimensions":
+// quality, planningFidelity, autonomy, efficiency, overheadRatio — plus the
+// control-arm null behaviour and the divide-by-zero / no-codegen edges.
+
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import {
+  computeAutonomy,
+  computeDimensions,
+  computeEfficiency,
+  computeOverheadRatio,
+  computePlanningFidelity,
+  computeQuality,
+  fileFootprintDrift,
+  QUALITY_WEIGHTS,
+} from '../../../bench/score/dimensions.js';
+
+const approx = (actual, expected, eps = 1e-9) =>
+  assert.ok(
+    Math.abs(actual - expected) <= eps,
+    `expected ${actual} ≈ ${expected} (±${eps})`,
+  );
+
+describe('computeQuality', () => {
+  it('blends frozen-suite pass rate (0.7) and judge score (0.3)', () => {
+    const q = computeQuality({
+      frozenSuitePassed: 6,
+      frozenSuiteTotal: 6,
+      acceptanceEvalScore: 0.5,
+    });
+    approx(q.frozenSuitePassRate, 1);
+    // 0.7*1 + 0.3*0.5 = 0.85
+    approx(q.score, QUALITY_WEIGHTS.suite * 1 + QUALITY_WEIGHTS.judge * 0.5);
+    assert.equal(q.frozenSuitePassed, 6);
+    assert.equal(q.frozenSuiteTotal, 6);
+    assert.equal(q.acceptanceEvalScore, 0.5);
+  });
+
+  it('folds judge weight onto the suite when acceptanceEvalScore is null', () => {
+    const q = computeQuality({
+      frozenSuitePassed: 3,
+      frozenSuiteTotal: 4,
+      acceptanceEvalScore: null,
+    });
+    approx(q.frozenSuitePassRate, 0.75);
+    // judge null ⇒ score === pass rate (w_suite renormalized to 1.0)
+    approx(q.score, 0.75);
+    assert.equal(q.acceptanceEvalScore, null);
+  });
+
+  it('treats a missing judge score the same as null', () => {
+    const q = computeQuality({ frozenSuitePassed: 1, frozenSuiteTotal: 2 });
+    approx(q.score, 0.5);
+    assert.equal(q.acceptanceEvalScore, null);
+  });
+
+  it('scores a delivered-but-empty suite (total 0) as 0, not NaN', () => {
+    const q = computeQuality({ frozenSuitePassed: 0, frozenSuiteTotal: 0 });
+    approx(q.frozenSuitePassRate, 0);
+    approx(q.score, 0);
+  });
+
+  it('a run that fails every assertion scores 0', () => {
+    const q = computeQuality({
+      frozenSuitePassed: 0,
+      frozenSuiteTotal: 6,
+      acceptanceEvalScore: 0,
+    });
+    approx(q.score, 0);
+  });
+
+  it('clamps an out-of-range judge score into [0,1]', () => {
+    const q = computeQuality({
+      frozenSuitePassed: 2,
+      frozenSuiteTotal: 2,
+      acceptanceEvalScore: 5,
+    });
+    assert.ok(q.acceptanceEvalScore <= 1 && q.acceptanceEvalScore >= 0);
+    assert.ok(q.score <= 1);
+  });
+});
+
+describe('fileFootprintDrift', () => {
+  it('is 0 for identical path sets', () => {
+    approx(fileFootprintDrift(['a', 'b'], ['a', 'b']), 0);
+  });
+
+  it('is 1 for disjoint path sets', () => {
+    approx(fileFootprintDrift(['a'], ['b']), 1);
+  });
+
+  it('is the Jaccard distance for partial overlap', () => {
+    // P={a,b,c} A={b,c,d} ∩=2 ∪=4 ⇒ 1 − 2/4 = 0.5
+    approx(fileFootprintDrift(['a', 'b', 'c'], ['b', 'c', 'd']), 0.5);
+  });
+
+  it('is 0 when both sets are empty', () => {
+    approx(fileFootprintDrift([], []), 0);
+  });
+});
+
+describe('computePlanningFidelity', () => {
+  it('averages story accuracy, re-plan penalty, and footprint accuracy', () => {
+    const pf = computePlanningFidelity({
+      arm: 'mandrel',
+      rePlanCount: 0,
+      plannedStoryCount: 2,
+      deliveredStoryCount: 2,
+      fileFootprintDrift: 0,
+    });
+    // storyAccuracy=1, rePlanPenalty=1, footprintAccuracy=1 ⇒ 1
+    approx(pf.score, 1);
+  });
+
+  it('penalizes re-plans and story-count drift', () => {
+    const pf = computePlanningFidelity({
+      arm: 'mandrel',
+      rePlanCount: 1, // penalty = 1/2
+      plannedStoryCount: 2,
+      deliveredStoryCount: 4, // accuracy = 1 - 2/4 = 0.5
+      fileFootprintDrift: 0.25, // footprintAccuracy = 0.75
+    });
+    approx(pf.score, (0.5 + 0.5 + 0.75) / 3);
+  });
+
+  it('derives footprint drift from planned/actual paths when not supplied', () => {
+    const pf = computePlanningFidelity({
+      arm: 'mandrel',
+      rePlanCount: 0,
+      plannedStoryCount: 1,
+      deliveredStoryCount: 1,
+      plannedPaths: ['a', 'b'],
+      actualPaths: ['b', 'c'], // ∩=1 ∪=3 ⇒ drift 2/3, footprintAccuracy 1/3
+    });
+    approx(pf.fileFootprintDrift, 2 / 3);
+    approx(pf.score, (1 + 1 + 1 / 3) / 3);
+  });
+
+  it('is null for the control arm (no plan authored)', () => {
+    const pf = computePlanningFidelity({
+      arm: 'control',
+      plannedStoryCount: 0,
+      deliveredStoryCount: 1,
+    });
+    assert.equal(pf.score, null);
+    // sub-signals still reported for shape stability
+    assert.equal(pf.deliveredStoryCount, 1);
+  });
+
+  it('honours an explicit planAuthored:false override', () => {
+    const pf = computePlanningFidelity({ planAuthored: false });
+    assert.equal(pf.score, null);
+  });
+});
+
+describe('computeAutonomy', () => {
+  it('is 1.0 for a fully unattended run', () => {
+    const a = computeAutonomy({
+      hitlStops: 0,
+      blockedEvents: 0,
+      manualRescues: 0,
+    });
+    approx(a.score, 1);
+  });
+
+  it('collapses interventions via 1/(1+interventions)', () => {
+    const a = computeAutonomy({
+      hitlStops: 1,
+      blockedEvents: 1,
+      manualRescues: 1,
+    });
+    // interventions = 3 ⇒ 1/4
+    approx(a.score, 0.25);
+  });
+
+  it('coerces malformed counters to 0', () => {
+    const a = computeAutonomy({
+      hitlStops: -3,
+      blockedEvents: 'x',
+      manualRescues: 2.9,
+    });
+    // -3→0, 'x'→0, 2.9→2 ⇒ interventions 2 ⇒ 1/3
+    approx(a.score, 1 / 3);
+  });
+});
+
+describe('computeEfficiency', () => {
+  it('reports the vector and preserves a reported costUsd', () => {
+    const e = computeEfficiency({
+      wallClockMs: 612000,
+      totalTokens: 184320,
+      inputTokens: 151200,
+      outputTokens: 33120,
+      dispatches: 2,
+      costUsd: 1.47,
+    });
+    assert.deepEqual(e, {
+      wallClockMs: 612000,
+      totalTokens: 184320,
+      inputTokens: 151200,
+      outputTokens: 33120,
+      dispatches: 2,
+      costUsd: 1.47,
+    });
+  });
+
+  it('coerces a missing/negative costUsd to null', () => {
+    assert.equal(computeEfficiency({ costUsd: -1 }).costUsd, null);
+    assert.equal(computeEfficiency({}).costUsd, null);
+  });
+});
+
+describe('computeOverheadRatio', () => {
+  it('is ceremonyTokens / codegenTokens', () => {
+    const o = computeOverheadRatio({
+      ceremonyTokens: 148800,
+      codegenTokens: 35520,
+    });
+    approx(o.tokenRatio, 148800 / 35520);
+    assert.equal(o.timeRatio, null);
+  });
+
+  it('computes timeRatio when both ms values are present', () => {
+    const o = computeOverheadRatio({
+      ceremonyTokens: 4,
+      codegenTokens: 1,
+      ceremonyMs: 360,
+      codegenMs: 100,
+    });
+    approx(o.timeRatio, 3.6);
+  });
+
+  it('reports 0 (not Infinity) when no codegen tokens were recorded', () => {
+    const o = computeOverheadRatio({ ceremonyTokens: 1000, codegenTokens: 0 });
+    approx(o.tokenRatio, 0);
+  });
+
+  it('control-arm-like input (near-zero ceremony) sits near the floor', () => {
+    const o = computeOverheadRatio({ ceremonyTokens: 0, codegenTokens: 5000 });
+    approx(o.tokenRatio, 0);
+  });
+});
+
+describe('computeDimensions', () => {
+  it('produces all five dimensions with the canonical keys', () => {
+    const dims = computeDimensions({
+      arm: 'mandrel',
+      frozenSuitePassed: 6,
+      frozenSuiteTotal: 6,
+      acceptanceEvalScore: 1,
+      rePlanCount: 0,
+      plannedStoryCount: 2,
+      deliveredStoryCount: 2,
+      fileFootprintDrift: 0.08,
+      hitlStops: 0,
+      blockedEvents: 0,
+      manualRescues: 0,
+      wallClockMs: 612000,
+      totalTokens: 184320,
+      inputTokens: 151200,
+      outputTokens: 33120,
+      dispatches: 2,
+      costUsd: 1.47,
+      ceremonyTokens: 148800,
+      codegenTokens: 35520,
+    });
+    assert.deepEqual(Object.keys(dims).sort(), [
+      'autonomy',
+      'efficiency',
+      'overheadRatio',
+      'planningFidelity',
+      'quality',
+    ]);
+    approx(dims.quality.score, 1);
+    approx(dims.autonomy.score, 1);
+    assert.equal(typeof dims.planningFidelity.score, 'number');
+  });
+
+  it('nulls planningFidelity when arm is control', () => {
+    const dims = computeDimensions({
+      arm: 'control',
+      frozenSuitePassed: 6,
+      frozenSuiteTotal: 6,
+      ceremonyTokens: 0,
+      codegenTokens: 5000,
+    });
+    assert.equal(dims.planningFidelity.score, null);
+    // control quality with no judge folds onto the frozen suite
+    approx(dims.quality.score, 1);
+  });
+});


### PR DESCRIPTION
## Epic #4211 — Mandrel Self-Benchmark Harness

Internal benchmarking tooling (under `bench/` + `tests/bench/`, **not** shipped in the distributed `.agents/` bundle) that drives Mandrel's own `/plan`→`/deliver` pipeline plus a bare-model control over a scenario set, scores five dimensions, and tracks framework value-add over time. Authored and delivered through Mandrel's own `/plan` → `/deliver`.

### Delivered (5 Stories)
- **#4215** — metrics model + scorecard JSON schema + variance/noise-band + the two cross-scenario derived metrics (difficulty-monotonicity, overhead-floor)
- **#4214** — hello-world + CRUD+DB scenarios with frozen acceptance oracles + acceptance-eval cross-check
- **#4216** — headless `claude -p` run driver + ephemeral sandbox lifecycle + the unattended-mode finding
- **#4217** — telemetry/cost collector + five-dimension scoring + Mandrel-vs-control differential
- **#4218** — value-add report (distributions, deltas, scaling view, Recommended improvements) + stamped persistence + cross-run compare

### Validation
- `epic/4211` green: **9564 tests, 0 failures**; `npm run lint` + `biome ci` clean; baselines gate clean (change set is `bench/` + `tests/bench/` only, outside the gated dirs).
- Per-Story `acceptance-eval` gates all returned `proceed`.
- Code-review (Phase 5): **0 🔴 / 0 🟠**; advisory 🟡/🟢 notes on the `code-review` comment of #4211.

### Make-or-break finding (#4216)
Unattended-mode is **yellow**: `/deliver` is headless-drivable (`--yes` + auto-merge arm), but `/plan` ships no headless flag — mitigated by a prompt-level auto-proceed directive, with a `meta::framework-gap` follow-up filed for the clean fix.

### Manual interventions (recorded — auto-merge intentionally NOT armed)
1. **Phase 4 epic-audit skipped** — the change-set selector over-fired (8 lenses incl. inapplicable `lighthouse`/`ux-ui`/`devops` on non-web/non-CI code); correctness + security deferred to the Phase 5 code-review over the same diff.
2. **No auto-merge** — operator requested manual review.

### Release-type note
This is **internal tooling** (not shipped to consumers), so consider squash-merging as `chore(bench):` rather than `feat(bench):` to keep it out of the consumer-facing changelog.

Planning artifacts: PRD #4212, Tech Spec #4213 (closed at finalize). One-pager `docs/ideas/mandrel-self-benchmark.md` was stashed during delivery — `git stash pop` if you want it tracked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
