### PR TITLE
feat(plan): delivery-shape modes — spec-only, single-delivery marker, amend delta (refs #4474)

### DIFF
--- a/.agents/schemas/risk-verdict.schema.json
+++ b/.agents/schemas/risk-verdict.schema.json
@@ -47,7 +47,20 @@
       "type": "string",
       "minLength": 1,
       "description": "One-paragraph overall risk narrative for the audit trail (the rationale the retired regex classifier could never produce)."
+    },
+    "deliveryShape": {
+      "type": "string",
+      "enum": ["fan-out", "single"],
+      "description": "Planner-judged delivery shape for the Epic (Epic #4474 PR4, design §2 mode matrix). 'fan-out' persists a Story tree (the default when the field is absent — existing verdicts stay valid); 'single' is the spec-only single-delivery mode: no tickets are authored, the ticket validator + DAG are skipped, and plan-persist applies the delivery::single routing marker instead of a Story tree. The marker is inert until #4475 lands the deliver-side reader."
+    },
+    "deliveryShapeRationale": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Concrete justification for the declared deliveryShape, grounded in the Delivery Slicing table (slice count / chain shape). Required whenever deliveryShape is present; surfaced as the routingReasons of the single-mode plan summary."
     }
+  },
+  "dependentRequired": {
+    "deliveryShape": ["deliveryShapeRationale"]
   },
   "additionalProperties": false
 }

