### PR TITLE
feat: bless the index + decisions/ ADR-directory layout as a first-class option (template + doc references) (#4229)

### DIFF
--- a/.agents/docs/configuration.md
+++ b/.agents/docs/configuration.md
@@ -358,6 +358,19 @@ Read with `getCommands(config)` — see
 | ------------------ | -------- | ------- | -------------------------------------------------------------------------------------------------- |
 | `docsContextFiles` | No       | `[]`    | Files the context-hydration engine includes when assembling agent prompts. Resolved against `paths.docsRoot`. |
 
+> **Entries are plain filenames, not globs.** Each entry is resolved as a
+> single file under `paths.docsRoot`; the loader does **not** expand glob
+> patterns. This matters for the decisions log: when a project adopts the
+> index + `decisions/` ADR-directory layout (see
+> [`documentation-and-adrs`](../skills/core/documentation-and-adrs/SKILL.md)),
+> the **index** `decisions.md` stays the mandatory-read and the per-ADR bodies
+> under `decisions/` are link-followed on demand — **index-only by default**.
+> Auto-loading every ADR body into each task's context would reintroduce the
+> bloat the directory split exists to remove. A project that genuinely wants
+> the full ADR set in mandatory context must opt in by listing the individual
+> ADR files explicitly (one filename per entry); there is no built-in
+> `decisions/*.md` glob.
+
 ---
 
 ## `github`

--- a/.agents/instructions.md
+++ b/.agents/instructions.md
@@ -240,7 +240,13 @@ stops.
      data dictionary, decisions log, patterns, etc.) and replaces any
      hardcoded filename list. Resolve each entry against
      `project.paths.docsRoot` (default `docs/`) and skip silently
-     when an entry's file is absent.
+     when an entry's file is absent. The decisions log (`decisions.md`) may
+     be either a single-file dated-entry log or an **index** into a
+     `decisions/` ADR directory — both are first-class layouts (see
+     [`skills/core/documentation-and-adrs`](skills/core/documentation-and-adrs/SKILL.md)).
+     When it is an index, only the index is the mandatory-read; the
+     per-ADR bodies under `decisions/` are link-followed on demand
+     (index-only by default), not auto-loaded into every task's context.
    - **Conditional Reads**: When the task touches UI copy, layout, or
      routing and the corresponding file is present in the project, also
      read `docs/style-guide.md` and `docs/web-routes.md`. Skip both when

--- a/.agents/skills/core/documentation-and-adrs/SKILL.md
+++ b/.agents/skills/core/documentation-and-adrs/SKILL.md
@@ -12,7 +12,7 @@ description:
 
 - Document the **why**, not the what. Capture context, constraints, alternatives considered, and trade-offs — code already shows what was built.
 - Write an ADR for any decision that would be expensive to reverse (framework choice, data model, auth strategy, API architecture, hosting platform).
