### PR TITLE
fix(deliver): verify the remote at orchestration entry — land or block explicitly, never a silent local-main build

### DIFF
--- a/.agents/scripts/epic-deliver-preflight.js
+++ b/.agents/scripts/epic-deliver-preflight.js
@@ -11,7 +11,12 @@
  *      `storyCount`, `installCostSeconds`, `dependencyDepth`,
  *      `githubApiRequests`, `claudeQuotaTokens`, plus `breaches`
  *      (the non-empty subset of `delivery.preflight.max*` thresholds the
- *      estimate exceeds).
+ *      estimate exceeds), plus `remoteVerified` / `remoteProbe` — the
+ *      issue #4483 deterministic remote evidence (`git remote get-url
+ *      origin` + bounded `git ls-remote origin HEAD`). On
+ *      `remoteVerified: false` the workflow MUST flip the Epic to
+ *      `agent::blocked` quoting `remoteProbe.detail` — inline delivery to
+ *      local `main` is never a sanctioned fallback.
  *   2. When `--post` is set (and `--dry-run` is not), an upserted
  *      `delivery-preflight` structured comment on the Epic ticket so
  *      reviewers reading the Epic discover the same numbers without
@@ -66,6 +71,7 @@ import {
   computeBaseSha,
   writePreflightCache,
 } from './lib/orchestration/preflight-cache.js';
+import { verifyRemote } from './lib/orchestration/remote-verifier.js';
 import { upsertStructuredComment } from './lib/orchestration/ticketing.js';
 import { createProvider } from './lib/provider-factory.js';
 
@@ -218,10 +224,23 @@ export function renderPreflightBody({
   estimate,
   breaches,
   thresholds,
+  remote,
 }) {
   const lines = [];
   lines.push(`### 🛫 Delivery preflight — Epic #${epicId}`);
   lines.push('');
