### PR TITLE
feat(planning): remove hard acceptance ceiling and add delivery-schedule simulation to decomposer

### DIFF
--- a/.agents/docs/agentrc-reference.json
+++ b/.agents/docs/agentrc-reference.json
@@ -92,7 +92,6 @@
     "taskSizing": {
       "softFiles": 15,
       "hardFiles": 30,
-      "maxAcceptance": 14,
       "softAcceptanceCount": 10
     }
   },

--- a/.agents/docs/configuration.md
+++ b/.agents/docs/configuration.md
@@ -108,8 +108,7 @@ top-level keys are validation errors.
 | `taskSizing` | No | `object` | — | Story-sizing thresholds consumed by ticket-validator-sizing.js. Operator overrides shallow-merge with DEFAULT_TASK_SIZING defaults. Story #3760 collapsed the per-profile matrix and the parallel testSurface axis into a flat set of knobs; the sizingProfile enum was replaced by an optional body-level `wide` declaration that lifts the hardFiles rejection. Story #3874 cut over to one uniform relaxed profile sized for capability slices a frontier model delivers and self-verifies in one pass. |
 | `taskSizing.softFiles` | No | `integer` | — | File-count soft-warn threshold above which a typical-Story width finding fires (default 15). |
 | `taskSizing.hardFiles` | No | `integer` | — | File-count hard ceiling: a Story exceeding it is rejected unless it declares `wide` with a reason (default 30). |
