### PR TITLE
feat(delivery): honor delivery.ci.autoMerge policy in standalone Story close

### DIFF
--- a/.agents/scripts/lib/orchestration/single-story-close/phases/auto-merge.js
+++ b/.agents/scripts/lib/orchestration/single-story-close/phases/auto-merge.js
@@ -139,6 +139,7 @@ function makeDefaultGhAutoMergeRunner(gh) {
  *   prNumber: number|null,
  *   prUrl: string,
  *   noAutoMerge: boolean,
+ *   autoMergePolicy?: 'trust-ci'|'strict',
  *   gh?: ReturnType<typeof import('../../../gh-exec.js').createGh>,
  *   progress: (tag: string, msg: string) => void,
  * }} args
@@ -149,12 +150,30 @@ export async function runAutoMergePhase({
   prNumber,
   prUrl,
   noAutoMerge,
+  autoMergePolicy = 'trust-ci',
   gh,
   progress,
 }) {
   if (noAutoMerge) {
     progress('PR', '⏭  Auto-merge disabled (--no-auto-merge).');
     return { autoMergeEnabled: false, autoMergeReason: 'disabled-by-flag' };
+  }
+  // `delivery.ci.autoMerge: "strict"` opts standalone Stories out of
+  // auto-merge (parallel to the Epic path's strict predicate): the PR opens
+  // and waits for an operator merge instead of arming native auto-merge.
+  // The default `"trust-ci"` keeps arming on green required CI — GitHub's
+  // native `--auto` is the required-check gate, so no client-side predicate
+  // is needed here (unlike the Epic path, which gates on local
+  // audit/review/retro signals a standalone Story does not produce).
+  if (autoMergePolicy === 'strict') {
+    progress(
+      'PR',
+      '⏭  Auto-merge skipped (delivery.ci.autoMerge="strict") — operator merges.',
+    );
+    return {
+      autoMergeEnabled: false,
+      autoMergeReason: 'disabled-by-policy-strict',
+    };
   }
   if (prNumber == null) {
     progress(

--- a/.agents/scripts/lib/orchestration/single-story-close/runner.js
+++ b/.agents/scripts/lib/orchestration/single-story-close/runner.js
@@ -2,6 +2,7 @@ import nodeFs from 'node:fs';
 import path from 'node:path';
 import { buildDefaultGates } from '../../close-validation/gates.js';
 import { runCloseValidation } from '../../close-validation/runner.js';
+import { getCiDelivery } from '../../config/ci.js';
 import { resolveConfig } from '../../config-resolver.js';
 import { getStoryBranch, gitSync } from '../../git-utils.js';
 import { Logger } from '../../Logger.js';
@@ -316,6 +317,7 @@ export async function runSingleStoryClose({
     prNumber,
     prUrl,
     noAutoMerge: options.noAutoMerge,
+    autoMergePolicy: getCiDelivery(config).autoMerge,
     gh: injectedGh,
     progress,
   });

--- a/.agents/workflows/helpers/single-story-deliver.md
+++ b/.agents/workflows/helpers/single-story-deliver.md
@@ -223,9 +223,22 @@ The script runs the close-validation gates against `baseBranch`, syncs the
 Story branch from `origin/<baseBranch>` (Story #2580 — the parallel-race
 defence), pushes `story-<id>`, opens (or reuses) a PR against `baseBranch`
 with a `Closes #<storyId>` footer, enables GitHub native auto-merge
-(`--auto --squash --delete-branch`), flips the Story to **`agent::closing`**
+(`--auto --squash --delete-branch`) **when `delivery.ci.autoMerge` is
+`"trust-ci"` (the default)**, flips the Story to **`agent::closing`**
 (NOT `agent::done` — the issue stays OPEN until Step 5 confirms the merge,
 Story #3385), reaps the worktree, and releases the Story lease.
+
+> **`delivery.ci.autoMerge` policy (shared with the Epic path).** The
+> standalone close honours the same config knob the Epic Phase 8.5 gate
+> reads. Under the default `"trust-ci"`, GitHub native auto-merge is armed
+> and the PR squash-merges once its **required** checks pass (GitHub's
+> `--auto` is the required-check gate — no client-side predicate is needed
+> here, unlike the Epic path, because a standalone Story runs no
+> audit/review/retro phase to gate on). Under `"strict"`, the close **does
+> not arm auto-merge** — the PR opens and waits for an **operator merge**,
+> exactly as `--no-auto-merge` does per-run. This lets a consumer who tightens
+> Epic merges with `"strict"` get the same operator-in-the-loop behaviour for
+> standalone Stories.
 
 Flags:
 

--- a/tests/single-story-close-orchestration.test.js
+++ b/tests/single-story-close-orchestration.test.js
@@ -151,6 +151,7 @@ function fakeConfig({
   baseBranch = 'main',
   reapOnSuccess = false,
   worktreeRoot = '.no-such-worktree-root',
+  autoMerge,
 } = {}) {
   return {
     project: { baseBranch, commands: {} },
@@ -160,6 +161,7 @@ function fakeConfig({
         root: worktreeRoot,
         reapOnSuccess,
       },
+      ...(autoMerge ? { ci: { autoMerge } } : {}),
     },
   };
 }
@@ -518,6 +520,46 @@ describe('runSingleStoryClose orchestration', () => {
     assert.equal(result.autoMergeEnabled, false);
     assert.equal(result.autoMergeReason, 'disabled-by-flag');
     assert.match(result.note, /Operator merges via GitHub UI/);
+    assert.equal(ghCalls.length, 2);
+  });
+
+  it('skips auto-merge under delivery.ci.autoMerge="strict" (operator merges)', async (t) => {
+    const ghCalls = [];
+    const gh = makeFakeGh((args) => {
+      ghCalls.push(args.slice());
+      if (args[1] === 'list') return [];
+      if (args[1] === 'create') {
+        return 'https://github.com/owner/repo/pull/77\n';
+      }
+      throw new Error('gh merge must not run under autoMerge=strict');
+    });
+    t.mock.module(GIT_UTILS_URL, defaultGitUtilsMock());
+    mockCloseValidation(t, defaultCloseValidationMock());
+    t.mock.module(WORKTREE_MANAGER_URL, defaultWorktreeManagerMock());
+
+    const { runSingleStoryClose } = await import(`${SUT_URL}?t=strict-policy`);
+    const { result } = await runSingleStoryClose({
+      storyId: 77,
+      cwd: '/repo',
+      skipValidation: true,
+      skipSync: true,
+      // noAutoMerge NOT set — the skip is driven purely by the config policy.
+      injectedProvider: makeFakeProvider({
+        initialStory: {
+          id: 77,
+          state: 'open',
+          title: 'Strict policy',
+          labels: [],
+        },
+      }),
+      injectedConfig: fakeConfig({ autoMerge: 'strict' }),
+      injectedRunCodeReview: noopReview(),
+      injectedGh: gh,
+    });
+
+    assert.equal(result.autoMergeEnabled, false);
+    assert.equal(result.autoMergeReason, 'disabled-by-policy-strict');
+    // The gh merge call is never made — only list + create ran.
     assert.equal(ghCalls.length, 2);
   });
 


### PR DESCRIPTION
## Summary

Follow-up to Epic #4355. Makes standalone Story delivery respect the `delivery.ci.autoMerge` policy the Epic Phase 8.5 gate already reads, closing a consistency gap.

**Finding first:** standalone Stories *already* auto-merge — `single-story-close.js` arms GitHub native auto-merge (`gh pr merge --auto --squash --delete-branch`) at close, gated only by the per-run `--no-auto-merge` flag. What was missing is that it ignored `delivery.ci.autoMerge` entirely, so a consumer who set `"strict"` to tighten Epic merges saw no effect on standalone Stories.

## Change

- `runAutoMergePhase` gains an `autoMergePolicy` param (default `"trust-ci"`). Under `"strict"` it skips arming (`autoMergeReason: "disabled-by-policy-strict"`) so the PR opens and waits for an **operator merge**, exactly like `--no-auto-merge`.
- `runner.js` resolves the policy via `getCiDelivery(config).autoMerge`.
- `single-story-deliver.md` documents the shared policy.
- Test: `single-story-close-orchestration.test.js` asserts a `strict` config skips the `gh merge` call (only list + create run) and reports `disabled-by-policy-strict`.

## Why NOT share the Epic AutomergePredicate

Considered and deliberately rejected. The predicate's inputs — 🔴 critical **code-review** findings, `cleanSprint` **retro** trailer, manual-intervention counts from **epic-run-state** — do not exist in the standalone flow (no Phase 4/5/6). And GitHub native `--auto` already refuses to merge until **required** checks pass server-side, giving the same fail-closed-on-CI guarantee the Epic path's live `gh pr checks --required` probe provides client-side. So the shared surface is the **config knob**, not the predicate code; bolting the predicate on would feed it empty signals that arm anyway under `trust-ci` — dead complexity.

## Behavior

- Default (`trust-ci`): unchanged — standalone auto-merges on green required CI.
- `strict`: standalone no longer arms auto-merge; operator merges via the GitHub UI (parallel to the Epic strict predicate's operator-in-the-loop intent).

## Verification

- `npm test` → 9665 pass / 0 fail
- `npm run lint`, `check-baselines` / `check-arch-cycles` / `check-dead-exports` → all exit 0
- `npx biome ci` on touched JS → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)