### PR TITLE
fix(auto-merge): make native auto-merge arming robust when the base branch is checked out by a git worktree (#4282)

### DIFF
--- a/.agents/scripts/lib/orchestration/auto-merge-cwd.js
+++ b/.agents/scripts/lib/orchestration/auto-merge-cwd.js
@@ -1,0 +1,128 @@
+/**
+ * auto-merge-cwd.js — resolve a worktree-collision-safe cwd for arming
+ * GitHub native auto-merge (Story #4282).
+ *
+ * Root cause this module exists to defeat:
+ *   Arming auto-merge runs, in effect,
+ *   `gh pr merge <pr> --auto --squash --delete-branch`. The
+ *   `--delete-branch` flag makes `gh` shell out to local `git` to leave
+ *   and delete the PR head branch — including a `git checkout <base>` to
+ *   switch the working tree off the head branch. When the arm runs from a
+ *   per-Story worktree cwd (checked out on the head branch `story-<id>`)
+ *   while the base branch (`main`) is already occupied by the primary
+ *   worktree, `gh`'s internal `git checkout <base>` collides:
+ *
+ *     fatal: '<base>' is already used by worktree at '<primary>'
+ *
+ *   The arm fails (non-fatally), defeating the unattended auto-merge
+ *   contract — the operator must re-run the merge manually from a clean cwd.
+ *
+ * Fix (advisory direction #1 from the Story — "ensure the cwd is already
+ * on the base branch so gh's `git checkout <base>` is a no-op"):
+ *   Re-point the arm at the **primary worktree root** — the working tree
+ *   that holds the base branch — discovered via `git worktree list
+ *   --porcelain`. From the primary worktree, `gh`'s `--delete-branch`
+ *   cleanup never has to `git checkout <base>` (it is already there), so
+ *   the collision cannot occur. `--delete-branch` is preserved verbatim,
+ *   so the PR head branch is still removed on merge with no dependency on
+ *   the consumer's repo-level "auto-delete head branches" toggle.
+ *
+ * Non-fatal by construction: any failure to resolve the primary worktree
+ * (not a git repo, `git` missing, single-worktree layout, parse failure)
+ * degrades to returning the original `cwd` unchanged. Worst case is the
+ * pre-fix behaviour; this helper never throws and never blocks arming.
+ */
+
+import { gitSpawn as defaultGitSpawn } from '../git-utils.js';
+
+/**
+ * Parse `git worktree list --porcelain` output into structured records.
+ *
+ * The porcelain format emits one stanza per worktree, blank-line
+ * separated, e.g.:
+ *
+ *   worktree /abs/path/to/primary
+ *   HEAD <sha>
+ *   branch refs/heads/main
+ *
+ *   worktree /abs/path/to/.worktrees/story-4282
+ *   HEAD <sha>
+ *   branch refs/heads/story-4282
+ *
+ * A linked worktree with a detached HEAD emits `detached` instead of a
+ * `branch` line. Pure — exported for tests.
+ *
+ * @param {string} stdout
+ * @returns {Array<{ path: string, branch: string|null }>}
+ */
+export function parseWorktreeList(stdout) {
+  const text = String(stdout ?? '');
+  const records = [];
+  let current = null;
+  for (const rawLine of text.split('\n')) {
+    const line = rawLine.replace(/\r$/, '');
+    if (line.startsWith('worktree ')) {
+      if (current) records.push(current);
+      current = { path: line.slice('worktree '.length).trim(), branch: null };
+    } else if (line.startsWith('branch ') && current) {
+      current.branch = line
+        .slice('branch '.length)
+        .trim()
+        .replace(/^refs\/heads\//, '');
+    }
+    // `HEAD <sha>`, `detached`, `bare`, `locked`, `prunable` lines carry
+    // no field we need; ignored.
+  }
+  if (current) records.push(current);
+  return records;
+}
+
+/**
+ * Pick the primary worktree from a parsed worktree list. The primary
+ * worktree is the first stanza `git worktree list` emits — it is the
+ * original (non-linked) working tree and, during delivery, the one that
+ * holds the base branch. Returns its absolute path, or `null` when the
+ * list is empty / unparseable.
+ *
+ * Pure — exported for tests.
+ *
+ * @param {Array<{ path: string, branch: string|null }>} records
+ * @returns {string|null}
+ */
+export function pickPrimaryWorktreePath(records) {
+  if (!Array.isArray(records) || records.length === 0) return null;
+  const first = records[0];
+  return first && typeof first.path === 'string' && first.path.length > 0
+    ? first.path
+    : null;
+}
+
+/**
+ * Resolve a worktree-collision-safe cwd for arming auto-merge.
+ *
+ * Returns the primary worktree root (which holds the base branch) when it
+ * can be discovered AND it differs from `cwd`; otherwise returns `cwd`
+ * unchanged. Never throws.
+ *
+ * @param {string} cwd — the cwd the caller would otherwise arm from
+ *   (often a per-Story worktree on the head branch).
+ * @param {{ gitSpawn?: typeof import('../git-utils.js').gitSpawn }} [deps]
+ * @returns {string} a cwd safe to run `gh pr merge --delete-branch` from.
+ */
+export function resolveAutoMergeArmCwd(
+  cwd,
+  { gitSpawn = defaultGitSpawn } = {},
+) {
+  if (typeof cwd !== 'string' || cwd.length === 0) return cwd;
+  try {
+    const result = gitSpawn(cwd, 'worktree', 'list', '--porcelain');
+    if (!result || result.status !== 0) return cwd;
+    const primary = pickPrimaryWorktreePath(parseWorktreeList(result.stdout));
+    if (!primary) return cwd;
+    return primary;
+  } catch {
+    // Any unexpected failure (git missing, non-repo cwd, etc.) degrades
+    // to the original cwd — arming stays best-effort.
+    return cwd;
+  }
+}

--- a/.agents/scripts/lib/orchestration/lifecycle/listeners/automerge-armer.js
+++ b/.agents/scripts/lib/orchestration/lifecycle/listeners/automerge-armer.js
@@ -54,6 +54,8 @@
 
 import { spawnSync } from 'node:child_process';
 
+import { resolveAutoMergeArmCwd } from '../../auto-merge-cwd.js';
+
 /**
  * Default `gh pr view --json autoMergeRequest` probe. Pure-spawn helper
  * — exported so tests can stub the shell-out without touching the
@@ -77,12 +79,28 @@ export function ghPrViewAutoMerge({ prUrl, cwd, spawnFn = spawnSync }) {
  * helper. Exported so tests can stub. The arg list is captured in a
  * single helper so the merge-lockout lint allow-list narrows to one
  * literal site.
+ *
+ * Story #4282: `--delete-branch` makes `gh` shell out to local `git`
+ * (including a `git checkout <base>`). When this arm runs from a per-Story
+ * worktree cwd checked out on the head branch while the base branch is
+ * occupied by the primary worktree, that checkout collides
+ * (`fatal: '<base>' is already used by worktree`). We re-point the spawn
+ * cwd at the primary worktree root (which holds the base branch) via
+ * `resolveAutoMergeArmCwd`, so the local checkout is a no-op while
+ * `--delete-branch` (head-branch-removed-on-merge) is preserved. The
+ * resolver is non-fatal — it degrades to the original cwd.
  */
-export function ghPrMergeAuto({ prUrl, cwd, spawnFn = spawnSync }) {
+export function ghPrMergeAuto({
+  prUrl,
+  cwd,
+  spawnFn = spawnSync,
+  resolveArmCwd = resolveAutoMergeArmCwd,
+}) {
+  const armCwd = resolveArmCwd(cwd);
   const result = spawnFn(
     'gh',
     ['pr', 'merge', prUrl, '--auto', '--squash', '--delete-branch'],
-    { cwd, encoding: 'utf-8', shell: false },
+    { cwd: armCwd, encoding: 'utf-8', shell: false },
   );
   return {
     status: result.status ?? 1,

--- a/.agents/scripts/lib/orchestration/single-story-close/phases/auto-merge.js
+++ b/.agents/scripts/lib/orchestration/single-story-close/phases/auto-merge.js
@@ -12,9 +12,21 @@
  * inject a synchronous fake; the default runner delegates to
  * `gh.pr.merge`, which spawns through the classified, typed-error
  * surface instead of a raw `execFileSync('gh', …)` call.
+ *
+ * Story #4282 made arming robust when the base branch is checked out by a
+ * git worktree. The `--delete-branch` flag makes `gh` shell out to local
+ * `git` (including a `git checkout <base>`); from a per-Story worktree cwd
+ * that collides with the base branch already checked out by the primary
+ * worktree (`fatal: '<base>' is already used by worktree`). We now resolve
+ * the arm cwd to the **primary worktree root** (which holds the base
+ * branch) via `resolveAutoMergeArmCwd`, so `gh`'s local checkout is a
+ * no-op. `--delete-branch` is preserved verbatim, so the PR head branch is
+ * still deleted on merge without depending on the repo's auto-delete
+ * setting. Resolution is non-fatal — it degrades to the original cwd.
  */
 
 import { gh as defaultGh } from '../../../gh-exec.js';
+import { resolveAutoMergeArmCwd } from '../../auto-merge-cwd.js';
 
 /**
  * Enable GitHub native auto-merge on the PR. Non-fatal.
@@ -24,11 +36,22 @@ import { gh as defaultGh } from '../../../gh-exec.js';
  *   prNumber: number,
  *   gh?: ReturnType<typeof import('../../../gh-exec.js').createGh>,
  *   runner?: (args: string[], opts: object) => ({ status: number, stdout?: string, stderr?: string } | Promise<{ status: number, stdout?: string, stderr?: string }>),
+ *   resolveArmCwd?: (cwd: string) => string,
  * }} opts
  * @returns {Promise<{ enabled: boolean, reason?: string }>}
  */
-export async function enableAutoMergeWith({ cwd, prNumber, gh, runner }) {
+export async function enableAutoMergeWith({
+  cwd,
+  prNumber,
+  gh,
+  runner,
+  resolveArmCwd = resolveAutoMergeArmCwd,
+}) {
   const exec = runner ?? makeDefaultGhAutoMergeRunner(gh ?? defaultGh);
+  // Re-point the arm at the base-branch (primary) worktree so gh's
+  // `--delete-branch` local `git checkout <base>` cannot collide with the
+  // base branch already checked out by the primary worktree (Story #4282).
+  const armCwd = resolveArmCwd(cwd);
   try {
     const result = await exec(
       [
@@ -39,7 +62,7 @@ export async function enableAutoMergeWith({ cwd, prNumber, gh, runner }) {
         '--squash',
         '--delete-branch',
       ],
-      { cwd },
+      { cwd: armCwd },
     );
     if (result.status === 0) return { enabled: true };
     return {

--- a/tests/lib/orchestration/auto-merge-cwd.test.js
+++ b/tests/lib/orchestration/auto-merge-cwd.test.js
@@ -1,0 +1,127 @@
+/**
+ * tests/lib/orchestration/auto-merge-cwd.test.js — unit tests for the
+ * worktree-collision-safe arm-cwd resolver (Story #4282).
+ *
+ * The resolver re-points auto-merge arming at the primary worktree root
+ * (which holds the base branch) so `gh pr merge --delete-branch`'s local
+ * `git checkout <base>` cannot collide with the base branch already
+ * checked out by the primary worktree.
+ */
+
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import {
+  parseWorktreeList,
+  pickPrimaryWorktreePath,
+  resolveAutoMergeArmCwd,
+} from '../../../.agents/scripts/lib/orchestration/auto-merge-cwd.js';
+
+const PORCELAIN = [
+  'worktree /repo/primary',
+  'HEAD 1111111111111111111111111111111111111111',
+  'branch refs/heads/main',
+  '',
+  'worktree /repo/.worktrees/story-4282',
+  'HEAD 2222222222222222222222222222222222222222',
+  'branch refs/heads/story-4282',
+  '',
+].join('\n');
+
+describe('parseWorktreeList', () => {
+  it('parses porcelain stanzas into path + branch records', () => {
+    const records = parseWorktreeList(PORCELAIN);
+    assert.deepEqual(records, [
+      { path: '/repo/primary', branch: 'main' },
+      { path: '/repo/.worktrees/story-4282', branch: 'story-4282' },
+    ]);
+  });
+
+  it('handles a detached-HEAD worktree (no branch line)', () => {
+    const records = parseWorktreeList(
+      ['worktree /repo/primary', 'HEAD abc', 'detached', ''].join('\n'),
+    );
+    assert.deepEqual(records, [{ path: '/repo/primary', branch: null }]);
+  });
+
+  it('tolerates CRLF line endings', () => {
+    const records = parseWorktreeList(
+      'worktree /repo/primary\r\nbranch refs/heads/main\r\n',
+    );
+    assert.deepEqual(records, [{ path: '/repo/primary', branch: 'main' }]);
+  });
+
+  it('returns [] for empty input', () => {
+    assert.deepEqual(parseWorktreeList(''), []);
+    assert.deepEqual(parseWorktreeList(null), []);
+  });
+});
+
+describe('pickPrimaryWorktreePath', () => {
+  it('returns the first stanza path (the primary working tree)', () => {
+    assert.equal(
+      pickPrimaryWorktreePath(parseWorktreeList(PORCELAIN)),
+      '/repo/primary',
+    );
+  });
+
+  it('returns null for an empty / malformed list', () => {
+    assert.equal(pickPrimaryWorktreePath([]), null);
+    assert.equal(pickPrimaryWorktreePath(null), null);
+    assert.equal(pickPrimaryWorktreePath([{ path: '' }]), null);
+  });
+});
+
+describe('resolveAutoMergeArmCwd', () => {
+  it('re-points a per-Story worktree cwd at the primary worktree root', () => {
+    const gitSpawn = (cwd, ...args) => {
+      assert.equal(cwd, '/repo/.worktrees/story-4282');
+      assert.deepEqual(args, ['worktree', 'list', '--porcelain']);
+      return { status: 0, stdout: PORCELAIN, stderr: '' };
+    };
+    const resolved = resolveAutoMergeArmCwd('/repo/.worktrees/story-4282', {
+      gitSpawn,
+    });
+    assert.equal(
+      resolved,
+      '/repo/primary',
+      'arm must run from the base-branch worktree, not the head-branch worktree',
+    );
+  });
+
+  it('degrades to the original cwd when git worktree list fails', () => {
+    const gitSpawn = () => ({ status: 1, stdout: '', stderr: 'not a repo' });
+    assert.equal(
+      resolveAutoMergeArmCwd('/some/cwd', { gitSpawn }),
+      '/some/cwd',
+    );
+  });
+
+  it('degrades to the original cwd when gitSpawn throws', () => {
+    const gitSpawn = () => {
+      throw new Error('git missing');
+    };
+    assert.equal(
+      resolveAutoMergeArmCwd('/some/cwd', { gitSpawn }),
+      '/some/cwd',
+    );
+  });
+
+  it('degrades to the original cwd when the list is empty', () => {
+    const gitSpawn = () => ({ status: 0, stdout: '', stderr: '' });
+    assert.equal(
+      resolveAutoMergeArmCwd('/some/cwd', { gitSpawn }),
+      '/some/cwd',
+    );
+  });
+
+  it('returns a non-string cwd unchanged without spawning git', () => {
+    let called = false;
+    const gitSpawn = () => {
+      called = true;
+      return { status: 0, stdout: PORCELAIN, stderr: '' };
+    };
+    assert.equal(resolveAutoMergeArmCwd(undefined, { gitSpawn }), undefined);
+    assert.equal(called, false);
+  });
+});

--- a/tests/lib/orchestration/lifecycle/listener-armer.test.js
+++ b/tests/lib/orchestration/lifecycle/listener-armer.test.js
@@ -14,10 +14,11 @@
 
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
-
+import { resolveAutoMergeArmCwd } from '../../../../.agents/scripts/lib/orchestration/auto-merge-cwd.js';
 import { Bus } from '../../../../.agents/scripts/lib/orchestration/lifecycle/bus.js';
 import {
   AutomergeArmer,
+  ghPrMergeAuto,
   parseAutoMergeArmed,
 } from '../../../../.agents/scripts/lib/orchestration/lifecycle/listeners/automerge-armer.js';
 
@@ -227,5 +228,88 @@ describe('AutomergeArmer (bus integration)', () => {
     assert.equal(mergeCalls.length, 1);
     assert.equal(emits.length, 1);
     assert.equal(emits[0].event, 'epic.merge.armed');
+  });
+});
+
+describe('ghPrMergeAuto — worktree-occupied-base-branch robustness (Story #4282)', () => {
+  const PORCELAIN = [
+    'worktree /repo/primary',
+    'branch refs/heads/main',
+    '',
+    'worktree /repo/.worktrees/story-4282',
+    'branch refs/heads/story-4282',
+    '',
+  ].join('\n');
+
+  // Models `gh pr merge --delete-branch`: collides with the primary
+  // worktree's base-branch checkout when run from the head-branch
+  // worktree, succeeds when run from the base-branch (primary) worktree.
+  function worktreeAwareSpawn(capture) {
+    return (_bin, _args, opts) => {
+      capture.cwd = opts.cwd;
+      if (opts.cwd === '/repo/.worktrees/story-4282') {
+        return {
+          status: 1,
+          stdout: '',
+          stderr:
+            "failed to run git: fatal: 'main' is already used by worktree at '/repo/primary'",
+        };
+      }
+      return { status: 0, stdout: '', stderr: '' };
+    };
+  }
+
+  it('re-points the spawn cwd at the primary worktree so the arm succeeds', () => {
+    const capture = {};
+    const resolveArmCwd = (cwd) =>
+      resolveAutoMergeArmCwd(cwd, {
+        gitSpawn: () => ({ status: 0, stdout: PORCELAIN, stderr: '' }),
+      });
+    const result = ghPrMergeAuto({
+      prUrl: 'https://github.com/o/r/pull/88',
+      cwd: '/repo/.worktrees/story-4282',
+      spawnFn: worktreeAwareSpawn(capture),
+      resolveArmCwd,
+    });
+    assert.equal(result.status, 0, 'arm queued without a worktree collision');
+    assert.equal(
+      capture.cwd,
+      '/repo/primary',
+      'arm must spawn gh from the base-branch worktree, not the head-branch worktree',
+    );
+    assert.doesNotMatch(result.stderr, /already used by worktree/);
+  });
+
+  it('regression baseline: arming from the head-branch worktree still hits the gh worktree error', () => {
+    const capture = {};
+    const result = ghPrMergeAuto({
+      prUrl: 'https://github.com/o/r/pull/88',
+      cwd: '/repo/.worktrees/story-4282',
+      spawnFn: worktreeAwareSpawn(capture),
+      resolveArmCwd: (cwd) => cwd, // pin to the buggy head-branch worktree
+    });
+    assert.equal(result.status, 1);
+    assert.match(result.stderr, /already used by worktree/);
+  });
+
+  it('preserves the --auto --squash --delete-branch argv shape', () => {
+    let capturedArgs = null;
+    ghPrMergeAuto({
+      prUrl: 'https://github.com/o/r/pull/88',
+      cwd: '/repo/primary',
+      spawnFn: (_bin, args) => {
+        capturedArgs = args;
+        return { status: 0, stdout: '', stderr: '' };
+      },
+      resolveArmCwd: (cwd) => cwd,
+    });
+    assert.deepEqual(capturedArgs, [
+      'pr',
+      'merge',
+      'https://github.com/o/r/pull/88',
+      '--auto',
+      '--squash',
+      '--delete-branch',
+    ]);
   });
 });

--- a/tests/single-story-close-auto-merge.test.js
+++ b/tests/single-story-close-auto-merge.test.js
@@ -8,11 +8,14 @@
  *     `{ enabled: false, reason }` on non-zero / spawn errors.
  *   - Spawn args wire `--auto --squash --delete-branch` so GitHub merges
  *     the PR when required checks pass and deletes the source branch.
+ *   - Story #4282: the arm runs from the primary (base-branch) worktree
+ *     root so `gh`'s `--delete-branch` local checkout cannot collide with
+ *     the base branch occupied by the primary worktree.
  */
 
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
-
+import { enableAutoMergeWith } from '../.agents/scripts/lib/orchestration/single-story-close/phases/auto-merge.js';
 import {
   enableAutoMerge,
   parsePrNumber,
@@ -120,5 +123,95 @@ describe('enableAutoMerge', () => {
       runner,
     });
     assert.ok(result.reason.length < 250);
+  });
+});
+
+describe('enableAutoMergeWith — worktree-occupied-base-branch robustness (Story #4282)', () => {
+  // The primary worktree holds the base branch (`main`); the close runs
+  // from the per-Story worktree (`story-4282`). `git checkout main` from
+  // that worktree collides with the primary worktree's checkout.
+  const PORCELAIN = [
+    'worktree /repo/primary',
+    'branch refs/heads/main',
+    '',
+    'worktree /repo/.worktrees/story-4282',
+    'branch refs/heads/story-4282',
+    '',
+  ].join('\n');
+
+  // Models `gh pr merge --delete-branch`: succeeds when run from the
+  // base-branch (primary) worktree; reproduces the consumer's
+  // `gh-exit-1: fatal: 'main' is already used by worktree` failure when
+  // run from the head-branch worktree (because gh's local `git checkout
+  // main` collides there).
+  function worktreeAwareRunner(capture) {
+    return (_args, opts) => {
+      capture.cwd = opts.cwd;
+      if (opts.cwd === '/repo/.worktrees/story-4282') {
+        return {
+          status: 1,
+          stdout: '',
+          stderr:
+            "failed to run git: fatal: 'main' is already used by worktree at '/repo/primary'",
+        };
+      }
+      return { status: 0, stdout: '', stderr: '' };
+    };
+  }
+
+  it('with the resolver re-pointing to the primary worktree, the arm succeeds and queues without the worktree error', async () => {
+    const capture = {};
+    const result = await enableAutoMergeWith({
+      cwd: '/repo/.worktrees/story-4282',
+      prNumber: 88,
+      runner: worktreeAwareRunner(capture),
+      resolveArmCwd: () => '/repo/primary',
+    });
+    assert.deepEqual(result, { enabled: true });
+    assert.equal(
+      capture.cwd,
+      '/repo/primary',
+      'arm must run from the base-branch worktree, not the head-branch worktree',
+    );
+  });
+
+  it('end-to-end with the real resolver (gitSpawn injected) avoids the worktree collision', async () => {
+    const capture = {};
+    // Real resolveAutoMergeArmCwd is the default; feed it a fake gitSpawn
+    // by importing the module-level helper through resolveArmCwd binding.
+    const { resolveAutoMergeArmCwd } = await import(
+      '../.agents/scripts/lib/orchestration/auto-merge-cwd.js'
+    );
+    const resolveArmCwd = (cwd) =>
+      resolveAutoMergeArmCwd(cwd, {
+        gitSpawn: () => ({ status: 0, stdout: PORCELAIN, stderr: '' }),
+      });
+    const result = await enableAutoMergeWith({
+      cwd: '/repo/.worktrees/story-4282',
+      prNumber: 88,
+      runner: worktreeAwareRunner(capture),
+      resolveArmCwd,
+    });
+    assert.deepEqual(result, { enabled: true });
+    assert.equal(capture.cwd, '/repo/primary');
+    assert.doesNotMatch(
+      String(result.reason ?? ''),
+      /already used by worktree/,
+      'the worktree-occupied-base-branch failure must not surface',
+    );
+  });
+
+  it('regression baseline: arming from the head-branch worktree still emits the gh-exit-1 worktree error', async () => {
+    const capture = {};
+    const result = await enableAutoMergeWith({
+      cwd: '/repo/.worktrees/story-4282',
+      prNumber: 88,
+      runner: worktreeAwareRunner(capture),
+      // Pin the cwd to the (buggy) head-branch worktree to prove the test
+      // double actually reproduces the failure the fix prevents.
+      resolveArmCwd: (cwd) => cwd,
+    });
+    assert.equal(result.enabled, false);
+    assert.match(result.reason, /already used by worktree/);
   });
 });


### PR DESCRIPTION
Closes #4282

_Auto-opened by `/single-story-deliver`._