+  // Issue #4483 — verified remote evidence at entry. Rendered before the
+  // metric table so a reviewer (and the orchestrating agent) sees the
+  // land-or-block fact first. Omitted when the caller has no probe result
+  // (legacy callers / tests that only exercise the estimate math).
+  if (remote) {
+    lines.push(
+      remote.remoteVerified
+        ? `✅ **remoteVerified: true** — ${remote.detail}`
+        : `⛔ **remoteVerified: false** — ${remote.detail} — \`/deliver\` MUST transition the Epic to \`agent::blocked\` quoting this probe; inline delivery to local \`main\` is forbidden.`,
+    );
+    lines.push('');
+  }
   lines.push('| Metric | Estimate | Threshold |');
   lines.push('| --- | ---: | ---: |');
   const rows = [
@@ -276,6 +295,7 @@ export function renderPreflightBody({
  *   perStoryClaudeTokens?: number,
  *   injectedProvider?: object,
  *   injectedConfig?: object,
+ *   verifyRemoteFn?: typeof verifyRemote,
  * }} args
  */
 export async function runPreflight({
@@ -288,6 +308,7 @@ export async function runPreflight({
   perStoryClaudeTokens,
   injectedProvider,
   injectedConfig,
+  verifyRemoteFn = verifyRemote,
 }) {
   if (!Number.isInteger(epicId) || epicId <= 0) {
     throw new TypeError('runPreflight: --epic must be a positive integer');
@@ -296,6 +317,13 @@ export async function runPreflight({
   const config = injectedConfig ?? resolveConfig({ cwd });
   const provider = injectedProvider ?? createProvider(config);
   const thresholds = getPreflight(config);
+
+  // Issue #4483 — deterministic remote evidence at entry. Probe BEFORE any
+  // provider work so the envelope always carries verified fact (not the
+  // agent's perception) about whether a live, pushable `origin` exists.
+  // The CLI records; the `/deliver` workflow owns the `agent::blocked`
+  // transition on `remoteVerified: false` (same split as breach handling).
+  const remote = verifyRemoteFn({ cwd });
 
   // Compose the same two phases /deliver Phase 1 runs so the
   // preflight numbers match the actual dispatch plan.
@@ -348,6 +376,13 @@ export async function runPreflight({
     thresholds,
     baseSha,
     cacheWritten,
+    // Issue #4483 — verified remote evidence. `remoteVerified: false`
+    // REQUIRES the workflow to block explicitly (never build inline).
+    remoteVerified: remote.remoteVerified,
+    remoteProbe: {
+      remoteUrl: remote.remoteUrl,
+      detail: remote.detail,
+    },
   };
 
   if (post && !dryRun) {
@@ -356,6 +391,7 @@ export async function runPreflight({
       estimate,
       breaches,
       thresholds,
+      remote,
     });
     await upsertStructuredComment(provider, epicId, 'delivery-preflight', body);
     envelope.commentUpserted = true;

--- a/.agents/scripts/lib/orchestration/lifecycle/listeners/finalizer.js
+++ b/.agents/scripts/lib/orchestration/lifecycle/listeners/finalizer.js
@@ -82,6 +82,7 @@ import {
   openOrLocatePr as defaultOpenOrLocatePr,
 } from '../../finalize/open-or-locate-pr.js';
 import { postHandoffComment as defaultPostHandoffComment } from '../../finalize/post-handoff-comment.js';
+import { probeRemoteBranch as defaultProbeRemoteBranch } from '../../remote-verifier.js';
 
 /**
  * Build the production default `runFinalizeFn` that composes the
@@ -103,12 +104,22 @@ import { postHandoffComment as defaultPostHandoffComment } from '../../finalize/
  * contract is identical and `markPrReady` is a no-op on an already-ready
  * PR, so replay stays idempotent.
  *
+ * Issue #4483 — deterministic land-or-block backstop. Before opening (or
+ * readying) the PR, finalize asserts the delivery branch `epic/<id>`
+ * actually exists on origin. A delivery that was never pushed — e.g. an
+ * agent that built the Epic inline on local `main` and skipped the
+ * orchestration — MUST surface as an explicit
+ * `delivery-branch-missing-on-origin` blocker (which keeps the Epic at
+ * `agent::blocked`), never a declared success. The probe is bounded
+ * (timeout + SIGKILL) so a hung remote degrades to a blocker too.
+ *
  * @param {{
  *   provider?: object|null,
  *   earlyPr?: boolean,
  *   openOrLocatePrFn?: typeof defaultOpenOrLocatePr,
  *   markPrReadyFn?: typeof defaultMarkPrReady,
  *   postHandoffCommentFn?: typeof defaultPostHandoffComment,
+ *   probeRemoteBranchFn?: typeof defaultProbeRemoteBranch,
  * }} deps
  */
 export function composeBusOwnedFinalize(deps = {}) {
@@ -116,6 +127,8 @@ export function composeBusOwnedFinalize(deps = {}) {
   const markPrReadyFn = deps.markPrReadyFn ?? defaultMarkPrReady;
   const postHandoffCommentFn =
     deps.postHandoffCommentFn ?? defaultPostHandoffComment;
+  const probeRemoteBranchFn =
+    deps.probeRemoteBranchFn ?? defaultProbeRemoteBranch;
   const provider = deps.provider ?? null;
   const earlyPr = deps.earlyPr !== false;
 
@@ -128,6 +141,25 @@ export function composeBusOwnedFinalize(deps = {}) {
         },
       };
     }
+
+    // Issue #4483 backstop — the delivery branch MUST be on origin before
+    // finalize declares any success. A never-pushed branch is the silent
+    // local-main failure shape; block explicitly with the probe detail.
+    let branchProbe;
+    try {
+      branchProbe = probeRemoteBranchFn({ branch: `epic/${epicId}`, cwd });
+    } catch (err) {
+      branchProbe = { exists: false, detail: err?.message ?? String(err) };
+    }
+    if (!branchProbe.exists) {
+      return {
+        blocker: {
+          reason: 'delivery-branch-missing-on-origin',
+          detail: `epic/${epicId} is not on origin — the delivery was never pushed; refusing to finalize (issue #4483). Probe: ${branchProbe.detail}`,
+        },
+      };
+    }
+
     let openResult;
     try {
       openResult = await openOrLocatePrFn({

--- a/.agents/scripts/lib/orchestration/remote-verifier.js
+++ b/.agents/scripts/lib/orchestration/remote-verifier.js
@@ -1,0 +1,165 @@
+// .agents/scripts/lib/orchestration/remote-verifier.js
+/**
+ * remote-verifier.js — deterministic "is there a live, pushable remote?"
+ * evidence for the delivery entry seams. Issue #4483.
+ *
+ * `/deliver` could silently shortcut the entire orchestration — building
+ * the delivery inline and committing to local `main` without pushing —
+ * when the driving agent *perceived* the environment had no live GitHub
+ * remote. The judgment was vibes, not fact. This module gives the entry
+ * seams (`epic-deliver-preflight.js`, `single-story-init.js`) a verified
+ * probe result to record in their envelopes so the workflow can branch on
+ * `remoteVerified: true|false` deterministically: use the remote, or
+ * transition to `agent::blocked` quoting the probe output — never a
+ * silent local build.
+ *
+ * Two probes, both bounded (a hung git spawn must not park the entry
+ * seam — mirrors the `ghPrListHead` timeout contract in `finalizer.js`):
+ *
+ *   1. `git remote get-url origin`  — is an `origin` remote configured?
+ *   2. `git ls-remote origin HEAD`  — is it reachable with current auth?
+ *
+ * `remoteVerified` is true only when BOTH succeed. The CLI callers do
+ * NOT flip labels on a false result — the workflow owns the
+ * `agent::blocked` transition (same division of labour as the preflight
+ * breach handling).
+ */
+
+import { spawnSync } from 'node:child_process';
+
+/**
+ * Bounded timeout for each git probe. `ls-remote` is a network call;
+ * SIGKILL at the bound so an unreachable or hanging remote degrades to a
+ * deterministic `remoteVerified: false` instead of a stuck entry seam.
+ */
+export const REMOTE_PROBE_TIMEOUT_MS = 30_000;
+
+function runProbe({ args, cwd, spawnFn, timeoutMs }) {
+  const result = spawnFn('git', args, {
+    cwd,
+    encoding: 'utf-8',
+    shell: false,
+    timeout: timeoutMs,
+    killSignal: 'SIGKILL',
+  });
+  return {
+    args: ['git', ...args].join(' '),
+    status: result.status ?? 1,
+    stdout: (result.stdout ?? '').trim(),
+    stderr: (result.stderr ?? '').trim(),
+  };
+}
+
+/**
+ * Probe the `origin` remote for existence + reachability.
+ *
+ * @param {{
+ *   cwd?: string,
+ *   spawnFn?: typeof spawnSync,
+ *   timeoutMs?: number,
+ * }} [opts]
+ * @returns {{
+ *   remoteVerified: boolean,
+ *   remoteUrl: string|null,
+ *   detail: string,
+ *   probes: {
+ *     getUrl: { args: string, status: number, stdout: string, stderr: string },
+ *     lsRemote: { args: string, status: number, stdout: string, stderr: string }|null,
+ *   },
+ * }}
+ */
+export function verifyRemote({
+  cwd = process.cwd(),
+  spawnFn = spawnSync,
+  timeoutMs = REMOTE_PROBE_TIMEOUT_MS,
+} = {}) {
+  const getUrl = runProbe({
+    args: ['remote', 'get-url', 'origin'],
+    cwd,
+    spawnFn,
+    timeoutMs,
+  });
+  if (getUrl.status !== 0) {
+    return {
+      remoteVerified: false,
+      remoteUrl: null,
+      detail: `no 'origin' remote configured — \`${getUrl.args}\` exited ${getUrl.status}: ${getUrl.stderr || '(no stderr)'}`,
+      probes: { getUrl, lsRemote: null },
+    };
+  }
+  const remoteUrl = getUrl.stdout;
+
+  const lsRemote = runProbe({
+    args: ['ls-remote', 'origin', 'HEAD'],
+    cwd,
+    spawnFn,
+    timeoutMs,
+  });
+  if (lsRemote.status !== 0 || lsRemote.stdout.length === 0) {
+    return {
+      remoteVerified: false,
+      remoteUrl,
+      detail: `'origin' (${remoteUrl}) is unreachable — \`${lsRemote.args}\` exited ${lsRemote.status}: ${lsRemote.stderr || '(empty ls-remote output)'}`,
+      probes: { getUrl, lsRemote },
+    };
+  }
+
+  return {
+    remoteVerified: true,
+    remoteUrl,
+    detail: `origin verified (${remoteUrl}); ls-remote HEAD → ${lsRemote.stdout.split(/\s+/)[0]}`,
+    probes: { getUrl, lsRemote },
+  };
+}
+
+/**
+ * Probe whether a specific branch exists on `origin` — the deterministic
+ * finalize backstop (issue #4483 fix direction 3): a delivery branch that
+ * was never pushed MUST fail finalize with an explicit blocker rather
+ * than let the run declare success.
+ *
+ * Distinct from `git-branch-lifecycle.js#branchExistsRemotely` in two
+ * load-bearing ways: the spawn is bounded (timeout + SIGKILL, so a hung
+ * remote cannot park the finalize seam) and the result carries the probe
+ * detail for the blocker envelope instead of a bare boolean.
+ *
+ * @param {{
+ *   branch: string,
+ *   cwd?: string,
+ *   spawnFn?: typeof spawnSync,
+ *   timeoutMs?: number,
+ * }} opts
+ * @returns {{ exists: boolean, detail: string }}
+ */
+export function probeRemoteBranch({
+  branch,
+  cwd = process.cwd(),
+  spawnFn = spawnSync,
+  timeoutMs = REMOTE_PROBE_TIMEOUT_MS,
+}) {
+  if (typeof branch !== 'string' || branch.length === 0) {
+    throw new TypeError('probeRemoteBranch: branch must be a non-empty string');
+  }
+  const probe = runProbe({
+    args: ['ls-remote', '--heads', 'origin', branch],
+    cwd,
+    spawnFn,
+    timeoutMs,
+  });
+  if (probe.status !== 0) {
+    return {
+      exists: false,
+      detail: `\`${probe.args}\` exited ${probe.status}: ${probe.stderr || '(no stderr)'}`,
+    };
+  }
+  if (probe.stdout.length === 0) {
+    return {
+      exists: false,
+      detail: `\`${probe.args}\` found no ref — ${branch} was never pushed to origin`,
+    };
+  }
+  return {
+    exists: true,
+    detail: `${branch} on origin at ${probe.stdout.split(/\s+/)[0]}`,
+  };
+}

--- a/.agents/scripts/lib/orchestration/single-story-close/phases/push.js
+++ b/.agents/scripts/lib/orchestration/single-story-close/phases/push.js
@@ -5,6 +5,16 @@
  * subsequent fetches are cheap. A push failure raises so the caller
  * fails non-zero — the operator must resolve before retrying.
  *
+ * Issue #4483 — this phase IS the standalone path's deterministic
+ * land-or-block backstop (the counterpart to the Epic finalize seam's
+ * `delivery-branch-missing-on-origin` blocker). `git push` exits 0 only
+ * after origin has accepted the ref, so the throw below is the origin
+ * assertion: every later close phase (PR open, auto-merge, the
+ * `closeResult` success envelope) is unreachable unless the Story branch
+ * verifiably landed on origin. No post-push `ls-remote` re-probe is
+ * added because it would re-ask a question the push exit code already
+ * answered authoritatively.
+ *
  * `gitSync` is accepted as an injected dependency rather than statically
  * imported so the caller's (cache-busted) binding wins. The
  * `single-story-close.js` orchestrator owns the static import; test

--- a/.agents/scripts/single-story-init.js
+++ b/.agents/scripts/single-story-init.js
@@ -59,6 +59,7 @@ import {
   executeFastForward,
   planFastForward,
 } from './lib/orchestration/git-cleanup/phases/fast-forward.js';
+import { verifyRemote } from './lib/orchestration/remote-verifier.js';
 import { acquireStoryLease } from './lib/orchestration/single-story-lease-guard.js';
 import {
   STATE_LABELS,
@@ -446,6 +447,7 @@ export async function runSingleStoryInit({
   injectedAcquireLease,
   steal = false,
   leaseNow,
+  injectedVerifyRemote,
 } = {}) {
   const parsed =
     storyIdParam !== undefined
@@ -486,6 +488,20 @@ export async function runSingleStoryInit({
     `worktreeIsolation=${runtime.worktreeEnabled ? 'on' : 'off'} (${runtime.worktreeEnabledSource})`,
   );
   progress('INIT', `Initializing standalone Story #${storyId}...`);
+
+  // Issue #4483 — deterministic remote evidence at the standalone entry
+  // seam (the counterpart to `epic-deliver-preflight.js`'s probe). The
+  // probe is read-only, so it runs under --dry-run too. The CLI records
+  // the fact; the workflow owns the `agent::blocked` transition on
+  // `remoteVerified: false` — inline delivery to local `main` is never a
+  // sanctioned fallback.
+  const remote = (injectedVerifyRemote ?? verifyRemote)({ cwd });
+  progress(
+    'REMOTE',
+    remote.remoteVerified
+      ? `✅ remoteVerified=true — ${remote.detail}`
+      : `⛔ remoteVerified=false — ${remote.detail}`,
+  );
 
   const story = await provider.getTicket(storyId);
   assertDeliverableStory(story, storyId);
@@ -563,6 +579,9 @@ export async function runSingleStoryInit({
     dependenciesInstalled,
     installFailed: installStatus.status === 'failed',
     dryRun,
+    // Issue #4483 — verified remote evidence for the orchestrating agent.
+    remoteVerified: remote.remoteVerified,
+    remoteProbe: { remoteUrl: remote.remoteUrl, detail: remote.detail },
   };
 
   // Upsert the `story-init` structured comment + flip Story to executing.
@@ -632,6 +651,8 @@ export function renderSingleStoryInitComment(result) {
     worktreeCreated: result.worktreeCreated,
     dependenciesInstalled: result.dependenciesInstalled,
     installStatus: result.installStatus,
+    remoteVerified: result.remoteVerified,
+    remoteProbe: result.remoteProbe,
   };
   return [
     '## Story init (standalone)',
@@ -641,6 +662,7 @@ export function renderSingleStoryInitComment(result) {
     `- **baseBranch:** \`${result.baseBranch}\``,
     `- **workCwd:** \`${result.workCwd}\``,
     `- **worktreeEnabled:** \`${result.worktreeEnabled}\``,
+    `- **remoteVerified:** \`${result.remoteVerified}\``,
     `- **dependenciesInstalled:** \`${result.dependenciesInstalled}\``,
     '',
     '```json',

--- a/.agents/workflows/deliver.md
+++ b/.agents/workflows/deliver.md
@@ -131,6 +131,14 @@ the standalone segment; segments themselves remain strictly sequential.
 
 ## Constraints
 
+- **Land or block — never a silent local build (issue #4483).** The
+  helpers' orchestration path (worktrees, `story-<id>`/`epic/<id>` branches,
+  close-validation, PR) is the ONLY sanctioned delivery mechanism.
+  Executing story slices inline in this session and/or committing the
+  delivery to local `main` is expressly forbidden, regardless of how the
+  environment looks. Each path surfaces verified remote evidence
+  (`remoteVerified`) at entry; on `false`, transition the ticket to
+  `agent::blocked` quoting `remoteProbe.detail` and halt.
 - `/deliver` requires planned tickets: Epics at `agent::ready` (the
   Epic helper's preflight enforces this, per segment) or well-formed
   standalone Stories. Planning happens in [`/plan`](plan.md); the

--- a/.agents/workflows/helpers/deliver-epic.md
+++ b/.agents/workflows/helpers/deliver-epic.md
@@ -181,6 +181,17 @@ Threshold defaults live in `delivery.preflight.*` in `.agentrc.json`
 (all keys default to "no cap" — the gate is opt-in until an operator
 configures `maxStories` etc.).
 
+**Remote evidence — land or block (issue #4483).** The envelope also
+carries `remoteVerified` + `remoteProbe` (deterministic probes:
+`git remote get-url origin`, bounded `git ls-remote origin HEAD`). When
+`remoteVerified` is `false`, flip the Epic to `agent::blocked`, post a
+friction comment quoting `remoteProbe.detail`, and halt — the same
+explicit-block shape as #4425/#4480. NEVER fall back to executing Stories
+inline in this session or committing the delivery to local `main`; the
+worktree/branch/PR path below is the only sanctioned mechanism. Phase 7's
+finalize additionally refuses with a `delivery-branch-missing-on-origin`
+blocker when `epic/<epicId>` never reached origin.
+
 ### Phase 1 main — Seed the wave plan
 
 ```bash

--- a/.agents/workflows/helpers/single-story-deliver.md
+++ b/.agents/workflows/helpers/single-story-deliver.md
@@ -97,6 +97,14 @@ Capture `workCwd` from the result envelope. Add `--dry-run` to inspect
 the planned actions without git or ticket mutations (dry-run also skips
 the lease and the sweep).
 
+**Remote evidence — land or block (issue #4483).** The envelope also
+carries `remoteVerified` + `remoteProbe` (`git remote get-url origin` +
+bounded `git ls-remote origin HEAD`). When `remoteVerified` is `false`,
+transition the Story to `agent::blocked` quoting `remoteProbe.detail` and
+stop. Implementing the Story inline outside the worktree/branch/PR path
+and/or committing it to local `main` is expressly forbidden — the close
+pipeline's push is the only sanctioned landing.
+
 ### Step 0.5 — `cd` into the workCwd
 
 ```bash

--- a/tests/contract/delivery/preflight-estimate.test.js
+++ b/tests/contract/delivery/preflight-estimate.test.js
@@ -158,6 +158,41 @@ describe('contract/delivery/preflight-estimate', () => {
       assert.match(body, /storyCount/);
       assert.match(body, /Threshold breaches/);
     });
+
+    it('renders the remote-evidence line (issue #4483)', () => {
+      const e = computeEstimate({ storyCount: 1, dependencyDepth: 1 });
+      const t = {
+        maxStories: null,
+        maxWaves: null,
+        maxInstallCostSeconds: null,
+        maxGithubApiRequests: null,
+        maxClaudeQuotaTokens: null,
+      };
+      const verified = renderPreflightBody({
+        epicId: 1,
+        estimate: e,
+        breaches: [],
+        thresholds: t,
+        remote: {
+          remoteVerified: true,
+          detail: 'origin verified (https://github.com/o/r.git)',
+        },
+      });
+      assert.match(verified, /remoteVerified: true/);
+      const unverified = renderPreflightBody({
+        epicId: 1,
+        estimate: e,
+        breaches: [],
+        thresholds: t,
+        remote: {
+          remoteVerified: false,
+          detail: "no 'origin' remote configured",
+        },
+      });
+      assert.match(unverified, /remoteVerified: false/);
+      assert.match(unverified, /agent::blocked/);
+      assert.match(unverified, /inline delivery to local `main` is forbidden/);
+    });
   });
 
   describe('runPreflight (programmatic)', () => {
@@ -175,6 +210,11 @@ describe('contract/delivery/preflight-estimate', () => {
         dryRun: true,
         injectedProvider: provider,
         injectedConfig: FAKE_CONFIG,
+        verifyRemoteFn: () => ({
+          remoteVerified: true,
+          remoteUrl: 'https://github.com/o/r.git',
+          detail: 'origin verified (stub)',
+        }),
       });
       // AC1 — envelope carries the five canonical keys.
       assert.equal(envelope.storyCount, 4);
@@ -184,8 +224,47 @@ describe('contract/delivery/preflight-estimate', () => {
       assert.equal(typeof envelope.claudeQuotaTokens, 'number');
       assert.deepEqual(envelope.breaches, []);
       assert.equal(envelope.commentUpserted, false);
+      // Issue #4483 — the envelope carries the verified remote evidence.
+      assert.equal(envelope.remoteVerified, true);
+      assert.equal(
+        envelope.remoteProbe.remoteUrl,
+        'https://github.com/o/r.git',
+      );
+      assert.match(envelope.remoteProbe.detail, /origin verified/);
       // Dry-run MUST NOT write a comment.
       assert.equal(provider._comments.size, 0);
+    });
+
+    it('records remoteVerified: false in the envelope and comment (issue #4483)', async () => {
+      const stories = [401].map((id) => ({
+        id,
+        number: id,
+        labels: ['type::story'],
+        body: '',
+        title: `Story #${id}`,
+      }));
+      const provider = buildFakeProvider({ epicId: 88, stories });
+      const envelope = await runPreflight({
+        epicId: 88,
+        dryRun: false,
+        post: true,
+        injectedProvider: provider,
+        injectedConfig: FAKE_CONFIG,
+        verifyRemoteFn: () => ({
+          remoteVerified: false,
+          remoteUrl: null,
+          detail:
+            "no 'origin' remote configured — `git remote get-url origin` exited 2",
+        }),
+      });
+      assert.equal(envelope.remoteVerified, false);
+      assert.equal(envelope.remoteProbe.remoteUrl, null);
+      assert.match(envelope.remoteProbe.detail, /no 'origin' remote/);
+      // The posted comment quotes the probe so a reviewer sees the
+      // land-or-block fact on the ticket.
+      const comment = Array.from(provider._comments.values())[0];
+      assert.match(comment.body, /remoteVerified: false/);
+      assert.match(comment.body, /agent::blocked/);
     });
 
     it('upserts a delivery-preflight comment on --post', async () => {
@@ -205,6 +284,11 @@ describe('contract/delivery/preflight-estimate', () => {
         post: true,
         injectedProvider: provider,
         injectedConfig: FAKE_CONFIG,
+        verifyRemoteFn: () => ({
+          remoteVerified: true,
+          remoteUrl: 'https://github.com/o/r.git',
+          detail: 'origin verified (stub)',
+        }),
       });
       assert.equal(first.commentUpserted, true);
       assert.equal(provider._comments.size, 1);
@@ -220,6 +304,11 @@ describe('contract/delivery/preflight-estimate', () => {
         post: true,
         injectedProvider: provider,
         injectedConfig: FAKE_CONFIG,
+        verifyRemoteFn: () => ({
+          remoteVerified: true,
+          remoteUrl: 'https://github.com/o/r.git',
+          detail: 'origin verified (stub)',
+        }),
       });
       assert.equal(provider._comments.size, 1);
     });
@@ -237,6 +326,11 @@ describe('contract/delivery/preflight-estimate', () => {
         epicId: 55,
         injectedProvider: provider,
         injectedConfig: FAKE_CONFIG,
+        verifyRemoteFn: () => ({
+          remoteVerified: true,
+          remoteUrl: 'https://github.com/o/r.git',
+          detail: 'origin verified (stub)',
+        }),
       });
       assert.equal(envelope.commentUpserted, false);
       assert.equal(provider._comments.size, 0);

--- a/tests/contract/finalize/finalizer-bus-owned.test.js
+++ b/tests/contract/finalize/finalizer-bus-owned.test.js
@@ -63,6 +63,7 @@ describe('composeBusOwnedFinalize', () => {
   it('invokes openOrLocatePr → markPrReady (earlyPr on) → postHandoffComment in order', async () => {
     const calls = [];
     const run = composeBusOwnedFinalize({
+      probeRemoteBranchFn: () => ({ exists: true, detail: 'stub' }),
       provider: { sentinel: true },
       // Default earlyPr (on): the wave-1 draft is located then marked ready.
       openOrLocatePrFn: async (args) => {
@@ -110,6 +111,7 @@ describe('composeBusOwnedFinalize', () => {
 
   it('routes openOrLocatePr failure to a blocker envelope', async () => {
     const run = composeBusOwnedFinalize({
+      probeRemoteBranchFn: () => ({ exists: true, detail: 'stub' }),
       provider: { sentinel: true },
       openOrLocatePrFn: async () => {
         throw new Error('branch behind base');
@@ -126,6 +128,7 @@ describe('composeBusOwnedFinalize', () => {
 
   it('treats handoff-comment failures as non-blocking', async () => {
     const run = composeBusOwnedFinalize({
+      probeRemoteBranchFn: () => ({ exists: true, detail: 'stub' }),
       provider: { sentinel: true },
       openOrLocatePrFn: async () => ({
         prNumber: 1,
@@ -145,6 +148,7 @@ describe('composeBusOwnedFinalize', () => {
 
   it('skips the handoff comment when provider is absent', async () => {
     const run = composeBusOwnedFinalize({
+      probeRemoteBranchFn: () => ({ exists: true, detail: 'stub' }),
       provider: null,
       openOrLocatePrFn: async () => ({
         prNumber: 5,
@@ -167,6 +171,7 @@ describe('composeBusOwnedFinalize', () => {
   it('skips markPrReady when earlyPr is off (Story #4359)', async () => {
     const calls = [];
     const run = composeBusOwnedFinalize({
+      probeRemoteBranchFn: () => ({ exists: true, detail: 'stub' }),
       provider: null,
       earlyPr: false,
       openOrLocatePrFn: async () => {
@@ -189,8 +194,56 @@ describe('composeBusOwnedFinalize', () => {
     assert.equal(result.prNumber, 7);
   });
 
+  it('blocks with delivery-branch-missing-on-origin when epic/<id> is not on origin (issue #4483)', async () => {
+    const calls = [];
+    const run = composeBusOwnedFinalize({
+      provider: { sentinel: true },
+      probeRemoteBranchFn: ({ branch, cwd }) => {
+        calls.push({ step: 'probeRemoteBranch', branch, cwd });
+        return {
+          exists: false,
+          detail: 'ls-remote found no ref — never pushed',
+        };
+      },
+      openOrLocatePrFn: async () => {
+        calls.push({ step: 'openOrLocatePr' });
+        throw new Error('must not be called when the branch is not on origin');
+      },
+      postHandoffCommentFn: async () => {
+        throw new Error('must not be called');
+      },
+    });
+    const result = await run({ epicId: 4483, cwd: '/tmp' });
+    // The probe runs FIRST — the land-or-block decision precedes any PR
+    // side effect — and names the delivery branch.
+    assert.deepEqual(
+      calls.map((c) => c.step),
+      ['probeRemoteBranch'],
+    );
+    assert.equal(calls[0].branch, 'epic/4483');
+    assert.equal(result?.blocker?.reason, 'delivery-branch-missing-on-origin');
+    assert.match(result.blocker.detail, /never pushed/);
+    assert.match(result.blocker.detail, /epic\/4483/);
+  });
+
+  it('routes a probeRemoteBranch throw to the same blocker (fail closed, issue #4483)', async () => {
+    const run = composeBusOwnedFinalize({
+      provider: null,
+      probeRemoteBranchFn: () => {
+        throw new Error('ls-remote timed out');
+      },
+      openOrLocatePrFn: async () => {
+        throw new Error('must not be called');
+      },
+    });
+    const result = await run({ epicId: 1, cwd: '/tmp' });
+    assert.equal(result?.blocker?.reason, 'delivery-branch-missing-on-origin');
+    assert.match(result.blocker.detail, /ls-remote timed out/);
+  });
+
   it('routes a markPrReady failure to a blocker envelope (earlyPr on)', async () => {
     const run = composeBusOwnedFinalize({
+      probeRemoteBranchFn: () => ({ exists: true, detail: 'stub' }),
       provider: null,
       openOrLocatePrFn: async () => ({
         prNumber: 8,
@@ -218,6 +271,7 @@ describe('Finalizer with the bus-owned default', () => {
       // Stub the probe so we go through the create path.
       ghPrListHeadFn: () => ({ status: 0, stdout: '', stderr: '' }),
       runFinalizeFn: composeBusOwnedFinalize({
+        probeRemoteBranchFn: () => ({ exists: true, detail: 'stub' }),
         provider: { sentinel: true },
         openOrLocatePrFn: async () => ({
           prNumber: 99,

--- a/tests/epic-deliver-preflight-cache.test.js
+++ b/tests/epic-deliver-preflight-cache.test.js
@@ -83,6 +83,11 @@ describe('epic-deliver-preflight cache write', () => {
     const provider = buildFakeProvider({ epicId: 4242, stories });
 
     const envelope = await runPreflight({
+      verifyRemoteFn: () => ({
+        remoteVerified: true,
+        remoteUrl: 'https://github.com/o/r.git',
+        detail: 'origin verified (stub)',
+      }),
       epicId: 4242,
       cwd: workCwd,
       injectedProvider: provider,
@@ -119,6 +124,11 @@ describe('epic-deliver-preflight cache write', () => {
     const provider = buildFakeProvider({ epicId: 7777, stories });
 
     const envelope = await runPreflight({
+      verifyRemoteFn: () => ({
+        remoteVerified: true,
+        remoteUrl: 'https://github.com/o/r.git',
+        detail: 'origin verified (stub)',
+      }),
       epicId: 7777,
       cwd: workCwd,
       injectedProvider: provider,
@@ -149,6 +159,11 @@ describe('epic-deliver-preflight cache write', () => {
     const provider = buildFakeProvider({ epicId: 5151, stories });
 
     const envelope = await runPreflight({
+      verifyRemoteFn: () => ({
+        remoteVerified: true,
+        remoteUrl: 'https://github.com/o/r.git',
+        detail: 'origin verified (stub)',
+      }),
       epicId: 5151,
       cwd: workCwd,
       dryRun: true,

--- a/tests/lib/orchestration/remote-verifier.test.js
+++ b/tests/lib/orchestration/remote-verifier.test.js
@@ -1,0 +1,168 @@
+/**
+ * tests/lib/orchestration/remote-verifier.test.js — issue #4483.
+ *
+ * Unit tests for the deterministic remote-evidence probes that back the
+ * `/deliver` land-or-block entry contract:
+ *
+ *   - `verifyRemote` — `git remote get-url origin` + bounded
+ *     `git ls-remote origin HEAD`; `remoteVerified` is true only when
+ *     BOTH succeed.
+ *   - `probeRemoteBranch` — the finalize backstop's "is the delivery
+ *     branch actually on origin?" probe.
+ *
+ * The git boundary is injected (`spawnFn`) so no test touches a real
+ * remote, mirroring how the finalizer's `ghPrListHead` probe is stubbed.
+ */
+
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'node:test';
+
+import {
+  probeRemoteBranch,
+  REMOTE_PROBE_TIMEOUT_MS,
+  verifyRemote,
+} from '../../../.agents/scripts/lib/orchestration/remote-verifier.js';
+
+/**
+ * Build a spawnFn stub that dispatches on the git subcommand and records
+ * every invocation (args + options) for spawn-contract assertions.
+ */
+function makeSpawnStub(responses) {
+  const calls = [];
+  const spawnFn = (cmd, args, opts) => {
+    calls.push({ cmd, args, opts });
+    const key = args[0]; // 'remote' | 'ls-remote'
+    const res = responses[key] ?? { status: 1, stdout: '', stderr: 'no stub' };
+    return { status: res.status, stdout: res.stdout, stderr: res.stderr };
+  };
+  return { spawnFn, calls };
+}
+
+describe('verifyRemote', () => {
+  it('verifies when origin is configured and ls-remote answers', () => {
+    const { spawnFn, calls } = makeSpawnStub({
+      remote: {
+        status: 0,
+        stdout: 'https://github.com/o/r.git\n',
+        stderr: '',
+      },
+      'ls-remote': {
+        status: 0,
+        stdout: 'abc123\tHEAD\n',
+        stderr: '',
+      },
+    });
+    const result = verifyRemote({ cwd: '/tmp/repo', spawnFn });
+    assert.equal(result.remoteVerified, true);
+    assert.equal(result.remoteUrl, 'https://github.com/o/r.git');
+    assert.match(result.detail, /origin verified/);
+    assert.match(result.detail, /abc123/);
+    // Both probes ran, in order, bounded and shell-free.
+    assert.deepEqual(
+      calls.map((c) => c.args),
+      [
+        ['remote', 'get-url', 'origin'],
+        ['ls-remote', 'origin', 'HEAD'],
+      ],
+    );
+    for (const c of calls) {
+      assert.equal(c.cmd, 'git');
+      assert.equal(c.opts.shell, false);
+      assert.equal(c.opts.timeout, REMOTE_PROBE_TIMEOUT_MS);
+      assert.equal(c.opts.killSignal, 'SIGKILL');
+      assert.equal(c.opts.cwd, '/tmp/repo');
+    }
+  });
+
+  it('fails with no-origin detail (and skips ls-remote) when no origin is configured', () => {
+    const { spawnFn, calls } = makeSpawnStub({
+      remote: {
+        status: 2,
+        stdout: '',
+        stderr: "error: No such remote 'origin'",
+      },
+    });
+    const result = verifyRemote({ cwd: '/tmp/repo', spawnFn });
+    assert.equal(result.remoteVerified, false);
+    assert.equal(result.remoteUrl, null);
+    assert.match(result.detail, /no 'origin' remote configured/);
+    assert.match(result.detail, /No such remote/);
+    assert.equal(result.probes.lsRemote, null);
+    assert.equal(calls.length, 1);
+  });
+
+  it('fails with unreachable detail when ls-remote exits non-zero', () => {
+    const { spawnFn } = makeSpawnStub({
+      remote: { status: 0, stdout: 'git@github.com:o/r.git\n', stderr: '' },
+      'ls-remote': { status: 128, stdout: '', stderr: 'fatal: could not read' },
+    });
+    const result = verifyRemote({ cwd: '/x', spawnFn });
+    assert.equal(result.remoteVerified, false);
+    assert.equal(result.remoteUrl, 'git@github.com:o/r.git');
+    assert.match(result.detail, /unreachable/);
+    assert.match(result.detail, /could not read/);
+  });
+
+  it('fails when ls-remote succeeds but returns no output (killed at the timeout bound)', () => {
+    // spawnSync reports a SIGKILLed child as status null → normalized 1,
+    // but even a status-0 empty answer must not verify.
+    const { spawnFn } = makeSpawnStub({
+      remote: { status: 0, stdout: 'https://github.com/o/r.git', stderr: '' },
+      'ls-remote': { status: 0, stdout: '', stderr: '' },
+    });
+    const result = verifyRemote({ cwd: '/x', spawnFn });
+    assert.equal(result.remoteVerified, false);
+    assert.match(result.detail, /empty ls-remote output/);
+  });
+});
+
+describe('probeRemoteBranch', () => {
+  it('reports exists with the remote SHA when the ref is on origin', () => {
+    const { spawnFn, calls } = makeSpawnStub({
+      'ls-remote': {
+        status: 0,
+        stdout: 'def456\trefs/heads/epic/7\n',
+        stderr: '',
+      },
+    });
+    const result = probeRemoteBranch({
+      branch: 'epic/7',
+      cwd: '/tmp/repo',
+      spawnFn,
+    });
+    assert.equal(result.exists, true);
+    assert.match(result.detail, /def456/);
+    assert.deepEqual(calls[0].args, [
+      'ls-remote',
+      '--heads',
+      'origin',
+      'epic/7',
+    ]);
+    assert.equal(calls[0].opts.timeout, REMOTE_PROBE_TIMEOUT_MS);
+  });
+
+  it('reports never-pushed when ls-remote answers with no ref', () => {
+    const { spawnFn } = makeSpawnStub({
+      'ls-remote': { status: 0, stdout: '', stderr: '' },
+    });
+    const result = probeRemoteBranch({ branch: 'epic/7', cwd: '/x', spawnFn });
+    assert.equal(result.exists, false);
+    assert.match(result.detail, /never pushed/);
+  });
+
+  it('reports the probe failure detail when ls-remote exits non-zero', () => {
+    const { spawnFn } = makeSpawnStub({
+      'ls-remote': { status: 128, stdout: '', stderr: 'fatal: no remote' },
+    });
+    const result = probeRemoteBranch({ branch: 'epic/7', cwd: '/x', spawnFn });
+    assert.equal(result.exists, false);
+    assert.match(result.detail, /fatal: no remote/);
+  });
+
+  it('rejects an empty branch', () => {
+    assert.throws(
+      () => probeRemoteBranch({ branch: '', cwd: '/x' }),
+      /non-empty string/,
+    );
+  });
+});


### PR DESCRIPTION
## Root cause

`/deliver` could silently shortcut the entire orchestration — executing the epic's story slices inline in the parent session and committing to **local `main` without pushing** — when the driving agent *perceived* the environment had no live GitHub remote (mandrel-bench Gate G0, 2026-07-12: the sandbox had a configured, pushable `origin`; the judgment was wrong). Nothing in the framework gave the agent verified fact about the remote at the entry decision, nothing in the workflow prose forbade the inline fallback, and nothing deterministic asserted the delivery ever reached origin before success was declared. Same silent-non-landing anti-pattern #4472/#4480 fixed at merge time, resurfacing at orchestration entry.

## The three mechanisms

1. **Deterministic remote evidence at entry** — new shared probe module `.agents/scripts/lib/orchestration/remote-verifier.js` (`verifyRemote`: `git remote get-url origin` + bounded 30s SIGKILL `git ls-remote origin HEAD`; verified only when both succeed). Wired into:
   - `epic-deliver-preflight.js` — the envelope (and the upserted `delivery-preflight` comment) now carries `remoteVerified: true|false` + `remoteProbe { remoteUrl, detail }`.
   - `single-story-init.js` (the standalone path's entry seam) — same fields on the init result envelope and the `story-init` structured comment, plus a `REMOTE` progress line.
   - The CLIs record fact; the workflow owns the `agent::blocked` transition (same split as the existing preflight breach handling).

2. **Contract prohibition** in the workflow prose (kept tight per the workflow-byte diet; context-budget ratchet stays green):
   - `deliver.md` — new leading Constraint: orchestration path is the ONLY sanctioned delivery mechanism; inline execution / committing the delivery to local `main` is expressly forbidden; `remoteVerified: false` → `agent::blocked` quoting `remoteProbe.detail`.
   - `helpers/deliver-epic.md` — Phase 1 prelude "Remote evidence — land or block" block (mirrors the #4425/#4480 explicit-block shape), anchored where the agent reads the preflight envelope.
   - `helpers/single-story-deliver.md` — same block at Step 0 where the init envelope is read.

3. **Deterministic backstop at the terminal success seam**:
   - Epic path: `composeBusOwnedFinalize` (`lifecycle/listeners/finalizer.js`) now asserts `epic/<id>` exists on origin (bounded `probeRemoteBranch`) **before** any PR open/ready side effect; a never-pushed branch returns a `delivery-branch-missing-on-origin` blocker (Epic stays blocked; `pr.created`/`epic.finalize.end`/`epic.complete` unreachable). A probe throw fails closed to the same blocker.
   - Standalone path: `single-story-close` phase 3 (`phases/push.js`) is the existing seam — `git push` exits 0 only after origin accepted the ref, and every later close phase (PR, auto-merge, success envelope) is unreachable without it. Documented at the seam rather than adding a redundant post-push `ls-remote` re-probe.

## Test evidence

- New `tests/lib/orchestration/remote-verifier.test.js` — 8 tests (injected git runner; verifies probe order, bounded/shell-free spawn contract, no-origin / unreachable / empty-answer failure shapes).
- `tests/contract/finalize/finalizer-bus-owned.test.js` — 2 new tests (probe-first ordering + missing-branch blocker; fail-closed on probe throw); existing tests inject a passing probe stub.
- `tests/contract/delivery/preflight-estimate.test.js` — envelope + comment assertions for `remoteVerified` true/false; new remote-evidence render test.
- Full suite: **10113 tests, 10109 pass, 0 fail, 4 skipped** (`npm test`); `npm run lint` (incl. docs drift checks + markdownlint) → 0 errors; `check-baselines` / `check-arch-cycles` / `check-dead-exports` / `check-context-budget` all green; `npm run test:coverage` green.
- Live smoke: `verifyRemote` against this repo returns `remoteVerified: true` with the origin URL + HEAD SHA; `probeRemoteBranch('main')` returns the remote SHA.

Closes #4483

🤖 Generated with [Claude Code](https://claude.com/claude-code)
