### PR TITLE
feat(plan): close the measured turn gap — seed-mode ideation, authoritative summaries, batched writes (refs #4496)

### DIFF
--- a/.agents/scripts/lib/orchestration/file-assumptions.js
+++ b/.agents/scripts/lib/orchestration/file-assumptions.js
@@ -15,7 +15,13 @@
  *
  * Rules (one error per mismatched path):
  *   - `creates`            + path **exists**  → error (Story would clobber).
- *   - `refactors-existing` + path **absent** → error (no target to refactor).
+ *   - `refactors-existing` (via `changes`) + path **absent** →
+ *     auto-normalized to `creates` with a logged warning (#4496 fix 5):
+ *     a refactor declaration against a base-untracked path is
+ *     deterministically a create, so rejecting it only forces a
+ *     reject→amend→re-persist cycle for a mechanical rewrite. Genuine
+ *     mismatches keep failing — a `references`-sourced `refactors-existing`
+ *     on an absent path is a missing read dependency and stays an error.
  *   - `exists`             + path **absent** → error (read dependency missing).
  *   - `deletes`            + path **absent** → error (nothing to delete).
  *
@@ -186,6 +192,18 @@ function renderMismatch({
 }
 
 /**
+ * Render an auto-normalization (#4496 fix 5) into a stable warning string.
+ * Kept pure and exported through the report so callers log a
+ * self-explanatory line rather than re-deriving the rationale.
+ *
+ * @param {{ slug: string, source: string, path: string, assumption: string }} normalization
+ * @returns {string}
+ */
+function renderNormalization({ slug, source, path, assumption }) {
+  return `"${slug}" → body.${source} declares assumption="${assumption}" for ${path} but the path is untracked at the base branch — auto-normalized to "creates" (a refactor of a base-untracked path is deterministically a create). Declare assumption="creates" in the plan to silence this warning.`;
+}
+
+/**
  * Index, across every Story, which Stories declare a `creates` (and which
  * declare a `deletes`) for each `changes`-sourced path. The maps drive the
  * wave-aware simulated-tree overlay: a path created by a transitive
@@ -251,8 +269,11 @@ function predecessorMutator(index, path, predecessors) {
  *
  *   {
  *     errors:    string[]   // one entry per mismatch, batched per Story
- *     warnings:  string[]   // legacy/no-assumption deprecation nudges
+ *     warnings:  string[]   // legacy/no-assumption deprecation nudges +
+ *                           // auto-normalization notices (#4496 fix 5)
  *     mismatches: object[]  // structured payload for downstream tooling
+ *     normalizations: object[] // `refactors-existing`→`creates`
+ *                           // auto-normalizations on base-untracked paths
  *   }
  *
  * Under the 2-tier hierarchy the Story is the implementation unit, so the
@@ -283,6 +304,7 @@ export function validateStoryFileAssumptions(opts) {
   const errors = [];
   const warnings = [];
   const mismatches = [];
+  const normalizations = [];
   const probeCache = new Map();
 
   // Wave-aware setup (Story #3960): transitive predecessor sets over the
@@ -350,6 +372,14 @@ export function validateStoryFileAssumptions(opts) {
         predecessorCreator,
       });
       if (mismatch !== null) {
+        // Auto-normalization (#4496 fix 5): a deterministic
+        // `refactors-existing`→`creates` rewrite is a warning, never a
+        // rejection — genuine mismatches keep flowing to `errors`.
+        if (mismatch.normalizedTo === 'creates') {
+          normalizations.push(mismatch);
+          warnings.push(renderNormalization(mismatch));
+          continue;
+        }
         mismatches.push(mismatch);
         errors.push(renderMismatch(mismatch));
         continue;
@@ -384,7 +414,7 @@ export function validateStoryFileAssumptions(opts) {
       }
     }
   }
-  return { errors, warnings, mismatches };
+  return { errors, warnings, mismatches, normalizations };
 }
 
 /**
@@ -468,12 +498,43 @@ function checkAssumption({
       }
       return null;
     case 'refactors-existing':
+      // Validate against the simulated tree: a predecessor `creates` makes
+      // an otherwise-absent base path present, so `refactors-existing`
+      // against it is no longer a false-positive mismatch (Story #3960).
+      if (!simulatedExists) {
+        // Auto-normalization (#4496 fix 5): a `changes`-sourced refactor
+        // declaration on a path untracked at the base branch (and not
+        // produced by any predecessor) is deterministically a create —
+        // downgrade to a normalization warning instead of rejecting. Two
+        // genuine mismatches stay hard errors: a `references`-sourced entry
+        // (a read dependency this Story does not author cannot be "created"
+        // here), and a base-TRACKED path a predecessor deletes (the absence
+        // is a plan-shape conflict, not an untracked-path misdeclaration).
+        if (source === 'changes' && !baseExists) {
+          return {
+            slug,
+            source,
+            path,
+            assumption,
+            expected: 'creates',
+            actual: 'absent',
+            normalizedTo: 'creates',
+          };
+        }
+        return {
+          slug,
+          source,
+          path,
+          assumption,
+          expected: 'present',
+          actual: 'absent',
+        };
+      }
+      return null;
     case 'exists':
     case 'deletes':
-      // Validate against the simulated tree: a predecessor `creates` makes
-      // an otherwise-absent base path present, so `refactors-existing` /
-      // `exists` / `deletes` against it is no longer a false-positive
-      // mismatch (Story #3960).
+      // Same simulated-tree overlay as above (Story #3960); an absent path
+      // remains a genuine mismatch for both assumptions.
       if (!simulatedExists) {
         return {
           slug,

--- a/.agents/scripts/lib/orchestration/plan-context.js
+++ b/.agents/scripts/lib/orchestration/plan-context.js
@@ -11,7 +11,7 @@
  * file instead of shim-scripting library imports (the bench measured
  * ~12–15 turns of shim-writing for the dup search alone).
  *
- * Two modes (the design's mode matrix):
+ * Three modes (the design's mode matrix + the #4496 seed entry):
  *   - `epic`      — the Epic exists. Carries `epic`, `clarity` (the Epic
  *                   Clarity Gate rubric — free, same body fetch), `replan`
  *                   (already-planned signals) and `planState`.
@@ -19,6 +19,14 @@
  *                   to the persist half). Carries `onePager` and
  *                   `duplicates[]` (cross-Epic dup search). Clarity is not
  *                   scored — the ideation path is definitionally clear.
+ *   - `seed`      — headless ideation entry (#4496 fix 1): the one-pager
+ *                   does not exist yet either. The dup search runs off the
+ *                   raw seed text, and the envelope additively carries
+ *                   `seed`, `scopeTriage` (the scope-triage rubric applied
+ *                   CLI-side — no skill Reads on the headless path) and
+ *                   `onePagerSpec` (the canonical one-pager sections, so
+ *                   the authoring pass writes the one-pager in the SAME
+ *                   batched write as the spec artifacts).
  *
  * All fields are JSON-serialisable; the module performs no GitHub writes.
  * The only I/O surfaces are the injected `provider` (reads) and the
@@ -78,6 +86,131 @@ export const TICKET_SCHEMA_DESCRIPTOR = Object.freeze({
   validatedBy:
     'validateAndNormalizeTickets (lib/orchestration/ticket-validator.js) at persist time',
 });
+
+/**
+ * Canonical one-pager authoring descriptor for the `seed` envelope
+ * (#4496 fix 1). The section names are the ones `plan-epic.md`'s ideation
+ * entry has always named, chosen so the authored headings parse against
+ * the `SECTION_RE` map in `lib/epic-plan-ideation.js` (which renders the
+ * Epic body from the one-pager at persist time via
+ * `.agents/templates/epic-from-idea.md`).
+ */
+export const ONE_PAGER_AUTHORING_SPEC = Object.freeze({
+  sections: Object.freeze([
+    'Problem Statement',
+    'Recommended Direction',
+    'Key Assumptions',
+    'MVP Scope',
+    'Not Doing',
+  ]),
+  instruction:
+    'Author the one-pager markdown (the canonical sections above, as `## ` ' +
+    'headings) in the SAME batched write as the other planning artifacts — ' +
+    'no separate ideation pass and no idea-refinement skill activation on ' +
+    'this path. Every unresolved unknown lands in Key Assumptions instead ' +
+    'of a question.',
+  consumedBy:
+    'plan-persist.js --one-pager (ideation Epic creation via ' +
+    '.agents/templates/epic-from-idea.md)',
+});
+
+/**
+ * Count top-level enumerated items (`- `, `* `, `1. `) anywhere in a
+ * free-form seed text. Unlike {@link countScopeItems} this does not require
+ * a scope-shaped heading — a raw `--idea` seed rarely has one.
+ *
+ * @param {string} text
+ * @returns {number}
+ */
+function countEnumeratedItems(text) {
+  if (typeof text !== 'string' || text.length === 0) return 0;
+  return text
+    .split(/\r?\n/)
+    .filter((line) => /^\s*(?:[-*]|\d+\.)\s+\S/.test(line)).length;
+}
+
+/**
+ * Delta-shaped change-request verbs — the `core/scope-triage` skill's
+ * change-request rubric routes these to `story` by default when the
+ * footprint stays inside Story width.
+ */
+const DELTA_VERB_RE =
+  /\b(fix(?:es)?|tweak(?:s)?|extend(?:s)?|update(?:s)?|adjust(?:s)?|rename(?:s)?|correct(?:s)?|patch(?:es)?|bug|regression|flaky)\b/i;
+
+/**
+ * Deterministic, CLI-applied scope-triage verdict over a raw `--idea` seed
+ * (#4496 fix 6). Embedding the verdict in the `--seed` envelope removes the
+ * two skill Reads (`core/scope-triage` + the gate fragment's rubric pass)
+ * from the headless path; the attended path keeps the skill-based judgment.
+ *
+ * The heuristics anchor to the same sizing SSOT the skill anchors to —
+ * `DELIVERABLE_GRANULARITY_GUIDANCE` / `DEFAULT_TASK_SIZING` in
+ * `ticket-validator-sizing.js` (one Story = one coherent capability slice;
+ * multiple independent capabilities = an Epic) — and to the skill's
+ * change-request delta rubric. Like the skill, the verdict is **advisory**:
+ * being wrong in the `epic` direction is cheap (the consolidation critic and
+ * the sizing validator catch an over-planned Story later), and `borderline`
+ * is a first-class output, not a forced call.
+ *
+ * @param {{ seedText?: string }} args
+ * @returns {{ verdict: 'epic'|'story'|'borderline', reasons: string[], advisory: true, appliedBy: 'cli' }}
+ */
+export function buildScopeTriageSignal({ seedText = '' } = {}) {
+  const advisory = /** @type {const} */ (true);
+  const appliedBy = /** @type {const} */ ('cli');
+  const text = typeof seedText === 'string' ? seedText : '';
+  const listItems = countEnumeratedItems(text);
+  const wordCount = text.split(/\s+/).filter(Boolean).length;
+
+  if (listItems >= 3) {
+    return {
+      verdict: 'epic',
+      reasons: [
+        `seed enumerates ${listItems} candidate capabilities — a genuine fan-out surface`,
+      ],
+      advisory,
+      appliedBy,
+    };
+  }
+  if (listItems >= 1) {
+    return {
+      verdict: 'story',
+      reasons: [
+        `seed enumerates ${listItems} capability item(s) — one coherent change with one reason to exist`,
+      ],
+      advisory,
+      appliedBy,
+    };
+  }
+  if (DELTA_VERB_RE.test(text) && wordCount <= 120) {
+    return {
+      verdict: 'story',
+      reasons: [
+        'delta-shaped seed (change-request verb, no capability enumeration) within Story width',
+      ],
+      advisory,
+      appliedBy,
+    };
+  }
+  if (wordCount >= 250) {
+    return {
+      verdict: 'epic',
+      reasons: [
+        `broad prose seed (~${wordCount} words) with no enumeration — plausibly multiple independent capabilities`,
+      ],
+      advisory,
+      appliedBy,
+    };
+  }
+  return {
+    verdict: 'borderline',
+    reasons: [
+      'no capability enumeration and no clear delta signal — could be one ambitious Story or a small Epic; the operator (or the --yes Recommended branch) decides',
+    ],
+    advisory,
+    appliedBy,
+  };
+}
 
 /**
  * Resolve the planning risk heuristics list from the canonical config
@@ -450,13 +583,55 @@ async function buildOnePagerModeEnvelope({
 }
 
 /**
+ * Build the seed-mode (headless ideation) envelope — #4496 fix 1. The
+ * one-pager does not exist yet: the dup search and the authoring-context
+ * fold both run off the raw seed text (the same builders the one-pager mode
+ * uses), and the envelope additively carries `seed`, the CLI-applied
+ * `scopeTriage` verdict (fix 6 — no skill Reads on the headless path), and
+ * `onePagerSpec` so the one-pager sections are authored in the same batched
+ * write as the spec artifacts.
+ */
+async function buildSeedModeEnvelope({
+  seedText,
+  provider,
+  config,
+  settings,
+  fullContext,
+  cwd,
+}) {
+  if (typeof seedText !== 'string' || seedText.trim().length === 0) {
+    throw new Error(
+      '[plan-context] --seed requires non-empty seed text — nothing to plan from.',
+    );
+  }
+  const base = await buildOnePagerModeEnvelope({
+    onePagerPath: undefined,
+    onePagerContent: seedText,
+    provider,
+    config,
+    settings,
+    fullContext,
+    cwd,
+  });
+  const { onePager: _onePager, ...rest } = base;
+  return {
+    ...rest,
+    mode: 'seed',
+    seed: { text: seedText },
+    scopeTriage: buildScopeTriageSignal({ seedText }),
+    onePagerSpec: ONE_PAGER_AUTHORING_SPEC,
+  };
+}
+
+/**
  * Build the single planner-context envelope.
  *
  * @param {{
- *   mode: 'epic'|'one-pager',
+ *   mode: 'epic'|'one-pager'|'seed',
  *   epicId?: number,
  *   onePagerPath?: string,
  *   onePagerContent?: string,
+ *   seedText?: string,
  *   provider: object,
  *   config: object,
  *   settings: object,
@@ -469,6 +644,7 @@ export async function buildPlanContext({
   epicId,
   onePagerPath,
   onePagerContent,
+  seedText,
   provider,
   config = {},
   settings = {},
@@ -504,7 +680,17 @@ export async function buildPlanContext({
       cwd,
     });
   }
+  if (mode === 'seed') {
+    return buildSeedModeEnvelope({
+      seedText,
+      provider,
+      config,
+      settings,
+      fullContext,
+      cwd,
+    });
+  }
   throw new Error(
-    `[plan-context] unknown mode "${mode}" — expected "epic" or "one-pager".`,
+    `[plan-context] unknown mode "${mode}" — expected "epic", "one-pager" or "seed".`,
   );
 }

--- a/.agents/scripts/lib/orchestration/plan-critics-evaluate.js
+++ b/.agents/scripts/lib/orchestration/plan-critics-evaluate.js
@@ -1,0 +1,99 @@
+/**
+ * plan-critics-evaluate.js — shared critic-dispatch evaluation for the
+ * collapsed /plan flow (#4496 fix 6; extracted from the `plan-critics.js`
+ * CLI so the persist surface folds the same evaluation in as a pre-write
+ * phase).
+ *
+ * Two consumers:
+ *   - `plan-persist.js` (via `runPlanPersist`) — evaluates the dispatch
+ *     conditions as a deterministic pre-write phase, prints the verdicts,
+ *     and records every skip on the plan-metrics ledger, so the headless
+ *     path never pays a standalone CLI turn for the same decision.
+ *   - `plan-critics.js` — the standalone CLI survives one release as a
+ *     thin shim over this module for the attended pre-gate evaluation
+ *     (the verdict folds into gate #2's view before the persist runs).
+ *
+ * Pure evaluation: no file I/O, no GitHub calls, no ledger writes — the
+ * callers own artifact loading and skip recording.
+ *
+ * @module lib/orchestration/plan-critics-evaluate
+ */
+
+import { getLimits } from '../config-resolver.js';
+import {
+  evaluateConsolidationDispatch,
+  evaluatePremortemDispatch,
+} from './plan-critic-conditions.js';
+
+/**
+ * Resolve the planning risk heuristics list from the canonical config
+ * block (same resolution `plan-context.js` and the decompose context use).
+ *
+ * @param {object} config
+ * @returns {string[]}
+ */
+function resolveRiskHeuristics(config = {}) {
+  if (Array.isArray(config.planning?.riskHeuristics)) {
+    return config.planning.riskHeuristics;
+  }
+  return config.agentSettings?.planning?.riskHeuristics || [];
+}
+
+/**
+ * Evaluate the consolidation + pre-mortem critic dispatch conditions over
+ * the authored planning artifacts (design §4 / #4474 PR6 conditions,
+ * unchanged):
+ *
+ *   - Consolidation: skipped outright when `tickets` is null/absent (the
+ *     single-delivery shape authors no draft tickets); otherwise the
+ *     deterministic precondition + size/divergence conditions.
+ *   - Pre-mortem: risk verdict overall level high, OR ticket count at least
+ *     half `maxTickets`, OR any `planning.riskHeuristics` phrase matching
+ *     the plan text.
+ *
+ * @param {{
+ *   techSpecContent: string,
+ *   riskVerdict: { summary?: string },
+ *   tickets?: Array<object>|null,
+ *   config?: object,
+ * }} args
+ * @returns {{
+ *   consolidation: { critic: string, dispatch: boolean, reasons: string[] },
+ *   premortem: { critic: string, dispatch: boolean, reasons: string[] },
+ * }}
+ */
+export function evaluatePlanCritics({
+  techSpecContent,
+  riskVerdict,
+  tickets = null,
+  config = {},
+}) {
+  const ticketList = Array.isArray(tickets) ? tickets : null;
+  const consolidation =
+    ticketList === null
+      ? {
+          critic: 'consolidation',
+          dispatch: false,
+          reasons: [
+            'single-delivery shape — no draft tickets exist to consolidate.',
+          ],
+        }
+      : evaluateConsolidationDispatch({
+          draftStories: ticketList,
+          specText: techSpecContent,
+        });
+
+  const premortem = evaluatePremortemDispatch({
+    riskVerdict,
+    ticketCount: ticketList?.length ?? 0,
+    maxTickets: getLimits(config).maxTickets,
+    riskHeuristics: resolveRiskHeuristics(config),
+    planText: [
+      techSpecContent ?? '',
+      ticketList ? JSON.stringify(ticketList) : '',
+      riskVerdict?.summary ?? '',
+    ].join('\n'),
+  });
+
+  return { consolidation, premortem };
+}

--- a/.agents/scripts/lib/orchestration/plan-persist/run-plan-persist.js
+++ b/.agents/scripts/lib/orchestration/plan-persist/run-plan-persist.js
@@ -130,6 +130,7 @@ import {
   read as readPlanState,
   write as writePlanState,
 } from '../epic-plan-state-store.js';
+import { evaluatePlanCritics } from '../plan-critics-evaluate.js';
 import {
   appendCriticSkip,
   readPlanMetrics,
@@ -426,9 +427,10 @@ export async function runPlanPersist({
   let validated = null;
   let amendPartition = null;
   let reachability = null;
+  let gateSet = null;
   if (mode !== 'single') {
     amendPartition = mode === 'amend' ? partitionAmendTickets(tickets) : null;
-    const gateSet = mode === 'amend' ? buildMergedTicketSet(tickets) : tickets;
+    gateSet = mode === 'amend' ? buildMergedTicketSet(tickets) : tickets;
     const maxTickets = getLimits(config).maxTickets;
     if (gateSet.length > maxTickets && !allowOverBudget) {
       throw new Error(
@@ -531,6 +533,40 @@ export async function runPlanPersist({
       },
       config,
     );
+  }
+
+  // ---- Step 4.7: folded critic dispatch evaluation (#4496 fix 6 — the
+  // former standalone `plan-critics.js` turn). Deterministic and git-local,
+  // still zero provider calls: the verdicts are printed (and returned on
+  // the result) as part of the pre-write phase, and every skip decision is
+  // appended to the plan-metrics ledger exactly as the standalone CLI did,
+  // so under-firing stays auditable without a separate invocation on the
+  // headless path. Advisory by construction — the deterministic validators
+  // above remain the unchanged hard gates. ----
+  const critics = evaluatePlanCritics({
+    techSpecContent,
+    riskVerdict,
+    tickets: gateSet,
+    config,
+  });
+  for (const decision of [critics.consolidation, critics.premortem]) {
+    Logger.info(
+      `[plan-persist] critic ${decision.critic}: ` +
+        `${decision.dispatch ? 'dispatch' : 'skip'} — ` +
+        decision.reasons.join('; '),
+    );
+    if (!decision.dispatch) {
+      // Best-effort by contract — a failed append never fails the persist.
+      await appendCriticSkip(
+        {
+          critic: decision.critic,
+          reasons: decision.reasons,
+          cli: 'plan-persist',
+          epicId: requestedEpicId,
+        },
+        config,
+      );
+    }
   }
 
   // ---- Step 5: ideation fold / Epic resolution (first provider call). ----
@@ -902,6 +938,7 @@ export async function runPlanPersist({
       freshness,
       healthcheck,
       reachability,
+      critics,
       reconcile,
       specPath: specFilePath,
       waveTable,

--- a/.agents/scripts/lib/orchestration/plan-persist/summary.js
+++ b/.agents/scripts/lib/orchestration/plan-persist/summary.js
@@ -89,10 +89,16 @@ function renderWaveTableLines(waveTable) {
  * record `{ deliveryShape, sliceCount, routingReasons }` (Epic #4474 PR4)
  * for the spec-only mode.
  *
+ * Every auto-waiver the persist derived is printed WITH its reason
+ * (#4496 fix 2) — e.g. the no-BDD-runner acceptance-disposition waiver
+ * (`planningRisk.acceptanceWaivedReason`) — so the summary is
+ * self-explanatory and a headless reader never has to re-derive a persist
+ * outcome from framework source.
+ *
  * @param {{
  *   epicId: number,
  *   ticketCount: number,
- *   planningRisk: { overallLevel?: string, gateDecision?: string },
+ *   planningRisk: { overallLevel?: string, gateDecision?: string, acceptanceDisposition?: string, acceptanceWaivedReason?: string },
  *   reviewRouting: { decision?: string },
  *   freshness?: { stale?: number, ambiguous?: number },
  *   healthcheck?: { ok?: boolean, waived?: boolean, skipped?: boolean },
@@ -137,6 +143,14 @@ export function buildPlanSummaryCommentBody({
       ? `- Single-delivery plan (\`delivery::single\`): no Story tree — the Delivery Slicing table is the audit trail.`
       : `- ${ticketCount} Story ticket(s) persisted across ${waveTable.length} wave(s).`;
 
+  // Auto-waivers always ship with their reason (#4496 fix 2): the summary
+  // is authoritative, so the line must be self-explanatory on its own.
+  const waiverLines = planningRisk?.acceptanceWaivedReason
+    ? [
+        `- ⚠️ Acceptance disposition auto-waived to \`not-applicable\` — ${planningRisk.acceptanceWaivedReason}`,
+      ]
+    : [];
+
   const amendLines = amend
     ? [
         `- Amend delta: ${amend.created.length} added, ${amend.recreated.length} modified (closed + recreated), ${amend.closed.length} closed, ${amend.keptCount} kept untouched.`,
@@ -176,6 +190,7 @@ export function buildPlanSummaryCommentBody({
     headLine,
     ...amendLines,
     `- Risk: ${planningRisk?.overallLevel ?? 'unknown'} · ${planningRisk?.gateDecision ?? 'unknown'} (review routing: ${reviewRouting?.decision ?? 'unknown'}).`,
+    ...waiverLines,
     freshnessLine,
     healthcheckLine,
     // G2 measurement receipt (Epic #4474 PR1/PR7): the plan-CLI invocation

--- a/.agents/scripts/lib/orchestration/ticket-validator.js
+++ b/.agents/scripts/lib/orchestration/ticket-validator.js
@@ -589,8 +589,25 @@ export function validateAndNormalizeTickets(tickets, opts = {}) {
       gitRunner: sharedGitRunner,
       cwd: opts.cwd,
     });
+    // Auto-normalizations (#4496 fix 5) get their own prefix so the logged
+    // warning is self-explanatory; everything else on the warnings channel
+    // is a legacy-shape deprecation nudge.
+    const normalizationWarnings = new Set(
+      (assumptionReport.normalizations ?? []).map((n) => n.path),
+    );
     for (const warning of assumptionReport.warnings) {
-      Logger.warn(`[ticket-validator] assumption-deprecation: ${warning}`);
+      const isNormalization = warning.includes('auto-normalized to "creates"');
+      Logger.warn(
+        `[ticket-validator] ${isNormalization ? 'assumption-normalized' : 'assumption-deprecation'}: ${warning}`,
+      );
+    }
+    if (normalizationWarnings.size > 0) {
+      Logger.warn(
+        `[ticket-validator] ${normalizationWarnings.size} refactors-existing ` +
+          'declaration(s) on base-untracked path(s) auto-normalized to ' +
+          '"creates" — the gate proceeds; update the plan declarations at ' +
+          'the next amend.',
+      );
     }
     assumptionErrors = assumptionReport.errors;
   }

--- a/.agents/scripts/plan-context.js
+++ b/.agents/scripts/plan-context.js
@@ -11,7 +11,7 @@
  * stdout-pure JSON envelope. The PR7 cutover retired the delegate CLIs —
  * this is the only emit-context surface.
  *
- * Two entry forms (exactly one is required):
+ * Three entry forms (exactly one is required):
  *
  *   --epic <id>          Existing-Epic mode. Envelope carries `epic`,
  *                        `clarity` (Epic Clarity Gate rubric), `replan`
@@ -22,6 +22,15 @@
  *                        carries `onePager` and `duplicates[]` (cross-Epic
  *                        dup search). No clarity score: the ideation path
  *                        is definitionally clear.
+ *
+ *   --seed "<text>"      Headless ideation entry (#4496 fix 1) — neither
+ *                        the Epic nor the one-pager exists yet. The dup
+ *                        search runs off the raw seed text, and the
+ *                        envelope additively carries `seed`, `scopeTriage`
+ *                        (the scope-triage rubric applied CLI-side — fix 6)
+ *                        and `onePagerSpec`, so the one-pager sections are
+ *                        authored in the same batched write as the spec
+ *                        artifacts.
  *
  * Flags:
  *   --pretty         Pretty-print the JSON envelope.
@@ -58,10 +67,11 @@ import { createProvider } from './lib/provider-factory.js';
  * captured output is exactly one `JSON.parse`-able payload.
  *
  * @param {{
- *   mode: 'epic'|'one-pager',
+ *   mode: 'epic'|'one-pager'|'seed',
  *   epicId?: number,
  *   onePagerPath?: string,
  *   onePagerContent?: string,
+ *   seedText?: string,
  *   provider: object,
  *   config: object,
  *   settings: object,
@@ -77,6 +87,7 @@ export async function emitPlanContext({
   epicId,
   onePagerPath,
   onePagerContent,
+  seedText,
   provider,
   config,
   settings,
@@ -90,6 +101,7 @@ export async function emitPlanContext({
     epicId,
     onePagerPath,
     onePagerContent,
+    seedText,
     provider,
     config,
     settings,
@@ -108,6 +120,7 @@ async function main() {
     options: {
       epic: { type: 'string' },
       'one-pager': { type: 'string' },
+      seed: { type: 'string' },
       pretty: { type: 'boolean', default: false },
       'full-context': { type: 'boolean', default: false },
     },
@@ -117,12 +130,16 @@ async function main() {
   const hasEpic = typeof values.epic === 'string' && values.epic.length > 0;
   const hasOnePager =
     typeof values['one-pager'] === 'string' && values['one-pager'].length > 0;
-  if (hasEpic === hasOnePager) {
+  const hasSeed = typeof values.seed === 'string' && values.seed.length > 0;
+  const entryForms = [hasEpic, hasOnePager, hasSeed].filter(Boolean).length;
+  if (entryForms !== 1) {
     throw new Error(
-      'Pass exactly one of --epic <id> or --one-pager <path>. ' +
-        '(--epic: existing-Epic mode; --one-pager: ideation mode.)',
+      'Pass exactly one of --epic <id>, --one-pager <path> or --seed "<text>". ' +
+        '(--epic: existing-Epic mode; --one-pager: ideation mode; ' +
+        '--seed: headless ideation entry.)',
     );
   }
+  const mode = hasEpic ? 'epic' : hasOnePager ? 'one-pager' : 'seed';
 
   let epicId;
   if (hasEpic) {
@@ -159,21 +176,22 @@ async function main() {
   const provider = createProvider(config);
 
   // Plan-metrics ledger (#4474 PR1): stamp entry/exit + mode so the folded
-  // emit surface is measured against the 12-phase baseline. One-pager mode
-  // has no Epic yet, so the record routes to the standalone stream
-  // (epicId null) exactly like `story-plan.js`.
+  // emit surface is measured against the 12-phase baseline. One-pager and
+  // seed modes have no Epic yet, so the record routes to the standalone
+  // stream (epicId null) exactly like `story-plan.js`.
   await recordPlanInvocation(
     {
       cli: 'plan-context',
-      mode: hasEpic ? 'epic' : 'one-pager',
+      mode,
       epicId: hasEpic ? epicId : null,
       config,
     },
     () =>
       emitPlanContext({
-        mode: hasEpic ? 'epic' : 'one-pager',
+        mode,
         epicId,
         onePagerPath: hasOnePager ? values['one-pager'] : undefined,
+        seedText: hasSeed ? values.seed : undefined,
         provider,
         config,
         settings,

--- a/.agents/scripts/plan-critics.js
+++ b/.agents/scripts/plan-critics.js
@@ -5,15 +5,24 @@
  * author-step critics of the collapsed /plan flow (Epic #4474 PR6,
  * design §4).
  *
+ * **Thin shim (#4496 fix 6).** The evaluation itself now lives in
+ * `lib/orchestration/plan-critics-evaluate.js` and is folded into
+ * `plan-persist.js` as a pre-write phase, so the headless (`--yes`) path
+ * never pays a standalone CLI turn for the dispatch decision. This CLI
+ * survives one release for the attended pre-gate evaluation (the verdict
+ * folds into gate #2's view before the persist runs) and for any external
+ * scripting; it delegates to the shared module and keeps its exact output
+ * contract.
+ *
  * Runs between authoring and gate #2, entirely git-local (zero GitHub
  * calls): reads the authored artifacts, evaluates the risk/size dispatch
  * conditions for the consolidation (8.3) and pre-mortem (8.5) critics via
- * `lib/orchestration/plan-critic-conditions.js`, and emits one JSON
- * verdict on stdout. The workflow dispatches a fresh-context sub-agent
- * ONLY for critics with `dispatch: true`; every skip decision is appended
- * to the plan-metrics ledger (`kind: "critic-skip"`, with reasons) so
- * under-firing is auditable — the persist validators remain unchanged
- * hard gates regardless of what this gate decides.
+ * the shared evaluator, and emits one JSON verdict on stdout. The workflow
+ * dispatches a fresh-context sub-agent ONLY for critics with
+ * `dispatch: true`; every skip decision is appended to the plan-metrics
+ * ledger (`kind: "critic-skip"`, with reasons) so under-firing is
+ * auditable — the persist validators remain unchanged hard gates
+ * regardless of what this gate decides.
  *
  * Conditions (design §4 / §6 PR6):
  *   - Consolidation: the existing deterministic precondition
@@ -53,16 +62,12 @@ import { parseArgs } from 'node:util';
 import { runAsCli } from './lib/cli-utils.js';
 import { epicArtifactPath } from './lib/config/temp-paths.js';
 import {
-  getLimits,
   resolveConfig,
   validateOrchestrationConfig,
 } from './lib/config-resolver.js';
 import { routeAllOutputToStderr } from './lib/Logger.js';
 import { loadRiskVerdict } from './lib/orchestration/epic-plan-spec/phases/risk-verdict.js';
-import {
-  evaluateConsolidationDispatch,
-  evaluatePremortemDispatch,
-} from './lib/orchestration/plan-critic-conditions.js';
+import { evaluatePlanCritics } from './lib/orchestration/plan-critics-evaluate.js';
 import {
   appendCriticSkip,
   recordPlanInvocation,
@@ -71,20 +76,6 @@ import {
 const USAGE =
   'Usage: plan-critics.js (--epic <EpicId> | --tech-spec <file> ' +
   '--risk-verdict <file> [--tickets <file>]) [--pretty]';
-
-/**
- * Resolve the planning risk heuristics list from the canonical config
- * block (same resolution `plan-context.js` and the decompose context use).
- *
- * @param {object} config
- * @returns {string[]}
- */
-function resolveRiskHeuristics(config = {}) {
-  if (Array.isArray(config.planning?.riskHeuristics)) {
-    return config.planning.riskHeuristics;
-  }
-  return config.agentSettings?.planning?.riskHeuristics || [];
-}
 
 async function readOptional(filePath, { required }) {
   try {
@@ -172,30 +163,11 @@ async function main() {
         }
       }
 
-      const consolidation =
-        tickets === null
-          ? {
-              critic: 'consolidation',
-              dispatch: false,
-              reasons: [
-                'single-delivery shape — no draft tickets exist to consolidate.',
-              ],
-            }
-          : evaluateConsolidationDispatch({
-              draftStories: tickets,
-              specText: techSpecContent,
-            });
-
-      const premortem = evaluatePremortemDispatch({
+      const { consolidation, premortem } = evaluatePlanCritics({
+        techSpecContent,
         riskVerdict,
-        ticketCount: tickets?.length ?? 0,
-        maxTickets: getLimits(config).maxTickets,
-        riskHeuristics: resolveRiskHeuristics(config),
-        planText: [
-          techSpecContent,
-          ticketsRaw ?? '',
-          riskVerdict.summary ?? '',
-        ].join('\n'),
+        tickets,
+        config,
       });
 
       // Skip-audit trail (#4474 PR6): every non-dispatch is a ledger

--- a/.agents/workflows/helpers/plan-epic-reference.md
+++ b/.agents/workflows/helpers/plan-epic-reference.md
@@ -100,19 +100,30 @@ reseeding from live GitHub state when the file is missing — so only the
 genuinely-missing children are created; the existing tree is never
 duplicated.
 
-## Measurement — the G2 acceptance gate (Epic #4474)
+## Measurement — the G2 acceptance gate (Epic #4474, restated per #4496)
 
-The 3-step collapse is **measured, not asserted**. The acceptance bar the
-next benchmark cohort reads as the gate:
+The 3-step collapse is **measured, not asserted**. The gate is stated
+**per mode** (#4496 — adopted in the bench roadmap after the first measured
+headless run):
 
-- **Turns-per-plan ≤ ~15** at the epic rung (from the 55–72-turn 12-phase
-  baseline). The turns proxy is the plan-metrics invocation ledger
+- **Epic-mode** (`/plan <id> --yes`): **≤ ~12 turns / ≤ ~1.1M tokens**.
+- **Ideation-mode** (`/plan --idea --yes`): **≤ ~15 turns / ≤ ~1.5M
+  tokens** once the #4496 fixes (seed-mode ideation, authoritative persist
+  summaries, batched artifact writes) are in play; **interim smoke
+  threshold ≤ ~20 turns / ≤ ~2.0M tokens** for runs measured before/during
+  the rollout.
+- Verification is a cheap direct `/plan --idea --yes` probe reading the
+  plan-metrics ledger (~$3–4), not a full bench cell.
+
+Shared mechanics behind both rungs (from the 55–72-turn / 7.3–8.9M
+12-phase baseline):
+
+- The turns proxy is the plan-metrics invocation ledger
   (`temp/epic-<id>/plan-metrics.json`) plus the host session's turn
   accounting — ledger records count CLI invocations from the parent
   session's perspective, not sub-agent turns.
-- **Plan tokens ≤ ~1.5M** at the epic rung (from 7.3–8.9M) — owned by the
-  host's session accounting (mandrel-bench `modelUsage`), not by any
-  in-repo counter.
+- Plan tokens are owned by the host's session accounting (mandrel-bench
+  `modelUsage`), not by any in-repo counter.
 - **Unchanged validator coverage** — every deterministic gate of the
   retired pipeline still fires on the persist path: section gate, ticket
   validator, file-assumption, DAG, budget, draft reachability, inline

--- a/.agents/workflows/helpers/plan-epic.md
+++ b/.agents/workflows/helpers/plan-epic.md
@@ -35,6 +35,9 @@ confirmed (gate #1).
 
 ### Ideation entry (`--idea "<seed>"` or no argument)
 
+**Attended (no `--yes`)** — the interactive grill loop is HITL by
+definition and stays:
+
 1. Activate the [`core/idea-refinement`](../../skills/core/idea-refinement/SKILL.md)
    skill with the seed. It returns a one-pager with the canonical sections
    (Problem Statement, Recommended Direction, Key Assumptions, MVP Scope,
@@ -63,6 +66,26 @@ confirmed (gate #1).
 4. Review `duplicates[]`. A non-empty ranked list folds into gate #1: the
    operator either confirms the new Epic is distinct or folds the idea into
    an existing Epic (in which case `/plan` exits).
+
+**Headless (`--yes`) — seed entry (#4496 fix 1).** There is no one to
+grill, so the one-pager prelude is pure ceremony: do **not** activate the
+`idea-refinement` skill and do **not** write a separate one-pager file
+before authoring. Instead, emit the envelope directly off the seed:
+
+```bash
+node .agents/scripts/plan-context.js --seed "<seed text>" \
+  > temp/plan-ideation/<slug>/plan-context.json
+```
+
+(slug from the seed's leading phrase; the tree is gitignored). The seed envelope is the one-pager envelope plus three additive fields:
+`seed` (the raw text), `scopeTriage` (the scope-triage rubric applied
+CLI-side — no skill Reads on this path; a `story` / `borderline` verdict
+resolves to its Recommended handoff per
+[`scope-triage-gate.md`](scope-triage-gate.md)), and `onePagerSpec` (the
+canonical one-pager sections). The one-pager markdown is authored **in
+step 2's single batched write**, alongside the other artifacts — every
+unresolved unknown lands in its Key Assumptions section. `duplicates[]`
+resolves headlessly per gate #1's `--yes` note.
 
 ### Existing-Epic entry (`/plan <epicId>`)
 
@@ -126,25 +149,38 @@ step 2 until the operator explicitly confirms.
 Read the envelope with the `Read` tool and write the planning artifacts to
 `temp/epic-[Epic_ID]/` (ideation: the `temp/plan-ideation/<slug>/` tree).
 The single `plan-context.json` envelope supersedes the per-phase
-`planner-context.json` / `decomposer-context.json` files the authoring
-skills name — read the envelope wherever a skill asks for either.
+`planner-context.json` / `decomposer-context.json` files.
 
-1. **`techspec.md`** — activate the
-   [`epic-plan-spec-author`](../../skills/core/epic-plan-spec-author/SKILL.md)
-   skill. The Tech Spec opens with `## Delivery Slicing` and never restates
-   the Epic's Context/Goal/Scope.
-2. **`risk-verdict.json`** — same skill; the schema-conformant verdict
+**The envelope's `systemPrompts` ARE the authoring instructions on this
+path** (#4496 fix 4): `systemPrompts.spec` / `systemPrompts.acceptance`
+govern the Tech Spec, risk verdict, and Acceptance Spec;
+`systemPrompts.decompose` (with `ticketSchema` and `maxTickets`) governs
+the tickets. Do **not** read the
+[`epic-plan-spec-author`](../../skills/core/epic-plan-spec-author/SKILL.md)
+or
+[`epic-plan-decompose-author`](../../skills/core/epic-plan-decompose-author/SKILL.md)
+SKILL.md files here — they remain the reference source the prompts render
+from, but re-reading them double-pays instructions the envelope already
+carries.
+
+**Batched writes (#4496 fix 3).** Emit the artifact files as **parallel
+`Write` calls in ONE message** — `techspec.md`, `risk-verdict.json`,
+`acceptance-spec.md`, and `tickets.json` together (ideation: the one-pager
+markdown joins the same batch). Never write them one-per-turn.
+
+1. **`techspec.md`** — per `systemPrompts.spec`. The Tech Spec opens with
+   `## Delivery Slicing` and never restates the Epic's Context/Goal/Scope.
+2. **`risk-verdict.json`** — the schema-conformant verdict
    **plus `deliveryShape: "fan-out"|"single"`** and a one-line rationale.
    Seed the shape from the envelope's `deliveryShapeSignal` (advisory —
    the operator vetoes it at gate #2). `"single"` means one-pass-sized or a
    pure dependent chain: the plan ships as spec-only, with **no tickets**.
-3. **`acceptance-spec.md`** — same skill; omit only when the Epic carries
-   the `acceptance::n-a` waiver label.
-4. **`tickets.json`** — fan-out shape only: activate the
-   [`epic-plan-decompose-author`](../../skills/core/epic-plan-decompose-author/SKILL.md)
-   skill against the same envelope (its `systemPrompts.decompose`,
-   `ticketSchema`, and `maxTickets` fields). In single-delivery shape author
-   **no** tickets file — the Delivery Slicing table is the plan.
+3. **`acceptance-spec.md`** — per `systemPrompts.acceptance`; omit only
+   when the Epic carries the `acceptance::n-a` waiver label.
+4. **`tickets.json`** — fan-out shape only: author against the same
+   envelope (its `systemPrompts.decompose`, `ticketSchema`, and
+   `maxTickets` fields). In single-delivery shape author **no** tickets
+   file — the Delivery Slicing table is the plan.
 
 > **One-pass refinement contract (amend, don't regenerate).** When a critic
 > flags Stories or the step 3 persist rejects an artifact, apply **targeted
@@ -153,8 +189,12 @@ skills name — read the envelope wherever a skill asks for either.
 
 ### Conditional critics (between authoring and gate #2)
 
-Evaluate the dispatch conditions deterministically first — one git-local
-CLI call, zero GitHub reads:
+The evaluation is folded into `plan-persist.js` as a deterministic
+pre-write phase (#4496 fix 6) — the persist prints both verdicts, returns
+them on its result envelope, and ledger-logs every skip. **Attended runs**
+evaluate the dispatch conditions before gate #2 so the verdicts fold into
+its view — one git-local CLI call, zero GitHub reads, via the thin shim
+(kept one release over the shared evaluator):
 
 ```bash
 node .agents/scripts/plan-critics.js --epic [Epic_ID]
@@ -166,6 +206,14 @@ a sub-agent ONLY for a critic with `dispatch: true`; surface each skip as a
 one-line note. Every skip decision is appended to the plan-metrics ledger
 (`kind: "critic-skip"`, with reasons) so under-firing is auditable — the
 persist validators remain unchanged hard gates either way.
+
+> **`--yes` (headless).** Do **not** run the standalone CLI and do **not**
+> dispatch critic sub-agents: the critics' findings would fold into a gate
+> that auto-proceeds, so a report nobody reviews is pure spend. The
+> persist's folded pre-write evaluation is the audit record — its verdicts
+> print in the persist output, a `dispatch: true` verdict surfaces as a
+> one-line advisory note in the run summary, and every skip still lands on
+> the plan-metrics ledger.
 
 Both critics are **fresh-context sub-agents** (`Agent` tool,
 `subagent_type: general-purpose`) — never inline skill activations, so they
@@ -252,6 +300,24 @@ intermediate `agent::review-spec`) → checkpoint v2 + a single `plan-summary`
 comment carrying the dry-run wave table → temp cleanup **only at terminal
 success**, so a failed run leaves the artifacts in place for `--force` /
 `--resume` reuse.
+
+Two deterministic softenings ride the gate list:
+
+- The file-assumption gate **auto-normalizes** a `refactors-existing`
+  declaration on a base-untracked path to `creates` with a logged warning
+  (#4496 fix 5) — a refactor of a path that does not exist is
+  deterministically a create, so no amend cycle is forced. Genuine
+  mismatches (an absent read dependency, a clobbering `creates`, a missing
+  `deletes` target) still reject.
+- Every auto-waiver the persist derives is printed **with its reason** in
+  the `plan-summary` comment and the result JSON (#4496 fix 2) — e.g. the
+  no-BDD-runner acceptance-disposition waiver.
+
+> **`--yes` (headless): persist outcomes are authoritative.** Read the
+> persist's result JSON and `plan-summary` receipts as the final word — do
+> **not** re-derive a waiver, disposition, or routing decision from
+> framework source. If a summary line seems surprising, its reason is on
+> the line itself; spend zero turns re-verifying it.
 
 ### Persist rejections and soft failures
 

--- a/.agents/workflows/helpers/scope-triage-gate.md
+++ b/.agents/workflows/helpers/scope-triage-gate.md
@@ -87,6 +87,15 @@ meanings; it only forces the Recommended resolution where the gate would
 otherwise STOP. See
 [`plan.md` § Headless / non-interactive mode](../plan.md#headless--non-interactive-mode---yes).
 
+**Headless seed entry — the verdict is already in the envelope (#4496).**
+On the `--idea` `--yes` path the rubric is applied **CLI-side** by
+`plan-context.js --seed` and shipped as the envelope's `scopeTriage` field
+(`{ verdict, reasons, advisory: true, appliedBy: "cli" }`), anchored to the
+same sizing SSOT this skill anchors to. Do **not** Read the
+`core/scope-triage` skill headless — use the envelope verdict and resolve it
+per this section. The attended paths keep the skill-based judgment
+unchanged.
+
 ## No-re-triage rule
 
 A **scope-triage handoff** is a triage decision *already made*. When `/plan` is

--- a/.agents/workflows/plan.md
+++ b/.agents/workflows/plan.md
@@ -88,7 +88,10 @@ exactly **two** HITL STOP gates, and `--yes` deterministically auto-proceeds
    exactly one bounded pass**: no operator questions are asked — facts come
    from the codebase, and every unresolved unknown lands in the one-pager's
    **Key Assumptions** section instead of a question, so a headless driver
-   can never hang inside a free-form interrogation. The verdict / clarity
+   can never hang inside a free-form interrogation. On the `--idea` Epic
+   path this bounded pass IS the seed entry (#4496): `plan-context.js
+   --seed` replaces the idea-refinement prelude, and the one-pager is
+   authored in the same batched write as the spec artifacts. The verdict / clarity
    scoring is still recorded in chat (one line); only the *wait* is
    suppressed — the deterministic clarity *scoring* inside the
    `plan-context.js` envelope always runs.
@@ -126,15 +129,24 @@ advisory critic diffs — auto-proceed for the same headless reason.
 1. **Parse args.** Exactly one of `<epicId>`, `--idea`, `--from-notes`, or
    `--body` must be present; anything else is a usage error naming the four
    forms. A `--body` invocation routes to the story path (no triage).
-2. **Triage (idea path only).** Run the
+2. **Triage (idea path only).** Attended: run the
    [`core/scope-triage`](../skills/core/scope-triage/SKILL.md) skill on the
-   seed. Record the verdict in chat (one line).
+   seed. Record the verdict in chat (one line). **Under `--yes`, do not
+   Read the skill**: delegate straight to
+   [`helpers/plan-epic.md`](helpers/plan-epic.md)'s ideation entry — its
+   `plan-context.js --seed` envelope carries the rubric's verdict applied
+   CLI-side (`scopeTriage`), and a `story` / `borderline` verdict resolves
+   to the Recommended handoff from inside the helper (see
+   [`helpers/scope-triage-gate.md`](helpers/scope-triage-gate.md)).
 3. **Delegate.** Read the selected path helper **in full** and execute it
    from its entry, forwarding the absorbed flags (including `--yes`). The
    helper's steps, HITL gates, and scripts are the procedure — this router
    adds no step content. When `--yes` is present, the two HITL STOP gates
    auto-proceed per [Headless / non-interactive mode](#headless--non-interactive-mode---yes)
-   above; every deterministic gate still runs.
+   above; every deterministic gate still runs. **Under `--yes`, when the
+   helper content is already injected or present in context, execute it
+   directly — do not spend a separate read-in-full turn re-reading content
+   you already hold.**
 4. **Internal returns.** When a path helper would historically have handed
    off to the other planning command, switch helpers in-place and continue;
    surface the switch to the operator as a one-line note.

--- a/tests/contract/planning/plan-persist-validator-coverage.test.js
+++ b/tests/contract/planning/plan-persist-validator-coverage.test.js
@@ -306,7 +306,7 @@ describe('plan-persist — deterministic gate coverage inventory (#4474 G2 recei
     );
   });
 
-  it('gate 4 — file-assumption gate rejects a refactors-existing claim on a path absent from the base branch', async () => {
+  it('gate 4 — file-assumption gate rejects a genuine mismatch (absent read dependency)', async () => {
     const provider = buildStubProvider();
     const acceptance = ['bad-path done'];
     await assert.rejects(
@@ -316,11 +316,14 @@ describe('plan-persist — deterministic gate coverage inventory (#4474 G2 recei
             tickets: [
               ticket('bad-path', {
                 body: serialize({
-                  goal: 'Refactor a file that does not exist.',
+                  goal: 'Read a file that does not exist.',
                   changes: [
+                    { path: 'package.json', assumption: 'refactors-existing' },
+                  ],
+                  references: [
                     {
                       path: 'definitely/not/a/real/file.js',
-                      assumption: 'refactors-existing',
+                      assumption: 'exists',
                     },
                   ],
                   acceptance,
@@ -333,6 +336,38 @@ describe('plan-persist — deterministic gate coverage inventory (#4474 G2 recei
         }),
       ),
       /assumption/i,
+    );
+  });
+
+  it('gate 4b — refactors-existing on a base-untracked path auto-normalizes to creates instead of rejecting (#4496 fix 5)', async () => {
+    const provider = buildStubProvider();
+    const acceptance = ['new-path done'];
+    const result = await runPlanPersist(
+      baseInput(provider, {
+        artifacts: {
+          tickets: [
+            ticket('new-path', {
+              body: serialize({
+                goal: 'Refactor a file that turns out to be brand new.',
+                changes: [
+                  {
+                    path: 'definitely/not/a/real/file.js',
+                    assumption: 'refactors-existing',
+                  },
+                ],
+                acceptance,
+                verify: ['npm test (validate)'],
+              }),
+              acceptance,
+            }),
+          ],
+        },
+      }),
+    );
+    assert.equal(result.labelTransition, 'ready');
+    assert.ok(
+      provider.issues.get(EPIC_ID).labels.includes(AGENT_LABELS.READY),
+      'the deterministic normalization must not block the persist',
     );
   });
 

--- a/tests/file-assumptions.test.js
+++ b/tests/file-assumptions.test.js
@@ -212,11 +212,15 @@ describe('validateStoryFileAssumptions — rules table', () => {
       expectError: false,
     },
     {
-      label: 'refactors-existing + absent → error',
+      // #4496 fix 5: a changes-sourced refactor declaration on a
+      // base-untracked path is deterministically a create — it
+      // auto-normalizes with a warning instead of rejecting.
+      label:
+        'refactors-existing + absent (changes) → auto-normalized to creates, no error',
       assumption: 'refactors-existing',
       exists: false,
-      expectError: true,
-      expected: 'present',
+      expectError: false,
+      expectNormalization: true,
     },
     {
       label: 'exists + present → ok',
@@ -268,6 +272,12 @@ describe('validateStoryFileAssumptions — rules table', () => {
         assert.equal(report.mismatches[0].expected, tc.expected);
       } else {
         assert.deepEqual(report.errors, []);
+      }
+      if (tc.expectNormalization) {
+        assert.equal(report.normalizations.length, 1);
+        assert.equal(report.normalizations[0].normalizedTo, 'creates');
+        assert.equal(report.warnings.length, 1);
+        assert.match(report.warnings[0], /auto-normalized to "creates"/);
       }
     });
   }
@@ -329,14 +339,14 @@ describe('validateStoryFileAssumptions — rules table', () => {
         slug: 'story-b',
         body: {
           goal: 'g',
-          changes: [{ path: 'src/b.ts', assumption: 'refactors-existing' }],
+          changes: [{ path: 'src/b.ts', assumption: 'deletes' }],
           acceptance: ['ac'],
           verify: ['node --test tests/x.test.js (unit)'],
         },
       }),
     ];
     // Both probes return the *opposite* of what each story expects.
-    const probe = ({ path }) => path === 'src/a.ts'; // a exists (bad for creates), b absent (bad for refactors)
+    const probe = ({ path }) => path === 'src/a.ts'; // a exists (bad for creates), b absent (bad for deletes)
     const report = validateStoryFileAssumptions({
       tickets,
       baseBranchRef: 'main',
@@ -693,5 +703,99 @@ describe('validateStoryFileAssumptions — wave-aware predecessor tree (Story #3
     );
     assert.equal(consumerMismatch.expected, 'absent');
     assert.equal(consumerMismatch.actual, 'present');
+  });
+});
+
+describe('refactors-existing auto-normalization on base-untracked paths (#4496 fix 5)', () => {
+  it('changes-sourced refactors-existing on an untracked path normalizes to creates with a warning', () => {
+    const tickets = [
+      makeStory({
+        slug: 'normalized-story',
+        body: {
+          goal: 'g',
+          changes: [
+            { path: 'src/brand-new.ts', assumption: 'refactors-existing' },
+          ],
+          acceptance: ['ac'],
+          verify: ['node --test tests/x.test.js (unit)'],
+        },
+      }),
+    ];
+    const report = validateStoryFileAssumptions({
+      tickets,
+      baseBranchRef: 'main',
+      gitRunner: () => false,
+    });
+    assert.deepEqual(report.errors, []);
+    assert.deepEqual(report.mismatches, []);
+    assert.equal(report.normalizations.length, 1);
+    const n = report.normalizations[0];
+    assert.equal(n.slug, 'normalized-story');
+    assert.equal(n.path, 'src/brand-new.ts');
+    assert.equal(n.assumption, 'refactors-existing');
+    assert.equal(n.normalizedTo, 'creates');
+    assert.equal(report.warnings.length, 1);
+    assert.match(report.warnings[0], /untracked at the base branch/);
+    assert.match(report.warnings[0], /auto-normalized to "creates"/);
+  });
+
+  it('references-sourced refactors-existing on an absent path is a genuine mismatch and still fails', () => {
+    const tickets = [
+      makeStory({
+        slug: 'reader-story',
+        body: {
+          goal: 'g',
+          changes: [{ path: 'src/edit.ts', assumption: 'creates' }],
+          references: [
+            { path: 'src/missing-dep.ts', assumption: 'refactors-existing' },
+          ],
+          acceptance: ['ac'],
+          verify: ['node --test tests/x.test.js (unit)'],
+        },
+      }),
+    ];
+    const report = validateStoryFileAssumptions({
+      tickets,
+      baseBranchRef: 'main',
+      gitRunner: () => false,
+    });
+    assert.deepEqual(report.normalizations, []);
+    assert.equal(report.errors.length, 1);
+    assert.match(report.errors[0], /body\.references/);
+    assert.match(report.errors[0], /absent at the base branch/);
+  });
+
+  it('base-TRACKED path deleted by a predecessor keeps the genuine mismatch (no normalization)', () => {
+    const tickets = [
+      makeStory({
+        slug: 'deleter',
+        body: {
+          goal: 'g',
+          changes: [{ path: 'src/old.ts', assumption: 'deletes' }],
+          acceptance: ['ac'],
+          verify: ['node --test tests/x.test.js (unit)'],
+        },
+      }),
+      {
+        ...makeStory({
+          slug: 'late-refactorer',
+          body: {
+            goal: 'g',
+            changes: [{ path: 'src/old.ts', assumption: 'refactors-existing' }],
+            acceptance: ['ac'],
+            verify: ['node --test tests/x.test.js (unit)'],
+          },
+        }),
+        depends_on: ['deleter'],
+      },
+    ];
+    const report = validateStoryFileAssumptions({
+      tickets,
+      baseBranchRef: 'main',
+      gitRunner: () => true, // tracked at base; absence comes from the delete
+    });
+    assert.deepEqual(report.normalizations, []);
+    assert.equal(report.errors.length, 1);
+    assert.match(report.errors[0], /"late-refactorer"/);
   });
 });

--- a/tests/plan-context.test.js
+++ b/tests/plan-context.test.js
@@ -28,7 +28,9 @@ import {
   buildDeliveryShapeSignal,
   buildPlanContext,
   buildReplanSignal,
+  buildScopeTriageSignal,
   buildSystemPrompts,
+  ONE_PAGER_AUTHORING_SPEC,
   PLAN_CONTEXT_ENVELOPE_BYTE_CEILING,
   TICKET_SCHEMA_DESCRIPTOR,
 } from '../.agents/scripts/lib/orchestration/plan-context.js';
@@ -128,6 +130,28 @@ const EPIC_MODE_KEYS = [
   'ticketSchema',
 ];
 
+const SEED_MODE_KEYS = [
+  'bddRunner',
+  'bddScenarios',
+  'codebaseSnapshot',
+  'deliveryShapeSignal',
+  'docsContext',
+  'duplicates',
+  'maxTickets',
+  'maxTokenBudget',
+  'memoryFreshness',
+  'mode',
+  'onePagerSpec',
+  'planState',
+  'preflightCeilings',
+  'priorFeedback',
+  'riskHeuristics',
+  'scopeTriage',
+  'seed',
+  'systemPrompts',
+  'ticketSchema',
+];
+
 const ONE_PAGER_MODE_KEYS = [
   'bddRunner',
   'bddScenarios',
@@ -177,7 +201,33 @@ describe('plan-context envelope schema (design §1 step 1)', () => {
     assert.equal(env.planState, null);
   });
 
-  it('rejects an unknown mode and a non-numeric epic id', async () => {
+  it('seed mode emits the one-pager key set plus the additive seed fields (#4496)', async () => {
+    const env = await buildPlanContext({
+      mode: 'seed',
+      seedText: ONE_PAGER,
+      provider: buildProvider(),
+      config: { github: { owner: 'o', repo: 'r' } },
+      settings: {},
+    });
+    assert.deepEqual(Object.keys(env).sort(), SEED_MODE_KEYS);
+    assert.equal(env.mode, 'seed');
+    assert.equal(env.seed.text, ONE_PAGER);
+    assert.ok(
+      !('onePager' in env),
+      'the one-pager does not exist yet in seed mode',
+    );
+    assert.equal(env.planState, null);
+    assert.deepEqual(env.onePagerSpec, ONE_PAGER_AUTHORING_SPEC);
+    assert.deepEqual(env.onePagerSpec.sections, [
+      'Problem Statement',
+      'Recommended Direction',
+      'Key Assumptions',
+      'MVP Scope',
+      'Not Doing',
+    ]);
+  });
+
+  it('rejects an unknown mode, a non-numeric epic id, and an empty seed', async () => {
     await assert.rejects(
       () => buildPlanContext({ mode: 'bogus', provider: buildProvider() }),
       /unknown mode/,
@@ -185,6 +235,15 @@ describe('plan-context envelope schema (design §1 step 1)', () => {
     await assert.rejects(
       () => buildPlanContext({ mode: 'epic', provider: buildProvider() }),
       /numeric epicId/,
+    );
+    await assert.rejects(
+      () =>
+        buildPlanContext({
+          mode: 'seed',
+          seedText: '   ',
+          provider: buildProvider(),
+        }),
+      /non-empty seed text/,
     );
   });
 });
@@ -248,6 +307,26 @@ describe('plan-context dup-search fold parity vs library', () => {
     const env = await buildPlanContext({
       mode: 'one-pager',
       onePagerContent: ONE_PAGER,
+      provider,
+      config,
+      settings: {},
+    });
+    const direct = await findSimilarOpenEpics({
+      onePager: ONE_PAGER,
+      provider,
+      owner: 'o',
+      repo: 'r',
+    });
+    assert.ok(direct.length > 0, 'fixture must produce at least one candidate');
+    assert.deepEqual(env.duplicates, direct);
+  });
+
+  it('seed mode runs the dup search off the raw seed text (#4496 fix 1)', async () => {
+    const provider = buildProvider();
+    const config = { github: { owner: 'o', repo: 'r' } };
+    const env = await buildPlanContext({
+      mode: 'seed',
+      seedText: ONE_PAGER,
       provider,
       config,
       settings: {},
@@ -472,5 +551,63 @@ describe('plan-context envelope byte ceiling (PR2 named risk)', () => {
     // The budget must have engaged (body over 50 KB cannot ride through full).
     assert.equal(env.epic.body, null);
     assert.ok(env.epic.bodySummary, 'expected the applyBudget summary mode');
+  });
+});
+
+describe('plan-context scopeTriage signal (CLI-applied rubric, #4496 fix 6)', () => {
+  it('is embedded in the seed envelope as an advisory, cli-applied verdict', async () => {
+    const env = await buildPlanContext({
+      mode: 'seed',
+      seedText: ONE_PAGER,
+      provider: buildProvider(),
+      config: {},
+      settings: {},
+    });
+    assert.ok(
+      ['epic', 'story', 'borderline'].includes(env.scopeTriage.verdict),
+      'verdict must be one of the three canonical scope-triage verdicts',
+    );
+    assert.equal(env.scopeTriage.advisory, true);
+    assert.equal(env.scopeTriage.appliedBy, 'cli');
+    assert.ok(env.scopeTriage.reasons.length > 0);
+  });
+
+  it('verdicts epic when the seed enumerates 3+ candidate capabilities', () => {
+    const signal = buildScopeTriageSignal({
+      seedText:
+        'Build the reporting surface:\n- export engine\n- scheduling\n- share links\n- audit log\n',
+    });
+    assert.equal(signal.verdict, 'epic');
+    assert.match(signal.reasons[0], /enumerates 4 candidate capabilities/);
+  });
+
+  it('verdicts story for a short enumeration and for a delta-shaped seed', () => {
+    const enumerated = buildScopeTriageSignal({
+      seedText: 'Improve onboarding:\n- add a progress meter\n',
+    });
+    assert.equal(enumerated.verdict, 'story');
+
+    const delta = buildScopeTriageSignal({
+      seedText:
+        'Fix the flaky retry in the evidence gate so CI stops re-running.',
+    });
+    assert.equal(delta.verdict, 'story');
+    assert.match(delta.reasons[0], /delta-shaped seed/);
+  });
+
+  it('verdicts borderline when there is no enumeration and no delta signal', () => {
+    const signal = buildScopeTriageSignal({
+      seedText:
+        'A better way to think about how planning context reaches the model.',
+    });
+    assert.equal(signal.verdict, 'borderline');
+  });
+
+  it('verdicts epic for a broad prose seed with no enumeration', () => {
+    const signal = buildScopeTriageSignal({
+      seedText: `${'word '.repeat(260)}`,
+    });
+    assert.equal(signal.verdict, 'epic');
+    assert.match(signal.reasons[0], /broad prose seed/);
   });
 });

--- a/tests/plan-critics-workflow.test.js
+++ b/tests/plan-critics-workflow.test.js
@@ -145,6 +145,29 @@ describe('author-step critics — shared sub-agent mechanics', () => {
     );
   });
 
+  it('documents the persist fold + the headless no-dispatch rule (#4496 fix 6)', () => {
+    assert.match(
+      criticsSection,
+      /folded into `plan-persist\.js` as a deterministic\s*\n?pre-write phase/i,
+      'the persist fold must be documented',
+    );
+    assert.match(
+      criticsSection,
+      /thin shim/i,
+      'the standalone CLI must be described as a one-release thin shim',
+    );
+    assert.match(
+      criticsSection,
+      /Do \*\*not\*\* run the standalone CLI/,
+      'headless runs must not pay the standalone CLI turn',
+    );
+    assert.match(
+      criticsSection,
+      /do \*\*not\*\*\s*\n?>?\s*dispatch critic sub-agents/i,
+      'headless runs must not dispatch critic sub-agents',
+    );
+  });
+
   it('logs every skip decision to the plan-metrics ledger for audit', () => {
     assert.match(
       criticsSection,

--- a/tests/plan-yes-flag-workflow.test.js
+++ b/tests/plan-yes-flag-workflow.test.js
@@ -392,3 +392,137 @@ describe('/plan --yes headless flag — gate #2 (risk-routed pre-persist review)
     );
   });
 });
+
+describe('/plan --yes headless turn-gap fixes (#4496)', () => {
+  const ideation =
+    epicSource.match(
+      /### Ideation entry[\s\S]*?(?=\n### Existing-Epic entry)/,
+    )?.[0] ?? '';
+  const step2 =
+    epicSource.match(
+      /## Step 2 — Author[\s\S]*?(?=\n### Conditional critics)/,
+    )?.[0] ?? '';
+  const step3 =
+    epicSource.match(
+      /## Step 3 — Persist[\s\S]*?(?=\n## Troubleshooting)/,
+    )?.[0] ?? '';
+
+  it('fix 1 — the headless ideation entry is seed-mode: no idea-refinement activation, no separate one-pager write', () => {
+    assert.match(
+      ideation,
+      /plan-context\.js --seed/,
+      'the headless entry must run plan-context.js --seed',
+    );
+    assert.match(
+      ideation,
+      /do \*\*not\*\* activate the\s*\n?`idea-refinement` skill/i,
+      'the headless entry must not activate idea-refinement',
+    );
+    assert.match(
+      ideation,
+      /Attended \(no `--yes`\)/,
+      'the attended grill loop must survive (HITL by definition)',
+    );
+    assert.match(
+      ideation,
+      /authored \*\*in\s*\nstep 2's single batched write\*\*/,
+      'the one-pager must be authored in the batched write',
+    );
+  });
+
+  it('fix 3 — step 2 mandates parallel Write calls in ONE message', () => {
+    assert.match(
+      step2,
+      /\*\*parallel\s*\n?`Write` calls in ONE message\*\*/,
+      'the batched-write mandate must be stated',
+    );
+    assert.match(step2, /Never write them one-per-turn/);
+  });
+
+  it('fix 4 — the envelope systemPrompts are the authoring instructions (no mandated author-skill reads)', () => {
+    assert.match(
+      step2,
+      /`systemPrompts` ARE the authoring instructions/,
+      'the envelope-authoritative statement must be present',
+    );
+    assert.match(
+      step2,
+      /Do \*\*not\*\* read the/,
+      'the author SKILL.md reads must be explicitly retired on this path',
+    );
+    assert.doesNotMatch(
+      step2,
+      /activate the\s*\n?\s*\[`epic-plan-spec-author`\]/,
+      'no mandated spec-author skill activation may survive',
+    );
+  });
+
+  it('fix 2 — persist outcomes are authoritative under --yes (no re-derivation)', () => {
+    assert.match(
+      step3,
+      /persist outcomes are authoritative/i,
+      'the authoritative-summary rule must be stated',
+    );
+    assert.match(
+      step3,
+      /do\s*\n?>?\s*\*\*not\*\* re-derive/i,
+      'the no-re-derivation prohibition must be stated',
+    );
+    assert.match(
+      step3,
+      /with its reason/i,
+      'auto-waivers must be documented as printed with reasons',
+    );
+  });
+
+  it('fix 5 — the untracked-path auto-normalization is documented at the persist gate list', () => {
+    assert.match(step3, /auto-normalizes/i);
+    assert.match(step3, /`refactors-existing`[\s\S]*`creates`/);
+    assert.match(step3, /Genuine\s*\n?\s*mismatches[\s\S]*still reject/i);
+  });
+
+  it('fix 6 — the seed envelope carries the CLI-applied scopeTriage verdict; the fragment forbids the headless skill Read', () => {
+    assert.match(ideation, /`scopeTriage`/);
+    assert.match(
+      gateFragmentSource,
+      /applied \*\*CLI-side\*\*/,
+      'the fragment must document the CLI-side rubric',
+    );
+    assert.match(
+      gateFragmentSource,
+      /Do \*\*not\*\* Read the\s*\n?`core\/scope-triage` skill headless/,
+      'the fragment must forbid the headless skill Read',
+    );
+    assert.match(
+      planSource,
+      /Under `--yes`, do not\s*\n?\s*Read the skill/i,
+      'the router must skip the triage skill Read under --yes',
+    );
+  });
+
+  it('fix 7 — the router executes injected helper content without a read-in-full turn under --yes', () => {
+    assert.match(
+      planSource,
+      /already injected or present in context, execute it\s*\n?\s*directly/i,
+      'the read-in-full exemption must be stated',
+    );
+    assert.match(
+      planSource,
+      /do not spend a separate read-in-full turn/i,
+      'the exemption must name the read-in-full turn',
+    );
+  });
+
+  it('gate restatement — the G2 reference states the per-mode turn/token gates', () => {
+    const reference = readFileSync(
+      path.join(WORKFLOWS, 'helpers', 'plan-epic-reference.md'),
+      'utf8',
+    );
+    assert.match(reference, /Epic-mode[\s\S]*≤ ~12 turns \/ ≤ ~1\.1M/);
+    assert.match(reference, /Ideation-mode[\s\S]*≤ ~15 turns \/ ≤ ~1\.5M/m);
+    assert.match(
+      reference,
+      /interim smoke\s*\n?\s*threshold ≤ ~20 turns \/ ≤ ~2\.0M/i,
+    );
+  });
+});

--- a/tests/scripts/plan-persist.critics-fold.test.js
+++ b/tests/scripts/plan-persist.critics-fold.test.js
@@ -1,0 +1,322 @@
+/**
+ * tests/scripts/plan-persist.critics-fold.test.js — #4496 fix 6.
+ *
+ * Persist-side coverage for the folded author-critics evaluation (the
+ * former standalone `plan-critics.js` turn, now a deterministic pre-write
+ * phase inside `runPlanPersist`):
+ *
+ *   - the result envelope carries `critics.consolidation` /
+ *     `critics.premortem` with the same `{ critic, dispatch, reasons }`
+ *     verdict shape the standalone CLI emits;
+ *   - PRE-WRITE ORDERING: the evaluation (and its critic-skip ledger
+ *     records) lands BEFORE the first provider call — a persist that dies
+ *     at Epic resolution has already recorded the verdicts;
+ *   - skip decisions are appended to the plan-metrics ledger with
+ *     `cli: 'plan-persist'` so under-firing stays auditable without a
+ *     standalone CLI invocation;
+ *   - the single-delivery shape records the no-tickets consolidation skip
+ *     reason (parity with the standalone CLI's single-shape branch);
+ *   - the standalone `plan-critics.js` CLI survives as a thin shim over the
+ *     shared evaluator (`lib/orchestration/plan-critics-evaluate.js`), so
+ *     both surfaces produce identical verdicts for identical artifacts.
+ */
+
+import assert from 'node:assert/strict';
+import { mkdtempSync, rmSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, it } from 'node:test';
+
+import { upsertEpicSection } from '../../.agents/scripts/lib/epic-body-sections.js';
+import { evaluatePlanCritics } from '../../.agents/scripts/lib/orchestration/plan-critics-evaluate.js';
+import {
+  PLAN_METRICS_KIND_CRITIC_SKIP,
+  readPlanMetrics,
+} from '../../.agents/scripts/lib/orchestration/plan-metrics.js';
+import { runPlanPersist } from '../../.agents/scripts/lib/orchestration/plan-persist/run-plan-persist.js';
+import { writeSpec } from '../../.agents/scripts/lib/spec/index.js';
+import { serialize } from '../../.agents/scripts/lib/story-body/story-body.js';
+
+const EPIC_ID = 9944;
+const OPERATOR = 'plan-persist-critics-tester';
+
+const TECH_SPEC = [
+  '## Delivery Slicing',
+  '',
+  '| Slice | What ships | Independent? |',
+  '| --- | --- | --- |',
+  '| S1 | the change | Yes |',
+].join('\n');
+
+const LOW_VERDICT = {
+  axes: [
+    {
+      axis: 'internal-refactor',
+      level: 'low',
+      rationale: 'Test fixture — internal tooling only.',
+    },
+  ],
+  summary: 'Low-risk fixture.',
+};
+
+const SINGLE_VERDICT = {
+  ...LOW_VERDICT,
+  deliveryShape: 'single',
+  deliveryShapeRationale: 'One-pass-sized (test fixture).',
+};
+
+function ticket(slug) {
+  const acceptance = [`${slug} done`];
+  return {
+    slug,
+    type: 'story',
+    title: `Story ${slug}`,
+    body: serialize({
+      goal: `Goal of ${slug}.`,
+      changes: [{ path: 'package.json', assumption: 'refactors-existing' }],
+      acceptance,
+      verify: ['npm test (validate)'],
+    }),
+    labels: ['type::story'],
+    depends_on: [],
+    acceptance,
+    verify: ['npm test (validate)'],
+  };
+}
+
+/** Minimal provider stub (same surface the persist integration stub uses). */
+function buildStubProvider() {
+  let nextId = EPIC_ID + 1;
+  let nextCommentId = 5000;
+  const issues = new Map();
+  const comments = new Map();
+  issues.set(EPIC_ID, {
+    id: EPIC_ID,
+    title: 'Critics Fold Test Epic',
+    body: upsertEpicSection(
+      '## Context\nCritics fixture.\n',
+      'techSpec',
+      TECH_SPEC,
+    ),
+    labels: ['type::epic'],
+    assignees: [],
+    state: 'open',
+  });
+  return {
+    issues,
+    comments,
+    async getEpic(id) {
+      return issues.get(id);
+    },
+    async getTicket(id) {
+      return issues.get(id);
+    },
+    async getTickets() {
+      return [];
+    },
+    async getSubTickets() {
+      return [];
+    },
+    async createIssue({ title, body, labels = [] }) {
+      const id = nextId++;
+      issues.set(id, { id, title, body, labels, assignees: [], state: 'open' });
+      return { id };
+    },
+    async createTicket(parentId, payload) {
+      const id = nextId++;
+      issues.set(id, {
+        id,
+        parentId,
+        title: payload.title,
+        body: payload.body ?? '',
+        labels: payload.labels ?? [],
+        assignees: [],
+        state: 'open',
+      });
+      return { id };
+    },
+    async updateTicket(id, patch) {
+      const cur = issues.get(id) ?? { id, labels: [], assignees: [] };
+      if (patch.body !== undefined) cur.body = patch.body;
+      if (Array.isArray(patch.assignees)) cur.assignees = [...patch.assignees];
+      if (Array.isArray(patch.labels)) cur.labels = [...patch.labels];
+      if (
+        patch.labels &&
+        typeof patch.labels === 'object' &&
+        !Array.isArray(patch.labels)
+      ) {
+        const existing = new Set(cur.labels ?? []);
+        for (const add of patch.labels.add ?? []) existing.add(add);
+        for (const rm of patch.labels.remove ?? []) existing.delete(rm);
+        cur.labels = Array.from(existing);
+      }
+      issues.set(id, cur);
+      return cur;
+    },
+    async getTicketComments(id) {
+      return comments.get(id) ?? [];
+    },
+    async createComment(id, body) {
+      const cid = nextCommentId++;
+      const arr = comments.get(id) ?? [];
+      arr.push({ id: cid, body });
+      comments.set(id, arr);
+      return { id: cid, body };
+    },
+    async postComment(id, payload) {
+      const body = typeof payload === 'string' ? payload : payload.body;
+      return this.createComment(id, body);
+    },
+    async updateComment(_issueId, commentId, body) {
+      for (const arr of comments.values()) {
+        for (const c of arr) {
+          if (c.id === commentId) {
+            c.body = body;
+            return c;
+          }
+        }
+      }
+      return null;
+    },
+    async deleteComment() {
+      return false;
+    },
+    async addSubIssue() {
+      return { ok: true };
+    },
+    async removeSubIssue() {
+      return { ok: true };
+    },
+    primeTicketCache() {},
+  };
+}
+
+let sandbox;
+let epicsDir;
+let config;
+
+beforeEach(() => {
+  sandbox = mkdtempSync(path.join(os.tmpdir(), 'plan-persist-critics-'));
+  epicsDir = path.join(sandbox, '.agents', 'epics');
+  config = {
+    github: { operatorHandle: OPERATOR },
+    project: { paths: { tempRoot: path.join(sandbox, 'temp') } },
+  };
+});
+
+afterEach(() => {
+  if (sandbox) rmSync(sandbox, { recursive: true, force: true });
+});
+
+function baseInput(provider, { artifacts = {}, opts = {} } = {}) {
+  return {
+    epicId: EPIC_ID,
+    provider,
+    artifacts: {
+      techSpecContent: TECH_SPEC,
+      acceptanceSpecContent: null,
+      riskVerdict: LOW_VERDICT,
+      tickets: [ticket('story-one')],
+      ...artifacts,
+    },
+    config,
+    settings: {
+      baseBranch: 'main',
+      paths: { tempRoot: path.join(sandbox, 'temp') },
+    },
+    opts: {
+      skipHealthcheck: true,
+      skipCleanup: true,
+      spawnSync: () => ({ status: 0, stdout: '', stderr: '' }),
+      writeSpecFn: (epicId, spec) => writeSpec(epicId, spec, { epicsDir }),
+      loadStateFn: () => ({ epicId: EPIC_ID, mapping: {} }),
+      writeStateFn: () => '/dev/null',
+      bddProbeFn: async () => null,
+      ...opts,
+    },
+  };
+}
+
+function authorCriticSkips(entries) {
+  return entries.filter(
+    (e) =>
+      e.kind === PLAN_METRICS_KIND_CRITIC_SKIP &&
+      (e.critic === 'consolidation' || e.critic === 'pre-mortem'),
+  );
+}
+
+describe('plan-persist — folded critic evaluation (pre-write phase, #4496 fix 6)', () => {
+  it('returns both critic verdicts on the result envelope', async () => {
+    const provider = buildStubProvider();
+    const result = await runPlanPersist(baseInput(provider));
+    assert.equal(result.critics.consolidation.critic, 'consolidation');
+    assert.equal(typeof result.critics.consolidation.dispatch, 'boolean');
+    assert.ok(result.critics.consolidation.reasons.length > 0);
+    assert.equal(result.critics.premortem.critic, 'pre-mortem');
+    assert.equal(typeof result.critics.premortem.dispatch, 'boolean');
+    assert.ok(result.critics.premortem.reasons.length > 0);
+  });
+
+  it('records skip decisions on the ledger with cli plan-persist', async () => {
+    const provider = buildStubProvider();
+    const result = await runPlanPersist(baseInput(provider));
+    const { entries } = await readPlanMetrics(EPIC_ID, config);
+    const skips = authorCriticSkips(entries);
+    const skippedCritics = [
+      result.critics.consolidation,
+      result.critics.premortem,
+    ].filter((d) => !d.dispatch);
+    assert.equal(skips.length, skippedCritics.length);
+    for (const skip of skips) {
+      assert.equal(skip.cli, 'plan-persist');
+      assert.equal(skip.epicId, EPIC_ID);
+      assert.ok(skip.reasons.length > 0);
+    }
+  });
+
+  it('evaluates BEFORE the first provider call — a persist that dies at Epic resolution has already ledger-logged the verdicts', async () => {
+    const provider = buildStubProvider();
+    provider.getEpic = async () => {
+      throw new Error('provider unavailable (sentinel)');
+    };
+    await assert.rejects(
+      runPlanPersist(baseInput(provider)),
+      /provider unavailable \(sentinel\)/,
+    );
+    const { entries } = await readPlanMetrics(EPIC_ID, config);
+    assert.ok(
+      authorCriticSkips(entries).length > 0,
+      'critic evaluation must precede the first provider call',
+    );
+  });
+
+  it('records the single-delivery consolidation skip reason (CLI parity)', async () => {
+    const provider = buildStubProvider();
+    const result = await runPlanPersist(
+      baseInput(provider, {
+        artifacts: { riskVerdict: SINGLE_VERDICT, tickets: null },
+      }),
+    );
+    assert.equal(result.mode, 'single');
+    assert.match(
+      result.critics.consolidation.reasons[0],
+      /single-delivery shape/,
+    );
+    assert.equal(result.critics.consolidation.dispatch, false);
+  });
+
+  it('produces the same verdicts as the shared evaluator (thin-shim parity)', async () => {
+    const provider = buildStubProvider();
+    const tickets = [ticket('story-one')];
+    const result = await runPlanPersist(
+      baseInput(provider, { artifacts: { tickets } }),
+    );
+    const direct = evaluatePlanCritics({
+      techSpecContent: TECH_SPEC,
+      riskVerdict: LOW_VERDICT,
+      tickets,
+      config,
+    });
+    assert.deepEqual(result.critics, direct);
+  });
+});

--- a/tests/scripts/plan-persist.reachability.test.js
+++ b/tests/scripts/plan-persist.reachability.test.js
@@ -242,7 +242,13 @@ function baseInput(provider, { artifacts = {}, planning, opts = {} } = {}) {
 }
 
 function criticSkips(entries) {
-  return entries.filter((e) => e.kind === PLAN_METRICS_KIND_CRITIC_SKIP);
+  // The folded author-critics evaluation (#4496 fix 6) appends its own
+  // consolidation/pre-mortem skip records; this suite audits only the
+  // reachability channel.
+  return entries.filter(
+    (e) =>
+      e.kind === PLAN_METRICS_KIND_CRITIC_SKIP && e.critic === 'reachability',
+  );
 }
 
 describe('plan-persist — deterministic reachability (step 4.5, PR6)', () => {

--- a/tests/scripts/plan-persist.summary.test.js
+++ b/tests/scripts/plan-persist.summary.test.js
@@ -1,0 +1,77 @@
+/**
+ * tests/scripts/plan-persist.summary.test.js — #4496 fix 2.
+ *
+ * Unit coverage for the `plan-summary` comment body's auto-waiver line:
+ * every auto-waiver the persist derives must be printed WITH its reason so
+ * the summary is self-explanatory — the measured failure mode was a
+ * headless run spending 3–5 turns re-deriving an unexplained
+ * `required → not-applicable` acceptance flip from framework source.
+ */
+
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { buildPlanSummaryCommentBody } from '../../.agents/scripts/lib/orchestration/plan-persist/summary.js';
+import { deriveRiskEnvelope } from '../../.agents/scripts/lib/orchestration/planning-risk.js';
+
+const BASE = {
+  epicId: 4242,
+  ticketCount: 2,
+  reviewRouting: { decision: 'auto-proceed' },
+  freshness: { stale: 0, ambiguous: 0 },
+  healthcheck: { ok: true },
+  waveTable: [
+    { wave: 0, stories: [{ slug: 'a', title: 'A' }] },
+    { wave: 1, stories: [{ slug: 'b', title: 'B' }] },
+  ],
+};
+
+describe('plan-summary — auto-waiver reason line (#4496 fix 2)', () => {
+  it('prints the acceptance auto-waiver WITH its reason', () => {
+    // Derive a real waiver the way the persist does: an axes-required
+    // disposition forced to not-applicable by the no-BDD-runner probe.
+    const planningRisk = deriveRiskEnvelope(
+      {
+        axes: [
+          {
+            axis: 'visible-behavior',
+            level: 'high',
+            rationale: 'User-facing flow changes.',
+          },
+        ],
+        summary: 'High-risk fixture.',
+      },
+      { bddRunner: { fallback: true, reason: 'no-bdd-runner-detected' } },
+    );
+    assert.ok(
+      planningRisk.acceptanceWaivedReason,
+      'fixture must actually derive a waiver',
+    );
+    const body = buildPlanSummaryCommentBody({ ...BASE, planningRisk });
+    const waiverLine = body
+      .split('\n')
+      .find((l) => l.includes('Acceptance disposition auto-waived'));
+    assert.ok(waiverLine, 'the summary must carry a dedicated waiver line');
+    assert.ok(
+      waiverLine.includes(planningRisk.acceptanceWaivedReason),
+      'the waiver line must carry the full reason — the summary is authoritative',
+    );
+    assert.match(waiverLine, /not-applicable/);
+    assert.match(waiverLine, /no BDD runner detected/);
+  });
+
+  it('omits the waiver line when no auto-waiver was derived', () => {
+    const planningRisk = deriveRiskEnvelope({
+      axes: [
+        {
+          axis: 'internal-refactor',
+          level: 'low',
+          rationale: 'Internal only.',
+        },
+      ],
+      summary: 'Low-risk fixture.',
+    });
+    assert.equal(planningRisk.acceptanceWaivedReason, undefined);
+    const body = buildPlanSummaryCommentBody({ ...BASE, planningRisk });
+    assert.ok(!body.includes('auto-waived'), 'no waiver line without a waiver');
+  });
+});


### PR DESCRIPTION
## What

Implements the six mechanical fixes (+ the router diet) the static turn re-audit of the first measured headless `/plan --idea --yes` run attributed the ~20 excess turns to (32 turns / 2.83M tokens vs the ≤~15 / ≤~1.5M G2 gate). Turn count is the dominant lever (~84k resident re-read per turn); the token gate follows from the turn gate.

## Fix → implementation map

| # | Fix | Implementation | Est. savings |
| --- | --- | --- | --- |
| 1 | Fold the one-pager into the author pass under `--yes` | `plan-context.js --seed "<text>"` (new entry form): dup search off the seed; envelope = one-pager envelope + additive `seed` / `scopeTriage` / `onePagerSpec` fields. `plan-epic.md` ideation entry split attended/headless — headless activates NO `idea-refinement` skill and writes NO separate one-pager; the one-pager sections are authored in step 2's batched write. Attended grill loop untouched (HITL by definition). | 5–7 turns |
| 2 | Kill the post-persist self-investigation | `plan-persist` summary prints every auto-waiver WITH its reason (`Acceptance disposition auto-waived to not-applicable — <full derivation>` in the `plan-summary` comment, `summary.js`). Prose: under `--yes` persist outcomes are authoritative — no re-derivation. | 3–5 turns |
| 3 | Batch the artifact Writes | `plan-epic.md` step 2 mandates emitting techspec/risk-verdict/acceptance-spec/tickets (+ the ideation one-pager) as **parallel Write calls in ONE message**. | 2–3 turns |
| 4 | Stop double-paid authoring instructions | `plan-epic.md` step 2: the envelope's `systemPrompts` ARE the authoring instructions; the mandated `epic-plan-spec-author` / `epic-plan-decompose-author` SKILL.md reads are removed (skill files stay — #4479's surface). | 2 turns + ~26k/turn residency |
| 5 | Auto-normalize the untracked-path file-assumption case | `file-assumptions.js`: a `changes`-sourced `refactors-existing` on a base-untracked path normalizes to `creates` with a logged warning (`normalizations[]` on the report; distinct `assumption-normalized` log prefix in `ticket-validator.js`). Genuine mismatches (absent read dependency, clobbering `creates`, missing `deletes` target, predecessor-deleted tracked path) still reject. | 3 turns |
| 6 | Fold `plan-critics.js` into persist + triage in the envelope | Evaluation extracted to `lib/orchestration/plan-critics-evaluate.js`; `runPlanPersist` runs it as a deterministic pre-write phase (verdicts printed + returned on the result, skips ledger-logged, before any provider call). CLI kept one release as a thin shim (grep: `plan-epic.md` + tests were the only consumers). Scope-triage verdict embedded in the `--seed` envelope (`buildScopeTriageSignal`, rubric applied CLI-side, anchored to the sizing SSOT) — the two headless skill Reads disappear; attended paths keep the skill. | ~3 turns |
| 7 | Router diet | `plan.md`: under `--yes`, execute injected/in-context helper content without the read-in-full turn; skip the router-level triage skill Read (the seed envelope's verdict routes). | 0–1 turns |

Also restates the G2 gate per mode in `plan-epic-reference.md`: **epic ≤ ~12 turns / ≤ ~1.1M**, **ideation ≤ ~15 / ≤ ~1.5M post-fixes**, **interim smoke ≤ ~20 / ≤ ~2.0M** — verification via a cheap direct `/plan --idea --yes` probe of the plan-metrics ledger.

Arithmetic per the ticket: fixes 1–3 land ~18–22 turns; adding 4–6 lands **13–17 turns ≈ 1.35M tokens** — gate met without the separate M7 residency diet.

## Tests

- Seed-mode envelope key set, dup-search-off-seed parity, empty-seed rejection, `onePagerSpec` sections, `scopeTriage` verdict heuristics (epic/story/borderline) — `tests/plan-context.test.js`
- Waiver-reason summary line (present with full reason; absent without a waiver) — `tests/scripts/plan-persist.summary.test.js`
- Untracked-path normalization incl. genuine-mismatch still-fails cases (references-sourced, predecessor-deleted) — `tests/file-assumptions.test.js`, contract gate 4/4b — `tests/contract/planning/plan-persist-validator-coverage.test.js`
- Critics-fold: result envelope shape, pre-write ordering (verdicts ledger-logged before the first provider call), single-shape skip reason, thin-shim parity — `tests/scripts/plan-persist.critics-fold.test.js`
- Prose drift-guards updated/extended — `tests/plan-yes-flag-workflow.test.js`, `tests/plan-critics-workflow.test.js`

Local gates: `npm test` (10169 pass / 0 fail), `npm run lint` (incl. workflow-cli-lint, docs:check), `lint:md`, `check-dead-exports`, `check-arch-cycles`, `check-context-budget`, `check-baselines`, `check-doc-links`, `sync:commands` — all green.

Closes #4496

🤖 Generated with [Claude Code](https://claude.com/claude-code)