-- Store ADRs at `docs/decisions/` with sequential numbering (`ADR-001`, `ADR-002`, …) and the canonical sections: **Status, Date, Context, Decision, Alternatives Considered, Consequences**.
+- Mandrel ships **two first-class decisions-log layouts** — pick one at onboarding (see [Decisions-log layouts](#decisions-log-layouts)): the **single-file dated-entry** `docs/decisions.md` (default; best for small projects) or the **index + `docs/decisions/` directory** (MADR-style, one file per ADR; best once the log outgrows a single file). Either way, the canonical ADR sections are **Status, Date, Deciders, Context, Decision, (Alternatives Considered), Consequences**.
 - Mark an ADR's status as `Accepted`, `Superseded by ADR-XXX`, or `Deprecated`. Never silently delete an ADR — supersede it.
 - Do **not** document obvious code; do **not** restate what the code already says. Stale or redundant docs are worse than no docs.
 - Comments explain **non-obvious intent** (the why). If a comment describes what the code does, refactor the code instead.
@@ -54,9 +54,41 @@ highest-value documentation you can write.
 - Choosing between build tools, hosting platforms, or infrastructure
 - Any decision that would be expensive to reverse
 
+### Decisions-log layouts
+
+Mandrel ships **two supported layouts** for the decisions log. Both keep the
+mandatory-read file named `docs/decisions.md` (the `project.docsContextFiles`
+default), so `config-resolver.js` and every `.agents/` reference resolve the
+same regardless of which you pick — only the **shape** differs. Choose one at
+onboarding:
+
+| Layout                              | Shape                                                                 | Template(s)                                                                                                | When to use                                                                       |
+| ----------------------------------- | --------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------- |
+| **Single-file dated entries** (default) | One `decisions.md` of append-only `## YYYY-MM-DD — title` entries     | [`templates/docs/decisions.md`](../../../templates/docs/decisions.md)                                      | Small projects; a handful of decisions; you want everything in one scannable file. |
+| **Index + `decisions/` directory**  | `decisions.md` is a one-row-per-ADR **index**; each ADR is `decisions/NNNN-*.md` | [`templates/docs/decisions.index.md`](../../../templates/docs/decisions.index.md) + [`templates/docs/decisions/_template.md`](../../../templates/docs/decisions/_template.md) | The log has outgrown a single file (dozens of ADRs); you want per-decision history and `git blame` per ADR. |
+
+To adopt the directory layout, replace `decisions.md` with the index variant,
+create a `decisions/` directory beside it, and scaffold each ADR from
+`decisions/_template.md` using zero-padded sequential numbering
+(`0001-*.md`, `0002-*.md`, …).
+
+> **Loading model (resolved design question).** The decisions **index** is the
+> only artifact loaded into mandatory task context — individual ADR bodies
+> under `decisions/` are **lazy / link-followed**, not auto-loaded. This is
+> **index-only by default**: auto-loading every ADR body into each task's
+> context would reintroduce exactly the bloat the split exists to remove.
+> `project.docsContextFiles` entries are plain filenames resolved against the
+> docs root (no glob expansion in the loader), so the index ships as a normal
+> mandatory-read with no loader change. A project that genuinely wants the full
+> ADR set in mandatory context can add explicit per-file entries (or a
+> `decisions/*.md`-style entry if it maintains its own globbing) as a
+> deliberate opt-in, but that is the exception, not the default.
+
 ### ADR Template
 
-Store ADRs in `docs/decisions/` with sequential numbering:
+In the **single-file** layout, append a short dated entry per the
+`templates/docs/decisions.md` format. In the **directory** layout, store ADRs
+in `docs/decisions/` with sequential numbering:
 
 ```markdown
 # ADR-001: Use PostgreSQL for primary database
@@ -68,6 +100,10 @@ Accepted | Superseded by ADR-XXX | Deprecated
 ## Date
 
 2025-01-15
+
+## Deciders
+
+The platform team (architect + two senior engineers).
 
 ## Context
 

--- a/.agents/templates/docs/architecture.md
+++ b/.agents/templates/docs/architecture.md
@@ -27,4 +27,7 @@ Describe the top-level directories and their responsibilities.
 
 ## Key Decisions
 
-Link to `decisions.md` for the architectural decision log.
+Link to `decisions.md` for the architectural decision log. Mandrel supports two
+first-class layouts for it: a single-file dated-entry `decisions.md` (default)
+or an index + `decisions/` ADR directory — see
+[`.agents/skills/core/documentation-and-adrs/SKILL.md`](../../skills/core/documentation-and-adrs/SKILL.md).

--- a/.agents/templates/docs/decisions.index.md
+++ b/.agents/templates/docs/decisions.index.md
@@ -1,0 +1,49 @@
+# Architectural Decisions Log (Index)
+
+> **Directory-layout variant.** This is the MADR-style **index + `decisions/`
+> directory** alternative to the default single-file dated-entry
+> [`decisions.md`](decisions.md). To adopt it, replace your `decisions.md` with
+> this index, create a `decisions/` directory next to it, and scaffold ADRs
+> from [`decisions/_template.md`](decisions/_template.md). This file stays named
+> `decisions.md` so it remains the `project.docsContextFiles` mandatory-read
+> every `.agents/` reference and `config-resolver.js` already point at — only
+> its **shape** changes from dated entries to an index.
+>
+> Prefer this layout once the single-file log grows past a few dozen entries
+> (athportal hit ~1060 lines / 32 ADRs before splitting). For small projects,
+> keep the default single-file template instead.
+
+## How this layout works
+
+- **This file is the index** — one row per ADR, newest at the top. It is the
+  mandatory-read; agents scan the index and follow the link into a specific
+  ADR only when the detail is relevant (index-only by default — see
+  [Loading model](#loading-model)).
+- **Each ADR is its own file** under `decisions/`, named
+  `NNNN-<kebab-title>.md` with a zero-padded sequential number.
+- **ADRs are append-only.** Never rewrite or delete an accepted ADR — write a
+  new one and flip the old one's status to `Superseded by ADR-NNNN`.
+- **Scaffold new ADRs** from [`decisions/_template.md`](decisions/_template.md)
+  (Status / Date / Deciders / Context / Decision / Consequences).
+
+## Loading model
+
+This index is the only decisions artifact loaded into mandatory task context
+(`project.docsContextFiles`). Individual ADR bodies under `decisions/` are
+**lazy / link-followed**, not auto-loaded — that is the whole point of the
+split: keep the per-task context lean while preserving the full decision
+history on disk. If a project genuinely wants the entire ADR set in mandatory
+context, it can add an explicit `decisions/*.md`-style entry to
+`project.docsContextFiles` as an opt-in (see the configuration reference), but
+index-only is the intended default.
+
+## Index
+
+| ADR      | Title                                    | Status   | Date       |
+| -------- | ---------------------------------------- | -------- | ---------- |
+| ADR-0001 | _Example — replace with your first ADR_  | Proposed | YYYY-MM-DD |
+
+_Add new rows above this line, newest first. Once you scaffold a real ADR from
+[`decisions/_template.md`](decisions/_template.md) into
+`decisions/0001-<title>.md`, link the ADR id to that file (e.g.
+`[ADR-0001](decisions/0001-<title>.md)`) and delete this example row._

--- a/.agents/templates/docs/decisions.md
+++ b/.agents/templates/docs/decisions.md
@@ -4,6 +4,17 @@
 > decisions here as dated entries. This file is one of the
 > `project.docsContextFiles` mandatory-reads — agents consult it before every
 > task to avoid re-litigating settled choices.
+>
+> **Two supported layouts — pick one at onboarding.** This single-file
+> dated-entry layout is the **default**, ideal for small projects. Once the
+> log grows past a few dozen entries it becomes a context-bloat liability;
+> at that point switch to the first-class **index + `decisions/` directory**
+> variant ([`decisions.index.md`](decisions.index.md) + the ADR scaffold at
+> [`decisions/_template.md`](decisions/_template.md)). Both layouts keep the
+> file named `decisions.md` so the `project.docsContextFiles` mandatory-read
+> resolves the same; only the shape differs. See
+> [`.agents/skills/core/documentation-and-adrs/SKILL.md`](../../skills/core/documentation-and-adrs/SKILL.md)
+> for when to choose which.
 
 ## Format
 

--- a/.agents/templates/docs/decisions/_template.md
+++ b/.agents/templates/docs/decisions/_template.md
@@ -1,0 +1,35 @@
+# ADR-NNNN: <short decision title>
+
+> Copy this file to `decisions/NNNN-<kebab-title>.md` (zero-padded, sequential
+> — `0001`, `0002`, …) and add a matching row to the `decisions.md` index.
+> ADRs are **append-only**: never rewrite or delete an accepted ADR — supersede
+> it with a new one and flip this one's **Status** to `Superseded by ADR-NNNN`.
+
+## Status
+
+Accepted
+
+<!-- One of: Proposed | Accepted | Superseded by ADR-NNNN | Deprecated -->
+
+## Date
+
+YYYY-MM-DD
+
+## Deciders
+
+<!-- Who made the call (names / roles / "the team"). -->
+
+## Context
+
+<!-- What forced the decision: the constraint, problem, or trade-off. What
+were the requirements and the forces in tension? -->
+
+## Decision
+
+<!-- What was chosen, stated plainly. -->
+
+## Consequences
+
+<!-- What this enables and what it costs going forward — positive and negative.
+Include follow-on work, new constraints, and anything a future reader must
+know before reversing this. -->


### PR DESCRIPTION
Closes #4229

_Auto-opened by `/single-story-deliver`._