### PR TITLE
fix: single-story-close: wrong-tree guard intersects stray paths with the Story diff instead of aborting on any main-checkout dirt (#4424)

### DIFF
--- a/.agents/scripts/lib/orchestration/single-story-close/phases/wrong-tree-guard.js
+++ b/.agents/scripts/lib/orchestration/single-story-close/phases/wrong-tree-guard.js
@@ -18,15 +18,33 @@
  * Detection: when a worktree is the active work tree (it exists on disk and is
  * distinct from `cwd`), inspect `git -C <mainCheckout> status --porcelain`. Any
  * **tracked-path** change (modified, staged, deleted, renamed) in the main
- * checkout is the wrong-tree signal. Untracked files (`??`) are ignored — they
- * are scratch artifacts, not relocated Story work, and flagging them would
- * produce false positives on every run.
+ * checkout is the candidate wrong-tree signal. Untracked files (`??`) are
+ * ignored — they are scratch artifacts, not relocated Story work, and flagging
+ * them would produce false positives on every run.
  *
- * The guard runs before the gate chain. On detection it posts a `friction`
- * structured comment naming the stray files and throws, so the operator/agent
- * relocates the edits into the worktree before close proceeds. This is the
- * load-bearing, detection-based fix: it fires regardless of whether the agent
- * ever realized it edited the wrong tree.
+ * Story #4424 — the raw "main checkout is dirty" signal is too coarse for
+ * multi-session operation: uncommitted tracked-path changes in the main
+ * checkout can belong to a **different concurrent session** and have nothing to
+ * do with the Story being closed (framework-gap #4420). The guard therefore
+ * intersects the main-checkout stray tracked paths with the **Story's own
+ * diff-path set** (paths changed on the worktree branch vs the base branch,
+ * plus the worktree's uncommitted tracked changes):
+ *   - **Overlap non-empty** → genuine wrong-tree signal: post a `friction`
+ *     comment and throw (abort close), exactly as before.
+ *   - **Disjoint** (Story diff-path set non-empty, no shared path) → another
+ *     session's business: post a `friction` comment whose wording states close
+ *     PROCEEDED and names the disjoint stray files (telemetry for
+ *     concurrent-session hygiene), then return without throwing.
+ *   - **Empty Story diff-path set** with stray paths → keep the abort (the
+ *     #3364 silent empty-diff backstop; an empty set makes every stray path
+ *     disjoint-by-definition, which must not downgrade the guard).
+ *   - **Story-diff probe failure** with stray paths present → fall back to the
+ *     coarse abort rather than fail-open, so a probe hiccup never converts a
+ *     would-be abort into a silent pass.
+ *
+ * The main-checkout status probe keeps its fail-open semantics: a probe failure
+ * downgrades to a warning and skips the guard — it never blocks an otherwise
+ * valid close.
  */
 
 import path from 'node:path';
@@ -85,6 +103,20 @@ export function collectStrayTrackedPaths(entries) {
 }
 
 /**
+ * Parse `git diff --name-only` output into a list of repo-relative paths.
+ *
+ * @param {string} raw - Raw `git diff --name-only` stdout (may be empty).
+ * @returns {string[]}
+ */
+export function parseDiffNameOnly(raw) {
+  if (typeof raw !== 'string' || raw.trim() === '') return [];
+  return raw
+    .split('\n')
+    .map((line) => line.replace(/\r$/, '').trim())
+    .filter(Boolean);
+}
+
+/**
  * Decide whether the wrong-tree guard applies for this close.
  *
  * The guard only makes sense when a worktree is the active work tree: it must
@@ -101,7 +133,77 @@ export function guardApplies({ cwd, worktreePath }) {
 }
 
 /**
- * Format the `friction` finding body naming the stray files.
+ * Compute the Story's own diff-path set from the worktree: the union of paths
+ * changed on the worktree branch vs the base branch (committed diff) and the
+ * worktree's uncommitted tracked changes.
+ *
+ * Both probes are keyed off the worktree, so the returned paths are
+ * repo-relative and directly comparable to the main-checkout porcelain paths.
+ * A probe failure (thrown error or non-zero git exit) returns `{ ok: false }`
+ * so the caller can fall back to the coarse abort rather than fail-open.
+ *
+ * @param {{ worktreePath: string, baseBranch: string, gitSpawnFn: Function }} opts
+ * @returns {{ ok: boolean, paths: string[], error?: string }}
+ */
+export function collectStoryDiffPaths({
+  worktreePath,
+  baseBranch,
+  gitSpawnFn,
+}) {
+  let diffResult;
+  try {
+    diffResult = gitSpawnFn(
+      worktreePath,
+      'diff',
+      '--name-only',
+      `${baseBranch}...HEAD`,
+    );
+  } catch (err) {
+    return { ok: false, paths: [], error: err?.message ?? String(err) };
+  }
+  if (!diffResult || diffResult.status !== 0) {
+    return { ok: false, paths: [], error: diffResult?.stderr || '(no stderr)' };
+  }
+
+  let statusResult;
+  try {
+    statusResult = gitSpawnFn(worktreePath, 'status', '--porcelain');
+  } catch (err) {
+    return { ok: false, paths: [], error: err?.message ?? String(err) };
+  }
+  if (!statusResult || statusResult.status !== 0) {
+    return {
+      ok: false,
+      paths: [],
+      error: statusResult?.stderr || '(no stderr)',
+    };
+  }
+
+  const committed = parseDiffNameOnly(diffResult.stdout ?? '');
+  const uncommitted = collectStrayTrackedPaths(
+    parsePorcelainStatus(statusResult.stdout ?? ''),
+  );
+  const union = Array.from(new Set([...committed, ...uncommitted])).sort();
+  return { ok: true, paths: union };
+}
+
+/**
+ * Repo-relative path intersection. Both sides are git-emitted repo-relative
+ * paths (forward-slash separated on every platform), so plain string equality
+ * is correct regardless of which tree the probe ran in.
+ *
+ * @param {string[]} mainStray
+ * @param {string[]} storyPaths
+ * @returns {string[]} sorted intersection.
+ */
+export function intersectPaths(mainStray, storyPaths) {
+  const set = new Set(storyPaths);
+  return mainStray.filter((p) => set.has(p)).sort();
+}
+
+/**
+ * Format the `friction` finding body for an ABORT (overlap, empty-diff
+ * backstop, or diff-probe-failure fallback) naming the stray files.
  *
  * @param {{ storyId: number, strayFiles: string[], worktreePath: string }} opts
  * @returns {string}
@@ -111,7 +213,8 @@ export function formatWrongTreeFinding({ storyId, strayFiles, worktreePath }) {
   return (
     `### wrong-tree edit detected (close aborted)\n\n` +
     `Story #${storyId}: the main checkout has uncommitted changes under ` +
-    `tracked paths while the active work tree is the per-Story worktree:\n\n` +
+    `tracked paths that intersect the Story's own diff-path set while the ` +
+    `active work tree is the per-Story worktree:\n\n` +
     `\`${worktreePath}\`\n\n` +
     `This is the wrong-tree failure mode: edits intended for the worktree ` +
     `landed in the main checkout instead (on Windows, \`cd\` steers the Bash ` +
@@ -127,31 +230,182 @@ export function formatWrongTreeFinding({ storyId, strayFiles, worktreePath }) {
 }
 
 /**
+ * Format the `friction` finding body for the DOWNGRADE outcome — the main
+ * checkout has stray tracked paths, but they are fully disjoint from the
+ * Story's non-empty diff-path set (another concurrent session's work). Close
+ * proceeds; this comment is telemetry for concurrent-session hygiene.
+ *
+ * @param {{ storyId: number, strayFiles: string[], worktreePath: string }} opts
+ * @returns {string}
+ */
+export function formatWrongTreeDowngradeFinding({
+  storyId,
+  strayFiles,
+  worktreePath,
+}) {
+  const list = strayFiles.map((f) => `- \`${f}\``).join('\n');
+  return (
+    `### wrong-tree probe: disjoint main-checkout dirt (close proceeded)\n\n` +
+    `Story #${storyId}: the main checkout has uncommitted changes under ` +
+    `tracked paths while the active work tree is the per-Story worktree:\n\n` +
+    `\`${worktreePath}\`\n\n` +
+    `These stray paths are **fully disjoint** from the Story's own diff-path ` +
+    `set (committed diff vs base + uncommitted worktree changes), so they ` +
+    `belong to another concurrent session rather than this Story's work. ` +
+    `Close **proceeded** — this comment is telemetry for concurrent-session ` +
+    `hygiene, not an abort.\n\n` +
+    `**Disjoint stray files in the main checkout:**\n\n${list}\n`
+  );
+}
+
+/**
+ * Post the ABORT friction comment and throw to abort close. Shared by the
+ * overlap, empty-diff-backstop, and diff-probe-failure-fallback paths.
+ *
+ * @param {{
+ *   storyId: number,
+ *   strayFiles: string[],
+ *   worktreePath: string,
+ *   provider: object,
+ *   progress: (tag: string, msg: string) => void,
+ *   reasonTag: string,
+ * }} opts
+ * @throws {Error} always.
+ */
+async function abortWrongTree({
+  storyId,
+  strayFiles,
+  worktreePath,
+  provider,
+  progress,
+  reasonTag,
+}) {
+  const body = formatWrongTreeFinding({ storyId, strayFiles, worktreePath });
+  try {
+    await postStructuredComment(provider, storyId, 'friction', body);
+    progress(
+      'WRONG-TREE',
+      `🛑 Wrong-tree edits detected (${reasonTag}): ${strayFiles.length} stray file(s). Posted friction comment to Story #${storyId}.`,
+    );
+  } catch (err) {
+    progress(
+      'WRONG-TREE',
+      `⚠️ Failed to post wrong-tree friction comment: ${err?.message ?? err}`,
+    );
+  }
+
+  throw new Error(
+    `[single-story-close] Wrong-tree edits detected (${reasonTag}): the main ` +
+      `checkout has uncommitted tracked-path changes intersecting the Story's ` +
+      `diff-path set while the worktree (${worktreePath}) is the active work ` +
+      `tree. Close aborted to avoid an empty-diff PR. Stray files: ` +
+      `${strayFiles.join(', ')}. Relocate the edits into the worktree, ` +
+      `restore the main checkout, then re-run /single-story-deliver.`,
+  );
+}
+
+/**
+ * Post the DOWNGRADE friction comment (telemetry) without throwing. Best-effort:
+ * a post failure is logged but never converts the proceed into an abort.
+ *
+ * @param {{
+ *   storyId: number,
+ *   strayFiles: string[],
+ *   worktreePath: string,
+ *   provider: object,
+ *   progress: (tag: string, msg: string) => void,
+ * }} opts
+ * @returns {Promise<void>}
+ */
+async function reportDisjointDirt({
+  storyId,
+  strayFiles,
+  worktreePath,
+  provider,
+  progress,
+}) {
+  const body = formatWrongTreeDowngradeFinding({
+    storyId,
+    strayFiles,
+    worktreePath,
+  });
+  try {
+    await postStructuredComment(provider, storyId, 'friction', body);
+    progress(
+      'WRONG-TREE',
+      `⚠️ Main-checkout dirt disjoint from Story diff (${strayFiles.length} stray file(s) belong to another session). Close proceeds; posted telemetry friction comment to Story #${storyId}.`,
+    );
+  } catch (err) {
+    progress(
+      'WRONG-TREE',
+      `⚠️ Failed to post disjoint-dirt friction comment: ${err?.message ?? err}`,
+    );
+  }
+}
+
+/**
+ * Probe the main checkout for stray tracked-path changes.
+ *
+ * Fail-open on the probe: a thrown error or non-zero git exit returns
+ * `{ ok: false }` so the caller skips the guard rather than blocking a valid
+ * close on a git hiccup.
+ *
+ * @param {{ cwd: string, gitSpawnFn: Function, progress: Function }} opts
+ * @returns {{ ok: boolean, strayFiles: string[] }}
+ */
+function probeMainCheckoutStray({ cwd, gitSpawnFn, progress }) {
+  let result;
+  try {
+    result = gitSpawnFn(cwd, 'status', '--porcelain');
+  } catch (err) {
+    progress(
+      'WRONG-TREE',
+      `⚠️ Could not probe main checkout status: ${err?.message ?? err}. Skipping guard.`,
+    );
+    return { ok: false, strayFiles: [] };
+  }
+
+  if (!result || result.status !== 0) {
+    progress(
+      'WRONG-TREE',
+      `⚠️ git status probe exited non-zero: ${result?.stderr || '(no stderr)'}. Skipping guard.`,
+    );
+    return { ok: false, strayFiles: [] };
+  }
+
+  const strayFiles = collectStrayTrackedPaths(
+    parsePorcelainStatus(result.stdout ?? ''),
+  );
+  return { ok: true, strayFiles };
+}
+
+/**
  * Run the wrong-tree detection guard for `single-story-close`.
  *
- * When a worktree is the active work tree and the main checkout has uncommitted
- * tracked-path changes, posts a `friction` comment naming the stray files and
- * throws to abort close. Otherwise returns a clean result.
- *
- * Unlike the soft drift-detection phase, this guard is **load-bearing**: a
- * positive detection aborts close (throws). Failures to run git, however, are
- * swallowed as warnings — a probe failure must not block an otherwise valid
- * close (fail-open on the probe, fail-closed on a confirmed positive).
+ * When a worktree is the active work tree and the main checkout has stray
+ * tracked-path changes, the guard intersects those paths with the Story's own
+ * diff-path set (Story #4424): overlap aborts close (throws), a disjoint set
+ * downgrades to a proceed-with-telemetry `friction` comment, an empty Story
+ * diff-path set keeps the abort (empty-diff backstop), and a Story-diff probe
+ * failure falls back to the coarse abort. A main-checkout status probe failure
+ * skips the guard (fail-open on the probe, fail-closed on a confirmed positive).
  *
  * @param {{
  *   cwd: string,
  *   worktreePath: string|null,
+ *   baseBranch: string,
  *   storyId: number,
  *   provider: object,
  *   progress: (tag: string, msg: string) => void,
  *   gitSpawn?: Function,
  * }} args
- * @returns {Promise<{ applied: boolean, strayFiles: string[] }>}
- * @throws {Error} when stray tracked-path edits are detected in the main checkout.
+ * @returns {Promise<{ applied: boolean, strayFiles: string[], overlap?: string[] }>}
+ * @throws {Error} when overlapping stray edits are detected in the main checkout.
  */
 export async function runWrongTreeGuardPhase({
   cwd,
   worktreePath,
+  baseBranch = 'main',
   storyId,
   provider,
   progress,
@@ -171,55 +425,78 @@ export async function runWrongTreeGuardPhase({
     `Checking main checkout for stray edits (worktree-isolated Story #${storyId})...`,
   );
 
-  let result;
-  try {
-    result = gitSpawnFn(cwd, 'status', '--porcelain');
-  } catch (err) {
-    // Probe failure is non-fatal — never block a valid close on a git hiccup.
-    progress(
-      'WRONG-TREE',
-      `⚠️ Could not probe main checkout status: ${err?.message ?? err}. Skipping guard.`,
-    );
+  const mainProbe = probeMainCheckoutStray({ cwd, gitSpawnFn, progress });
+  if (!mainProbe.ok) {
     return { applied: false, strayFiles: [] };
   }
 
-  if (!result || result.status !== 0) {
-    progress(
-      'WRONG-TREE',
-      `⚠️ git status probe exited non-zero: ${result?.stderr || '(no stderr)'}. Skipping guard.`,
-    );
-    return { applied: false, strayFiles: [] };
-  }
-
-  const strayFiles = collectStrayTrackedPaths(
-    parsePorcelainStatus(result.stdout ?? ''),
-  );
-
+  const strayFiles = mainProbe.strayFiles;
   if (strayFiles.length === 0) {
     progress('WRONG-TREE', '✅ Main checkout clean — no wrong-tree edits.');
-    return { applied: true, strayFiles: [] };
+    return { applied: true, strayFiles: [], overlap: [] };
   }
 
-  // Confirmed positive: post a friction comment and abort close.
-  const body = formatWrongTreeFinding({ storyId, strayFiles, worktreePath });
-  try {
-    await postStructuredComment(provider, storyId, 'friction', body);
+  // Stray paths present — intersect with the Story's own diff-path set to tell
+  // this Story's misplaced work apart from a concurrent session's dirt.
+  const storyDiff = collectStoryDiffPaths({
+    worktreePath,
+    baseBranch,
+    gitSpawnFn,
+  });
+
+  if (!storyDiff.ok) {
+    // A failed Story-diff probe must NOT silently convert a would-be abort into
+    // a pass — fall back to the coarse (#3364) abort behavior.
     progress(
       'WRONG-TREE',
-      `🛑 Wrong-tree edits detected: ${strayFiles.length} stray file(s). Posted friction comment to Story #${storyId}.`,
+      `⚠️ Could not probe Story diff paths (${storyDiff.error}); falling back to coarse abort.`,
     );
-  } catch (err) {
-    progress(
-      'WRONG-TREE',
-      `⚠️ Failed to post wrong-tree friction comment: ${err?.message ?? err}`,
-    );
+    await abortWrongTree({
+      storyId,
+      strayFiles,
+      worktreePath,
+      provider,
+      progress,
+      reasonTag: 'diff-probe-failed',
+    });
   }
 
-  throw new Error(
-    `[single-story-close] Wrong-tree edits detected: the main checkout has ` +
-      `uncommitted tracked-path changes while the worktree (${worktreePath}) is ` +
-      `the active work tree. Close aborted to avoid an empty-diff PR. Stray ` +
-      `files: ${strayFiles.join(', ')}. Relocate the edits into the worktree, ` +
-      `restore the main checkout, then re-run /single-story-deliver.`,
-  );
+  if (storyDiff.paths.length === 0) {
+    // Empty-diff backstop: an empty Story diff-path set makes every stray path
+    // disjoint-by-definition; that is exactly the #3364 silent empty-diff
+    // failure mode, so keep the abort.
+    await abortWrongTree({
+      storyId,
+      strayFiles,
+      worktreePath,
+      provider,
+      progress,
+      reasonTag: 'empty-diff-backstop',
+    });
+  }
+
+  const overlap = intersectPaths(strayFiles, storyDiff.paths);
+
+  if (overlap.length > 0) {
+    await abortWrongTree({
+      storyId,
+      strayFiles,
+      worktreePath,
+      provider,
+      progress,
+      reasonTag: 'overlap',
+    });
+  }
+
+  // Disjoint: the stray paths belong to another session. Post a proceed-wording
+  // friction comment (telemetry) and return without throwing.
+  await reportDisjointDirt({
+    storyId,
+    strayFiles,
+    worktreePath,
+    provider,
+    progress,
+  });
+
+  return { applied: true, strayFiles, overlap: [] };
 }

--- a/.agents/scripts/lib/orchestration/single-story-close/runner.js
+++ b/.agents/scripts/lib/orchestration/single-story-close/runner.js
@@ -57,6 +57,7 @@ async function runPrePushPhases({
   await runWrongTreeGuardPhase({
     cwd,
     worktreePath,
+    baseBranch,
     storyId,
     provider,
     progress,

--- a/tests/single-story-close-wrong-tree-guard.test.js
+++ b/tests/single-story-close-wrong-tree-guard.test.js
@@ -8,22 +8,32 @@
  * the close path detected it — close would commit an unchanged worktree and
  * open an empty-diff PR.
  *
- * Asserts:
- *   AC-1: when the worktree is the active work tree and the main checkout has
- *         uncommitted tracked-path changes, the guard throws (close aborts)
- *         and posts a `friction` comment naming the stray files.
- *   AC-2: the helper workflow doc states the worktree-scope requirement for
- *         the path-based edit tools, not only for the Bash cwd (asserted in a
- *         sibling doc-contract assertion at the bottom of this file).
- *   - The guard does not fire in single-tree mode (worktree === main checkout).
- *   - The guard does not fire when no worktree exists.
- *   - The guard ignores untracked (`??`) files — only tracked-path edits count.
- *   - The guard fails open on a git probe error (never blocks a valid close).
+ * Story #4424 — the raw "main checkout is dirty" signal is too coarse for
+ * multi-session operation: stray main-checkout paths can belong to another
+ * concurrent session. The guard now intersects the main-checkout stray tracked
+ * paths with the Story's own diff-path set (committed diff vs base + the
+ * worktree's uncommitted tracked changes):
+ *   AC-1 (overlap):     at least one stray path is in the Story diff set →
+ *                       throw (close aborts) + friction comment naming strays.
+ *   Disjoint downgrade: Story diff set non-empty and fully disjoint from the
+ *                       strays → no throw, a "close proceeded" friction comment
+ *                       naming the disjoint strays, result identifies the
+ *                       downgrade (`overlap: []`).
+ *   Empty-diff backstop: empty Story diff set + stray paths → keep the abort
+ *                       (the original #3364 silent empty-diff failure mode).
+ *   Probe failure:      a main-checkout status probe failure still skips the
+ *                       guard (fail-open); a Story-diff probe failure with
+ *                       strays present falls back to the coarse abort.
+ *   AC-2:               the helper workflow doc states the worktree-scope
+ *                       requirement for the path-based edit tools (asserted in
+ *                       a sibling doc-contract assertion at the bottom).
  *
  * Tests exercise the pure helpers directly (`parsePorcelainStatus`,
- * `collectStrayTrackedPaths`, `guardApplies`, `formatWrongTreeFinding`) and the
- * orchestration wrapper (`runWrongTreeGuardPhase`) with an in-memory provider
- * and an injected fake `gitSpawn` so no real git or GitHub call is made.
+ * `collectStrayTrackedPaths`, `parseDiffNameOnly`, `intersectPaths`,
+ * `collectStoryDiffPaths`, `guardApplies`, `formatWrongTreeFinding`,
+ * `formatWrongTreeDowngradeFinding`) and the orchestration wrapper
+ * (`runWrongTreeGuardPhase`) with an in-memory provider and an injected fake
+ * `gitSpawn` so no real git or GitHub call is made.
  */
 
 import assert from 'node:assert/strict';
@@ -32,9 +42,13 @@ import path from 'node:path';
 import { describe, it } from 'node:test';
 import { fileURLToPath } from 'node:url';
 import {
+  collectStoryDiffPaths,
   collectStrayTrackedPaths,
+  formatWrongTreeDowngradeFinding,
   formatWrongTreeFinding,
   guardApplies,
+  intersectPaths,
+  parseDiffNameOnly,
   parsePorcelainStatus,
   runWrongTreeGuardPhase,
 } from '../.agents/scripts/lib/orchestration/single-story-close/phases/wrong-tree-guard.js';
@@ -63,9 +77,46 @@ function makeProvider() {
   };
 }
 
-/** Build a fake `gitSpawn` result envelope. */
-function spawnResult(stdout, { status = 0, stderr = '' } = {}) {
-  return () => ({ status, stdout, stderr });
+/**
+ * Build a fake `gitSpawn(dir, ...args)` that dispatches by command + tree.
+ *
+ * `status --porcelain` against a `.worktrees/` path is the worktree probe;
+ * against any other dir it is the main-checkout probe. `diff` is the worktree
+ * committed-diff probe. Any probe can be forced to throw or exit non-zero.
+ */
+function fakeGit({
+  main = '',
+  mainStatus = 0,
+  mainThrows = null,
+  diff = '',
+  diffStatus = 0,
+  diffThrows = null,
+  wtStatus = '',
+  wtStatusCode = 0,
+} = {}) {
+  return (dir, ...args) => {
+    if (args[0] === 'status') {
+      const isWorktree = String(dir).includes('.worktrees');
+      if (isWorktree) {
+        return { status: wtStatusCode, stdout: wtStatus, stderr: '' };
+      }
+      if (mainThrows) throw new Error(mainThrows);
+      return {
+        status: mainStatus,
+        stdout: main,
+        stderr: mainStatus === 0 ? '' : 'main status err',
+      };
+    }
+    if (args[0] === 'diff') {
+      if (diffThrows) throw new Error(diffThrows);
+      return {
+        status: diffStatus,
+        stdout: diff,
+        stderr: diffStatus === 0 ? '' : 'diff err',
+      };
+    }
+    throw new Error(`unexpected git ${args.join(' ')}`);
+  };
 }
 
 function noop() {}
@@ -147,6 +198,115 @@ describe('collectStrayTrackedPaths — pure unit', () => {
 });
 
 // ---------------------------------------------------------------------------
+// parseDiffNameOnly — pure unit
+// ---------------------------------------------------------------------------
+
+describe('parseDiffNameOnly — pure unit', () => {
+  it('returns empty array for empty input', () => {
+    assert.deepEqual(parseDiffNameOnly(''), []);
+    assert.deepEqual(parseDiffNameOnly('  '), []);
+    assert.deepEqual(parseDiffNameOnly(undefined), []);
+  });
+
+  it('splits newline-separated paths and trims CR', () => {
+    assert.deepEqual(parseDiffNameOnly('src/a.js\nsrc/b.js\r'), [
+      'src/a.js',
+      'src/b.js',
+    ]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// intersectPaths — pure unit
+// ---------------------------------------------------------------------------
+
+describe('intersectPaths — pure unit', () => {
+  it('returns the sorted shared paths', () => {
+    assert.deepEqual(
+      intersectPaths(['b.js', 'a.js', 'c.js'], ['c.js', 'a.js']),
+      ['a.js', 'c.js'],
+    );
+  });
+
+  it('returns empty for disjoint sets', () => {
+    assert.deepEqual(intersectPaths(['x.js'], ['y.js']), []);
+  });
+
+  it('uses repo-relative path equality regardless of probe tree', () => {
+    // The same file edited in both trees must intersect even though the probes
+    // ran in different working directories.
+    assert.deepEqual(
+      intersectPaths(['.agents/scripts/foo.js'], ['.agents/scripts/foo.js']),
+      ['.agents/scripts/foo.js'],
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// collectStoryDiffPaths — pure unit
+// ---------------------------------------------------------------------------
+
+describe('collectStoryDiffPaths — pure unit', () => {
+  it('unions committed diff and uncommitted tracked changes, sorted', () => {
+    const result = collectStoryDiffPaths({
+      worktreePath: '/repo/.worktrees/story-1',
+      baseBranch: 'main',
+      gitSpawnFn: fakeGit({
+        diff: 'src/b.js\nsrc/a.js',
+        wtStatus: ' M src/c.js',
+      }),
+    });
+    assert.equal(result.ok, true);
+    assert.deepEqual(result.paths, ['src/a.js', 'src/b.js', 'src/c.js']);
+  });
+
+  it('deduplicates a path present in both committed and uncommitted sets', () => {
+    const result = collectStoryDiffPaths({
+      worktreePath: '/repo/.worktrees/story-1',
+      baseBranch: 'main',
+      gitSpawnFn: fakeGit({ diff: 'src/a.js', wtStatus: ' M src/a.js' }),
+    });
+    assert.deepEqual(result.paths, ['src/a.js']);
+  });
+
+  it('excludes untracked worktree files from the diff set', () => {
+    const result = collectStoryDiffPaths({
+      worktreePath: '/repo/.worktrees/story-1',
+      baseBranch: 'main',
+      gitSpawnFn: fakeGit({ diff: '', wtStatus: '?? scratch.txt' }),
+    });
+    assert.deepEqual(result.paths, []);
+  });
+
+  it('reports ok:false when the diff probe throws', () => {
+    const result = collectStoryDiffPaths({
+      worktreePath: '/repo/.worktrees/story-1',
+      baseBranch: 'main',
+      gitSpawnFn: fakeGit({ diffThrows: 'git not found' }),
+    });
+    assert.equal(result.ok, false);
+  });
+
+  it('reports ok:false when the diff probe exits non-zero', () => {
+    const result = collectStoryDiffPaths({
+      worktreePath: '/repo/.worktrees/story-1',
+      baseBranch: 'main',
+      gitSpawnFn: fakeGit({ diffStatus: 128 }),
+    });
+    assert.equal(result.ok, false);
+  });
+
+  it('reports ok:false when the worktree status probe exits non-zero', () => {
+    const result = collectStoryDiffPaths({
+      worktreePath: '/repo/.worktrees/story-1',
+      baseBranch: 'main',
+      gitSpawnFn: fakeGit({ diff: 'src/a.js', wtStatusCode: 128 }),
+    });
+    assert.equal(result.ok, false);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // guardApplies — pure unit
 // ---------------------------------------------------------------------------
 
@@ -171,7 +331,7 @@ describe('guardApplies — pure unit', () => {
 });
 
 // ---------------------------------------------------------------------------
-// formatWrongTreeFinding — pure unit
+// formatWrongTreeFinding / formatWrongTreeDowngradeFinding — pure unit
 // ---------------------------------------------------------------------------
 
 describe('formatWrongTreeFinding — pure unit', () => {
@@ -196,12 +356,27 @@ describe('formatWrongTreeFinding — pure unit', () => {
   });
 });
 
+describe('formatWrongTreeDowngradeFinding — pure unit', () => {
+  it('states close proceeded and names the disjoint stray files', () => {
+    const body = formatWrongTreeDowngradeFinding({
+      storyId: 7,
+      strayFiles: ['other/session.js'],
+      worktreePath: '/repo/.worktrees/story-7',
+    });
+    assert.match(body, /#7/);
+    assert.match(body, /proceeded/i);
+    assert.match(body, /disjoint/i);
+    assert.match(body, /`other\/session\.js`/);
+    assert.doesNotMatch(body, /aborted/i);
+  });
+});
+
 // ---------------------------------------------------------------------------
 // runWrongTreeGuardPhase — orchestration contract tests
 // ---------------------------------------------------------------------------
 
-describe('runWrongTreeGuardPhase — AC-1: aborts on stray main-checkout edits', () => {
-  it('throws and posts a friction comment naming the stray files', async () => {
+describe('runWrongTreeGuardPhase — AC-1: aborts on overlap with the Story diff', () => {
+  it('throws and posts a friction comment naming the stray files when a stray path is in the Story diff', async () => {
     const storyId = 200;
     const provider = makeProvider();
 
@@ -210,10 +385,16 @@ describe('runWrongTreeGuardPhase — AC-1: aborts on stray main-checkout edits',
         runWrongTreeGuardPhase({
           cwd: '/repo',
           worktreePath: '/repo/.worktrees/story-200',
+          baseBranch: 'main',
           storyId,
           provider,
           progress: noop,
-          gitSpawn: spawnResult(' M .agents/scripts/foo.js\nM  docs/bar.md'),
+          // Main checkout has two stray files; the Story's committed diff
+          // touches one of them → overlap → abort.
+          gitSpawn: fakeGit({
+            main: ' M .agents/scripts/foo.js\nM  docs/bar.md',
+            diff: '.agents/scripts/foo.js',
+          }),
         }),
       /Wrong-tree edits detected/,
     );
@@ -221,6 +402,7 @@ describe('runWrongTreeGuardPhase — AC-1: aborts on stray main-checkout edits',
     const comments = await provider.getTicketComments(storyId);
     assert.equal(comments.length, 1, 'expected one friction comment');
     assert.equal(comments[0].type, 'friction');
+    assert.match(comments[0].body, /aborted/i);
     assert.match(comments[0].body, /`\.agents\/scripts\/foo\.js`/);
     assert.match(comments[0].body, /`docs\/bar\.md`/);
   });
@@ -232,26 +414,144 @@ describe('runWrongTreeGuardPhase — AC-1: aborts on stray main-checkout edits',
         runWrongTreeGuardPhase({
           cwd: '/repo',
           worktreePath: '/repo/.worktrees/story-201',
+          baseBranch: 'main',
           storyId: 201,
           provider,
           progress: noop,
-          gitSpawn: spawnResult(' M src/leaked.js'),
+          gitSpawn: fakeGit({
+            main: ' M src/leaked.js',
+            diff: 'src/leaked.js',
+          }),
         }),
       /src\/leaked\.js/,
     );
   });
+
+  it('intersects an uncommitted worktree change (not only the committed diff)', async () => {
+    const provider = makeProvider();
+    await assert.rejects(
+      () =>
+        runWrongTreeGuardPhase({
+          cwd: '/repo',
+          worktreePath: '/repo/.worktrees/story-208',
+          baseBranch: 'main',
+          storyId: 208,
+          provider,
+          progress: noop,
+          // No committed diff, but the worktree has an uncommitted edit to the
+          // same file that is stray in the main checkout → overlap → abort.
+          gitSpawn: fakeGit({
+            main: ' M src/shared.js',
+            diff: '',
+            wtStatus: ' M src/shared.js',
+          }),
+        }),
+      /Wrong-tree edits detected/,
+    );
+  });
 });
 
-describe('runWrongTreeGuardPhase — clean main checkout proceeds', () => {
+describe('runWrongTreeGuardPhase — disjoint downgrade proceeds without throwing', () => {
+  it('does not throw, posts a proceeded-wording friction comment naming the disjoint strays, and reports overlap:[]', async () => {
+    const storyId = 210;
+    const provider = makeProvider();
+    const result = await runWrongTreeGuardPhase({
+      cwd: '/repo',
+      worktreePath: '/repo/.worktrees/story-210',
+      baseBranch: 'main',
+      storyId,
+      provider,
+      progress: noop,
+      // Main-checkout strays belong to another session; the Story diff is a
+      // non-empty, fully disjoint set → downgrade → proceed.
+      gitSpawn: fakeGit({
+        main: ' M other/alpha.js\nM  other/beta.js',
+        diff: 'src/mine.js',
+      }),
+    });
+
+    assert.equal(result.applied, true);
+    assert.deepEqual(result.overlap, []);
+    assert.deepEqual(result.strayFiles, ['other/alpha.js', 'other/beta.js']);
+
+    const comments = await provider.getTicketComments(storyId);
+    assert.equal(comments.length, 1, 'expected one telemetry friction comment');
+    assert.equal(comments[0].type, 'friction');
+    assert.match(comments[0].body, /proceeded/i);
+    assert.doesNotMatch(comments[0].body, /aborted/i);
+    assert.match(comments[0].body, /`other\/alpha\.js`/);
+    assert.match(comments[0].body, /`other\/beta\.js`/);
+  });
+});
+
+describe('runWrongTreeGuardPhase — empty-diff backstop keeps the abort', () => {
+  it('throws when the Story diff-path set is empty and the main checkout has stray tracked paths', async () => {
+    const storyId = 211;
+    const provider = makeProvider();
+    await assert.rejects(
+      () =>
+        runWrongTreeGuardPhase({
+          cwd: '/repo',
+          worktreePath: '/repo/.worktrees/story-211',
+          baseBranch: 'main',
+          storyId,
+          provider,
+          progress: noop,
+          // The worktree has no committed diff and no uncommitted tracked
+          // changes → empty Story diff set → keep the #3364 abort.
+          gitSpawn: fakeGit({
+            main: ' M src/leaked.js',
+            diff: '',
+            wtStatus: '',
+          }),
+        }),
+      /Wrong-tree edits detected/,
+    );
+    const comments = await provider.getTicketComments(storyId);
+    assert.equal(comments.length, 1);
+    assert.match(comments[0].body, /aborted/i);
+  });
+});
+
+describe('runWrongTreeGuardPhase — Story-diff probe failure falls back to abort', () => {
+  it('throws (coarse abort) when strays are present but the diff probe fails', async () => {
+    const storyId = 212;
+    const provider = makeProvider();
+    await assert.rejects(
+      () =>
+        runWrongTreeGuardPhase({
+          cwd: '/repo',
+          worktreePath: '/repo/.worktrees/story-212',
+          baseBranch: 'main',
+          storyId,
+          provider,
+          progress: noop,
+          // Main checkout dirty, but the Story-diff probe blows up → must NOT
+          // silently pass; fall back to the coarse abort.
+          gitSpawn: fakeGit({
+            main: ' M src/leaked.js',
+            diffThrows: 'git boom',
+          }),
+        }),
+      /Wrong-tree edits detected/,
+    );
+    const comments = await provider.getTicketComments(storyId);
+    assert.equal(comments.length, 1);
+    assert.match(comments[0].body, /aborted/i);
+  });
+});
+
+describe('runWrongTreeGuardPhase — clean / ignored main checkout proceeds', () => {
   it('returns applied:true and does not throw when main checkout is clean', async () => {
     const provider = makeProvider();
     const result = await runWrongTreeGuardPhase({
       cwd: '/repo',
       worktreePath: '/repo/.worktrees/story-202',
+      baseBranch: 'main',
       storyId: 202,
       provider,
       progress: noop,
-      gitSpawn: spawnResult(''),
+      gitSpawn: fakeGit({ main: '' }),
     });
     assert.equal(result.applied, true);
     assert.deepEqual(result.strayFiles, []);
@@ -264,10 +564,11 @@ describe('runWrongTreeGuardPhase — clean main checkout proceeds', () => {
     const result = await runWrongTreeGuardPhase({
       cwd: '/repo',
       worktreePath: '/repo/.worktrees/story-203',
+      baseBranch: 'main',
       storyId: 203,
       provider,
       progress: noop,
-      gitSpawn: spawnResult('?? temp/scratch.json\n?? notes.txt'),
+      gitSpawn: fakeGit({ main: '?? temp/scratch.json\n?? notes.txt' }),
     });
     assert.equal(result.applied, true);
     assert.deepEqual(result.strayFiles, []);
@@ -282,6 +583,7 @@ describe('runWrongTreeGuardPhase — guard does not apply', () => {
     const result = await runWrongTreeGuardPhase({
       cwd: '/repo',
       worktreePath: '/repo',
+      baseBranch: 'main',
       storyId: 204,
       provider: makeProvider(),
       progress: noop,
@@ -298,38 +600,39 @@ describe('runWrongTreeGuardPhase — guard does not apply', () => {
     const result = await runWrongTreeGuardPhase({
       cwd: '/repo',
       worktreePath: null,
+      baseBranch: 'main',
       storyId: 205,
       provider: makeProvider(),
       progress: noop,
-      gitSpawn: spawnResult(' M src/a.js'),
+      gitSpawn: fakeGit({ main: ' M src/a.js' }),
     });
     assert.equal(result.applied, false);
   });
 });
 
-describe('runWrongTreeGuardPhase — fail-open on probe error', () => {
+describe('runWrongTreeGuardPhase — fail-open on main-checkout probe error', () => {
   it('does not throw when gitSpawn throws (probe hiccup never blocks close)', async () => {
     const result = await runWrongTreeGuardPhase({
       cwd: '/repo',
       worktreePath: '/repo/.worktrees/story-206',
+      baseBranch: 'main',
       storyId: 206,
       provider: makeProvider(),
       progress: noop,
-      gitSpawn: () => {
-        throw new Error('git not found');
-      },
+      gitSpawn: fakeGit({ mainThrows: 'git not found' }),
     });
     assert.equal(result.applied, false);
   });
 
-  it('does not throw when git status exits non-zero', async () => {
+  it('does not throw when main git status exits non-zero', async () => {
     const result = await runWrongTreeGuardPhase({
       cwd: '/repo',
       worktreePath: '/repo/.worktrees/story-207',
+      baseBranch: 'main',
       storyId: 207,
       provider: makeProvider(),
       progress: noop,
-      gitSpawn: spawnResult('', { status: 128, stderr: 'fatal: not a repo' }),
+      gitSpawn: fakeGit({ mainStatus: 128 }),
     });
     assert.equal(result.applied, false);
   });


### PR DESCRIPTION
Closes #4424
Closes #4420

Refines the standalone close's wrong-tree guard (Story #3364) so it intersects the main-checkout stray tracked paths with the Story's own diff-path set (committed diff vs base + uncommitted worktree tracked changes) instead of aborting on any main-checkout dirt. Overlap aborts as before; a non-empty, fully-disjoint Story diff downgrades to a proceed-with-telemetry friction comment (fixes the framework-gap #4420 false positive from concurrent sessions); an empty Story diff keeps the #3364 empty-diff abort backstop; a Story-diff probe failure falls back to the coarse abort. Runner threads baseBranch into the guard.

_Auto-opened by `/single-story-deliver`._