### PR TITLE
fix: branchCleaner false-blocks a successfully-merged Epic when local branches are already reaped (#4393)

### DIFF
--- a/.agents/scripts/lib/orchestration/epic-cleanup.js
+++ b/.agents/scripts/lib/orchestration/epic-cleanup.js
@@ -153,6 +153,40 @@ export function findWorktreePathForBranch(branch, worktrees) {
 }
 
 /**
+ * Classify a `git branch -D <branch>` result. Pure — no IO. Exported as the
+ * clean unit-test seam for the not-found rule (this module carries a
+ * `node:coverage ignore file` header, so the git-side glue is not directly
+ * covered).
+ *
+ * Story #4393 — on the `/deliver` post-merge reap path a branch is routinely
+ * *already gone* (a prior sweep, a re-run, or GitHub's `--delete-branch`
+ * already dropped it). `git branch -D` then exits non-zero with a "not found"
+ * stderr. That is an **already-reaped success**, not a reap failure: counting
+ * it as a failure forces `reapEpicBranches().ok` false, which makes
+ * BranchCleaner classify `failed`, which flips the merged Epic to
+ * `agent::blocked` and reopens it. Only a not-found stderr is absorbed as
+ * success; every other non-zero exit stays a genuine failure.
+ *
+ * @param {{ status: number, stderr?: string }} branchDel
+ * @returns {{ branchDeleted: boolean, alreadyAbsent: boolean, stderr?: string }}
+ */
+export function classifyBranchDeletion(branchDel) {
+  if (branchDel?.status === 0) {
+    return { branchDeleted: true, alreadyAbsent: false };
+  }
+  const stderr = (branchDel?.stderr ?? '').trim();
+  // git's own message for a missing ref: "error: branch 'foo' not found."
+  if (/\bnot found\b/i.test(stderr)) {
+    return { branchDeleted: true, alreadyAbsent: true };
+  }
+  return {
+    branchDeleted: false,
+    alreadyAbsent: false,
+    ...(stderr ? { stderr } : {}),
+  };
+}
+
+/**
  * Reap a single branch. Best-effort worktree remove → fallback to `--force`
  * → fallback to filesystem rm → `git worktree prune` → `git branch -D`.
  *
@@ -164,7 +198,7 @@ export function findWorktreePathForBranch(branch, worktrees) {
  *   rmSyncFn?: (path: string, opts: object) => void,
  *   logger?: { info?: Function, warn?: Function },
  * }} opts
- * @returns {{ branch: string, worktreeReaped: boolean, branchDeleted: boolean, method: string, stderr?: string }}
+ * @returns {{ branch: string, worktreeReaped: boolean, branchDeleted: boolean, alreadyAbsent: boolean, method: string, stderr?: string }}
  */
 export function reapBranch(opts) {
   const { branch, cwd, worktreePath, gitSpawn, rmSyncFn, logger } = opts;
@@ -201,16 +235,18 @@ export function reapBranch(opts) {
     gitSpawn(cwd, 'worktree', 'prune');
   }
 
-  // Drop the local branch.
+  // Drop the local branch. An already-absent branch (git → "not found") is
+  // already reaped — classifyBranchDeletion absorbs it as success so a benign
+  // missing ref never counts as a reap failure (Story #4393).
   const branchDel = gitSpawn(cwd, 'branch', '-D', branch);
-  const branchDeleted = branchDel.status === 0;
-  const stderr =
-    !branchDeleted && branchDel.stderr ? branchDel.stderr.trim() : undefined;
+  const { branchDeleted, alreadyAbsent, stderr } =
+    classifyBranchDeletion(branchDel);
 
   return {
     branch,
     worktreeReaped,
     branchDeleted,
+    alreadyAbsent,
     method: method ?? 'unknown',
     ...(stderr ? { stderr } : {}),
   };

--- a/tests/lib/orchestration/epic-cleanup.test.js
+++ b/tests/lib/orchestration/epic-cleanup.test.js
@@ -3,6 +3,7 @@ import { describe, it } from 'node:test';
 
 import {
   armCleanupIfMerged,
+  classifyBranchDeletion,
   deleteWtBranchIfPresent,
   detectMergedUncleanedEpic,
   epicBranchHasOpenPr,
@@ -71,6 +72,41 @@ describe('findWorktreePathForBranch', () => {
     ];
     assert.equal(findWorktreePathForBranch('story-9', wts), '/b');
     assert.equal(findWorktreePathForBranch('story-42', wts), null);
+  });
+});
+
+describe('classifyBranchDeletion (Story #4393)', () => {
+  it('treats a clean exit (status 0) as a real deletion', () => {
+    const out = classifyBranchDeletion({ status: 0, stderr: '' });
+    assert.deepEqual(out, { branchDeleted: true, alreadyAbsent: false });
+  });
+
+  it('absorbs an already-absent branch (not-found stderr) as success', () => {
+    const out = classifyBranchDeletion({
+      status: 1,
+      stderr: "error: branch 'story-100' not found.",
+    });
+    assert.equal(out.branchDeleted, true);
+    assert.equal(out.alreadyAbsent, true);
+    // No stderr surfaced — a benign missing ref is not a failure.
+    assert.equal(out.stderr, undefined);
+  });
+
+  it('keeps a genuine reap failure (other stderr) classified as failed', () => {
+    const out = classifyBranchDeletion({
+      status: 128,
+      stderr: "error: branch 'story-7' is checked out at '/wt'",
+    });
+    assert.equal(out.branchDeleted, false);
+    assert.equal(out.alreadyAbsent, false);
+    assert.match(out.stderr, /checked out/);
+  });
+
+  it('is defensive against a missing/empty result envelope', () => {
+    assert.deepEqual(classifyBranchDeletion({}), {
+      branchDeleted: false,
+      alreadyAbsent: false,
+    });
   });
 });
 
