### PR TITLE
feat: story-plan tech-stack hydrator is hard-bound to architecture.md §Tech Stack and misses numbered/relocated headings (#4228)

### DIFF
--- a/.agents/instructions.md
+++ b/.agents/instructions.md
@@ -86,11 +86,13 @@ apply by checking the `.agents/rules/` directory (e.g.,
 ### G. Structured Configuration
 
 Refer to `.agentrc.json` to understand your operational limits (e.g., allowed
-auto-run permissions, default personas). Refer to the **Tech Stack** section
-of `docs/architecture.md` for the project's specific technology choices
-(database, ORM, API framework, auth provider, validation library, workspace
-paths). Project-specific technology context is intentionally kept out of
-`.agentrc.json`.
+auto-run permissions, default personas). For the project's specific
+technology choices (database, ORM, API framework, auth provider, validation
+library, workspace paths), refer to the project's Tech Stack inventory: a
+dedicated `docs/tech-stack.md` when present (the single-ownership convention),
+otherwise the **Tech Stack** section of `docs/architecture.md` (a numbered or
+decorated heading such as `## 1. Tech Stack` is fine). Project-specific
+technology context is intentionally kept out of `.agentrc.json`.
 
 ### H. Observability & Friction Telemetry
 

--- a/.agents/personas/devops-engineer.md
+++ b/.agents/personas/devops-engineer.md
@@ -14,8 +14,10 @@ express it through code or documented configuration files.
 
 1. **Read Context:** Before making any infrastructure changes, analyze the
    existing CI/CD, deployment, and security configurations.
-2. **Follow Protocols:** Adhere strictly to the **Tech Stack** section of
-   `docs/architecture.md` and the `orchestration` block of `.agentrc.json`.
+2. **Follow Protocols:** Adhere strictly to the project's Tech Stack
+   inventory — a dedicated `docs/tech-stack.md` when present, otherwise the
+   **Tech Stack** section of `docs/architecture.md` — and the `orchestration`
+   block of `.agentrc.json`.
 3. **Validate Always:** For every task, determine how the change will be
    monitored and validated (logs, health checks, or test gates).
 

--- a/.agents/scripts/lib/story-plan.js
+++ b/.agents/scripts/lib/story-plan.js
@@ -227,13 +227,51 @@ export function buildContextEnvelope({
 }
 
 /**
- * Strip the leading "Tech Stack" section of `docs/architecture.md` for
- * the host LLM. Returns `null` when the file or section is missing.
+ * Extract the "Tech Stack" `##` section from a markdown document.
+ *
+ * Tolerates a numbered / decorated heading (`## 1. Tech Stack`,
+ * `## Tech Stack`, etc.) and a section that is the final `##` in the
+ * file (the terminator matches the next `##` heading **or** end-of-file).
+ * Returns the matched section text (re-headed to a clean `## Tech Stack`)
+ * or `null` when no Tech Stack heading is present.
+ *
+ * @param {string} content
+ * @returns {string|null}
+ */
+function extractTechStackSection(content) {
+  const match = content.match(
+    /^##\s+(?:\d+[.)]\s+)?Tech Stack\s*$([\s\S]*?)(?=^##\s+|(?![\s\S]))/m,
+  );
+  return match ? `## Tech Stack${match[1]}`.trim() : null;
+}
+
+/**
+ * Resolve the project's Tech Stack inventory for the host LLM, in order:
+ *
+ *   1. A dedicated `docs/tech-stack.md` when present (the emerging
+ *      single-ownership convention — WHAT in tech-stack.md, HOW in
+ *      architecture.md, WHY in the ADRs). Its full body is returned.
+ *   2. Otherwise, the `## Tech Stack` section of `docs/architecture.md`,
+ *      tolerating a numbered/decorated heading and a final-section
+ *      heading (no following `##` required).
+ *
+ * Returns `null` when neither source yields an inventory.
  *
  * @param {string} projectRoot
  * @returns {Promise<string|null>}
  */
 export async function readTechStackSummary(projectRoot) {
+  const dedicatedPath = path.join(projectRoot, 'docs', 'tech-stack.md');
+  try {
+    const dedicated = await readFile(dedicatedPath, 'utf8');
+    const trimmed = dedicated.trim();
+    if (trimmed) {
+      return trimmed;
+    }
+  } catch {
+    // No dedicated tech-stack.md — fall through to architecture.md.
+  }
+
   const archPath = path.join(projectRoot, 'docs', 'architecture.md');
   let content;
   try {
@@ -241,6 +279,5 @@ export async function readTechStackSummary(projectRoot) {
   } catch {
     return null;
   }
-  const match = content.match(/^##\s+Tech Stack\s*$([\s\S]*?)(?=^##\s+\S)/m);
-  return match ? `## Tech Stack${match[1]}`.trim() : null;
+  return extractTechStackSection(content);
 }

--- a/.agents/workflows/helpers/plan-story.md
+++ b/.agents/workflows/helpers/plan-story.md
@@ -97,7 +97,7 @@ Envelope fields (`kind: "story-plan-context"`, `version: 1`):
 | `bodyTemplate`         | Contents of `.agents/templates/single-story-body.md`.     |
 | `requiredSections`     | `["Context", "Acceptance Criteria", "Out of Scope", "Notes"]`. |
 | `duplicateCandidates`  | Ranked open Stories whose titles fuzzy-match the seed.    |
-| `techStack`            | The `## Tech Stack` section of `docs/architecture.md`.    |
+| `techStack`            | The project's Tech Stack inventory, resolved in order: `docs/tech-stack.md` (full body) when present, else the `## Tech Stack` section of `docs/architecture.md` (numbered/decorated and final-section headings tolerated). |
 | `deliverContract`      | Workflow path + required/forbidden labels and references. |
 
 ### Refine heuristic

--- a/tests/story-plan.test.js
+++ b/tests/story-plan.test.js
@@ -18,7 +18,7 @@
 
 import assert from 'node:assert/strict';
 import { spawnSync } from 'node:child_process';
-import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { afterEach, beforeEach, describe, it } from 'node:test';
@@ -30,6 +30,7 @@ import {
   DEFAULT_REFINE_THRESHOLD,
   REQUIRED_SECTIONS,
   rankDuplicateCandidates,
+  readTechStackSummary,
   shouldRefine,
   validateStoryBody,
 } from '../.agents/scripts/lib/story-plan.js';
@@ -416,5 +417,78 @@ describe('story-plan.js runPersist: Projects V2 board membership (Story #3822)',
     assert.deepEqual(projectCalls, []);
     const summary = JSON.parse(summaries.join(''));
     assert.equal(summary.issueNumber, 8181);
+  });
+});
+
+describe('readTechStackSummary (Story #4228)', () => {
+  let tmp;
+
+  beforeEach(() => {
+    tmp = mkdtempSync(path.join(os.tmpdir(), 'tech-stack-'));
+    mkdirSync(path.join(tmp, 'docs'), { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it('prefers a dedicated docs/tech-stack.md when present', async () => {
+    writeFileSync(
+      path.join(tmp, 'docs', 'tech-stack.md'),
+      '# Tech Stack\n\nNode 22, React 19, Postgres.\n',
+    );
+    // architecture.md is also present, but the dedicated file wins.
+    writeFileSync(
+      path.join(tmp, 'docs', 'architecture.md'),
+      '## Tech Stack\n\nStale pointer-stub: see tech-stack.md\n',
+    );
+
+    const summary = await readTechStackSummary(tmp);
+    assert.equal(summary, '# Tech Stack\n\nNode 22, React 19, Postgres.');
+  });
+
+  it('falls back to architecture.md when no dedicated file exists', async () => {
+    writeFileSync(
+      path.join(tmp, 'docs', 'architecture.md'),
+      '# Architecture\n\n## Tech Stack\n\nNode 22\n\n## Decisions\n\nfoo\n',
+    );
+
+    const summary = await readTechStackSummary(tmp);
+    assert.equal(summary, '## Tech Stack\nNode 22');
+  });
+
+  it('resolves a numbered heading (## 1. Tech Stack)', async () => {
+    writeFileSync(
+      path.join(tmp, 'docs', 'architecture.md'),
+      '# Architecture\n\n## 1. Tech Stack\n\nNode 22\n\n## 2. Decisions\n\nfoo\n',
+    );
+
+    const summary = await readTechStackSummary(tmp);
+    assert.equal(summary, '## Tech Stack\nNode 22');
+  });
+
+  it('resolves a Tech Stack section that is the final ## in the file', async () => {
+    writeFileSync(
+      path.join(tmp, 'docs', 'architecture.md'),
+      '# Architecture\n\n## Overview\n\nbar\n\n## Tech Stack\n\nNode 22\nReact 19\n',
+    );
+
+    const summary = await readTechStackSummary(tmp);
+    assert.equal(summary, '## Tech Stack\nNode 22\nReact 19');
+  });
+
+  it('returns null when neither source is present', async () => {
+    const summary = await readTechStackSummary(tmp);
+    assert.equal(summary, null);
+  });
+
+  it('returns null when architecture.md lacks a Tech Stack heading', async () => {
+    writeFileSync(
+      path.join(tmp, 'docs', 'architecture.md'),
+      '# Architecture\n\n## Overview\n\nNo stack section here.\n',
+    );
+
+    const summary = await readTechStackSummary(tmp);
+    assert.equal(summary, null);
   });
 });


### PR DESCRIPTION
Closes #4228

_Auto-opened by `/single-story-deliver`._