### PR TITLE
feat(plan): close --tickets source issues as superseded by default (#4535)

### DIFF
--- a/.agents/scripts/lib/orchestration/plan-persist/run-plan-persist.js
+++ b/.agents/scripts/lib/orchestration/plan-persist/run-plan-persist.js
@@ -12,7 +12,9 @@
  *      label when N>1)
  *   6. Upsert `risk-verdict` + `story-plan-state` on every created Story;
  *      upsert `plan-summary` on the primary Story
- *   7. Temp cleanup at terminal success only
+ *   7. Comment on + close the superseded `--tickets` source issues
+ *      (Story #4535) — bookkeeping only; never fails the run
+ *   8. Temp cleanup at terminal success only
  *
  * Hard cutover: no Epic parent, no reconciler, no `deliveryShape`, no
  * `--amend` tree cascades. Those surfaces die with Stages 4–5 for any
@@ -51,6 +53,7 @@ import {
   buildWaveTable,
   PLAN_SUMMARY_COMMENT_TYPE,
 } from './summary.js';
+import { closeSupersededTickets } from './supersede-ops.js';
 
 /** Checkpoint schema version written on each Story's story-plan-state. */
 const PLAN_CHECKPOINT_SCHEMA_VERSION_V2 = 2;
@@ -124,6 +127,39 @@ function enforceTicketValidation(validated, { config, settings, cwd }) {
   );
 }
 
+/**
+ * Run the supersede close phase behind a belt-and-braces guard.
+ *
+ * `closeSupersededTickets` already swallows per-ticket failures, but this
+ * phase runs *after* `createIssue`, so an unexpected throw anywhere in it
+ * would leave the run half-done with Stories already live. Degrade to a
+ * reported failure instead.
+ *
+ * @returns {Promise<import('./supersede-ops.js').SupersedeReport>}
+ */
+async function runSupersedePhase(args) {
+  try {
+    return await closeSupersededTickets(args);
+  } catch (err) {
+    Logger.warn(
+      `[plan-persist] supersede close phase failed: ${err.message} — ` +
+        'Stories were created; close the source tickets by hand.',
+    );
+    return {
+      enabled: true,
+      dryRun: args.dryRun === true,
+      reason: `phase-error: ${err.message}`,
+      closed: [],
+      planned: [],
+      skipped: [],
+      failed: (args.sourceTicketIds ?? []).map((ticket) => ({
+        ticket,
+        reason: err.message,
+      })),
+    };
+  }
+}
+
 function riskVerdictCommentBody(riskVerdict) {
   return [
     '### risk-verdict',
@@ -157,6 +193,8 @@ function riskVerdictCommentBody(riskVerdict) {
  *     planDir?: string,
  *     fanOutCounter?: Function,
  *     cwd?: string,
+ *     sourceTicketIds?: number[],
+ *     closeSuperseded?: boolean,
  *   },
  * }} input
  */
