### PR TITLE
fix(v2): comprehensive review remediation for plan/deliver

### DIFF
--- a/.agents/README.md
+++ b/.agents/README.md
@@ -545,7 +545,7 @@ sessions, `gh auth login` is sufficient.
 ## Self-Healing Checks
 
 `scripts/lib/checks/` is the discovery-based registry of named checks
-consumed by preflight guards (`/deliver`, `/story-close`, `npm test`),
+consumed by preflight guards (`/deliver`, `single-story-close`, `npm test`),
 the `diagnose.js` ad-hoc viewer, and the retro surface. Use one check per
 file. The runner (`index.js`) loads checks at process start and filters by
 scope at each call site.
@@ -554,9 +554,9 @@ Each check module default-exports an object with this shape:
 
 ```js
 export default {
-  id: 'stale-origin-epic',
+  id: 'stale-origin-main',
   severity: 'blocker', // 'blocker' | 'warning' | 'info'
-  scope: ['epic-deliver', 'story-close', 'retro'],
+  scope: ['deliver', 'single-story-close', 'retro'],
   autoCorrect: 'refuse-and-print', // 'auto' | 'refuse-and-print'
   detect(state) {
     return null;

--- a/.agents/scripts/lib/label-constants.js
+++ b/.agents/scripts/lib/label-constants.js
@@ -10,12 +10,12 @@ export const AGENT_LABELS = {
   REVIEW_SPEC: 'agent::review-spec',
   READY: 'agent::ready',
   EXECUTING: 'agent::executing',
-  // Story #2144 — intermediate state owned by `story-close.js`. A Story
+  // Story #2144 — intermediate state owned by `single-story-close.js`. A Story
   // flips to `agent::closing` after preflight validation succeeds and
-  // before the merge into `epic/<id>` is attempted. It flips to
-  // `agent::done` only after the post-merge pipeline confirms the merge
+  // the Story PR is opened against `main`. It flips to
+  // `agent::done` only after the close pipeline confirms the PR merge
   // landed; if the close is killed mid-flight, the Story remains at
-  // `agent::closing` so a `/story-execute --resume` can pick up at the
+  // `agent::closing` so `/deliver` can pick up at the
   // post-merge phase rather than re-running preflight. The label is the
   // distinguishing signal between "hung close" and "finished work".
   CLOSING: 'agent::closing',

--- a/.agents/scripts/lib/orchestration/plan-persist/amend.js
+++ b/.agents/scripts/lib/orchestration/plan-persist/amend.js
@@ -1,6 +1,14 @@
 /**
- * amend.js — the `--amend` change-request delta path of the collapsed
- * persist surface (Epic #4474 PR4, design §2 mode matrix, amend row).
+ * amend.js — DEAD / NOT WIRED (v2 Stages 4–5).
+ *
+ * `run-plan-persist.js` no longer imports this module; `--amend` tree
+ * cascades and the reconciler ledger (`.agents/epics/<id>.state.json`)
+ * are gone from the live `/plan` path. Kept only so the maintainability
+ * baseline does not need a delete-refresh in this pass. Do not re-wire
+ * without an explicit product decision to restore amend semantics.
+ *
+ * Historical notes — the `--amend` change-request delta path of the
+ * collapsed persist surface (Epic #4474 PR4, design §2 mode matrix):
  *
  * An amend run receives the full ticket set with every ticket carrying an
  * `op` field:

--- a/.agents/scripts/lib/orchestration/plan-persist/persist-helpers.js
+++ b/.agents/scripts/lib/orchestration/plan-persist/persist-helpers.js
@@ -2,8 +2,10 @@
  * persist-helpers.js — pure helper surface for the flat Story `/plan` persist.
  *
  * Exports:
- *   - `validateTickets(tickets, config)` — runs the cross-link / freshness
- *     normaliser and the task-body validator in one pass.
+ *   - `validateTickets(tickets, config)` — runs the cross-link, model-capacity,
+ *     freshness, and task-body validators in one pass. Capacity settings are
+ *     explicit inputs so the validator and decomposer share one live delivery
+ *     envelope instead of silently falling back to framework defaults.
  *   - `makeDefaultFanOutCounter({ baseBranchRef, cwd })` — production
  *     fan-out probe used by the conflict policy.
  *
@@ -75,7 +77,7 @@ export function validateTickets(tickets, config, opts = {}) {
   const conflictPolicy = resolveConflictPolicy(config);
   if (typeof opts.fanOutCounter === 'function') {
     conflictPolicy.fanOutCounter = opts.fanOutCounter;
-  } else if (!conflictPolicy.fanOutCounter) {
+  } else {
     conflictPolicy.fanOutCounter = makeDefaultFanOutCounter({
       baseBranchRef,
       cwd: opts.cwd,
@@ -84,6 +86,8 @@ export function validateTickets(tickets, config, opts = {}) {
   const validated = validateAndNormalizeTickets(tickets, {
     baseBranchRef,
     conflictPolicy,
+    modelCapacity: opts.modelCapacity,
+    maxTokenBudget: opts.maxTokenBudget,
     // Thread the repo cwd into the AC-freshness / file-assumption git
     // probes (#4474 PR7) — without it they silently ran against
     // process.cwd(), which is only the repo root by coincidence.

--- a/.agents/scripts/lib/orchestration/plan-persist/run-plan-persist.js
+++ b/.agents/scripts/lib/orchestration/plan-persist/run-plan-persist.js
@@ -88,6 +88,42 @@ export async function writeCheckpointV2(provider, storyId, state) {
   return state;
 }
 
+function enforceTicketValidation(validated, { config, settings, cwd }) {
+  const validationErrors = validated.errors ?? [];
+  const assumptionFailures = validationErrors.filter((error) =>
+    error.startsWith('File assumption mismatch:'),
+  );
+  const blockingErrors = validationErrors.filter(
+    (error) => !error.startsWith('File assumption mismatch:'),
+  );
+  if (blockingErrors.length > 0) {
+    throw new Error(
+      `[plan-persist] ticket validation failed with ${blockingErrors.length} ` +
+        `hard error(s):\n${blockingErrors.map((error) => `  - ${error}`).join('\n')}`,
+    );
+  }
+  if (assumptionFailures.length === 0) return;
+  const gateBaseRef = config?.baseBranch ?? settings?.baseBranch ?? 'main';
+  const refResolves =
+    gitSpawn(
+      cwd ?? process.cwd(),
+      'rev-parse',
+      '--verify',
+      '--quiet',
+      `${gateBaseRef}^{commit}`,
+    ).status === 0;
+  if (refResolves) {
+    throw new Error(
+      `[plan-persist] file-assumption gate: ${assumptionFailures.length} ` +
+        `mismatch(es):\n${assumptionFailures.map((error) => `  - ${error}`).join('\n')}`,
+    );
+  }
+  Logger.warn(
+    `[plan-persist] file-assumption gate skipped: base ref '${gateBaseRef}' ` +
+      `does not resolve — ${assumptionFailures.length} finding(s) downgraded.`,
+  );
+}
+
 /**
  * Execute the flat Story persist end to end.
  *
@@ -184,34 +220,12 @@ export async function runPlanPersist({
   const validated = validateTickets(rawStories, config, {
     fanOutCounter,
     cwd,
+    modelCapacity: config?.planning?.modelCapacity,
+    maxTokenBudget: getLimits(config).maxTokenBudget,
   });
   enforceFanOutGate(validated.findings, allowLargeFanOut, 'plan-persist');
   surfaceSoftConflictFindings(validated.findings, 'plan-persist');
-
-  const assumptionFailures = (validated.errors ?? []).filter((e) =>
-    e.startsWith('File assumption mismatch:'),
-  );
-  if (assumptionFailures.length > 0) {
-    const gateBaseRef = config?.baseBranch ?? settings?.baseBranch ?? 'main';
-    const refResolves =
-      gitSpawn(
-        cwd ?? process.cwd(),
-        'rev-parse',
-        '--verify',
-        '--quiet',
-        `${gateBaseRef}^{commit}`,
-      ).status === 0;
-    if (refResolves) {
-      throw new Error(
-        `[plan-persist] file-assumption gate: ${assumptionFailures.length} ` +
-          `mismatch(es):\n${assumptionFailures.map((e) => `  - ${e}`).join('\n')}`,
-      );
-    }
-    Logger.warn(
-      `[plan-persist] file-assumption gate skipped: base ref '${gateBaseRef}' ` +
-        `does not resolve — ${assumptionFailures.length} finding(s) downgraded.`,
-    );
-  }
+  enforceTicketValidation(validated, { config, settings, cwd });
 
   const reachability = evaluateDraftReachability({
     tickets: rawStories,

--- a/.agents/scripts/lib/orchestration/plan-persist/run-plan-persist.js
+++ b/.agents/scripts/lib/orchestration/plan-persist/run-plan-persist.js
@@ -10,8 +10,8 @@
  *   4. Split-policy partition (`assertAcceptancePartition`) + spec fold/spill
  *   5. Create Story issues (`type::story` + `agent::ready`; `plan-run::`
  *      label when N>1)
- *   6. Upsert `risk-verdict` + `plan-summary` (+ `story-plan-state`) on the
- *      primary Story
+ *   6. Upsert `risk-verdict` + `story-plan-state` on every created Story;
+ *      upsert `plan-summary` on the primary Story
  *   7. Temp cleanup at terminal success only
  *
  * Hard cutover: no Epic parent, no reconciler, no `deliveryShape`, no
@@ -59,7 +59,7 @@ const PLAN_CHECKPOINT_SCHEMA_VERSION_V2 = 2;
 const STORY_PLAN_STATE_TYPE = 'story-plan-state';
 
 /**
- * Write the `story-plan-state` checkpoint on the primary Story.
+ * Write the `story-plan-state` checkpoint on a Story.
  *
  * @param {object} provider
  * @param {number} storyId
@@ -122,6 +122,16 @@ function enforceTicketValidation(validated, { config, settings, cwd }) {
     `[plan-persist] file-assumption gate skipped: base ref '${gateBaseRef}' ` +
       `does not resolve — ${assumptionFailures.length} finding(s) downgraded.`,
   );
+}
+
+function riskVerdictCommentBody(riskVerdict) {
+  return [
+    '### risk-verdict',
+    '',
+    '```json',
+    JSON.stringify(riskVerdict, null, 2),
+    '```',
+  ].join('\n');
 }
 
 /**
@@ -327,40 +337,40 @@ export async function runPlanPersist({
   });
 
   if (!dryRun) {
-    await upsertStructuredComment(
-      provider,
-      primary.id,
-      'risk-verdict',
-      [
-        '### risk-verdict',
-        '',
-        '```json',
-        JSON.stringify(riskVerdict, null, 2),
-        '```',
-      ].join('\n'),
-    );
+    for (const story of created) {
+      await upsertStructuredComment(
+        provider,
+        story.id,
+        'risk-verdict',
+        riskVerdictCommentBody(riskVerdict),
+      );
+      await writeCheckpointV2(provider, story.id, {
+        planningRisk,
+        riskVerdict,
+        reviewRouting,
+        persist: {
+          completedAt: new Date().toISOString(),
+          storyCount: created.length,
+          planRunLabel,
+          primaryStoryId: primary.id,
+          stories: created.map((createdStory) => ({
+            slug: createdStory.slug,
+            id: createdStory.id,
+          })),
+          spills: spills.map((spill) => ({
+            slug: spill.slug,
+            spilled: spill.spill.spilled,
+            docPath: spill.spill.docPath,
+          })),
+        },
+      });
+    }
     await upsertStructuredComment(
       provider,
       primary.id,
       PLAN_SUMMARY_COMMENT_TYPE,
       summaryBody,
     );
-    await writeCheckpointV2(provider, primary.id, {
-      planningRisk,
-      riskVerdict,
-      reviewRouting,
-      persist: {
-        completedAt: new Date().toISOString(),
-        storyCount: created.length,
-        planRunLabel,
-        stories: created.map((c) => ({ slug: c.slug, id: c.id })),
-        spills: spills.map((s) => ({
-          slug: s.slug,
-          spilled: s.spill.spilled,
-          docPath: s.spill.docPath,
-        })),
-      },
-    });
   }
 
   if (!skipCleanup && planDir) {

--- a/.agents/scripts/lib/orchestration/plan-persist/run-plan-persist.js
+++ b/.agents/scripts/lib/orchestration/plan-persist/run-plan-persist.js
@@ -52,7 +52,7 @@ import {
   PLAN_SUMMARY_COMMENT_TYPE,
 } from './summary.js';
 
-/** Checkpoint schema version written on the primary Story. */
+/** Checkpoint schema version written on each Story's story-plan-state. */
 const PLAN_CHECKPOINT_SCHEMA_VERSION_V2 = 2;
 
 /** Structured-comment type for the per-plan Story checkpoint. */

--- a/.agents/scripts/lib/orchestration/plan-persist/story-ops.js
+++ b/.agents/scripts/lib/orchestration/plan-persist/story-ops.js
@@ -88,6 +88,22 @@ function normalizeDependsOn(ticket, bodyObject) {
   return Array.isArray(bodyObject.depends_on) ? bodyObject.depends_on : [];
 }
 
