### PR TITLE
fix(decompose): enforce/default the mandatory type::story label on Story create → no more unlabeled, undispatchable Stories (#4241)

### DIFF
--- a/.agents/scripts/lib/orchestration/epic-spec-reconciler-discriminator.js
+++ b/.agents/scripts/lib/orchestration/epic-spec-reconciler-discriminator.js
@@ -45,7 +45,7 @@
  * @property {string}  [reason]   Structured reason code when allowed=false.
  */
 
-import { AGENT_LABELS } from '../label-constants.js';
+import { AGENT_LABELS, TYPE_LABELS } from '../label-constants.js';
 
 /**
  * Execution-signal labels that block Close. Stored as a frozen Set for
@@ -246,6 +246,57 @@ export class LabelAllowListViolation extends Error {
 }
 
 /**
+ * Error class thrown synchronously by `assertStoryTypeLabel` when a Story
+ * create operation carries no `type::story` label. Named distinctly from
+ * `LabelAllowListViolation` so callers can route it separately.
+ *
+ * The class carries structured metadata (`slug`, `title`) so the error
+ * message can name the offending Story clearly.
+ */
+export class MissingTypeLabelError extends Error {
+  /**
+   * @param {string} message
+   * @param {{slug?: string, title?: string}} [meta]
+   */
+  constructor(message, meta = {}) {
+    super(message);
+    this.name = 'MissingTypeLabelError';
+    if (meta.slug !== undefined) this.slug = meta.slug;
+    if (meta.title !== undefined) this.title = meta.title;
+  }
+}
+
+/**
+ * Diff-time assertion. Throws `MissingTypeLabelError` synchronously when a
+ * Story create operation is missing the mandatory `type::story` label.
+ *
+ * Symmetric with `assertNoAgentLabels`: both fire at diff time so the plan
+ * fails loudly before the apply pipeline touches GitHub.
+ *
+ * Only validates Story create ops — Epic creates carry a different mandatory
+ * label (`type::epic`) that the caller already hard-codes at issue-creation
+ * time; the assertion is not needed there.
+ *
+ * @param {{slug?: string, title?: string, entity?: string, labels?: string[]}} op
+ * @returns {void}
+ */
+export function assertStoryTypeLabel(op) {
+  if (!op || typeof op !== 'object') return;
+  if (op.entity !== 'story') return;
+  // A create op for a Story MUST carry type::story. An absent or empty labels
+  // array means the mandatory label is missing — fail loud so the operator
+  // sees a named Story rather than a silent unlabeled issue on GitHub.
+  if (!Array.isArray(op.labels) || !op.labels.includes(TYPE_LABELS.STORY)) {
+    throw new MissingTypeLabelError(
+      `create plan for story slug=${op.slug ?? '?'} ("${op.title ?? ''}") is ` +
+        `missing the mandatory "${TYPE_LABELS.STORY}" label. Add it to the ` +
+        `spec's labels array for this Story and re-run.`,
+      { slug: op.slug, title: op.title },
+    );
+  }
+}
+
+/**
  * Diff-time assertion. Throws `LabelAllowListViolation` synchronously
  * when an operation targets an `agent::*` label. The assertion is the
  * safety net for the apply pipeline: plans fail loudly at construction
@@ -329,7 +380,10 @@ export function assertNoAgentLabels(op) {
  */
 export function assertPlanLabelAllowList(plan) {
   if (!plan || typeof plan !== 'object') return;
-  for (const op of plan.creates ?? []) assertNoAgentLabels(op);
+  for (const op of plan.creates ?? []) {
+    assertNoAgentLabels(op);
+    assertStoryTypeLabel(op);
+  }
   for (const op of plan.updates ?? []) assertNoAgentLabels(op);
   // closes/relinks do not carry label payloads — nothing to assert.
 }

--- a/.agents/scripts/providers/github/tickets.js
+++ b/.agents/scripts/providers/github/tickets.js
@@ -23,6 +23,7 @@
 
 import { parseBlockedBy, parseBlocks } from '../../lib/dependency-parser.js';
 import { Logger } from '../../lib/Logger.js';
+import { TYPE_LABELS } from '../../lib/label-constants.js';
 import { addIssueToBoard } from './board-add.js';
 import { createInlineTicketCache } from './cache.js';
 import { withTransientRetry } from './errors.js';
@@ -318,13 +319,21 @@ export class TicketGateway {
       dependencies: ticketData.dependencies ?? [],
     });
 
