### PR TITLE
feat(git-cleanup): detect content-merged branches and surface silent skips (#4395)

### DIFF
--- a/.agents/scripts/git-cleanup.js
+++ b/.agents/scripts/git-cleanup.js
@@ -55,11 +55,14 @@ import {
   computeProtectedSet,
 } from './lib/orchestration/git-cleanup/phases/filters.js';
 import {
+  branchLastCommitAt,
   branchTipSha,
   classifyLatestPr,
   probeAllPrs,
+  probeContentEquivalent,
   probeLatestPr,
   probeMergedPr,
+  refExists,
 } from './lib/orchestration/git-cleanup/phases/git-probes.js';
 import { parseCleanupArgs } from './lib/orchestration/git-cleanup/phases/parse-args.js';
 import {
@@ -74,6 +77,7 @@ import {
   renderExecutionLine,
   renderExecutionSummary,
   renderLatestPrSkipLine,
+  renderNotMergedSkipLine,
   renderPruneLine,
 } from './lib/orchestration/git-cleanup/phases/render.js';
 import {
@@ -86,6 +90,7 @@ import {
 
 // Public surface preserved for tests + `single-story-sweep.js`.
 export {
+  branchLastCommitAt,
   branchTipSha,
   buildAllowlistDecider,
   buildGlobFilter,
@@ -105,13 +110,16 @@ export {
   planFastForward,
   planStashes,
   probeAllPrs,
+  probeContentEquivalent,
   probeLatestPr,
   probeMergedPr,
+  refExists,
   renderDeferredLine,
   renderDryRun,
   renderExecutionLine,
   renderExecutionSummary,
   renderLatestPrSkipLine,
+  renderNotMergedSkipLine,
   renderPruneLine,
   stashRefIndex,
 };

--- a/.agents/scripts/lib/orchestration/git-cleanup/phases/branches.js
+++ b/.agents/scripts/lib/orchestration/git-cleanup/phases/branches.js
@@ -21,6 +21,7 @@ import {
 } from './branches-reap.js';
 import { computeProtectedReason } from './filters.js';
 import {
+  branchLastCommitAt,
   branchTipSha,
   classifyLatestPr,
   currentBranch as defaultCurrentBranch,
@@ -28,13 +29,17 @@ import {
   listMergedBranches,
   listRemoteBranches,
   probeAllPrs,
+  probeContentEquivalent,
   probeLatestPr,
   pruneRemoteTracking,
   readProtectedConfig,
+  refExists,
   removeWorktree,
   worktreesByBranch,
 } from './git-probes.js';
 import { parsePrunedRefs } from './prune.js';
+
+const TAG = '[git-cleanup]';
 
 function skipEntryFromVerdict(branch, verdict) {
   const entry = { branch, reason: verdict.reason };
@@ -44,8 +49,37 @@ function skipEntryFromVerdict(branch, verdict) {
   return entry;
 }
 
+/**
+ * Story #4395 — the third detection signal. Reached only when the branch
+ * has no reapable PR verdict and is not an ancestor of `<base>` (or
+ * `origin/<base>`). Probes content-equivalence via `git merge-tree
+ * --write-tree` and, when the probe is conclusive and the merge is a
+ * no-op, classifies the branch as `content-merged` instead of falling
+ * through to the `not-merged` skip.
+ */
+function evaluateContentEquivalence({
+  branch,
+  baseBranch,
+  cwd,
+  contentEquivalentFn,
+  branchLastCommitFn,
+}) {
+  const verdict = contentEquivalentFn({ cwd, base: baseBranch, branch });
+  if (verdict?.supported && verdict.equivalent) {
+    return { detectedBy: 'content-merged' };
+  }
+  return {
+    skip: {
+      branch,
+      reason: 'not-merged',
+      lastCommitAt: branchLastCommitFn(cwd, branch),
+    },
+  };
+}
+
 function evaluateLocalBranch({
   branch,
+  baseBranch,
   classify,
   filter,
   mergedByGit,
@@ -54,6 +88,8 @@ function evaluateLocalBranch({
   wtMap,
   remoteName,
   branchTipShaFn,
+  contentEquivalentFn,
+  branchLastCommitFn,
 }) {
   const protectedReason = classify(branch);
   if (protectedReason) return { skip: { branch, reason: protectedReason } };
@@ -78,7 +114,15 @@ function evaluateLocalBranch({
   } else if (mergedByGit.has(branch)) {
     detectedBy = 'git-merged';
   } else {
-    return { skip: { branch, reason: 'not-merged' } };
+    const out = evaluateContentEquivalence({
+      branch,
+      baseBranch,
+      cwd,
+      contentEquivalentFn,
+      branchLastCommitFn,
+    });
+    if (out.skip) return out;
+    detectedBy = out.detectedBy;
   }
   const wt = wtMap.get(branch);
   return {
@@ -156,7 +200,43 @@ function collectRemoteOnlyCandidates({
  * the per-branch fallback for head refs absent from the bulk page (a PR
  * that fell outside the fetch window), so correctness is preserved for
  * every branch. Injecting `prProbe` bypasses the bulk fetch entirely.
+ *
+ * Story #4395 adds three refinements:
+ *   - **Content-equivalence signal.** A local branch with no reapable PR
+ *     verdict and no ancestry match gets one more chance via
+ *     {@link probeContentEquivalent} (`git merge-tree --write-tree`):
+ *     when merging it into `baseBranch` would be a content no-op, it is
+ *     classified `detectedBy: 'content-merged'` instead of skipped.
+ *   - **Fresh ancestry anchor.** The ancestry signal (`git branch --merged`)
+ *     is unioned against `origin/<base>` (via `refExistsFn` + `mergedLister`)
+ *     whenever that remote-tracking ref exists, so a stale local `<base>`
+ *     no longer hides a branch already merged on the remote.
+ *   - **Graceful `gh` degradation.** A throwing `gh` runner (auth failure,
+ *     rate limit, missing binary) inside the bulk index fetch or the
+ *     per-branch fallback is caught, logged once, and degrades to
+ *     git-only signals (ancestry + content-equivalence) rather than
+ *     aborting the whole plan. The returned envelope's `ghDegraded` flag
+ *     records whether this happened.
  */
+function buildGuardedPrProbe({ cwd, prIndexFn, prFallback, onDegrade }) {
+  let prIndex;
+  try {
+    prIndex = prIndexFn(cwd);
+  } catch (err) {
+    onDegrade(err);
+    prIndex = new Map();
+  }
+  return (branch, c) => {
+    if (prIndex.has(branch)) return prIndex.get(branch);
+    try {
+      return prFallback(branch, c);
+    } catch (err) {
+      onDegrade(err);
+      return null;
+    }
+  };
+}
+
 export function planCleanup(ctx) {
   const {
     cwd,
@@ -170,18 +250,26 @@ export function planCleanup(ctx) {
     prIndexFn = probeAllPrs,
     prFallback = probeLatestPr,
     branchTipShaFn = branchTipSha,
+    contentEquivalentFn = probeContentEquivalent,
+    branchLastCommitFn = branchLastCommitAt,
+    refExistsFn = refExists,
     filter = () => true,
     includeRemoteOnly = false,
     remoteLister = listRemoteBranches,
     remoteName = 'origin',
+    logger = Logger,
   } = ctx;
+  let ghDegraded = false;
+  const onDegrade = (err) => {
+    if (ghDegraded) return;
+    ghDegraded = true;
+    logger.warn?.(
+      `${TAG} ⚠️ gh probe failed (${err?.message ?? err}); continuing with git-only signals`,
+    );
+  };
   const prProbe =
     injectedPrProbe ??
-    (() => {
-      const prIndex = prIndexFn(cwd);
-      return (branch, c) =>
-        prIndex.has(branch) ? prIndex.get(branch) : prFallback(branch, c);
-    })();
+    buildGuardedPrProbe({ cwd, prIndexFn, prFallback, onDegrade });
   const resolvedCurrent = currentBranchFn(cwd);
   const resolvedConfigured = protectedConfigFn(cwd);
   const classify = (branch) =>
@@ -193,6 +281,10 @@ export function planCleanup(ctx) {
     });
   const wtMap = worktreesFn(cwd);
   const mergedByGit = new Set(mergedLister(cwd, baseBranch));
+  const remoteBaseRef = `${remoteName}/${baseBranch}`;
+  if (refExistsFn(cwd, remoteBaseRef)) {
+    for (const b of mergedLister(cwd, remoteBaseRef)) mergedByGit.add(b);
+  }
   const localBranches = localLister(cwd);
   const localSet = new Set(localBranches);
   const candidates = [];
@@ -200,6 +292,7 @@ export function planCleanup(ctx) {
   for (const branch of localBranches) {
     const out = evaluateLocalBranch({
       branch,
+      baseBranch,
       classify,
       filter,
       mergedByGit,
@@ -208,6 +301,8 @@ export function planCleanup(ctx) {
       wtMap,
       remoteName,
       branchTipShaFn,
+      contentEquivalentFn,
+      branchLastCommitFn,
     });
     if (out.skip) skipped.push(out.skip);
     else candidates.push(out.candidate);
@@ -227,7 +322,7 @@ export function planCleanup(ctx) {
       }),
     );
   }
-  return { candidates, skipped };
+  return { candidates, skipped, ghDegraded };
 }
 
 /**

--- a/.agents/scripts/lib/orchestration/git-cleanup/phases/git-probes.js
+++ b/.agents/scripts/lib/orchestration/git-cleanup/phases/git-probes.js
@@ -344,7 +344,91 @@ export function branchTipSha({
   return res.status !== 0 ? null : validSha(firstLsRemoteSha(res.stdout));
 }
 
-export const __testing = { validSha, firstLsRemoteSha };
+/* node:coverage ignore next */
+// Story #4395: ancestry-anchor freshness check. `planCleanup` calls this
+// before unioning `git branch --merged origin/<base>` into the ancestry
+// signal so a stale local `<base>` (fast-forward phase skipped or
+// `--branches` run alone) doesn't hide a branch that's already merged on
+// the remote.
+export function refExists(cwd, ref) {
+  const res = gitSpawn(cwd, 'rev-parse', '--verify', '--quiet', ref);
+  return res.status === 0;
+}
+
+/* node:coverage ignore next */
+// Story #4395: last-commit timestamp for the dry-run `not-merged`
+// skip-visibility line (branch name + last-commit age).
+export function branchLastCommitAt(cwd, branch) {
+  const res = gitSpawn(
+    cwd,
+    'log',
+    '-1',
+    '--format=%cI',
+    `refs/heads/${branch}`,
+    '--',
+  );
+  if (res.status !== 0) return null;
+  return res.stdout.trim() || null;
+}
+
+/**
+ * First non-empty trimmed stdout line — the resulting tree OID on a clean
+ * `git merge-tree --write-tree` run.
+ *
+ * @param {string} stdout
+ * @returns {string}
+ */
+function firstStdoutLine(stdout) {
+  const first = (stdout ?? '')
+    .split('\n')
+    .map((l) => l.trim())
+    .find(Boolean);
+  return first ?? '';
+}
+
+/**
+ * Probe content-equivalence between `base` and `branch` via
+ * `git merge-tree --write-tree <base> <branch>` (git >= 2.38, Story #4395).
+ *
+ * A clean merge (exit 0) whose resulting tree OID equals `<base>`'s own
+ * tree OID means applying `branch`'s changes on top of `base` is a no-op —
+ * `branch`'s content already lives in `base` by another route (a
+ * squash-merged Epic PR, a cherry-pick, a manual `merge --squash`) that
+ * neither the PR probe nor the ancestry check can see.
+ *
+ * Both the "unsupported" case (git < 2.38 rejects `--write-tree`) and the
+ * "real conflict" case (branch and base diverge and cannot auto-merge)
+ * surface as a non-zero exit. This probe treats them identically — the
+ * signal is inconclusive, so the caller keeps the branch's current
+ * `not-merged` classification rather than guessing.
+ *
+ * @param {{ cwd: string, base: string, branch: string, spawn?: typeof gitSpawn }} args
+ * @returns {{ supported: false } | { supported: true, equivalent: boolean }}
+ */
+export function probeContentEquivalent({
+  cwd,
+  base,
+  branch,
+  spawn = gitSpawn,
+}) {
+  const merged = spawn(cwd, 'merge-tree', '--write-tree', base, branch);
+  if (merged.status !== 0) return { supported: false };
+  const mergedTree = validSha(firstStdoutLine(merged.stdout));
+  if (!mergedTree) return { supported: false };
+  const baseTreeRes = spawn(
+    cwd,
+    'rev-parse',
+    '--verify',
+    '--quiet',
+    `${base}^{tree}`,
+  );
+  if (baseTreeRes.status !== 0) return { supported: false };
+  const baseTree = validSha(baseTreeRes.stdout);
+  if (!baseTree) return { supported: false };
+  return { supported: true, equivalent: mergedTree === baseTree };
+}
+
+export const __testing = { validSha, firstLsRemoteSha, firstStdoutLine };
 
 /**
  * Pure-ish: classify a latest-PR probe row into a planner verdict.

--- a/.agents/scripts/lib/orchestration/git-cleanup/phases/phase-drivers.js
+++ b/.agents/scripts/lib/orchestration/git-cleanup/phases/phase-drivers.js
@@ -191,6 +191,22 @@ export async function runPrunePhase(opts, cwd) {
 // =====================================================================
 
 /**
+ * Count of a plan's *actionable* candidates — the ones `executeCleanup`
+ * will actually delete given the current `--remote` setting. Story #4395
+ * always enumerates remote-only candidates in `plan.candidates` (so the
+ * operator sees them in the dry-run list), but their deletion still
+ * requires `--remote`; without it, `executeCleanup` no-ops on every
+ * `localExists: false` candidate. Counting only the actionable subset
+ * keeps the "no-candidates" short-circuit and the confirmation prompt's
+ * "Reap N" count honest about what will actually happen.
+ */
+function countActionableCandidates(candidates, remote) {
+  return remote
+    ? candidates.length
+    : candidates.filter((c) => c.localExists !== false).length;
+}
+
+/**
  * Pure: decide what the branch-reap phase should do given the plan.
  *
  * Returns an action record:
@@ -209,7 +225,11 @@ export function decideBranchPhase(state) {
   if (opts.dryRun) {
     return { kind: 'dry-run', plan, result: { plan, result: null } };
   }
-  if (plan.candidates.length === 0) {
+  const actionableCount = countActionableCandidates(
+    plan.candidates,
+    opts.remote,
+  );
+  if (actionableCount === 0) {
     return { kind: 'no-candidates', plan, result: { plan, result: null } };
   }
   const executeArgs = {
@@ -218,10 +238,17 @@ export function decideBranchPhase(state) {
     remote: opts.remote,
   };
   if (!opts.yes) {
+    const contentMergedCount = plan.candidates.filter(
+      (c) => c.detectedBy === 'content-merged',
+    ).length;
+    const weakSignalNote =
+      contentMergedCount > 0
+        ? ` (${contentMergedCount} content-merged — weaker signal, verify before confirming)`
+        : '';
     return {
       kind: 'prompt-then-execute',
       plan,
-      promptMessage: `${TAG} Reap ${plan.candidates.length} merged branch(es)${opts.remote ? ' (including origin)' : ''}?`,
+      promptMessage: `${TAG} Reap ${actionableCount} merged branch(es)${opts.remote ? ' (including origin)' : ''}${weakSignalNote}?`,
       declinedResult: { plan, result: null, declined: true },
       executeArgs,
     };
@@ -254,11 +281,15 @@ export async function runBranchPhase(opts, cwd, baseBranch) {
     include: opts.include,
     exclude: opts.exclude,
   });
+  // Story #4395: always enumerate remote-only merged branches so the
+  // dry-run / prompt shows them without requiring `--remote`. Deletion of
+  // a remote-only candidate still requires `--remote` — `executeCleanup`
+  // no-ops on `localExists: false` candidates otherwise (unchanged).
   const plan = planCleanup({
     cwd,
     baseBranch,
     filter,
-    includeRemoteOnly: opts.remote === true,
+    includeRemoteOnly: true,
   });
   emitDryRunHuman(plan, baseBranch);
   const action = decideBranchPhase({ plan, opts, cwd });

--- a/.agents/scripts/lib/orchestration/git-cleanup/phases/render.js
+++ b/.agents/scripts/lib/orchestration/git-cleanup/phases/render.js
@@ -9,10 +9,61 @@
  */
 
 const TAG = '[git-cleanup]';
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * Pure: format a last-commit ISO timestamp as a short relative-age string
+ * for the `not-merged` skip-visibility line (Story #4395). Returns
+ * `'unknown'` when `iso` is missing or unparseable — a branch whose commit
+ * date could not be resolved (e.g. `gh`-degraded run, deleted ref) still
+ * gets a line, just without an age.
+ *
+ * @param {string|null|undefined} iso
+ * @param {number} now  Epoch-ms reference clock (injectable for tests).
+ * @returns {string}
+ */
+function formatCommitAge(iso, now) {
+  if (!iso) return 'unknown';
+  const then = Date.parse(iso);
+  if (!Number.isFinite(then)) return 'unknown';
+  const days = Math.max(0, Math.floor((now - then) / DAY_MS));
+  if (days === 0) return 'today';
+  if (days === 1) return '1 day ago';
+  return `${days} days ago`;
+}
+
+/**
+ * Pure: render a single `not-merged` skip-visibility line (Story #4395).
+ * `renderDryRun` previously kept `not-merged` survivors silent; this
+ * surfaces each one with its last-commit age so the operator can see why
+ * a leftover branch isn't reaped instead of hunting for it by hand.
+ *
+ * @param {{ branch: string, reason: string, lastCommitAt?: string|null }} skip
+ * @param {{ now?: number }} [opts]
+ * @returns {string | null}
+ */
+export function renderNotMergedSkipLine(skip, opts = {}) {
+  if (!skip || skip.reason !== 'not-merged') return null;
+  const now = opts.now ?? Date.now();
+  const age = formatCommitAge(skip.lastCommitAt, now);
+  return `${TAG} ⏭️  ${skip.branch} skipped — not merged (last commit: ${age})`;
+}
+
+/**
+ * Pure: render a single content-merged candidate annotation line
+ * (Story #4395). `content-merged` is a weaker signal than a merged PR or
+ * git ancestry — this note lets the operator tell it apart in both the
+ * dry-run list and the confirmation prompt.
+ */
+function contentMergedNote(candidate) {
+  return candidate.detectedBy === 'content-merged'
+    ? ' (weaker signal — verify before deleting)'
+    : '';
+}
 
 /** Pure: render the dry-run plan as the operator-facing text block. */
 export function renderDryRun(plan, opts = {}) {
-  const { baseBranch = null } = opts;
+  const { baseBranch = null, now } = opts;
   const lines = [
     `${TAG} DRY RUN (nothing deleted) — ${plan.candidates.length} candidate(s)`,
   ];
@@ -23,7 +74,9 @@ export function renderDryRun(plan, opts = {}) {
       const pr = c.prNumber ? `PR #${c.prNumber}` : c.detectedBy;
       const wt = c.hasWorktree ? ` (worktree: ${c.worktreePath})` : '';
       const remoteOnly = c.localExists === false ? ' (remote-only)' : '';
-      lines.push(`  • ${c.branch} — ${pr}${wt}${remoteOnly}`);
+      lines.push(
+        `  • ${c.branch} — ${pr}${wt}${remoteOnly}${contentMergedNote(c)}`,
+      );
     }
   }
   const skipped = plan.skipped ?? [];
@@ -40,6 +93,15 @@ export function renderDryRun(plan, opts = {}) {
     const line = renderLatestPrSkipLine(skip);
     if (line) lines.push(line);
   }
+  for (const skip of skipped) {
+    const line = renderNotMergedSkipLine(skip, { now });
+    if (line) lines.push(line);
+  }
+  if (plan.ghDegraded) {
+    lines.push(
+      `${TAG} ⚠️ gh probe degraded — candidates rely on git-only signals (ancestry + content-equivalence) for this run`,
+    );
+  }
   return lines;
 }
 
@@ -47,7 +109,8 @@ export function renderDryRun(plan, opts = {}) {
  * Pure: render a single latest-PR-state skip line. Returns null when the
  * skip reason is not one of the latest-PR family — `renderDryRun` filters
  * by truthy return value so unrelated skip reasons (`protected`,
- * `current-head`, `filtered`, `not-merged`) stay quiet.
+ * `current-head`, `filtered`) stay quiet here. `not-merged` gets its own
+ * renderer ({@link renderNotMergedSkipLine}).
  *
  * @param {{ branch: string, reason: string, prNumber?: number, tipSha?: string, mergedSha?: string }} skip
  * @returns {string | null}
@@ -64,7 +127,10 @@ export function renderLatestPrSkipLine(skip) {
   if (skip.reason === 'tip-diverged-from-merge') {
     const tip = skip.tipSha ? skip.tipSha.slice(0, 7) : '<unknown>';
     const merged = skip.mergedSha ? skip.mergedSha.slice(0, 7) : '<unknown>';
-    return `${TAG} ⏭️  ${skip.branch} skipped — tip ${tip} diverges from ${prRef}'s merged ${merged} (post-merge force-push)`;
+    return (
+      `${TAG} ⏭️  ${skip.branch} skipped — tip ${tip} diverges from ${prRef}'s merged ${merged} (post-merge force-push); ` +
+      `resolve by deleting manually (\`git branch -D ${skip.branch}\`) or pushing the follow-up commit`
+    );
   }
   if (skip.reason === 'latest-pr-unknown-state') {
     return `${TAG} ⏭️  ${skip.branch} skipped — ${prRef} has an unrecognized state`;
@@ -160,6 +226,7 @@ export function buildJsonEnvelope({
     baseBranch,
     candidates: plan.candidates,
     skipped: plan.skipped,
+    ghDegraded: plan.ghDegraded ?? false,
     worktrees: r.worktrees,
     local: r.local,
     remote: r.remote,

--- a/.agents/workflows/git-cleanup.md
+++ b/.agents/workflows/git-cleanup.md
@@ -18,11 +18,17 @@ confirmation:
 3. **reap merged local branches** — the existing squash-aware
    `gh pr list --state merged` + `git branch --merged <base>` sweep,
    with attached worktrees removed first. Optionally also deletes the
-   `origin/<branch>` ref when `--remote` is passed. With `--remote`,
-   the planner additionally enumerates `refs/remotes/origin/*` and
-   reaps any **remote-only** merged branches — branches whose local
-   ref is already gone (or never existed) but whose `origin/<branch>`
-   still points at a merged PR.
+   `origin/<branch>` ref when `--remote` is passed. Every default run
+   also **enumerates** `refs/remotes/origin/*` and reports any
+   **remote-only** merged branches — branches whose local ref is
+   already gone (or never existed) but whose `origin/<branch>` still
+   points at a merged PR — even without `--remote`; `--remote` is still
+   required to *delete* them. A third branch, whose content already
+   landed in `<base>` by another route (a squash-merged Epic PR, a
+   cherry-pick, a manual `merge --squash`), is caught by a
+   **content-equivalence probe** (`git merge-tree --write-tree`,
+   git ≥ 2.38) even when it has no merged PR of its own and is not a
+   git ancestor of `<base>`.
 4. **triage `git stash` entries** — list every stash and prompt for
    `drop / keep / quit` per entry (or pass `--drop-stashes <ref>` for
    non-interactive use).
@@ -150,6 +156,10 @@ programmatic consumption:
       "detectedBy": "gh"
     }
   ],
+  "skipped": [
+    { "branch": "story-4200", "reason": "not-merged", "lastCommitAt": "2026-05-01T00:00:00Z" }
+  ],
+  "ghDegraded": false,
   "worktrees": [{ "path": "C:/repo/.worktrees/fix-foo", "ok": true, "dirty": false }],
   "local":  [{ "branch": "fix/foo", "ok": true, "alreadyGone": false }],
   "remote": [{ "branch": "fix/foo", "ok": true, "alreadyGone": true }],
@@ -200,18 +210,51 @@ follow-up prune when `--remote` is set, so passing both is idempotent
 
 ### branches
 
-The merged-branch sweep semantics:
+The merged-branch sweep recognizes three detection signals, in order:
 
-- A branch is a candidate iff it is not `<base>`, not the current
-  HEAD, not in `git config branch.protectedBranches`, and either has a
-  merged PR (`gh pr list --head <branch> --state merged`) or appears in
-  `git branch --merged <base>`.
+1. **`detectedBy: 'gh'`** — the branch has a merged PR
+   (`gh pr list --head <branch> --state all`, classified by the
+   **latest** PR's state).
+2. **`detectedBy: 'git-merged'`** — the branch is a git ancestor of
+   `<base>` (`git branch --merged <base>`), or of `origin/<base>` when
+   that remote-tracking ref exists (unioned so a stale local `<base>` —
+   fast-forward phase skipped, or `--branches` run alone — no longer
+   hides a branch already merged on the remote).
+3. **`detectedBy: 'content-merged'`** (Story #4395) — the branch has no
+   reapable PR verdict and is not an ancestor of `<base>` under either
+   anchor, but simulating the merge via
+   `git merge-tree --write-tree <base> <branch>` (git ≥ 2.38) produces a
+   tree identical to `<base>`'s own tree — i.e. applying the branch's
+   changes on top of `<base>` is a content no-op. This catches
+   `story-<id>` branches merged into `epic/<id>` whose Epic PR
+   **squash-merged** to `main` (the story commits are not ancestors of
+   `main` and the story branch usually has no PR of its own), and any
+   other branch whose content landed via a different route (a renamed
+   head, a cherry-pick, a manual `merge --squash`). When git rejects
+   `--write-tree` (git < 2.38) or the simulated merge conflicts, the
+   probe is inconclusive and the branch keeps its existing `not-merged`
+   skip — the signal never guesses. `content-merged` candidates render
+   with a "weaker signal — verify before deleting" annotation in the
+   dry-run list and are called out separately in the confirmation
+   prompt, since — unlike a merged PR or git ancestry — no CI or GitHub
+   merge check ever validated this branch's exact diff.
+
+Other candidate semantics:
+
+- A branch is a candidate iff it is not `<base>`, not the current HEAD,
+  not in `git config branch.protectedBranches`, and matches one of the
+  three signals above.
 - When a candidate has an attached worktree, the worktree is removed
   (force if dirty) **before** `git branch -D`, mirroring the pattern in
   [`worktree-lifecycle.md`](helpers/worktree-lifecycle.md).
 - `--remote` is required on top of `--execute` to touch `origin/`.
+- A throwing `gh` runner (auth failure, rate limit, missing binary) no
+  longer aborts the run: the branches phase logs one warning and
+  continues with the git-only signals (ancestry + content-equivalence).
+  The JSON envelope's `ghDegraded: true` records that this happened for
+  the run, and the dry-run text carries a matching warning line.
 
-The skip taxonomy distinguishes two unreapable cases:
+The skip taxonomy:
 
 - `reason: 'protected'` — the base branch or a name in
   `git config branch.protectedBranches`. Not reapable; ignore.
@@ -219,15 +262,26 @@ The skip taxonomy distinguishes two unreapable cases:
   `git checkout <base>`. The dry-run output surfaces a remediation
   hint so the operator sees the recovery path without having to look
   in the JSON envelope.
+- `reason: 'tip-diverged-from-merge'` — the latest PR merged, but the
+  branch's tip has since moved past the merged commit (a post-merge
+  force-push). The dry-run line names both SHAs and a remediation hint
+  (delete manually via `git branch -D <branch>`, or push the follow-up
+  commit).
+- `reason: 'not-merged'` — none of the three detection signals matched.
+  Previously silent; the dry-run output now lists every surviving
+  `not-merged` branch as a one-line-per-branch summary with its
+  last-commit age, so the operator can see why a leftover branch isn't
+  reaped instead of hunting for it by hand.
 
-The `--remote` flag also opts the planner into a **remote-only
+Every default run also opts the planner into a **remote-only
 enumeration pass**: in addition to walking `refs/heads/*`, the planner
 also walks `refs/remotes/origin/*` and emits candidates for any branch
 that exists on `origin` with a merged PR but has no local ref. These
-candidates carry `detectedBy: 'remote-only'` and `localExists: false`,
-and the executor runs only the `git push --delete origin/<branch>`
-path for them (no local `git branch -D` is attempted — there is no
-local branch to delete).
+candidates carry `detectedBy: 'remote-only'` and `localExists: false`
+and are always shown in the dry-run list; **deleting** them (via the
+`git push --delete origin/<branch>` path — no local `git branch -D` is
+attempted, since there is no local branch) still requires `--remote` on
+top of `--execute`, unchanged.
 
 ### stashes
 

--- a/tests/lib/orchestration/git-cleanup-content-merged.integration.test.js
+++ b/tests/lib/orchestration/git-cleanup-content-merged.integration.test.js
@@ -1,0 +1,170 @@
+// tests/lib/orchestration/git-cleanup-content-merged.integration.test.js
+//
+// Real-git round-trip tests for the Story #4395 content-equivalence signal
+// (`probeContentEquivalent` + `planCleanup`'s `content-merged` detection).
+// These spawn real git processes against a tmp repo and take longer than
+// the mocked unit suite in tests/scripts/git-cleanup.test.js; excluded from
+// `test:quick`, run under `test:integration` / `npm test`.
+
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, it } from 'node:test';
+
+import { planCleanup } from '../../../.agents/scripts/lib/orchestration/git-cleanup/phases/branches.js';
+import { probeContentEquivalent } from '../../../.agents/scripts/lib/orchestration/git-cleanup/phases/git-probes.js';
+
+// Strip every GIT_* env var so the tmpdir cwd wins even when this suite
+// runs inside a git hook (husky pre-push exports GIT_DIR / GIT_WORK_TREE /
+// etc that would otherwise override execFileSync's `cwd`).
+const CLEAN_ENV = Object.fromEntries(
+  Object.entries(process.env).filter(([k]) => !k.startsWith('GIT_')),
+);
+
+function run(cwd, ...args) {
+  return execFileSync('git', args, {
+    cwd,
+    encoding: 'utf8',
+    stdio: ['pipe', 'pipe', 'pipe'],
+    env: CLEAN_ENV,
+  });
+}
+
+function writeFile(repo, name, content) {
+  fs.writeFileSync(path.join(repo, name), content);
+}
+
+describe('probeContentEquivalent + planCleanup content-merged (real git, Story #4395)', () => {
+  let repo;
+
+  beforeEach(() => {
+    repo = fs.realpathSync.native(
+      fs.mkdtempSync(path.join(os.tmpdir(), 'git-cleanup-cm-')),
+    );
+    run(repo, 'init', '-b', 'main');
+    run(repo, 'config', 'user.email', 'test@example.com');
+    run(repo, 'config', 'user.name', 'Test');
+    writeFile(repo, 'README.md', 'root\n');
+    run(repo, 'add', '.');
+    run(repo, 'commit', '-m', 'init');
+  });
+
+  afterEach(() => {
+    fs.rmSync(repo, { recursive: true, force: true });
+  });
+
+  it('reports equivalent: true for a squash-orphaned branch', () => {
+    // Branch off main, add a feature commit.
+    run(repo, 'checkout', '-b', 'story-100');
+    writeFile(repo, 'feature.txt', 'hello from story-100\n');
+    run(repo, 'add', '.');
+    run(repo, 'commit', '-m', 'feat: add feature.txt');
+
+    // Simulate a squash-merged Epic PR: apply the same diff on main via a
+    // brand-new commit (no ancestry link back to story-100's tip).
+    run(repo, 'checkout', 'main');
+    run(repo, 'merge', '--squash', 'story-100');
+    run(repo, 'commit', '-m', 'feat: Epic (squash of story-100)');
+
+    // story-100 is neither a git ancestor of main (squash breaks ancestry)
+    // nor associated with any PR — exactly the silent-skip shape.
+    const out = probeContentEquivalent({
+      cwd: repo,
+      base: 'main',
+      branch: 'story-100',
+    });
+    assert.equal(out.supported, true);
+    assert.equal(out.equivalent, true);
+  });
+
+  it('reports equivalent: false for a branch with genuinely unmerged content', () => {
+    run(repo, 'checkout', '-b', 'story-101');
+    writeFile(repo, 'unmerged.txt', 'never landed on main\n');
+    run(repo, 'add', '.');
+    run(repo, 'commit', '-m', 'feat: add unmerged.txt');
+    run(repo, 'checkout', 'main');
+
+    const out = probeContentEquivalent({
+      cwd: repo,
+      base: 'main',
+      branch: 'story-101',
+    });
+    assert.equal(out.supported, true);
+    assert.equal(out.equivalent, false);
+  });
+
+  it('returns supported: false (inconclusive) when the simulated merge conflicts', () => {
+    // Diverge both main and the branch on the same line of the same file
+    // from a common ancestor so `merge-tree --write-tree` cannot
+    // auto-resolve.
+    writeFile(repo, 'shared.txt', 'base\n');
+    run(repo, 'add', '.');
+    run(repo, 'commit', '-m', 'chore: add shared.txt');
+
+    run(repo, 'checkout', '-b', 'story-102');
+    writeFile(repo, 'shared.txt', 'branch-version\n');
+    run(repo, 'add', '.');
+    run(repo, 'commit', '-m', 'chore: branch edits shared.txt');
+
+    run(repo, 'checkout', 'main');
+    writeFile(repo, 'shared.txt', 'main-version\n');
+    run(repo, 'add', '.');
+    run(repo, 'commit', '-m', 'chore: main edits shared.txt');
+
+    const out = probeContentEquivalent({
+      cwd: repo,
+      base: 'main',
+      branch: 'story-102',
+    });
+    assert.equal(out.supported, false);
+  });
+
+  it('planCleanup classifies the squash-orphaned branch as content-merged end-to-end', () => {
+    run(repo, 'checkout', '-b', 'story-200');
+    writeFile(repo, 'feature.txt', 'hello from story-200\n');
+    run(repo, 'add', '.');
+    run(repo, 'commit', '-m', 'feat: add feature.txt');
+    run(repo, 'checkout', 'main');
+    run(repo, 'merge', '--squash', 'story-200');
+    run(repo, 'commit', '-m', 'feat: Epic (squash of story-200)');
+
+    const plan = planCleanup({
+      cwd: repo,
+      baseBranch: 'main',
+      prProbe: () => null, // no gh access in this fixture
+      refExistsFn: () => false, // no origin remote configured
+    });
+
+    const candidate = plan.candidates.find((c) => c.branch === 'story-200');
+    assert.ok(candidate, 'story-200 should be a reap candidate');
+    assert.equal(candidate.detectedBy, 'content-merged');
+  });
+
+  it('planCleanup leaves a genuinely-unmerged branch skipped as not-merged end-to-end', () => {
+    run(repo, 'checkout', '-b', 'story-201');
+    writeFile(repo, 'unmerged.txt', 'still needs review\n');
+    run(repo, 'add', '.');
+    run(repo, 'commit', '-m', 'feat: add unmerged.txt');
+    run(repo, 'checkout', 'main');
+
+    const plan = planCleanup({
+      cwd: repo,
+      baseBranch: 'main',
+      prProbe: () => null,
+      refExistsFn: () => false,
+    });
+
+    assert.equal(
+      plan.candidates.find((c) => c.branch === 'story-201'),
+      undefined,
+    );
+    const skip = plan.skipped.find((s) => s.branch === 'story-201');
+    assert.equal(skip.reason, 'not-merged');
+    assert.ok(
+      skip.lastCommitAt,
+      'not-merged skip should carry a commit timestamp',
+    );
+  });
+});

--- a/tests/lib/orchestration/git-cleanup-phase-drivers-decide.test.js
+++ b/tests/lib/orchestration/git-cleanup-phase-drivers-decide.test.js
@@ -174,6 +174,68 @@ describe('decideBranchPhase', () => {
       remote: true,
     });
   });
+
+  // -------------------------------------------------------------------
+  // Story #4395 — remote-only always-enumerated + content-merged prompt
+  // -------------------------------------------------------------------
+
+  it('returns no-candidates when the plan holds only remote-only candidates and --remote is absent', () => {
+    const plan = {
+      candidates: [{ branch: 'fix/remote-only', localExists: false }],
+    };
+    const action = decideBranchPhase({ plan, opts: {}, cwd });
+    assert.equal(action.kind, 'no-candidates');
+  });
+
+  it('counts remote-only candidates toward "no-candidates" once --remote is set', () => {
+    const plan = {
+      candidates: [{ branch: 'fix/remote-only', localExists: false }],
+    };
+    const action = decideBranchPhase({ plan, opts: { remote: true }, cwd });
+    assert.equal(action.kind, 'prompt-then-execute');
+    assert.match(action.promptMessage, /Reap 1 merged branch\(es\)/);
+  });
+
+  it('the prompt "Reap N" count excludes remote-only candidates when --remote is absent', () => {
+    const plan = {
+      candidates: [
+        { branch: 'fix/local', localExists: true },
+        { branch: 'fix/remote-only', localExists: false },
+      ],
+    };
+    const action = decideBranchPhase({ plan, opts: {}, cwd });
+    assert.equal(action.kind, 'prompt-then-execute');
+    assert.match(action.promptMessage, /Reap 1 merged branch\(es\)\?/);
+    // executeArgs still carries every candidate — executeCleanup no-ops
+    // the remote-only one when `remote` is falsy.
+    assert.deepEqual(action.executeArgs.candidates, plan.candidates);
+  });
+
+  it('the prompt calls out content-merged candidates as a weaker signal', () => {
+    const plan = {
+      candidates: [
+        { branch: 'fix/a', localExists: true, detectedBy: 'gh' },
+        {
+          branch: 'story-4200',
+          localExists: true,
+          detectedBy: 'content-merged',
+        },
+      ],
+    };
+    const action = decideBranchPhase({ plan, opts: {}, cwd });
+    assert.match(
+      action.promptMessage,
+      /Reap 2 merged branch\(es\) \(1 content-merged — weaker signal, verify before confirming\)\?/,
+    );
+  });
+
+  it('the prompt omits the content-merged note when none are present', () => {
+    const plan = {
+      candidates: [{ branch: 'fix/a', localExists: true, detectedBy: 'gh' }],
+    };
+    const action = decideBranchPhase({ plan, opts: {}, cwd });
+    assert.doesNotMatch(action.promptMessage, /content-merged/);
+  });
 });
 
 // ---------------------------------------------------------------------

--- a/tests/lib/orchestration/git-cleanup-probe-helpers.test.js
+++ b/tests/lib/orchestration/git-cleanup-probe-helpers.test.js
@@ -9,10 +9,13 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 
-import { __testing as probeTesting } from '../../../.agents/scripts/lib/orchestration/git-cleanup/phases/git-probes.js';
+import {
+  probeContentEquivalent,
+  __testing as probeTesting,
+} from '../../../.agents/scripts/lib/orchestration/git-cleanup/phases/git-probes.js';
 import { decideStashAnswer } from '../../../.agents/scripts/lib/orchestration/git-cleanup/phases/prompts.js';
 
-const { validSha, firstLsRemoteSha } = probeTesting;
+const { validSha, firstLsRemoteSha, firstStdoutLine } = probeTesting;
 
 describe('validSha', () => {
   it('returns the trimmed SHA when it matches the 7-40 hex shape', () => {
@@ -47,6 +50,115 @@ describe('firstLsRemoteSha', () => {
   it('returns empty string when stdout has no usable line', () => {
     assert.equal(firstLsRemoteSha(''), '');
     assert.equal(firstLsRemoteSha('\n\n   \n'), '');
+  });
+});
+
+describe('firstStdoutLine', () => {
+  it('extracts the first non-empty trimmed line', () => {
+    assert.equal(firstStdoutLine('abc123\nconflict info\n'), 'abc123');
+  });
+
+  it('returns empty string when stdout has no usable line', () => {
+    assert.equal(firstStdoutLine(''), '');
+    assert.equal(firstStdoutLine('\n  \n'), '');
+    assert.equal(firstStdoutLine(undefined), '');
+  });
+});
+
+describe('probeContentEquivalent (Story #4395)', () => {
+  const TREE_A = 'a'.repeat(40);
+  const TREE_B = 'b'.repeat(40);
+
+  function fakeSpawn(responses) {
+    const calls = [];
+    return {
+      calls,
+      spawn: (_cwd, ...args) => {
+        calls.push(args);
+        const key = args[0];
+        return responses[key] ?? { status: 1, stdout: '', stderr: '' };
+      },
+    };
+  }
+
+  it('returns unsupported when merge-tree exits non-zero (old git / conflict)', () => {
+    const { spawn } = fakeSpawn({
+      'merge-tree': { status: 1, stdout: '', stderr: 'conflict' },
+    });
+    const out = probeContentEquivalent({
+      cwd: '/repo',
+      base: 'main',
+      branch: 'story-4200',
+      spawn,
+    });
+    assert.deepEqual(out, { supported: false });
+  });
+
+  it('returns unsupported when the merge-tree stdout has no usable tree OID', () => {
+    const { spawn } = fakeSpawn({
+      'merge-tree': { status: 0, stdout: '', stderr: '' },
+    });
+    const out = probeContentEquivalent({
+      cwd: '/repo',
+      base: 'main',
+      branch: 'story-4200',
+      spawn,
+    });
+    assert.deepEqual(out, { supported: false });
+  });
+
+  it('returns unsupported when the base tree OID cannot be resolved', () => {
+    const { spawn } = fakeSpawn({
+      'merge-tree': { status: 0, stdout: TREE_A, stderr: '' },
+      'rev-parse': { status: 1, stdout: '', stderr: '' },
+    });
+    const out = probeContentEquivalent({
+      cwd: '/repo',
+      base: 'main',
+      branch: 'story-4200',
+      spawn,
+    });
+    assert.deepEqual(out, { supported: false });
+  });
+
+  it('reports equivalent: true when the merged tree equals the base tree', () => {
+    const { spawn, calls } = fakeSpawn({
+      'merge-tree': { status: 0, stdout: TREE_A, stderr: '' },
+      'rev-parse': { status: 0, stdout: TREE_A, stderr: '' },
+    });
+    const out = probeContentEquivalent({
+      cwd: '/repo',
+      base: 'main',
+      branch: 'story-4200',
+      spawn,
+    });
+    assert.deepEqual(out, { supported: true, equivalent: true });
+    assert.deepEqual(calls[0], [
+      'merge-tree',
+      '--write-tree',
+      'main',
+      'story-4200',
+    ]);
+    assert.deepEqual(calls[1], [
+      'rev-parse',
+      '--verify',
+      '--quiet',
+      'main^{tree}',
+    ]);
+  });
+
+  it('reports equivalent: false when the branch carries genuinely unmerged content', () => {
+    const { spawn } = fakeSpawn({
+      'merge-tree': { status: 0, stdout: TREE_B, stderr: '' },
+      'rev-parse': { status: 0, stdout: TREE_A, stderr: '' },
+    });
+    const out = probeContentEquivalent({
+      cwd: '/repo',
+      base: 'main',
+      branch: 'feat/unmerged',
+      spawn,
+    });
+    assert.deepEqual(out, { supported: true, equivalent: false });
   });
 });
 

--- a/tests/scripts/git-cleanup.test.js
+++ b/tests/scripts/git-cleanup.test.js
@@ -25,6 +25,7 @@ import {
   renderExecutionLine,
   renderExecutionSummary,
   renderLatestPrSkipLine,
+  renderNotMergedSkipLine,
   renderPruneLine,
   stashRefIndex,
 } from '../../.agents/scripts/git-cleanup.js';
@@ -417,6 +418,216 @@ describe('git-cleanup.planCleanup', () => {
       }),
     );
     assert.deepEqual(plan.candidates, []);
+  });
+});
+
+describe('git-cleanup.planCleanup content-merged detection (Story #4395)', () => {
+  const baseCtx = (overrides) => ({
+    cwd: '/repo',
+    baseBranch: 'main',
+    localLister: () => ['story-4200'],
+    mergedLister: () => [],
+    currentBranchFn: () => 'main',
+    protectedConfigFn: () => [],
+    worktreesFn: () => new Map(),
+    prProbe: () => null,
+    branchTipShaFn: () => null,
+    refExistsFn: () => false,
+    branchLastCommitFn: () => '2026-06-01T00:00:00Z',
+    filter: () => true,
+    ...overrides,
+  });
+
+  it('classifies a squash-orphaned branch as content-merged when the probe reports equivalent: true', () => {
+    const plan = planCleanup(
+      baseCtx({
+        contentEquivalentFn: () => ({ supported: true, equivalent: true }),
+      }),
+    );
+    assert.equal(plan.candidates.length, 1);
+    assert.equal(plan.candidates[0].branch, 'story-4200');
+    assert.equal(plan.candidates[0].detectedBy, 'content-merged');
+    assert.equal(plan.candidates[0].prNumber, null);
+  });
+
+  it('keeps a genuinely-unmerged branch skipped as not-merged when the probe reports equivalent: false', () => {
+    const plan = planCleanup(
+      baseCtx({
+        contentEquivalentFn: () => ({ supported: true, equivalent: false }),
+      }),
+    );
+    assert.equal(plan.candidates.length, 0);
+    const skip = plan.skipped.find((s) => s.branch === 'story-4200');
+    assert.equal(skip.reason, 'not-merged');
+  });
+
+  it('keeps not-merged classification when the probe is unsupported (old git / conflict)', () => {
+    const plan = planCleanup(
+      baseCtx({
+        contentEquivalentFn: () => ({ supported: false }),
+      }),
+    );
+    assert.equal(plan.candidates.length, 0);
+    const skip = plan.skipped.find((s) => s.branch === 'story-4200');
+    assert.equal(skip.reason, 'not-merged');
+  });
+
+  it('records the last-commit timestamp on not-merged skips for the dry-run age line', () => {
+    const plan = planCleanup(
+      baseCtx({
+        contentEquivalentFn: () => ({ supported: false }),
+        branchLastCommitFn: () => '2026-05-01T00:00:00Z',
+      }),
+    );
+    const skip = plan.skipped.find((s) => s.branch === 'story-4200');
+    assert.equal(skip.lastCommitAt, '2026-05-01T00:00:00Z');
+  });
+
+  it('never probes content-equivalence when a gh or ancestry signal already matched', () => {
+    let probeCalls = 0;
+    const plan = planCleanup(
+      baseCtx({
+        prProbe: () => ({ number: 1, state: 'MERGED', headRefOid: null }),
+        contentEquivalentFn: () => {
+          probeCalls += 1;
+          return { supported: true, equivalent: true };
+        },
+      }),
+    );
+    assert.equal(plan.candidates[0].detectedBy, 'gh');
+    assert.equal(
+      probeCalls,
+      0,
+      'content probe should be skipped once gh already matched',
+    );
+  });
+});
+
+describe('git-cleanup.planCleanup ancestry anchor union (Story #4395)', () => {
+  const baseCtx = (overrides) => ({
+    cwd: '/repo',
+    baseBranch: 'main',
+    localLister: () => ['story-4200'],
+    currentBranchFn: () => 'main',
+    protectedConfigFn: () => [],
+    worktreesFn: () => new Map(),
+    prProbe: () => null,
+    branchTipShaFn: () => null,
+    contentEquivalentFn: () => ({ supported: false }),
+    filter: () => true,
+    ...overrides,
+  });
+
+  it('unions git-merged against origin/<base> when the remote-tracking ref exists', () => {
+    const mergedCalls = [];
+    const plan = planCleanup(
+      baseCtx({
+        mergedLister: (_cwd, base) => {
+          mergedCalls.push(base);
+          return base === 'origin/main' ? ['story-4200'] : [];
+        },
+        refExistsFn: (_cwd, ref) => ref === 'origin/main',
+      }),
+    );
+    assert.deepEqual(mergedCalls, ['main', 'origin/main']);
+    assert.equal(plan.candidates.length, 1);
+    assert.equal(plan.candidates[0].detectedBy, 'git-merged');
+  });
+
+  it('does not consult origin/<base> when the remote-tracking ref is absent', () => {
+    const mergedCalls = [];
+    const plan = planCleanup(
+      baseCtx({
+        mergedLister: (_cwd, base) => {
+          mergedCalls.push(base);
+          return [];
+        },
+        refExistsFn: () => false,
+      }),
+    );
+    assert.deepEqual(mergedCalls, ['main']);
+    assert.equal(plan.candidates.length, 0);
+  });
+});
+
+describe('git-cleanup.planCleanup gh degradation (Story #4395)', () => {
+  const baseCtx = (overrides) => ({
+    cwd: '/repo',
+    baseBranch: 'main',
+    localLister: () => ['fix/a'],
+    mergedLister: () => [],
+    currentBranchFn: () => 'main',
+    protectedConfigFn: () => [],
+    worktreesFn: () => new Map(),
+    branchTipShaFn: () => null,
+    refExistsFn: () => false,
+    contentEquivalentFn: () => ({ supported: false }),
+    filter: () => true,
+    ...overrides,
+  });
+
+  function quietLogger() {
+    const warnings = [];
+    return { warnings, logger: { warn: (m) => warnings.push(m) } };
+  }
+
+  it('a throwing bulk-index probe degrades to git-only signals instead of crashing', () => {
+    const { warnings, logger } = quietLogger();
+    const plan = planCleanup(
+      baseCtx({
+        logger,
+        prIndexFn: () => {
+          throw new Error('gh: authentication failed');
+        },
+      }),
+    );
+    assert.equal(plan.ghDegraded, true);
+    assert.equal(plan.candidates.length, 0);
+    const skip = plan.skipped.find((s) => s.branch === 'fix/a');
+    assert.equal(skip.reason, 'not-merged');
+    assert.equal(warnings.length, 1, 'exactly one warning should be logged');
+    assert.match(warnings[0], /gh probe failed/);
+  });
+
+  it('a throwing per-branch fallback probe degrades without aborting the run', () => {
+    const { warnings, logger } = quietLogger();
+    const plan = planCleanup(
+      baseCtx({
+        localLister: () => ['fix/a', 'fix/b'],
+        logger,
+        prIndexFn: () => new Map(),
+        prFallback: () => {
+          throw new Error('rate limited');
+        },
+      }),
+    );
+    assert.equal(plan.ghDegraded, true);
+    assert.equal(
+      warnings.length,
+      1,
+      'degradation warning fires once, not per branch',
+    );
+  });
+
+  it('does not degrade when the caller injects its own prProbe', () => {
+    const plan = planCleanup(
+      baseCtx({
+        prProbe: () => null,
+        prIndexFn: () => {
+          throw new Error('should never be called');
+        },
+      }),
+    );
+    assert.equal(plan.ghDegraded, false);
+  });
+
+  it('ghDegraded defaults to false on a clean run', () => {
+    const plan = planCleanup(
+      baseCtx({
+        prProbe: () => null,
+      }),
+    );
+    assert.equal(plan.ghDegraded, false);
   });
 });
 
@@ -871,6 +1082,20 @@ describe('git-cleanup.buildJsonEnvelope', () => {
     });
     assert.equal(env.ok, false);
     assert.equal(env.failures.length, 1);
+  });
+
+  it('defaults ghDegraded to false when the plan omits it', () => {
+    const env = buildJsonEnvelope({ dryRun: true, baseBranch: 'main', plan });
+    assert.equal(env.ghDegraded, false);
+  });
+
+  it('carries plan.ghDegraded through to the envelope (Story #4395)', () => {
+    const env = buildJsonEnvelope({
+      dryRun: true,
+      baseBranch: 'main',
+      plan: { ...plan, ghDegraded: true },
+    });
+    assert.equal(env.ghDegraded, true);
   });
 });
 
@@ -2117,5 +2342,140 @@ describe('git-cleanup.renderDryRun (latest-PR skip integration)', () => {
       lines.find((l) => /b skipped — PR #2 was closed without merging/.test(l)),
     );
     assert.ok(lines.find((l) => /c skipped — tip aaaaaaa/.test(l)));
+  });
+});
+
+describe('git-cleanup.renderLatestPrSkipLine tip-diverged remediation hint (Story #4395)', () => {
+  it('names both SHAs and a remediation path', () => {
+    const line = renderLatestPrSkipLine({
+      branch: 'release-please/foo',
+      reason: 'tip-diverged-from-merge',
+      prNumber: 2447,
+      tipSha: 'abcdef1234567890',
+      mergedSha: '1234567abcdef000',
+    });
+    assert.match(line, /branch -D release-please\/foo/);
+    assert.match(line, /pushing the follow-up commit/);
+  });
+});
+
+describe('git-cleanup.renderNotMergedSkipLine (Story #4395)', () => {
+  const NOW = Date.parse('2026-06-15T00:00:00Z');
+
+  it('returns null for a non-not-merged skip', () => {
+    assert.equal(
+      renderNotMergedSkipLine({ branch: 'main', reason: 'protected' }),
+      null,
+    );
+  });
+
+  it('returns null for a null/undefined skip', () => {
+    assert.equal(renderNotMergedSkipLine(null), null);
+  });
+
+  it('renders the branch name and a relative last-commit age', () => {
+    const line = renderNotMergedSkipLine(
+      {
+        branch: 'story-4200',
+        reason: 'not-merged',
+        lastCommitAt: '2026-06-01T00:00:00Z',
+      },
+      { now: NOW },
+    );
+    assert.match(line, /story-4200 skipped — not merged/);
+    assert.match(line, /14 days ago/);
+  });
+
+  it('renders "unknown" when lastCommitAt is missing', () => {
+    const line = renderNotMergedSkipLine(
+      { branch: 'story-4200', reason: 'not-merged', lastCommitAt: null },
+      { now: NOW },
+    );
+    assert.match(line, /last commit: unknown/);
+  });
+
+  it('renders "today" for a same-day commit', () => {
+    const line = renderNotMergedSkipLine(
+      {
+        branch: 'story-4200',
+        reason: 'not-merged',
+        lastCommitAt: '2026-06-15T00:00:00Z',
+      },
+      { now: NOW },
+    );
+    assert.match(line, /last commit: today/);
+  });
+});
+
+describe('git-cleanup.renderDryRun not-merged skip-visibility integration (Story #4395)', () => {
+  const NOW = Date.parse('2026-06-15T00:00:00Z');
+
+  it('lists not-merged survivors instead of staying silent', () => {
+    const lines = renderDryRun(
+      {
+        candidates: [],
+        skipped: [
+          {
+            branch: 'story-4200',
+            reason: 'not-merged',
+            lastCommitAt: '2026-06-01T00:00:00Z',
+          },
+        ],
+      },
+      { baseBranch: 'main', now: NOW },
+    );
+    assert.ok(lines.find((l) => /story-4200 skipped — not merged/.test(l)));
+  });
+
+  it('appends a gh-degraded warning line when the plan reports ghDegraded: true', () => {
+    const lines = renderDryRun({
+      candidates: [],
+      skipped: [],
+      ghDegraded: true,
+    });
+    assert.ok(lines.find((l) => /gh probe degraded/.test(l)));
+  });
+
+  it('omits the gh-degraded line on a clean run', () => {
+    const lines = renderDryRun({ candidates: [], skipped: [] });
+    assert.equal(
+      lines.find((l) => /gh probe degraded/.test(l)),
+      undefined,
+    );
+  });
+});
+
+describe('git-cleanup.renderDryRun content-merged distinctness (Story #4395)', () => {
+  it('annotates a content-merged candidate as a weaker signal', () => {
+    const lines = renderDryRun({
+      candidates: [
+        {
+          branch: 'story-4200',
+          prNumber: null,
+          hasWorktree: false,
+          localExists: true,
+          detectedBy: 'content-merged',
+        },
+      ],
+      skipped: [],
+    });
+    assert.match(lines[1], /story-4200 — content-merged/);
+    assert.match(lines[1], /weaker signal/);
+  });
+
+  it('does not annotate a gh or git-merged candidate', () => {
+    const lines = renderDryRun({
+      candidates: [
+        {
+          branch: 'fix/a',
+          prNumber: 42,
+          hasWorktree: false,
+          localExists: true,
+          detectedBy: 'gh',
+        },
+      ],
+      skipped: [],
+    });
+    assert.doesNotMatch(lines[1], /weaker signal/);
   });
 });


### PR DESCRIPTION
Closes #4395

_Auto-opened by `/single-story-deliver`._