### PR TITLE
feat: single-source acceptance criteria: Acceptance Spec keys off the Epic AC bullets (#4315)

### DIFF
--- a/.agents/scripts/lib/orchestration/epic-plan-spec/phases/prompts.js
+++ b/.agents/scripts/lib/orchestration/epic-plan-spec/phases/prompts.js
@@ -39,10 +39,14 @@ The Acceptance Spec should outline:
 2. Stable AC IDs — assign AC-1, AC-2, ... in document order; reuse the same ID across re-plans when an Outcome is materially unchanged so scenario tags (@ac-N) stay aligned
 3. Disposition — tag each row with one of: new | updated | unchanged
 
+The Epic body's \`## Acceptance Criteria\` bullets are the single source of truth for what the spec verifies. Your table does not re-invent criteria — it anchors each one to a specific Epic AC bullet.
+
 CRITICAL REQUIREMENTS:
 - Respond ONLY with valid Markdown.
 - Do not use top-level <h1> (# ) tags. Start with ## Acceptance Criteria.
 - Every AC row MUST have a stable AC ID of the form AC-<n> (AC-1, AC-2, ...) — do not reorder IDs across re-plans; new ACs get fresh sequential IDs.
 - Every AC row MUST carry a Disposition value from the enum: new | updated | unchanged.
-- Each Outcome MUST be a single user-visible behaviour — no DB assertions, no HTTP status codes, no internal implementation details.
+- Each Outcome MUST be a **terse restatement keyed to a specific Epic \`## Acceptance Criteria\` bullet** — lead the Outcome with the bullet's anchor (its quoted lead phrase or an explicit "Epic AC N" index) and keep the rest to a single user-visible behaviour. Do NOT re-elaborate the Epic bullet in independent words: a free-standing Outcome that paraphrases the criterion without naming the bullet it verifies is forbidden, because it drifts from the Epic silently. No DB assertions, no HTTP status codes, no internal implementation details.
+- Where one Epic AC bullet genuinely expands into several user-visible outcomes, emit one row per outcome and declare the split on each — e.g. lead with "splits Epic AC 3" — so the fan-out is explicit rather than hidden.
+- Anchor coverage MUST be complete and auditable: every Epic AC bullet MUST be covered by at least one row, and every row MUST anchor to an Epic AC bullet. Flag divergence in the authored spec instead of dropping it — if an Epic AC bullet has no corresponding row, or a row has no Epic anchor, call it out explicitly (a note beneath the table) rather than silently omitting the bullet or emitting an unanchored row.
 - Cite proposed feature file paths under tests/features/** so Phase 8 can scaffold matching scenarios.`;

--- a/.agents/skills/core/epic-plan-spec-author/SKILL.md
+++ b/.agents/skills/core/epic-plan-spec-author/SKILL.md
@@ -356,6 +356,26 @@ MUST:
 - Start with `## Acceptance Criteria` — never a top-level `#` heading.
 - Render the AC table with the canonical column shape documented in Tech
   Spec #2083: `| AC ID | Outcome | Feature File | Scenario | Disposition |`.
+- **Key each `Outcome` off a specific Epic `## Acceptance Criteria`
+  bullet** — the Epic body's AC bullets are the single source of truth, so
+  the `Outcome` column is a **terse restatement anchored to one Epic
+  bullet**, not an independent re-elaboration. Lead each `Outcome` with its
+  anchor (the bullet's quoted lead phrase or an explicit `Epic AC N` index),
+  then state the single user-visible behaviour. A free-standing `Outcome`
+  that paraphrases a criterion in new words without naming the Epic bullet
+  it verifies is the drift this rule exists to prevent — it decouples the
+  spec from the Epic silently.
+  - **Split case (one Epic AC → several rows).** When one Epic AC bullet
+    genuinely expands into several user-visible outcomes, emit one row per
+    outcome and **declare the split on each** row (e.g. lead with
+    `splits Epic AC 3`) so the fan-out is explicit, not hidden.
+  - **Flag divergence, do not absorb it.** Anchor coverage MUST be complete
+    and auditable: every Epic AC bullet is covered by at least one row and
+    every row anchors to an Epic bullet. Call out any Epic AC bullet with
+    **no** corresponding row, and any AC row with **no** Epic anchor, in a
+    note directly beneath the AC table — surfacing spec/Epic divergence at
+    authoring time. Never silently drop an uncovered Epic bullet or emit an
+    unanchored row.
 - Use **stable AC IDs** of the form `AC-1`, `AC-2`, … assigned in document
   order. On re-plan, reuse the ID for any AC whose Outcome text is
   materially unchanged; new ACs receive fresh sequential IDs (existing
@@ -386,12 +406,16 @@ The Acceptance Spec should outline:
 2. Stable AC IDs — assign AC-1, AC-2, ... in document order; reuse the same ID across re-plans when an Outcome is materially unchanged so scenario tags (@ac-N) stay aligned
 3. Disposition — tag each row with one of: new | updated | unchanged
 
+The Epic body's `## Acceptance Criteria` bullets are the single source of truth for what the spec verifies. Your table does not re-invent criteria — it anchors each one to a specific Epic AC bullet.
+
 CRITICAL REQUIREMENTS:
 - Respond ONLY with valid Markdown.
 - Do not use top-level <h1> (# ) tags. Start with ## Acceptance Criteria.
 - Every AC row MUST have a stable AC ID of the form AC-<n> (AC-1, AC-2, ...) — do not reorder IDs across re-plans; new ACs get fresh sequential IDs.
 - Every AC row MUST carry a Disposition value from the enum: new | updated | unchanged.
-- Each Outcome MUST be a single user-visible behaviour — no DB assertions, no HTTP status codes, no internal implementation details.
+- Each Outcome MUST be a **terse restatement keyed to a specific Epic `## Acceptance Criteria` bullet** — lead the Outcome with the bullet's anchor (its quoted lead phrase or an explicit "Epic AC N" index) and keep the rest to a single user-visible behaviour. Do NOT re-elaborate the Epic bullet in independent words: a free-standing Outcome that paraphrases the criterion without naming the bullet it verifies is forbidden, because it drifts from the Epic silently. No DB assertions, no HTTP status codes, no internal implementation details.
+- Where one Epic AC bullet genuinely expands into several user-visible outcomes, emit one row per outcome and declare the split on each — e.g. lead with "splits Epic AC 3" — so the fan-out is explicit rather than hidden.
+- Anchor coverage MUST be complete and auditable: every Epic AC bullet MUST be covered by at least one row, and every row MUST anchor to an Epic AC bullet. Flag divergence in the authored spec instead of dropping it — if an Epic AC bullet has no corresponding row, or a row has no Epic anchor, call it out explicitly (a note beneath the table) rather than silently omitting the bullet or emitting an unanchored row.
 - Cite proposed feature file paths under tests/features/** so Phase 8 can scaffold matching scenarios.
 - Acceptance Outcomes MUST NOT prescribe a commit subject that begins with a non-Conventional-Commits prefix (allowed leading types: feat|fix|chore|refactor|perf|docs|style|test|build|ci|revert). The legacy `baseline-refresh` token used as a leading subject prescription is forbidden — commitlint will reject it at commit time, and the decompose-time validator (`ticket-validator.js` → `validateAcceptanceSubjectPrefix`) will reject the decompose with `code: 'forbidden-subject-prefix'`. Use a Conventional-Commits subject (e.g. `chore(baselines): refresh ...`) and a body trailer (e.g. `baseline-refresh: true` — trailer with a value, not a subject prefix) when a machine-readable marker is needed. See Epic #2501 for rationale.
 ```


### PR DESCRIPTION
Closes #4315

_Auto-opened by `/single-story-deliver`._