@@ -161,6 +197,23 @@ describe('reapBranch', () => {
     assert.match(out.stderr, /checked out/);
   });
 
+  it('treats an already-absent branch (not-found) as reaped, not failed (Story #4393)', () => {
+    const { gitSpawn } = fakeGitSpawnSequence([
+      { status: 0, stdout: '', stderr: '' }, // worktree remove
+      { status: 0, stdout: '', stderr: '' }, // prune
+      { status: 1, stdout: '', stderr: "error: branch 'story-6' not found." },
+    ]);
+    const out = reapBranch({
+      branch: 'story-6',
+      cwd: '/repo',
+      worktreePath: '/wt',
+      gitSpawn,
+    });
+    assert.equal(out.branchDeleted, true);
+    assert.equal(out.alreadyAbsent, true);
+    assert.equal(out.stderr, undefined);
+  });
+
   it('skips worktree steps when no path is given', () => {
     const { gitSpawn, calls } = fakeGitSpawnSequence([
       { status: 0, stdout: '', stderr: '' }, // branch -D only
@@ -242,6 +295,68 @@ describe('reapEpicBranches', () => {
     assert.equal(out.ok, false);
     assert.equal(out.failures.length, 1);
     assert.equal(out.failures[0].branch, 'story-99');
+  });
+
+  it('stays ok=true when every story + epic branch is already absent (Story #4393)', () => {
+    const gitSpawn = (_cwd, ...args) => {
+      if (args[0] === 'worktree' && args[1] === 'list') {
+        return { status: 0, stdout: '', stderr: '' };
+      }
+      if (args[0] === 'branch' && args[1] === '-D') {
+        // Every ref is already gone — GitHub's --delete-branch / a prior
+        // sweep dropped it. git exits non-zero with a not-found stderr.
+        return {
+          status: 1,
+          stdout: '',
+          stderr: `error: branch '${args[2]}' not found.`,
+        };
+      }
+      return { status: 0, stdout: '', stderr: '' };
+    };
+    const out = reapEpicBranches({
+      state: {
+        epicId: 4372,
+        stories: { 1: { status: 'done' }, 2: { status: 'done' } },
+      },
+      cwd: '/repo',
+      gitSpawn,
+      epicBranchHasOpenPrFn: () => false,
+    });
+    assert.equal(out.ok, true, 'already-absent branches must not force ok:false');
+    assert.equal(out.failures.length, 0);
+    assert.equal(out.reaped.length, 3);
+    assert.ok(
+      out.reaped.every((r) => r.branchDeleted === true && r.alreadyAbsent === true),
+      'every already-absent branch is recorded as reaped',
+    );
+  });
+
+  it('still fails when a genuine (non-not-found) reap error occurs (Story #4393)', () => {
+    const gitSpawn = (_cwd, ...args) => {
+      if (args[0] === 'worktree' && args[1] === 'list') {
+        return { status: 0, stdout: '', stderr: '' };
+      }
+      if (args[0] === 'branch' && args[1] === '-D' && args[2] === 'story-5') {
+        // Not a not-found error — a real refusal that must stay classified
+        // as a failure.
+        return {
+          status: 128,
+          stdout: '',
+          stderr: "error: branch 'story-5' is checked out at '/wt'",
+        };
+      }
+      return { status: 0, stdout: '', stderr: '' };
+    };
+    const out = reapEpicBranches({
+      state: { epicId: 8, stories: { 5: { status: 'done' } } },
+      cwd: '/repo',
+      gitSpawn,
+      epicBranchHasOpenPrFn: () => false,
+    });
+    assert.equal(out.ok, false);
+    assert.equal(out.failures.length, 1);
+    assert.equal(out.failures[0].branch, 'story-5');
+    assert.match(out.failures[0].stderr, /checked out/);
   });
 
   it('switches main checkout off epic/<id> before deleting it', () => {

--- a/tests/lib/orchestration/epic-cleanup.test.js
+++ b/tests/lib/orchestration/epic-cleanup.test.js
@@ -322,11 +322,17 @@ describe('reapEpicBranches', () => {
       gitSpawn,
       epicBranchHasOpenPrFn: () => false,
     });
-    assert.equal(out.ok, true, 'already-absent branches must not force ok:false');
+    assert.equal(
+      out.ok,
+      true,
+      'already-absent branches must not force ok:false',
+    );
     assert.equal(out.failures.length, 0);
     assert.equal(out.reaped.length, 3);
     assert.ok(
-      out.reaped.every((r) => r.branchDeleted === true && r.alreadyAbsent === true),
+      out.reaped.every(
+        (r) => r.branchDeleted === true && r.alreadyAbsent === true,
+      ),
       'every already-absent branch is recorded as reaped',
     );
   });

--- a/tests/lib/orchestration/lifecycle/listener-branch-cleaner.test.js
+++ b/tests/lib/orchestration/lifecycle/listener-branch-cleaner.test.js
@@ -185,6 +185,40 @@ describe('BranchCleaner — handle()', () => {
     assert.equal(last.failures[0].stderr, 'pinned');
   });
 
+  it('records reaped (not failed) when every branch is already absent (Story #4393)', async () => {
+    const state = {
+      epicId: 4372,
+      stories: { 100: { status: 'done' }, 101: { status: 'done' } },
+    };
+    const { cleaner } = buildHarness({
+      state,
+      gitOverrides: [
+        {
+          // Every `git branch -D` reports the ref is already gone — the
+          // /deliver post-merge path where GitHub / a prior sweep already
+          // dropped the branches. classifyBranchDeletion keys off the
+          // "not found" substring, so a fixed message covers every ref.
+          match: (args) => args[0] === 'branch' && args[1] === '-D',
+          result: {
+            status: 1,
+            stdout: '',
+            stderr: 'error: branch not found.',
+          },
+        },
+      ],
+    });
+    await cleaner.handle({ event: 'epic.cleanup.start', seqId: 40 });
+    const last = cleaner.classifications.at(-1);
+    assert.equal(
+      last.outcome,
+      'reaped',
+      'an all-already-absent cleanup must NOT classify as failed (would false-block the merged Epic)',
+    );
+    assert.equal(last.epicId, 4372);
+    // 2 story branches + the epic branch (wt-branch is a separate sweep).
+    assert.equal(last.branchesDeleted, 3);
+  });
+
   it('records skipped-duplicate on a replayed (event, seqId)', async () => {
     const state = { epicId: 1, stories: { 9: { status: 'done' } } };
     const { cleaner } = buildHarness({ state });


### PR DESCRIPTION
Closes #4393

_Auto-opened by `/single-story-deliver`._