### PR TITLE
fix(delivery): prepare-branch smoke coverage + undeclared-var guard + docs-freshness hygiene

### DIFF
--- a/.agents/scripts/validate-docs-freshness.js
+++ b/.agents/scripts/validate-docs-freshness.js
@@ -1,5 +1,4 @@
 #!/usr/bin/env node
-/* node:coverage ignore file -- pre-push docs-freshness gate; pure git-mtime walk with no testable branching beyond filesystem state */
 
 /**
  * .agents/scripts/validate-docs-freshness.js — Documentation Freshness Gate
@@ -31,7 +30,7 @@
  * "does it mention the Epic?".
  *
  * Usage:
- *   node .agents/scripts/validate-docs-freshness.js --epic <EPIC_ID> [--base main] [--docs <comma-separated>] [--json]
+ *   node .agents/scripts/validate-docs-freshness.js --epic <EPIC_ID> [--docs <comma-separated>] [--json]
  *
  * `--json` emits a single JSON object on stdout with
  *   { ok, epicId, results: [{ file, pass, reason }, ...] }
@@ -107,6 +106,8 @@ function epicRefMatcher(epicId) {
   return new RegExp(`#${epicId}(?!\\d)`);
 }
 
+/* node:coverage disable -- real `git log` shell-out; exercised via the
+   injectable `commitsForFile` seam in runFreshnessGate, not directly. */
 function commitsMentioningEpic(docPath, epicId, cwd = PROJECT_ROOT) {
   const res = gitSpawn(
     cwd,
@@ -123,6 +124,7 @@ function commitsMentioningEpic(docPath, epicId, cwd = PROJECT_ROOT) {
     .map((s) => s.trim())
     .filter(Boolean);
 }
+/* node:coverage enable */
 
 function fileBodyMentionsEpic(
   docPath,
@@ -208,7 +210,6 @@ export function parseFreshnessArgs(argv) {
     args: argv,
     options: {
       epic: { type: 'string' },
-      base: { type: 'string' },
       docs: { type: 'string' },
       json: { type: 'boolean', default: false },
     },
@@ -259,6 +260,9 @@ export function renderFreshnessSuccessMessage(epicId, count) {
   return `[docs-freshness] ✅ All ${count} doc(s) reference Epic #${epicId}.`;
 }
 
+/* node:coverage disable -- process I/O + real config/git wiring (stdout,
+   process.exit, resolveConfig, runAsCli); the pure logic these thin wrappers
+   call is covered directly above. */
 function reportEmptyDocs(epicId, json) {
   if (json) {
     process.stdout.write(
@@ -306,3 +310,4 @@ async function main() {
 }
 
 runAsCli(import.meta.url, main, { source: 'validate-docs-freshness' });
+/* node:coverage enable */

--- a/biome.json
+++ b/biome.json
@@ -17,7 +17,10 @@
   "linter": {
     "enabled": true,
     "rules": {
-      "preset": "recommended"
+      "preset": "recommended",
+      "correctness": {
+        "noUndeclaredVariables": "error"
+      }
     }
   },
   "javascript": {

--- a/tests/epic-execute/epic-deliver-prepare-checklists.test.js
+++ b/tests/epic-execute/epic-deliver-prepare-checklists.test.js
@@ -4,7 +4,11 @@ import os from 'node:os';
 import path from 'node:path';
 import { afterEach, beforeEach, describe, it } from 'node:test';
 
-import { writeStoryChecklists } from '../../.agents/scripts/epic-deliver-prepare.js';
+import {
+  runEpicDeliverPrepare,
+  writeStoryChecklists,
+} from '../../.agents/scripts/epic-deliver-prepare.js';
+import { serialize } from '../../.agents/scripts/lib/story-body/story-body.js';
 
 /**
  * Regression guard for the `fs is not defined` ReferenceError that shipped in
@@ -62,5 +66,126 @@ describe('writeStoryChecklists — fs write path', () => {
 
     assert.equal(result[0].checklistPath, null);
     assert.equal(fs.existsSync(path.join(cwd, 'temp', 'epic-4430')), false);
+  });
+});
+
+/**
+ * End-to-end smoke coverage (issue #4466). The unit tests above inject
+ * `buildPayload`; this drives the WHOLE `runEpicDeliverPrepare` runner through
+ * the REAL `buildChecklistPayload` (real `.agents/schemas/audit-rules.json` +
+ * committed `.agents/audit-checklists/*.md`) with a Story whose serialized
+ * `## Changes` footprint matches a local lens — so the conditional
+ * checklist-writing branch actually executes end-to-end, not just the
+ * happy no-op path the pre-existing `epic-deliver-prepare.test.js` fixtures
+ * (empty Story bodies → empty footprint → null payload) ever reached. That
+ * blind spot is exactly how the `fs is not defined` ReferenceError shipped
+ * green (PR #4465); this test would have caught it through the real runner.
+ */
+describe('runEpicDeliverPrepare — checklist-writing branch executes end-to-end', () => {
+  let scratch;
+
+  beforeEach(() => {
+    scratch = fs.mkdtempSync(path.join(os.tmpdir(), 'mandrel-prepare-smoke-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(scratch, { recursive: true, force: true });
+  });
+
+  function createFakeProvider({ epic, descendants }) {
+    let autoId = 1;
+    const comments = new Map();
+    return {
+      _comments: comments,
+      async getTicket(id) {
+        if (id === epic.id) return epic;
+        return descendants.find((d) => d.id === id) ?? null;
+      },
+      async getSubTickets() {
+        return descendants;
+      },
+      async getTicketComments(ticketId) {
+        return comments.get(ticketId) ?? [];
+      },
+      async postComment(ticketId, payload) {
+        const list = comments.get(ticketId) ?? [];
+        const c = { id: autoId++, body: payload.body };
+        list.push(c);
+        comments.set(ticketId, list);
+        return c;
+      },
+      async deleteComment(commentId) {
+        for (const [, list] of comments) {
+          const idx = list.findIndex((c) => c.id === commentId);
+          if (idx !== -1) list.splice(idx, 1);
+        }
+      },
+    };
+  }
+
+  it('writes a real footprint-matched checklist for a Story through the full runner', async () => {
+    const epicId = 987654;
+    const storyId = 987655;
+    const epic = { id: epicId, labels: ['type::epic', 'acceptance::n-a'] };
+    // A serialized Story body carrying a `## Changes` path. `audit-clean-code`
+    // is a `scope: local` lens with the universal `**/*` glob and a committed
+    // checklist, so ANY changes path matches it → non-empty payload → the
+    // `fs.promises.mkdir`/`writeFile` branch runs.
+    const storyBody = serialize({
+      goal: 'Touch a source file so the local-lens footprint matches.',
+      changes: [{ path: 'src/example.js', assumption: 'creates' }],
+    });
+    const descendants = [
+      {
+        id: storyId,
+        number: storyId,
+        title: 'Footprint-matched story',
+        labels: ['type::story'],
+        body: storyBody,
+      },
+    ];
+    const provider = createFakeProvider({ epic, descendants });
+    // `tempRoot` points at a scratch dir so the checklist write does not touch
+    // the repo's real `temp/`; `agentRoot` stays `.agents` so the runner reads
+    // the real audit-rules + committed checklists (resolved via PROJECT_ROOT).
+    const config = {
+      github: { owner: 'test-owner', repo: 'test-repo' },
+      project: {
+        paths: { agentRoot: '.agents', docsRoot: 'docs', tempRoot: scratch },
+      },
+      orchestration: {
+        runners: {
+          deliverRunner: { enabled: true, concurrencyCap: 3 },
+        },
+      },
+    };
+
+    const out = await runEpicDeliverPrepare({
+      epicId,
+      injectedProvider: provider,
+      injectedConfig: config,
+      // Bypass the git-dependent preflight guards (checkout-safety, lease) and
+      // the boot sweep — the runner logic under test is the checklist-writing
+      // branch, not the git plumbing.
+      skipPreflightGuards: true,
+    });
+
+    const entry = out.stories.find((s) => s.storyId === storyId);
+    assert.ok(entry, 'the story appears in the dispatch hint');
+    assert.ok(
+      typeof entry.checklistPath === 'string' && entry.checklistPath.length > 0,
+      'checklistPath is non-null — the fs-write branch executed',
+    );
+
+    // The file the runner promised must exist on disk with real checklist
+    // content (proving it went through the real buildChecklistPayload, not a
+    // stub). `entry.checklistPath` is absolute because tempRoot is absolute.
+    const written = fs.readFileSync(entry.checklistPath, 'utf-8');
+    assert.ok(written.length > 0, 'the checklist file is non-empty');
+    assert.match(
+      written,
+      /audit-clean-code|Clean Code|clean-code/i,
+      'the checklist body came from the real clean-code lens artifact',
+    );
   });
 });


### PR DESCRIPTION
Clears two of the three Epic #4430 close follow-ups before we cut v1.89.0. (#4467 is deferred — see below.)

## Closes #4466 — real-run smoke coverage for the delivery CLIs

The `fs is not defined` ReferenceError (fixed in #4465) shipped green because the prepare runner's checklist-writing branch was never executed by any test — the existing fixtures use empty Story bodies, so the footprint is empty, the payload is null, and the `fs.promises` write is never reached.

- **End-to-end smoke test**: drives the whole `runEpicDeliverPrepare` through the **real** `buildChecklistPayload` (real `audit-rules.json` + committed `audit-checklists/*.md`) with a Story whose serialized `## Changes` footprint matches a local lens (`audit-clean-code`'s `**/*`), so the branch actually runs and writes a real checklist. Proven to catch the regression: removing the `import fs` fails it with the ReferenceError.
- **`noUndeclaredVariables` lint rule enabled** (biome `lint/correctness/noUndeclaredVariables` → error). This is the durable, class-killing guard the issue asked us to consider — it flags an undeclared namespace used without import (`fs.`/`os.`/`crypto.`) across **every** file, so the peer-CLI audit is covered mechanically rather than by hand. **Zero false positives repo-wide** (1663 files); confirmed it fires precisely on the original bug.

## Closes #4469 — docs-freshness gate hygiene

`validate-docs-freshness.js`:
- Replaced the stale whole-file `node:coverage ignore file` (its "no testable branching" claim went false when Story #4436 added `isChangelogClass` + the changelog-only pass condition **and** tests) with narrow `disable`/`enable` regions around only the genuinely git/process-dependent helpers. The pure, tested logic now counts in the coverage/CRAP baseline.
- Dropped the dead `--base` flag (unused `parseArgs` option + usage docstring).

## #4467 — deferred (not in this PR)

Root-cause investigation ([note on the issue](https://github.com/dsj1984/mandrel/issues/4467#issuecomment-4948883250)): there is no deterministic "run a lens as a review dimension" seam — lenses are walked by the host LLM reading `code-review.md`, and the story-close subprocess has no LLM. Making the story-scope pass a real verifier requires adding an LLM sub-agent to the deterministic close path — a genuine architectural change. Correctness is already fine (the stopgap runs local lenses at Epic close), so this is an optimization, deferred rather than rushed pre-release.

## Verification

- `npm test` — 10,068 pass / 0 fail
- `npm run lint` + `npx biome ci` — clean (rule active, no false positives)
- crap / maintainability / duplication baselines — PASS; dead-exports `added=0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)