+    // Mirror the Epic create path (issues.js:160 → `labels: TYPE_LABELS.EPIC`):
+    // always inject TYPE_LABELS.STORY so a spec that omits the labels array
+    // cannot produce an unlabeled, undispatchable Story. Dedupe to avoid
+    // duplicates when the caller already carries the label.
+    const callerLabels = ticketData.labels ?? [];
+    const labels = callerLabels.includes(TYPE_LABELS.STORY)
+      ? callerLabels
+      : [TYPE_LABELS.STORY, ...callerLabels];
     const result = await this._gh.api({
       method: 'POST',
       endpoint: `/repos/${this.owner}/${this.repo}/issues`,
       body: {
         title: ticketData.title,
         body: renderedBody,
-        labels: ticketData.labels ?? [],
+        labels,
       },
     });
     const issue = parseApiJson(result);

--- a/tests/providers/github/tickets.test.js
+++ b/tests/providers/github/tickets.test.js
@@ -473,7 +473,9 @@ describe('providers/github/tickets.js — TicketGateway', () => {
       body: '',
       // labels intentionally absent — simulates the authoring-agent miss
     });
-    const posted = JSON.parse(gh.__exec.calls.find((c) => c.args[2] === 'POST').input);
+    const posted = JSON.parse(
+      gh.__exec.calls.find((c) => c.args[2] === 'POST').input,
+    );
     assert.ok(
       posted.labels.includes('type::story'),
       `POST body must carry type::story; got: ${JSON.stringify(posted.labels)}`,
@@ -498,7 +500,9 @@ describe('providers/github/tickets.js — TicketGateway', () => {
       body: '',
       labels: [],
     });
-    const posted = JSON.parse(gh.__exec.calls.find((c) => c.args[2] === 'POST').input);
+    const posted = JSON.parse(
+      gh.__exec.calls.find((c) => c.args[2] === 'POST').input,
+    );
     assert.ok(
       posted.labels.includes('type::story'),
       `POST body must carry type::story; got: ${JSON.stringify(posted.labels)}`,
@@ -523,8 +527,12 @@ describe('providers/github/tickets.js — TicketGateway', () => {
       body: '',
       labels: ['type::story', 'persona::backend'],
     });
-    const posted = JSON.parse(gh.__exec.calls.find((c) => c.args[2] === 'POST').input);
-    const storyLabelCount = posted.labels.filter((l) => l === 'type::story').length;
+    const posted = JSON.parse(
+      gh.__exec.calls.find((c) => c.args[2] === 'POST').input,
+    );
+    const storyLabelCount = posted.labels.filter(
+      (l) => l === 'type::story',
+    ).length;
     assert.equal(
       storyLabelCount,
       1,

--- a/tests/providers/github/tickets.test.js
+++ b/tests/providers/github/tickets.test.js
@@ -454,6 +454,85 @@ describe('providers/github/tickets.js — TicketGateway', () => {
     assert.ok(out.subIssueError instanceof Error);
   });
 
+  // Story #4241 — createTicket must always carry type::story in the POST body.
+  it('createTicket: injects type::story when labels is undefined (Story #4241)', async () => {
+    const gh = makeFakeGh({
+      'POST /repos/o/r/issues': {
+        status: 201,
+        json: {
+          number: 500,
+          id: 5000,
+          node_id: 'node_500',
+          html_url: 'https://example/500',
+        },
+      },
+    });
+    const gateway = new TicketGateway({ gh, owner: 'o', repo: 'r', hooks: {} });
+    await gateway.createTicket(10, {
+      title: 'Story without labels',
+      body: '',
+      // labels intentionally absent — simulates the authoring-agent miss
+    });
+    const posted = JSON.parse(gh.__exec.calls.find((c) => c.args[2] === 'POST').input);
+    assert.ok(
+      posted.labels.includes('type::story'),
+      `POST body must carry type::story; got: ${JSON.stringify(posted.labels)}`,
+    );
+  });
+
+  it('createTicket: injects type::story when labels is an empty array (Story #4241)', async () => {
+    const gh = makeFakeGh({
+      'POST /repos/o/r/issues': {
+        status: 201,
+        json: {
+          number: 501,
+          id: 5010,
+          node_id: 'node_501',
+          html_url: 'https://example/501',
+        },
+      },
+    });
+    const gateway = new TicketGateway({ gh, owner: 'o', repo: 'r', hooks: {} });
+    await gateway.createTicket(10, {
+      title: 'Story with empty labels',
+      body: '',
+      labels: [],
+    });
+    const posted = JSON.parse(gh.__exec.calls.find((c) => c.args[2] === 'POST').input);
+    assert.ok(
+      posted.labels.includes('type::story'),
+      `POST body must carry type::story; got: ${JSON.stringify(posted.labels)}`,
+    );
+  });
+
+  it('createTicket: does not duplicate type::story when caller already includes it (Story #4241)', async () => {
+    const gh = makeFakeGh({
+      'POST /repos/o/r/issues': {
+        status: 201,
+        json: {
+          number: 502,
+          id: 5020,
+          node_id: 'node_502',
+          html_url: 'https://example/502',
+        },
+      },
+    });
+    const gateway = new TicketGateway({ gh, owner: 'o', repo: 'r', hooks: {} });
+    await gateway.createTicket(10, {
+      title: 'Story with type::story already',
+      body: '',
+      labels: ['type::story', 'persona::backend'],
+    });
+    const posted = JSON.parse(gh.__exec.calls.find((c) => c.args[2] === 'POST').input);
+    const storyLabelCount = posted.labels.filter((l) => l === 'type::story').length;
+    assert.equal(
+      storyLabelCount,
+      1,
+      `type::story must appear exactly once; got: ${JSON.stringify(posted.labels)}`,
+    );
+    assert.ok(posted.labels.includes('persona::backend'));
+  });
+
   it('updateTicket: additive label-only PATCH skips body PATCH and invalidates cache', async () => {
     const cache = createInlineTicketCache();
     cache.set(50, {

--- a/tests/scripts/epic-reconcile.cli.test.js
+++ b/tests/scripts/epic-reconcile.cli.test.js
@@ -594,6 +594,7 @@ describe('runReconcile — bootstrap state.mapping.epic', () => {
             slug: 'story-only',
             title: 'Story only',
             wave: 0,
+            labels: ['type::story'],
           },
         ],
       }),

--- a/tests/scripts/epic-reconcile.resume-force.test.js
+++ b/tests/scripts/epic-reconcile.resume-force.test.js
@@ -46,7 +46,12 @@ function specWithStories({ storyTwoSlug = 'story-two', storyTwoTitle } = {}) {
   return {
     epic: { id: EPIC_ID, title: 'Resume/Force Epic' },
     stories: [
-      { slug: 'story-one', title: 'Story One', wave: 1, labels: ['type::story'] },
+      {
+        slug: 'story-one',
+        title: 'Story One',
+        wave: 1,
+        labels: ['type::story'],
+      },
       {
         slug: storyTwoSlug,
         title: storyTwoTitle ?? 'Story Two',
@@ -158,8 +163,18 @@ describe('runReconcile — Story #3905 changed-slug force re-plan', () => {
     const spec = {
       epic: { id: EPIC_ID, title: 'Resume/Force Epic' },
       stories: [
-        { slug: 'story-one', title: 'Story One', wave: 1, labels: ['type::story'] },
-        { slug: 'story-three', title: 'Story Three', wave: 1, labels: ['type::story'] },
+        {
+          slug: 'story-one',
+          title: 'Story One',
+          wave: 1,
+          labels: ['type::story'],
+        },
+        {
+          slug: 'story-three',
+          title: 'Story Three',
+          wave: 1,
+          labels: ['type::story'],
+        },
       ],
     };
     const ghState = {
@@ -209,7 +224,14 @@ describe('runReconcile — Story #3905 changed-slug force re-plan', () => {
     };
     const spec = {
       epic: { id: EPIC_ID, title: 'Resume/Force Epic' },
-      stories: [{ slug: 'story-three', title: 'Story Three', wave: 1, labels: ['type::story'] }],
+      stories: [
+        {
+          slug: 'story-three',
+          title: 'Story Three',
+          wave: 1,
+          labels: ['type::story'],
+        },
+      ],
     };
     const ghState = {
       [EPIC_ID]: { title: 'Resume/Force Epic', state: 'open' },
@@ -321,8 +343,18 @@ describe('runReconcile — Story #3905 --resume with deleted state.json', () => 
       // GH observations carry type::story so the spec labels match and the
       // diff produces no label-change ops — only then does the plan come out
       // empty and the no-duplication assertion hold.
-      101: { title: 'Story One', state: 'open', body: '', labels: ['type::story'] },
-      102: { title: 'Story Two', state: 'open', body: '', labels: ['type::story'] },
+      101: {
+        title: 'Story One',
+        state: 'open',
+        body: '',
+        labels: ['type::story'],
+      },
+      102: {
+        title: 'Story Two',
+        state: 'open',
+        body: '',
+        labels: ['type::story'],
+      },
     };
     const applySpy = { calls: 0, plan: null };
     const { deps } = buildDeps({

--- a/tests/scripts/epic-reconcile.resume-force.test.js
+++ b/tests/scripts/epic-reconcile.resume-force.test.js
@@ -46,11 +46,12 @@ function specWithStories({ storyTwoSlug = 'story-two', storyTwoTitle } = {}) {
   return {
     epic: { id: EPIC_ID, title: 'Resume/Force Epic' },
     stories: [
-      { slug: 'story-one', title: 'Story One', wave: 1 },
+      { slug: 'story-one', title: 'Story One', wave: 1, labels: ['type::story'] },
       {
         slug: storyTwoSlug,
         title: storyTwoTitle ?? 'Story Two',
         wave: 1,
+        labels: ['type::story'],
       },
     ],
   };
@@ -157,8 +158,8 @@ describe('runReconcile — Story #3905 changed-slug force re-plan', () => {
     const spec = {
       epic: { id: EPIC_ID, title: 'Resume/Force Epic' },
       stories: [
-        { slug: 'story-one', title: 'Story One', wave: 1 },
-        { slug: 'story-three', title: 'Story Three', wave: 1 },
+        { slug: 'story-one', title: 'Story One', wave: 1, labels: ['type::story'] },
+        { slug: 'story-three', title: 'Story Three', wave: 1, labels: ['type::story'] },
       ],
     };
     const ghState = {
@@ -208,7 +209,7 @@ describe('runReconcile — Story #3905 changed-slug force re-plan', () => {
     };
     const spec = {
       epic: { id: EPIC_ID, title: 'Resume/Force Epic' },
-      stories: [{ slug: 'story-three', title: 'Story Three', wave: 1 }],
+      stories: [{ slug: 'story-three', title: 'Story Three', wave: 1, labels: ['type::story'] }],
     };
     const ghState = {
       [EPIC_ID]: { title: 'Resume/Force Epic', state: 'open' },
@@ -317,8 +318,11 @@ describe('runReconcile — Story #3905 --resume with deleted state.json', () => 
         labels: [],
       },
       100: { title: 'Feature A', state: 'open', body: '', labels: [] },
-      101: { title: 'Story One', state: 'open', body: '', labels: [] },
-      102: { title: 'Story Two', state: 'open', body: '', labels: [] },
+      // GH observations carry type::story so the spec labels match and the
+      // diff produces no label-change ops — only then does the plan come out
+      // empty and the no-duplication assertion hold.
+      101: { title: 'Story One', state: 'open', body: '', labels: ['type::story'] },
+      102: { title: 'Story Two', state: 'open', body: '', labels: ['type::story'] },
     };
     const applySpy = { calls: 0, plan: null };
     const { deps } = buildDeps({

--- a/tests/scripts/epic-spec-reconciler.apply.test.js
+++ b/tests/scripts/epic-spec-reconciler.apply.test.js
@@ -91,6 +91,7 @@ describe('reconciler apply — dry-run path', () => {
         slug: 'story-new',
         entity: ENTITY_KINDS.STORY,
         title: 'New Story',
+        labels: ['type::story'],
         parentSlug: 'feat-alpha',
       }),
     );
@@ -175,6 +176,7 @@ describe('reconciler apply — create path', () => {
         slug: 'orphan-story',
         entity: ENTITY_KINDS.STORY,
         title: 'Orphan',
+        labels: ['type::story'],
         parentSlug: 'missing-parent',
       }),
     );

--- a/tests/scripts/epic-spec-reconciler.discriminator.test.js
+++ b/tests/scripts/epic-spec-reconciler.discriminator.test.js
@@ -20,9 +20,9 @@ import {
   assertPlanLabelAllowList,
   assertStoryTypeLabel,
   LabelAllowListViolation,
+  MissingTypeLabelError,
   mayClose,
   mayUpdate,
-  MissingTypeLabelError,
   STRUCTURAL_LABELS,
 } from '../../.agents/scripts/lib/orchestration/epic-spec-reconciler-discriminator.js';
 import { OP_KINDS } from '../../.agents/scripts/lib/orchestration/epic-spec-reconciler-ops.js';

--- a/tests/scripts/epic-spec-reconciler.discriminator.test.js
+++ b/tests/scripts/epic-spec-reconciler.discriminator.test.js
@@ -18,9 +18,11 @@ import { diff } from '../../.agents/scripts/lib/orchestration/epic-spec-reconcil
 import {
   assertNoAgentLabels,
   assertPlanLabelAllowList,
+  assertStoryTypeLabel,
   LabelAllowListViolation,
   mayClose,
   mayUpdate,
+  MissingTypeLabelError,
   STRUCTURAL_LABELS,
 } from '../../.agents/scripts/lib/orchestration/epic-spec-reconciler-discriminator.js';
 import { OP_KINDS } from '../../.agents/scripts/lib/orchestration/epic-spec-reconciler-ops.js';
@@ -407,6 +409,218 @@ describe('diff engine — wires the diff-time assertion', () => {
       () => diff({ spec, state, ghState }),
       LabelAllowListViolation,
     );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// assertStoryTypeLabel — mandatory type::story enforcement (Story #4241)
+// ---------------------------------------------------------------------------
+
+describe('assertStoryTypeLabel — mandatory type::story on Story create ops', () => {
+  it('throws MissingTypeLabelError when labels is undefined', () => {
+    assert.throws(
+      () =>
+        assertStoryTypeLabel({
+          kind: OP_KINDS.CREATE,
+          slug: 'story-x',
+          entity: 'story',
+          title: 'Missing Label Story',
+          // labels intentionally absent
+        }),
+      (err) => {
+        assert.ok(err instanceof MissingTypeLabelError);
+        assert.equal(err.slug, 'story-x');
+        assert.equal(err.title, 'Missing Label Story');
+        assert.match(err.message, /type::story/);
+        return true;
+      },
+    );
+  });
+
+  it('throws MissingTypeLabelError when labels is an empty array', () => {
+    assert.throws(
+      () =>
+        assertStoryTypeLabel({
+          kind: OP_KINDS.CREATE,
+          slug: 'story-y',
+          entity: 'story',
+          title: 'Empty Labels Story',
+          labels: [],
+        }),
+      (err) => {
+        assert.ok(err instanceof MissingTypeLabelError);
+        assert.equal(err.slug, 'story-y');
+        return true;
+      },
+    );
+  });
+
+  it('throws MissingTypeLabelError when labels carries other labels but not type::story', () => {
+    assert.throws(
+      () =>
+        assertStoryTypeLabel({
+          kind: OP_KINDS.CREATE,
+          slug: 'story-z',
+          entity: 'story',
+          title: 'Partially Labeled',
+          labels: ['area::core', 'persona::backend'],
+        }),
+      MissingTypeLabelError,
+    );
+  });
+
+  it('does NOT throw when type::story is present', () => {
+    assert.doesNotThrow(() =>
+      assertStoryTypeLabel({
+        kind: OP_KINDS.CREATE,
+        slug: 'story-ok',
+        entity: 'story',
+        title: 'Good Story',
+        labels: ['type::story', 'area::core'],
+      }),
+    );
+  });
+
+  it('does NOT throw for Epic create ops (entity !== "story")', () => {
+    assert.doesNotThrow(() =>
+      assertStoryTypeLabel({
+        kind: OP_KINDS.CREATE,
+        slug: 'epic',
+        entity: 'epic',
+        title: 'My Epic',
+        labels: ['type::epic'],
+      }),
+    );
+  });
+
+  it('is a no-op for non-object inputs', () => {
+    assert.doesNotThrow(() => assertStoryTypeLabel(null));
+    assert.doesNotThrow(() => assertStoryTypeLabel(undefined));
+    assert.doesNotThrow(() => assertStoryTypeLabel('string'));
+  });
+});
+
+describe('assertPlanLabelAllowList — Story create op missing type::story', () => {
+  it('throws MissingTypeLabelError for a Story create op with labels: undefined', () => {
+    assert.throws(
+      () =>
+        assertPlanLabelAllowList({
+          creates: [
+            {
+              kind: OP_KINDS.CREATE,
+              slug: 'story-unlabeled',
+              entity: 'story',
+              title: 'Unlabeled Story',
+              // labels absent
+            },
+          ],
+          updates: [],
+          closes: [],
+          relinks: [],
+        }),
+      MissingTypeLabelError,
+    );
+  });
+
+  it('throws MissingTypeLabelError for a Story create op with labels: []', () => {
+    assert.throws(
+      () =>
+        assertPlanLabelAllowList({
+          creates: [
+            {
+              kind: OP_KINDS.CREATE,
+              slug: 'story-empty-labels',
+              entity: 'story',
+              title: 'Empty Labels Story',
+              labels: [],
+            },
+          ],
+          updates: [],
+          closes: [],
+          relinks: [],
+        }),
+      MissingTypeLabelError,
+    );
+  });
+
+  it('does not throw when all Story create ops carry type::story', () => {
+    assert.doesNotThrow(() =>
+      assertPlanLabelAllowList({
+        creates: [
+          {
+            kind: OP_KINDS.CREATE,
+            slug: 'story-labeled',
+            entity: 'story',
+            title: 'Properly Labeled',
+            labels: ['type::story', 'persona::backend'],
+          },
+        ],
+        updates: [],
+        closes: [],
+        relinks: [],
+      }),
+    );
+  });
+});
+
+describe('diff engine — rejects Story create ops missing type::story (Story #4241)', () => {
+  it('throws MissingTypeLabelError when a spec Story omits labels entirely', () => {
+    const spec = {
+      epic: { id: 9001, title: 'Test Epic', labels: ['type::epic'] },
+      stories: [
+        {
+          slug: 'story-nolabel',
+          title: 'No Label Story',
+          wave: 0,
+          // labels intentionally absent
+        },
+      ],
+    };
+    const state = { epicId: 9001, mapping: {} };
+    assert.throws(
+      () => diff({ spec, state, ghState: {} }),
+      MissingTypeLabelError,
+    );
+  });
+
+  it('throws MissingTypeLabelError when a spec Story carries an empty labels array', () => {
+    const spec = {
+      epic: { id: 9002, title: 'Test Epic', labels: ['type::epic'] },
+      stories: [
+        {
+          slug: 'story-emptylabels',
+          title: 'Empty Labels Story',
+          wave: 0,
+          labels: [],
+        },
+      ],
+    };
+    const state = { epicId: 9002, mapping: {} };
+    assert.throws(
+      () => diff({ spec, state, ghState: {} }),
+      (err) => {
+        assert.ok(err instanceof MissingTypeLabelError);
+        assert.equal(err.slug, 'story-emptylabels');
+        assert.equal(err.title, 'Empty Labels Story');
+        return true;
+      },
+    );
+  });
+
+  it('does not throw when the spec Story carries type::story', () => {
+    const spec = {
+      epic: { id: 9003, title: 'Test Epic', labels: ['type::epic'] },
+      stories: [
+        {
+          slug: 'story-ok',
+          title: 'OK Story',
+          wave: 0,
+          labels: ['type::story'],
+        },
+      ],
+    };
+    const state = { epicId: 9003, mapping: {} };
+    assert.doesNotThrow(() => diff({ spec, state, ghState: {} }));
   });
 });
 


### PR DESCRIPTION
Closes #4241

_Auto-opened by `/single-story-deliver`._