### PR TITLE
feat: add envelope-floor soft guidance to the decomposer sizing prompt (#4313)

### DIFF
--- a/.agents/scripts/lib/orchestration/ticket-validator-sizing.js
+++ b/.agents/scripts/lib/orchestration/ticket-validator-sizing.js
@@ -151,6 +151,16 @@ export const DEFAULT_TASK_SIZING = Object.freeze({
  * as a single PR — not a single module or file. Module-level slices fold into
  * the capability they belong to, and a Story whose only consumer is one
  * sibling Story is merged into that sibling (single-consumer merge rule).
+ *
+ * The `envelopeFloor` sentence is the **soft** complement to the sizing
+ * section's envelope framing (Story #4313): the delivery envelope
+ * (`maxTokenBudget`) bounds the TOP of a Story, but under-utilizing it is
+ * itself a merge signal. It is deliberately prose-only — an illustrative
+ * fraction, not a threshold constant, and no validator finding backs it (the
+ * mechanical backstop is the `merge-candidate` finding). It names the
+ * per-Story delivery-session cost (hydration, branch, PR, review, CI) so the
+ * "models one-shot bigger things now" planning assumption is stated, not
+ * implicit.
  */
 export const DELIVERABLE_GRANULARITY_GUIDANCE = Object.freeze({
   // The one-sentence definition of Story granularity.
@@ -159,6 +169,9 @@ export const DELIVERABLE_GRANULARITY_GUIDANCE = Object.freeze({
   // The single-consumer merge rule.
   singleConsumerRule:
     '**Single-consumer merge rule.** A Story whose only consumer is one sibling Story should be **merged into that sibling** rather than emitted separately — a single-consumer downstream slice is not its own unit of work.',
+  // The envelope-floor heuristic (soft; no validator finding — Story #4313).
+  envelopeFloor:
+    '**Envelope floor — under-utilizing the envelope is a merge signal.** A Story that would plausibly consume well under a third of the delivery envelope (`maxTokenBudget`) and is neither parallel-deliverable nor orthogonal to its siblings should be **merged into its consumer**. The fraction is illustrative, not a threshold — the point is that modern frontier models one-shot capability-sized changes, so a chain of small dependent Stories needlessly pays a full delivery session (hydration, branch, PR, review, CI) per link. Merge such links up unless a parallelism or orthogonality reason justifies the separate slice.',
 });
 
 /**

--- a/.agents/scripts/lib/templates/decomposer-prompts.js
+++ b/.agents/scripts/lib/templates/decomposer-prompts.js
@@ -52,12 +52,16 @@ function render2TierPrompt({ maxTickets, maxTokenBudget, epicId = null }) {
   // (ticket-validator-sizing.js) so the prompt and the validator cannot drift.
   const { softFiles, hardFiles, maxAcceptance, softAcceptanceCount } =
     DEFAULT_TASK_SIZING;
-  // Deliverable-granularity definition + single-consumer merge rule are
-  // sourced from the single DELIVERABLE_GRANULARITY_GUIDANCE constant
-  // (ticket-validator-sizing.js) so the prompt and the authoring SKILL
-  // cannot drift (Story #3777).
-  const { definition: granularityDefinition, singleConsumerRule } =
-    DELIVERABLE_GRANULARITY_GUIDANCE;
+  // Deliverable-granularity definition + single-consumer merge rule + the
+  // soft envelope-floor heuristic are sourced from the single
+  // DELIVERABLE_GRANULARITY_GUIDANCE constant (ticket-validator-sizing.js) so
+  // the prompt and the authoring SKILL cannot drift (Story #3777; the
+  // envelope-floor sentence added by Story #4313).
+  const {
+    definition: granularityDefinition,
+    singleConsumerRule,
+    envelopeFloor,
+  } = DELIVERABLE_GRANULARITY_GUIDANCE;
   // The binding-vs-advisory authoring altitude + the New-File Contract are
   // sourced from the single AUTHORING_ALTITUDE_GUIDANCE constant
   // (ticket-validator-sizing.js) so the prompt and the authoring SKILL cannot
@@ -161,6 +165,8 @@ ${advisoryCaveat}
 The primary question is **cohesion, not count**: *is this one coherent change with one reason to exist?* File count cannot tell a trivial ${softFiles}-file rename from a hard 3-file parser+caller+config change — so lead with the change's reason, not its size.
 
 **Size against the real one-pass delivery envelope.** Each Story is delivered and self-verified by a single agent in one pass, whose context is capped by the delivery token budget \`maxTokenBudget = ${maxTokenBudget}\` tokens (the task-prompt hydration cap). Use that envelope — not the file count alone — as the leading sizing input: a Story is correctly sized when one agent can hold its full change, acceptance, and verification in a single pass within \`maxTokenBudget\`. The numeric file thresholds below are a coarse backstop on top of this envelope, not the primary signal.
+
+${envelopeFloor}
 
 - **One Story = one coherent change with one reason to exist.** If you cannot state that reason in a sentence, the Story is probably two Stories — or two Stories that should be one. State that sentence explicitly in the Story's \`reason_to_exist\` meta field (see STORY BODY RULES) so the consolidate critic can check it.
 - ${singleConsumerRule}

--- a/.agents/skills/core/epic-plan-decompose-author/SKILL.md
+++ b/.agents/skills/core/epic-plan-decompose-author/SKILL.md
@@ -224,6 +224,8 @@ They are NOT top-level ticket fields.
 
 The first question is **cohesion, not count**: *is this one coherent change with one reason to exist?* File count cannot tell a trivial 10-file mechanical rename from a hard 3-file parser+caller+config change — so lead with the change's reason, not its size. Size against the real one-pass delivery envelope (`maxTokenBudget`): a Story is correctly sized when a single agent can hold its full change, acceptance, and verification in one pass within that budget.
 
+The envelope also has a **floor**, not just a ceiling: a Story that would plausibly use well under a third of `maxTokenBudget` and is neither parallel-deliverable nor orthogonal to its siblings is a **merge candidate** — modern frontier models one-shot capability-sized changes, so a chain of small dependent Stories needlessly pays a full per-Story delivery session (hydration, branch, PR, review, CI) per link. This is soft guidance, not a threshold or validator finding; the canonical phrasing lives in `DELIVERABLE_GRANULARITY_GUIDANCE.envelopeFloor` in `ticket-validator-sizing.js`, which the decomposer prompt interpolates — do not restate a divergent version here.
+
 - **One Story = one coherent change with one reason to exist.** If you cannot state that reason in a sentence, the Story is probably two Stories.
 - **Single-consumer merge rule.** A Story whose only consumer is one sibling Story should be **merged into that sibling** rather than emitted separately — a single-consumer downstream slice is not its own unit of work.
 - **Split independent, parallelizable work** into sibling Stories — but only when the pieces genuinely have separate reasons to exist.

--- a/tests/skills/epic-plan-decompose-author.test.js
+++ b/tests/skills/epic-plan-decompose-author.test.js
@@ -222,6 +222,26 @@ describe('skill:epic-plan-decompose-author — smoke', () => {
             'Skill body must say a single-consumer Story is merged into that sibling (Story #3777)',
           );
         }
+        // Story #4313 — the SKILL must reference the soft envelope-floor
+        // guidance (under-utilizing the delivery envelope is a merge signal,
+        // naming the per-Story delivery-session cost) rather than only the
+        // ceiling framing. Single-sourced in DELIVERABLE_GRANULARITY_GUIDANCE;
+        // the SKILL references rather than restates the full passage.
+        if (!/\bfloor\b/i.test(body) || !/merge candidate/i.test(body)) {
+          errors.push(
+            'Skill body must reference the envelope-floor merge-candidate guidance (Story #4313)',
+          );
+        }
+        if (!/hydration, branch, PR, review, CI/i.test(body)) {
+          errors.push(
+            'Skill body must name the per-Story delivery-session cost the envelope floor guards against (Story #4313)',
+          );
+        }
+        if (!/DELIVERABLE_GRANULARITY_GUIDANCE\.envelopeFloor/.test(body)) {
+          errors.push(
+            'Skill body must reference the single-source envelopeFloor constant rather than restate a divergent version (Story #4313)',
+          );
+        }
         // Story #3263 — SKILL must document hyphen-case slug format.
         if (!/hyphen[-\s]case|\\^\\[a-z0-9\\]|a-z0-9.*-/i.test(body)) {
           errors.push(

--- a/tests/ticket-decomposer.test.js
+++ b/tests/ticket-decomposer.test.js
@@ -481,6 +481,32 @@ describe('ticket-decomposer buildDecomposerSystemPrompt', () => {
       'prompt must interpolate the canonical single-consumer rule verbatim',
     );
   });
+
+  it('carries the soft envelope-floor guidance from the single shared constant — no drift (Story #4313)', () => {
+    // The envelope-floor passage is single-sourced in
+    // DELIVERABLE_GRANULARITY_GUIDANCE.envelopeFloor and interpolated verbatim,
+    // so the exact canonical sentence must appear in the rendered prompt.
+    const prompt = buildDecomposerSystemPrompt([]);
+    assert.ok(
+      prompt.includes(DELIVERABLE_GRANULARITY_GUIDANCE.envelopeFloor),
+      'prompt must interpolate the canonical envelope-floor guidance verbatim',
+    );
+    // The guidance frames under-utilizing the envelope as a merge signal...
+    assert.ok(
+      /under-utilizing the envelope is a merge signal/i.test(prompt),
+      'prompt must frame under-utilizing the delivery envelope as a merge signal',
+    );
+    // ...and names the per-Story delivery-session cost as the reason.
+    assert.ok(
+      /hydration, branch, PR, review, CI/i.test(prompt),
+      'prompt must name the per-Story delivery-session cost (hydration, branch, PR, review, CI)',
+    );
+    // Soft guidance only: it is illustrative prose, not a threshold constant.
+    assert.ok(
+      /illustrative, not a threshold/i.test(prompt),
+      'envelope-floor guidance must be phrased as guidance, not a numeric threshold',
+    );
+  });
 });
 
 describe('ticket-decomposer prompt single-sourcing (Story #4162)', () => {


### PR DESCRIPTION
Closes #4313

_Auto-opened by `/single-story-deliver`._