### PR TITLE
feat(plan): plan-context emit cli — single envelope for the 3-step collapse (refs #4474)

### DIFF
--- a/.agents/scripts/lib/orchestration/epic-plan-spec/phases/authoring-context.js
+++ b/.agents/scripts/lib/orchestration/epic-plan-spec/phases/authoring-context.js
@@ -113,7 +113,12 @@ export async function buildAuthoringContext(
   settings = {},
   opts = {},
 ) {
-  const epic = await provider.getEpic(epicId);
+  // Epic #4474 (M3 PR2): `opts.epic` is an optional prefetched Epic object
+  // so a caller that already holds the issue (the folded `plan-context.js`
+  // envelope build, which also needs the raw body for clarity scoring and
+  // re-plan detection) does not pay a second provider fetch. Absent, the
+  // fetch behaviour is unchanged.
+  const epic = opts.epic ?? (await provider.getEpic(epicId));
   if (!epic) {
     throw new Error(`Epic #${epicId} not found.`);
   }

--- a/.agents/scripts/lib/orchestration/plan-context.js
+++ b/.agents/scripts/lib/orchestration/plan-context.js
@@ -1,0 +1,510 @@
+/**
+ * plan-context.js — single planner-context envelope build (Epic #4474, M3
+ * PR2 — `/plan` collapse step 1).
+ *
+ * Folds the two `--emit-context` halves of the 12-phase pipeline
+ * (`buildAuthoringContext` from `epic-plan-spec/phases/authoring-context.js`
+ * and `buildDecompositionContext` from
+ * `epic-plan-decompose/phases/context.js`) plus the three currently-no-CLI
+ * library calls (`findSimilarOpenEpics`, clarity scoring, re-plan
+ * detection) into ONE JSON envelope, so the authoring middle reads a single
+ * file instead of shim-scripting library imports (the bench measured
+ * ~12–15 turns of shim-writing for the dup search alone).
+ *
+ * Two modes (the design's mode matrix):
+ *   - `epic`      — the Epic exists. Carries `epic`, `clarity` (the Epic
+ *                   Clarity Gate rubric — free, same body fetch), `replan`
+ *                   (already-planned signals) and `planState`.
+ *   - `one-pager` — ideation; the Epic does not exist yet (creation moves
+ *                   to the persist half). Carries `onePager` and
+ *                   `duplicates[]` (cross-Epic dup search). Clarity is not
+ *                   scored — the ideation path is definitionally clear.
+ *
+ * All fields are JSON-serialisable; the module performs no GitHub writes.
+ * The only I/O surfaces are the injected `provider` (reads) and the
+ * best-effort local scans the folded builders already perform.
+ */
+
+import { readFile } from 'node:fs/promises';
+import { getLimits, resolvePreflightCeilings } from '../config-resolver.js';
+import { findSimilarOpenEpics } from '../duplicate-search.js';
+import { hasEpicSection, hasTechSpecContent } from '../epic-body-sections.js';
+import { scoreEpicBody } from '../epic-plan-clarity.js';
+import { Logger } from '../Logger.js';
+import {
+  renderAcceptanceSpecSystemPrompt,
+  renderTechSpecSystemPrompt,
+} from '../templates/spec-author-prompts.js';
+import { parseDeliverySlicingTable } from './consolidation-precondition.js';
+import { buildDocsDigest } from './docs-digest.js';
+import { buildDecomposerSystemPrompt } from './epic-plan-decompose/phases/context.js';
+import { buildAuthoringContext } from './epic-plan-spec/phases/authoring-context.js';
+import { read as readPlanState } from './epic-plan-state-store.js';
+
+/**
+ * Envelope byte ceiling (regression guard for the design's named PR2 risk:
+ * two envelopes → one bigger one). The folded envelope's bounded parts are:
+ * the `applyBudget`-capped body (`planningContext.maxBytes` = 50 KB), the
+ * tier-capped codebase snapshot (~35 KB skinny on this repo), the three
+ * rendered system prompts (~15 KB), and the digest-first `docsContext`
+ * (outline-only, pointer in epic mode). Measured folded envelopes on this
+ * repo land at ~42 KB; 256 KB (~64K tokens at the ≈4-chars/token estimate)
+ * gives >2× headroom over a worst-case budgeted body + medium-tier snapshot
+ * while staying an order of magnitude under the session budget. The test
+ * suite asserts serialized envelopes stay under this value — raise it only
+ * with a measured justification.
+ */
+export const PLAN_CONTEXT_ENVELOPE_BYTE_CEILING = 256_000;
+
+/**
+ * Compact, machine-readable descriptor of the `tickets.json` array the
+ * authoring pass writes and `validateAndNormalizeTickets` gates at persist
+ * time. A descriptor, not a validator: the deterministic gate stays in the
+ * persist half (design § 1 step 3); this field exists so the authoring
+ * middle knows the shape without re-reading the decomposer prompt prose.
+ */
+export const TICKET_SCHEMA_DESCRIPTOR = Object.freeze({
+  shape: 'array',
+  itemFields: Object.freeze({
+    slug: 'string — ^[a-z0-9][a-z0-9-]*$ (hyphen-case, unique per decompose)',
+    type: "string — literal 'story' (2-tier hierarchy: Epic → Story only)",
+    title: 'string — short descriptive title',
+    body: 'string — serialized Story-body markdown (never a JSON object)',
+    acceptance: 'string[] — top-level testable criteria (not nested in body)',
+    verify: 'string[] — top-level exact commands/test paths with (<tier>)',
+    labels: "string[] — must include 'type::story' and one 'persona::*'",
+    depends_on: 'string[]? — sibling Story slugs that block execution',
+  }),
+  validatedBy:
+    'validateAndNormalizeTickets (lib/orchestration/ticket-validator.js) at persist time',
+});
+
+/**
+ * Resolve the planning risk heuristics list from the canonical config
+ * block (same resolution the decompose context uses).
+ *
+ * @param {object} config
+ * @returns {string[]}
+ */
+function resolveRiskHeuristics(config = {}) {
+  if (Array.isArray(config.planning?.riskHeuristics)) {
+    return config.planning.riskHeuristics;
+  }
+  return config.agentSettings?.planning?.riskHeuristics || [];
+}
+
+/**
+ * Count top-level enumerated items (`- `, `* `, `1. `) under the first
+ * scope-shaped `## ` heading (Scope / MVP Scope / Proposed Scope / Work
+ * Breakdown / Capabilities), up to the next `## ` heading. Returns `null`
+ * when no scope-shaped heading exists — the caller treats that as "no
+ * sizing signal" and defaults to fan-out.
+ *
+ * @param {string} body
+ * @returns {number|null}
+ */
+function countScopeItems(body) {
+  if (typeof body !== 'string' || body.length === 0) return null;
+  const lines = body.split(/\r?\n/);
+  const headingIdx = lines.findIndex((line) =>
+    /^##\s+(?:(?:MVP\s+|Proposed\s+)?Scope(?:\s+\([^)]+\))?|Work\s+Breakdown|Capabilities)\s*$/i.test(
+      line.trim(),
+    ),
+  );
+  if (headingIdx === -1) return null;
+  let count = 0;
+  for (let i = headingIdx + 1; i < lines.length; i++) {
+    const line = lines[i];
+    if (/^##\s+/.test(line)) break;
+    if (/^\s*(?:[-*]|\d+\.)\s+\S/.test(line)) count += 1;
+  }
+  return count;
+}
+
+/**
+ * Advisory single-vs-fan-out delivery-shape signal (design § 1 step 1;
+ * routing pilot #4475). Derived from the same size/shape heuristics the
+ * scope-triage rubric anchors to — the Delivery Slicing table when the Epic
+ * body already carries one (slice count + "Independent?" chain shape,
+ * via the Phase 8.3 precondition parser), else a scope-enumeration count.
+ *
+ * **Advisory only, fan-out by default.** This signal changes no routing
+ * behaviour in this PR: the deliver-side reader is #4475's scope, and until
+ * it lands the recommendation defaults to `fan-out` for every ambiguous
+ * case. `single` is recommended only on clear one-pass indicators: a
+ * slicing table proposing ≤ 2 slices, a pure dependent chain (zero
+ * realized parallelism from the Story tier — the N=2 bench finding), or a
+ * scope enumeration of ≤ 2 capabilities.
+ *
+ * @param {{ body: string }} args
+ * @returns {{ recommendation: 'single'|'fan-out', reasons: string[], advisory: true }}
+ */
+export function buildDeliveryShapeSignal({ body } = {}) {
+  const advisory = /** @type {const} */ (true);
+  const rows = parseDeliverySlicingTable(body ?? '');
+
+  if (Array.isArray(rows) && rows.length > 0) {
+    if (rows.length <= 2) {
+      return {
+        recommendation: 'single',
+        reasons: [
+          `delivery-slicing table proposes ${rows.length} slice(s) — one-pass-sized`,
+        ],
+        advisory,
+      };
+    }
+    const chain = rows.slice(1).every((r) => r.independent === false);
+    if (chain) {
+      return {
+        recommendation: 'single',
+        reasons: [
+          `delivery-slicing table is a pure dependent chain (${rows.length} slices, every non-first slice "Independent? No") — zero parallelism value from Story fan-out`,
+        ],
+        advisory,
+      };
+    }
+    return {
+      recommendation: 'fan-out',
+      reasons: [
+        `delivery-slicing table proposes ${rows.length} slices with independent parallelism`,
+      ],
+      advisory,
+    };
+  }
+
+  const scopeItems = countScopeItems(body ?? '');
+  if (scopeItems !== null && scopeItems > 0 && scopeItems <= 2) {
+    return {
+      recommendation: 'single',
+      reasons: [
+        `scope enumerates ${scopeItems} capability item(s) — one-pass-sized`,
+      ],
+      advisory,
+    };
+  }
+  if (scopeItems !== null && scopeItems > 2) {
+    return {
+      recommendation: 'fan-out',
+      reasons: [`scope enumerates ${scopeItems} capability items`],
+      advisory,
+    };
+  }
+  return {
+    recommendation: 'fan-out',
+    reasons: [
+      'no delivery-slicing table or scope enumeration to size against — defaulting to fan-out',
+    ],
+    advisory,
+  };
+}
+
+/**
+ * Re-plan detection signals (folds the workflow's Phase 5 into the
+ * envelope): the Tech Spec sections alone are the already-planned signal;
+ * the open-Story count and section presence let the authoring middle (and
+ * the persist half's `--force` prompt) cite concrete numbers.
+ *
+ * `openStoryCount` is best-effort: a provider listing failure degrades to
+ * `null` rather than aborting the envelope build.
+ *
+ * @param {{ epicBody: string, provider: object, epicId: number }} args
+ * @returns {Promise<{
+ *   alreadyPlanned: boolean,
+ *   planningSections: { techSpec: boolean, acceptanceTable: boolean },
+ *   openStoryCount: number|null,
+ * }>}
+ */
+export async function buildReplanSignal({ epicBody, provider, epicId }) {
+  const body = epicBody ?? '';
+  let openStoryCount = null;
+  try {
+    const tickets = await provider.getTickets(epicId, { state: 'open' });
+    if (Array.isArray(tickets)) openStoryCount = tickets.length;
+  } catch (err) {
+    Logger.warn(
+      `[plan-context] open-children listing skipped: ${err?.message ?? err}`,
+    );
+  }
+  return {
+    alreadyPlanned: hasTechSpecContent(body),
+    planningSections: {
+      techSpec: hasEpicSection(body, 'techSpec'),
+      acceptanceTable: hasEpicSection(body, 'acceptanceTable'),
+    },
+    openStoryCount,
+  };
+}
+
+/**
+ * Render the three authoring system prompts the collapsed pipeline's
+ * single authoring pass consumes. The spec/acceptance prompts render from
+ * `lib/templates/spec-author-prompts.js` (the M3/M8 handshake — envelope
+ * authoritative from day one); the decompose prompt reuses the existing
+ * Story #4162 carrier including the risk-heuristics suffix.
+ *
+ * @param {{ heuristics?: string[], maxTickets?: number, maxTokenBudget?: number, epicId?: number|null }} args
+ * @returns {{ spec: string, acceptance: string, decompose: string }}
+ */
+export function buildSystemPrompts({
+  heuristics = [],
+  maxTickets,
+  maxTokenBudget,
+  epicId = null,
+} = {}) {
+  return {
+    spec: renderTechSpecSystemPrompt(),
+    acceptance: renderAcceptanceSpecSystemPrompt(),
+    decompose: buildDecomposerSystemPrompt(heuristics, {
+      maxTickets,
+      maxTokenBudget,
+      epicId,
+    }),
+  };
+}
+
+/**
+ * Read the `epic-plan-state` structured comment, degrading to `null` when
+ * the comment is missing/unparseable or the provider fetch fails (same
+ * tolerance the decompose context applies).
+ *
+ * @param {{ provider: object, epicId: number }} args
+ * @returns {Promise<object|null>}
+ */
+async function readPlanStateTolerant({ provider, epicId }) {
+  try {
+    return await readPlanState({ provider, epicId });
+  } catch (_err) {
+    return null;
+  }
+}
+
+/**
+ * Build the epic-mode envelope. One Epic fetch feeds everything: the
+ * authoring context (prefetch seam on `buildAuthoringContext`), clarity
+ * scoring, re-plan detection, and the delivery-shape heuristics — the
+ * fetch-twice shape of the split pipeline is gone.
+ */
+async function buildEpicModeEnvelope({
+  epicId,
+  provider,
+  config,
+  settings,
+  fullContext,
+  cwd,
+}) {
+  const epic = await provider.getEpic(epicId);
+  if (!epic) {
+    throw new Error(`[plan-context] Epic #${epicId} not found.`);
+  }
+  const body = epic.body ?? '';
+
+  const authoringOpts = {
+    epic,
+    fullContext,
+    github: config.github ?? null,
+  };
+  if (cwd) authoringOpts.cwd = cwd;
+  const authoring = await buildAuthoringContext(
+    epicId,
+    provider,
+    settings,
+    authoringOpts,
+  );
+
+  const limits = getLimits(config);
+  const heuristics = resolveRiskHeuristics(config);
+  const clarityScore = scoreEpicBody({ body });
+  const [replan, planState] = await Promise.all([
+    buildReplanSignal({ epicBody: body, provider, epicId }),
+    readPlanStateTolerant({ provider, epicId }),
+  ]);
+
+  return {
+    mode: 'epic',
+    epic: authoring.epic,
+    clarity: clarityScore,
+    replan,
+    docsContext: authoring.docsContext,
+    codebaseSnapshot: authoring.codebaseSnapshot,
+    bddRunner: authoring.bddRunner,
+    bddScenarios: authoring.bddScenarios,
+    memoryFreshness: authoring.memoryFreshness,
+    priorFeedback: authoring.priorFeedback,
+    ticketSchema: TICKET_SCHEMA_DESCRIPTOR,
+    maxTickets: limits.maxTickets,
+    maxTokenBudget: limits.maxTokenBudget,
+    preflightCeilings: resolvePreflightCeilings(config),
+    riskHeuristics: heuristics,
+    systemPrompts: buildSystemPrompts({
+      heuristics,
+      maxTickets: limits.maxTickets,
+      maxTokenBudget: limits.maxTokenBudget,
+      epicId,
+    }),
+    deliveryShapeSignal: buildDeliveryShapeSignal({ body }),
+    planState,
+  };
+}
+
+/**
+ * Build the one-pager (ideation) envelope. The Epic does not exist yet —
+ * creation moves to the persist half — so there is no clarity score, no
+ * re-plan signal, and no plan state; the dup search replaces them as the
+ * mode's gating input. `docsContext` is inline-digest (the standalone
+ * `story-plan.js --emit-context` convention): there is no per-Epic temp
+ * directory to anchor a digest file to yet.
+ */
+async function buildOnePagerModeEnvelope({
+  onePagerPath,
+  onePagerContent,
+  provider,
+  config,
+  settings,
+  fullContext,
+  cwd,
+}) {
+  const content =
+    onePagerContent ?? (await readFile(onePagerPath ?? '', 'utf-8'));
+  if (typeof content !== 'string' || content.trim().length === 0) {
+    throw new Error(
+      `[plan-context] one-pager at ${onePagerPath} is empty — nothing to plan from.`,
+    );
+  }
+
+  let duplicates = [];
+  try {
+    duplicates = await findSimilarOpenEpics({
+      onePager: content,
+      provider,
+      owner: config.github?.owner,
+      repo: config.github?.repo,
+    });
+  } catch (err) {
+    // The dup search is a triage signal, not a gate: a provider listing
+    // failure must not abort the envelope build. Surface the degradation
+    // on stderr; the authoring middle sees an empty candidate list.
+    Logger.warn(
+      `[plan-context] duplicate search degraded to no candidates: ${err?.message ?? err}`,
+    );
+    duplicates = [];
+  }
+
+  // Fold the same authoring-context builders the epic path uses, grounded
+  // in the one-pager prose instead of an Epic body. Reuse
+  // `buildAuthoringContext` via the prefetch seam so the fold has exactly
+  // one implementation of the snapshot/BDD/memory/feedback pipeline to
+  // drift from. `docsContextFiles` is emptied for this call: the per-Epic
+  // digest-file path needs an Epic id (and a temp directory) that does not
+  // exist yet — the inline digest below replaces it.
+  const authoring = await buildAuthoringContext(
+    0,
+    /* provider (unused behind the prefetch seam) */ {},
+    { ...settings, docsContextFiles: [] },
+    {
+      epic: { id: 0, title: onePagerPath ?? 'one-pager', body: content },
+      fullContext,
+      github: config.github ?? null,
+      cwd,
+    },
+  );
+
+  // Replace the per-Epic digest-file pointer with an inline digest — the
+  // Epic (and its temp directory) does not exist yet.
+  const paths = settings?.paths ?? {};
+  const inlineDigest = await buildDocsDigest({
+    docsContextFiles: settings?.docsContextFiles,
+    docsRoot: paths.docsRoot,
+  });
+  const docsContext =
+    inlineDigest == null
+      ? null
+      : { mode: 'digest-inline', digest: inlineDigest };
+
+  const limits = getLimits(config);
+  const heuristics = resolveRiskHeuristics(config);
+
+  return {
+    mode: 'one-pager',
+    onePager: { path: onePagerPath ?? null, content },
+    duplicates,
+    docsContext,
+    codebaseSnapshot: authoring.codebaseSnapshot,
+    bddRunner: authoring.bddRunner,
+    bddScenarios: authoring.bddScenarios,
+    memoryFreshness: authoring.memoryFreshness,
+    priorFeedback: authoring.priorFeedback,
+    ticketSchema: TICKET_SCHEMA_DESCRIPTOR,
+    maxTickets: limits.maxTickets,
+    maxTokenBudget: limits.maxTokenBudget,
+    preflightCeilings: resolvePreflightCeilings(config),
+    riskHeuristics: heuristics,
+    systemPrompts: buildSystemPrompts({
+      heuristics,
+      maxTickets: limits.maxTickets,
+      maxTokenBudget: limits.maxTokenBudget,
+      epicId: null,
+    }),
+    deliveryShapeSignal: buildDeliveryShapeSignal({ body: content }),
+    planState: null,
+  };
+}
+
+/**
+ * Build the single planner-context envelope.
+ *
+ * @param {{
+ *   mode: 'epic'|'one-pager',
+ *   epicId?: number,
+ *   onePagerPath?: string,
+ *   onePagerContent?: string,
+ *   provider: object,
+ *   config: object,
+ *   settings: object,
+ *   cwd?: string,
+ * }} args
+ * @returns {Promise<object>} the JSON-serialisable envelope.
+ */
+export async function buildPlanContext({
+  mode,
+  epicId,
+  onePagerPath,
+  onePagerContent,
+  provider,
+  config = {},
+  settings = {},
+  fullContext = false,
+  cwd,
+}) {
+  if (mode === 'epic') {
+    if (!Number.isInteger(epicId)) {
+      throw new Error('[plan-context] epic mode requires a numeric epicId.');
+    }
+    return buildEpicModeEnvelope({
+      epicId,
+      provider,
+      config,
+      settings,
+      fullContext,
+      cwd,
+    });
+  }
+  if (mode === 'one-pager') {
+    if (!onePagerPath && typeof onePagerContent !== 'string') {
+      throw new Error(
+        '[plan-context] one-pager mode requires --one-pager <path>.',
+      );
+    }
+    return buildOnePagerModeEnvelope({
+      onePagerPath,
+      onePagerContent,
+      provider,
+      config,
+      settings,
+      fullContext,
+      cwd,
+    });
+  }
+  throw new Error(
+    `[plan-context] unknown mode "${mode}" — expected "epic" or "one-pager".`,
+  );
+}

--- a/.agents/scripts/lib/templates/spec-author-prompts.js
+++ b/.agents/scripts/lib/templates/spec-author-prompts.js
@@ -1,0 +1,74 @@
+/**
+ * spec-author-prompts.js — single source of the Tech Spec and Acceptance
+ * Spec authoring system prompts (Epic #4474, M3 PR2).
+ *
+ * **Single source of the prompt bodies.** These two prompts were lifted
+ * VERBATIM from the "(authoritative)" fenced blocks in
+ * `.agents/skills/core/epic-plan-spec-author/SKILL.md` (§ "Tech Spec system
+ * prompt" and § "Acceptance Spec system prompt") as the M3 side of the
+ * M3/M8 boundary handshake: the `plan-context.js` envelope renders them
+ * into `systemPrompts.spec` / `systemPrompts.acceptance` so the envelope
+ * is authoritative from day one, and M8 (#4479) then deletes the
+ * skill-side copies. This mirrors the Story #4162 pattern established by
+ * `decomposer-prompts.js` for the decompose prompt: one rendered carrier,
+ * no second verbatim copy to drift.
+ */
+
+/**
+ * The Tech Spec authoring system prompt (verbatim from the
+ * `epic-plan-spec-author` SKILL's authoritative block).
+ *
+ * @returns {string}
+ */
+export function renderTechSpecSystemPrompt() {
+  return TECH_SPEC_SYSTEM_PROMPT;
+}
+
+/**
+ * The Acceptance Spec authoring system prompt (verbatim from the
+ * `epic-plan-spec-author` SKILL's authoritative block).
+ *
+ * @returns {string}
+ */
+export function renderAcceptanceSpecSystemPrompt() {
+  return ACCEPTANCE_SPEC_SYSTEM_PROMPT;
+}
+
+const TECH_SPEC_SYSTEM_PROMPT = `You are an expert Engineering Architect.
+Your job is to convert an Epic into a Technical Specification for implementation.
+
+The Tech Spec should outline:
+1. Delivery Slicing — propose how the Epic's enumerated capabilities cluster into shippable Stories. This count is a CEILING, not a target: the Phase 8 consolidation pass may merge below your proposed count when slices form dependent single-consumer chains, but never splits above it. Do NOT coarsen the Epic enumeration to produce this; the grouping recommendation is the granularity lever.
+2. Architecture & Design
+3. Data Models (if any)
+4. API Changes (if any)
+5. Core Components
+6. Security & Privacy Considerations
+
+CRITICAL REQUIREMENTS:
+- Respond ONLY with valid Markdown.
+- Do not use top-level <h1> (# ) tags. Open the document with the \`## Delivery Slicing\` section — it is the primary input to Phase 8 consolidation, so author it first and hang the rest of the spec off it.
+- Do NOT restate the Epic's Context, Goal, or Scope — your output lands as sections of the same Epic body, which travels into every downstream story agent's prompt, so any restatement is pure duplication and a drift risk. If a brief technical orientation is genuinely useful, add an optional \`## Technical Overview\` of no more than 2–3 sentences that names the *technical approach* only (which subsystems are touched and reused); never re-narrate the problem statement, goals, or scope.
+- Format architectural decisions clearly with bullet points.
+- Author the \`## Delivery Slicing\` section as a markdown table with columns \`Slice | What ships | Independent?\`, using noun-phrase slice names (e.g. "Foundation", "Transport seam", "Send helper") that map onto Feature titles. "Independent?" answers: can this slice ship to production and provide value without the next slice landing? A slice you mark "Independent? No" MUST carry a one-line justification (parallelism, risk isolation, or delivery-envelope pressure); an unjustified dependent single-consumer slice folds into its consumer by default rather than shipping as its own Story.`;
+
+const ACCEPTANCE_SPEC_SYSTEM_PROMPT = `You are an expert Acceptance Engineer.
+Your job is to convert an Epic and a Tech Spec into a structured Acceptance Specification that drives features-first BDD authoring.
+
+The Acceptance Spec should outline:
+1. Acceptance Table — one row per user-visible outcome, expressed as a Markdown table with columns: AC ID | Outcome | Feature File | Scenario | Disposition
+2. Stable AC IDs — assign AC-1, AC-2, ... in document order; reuse the same ID across re-plans when an Outcome is materially unchanged so scenario tags (@ac-N) stay aligned
+3. Disposition — tag each row with one of: new | updated | unchanged
+
+The Epic body's \`## Acceptance Criteria\` bullets are the single source of truth for what the spec verifies. Your table does not re-invent criteria — it anchors each one to a specific Epic AC bullet.
+
+CRITICAL REQUIREMENTS:
+- Respond ONLY with valid Markdown.
+- Do not use top-level <h1> (# ) tags. Start with ## Acceptance Table — the table lands as a section of the Epic body, so it must NOT reuse the Epic's own ## Acceptance Criteria heading.
+- Every AC row MUST have a stable AC ID of the form AC-<n> (AC-1, AC-2, ...) — do not reorder IDs across re-plans; new ACs get fresh sequential IDs.
+- Every AC row MUST carry a Disposition value from the enum: new | updated | unchanged. (At Epic close, the acceptance reconciler overwrites Disposition with the verification outcome — satisfied | pending | missing — inside this section only; on re-plan, reset each row to the authoring enum.)
+- Each Outcome MUST be a **terse restatement keyed to a specific Epic \`## Acceptance Criteria\` bullet** — lead the Outcome with the bullet's anchor (its quoted lead phrase or an explicit "Epic AC N" index) and keep the rest to a single user-visible behaviour. Do NOT re-elaborate the Epic bullet in independent words: a free-standing Outcome that paraphrases the criterion without naming the bullet it verifies is forbidden, because it drifts from the Epic silently. No DB assertions, no HTTP status codes, no internal implementation details.
+- Where one Epic AC bullet genuinely expands into several user-visible outcomes, emit one row per outcome and declare the split on each — e.g. lead with "splits Epic AC 3" — so the fan-out is explicit rather than hidden.
+- Anchor coverage MUST be complete and auditable: every Epic AC bullet MUST be covered by at least one row, and every row MUST anchor to an Epic AC bullet. Flag divergence in the authored spec instead of dropping it — if an Epic AC bullet has no corresponding row, or a row has no Epic anchor, call it out explicitly (a note beneath the table) rather than silently omitting the bullet or emitting an unanchored row.
+- Cite proposed feature file paths under tests/features/** so Phase 8 can scaffold matching scenarios.
+- Acceptance Outcomes MUST NOT prescribe a commit subject that begins with a non-Conventional-Commits prefix (allowed leading types: feat|fix|chore|refactor|perf|docs|style|test|build|ci|revert). The legacy \`baseline-refresh\` token used as a leading subject prescription is forbidden — commitlint will reject it at commit time, and the decompose-time validator (\`ticket-validator.js\` → \`validateAcceptanceSubjectPrefix\`) will reject the decompose with \`code: 'forbidden-subject-prefix'\`. Use a Conventional-Commits subject (e.g. \`chore(baselines): refresh ...\`) and a body trailer (e.g. \`baseline-refresh: true\` — trailer with a value, not a subject prefix) when a machine-readable marker is needed. See Epic #2501 for rationale.`;

--- a/.agents/scripts/plan-context.js
+++ b/.agents/scripts/plan-context.js
@@ -1,0 +1,187 @@
+#!/usr/bin/env node
+/* node:coverage ignore file */
+
+/**
+ * plan-context.js — step 1 of the collapsed `/plan` pipeline (Epic #4474,
+ * M3 PR2): the single emit-context CLI.
+ *
+ * Folds the two `--emit-context` halves of the 12-phase pipeline
+ * (`epic-plan-spec.js --emit-context` + `epic-plan-decompose.js
+ * --emit-context`) plus the three previously-no-CLI library calls
+ * (`findSimilarOpenEpics`, clarity scoring, re-plan detection) into ONE
+ * stdout-pure JSON envelope. The existing CLIs are untouched — they stay
+ * available in parallel until the PR5/PR7 cutover retires them.
+ *
+ * Two entry forms (exactly one is required):
+ *
+ *   --epic <id>          Existing-Epic mode. Envelope carries `epic`,
+ *                        `clarity` (Epic Clarity Gate rubric), `replan`
+ *                        (already-planned signals) and `planState`.
+ *
+ *   --one-pager <path>   Ideation mode — the Epic does not exist yet
+ *                        (creation moves to the persist half). Envelope
+ *                        carries `onePager` and `duplicates[]` (cross-Epic
+ *                        dup search). No clarity score: the ideation path
+ *                        is definitionally clear.
+ *
+ * Flags:
+ *   --pretty         Pretty-print the JSON envelope.
+ *   --full-context   Bypass the planning-context budget (unbounded body).
+ *
+ * stdout is reserved for the JSON envelope (Story #2278 discipline):
+ * `routeAllOutputToStderr()` runs before any pipeline code so a captured
+ * file is unconditionally parseable by `JSON.parse`.
+ *
+ * Exit codes:
+ *   0 — envelope emitted.
+ *   1 — fatal error (see stderr).
+ */
+
+// Fail-fast if the framework's runtime deps are not installed — must be the
+// first import so the check runs before any third-party-importing sibling
+// module is evaluated (Story #3432).
+import './lib/runtime-deps/ensure-installed.js';
+import { parseArgs } from 'node:util';
+import { runAsCli } from './lib/cli-utils.js';
+import {
+  resolveConfig,
+  validateOrchestrationConfig,
+} from './lib/config-resolver.js';
+import { routeAllOutputToStderr } from './lib/Logger.js';
+import { buildPlanContext } from './lib/orchestration/plan-context.js';
+import { recordPlanInvocation } from './lib/orchestration/plan-metrics.js';
+import { createProvider } from './lib/provider-factory.js';
+
+/**
+ * Build the envelope and write it to `stdout` as a single JSON line
+ * (or pretty-printed with --pretty). Exported for tests: the stdout-purity
+ * test injects a fake provider and a capture stream and asserts the
+ * captured output is exactly one `JSON.parse`-able payload.
+ *
+ * @param {{
+ *   mode: 'epic'|'one-pager',
+ *   epicId?: number,
+ *   onePagerPath?: string,
+ *   onePagerContent?: string,
+ *   provider: object,
+ *   config: object,
+ *   settings: object,
+ *   fullContext?: boolean,
+ *   pretty?: boolean,
+ *   cwd?: string,
+ *   stdout?: { write: (chunk: string) => void },
+ * }} args
+ * @returns {Promise<object>} the emitted envelope.
+ */
+export async function emitPlanContext({
+  mode,
+  epicId,
+  onePagerPath,
+  onePagerContent,
+  provider,
+  config,
+  settings,
+  fullContext = false,
+  pretty = false,
+  cwd,
+  stdout = process.stdout,
+}) {
+  const envelope = await buildPlanContext({
+    mode,
+    epicId,
+    onePagerPath,
+    onePagerContent,
+    provider,
+    config,
+    settings,
+    fullContext,
+    cwd,
+  });
+  const json = pretty
+    ? JSON.stringify(envelope, null, 2)
+    : JSON.stringify(envelope);
+  stdout.write(`${json}\n`);
+  return envelope;
+}
+
+async function main() {
+  const { values } = parseArgs({
+    options: {
+      epic: { type: 'string' },
+      'one-pager': { type: 'string' },
+      pretty: { type: 'boolean', default: false },
+      'full-context': { type: 'boolean', default: false },
+    },
+    strict: true,
+  });
+
+  const hasEpic = typeof values.epic === 'string' && values.epic.length > 0;
+  const hasOnePager =
+    typeof values['one-pager'] === 'string' && values['one-pager'].length > 0;
+  if (hasEpic === hasOnePager) {
+    throw new Error(
+      'Pass exactly one of --epic <id> or --one-pager <path>. ' +
+        '(--epic: existing-Epic mode; --one-pager: ideation mode.)',
+    );
+  }
+
+  let epicId;
+  if (hasEpic) {
+    epicId = Number.parseInt(values.epic, 10);
+    if (!Number.isInteger(epicId)) {
+      throw new Error(
+        `--epic must be a numeric issue id (got "${values.epic}").`,
+      );
+    }
+  }
+
+  // stdout is reserved for the JSON envelope: flip every Logger sink that
+  // could land on stdout to stderr BEFORE any pipeline code runs
+  // (Story #2278 — the same guarantee `epic-plan-spec.js --emit-context`
+  // gives; this CLI is emit-only so the flip is unconditional).
+  routeAllOutputToStderr();
+
+  let config;
+  let settings;
+  try {
+    config = resolveConfig();
+    // `settings` retains the legacy bag shape `buildAuthoringContext` and
+    // friends consume: `{ baseBranch, paths, planning, docsContextFiles }`.
+    settings = {
+      baseBranch: config.project?.baseBranch,
+      paths: config.project?.paths,
+      planning: config.planning,
+      docsContextFiles: config.project?.docsContextFiles,
+    };
+    validateOrchestrationConfig(config);
+  } catch (err) {
+    throw new Error(`Config schema validation failed:\n${err.message}`);
+  }
+  const provider = createProvider(config);
+
+  // Plan-metrics ledger (#4474 PR1): stamp entry/exit + mode so the folded
+  // emit surface is measured against the 12-phase baseline. One-pager mode
+  // has no Epic yet, so the record routes to the standalone stream
+  // (epicId null) exactly like `story-plan.js`.
+  await recordPlanInvocation(
+    {
+      cli: 'plan-context',
+      mode: hasEpic ? 'epic' : 'one-pager',
+      epicId: hasEpic ? epicId : null,
+      config,
+    },
+    () =>
+      emitPlanContext({
+        mode: hasEpic ? 'epic' : 'one-pager',
+        epicId,
+        onePagerPath: hasOnePager ? values['one-pager'] : undefined,
+        provider,
+        config,
+        settings,
+        fullContext: values['full-context'],
+        pretty: values.pretty,
+      }),
+  );
+}
+
+runAsCli(import.meta.url, main, { source: 'plan-context' });

--- a/tests/plan-context.test.js
+++ b/tests/plan-context.test.js
@@ -1,0 +1,476 @@
+/**
+ * tests/plan-context.test.js — unit tests for the folded planner-context
+ * envelope (Epic #4474, M3 PR2 — `/plan` collapse step 1).
+ *
+ * Covers the design's named PR2 test surface:
+ *  - stdout purity: everything the emit path writes to stdout is exactly
+ *    one `JSON.parse`-able payload (Logger output routed to stderr).
+ *  - envelope schema snapshot: the sorted key set per mode.
+ *  - mode-specific field presence: `clarity`/`replan` only in epic mode;
+ *    `duplicates`/`onePager` only in one-pager mode.
+ *  - dup-search fold parity: envelope `duplicates[]` deep-equals a direct
+ *    `findSimilarOpenEpics` call over the same provider + one-pager.
+ *  - envelope byte ceiling: serialized envelopes stay under
+ *    `PLAN_CONTEXT_ENVELOPE_BYTE_CEILING`, including with a body at the
+ *    planning-context budget cap.
+ *  - systemPrompts fold: spec/acceptance render verbatim from
+ *    `lib/templates/spec-author-prompts.js`; decompose matches the existing
+ *    `buildDecomposerSystemPrompt` carrier.
+ *  - deliveryShapeSignal: advisory recommendation + reasons per the
+ *    slicing-table / scope-enumeration heuristics, fan-out by default.
+ */
+
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { findSimilarOpenEpics } from '../.agents/scripts/lib/duplicate-search.js';
+import { buildDecomposerSystemPrompt } from '../.agents/scripts/lib/orchestration/epic-plan-decompose/phases/context.js';
+import {
+  buildDeliveryShapeSignal,
+  buildPlanContext,
+  buildReplanSignal,
+  buildSystemPrompts,
+  PLAN_CONTEXT_ENVELOPE_BYTE_CEILING,
+  TICKET_SCHEMA_DESCRIPTOR,
+} from '../.agents/scripts/lib/orchestration/plan-context.js';
+import {
+  renderAcceptanceSpecSystemPrompt,
+  renderTechSpecSystemPrompt,
+} from '../.agents/scripts/lib/templates/spec-author-prompts.js';
+import { emitPlanContext } from '../.agents/scripts/plan-context.js';
+
+const CLEAR_EPIC_BODY = `# Widget Epic
+
+## Context
+
+Users drop off during onboarding.
+
+## Goal
+
+Raise activation.
+
+## Non-Goals
+
+- Redesigning billing.
+
+## Scope
+
+- improve widget onboarding flow
+- activation email
+- progress meter
+
+## Acceptance Criteria
+
+- [ ] Activation rate is measured.
+- [ ] Onboarding completes in one session.
+`;
+
+const ONE_PAGER = `# Widget onboarding
+
+## Context
+
+Users drop off during onboarding.
+
+## Scope
+
+- improve widget onboarding flow
+- activation email
+`;
+
+const OPEN_EPICS = [
+  {
+    id: 9,
+    title: 'Improve widget onboarding flow',
+    body: '## Scope\n- widget onboarding improvements for user activation',
+  },
+  {
+    id: 11,
+    title: 'Unrelated database migration tooling',
+    body: '## Scope\n- migrate schema pipeline',
+  },
+];
+
+/** Minimal provider double covering every read the envelope build makes. */
+function buildProvider({ body = CLEAR_EPIC_BODY, openStories = [] } = {}) {
+  return {
+    async getEpic(id) {
+      return { id, title: 'Widget Epic', body };
+    },
+    async getTickets(_epicId, _filters) {
+      return openStories;
+    },
+    async getEpics(_filters) {
+      return OPEN_EPICS;
+    },
+    async getTicketComments(_id) {
+      return [];
+    },
+  };
+}
+
+const EPIC_MODE_KEYS = [
+  'bddRunner',
+  'bddScenarios',
+  'clarity',
+  'codebaseSnapshot',
+  'deliveryShapeSignal',
+  'docsContext',
+  'epic',
+  'maxTickets',
+  'maxTokenBudget',
+  'memoryFreshness',
+  'mode',
+  'planState',
+  'preflightCeilings',
+  'priorFeedback',
+  'replan',
+  'riskHeuristics',
+  'systemPrompts',
+  'ticketSchema',
+];
+
+const ONE_PAGER_MODE_KEYS = [
+  'bddRunner',
+  'bddScenarios',
+  'codebaseSnapshot',
+  'deliveryShapeSignal',
+  'docsContext',
+  'duplicates',
+  'maxTickets',
+  'maxTokenBudget',
+  'memoryFreshness',
+  'mode',
+  'onePager',
+  'planState',
+  'preflightCeilings',
+  'priorFeedback',
+  'riskHeuristics',
+  'systemPrompts',
+  'ticketSchema',
+];
+
+describe('plan-context envelope schema (design §1 step 1)', () => {
+  it('epic mode emits exactly the epic-mode key set', async () => {
+    const env = await buildPlanContext({
+      mode: 'epic',
+      epicId: 7,
+      provider: buildProvider(),
+      config: {},
+      settings: {},
+    });
+    assert.deepEqual(Object.keys(env).sort(), EPIC_MODE_KEYS);
+    assert.equal(env.mode, 'epic');
+    assert.equal(env.epic.id, 7);
+  });
+
+  it('one-pager mode emits exactly the one-pager-mode key set', async () => {
+    const env = await buildPlanContext({
+      mode: 'one-pager',
+      onePagerContent: ONE_PAGER,
+      onePagerPath: 'temp/one-pager.md',
+      provider: buildProvider(),
+      config: { github: { owner: 'o', repo: 'r' } },
+      settings: {},
+    });
+    assert.deepEqual(Object.keys(env).sort(), ONE_PAGER_MODE_KEYS);
+    assert.equal(env.mode, 'one-pager');
+    assert.equal(env.onePager.content, ONE_PAGER);
+    assert.equal(env.planState, null);
+  });
+
+  it('rejects an unknown mode and a non-numeric epic id', async () => {
+    await assert.rejects(
+      () => buildPlanContext({ mode: 'bogus', provider: buildProvider() }),
+      /unknown mode/,
+    );
+    await assert.rejects(
+      () => buildPlanContext({ mode: 'epic', provider: buildProvider() }),
+      /numeric epicId/,
+    );
+  });
+});
+
+describe('plan-context mode-specific field presence', () => {
+  it('clarity and replan appear only in epic mode', async () => {
+    const epicEnv = await buildPlanContext({
+      mode: 'epic',
+      epicId: 7,
+      provider: buildProvider(),
+      config: {},
+      settings: {},
+    });
+    assert.equal(epicEnv.clarity.verdict, 'clear');
+    assert.equal(epicEnv.replan.alreadyPlanned, false);
+    assert.ok(
+      !('duplicates' in epicEnv),
+      'duplicates must not leak into epic mode',
+    );
+    assert.ok(
+      !('onePager' in epicEnv),
+      'onePager must not leak into epic mode',
+    );
+
+    const opEnv = await buildPlanContext({
+      mode: 'one-pager',
+      onePagerContent: ONE_PAGER,
+      provider: buildProvider(),
+      config: {},
+      settings: {},
+    });
+    assert.ok(
+      !('clarity' in opEnv),
+      'clarity must not leak into one-pager mode',
+    );
+    assert.ok(!('replan' in opEnv), 'replan must not leak into one-pager mode');
+    assert.ok(Array.isArray(opEnv.duplicates));
+  });
+
+  it('epic mode flags an already-planned Epic via replan signals', async () => {
+    const plannedBody = `${CLEAR_EPIC_BODY}\n## Delivery Slicing\n\n| Slice | What ships | Independent? |\n|---|---|---|\n| Foundation | core | Yes |\n| Surface | api | Yes |\n| Polish | docs | Yes |\n`;
+    const env = await buildPlanContext({
+      mode: 'epic',
+      epicId: 7,
+      provider: buildProvider({
+        body: plannedBody,
+        openStories: [{ id: 101 }, { id: 102 }],
+      }),
+      config: {},
+      settings: {},
+    });
+    assert.equal(env.replan.alreadyPlanned, true);
+    assert.equal(env.replan.openStoryCount, 2);
+  });
+});
+
+describe('plan-context dup-search fold parity vs library', () => {
+  it('envelope duplicates[] deep-equals a direct findSimilarOpenEpics call', async () => {
+    const provider = buildProvider();
+    const config = { github: { owner: 'o', repo: 'r' } };
+    const env = await buildPlanContext({
+      mode: 'one-pager',
+      onePagerContent: ONE_PAGER,
+      provider,
+      config,
+      settings: {},
+    });
+    const direct = await findSimilarOpenEpics({
+      onePager: ONE_PAGER,
+      provider,
+      owner: 'o',
+      repo: 'r',
+    });
+    assert.ok(direct.length > 0, 'fixture must produce at least one candidate');
+    assert.deepEqual(env.duplicates, direct);
+  });
+
+  it('degrades to an empty duplicates[] when the provider listing fails', async () => {
+    const provider = buildProvider();
+    provider.getEpics = async () => {
+      throw new Error('rate limited');
+    };
+    const env = await buildPlanContext({
+      mode: 'one-pager',
+      onePagerContent: ONE_PAGER,
+      provider,
+      config: {},
+      settings: {},
+    });
+    assert.deepEqual(env.duplicates, []);
+  });
+});
+
+describe('plan-context systemPrompts fold', () => {
+  it('renders spec/acceptance from spec-author-prompts.js and decompose from the existing carrier', async () => {
+    const env = await buildPlanContext({
+      mode: 'epic',
+      epicId: 7,
+      provider: buildProvider(),
+      config: { planning: { riskHeuristics: ['touches auth'] } },
+      settings: {},
+    });
+    assert.equal(env.systemPrompts.spec, renderTechSpecSystemPrompt());
+    assert.equal(
+      env.systemPrompts.acceptance,
+      renderAcceptanceSpecSystemPrompt(),
+    );
+    assert.equal(
+      env.systemPrompts.decompose,
+      buildDecomposerSystemPrompt(['touches auth'], {
+        maxTickets: env.maxTickets,
+        maxTokenBudget: env.maxTokenBudget,
+        epicId: 7,
+      }),
+    );
+    assert.deepEqual(env.riskHeuristics, ['touches auth']);
+    assert.match(env.systemPrompts.spec, /Engineering Architect/);
+    assert.match(env.systemPrompts.acceptance, /Acceptance Engineer/);
+    // The envelope's systemPrompts are exactly what the exported helper
+    // renders for the same inputs, and the ticketSchema is the shared
+    // frozen descriptor.
+    assert.deepEqual(
+      env.systemPrompts,
+      buildSystemPrompts({
+        heuristics: ['touches auth'],
+        maxTickets: env.maxTickets,
+        maxTokenBudget: env.maxTokenBudget,
+        epicId: 7,
+      }),
+    );
+    assert.equal(env.ticketSchema, TICKET_SCHEMA_DESCRIPTOR);
+    assert.equal(env.ticketSchema.itemFields.type.includes('story'), true);
+  });
+});
+
+describe('plan-context deliveryShapeSignal (advisory, #4475 heuristics)', () => {
+  it('recommends single for a delivery-slicing table of ≤ 2 slices', () => {
+    const body = `## Delivery Slicing\n\n| Slice | What ships | Independent? |\n|---|---|---|\n| All of it | everything | Yes |\n`;
+    const signal = buildDeliveryShapeSignal({ body });
+    assert.equal(signal.recommendation, 'single');
+    assert.equal(signal.advisory, true);
+    assert.match(signal.reasons[0], /one-pass-sized/);
+  });
+
+  it('recommends single for a pure dependent chain (zero fan-out parallelism)', () => {
+    const body = `## Delivery Slicing\n\n| Slice | What ships | Independent? |\n|---|---|---|\n| A | a | Yes |\n| B | b | No — needs A |\n| C | c | No — needs B |\n| D | d | No — needs C |\n`;
+    const signal = buildDeliveryShapeSignal({ body });
+    assert.equal(signal.recommendation, 'single');
+    assert.match(signal.reasons[0], /pure dependent chain/);
+  });
+
+  it('recommends fan-out for a slicing table with independent parallelism', () => {
+    const body = `## Delivery Slicing\n\n| Slice | What ships | Independent? |\n|---|---|---|\n| A | a | Yes |\n| B | b | Yes |\n| C | c | Yes |\n`;
+    const signal = buildDeliveryShapeSignal({ body });
+    assert.equal(signal.recommendation, 'fan-out');
+  });
+
+  it('defaults to fan-out when there is no sizing signal at all', () => {
+    const signal = buildDeliveryShapeSignal({ body: 'freeform prose only' });
+    assert.equal(signal.recommendation, 'fan-out');
+    assert.match(signal.reasons[0], /defaulting to fan-out/);
+  });
+
+  it('uses the scope enumeration when no slicing table exists', () => {
+    const single = buildDeliveryShapeSignal({
+      body: '## Scope\n- one thing\n- another\n',
+    });
+    assert.equal(single.recommendation, 'single');
+    const fanOut = buildDeliveryShapeSignal({
+      body: '## Scope\n- a\n- b\n- c\n- d\n',
+    });
+    assert.equal(fanOut.recommendation, 'fan-out');
+  });
+});
+
+describe('plan-context replan signal tolerance', () => {
+  it('degrades openStoryCount to null when the children listing fails', async () => {
+    const provider = buildProvider();
+    provider.getTickets = async () => {
+      throw new Error('boom');
+    };
+    const signal = await buildReplanSignal({
+      epicBody: CLEAR_EPIC_BODY,
+      provider,
+      epicId: 7,
+    });
+    assert.equal(signal.openStoryCount, null);
+    assert.equal(signal.alreadyPlanned, false);
+  });
+});
+
+describe('plan-context stdout purity (Story #2278 discipline)', () => {
+  it('the emit path writes exactly one JSON.parse-able payload to stdout', async () => {
+    // Capture everything that would land on the process stdout fd —
+    // both the injected envelope stream and any stray console.log from
+    // the folded builders (Logger routes to console.error once
+    // routeAllOutputToStderr() has run; the CLI calls it before building).
+    const { routeAllOutputToStderr } = await import(
+      '../.agents/scripts/lib/Logger.js'
+    );
+    routeAllOutputToStderr();
+
+    let captured = '';
+    const capture = {
+      write(chunk) {
+        captured += chunk;
+        return true;
+      },
+    };
+    const originalLog = console.log;
+    const strayStdout = [];
+    console.log = (...args) => strayStdout.push(args.join(' '));
+    let envelope;
+    try {
+      envelope = await emitPlanContext({
+        mode: 'epic',
+        epicId: 7,
+        provider: buildProvider(),
+        config: {},
+        settings: {},
+        stdout: capture,
+      });
+    } finally {
+      console.log = originalLog;
+    }
+
+    assert.deepEqual(
+      strayStdout,
+      [],
+      `no builder may write to stdout during the envelope build: ${strayStdout.join('\n')}`,
+    );
+    const lines = captured.split('\n').filter((l) => l.length > 0);
+    assert.equal(lines.length, 1, 'exactly one stdout line');
+    const parsed = JSON.parse(lines[0]);
+    assert.deepEqual(parsed, JSON.parse(JSON.stringify(envelope)));
+    assert.equal(parsed.mode, 'epic');
+  });
+});
+
+describe('plan-context envelope byte ceiling (PR2 named risk)', () => {
+  it('epic-mode and one-pager-mode envelopes stay under the ceiling', async () => {
+    const epicEnv = await buildPlanContext({
+      mode: 'epic',
+      epicId: 7,
+      provider: buildProvider(),
+      config: {},
+      settings: {},
+    });
+    const opEnv = await buildPlanContext({
+      mode: 'one-pager',
+      onePagerContent: ONE_PAGER,
+      provider: buildProvider(),
+      config: {},
+      settings: {},
+    });
+    for (const [name, env] of [
+      ['epic', epicEnv],
+      ['one-pager', opEnv],
+    ]) {
+      const bytes = Buffer.byteLength(JSON.stringify(env), 'utf-8');
+      assert.ok(
+        bytes < PLAN_CONTEXT_ENVELOPE_BYTE_CEILING,
+        `${name} envelope is ${bytes} bytes — ceiling is ${PLAN_CONTEXT_ENVELOPE_BYTE_CEILING}`,
+      );
+    }
+  });
+
+  it('holds even when the Epic body sits at the planning-context budget cap', async () => {
+    // A body larger than planningContext.maxBytes (50 KB default) downgrades
+    // to the applyBudget summary representation — the ceiling must hold for
+    // the worst legal case, not just tiny fixtures.
+    const hugeBody = `${CLEAR_EPIC_BODY}\n## Appendix\n\n${'lorem ipsum dolor sit amet consectetur. '.repeat(4000)}`;
+    const env = await buildPlanContext({
+      mode: 'epic',
+      epicId: 7,
+      provider: buildProvider({ body: hugeBody }),
+      config: {},
+      settings: {},
+    });
+    const bytes = Buffer.byteLength(JSON.stringify(env), 'utf-8');
+    assert.ok(
+      bytes < PLAN_CONTEXT_ENVELOPE_BYTE_CEILING,
+      `budget-capped envelope is ${bytes} bytes — ceiling is ${PLAN_CONTEXT_ENVELOPE_BYTE_CEILING}`,
+    );
+    // The budget must have engaged (body over 50 KB cannot ride through full).
+    assert.equal(env.epic.body, null);
+    assert.ok(env.epic.bodySummary, 'expected the applyBudget summary mode');
+  });
+});


### PR DESCRIPTION
PR2 of the M3 `/plan`-collapse design ([#4474](https://github.com/dsj1984/mandrel/issues/4474), design comment §1 Step 1 / §6 PR2). New stdout-pure emit CLI folding both `--emit-context` halves + the three previously-no-CLI library calls into ONE envelope. **Existing CLIs untouched** (parallel availability until PR5/PR7). References — does not close — #4474.

## What ships

- **`.agents/scripts/plan-context.js`** — `--epic <id>` | `--one-pager <path>` (exactly one), `--pretty`, `--full-context`. `routeAllOutputToStderr()` runs before any pipeline code (Story #2278 discipline). Stamped into the PR1 (#4487) plan-metrics ledger (`cli: 'plan-context'`; one-pager mode routes to the standalone stream, epicId null).
- **`lib/orchestration/plan-context.js`** — `buildPlanContext` folds `buildAuthoringContext` (one Epic fetch via a new additive `opts.epic` prefetch seam — the split pipeline fetched twice), the decompose-context fields (`maxTickets`/`maxTokenBudget`/`preflightCeilings`/`riskHeuristics`), `findSimilarOpenEpics` → `duplicates[]`, clarity scoring, re-plan signals, `epic-plan-state`, a `ticketSchema` descriptor, and the advisory `deliveryShapeSignal`.
- **`lib/templates/spec-author-prompts.js`** — Tech Spec + Acceptance Spec system prompts lifted **verbatim** (programmatically extracted and byte-equality-verified) from the `epic-plan-spec-author` SKILL's "(authoritative)" blocks — the M3/M8 handshake. The skill file itself is untouched (M8/#4479's surface). Decompose prompt reuses the existing `decomposer-prompts.js` carrier.

## Envelope schema (design §1)

| Field | epic mode | one-pager mode |
| --- | --- | --- |
| `mode` | `"epic"` | `"one-pager"` |
| `epic` / `onePager` | `epic` (applyBudget-bounded body + planningSections) | `onePager { path, content }` |
| `clarity` | ✅ (Epic Clarity Gate rubric — same body fetch) | — (ideation is definitionally clear) |
| `replan` | ✅ `{ alreadyPlanned, planningSections, openStoryCount }` | — |
| `duplicates[]` | — | ✅ (`findSimilarOpenEpics`, degrade-to-empty on listing failure) |
| `planState` | epic-plan-state comment (tolerant read) | `null` |
| `docsContext` | digest-first pointer (unchanged path) | `digest-inline` (no per-Epic temp dir exists yet) |
| `codebaseSnapshot`, `bddRunner`, `bddScenarios`, `memoryFreshness`, `priorFeedback` | ✅ | ✅ (grounded in the one-pager prose) |
| `ticketSchema`, `maxTickets`, `maxTokenBudget`, `preflightCeilings`, `riskHeuristics` | ✅ | ✅ |
| `systemPrompts` | `{ spec, acceptance, decompose }` rendered from `lib/templates/*` | same (`epicId: null` in decompose render) |
| `deliveryShapeSignal` | `{ recommendation: "single"\|"fan-out", reasons[], advisory: true }` | same |

`deliveryShapeSignal` derives from #4475's named signals (scope-triage-style size heuristics): Delivery Slicing slice count (≤ 2 → single), pure dependent chain (every non-first slice "Independent? No" → single — the N=2 bench zero-parallelism finding), else scope-enumeration count; **fan-out by default for every ambiguous case, advisory only, no routing behavior change** (deliver-side reader is #4475 / PR4 scope).

## Fold parity evidence

- **Dup search**: test asserts envelope `duplicates[]` `deepEqual`s a direct `findSimilarOpenEpics` call over the same provider + one-pager (and degrade-to-`[]` on provider failure).
- **Prompts**: `systemPrompts.spec`/`.acceptance` assert byte-equality with the `spec-author-prompts.js` renders (themselves verified byte-identical to the SKILL's authoritative blocks at extraction time); `systemPrompts.decompose` asserts equality with the existing `buildDecomposerSystemPrompt` carrier including the risk-heuristics suffix.
- **Authoring/decompose halves**: epic mode reuses `buildAuthoringContext` itself (no copy) plus the same `getLimits`/`resolvePreflightCeilings`/heuristics resolution the decompose context uses.

## Envelope size (PR2 named risk)

Measured folded envelopes on this repo: ~42 KB (epic and one-pager fixtures, real codebase snapshot). Ceiling asserted in test: **`PLAN_CONTEXT_ENVELOPE_BYTE_CEILING = 256 000` bytes** (~64K tokens at the ≈4-char/token estimate) — >2× headroom over a worst-case `applyBudget`-capped body (50 KB) + snapshot + prompts, an order of magnitude under the session budget. A dedicated test also pins the ceiling with an over-budget Epic body (asserts the summary downgrade engaged).

## Tests

- `tests/plan-context.test.js` — 17 tests: stdout purity (`JSON.parse` of captured output + stray-`console.log` guard), envelope key-set snapshot per mode, mode-specific presence (clarity/replan never leak into one-pager; duplicates/onePager never into epic), dup-search parity, deliveryShapeSignal heuristics (5 cases), replan tolerance, byte ceiling (2 cases).
- Full suite: **10 140 pass / 0 fail** (10 144 tests, 4 skipped). Lint + docs:check green; `check-dead-exports` / `check-arch-cycles` / `check-context-budget` / `check-baselines` (crap, maintainability, duplication) all PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
