### PR TITLE
fix(quality): retire the unconsumed miDropMustRefactor/miDropCap knobs and make maintainability.tolerance the single MI-drop control (#4531)

### DIFF
--- a/.agents/docs/agentrc-reference.json
+++ b/.agents/docs/agentrc-reference.json
@@ -336,12 +336,10 @@
       "codingGuardrails": {
         "cyclomaticFlag": 8,
         "cyclomaticMustFix": 12,
-        "miDropMustRefactor": 1.5,
         "requireSiblingTest": false
       },
       "autoRefresh": {
         "enabled": true,
-        "miDropCap": 1.5,
         "crapJumpCap": 5,
         "scope": "diff"
       },

--- a/.agents/docs/configuration.md
+++ b/.agents/docs/configuration.md
@@ -235,11 +235,9 @@ top-level keys are validation errors.
 | `quality.codingGuardrails` | No | `object` | — | Nested configuration block. |
 | `quality.codingGuardrails.cyclomaticFlag` | No | `integer` | — | — |
 | `quality.codingGuardrails.cyclomaticMustFix` | No | `integer` | — | — |
-| `quality.codingGuardrails.miDropMustRefactor` | No | `number` | — | — |
 | `quality.codingGuardrails.requireSiblingTest` | No | `boolean` | — | — |
 | `quality.autoRefresh` | No | `object` | — | Nested configuration block. |
 | `quality.autoRefresh.enabled` | No | `boolean` | — | — |
-| `quality.autoRefresh.miDropCap` | No | `number` | — | — |
 | `quality.autoRefresh.crapJumpCap` | No | `number` | — | — |
 | `quality.autoRefresh.scope` | No | `"diff"` \| `"full"` | — | — |
 | `quality.baselineEpsilon` | No | `object` | — | Per-kind epsilon for s-stability-epsilon (Story #1964). Sub-epsilon row deltas resolve to prior bytes so env variance does not rewrite the on-disk baseline. |
@@ -666,7 +664,6 @@ for `BUNDLE_SIZE_REFRESH=1` usage.
 | ---------------------- | -------- | ------- | ------------------------------------------------------------------ |
 | `cyclomaticFlag`       | No       | (none)  | Cyclomatic-complexity value at which the engineer should refactor.  |
 | `cyclomaticMustFix`    | No       | (none)  | Cyclomatic-complexity value that hard-fails the gate.               |
-| `miDropMustRefactor`   | No       | (none)  | MI drop that mandates a refactor.                                   |
 | `requireSiblingTest`   | No       | (none)  | When `true`, a new function requires a sibling test file.           |
 
 #### `delivery.quality.autoRefresh`
@@ -676,7 +673,6 @@ Controls Story-close auto-baseline-refresh for gated metrics.
 | Field         | Required | Default | Purpose                                                  |
 | ------------- | -------- | ------- | -------------------------------------------------------- |
 | `enabled`     | No       | (none)  | Master switch.                                           |
-| `miDropCap`   | No       | (none)  | Max MI drop the auto-refresher will absorb before failing. |
 | `crapJumpCap` | No       | (none)  | Max CRAP jump the auto-refresher will absorb before failing. |
 | `scope`       | No       | (none)  | One of `'diff'` or `'full'`.                              |
 

--- a/.agents/schemas/agentrc.schema.json
+++ b/.agents/schemas/agentrc.schema.json
@@ -1076,10 +1076,6 @@
           "type": "integer",
           "minimum": 1
         },
-        "miDropMustRefactor": {
-          "type": "number",
-          "minimum": 0
-        },
         "requireSiblingTest": {
           "type": "boolean"
         }
@@ -1091,10 +1087,6 @@
       "properties": {
         "enabled": {
           "type": "boolean"
-        },
-        "miDropCap": {
-          "type": "number",
-          "minimum": 0
         },
         "crapJumpCap": {
           "type": "number",

--- a/.agents/scripts/lib/bootstrap/quality-bootstrap.js
+++ b/.agents/scripts/lib/bootstrap/quality-bootstrap.js
@@ -76,12 +76,10 @@ export const QUALITY_CONFIG_DEFAULTS = Object.freeze({
   codingGuardrails: Object.freeze({
     cyclomaticFlag: 8,
     cyclomaticMustFix: 12,
-    miDropMustRefactor: 1.5,
     requireSiblingTest: false,
   }),
   autoRefresh: Object.freeze({
     enabled: true,
-    miDropCap: 1.5,
     crapJumpCap: 5,
     scope: 'diff',
   }),

--- a/.agents/scripts/lib/config-settings-schema-quality.js
+++ b/.agents/scripts/lib/config-settings-schema-quality.js
@@ -14,12 +14,20 @@
 // aggregate into per-gate files under `config/gates/`.
 import { GATES_SCHEMA } from './config/gates/index.js';
 
+// Story #4531: miDropMustRefactor (here) and autoRefresh.miDropCap (below)
+// were retired. Both were schema-validated, defaulted, and resolved, but
+// never consumed by the gate they were named for — quality-preview.js's
+// computeExitCode short-circuits on miExit (derived from the ALREADY-
+// consumed delivery.quality.gates.maintainability.tolerance) before either
+// knob is ever read. maintainability.tolerance is now the single documented
+// MI-drop control. See lib/migrations/index.js for the consumer-config
+// migration that strips these keys on upgrade (additionalProperties: false
+// below means a leftover key is a hard AJV failure, not a silent no-op).
 const CODING_GUARDRAILS_SCHEMA = {
   type: 'object',
   properties: {
     cyclomaticFlag: { type: 'integer', minimum: 1 },
     cyclomaticMustFix: { type: 'integer', minimum: 1 },
-    miDropMustRefactor: { type: 'number', minimum: 0 },
     requireSiblingTest: { type: 'boolean' },
   },
   additionalProperties: false,
@@ -29,7 +37,6 @@ const AUTO_REFRESH_SCHEMA = {
   type: 'object',
   properties: {
     enabled: { type: 'boolean' },
-    miDropCap: { type: 'number', minimum: 0 },
     crapJumpCap: { type: 'number', minimum: 0 },
     scope: { type: 'string', enum: ['diff', 'full'] },
   },

--- a/.agents/scripts/lib/config/quality.js
+++ b/.agents/scripts/lib/config/quality.js
@@ -366,14 +366,19 @@ function resolveCoverageGate(userBlock) {
 }
 
 /**
- * Framework defaults for `delivery.quality.codingGuardrails`. The legacy
- * field name `miDropRefactor` was renamed to `miDropMustRefactor` in
- * Story 1 to avoid semantic collision with `autoRefresh.miDropCap`.
+ * Framework defaults for `delivery.quality.codingGuardrails`.
+ *
+ * `miDropMustRefactor` was retired in Story #4531: schema-validated,
+ * defaulted, and resolved, but never consumed — the gate it named
+ * (`quality-preview.js`'s `computeExitCode`) short-circuits on `miExit`
+ * (derived from the already-consumed `gates.maintainability.tolerance`)
+ * before this value is ever read. `maintainability.tolerance` is the one
+ * documented MI-drop control now; see `lib/migrations/index.js` for the
+ * consumer-config migration that strips a leftover key on upgrade.
  */
 export const CODING_GUARDRAILS_DEFAULTS = Object.freeze({
   cyclomaticFlag: 8,
   cyclomaticMustFix: 12,
-  miDropMustRefactor: 1.5,
   requireSiblingTest: false,
 });
 
@@ -393,8 +398,6 @@ export function resolveCodingGuardrails(userBlock) {
     cyclomaticFlag: userBlock.cyclomaticFlag ?? defaults.cyclomaticFlag,
     cyclomaticMustFix:
       userBlock.cyclomaticMustFix ?? defaults.cyclomaticMustFix,
-    miDropMustRefactor:
-      userBlock.miDropMustRefactor ?? defaults.miDropMustRefactor,
     requireSiblingTest:
       typeof userBlock.requireSiblingTest === 'boolean'
         ? userBlock.requireSiblingTest
@@ -402,9 +405,10 @@ export function resolveCodingGuardrails(userBlock) {
   };
 }
 
+// autoRefresh.miDropCap was retired alongside codingGuardrails.
+// miDropMustRefactor in Story #4531 — same unconsumed-knob shape, same fix.
 const AUTO_REFRESH_DEFAULTS = Object.freeze({
   enabled: true,
-  miDropCap: 1.5,
   crapJumpCap: 5,
   scope: 'diff',
 });
@@ -416,7 +420,6 @@ function resolveAutoRefresh(userBlock) {
   if (userBlock == null || typeof userBlock !== 'object') {
     return {
       enabled: defaults.enabled,
-      miDropCap: defaults.miDropCap,
       crapJumpCap: defaults.crapJumpCap,
       scope: defaults.scope,
     };
@@ -429,12 +432,6 @@ function resolveAutoRefresh(userBlock) {
       typeof userBlock.enabled === 'boolean'
         ? userBlock.enabled
         : defaults.enabled,
-    miDropCap:
-      typeof userBlock.miDropCap === 'number' &&
-      Number.isFinite(userBlock.miDropCap) &&
-      userBlock.miDropCap >= 0
-        ? userBlock.miDropCap
-        : defaults.miDropCap,
     crapJumpCap:
       typeof userBlock.crapJumpCap === 'number' &&
       Number.isFinite(userBlock.crapJumpCap) &&

--- a/.agents/workflows/audit-clean-code.md
+++ b/.agents/workflows/audit-clean-code.md
@@ -102,8 +102,9 @@ Analyze the repository with a focus on:
   cyclomatic complexity > 8 (`delivery.quality.codingGuardrails.cyclomaticFlag`)
   is **flag in review** (annotate or split); > 12
   (`codingGuardrails.cyclomaticMustFix`) is **must-fix** before the work merges.
-  A per-file MI drop > 1.5pt (`codingGuardrails.miDropMustRefactor`) requires a
-  refactor in the same Story rather than a baseline bump.
+  A per-file MI drop beyond the configured
+  `delivery.quality.gates.maintainability.tolerance` (default 0.5pt) requires
+  a refactor in the same Story rather than a baseline bump.
 - **Duplication:** Find "copy-paste" logic that should be abstracted into
   reusable utilities or hooks.
 - **Component Health:** In UI code, look for "component bloat" (files > 300

--- a/.agents/workflows/helpers/code-quality-guardrails.md
+++ b/.agents/workflows/helpers/code-quality-guardrails.md
@@ -58,13 +58,13 @@ review-time prose rule.
 
 Per-file Maintainability Index (MI) is tracked in
 [`baselines/maintainability.json`](../../../baselines/maintainability.json).
-A commit that drops a file's MI by more than
-`delivery.quality.codingGuardrails.miDropMustRefactor` points (default
-`1.5`) requires a refactor in the same Story — not a baseline bump. The MI
-ratchet's per-file `tolerance` (default `0.5`) is a noise filter, **not**
-permission to spend the budget; the 1.5-point ceiling is the upper bound
-above which the change is treated as a regression that must be undone or
-offset, not absorbed.
+A commit that drops a file's MI by more than the configured
+`delivery.quality.gates.maintainability.tolerance` (default `0.5` points)
+requires a refactor in the same Story — not a baseline bump. `tolerance` is
+the single MI-drop control: it is not a noise filter beneath a separate
+must-refactor ceiling — any drop past it is treated as a regression that
+must be undone or offset, not absorbed. Set `tolerance` higher only when the
+project deliberately wants a looser MI-drop budget.
 
 `quality:preview --changed-since HEAD` shows the per-file MI delta in the
 working tree before the commit lands.

--- a/lib/migrations/README.md
+++ b/lib/migrations/README.md
@@ -9,11 +9,13 @@ filtering, idempotency enforcement, and the actionable per-step log line. The
 `migrations` array is the single source of truth for which steps exist and in
 what order they run.
 
-> The registry currently ships **empty**. The project sits on the 1.x line
-> under release-please `always-bump-minor`, and no real contract break has
-> landed yet. The machinery is exercised by fixture steps in
-> [`__tests__/index.test.js`](./__tests__/index.test.js). Add the first real
-> step here when the first contract cutover lands.
+> Story #4531 registered the first real step —
+> [`steps/2.1.0-retire-mi-drop-knobs.js`](./steps/2.1.0-retire-mi-drop-knobs.js),
+> which strips the retired `codingGuardrails.miDropMustRefactor` and
+> `autoRefresh.miDropCap` keys from a consumer's `.agentrc.json`. The
+> machinery itself is still exercised independently by fixture steps in
+> [`__tests__/index.test.js`](./__tests__/index.test.js). Add the next real
+> step here (ascending by version) when the next contract cutover lands.
 
 ## Step shape
 

--- a/lib/migrations/__tests__/index.test.js
+++ b/lib/migrations/__tests__/index.test.js
@@ -68,8 +68,9 @@ describe('migrations module exports', () => {
     assert.ok(Array.isArray(migrations));
   });
 
-  it('ships an empty registry (no real contract break yet)', () => {
-    assert.equal(migrations.length, 0);
+  it('ships the Story #4531 mi-drop-knobs retirement as its first real step', () => {
+    assert.equal(migrations.length, 1);
+    assert.equal(migrations[0].version, '2.1.0');
   });
 });
 

--- a/lib/migrations/index.js
+++ b/lib/migrations/index.js
@@ -43,18 +43,20 @@
  * already in the tree (the consumer was on that version) and is skipped; a
  * step at exactly `toVersion` is the target and runs.
  *
- * The registry currently ships empty: v2.0.0's Story-collapse cutover did
- * not register a config migration step (consumers wipe/re-sync `.agents/`
- * and re-seed `.agentrc.json` from the starter). The machinery is proven
- * by the fixture steps in `__tests__/index.test.js`. When the next real
- * contract cutover lands, add its step here (ascending by version) with
- * an idempotent `detect`/`apply`.
+ * v2.0.0's Story-collapse cutover did not register a config migration step
+ * (consumers wipe/re-sync `.agents/` and re-seed `.agentrc.json` from the
+ * starter). Story #4531 registered the first real step — see
+ * `steps/2.1.0-retire-mi-drop-knobs.js` — alongside the fixture steps in
+ * `__tests__/index.test.js` that prove the machinery independent of any
+ * real step. When the next contract cutover lands, add its step here
+ * (ascending by version) with an idempotent `detect`/`apply`.
  */
+
+import { retireMiDropKnobs } from './steps/2.1.0-retire-mi-drop-knobs.js';
 
 /**
  * Ordered registry of migration steps. MUST stay sorted ascending by
- * `version`. Empty until the first real contract cutover graduates a step
- * here.
+ * `version`.
  *
  * @type {Array<{
  *   version: string,
@@ -63,7 +65,7 @@
  *   apply: (ctx: unknown) => void,
  * }>}
  */
-export const migrations = [];
+export const migrations = [retireMiDropKnobs];
 
 /**
  * Parse a dotted semver-ish string into a numeric tuple for comparison.

--- a/lib/migrations/steps/2.1.0-retire-mi-drop-knobs.js
+++ b/lib/migrations/steps/2.1.0-retire-mi-drop-knobs.js
@@ -1,0 +1,102 @@
+// lib/migrations/steps/2.1.0-retire-mi-drop-knobs.js
+/**
+ * Story #4531 — the first real step in the migration registry.
+ *
+ * `delivery.quality.codingGuardrails.miDropMustRefactor` and
+ * `delivery.quality.autoRefresh.miDropCap` were schema-validated, defaulted,
+ * and seeded by `apply-quality-bootstrap.js` into a consumer's
+ * `.agentrc.json` — but never consumed by the gate they were named for
+ * (`maintainability.tolerance` is the knob actually in force; see the
+ * Story body for the full diagnosis). Both retired keys lived under
+ * sub-schemas with `additionalProperties: false`, so a consumer whose
+ * config still carries either key hits a hard AJV validation failure on
+ * upgrade, not a warning. This step strips them before that check runs.
+ */
+
+import nodeFs from 'node:fs';
+import path from 'node:path';
+
+const AGENTRC_FILENAME = '.agentrc.json';
+
+/**
+ * @param {unknown} ctx
+ * @returns {string}
+ */
+function resolveAgentrcPath(ctx) {
+  const projectRoot = ctx?.projectRoot ?? process.cwd();
+  return path.join(projectRoot, AGENTRC_FILENAME);
+}
+
+/**
+ * @param {unknown} ctx
+ * @param {typeof nodeFs} fsImpl
+ * @returns {object | null}
+ */
+function readAgentrcConfig(ctx, fsImpl) {
+  try {
+    const raw = fsImpl.readFileSync(resolveAgentrcPath(ctx), 'utf8');
+    return JSON.parse(raw);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * @param {object | null} config
+ * @returns {boolean}
+ */
+function hasRetiredKey(config) {
+  const guardrails = config?.delivery?.quality?.codingGuardrails;
+  const autoRefresh = config?.delivery?.quality?.autoRefresh;
+  return (
+    (Boolean(guardrails) && Object.hasOwn(guardrails, 'miDropMustRefactor')) ||
+    (Boolean(autoRefresh) && Object.hasOwn(autoRefresh, 'miDropCap'))
+  );
+}
+
+export const retireMiDropKnobs = {
+  version: '2.1.0',
+  description:
+    'strip retired delivery.quality.codingGuardrails.miDropMustRefactor ' +
+    'and delivery.quality.autoRefresh.miDropCap from .agentrc.json',
+  /**
+   * @param {{ projectRoot?: string, fs?: typeof nodeFs }} [ctx]
+   * @returns {boolean}
+   */
+  detect(ctx) {
+    const fsImpl = ctx?.fs ?? nodeFs;
+    return hasRetiredKey(readAgentrcConfig(ctx, fsImpl));
+  },
+  /**
+   * @param {{ projectRoot?: string, fs?: typeof nodeFs }} [ctx]
+   * @returns {void}
+   */
+  apply(ctx) {
+    const fsImpl = ctx?.fs ?? nodeFs;
+    const config = readAgentrcConfig(ctx, fsImpl);
+    if (!config) return;
+
+    const guardrails = config.delivery?.quality?.codingGuardrails;
+    if (guardrails && Object.hasOwn(guardrails, 'miDropMustRefactor')) {
+      delete guardrails.miDropMustRefactor;
+      if (Object.keys(guardrails).length === 0) {
+        delete config.delivery.quality.codingGuardrails;
+      }
+    }
+
+    const autoRefresh = config.delivery?.quality?.autoRefresh;
+    if (autoRefresh && Object.hasOwn(autoRefresh, 'miDropCap')) {
+      delete autoRefresh.miDropCap;
+      if (Object.keys(autoRefresh).length === 0) {
+        delete config.delivery.quality.autoRefresh;
+      }
+    }
+
+    fsImpl.writeFileSync(
+      resolveAgentrcPath(ctx),
+      `${JSON.stringify(config, null, 2)}\n`,
+    );
+  },
+};
+
+export default retireMiDropKnobs;

--- a/lib/migrations/steps/2.1.0-retire-mi-drop-knobs.js
+++ b/lib/migrations/steps/2.1.0-retire-mi-drop-knobs.js
@@ -98,5 +98,3 @@ export const retireMiDropKnobs = {
     );
   },
 };
-
-export default retireMiDropKnobs;

--- a/lib/migrations/steps/__tests__/2.1.0-retire-mi-drop-knobs.test.js
+++ b/lib/migrations/steps/__tests__/2.1.0-retire-mi-drop-knobs.test.js
@@ -1,0 +1,149 @@
+// lib/migrations/steps/__tests__/2.1.0-retire-mi-drop-knobs.test.js
+/**
+ * Unit tests for the Story #4531 migration step — strips the retired
+ * `delivery.quality.codingGuardrails.miDropMustRefactor` and
+ * `delivery.quality.autoRefresh.miDropCap` keys from a consumer
+ * `.agentrc.json`. All tests drive `detect`/`apply` against an in-memory
+ * fake fs (testing-standards § Unit) — no real filesystem I/O.
+ */
+
+import assert from 'node:assert/strict';
+import path from 'node:path';
+import { describe, it } from 'node:test';
+
+import { retireMiDropKnobs } from '../2.1.0-retire-mi-drop-knobs.js';
+
+const PROJECT_ROOT = '/consumer';
+const AGENTRC_PATH = path.join(PROJECT_ROOT, '.agentrc.json');
+
+/**
+ * @param {object | null} initialConfig - `null` means no file on disk.
+ * @returns {{ ctx: object, readConfig: () => object }}
+ */
+function makeCtx(initialConfig) {
+  const files = new Map();
+  if (initialConfig !== null) {
+    files.set(AGENTRC_PATH, JSON.stringify(initialConfig, null, 2));
+  }
+
+  const fs = {
+    readFileSync(filePath) {
+      if (!files.has(filePath)) {
+        const err = new Error(`ENOENT: ${filePath}`);
+        err.code = 'ENOENT';
+        throw err;
+      }
+      return files.get(filePath);
+    },
+    writeFileSync(filePath, contents) {
+      files.set(filePath, contents);
+    },
+  };
+
+  return {
+    ctx: { projectRoot: PROJECT_ROOT, fs },
+    readConfig: () => JSON.parse(files.get(AGENTRC_PATH)),
+  };
+}
+
+describe('retireMiDropKnobs — detect', () => {
+  it('detects a config carrying miDropMustRefactor', () => {
+    const { ctx } = makeCtx({
+      delivery: { quality: { codingGuardrails: { miDropMustRefactor: 1.5 } } },
+    });
+    assert.equal(retireMiDropKnobs.detect(ctx), true);
+  });
+
+  it('detects a config carrying miDropCap', () => {
+    const { ctx } = makeCtx({
+      delivery: { quality: { autoRefresh: { miDropCap: 1.5 } } },
+    });
+    assert.equal(retireMiDropKnobs.detect(ctx), true);
+  });
+
+  it('does not detect a clean config', () => {
+    const { ctx } = makeCtx({
+      delivery: {
+        quality: {
+          codingGuardrails: { cyclomaticFlag: 8 },
+          autoRefresh: { enabled: true },
+        },
+      },
+    });
+    assert.equal(retireMiDropKnobs.detect(ctx), false);
+  });
+
+  it('does not detect when .agentrc.json is absent', () => {
+    const { ctx } = makeCtx(null);
+    assert.equal(retireMiDropKnobs.detect(ctx), false);
+  });
+});
+
+describe('retireMiDropKnobs — apply', () => {
+  it('strips both retired keys and preserves sibling keys', () => {
+    const { ctx, readConfig } = makeCtx({
+      delivery: {
+        quality: {
+          codingGuardrails: { miDropMustRefactor: 1.5, cyclomaticFlag: 8 },
+          autoRefresh: { miDropCap: 1.5, enabled: true },
+          gates: { crap: { floors: { '*': { max: 30 } } } },
+        },
+      },
+    });
+
+    retireMiDropKnobs.apply(ctx);
+
+    const written = readConfig();
+    assert.equal(
+      written.delivery.quality.codingGuardrails.miDropMustRefactor,
+      undefined,
+    );
+    assert.equal(written.delivery.quality.codingGuardrails.cyclomaticFlag, 8);
+    assert.equal(written.delivery.quality.autoRefresh.miDropCap, undefined);
+    assert.equal(written.delivery.quality.autoRefresh.enabled, true);
+    assert.deepEqual(written.delivery.quality.gates, {
+      crap: { floors: { '*': { max: 30 } } },
+    });
+  });
+
+  it('removes an emptied parent object entirely', () => {
+    const { ctx, readConfig } = makeCtx({
+      delivery: {
+        quality: {
+          codingGuardrails: { miDropMustRefactor: 1.5 },
+          autoRefresh: { miDropCap: 1.5 },
+        },
+      },
+    });
+
+    retireMiDropKnobs.apply(ctx);
+
+    const written = readConfig();
+    assert.equal('codingGuardrails' in written.delivery.quality, false);
+    assert.equal('autoRefresh' in written.delivery.quality, false);
+  });
+
+  it('is a no-op when .agentrc.json is absent', () => {
+    const { ctx } = makeCtx(null);
+    assert.doesNotThrow(() => retireMiDropKnobs.apply(ctx));
+  });
+
+  it('satisfies the idempotency contract: detect is false after apply', () => {
+    const { ctx } = makeCtx({
+      delivery: {
+        quality: {
+          codingGuardrails: { miDropMustRefactor: 1.5 },
+          autoRefresh: { miDropCap: 1.5 },
+        },
+      },
+    });
+
+    assert.equal(retireMiDropKnobs.detect(ctx), true);
+    retireMiDropKnobs.apply(ctx);
+    assert.equal(retireMiDropKnobs.detect(ctx), false);
+
+    // A second apply must not throw or change anything further.
+    assert.doesNotThrow(() => retireMiDropKnobs.apply(ctx));
+    assert.equal(retireMiDropKnobs.detect(ctx), false);
+  });
+});

--- a/tests/baselines/kinds/maintainability.compare.test.js
+++ b/tests/baselines/kinds/maintainability.compare.test.js
@@ -43,8 +43,8 @@ describe('kinds/maintainability.compare()', () => {
   it('low-MI new files (e.g. 22 vs implicit 100) are additions, not regressions', () => {
     // Regression test for the specific Story #2012 scenario: a new file
     // with an MI well below 100 used to surface as a -78 MI drop and
-    // breached every reasonable miDropCap. With the fix it lands in
-    // `additions` and the regression arm stays empty.
+    // breached any reasonable maintainability.tolerance. With the fix it
+    // lands in `additions` and the regression arm stays empty.
     const head = { rows: [{ path: 'lib/new.js', mi: 22 }] };
     const base = { rows: [] };
     const out = compare(head, base);

--- a/tests/config-schema-mirror-drift.test.js
+++ b/tests/config-schema-mirror-drift.test.js
@@ -170,13 +170,31 @@ describe('agentrc.schema.json mirror — drift vs runtime AJV schema', () => {
             codingGuardrails: {
               cyclomaticFlag: 8,
               cyclomaticMustFix: 12,
-              miDropMustRefactor: 1.5,
               requireSiblingTest: false,
             },
           },
         },
       },
       'fully populated doc',
+    );
+  });
+
+  it('rejects the retired miDropMustRefactor / miDropCap keys on both sides (Story #4531)', () => {
+    assertAgree(
+      {
+        ...REQ,
+        delivery: {
+          quality: { codingGuardrails: { miDropMustRefactor: 1.5 } },
+        },
+      },
+      'retired codingGuardrails.miDropMustRefactor',
+    );
+    assertAgree(
+      {
+        ...REQ,
+        delivery: { quality: { autoRefresh: { miDropCap: 1.5 } } },
+      },
+      'retired autoRefresh.miDropCap',
     );
   });
 

--- a/tests/config-settings-schema.test.js
+++ b/tests/config-settings-schema.test.js
@@ -472,12 +472,10 @@ describe('delivery.quality.* shape — uniform gates (Story #1737)', () => {
             codingGuardrails: {
               cyclomaticFlag: 8,
               cyclomaticMustFix: 12,
-              miDropMustRefactor: 1.5,
               requireSiblingTest: false,
             },
             autoRefresh: {
               enabled: true,
-              miDropCap: 1.5,
               crapJumpCap: 5,
               scope: 'diff',
             },
@@ -485,6 +483,31 @@ describe('delivery.quality.* shape — uniform gates (Story #1737)', () => {
         },
       }),
       true,
+    );
+  });
+
+  it('rejects the retired miDropMustRefactor / miDropCap keys (Story #4531)', () => {
+    expectErrors(
+      {
+        ...REQ,
+        delivery: {
+          quality: {
+            codingGuardrails: { miDropMustRefactor: 1.5 },
+          },
+        },
+      },
+      /codingGuardrails/,
+    );
+    expectErrors(
+      {
+        ...REQ,
+        delivery: {
+          quality: {
+            autoRefresh: { miDropCap: 1.5 },
+          },
+        },
+      },
+      /autoRefresh/,
     );
   });
 

--- a/tests/lib/config-resolver.test.js
+++ b/tests/lib/config-resolver.test.js
@@ -413,9 +413,9 @@ describe('resolveQuality / resolveMaintainabilityCrap / resolveCodingGuardrails'
     assert.equal(crap.diffRef, 'develop');
   });
 
-  it('resolveCodingGuardrails preserves miDropMustRefactor', () => {
+  it('resolveCodingGuardrails drops the retired miDropMustRefactor key (Story #4531)', () => {
     const guard = resolveCodingGuardrails({ miDropMustRefactor: 2.0 });
-    assert.equal(guard.miDropMustRefactor, 2.0);
+    assert.equal('miDropMustRefactor' in guard, false);
   });
 });
 


### PR DESCRIPTION
Closes #4531

_Auto-opened by `/single-story-deliver`._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> This is a breaking `.agentrc` contract change for configs that still set the retired keys; behavior should match prior effective gating only if operators relied on `maintainability.tolerance`, not the removed knobs. Upgrade safety depends on migrations running before validation.
> 
> **Overview**
> Retires **`delivery.quality.codingGuardrails.miDropMustRefactor`** and **`delivery.quality.autoRefresh.miDropCap`**, which were validated and defaulted but never read by `quality-preview.js` (MI exit already comes from **`delivery.quality.gates.maintainability.tolerance`**). Those keys are removed from AJV/schema mirrors, bootstrap defaults, and the quality resolver; docs and audit workflows now point operators at **`maintainability.tolerance`** (default 0.5pt) as the single MI-drop rule.
> 
> Because `codingGuardrails` / `autoRefresh` use **`additionalProperties: false`**, leftover keys would hard-fail validation on upgrade. The PR registers the first real migration step **`2.1.0-retire-mi-drop-knobs`**, which idempotently deletes the retired fields from `.agentrc.json` before AJV runs. Schema, resolver, and drift tests reject the old keys and assert the migration registry ships that step.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f3d5d151af3b0e35962042045ecbbd1383124a72. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->