### PR TITLE
docs: rewrite instructions.md § 4 subagent guidance into a cost-aware, provider-neutral heuristic (#4331)

### DIFF
--- a/.agents/instructions.md
+++ b/.agents/instructions.md
@@ -289,9 +289,18 @@ stops.
 
 - **Re-Plan on Failure:** If a strategy fails, **STOP** and re-plan
   immediately. Do not repeat a broken approach.
-- **Subagent Strategy:** Use subagents liberally for research, exploration,
-  or parallel analysis to keep the main context window focused. One
-  objective per subagent.
+- **Subagent Strategy:** Spawning a subagent is not free — each spawn
+  re-pays the full always-loaded context, so treat it as a cost decision,
+  not a reflex. Prefer an **inline search** (grep, a targeted read) for
+  small or localized lookups where you already know roughly where to look;
+  reach for a subagent **only when the work is large enough to justify
+  replicating context** — a broad multi-file investigation, a parallel
+  exploration front, or an isolated task that would otherwise crowd the main
+  context window. One objective per subagent. When the host exposes a
+  cheaper or faster capability, prefer it for **mechanical or read-only**
+  spawns (search, doc regeneration, lint, log triage) and keep
+  **implementation and design** work on the default capability; name no
+  specific model — let the host and operator own the concrete mapping.
 - **Anti-Laziness:** NEVER use placeholder comments like
   `// ... existing code ...`, `/* rest of file */`, or
   `// implementation here`. You MUST output the ENTIRE file or the ENTIRE

--- a/.agents/workflows/helpers/deliver-epic.md
+++ b/.agents/workflows/helpers/deliver-epic.md
@@ -365,9 +365,14 @@ from the Story's live labels and comments.
 **Sub-agent dispatch.** `Agent` calls emit no `model:` argument by
 default — children inherit from the `general-purpose` sub-agent
 definition and the parent's worktree context. No
-`--dangerously-skip-permissions` (no subprocess is spawned). If a
-specific call needs to override the inherited model, pass `model:` as a
-per-call literal at the `Agent(...)` site.
+`--dangerously-skip-permissions` (no subprocess is spawned). Per
+[`.agents/instructions.md` § 4](../../instructions.md)'s cost-aware
+spawning heuristic, this optional per-call `model:` is the escape hatch:
+if a specific call would run better on a cheaper or faster capability the
+host exposes (a mechanical or read-only Story), pass `model:` as a
+per-call literal at the `Agent(...)` site. This is **guidance only** — it
+adds no config key, requires no model argument, and names no specific
+model; the host and operator own the concrete choice.
 
 ### 2c. Record the Story outcomes
 


### PR DESCRIPTION
Closes #4331

_Auto-opened by `/single-story-deliver`._