### PR TITLE
feat: add --epic/--branch flags to story-phase.js and drop the duplicate closing snapshot (#4256)

### DIFF
--- a/.agents/scripts/__tests__/story-phase.test.js
+++ b/.agents/scripts/__tests__/story-phase.test.js
@@ -1,0 +1,174 @@
+import assert from 'node:assert/strict';
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, it } from 'node:test';
+
+import { parseArgv, runStoryPhase } from '../story-phase.js';
+
+// ---------------------------------------------------------------------------
+// Story #4256 — `--epic` / `--branch` skip the GitHub reads.
+//
+// `story-phase.js` is invoked 3–5×/story by the `/deliver` worker. Each call
+// re-fetched the (immutable) epicId via `readEpicIdFromStory` (a `getTicket`
+// read) and the Story branch via `resolveStoryBranch` (a `getTicketComments`
+// read) — even though both are known from `story-init.js`'s Step 0 envelope.
+// Passing `--epic` / `--branch` short-circuits both reads. This suite is the
+// regression guard for "zero GitHub reads when the flags are supplied".
+// ---------------------------------------------------------------------------
+
+const EPIC_ID = 9;
+const STORY_ID = 104;
+
+/**
+ * In-memory provider that counts the two read surfaces `runStoryPhase`
+ * consumes for hierarchy / branch resolution (`getTicket`,
+ * `getTicketComments`). postComment / deleteComment / updateTicket back the
+ * render-only snapshot upsert and are not part of the read-skip contract.
+ */
+function makeCountingProvider({ storyBody } = {}) {
+  const comments = [];
+  let nextId = 1;
+  const reads = { getTicket: 0, getTicketComments: 0 };
+  return {
+    reads,
+    comments,
+    async getTicket(id) {
+      reads.getTicket += 1;
+      return { id, body: storyBody ?? '', assignees: [] };
+    },
+    async getTicketComments(_id) {
+      reads.getTicketComments += 1;
+      return comments;
+    },
+    async postComment(_id, { body }) {
+      const comment = { id: nextId++, body };
+      comments.push(comment);
+      return { commentId: comment.id, id: comment.id };
+    },
+    async deleteComment(commentId) {
+      const idx = comments.findIndex((c) => c.id === commentId);
+      if (idx >= 0) comments.splice(idx, 1);
+    },
+    async updateTicket() {},
+  };
+}
+
+let ledgerDir;
+beforeEach(() => {
+  ledgerDir = mkdtempSync(path.join(tmpdir(), 'story-phase-flags-'));
+});
+afterEach(() => {
+  ledgerDir = null;
+});
+
+describe('story-phase — --epic / --branch skip GitHub reads (Story #4256)', () => {
+  it('performs ZERO getTicket / getTicketComments reads when both flags are supplied', async () => {
+    const provider = makeCountingProvider();
+    const ledgerPath = path.join(ledgerDir, 'lifecycle.ndjson');
+
+    const envelope = await runStoryPhase({
+      storyId: STORY_ID,
+      phase: 'implementing',
+      epicId: EPIC_ID,
+      branch: `story-${STORY_ID}`,
+      provider,
+      config: { github: {} },
+      ledgerPath,
+    });
+
+    assert.equal(provider.reads.getTicket, 0);
+    assert.equal(provider.reads.getTicketComments, 0);
+    // The supplied values are used verbatim, not re-derived.
+    assert.equal(envelope.epicId, EPIC_ID);
+    assert.equal(envelope.branch, `story-${STORY_ID}`);
+    assert.equal(envelope.heartbeatEmitted, true);
+  });
+
+  it('still performs the GitHub reads when the flags are absent (interactive fallback)', async () => {
+    const provider = makeCountingProvider({
+      storyBody: `Story body.\n\nEpic: #${EPIC_ID}\n`,
+    });
+    const ledgerPath = path.join(ledgerDir, 'lifecycle.ndjson');
+
+    const envelope = await runStoryPhase({
+      storyId: STORY_ID,
+      phase: 'implementing',
+      // no epicId / branch overrides
+      provider,
+      config: { github: {} },
+      ledgerPath,
+    });
+
+    // readEpicIdFromStory ran (getTicket) and resolveStoryBranch ran
+    // (getTicketComments).
+    assert.equal(provider.reads.getTicket, 1);
+    assert.ok(provider.reads.getTicketComments >= 1);
+    // Resolution still produces the right values from the body / fallback.
+    assert.equal(envelope.epicId, EPIC_ID);
+    assert.equal(envelope.branch, `story-${STORY_ID}`);
+  });
+
+  it('skips only the branch read when --branch alone is supplied', async () => {
+    const provider = makeCountingProvider({
+      storyBody: `Story body.\n\nEpic: #${EPIC_ID}\n`,
+    });
+    const ledgerPath = path.join(ledgerDir, 'lifecycle.ndjson');
+
+    await runStoryPhase({
+      storyId: STORY_ID,
+      phase: 'implementing',
+      branch: `story-${STORY_ID}`,
+      provider,
+      config: { github: {} },
+      ledgerPath,
+    });
+
+    // Branch supplied → no getTicketComments read; epicId still resolved off
+    // the body → one getTicket read.
+    assert.equal(provider.reads.getTicketComments, 0);
+    assert.equal(provider.reads.getTicket, 1);
+  });
+
+  it('skips only the epic read when --epic alone is supplied', async () => {
+    const provider = makeCountingProvider();
+    const ledgerPath = path.join(ledgerDir, 'lifecycle.ndjson');
+
+    await runStoryPhase({
+      storyId: STORY_ID,
+      phase: 'implementing',
+      epicId: EPIC_ID,
+      provider,
+      config: { github: {} },
+      ledgerPath,
+    });
+
+    // Epic supplied → no getTicket read; branch still resolved via snapshot
+    // lookup → at least one getTicketComments read.
+    assert.equal(provider.reads.getTicket, 0);
+    assert.ok(provider.reads.getTicketComments >= 1);
+  });
+});
+
+describe('story-phase — parseArgv flag wiring (Story #4256)', () => {
+  it('parses --epic into a numeric epicId and --branch into branch', () => {
+    const parsed = parseArgv([
+      '--story',
+      '104',
+      '--phase',
+      'closing',
+      '--epic',
+      '9',
+      '--branch',
+      'story-104',
+    ]);
+    assert.equal(parsed.epicId, 9);
+    assert.equal(parsed.branch, 'story-104');
+  });
+
+  it('leaves epicId / branch undefined when the flags are absent', () => {
+    const parsed = parseArgv(['--story', '104', '--phase', 'closing']);
+    assert.equal(parsed.epicId, undefined);
+    assert.equal(parsed.branch, undefined);
+  });
+});

