### PR TITLE
feat: persist Projects v2 board metadata to a disk cache (#4252)

### DIFF
--- a/.agents/scripts/lib/config/temp-paths.js
+++ b/.agents/scripts/lib/config/temp-paths.js
@@ -128,7 +128,7 @@ export function _clearMainCheckoutRootCache() {
  * @param {string} tempRoot
  * @returns {string}
  */
-function anchorTempRoot(tempRoot) {
+export function anchorTempRoot(tempRoot) {
   if (path.isAbsolute(tempRoot)) return tempRoot;
   const root = mainCheckoutRoot();
   return root ? path.join(root, tempRoot) : tempRoot;

--- a/.agents/scripts/lib/orchestration/__tests__/column-sync.test.js
+++ b/.agents/scripts/lib/orchestration/__tests__/column-sync.test.js
@@ -18,11 +18,15 @@ import { afterEach, beforeEach, describe, it } from 'node:test';
 
 import { ColumnSync } from '../column-sync.js';
 import {
-  DEFAULT_META_TTL_MS,
-  projectMetaCachePath,
   readProjectMetaCache,
   writeProjectMetaCache,
 } from '../project-meta-cache.js';
+
+// The on-disk cache layout under tempRoot (mirrors the module's internal
+// `projectMetaCachePath`). Pinned here so the AC5 assertion verifies the
+// exact path shape independently of the implementation helper.
+const cachePathFor = (tmpDir) =>
+  path.join(tmpDir, 'cache', 'project-meta.json');
 
 /**
  * A fresh isolated tempRoot per test so the on-disk cache never bleeds
@@ -122,7 +126,7 @@ describe('project-meta disk cache (Story #4252)', () => {
     const sync = new ColumnSync({ provider, config: tmp.config });
     await sync.sync(321, ['agent::executing']);
 
-    const cacheFile = projectMetaCachePath(tmp.config);
+    const cacheFile = cachePathFor(tmp.dir);
     // The cache file lives under the resolved tempRoot.
     assert.ok(
       cacheFile.startsWith(tmp.dir),
@@ -184,7 +188,9 @@ describe('project-meta disk cache (Story #4252)', () => {
         options: new Map([['In Progress', 'stale-opt']]),
       },
       config: tmp.config,
-      now: Date.now() - (DEFAULT_META_TTL_MS + 60_000),
+      // Stamp the entry at the Unix epoch so it is always outside any
+      // reasonable TTL window — the read must treat it as expired.
+      now: 0,
     });
 
     const provider = recordingProvider();

--- a/.agents/scripts/lib/orchestration/__tests__/column-sync.test.js
+++ b/.agents/scripts/lib/orchestration/__tests__/column-sync.test.js
@@ -1,0 +1,290 @@
+/**
+ * column-sync — on-disk board-metadata cache tests (Story #4252).
+ *
+ * The companion behavioural suite for `columnForLabels` / `ColumnSync.sync` /
+ * `readCurrentColumn` lives at `tests/lib/orchestration/column-sync.test.js`.
+ * This file is the test home the Story's `verify[]` command names and is
+ * scoped to the disk-cache contract: warm-cache collapses a flip to ~1
+ * GraphQL call, the cache is keyed by `owner/projectNumber` under `tempRoot`,
+ * it carries a TTL, and it is invalidated on a GraphQL mutation error so a
+ * mid-run board reconfiguration self-heals.
+ */
+
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, it } from 'node:test';
+
+import { ColumnSync } from '../column-sync.js';
+import {
+  DEFAULT_META_TTL_MS,
+  projectMetaCachePath,
+  readProjectMetaCache,
+  writeProjectMetaCache,
+} from '../project-meta-cache.js';
+
+/**
+ * A fresh isolated tempRoot per test so the on-disk cache never bleeds
+ * across cases (or into the repo's real `temp/`). Returned as a config bag
+ * shaped like the resolved config (`project.paths.tempRoot`). The absolute
+ * path is honoured verbatim by the temp-paths anchor.
+ */
+function makeTempConfig() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'mandrel-pmcache-'));
+  return { dir, config: { project: { paths: { tempRoot: dir } } } };
+}
+
+/**
+ * A provider whose `graphql` records every call and answers the three query
+ * shapes ColumnSync issues: the board-metadata resolve, the by-issue
+ * projectItems lookup, and the Status mutation. `onMutate` lets a test make
+ * the mutation throw to exercise invalidate-on-error.
+ */
+function recordingProvider({ onMutate } = {}) {
+  const graphqlCalls = [];
+  const provider = {
+    graphqlCalls,
+    projectNumber: 42,
+    owner: 'acme',
+    repo: 'widgets',
+    async graphql(query, vars) {
+      graphqlCalls.push({ query, vars });
+      if (
+        query.includes('projectV2(number') &&
+        !query.includes('projectItems')
+      ) {
+        return {
+          viewer: {
+            projectV2: {
+              id: 'PROJ',
+              field: {
+                id: 'FIELD',
+                options: [
+                  { id: 'opt-todo', name: 'Todo' },
+                  { id: 'opt-inprog', name: 'In Progress' },
+                  { id: 'opt-done', name: 'Done' },
+                ],
+              },
+            },
+          },
+        };
+      }
+      if (query.includes('projectItems(first')) {
+        return {
+          repository: {
+            issue: {
+              projectItems: {
+                nodes: [{ id: 'ITEM-1', project: { id: 'PROJ' } }],
+              },
+            },
+          },
+        };
+      }
+      if (query.includes('updateProjectV2ItemFieldValue')) {
+        if (onMutate) onMutate();
+        return {
+          updateProjectV2ItemFieldValue: { projectV2Item: { id: vars.itemId } },
+        };
+      }
+      return {};
+    },
+  };
+  return provider;
+}
+
+const countResolveCalls = (provider) =>
+  provider.graphqlCalls.filter(
+    (c) =>
+      c.query.includes('projectV2(number') && !c.query.includes('projectItems'),
+  ).length;
+const countItemLookups = (provider) =>
+  provider.graphqlCalls.filter((c) => c.query.includes('projectItems(first'))
+    .length;
+const countMutations = (provider) =>
+  provider.graphqlCalls.filter((c) =>
+    c.query.includes('updateProjectV2ItemFieldValue'),
+  ).length;
+
+describe('project-meta disk cache (Story #4252)', () => {
+  let tmp;
+
+  beforeEach(() => {
+    tmp = makeTempConfig();
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmp.dir, { recursive: true, force: true });
+  });
+
+  it('persists { projectId, fieldId, options } keyed by owner/projectNumber under tempRoot', async () => {
+    const provider = recordingProvider();
+    const sync = new ColumnSync({ provider, config: tmp.config });
+    await sync.sync(321, ['agent::executing']);
+
+    const cacheFile = projectMetaCachePath(tmp.config);
+    // The cache file lives under the resolved tempRoot.
+    assert.ok(
+      cacheFile.startsWith(tmp.dir),
+      `cache file ${cacheFile} should live under tempRoot ${tmp.dir}`,
+    );
+    assert.ok(fs.existsSync(cacheFile), 'cache file was written');
+
+    const store = JSON.parse(fs.readFileSync(cacheFile, 'utf8'));
+    const entry = store['acme/42'];
+    assert.ok(entry, 'cache is keyed by owner/projectNumber');
+    assert.equal(entry.projectId, 'PROJ');
+    assert.equal(entry.fieldId, 'FIELD');
+    assert.deepEqual(entry.options, {
+      Todo: 'opt-todo',
+      'In Progress': 'opt-inprog',
+      Done: 'opt-done',
+    });
+    assert.equal(typeof entry.cachedAt, 'number');
+  });
+
+  it('warm cache collapses a label flip to ~1 GraphQL call (the mutation)', async () => {
+    // Cold process #1: full resolve + item lookup + mutation = 3 calls.
+    const cold = recordingProvider();
+    const coldSync = new ColumnSync({ provider: cold, config: tmp.config });
+    const coldRes = await coldSync.sync(321, ['agent::executing']);
+    assert.equal(coldRes.status, 'synced');
+    assert.ok(countResolveCalls(cold) >= 1, 'cold resolve happened');
+    assert.equal(countMutations(cold), 1);
+
+    // Cold process #2: a *new* ColumnSync (empty in-process cache, as a
+    // separate CLI process would have) reads the metadata from disk and
+    // skips the resolve entirely. The only metadata-shaped call left is the
+    // by-issue item lookup; the mutation is the single board-state write.
+    const warm = recordingProvider();
+    const warmSync = new ColumnSync({ provider: warm, config: tmp.config });
+    const warmRes = await warmSync.sync(321, ['agent::executing']);
+    assert.equal(warmRes.status, 'synced');
+
+    assert.equal(
+      countResolveCalls(warm),
+      0,
+      'warm cache skips resolveProjectMeta (the ~2 metadata round-trips)',
+    );
+    assert.equal(countMutations(warm), 1, 'still issues exactly the mutation');
+    // ~1 GraphQL call: the mutation. (An item-id lookup is still needed to
+    // address the per-issue project item; it is not board metadata and is
+    // out of scope per the Story.)
+    assert.equal(countItemLookups(warm), 1, 'one item-id lookup, no resolve');
+  });
+
+  it('treats an expired entry as a miss and re-resolves (TTL)', async () => {
+    // Seed a stale entry well outside the TTL window.
+    writeProjectMetaCache({
+      owner: 'acme',
+      projectNumber: 42,
+      meta: {
+        projectId: 'STALE',
+        fieldId: 'STALE',
+        options: new Map([['In Progress', 'stale-opt']]),
+      },
+      config: tmp.config,
+      now: Date.now() - (DEFAULT_META_TTL_MS + 60_000),
+    });
+
+    const provider = recordingProvider();
+    const sync = new ColumnSync({ provider, config: tmp.config });
+    const res = await sync.sync(321, ['agent::executing']);
+    assert.equal(res.status, 'synced');
+    // Expired → resolve fired again and the live projectId was used.
+    assert.ok(
+      countResolveCalls(provider) >= 1,
+      'expired entry forced a re-resolve',
+    );
+    const mutation = provider.graphqlCalls.find((c) =>
+      c.query.includes('updateProjectV2ItemFieldValue'),
+    );
+    assert.equal(
+      mutation.vars.projectId,
+      'PROJ',
+      'used freshly-resolved board id',
+    );
+  });
+
+  it('invalidates the disk cache on a GraphQL mutation error so the next flip re-resolves', async () => {
+    // Warm the cache from a clean process.
+    const warmProvider = recordingProvider();
+    await new ColumnSync({ provider: warmProvider, config: tmp.config }).sync(
+      321,
+      ['agent::executing'],
+    );
+    assert.ok(
+      readProjectMetaCache({
+        owner: 'acme',
+        projectNumber: 42,
+        config: tmp.config,
+      }),
+    );
+
+    // Next cold process reads the warm cache, but the mutation fails (e.g.
+    // the board was reconfigured and the cached optionId is now invalid).
+    const failingProvider = recordingProvider({
+      onMutate() {
+        throw new Error('board reconfigured');
+      },
+    });
+    const failingSync = new ColumnSync({
+      provider: failingProvider,
+      config: tmp.config,
+      logger: { warn: () => {} },
+    });
+    await assert.rejects(
+      () => failingSync.sync(321, ['agent::executing']),
+      /board reconfigured/,
+    );
+
+    // The error invalidated the cache entry — the next flip will re-resolve.
+    assert.equal(
+      readProjectMetaCache({
+        owner: 'acme',
+        projectNumber: 42,
+        config: tmp.config,
+      }),
+      null,
+      'cache entry was invalidated after the mutation error',
+    );
+
+    // Prove self-heal: a fresh process now re-resolves against the live board.
+    const healed = recordingProvider();
+    const healedRes = await new ColumnSync({
+      provider: healed,
+      config: tmp.config,
+    }).sync(321, ['agent::executing']);
+    assert.equal(healedRes.status, 'synced');
+    assert.ok(countResolveCalls(healed) >= 1, 'self-healed by re-resolving');
+  });
+
+  it('does not invalidate the cache when the failing meta was freshly resolved (cold miss)', async () => {
+    // No warm entry: the mutation error is transient/live, not a stale-cache
+    // problem, so the just-written cache entry must survive.
+    const provider = recordingProvider({
+      onMutate() {
+        throw new Error('transient API blip');
+      },
+    });
+    const sync = new ColumnSync({
+      provider,
+      config: tmp.config,
+      logger: { warn: () => {} },
+    });
+    await assert.rejects(
+      () => sync.sync(321, ['agent::executing']),
+      /transient API blip/,
+    );
+    // The resolve still wrote the cache; a transient mutation failure must
+    // not discard freshly-resolved, valid metadata.
+    assert.ok(
+      readProjectMetaCache({
+        owner: 'acme',
+        projectNumber: 42,
+        config: tmp.config,
+      }),
+      'fresh-resolve cache entry survives a transient mutation error',
+    );
+  });
+});

