### PR TITLE
feat: add a cross-epic guard to story-close.js's shared-checkout merge phase (#4460)

### DIFF
--- a/.agents/rules/git-conventions.md
+++ b/.agents/rules/git-conventions.md
@@ -165,6 +165,56 @@ operator intervention:
   owning flow's hygiene step regressed — fix the flow, do not codify the manual
   sweep.
 
+### Shared-checkout contention (Story #4460)
+
+`story-close.js`'s merge phase runs `git checkout <epic-branch>` directly in
+the **shared main repo checkout** (`close-inputs.js` resolves `mainCwd` to
+`PROJECT_ROOT`), not an isolated worktree. `lib/epic-merge-lock.js` guards
+that checkout with a **per-Epic** filesystem lock
+(`epic-<epicId>.merge.lock`) so two `story-close.js` runs for the **same**
+Epic serialize against each other — but nothing stops a **different**
+Epic's concurrently-running `story-close.js` from treating the same shared
+checkout as scratch space at the same time.
+
+- **Recognition signature**: a `git checkout`/`git switch` failure during
+  the merge phase whose message is `error: Your local changes ... would be
+  overwritten by checkout`, where the shared checkout is parked on a
+  **different** epic's branch (e.g. `epic/4405`) than the one the current
+  `story-close.js` run is trying to merge (e.g. `epic/4425`), with
+  uncommitted edits that belong to that other Epic's delivery. This was
+  observed live during Epic #4425 delivery (Stories #4427/#4428) colliding
+  with a concurrently-running Epic #4405 session, and had to be worked
+  around by hand via `git stash push -u`.
+- **The fix — `assertSharedCheckoutAvailable`**
+  (`lib/orchestration/story-close/shared-checkout-guard.js`), called from
+  `runFinalizeMerge` in `lib/orchestration/story-close/merge-runner.js`
+  immediately before the merge-phase `git checkout <epicBranch>`. It
+  **composes with, not replaces,** the per-Epic lock:
+  - It first checks the shared common `.git/` dir for a **foreign**
+    (different-epic) `epic-*.merge.lock` file whose recorded PID is still
+    alive (`findForeignActiveEpicLock` in `lib/epic-merge-lock.js`). If
+    found, the merge phase fails fast with a diagnostic naming the holding
+    epic id, its lock-file path, and its PID/acquired-at timestamp —
+    instead of surfacing the raw git checkout error.
+  - It then checks whether the shared checkout is simply dirty (via `git
+    status --porcelain`), regardless of whose branch is checked out, and
+    reports the dirty file list plus the currently-checked-out branch in
+    the failure diagnostic.
+  - It never inspects the **caller's own** epic-id lock namespace, so
+    same-epic concurrent `story-close.js` runs continue to serialize
+    solely through `withEpicMergeLock` (the existing per-Epic lock) before
+    this guard ever executes — this guard only ever refuses on a truly
+    _foreign_ epic's live lock or unrelated dirt.
+- **Not fixed by this guard**: the guard reports the contention early and
+  actionably; it does not redesign the merge phase to use an isolated
+  worktree, and it does not change `restoreStartingBranch`'s existing
+  dirty-tree refusal behavior (`phases/branch-restore.js`) — both remain
+  out of scope. Resolution of an actual collision is still manual: wait for
+  the other Epic's story-close run to finish, or — only once you have
+  independently confirmed that process is no longer running — remove the
+  stale lock file and resolve the dirty tree by hand (stash/commit/reset;
+  never `git reset --hard` or `git checkout --force`).
+
 ## Meta Labels (Retrospective Signal Routing)
 
 Two `meta::*` labels route retrospective signals into durable substrates so

--- a/.agents/scripts/lib/epic-merge-lock.js
+++ b/.agents/scripts/lib/epic-merge-lock.js
@@ -237,3 +237,86 @@ export function releaseEpicMergeLock(handle, fsImpl = fs) {
     if (err.code !== 'ENOENT') throw err;
   }
 }