-| `taskSizing.maxAcceptance` | No | `integer` | — | Hard ceiling on acceptance[] item count (default 14). |
-| `taskSizing.softAcceptanceCount` | No | `integer` | — | Soft-warn threshold on acceptance[] item count (default 10). |
+| `taskSizing.softAcceptanceCount` | No | `integer` | — | Soft-warn threshold on acceptance[] item count (default 10). Acceptance mass is advisory-only — there is no hard acceptance ceiling. |
 | `taskSizing.mergeCandidateMaxFiles` | No | `integer` | — | Under-size threshold (Story #4312): a Story with at most this many declared changes[] files, at most mergeCandidateMaxAcceptance acceptance items, and at least one depends_on edge to a sibling trips the advisory `merge-candidate` soft finding (default 3). |
 | `taskSizing.mergeCandidateMaxAcceptance` | No | `integer` | — | Under-size threshold (Story #4312): the acceptance[] item ceiling of the `merge-candidate` soft finding heuristic (default 4). |
 | `failOnSharedEditors` | No | `boolean` | — | — |

--- a/.agents/schemas/agentrc.schema.json
+++ b/.agents/schemas/agentrc.schema.json
@@ -339,15 +339,10 @@
           "minimum": 1,
           "description": "File-count hard ceiling: a Story exceeding it is rejected unless it declares `wide` with a reason (default 30)."
         },
-        "maxAcceptance": {
-          "type": "integer",
-          "minimum": 1,
-          "description": "Hard ceiling on acceptance[] item count (default 14)."
-        },
         "softAcceptanceCount": {
           "type": "integer",
           "minimum": 1,
-          "description": "Soft-warn threshold on acceptance[] item count (default 10)."
+          "description": "Soft-warn threshold on acceptance[] item count (default 10). Acceptance mass is advisory-only — there is no hard acceptance ceiling."
         },
         "mergeCandidateMaxFiles": {
           "type": "integer",

--- a/.agents/scripts/lib/config-settings-schema.js
+++ b/.agents/scripts/lib/config-settings-schema.js
@@ -250,18 +250,18 @@ const CODEBASE_SNAPSHOT_SCHEMA = {
  * `planning.taskSizing` — Story-sizing thresholds consumed by
  * `ticket-validator-sizing.js`. Operator overrides shallow-merge with
  * `DEFAULT_TASK_SIZING` defaults (softFiles 15, hardFiles 30,
- * maxAcceptance 14, softAcceptanceCount 10 — the uniform relaxed profile
- * from Story #3874). Story #3760 collapsed the per-profile matrix and the
- * parallel `testSurface` axis into a flat set of knobs; the `sizingProfile`
- * enum was replaced by an optional body-level `wide` declaration that lifts
- * the `hardFiles` rejection.
+ * softAcceptanceCount 10 — the uniform relaxed profile from Story #3874).
+ * Story #3760 collapsed the per-profile matrix and the parallel
+ * `testSurface` axis into a flat set of knobs; the `sizingProfile` enum was
+ * replaced by an optional body-level `wide` declaration that lifts the
+ * `hardFiles` rejection. The hard `maxAcceptance` ceiling was removed after
+ * the Epic #4355 decomposition experiment — acceptance mass is advisory-only.
  */
 const TASK_SIZING_SCHEMA = {
   type: 'object',
   properties: {
     softFiles: { type: 'integer', minimum: 1 },
     hardFiles: { type: 'integer', minimum: 1 },
-    maxAcceptance: { type: 'integer', minimum: 1 },
     softAcceptanceCount: { type: 'integer', minimum: 1 },
     // Under-size (merge-candidate) thresholds (Story #4312). A Story whose
     // footprint is at or below BOTH ceilings and that carries a `depends_on`

--- a/.agents/scripts/lib/config/explain.js
+++ b/.agents/scripts/lib/config/explain.js
@@ -126,10 +126,8 @@ const KEY_MEANINGS = Object.freeze({
     'How many recent commits the snapshot summarizes.',
   'planning.riskHeuristics':
     'Phrases that flag a Story as high-risk for HITL escalation.',
-  'planning.taskSizing.maxAcceptance':
-    'Hard ceiling on acceptance criteria per Story.',
   'planning.taskSizing.softAcceptanceCount':
-    'Acceptance-criteria count above which a Story is flagged as large.',
+    'Acceptance-criteria count above which a Story is flagged as large (advisory-only — there is no hard acceptance ceiling).',
   'planning.taskSizing.softFiles':
     'Touched-file count above which a Story is flagged as large.',
   'planning.taskSizing.hardFiles':

--- a/.agents/scripts/lib/orchestration/ticket-validator-sizing.js
+++ b/.agents/scripts/lib/orchestration/ticket-validator-sizing.js
@@ -17,10 +17,12 @@
  * `.agents/scripts/lib/config-settings-schema.js`.
  *
  * Sizing model (Story #3760 — profile-matrix collapse; Story #3874 — one
- * uniform relaxed profile):
- *   - Flat knobs: `softFiles` (~15), `hardFiles` (~30), `maxAcceptance` (~14),
+ * uniform relaxed profile; the hard acceptance ceiling was removed after the
+ * Epic #4355 decomposition experiment showed it forced fragmentation):
+ *   - Flat knobs: `softFiles` (~15), `hardFiles` (~30),
  *     `softAcceptanceCount` (~10). No per-profile ceiling map, no parallel
- *     `testSurface` axis, no selector and no second profile.
+ *     `testSurface` axis, no selector and no second profile. Acceptance
+ *     mass is advisory-only.
  *   - The four-profile `sizingProfile` enum is replaced by a single optional
  *     `wide` declaration carrying a one-line human-readable reason. Declaring
  *     `wide` with a reason lifts the `hardFiles` rejection; no Story is
@@ -119,9 +121,12 @@ export const DEFAULT_TASK_SIZING = Object.freeze({
   // The hard `hardFiles` rejection (30) is unchanged.
   softFiles: 15,
   softAcceptanceCount: 10,
-  // Hard ceilings (rejection unless lifted).
+  // Hard ceiling (rejection unless lifted via `wide`). Acceptance mass has
+  // no hard ceiling: the former `maxAcceptance` rejection forced careful,
+  // fine-grained specs to fragment one coherent capability into dependent
+  // slices (observed on Epic #4355), so it was removed — the delivery-
+  // schedule simulation in the decomposer prompt owns that judgment now.
   hardFiles: 30,
-  maxAcceptance: 14,
   // Under-size (merge-candidate) thresholds (Story #4312). A Story with a
   // footprint at or below BOTH ceilings that also carries at least one
   // `depends_on` edge to a sibling looks like a dependent fragment rather than
@@ -528,17 +533,13 @@ function computeStorySizingFindings(story, sizing) {
     ),
   );
 
-  // Acceptance ceiling + soft warn.
-  if (acceptance.length > sizing.maxAcceptance) {
-    out.push(
-      makeOversized(
-        story.slug,
-        'acceptance',
-        acceptance.length,
-        sizing.maxAcceptance,
-      ),
-    );
-  } else if (acceptance.length > sizing.softAcceptanceCount) {
+  // Acceptance mass is advisory-only (Story #4312's under-size heuristic is
+  // the merge signal; the former hard `maxAcceptance` rejection is removed).
+  // A long binding contract is a re-check-cohesion nudge, never by itself a
+  // decomposition error — cohesion and the delivery envelope govern Story
+  // size, and the delivery-schedule simulation in the decomposer prompt owns
+  // the fragmentation/consolidation judgment.
+  if (acceptance.length > sizing.softAcceptanceCount) {
     out.push(
       makeSoftWidth(
         story.slug,

--- a/.agents/scripts/lib/templates/decomposer-prompts.js
+++ b/.agents/scripts/lib/templates/decomposer-prompts.js
@@ -50,8 +50,7 @@ export function renderDecomposerSystemPrompt({
 function render2TierPrompt({ maxTickets, maxTokenBudget, epicId = null }) {
   // Sizing thresholds are sourced from the single DEFAULT_TASK_SIZING constant
   // (ticket-validator-sizing.js) so the prompt and the validator cannot drift.
-  const { softFiles, hardFiles, maxAcceptance, softAcceptanceCount } =
-    DEFAULT_TASK_SIZING;
+  const { softFiles, hardFiles, softAcceptanceCount } = DEFAULT_TASK_SIZING;
   // Deliverable-granularity definition + single-consumer merge rule + the
   // soft envelope-floor heuristic are sourced from the single
   // DELIVERABLE_GRANULARITY_GUIDANCE constant (ticket-validator-sizing.js) so
@@ -177,7 +176,22 @@ ${envelopeFloor}
 
 - A Story touching more than **${softFiles} files** (\`softFiles\`) emits an advisory width finding — a nudge to check cohesion or declare \`wide\`.
 - A Story touching more than **${hardFiles} files** (\`hardFiles\`) is **rejected** unless it declares \`wide\` with a reason.
-- A Story with more than **${maxAcceptance} acceptance items** (\`maxAcceptance\`) is **rejected**; more than ${softAcceptanceCount} (\`softAcceptanceCount\`) emits an advisory warning.
+- Acceptance mass is **advisory only**: more than **${softAcceptanceCount} acceptance items** (\`softAcceptanceCount\`) emits an advisory warning. There is NO hard acceptance ceiling — a long binding contract is a signal to re-check cohesion, never a reason to fragment one coherent capability into dependent slices.
+
+#### DELIVERY-SCHEDULE SIMULATION — the story count must earn itself:
+
+Before emitting, simulate the delivery schedule your plan implies, and judge the plan by its schedule — not by how tidy the taxonomy looks:
+
+1. **Build the wave schedule.** A Story runs only after every \`depends_on\` completes, and two Stories that name the same file in \`changes[]\` cannot run in the same wave (the scheduler serializes file-overlapping Stories even when no \`depends_on\` edge links them).
+2. **Compute the parallelism yield**: story count ÷ critical-path length in waves. A yield near 1.0 means the plan is a serial chain — N Stories that deliver no faster than one Story while paying N delivery sessions (hydration, branch, PR, review, CI).
+3. **Every Story must earn its slot** by at least one of:
+   - **(a) parallelism** — it actually runs concurrently with a sibling in the schedule you just built ("logically independent" does not count; *schedule*-independent does);
+   - **(b) risk isolation** — it isolates a consumer-facing behavior change or high-risk cutover into its own reviewable, revertable unit;
+   - **(c) envelope pressure** — merged into its neighbor it would exceed the one-pass delivery envelope (\`maxTokenBudget\`).
+4. **A dependent link with none of those justifications merges into its consumer.** This generalizes the single-consumer merge rule from pairs to chains.
+5. **Hot-file rule.** When one file appears in the \`changes[]\` of more than a third of your Stories, the slicing axis cuts across a shared seam — merge the Stories that co-edit it, or re-slice along the seam so each Story owns its files.
+
+End each Story's \`reason_to_exist\` with its justification letter and one clause, e.g. "… (a: runs in wave 1 alongside <slug>)" or "(b: isolates the auto-merge default change)". A reason that names only a topic ("config work", "docs") with no justification is a merge signal.
 
 #### \`wide\` DECLARATION (optional — for legitimately broad changes):
 

--- a/.agents/skills/core/epic-plan-decompose-author/SKILL.md
+++ b/.agents/skills/core/epic-plan-decompose-author/SKILL.md
@@ -238,7 +238,38 @@ The envelope also has a **floor**, not just a ceiling: a Story that would plausi
 
 - A Story touching more than **`softFiles` (15)** files emits an advisory width finding — a nudge to check cohesion or declare `wide`.
 - A Story touching more than **`hardFiles` (30)** files is **rejected** unless it declares `wide` with a reason.
-- A Story with more than **`maxAcceptance` (14)** acceptance items is **rejected**; more than **`softAcceptanceCount` (10)** emits an advisory warning.
+- Acceptance mass is **advisory only**: more than **`softAcceptanceCount` (10)** acceptance items emits an advisory warning. There is NO hard acceptance ceiling — a long binding contract is a signal to re-check cohesion, never a reason to fragment one coherent capability into dependent slices.
+
+#### DELIVERY-SCHEDULE SIMULATION (the story count must earn itself)
+
+Before emitting, simulate the delivery schedule the plan implies and judge the
+plan by its schedule, not by how tidy the taxonomy looks. The canonical rules
+live in the rendered decomposer prompt (`decomposer-prompts.js`) — in brief:
+
+1. **Build the wave schedule.** A Story runs only after every `depends_on`
+   completes, and two Stories that name the same file in `changes[]` cannot
+   run in the same wave (the scheduler serializes file-overlapping Stories
+   even when no `depends_on` edge links them).
+2. **Compute the parallelism yield** — story count ÷ critical-path length in
+   waves. A yield near 1.0 means the plan is a serial chain: N Stories that
+   deliver no faster than one Story while paying N delivery sessions.
+3. **Every Story must earn its slot** by at least one of **(a) parallelism**
+   (it runs concurrently with a sibling in the schedule just built — not
+   merely "logically independent"), **(b) risk isolation** (it isolates a
+   consumer-facing behavior change or high-risk cutover into its own
+   reviewable, revertable unit), or **(c) envelope pressure** (merged into its
+   neighbor it would exceed the one-pass delivery envelope).
+4. **A dependent link with none of those justifications merges into its
+   consumer** — the single-consumer merge rule generalized from pairs to
+   chains.
+5. **Hot-file rule.** When one file appears in the `changes[]` of more than a
+   third of the Stories, the slicing axis cuts across a shared seam — merge
+   the Stories that co-edit it, or re-slice along the seam.
+
+End each Story's `reason_to_exist` with its justification letter and one
+clause, e.g. "… (a: runs in wave 1 alongside <slug>)" or "(b: isolates the
+auto-merge default change)". A reason that names only a topic ("config work",
+"docs") with no justification is a merge signal.
 
 #### DELIVERY SLICING (consume the Tech Spec target grouping when present)
 

--- a/.agents/skills/core/scope-triage/SKILL.md
+++ b/.agents/skills/core/scope-triage/SKILL.md
@@ -50,10 +50,11 @@ The work is a single shippable capability. Signals:
 - **One capability, one reason to exist.** The artifact describes one coherent
   change a reviewer would accept as a single PR — the
   `DELIVERABLE_GRANULARITY_GUIDANCE.definition` notion of a Story.
-- **Acceptance fits one Story.** The acceptance-criteria list plausibly fits a
-  single Story's inline `acceptance[]` — i.e. it sits under the
-  `maxAcceptance` ceiling in `DEFAULT_TASK_SIZING` rather than spanning many
-  independent outcomes.
+- **Acceptance fits one Story.** The acceptance-criteria list reads as the
+  binding contract of one coherent capability rather than spanning many
+  independent outcomes. Acceptance mass is advisory-only (the
+  `softAcceptanceCount` nudge in `DEFAULT_TASK_SIZING` — there is no hard
+  ceiling), so the question is cohesion, not count.
 - **Footprint fits Story sizing.** The plausible file footprint fits the Story
   width described by `DEFAULT_TASK_SIZING` (the `softFiles` / `hardFiles`
   knobs); a legitimately broad-but-cohesive change would declare `wide` rather

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -150,8 +150,10 @@ guardrails and Part 3 and are recorded here as the current baseline:
 - **One uniform sizing profile — sizing decoupled from risk.** Every Epic, at
   any risk level, plans under one relaxed `DEFAULT_TASK_SIZING`
   ([`ticket-validator-sizing.js`](../.agents/scripts/lib/orchestration/ticket-validator-sizing.js)):
-  `softFiles: 15`, `hardFiles: 30`, `softAcceptanceCount: 10`,
-  `maxAcceptance: 14`. There is **no** per-Feature fan-out cap — the Feature
+  `softFiles: 15`, `hardFiles: 30`, `softAcceptanceCount: 10` (acceptance
+  mass is advisory-only — the hard `maxAcceptance` ceiling was removed after
+  the Epic #4355 decomposition experiment). There is **no** per-Feature
+  fan-out cap — the Feature
   tier itself was removed by the 2-tier hard cutover (Story #4041). `wide`
   (with a reason) is the only beyond-ceiling path. Story size measures uniform
   delivery capacity; risk routes *rigor*, not scope.

--- a/tests/config-schema-mirror-drift.test.js
+++ b/tests/config-schema-mirror-drift.test.js
@@ -400,7 +400,6 @@ describe('agentrc.schema.json mirror — drift vs runtime AJV schema', () => {
           taskSizing: {
             softFiles: 6,
             hardFiles: 18,
-            maxAcceptance: 10,
             softAcceptanceCount: 6,
           },
         },

--- a/tests/config-settings-schema.test.js
+++ b/tests/config-settings-schema.test.js
@@ -230,12 +230,26 @@ describe('planning.* shape', () => {
           taskSizing: {
             softFiles: 5,
             hardFiles: 15,
-            maxAcceptance: 8,
             softAcceptanceCount: 6,
           },
         },
       }),
       true,
+    );
+  });
+
+  it('rejects the removed maxAcceptance knob — acceptance mass is advisory-only', () => {
+    // The hard acceptance ceiling was removed after the Epic #4355
+    // decomposition experiment; `additionalProperties: false` on the
+    // taskSizing block now rejects the retired key.
+    expectErrors(
+      {
+        ...REQ,
+        planning: {
+          taskSizing: { maxAcceptance: 14 },
+        },
+      },
+      /additional propert/i,
     );
   });
 

--- a/tests/fixtures/sizing-ab/plan.new.json
+++ b/tests/fixtures/sizing-ab/plan.new.json
@@ -1,7 +1,7 @@
 {
   "profile": "new",
-  "epic": "#3865 — model-evolution recalibration (A/B fixture)",
-  "note": "The decomposition the NEW sizing profile (hardFiles=30, softFiles=15, maxAcceptance=14, softAcceptanceCount=10) accepts. Each wide capability is one Story; two of them exceed the OLD hardFiles=15 ceiling, so the old profile could not have accepted this slicing. The union of all changes[] paths equals plan.old.json (profiles.totalFiles=58).",
+  "epic": "#3865 \u2014 model-evolution recalibration (A/B fixture)",
+  "note": "The decomposition the NEW sizing profile (hardFiles=30, softFiles=15, softAcceptanceCount=10; acceptance mass advisory-only) accepts. Each wide capability is one Story; two of them exceed the OLD hardFiles=15 ceiling, so the old profile could not have accepted this slicing. The union of all changes[] paths equals plan.old.json (profiles.totalFiles=58).",
   "stories": [
     {
       "slug": "n1",
@@ -9,7 +9,7 @@
       "title": "Relax sizing constants and thread them through every SSOT surface",
       "body": {
         "acceptance": [
-          "DEFAULT_TASK_SIZING carries the relaxed profile (softFiles 15, hardFiles 30, maxAcceptance 14)",
+          "DEFAULT_TASK_SIZING carries the relaxed profile (softFiles 15, hardFiles 30; acceptance mass advisory-only)",
           "SOFT_STORIES_PER_FEATURE is 7 and rendered into the decomposer prompt",
           "agentrc schema + JS mirror match the relaxed constants",
           "the ticket-decomposer prompt test asserts the relaxed threshold sentence",

--- a/tests/fixtures/sizing-ab/profiles.json
+++ b/tests/fixtures/sizing-ab/profiles.json
@@ -11,7 +11,6 @@
     "softFiles": 15,
     "softAcceptanceCount": 10,
     "hardFiles": 30,
-    "maxAcceptance": 14,
     "softStoriesPerFeature": 7
   },
   "totalFiles": 58

--- a/tests/lib/orchestration/ticket-validator-sizing.test.js
+++ b/tests/lib/orchestration/ticket-validator-sizing.test.js
@@ -12,15 +12,17 @@ import { serialize as serializeStoryBody } from '../../../.agents/scripts/lib/st
  * are gone. The model is now:
  *
  *   - Flat knobs (DEFAULT_TASK_SIZING): softFiles=15, hardFiles=30,
- *     maxAcceptance=14, softAcceptanceCount=10.
+ *     softAcceptanceCount=10. The former hard `maxAcceptance` ceiling was
+ *     removed (Epic #4355 decomposition experiment) — acceptance mass is
+ *     advisory-only.
  *   - A single optional `body.wide = { reason }` declaration. Declaring `wide`
  *     with a non-empty reason lifts the hardFiles rejection — no Story is
  *     rejected for width when `wide` is declared.
  *   - Cohesion is the primary heuristic; the numeric ceiling is a backstop.
  *
  * Findings:
- *   - oversized-task (hard) — acceptance > maxAcceptance, or fileCount >
- *     hardFiles when `wide` is not declared.
+ *   - oversized-task (hard) — fileCount > hardFiles when `wide` is not
+ *     declared.
  *   - soft-task-width (soft) — acceptance > softAcceptanceCount, or fileCount >
  *     softFiles (when `wide` IS declared — declared-wide Stories still surface
  *     the width as advisory signal).
@@ -110,13 +112,13 @@ test('narrow Story with no wide declaration produces no findings', () => {
 });
 
 // ---------------------------------------------------------------------------
-// Acceptance ceiling — maxAcceptance=14, softAcceptanceCount=10
+// Acceptance mass — advisory-only (softAcceptanceCount=10; no hard ceiling)
 // ---------------------------------------------------------------------------
 
-test('Story with 14 acceptance items validates clean (maxAcceptance=14)', () => {
+test('Story with 10 acceptance items (at softAcceptanceCount) validates clean', () => {
   const result = validateStory(
-    makeStory('t-14ac', {
-      acceptance: Array.from({ length: 14 }, (_, i) => `criterion ${i}`),
+    makeStory('t-10ac', {
+      acceptance: Array.from({ length: 10 }, (_, i) => `criterion ${i}`),
     }),
   );
   const hard = result.findings.filter((f) => f.severity === 'hard');
@@ -124,22 +126,27 @@ test('Story with 14 acceptance items validates clean (maxAcceptance=14)', () => 
   assert.deepEqual(result.errors, []);
 });
 
-test('Story with 15 acceptance items trips hard oversized-task (ceiling=14)', () => {
+test('Story with 20 acceptance items emits only the soft advisory — no hard finding at any acceptance count', () => {
+  // The former hard maxAcceptance ceiling forced careful, fine-grained specs
+  // to fragment one coherent capability into dependent slices (observed on
+  // Epic #4355), so it was removed. A long binding contract is advisory
+  // signal, never a rejection.
   const result = validateStory(
-    makeStory('t-15ac', {
-      acceptance: Array.from({ length: 15 }, (_, i) => `criterion ${i}`),
+    makeStory('t-20ac', {
+      acceptance: Array.from({ length: 20 }, (_, i) => `criterion ${i}`),
     }),
   );
   const hard = result.findings.filter(
     (f) => f.kind === 'oversized-task' && f.field === 'acceptance',
   );
-  assert.equal(hard.length, 1);
-  assert.equal(hard[0].observed, 15);
-  assert.equal(hard[0].ceiling, 14);
-  assert.equal(
-    result.errors.filter((e) => e.includes('acceptance ceiling')).length,
-    1,
+  assert.deepEqual(hard, []);
+  assert.deepEqual(result.errors, []);
+  const soft = result.findings.filter(
+    (f) => f.kind === 'soft-task-width' && f.field === 'acceptance',
   );
+  assert.equal(soft.length, 1);
+  assert.equal(soft[0].observed, 20);
+  assert.equal(soft[0].soft, 10);
 });
 
 test('Story with 11 acceptance items emits soft-task-width on acceptance field', () => {
@@ -160,7 +167,7 @@ test('Story with 11 acceptance items emits soft-task-width on acceptance field',
   assert.equal(soft[0].soft, 10);
 });
 
-test('wide lifts only the file ceiling — 15 acceptance items still hard-reject with wide declared', () => {
+test('wide is orthogonal to acceptance mass — 15 acceptance items with wide declared stay advisory-only', () => {
   const result = validateStory(
     makeStory('t-15ac-wide', {
       acceptance: Array.from({ length: 15 }, (_, i) => `criterion ${i}`),
@@ -170,13 +177,12 @@ test('wide lifts only the file ceiling — 15 acceptance items still hard-reject
   const hard = result.findings.filter(
     (f) => f.kind === 'oversized-task' && f.field === 'acceptance',
   );
-  assert.equal(hard.length, 1);
-  assert.equal(hard[0].observed, 15);
-  assert.equal(hard[0].ceiling, 14);
-  assert.equal(
-    result.errors.filter((e) => e.includes('acceptance ceiling')).length,
-    1,
+  assert.deepEqual(hard, []);
+  const soft = result.findings.filter(
+    (f) => f.kind === 'soft-task-width' && f.field === 'acceptance',
   );
+  assert.equal(soft.length, 1);
+  assert.equal(soft[0].observed, 15);
 });
 
 // ---------------------------------------------------------------------------
@@ -390,8 +396,8 @@ test('rejects a Story that lacks an inline acceptance + verify contract', () => 
 //
 // The decomposer mandates `body` as a serialized markdown string, but the
 // sizing layers historically read `story.body` only when it was already an
-// object — so on the production string shape `hardFiles`, `maxAcceptance`,
-// and the `unanchored-constant` nudge all emitted nothing. These fixtures
+// object — so on the production string shape `hardFiles`, the acceptance
+// advisory, and the `unanchored-constant` nudge all emitted nothing. These fixtures
 // exercise the canonical string shape at parity with the object-body cases
 // above. The freshness gate already string-aware via parseStoryBody;
 // `computeStorySizingFindings` now mirrors that.
@@ -449,7 +455,7 @@ test('string body: >hardFiles distinct changes paths trips hard oversized-task o
   );
 });
 
-test('string body: >maxAcceptance acceptance items trips hard oversized-task on acceptance', () => {
+test('string body: >softAcceptanceCount acceptance items emits the soft advisory, never a hard finding', () => {
   const result = validateStory(
     makeStringStory('t-str-15ac', {
       acceptance: Array.from({ length: 15 }, (_, i) => `criterion ${i}`),
@@ -458,13 +464,17 @@ test('string body: >maxAcceptance acceptance items trips hard oversized-task on 
   const hard = result.findings.filter(
     (f) => f.kind === 'oversized-task' && f.field === 'acceptance',
   );
-  assert.equal(
-    hard.length,
-    1,
-    'expected the acceptance hard finding on a string body',
+  assert.deepEqual(hard, [], 'acceptance mass must never hard-reject');
+  const soft = result.findings.filter(
+    (f) => f.kind === 'soft-task-width' && f.field === 'acceptance',
   );
-  assert.equal(hard[0].observed, 15);
-  assert.equal(hard[0].ceiling, 14);
+  assert.equal(
+    soft.length,
+    1,
+    'expected the acceptance soft advisory on a string body',
+  );
+  assert.equal(soft[0].observed, 15);
+  assert.equal(soft[0].soft, 10);
 });
 
 test('string body: unanchored-constant fires identically to the object case', () => {
@@ -494,10 +504,10 @@ test('string body: a declared wide reason lifts the hard file ceiling', () => {
   assert.equal(soft[0].observed, 31);
 });
 
-test('acceptance ceiling reads the authoritative top-level story.acceptance, not body.acceptance', () => {
-  // Top-level acceptance carries 15 items (> ceiling 14); the structured
-  // body's acceptance carries only 2. The ceiling MUST read the top-level
-  // binding contract regardless of what the body says.
+test('acceptance advisory reads the authoritative top-level story.acceptance, not body.acceptance', () => {
+  // Top-level acceptance carries 15 items (> softAcceptanceCount 10); the
+  // structured body's acceptance carries only 2. The advisory MUST read the
+  // top-level binding contract regardless of what the body says.
   const result = validateStory({
     type: 'story',
     slug: 't-toplevel-ac',
@@ -511,11 +521,11 @@ test('acceptance ceiling reads the authoritative top-level story.acceptance, not
       verify: ['npm test (unit)'],
     },
   });
-  const hard = result.findings.filter(
-    (f) => f.kind === 'oversized-task' && f.field === 'acceptance',
+  const soft = result.findings.filter(
+    (f) => f.kind === 'soft-task-width' && f.field === 'acceptance',
   );
-  assert.equal(hard.length, 1);
-  assert.equal(hard[0].observed, 15);
+  assert.equal(soft.length, 1);
+  assert.equal(soft[0].observed, 15);
 });
 
 // ---------------------------------------------------------------------------

--- a/tests/sizing-ab-calibration.test.js
+++ b/tests/sizing-ab-calibration.test.js
@@ -147,6 +147,10 @@ describe('sizing A/B re-plan calibration (Story #3877)', () => {
       DEFAULT_TASK_SIZING.softAcceptanceCount,
     );
     assert.equal(profiles.new.hardFiles, DEFAULT_TASK_SIZING.hardFiles);
-    assert.equal(profiles.new.maxAcceptance, DEFAULT_TASK_SIZING.maxAcceptance);
+    // The hard maxAcceptance ceiling was removed (acceptance mass is
+    // advisory-only) — neither the live constant nor the recorded new
+    // profile carries it.
+    assert.equal(profiles.new.maxAcceptance, undefined);
+    assert.equal(DEFAULT_TASK_SIZING.maxAcceptance, undefined);
   });
 });

--- a/tests/skills/epic-plan-decompose-author.test.js
+++ b/tests/skills/epic-plan-decompose-author.test.js
@@ -98,9 +98,9 @@ describe('skill:epic-plan-decompose-author — smoke', () => {
         }
         // Story #2798 — the maxTickets section MUST not call the budget a
         // "hard cap" or "hard ceiling". The unrelated task-sizing
-        // validator phrasing ("validator's hard ceilings (default
-        // maxAcceptance ...") stays legitimate, so the check is scoped
-        // to lines that mention maxTickets in the same sentence.
+        // validator phrasing (the hardFiles ceiling) stays legitimate, so
+        // the check is scoped to lines that mention maxTickets in the same
+        // sentence.
         const maxTicketsLines = body
           .split('\n')
           .filter((l) => /maxTickets/.test(l));
@@ -112,12 +112,24 @@ describe('skill:epic-plan-decompose-author — smoke', () => {
           }
         }
         // Story #3760 — sizing thresholds have exactly one definition
-        // (DEFAULT_TASK_SIZING). The Skill body must advertise the relaxed
-        // ceilings (maxAcceptance=14, hardFiles=30 — Story #3874) and name
-        // the single constant.
-        if (!(/maxAcceptance/.test(body) && /\b14\b/.test(body))) {
+        // (DEFAULT_TASK_SIZING). The Skill body must advertise the remaining
+        // hard ceiling (hardFiles=30 — Story #3874), state that acceptance
+        // mass is advisory-only (the hard maxAcceptance ceiling was removed
+        // after the Epic #4355 decomposition experiment), and name the
+        // single constant.
+        if (/maxAcceptance/.test(body)) {
           errors.push(
-            'Skill body must advertise the maxAcceptance ceiling of 14 (Story #3874)',
+            'Skill body must not reference the removed maxAcceptance ceiling',
+          );
+        }
+        if (!/advisory only/i.test(body)) {
+          errors.push(
+            'Skill body must state that acceptance mass is advisory-only',
+          );
+        }
+        if (!/DELIVERY-SCHEDULE SIMULATION/i.test(body)) {
+          errors.push(
+            'Skill body must mirror the delivery-schedule simulation section',
           );
         }
         if (!(/hardFiles/.test(body) && /\b30\b/.test(body))) {

--- a/tests/ticket-decomposer.test.js
+++ b/tests/ticket-decomposer.test.js
@@ -353,18 +353,43 @@ describe('ticket-decomposer buildDecomposerSystemPrompt', () => {
     );
   });
 
-  it('advertises the maxAcceptance and hardFiles ceilings from the single sizing constant (Story #3760, relaxed by Story #3874)', () => {
+  it('advertises the hardFiles ceiling and advisory-only acceptance mass from the single sizing constant (Story #3760, relaxed by Story #3874; hard acceptance ceiling removed)', () => {
     // The prompt sources its threshold sentence from DEFAULT_TASK_SIZING so
-    // the two surfaces cannot drift. The relaxed default ceilings are
-    // maxAcceptance=14 and hardFiles=30.
+    // the two surfaces cannot drift. The only remaining hard ceiling is
+    // hardFiles=30; acceptance mass is advisory-only (softAcceptanceCount=10).
     const prompt = buildDecomposerSystemPrompt([]);
     assert.ok(
-      /maxAcceptance/.test(prompt) && /\b14\b/.test(prompt),
-      'prompt must advertise the maxAcceptance ceiling of 14',
+      !/maxAcceptance/.test(prompt),
+      'prompt must not reference the removed maxAcceptance ceiling',
+    );
+    assert.ok(
+      /Acceptance mass is \*\*advisory only\*\*/.test(prompt) &&
+        /NO hard acceptance ceiling/.test(prompt),
+      'prompt must state that acceptance mass is advisory-only with no hard ceiling',
     );
     assert.ok(
       /hardFiles/.test(prompt) && /\b30\b/.test(prompt),
       'prompt must advertise the hardFiles ceiling of 30',
+    );
+  });
+
+  it('carries the delivery-schedule simulation section (story count must earn itself)', () => {
+    const prompt = buildDecomposerSystemPrompt([]);
+    assert.ok(
+      /DELIVERY-SCHEDULE SIMULATION/.test(prompt),
+      'prompt must carry the delivery-schedule simulation section',
+    );
+    assert.ok(
+      /parallelism yield/i.test(prompt),
+      'prompt must ask the author to compute the parallelism yield',
+    );
+    assert.ok(
+      /Hot-file rule/.test(prompt),
+      'prompt must state the hot-file re-slicing rule',
+    );
+    assert.ok(
+      /risk isolation/.test(prompt) && /envelope pressure/.test(prompt),
+      'prompt must enumerate the per-Story slot justifications',
     );
   });
 


### PR DESCRIPTION
## Why

A planning deep-dive on Epic #4355 showed the decomposition machinery working against delivery effectiveness in two ways:

1. **The hard `maxAcceptance` (14) ceiling forced fragmentation.** Careful, fine-grained specs grow acceptance mass with merged capability, so the ceiling structurally prevented consolidating one coherent capability — the merge math kept colliding with it while `hardFiles` has a `wide` escape and acceptance had none.
2. **Nothing judged the plan by its schedule.** Slices the Tech Spec called *independent* serialized anyway through shared hot files (`deliver-epic.md` appeared in 4 of 6 Stories), yielding a 6-Story / 5-wave near-serial chain that paid 6 delivery sessions for ~zero parallelism.

## What

- **Remove the hard acceptance rejection and the `maxAcceptance` knob entirely** (hard cutover per `git-conventions.md`: runtime AJV + published schema + `agentrc-reference.json` + `explain.js` + generated `configuration.md` + SKILL prose + roadmap). Acceptance mass stays advisory via `softAcceptanceCount` (10). A consumer setting `planning.taskSizing.maxAcceptance` now gets a schema rejection at upgrade time.
- **Add a `DELIVERY-SCHEDULE SIMULATION` section to the decomposer prompt** (single-sourced in `decomposer-prompts.js`, mirrored in the `epic-plan-decompose-author` SKILL): build the actual wave schedule (`depends_on` + file-overlap serialization), compute parallelism yield, and require every Story to earn its slot via **(a)** schedule-parallelism, **(b)** risk isolation, or **(c)** envelope pressure — with the justification letter recorded in `reason_to_exist` so the consolidate critic can check it, plus a hot-file re-slicing rule.

## Evidence

Real-world A/B on Epic #4355 (throwaway clone #4362; test Stories #4363–#4365, closed as not planned):

| | delivered plan | re-decomposed under this change |
|---|---|---|
| Stories | 6 | 3 |
| Waves | 5 | 2 |
| Parallelism yield | 1.2 | 1.5 |

Identical acceptance/verify scope conserved. The merged `ci-feedback-loop` Story (14 files, 20 acceptance) is **hard-rejected** by the pre-change validator and passes advisory-clean after it. The 3-ticket set was validated end-to-end: `validateTickets` → reconciler persist → `epic-plan-healthcheck --paranoid`, all green.

## Verification

- `npm run lint` ✅ (docs drift gate clean after `docs:gen`)
- `npm test` ✅ 9606 tests, 0 fail
- `node .agents/scripts/check-baselines.js` ✅ exit 0
- `npx biome ci` on every touched JS file ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)