### PR TITLE
perf: resolve the Epic once in /deliver and thread --prd/--tech-spec into story-init (#4253)

### DIFF
--- a/.agents/scripts/epic-deliver-prepare.js
+++ b/.agents/scripts/epic-deliver-prepare.js
@@ -38,6 +38,7 @@ import { runAsCli } from './lib/cli-utils.js';
 import { getRunners, resolveConfig } from './lib/config-resolver.js';
 import { currentBranch as gitCurrentBranch } from './lib/git-branch-lifecycle.js';
 import { getEpicBranch, gitSpawn } from './lib/git-utils.js';
+import { parseLinkedIssues } from './lib/issue-link-parser.js';
 import { Logger } from './lib/Logger.js';
 import {
   resolveOperator,
@@ -143,6 +144,8 @@ function resolveGitUserEmail(cwd) {
  *   storyCount: number,
  *   concurrencyCap: number,
  *   stories: Array<{ storyId: number, title: string, worktree?: string }>,
+ *   prdId: number|null,
+ *   techSpecId: number|null,
  *   checkpointInitializedAt: string,
  * }>}
  */
@@ -374,17 +377,45 @@ export async function runEpicDeliverPrepare({
     });
   }
 
+  // Story #4253: resolve the Epic's PRD / Tech-Spec linkages ONCE here and
+  // surface them in the prepare envelope. The /deliver fan-out threads these
+  // into each per-Story `story-init.js --prd/--tech-spec`, collapsing the
+  // N per-Story `getEpic` round-trips to this single parent-side resolution.
+  // The Epic snapshot is already in hand (`state.epic`), so this adds no
+  // extra fetch; the body-parse fallback mirrors hierarchy-tracer's source.
+  const { prdId, techSpecId } = resolveEpicLinkages(state.epic);
+
   return {
     epicId,
     storyCount: openStories.length,
     concurrencyCap,
     stories,
+    prdId,
+    techSpecId,
     checkpointInitializedAt:
       checkpointState.startedAt ??
       checkpointState.lastUpdatedAt ??
       new Date().toISOString(),
     concurrencyHazardsBypassed: gate.bypassed,
     preflightCache: cacheStatus,
+  };
+}
+
+/**
+ * Resolve an Epic's linked PRD / Tech-Spec issue ids from the snapshot ticket.
+ * Prefers the provider-supplied `linkedIssues` map and falls back to parsing
+ * the Epic body's `## Planning Artifacts` section — the same two sources
+ * `hierarchy-tracer.js` reads — so the threaded ids match what an unthreaded
+ * `story-init.js` run would have resolved itself. Story #4253.
+ *
+ * @param {{ linkedIssues?: { prd?: number|null, techSpec?: number|null }|null, body?: string }|null|undefined} epic
+ * @returns {{ prdId: number|null, techSpecId: number|null }}
+ */
+function resolveEpicLinkages(epic) {
+  const linked = epic?.linkedIssues ?? parseLinkedIssues(epic?.body ?? '');
+  return {
+    prdId: linked?.prd ?? null,
+    techSpecId: linked?.techSpec ?? null,
   };
 }
 