+
+const LOCK_FILE_PREFIX = 'epic-';
+const LOCK_FILE_SUFFIX = '.merge.lock';
+
+// Extract the epic id from a lock filename, or `null` when `entry` isn't a
+// `epic-*.merge.lock` file. Split out of `findForeignActiveEpicLock` so
+// that function stays a flat filter+map instead of a nested-conditional
+// loop body (Story #4460).
+function parseLockFileEpicId(entry) {
+  if (
+    !entry.startsWith(LOCK_FILE_PREFIX) ||
+    !entry.endsWith(LOCK_FILE_SUFFIX)
+  ) {
+    return null;
+  }
+  return entry.slice(
+    LOCK_FILE_PREFIX.length,
+    entry.length - LOCK_FILE_SUFFIX.length,
+  );
+}
+
+// Read `<dir>/<entry>`'s lock meta and report it only when the recorded
+// pid is still alive — a foreign lock whose pid is dead (or whose meta is
+// unreadable/corrupt) is stale debris, not an active holder, mirroring the
+// pid-liveness half of `tryStealStale`'s heuristic.
+function readLiveLock(dir, entry, otherEpicId, fsImpl, killFn) {
+  const filePath = path.join(dir, entry);
+  const meta = readLockMeta(filePath, fsImpl);
+  if (!meta || !isProcessRunning(meta.pid, killFn)) return null;
+  return {
+    epicId: otherEpicId,
+    filePath,
+    pid: meta.pid,
+    acquiredAt: meta.acquiredAt,
+  };
+}
+
+/**
+ * Scan the shared common `.git/` dir for a *different* epic's live
+ * merge lock (Story #4460 — cross-epic shared-checkout guard).
+ *
+ * `acquireEpicMergeLock` only ever contends against locks for the *same*
+ * `epicId` (its own lock filename). This helper is the cross-epic
+ * counterpart: it lists every `epic-*.merge.lock` file in the common
+ * gitdir, skips the caller's own `epicId` namespace, and returns the
+ * first foreign lock whose recorded `pid` is still alive.
+ *
+ * @param {number|string} epicId Caller's own epic id (excluded from the scan).
+ * @param {{
+ *   repoRoot: string,
+ *   fsImpl?: object,
+ *   killFn?: (pid:number, signal:number)=>void,
+ * }} opts
+ * @returns {{ epicId: string, filePath: string, pid: number, acquiredAt: number }|null}
+ */
+export function findForeignActiveEpicLock(
+  epicId,
+  { repoRoot, fsImpl = fs, killFn = process.kill.bind(process) } = {},
+) {
+  if (!repoRoot) {
+    throw new Error('findForeignActiveEpicLock: repoRoot is required');
+  }
+  const dir = resolveGitCommonDir(repoRoot, fsImpl);
+  let entries;
+  try {
+    entries = fsImpl.readdirSync(dir);
+  } catch {
+    return null;
+  }
+
+  const foreignEntries = entries
+    .map((entry) => ({ entry, otherEpicId: parseLockFileEpicId(entry) }))
+    .filter(
+      ({ otherEpicId }) =>
+        otherEpicId !== null && String(otherEpicId) !== String(epicId),
+    );
+
+  for (const { entry, otherEpicId } of foreignEntries) {
+    const live = readLiveLock(dir, entry, otherEpicId, fsImpl, killFn);
+    if (live) return live;
+  }
+  return null;
+}

--- a/.agents/scripts/lib/orchestration/story-close/merge-runner.js
+++ b/.agents/scripts/lib/orchestration/story-close/merge-runner.js
@@ -55,6 +55,7 @@ import {
   buildMergeMessageWithCap,
   loadHeaderMaxLength,
 } from './merge-subject.js';