--- a/.agents/scripts/lib/orchestration/column-sync.js
+++ b/.agents/scripts/lib/orchestration/column-sync.js
@@ -35,6 +35,11 @@
  */
 
 import { AGENT_LABELS } from '../label-constants.js';
+import {
+  invalidateProjectMetaCache,
+  readProjectMetaCache,
+  writeProjectMetaCache,
+} from './project-meta-cache.js';
 import { resolveProjectMeta } from './project-meta-resolver.js';
 
 export const LABEL_TO_COLUMN = Object.freeze({
@@ -74,6 +79,7 @@ export class ColumnSync {
    *   projectNumber?: number | null,
    *   projectOwner?: string | null,
    *   logger?: { info: Function, warn: Function },
+   *   config?: object,
    *   ctx?: { provider?: object, config?: { github?: { projectNumber?: number|null } }, logger?: object },
    * }} opts
    */
@@ -89,7 +95,16 @@ export class ColumnSync {
       null;
     this.projectOwner = opts.projectOwner ?? provider.projectOwner ?? null;
     this.logger = opts.logger ?? ctx?.logger ?? console;
+    // Resolved config bag used to locate the on-disk meta cache's tempRoot.
+    // Optional — when omitted, the cache resolves the framework-default
+    // `temp` root (Story #4252).
+    this.config = opts.config ?? ctx?.config ?? undefined;
     this._meta = null; // lazy-cached { projectId, fieldId, options: Map<name, id> }
+    // Records whether the in-process `_meta` was hydrated from the on-disk
+    // cache, so a GraphQL error against possibly-stale cached metadata can
+    // invalidate the disk entry and force a fresh resolve on the next flip
+    // (Story #4252).
+    this._metaFromDiskCache = false;
   }
 
   /**
@@ -117,8 +132,9 @@ export class ColumnSync {
     const itemId = await this.#getProjectItemId(issueId, meta.projectId);
     if (!itemId) return { status: 'skipped', reason: 'not-on-project' };
 
-    await this.provider.graphql(
-      `
+    try {
+      await this.provider.graphql(
+        `
       mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $optionId: String!) {
         updateProjectV2ItemFieldValue(
           input: {
@@ -129,18 +145,71 @@ export class ColumnSync {
           }
         ) { projectV2Item { id } }
       }`,
-      {
-        projectId: meta.projectId,
-        itemId,
-        fieldId: meta.fieldId,
-        optionId,
-      },
-    );
+        {
+          projectId: meta.projectId,
+          itemId,
+          fieldId: meta.fieldId,
+          optionId,
+        },
+      );
+    } catch (err) {
+      // A failed mutation against metadata that came from the disk cache
+      // most likely means the board was reconfigured since the entry was
+      // written (a stale projectId / fieldId / optionId). Invalidate the
+      // disk entry so the next flip re-resolves against the live board and
+      // self-heals (Story #4252). Re-throw so the caller's existing error
+      // handling (e.g. `syncProjectStatusColumn`'s warn) is preserved.
+      this.#invalidateMetaCache();
+      throw err;
+    }
     return { status: 'synced', column };
+  }
+
+  /**
+   * The `(owner, projectNumber)` pair the disk cache is keyed by. Mirrors
+   * the owner that `#loadMeta` resolves the board against so a cache hit and
+   * a live resolve agree on the same board identity.
+   *
+   * @returns {{ owner: string|null, projectNumber: number|null }}
+   */
+  get #cacheBoard() {
+    return {
+      owner: this.projectOwner ?? this.provider.owner ?? null,
+      projectNumber: this.projectNumber,
+    };
+  }
+
+  /**
+   * Invalidate the on-disk metadata cache entry for this board and drop the
+   * in-process copy, so the next `#loadMeta` re-resolves from the live
+   * board. Only fires when the current `_meta` came from the disk cache —
+   * a freshly-resolved entry that fails the mutation is a transient/live
+   * problem, not a stale-cache problem.
+   */
+  #invalidateMetaCache() {
+    if (!this._metaFromDiskCache) return;
+    const { owner, projectNumber } = this.#cacheBoard;
+    invalidateProjectMetaCache({ owner, projectNumber, config: this.config });
+    this._meta = null;
+    this._metaFromDiskCache = false;
   }
 
   async #loadMeta() {
     if (this._meta !== null) return this._meta || null;
