### PR TITLE
fix(baselines): honor maintainability ignoreGlobs in story-close auto-refresh + floor check

### DIFF
--- a/.agents/scripts/lib/orchestration/check-baselines/phases/evaluate.js
+++ b/.agents/scripts/lib/orchestration/check-baselines/phases/evaluate.js
@@ -40,10 +40,14 @@ import { applyFloors, flattenBreaches } from './floors.js';
  * input. All three `ignoreGlobs`-configured gates (maintainability, crap,
  * duplication) are `path`-keyed, so the shared path matcher applies uniformly.
  *
+ * Kept module-local (not exported): the poison-exclusion behaviour is covered
+ * end-to-end through `evaluateKind` by the `check-baselines.min-floor` suite,
+ * so there is no external consumer to justify widening the surface.
+ *
  * @param {{ kind: string, baseline: { rollup?: object, rows?: object[] }, ignoreGlobs?: string[], cwd?: string }} args
  * @returns {object} the effective rollup to feed the floor check
  */
-export function rollupExcludingIgnored({ kind, baseline, ignoreGlobs, cwd }) {
+function rollupExcludingIgnored({ kind, baseline, ignoreGlobs, cwd }) {
   const rollup = baseline?.rollup;
   if (!Array.isArray(ignoreGlobs) || ignoreGlobs.length === 0) return rollup;
   const rows = baseline?.rows;

--- a/.agents/scripts/lib/orchestration/check-baselines/phases/evaluate.js
+++ b/.agents/scripts/lib/orchestration/check-baselines/phases/evaluate.js
@@ -8,11 +8,64 @@
  */
 
 import { resolveBundleSizeEnvOverrides } from '../../../baselines/env-overrides.js';
-import { checkKernelVersion } from '../../../baselines/kernel.js';
+import {
+  checkKernelVersion,
+  getKindModule,
+} from '../../../baselines/kernel.js';
 import * as reader from '../../../baselines/reader.js';
 import { Logger } from '../../../Logger.js';
+import { isIgnoredByGlobs } from '../../../maintainability-utils.js';
 import { applyTolerance, evaluateCompare, runCompareStage } from './compare.js';
 import { applyFloors, flattenBreaches } from './floors.js';
+
+/**
+ * Defense-in-depth against an `ignoreGlobs`-poisoned baseline (Epic #4326
+ * incident). The generation path already drops `ignoreGlobs`-matched files
+ * before they reach `rows` (both the canonical `buildDefaultMaintainabilityScorer`
+ * and the story-close `buildKindScorer`), so a freshly-generated baseline's
+ * `rollup["*"]` never includes an ignored file. But the floor check trusts the
+ * *stored* `rollup["*"]`: if a baseline is poisoned by some other route — a
+ * stale branch's older tooling, a hand-edit, a future generation bug — an
+ * ignored file's metric can still drag the global floor axis (e.g.
+ * maintainability `min`) below its floor and block every downstream close.
+ *
+ * This recomputes the global `*` aggregate over the baseline rows that are NOT
+ * matched by the gate's `ignoreGlobs`, using the kind's own canonical
+ * `rollup()` aggregator, so the floor axis reflects only the files the gate is
+ * meant to police. It is a **no-op for a correctly-generated baseline** (no
+ * ignored file is present in `rows`, so the filtered set is identical and the
+ * stored `rollup["*"]` is returned unchanged) and only affects the `*`
+ * component the incident poisons; named-component rollups are left as stored.
+ * The compare/regression stage is untouched — this only reshapes the floor
+ * input. All three `ignoreGlobs`-configured gates (maintainability, crap,
+ * duplication) are `path`-keyed, so the shared path matcher applies uniformly.
+ *
+ * @param {{ kind: string, baseline: { rollup?: object, rows?: object[] }, ignoreGlobs?: string[], cwd?: string }} args
+ * @returns {object} the effective rollup to feed the floor check
+ */
+export function rollupExcludingIgnored({ kind, baseline, ignoreGlobs, cwd }) {
+  const rollup = baseline?.rollup;
+  if (!Array.isArray(ignoreGlobs) || ignoreGlobs.length === 0) return rollup;
+  const rows = baseline?.rows;
+  if (!Array.isArray(rows) || rows.length === 0) return rollup;
+  let mod;
+  try {
+    mod = getKindModule(kind);
+  } catch {
+    return rollup;
+  }
+  if (mod?.keyField !== 'path' || typeof mod.rollup !== 'function')
+    return rollup;
+  const kept = rows.filter((row) => {
+    const p = row?.path;
+    return typeof p !== 'string' || !isIgnoredByGlobs(p, ignoreGlobs, cwd);
+  });
+  // Nothing ignored is present → the stored rollup already excludes ignored
+  // files (the correct-baseline fast path); return it untouched.
+  if (kept.length === rows.length) return rollup;
+  const recomputed = mod.rollup(kept);
+  return { ...rollup, '*': recomputed?.['*'] ?? rollup?.['*'] };
+}
 
 function loadHeadBaseline(kind, cwd, configPath) {
   try {
@@ -100,7 +153,13 @@ export async function evaluateKind({
   const headLoad = loadHeadBaseline(kind, cwd, configPath);
   if (headLoad.schemaError) return { kind, schemaError: headLoad.schemaError };
   const baseline = headLoad.baseline;
-  const findings = applyFloors(kind, baseline.rollup, gateBlock.floors ?? {});
+  const floorRollup = rollupExcludingIgnored({
+    kind,
+    baseline,
+    ignoreGlobs: gateBlock.ignoreGlobs,
+    cwd,
+  });
+  const findings = applyFloors(kind, floorRollup, gateBlock.floors ?? {});
   const breaches = flattenBreaches(findings);
   const cmp = await evaluateCompare({ kind, gateBlock, scope, cwd });
   const rawCompare = runCompareStage(baseline, cmp);

--- a/.agents/scripts/lib/orchestration/story-close/baseline-attribution/phases/refresh-commit.js
+++ b/.agents/scripts/lib/orchestration/story-close/baseline-attribution/phases/refresh-commit.js
@@ -32,6 +32,7 @@ import { Logger as DefaultLogger } from '../../../../Logger.js';
 import {
   calculateAll as defaultCalculateAll,
   scanDirectory as defaultScanDirectory,
+  isIgnoredByGlobs as isIgnoredByGlobsMi,
 } from '../../../../maintainability-utils.js';
 
 /**
@@ -101,7 +102,20 @@ export function buildKindScorer({
           const underTarget = targetAbsDirs.some(
             (root) => abs === root || abs.startsWith(`${root}${path.sep}`),
           );
-          if (underTarget) sourceList.push(abs);
+          // Apply `ignoreGlobs` here too — the full-scope walk drops
+          // ignore-matched files via `scanDirectory`, so the diff-scope path
+          // must do the same or an ignored-but-changed file (e.g. one matched
+          // by `config-settings-schema*.js`) enters `rows` and drags the
+          // `rollup["*"].min` below the maintainability floor. This mirrors the
+          // canonical `buildDefaultMaintainabilityScorer` (refresh-service.js,
+          // Story #4293); the story-close auto-refresh routes through this
+          // scorer, not that one, so the fix has to live here too.
+          if (
+            underTarget &&
+            !isIgnoredByGlobsMi(abs, miIgnoreGlobs, effectiveCwd)
+          ) {
+            sourceList.push(abs);
+          }
         }
       }
       const scores = await calculateAll(sourceList);

--- a/tests/lib/orchestration/story-close/build-kind-scorer-diff-scope.test.js
+++ b/tests/lib/orchestration/story-close/build-kind-scorer-diff-scope.test.js
@@ -97,6 +97,58 @@ describe('buildKindScorer — maintainability — diff-scope path (Story #3647)'
     assert.equal(rows.length, 1);
   });
 
+  it('excludes ignoreGlobs-matched files in diff-scope mode (Epic #4326 poison regression)', async () => {
+    // The story-close auto-refresh routes through this scorer, NOT the
+    // canonical `buildDefaultMaintainabilityScorer` that Story #4293 fixed.
+    // An ignored-but-changed file (matched by `config-settings-schema*.js`)
+    // must never reach `calculateAll`, or its low MI enters `rows` and drags
+    // `rollup["*"].min` below the maintainability floor — the exact poison
+    // that blocked every downstream Story close during Epic #4326 delivery.
+    const scanned = [];
+    const calculateAll = async (absPaths) => {
+      scanned.push(...absPaths);
+      return Object.fromEntries(absPaths.map((p) => [p, 80]));
+    };
+    const scanDirectory = () => {
+      throw new Error('scanDirectory must not be called in diff-scope mode');
+    };
+
+    const scorer = buildKindScorer({
+      kind: 'maintainability',
+      cwd: FAKE_CWD,
+      config: null,
+      getQuality: () => ({
+        maintainability: {
+          targetDirs: ['.agents/scripts'],
+          ignoreGlobs: ['.agents/scripts/lib/config-settings-schema*.js'],
+        },
+      }),
+      scanDirectory,
+      calculateAll,
+    });
+
+    const rows = await scorer(
+      [
+        '.agents/scripts/lib/config-settings-schema.js', // ignored + under target
+        '.agents/scripts/lib/foo.js', // scored
+      ],
+      { fullScope: false, cwd: FAKE_CWD },
+    );
+
+    assert.ok(
+      !scanned.includes(
+        path.resolve(FAKE_CWD, '.agents/scripts/lib/config-settings-schema.js'),
+      ),
+      'ignoreGlobs-matched file must not be scored',
+    );
+    assert.equal(scanned.length, 1, 'only the non-ignored file is scored');
+    assert.equal(rows.length, 1);
+    assert.ok(
+      !rows.some((r) => /config-settings-schema/.test(r.path)),
+      'ignored file must not appear in rows',
+    );
+  });
+
   it('returns empty rows when files list is empty in diff-scope mode', async () => {
     const calculateAll = async (absPaths) =>
       Object.fromEntries(absPaths.map((p) => [p, 80]));

--- a/tests/scripts/check-baselines.min-floor.test.js
+++ b/tests/scripts/check-baselines.min-floor.test.js
@@ -145,3 +145,95 @@ describe('check-baselines — maintainability min floor (Story #2193 AC-5)', () 
     assert.equal(res.report.gates[0].breaches[0].value, 75);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Epic #4326 incident — floor-path defence against an ignoreGlobs-poisoned
+// baseline. Even if a baseline (from stale tooling, a hand-edit, or a future
+// generation bug) records an `ignoreGlobs`-matched file in its rows and drags
+// `rollup["*"].min` below the floor, the floor check must recompute the `*`
+// aggregate over non-ignored rows and NOT trip.
+// ---------------------------------------------------------------------------
+
+function setupRepoWithIgnoreGlobs({ floors, ignoreGlobs } = {}) {
+  const root = mkdtempSync(path.join(tmpdir(), 'check-baselines-mi-ignore-'));
+  mkdirSync(path.join(root, 'baselines'), { recursive: true });
+  const gate = {
+    enabled: true,
+    baselinePath: 'baselines/maintainability.json',
+    tolerance: { kind: 'absolute', value: 0.5 },
+  };
+  if (floors !== undefined) gate.floors = floors;
+  if (ignoreGlobs !== undefined) gate.ignoreGlobs = ignoreGlobs;
+  const agentrc = {
+    project: {
+      baseBranch: 'main',
+      paths: { agentRoot: '.agents', docsRoot: 'docs', tempRoot: 'temp' },
+      docsContextFiles: [],
+      commands: { lintBaseline: 'echo', test: 'echo', typecheck: 'echo' },
+    },
+    github: { owner: 'x', repo: 'y', operatorHandle: '@ci' },
+    delivery: { quality: { gates: { maintainability: gate } } },
+  };
+  writeJson(path.join(root, '.agentrc.json'), agentrc);
+  return root;
+}
+
+// A poisoned envelope: an ignored file leaked into rows with a below-floor MI,
+// dragging the stored rollup min to that value; a second, healthy file sits at
+// 72 (above the 70 floor). With the ignored row excluded, the effective min is
+// 72 and the gate passes.
+function poisonedEnvelope() {
+  return {
+    $schema: 'maintainability.schema.json',
+    kernelVersion: currentKernelVersion('maintainability'),
+    generatedAt: '2026-01-01T00:00:00.000Z',
+    rollup: { '*': { min: 48.787, p50: 88, p95: 95 } },
+    rows: [
+      { path: '.agents/scripts/lib/config-settings-schema.js', mi: 48.787 },
+      { path: '.agents/scripts/lib/healthy.js', mi: 72 },
+    ],
+  };
+}
+
+describe('check-baselines — maintainability floor ignores ignoreGlobs-matched rows (Epic #4326)', () => {
+  let root;
+  afterEach(() => {
+    if (root) rmSync(root, { recursive: true, force: true });
+    root = undefined;
+  });
+
+  it('passes: a poisoned baseline clears the floor once the ignored row is excluded', async () => {
+    root = setupRepoWithIgnoreGlobs({
+      floors: { '*': { min: 70 } },
+      ignoreGlobs: ['.agents/scripts/lib/config-settings-schema*.js'],
+    });
+    writeJson(
+      path.join(root, 'baselines', 'maintainability.json'),
+      poisonedEnvelope(),
+    );
+    const res = await runCheckBaselines({
+      argv: ['--no-friction', '--gate', 'maintainability'],
+      cwd: root,
+    });
+    assert.equal(
+      res.exitCode,
+      0,
+      'ignored row excluded → effective min 72 clears the 70 floor',
+    );
+    assert.equal(res.report.totalBreaches, 0);
+  });
+
+  it('control: the same poisoned baseline trips the floor when no ignoreGlobs is configured', async () => {
+    root = setupRepoWithIgnoreGlobs({ floors: { '*': { min: 70 } } });
+    writeJson(
+      path.join(root, 'baselines', 'maintainability.json'),
+      poisonedEnvelope(),
+    );
+    const res = await runCheckBaselines({
+      argv: ['--no-friction', '--gate', 'maintainability'],
+      cwd: root,
+    });
+    assert.equal(res.exitCode, 1, 'no ignoreGlobs → stored poisoned min trips');
+    assert.equal(res.report.gates[0].breaches[0].value, 48.787);
+  });
+});


### PR DESCRIPTION
## Problem

During Epic #4326 delivery, the story-close \`check-baselines\` gate blocked two Stories on a false maintainability floor breach. A \`chore(baselines): refresh maintainability\` step recorded an entry for \`.agents/scripts/lib/config-settings-schema.js\` (MI 48.787) — a file explicitly in \`delivery.quality.gates.maintainability.ignoreGlobs\` (\`config-settings-schema*.js\`). Its inclusion dropped the rollup \`*.min\` from 70.566 to 48.787, tripping \`min < floor(70)\` for **every** downstream Story close. The incident was worked around by reverting the baseline (commit d01eb687 on epic/4326).

## Two bugs, two fixes

**1. Generation (root cause) — `buildKindScorer` diff-scope leak.**
Story #4293 fixed the *manual* CLI (`update-maintainability-baseline.js`) to route through the canonical `buildDefaultMaintainabilityScorer`, which applies `ignoreGlobs` on both scope branches. But the **story-close auto-refresh** (`auto-refresh-runner.js`) routes through a *different* scorer — `buildKindScorer` in `refresh-commit.js` — whose maintainability diff-scope branch filtered by target dir but **never applied `ignoreGlobs`**. That's the scorer that wrote the poison commit. Fix: apply the same `isIgnoredByGlobs` filter #4293 added to the canonical scorer. (`filterExcludedRows` is only a hardcoded parse-fail allowlist, not the config filter.)

**2. Floor check (defense-in-depth) — the gate trusted a poisoned rollup.**
The check-baselines floor path read the *stored* `rollup['*']` and consulted `ignoreGlobs` nowhere, so a baseline poisoned by any route (stale tooling, hand-edit, a future generation bug) still tripped the floor. Fix: `rollupExcludingIgnored` recomputes the `*` aggregate over non-ignored rows using the kind's own canonical `rollup()`. It is a **no-op for a correctly-generated baseline** (no ignored file present → stored rollup returned unchanged), touches only the `*` floor input (compare/regression stage untouched), and now applies consistently across all three `path`-keyed `ignoreGlobs` gates (maintainability, crap, duplication).

## Verification

- **Reproduced** both bugs before fixing (buildKindScorer leaked `config-settings-schema.js` at mi=48.787; a poisoned baseline min 48.787 tripped floor 70) and confirmed each fix resolves it (0 leaked rows; effective min 70.566, no breach).
- **New tests:** `build-kind-scorer-diff-scope.test.js` asserts the diff-scope scorer excludes `ignoreGlobs` matches; `check-baselines.min-floor.test.js` asserts a poisoned baseline passes with `ignoreGlobs` configured and trips without it (control).
- Related baseline/check suites: 328 pass / 0 fail. Full `npm run lint` green.

_Note: 5 pre-existing `merge-runner-finalize` test failures in the story-close suite are environmental (git-mock) and unrelated — they fail identically with these changes stashed._

🤖 Generated with [Claude Code](https://claude.com/claude-code)