+import { assertSharedCheckoutAvailable as defaultAssertSharedCheckoutAvailable } from './shared-checkout-guard.js';
 
 /**
  * Render the lock-file path for a given main-repo `cwd` + `epicId`. Pure;
@@ -424,7 +425,7 @@ export async function runFinalizeMerge({
   storyBranch,
   storyTitle,
   storyId,
-  epicId: _epicId,
+  epicId,
   cwd,
   config,
   bus = null,
@@ -432,6 +433,7 @@ export async function runFinalizeMerge({
   logger = DefaultLogger,
   gitSync = defaultGitSync,
   gitSpawn = defaultGitSpawn,
+  assertSharedCheckoutAvailable = defaultAssertSharedCheckoutAvailable,
 }) {
   rebaseStoryOnEpic({
     config,
@@ -442,6 +444,15 @@ export async function runFinalizeMerge({
     log,
     gitSpawn,
   });
+
+  // Story #4460 — cross-epic shared-checkout guard. Runs AFTER the
+  // per-Epic merge lock is already held (acquired around the whole close
+  // flow in story-close.js) so it composes with, rather than replaces,
+  // that same-epic serialization. Fails fast with an actionable
+  // diagnostic instead of letting a raw `git checkout` error surface
+  // when another epic's merge phase (or unrelated dirt) holds the
+  // shared checkout.
+  assertSharedCheckoutAvailable({ cwd, epicId, gitSpawn });
 
   log('GIT', `Checking out ${epicBranch}...`);
   gitSync(cwd, 'checkout', epicBranch);

--- a/.agents/scripts/lib/orchestration/story-close/shared-checkout-guard.js
+++ b/.agents/scripts/lib/orchestration/story-close/shared-checkout-guard.js
@@ -1,0 +1,133 @@
+/**
+ * shared-checkout-guard.js — cross-epic contention guard for the merge
+ * phase's `git checkout <epicBranch>` in the shared main checkout
+ * (Story #4460).
+ *
+ * `story-close.js`'s merge phase (`runFinalizeMerge` in `merge-runner.js`)
+ * runs `git checkout <epicBranch>` directly in the shared main repo
+ * checkout — `close-inputs.js` resolves `cwd` to `PROJECT_ROOT`, not an
+ * isolated worktree. The only exclusivity guard around that shared
+ * checkout is the per-Epic `epic-merge-lock.js` mutex, which only
+ * serializes concurrent runs for the SAME epic. Nothing stops a
+ * DIFFERENT epic's concurrently-running `story-close.js` from treating
+ * the same shared checkout as scratch space at the same time.
+ *
+ * This was observed live: while delivering Epic #4425 Stories #4427/#4428,
+ * the shared checkout repeatedly carried uncommitted stray changes
+ * belonging to a concurrently-running Epic #4405 delivery (parked on
+ * `epic/4405` with dirty edits), which blocked the `git checkout epic/4425`
+ * merge step with a raw `error: Your local changes ... would be
+ * overwritten by checkout`.
+ *
+ * `assertSharedCheckoutAvailable` runs immediately before that checkout
+ * and fails fast with an actionable, story-close-specific diagnostic
+ * instead of letting the raw git error surface. It COMPOSES with (does
+ * not replace) the per-Epic lock: by the time this guard runs, the
+ * caller's own epic lock is already held (acquired around the whole
+ * close flow in `story-close.js`), so this guard only inspects OTHER
+ * epics' lock files plus the tree's overall dirty state — it never
+ * contends with same-epic concurrent runs, which continue to serialize
+ * solely via `withEpicMergeLock` before this guard ever executes.
+ */
+
+import { findForeignActiveEpicLock as defaultFindForeignActiveEpicLock } from '../../epic-merge-lock.js';
+import { gitSpawn as defaultGitSpawn } from '../../git-utils.js';
+
+const MAX_LISTED_DIRTY_FILES = 20;
+
+function describeForeignLock(foreign) {
+  const acquired = Number.isFinite(foreign.acquiredAt)
+    ? new Date(foreign.acquiredAt).toISOString()
+    : 'an unknown time';
+  return (
+    `[story-close] shared-checkout guard: refusing to touch the shared main checkout — ` +
+    `it is currently held by epic #${foreign.epicId}'s story-close merge phase ` +
+    `(lock ${foreign.filePath}, pid ${foreign.pid}, acquired ${acquired}). ` +
+    `Wait for that epic's story-close run to finish before retrying this merge. ` +
+    `If you have independently confirmed that process is no longer running, remove ` +
+    `the lock file by hand — never force a checkout past a live foreign lock. ` +
+    `See .agents/rules/git-conventions.md § Shared-checkout contention (Story #4460).`
+  );
+}
+
+function listDirtyFiles(porcelainOutput) {
+  // `git status --porcelain` lines are `XY <path>` — a fixed 2-char status
+  // column, a space, then the path. Strip only a trailing `\r` (Windows)
+  // before slicing off that 3-char prefix; trimming the whole line first
+  // would shift the slice offset whenever the status column starts with a
+  // space (the common "unstaged modification" case), truncating the path.
+  const lines = porcelainOutput
+    .split('\n')
+    .map((line) => line.replace(/\r$/, ''))
+    .filter((line) => line.length > 0);
+  const shown = lines
+    .slice(0, MAX_LISTED_DIRTY_FILES)
+    .map((line) => line.slice(3).trim() || line);
+  const overflow = lines.length - shown.length;
+  return overflow > 0
+    ? `${shown.join(', ')}, … (+${overflow} more)`
+    : shown.join(', ');
+}
+
+function describeDirtyCheckout({ cwd, epicId, currentBranch, dirtyFiles }) {
+  return (
+    `[story-close] shared-checkout guard: refusing to check out the epic branch for ` +
+    `epic #${epicId} — the shared main checkout at ${cwd} is dirty (currently on ` +
+    `\`${currentBranch}\`). Dirty files: ${dirtyFiles}. This usually means another ` +
+    `epic's story-close run left uncommitted work in the shared checkout, or a prior ` +
+    `run crashed mid-merge. Resolve manually (stash/commit/reset in ${cwd}) before ` +
+    `retrying. See .agents/rules/git-conventions.md § Shared-checkout contention ` +
+    `(Story #4460).`
+  );
+}
+
+/**
+ * Fail fast when the shared main checkout is not safely available for this
+ * epic's merge-phase `git checkout <epicBranch>` — either because another
+ * epic's story-close merge phase currently holds it (a live foreign lock),
+ * or because it is simply dirty (regardless of whose branch is checked
+ * out). Silent no-op when the checkout is clean and uncontended.
+ *
+ * @param {{
+ *   cwd: string,
+ *   epicId: number|string,
+ *   gitSpawn?: typeof defaultGitSpawn,
+ *   findForeignActiveEpicLock?: typeof defaultFindForeignActiveEpicLock,
+ * }} opts
+ * @throws {Error} with an actionable, story-close-specific diagnostic.
+ */
+export function assertSharedCheckoutAvailable({
+  cwd,
+  epicId,
+  gitSpawn = defaultGitSpawn,
+  findForeignActiveEpicLock = defaultFindForeignActiveEpicLock,
+}) {
+  const foreign = findForeignActiveEpicLock(epicId, { repoRoot: cwd });
+  if (foreign) {
+    throw new Error(describeForeignLock(foreign));
+  }
+
+  const statusRes = gitSpawn(cwd, 'status', '--porcelain');
+  if (statusRes.status !== 0) {
+    // Can't determine dirtiness from here — let the downstream checkout
+    // surface whatever git itself reports rather than guessing.
+    return;
+  }
+  const porcelain = statusRes.stdout || '';
+  if (porcelain.trim().length === 0) return;
+
+  const branchRes = gitSpawn(cwd, 'rev-parse', '--abbrev-ref', 'HEAD');
+  const currentBranch =
+    branchRes.status === 0
+      ? (branchRes.stdout || '').trim() || 'unknown'
+      : 'unknown';
+
+  throw new Error(
+    describeDirtyCheckout({
+      cwd,
+      epicId,
+      currentBranch,
+      dirtyFiles: listDirtyFiles(porcelain),
+    }),
+  );
+}

