### PR TITLE
fix(hydration): gate AC/verify strip on each dedicated section separately

### DIFF
--- a/.agents/scripts/lib/orchestration/context-hydration-engine.js
+++ b/.agents/scripts/lib/orchestration/context-hydration-engine.js
@@ -269,14 +269,32 @@ function stripSection(body, heading) {
  * content appears exactly once in the hydrated envelope rather than being
  * duplicated between the dedicated sections and the full task body.
  *
+ * Each heading group is stripped only when its own dedicated section was
+ * emitted (`acceptance` gates `## Acceptance Criteria` + `## Acceptance`;
+ * `verify` gates `## Verify`). This keeps the strip symmetric with what was
+ * reproduced elsewhere in the envelope: a `## Verify` section that carried no
+ * bullets (so no dedicated `verificationCommands` section fired) is left
+ * intact in `taskInstructions` rather than being silently dropped. Both flags
+ * default to `true` so a no-argument call preserves the original
+ * strip-everything behaviour.
+ *
  * @param {string} body
+ * @param {{ acceptance?: boolean, verify?: boolean }} [opts]
  * @returns {string}
  */
-export function stripStorySectionsForTaskInstructions(body) {
+export function stripStorySectionsForTaskInstructions(
+  body,
+  { acceptance = true, verify = true } = {},
+) {
   if (typeof body !== 'string' || body.length === 0) return body ?? '';
-  let out = stripSection(body, 'Acceptance Criteria');
-  out = stripSection(out, 'Acceptance');
-  out = stripSection(out, 'Verify');
+  let out = body;
+  if (acceptance) {
+    out = stripSection(out, 'Acceptance Criteria');
+    out = stripSection(out, 'Acceptance');
+  }
+  if (verify) {
+    out = stripSection(out, 'Verify');
+  }
   return out;
 }
 
@@ -531,14 +549,16 @@ function buildStaticSections(
     }
   }
 
-  // Track whether either dedicated acceptance/verify section was emitted so
-  // taskInstructions can drop the duplicated inline sections from the body —
-  // keeping each binding acceptance/verify item in the envelope exactly once.
-  let dedicatedSectionsEmitted = false;
+  // Track which dedicated section(s) were emitted so taskInstructions drops
+  // only the inline sections that were actually reproduced elsewhere in the
+  // envelope — keeping each binding acceptance/verify item present exactly
+  // once, without dropping a bulletless section that has no dedicated twin.
+  let acceptanceEmitted = false;
+  let verifyEmitted = false;
   if (isTwoTierStoryTask(task)) {
     const { acceptance, verify } = extractStorySections(task.body ?? '');
     if (acceptance.length > 0) {
-      dedicatedSectionsEmitted = true;
+      acceptanceEmitted = true;
       sections.push({
         name: 'acceptanceCriteria',
         priority: DEFAULT_SECTION_PRIORITIES.acceptanceCriteria,
@@ -550,7 +570,7 @@ function buildStaticSections(
       });
     }
     if (verify.length > 0) {
-      dedicatedSectionsEmitted = true;
+      verifyEmitted = true;
       sections.push({
         name: 'verificationCommands',
         priority: DEFAULT_SECTION_PRIORITIES.verificationCommands,
@@ -563,12 +583,19 @@ function buildStaticSections(
     }
   }
 
-  // When the dedicated acceptance/verify sections carry those lists, strip
-  // them from the task body so they are not duplicated in taskInstructions.
-  // When absent, taskInstructions is byte-identical to the full body.
-  const taskBody = dedicatedSectionsEmitted
-    ? stripStorySectionsForTaskInstructions(task.body ?? '')
-    : task.body;
+  // When a dedicated acceptance/verify section carries that list, strip the
+  // matching inline heading(s) from the task body so they are not duplicated
+  // in taskInstructions. Each group is gated on its own section: an inline
+  // section with no dedicated twin (e.g. a bulletless `## Verify`) is left
+  // intact. When neither fired, taskInstructions is byte-identical to the
+  // full body.
+  const taskBody =
+    acceptanceEmitted || verifyEmitted
+      ? stripStorySectionsForTaskInstructions(task.body ?? '', {
+          acceptance: acceptanceEmitted,
+          verify: verifyEmitted,
+        })
+      : task.body;
   sections.push({
     name: 'taskInstructions',
     priority: DEFAULT_SECTION_PRIORITIES.taskInstructions,

--- a/tests/orchestration/context-hydration-engine.test.js
+++ b/tests/orchestration/context-hydration-engine.test.js
@@ -542,6 +542,59 @@ describe('stripStorySectionsForTaskInstructions', () => {
     assert.equal(stripStorySectionsForTaskInstructions(''), '');
     assert.equal(stripStorySectionsForTaskInstructions(null), '');
   });
+
+  it('acceptance-only: strips the acceptance headings but preserves ## Verify', () => {
+    const body = [
+      '## Acceptance',
+      '- do the thing',
+      '',
+      '## Verify',
+      'Prose-only verify with no bullets — kept.',
+    ].join('\n');
+    const out = stripStorySectionsForTaskInstructions(body, {
+      acceptance: true,
+      verify: false,
+    });
+    assert.ok(!out.includes('## Acceptance'), 'acceptance heading stripped');
+    assert.ok(!out.includes('do the thing'), 'acceptance body stripped');
+    assert.ok(out.includes('## Verify'), '## Verify heading preserved');
+    assert.ok(
+      out.includes('Prose-only verify with no bullets — kept.'),
+      'verify prose preserved',
+    );
+  });
+
+  it('verify-only: strips ## Verify but preserves the acceptance section', () => {
+    const body = [
+      '## Acceptance',
+      'Prose-only acceptance with no bullets — kept.',
+      '',
+      '## Verify',
+      '- node --test foo.test.js',
+    ].join('\n');
+    const out = stripStorySectionsForTaskInstructions(body, {
+      acceptance: false,
+      verify: true,
+    });
+    assert.ok(out.includes('## Acceptance'), '## Acceptance heading preserved');
+    assert.ok(
+      out.includes('Prose-only acceptance with no bullets — kept.'),
+      'acceptance prose preserved',
+    );
+    assert.ok(!out.includes('## Verify'), 'verify heading stripped');
+    assert.ok(!out.includes('node --test foo.test.js'), 'verify body stripped');
+  });
+
+  it('neither flag: returns the body unchanged', () => {
+    const body = '## Acceptance\n- a\n\n## Verify\n- b';
+    assert.equal(
+      stripStorySectionsForTaskInstructions(body, {
+        acceptance: false,
+        verify: false,
+      }),
+      body,
+    );
+  });
 });
 
 describe('hydrateContext — acceptance/verify de-duplication (dedup on/off)', () => {
@@ -682,6 +735,103 @@ describe('hydrateContext — acceptance/verify de-duplication (dedup on/off)', (
     assert.equal(
       taskInst.content,
       `## Task Instructions (Issue #801: Bare Story)\n\n${storyBody}`,
+    );
+  });
+
+  it('asymmetric: a bulletless ## Verify (no dedicated section) is NOT stripped when only acceptance fired', async () => {
+    // Acceptance carries bullets (dedicated section fires); Verify carries
+    // only prose (no bullets → no verificationCommands section). The old
+    // single-flag guard would strip ## Verify anyway, dropping content that
+    // nothing else in the envelope reproduces. It must be preserved.
+    const storyBody = [
+      '> Epic: #1',
+      '',
+      'Story narrative body.',
+      '',
+      '## Acceptance',
+      '- [ ] Inline AC alpha',
+      '',
+      '## Verify',
+      'Manual verification prose — no bullets here.',
+    ].join('\n');
+
+    const envelope = await hydrateContext(
+      {
+        id: 810,
+        title: 'Asymmetric Story',
+        body: storyBody,
+        labels: ['type::story'],
+      },
+      epicProvider(),
+      'epic/1',
+      'story-810',
+      1,
+    );
+
+    const taskInst = envelope.sections.find(
+      (s) => s.name === 'taskInstructions',
+    );
+    assert.ok(taskInst, 'taskInstructions section must be emitted');
+    // Acceptance was reproduced in its dedicated section, so it is stripped…
+    assert.ok(!taskInst.content.includes('Inline AC alpha'));
+    // …but the bulletless ## Verify has no dedicated twin and MUST survive.
+    assert.ok(taskInst.content.includes('## Verify'), '## Verify preserved');
+    assert.ok(
+      taskInst.content.includes('Manual verification prose — no bullets here.'),
+      'verify prose preserved',
+    );
+    assert.ok(envelope.sections.some((s) => s.name === 'acceptanceCriteria'));
+    assert.ok(
+      !envelope.sections.some((s) => s.name === 'verificationCommands'),
+      'no verificationCommands section for a bulletless Verify',
+    );
+  });
+
+  it('asymmetric: a bulletless ## Acceptance (no dedicated section) is NOT stripped when only verify fired', async () => {
+    const storyBody = [
+      '> Epic: #1',
+      '',
+      'Story narrative body.',
+      '',
+      '## Acceptance',
+      'Prose-only acceptance — no bullets here.',
+      '',
+      '## Verify',
+      '- node --test tests/beta.test.js',
+    ].join('\n');
+
+    const envelope = await hydrateContext(
+      {
+        id: 811,
+        title: 'Asymmetric Story',
+        body: storyBody,
+        labels: ['type::story'],
+      },
+      epicProvider(),
+      'epic/1',
+      'story-811',
+      1,
+    );
+
+    const taskInst = envelope.sections.find(
+      (s) => s.name === 'taskInstructions',
+    );
+    assert.ok(taskInst, 'taskInstructions section must be emitted');
+    // Verify was reproduced in its dedicated section, so it is stripped…
+    assert.ok(!taskInst.content.includes('node --test tests/beta.test.js'));
+    // …but the bulletless ## Acceptance has no dedicated twin and MUST survive.
+    assert.ok(
+      taskInst.content.includes('## Acceptance'),
+      '## Acceptance preserved',
+    );
+    assert.ok(
+      taskInst.content.includes('Prose-only acceptance — no bullets here.'),
+      'acceptance prose preserved',
+    );
+    assert.ok(envelope.sections.some((s) => s.name === 'verificationCommands'));
+    assert.ok(
+      !envelope.sections.some((s) => s.name === 'acceptanceCriteria'),
+      'no acceptanceCriteria section for a bulletless Acceptance',
     );
   });
 });


### PR DESCRIPTION
## Why

`buildStaticSections` in `context-hydration-engine.js` used a single `dedicatedSectionsEmitted` OR flag: if **either** the acceptance or the verify dedicated envelope section fired, `stripStorySectionsForTaskInstructions` stripped **all three** heading variants (`## Acceptance Criteria`, `## Acceptance`, `## Verify`) from the `taskInstructions` body.

For validated Story bodies this is harmless — decompose-time validation guarantees bullet-shaped `acceptance[]`/`verify[]`, so a bulletless section carries nothing binding. But it's an asymmetry: a Story whose `## Verify` held only prose (`verify.length === 0`, so no dedicated `verificationCommands` twin) would still have that prose stripped from `taskInstructions` with nothing reproducing it.

## What

- `stripStorySectionsForTaskInstructions(body, { acceptance, verify })` now gates each heading group on its own flag. Both default `true`, so a no-argument call preserves the original strip-everything behaviour.
- The call site tracks `acceptanceEmitted` / `verifyEmitted` separately and strips a group only when its own dedicated section was emitted.

## Tests

- Unit coverage for the per-section opts (acceptance-only, verify-only, neither).
- Two `hydrateContext`-level tests proving a bulletless `## Verify` / `## Acceptance` survives in `taskInstructions` when only its sibling section fired.
- `node --test tests/orchestration/context-hydration-engine.test.js` → 25/25 pass. `biome ci` clean on both files.

Surfaced during the `/deliver` code review of Epic #4337 (Story #4340) as a non-blocking 🟡; this is the follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)