### PR TITLE
fix: make `npm run verify` a true CI mirror: include dead-exports + arch-cycles (or catalogue them as CI-only) (#4549)

### DIFF
--- a/.agents/scripts/run-verify.js
+++ b/.agents/scripts/run-verify.js
@@ -5,22 +5,26 @@
  * Local full verification — a true CI mirror for the gates that CAN be proven
  * locally, without epic-scoped MI projection or push semantics.
  *
- * Order: audit (SCA) → lint (includes docs:check) → full test suite →
- * unified baselines → the standalone ratchets (arch-cycles, dead-exports,
- * context-budget).
+ * Order: audit (SCA) → lint (includes docs:check + the arch-cycles ratchet) →
+ * full test suite → unified baselines → the dead-exports and context-budget
+ * ratchets.
  *
  * The `audit` step runs `npm audit --audit-level=high`, matching CI's
  * "Dependency Vulnerability Audit (SCA)" gate so a local green no longer hides
  * a high-severity advisory that CI would fail on. It is independent of the
  * pre-push `PREPUSH_AUDIT` opt-in, which stays unchanged.
  *
- * The three standalone ratchets mirror CI's "Architecture Cycle Check" step in
- * the `baselines` job (Story #4549). They were previously reachable locally
- * only via the diff-scoped `npm run quality:preview` or a direct invocation, so
- * a clean `verify` could still hide a CI-red — the failure Story #4531 /
- * PR #4548 paid for with a full push → CI → fix → push round-trip. All three
- * are pure-Node and baseline-aware, and together add ~3s to a command that
- * already carries the full test suite.
+ * The trailing ratchets complete the mirror of CI's "Architecture Cycle Check"
+ * step in the `baselines` job (Story #4549). That step runs three checks;
+ * `check-arch-cycles.js` is deliberately absent from STEPS because the `lint`
+ * step above already runs it (see run-lint.js) — re-running it here would
+ * double-pay a gate verify already covers. `check-dead-exports.js` and
+ * `check-context-budget.js` had no such cover: they were reachable locally only
+ * via the diff-scoped `npm run quality:preview` or a direct invocation, so a
+ * clean `verify` could still hide a CI-red — the failure Story #4531 / PR #4548
+ * paid for with a full push → CI → fix → push round-trip. Both are pure-Node
+ * and baseline-aware, adding ~3s to a command that already carries the full
+ * test suite.
  *
  * A handful of CI gates cannot be reproduced by this command (action pinning,
  * TruffleHog secret scan, the BASELINE_SCOPE=full push-scoped maintainability
@@ -42,11 +46,6 @@ const STEPS = [
     label: 'baselines',
     cmd: 'node',
     args: ['.agents/scripts/check-baselines.js'],
-  },
-  {
-    label: 'arch-cycles',
-    cmd: 'node',
-    args: ['.agents/scripts/check-arch-cycles.js', '--format', 'text'],
   },
   {
     label: 'dead-exports',

--- a/.agents/scripts/run-verify.js
+++ b/.agents/scripts/run-verify.js
@@ -23,8 +23,9 @@
  * via the diff-scoped `npm run quality:preview` or a direct invocation, so a
  * clean `verify` could still hide a CI-red — the failure Story #4531 / PR #4548
  * paid for with a full push → CI → fix → push round-trip. Both are pure-Node
- * and baseline-aware, adding ~3s to a command that already carries the full
- * test suite.
+ * and baseline-aware, adding ~15s on a cold cache (dominated by knip's
+ * full-tree scan in check-dead-exports.js) to a command that already carries
+ * the full test suite.
  *
  * A handful of CI gates cannot be reproduced by this command (action pinning,
  * TruffleHog secret scan, the BASELINE_SCOPE=full push-scoped maintainability

--- a/.agents/scripts/run-verify.js
+++ b/.agents/scripts/run-verify.js
@@ -6,12 +6,21 @@
  * locally, without epic-scoped MI projection or push semantics.
  *
  * Order: audit (SCA) → lint (includes docs:check) → full test suite →
- * unified baselines.
+ * unified baselines → the standalone ratchets (arch-cycles, dead-exports,
+ * context-budget).
  *
  * The `audit` step runs `npm audit --audit-level=high`, matching CI's
  * "Dependency Vulnerability Audit (SCA)" gate so a local green no longer hides
  * a high-severity advisory that CI would fail on. It is independent of the
  * pre-push `PREPUSH_AUDIT` opt-in, which stays unchanged.
+ *
+ * The three standalone ratchets mirror CI's "Architecture Cycle Check" step in
+ * the `baselines` job (Story #4549). They were previously reachable locally
+ * only via the diff-scoped `npm run quality:preview` or a direct invocation, so
+ * a clean `verify` could still hide a CI-red — the failure Story #4531 /
+ * PR #4548 paid for with a full push → CI → fix → push round-trip. All three
+ * are pure-Node and baseline-aware, and together add ~3s to a command that
+ * already carries the full test suite.
  *
  * A handful of CI gates cannot be reproduced by this command (action pinning,
  * TruffleHog secret scan, the BASELINE_SCOPE=full push-scoped maintainability
@@ -33,6 +42,21 @@ const STEPS = [
     label: 'baselines',
     cmd: 'node',
     args: ['.agents/scripts/check-baselines.js'],
+  },
+  {
+    label: 'arch-cycles',
+    cmd: 'node',
+    args: ['.agents/scripts/check-arch-cycles.js', '--format', 'text'],
+  },
+  {
+    label: 'dead-exports',
+    cmd: 'node',
+    args: ['.agents/scripts/check-dead-exports.js'],
+  },
+  {
+    label: 'context-budget',
+    cmd: 'node',
+    args: ['.agents/scripts/check-context-budget.js'],
   },
 ];
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -125,12 +125,15 @@ npm run test:integration  # Real-git / hook-chain / long orchestration suites on
 npm test                  # Full suite (same as CI test gate)
 npm run test:profile      # Slow-test report → temp/test-profile.{tap,summary.txt}
 npm run verify            # Full local gate: audit + lint + full tests + baselines
+                          #   + ratchets (arch-cycles/dead-exports/context-budget)
                           #   (true CI mirror; CI-only gates in docs/ci-contract.md)
 ```
 
 Use `test:quick` while iterating, `test:integration` before pushing when you
 touched git/orchestration hooks, and `npm run verify` when you want pre-PR
-confidence (audit + lint + full tests + baselines). `npm run verify` is a
+confidence (audit + lint + full tests + baselines + the standalone ratchets
+CI's `baselines` job runs: arch-cycles, dead-exports, and context-budget).
+`npm run verify` is a
 **true CI mirror** for the gates it can prove locally, but a small set of CI
 gates (action pinning, the TruffleHog secret scan, and the push-scoped
 `BASELINE_SCOPE=full` maintainability run) cannot be reproduced from a local

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -125,14 +125,14 @@ npm run test:integration  # Real-git / hook-chain / long orchestration suites on
 npm test                  # Full suite (same as CI test gate)
 npm run test:profile      # Slow-test report → temp/test-profile.{tap,summary.txt}
 npm run verify            # Full local gate: audit + lint + full tests + baselines
-                          #   + ratchets (arch-cycles/dead-exports/context-budget)
+                          #   + dead-exports/context-budget ratchets
                           #   (true CI mirror; CI-only gates in docs/ci-contract.md)
 ```
 
 Use `test:quick` while iterating, `test:integration` before pushing when you
 touched git/orchestration hooks, and `npm run verify` when you want pre-PR
-confidence (audit + lint + full tests + baselines + the standalone ratchets
-CI's `baselines` job runs: arch-cycles, dead-exports, and context-budget).
+confidence (audit + lint + full tests + baselines + the dead-exports and
+context-budget ratchets; the arch-cycles ratchet rides along inside `lint`).
 `npm run verify` is a
 **true CI mirror** for the gates it can prove locally, but a small set of CI
 gates (action pinning, the TruffleHog secret scan, and the push-scoped

--- a/docs/ci-contract.md
+++ b/docs/ci-contract.md
@@ -4,9 +4,10 @@
 CI mirror** for every gate it *can* prove on a developer's machine: it runs
 `npm audit --audit-level=high` (matching CI's SCA step), then `npm run lint`,
 the full `npm test` suite, the unified baselines (`check-baselines.js`), and —
-as of Story #4549 — the three standalone ratchets CI's `baselines` job runs in
-its "Architecture Cycle Check" step (`check-arch-cycles.js`,
-`check-dead-exports.js`, `check-context-budget.js`) — the same shape CI runs.
+as of Story #4549 — the standalone ratchets CI's `baselines` job runs in its
+"Architecture Cycle Check" step (`check-dead-exports.js` and
+`check-context-budget.js`; the third, `check-arch-cycles.js`, is already run by
+the `lint` step) — the same shape CI runs.
 
 A green `npm run verify` therefore no longer hides a high-severity advisory
 that CI's audit step would fail on. It is still **not** a total substitute for
@@ -22,17 +23,24 @@ authoritative verdict is the CI run on the pull request.
 > deliberately left off by default and is unchanged — the audit belongs in the
 > full `verify` gate, not on every push.
 
-> **Not** CI-only gates: the three standalone ratchets. `check-arch-cycles.js`,
-> `check-dead-exports.js`, and `check-context-budget.js` are pure-Node,
-> baseline-aware, and full-tree-safe, so `npm run verify` runs all three
-> (Story #4549). Before that they sat in a contract hole — omitted from the
-> mirror *and* absent from the CI-only table below — reachable locally only by
-> a direct invocation or via `npm run quality:preview`, whose
-> `--changed-since HEAD` diff scoping makes it a pre-commit tool rather than a
-> full-tree gate. That hole cost Story #4531 / PR #4548 a full
-> push → CI-red → fix → push round-trip on a stray `export default` a
-> two-second local check would have caught. `quality:preview` keeps its
-> existing scope and gate set — the two commands serve different moments.
+> **Not** CI-only gates: the standalone ratchets in CI's "Architecture Cycle
+> Check" step. All three are pure-Node, baseline-aware and full-tree-safe, so
+> `npm run verify` covers every one (Story #4549):
+>
+> | Ratchet | How `npm run verify` covers it |
+> | --- | --- |
+> | `check-arch-cycles.js` | Via the `lint` step — `run-lint.js` has run it since Story #3991. Deliberately **not** repeated in `run-verify.js`; doing so would double-pay the gate. |
+> | `check-dead-exports.js` | Its own `dead-exports` step (Story #4549). |
+> | `check-context-budget.js` | Its own `context-budget` step (Story #4549). |
+>
+> Before #4549 the latter two sat in a contract hole — omitted from the mirror
+> *and* absent from the CI-only table below — reachable locally only by a direct
+> invocation or via `npm run quality:preview`, whose `--changed-since HEAD` diff
+> scoping makes it a pre-commit tool rather than a full-tree gate. That hole
+> cost Story #4531 / PR #4548 a full push → CI-red → fix → push round-trip on a
+> stray `export default` a two-second local check would have caught.
+> `quality:preview` keeps its existing scope and gate set — the two commands
+> serve different moments.
 
 ## CI-only gates `npm run verify` cannot prove locally
 

--- a/docs/ci-contract.md
+++ b/docs/ci-contract.md
@@ -38,7 +38,7 @@ authoritative verdict is the CI run on the pull request.
 > invocation or via `npm run quality:preview`, whose `--changed-since HEAD` diff
 > scoping makes it a pre-commit tool rather than a full-tree gate. That hole
 > cost Story #4531 / PR #4548 a full push → CI-red → fix → push round-trip on a
-> stray `export default` a two-second local check would have caught.
+> stray `export default` a local check would have caught in seconds.
 > `quality:preview` keeps its existing scope and gate set — the two commands
 > serve different moments.
 

--- a/docs/ci-contract.md
+++ b/docs/ci-contract.md
@@ -3,8 +3,10 @@
 `npm run verify` is the local pre-PR gate. As of Story #4357 it is a **true
 CI mirror** for every gate it *can* prove on a developer's machine: it runs
 `npm audit --audit-level=high` (matching CI's SCA step), then `npm run lint`,
-the full `npm test` suite, and the unified baselines
-(`check-baselines.js`) — the same shape CI runs.
+the full `npm test` suite, the unified baselines (`check-baselines.js`), and —
+as of Story #4549 — the three standalone ratchets CI's `baselines` job runs in
+its "Architecture Cycle Check" step (`check-arch-cycles.js`,
+`check-dead-exports.js`, `check-context-budget.js`) — the same shape CI runs.
 
 A green `npm run verify` therefore no longer hides a high-severity advisory
 that CI's audit step would fail on. It is still **not** a total substitute for
@@ -19,6 +21,18 @@ authoritative verdict is the CI run on the pull request.
 > the pre-push `PREPUSH_AUDIT=1` opt-in (`.husky/pre-push`), which is
 > deliberately left off by default and is unchanged — the audit belongs in the
 > full `verify` gate, not on every push.
+
+> **Not** CI-only gates: the three standalone ratchets. `check-arch-cycles.js`,
+> `check-dead-exports.js`, and `check-context-budget.js` are pure-Node,
+> baseline-aware, and full-tree-safe, so `npm run verify` runs all three
+> (Story #4549). Before that they sat in a contract hole — omitted from the
+> mirror *and* absent from the CI-only table below — reachable locally only by
+> a direct invocation or via `npm run quality:preview`, whose
+> `--changed-since HEAD` diff scoping makes it a pre-commit tool rather than a
+> full-tree gate. That hole cost Story #4531 / PR #4548 a full
+> push → CI-red → fix → push round-trip on a stray `export default` a
+> two-second local check would have caught. `quality:preview` keeps its
+> existing scope and gate set — the two commands serve different moments.
 
 ## CI-only gates `npm run verify` cannot prove locally
 
@@ -51,6 +65,6 @@ arming gate regardless of the required-check configuration.
 ## Practical implication
 
 Run `npm run verify` before opening a PR for fast, local confidence across
-audit + lint + test + baselines. Treat the three gates above as the residual
+audit + lint + test + baselines + ratchets. Treat the three gates above as the residual
 risk that only the CI run on the pull request can close — do not read a local
 green as a guaranteed remote green.

--- a/tests/scripts/run-verify.test.js
+++ b/tests/scripts/run-verify.test.js
@@ -1,7 +1,16 @@
 import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
 import { test } from 'node:test';
+import { fileURLToPath } from 'node:url';
 
 import { runVerifySteps } from '../../.agents/scripts/run-verify.js';
+
+const REPO_ROOT = path.join(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '..',
+  '..',
+);
 
 test('runVerifySteps stops on first failing step', () => {
   const calls = [];
@@ -36,7 +45,6 @@ test('runVerifySteps runs audit, lint, test, baselines, then the ratchets in ord
     ['npm', 'run', 'lint'],
     ['npm', 'test'],
     ['node', '.agents/scripts/check-baselines.js'],
-    ['node', '.agents/scripts/check-arch-cycles.js', '--format', 'text'],
     ['node', '.agents/scripts/check-dead-exports.js'],
     ['node', '.agents/scripts/check-context-budget.js'],
   ]);
@@ -45,7 +53,7 @@ test('runVerifySteps runs audit, lint, test, baselines, then the ratchets in ord
 // Story #4549: verify advertises itself as a true CI mirror, so every gate CI's
 // `baselines` job runs must be reachable from it. A clean verify that skipped
 // the dead-export ratchet is exactly what let PR #4548 reach a red CI.
-test('runVerifySteps mirrors every check in CI’s "Architecture Cycle Check" step', () => {
+test('runVerifySteps runs the ratchets CI’s "Architecture Cycle Check" step covers', () => {
   const calls = [];
   runVerifySteps({
     spawn: (cmd, args) => {
@@ -54,16 +62,47 @@ test('runVerifySteps mirrors every check in CI’s "Architecture Cycle Check" st
     },
     shell: false,
   });
-  for (const script of [
-    'check-arch-cycles.js',
-    'check-dead-exports.js',
-    'check-context-budget.js',
-  ]) {
+  for (const script of ['check-dead-exports.js', 'check-context-budget.js']) {
     assert.ok(
       calls.some((call) => call.includes(script)),
       `expected verify to run ${script}`,
     );
   }
+});
+
+// The third check in that CI step, check-arch-cycles.js, is already run by the
+// `lint` step (run-lint.js). Adding it to STEPS as well would double-pay a gate
+// verify already covers — this guards against that regression.
+test('runVerifySteps does not re-run arch-cycles, which the lint step already covers', () => {
+  const calls = [];
+  runVerifySteps({
+    spawn: (cmd, args) => {
+      calls.push([cmd, ...args].join(' '));
+      return { status: 0 };
+    },
+    shell: false,
+  });
+  assert.equal(
+    calls.filter((call) => call.includes('check-arch-cycles.js')).length,
+    0,
+  );
+  assert.ok(calls.includes('npm run lint'));
+});
+
+// The test above is only safe while `lint` really does carry arch-cycles. Pin
+// that, or dropping it from run-lint.js would silently reopen the very gap
+// this Story closed. Asserted against the source text rather than an import:
+// run-lint.js is a top-level-await driver that would spawn biome on import.
+test('run-lint.js still carries the arch-cycles ratchet verify relies on it for', () => {
+  const source = readFileSync(
+    path.join(REPO_ROOT, '.agents/scripts/run-lint.js'),
+    'utf8',
+  );
+  assert.ok(
+    source.includes('check-arch-cycles.js'),
+    'run-lint.js no longer runs check-arch-cycles.js — verify now has no ' +
+      'arch-cycles coverage; add it to run-verify.js STEPS.',
+  );
 });
 
 test('runVerifySteps reports a failing ratchet by its own step label', () => {

--- a/tests/scripts/run-verify.test.js
+++ b/tests/scripts/run-verify.test.js
@@ -21,7 +21,7 @@ test('runVerifySteps stops on first failing step', () => {
   assert.equal(calls.length, 3);
 });
 
-test('runVerifySteps runs audit, lint, test, and baselines in order', () => {
+test('runVerifySteps runs audit, lint, test, baselines, then the ratchets in order', () => {
   const calls = [];
   const outcome = runVerifySteps({
     spawn: (cmd, args) => {
@@ -31,10 +31,52 @@ test('runVerifySteps runs audit, lint, test, and baselines in order', () => {
     shell: false,
   });
   assert.deepEqual(outcome, { ok: true });
-  assert.deepEqual(calls[0], ['npm', 'audit', '--audit-level=high']);
-  assert.deepEqual(calls[1], ['npm', 'run', 'lint']);
-  assert.deepEqual(calls[2], ['npm', 'test']);
-  assert.deepEqual(calls[3], ['node', '.agents/scripts/check-baselines.js']);
+  assert.deepEqual(calls, [
+    ['npm', 'audit', '--audit-level=high'],
+    ['npm', 'run', 'lint'],
+    ['npm', 'test'],
+    ['node', '.agents/scripts/check-baselines.js'],
+    ['node', '.agents/scripts/check-arch-cycles.js', '--format', 'text'],
+    ['node', '.agents/scripts/check-dead-exports.js'],
+    ['node', '.agents/scripts/check-context-budget.js'],
+  ]);
+});
+
+// Story #4549: verify advertises itself as a true CI mirror, so every gate CI's
+// `baselines` job runs must be reachable from it. A clean verify that skipped
+// the dead-export ratchet is exactly what let PR #4548 reach a red CI.
+test('runVerifySteps mirrors every check in CI’s "Architecture Cycle Check" step', () => {
+  const calls = [];
+  runVerifySteps({
+    spawn: (cmd, args) => {
+      calls.push([cmd, ...args].join(' '));
+      return { status: 0 };
+    },
+    shell: false,
+  });
+  for (const script of [
+    'check-arch-cycles.js',
+    'check-dead-exports.js',
+    'check-context-budget.js',
+  ]) {
+    assert.ok(
+      calls.some((call) => call.includes(script)),
+      `expected verify to run ${script}`,
+    );
+  }
+});
+
+test('runVerifySteps reports a failing ratchet by its own step label', () => {
+  const outcome = runVerifySteps({
+    spawn: (_cmd, args) =>
+      args.some((arg) => arg.includes('check-dead-exports.js'))
+        ? { status: 1 }
+        : { status: 0 },
+    shell: false,
+  });
+  assert.equal(outcome.ok, false);
+  assert.equal(outcome.failedStep, 'dead-exports');
+  assert.equal(outcome.exitCode, 1);
 });
 
 test('runVerifySteps surfaces a failing high-severity audit first', () => {


### PR DESCRIPTION
Closes #4549

_Auto-opened by `/single-story-deliver`._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes only extend the local verify orchestrator, documentation, and tests; no runtime product or security-sensitive logic is modified.
> 
> **Overview**
> **`npm run verify` now runs the same standalone architecture ratchets as CI’s baselines “Architecture Cycle Check” step**, closing a gap where local green could still fail remotely (e.g. stray dead exports).
> 
> After audit → lint → test → unified baselines, verify adds **`check-dead-exports.js`** and **`check-context-budget.js`** as dedicated steps. **`check-arch-cycles.js` is not duplicated** in verify because it already runs inside `npm run lint` via `run-lint.js`.
> 
> **Docs** (`AGENTS.md`, `docs/ci-contract.md`) describe the expanded verify pipeline and document how each of the three ratchets is covered locally vs. the unchanged CI-only gates.
> 
> **Tests** assert step order, ratchet presence, no double arch-cycles run, a source-text guard that lint still invokes arch-cycles, and that a failing ratchet surfaces its step label (`dead-exports`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 25612988be6174b2516835f51ad13c09efd3373e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->