--- a/tests/lib/epic-merge-lock.test.js
+++ b/tests/lib/epic-merge-lock.test.js
@@ -6,6 +6,7 @@ import path from 'node:path';
 import { afterEach, beforeEach, describe, it } from 'node:test';
 import {
   acquireEpicMergeLock,
+  findForeignActiveEpicLock,
   releaseEpicMergeLock,
   resolveGitCommonDir,
 } from '../../.agents/scripts/lib/epic-merge-lock.js';
@@ -240,6 +241,87 @@ describe('epic-merge-lock', () => {
       }
     } finally {
       fs.rmSync(mainRepo, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('findForeignActiveEpicLock (Story #4460 — cross-epic shared-checkout guard)', () => {
+  let repoRoot;
+
+  beforeEach(() => {
+    repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'epic-lock-foreign-'));
+    fs.mkdirSync(path.join(repoRoot, '.git'), { recursive: true });
+  });
+
+  afterEach(() => {
+    fs.rmSync(repoRoot, { recursive: true, force: true });
+  });
+
+  it('returns null when no other epic holds a lock', () => {
+    const result = findForeignActiveEpicLock(4425, { repoRoot });
+    assert.equal(result, null);
+  });
+
+  it('ignores its own epic id namespace even if that lock file exists', () => {
+    const filePath = path.join(repoRoot, '.git', 'epic-4425.merge.lock');
+    fs.writeFileSync(
+      filePath,
+      JSON.stringify({ pid: process.pid, acquiredAt: Date.now() }),
+    );
+    const result = findForeignActiveEpicLock(4425, { repoRoot });
+    assert.equal(result, null, 'own epic namespace must never read as foreign');
+  });
+
+  it('detects a different epic id holding a live lock', () => {
+    const acquiredAt = Date.now();
+    const filePath = path.join(repoRoot, '.git', 'epic-4405.merge.lock');
+    fs.writeFileSync(
+      filePath,
+      JSON.stringify({ pid: process.pid, acquiredAt }),
+    );
+    const result = findForeignActiveEpicLock(4425, { repoRoot });
+    assert.ok(result, 'expected a foreign lock to be detected');
+    assert.equal(result.epicId, '4405');
+    assert.equal(result.filePath, filePath);
+    assert.equal(result.pid, process.pid);
+    assert.equal(result.acquiredAt, acquiredAt);
+  });
+
+  it('treats a foreign lock whose pid is dead as stale, not a live holder', () => {
+    const filePath = path.join(repoRoot, '.git', 'epic-4405.merge.lock');
+    fs.writeFileSync(
+      filePath,
+      JSON.stringify({ pid: 999999, acquiredAt: Date.now() }),
+    );
+    const killFn = () => {
+      const err = new Error('no such process');
+      err.code = 'ESRCH';
+      throw err;
+    };
+    const result = findForeignActiveEpicLock(4425, { repoRoot, killFn });
+    assert.equal(result, null, 'dead-pid foreign lock is not an active holder');
+  });
+
+  it('ignores non-lock files and corrupt lock meta in the common gitdir', () => {
+    fs.writeFileSync(
+      path.join(repoRoot, '.git', 'unrelated-file.txt'),
+      'noise',
+    );
+    fs.writeFileSync(
+      path.join(repoRoot, '.git', 'epic-4406.merge.lock'),
+      '{ corrupted',
+    );
+    const result = findForeignActiveEpicLock(4425, { repoRoot });
+    assert.equal(result, null);
+  });
+
+  it('returns null when the common gitdir does not exist yet', () => {
+    const bareDir = fs.mkdtempSync(path.join(os.tmpdir(), 'epic-lock-bare-'));
+    try {
+      const result = findForeignActiveEpicLock(4425, { repoRoot: bareDir });
+      assert.equal(result, null);
+    } finally {
+      fs.rmSync(bareDir, { recursive: true, force: true });
     }
   });
 });

