### PR TITLE
fix(deliver): add missing fs import in epic-deliver-prepare

### DIFF
--- a/.agents/scripts/epic-deliver-prepare.js
+++ b/.agents/scripts/epic-deliver-prepare.js
@@ -32,6 +32,7 @@
  *   node .agents/scripts/epic-deliver-prepare.js --epic <epicId>
  */
 
+import fs from 'node:fs';
 import path from 'node:path';
 import { parseArgs } from 'node:util';
 
@@ -389,12 +390,13 @@ async function writeDocsDigest({ epicId, cwd, config }) {
  * }} args
  * @returns {Promise<Array<{ storyId: number, worktree?: string, title?: string, checklistPath: string|null }>>}
  */
-async function writeStoryChecklists({
+export async function writeStoryChecklists({
   epicId,
   cwd,
   config,
   stories,
   storyById,
+  buildPayload = buildChecklistPayload,
 }) {
   const paths = getPaths(config);
   const root = path.resolve(cwd ?? process.cwd());
@@ -405,7 +407,7 @@ async function writeStoryChecklists({
       const footprint = ticket
         ? collectStoryAssumptionEntries(ticket).map((e) => e.path)
         : [];
-      const { payload } = buildChecklistPayload({ footprint, logger: Logger });
+      const { payload } = buildPayload({ footprint, logger: Logger });
       if (!payload) return { ...entry, checklistPath: null };
 
       const relPath = path.join(

--- a/tests/epic-execute/epic-deliver-prepare-checklists.test.js
+++ b/tests/epic-execute/epic-deliver-prepare-checklists.test.js
@@ -1,0 +1,66 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, it } from 'node:test';
+
+import { writeStoryChecklists } from '../../.agents/scripts/epic-deliver-prepare.js';
+
+/**
+ * Regression guard for the `fs is not defined` ReferenceError that shipped in
+ * `writeStoryChecklists` (missing `import fs`): the function reached
+ * `fs.promises.mkdir` / `fs.promises.writeFile` at runtime and threw, blocking
+ * every `/deliver <epic>` at the prepare step. This test drives the real write
+ * path (a matched footprint yields a non-empty payload) so the module-level
+ * `fs` import is exercised, not just parsed.
+ */
+describe('writeStoryChecklists — fs write path', () => {
+  let cwd;
+
+  beforeEach(() => {
+    cwd = fs.mkdtempSync(path.join(os.tmpdir(), 'mandrel-checklists-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(cwd, { recursive: true, force: true });
+  });
+
+  it('writes the checklist file for a Story with a non-empty payload', async () => {
+    const result = await writeStoryChecklists({
+      epicId: 4430,
+      cwd,
+      config: {},
+      stories: [{ storyId: 42, worktree: 'wt', title: 'demo' }],
+      storyById: new Map(),
+      // Inject a deterministic payload so the test does not depend on the
+      // repo's audit-rules content — the point is to exercise the fs writes.
+      buildPayload: () => ({ payload: '# Checklist\n- concern one' }),
+    });
+
+    assert.equal(result.length, 1);
+    const relPath = result[0].checklistPath;
+    assert.equal(
+      relPath,
+      path.join('temp', 'epic-4430', 'checklists', 'story-42.md'),
+    );
+
+    // The file the prepare step promised must actually exist on disk with the
+    // payload content — this is the exact mkdir+writeFile pair that threw.
+    const written = fs.readFileSync(path.resolve(cwd, relPath), 'utf-8');
+    assert.equal(written, '# Checklist\n- concern one');
+  });
+
+  it('returns a null checklistPath (and writes nothing) when the payload is empty', async () => {
+    const result = await writeStoryChecklists({
+      epicId: 4430,
+      cwd,
+      config: {},
+      stories: [{ storyId: 7, worktree: 'wt', title: 'no-match' }],
+      storyById: new Map(),
+      buildPayload: () => ({ payload: '' }),
+    });
+
+    assert.equal(result[0].checklistPath, null);
+    assert.equal(fs.existsSync(path.join(cwd, 'temp', 'epic-4430')), false);
+  });
+});


### PR DESCRIPTION
## Why

`writeStoryChecklists` in `epic-deliver-prepare.js` calls `fs.promises.mkdir` / `fs.promises.writeFile`, but the module never imported `fs`. Every `/deliver <epic>` run hit `ReferenceError: fs is not defined` at the Phase 1 prepare step — a hard block on **all** Epic delivery.

The function was added by Story #4410 (Epic #4405, merged via #4463). It shipped broken because **no test exercised the real checklist-writing path** — CI parsed the module fine (the `fs` reference is only resolved at call time) but never invoked the `fs` writes.

## What

- Add the missing `import fs from 'node:fs'`.
- Export `writeStoryChecklists` and add an injectable `buildPayload` seam so the write path is unit-testable without coupling to audit-rules content.
- Add `tests/epic-execute/epic-deliver-prepare-checklists.test.js` — a regression test that drives the exact `mkdir`+`writeFile` pair. It fails with `ReferenceError: fs is not defined` on the pre-fix code and passes on the fix, closing the CI gap that let this ship.

## Verification

- `node --test tests/epic-execute/epic-deliver-prepare-checklists.test.js` — green (2/2); fails on the reverted import.
- `node --test tests/epic-execute/epic-deliver-prepare.test.js tests/epic-deliver-prepare-cache.test.js` — 16/16 green (DI seam + export are backward-compatible).
- `npm run lint` + `npx biome ci` — clean.

Unblocks `/deliver 4430` (and every other Epic delivery).

🤖 Generated with [Claude Code](https://claude.com/claude-code)