### PR TITLE
ci(release): pin publish npm to 11.18.0 and add dispatch recovery

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -79,9 +79,17 @@ jobs:
     #
     # Gated on the root component's release output so the publish runs only
     # when release-please cuts a new root release.
+    # Normally gated on the root release-please cut. Also runs on a manual
+    # `workflow_dispatch` so a **stuck release** — one release-please already
+    # tagged/released but whose npm publish failed (e.g. the npm 12.0.0
+    # provenance regression above) — can be re-published without waiting for a
+    # new version to be cut. This is safe: the npm registry rejects
+    # re-publishing an already-present version, so a dispatch can only fill the
+    # gap (publish the current `package.json` version if, and only if, it is
+    # missing on npm), never clobber an existing one.
     name: Publish to npm
     needs: release-please
-    if: ${{ needs.release-please.outputs.root_release_created == 'true' }}
+    if: ${{ needs.release-please.outputs.root_release_created == 'true' || github.event_name == 'workflow_dispatch' }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -99,8 +107,17 @@ jobs:
       - name: Install Dependencies
         run: npm ci --ignore-scripts
 
+      # Pinned, not `npm@latest` (Story #3399 supply-chain policy applied to
+      # the toolchain, not just `uses:` refs). The floating `@latest` bit us
+      # when npm 12.0.0 shipped: its in-place global self-upgrade leaves the
+      # freshly-replaced global npm tree unable to resolve the bundled
+      # `sigstore` module from `libnpmpublish/lib/provenance.js`, so
+      # `npm publish` (provenance on) dies with `Cannot find module
+      # 'sigstore'` — with zero change on our side. Pin to the last known-good
+      # npm 11 line (>=11.5.1 required for Trusted Publishing) and bump
+      # deliberately once a 12.x self-upgrade is verified clean.
       - name: Upgrade npm for Trusted Publishing
-        run: npm install -g npm@latest
+        run: npm install -g npm@11.18.0
 
       - name: Publish package
         run: npm publish


### PR DESCRIPTION
## Why

The **Publish to npm** job in `release-please.yml` failed on the v1.88.0 release ([run 28989465188](https://github.com/dsj1984/mandrel/actions/runs/28989465188/job/86025892493)) with:

```
npm error code MODULE_NOT_FOUND
npm error Cannot find module 'sigstore'
npm error - .../node_modules/npm/node_modules/libnpmpublish/lib/provenance.js
```

Root cause: the job floated `npm install -g npm@latest`. **npm 12.0.0** shipped as the new `latest`, and its in-place global self-upgrade leaves the freshly-replaced global npm tree unable to resolve the bundled `sigstore` module from `libnpmpublish`'s provenance path. With `publishConfig.provenance: true`, `npm publish` dies — with zero change on our side. The prior release (1.87.0) published fine on npm 11.x.

Consequence: **v1.88.0 is a stuck release** — tagged and GitHub-released, `package.json` bumped on `main`, but never published to npm (registry `latest` is still 1.87.0). A plain forward-merge won't republish it, because release-please already considers 1.88.0 released so the publish job's `release_created` gate stays `false`.

## What

- **Pin** the upgrade to `npm@11.18.0` (last known-good 11.x line; `>=11.5.1` is required for Trusted Publishing) instead of floating `@latest`. Matches the repo's Story #3399 supply-chain pinning policy — bump deliberately once a 12.x self-upgrade is verified clean.
- **Add `workflow_dispatch` recovery** to the publish job's `if:` so a stuck release can be re-published on demand without waiting for a new version cut. Safe by construction: the npm registry rejects re-publishing an existing version, so a dispatch can only fill the gap, never clobber.

## Verify

- `check-action-pinning.js` guard: `violations=0`.
- `tests/contract/release-please-publish-gate.test.js` + `tests/check-action-pinning.test.js`: 26/26 pass (the gate-wiring assertion still holds — the `if:` still references `steps.release.outputs.release_created`).

## Follow-up (after merge)

v1.88.0 still needs to reach npm. Once this lands on `main`, run the publish job manually against `main` (which now carries the fixed workflow):

```
gh workflow run "Release Please" --repo dsj1984/mandrel --ref main
```

It will publish 1.88.0 (the registry no-ops if it somehow already exists).