### PR TITLE
fix: rebuild the audit-to-stories Story body to the canonical inline-contract shape and gate it before issue creation (#4270)

### DIFF
--- a/.agents/scripts/audit-to-stories.js
+++ b/.agents/scripts/audit-to-stories.js
@@ -40,6 +40,7 @@ import { parseAuditReports } from './lib/audit-to-stories/parse-audit-md.js';
 import { buildEpicSeedMarkdown } from './lib/audit-to-stories/seed-epic-from-findings.js';
 import { runAsCli } from './lib/cli-utils.js';
 import { Logger } from './lib/Logger.js';
+import { parse as parseStoryBody } from './lib/story-body/story-body.js';
 
 const SEVERITY_RANK = { critical: 4, high: 3, medium: 2, low: 1 };
 const DEFAULT_GLOB = 'temp/audits/audit-*-results.md';
@@ -227,6 +228,46 @@ function loadPlan(planPath) {
   return JSON.parse(fs.readFileSync(planPath, 'utf8'));
 }
 
+/**
+ * Build every eligible group into a `{ title, body, labels }` Story object and
+ * gate the batch against the inline-contract bar BEFORE any issue is opened.
+ *
+ * The `--emit-stories` path opens GitHub issues directly (no decomposer
+ * round-trip), so `assertEveryStoryHasInlineContract` never runs against these
+ * bodies. This gate restores that guarantee at the standalone seam: each
+ * emitted body is re-parsed through the canonical `story-body` parser and must
+ * carry a non-empty `acceptance[]` AND a non-empty `verify[]`. A body that
+ * fails throws, surfacing the gap instead of opening an ungated Story
+ * (Story #4270).
+ *
+ * @param {Array<{ group: object }>} eligible — classifications eligible to create.
+ * @param {Array<{ fromGroupKey: string, toGroupKey: string }>} edges — sequencing edges.
+ * @returns {Array<{ title: string, body: string, labels: string[] }>}
+ */
+function buildAndGateStories(eligible, edges) {
+  const built = eligible.map((g) => buildStoryBody({ group: g, edges }));
+  const offenders = [];
+  for (const story of built) {
+    const { body } = parseStoryBody(story.body);
+    const ok =
+      Array.isArray(body.acceptance) &&
+      body.acceptance.length > 0 &&
+      Array.isArray(body.verify) &&
+      body.verify.length > 0;
+    if (!ok) offenders.push(story.title);
+  }
+  if (offenders.length > 0) {
+    throw new Error(
+      `inline-contract gate failed: ${offenders.length} generated audit Story/Stories lack a non-empty acceptance[] + verify[] contract: ${offenders
+        .map((t) => `"${t}"`)
+        .join(
+          ', ',
+        )}. No issues were opened. Every emitted Story must carry both arrays.`,
+    );
+  }
+  return built;
+}
+
 function persist(text, outPath) {
   if (!outPath) {
     process.stdout.write(text);
@@ -242,6 +283,7 @@ export const __testing = {
   buildPlan,
   loadProvider,
   dedupSkippedWarning,
+  buildAndGateStories,
 };
 
 async function main() {
@@ -289,7 +331,7 @@ async function main() {
     const eligible = (plan.classifications ?? [])
       .filter((c) => c.action === 'create')
       .map((c) => c.group);
-    const built = eligible.map((g) => buildStoryBody({ group: g }));
+    const built = buildAndGateStories(eligible, plan.edges ?? []);
     const out = values.json
       ? JSON.stringify(built, null, 2)
       : built

--- a/.agents/scripts/lib/audit-to-stories/__tests__/build-story-body.test.js
+++ b/.agents/scripts/lib/audit-to-stories/__tests__/build-story-body.test.js
@@ -1,0 +1,182 @@
+/**
+ * Colocated unit tests for the rebuilt audit Story-body shape (Story #4270).
+ *
+ * Asserts the inline-contract acceptance criteria:
+ *   1. goal is the group intent only — no ordinal, no [SEVERITY]/(dimension).
+ *   2. acceptance items are observable end-states, not verbatim recommendations.
+ *   3. changes[] is populated from files[] in { path, assumption } form, and
+ *      edges[] sequencing is carried through to depends_on[].
+ *   4. verify[] is non-empty and tier-tagged with harness commands.
+ *   5. the --emit-stories gate (buildAndGateStories) rejects an empty contract.
+ *   6. the generated body round-trips through parse() / serialize().
+ */
+
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import { __testing as auditCli } from '../../../audit-to-stories.js';
+import { parse, serialize } from '../../story-body/story-body.js';
+import {
+  __testing as bodyTesting,
+  buildStoryBody,
+} from '../build-story-body.js';
+
+const { buildAndGateStories } = auditCli;
+const { DEFAULT_VERIFY, sequencingDepsForGroup } = bodyTesting;
+
+/** A representative cross-audit group with files[], recommendations, prompts. */
+function makeGroup(overrides = {}) {
+  return {
+    groupKey: 'file:.agents/scripts/lib/audit-to-stories/build-story-body.js',
+    title: 'Remediate clean-code / security findings in build-story-body.js',
+    dimensions: ['clean-code', 'injection'],
+    files: ['.agents/scripts/lib/audit-to-stories/build-story-body.js'],
+    severity: 'high',
+    findings: [
+      {
+        title: 'Goal carries leftover ordinal + severity prefix',
+        severity: 'high',
+        dimension: 'clean-code',
+        currentState: 'goal is polluted with `1. [HIGH] (clean-code)` prose',
+        recommendation:
+          'Derive goal from group.title only; drop summaryFromGroup.',
+        agentPrompt: 'Rewrite goalFromGroup to return group.title.trim().',
+        sourceReport: 'temp/audits/audit-clean-code-results.md',
+        files: ['.agents/scripts/lib/audit-to-stories/build-story-body.js'],
+        fingerprint: { full: 'a'.repeat(40), short: 'a'.repeat(12) },
+      },
+      {
+        title: 'verify[] hardcoded empty',
+        severity: 'medium',
+        dimension: 'clean-code',
+        currentState: 'verify: [] ships an ungated Story',
+        recommendation: 'Populate verify[] with harness commands.',
+        agentPrompt: '',
+        sourceReport: 'temp/audits/audit-clean-code-results.md',
+        files: ['.agents/scripts/lib/audit-to-stories/build-story-body.js'],
+        fingerprint: { full: 'b'.repeat(40), short: 'b'.repeat(12) },
+      },
+    ],
+    ...overrides,
+  };
+}
+
+describe('buildStoryBody goal (criterion 1)', () => {
+  it('uses the group title only — no ordinal, no [SEVERITY]/(dimension) prefix', () => {
+    const { body } = parse(buildStoryBody({ group: makeGroup() }).body);
+    assert.equal(
+      body.goal,
+      'Remediate clean-code / security findings in build-story-body.js',
+    );
+    assert.ok(
+      !/^\d+\.\s/.test(body.goal),
+      'goal must not lead with an ordinal',
+    );
+    assert.ok(!/\[[A-Z]+\]/.test(body.goal), 'goal must not carry [SEVERITY]');
+    assert.ok(
+      !/\((clean-code|injection)\)/.test(body.goal),
+      'goal must not carry a (dimension) prefix',
+    );
+  });
+});
+
+describe('buildStoryBody acceptance (criterion 2)', () => {
+  it('emits observable, non-verbatim end-states anchored on title + primary file', () => {
+    const { body } = parse(buildStoryBody({ group: makeGroup() }).body);
+    assert.equal(body.acceptance.length, 2);
+    for (const item of body.acceptance) {
+      assert.match(item, /is remediated/);
+      assert.match(item, /no longer reproducible/);
+    }
+    // Must NOT be the verbatim recommendation paragraph.
+    assert.ok(
+      !body.acceptance.some((a) => a.includes('drop summaryFromGroup')),
+      'acceptance must not echo the verbatim recommendation',
+    );
+    // Anchored on the primary file.
+    assert.ok(
+      body.acceptance[0].includes('build-story-body.js'),
+      'acceptance should name the primary file',
+    );
+  });
+});
+
+describe('buildStoryBody changes + edges (criterion 3)', () => {
+  it('populates changes[] from files[] in canonical { path, assumption } form', () => {
+    const { body } = parse(buildStoryBody({ group: makeGroup() }).body);
+    assert.deepEqual(body.changes, [
+      {
+        path: '.agents/scripts/lib/audit-to-stories/build-story-body.js',
+        assumption: 'refactors-existing',
+      },
+    ]);
+  });
+
+  it('resolves edges[] anchored on the group and renders a ## Sequencing block', () => {
+    const group = makeGroup();
+    const edges = [
+      { fromGroupKey: group.groupKey, toGroupKey: 'file:other.js', via: 'x' },
+      { fromGroupKey: 'file:unrelated.js', toGroupKey: 'file:nope.js' },
+    ];
+    assert.deepEqual(sequencingDepsForGroup(group, edges), ['file:other.js']);
+    const { body } = buildStoryBody({ group, edges });
+    assert.match(body, /## Sequencing/);
+    assert.match(body, /depends on group `file:other\.js`/);
+    // The unrelated edge's target must not leak in.
+    assert.ok(!body.includes('file:nope.js'));
+  });
+
+  it('omits the ## Sequencing block when no edge anchors on the group', () => {
+    const { body } = buildStoryBody({ group: makeGroup() });
+    assert.ok(!body.includes('## Sequencing'));
+    assert.deepEqual(parse(body).body.depends_on, []);
+  });
+});
+
+describe('buildStoryBody verify (criterion 4)', () => {
+  it('is non-empty and tier-tagged with harness commands', () => {
+    const { body } = parse(buildStoryBody({ group: makeGroup() }).body);
+    assert.ok(body.verify.length > 0);
+    assert.deepEqual(body.verify, [...DEFAULT_VERIFY]);
+    for (const v of body.verify) {
+      assert.match(v, /\((validate|unit|contract|e2e)\)$/);
+    }
+  });
+});
+
+describe('buildStoryBody round-trip (criterion 6)', () => {
+  it('round-trips the canonical structured sections through parse()/serialize()', () => {
+    const { body } = parse(buildStoryBody({ group: makeGroup() }).body);
+    // Re-serialize the parsed structured body and re-parse; the structured
+    // fields must be stable.
+    const reparsed = parse(serialize(body)).body;
+    assert.equal(reparsed.goal, body.goal);
+    assert.deepEqual(reparsed.changes, body.changes);
+    assert.deepEqual(reparsed.acceptance, body.acceptance);
+    assert.deepEqual(reparsed.verify, body.verify);
+  });
+});
+
+describe('buildAndGateStories inline-contract gate (criterion 5)', () => {
+  it('passes a well-formed batch and threads edges through', () => {
+    const group = makeGroup();
+    const built = buildAndGateStories(
+      [group],
+      [{ fromGroupKey: group.groupKey, toGroupKey: 'file:other.js' }],
+    );
+    assert.equal(built.length, 1);
+    const { body } = parse(built[0].body);
+    assert.ok(body.acceptance.length > 0 && body.verify.length > 0);
+    assert.match(built[0].body, /depends on group `file:other\.js`/);
+  });
+
+  it('throws (opening no issues) when a group yields no acceptance items', () => {
+    // A group with zero findings yields an empty acceptance[] — the legacy
+    // ungated shape. The gate must reject it.
+    const emptyGroup = makeGroup({ findings: [], files: [] });
+    assert.throws(
+      () => buildAndGateStories([emptyGroup], []),
+      /inline-contract gate failed/,
+    );
+  });
+});

--- a/.agents/scripts/lib/audit-to-stories/__tests__/build-story-body.test.js
+++ b/.agents/scripts/lib/audit-to-stories/__tests__/build-story-body.test.js
@@ -16,13 +16,14 @@ import { describe, it } from 'node:test';
 
 import { __testing as auditCli } from '../../../audit-to-stories.js';
 import { parse, serialize } from '../../story-body/story-body.js';
-import {
-  __testing as bodyTesting,
-  buildStoryBody,
-} from '../build-story-body.js';
+import { buildStoryBody } from '../build-story-body.js';
 
 const { buildAndGateStories } = auditCli;
-const { DEFAULT_VERIFY, sequencingDepsForGroup } = bodyTesting;
+
+// The verify[] contract every generated audit Story carries (mirrors the
+// frozen DEFAULT_VERIFY in build-story-body.js — asserted against literals so
+// the module needs no test-only export).
+const DEFAULT_VERIFY = ['npm run lint (validate)', 'npm test (unit)'];
 
 /** A representative cross-audit group with files[], recommendations, prompts. */
 function makeGroup(overrides = {}) {
@@ -112,13 +113,12 @@ describe('buildStoryBody changes + edges (criterion 3)', () => {
     ]);
   });
 
-  it('resolves edges[] anchored on the group and renders a ## Sequencing block', () => {
+  it('carries edges[] anchored on the group through a ## Sequencing block', () => {
     const group = makeGroup();
     const edges = [
       { fromGroupKey: group.groupKey, toGroupKey: 'file:other.js', via: 'x' },
       { fromGroupKey: 'file:unrelated.js', toGroupKey: 'file:nope.js' },
     ];
-    assert.deepEqual(sequencingDepsForGroup(group, edges), ['file:other.js']);
     const { body } = buildStoryBody({ group, edges });
     assert.match(body, /## Sequencing/);
     assert.match(body, /depends on group `file:other\.js`/);

--- a/.agents/scripts/lib/audit-to-stories/build-story-body.js
+++ b/.agents/scripts/lib/audit-to-stories/build-story-body.js
@@ -1,10 +1,11 @@
 /**
  * lib/audit-to-stories/build-story-body.js
  *
- * Render the canonical Story body for the standalone grouping mode. The
- * body follows the contract spelled out in Story #2583 acceptance
- * criteria #8: Title (caller), Summary, Acceptance Criteria, Agent
- * Prompts, Context block, fingerprint footer.
+ * Render the canonical Story body for the standalone grouping mode so a
+ * generated audit Story clears the same inline-contract bar the decomposer
+ * enforces (`assertEveryStoryHasInlineContract`): a clean goal, observable
+ * `acceptance[]`, a populated `changes[]` footprint, and a non-empty,
+ * tier-tagged `verify[]` (Story #4270).
  *
  * Pure: returns { title, body, labels }. Labels carry one canonical
  * `audit::<lens>` per distinct source report represented in the merge
@@ -14,10 +15,11 @@
  * `risk::high`.
  *
  * The body is serialized via the canonical story-body serializer
- * (`.agents/scripts/lib/story-body/story-body.js`) so the output is
- * parseable by `parse()` and round-trippable. Audit-specific content
- * (agent prompts, context links, fingerprint footer) is appended after
- * the canonical sections as extended markdown.
+ * (`.agents/scripts/lib/story-body/story-body.js`) so the output round-trips
+ * through `parse()` / `serialize()`. Audit-specific content (agent prompts,
+ * context links, fingerprint footer) is appended after the canonical sections
+ * as extended markdown — it is informational only and is not part of the
+ * structured contract.
  */
 
 import { serialize } from '../story-body/story-body.js';
@@ -26,36 +28,128 @@ import { renderFingerprintFooter } from './finding-adapter.js';
 
 const STATIC_LABELS = Object.freeze(['type::story', 'agent::ready']);
 
+// The verify[] contract every generated audit Story carries. These commands
+// exist in this repo's harness (package.json scripts) so the Story satisfies
+// the inline-contract bar with runnable, tier-tagged gates rather than
+// placeholder prose. Kept as a frozen constant so the same contract is
+// asserted by the unit suite.
+const DEFAULT_VERIFY = Object.freeze([
+  'npm run lint (validate)',
+  'npm test (unit)',
+]);
+
 function uniq(items) {
   return [...new Set(items)];
 }
 
-function summaryFromGroup(group) {
-  const lines = group.findings.map((f, idx) => {
-    const sev = f.severity ? `[${f.severity.toUpperCase()}]` : '[—]';
-    const dim = f.dimension ? `(${f.dimension})` : '';
-    return `${idx + 1}. ${sev} ${dim} **${f.title}** — ${
-      f.currentState || '_(no current-state captured)_'
-    }`;
-  });
-  return lines.join('\n');
+/**
+ * The goal is the group intent only — the synthesized `group.title`. It
+ * carries no leading ordinal (`1.`/`2.`) and no `[SEVERITY]` / `(dimension)`
+ * prefix (the polluted shape Story #4270 replaced); those signals live in the
+ * per-finding fingerprint footer and the extended Agent Prompts section, not
+ * in the goal.
+ *
+ * @param {object} group
+ * @returns {string}
+ */
+function goalFromGroup(group) {
+  return (group.title ?? '').trim();
 }
 
-function goalFromGroup(group) {
-  // Derive a concise goal statement from the group title + finding summary.
-  const summary = summaryFromGroup(group);
-  return `${group.title}\n\n${summary}`;
+/**
+ * Map every distinct file mentioned across the merge onto a canonical
+ * `changes[]` PathEntry (`{ path, assumption }`). Audit findings remediate
+ * code that already exists, so the assumption is `refactors-existing`.
+ *
+ * `group.files` is an array post-`groupFindings`; fall back to scanning the
+ * findings' own `files[]` when an upstream caller hands a group whose `files`
+ * aggregate was not materialized.
+ *
+ * @param {object} group
+ * @returns {Array<{ path: string, assumption: string }>}
+ */
+function changesFromGroup(group) {
+  const fromGroup = Array.isArray(group.files) ? group.files : [];
+  const fromFindings = (group.findings ?? []).flatMap((f) =>
+    Array.isArray(f.files) ? f.files : [],
+  );
+  const paths = uniq(
+    [...fromGroup, ...fromFindings].filter(
+      (p) => typeof p === 'string' && p.length > 0,
+    ),
+  );
+  return paths.map((path) => ({ path, assumption: 'refactors-existing' }));
+}
+
+/**
+ * Build an observable acceptance item from a single finding: a checkable
+ * end-state a reviewer can confirm, NOT the verbatim recommendation
+ * paragraph. The recommendation prose is preserved verbatim in the Agent
+ * Prompts / fingerprint footer for the implementer; the acceptance line is
+ * the binding, confirmable outcome.
+ *
+ * Shape: `<title> is remediated in <primary file>: the recommended end-state
+ * holds and the finding is no longer reproducible.` — anchored on the finding
+ * title and primary file so the reviewer knows exactly what to check.
+ *
+ * @param {object} finding
+ * @returns {string}
+ */
+function acceptanceItemFromFinding(finding) {
+  const title = (finding.title ?? 'finding').trim();
+  const primaryFile =
+    Array.isArray(finding.files) && finding.files.length > 0
+      ? finding.files[0]
+      : null;
+  const where = primaryFile ? ` in \`${primaryFile}\`` : '';
+  return `${title} is remediated${where}: the recommended end-state holds and the finding is no longer reproducible`;
 }
 
 function acceptanceCriteriaFromGroup(group) {
-  return group.findings.map((f) => {
-    const rec = f.recommendation || '_(no recommendation captured)_';
-    return `${f.title} — ${rec}`;
-  });
+  return (group.findings ?? []).map(acceptanceItemFromFinding);
+}
+
+/**
+ * Resolve the `edges[]` sequencing anchored on this group. Each edge whose
+ * `fromGroupKey` matches this group's key contributes its `toGroupKey`. Group
+ * keys are the only stable identifier available at emit time — issues are not
+ * numbered yet — so the relationship is preserved as machine-readable keys the
+ * operator can resolve.
+ *
+ * @param {object} group
+ * @param {Array<{ fromGroupKey: string, toGroupKey: string }>} edges
+ * @returns {string[]}
+ */
+function sequencingDepsForGroup(group, edges) {
+  if (!Array.isArray(edges) || edges.length === 0) return [];
+  const deps = edges
+    .filter((e) => e && e.fromGroupKey === group.groupKey)
+    .map((e) => e.toGroupKey)
+    .filter((k) => typeof k === 'string' && k.length > 0);
+  return uniq(deps);
+}
+
+/**
+ * Render the carried-through `edges[]` sequencing as a dedicated extended
+ * markdown block. The canonical `depends_on[]` footer only round-trips `#N`
+ * issue refs (`blocked by #123`), which do not exist before the issues are
+ * opened; rendering the group-key sequencing as its own informational section
+ * keeps the signal in the body (not discarded — Story #4270) and survives
+ * `parse()` / `serialize()` round-tripping (it is preamble/extended content,
+ * not a structured section). Returns the empty string when there is no
+ * sequencing to surface.
+ *
+ * @param {string[]} deps
+ * @returns {string}
+ */
+function sequencingSection(deps) {
+  if (deps.length === 0) return '';
+  const lines = deps.map((k) => `- depends on group \`${k}\``);
+  return ['## Sequencing', '', lines.join('\n'), ''].join('\n');
 }
 
 function agentPromptsSection(group) {
-  const blocks = group.findings
+  const blocks = (group.findings ?? [])
     .filter(
       (f) => typeof f.agentPrompt === 'string' && f.agentPrompt.length > 0,
     )
@@ -65,7 +159,7 @@ function agentPromptsSection(group) {
 
 function contextLinksFromGroup(group) {
   const reports = uniq(
-    group.findings
+    (group.findings ?? [])
       .map((f) => f.sourceReport)
       .filter((s) => typeof s === 'string'),
   );
@@ -93,34 +187,47 @@ function labelsForGroup(group) {
 /**
  * @param {object} params
  * @param {object} params.group — output of `groupFindings` (one entry).
+ * @param {Array<{ fromGroupKey: string, toGroupKey: string }>} [params.edges]
+ *   — the dependency `edges[]` emitted by `groupFindings`. Edges anchored on
+ *   this group are carried through to `depends_on[]`; omit when no sequencing
+ *   is known.
  * @returns {{ title: string, body: string, labels: string[] }}
  */
-export function buildStoryBody({ group }) {
+export function buildStoryBody({ group, edges = [] }) {
   if (!group || !Array.isArray(group.findings)) {
     throw new Error('buildStoryBody: group with findings[] is required');
   }
   const title = group.title;
 
-  // Build the canonical StoryBody object from the audit group data.
+  // Build the canonical StoryBody object from the audit group data. The
+  // acceptance + verify arrays are populated so the body clears the
+  // inline-contract bar; changes[] carries the file footprint. The edges[]
+  // sequencing is carried through as an extended `## Sequencing` block (see
+  // sequencingSection) — group keys are not `#N` refs, so they cannot ride the
+  // canonical depends_on footer.
   const storyBody = {
     goal: goalFromGroup(group),
-    changes: [],
+    changes: changesFromGroup(group),
     acceptance: acceptanceCriteriaFromGroup(group),
-    verify: [],
+    verify: [...DEFAULT_VERIFY],
     references: [],
     wide: null,
+    reason_to_exist: null,
     depends_on: [],
     estimated_test_files: null,
   };
 
-  // Serialize via the canonical serializer.
+  // Serialize via the canonical serializer (no footer — depends_on is empty).
   const canonicalSections = serialize(storyBody);
+  const sequencing = sequencingSection(sequencingDepsForGroup(group, edges));
 
-  // Append audit-specific extended sections (agent prompts, context links,
-  // fingerprint footer) that are not part of the canonical shape.
+  // Append audit-specific extended sections (sequencing, agent prompts,
+  // context links, fingerprint footer) that are not part of the canonical
+  // shape.
   const body = [
     canonicalSections,
     '',
+    ...(sequencing ? [sequencing] : []),
     '## Agent Prompts',
     '',
     agentPromptsSection(group),
@@ -136,3 +243,9 @@ export function buildStoryBody({ group }) {
 
   return { title, body, labels: labelsForGroup(group) };
 }
+
+export const __testing = {
+  DEFAULT_VERIFY,
+  sequencingDepsForGroup,
+  changesFromGroup,
+};

--- a/.agents/scripts/lib/audit-to-stories/build-story-body.js
+++ b/.agents/scripts/lib/audit-to-stories/build-story-body.js
@@ -243,9 +243,3 @@ export function buildStoryBody({ group, edges = [] }) {
 
   return { title, body, labels: labelsForGroup(group) };
 }
-
-export const __testing = {
-  DEFAULT_VERIFY,
-  sequencingDepsForGroup,
-  changesFromGroup,
-};

--- a/.agents/scripts/lib/story-body/story-body.js
+++ b/.agents/scripts/lib/story-body/story-body.js
@@ -346,15 +346,29 @@ function splitSections(markdown) {
     // Forms (Story #4227) render every field label as a level-3 heading
     // (`### Goal`), not the level-2 the canonical serializer emits, so the
     // parser accepts both levels. Any other heading depth is ignored.
-    const headingMatch = line.match(/^#{2,3}\s+(\w+)\s*$/i);
-    if (headingMatch) {
-      const name = headingMatch[1].toLowerCase();
+    const fieldHeadingMatch = line.match(/^#{2,3}\s+(\w+)\s*$/i);
+    if (fieldHeadingMatch) {
+      const name = fieldHeadingMatch[1].toLowerCase();
       if (HEADING_TO_FIELD.has(name)) {
         inPreamble = false;
         currentSection = name;
         if (!sections.has(currentSection)) sections.set(currentSection, []);
         continue;
       }
+    }
+
+    // Any other markdown heading (`## …` / `### …`, single- or multi-word)
+    // that is NOT a canonical field heading TERMINATES the current structured
+    // section. Trailing extended content a producer appends after the
+    // canonical block — `audit-to-stories`'s `## Agent Prompts` / `## Context`
+    // / `## Sequencing` blocks, for instance — must not bleed into the last
+    // structured section's bullet list (Story #4270). Without this, those
+    // lines were silently absorbed into `verify[]` / `acceptance[]`. The
+    // heading and everything under it is dropped from structured parsing
+    // (it is extended, non-canonical markdown).
+    if (!inPreamble && /^#{1,6}\s+\S/.test(line)) {
+      currentSection = null;
+      continue;
     }
 
     // The trailing `<!-- meta: {...} -->` block is machine metadata, not

--- a/tests/audit-to-stories/build-story-body.test.js
+++ b/tests/audit-to-stories/build-story-body.test.js
@@ -8,6 +8,7 @@ import { withFingerprints } from '../../.agents/scripts/lib/audit-to-stories/fin
 import { groupFindings } from '../../.agents/scripts/lib/audit-to-stories/group-findings.js';
 import { parseAuditReports } from '../../.agents/scripts/lib/audit-to-stories/parse-audit-md.js';
 import { parseFingerprintFooter } from '../../.agents/scripts/lib/findings/route-finding.js';
+import { parse as parseStoryBody } from '../../.agents/scripts/lib/story-body/story-body.js';
 
 const __filename = url.fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -105,4 +106,34 @@ test('buildStoryBody Context section links every distinct source report', () => 
   for (const r of unique) {
     assert.ok(body.includes(r));
   }
+});
+
+test('buildStoryBody (real fixtures) clears the inline-contract bar and round-trips', () => {
+  // Story #4270: a generated audit Story body must parse into a clean,
+  // structured StoryBody with a populated changes[] footprint, non-empty
+  // observable acceptance[], and a non-empty tier-tagged verify[] — and the
+  // trailing Agent Prompts / Context blocks must NOT bleed into those arrays.
+  const group = loginGroup();
+  const { body } = parseStoryBody(buildStoryBody({ group }).body);
+
+  // Goal is the group intent only — no leftover ordinal / [SEVERITY] prefix.
+  assert.ok(!/^\d+\.\s/.test(body.goal), 'goal must not lead with an ordinal');
+  assert.ok(!/\[[A-Z]+\]/.test(body.goal), 'goal must not carry [SEVERITY]');
+
+  // changes[] is canonical { path, assumption } entries drawn from files[].
+  assert.ok(body.changes.length > 0, 'changes[] must be populated');
+  for (const c of body.changes) {
+    assert.equal(typeof c.path, 'string');
+    assert.equal(c.assumption, 'refactors-existing');
+  }
+
+  // acceptance[] is observable and is NOT swamped by extended sections.
+  assert.equal(body.acceptance.length, group.findings.length);
+  for (const a of body.acceptance) {
+    assert.match(a, /is remediated/);
+    assert.ok(!a.includes('## Agent Prompts'));
+  }
+
+  // verify[] survives intact — extended markdown did not bleed in.
+  assert.deepEqual(body.verify, ['npm run lint (validate)', 'npm test (unit)']);
 });

--- a/tests/lib/story-body/story-body.test.js
+++ b/tests/lib/story-body/story-body.test.js
@@ -445,6 +445,40 @@ g
     assert.deepEqual(body.verify, ['npm test (unit)']);
   });
 
+  it('stops a structured section at an unrecognized heading (extended content does not bleed in)', () => {
+    // Story #4270: producers (audit-to-stories) append non-canonical
+    // `## Agent Prompts` / `## Context` blocks after the canonical sections.
+    // Those headings — single- or multi-word — must terminate the prior
+    // section so their lines are not absorbed into verify[] / acceptance[].
+    const md = `## Goal
+g
+
+## Acceptance
+- [ ] observable outcome
+
+## Verify
+- npm run lint (validate)
+- npm test (unit)
+
+## Agent Prompts
+
+**Some finding**
+
+\`\`\`
+do the thing
+\`\`\`
+
+## Context
+
+linked report`;
+    const { body } = parse(md);
+    assert.deepEqual(body.verify, [
+      'npm run lint (validate)',
+      'npm test (unit)',
+    ]);
+    assert.deepEqual(body.acceptance, ['observable outcome']);
+  });
+
   it('parses a mix of object-form and legacy-string change entries', () => {
     const md = `## Goal
 g


### PR DESCRIPTION
Closes #4270

_Auto-opened by `/single-story-deliver`._