### PR TITLE
feat: move the binding-vs-advisory authoring altitude into the single-sourced decomposer prompt (#4272)

### DIFF
--- a/.agents/scripts/lib/orchestration/ticket-validator-sizing.js
+++ b/.agents/scripts/lib/orchestration/ticket-validator-sizing.js
@@ -128,6 +128,39 @@ export const DELIVERABLE_GRANULARITY_GUIDANCE = Object.freeze({
 });
 
 /**
+ * `AUTHORING_ALTITUDE_GUIDANCE` is the **single source of truth** for the
+ * binding-vs-advisory authoring altitude (Epic #4131 F8) and the New-File
+ * Contract (Story #4272). It is stated ONCE here and consumed by BOTH the
+ * decomposer prompt template
+ * (`.agents/scripts/lib/templates/decomposer-prompts.js`, which interpolates
+ * the strings verbatim into the rendered system prompt) AND the authoring
+ * SKILL (`.agents/skills/core/epic-plan-decompose-author/SKILL.md`, whose
+ * prose mirrors these sentences). The SKILL cannot import JS, so the
+ * `ticket-decomposer` prompt test asserts the canonical phrasing on both
+ * surfaces — a divergent restatement fails that gate. This reuses the #3777
+ * single-source mechanism (one constant, two surfaces, drift-gated by tests).
+ *
+ * The altitude: `acceptance[]` / `verify[]` are the **binding contract** (the
+ * sole definition of "done"); `changes[]` / `references[]` are an **advisory
+ * implementation sketch** the executor MAY revise. Author acceptance to assert
+ * the **outcome** independent of file layout — never pin an incidental helper
+ * name or private path into an acceptance item. The advisory sketch is still
+ * validated (base-branch probes, New-File Contract) and never licenses
+ * skipping `acceptance[]` / `verify[]` or any `rules/security-baseline.md` MUST.
+ */
+export const AUTHORING_ALTITUDE_GUIDANCE = Object.freeze({
+  // The binding-vs-advisory altitude statement.
+  altitude:
+    '**Binding contract vs advisory sketch.** `acceptance[]` and `verify[]` are the Story\'s **binding contract** — the executor MUST satisfy them exactly, and they are the only definition of "done." `changes[]` and `references[]` are an **advisory implementation sketch**: your best prediction of the file footprint, which the executor MAY revise when the real codebase diverges from the sketch. Author `acceptance[]` / `verify[]` to assert the **outcome** independent of any one file layout — never pin an incidental implementation detail (an internal helper name, a private file path) into an acceptance item that the advisory `changes[]` is free to reshape; assert the observable behaviour instead.',
+  // The advisory-does-not-mean-unvalidated caveat.
+  advisoryCaveat:
+    "**Advisory does not mean unvalidated.** `changes[]` paths still pass the base-branch file-assumption probes (a `creates` against an existing path still fails), the New-File Contract still holds, and the executor's latitude to revise the approach never licenses skipping `acceptance[]` / `verify[]` or relaxing any `rules/security-baseline.md` MUST.",
+  // The New-File Contract.
+  newFileContract:
+    '**New-File Contract.** Any path named in a Story\'s `goal`, `acceptance`, or `verify` that does NOT already exist on `main` MUST also appear in that Story\'s `changes[]` with `assumption: "creates"`; otherwise the freshness validator rejects the decompose — even when the Story is the one authoring the file.',
+});
+
+/**
  * Configuration-constant phrase patterns the `unanchored-constant` heuristic
  * scans Story acceptance criteria for. Each entry matches the *kind* of
  * tunable an implementing agent would otherwise have to context-hop to the

--- a/.agents/scripts/lib/templates/decomposer-prompts.js
+++ b/.agents/scripts/lib/templates/decomposer-prompts.js
@@ -1,5 +1,6 @@
 import { LIMITS_DEFAULTS } from '../config/limits.js';
 import {
+  AUTHORING_ALTITUDE_GUIDANCE,
   DEFAULT_TASK_SIZING,
   DELIVERABLE_GRANULARITY_GUIDANCE,
 } from '../orchestration/ticket-validator-sizing.js';
@@ -56,6 +57,15 @@ function render2TierPrompt({ maxTickets, maxTokenBudget }) {
   // cannot drift (Story #3777).
   const { definition: granularityDefinition, singleConsumerRule } =
     DELIVERABLE_GRANULARITY_GUIDANCE;
+  // The binding-vs-advisory authoring altitude + the New-File Contract are
+  // sourced from the single AUTHORING_ALTITUDE_GUIDANCE constant
+  // (ticket-validator-sizing.js) so the prompt and the authoring SKILL cannot
+  // drift (Story #4272).
+  const {
+    altitude: authoringAltitude,
+    advisoryCaveat,
+    newFileContract,
+  } = AUTHORING_ALTITUDE_GUIDANCE;
   return `You are an expert Senior Project Manager and Orchestrator.
 Your job is to take a Product Requirements Document (PRD) and a Technical Specification and decompose them into a flat list of Story tickets for an AI Agent to execute.
 
@@ -122,6 +132,14 @@ The serialized \`body\` string renders these markdown sections (in order):
 - **verify** (top-level array on the ticket object): Each entry MUST name a testing tier in parentheses, drawn from \`unit\` / \`contract\` / \`e2e\` / \`validate\`. Example: \`npm run test -- src/x.test.ts (unit)\`, \`npm run validate (validate)\`. Stories with zero verify entries SHOULD fail validation; if a story is genuinely unverifiable in isolation (e.g., a copy edit auditor will eyeball), the literal entry \`manual:<reason>\` is allowed so the absence is intentional, not lazy. Manual entries without a reason are rejected.
 - **reason to exist** (REQUIRED, encoded as the \`reason_to_exist\` field of the \`<!-- meta: {...} -->\` comment appended to the serialized body string — NOT a top-level ticket field): One sentence stating the single coherent reason this Story exists, distinct from its broader \`## Goal\` prose. Every Story MUST carry a non-empty \`reason_to_exist\`; it is the machine-checkable form of the cohesion rule (**one Story = one coherent change with one reason to exist**) and the \`epic-plan-consolidate\` critic flags any Story whose body carries no non-empty reason to exist. Encode it as \`<!-- meta: {"reason_to_exist": "..."} -->\`.
 - **estimated_test_files** (optional, encoded in the \`<!-- meta: {...} -->\` comment appended to the serialized body string — NOT a top-level ticket field): Integer estimate of how many test files this Story creates or modifies. Omit when the number is not estimable. Informational only — it does not gate the decompose.
+
+#### AUTHORING ALTITUDE — BINDING ACCEPTANCE vs ADVISORY CHANGES:
+
+${authoringAltitude}
+
+${newFileContract}
+
+${advisoryCaveat}
 
 #### STORY SIZING — COHESION FIRST (the numeric ceiling is only a backstop):
 

--- a/.agents/skills/core/epic-plan-decompose-author/SKILL.md
+++ b/.agents/skills/core/epic-plan-decompose-author/SKILL.md
@@ -266,10 +266,11 @@ Declaring `wide` with a non-empty reason **lifts the `hardFiles` rejection** —
 
 #### BINDING ACCEPTANCE vs ADVISORY CHANGES (authoring altitude)
 
-`acceptance[]` and `verify[]` are the **binding contract** the executor MUST satisfy — they are the sole definition of "done." `changes[]` and `references[]` are an **advisory implementation sketch**: your best prediction of the file footprint, which the executor is permitted to revise when the real codebase diverges from the sketch. Author at that altitude:
+The canonical altitude + New-File Contract wording is single-sourced in `AUTHORING_ALTITUDE_GUIDANCE` in `ticket-validator-sizing.js` (Story #4272); the rendered decomposer prompt interpolates the same strings, so do not restate a divergent version here. The three canonical statements:
 
-- Write `acceptance[]`/`verify[]` to capture the **outcome**, independent of any one file layout. Do NOT pin an incidental implementation detail (an internal helper name, a private file path) into an acceptance item that the advisory `changes[]` is free to reshape — assert the observable behaviour instead.
-- Keep `changes[]`/`references[]` as the honest predicted footprint. They still pass through the structural file-assumption gate (the `creates`/`refactors-existing`/`deletes` probes against the base branch) and the New-File Contract unchanged — advisory does NOT mean unvalidated. The executor's latitude to revise the approach never licenses skipping `acceptance[]`/`verify[]` or any `rules/security-baseline.md` MUST.
+- **Binding contract vs advisory sketch.** `acceptance[]` and `verify[]` are the Story's **binding contract** — the executor MUST satisfy them exactly, and they are the only definition of "done." `changes[]` and `references[]` are an **advisory implementation sketch**: your best prediction of the file footprint, which the executor MAY revise when the real codebase diverges from the sketch. Author `acceptance[]` / `verify[]` to assert the **outcome** independent of any one file layout — never pin an incidental implementation detail (an internal helper name, a private file path) into an acceptance item that the advisory `changes[]` is free to reshape; assert the observable behaviour instead.
+- **New-File Contract.** Any path named in a Story's `goal`, `acceptance`, or `verify` that does NOT already exist on `main` MUST also appear in that Story's `changes[]` with `assumption: "creates"`; otherwise the freshness validator rejects the decompose — even when the Story is the one authoring the file.
+- **Advisory does not mean unvalidated.** `changes[]` paths still pass the base-branch file-assumption probes (a `creates` against an existing path still fails), the New-File Contract still holds, and the executor's latitude to revise the approach never licenses skipping `acceptance[]` / `verify[]` or relaxing any `rules/security-baseline.md` MUST.
 
 #### NAVIGATE-DON'T-DEEP-LINK (signed-in acceptance scenarios)
 

--- a/tests/ticket-decomposer.test.js
+++ b/tests/ticket-decomposer.test.js
@@ -22,7 +22,10 @@ import {
   resolveDependencies,
   runDecomposePhase,
 } from '../.agents/scripts/epic-plan-decompose.js';
-import { DELIVERABLE_GRANULARITY_GUIDANCE } from '../.agents/scripts/lib/orchestration/ticket-validator-sizing.js';
+import {
+  AUTHORING_ALTITUDE_GUIDANCE,
+  DELIVERABLE_GRANULARITY_GUIDANCE,
+} from '../.agents/scripts/lib/orchestration/ticket-validator-sizing.js';
 import { renderDecomposerSystemPrompt } from '../.agents/scripts/lib/templates/decomposer-prompts.js';
 
 // 2-tier (Story #4041): a flat Story backlog attached directly to the Epic,
@@ -556,6 +559,79 @@ describe('ticket-decomposer prompt single-sourcing (Story #4162)', () => {
       ),
       'prompt must frame maxTokenBudget as the one-pass delivery envelope',
     );
+  });
+
+  it('renders the binding-vs-advisory authoring altitude in the prompt (Story #4272)', () => {
+    const prompt = renderDecomposerSystemPrompt();
+    // binding acceptance / verify vs advisory changes / references
+    assert.ok(
+      /binding contract/i.test(prompt),
+      'prompt must name acceptance/verify as the binding contract',
+    );
+    assert.ok(
+      /advisory implementation sketch/i.test(prompt),
+      'prompt must frame changes/references as an advisory sketch the executor may revise',
+    );
+    // assert the OUTCOME, never pin an incidental helper/path
+    assert.ok(
+      /assert the \*\*outcome\*\*|capture the \*\*outcome\*\*/i.test(prompt) ||
+        /the \*\*outcome\*\* independent/i.test(prompt),
+      'prompt must instruct authoring acceptance to assert the outcome independent of file layout',
+    );
+    assert.ok(
+      /never pin an incidental implementation detail/i.test(prompt),
+      'prompt must forbid pinning an incidental helper name / private path into acceptance',
+    );
+  });
+
+  it('renders the New-File Contract in the prompt (Story #4272)', () => {
+    const prompt = renderDecomposerSystemPrompt();
+    assert.ok(
+      /New-File Contract/i.test(prompt),
+      'prompt must state the New-File Contract',
+    );
+    assert.ok(
+      /does NOT already exist on .?main.? MUST also appear in .* `changes\[\]` with `assumption: "creates"`/i.test(
+        prompt,
+      ),
+      'prompt must require a not-on-main referenced path to appear in changes[] with assumption creates',
+    );
+  });
+
+  it('retains the "advisory does not mean unvalidated" caveat in the prompt (Story #4272)', () => {
+    const prompt = renderDecomposerSystemPrompt();
+    assert.ok(
+      /Advisory does not mean unvalidated/i.test(prompt),
+      'prompt must keep the advisory-still-validated caveat',
+    );
+    assert.ok(
+      /base-branch file-assumption probes/i.test(prompt) &&
+        /security-baseline\.md/i.test(prompt),
+      'caveat must name the base-branch probes and the inviolable security baseline',
+    );
+  });
+
+  it('single-sources the altitude + New-File wording so the prompt and the SKILL cannot drift (Story #4272)', () => {
+    const prompt = renderDecomposerSystemPrompt();
+    const skill = readFileSync(SKILL_PATH, 'utf8');
+    // The prompt interpolates AUTHORING_ALTITUDE_GUIDANCE verbatim; the SKILL
+    // mirrors the same canonical sentences. Asserting each constant string is
+    // present on BOTH surfaces is the drift gate — a divergent restatement on
+    // either surface fails here.
+    for (const canonical of [
+      AUTHORING_ALTITUDE_GUIDANCE.altitude,
+      AUTHORING_ALTITUDE_GUIDANCE.newFileContract,
+      AUTHORING_ALTITUDE_GUIDANCE.advisoryCaveat,
+    ]) {
+      assert.ok(
+        prompt.includes(canonical),
+        'rendered prompt must interpolate the shared AUTHORING_ALTITUDE_GUIDANCE wording verbatim',
+      );
+      assert.ok(
+        skill.includes(canonical),
+        'SKILL.md must mirror the shared AUTHORING_ALTITUDE_GUIDANCE wording verbatim',
+      );
+    }
   });
 });
 


### PR DESCRIPTION
Closes #4272

_Auto-opened by `/single-story-deliver`._