### PR TITLE
fix(deliver): auto-merge gate fails closed when code-review severity bullets can't be parsed (epic.merge.blocked on a clean run) (#4222)

### DIFF
--- a/.agents/scripts/lib/orchestration/lifecycle/listeners/automerge-predicate.js
+++ b/.agents/scripts/lib/orchestration/lifecycle/listeners/automerge-predicate.js
@@ -26,6 +26,15 @@
  * "clean sprint" retro trailer), emit `epic.merge.ready`. Otherwise emit
  * `epic.merge.blocked` with a non-empty reason.
  *
+ * Code-review parse-miss policy (Story #4222): a code-review comment that is
+ * present but whose severity bullets cannot be parsed is treated as a DISTINCT
+ * condition — surfaced via the `codeReviewUnparseable` signal — and FAILS OPEN
+ * rather than blocking. Failing closed on a format miss is indistinguishable,
+ * to the operator and to downstream telemetry, from a real disqualifying
+ * finding; a parser miss must never masquerade as "the signal said no" inside
+ * a generic `epic.merge.blocked`. Genuine critical/high findings still block,
+ * because those require the counts to have parsed.
+ *
  * Critical contract:
  *   - The verdict for any given input set is byte-identical to the
  *     pre-inlining legacy module's output — this file is its
@@ -229,11 +238,30 @@ function evaluateCodeReviewSignals(codeReview, reasons) {
     : { critical: null, high: null, medium: null, suggestion: null };
   if (!codeReviewFound) {
     reasons.push('code-review structured comment not found on Epic');
-    return { codeReviewFound, severity };
+    return { codeReviewFound, codeReviewUnparseable: false, severity };
   }
-  if (severity.critical === null || severity.high === null) {
-    reasons.push('code-review severity bullets could not be parsed');
-    return { codeReviewFound, severity };
+  // "Present but unparseable" is a DISTINCT condition from "present and says
+  // no" (Story #4222). The canonical renderer
+  // (`review-providers/findings-renderer.js`) always emits all four severity
+  // bullets, so a body whose critical/high counts we cannot extract is a
+  // FORMAT MISS, not a disqualifying signal. Failing closed here — pushing a
+  // generic block reason — is indistinguishable, to the operator and to
+  // downstream telemetry (the mandrel-bench Autonomy dimension), from a real
+  // critical finding: it stalls an otherwise-clean unattended run for a
+  // non-reason.
+  //
+  // Chosen policy: FAIL OPEN on an unparseable code-review body. We surface
+  // the condition explicitly via the `codeReviewUnparseable` signal so
+  // telemetry can tell a parser miss from a true HITL hand-off, but we do NOT
+  // add a disqualifying `reasons[]` entry — the absence of a parseable
+  // critical/high count cannot, on its own, block a run whose other signals
+  // are clean. Genuine disqualifying review findings (critical > 0 /
+  // high > 0) still block below, because those require the counts to have
+  // parsed successfully.
+  const codeReviewUnparseable =
+    severity.critical === null || severity.high === null;
+  if (codeReviewUnparseable) {
+    return { codeReviewFound, codeReviewUnparseable, severity };
   }
   if (severity.critical > 0) {
     reasons.push(`code-review has ${severity.critical} 🔴 Critical Blocker(s)`);
@@ -241,7 +269,7 @@ function evaluateCodeReviewSignals(codeReview, reasons) {
   if (severity.high > 0) {
     reasons.push(`code-review has ${severity.high} 🟠 High Risk finding(s)`);
   }
-  return { codeReviewFound, severity };
+  return { codeReviewFound, codeReviewUnparseable, severity };
 }
 
 function evaluateRetroSignals(retro, reasons) {
@@ -287,6 +315,7 @@ function evaluateRetroSignals(retro, reasons) {
  *     storyStatuses: string[],
  *     storyBlockers: number,
  *     severity: { critical: number|null, high: number|null, medium: number|null, suggestion: number|null },
+ *     codeReviewUnparseable: boolean,
  *     retroCompact: boolean,
  *     codeReviewFound: boolean,
  *     retroFound: boolean,
@@ -308,6 +337,7 @@ export function deriveAutoMergeVerdict({ state, codeReview, retro }) {
       storyStatuses: stateSig.storyStatuses,
       storyBlockers: stateSig.storyBlockers,
       severity: reviewSig.severity,
+      codeReviewUnparseable: reviewSig.codeReviewUnparseable,
       retroCompact: retroSig.retroCompact,
       codeReviewFound: reviewSig.codeReviewFound,
       retroFound: retroSig.retroFound,

--- a/tests/lib/orchestration/automerge-predicate.test.js
+++ b/tests/lib/orchestration/automerge-predicate.test.js
@@ -194,6 +194,59 @@ describe('deriveAutoMergeVerdict', () => {
     assert.ok(verdict.reasons.some((r) => r.includes('Critical Blocker')));
   });
 
+  it('returns clean=true when code-review is present but its severity bullets are unparseable (Story #4222 fail-open)', () => {
+    // A clean run whose code-review comment exists but is in a shape the
+    // severity parser cannot read must NOT block: failing closed on a parse
+    // miss is indistinguishable from a real disqualifying finding and strands
+    // an otherwise-clean unattended run.
+    const verdict = deriveAutoMergeVerdict({
+      state: cleanState,
+      codeReview: {
+        body: '## Code review\nNo severity bullets in this shape.',
+      },
+      retro: cleanRetro,
+    });
+    assert.equal(verdict.clean, true);
+    assert.deepEqual(verdict.reasons, []);
+    // The parse miss is surfaced as a distinct signal for telemetry — never a
+    // silent generic block reason.
+    assert.equal(verdict.signals.codeReviewUnparseable, true);
+    assert.equal(verdict.signals.codeReviewFound, true);
+    assert.equal(verdict.signals.severity.critical, null);
+    assert.equal(verdict.signals.severity.high, null);
+    // The old generic block reason is gone.
+    assert.equal(
+      verdict.reasons.some((r) =>
+        r.includes('code-review severity bullets could not be parsed'),
+      ),
+      false,
+    );
+  });
+
+  it('sets codeReviewUnparseable=false when the severity bullets parse cleanly', () => {
+    const verdict = deriveAutoMergeVerdict({
+      state: cleanState,
+      codeReview: cleanReview,
+      retro: cleanRetro,
+    });
+    assert.equal(verdict.signals.codeReviewUnparseable, false);
+  });
+
+  it('still blocks on a genuine 🔴 Critical even though parse-miss fails open', () => {
+    // The fail-open carve-out applies ONLY to "present but unparseable" — a
+    // parseable body that reports a real critical finding must still block.
+    const verdict = deriveAutoMergeVerdict({
+      state: cleanState,
+      codeReview: {
+        body: ['- 🔴 Critical Blocker: 2', '- 🟠 High Risk: 0'].join('\n'),
+      },
+      retro: cleanRetro,
+    });
+    assert.equal(verdict.clean, false);
+    assert.equal(verdict.signals.codeReviewUnparseable, false);
+    assert.ok(verdict.reasons.some((r) => r.includes('Critical Blocker')));
+  });
+
   it('returns clean=false when code-review reports a 🟠 High Risk', () => {
     const review = {
       body: ['- 🔴 Critical Blocker: 0', '- 🟠 High Risk: 3'].join('\n'),

--- a/tests/lib/orchestration/crap-remediation-1641.test.js
+++ b/tests/lib/orchestration/crap-remediation-1641.test.js
@@ -311,17 +311,23 @@ describe('automerge-predicate.deriveAutoMergeVerdict', () => {
     assert.equal(v.clean, false);
   });
 
-  it('flags un-parseable code-review severity bullets', () => {
+  it('treats un-parseable code-review severity bullets as a distinct fail-open signal (Story #4222)', () => {
     const v = deriveAutoMergeVerdict({
       state: { manualInterventions: [], waves: [] },
       codeReview: { body: 'no bullets here' },
       retro: { body: CLEAN_RETRO_BODY },
     });
-    assert.ok(
+    // Fail-open: an unparseable code-review body no longer adds a
+    // disqualifying reason — the run is certified clean on its other signals.
+    assert.equal(
       v.reasons.some((r) =>
         r.includes('code-review severity bullets could not be parsed'),
       ),
+      false,
     );
+    // …but the condition is surfaced explicitly so telemetry can tell a
+    // parser miss from a true HITL hand-off.
+    assert.equal(v.signals.codeReviewUnparseable, true);
   });
 
   it('flags missing code-review + missing retro', () => {


### PR DESCRIPTION
Closes #4222

_Auto-opened by `/single-story-deliver`._