### PR TITLE
fix(cli): stop sync pruning generated .agents/ files — declare a never-pruned registry so the install ledger survives (#4534)

### DIFF
--- a/lib/cli/__tests__/sync-prune.test.js
+++ b/lib/cli/__tests__/sync-prune.test.js
@@ -654,6 +654,54 @@ describe('runSync — the generated-files registry narrows, not disables, prune'
 });
 
 // ---------------------------------------------------------------------------
+// Story #4534 — the local-zone skip stays top-level-only
+// ---------------------------------------------------------------------------
+
+describe('runSync — the local/ prune skip is scoped to the top level', () => {
+  it('still prunes a stale file under a NESTED dir named local/', () => {
+    // The zone exemption is `.agents/local/`, not "any directory named
+    // local". Guards the prune side of that scoping (the copy side is covered
+    // in sync-local-zone.test.js): a nested `local/` is an ordinary
+    // managed-zone directory and its stale files are still enumerated.
+    const nestedLocalFile = path.join(
+      DEST_AGENTS,
+      'rules',
+      'local',
+      'stale-note.md',
+    );
+    const topLevelLocalFile = path.join(DEST_AGENTS, 'local', 'team-notes.md');
+    const fs = makeFs({
+      ...seedPayload(),
+      [nestedLocalFile]: '# nested local — still managed\n',
+      [topLevelLocalFile]: '# consumer-owned — exempt\n',
+    });
+    const cap = makeCapture();
+
+    const result = runSync({
+      argv: [],
+      resolvePackageRoot: resolveToPkg,
+      fs,
+      cwd: () => PROJECT,
+      write: cap.write,
+      writeErr: cap.writeErr,
+      exit: cap.exit,
+    });
+
+    assert.equal(
+      fs.files.has(nestedLocalFile),
+      false,
+      'a stale file under a nested local/ dir must still be pruned',
+    );
+    assert.equal(
+      fs.files.has(topLevelLocalFile),
+      true,
+      'the top-level .agents/local/ zone stays exempt',
+    );
+    assert.equal(result.pruned, 1);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Story #4534 — the registry is the SSOT the generators key off
 // ---------------------------------------------------------------------------
 

--- a/lib/cli/__tests__/sync-prune.test.js
+++ b/lib/cli/__tests__/sync-prune.test.js
@@ -18,6 +18,16 @@
  *      the tree byte-identical and prunes nothing.
  *   6. `result.pruned` reports the number of deleted stale files.
  *
+ * Extended by Story #4534 (the generated, never-pruned registry):
+ *   7. A bootstrap-written install ledger survives two consecutive syncs —
+ *      the reproduced bug (#4532) that made `mandrel uninstall` silently
+ *      reverse nothing.
+ *   8. The registry NARROWS the prune rather than disabling it: an
+ *      unregistered stale dotfile, and a lookalike basename at a
+ *      non-registered path, are both still pruned.
+ *   9. The registry is keyed off each generator's own exported constant
+ *      (`LEDGER_RELATIVE_PATH`), never a duplicated literal.
+ *
  * Tier: unit (testing-standards § Unit). All filesystem I/O is mocked via
  * the in-memory fs fake used by sync.test.js.
  *
@@ -29,7 +39,12 @@ import assert from 'node:assert/strict';
 import path from 'node:path';
 import { describe, it } from 'node:test';
 
-import { runSync } from '../sync.js';
+import { LEDGER_RELATIVE_PATH } from '../../../.agents/scripts/lib/bootstrap/install-ledger.js';
+import {
+  GENERATED_FILES,
+  runSync,
+  VERSION_MARKER_RELATIVE_PATH,
+} from '../sync.js';
 
 // ---------------------------------------------------------------------------
 // In-memory filesystem fake (extends sync.test.js fake with unlinkSync)
@@ -123,6 +138,23 @@ const PROJECT = path.join(path.sep, 'proj');
 const PKG_ROOT = path.join(PROJECT, 'node_modules', 'mandrel');
 const SRC_AGENTS = path.join(PKG_ROOT, '.agents');
 const DEST_AGENTS = path.join(PROJECT, '.agents');
+/**
+ * Absolute destination path of the install ledger, derived from the
+ * generator's own exported constant (POSIX, project-root-relative) rather
+ * than re-spelling the literal — the same SSOT discipline the registry
+ * itself follows (Story #4534). `path.join(...segments)` keeps the fixture
+ * key OS-correct so the in-memory fs fake matches on Windows too.
+ */
+const LEDGER_DEST_PATH = path.join(PROJECT, ...LEDGER_RELATIVE_PATH.split('/'));
+/**
+ * Ledger content shaped like the real thing but carrying no secrets
+ * (security-baseline § Data Leakage) — only a schema version and an entry
+ * kind, which is all these tests need to prove the bytes survive untouched.
+ */
+const LEDGER_CONTENT = `${JSON.stringify({
+  schemaVersion: 2,
+  entries: [{ kind: 'gitignore', executedAction: 'seeded' }],
+})}\n`;
 const resolveToPkg = () => PKG_ROOT;
 
 /** Seed a minimal payload: two files, plus the package's own package.json
@@ -474,6 +506,175 @@ describe('runSync — .agents/.mandrel-version survives the prune pass', () => {
     assert.doesNotMatch(cap.out.join(''), /pruned/);
     // Overwritten to the current run's version, not left at the stale value.
     assert.equal(fs.files.get(markerPath), '9.9.9\n');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Story #4534 — the install ledger survives the prune pass
+// ---------------------------------------------------------------------------
+
+describe('runSync — the install ledger survives the prune pass', () => {
+  it('leaves a bootstrap-written ledger present after two syncs (regression, #4532)', () => {
+    // The reproduced bug: bootstrap writes the ledger, the very next sync
+    // prunes it (it has no payload counterpart), and `mandrel uninstall` then
+    // reports "No install ledger found" and exits 0 with every mutation still
+    // applied.
+    const fs = makeFs({
+      ...seedPayload(),
+      [LEDGER_DEST_PATH]: LEDGER_CONTENT,
+    });
+    const opts = {
+      argv: [],
+      resolvePackageRoot: resolveToPkg,
+      fs,
+      cwd: () => PROJECT,
+      write: () => {},
+      writeErr: () => {},
+      exit: () => {},
+    };
+
+    const r1 = runSync(opts);
+    assert.equal(
+      fs.files.get(LEDGER_DEST_PATH),
+      LEDGER_CONTENT,
+      'ledger must survive the first sync byte-identical',
+    );
+    assert.equal(r1.pruned, 0, 'the ledger is generated, not stale');
+
+    const r2 = runSync(opts);
+    assert.equal(
+      fs.files.get(LEDGER_DEST_PATH),
+      LEDGER_CONTENT,
+      'ledger must survive a second sync — sync must never own deleting it',
+    );
+    assert.equal(r2.pruned, 0);
+    assert.deepEqual(
+      fs.unlinked,
+      [],
+      'no unlink may target the ledger across either pass',
+    );
+  });
+
+  it('is not offered for pruning in the --dry-run plan', () => {
+    // The dry-run plan and the real prune pass share listDestFiles, so a
+    // ledger listed here would mean a ledger deleted there.
+    const fs = makeFs({
+      ...seedPayload(),
+      [LEDGER_DEST_PATH]: LEDGER_CONTENT,
+    });
+    const cap = makeCapture();
+
+    runSync({
+      argv: ['--dry-run'],
+      resolvePackageRoot: resolveToPkg,
+      fs,
+      cwd: () => PROJECT,
+      write: cap.write,
+      writeErr: cap.writeErr,
+      exit: cap.exit,
+    });
+
+    assert.doesNotMatch(cap.out.join(''), /would prune .*install-manifest/);
+    assert.match(cap.out.join(''), /0 stale file\(s\) would be pruned/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Story #4534 — the registry narrows the prune; it does not disable it
+// ---------------------------------------------------------------------------
+
+describe('runSync — the generated-files registry narrows, not disables, prune', () => {
+  it('still prunes a stale dotfile that is not registered as generated', () => {
+    // Guards the plausible over-correction: exempting generated dotfiles by
+    // pattern (e.g. "skip every top-level dotfile") rather than by
+    // registration. `.agents/.stale-cache.json` looks exactly like a
+    // registered artifact and must still be pruned.
+    const staleDotfile = path.join(DEST_AGENTS, '.stale-cache.json');
+    const fs = makeFs({
+      ...seedPayload(),
+      [staleDotfile]: '{"cached":true}\n',
+      [LEDGER_DEST_PATH]: LEDGER_CONTENT,
+    });
+    const cap = makeCapture();
+
+    const result = runSync({
+      argv: [],
+      resolvePackageRoot: resolveToPkg,
+      fs,
+      cwd: () => PROJECT,
+      write: cap.write,
+      writeErr: cap.writeErr,
+      exit: cap.exit,
+    });
+
+    assert.equal(
+      fs.files.has(staleDotfile),
+      false,
+      'an unregistered stale dotfile must still be pruned',
+    );
+    assert.equal(result.pruned, 1);
+    assert.equal(
+      fs.files.get(LEDGER_DEST_PATH),
+      LEDGER_CONTENT,
+      'the registered ledger survives the same pass that prunes its neighbour',
+    );
+  });
+
+  it('registers the ledger under its real name — a lookalike basename elsewhere is still pruned', () => {
+    // The registry is keyed on the `.agents/`-relative path, not a basename
+    // match: a nested file that merely shares the ledger's name is stale.
+    const lookalike = path.join(
+      DEST_AGENTS,
+      'scripts',
+      '.install-manifest.json',
+    );
+    const fs = makeFs({
+      ...seedPayload(),
+      [lookalike]: '{}\n',
+    });
+    const cap = makeCapture();
+
+    const result = runSync({
+      argv: [],
+      resolvePackageRoot: resolveToPkg,
+      fs,
+      cwd: () => PROJECT,
+      write: cap.write,
+      writeErr: cap.writeErr,
+      exit: cap.exit,
+    });
+
+    assert.equal(
+      fs.files.has(lookalike),
+      false,
+      'only the registered path is exempt, not every file sharing its basename',
+    );
+    assert.equal(result.pruned, 1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Story #4534 — the registry is the SSOT the generators key off
+// ---------------------------------------------------------------------------
+
+describe('GENERATED_FILES registry', () => {
+  it('registers the install ledger via install-ledger.js LEDGER_RELATIVE_PATH', () => {
+    // Keying off the generator's own constant is what makes a rename move the
+    // exemption with it. Asserting the derivation (not a literal) is what
+    // makes this test fail if someone re-hardcodes the string.
+    const expected = LEDGER_RELATIVE_PATH.split('/').slice(1).join(path.sep);
+    assert.ok(
+      GENERATED_FILES.includes(expected),
+      `registry must contain ${expected} derived from LEDGER_RELATIVE_PATH`,
+    );
+  });
+
+  it('registers the version marker', () => {
+    assert.ok(GENERATED_FILES.includes(VERSION_MARKER_RELATIVE_PATH));
+  });
+
+  it('is frozen — the never-prune contract is not mutable at runtime', () => {
+    assert.ok(Object.isFrozen(GENERATED_FILES));
   });
 });
 

--- a/lib/cli/sync.js
+++ b/lib/cli/sync.js
@@ -26,11 +26,16 @@
  *     managed `.agents/` zone (everything except `.agents/local/`) that has
  *     no counterpart in the package payload is deleted. Consumer additions
  *     under `.agents/local/` are never touched.
+ *   - Generated, never-pruned registry (Story #4534). Framework-generated
+ *     `.agents/` files have no payload counterpart by design, so the prune
+ *     pass would delete each one unless it is declared in
+ *     {@link GENERATED_FILES}. That registry — not a per-file special case in
+ *     {@link listDestFiles} — is the single place a generated artifact is
+ *     exempted. Registered today: the version marker (Story #4530) and the
+ *     install ledger the bootstrap writes and `mandrel uninstall` reads.
  *   - Version marker (Story #4530). After the prune pass, `.agents/.mandrel-
- *     version` is (re)written with the executing package's own version. It
- *     has no payload counterpart by design — see {@link GENERATED_FILES} for
- *     why it must be exempted from prune rather than merely written after
- *     it, and {@link readVersionMarker} for how callers consume it.
+ *     version` is (re)written with the executing package's own version. See
+ *     {@link readVersionMarker} for how callers consume it.
  *
  * Security (Tech Spec #3459 "Postinstall safety"):
  *   - Does nothing beyond a local file copy: no network, no shell, no writes
@@ -50,7 +55,18 @@ import nodeFs from 'node:fs';
 import { createRequire } from 'node:module';
 import path from 'node:path';
 
+import { LEDGER_RELATIVE_PATH } from '../../.agents/scripts/lib/bootstrap/install-ledger.js';
+
 export const PACKAGE_NAME = 'mandrel';
+
+/**
+ * Name of the managed destination directory, relative to the project root.
+ * Generating modules export their artifact paths relative to the *project
+ * root* (e.g. `install-ledger.js`'s `LEDGER_RELATIVE_PATH`), whereas the
+ * prune pass compares paths relative to this directory — {@link
+ * toManagedZoneRelative} is the one conversion between the two.
+ */
+const AGENTS_DIR = '.agents';
 
 /**
  * Top-level directory name (relative to `.agents/`) reserved as the
@@ -82,21 +98,68 @@ export const LOCAL_OVERRIDE_RE = /\.local\.[^.]+$/;
 export const VERSION_MARKER_RELATIVE_PATH = '.mandrel-version';
 
 /**
- * Framework-generated `.agents/` files that have no payload counterpart and
- * must therefore be exempted from the prune pass, alongside the
- * `.agents/local/` zone and `*.local.*` overrides (Story #4530).
+ * Convert a project-root-relative POSIX path — the shape a generating module
+ * exports as its own source of truth (e.g. `install-ledger.js`'s
+ * `LEDGER_RELATIVE_PATH`, `'.agents/.install-manifest.json'`) — into the
+ * `.agents/`-relative, OS-separator form {@link listDestFiles} enumerates and
+ * {@link GENERATED_FILES} is compared against.
+ *
+ * Throws on a path outside `.agents/`: a generated file the sync prune pass
+ * never walks has no business in the registry, and registering one would be a
+ * silent no-op that reads as protection. Failing at module load surfaces the
+ * mistake at the first import rather than as a mystery deletion in a
+ * consumer's tree.
+ *
+ * @param {string} projectRelativePosixPath - e.g. `.agents/.install-manifest.json`.
+ * @returns {string} e.g. `.install-manifest.json` (OS separators).
+ */
+function toManagedZoneRelative(projectRelativePosixPath) {
+  const segments = projectRelativePosixPath.split('/');
+  if (segments[0] !== AGENTS_DIR || segments.length < 2) {
+    throw new Error(
+      `generated-files registry: '${projectRelativePosixPath}' is not inside ${AGENTS_DIR}/ — ` +
+        'only files the sync prune pass walks can be registered as never-pruned.',
+    );
+  }
+  return path.join(...segments.slice(1));
+}
+
+/**
+ * The **generated, never-pruned registry**: every framework-generated
+ * `.agents/` file that has no payload counterpart and must therefore be
+ * exempted from the prune pass. Paths are `.agents/`-relative with OS
+ * separators, matching what {@link listDestFiles} enumerates.
  *
  * The prune pass (Story #4046 A3) deletes any managed-zone file absent from
- * the payload — that is the correct rule for consumer drift, but it is also
- * exactly the shape of every file the framework itself generates and writes
- * into `.agents/` outside the payload (the version marker here; the install
- * ledger at `.agents/.install-manifest.json`, Story #4534). Without this
- * registry each one gets pruned by the very sync that wrote it unless the
- * exemption is hand-added — a trap already proven on the install ledger
- * before this Story. Register a new generated file here, in this one place,
- * rather than adding another special case to {@link listDestFiles}.
+ * the payload. That is the correct rule for consumer drift, but it is also
+ * exactly the shape of every file the framework itself generates into
+ * `.agents/` outside the payload — so each such artifact is deleted by the very
+ * sync that wrote it unless registered here. Two have hit this already: the
+ * install ledger (`.agents/.install-manifest.json`), whose loss made
+ * `mandrel uninstall` silently reverse nothing and exit 0 (Story #4534), and
+ * the version marker (Story #4530).
+ *
+ * This is deliberately a **registry, not a list of special cases**. Register a
+ * new generated file by adding one entry here — keyed off the generating
+ * module's own exported constant wherever one exists, never a duplicated
+ * string literal — rather than by adding another branch to
+ * {@link listDestFiles}. That keeps the never-prune contract declared in one
+ * place and keeps the registry honest: if the generator renames its artifact,
+ * the exemption moves with it.
+ *
+ * This registry does **not** subsume the `.agents/local/` zone or the
+ * `*.local.*` overrides ({@link LOCAL_ZONE_DIR}, {@link LOCAL_OVERRIDE_RE}).
+ * Those are a different concept — consumer-authored overrides, not
+ * framework-generated artifacts — and stay separate on purpose.
  */
-export const GENERATED_FILES = Object.freeze([VERSION_MARKER_RELATIVE_PATH]);
+export const GENERATED_FILES = Object.freeze([
+  // Version marker (Story #4530) — written by runSync itself, below.
+  VERSION_MARKER_RELATIVE_PATH,
+  // Install ledger (Story #4534) — written by the bootstrap
+  // (`install-ledger.js`), read by `mandrel uninstall` as its single source of
+  // truth. Keyed off the generator's exported constant.
+  toManagedZoneRelative(LEDGER_RELATIVE_PATH),
+]);
 
 /**
  * Resolve the version of the package whose `.agents/` payload was just
@@ -197,12 +260,22 @@ export function listFiles(dir, fsImpl, prefix = '') {
 
 /**
  * Recursively enumerate every regular file under `dir`, returning paths
- * relative to `dir` using OS separators. The top-level `local/` subtree is
- * skipped so consumer additions inside `.agents/local/` are never pruned
- * (Story #3498). Files following the `*.local.*` naming convention (e.g.
- * `.agents/instructions.local.md` — the documented consumer override
- * mechanism, instructions.md § 1.E) are also skipped: they never ship in
- * the payload and must survive every sync.
+ * relative to `dir` using OS separators. Three disjoint classes are skipped,
+ * so a caller diffing this against the payload never treats them as stale:
+ *
+ *   1. The top-level `local/` subtree — consumer additions inside
+ *      `.agents/local/` are never pruned (Story #3498).
+ *   2. Files matching the `*.local.*` convention (e.g.
+ *      `.agents/instructions.local.md`) — the documented consumer override
+ *      mechanism (instructions.md § 1.E); they never ship in the payload and
+ *      must survive every sync.
+ *   3. Everything declared in the {@link GENERATED_FILES} registry —
+ *      framework-generated artifacts with no payload counterpart by design
+ *      (Story #4534). New generated files are registered there, not added as
+ *      a fourth branch here.
+ *
+ * (1) and (2) are consumer-authored; (3) is framework-generated. They are
+ * kept separate deliberately — conflating them would muddy both contracts.
  *
  * Mirrors `listFiles` but operates on the destination tree so we can
  * identify stale files that have no payload counterpart (Story #4046 A3).
@@ -233,7 +306,8 @@ function listDestFiles(dir, fsImpl, prefix = '') {
       continue;
     }
     const rel = prefix ? path.join(prefix, ent.name) : ent.name;
-    // Framework-generated files (Story #4530) — see GENERATED_FILES.
+    // Framework-generated artifacts — declared once in the never-pruned
+    // registry (Story #4534); see GENERATED_FILES.
     if (!ent.isDirectory() && GENERATED_FILES.includes(rel)) {
       continue;
     }
@@ -349,10 +423,12 @@ export function runSync({
   }
 
   // Version marker (Story #4530): written AFTER the prune pass, never
-  // before — GENERATED_FILES already keeps listDestFiles from ever
-  // enumerating it as stale, but ordering the write after prune is a second,
-  // independent safeguard against the same class of bug (see GENERATED_FILES
-  // doc comment) surviving a future prune-pass reorder.
+  // before — the GENERATED_FILES registry already keeps listDestFiles from
+  // ever enumerating it as stale, but ordering the write after prune is a
+  // second, independent safeguard against the same class of bug (see the
+  // GENERATED_FILES doc comment) surviving a future prune-pass reorder. The
+  // install ledger gets no such belt-and-braces: it is written by the
+  // bootstrap, not here, so the registry is its only protection.
   const packageVersion = resolvePackageVersion(packageRoot, fs);
   fs.writeFileSync(
     path.join(destRoot, VERSION_MARKER_RELATIVE_PATH),

--- a/tests/e2e/sync-prune.integration.test.js
+++ b/tests/e2e/sync-prune.integration.test.js
@@ -19,6 +19,11 @@
  *   1. Managed payload files are copied into ./.agents/.
  *   2. A stale managed file (no payload counterpart) is DELETED by prune.
  *   3. A `.agents/local/**` addition — and a `*.local.*` override — SURVIVE.
+ *
+ * Extended by Story #4534: every file in the generated, never-pruned registry
+ * SURVIVES a real sync, and the chain that motivated the registry —
+ * bootstrap → sync → `mandrel uninstall` — is proven end to end against the
+ * real binaries rather than inferred from the unit fakes.
  */
 
 import assert from 'node:assert/strict';
@@ -26,6 +31,8 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { afterEach, beforeEach, describe, it } from 'node:test';
 
+import { LEDGER_SCHEMA_VERSION } from '../../.agents/scripts/lib/bootstrap/install-ledger.js';
+import { GITIGNORE_BLOCKS } from '../../.agents/scripts/lib/bootstrap/project-bootstrap.js';
 import {
   cleanupAll,
   makeTempConsumer,
@@ -206,6 +213,120 @@ describe('mandrel sync — real-binary copy + prune (e2e)', () => {
       second.stdout,
       /pruned \d+ stale file\(s\)/,
       'the marker must not be reported as a stale prune candidate',
+    );
+  });
+
+  it('a bootstrap-written .agents/.install-manifest.json survives two syncs (Story #4534)', () => {
+    // The reproduced bug (#4532): the bootstrap writes the install ledger, and
+    // the very next sync prunes it because it has no payload counterpart.
+    const ledgerPath = path.join(consumer.agentsDir, '.install-manifest.json');
+    const ledgerContent = `${JSON.stringify(
+      {
+        schemaVersion: LEDGER_SCHEMA_VERSION,
+        appliedAt: '2026-01-01T00:00:00.000Z',
+        repo: null,
+        approvedGroups: ['ide-wiring'],
+        entries: [
+          {
+            phaseGroup: 'ide-wiring',
+            target: '.gitignore',
+            action: 'merge',
+            reversible: true,
+          },
+        ],
+      },
+      null,
+      2,
+    )}\n`;
+
+    fs.mkdirSync(consumer.agentsDir, { recursive: true });
+    fs.writeFileSync(ledgerPath, ledgerContent);
+
+    const first = runMandrel(consumer.dir, ['sync']);
+    assert.equal(first.status, 0, `first sync failed: ${first.stderr}`);
+    assert.ok(
+      fs.existsSync(ledgerPath),
+      'ledger must survive the first sync — it is generated, not stale',
+    );
+
+    const second = runMandrel(consumer.dir, ['sync']);
+    assert.equal(second.status, 0, `second sync failed: ${second.stderr}`);
+    assert.equal(
+      fs.readFileSync(ledgerPath, 'utf8'),
+      ledgerContent,
+      'ledger must survive a second sync byte-for-byte — sync never owns deleting it',
+    );
+    assert.doesNotMatch(
+      second.stdout,
+      /pruned \d+ stale file\(s\)/,
+      'the ledger must not be reported as a stale prune candidate',
+    );
+  });
+
+  it('bootstrap → sync → uninstall: uninstall finds its ledger and reverses (Story #4534)', () => {
+    // The end-to-end chain the registry exists to protect. Before the fix,
+    // sync pruned the ledger and uninstall printed "No install ledger found —
+    // nothing to uninstall.", exited 0, and left every mutation applied.
+    //
+    // A `.gitignore` merge entry is used as the reversible mutation because it
+    // is a pure local-file reversal: no network, no GitHub admin surface.
+    const ledgerPath = path.join(consumer.agentsDir, '.install-manifest.json');
+    const gitignorePath = path.join(consumer.dir, '.gitignore');
+
+    // Arrange: a .gitignore carrying the block a real bootstrap would have
+    // merged in, plus the ledger recording that mutation.
+    const mandrelBlock = GITIGNORE_BLOCKS.mcp.block;
+    fs.writeFileSync(gitignorePath, `node_modules/\n${mandrelBlock}`);
+    fs.mkdirSync(consumer.agentsDir, { recursive: true });
+    fs.writeFileSync(
+      ledgerPath,
+      `${JSON.stringify(
+        {
+          schemaVersion: LEDGER_SCHEMA_VERSION,
+          appliedAt: '2026-01-01T00:00:00.000Z',
+          repo: null,
+          approvedGroups: ['ide-wiring'],
+          entries: [
+            {
+              phaseGroup: 'ide-wiring',
+              target: '.gitignore',
+              action: 'merge',
+              reversible: true,
+            },
+          ],
+        },
+        null,
+        2,
+      )}\n`,
+    );
+
+    // Act 1: sync — the step that used to destroy the ledger.
+    const sync = runMandrel(consumer.dir, ['sync']);
+    assert.equal(sync.status, 0, `sync failed: ${sync.stderr}`);
+
+    // Act 2: uninstall — must find the ledger sync just ran over.
+    const uninstall = runMandrel(consumer.dir, ['uninstall']);
+
+    // Assert: the exact failure signature of the bug is absent.
+    assert.doesNotMatch(
+      uninstall.stdout,
+      /No install ledger found/,
+      'uninstall must find the ledger after a sync — this is the #4532 regression',
+    );
+    assert.equal(uninstall.status, 0, `uninstall failed: ${uninstall.stderr}`);
+
+    // …and the recorded mutation was actually reversed, not merely reported.
+    assert.match(uninstall.stdout, /reverted\s+\.gitignore/);
+    const gitignoreAfter = fs.readFileSync(gitignorePath, 'utf8');
+    assert.doesNotMatch(
+      gitignoreAfter,
+      /^\s*\.mcp\.json\s*$/m,
+      'the recorded .gitignore mutation must be reversed',
+    );
+    assert.match(
+      gitignoreAfter,
+      /node_modules\//,
+      'reversal must strip only the mandrel block, not the consumer’s own lines',
     );
   });
 


### PR DESCRIPTION
Closes #4534

_Auto-opened by `/single-story-deliver`._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes sync prune semantics for `.agents/` managed files; incorrect registry entries could leave stale files or delete needed artifacts, but scope is localized to sync and covered by extensive regression tests including real-binary uninstall.
> 
> **Overview**
> **`mandrel sync`** no longer treats bootstrap-generated artifacts as stale during prune. The **`GENERATED_FILES`** registry now exempts **`.agents/.install-manifest.json`** (via **`LEDGER_RELATIVE_PATH`** from `install-ledger.js`) alongside **`.mandrel-version`**, with **`toManagedZoneRelative`** converting generator paths and failing fast if a registry entry is outside `.agents/`.
> 
> **`listDestFiles`** documents and relies on that registry as the single exemption mechanism for framework-generated files (separate from `.agents/local/` and `*.local.*`). Prune behavior otherwise unchanged: unregistered stale files still delete, including lookalike paths and nested `local/` dirs.
> 
> Unit and e2e tests cover ledger survival across syncs/dry-run, registry narrowing (not blanket dotfile skips), and **bootstrap → sync → uninstall** reversing a recorded `.gitignore` merge.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 07c188de669b1a9103ccd64ada1911f8d80708bc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->