### PR TITLE
test(boot-sweep): fix Windows Smoke path assertion

### DIFF
--- a/tests/scripts/boot-sweep.test.js
+++ b/tests/scripts/boot-sweep.test.js
@@ -1,4 +1,5 @@
 import assert from 'node:assert/strict';
+import path from 'node:path';
 import { describe, it } from 'node:test';
 
 import { runBootSweep } from '../../.agents/scripts/boot-sweep.js';
@@ -42,7 +43,11 @@ describe('runBootSweep', () => {
     assert.equal(seen.fastForward, true);
     assert.equal(typeof seen.protectionCtx.getTicket, 'function');
     assert.equal(typeof seen.protectionCtx.ghRunner, 'function');
-    assert.equal(seen.protectionCtx.repoRoot, '/tmp/repo');
+    // runBootSweep resolves cwd via path.resolve, so the repoRoot it threads
+    // into the protection ctx is the platform-absolute form ('/tmp/repo' on
+    // POSIX, 'D:\\tmp\\repo' on Windows). Resolve the expected value the same
+    // way so the assertion holds cross-platform (Windows Smoke).
+    assert.equal(seen.protectionCtx.repoRoot, path.resolve('/tmp/repo'));
     assert.match(seen.lockPath, /boot-sweep\.lock$/);
     assert.equal(seen.lockTimeoutMs, 1234);
   });


### PR DESCRIPTION
The `runBootSweep — defaults the include glob to story-*` test asserted `protectionCtx.repoRoot === '/tmp/repo'`, but `runBootSweep` threads `path.resolve(cwd)` into the ctx — on Windows that is `D:\\tmp\\repo`, so the assertion deterministically failed the **Windows Smoke** slice (green on Linux where `path.resolve('/tmp/repo')` is a no-op). Latent since #4373; Windows Smoke isn't a required check so it didn't block the epic merge, but it surfaces red on release PR #4378.

Fix: resolve the expected value the same way (`path.resolve('/tmp/repo')`) so the assertion holds cross-platform. Test-only; behaviour unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)