### PR TITLE
fix(plan): stop stamping context spec tickets as type::story so first decompose isn't blocked (#4246)

### DIFF
--- a/.agents/scripts/lib/orchestration/epic-plan-lease-guard.js
+++ b/.agents/scripts/lib/orchestration/epic-plan-lease-guard.js
@@ -341,11 +341,20 @@ export async function assertNoOpenPlanChildren({
   const openChildren = (children ?? []).filter((t) => {
     const labels = Array.isArray(t.labels) ? t.labels : [];
     const isOpen = t.state === undefined || t.state === 'open';
-    // Any open typed plan ticket counts — `type::story` plus pre-v4
-    // `type::feature` leftovers. The prefix check is legacy-data
-    // detection, not compat support: the guard only refuses, it never
-    // processes the legacy tier. Context tickets (`context::*`) are
-    // untouched.
+    // Context spec tickets (PRD / Tech Spec / Acceptance Spec) carry a
+    // `context::*` label and — since the `createTicket` factory injects
+    // `type::story` by default — also `type::story`. They are reference
+    // artifacts that stay open across delivery, NOT plan children, so they
+    // MUST be excluded here: counting them would make every first decompose
+    // (where the three context tickets are the only open children) refuse.
+    const isContext = labels.some(
+      (l) => typeof l === 'string' && l.startsWith('context::'),
+    );
+    if (isContext) return false;
+    // Any remaining open typed plan ticket counts — `type::story` plus pre-v4
+    // `type::feature` leftovers. The prefix check is legacy-data detection,
+    // not compat support: the guard only refuses, it never processes the
+    // legacy tier.
     return (
       isOpen &&
       labels.some((l) => typeof l === 'string' && l.startsWith('type::'))

--- a/.agents/scripts/lib/orchestration/epic-runner/phases/build-wave-dag.js
+++ b/.agents/scripts/lib/orchestration/epic-runner/phases/build-wave-dag.js
@@ -41,7 +41,9 @@ export async function discoverOpenStories({ epicId, provider }) {
     // tickets that way, but a context ticket mislabelled out-of-band must
     // still never reach a delivery wave (it has no `story-<id>` branch or
     // acceptance contract to deliver against).
-    if (labels.some((l) => typeof l === 'string' && l.startsWith('context::'))) {
+    if (
+      labels.some((l) => typeof l === 'string' && l.startsWith('context::'))
+    ) {
       continue;
     }
     const rawState = t.state ?? 'open';

--- a/.agents/scripts/lib/orchestration/epic-runner/phases/build-wave-dag.js
+++ b/.agents/scripts/lib/orchestration/epic-runner/phases/build-wave-dag.js
@@ -35,6 +35,15 @@ export async function discoverOpenStories({ epicId, provider }) {
   for (const t of descendants) {
     const labels = t.labels ?? [];
     if (!labels.includes(TYPE_LABELS.STORY)) continue;
+    // Defense-in-depth: never enumerate a context spec ticket (PRD / Tech
+    // Spec / Acceptance Spec) as a deliverable Story even if it carries
+    // `type::story`. The `createTicket` factory no longer stamps context
+    // tickets that way, but a context ticket mislabelled out-of-band must
+    // still never reach a delivery wave (it has no `story-<id>` branch or
+    // acceptance contract to deliver against).
+    if (labels.some((l) => typeof l === 'string' && l.startsWith('context::'))) {
+      continue;
+    }
     const rawState = t.state ?? 'open';
     const norm = typeof rawState === 'string' ? rawState.toLowerCase() : 'open';
     if (norm !== 'open') continue;

--- a/.agents/scripts/providers/github/tickets.js
+++ b/.agents/scripts/providers/github/tickets.js
@@ -320,13 +320,26 @@ export class TicketGateway {
     });
 
     // Mirror the Epic create path (issues.js:160 → `labels: TYPE_LABELS.EPIC`):
-    // always inject TYPE_LABELS.STORY so a spec that omits the labels array
-    // cannot produce an unlabeled, undispatchable Story. Dedupe to avoid
-    // duplicates when the caller already carries the label.
+    // inject TYPE_LABELS.STORY so a spec that omits the labels array cannot
+    // produce an unlabeled, undispatchable Story. Dedupe to avoid duplicates
+    // when the caller already carries the label.
+    //
+    // Context spec tickets (PRD / Tech Spec / Acceptance Spec) are a distinct
+    // ticket class created through this same factory carrying a `context::*`
+    // label (and no `type::story`). They MUST NOT be stamped `type::story`:
+    // doing so makes every `type::story`-counting consumer — the decompose
+    // open-children guard (`assertNoOpenPlanChildren`), the delivery wave
+    // builder (`discoverOpenStories`), the plan healthcheck — mis-classify
+    // them as deliverable Stories. Skip the injection when the caller's labels
+    // already classify the ticket as context.
     const callerLabels = ticketData.labels ?? [];
-    const labels = callerLabels.includes(TYPE_LABELS.STORY)
-      ? callerLabels
-      : [TYPE_LABELS.STORY, ...callerLabels];
+    const isContextTicket = callerLabels.some(
+      (l) => typeof l === 'string' && l.startsWith('context::'),
+    );
+    const labels =
+      isContextTicket || callerLabels.includes(TYPE_LABELS.STORY)
+        ? callerLabels
+        : [TYPE_LABELS.STORY, ...callerLabels];
     const result = await this._gh.api({
       method: 'POST',
       endpoint: `/repos/${this.owner}/${this.repo}/issues`,

--- a/tests/lib/orchestration/epic-plan-lease-guard.test.js
+++ b/tests/lib/orchestration/epic-plan-lease-guard.test.js
@@ -475,6 +475,65 @@ describe('epic-plan-lease-guard — assertNoOpenPlanChildren', () => {
     });
     assert.deepEqual(result.openChildren, []);
   });
+
+  it('does not count context tickets that also carry type::story (Story #4246)', async () => {
+    // Regression: createTicket's default-label injection stamps the three
+    // context spec tickets with type::story alongside their context:: label.
+    // On a FIRST decompose these are the only open children — the guard must
+    // exclude them (by their context:: label) rather than refuse persist.
+    const provider = makeProvider({
+      children: [
+        {
+          id: 13,
+          title: 'PRD',
+          labels: ['type::story', 'context::prd'],
+          state: 'open',
+        },
+        {
+          id: 14,
+          title: 'Tech Spec',
+          labels: ['type::story', 'context::tech-spec'],
+          state: 'open',
+        },
+        {
+          id: 15,
+          title: 'Acceptance Spec',
+          labels: ['type::story', 'context::acceptance-spec'],
+          state: 'open',
+        },
+      ],
+    });
+    const result = await assertNoOpenPlanChildren({
+      provider,
+      epicId: 9,
+      force: false,
+    });
+    assert.deepEqual(result.openChildren, []);
+  });
+
+  it('still refuses real Stories even when context tickets are present (Story #4246)', async () => {
+    // The context exclusion must not blind the guard to a genuine open Story
+    // sitting alongside the context tickets on a re-decompose.
+    const provider = makeProvider({
+      children: [
+        {
+          id: 13,
+          title: 'PRD',
+          labels: ['type::story', 'context::prd'],
+          state: 'open',
+        },
+        { id: 16, title: 'Story A', labels: ['type::story'], state: 'open' },
+      ],
+    });
+    await assert.rejects(
+      assertNoOpenPlanChildren({ provider, epicId: 9, force: false }),
+      (err) => {
+        assert.match(err.message, /already has 1 open plan child/);
+        assert.match(err.message, /#16 Story A/);
+        return true;
+      },
+    );
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/tests/lib/orchestration/epic-runner/phases/build-wave-dag.test.js
+++ b/tests/lib/orchestration/epic-runner/phases/build-wave-dag.test.js
@@ -1,0 +1,69 @@
+// tests/lib/orchestration/epic-runner/phases/build-wave-dag.test.js
+//
+// Unit coverage for `discoverOpenStories` — the shared Story-enumeration
+// contract behind the wave DAG, the snapshot payload, and the preflight
+// Story count. Story #4246 adds the context-ticket exclusion so a context
+// spec ticket can never be enumerated as a deliverable Story.
+
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import { discoverOpenStories } from '../../../../../.agents/scripts/lib/orchestration/epic-runner/phases/build-wave-dag.js';
+
+function makeProvider(children) {
+  return {
+    async getSubTickets(_epicId) {
+      return children;
+    },
+  };
+}
+
+describe('build-wave-dag — discoverOpenStories', () => {
+  it('returns the open type::story children', async () => {
+    const provider = makeProvider([
+      { id: 11, labels: ['type::story'], state: 'open' },
+      { id: 12, labels: ['type::story'], state: 'open' },
+    ]);
+    const stories = await discoverOpenStories({ epicId: 9, provider });
+    assert.deepEqual(
+      stories.map((s) => s.id),
+      [11, 12],
+    );
+  });
+
+  it('skips closed Stories', async () => {
+    const provider = makeProvider([
+      { id: 11, labels: ['type::story'], state: 'open' },
+      { id: 12, labels: ['type::story'], state: 'closed' },
+    ]);
+    const stories = await discoverOpenStories({ epicId: 9, provider });
+    assert.deepEqual(
+      stories.map((s) => s.id),
+      [11],
+    );
+  });
+
+  it('excludes context spec tickets even when they carry type::story (Story #4246)', async () => {
+    // A context ticket mislabelled with type::story must never reach a
+    // delivery wave — it has no story branch or acceptance contract.
+    const provider = makeProvider([
+      { id: 13, labels: ['type::story', 'context::prd'], state: 'open' },
+      {
+        id: 14,
+        labels: ['type::story', 'context::tech-spec'],
+        state: 'open',
+      },
+      {
+        id: 15,
+        labels: ['type::story', 'context::acceptance-spec'],
+        state: 'open',
+      },
+      { id: 16, labels: ['type::story'], state: 'open' },
+    ]);
+    const stories = await discoverOpenStories({ epicId: 9, provider });
+    assert.deepEqual(
+      stories.map((s) => s.id),
+      [16],
+    );
+  });
+});

--- a/tests/providers/github/tickets.test.js
+++ b/tests/providers/github/tickets.test.js
@@ -541,6 +541,39 @@ describe('providers/github/tickets.js — TicketGateway', () => {
     assert.ok(posted.labels.includes('persona::backend'));
   });
 
+  it('createTicket: does NOT inject type::story onto context spec tickets (Story #4246)', async () => {
+    // Context tickets (PRD / Tech Spec / Acceptance Spec) are created through
+    // this same factory carrying only a context:: label. Stamping them
+    // type::story makes every story-counting consumer (the decompose
+    // open-children guard, the delivery wave builder) mis-classify them as
+    // deliverable Stories. The injection must be skipped for context tickets.
+    const gh = makeFakeGh({
+      'POST /repos/o/r/issues': {
+        status: 201,
+        json: {
+          number: 503,
+          id: 5030,
+          node_id: 'node_503',
+          html_url: 'https://example/503',
+        },
+      },
+    });
+    const gateway = new TicketGateway({ gh, owner: 'o', repo: 'r', hooks: {} });
+    await gateway.createTicket(10, {
+      title: '[PRD] Some Epic',
+      body: '',
+      labels: ['context::prd'],
+    });
+    const posted = JSON.parse(
+      gh.__exec.calls.find((c) => c.args[2] === 'POST').input,
+    );
+    assert.ok(
+      !posted.labels.includes('type::story'),
+      `context ticket must NOT carry type::story; got: ${JSON.stringify(posted.labels)}`,
+    );
+    assert.deepEqual(posted.labels, ['context::prd']);
+  });
+
   it('updateTicket: additive label-only PATCH skips body PATCH and invalidates cache', async () => {
     const cache = createInlineTicketCache();
     cache.set(50, {


### PR DESCRIPTION
Closes #4246

_Auto-opened by `/single-story-deliver`._