### PR TITLE
fix: fix plan-run epilogue audit-roster: its combined-diff file set is empty by construction (#4550)

### DIFF
--- a/.agents/scripts/lib/orchestration/run-epilogue.js
+++ b/.agents/scripts/lib/orchestration/run-epilogue.js
@@ -131,22 +131,280 @@ export function planRunEpilogue({ planRunId, stories } = {}) {
   };
 }
 
-async function listChangedFiles(cwd, baseRef = 'origin/main') {
+/**
+ * How many first-parent commits of the base ref to scan when looking for the
+ * run's landed squash-merges. The epilogue fires immediately after the run's
+ * last Story lands, so the run's merges sit within the first handful of
+ * commits; the limit only bounds the pathological case.
+ * @type {number}
+ */
+const BASE_SCAN_LIMIT = 500;
+
+/** ASCII unit separator — cannot occur in a git commit subject. */
+const FIELD_SEP = '\x1f';
+
+/**
+ * Read the base ref's first-parent history as `{ sha, parents, subject }`
+ * records, newest-first.
+ *
+ * @param {object} args
+ * @param {string} args.cwd
+ * @param {string} args.baseRef
+ * @param {number} args.scanLimit
+ * @param {{ gitSpawn: Function }} args.git
+ * @returns {{ ok: true, commits: Array<{sha: string, parents: string[], subject: string}> }
+ *          | { ok: false, reason: string }}
+ */
+function readFirstParentHistory({ cwd, baseRef, scanLimit, git }) {
+  let result;
   try {
-    const result = gitSpawn(cwd, 'diff', '--name-only', `${baseRef}...HEAD`);
-    if (result.status !== 0) return [];
-    return String(result.stdout ?? '')
-      .split('\n')
-      .map((line) => line.trim())
-      .filter(Boolean);
-  } catch {
-    return [];
+    result = git.gitSpawn(
+      cwd,
+      'log',
+      '--first-parent',
+      baseRef,
+      `--max-count=${scanLimit}`,
+      `--format=%H${FIELD_SEP}%P${FIELD_SEP}%s`,
+    );
+  } catch (err) {
+    return {
+      ok: false,
+      reason: `\`git log ${baseRef}\` could not be spawned: ${err?.message ?? String(err)}`,
+    };
   }
+  if (result?.status !== 0) {
+    const detail =
+      String(result?.stderr ?? '').split('\n')[0] || 'unknown error';
+    return {
+      ok: false,
+      reason: `\`git log ${baseRef}\` failed (is \`${baseRef}\` fetched?): ${detail}`,
+    };
+  }
+  const commits = String(result.stdout ?? '')
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((line) => {
+      const [sha, parents, ...rest] = line.split(FIELD_SEP);
+      return {
+        sha,
+        parents: parents ? parents.split(' ').filter(Boolean) : [],
+        subject: rest.join(FIELD_SEP),
+      };
+    });
+  return { ok: true, commits };
 }
 
-async function executeAuditRoster({ planRunId, stories, cwd, provider }) {
+/**
+ * Resolve the **pre-run base sha**: the commit the base branch pointed at
+ * before the run's first Story landed.
+ *
+ * Why not `origin/main...HEAD` (the bug this replaces): the epilogue runs
+ * *after* the run's last Story lands, so HEAD in the main checkout is either
+ * `origin/main` itself or an ancestor of it. The three-dot merge-base is then
+ * HEAD, and the diff is empty **by construction** — it never reported the
+ * run's real diff. Rolling HEAD back does not help, so branch-reaping /
+ * cleanup ordering is not the cause; the refs being compared are.
+ *
+ * The derivation walks the base ref's first-parent history for the run's
+ * landed squash-merges. Every Story PR title carries a `(#<storyId>)` suffix
+ * (guaranteed by `normalizePrTitle` in the close pipeline) and GitHub uses the
+ * PR title as the squash subject, so the marker is a reliable, offline handle
+ * that does **not** depend on the Story branches still existing. The earliest
+ * such merge's first parent is the pre-run base.
+ *
+ * @param {object} args
+ * @param {Array<string|number>} args.stories - Story ids in the run.
+ * @param {string} args.cwd
+ * @param {string} [args.baseRef] - Remote-tracking base ref, e.g. `origin/main`.
+ * @param {number} [args.scanLimit]
+ * @param {{ gitSpawn: Function }} [args.git]
+ * @returns {{ resolved: true, baseSha: string, mergeSha: string, storyId: number, baseRef: string }
+ *          | { resolved: false, reason: string, baseRef: string }}
+ */
+export function resolveRunBaseSha({
+  stories,
+  cwd,
+  baseRef = 'origin/main',
+  scanLimit = BASE_SCAN_LIMIT,
+  git = { gitSpawn },
+} = {}) {
+  const ids = (Array.isArray(stories) ? stories : [])
+    .map(Number)
+    .filter((n) => Number.isInteger(n) && n > 0);
+  if (ids.length === 0) {
+    return {
+      resolved: false,
+      baseRef,
+      reason:
+        'the run carries no numeric Story ids to match landed merges against',
+    };
+  }
+
+  const history = readFirstParentHistory({ cwd, baseRef, scanLimit, git });
+  if (!history.ok) {
+    return { resolved: false, baseRef, reason: history.reason };
+  }
+
+  // `git log` is newest-first; walk backwards so the first hit is the
+  // *earliest* merge belonging to the run.
+  const markers = ids.map((id) => ({ id, marker: `(#${id})` }));
+  for (let i = history.commits.length - 1; i >= 0; i -= 1) {
+    const commit = history.commits[i];
+    const hit = markers.find(({ marker }) => commit.subject.includes(marker));
+    if (!hit) continue;
+    const baseSha = commit.parents[0];
+    if (!baseSha) {
+      return {
+        resolved: false,
+        baseRef,
+        reason: `the earliest landed merge for the run (${commit.sha}, Story #${hit.id}) is a root commit — it has no first parent to use as the pre-run base`,
+      };
+    }
+    return {
+      resolved: true,
+      baseRef,
+      baseSha,
+      mergeSha: commit.sha,
+      storyId: hit.id,
+    };
+  }
+
+  return {
+    resolved: false,
+    baseRef,
+    reason: `no landed squash-merge carrying a \`(#<storyId>)\` marker for ${ids
+      .map((id) => `#${id}`)
+      .join(
+        ', ',
+      )} was found in the last ${scanLimit} first-parent commits of \`${baseRef}\` — has the run landed?`,
+  };
+}
+
+/**
+ * List the files the run changed: `<pre-run base>...<baseRef>`.
+ *
+ * @returns {{ ok: true, files: string[] } | { ok: false, reason: string }}
+ */
+function listChangedFiles({ cwd, baseSha, headRef, git }) {
+  const range = `${baseSha}...${headRef}`;
+  let result;
+  try {
+    result = git.gitSpawn(cwd, 'diff', '--name-only', range);
+  } catch (err) {
+    return {
+      ok: false,
+      reason: `\`git diff ${range}\` could not be spawned: ${err?.message ?? String(err)}`,
+    };
+  }
+  if (result?.status !== 0) {
+    const detail =
+      String(result?.stderr ?? '').split('\n')[0] || 'unknown error';
+    return { ok: false, reason: `\`git diff ${range}\` failed: ${detail}` };
+  }
+  return {
+    ok: true,
+    files: String(result.stdout ?? '')
+      .split('\n')
+      .map((line) => line.trim())
+      .filter(Boolean),
+  };
+}
+
+/**
+ * Resolve the run's combined landed diff, or an explicit reason it could not
+ * be computed. Never conflates "could not compute" with "zero files changed".
+ *
+ * @returns {{ resolved: boolean, changedFiles: string[], baseSha: string|null,
+ *             mergeSha: string|null, baseRef: string, reason: string|null }}
+ */
+function resolveCombinedDiff({ stories, cwd, baseRef, git }) {
+  const base = resolveRunBaseSha({ stories, cwd, baseRef, git });
+  if (!base.resolved) {
+    return {
+      resolved: false,
+      changedFiles: [],
+      baseSha: null,
+      mergeSha: null,
+      baseRef,
+      reason: base.reason,
+    };
+  }
+  const diff = listChangedFiles({
+    cwd,
+    baseSha: base.baseSha,
+    headRef: baseRef,
+    git,
+  });
+  if (!diff.ok) {
+    return {
+      resolved: false,
+      changedFiles: [],
+      baseSha: base.baseSha,
+      mergeSha: base.mergeSha,
+      baseRef,
+      reason: diff.reason,
+    };
+  }
+  return {
+    resolved: true,
+    changedFiles: diff.files,
+    baseSha: base.baseSha,
+    mergeSha: base.mergeSha,
+    baseRef,
+    reason: null,
+  };
+}
+
+/**
+ * The diff line of the roster comment. An unresolved base MUST read as a
+ * loud failure, never as `Changed files considered: 0`.
+ *
+ * @param {ReturnType<typeof resolveCombinedDiff>} diff
+ * @returns {string[]}
+ */
+function renderDiffLines(diff) {
+  if (!diff.resolved) {
+    return [
+      '> ⚠️ **Combined landed diff unavailable — this is NOT "zero files changed".**',
+      `> The pre-run base sha could not be resolved: ${diff.reason}`,
+      '> Walk the lenses below against the run diff determined by hand.',
+    ];
+  }
+  return [
+    `Combined landed diff \`${diff.baseSha}...${diff.baseRef}\` — ` +
+      `**${diff.changedFiles.length}** changed file(s).`,
+  ];
+}
+
+/**
+ * @param {object} config
+ * @returns {string} the remote-tracking base ref, e.g. `origin/main`.
+ */
+function resolveBaseRef(config) {
+  const baseBranch = config?.project?.baseBranch;
+  const branch =
+    typeof baseBranch === 'string' && baseBranch.trim() !== ''
+      ? baseBranch.trim()
+      : 'main';
+  return `origin/${branch}`;
+}
+
+async function executeAuditRoster({
+  planRunId,
+  stories,
+  cwd,
+  provider,
+  config,
+  git,
+}) {
   const primaryId = Number(stories[0]);
-  const changedFiles = await listChangedFiles(cwd);
+  const diff = resolveCombinedDiff({
+    stories,
+    cwd,
+    baseRef: resolveBaseRef(config),
+    git,
+  });
   let selectedAudits = [];
   if (Number.isInteger(primaryId) && primaryId > 0) {
     const selected = await selectAudits({
@@ -162,12 +420,17 @@ async function executeAuditRoster({ planRunId, stories, cwd, provider }) {
         ? selected
         : [];
   }
+  if (!diff.resolved) {
+    Logger.warn(
+      `[run-epilogue] plan-run ${planRunId}: combined landed diff unavailable — ${diff.reason}`,
+    );
+  }
   const body = [
     '### plan-run-audit-roster',
     '',
     `Cross-Story audit roster for plan-run \`${planRunId}\`.`,
     '',
-    `Changed files considered: ${changedFiles.length}.`,
+    ...renderDiffLines(diff),
     '',
     '**Selected lenses** (host MUST walk each against the combined landed diff):',
     ...(selectedAudits.length > 0
@@ -179,7 +442,14 @@ async function executeAuditRoster({ planRunId, stories, cwd, provider }) {
       {
         planRunId,
         stories: stories.map(Number),
-        changedFiles,
+        baseResolution: {
+          resolved: diff.resolved,
+          baseRef: diff.baseRef,
+          baseSha: diff.baseSha,
+          mergeSha: diff.mergeSha,
+          reason: diff.reason,
+        },
+        changedFiles: diff.resolved ? diff.changedFiles : null,
         selectedAudits,
       },
       null,
@@ -198,7 +468,17 @@ async function executeAuditRoster({ planRunId, stories, cwd, provider }) {
   return {
     kind: 'audit-roster',
     selectedAudits,
-    changedFileCount: changedFiles.length,
+    // `null` — not `0` — when unresolved: a zero count must only ever mean
+    // "the run genuinely changed nothing".
+    changedFileCount: diff.resolved ? diff.changedFiles.length : null,
+    changedFiles: diff.resolved ? diff.changedFiles : null,
+    baseResolution: {
+      resolved: diff.resolved,
+      baseRef: diff.baseRef,
+      baseSha: diff.baseSha,
+      mergeSha: diff.mergeSha,
+      reason: diff.reason,
+    },
   };
 }
 
@@ -359,6 +639,7 @@ async function executeSiblingCoherence({ planRunId, stories, provider }) {
  * @param {object} args.provider
  * @param {object} [args.config]
  * @param {string} [args.cwd]
+ * @param {{ gitSpawn: Function }} [args.git] - Injection seam for tests.
  * @returns {Promise<object>}
  */
 export async function runPlanRunEpilogue({
@@ -367,6 +648,7 @@ export async function runPlanRunEpilogue({
   provider,
   config,
   cwd = process.cwd(),
+  git = { gitSpawn },
 } = {}) {
   const plan = planRunEpilogue({ planRunId, stories });
   if (!plan.applicable) {
@@ -387,6 +669,8 @@ export async function runPlanRunEpilogue({
             stories: plan.stories,
             cwd,
             provider,
+            config,
+            git,
           }),
         );
       } else if (step.kind === 'follow-up-rollup') {

--- a/.agents/scripts/plan-run-epilogue.js
+++ b/.agents/scripts/plan-run-epilogue.js
@@ -87,11 +87,37 @@ export async function main(argv = process.argv.slice(2)) {
     config,
     cwd,
   });
+  warnOnUnresolvedBase(result);
   Logger.info(JSON.stringify(result, null, 2));
   if (result.errors?.length) {
     process.exitCode = 1;
   }
   return result;
+}
+
+/**
+ * Surface an unresolvable combined landed diff as a loud operator warning.
+ *
+ * The roster's changed-file set is the input the host walks its audit lenses
+ * against; a silent absence would read as "nothing changed" and the lens walk
+ * would look complete while covering nothing. Not fatal — lens selection is
+ * independent of the diff, so the rest of the roster is still useful.
+ *
+ * @param {object} result - `runPlanRunEpilogue` envelope.
+ * @returns {void}
+ */
+function warnOnUnresolvedBase(result) {
+  const roster = (result?.results ?? []).find(
+    (r) => r?.kind === 'audit-roster',
+  );
+  const base = roster?.baseResolution;
+  if (base?.resolved !== false) return;
+  Logger.warn(
+    `⚠️  Combined landed diff unavailable — the pre-run base sha could not be ` +
+      `resolved against \`${base.baseRef}\`: ${base.reason}\n` +
+      `    changedFiles is null (NOT an empty set). Determine the run diff by ` +
+      `hand before walking the selected lenses.`,
+  );
 }
 
 await runAsCli(import.meta.url, main);

--- a/tests/lib/orchestration/run-epilogue-base.integration.test.js
+++ b/tests/lib/orchestration/run-epilogue-base.integration.test.js
@@ -1,0 +1,316 @@
+// tests/lib/orchestration/run-epilogue-base.integration.test.js
+//
+// Real-git round-trip for the Story #4550 structural defect: the plan-run
+// audit roster diffed `origin/main...HEAD` from a checkout whose HEAD *is*
+// origin/main (or an ancestor of it), so the three-dot merge-base was HEAD
+// and the changed-file set was empty by construction — never a race, and not
+// fixable by reordering branch cleanup.
+//
+// These spawn real git processes against a tmp repo, so they are excluded
+// from `test:quick` and run under `test:integration` / `npm test`.
+
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, it } from 'node:test';
+
+import {
+  resolveRunBaseSha,
+  runPlanRunEpilogue,
+} from '../../../.agents/scripts/lib/orchestration/run-epilogue.js';
+
+// Strip every GIT_* env var so the tmpdir cwd wins even when this suite runs
+// inside a git hook (husky exports GIT_DIR / GIT_WORK_TREE, which would
+// otherwise override execFileSync's `cwd`).
+const CLEAN_ENV = Object.fromEntries(
+  Object.entries(process.env).filter(([k]) => !k.startsWith('GIT_')),
+);
+
+function run(cwd, ...args) {
+  return execFileSync('git', args, {
+    cwd,
+    encoding: 'utf8',
+    stdio: ['pipe', 'pipe', 'pipe'],
+    env: CLEAN_ENV,
+  });
+}
+
+function commitFile(repo, name, content, subject) {
+  fs.writeFileSync(path.join(repo, name), content);
+  run(repo, 'add', '.');
+  run(repo, 'commit', '-m', subject);
+}
+
+/**
+ * A provider stub that satisfies the epilogue's ticketing surface. Story
+ * bodies are irrelevant to the audit-roster step under test.
+ */
+function stubProvider(comments) {
+  return {
+    getTicket: async (id) => ({
+      id,
+      title: `Story ${id}`,
+      body: '',
+      labels: [],
+    }),
+    getTicketComments: async () => [],
+    postComment: async (ticketId, payload) => {
+      comments.push({ ticketId, body: payload.body });
+      return { commentId: comments.length };
+    },
+    deleteComment: async () => {},
+  };
+}
+
+describe('run-epilogue combined landed diff (real git, Story #4550)', () => {
+  let repo;
+  /** The commit `main` pointed at before the run's first Story landed. */
+  let preRunBase;
+
+  beforeEach(() => {
+    repo = fs.realpathSync.native(
+      fs.mkdtempSync(path.join(os.tmpdir(), 'run-epilogue-base-')),
+    );
+    run(repo, 'init', '-b', 'main');
+    run(repo, 'config', 'user.email', 'test@example.com');
+    run(repo, 'config', 'user.name', 'Test');
+
+    commitFile(repo, 'README.md', 'root\n', 'chore: init');
+    commitFile(
+      repo,
+      'pre-run.txt',
+      'before the run\n',
+      'chore: pre-run commit',
+    );
+
+    // This is the commit `main` pointed at before the run's Stories landed.
+    preRunBase = run(repo, 'rev-parse', 'HEAD').trim();
+
+    // The run's two Stories land as squash-merges. `normalizePrTitle` in the
+    // close pipeline guarantees the `(#<storyId>)` suffix on the PR title,
+    // and GitHub uses the PR title as the squash subject on main.
+    commitFile(
+      repo,
+      'story-101.txt',
+      'from 101\n',
+      'fix(cli): first story of the run (#101) (#900)',
+    );
+    commitFile(
+      repo,
+      'story-102.txt',
+      'from 102\n',
+      'feat(core): second story of the run (#102) (#901)',
+    );
+
+    // A later, unrelated commit that merely *mentions* the Story ids in prose
+    // — the earliest-merge walk must not be fooled into anchoring on it, and
+    // the bare `#101` substring must not out-rank the `(#101)` marker.
+    fs.writeFileSync(path.join(repo, 'later.txt'), 'later\n');
+    run(repo, 'add', '.');
+    run(
+      repo,
+      'commit',
+      '-m',
+      'docs: follow-up',
+      '-m',
+      'Supersedes the analysis in #101 and #102.',
+    );
+
+    // Simulate the post-land main checkout: `origin/main` exists as a
+    // remote-tracking ref and HEAD *equals* it. This is exactly the state in
+    // which the old `origin/main...HEAD` diff returned zero files.
+    run(repo, 'update-ref', 'refs/remotes/origin/main', 'HEAD');
+  });
+
+  afterEach(() => {
+    fs.rmSync(repo, { recursive: true, force: true });
+  });
+
+  it('pins the structural bug: `origin/main...HEAD` is empty where the real diff is not', () => {
+    // The old implementation's exact range, at the real post-land state.
+    const oldRange = execFileSync(
+      'git',
+      ['diff', '--name-only', 'origin/main...HEAD'],
+      { cwd: repo, encoding: 'utf8', env: CLEAN_ENV },
+    ).trim();
+    assert.equal(
+      oldRange,
+      '',
+      'the old origin/main...HEAD range must be empty — that IS the defect',
+    );
+
+    // The run demonstrably changed files, so an empty set is not the truth.
+    const realDiff = execFileSync(
+      'git',
+      ['diff', '--name-only', `${preRunBase}...origin/main`],
+      { cwd: repo, encoding: 'utf8', env: CLEAN_ENV },
+    ).trim();
+    assert.ok(
+      realDiff.includes('story-101.txt') && realDiff.includes('story-102.txt'),
+      'the run really did change files',
+    );
+  });
+
+  it('resolves the pre-run base from the earliest landed merge of the run', () => {
+    const base = resolveRunBaseSha({ stories: [101, 102], cwd: repo });
+    assert.equal(base.resolved, true);
+    assert.equal(base.baseSha, preRunBase);
+    assert.equal(
+      base.storyId,
+      101,
+      'earliest merge in the run belongs to #101',
+    );
+  });
+
+  it('is order-independent — the run Story order does not move the base', () => {
+    const base = resolveRunBaseSha({ stories: [102, 101], cwd: repo });
+    assert.equal(base.resolved, true);
+    assert.equal(base.baseSha, preRunBase);
+  });
+
+  it('reports the run real changed files with HEAD == origin/main (the regression)', async () => {
+    const comments = [];
+    const result = await runPlanRunEpilogue({
+      planRunId: 'fixture-run',
+      stories: [101, 102],
+      provider: stubProvider(comments),
+      config: {
+        github: { owner: 'o', repo: 'r' },
+        project: { baseBranch: 'main' },
+      },
+      cwd: repo,
+    });
+
+    const roster = result.results.find((r) => r.kind === 'audit-roster');
+    assert.ok(roster, 'audit-roster step ran');
+    assert.equal(roster.baseResolution.resolved, true);
+    assert.equal(roster.baseResolution.baseSha, preRunBase);
+    assert.deepEqual(
+      [...roster.changedFiles].sort(),
+      ['later.txt', 'story-101.txt', 'story-102.txt'],
+      'the combined landed diff names the files the run actually changed',
+    );
+    assert.equal(roster.changedFileCount, 3);
+
+    const body = comments.find((c) =>
+      /plan-run-audit-roster/.test(c.body),
+    )?.body;
+    assert.ok(body, 'roster comment posted');
+    assert.match(body, /Combined landed diff/);
+    assert.match(body, /story-101\.txt/);
+    assert.doesNotMatch(
+      body,
+      /Changed files considered: 0/,
+      'the silent zero-file line must be gone',
+    );
+  });
+
+  it('does not depend on the Story branches still existing', async () => {
+    // Materialize and then reap the Story branches — the epilogue must be
+    // indifferent (candidate strategy 3 in the Spec would break here).
+    run(repo, 'branch', 'story-101', preRunBase);
+    run(repo, 'branch', '-D', 'story-101');
+
+    const result = await runPlanRunEpilogue({
+      planRunId: 'fixture-run',
+      stories: [101, 102],
+      provider: stubProvider([]),
+      config: { project: { baseBranch: 'main' } },
+      cwd: repo,
+    });
+    const roster = result.results.find((r) => r.kind === 'audit-roster');
+    assert.equal(roster.baseResolution.resolved, true);
+    assert.ok(roster.changedFiles.includes('story-101.txt'));
+  });
+
+  it('reports an unresolvable base explicitly rather than a zero-file set', async () => {
+    const comments = [];
+    const result = await runPlanRunEpilogue({
+      planRunId: 'fixture-run',
+      // Story ids that never landed on this base ref.
+      stories: [777, 778],
+      provider: stubProvider(comments),
+      config: { project: { baseBranch: 'main' } },
+      cwd: repo,
+    });
+
+    const roster = result.results.find((r) => r.kind === 'audit-roster');
+    assert.equal(roster.baseResolution.resolved, false);
+    assert.match(roster.baseResolution.reason, /#777, #778/);
+    assert.equal(
+      roster.changedFileCount,
+      null,
+      'null — not 0 — so "could not compute" never reads as "nothing changed"',
+    );
+    assert.equal(roster.changedFiles, null);
+
+    const body = comments.find((c) =>
+      /plan-run-audit-roster/.test(c.body),
+    )?.body;
+    assert.match(body, /Combined landed diff unavailable/);
+    assert.match(body, /NOT "zero files changed"/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Real-history fixture: plan-run fbcec023 (Stories #4530, #4531).
+//
+// This run is the one the defect was reproduced on. Its commits are immutable
+// history, so the expectations below are stable — `HEAD_AT_RUN_END` pins the
+// base ref to what `origin/main` actually was when the epilogue fired, rather
+// than to a moving `origin/main`.
+// ---------------------------------------------------------------------------
+describe('run-epilogue against real plan-run fbcec023 (Story #4550)', () => {
+  const REPO_ROOT = path.resolve(import.meta.dirname, '../../..');
+  /** `main` before the run's first Story (#4530) landed. */
+  const PRE_RUN_BASE = 'c9491739';
+  /** `main` after the run's last Story (#4531) landed — the epilogue's headRef. */
+  const HEAD_AT_RUN_END = 'fe0c7ce3';
+
+  function hasFixtureHistory() {
+    try {
+      execFileSync('git', ['cat-file', '-e', `${PRE_RUN_BASE}^{commit}`], {
+        cwd: REPO_ROOT,
+        stdio: 'ignore',
+        env: CLEAN_ENV,
+      });
+      return true;
+    } catch {
+      // Shallow clone — the fixture commits are not fetched. CI uses
+      // fetch-depth: 0, so this only trips on a local shallow checkout.
+      return false;
+    }
+  }
+
+  it('derives the pre-run base c9491739 from the run stories, not from HEAD', {
+    skip: hasFixtureHistory()
+      ? false
+      : 'shallow clone — fixture history absent',
+  }, () => {
+    const base = resolveRunBaseSha({
+      stories: [4530, 4531],
+      cwd: REPO_ROOT,
+      baseRef: HEAD_AT_RUN_END,
+    });
+    assert.equal(base.resolved, true);
+    assert.ok(
+      base.baseSha.startsWith(PRE_RUN_BASE),
+      `expected base ${PRE_RUN_BASE}, got ${base.baseSha}`,
+    );
+    assert.equal(base.storyId, 4530, '#4530 landed first in the run');
+
+    // The run's real combined diff — 56 files, versus the 0 the old
+    // `origin/main...HEAD` range reported when this epilogue actually ran.
+    const changed = execFileSync(
+      'git',
+      ['diff', '--name-only', `${base.baseSha}...${HEAD_AT_RUN_END}`],
+      { cwd: REPO_ROOT, encoding: 'utf8', env: CLEAN_ENV },
+    )
+      .trim()
+      .split('\n')
+      .filter(Boolean);
+    assert.equal(changed.length, 56, 'the 56 files the run really changed');
+  });
+});

--- a/tests/lib/orchestration/run-epilogue.test.js
+++ b/tests/lib/orchestration/run-epilogue.test.js
@@ -7,8 +7,35 @@ import { describe, it } from 'node:test';
 import {
   planRunEpilogue,
   RUN_EPILOGUE_STEP_KINDS,
+  resolveRunBaseSha,
   runPlanRunEpilogue,
 } from '../../../.agents/scripts/lib/orchestration/run-epilogue.js';
+
+const US = String.fromCharCode(31);
+
+/**
+ * Build a `gitSpawn` stub over a scripted `git log` first-parent history.
+ *
+ * @param {Array<{sha: string, parents?: string[], subject: string}>} commits
+ *   Newest-first, as real `git log --first-parent` emits.
+ */
+function gitStub(commits, { logStatus = 0, stderr = '' } = {}) {
+  return {
+    gitSpawn: (_cwd, ...args) => {
+      if (args[0] === 'log') {
+        if (logStatus !== 0) return { status: logStatus, stdout: '', stderr };
+        const stdout = commits
+          .map(
+            (c) =>
+              `${c.sha}${US}${(c.parents ?? []).join(' ')}${US}${c.subject}`,
+          )
+          .join('\n');
+        return { status: 0, stdout, stderr: '' };
+      }
+      return { status: 0, stdout: '', stderr: '' };
+    },
+  };
+}
 
 describe('planRunEpilogue — not applicable', () => {
   it('is inapplicable for a single-Story run (common case)', () => {
@@ -70,6 +97,140 @@ describe('planRunEpilogue — applicable (N>1)', () => {
   it('is pure — no side effects, deterministic output', () => {
     const args = { planRunId: 'run-9', stories: ['a', 'b'] };
     assert.deepEqual(planRunEpilogue(args), planRunEpilogue(args));
+  });
+});
+
+describe('resolveRunBaseSha — pre-run base derivation (Story #4550)', () => {
+  const HISTORY = [
+    { sha: 'ddd', parents: ['ccc'], subject: 'docs: unrelated later commit' },
+    {
+      sha: 'ccc',
+      parents: ['bbb'],
+      subject: 'feat: second story (#102) (#901)',
+    },
+    { sha: 'bbb', parents: ['aaa'], subject: 'fix: first story (#101) (#900)' },
+    { sha: 'aaa', parents: ['000'], subject: 'chore: pre-run tip' },
+  ];
+
+  it('anchors on the earliest run merge and returns its first parent', () => {
+    const base = resolveRunBaseSha({
+      stories: [101, 102],
+      cwd: '/repo',
+      git: gitStub(HISTORY),
+    });
+    assert.equal(base.resolved, true);
+    assert.equal(base.baseSha, 'aaa');
+    assert.equal(base.mergeSha, 'bbb');
+    assert.equal(base.storyId, 101);
+  });
+
+  it('matches the `(#id)` marker, not a bare `#id` prose mention', () => {
+    const base = resolveRunBaseSha({
+      stories: [101],
+      cwd: '/repo',
+      git: gitStub([
+        {
+          sha: 'ccc',
+          parents: ['bbb'],
+          subject: 'fix: real story (#101) (#900)',
+        },
+        // An *earlier* commit that merely mentions the id — must not anchor.
+        {
+          sha: 'bbb',
+          parents: ['aaa'],
+          subject: 'docs: plan for #101 refactor',
+        },
+        { sha: 'aaa', parents: ['000'], subject: 'chore: root' },
+      ]),
+    });
+    assert.equal(base.resolved, true);
+    assert.equal(
+      base.baseSha,
+      'bbb',
+      'anchored on the (#101) merge, not the prose',
+    );
+  });
+
+  it('honours a non-default baseBranch ref', () => {
+    const seen = [];
+    const base = resolveRunBaseSha({
+      stories: [101],
+      cwd: '/repo',
+      baseRef: 'origin/trunk',
+      git: {
+        gitSpawn: (_cwd, ...args) => {
+          seen.push(args);
+          return {
+            status: 0,
+            stdout: `bbb${US}aaa${US}fix: s (#101) (#900)`,
+            stderr: '',
+          };
+        },
+      },
+    });
+    assert.equal(base.resolved, true);
+    assert.ok(seen[0].includes('origin/trunk'));
+  });
+
+  it('reports unresolved — not an empty set — when no run merge landed', () => {
+    const base = resolveRunBaseSha({
+      stories: [777],
+      cwd: '/repo',
+      git: gitStub(HISTORY),
+    });
+    assert.equal(base.resolved, false);
+    assert.match(base.reason, /#777/);
+    assert.match(base.reason, /has the run landed/);
+  });
+
+  it('reports unresolved when the base ref is unreadable', () => {
+    const base = resolveRunBaseSha({
+      stories: [101],
+      cwd: '/repo',
+      git: gitStub([], {
+        logStatus: 128,
+        stderr: "fatal: bad revision 'origin/main'",
+      }),
+    });
+    assert.equal(base.resolved, false);
+    assert.match(base.reason, /git log origin\/main.*failed/);
+    assert.match(base.reason, /bad revision/);
+  });
+
+  it('reports unresolved when the run merge is a root commit', () => {
+    const base = resolveRunBaseSha({
+      stories: [101],
+      cwd: '/repo',
+      git: gitStub([
+        { sha: 'aaa', parents: [], subject: 'fix: s (#101) (#900)' },
+      ]),
+    });
+    assert.equal(base.resolved, false);
+    assert.match(base.reason, /root commit/);
+  });
+
+  it('reports unresolved when the run carries no numeric Story ids', () => {
+    const base = resolveRunBaseSha({
+      stories: ['slug-a', 'slug-b'],
+      cwd: '/repo',
+      git: gitStub(HISTORY),
+    });
+    assert.equal(base.resolved, false);
+    assert.match(base.reason, /no numeric Story ids/);
+  });
+
+  it('survives a throwing git without taking the epilogue down', () => {
+    const base = resolveRunBaseSha({
+      stories: [101],
+      cwd: '/repo',
+      git: {
+        gitSpawn: () => {
+          throw new Error('ENOENT: git not found');
+        },
+      },
+    });
+    assert.equal(base.resolved, false);
+    assert.match(base.reason, /could not be spawned/);
   });
 });
 


### PR DESCRIPTION
Closes #4550

_Auto-opened by `/single-story-deliver`._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how multi-Story plan-run closeout computes the audit diff; wrong base resolution could mis-scope lens walks, but impact is limited to orchestration tooling rather than production app runtime.
> 
> **Overview**
> Fixes **Story #4550**: the plan-run epilogue audit roster no longer uses `origin/main...HEAD`, which was **empty by construction** after the last Story lands when HEAD equals `origin/main`.
> 
> The roster now derives a **pre-run base SHA** by scanning first-parent history on `origin/<baseBranch>` for squash-merge subjects containing `(#<storyId>)`, takes the **earliest** run merge’s first parent, and diffs **`baseSha...origin/main`** for the combined changed-file set. Resolution failures surface as **explicit warnings** in the roster comment, JSON (`baseResolution`, `changedFiles: null`), and CLI output—never as “0 files changed.”
> 
> `runPlanRunEpilogue` accepts an injectable `git` seam; unit and real-git integration tests cover the regression and a pinned production plan-run fixture.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3ab8569cc653d81898aa0f6d4f36a458606e358e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->