--- a/.agents/scripts/lib/label-constants.js
+++ b/.agents/scripts/lib/label-constants.js
@@ -147,6 +147,20 @@ export const PLANNING_LABELS = {
  */
 export const PLANNING_HEALTHCHECK_WAIVED = 'planning::healthcheck-waived';
 
+/**
+ * Delivery-routing labels (Epic #4474 PR4 — design §2 mode matrix).
+ * `delivery::single` marks an Epic whose plan was persisted in the
+ * spec-only single-delivery mode: no Story tree exists and the Delivery
+ * Slicing table of the Epic body's Tech Spec is the audit trail.
+ * `plan-persist.js` applies it when the risk verdict declares
+ * `deliveryShape: "single"`; a fan-out re-persist over the same Epic
+ * removes it. The marker is **inert until #4475** lands the deliver-side
+ * reader — nothing in the deliver path consumes it yet.
+ */
+export const DELIVERY_LABELS = {
+  SINGLE: 'delivery::single',
+};
+
 /** Palette for the taxonomy; consumed by label-taxonomy.js. */
 export const LABEL_COLORS = {
   TYPE: '#7057FF',
@@ -155,4 +169,5 @@ export const LABEL_COLORS = {
   PERSONA: '#C5DEF5',
   ACCEPTANCE: '#FBCA04',
   PLANNING: '#FEF2C0',
+  DELIVERY: '#BFD4F2',
 };

--- a/.agents/scripts/lib/label-taxonomy.js
+++ b/.agents/scripts/lib/label-taxonomy.js
@@ -12,6 +12,7 @@ import { fileURLToPath } from 'node:url';
 import {
   ACCEPTANCE_LABELS,
   AGENT_LABELS,
+  DELIVERY_LABELS,
   LABEL_COLORS,
   PERSONA_LABEL_PREFIX,
   PLANNING_LABELS,
@@ -116,6 +117,16 @@ export const LABEL_TAXONOMY = [
     color: LABEL_COLORS.PLANNING,
     description:
       'Operator override — allows agent::ready handoff despite a failing post-plan healthcheck',
+  },
+
+  // Delivery routing — applied by `plan-persist.js` when the risk verdict
+  // declares `deliveryShape: "single"` (Epic #4474 PR4). Inert until #4475
+  // lands the deliver-side reader.
+  {
+    name: DELIVERY_LABELS.SINGLE,
+    color: LABEL_COLORS.DELIVERY,
+    description:
+      'Single-delivery plan — no Story tree; the Delivery Slicing table is the audit trail (#4474/#4475)',
   },
 ];
 

--- a/.agents/scripts/lib/orchestration/plan-persist/amend.js
+++ b/.agents/scripts/lib/orchestration/plan-persist/amend.js
@@ -1,0 +1,359 @@
+/**
+ * amend.js — the `--amend` change-request delta path of the collapsed
+ * persist surface (Epic #4474 PR4, design §2 mode matrix, amend row).
+ *
+ * An amend run receives the full ticket set with every ticket carrying an
+ * `op` field:
+ *
+ *   - `add`    — a new Story; created fresh.
+ *   - `modify` — an existing Story whose contract changed; closed and
+ *                recreated (close-and-recreate is scoped to modify/close
+ *                slugs ONLY — never the whole tree, which is `--force`'s
+ *                semantics).
+ *   - `keep`   — an existing Story left byte-untouched; it participates in
+ *                the merged-set DAG validation but no provider mutation
+ *                ever targets it.
+ *   - `close`  — an existing Story dropped from the plan; closed.
+ *
+ * The DAG (and the full ticket validator) runs over the MERGED set —
+ * keeps + adds + modifies, closes excluded — so a cycle introduced by an
+ * add that depends on a kept Story that depends on a modify is caught
+ * before any GitHub call, and a dependency pointing at a closed slug fails
+ * the unknown-slug check.
+ *
+ * Close ops are destructive, so they are gated behind the same explicit
+ * confirmation contract as `epic-reconcile.js`: without `--explicit-delete`
+ * the run stops BEFORE any mutation, prints the dry-run op diff, and exits
+ * 2 ({@link AmendExplicitCloseError} carries the rendered diff; the CLI
+ * maps it onto the exit code). Non-interactive callers pass the flag.
+ *
+ * Slug → issue resolution: an explicit `id` on the ticket (the authoring
+ * envelope's open-children listing carries issue numbers) wins; otherwise
+ * the reconciler state ledger (`.agents/epics/<id>.state.json`) resolves
+ * the slug. A modify/keep/close slug that resolves nowhere is a hard error
+ * — the amend never guesses which Story it is about to close.
+ *
+ * @module lib/orchestration/plan-persist/amend
+ */
+
+import { Logger } from '../../Logger.js';
+
+/** Valid `op` values on an amend ticket. */
+const AMEND_OPS = Object.freeze(['add', 'modify', 'keep', 'close']);
+
+/**
+ * Error carrying the rendered dry-run diff for the exit-2 confirmation
+ * path (mirrors `epic-reconcile.js` EXIT_CODES.EXPLICIT_DELETE_REQUIRED).
+ */
+export class AmendExplicitCloseError extends Error {
+  /**
+   * @param {string} message
+   * @param {{ diff: string }} detail
+   */
+  constructor(message, { diff }) {
+    super(message);
+    this.name = 'AmendExplicitCloseError';
+    this.code = 'PLAN_AMEND_EXPLICIT_DELETE_REQUIRED';
+    this.diff = diff;
+  }
+}
+
+/**
+ * Partition an amend ticket set by `op`, validating the op vocabulary and
+ * slug uniqueness. Every ticket MUST carry an op — a missing op on one
+ * ticket of an amend payload is an authoring defect, not a default.
+ *
+ * @param {Array<{ slug?: string, op?: string }>} tickets
+ * @returns {{ add: object[], modify: object[], keep: object[], close: object[] }}
+ */
+export function partitionAmendTickets(tickets) {
+  const partition = { add: [], modify: [], keep: [], close: [] };
+  const seen = new Set();
+  for (const ticket of tickets) {
+    const slug = ticket?.slug;
+    if (typeof slug !== 'string' || slug.length === 0) {
+      throw new Error(
+        '[plan-persist] amend ticket without a slug — every amend ticket ' +
+          'must carry both slug and op.',
+      );
+    }
+    if (seen.has(slug)) {
+      throw new Error(
+        `[plan-persist] duplicate slug "${slug}" in the amend payload.`,
+      );
+    }
+    seen.add(slug);
+    const op = ticket?.op;
+    if (!AMEND_OPS.includes(op)) {
+      throw new Error(
+        `[plan-persist] amend ticket "${slug}" carries invalid op ` +
+          `"${op}" — expected one of ${AMEND_OPS.join(', ')}.`,
+      );
+    }
+    partition[op].push(ticket);
+  }
+  return partition;
+}
+
+/**
+ * Project the MERGED ticket set for validation and spec rendering:
+ * keeps + adds + modifies in original authoring order, closes excluded,
+ * with the amend-only `op`/`id` carrier fields stripped so the ticket
+ * validator and `renderSpec` see the exact fan-out ticket shape.
+ *
+ * @param {Array<{ op?: string }>} tickets the full amend payload
+ * @returns {object[]} merged set, op/id stripped
+ */
+export function buildMergedTicketSet(tickets) {
+  return tickets
+    .filter((t) => t?.op !== 'close')
+    .map(({ op: _op, id: _id, ...rest }) => rest);
+}
+
+/**
+ * Resolve every modify/keep/close slug to its live issue number and
+ * hard-error on any ambiguity (the "closing the wrong stories" risk):
+ *
+ *   - modify/keep/close must resolve via explicit `id` or the state
+ *     ledger mapping — no resolution is a hard error;
+ *   - an add slug must NOT already resolve to an issue (a collision means
+ *     the author meant modify, or picked a stale slug);
+ *   - resolved modify/close targets are fetched and must exist; a target
+ *     already closed on GitHub is surfaced (skipped close, not an error —
+ *     re-running an interrupted amend must stay safe).
+ *
+ * @param {{
+ *   partition: ReturnType<typeof partitionAmendTickets>,
+ *   stateMapping: Record<string, { issueNumber?: number }>,
+ *   provider: { getTicket: (id: number) => Promise<object|null> },
+ * }} args
+ * @returns {Promise<{
+ *   modify: Array<{ ticket: object, issueNumber: number, alreadyClosed: boolean }>,
+ *   keep: Array<{ ticket: object, issueNumber: number }>,
+ *   close: Array<{ ticket: object, issueNumber: number, alreadyClosed: boolean }>,
+ * }>}
+ */
+export async function resolveAmendTargets({
+  partition,
+  stateMapping,
+  provider,
+}) {
+  const mapping = stateMapping ?? {};
+  const resolveSlug = (ticket) => {
+    if (Number.isInteger(ticket.id)) return ticket.id;
+    const entry = mapping[ticket.slug];
+    if (Number.isInteger(entry?.issueNumber)) return entry.issueNumber;
+    return null;
+  };
+
+  for (const ticket of partition.add) {
+    const collision = resolveSlug(ticket);
+    if (collision !== null) {
+      throw new Error(
+        `[plan-persist] amend op "add" for slug "${ticket.slug}" collides ` +
+          `with existing issue #${collision} — use op "modify" to replace ` +
+          'it, or pick a fresh slug.',
+      );
+    }
+  }
+
+  const resolveExisting = async (ticket, op) => {
+    const issueNumber = resolveSlug(ticket);
+    if (issueNumber === null) {
+      throw new Error(
+        `[plan-persist] amend op "${op}" for slug "${ticket.slug}" resolves ` +
+          'to no existing issue (no `id` on the ticket, no state-ledger ' +
+          'mapping). Refusing to guess — carry the issue number as `id`.',
+      );
+    }
+    const issue = await provider.getTicket(issueNumber);
+    if (!issue) {
+      throw new Error(
+        `[plan-persist] amend op "${op}" for slug "${ticket.slug}" points ` +
+          `at issue #${issueNumber}, which does not exist.`,
+      );
+    }
+    return { ticket, issueNumber, alreadyClosed: issue.state === 'closed' };
+  };
+
+  const modify = [];
+  for (const t of partition.modify)
+    modify.push(await resolveExisting(t, 'modify'));
+  const close = [];
+  for (const t of partition.close)
+    close.push(await resolveExisting(t, 'close'));
+  const keep = [];
+  for (const t of partition.keep) {
+    const { ticket, issueNumber } = await resolveExisting(t, 'keep');
+    keep.push({ ticket, issueNumber });
+  }
+  return { modify, keep, close };
+}
+
+/**
+ * Render the operator-facing dry-run diff of the amend plan — printed on
+ * the exit-2 confirmation path and logged before an `--explicit-delete`
+ * apply so the destructive set is always visible.
+ *
+ * @param {{
+ *   epicId: number,
+ *   targets: Awaited<ReturnType<typeof resolveAmendTargets>>,
+ *   adds: Array<{ slug: string, title?: string }>,
+ * }} args
+ * @returns {string}
+ */
+export function renderAmendPlanDiff({ epicId, targets, adds }) {
+  const rows = [
+    ...targets.close.map(
+      (t) =>
+        `| close | \`${t.ticket.slug}\` | #${t.issueNumber} | closed${t.alreadyClosed ? ' (already closed)' : ''} |`,
+    ),
+    ...targets.modify.map(
+      (t) =>
+        `| modify | \`${t.ticket.slug}\` | #${t.issueNumber} | closed + recreated |`,
+    ),
+    ...adds.map((t) => `| add | \`${t.slug}\` | — | created |`),
+    ...targets.keep.map(
+      (t) => `| keep | \`${t.ticket.slug}\` | #${t.issueNumber} | untouched |`,
+    ),
+  ];
+  return [
+    `Amend plan for Epic #${epicId} (dry-run):`,
+    '',
+    '| Op | Slug | Issue | Effect |',
+    '| --- | --- | --- | --- |',
+    ...rows,
+  ].join('\n');
+}
+
+/**
+ * Enforce the close-op confirmation gate: when the amend plan carries
+ * close ops (including the close half of modify) affecting live issues and
+ * `--explicit-delete` was not passed, throw {@link AmendExplicitCloseError}
+ * with the rendered diff — BEFORE any mutation. Mirrors the
+ * `epic-reconcile.js` exit-2 contract.
+ *
+ * @param {{
+ *   epicId: number,
+ *   targets: Awaited<ReturnType<typeof resolveAmendTargets>>,
+ *   adds: object[],
+ *   explicitDelete: boolean,
+ * }} args
+ */
+export function enforceAmendCloseGate({
+  epicId,
+  targets,
+  adds,
+  explicitDelete,
+}) {
+  const liveCloses = [
+    ...targets.close.filter((t) => !t.alreadyClosed),
+    ...targets.modify.filter((t) => !t.alreadyClosed),
+  ];
+  if (liveCloses.length === 0 || explicitDelete) return;
+  const diff = renderAmendPlanDiff({ epicId, targets, adds });
+  const named = liveCloses
+    .map((t) => `#${t.issueNumber} (\`${t.ticket.slug}\`)`)
+    .join(', ');
+  throw new AmendExplicitCloseError(
+    `[plan-persist] amend plan would close ${liveCloses.length} live ` +
+      `issue(s): ${named}. Review the dry-run diff and re-run with ` +
+      '--explicit-delete to apply.',
+    { diff },
+  );
+}
+
+/**
+ * Apply the amend ops against the provider, in destructive-last order per
+ * slug class: closes first (their disappearance is what the operator
+ * confirmed), then modify (close old + create new), then adds. Keeps are
+ * never touched by construction — no code path here receives them.
+ *
+ * @param {{
+ *   epicId: number,
+ *   provider: {
+ *     updateTicket: (id: number, patch: object) => Promise<object>,
+ *     createTicket: (parentId: number, payload: object) => Promise<{ id: number }>,
+ *   },
+ *   targets: Awaited<ReturnType<typeof resolveAmendTargets>>,
+ *   validatedBySlug: Map<string, { slug: string, title: string, body?: string, labels?: string[] }>,
+ * }} args
+ * @returns {Promise<{
+ *   closed: Array<{ slug: string, issueNumber: number }>,
+ *   recreated: Array<{ slug: string, oldIssueNumber: number, issueNumber: number }>,
+ *   created: Array<{ slug: string, issueNumber: number }>,
+ *   mapping: Record<string, { entity: 'story', issueNumber: number }>,
+ *   closedSlugs: string[],
+ * }>}
+ */
+export async function applyAmendOps({
+  epicId,
+  provider,
+  targets,
+  validatedBySlug,
+}) {
+  const closed = [];
+  const recreated = [];
+  const created = [];
+  const mapping = {};
+  const closedSlugs = [];
+
+  const createFromValidated = async (slug) => {
+    const validated = validatedBySlug.get(slug);
+    if (!validated) {
+      throw new Error(
+        `[plan-persist] amend apply: no validated ticket for slug "${slug}".`,
+      );
+    }
+    const result = await provider.createTicket(epicId, {
+      title: validated.title,
+      body: validated.body ?? '',
+      labels: validated.labels ?? [],
+    });
+    return result.id;
+  };
+
+  for (const target of targets.close) {
+    if (!target.alreadyClosed) {
+      await provider.updateTicket(target.issueNumber, { state: 'closed' });
+    } else {
+      Logger.info(
+        `[plan-persist] amend close: #${target.issueNumber} ` +
+          `(${target.ticket.slug}) already closed — skipping.`,
+      );
+    }
+    closed.push({ slug: target.ticket.slug, issueNumber: target.issueNumber });
+    closedSlugs.push(target.ticket.slug);
+  }
+
+  for (const target of targets.modify) {
+    if (!target.alreadyClosed) {
+      await provider.updateTicket(target.issueNumber, { state: 'closed' });
+    }
+    const newId = await createFromValidated(target.ticket.slug);
+    recreated.push({
+      slug: target.ticket.slug,
+      oldIssueNumber: target.issueNumber,
+      issueNumber: newId,
+    });
+    mapping[target.ticket.slug] = { entity: 'story', issueNumber: newId };
+  }
+
+  for (const [slug] of validatedBySlug) {
+    const isModify = targets.modify.some((t) => t.ticket.slug === slug);
+    const isKeep = targets.keep.some((t) => t.ticket.slug === slug);
+    if (isModify || isKeep) continue;
+    const newId = await createFromValidated(slug);
+    created.push({ slug, issueNumber: newId });
+    mapping[slug] = { entity: 'story', issueNumber: newId };
+  }
+
+  for (const target of targets.keep) {
+    mapping[target.ticket.slug] = {
+      entity: 'story',
+      issueNumber: target.issueNumber,
+    };
+  }
+
+  return { closed, recreated, created, mapping, closedSlugs };
+}

--- a/.agents/scripts/lib/orchestration/plan-persist/delivery-mode.js
+++ b/.agents/scripts/lib/orchestration/plan-persist/delivery-mode.js
@@ -1,0 +1,127 @@
+/**
+ * delivery-mode.js — delivery-shape mode resolution for the collapsed
+ * persist surface (Epic #4474 PR4, design §2 mode matrix).
+ *
+ * The risk verdict's optional `deliveryShape` field ("fan-out" | "single",
+ * absent → fan-out so every existing verdict stays valid) selects between
+ * the three persist modes:
+ *
+ *   - `fan-out` — the full mode: ticket validator + DAG + budget gates,
+ *     Story-tree creation via the structural reconciler.
+ *   - `single` — the spec-only single-delivery mode: NO tickets are
+ *     authored, the ticket validator + DAG are skipped (fenced by
+ *     construction — {@link resolveDeliveryMode} hard-refuses the
+ *     combination of `deliveryShape: "single"` with a tickets payload, so
+ *     the skip branch is unreachable when tickets are present), and the
+ *     persist applies the `delivery::single` routing marker instead of a
+ *     Story tree. Inert until #4475 lands the deliver-side reader.
+ *   - `amend` — the change-request delta path (`--amend`): tickets carry
+ *     `op: add|modify|keep|close` and the persist maps the ops onto the
+ *     existing Story tree (see `plan-persist/amend.js`).
+ *
+ * @module lib/orchestration/plan-persist/delivery-mode
+ */
+
+import { parseDeliverySlicingTable } from '../consolidation-precondition.js';
+
+/** Canonical delivery-shape values the risk-verdict schema admits. */
+const DELIVERY_SHAPES = Object.freeze(['fan-out', 'single']);
+
+/**
+ * Mode-coherence hard error (design §1 step 3 item 3, extended for PR4).
+ *
+ * Resolves the persist mode from the risk verdict's `deliveryShape` (absent
+ * → `fan-out`), the tickets payload, and the `--amend` flag — and refuses
+ * every incoherent combination loudly instead of silently coercing:
+ *
+ *   - unknown `deliveryShape` values;
+ *   - `deliveryShape: "single"` WITH a tickets payload (the DAG-skip
+ *     leakage risk — the single mode's validator/DAG skip is only sound
+ *     when there are no tickets to validate);
+ *   - fan-out without a non-empty tickets array;
+ *   - `--amend` combined with `deliveryShape: "single"` (the delta path is
+ *     fan-out-shaped by definition — a single-delivery re-plan is a
+ *     `--force` re-persist);
+ *   - `--amend` without tickets (the delta IS the tickets-with-ops
+ *     payload);
+ *   - `op` fields present without `--amend` (a full persist must never
+ *     silently reinterpret an amend delta as a fresh tree).
+ *
+ * @param {{ deliveryShape?: string }} riskVerdict schema-validated verdict
+ * @param {unknown} tickets parsed tickets payload (null when no file)
+ * @param {{ amend?: boolean }} [opts]
+ * @returns {'fan-out'|'single'|'amend'} the resolved persist mode
+ */
+export function resolveDeliveryMode(riskVerdict, tickets, opts = {}) {
+  const { amend = false } = opts;
+  const shape = riskVerdict?.deliveryShape ?? 'fan-out';
+  if (!DELIVERY_SHAPES.includes(shape)) {
+    throw new Error(
+      `[plan-persist] unknown deliveryShape "${shape}" — expected one of ` +
+        `${DELIVERY_SHAPES.join(', ')} (or omit the field for fan-out).`,
+    );
+  }
+  const hasTickets = Array.isArray(tickets) && tickets.length > 0;
+
+  if (amend) {
+    if (shape === 'single') {
+      throw new Error(
+        '[plan-persist] --amend is incoherent with deliveryShape "single" — ' +
+          'the amend delta maps ops onto an existing Story tree, and a ' +
+          'single-delivery plan has none. Re-author the verdict as fan-out, ' +
+          'or re-persist the single plan with --force.',
+      );
+    }
+    if (!hasTickets) {
+      throw new Error(
+        '[plan-persist] --amend requires a tickets payload carrying ' +
+          '`op: add|modify|keep|close` on every ticket — the delta IS the ' +
+          'tickets file (--tickets <file>).',
+      );
+    }
+    return 'amend';
+  }
+
+  if (shape === 'single') {
+    if (hasTickets) {
+      throw new Error(
+        '[plan-persist] mode-coherence: deliveryShape "single" with a ' +
+          'tickets payload is contradictory — the single-delivery mode ' +
+          'authors NO tickets (the Delivery Slicing table is the audit ' +
+          'trail). Remove the tickets file, or re-author the risk verdict ' +
+          'as fan-out.',
+      );
+    }
+    return 'single';
+  }
+
+  if (!hasTickets) {
+    throw new Error(
+      '[plan-persist] fan-out persist requires a non-empty tickets array ' +
+        '(--tickets <file>). A ticket-less spec-only plan must declare ' +
+        'deliveryShape: "single" in the risk verdict.',
+    );
+  }
+  if (tickets.some((t) => t && typeof t === 'object' && 'op' in t)) {
+    throw new Error(
+      '[plan-persist] tickets carry `op` fields but --amend was not passed ' +
+        '— refusing to reinterpret an amend delta as a full persist. Pass ' +
+        '--amend, or strip the op fields for a fresh fan-out.',
+    );
+  }
+  return 'fan-out';
+}
+
+/**
+ * Count the slices of the authored Tech Spec's `## Delivery Slicing` table
+ * — the single-mode plan summary's `sliceCount` (design §2: the slicing
+ * table IS the single mode's audit trail). Returns `null` when the table
+ * is absent or unparseable (fail-open, mirroring the parser's contract).
+ *
+ * @param {string} techSpecContent
+ * @returns {number|null}
+ */
+export function countDeliverySlices(techSpecContent) {
+  const rows = parseDeliverySlicingTable(techSpecContent ?? '');
+  return Array.isArray(rows) ? rows.length : null;
+}

--- a/.agents/scripts/lib/orchestration/plan-persist/run-plan-persist.js
+++ b/.agents/scripts/lib/orchestration/plan-persist/run-plan-persist.js
@@ -1,31 +1,50 @@
 /**
  * run-plan-persist.js — single GitHub-write surface for the /plan collapse
- * (Epic #4474, PR3).
+ * (Epic #4474, PR3 + PR4 modes).
  *
  * Implements the ordered, fail-closed superset persist that replaces the
  * separate `epic-plan-spec.js` / `epic-plan-decompose.js` persist halves
- * (design §1 Step 3, issue #4474):
+ * (design §1 Step 3 + §2 mode matrix, issue #4474):
  *
  *    1. args (owned by the `plan-persist.js` CLI shell)
  *    2. section gate — `validateSpecSections` runs BEFORE the lease and
  *       BEFORE any provider call; a rejection makes zero GitHub calls.
  *    3. risk-verdict validation (CLI-owned `loadRiskVerdict`) +
- *       mode-coherence hard error (fan-out requires tickets; `single` is
- *       PR4's surface — see {@link assertFanOutMode}).
+ *       mode-coherence hard error (`resolveDeliveryMode`): fan-out requires
+ *       tickets; `deliveryShape: "single"` refuses any tickets payload —
+ *       the single mode's validator/DAG skip is fenced by construction,
+ *       unreachable when tickets are present; `--amend` requires tickets
+ *       carrying `op` fields and refuses the single shape.
  *    4. ticket validator + file-assumption gate + DAG + sizing + budget
- *       (fan-out only; all git-local, still zero provider calls).
+ *       (fan-out and amend; amend validates the MERGED set — existing
+ *       keeps + adds + modifies, closes excluded; all git-local, still
+ *       zero provider calls). Skipped entirely in single mode (no tickets
+ *       exist to validate).
  *    5. ideation fold — `renderEpicBody` / `openEpicFromOnePager` create
  *       the Epic when the run starts from a one-pager (the first provider
- *       call of the run).
+ *       call of the run). Amend additionally resolves every
+ *       modify/keep/close slug to its live issue and enforces the close-op
+ *       confirmation gate (exit 2 without `--explicit-delete`) BEFORE the
+ *       lease and before any mutation.
  *    6. Epic lease (KEEP — documented double-create at ~80 creations).
  *       From here the lease is released on EVERY exit path (success, gate
  *       failure, throw) via try/finally.
  *    7. managed Tech Spec / Acceptance Table sections + risk-verdict
  *       structured comment + spec-freshness advisory.
- *    8. story creation via the structural reconciler (idempotent per-slug
- *       creation; the reconciler's state file is the per-slug resume
- *       ledger), bracketed by checkpoint-v2 writes so a rate-limit crash
- *       resumes losslessly with `--resume`.
+ *    8. mode-split mutation:
+ *       - fan-out: story creation via the structural reconciler
+ *         (idempotent per-slug creation; the reconciler's state file is
+ *         the per-slug resume ledger), bracketed by checkpoint-v2 writes
+ *         so a rate-limit crash resumes losslessly with `--resume`;
+ *       - single: NO story tree — the `delivery::single` routing marker is
+ *         applied instead (inert until #4475 lands the deliver-side
+ *         reader), and `decompose = { ticketCount: 0, shape: "single" }`
+ *         is checkpointed so delivery-time consumers never misread absence
+ *         as unplanned;
+ *       - amend: op-mapped delta — close ops close, modify ops
+ *         close-and-recreate, add ops create, keep ops are untouched by
+ *         construction; the state ledger and blocked-by edges are rebuilt
+ *         over the merged set.
  *    9. inline post-plan healthcheck (the `agent::ready` exit condition,
  *       Story #2921).
  *   10. single terminal `agent::ready` flip — the intermediate
@@ -34,7 +53,8 @@
  *       `agent::ready`).
  *   11. checkpoint v2 + single `plan-summary` comment carrying the dry-run
  *       wave table as closing text (replaces the Phase 9 dispatcher
- *       round-trip and the Phase 12 notify).
+ *       round-trip and the Phase 12 notify). The single-mode summary
+ *       records `{ deliveryShape: "single", sliceCount, routingReasons }`.
  *   12. temp cleanup ONLY at terminal success — a failed run leaves
  *       techspec/acceptance/risk-verdict/tickets artifacts on disk so a
  *       `--force`/`--resume` re-persist reuses them (fixes the
@@ -50,10 +70,6 @@
  * additions are the `version` bump and the additive `persist` progress
  * block; consumers key on field presence, never on `version`.
  *
- * Single-delivery (`deliveryShape: "single"`) and `--amend` are PR4's
- * surface — this module hard-refuses both (see the mode guard) rather than
- * shipping a half-built branch.
- *
  * @module lib/orchestration/plan-persist/run-plan-persist
  */
 
@@ -65,9 +81,13 @@ import { verifyBddRunnerPendingTag } from '../../bdd-runner-detect.js';
 import { getLimits, PROJECT_ROOT } from '../../config-resolver.js';
 import { openEpicFromOnePager } from '../../epic-plan-ideation.js';
 import { Logger } from '../../Logger.js';
-import { AGENT_LABELS, TYPE_LABELS } from '../../label-constants.js';
+import {
+  AGENT_LABELS,
+  DELIVERY_LABELS,
+  TYPE_LABELS,
+} from '../../label-constants.js';
 import { cleanupPhaseTempFiles } from '../../plan-phase-cleanup.js';
-import { loadState, writeSpec } from '../../spec/index.js';
+import { loadState, writeSpec, writeState } from '../../spec/index.js';
 import {
   reconcileSubIssueLinks,
   setBlockedByDependencies,
@@ -108,6 +128,15 @@ import {
 } from '../spec-section-validator.js';
 import { upsertStructuredComment } from '../ticketing.js';
 import {
+  applyAmendOps,
+  buildMergedTicketSet,
+  enforceAmendCloseGate,
+  partitionAmendTickets,
+  renderAmendPlanDiff,
+  resolveAmendTargets,
+} from './amend.js';
+import { countDeliverySlices, resolveDeliveryMode } from './delivery-mode.js';
+import {
   buildPlanSummaryCommentBody,
   buildWaveTable,
   PLAN_SUMMARY_COMMENT_TYPE,
@@ -116,41 +145,10 @@ import {
 /** Checkpoint schema version written by this surface. */
 export const PLAN_CHECKPOINT_SCHEMA_VERSION_V2 = 2;
 
-/**
- * Mode-coherence hard error (design §1 Step 3 item 3).
- *
- * PR3 ships the fan-out path only. `deliveryShape: "single"` (the spec-only
- * / single-delivery variant) and the `--amend` delta path are PR4's surface
- * (#4474 design §6); this guard is the deliberate seam they land behind —
- * a verdict declaring any non-fan-out shape refuses loudly instead of being
- * silently treated as fan-out.
- *
- * TODO(#4474 PR4): accept `deliveryShape: "single"` here (skip the ticket
- * validator + DAG in that mode only, persist the `delivery::single` routing
- * marker, no story tree) once the risk-verdict schema carries the field and
- * #4475's deliver-side reader exists.
- *
- * @param {{ deliveryShape?: string }} riskVerdict schema-validated verdict
- * @param {unknown} tickets parsed tickets payload
- */
-export function assertFanOutMode(riskVerdict, tickets) {
-  const shape = riskVerdict?.deliveryShape ?? 'fan-out';
-  if (shape !== 'fan-out') {
-    throw new Error(
-      `[plan-persist] deliveryShape "${shape}" is not supported yet — the ` +
-        'single-delivery persist variant lands in #4474 PR4 (inert until ' +
-        '#4475 ships the deliver-side reader). Re-author the risk verdict ' +
-        'without deliveryShape, or wait for PR4.',
-    );
-  }
-  if (!Array.isArray(tickets) || tickets.length === 0) {
-    throw new Error(
-      '[plan-persist] fan-out persist requires a non-empty tickets array ' +
-        '(--tickets <file>). A ticket-less spec-only plan is the ' +
-        'single-delivery mode, which lands in #4474 PR4.',
-    );
-  }
-}
+// Mode-coherence resolution (design §1 Step 3 item 3 + §2 mode matrix)
+// lives in `delivery-mode.js`; re-exported here so the CLI's stable public
+// API keeps a single import root for the persist surface.
+export { resolveDeliveryMode };
 
 /**
  * Merge-write the epic-plan-state checkpoint at schema v2. Reads the
@@ -256,7 +254,8 @@ async function resolveTargetEpic({
 
 /**
  * Execute the collapsed persist end to end (module doc has the 12-step
- * order). Fan-out mode only in PR3.
+ * order). Modes: fan-out (default), single (`deliveryShape: "single"`),
+ * amend (`--amend`).
  *
  * @param {{
  *   epicId?: number|null,
@@ -265,7 +264,7 @@ async function resolveTargetEpic({
  *     techSpecContent: string,
  *     acceptanceSpecContent?: string|null,
  *     riskVerdict: import('../planning-risk.js').RiskVerdict,
- *     tickets: Array<object>,
+ *     tickets?: Array<object>|null,
  *     onePagerContent?: string|null,
  *     templateContent?: string|null,
  *   },
@@ -274,6 +273,8 @@ async function resolveTargetEpic({
  *   opts?: {
  *     force?: boolean,
  *     resume?: boolean,
+ *     amend?: boolean,
+ *     explicitDelete?: boolean,
  *     steal?: boolean,
  *     forceReview?: boolean,
  *     allowOverBudget?: boolean,
@@ -286,6 +287,7 @@ async function resolveTargetEpic({
  *     writeSpecFn?: typeof writeSpec,
  *     renderSpecFn?: typeof renderSpec,
  *     loadStateFn?: typeof loadState,
+ *     writeStateFn?: typeof writeState,
  *     runHealthcheckFn?: typeof defaultRunPlanHealthcheck,
  *     bddProbeFn?: typeof verifyBddRunnerPendingTag,
  *     fanOutCounter?: (arg: { path: string }) => number,
@@ -305,13 +307,15 @@ export async function runPlanPersist({
     techSpecContent,
     acceptanceSpecContent = null,
     riskVerdict,
-    tickets,
+    tickets = null,
     onePagerContent = null,
     templateContent = null,
   } = artifacts ?? {};
   const {
     force = false,
     resume = false,
+    amend = false,
+    explicitDelete = false,
     steal = false,
     forceReview = false,
     allowOverBudget = false,
@@ -323,6 +327,7 @@ export async function runPlanPersist({
     writeSpecFn = writeSpec,
     renderSpecFn = renderSpec,
     loadStateFn = loadState,
+    writeStateFn = writeState,
     runHealthcheckFn = defaultRunPlanHealthcheck,
     bddProbeFn = verifyBddRunnerPendingTag,
     fanOutCounter = undefined,
@@ -333,6 +338,18 @@ export async function runPlanPersist({
   if (force && resume) {
     throw new Error(
       '[plan-persist] --force and --resume are mutually exclusive.',
+    );
+  }
+  if (amend && (force || resume)) {
+    throw new Error(
+      '[plan-persist] --amend is mutually exclusive with --force/--resume ' +
+        '— the amend delta is already an incremental re-persist.',
+    );
+  }
+  if (amend && onePagerContent) {
+    throw new Error(
+      '[plan-persist] --amend requires --epic <id> — there is no existing ' +
+        'plan to amend in ideation mode.',
     );
   }
   if (onePagerContent && resume) {
@@ -375,32 +392,45 @@ export async function runPlanPersist({
         'and pass it with --risk-verdict.',
     );
   }
-  assertFanOutMode(riskVerdict, tickets);
+  const mode = resolveDeliveryMode(riskVerdict, tickets, { amend });
 
   // ---- Step 4: ticket validator + file-assumption gate + DAG + sizing +
-  // budget (fan-out only; git-local — still no provider call). ----
-  const maxTickets = getLimits(config).maxTickets;
-  if (tickets.length > maxTickets && !allowOverBudget) {
-    throw new Error(
-      `[plan-persist] Tickets (${tickets.length}) exceed the reviewability ` +
-        `budget (${maxTickets}). Re-scope the Epic into a smaller plan, or ` +
-        'rerun with --allow-over-budget after confirming the over-budget ' +
-        'rationale on the Epic.',
+  // budget (fan-out and amend; git-local — still no provider call). In
+  // amend mode every gate runs over the MERGED set — keeps + adds +
+  // modifies, closes excluded — so the DAG is validated against the tree
+  // that will actually exist post-amend. The skip branch below is fenced
+  // by construction: `resolveDeliveryMode` hard-refuses `deliveryShape:
+  // "single"` with any tickets payload, so single mode can only reach here
+  // with no tickets to validate. ----
+  let validated = null;
+  let amendPartition = null;
+  if (mode !== 'single') {
+    amendPartition = mode === 'amend' ? partitionAmendTickets(tickets) : null;
+    const gateSet = mode === 'amend' ? buildMergedTicketSet(tickets) : tickets;
+    const maxTickets = getLimits(config).maxTickets;
+    if (gateSet.length > maxTickets && !allowOverBudget) {
+      throw new Error(
+        `[plan-persist] Tickets (${gateSet.length}) exceed the reviewability ` +
+          `budget (${maxTickets}). Re-scope the Epic into a smaller plan, or ` +
+          'rerun with --allow-over-budget after confirming the over-budget ' +
+          'rationale on the Epic.',
+      );
+    }
+    warnTicketCapNearLimit(gateSet, maxTickets, 'plan-persist');
+    if (gateSet.length > maxTickets && allowOverBudget) {
+      Logger.warn(
+        `[plan-persist] Persisting an over-budget decomposition: ${gateSet.length} ` +
+          `tickets vs. budget ${maxTickets} (operator override --allow-over-budget).`,
+      );
+    }
+    Logger.info(
+      `[plan-persist] Running cross-validation on ${gateSet.length} tickets` +
+        `${mode === 'amend' ? ' (merged amend set)' : ''}...`,
     );
+    validated = validateTickets(gateSet, config, { fanOutCounter, cwd });
+    enforceFanOutGate(validated.findings, allowLargeFanOut, 'plan-persist');
+    surfaceSoftConflictFindings(validated.findings, 'plan-persist');
   }
-  warnTicketCapNearLimit(tickets, maxTickets, 'plan-persist');
-  if (tickets.length > maxTickets && allowOverBudget) {
-    Logger.warn(
-      `[plan-persist] Persisting an over-budget decomposition: ${tickets.length} ` +
-        `tickets vs. budget ${maxTickets} (operator override --allow-over-budget).`,
-    );
-  }
-  Logger.info(
-    `[plan-persist] Running cross-validation on ${tickets.length} tickets...`,
-  );
-  const validated = validateTickets(tickets, config, { fanOutCounter, cwd });
-  enforceFanOutGate(validated.findings, allowLargeFanOut, 'plan-persist');
-  surfaceSoftConflictFindings(validated.findings, 'plan-persist');
 
   // ---- Step 5: ideation fold / Epic resolution (first provider call). ----
   const { epicId, epic, created } = await resolveTargetEpic({
@@ -410,6 +440,33 @@ export async function runPlanPersist({
     provider,
   });
 
+  // Amend pre-mutation resolution: every modify/keep/close slug must
+  // resolve to a live issue, and close ops require --explicit-delete
+  // (exit 2 with the dry-run diff otherwise — the epic-reconcile.js
+  // contract). Runs BEFORE the lease and before any mutation.
+  let amendTargets = null;
+  if (mode === 'amend') {
+    const priorState = loadStateFn(epicId);
+    amendTargets = await resolveAmendTargets({
+      partition: amendPartition,
+      stateMapping: priorState.mapping,
+      provider,
+    });
+    enforceAmendCloseGate({
+      epicId,
+      targets: amendTargets,
+      adds: amendPartition.add,
+      explicitDelete,
+    });
+    Logger.info(
+      renderAmendPlanDiff({
+        epicId,
+        targets: amendTargets,
+        adds: amendPartition.add,
+      }),
+    );
+  }
+
   // ---- Step 6: Epic lease. Every path after a successful acquire runs
   // through the finally below, so the lease is released on success, on a
   // gate failure, and on a throw alike. ----
@@ -418,12 +475,15 @@ export async function runPlanPersist({
   try {
     // Refuse a duplicate story tree unless this is a deliberate re-persist
     // (`--force` closes + recreates via the reconciler's close ops;
-    // `--resume` continues a partial persist).
-    await assertNoOpenPlanChildren({
-      provider,
-      epicId,
-      force: force || resume,
-    });
+    // `--resume` continues a partial persist). Amend is exempt by
+    // definition — its whole purpose is mutating the existing open tree.
+    if (mode !== 'amend') {
+      await assertNoOpenPlanChildren({
+        provider,
+        epicId,
+        force: force || resume,
+      });
+    }
 
     await initializePlanState({ provider, epicId });
 
@@ -447,12 +507,15 @@ export async function runPlanPersist({
       );
     }
 
+    // Amend always overwrites the managed sections — the amended Tech Spec
+    // IS the delta's spec half (planEpic would otherwise short-circuit
+    // `already-planned` on the pre-amend sections).
     const planResult = await planEpic(
       epicId,
       provider,
       { techSpecContent, acceptanceSpecContent },
       settings,
-      { force, planningRisk },
+      { force: force || mode === 'amend', planningRisk },
     );
 
     const reviewRouting = resolveReviewRouting({ planningRisk, forceReview });
@@ -496,59 +559,157 @@ export async function runPlanPersist({
         completedAt: new Date().toISOString(),
       },
       persist: {
-        mode: 'fan-out',
+        mode,
         cli: 'plan-persist',
         startedAt: new Date().toISOString(),
         completedAt: null,
       },
     });
 
-    // ---- Step 8: story creation via the structural reconciler. ----
-    Logger.info(
-      `[plan-persist] Rendering spec for Epic #${epicId} (${validated.length} tickets)...`,
-    );
-    const spec = renderSpecFn(validated, {
-      epic: buildEpicSpecInput(epic, epicId),
-    });
-    const specFilePath = writeSpecFn(epicId, spec, { epicsDir: undefined });
-    Logger.info(`[plan-persist] Wrote spec → ${specFilePath}`);
+    // ---- Step 8: mode-split mutation. ----
+    let reconcile = null;
+    let specFilePath = null;
+    let ticketCount = 0;
+    let single = null;
+    let amendSummary = null;
 
-    // Pre-creation checkpoint: marks creation in flight so a rate-limit
-    // crash mid-creation leaves a checkpoint pointing at the spec + the
-    // reconciler's per-slug state file (the resume ledger). `--resume`
-    // re-runs the reconciler, which creates only the missing slugs.
-    await writeCheckpointV2(provider, epicId, {
-      decompose: { ticketCount: null, completedAt: null },
-    });
+    if (mode === 'fan-out') {
+      // Story creation via the structural reconciler.
+      Logger.info(
+        `[plan-persist] Rendering spec for Epic #${epicId} (${validated.length} tickets)...`,
+      );
+      const spec = renderSpecFn(validated, {
+        epic: buildEpicSpecInput(epic, epicId),
+      });
+      specFilePath = writeSpecFn(epicId, spec, { epicsDir: undefined });
+      Logger.info(`[plan-persist] Wrote spec → ${specFilePath}`);
 
-    Logger.info(
-      `[plan-persist] Spawning epic-reconcile.js --apply --yes for Epic #${epicId}...`,
-    );
-    const reconcile = spawnReconcilerApply({
-      spawnSync,
-      reconcileCli,
-      epicId,
-      cwd,
-      explicitDelete: force,
-    });
+      // Pre-creation checkpoint: marks creation in flight so a rate-limit
+      // crash mid-creation leaves a checkpoint pointing at the spec + the
+      // reconciler's per-slug state file (the resume ledger). `--resume`
+      // re-runs the reconciler, which creates only the missing slugs.
+      await writeCheckpointV2(provider, epicId, {
+        decompose: { ticketCount: null, completedAt: null },
+      });
 
-    await reconcileSubIssueLinks(epicId, provider);
+      Logger.info(
+        `[plan-persist] Spawning epic-reconcile.js --apply --yes for Epic #${epicId}...`,
+      );
+      reconcile = spawnReconcilerApply({
+        spawnSync,
+        reconcileCli,
+        epicId,
+        cwd,
+        explicitDelete: force,
+      });
 
-    const postReconcileState = loadStateFn(epicId);
-    await setBlockedByDependencies(
-      epicId,
-      provider,
-      spec,
-      postReconcileState.mapping,
-    );
+      await reconcileSubIssueLinks(epicId, provider);
 
-    // Post-creation checkpoint (the former recordCheckpoint half).
-    await writeCheckpointV2(provider, epicId, {
-      decompose: {
-        ticketCount: tickets.length,
-        completedAt: new Date().toISOString(),
-      },
-    });
+      const postReconcileState = loadStateFn(epicId);
+      await setBlockedByDependencies(
+        epicId,
+        provider,
+        spec,
+        postReconcileState.mapping,
+      );
+
+      ticketCount = tickets.length;
+      // Post-creation checkpoint (the former recordCheckpoint half).
+      await writeCheckpointV2(provider, epicId, {
+        decompose: {
+          ticketCount,
+          shape: 'fan-out',
+          completedAt: new Date().toISOString(),
+        },
+      });
+
+      // A force re-persist over a former single-delivery plan flips the
+      // routing shape — drop the stale marker so #4475's reader never sees
+      // a fan-out tree labelled single.
+      await removeSingleDeliveryMarker(provider, epicId, epic);
+    } else if (mode === 'single') {
+      // Single-delivery: NO story tree. The delivery::single routing
+      // marker (inert until #4475's deliver-side reader) plus the Delivery
+      // Slicing table of the persisted Tech Spec are the plan.
+      single = {
+        deliveryShape: 'single',
+        sliceCount: countDeliverySlices(techSpecContent),
+        routingReasons: riskVerdict.deliveryShapeRationale
+          ? [riskVerdict.deliveryShapeRationale]
+          : [],
+      };
+      Logger.info(
+        `[plan-persist] Single-delivery mode: applying ${DELIVERY_LABELS.SINGLE} ` +
+          `to Epic #${epicId} (no story tree).`,
+      );
+      await provider.updateTicket(epicId, {
+        labels: { add: [DELIVERY_LABELS.SINGLE], remove: [] },
+      });
+      // Explicit zero-ticket checkpoint so delivery-time consumers read a
+      // deliberate single-shape plan, never an unplanned absence.
+      await writeCheckpointV2(provider, epicId, {
+        decompose: {
+          ticketCount: 0,
+          shape: 'single',
+          completedAt: new Date().toISOString(),
+        },
+      });
+    } else {
+      // Amend delta: close-and-recreate is scoped to modify/close slugs
+      // only; keeps are untouched by construction (no code path receives
+      // them); adds are created fresh. The state ledger and blocked-by
+      // edges are rebuilt over the merged set.
+      const spec = renderSpecFn(validated, {
+        epic: buildEpicSpecInput(epic, epicId),
+      });
+      specFilePath = writeSpecFn(epicId, spec, { epicsDir: undefined });
+      Logger.info(`[plan-persist] Wrote amended spec → ${specFilePath}`);
+
+      await writeCheckpointV2(provider, epicId, {
+        decompose: { ticketCount: null, completedAt: null },
+      });
+
+      const validatedBySlug = new Map(validated.map((t) => [t.slug, t]));
+      const applied = await applyAmendOps({
+        epicId,
+        provider,
+        targets: amendTargets,
+        validatedBySlug,
+      });
+
+      // Rebuild the state ledger over the merged set: prior mapping minus
+      // closed/replaced slugs, plus the fresh create/recreate numbers.
+      const priorState = loadStateFn(epicId);
+      const mergedMapping = { ...(priorState.mapping ?? {}) };
+      for (const slug of applied.closedSlugs) delete mergedMapping[slug];
+      Object.assign(mergedMapping, applied.mapping);
+      writeStateFn(epicId, {
+        epicId,
+        mapping: mergedMapping,
+        lastReconciledAt: new Date().toISOString(),
+      });
+
+      await reconcileSubIssueLinks(epicId, provider);
+      await setBlockedByDependencies(epicId, provider, spec, mergedMapping);
+
+      ticketCount = validated.length;
+      amendSummary = {
+        closed: applied.closed,
+        recreated: applied.recreated,
+        created: applied.created,
+        keptCount: amendTargets.keep.length,
+      };
+      await writeCheckpointV2(provider, epicId, {
+        decompose: {
+          ticketCount,
+          shape: 'fan-out',
+          completedAt: new Date().toISOString(),
+        },
+      });
+
+      // An amended plan is fan-out-shaped; drop a stale single marker.
+      await removeSingleDeliveryMarker(provider, epicId, epic);
+    }
 
     // ---- Step 9: inline healthcheck — the agent::ready exit condition. ----
     const healthcheck = skipHealthcheck
@@ -569,8 +730,10 @@ export async function runPlanPersist({
     await setEpicLabel(provider, epicId, AGENT_LABELS.READY);
 
     // ---- Step 11: final checkpoint v2 + single plan-summary comment with
-    // the dry-run wave table as closing text. ----
-    const waveTable = buildWaveTable(validated);
+    // the dry-run wave table as closing text (single mode records the
+    // { deliveryShape, sliceCount, routingReasons } routing record
+    // instead). ----
+    const waveTable = mode === 'single' ? [] : buildWaveTable(validated);
     const checkpoint = await writeCheckpointV2(provider, epicId, {
       persist: { completedAt: new Date().toISOString() },
     });
@@ -580,12 +743,15 @@ export async function runPlanPersist({
       PLAN_SUMMARY_COMMENT_TYPE,
       buildPlanSummaryCommentBody({
         epicId,
-        ticketCount: tickets.length,
+        ticketCount,
         planningRisk,
         reviewRouting,
         freshness,
         healthcheck,
         waveTable,
+        mode,
+        single,
+        amend: amendSummary,
       }),
     );
 
@@ -595,8 +761,8 @@ export async function runPlanPersist({
       ? { deleted: [], missing: [], failed: [], skipped: true }
       : await cleanupPhaseTempFiles({ phase: 'persist', epicId });
     Logger.info(
-      `[plan-persist] ✅ Persist complete for Epic #${epicId}. ` +
-        `${tickets.length} ticket(s) persisted; Epic is ${AGENT_LABELS.READY}.`,
+      `[plan-persist] ✅ Persist complete for Epic #${epicId} (${mode}). ` +
+        `${ticketCount} ticket(s) persisted; Epic is ${AGENT_LABELS.READY}.`,
     );
     if (cleanup.deleted.length > 0) {
       Logger.info(
@@ -607,7 +773,8 @@ export async function runPlanPersist({
     return {
       epicId,
       epicCreated: created,
-      ticketCount: tickets.length,
+      mode,
+      ticketCount,
       checkpoint,
       planningRisk,
       reviewRouting,
@@ -616,6 +783,8 @@ export async function runPlanPersist({
       reconcile,
       specPath: specFilePath,
       waveTable,
+      single,
+      amend: amendSummary,
       cleanup,
       labelTransition: 'ready',
     };
@@ -624,6 +793,26 @@ export async function runPlanPersist({
     // Best-effort by contract — releaseEpicPlanLease never throws.
     await releaseEpicPlanLease({ provider, epicId, config });
   }
+}
+
+/**
+ * Drop a stale `delivery::single` marker when a fan-out-shaped persist
+ * (full re-persist or amend) lands over a formerly single-delivery plan.
+ * No-op — and no API call — when the fetched Epic never carried it.
+ *
+ * @param {object} provider
+ * @param {number} epicId
+ * @param {{ labels?: string[] }} epic the Epic as fetched at step 5
+ */
+async function removeSingleDeliveryMarker(provider, epicId, epic) {
+  if (!epic?.labels?.includes(DELIVERY_LABELS.SINGLE)) return;
+  Logger.info(
+    `[plan-persist] Removing stale ${DELIVERY_LABELS.SINGLE} marker from ` +
+      `Epic #${epicId} (plan is fan-out-shaped now).`,
+  );
+  await provider.updateTicket(epicId, {
+    labels: { add: [], remove: [DELIVERY_LABELS.SINGLE] },
+  });
 }
 
 /**

--- a/.agents/scripts/lib/orchestration/plan-persist/summary.js
+++ b/.agents/scripts/lib/orchestration/plan-persist/summary.js
@@ -84,7 +84,10 @@ function renderWaveTableLines(waveTable) {
 
 /**
  * Build the `plan-summary` structured-comment body: risk + routing +
- * freshness + healthcheck receipts, closing with the dry-run wave table.
+ * freshness + healthcheck receipts, closing with the mode-specific tail —
+ * the dry-run wave table for fan-out/amend, or the single-delivery routing
+ * record `{ deliveryShape, sliceCount, routingReasons }` (Epic #4474 PR4)
+ * for the spec-only mode.
  *
  * @param {{
  *   epicId: number,
@@ -94,6 +97,14 @@ function renderWaveTableLines(waveTable) {
  *   freshness?: { stale?: number, ambiguous?: number },
  *   healthcheck?: { ok?: boolean, waived?: boolean, skipped?: boolean },
  *   waveTable: ReturnType<typeof buildWaveTable>,
+ *   mode?: 'fan-out'|'single'|'amend',
+ *   single?: { deliveryShape: 'single', sliceCount: number|null, routingReasons: string[] }|null,
+ *   amend?: {
+ *     closed: Array<{ slug: string, issueNumber: number }>,
+ *     recreated: Array<{ slug: string, oldIssueNumber: number, issueNumber: number }>,
+ *     created: Array<{ slug: string, issueNumber: number }>,
+ *     keptCount: number,
+ *   }|null,
  * }} input
  * @returns {string}
  */
@@ -105,6 +116,9 @@ export function buildPlanSummaryCommentBody({
   freshness,
   healthcheck,
   waveTable,
+  mode = 'fan-out',
+  single = null,
+  amend = null,
 }) {
   const freshnessLine =
     (freshness?.stale ?? 0) > 0 || (freshness?.ambiguous ?? 0) > 0
@@ -115,18 +129,54 @@ export function buildPlanSummaryCommentBody({
     : healthcheck?.ok
       ? '- Healthcheck: passed.'
       : `- Healthcheck: failed, waived by operator label.`;
+
+  const headLine =
+    mode === 'single'
+      ? `- Single-delivery plan (\`delivery::single\`): no Story tree — the Delivery Slicing table is the audit trail.`
+      : `- ${ticketCount} Story ticket(s) persisted across ${waveTable.length} wave(s).`;
+
+  const amendLines = amend
+    ? [
+        `- Amend delta: ${amend.created.length} added, ${amend.recreated.length} modified (closed + recreated), ${amend.closed.length} closed, ${amend.keptCount} kept untouched.`,
+      ]
+    : [];
+
+  const tail =
+    mode === 'single'
+      ? [
+          '#### Delivery routing record',
+          '',
+          '```json',
+          JSON.stringify(
+            {
+              deliveryShape: 'single',
+              sliceCount: single?.sliceCount ?? null,
+              routingReasons: single?.routingReasons ?? [],
+            },
+            null,
+            2,
+          ),
+          '```',
+          '',
+          '_Marker is inert until #4475 lands the deliver-side reader — `/deliver` still treats this Epic as fan-out until then._',
+        ]
+      : [
+          '#### Dry-run wave table',
+          '',
+          ...renderWaveTableLines(waveTable),
+          '',
+          '_Preview only — the authoritative dispatch manifest is written at deliver time (`wave-record-io.js`)._',
+        ];
+
   return [
     `### 📋 Plan Summary — Epic #${epicId} is \`agent::ready\``,
     '',
-    `- ${ticketCount} Story ticket(s) persisted across ${waveTable.length} wave(s).`,
+    headLine,
+    ...amendLines,
     `- Risk: ${planningRisk?.overallLevel ?? 'unknown'} · ${planningRisk?.gateDecision ?? 'unknown'} (review routing: ${reviewRouting?.decision ?? 'unknown'}).`,
     freshnessLine,
     healthcheckLine,
     '',
-    '#### Dry-run wave table',
-    '',
-    ...renderWaveTableLines(waveTable),
-    '',
-    '_Preview only — the authoritative dispatch manifest is written at deliver time (`wave-record-io.js`)._',
+    ...tail,
   ].join('\n');
 }

--- a/.agents/scripts/plan-persist.js
+++ b/.agents/scripts/plan-persist.js
@@ -30,6 +30,16 @@
  *                        Phase 3/4 steps in). Artifact paths must be
  *                        explicit (there is no Epic id to derive them from).
  *
+ * Modes (Epic #4474 PR4, design §2 mode matrix): the risk verdict's
+ * optional `deliveryShape` field selects between the full fan-out persist
+ * (default; requires tickets) and the spec-only single-delivery variant
+ * (`deliveryShape: "single"`; NO tickets — the ticket validator + DAG are
+ * skipped, fenced by construction, and the `delivery::single` routing
+ * marker is applied instead of a Story tree; inert until #4475 lands the
+ * deliver-side reader). `--amend` selects the change-request delta path:
+ * tickets carry `op: add|modify|keep|close` and the persist maps the ops
+ * onto the existing tree.
+ *
  * Flags:
  *   --force              Deliberate re-persist: overwrite managed sections,
  *                        close + recreate the story tree (reconciler
@@ -40,16 +50,24 @@
  *                        (rate-limit, network): sections short-circuit
  *                        idempotently, the reconciler creates only the
  *                        missing slugs from its per-slug state ledger.
+ *   --amend              Change-request delta persist: every ticket carries
+ *                        `op: add|modify|keep|close`; close-and-recreate is
+ *                        scoped to modify/close slugs only, keeps are
+ *                        untouched, and the DAG is validated over the
+ *                        merged set.
+ *   --explicit-delete    Confirm the close ops of an --amend plan (mirrors
+ *                        epic-reconcile.js). Without it, an amend carrying
+ *                        close ops prints the dry-run diff and exits 2.
  *   --steal              Force-transfer a live foreign Epic-lease claim.
  *   --force-review       Operator-forced review routing (recorded in the
  *                        checkpoint's reviewRouting envelope).
  *   --allow-over-budget / --allow-large-fan-out
  *                        Same overrides as the retired split persist.
- *   --amend              NOT IMPLEMENTED — the change-request delta path is
- *                        #4474 PR4's surface. Hard-refuses.
  *
  * Exit codes: 0 — persist complete, Epic is `agent::ready`; 1 — fatal
- * error (see stderr). The Epic lease is released on every exit path.
+ * error (see stderr); 2 — amend close ops require --explicit-delete (the
+ * dry-run diff is printed; nothing was mutated). The Epic lease is
+ * released on every exit path.
  */
 
 // Fail-fast if the framework's runtime deps are not installed — must be the
@@ -77,7 +95,7 @@ import {
   summarizePlanMetrics,
 } from './lib/orchestration/plan-metrics.js';
 import {
-  assertFanOutMode,
+  resolveDeliveryMode,
   runPlanPersist,
   writeCheckpointV2,
 } from './lib/orchestration/plan-persist/run-plan-persist.js';
@@ -91,10 +109,10 @@ import { createProvider } from './lib/provider-factory.js';
 // Re-exports for the stable public API (tests import through the CLI
 // module, mirroring the epic-plan-spec.js / epic-plan-decompose.js shape).
 export {
-  assertFanOutMode,
   buildPlanSummaryCommentBody,
   buildWaveTable,
   PLAN_SUMMARY_COMMENT_TYPE,
+  resolveDeliveryMode,
   runPlanPersist,
   writeCheckpointV2,
 };
@@ -120,13 +138,14 @@ const CLI_OPTIONS = {
   'allow-over-budget': { type: 'boolean', default: false },
   'allow-large-fan-out': { type: 'boolean', default: false },
   amend: { type: 'boolean', default: false },
+  'explicit-delete': { type: 'boolean', default: false },
 };
 
 const USAGE =
   'Usage: plan-persist.js (--epic <EpicId> | --one-pager <file>) ' +
   '[--tech-spec <file>] [--acceptance-table <file>] [--risk-verdict <file>] ' +
-  '[--tickets <file>] [--force | --resume] [--steal] [--force-review] ' +
-  '[--allow-over-budget] [--allow-large-fan-out]';
+  '[--tickets <file>] [--force | --resume | --amend [--explicit-delete]] ' +
+  '[--steal] [--force-review] [--allow-over-budget] [--allow-large-fan-out]';
 
 /**
  * Parse `--epic`; returns null when absent (ideation mode).
@@ -159,9 +178,9 @@ function resolveArtifactPaths({ epicId, values, config }) {
   const ticketsPath = values.tickets ?? fallback('tickets.json');
   const acceptancePath =
     values['acceptance-table'] ?? fallback('acceptance-spec.md');
-  if (!techSpecPath || !riskVerdictPath || !ticketsPath) {
+  if (!techSpecPath || !riskVerdictPath) {
     throw new Error(
-      `Missing artifact path(s): ideation mode requires explicit --tech-spec, --risk-verdict, and --tickets.\n${USAGE}`,
+      `Missing artifact path(s): ideation mode requires explicit --tech-spec and --risk-verdict.\n${USAGE}`,
     );
   }
   return {
@@ -170,6 +189,7 @@ function resolveArtifactPaths({ epicId, values, config }) {
     ticketsPath,
     acceptancePath,
     acceptanceExplicit: values['acceptance-table'] !== undefined,
+    ticketsExplicit: values.tickets !== undefined,
   };
 }
 
@@ -185,15 +205,14 @@ async function readOptional(filePath, { required }) {
 async function main() {
   const { values } = parseArgs({ options: CLI_OPTIONS });
 
-  if (values.amend) {
-    throw new Error(
-      '[plan-persist] --amend (the change-request delta path) is #4474 ' +
-        "PR4's surface and is not implemented yet. Use --force for a full " +
-        're-persist, or wait for PR4.',
-    );
-  }
   if (values.force && values.resume) {
     throw new Error('--force and --resume are mutually exclusive.');
+  }
+  if (values.amend && (values.force || values.resume)) {
+    throw new Error(
+      '--amend is mutually exclusive with --force/--resume — the amend ' +
+        'delta is already an incremental re-persist.',
+    );
   }
 
   const epicId = parseEpicId(values.epic);
@@ -239,6 +258,7 @@ async function main() {
     ticketsPath,
     acceptancePath,
     acceptanceExplicit,
+    ticketsExplicit,
   } = resolveArtifactPaths({ epicId, values, config });
 
   // Deterministic local reads + validation before any GitHub call. A
@@ -246,14 +266,25 @@ async function main() {
   // gate itself runs first inside runPlanPersist.
   const techSpecContent = await readOptional(techSpecPath, { required: true });
   const riskVerdict = loadRiskVerdict(riskVerdictPath);
-  const ticketsRaw = await readOptional(ticketsPath, { required: true });
-  let tickets;
-  try {
-    tickets = JSON.parse(ticketsRaw);
-  } catch (err) {
-    throw new Error(
-      `Failed to parse tickets file "${ticketsPath}" as JSON: ${err.message}`,
-    );
+  // Tickets are mode-dependent (#4474 PR4): required when explicitly
+  // passed or in --amend mode; otherwise best-effort — a single-delivery
+  // plan authors no tickets file at all, and the mode-coherence gate
+  // (`resolveDeliveryMode`) hard-errors on every contradictory combination
+  // (including a stale tickets.json next to a `deliveryShape: "single"`
+  // verdict).
+  const ticketsRequired = ticketsExplicit || values.amend;
+  const ticketsRaw = ticketsPath
+    ? await readOptional(ticketsPath, { required: ticketsRequired })
+    : null;
+  let tickets = null;
+  if (ticketsRaw !== null) {
+    try {
+      tickets = JSON.parse(ticketsRaw);
+    } catch (err) {
+      throw new Error(
+        `Failed to parse tickets file "${ticketsPath}" as JSON: ${err.message}`,
+      );
+    }
   }
   // Acceptance table: explicit path is required to exist; the per-Epic
   // default is best-effort (absent file → no acceptance section, matching
@@ -270,33 +301,55 @@ async function main() {
 
   // Plan-metrics ledger (#4474 PR1): stamp entry/exit + mode. Ideation runs
   // have no Epic id at entry, so they stamp on the standalone stream.
-  const mode = values.resume ? 'resume' : values.force ? 'force' : 'persist';
-  const result = await recordPlanInvocation(
-    { cli: 'plan-persist', mode, epicId, config },
-    () =>
-      runPlanPersist({
-        epicId,
-        provider,
-        artifacts: {
-          techSpecContent,
-          acceptanceSpecContent,
-          riskVerdict,
-          tickets,
-          onePagerContent,
-          templateContent,
-        },
-        config,
-        settings,
-        opts: {
-          force: values.force,
-          resume: values.resume,
-          steal: values.steal,
-          forceReview: values['force-review'],
-          allowOverBudget: values['allow-over-budget'],
-          allowLargeFanOut: values['allow-large-fan-out'],
-        },
-      }),
-  );
+  const mode = values.amend
+    ? 'amend'
+    : values.resume
+      ? 'resume'
+      : values.force
+        ? 'force'
+        : 'persist';
+  let result;
+  try {
+    result = await recordPlanInvocation(
+      { cli: 'plan-persist', mode, epicId, config },
+      () =>
+        runPlanPersist({
+          epicId,
+          provider,
+          artifacts: {
+            techSpecContent,
+            acceptanceSpecContent,
+            riskVerdict,
+            tickets,
+            onePagerContent,
+            templateContent,
+          },
+          config,
+          settings,
+          opts: {
+            force: values.force,
+            resume: values.resume,
+            amend: values.amend,
+            explicitDelete: values['explicit-delete'],
+            steal: values.steal,
+            forceReview: values['force-review'],
+            allowOverBudget: values['allow-over-budget'],
+            allowLargeFanOut: values['allow-large-fan-out'],
+          },
+        }),
+    );
+  } catch (err) {
+    // Amend close-op confirmation gate (exit 2, mirroring the
+    // epic-reconcile.js contract): print the dry-run diff so the operator
+    // reviews exactly what would close, mutate nothing, and exit 2 so
+    // non-interactive callers can branch on the code.
+    if (err?.code === 'PLAN_AMEND_EXPLICIT_DELETE_REQUIRED') {
+      process.stdout.write(`${err.diff}\n\n${err.message}\n`);
+      process.exitCode = 2;
+      return;
+    }
+    throw err;
+  }
 
   // Surface the whole plan run's invocation ledger in the persist summary
   // (#4474 PR1). Additive and best-effort.

--- a/tests/bootstrap.test.js
+++ b/tests/bootstrap.test.js
@@ -152,7 +152,9 @@ describe('Bootstrap — LABEL_TAXONOMY', () => {
     // Story #4314 — removed the `context::prd` label (PRD artifact retired).
     // Story #4324 — removed `context::tech-spec` + `context::acceptance-spec`
     // (planning content folded into managed Epic-body sections).
-    const nonPersonaBase = 10;
+    // Epic #4474 PR4 — added `delivery::single` (single-delivery routing
+    // marker applied by plan-persist.js; inert until #4475).
+    const nonPersonaBase = 11;
     assert.equal(LABEL_TAXONOMY.length, nonPersonaBase + PERSONA_NAMES.length);
   });
 

--- a/tests/scripts/plan-persist.checkpoint-consumers.test.js
+++ b/tests/scripts/plan-persist.checkpoint-consumers.test.js
@@ -211,6 +211,78 @@ describe('plan-persist checkpoint v2 — four-consumer round-trip (#4474 §3)', 
   });
 });
 
+describe('plan-persist checkpoint v2 — single-mode fixture round-trip (#4474 PR4)', () => {
+  /** @type {ReturnType<typeof buildProvider>} */
+  let provider;
+
+  beforeEach(async () => {
+    provider = buildProvider();
+    // The single-delivery persist variant: decompose is a DELIBERATE
+    // zero-ticket single-shape block (never an absence delivery-time
+    // consumers could misread as unplanned).
+    await writeCheckpointV2(provider, EPIC_ID, {
+      planningRisk: PLANNING_RISK,
+      riskVerdict: {
+        ...RISK_VERDICT,
+        deliveryShape: 'single',
+        deliveryShapeRationale: 'Pure dependent chain — one-pass-sized.',
+      },
+      reviewRouting: REVIEW_ROUTING,
+      spec: {
+        techSpecPersisted: true,
+        acceptanceTable: 'persisted',
+        completedAt: new Date().toISOString(),
+      },
+      decompose: {
+        ticketCount: 0,
+        shape: 'single',
+        completedAt: new Date().toISOString(),
+      },
+      persist: { mode: 'single', cli: 'plan-persist', completedAt: null },
+    });
+  });
+
+  it('records the deliberate zero-ticket single-shape decompose block', async () => {
+    const state = await readPlanState({ provider, epicId: EPIC_ID });
+    assert.equal(state.decompose.ticketCount, 0);
+    assert.equal(state.decompose.shape, 'single');
+    assert.ok(state.decompose.completedAt, 'planned, not unplanned');
+  });
+
+  it('consumer 1 — code-review.js resolves review depth off the single-mode checkpoint', async () => {
+    const depth = await resolveReviewDepthForEpic({
+      epicId: EPIC_ID,
+      provider,
+    });
+    assert.equal(depth, 'deep');
+  });
+
+  it('consumer 2 — epic-audit-prepare.js routes lenses off the single-mode checkpoint', async () => {
+    const lenses = await resolveRiskRoutedLenses({
+      epicId: EPIC_ID,
+      provider,
+      resolveAuditLenses: (envelope) => envelope.axes.map((a) => a.axis),
+    });
+    assert.deepEqual(lenses, ['critical-workflow']);
+  });
+
+  it('consumer 3 — locked-pipeline.js inherits the envelope from the single-mode checkpoint', async () => {
+    const envelope = await resolveParentEpicPlanningRisk({
+      provider,
+      epicId: EPIC_ID,
+    });
+    assert.deepEqual(envelope, PLANNING_RISK);
+  });
+
+  it('consumer 4 — the decompose context reader surfaces the single-mode fields verbatim', async () => {
+    const ctx = await buildDecompositionContext(EPIC_ID, provider, {
+      planning: { maxTickets: 60 },
+    });
+    assert.deepEqual(ctx.planningRisk, PLANNING_RISK);
+    assert.deepEqual(ctx.reviewRouting, REVIEW_ROUTING);
+  });
+});
+
 describe('plan-persist — ≥60-ticket rate-limit recovery re-proof (#4474 PR3 risk)', () => {
   let sandbox;
   let epicsDir;

--- a/tests/scripts/plan-persist.integration.test.js
+++ b/tests/scripts/plan-persist.integration.test.js
@@ -43,8 +43,8 @@ import { upsertEpicSection } from '../../.agents/scripts/lib/epic-body-sections.
 import { AGENT_LABELS } from '../../.agents/scripts/lib/label-constants.js';
 import { read as readPlanState } from '../../.agents/scripts/lib/orchestration/epic-plan-state-store.js';
 import {
-  assertFanOutMode,
   PLAN_CHECKPOINT_SCHEMA_VERSION_V2,
+  resolveDeliveryMode,
   runPlanPersist,
 } from '../../.agents/scripts/lib/orchestration/plan-persist/run-plan-persist.js';
 import {
@@ -470,29 +470,26 @@ describe('plan-persist — fail-closed ordering (design non-negotiable 2)', () =
   });
 });
 
-describe('plan-persist — mode coherence (PR4 seam)', () => {
+describe('plan-persist — mode coherence (PR4: resolveDeliveryMode)', () => {
   it('refuses fan-out without tickets', () => {
     assert.throws(
-      () => assertFanOutMode(RISK_VERDICT, undefined),
+      () => resolveDeliveryMode(RISK_VERDICT, undefined),
       /fan-out persist requires a non-empty tickets array/,
     );
     assert.throws(
-      () => assertFanOutMode(RISK_VERDICT, []),
+      () => resolveDeliveryMode(RISK_VERDICT, []),
       /non-empty tickets/,
     );
   });
 
-  it('refuses deliveryShape "single" until PR4 lands', () => {
-    // NOTE: the shipped risk-verdict schema (additionalProperties: false)
-    // also rejects deliveryShape at the CLI's loadRiskVerdict boundary; this
-    // module-level guard is the explicit seam PR4 replaces.
+  it('refuses deliveryShape "single" combined with a tickets payload (DAG-skip fence)', () => {
     assert.throws(
       () =>
-        assertFanOutMode(
+        resolveDeliveryMode(
           { ...RISK_VERDICT, deliveryShape: 'single' },
           buildTickets(),
         ),
-      /PR4/,
+      /mode-coherence/,
     );
   });
 

--- a/tests/scripts/plan-persist.modes.test.js
+++ b/tests/scripts/plan-persist.modes.test.js
@@ -1,0 +1,933 @@
+/**
+ * tests/scripts/plan-persist.modes.test.js — Epic #4474 PR4.
+ *
+ * Mode-matrix coverage for the delivery-shape modes of the collapsed
+ * persist surface (design §2):
+ *
+ *   - risk-verdict schema: the new optional `deliveryShape` /
+ *     `deliveryShapeRationale` fields validate; existing verdicts stay
+ *     valid; bad enums and a shape without rationale fail closed;
+ *   - table-driven mode coherence (`resolveDeliveryMode`): full /
+ *     spec-only / amend × valid and incoherent inputs — including the
+ *     DAG-skip fence (single + tickets is a hard error, so the
+ *     validator/DAG skip branch is unreachable when tickets are present);
+ *   - single-delivery persist variant: `delivery::single` marker, NO story
+ *     tree, `decompose = { ticketCount: 0, shape: "single" }` checkpoint,
+ *     summary routing record `{ deliveryShape, sliceCount,
+ *     routingReasons }`, section gate + healthcheck still enforced;
+ *   - fan-out `--force` over a former single plan drops the stale marker;
+ *   - `--amend` delta path: op partition validation, merged-set DAG
+ *     (cycle spanning add → keep → modify; dependency on a closed slug),
+ *     close-op confirmation gate (exit-2-style error with the dry-run
+ *     diff, zero mutations), op-mapped apply (close, close-and-recreate,
+ *     create, keep untouched by construction), state-ledger rebuild.
+ */
+
+import assert from 'node:assert/strict';
+import { mkdtempSync, rmSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, it } from 'node:test';
+
+import { upsertEpicSection } from '../../.agents/scripts/lib/epic-body-sections.js';
+import {
+  AGENT_LABELS,
+  DELIVERY_LABELS,
+} from '../../.agents/scripts/lib/label-constants.js';
+import { validateRiskVerdict } from '../../.agents/scripts/lib/orchestration/epic-plan-spec/phases/risk-verdict.js';
+import { read as readPlanState } from '../../.agents/scripts/lib/orchestration/epic-plan-state-store.js';
+import {
+  AmendExplicitCloseError,
+  buildMergedTicketSet,
+  partitionAmendTickets,
+} from '../../.agents/scripts/lib/orchestration/plan-persist/amend.js';
+import {
+  countDeliverySlices,
+  resolveDeliveryMode,
+} from '../../.agents/scripts/lib/orchestration/plan-persist/delivery-mode.js';
+import { runPlanPersist } from '../../.agents/scripts/lib/orchestration/plan-persist/run-plan-persist.js';
+import { PLAN_SUMMARY_COMMENT_TYPE } from '../../.agents/scripts/lib/orchestration/plan-persist/summary.js';
+import { structuredCommentMarker } from '../../.agents/scripts/lib/orchestration/ticketing.js';
+import { writeSpec } from '../../.agents/scripts/lib/spec/index.js';
+import { serialize } from '../../.agents/scripts/lib/story-body/story-body.js';
+
+const EPIC_ID = 8877;
+const OPERATOR = 'plan-persist-modes-tester';
+const CONFIG = { github: { operatorHandle: OPERATOR } };
+
+const TECH_SPEC = [
+  '## Delivery Slicing',
+  '',
+  '| Slice | What ships | Independent? |',
+  '| --- | --- | --- |',
+  '| S1 | the schema | No |',
+  '| S2 | the modes | No |',
+].join('\n');
+
+const FAN_OUT_VERDICT = {
+  axes: [
+    {
+      axis: 'internal-refactor',
+      level: 'low',
+      rationale: 'Test fixture — internal tooling only.',
+    },
+  ],
+  summary: 'Low-risk internal refactor (test fixture).',
+};
+
+const SINGLE_VERDICT = {
+  ...FAN_OUT_VERDICT,
+  deliveryShape: 'single',
+  deliveryShapeRationale:
+    'Delivery Slicing is a pure 2-slice dependent chain — one-pass-sized.',
+};
+
+/** Build a minimal valid Story ticket. */
+function ticket(slug, { dependsOn = [], op, id, title } = {}) {
+  const t = {
+    slug,
+    type: 'story',
+    title: title ?? `Story ${slug}`,
+    body: serialize({
+      goal: `Goal of ${slug}.`,
+      changes: [
+        {
+          path: 'tests/scripts/epic-plan.spec-flow.test.js',
+          assumption: 'refactors-existing',
+        },
+      ],
+      acceptance: [`${slug} done`],
+      verify: ['npm test (validate)'],
+    }),
+    labels: ['type::story'],
+    depends_on: dependsOn,
+    acceptance: [`${slug} done`],
+    verify: ['npm test (validate)'],
+  };
+  if (op !== undefined) t.op = op;
+  if (id !== undefined) t.id = id;
+  return t;
+}
+
+/** In-memory provider stub (same surface the PR3 integration stub covers). */
+function buildStubProvider({
+  epicLabels = ['type::epic'],
+  children = [],
+} = {}) {
+  let nextId = 9500;
+  let nextCommentId = 1000;
+  const issues = new Map();
+  const comments = new Map();
+  const labelHistory = [];
+  issues.set(EPIC_ID, {
+    id: EPIC_ID,
+    title: 'Modes Test Epic',
+    body: upsertEpicSection(
+      '## Context\nModes fixture.\n',
+      'techSpec',
+      TECH_SPEC,
+    ),
+    labels: [...epicLabels],
+    assignees: [],
+    state: 'open',
+  });
+  for (const child of children) {
+    issues.set(child.id, {
+      parentId: EPIC_ID,
+      labels: ['type::story'],
+      assignees: [],
+      state: 'open',
+      body: '',
+      ...child,
+    });
+  }
+  return {
+    issues,
+    comments,
+    labelHistory,
+    createTicketCalls: 0,
+    async getEpic(id) {
+      return issues.get(id);
+    },
+    async getTicket(id) {
+      return issues.get(id);
+    },
+    async getTickets() {
+      return Array.from(issues.values()).filter((t) => t.id !== EPIC_ID);
+    },
+    async getSubTickets(parentId) {
+      return Array.from(issues.values()).filter(
+        (t) => t.parentId === parentId && t.state === 'open',
+      );
+    },
+    async createTicket(parentId, payload) {
+      this.createTicketCalls += 1;
+      const id = nextId++;
+      issues.set(id, {
+        id,
+        parentId,
+        title: payload.title,
+        body: payload.body ?? '',
+        labels: payload.labels ?? [],
+        assignees: [],
+        state: 'open',
+      });
+      return { id, url: `https://stub/issues/${id}` };
+    },
+    async updateTicket(id, patch) {
+      const cur = issues.get(id) ?? { id, labels: [], assignees: [] };
+      if (patch.title) cur.title = patch.title;
+      if (patch.body !== undefined) cur.body = patch.body;
+      if (Array.isArray(patch.assignees)) cur.assignees = [...patch.assignees];
+      if (Array.isArray(patch.labels)) cur.labels = [...patch.labels];
+      if (
+        patch.labels &&
+        typeof patch.labels === 'object' &&
+        !Array.isArray(patch.labels)
+      ) {
+        const existing = new Set(cur.labels ?? []);
+        for (const add of patch.labels.add ?? []) {
+          existing.add(add);
+          labelHistory.push({ id, op: 'add', label: add });
+        }
+        for (const rm of patch.labels.remove ?? []) {
+          existing.delete(rm);
+          labelHistory.push({ id, op: 'remove', label: rm });
+        }
+        cur.labels = Array.from(existing);
+      }
+      if (patch.state) cur.state = patch.state;
+      issues.set(id, cur);
+      return cur;
+    },
+    async getTicketComments(id) {
+      return comments.get(id) ?? [];
+    },
+    async createComment(id, body) {
+      const cid = nextCommentId++;
+      const arr = comments.get(id) ?? [];
+      arr.push({ id: cid, body });
+      comments.set(id, arr);
+      return { id: cid, body };
+    },
+    async postComment(id, payload) {
+      const body = typeof payload === 'string' ? payload : payload.body;
+      return this.createComment(id, body);
+    },
+    async updateComment(_issueId, commentId, body) {
+      for (const arr of comments.values()) {
+        for (const c of arr) {
+          if (c.id === commentId) {
+            c.body = body;
+            return c;
+          }
+        }
+      }
+      return null;
+    },
+    async deleteComment() {
+      return false;
+    },
+    async addSubIssue() {
+      return { ok: true };
+    },
+    async removeSubIssue() {
+      return { ok: true };
+    },
+    primeTicketCache() {},
+  };
+}
+
+function commentsOfType(provider, epicId, type) {
+  const marker = structuredCommentMarker(type);
+  return (provider.comments.get(epicId) ?? []).filter((c) =>
+    c.body.startsWith(marker),
+  );
+}
+
+let sandbox;
+let epicsDir;
+
+beforeEach(() => {
+  sandbox = mkdtempSync(path.join(os.tmpdir(), 'plan-persist-modes-'));
+  epicsDir = path.join(sandbox, '.agents', 'epics');
+});
+
+afterEach(() => {
+  if (sandbox) rmSync(sandbox, { recursive: true, force: true });
+});
+
+function baseOpts(overrides = {}) {
+  return {
+    skipHealthcheck: true,
+    skipCleanup: true,
+    spawnSync: () => ({ status: 0, stdout: '', stderr: '' }),
+    writeSpecFn: (epicId, spec) => writeSpec(epicId, spec, { epicsDir }),
+    loadStateFn: () => ({ epicId: EPIC_ID, mapping: {} }),
+    writeStateFn: () => '/dev/null',
+    bddProbeFn: async () => null,
+    ...overrides,
+  };
+}
+
+function baseInput(provider, { artifacts = {}, opts = {} } = {}) {
+  return {
+    epicId: EPIC_ID,
+    provider,
+    artifacts: {
+      techSpecContent: TECH_SPEC,
+      acceptanceSpecContent: null,
+      riskVerdict: FAN_OUT_VERDICT,
+      tickets: null,
+      ...artifacts,
+    },
+    config: CONFIG,
+    settings: {
+      baseBranch: 'main',
+      paths: { tempRoot: path.join(sandbox, 'temp') },
+    },
+    opts: baseOpts(opts),
+  };
+}
+
+describe('risk-verdict schema — deliveryShape field (PR4)', () => {
+  it('accepts a verdict without deliveryShape (existing verdicts stay valid)', () => {
+    assert.equal(validateRiskVerdict(FAN_OUT_VERDICT), FAN_OUT_VERDICT);
+  });
+
+  it('accepts deliveryShape "single" and "fan-out" with a rationale', () => {
+    assert.ok(validateRiskVerdict(SINGLE_VERDICT));
+    assert.ok(
+      validateRiskVerdict({
+        ...FAN_OUT_VERDICT,
+        deliveryShape: 'fan-out',
+        deliveryShapeRationale: '4 independent slices.',
+      }),
+    );
+  });
+
+  it('rejects an unknown deliveryShape enum value', () => {
+    assert.throws(
+      () =>
+        validateRiskVerdict({
+          ...FAN_OUT_VERDICT,
+          deliveryShape: 'mob',
+          deliveryShapeRationale: 'x',
+        }),
+      /schema validation/,
+    );
+  });
+
+  it('rejects deliveryShape without deliveryShapeRationale (dependentRequired)', () => {
+    assert.throws(
+      () =>
+        validateRiskVerdict({ ...FAN_OUT_VERDICT, deliveryShape: 'single' }),
+      /schema validation/,
+    );
+  });
+});
+
+describe('resolveDeliveryMode — table-driven mode matrix (design §2)', () => {
+  const tickets = () => [ticket('story-a')];
+  const amendTickets = () => [ticket('story-a', { op: 'add' })];
+
+  const rows = [
+    {
+      name: 'full fan-out (shape absent) with tickets',
+      verdict: FAN_OUT_VERDICT,
+      tickets: tickets(),
+      amend: false,
+      expect: 'fan-out',
+    },
+    {
+      name: 'explicit fan-out with tickets',
+      verdict: { ...FAN_OUT_VERDICT, deliveryShape: 'fan-out' },
+      tickets: tickets(),
+      amend: false,
+      expect: 'fan-out',
+    },
+    {
+      name: 'spec-only single with no tickets',
+      verdict: SINGLE_VERDICT,
+      tickets: null,
+      amend: false,
+      expect: 'single',
+    },
+    {
+      name: 'single with an empty tickets array is still single (no payload)',
+      verdict: SINGLE_VERDICT,
+      tickets: [],
+      amend: false,
+      expect: 'single',
+    },
+    {
+      name: 'single WITH tickets — DAG-skip fence (incoherent)',
+      verdict: SINGLE_VERDICT,
+      tickets: tickets(),
+      amend: false,
+      expect: /mode-coherence/,
+    },
+    {
+      name: 'fan-out without tickets (incoherent)',
+      verdict: FAN_OUT_VERDICT,
+      tickets: null,
+      amend: false,
+      expect: /non-empty tickets array/,
+    },
+    {
+      name: 'unknown shape (incoherent)',
+      verdict: { ...FAN_OUT_VERDICT, deliveryShape: 'mob' },
+      tickets: tickets(),
+      amend: false,
+      expect: /unknown deliveryShape/,
+    },
+    {
+      name: 'amend with op-carrying tickets',
+      verdict: FAN_OUT_VERDICT,
+      tickets: amendTickets(),
+      amend: true,
+      expect: 'amend',
+    },
+    {
+      name: 'amend + single shape (incoherent)',
+      verdict: SINGLE_VERDICT,
+      tickets: amendTickets(),
+      amend: true,
+      expect: /incoherent with deliveryShape "single"/,
+    },
+    {
+      name: 'amend without tickets (incoherent)',
+      verdict: FAN_OUT_VERDICT,
+      tickets: null,
+      amend: true,
+      expect: /--amend requires a tickets payload/,
+    },
+    {
+      name: 'op fields without --amend (incoherent)',
+      verdict: FAN_OUT_VERDICT,
+      tickets: amendTickets(),
+      amend: false,
+      expect: /--amend was not passed/,
+    },
+  ];
+
+  for (const row of rows) {
+    it(row.name, () => {
+      if (typeof row.expect === 'string') {
+        assert.equal(
+          resolveDeliveryMode(row.verdict, row.tickets, { amend: row.amend }),
+          row.expect,
+        );
+      } else {
+        assert.throws(
+          () =>
+            resolveDeliveryMode(row.verdict, row.tickets, {
+              amend: row.amend,
+            }),
+          row.expect,
+        );
+      }
+    });
+  }
+});
+
+describe('plan-persist — single-delivery variant (spec-only)', () => {
+  it('applies delivery::single, creates NO story tree, checkpoints {ticketCount: 0, shape: "single"}, and records the routing record', async () => {
+    const provider = buildStubProvider();
+    const spawnCalls = [];
+    const result = await runPlanPersist(
+      baseInput(provider, {
+        artifacts: { riskVerdict: SINGLE_VERDICT, tickets: null },
+        opts: {
+          spawnSync: (...args) => {
+            spawnCalls.push(args);
+            return { status: 0, stdout: '', stderr: '' };
+          },
+        },
+      }),
+    );
+
+    const epic = provider.issues.get(EPIC_ID);
+    // Marker + terminal ready flip; no story tree, no reconciler spawn.
+    assert.ok(epic.labels.includes(DELIVERY_LABELS.SINGLE));
+    assert.ok(epic.labels.includes(AGENT_LABELS.READY));
+    assert.equal(provider.createTicketCalls, 0, 'no story tree in single mode');
+    assert.equal(spawnCalls.length, 0, 'reconciler never spawned');
+
+    // Managed sections + risk comment still persisted (single mode skips
+    // ONLY the ticket validator/DAG and the story tree).
+    assert.match(epic.body, /## Delivery Slicing/);
+    assert.equal(commentsOfType(provider, EPIC_ID, 'risk-verdict').length, 1);
+
+    // Checkpoint: deliberate zero-ticket single-shape decompose block.
+    const state = await readPlanState({ provider, epicId: EPIC_ID });
+    assert.equal(state.decompose.ticketCount, 0);
+    assert.equal(state.decompose.shape, 'single');
+    assert.ok(state.decompose.completedAt);
+    assert.equal(state.persist.mode, 'single');
+    assert.ok(state.persist.completedAt);
+
+    // Summary carries the routing record with sliceCount from the
+    // Delivery Slicing table and the verdict rationale as routingReasons.
+    const summaries = commentsOfType(
+      provider,
+      EPIC_ID,
+      PLAN_SUMMARY_COMMENT_TYPE,
+    );
+    assert.equal(summaries.length, 1);
+    assert.match(summaries[0].body, /"deliveryShape": "single"/);
+    assert.match(summaries[0].body, /"sliceCount": 2/);
+    assert.match(summaries[0].body, /pure 2-slice dependent chain/);
+    assert.match(summaries[0].body, /inert until #4475/);
+
+    // Result envelope.
+    assert.equal(result.mode, 'single');
+    assert.equal(result.ticketCount, 0);
+    assert.deepEqual(result.waveTable, []);
+    assert.equal(result.single.sliceCount, 2);
+    assert.deepEqual(
+      provider.issues.get(EPIC_ID).assignees,
+      [],
+      'lease released',
+    );
+  });
+
+  it('still enforces the section gate with ZERO provider calls', async () => {
+    const inner = buildStubProvider();
+    let providerCalls = 0;
+    const counting = new Proxy(inner, {
+      get(target, prop, receiver) {
+        const value = Reflect.get(target, prop, receiver);
+        if (typeof value === 'function') {
+          return (...args) => {
+            providerCalls += 1;
+            return value.apply(target, args);
+          };
+        }
+        return value;
+      },
+    });
+    await assert.rejects(
+      runPlanPersist(
+        baseInput(counting, {
+          artifacts: {
+            techSpecContent: '## Not A Spec\n\nNo slicing here.',
+            riskVerdict: SINGLE_VERDICT,
+            tickets: null,
+          },
+        }),
+      ),
+      /Delivery Slicing/,
+    );
+    assert.equal(providerCalls, 0);
+  });
+
+  it('still runs the healthcheck gate (a failure refuses the ready flip)', async () => {
+    const provider = buildStubProvider();
+    await assert.rejects(
+      runPlanPersist(
+        baseInput(provider, {
+          artifacts: { riskVerdict: SINGLE_VERDICT, tickets: null },
+          opts: {
+            skipHealthcheck: false,
+            runHealthcheckFn: async () => ({
+              ok: false,
+              reason: 'git remote unreachable',
+            }),
+          },
+        }),
+      ),
+      /Refusing agent::ready handoff/,
+    );
+    const epic = provider.issues.get(EPIC_ID);
+    assert.ok(!epic.labels.includes(AGENT_LABELS.READY));
+    assert.deepEqual(epic.assignees, [], 'lease released on gate failure');
+  });
+
+  it('a fan-out --force re-persist over a former single plan drops the stale marker', async () => {
+    const provider = buildStubProvider({
+      epicLabels: ['type::epic', DELIVERY_LABELS.SINGLE],
+    });
+    await runPlanPersist(
+      baseInput(provider, {
+        artifacts: {
+          riskVerdict: FAN_OUT_VERDICT,
+          tickets: [
+            ticket('story-a'),
+            ticket('story-b', { dependsOn: ['story-a'] }),
+          ],
+        },
+        opts: { force: true },
+      }),
+    );
+    const epic = provider.issues.get(EPIC_ID);
+    assert.ok(!epic.labels.includes(DELIVERY_LABELS.SINGLE));
+    assert.ok(epic.labels.includes(AGENT_LABELS.READY));
+  });
+
+  it('countDeliverySlices fails open to null without a slicing table', () => {
+    assert.equal(countDeliverySlices('## Something Else\n\ntext'), null);
+    assert.equal(countDeliverySlices(TECH_SPEC), 2);
+  });
+});
+
+describe('plan-persist — amend op partition and merged set', () => {
+  it('partitions valid ops and rejects unknown/missing ops and duplicate slugs', () => {
+    const partition = partitionAmendTickets([
+      ticket('a', { op: 'add' }),
+      ticket('b', { op: 'modify' }),
+      ticket('c', { op: 'keep' }),
+      ticket('d', { op: 'close' }),
+    ]);
+    assert.deepEqual(
+      [
+        partition.add.length,
+        partition.modify.length,
+        partition.keep.length,
+        partition.close.length,
+      ],
+      [1, 1, 1, 1],
+    );
+    assert.throws(
+      () => partitionAmendTickets([ticket('a', { op: 'replace' })]),
+      /invalid op/,
+    );
+    assert.throws(() => partitionAmendTickets([ticket('a')]), /invalid op/);
+    assert.throws(
+      () =>
+        partitionAmendTickets([
+          ticket('a', { op: 'add' }),
+          ticket('a', { op: 'keep' }),
+        ]),
+      /duplicate slug/,
+    );
+  });
+
+  it('buildMergedTicketSet excludes closes and strips op/id carrier fields', () => {
+    const merged = buildMergedTicketSet([
+      ticket('a', { op: 'add' }),
+      ticket('b', { op: 'keep', id: 9001 }),
+      ticket('c', { op: 'close', id: 9002 }),
+    ]);
+    assert.deepEqual(
+      merged.map((t) => t.slug),
+      ['a', 'b'],
+    );
+    for (const t of merged) {
+      assert.ok(!('op' in t), 'op stripped');
+      assert.ok(!('id' in t), 'id stripped');
+    }
+  });
+});
+
+describe('plan-persist — amend delta path (integration)', () => {
+  const KEEP_ID = 9001;
+  const MOD_ID = 9002;
+  const CLOSE_ID = 9003;
+
+  function amendChildren() {
+    return [
+      { id: KEEP_ID, title: 'Story story-keep', body: 'keep body' },
+      { id: MOD_ID, title: 'Story story-mod', body: 'old mod body' },
+      { id: CLOSE_ID, title: 'Story story-close', body: 'close body' },
+    ];
+  }
+
+  function ledger() {
+    return {
+      epicId: EPIC_ID,
+      mapping: {
+        'story-keep': { entity: 'story', issueNumber: KEEP_ID },
+        'story-mod': { entity: 'story', issueNumber: MOD_ID },
+        'story-close': { entity: 'story', issueNumber: CLOSE_ID },
+      },
+    };
+  }
+
+  function amendPayload() {
+    return [
+      ticket('story-keep', { op: 'keep' }),
+      ticket('story-mod', { op: 'modify', dependsOn: ['story-keep'] }),
+      ticket('story-new', { op: 'add', dependsOn: ['story-mod'] }),
+      ticket('story-close', { op: 'close' }),
+    ];
+  }
+
+  it('refuses close ops without --explicit-delete: exit-2-style error, dry-run diff, ZERO mutations', async () => {
+    const provider = buildStubProvider({ children: amendChildren() });
+    let caught;
+    try {
+      await runPlanPersist(
+        baseInput(provider, {
+          artifacts: { tickets: amendPayload() },
+          opts: { amend: true, loadStateFn: () => ledger() },
+        }),
+      );
+      assert.fail('expected AmendExplicitCloseError');
+    } catch (err) {
+      caught = err;
+    }
+    assert.ok(caught instanceof AmendExplicitCloseError);
+    assert.equal(caught.code, 'PLAN_AMEND_EXPLICIT_DELETE_REQUIRED');
+    assert.match(
+      caught.diff,
+      /\| close \| `story-close` \| #9003 \| closed \|/,
+    );
+    assert.match(
+      caught.diff,
+      /\| modify \| `story-mod` \| #9002 \| closed \+ recreated \|/,
+    );
+    assert.match(caught.diff, /\| add \| `story-new` \| — \| created \|/);
+    assert.match(
+      caught.diff,
+      /\| keep \| `story-keep` \| #9001 \| untouched \|/,
+    );
+
+    // Nothing mutated: all three children still open, no new issues.
+    assert.equal(provider.issues.get(CLOSE_ID).state, 'open');
+    assert.equal(provider.issues.get(MOD_ID).state, 'open');
+    assert.equal(provider.createTicketCalls, 0);
+  });
+
+  it('applies the op map with --explicit-delete: close, close-and-recreate, create, keep untouched', async () => {
+    const provider = buildStubProvider({ children: amendChildren() });
+    const stateWrites = [];
+    const spawnCalls = [];
+    const result = await runPlanPersist(
+      baseInput(provider, {
+        artifacts: { tickets: amendPayload() },
+        opts: {
+          amend: true,
+          explicitDelete: true,
+          loadStateFn: () => ledger(),
+          writeStateFn: (epicId, state) => {
+            stateWrites.push({ epicId, state });
+            return '/dev/null';
+          },
+          spawnSync: (...args) => {
+            spawnCalls.push(args);
+            return { status: 0, stdout: '', stderr: '' };
+          },
+        },
+      }),
+    );
+
+    // close op: closed. modify op: closed + recreated. keep: byte-untouched.
+    assert.equal(provider.issues.get(CLOSE_ID).state, 'closed');
+    assert.equal(provider.issues.get(MOD_ID).state, 'closed');
+    const keep = provider.issues.get(KEEP_ID);
+    assert.equal(keep.state, 'open');
+    assert.equal(keep.body, 'keep body', 'keep is never touched');
+    // Two creations: the modify recreate + the add.
+    assert.equal(provider.createTicketCalls, 2);
+    assert.equal(spawnCalls.length, 0, 'amend never spawns the reconciler');
+
+    // Result envelope + summary.
+    assert.equal(result.mode, 'amend');
+    assert.equal(result.ticketCount, 3, 'merged set: keep + modify + add');
+    assert.equal(result.amend.closed.length, 1);
+    assert.equal(result.amend.recreated.length, 1);
+    assert.equal(result.amend.created.length, 1);
+    assert.equal(result.amend.keptCount, 1);
+    const summaries = commentsOfType(
+      provider,
+      EPIC_ID,
+      PLAN_SUMMARY_COMMENT_TYPE,
+    );
+    assert.equal(summaries.length, 1);
+    assert.match(
+      summaries[0].body,
+      /Amend delta: 1 added, 1 modified \(closed \+ recreated\), 1 closed, 1 kept untouched\./,
+    );
+
+    // Merged-set checkpoint (fan-out shape) + terminal persist mode.
+    const state = await readPlanState({ provider, epicId: EPIC_ID });
+    assert.equal(state.decompose.ticketCount, 3);
+    assert.equal(state.decompose.shape, 'fan-out');
+    assert.equal(state.persist.mode, 'amend');
+    assert.ok(state.persist.completedAt);
+
+    // State ledger rebuilt over the merged set: closed slugs dropped,
+    // recreated/created slugs mapped to fresh issue numbers, keep intact.
+    const written = stateWrites.at(-1).state;
+    assert.ok(!('story-close' in written.mapping));
+    assert.equal(written.mapping['story-keep'].issueNumber, KEEP_ID);
+    assert.notEqual(written.mapping['story-mod'].issueNumber, MOD_ID);
+    assert.ok(Number.isInteger(written.mapping['story-new'].issueNumber));
+
+    // Terminal flip + lease release.
+    const epic = provider.issues.get(EPIC_ID);
+    assert.ok(epic.labels.includes(AGENT_LABELS.READY));
+    assert.deepEqual(epic.assignees, []);
+  });
+
+  it('an amend without live close ops proceeds without --explicit-delete', async () => {
+    const provider = buildStubProvider({
+      children: [{ id: KEEP_ID, title: 'Story story-keep', body: 'keep body' }],
+    });
+    const result = await runPlanPersist(
+      baseInput(provider, {
+        artifacts: {
+          tickets: [
+            ticket('story-keep', { op: 'keep' }),
+            ticket('story-new', { op: 'add', dependsOn: ['story-keep'] }),
+          ],
+        },
+        opts: {
+          amend: true,
+          loadStateFn: () => ({
+            epicId: EPIC_ID,
+            mapping: {
+              'story-keep': { entity: 'story', issueNumber: KEEP_ID },
+            },
+          }),
+        },
+      }),
+    );
+    assert.equal(result.mode, 'amend');
+    assert.equal(result.amend.created.length, 1);
+    assert.equal(provider.issues.get(KEEP_ID).state, 'open');
+  });
+
+  it('validates the DAG over the MERGED set: a cycle spanning add → keep → modify is rejected before any provider call', async () => {
+    const inner = buildStubProvider({ children: amendChildren() });
+    let providerCalls = 0;
+    const counting = new Proxy(inner, {
+      get(target, prop, receiver) {
+        const value = Reflect.get(target, prop, receiver);
+        if (typeof value === 'function') {
+          return (...args) => {
+            providerCalls += 1;
+            return value.apply(target, args);
+          };
+        }
+        return value;
+      },
+    });
+    await assert.rejects(
+      runPlanPersist(
+        baseInput(counting, {
+          artifacts: {
+            tickets: [
+              ticket('story-keep', { op: 'keep', dependsOn: ['story-mod'] }),
+              ticket('story-mod', { op: 'modify', dependsOn: ['story-new'] }),
+              ticket('story-new', { op: 'add', dependsOn: ['story-keep'] }),
+            ],
+          },
+          opts: {
+            amend: true,
+            explicitDelete: true,
+            loadStateFn: () => ledger(),
+          },
+        }),
+      ),
+      /Circular dependency/,
+    );
+    assert.equal(providerCalls, 0, 'merged-set DAG rejects pre-provider');
+  });
+
+  it('rejects a dependency pointing at a closed slug (unknown in the merged set)', async () => {
+    const provider = buildStubProvider({ children: amendChildren() });
+    await assert.rejects(
+      runPlanPersist(
+        baseInput(provider, {
+          artifacts: {
+            tickets: [
+              ticket('story-keep', { op: 'keep', dependsOn: ['story-close'] }),
+              ticket('story-close', { op: 'close' }),
+            ],
+          },
+          opts: {
+            amend: true,
+            explicitDelete: true,
+            loadStateFn: () => ledger(),
+          },
+        }),
+      ),
+      /unknown slugs/,
+    );
+  });
+
+  it('hard-errors when a modify slug resolves to no existing issue (never guesses)', async () => {
+    const provider = buildStubProvider({ children: amendChildren() });
+    await assert.rejects(
+      runPlanPersist(
+        baseInput(provider, {
+          artifacts: {
+            tickets: [ticket('story-ghost', { op: 'modify' })],
+          },
+          opts: {
+            amend: true,
+            explicitDelete: true,
+            loadStateFn: () => ledger(),
+          },
+        }),
+      ),
+      /resolves to no existing issue/,
+    );
+  });
+
+  it('hard-errors when an add slug collides with an existing mapped issue', async () => {
+    const provider = buildStubProvider({ children: amendChildren() });
+    await assert.rejects(
+      runPlanPersist(
+        baseInput(provider, {
+          artifacts: {
+            tickets: [ticket('story-keep', { op: 'add' })],
+          },
+          opts: {
+            amend: true,
+            explicitDelete: true,
+            loadStateFn: () => ledger(),
+          },
+        }),
+      ),
+      /collides with existing issue #9001/,
+    );
+  });
+
+  it('resolves an explicit ticket `id` ahead of the state ledger', async () => {
+    // Empty ledger; the ticket carries the issue number itself (the
+    // authoring envelope's open-children listing is the source).
+    const provider = buildStubProvider({ children: amendChildren() });
+    const result = await runPlanPersist(
+      baseInput(provider, {
+        artifacts: {
+          tickets: [ticket('story-keep', { op: 'keep', id: KEEP_ID })],
+        },
+        opts: {
+          amend: true,
+          loadStateFn: () => ({ epicId: EPIC_ID, mapping: {} }),
+        },
+      }),
+    );
+    assert.equal(result.amend.keptCount, 1);
+  });
+
+  it('rejects --amend combined with --force or --resume, and with ideation mode', async () => {
+    const provider = buildStubProvider({ children: amendChildren() });
+    await assert.rejects(
+      runPlanPersist(
+        baseInput(provider, {
+          artifacts: { tickets: amendPayload() },
+          opts: { amend: true, force: true },
+        }),
+      ),
+      /mutually exclusive/,
+    );
+    await assert.rejects(
+      runPlanPersist({
+        ...baseInput(provider, {
+          artifacts: {
+            tickets: amendPayload(),
+            onePagerContent: '# Idea\n\n## Context\nx\n',
+            templateContent: '# {{title}}\n\n## Context\n{{context}}\n',
+          },
+          opts: { amend: true },
+        }),
+        epicId: null,
+      }),
+      /--amend requires --epic/,
+    );
+  });
+});


### PR DESCRIPTION
PR4 of the M3 `/plan`-collapse migration (#4474, design §2 mode matrix + §6 PR4). Builds on PR1 (plan-metrics), PR2 (`plan-context.js`), and PR3 (`plan-persist.js`, #4490); replaces the PR3 seams that hard-refused `deliveryShape: "single"` and `--amend`.

## Mode matrix as implemented

| Mode | Selector | Gates | Mutation |
| --- | --- | --- | --- |
| **Full (fan-out)** | `deliveryShape` absent or `"fan-out"` + tickets | section gate, risk schema, ticket validator, file-assumption gate, DAG, sizing, budget, freshness, healthcheck | story tree via the structural reconciler (unchanged from PR3); a `--force` re-persist over a former single plan drops the stale `delivery::single` marker |
| **Spec-only / single-delivery** | `deliveryShape: "single"` + **no** tickets | section gate, risk schema, freshness, healthcheck; ticket validator + DAG **skipped — fenced by construction**: `resolveDeliveryMode` hard-errors on `single` + any tickets payload, so the skip branch is unreachable when tickets are present | NO story tree; `delivery::single` label applied (new taxonomy entry, ensured by bootstrap); checkpoint `decompose = { ticketCount: 0, shape: "single" }` so delivery-time consumers never misread absence as unplanned; summary records the routing record `{ deliveryShape: "single", sliceCount, routingReasons }` (sliceCount parsed from the spec's Delivery Slicing table, routingReasons from the verdict's `deliveryShapeRationale`) |
| **Change-request amend** | `--amend` + tickets carrying `op: add\|modify\|keep\|close` | all fan-out gates over the **merged set** (existing keeps + adds + modifies − closes): a cycle spanning an add → kept story → modify is caught pre-provider, and a dependency on a closed slug fails the unknown-slug check | op-mapped delta: close ops close; modify ops close-and-recreate (scoped to modify/close slugs ONLY — never the whole tree, which stays `--force` semantics); adds created; keeps untouched by construction (no code path receives them); state ledger + blocked-by edges rebuilt over the merged set; managed sections force-overwritten (the amended spec IS the delta's spec half). AC IDs stay stable per the re-plan contract (`authoring-context.js:249-256` — prior sections ride along in the epic body; persist never mangles authored bodies) |

**Close-op confirmation (exit 2).** An amend whose plan would close live issues (close ops + the close half of modify) without `--explicit-delete` prints the dry-run op diff (`| Op | Slug | Issue | Effect |`) and exits **2**, mutating nothing — mirroring the `epic-reconcile.js` `EXIT_CODES.EXPLICIT_DELETE_REQUIRED` contract. Non-interactive callers pass `--explicit-delete`. Slug → issue resolution never guesses: explicit ticket `id` wins, else the reconciler state ledger, else a hard error naming the slug.

## Schema

`risk-verdict.schema.json` gains optional `deliveryShape` (`"fan-out" | "single"`) and `deliveryShapeRationale` (`dependentRequired` — any explicit shape needs a rationale). Absent field defaults to fan-out, so **every existing verdict stays valid**.

## Inert-by-default

Nothing in the deliver path reads `delivery::single` — the deliver-side reader is **#4475's scope**, not this PR's. Until it lands, `plan-context.js`'s `deliveryShapeSignal` keeps recommending fan-out for every ambiguous case, and a `delivery::single` epic is simply an epic with no story tree that `/deliver` does not yet know how to route. PR4 is therefore shippable independently of the merge decision (design review note 3).

## Consumer-compat evidence (single-mode checkpoint)

`tests/scripts/plan-persist.checkpoint-consumers.test.js` gained a single-mode fixture round-trip: a checkpoint written by the real `writeCheckpointV2` with `decompose = { ticketCount: 0, shape: "single" }` + `persist.mode: "single"` is read, unmodified, by all four delivery-time consumers the PR3 regression suite pinned:

1. `lib/orchestration/code-review.js` — `resolveReviewDepthForEpic` resolves `deep` off the judged risk;
2. `epic-audit-prepare.js` — `resolveRiskRoutedLenses` routes lenses off `planningRisk.axes`;
3. `story-close/phases/locked-pipeline.js` — `resolveParentEpicPlanningRisk` inherits the envelope;
4. the decompose context reader — surfaces `planningRisk` / `reviewRouting` verbatim.

## Tests

- table-driven mode matrix (11 rows: full / spec-only / amend × valid + every incoherent combination, incl. the DAG-skip fence and `op` fields without `--amend`);
- schema validation (new fields accepted, bad enum rejected, `dependentRequired` enforced, legacy verdicts valid);
- single-mode persist integration (marker applied, zero story creations, zero reconciler spawns, checkpoint, routing record, section gate + healthcheck still enforced);
- merged-set DAG on amend (cycle via an add depending on a kept story that depends on a modify; dep on a closed slug);
- close-op confirmation (refuses with the dry-run diff and zero mutations; proceeds with `--explicit-delete`; add/keep-only amends need no flag);
- amend apply semantics (close, close-and-recreate, create, keep byte-untouched, state-ledger rebuild).

## Gates

`npm test` (10084 pass / 0 fail), `npm run lint` (biome ci + docs:check), `npm run lint:md` (0 errors), `check-dead-exports.js` (ok), `check-arch-cycles.js` (ok), `check-context-budget.js` (ok), `check-baselines.js` (exit 0) — all run locally before push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
