### PR TITLE
fix(baselines): repair check-baselines auto-refresh + dedupe FF probes

### DIFF
--- a/.agents/scripts/lib/orchestration/epic-cleanup.js
+++ b/.agents/scripts/lib/orchestration/epic-cleanup.js
@@ -34,6 +34,7 @@ import {
   executeFastForward,
   planFastForward,
 } from './git-cleanup/phases/fast-forward.js';
+import { makeFfProbes } from './git-cleanup/phases/git-probes-ff.js';
 
 const WT_SCRATCH_BRANCH = 'wt-branch';
 
@@ -329,63 +330,6 @@ export function deleteWtBranchIfPresent(opts) {
     `[epic-cleanup] could not delete ${WT_SCRATCH_BRANCH}: ${stderr}`,
   );
   return { deleted: false, present: true, stderr };
-}
-
-/**
- * Build `gitSpawn`-bound probe adapters for the fast-forward phase. The
- * shared `git-probes-ff` wrappers hardcode the module-level `gitSpawn`, so
- * they cannot honour the injected-port test seam every other function in
- * this module uses. These thin adapters replay the same git commands
- * through the injected spawner, letting `fastForwardBaseBranch` REUSE the
- * `planFastForward` / `executeFastForward` pair from the phase library while
- * staying hermetic under unit tests.
- *
- * @param {(cwd: string, ...args: string[]) => { status: number, stdout: string, stderr: string }} gitSpawn
- */
-function makeFfProbes(gitSpawn) {
-  return {
-    isClean: (cwd) => {
-      const r = gitSpawn(cwd, 'status', '--porcelain');
-      return r.status === 0 && String(r.stdout ?? '').trim() === '';
-    },
-    currentBranch: (cwd) => {
-      const r = gitSpawn(cwd, 'symbolic-ref', '--quiet', '--short', 'HEAD');
-      return r.status !== 0 ? null : String(r.stdout ?? '').trim() || null;
-    },
-    fetch: (cwd, remoteName, ref) => {
-      const r = gitSpawn(cwd, 'fetch', '--quiet', remoteName, ref);
-      return r.status === 0 ? { ok: true } : { ok: false, stderr: r.stderr };
-    },
-    canFastForward: (cwd, baseBranch, remoteName) => {
-      const ref = `${remoteName}/${baseBranch}`;
-      const r = gitSpawn(
-        cwd,
-        'rev-list',
-        '--left-right',
-        '--count',
-        `${baseBranch}...${ref}`,
-      );
-      if (r.status !== 0)
-        return { ok: false, behind: 0, reason: 'rev-list-failed' };
-      const [ahead, behind] = String(r.stdout ?? '')
-        .trim()
-        .split(/\s+/);
-      const localAhead = Number(ahead) || 0;
-      const remoteAhead = Number(behind) || 0;
-      if (localAhead > 0) {
-        return { ok: false, behind: remoteAhead, reason: 'not-fast-forward' };
-      }
-      return { ok: true, behind: remoteAhead };
-    },
-    checkout: (cwd, branch) => {
-      const r = gitSpawn(cwd, 'checkout', branch);
-      return r.status === 0 ? { ok: true } : { ok: false, stderr: r.stderr };
-    },
-    merge: (cwd, ref) => {
-      const r = gitSpawn(cwd, 'merge', '--ff-only', ref);
-      return r.status === 0 ? { ok: true } : { ok: false, stderr: r.stderr };
-    },
-  };
 }
 
 /**

--- a/.agents/scripts/lib/orchestration/git-cleanup/phases/git-probes-ff.js
+++ b/.agents/scripts/lib/orchestration/git-cleanup/phases/git-probes-ff.js
@@ -34,53 +34,106 @@ export function isWorktreeLockFailure(stderr) {
 
 /* node:coverage ignore next */
 export function isWorkingTreeClean(cwd) {
-  const res = gitSpawn(cwd, 'status', '--porcelain');
-  if (res.status !== 0) return false;
-  return res.stdout.trim() === '';
+  return defaultFfProbes.isClean(cwd);
 }
 
 /* node:coverage ignore next */
 export function fetchRef(cwd, remoteName, ref) {
-  const res = gitSpawn(cwd, 'fetch', '--quiet', remoteName, ref);
-  if (res.status !== 0) return { ok: false, stderr: res.stderr };
-  return { ok: true };
+  return defaultFfProbes.fetch(cwd, remoteName, ref);
 }
 
 /* node:coverage ignore next */
 export function canFastForward(cwd, baseBranch, remoteName) {
-  const ref = `${remoteName}/${baseBranch}`;
-  const ahead = gitSpawn(
-    cwd,
-    'rev-list',
-    '--left-right',
-    '--count',
-    `${baseBranch}...${ref}`,
-  );
-  if (ahead.status !== 0) {
-    return { ok: false, behind: 0, reason: 'rev-list-failed' };
-  }
-  const parts = ahead.stdout.trim().split(/\s+/);
-  const localAhead = Number(parts[0]) || 0;
-  const remoteAhead = Number(parts[1]) || 0;
-  if (localAhead > 0) {
-    return { ok: false, behind: remoteAhead, reason: 'not-fast-forward' };
-  }
-  return { ok: true, behind: remoteAhead };
+  return defaultFfProbes.canFastForward(cwd, baseBranch, remoteName);
 }
 
 /* node:coverage ignore next */
 export function checkoutBranch(cwd, branch) {
-  const res = gitSpawn(cwd, 'checkout', branch);
-  if (res.status !== 0) return { ok: false, stderr: res.stderr };
-  return { ok: true };
+  return defaultFfProbes.checkout(cwd, branch);
 }
 
 /* node:coverage ignore next */
 export function mergeFastForward(cwd, ref) {
-  const res = gitSpawn(cwd, 'merge', '--ff-only', ref);
-  if (res.status !== 0) return { ok: false, stderr: res.stderr };
-  return { ok: true };
+  return defaultFfProbes.merge(cwd, ref);
 }