--- a/.agents/scripts/lib/cli-args.js
+++ b/.agents/scripts/lib/cli-args.js
@@ -60,6 +60,8 @@ export function parseSprintArgs(args = process.argv) {
       'no-full-scope-crap': { type: 'boolean', default: false },
       executor: { type: 'string' },
       cwd: { type: 'string' },
+      prd: { type: 'string' },
+      'tech-spec': { type: 'string' },
       'recut-of': { type: 'string' },
       resume: { type: 'boolean', default: false },
       restart: { type: 'boolean', default: false },
@@ -86,6 +88,10 @@ export function parseSprintArgs(args = process.argv) {
       process.env.AGENT_WORKTREE_ROOT ||
       null,
     recutOf: parseTicketId(values['recut-of']),
+    // Story #4253: pre-resolved Epic linkages threaded by the /deliver
+    // fan-out so `story-init.js` can skip the per-Story `getEpic` round-trip.
+    prdId: parseTicketId(values.prd),
+    techSpecId: parseTicketId(values['tech-spec']),
     resume: values.resume ?? false,
     restart: values.restart ?? false,
     noEvidence: values['no-evidence'] ?? false,

--- a/.agents/scripts/lib/story-init/__tests__/hierarchy-tracer.test.js
+++ b/.agents/scripts/lib/story-init/__tests__/hierarchy-tracer.test.js
@@ -1,0 +1,116 @@
+/**
+ * hierarchy-tracer.test.js — Story #4253 (thread --prd/--tech-spec to skip getEpic).
+ *
+ * Colocated under the module's `__tests__/` directory per the named
+ * `/single-story-deliver` Verify command for this Story and the unit-tier
+ * colocation convention in `rules/testing-standards.md`.
+ *
+ * The binding assertion is a `getEpic` call count: when the /deliver fan-out
+ * threads both pre-resolved ids in (`input.prdId` + `input.techSpecId`), the
+ * tracer MUST short-circuit and issue **zero** `getEpic` round-trips. When
+ * either id is absent it falls back to the legacy single `getEpic` resolution,
+ * preserving its graceful degradation on a missing Epic.
+ */
+
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { traceHierarchy } from '../hierarchy-tracer.js';
+
+/**
+ * Recording provider whose `getEpic` counts every call and returns a fixed
+ * linkedIssues map. The call count is the contract under test.
+ */
+function makeRecordingProvider({ prd = 7001, techSpec = 7002 } = {}) {
+  const calls = { getEpic: [] };
+  return {
+    calls,
+    async getEpic(epicId) {
+      calls.getEpic.push(epicId);
+      return { linkedIssues: { prd, techSpec } };
+    },
+  };
+}
+
+/** A logger that swallows warnings so the fetch-failure path stays quiet. */
+const silentLogger = { warn: () => {} };
+
+describe('traceHierarchy', () => {
+  it('short-circuits with zero getEpic calls when both ids are threaded', async () => {
+    const provider = makeRecordingProvider();
+
+    const result = await traceHierarchy({
+      provider,
+      logger: silentLogger,
+      input: { epicId: 100, prdId: 42, techSpecId: 43 },
+    });
+
+    assert.equal(
+      provider.calls.getEpic.length,
+      0,
+      'getEpic must not be called when both --prd and --tech-spec are supplied',
+    );
+    assert.deepEqual(result, { prdId: 42, techSpecId: 43 });
+  });
+
+  it('falls back to getEpic when no ids are threaded (legacy path)', async () => {
+    const provider = makeRecordingProvider({ prd: 5001, techSpec: 5002 });
+
+    const result = await traceHierarchy({
+      provider,
+      logger: silentLogger,
+      input: { epicId: 100 },
+    });
+
+    assert.equal(provider.calls.getEpic.length, 1);
+    assert.deepEqual(result, { prdId: 5001, techSpecId: 5002 });
+  });
+
+  it('falls back to getEpic when only --prd is supplied (partial)', async () => {
+    const provider = makeRecordingProvider({ prd: 5001, techSpec: 5002 });
+
+    const result = await traceHierarchy({
+      provider,
+      logger: silentLogger,
+      input: { epicId: 100, prdId: 42, techSpecId: null },
+    });
+
+    assert.equal(
+      provider.calls.getEpic.length,
+      1,
+      'a partial threading (one id missing) must still resolve via getEpic',
+    );
+    assert.deepEqual(result, { prdId: 5001, techSpecId: 5002 });
+  });
+
+  it('falls back to getEpic when only --tech-spec is supplied (partial)', async () => {
+    const provider = makeRecordingProvider({ prd: 5001, techSpec: 5002 });
+
+    const result = await traceHierarchy({
+      provider,
+      logger: silentLogger,
+      input: { epicId: 100, prdId: null, techSpecId: 43 },
+    });
+
+    assert.equal(provider.calls.getEpic.length, 1);
+    assert.deepEqual(result, { prdId: 5001, techSpecId: 5002 });
+  });
+
+  it('degrades gracefully (null linkages) when getEpic throws on the legacy path', async () => {
+    const provider = {
+      calls: { getEpic: [] },
+      async getEpic(epicId) {
+        this.calls.getEpic.push(epicId);
+        throw new Error('boom');
+      },
+    };
+
+    const result = await traceHierarchy({
+      provider,
+      logger: silentLogger,
+      input: { epicId: 100 },
+    });
+
+    assert.equal(provider.calls.getEpic.length, 1);
+    assert.deepEqual(result, { prdId: null, techSpecId: null });
+  });
+});

--- a/.agents/scripts/lib/story-init/hierarchy-tracer.js
+++ b/.agents/scripts/lib/story-init/hierarchy-tracer.js
@@ -2,10 +2,19 @@ import { Logger } from '../Logger.js';
 /**
  * hierarchy-tracer.js — Stage 2 of the story-init pipeline.
  *
- * Given an epicId, resolves the linked PRD and Tech Spec issue IDs by
- * fetching the Epic. Fetch failures are logged but non-fatal — the result
- * simply reports `null` for whichever linkage could not be resolved, which
- * mirrors legacy behaviour in story-init.js.
+ * Resolves the linked PRD and Tech Spec issue IDs for a Story's parent Epic.
+ *
+ * Story #4253: when both `prdId` and `techSpecId` are supplied as input
+ * (the `/deliver` fan-out resolves the immutable Epic once at the top of the
+ * run and threads the two ids down via `story-init.js --prd/--tech-spec`),
+ * this stage short-circuits and does NOT call `provider.getEpic`. The Epic
+ * issue is invariant for the lifetime of a delivery run, so the N per-Story
+ * `getEpic` round-trips collapse to one parent-side resolution.
+ *
+ * When the flags are absent (interactive / single-story use), the legacy
+ * `getEpic` resolution runs unchanged. Fetch failures are logged but
+ * non-fatal — the result simply reports `null` for whichever linkage could
+ * not be resolved, preserving the graceful degradation on a missing Epic.
  */
 
 /**
@@ -14,11 +23,23 @@ import { Logger } from '../Logger.js';
  * @param {object} [deps.logger]
  * @param {object} deps.input
  * @param {number} deps.input.epicId
+ * @param {number|null} [deps.input.prdId] Pre-resolved PRD id (from --prd).
+ * @param {number|null} [deps.input.techSpecId] Pre-resolved Tech Spec id
+ *   (from --tech-spec). When both `prdId` and `techSpecId` are supplied,
+ *   `getEpic` is skipped.
  * @returns {Promise<{ prdId: number|null, techSpecId: number|null }>}
  */
 export async function traceHierarchy({ provider, logger, input }) {
   const { epicId } = input;
   const warn = logger?.warn ?? ((msg) => Logger.error(msg));
+
+  // Short-circuit: the parent already resolved both linkages once and threaded
+  // them in, so there is nothing left to fetch. Skip the per-Story getEpic.
+  const suppliedPrdId = input.prdId ?? null;
+  const suppliedTechSpecId = input.techSpecId ?? null;
+  if (suppliedPrdId !== null && suppliedTechSpecId !== null) {
+    return { prdId: suppliedPrdId, techSpecId: suppliedTechSpecId };
+  }
 
   let prdId = null;
   let techSpecId = null;

--- a/.agents/scripts/story-init.js
+++ b/.agents/scripts/story-init.js
@@ -88,6 +88,8 @@ export async function runStoryInit({
   dryRun: dryRunParam,
   cwd: cwdParam,
   recutOf: recutOfParam,
+  prdId: prdIdParam,
+  techSpecId: techSpecIdParam,
   injectedProvider,
   injectedConfig,
 } = {}) {
@@ -98,10 +100,17 @@ export async function runStoryInit({
           dryRun: !!dryRunParam,
           cwd: cwdParam ?? null,
           recutOf: recutOfParam ?? null,
+          prdId: prdIdParam ?? null,
+          techSpecId: techSpecIdParam ?? null,
         }
       : parseSprintArgs();
   const { storyId, dryRun } = parsed;
   const recutOf = recutOfParam ?? parsed.recutOf ?? null;
+  // Story #4253: pre-resolved Epic linkages (from the /deliver fan-out's
+  // one-time Epic resolution). When both are present, hierarchy-tracer skips
+  // the per-Story getEpic round-trip; when absent it resolves them itself.
+  const threadedPrdId = prdIdParam ?? parsed.prdId ?? null;
+  const threadedTechSpecId = techSpecIdParam ?? parsed.techSpecId ?? null;
   // Worktree-aware cwd resolution: explicit param > --cwd flag > env > PROJECT_ROOT.
   const cwd = path.resolve(cwdParam ?? parsed.cwd ?? PROJECT_ROOT);
 
@@ -146,11 +155,13 @@ export async function runStoryInit({
     input: { storyId, recutOf, dryRun },
   });
 
-  // Stage 2 — hierarchy.
+  // Stage 2 — hierarchy. When the /deliver fan-out threaded --prd/--tech-spec
+  // (both resolved once by the parent), this short-circuits the per-Story
+  // getEpic. Absent flags fall back to the legacy getEpic resolution.
   const { prdId, techSpecId } = await traceHierarchy({
     provider,
     logger: stageLogger,
-    input: { epicId },
+    input: { epicId, prdId: threadedPrdId, techSpecId: threadedTechSpecId },
   });
 
   progress('CONTEXT', `Epic: #${epicId}, Parent: #${parentId ?? 'none'}`);

--- a/.agents/workflows/helpers/deliver-epic.md
+++ b/.agents/workflows/helpers/deliver-epic.md
@@ -167,10 +167,24 @@ Validates `type::epic`, enumerates `type::story` descendants, parses
 (to enumerate the open Story set), and upserts the `epic-run-state`
 checkpoint in the per-Story-status shape (a flat `stories` map seeded at
 `pending`, plus the global `concurrencyCap`). Treat the printed JSON as
-`state`: `{ epicId, storyCount, concurrencyCap, stories, checkpointInitializedAt }`.
+`state`: `{ epicId, storyCount, concurrencyCap, stories, prdId, techSpecId, checkpointInitializedAt }`.
 `stories` is the flat dispatch hint (`{ storyId, worktree, title }` per open
 Story); the ready-set `tick` (Phase 2) decides which to dispatch on each
 beat. Flip the Epic to `agent::executing` (idempotent) after the CLI returns.
+
+**Epic linkages resolved once (Story #4253).** The envelope also carries
+`prdId` and `techSpecId` — the Epic's linked PRD / Tech-Spec issue ids,
+resolved a **single** time here from the Epic snapshot prepare already
+holds (no extra fetch). Capture both and thread them into **every**
+per-Story `story-init.js` invocation (§ 2b → `epic-deliver-story` Step 0)
+as `--prd <prdId> --tech-spec <techSpecId>`. This collapses the N
+per-Story `getEpic` round-trips (one per child, each in its own process
+with its own provider cache) to this one parent-side resolution — the
+immutable Epic issue is invariant for the lifetime of a delivery run.
+When a linkage is `null` (the Epic links no PRD or Tech Spec), omit the
+corresponding flag; the child's `story-init.js` then falls back to its
+own `getEpic` resolution for the missing id, preserving graceful
+degradation.
 
 > **Preflight guards (Story #3482 / F-workflow-guards).** Before the
 > snapshot phase runs — and before any worktree is created — prepare runs
@@ -334,7 +348,10 @@ matching `story.dispatch.end` record is appended later by
 `epic-execute-record-wave.js` (via `emit-story-dispatch-end.js`, Story #3900)
 after the Agent return is recorded in § 2c.
 
-Each Agent call's prompt must (1) name the Story + Epic ids, (2)
+Each Agent call's prompt must (1) name the Story + Epic ids **and the
+`prdId` / `techSpecId` from the Phase 1 prepare envelope** (Story #4253) so
+the child can thread `--prd <prdId> --tech-spec <techSpecId>` into its
+`story-init.js` Step 0 — omit whichever flag is `null`, (2)
 instruct the child to invoke `helpers/epic-deliver-story <storyId>`
 (whose Step 4 defines the child's return shape), (3) remind the child
 of the **non-interactive contract** (no clarifying questions;

--- a/.agents/workflows/helpers/epic-deliver-story.md
+++ b/.agents/workflows/helpers/epic-deliver-story.md
@@ -77,8 +77,21 @@ the parent's permissions but have **no input channel** mid-run.
 Run from the **main checkout** (the worktree does not exist yet):
 
 ```bash
-node .agents/scripts/story-init.js --story <storyId>
+node .agents/scripts/story-init.js --story <storyId> \
+  --prd <prdId> --tech-spec <techSpecId>
 ```
+
+**Thread the Epic linkages (Story #4253).** The parent `/deliver` resolved
+the Epic's `prdId` / `techSpecId` **once** in its Phase 1 prepare and passed
+them into your dispatch prompt. Forward them as `--prd` / `--tech-spec` so
+this `story-init.js` run **skips** the per-Story `getEpic` round-trip — the
+two ids are invariant for the whole delivery run, so re-fetching the
+immutable Epic per Story is pure waste (and secondary-rate-limit pressure
+during wide fan-out). **Omit** whichever flag the prompt reported as `null`;
+`story-init.js` then falls back to its own `getEpic` resolution for the
+missing id (graceful degradation on a missing Epic linkage). When dispatched
+interactively with neither flag, drop both — the legacy single-fetch path is
+unchanged.
 
 > **Execution mode (sub-agents must read).** This command typically takes
 > 3–6 minutes when the worktree's per-tree install runs. Invoke it

--- a/tests/epic-execute/epic-deliver-prepare.test.js
+++ b/tests/epic-execute/epic-deliver-prepare.test.js
@@ -178,6 +178,82 @@ describe('runEpicDeliverPrepare', () => {
     );
   });
 
+  it('surfaces the Epic PRD / Tech-Spec ids from linkedIssues (Story #4253)', async () => {
+    const epic = {
+      id: 110,
+      labels: ['type::epic', 'acceptance::n-a'],
+      linkedIssues: { prd: 911, techSpec: 912 },
+    };
+    const descendants = [
+      {
+        id: 401,
+        number: 401,
+        title: 'Story A',
+        labels: ['type::story'],
+        body: '',
+      },
+    ];
+    const provider = createFakeProvider({ epic, descendants });
+    const out = await runEpicDeliverPrepare({
+      epicId: 110,
+      injectedProvider: provider,
+      injectedConfig: baseConfig,
+    });
+    assert.equal(out.prdId, 911);
+    assert.equal(out.techSpecId, 912);
+  });
+
+  it('falls back to body-parsed PRD / Tech-Spec ids when linkedIssues absent (Story #4253)', async () => {
+    const epic = {
+      id: 111,
+      labels: ['type::epic', 'acceptance::n-a'],
+      body: [
+        '## Planning Artifacts',
+        '',
+        '- [x] PRD: #921',
+        '- [x] Tech Spec: #922',
+      ].join('\n'),
+    };
+    const descendants = [
+      {
+        id: 411,
+        number: 411,
+        title: 'Story B',
+        labels: ['type::story'],
+        body: '',
+      },
+    ];
+    const provider = createFakeProvider({ epic, descendants });
+    const out = await runEpicDeliverPrepare({
+      epicId: 111,
+      injectedProvider: provider,
+      injectedConfig: baseConfig,
+    });
+    assert.equal(out.prdId, 921);
+    assert.equal(out.techSpecId, 922);
+  });
+
+  it('surfaces null PRD / Tech-Spec ids when the Epic links neither (Story #4253)', async () => {
+    const epic = { id: 112, labels: ['type::epic', 'acceptance::n-a'] };
+    const descendants = [
+      {
+        id: 421,
+        number: 421,
+        title: 'Story C',
+        labels: ['type::story'],
+        body: '',
+      },
+    ];
+    const provider = createFakeProvider({ epic, descendants });
+    const out = await runEpicDeliverPrepare({
+      epicId: 112,
+      injectedProvider: provider,
+      injectedConfig: baseConfig,
+    });
+    assert.equal(out.prdId, null);
+    assert.equal(out.techSpecId, null);
+  });
+
   it('throws when the Epic has no child stories', async () => {
     const epic = { id: 102, labels: ['type::epic', 'acceptance::n-a'] };
     const provider = createFakeProvider({ epic, descendants: [] });


### PR DESCRIPTION
Closes #4253

_Auto-opened by `/single-story-deliver`._