### PR TITLE
feat: project .agents/local/workflows/ into slash commands (prune-exempt consumer commands) (#4243)

### DIFF
--- a/.agents/instructions.md
+++ b/.agents/instructions.md
@@ -76,6 +76,15 @@ environment variables that override project defaults. The config resolver
 deep-merges `.agentrc.local.json` over `.agentrc.json` (local wins; absent
 local file is a no-op). Do not modify these local files unless requested.
 
+**Durable slash commands.** Any `.md` file placed at
+`.agents/local/workflows/<name>.md` is automatically projected into
+`.claude/commands/<name>.md` by `sync-claude-commands.js`, making it
+invocable as `/<name>`. Because the entire `.agents/local/` subtree is
+exempt from `mandrel sync`'s prune pass, these commands survive
+`npm install`, `mandrel sync`, and `mandrel update` with no manual
+re-sync. Core payload commands of the same basename always win (the
+local copy is ignored with a `shadowed` warning).
+
 ### F. Modular Global Rules
 
 Before writing code or documentation, verify if any domain-agnostic rules

--- a/.agents/scripts/sync-claude-commands.js
+++ b/.agents/scripts/sync-claude-commands.js
@@ -1,10 +1,18 @@
 #!/usr/bin/env node
 
 /**
- * Projects .agents/workflows/ into a flat `.claude/commands/` tree so Claude
- * Code exposes each workflow as a bare `/<name>` slash command. The workflows
- * directory remains the single source of truth; this script is the only writer
- * of `.claude/commands/`.
+ * Projects .agents/workflows/ (and .agents/local/workflows/ when present) into
+ * a flat `.claude/commands/` tree so Claude Code exposes each workflow as a
+ * bare `/<name>` slash command. Two source directories are enumerated in order:
+ *
+ *   1. PAYLOAD_SRC  — `.agents/workflows/`  (the installed Mandrel payload)
+ *   2. LOCAL_SRC    — `.agents/local/workflows/`  (consumer-authored, prune-exempt)
+ *
+ * The payload directory wins on basename collision: if both sources supply
+ * `foo.md`, the payload copy is projected and the local copy is ignored with a
+ * `shadowed` warning. Because both sources are unioned into `sourceSet`, local
+ * commands are also protected from the orphan-reap — they survive
+ * `npm install`, `mandrel sync`, and `mandrel update` with no manual re-sync.
  *
  * Flat projection (reverts the #3576 plugin cutover): the plugin command tree
  * (`.claude/plugins/mandrel/`) and the repo-local marketplace
@@ -48,15 +56,37 @@ const PROJECT_ROOT = process.cwd();
 // fixture workflow tree in isolation (regression test for the Epic #1185
 // frontmatter pass-through contract). When unset, behaviour is unchanged
 // — the script defaults to the real workflows / commands directories.
-const SRC_DIR =
+// SYNC_CLAUDE_COMMANDS_SRC overrides the PAYLOAD source only; the LOCAL_SRC
+// is always derived from the project root so fixture tests can isolate the
+// payload source while still allowing LOCAL_SRC to be present if needed.
+const PAYLOAD_SRC =
   process.env.SYNC_CLAUDE_COMMANDS_SRC ??
   path.join(PROJECT_ROOT, '.agents', 'workflows');
+const LOCAL_SRC = path.join(PROJECT_ROOT, '.agents', 'local', 'workflows');
+
 const DEST_DIR =
   process.env.SYNC_CLAUDE_COMMANDS_DEST ??
   path.join(PROJECT_ROOT, '.claude', 'commands');
 
 export const HEADER =
   '<!-- AUTO-GENERATED — do not edit. Source of truth: .agents/workflows/ -->\n<!-- Re-run: npm run sync:commands -->\n\n';
+
+export const LOCAL_HEADER =
+  '<!-- AUTO-GENERATED from .agents/local/ — do not edit. Source of truth: .agents/local/workflows/ -->\n<!-- Re-run: npm run sync:commands -->\n\n';
+
+/**
+ * Return true when the given directory path exists and is accessible.
+ *
+ * @param {string} dir
+ * @returns {boolean}
+ */
+function dirExists(dir) {
+  try {
+    return fs.statSync(dir).isDirectory();
+  } catch {
+    return false;
+  }
+}
 
 /**
  * Reap the generated plugin projection (the #3576 surface) so the namespaced
@@ -102,12 +132,33 @@ fs.mkdirSync(DEST_DIR, { recursive: true });
 const isTopLevelWorkflow = (entry) =>
   entry.isFile() && entry.name.endsWith('.md');
 
+// Enumerate sources: payload first, then local (if it exists). Payload wins
+// on basename collision — a consumer must not silently shadow a core command.
+const SRC_DIRS = [PAYLOAD_SRC, LOCAL_SRC].filter(dirExists);
+
+/** @type {Array<{dir: string, name: string}>} */
+const entries = SRC_DIRS.flatMap((dir) =>
+  fs
+    .readdirSync(dir, { withFileTypes: true })
+    .filter(isTopLevelWorkflow)
+    .map((e) => ({ dir, name: e.name })),
+);
+
+// Collision policy: payload wins, warn on a shadowed local file.
+const byName = new Map();
+for (const e of entries) {
+  if (byName.has(e.name)) {
+    Logger.warn(`  shadowed  ${e.name} (local copy ignored; payload wins)`);
+    continue;
+  }
+  byName.set(e.name, e);
+}
+
+// sourceSet drives the orphan-reap: any existing command not in this set is
+// removed. Local-projected commands are included, so they survive the reap.
+const sourceSet = new Set(byName.keys());
+
 const existing = fs.readdirSync(DEST_DIR).filter((f) => f.endsWith('.md'));
-const sources = fs
-  .readdirSync(SRC_DIR, { withFileTypes: true })
-  .filter(isTopLevelWorkflow)
-  .map((entry) => entry.name);
-const sourceSet = new Set(sources);
 
 for (const file of existing) {
   if (!sourceSet.has(file)) {
@@ -118,18 +169,18 @@ for (const file of existing) {
 
 // Copy each workflow, injecting the auto-generated header after any leading
 // frontmatter (so the `---` block stays on line 1 and Claude Code parses the
-// command description). Parallelised so the ~30-file sync doesn't serialise on
-// per-file fs latency (noticeable on Windows where each syscall pays a larger
-// fixed cost).
+// command description). Use a distinct header comment for local-origin files.
+// Parallelised so the ~30-file sync doesn't serialise on per-file fs latency
+// (noticeable on Windows where each syscall pays a larger fixed cost).
 let synced = 0;
+const resolvedEntries = Array.from(byName.values());
 await Promise.all(
-  sources.map(async (file) => {
-    const content = await fs.promises.readFile(
-      path.join(SRC_DIR, file),
-      'utf8',
-    );
-    const dest = path.join(DEST_DIR, file);
-    const target = applyHeader(content, HEADER);
+  resolvedEntries.map(async ({ dir, name }) => {
+    const isLocal = dir === LOCAL_SRC;
+    const header = isLocal ? LOCAL_HEADER : HEADER;
+    const content = await fs.promises.readFile(path.join(dir, name), 'utf8');
+    const dest = path.join(DEST_DIR, name);
+    const target = applyHeader(content, header);
 
     // Skip write if content is already identical (avoid noisy git diffs).
     // Use try/catch over existsSync+readFile so we only pay one syscall.
@@ -142,10 +193,10 @@ await Promise.all(
 
     await fs.promises.writeFile(dest, target, 'utf8');
     synced++;
-    Logger.info(`  synced   ${file}`);
+    Logger.info(`  synced   ${name}`);
   }),
 );
 
 Logger.info(
-  `\n✔ ${synced} file(s) synced, ${sources.length} total commands in .claude/commands/`,
+  `\n✔ ${synced} file(s) synced, ${sourceSet.size} total commands in .claude/commands/`,
 );

--- a/tests/sync-claude-commands-local.test.js
+++ b/tests/sync-claude-commands-local.test.js
@@ -1,0 +1,370 @@
+/**
+ * sync-claude-commands — local/workflows/ source (Story #4243)
+ *
+ * Verifies the prune-exempt second source directory:
+ *   AC1. A file at .agents/local/workflows/foo.md projects to
+ *        .claude/commands/foo.md (invocable as /foo).
+ *   AC2. The projected command survives a second sync run (idempotent /
+ *        prune-exempt: no "no longer in workflows" removal).
+ *   AC3. A core payload command of the same basename wins; the local copy
+ *        is ignored with a "shadowed" warning on stderr/stdout.
+ *   AC4. Removing the local file removes its projected command on the next
+ *        sync (still reaped when absent from both sources).
+ *   AC5. The SYNC_CLAUDE_COMMANDS_SRC test override still works (existing
+ *        fixture tests continue to pass; LOCAL_SRC remains absent or empty
+ *        when the fixture tree has no local/workflows/).
+ */
+
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const PROJECT_ROOT = path.resolve(__dirname, '..');
+const SYNC_SCRIPT = path.join(
+  PROJECT_ROOT,
+  '.agents',
+  'scripts',
+  'sync-claude-commands.js',
+);
+
+const LOCAL_HEADER =
+  '<!-- AUTO-GENERATED from .agents/local/ — do not edit. Source of truth: .agents/local/workflows/ -->\n<!-- Re-run: npm run sync:commands -->\n\n';
+
+const PAYLOAD_HEADER =
+  '<!-- AUTO-GENERATED — do not edit. Source of truth: .agents/workflows/ -->\n<!-- Re-run: npm run sync:commands -->\n\n';
+
+/**
+ * Run sync-claude-commands.js with a fully isolated fixture tree.
+ *
+ * `options.payloadFiles`  — map of name→content to write under workflows/
+ * `options.localFiles`    — map of name→content to write under local/workflows/
+ * `options.existingDest`  — map of name→content to pre-populate .claude/commands/
+ *
+ * Returns { dest, result, commands, tmp, cleanup }.
+ */
+function runSyncIsolated({
+  payloadFiles = {},
+  localFiles = {},
+  existingDest = {},
+} = {}) {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'sync-local-test-'));
+
+  // Payload source (overridden via SYNC_CLAUDE_COMMANDS_SRC)
+  const payloadSrc = path.join(tmp, 'workflows');
+  fs.mkdirSync(payloadSrc, { recursive: true });
+  for (const [name, content] of Object.entries(payloadFiles)) {
+    fs.writeFileSync(path.join(payloadSrc, name), content, 'utf8');
+  }
+
+  // Local source — lives at <cwd>/.agents/local/workflows/ relative to the
+  // project root that sync-claude-commands derives from process.cwd().
+  // We set cwd to `tmp` and create the local/ tree there.
+  const localSrc = path.join(tmp, '.agents', 'local', 'workflows');
+  if (Object.keys(localFiles).length > 0) {
+    fs.mkdirSync(localSrc, { recursive: true });
+    for (const [name, content] of Object.entries(localFiles)) {
+      fs.writeFileSync(path.join(localSrc, name), content, 'utf8');
+    }
+  }
+
+  // Destination
+  const dest = path.join(tmp, '.claude', 'commands');
+  fs.mkdirSync(dest, { recursive: true });
+  for (const [name, content] of Object.entries(existingDest)) {
+    fs.writeFileSync(path.join(dest, name), content, 'utf8');
+  }
+
+  const result = spawnSync(process.execPath, [SYNC_SCRIPT], {
+    cwd: tmp,
+    env: {
+      ...process.env,
+      SYNC_CLAUDE_COMMANDS_SRC: payloadSrc,
+      SYNC_CLAUDE_COMMANDS_DEST: dest,
+    },
+    encoding: 'utf8',
+  });
+
+  const commands = {};
+  for (const f of fs.readdirSync(dest)) {
+    commands[f] = fs.readFileSync(path.join(dest, f), 'utf8');
+  }
+
+  return {
+    dest,
+    result,
+    commands,
+    tmp,
+    localSrc,
+    cleanup: () => fs.rmSync(tmp, { recursive: true, force: true }),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// AC1: local file projects to commands/
+// ---------------------------------------------------------------------------
+
+test('AC1: .agents/local/workflows/foo.md projects to .claude/commands/foo.md', () => {
+  const run = runSyncIsolated({
+    localFiles: {
+      'benchmark.md': '# /benchmark\n\nA durable consumer command.\n',
+    },
+  });
+  try {
+    assert.equal(run.result.status, 0, run.result.stderr);
+    assert.ok(
+      run.commands['benchmark.md'],
+      'benchmark.md should appear in .claude/commands/',
+    );
+    // Must carry the local header, not the payload header
+    assert.ok(
+      run.commands['benchmark.md'].includes(
+        'AUTO-GENERATED from .agents/local/',
+      ),
+      'projected local command must carry the local-origin header',
+    );
+    assert.ok(
+      run.commands['benchmark.md'].includes('A durable consumer command.'),
+      'body content must be preserved',
+    );
+  } finally {
+    run.cleanup();
+  }
+});
+
+// ---------------------------------------------------------------------------
+// AC2: projected command survives a re-run (prune-exempt)
+// ---------------------------------------------------------------------------
+
+test('AC2: local command survives a second sync run (prune-exempt)', () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'sync-local-survive-'));
+  try {
+    const payloadSrc = path.join(tmp, 'workflows');
+    fs.mkdirSync(payloadSrc, { recursive: true });
+
+    const localSrc = path.join(tmp, '.agents', 'local', 'workflows');
+    fs.mkdirSync(localSrc, { recursive: true });
+    fs.writeFileSync(
+      path.join(localSrc, 'my-command.md'),
+      '# /my-command\n\nDurable.\n',
+      'utf8',
+    );
+
+    const dest = path.join(tmp, '.claude', 'commands');
+    fs.mkdirSync(dest, { recursive: true });
+
+    const env = {
+      ...process.env,
+      SYNC_CLAUDE_COMMANDS_SRC: payloadSrc,
+      SYNC_CLAUDE_COMMANDS_DEST: dest,
+    };
+
+    // First run — projects the command
+    const first = spawnSync(process.execPath, [SYNC_SCRIPT], {
+      cwd: tmp,
+      env,
+      encoding: 'utf8',
+    });
+    assert.equal(first.status, 0, first.stderr);
+    assert.ok(
+      fs.existsSync(path.join(dest, 'my-command.md')),
+      'command must exist after first run',
+    );
+
+    // Second run — must not reap the command
+    const second = spawnSync(process.execPath, [SYNC_SCRIPT], {
+      cwd: tmp,
+      env,
+      encoding: 'utf8',
+    });
+    assert.equal(second.status, 0, second.stderr);
+    assert.ok(
+      fs.existsSync(path.join(dest, 'my-command.md')),
+      'command must still exist after second run (prune-exempt)',
+    );
+    assert.doesNotMatch(
+      second.stdout + second.stderr,
+      /removed.*my-command/,
+      'second run must not report the local command as removed',
+    );
+  } finally {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// AC3: payload wins on collision; shadowed warning emitted
+// ---------------------------------------------------------------------------
+
+test('AC3: payload command wins when local has same basename; shadowed warning emitted', () => {
+  const payloadContent = '# /deliver\n\nThis is the PAYLOAD deliver command.\n';
+  const localContent = '# /deliver\n\nThis is the LOCAL deliver command.\n';
+
+  const run = runSyncIsolated({
+    payloadFiles: { 'deliver.md': payloadContent },
+    localFiles: { 'deliver.md': localContent },
+  });
+  try {
+    assert.equal(run.result.status, 0, run.result.stderr);
+    assert.ok(run.commands['deliver.md'], 'deliver.md must be projected');
+
+    // Payload body must win
+    assert.ok(
+      run.commands['deliver.md'].includes('PAYLOAD deliver command'),
+      'projected command must contain payload content, not local content',
+    );
+    assert.ok(
+      !run.commands['deliver.md'].includes('LOCAL deliver command'),
+      'local content must be suppressed when shadowed',
+    );
+
+    // A "shadowed" warning must be emitted (Logger.warn goes to stdout in
+    // this project's Logger implementation)
+    const combinedOutput = run.result.stdout + run.result.stderr;
+    assert.match(
+      combinedOutput,
+      /shadowed.*deliver\.md|deliver\.md.*shadowed/i,
+      'a shadowed warning must be logged for the collision',
+    );
+  } finally {
+    run.cleanup();
+  }
+});
+
+// ---------------------------------------------------------------------------
+// AC4: removing local file removes its projected command on next sync
+// ---------------------------------------------------------------------------
+
+test('AC4: removing .agents/local/workflows/foo.md reaps .claude/commands/foo.md on next sync', () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'sync-local-reap-'));
+  try {
+    const payloadSrc = path.join(tmp, 'workflows');
+    fs.mkdirSync(payloadSrc, { recursive: true });
+
+    const localSrc = path.join(tmp, '.agents', 'local', 'workflows');
+    fs.mkdirSync(localSrc, { recursive: true });
+    fs.writeFileSync(
+      path.join(localSrc, 'to-remove.md'),
+      '# /to-remove\n',
+      'utf8',
+    );
+
+    const dest = path.join(tmp, '.claude', 'commands');
+    fs.mkdirSync(dest, { recursive: true });
+
+    const env = {
+      ...process.env,
+      SYNC_CLAUDE_COMMANDS_SRC: payloadSrc,
+      SYNC_CLAUDE_COMMANDS_DEST: dest,
+    };
+
+    // First run — projects the command
+    const first = spawnSync(process.execPath, [SYNC_SCRIPT], {
+      cwd: tmp,
+      env,
+      encoding: 'utf8',
+    });
+    assert.equal(first.status, 0, first.stderr);
+    assert.ok(
+      fs.existsSync(path.join(dest, 'to-remove.md')),
+      'command must exist after first run',
+    );
+
+    // Delete the local source file
+    fs.unlinkSync(path.join(localSrc, 'to-remove.md'));
+
+    // Second run — must reap the now-orphaned command
+    const second = spawnSync(process.execPath, [SYNC_SCRIPT], {
+      cwd: tmp,
+      env,
+      encoding: 'utf8',
+    });
+    assert.equal(second.status, 0, second.stderr);
+    assert.equal(
+      fs.existsSync(path.join(dest, 'to-remove.md')),
+      false,
+      'command must be reaped after its local source is deleted',
+    );
+  } finally {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// AC5: SYNC_CLAUDE_COMMANDS_SRC override still works (existing fixture contract)
+// ---------------------------------------------------------------------------
+
+test('AC5: SYNC_CLAUDE_COMMANDS_SRC override still works; no local/ = no extra commands', () => {
+  // When the cwd has no .agents/local/workflows/, LOCAL_SRC is silently skipped
+  // and the behaviour is identical to the pre-#4243 single-source mode.
+  const run = runSyncIsolated({
+    payloadFiles: {
+      'plan.md': '# /plan\n\nPayload-only command.\n',
+    },
+    // No localFiles — no .agents/local/workflows/ created
+  });
+  try {
+    assert.equal(run.result.status, 0, run.result.stderr);
+    const names = Object.keys(run.commands).sort();
+    assert.deepEqual(
+      names,
+      ['plan.md'],
+      'only the payload command should exist',
+    );
+    // Payload header must be applied (not local header)
+    assert.ok(
+      run.commands['plan.md'].includes(
+        'AUTO-GENERATED — do not edit. Source of truth: .agents/workflows/',
+      ),
+      'payload command must carry the standard payload header',
+    );
+    assert.ok(
+      !run.commands['plan.md'].includes('AUTO-GENERATED from .agents/local/'),
+      'payload command must not carry the local header',
+    );
+  } finally {
+    run.cleanup();
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Extra: local and payload commands coexist without interfering
+// ---------------------------------------------------------------------------
+
+test('local and payload commands coexist without interfering', () => {
+  const run = runSyncIsolated({
+    payloadFiles: {
+      'deliver.md': '# /deliver\n\nPayload deliver.\n',
+      'plan.md': '# /plan\n\nPayload plan.\n',
+    },
+    localFiles: {
+      'benchmark.md': '# /benchmark\n\nLocal benchmark.\n',
+    },
+  });
+  try {
+    assert.equal(run.result.status, 0, run.result.stderr);
+    const names = Object.keys(run.commands).sort();
+    assert.deepEqual(
+      names,
+      ['benchmark.md', 'deliver.md', 'plan.md'],
+      'all three commands must be projected',
+    );
+    // benchmark uses local header; deliver + plan use payload header
+    assert.ok(
+      run.commands['benchmark.md'].includes(
+        'AUTO-GENERATED from .agents/local/',
+      ),
+    );
+    assert.ok(
+      run.commands['deliver.md'].includes(
+        'AUTO-GENERATED — do not edit. Source of truth: .agents/workflows/',
+      ),
+    );
+  } finally {
+    run.cleanup();
+  }
+});


### PR DESCRIPTION
Closes #4243

_Auto-opened by `/single-story-deliver`._