+function assertContractFieldMatches(ticket, bodyObject, field) {
+  if (!Array.isArray(ticket[field])) return;
+  const topLevel = ticket[field].map(String);
+  const bodyValue = Array.isArray(bodyObject[field])
+    ? bodyObject[field].map(String)
+    : [];
+  if (
+    topLevel.length !== bodyValue.length ||
+    topLevel.some((value, index) => value !== bodyValue[index])
+  ) {
+    throw new Error(
+      `[plan-persist] Story "${ticket.slug ?? ticket.title ?? 'unknown'}" has mismatched top-level and body ${field} arrays`,
+    );
+  }
+}
+
 /**
  * Normalize a plan Story ticket into `{ slug, title, bodyObject }`.
  * Accepts either a serialized markdown `body` string or a structured body.
@@ -113,6 +129,8 @@ export function normalizeStoryTicket(ticket) {
       ? ticket.title.trim()
       : `Story ${slug}`;
   const bodyObject = bodyObjectFromTicket(ticket);
+  assertContractFieldMatches(ticket, bodyObject, 'acceptance');
+  assertContractFieldMatches(ticket, bodyObject, 'verify');
   const depends_on = normalizeDependsOn(ticket, bodyObject);
 
   return { slug, title, bodyObject, depends_on };
@@ -199,6 +217,7 @@ function assembleOnePlanStory(ticket, opts) {
       slug,
       title,
       body,
+      bodyObject: { ...folded, depends_on },
       acceptance: Array.isArray(folded.acceptance) ? folded.acceptance : [],
       depends_on,
     },
@@ -238,6 +257,36 @@ export function assemblePlanStories(tickets, opts = {}) {
   });
 
   return { stories, spills };
+}
+
+function orderStoriesByDependencies(stories) {
+  const list = Array.isArray(stories) ? stories : [];
+  const known = new Set(list.map((story) => story.slug));
+  for (const story of list) {
+    const unknown = story.depends_on.filter((slug) => !known.has(slug));
+    if (unknown.length > 0) {
+      throw new Error(
+        `[plan-persist] Story "${story.slug}" depends on unknown sibling(s): ${unknown.join(', ')}`,
+      );
+    }
+  }
+  const ordered = [];
+  const scheduled = new Set();
+  const pending = [...list];
+  while (pending.length > 0) {
+    const index = pending.findIndex((story) =>
+      story.depends_on.every((slug) => scheduled.has(slug)),
+    );
+    if (index === -1) {
+      throw new Error(
+        `[plan-persist] dependency cycle prevents Story creation: ${pending.map((story) => story.slug).join(', ')}`,
+      );
+    }
+    const [story] = pending.splice(index, 1);
+    ordered.push(story);
+    scheduled.add(story.slug);
+  }
+  return ordered;
 }
 
 /**
@@ -284,10 +333,21 @@ export async function createStoryIssues({ provider, stories, opts = {} }) {
   }
 
   const created = [];
-  for (const story of list) {
+  const createdBySlug = new Map();
+  for (const story of orderStoriesByDependencies(list)) {
+    const dependencyRefs = story.depends_on.map(
+      (slug) => `#${createdBySlug.get(slug)}`,
+    );
+    const body =
+      dependencyRefs.length === 0
+        ? story.body
+        : serializeStoryBody(
+            { ...story.bodyObject, depends_on: dependencyRefs },
+            { includeFooter: true },
+          );
     const result = await provider.createIssue({
       title: story.title,
-      body: story.body,
+      body,
       labels: [...labels],
     });
     const id = result?.id ?? result?.number;
@@ -302,6 +362,7 @@ export async function createStoryIssues({ provider, stories, opts = {} }) {
       title: story.title,
       url: result.url,
     });
+    createdBySlug.set(story.slug, id);
   }
 
   return { created, planRunLabel: planLabel };

--- a/.agents/scripts/lib/orchestration/plan-persist/story-ops.js
+++ b/.agents/scripts/lib/orchestration/plan-persist/story-ops.js
@@ -27,6 +27,21 @@ import { assertAcceptancePartition } from '../split-policy-validator.js';
 export const PLAN_RUN_LABEL_PREFIX = 'plan-run::';
 
 /**
+ * Normalize a caller-supplied plan-run token. Persistence and resolution
+ * share this helper so human-readable ids map to one canonical label.
+ *
+ * @param {string} id
+ * @returns {string}
+ */
+export function normalizePlanRunId(id) {
+  return String(id ?? '')
+    .trim()
+    .toLowerCase()
+    .replace(/^plan-run::/, '')
+    .replace(/[^a-z0-9._-]+/g, '-');
+}
+
+/**
  * Build a `plan-run::<id>` label. When `id` is omitted, generates a short
  * random hex token (8 chars) suitable for a rare multi-Story plan.
  *
@@ -36,10 +51,7 @@ export const PLAN_RUN_LABEL_PREFIX = 'plan-run::';
 export function planRunLabel(id) {
   const token =
     typeof id === 'string' && id.trim() !== ''
-      ? id
-          .trim()
-          .toLowerCase()
-          .replace(/[^a-z0-9._-]+/g, '-')
+      ? normalizePlanRunId(id)
       : randomBytes(4).toString('hex');
   return `${PLAN_RUN_LABEL_PREFIX}${token}`;
 }

--- a/.agents/scripts/lib/orchestration/plan-persist/story-ops.js
+++ b/.agents/scripts/lib/orchestration/plan-persist/story-ops.js
@@ -34,11 +34,15 @@ export const PLAN_RUN_LABEL_PREFIX = 'plan-run::';
  * @returns {string}
  */
 export function normalizePlanRunId(id) {
-  return String(id ?? '')
+  const token = String(id ?? '')
     .trim()
     .toLowerCase()
     .replace(/^plan-run::/, '')
     .replace(/[^a-z0-9._-]+/g, '-');
+  if (!token) {
+    throw new Error('plan-run id requires a non-empty planRunId');
+  }
+  return token;
 }
 
 /**

--- a/.agents/scripts/lib/orchestration/resolve-plan-run.js
+++ b/.agents/scripts/lib/orchestration/resolve-plan-run.js
@@ -7,7 +7,10 @@
 
 import { TYPE_LABELS } from '../label-constants.js';
 import { buildStoryAdjacency } from '../story-adjacency.js';
-import { PLAN_RUN_LABEL_PREFIX } from './plan-persist/story-ops.js';
+import {
+  normalizePlanRunId,
+  PLAN_RUN_LABEL_PREFIX,
+} from './plan-persist/story-ops.js';
 
 /**
  * Normalize a plan-run id into the canonical label `plan-run::<token>`.
@@ -16,10 +19,7 @@ import { PLAN_RUN_LABEL_PREFIX } from './plan-persist/story-ops.js';
  * @returns {string}
  */
 export function normalizePlanRunLabel(raw) {
-  const token = String(raw ?? '')
-    .trim()
-    .toLowerCase()
-    .replace(/^plan-run::/, '');
+  const token = normalizePlanRunId(raw);
   if (!token) {
     throw new Error('resolve-plan-run: --run requires a non-empty planRunId');
   }
@@ -52,7 +52,7 @@ export function normalizeIssueLabels(issue) {
 
 /**
  * @param {object} issue
- * @returns {{ id: number, title: string, body: string, url: string|null, labels: string[] }|null}
+ * @returns {{ id: number, title: string, body: string, url: string|null, labels: string[], state: string }|null}
  */
 export function toStoryRecord(issue) {
   const id = Number(issue?.number ?? issue?.id);
@@ -65,6 +65,7 @@ export function toStoryRecord(issue) {
     body: String(issue?.body ?? ''),
     url: issue?.html_url ?? issue?.url ?? null,
     labels,
+    state: String(issue?.state ?? 'open').toLowerCase(),
   };
 }
 
@@ -97,13 +98,20 @@ export function buildPlanRunEnvelope(issues, { planRunId, planRunLabel }) {
     kind: 'plan-run',
     planRunId,
     planRunLabel,
-    stories: stories.map(({ id, title, url, labels }) => ({
+    stories: stories.map(({ id, title, url, labels, state }) => ({
       id,
       title,
       url,
       labels,
+      state,
     })),
     dag: storiesToDag(stories),
+    done: stories
+      .filter(
+        (story) =>
+          story.state === 'closed' || story.labels.includes('agent::done'),
+      )
+      .map((story) => story.id),
   };
 }
 

--- a/.agents/scripts/lib/orchestration/resolve-plan-run.js
+++ b/.agents/scripts/lib/orchestration/resolve-plan-run.js
@@ -20,9 +20,6 @@ import {
  */
 export function normalizePlanRunLabel(raw) {
   const token = normalizePlanRunId(raw);
-  if (!token) {
-    throw new Error('resolve-plan-run: --run requires a non-empty planRunId');
-  }
   return `${PLAN_RUN_LABEL_PREFIX}${token}`;
 }
 

--- a/.agents/scripts/lib/orchestration/run-epilogue.js
+++ b/.agents/scripts/lib/orchestration/run-epilogue.js
@@ -44,9 +44,25 @@ export const RUN_EPILOGUE_STEP_KINDS = Object.freeze([
  */
 
 /**
+ * @param {string|number|{ id?: string|number, slug?: string }} entry
+ * @returns {string|null}
+ */
+function normalizeStoryId(entry) {
+  if (typeof entry === 'string') return entry.trim() || null;
+  if (typeof entry === 'number' && Number.isInteger(entry)) {
+    return String(entry);
+  }
+  if (!entry || typeof entry !== 'object') return null;
+  if (typeof entry.id === 'string' || Number.isInteger(entry.id)) {
+    return String(entry.id).trim() || null;
+  }
+  return typeof entry.slug === 'string' ? entry.slug.trim() || null : null;
+}
+
+/**
  * Normalize the `stories` input to an ordered, deduped list of non-empty ids.
  *
- * @param {Array<string | { id?: string, slug?: string }>} stories
+ * @param {Array<string|number|{ id?: string|number, slug?: string }>} stories
  * @returns {string[]}
  */
 function normalizeStoryIds(stories) {
@@ -54,10 +70,7 @@ function normalizeStoryIds(stories) {
   const seen = new Set();
   const ids = [];
   for (const entry of list) {
-    let id = null;
-    if (typeof entry === 'string') id = entry.trim();
-    else if (entry && typeof entry.id === 'string') id = entry.id.trim();
-    else if (entry && typeof entry.slug === 'string') id = entry.slug.trim();
+    const id = normalizeStoryId(entry);
     if (!id || seen.has(id)) continue;
     seen.add(id);
     ids.push(id);
@@ -71,7 +84,7 @@ function normalizeStoryIds(stories) {
  *
  * @param {object} args
  * @param {string} args.planRunId The plan-run id grouping the Stories.
- * @param {Array<string | { id?: string, slug?: string }>} args.stories
+ * @param {Array<string|number|{ id?: string|number, slug?: string }>} args.stories
  *   The run's Stories (ids, slugs, or objects carrying either).
  * @returns {RunEpiloguePlan}
  */

--- a/.agents/scripts/lib/orchestration/single-story-close/phases/code-review.js
+++ b/.agents/scripts/lib/orchestration/single-story-close/phases/code-review.js
@@ -21,13 +21,14 @@
  * the caller raises that to a thrown error so auto-merge is not enabled.
  *
  * Delegates the `runCodeReview` invocation to `runStoryReviewCore`
- * (exported from `story-close/phases/code-review.js`) so both the
- * Epic-attached and standalone close paths share a single invocation
- * pattern (Story #3653).
+ * (exported from `story-close/phases/code-review.js`) so the close path
+ * shares a single invocation pattern (Story #3653). When `planningRisk`
+ * is omitted, loads it from the Story's `story-plan-state` checkpoint.
  */
 
 import { parsePrNumberFromUrl } from '../../../github-url.js';
 import { runStoryReviewCore } from '../../story-close/phases/code-review.js';
+import { resolveStoryPlanningRisk } from '../../story-plan-state.js';
 import { postStructuredComment } from '../../ticketing/state.js';
 
 /**
@@ -71,6 +72,79 @@ export function buildStoryReviewCrossRefBody({
   );
 }
 
+async function invokeStoryReviewCore({
+  storyId,
+  storyBranch,
+  baseBranch,
+  prNumber,
+  provider,
+  planningRisk,
+  runCodeReviewFn,
+  runLocalLensReviewFn,
+  progress,
+}) {
+  return runStoryReviewCore({
+    storyId,
+    baseRef: baseBranch,
+    headRef: storyBranch,
+    commentTargetId: prNumber,
+    provider,
+    planningRisk: await resolveStoryPlanningRisk({
+      provider,
+      storyId,
+      planningRisk,
+    }),
+    progress,
+    progressTag: 'REVIEW',
+    runCodeReviewFn,
+    // Forward the seam only when the caller injects it; otherwise
+    // `runStoryReviewCore` uses its default local-lens pass. `undefined`
+    // deep-merges to the default via the destructuring default there.
+    ...(runLocalLensReviewFn ? { runLocalLensReviewFn } : {}),
+  });
+}
+
+async function postStoryReviewCrossRef({
+  provider,
+  storyId,
+  prUrl,
+  prNumber,
+  result,
+  severity,
+  progress,
+}) {
+  if (result.posted && Number.isInteger(result.postedCommentId)) {
+    const commentUrl = `${prUrl}#issuecomment-${result.postedCommentId}`;
+    const body = buildStoryReviewCrossRefBody({
+      prUrl,
+      prNumber,
+      commentUrl,
+      severity,
+    });
+    try {
+      await postStructuredComment(provider, storyId, 'notification', body);
+      progress(
+        'REVIEW',
+        `📝 Cross-reference comment posted on Story #${storyId} → ${commentUrl}`,
+      );
+      return true;
+    } catch (err) {
+      progress(
+        'REVIEW',
+        `⚠️ Failed to post Story cross-reference comment: ${err?.message ?? err}`,
+      );
+      return false;
+    }
+  }
+  if (!result.posted) {
+    progress(
+      'REVIEW',
+      '⚠️ Skipping Story cross-reference comment: PR-side review comment did not post.',
+    );
+  }
+  return false;
+}
+
 /**
  * Run the Story-scope code review against `main`, post the structured
  * findings comment to the PR, and add a one-line cross-reference comment
@@ -93,6 +167,7 @@ export function buildStoryReviewCrossRefBody({
  *   prUrl: string,
  *   prNumber: number|null,
  *   provider: object,
+ *   planningRisk?: object|null, // omit to load from story-plan-state
  *   runCodeReviewFn: Function,
  *   runLocalLensReviewFn?: Function,
  *   progress: (tag: string, msg: string) => void,
@@ -115,6 +190,7 @@ export async function runStoryScopeReview({
   prUrl,
   prNumber,
   provider,
+  planningRisk,
   runCodeReviewFn,
   runLocalLensReviewFn,
   progress,
@@ -132,19 +208,16 @@ export async function runStoryScopeReview({
     `Running Story-scope code review for Story #${storyId} (${baseBranch}...${storyBranch}) → PR #${prNumber}...`,
   );
 
-  const result = await runStoryReviewCore({
+  const result = await invokeStoryReviewCore({
     storyId,
-    baseRef: baseBranch,
-    headRef: storyBranch,
-    commentTargetId: prNumber,
+    storyBranch,
+    baseBranch,
+    prNumber,
     provider,
-    progress,
-    progressTag: 'REVIEW',
+    planningRisk,
     runCodeReviewFn,
-    // Forward the seam only when the caller injects it; otherwise
-    // `runStoryReviewCore` uses its default local-lens pass. `undefined`
-    // deep-merges to the default via the destructuring default there.
-    ...(runLocalLensReviewFn ? { runLocalLensReviewFn } : {}),
+    runLocalLensReviewFn,
+    progress,
   });
 
   const sev = result.severity ?? {
@@ -158,34 +231,15 @@ export async function runStoryScopeReview({
     `Findings — critical:${sev.critical} high:${sev.high} medium:${sev.medium} suggestion:${sev.suggestion}. Posted to PR #${prNumber}: ${result.posted}.`,
   );
 
-  let crossRefPosted = false;
-  if (result.posted && Number.isInteger(result.postedCommentId)) {
-    const commentUrl = `${prUrl}#issuecomment-${result.postedCommentId}`;
-    const body = buildStoryReviewCrossRefBody({
-      prUrl,
-      prNumber,
-      commentUrl,
-      severity: sev,
-    });
-    try {
-      await postStructuredComment(provider, storyId, 'notification', body);
-      crossRefPosted = true;
-      progress(
-        'REVIEW',
-        `📝 Cross-reference comment posted on Story #${storyId} → ${commentUrl}`,
-      );
-    } catch (err) {
-      progress(
-        'REVIEW',
-        `⚠️ Failed to post Story cross-reference comment: ${err?.message ?? err}`,
-      );
-    }
-  } else if (!result.posted) {
-    progress(
-      'REVIEW',
-      '⚠️ Skipping Story cross-reference comment: PR-side review comment did not post.',
-    );
-  }
+  const crossRefPosted = await postStoryReviewCrossRef({
+    provider,
+    storyId,
+    prUrl,
+    prNumber,
+    result,
+    severity: sev,
+    progress,
+  });
 
   return {
     halted: !!result.halted,

--- a/.agents/scripts/lib/orchestration/single-story-close/phases/review-block.js
+++ b/.agents/scripts/lib/orchestration/single-story-close/phases/review-block.js
@@ -1,0 +1,40 @@
+import { Logger } from '../../../Logger.js';
+import { AGENT_LABELS } from '../../../label-constants.js';
+import { upsertStructuredComment } from '../../ticketing.js';
+
+/**
+ * Record a critical code-review halt as authoritative blocked state before
+ * close releases the Story lease and returns non-zero.
+ */
+export async function handleCriticalReviewBlock({
+  provider,
+  storyId,
+  prUrl,
+  criticalCount,
+}) {
+  const body = [
+    '### Code review blocked delivery',
+    '',
+    `The Story-scope review reported **${criticalCount} critical blocker(s)** on ${prUrl}.`,
+    'Remediate the posted findings, then re-run `/deliver`.',
+  ].join('\n');
+  try {
+    await upsertStructuredComment(provider, storyId, 'friction', body);
+  } catch (err) {
+    Logger.warn(
+      `[single-story-close] failed to post review-block friction: ${err?.message ?? err}`,
+    );
+  }
+  try {
+    await provider.updateTicket(storyId, {
+      labels: {
+        add: [AGENT_LABELS.BLOCKED],
+        remove: [AGENT_LABELS.EXECUTING, AGENT_LABELS.READY],
+      },
+    });
+  } catch (err) {
+    Logger.warn(
+      `[single-story-close] failed to block Story after critical review: ${err?.message ?? err}`,
+    );
+  }
+}

--- a/.agents/scripts/lib/orchestration/single-story-close/runner.js
+++ b/.agents/scripts/lib/orchestration/single-story-close/runner.js
@@ -19,6 +19,7 @@ import { runConfirmMergePhase } from './phases/confirm-merge.js';
 import { parseCloseOptions } from './phases/options.js';
 import { ensurePullRequestWith } from './phases/pull-request.js';
 import { pushStoryBranch } from './phases/push.js';
+import { handleCriticalReviewBlock } from './phases/review-block.js';
 import { reapWorktreePhase } from './phases/worktree-reap.js';
 import { runWrongTreeGuardPhase } from './phases/wrong-tree-guard.js';
 
@@ -128,8 +129,15 @@ async function openAndReviewPr({
     progress,
   });
   if (reviewOutcome.halted) {
+    const criticalCount = reviewOutcome.severity?.critical ?? 0;
+    await handleCriticalReviewBlock({
+      provider,
+      storyId,
+      prUrl,
+      criticalCount,
+    });
     throw new Error(
-      `[single-story-close] Story-scope review reported ${reviewOutcome.severity?.critical ?? 0} critical blocker(s) on PR ${prUrl}. ` +
+      `[single-story-close] Story-scope review reported ${criticalCount} critical blocker(s) on PR ${prUrl}. ` +
         'Auto-merge was not enabled. Remediate the findings posted to the PR and re-run `/single-story-deliver`.',
     );
   }

--- a/.agents/scripts/lib/orchestration/single-story-close/runner.js
+++ b/.agents/scripts/lib/orchestration/single-story-close/runner.js
@@ -138,7 +138,7 @@ async function openAndReviewPr({
     });
     throw new Error(
       `[single-story-close] Story-scope review reported ${criticalCount} critical blocker(s) on PR ${prUrl}. ` +
-        'Auto-merge was not enabled. Remediate the findings posted to the PR and re-run `/single-story-deliver`.',
+        'Auto-merge was not enabled. Remediate the findings posted to the PR and re-run `/deliver`.',
     );
   }
   return { prUrl, prNumber };

--- a/.agents/scripts/lib/orchestration/story-init-remote.js
+++ b/.agents/scripts/lib/orchestration/story-init-remote.js
@@ -1,0 +1,47 @@
+import { Logger } from '../Logger.js';
+import { AGENT_LABELS } from '../label-constants.js';
+import { upsertStructuredComment } from './ticketing.js';
+
+/**
+ * Fail closed when the repository remote cannot be verified. The Story is
+ * blocked before lease/branch/worktree mutation so a host that misses the
+ * result envelope cannot strand an executing Story.
+ */
+export async function handleRemoteVerificationFailure({
+  provider,
+  storyId,
+  remote,
+  dryRun = false,
+}) {
+  if (remote?.remoteVerified) return;
+  const message =
+    `[single-story-init] remote verification failed for Story #${storyId}: ` +
+    `${remote?.detail ?? 'origin is unavailable'}`;
+  if (!dryRun) {
+    try {
+      await upsertStructuredComment(
+        provider,
+        storyId,
+        'friction',
+        `### Remote verification blocked delivery\n\n${message}`,
+      );
+    } catch (err) {
+      Logger.warn(
+        `[single-story-init] failed to post remote-verification friction: ${err?.message ?? err}`,
+      );
+    }
+    try {
+      await provider.updateTicket(storyId, {
+        labels: {
+          add: [AGENT_LABELS.BLOCKED],
+          remove: [AGENT_LABELS.READY, AGENT_LABELS.EXECUTING],
+        },
+      });
+    } catch (err) {
+      Logger.warn(
+        `[single-story-init] failed to block Story after remote verification: ${err?.message ?? err}`,
+      );
+    }
+  }
+  throw new Error(message);
+}

--- a/.agents/scripts/lib/orchestration/story-plan-state.js
+++ b/.agents/scripts/lib/orchestration/story-plan-state.js
@@ -1,0 +1,48 @@
+import { parseFencedJsonComment } from './structured-comment-parser.js';
+import { findStructuredComment } from './ticketing.js';
+
+/**
+ * Read the v2 Story planning checkpoint. Missing/malformed comments degrade
+ * to null so unplanned Stories still receive the neutral review posture.
+ */
+export async function readStoryPlanState({
+  provider,
+  storyId,
+  findCommentFn = findStructuredComment,
+}) {
+  const comment = await findCommentFn(
+    provider,
+    Number(storyId),
+    'story-plan-state',
+  );
+  const state = parseFencedJsonComment(comment);
+  return state && typeof state === 'object' ? state : null;
+}
+
+export async function readStoryPlanningRisk(args) {
+  const state = await readStoryPlanState(args);
+  return state?.planningRisk ?? null;
+}
+
+export async function readStoryPlanningRiskSafe(args) {
+  try {
+    return await readStoryPlanningRisk(args);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Prefer an explicit `planningRisk` override; otherwise load the Story
+ * checkpoint. Callers that omit the field (or pass `undefined`) get the
+ * persisted plan risk; callers that pass `null` keep the neutral posture.
+ */
+export async function resolveStoryPlanningRisk({
+  provider,
+  storyId,
+  planningRisk,
+  findCommentFn,
+}) {
+  if (planningRisk !== undefined) return planningRisk;
+  return readStoryPlanningRiskSafe({ provider, storyId, findCommentFn });
+}

--- a/.agents/scripts/lib/orchestration/ticketing/reads.js
+++ b/.agents/scripts/lib/orchestration/ticketing/reads.js
@@ -24,7 +24,7 @@ export const STATE_LABELS = {
   READY: AGENT_LABELS.READY,
   EXECUTING: AGENT_LABELS.EXECUTING,
   // Story #2144 — intermediate state held by a Story between successful
-  // close-preflight and a confirmed merge into `epic/<id>`. Included in
+  // close-preflight and a confirmed Story PR merge into `main`. Included in
   // the state enum so `transitionTicketState` can apply the label via
   // the canonical one-state-at-a-time path (which removes every other
   // `agent::*` label in the same call) and so the read-side `ALL_STATES`

--- a/.agents/scripts/lib/orchestration/ticketing/reads.js
+++ b/.agents/scripts/lib/orchestration/ticketing/reads.js
@@ -176,8 +176,8 @@ export const STRUCTURED_COMMENT_TYPES = Object.freeze([
   // success, carrying risk / routing receipts and the depends_on order
   // table. One entry per plan; a re-persist upserts in place.
   'plan-summary',
-  // v2 Stage 3 — flat Story persist checkpoint on the primary Story
-  // (replaces epic-plan-state for new plans).
+  // v2 Stage 3 — flat Story persist checkpoint on every created Story
+  // (replaces epic-plan-state for new plans). plan-summary stays primary-only.
   'story-plan-state',
 ]);
 

--- a/.agents/scripts/lib/story-body/story-body.js
+++ b/.agents/scripts/lib/story-body/story-body.js
@@ -153,6 +153,7 @@ const HEADING_TO_FIELD = new Map([
   ['references', 'references'],
   ['non_goals', 'non_goals'],
 ]);
+const TEXT_BLOCK_FIELDS = new Set(['slicing', 'spec']);
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -393,27 +394,11 @@ function splitSections(markdown) {
     // below, which closes the open section. The chosen canonical spelling is
     // therefore the hyphenated single token `## Non-Goals`.
     const fieldHeadingMatch = line.match(/^#{2,3}\s+([\w-]+)\s*$/i);
-    if (fieldHeadingMatch) {
-      const name = fieldHeadingMatch[1].toLowerCase().replace(/-/g, '_');
-      if (HEADING_TO_FIELD.has(name)) {
-        inPreamble = false;
-        currentSection = name;
-        if (!sections.has(currentSection)) sections.set(currentSection, []);
-        continue;
-      }
-      // A heading that matches the canonical `## Word` shape but is not a
-      // recognized field name (e.g. a trailing free-form `## Notes`) closes
-      // the currently-open section. Without this reset, the unknown heading
-      // and its bullets bleed into the previously-recognized section,
-      // silently corrupting `verify[]` / `acceptance[]`. We do NOT re-enter
-      // the preamble (`inPreamble` stays false), so a later recognized
-      // heading still registers normally; we only stop appending to the
-      // closed section. The heading line and its body are dropped from all
-      // sections. (Multi-word free-form headings like `## Out of Scope` —
-      // with internal spaces — do not match the `[\w-]+` single-token shape
-      // and reach this branch too. The hyphenated single-token canonical
-      // negative-scope heading is `## Non-Goals`, which IS recognized above.)
-      currentSection = null;
+    const fieldName = fieldHeadingMatch?.[1]?.toLowerCase().replace(/-/g, '_');
+    if (HEADING_TO_FIELD.has(fieldName)) {
+      inPreamble = false;
+      currentSection = fieldName;
+      if (!sections.has(currentSection)) sections.set(currentSection, []);
       continue;
     }
 
@@ -426,7 +411,11 @@ function splitSections(markdown) {
     // lines were silently absorbed into `verify[]` / `acceptance[]`. The
     // heading and everything under it is dropped from structured parsing
     // (it is extended, non-canonical markdown).
-    if (!inPreamble && /^#{1,6}\s+\S/.test(line)) {
+    if (
+      !inPreamble &&
+      /^#{1,6}\s+\S/.test(line) &&
+      !TEXT_BLOCK_FIELDS.has(currentSection)
+    ) {
       currentSection = null;
       continue;
     }
@@ -450,10 +439,7 @@ function splitSections(markdown) {
     if (inPreamble) {
       preambleLines.push(line);
     } else if (currentSection !== null) {
-      const trimmed = line.trim();
-      if (trimmed.length > 0) {
-        sections.get(currentSection).push(line);
-      }
+      sections.get(currentSection).push(line);
     }
   }
 
@@ -541,9 +527,9 @@ function parseGoalSection(lines) {
  */
 function parseTextBlockSection(lines) {
   return lines
-    .map((l) => l.replace(/\s+$/, ''))
-    .filter((l) => l.trim() !== '')
-    .join('\n');
+    .map((line) => line.replace(/\s+$/, ''))
+    .join('\n')
+    .replace(/^\n+|\n+$/g, '');
 }
 
 /**

--- a/.agents/scripts/plan-persist.js
+++ b/.agents/scripts/plan-persist.js
@@ -11,7 +11,8 @@
  *   risk-verdict → ticket validator / DAG / capacity → reachability →
  *   split-policy partition → fold/spill Spec into each Story body →
  *   createIssue(s) with type::story + agent::ready → risk-verdict +
- *   plan-summary + story-plan-state on the primary Story → temp cleanup.
+ *   story-plan-state on every Story; plan-summary on the primary → temp
+ *   cleanup.
  *
  * CLI:
  *   --stories <file>         Required Story ticket array (default length 1)

--- a/.agents/scripts/resolve-plan-run.js
+++ b/.agents/scripts/resolve-plan-run.js
@@ -56,6 +56,23 @@ function writeEnvelope(envelope, pretty) {
   process.stdout.write(text);
 }
 
+/**
+ * Resolve config once and pass it to the provider factory. Kept as an
+ * injectable seam so the CLI contract is covered without network access.
+ *
+ * @param {object} [deps]
+ * @param {Function} [deps.resolveConfigFn]
+ * @param {Function} [deps.createProviderFn]
+ * @returns {object}
+ */
+export function resolvePlanRunProvider({
+  resolveConfigFn = resolveConfig,
+  createProviderFn = createProvider,
+} = {}) {
+  const config = resolveConfigFn();
+  return createProviderFn(config);
+}
+
 async function main() {
   const { values } = parseArgs({
     options: {
@@ -80,8 +97,7 @@ async function main() {
   const planRunLabel = normalizePlanRunLabel(values.run);
   const planRunId = planRunIdFromLabel(planRunLabel);
 
-  resolveConfig();
-  const provider = createProvider();
+  const provider = resolvePlanRunProvider();
   const issues = await fetchPlanRunIssues(provider, { planRunLabel, state });
   const envelope = buildPlanRunEnvelope(issues, { planRunId, planRunLabel });
   writeEnvelope(envelope, values.pretty);

--- a/.agents/scripts/signals-view.js
+++ b/.agents/scripts/signals-view.js
@@ -5,7 +5,7 @@
  * Task #1463).
  *
  * Reads signals via `lib/signals/read`, materialises a span-tree via
- * `lib/signals/buildSpanTree`, and prints a readable Epic → Story → Task →
+ * `lib/signals/buildSpanTree`, and prints a readable run → Story →
  * events tree to stdout. The output is **plain text via
  * `process.stdout.write`** — no Ink, no blessed, no terminal-control
  * escape sequences — so it works on Windows + bash hosts (see
@@ -16,10 +16,10 @@
  * stdout uses `process.stdout.write`, not the console).
  *
  * Usage:
- *   node .agents/scripts/signals-view.js <epic-id> [--story <id>]
+ *   node .agents/scripts/signals-view.js <run-id> [--story <id>]
  *
  * Args:
- *   <epic-id>            Positive integer Epic ID. Required.
+ *   <run-id>             Positive integer run ID. Required.
  *   --story <id>         Optional positive integer Story ID. When set,
  *                        narrows the printed tree to a single Story
  *                        subtree.
@@ -27,7 +27,7 @@
  * Exit codes:
  *   0  — happy path, OR missing signals file (friendly message printed,
  *        no stack trace).
- *   1  — bad arguments (non-integer epic, missing positional, etc.).
+ *   1  — bad arguments (non-integer run, missing positional, etc.).
  *
  * Tempfile contract:
  *   The viewer resolves the on-disk signals path via the configured
@@ -57,7 +57,7 @@ function println(line) {
 }
 
 const USAGE =
-  'Usage: node .agents/scripts/signals-view.js <epic-id> [--story <id>] [--temp-root <path>]';
+  'Usage: node .agents/scripts/signals-view.js <run-id> [--story <id>] [--temp-root <path>]';
 
 /**
  * Parse a token as a strict positive integer (no leading +, no float, no
@@ -86,7 +86,7 @@ const HELP_FLAGS = new Set(['--help', '-h']);
  * print a friendly message and exit 1 without a stack trace.
  *
  * Delegates the flag walking to `parseStandardCliArgs` and post-validates
- * the diagnose-specific invariants (single positional epic-id, strictly
+ * the signals-view-specific invariants (single positional run-id, strictly
  * positive integers for both ids).
  *
  * @param {string[]} argv
@@ -94,7 +94,7 @@ const HELP_FLAGS = new Set(['--help', '-h']);
  */
 export function parseArgs(argv) {
   if (!Array.isArray(argv) || argv.length === 0) {
-    return err(`missing <epic-id>. ${USAGE}`);
+    return err(`missing <run-id>. ${USAGE}`);
   }
   if (argv.some((t) => HELP_FLAGS.has(t))) return err(USAGE);
 
@@ -118,7 +118,7 @@ export function parseArgs(argv) {
   // Exactly one positional, which must be a strictly positive integer
   // (no leading `+`, no float, no trailing junk).
   if (positionals.length === 0) {
-    return err(`missing <epic-id>. ${USAGE}`);
+    return err(`missing <run-id>. ${USAGE}`);
   }
   if (positionals.length > 1) {
     return err(`unexpected token ${JSON.stringify(positionals[1])}. ${USAGE}`);
@@ -126,7 +126,7 @@ export function parseArgs(argv) {
   const epic = parseStrictPositiveInt(positionals[0]);
   if (epic == null) {
     return err(
-      `<epic-id> must be a positive integer; got ${JSON.stringify(positionals[0])}. ${USAGE}`,
+      `<run-id> must be a positive integer; got ${JSON.stringify(positionals[0])}. ${USAGE}`,
     );
   }
 
@@ -180,7 +180,7 @@ function describeEvent(evt) {
  */
 export function renderTree(tree, opts = {}) {
   const filter = opts.storyFilter ?? null;
-  println(`Epic #${tree.epic ?? '?'}`);
+  println(`Run #${tree.epic ?? '?'}`);
   const stories =
     filter == null ? tree.stories : tree.stories.filter((s) => s.id === filter);
 
@@ -226,12 +226,16 @@ export async function main(argv, deps = {}) {
     println(parsed.error);
     return 1;
   }
-  const { epic, story, tempRoot } = parsed;
+  const { epic: runId, story, tempRoot } = parsed;
   const read = deps.read ?? signals.read;
   const buildSpanTree = deps.buildSpanTree ?? signals.buildSpanTree;
   const config = buildConfig(tempRoot);
 
-  const iter = read(story != null ? { epic, story, config } : { epic, config });
+  // The reader API still accepts the historical `epic` key while resolving
+  // the run directory through temp-paths (`temp/run-<id>/`).
+  const iter = read(
+    story != null ? { epic: runId, story, config } : { epic: runId, config },
+  );
 
   // Eagerly collect to detect the missing-file case before we start
   // printing — when the iterator yields nothing we want a friendly
@@ -241,7 +245,7 @@ export async function main(argv, deps = {}) {
     tree = await buildSpanTree(iter);
   } catch (err) {
     println(
-      `signals: failed to read signals for Epic #${epic}: ${
+      `signals: failed to read signals for run #${runId}: ${
         err instanceof Error ? err.message : String(err)
       }`,
     );
@@ -250,7 +254,7 @@ export async function main(argv, deps = {}) {
 
   if (tree.stories.length === 0) {
     const scope = story != null ? ` (Story #${story})` : '';
-    println(`No signals found for Epic #${epic}${scope}.`);
+    println(`No signals found for run #${runId}${scope}.`);
     return 0;
   }
 
@@ -258,15 +262,16 @@ export async function main(argv, deps = {}) {
   // `story` is omitted. If the requested Story filter doesn't match any
   // observed Story id, treat that as the missing-file case too.
   if (story != null && !tree.stories.some((s) => s.id === story)) {
-    println(`No signals found for Epic #${epic} (Story #${story}).`);
+    println(`No signals found for run #${runId} (Story #${story}).`);
     return 0;
   }
 
-  // Pin the Epic id on the tree to the requested one — `buildSpanTree`
-  // pins it from the first observed event, which is normally the same,
-  // but if every event lacks an `epic` field the tree's `epic` would be
+  // Pin the run id on the tree to the requested one — `buildSpanTree`
+  // stores it in the legacy `epic` field from the first observed event,
+  // which is normally the same, but if every event lacks that field the
+  // tree's `epic` would be
   // `null` while we still know what was requested.
-  if (tree.epic == null) tree = { ...tree, epic };
+  if (tree.epic == null) tree = { ...tree, epic: runId };
 
   renderTree(tree, { storyFilter: story });
   return 0;

--- a/.agents/scripts/single-story-close.js
+++ b/.agents/scripts/single-story-close.js
@@ -1,13 +1,11 @@
 #!/usr/bin/env node
 
 /**
- * single-story-close.js — Close a standalone Story (no parent Epic).
+ * single-story-close.js — Close a Story against `main` (v2 `/deliver` path).
  *
- * Thin CLI entry for the `/single-story-deliver` workflow. Counterpart to
- * `story-close.js`, but skips the Epic-attached machinery (epic-merge-lock,
- * dispatchRecovery, auto-refresh, post-merge pipeline) because a standalone
- * Story has no parent to cascade to and reaches `main` via a human-approved
- * PR rather than an in-script merge.
+ * Thin CLI entry for `/deliver` / `helpers/deliver-story`. Opens a PR from
+ * `story-<id>` to `project.baseBranch`, runs Story-scope review, and arms
+ * auto-merge. There is no Epic parent, epic-merge-lock, or wave merge.
  *
  * Pipeline (each step is a phase under
  * `./lib/orchestration/single-story-close/phases/`):
@@ -44,18 +42,17 @@
  *                              [--wait-merge | --no-wait-merge]
  *
  * `--wait-merge` is the headless must-land signal (Story #4428, Epic
- * #4425): the invoking surface (a headless `/single-story-deliver` run, a
- * CI-driven wrapper, or `/deliver`'s standalone multi-Story fan-out) opts
- * in explicitly — attended runs never pass it, so the default exit shape
- * (rest at `agent::closing`, issue OPEN) is unchanged. `--no-wait-merge` is
- * the explicit opt-out that always wins over `--wait-merge`, for a caller
- * that wants to manage merge confirmation externally even in an otherwise
- * headless context.
+ * #4425): the invoking surface (a headless `/deliver` run or a CI-driven
+ * wrapper) opts in explicitly — attended runs never pass it, so the default
+ * exit shape (rest at `agent::closing`, issue OPEN) is unchanged.
+ * `--no-wait-merge` is the explicit opt-out that always wins over
+ * `--wait-merge`, for a caller that wants to manage merge confirmation
+ * externally even in an otherwise headless context.
  *
  * Exit codes: 0 ok, 1 error (including a headless `--wait-merge` run that
  * gave up without a confirmed merge — see phase 9 above).
  *
- * @see .agents/workflows/helpers/single-story-deliver.md
+ * @see .agents/workflows/helpers/deliver-story.md
  */
 
 import { runAsCli } from './lib/cli-utils.js';

--- a/.agents/scripts/single-story-confirm-merge.js
+++ b/.agents/scripts/single-story-confirm-merge.js
@@ -10,7 +10,7 @@
  * auto-merge completes *asynchronously* after the close script exits, so
  * the `agent::done` flip (which closes the issue) is deferred to this
  * confirmation step, invoked by the CI-watch loop in
- * `single-story-deliver.md` Step 5 once `pr-watch-with-update.js` exits.
+ * `helpers/deliver-story.md` once `pr-watch-with-update.js` exits.
  *
  * The script:
  *   1. Resolves the PR number (`--pr <n>`, or probes
@@ -32,7 +32,7 @@
  *
  * Exit codes: 0 ok (merged, pending, or noop), 1 error.
  *
- * @see .agents/workflows/helpers/single-story-deliver.md § Step 5
+ * @see .agents/workflows/helpers/deliver-story.md
  */
 
 import { parseArgs } from 'node:util';

--- a/.agents/scripts/single-story-init.js
+++ b/.agents/scripts/single-story-init.js
@@ -61,6 +61,7 @@ import {
 } from './lib/orchestration/git-cleanup/phases/fast-forward.js';
 import { verifyRemote } from './lib/orchestration/remote-verifier.js';
 import { acquireStoryLease } from './lib/orchestration/single-story-lease-guard.js';
+import { handleRemoteVerificationFailure } from './lib/orchestration/story-init-remote.js';
 import {
   STATE_LABELS,
   transitionTicketState,
@@ -74,6 +75,7 @@ import { buildProtectionCtx } from './lib/single-story-sweep/protection-ctx.js';
 // friendly "run npm install" message.
 import { WorktreeManager } from './lib/worktree-manager.js';
 
+export { handleRemoteVerificationFailure } from './lib/orchestration/story-init-remote.js';
 // `makeGhRunner` moved to the shared `single-story-sweep/protection-ctx.js`
 // module (Story #4373) so the three boot callers build an identical
 // protection ctx. Re-exported here to preserve its existing import path.
@@ -505,6 +507,12 @@ export async function runSingleStoryInit({
 
   const story = await provider.getTicket(storyId);
   assertDeliverableStory(story, storyId);
+  await handleRemoteVerificationFailure({
+    provider,
+    storyId,
+    remote,
+    dryRun,
+  });
 
   progress(
     'CONTEXT',

--- a/.agents/scripts/single-story-init.js
+++ b/.agents/scripts/single-story-init.js
@@ -2,14 +2,12 @@
 /* node:coverage ignore file */
 
 /**
- * single-story-init.js — Initialize a standalone Story (no parent Epic).
+ * single-story-init.js — Initialize a Story for v2 `/deliver`.
  *
- * Counterpart to `story-init.js` for the `/single-story-deliver` workflow.
- * The framework's main `story-init.js` requires an `Epic: #N` reference in
- * the Story body to trace hierarchy, seed the Story branch from
- * `epic/<id>`, and gate execution on the epic's dispatch manifest. None of
- * that applies to a standalone Story — a top-level work unit that branches
- * directly from `main` and opens its PR straight to `main`.
+ * Seeds `story-<id>` from `project.baseBranch` (default `main`), materialises
+ * the per-Story worktree when isolation is enabled, upserts a `story-init`
+ * structured comment, and flips the Story to `agent::executing`. There is no
+ * Epic parent, epic branch, or dispatch-manifest gate.
  *
  * What this script does:
  *   1. Validate the Story (type::story, not closed).
@@ -22,17 +20,14 @@
  *      `standalone: true`.
  *   6. Flip the Story to `agent::executing`.
  *
- * What this script does NOT do (and why):
- *   - Skips `validateBlockers` against the body's `Blocked by:` markers —
- *     pre-flight is still the operator's responsibility, but the Epic-scope
- *     blocker chain doesn't fit.
- *   - Skips child-Task transitions — a standalone Story is treated as
- *     atomic (one branch, one commit-set, one PR).
+ * What this script does NOT do:
+ *   - Child-Task transitions — a Story is atomic (one branch, one
+ *     commit-set, one PR to `main`).
  *
  * Usage: `node single-story-init.js --story <STORY_ID> [--dry-run]`
  * Exit codes: 0 ok, 1 error.
  *
- * @see .agents/workflows/helpers/single-story-deliver.md
+ * @see .agents/workflows/helpers/deliver-story.md
  */
 
 import { existsSync } from 'node:fs';

--- a/.agents/skills/core/analyze-execution/SKILL.md
+++ b/.agents/skills/core/analyze-execution/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: analyze-execution
 description: >-
-  Aggregate per-Story or per-Epic execution signals into a structured
+  Aggregate per-Story or per-plan-run execution signals into a structured
   perf-summary or perf-report and upsert it onto the corresponding GitHub
-  ticket. Use after a Story closes (Story mode) or as part of
-  `/deliver` Phase 6 (Epic mode). Reads NDJSON via
+  ticket. Use after a Story closes (Story mode) or during run closeout
+  (plan-run mode). Reads NDJSON via
   `lib/signals/read` and writes a single structured comment.
 allowed_tools:
   - Read
@@ -16,42 +16,42 @@ allowed_tools:
 ## Policy Capsule
 
 - Invoke via the wrapping CLI `node .agents/scripts/analyze-execution.js`; do not duplicate the read/write logic from this Skill body.
-- Resolve mode strictly by flags: `--story <sid> --epic <eid>` → Story mode; `--epic <eid>` alone → Epic mode.
-- Read NDJSON signals only through `lib/signals/read` (the async-iterator entry point). Never open `<tempRoot>/epic-<eid>/story-<sid>/signals.ndjson` directly — the reader owns the warn-once malformed-JSON policy.
+- Resolve mode strictly by flags: Story + run id → Story mode; run id alone → plan-run mode. The current CLI still spells the run-id flag as `--epic <id>`; treat that value as the run id and do not add a second executor path here.
+- Read NDJSON signals only through `lib/signals/read` (the async-iterator entry point). Never open `<tempRoot>/run-<id>/stories/story-<sid>/signals.ndjson` directly — the reader owns the warn-once malformed-JSON policy.
 - Emit a single structured GitHub comment per ticket (`<!-- structured:story-perf-summary -->` or `<!-- structured:epic-perf-report -->`); rely on `upsertStructuredComment` for idempotence — never post duplicates.
-- Never rename or alter the structured-marker IDs; the retro composer and Epic dashboard grep them verbatim.
+- Never rename or alter the structured-marker IDs; the retro composer and run dashboard grep them verbatim.
 - Validate the structured payload against `docs/data-dictionary.md §StoryPerfSummary` or `§EpicPerfReport` before posting. Schema violations exit non-zero.
-- Soft-fail (exit 0 with a warning) when NDJSON is missing for a Story or an Epic has no children — observability output MUST NOT block the close pipeline.
+- Soft-fail (exit 0 with a warning) when NDJSON is missing for a Story or a plan-run has no children — observability output MUST NOT block the close pipeline.
 - Do not write to disk. Persistence is GitHub; the Skill is read-NDJSON + post-comment only.
 
 ## Role
 
 Observability writer. Composes the structured `story-perf-summary` /
 `epic-perf-report` comment bodies the retro composer downstream renders
-into the Epic dashboard.
+into the run dashboard.
 
 ## When to use
 
-- **Story mode** — after `story-close.js` finishes, the post-merge
+- **Story mode** — after `single-story-close.js` finishes, the close
   pipeline dispatches this Skill (or the wrapping script) to roll up the
   Story's NDJSON signals into a single `<!-- structured:story-perf-summary -->`
   marker comment on the Story ticket.
-- **Epic mode** — during `/deliver` Phase 6.0 (or the retro
-  composer), the Skill fans out across every Story under the Epic,
+- **Plan-run mode** — during run closeout (or the retro
+  composer), the Skill fans out across every Story under the plan-run,
   reads each Story's structured perf summary, and posts a single
-  `<!-- structured:epic-perf-report -->` marker on the Epic ticket.
+  `<!-- structured:epic-perf-report -->` marker on the run ticket.
 
 ## Inputs
 
 The Skill reads (never writes) the NDJSON signal stream at:
 
 ```text
-<tempRoot>/epic-<eid>/story-<sid>/signals.ndjson
+<tempRoot>/run-<id>/stories/story-<sid>/signals.ndjson
 ```
 
 Use the `lib/signals/read` async-iterator entry point — never open the
 file directly. Story mode also reads `phase-timings.json` written by
-`post-merge-close.js`.
+the close pipeline.
 
 ## Outputs
 
@@ -64,8 +64,8 @@ the new one.
 
 ### Step 1 — Resolve mode
 
-If both `--story <sid>` and `--epic <eid>` are supplied → Story mode.
-If only `--epic <eid>` is supplied → Epic mode. The script
+If both Story id and run id are supplied → Story mode.
+If only run id is supplied → plan-run mode. The script
 `analyze-execution.js` is the dispatcher today; this Skill documents the
 contract the dispatcher implements.
 
@@ -76,6 +76,9 @@ node .agents/scripts/analyze-execution.js --story <sid> --epic <eid>
 # or
 node .agents/scripts/analyze-execution.js --epic <eid>
 ```
+
+`--epic <eid>` is the legacy spelling of the run-id flag in the current
+CLI; treat `<eid>` as the run id for path/layout purposes.
 
 ### Step 3 — Validate the structured payload before posting
 
@@ -92,7 +95,7 @@ the contract so we never silently emit malformed comments.
 - Do **not** rename the structured-marker IDs
   (`<!-- structured:story-perf-summary -->`,
   `<!-- structured:epic-perf-report -->`); the retro composer and the
-  Epic dashboard both grep for them verbatim.
+  run dashboard both grep for them verbatim.
 - Soft-failure mode is intentional: missing NDJSON for a Story or no
-  children for an Epic returns exit 0 with a warning so close pipelines
+  children for a plan-run returns exit 0 with a warning so close pipelines
   never block on observability output.

--- a/.agents/skills/skills.index.json
+++ b/.agents/skills/skills.index.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-07-14T15:32:53.512Z",
+  "generatedAt": "2026-07-14T20:48:55.222Z",
   "generator": "generate-skills-index.js@1",
   "skills": [
     {
@@ -7,7 +7,7 @@
       "tier": "core",
       "category": "core",
       "path": ".agents/skills/core/analyze-execution/SKILL.md",
-      "description": "Aggregate per-Story or per-Epic execution signals into a structured perf-summary or perf-report and upsert it onto the corresponding GitHub ticket. Use after a Story closes (Story mode) or as part of `/deliver` Phase 6 (Epic mode). Reads NDJSON via `lib/signals/read` and writes a single structured comment.",
+      "description": "Aggregate per-Story or per-plan-run execution signals into a structured perf-summary or perf-report and upsert it onto the corresponding GitHub ticket. Use after a Story closes (Story mode) or during run closeout (plan-run mode). Reads NDJSON via `lib/signals/read` and writes a single structured comment.",
       "policyCapsuleBullets": 8,
       "allowedTools": ["Read", "Bash"],
       "vendor": null

--- a/.agents/workflows/helpers/code-review.md
+++ b/.agents/workflows/helpers/code-review.md
@@ -1,47 +1,50 @@
 ---
 description: >-
-  Perform a comprehensive code review of a change set scoped to either a Story
-  branch or an Epic branch
+  Perform a comprehensive code review of a Story change set against main
+  before `/deliver` opens or merges the Story PR
 ---
 
 # Code Review (helper)
 
 > **Helper module.** Not a slash command. Invoked automatically from
-> `/deliver` (Story scope) and `/deliver` Phase 5 (Epic scope).
-> To run a review directly, invoke the parent workflow — operators do not
-> call this helper by hand.
+> `/deliver` via `single-story-close.js`. To run a review directly, invoke
+> the parent workflow — operators do not call this helper by hand.
 
 This helper performs a comprehensive code review of a change set before it
-is merged upstream. It runs in two scopes:
+is merged to `main`. The live v2 path is **Story scope only**:
 
-- **Story scope** — reviews the diff between a Story branch and its parent
-  Epic branch, before `story-close.js` merges the Story into the Epic.
-- **Epic scope** — reviews the cumulative diff between an Epic branch and
-  `main`, before `/deliver` opens the integration pull request.
+- **Story scope** — reviews `main...story-<storyId>` (or
+  `project.baseBranch...story-<storyId>`) inside `single-story-close.js`
+  after the PR opens and before auto-merge. Findings post to the PR;
+  critical findings block close (`agent::blocked`).
+
+Legacy `scope: epic` / Epic-branch review text below is retained only for
+historical adapters and is **not** on the `/deliver` hot path.
 
 **Invariant — Story-scope review runs outside the maker's LLM context.**
-The Story-scope review executes inside the `story-close.js` /
-`single-story-close.js` close subprocess, **not** in the delivering
-child's (maker agent's) LLM context. The close pipeline invokes it after
-the delivering child has exited, so the change set is reviewed by a
-process the maker cannot influence. The enforcing code path is
-[`.agents/scripts/lib/orchestration/story-close/phases/code-review.js`](../../scripts/lib/orchestration/story-close/phases/code-review.js)
-(invoked from `runStoryCloseLocked`; both close entry points reach it
-through the shared `runStoryReviewCore` spine). A future refactor MUST
-preserve this isolation: do not move Story-scope review into the maker's
-context or run it as a step of the delivering child.
+The Story-scope review executes inside the `single-story-close.js` close
+subprocess, **not** in the delivering child's (maker agent's) LLM context.
+The close pipeline invokes it after the delivering child has exited, so
+the change set is reviewed by a process the maker cannot influence. The
+enforcing code path is
+[`runStoryScopeReview`](../../scripts/lib/orchestration/single-story-close/phases/code-review.js)
+→ shared
+[`runStoryReviewCore`](../../scripts/lib/orchestration/story-close/phases/code-review.js).
+A future refactor MUST preserve this isolation: do not move Story-scope
+review into the maker's context or run it as a step of the delivering
+child.
 
 > **Persona**: `architect` · **Skills**: `core/code-review-and-quality`,
 > `core/security-and-hardening`
 
 ## Argument contract
 
-The caller passes the following arguments (`/deliver` Story workflows pass
-`scope: story`; legacy cumulative callers may pass `scope: epic`):
+The caller passes the following arguments (`/deliver` passes
+`scope: story`):
 
 | Argument    | Type                                  | Required | Meaning                                                                                          |
 | ----------- | ------------------------------------- | -------- | ------------------------------------------------------------------------------------------------ |
-| `scope`     | `"story"` \| `"epic"`                 | yes      | Selects the integration-pillar diff base and the structured-comment target ticket.               |
+| `scope`     | `"story"` \| `"epic"`                 | yes      | Live path is `"story"`. `"epic"` remains only for legacy cumulative adapters.                    |
 | `ticketId`  | integer                               | yes      | GitHub issue number of the Story (when `scope === 'story'`) or cumulative ticket (legacy `scope === 'epic'`). |
 | `baseRef`   | string (git ref)                      | yes      | The diff base. Story scope: `main` (or `project.baseBranch`). Legacy cumulative scope: caller-provided base. |
 | `headRef`   | string (git ref)                      | yes      | The branch tip under review. Story scope: `story-<storyId>`. Legacy cumulative scope: caller-provided head. |
@@ -54,18 +57,18 @@ the argument envelope.
 ### Review depth (`depth`)
 
 `depth` is the risk-derived thoroughness lever introduced by Story #3876 and
-made a live consumed signal end to end by Story #3937. The Epic caller
-(`/deliver` Phase 5) resolves it from the Epic's judged `planningRisk`
-envelope via
-[`resolveReviewDepthForEpic`](../../scripts/lib/orchestration/code-review.js)
-(`high` → `deep`, `low` → `light`, everything else — including a missing
-`epic-plan-state` checkpoint — → `standard`) and passes it in this envelope.
+made a live consumed signal end to end by Story #3937. The live `/deliver`
+close path resolves it from the Story's judged `planningRisk` envelope
+(read from the per-Story `story-plan-state` checkpoint via
+[`resolveStoryPlanningRisk`](../../scripts/lib/orchestration/story-plan-state.js);
+`high` → `deep`, `low` → `light`, everything else — including a missing
+checkpoint — → `standard`) and passes it into `runCodeReview`.
 `runCodeReview` forwards `depth` to every provider's `runReview` input.
 
 It is an **input-only** signal: it changes *how thorough* the review is, never
 the findings envelope (`{ status, severity, posted, report, halted,
 blockerReason }`) nor the posted `verification-results` structured-comment body. An
-absent or malformed `depth` is treated as `standard`, so an Epic that skipped
+absent or malformed `depth` is treated as `standard`, so a Story that skipped
 `/plan` still gets a passing review with no new failure mode.
 
 How each tier changes the review protocol:
@@ -89,17 +92,13 @@ review yourself, honor the `depth` semantics above directly.
 
 ## Step 0 — Resolve Context
 
-1. Resolve `[TICKET_ID]` from `ticketId` (Story or Epic depending on `scope`).
+1. Resolve `[TICKET_ID]` from `ticketId` (the Story for live `scope: story`).
 2. Resolve `[BASE_REF]` from `baseRef` and `[HEAD_REF]` from `headRef`.
-3. Fetch the `[TICKET_ID]` ticket and resolve the planning context:
-   - **Story scope** — read the parent Epic from the Story body, then load
-     the Epic body (including its `## User Stories` section and its folded
-     Tech Spec sections).
-   - **Epic scope** — read the Epic body directly; its managed sections
-     carry the Tech Spec.
-4. Read the Epic body fully (including its Tech Spec sections) to
-   understand the intended
-   scope, architectural decisions, and acceptance criteria.
+3. Fetch the Story ticket and resolve the planning context from its own
+   body: folded `## Spec` / `## Slicing`, acceptance criteria, and the
+   `story-plan-state` / `risk-verdict` structured comments when present.
+4. Read that Spec fully to understand the intended scope, architectural
+   decisions, and acceptance criteria. Do **not** look for a parent Epic.
 
 ## Step 1 — Automated Audit (Pre-Review)
 
@@ -142,18 +141,15 @@ A diff that matches no local lens adds **no** lens work (the roster is empty and
 or materialization failure degrades to a skipped envelope and never blocks the
 close.
 
-Both close entry points —
-[`runStoryCodeReview`](../../scripts/lib/orchestration/story-close/phases/code-review.js)
-(Epic-attached) and
+The live close entry point —
 [`runStoryScopeReview`](../../scripts/lib/orchestration/single-story-close/phases/code-review.js)
-(standalone) — reach this pass through the single `runStoryReviewCore` spine, so
-standalone Stories gain local-lens coverage for the first time. Because the pass
-lives inside the close subprocess (invoked after the delivering child exits), it
-honors the maker-blind invariant above: a maker never runs its own local-lens
-review. This step does not apply to `scope: epic`, whose lens roster is the
-cumulative + global + risk-routed set resolved at Epic close (Step 1b).
+— reaches this pass through the shared `runStoryReviewCore` spine. Because
+the pass lives inside the close subprocess (invoked after the delivering
+child exits), it honors the maker-blind invariant above: a maker never runs
+its own local-lens review. This step does not apply to legacy `scope: epic`
+(Step 1b).
 
-### Step 1b — Epic-close lens roster (`scope: epic` only, Epic #4405)
+### Step 1b — Legacy Epic-close lens roster (`scope: epic` only; not on `/deliver`)
 
 When `scope === 'epic'`, the cumulative Epic diff is walked **once** at close:
 the Epic-close lens roster is executed as **dimensions of this same review
@@ -205,12 +201,11 @@ never reduced to a scan.
 
 ### Pillar 1: Spec Adherence
 
-Does the implementation match the Epic's requirements and Tech Spec architecture?
+Does the implementation match the Story's acceptance criteria and folded Spec?
 
-- Compare each completed Story/Task against its stated acceptance criteria.
+- Compare the completed Story against its stated acceptance criteria.
 - Flag any undocumented deviations, missing features, or scope creep.
-- Verify API contracts, data models, and interface boundaries match the Tech
-  Spec.
+- Verify API contracts, data models, and interface boundaries match the Spec.
 
 ### Pillar 2: Integration Review
 
@@ -574,7 +569,7 @@ to the next phase of the parent workflow.
   the scope is set by the caller, and reviewing against the wrong base
   produces either a hollow review (too small a diff) or noise (too large a
   diff that includes unrelated history).
-- **Always** read the Epic body and Tech Spec before reviewing code. Findings without
+- **Always** read the Story body and folded Spec before reviewing code. Findings without
   spec context are noise.
 - **Never** implement fixes unless the operator explicitly requests it. The
   default mode is read-only audit.

--- a/.agents/workflows/helpers/diagnose.md
+++ b/.agents/workflows/helpers/diagnose.md
@@ -9,7 +9,7 @@ description: >-
 
 > **Helper, not a slash command.** Files under `workflows/helpers/` are not
 > projected into the mandrel plugin command tree. The same `lib/checks/` registry runs
-> automatically as preflight inside `/deliver`, `/story-close`, and
+> automatically as preflight inside `/deliver`, `single-story-close`, and
 > `npm test` — this viewer exists only for ad-hoc inspection. Invoke the
 > backing script directly: `node .agents/scripts/diagnose.js [args]`.
 
@@ -18,8 +18,8 @@ description: >-
 `diagnose.js` runs the checks registry assembled under
 `.agents/scripts/lib/checks/` in read-only mode and surfaces every
 finding declared on the requested scope. It is the operator-facing read
-of the same registry that preflight guards (`epic-deliver`,
-`story-close`), the retro hook, and `npm test` consult — but with
+of the same registry that preflight guards (`/deliver`,
+`single-story-close`), the retro hook, and `npm test` consult — but with
 `autoFix: false` always, no remote GitHub writes, and no commits.
 
 It is distinct from `diagnose-friction.js` (the per-Task signal capture
@@ -37,7 +37,7 @@ node .agents/scripts/diagnose.js [--scope <scope>] [--fail-on-blocker] [--json]
 
 | Flag                 | Default      | Description                                                                                                                                                                                                          |
 | -------------------- | ------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `--scope <s>`        | `diagnose`   | Filter checks by declared scope. Use `all` to disable the filter and run every registered check. Other surface scopes (`epic-deliver`, `story-close`, `retro`) are accepted verbatim — checks whose `scope[]` includes the value will fire. |
+| `--scope <s>`        | `diagnose`   | Filter checks by declared scope. Use `all` to disable the filter and run every registered check. Other surface scopes (`deliver`, `single-story-close`, `retro`) are accepted verbatim — checks whose `scope[]` includes the value will fire. |
 | `--fail-on-blocker`  | off          | Exit `2` when at least one finding has `severity === 'blocker'`. Without this flag the command always exits `0` even when blockers are present (it is by default an advisory read).                              |
 | `--json`             | off          | Emit a single line of JSON shaped as `{ scope, findings: [...] }` to stdout in place of the human table. Findings preserve the registry's `Finding` shape (id, severity, scope, summary, fixCommand, detail?, autoCorrectable). |
 
@@ -59,7 +59,7 @@ node .agents/scripts/diagnose.js
 node .agents/scripts/diagnose.js --scope all --json
 
 # Use inside a preflight script that should block on a blocker.
-node .agents/scripts/diagnose.js --scope story-close --fail-on-blocker
+node .agents/scripts/diagnose.js --scope single-story-close --fail-on-blocker
 ```
 
 ## Output shape

--- a/.agents/workflows/helpers/signals.md
+++ b/.agents/workflows/helpers/signals.md
@@ -1,7 +1,7 @@
 ---
 description: >-
   Helper doc for the signals-view.js debug viewer. Renders the signals
-  span-tree for an Epic (and optionally a single Story) to the terminal.
+  span-tree for a run (and optionally a single Story) to the terminal.
   Read-only over `lib/signals/` — no remote writes, no state mutation, no
   auto-fixes. Dumb-terminal-safe (`console.log` only). Not a slash command —
   invoke the script directly when needed.
@@ -14,7 +14,7 @@ description: >-
 > (`lib/signals/`, writer, schema, detectors, NDJSON listeners) runs as
 > part of the normal `/deliver` machinery — this viewer is for
 > ad-hoc debugging when you need to inspect the span-tree directly.
-> Invoke the backing script: `node .agents/scripts/signals-view.js <epic-id> [--story <id>]`.
+> Invoke the backing script: `node .agents/scripts/signals-view.js <run-id> [--story <id>]`.
 
 ## Overview
 
@@ -42,8 +42,8 @@ node .agents/scripts/signals-view.js <run-id> [--story <id>]
 
 | Argument         | Required | Description                                                                                                                            |
 | ---------------- | -------- | -------------------------------------------------------------------------------------------------------------------------------------- |
-| `<epic-id>`      | yes      | Positive integer Epic ID. The viewer resolves `temp/epic-<id>/` under the configured `project.paths.tempRoot`.                  |
-| `--story <id>`   | no       | Positive integer Story ID. When set, the printed tree is narrowed to a single Story subtree under the Epic.                            |
+| `<run-id>`       | yes      | Positive integer run ID. The viewer resolves `temp/run-<id>/` under the configured `project.paths.tempRoot`.                         |
+| `--story <id>`   | no       | Positive integer Story ID. When set, the printed tree is narrowed to a single Story subtree under the run.                            |
 
 ## Flags (test-only)
 
@@ -55,13 +55,13 @@ node .agents/scripts/signals-view.js <run-id> [--story <id>]
 
 | Code | Meaning                                                                                       |
 | ---- | --------------------------------------------------------------------------------------------- |
-| `0`  | Happy path **or** missing signals file. The missing-file path prints a friendly message ("No signals found for Epic #N"), never a stack trace. |
-| `1`  | Bad arguments (non-integer `<epic-id>`, missing positional, malformed `--story`).             |
+| `0`  | Happy path **or** missing signals file. The missing-file path prints a friendly message ("No signals found for run #N"), never a stack trace. |
+| `1`  | Bad arguments (non-integer `<run-id>`, missing positional, malformed `--story`).              |
 
 ## Examples
 
 ```bash
-# Render every Story under Epic #1181.
+# Render every Story under run #1181.
 node .agents/scripts/signals-view.js 1181
 
 # Narrow to a single Story subtree.
@@ -69,15 +69,15 @@ node .agents/scripts/signals-view.js 1181 --story 1438
 
 # No signals yet — friendly message, exit 0.
 node .agents/scripts/signals-view.js 9999
-# → No signals found for Epic #9999.
+# → No signals found for run #9999.
 ```
 
 ## Phase steps
 
-1. Parse `<epic-id>` and optional `--story <id>` from the slash-command
+1. Parse `<run-id>` and optional `--story <id>` from the CLI
    arguments. Reject non-integer or non-positive inputs with exit 1 and
    the canonical usage line.
-2. Invoke `node .agents/scripts/signals-view.js <epic-id> [--story <id>]`
+2. Invoke `node .agents/scripts/signals-view.js <run-id> [--story <id>]`
    from the operator's working directory. The script resolves
    `tempRoot` from the project's `.agentrc.json` (or the framework
    default `'temp'`).

--- a/.agents/workflows/helpers/worktree-lifecycle.md
+++ b/.agents/workflows/helpers/worktree-lifecycle.md
@@ -7,16 +7,15 @@ description: >-
 
 # Worktree-per-Story Lifecycle
 
-Parallel epic execution can race when multiple story agents share one working
+Parallel Story delivery can race when multiple agents share one working
 tree: rapid `git checkout` swaps cause `git add` to sweep another agent's WIP
-into the wrong commit. Epic #229 moves each dispatched story into its own
-`git worktree` at `.worktrees/story-<id>/` so branch swaps, staging, and reflog
-activity are isolated per-story. The main checkout stays quiet.
+into the wrong commit. Each Story runs in its own `git worktree` at
+`.worktrees/story-<id>/` so branch swaps, staging, and reflog activity are
+isolated per-Story. The main checkout stays quiet.
 
 This document is the operator and reviewer reference. See
 [`/deliver`](../deliver.md) and [`helpers/deliver-story`](deliver-story.md)
-for the broader execution flow and the Epic-229 Tech Spec for architectural
-rationale.
+for the broader execution flow.
 
 ## Configuration
 
@@ -47,20 +46,20 @@ are all rejected at config-load time.
 
 | Phase           | When                                                                          | What happens                                                                                                                                                |
 | --------------- | ----------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Sweep**       | Dispatch-manifest build (`/plan`) and `/deliver` | Stale `*.lock` files under `.git/` (older than 5 min) are removed before GC.                                                                                |
-| **GC**          | Dispatch-manifest build (`/plan`) and `/deliver` | Orphan `.worktrees/story-*` whose stories are closed are reaped if clean.                                                                                   |
-| **Force-drain** | `/plan` boot (`worktree-sweep.js` via `drainPendingCleanupAtBoot`), `story-close` post-merge (`forceDrainPendingCleanup`), `/deliver` Phase 7 | Retries `.worktrees/.pending-cleanup.json` (`git worktree remove` then `fs.rm`); Windows-only escalation enumerates user-mode handle holders and `taskkill`s them before re-trying. |
-| **Ensure**      | `story-init` (entry for `/deliver`)                  | `git worktree add .worktrees/story-<id>/` on the `story-<id>` branch.                                                                                       |
-| **Run**         | During story execution                                                        | Agent runs inside the worktree; HEAD/reflog activity is isolated.                                                                                           |
-| **Reap**        | After successful story merge (in `story-close`)                              | `git worktree remove` — refuses to delete dirty trees or unmerged branches.                                                                                 |
+| **Sweep**       | `/deliver` boot / Story init                                                  | Stale `*.lock` files under `.git/` (older than 5 min) are removed before GC.                                                                                |
+| **GC**          | `/deliver` boot / Story init                                                  | Orphan `.worktrees/story-*` whose Stories are closed are reaped if clean.                                                                                   |
+| **Force-drain** | `/deliver` boot (`worktree-sweep.js` via `drainPendingCleanupAtBoot`), `single-story-close` post-merge | Retries `.worktrees/.pending-cleanup.json` (`git worktree remove` then `fs.rm`); Windows-only escalation enumerates user-mode handle holders and `taskkill`s them before re-trying. |
+| **Ensure**      | `single-story-init.js` (entry for `/deliver`)                                 | `git worktree add .worktrees/story-<id>/` on the `story-<id>` branch.                                                                                       |
+| **Run**         | During Story execution                                                        | Agent runs inside the worktree; HEAD/reflog activity is isolated.                                                                                           |
+| **Reap**        | After successful Story merge (in `single-story-close`)                        | `git worktree remove` — refuses to delete dirty trees or unmerged branches.                                                                                 |
 
 The `WorktreeManager` (`.agents/scripts/lib/worktree-manager.js`) is the single
 authority for `ensure`, `reap`, `list`, `isSafeToRemove`, `gc`, `prune`, and
 `sweepStaleLocks`. No other script may call `git worktree` directly.
 
-Managed story worktrees are only eligible for `reap`/`gc` when the caller
-provides the expected Epic branch, so cleanup cannot silently skip the merge
-verification step.
+Managed Story worktrees are only eligible for `reap`/`gc` when the Story is
+merged (or otherwise confirmed closed) so cleanup cannot silently drop an
+unlanded branch.
 
 ### Stale-lock sweep
 

--- a/tests/lib/orchestration/plan-persist-story-ops.test.js
+++ b/tests/lib/orchestration/plan-persist-story-ops.test.js
@@ -17,7 +17,10 @@ import {
   planRunLabel,
 } from '../../../.agents/scripts/lib/orchestration/plan-persist/story-ops.js';
 import { DEFAULT_SPEC_BODY_TOKEN_BUDGET } from '../../../.agents/scripts/lib/orchestration/spec-spill.js';
-import { serialize } from '../../../.agents/scripts/lib/story-body/story-body.js';
+import {
+  parse,
+  serialize,
+} from '../../../.agents/scripts/lib/story-body/story-body.js';
 
 function storyTicket(slug, overrides = {}) {
   return {
@@ -52,6 +55,16 @@ describe('normalizeStoryTicket', () => {
     assert.equal(n.slug, 'alpha');
     assert.equal(n.bodyObject.goal, 'Goal of alpha.');
     assert.deepEqual(n.bodyObject.acceptance, ['alpha works']);
+  });
+
+  it('rejects disagreement between top-level and body contracts', () => {
+    assert.throws(
+      () =>
+        normalizeStoryTicket(
+          storyTicket('alpha', { acceptance: ['different contract'] }),
+        ),
+      /mismatched top-level and body acceptance/,
+    );
   });
 });
 
@@ -146,5 +159,51 @@ describe('createStoryIssues', () => {
     assert.ok(calls[0].labels.includes(TYPE_LABELS.STORY));
     assert.ok(calls[0].labels.includes(AGENT_LABELS.READY));
     assert.ok(calls[0].labels.includes(label));
+  });
+
+  it('creates dependencies first and persists numeric blocked-by edges', async () => {
+    const calls = [];
+    const provider = {
+      createIssue: async (payload) => {
+        calls.push(payload);
+        return { id: 200 + calls.length };
+      },
+    };
+    const { stories } = assemblePlanStories(
+      [
+        storyTicket('consumer', { depends_on: ['migration'] }),
+        storyTicket('migration'),
+      ],
+      { write: false },
+    );
+    const { created } = await createStoryIssues({
+      provider,
+      stories,
+      opts: { planRunId: 'ordered' },
+    });
+    assert.deepEqual(
+      created.map((story) => story.slug),
+      ['migration', 'consumer'],
+    );
+    assert.deepEqual(parse(calls[1].body).body.depends_on, ['#201']);
+  });
+
+  it('rejects unknown dependencies before any issue write', async () => {
+    let writes = 0;
+    const provider = {
+      createIssue: async () => {
+        writes += 1;
+        return { id: 1 };
+      },
+    };
+    const { stories } = assemblePlanStories(
+      [storyTicket('consumer', { depends_on: ['missing'] })],
+      { write: false },
+    );
+    await assert.rejects(
+      () => createStoryIssues({ provider, stories }),
+      /unknown sibling/,
+    );
+    assert.equal(writes, 0);
   });
 });

--- a/tests/lib/orchestration/run-epilogue.test.js
+++ b/tests/lib/orchestration/run-epilogue.test.js
@@ -56,6 +56,15 @@ describe('planRunEpilogue — applicable (N>1)', () => {
     assert.deepEqual(plan.stories, ['s1', 's2', 's3']);
   });
 
+  it('accepts numeric Story ids from resolve-plan-run envelopes', () => {
+    const plan = planRunEpilogue({
+      planRunId: 'run-8',
+      stories: [{ id: 101 }, { id: 102 }, 103],
+    });
+    assert.equal(plan.applicable, true);
+    assert.deepEqual(plan.stories, ['101', '102', '103']);
+  });
+
   it('is pure — no side effects, deterministic output', () => {
     const args = { planRunId: 'run-9', stories: ['a', 'b'] };
     assert.deepEqual(planRunEpilogue(args), planRunEpilogue(args));

--- a/tests/lib/orchestration/story-plan-state.test.js
+++ b/tests/lib/orchestration/story-plan-state.test.js
@@ -1,0 +1,53 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import {
+  readStoryPlanningRisk,
+  readStoryPlanningRiskSafe,
+  resolveStoryPlanningRisk,
+} from '../../../.agents/scripts/lib/orchestration/story-plan-state.js';
+
+describe('Story planning state', () => {
+  it('reads planningRisk from the Story checkpoint', async () => {
+    const planningRisk = { overallLevel: 'high', axes: [] };
+    const result = await readStoryPlanningRisk({
+      provider: {},
+      storyId: 17,
+      findCommentFn: async () => ({
+        body: [
+          '<!-- ap:structured-comment type="story-plan-state" -->',
+          '### story-plan-state',
+          '',
+          '```json',
+          JSON.stringify({ version: 2, storyId: 17, planningRisk }),
+          '```',
+        ].join('\n'),
+      }),
+    });
+    assert.deepEqual(result, planningRisk);
+  });
+
+  it('degrades provider failures to neutral risk', async () => {
+    const result = await readStoryPlanningRiskSafe({
+      provider: {},
+      storyId: 17,
+      findCommentFn: async () => {
+        throw new Error('network');
+      },
+    });
+    assert.equal(result, null);
+  });
+
+  it('prefers an explicit planningRisk override', async () => {
+    const override = { overallLevel: 'medium', axes: [] };
+    const result = await resolveStoryPlanningRisk({
+      provider: {},
+      storyId: 17,
+      planningRisk: override,
+      findCommentFn: async () => {
+        throw new Error('must not read when override is set');
+      },
+    });
+    assert.deepEqual(result, override);
+  });
+});

--- a/tests/lib/story-body/story-body.test.js
+++ b/tests/lib/story-body/story-body.test.js
@@ -805,6 +805,40 @@ Use the existing widget repository seam.
     assert.equal(serialize(reparsed), serialize(body));
   });
 
+  it('preserves nested headings and interior blank lines inside the folded spec', () => {
+    const markdown = `## Goal
+Ship the widget.
+
+## Spec
+Overview paragraph.
+
+## Architecture
+Use the existing repository.
+
+### Risks
+- Migration ordering.
+
+## Acceptance
+- [ ] widget ships
+
+## Verify
+- npm test (unit)`;
+    const { body } = parse(markdown);
+    assert.equal(
+      body.spec,
+      [
+        'Overview paragraph.',
+        '',
+        '## Architecture',
+        'Use the existing repository.',
+        '',
+        '### Risks',
+        '- Migration ordering.',
+      ].join('\n'),
+    );
+    assert.deepEqual(body.acceptance, ['widget ships']);
+  });
+
   it('structured-object parse preserves an inline spec string', () => {
     const { body, info } = parse({
       goal: 'g',

--- a/tests/scripts/plan-persist.flat-stories.test.js
+++ b/tests/scripts/plan-persist.flat-stories.test.js
@@ -187,6 +187,12 @@ describe('runPlanPersist — flat Story ops', () => {
     for (const s of result.stories) {
       const issue = provider.issues.get(s.id);
       assert.ok(issue.labels.includes('plan-run::stage3'));
+      const storyComments = provider.comments
+        .filter((comment) => comment.issueNumber === s.id)
+        .map((comment) => comment.body)
+        .join('\n');
+      assert.match(storyComments, /risk-verdict/);
+      assert.match(storyComments, /story-plan-state/);
     }
   });
 });

--- a/tests/scripts/plan-persist.flat-stories.test.js
+++ b/tests/scripts/plan-persist.flat-stories.test.js
@@ -124,6 +124,50 @@ describe('runPlanPersist — flat Story ops', () => {
     );
   });
 
+  it('rejects hard model-capacity findings before issue creation', async () => {
+    const provider = fakeProvider();
+    const oversized = ticket('oversized');
+    oversized.acceptance = Array.from(
+      { length: 20 },
+      (_, index) => `criterion ${index}`,
+    );
+    oversized.body = serialize({
+      goal: 'A cohesive but oversized session.',
+      changes: [
+        {
+          path: 'tests/scripts/plan-persist.flat-stories.test.js',
+          assumption: 'refactors-existing',
+        },
+      ],
+      acceptance: oversized.acceptance,
+      verify: oversized.verify,
+      reason_to_exist: 'Prove hard capacity is enforced',
+    });
+
+    await assert.rejects(
+      () =>
+        runPlanPersist({
+          provider,
+          artifacts: {
+            stories: [oversized],
+            riskVerdict: VERDICT,
+          },
+          config: {
+            delivery: { maxTokenBudget: 1000 },
+            planning: {
+              modelCapacity: {
+                hardSessionFraction: 0.1,
+                softSessionFraction: 0.05,
+              },
+            },
+          },
+          opts: { skipCleanup: true, writeSpill: false },
+        }),
+      /ticket validation failed.*oversized/s,
+    );
+    assert.equal(provider.issues.size, 0);
+  });
+
   it('labels N>1 Stories with a shared plan-run:: label', async () => {
     const provider = fakeProvider();
     const result = await runPlanPersist({

--- a/tests/scripts/resolve-plan-run.test.js
+++ b/tests/scripts/resolve-plan-run.test.js
@@ -1,0 +1,58 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import {
+  normalizePlanRunLabel,
+  resolvePlanRunFromIssues,
+} from '../../.agents/scripts/lib/orchestration/resolve-plan-run.js';
+import { resolvePlanRunProvider } from '../../.agents/scripts/resolve-plan-run.js';
+
+describe('resolve-plan-run provider construction', () => {
+  it('passes the resolved config to createProvider', () => {
+    const config = { github: { owner: 'o', repo: 'r' } };
+    let received;
+    const provider = { listIssuesByLabel() {} };
+    const result = resolvePlanRunProvider({
+      resolveConfigFn: () => config,
+      createProviderFn: (value) => {
+        received = value;
+        return provider;
+      },
+    });
+    assert.equal(received, config);
+    assert.equal(result, provider);
+  });
+});
+
+describe('plan-run label normalization', () => {
+  it('uses the same canonical token as plan persistence', () => {
+    assert.equal(normalizePlanRunLabel('My Run'), 'plan-run::my-run');
+    assert.equal(normalizePlanRunLabel('plan-run::My Run'), 'plan-run::my-run');
+  });
+});
+
+describe('resolvePlanRunFromIssues', () => {
+  it('retains closed Stories so resume can mark dependencies complete', () => {
+    const envelope = resolvePlanRunFromIssues({
+      run: 'resume',
+      issues: [
+        {
+          number: 10,
+          state: 'closed',
+          title: 'Migration',
+          labels: ['type::story', 'agent::done'],
+          body: '## Goal\nDone',
+        },
+        {
+          number: 11,
+          state: 'open',
+          title: 'Consumer',
+          labels: ['type::story', 'agent::ready'],
+          body: '## Goal\nUse it\n\n---\nblocked by #10',
+        },
+      ],
+    });
+    assert.equal(envelope.stories[0].state, 'closed');
+    assert.deepEqual(envelope.done, [10]);
+    assert.deepEqual(envelope.dag[1], { id: 11, dependsOn: [10] });
+  });
+});

--- a/tests/scripts/resolve-plan-run.test.js
+++ b/tests/scripts/resolve-plan-run.test.js
@@ -28,6 +28,10 @@ describe('plan-run label normalization', () => {
     assert.equal(normalizePlanRunLabel('My Run'), 'plan-run::my-run');
     assert.equal(normalizePlanRunLabel('plan-run::My Run'), 'plan-run::my-run');
   });
+
+  it('rejects an empty run token', () => {
+    assert.throws(() => normalizePlanRunLabel('  '), /non-empty planRunId/);
+  });
 });
 
 describe('resolvePlanRunFromIssues', () => {

--- a/tests/scripts/single-story-init-remote.test.js
+++ b/tests/scripts/single-story-init-remote.test.js
@@ -1,0 +1,55 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import { handleRemoteVerificationFailure } from '../../.agents/scripts/single-story-init.js';
+
+describe('single-story-init remote verification', () => {
+  it('blocks the Story and throws before delivery mutation', async () => {
+    const updates = [];
+    const comments = [];
+    const provider = {
+      async getTicketComments() {
+        return [];
+      },
+      async postComment(storyId, payload) {
+        comments.push({ storyId, body: payload.body });
+        return { id: 1 };
+      },
+      async deleteComment() {},
+      async updateTicket(storyId, payload) {
+        updates.push({ storyId, payload });
+      },
+    };
+
+    await assert.rejects(
+      () =>
+        handleRemoteVerificationFailure({
+          provider,
+          storyId: 42,
+          remote: {
+            remoteVerified: false,
+            detail: 'origin is unreachable',
+          },
+        }),
+      /remote verification failed/,
+    );
+    assert.deepEqual(updates[0], {
+      storyId: 42,
+      payload: {
+        labels: {
+          add: ['agent::blocked'],
+          remove: ['agent::ready', 'agent::executing'],
+        },
+      },
+    });
+    assert.match(comments[0].body, /origin is unreachable/);
+  });
+
+  it('does not mutate or throw for a verified remote', async () => {
+    await handleRemoteVerificationFailure({
+      provider: null,
+      storyId: 42,
+      remote: { remoteVerified: true },
+    });
+  });
+});

--- a/tests/signals-view.test.js
+++ b/tests/signals-view.test.js
@@ -4,7 +4,7 @@
  *
  * AC coverage (per Task ticket #1464):
  *   1. Happy path: a checked-in (synthesised in `beforeEach`) signals
- *      stream renders an Epic → Story → Task tree to stdout.
+ *      stream renders a run → Story tree to stdout.
  *   2. Missing-file friendly message: when no signals.ndjson exists, the
  *      viewer prints a friendly "no signals found" line and exits 0
  *      (NOT a stack trace).
@@ -76,26 +76,26 @@ async function writeSignalsFile(rootDir, epic, story, events) {
 }
 
 describe('signals-view — argument parsing', () => {
-  it('rejects missing epic-id', () => {
+  it('rejects missing run-id', () => {
     const r = parseArgs([]);
     assert.equal(r.ok, false);
-    assert.match(r.error, /missing <epic-id>/);
+    assert.match(r.error, /missing <run-id>/);
   });
 
-  it('rejects non-integer epic-id', () => {
+  it('rejects non-integer run-id', () => {
     const r = parseArgs(['abc']);
     assert.equal(r.ok, false);
-    assert.match(r.error, /<epic-id>/);
+    assert.match(r.error, /<run-id>/);
   });
 
-  it('rejects negative or zero epic-id', () => {
+  it('rejects negative or zero run-id', () => {
     const r1 = parseArgs(['0']);
     const r2 = parseArgs(['-7']);
     assert.equal(r1.ok, false);
     assert.equal(r2.ok, false);
   });
 
-  it('accepts positive epic-id alone', () => {
+  it('accepts positive run-id alone', () => {
     const r = parseArgs(['1181']);
     assert.deepEqual(r, { ok: true, epic: 1181, story: null, tempRoot: null });
   });
@@ -152,7 +152,7 @@ describe('signals-view — happy path', () => {
     }
     const out = cap.output();
     assert.equal(exitCode, 0);
-    assert.match(out, /Epic #1181/);
+    assert.match(out, /Run #1181/);
     assert.match(out, /Story #1438/);
     // Duration is computed from wave-start → wave-end (60s).
     assert.match(out, /1m0\.0s/);
@@ -207,7 +207,7 @@ describe('signals-view — missing-file friendly message', () => {
     );
     assert.match(
       out,
-      /No signals found for Epic #9999/,
+      /No signals found for run #9999/,
       `expected friendly missing-file message; got:\n${out}`,
     );
     // Negative control: never a stack trace.
@@ -233,7 +233,7 @@ describe('signals-view — missing-file friendly message', () => {
       cap.restore();
     }
     assert.equal(exitCode, 0);
-    assert.match(cap.output(), /No signals found for Epic #9999 \(Story #2\)/);
+    assert.match(cap.output(), /No signals found for run #9999 \(Story #2\)/);
   });
 });
 
@@ -295,7 +295,7 @@ describe('signals-view — tempRoot honour (memory: phase_timings_uses_project_r
         cap.restore();
       }
       assert.equal(exitCode, 0);
-      assert.match(cap.output(), /No signals found for Epic #1181/);
+      assert.match(cap.output(), /No signals found for run #1181/);
     } finally {
       rmSync(otherRoot, { recursive: true, force: true });
     }

--- a/tests/single-story-close-review.test.js
+++ b/tests/single-story-close-review.test.js
@@ -263,6 +263,72 @@ describe('runStoryScopeReview (direct)', () => {
     assert.match(recorder.postedComments[0].payload.body, /critical:2/);
   });
 
+  it('forwards Story planning risk into review depth resolution', async () => {
+    const { runStoryScopeReview } = await import(SUT_URL);
+    const recorder = fakeProviderRecorder();
+    let seenRisk = null;
+    await runStoryScopeReview({
+      cwd: '/repo',
+      storyId: 2839,
+      storyBranch: 'story-2839',
+      baseBranch: 'main',
+      prUrl: 'https://github.com/owner/repo/pull/123',
+      prNumber: 123,
+      provider: recorder.provider,
+      planningRisk: { overallLevel: 'high', axes: [] },
+      runCodeReviewFn: async (opts) => {
+        seenRisk = opts.planningRisk;
+        return {
+          severity: { critical: 0, high: 0, medium: 0, suggestion: 0 },
+          posted: false,
+          halted: false,
+        };
+      },
+      runLocalLensReviewFn: async () => ({ skipped: true }),
+      progress: () => {},
+    });
+    assert.deepEqual(seenRisk, { overallLevel: 'high', axes: [] });
+  });
+
+  it('loads planningRisk from story-plan-state when omitted', async () => {
+    const { runStoryScopeReview } = await import(SUT_URL);
+    const planningRisk = { overallLevel: 'high', axes: [] };
+    const recorder = fakeProviderRecorder();
+    recorder.provider.getTicketComments = async () => [
+      {
+        body: [
+          '<!-- ap:structured-comment type="story-plan-state" -->',
+          '### story-plan-state',
+          '',
+          '```json',
+          JSON.stringify({ version: 2, storyId: 2839, planningRisk }),
+          '```',
+        ].join('\n'),
+      },
+    ];
+    let seenRisk = null;
+    await runStoryScopeReview({
+      cwd: '/repo',
+      storyId: 2839,
+      storyBranch: 'story-2839',
+      baseBranch: 'main',
+      prUrl: 'https://github.com/owner/repo/pull/123',
+      prNumber: 123,
+      provider: recorder.provider,
+      runCodeReviewFn: async (opts) => {
+        seenRisk = opts.planningRisk;
+        return {
+          severity: { critical: 0, high: 0, medium: 0, suggestion: 0 },
+          posted: false,
+          halted: false,
+        };
+      },
+      runLocalLensReviewFn: async () => ({ skipped: true }),
+      progress: () => {},
+    });
+    assert.deepEqual(seenRisk, planningRisk);
+  });
+
   it('skips when prNumber is null', async () => {
     const { runStoryScopeReview } = await import(SUT_URL);
     const recorder = fakeProviderRecorder();

--- a/tests/single-story-close-review.test.js
+++ b/tests/single-story-close-review.test.js
@@ -90,9 +90,11 @@ function makeFakeGh(handler) {
 
 function fakeProviderRecorder() {
   const postedComments = [];
+  const updates = [];
   let nextId = 5000;
   return {
     postedComments,
+    updates,
     provider: {
       getTicket: async () => ({
         id: 2839,
@@ -100,7 +102,9 @@ function fakeProviderRecorder() {
         title: 'Story scope review test',
         labels: ['agent::executing'],
       }),
-      updateTicket: async () => {},
+      updateTicket: async (ticketId, payload) => {
+        updates.push({ ticketId, payload });
+      },
       postComment: async (ticketId, payload) => {
         const id = nextId++;
         postedComments.push({ ticketId, payload, id });
@@ -363,6 +367,19 @@ describe('runSingleStoryClose review-halt orchestration', () => {
       ghCalls.find((c) => c[1] === 'merge'),
       undefined,
       'auto-merge gh call must be skipped on review halt',
+    );
+    assert.deepEqual(recorder.updates.at(-1), {
+      ticketId: 2839,
+      payload: {
+        labels: {
+          add: ['agent::blocked'],
+          remove: ['agent::executing', 'agent::ready'],
+        },
+      },
+    });
+    assert.match(
+      recorder.postedComments.at(-1).payload.body,
+      /Code review blocked delivery/,
     );
   });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Hardens the v2 Story-only `/plan` and `/deliver` paths after Stages 4–6 landed on `v2`. Fixes objective gaps found in a roadmap + prior-era behavior review, retargets agent-facing docs that still taught Epic-parent flows, and leaves product-level cutover choices for explicit decision.

**Base:** `v2` only (does **not** merge to `main`).

## Fixes landed

### Plan
- Restore plan-run resolution (provider config, label normalization, resume `done`, epilogue numeric IDs)
- Enforce hard ticket validation before persist; topo-create Stories with `#id` `depends_on` edges
- Preserve nested headings in folded `## Spec` / `## Slicing`
- Stamp `risk-verdict` + `story-plan-state` on **every** Story in a plan-run (not only primary)

### Deliver
- Fail closed when `origin` is unavailable during Story init remote verify
- Block Stories on critical review findings (`agent::blocked` + friction)
- Load per-Story `planningRisk` into Story-scope review depth when omitted by the caller

### Docs / residue
- Retarget `helpers/code-review.md` + `worktree-lifecycle.md` to Story → `main` / `single-story-close`
- Point CLI `@see` links at `deliver-story.md`; mark unwired `plan-persist/amend.js` as dead
- Clean signals / diagnose / analyze-execution / README Epic-path residue (`temp/run-<id>/`)

## Product decisions needed

These are intentionally **not** guessed in this PR:

| # | Decision | Option A | Option B | Tradeoff |
|---|----------|----------|----------|----------|
| 1 | Spec spill durability | Keep inline fold/spill in Story body / temp | Commit spilled specs under `docs/specs/` in the Story worktree | A is simpler; B survives temp cleanup and is reviewable in the PR |
| 2 | Run epilogue | Implement executable `planRunEpilogue` steps | Document as host-only ceremony; require `--run` for N>1 | A restores audits/retro automation; B avoids shipping inert scaffolding as if live |
| 3 | Risk-routed critics / audit lenses | Blocking gates from `planningRisk` | Advisory only (log + comment) | A preserves epic-era quality pressure; B avoids false blocks on missing checkpoints |
| 4 | Epic surface retirement | Hard-delete `--epic` CLIs, epic-plan skills, `delivery.preflight` / `ci.earlyPr`, epic-audit prepare | Soft-deprecate (keep files, docs say unused) | A shrinks the product surface; B keeps migration escape hatches |
| 5 | CLI rename | Rename `single-story-*` → `story-*` | Keep `single-story-*` names | A matches v2 vocabulary; B avoids churn for consumers/tests |
| 6 | `slice.*` lifecycle | Keep for large-Story slicing | Retire with Epic machinery | A useful for oversized Stories; B simplifies lifecycle schemas |

## Test plan

- [x] `npm run test:quick` (local, green after risk-stamp + docs commits)
- [x] Focused suites: plan-persist flat stories, story-plan-state, single-story-close-review, signals-view
- [ ] CI on PR #4518
- [ ] Human pick on the six decisions above before any hard-delete / epilogue implementation follow-up

## Out of scope

- Merge `v2` → `main`
- Hard-delete of Epic CLIs / skills / config keys
- Implementing live run-epilogue executors
- Renaming `single-story-*` CLIs
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8acdd460-eb42-4733-9eef-51a4cfd8adb2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8acdd460-eb42-4733-9eef-51a4cfd8adb2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

