### PR TITLE
fix: force re-decompose strips the `Epic: #<id>` marker from Story bodies → /deliver blocks at story-init (#4300)

### DIFF
--- a/.agents/scripts/lib/orchestration/epic-spec-reconciler-diff.js
+++ b/.agents/scripts/lib/orchestration/epic-spec-reconciler-diff.js
@@ -80,6 +80,7 @@
  *     issue with an empty body.
  */
 
+import { composeStoryBody } from '../../providers/github/tickets.js';
 import { assertPlanLabelAllowList } from './epic-spec-reconciler-discriminator.js';
 import {
   closeOp,
@@ -209,34 +210,6 @@ function stripFooter(body) {
 }
 
 /**
- * Render the canonical orchestrator footer (no leading newline). Format
- * matches the byte-stable shape that the cascade-reading consumers
- * (story-init, dispatcher, manifest, close-gate) parse line-anchored:
- *
- *   ---
- *   parent: #<parentId>
- *   [Epic: #<epicId>]            // only when epicId !== parentId
- *
- *   [blocked by #<dep>]          // one per dependency
- *
- * @param {{parentId: number, epicId?: number, dependencies?: number[]}} opts
- * @returns {string}
- */
-function renderFooter({ parentId, epicId, dependencies = [] }) {
-  const lines = ['---', `parent: #${parentId}`];
-  if (epicId !== undefined && epicId !== null && epicId !== parentId) {
-    lines.push(`Epic: #${epicId}`);
-  }
-  if (dependencies.length > 0) {
-    lines.push('');
-    for (const dep of dependencies) {
-      lines.push(`blocked by #${dep}`);
-    }
-  }
-  return lines.join('\n');
-}
-
-/**
  * Compose the canonical orchestrator footer onto a spec body for non-epic
  * entities. Resolves `parentSlug`/`dependsOn` slugs against the running
  * `state.mapping` so the rendered footer carries the live issue numbers.
@@ -246,12 +219,19 @@ function renderFooter({ parentId, epicId, dependencies = [] }) {
  * the YAML spec writes just the description, silently stripping
  * `parent: #N` / `Epic: #M` / `blocked by #X` and breaking the cascade.
  *
- * Story #3185 — the footer compose/strip logic is inlined here rather
- * than reused from the legacy Task-body renderer module. That renderer
- * was removed, so the diff engine carries its own footer shape. The shape
- * is byte-identical to the legacy renderer's `parent: #<n>` /
- * `Epic: #<m>` / `blocked by #<x>` output so cascade-readers continue
- * to parse it unchanged.
+ * Story #4300 — the footer rendering is single-sourced from
+ * `composeStoryBody` (`providers/github/tickets.js`), the same helper the
+ * CREATE path (`epic-spec-reconciler-apply.js` → `provider.createTicket`)
+ * uses. Story #3185 previously inlined a parallel `renderFooter` here to
+ * avoid depending on the (now-removed) legacy Task-body renderer; that
+ * inlined copy silently diverged from `composeStoryBody` by gating the
+ * `Epic: #<id>` line on `epicId !== parentId` — a 3-tier-era condition
+ * that is always false under the 2-tier hierarchy (a Story's parent IS
+ * the Epic), so force re-decompose (`/plan --force`, which routes through
+ * this UPDATE path) silently dropped `Epic: #<id>` from every refreshed
+ * Story body and broke `story-init.js`'s hierarchy resolution. Importing
+ * `composeStoryBody` directly makes that divergence structurally
+ * impossible going forward.
  *
  * @param {{entity: string, parentSlug?: string|null, dependsOn?: string[]}} specEntity
  * @param {string} specBody
@@ -284,8 +264,7 @@ function composeBodyWithFooter(specEntity, specBody, ctx) {
   // included) or emits a canonical-form body. With the strip, the
   // function is idempotent against its own output.
   const head = stripFooter(specBody);
-  const footer = renderFooter({ parentId, epicId, dependencies });
-  return `${head}\n\n${footer}`;
+  return composeStoryBody({ body: head, parentId, epicId, dependencies });
 }
 
 /**

--- a/.agents/scripts/lib/story-lifecycle.js
+++ b/.agents/scripts/lib/story-lifecycle.js
@@ -23,6 +23,15 @@ import {
 /**
  * Parse the `Epic: #N` and `parent: #N` references from a Story body.
  *
+ * Story #4300 (defense-in-depth): under the 2-tier hierarchy
+ * (Epic → Story) a Story's `parent: #N` marker always IS the parent
+ * Epic, so when the `Epic: #N` line is missing — e.g. a Story body
+ * refreshed by the reconciler's UPDATE op before Story #4300's
+ * single-sourced footer rendering landed — `epicId` falls back to the
+ * resolved `parentId` rather than reporting `null` and aborting
+ * delivery. A body that carries neither marker still resolves
+ * `epicId: null` (no parent to fall back to).
+ *
  * @param {string} body  Raw Story body Markdown.
  * @returns {{ epicId: number|null, parentId: number|null }}
  */
@@ -30,10 +39,9 @@ export function resolveStoryHierarchy(body) {
   const source = body ?? '';
   const epicMatch = source.match(/(?:^\s*epic:\s*#(\d+))/im);
   const parentMatch = source.match(/(?:^\s*parent:\s*#(\d+))/im);
-  return {
-    epicId: epicMatch ? Number.parseInt(epicMatch[1], 10) : null,
-    parentId: parentMatch ? Number.parseInt(parentMatch[1], 10) : null,
-  };
+  const parentId = parentMatch ? Number.parseInt(parentMatch[1], 10) : null;
+  const epicId = epicMatch ? Number.parseInt(epicMatch[1], 10) : parentId;
+  return { epicId, parentId };
 }
 
 /**

--- a/tests/lib/story-init/context-resolver.test.js
+++ b/tests/lib/story-init/context-resolver.test.js
@@ -78,6 +78,28 @@ test('resolveContext resolves a directly-attached 2-tier Story body without thro
   assert.strictEqual(out.parentId, 23);
 });
 
+// Story #4300 — a Story body refreshed by the epic-spec-reconciler's
+// UPDATE op (e.g. via `/plan <epicId> --force`) that, pre-fix, dropped the
+// `Epic: #N` line and left only `parent: #N`. resolveContext (via
+// resolveStoryHierarchy's defense-in-depth fallback) must resolve the
+// hierarchy from `parent: #N` rather than throwing
+// `has no "Epic: #N" reference`.
+test('resolveContext falls back to parent: #N when Epic: #N is absent (UPDATE-path body)', async () => {
+  const provider = makeProvider({
+    tickets: {
+      30: {
+        id: 30,
+        labels: ['type::story'],
+        body: 'story description\n\n---\nparent: #23',
+        title: 'S',
+      },
+    },
+  });
+  const out = await resolveContext({ provider, input: { storyId: 30 } });
+  assert.strictEqual(out.epicId, 23);
+  assert.strictEqual(out.parentId, 23);
+});
+
 test('resolveContext rejects self-referential recut', async () => {
   const provider = makeProvider({
     tickets: {

--- a/tests/lib/story-lifecycle.test.js
+++ b/tests/lib/story-lifecycle.test.js
@@ -43,6 +43,27 @@ describe('story-lifecycle', () => {
         parentId: 2,
       });
     });
+
+    // Story #4300 (defense-in-depth) — under the 2-tier hierarchy a
+    // Story's `parent: #N` marker always IS the parent Epic, so a body
+    // that carries `parent: #N` but is missing `Epic: #N` (e.g. one
+    // refreshed by a stale UPDATE-op renderer pre-fix) must still
+    // resolve a non-null epicId rather than aborting delivery.
+    it('falls back to parent: #N when Epic: #N is absent', () => {
+      const body = 'Some story description\n\n---\nparent: #42';
+      assert.deepEqual(resolveStoryHierarchy(body), {
+        epicId: 42,
+        parentId: 42,
+      });
+    });
+
+    it('prefers the explicit Epic: #N marker over the parent fallback', () => {
+      const body = 'Some story description\n\n---\nparent: #42\nEpic: #7';
+      assert.deepEqual(resolveStoryHierarchy(body), {
+        epicId: 7,
+        parentId: 42,
+      });
+    });
   });
 
   // Story #4102 — the producer↔consumer contract for the Story-body Epic
@@ -64,14 +85,21 @@ describe('story-lifecycle', () => {
       });
     });
 
-    it('resolves epicId: null for a standalone Story (parent but no Epic)', () => {
+    // Story #4300 — composeStoryBody({ parentId, no epicId }) is a synthetic
+    // input: every production createTicket call site resolves
+    // `epicId = ticketData.epicId || parentId` before calling
+    // composeStoryBody (tickets.js `createTicket`), so a real created Story
+    // body never carries `parent:` without `Epic:`. resolveStoryHierarchy's
+    // defense-in-depth fallback (Story #4300 AC #2) now recovers epicId from
+    // parentId in this shape too, so the round-trip stays non-null.
+    it('falls back to parentId when composeStoryBody omits epicId', () => {
       const body = composeStoryBody({
         body: '# Story body',
         parentId: 23,
         dependencies: [],
       });
       assert.deepEqual(resolveStoryHierarchy(body), {
-        epicId: null,
+        epicId: 23,
         parentId: 23,
       });
     });

--- a/tests/scripts/epic-reconcile.cli.test.js
+++ b/tests/scripts/epic-reconcile.cli.test.js
@@ -702,8 +702,13 @@ describe('fetchGhState — scoped child enumeration (Story #3455)', () => {
     const storyIssue = 911;
 
     // Compose the canonical orchestrator footer the diff engine expects on
-    // non-epic bodies so the body comparison is a no-op.
-    const storyBody = `A delivered story.\n\n---\nparent: #${epicIssue}`;
+    // non-epic bodies so the body comparison is a no-op. Story #4300:
+    // a directly-attached 2-tier Story has parentId === epicId, and the
+    // canonical footer carries `Epic: #<id>` alongside `parent: #<id>` —
+    // omitting it here previously masked the renderFooter divergence bug
+    // by accident (this fixture's "no-op" assertion only held because the
+    // pre-fix renderer also dropped the Epic: line for this exact shape).
+    const storyBody = `A delivered story.\n\n---\nparent: #${epicIssue}\nEpic: #${epicIssue}`;
 
     const spec = {
       epic: { id: epicId, title: 'Partially Delivered Epic', body: '' },

--- a/tests/scripts/epic-spec-reconciler.diff.test.js
+++ b/tests/scripts/epic-spec-reconciler.diff.test.js
@@ -715,7 +715,14 @@ describe('reconciler diff — orchestrator footer preservation (Story #2982)', (
     return { spec, state, ghState };
   }
 
-  const canonicalFooter = '\n\n---\nparent: #7000\n\nblocked by #7201';
+  // Story #4300 — the canonical footer for a directly-attached 2-tier
+  // Story (parentId === epicId, both #7000 here) carries `Epic: #7000`
+  // alongside `parent: #7000`. Pre-fix this fixture omitted the `Epic:`
+  // line, which happened to match the buggy renderer's
+  // `epicId !== parentId` gate — that match masked the bug rather than
+  // proving the canonical shape.
+  const canonicalFooter =
+    '\n\n---\nparent: #7000\nEpic: #7000\n\nblocked by #7201';
 
   it('does not flap when GH already carries the canonical footer (description match)', () => {
     const description = 'story description';
@@ -790,6 +797,33 @@ describe('reconciler diff — orchestrator footer preservation (Story #2982)', (
       'an Update should fire to restore the missing footer',
     );
     assert.match(storyUpdate.changes.body.after, /\n---\nparent: #7000\n/);
+  });
+
+  // Story #4300 — force re-decompose (`/plan <epicId> --force`) routes
+  // every Story body refresh through this UPDATE op. Under the 2-tier
+  // hierarchy a Story's `parentSlug` always resolves to the Epic, so
+  // `epicId === parentId` for every directly-attached Story (here both
+  // are #7000, matching `buildInputs`' fixture). Before this fix, the
+  // diff engine's inlined `renderFooter` gated the `Epic: #<id>` line on
+  // `epicId !== parentId` — a stale 3-tier-era condition that is always
+  // false in this shape — so the UPDATE op silently dropped `Epic: #7000`
+  // from the refreshed body and `story-init.js` aborted Step 0 with
+  // "has no 'Epic: #N' reference". The Update op must render the same
+  // `parent: #<id>` + `Epic: #<id>` trailer CREATE renders.
+  it('retains Epic: #<id> on the UPDATE op for a directly-attached 2-tier Story (force re-decompose)', () => {
+    const { spec, state, ghState } = buildInputs({
+      specBody: 'new description',
+      obsBody: 'old description',
+    });
+    const plan = diff({ spec, state, ghState });
+    const storyUpdate = plan.updates.find((op) => op.slug === 'story-cascade');
+    assert.ok(storyUpdate, 'an Update should fire when description changes');
+    assert.match(storyUpdate.changes.body.after, /\n---\nparent: #7000\n/);
+    assert.match(
+      storyUpdate.changes.body.after,
+      /\nEpic: #7000\n/,
+      'the refreshed body must retain the Epic: #<id> trailer line',
+    );
   });
 });
 


### PR DESCRIPTION
Closes #4300

_Auto-opened by `/single-story-deliver`._