+    // Disk cache hit short-circuits the ~2 metadata GraphQL round-trips
+    // (resolveProjectMeta) — repo-invariant board metadata persists across
+    // the cold CLI processes of a single-story delivery (Story #4252).
+    const cachedBoard = this.#cacheBoard;
+    const cached = readProjectMetaCache({
+      owner: cachedBoard.owner,
+      projectNumber: cachedBoard.projectNumber,
+      config: this.config,
+    });
+    if (cached) {
+      this._meta = cached;
+      this._metaFromDiskCache = true;
+      return this._meta;
+    }
     try {
       // Resolve the board by walking the owner-type ladder
       // (organization → user → viewer) via the shared resolver so the
@@ -176,6 +245,16 @@ export class ColumnSync {
         fieldId: field.id,
         options,
       };
+      // Persist the freshly-resolved, repo-invariant metadata so the next
+      // cold flip reads it from disk instead of re-paying the resolve
+      // (Story #4252). Best-effort: a write failure never blocks the sync.
+      writeProjectMetaCache({
+        owner: cachedBoard.owner,
+        projectNumber: cachedBoard.projectNumber,
+        meta: this._meta,
+        config: this.config,
+      });
+      this._metaFromDiskCache = false;
       return this._meta;
     } catch (err) {
       this.logger.warn?.(

--- a/.agents/scripts/lib/orchestration/project-meta-cache.js
+++ b/.agents/scripts/lib/orchestration/project-meta-cache.js
@@ -1,0 +1,238 @@
+/**
+ * project-meta-cache — on-disk cache for repo-invariant GitHub Projects v2
+ * board metadata (Story #4252).
+ *
+ * Every `agent::*` label flip routes through `transitionTicketState` →
+ * `ColumnSync.sync`, which must resolve the board's `{ projectId, fieldId,
+ * options }` before issuing the Status mutation. Single-story delivery
+ * performs each flip in a *separate cold CLI process* (init → executing,
+ * close → closing, confirm-merge → done, plus `resync-status-column`), so
+ * the in-process `_meta` cache is always empty and every flip re-pays
+ * `resolveProjectMeta` + an item-id lookup + the mutation (~3 GraphQL
+ * round-trips).
+ *
+ * The board metadata is **repo-invariant** — it changes only when the
+ * Status single-select field is reconfigured — so it is a prime candidate
+ * for an on-disk cache that survives across the cold processes. This module
+ * persists the resolved metadata to a small JSON file under the resolved
+ * `tempRoot`, keyed by `owner/projectNumber`, carrying a TTL. Correctness
+ * is bounded by "the mutation still validates against the live board": a
+ * stale entry at worst causes one failed mutation, which the caller treats
+ * as a signal to invalidate the entry and re-resolve — never a wrong write.
+ *
+ * Layout: `<tempRoot>/cache/project-meta.json`, a single JSON object keyed
+ * by `<owner>/<projectNumber>`:
+ *
+ *   {
+ *     "dsj1984/1": {
+ *       "cachedAt": 1718000000000,
+ *       "projectId": "PVT_…",
+ *       "fieldId": "PVTSSF_…",
+ *       "options": { "Todo": "abc", "In Progress": "def", "Done": "ghi" }
+ *     }
+ *   }
+ *
+ * The `options` map is serialised as a plain object and re-hydrated into a
+ * `Map<name, id>` on read so the ColumnSync call site is identical whether
+ * the metadata came from the disk cache or a live resolve.
+ *
+ * The cache file lives under `tempRoot`, which is gitignored
+ * (`temp/` in `.gitignore`), so it introduces no new tracked artifact.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { anchorTempRoot, tempRootFrom } from '../config/temp-paths.js';
+
+/**
+ * Default time-to-live for a cached board-metadata entry, in milliseconds.
+ * Board metadata is repo-invariant (it only changes on a manual Status
+ * field reconfiguration), so a generous TTL is safe — and a stale entry is
+ * self-healing via invalidate-on-error regardless. One hour comfortably
+ * spans a single `/single-story-deliver` run's four cold flips while still
+ * forcing a periodic re-resolve.
+ */
+export const DEFAULT_META_TTL_MS = 60 * 60 * 1000;
+
+/**
+ * Resolve the path to the on-disk project-meta cache file under the
+ * (anchored) resolved `tempRoot`. A relative `tempRoot` is anchored to the
+ * main checkout root so a worktree child and the main-checkout host
+ * converge on the same file (Story #3900 semantics, reused here).
+ *
+ * @param {object} [config] Optional resolved config bag. Omitted → framework
+ *   default (`temp`).
+ * @returns {string}
+ */
+export function projectMetaCachePath(config) {
+  return path.join(
+    anchorTempRoot(tempRootFrom(config)),
+    'cache',
+    'project-meta.json',
+  );
+}
+
+/**
+ * Build the per-board cache key from `(owner, projectNumber)`.
+ *
+ * @param {string|null|undefined} owner
+ * @param {number|string|null|undefined} projectNumber
+ * @returns {string|null} `<owner>/<projectNumber>`, or null when either part
+ *   is missing (an un-keyable board — caller skips the cache).
+ */
+export function projectMetaCacheKey(owner, projectNumber) {
+  if (!owner || projectNumber === null || projectNumber === undefined) {
+    return null;
+  }
+  return `${owner}/${projectNumber}`;
+}
+
+/**
+ * Read the entire cache file as a plain object. Returns an empty object on
+ * any read/parse failure (missing file, malformed JSON) so the caller treats
+ * a corrupt cache as a cold miss rather than throwing.
+ *
+ * @param {string} filePath
+ * @returns {Record<string, object>}
+ */
+function readCacheFile(filePath) {
+  try {
+    const raw = fs.readFileSync(filePath, 'utf8');
+    const parsed = JSON.parse(raw);
+    return parsed && typeof parsed === 'object' ? parsed : {};
+  } catch {
+    return {};
+  }
+}
+
+/**
+ * Read a cached metadata entry for `(owner, projectNumber)`.
+ *
+ * Returns the re-hydrated `{ projectId, fieldId, options: Map }` descriptor
+ * when a fresh (within TTL) entry exists, or `null` on a miss / expired /
+ * malformed entry. Never throws — a read failure is a cache miss.
+ *
+ * @param {{
+ *   owner?: string|null,
+ *   projectNumber?: number|string|null,
+ *   config?: object,
+ *   ttlMs?: number,
+ *   now?: number,
+ * }} opts
+ * @returns {{ projectId: string, fieldId: string, options: Map<string,string> } | null}
+ */
+export function readProjectMetaCache(opts = {}) {
+  const key = projectMetaCacheKey(opts.owner, opts.projectNumber);
+  if (!key) return null;
+  const ttlMs = opts.ttlMs ?? DEFAULT_META_TTL_MS;
+  const now = opts.now ?? Date.now();
+
+  const filePath = projectMetaCachePath(opts.config);
+  const store = readCacheFile(filePath);
+  const entry = store[key];
+  if (!entry || typeof entry !== 'object') return null;
+
+  const { cachedAt, projectId, fieldId, options } = entry;
+  if (
+    typeof cachedAt !== 'number' ||
+    typeof projectId !== 'string' ||
+    typeof fieldId !== 'string' ||
+    !options ||
+    typeof options !== 'object'
+  ) {
+    return null;
+  }
+  // TTL check — an expired entry is a miss so the caller re-resolves.
+  if (now - cachedAt > ttlMs) return null;
+
+  return {
+    projectId,
+    fieldId,
+    options: new Map(Object.entries(options)),
+  };
+}
+
+/**
+ * Persist a resolved metadata descriptor for `(owner, projectNumber)`.
+ *
+ * The `options` value may be a `Map<name,id>` or a plain object; it is
+ * normalised to a plain object on disk. Best-effort: any write failure is
+ * swallowed (the cache is a pure optimisation — a failed write just means
+ * the next process re-resolves). Writes the rest of the store back intact so
+ * sibling board entries are preserved.
+ *
+ * @param {{
+ *   owner?: string|null,
+ *   projectNumber?: number|string|null,
+ *   meta: { projectId: string, fieldId: string, options: Map<string,string>|Record<string,string> },
+ *   config?: object,
+ *   now?: number,
+ * }} opts
+ * @returns {boolean} true when the entry was written, false on a skip/failure.
+ */
+export function writeProjectMetaCache(opts = {}) {
+  const key = projectMetaCacheKey(opts.owner, opts.projectNumber);
+  if (!key) return false;
+  const meta = opts.meta;
+  if (
+    !meta ||
+    typeof meta.projectId !== 'string' ||
+    typeof meta.fieldId !== 'string'
+  ) {
+    return false;
+  }
+  const now = opts.now ?? Date.now();
+
+  const options =
+    meta.options instanceof Map
+      ? Object.fromEntries(meta.options)
+      : { ...(meta.options ?? {}) };
+
+  const filePath = projectMetaCachePath(opts.config);
+  try {
+    const store = readCacheFile(filePath);
+    store[key] = {
+      cachedAt: now,
+      projectId: meta.projectId,
+      fieldId: meta.fieldId,
+      options,
+    };
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    fs.writeFileSync(filePath, `${JSON.stringify(store, null, 2)}\n`, 'utf8');
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Invalidate (delete) the cached entry for `(owner, projectNumber)`.
+ *
+ * Called when a GraphQL error fires against a board whose metadata came from
+ * the cache, so a mid-run board reconfiguration self-heals on the next flip
+ * (which re-resolves and re-writes). Best-effort and idempotent: a missing
+ * entry or unreadable file is a no-op. Returns true when an entry was
+ * actually removed.
+ *
+ * @param {{
+ *   owner?: string|null,
+ *   projectNumber?: number|string|null,
+ *   config?: object,
+ * }} opts
+ * @returns {boolean}
+ */
+export function invalidateProjectMetaCache(opts = {}) {
+  const key = projectMetaCacheKey(opts.owner, opts.projectNumber);
+  if (!key) return false;
+  const filePath = projectMetaCachePath(opts.config);
+  try {
+    const store = readCacheFile(filePath);
+    if (!(key in store)) return false;
+    delete store[key];
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    fs.writeFileSync(filePath, `${JSON.stringify(store, null, 2)}\n`, 'utf8');
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/.agents/scripts/lib/orchestration/project-meta-cache.js
+++ b/.agents/scripts/lib/orchestration/project-meta-cache.js
@@ -52,7 +52,7 @@ import { anchorTempRoot, tempRootFrom } from '../config/temp-paths.js';
  * spans a single `/single-story-deliver` run's four cold flips while still
  * forcing a periodic re-resolve.
  */
-export const DEFAULT_META_TTL_MS = 60 * 60 * 1000;
+const DEFAULT_META_TTL_MS = 60 * 60 * 1000;
 
 /**
  * Resolve the path to the on-disk project-meta cache file under the
@@ -64,7 +64,7 @@ export const DEFAULT_META_TTL_MS = 60 * 60 * 1000;
  *   default (`temp`).
  * @returns {string}
  */
-export function projectMetaCachePath(config) {
+function projectMetaCachePath(config) {
   return path.join(
     anchorTempRoot(tempRootFrom(config)),
     'cache',
@@ -80,7 +80,7 @@ export function projectMetaCachePath(config) {
  * @returns {string|null} `<owner>/<projectNumber>`, or null when either part
  *   is missing (an un-keyable board — caller skips the cache).
  */
-export function projectMetaCacheKey(owner, projectNumber) {
+function projectMetaCacheKey(owner, projectNumber) {
   if (!owner || projectNumber === null || projectNumber === undefined) {
     return null;
   }

--- a/.agents/scripts/lib/orchestration/reassert-status-column.js
+++ b/.agents/scripts/lib/orchestration/reassert-status-column.js
@@ -89,6 +89,7 @@ function defaultSleep(ms) {
  *   pollAttempts?: number,
  *   pollDelayMs?: number,
  *   sleepFn?: (ms: number) => Promise<void>,
+ *   config?: object,
  * }} args
  * @returns {Promise<{ status: string, column?: string, reason?: string, attempts?: number }>}
  */
@@ -100,6 +101,7 @@ export async function reassertStatusColumn(args) {
     pollAttempts = DEFAULT_POLL_ATTEMPTS,
     pollDelayMs = DEFAULT_POLL_DELAY_MS,
     sleepFn = defaultSleep,
+    config,
   } = args ?? {};
   if (!provider || typeof provider.getTicket !== 'function') {
     throw new TypeError(
@@ -128,7 +130,7 @@ export async function reassertStatusColumn(args) {
   if (!targetColumn) {
     return { status: 'skipped', reason: 'no-matching-label' };
   }
-  const sync = new ColumnSync({ provider, logger: logger ?? console });
+  const sync = new ColumnSync({ provider, logger: logger ?? console, config });
 
   // First attempt — always fires through ColumnSync.sync so the skip
   // paths (no-project / no-meta / no-option-<col> / not-on-project)

--- a/.agents/scripts/lib/orchestration/ticketing/transition.js
+++ b/.agents/scripts/lib/orchestration/ticketing/transition.js
@@ -179,6 +179,7 @@ async function syncProjectStatusColumn(
   ticketId,
   newState,
   _makeColumnSync,
+  config,
 ) {
   try {
     let sync;
@@ -191,10 +192,15 @@ async function syncProjectStatusColumn(
       // The instance's `_meta` cache survives across label transitions
       // so the invariant project metadata (projectId, fieldId, options)
       // is only fetched once per process run. Story #3661.
+      //
+      // Story #4252 — `config` is threaded so the on-disk board-metadata
+      // cache lands under the project's configured tempRoot. It is read at
+      // construction only; the registry caches the first instance per
+      // provider, so a later transition's config is intentionally ignored.
       if (!_columnSyncRegistry.has(provider)) {
         _columnSyncRegistry.set(
           provider,
-          new ColumnSync({ provider, logger: Logger }),
+          new ColumnSync({ provider, logger: Logger, config }),
         );
       }
       sync = _columnSyncRegistry.get(provider);
@@ -363,6 +369,7 @@ export async function transitionTicketState(
     ticketId,
     newState,
     opts._makeColumnSync,
+    opts.config,
   );
 
   // Automatically trigger upward cascade on every transition (Story

--- a/.agents/scripts/resync-status-column.js
+++ b/.agents/scripts/resync-status-column.js
@@ -127,6 +127,7 @@ export function buildReassertOptions({
   logger,
   pollAttempts,
   pollDelayMs,
+  config,
 }) {
   const opts = {
     provider,
@@ -135,6 +136,9 @@ export function buildReassertOptions({
   };
   if (pollAttempts !== undefined) opts.pollAttempts = pollAttempts;
   if (pollDelayMs !== undefined) opts.pollDelayMs = pollDelayMs;
+  // Story #4252 — forward the resolved config so ColumnSync's on-disk
+  // board-metadata cache lands under the project's configured tempRoot.
+  if (config !== undefined) opts.config = config;
   return opts;
 }
 
@@ -168,6 +172,7 @@ export async function main(argv = process.argv.slice(2)) {
       logger: Logger,
       pollAttempts,
       pollDelayMs,
+      config: effectiveConfig,
     }),
   );
   process.stdout.write(`${JSON.stringify({ ticketId, ...result })}\n`);

--- a/tests/lib/orchestration/column-sync.test.js
+++ b/tests/lib/orchestration/column-sync.test.js
@@ -1,10 +1,38 @@
 import assert from 'node:assert/strict';
-import { describe, it } from 'node:test';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, it } from 'node:test';
 
 import {
   ColumnSync,
   columnForLabels,
 } from '../../../.agents/scripts/lib/orchestration/column-sync.js';
+
+// Story #4252 — ColumnSync now persists resolved board metadata to an
+// on-disk cache under the resolved `tempRoot`. Give every ColumnSync in this
+// suite an isolated, per-test tempRoot so that cache (a) never bleeds across
+// cases or test runs and (b) never writes into the repo's real `temp/`. The
+// `config` bag is shaped like the resolved config (`project.paths.tempRoot`);
+// an absolute path is honoured verbatim by the temp-paths anchor.
+let _testTempDir;
+let _testConfig;
+beforeEach(() => {
+  _testTempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mandrel-cs-cache-'));
+  _testConfig = { project: { paths: { tempRoot: _testTempDir } } };
+});
+afterEach(() => {
+  if (_testTempDir) fs.rmSync(_testTempDir, { recursive: true, force: true });
+});
+
+/**
+ * Construct a ColumnSync with the per-test isolated tempRoot config merged
+ * in, so the disk cache is sandboxed. Tests pass the same `opts` they always
+ * have; `config` is injected unless a test overrides it explicitly.
+ */
+function makeSync(opts) {
+  return new ColumnSync({ config: _testConfig, ...opts });
+}
 
 describe('columnForLabels', () => {
   it('maps agent lifecycle labels to the three stock columns', () => {
@@ -102,7 +130,7 @@ function providerWithProject() {
 describe('ColumnSync.sync', () => {
   it('syncs to the computed column via GraphQL when project is configured', async () => {
     const provider = providerWithProject();
-    const sync = new ColumnSync({ provider });
+    const sync = makeSync({ provider });
     const res = await sync.sync(321, ['agent::executing']);
     assert.equal(res.status, 'synced');
     assert.equal(res.column, 'In Progress');
@@ -119,7 +147,7 @@ describe('ColumnSync.sync', () => {
 
   it('no-ops when projectNumber is absent', async () => {
     const provider = { graphql: async () => ({}) };
-    const sync = new ColumnSync({ provider, projectNumber: null });
+    const sync = makeSync({ provider, projectNumber: null });
     const res = await sync.sync(321, ['agent::executing']);
     assert.equal(res.status, 'skipped');
     assert.equal(res.reason, 'no-project');
@@ -127,7 +155,7 @@ describe('ColumnSync.sync', () => {
 
   it('no-ops when the label has no column mapping', async () => {
     const provider = providerWithProject();
-    const sync = new ColumnSync({ provider });
+    const sync = makeSync({ provider });
     const res = await sync.sync(321, ['type::epic']);
     assert.equal(res.status, 'skipped');
     assert.equal(res.reason, 'no-matching-label');
@@ -140,7 +168,7 @@ describe('ColumnSync.sync', () => {
         return { viewer: { projectV2: { id: 'PROJ', field: null } } };
       },
     };
-    const sync = new ColumnSync({ provider });
+    const sync = makeSync({ provider });
     const res = await sync.sync(321, ['agent::done']);
     assert.equal(res.status, 'skipped');
     assert.equal(res.reason, 'no-meta');
@@ -179,7 +207,7 @@ describe('ColumnSync.sync', () => {
         throw new Error('API boom');
       },
     };
-    const sync = new ColumnSync({ provider, logger: { warn: () => {} } });
+    const sync = makeSync({ provider, logger: { warn: () => {} } });
     await assert.rejects(() => sync.sync(321, ['agent::done']), /API boom/);
   });
 
@@ -189,7 +217,7 @@ describe('ColumnSync.sync', () => {
     // for any issue beyond the first 100 board items. The fix walks from
     // the issue to its projectItems and picks the match by project.id.
     const provider = providerWithProject();
-    const sync = new ColumnSync({ provider });
+    const sync = makeSync({ provider });
     const res = await sync.sync(2586, ['agent::executing']);
 
     assert.equal(res.status, 'synced');
@@ -258,7 +286,7 @@ describe('ColumnSync.sync', () => {
         return {};
       },
     };
-    const sync = new ColumnSync({ provider });
+    const sync = makeSync({ provider });
     const res = await sync.sync(321, ['agent::executing']);
     assert.equal(res.status, 'skipped');
     assert.equal(res.reason, 'not-on-project');
@@ -284,7 +312,7 @@ describe('ColumnSync.sync', () => {
         return {};
       },
     };
-    const sync = new ColumnSync({ provider });
+    const sync = makeSync({ provider });
     const res = await sync.sync(321, ['agent::executing']);
     assert.equal(res.status, 'skipped');
     assert.equal(res.reason, 'not-on-project');
@@ -342,7 +370,7 @@ describe('ColumnSync.sync', () => {
       },
     };
 
-    const sync = new ColumnSync({ provider });
+    const sync = makeSync({ provider });
     const res = await sync.sync(100, ['agent::done']);
     assert.equal(res.status, 'synced');
     assert.equal(res.column, 'Done');
@@ -426,7 +454,7 @@ describe('ColumnSync.sync', () => {
       },
     };
 
-    const sync = new ColumnSync({ provider });
+    const sync = makeSync({ provider });
     const res = await sync.sync(50, ['agent::done']);
     assert.equal(res.status, 'synced');
     assert.equal(res.column, 'Done');
@@ -494,7 +522,7 @@ describe('ColumnSync.sync', () => {
       },
     };
 
-    const sync = new ColumnSync({ provider });
+    const sync = makeSync({ provider });
     const res = await sync.sync(2, ['agent::executing']);
     assert.equal(res.status, 'synced');
     assert.equal(res.column, 'In Progress');
@@ -574,7 +602,7 @@ describe('ColumnSync.sync', () => {
       },
     };
 
-    const sync = new ColumnSync({ provider });
+    const sync = makeSync({ provider });
     const res = await sync.sync(7, ['agent::done']);
     assert.equal(res.status, 'synced');
     assert.equal(res.column, 'Done');
@@ -642,14 +670,14 @@ describe('ColumnSync.readCurrentColumn (Story #2876)', () => {
   }
 
   it('returns the live column name when set', async () => {
-    const sync = new ColumnSync({
+    const sync = makeSync({
       provider: readProvider({ statusByItem: { PVTI_n: 'Done' } }),
     });
     assert.equal(await sync.readCurrentColumn(7), 'Done');
   });
 
   it('returns null when the field has no current value', async () => {
-    const sync = new ColumnSync({
+    const sync = makeSync({
       provider: readProvider({ statusByItem: {} }),
     });
     assert.equal(await sync.readCurrentColumn(7), null);
@@ -658,7 +686,7 @@ describe('ColumnSync.readCurrentColumn (Story #2876)', () => {
   it('returns null when projectNumber is unset', async () => {
     const provider = readProvider({ statusByItem: { PVTI_n: 'Done' } });
     provider.projectNumber = null;
-    const sync = new ColumnSync({ provider });
+    const sync = makeSync({ provider });
     assert.equal(await sync.readCurrentColumn(7), null);
   });
 
@@ -672,7 +700,7 @@ describe('ColumnSync.readCurrentColumn (Story #2876)', () => {
       }
       return origGraphql(query, vars);
     };
-    const sync = new ColumnSync({
+    const sync = makeSync({
       provider: baseProvider,
       logger: { info: () => {}, warn: (m) => warned.push(m) },
     });

--- a/tests/lib/orchestration/reassert-status-column.test.js
+++ b/tests/lib/orchestration/reassert-status-column.test.js
@@ -1,7 +1,36 @@
 import assert from 'node:assert/strict';
-import { describe, it } from 'node:test';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, it } from 'node:test';
 
 import { reassertStatusColumn } from '../../../.agents/scripts/lib/orchestration/reassert-status-column.js';
+
+// Story #4252 — ColumnSync (used internally by reassertStatusColumn) now
+// persists resolved board metadata to an on-disk cache under the resolved
+// `tempRoot`. Sandbox every call in this suite to a fresh per-test tempRoot
+// so cached metadata never bleeds across cases (which reuse the same
+// owner/projectNumber with different board ids) or into the repo's `temp/`.
+let _testTempDir;
+let _testConfig;
+beforeEach(() => {
+  _testTempDir = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'mandrel-reassert-cache-'),
+  );
+  _testConfig = { project: { paths: { tempRoot: _testTempDir } } };
+});
+afterEach(() => {
+  if (_testTempDir) fs.rmSync(_testTempDir, { recursive: true, force: true });
+});
+
+/**
+ * Invoke reassertStatusColumn with the per-test isolated tempRoot config
+ * injected, so the ColumnSync disk cache is sandboxed. Tests pass the same
+ * args they always have; `config` is injected unless overridden explicitly.
+ */
+function callReassert(args) {
+  return reassertStatusColumn({ config: _testConfig, ...args });
+}
 
 /**
  * Provider fake that records every GraphQL call and supports the four
@@ -114,7 +143,7 @@ describe('reassertStatusColumn — basics', () => {
       ticketLabels: { 2813: ['type::story', 'agent::done'] },
       itemIdByTicket: { 2813: 'PVTI_abc' },
     });
-    const result = await reassertStatusColumn({
+    const result = await callReassert({
       provider,
       ticketId: 2813,
       sleepFn: fastSleep,
@@ -129,7 +158,7 @@ describe('reassertStatusColumn — basics', () => {
     const provider = makeProvider({
       ticketLabels: { 99: ['type::story'] },
     });
-    const result = await reassertStatusColumn({
+    const result = await callReassert({
       provider,
       ticketId: 99,
       sleepFn: fastSleep,
@@ -144,7 +173,7 @@ describe('reassertStatusColumn — basics', () => {
       ticketLabels: { 5: ['agent::executing'] },
       itemIdByTicket: {}, // no item registered for #5
     });
-    const result = await reassertStatusColumn({
+    const result = await callReassert({
       provider,
       ticketId: 5,
       sleepFn: fastSleep,
@@ -155,22 +184,22 @@ describe('reassertStatusColumn — basics', () => {
 
   it('rejects bad inputs', async () => {
     await assert.rejects(
-      reassertStatusColumn({ provider: {}, ticketId: 1 }),
+      callReassert({ provider: {}, ticketId: 1 }),
       /provider with getTicket/,
     );
     await assert.rejects(
-      reassertStatusColumn({
+      callReassert({
         provider: { getTicket: () => null },
         ticketId: 1,
       }),
       /provider with graphql/,
     );
     await assert.rejects(
-      reassertStatusColumn({ provider: makeProvider(), ticketId: 0 }),
+      callReassert({ provider: makeProvider(), ticketId: 0 }),
       /positive integer ticketId/,
     );
     await assert.rejects(
-      reassertStatusColumn({
+      callReassert({
         provider: makeProvider(),
         ticketId: 1,
         pollAttempts: 0,
@@ -197,7 +226,7 @@ describe('reassertStatusColumn — poll-and-retry loop (Story #2876)', () => {
         }
       },
     });
-    const result = await reassertStatusColumn({
+    const result = await callReassert({
       provider,
       ticketId: 7,
       sleepFn: fastSleep,
@@ -218,7 +247,7 @@ describe('reassertStatusColumn — poll-and-retry loop (Story #2876)', () => {
         provider.calls.statusByItem[itemId] = 'OPT_inprog';
       },
     });
-    const result = await reassertStatusColumn({
+    const result = await callReassert({
       provider,
       ticketId: 7,
       pollAttempts: 3,
@@ -238,7 +267,7 @@ describe('reassertStatusColumn — poll-and-retry loop (Story #2876)', () => {
         mutationCount += 1;
       },
     });
-    const result = await reassertStatusColumn({
+    const result = await callReassert({
       provider,
       ticketId: 7,
       pollAttempts: 1,
@@ -258,7 +287,7 @@ describe('reassertStatusColumn — poll-and-retry loop (Story #2876)', () => {
       sleeps += 1;
       return Promise.resolve();
     };
-    const result = await reassertStatusColumn({
+    const result = await callReassert({
       provider,
       ticketId: 99,
       sleepFn,
@@ -285,7 +314,7 @@ describe('reassertStatusColumn — poll-and-retry loop (Story #2876)', () => {
       return origGraphql(query, vars);
     };
     const warned = [];
-    const result = await reassertStatusColumn({
+    const result = await callReassert({
       provider: baseProvider,
       ticketId: 7,
       pollAttempts: 3,

--- a/tests/lib/orchestration/ticketing/state.test.js
+++ b/tests/lib/orchestration/ticketing/state.test.js
@@ -8,7 +8,10 @@
  */
 
 import assert from 'node:assert/strict';
-import { beforeEach, describe, it } from 'node:test';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, it } from 'node:test';
 import { ITicketingProvider } from '../../../../.agents/scripts/lib/ITicketingProvider.js';
 import {
   _resetStructuredCommentCache,
@@ -98,11 +101,27 @@ class MockProvider extends ITicketingProvider {
 
 describe('ticketing/state — transitionTicketState', () => {
   let mock;
+  // Story #4252 — ColumnSync now persists board metadata to an on-disk
+  // cache. Sandbox it to a fresh per-test tempRoot so the registry test's
+  // "meta fetched once" assertion sees a cold disk cache (one resolve, then
+  // the in-process registry serves the rest) and never reads a warm cache
+  // written by a sibling test or a prior run.
+  let isolatedTempDir;
+  let isolatedConfig;
 
   beforeEach(() => {
     mock = new MockProvider();
     _resetStructuredCommentCache(mock);
     _resetColumnSyncCache(mock);
+    isolatedTempDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'mandrel-state-cache-'),
+    );
+    isolatedConfig = { project: { paths: { tempRoot: isolatedTempDir } } };
+  });
+
+  afterEach(() => {
+    if (isolatedTempDir)
+      fs.rmSync(isolatedTempDir, { recursive: true, force: true });
   });
 
   it('validateTransitionInputs throws on unknown state labels', async () => {
@@ -295,14 +314,19 @@ describe('ticketing/state — transitionTicketState', () => {
     _resetColumnSyncCache(mock);
 
     // Act: fire three label transitions without injecting _makeColumnSync.
+    // The isolated tempRoot keeps the on-disk meta cache cold so the only
+    // resolve is the first transition's (the registry serves the rest).
     await transitionTicketState(mock, 10, STATE_LABELS.EXECUTING, {
       cascade: false,
+      config: isolatedConfig,
     });
     await transitionTicketState(mock, 10, STATE_LABELS.BLOCKED, {
       cascade: false,
+      config: isolatedConfig,
     });
     await transitionTicketState(mock, 10, STATE_LABELS.EXECUTING, {
       cascade: false,
+      config: isolatedConfig,
     });
 
     // Assert: the meta GraphQL query fired exactly once across all three


### PR DESCRIPTION
Closes #4252

_Auto-opened by `/single-story-deliver`._