+
+/**
+ * Build the fast-forward probe bundle bound to a `gitSpawn`.
+ *
+ * This is the **single implementation** of the FF/base-sync git wrappers.
+ * The standalone exports above delegate to a default instance bound to the
+ * shared `gitSpawn`; callers that need to inject their own spawn for testing
+ * (e.g. the epic-cleanup runner) call this factory directly instead of
+ * hand-rolling a parallel copy (framework-gap #4379). The bundle also carries
+ * `currentBranch` so an injecting caller gets the whole FF surface from one
+ * place.
+ *
+ * @param {(cwd: string, ...args: string[]) => { status: number, stdout: string, stderr: string }} [spawn]
+ * @returns {{
+ *   isClean: (cwd: string) => boolean,
+ *   currentBranch: (cwd: string) => string|null,
+ *   fetch: (cwd: string, remoteName: string, ref: string) => { ok: boolean, stderr?: string },
+ *   canFastForward: (cwd: string, baseBranch: string, remoteName: string) => { ok: boolean, behind: number, reason?: string },
+ *   checkout: (cwd: string, branch: string) => { ok: boolean, stderr?: string },
+ *   merge: (cwd: string, ref: string) => { ok: boolean, stderr?: string },
+ * }}
+ */
+export function makeFfProbes(spawn = gitSpawn) {
+  return {
+    isClean: (cwd) => {
+      const res = spawn(cwd, 'status', '--porcelain');
+      return res.status === 0 && String(res.stdout ?? '').trim() === '';
+    },
+    currentBranch: (cwd) => {
+      const res = spawn(cwd, 'symbolic-ref', '--quiet', '--short', 'HEAD');
+      return res.status !== 0 ? null : String(res.stdout ?? '').trim() || null;
+    },
+    fetch: (cwd, remoteName, ref) => {
+      const res = spawn(cwd, 'fetch', '--quiet', remoteName, ref);
+      return res.status === 0
+        ? { ok: true }
+        : { ok: false, stderr: res.stderr };
+    },
+    canFastForward: (cwd, baseBranch, remoteName) => {
+      const ref = `${remoteName}/${baseBranch}`;
+      const ahead = spawn(
+        cwd,
+        'rev-list',
+        '--left-right',
+        '--count',
+        `${baseBranch}...${ref}`,
+      );
+      if (ahead.status !== 0) {
+        return { ok: false, behind: 0, reason: 'rev-list-failed' };
+      }
+      const parts = String(ahead.stdout ?? '')
+        .trim()
+        .split(/\s+/);
+      const localAhead = Number(parts[0]) || 0;
+      const remoteAhead = Number(parts[1]) || 0;
+      if (localAhead > 0) {
+        return { ok: false, behind: remoteAhead, reason: 'not-fast-forward' };
+      }
+      return { ok: true, behind: remoteAhead };
+    },
+    checkout: (cwd, branch) => {
+      const res = spawn(cwd, 'checkout', branch);
+      return res.status === 0
+        ? { ok: true }
+        : { ok: false, stderr: res.stderr };
+    },
+    merge: (cwd, ref) => {
+      const res = spawn(cwd, 'merge', '--ff-only', ref);
+      return res.status === 0
+        ? { ok: true }
+        : { ok: false, stderr: res.stderr };
+    },
+  };
+}
+
+// Default instance bound to the shared gitSpawn; the standalone wrappers
+// above delegate to it so there is exactly one FF-probe implementation.
+const defaultFfProbes = makeFfProbes(gitSpawn);
 
 /* node:coverage ignore next */
 export function removeWorktree(worktreePath, cwd) {

--- a/.agents/scripts/lib/orchestration/story-close/baseline-attribution/phases/gate-failure.js
+++ b/.agents/scripts/lib/orchestration/story-close/baseline-attribution/phases/gate-failure.js
@@ -47,6 +47,51 @@ export const DEFAULT_GATE_REGISTRY = {
   },
 };
 
