### PR TITLE
fix: stop the Story-body parser bleeding unknown-heading content into the previously-open section (#4274)

### DIFF
--- a/.agents/scripts/lib/story-body/story-body.js
+++ b/.agents/scripts/lib/story-body/story-body.js
@@ -355,6 +355,19 @@ function splitSections(markdown) {
         if (!sections.has(currentSection)) sections.set(currentSection, []);
         continue;
       }
+      // A heading that matches the canonical `## Word` shape but is not a
+      // recognized field name (e.g. a trailing free-form `## Notes`) closes
+      // the currently-open section. Without this reset, the unknown heading
+      // and its bullets bleed into the previously-recognized section,
+      // silently corrupting `verify[]` / `acceptance[]`. We do NOT re-enter
+      // the preamble (`inPreamble` stays false), so a later recognized
+      // heading still registers normally; we only stop appending to the
+      // closed section. The heading line and its body are dropped from all
+      // sections. (Multi-word free-form headings like `## Out of Scope` do
+      // not match this single-word shape and are intentionally out of scope
+      // here — widening the regex is a separate decision.)
+      currentSection = null;
+      continue;
     }
 
     // The trailing `<!-- meta: {...} -->` block is machine metadata, not

--- a/tests/lib/story-body/story-body.test.js
+++ b/tests/lib/story-body/story-body.test.js
@@ -129,6 +129,47 @@ describe('parse() — markdown', () => {
     const { body } = parse(CANONICAL_MARKDOWN);
     assert.equal(body.wide, null);
   });
+
+  it('does not bleed a trailing unrecognized heading into the prior section', () => {
+    // A canonical body followed by a free-form, single-word `## Notes`
+    // section (a heading that matches the canonical `## Word` shape but is
+    // not a recognized field). Before the fix, the unknown heading + its
+    // bullets bled into the previously-open `verify` section, corrupting
+    // `verify[]`. The fix resets currentSection to null on the unrecognized
+    // heading so the trailing section is dropped, not appended.
+    const md = `${CANONICAL_MARKDOWN}
+
+## Notes
+- not touching b.js
+- some other negative bound`;
+    const { body } = parse(md);
+    // The recognized sections stay clean — the unknown heading and its
+    // bullets are dropped, not appended to verify[] / acceptance[].
+    assert.deepEqual(body.verify, [
+      'npm test -- tests/lib/story-body/story-body.test.js (unit)',
+    ]);
+    assert.deepEqual(body.acceptance, [
+      'parse() returns a StoryBody with all sections populated',
+      'serialize(parse(md)) round-trips cleanly',
+    ]);
+  });
+
+  it('still registers a recognized heading that follows an unrecognized one', () => {
+    // A single-word unknown heading between Goal and Verify must close the
+    // Goal section without re-entering the preamble, so the later
+    // `## Verify` still registers normally.
+    const md = `## Goal
+Do the thing.
+
+## Notes
+- nope
+
+## Verify
+- npm test (unit)`;
+    const { body } = parse(md);
+    assert.equal(body.goal, 'Do the thing.');
+    assert.deepEqual(body.verify, ['npm test (unit)']);
+  });
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #4274

_Auto-opened by `/single-story-deliver`._