### PR TITLE
fix: make the sizing and conflict validation gates parse string Story bodies so the numeric backstops are not blind on the production shape (#4271)

### DIFF
--- a/.agents/scripts/lib/orchestration/ticket-validator-conflicts.js
+++ b/.agents/scripts/lib/orchestration/ticket-validator-conflicts.js
@@ -1,5 +1,48 @@
+import { parse as parseStoryBody } from '../story-body/story-body.js';
 import { collectStoryAssumptionEntries } from './file-assumptions.js';
 import { computeStoryReachability } from './story-reachability.js';
+
+/**
+ * Normalize a Story so its `body` is the structured object the conflict
+ * passes scan, mirroring `validateAcFreshness` /
+ * `collectStoryAssumptionEntries` (Story #3302) and the sizing gate's
+ * `resolveStoryBody` (Story #4271).
+ *
+ * The decomposer emits `body` as the canonical serialized **string**, but
+ * the conflict passes (`indexConsumers`, `indexAssumptionEntries`,
+ * `computeMissingBddScaffoldFindings`, the sibling-create scan in
+ * `computeRegistryFindings`, and the legacy-bullet branch of
+ * `collectStoryProducerPaths`) historically read `story.body` only when it
+ * was already an object — so on the production string shape the
+ * `implicit-cross-story-dep`, `fan-out`, registry, and `missing-bdd-scaffold`
+ * findings emitted nothing. Parsing the body once at the entry point and
+ * threading the normalized Story through every pass restores parity.
+ *
+ * `collectStoryAssumptionEntries` already parses string bodies itself, so a
+ * normalized object body round-trips through it unchanged. The returned Story
+ * keeps every other field (notably `slug` and `depends_on`) intact.
+ *
+ *   - **string body** → parsed via `parseStoryBody`; an unparseable string
+ *     yields `body: null` (the passes degrade to "no structured signal",
+ *     never throw mid-validation).
+ *   - **object body** → returned verbatim.
+ *   - **null / other** → `body: null`.
+ *
+ * @param {object} story
+ * @returns {object} A shallow clone of `story` with a structured `body`.
+ */
+function normalizeStoryBody(story) {
+  const body = story?.body;
+  if (typeof body === 'string') {
+    if (body.trim().length === 0) return { ...story, body: null };
+    try {
+      return { ...story, body: parseStoryBody(body).body };
+    } catch {
+      return { ...story, body: null };
+    }
+  }
+  return story;
+}
 
 /**
  * Cross-Story path-conflict & implicit-dependency findings.
@@ -661,7 +704,11 @@ function computeFanOutFindings({
  */
 export function computeConflictFindings({ stories, policy } = {}) {
   const merged = { ...DEFAULT_POLICY, ...(policy ?? {}) };
-  const storyList = stories ?? [];
+  // Story #4271: normalize every Story's body to its structured object form
+  // once, up front, so the canonical serialized **string** shape the
+  // decomposer emits is scanned at parity with the pre-serialize object
+  // shape across every conflict pass.
+  const storyList = (stories ?? []).map(normalizeStoryBody);
   const producers = indexProducers(storyList);
   const consumers = indexConsumers(storyList, producers);
   const reach = computeStoryReachability(storyList);

--- a/.agents/scripts/lib/orchestration/ticket-validator-sizing.js
+++ b/.agents/scripts/lib/orchestration/ticket-validator-sizing.js
@@ -30,6 +30,62 @@
  *     decomposer prompt and authoring SKILL.
  */
 
+import { parse as parseStoryBody } from '../story-body/story-body.js';
+
+/**
+ * Normalize a Story's `body` to the structured object the sizing layers
+ * score, mirroring `validateAcFreshness` / `collectStoryAssumptionEntries`
+ * (Story #3302) and `resolveStructuredBody` in `task-body-validator.js`.
+ *
+ * The decomposer emits `body` as the canonical serialized **string**
+ * (`decomposer-prompts.js`), but the sizing layers historically read
+ * `story.body` only when it was already an object — so on the production
+ * string shape `changes` / `wide` fell through to empty and the `hardFiles`
+ * / unanchored-constant backstops emitted nothing. A defensive parse here
+ * restores parity:
+ *   - **string body** → parsed via `parseStoryBody`; an unparseable string
+ *     yields `null` (the gate degrades to "no structured signal", never
+ *     throws mid-validation).
+ *   - **object body** → returned verbatim (a caller may pass the
+ *     pre-serialize shape directly; `parse` round-trips it).
+ *   - **null / other** → `null`.
+ *
+ * @param {object} story
+ * @returns {object|null}
+ */
+function resolveStoryBody(story) {
+  const body = story?.body;
+  if (typeof body === 'string') {
+    if (body.trim().length === 0) return null;
+    try {
+      return parseStoryBody(body).body;
+    } catch {
+      return null;
+    }
+  }
+  if (body !== null && typeof body === 'object') return body;
+  return null;
+}
+
+/**
+ * Resolve the acceptance-criteria array for a Story, preferring the
+ * authoritative top-level `story.acceptance` (the binding contract the
+ * validator already requires every Story to carry inline) over the
+ * structured body's `acceptance`. Reading the top-level array makes the
+ * acceptance ceiling correct regardless of body shape — a string body whose
+ * structured `acceptance` is only reachable after a parse, or an object body
+ * (Story #4271). Falls back to `resolveStoryBody(story).acceptance` only when
+ * the top-level array is absent.
+ *
+ * @param {object} story
+ * @returns {unknown[]}
+ */
+function resolveAcceptance(story) {
+  if (Array.isArray(story?.acceptance)) return story.acceptance;
+  const body = resolveStoryBody(story);
+  return Array.isArray(body?.acceptance) ? body.acceptance : [];
+}
+
 export const DEFAULT_TASK_SIZING = Object.freeze({
   // Typical-Story warning thresholds (soft — emit advisory findings).
   // Story #4162 raised `softFiles` 8 → 15: a capability-sized Story routinely
@@ -143,8 +199,11 @@ function makeUnanchoredConstant(slug, criterion) {
  */
 function computeUnanchoredConstantFindings(story) {
   const out = [];
-  const body = story.body && typeof story.body === 'object' ? story.body : null;
-  const acceptance = Array.isArray(body?.acceptance) ? body.acceptance : [];
+  // Read the authoritative top-level `story.acceptance` (the binding
+  // contract), falling back to the structured body's acceptance only when the
+  // top-level array is absent. This is correct regardless of body shape —
+  // string or object (Story #4271).
+  const acceptance = resolveAcceptance(story);
   for (const item of acceptance) {
     const criterion = String(item ?? '');
     if (CONCRETE_VALUE_RE.test(criterion)) continue;
@@ -253,8 +312,12 @@ function isDeclaredWide(wide) {
  */
 function computeStorySizingFindings(story, sizing) {
   const out = [];
-  const body = story.body && typeof story.body === 'object' ? story.body : null;
-  const acceptance = Array.isArray(body?.acceptance) ? body.acceptance : [];
+  // Story #4271: normalize the body so the canonical serialized **string**
+  // shape the decomposer emits is scored at parity with the pre-serialize
+  // object shape. The acceptance ceiling reads the authoritative top-level
+  // `story.acceptance` (the binding contract), not `body.acceptance`.
+  const body = resolveStoryBody(story);
+  const acceptance = resolveAcceptance(story);
   const changes = Array.isArray(body?.changes) ? body.changes : [];
   const declaredWide = isDeclaredWide(body?.wide ?? null);
 

--- a/tests/lib/orchestration/ticket-validator-conflicts.test.js
+++ b/tests/lib/orchestration/ticket-validator-conflicts.test.js
@@ -6,6 +6,7 @@ import {
   computeConflictFindings,
   renderHardConflictError,
 } from '../../../.agents/scripts/lib/orchestration/ticket-validator-conflicts.js';
+import { serialize as serializeStoryBody } from '../../../.agents/scripts/lib/story-body/story-body.js';
 
 /**
  * Cross-Story path-conflict & implicit-dependency findings (Story #2296).
@@ -621,4 +622,166 @@ test('collectStoryProducerPaths: object-form writes + legacy bullets, dropping r
     'src/refactored.ts',
     'src/removed.ts',
   ]);
+});
+
+// ---------------------------------------------------------------------------
+// Canonical serialized STRING body — production shape (Story #4271)
+//
+// The decomposer mandates `body` as a serialized markdown string, but the
+// conflict passes (`indexConsumers`, `indexAssumptionEntries`,
+// `computeMissingBddScaffoldFindings`, the sibling-create scan in
+// `computeRegistryFindings`) historically read `story.body` only when it was
+// already an object — so on the production string shape the
+// `implicit-cross-story-dep`, `fan-out`, and `missing-bdd-scaffold` findings
+// emitted nothing. `computeConflictFindings` now normalizes every body up
+// front, so these fixtures exercise the canonical string shape at parity with
+// the object-body cases above.
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a Story whose `body` is the canonical serialized **string** the
+ * decomposer emits, with the authoritative top-level `acceptance[]` /
+ * `verify[]` inline contract. The structured `changes` / `verify` fields
+ * survive the serialize → parse round-trip the conflict passes run.
+ */
+function makeStringStory(slug, body = {}, extras = {}) {
+  const structured = {
+    goal: `Goal for ${slug}.`,
+    changes: ['src/default.js: edit'],
+    acceptance: ['observable criterion'],
+    verify: ['npm test (unit)'],
+    ...body,
+  };
+  return {
+    type: 'story',
+    slug,
+    title: `Story ${slug}`,
+    acceptance: structured.acceptance,
+    verify: structured.verify,
+    body: serializeStoryBody(structured),
+    ...extras,
+  };
+}
+
+test('string body: emits shared-editor when two string-body Stories write the same path in one wave', () => {
+  const tickets = [
+    makeStringStory('s-a', {
+      changes: [
+        {
+          path: '.github/workflows/quality.yml',
+          assumption: 'refactors-existing',
+        },
+      ],
+    }),
+    makeStringStory('s-b', {
+      changes: [
+        {
+          path: '.github/workflows/quality.yml',
+          assumption: 'refactors-existing',
+        },
+      ],
+    }),
+  ];
+  const result = validateAndNormalizeTickets(tickets);
+  const shared = result.findings.filter((f) => f.kind === 'shared-editor');
+  assert.equal(shared.length, 1);
+  assert.equal(shared[0].path, '.github/workflows/quality.yml');
+  assert.deepEqual(shared[0].storySlugs, ['s-a', 's-b']);
+});
+
+test("string body: emits implicit-cross-story-dep when a string-body consumer verifies another Story's declared path", () => {
+  const tickets = [
+    makeStringStory('s-producer', {
+      changes: [
+        {
+          path: '.agents/schemas/baselines/coverage.schema.json',
+          assumption: 'creates',
+        },
+      ],
+    }),
+    makeStringStory('s-consumer', {
+      changes: [{ path: 'src/consumer.js', assumption: 'creates' }],
+      verify: [
+        'ajv validate -s .agents/schemas/baselines/coverage.schema.json (contract)',
+      ],
+    }),
+  ];
+  const result = validateAndNormalizeTickets(tickets);
+  const implicit = result.findings.filter(
+    (f) => f.kind === 'implicit-cross-story-dep',
+  );
+  assert.equal(implicit.length, 1);
+  assert.equal(
+    implicit[0].path,
+    '.agents/schemas/baselines/coverage.schema.json',
+  );
+  assert.equal(implicit[0].producer.storySlug, 's-producer');
+  assert.equal(implicit[0].consumer.storySlug, 's-consumer');
+  assert.equal(implicit[0].consumer.sourceField, 'verify');
+});
+
+test('string body: emits missing-bdd-scaffold when a string-body Story verifies a same-wave .feature creator', () => {
+  const tickets = [
+    makeStringStory('s-scaffold', {
+      changes: [
+        {
+          path: 'tests/features/billing/invoice.feature',
+          assumption: 'creates',
+        },
+      ],
+    }),
+    makeStringStory('s-impl', {
+      changes: [{ path: 'src/billing.js', assumption: 'creates' }],
+      verify: ['npx bddgen tests/features/billing/invoice.feature (e2e)'],
+    }),
+  ];
+  const result = validateAndNormalizeTickets(tickets);
+  const bdd = result.findings.filter((f) => f.kind === 'missing-bdd-scaffold');
+  assert.equal(bdd.length, 1);
+  assert.equal(bdd[0].path, 'tests/features/billing/invoice.feature');
+  assert.equal(bdd[0].producer.storySlug, 's-scaffold');
+  assert.equal(bdd[0].consumer.storySlug, 's-impl');
+});
+
+test('string body: fan-out finding fires on a string-body deletes entry', () => {
+  const del = makeStringStory('s-del', {
+    changes: [{ path: 'src/legacy/old.js', assumption: 'deletes' }],
+  });
+  const findings = computeConflictFindings({
+    stories: [del],
+    policy: { largeFanOutThreshold: 2, fanOutCounter: () => 5 },
+  });
+  const fanOut = findings.filter((f) => f.kind === 'fan-out-warning');
+  assert.equal(fanOut.length, 1);
+  assert.equal(fanOut[0].path, 'src/legacy/old.js');
+  assert.equal(fanOut[0].callSiteCount, 5);
+  assert.equal(fanOut[0].storySlug, 's-del');
+});
+
+test('string body: a depends_on chain still serialises string-body writers (no shared-editor)', () => {
+  const tickets = [
+    makeStringStory('s-a', {
+      changes: [
+        {
+          path: '.github/workflows/quality.yml',
+          assumption: 'refactors-existing',
+        },
+      ],
+    }),
+    makeStringStory(
+      's-b',
+      {
+        changes: [
+          {
+            path: '.github/workflows/quality.yml',
+            assumption: 'refactors-existing',
+          },
+        ],
+      },
+      { depends_on: ['s-a'] },
+    ),
+  ];
+  const result = validateAndNormalizeTickets(tickets);
+  const shared = result.findings.filter((f) => f.kind === 'shared-editor');
+  assert.deepEqual(shared, []);
 });

--- a/tests/lib/orchestration/ticket-validator-sizing.test.js
+++ b/tests/lib/orchestration/ticket-validator-sizing.test.js
@@ -1,6 +1,7 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 import { validateAndNormalizeTickets } from '../../../.agents/scripts/lib/orchestration/ticket-validator.js';
+import { serialize as serializeStoryBody } from '../../../.agents/scripts/lib/story-body/story-body.js';
 
 /**
  * Sizing validator fixtures for the collapsed sizing model (Story #3760),
@@ -32,19 +33,24 @@ import { validateAndNormalizeTickets } from '../../../.agents/scripts/lib/orches
  */
 
 function makeStory(slug = 's-sizing', body) {
+  const structured = {
+    goal: `Goal for ${slug}.`,
+    changes: ['src/a.js: edit'],
+    acceptance: ['observable criterion'],
+    verify: ['npm test (unit)'],
+    ...body,
+  };
+  // The decomposer mirrors the structured body's acceptance / verify onto the
+  // authoritative top-level inline contract. Mirror that here so the
+  // acceptance ceiling — which reads the top-level `story.acceptance`
+  // (Story #4271) — sees whatever the fixture's body declares.
   return {
     type: 'story',
     slug,
     title: `Sizing story ${slug}`,
-    acceptance: ['observable criterion'],
-    verify: ['npm test (unit)'],
-    body: {
-      goal: `Goal for ${slug}.`,
-      changes: ['src/a.js: edit'],
-      acceptance: ['observable criterion'],
-      verify: ['npm test (unit)'],
-      ...body,
-    },
+    acceptance: structured.acceptance,
+    verify: structured.verify,
+    body: structured,
   };
 }
 
@@ -371,4 +377,137 @@ test('rejects a Story that lacks an inline acceptance + verify contract', () => 
       ]),
     /lack an inline acceptance \+ verify contract/,
   );
+});
+
+// ---------------------------------------------------------------------------
+// Canonical serialized STRING body — production shape (Story #4271)
+//
+// The decomposer mandates `body` as a serialized markdown string, but the
+// sizing layers historically read `story.body` only when it was already an
+// object — so on the production string shape `hardFiles`, `maxAcceptance`,
+// and the `unanchored-constant` nudge all emitted nothing. These fixtures
+// exercise the canonical string shape at parity with the object-body cases
+// above. The freshness gate already string-aware via parseStoryBody;
+// `computeStorySizingFindings` now mirrors that.
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a Story whose `body` is the canonical serialized **string** the
+ * decomposer emits (via `serialize()`), with the authoritative top-level
+ * `acceptance[]` / `verify[]` inline contract the validator requires. The
+ * structured body fields (`changes` / `wide` / body-level `acceptance`)
+ * survive the serialize → parse round-trip the gate runs internally.
+ */
+function makeStringStory(slug, body = {}) {
+  const structured = {
+    goal: `Goal for ${slug}.`,
+    changes: ['src/a.js: edit'],
+    acceptance: ['observable criterion'],
+    verify: ['npm test (unit)'],
+    ...body,
+  };
+  return {
+    type: 'story',
+    slug,
+    title: `Sizing story ${slug}`,
+    acceptance: structured.acceptance,
+    verify: structured.verify,
+    body: serializeStoryBody(structured),
+  };
+}
+
+function objectChanges(n, verb = 'refactors-existing') {
+  return Array.from({ length: n }, (_, i) => ({
+    path: `src/file${i}.js`,
+    assumption: i === 0 ? 'creates' : verb,
+  }));
+}
+
+test('string body: >hardFiles distinct changes paths trips hard oversized-task on fileCount', () => {
+  const result = validateStory(
+    makeStringStory('t-str-31files', { changes: objectChanges(31) }),
+  );
+  const hard = result.findings.filter(
+    (f) => f.kind === 'oversized-task' && f.field === 'fileCount',
+  );
+  assert.equal(
+    hard.length,
+    1,
+    'expected the file-width hard finding on a string body',
+  );
+  assert.equal(hard[0].observed, 31);
+  assert.equal(hard[0].ceiling, 30);
+  assert.equal(
+    result.errors.filter((e) => e.includes('fileCount ceiling')).length,
+    1,
+  );
+});
+
+test('string body: >maxAcceptance acceptance items trips hard oversized-task on acceptance', () => {
+  const result = validateStory(
+    makeStringStory('t-str-15ac', {
+      acceptance: Array.from({ length: 15 }, (_, i) => `criterion ${i}`),
+    }),
+  );
+  const hard = result.findings.filter(
+    (f) => f.kind === 'oversized-task' && f.field === 'acceptance',
+  );
+  assert.equal(
+    hard.length,
+    1,
+    'expected the acceptance hard finding on a string body',
+  );
+  assert.equal(hard[0].observed, 15);
+  assert.equal(hard[0].ceiling, 14);
+});
+
+test('string body: unanchored-constant fires identically to the object case', () => {
+  const result = validateStory(
+    makeStringStory('t-str-unanch', {
+      acceptance: ['Records older than the retention window are purged'],
+    }),
+  );
+  const nudge = result.findings.filter((f) => f.kind === 'unanchored-constant');
+  assert.equal(nudge.length, 1);
+  assert.equal(nudge[0].ticketSlug, 't-str-unanch');
+});
+
+test('string body: a declared wide reason lifts the hard file ceiling', () => {
+  const result = validateStory(
+    makeStringStory('t-str-31files-wide', {
+      changes: objectChanges(31),
+      wide: { reason: 'hard contract cutover across every call site' },
+    }),
+  );
+  const hard = result.findings.filter((f) => f.severity === 'hard');
+  assert.deepEqual(hard, []);
+  const soft = result.findings.filter(
+    (f) => f.kind === 'soft-task-width' && f.field === 'fileCount',
+  );
+  assert.equal(soft.length, 1);
+  assert.equal(soft[0].observed, 31);
+});
+
+test('acceptance ceiling reads the authoritative top-level story.acceptance, not body.acceptance', () => {
+  // Top-level acceptance carries 15 items (> ceiling 14); the structured
+  // body's acceptance carries only 2. The ceiling MUST read the top-level
+  // binding contract regardless of what the body says.
+  const result = validateStory({
+    type: 'story',
+    slug: 't-toplevel-ac',
+    title: 'Top-level acceptance authority',
+    acceptance: Array.from({ length: 15 }, (_, i) => `top criterion ${i}`),
+    verify: ['npm test (unit)'],
+    body: {
+      goal: 'Goal.',
+      changes: ['src/a.js: edit'],
+      acceptance: ['only two', 'criteria'],
+      verify: ['npm test (unit)'],
+    },
+  });
+  const hard = result.findings.filter(
+    (f) => f.kind === 'oversized-task' && f.field === 'acceptance',
+  );
+  assert.equal(hard.length, 1);
+  assert.equal(hard[0].observed, 15);
 });


### PR DESCRIPTION
Closes #4271

_Auto-opened by `/single-story-deliver`._