### PR TITLE
fix(close-validate): probe the check-baselines consumer contract before failing (refs #4495)

### DIFF
--- a/.agents/docs/configuration.md
+++ b/.agents/docs/configuration.md
@@ -262,6 +262,7 @@ top-level keys are validation errors.
 | `quality.baselineEpsilon.lighthouse` | No | `number` | — | — |
 | `quality.baselineEpsilon.bundle-size` | No | `number` | — | — |
 | `quality.baselineEpsilon.duplication` | No | `number` | — | — |
+| `quality.requireBaselines` | No | `boolean` | — | Story #4495. Fail-closed baseline-enforcement policy for the unified check-baselines close-validation gate. When false (default), a consumer that enables baseline gates (crap/maintainability/…) but has not committed the corresponding baseline artifacts under baselines/ gets a clean skip-with-reason instead of a deterministic first-try close failure. Set true to keep the gate registered so an absent baseline artifact fails close-validation with a preflight hint naming the fix (the fail-closed posture, analogous to delivery.ci.requireChecks). |
 | `quality.navigability` | No | `object` | — | Navigability lens + post-wave integration gate config (Epic #4131, F2/F3/F1/F4). Read by audit-suite/selector.js (route globs) and the deliver-epic.md Phase 6.5 gate (journey suite). Opt-in: absent or empty routeGlobs degrades to a silent no-op. |
 | `quality.navigability.routeGlobs` | No | `array<string>` | — | Glob patterns (pages/**, app/**/route.ts) marking paths that add a user-facing route — the route-tree SSOT the navigability lens enumerates and the route-added routing predicate matches against. |
 | `quality.navigability.navRegistry` | No | `array<string>` | — | Tokens identifying the nav-registry SSOT the navigability lens checks every route resolves a nav door against. |

--- a/.agents/schemas/agentrc.schema.json
+++ b/.agents/schemas/agentrc.schema.json
@@ -1325,6 +1325,10 @@
         "baselineEpsilon": {
           "$ref": "#/$defs/baselineEpsilon"
         },
+        "requireBaselines": {
+          "type": "boolean",
+          "description": "Story #4495. Fail-closed baseline-enforcement policy for the unified check-baselines close-validation gate. When false (default), a consumer that enables baseline gates (crap/maintainability/…) but has not committed the corresponding baseline artifacts under baselines/ gets a clean skip-with-reason instead of a deterministic first-try close failure. Set true to keep the gate registered so an absent baseline artifact fails close-validation with a preflight hint naming the fix (the fail-closed posture, analogous to delivery.ci.requireChecks)."
+        },
         "navigability": {
           "type": "object",
           "description": "Navigability lens + post-wave integration gate config (Epic #4131, F2/F3/F1/F4). Read by audit-suite/selector.js (route globs) and the deliver-epic.md Phase 6.5 gate (journey suite). Opt-in: absent or empty routeGlobs degrades to a silent no-op.",

--- a/.agents/scripts/lib/close-validation/gates.js
+++ b/.agents/scripts/lib/close-validation/gates.js
@@ -6,7 +6,12 @@
  * runner (`INDEPENDENT_GATE_NAMES` / `partitionGates`).
  */
 
+import { existsSync } from 'node:fs';
+
+import { _internals as baselineReaderInternals } from '../baselines/reader.js';
+import { getQuality } from '../config/quality.js';
 import { hasNpmScript, readPackageScripts } from '../npm-scripts.js';
+import { KNOWN_KINDS } from '../orchestration/check-baselines/phases/parse-args.js';
 import {
   buildFormatHint,
   FORMAT_CHECK_FALLBACK,
@@ -115,6 +120,106 @@ function buildTestGateEntry(coverageCaptureActive) {
   return [{ name: 'test', cmd: 'npm', args: ['test'] }];
 }
 
+const CHECK_BASELINES_HINT =
+  'Unified baselines gate breached. Inspect the JSON report (`node .agents/scripts/check-baselines.js`) to see which kind/component/axis fell below floor; remediate the underlying file(s) or — when the regression is intentional — refresh the relevant baseline through its per-kind update script and commit with a `baseline-refresh:` tagged subject.';
+
+/**
+ * Baseline kinds the resolved config enables for the unified
+ * `check-baselines` gate. Mirrors `selectEnabledGates` in the check-baselines
+ * pipeline (a kind runs when its `gates.<kind>` block is present and not
+ * explicitly disabled) so the registration probe's view of "what will run"
+ * matches the gate's own view exactly.
+ *
+ * @param {object|undefined|null} config canonical resolved config
+ * @returns {string[]}
+ */
+function enabledBaselineKinds(config) {
+  const gates = getQuality(config)?.gates ?? {};
+  return KNOWN_KINDS.filter((kind) => {
+    const block = gates[kind];
+    return block && typeof block === 'object' && block.enabled !== false;
+  });
+}
+
+/**
+ * Whether the consumer opted into fail-closed baseline enforcement via
+ * `delivery.quality.requireBaselines: true`. Default false — a consumer that
+ * enables baseline gates but has not committed baseline artifacts gets a
+ * clean skip (see `probeBaselinesGate`) rather than a deterministic first-try
+ * close failure. Mirrors the `delivery.ci.requireChecks` escape hatch (#4472).
+ *
+ * @param {object|undefined|null} config
+ * @returns {boolean}
+ */
+function baselinesRequiredByConfig(config) {
+  return config?.delivery?.quality?.requireBaselines === true;
+}
+
+function toKindSet(presentBaselines) {
+  if (presentBaselines instanceof Set) return presentBaselines;
+  if (Array.isArray(presentBaselines)) return new Set(presentBaselines);
+  return new Set();
+}
+
+/**
+ * Probe whether the `check-baselines` consumer contract is satisfied before
+ * registering the gate (#4495 — mirrors the #4473/#4480 coverage-capture
+ * remedy). The contract: every enabled baseline kind carries a committed
+ * baseline artifact on disk (the same path the gate's reader resolves).
+ *
+ * Decision shape:
+ *   - `{ register: false, reason }` — skip (caller logs the reason). Baseline
+ *     gates ARE enabled but none of the enabled kinds carry a committed
+ *     baseline artifact and the consumer has not set `requireBaselines`. This
+ *     is the bench/greenfield case: the gate would otherwise fail
+ *     deterministically on first try reading a non-existent
+ *     `baselines/<kind>.json`.
+ *   - `{ register: true }` — at least one committed baseline artifact is
+ *     present, OR no baseline kinds are enabled at all (the gate then self-
+ *     skips every kind and exits a clean empty PASS — no failure to avoid, so
+ *     the gate stays registered exactly as pre-#4495); run the gate.
+ *   - `{ register: true, hint }` — baselines are required-by-config
+ *     (`requireBaselines: true`) but absent; keep the gate registered so it
+ *     fails, with a preflight hint naming the fix.
+ *
+ * @param {{ config?: object, cwd?: string, presentBaselines?: string[]|Set<string> }} opts
+ *   `presentBaselines` injects the set of kinds whose baseline artifact
+ *   exists (tests), short-circuiting the on-disk probe.
+ * @returns {{ register: boolean, reason?: string, hint?: string }}
+ */
+function probeBaselinesGate({ config, cwd, presentBaselines } = {}) {
+  const enabled = enabledBaselineKinds(config);
+  if (enabled.length === 0) {
+    // No enabled baseline kinds → `check-baselines.js` self-skips every kind
+    // and exits clean (an empty PASS). There is no deterministic-failure risk
+    // to avoid, so keep the gate registered exactly as it was pre-#4495; the
+    // #4495 skip is confined strictly to the read-miss-would-fail case below.
+    return { register: true };
+  }
+  const injected =
+    presentBaselines != null ? toKindSet(presentBaselines) : null;
+  const present = enabled.filter((kind) =>
+    injected
+      ? injected.has(kind)
+      : existsSync(baselineReaderInternals.resolveBaselinePath(kind, { cwd })),
+  );
+  if (present.length > 0) return { register: true };
+  if (baselinesRequiredByConfig(config)) {
+    return {
+      register: true,
+      hint:
+        `Baselines are required (delivery.quality.requireBaselines) but no committed baseline artifact was found for enabled kind(s): ${enabled.join(', ')}. ` +
+        'Generate the baseline(s) with the per-kind update script (e.g. `npm run crap:update`, `npm run maintainability:update`) and commit them, or unset requireBaselines to skip the gate until baselines exist.',
+    };
+  }
+  return {
+    register: false,
+    reason:
+      `check-baselines skipped — enabled kind(s) ${enabled.join(', ')} have no committed baseline artifact under baselines/ ` +
+      'and delivery.quality.requireBaselines is not set. Commit baseline artifacts (or set requireBaselines to enforce them) to activate the gate.',
+  };
+}
+
 /**
  * Build the canonical close-validation gate list.
  *
@@ -152,15 +257,30 @@ function buildTestGateEntry(coverageCaptureActive) {
  * instead of a deterministic close failure with no test gate at all. The
  * probe reads `package.json` at `cwd` (the gate execution directory).
  *
- * @param {{ config?: object, epicBranch?: string, cwd?: string, packageScripts?: Record<string, string> }} [opts]
+ * Story #4495 — the unified `check-baselines` gate reads a committed
+ * `baselines/<kind>.json` for each enabled kind; a consumer that enables
+ * baseline gates but ships no `baselines/` tree (every bench sandbox, any
+ * greenfield consumer) failed the gate deterministically on first try. The
+ * gate is now registered only when its consumer contract is satisfied
+ * (`probeBaselinesGate`): at least one enabled kind carries a committed
+ * baseline, OR the consumer opted into fail-closed enforcement via
+ * `delivery.quality.requireBaselines`. When no baselines are committed and
+ * none are required, the gate is skipped with a logged reason (via `log`)
+ * instead of a blocking failure.
+ *
+ * @param {{ config?: object, epicBranch?: string, cwd?: string, packageScripts?: Record<string, string>, presentBaselines?: string[]|Set<string>, log?: (message: string) => void }} [opts]
  *   `config` is the canonical resolved config (`{ project, delivery, ... }`);
  *   gate commands resolve from `project.commands` and the CRAP toggle from
  *   `delivery.quality.gates.crap.enabled`. `epicBranch` is the close run's
  *   integration branch (`epic/<id>` for Epic-attached Stories, the base
  *   branch for standalone Stories). `cwd` is where the `package.json`
- *   coverage-script probe reads from (defaults to `process.cwd()`);
- *   `packageScripts` injects the scripts map directly (tests) and short-
- *   circuits the disk read.
+ *   coverage-script probe and the `baselines/<kind>.json` presence probe
+ *   read from (defaults to `process.cwd()`); `packageScripts` injects the
+ *   scripts map directly (tests) and short-circuits the coverage-script disk
+ *   read; `presentBaselines` injects the set of kinds whose baseline artifact
+ *   exists (tests) and short-circuits the baseline-presence disk read; `log`
+ *   receives the skip reason when the `check-baselines` gate is not
+ *   registered.
  * @returns {Gate[]}
  */
 export function buildDefaultGates({
@@ -168,6 +288,8 @@ export function buildDefaultGates({
   epicBranch,
   cwd,
   packageScripts,
+  presentBaselines,
+  log,
 } = {}) {
   const scripts = packageScripts ?? readPackageScripts(cwd);
   const coverageCaptureActive =
@@ -186,6 +308,14 @@ export function buildDefaultGates({
       ? buildChangedFileScope(epicBranch)
       : null;
   const baselinesGateEnv = buildBaselinesGateEnv(epicBranch);
+  const baselinesDecision = probeBaselinesGate({
+    config,
+    cwd,
+    presentBaselines,
+  });
+  if (!baselinesDecision.register && baselinesDecision.reason) {
+    log?.(`[close-validation] ${baselinesDecision.reason}`);
+  }
   return [
     {
       name: 'typecheck',
@@ -218,23 +348,31 @@ export function buildDefaultGates({
           },
         ]
       : []),
-    {
-      // Story #2210 — unified `check-baselines` gate is the only path for
-      // per-kind regression enforcement. The legacy per-kind in-process
-      // gates were retired because their regression-compare semantics are
-      // fully subsumed by this gate's attribution-wired floor + tolerance +
-      // schema enforcement, and running both paths in series was redundant
-      // and conflict-prone.
-      //
-      // `check-baselines.js` self-skips per-kind gates whose
-      // `enabled === false` is configured, so registering it
-      // unconditionally is safe.
-      name: 'check-baselines',
-      cmd: 'node',
-      args: ['.agents/scripts/check-baselines.js', '--format', 'text'],
-      hint: 'Unified baselines gate breached. Inspect the JSON report (`node .agents/scripts/check-baselines.js`) to see which kind/component/axis fell below floor; remediate the underlying file(s) or — when the regression is intentional — refresh the relevant baseline through its per-kind update script and commit with a `baseline-refresh:` tagged subject.',
-      ...(baselinesGateEnv ? { env: baselinesGateEnv } : {}),
-    },
+    // Story #2210 — unified `check-baselines` gate is the only path for
+    // per-kind regression enforcement. The legacy per-kind in-process gates
+    // were retired because their regression-compare semantics are fully
+    // subsumed by this gate's attribution-wired floor + tolerance + schema
+    // enforcement, and running both paths in series was redundant and
+    // conflict-prone.
+    //
+    // `check-baselines.js` self-skips per-kind gates whose `enabled === false`
+    // is configured. Story #4495: it is now also skipped entirely when the
+    // consumer enables baseline gates but ships no committed baseline artifact
+    // (and has not set `delivery.quality.requireBaselines`) — otherwise the
+    // gate fails deterministically on first try reading a non-existent
+    // `baselines/<kind>.json` (`probeBaselinesGate`). When required-by-config
+    // but absent, it stays registered with a preflight hint naming the fix.
+    ...(baselinesDecision.register
+      ? [
+          {
+            name: 'check-baselines',
+            cmd: 'node',
+            args: ['.agents/scripts/check-baselines.js', '--format', 'text'],
+            hint: baselinesDecision.hint ?? CHECK_BASELINES_HINT,
+            ...(baselinesGateEnv ? { env: baselinesGateEnv } : {}),
+          },
+        ]
+      : []),
   ];
 }
 

--- a/.agents/scripts/lib/config-settings-schema-quality.js
+++ b/.agents/scripts/lib/config-settings-schema-quality.js
@@ -96,6 +96,15 @@ export const QUALITY_SCHEMA = {
     codingGuardrails: CODING_GUARDRAILS_SCHEMA,
     autoRefresh: AUTO_REFRESH_SCHEMA,
     baselineEpsilon: BASELINE_EPSILON_SCHEMA,
+    // Story #4495. Fail-closed baseline-enforcement policy for the unified
+    // check-baselines close-validation gate. Default false: a consumer that
+    // enables baseline gates but has not committed baseline artifacts under
+    // baselines/ gets a clean skip-with-reason from buildDefaultGates rather
+    // than a deterministic first-try close failure. Set true to keep the gate
+    // registered so an absent baseline artifact fails close-validation with a
+    // preflight hint (the fail-closed posture, analogous to
+    // delivery.ci.requireChecks).
+    requireBaselines: { type: 'boolean' },
     // Navigability lens + post-wave integration gate config (Epic #4131,
     // F2/F3/F1/F4). Read by audit-suite/selector.js (route globs) and the
     // deliver-epic.md Phase 6.5 gate (journey suite). Opt-in: absent or empty

--- a/.agents/scripts/lib/orchestration/single-story-close/phases/close-validation.js
+++ b/.agents/scripts/lib/orchestration/single-story-close/phases/close-validation.js
@@ -129,6 +129,7 @@ export async function runCloseValidationPhase({
       config,
       epicBranch: baseBranch,
       cwd: worktreePath || cwd,
+      log: (m) => Logger.info(m),
     }),
     log: (m) => Logger.info(m),
     storyId,

--- a/.agents/scripts/lib/orchestration/story-close/pre-merge-validation.js
+++ b/.agents/scripts/lib/orchestration/story-close/pre-merge-validation.js
@@ -140,6 +140,7 @@ export async function runPreMergeGates({
     config,
     epicBranch,
     cwd: worktreePath || cwd,
+    log: (m) => logger.info?.(m),
   });
   const gateCount = Array.isArray(gates) ? gates.length : 0;
   // Story #2250 — emit `close-validate.start` only when both an epicId

--- a/baselines/dead-exports.json
+++ b/baselines/dead-exports.json
@@ -64,10 +64,6 @@
       "symbol": "BASELINE_KIND_SCHEMA_FILES"
     },
     {
-      "file": ".agents/scripts/lib/baselines/reader.js",
-      "symbol": "_internals"
-    },
-    {
       "file": ".agents/scripts/lib/bootstrap/branch-protection.js",
       "symbol": "diffProtection"
     },

--- a/tests/lib/close-validation/baselines-gate-registration.test.js
+++ b/tests/lib/close-validation/baselines-gate-registration.test.js
@@ -1,0 +1,131 @@
+/**
+ * tests/lib/close-validation/baselines-gate-registration.test.js — Story #4495.
+ *
+ * The unified `check-baselines` gate reads a committed `baselines/<kind>.json`
+ * for every enabled baseline kind. Registering it for a consumer that enables
+ * baseline gates (crap/maintainability/…) but ships no committed `baselines/`
+ * tree — every bench sandbox, any greenfield consumer — is a guaranteed
+ * first-try close failure (read-miss → EXIT_SCHEMA). `buildDefaultGates` now
+ * probes the consumer contract (`probeBaselinesGate`) and:
+ *   - SKIPS the gate (with a logged reason) when baseline gates are enabled but
+ *     no committed baseline artifact exists and `requireBaselines` is unset;
+ *   - REGISTERS the gate normally when at least one committed baseline exists;
+ *   - REGISTERS the gate with a preflight hint when baselines are
+ *     required-by-config (`delivery.quality.requireBaselines: true`) but absent;
+ *   - SKIPS the gate when no baseline gates are enabled at all.
+ *
+ * Baseline presence is injected via `presentBaselines` so the probe never
+ * touches disk, mirroring the `packageScripts` injection in the sibling
+ * coverage-gate-registration suite.
+ */
+
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import { buildDefaultGates } from '../../../.agents/scripts/lib/close-validation/gates.js';
+
+const names = (gates) => gates.map((g) => g.name);
+const crapEnabledConfig = {
+  delivery: { quality: { gates: { crap: { enabled: true } } } },
+};
+
+describe('buildDefaultGates — check-baselines registration (Story #4495)', () => {
+  it('enabled baseline kind + no committed baselines + requireBaselines unset → gate SKIPPED with a logged reason', () => {
+    const logged = [];
+    const gates = buildDefaultGates({
+      config: crapEnabledConfig,
+      presentBaselines: [],
+      log: (m) => logged.push(m),
+    });
+    assert.ok(
+      !names(gates).includes('check-baselines'),
+      'check-baselines must not be registered without committed baselines',
+    );
+    assert.equal(logged.length, 1, 'the skip must be logged exactly once');
+    assert.match(logged[0], /check-baselines skipped/);
+    assert.match(logged[0], /crap/);
+    assert.match(logged[0], /requireBaselines/);
+  });
+
+  it('enabled baseline kind + no committed baselines + requireBaselines:true → gate REGISTERED with a preflight hint (fail-closed)', () => {
+    const logged = [];
+    const gates = buildDefaultGates({
+      config: {
+        delivery: {
+          quality: {
+            requireBaselines: true,
+            gates: { crap: { enabled: true } },
+          },
+        },
+      },
+      presentBaselines: [],
+      log: (m) => logged.push(m),
+    });
+    assert.ok(
+      names(gates).includes('check-baselines'),
+      'requireBaselines keeps the gate registered so an absent artifact fails',
+    );
+    assert.equal(logged.length, 0, 'a registered gate emits no skip log');
+    const gate = gates.find((g) => g.name === 'check-baselines');
+    assert.match(gate.hint, /required \(delivery\.quality\.requireBaselines\)/);
+    assert.match(gate.hint, /crap/);
+    assert.match(gate.hint, /:update/);
+  });
+
+  it('enabled baseline kind + a committed baseline present → gate REGISTERED normally', () => {
+    const gates = buildDefaultGates({
+      config: crapEnabledConfig,
+      presentBaselines: ['crap'],
+    });
+    assert.ok(names(gates).includes('check-baselines'));
+    const gate = gates.find((g) => g.name === 'check-baselines');
+    assert.deepEqual(gate.args, [
+      '.agents/scripts/check-baselines.js',
+      '--format',
+      'text',
+    ]);
+    // Default breach hint (not the required-but-absent preflight hint).
+    assert.match(gate.hint, /Unified baselines gate breached/);
+  });
+
+  it('no baseline gates enabled → gate REGISTERED (harmless empty pass, unchanged pre-#4495 behavior)', () => {
+    const logged = [];
+    const gates = buildDefaultGates({
+      config: { delivery: { quality: { gates: {} } } },
+      presentBaselines: [],
+      log: (m) => logged.push(m),
+    });
+    assert.ok(
+      names(gates).includes('check-baselines'),
+      'zero enabled kinds is a clean empty pass, not a first-try failure — keep the gate',
+    );
+    assert.equal(logged.length, 0, 'no skip when there is nothing to fail on');
+  });
+
+  it('a disabled kind does not count as enabled → treated as zero enabled kinds → gate REGISTERED', () => {
+    const gates = buildDefaultGates({
+      config: {
+        delivery: { quality: { gates: { crap: { enabled: false } } } },
+      },
+      presentBaselines: [],
+    });
+    assert.ok(names(gates).includes('check-baselines'));
+  });
+
+  it('present baseline for only one of several enabled kinds → gate REGISTERED (tree exists)', () => {
+    const gates = buildDefaultGates({
+      config: {
+        delivery: {
+          quality: {
+            gates: {
+              crap: { enabled: true },
+              maintainability: { enabled: true },
+            },
+          },
+        },
+      },
+      presentBaselines: ['crap'],
+    });
+    assert.ok(names(gates).includes('check-baselines'));
+  });
+});


### PR DESCRIPTION
## Why

The unified `check-baselines` close-validation gate reads a committed `baselines/<kind>.json` for every enabled baseline kind, but it was registered **unconditionally**. A consumer that enables baseline gates (crap / maintainability / duplication) yet ships no committed `baselines/` tree — every mandrel-bench sandbox (the bench overlay copies the framework `.agentrc.json` into the sandbox, enabling those gates, but commits no baselines), any greenfield consumer — failed the gate deterministically on first try (read-miss → `EXIT_SCHEMA`).

Observed on the 1.92.0 smoke: **4× `story.blocked` reason `close-validate-failed:check-baselines`** per epic cell, one per story, all self-recovered and merged — `gateRetries: 4`, pure churn. Same consumer-contract class as the fixed coverage-capture defect (#4473 / #4480).

## The probe (mirrors #4480's coverage-capture remedy)

`buildDefaultGates` now probes the contract (`probeBaselinesGate`) before registering the gate, exactly parallel to how coverage-capture is conditionally registered:

| Condition | Decision |
| --- | --- |
| Baseline kinds enabled, **no** committed artifact, `requireBaselines` unset | **Skip** the gate, log a reason (no blocking failure) — the bench/greenfield case |
| At least one committed baseline present | Register normally |
| `requireBaselines: true` but artifacts absent | Register, **fail with a preflight hint** naming the per-kind update scripts (fail-closed escape hatch, analogous to `delivery.ci.requireChecks`) |
| No baseline kinds enabled at all | Register unchanged (gate self-skips every kind → clean empty PASS; no failure to avoid) |

The presence probe resolves each enabled kind's baseline path via the reader's own resolver and `existsSync`, so it checks the same path the gate would read. A `log` callback is threaded from both close-validation callers (`story-close/pre-merge-validation.js`, `single-story-close/phases/close-validation.js`) so the skip reason surfaces in the close log.

Adds `delivery.quality.requireBaselines` (boolean, default false) to the runtime schema (`config-settings-schema-quality.js`, the source of truth), the advisory mirror (`agentrc.schema.json`), and the generated config docs.

## Remaining-gates audit — is check-baselines the last of its class?

**Yes.** The class is "gate that reads a committed consumer-contract artifact a bare consumer may lack, registered without probing for it":

- `coverage-capture` — needs a `test:coverage` script — probed since #4473.
- `check-baselines` — needs `baselines/<kind>.json` — probed here.

The other gates (`typecheck`, `lint`, `test`, `format`) run resolved commands from `project.commands` / npm scripts — the universally-scaffolded core, not optional committed artifacts — and degrade through npm's own missing-script error. No further unprobed artifact-dependent gate remains.

## Test evidence

- New `tests/lib/close-validation/baselines-gate-registration.test.js` (6 cases, mirrors the sibling coverage-gate-registration suite): no-baselines-skip + logged reason, required-but-absent → registered with preflight hint, present-baseline → registered normally, zero-enabled → registered, disabled-kind, partial tree.
- Full suite: **10175 pass**, 2 fail — both pre-existing environmental failures on clean `origin/main` (incomplete local `node_modules`: `sentinel: ajv presence`, `typhonjs-escomplex` version) and unrelated to this change. Zero new failures.
- Green: `npm run lint`, `check-arch-cycles`, `check-dead-exports`, `check:context-budget`, `check-baselines`, `check-doc-links`.

Closes #4495. Refs #4473, #4480.

🤖 Generated with [Claude Code](https://claude.com/claude-code)