### PR TITLE
fix(baselines): add one-shot BUNDLE_SIZE_REFRESH acknowledge for the bundle-size ratchet

### DIFF
--- a/.agents/docs/configuration.md
+++ b/.agents/docs/configuration.md
@@ -627,6 +627,12 @@ No tier-specific knobs beyond the common shape.
 | --------- | -------- | ------- | ---------------------------------------------------------------------------------------- |
 | `bundles` | No       | `[]`    | Array of `{ name, path, limit }` entries (e.g. `{ "name": "app", "path": "dist/app.js", "limit": "100kB" }`). |
 
+Unlike `crap` / `maintainability`, this gate has no `refreshTag` config
+field — there is no scorer to regenerate the baseline from source, so the
+one-shot refresh/acknowledge mechanism is an env var, not a config knob.
+See [`.agents/docs/quality-gates.md` § Bundle-size ratchet](quality-gates.md#bundle-size-ratchet--one-shot-refreshacknowledge-story-151)
+for `BUNDLE_SIZE_REFRESH=1` usage.
+
 #### `delivery.quality.formatAutofix`
 
 | Field       | Required | Default | Purpose                                                                                                                  |
@@ -791,6 +797,7 @@ the lint ratchet, and the CRAP/MI gates.
 | `baselines/lint.json`             | `lint-baseline.js`                   | `node .agents/scripts/lint-baseline.js capture`                       |
 | `baselines/crap.json`             | `update-crap-baseline.js`            | `npm run crap:update`                                                   |
 | `baselines/maintainability.json`  | `update-maintainability-baseline.js` | `npm run maintainability:update`                                        |
+| `baselines/bundle-size.json`      | consumer's own build/measure step    | Commit the build's measured sizes; for an intentional growth, run the check with `BUNDLE_SIZE_REFRESH=1` (see [Bundle-size ratchet](quality-gates.md#bundle-size-ratchet--one-shot-refreshacknowledge-story-151)) |
 
 These files are the contract. They are read by every gate (Story close, push
 hook, CI) and are regenerated only via tagged `baseline-refresh:` commits

--- a/.agents/docs/quality-gates.md
+++ b/.agents/docs/quality-gates.md
@@ -452,6 +452,67 @@ watch loop — an unjustified baseline ratchet is no longer caught by CI.
 
 ---
 
+## Bundle-size ratchet — one-shot refresh/acknowledge (Story #151)
+
+> Baseline envelope, axes, and component model: see the
+> [Baseline reference](#baseline-reference) section below.
+
+`check-baselines --gate bundle-size` is a **strict** ratchet: it diffs the
+branch's committed `baselines/bundle-size.json` (head) against the base
+ref's copy (`origin/main` by default) using the gate's configured
+`tolerance`, and separately checks the head aggregate against `floors`.
+Unlike `coverage` / `crap` / `maintainability`, bundle-size has **no
+scorer of its own** — the measured `rawKb` / `gzippedKb` numbers come from
+whatever build step the consumer already runs, not a source-tree rescan —
+so there is no `refreshBaseline({ kind: 'bundle-size', ... })` path to
+regenerate a "corrected" baseline the way `npm run crap:update` does.
+
+This makes an **intentional** bundle-size growth (a framework major bump,
+a new dependency, an SSR runtime swap) impossible to land cleanly with the
+usual levers: permanently raising `tolerance` in `.agentrc.json` disables
+the ratchet for every *future* PR too, not just the one that legitimately
+grew.
+
+### `BUNDLE_SIZE_REFRESH=1`
+
+Set the environment variable for the one CI/local run that needs to land
+the growth:
+
+```bash
+BUNDLE_SIZE_REFRESH=1 npm run bundle-size:check
+# or, calling the dispatcher directly:
+BUNDLE_SIZE_REFRESH=1 node .agents/scripts/check-baselines.js --gate bundle-size
+```
+
+When set (`1` or `true`, case-insensitive), every `bundle-size`
+head-vs-base regression is demoted to `unchanged` **for that invocation
+only** — the gate compares head-vs-head in effect, so it passes even
+though the committed baseline grew. **Floors still apply**: an
+acknowledged PR can still fail if the head aggregate breaches the
+configured `floors` budget, so a genuinely runaway regression isn't
+silently waved through under the guise of "intentional".
+
+Commit the regenerated `baselines/bundle-size.json` (reflecting the real,
+larger sizes) in the same PR so the new numbers become the base for the
+*next* PR's diff.
+
+### The ratchet returns to full strength automatically
+
+`BUNDLE_SIZE_REFRESH` is read fresh on every invocation and is **never
+persisted** — no config write, no committed tag, no lingering state. The
+very next `check-baselines --gate bundle-size` run (i.e. the next PR),
+without the env var set, re-enforces the ratchet at full strength against
+the now-larger committed baseline. There is nothing to remember to reset.
+
+This mirrors the `CRAP_TOLERANCE` env-override precedent (see
+[CRAP gate — Consumer onboarding](#crap-gate--consumer-onboarding) above),
+but as a true one-shot acknowledgment rather than a run-scoped tolerance
+override: `CRAP_TOLERANCE` changes the *threshold*, `BUNDLE_SIZE_REFRESH`
+demotes the *outcome* of an already-flagged regression, which is the
+correct shape for a gate with no rescoring path of its own.
+
+---
+
 ## HITL blocker escalation
 
 `risk::high` is informational/planning metadata only. Runtime execution

--- a/.agents/scripts/lib/baselines/env-overrides.js
+++ b/.agents/scripts/lib/baselines/env-overrides.js
@@ -83,6 +83,41 @@ export function resolveCrapEnvOverrides(crapConfig, env) {
 }
 
 /**
+ * Pure helper: resolve the one-shot bundle-size refresh/acknowledge flag
+ * (Story #151). Unlike `coverage` / `crap` / `maintainability`, the
+ * bundle-size gate has no scorer of its own — the measured sizes come from
+ * a build step the operator already runs, not a source-tree rescan — so
+ * there is no `refreshBaseline({ kind: 'bundle-size', ... })` path to
+ * regenerate a "corrected" baseline. Instead, `BUNDLE_SIZE_REFRESH=1`
+ * (mirroring `CRAP_TOLERANCE`'s env-override precedent) tells
+ * `check-baselines --gate bundle-size` to treat this run's head
+ * measurements as the newly acknowledged baseline: head-vs-base
+ * regressions are demoted to `unchanged` for this invocation only. Floors
+ * still apply — an acknowledged PR can still fail on an absolute budget
+ * breach, only the ratchet-vs-`origin/main` comparison is suspended.
+ *
+ * The flag is **not persisted** anywhere (no config write, no committed
+ * tag): the very next `check-baselines` invocation without the env var —
+ * i.e. the next PR — reverts to full strict enforcement automatically, so
+ * there is no lingering loosened tolerance to remember to reset (AC-3).
+ *
+ * Accepted truthy values: `1`, `true` (case-insensitive). Anything else
+ * (including unset/empty) resolves to `acknowledged: false`.
+ *
+ * @param {NodeJS.ProcessEnv} env
+ * @returns {{ acknowledged: boolean, overrides: string[] }}
+ */
+export function resolveBundleSizeEnvOverrides(env) {
+  const raw = env?.BUNDLE_SIZE_REFRESH;
+  const acknowledged =
+    typeof raw === 'string' && /^(1|true)$/i.test(raw.trim());
+  const overrides = acknowledged
+    ? [`acknowledged=true (BUNDLE_SIZE_REFRESH=${raw})`]
+    : [];
+  return { acknowledged, overrides };
+}
+
+/**
  * Pure helper: resolve the effective MI tolerance by layering precedence:
  *   1. `CRAP_TOLERANCE` env-var (CI override — the baseline-refresh-
  *      guardrail uses this to force base-branch values on both gates).

--- a/.agents/scripts/lib/orchestration/check-baselines/phases/evaluate.js
+++ b/.agents/scripts/lib/orchestration/check-baselines/phases/evaluate.js
@@ -7,8 +7,10 @@
  * @module lib/orchestration/check-baselines/phases/evaluate
  */
 
+import { resolveBundleSizeEnvOverrides } from '../../../baselines/env-overrides.js';
 import { checkKernelVersion } from '../../../baselines/kernel.js';
 import * as reader from '../../../baselines/reader.js';
+import { Logger } from '../../../Logger.js';
 import { applyTolerance, evaluateCompare, runCompareStage } from './compare.js';
 import { applyFloors, flattenBreaches } from './floors.js';
 
@@ -22,6 +24,38 @@ function loadHeadBaseline(kind, cwd, configPath) {
   }
 }
 
+/**
+ * One-shot bundle-size refresh/acknowledge (Story #151). When
+ * `BUNDLE_SIZE_REFRESH=1` is set, demote every `bundle-size` regression to
+ * `unchanged` for this run only — floors still apply, so a genuine budget
+ * breach is still caught. The flag is read fresh on every invocation and
+ * never persisted, so the ratchet returns to full strength automatically on
+ * the very next run (no lingering loosened tolerance to remember to reset).
+ *
+ * No-op for every other kind.
+ */
+function applyBundleSizeAcknowledgment(kind, compareOutput, env) {
+  if (kind !== 'bundle-size') return { compareOutput, acknowledged: false };
+  const { acknowledged, overrides } = resolveBundleSizeEnvOverrides(env);
+  if (!acknowledged || compareOutput.regressions.length === 0) {
+    return { compareOutput, acknowledged: false };
+  }
+  Logger.warn(
+    `[bundle-size] ⚠ ${overrides.join(', ')} — ` +
+      `${compareOutput.regressions.length} regression(s) acknowledged for this run only; ` +
+      'floors still enforced. This does not persist: the next run without ' +
+      'BUNDLE_SIZE_REFRESH re-enforces the ratchet at full strength.',
+  );
+  return {
+    acknowledged: true,
+    compareOutput: {
+      ...compareOutput,
+      regressions: [],
+      unchanged: [...compareOutput.unchanged, ...compareOutput.regressions],
+    },
+  };
+}
+
 function buildGateReport({
   kind,
   gateBlock,
@@ -30,6 +64,7 @@ function buildGateReport({
   breaches,
   compareOutput,
   cmp,
+  acknowledged,
 }) {
   const kernel = checkKernelVersion(kind, baseline.kernelVersion);
   return {
@@ -50,6 +85,7 @@ function buildGateReport({
     regressionCount: compareOutput.regressions.length,
     baseRef: cmp.baseRef ?? null,
     generatedAt: baseline.generatedAt,
+    acknowledged,
   };
 }
 
@@ -59,6 +95,7 @@ export async function evaluateKind({
   scope,
   cwd,
   configPath,
+  env = process.env,
 }) {
   const headLoad = loadHeadBaseline(kind, cwd, configPath);
   if (headLoad.schemaError) return { kind, schemaError: headLoad.schemaError };
@@ -67,7 +104,15 @@ export async function evaluateKind({
   const breaches = flattenBreaches(findings);
   const cmp = await evaluateCompare({ kind, gateBlock, scope, cwd });
   const rawCompare = runCompareStage(baseline, cmp);
-  const compareOutput = applyTolerance(rawCompare, gateBlock.tolerance ?? null);
+  const toleratedCompare = applyTolerance(
+    rawCompare,
+    gateBlock.tolerance ?? null,
+  );
+  const { compareOutput, acknowledged } = applyBundleSizeAcknowledgment(
+    kind,
+    toleratedCompare,
+    env,
+  );
   return buildGateReport({
     kind,
     gateBlock,
@@ -76,5 +121,6 @@ export async function evaluateKind({
     breaches,
     compareOutput,
     cmp,
+    acknowledged,
   });
 }

--- a/.agents/scripts/lib/orchestration/check-baselines/phases/parse-args.js
+++ b/.agents/scripts/lib/orchestration/check-baselines/phases/parse-args.js
@@ -43,6 +43,13 @@ Unified baseline dispatcher. Per-kind pipeline (schema → floor → tolerance �
 compare) over every configured gate, with centralised friction emission and
 aggregated exit codes.
 
+Env vars:
+  BUNDLE_SIZE_REFRESH=1  One-shot acknowledge for an intentional bundle-size
+                         growth: demotes bundle-size regressions to
+                         "unchanged" for this run only (floors still
+                         enforced). Never persisted — the next run without
+                         this flag re-enforces the ratchet.
+
 Exit codes:
   0  every enabled gate passes
   1  any floor breach

--- a/.agents/scripts/lib/orchestration/check-baselines/phases/pipeline.js
+++ b/.agents/scripts/lib/orchestration/check-baselines/phases/pipeline.js
@@ -59,7 +59,7 @@ function dispatchPerKind({ wanted, quality, env, cwd, configPath }) {
     wanted.map((kind) => {
       const gateBlock = quality.gates[kind];
       const scope = resolveDispatchScope({ kind, quality, env });
-      return evaluateKind({ kind, gateBlock, scope, cwd, configPath });
+      return evaluateKind({ kind, gateBlock, scope, cwd, configPath, env });
     }),
   );
 }

--- a/.agents/scripts/lib/orchestration/check-baselines/phases/report.js
+++ b/.agents/scripts/lib/orchestration/check-baselines/phases/report.js
@@ -27,7 +27,8 @@ function formatGateLine(g) {
     ? ''
     : ` [kernel drift ${g.kernelBaseline} → ${g.kernelCurrent}]`;
   const baseRef = g.baseRef ? ` [baseRef=${g.baseRef}]` : '';
-  return `  - ${g.kind}: ${status}${drift}${baseRef}`;
+  const ack = g.acknowledged ? ' [ACKNOWLEDGED — this run only]' : '';
+  return `  - ${g.kind}: ${status}${drift}${baseRef}${ack}`;
 }
 
 function formatViolationLine(component, v) {

--- a/tests/check-bundle-size-env-overrides.test.js
+++ b/tests/check-bundle-size-env-overrides.test.js
@@ -1,0 +1,94 @@
+import assert from 'node:assert';
+import { test } from 'node:test';
+import { resolveBundleSizeEnvOverrides } from '../.agents/scripts/lib/baselines/env-overrides.js';
+
+/**
+ * Tests for `resolveBundleSizeEnvOverrides` (Story #151 upstream port,
+ * mandrel-platform#151 / PR #156). Mirrors the precedence + malformed-value
+ * coverage style of `tests/check-crap-env-overrides.test.js` for the
+ * `CRAP_TOLERANCE` resolver — pinning that `BUNDLE_SIZE_REFRESH` is a true
+ * one-shot acknowledge flag: no persistence, strict truthy-value parsing,
+ * case-insensitive, and a no-op (not a crash) on anything malformed.
+ */
+
+test('resolveBundleSizeEnvOverrides — no env var: not acknowledged, no overrides', () => {
+  const result = resolveBundleSizeEnvOverrides({});
+  assert.strictEqual(result.acknowledged, false);
+  assert.deepStrictEqual(result.overrides, []);
+});
+
+test('resolveBundleSizeEnvOverrides — undefined env object: not acknowledged', () => {
+  const result = resolveBundleSizeEnvOverrides(undefined);
+  assert.strictEqual(result.acknowledged, false);
+  assert.deepStrictEqual(result.overrides, []);
+});
+
+test('resolveBundleSizeEnvOverrides — BUNDLE_SIZE_REFRESH=1 acknowledges', () => {
+  const result = resolveBundleSizeEnvOverrides({ BUNDLE_SIZE_REFRESH: '1' });
+  assert.strictEqual(result.acknowledged, true);
+  assert.strictEqual(result.overrides.length, 1);
+  assert.ok(result.overrides[0].includes('BUNDLE_SIZE_REFRESH=1'));
+});
+
+test('resolveBundleSizeEnvOverrides — BUNDLE_SIZE_REFRESH=true acknowledges', () => {
+  const result = resolveBundleSizeEnvOverrides({ BUNDLE_SIZE_REFRESH: 'true' });
+  assert.strictEqual(result.acknowledged, true);
+  assert.ok(result.overrides[0].includes('BUNDLE_SIZE_REFRESH=true'));
+});
+
+test('resolveBundleSizeEnvOverrides — case-insensitive truthy values (TRUE, True)', () => {
+  assert.strictEqual(
+    resolveBundleSizeEnvOverrides({ BUNDLE_SIZE_REFRESH: 'TRUE' }).acknowledged,
+    true,
+  );
+  assert.strictEqual(
+    resolveBundleSizeEnvOverrides({ BUNDLE_SIZE_REFRESH: 'True' }).acknowledged,
+    true,
+  );
+});
+
+test('resolveBundleSizeEnvOverrides — surrounding whitespace is trimmed before matching', () => {
+  const result = resolveBundleSizeEnvOverrides({ BUNDLE_SIZE_REFRESH: '  1  ' });
+  assert.strictEqual(result.acknowledged, true);
+});
+
+test('resolveBundleSizeEnvOverrides — empty string is treated as unset', () => {
+  const result = resolveBundleSizeEnvOverrides({ BUNDLE_SIZE_REFRESH: '' });
+  assert.strictEqual(result.acknowledged, false);
+  assert.deepStrictEqual(result.overrides, []);
+});
+
+test('resolveBundleSizeEnvOverrides — malformed value (e.g. "yes") is a no-op, not acknowledged', () => {
+  const result = resolveBundleSizeEnvOverrides({ BUNDLE_SIZE_REFRESH: 'yes' });
+  assert.strictEqual(result.acknowledged, false);
+  assert.deepStrictEqual(result.overrides, []);
+});
+
+test('resolveBundleSizeEnvOverrides — "0" and "false" are not acknowledged', () => {
+  assert.strictEqual(
+    resolveBundleSizeEnvOverrides({ BUNDLE_SIZE_REFRESH: '0' }).acknowledged,
+    false,
+  );
+  assert.strictEqual(
+    resolveBundleSizeEnvOverrides({ BUNDLE_SIZE_REFRESH: 'false' }).acknowledged,
+    false,
+  );
+});
+
+test('resolveBundleSizeEnvOverrides — numeric non-string env values are ignored (defensive)', () => {
+  // process.env values are always strings in real life, but the resolver
+  // should not throw or misbehave if a test/caller passes a non-string.
+  const result = resolveBundleSizeEnvOverrides({ BUNDLE_SIZE_REFRESH: 1 });
+  assert.strictEqual(result.acknowledged, false);
+  assert.deepStrictEqual(result.overrides, []);
+});
+
+test('resolveBundleSizeEnvOverrides — other env vars present do not interfere', () => {
+  const result = resolveBundleSizeEnvOverrides({
+    CRAP_TOLERANCE: '0.5',
+    BUNDLE_SIZE_REFRESH: '1',
+    PATH: '/usr/bin',
+  });
+  assert.strictEqual(result.acknowledged, true);
+  assert.strictEqual(result.overrides.length, 1);
+});

--- a/tests/check-bundle-size-env-overrides.test.js
+++ b/tests/check-bundle-size-env-overrides.test.js
@@ -48,7 +48,9 @@ test('resolveBundleSizeEnvOverrides — case-insensitive truthy values (TRUE, Tr
 });
 
 test('resolveBundleSizeEnvOverrides — surrounding whitespace is trimmed before matching', () => {
-  const result = resolveBundleSizeEnvOverrides({ BUNDLE_SIZE_REFRESH: '  1  ' });
+  const result = resolveBundleSizeEnvOverrides({
+    BUNDLE_SIZE_REFRESH: '  1  ',
+  });
   assert.strictEqual(result.acknowledged, true);
 });
 
@@ -70,7 +72,8 @@ test('resolveBundleSizeEnvOverrides — "0" and "false" are not acknowledged', (
     false,
   );
   assert.strictEqual(
-    resolveBundleSizeEnvOverrides({ BUNDLE_SIZE_REFRESH: 'false' }).acknowledged,
+    resolveBundleSizeEnvOverrides({ BUNDLE_SIZE_REFRESH: 'false' })
+      .acknowledged,
     false,
   );
 });

--- a/tests/contract/check-baselines-bundle-size-refresh.test.js
+++ b/tests/contract/check-baselines-bundle-size-refresh.test.js
@@ -1,0 +1,236 @@
+// tests/contract/check-baselines-bundle-size-refresh.test.js
+//
+// Story #151 upstream port (mandrel-platform#151 / PR #156) — dispatcher
+// contract test for the `BUNDLE_SIZE_REFRESH=1` one-shot acknowledge flag.
+//
+// Mirrors `tests/contract/check-baselines-regression.test.js`'s technique:
+// spawn the real `check-baselines.js` binary against a synthetic git
+// repository whose initial commit holds a "base" bundle-size baseline, and
+// whose working-tree baseline regresses against that base. Asserts:
+//
+//   - Without the env var: a bundle-size regression exits 4 (EXIT_REGRESSION).
+//   - With BUNDLE_SIZE_REFRESH=1: the same regression is acknowledged and
+//     the run exits 0 — but the JSON report still records
+//     `acknowledged: true` on the bundle-size gate so the outcome is
+//     auditable, not silently invisible.
+//   - Floors still apply even when acknowledged: a regression that also
+//     breaches the configured `floors` budget still fails (EXIT_FLOOR)
+//     with BUNDLE_SIZE_REFRESH=1 set.
+//   - A malformed/absent env var value is a no-op — falls back to full
+//     strict enforcement (same as the "without the env var" case).
+
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { after, before, describe, it } from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+import { currentKernelVersion } from '../../.agents/scripts/lib/baselines/kernel.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const repoRoot = path.resolve(path.dirname(__filename), '..', '..');
+const dispatcherBin = path.join(
+  repoRoot,
+  '.agents',
+  'scripts',
+  'check-baselines.js',
+);
+
+function writeJson(p, value) {
+  writeFileSync(p, JSON.stringify(value, null, 2));
+}
+
+function bundleSizeEnvelope({ rollup, rows } = {}) {
+  return {
+    $schema: 'bundle-size.schema.json',
+    kernelVersion: currentKernelVersion('bundle-size'),
+    generatedAt: '2026-01-01T00:00:00.000Z',
+    rollup: rollup ?? { '*': { totalKb: 200, gzippedKb: 80 } },
+    rows: rows ?? [{ bundle: 'main', rawKb: 200, gzippedKb: 80 }],
+  };
+}
+
+function runGit(args, cwd) {
+  const res = spawnSync('git', args, {
+    cwd,
+    stdio: ['ignore', 'pipe', 'pipe'],
+    encoding: 'utf8',
+  });
+  if (res.status !== 0) {
+    throw new Error(
+      `git ${args.join(' ')} failed (exit=${res.status}): ${res.stderr}`,
+    );
+  }
+  return res.stdout;
+}
+
+function baseAgentrc(floors) {
+  return {
+    project: {
+      baseBranch: 'main',
+      paths: { agentRoot: '.agents', docsRoot: 'docs', tempRoot: 'temp' },
+      docsContextFiles: [],
+      commands: { lintBaseline: 'echo', test: 'echo', typecheck: 'echo' },
+    },
+    github: { owner: 'x', repo: 'y', operatorHandle: '@ci' },
+    delivery: {
+      quality: {
+        gateScoping: { scope: 'diff', diffRef: 'main' },
+        gates: {
+          'bundle-size': {
+            enabled: true,
+            baselinePath: 'baselines/bundle-size.json',
+            tolerance: { kind: 'absolute', value: 0 },
+            floors: floors ?? { '*': { totalKb: 100000, gzippedKb: 100000 } },
+          },
+        },
+      },
+    },
+  };
+}
+
+function setupRepo({ floors } = {}) {
+  const root = mkdtempSync(path.join(tmpdir(), 'cb-contract-bundlesize-'));
+  mkdirSync(path.join(root, 'baselines'), { recursive: true });
+
+  writeJson(path.join(root, '.agentrc.json'), baseAgentrc(floors));
+
+  runGit(['init', '--initial-branch=main'], root);
+  runGit(['config', 'user.email', 'contract@example.com'], root);
+  runGit(['config', 'user.name', 'contract'], root);
+  runGit(['config', 'commit.gpgsign', 'false'], root);
+
+  // Base commit: baseline with a "main" bundle at 200/80 KB.
+  writeJson(
+    path.join(root, 'baselines', 'bundle-size.json'),
+    bundleSizeEnvelope(),
+  );
+  runGit(['add', '.agentrc.json', 'baselines/bundle-size.json'], root);
+  runGit(['commit', '-m', 'baseline: initial'], root);
+
+  return root;
+}
+
+function spawnDispatcher(cwd, extraEnv = {}) {
+  return spawnSync(
+    process.execPath,
+    [dispatcherBin, '--no-friction', '--format', 'json'],
+    {
+      cwd,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+      env: { ...process.env, ...extraEnv },
+    },
+  );
+}
+
+function bundleSizeGate(res) {
+  const report = JSON.parse(res.stdout);
+  return report.gates.find((g) => g.kind === 'bundle-size');
+}
+
+describe('check-baselines (binary spawn) — bundle-size BUNDLE_SIZE_REFRESH contract', () => {
+  let root;
+
+  before(() => {
+    root = setupRepo();
+  });
+
+  after(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it('exits 4 on a bundle-size regression when BUNDLE_SIZE_REFRESH is unset', () => {
+    writeJson(
+      path.join(root, 'baselines', 'bundle-size.json'),
+      bundleSizeEnvelope({
+        rollup: { '*': { totalKb: 220, gzippedKb: 80 } },
+        rows: [{ bundle: 'main', rawKb: 220, gzippedKb: 80 }],
+      }),
+    );
+
+    const res = spawnDispatcher(root);
+    assert.equal(
+      res.status,
+      4,
+      `expected exit 4, got ${res.status}; stdout=${res.stdout}; stderr=${res.stderr}`,
+    );
+    const gate = bundleSizeGate(res);
+    assert.equal(gate.acknowledged, false);
+    assert.equal(gate.regressionCount, 1);
+  });
+
+  it('exits 0 and marks the gate acknowledged when BUNDLE_SIZE_REFRESH=1 is set', () => {
+    // Same regressing working tree as above (still uncommitted).
+    const res = spawnDispatcher(root, { BUNDLE_SIZE_REFRESH: '1' });
+    assert.equal(
+      res.status,
+      0,
+      `expected exit 0, got ${res.status}; stdout=${res.stdout}; stderr=${res.stderr}`,
+    );
+    const gate = bundleSizeGate(res);
+    assert.equal(gate.acknowledged, true);
+    assert.equal(gate.regressionCount, 0);
+    assert.equal(gate.breachCount, 0);
+  });
+
+  it('malformed BUNDLE_SIZE_REFRESH value is a no-op: falls back to strict enforcement (exit 4)', () => {
+    const res = spawnDispatcher(root, { BUNDLE_SIZE_REFRESH: 'yes-please' });
+    assert.equal(
+      res.status,
+      4,
+      `expected exit 4 (malformed flag is a no-op), got ${res.status}; stdout=${res.stdout}; stderr=${res.stderr}`,
+    );
+    const gate = bundleSizeGate(res);
+    assert.equal(gate.acknowledged, false);
+  });
+
+  it('parity (head === base): exits 0 regardless of BUNDLE_SIZE_REFRESH', () => {
+    writeJson(
+      path.join(root, 'baselines', 'bundle-size.json'),
+      bundleSizeEnvelope(),
+    );
+    const res = spawnDispatcher(root);
+    assert.equal(res.status, 0);
+    const gate = bundleSizeGate(res);
+    assert.equal(gate.acknowledged, false);
+    assert.equal(gate.regressionCount, 0);
+  });
+});
+
+describe('check-baselines (binary spawn) — floors still enforced when acknowledged', () => {
+  let root;
+
+  before(() => {
+    // Floor budget tight enough that the regressed head aggregate breaches
+    // it even though the ratchet-vs-base comparison would be acknowledged.
+    root = setupRepo({ floors: { '*': { totalKb: 210, gzippedKb: 100000 } } });
+  });
+
+  after(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it('BUNDLE_SIZE_REFRESH=1 acknowledges the ratchet regression but floors still fail (exit 1)', () => {
+    writeJson(
+      path.join(root, 'baselines', 'bundle-size.json'),
+      bundleSizeEnvelope({
+        rollup: { '*': { totalKb: 220, gzippedKb: 80 } },
+        rows: [{ bundle: 'main', rawKb: 220, gzippedKb: 80 }],
+      }),
+    );
+
+    const res = spawnDispatcher(root, { BUNDLE_SIZE_REFRESH: '1' });
+    assert.equal(
+      res.status,
+      1,
+      `expected exit 1 (floor breach survives acknowledgment), got ${res.status}; stdout=${res.stdout}; stderr=${res.stderr}`,
+    );
+    const gate = bundleSizeGate(res);
+    assert.equal(gate.acknowledged, true);
+    assert.equal(gate.regressionCount, 0, 'ratchet regression is demoted');
+    assert.ok(gate.breachCount > 0, 'floor breach is not suppressed');
+  });
+});


### PR DESCRIPTION
## Summary
- The bundle-size baseline gate (`check-baselines --gate bundle-size`) is a strict ratchet with no per-PR refresh/acknowledge mechanism, unlike `coverage`/`crap`/`maintainability` — making an intentional bundle-size growth (e.g. a framework major bump) impossible to land without permanently loosening `tolerance`.
- Adds `BUNDLE_SIZE_REFRESH=1` (mirroring the existing `CRAP_TOLERANCE` env-override precedent): a head-vs-base regression is demoted to `unchanged` for that invocation only. `floors` still apply. Never persisted.
- Ported from a consumer-side attempt ([dsj1984/mandrel-platform#151](https://github.com/dsj1984/mandrel-platform/issues/151), [PR #156](https://github.com/dsj1984/mandrel-platform/pull/156)) that wrongly landed under the consumer's own `.agents/` tree — which is materialized/overwritten by every `mandrel sync` — so it silently disappeared the moment that consumer bumped its `mandrel` dependency. The fix belongs here.

## Test plan
- [x] New resolver unit tests: `tests/check-bundle-size-env-overrides.test.js` — precedence, malformed-value handling, truthy-value parsing (mirrors `tests/check-crap-env-overrides.test.js`'s pattern for `CRAP_TOLERANCE`).
- [x] New binary-spawn contract tests: `tests/contract/check-baselines-bundle-size-refresh.test.js` — regression demoted when acknowledged, strict enforcement when unset, malformed value is a no-op, floors still enforced even when acknowledged, parity is a no-op regardless of the flag.
- [x] Full local suite: `npm run lint` (0 errors — 1 pre-existing unrelated warning in `tests/sync-claude-commands-local.test.js`) and `npm test` (9613 passed, 0 failed).

Co-authored-by: Claude Sonnet 5 <noreply@anthropic.com>