### PR TITLE
feat(plan): plan-metrics ledger — measure turns-per-plan before the collapse (refs #4474)

### DIFF
--- a/.agents/scripts/analyze-execution.js
+++ b/.agents/scripts/analyze-execution.js
@@ -72,6 +72,11 @@ import {
   renderStoryBody,
   STORY_PERF_TYPE,
 } from './lib/observability/perf-report-render.js';
+import {
+  readPlanMetrics,
+  renderPlanMetricsSummaryLine,
+  summarizePlanMetrics,
+} from './lib/orchestration/plan-metrics.js';
 import { upsertStructuredComment } from './lib/orchestration/ticketing.js';
 import { createProvider } from './lib/provider-factory.js';
 
@@ -284,11 +289,34 @@ export async function runEpicMode(ctx) {
   logger.info?.(
     `[analyze-execution] epic-perf-report upserted on Epic #${epicId} (commentId=${result.commentId}, stories=${summaries.length})`,
   );
+
+  // Plan-metrics roll-up (#4474 PR1) — surface the plan-CLI invocation
+  // ledger (`temp/epic-<id>/plan-metrics.json`) alongside the perf report.
+  // Additive and non-fatal: a missing or unreadable ledger yields `null`.
+  let planMetrics = null;
+  try {
+    planMetrics = summarizePlanMetrics(
+      await readPlanMetrics(epicId, ctx.config),
+    );
+    if (planMetrics) {
+      logger.info?.(
+        `[analyze-execution] ${renderPlanMetricsSummaryLine(planMetrics)}`,
+      );
+    }
+  } catch (err) {
+    logger.warn?.(
+      `[analyze-execution] plan-metrics read failed (non-fatal): ${
+        err instanceof Error ? err.message : String(err)
+      }`,
+    );
+  }
+
   return {
     commentId: result.commentId,
     payload,
     baselineRefreshRate,
     qualityGateFriction,
+    planMetrics,
   };
 }
 

--- a/.agents/scripts/epic-plan-clarity.js
+++ b/.agents/scripts/epic-plan-clarity.js
@@ -34,6 +34,7 @@ import {
 } from './lib/config-resolver.js';
 import { scoreEpicBody } from './lib/epic-plan-clarity.js';
 import { Logger, routeAllOutputToStderr } from './lib/Logger.js';
+import { recordPlanInvocation } from './lib/orchestration/plan-metrics.js';
 import { upsertStructuredComment } from './lib/orchestration/ticketing.js';
 import { createProvider } from './lib/provider-factory.js';
 
@@ -175,7 +176,11 @@ async function main() {
   // additions cannot silently corrupt the captured file.
   if (values['emit-context']) {
     routeAllOutputToStderr();
-    const envelope = await buildClarityContext({ epicId, provider });
+    // Plan-metrics ledger (#4474 PR1): stamp entry/exit + mode.
+    const envelope = await recordPlanInvocation(
+      { cli: 'epic-plan-clarity', mode: 'emit-context', epicId, config },
+      () => buildClarityContext({ epicId, provider }),
+    );
     const json = values.pretty
       ? JSON.stringify(envelope, null, 2)
       : JSON.stringify(envelope);
@@ -190,11 +195,16 @@ async function main() {
   }
 
   const updatedBody = await readFile(values['updated-body'], 'utf8');
-  const result = await persistClarityUpdate({
-    epicId,
-    updatedBody,
-    provider,
-  });
+  // Plan-metrics ledger (#4474 PR1): stamp entry/exit + mode.
+  const result = await recordPlanInvocation(
+    { cli: 'epic-plan-clarity', mode: 'persist', epicId, config },
+    () =>
+      persistClarityUpdate({
+        epicId,
+        updatedBody,
+        provider,
+      }),
+  );
   process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
 }
 

--- a/.agents/scripts/epic-plan-healthcheck.js
+++ b/.agents/scripts/epic-plan-healthcheck.js
@@ -47,6 +47,7 @@ import {
 import { gitSpawn } from './lib/git-utils.js';
 import { Logger } from './lib/Logger.js';
 import { TYPE_LABELS } from './lib/label-constants.js';
+import { recordPlanInvocation } from './lib/orchestration/plan-metrics.js';
 import { createProvider } from './lib/provider-factory.js';
 
 const progress = Logger.createProgress('plan-healthcheck', { stderr: true });
@@ -543,6 +544,31 @@ export async function runPlanHealthcheck(opts = {}) {
 // Main guard
 // ---------------------------------------------------------------------------
 
-runAsCli(import.meta.url, runPlanHealthcheck, {
+/**
+ * CLI wrapper: stamp the plan-metrics ledger (#4474 PR1) around the direct
+ * invocation only. In-process callers (the decompose persist gate imports
+ * `runPlanHealthcheck` directly) are already covered by their own CLI's
+ * stamp — wrapping here too would double-count the inline gate.
+ */
+async function cliMain() {
+  const { epicId } = parseHealthcheckArgs();
+  let config;
+  try {
+    config = resolveConfig();
+  } catch {
+    config = undefined;
+  }
+  return recordPlanInvocation(
+    {
+      cli: 'epic-plan-healthcheck',
+      mode: 'healthcheck',
+      epicId: epicId ?? null,
+      config,
+    },
+    () => runPlanHealthcheck(),
+  );
+}
+
+runAsCli(import.meta.url, cliMain, {
   source: 'epic-plan-healthcheck',
 });

--- a/.agents/scripts/epic-plan-spec.js
+++ b/.agents/scripts/epic-plan-spec.js
@@ -76,6 +76,7 @@ import {
 } from './lib/orchestration/epic-plan-spec/phases/risk-verdict.js';
 import { runSpecPhase } from './lib/orchestration/epic-plan-spec/phases/run-spec-phase.js';
 import { runSpecFreshnessCheck } from './lib/orchestration/epic-plan-spec/phases/spec-freshness.js';
+import { recordPlanInvocation } from './lib/orchestration/plan-metrics.js';
 import { resolveReviewRouting } from './lib/orchestration/plan-review-routing.js';
 import { createProvider } from './lib/provider-factory.js';
 
@@ -143,10 +144,16 @@ async function main() {
   }
 
   if (emitContext) {
-    const ctx = await buildAuthoringContext(epicId, provider, settings, {
-      fullContext: values['full-context'],
-      github: config.github ?? null,
-    });
+    // Plan-metrics ledger (#4474 PR1): stamp entry/exit + mode so the
+    // 12-phase baseline is measurable before the collapse changes anything.
+    const ctx = await recordPlanInvocation(
+      { cli: 'epic-plan-spec', mode: 'emit-context', epicId, config },
+      () =>
+        buildAuthoringContext(epicId, provider, settings, {
+          fullContext: values['full-context'],
+          github: config.github ?? null,
+        }),
+    );
     const json = values.pretty
       ? JSON.stringify(ctx, null, 2)
       : JSON.stringify(ctx);
@@ -171,18 +178,23 @@ async function main() {
   const [techSpecContent, acceptanceSpecContent = null] =
     await Promise.all(readPromises);
 
-  const result = await runSpecPhase(
-    epicId,
-    provider,
-    { techSpecContent, acceptanceSpecContent },
-    settings,
-    {
-      force: values.force,
-      forceReview: values['force-review'],
-      steal: values.steal === true,
-      config,
-      riskVerdict,
-    },
+  // Plan-metrics ledger (#4474 PR1): stamp entry/exit + mode.
+  const result = await recordPlanInvocation(
+    { cli: 'epic-plan-spec', mode: 'persist', epicId, config },
+    () =>
+      runSpecPhase(
+        epicId,
+        provider,
+        { techSpecContent, acceptanceSpecContent },
+        settings,
+        {
+          force: values.force,
+          forceReview: values['force-review'],
+          steal: values.steal === true,
+          config,
+          riskVerdict,
+        },
+      ),
   );
 
   process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);

--- a/.agents/scripts/lib/orchestration/epic-plan-decompose/phases/cli.js
+++ b/.agents/scripts/lib/orchestration/epic-plan-decompose/phases/cli.js
@@ -25,6 +25,12 @@ import {
   STDERR_LOGGER,
 } from '../../../Logger.js';
 import { createProvider } from '../../../provider-factory.js';
+import {
+  readPlanMetrics,
+  recordPlanInvocation,
+  renderPlanMetricsSummaryLine,
+  summarizePlanMetrics,
+} from '../../plan-metrics.js';
 import { buildDecompositionContext } from './context.js';
 import { reportPartialFailure } from './diagnostics.js';
 import { runDecomposePhase } from './persist.js';
@@ -123,15 +129,36 @@ async function runPersistPath({ epicId, provider, config, values }) {
   const tickets = await loadTicketsFile(values.tickets);
   let result;
   try {
-    result = await runDecomposePhase(epicId, provider, { tickets }, config, {
-      force: values.force,
-      resume: values.resume,
-      allowOverBudget: values['allow-over-budget'],
-      allowLargeFanOut: values['allow-large-fan-out'],
-    });
+    // Plan-metrics ledger (#4474 PR1): stamp entry/exit + mode.
+    result = await recordPlanInvocation(
+      { cli: 'epic-plan-decompose', mode: 'persist', epicId, config },
+      () =>
+        runDecomposePhase(epicId, provider, { tickets }, config, {
+          force: values.force,
+          resume: values.resume,
+          allowOverBudget: values['allow-over-budget'],
+          allowLargeFanOut: values['allow-large-fan-out'],
+        }),
+    );
   } catch (err) {
     await reportPartialFailure({ epicId, provider, err });
     throw err;
+  }
+  // Surface the whole plan run's invocation ledger in the persist summary
+  // (#4474 PR1). Additive and best-effort: a read failure never fails the
+  // persist that already succeeded.
+  try {
+    const summary = summarizePlanMetrics(await readPlanMetrics(epicId, config));
+    if (summary) {
+      result.planMetrics = summary;
+      Logger.info(
+        `[epic-plan-decompose] ${renderPlanMetricsSummaryLine(summary)}`,
+      );
+    }
+  } catch (err) {
+    Logger.warn(
+      `[epic-plan-decompose] plan-metrics summary skipped: ${err.message}`,
+    );
   }
   process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
 }
@@ -160,7 +187,11 @@ export async function main() {
   await driveDrainPendingCleanup({ config, provider, emitContext });
 
   if (emitContext) {
-    await runEmitContextPath({ epicId, provider, config, values });
+    // Plan-metrics ledger (#4474 PR1): stamp entry/exit + mode.
+    await recordPlanInvocation(
+      { cli: 'epic-plan-decompose', mode: 'emit-context', epicId, config },
+      () => runEmitContextPath({ epicId, provider, config, values }),
+    );
     return;
   }
   await runPersistPath({ epicId, provider, config, values });

--- a/.agents/scripts/lib/orchestration/plan-metrics.js
+++ b/.agents/scripts/lib/orchestration/plan-metrics.js
@@ -1,0 +1,346 @@
+/**
+ * plan-metrics.js — append-only plan-invocation ledger (Epic #4474, PR1).
+ *
+ * The `/plan` collapse (#4474) is measured, not asserted: before any pipeline
+ * phase is removed, every plan CLI invocation stamps an entry/exit record so
+ * the current 12-phase baseline is captured on disk. Each record is one
+ * newline-terminated JSON line appended to
+ * `temp/epic-<id>/plan-metrics.json` (per-Epic plan CLIs) or
+ * `temp/standalone/plan-metrics.json` (the standalone `story-plan.js` path
+ * and Epic-less healthcheck runs — same standalone routing the friction
+ * ledger uses).
+ *
+ * Record shape (v1):
+ *
+ * ```json
+ * { "v": 1, "cli": "epic-plan-spec", "mode": "emit-context",
+ *   "epicId": 4474, "startedAt": "...", "endedAt": "...",
+ *   "durationMs": 1234, "ok": true }
+ * ```
+ *
+ * Attribution note (#4474 PR1 risk register): these records count **CLI
+ * invocations from the parent session's perspective**. Sub-agent sessions
+ * spawned by the workflow do not write here; they are attributed separately
+ * by the host's session accounting. Do not read `invocations` as "turns".
+ *
+ * Robustness contract (mirrors `lib/observability/signals-writer.js`):
+ *   - **Best-effort writes.** A failed append is a missing metric, not a
+ *     failed plan phase — fs errors are swallowed after a `Logger.warn`.
+ *   - **No buffering.** Each append opens, writes one line, closes.
+ *   - **Malformed-line tolerance on read.** The reader skips unparseable
+ *     lines (counting them) instead of throwing, so a torn write can never
+ *     wedge the analyzer.
+ *   - **Rotation.** When an append would push the ledger past
+ *     `MAX_LEDGER_BYTES`, the current file is renamed to
+ *     `plan-metrics.json.1` (replacing any prior rollover) and the append
+ *     starts a fresh ledger, so a long-lived Epic cannot grow the file
+ *     unboundedly. Readers only consume the active generation — the
+ *     rollover exists for manual archaeology.
+ *
+ * `plan-metrics.json` is intentionally NOT in
+ * `lib/plan-phase-cleanup.js#PHASE_TEMP_BASENAMES`: the ledger must survive
+ * phase cleanup so the whole plan run (spec → decompose → healthcheck) is
+ * visible in one stream.
+ */
+
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
+import {
+  anchorTempRoot,
+  epicArtifactPath,
+  tempRootFrom,
+} from '../config/temp-paths.js';
+import { Logger } from '../Logger.js';
+
+export const PLAN_METRICS_BASENAME = 'plan-metrics.json';
+export const PLAN_METRICS_SCHEMA_VERSION = 1;
+
+/**
+ * Rotation threshold. At ~200 bytes per record this is ~5000 invocations —
+ * far beyond any real plan run, so rotation only fires on pathological
+ * accumulation.
+ */
+export const MAX_LEDGER_BYTES = 1024 * 1024;
+
+/**
+ * Resolve the ledger path for an Epic (or the standalone stream when
+ * `epicId` is `null` — the `story-plan.js` / Epic-less healthcheck case).
+ *
+ * @param {number|null} epicId
+ * @param {object} [config] Resolved config (threads `project.paths.tempRoot`).
+ * @returns {string}
+ */
+export function planMetricsPath(epicId, config) {
+  if (epicId === null || epicId === undefined) {
+    return path.join(
+      anchorTempRoot(tempRootFrom(config)),
+      'standalone',
+      PLAN_METRICS_BASENAME,
+    );
+  }
+  return epicArtifactPath(epicId, PLAN_METRICS_BASENAME, config);
+}
+
+/**
+ * Rotate the ledger when appending `incomingBytes` would exceed
+ * `maxBytes`. Single-generation rollover: `plan-metrics.json` →
+ * `plan-metrics.json.1` (any prior `.1` is replaced).
+ *
+ * @param {string} filePath
+ * @param {number} incomingBytes
+ * @param {number} [maxBytes]
+ * @returns {Promise<boolean>} true when a rotation happened.
+ */
+async function rotateIfNeeded(filePath, incomingBytes, maxBytes) {
+  let size = 0;
+  try {
+    size = (await fs.stat(filePath)).size;
+  } catch {
+    return false; // No existing ledger — nothing to rotate.
+  }
+  if (size + incomingBytes <= maxBytes) return false;
+  await fs.rename(filePath, `${filePath}.1`);
+  return true;
+}
+
+/**
+ * Append one invocation record to the ledger. Best-effort: returns `false`
+ * (after a `Logger.warn`) instead of throwing on any fs failure, so metric
+ * capture can never fail a plan phase.
+ *
+ * @param {{
+ *   cli: string,
+ *   mode: string,
+ *   epicId?: number|null,
+ *   startedAt: string,
+ *   endedAt: string,
+ *   ok: boolean,
+ * }} entry
+ * @param {object} [config]
+ * @param {{ maxBytes?: number }} [opts] Test seam for the rotation threshold.
+ * @returns {Promise<boolean>} true when the line was written.
+ */
+export async function appendPlanMetric(entry, config, opts = {}) {
+  try {
+    if (!entry || typeof entry !== 'object') {
+      throw new TypeError('appendPlanMetric requires an entry object');
+    }
+    if (typeof entry.cli !== 'string' || entry.cli.length === 0) {
+      throw new TypeError('appendPlanMetric requires a non-empty entry.cli');
+    }
+    if (typeof entry.mode !== 'string' || entry.mode.length === 0) {
+      throw new TypeError('appendPlanMetric requires a non-empty entry.mode');
+    }
+    const epicId = entry.epicId ?? null;
+    const record = {
+      v: PLAN_METRICS_SCHEMA_VERSION,
+      cli: entry.cli,
+      mode: entry.mode,
+      epicId,
+      startedAt: entry.startedAt,
+      endedAt: entry.endedAt,
+      durationMs:
+        typeof entry.durationMs === 'number'
+          ? entry.durationMs
+          : Math.max(
+              0,
+              Date.parse(entry.endedAt) - Date.parse(entry.startedAt),
+            ) || 0,
+      ok: entry.ok === true,
+    };
+    const filePath = planMetricsPath(epicId, config);
+    const line = `${JSON.stringify(record)}\n`;
+    await fs.mkdir(path.dirname(filePath), { recursive: true });
+    await rotateIfNeeded(
+      filePath,
+      Buffer.byteLength(line),
+      opts.maxBytes ?? MAX_LEDGER_BYTES,
+    );
+    await fs.appendFile(filePath, line, 'utf8');
+    return true;
+  } catch (err) {
+    Logger.warn(
+      `[plan-metrics] append failed (non-fatal): ${err?.message ?? err}`,
+    );
+    return false;
+  }
+}
+
+/**
+ * Wrap one plan CLI invocation: stamp `startedAt`, run `fn`, stamp
+ * `endedAt` + `ok`, append the record, and re-throw the original error on
+ * failure. The metric write itself is best-effort and can never mask or
+ * replace the wrapped function's outcome.
+ *
+ * @template T
+ * @param {{ cli: string, mode: string, epicId?: number|null, config?: object }} meta
+ * @param {() => Promise<T>} fn
+ * @returns {Promise<T>}
+ */
+export async function recordPlanInvocation(meta, fn) {
+  const startedAt = new Date().toISOString();
+  const startMs = Date.now();
+  let ok = false;
+  try {
+    const result = await fn();
+    ok = true;
+    return result;
+  } finally {
+    await appendPlanMetric(
+      {
+        cli: meta.cli,
+        mode: meta.mode,
+        epicId: meta.epicId ?? null,
+        startedAt,
+        endedAt: new Date().toISOString(),
+        durationMs: Date.now() - startMs,
+        ok,
+      },
+      meta.config,
+    );
+  }
+}
+
+/**
+ * Read the active ledger generation. Missing file → `{ entries: [],
+ * malformedLines: 0, missing: true }`. Malformed lines are skipped and
+ * counted, never thrown.
+ *
+ * @param {number|null} epicId
+ * @param {object} [config]
+ * @returns {Promise<{ entries: object[], malformedLines: number, missing: boolean }>}
+ */
+export async function readPlanMetrics(epicId, config) {
+  const filePath = planMetricsPath(epicId, config);
+  let raw;
+  try {
+    raw = await fs.readFile(filePath, 'utf8');
+  } catch {
+    return { entries: [], malformedLines: 0, missing: true };
+  }
+  const entries = [];
+  let malformedLines = 0;
+  for (const line of raw.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    try {
+      const parsed = JSON.parse(trimmed);
+      if (
+        parsed &&
+        typeof parsed === 'object' &&
+        typeof parsed.cli === 'string'
+      ) {
+        entries.push(parsed);
+      } else {
+        malformedLines += 1;
+      }
+    } catch {
+      malformedLines += 1;
+    }
+  }
+  return { entries, malformedLines, missing: false };
+}
+
+/**
+ * Roll a read ledger up into the compact summary surfaced by the persist
+ * summary and `analyze-execution.js`. Returns `null` when there is nothing
+ * to summarize (missing ledger or zero parseable entries).
+ *
+ * @param {{ entries: object[], malformedLines?: number }} ledger
+ * @returns {{
+ *   invocations: number,
+ *   failures: number,
+ *   byCli: Record<string, number>,
+ *   byMode: Record<string, number>,
+ *   firstStartedAt: string|null,
+ *   lastEndedAt: string|null,
+ *   spanMs: number|null,
+ *   totalDurationMs: number,
+ *   malformedLines: number,
+ * }|null}
+ */
+export function summarizePlanMetrics(ledger) {
+  const entries = ledger?.entries ?? [];
+  if (entries.length === 0) return null;
+  const byCli = {};
+  const byMode = {};
+  let failures = 0;
+  let totalDurationMs = 0;
+  let firstStartedAt = null;
+  let lastEndedAt = null;
+  for (const e of entries) {
+    byCli[e.cli] = (byCli[e.cli] ?? 0) + 1;
+    if (typeof e.mode === 'string') byMode[e.mode] = (byMode[e.mode] ?? 0) + 1;
+    if (e.ok !== true) failures += 1;
+    if (typeof e.durationMs === 'number') totalDurationMs += e.durationMs;
+    if (typeof e.startedAt === 'string') {
+      if (firstStartedAt === null || e.startedAt < firstStartedAt) {
+        firstStartedAt = e.startedAt;
+      }
+    }
+    if (typeof e.endedAt === 'string') {
+      if (lastEndedAt === null || e.endedAt > lastEndedAt) {
+        lastEndedAt = e.endedAt;
+      }
+    }
+  }
+  let spanMs = null;
+  if (firstStartedAt !== null && lastEndedAt !== null) {
+    const span = Date.parse(lastEndedAt) - Date.parse(firstStartedAt);
+    if (Number.isFinite(span)) spanMs = Math.max(0, span);
+  }
+  return {
+    invocations: entries.length,
+    failures,
+    byCli,
+    byMode,
+    firstStartedAt,
+    lastEndedAt,
+    spanMs,
+    totalDurationMs,
+    malformedLines: ledger?.malformedLines ?? 0,
+  };
+}
+
+/**
+ * Render the one-line human summary (snapshot-tested). Example:
+ *
+ *   `plan-metrics: 5 invocation(s) (1 failed) across epic-plan-spec ×2,
+ *    epic-plan-decompose ×2, epic-plan-healthcheck ×1 — span 12m 3s`
+ *
+ * @param {ReturnType<typeof summarizePlanMetrics>} summary
+ * @returns {string}
+ */
+export function renderPlanMetricsSummaryLine(summary) {
+  if (!summary) return 'plan-metrics: no invocations recorded';
+  const cliParts = Object.entries(summary.byCli)
+    .map(([cli, count]) => `${cli} ×${count}`)
+    .join(', ');
+  const failed = summary.failures > 0 ? ` (${summary.failures} failed)` : '';
+  const span = summary.spanMs === null ? 'n/a' : formatSpan(summary.spanMs);
+  const malformed =
+    summary.malformedLines > 0
+      ? `; ${summary.malformedLines} malformed line(s) skipped`
+      : '';
+  return (
+    `plan-metrics: ${summary.invocations} invocation(s)${failed} across ` +
+    `${cliParts} — span ${span}${malformed}`
+  );
+}
+
+/**
+ * Compact duration formatter: `45s`, `12m 3s`, `2h 5m`.
+ *
+ * @param {number} ms
+ * @returns {string}
+ */
+function formatSpan(ms) {
+  const totalSeconds = Math.round(ms / 1000);
+  if (totalSeconds < 60) return `${totalSeconds}s`;
+  const totalMinutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  if (totalMinutes < 60) return `${totalMinutes}m ${seconds}s`;
+  const hours = Math.floor(totalMinutes / 60);
+  return `${hours}h ${totalMinutes % 60}m`;
+}

--- a/.agents/scripts/story-plan.js
+++ b/.agents/scripts/story-plan.js
@@ -39,6 +39,7 @@ import { PROJECT_ROOT, resolveConfig } from './lib/config-resolver.js';
 import { exec as ghExec } from './lib/gh-exec.js';
 import { Logger, routeAllOutputToStderr } from './lib/Logger.js';
 import { TYPE_LABELS } from './lib/label-constants.js';
+import { recordPlanInvocation } from './lib/orchestration/plan-metrics.js';
 import { buildCorpusContext } from './lib/planning-corpus.js';
 import { createProvider } from './lib/provider-factory.js';
 import {
@@ -300,14 +301,25 @@ async function main() {
     // unconditionally parseable by `JSON.parse`. Mirrors the contract
     // `epic-plan-spec.js` enforces for its own --emit-context mode.
     routeAllOutputToStderr();
-    return runEmitContext({ values, provider, projectRoot, config });
+    // Plan-metrics ledger (#4474 PR1): standalone plans have no Epic, so
+    // `epicId: null` routes the stamp to the standalone stream
+    // (`temp/standalone/plan-metrics.json`) — same pattern as friction.
+    return recordPlanInvocation(
+      { cli: 'story-plan', mode: 'emit-context', epicId: null, config },
+      () => runEmitContext({ values, provider, projectRoot, config }),
+    );
   }
 
-  return runPersist({
-    values,
-    provider,
-    dryRun: values['dry-run'],
-  });
+  // Plan-metrics ledger (#4474 PR1): stamp entry/exit + mode.
+  return recordPlanInvocation(
+    { cli: 'story-plan', mode: 'persist', epicId: null, config },
+    () =>
+      runPersist({
+        values,
+        provider,
+        dryRun: values['dry-run'],
+      }),
+  );
 }
 
 runAsCli(import.meta.url, main, { source: 'story-plan' });

--- a/tests/plan-metrics.test.js
+++ b/tests/plan-metrics.test.js
@@ -1,0 +1,257 @@
+/**
+ * plan-metrics.test.js — unit coverage for the #4474 PR1 plan-invocation
+ * ledger: path routing, append + rotation, malformed-line tolerance on
+ * read, the roll-up summary, and a snapshot of the rendered summary line.
+ */
+
+import assert from 'node:assert/strict';
+import { mkdtempSync, rmSync } from 'node:fs';
+import fs from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, it } from 'node:test';
+import {
+  appendPlanMetric,
+  MAX_LEDGER_BYTES,
+  PLAN_METRICS_BASENAME,
+  PLAN_METRICS_SCHEMA_VERSION,
+  planMetricsPath,
+  readPlanMetrics,
+  recordPlanInvocation,
+  renderPlanMetricsSummaryLine,
+  summarizePlanMetrics,
+} from '../.agents/scripts/lib/orchestration/plan-metrics.js';
+
+let workRoot;
+let config;
+
+beforeEach(() => {
+  workRoot = mkdtempSync(path.join(tmpdir(), 'plan-metrics-'));
+  // Absolute tempRoot is honoured verbatim by temp-paths, so the ledger
+  // lands inside the per-test sandbox with no git anchoring involved.
+  config = { project: { paths: { tempRoot: workRoot } } };
+});
+
+afterEach(() => {
+  rmSync(workRoot, { recursive: true, force: true });
+});
+
+describe('planMetricsPath', () => {
+  it('routes an Epic-scoped ledger under temp/epic-<id>/', () => {
+    assert.equal(
+      planMetricsPath(4474, config),
+      path.join(workRoot, 'epic-4474', PLAN_METRICS_BASENAME),
+    );
+  });
+
+  it('routes epicId=null to the standalone stream', () => {
+    assert.equal(
+      planMetricsPath(null, config),
+      path.join(workRoot, 'standalone', PLAN_METRICS_BASENAME),
+    );
+  });
+});
+
+describe('appendPlanMetric', () => {
+  const entry = (over = {}) => ({
+    cli: 'epic-plan-spec',
+    mode: 'emit-context',
+    epicId: 4474,
+    startedAt: '2026-07-12T10:00:00.000Z',
+    endedAt: '2026-07-12T10:00:05.000Z',
+    ok: true,
+    ...over,
+  });
+
+  it('creates the directory lazily and appends one JSON line per call', async () => {
+    assert.equal(await appendPlanMetric(entry(), config), true);
+    assert.equal(await appendPlanMetric(entry({ ok: false }), config), true);
+
+    const raw = await fs.readFile(planMetricsPath(4474, config), 'utf8');
+    const lines = raw.trim().split('\n');
+    assert.equal(lines.length, 2);
+    const first = JSON.parse(lines[0]);
+    assert.equal(first.v, PLAN_METRICS_SCHEMA_VERSION);
+    assert.equal(first.cli, 'epic-plan-spec');
+    assert.equal(first.mode, 'emit-context');
+    assert.equal(first.epicId, 4474);
+    assert.equal(first.ok, true);
+    assert.equal(first.durationMs, 5000); // derived from the timestamps
+    assert.equal(JSON.parse(lines[1]).ok, false);
+  });
+
+  it('returns false (never throws) on an invalid entry', async () => {
+    assert.equal(await appendPlanMetric(null, config), false);
+    assert.equal(await appendPlanMetric(entry({ cli: '' }), config), false);
+    assert.equal(await appendPlanMetric(entry({ mode: '' }), config), false);
+  });
+
+  it('rotates the ledger to <name>.1 when the byte cap would be exceeded', async () => {
+    assert.ok(MAX_LEDGER_BYTES > 0);
+    const filePath = planMetricsPath(4474, config);
+    await appendPlanMetric(entry(), config, { maxBytes: 64 });
+    // First append fits (empty file). The second would exceed 64 bytes,
+    // so the existing ledger rolls over and the append starts fresh.
+    await appendPlanMetric(entry({ mode: 'persist' }), config, {
+      maxBytes: 64,
+    });
+
+    const rotated = await fs.readFile(`${filePath}.1`, 'utf8');
+    assert.equal(JSON.parse(rotated.trim()).mode, 'emit-context');
+    const active = await fs.readFile(filePath, 'utf8');
+    const activeLines = active.trim().split('\n');
+    assert.equal(activeLines.length, 1);
+    assert.equal(JSON.parse(activeLines[0]).mode, 'persist');
+  });
+});
+
+describe('recordPlanInvocation', () => {
+  it('stamps ok:true around a successful invocation and returns its result', async () => {
+    const result = await recordPlanInvocation(
+      { cli: 'epic-plan-decompose', mode: 'persist', epicId: 7, config },
+      async () => 'the-result',
+    );
+    assert.equal(result, 'the-result');
+    const { entries } = await readPlanMetrics(7, config);
+    assert.equal(entries.length, 1);
+    assert.equal(entries[0].ok, true);
+    assert.equal(entries[0].cli, 'epic-plan-decompose');
+    assert.equal(entries[0].mode, 'persist');
+    assert.ok(entries[0].startedAt <= entries[0].endedAt);
+  });
+
+  it('stamps ok:false and re-throws the original error on failure', async () => {
+    await assert.rejects(
+      recordPlanInvocation(
+        { cli: 'story-plan', mode: 'emit-context', epicId: null, config },
+        async () => {
+          throw new Error('authoring exploded');
+        },
+      ),
+      /authoring exploded/,
+    );
+    const { entries } = await readPlanMetrics(null, config);
+    assert.equal(entries.length, 1);
+    assert.equal(entries[0].ok, false);
+    assert.equal(entries[0].epicId, null);
+  });
+});
+
+describe('readPlanMetrics', () => {
+  it('returns missing:true for an absent ledger', async () => {
+    const result = await readPlanMetrics(999_001, config);
+    assert.deepEqual(result, { entries: [], malformedLines: 0, missing: true });
+  });
+
+  it('skips malformed lines and counts them instead of throwing', async () => {
+    const filePath = planMetricsPath(42, config);
+    await fs.mkdir(path.dirname(filePath), { recursive: true });
+    const good = JSON.stringify({
+      v: 1,
+      cli: 'epic-plan-spec',
+      mode: 'persist',
+      epicId: 42,
+      startedAt: '2026-07-12T10:00:00.000Z',
+      endedAt: '2026-07-12T10:00:01.000Z',
+      durationMs: 1000,
+      ok: true,
+    });
+    await fs.writeFile(
+      filePath,
+      `${good}\n{"torn write\n\n42\n${good}\n`,
+      'utf8',
+    );
+
+    const result = await readPlanMetrics(42, config);
+    assert.equal(result.missing, false);
+    assert.equal(result.entries.length, 2);
+    assert.equal(result.malformedLines, 2); // torn JSON + bare number
+  });
+});
+
+describe('summarizePlanMetrics', () => {
+  const ledger = () => ({
+    malformedLines: 1,
+    entries: [
+      {
+        cli: 'epic-plan-spec',
+        mode: 'emit-context',
+        startedAt: '2026-07-12T10:00:00.000Z',
+        endedAt: '2026-07-12T10:01:00.000Z',
+        durationMs: 60_000,
+        ok: true,
+      },
+      {
+        cli: 'epic-plan-spec',
+        mode: 'persist',
+        startedAt: '2026-07-12T10:05:00.000Z',
+        endedAt: '2026-07-12T10:06:00.000Z',
+        durationMs: 60_000,
+        ok: true,
+      },
+      {
+        cli: 'epic-plan-decompose',
+        mode: 'persist',
+        startedAt: '2026-07-12T10:10:00.000Z',
+        endedAt: '2026-07-12T10:12:03.000Z',
+        durationMs: 123_000,
+        ok: false,
+      },
+    ],
+  });
+
+  it('returns null when there is nothing to summarize', () => {
+    assert.equal(summarizePlanMetrics(null), null);
+    assert.equal(summarizePlanMetrics({ entries: [] }), null);
+  });
+
+  it('rolls up counts, failures, span, and malformed-line count', () => {
+    const summary = summarizePlanMetrics(ledger());
+    assert.deepEqual(summary, {
+      invocations: 3,
+      failures: 1,
+      byCli: { 'epic-plan-spec': 2, 'epic-plan-decompose': 1 },
+      byMode: { 'emit-context': 1, persist: 2 },
+      firstStartedAt: '2026-07-12T10:00:00.000Z',
+      lastEndedAt: '2026-07-12T10:12:03.000Z',
+      spanMs: 723_000,
+      totalDurationMs: 243_000,
+      malformedLines: 1,
+    });
+  });
+
+  it('renderPlanMetricsSummaryLine snapshot', () => {
+    const summary = summarizePlanMetrics(ledger());
+    assert.equal(
+      renderPlanMetricsSummaryLine(summary),
+      'plan-metrics: 3 invocation(s) (1 failed) across epic-plan-spec ×2, ' +
+        'epic-plan-decompose ×1 — span 12m 3s; 1 malformed line(s) skipped',
+    );
+  });
+
+  it('renderPlanMetricsSummaryLine handles the empty ledger', () => {
+    assert.equal(
+      renderPlanMetricsSummaryLine(null),
+      'plan-metrics: no invocations recorded',
+    );
+  });
+
+  it('renderPlanMetricsSummaryLine formats a clean sub-minute run', () => {
+    const summary = summarizePlanMetrics({
+      entries: [
+        {
+          cli: 'story-plan',
+          mode: 'emit-context',
+          startedAt: '2026-07-12T10:00:00.000Z',
+          endedAt: '2026-07-12T10:00:45.000Z',
+          durationMs: 45_000,
+          ok: true,
+        },
+      ],
+    });
+    assert.equal(
+      renderPlanMetricsSummaryLine(summary),
+      'plan-metrics: 1 invocation(s) across story-plan ×1 — span 45s',
+    );
+  });
+});


### PR DESCRIPTION
PR1 of the M3 `/plan`-collapse design (refs #4474 — design comment "Implementation design (orchestrated design pass, 2026-07-12)"). Metric instrumentation lands **first** so the current 12-phase pipeline is measured, not asserted, before any collapse PR changes it. Purely additive — no behavior changes, no workflow prose touched.

## Ledger

New module `.agents/scripts/lib/orchestration/plan-metrics.js` — append-only ledger at `temp/epic-<id>/plan-metrics.json` (path resolved via `lib/config/temp-paths.js`; standalone/no-Epic runs route to `temp/standalone/plan-metrics.json`, the same routing the friction stream uses). One newline-terminated JSON line per plan CLI invocation:

```json
{ "v": 1, "cli": "epic-plan-spec", "mode": "emit-context",
  "epicId": 4474, "startedAt": "...", "endedAt": "...",
  "durationMs": 1234, "ok": true }
```

Robustness contract mirrors `signals-writer.js`: best-effort writes (a failed append never fails a plan phase), no buffering, malformed-line-tolerant reads (skipped + counted), and a 1 MiB single-generation rotation to `plan-metrics.json.1`. The basename is deliberately **not** in `PHASE_TEMP_BASENAMES`, so phase cleanup cannot delete the baseline mid-run.

**Attribution** (design risk register): records count parent-session CLI invocations; sub-agent sessions are attributed separately by host session accounting — `invocations` is not "turns".

## Instrumented CLIs

| CLI | Modes stamped |
| --- | --- |
| `epic-plan-spec.js` | `emit-context`, `persist` |
| `epic-plan-decompose.js` | `emit-context`, `persist` |
| `epic-plan-clarity.js` | `emit-context`, `persist` |
| `epic-plan-healthcheck.js` | `healthcheck` (CLI entry only — the inline decompose gate import is covered by the parent CLI's stamp, avoiding double-count) |
| `story-plan.js` | `emit-context`, `persist` (standalone stream, `epicId: null`) |

## Surfacing

- **Decompose persist summary**: `runPersistPath` attaches a `planMetrics` roll-up (`invocations`, `failures`, `byCli`, `byMode`, `firstStartedAt`/`lastEndedAt`, `spanMs`, `totalDurationMs`, `malformedLines`) to the printed result and logs the one-line summary.
- **`analyze-execution.js` epic mode**: same roll-up on the result envelope (`planMetrics`, `null` when no ledger) plus a log line. The structured-comment body schema is untouched.

## Test evidence

- New `tests/plan-metrics.test.js`: path routing (epic vs standalone), lazy dir creation + append, rotation, invalid-entry tolerance, `recordPlanInvocation` success/failure (re-throws, stamps `ok:false`), malformed-line tolerance, summary roll-up, and a snapshot of the rendered summary line — 14/14 pass.
- Full gates green locally: `npm test` — **10127 tests, 10123 pass, 0 fail, 4 skipped**; `npm run lint` (biome + docs:check) clean; `npm run lint:md` 0 errors; `check-baselines` (crap/maintainability/duplication) PASS; `check-arch-cycles` added=0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
