### PR TITLE
feat(planning): stamp authoring Mandrel version onto Epic and Story bodies (#4382)

### DIFF
--- a/.agents/scripts/lib/epic-plan-ideation.js
+++ b/.agents/scripts/lib/epic-plan-ideation.js
@@ -13,6 +13,10 @@
  * mock the provider call without touching the GitHub HTTP client.
  */
 
+import {
+  extractFrameworkStamp,
+  stampFrameworkVersion,
+} from './framework-version.js';
 import { TYPE_LABELS } from './label-constants.js';
 
 // Canonical section keys match the rendered template at
@@ -113,24 +117,33 @@ export function parseOnePager(onePager) {
  * sections are rendered as `_(not specified)_` so the operator can spot
  * gaps during the HITL review (Phase 3).
  *
+ * Story #4382 — the rendered body is stamped with the Mandrel framework
+ * version + authoring date (hidden `mandrel_version` / `authored_at` meta
+ * field + a visible `> 🏷️ Authored with Mandrel …` marker) via
+ * {@link stampFrameworkVersion}. Pass `stamp` to preserve a
+ * previously-authored version on re-render (the Epic edit path does this);
+ * omit it to stamp the running version and today's date.
+ *
  * @param {{
  *   onePager: string,
  *   template: string,
+ *   stamp?: { version?: string, authoredAt?: string },
  * }} args
  * @returns {{ title: string, body: string }}
  */
-export function renderEpicBody({ onePager, template }) {
+export function renderEpicBody({ onePager, template, stamp }) {
   if (!template || typeof template !== 'string') {
     throw new Error('renderEpicBody: template must be a non-empty string');
   }
   const parsed = parseOnePager(onePager);
 
-  const body = template.replace(/\{\{(\w+)\}\}/g, (_, key) => {
+  const rendered = template.replace(/\{\{(\w+)\}\}/g, (_, key) => {
     if (key === 'title') return parsed.title;
     const value = parsed[key];
     return value && value.length > 0 ? value : '_(not specified)_';
   });
 
+  const body = stampFrameworkVersion(rendered, stamp ?? {});
   return { title: parsed.title, body };
 }
 
@@ -226,7 +239,15 @@ export async function updateEpicFromOnePager({
     );
   }
 
-  const { title, body } = renderEpicBody({ onePager, template });
+  // Story #4382 — preserve the originally-authored version stamp on edit
+  // rather than bumping it to whatever version is running now. When the
+  // current body carries no stamp (legacy Epic), a fresh stamp is applied.
+  const priorStamp = extractFrameworkStamp(currentBody ?? '');
+  const stamp = priorStamp
+    ? { version: priorStamp.version, authoredAt: priorStamp.authoredAt }
+    : undefined;
+
+  const { title, body } = renderEpicBody({ onePager, template, stamp });
 
   if (typeof currentBody === 'string' && currentBody === body) {
     return { epicId, title, body, changed: false };

--- a/.agents/scripts/lib/framework-version.js
+++ b/.agents/scripts/lib/framework-version.js
@@ -1,0 +1,210 @@
+// .agents/scripts/lib/framework-version.js
+/**
+ * framework-version.js — single source of truth for the running Mandrel
+ * framework version and the ticket-body authoring stamp.
+ *
+ * Two concerns live here:
+ *
+ * 1. **Version resolution.** Under npm distribution the root `package.json`
+ *    is the canonical version marker. {@link resolveFrameworkVersion} reads it
+ *    and degrades to `'unknown'` (never throws) so a missing/unreadable
+ *    manifest can never crash an authoring or hydration path. The private
+ *    `getVersion()` in `lib/orchestration/context-hydration-engine.js`
+ *    delegates here (DRY — one manifest reader).
+ *
+ * 2. **Ticket-body stamp.** Epics and Stories are stamped **once at authoring
+ *    time** with the running version and the authoring date, via a hybrid
+ *    surface:
+ *      - a hidden machine-readable field in the trailing
+ *        `<!-- meta: {"mandrel_version":"…","authored_at":"…"} -->` block
+ *        (the source of truth, queryable by tooling), and
+ *      - a single visible footer line
+ *        `> 🏷️ Authored with Mandrel v<version> · <YYYY-MM-DD>` so a human
+ *        reading the raw GitHub issue sees the provenance without any tooling.
+ *
+ *    The stamp is **immutable**: {@link stampFrameworkVersion} is a no-op when
+ *    the body already carries a `mandrel_version`, so a later re-render or
+ *    Epic-body edit preserves the originally-authored version verbatim rather
+ *    than bumping it to whatever version happens to be running.
+ *
+ * This module imports only Node builtins so it can be pulled in from the
+ * story-body serializer, the ticket provider, and the Epic ideation renderer
+ * without risking an import cycle.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+/** Returned when the package manifest is absent or unreadable. */
+export const FALLBACK_VERSION = 'unknown';
+
+/**
+ * Trailing machine-metadata comment block: `<!-- meta: {...} -->`. Mirrors the
+ * regex the Story-body parser uses so both surfaces recognise the same block.
+ */
+const META_BLOCK_RE = /<!--\s*meta:\s*(\{[\s\S]*?\})\s*-->/;
+
+/**
+ * The visible authoring marker line. A blockquote so GitHub renders it as a
+ * callout. Used both to detect an already-emitted marker (for the strip step)
+ * and, in the Story-body parser, to skip the line during section parsing so it
+ * never pollutes the last structured section.
+ */
+export const AUTHORED_MARKER_LINE_RE = /^\s*>\s*🏷️\s+Authored with Mandrel\b/;
+
+/**
+ * Compute the default path to the root `package.json`. This module ships inside
+ * the `mandrel` package at `<pkgRoot>/.agents/scripts/lib/framework-version.js`,
+ * so the manifest sits three directories up — the same layout in the dev repo
+ * and the published tarball.
+ *
+ * @returns {string}
+ */
+function defaultPkgPath() {
+  const moduleDir = path.dirname(fileURLToPath(import.meta.url));
+  return path.resolve(moduleDir, '../../..', 'package.json');
+}
+
+/**
+ * Resolve the running framework version from the root `package.json`. Degrades
+ * to {@link FALLBACK_VERSION} (never throws) on any read or parse failure so a
+ * missing/unreadable manifest can never crash an authoring or hydration path.
+ *
+ * @param {{ pkgPath?: string }} [opts] - `pkgPath` override (test seam).
+ * @returns {string}
+ */
+export function resolveFrameworkVersion({ pkgPath } = {}) {
+  try {
+    const resolved = typeof pkgPath === 'string' ? pkgPath : defaultPkgPath();
+    const parsed = JSON.parse(fs.readFileSync(resolved, 'utf8'));
+    return typeof parsed.version === 'string' && parsed.version.trim()
+      ? parsed.version.trim()
+      : FALLBACK_VERSION;
+  } catch {
+    return FALLBACK_VERSION;
+  }
+}
+
+/**
+ * Format an authoring date as `YYYY-MM-DD` (UTC). Matches the date shape the
+ * rest of the authoring path uses (e.g. `qa-session`).
+ *
+ * @param {Date} [date=new Date()]
+ * @returns {string}
+ */
+export function formatAuthoredDate(date = new Date()) {
+  const d =
+    date instanceof Date && !Number.isNaN(date.getTime()) ? date : new Date();
+  return d.toISOString().slice(0, 10);
+}
+
+/**
+ * Build the visible authoring marker line for a given stamp. Centralised so
+ * the string is byte-identical across the two producers (the Story-body
+ * serializer and {@link stampFrameworkVersion}).
+ *
+ * @param {{ version: string, authoredAt: string }} stamp
+ * @returns {string}
+ */
+export function authoredMarkerLine({ version, authoredAt }) {
+  return `> 🏷️ Authored with Mandrel v${version} · ${authoredAt}`;
+}
+
+/**
+ * Read the framework stamp from a body's trailing meta block. Returns
+ * `{ version, authoredAt }` when a non-empty `mandrel_version` is present, or
+ * `null` when the body carries no stamp (or the meta block is malformed).
+ * `authoredAt` is `null` when the version is present but the date is absent.
+ *
+ * @param {string} markdown
+ * @returns {{ version: string, authoredAt: string|null }|null}
+ */
+export function extractFrameworkStamp(markdown) {
+  if (typeof markdown !== 'string') return null;
+  const match = markdown.match(META_BLOCK_RE);
+  if (!match) return null;
+  let parsed;
+  try {
+    parsed = JSON.parse(match[1]);
+  } catch {
+    return null;
+  }
+  if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    return null;
+  }
+  const version =
+    typeof parsed.mandrel_version === 'string' && parsed.mandrel_version.trim()
+      ? parsed.mandrel_version.trim()
+      : null;
+  if (version === null) return null;
+  const authoredAt =
+    typeof parsed.authored_at === 'string' && parsed.authored_at.trim()
+      ? parsed.authored_at.trim()
+      : null;
+  return { version, authoredAt };
+}
+
+/**
+ * Stamp a ticket body (Epic or Story markdown) with the framework version and
+ * authoring date — **once**. When the body already carries a `mandrel_version`
+ * the body is returned verbatim (immutability: never re-derive or bump an
+ * already-authored stamp). Otherwise the version keys are merged into (or
+ * create) the trailing `<!-- meta -->` block — appended **last** so the key
+ * order stays stable with the Story-body serializer — and the visible marker
+ * line is (re)emitted just above it.
+ *
+ * The `version` / `authoredAt` overrides let a caller (e.g. the Epic edit path)
+ * preserve a previously-authored stamp; both default to the running version and
+ * today's date when omitted.
+ *
+ * @param {string} markdown
+ * @param {{ version?: string, authoredAt?: string }} [stamp]
+ * @returns {string}
+ */
+export function stampFrameworkVersion(markdown, stamp = {}) {
+  const body = typeof markdown === 'string' ? markdown : '';
+
+  // Immutability: a body that already carries a version is preserved verbatim.
+  if (extractFrameworkStamp(body) !== null) return body;
+
+  const version =
+    typeof stamp?.version === 'string' && stamp.version.trim()
+      ? stamp.version.trim()
+      : resolveFrameworkVersion();
+  const authoredAt =
+    typeof stamp?.authoredAt === 'string' && stamp.authoredAt.trim()
+      ? stamp.authoredAt.trim()
+      : formatAuthoredDate();
+
+  // Merge into any existing (version-less) meta block, appending the version
+  // keys last for stable key order.
+  const metaMatch = body.match(META_BLOCK_RE);
+  const meta = {};
+  if (metaMatch) {
+    try {
+      const parsed = JSON.parse(metaMatch[1]);
+      if (
+        parsed !== null &&
+        typeof parsed === 'object' &&
+        !Array.isArray(parsed)
+      ) {
+        Object.assign(meta, parsed);
+      }
+    } catch {
+      // Malformed meta comment — drop it and re-emit a clean block.
+    }
+  }
+  meta.mandrel_version = version;
+  meta.authored_at = authoredAt;
+
+  // Strip any existing meta block / marker so both re-append canonically.
+  const head = body
+    .replace(META_BLOCK_RE, '')
+    .replace(new RegExp(AUTHORED_MARKER_LINE_RE.source, 'm'), '')
+    .replace(/\n{3,}/g, '\n\n')
+    .trimEnd();
+
+  const marker = authoredMarkerLine({ version, authoredAt });
+  return `${head}\n\n${marker}\n\n<!-- meta: ${JSON.stringify(meta)} -->`;
+}

--- a/.agents/scripts/lib/orchestration/context-hydration-engine.js
+++ b/.agents/scripts/lib/orchestration/context-hydration-engine.js
@@ -19,7 +19,6 @@
 import crypto from 'node:crypto';
 import fs from 'node:fs';
 import path from 'node:path';
-import { fileURLToPath } from 'node:url';
 import { getCommands } from '../config/commands.js';
 import {
   getLimits,
@@ -28,6 +27,7 @@ import {
   resolveConfig,
 } from '../config-resolver.js';
 import { sliceEpicBodyForDelivery } from '../epic-body-sections.js';
+import { resolveFrameworkVersion } from '../framework-version.js';
 import { Logger } from '../Logger.js';
 import {
   buildEnvelope,
@@ -133,31 +133,16 @@ export function formatSkillCapsulesSection(entries) {
 // ---------------------------------------------------------------------------
 
 /**
- * Resolve the framework version from the installed package's `package.json`.
- *
- * Under npm distribution `package.json` is the single source of truth for the
- * framework version (the legacy plaintext version marker is retired). This
- * module ships inside the `mandrel` package at
- * `<pkgRoot>/.agents/scripts/lib/orchestration/context-hydration-engine.js`,
- * so the package manifest sits four directories up — the same layout in the
- * dev repo and in the published tarball. Read that manifest's `version`.
- *
- * Falls back to `'unknown'` when the manifest is absent or unreadable so a
- * missing package.json never crashes hydration.
+ * Resolve the framework version. Delegates to the shared
+ * {@link resolveFrameworkVersion} helper (single owner of the root
+ * `package.json` read) so the hydrator and the ticket-body stamp read the same
+ * source. Retained as a thin named wrapper so the mismatch-warning call sites
+ * below read against a stable local name.
  *
  * @returns {string}
  */
 function getVersion() {
-  try {
-    const moduleDir = path.dirname(fileURLToPath(import.meta.url));
-    const pkgPath = path.resolve(moduleDir, '../../../..', 'package.json');
-    const parsed = JSON.parse(fs.readFileSync(pkgPath, 'utf8'));
-    return typeof parsed.version === 'string' && parsed.version.trim()
-      ? parsed.version.trim()
-      : 'unknown';
-  } catch {
-    return 'unknown';
-  }
+  return resolveFrameworkVersion();
 }
 
 /**

--- a/.agents/scripts/lib/orchestration/epic-spec-reconciler-diff.js
+++ b/.agents/scripts/lib/orchestration/epic-spec-reconciler-diff.js
@@ -81,6 +81,10 @@
  */
 
 import { composeStoryBody } from '../../providers/github/tickets.js';
+import {
+  extractFrameworkStamp,
+  stampFrameworkVersion,
+} from '../framework-version.js';
 import { assertPlanLabelAllowList } from './epic-spec-reconciler-discriminator.js';
 import {
   closeOp,
@@ -233,12 +237,21 @@ function stripFooter(body) {
  * `composeStoryBody` directly makes that divergence structurally
  * impossible going forward.
  *
+ * Story #4382 — the create-time authoring stamp (`mandrel_version` /
+ * `authored_at` meta field + visible marker) is provenance, not spec-derived
+ * content, so this UPDATE path never mints or bumps it (which would also break
+ * this function's purity — the stamp uses a clock). Instead the stamp already
+ * present on the **live** GH body (`obsBody`) is preserved verbatim, and a
+ * legacy stamp-less body is left stamp-less (no backfill — see the Story's
+ * Out-of-Scope). Footer recomposition therefore runs in `stamp: false` mode.
+ *
  * @param {{entity: string, parentSlug?: string|null, dependsOn?: string[]}} specEntity
  * @param {string} specBody
  * @param {{state?: StateInput}} ctx
+ * @param {string} [obsBody] - The live GH body, source of the preserved stamp.
  * @returns {string}
  */
-function composeBodyWithFooter(specEntity, specBody, ctx) {
+function composeBodyWithFooter(specEntity, specBody, ctx, obsBody = '') {
   const state = ctx?.state ?? {};
   const mapping = state.mapping ?? {};
   const parentSlug = specEntity.parentSlug ?? null;
@@ -264,7 +277,25 @@ function composeBodyWithFooter(specEntity, specBody, ctx) {
   // included) or emits a canonical-form body. With the strip, the
   // function is idempotent against its own output.
   const head = stripFooter(specBody);
-  return composeStoryBody({ body: head, parentId, epicId, dependencies });
+  // Preserve the live body's create-time authoring stamp (Story #4382). When
+  // the spec head already carries it, `stampFrameworkVersion` is a no-op
+  // (immutable); when it doesn't, the stamp is restored from the live body so
+  // the recomposed form matches GH and no spurious body Update fires. A
+  // legacy body with no stamp stays stamp-less (no backfill).
+  const priorStamp = extractFrameworkStamp(obsBody);
+  const stampedHead = priorStamp
+    ? stampFrameworkVersion(head, {
+        version: priorStamp.version,
+        authoredAt: priorStamp.authoredAt,
+      })
+    : head;
+  return composeStoryBody({
+    body: stampedHead,
+    parentId,
+    epicId,
+    dependencies,
+    stamp: false,
+  });
 }
 
 /**
@@ -329,7 +360,7 @@ function fieldChanges(specEntity, obs, mapping, ctx = {}) {
       // Emit a body change only when the canonical form differs from
       // what is on GH today — and write the canonical form back, so the
       // footer cascade-readers depend on stays intact across resumes.
-      const after = composeBodyWithFooter(specEntity, specBody, ctx);
+      const after = composeBodyWithFooter(specEntity, specBody, ctx, obsBody);
       if (after !== obsBody) {
         changes.body = { before: obsBody, after };
       }

--- a/.agents/scripts/lib/story-body/story-body.js
+++ b/.agents/scripts/lib/story-body/story-body.js
@@ -42,6 +42,10 @@
  * @module story-body
  */
 
+import {
+  AUTHORED_MARKER_LINE_RE,
+  authoredMarkerLine,
+} from '../framework-version.js';
 import { FILE_ASSUMPTION_VALUES } from '../orchestration/file-assumption-enum.js';
 
 // ---------------------------------------------------------------------------
@@ -75,6 +79,8 @@ import { FILE_ASSUMPTION_VALUES } from '../orchestration/file-assumption-enum.js
  * @property {string|null}   reason_to_exist     - One-sentence cohesion reason ("why this Story exists"), or null.
  * @property {string[]}      depends_on          - Blocking story slugs / issue refs.
  * @property {number|null}   estimated_test_files - Test surface count or null.
+ * @property {string|null}   mandrel_version     - Framework version stamped at authoring, or null.
+ * @property {string|null}   authored_at         - Authoring date (YYYY-MM-DD) stamped at authoring, or null.
  */
 
 /**
@@ -253,14 +259,21 @@ const META_BLOCK_RE = /<!--\s*meta:\s*(\{[\s\S]*?\})\s*-->/;
  * otherwise-valid Story body. A parse failure degrades to the absent-meta
  * defaults instead of throwing.
  *
+ * The `mandrel_version` / `authored_at` provenance stamp (written once at
+ * authoring time by the ticket-creation path) is recovered here too so a later
+ * `parse → serialize` preserves the originally-authored version verbatim
+ * rather than dropping or re-deriving it.
+ *
  * @param {string} markdown
- * @returns {{ wide: { reason: string }|null, reason_to_exist: string|null, estimated_test_files: number|null }}
+ * @returns {{ wide: { reason: string }|null, reason_to_exist: string|null, estimated_test_files: number|null, mandrel_version: string|null, authored_at: string|null }}
  */
 function extractMeta(markdown) {
   const result = {
     wide: null,
     reason_to_exist: null,
     estimated_test_files: null,
+    mandrel_version: null,
+    authored_at: null,
   };
   const match = markdown.match(META_BLOCK_RE);
   if (!match) return result;
@@ -278,6 +291,15 @@ function extractMeta(markdown) {
   result.reason_to_exist = normalizeReasonToExist(parsed.reason_to_exist);
   if (typeof parsed.estimated_test_files === 'number') {
     result.estimated_test_files = parsed.estimated_test_files;
+  }
+  if (
+    typeof parsed.mandrel_version === 'string' &&
+    parsed.mandrel_version.trim()
+  ) {
+    result.mandrel_version = parsed.mandrel_version.trim();
+  }
+  if (typeof parsed.authored_at === 'string' && parsed.authored_at.trim()) {
+    result.authored_at = parsed.authored_at.trim();
   }
   return result;
 }
@@ -409,6 +431,14 @@ function splitSections(markdown) {
       continue;
     }
 
+    // The visible `> 🏷️ Authored with Mandrel …` provenance marker is
+    // machine-managed metadata too (emitted alongside the meta block by the
+    // authoring path). Skip it so it never bleeds into the trailing structured
+    // section (e.g. `## Verify`); the value round-trips via the meta block.
+    if (AUTHORED_MARKER_LINE_RE.test(line)) {
+      continue;
+    }
+
     if (inPreamble) {
       preambleLines.push(line);
     } else if (currentSection !== null) {
@@ -456,6 +486,8 @@ function parseLegacyStringBody(input, preamble, footer) {
     reason_to_exist: null,
     depends_on: extractBlockedBy(footer),
     estimated_test_files: null,
+    mandrel_version: null,
+    authored_at: null,
   };
   return {
     body,
@@ -602,6 +634,8 @@ export function parse(input) {
   const estimated_test_files = meta.estimated_test_files;
   const wide = meta.wide;
   const reason_to_exist = meta.reason_to_exist;
+  const mandrel_version = meta.mandrel_version;
+  const authored_at = meta.authored_at;
   if (estimated_test_files === null) {
     warnings.push(
       'test-surface-unestimated: estimated_test_files not present.',
@@ -619,6 +653,8 @@ export function parse(input) {
     reason_to_exist,
     depends_on: dependsOn,
     estimated_test_files,
+    mandrel_version,
+    authored_at,
   };
 
   return {
@@ -699,6 +735,16 @@ function parseStructuredObject(obj) {
     );
   }
 
+  // Provenance stamp (preserved verbatim; never re-derived here).
+  const mandrel_version =
+    typeof obj.mandrel_version === 'string' && obj.mandrel_version.trim()
+      ? obj.mandrel_version.trim()
+      : null;
+  const authored_at =
+    typeof obj.authored_at === 'string' && obj.authored_at.trim()
+      ? obj.authored_at.trim()
+      : null;
+
   const body = {
     goal,
     changes,
@@ -710,6 +756,8 @@ function parseStructuredObject(obj) {
     reason_to_exist,
     depends_on,
     estimated_test_files,
+    mandrel_version,
+    authored_at,
   };
 
   return {
@@ -812,9 +860,11 @@ const SERIALIZE_SECTIONS = [
  * `estimated_test_files`). Returns the empty string when no meta field is
  * present so {@link serialize} appends nothing.
  *
- * Key insertion order (`wide` → `reason_to_exist` → `estimated_test_files`)
- * is load-bearing: it fixes the serialized JSON byte sequence the parser's
- * meta round-trip and the unit suite assert against.
+ * Key insertion order (`wide` → `reason_to_exist` → `estimated_test_files` →
+ * `mandrel_version` → `authored_at`) is load-bearing: it fixes the serialized
+ * JSON byte sequence the parser's meta round-trip and the unit suite assert
+ * against. The provenance stamp keys are appended **last** so every
+ * pre-existing (stamp-less) body serialises byte-identically to before.
  *
  * @param {StoryBody} body
  * @returns {string}
@@ -832,8 +882,34 @@ function serializeMetaBlock(body) {
   if (typeof body.estimated_test_files === 'number') {
     metaFields.estimated_test_files = body.estimated_test_files;
   }
+  if (typeof body.mandrel_version === 'string' && body.mandrel_version.trim()) {
+    metaFields.mandrel_version = body.mandrel_version.trim();
+  }
+  if (typeof body.authored_at === 'string' && body.authored_at.trim()) {
+    metaFields.authored_at = body.authored_at.trim();
+  }
   if (Object.keys(metaFields).length === 0) return '';
   return `\n\n<!-- meta: ${JSON.stringify(metaFields)} -->`;
+}
+
+/**
+ * Build the visible `> 🏷️ Authored with Mandrel v<version> · <date>` marker
+ * line when the body carries a complete provenance stamp
+ * (`mandrel_version` + `authored_at`). Emitted just above the meta block so it
+ * round-trips with the hidden field. Returns the empty string when either
+ * field is absent, so every pre-existing (stamp-less) body serialises
+ * byte-identically to before.
+ *
+ * @param {StoryBody} body
+ * @returns {string}
+ */
+function serializeAuthoredMarker(body) {
+  const version =
+    typeof body.mandrel_version === 'string' ? body.mandrel_version.trim() : '';
+  const authoredAt =
+    typeof body.authored_at === 'string' ? body.authored_at.trim() : '';
+  if (!version || !authoredAt) return '';
+  return `\n\n${authoredMarkerLine({ version, authoredAt })}`;
 }
 
 /**
@@ -888,6 +964,7 @@ export function serialize(body, opts = {}) {
 
   return (
     sections.join('\n\n') +
+    serializeAuthoredMarker(body) +
     serializeMetaBlock(body) +
     serializeFooter(body, opts)
   );

--- a/.agents/scripts/providers/github/tickets.js
+++ b/.agents/scripts/providers/github/tickets.js
@@ -22,6 +22,7 @@
  */
 
 import { parseBlockedBy, parseBlocks } from '../../lib/dependency-parser.js';
+import { stampFrameworkVersion } from '../../lib/framework-version.js';
 import { Logger } from '../../lib/Logger.js';
 import { TYPE_LABELS } from '../../lib/label-constants.js';
 import { addIssueToBoard } from './board-add.js';
@@ -56,11 +57,20 @@ const SEARCH_PAGE_CAP = 10;
  * arrays on the Story body authored by the decomposer; there is no
  * server-side rendering of a four-section payload at create time.
  *
+ * Story #4382 — this is also where a Story body is stamped, once, with the
+ * running Mandrel framework version and authoring date (hidden `mandrel_version`
+ * / `authored_at` meta field + a visible `> 🏷️ Authored with Mandrel …`
+ * marker) via {@link stampFrameworkVersion}. The stamp is immutable: a body
+ * that already carries a version (e.g. a reconciler re-create) is preserved
+ * verbatim. The `stamp` override exists for deterministic tests; production
+ * callers omit it so the running version and today's date are used.
+ *
  * @param {{
  *   body: string,
  *   parentId: number,
  *   epicId?: number,
  *   dependencies?: number[],
+ *   stamp?: { version?: string, authoredAt?: string } | false,
  * }} opts
  * @returns {string}
  *
@@ -75,8 +85,15 @@ export function composeStoryBody({
   parentId,
   epicId,
   dependencies = [],
+  stamp,
 }) {
-  const head = typeof body === 'string' ? body : '';
+  const rawHead = typeof body === 'string' ? body : '';
+  // `stamp === false` → footer-only recomposition: the caller (the reconciler
+  // UPDATE/diff path) owns stamp preservation itself and must NOT introduce a
+  // fresh authoring stamp, which would churn or bump the version on every
+  // reconcile. Every other call is a create — stamp once (immutably).
+  const head =
+    stamp === false ? rawHead : stampFrameworkVersion(rawHead, stamp ?? {});
   const lines = ['---', `parent: #${parentId}`];
   if (epicId !== undefined && epicId !== null) {
     lines.push(`Epic: #${epicId}`);

--- a/tests/lib/framework-version.test.js
+++ b/tests/lib/framework-version.test.js
@@ -1,0 +1,154 @@
+// tests/lib/framework-version.test.js
+/**
+ * Unit tests for the framework-version helper (Story #4382).
+ *
+ * Covers:
+ *  - resolveFrameworkVersion() returns the root package.json version and
+ *    degrades to 'unknown' (never throws) when the manifest is unreadable.
+ *  - formatAuthoredDate() renders YYYY-MM-DD.
+ *  - stampFrameworkVersion() stamps the hidden meta field + visible marker
+ *    once and is immutable on an already-stamped body.
+ *  - extractFrameworkStamp() recovers the stamp (and returns null when absent).
+ */
+
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { describe, it } from 'node:test';
+import { fileURLToPath } from 'node:url';
+import {
+  authoredMarkerLine,
+  extractFrameworkStamp,
+  FALLBACK_VERSION,
+  formatAuthoredDate,
+  resolveFrameworkVersion,
+  stampFrameworkVersion,
+} from '../../.agents/scripts/lib/framework-version.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT_PKG = path.resolve(__dirname, '../../package.json');
+const PKG_VERSION = JSON.parse(fs.readFileSync(ROOT_PKG, 'utf8')).version;
+
+describe('resolveFrameworkVersion', () => {
+  it('returns the root package.json version', () => {
+    assert.equal(resolveFrameworkVersion(), PKG_VERSION);
+  });
+
+  it('degrades to the fallback (unknown) when the manifest is unreadable', () => {
+    const missing = path.join(__dirname, 'does-not-exist-pkg.json');
+    let result;
+    assert.doesNotThrow(() => {
+      result = resolveFrameworkVersion({ pkgPath: missing });
+    });
+    assert.equal(result, FALLBACK_VERSION);
+    assert.equal(FALLBACK_VERSION, 'unknown');
+  });
+
+  it('degrades to the fallback when the manifest has no version field', () => {
+    const tmp = path.join(__dirname, 'framework-version-noversion.tmp.json');
+    fs.writeFileSync(tmp, JSON.stringify({ name: 'x' }), 'utf8');
+    try {
+      assert.equal(resolveFrameworkVersion({ pkgPath: tmp }), FALLBACK_VERSION);
+    } finally {
+      fs.rmSync(tmp, { force: true });
+    }
+  });
+});
+
+describe('formatAuthoredDate', () => {
+  it('renders a fixed date as YYYY-MM-DD', () => {
+    assert.equal(
+      formatAuthoredDate(new Date('2026-07-07T13:45:00Z')),
+      '2026-07-07',
+    );
+  });
+
+  it('renders a YYYY-MM-DD shape for the default (now) argument', () => {
+    assert.match(formatAuthoredDate(), /^\d{4}-\d{2}-\d{2}$/);
+  });
+});
+
+describe('stampFrameworkVersion', () => {
+  it('adds the hidden meta field and the visible marker line', () => {
+    const out = stampFrameworkVersion('## Goal\nDo the thing.', {
+      version: '1.2.3',
+      authoredAt: '2026-07-07',
+    });
+    assert.match(
+      out,
+      /<!-- meta: \{"mandrel_version":"1\.2\.3","authored_at":"2026-07-07"\} -->/,
+    );
+    assert.ok(out.includes('> 🏷️ Authored with Mandrel v1.2.3 · 2026-07-07'));
+  });
+
+  it('defaults to the running version + today when no stamp is supplied', () => {
+    const out = stampFrameworkVersion('body');
+    const stamp = extractFrameworkStamp(out);
+    assert.equal(stamp.version, PKG_VERSION);
+    assert.match(stamp.authoredAt, /^\d{4}-\d{2}-\d{2}$/);
+  });
+
+  it('is immutable: an already-stamped body is returned verbatim', () => {
+    const once = stampFrameworkVersion('body', {
+      version: '1.0.0',
+      authoredAt: '2026-01-01',
+    });
+    const twice = stampFrameworkVersion(once, {
+      version: '9.9.9',
+      authoredAt: '2026-12-31',
+    });
+    assert.equal(twice, once);
+    assert.equal(extractFrameworkStamp(twice).version, '1.0.0');
+  });
+
+  it('merges the stamp into an existing (version-less) meta block, keys last', () => {
+    const withMeta = 'body\n\n<!-- meta: {"estimated_test_files":2} -->';
+    const out = stampFrameworkVersion(withMeta, {
+      version: '2.0.0',
+      authoredAt: '2026-02-02',
+    });
+    assert.match(
+      out,
+      /<!-- meta: \{"estimated_test_files":2,"mandrel_version":"2\.0\.0","authored_at":"2026-02-02"\} -->/,
+    );
+  });
+});
+
+describe('extractFrameworkStamp', () => {
+  it('recovers the version + authoredAt from a stamped body', () => {
+    const out = stampFrameworkVersion('body', {
+      version: '3.3.3',
+      authoredAt: '2026-03-03',
+    });
+    assert.deepEqual(extractFrameworkStamp(out), {
+      version: '3.3.3',
+      authoredAt: '2026-03-03',
+    });
+  });
+
+  it('returns null for a body with no stamp', () => {
+    assert.equal(extractFrameworkStamp('## Goal\nno stamp here'), null);
+    assert.equal(
+      extractFrameworkStamp(
+        'body\n\n<!-- meta: {"estimated_test_files":1} -->',
+      ),
+      null,
+    );
+  });
+
+  it('returns null for a malformed meta block', () => {
+    assert.equal(
+      extractFrameworkStamp('body\n\n<!-- meta: {not json} -->'),
+      null,
+    );
+  });
+});
+
+describe('authoredMarkerLine', () => {
+  it('renders the canonical marker string', () => {
+    assert.equal(
+      authoredMarkerLine({ version: '1.86.0', authoredAt: '2026-07-07' }),
+      '> 🏷️ Authored with Mandrel v1.86.0 · 2026-07-07',
+    );
+  });
+});

--- a/tests/lib/story-body/story-body-meta-round-trip.test.js
+++ b/tests/lib/story-body/story-body-meta-round-trip.test.js
@@ -269,3 +269,68 @@ describe('round-trip: serialize → parse → serialize', () => {
     assert.ok(twice.includes('"estimated_test_files":3'));
   });
 });
+
+// ---------------------------------------------------------------------------
+// Framework provenance stamp (Story #4382): mandrel_version + authored_at
+// round-trip through the meta block and the visible marker, and are IMMUTABLE
+// across a parse → serialize (never re-derived / bumped).
+// ---------------------------------------------------------------------------
+
+const STAMPED_BODY = {
+  ...BODY_WITH_META,
+  mandrel_version: '1.2.3',
+  authored_at: '2026-07-07',
+};
+
+describe('parse()/serialize() — framework-version stamp round-trip', () => {
+  it('emits the hidden mandrel_version + authored_at fields into the meta block', () => {
+    const md = serialize(STAMPED_BODY);
+    assert.ok(md.includes('"mandrel_version":"1.2.3"'));
+    assert.ok(md.includes('"authored_at":"2026-07-07"'));
+  });
+
+  it('emits the visible authoring marker line', () => {
+    const md = serialize(STAMPED_BODY);
+    assert.ok(md.includes('> 🏷️ Authored with Mandrel v1.2.3 · 2026-07-07'));
+  });
+
+  it('appends the stamp keys LAST in the meta block (stable key order)', () => {
+    const md = serialize(STAMPED_BODY);
+    assert.match(
+      md,
+      /"estimated_test_files":3,"mandrel_version":"1\.2\.3","authored_at":"2026-07-07"\}/,
+    );
+  });
+
+  it('recovers mandrel_version + authored_at on parse', () => {
+    const { body } = parse(serialize(STAMPED_BODY));
+    assert.equal(body.mandrel_version, '1.2.3');
+    assert.equal(body.authored_at, '2026-07-07');
+  });
+
+  it('the visible marker does not pollute the trailing structured section', () => {
+    // verify[] is the last structured section; the marker must not bleed in.
+    const { body } = parse(serialize(STAMPED_BODY));
+    assert.deepEqual(body.verify, STAMPED_BODY.verify);
+    assert.ok(!body.verify.some((v) => v.includes('Authored with Mandrel')));
+  });
+
+  it('is byte-stable and version-immutable across serialize → parse → serialize', () => {
+    const once = serialize(STAMPED_BODY);
+    const twice = serialize(parse(once).body);
+    assert.equal(twice, once);
+    assert.equal(extractVersion(twice), '1.2.3');
+  });
+
+  it('leaves a stamp-less body byte-identical to before (no marker, no keys)', () => {
+    const md = serialize(BODY_WITH_META);
+    assert.ok(!md.includes('mandrel_version'));
+    assert.ok(!md.includes('Authored with Mandrel'));
+  });
+});
+
+/** Pull the mandrel_version out of a serialized meta block for assertions. */
+function extractVersion(md) {
+  const m = md.match(/"mandrel_version":"([^"]+)"/);
+  return m ? m[1] : null;
+}

--- a/tests/providers/github/tickets.test.js
+++ b/tests/providers/github/tickets.test.js
@@ -10,6 +10,7 @@
  */
 
 import assert from 'node:assert/strict';
+import fs from 'node:fs';
 import path from 'node:path';
 import { describe, it } from 'node:test';
 import { fileURLToPath, pathToFileURL } from 'node:url';
@@ -827,6 +828,63 @@ describe('composeStoryBody — 2-tier Epic footer (Story #4102)', () => {
     });
     assert.match(out, /---\nparent: #23$/);
     assert.doesNotMatch(out, /Epic: #/);
+  });
+});
+
+// Story #4382 — composeStoryBody stamps a newly-created Story body with the
+// running Mandrel framework version + authoring date (hidden meta field +
+// visible marker), once. The footer stays canonical and the stamp lands in the
+// human body (before the `---` trailer).
+describe('composeStoryBody — framework-version stamp (Story #4382)', () => {
+  it('stamps the hidden meta field and the visible marker before the footer', () => {
+    const out = composeStoryBody({
+      body: '## Goal\nDo the thing.',
+      parentId: 10,
+      epicId: 10,
+      stamp: { version: '4.2.0', authoredAt: '2026-07-07' },
+    });
+    assert.ok(
+      out.includes(
+        '<!-- meta: {"mandrel_version":"4.2.0","authored_at":"2026-07-07"} -->',
+      ),
+    );
+    assert.ok(out.includes('> 🏷️ Authored with Mandrel v4.2.0 · 2026-07-07'));
+    // Stamp is inside the human body, above the `---` / `parent:` trailer.
+    const footerIdx = out.indexOf('\n---\nparent:');
+    assert.ok(footerIdx > out.indexOf('Authored with Mandrel'));
+    assert.match(out, /---\nparent: #10\nEpic: #10$/);
+  });
+
+  it('defaults to the running package.json version when no stamp is passed', () => {
+    const pkgVersion = JSON.parse(
+      fs.readFileSync(path.join(ROOT, 'package.json'), 'utf8'),
+    ).version;
+    const out = composeStoryBody({
+      body: '## Goal\nx',
+      parentId: 1,
+      epicId: 1,
+    });
+    assert.ok(out.includes(`"mandrel_version":"${pkgVersion}"`));
+  });
+
+  it('is immutable: an already-stamped body keeps its original version', () => {
+    const first = composeStoryBody({
+      body: '## Goal\nx',
+      parentId: 1,
+      epicId: 1,
+      stamp: { version: '1.0.0', authoredAt: '2026-01-01' },
+    });
+    // Feed the already-stamped head (minus the footer) back through with a
+    // newer running version — the original stamp must win.
+    const headOnly = first.split('\n\n---\n')[0];
+    const second = composeStoryBody({
+      body: headOnly,
+      parentId: 1,
+      epicId: 1,
+      stamp: { version: '9.9.9', authoredAt: '2026-12-31' },
+    });
+    assert.ok(second.includes('"mandrel_version":"1.0.0"'));
+    assert.ok(!second.includes('9.9.9'));
   });
 });
 

--- a/tests/scripts/epic-spec-reconciler.diff.test.js
+++ b/tests/scripts/epic-spec-reconciler.diff.test.js
@@ -34,6 +34,7 @@ import {
   isPlan,
   OP_KINDS,
 } from '../../.agents/scripts/lib/orchestration/epic-spec-reconciler-ops.js';
+import { composeStoryBody } from '../../.agents/scripts/providers/github/tickets.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const FIXTURE_DIR = path.resolve(__dirname, '..', 'fixtures', 'reconciler');
@@ -964,5 +965,101 @@ describe('reconciler diff — duplicate story slugs', () => {
         return true;
       },
     );
+  });
+});
+
+// Story #4382 — the create-time authoring stamp is provenance, not spec
+// content. The reconciler UPDATE/diff path MUST preserve the live body's stamp
+// (never mint/bump it — that would also break diff() purity by using a clock),
+// so a stamp on GH that the spec body lacks does not churn a spurious body
+// Update, and a real edit keeps the original version verbatim.
+describe('reconciler diff — framework-version stamp preservation (Story #4382)', () => {
+  const DESC =
+    '## Goal\nStamp preservation.\n\n## Acceptance\n- [ ] works\n\n## Verify\n- npm test (unit)';
+
+  function inputs(specBody, ghBody) {
+    return {
+      spec: {
+        epic: { id: 500, title: 'E', labels: ['type::epic'] },
+        stories: [
+          {
+            slug: 'story-a',
+            title: 'A',
+            wave: 0,
+            dependsOn: [],
+            labels: ['type::story'],
+            body: specBody,
+          },
+        ],
+      },
+      state: {
+        epicId: 500,
+        mapping: {
+          epic: { issueNumber: 500, entity: 'epic', parentSlug: null },
+          'story-a': {
+            issueNumber: 501,
+            entity: 'story',
+            parentSlug: 'epic',
+            dependsOn: [],
+            wave: 0,
+          },
+        },
+      },
+      ghState: {
+        500: { title: 'E', labels: ['type::epic'], state: 'open' },
+        501: {
+          title: 'A',
+          labels: ['type::story'],
+          state: 'open',
+          body: ghBody,
+        },
+      },
+    };
+  }
+
+  it('emits no body Update when only the stamp is present on GH (no churn)', () => {
+    // Live body created (once) under an OLD version; spec body is stamp-less.
+    const created = composeStoryBody({
+      body: DESC,
+      parentId: 500,
+      epicId: 500,
+      stamp: { version: '1.0.0', authoredAt: '2026-01-01' },
+    });
+    const { spec, state, ghState } = inputs(DESC, created);
+    const plan = diff({ spec, state, ghState });
+    const op = plan.updates.find((u) => u.slug === 'story-a');
+    assert.ok(!op || !('body' in op.changes), 'no spurious body Update');
+  });
+
+  it('preserves the original version verbatim on a real description edit', () => {
+    const created = composeStoryBody({
+      body: DESC,
+      parentId: 500,
+      epicId: 500,
+      stamp: { version: '1.0.0', authoredAt: '2026-01-01' },
+    });
+    const editedDesc = DESC.replace('Stamp preservation.', 'Edited goal.');
+    const { spec, state, ghState } = inputs(editedDesc, created);
+    const plan = diff({ spec, state, ghState });
+    const op = plan.updates.find((u) => u.slug === 'story-a');
+    assert.ok(op && op.changes.body, 'a real edit emits a body Update');
+    assert.ok(op.changes.body.after.includes('"mandrel_version":"1.0.0"'));
+    assert.ok(!op.changes.body.after.includes('mandrel_version":"unknown'));
+    assert.ok(op.changes.body.after.includes('Edited goal.'));
+  });
+
+  it('does not backfill a stamp onto a legacy (stamp-less) live body', () => {
+    // Legacy body: created before the stamp feature — no marker, no meta.
+    const legacy = composeStoryBody({
+      body: DESC,
+      parentId: 500,
+      epicId: 500,
+      stamp: false,
+    });
+    assert.ok(!legacy.includes('mandrel_version'));
+    const { spec, state, ghState } = inputs(DESC, legacy);
+    const plan = diff({ spec, state, ghState });
+    const op = plan.updates.find((u) => u.slug === 'story-a');
+    assert.ok(!op || !('body' in op.changes), 'no backfill churn');
   });
 });

--- a/tests/workflows/epic-plan-ideation.test.js
+++ b/tests/workflows/epic-plan-ideation.test.js
@@ -22,7 +22,9 @@ import {
   openEpicFromOnePager,
   parseOnePager,
   renderEpicBody,
+  updateEpicFromOnePager,
 } from '../../.agents/scripts/lib/epic-plan-ideation.js';
+import { extractFrameworkStamp } from '../../.agents/scripts/lib/framework-version.js';
 import { createGh } from '../../.agents/scripts/lib/gh-exec.js';
 import { TicketGateway } from '../../.agents/scripts/providers/github/tickets.js';
 
@@ -141,6 +143,102 @@ describe('renderEpicBody', () => {
     assert.match(body, /## Scope\n\n_\(not specified\)_/);
     assert.match(body, /## Acceptance Criteria\n\n_\(not specified\)_/);
     assert.ok(!body.includes('{{'));
+  });
+});
+
+// Story #4382 — the rendered Epic body is stamped with the framework version +
+// authoring date (hidden meta field + visible marker), and the Epic edit path
+// preserves the originally-authored version instead of bumping it.
+describe('renderEpicBody — framework-version stamp (Story #4382)', () => {
+  it('appends the hidden meta field and the visible marker', () => {
+    const template = fs.readFileSync(TEMPLATE_PATH, 'utf8');
+    const { body } = renderEpicBody({
+      onePager: CANONICAL_ONE_PAGER,
+      template,
+      stamp: { version: '5.1.0', authoredAt: '2026-07-07' },
+    });
+    assert.ok(
+      body.includes(
+        '<!-- meta: {"mandrel_version":"5.1.0","authored_at":"2026-07-07"} -->',
+      ),
+    );
+    assert.ok(body.includes('> 🏷️ Authored with Mandrel v5.1.0 · 2026-07-07'));
+    assert.deepEqual(extractFrameworkStamp(body), {
+      version: '5.1.0',
+      authoredAt: '2026-07-07',
+    });
+  });
+
+  it('defaults to the running package.json version when no stamp is passed', () => {
+    const template = fs.readFileSync(TEMPLATE_PATH, 'utf8');
+    const pkgVersion = JSON.parse(
+      fs.readFileSync(path.resolve(__dirname, '../../package.json'), 'utf8'),
+    ).version;
+    const { body } = renderEpicBody({
+      onePager: CANONICAL_ONE_PAGER,
+      template,
+    });
+    assert.equal(extractFrameworkStamp(body).version, pkgVersion);
+  });
+});
+
+describe('updateEpicFromOnePager — stamp preservation (Story #4382)', () => {
+  it('preserves the originally-authored version on edit (idempotent, no bump)', async () => {
+    const template = fs.readFileSync(TEMPLATE_PATH, 'utf8');
+    // A body originally authored under an OLD version.
+    const original = renderEpicBody({
+      onePager: CANONICAL_ONE_PAGER,
+      template,
+      stamp: { version: '1.0.0', authoredAt: '2026-01-01' },
+    }).body;
+
+    let edited = null;
+    const result = await updateEpicFromOnePager({
+      epicId: 42,
+      onePager: CANONICAL_ONE_PAGER,
+      template,
+      currentBody: original,
+      editIssue: async ({ body }) => {
+        edited = body;
+      },
+    });
+
+    // Same onePager + preserved stamp → byte-identical → no write.
+    assert.equal(result.changed, false);
+    assert.equal(result.body, original);
+    assert.equal(edited, null);
+    assert.equal(extractFrameworkStamp(result.body).version, '1.0.0');
+  });
+
+  it('preserves the original version even when the body content changes', async () => {
+    const template = fs.readFileSync(TEMPLATE_PATH, 'utf8');
+    const original = renderEpicBody({
+      onePager: CANONICAL_ONE_PAGER,
+      template,
+      stamp: { version: '1.0.0', authoredAt: '2026-01-01' },
+    }).body;
+
+    const editedOnePager = CANONICAL_ONE_PAGER.replace(
+      'single-region MVP is enough.',
+      'now with cross-region support.',
+    );
+
+    let written = null;
+    const result = await updateEpicFromOnePager({
+      epicId: 42,
+      onePager: editedOnePager,
+      template,
+      currentBody: original,
+      editIssue: async ({ body }) => {
+        written = body;
+      },
+    });
+
+    assert.equal(result.changed, true);
+    assert.ok(written !== null);
+    // Content changed, but the authored version is preserved (not bumped).
+    assert.equal(extractFrameworkStamp(result.body).version, '1.0.0');
+    assert.ok(result.body.includes('cross-region support'));
   });
 });
 


### PR DESCRIPTION
Closes #4382

_Auto-opened by `/single-story-deliver`._