@@ -183,6 +221,8 @@ export async function runPlanPersist({
     planDir = null,
     fanOutCounter = undefined,
     cwd = PROJECT_ROOT,
+    sourceTicketIds = [],
+    closeSuperseded = true,
   } = opts;
 
   if (!riskVerdict || !Array.isArray(riskVerdict.axes)) {
@@ -280,6 +320,7 @@ export async function runPlanPersist({
   const { stories } = assemblePlanStories(rawStories, {
     sharedSpec: techSpecContent,
     planAcceptance: planAcceptance ?? undefined,
+    sourceTicketIds,
   });
 
   const planningRisk = deriveRiskEnvelope(riskVerdict);
@@ -357,6 +398,16 @@ export async function runPlanPersist({
     );
   }
 
+  const supersede = await runSupersedePhase({
+    provider,
+    stories,
+    created,
+    sourceTicketIds,
+    planRunLabel,
+    dryRun,
+    closeSuperseded,
+  });
+
   if (!skipCleanup && planDir) {
     try {
       await rm(planDir, { recursive: true, force: true });
@@ -380,5 +431,6 @@ export async function runPlanPersist({
     critics,
     reachability,
     waveTable,
+    supersede,
   };
 }

--- a/.agents/scripts/lib/orchestration/plan-persist/story-ops.js
+++ b/.agents/scripts/lib/orchestration/plan-persist/story-ops.js
@@ -24,6 +24,10 @@ import {
 } from '../../story-body/story-body.js';
 import { assertSpecWithinBudget } from '../spec-spill.js';
 import { assertAcceptancePartition } from '../split-policy-validator.js';
+import {
+  assertSupersedePartition,
+  normalizeSupersedes,
+} from './supersede-ops.js';
 
 /** Label prefix grouping sibling Stories from one plan run (N>1). */
 export const PLAN_RUN_LABEL_PREFIX = 'plan-run::';
@@ -126,8 +130,12 @@ function syncContractFieldFromTopLevel(ticket, bodyObject, field) {
  * Normalize a plan Story ticket into `{ slug, title, bodyObject }`.
  * Accepts either a serialized markdown `body` string or a structured body.
  *
+ * `supersedes[]` is a top-level-only field (Story #4535) — it is planning
+ * bookkeeping for the `--tickets` source issues, not part of the Story's
+ * executable body, so it is deliberately not serialized into the markdown.
+ *
  * @param {object} ticket
- * @returns {{ slug: string, title: string, bodyObject: object, depends_on: string[] }}
+ * @returns {{ slug: string, title: string, bodyObject: object, depends_on: string[], supersedes: Array<{ id: number, note: string|null }> }}
  */
 export function normalizeStoryTicket(ticket) {
   if (!ticket || typeof ticket !== 'object') {
@@ -150,8 +158,9 @@ export function normalizeStoryTicket(ticket) {
   syncContractFieldFromTopLevel(ticket, bodyObject, 'acceptance');
   syncContractFieldFromTopLevel(ticket, bodyObject, 'verify');
   const depends_on = normalizeDependsOn(ticket, bodyObject);
+  const supersedes = normalizeSupersedes(ticket, slug);
 
-  return { slug, title, bodyObject, depends_on };
+  return { slug, title, bodyObject, depends_on, supersedes };
 }
 
 /**
@@ -194,7 +203,8 @@ export function foldSpecIntoStoryBody(bodyObject, slug, opts = {}) {
 }
 
 function assembleOnePlanStory(ticket, opts) {
-  const { slug, title, bodyObject, depends_on } = normalizeStoryTicket(ticket);
+  const { slug, title, bodyObject, depends_on, supersedes } =
+    normalizeStoryTicket(ticket);
   const { bodyObject: folded } = foldSpecIntoStoryBody(bodyObject, slug, {
     sharedSpec: opts.sharedSpec ?? null,
   });
@@ -207,6 +217,7 @@ function assembleOnePlanStory(ticket, opts) {
       bodyObject: { ...folded, depends_on },
       acceptance: Array.isArray(folded.acceptance) ? folded.acceptance : [],
       depends_on,
+      supersedes,
     },
   };
 }
@@ -230,13 +241,17 @@ function assertSharedSpecAllowed(tickets, sharedSpec) {
 
 /**
  * Assemble markdown bodies for every Story: normalize → fold spec →
- * assertAcceptancePartition → serialize.
+ * assertAcceptancePartition → assertSupersedePartition → serialize.
+ *
+ * Both partition checks run **before** any GitHub write so a mis-authored
+ * plan never leaves Stories live against an inconsistent tracker.
  *
  * @param {object[]} tickets
  * @param {object} [opts]
  * @param {string|null} [opts.sharedSpec]
  * @param {string[]} [opts.planAcceptance]
- * @returns {{ stories: Array<{ slug: string, title: string, body: string, acceptance: string[], depends_on: string[] }> }}
+ * @param {number[]} [opts.sourceTicketIds] Ids passed to `/plan --tickets`.
+ * @returns {{ stories: Array<{ slug: string, title: string, body: string, acceptance: string[], depends_on: string[], supersedes: Array<{ id: number, note: string|null }> }> }}
  */
 export function assemblePlanStories(tickets, opts = {}) {
   if (!Array.isArray(tickets) || tickets.length === 0) {
@@ -254,6 +269,7 @@ export function assemblePlanStories(tickets, opts = {}) {
   assertAcceptancePartition(stories, {
     planAcceptance: opts.planAcceptance,
   });
+  assertSupersedePartition(stories, opts.sourceTicketIds ?? []);
 
   return { stories };
 }

--- a/.agents/scripts/lib/orchestration/plan-persist/supersede-ops.js
+++ b/.agents/scripts/lib/orchestration/plan-persist/supersede-ops.js
@@ -299,7 +299,10 @@ async function closeOneSupersededTicket({
  * @property {boolean} dryRun
  * @property {string|null} reason  Why the phase was skipped wholesale.
  * @property {number[]} closed
- * @property {Array<{ ticket: number, storyId: number }>} planned Dry-run only.
+ * @property {Array<{ ticket: number, storySlug: string }>} planned Dry-run
+ *   only. Keyed by slug, not id: under `--dry-run` no issue was created, so
+ *   `createStoryIssues` hands back a synthetic negative placeholder id. The
+ *   slug is the only identifier that means anything before the writes land.
  * @property {Array<{ ticket: number, reason: string }>} skipped
  * @property {Array<{ ticket: number, reason: string }>} failed
  */
@@ -365,7 +368,7 @@ export async function closeSupersededTickets({
         continue;
       }
       if (dryRun) {
-        report.planned.push({ ticket: id, storyId: createdStory.id });
+        report.planned.push({ ticket: id, storySlug: createdStory.slug });
         continue;
       }
       const result = await closeOneSupersededTicket({
@@ -398,10 +401,10 @@ export async function closeSupersededTickets({
  */
 function logSupersedeReport(report) {
   if (report.dryRun) {
-    for (const { ticket, storyId } of report.planned) {
+    for (const { ticket, storySlug } of report.planned) {
       Logger.info(
         `[plan-persist] dry-run: would comment on and close #${ticket} ` +
-          `as superseded by #${storyId} (${SUPERSEDE_CLOSE_REASON}).`,
+          `as superseded by Story "${storySlug}" (${SUPERSEDE_CLOSE_REASON}).`,
       );
     }
     return;

--- a/.agents/scripts/lib/orchestration/plan-persist/supersede-ops.js
+++ b/.agents/scripts/lib/orchestration/plan-persist/supersede-ops.js
@@ -1,0 +1,424 @@
+/**
+ * supersede-ops.js — close the `/plan --tickets` source issues that the
+ * authored Stories supersede (Story #4535).
+ *
+ * `plan-context.js` fetches the source issues and emits `sourceTickets[]`;
+ * before this module nothing downstream consumed it, so every
+ * `/plan --tickets` run ended with an untracked manual chore and the tracker
+ * kept asserting that already-planned work was unowned.
+ *
+ * Two halves, deliberately separated by the `createIssue` boundary:
+ *
+ *   1. **`assertSupersedePartition`** — a plan-time, fail-closed check that
+ *      runs *before* any GitHub write. Mirrors `assertAcceptancePartition`:
+ *      every id passed to `--tickets` must be claimed by exactly one Story,
+ *      and no Story may claim an id that was not a source ticket. A partial
+ *      supersede map is a planning error, not something to paper over at
+ *      write time.
+ *   2. **`closeSupersededTickets`** — the bookkeeping pass that runs *after*
+ *      the Stories exist. It **never throws**: a throw here would leave the
+ *      run half-done with Stories already live. An already-closed, deleted,
+ *      or inaccessible source ticket is a clean skip-and-report, and a
+ *      partial failure reports which tickets were and were not closed so the
+ *      operator can finish by hand.
+ *
+ * Idempotency is keyed off the `superseded-by` structured-comment marker
+ * (`upsertStructuredComment`), not a bare `postComment`, so a re-run cannot
+ * double-comment.
+ *
+ * @module lib/orchestration/plan-persist/supersede-ops
+ */
+
+import { Logger } from '../../Logger.js';
+import { upsertStructuredComment } from '../ticketing.js';
+
+/** Structured-comment type marking a source issue as superseded. */
+const SUPERSEDED_BY_COMMENT_TYPE = 'superseded-by';
+
+/**
+ * GitHub `state_reason` used when closing a superseded source issue.
+ *
+ * At persist time nothing has shipped — the issue will not be actioned in
+ * its own right, so `not_planned` (not `completed`) is the honest reason.
+ * The repo history was inconsistent here (#4211 used `completed`, #2870
+ * `not_planned`); this constant settles it.
+ */
+export const SUPERSEDE_CLOSE_REASON = 'not_planned';
+
+/**
+ * Coerce one `supersedes[]` entry into `{ id, note }`.
+ *
+ * Accepts a bare issue number (`4525`), a numeric string (`"4525"`, `"#4525"`),
+ * or an object carrying an optional per-supersede note
+ * (`{ id: 4525, note: "…" }`). The note is what lets a Story record a
+ * *correction* to the source issue's analysis rather than template-only prose.
+ *
+ * @param {unknown} entry
+ * @param {string} slug Story slug, for error reporting.
+ * @returns {{ id: number, note: string|null }}
+ */
+function normalizeSupersedeEntry(entry, slug) {
+  const raw =
+    entry !== null && typeof entry === 'object'
+      ? (entry.id ?? entry.ticket)
+      : entry;
+  const id =
+    typeof raw === 'string' ? Number(raw.trim().replace(/^#/, '')) : raw;
+  if (!Number.isInteger(id) || id <= 0) {
+    throw new Error(
+      `[plan-persist] Story "${slug}" has an invalid supersedes entry: ` +
+        `${JSON.stringify(entry)} — expected a positive issue number or ` +
+        '{ id, note }.',
+    );
+  }
+  const note =
+    entry !== null &&
+    typeof entry === 'object' &&
+    typeof entry.note === 'string' &&
+    entry.note.trim() !== ''
+      ? entry.note.trim()
+      : null;
+  return { id, note };
+}
+
+/**
+ * Normalize a plan Story ticket's `supersedes[]` into `{ id, note }[]`.
+ * Absent / empty is a no-op returning `[]`.
+ *
+ * @param {object} ticket
+ * @param {string} slug
+ * @returns {Array<{ id: number, note: string|null }>}
+ */
+export function normalizeSupersedes(ticket, slug) {
+  const raw = ticket?.supersedes;
+  if (raw === undefined || raw === null) return [];
+  if (!Array.isArray(raw)) {
+    throw new Error(
+      `[plan-persist] Story "${slug}" has a non-array supersedes field — ` +
+        'expected number[] (or { id, note }[]).',
+    );
+  }
+  const normalized = raw.map((entry) => normalizeSupersedeEntry(entry, slug));
+  const seen = new Set();
+  for (const { id } of normalized) {
+    if (seen.has(id)) {
+      throw new Error(
+        `[plan-persist] Story "${slug}" claims #${id} twice in supersedes[].`,
+      );
+    }
+    seen.add(id);
+  }
+  return normalized;
+}
+
+/**
+ * Normalize the operator-supplied source-ticket id list (`--source-tickets`).
+ *
+ * @param {unknown} ids
+ * @returns {number[]}
+ */
+export function normalizeSourceTicketIds(ids) {
+  if (ids === undefined || ids === null) return [];
+  const list = Array.isArray(ids)
+    ? ids
+    : String(ids)
+        .split(',')
+        .map((token) => token.trim())
+        .filter((token) => token !== '');
+  const out = [];
+  for (const entry of list) {
+    const id =
+      typeof entry === 'string' ? Number(entry.replace(/^#/, '')) : entry;
+    if (!Number.isInteger(id) || id <= 0) {
+      throw new Error(
+        `[plan-persist] --source-tickets expects positive issue ids; got ${JSON.stringify(entry)}.`,
+      );
+    }
+    if (!out.includes(id)) out.push(id);
+  }
+  return out;
+}
+
+function describeStoryIds(entries) {
+  return entries.map((e) => `"${e}"`).join(', ');
+}
+
+/**
+ * Fail closed on a partial supersede map.
+ *
+ * Runs **before** `createIssue` so a mis-authored map never leaves Stories
+ * live against an inconsistent tracker.
+ *
+ * @param {Array<{ slug: string, supersedes: Array<{ id: number }> }>} stories
+ * @param {number[]} sourceTicketIds Ids passed to `/plan --tickets`.
+ */
+export function assertSupersedePartition(stories, sourceTicketIds = []) {
+  const list = Array.isArray(stories) ? stories : [];
+  const sources = new Set(sourceTicketIds);
+
+  /** @type {Map<number, string[]>} */
+  const claims = new Map();
+  for (const story of list) {
+    for (const { id } of story.supersedes ?? []) {
+      const owners = claims.get(id) ?? [];
+      owners.push(story.slug);
+      claims.set(id, owners);
+    }
+  }
+
+  const errors = [];
+
+  for (const [id, owners] of claims) {
+    if (owners.length > 1) {
+      errors.push(
+        `source ticket #${id} is claimed by ${owners.length} Stories ` +
+          `(${describeStoryIds(owners)}) — exactly one Story must own it.`,
+      );
+    }
+    if (!sources.has(id)) {
+      errors.push(
+        `Story "${owners[0]}" supersedes #${id}, which was not passed to ` +
+          '--tickets. Only source tickets may be superseded.',
+      );
+    }
+  }
+
+  for (const id of sources) {
+    if (!claims.has(id)) {
+      errors.push(
+        `source ticket #${id} is not claimed by any Story's supersedes[] — ` +
+          'a partial supersede map is a planning error. Claim it, or drop it ' +
+          'from --tickets.',
+      );
+    }
+  }
+
+  if (errors.length > 0) {
+    throw new Error(
+      `[plan-persist] supersede partition failed with ${errors.length} ` +
+        `error(s):\n${errors.map((e) => `  - ${e}`).join('\n')}`,
+    );
+  }
+}
+
+/**
+ * Render the supersede comment posted on a source issue.
+ *
+ * @param {object} args
+ * @param {{ id: number, title: string }} args.story The claiming Story.
+ * @param {string|null} [args.note] Optional per-supersede note authored on
+ *   the Story — carries a correction to this issue's analysis.
+ * @param {number[]} args.sourceTicketIds Full `--tickets` argument.
+ * @param {string|null} [args.planRunLabel]
+ * @returns {string}
+ */
+export function buildSupersedeCommentBody({
+  story,
+  note = null,
+  sourceTicketIds,
+  planRunLabel = null,
+}) {
+  const labels = ['`type::story`', '`agent::ready`'];
+  if (planRunLabel) labels.push(`\`${planRunLabel}\``);
+
+  const lines = [
+    `**Superseded by #${story.id}** — *${story.title}* (${labels.join(', ')}).`,
+    '',
+    `Planned via \`/plan --tickets ${sourceTicketIds.join(',')}\`.`,
+  ];
+  if (note) {
+    lines.push('', note);
+  }
+  lines.push(
+    '',
+    'The analysis in this issue is preserved as the historical record; ' +
+      `#${story.id} carries the delivery contract.`,
+  );
+  return lines.join('\n');
+}
+
+/**
+ * Resolve the live state of a source ticket.
+ *
+ * @returns {Promise<{ ok: true, state: string } | { ok: false, reason: string }>}
+ */
+async function probeSourceTicket(provider, id) {
+  try {
+    const ticket = await provider.getTicket(id, { fresh: true });
+    if (!ticket) return { ok: false, reason: 'not-found' };
+    return { ok: true, state: String(ticket.state ?? 'open').toLowerCase() };
+  } catch (err) {
+    return { ok: false, reason: `inaccessible: ${err.message}` };
+  }
+}
+
+/**
+ * Comment on and close one source ticket. Never throws.
+ *
+ * @returns {Promise<{ outcome: 'closed'|'skipped'|'failed', reason?: string }>}
+ */
+async function closeOneSupersededTicket({
+  provider,
+  id,
+  note,
+  story,
+  sourceTicketIds,
+  planRunLabel,
+}) {
+  const probe = await probeSourceTicket(provider, id);
+  if (!probe.ok) return { outcome: 'skipped', reason: probe.reason };
+  if (probe.state === 'closed') {
+    return { outcome: 'skipped', reason: 'already-closed' };
+  }
+
+  try {
+    await upsertStructuredComment(
+      provider,
+      id,
+      SUPERSEDED_BY_COMMENT_TYPE,
+      buildSupersedeCommentBody({
+        story,
+        note,
+        sourceTicketIds,
+        planRunLabel,
+      }),
+    );
+    await provider.updateTicket(id, {
+      state: 'closed',
+      state_reason: SUPERSEDE_CLOSE_REASON,
+    });
+    return { outcome: 'closed' };
+  } catch (err) {
+    return { outcome: 'failed', reason: err.message };
+  }
+}
+
+/**
+ * @typedef {object} SupersedeReport
+ * @property {boolean} enabled
+ * @property {boolean} dryRun
+ * @property {string|null} reason  Why the phase was skipped wholesale.
+ * @property {number[]} closed
+ * @property {Array<{ ticket: number, storyId: number }>} planned Dry-run only.
+ * @property {Array<{ ticket: number, reason: string }>} skipped
+ * @property {Array<{ ticket: number, reason: string }>} failed
+ */
+
+function emptyReport(overrides) {
+  return {
+    enabled: false,
+    dryRun: false,
+    reason: null,
+    closed: [],
+    planned: [],
+    skipped: [],
+    failed: [],
+    ...overrides,
+  };
+}
+
+/**
+ * Comment on and close every superseded source ticket.
+ *
+ * **Never throws** and never fails the run — Stories are already live by the
+ * time this executes, so bookkeeping failures degrade to a report the
+ * operator can act on.
+ *
+ * @param {object} args
+ * @param {object} args.provider
+ * @param {Array<{ slug: string, supersedes: Array<{ id: number, note: string|null }> }>} args.stories
+ * @param {Array<{ slug: string, id: number, title: string }>} args.created
+ * @param {number[]} args.sourceTicketIds
+ * @param {string|null} [args.planRunLabel]
+ * @param {boolean} [args.dryRun=false]
+ * @param {boolean} [args.closeSuperseded=true]
+ * @returns {Promise<SupersedeReport>}
+ */
+export async function closeSupersededTickets({
+  provider,
+  stories,
+  created,
+  sourceTicketIds,
+  planRunLabel = null,
+  dryRun = false,
+  closeSuperseded = true,
+}) {
+  const sources = Array.isArray(sourceTicketIds) ? sourceTicketIds : [];
+  if (sources.length === 0) {
+    return emptyReport({ reason: 'no-source-tickets' });
+  }
+  if (!closeSuperseded) {
+    return emptyReport({ reason: 'disabled-by-flag' });
+  }
+
+  const createdBySlug = new Map(
+    (created ?? []).map((story) => [story.slug, story]),
+  );
+
+  const report = emptyReport({ enabled: true, dryRun });
+
+  for (const story of stories ?? []) {
+    const createdStory = createdBySlug.get(story.slug);
+    for (const { id, note } of story.supersedes ?? []) {
+      if (!createdStory) {
+        report.skipped.push({ ticket: id, reason: 'story-not-created' });
+        continue;
+      }
+      if (dryRun) {
+        report.planned.push({ ticket: id, storyId: createdStory.id });
+        continue;
+      }
+      const result = await closeOneSupersededTicket({
+        provider,
+        id,
+        note,
+        story: createdStory,
+        sourceTicketIds: sources,
+        planRunLabel,
+      });
+      if (result.outcome === 'closed') {
+        report.closed.push(id);
+      } else if (result.outcome === 'skipped') {
+        report.skipped.push({ ticket: id, reason: result.reason });
+      } else {
+        report.failed.push({ ticket: id, reason: result.reason });
+      }
+    }
+  }
+
+  logSupersedeReport(report);
+  return report;
+}
+
+/**
+ * Surface the supersede outcome on the console so a partial failure is
+ * visible without reading the JSON envelope.
+ *
+ * @param {SupersedeReport} report
+ */
+function logSupersedeReport(report) {
+  if (report.dryRun) {
+    for (const { ticket, storyId } of report.planned) {
+      Logger.info(
+        `[plan-persist] dry-run: would comment on and close #${ticket} ` +
+          `as superseded by #${storyId} (${SUPERSEDE_CLOSE_REASON}).`,
+      );
+    }
+    return;
+  }
+  if (report.closed.length > 0) {
+    Logger.info(
+      `[plan-persist] closed ${report.closed.length} superseded source ` +
+        `ticket(s): ${report.closed.map((id) => `#${id}`).join(', ')}.`,
+    );
+  }
+  for (const { ticket, reason } of report.skipped) {
+    Logger.info(`[plan-persist] skipped source ticket #${ticket}: ${reason}.`);
+  }
+  for (const { ticket, reason } of report.failed) {
+    Logger.warn(
+      `[plan-persist] could NOT close source ticket #${ticket}: ${reason} — ` +
+        'close it by hand.',
+    );
+  }
+}

--- a/.agents/scripts/lib/orchestration/ticketing/reads.js
+++ b/.agents/scripts/lib/orchestration/ticketing/reads.js
@@ -183,6 +183,13 @@ export const STRUCTURED_COMMENT_TYPES = Object.freeze([
   // v2 Stage 3 — flat Story persist checkpoint on every created Story
   // (replaces epic-plan-state for new plans). plan-summary stays primary-only.
   'story-plan-state',
+  // Story #4535 — `plan-persist.js` upserts a `superseded-by` comment on
+  // each `/plan --tickets` source issue at persist time, naming the single
+  // Story that claims it (plus any per-supersede note the plan authored),
+  // immediately before closing the issue as `not_planned`. Keying off this
+  // marker rather than a bare `postComment` is what makes a re-run
+  // non-double-commenting. One entry per source issue.
+  'superseded-by',
 ]);
 
 export const WAVE_TYPE_PATTERN = WAVE_MARKER_RE;

--- a/.agents/scripts/plan-persist.js
+++ b/.agents/scripts/plan-persist.js
@@ -11,18 +11,23 @@
  *   risk-verdict → ticket validator / DAG / capacity → reachability →
  *   split-policy partition → fold/spill Spec into each Story body →
  *   createIssue(s) with type::story + agent::ready → risk-verdict +
- *   story-plan-state on every Story; plan-summary on the primary → temp
- *   cleanup.
+ *   story-plan-state on every Story; plan-summary on the primary →
+ *   comment + close superseded source tickets → temp cleanup.
  *
  * CLI:
- *   --stories <file>         Required Story ticket array (default length 1)
- *   --risk-verdict <file>    Required risk verdict (no deliveryShape)
- *   --tech-spec <file>       Optional shared Tech Spec folded into each Story
- *   --plan-dir <dir>         Optional temp dir deleted at terminal success
- *   --plan-acceptance <file> Optional JSON string[] for partition coverage
- *   --plan-run-id <id>       Optional plan-run token when N>1
- *   --dry-run                Assemble + validate without GitHub writes
- *   --force-review           Record operator-forced review routing
+ *   --stories <file>          Required Story ticket array (default length 1)
+ *   --risk-verdict <file>     Required risk verdict (no deliveryShape)
+ *   --tech-spec <file>        Optional shared Tech Spec folded into each Story
+ *   --plan-dir <dir>          Optional temp dir deleted at terminal success
+ *   --plan-acceptance <file>  Optional JSON string[] for partition coverage
+ *   --plan-run-id <id>        Optional plan-run token when N>1
+ *   --source-tickets <ids>    Ids passed to `/plan --tickets` — each must be
+ *                             claimed by exactly one Story's `supersedes[]`;
+ *                             they are commented on and closed as superseded
+ *   --no-close-superseded     Keep the source tickets open (no comment, no
+ *                             close) — for a genuinely partial supersede
+ *   --dry-run                 Assemble + validate without GitHub writes
+ *   --force-review            Record operator-forced review routing
  *   --allow-over-budget / --allow-large-fan-out
  *
  * Exit codes: 0 success; 1 fatal; 3 reachability orphans (nothing mutated).
@@ -54,6 +59,7 @@ import {
   buildWaveTable,
   PLAN_SUMMARY_COMMENT_TYPE,
 } from './lib/orchestration/plan-persist/summary.js';
+import { normalizeSourceTicketIds } from './lib/orchestration/plan-persist/supersede-ops.js';
 import { loadRiskVerdict } from './lib/orchestration/planning/risk-verdict.js';
 import { createProvider } from './lib/provider-factory.js';
 
@@ -72,6 +78,9 @@ const CLI_OPTIONS = {
   'plan-dir': { type: 'string' },
   'plan-acceptance': { type: 'string' },
   'plan-run-id': { type: 'string' },
+  'source-tickets': { type: 'string' },
+  'close-superseded': { type: 'boolean', default: true },
+  'no-close-superseded': { type: 'boolean', default: false },
   'dry-run': { type: 'boolean', default: false },
   'force-review': { type: 'boolean', default: false },
   'allow-over-budget': { type: 'boolean', default: false },
@@ -81,7 +90,8 @@ const CLI_OPTIONS = {
 const USAGE =
   'Usage: plan-persist.js --stories <file> --risk-verdict <file> ' +
   '[--tech-spec <file>] [--plan-dir <dir>] [--plan-acceptance <file>] ' +
-  '[--plan-run-id <id>] [--dry-run] [--force-review] ' +
+  '[--plan-run-id <id>] [--source-tickets <ids>] [--no-close-superseded] ' +
+  '[--dry-run] [--force-review] ' +
   '[--allow-over-budget] [--allow-large-fan-out]';
 
 async function readOptional(filePath, { required }) {
@@ -140,6 +150,13 @@ function buildPersistOptions(values, paths) {
     planRunId: values['plan-run-id'],
     planDir: paths.planDir,
     skipCleanup: values['dry-run'],
+    sourceTicketIds: normalizeSourceTicketIds(values['source-tickets']),
+    // Default-on: `--no-close-superseded` is the explicit escape and always
+    // wins over the (default `true`) `--close-superseded`.
+    closeSuperseded:
+      values['no-close-superseded'] === true
+        ? false
+        : values['close-superseded'] !== false,
   };
 }
 

--- a/.agents/workflows/plan.md
+++ b/.agents/workflows/plan.md
@@ -37,7 +37,8 @@ Audit findings become Stories via [`/audit-to-stories`](audit-to-stories.md)
 | --- | --- |
 | `--seed "<text>"` | Seed text for ideation. |
 | `--seed-file <path>` | Pre-authored notes / plan-seed path. |
-| `--tickets <ids>` | Comma-separated issue ids to analyze. |
+| `--tickets <ids>` | Comma-separated issue ids to analyze. Closed as superseded at persist (see below). |
+| `--no-close-superseded` | Keep the `--tickets` source issues open — no supersede comment, no close. |
 | `--force-review` | Force gate #2 operator review even when risk routing would skip it. |
 | `--allow-over-budget` | Permit a plan that exceeds `maxTickets` (rare N>1). |
 | `--yes` | Non-interactive: auto-proceed gate #1 and gate #2 HITL waits. |
@@ -100,6 +101,38 @@ Write artifacts under `temp/plan-<slug>/`:
 For N=1, use the envelope `systemPrompts.story` and emit one cohesive
 Story. Split only under the policy above.
 
+**Tickets mode — author `supersedes[]` on every Story.** In `--tickets`
+mode each Story carries a top-level `supersedes` array claiming the source
+issues it replaces. It is bookkeeping, not part of the Story body, so it is
+never serialized into the markdown:
+
+```jsonc
+{
+  "slug": "close-superseded",
+  "supersedes": [
+    4525,
+    { "id": 4529, "note": "The filed `--changed-only` fix is provably inert; the correction is recorded here." }
+  ]
+}
+```
+
+Entries are bare issue numbers, or `{ id, note }` when the plan has
+something to say about *that* source issue — a correction to its analysis,
+or why it was folded in with others. The optional `note` is rendered into
+that issue's supersede comment, so planning that materially corrects a
+source issue records the correction on the ticket rather than emitting
+template-only prose.
+
+### Supersede-map partition
+
+`plan-persist` refuses a partial supersede map **before** it creates any
+Story (mirroring `assertAcceptancePartition`): every id passed to
+`--tickets` must be claimed by **exactly one** Story, and no Story may
+claim an id that was not a source ticket. With N>1 the mapping is not
+total by default — an authored map is the only thing that can say
+`#4525-#4528 → #4530` while `#4529 → #4531`, which a blanket "superseded by
+this plan-run" reference could not.
+
 ### 3. Persist
 
 **Gate #2** — when risk routing requires review (or `--force-review`), STOP
@@ -112,6 +145,8 @@ node .agents/scripts/plan-persist.js \
   --risk-verdict temp/plan-<slug>/risk-verdict.json \
   [--tech-spec temp/plan-<slug>/techspec.md] \
   [--plan-dir temp/plan-<slug>] \
+  [--source-tickets 123,456] \
+  [--no-close-superseded] \
   [--dry-run] \
   [--force-review] \
   [--allow-over-budget]
@@ -120,6 +155,31 @@ node .agents/scripts/plan-persist.js \
 Persist creates Story issue(s) with `type::story` + `agent::ready`. When
 N>1 it also applies a shared `plan-run::<id>` label. Ends by naming
 `/deliver <storyId>` (or `/deliver --run <planRunId>` for N>1).
+
+In `--tickets` mode, pass the same ids to persist as `--source-tickets`.
+
+### Closing superseded source tickets
+
+**Default on.** After the Stories exist, persist comments on each source
+issue naming the specific Story that claims it — plus that Story's optional
+per-supersede `note` — and closes it with reason **`not_planned`**
+(`state_reason`). Nothing has shipped at persist time and the issue will not
+be actioned in its own right, so `not_planned` is the honest reason;
+`completed` would be a lie. This is what keeps the tracker from asserting
+that already-planned work is still unowned, and it writes down the supersede
+link that makes the history readable.
+
+| Behaviour | Contract |
+| --- | --- |
+| Default | Comment + close every source ticket as `not_planned`. |
+| `--no-close-superseded` | Skips all commenting and closing. Story creation is unchanged. Use it for a genuinely partial supersede — when the plan folded in only *part* of an issue and the remainder must stay open. |
+| `--dry-run` | Posts no comment and closes nothing; reports what it would have done. |
+| Re-run | Idempotent — the comment is keyed off a `superseded-by` structured-comment marker, and an already-closed source is skipped. |
+| Already closed / deleted / inaccessible | Skipped and reported. Never throws. |
+| Close-phase failure | **Never fails the run.** Stories stay created; the result envelope's `supersede` report names which tickets were and were not closed so the operator can finish by hand. |
+
+`--seed` / `--seed-file` modes have no source tickets, so no close phase
+runs at all.
 
 ## Constraints
 

--- a/tests/lib/orchestration/plan-persist-story-ops.test.js
+++ b/tests/lib/orchestration/plan-persist-story-ops.test.js
@@ -49,6 +49,44 @@ describe('planRunLabel', () => {
   });
 });
 
+describe('normalizeStoryTicket — supersedes (Story #4535)', () => {
+  it('normalizes a top-level supersedes[] onto the Story', () => {
+    const n = normalizeStoryTicket(
+      storyTicket('alpha', {
+        supersedes: [4525, { id: 4529, note: 'Correction.' }],
+      }),
+    );
+    assert.deepEqual(n.supersedes, [
+      { id: 4525, note: null },
+      { id: 4529, note: 'Correction.' },
+    ]);
+  });
+
+  it('defaults to [] when absent', () => {
+    assert.deepEqual(normalizeStoryTicket(storyTicket('alpha')).supersedes, []);
+  });
+
+  it('keeps supersedes out of the serialized body (bookkeeping, not contract)', () => {
+    const { stories } = assemblePlanStories(
+      [storyTicket('alpha', { supersedes: [4525] })],
+      { sourceTicketIds: [4525] },
+    );
+    assert.deepEqual(stories[0].supersedes, [{ id: 4525, note: null }]);
+    assert.doesNotMatch(stories[0].body, /supersede/i);
+    assert.equal(parse(stories[0].body).body.supersedes, undefined);
+  });
+
+  it('assemblePlanStories fails closed on a partial supersede map', () => {
+    assert.throws(
+      () =>
+        assemblePlanStories([storyTicket('alpha', { supersedes: [4525] })], {
+          sourceTicketIds: [4525, 4526],
+        }),
+      /supersede partition failed/,
+    );
+  });
+});
+
 describe('normalizeStoryTicket', () => {
   it('parses a serialized body', () => {
     const n = normalizeStoryTicket(storyTicket('alpha'));

--- a/tests/lib/orchestration/plan-persist-supersede-ops.test.js
+++ b/tests/lib/orchestration/plan-persist-supersede-ops.test.js
@@ -1,0 +1,327 @@
+/**
+ * Unit tests for the `/plan --tickets` supersede close phase (Story #4535).
+ */
+
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import {
+  assertSupersedePartition,
+  buildSupersedeCommentBody,
+  closeSupersededTickets,
+  normalizeSourceTicketIds,
+  normalizeSupersedes,
+  SUPERSEDE_CLOSE_REASON,
+} from '../../../.agents/scripts/lib/orchestration/plan-persist/supersede-ops.js';
+
+function story(slug, supersedes = []) {
+  return { slug, supersedes };
+}
+
+describe('normalizeSupersedes', () => {
+  it('accepts bare issue numbers (the documented number[] shape)', () => {
+    assert.deepEqual(normalizeSupersedes({ supersedes: [4525, 4526] }, 'a'), [
+      { id: 4525, note: null },
+      { id: 4526, note: null },
+    ]);
+  });
+
+  it('accepts { id, note } entries and carries the note', () => {
+    assert.deepEqual(
+      normalizeSupersedes(
+        { supersedes: [{ id: 4529, note: 'The filed fix is inert.' }] },
+        'a',
+      ),
+      [{ id: 4529, note: 'The filed fix is inert.' }],
+    );
+  });
+
+  it('accepts "#123" / "123" string ids', () => {
+    assert.deepEqual(normalizeSupersedes({ supersedes: ['#7', ' 8 '] }, 'a'), [
+      { id: 7, note: null },
+      { id: 8, note: null },
+    ]);
+  });
+
+  it('treats an absent field as a no-op', () => {
+    assert.deepEqual(normalizeSupersedes({}, 'a'), []);
+    assert.deepEqual(normalizeSupersedes({ supersedes: null }, 'a'), []);
+  });
+
+  it('drops a blank note to null', () => {
+    assert.deepEqual(
+      normalizeSupersedes({ supersedes: [{ id: 1, note: '  ' }] }, 'a'),
+      [{ id: 1, note: null }],
+    );
+  });
+
+  it('rejects a non-array field', () => {
+    assert.throws(
+      () => normalizeSupersedes({ supersedes: 4525 }, 'a'),
+      /non-array supersedes field/,
+    );
+  });
+
+  it('rejects a non-positive / non-numeric id', () => {
+    assert.throws(
+      () => normalizeSupersedes({ supersedes: [0] }, 'a'),
+      /invalid supersedes entry/,
+    );
+    assert.throws(
+      () => normalizeSupersedes({ supersedes: ['nope'] }, 'a'),
+      /invalid supersedes entry/,
+    );
+  });
+
+  it('rejects the same id claimed twice by one Story', () => {
+    assert.throws(
+      () => normalizeSupersedes({ supersedes: [5, { id: 5 }] }, 'a'),
+      /claims #5 twice/,
+    );
+  });
+});
+
+describe('normalizeSourceTicketIds', () => {
+  it('parses a comma-separated CLI string and dedupes', () => {
+    assert.deepEqual(
+      normalizeSourceTicketIds('4525, #4526,4525'),
+      [4525, 4526],
+    );
+  });
+
+  it('returns [] for absent input', () => {
+    assert.deepEqual(normalizeSourceTicketIds(undefined), []);
+    assert.deepEqual(normalizeSourceTicketIds(null), []);
+  });
+
+  it('rejects a non-positive id', () => {
+    assert.throws(
+      () => normalizeSourceTicketIds('4525,-1'),
+      /positive issue ids/,
+    );
+  });
+});
+
+describe('assertSupersedePartition', () => {
+  it('passes a total 1:1 map', () => {
+    assert.doesNotThrow(() =>
+      assertSupersedePartition(
+        [story('a', [{ id: 1 }]), story('b', [{ id: 2 }])],
+        [1, 2],
+      ),
+    );
+  });
+
+  it('passes an N<sources fold (4525-4528 → one Story)', () => {
+    assert.doesNotThrow(() =>
+      assertSupersedePartition(
+        [story('a', [{ id: 4525 }, { id: 4526 }, { id: 4527 }, { id: 4528 }])],
+        [4525, 4526, 4527, 4528],
+      ),
+    );
+  });
+
+  it('passes a no-source / no-claim plan (seed mode)', () => {
+    assert.doesNotThrow(() => assertSupersedePartition([story('a')], []));
+  });
+
+  it('rejects an unclaimed source ticket', () => {
+    assert.throws(
+      () => assertSupersedePartition([story('a', [{ id: 1 }])], [1, 2]),
+      /#2 is not claimed by any Story/,
+    );
+  });
+
+  it('rejects a source claimed by two Stories', () => {
+    assert.throws(
+      () =>
+        assertSupersedePartition(
+          [story('a', [{ id: 1 }]), story('b', [{ id: 1 }])],
+          [1],
+        ),
+      /#1 is claimed by 2 Stories/,
+    );
+  });
+
+  it('rejects a claim on a non-source ticket', () => {
+    assert.throws(
+      () =>
+        assertSupersedePartition([story('a', [{ id: 1 }, { id: 99 }])], [1]),
+      /#99, which was not passed to --tickets/,
+    );
+  });
+
+  it('rejects any claim when no source tickets were passed', () => {
+    assert.throws(
+      () => assertSupersedePartition([story('a', [{ id: 1 }])], []),
+      /was not passed to --tickets/,
+    );
+  });
+});
+
+describe('buildSupersedeCommentBody', () => {
+  const story4530 = { id: 4530, title: 'feat(plan): close superseded' };
+
+  it('names the specific Story, its labels, and the historical-record line', () => {
+    const body = buildSupersedeCommentBody({
+      story: story4530,
+      sourceTicketIds: [4525, 4526],
+      planRunLabel: 'plan-run::abc',
+    });
+    assert.match(
+      body,
+      /\*\*Superseded by #4530\*\* — \*feat\(plan\): close superseded\*/,
+    );
+    assert.match(body, /`type::story`, `agent::ready`, `plan-run::abc`/);
+    assert.match(body, /Planned via `\/plan --tickets 4525,4526`/);
+    assert.match(
+      body,
+      /preserved as the historical record; #4530 carries the delivery contract/,
+    );
+  });
+
+  it('omits the plan-run label for N=1', () => {
+    const body = buildSupersedeCommentBody({
+      story: story4530,
+      sourceTicketIds: [4525],
+    });
+    assert.doesNotMatch(body, /plan-run/);
+  });
+
+  it('renders the per-supersede note when present', () => {
+    const body = buildSupersedeCommentBody({
+      story: story4530,
+      note: 'The `--changed-only` fix filed here is provably inert.',
+      sourceTicketIds: [4529],
+    });
+    assert.match(
+      body,
+      /The `--changed-only` fix filed here is provably inert\./,
+    );
+  });
+});
+
+describe('closeSupersededTickets', () => {
+  function provider({ states = {}, onUpdate } = {}) {
+    const calls = { comments: [], updates: [] };
+    return {
+      calls,
+      async getTicket(id) {
+        const state = states[id];
+        if (state === undefined) throw new Error(`not found: #${id}`);
+        return { id, state };
+      },
+      async getTicketComments() {
+        return [];
+      },
+      async postComment(issueNumber, payload) {
+        calls.comments.push({ issueNumber, body: payload.body });
+        return { id: calls.comments.length };
+      },
+      async updateTicket(id, mutations) {
+        if (onUpdate) await onUpdate(id);
+        calls.updates.push({ id, mutations });
+      },
+    };
+  }
+
+  const stories = [{ slug: 'a', supersedes: [{ id: 1, note: null }] }];
+  const created = [{ slug: 'a', id: 500, title: 'Story A' }];
+
+  it('closes with state_reason not_planned', async () => {
+    const p = provider({ states: { 1: 'open' } });
+    const report = await closeSupersededTickets({
+      provider: p,
+      stories,
+      created,
+      sourceTicketIds: [1],
+    });
+    assert.deepEqual(report.closed, [1]);
+    assert.deepEqual(p.calls.updates, [
+      {
+        id: 1,
+        mutations: { state: 'closed', state_reason: SUPERSEDE_CLOSE_REASON },
+      },
+    ]);
+    assert.equal(SUPERSEDE_CLOSE_REASON, 'not_planned');
+  });
+
+  it('short-circuits with no-source-tickets when none were passed', async () => {
+    const p = provider();
+    const report = await closeSupersededTickets({
+      provider: p,
+      stories,
+      created,
+      sourceTicketIds: [],
+    });
+    assert.equal(report.enabled, false);
+    assert.equal(report.reason, 'no-source-tickets');
+    assert.deepEqual(p.calls.updates, []);
+  });
+
+  it('never throws when the provider write fails', async () => {
+    const p = provider({
+      states: { 1: 'open' },
+      onUpdate: () => {
+        throw new Error('boom');
+      },
+    });
+    const report = await closeSupersededTickets({
+      provider: p,
+      stories,
+      created,
+      sourceTicketIds: [1],
+    });
+    assert.deepEqual(report.failed, [{ ticket: 1, reason: 'boom' }]);
+    assert.deepEqual(report.closed, []);
+  });
+
+  it('does not double-comment on a re-run (structured-comment marker)', async () => {
+    // A source that stays open across runs (e.g. the close half failed the
+    // first time) is the only vector that can double-comment — the marker
+    // upsert must replace, not append.
+    const comments = [];
+    const p = {
+      async getTicket(id) {
+        return { id, state: 'open' };
+      },
+      async getTicketComments() {
+        return comments.map((c) => ({ ...c }));
+      },
+      async postComment(issueNumber, payload) {
+        comments.push({
+          id: comments.length + 1,
+          issueNumber,
+          body: payload.body,
+        });
+        return { id: comments.length };
+      },
+      async deleteComment(id) {
+        const idx = comments.findIndex((c) => c.id === id);
+        if (idx >= 0) comments.splice(idx, 1);
+      },
+      async updateTicket() {
+        throw new Error('close blocked');
+      },
+    };
+    const args = { provider: p, stories, created, sourceTicketIds: [1] };
+
+    await closeSupersededTickets(args);
+    await closeSupersededTickets(args);
+
+    assert.equal(comments.length, 1);
+    assert.match(comments[0].body, /Superseded by #500/);
+  });
+
+  it('reports a Story that was never created rather than throwing', async () => {
+    const p = provider({ states: { 1: 'open' } });
+    const report = await closeSupersededTickets({
+      provider: p,
+      stories,
+      created: [],
+      sourceTicketIds: [1],
+    });
+    assert.deepEqual(report.skipped, [
+      { ticket: 1, reason: 'story-not-created' },
+    ]);
+  });
+});

--- a/tests/scripts/plan-persist.flat-stories.test.js
+++ b/tests/scripts/plan-persist.flat-stories.test.js
@@ -375,8 +375,11 @@ describe('runPlanPersist — superseded source tickets (Story #4535)', () => {
     });
 
     assert.equal(result.supersede.dryRun, true);
-    assert.equal(result.supersede.planned.length, 1);
-    assert.equal(result.supersede.planned[0].ticket, 950);
+    // Reported by slug: dry-run creates no issue, so the only Story
+    // identifier that means anything here is the slug.
+    assert.deepEqual(result.supersede.planned, [
+      { ticket: 950, storySlug: 'solo' },
+    ]);
     assert.deepEqual(result.supersede.closed, []);
     assert.equal(sourceComments(provider, 950), '');
     assert.deepEqual(provider.updates, []);

--- a/tests/scripts/plan-persist.flat-stories.test.js
+++ b/tests/scripts/plan-persist.flat-stories.test.js
@@ -47,17 +47,39 @@ function ticket(slug) {
   };
 }
 
-function fakeProvider() {
+function fakeProvider({ sources = [] } = {}) {
   const issues = new Map();
   const comments = [];
+  const updates = [];
   let nextId = 5000;
+  for (const source of sources) {
+    issues.set(source.id, {
+      id: source.id,
+      title: source.title ?? `Source ${source.id}`,
+      body: source.body ?? '',
+      labels: [],
+      state: source.state ?? 'open',
+    });
+  }
   return {
     issues,
     comments,
+    updates,
     async createIssue({ title, body, labels }) {
       const id = nextId++;
       issues.set(id, { id, title, body, labels });
       return { id, url: `https://example.test/${id}` };
+    },
+    async getTicket(id) {
+      const issue = issues.get(id);
+      if (!issue) throw new Error(`ticket #${id} not found`);
+      return { ...issue, state: issue.state ?? 'open' };
+    },
+    async updateTicket(id, mutations) {
+      updates.push({ id, mutations });
+      const issue = issues.get(id);
+      if (!issue) throw new Error(`ticket #${id} not found`);
+      Object.assign(issue, mutations);
     },
     async getTicketComments(issueNumber) {
       return comments.filter((c) => c.issueNumber === issueNumber);
@@ -187,5 +209,254 @@ describe('runPlanPersist — flat Story ops', () => {
       assert.match(storyComments, /risk-verdict/);
       assert.match(storyComments, /story-plan-state/);
     }
+  });
+});
+
+describe('runPlanPersist — superseded source tickets (Story #4535)', () => {
+  function supersedingTicket(slug, supersedes) {
+    return { ...ticket(slug), supersedes };
+  }
+
+  function sourceComments(provider, id) {
+    return provider.comments
+      .filter((comment) => comment.issueNumber === id)
+      .map((comment) => comment.body)
+      .join('\n');
+  }
+
+  it('comments naming the claiming Story and closes as not_planned', async () => {
+    const provider = fakeProvider({
+      sources: [{ id: 900, title: 'Old idea' }],
+    });
+    const result = await runPlanPersist({
+      provider,
+      artifacts: {
+        stories: [supersedingTicket('solo', [900])],
+        riskVerdict: VERDICT,
+      },
+      opts: { skipCleanup: true, sourceTicketIds: [900] },
+    });
+
+    const storyId = result.primaryStoryId;
+    assert.deepEqual(result.supersede.closed, [900]);
+    assert.deepEqual(result.supersede.failed, []);
+
+    const body = sourceComments(provider, 900);
+    assert.match(body, new RegExp(`Superseded by #${storyId}`));
+    assert.match(body, /Story solo/);
+    assert.match(body, /superseded-by/);
+    // Names the specific Story, not a blanket plan-run reference.
+    assert.doesNotMatch(body, /superseded by this plan-run/i);
+
+    assert.deepEqual(provider.updates, [
+      { id: 900, mutations: { state: 'closed', state_reason: 'not_planned' } },
+    ]);
+    assert.equal(provider.issues.get(900).state, 'closed');
+  });
+
+  it('renders the per-supersede note authored on the Story', async () => {
+    const provider = fakeProvider({ sources: [{ id: 901 }] });
+    await runPlanPersist({
+      provider,
+      artifacts: {
+        stories: [
+          supersedingTicket('solo', [
+            {
+              id: 901,
+              note: 'The filed fix is provably inert — recorded here.',
+            },
+          ]),
+        ],
+        riskVerdict: VERDICT,
+      },
+      opts: { skipCleanup: true, sourceTicketIds: [901] },
+    });
+
+    assert.match(
+      sourceComments(provider, 901),
+      /The filed fix is provably inert — recorded here\./,
+    );
+  });
+
+  it('maps each source to exactly one Story when N>1', async () => {
+    const provider = fakeProvider({ sources: [{ id: 910 }, { id: 911 }] });
+    const result = await runPlanPersist({
+      provider,
+      artifacts: {
+        stories: [
+          supersedingTicket('one', [910]),
+          supersedingTicket('two', [911]),
+        ],
+        riskVerdict: VERDICT,
+      },
+      opts: { skipCleanup: true, sourceTicketIds: [910, 911], planRunId: 'r1' },
+    });
+
+    const byslug = new Map(result.stories.map((s) => [s.slug, s.id]));
+    assert.match(
+      sourceComments(provider, 910),
+      new RegExp(`Superseded by #${byslug.get('one')}`),
+    );
+    assert.match(
+      sourceComments(provider, 911),
+      new RegExp(`Superseded by #${byslug.get('two')}`),
+    );
+    assert.match(sourceComments(provider, 910), /plan-run::r1/);
+  });
+
+  it('fails closed on a partial supersede map before creating any Story', async () => {
+    const provider = fakeProvider({ sources: [{ id: 920 }, { id: 921 }] });
+    await assert.rejects(
+      () =>
+        runPlanPersist({
+          provider,
+          artifacts: {
+            stories: [supersedingTicket('solo', [920])],
+            riskVerdict: VERDICT,
+          },
+          opts: { skipCleanup: true, sourceTicketIds: [920, 921] },
+        }),
+      /supersede partition failed[\s\S]*#921 is not claimed/,
+    );
+    // Nothing was created: only the two pre-seeded sources remain.
+    assert.equal(provider.issues.size, 2);
+    assert.deepEqual(provider.updates, []);
+  });
+
+  it('rejects a Story claiming a ticket that was not a source', async () => {
+    const provider = fakeProvider({ sources: [{ id: 930 }] });
+    await assert.rejects(
+      () =>
+        runPlanPersist({
+          provider,
+          artifacts: {
+            stories: [supersedingTicket('solo', [930, 999])],
+            riskVerdict: VERDICT,
+          },
+          opts: { skipCleanup: true, sourceTicketIds: [930] },
+        }),
+      /#999, which was not passed to --tickets/,
+    );
+    assert.equal(provider.issues.size, 1);
+  });
+
+  it('--no-close-superseded leaves sources open but still creates Stories', async () => {
+    const provider = fakeProvider({ sources: [{ id: 940 }] });
+    const result = await runPlanPersist({
+      provider,
+      artifacts: {
+        stories: [supersedingTicket('solo', [940])],
+        riskVerdict: VERDICT,
+      },
+      opts: {
+        skipCleanup: true,
+        sourceTicketIds: [940],
+        closeSuperseded: false,
+      },
+    });
+
+    assert.equal(result.stories.length, 1);
+    assert.equal(result.supersede.enabled, false);
+    assert.equal(result.supersede.reason, 'disabled-by-flag');
+    assert.equal(sourceComments(provider, 940), '');
+    assert.deepEqual(provider.updates, []);
+    assert.equal(provider.issues.get(940).state, 'open');
+  });
+
+  it('--dry-run writes nothing and reports what it would have done', async () => {
+    const provider = fakeProvider({ sources: [{ id: 950 }] });
+    const result = await runPlanPersist({
+      provider,
+      artifacts: {
+        stories: [supersedingTicket('solo', [950])],
+        riskVerdict: VERDICT,
+      },
+      opts: { skipCleanup: true, sourceTicketIds: [950], dryRun: true },
+    });
+
+    assert.equal(result.supersede.dryRun, true);
+    assert.equal(result.supersede.planned.length, 1);
+    assert.equal(result.supersede.planned[0].ticket, 950);
+    assert.deepEqual(result.supersede.closed, []);
+    assert.equal(sourceComments(provider, 950), '');
+    assert.deepEqual(provider.updates, []);
+    assert.equal(provider.issues.get(950).state, 'open');
+  });
+
+  it('skips an already-closed source rather than re-commenting', async () => {
+    const provider = fakeProvider({
+      sources: [{ id: 960, state: 'closed' }],
+    });
+    const result = await runPlanPersist({
+      provider,
+      artifacts: {
+        stories: [supersedingTicket('solo', [960])],
+        riskVerdict: VERDICT,
+      },
+      opts: { skipCleanup: true, sourceTicketIds: [960] },
+    });
+
+    assert.deepEqual(result.supersede.closed, []);
+    assert.deepEqual(result.supersede.skipped, [
+      { ticket: 960, reason: 'already-closed' },
+    ]);
+    assert.equal(sourceComments(provider, 960), '');
+    assert.deepEqual(provider.updates, []);
+  });
+
+  it('skips an inaccessible source without failing the run', async () => {
+    const provider = fakeProvider();
+    const result = await runPlanPersist({
+      provider,
+      artifacts: {
+        stories: [supersedingTicket('solo', [970])],
+        riskVerdict: VERDICT,
+      },
+      opts: { skipCleanup: true, sourceTicketIds: [970] },
+    });
+
+    assert.equal(result.stories.length, 1);
+    assert.deepEqual(result.supersede.closed, []);
+    assert.equal(result.supersede.skipped[0].ticket, 970);
+    assert.match(result.supersede.skipped[0].reason, /inaccessible/);
+  });
+
+  it('reports a close failure without failing the run or orphaning Stories', async () => {
+    const provider = fakeProvider({ sources: [{ id: 980 }, { id: 981 }] });
+    provider.updateTicket = async (id) => {
+      if (id === 980) throw new Error('403 forbidden');
+      provider.issues.get(id).state = 'closed';
+    };
+
+    const result = await runPlanPersist({
+      provider,
+      artifacts: {
+        stories: [supersedingTicket('solo', [980, 981])],
+        riskVerdict: VERDICT,
+      },
+      opts: { skipCleanup: true, sourceTicketIds: [980, 981] },
+    });
+
+    // The Story survives — bookkeeping never fails the run.
+    assert.equal(result.stories.length, 1);
+    assert.ok(provider.issues.get(result.primaryStoryId));
+    assert.deepEqual(result.supersede.closed, [981]);
+    assert.deepEqual(result.supersede.failed, [
+      { ticket: 980, reason: '403 forbidden' },
+    ]);
+  });
+
+  it('runs no close phase in seed mode (no source tickets)', async () => {
+    const provider = fakeProvider();
+    const result = await runPlanPersist({
+      provider,
+      artifacts: { stories: [ticket('solo')], riskVerdict: VERDICT },
+      opts: { skipCleanup: true },
+    });
+
+    assert.equal(result.stories.length, 1);
+    assert.equal(result.supersede.enabled, false);
+    assert.equal(result.supersede.reason, 'no-source-tickets');
+    assert.deepEqual(provider.updates, []);
   });
 });


### PR DESCRIPTION
Closes #4535

_Auto-opened by `/single-story-deliver`._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Persist mutates GitHub issue state (comments and closes) on source tickets, but partition validation runs before Story creation and the close phase is designed not to roll back successful persists.
> 
> **Overview**
> **`/plan --tickets` persist now closes source issues by default** after Stories are created, instead of leaving them open for manual cleanup.
> 
> Stories in tickets mode carry a top-level **`supersedes[]`** (issue numbers or `{ id, note }`) that is planning bookkeeping only—it is **not** written into the Story markdown. **`assertSupersedePartition`** runs before any GitHub write (like acceptance partition): every `--source-tickets` id must be claimed by exactly one Story, with no extra or duplicate claims.
> 
> After Stories exist, persist upserts a **`superseded-by`** structured comment on each source issue (naming the claiming Story and optional per-issue note), then closes it with **`state_reason: not_planned`**. The close phase **never fails the run**; partial failures surface in a **`supersede`** report on the result envelope. **`--no-close-superseded`**, **`--dry-run`**, and idempotent re-runs are supported.
> 
> **CLI:** `plan-persist.js` gains **`--source-tickets`** and **`--no-close-superseded`**; **`plan.md`** documents authoring `supersedes[]` and the close contract.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2c2286b6a5f8e38985d5399f46d574d2b21ebbe6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->