### PR TITLE
feat(plan): risk/size-conditional critics — consolidation, reachability, pre-mortem (refs #4474)

### DIFF
--- a/.agents/scripts/epic-plan-healthcheck.js
+++ b/.agents/scripts/epic-plan-healthcheck.js
@@ -455,7 +455,11 @@ async function timed(name, fn) {
  *   checks: Array<{name: string, ok: boolean, durationMs: number, detail: string}>}>}
  */
 // exported for tests — direct-unit coverage of the reachability semantics.
-export { checkReachability, extractStoryPaths, globToRegExp };
+// (`resolveNavConfig` / `extractStoryPaths` / `globToRegExp` are also the
+// shared mechanics of the persist-side draft reachability check —
+// `lib/orchestration/plan-reachability.js`, Epic #4474 PR6 — so the two
+// surfaces can never drift apart.)
+export { checkReachability, extractStoryPaths, globToRegExp, resolveNavConfig };
 
 // exported for tests — Story-level reuse runner reserved for future test coverage
 export async function runPlanHealthcheck(opts = {}) {

--- a/.agents/scripts/lib/orchestration/consolidation-precondition.js
+++ b/.agents/scripts/lib/orchestration/consolidation-precondition.js
@@ -19,9 +19,12 @@
  * Delivery Slicing section, an unparseable "Independent?" cell — resolves to
  * `dispatch: true`. This gate can only ever *save* a dispatch when it is
  * confident the critic has nothing to do; it never disables the critic's
- * ability to catch a real divergence. Phase 8.4 (reachability critic), 8.5
- * (pre-mortem critic), and the deterministic ticket validator are
- * unconditional — this precondition governs only the 8.3 dispatch.
+ * ability to catch a real divergence. Since Epic #4474 PR6 this precondition
+ * is one input to the risk/size-conditional dispatch layer
+ * (`plan-critic-conditions.js`): reachability (8.4) is a deterministic
+ * persist-side check (`plan-reachability.js`) and the pre-mortem critic
+ * (8.5) is risk/size-gated; the deterministic ticket validator remains
+ * unconditional.
  *
  * Pure, synchronous, no I/O — callers own reading `tickets.json` and the
  * Epic body off disk / the GitHub API.
@@ -146,10 +149,14 @@ function isBddScaffoldStory(story) {
  *   top-level `slug` / `depends_on` / `body` (serialized string).
  * @param {string} input.epicBody - The Epic body carrying the folded Tech
  *   Spec sections (`## Delivery Slicing` onward).
- * @returns {{ dispatch: boolean, reasons: string[] }} `dispatch: false` only
- *   when the draft matches the Delivery Slicing table 1:1 in count and
- *   dependency shape; `dispatch: true` (with `reasons`) otherwise, including
- *   every fail-open case.
+ * @returns {{ dispatch: boolean, cause: 'match'|'divergence'|'fail-open', reasons: string[] }}
+ *   `dispatch: false` only when the draft matches the Delivery Slicing table
+ *   1:1 in count and dependency shape; `dispatch: true` (with `reasons`)
+ *   otherwise, including every fail-open case. `cause` distinguishes a
+ *   **confirmed** divergence (count or dependency-shape mismatch) from the
+ *   fail-open ambiguity (missing/unparseable table) — the #4474 PR6
+ *   conditional-dispatch layer treats only the former as a firing condition
+ *   on small drafts.
  */
 export function evaluateConsolidationPrecondition({ draftStories, epicBody }) {
   if (!Array.isArray(draftStories)) {
@@ -162,6 +169,7 @@ export function evaluateConsolidationPrecondition({ draftStories, epicBody }) {
   if (!slicing) {
     return {
       dispatch: true,
+      cause: 'fail-open',
       reasons: [
         'Delivery Slicing section is missing or unparseable — fail-open to the critic.',
       ],
@@ -175,6 +183,7 @@ export function evaluateConsolidationPrecondition({ draftStories, epicBody }) {
   if (slicedStories.length !== slicing.length) {
     return {
       dispatch: true,
+      cause: 'divergence',
       reasons: [
         `Story count diverges from Delivery Slicing: ${slicing.length} proposed slice(s) vs ${slicedStories.length} non-scaffold draft Story(ies).`,
       ],
@@ -201,11 +210,12 @@ export function evaluateConsolidationPrecondition({ draftStories, epicBody }) {
   }
 
   if (reasons.length > 0) {
-    return { dispatch: true, reasons };
+    return { dispatch: true, cause: 'divergence', reasons };
   }
 
   return {
     dispatch: false,
+    cause: 'match',
     reasons: [
       `Draft matches Delivery Slicing 1:1 in count and dependency shape (${slicing.length} slice(s)) — skipping the 8.3 consolidation dispatch.`,
     ],

--- a/.agents/scripts/lib/orchestration/plan-critic-conditions.js
+++ b/.agents/scripts/lib/orchestration/plan-critic-conditions.js
@@ -1,0 +1,177 @@
+/**
+ * plan-critic-conditions.js — risk/size-conditional dispatch decisions for
+ * the /plan author-step critics (Epic #4474 PR6, design §4).
+ *
+ * The collapsed plan flow keeps the consolidation (8.3) and pre-mortem
+ * (8.5) critics as fresh-context sub-agent dispatches, but makes each
+ * dispatch **conditional** instead of unconditional — the dominant plan
+ * cost is turns × standing context, and an unconditional critic pays a
+ * full sub-agent spawn even when it provably has nothing to find. This
+ * module computes those decisions deterministically so the workflow never
+ * judges its own dispatch conditions:
+ *
+ *   - **Consolidation (8.3)**: dispatch only when the existing
+ *     `evaluateConsolidationPrecondition` gate says `dispatch: true` AND
+ *     (the draft has more than `CONSOLIDATION_STORY_THRESHOLD` stories OR
+ *     the precondition confirmed a divergence from the Delivery Slicing
+ *     table). A fail-open precondition (missing/unparseable table) on a
+ *     small draft is NOT a confirmed divergence — it skips, because a
+ *     ≤-threshold draft is small enough for gate #2's single-view review
+ *     to catch a distorted shape without a dedicated sub-agent.
+ *   - **Pre-mortem (8.5)**: dispatch when the risk verdict's overall level
+ *     is `high`, OR the ticket count is at least half of `maxTickets`, OR
+ *     any configured `planning.riskHeuristics` phrase matches the plan
+ *     text (case-insensitive substring).
+ *
+ * Under-firing risk (design PR6 note): the persist validators are
+ * unchanged hard gates and G2's cohort re-measures plan quality; every
+ * skip decision this module produces is logged to the plan-metrics ledger
+ * (`appendCriticSkip`) by the callers so under-firing is auditable.
+ *
+ * Pure, synchronous, no I/O — the `plan-critics.js` CLI owns reading the
+ * authored artifacts and the resolved config.
+ */
+
+import { evaluateConsolidationPrecondition } from './consolidation-precondition.js';
+import { deriveRiskEnvelope } from './planning-risk.js';
+
+/**
+ * Draft-story count above which the consolidation critic fires even
+ * without a confirmed slicing divergence (design §6 PR6: "> 5 stories").
+ */
+export const CONSOLIDATION_STORY_THRESHOLD = 5;
+
+/**
+ * @typedef {Object} CriticDispatchDecision
+ * @property {'consolidation'|'pre-mortem'} critic
+ * @property {boolean} dispatch
+ * @property {string[]} reasons Why the critic fires — or why it is safe to
+ *   skip. Never empty: a skip's reasons are the audit trail the
+ *   plan-metrics ledger records.
+ */
+
+/**
+ * Decide the 8.3 consolidation dispatch: precondition AND size/divergence.
+ *
+ * @param {object} input
+ * @param {object[]} input.draftStories - The draft `tickets.json` array
+ *   (raw Story objects with top-level `slug` / `depends_on` / `body`).
+ * @param {string} input.specText - The text carrying the `## Delivery
+ *   Slicing` table. At author time this is the authored `techspec.md`
+ *   content (the Epic body carries the same folded section post-persist).
+ * @returns {CriticDispatchDecision}
+ */
+export function evaluateConsolidationDispatch({ draftStories, specText }) {
+  const precondition = evaluateConsolidationPrecondition({
+    draftStories,
+    epicBody: specText,
+  });
+
+  if (!precondition.dispatch) {
+    return {
+      critic: 'consolidation',
+      dispatch: false,
+      reasons: precondition.reasons,
+    };
+  }
+
+  const storyCount = draftStories.length;
+  const oversized = storyCount > CONSOLIDATION_STORY_THRESHOLD;
+  const diverges = precondition.cause === 'divergence';
+
+  if (!oversized && !diverges) {
+    return {
+      critic: 'consolidation',
+      dispatch: false,
+      reasons: [
+        `Draft has ${storyCount} story(ies) (≤ ${CONSOLIDATION_STORY_THRESHOLD}) and no confirmed Delivery Slicing divergence — gate #2's single-view review covers a draft this small.`,
+        ...precondition.reasons,
+      ],
+    };
+  }
+
+  const reasons = [];
+  if (diverges) reasons.push(...precondition.reasons);
+  if (oversized) {
+    reasons.push(
+      `Draft has ${storyCount} stories (> ${CONSOLIDATION_STORY_THRESHOLD}) — large enough that a distorted shape can hide from the gate #2 single view.`,
+    );
+  }
+  if (!diverges && precondition.cause === 'fail-open') {
+    reasons.push(...precondition.reasons);
+  }
+  return { critic: 'consolidation', dispatch: true, reasons };
+}
+
+/**
+ * Decide the 8.5 pre-mortem dispatch: high risk, or size ≥ ½ budget, or a
+ * risk-heuristic phrase match.
+ *
+ * @param {object} input
+ * @param {import('./planning-risk.js').RiskVerdict} input.riskVerdict -
+ *   The authored `risk-verdict.json` payload; the overall level is derived
+ *   deterministically from its axes (`deriveRiskEnvelope`), never trusted
+ *   as a free-standing field.
+ * @param {number} input.ticketCount - Draft ticket count (0 in the
+ *   single-delivery shape — no tickets exist).
+ * @param {number} input.maxTickets - The reviewability budget
+ *   (`getLimits(config).maxTickets`).
+ * @param {string[]} [input.riskHeuristics] - `planning.riskHeuristics`
+ *   phrases from the resolved config.
+ * @param {string} [input.planText] - Concatenated plan text the heuristics
+ *   match against (tech spec + serialized tickets + risk summary).
+ * @returns {CriticDispatchDecision}
+ */
+export function evaluatePremortemDispatch({
+  riskVerdict,
+  ticketCount,
+  maxTickets,
+  riskHeuristics = [],
+  planText = '',
+}) {
+  if (!Number.isInteger(maxTickets) || maxTickets <= 0) {
+    throw new TypeError(
+      'evaluatePremortemDispatch: maxTickets must be a positive integer',
+    );
+  }
+  const reasons = [];
+
+  const { overallLevel } = deriveRiskEnvelope(riskVerdict);
+  if (overallLevel === 'high') {
+    reasons.push(
+      'Risk verdict overall level is high — predicted-rework findings are worth a fresh-context pass.',
+    );
+  }
+
+  const count = Number.isInteger(ticketCount) ? ticketCount : 0;
+  if (count * 2 >= maxTickets) {
+    reasons.push(
+      `Ticket count ${count} is at least half the reviewability budget (maxTickets ${maxTickets}).`,
+    );
+  }
+
+  const haystack = String(planText).toLowerCase();
+  const matched = riskHeuristics.filter(
+    (phrase) =>
+      typeof phrase === 'string' &&
+      phrase.trim().length > 0 &&
+      haystack.includes(phrase.trim().toLowerCase()),
+  );
+  if (matched.length > 0) {
+    reasons.push(
+      `planning.riskHeuristics match(es) in the plan text: ${matched.map((p) => `"${p.trim()}"`).join(', ')}.`,
+    );
+  }
+
+  if (reasons.length > 0) {
+    return { critic: 'pre-mortem', dispatch: true, reasons };
+  }
+
+  return {
+    critic: 'pre-mortem',
+    dispatch: false,
+    reasons: [
+      `Overall risk is ${overallLevel} (not high), ticket count ${count} is under half the budget (maxTickets ${maxTickets}), and no planning.riskHeuristics phrase matches the plan text.`,
+    ],
+  };
+}

--- a/.agents/scripts/lib/orchestration/plan-metrics.js
+++ b/.agents/scripts/lib/orchestration/plan-metrics.js
@@ -18,6 +18,19 @@
  *   "durationMs": 1234, "ok": true }
  * ```
  *
+ * Critic-skip records (Epic #4474 PR6 — additive `kind` extension): the
+ * conditional-critic layer logs every skip decision so under-firing is
+ * auditable from the same stream:
+ *
+ * ```json
+ * { "v": 1, "kind": "critic-skip", "cli": "plan-critics",
+ *   "critic": "pre-mortem", "reasons": ["..."], "epicId": 4474,
+ *   "at": "..." }
+ * ```
+ *
+ * Records without a `kind` field are invocation records (the PR1 shape);
+ * readers key on `kind`, never on the absence of other fields.
+ *
  * Attribution note (#4474 PR1 risk register): these records count **CLI
  * invocations from the parent session's perspective**. Sub-agent sessions
  * spawned by the workflow do not write here; they are attributed separately
@@ -55,6 +68,9 @@ import { Logger } from '../Logger.js';
 
 export const PLAN_METRICS_BASENAME = 'plan-metrics.json';
 export const PLAN_METRICS_SCHEMA_VERSION = 1;
+
+/** Record kind for a logged critic skip decision (Epic #4474 PR6). */
+export const PLAN_METRICS_KIND_CRITIC_SKIP = 'critic-skip';
 
 /**
  * Rotation threshold. At ~200 bytes per record this is ~5000 invocations —
@@ -168,6 +184,60 @@ export async function appendPlanMetric(entry, config, opts = {}) {
 }
 
 /**
+ * Append one critic-skip audit record (Epic #4474 PR6). Every conditional
+ * critic that decides NOT to dispatch logs the decision here — with the
+ * deterministic reasons — so an under-firing critic layer (a distorted
+ * plan sailing through) is auditable after the fact. Best-effort with the
+ * same contract as `appendPlanMetric`: a failed append can never fail the
+ * plan step.
+ *
+ * @param {{
+ *   critic: string,
+ *   reasons: string[],
+ *   cli: string,
+ *   epicId?: number|null,
+ * }} entry
+ * @param {object} [config]
+ * @returns {Promise<boolean>} true when the line was written.
+ */
+export async function appendCriticSkip(entry, config) {
+  try {
+    if (!entry || typeof entry !== 'object') {
+      throw new TypeError('appendCriticSkip requires an entry object');
+    }
+    if (typeof entry.critic !== 'string' || entry.critic.length === 0) {
+      throw new TypeError('appendCriticSkip requires a non-empty entry.critic');
+    }
+    if (typeof entry.cli !== 'string' || entry.cli.length === 0) {
+      throw new TypeError('appendCriticSkip requires a non-empty entry.cli');
+    }
+    const epicId = entry.epicId ?? null;
+    const record = {
+      v: PLAN_METRICS_SCHEMA_VERSION,
+      kind: PLAN_METRICS_KIND_CRITIC_SKIP,
+      cli: entry.cli,
+      critic: entry.critic,
+      reasons: Array.isArray(entry.reasons)
+        ? entry.reasons.filter((r) => typeof r === 'string')
+        : [],
+      epicId,
+      at: new Date().toISOString(),
+    };
+    const filePath = planMetricsPath(epicId, config);
+    const line = `${JSON.stringify(record)}\n`;
+    await fs.mkdir(path.dirname(filePath), { recursive: true });
+    await rotateIfNeeded(filePath, Buffer.byteLength(line), MAX_LEDGER_BYTES);
+    await fs.appendFile(filePath, line, 'utf8');
+    return true;
+  } catch (err) {
+    Logger.warn(
+      `[plan-metrics] critic-skip append failed (non-fatal): ${err?.message ?? err}`,
+    );
+    return false;
+  }
+}
+
+/**
  * Wrap one plan CLI invocation: stamp `startedAt`, run `fn`, stamp
  * `endedAt` + `ok`, append the record, and re-throw the original error on
  * failure. The metric write itself is best-effort and can never mask or
@@ -247,12 +317,19 @@ export async function readPlanMetrics(epicId, config) {
  * summary and `analyze-execution.js`. Returns `null` when there is nothing
  * to summarize (missing ledger or zero parseable entries).
  *
+ * Critic-skip records (kind: 'critic-skip') are counted separately from
+ * invocations — `criticSkips` totals them and `criticSkipsByCritic` breaks
+ * them down, so the skip-audit trail is visible in the persist summary
+ * without inflating the turns-per-plan proxy.
+ *
  * @param {{ entries: object[], malformedLines?: number }} ledger
  * @returns {{
  *   invocations: number,
  *   failures: number,
  *   byCli: Record<string, number>,
  *   byMode: Record<string, number>,
+ *   criticSkips: number,
+ *   criticSkipsByCritic: Record<string, number>,
  *   firstStartedAt: string|null,
  *   lastEndedAt: string|null,
  *   spanMs: number|null,
@@ -265,11 +342,23 @@ export function summarizePlanMetrics(ledger) {
   if (entries.length === 0) return null;
   const byCli = {};
   const byMode = {};
+  const criticSkipsByCritic = {};
+  let criticSkips = 0;
   let failures = 0;
   let totalDurationMs = 0;
   let firstStartedAt = null;
   let lastEndedAt = null;
+  const invocationEntries = [];
   for (const e of entries) {
+    if (e.kind === PLAN_METRICS_KIND_CRITIC_SKIP) {
+      criticSkips += 1;
+      if (typeof e.critic === 'string') {
+        criticSkipsByCritic[e.critic] =
+          (criticSkipsByCritic[e.critic] ?? 0) + 1;
+      }
+      continue;
+    }
+    invocationEntries.push(e);
     byCli[e.cli] = (byCli[e.cli] ?? 0) + 1;
     if (typeof e.mode === 'string') byMode[e.mode] = (byMode[e.mode] ?? 0) + 1;
     if (e.ok !== true) failures += 1;
@@ -291,10 +380,12 @@ export function summarizePlanMetrics(ledger) {
     if (Number.isFinite(span)) spanMs = Math.max(0, span);
   }
   return {
-    invocations: entries.length,
+    invocations: invocationEntries.length,
     failures,
     byCli,
     byMode,
+    criticSkips,
+    criticSkipsByCritic,
     firstStartedAt,
     lastEndedAt,
     spanMs,
@@ -323,9 +414,17 @@ export function renderPlanMetricsSummaryLine(summary) {
     summary.malformedLines > 0
       ? `; ${summary.malformedLines} malformed line(s) skipped`
       : '';
+  const skips =
+    (summary.criticSkips ?? 0) > 0
+      ? `; ${summary.criticSkips} critic skip(s) logged (${Object.entries(
+          summary.criticSkipsByCritic ?? {},
+        )
+          .map(([critic, count]) => `${critic} ×${count}`)
+          .join(', ')})`
+      : '';
   return (
     `plan-metrics: ${summary.invocations} invocation(s)${failed} across ` +
-    `${cliParts} — span ${span}${malformed}`
+    `${cliParts || 'no plan CLIs'} — span ${span}${skips}${malformed}`
   );
 }
 

--- a/.agents/scripts/lib/orchestration/plan-persist/run-plan-persist.js
+++ b/.agents/scripts/lib/orchestration/plan-persist/run-plan-persist.js
@@ -20,6 +20,16 @@
  *       keeps + adds + modifies, closes excluded; all git-local, still
  *       zero provider calls). Skipped entirely in single mode (no tickets
  *       exist to validate).
+ *    4.5. deterministic draft reachability (Epic #4474 PR6, design §4 —
+ *       the 8.4 critic demoted into persist): route-glob scan of the
+ *       draft set vs `planning.navigation.navRegistry`, mirroring the
+ *       `--paranoid` F7 healthcheck mechanics. Orphan surfaces are a
+ *       NAMED SOFT FAILURE (`code: PLAN_REACHABILITY_ORPHANS`, CLI exit
+ *       3) raised before any provider call — the author appends the
+ *       single reachability Story in one targeted amend and re-runs the
+ *       persist once. Silent no-op when `planning.navigation` is
+ *       unconfigured; skip decisions are appended to the plan-metrics
+ *       ledger (`kind: critic-skip`) for audit.
  *    5. ideation fold — `renderEpicBody` / `openEpicFromOnePager` create
  *       the Epic when the run starts from a one-pager (the first provider
  *       call of the run). Amend additionally resolves every
@@ -119,6 +129,11 @@ import {
   read as readPlanState,
   write as writePlanState,
 } from '../epic-plan-state-store.js';
+import { appendCriticSkip } from '../plan-metrics.js';
+import {
+  evaluateDraftReachability,
+  renderReachabilityOrphans,
+} from '../plan-reachability.js';
 import { resolveReviewRouting } from '../plan-review-routing.js';
 import { deriveRiskEnvelope } from '../planning-risk.js';
 import { renderSpec } from '../spec-renderer.js';
@@ -404,6 +419,7 @@ export async function runPlanPersist({
   // with no tickets to validate. ----
   let validated = null;
   let amendPartition = null;
+  let reachability = null;
   if (mode !== 'single') {
     amendPartition = mode === 'amend' ? partitionAmendTickets(tickets) : null;
     const gateSet = mode === 'amend' ? buildMergedTicketSet(tickets) : tickets;
@@ -430,6 +446,43 @@ export async function runPlanPersist({
     validated = validateTickets(gateSet, config, { fanOutCounter, cwd });
     enforceFanOutGate(validated.findings, allowLargeFanOut, 'plan-persist');
     surfaceSoftConflictFindings(validated.findings, 'plan-persist');
+
+    // ---- Step 4.5: deterministic draft reachability (#4474 PR6 — the 8.4
+    // critic demoted into persist). Still git-local, zero provider calls,
+    // so the one-targeted-amend recovery re-runs a clean persist. ----
+    reachability = evaluateDraftReachability({ tickets: gateSet, config });
+    if (reachability.status === 'orphans') {
+      const err = new Error(renderReachabilityOrphans(reachability));
+      err.code = 'PLAN_REACHABILITY_ORPHANS';
+      err.orphans = reachability.orphans;
+      throw err;
+    }
+    Logger.info(`[plan-persist] reachability: ${reachability.reasons[0]}`);
+  } else {
+    reachability = {
+      status: 'skipped',
+      reasons: [
+        'single-delivery shape — no draft story tree to scan for orphan surfaces.',
+      ],
+      orphans: [],
+      scanned: 0,
+    };
+  }
+  if (reachability.status === 'skipped') {
+    // Audit trail for the skip decision (#4474 PR6). Best-effort by
+    // contract — a failed append never fails the persist. Logged before
+    // the first provider call so even an ideation run that later fails
+    // still records the decision (ideation has no Epic id yet, so the
+    // record lands on the standalone stream).
+    await appendCriticSkip(
+      {
+        critic: 'reachability',
+        reasons: reachability.reasons,
+        cli: 'plan-persist',
+        epicId: requestedEpicId,
+      },
+      config,
+    );
   }
 
   // ---- Step 5: ideation fold / Epic resolution (first provider call). ----
@@ -780,6 +833,7 @@ export async function runPlanPersist({
       reviewRouting,
       freshness,
       healthcheck,
+      reachability,
       reconcile,
       specPath: specFilePath,
       waveTable,

--- a/.agents/scripts/lib/orchestration/plan-reachability.js
+++ b/.agents/scripts/lib/orchestration/plan-reachability.js
@@ -1,0 +1,160 @@
+/**
+ * plan-reachability.js — deterministic draft-ticket reachability check for
+ * the persist surface (Epic #4474 PR6, design §4: the 8.4 reachability
+ * critic demoted from a fresh-context sub-agent to a persist-side scan).
+ *
+ * Mirrors the mechanics of the existing `--paranoid` F7 healthcheck
+ * (`epic-plan-healthcheck.js#checkReachability`) — route-glob scan of the
+ * paths a Story declares vs the `planning.navigation.navRegistry` token
+ * list — but runs it over the **draft** ticket set inside `plan-persist.js`
+ * step 4.5, before any provider call, so an orphaned surface is caught
+ * while a one-line targeted amend is still free (nothing has been written
+ * to GitHub yet).
+ *
+ * Plan-level coverage semantics (the convergence contract): a route-adding
+ * story that never references the nav registry produces orphan surfaces —
+ * UNLESS every one of its route paths is also mentioned by some story in
+ * the plan that DOES reference the registry (the "navigation owner"). That
+ * is exactly what the documented recovery produces: the author appends the
+ * single reachability Story (which cites the orphaned routes and the nav
+ * registry) in one targeted amend, and the re-run persist passes.
+ *
+ * Silent no-op when `planning.navigation` is unconfigured (`routeGlobs`
+ * empty) — same opt-in contract as F7 / AC-13 — reported as
+ * `status: 'skipped'` so the caller can append the audit record to the
+ * plan-metrics ledger.
+ *
+ * Pure over its inputs (tickets + resolved config), no I/O.
+ */
+
+import {
+  extractStoryPaths,
+  globToRegExp,
+  resolveNavConfig,
+} from '../../epic-plan-healthcheck.js';
+
+/**
+ * Fallback tokens when `navRegistry` is unconfigured but `routeGlobs` is —
+ * identical to the F7 healthcheck's fallback, so the two checks agree on
+ * what counts as a registry reference.
+ */
+const FALLBACK_REGISTRY_TOKENS = ['nav registry', 'navigation'];
+
+/**
+ * @typedef {Object} ReachabilityOrphan
+ * @property {string} story The offending draft story's slug (or title).
+ * @property {string[]} paths The route-matching paths with no navigation
+ *   owner anywhere in the plan.
+ */
+
+/**
+ * @typedef {Object} DraftReachabilityResult
+ * @property {'skipped'|'ok'|'orphans'} status
+ * @property {string[]} reasons
+ * @property {ReachabilityOrphan[]} orphans Empty unless `status` is
+ *   `'orphans'`.
+ * @property {number} scanned Draft stories scanned (0 when skipped).
+ */
+
+/**
+ * Evaluate draft-ticket reachability against the configured navigation
+ * surface.
+ *
+ * @param {object} input
+ * @param {Array<{ slug?: string, title?: string, body?: string }>} input.tickets
+ *   The draft ticket set the persist is about to create (fan-out: the
+ *   authored `tickets.json`; amend: the merged set).
+ * @param {object} [input.config] Resolved `.agentrc.json` (threads
+ *   `planning.navigation`).
+ * @returns {DraftReachabilityResult}
+ */
+export function evaluateDraftReachability({ tickets, config }) {
+  const { routeGlobs, navRegistry } = resolveNavConfig(config);
+
+  if (routeGlobs.length === 0) {
+    return {
+      status: 'skipped',
+      reasons: ['No planning.navigation.routeGlobs configured — skipped.'],
+      orphans: [],
+      scanned: 0,
+    };
+  }
+
+  const stories = Array.isArray(tickets) ? tickets : [];
+  const matchers = routeGlobs.map(globToRegExp);
+  const registryTokens =
+    navRegistry.length > 0
+      ? navRegistry.map((t) => t.toLowerCase())
+      : FALLBACK_REGISTRY_TOKENS;
+
+  // Pass 1: per-story scan — declared paths, route matches, registry refs.
+  const scannedStories = stories.map((story) => {
+    const body = typeof story?.body === 'string' ? story.body : '';
+    const paths = extractStoryPaths(body);
+    const routePaths = paths.filter((p) => matchers.some((rx) => rx.test(p)));
+    const text = [body, story?.title ?? ''].join('\n').toLowerCase();
+    const referencesRegistry = registryTokens.some((tok) => text.includes(tok));
+    return { story, paths, routePaths, referencesRegistry };
+  });
+
+  // Pass 2: navigation owners — every path mentioned by a
+  // registry-referencing story is covered plan-wide.
+  const coveredPaths = new Set();
+  for (const s of scannedStories) {
+    if (!s.referencesRegistry) continue;
+    for (const p of s.paths) coveredPaths.add(p);
+  }
+
+  const orphans = [];
+  for (const s of scannedStories) {
+    if (s.referencesRegistry || s.routePaths.length === 0) continue;
+    const uncovered = s.routePaths.filter((p) => !coveredPaths.has(p));
+    if (uncovered.length === 0) continue;
+    orphans.push({
+      story: s.story?.slug ?? s.story?.title ?? '<unnamed story>',
+      paths: uncovered,
+    });
+  }
+
+  if (orphans.length > 0) {
+    const registryHint =
+      navRegistry.length > 0 ? navRegistry.join(', ') : 'the nav registry';
+    return {
+      status: 'orphans',
+      reasons: [
+        `${orphans.length} route-adding draft story(ies) leave orphan surfaces with no navigation owner (registry: ${registryHint}).`,
+      ],
+      orphans,
+      scanned: stories.length,
+    };
+  }
+
+  return {
+    status: 'ok',
+    reasons: [
+      `${stories.length} draft story(ies) scanned — every route-adding story has a navigation owner.`,
+    ],
+    orphans: [],
+    scanned: stories.length,
+  };
+}
+
+/**
+ * Render the named soft-failure message the persist CLI prints — the
+ * orphan-surface list plus the one-targeted-amend recovery contract.
+ *
+ * @param {DraftReachabilityResult} result A `status: 'orphans'` result.
+ * @returns {string}
+ */
+export function renderReachabilityOrphans(result) {
+  const lines = [
+    '[plan-persist] SOFT FAILURE — reachability orphans (route-glob vs navRegistry):',
+    ...result.orphans.map((o) => `  - ${o.story}: ${o.paths.join(', ')}`),
+    '',
+    'Nothing was written to GitHub. Apply ONE targeted amend to tickets.json',
+    'adding a navigation owner (at most one reachability Story per plan) that',
+    'cites the orphaned routes and the nav registry, then re-run the persist',
+    'once.',
+  ];
+  return lines.join('\n');
+}

--- a/.agents/scripts/plan-critics.js
+++ b/.agents/scripts/plan-critics.js
@@ -1,0 +1,227 @@
+#!/usr/bin/env node
+
+/**
+ * plan-critics.js — deterministic dispatch gate for the conditional
+ * author-step critics of the collapsed /plan flow (Epic #4474 PR6,
+ * design §4).
+ *
+ * Runs between authoring and gate #2, entirely git-local (zero GitHub
+ * calls): reads the authored artifacts, evaluates the risk/size dispatch
+ * conditions for the consolidation (8.3) and pre-mortem (8.5) critics via
+ * `lib/orchestration/plan-critic-conditions.js`, and emits one JSON
+ * verdict on stdout. The workflow dispatches a fresh-context sub-agent
+ * ONLY for critics with `dispatch: true`; every skip decision is appended
+ * to the plan-metrics ledger (`kind: "critic-skip"`, with reasons) so
+ * under-firing is auditable — the persist validators remain unchanged
+ * hard gates regardless of what this gate decides.
+ *
+ * Conditions (design §4 / §6 PR6):
+ *   - Consolidation: the existing deterministic precondition
+ *     (`evaluateConsolidationPrecondition`) says dispatch AND (the draft
+ *     has > 5 stories OR a confirmed divergence from the Tech Spec's
+ *     Delivery Slicing table). Skipped outright in the single-delivery
+ *     shape (no tickets exist to consolidate).
+ *   - Pre-mortem: risk verdict overall level is high, OR ticket count is
+ *     at least half `maxTickets`, OR any `planning.riskHeuristics` phrase
+ *     matches the plan text (case-insensitive substring over tech spec +
+ *     tickets + risk summary).
+ *
+ * Modes:
+ *   --epic <id>          Artifact paths default to the per-Epic temp tree
+ *                        (`temp/epic-<id>/techspec.md`, `risk-verdict.json`,
+ *                        `tickets.json`); skip records land on the
+ *                        per-Epic plan-metrics ledger.
+ *   explicit paths       Ideation mode: pass --tech-spec/--risk-verdict
+ *                        (and --tickets when fan-out) explicitly; skip
+ *                        records land on the standalone ledger stream.
+ *
+ * Output (stdout-pure JSON):
+ *   { epicId, consolidation: { critic, dispatch, reasons },
+ *     premortem: { critic, dispatch, reasons } }
+ *
+ * Exit codes: 0 — verdict emitted (dispatch decisions are data, not
+ * failures); 1 — fatal error (unreadable/invalid artifacts, bad args).
+ */
+
+// Fail-fast if the framework's runtime deps are not installed — must be the
+// first import so the check runs before any third-party-importing sibling
+// module is evaluated (Story #3432).
+import './lib/runtime-deps/ensure-installed.js';
+import { readFile } from 'node:fs/promises';
+import { parseArgs } from 'node:util';
+
+import { runAsCli } from './lib/cli-utils.js';
+import { epicArtifactPath } from './lib/config/temp-paths.js';
+import {
+  getLimits,
+  resolveConfig,
+  validateOrchestrationConfig,
+} from './lib/config-resolver.js';
+import { routeAllOutputToStderr } from './lib/Logger.js';
+import { loadRiskVerdict } from './lib/orchestration/epic-plan-spec/phases/risk-verdict.js';
+import {
+  evaluateConsolidationDispatch,
+  evaluatePremortemDispatch,
+} from './lib/orchestration/plan-critic-conditions.js';
+import {
+  appendCriticSkip,
+  recordPlanInvocation,
+} from './lib/orchestration/plan-metrics.js';
+
+const USAGE =
+  'Usage: plan-critics.js (--epic <EpicId> | --tech-spec <file> ' +
+  '--risk-verdict <file> [--tickets <file>]) [--pretty]';
+
+/**
+ * Resolve the planning risk heuristics list from the canonical config
+ * block (same resolution `plan-context.js` and the decompose context use).
+ *
+ * @param {object} config
+ * @returns {string[]}
+ */
+function resolveRiskHeuristics(config = {}) {
+  if (Array.isArray(config.planning?.riskHeuristics)) {
+    return config.planning.riskHeuristics;
+  }
+  return config.agentSettings?.planning?.riskHeuristics || [];
+}
+
+async function readOptional(filePath, { required }) {
+  try {
+    return await readFile(filePath, 'utf8');
+  } catch (err) {
+    if (!required && err?.code === 'ENOENT') return null;
+    throw new Error(`Cannot read ${filePath}: ${err.message}`);
+  }
+}
+
+async function main() {
+  const { values } = parseArgs({
+    options: {
+      epic: { type: 'string' },
+      'tech-spec': { type: 'string' },
+      'risk-verdict': { type: 'string' },
+      tickets: { type: 'string' },
+      pretty: { type: 'boolean', default: false },
+    },
+    strict: true,
+  });
+
+  let epicId = null;
+  if (values.epic !== undefined) {
+    epicId = Number.parseInt(values.epic, 10);
+    if (!Number.isInteger(epicId)) {
+      throw new Error(
+        `--epic must be a numeric issue id (got "${values.epic}").\n${USAGE}`,
+      );
+    }
+  }
+
+  // stdout is reserved for the JSON verdict — flip every Logger sink to
+  // stderr before any pipeline code runs (same guarantee plan-context.js
+  // gives its envelope).
+  routeAllOutputToStderr();
+
+  let config;
+  try {
+    config = resolveConfig();
+    validateOrchestrationConfig(config);
+  } catch (err) {
+    throw new Error(`Config schema validation failed:\n${err.message}`);
+  }
+
+  const fallback = (basename) =>
+    epicId === null ? undefined : epicArtifactPath(epicId, basename, config);
+  const techSpecPath = values['tech-spec'] ?? fallback('techspec.md');
+  const riskVerdictPath =
+    values['risk-verdict'] ?? fallback('risk-verdict.json');
+  const ticketsPath = values.tickets ?? fallback('tickets.json');
+  if (!techSpecPath || !riskVerdictPath) {
+    throw new Error(
+      `Missing artifact path(s): without --epic, explicit --tech-spec and --risk-verdict are required.\n${USAGE}`,
+    );
+  }
+
+  const verdict = await recordPlanInvocation(
+    { cli: 'plan-critics', mode: 'evaluate', epicId, config },
+    async () => {
+      const techSpecContent = await readOptional(techSpecPath, {
+        required: true,
+      });
+      const riskVerdict = loadRiskVerdict(riskVerdictPath);
+      // Tickets are shape-dependent: a single-delivery plan authors none.
+      // Required only when passed explicitly.
+      const ticketsRaw = ticketsPath
+        ? await readOptional(ticketsPath, {
+            required: values.tickets !== undefined,
+          })
+        : null;
+      let tickets = null;
+      if (ticketsRaw !== null) {
+        try {
+          tickets = JSON.parse(ticketsRaw);
+        } catch (err) {
+          throw new Error(
+            `Failed to parse tickets file "${ticketsPath}" as JSON: ${err.message}`,
+          );
+        }
+        if (!Array.isArray(tickets)) {
+          throw new Error(
+            `Tickets file "${ticketsPath}" must contain a JSON array.`,
+          );
+        }
+      }
+
+      const consolidation =
+        tickets === null
+          ? {
+              critic: 'consolidation',
+              dispatch: false,
+              reasons: [
+                'single-delivery shape — no draft tickets exist to consolidate.',
+              ],
+            }
+          : evaluateConsolidationDispatch({
+              draftStories: tickets,
+              specText: techSpecContent,
+            });
+
+      const premortem = evaluatePremortemDispatch({
+        riskVerdict,
+        ticketCount: tickets?.length ?? 0,
+        maxTickets: getLimits(config).maxTickets,
+        riskHeuristics: resolveRiskHeuristics(config),
+        planText: [
+          techSpecContent,
+          ticketsRaw ?? '',
+          riskVerdict.summary ?? '',
+        ].join('\n'),
+      });
+
+      // Skip-audit trail (#4474 PR6): every non-dispatch is a ledger
+      // record. Best-effort — a failed append never fails the gate.
+      for (const decision of [consolidation, premortem]) {
+        if (!decision.dispatch) {
+          await appendCriticSkip(
+            {
+              critic: decision.critic,
+              reasons: decision.reasons,
+              cli: 'plan-critics',
+              epicId,
+            },
+            config,
+          );
+        }
+      }
+
+      return { epicId, consolidation, premortem };
+    },
+  );
+
+  const json = values.pretty
+    ? JSON.stringify(verdict, null, 2)
+    : JSON.stringify(verdict);
+  process.stdout.write(`${json}\n`);
+}
+
+runAsCli(import.meta.url, main, { source: 'plan-critics' });

--- a/.agents/scripts/plan-persist.js
+++ b/.agents/scripts/plan-persist.js
@@ -66,8 +66,12 @@
  *
  * Exit codes: 0 — persist complete, Epic is `agent::ready`; 1 — fatal
  * error (see stderr); 2 — amend close ops require --explicit-delete (the
- * dry-run diff is printed; nothing was mutated). The Epic lease is
- * released on every exit path.
+ * dry-run diff is printed; nothing was mutated); 3 — reachability orphans
+ * (Epic #4474 PR6 named soft failure: the deterministic route-glob vs
+ * `planning.navigation.navRegistry` scan found route-adding draft stories
+ * with no navigation owner — the orphan-surface list is printed, nothing
+ * was mutated; apply one targeted amend and re-run the persist once). The
+ * Epic lease is released on every exit path.
  */
 
 // Fail-fast if the framework's runtime deps are not installed — must be the
@@ -346,6 +350,14 @@ async function main() {
     if (err?.code === 'PLAN_AMEND_EXPLICIT_DELETE_REQUIRED') {
       process.stdout.write(`${err.diff}\n\n${err.message}\n`);
       process.exitCode = 2;
+      return;
+    }
+    // Reachability soft failure (#4474 PR6): the orphan-surface list is the
+    // message; nothing was mutated (the check runs before any provider
+    // call). Exit 3 so non-interactive callers can branch on the code.
+    if (err?.code === 'PLAN_REACHABILITY_ORPHANS') {
+      process.stdout.write(`${err.message}\n`);
+      process.exitCode = 3;
       return;
     }
     throw err;

--- a/.agents/workflows/helpers/plan-epic.md
+++ b/.agents/workflows/helpers/plan-epic.md
@@ -153,23 +153,40 @@ skills name — read the envelope wherever a skill asks for either.
 
 ### Conditional critics (between authoring and gate #2)
 
+Evaluate the dispatch conditions deterministically first — one git-local
+CLI call, zero GitHub reads:
+
+```bash
+node .agents/scripts/plan-critics.js --epic [Epic_ID]
+```
+
+(ideation: pass `--tech-spec`/`--risk-verdict`/`--tickets` explicitly). The
+verdict names each critic with `dispatch: true|false` and reasons. Dispatch
+a sub-agent ONLY for a critic with `dispatch: true`; surface each skip as a
+one-line note. Every skip decision is appended to the plan-metrics ledger
+(`kind: "critic-skip"`, with reasons) so under-firing is auditable — the
+persist validators remain unchanged hard gates either way.
+
 Both critics are **fresh-context sub-agents** (`Agent` tool,
 `subagent_type: general-purpose`) — never inline skill activations, so they
 cannot grade their own homework. Both are report-only: they never write to
 GitHub and never persist `tickets.json`; their findings fold into the gate #2
-view, and accepted findings get one targeted amend pass (above). PR6 wires
-their risk/size dispatch conditions; until then their current preconditions
-hold:
+view, and accepted findings get one targeted amend pass (above).
 
-- **Consolidation critic** (fan-out only): skip the dispatch when the draft
-  already matches the Tech Spec's Delivery Slicing table 1:1 in Story count
-  and dependency shape (surface the skip as a one-line note); otherwise the
-  sub-agent reads the
+- **Consolidation critic** (fan-out only): fires when the draft does NOT
+  already match the Tech Spec's Delivery Slicing table 1:1 in Story count
+  and dependency shape, AND the divergence is worth a dispatch — the draft
+  has more than 5 stories, or the mismatch is confirmed (a small draft
+  whose table is merely missing/unparseable skips: gate #2's single view
+  covers it). On dispatch the sub-agent reads the
   [`epic-plan-consolidate`](../../skills/core/epic-plan-consolidate/SKILL.md)
   skill and reconciles the draft against the slicing target. Its operations
   are scope-preserving only — merge sibling Stories and rewire `depends_on`;
   it MUST NOT add scope or invent tickets.
-- **Pre-mortem critic**: the sub-agent reads the
+- **Pre-mortem critic**: fires when the risk verdict's overall level is
+  high, OR the ticket count is at least half `maxTickets`, OR any
+  `planning.riskHeuristics` phrase matches the plan text. On dispatch the
+  sub-agent reads the
   [`epic-plan-premortem`](../../skills/core/epic-plan-premortem/SKILL.md)
   skill, reads the actual cited code surfaces, and emits predicted-rework
   findings to `temp/epic-[Epic_ID]/premortem-report.md`.
@@ -245,9 +262,9 @@ contract (step 2) and re-run the persist once:
   edit to `techspec.md` or `tickets.json`.
 - **Reachability orphans** (deterministic route-glob vs `navRegistry` check;
   a silent no-op when `planning.navigation` is unconfigured) — a named
-  **soft failure** listing the orphaned surfaces: apply one targeted amend
-  adding a navigation owner (at most one reachability Story per plan), then
-  re-persist.
+  **soft failure** (exit 3, before any GitHub write) listing the orphaned
+  surfaces: apply one targeted amend adding a navigation owner
+  (at most one reachability Story per plan), then re-persist.
 - **Over budget** (`maxTickets`) — re-scope, or re-run with
   `--allow-over-budget` after confirming the rationale on the Epic.
 - **Rate-limit abort on a large Epic** — resume with `--resume`; see

--- a/tests/plan-critic-conditions.test.js
+++ b/tests/plan-critic-conditions.test.js
@@ -1,0 +1,312 @@
+/**
+ * plan-critic-conditions.test.js — table-driven condition matrix for the
+ * #4474 PR6 conditional-critic dispatch layer:
+ *
+ *   - consolidation (8.3): precondition AND (>5 stories OR confirmed
+ *     divergence) — a fail-open precondition on a small draft skips;
+ *   - pre-mortem (8.5): high overall risk, OR ticket count ≥ ½ maxTickets,
+ *     OR a planning.riskHeuristics phrase match (case-insensitive);
+ *   - the additive `cause` field on the underlying consolidation
+ *     precondition ('match' | 'divergence' | 'fail-open').
+ */
+
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import { evaluateConsolidationPrecondition } from '../.agents/scripts/lib/orchestration/consolidation-precondition.js';
+import {
+  CONSOLIDATION_STORY_THRESHOLD,
+  evaluateConsolidationDispatch,
+  evaluatePremortemDispatch,
+} from '../.agents/scripts/lib/orchestration/plan-critic-conditions.js';
+
+/** Build a minimal draft story. */
+function story(slug, dependsOn = []) {
+  return { slug, depends_on: dependsOn, body: `## Goal\n${slug}.` };
+}
+
+/** Build a Delivery Slicing table matching `stories` 1:1. */
+function slicingTableFor(stories) {
+  const rows = stories.map(
+    (s) =>
+      `| ${s.slug} | ships ${s.slug} | ${s.depends_on.length > 0 ? 'No' : 'Yes'} |`,
+  );
+  return [
+    '## Delivery Slicing',
+    '',
+    '| Slice | What ships | Independent? |',
+    '| --- | --- | --- |',
+    ...rows,
+  ].join('\n');
+}
+
+function stories(n, { chained = false } = {}) {
+  return Array.from({ length: n }, (_, i) =>
+    story(`s${i + 1}`, chained && i > 0 ? [`s${i}`] : []),
+  );
+}
+
+describe('consolidation precondition — additive cause field', () => {
+  it("reports 'match' on a 1:1 draft", () => {
+    const draft = stories(3);
+    const result = evaluateConsolidationPrecondition({
+      draftStories: draft,
+      epicBody: slicingTableFor(draft),
+    });
+    assert.equal(result.dispatch, false);
+    assert.equal(result.cause, 'match');
+  });
+
+  it("reports 'divergence' on a count mismatch", () => {
+    const result = evaluateConsolidationPrecondition({
+      draftStories: stories(4),
+      epicBody: slicingTableFor(stories(3)),
+    });
+    assert.equal(result.dispatch, true);
+    assert.equal(result.cause, 'divergence');
+  });
+
+  it("reports 'divergence' on a dependency-shape mismatch", () => {
+    const draft = stories(2, { chained: true });
+    const result = evaluateConsolidationPrecondition({
+      draftStories: draft,
+      // Table says every slice is independent; s2 declares depends_on.
+      epicBody: slicingTableFor(stories(2)),
+    });
+    assert.equal(result.dispatch, true);
+    assert.equal(result.cause, 'divergence');
+  });
+
+  it("reports 'fail-open' when the table is missing", () => {
+    const result = evaluateConsolidationPrecondition({
+      draftStories: stories(2),
+      epicBody: '## Context\nNo slicing table here.',
+    });
+    assert.equal(result.dispatch, true);
+    assert.equal(result.cause, 'fail-open');
+  });
+});
+
+describe('consolidation dispatch — condition matrix (PR6)', () => {
+  it('pins the design §6 size threshold at 5 stories', () => {
+    assert.equal(CONSOLIDATION_STORY_THRESHOLD, 5);
+  });
+
+  const smallMatched = stories(3);
+  const largeMatched = stories(7);
+  const noTable = '## Context\nNo slicing table.';
+
+  const matrix = [
+    {
+      name: '1:1 match, small draft → skip (precondition wins)',
+      draft: smallMatched,
+      spec: slicingTableFor(smallMatched),
+      dispatch: false,
+    },
+    {
+      name: '1:1 match, large draft (>5) → still skip (precondition is an AND)',
+      draft: largeMatched,
+      spec: slicingTableFor(largeMatched),
+      dispatch: false,
+    },
+    {
+      name: 'confirmed divergence, small draft → dispatch',
+      draft: stories(4),
+      spec: slicingTableFor(stories(3)),
+      dispatch: true,
+    },
+    {
+      name: 'confirmed divergence, large draft → dispatch',
+      draft: stories(8),
+      spec: slicingTableFor(stories(3)),
+      dispatch: true,
+    },
+    {
+      name: 'fail-open (no table), small draft (≤5) → skip',
+      draft: stories(5),
+      spec: noTable,
+      dispatch: false,
+    },
+    {
+      name: 'fail-open (no table), large draft (>5) → dispatch',
+      draft: stories(6),
+      spec: noTable,
+      dispatch: true,
+    },
+    {
+      name: 'dependency-shape divergence, small draft → dispatch',
+      draft: stories(2, { chained: true }),
+      spec: slicingTableFor(stories(2)),
+      dispatch: true,
+    },
+  ];
+
+  for (const row of matrix) {
+    it(row.name, () => {
+      const decision = evaluateConsolidationDispatch({
+        draftStories: row.draft,
+        specText: row.spec,
+      });
+      assert.equal(decision.critic, 'consolidation');
+      assert.equal(decision.dispatch, row.dispatch);
+      assert.ok(
+        decision.reasons.length > 0,
+        'every decision carries at least one reason (the skip audit trail)',
+      );
+    });
+  }
+});
+
+describe('pre-mortem dispatch — condition matrix (PR6)', () => {
+  const lowVerdict = {
+    axes: [{ axis: 'internal-refactor', level: 'low', rationale: 'r' }],
+    summary: 'Low-risk fixture.',
+  };
+  const highVerdict = {
+    axes: [
+      { axis: 'internal-refactor', level: 'low', rationale: 'r' },
+      { axis: 'security', level: 'high', rationale: 'auth boundary' },
+    ],
+    summary: 'High-risk fixture.',
+  };
+  const mediumVerdict = {
+    axes: [{ axis: 'public-api', level: 'medium', rationale: 'r' }],
+    summary: 'Medium-risk fixture.',
+  };
+
+  const matrix = [
+    {
+      name: 'no condition fires → skip',
+      input: {
+        riskVerdict: lowVerdict,
+        ticketCount: 3,
+        maxTickets: 80,
+      },
+      dispatch: false,
+    },
+    {
+      name: 'high overall risk alone → dispatch',
+      input: {
+        riskVerdict: highVerdict,
+        ticketCount: 1,
+        maxTickets: 80,
+      },
+      dispatch: true,
+      reasonMatch: /overall level is high/i,
+    },
+    {
+      name: 'medium overall risk is not high → skip',
+      input: {
+        riskVerdict: mediumVerdict,
+        ticketCount: 3,
+        maxTickets: 80,
+      },
+      dispatch: false,
+    },
+    {
+      name: 'ticket count exactly half maxTickets → dispatch (boundary)',
+      input: {
+        riskVerdict: lowVerdict,
+        ticketCount: 40,
+        maxTickets: 80,
+      },
+      dispatch: true,
+      reasonMatch: /at least half the reviewability budget/i,
+    },
+    {
+      name: 'odd budget: ceil boundary (5 of 10 fires, 4 of 9 skips)',
+      input: {
+        riskVerdict: lowVerdict,
+        ticketCount: 4,
+        maxTickets: 9,
+      },
+      dispatch: false,
+    },
+    {
+      name: 'odd budget: 5 of 9 fires',
+      input: {
+        riskVerdict: lowVerdict,
+        ticketCount: 5,
+        maxTickets: 9,
+      },
+      dispatch: true,
+    },
+    {
+      name: 'one under the half-budget boundary → skip',
+      input: {
+        riskVerdict: lowVerdict,
+        ticketCount: 39,
+        maxTickets: 80,
+      },
+      dispatch: false,
+    },
+    {
+      name: 'risk-heuristic phrase match (case-insensitive) → dispatch',
+      input: {
+        riskVerdict: lowVerdict,
+        ticketCount: 2,
+        maxTickets: 80,
+        riskHeuristics: ['Destructive Schema Migration'],
+        planText: 'This plan includes a destructive schema migration step.',
+      },
+      dispatch: true,
+      reasonMatch: /riskHeuristics match/i,
+    },
+    {
+      name: 'heuristic configured but absent from the plan text → skip',
+      input: {
+        riskVerdict: lowVerdict,
+        ticketCount: 2,
+        maxTickets: 80,
+        riskHeuristics: ['billing'],
+        planText: 'Nothing risky in here.',
+      },
+      dispatch: false,
+    },
+    {
+      name: 'all three conditions at once → dispatch with all reasons',
+      input: {
+        riskVerdict: highVerdict,
+        ticketCount: 40,
+        maxTickets: 80,
+        riskHeuristics: ['auth'],
+        planText: 'Touches the auth boundary.',
+      },
+      dispatch: true,
+      minReasons: 3,
+    },
+  ];
+
+  for (const row of matrix) {
+    it(row.name, () => {
+      const decision = evaluatePremortemDispatch(row.input);
+      assert.equal(decision.critic, 'pre-mortem');
+      assert.equal(decision.dispatch, row.dispatch);
+      assert.ok(decision.reasons.length > 0, 'reasons are never empty');
+      if (row.reasonMatch) {
+        assert.ok(
+          decision.reasons.some((r) => row.reasonMatch.test(r)),
+          `expected a reason matching ${row.reasonMatch}: ${JSON.stringify(decision.reasons)}`,
+        );
+      }
+      if (row.minReasons) {
+        assert.ok(
+          decision.reasons.length >= row.minReasons,
+          `expected ≥ ${row.minReasons} reasons, got ${decision.reasons.length}`,
+        );
+      }
+    });
+  }
+
+  it('rejects a non-positive maxTickets', () => {
+    assert.throws(
+      () =>
+        evaluatePremortemDispatch({
+          riskVerdict: lowVerdict,
+          ticketCount: 1,
+          maxTickets: 0,
+        }),
+      TypeError,
+    );
+  });
+});

--- a/tests/plan-critics-workflow.test.js
+++ b/tests/plan-critics-workflow.test.js
@@ -6,8 +6,9 @@
  *
  *   - The consolidation critic and the pre-mortem critic survive as
  *     fresh-context sub-agent dispatches between authoring and gate #2 —
- *     report-only, never writing to GitHub (PR6 wires their new dispatch
- *     conditions; the current preconditions hold until then).
+ *     report-only, never writing to GitHub, and risk/size-conditional
+ *     since PR6: the deterministic `plan-critics.js` CLI owns the
+ *     dispatch decision and every skip is ledger-logged for audit.
  *   - The consolidation critic keeps its scope-preserving conservation
  *     invariant (merge-and-rewire only, never adds scope).
  *   - The reachability completeness check is DEMOTED from a workflow
@@ -126,11 +127,44 @@ describe('author-step critics — shared sub-agent mechanics', () => {
     );
   });
 
-  it('names PR6 as the owner of the new dispatch conditions', () => {
+  it('routes the dispatch decision through the deterministic plan-critics CLI', () => {
     assert.match(
       criticsSection,
+      /node \.agents\/scripts\/plan-critics\.js --epic/,
+      'the dispatch conditions must be evaluated by the plan-critics CLI, never judged inline',
+    );
+    assert.match(
+      criticsSection,
+      /dispatch: true\|false/,
+      'the CLI verdict shape must be documented',
+    );
+    assert.doesNotMatch(
+      criticsSection,
       /PR6 wires/i,
-      'the section must defer new dispatch conditions to PR6 while keeping current preconditions',
+      'the PR6 deferral note must be gone — the conditions are wired now',
+    );
+  });
+
+  it('logs every skip decision to the plan-metrics ledger for audit', () => {
+    assert.match(
+      criticsSection,
+      /plan-metrics ledger/,
+      'skips must be recorded in the plan-metrics ledger',
+    );
+    assert.match(
+      criticsSection,
+      /`kind: "critic-skip"`/,
+      'the additive critic-skip record kind must be named',
+    );
+    assert.match(
+      criticsSection,
+      /under-firing is auditable/i,
+      'the under-firing audit rationale must survive',
+    );
+    assert.match(
+      criticsSection,
+      /persist validators remain unchanged hard gates/i,
+      'the unchanged-hard-gates guarantee must be stated',
     );
   });
 });
@@ -144,8 +178,21 @@ describe('consolidation critic — conservation invariant', () => {
     );
     assert.match(
       criticsSection,
-      /matches[\s\S]*Delivery Slicing table 1:1/i,
+      /match[\s\S]*?Delivery Slicing table 1:1/i,
       'the deterministic 1:1 skip precondition must survive',
+    );
+  });
+
+  it('documents the PR6 size/divergence dispatch condition', () => {
+    assert.match(
+      criticsSection,
+      /more than 5 stories/,
+      'the >5-stories size condition must be stated',
+    );
+    assert.match(
+      criticsSection,
+      /mismatch is confirmed/i,
+      'the confirmed-divergence condition must be stated',
     );
   });
 
@@ -220,6 +267,24 @@ describe('pre-mortem critic — code-reading skill (F9)', () => {
     assert.ok(
       criticsIdx > 0 && persistIdx > criticsIdx,
       'the critics must be documented before the persist call',
+    );
+  });
+
+  it('documents the PR6 risk/size dispatch conditions', () => {
+    assert.match(
+      criticsSection,
+      /overall level is\s*\n?\s*high/i,
+      'the high-risk condition must be stated',
+    );
+    assert.match(
+      criticsSection,
+      /at least half `maxTickets`/,
+      'the half-budget size condition must be stated',
+    );
+    assert.match(
+      criticsSection,
+      /`planning\.riskHeuristics` phrase matches/,
+      'the risk-heuristics condition must be stated',
     );
   });
 

--- a/tests/plan-metrics.test.js
+++ b/tests/plan-metrics.test.js
@@ -11,9 +11,11 @@ import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { afterEach, beforeEach, describe, it } from 'node:test';
 import {
+  appendCriticSkip,
   appendPlanMetric,
   MAX_LEDGER_BYTES,
   PLAN_METRICS_BASENAME,
+  PLAN_METRICS_KIND_CRITIC_SKIP,
   PLAN_METRICS_SCHEMA_VERSION,
   planMetricsPath,
   readPlanMetrics,
@@ -84,6 +86,58 @@ describe('appendPlanMetric', () => {
     assert.equal(await appendPlanMetric(null, config), false);
     assert.equal(await appendPlanMetric(entry({ cli: '' }), config), false);
     assert.equal(await appendPlanMetric(entry({ mode: '' }), config), false);
+  });
+
+  it('appendCriticSkip writes the additive critic-skip record shape (PR6)', async () => {
+    assert.equal(
+      await appendCriticSkip(
+        {
+          critic: 'consolidation',
+          reasons: ['draft matches Delivery Slicing 1:1'],
+          cli: 'plan-critics',
+          epicId: 4474,
+        },
+        config,
+      ),
+      true,
+    );
+    const { entries } = await readPlanMetrics(4474, config);
+    assert.equal(entries.length, 1);
+    const record = entries[0];
+    assert.equal(record.v, PLAN_METRICS_SCHEMA_VERSION);
+    assert.equal(record.kind, PLAN_METRICS_KIND_CRITIC_SKIP);
+    assert.equal(record.cli, 'plan-critics');
+    assert.equal(record.critic, 'consolidation');
+    assert.deepEqual(record.reasons, ['draft matches Delivery Slicing 1:1']);
+    assert.equal(record.epicId, 4474);
+    assert.ok(typeof record.at === 'string' && record.at.length > 0);
+  });
+
+  it('appendCriticSkip routes epicId:null to the standalone stream and never throws', async () => {
+    assert.equal(
+      await appendCriticSkip(
+        {
+          critic: 'reachability',
+          reasons: ['unconfigured'],
+          cli: 'plan-persist',
+        },
+        config,
+      ),
+      true,
+    );
+    const { entries } = await readPlanMetrics(null, config);
+    assert.equal(entries.length, 1);
+    assert.equal(entries[0].epicId, null);
+    // Invalid entries degrade to false, never a throw.
+    assert.equal(await appendCriticSkip(null, config), false);
+    assert.equal(
+      await appendCriticSkip({ critic: '', cli: 'x' }, config),
+      false,
+    );
+    assert.equal(
+      await appendCriticSkip({ critic: 'x', cli: '' }, config),
+      false,
+    );
   });
 
   it('rotates the ledger to <name>.1 when the byte cap would be exceeded', async () => {
@@ -212,12 +266,49 @@ describe('summarizePlanMetrics', () => {
       failures: 1,
       byCli: { 'epic-plan-spec': 2, 'epic-plan-decompose': 1 },
       byMode: { 'emit-context': 1, persist: 2 },
+      criticSkips: 0,
+      criticSkipsByCritic: {},
       firstStartedAt: '2026-07-12T10:00:00.000Z',
       lastEndedAt: '2026-07-12T10:12:03.000Z',
       spanMs: 723_000,
       totalDurationMs: 243_000,
       malformedLines: 1,
     });
+  });
+
+  it('counts critic-skip records separately from invocations (PR6)', () => {
+    const withSkips = ledger();
+    withSkips.entries.push(
+      {
+        v: 1,
+        kind: PLAN_METRICS_KIND_CRITIC_SKIP,
+        cli: 'plan-critics',
+        critic: 'pre-mortem',
+        reasons: ['low risk, small plan'],
+        epicId: 4474,
+        at: '2026-07-12T10:13:00.000Z',
+      },
+      {
+        v: 1,
+        kind: PLAN_METRICS_KIND_CRITIC_SKIP,
+        cli: 'plan-persist',
+        critic: 'reachability',
+        reasons: ['No planning.navigation.routeGlobs configured — skipped.'],
+        epicId: 4474,
+        at: '2026-07-12T10:14:00.000Z',
+      },
+    );
+    const summary = summarizePlanMetrics(withSkips);
+    assert.equal(summary.invocations, 3, 'skips never inflate invocations');
+    assert.equal(summary.criticSkips, 2);
+    assert.deepEqual(summary.criticSkipsByCritic, {
+      'pre-mortem': 1,
+      reachability: 1,
+    });
+    assert.match(
+      renderPlanMetricsSummaryLine(summary),
+      /2 critic skip\(s\) logged \(pre-mortem ×1, reachability ×1\)/,
+    );
   });
 
   it('renderPlanMetricsSummaryLine snapshot', () => {

--- a/tests/plan-reachability.test.js
+++ b/tests/plan-reachability.test.js
@@ -1,0 +1,161 @@
+/**
+ * plan-reachability.test.js — orphan-surface detection fixtures for the
+ * #4474 PR6 deterministic persist-side reachability check (the demoted
+ * 8.4 critic):
+ *
+ *   - unconfigured `planning.navigation` → silent skip (status 'skipped');
+ *   - configured navRegistry × clean route set → ok;
+ *   - configured navRegistry × orphaned route set → named orphan list;
+ *   - plan-level coverage: appending one nav-owner Story that cites the
+ *     orphaned routes + the registry converges the re-run to ok (the
+ *     one-targeted-amend recovery contract);
+ *   - fallback registry tokens when navRegistry is empty;
+ *   - the rendered soft-failure message.
+ */
+
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import {
+  evaluateDraftReachability,
+  renderReachabilityOrphans,
+} from '../.agents/scripts/lib/orchestration/plan-reachability.js';
+
+const NAV_CONFIG = {
+  planning: {
+    navigation: {
+      routeGlobs: ['pages/**', 'app/**/route.ts'],
+      navRegistry: ['nav-registry.ts'],
+    },
+  },
+};
+
+/** Draft story with a serialized-shape body (`{"path":...}` descriptors). */
+function story(slug, { paths = [], extraBody = '' } = {}) {
+  const changes = paths
+    .map((p) => `- {"path":"${p}","assumption":"creates"}`)
+    .join('\n');
+  return {
+    slug,
+    title: `Story ${slug}`,
+    body: `## Goal\n${slug}.\n\n## Changes\n${changes}\n${extraBody}`,
+    depends_on: [],
+  };
+}
+
+describe('evaluateDraftReachability — fixtures', () => {
+  it('is a silent no-op when planning.navigation is unconfigured', () => {
+    const result = evaluateDraftReachability({
+      tickets: [story('a', { paths: ['pages/dashboard.tsx'] })],
+      config: {},
+    });
+    assert.equal(result.status, 'skipped');
+    assert.match(result.reasons[0], /No planning\.navigation\.routeGlobs/);
+    assert.deepEqual(result.orphans, []);
+    assert.equal(result.scanned, 0);
+  });
+
+  it('passes a clean route set (every route-adding story cites the registry)', () => {
+    const result = evaluateDraftReachability({
+      tickets: [
+        story('adds-page', {
+          paths: ['pages/reports.tsx'],
+          extraBody: '\nRegister the page in `nav-registry.ts`.',
+        }),
+        story('no-routes', { paths: ['lib/util.js'] }),
+      ],
+      config: NAV_CONFIG,
+    });
+    assert.equal(result.status, 'ok');
+    assert.equal(result.scanned, 2);
+  });
+
+  it('flags orphan surfaces: route-adding stories with no navigation owner', () => {
+    const result = evaluateDraftReachability({
+      tickets: [
+        story('orphan-a', { paths: ['pages/reports.tsx', 'lib/util.js'] }),
+        story('orphan-b', { paths: ['app/billing/route.ts'] }),
+        story('clean', { paths: ['lib/other.js'] }),
+      ],
+      config: NAV_CONFIG,
+    });
+    assert.equal(result.status, 'orphans');
+    assert.deepEqual(result.orphans, [
+      { story: 'orphan-a', paths: ['pages/reports.tsx'] },
+      { story: 'orphan-b', paths: ['app/billing/route.ts'] },
+    ]);
+  });
+
+  it('converges after the one-targeted-amend recovery (a nav-owner story covers the routes)', () => {
+    const orphaned = [
+      story('orphan-a', { paths: ['pages/reports.tsx'] }),
+      story('orphan-b', { paths: ['app/billing/route.ts'] }),
+    ];
+    assert.equal(
+      evaluateDraftReachability({ tickets: orphaned, config: NAV_CONFIG })
+        .status,
+      'orphans',
+    );
+    // The documented recovery: append ONE reachability Story citing the
+    // orphaned routes and the nav registry, then re-run.
+    const amended = [
+      ...orphaned,
+      story('nav-owner', {
+        paths: ['pages/reports.tsx', 'app/billing/route.ts'],
+        extraBody:
+          '\nWire both surfaces into `nav-registry.ts` so each has a nav door.',
+      }),
+    ];
+    const rerun = evaluateDraftReachability({
+      tickets: amended,
+      config: NAV_CONFIG,
+    });
+    assert.equal(rerun.status, 'ok');
+  });
+
+  it('falls back to generic registry tokens when navRegistry is empty', () => {
+    const config = {
+      planning: { navigation: { routeGlobs: ['pages/**'] } },
+    };
+    const flagged = evaluateDraftReachability({
+      tickets: [story('a', { paths: ['pages/x.tsx'] })],
+      config,
+    });
+    assert.equal(flagged.status, 'orphans');
+    const passing = evaluateDraftReachability({
+      tickets: [
+        story('a', {
+          paths: ['pages/x.tsx'],
+          extraBody: '\nAdd the page to the nav registry.',
+        }),
+      ],
+      config,
+    });
+    assert.equal(passing.status, 'ok');
+  });
+
+  it('handles an empty draft set as ok', () => {
+    const result = evaluateDraftReachability({
+      tickets: [],
+      config: NAV_CONFIG,
+    });
+    assert.equal(result.status, 'ok');
+    assert.equal(result.scanned, 0);
+  });
+});
+
+describe('renderReachabilityOrphans', () => {
+  it('renders the named soft failure with the orphan list and the recovery contract', () => {
+    const message = renderReachabilityOrphans({
+      status: 'orphans',
+      reasons: ['1 route-adding draft story(ies) leave orphan surfaces.'],
+      orphans: [{ story: 'orphan-a', paths: ['pages/reports.tsx'] }],
+      scanned: 1,
+    });
+    assert.match(message, /SOFT FAILURE — reachability orphans/);
+    assert.match(message, /orphan-a: pages\/reports\.tsx/);
+    assert.match(message, /Nothing was written to GitHub/);
+    assert.match(message, /ONE targeted amend/);
+    assert.match(message, /at most one reachability Story per plan/);
+  });
+});

--- a/tests/scripts/plan-persist.reachability.test.js
+++ b/tests/scripts/plan-persist.reachability.test.js
@@ -1,0 +1,351 @@
+/**
+ * tests/scripts/plan-persist.reachability.test.js — Epic #4474 PR6.
+ *
+ * Persist-side coverage for the deterministic draft reachability check
+ * (design §4: the 8.4 critic demoted into `plan-persist.js` step 4.5):
+ *
+ *   - orphaned route set → NAMED SOFT FAILURE
+ *     (`code: PLAN_REACHABILITY_ORPHANS`) raised with ZERO provider calls,
+ *     so the one-targeted-amend recovery re-runs a clean persist;
+ *   - configured navRegistry × clean route set → persist completes and the
+ *     result envelope records `reachability.status: 'ok'`;
+ *   - unconfigured `planning.navigation` → silent no-op, and the skip
+ *     decision is appended to the plan-metrics ledger
+ *     (`kind: 'critic-skip'`, critic 'reachability') for audit;
+ *   - single-delivery mode → no draft tree to scan; the skip is
+ *     ledger-logged with the single-shape reason.
+ */
+
+import assert from 'node:assert/strict';
+import { mkdtempSync, rmSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, it } from 'node:test';
+
+import { upsertEpicSection } from '../../.agents/scripts/lib/epic-body-sections.js';
+import { AGENT_LABELS } from '../../.agents/scripts/lib/label-constants.js';
+import {
+  PLAN_METRICS_KIND_CRITIC_SKIP,
+  readPlanMetrics,
+} from '../../.agents/scripts/lib/orchestration/plan-metrics.js';
+import { runPlanPersist } from '../../.agents/scripts/lib/orchestration/plan-persist/run-plan-persist.js';
+import { writeSpec } from '../../.agents/scripts/lib/spec/index.js';
+import { serialize } from '../../.agents/scripts/lib/story-body/story-body.js';
+
+const EPIC_ID = 8899;
+const OPERATOR = 'plan-persist-reachability-tester';
+
+const TECH_SPEC = [
+  '## Delivery Slicing',
+  '',
+  '| Slice | What ships | Independent? |',
+  '| --- | --- | --- |',
+  '| S1 | the page | Yes |',
+].join('\n');
+
+const LOW_VERDICT = {
+  axes: [
+    {
+      axis: 'internal-refactor',
+      level: 'low',
+      rationale: 'Test fixture — internal tooling only.',
+    },
+  ],
+  summary: 'Low-risk fixture.',
+};
+
+const SINGLE_VERDICT = {
+  ...LOW_VERDICT,
+  deliveryShape: 'single',
+  deliveryShapeRationale: 'One-pass-sized (test fixture).',
+};
+
+/** Build a minimal valid Story ticket touching `filePath`. */
+function ticket(slug, { filePath, acceptance } = {}) {
+  const acceptanceLines = acceptance ?? [`${slug} done`];
+  return {
+    slug,
+    type: 'story',
+    title: `Story ${slug}`,
+    body: serialize({
+      goal: `Goal of ${slug}.`,
+      changes: [{ path: filePath, assumption: 'creates' }],
+      acceptance: acceptanceLines,
+      verify: ['npm test (validate)'],
+    }),
+    labels: ['type::story'],
+    depends_on: [],
+    acceptance: acceptanceLines,
+    verify: ['npm test (validate)'],
+  };
+}
+
+/** In-memory provider stub (trimmed from the PR4 modes-test stub). */
+function buildStubProvider() {
+  let nextId = 9700;
+  let nextCommentId = 2000;
+  const issues = new Map();
+  const comments = new Map();
+  issues.set(EPIC_ID, {
+    id: EPIC_ID,
+    title: 'Reachability Test Epic',
+    body: upsertEpicSection(
+      '## Context\nReachability fixture.\n',
+      'techSpec',
+      TECH_SPEC,
+    ),
+    labels: ['type::epic'],
+    assignees: [],
+    state: 'open',
+  });
+  return {
+    issues,
+    comments,
+    createTicketCalls: 0,
+    async getEpic(id) {
+      return issues.get(id);
+    },
+    async getTicket(id) {
+      return issues.get(id);
+    },
+    async getTickets() {
+      return Array.from(issues.values()).filter((t) => t.id !== EPIC_ID);
+    },
+    async getSubTickets(parentId) {
+      return Array.from(issues.values()).filter(
+        (t) => t.parentId === parentId && t.state === 'open',
+      );
+    },
+    async createTicket(parentId, payload) {
+      this.createTicketCalls += 1;
+      const id = nextId++;
+      issues.set(id, {
+        id,
+        parentId,
+        title: payload.title,
+        body: payload.body ?? '',
+        labels: payload.labels ?? [],
+        assignees: [],
+        state: 'open',
+      });
+      return { id, url: `https://stub/issues/${id}` };
+    },
+    async updateTicket(id, patch) {
+      const cur = issues.get(id) ?? { id, labels: [], assignees: [] };
+      if (patch.title) cur.title = patch.title;
+      if (patch.body !== undefined) cur.body = patch.body;
+      if (Array.isArray(patch.assignees)) cur.assignees = [...patch.assignees];
+      if (Array.isArray(patch.labels)) cur.labels = [...patch.labels];
+      if (
+        patch.labels &&
+        typeof patch.labels === 'object' &&
+        !Array.isArray(patch.labels)
+      ) {
+        const existing = new Set(cur.labels ?? []);
+        for (const add of patch.labels.add ?? []) existing.add(add);
+        for (const rm of patch.labels.remove ?? []) existing.delete(rm);
+        cur.labels = Array.from(existing);
+      }
+      if (patch.state) cur.state = patch.state;
+      issues.set(id, cur);
+      return cur;
+    },
+    async getTicketComments(id) {
+      return comments.get(id) ?? [];
+    },
+    async createComment(id, body) {
+      const cid = nextCommentId++;
+      const arr = comments.get(id) ?? [];
+      arr.push({ id: cid, body });
+      comments.set(id, arr);
+      return { id: cid, body };
+    },
+    async postComment(id, payload) {
+      const body = typeof payload === 'string' ? payload : payload.body;
+      return this.createComment(id, body);
+    },
+    async updateComment(_issueId, commentId, body) {
+      for (const arr of comments.values()) {
+        for (const c of arr) {
+          if (c.id === commentId) {
+            c.body = body;
+            return c;
+          }
+        }
+      }
+      return null;
+    },
+    async deleteComment() {
+      return false;
+    },
+    async addSubIssue() {
+      return { ok: true };
+    },
+    async removeSubIssue() {
+      return { ok: true };
+    },
+    primeTicketCache() {},
+  };
+}
+
+let sandbox;
+let epicsDir;
+let config;
+
+beforeEach(() => {
+  sandbox = mkdtempSync(path.join(os.tmpdir(), 'plan-persist-reach-'));
+  epicsDir = path.join(sandbox, '.agents', 'epics');
+  config = {
+    github: { operatorHandle: OPERATOR },
+    project: { paths: { tempRoot: path.join(sandbox, 'temp') } },
+  };
+});
+
+afterEach(() => {
+  if (sandbox) rmSync(sandbox, { recursive: true, force: true });
+});
+
+const NAV_PLANNING = {
+  navigation: {
+    routeGlobs: ['pages/**'],
+    navRegistry: ['nav-registry.ts'],
+  },
+};
+
+function baseInput(provider, { artifacts = {}, planning, opts = {} } = {}) {
+  return {
+    epicId: EPIC_ID,
+    provider,
+    artifacts: {
+      techSpecContent: TECH_SPEC,
+      acceptanceSpecContent: null,
+      riskVerdict: LOW_VERDICT,
+      tickets: null,
+      ...artifacts,
+    },
+    config: planning ? { ...config, planning } : config,
+    settings: {
+      baseBranch: 'main',
+      paths: { tempRoot: path.join(sandbox, 'temp') },
+    },
+    opts: {
+      skipHealthcheck: true,
+      skipCleanup: true,
+      spawnSync: () => ({ status: 0, stdout: '', stderr: '' }),
+      writeSpecFn: (epicId, spec) => writeSpec(epicId, spec, { epicsDir }),
+      loadStateFn: () => ({ epicId: EPIC_ID, mapping: {} }),
+      writeStateFn: () => '/dev/null',
+      bddProbeFn: async () => null,
+      ...opts,
+    },
+  };
+}
+
+function criticSkips(entries) {
+  return entries.filter((e) => e.kind === PLAN_METRICS_KIND_CRITIC_SKIP);
+}
+
+describe('plan-persist — deterministic reachability (step 4.5, PR6)', () => {
+  it('raises the named soft failure on orphan surfaces with ZERO provider calls', async () => {
+    const inner = buildStubProvider();
+    let providerCalls = 0;
+    const counting = new Proxy(inner, {
+      get(target, prop, receiver) {
+        const value = Reflect.get(target, prop, receiver);
+        if (typeof value === 'function') {
+          return (...args) => {
+            providerCalls += 1;
+            return value.apply(target, args);
+          };
+        }
+        return value;
+      },
+    });
+
+    let caught;
+    try {
+      await runPlanPersist(
+        baseInput(counting, {
+          artifacts: {
+            tickets: [ticket('orphan-page', { filePath: 'pages/reports.tsx' })],
+          },
+          planning: NAV_PLANNING,
+        }),
+      );
+      assert.fail('expected PLAN_REACHABILITY_ORPHANS');
+    } catch (err) {
+      caught = err;
+    }
+    assert.equal(caught.code, 'PLAN_REACHABILITY_ORPHANS');
+    assert.match(caught.message, /SOFT FAILURE — reachability orphans/);
+    assert.match(caught.message, /orphan-page: pages\/reports\.tsx/);
+    assert.match(caught.message, /ONE targeted amend/);
+    assert.deepEqual(caught.orphans, [
+      { story: 'orphan-page', paths: ['pages/reports.tsx'] },
+    ]);
+    assert.equal(providerCalls, 0, 'soft failure precedes any GitHub write');
+    assert.equal(inner.createTicketCalls, 0);
+  });
+
+  it('passes a clean route set and records reachability in the result envelope', async () => {
+    const provider = buildStubProvider();
+    const result = await runPlanPersist(
+      baseInput(provider, {
+        artifacts: {
+          tickets: [
+            ticket('nav-owned-page', {
+              filePath: 'pages/reports.tsx',
+              acceptance: ['page is registered in nav-registry.ts'],
+            }),
+          ],
+        },
+        planning: NAV_PLANNING,
+      }),
+    );
+    assert.equal(result.reachability.status, 'ok');
+    assert.ok(provider.issues.get(EPIC_ID).labels.includes(AGENT_LABELS.READY));
+    const { entries } = await readPlanMetrics(EPIC_ID, config);
+    assert.equal(
+      criticSkips(entries).length,
+      0,
+      'a configured, clean scan is not a skip — nothing to audit',
+    );
+  });
+
+  it('is a silent no-op when planning.navigation is unconfigured — skip is ledger-logged', async () => {
+    const provider = buildStubProvider();
+    const result = await runPlanPersist(
+      baseInput(provider, {
+        artifacts: {
+          tickets: [ticket('orphan-page', { filePath: 'pages/reports.tsx' })],
+        },
+        // no planning.navigation
+      }),
+    );
+    assert.equal(result.reachability.status, 'skipped');
+    const { entries } = await readPlanMetrics(EPIC_ID, config);
+    const skips = criticSkips(entries);
+    assert.equal(skips.length, 1);
+    assert.equal(skips[0].critic, 'reachability');
+    assert.equal(skips[0].cli, 'plan-persist');
+    assert.equal(skips[0].epicId, EPIC_ID);
+    assert.match(skips[0].reasons[0], /No planning\.navigation\.routeGlobs/);
+  });
+
+  it('skips in single-delivery mode (no draft tree) and logs the shape reason', async () => {
+    const provider = buildStubProvider();
+    const result = await runPlanPersist(
+      baseInput(provider, {
+        artifacts: { riskVerdict: SINGLE_VERDICT, tickets: null },
+        planning: NAV_PLANNING,
+      }),
+    );
+    assert.equal(result.mode, 'single');
+    assert.equal(result.reachability.status, 'skipped');
+    const { entries } = await readPlanMetrics(EPIC_ID, config);
+    const skips = criticSkips(entries);
+    assert.equal(skips.length, 1);
+    assert.equal(skips[0].critic, 'reachability');
+    assert.match(skips[0].reasons[0], /single-delivery shape/);
+  });
+});


### PR DESCRIPTION
PR6 of the /plan collapse (#4474 — design §4 "Deleted phases' protections" + §6 PR6). Follows PR5 (#4492). The author-step critics become risk/size-conditional with deterministic, ledger-audited dispatch decisions; the persist validators are unchanged hard gates.

## What changed

- **`plan-critics.js` (new CLI)** — one git-local call between authoring and gate #2 evaluates both dispatch conditions (`lib/orchestration/plan-critic-conditions.js`) and emits `{ consolidation, premortem }` with `dispatch` + `reasons`. The workflow dispatches a fresh-context sub-agent only on `dispatch: true`.
- **Reachability (8.4) demoted into persist** — `lib/orchestration/plan-reachability.js` runs in `plan-persist.js` step 4.5 (before any provider call), mirroring the `--paranoid` F7 mechanics: route-glob scan of the draft/merged ticket set vs `planning.navigation.navRegistry`. Orphan surfaces are a **named soft failure** (`code: PLAN_REACHABILITY_ORPHANS`, CLI exit 3) listing story + uncovered routes; plan-level coverage semantics make the documented recovery converge — appending the single nav-owner reachability Story in one targeted amend re-persists clean. Silent no-op when `planning.navigation` is unconfigured.
- **Skip audit (PR1 ledger, additive)** — new `kind: 'critic-skip'` record shape `{ v, kind, cli, critic, reasons[], epicId, at }` via `appendCriticSkip`; the summarizer counts skips separately from invocations (`criticSkips` / `criticSkipsByCritic`) and the persist summary line surfaces them.
- **Workflow prose** — `plan-epic.md`'s critic section rewritten around the CLI verdict (the "PR6 wires…" deferral removed); the persist soft-failure bullet names exit 3. `check-workflow-cli-lint.js` + `check-doc-links.js` clean.
- Additive `cause: 'match'|'divergence'|'fail-open'` on `evaluateConsolidationPrecondition` so fail-open ambiguity is distinguishable from confirmed divergence.

## Condition matrix (as implemented)

| Critic | Fires when | Skips when |
| --- | --- | --- |
| Consolidation (8.3) | precondition `dispatch: true` **AND** (draft > 5 stories **OR** confirmed divergence from the Delivery Slicing table — count or dependency-shape mismatch) | draft matches the table 1:1 (any size); fail-open (missing/unparseable table) with ≤ 5 stories; single-delivery shape (no tickets) |
| Reachability (8.4, deterministic in persist) | orphan surfaces: a route-glob-matching path from a non-registry-referencing story, not covered by any nav-owner story → soft failure, exit 3, zero GitHub writes | `planning.navigation` unconfigured (silent no-op, skip logged); single-delivery shape (skip logged); clean/covered route sets pass |
| Pre-mortem (8.5) | overall risk `high` **OR** ticketCount × 2 ≥ `maxTickets` **OR** any `planning.riskHeuristics` phrase matches the plan text (case-insensitive) | none of the three conditions hold |

## Skip-audit evidence

Smoke run (`plan-critics.js` on a 1:1-matched low-risk 2-ticket draft) appended to the ledger:

```json
{"v":1,"kind":"critic-skip","cli":"plan-critics","critic":"consolidation","reasons":["Draft matches Delivery Slicing 1:1 in count and dependency shape (2 slice(s)) — skipping the 8.3 consolidation dispatch."],"epicId":null,"at":"2026-07-12T19:51:22.069Z"}
{"v":1,"kind":"critic-skip","cli":"plan-critics","critic":"pre-mortem","reasons":["Overall risk is low (not high), ticket count 2 is under half the budget (maxTickets 80), and no planning.riskHeuristics phrase matches the plan text."],"epicId":null,"at":"2026-07-12T19:51:22.083Z"}
```

`plan-persist` logs the same record shape (cli `plan-persist`, critic `reachability`) for the unconfigured-navigation and single-shape skips.

## Tests

- `tests/plan-critic-conditions.test.js` — table-driven fire/skip matrices for both critics (incl. `cause` pinning, half-budget boundary cases, case-insensitive heuristic match).
- `tests/plan-reachability.test.js` — orphan-surface fixtures: unconfigured, configured clean, configured orphaned, one-amend convergence, fallback registry tokens.
- `tests/scripts/plan-persist.reachability.test.js` — soft failure raised with ZERO provider calls; skip records asserted on the ledger for unconfigured + single modes.
- `tests/plan-metrics.test.js` / `tests/plan-critics-workflow.test.js` — critic-skip record shape + summary; workflow-prose pins updated.

## Gates

`npm test` (10141 tests, 0 fail), `npm run lint` (incl. `check-workflow-cli-lint.js`), `lint:md`, `check-dead-exports`, `check-arch-cycles`, `check-context-budget`, `check-baselines`, `check-doc-links` — all green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)