--- a/.agents/scripts/story-phase.js
+++ b/.agents/scripts/story-phase.js
@@ -27,6 +27,12 @@
  *   --story <id>                        Story ID (required).
  *   --phase <init|implementing|closing|blocked|done>
  *                                       Phase the Story is entering (required).
+ *   --epic <id>                         Parent Epic id from the Step 0 envelope.
+ *                                       When supplied, skips the readEpicIdFromStory
+ *                                       GitHub read.
+ *   --branch <name>                     Story branch from the Step 0 envelope.
+ *                                       When supplied, skips the resolveStoryBranch
+ *                                       GitHub read.
  *   --no-heartbeat                      Suppress the lifecycle emit (tests).
  *
  * Stdout: a single JSON envelope
@@ -67,12 +73,17 @@ const VALID_PHASES = new Set([
 
 const HELP = `Usage: node .agents/scripts/story-phase.js \\
   --story <id> --phase <init|implementing|closing|blocked|done> \\
-  [--no-heartbeat]
+  [--epic <id>] [--branch <name>] [--no-heartbeat]
 
 Renders the Story-phase snapshot for Story #<id> at the requested phase
 (returned as renderedBody for chat relay; no comment is posted) and
 (unless --no-heartbeat) appends one story.heartbeat record to the parent
 Epic's lifecycle ledger so the Idle Watchdog can confirm the Story is alive.
+
+--epic / --branch let the caller pass the parent Epic id and Story branch
+from story-init.js's Step 0 envelope, skipping the GitHub reads
+(readEpicIdFromStory / resolveStoryBranch) that would otherwise re-fetch
+these immutable values on every phase call. Omit both for interactive use.
 `;
 
 /**
@@ -216,9 +227,17 @@ function emitHeartbeatBestEffort({
  * End-to-end phase writer. DI-friendly: tests pass `provider`, override
  * the ledger path, and skip the heartbeat as needed.
  *
+ * When `epicId` / `branch` are supplied (the `/deliver` worker passes them
+ * from `story-init.js`'s Step 0 envelope), the corresponding GitHub read is
+ * skipped entirely: `epicId` short-circuits `readEpicIdFromStory` and
+ * `branch` short-circuits `resolveStoryBranch`. Omit both for interactive
+ * use to restore the original GitHub-read resolution.
+ *
  * @param {{
  *   storyId: number,
  *   phase: string,
+ *   epicId?: number|null,
+ *   branch?: string,
  *   noHeartbeat?: boolean,
  *   provider?: object,
  *   config?: object,
@@ -230,6 +249,8 @@ export async function runStoryPhase(args) {
   const {
     storyId,
     phase,
+    epicId: epicIdOverride,
+    branch: branchOverride,
     noHeartbeat = false,
     provider: providerOverride,
     config: configOverride,
@@ -253,8 +274,17 @@ export async function runStoryPhase(args) {
     : (ticketId, payload, opts = {}) =>
         notify(ticketId, payload, { config, provider, ...opts });
 
-  const branch = await resolveStoryBranch({ provider, storyId });
-  const epicId = await readEpicIdFromStory({ provider, storyId });
+  // When the Step 0 envelope supplied the branch / epicId (the /deliver
+  // worker passes them via --branch / --epic), skip the GitHub reads that
+  // would otherwise re-fetch these immutable values on every phase call.
+  const branch =
+    typeof branchOverride === 'string' && branchOverride
+      ? branchOverride
+      : await resolveStoryBranch({ provider, storyId });
+  const epicId =
+    epicIdOverride !== undefined
+      ? epicIdOverride
+      : await readEpicIdFromStory({ provider, storyId });
   const phases = phasesForWorkflowPhase(phase, now);
 
   const { body: renderedBody, payload: snapshot } =
@@ -301,17 +331,29 @@ export function parseArgv(argv) {
     options: {
       story: { type: 'string' },
       phase: { type: 'string' },
+      epic: { type: 'string' },
+      branch: { type: 'string' },
       'no-heartbeat': { type: 'boolean' },
       help: { type: 'boolean' },
     },
     strict: false,
   });
-  return {
+  // `--epic` absent → leave `epicId` undefined so runStoryPhase falls back to
+  // the readEpicIdFromStory GitHub read. `--branch` absent → leave `branch`
+  // undefined so it falls back to resolveStoryBranch.
+  const parsed = {
     help: Boolean(values.help),
     storyId: Number.parseInt(values.story ?? '', 10),
     phase: values.phase,
     noHeartbeat: Boolean(values['no-heartbeat']),
   };
+  if (values.epic !== undefined) {
+    parsed.epicId = Number.parseInt(values.epic, 10);
+  }
+  if (typeof values.branch === 'string' && values.branch) {
+    parsed.branch = values.branch;
+  }
+  return parsed;
 }
 
 export async function main(argv = process.argv.slice(2)) {

--- a/.agents/workflows/helpers/epic-deliver-story.md
+++ b/.agents/workflows/helpers/epic-deliver-story.md
@@ -139,11 +139,15 @@ the Story-level rollup the parent `/deliver` aggregator reads).
 Run a single Story-implementation phase against the inline `acceptance[]`
 / `verify[]` arrays on the Story body.
 
-1. Flip the snapshot to the `implementing` phase:
+1. Flip the snapshot to the `implementing` phase. Pass `--epic <epicId>`
+   and `--branch story-<storyId>` from the Step 0 envelope so the render
+   skips the `readEpicIdFromStory` / `resolveStoryBranch` GitHub reads
+   (pass these same flags to **every** `story-phase.js` call below):
 
    ```bash
    node .agents/scripts/story-phase.js \
-     --story <storyId> --phase implementing
+     --story <storyId> --epic <epicId> --branch story-<storyId> \
+     --phase implementing
    ```
 
 2. Read the Story body's inline `acceptance[]` and `verify[]` arrays
@@ -166,11 +170,14 @@ Run a single Story-implementation phase against the inline `acceptance[]`
    evidence** — they are no longer optional advisory pre-flight.
 
 5. Once the eval loop returns `proceed`, flip the snapshot to `closing`
-   and proceed to Step 3:
+   and proceed to Step 3 (Step 3 invokes close directly — it no longer
+   re-renders the `closing` snapshot, so this is the single `closing`
+   render):
 
    ```bash
    node .agents/scripts/story-phase.js \
-     --story <storyId> --phase closing
+     --story <storyId> --epic <epicId> --branch story-<storyId> \
+     --phase closing
    ```
 
 6. If blocked (including by the eval loop reaching its round cap with
@@ -180,7 +187,8 @@ Run a single Story-implementation phase against the inline `acceptance[]`
 
    ```bash
    node .agents/scripts/story-phase.js \
-     --story <storyId> --phase blocked
+     --story <storyId> --epic <epicId> --branch story-<storyId> \
+     --phase blocked
    ```
 
 ### Step 1a — Bounded acceptance self-eval loop (**required, not optional**)
@@ -235,16 +243,18 @@ fine as advisory pre-flight.)
 
 ## Step 3 — Close (`story-close.js`)
 
-Flip the snapshot to the closing phase, then invoke close. Pass the
-main-checkout path via `--cwd` so the merge and branch deletion run
-against the main repo (branches checked out in a worktree cannot be
+Step 1 item 5 already flipped the snapshot to the `closing` phase, so this
+step does **not** re-render it (the duplicate render was removed). Invoke
+close directly. Pass the parent Epic id via `--epic <epicId>` from the
+Step 0 envelope so close skips re-parsing the Epic hierarchy off the
+Story body (which also closes the malformed-`Epic:`-line failure mode).
+Pass the main-checkout path via `--cwd` so the merge and branch deletion
+run against the main repo (branches checked out in a worktree cannot be
 deleted from themselves):
 
 ```bash
-node .agents/scripts/story-phase.js \
-  --story <storyId> --phase closing
-
-node <main-repo>/.agents/scripts/story-close.js --story <storyId> --cwd <main-repo>
+node <main-repo>/.agents/scripts/story-close.js \
+  --story <storyId> --epic <epicId> --cwd <main-repo>
 ```
 
 In single-tree mode, `--cwd` defaults to `PROJECT_ROOT`. The script merges
@@ -261,7 +271,8 @@ After close, upsert a terminal snapshot:
 
 ```bash
 node .agents/scripts/story-phase.js \
-  --story <storyId> --phase done
+  --story <storyId> --epic <epicId> --branch story-<storyId> \
+  --phase done
 ```
 
 ---


### PR DESCRIPTION
Closes #4256

_Auto-opened by `/single-story-deliver`._