+/** Gate names that fan out to per-kind refreshers via `_gateKind` tags. */
+const COMPOSITE_GATE_KINDS = new Set(['check-baselines']);
+
+/**
+ * Resolve the refresh metadata + the regression subset a single failure
+ * cycle should act on.
+ *
+ * A direct per-kind gate (`check-maintainability` / `check-crap`) maps
+ * straight through. The unified `check-baselines` gate is a **composite**:
+ * its projected regressions are tagged with `_gateKind`, and each attribution
+ * cycle picks the first regressed kind not already refreshed this cycle
+ * (`cycleState.refreshedKinds`), scoping classify + refresh to that one kind.
+ * The retry loop re-drives for any remaining kinds — so a close that regresses
+ * both maintainability and CRAP converges in two cycles instead of dead-ending
+ * on an unrecognised gate name (framework-gap #4377).
+ *
+ * @returns {{ meta: object, regressions: Array } | null}
+ */
+export function resolveGateMeta({
+  gateName,
+  regressions,
+  cycleState = null,
+  gateRegistry = DEFAULT_GATE_REGISTRY,
+}) {
+  if (!Array.isArray(regressions) || regressions.length === 0) return null;
+
+  const direct = gateRegistry[gateName];
+  if (direct) return { meta: direct, regressions };
+
+  if (COMPOSITE_GATE_KINDS.has(gateName)) {
+    const refreshed = cycleState?.refreshedKinds ?? new Set();
+    for (const row of regressions) {
+      const kind = row?._gateKind;
+      const subMeta = kind ? gateRegistry[`check-${kind}`] : null;
+      if (subMeta && !refreshed.has(subMeta.kind)) {
+        return {
+          meta: subMeta,
+          regressions: regressions.filter((r) => r?._gateKind === kind),
+        };
+      }
+    }
+  }
+  return null;
+}
+
 /**
  * Top-level: handle a baseline gate failure by classifying drift and
  * either auto-refreshing (attributable-only) or posting friction (any
@@ -88,11 +133,14 @@ export async function handleBaselineGateFailure({
   gateRegistry = DEFAULT_GATE_REGISTRY,
   deps = {},
 } = {}) {
-  const meta = gateRegistry[gateName];
-  if (!meta) return { action: 'rethrow' };
-  if (!Array.isArray(regressions) || regressions.length === 0) {
-    return { action: 'rethrow' };
-  }
+  const resolved = resolveGateMeta({
+    gateName,
+    regressions,
+    cycleState,
+    gateRegistry,
+  });
+  if (!resolved) return { action: 'rethrow' };
+  const { meta, regressions: scopedRegressions } = resolved;
 
   const classify = deps.classifyBaselineDrift ?? defaultClassifyBaselineDrift;
   const renderBody =
@@ -114,7 +162,7 @@ export async function handleBaselineGateFailure({
 
   const epicRef = `origin/${epicBranch}`;
   const { attributable, nonAttributable } = classify({
-    regressions,
+    regressions: scopedRegressions,
     storyDiffPaths,
     epicRef,
     cwd,

--- a/.agents/scripts/lib/orchestration/story-close/baseline-attribution/phases/regression-projection.js
+++ b/.agents/scripts/lib/orchestration/story-close/baseline-attribution/phases/regression-projection.js
@@ -244,6 +244,24 @@ export const PROJECTORS = {
   'check-crap': projectCrapForGate,
 };
 
+/**
+ * Composite gates fan out to per-kind projectors. The baseline pipeline was
+ * unified behind a single `check-baselines` gate (per-kind pipeline: schema →
+ * floor → tolerance), but the attribution layer still keys on the original
+ * per-kind gate names. Without this map a `check-baselines` failure projects
+ * zero regressions, the gate-failure handler sees an empty list, and the
+ * auto-refresh path silently no-ops — so a legitimate MI/CRAP regression
+ * hard-fails the close instead of self-healing (framework-gap #4377).
+ */
+export const COMPOSITE_SUBGATES = {
+  'check-baselines': ['check-maintainability', 'check-crap'],
+};
+
+/** `check-maintainability` → `maintainability`. */
+function gateKind(gateName) {
+  return gateName.replace(/^check-/, '');
+}
+
 export function projectRegressionsForGate({
   gateName,
   cwd,
@@ -253,14 +271,27 @@ export function projectRegressionsForGate({
   projectMaintainability = defaultProjectMaintainabilityRegressions,
   getBaselines = defaultGetBaselines,
 }) {
-  const project = PROJECTORS[gateName];
-  if (!project) return [];
-  return project({
+  const ctx = {
     cwd,
     epicBranch,
     storyBranch,
     config,
     projectMaintainability,
     getBaselines,
-  });
+  };
+  const subGates = COMPOSITE_SUBGATES[gateName];
+  if (subGates) {
+    // Union the per-kind regressions, tagging each row with its baseline
+    // kind so the gate-failure handler can refresh the right baseline (one
+    // kind per attribution cycle; the retry loop converges the rest).
+    return subGates.flatMap((sub) => {
+      const project = PROJECTORS[sub];
+      if (!project) return [];
+      const kind = gateKind(sub);
+      return project(ctx).map((row) => ({ _gateKind: kind, ...row }));
+    });
+  }
+  const project = PROJECTORS[gateName];
+  if (!project) return [];
+  return project(ctx);
 }

--- a/tests/lib/orchestration/story-close/baseline-attribution-composite-gate.test.js
+++ b/tests/lib/orchestration/story-close/baseline-attribution-composite-gate.test.js
@@ -1,0 +1,130 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import {
+  DEFAULT_GATE_REGISTRY,
+  resolveGateMeta,
+} from '../../../../.agents/scripts/lib/orchestration/story-close/baseline-attribution/phases/gate-failure.js';
+import {
+  COMPOSITE_SUBGATES,
+  projectRegressionsForGate,
+} from '../../../../.agents/scripts/lib/orchestration/story-close/baseline-attribution/phases/regression-projection.js';
+
+/**
+ * baseline-attribution-composite-gate.test.js — framework-gap #4377.
+ *
+ * The baseline pipeline was unified behind a single `check-baselines` gate,
+ * but the attribution layer kept keying on the per-kind gate names
+ * (`check-maintainability` / `check-crap`). A `check-baselines` failure
+ * therefore projected zero regressions and the gate-failure handler dead-ended
+ * on an unrecognised gate name — the auto-refresh path silently no-op'd and a
+ * legitimate MI/CRAP regression hard-failed the close. These tests pin the
+ * composite decomposition so that path can never regress silently again.
+ */
+
+describe('COMPOSITE_SUBGATES', () => {
+  it('maps the unified check-baselines gate to its per-kind sub-gates', () => {
+    assert.deepEqual(COMPOSITE_SUBGATES['check-baselines'], [
+      'check-maintainability',
+      'check-crap',
+    ]);
+  });
+});
+
+describe('projectRegressionsForGate — gate-name contract', () => {
+  it('returns [] for a genuinely unknown gate (unchanged behaviour)', () => {
+    assert.deepEqual(
+      projectRegressionsForGate({
+        gateName: 'check-typecheck',
+        cwd: '/repo',
+        epicBranch: 'epic/1',
+        storyBranch: 'story-2',
+        config: {},
+      }),
+      [],
+    );
+  });
+});
+
+describe('resolveGateMeta — composite check-baselines decomposition', () => {
+  const registry = DEFAULT_GATE_REGISTRY;
+
+  it('passes a direct per-kind gate straight through', () => {
+    const regressions = [{ path: 'a.js' }];
+    const out = resolveGateMeta({
+      gateName: 'check-maintainability',
+      regressions,
+      gateRegistry: registry,
+    });
+    assert.equal(out.meta.kind, 'maintainability');
+    assert.deepEqual(out.regressions, regressions);
+  });
+
+  it('selects the first regressed kind and scopes regressions to it', () => {
+    const regressions = [
+      { path: 'a.js', _gateKind: 'maintainability' },
+      { path: 'b.js', _gateKind: 'crap' },
+    ];
+    const out = resolveGateMeta({
+      gateName: 'check-baselines',
+      regressions,
+      cycleState: { refreshedKinds: new Set() },
+      gateRegistry: registry,
+    });
+    assert.equal(out.meta.kind, 'maintainability');
+    assert.deepEqual(
+      out.regressions.map((r) => r.path),
+      ['a.js'],
+    );
+  });
+
+  it('skips a kind already refreshed this cycle and moves to the next', () => {
+    const regressions = [
+      { path: 'a.js', _gateKind: 'maintainability' },
+      { path: 'b.js', _gateKind: 'crap' },
+    ];
+    const out = resolveGateMeta({
+      gateName: 'check-baselines',
+      regressions,
+      cycleState: { refreshedKinds: new Set(['maintainability']) },
+      gateRegistry: registry,
+    });
+    assert.equal(out.meta.kind, 'crap');
+    assert.deepEqual(
+      out.regressions.map((r) => r.path),
+      ['b.js'],
+    );
+  });
+
+  it('returns null once every regressed kind has been refreshed (loop terminates)', () => {
+    const out = resolveGateMeta({
+      gateName: 'check-baselines',
+      regressions: [{ path: 'a.js', _gateKind: 'maintainability' }],
+      cycleState: { refreshedKinds: new Set(['maintainability']) },
+      gateRegistry: registry,
+    });
+    assert.equal(out, null);
+  });
+
+  it('returns null for an empty regression list', () => {
+    assert.equal(
+      resolveGateMeta({
+        gateName: 'check-baselines',
+        regressions: [],
+        gateRegistry: registry,
+      }),
+      null,
+    );
+  });
+
+  it('returns null for a composite row whose _gateKind has no registry entry', () => {
+    assert.equal(
+      resolveGateMeta({
+        gateName: 'check-baselines',
+        regressions: [{ path: 'a.js', _gateKind: 'lighthouse' }],
+        gateRegistry: registry,
+      }),
+      null,
+    );
+  });
+});


### PR DESCRIPTION
Two framework-gap fixes surfaced by Epic #4372's delivery + audit.

## #4377 — check-baselines gate-failure auto-refresh was dead
The baseline pipeline unified behind one `check-baselines` gate, but the story-close attribution layer still keyed on the old per-kind names (`check-maintainability` / `check-crap`). A `check-baselines` failure projected zero regressions and the handler dead-ended, so the auto-refresh path silently no-op'd and any legitimate MI/CRAP regression hard-failed the close (this is exactly what forced a manual intervention during Epic #4372). Now the composite gate fans out to its per-kind sub-gates: `projectRegressionsForGate` unions the tagged regressions and `resolveGateMeta` picks the first not-yet-refreshed kind per attribution cycle; the existing retry loop converges the rest. New unit tests pin the decomposition.

## #4379 — makeFfProbes duplication (audit medium)
`epic-cleanup.js` hand-rolled a probe bundle re-implementing the five `git-probes-ff.js` FF wrappers to inject a `gitSpawn` seam. Promoted a single `makeFfProbes(spawn)` factory into `git-probes-ff.js` as the one implementation; the standalone wrappers delegate to a default-bound instance and epic-cleanup imports the factory. Behaviour-preserving (git-cleanup 200 + epic-cleanup 60 + branch-cleaner 16 tests green).

Resolves #4377
Resolves #4379

🤖 Generated with [Claude Code](https://claude.com/claude-code)