--- a/tests/lib/orchestration/story-close/merge-runner-finalize.test.js
+++ b/tests/lib/orchestration/story-close/merge-runner-finalize.test.js
@@ -216,6 +216,102 @@ describe('runFinalizeMerge — happy and conflict paths (per-test mocks)', () =>
   });
 });
 
+describe('runFinalizeMerge — shared-checkout guard wiring (Story #4460)', () => {
+  it('runs assertSharedCheckoutAvailable before the epic-branch checkout and aborts on refusal', async (t) => {
+    pinMergeCollab(t, {
+      mergeResult: {
+        merged: true,
+        major: false,
+        autoResolved: false,
+        conflicts: { files: 0, lines: 0, fileList: [] },
+      },
+      pushResult: { ok: true, attempts: 1 },
+    });
+    const { runFinalizeMerge } = await import(
+      `${mergeRunnerUrl}?t=guard-refused`
+    );
+
+    const stub = gitStub();
+    const guardCalls = [];
+    const assertSharedCheckoutAvailable = (args) => {
+      guardCalls.push(args);
+      throw new Error(
+        '[story-close] shared-checkout guard: refusing to touch the shared main checkout',
+      );
+    };
+
+    await assert.rejects(
+      () =>
+        runFinalizeMerge({
+          epicBranch: 'epic/4425',
+          storyBranch: 'story-4427',
+          storyTitle: 'Guard wiring',
+          storyId: 4427,
+          epicId: 4425,
+          cwd: '/tmp',
+          orchestration: { worktreeIsolation: { enabled: false } },
+          log: () => {},
+          logger: { error: () => {} },
+          gitSync: () => ({ status: 0, stdout: '', stderr: '' }),
+          gitSpawn: stub.gitSpawn,
+          assertSharedCheckoutAvailable,
+        }),
+      /shared-checkout guard/,
+    );
+
+    assert.equal(guardCalls.length, 1);
+    assert.equal(guardCalls[0].cwd, '/tmp');
+    assert.equal(guardCalls[0].epicId, 4425);
+    // No `checkout` call reached git — the guard threw before it.
+    assert.ok(
+      !stub.calls.some((c) => c.args[0] === 'checkout'),
+      'checkout must not run when the guard refuses',
+    );
+  });
+
+  it('proceeds to checkout + merge when the guard passes', async (t) => {
+    pinMergeCollab(t, {
+      mergeResult: {
+        merged: true,
+        major: false,
+        autoResolved: false,
+        conflicts: { files: 0, lines: 0, fileList: [] },
+      },
+      pushResult: { ok: true, attempts: 1 },
+    });
+    const { runFinalizeMerge } = await import(
+      `${mergeRunnerUrl}?t=guard-passed`
+    );
+
+    const stub = gitStub();
+    const syncCalls = [];
+    let guardCallCount = 0;
+
+    await runFinalizeMerge({
+      epicBranch: 'epic/1',
+      storyBranch: 'story-1',
+      storyTitle: 'Guard passes',
+      storyId: 1,
+      epicId: 1,
+      cwd: '/tmp',
+      orchestration: { worktreeIsolation: { enabled: false } },
+      log: () => {},
+      logger: { error: () => {} },
+      gitSync: (_cwd, ...args) => {
+        syncCalls.push(args);
+        return { status: 0, stdout: '', stderr: '' };
+      },
+      gitSpawn: stub.gitSpawn,
+      assertSharedCheckoutAvailable: () => {
+        guardCallCount += 1;
+      },
+    });
+
+    assert.equal(guardCallCount, 1);
+    assert.ok(syncCalls.some((args) => args[0] === 'checkout'));
+  });
+});
+
 describe('finalizeMergeIfPending — pending merge path', () => {
   it('commits the pending merge when MERGE_HEAD exists', async () => {
     const { finalizeMergeIfPending } = await import(mergeRunnerUrl);

--- a/tests/lib/orchestration/story-close/shared-checkout-guard.test.js
+++ b/tests/lib/orchestration/story-close/shared-checkout-guard.test.js
@@ -1,0 +1,223 @@
+/**
+ * Unit coverage for `assertSharedCheckoutAvailable`
+ * (lib/orchestration/story-close/shared-checkout-guard.js — Story #4460).
+ *
+ * Covers the acceptance-criteria scenarios directly:
+ *   (a) a foreign (different-epic) live lock is refused with the new
+ *       story-close-specific diagnostic instead of a raw git error;
+ *   (b) same-epic runs are unaffected — this guard only looks at OTHER
+ *       epics' lock files, so it never fires on the caller's own epic id
+ *       (that serialization stays solely on `withEpicMergeLock`);
+ *   (c) a clean checkout on the caller's own epic branch proceeds
+ *       normally (no throw), including when the tree is merely dirty
+ *       with no foreign lock present (a distinct diagnostic naming the
+ *       dirty files).
+ */
+
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import { assertSharedCheckoutAvailable } from '../../../../.agents/scripts/lib/orchestration/story-close/shared-checkout-guard.js';
+
+function gitStub(routes = {}) {
+  const calls = [];
+  return {
+    calls,
+    gitSpawn: (cwd, ...args) => {
+      calls.push({ cwd, args });
+      const key = args.join(' ');
+      const route = routes[key];
+      if (typeof route === 'function') return route(cwd, args);
+      return route ?? { status: 0, stdout: '', stderr: '' };
+    },
+  };
+}
+
+describe('assertSharedCheckoutAvailable — foreign-epic collision (scenario a)', () => {
+  it('throws a story-close-specific diagnostic naming the foreign epic + pid + lock path', () => {
+    const acquiredAt = Date.parse('2026-07-11T12:00:00.000Z');
+    const findForeignActiveEpicLock = () => ({
+      epicId: '4405',
+      filePath: '/repo/.git/epic-4405.merge.lock',
+      pid: 55555,
+      acquiredAt,
+    });
+    const stub = gitStub();
+
+    assert.throws(
+      () =>
+        assertSharedCheckoutAvailable({
+          cwd: '/repo',
+          epicId: 4425,
+          gitSpawn: stub.gitSpawn,
+          findForeignActiveEpicLock,
+        }),
+      (err) => {
+        assert.match(err.message, /shared-checkout guard/);
+        assert.match(err.message, /epic #4405/);
+        assert.match(err.message, /pid 55555/);
+        assert.match(err.message, /epic-4405\.merge\.lock/);
+        assert.match(err.message, /2026-07-11T12:00:00\.000Z/);
+        return true;
+      },
+    );
+    // Refused before ever probing git status — the foreign-lock check
+    // short-circuits.
+    assert.equal(stub.calls.length, 0);
+  });
+
+  it("never treats the caller's own epic id as foreign (composes with, does not replace, the per-epic lock)", () => {
+    // Simulates the real findForeignActiveEpicLock contract: it already
+    // excludes the caller's own epicId namespace, so a same-epic
+    // concurrent run always resolves to null here — same-epic
+    // serialization remains solely owned by withEpicMergeLock upstream.
+    const findForeignActiveEpicLock = (epicId) => {
+      assert.equal(epicId, 4425);
+      return null;
+    };
+    const stub = gitStub({
+      'status --porcelain': { status: 0, stdout: '', stderr: '' },
+    });
+
+    assert.doesNotThrow(() =>
+      assertSharedCheckoutAvailable({
+        cwd: '/repo',
+        epicId: 4425,
+        gitSpawn: stub.gitSpawn,
+        findForeignActiveEpicLock,
+      }),
+    );
+  });
+});
+
+describe('assertSharedCheckoutAvailable — dirty shared checkout (no foreign lock)', () => {
+  it('throws naming the dirty files and current branch when no foreign lock is held', () => {
+    const findForeignActiveEpicLock = () => null;
+    const stub = gitStub({
+      'status --porcelain': {
+        status: 0,
+        stdout: ' M finalizer.js\n?? scratch.test.js\n',
+        stderr: '',
+      },
+      'rev-parse --abbrev-ref HEAD': {
+        status: 0,
+        stdout: 'epic/4405\n',
+        stderr: '',
+      },
+    });
+
+    assert.throws(
+      () =>
+        assertSharedCheckoutAvailable({
+          cwd: '/repo',
+          epicId: 4425,
+          gitSpawn: stub.gitSpawn,
+          findForeignActiveEpicLock,
+        }),
+      (err) => {
+        assert.match(err.message, /shared-checkout guard/);
+        assert.match(err.message, /epic #4425/);
+        assert.match(err.message, /currently on `epic\/4405`/);
+        assert.match(err.message, /finalizer\.js/);
+        assert.match(err.message, /scratch\.test\.js/);
+        return true;
+      },
+    );
+  });
+
+  it('falls back to "unknown" branch when rev-parse fails', () => {
+    const findForeignActiveEpicLock = () => null;
+    const stub = gitStub({
+      'status --porcelain': { status: 0, stdout: ' M x.js\n', stderr: '' },
+      'rev-parse --abbrev-ref HEAD': { status: 1, stdout: '', stderr: 'boom' },
+    });
+
+    assert.throws(
+      () =>
+        assertSharedCheckoutAvailable({
+          cwd: '/repo',
+          epicId: 1,
+          gitSpawn: stub.gitSpawn,
+          findForeignActiveEpicLock,
+        }),
+      /currently on `unknown`/,
+    );
+  });
+
+  it('truncates the dirty-file listing past the cap with an overflow count', () => {
+    const findForeignActiveEpicLock = () => null;
+    const many = Array.from({ length: 25 }, (_, i) => ` M file-${i}.js`).join(
+      '\n',
+    );
+    const stub = gitStub({
+      'status --porcelain': { status: 0, stdout: many, stderr: '' },
+      'rev-parse --abbrev-ref HEAD': {
+        status: 0,
+        stdout: 'epic/1\n',
+        stderr: '',
+      },
+    });
+
+    assert.throws(
+      () =>
+        assertSharedCheckoutAvailable({
+          cwd: '/repo',
+          epicId: 1,
+          gitSpawn: stub.gitSpawn,
+          findForeignActiveEpicLock,
+        }),
+      /\+5 more/,
+    );
+  });
+});
+
+describe('assertSharedCheckoutAvailable — clean checkout proceeds normally (scenario c)', () => {
+  it('does not throw when there is no foreign lock and the tree is clean', () => {
+    const findForeignActiveEpicLock = () => null;
+    const stub = gitStub({
+      'status --porcelain': { status: 0, stdout: '', stderr: '' },
+    });
+
+    assert.doesNotThrow(() =>
+      assertSharedCheckoutAvailable({
+        cwd: '/repo',
+        epicId: 4425,
+        gitSpawn: stub.gitSpawn,
+        findForeignActiveEpicLock,
+      }),
+    );
+  });
+
+  it('does not throw when `git status` itself fails to run (defers to the downstream checkout)', () => {
+    const findForeignActiveEpicLock = () => null;
+    const stub = gitStub({
+      'status --porcelain': { status: 128, stdout: '', stderr: 'not a repo' },
+    });
+
+    assert.doesNotThrow(() =>
+      assertSharedCheckoutAvailable({
+        cwd: '/repo',
+        epicId: 4425,
+        gitSpawn: stub.gitSpawn,
+        findForeignActiveEpicLock,
+      }),
+    );
+  });
+
+  it('uses the real findForeignActiveEpicLock default when not overridden, against a non-repo cwd', () => {
+    // No injected findForeignActiveEpicLock — exercises the real default
+    // wired from epic-merge-lock.js against a cwd with no .git directory,
+    // which resolves to "no foreign lock" rather than throwing.
+    const stub = gitStub({
+      'status --porcelain': { status: 0, stdout: '', stderr: '' },
+    });
+
+    assert.doesNotThrow(() =>
+      assertSharedCheckoutAvailable({
+        cwd: '/tmp/mandrel-shared-checkout-guard-default-test-nonexistent',
+        epicId: 4425,
+        gitSpawn: stub.gitSpawn,
+      }),
+    );
+  });
+});


### PR DESCRIPTION
Closes #4460

_Auto-opened by `/single-story-deliver`._