### PR TITLE
fix(close-validation): format gate false-negative when all formatter-eligible-by-extension changed files are biome-config-ignored (#4292)

### DIFF
--- a/.agents/scripts/lib/close-validation/process.js
+++ b/.agents/scripts/lib/close-validation/process.js
@@ -54,6 +54,34 @@ export function gateExitCode(code, sig) {
 }
 
 /**
+ * Biome's marker for "you handed me a path set, but every one of them is
+ * excluded by my own config (`files.includes` allowlist / `files.ignore` /
+ * `overrides`), so I processed nothing" — biome exits 1 in that case.
+ *
+ * The format gate scopes biome to the changed-file subset (Story #3410). When
+ * that subset is non-empty by extension but every path is biome-config-ignored,
+ * the scoped invocation reports this message and exits 1 even though
+ * `biome format .` over the whole tree is clean — a false negative for the
+ * gate (Story #4292). Detecting the marker lets the runner treat that exit as
+ * a clean skip rather than a formatting failure.
+ */
+const BIOME_NO_FILES_PROCESSED =
+  'No files were processed in the specified paths';
+
+/**
+ * Whether biome's combined gate output carries the "No files were processed"
+ * marker. Pure function — no I/O. Exported for unit coverage (Story #4292).
+ *
+ * @param {string} output - Combined stdout/stderr captured from the gate child.
+ * @returns {boolean}
+ */
+export function isBiomeNoFilesProcessed(output) {
+  return (
+    typeof output === 'string' && output.includes(BIOME_NO_FILES_PROCESSED)
+  );
+}
+
+/**
  * Default async gate runner — used by `runCloseValidation` when no `runner`
  * is injected. Spawns the gate via `child_process.spawn`, prefixes every
  * stdout/stderr line with `[gate-name] ` (so concurrent gates don't bleed
@@ -66,13 +94,19 @@ export function gateExitCode(code, sig) {
  * `runCloseValidation` sees a non-zero status and folds it into the
  * already-recorded first-failure.
  *
+ * When `opts.tolerateNoFilesProcessed` is set (the biome-scoped format gate —
+ * Story #4292), a non-zero exit whose combined output carries biome's
+ * "No files were processed" marker is downgraded to a clean `status: 0`,
+ * because that exit means every config-included path was already excluded,
+ * not that formatting drifted.
+ *
  * @param {string} cmd
  * @param {string[]} args
- * @param {{ cwd: string, signal?: AbortSignal, gateName?: string, log?: (m: string) => void, env?: Record<string, string> }} opts
+ * @param {{ cwd: string, signal?: AbortSignal, gateName?: string, log?: (m: string) => void, env?: Record<string, string>, tolerateNoFilesProcessed?: boolean }} opts
  * @returns {Promise<{ status: number }>}
  */
 export function defaultGateRunner(cmd, args, opts = {}) {
-  const { cwd, signal, gateName, log, env } = opts;
+  const { cwd, signal, gateName, log, env, tolerateNoFilesProcessed } = opts;
   const child = spawn(cmd, args, {
     cwd,
     shell: process.platform === 'win32',
@@ -85,13 +119,35 @@ export function defaultGateRunner(cmd, args, opts = {}) {
   const prefix = gateName ? `[${gateName}] ` : '';
   const emit =
     typeof log === 'function' ? log : (m) => process.stdout.write(`${m}\n`);
-  pipePrefixed(child.stdout, prefix, emit);
-  pipePrefixed(child.stderr, prefix, emit);
+  // Capture the combined output only when we may need to inspect it for the
+  // biome "No files were processed" marker — otherwise the stream is purely
+  // piped through to the operator (no retained buffer).
+  let captured = '';
+  const tap = tolerateNoFilesProcessed
+    ? (line) => {
+        captured += `${line}\n`;
+        emit(line);
+      }
+    : emit;
+  pipePrefixed(child.stdout, prefix, tap);
+  pipePrefixed(child.stderr, prefix, tap);
   const detach = attachGateAbortHandler(child, signal);
   return new Promise((resolve) => {
     child.on('exit', (code, sig) => {
       detach();
-      resolve({ status: gateExitCode(code, sig) });
+      const status = gateExitCode(code, sig);
+      if (
+        status !== 0 &&
+        tolerateNoFilesProcessed &&
+        isBiomeNoFilesProcessed(captured)
+      ) {
+        emit(
+          `${prefix}↳ biome processed zero files (all changed paths are config-ignored); treating as a clean skip`,
+        );
+        resolve({ status: 0 });
+        return;
+      }
+      resolve({ status });
     });
     child.on('error', () => {
       detach();

--- a/.agents/scripts/lib/close-validation/runner.js
+++ b/.agents/scripts/lib/close-validation/runner.js
@@ -50,11 +50,18 @@ function applyChangedFileScope({ gate, spawnCwd, log }) {
   log(
     `[close-validation] ↳ ${gate.name} scoped to ${eligibleFiles.length} formatter-eligible changed file(s) from ${gate.changedFileScope.baseRef}...HEAD`,
   );
+  // The extension filter cannot see biome's own config-ignore axis
+  // (`files.includes` allowlist / `files.ignore` / `overrides`). When every
+  // eligible-by-extension path is also config-ignored, the scoped biome
+  // invocation exits 1 with "No files were processed" — a false negative for
+  // the gate (Story #4292). Flag the scoped run so the runner downgrades that
+  // specific exit to a clean skip instead of a formatting failure.
   return {
     gate,
     cmd: gate.cmd,
     args: [...args, ...eligibleFiles],
     skip: false,
+    tolerateNoFilesProcessed: true,
   };
 }
 
@@ -209,6 +216,9 @@ export async function runCloseValidation({
       log,
       signal,
       ...(gate.env ? { env: gate.env } : {}),
+      ...(gate.tolerateNoFilesProcessed
+        ? { tolerateNoFilesProcessed: true }
+        : {}),
     });
     return { status: result?.status ?? 1 };
   };
@@ -255,7 +265,12 @@ export async function runCloseValidation({
     let result;
     try {
       result = await dispatchGate(
-        { ...gate, cmd: execution.cmd, args: execution.args },
+        {
+          ...gate,
+          cmd: execution.cmd,
+          args: execution.args,
+          tolerateNoFilesProcessed: execution.tolerateNoFilesProcessed,
+        },
         ac.signal,
       );
     } catch (err) {
@@ -321,6 +336,7 @@ export async function runCloseValidation({
       ...gate,
       cmd: execution.cmd,
       args: execution.args,
+      tolerateNoFilesProcessed: execution.tolerateNoFilesProcessed,
     });
     if (result.status !== 0) {
       failed.push({ gate, status: result.status, cwd: spawnCwd });

--- a/tests/story-close.test.js
+++ b/tests/story-close.test.js
@@ -1,6 +1,6 @@
 import assert from 'node:assert';
 import { spawnSync } from 'node:child_process';
-import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { test } from 'node:test';
@@ -12,6 +12,7 @@ import {
   buildDefaultGates,
   DEFAULT_GATES,
 } from '../.agents/scripts/lib/close-validation/gates.js';
+import { isBiomeNoFilesProcessed } from '../.agents/scripts/lib/close-validation/process.js';
 import { runCloseValidation as runCloseValidationOnly } from '../.agents/scripts/lib/close-validation/runner.js';
 import {
   drainPendingCleanupAfterClose,
@@ -454,6 +455,154 @@ test('runCloseValidation', async (t) => {
         );
       }
     },
+  );
+
+  // ── Story #4292 — biome "No files were processed" false-negative guard ──
+  // The extension filter cannot see biome's own config-ignore axis. When every
+  // eligible-by-extension changed file is also biome-config-ignored, the scoped
+  // biome invocation exits 1 with "No files were processed in the specified
+  // paths" even though `biome format .` over the tree is clean. The chosen fix
+  // (option 2) downgrades that specific exit to a clean pass.
+
+  await t.test(
+    "isBiomeNoFilesProcessed detects biome's zero-files marker and ignores unrelated output",
+    () => {
+      assert.equal(
+        isBiomeNoFilesProcessed(
+          '× No files were processed in the specified paths.\n',
+        ),
+        true,
+      );
+      assert.equal(
+        isBiomeNoFilesProcessed(
+          '[format] No files were processed in the specified paths',
+        ),
+        true,
+      );
+      assert.equal(
+        isBiomeNoFilesProcessed('Formatting drift in data.json'),
+        false,
+      );
+      assert.equal(isBiomeNoFilesProcessed(''), false);
+      assert.equal(isBiomeNoFilesProcessed(undefined), false);
+    },
+  );
+
+  // A stub formatter that mimics the slice of biome behaviour under test: when
+  // every path it is handed is in its config-ignore set, it prints biome's
+  // exact "No files were processed" line and exits 1; when handed a path that
+  // carries a "DRIFT" marker it exits 1 with a drift message; otherwise it
+  // exits 0. Used to exercise the real `defaultGateRunner` end to end.
+  const writeBiomeStub = (repoDir, ignoredFiles) => {
+    const stubPath = path.join(repoDir, 'biome-stub.cjs');
+    writeFileSync(
+      stubPath,
+      [
+        'const fs = require("node:fs");',
+        `const ignored = new Set(${JSON.stringify(ignoredFiles)});`,
+        '// args after the leading "format" token are the scoped file paths.',
+        'const files = process.argv.slice(3);',
+        'const processed = files.filter((f) => !ignored.has(f));',
+        'if (processed.length === 0) {',
+        '  process.stderr.write("× No files were processed in the specified paths.\\n");',
+        '  process.exit(1);',
+        '}',
+        'for (const f of processed) {',
+        '  const body = fs.readFileSync(f, "utf8");',
+        '  if (body.includes("DRIFT")) {',
+        '    process.stderr.write("Formatter would reformat " + f + "\\n");',
+        '    process.exit(1);',
+        '  }',
+        '}',
+        'process.exit(0);',
+      ].join('\n'),
+    );
+    return stubPath;
+  };
+
+  const formatGateOverStub = (stubPath) => {
+    const gate = buildDefaultGates({ epicBranch: 'main' }).find(
+      (g) => g.name === 'format',
+    );
+    // Repoint the gate's command at the stub while keeping the trailing "."
+    // so `applyChangedFileScope` strips it and appends the eligible paths.
+    return { ...gate, cmd: process.execPath, args: [stubPath, 'format', '.'] };
+  };
+
+  await t.test(
+    'format gate passes (not fails) when every eligible changed file is biome-config-ignored (Story #4292)',
+    async () =>
+      withTempGitRepo(async (repoDir) => {
+        runGit(repoDir, ['switch', '-c', 'story-4292']);
+        // Two formatter-eligible-by-extension files, both config-ignored by
+        // the stub — the exact athportal failure shape (root-config-only diff).
+        mkdirSync(path.join(repoDir, 'baselines'), { recursive: true });
+        writeFileSync(path.join(repoDir, '.agentrc.json'), '{ "a": 1 }\n');
+        writeFileSync(
+          path.join(repoDir, 'baselines', 'bundle-size.json'),
+          '{}\n',
+        );
+        runGit(repoDir, ['add', '.agentrc.json', 'baselines/bundle-size.json']);
+        runGit(repoDir, ['commit', '-m', 'chore: root config + baseline']);
+
+        const stub = writeBiomeStub(repoDir, [
+          '.agentrc.json',
+          'baselines/bundle-size.json',
+          // the stub itself + git plumbing never reach the gate, but list
+          // them defensively so any stray path is treated as ignored.
+          'biome-stub.cjs',
+        ]);
+        const gate = formatGateOverStub(stub);
+
+        const result = await runCloseValidationOnly({
+          cwd: repoDir,
+          gates: [gate],
+          // No injected runner → exercises the real defaultGateRunner, which
+          // owns the "No files were processed" downgrade.
+          log: () => {},
+        });
+
+        assert.equal(
+          result.ok,
+          true,
+          'all-config-ignored eligible diff must not fail the format gate',
+        );
+        assert.equal(result.failed.length, 0);
+      }),
+  );
+
+  await t.test(
+    'format gate still FAILS on real drift in a config-included file (Story #4292 — no blanket pass)',
+    async () =>
+      withTempGitRepo(async (repoDir) => {
+        runGit(repoDir, ['switch', '-c', 'story-4292-drift']);
+        // A config-included (.json, NOT in the stub's ignore set) file that
+        // carries the DRIFT marker — the stub exits 1 with a drift message,
+        // and the gate must surface that as a real failure.
+        writeFileSync(
+          path.join(repoDir, 'included.json'),
+          '{ "DRIFT": true }\n',
+        );
+        runGit(repoDir, ['add', 'included.json']);
+        runGit(repoDir, ['commit', '-m', 'feat: included config']);
+
+        const stub = writeBiomeStub(repoDir, ['biome-stub.cjs']);
+        const gate = formatGateOverStub(stub);
+
+        const result = await runCloseValidationOnly({
+          cwd: repoDir,
+          gates: [gate],
+          log: () => {},
+        });
+
+        assert.equal(
+          result.ok,
+          false,
+          'genuine formatting drift in a config-included file must fail the gate',
+        );
+        assert.equal(result.failed.length, 1);
+        assert.equal(result.failed[0].gate.name, 'format');
+      }),
   );
 
   await t.test(


### PR DESCRIPTION
Closes #4292

_Auto-opened by `/single-story-deliver`._