### PR TITLE
fix(plan): thread sourceTickets through the envelope so --tickets superseding cannot silently no-op (#4554)

### DIFF
--- a/.agents/scripts/lib/orchestration/plan-persist/plan-context-source.js
+++ b/.agents/scripts/lib/orchestration/plan-persist/plan-context-source.js
@@ -1,0 +1,116 @@
+/**
+ * plan-context-source.js — locate and read the `plan-context.js` envelope so
+ * persist can derive the `/plan --tickets` source ids from the run that
+ * actually fetched them (Story #4554).
+ *
+ * This lives beside the persist ops rather than inside `plan-persist.js` so
+ * the discovery + failure policy is directly testable: the CLI is a thin
+ * `parseArgs` shell, and the interesting behaviour here is exactly the part
+ * that decides whether a `--tickets` run can quietly lose its source set.
+ *
+ * @module lib/orchestration/plan-persist/plan-context-source
+ */
+
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+
+import { Logger } from '../../Logger.js';
+
+/**
+ * Filename the `/plan` interrogate step writes its envelope to inside
+ * `--plan-dir` (`plan-context.js --out <plan-dir>/plan-context.json`).
+ */
+export const PLAN_CONTEXT_FILENAME = 'plan-context.json';
+
+/**
+ * Decide where to look for the envelope.
+ *
+ * An explicit `--plan-context` path wins; otherwise the conventional file
+ * inside `--plan-dir`. With neither, there is nothing to read — the caller
+ * gets `null` and must warn (see `loadPlanContextEnvelope`).
+ *
+ * @param {string|null|undefined} explicitPath `--plan-context`.
+ * @param {string|null|undefined} planDir `--plan-dir`.
+ * @returns {{ path: string, explicit: boolean }|null}
+ */
+export function resolvePlanContextPath(explicitPath, planDir) {
+  if (explicitPath) {
+    return { path: path.resolve(explicitPath), explicit: true };
+  }
+  if (planDir) {
+    return {
+      path: path.join(path.resolve(planDir), PLAN_CONTEXT_FILENAME),
+      explicit: false,
+    };
+  }
+  return null;
+}
+
+/**
+ * The advice printed whenever persist has no envelope to derive ids from.
+ * Single-homed so the two no-envelope paths cannot drift apart.
+ */
+const CAPTURE_HINT =
+  'Re-run step 1 with `node .agents/scripts/plan-context.js … --out ' +
+  '<plan-dir>/plan-context.json` and pass --plan-dir, or pass ' +
+  '--source-tickets explicitly.';
+
+/**
+ * Read the `plan-context.js` envelope.
+ *
+ * Failure policy — the point is that a `--tickets` run can never *quietly*
+ * lose its source set, so every no-envelope path is audible:
+ *
+ * - **No path at all** (neither `--plan-dir` nor `--plan-context`): warn.
+ *   Persist cannot tell a legitimate `--seed` run from a `--tickets` run
+ *   whose envelope was never captured, so it says so rather than returning a
+ *   silent `null`.
+ * - **Explicit `--plan-context` missing**: throw. The operator named a file
+ *   and meant it.
+ * - **Auto-discovered file simply absent**: warn and degrade to
+ *   `--source-tickets`. A `--seed` run legitimately has no envelope, so
+ *   absence alone is not fatal.
+ * - **Present but unparseable**: throw either way. A corrupt envelope is not
+ *   the same as no envelope, and reading it as "no source tickets" is exactly
+ *   the vacuous pass this module exists to prevent.
+ *
+ * @param {{ path: string, explicit: boolean }|null} planContext
+ * @returns {Promise<object|null>} Parsed envelope, or null when absent.
+ */
+export async function loadPlanContextEnvelope(planContext) {
+  if (!planContext) {
+    Logger.warn(
+      '[plan-persist] no --plan-dir or --plan-context given, so no ' +
+        'plan-context envelope was read. If this was a `/plan --tickets` ' +
+        'run, its source tickets can only come from --source-tickets and ' +
+        `will NOT be closed otherwise. ${CAPTURE_HINT}`,
+    );
+    return null;
+  }
+
+  let raw;
+  try {
+    raw = await readFile(planContext.path, 'utf8');
+  } catch (err) {
+    if (err?.code === 'ENOENT' && !planContext.explicit) {
+      Logger.warn(
+        `[plan-persist] no plan-context envelope at ${planContext.path} — ` +
+          'source tickets can only come from --source-tickets. ' +
+          CAPTURE_HINT,
+      );
+      return null;
+    }
+    throw new Error(
+      `Cannot read plan-context envelope ${planContext.path}: ${err.message}`,
+    );
+  }
+
+  try {
+    return JSON.parse(raw);
+  } catch (err) {
+    throw new Error(
+      `Failed to parse plan-context envelope "${planContext.path}" as JSON: ` +
+        `${err.message}. ${CAPTURE_HINT}`,
+    );
+  }
+}

--- a/.agents/scripts/lib/orchestration/plan-persist/run-plan-persist.js
+++ b/.agents/scripts/lib/orchestration/plan-persist/run-plan-persist.js
@@ -194,6 +194,7 @@ function riskVerdictCommentBody(riskVerdict) {
  *     fanOutCounter?: Function,
  *     cwd?: string,
  *     sourceTicketIds?: number[],
+ *     sourceTicketOrigin?: 'flag'|'envelope'|'none',
  *     closeSuperseded?: boolean,
  *   },
  * }} input
@@ -222,6 +223,7 @@ export async function runPlanPersist({
     fanOutCounter = undefined,
     cwd = PROJECT_ROOT,
     sourceTicketIds = [],
+    sourceTicketOrigin = 'none',
     closeSuperseded = true,
   } = opts;
 
@@ -407,6 +409,10 @@ export async function runPlanPersist({
     dryRun,
     closeSuperseded,
   });
+  // Record which channel the ids came from so a run that superseded nothing
+  // says *why* (`none` = neither the envelope nor --source-tickets carried
+  // any) rather than reading as a clean no-op — Story #4554.
+  supersede.sourceTicketOrigin = sourceTicketOrigin;
 
   if (!skipCleanup && planDir) {
     try {

--- a/.agents/scripts/lib/orchestration/plan-persist/supersede-ops.js
+++ b/.agents/scripts/lib/orchestration/plan-persist/supersede-ops.js
@@ -2,10 +2,15 @@
  * supersede-ops.js — close the `/plan --tickets` source issues that the
  * authored Stories supersede (Story #4535).
  *
- * `plan-context.js` fetches the source issues and emits `sourceTickets[]`;
- * before this module nothing downstream consumed it, so every
- * `/plan --tickets` run ended with an untracked manual chore and the tracker
- * kept asserting that already-planned work was unowned.
+ * `plan-context.js` fetches the source issues and emits `sourceTickets[]` on
+ * the `/plan` envelope. That envelope **is** the source of truth for which
+ * ids were passed to `--tickets`: `resolveSourceTicketIds` below derives the
+ * id set from it, and `--source-tickets` is only an explicit override for
+ * hand-driven runs (Story #4554). Before that thread existed the ids reached
+ * this module *solely* via the hand-passed flag, so a forgotten flag left
+ * `sourceTicketIds` empty — the partition below then passed **vacuously** (an
+ * empty set trivially partitions), the close phase short-circuited, and the
+ * run reported success while every source issue stayed open.
  *
  * Two halves, deliberately separated by the `createIssue` boundary:
  *
@@ -112,12 +117,14 @@ export function normalizeSupersedes(ticket, slug) {
 }
 
 /**
- * Normalize the operator-supplied source-ticket id list (`--source-tickets`).
+ * Normalize a source-ticket id list into deduped positive integers.
  *
  * @param {unknown} ids
+ * @param {string} [label] Channel name used in the error message, so an
+ *   envelope-derived failure does not blame the `--source-tickets` flag.
  * @returns {number[]}
  */
-export function normalizeSourceTicketIds(ids) {
+export function normalizeSourceTicketIds(ids, label = '--source-tickets') {
   if (ids === undefined || ids === null) return [];
   const list = Array.isArray(ids)
     ? ids
@@ -131,12 +138,89 @@ export function normalizeSourceTicketIds(ids) {
       typeof entry === 'string' ? Number(entry.replace(/^#/, '')) : entry;
     if (!Number.isInteger(id) || id <= 0) {
       throw new Error(
-        `[plan-persist] --source-tickets expects positive issue ids; got ${JSON.stringify(entry)}.`,
+        `[plan-persist] ${label} expects positive issue ids; got ${JSON.stringify(entry)}.`,
       );
     }
     if (!out.includes(id)) out.push(id);
   }
   return out;
+}
+
+/**
+ * Pull the `--tickets` id set out of a `plan-context.js` envelope.
+ *
+ * The envelope's `sourceTickets[]` carries whole ticket records
+ * (`{ id, title, body, … }`); only the ids matter here. A non-`tickets`-mode
+ * envelope (seed / seed-file) has no source tickets and yields `[]`.
+ *
+ * @param {object|null} envelope
+ * @returns {number[]}
+ */
+export function extractEnvelopeSourceTicketIds(envelope) {
+  const raw = envelope?.sourceTickets;
+  if (!Array.isArray(raw) || raw.length === 0) return [];
+  return normalizeSourceTicketIds(
+    raw.map((ticket) =>
+      ticket !== null && typeof ticket === 'object' ? ticket.id : ticket,
+    ),
+    'plan-context envelope sourceTickets[]',
+  );
+}
+
+function sameIdSet(a, b) {
+  return a.length === b.length && a.every((id) => b.includes(id));
+}
+
+/**
+ * Resolve which source-ticket ids reach the partition and the close phase.
+ *
+ * Precedence — **envelope-first, flag-as-override** (Story #4554):
+ *
+ *   1. `--source-tickets` when supplied — the explicit override for
+ *      hand-driven runs. A disagreement with the envelope is warned about
+ *      loudly (the operator is overriding what the run actually fetched)
+ *      but honoured.
+ *   2. otherwise the envelope's `sourceTickets[]` — so the common
+ *      `/plan --tickets` path needs no flag at all.
+ *   3. otherwise empty, reported as `origin: 'none'`.
+ *
+ * `origin` is surfaced on the persist envelope so a run that superseded
+ * nothing says *why* rather than looking like a clean no-op.
+ *
+ * @param {object} [args]
+ * @param {unknown} [args.explicitIds] Raw `--source-tickets` value.
+ * @param {object|null} [args.envelope] Parsed `plan-context.js` envelope.
+ * @returns {{ ids: number[], origin: 'flag'|'envelope'|'none' }}
+ */
+export function resolveSourceTicketIds({
+  explicitIds = null,
+  envelope = null,
+} = {}) {
+  const explicit = normalizeSourceTicketIds(explicitIds);
+  const derived = extractEnvelopeSourceTicketIds(envelope);
+
+  if (explicit.length > 0) {
+    if (derived.length > 0 && !sameIdSet(explicit, derived)) {
+      Logger.warn(
+        '[plan-persist] --source-tickets ' +
+          `(${explicit.map((id) => `#${id}`).join(', ')}) disagrees with the ` +
+          'plan-context envelope ' +
+          `(${derived.map((id) => `#${id}`).join(', ')}) — honouring the ` +
+          'explicit flag. Drop --source-tickets to use the envelope.',
+      );
+    }
+    return { ids: explicit, origin: 'flag' };
+  }
+
+  if (derived.length > 0) {
+    Logger.info(
+      `[plan-persist] derived ${derived.length} source ticket(s) from the ` +
+        `plan-context envelope: ${derived.map((id) => `#${id}`).join(', ')}.`,
+    );
+    return { ids: derived, origin: 'envelope' };
+  }
+
+  return { ids: [], origin: 'none' };
 }
 
 function describeStoryIds(entries) {
@@ -298,6 +382,8 @@ async function closeOneSupersededTicket({
  * @property {boolean} enabled
  * @property {boolean} dryRun
  * @property {string|null} reason  Why the phase was skipped wholesale.
+ * @property {'flag'|'envelope'|'none'} [sourceTicketOrigin] Which channel the
+ *   source ids came from. Stamped by `runPlanPersist`, not this module.
  * @property {number[]} closed
  * @property {Array<{ ticket: number, storySlug: string }>} planned Dry-run
  *   only. Keyed by slug, not id: under `--dry-run` no issue was created, so

--- a/.agents/scripts/lib/orchestration/plan-persist/supersede-ops.js
+++ b/.agents/scripts/lib/orchestration/plan-persist/supersede-ops.js
@@ -2,11 +2,12 @@
  * supersede-ops.js — close the `/plan --tickets` source issues that the
  * authored Stories supersede (Story #4535).
  *
- * `plan-context.js` fetches the source issues and emits `sourceTickets[]` on
- * the `/plan` envelope. That envelope **is** the source of truth for which
- * ids were passed to `--tickets`: `resolveSourceTicketIds` below derives the
- * id set from it, and `--source-tickets` is only an explicit override for
- * hand-driven runs (Story #4554). Before that thread existed the ids reached
+ * `plan-context.js` fetches the source issues, emits `sourceTickets[]` on the
+ * `/plan` envelope, and (with `--out`) writes that envelope to disk.
+ * `resolveSourceTicketIds` below reads the id set back off it, so the normal
+ * `/plan --tickets` path needs no flag; an explicit `--source-tickets` still
+ * wins when passed, as the override for hand-driven runs (Story #4554).
+ * Before that thread existed the ids reached
  * this module *solely* via the hand-passed flag, so a forgotten flag left
  * `sourceTicketIds` empty — the partition below then passed **vacuously** (an
  * empty set trivially partitions), the close phase short-circuited, and the
@@ -174,7 +175,8 @@ function sameIdSet(a, b) {
 /**
  * Resolve which source-ticket ids reach the partition and the close phase.
  *
- * Precedence — **envelope-first, flag-as-override** (Story #4554):
+ * Precedence — an explicit flag wins, the envelope is the default channel
+ * (Story #4554):
  *
  *   1. `--source-tickets` when supplied — the explicit override for
  *      hand-driven runs. A disagreement with the envelope is warned about

--- a/.agents/scripts/plan-context.js
+++ b/.agents/scripts/plan-context.js
@@ -18,6 +18,13 @@
  *                             Stories. Envelope carries `sourceTickets[]`.
  *
  * Flags:
+ *   --out <path>     Also write the envelope to <path> (parent dirs created).
+ *                    `/plan` points this at `<plan-dir>/plan-context.json`,
+ *                    which is where `plan-persist.js` auto-discovers the
+ *                    `--tickets` source ids from (Story #4554). Without a
+ *                    captured envelope persist cannot know a `--tickets` run
+ *                    happened, and superseding degrades to the
+ *                    `--source-tickets` flag.
  *   --pretty         Pretty-print the JSON envelope.
  *   --full-context   Bypass the planning-context budget (unbounded body).
  *
@@ -34,13 +41,15 @@
 // first import so the check runs before any third-party-importing sibling
 // module is evaluated (Story #3432).
 import './lib/runtime-deps/ensure-installed.js';
+import { mkdir, writeFile } from 'node:fs/promises';
+import path from 'node:path';
 import { parseArgs } from 'node:util';
 import { runAsCli } from './lib/cli-utils.js';
 import {
   resolveConfig,
   validateOrchestrationConfig,
 } from './lib/config-resolver.js';
-import { routeAllOutputToStderr } from './lib/Logger.js';
+import { Logger, routeAllOutputToStderr } from './lib/Logger.js';
 import { buildPlanContext } from './lib/orchestration/plan-context.js';
 import { recordPlanInvocation } from './lib/orchestration/plan-metrics.js';
 import { createProvider } from './lib/provider-factory.js';
@@ -86,6 +95,7 @@ export async function emitPlanContext({
   settings,
   fullContext = false,
   pretty = false,
+  outPath = null,
   cwd,
   stdout = process.stdout,
 }) {
@@ -105,7 +115,32 @@ export async function emitPlanContext({
     ? JSON.stringify(envelope, null, 2)
     : JSON.stringify(envelope);
   stdout.write(`${json}\n`);
+  if (outPath) await writeEnvelopeFile(outPath, json);
   return envelope;
+}
+
+/**
+ * Persist the envelope to `--out` so `plan-persist.js` can derive the
+ * `--tickets` source ids from it without an operator re-typing them.
+ *
+ * Writing is part of emitting, not a best-effort extra: a failed write means
+ * persist will silently see no source tickets, so it throws rather than
+ * warning past the problem.
+ *
+ * @param {string} outPath
+ * @param {string} json
+ */
+async function writeEnvelopeFile(outPath, json) {
+  const resolved = path.resolve(outPath);
+  try {
+    await mkdir(path.dirname(resolved), { recursive: true });
+    await writeFile(resolved, `${json}\n`, 'utf8');
+  } catch (err) {
+    throw new Error(
+      `[plan-context] cannot write envelope to ${resolved}: ${err.message}`,
+    );
+  }
+  Logger.info(`[plan-context] wrote envelope to ${resolved}`);
 }
 
 async function main() {
@@ -114,6 +149,7 @@ async function main() {
       seed: { type: 'string' },
       'seed-file': { type: 'string' },
       tickets: { type: 'string' },
+      out: { type: 'string' },
       pretty: { type: 'boolean', default: false },
       'full-context': { type: 'boolean', default: false },
     },
@@ -187,6 +223,7 @@ async function main() {
         settings,
         fullContext: values['full-context'],
         pretty: values.pretty,
+        outPath: values.out || null,
       }),
   );
 }

--- a/.agents/scripts/plan-persist.js
+++ b/.agents/scripts/plan-persist.js
@@ -126,7 +126,13 @@ async function readJsonFile(filePath, label) {
   }
 }
 
-function resolveInputPaths(values) {
+/**
+ * Resolve every input path the CLI accepts, including where the
+ * `plan-context.js` envelope is discovered from. Exported for tests.
+ *
+ * @param {object} values Parsed `parseArgs` values.
+ */
+export function resolveInputPaths(values) {
   const planDir = values['plan-dir'] ? path.resolve(values['plan-dir']) : null;
   return {
     storiesPath: path.resolve(values.stories),
@@ -164,7 +170,19 @@ async function loadArtifacts(paths) {
   };
 }
 
-function buildPersistOptions(values, paths, planContextEnvelope) {
+/**
+ * Assemble the `runPlanPersist` opts bag from parsed CLI values.
+ *
+ * Exported for tests: this is the join where the envelope-derived source ids
+ * meet the persist engine, so a regression here silently un-wires
+ * `/plan --tickets` superseding (Story #4554).
+ *
+ * @param {object} values Parsed `parseArgs` values.
+ * @param {ReturnType<typeof resolveInputPaths>} paths
+ * @param {object|null} planContextEnvelope
+ * @returns {object} opts for `runPlanPersist`.
+ */
+export function buildPersistOptions(values, paths, planContextEnvelope) {
   const source = resolveSourceTicketIds({
     explicitIds: values['source-tickets'],
     envelope: planContextEnvelope,

--- a/.agents/scripts/plan-persist.js
+++ b/.agents/scripts/plan-persist.js
@@ -18,10 +18,16 @@
  *   --stories <file>          Required Story ticket array (default length 1)
  *   --risk-verdict <file>     Required risk verdict (no deliveryShape)
  *   --tech-spec <file>        Optional shared Tech Spec folded into each Story
- *   --plan-dir <dir>          Optional temp dir deleted at terminal success
+ *   --plan-dir <dir>          Optional temp dir deleted at terminal success.
+ *                             Also where the `plan-context.json` envelope is
+ *                             auto-discovered from (see --plan-context)
+ *   --plan-context <file>     Optional explicit path to the `plan-context.js`
+ *                             envelope. Its `sourceTickets[]` is what makes
+ *                             `--tickets` superseding work without a flag
  *   --plan-acceptance <file>  Optional JSON string[] for partition coverage
  *   --plan-run-id <id>        Optional plan-run token when N>1
- *   --source-tickets <ids>    Ids passed to `/plan --tickets` — each must be
+ *   --source-tickets <ids>    Explicit OVERRIDE of the envelope-derived source
+ *                             ids, for hand-driven runs. Each id must be
  *                             claimed by exactly one Story's `supersedes[]`;
  *                             they are commented on and closed as superseded
  *   --no-close-superseded     Keep the source tickets open (no comment, no
@@ -59,7 +65,7 @@ import {
   buildWaveTable,
   PLAN_SUMMARY_COMMENT_TYPE,
 } from './lib/orchestration/plan-persist/summary.js';
-import { normalizeSourceTicketIds } from './lib/orchestration/plan-persist/supersede-ops.js';
+import { resolveSourceTicketIds } from './lib/orchestration/plan-persist/supersede-ops.js';
 import { loadRiskVerdict } from './lib/orchestration/planning/risk-verdict.js';
 import { createProvider } from './lib/provider-factory.js';
 
@@ -76,6 +82,7 @@ const CLI_OPTIONS = {
   'risk-verdict': { type: 'string' },
   'tech-spec': { type: 'string' },
   'plan-dir': { type: 'string' },
+  'plan-context': { type: 'string' },
   'plan-acceptance': { type: 'string' },
   'plan-run-id': { type: 'string' },
   'source-tickets': { type: 'string' },
@@ -89,10 +96,18 @@ const CLI_OPTIONS = {
 
 const USAGE =
   'Usage: plan-persist.js --stories <file> --risk-verdict <file> ' +
-  '[--tech-spec <file>] [--plan-dir <dir>] [--plan-acceptance <file>] ' +
+  '[--tech-spec <file>] [--plan-dir <dir>] [--plan-context <file>] ' +
+  '[--plan-acceptance <file>] ' +
   '[--plan-run-id <id>] [--source-tickets <ids>] [--no-close-superseded] ' +
   '[--dry-run] [--force-review] ' +
   '[--allow-over-budget] [--allow-large-fan-out]';
+
+/**
+ * Filename `plan-context.js`'s envelope is captured to inside `--plan-dir`.
+ * `/plan` step 1 redirects stdout here, which is what lets persist derive the
+ * `--tickets` source ids with no flag (Story #4554).
+ */
+const PLAN_CONTEXT_FILENAME = 'plan-context.json';
 
 async function readOptional(filePath, { required }) {
   try {
@@ -115,6 +130,7 @@ async function readJsonFile(filePath, label) {
 }
 
 function resolveInputPaths(values) {
+  const planDir = values['plan-dir'] ? path.resolve(values['plan-dir']) : null;
   return {
     storiesPath: path.resolve(values.stories),
     riskVerdictPath: path.resolve(values['risk-verdict']),
@@ -124,8 +140,78 @@ function resolveInputPaths(values) {
     planAcceptancePath: values['plan-acceptance']
       ? path.resolve(values['plan-acceptance'])
       : null,
-    planDir: values['plan-dir'] ? path.resolve(values['plan-dir']) : null,
+    planDir,
+    planContextPath: resolvePlanContextPath(values['plan-context'], planDir),
   };
+}
+
+/**
+ * Where to look for the `plan-context.js` envelope: an explicit
+ * `--plan-context` path wins; otherwise the conventional file inside
+ * `--plan-dir`. Neither given → nothing to read.
+ *
+ * @param {string|undefined} explicitPath
+ * @param {string|null} planDir
+ * @returns {{ path: string, explicit: boolean }|null}
+ */
+function resolvePlanContextPath(explicitPath, planDir) {
+  if (explicitPath) {
+    return { path: path.resolve(explicitPath), explicit: true };
+  }
+  if (planDir) {
+    return { path: path.join(planDir, PLAN_CONTEXT_FILENAME), explicit: false };
+  }
+  return null;
+}
+
+/**
+ * Read the `plan-context.js` envelope so persist can derive the `--tickets`
+ * source ids from the run that actually fetched them (Story #4554).
+ *
+ * Failure policy — the point is that a `--tickets` run can never *quietly*
+ * lose its source set:
+ *
+ * - An **explicit** `--plan-context` that is missing or unparseable throws:
+ *   the operator named a file and meant it.
+ * - An auto-discovered `<plan-dir>/plan-context.json` that is simply absent
+ *   warns and degrades to `--source-tickets` — a seed-mode run legitimately
+ *   has no source tickets, so absence alone is not an error.
+ * - A **present but unparseable** envelope throws either way: a corrupt
+ *   envelope is not the same as no envelope, and silently treating it as
+ *   "no source tickets" is exactly the vacuous pass this Story closes.
+ *
+ * @param {{ path: string, explicit: boolean }|null} planContext
+ * @returns {Promise<object|null>}
+ */
+async function loadPlanContextEnvelope(planContext) {
+  if (!planContext) return null;
+
+  let raw;
+  try {
+    raw = await readFile(planContext.path, 'utf8');
+  } catch (err) {
+    if (err?.code === 'ENOENT' && !planContext.explicit) {
+      Logger.warn(
+        `[plan-persist] no plan-context envelope at ${planContext.path} — ` +
+          'source tickets can only come from --source-tickets. Capture ' +
+          "step 1's stdout there so `/plan --tickets` supersedes without a flag.",
+      );
+      return null;
+    }
+    throw new Error(
+      `Cannot read plan-context envelope ${planContext.path}: ${err.message}`,
+    );
+  }
+
+  try {
+    return JSON.parse(raw);
+  } catch (err) {
+    throw new Error(
+      `Failed to parse plan-context envelope "${planContext.path}" as JSON: ` +
+        `${err.message}. Re-capture it with ` +
+        `\`node .agents/scripts/plan-context.js … > ${planContext.path}\`.`,
+    );
+  }
 }
 
 async function loadArtifacts(paths) {
@@ -137,11 +223,25 @@ async function loadArtifacts(paths) {
   const planAcceptance = paths.planAcceptancePath
     ? await readJsonFile(paths.planAcceptancePath, 'plan-acceptance')
     : null;
+  const planContextEnvelope = await loadPlanContextEnvelope(
+    paths.planContextPath,
+  );
 
-  return { stories, riskVerdict, techSpecContent, planAcceptance };
+  return {
+    stories,
+    riskVerdict,
+    techSpecContent,
+    planAcceptance,
+    planContextEnvelope,
+  };
 }
 
-function buildPersistOptions(values, paths) {
+function buildPersistOptions(values, paths, planContextEnvelope) {
+  const source = resolveSourceTicketIds({
+    explicitIds: values['source-tickets'],
+    envelope: planContextEnvelope,
+  });
+
   return {
     forceReview: values['force-review'],
     allowOverBudget: values['allow-over-budget'],
@@ -150,7 +250,8 @@ function buildPersistOptions(values, paths) {
     planRunId: values['plan-run-id'],
     planDir: paths.planDir,
     skipCleanup: values['dry-run'],
-    sourceTicketIds: normalizeSourceTicketIds(values['source-tickets']),
+    sourceTicketIds: source.ids,
+    sourceTicketOrigin: source.origin,
     // Default-on: `--no-close-superseded` is the explicit escape and always
     // wins over the (default `true`) `--close-superseded`.
     closeSuperseded:
@@ -181,7 +282,7 @@ async function runPersistInvocation({ values, config, provider, artifacts }) {
         artifacts,
         config,
         settings,
-        opts: buildPersistOptions(values, paths),
+        opts: buildPersistOptions(values, paths, artifacts.planContextEnvelope),
       }),
   );
 }

--- a/.agents/scripts/plan-persist.js
+++ b/.agents/scripts/plan-persist.js
@@ -57,6 +57,10 @@ import {
   summarizePlanMetrics,
 } from './lib/orchestration/plan-metrics.js';
 import {
+  loadPlanContextEnvelope,
+  resolvePlanContextPath,
+} from './lib/orchestration/plan-persist/plan-context-source.js';
+import {
   runPlanPersist,
   writeCheckpointV2,
 } from './lib/orchestration/plan-persist/run-plan-persist.js';
@@ -102,13 +106,6 @@ const USAGE =
   '[--dry-run] [--force-review] ' +
   '[--allow-over-budget] [--allow-large-fan-out]';
 
-/**
- * Filename `plan-context.js`'s envelope is captured to inside `--plan-dir`.
- * `/plan` step 1 redirects stdout here, which is what lets persist derive the
- * `--tickets` source ids with no flag (Story #4554).
- */
-const PLAN_CONTEXT_FILENAME = 'plan-context.json';
-
 async function readOptional(filePath, { required }) {
   try {
     return await readFile(filePath, 'utf8');
@@ -143,75 +140,6 @@ function resolveInputPaths(values) {
     planDir,
     planContextPath: resolvePlanContextPath(values['plan-context'], planDir),
   };
-}
-
-/**
- * Where to look for the `plan-context.js` envelope: an explicit
- * `--plan-context` path wins; otherwise the conventional file inside
- * `--plan-dir`. Neither given → nothing to read.
- *
- * @param {string|undefined} explicitPath
- * @param {string|null} planDir
- * @returns {{ path: string, explicit: boolean }|null}
- */
-function resolvePlanContextPath(explicitPath, planDir) {
-  if (explicitPath) {
-    return { path: path.resolve(explicitPath), explicit: true };
-  }
-  if (planDir) {
-    return { path: path.join(planDir, PLAN_CONTEXT_FILENAME), explicit: false };
-  }
-  return null;
-}
-
-/**
- * Read the `plan-context.js` envelope so persist can derive the `--tickets`
- * source ids from the run that actually fetched them (Story #4554).
- *
- * Failure policy — the point is that a `--tickets` run can never *quietly*
- * lose its source set:
- *
- * - An **explicit** `--plan-context` that is missing or unparseable throws:
- *   the operator named a file and meant it.
- * - An auto-discovered `<plan-dir>/plan-context.json` that is simply absent
- *   warns and degrades to `--source-tickets` — a seed-mode run legitimately
- *   has no source tickets, so absence alone is not an error.
- * - A **present but unparseable** envelope throws either way: a corrupt
- *   envelope is not the same as no envelope, and silently treating it as
- *   "no source tickets" is exactly the vacuous pass this Story closes.
- *
- * @param {{ path: string, explicit: boolean }|null} planContext
- * @returns {Promise<object|null>}
- */
-async function loadPlanContextEnvelope(planContext) {
-  if (!planContext) return null;
-
-  let raw;
-  try {
-    raw = await readFile(planContext.path, 'utf8');
-  } catch (err) {
-    if (err?.code === 'ENOENT' && !planContext.explicit) {
-      Logger.warn(
-        `[plan-persist] no plan-context envelope at ${planContext.path} — ` +
-          'source tickets can only come from --source-tickets. Capture ' +
-          "step 1's stdout there so `/plan --tickets` supersedes without a flag.",
-      );
-      return null;
-    }
-    throw new Error(
-      `Cannot read plan-context envelope ${planContext.path}: ${err.message}`,
-    );
-  }
-
-  try {
-    return JSON.parse(raw);
-  } catch (err) {
-    throw new Error(
-      `Failed to parse plan-context envelope "${planContext.path}" as JSON: ` +
-        `${err.message}. Re-capture it with ` +
-        `\`node .agents/scripts/plan-context.js … > ${planContext.path}\`.`,
-    );
-  }
 }
 
 async function loadArtifacts(paths) {

--- a/.agents/workflows/plan.md
+++ b/.agents/workflows/plan.md
@@ -65,16 +65,24 @@ clarity, or reconciler ceremony for a single Story.
 ### 1. Interrogate
 
 ```bash
-node .agents/scripts/plan-context.js --seed "<seed>"
+mkdir -p temp/plan-<slug>
+node .agents/scripts/plan-context.js --seed "<seed>" > temp/plan-<slug>/plan-context.json
 # or: --seed-file <path>
 # or: --tickets 123,456
 ```
 
+**Capture the envelope to `temp/plan-<slug>/plan-context.json`.** The CLI is
+stdout-pure precisely so it can be redirected. Persist auto-discovers that
+file from `--plan-dir` and derives the `--tickets` source ids from its
+`sourceTickets[]` — that is what makes superseding work without anyone
+remembering a flag (Story #4554).
+
 The envelope carries docs context, codebase snapshot, BDD probe, risk
-heuristics, the story-author system prompt, and `duplicates[]` (open
-**Stories** whose title/body overlap the seed — never Epics). Under
-`--yes`, do not ask free-form operator questions — unresolved unknowns
-land in Key Assumptions.
+heuristics, the story-author system prompt, `sourceTickets[]` (`--tickets`
+mode), and `duplicates[]` (open **Stories** whose title/body overlap the
+seed — never Epics).
+Under `--yes`, do not ask free-form operator questions — unresolved
+unknowns land in Key Assumptions.
 
 **Gate #1** — STOP to confirm the sharpened plan intent and any
 duplicate-candidate review. Under `--yes`, auto-proceed.
@@ -145,6 +153,7 @@ node .agents/scripts/plan-persist.js \
   --risk-verdict temp/plan-<slug>/risk-verdict.json \
   [--tech-spec temp/plan-<slug>/techspec.md] \
   [--plan-dir temp/plan-<slug>] \
+  [--plan-context temp/plan-<slug>/plan-context.json] \
   [--source-tickets 123,456] \
   [--no-close-superseded] \
   [--dry-run] \
@@ -156,7 +165,30 @@ Persist creates Story issue(s) with `type::story` + `agent::ready`. When
 N>1 it also applies a shared `plan-run::<id>` label. Ends by naming
 `/deliver <storyId>` (or `/deliver --run <planRunId>` for N>1).
 
-In `--tickets` mode, pass the same ids to persist as `--source-tickets`.
+### How the source ids reach persist
+
+In `--tickets` mode persist needs to know which ids were fetched. It resolves
+them **envelope-first** (Story #4554):
+
+| Channel | When it wins |
+| --- | --- |
+| Envelope `sourceTickets[]` | **The normal path.** Read from `--plan-context <file>`, or auto-discovered at `<plan-dir>/plan-context.json`. No flag to forget. |
+| `--source-tickets <ids>` | Explicit **override** for hand-driven runs (no captured envelope, or deliberately narrowing the set). Wins over the envelope; a disagreement is warned about, not silently reconciled. |
+
+The result envelope's `supersede.sourceTicketOrigin` reports which channel was
+used (`envelope` \| `flag` \| `none`).
+
+An explicit `--plan-context` that is missing, or **any** envelope file that is
+present but unparseable, is a **fatal** error — a corrupt envelope is not the
+same as "no source tickets", and treating it as such is how a `--tickets` run
+used to report success having superseded nothing. An auto-discovered envelope
+that is simply absent warns and falls back to `--source-tickets`, because a
+`--seed` run legitimately has none.
+
+Whichever channel supplies them, the supersede-map partition above still
+fail-closes: a `--tickets` run whose Stories forgot `supersedes[]` is now
+**caught** (`source ticket #N is not claimed by any Story`) instead of
+partitioning an empty set and passing vacuously.
 
 ### Closing superseded source tickets
 

--- a/.agents/workflows/plan.md
+++ b/.agents/workflows/plan.md
@@ -65,17 +65,17 @@ clarity, or reconciler ceremony for a single Story.
 ### 1. Interrogate
 
 ```bash
-mkdir -p temp/plan-<slug>
-node .agents/scripts/plan-context.js --seed "<seed>" > temp/plan-<slug>/plan-context.json
+node .agents/scripts/plan-context.js --seed "<seed>" \
+  --out temp/plan-<slug>/plan-context.json
 # or: --seed-file <path>
 # or: --tickets 123,456
 ```
 
-**Capture the envelope to `temp/plan-<slug>/plan-context.json`.** The CLI is
-stdout-pure precisely so it can be redirected. Persist auto-discovers that
-file from `--plan-dir` and derives the `--tickets` source ids from its
-`sourceTickets[]` — that is what makes superseding work without anyone
-remembering a flag (Story #4554).
+**Always pass `--out temp/plan-<slug>/plan-context.json`.** The CLI writes the
+envelope there (creating parent dirs); persist auto-discovers that file from
+`--plan-dir` and derives the `--tickets` source ids from its `sourceTickets[]`.
+That is what makes superseding work without anyone re-typing ids
+(Story #4554). The envelope still goes to stdout too, so piping is unaffected.
 
 The envelope carries docs context, codebase snapshot, BDD probe, risk
 heuristics, the story-author system prompt, `sourceTickets[]` (`--tickets`
@@ -172,18 +172,22 @@ them **envelope-first** (Story #4554):
 
 | Channel | When it wins |
 | --- | --- |
-| Envelope `sourceTickets[]` | **The normal path.** Read from `--plan-context <file>`, or auto-discovered at `<plan-dir>/plan-context.json`. No flag to forget. |
+| Envelope `sourceTickets[]` | **The normal path.** Written by step 1's `--out`, then read from `--plan-context <file>` or auto-discovered at `<plan-dir>/plan-context.json`. No ids to re-type. |
 | `--source-tickets <ids>` | Explicit **override** for hand-driven runs (no captured envelope, or deliberately narrowing the set). Wins over the envelope; a disagreement is warned about, not silently reconciled. |
 
 The result envelope's `supersede.sourceTicketOrigin` reports which channel was
 used (`envelope` \| `flag` \| `none`).
 
-An explicit `--plan-context` that is missing, or **any** envelope file that is
-present but unparseable, is a **fatal** error — a corrupt envelope is not the
-same as "no source tickets", and treating it as such is how a `--tickets` run
-used to report success having superseded nothing. An auto-discovered envelope
-that is simply absent warns and falls back to `--source-tickets`, because a
-`--seed` run legitimately has none.
+Every path with no envelope is **audible** — persist cannot tell a legitimate
+`--seed` run from a `--tickets` run whose envelope was never captured, so it
+says so rather than deciding silently:
+
+| Situation | Behaviour |
+| --- | --- |
+| Neither `--plan-dir` nor `--plan-context` | **Warn** — nothing was read; only `--source-tickets` can supply ids. |
+| Auto-discovered `<plan-dir>/plan-context.json` absent | **Warn** — degrade to `--source-tickets`; a `--seed` run legitimately has none. |
+| Explicit `--plan-context` missing | **Fatal** — the operator named a file and meant it. |
+| Envelope present but unparseable | **Fatal** — a corrupt envelope is not "no source tickets"; treating it as such is how a `--tickets` run used to report success having superseded nothing. |
 
 Whichever channel supplies them, the supersede-map partition above still
 fail-closes: a `--tickets` run whose Stories forgot `supersedes[]` is now

--- a/tests/lib/orchestration/plan-persist-plan-context-source.test.js
+++ b/tests/lib/orchestration/plan-persist-plan-context-source.test.js
@@ -1,0 +1,113 @@
+/**
+ * Envelope discovery + read policy for `/plan --tickets` source ids
+ * (Story #4554).
+ *
+ * These exercise the real filesystem wiring — the part that decides whether a
+ * `--tickets` run can silently lose its source set — rather than hand-feeding
+ * an envelope object to the resolver.
+ */
+
+import assert from 'node:assert/strict';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { after, before, describe, it } from 'node:test';
+import {
+  loadPlanContextEnvelope,
+  PLAN_CONTEXT_FILENAME,
+  resolvePlanContextPath,
+} from '../../../.agents/scripts/lib/orchestration/plan-persist/plan-context-source.js';
+import { resolveSourceTicketIds } from '../../../.agents/scripts/lib/orchestration/plan-persist/supersede-ops.js';
+
+let planDir;
+
+before(async () => {
+  planDir = await mkdtemp(path.join(tmpdir(), 'plan-context-source-'));
+});
+
+after(async () => {
+  await rm(planDir, { recursive: true, force: true });
+});
+
+const TICKETS_ENVELOPE = {
+  mode: 'tickets',
+  sourceTickets: [
+    { id: 4525, title: 'Old idea', body: '' },
+    { id: 4526, title: 'Other idea', body: '' },
+  ],
+};
+
+describe('resolvePlanContextPath', () => {
+  it('prefers an explicit --plan-context and marks it explicit', () => {
+    const resolved = resolvePlanContextPath(
+      path.join(planDir, 'custom.json'),
+      planDir,
+    );
+    assert.equal(resolved.path, path.join(planDir, 'custom.json'));
+    assert.equal(resolved.explicit, true);
+  });
+
+  it('falls back to the conventional file inside --plan-dir', () => {
+    const resolved = resolvePlanContextPath(null, planDir);
+    assert.equal(resolved.path, path.join(planDir, PLAN_CONTEXT_FILENAME));
+    assert.equal(resolved.explicit, false);
+  });
+
+  it('returns null when neither is given', () => {
+    assert.equal(resolvePlanContextPath(null, null), null);
+  });
+});
+
+describe('loadPlanContextEnvelope', () => {
+  it('reads an envelope written to the conventional --plan-dir path', async () => {
+    const dir = await mkdtemp(path.join(tmpdir(), 'plan-ctx-ok-'));
+    const file = path.join(dir, PLAN_CONTEXT_FILENAME);
+    await writeFile(file, JSON.stringify(TICKETS_ENVELOPE), 'utf8');
+
+    const envelope = await loadPlanContextEnvelope(
+      resolvePlanContextPath(null, dir),
+    );
+    assert.equal(envelope.mode, 'tickets');
+    // The end-to-end point: ids reach the partition with no flag passed.
+    assert.deepEqual(resolveSourceTicketIds({ envelope }), {
+      ids: [4525, 4526],
+      origin: 'envelope',
+    });
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it('degrades to null (warn) when no path is resolvable at all', async () => {
+    assert.equal(await loadPlanContextEnvelope(null), null);
+  });
+
+  it('degrades to null when an auto-discovered envelope is simply absent', async () => {
+    const dir = await mkdtemp(path.join(tmpdir(), 'plan-ctx-absent-'));
+    assert.equal(
+      await loadPlanContextEnvelope(resolvePlanContextPath(null, dir)),
+      null,
+    );
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it('throws when an explicitly named --plan-context is missing', async () => {
+    const missing = path.join(planDir, 'nope.json');
+    await assert.rejects(
+      loadPlanContextEnvelope(resolvePlanContextPath(missing, null)),
+      /Cannot read plan-context envelope/,
+    );
+  });
+
+  // A corrupt envelope must never read as "no source tickets" — that is the
+  // vacuous pass this Story closes.
+  it('throws on a present-but-unparseable envelope rather than reading it as empty', async () => {
+    const dir = await mkdtemp(path.join(tmpdir(), 'plan-ctx-corrupt-'));
+    const file = path.join(dir, PLAN_CONTEXT_FILENAME);
+    await writeFile(file, '{ truncated', 'utf8');
+
+    await assert.rejects(
+      loadPlanContextEnvelope(resolvePlanContextPath(null, dir)),
+      /Failed to parse plan-context envelope/,
+    );
+    await rm(dir, { recursive: true, force: true });
+  });
+});

--- a/tests/lib/orchestration/plan-persist-supersede-ops.test.js
+++ b/tests/lib/orchestration/plan-persist-supersede-ops.test.js
@@ -8,13 +8,28 @@ import {
   assertSupersedePartition,
   buildSupersedeCommentBody,
   closeSupersededTickets,
+  extractEnvelopeSourceTicketIds,
   normalizeSourceTicketIds,
   normalizeSupersedes,
+  resolveSourceTicketIds,
   SUPERSEDE_CLOSE_REASON,
 } from '../../../.agents/scripts/lib/orchestration/plan-persist/supersede-ops.js';
 
 function story(slug, supersedes = []) {
   return { slug, supersedes };
+}
+
+/** A minimal `plan-context.js --tickets` envelope. */
+function ticketsEnvelope(ids) {
+  return {
+    mode: 'tickets',
+    sourceTickets: ids.map((id) => ({
+      id,
+      title: `source #${id}`,
+      body: '',
+      labels: [],
+    })),
+  };
 }
 
 describe('normalizeSupersedes', () => {
@@ -154,6 +169,85 @@ describe('assertSupersedePartition', () => {
     assert.throws(
       () => assertSupersedePartition([story('a', [{ id: 1 }])], []),
       /was not passed to --tickets/,
+    );
+  });
+});
+
+describe('extractEnvelopeSourceTicketIds', () => {
+  it('pulls the ids out of a --tickets envelope', () => {
+    assert.deepEqual(
+      extractEnvelopeSourceTicketIds(ticketsEnvelope([4525, 4526])),
+      [4525, 4526],
+    );
+  });
+
+  it('yields [] for a seed-mode envelope, a null envelope, and an empty set', () => {
+    assert.deepEqual(extractEnvelopeSourceTicketIds({ mode: 'seed' }), []);
+    assert.deepEqual(extractEnvelopeSourceTicketIds(null), []);
+    assert.deepEqual(
+      extractEnvelopeSourceTicketIds({ mode: 'tickets', sourceTickets: [] }),
+      [],
+    );
+  });
+
+  it('blames the envelope, not the flag, on a malformed id', () => {
+    assert.throws(
+      () =>
+        extractEnvelopeSourceTicketIds({
+          mode: 'tickets',
+          sourceTickets: [{ id: 0 }],
+        }),
+      /plan-context envelope sourceTickets\[\] expects positive issue ids/,
+    );
+  });
+});
+
+describe('resolveSourceTicketIds', () => {
+  // The Story #4554 regression: before the envelope was threaded through,
+  // omitting --source-tickets left the id set empty, so the partition passed
+  // vacuously and the close phase short-circuited on a run that had really
+  // fetched source tickets.
+  it('derives the ids from the envelope when no flag is passed', () => {
+    assert.deepEqual(
+      resolveSourceTicketIds({ envelope: ticketsEnvelope([4525, 4526]) }),
+      { ids: [4525, 4526], origin: 'envelope' },
+    );
+  });
+
+  it('lets an explicit --source-tickets value override the envelope', () => {
+    assert.deepEqual(
+      resolveSourceTicketIds({
+        explicitIds: '4525',
+        envelope: ticketsEnvelope([4525, 4526]),
+      }),
+      { ids: [4525], origin: 'flag' },
+    );
+  });
+
+  it('honours the flag when there is no envelope at all (hand-driven run)', () => {
+    assert.deepEqual(resolveSourceTicketIds({ explicitIds: '4525,4526' }), {
+      ids: [4525, 4526],
+      origin: 'flag',
+    });
+  });
+
+  it('reports origin "none" when neither channel carries ids (seed mode)', () => {
+    assert.deepEqual(resolveSourceTicketIds({ envelope: { mode: 'seed' } }), {
+      ids: [],
+      origin: 'none',
+    });
+    assert.deepEqual(resolveSourceTicketIds(), { ids: [], origin: 'none' });
+  });
+
+  it('an envelope-derived set still fail-closes the partition when a Story forgot supersedes[]', () => {
+    // The whole point: deriving the ids turns the old silent no-op into the
+    // existing loud partition error.
+    const { ids } = resolveSourceTicketIds({
+      envelope: ticketsEnvelope([4525]),
+    });
+    assert.throws(
+      () => assertSupersedePartition([story('a')], ids),
+      /#4525 is not claimed by any Story/,
     );
   });
 });

--- a/tests/plan-context.test.js
+++ b/tests/plan-context.test.js
@@ -22,6 +22,9 @@
  */
 
 import assert from 'node:assert/strict';
+import { mkdtemp, readdir, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
 import { describe, it } from 'node:test';
 import { findSimilarOpenStories } from '../.agents/scripts/lib/duplicate-search.js';
 import {
@@ -32,6 +35,12 @@ import {
   PLAN_CONTEXT_ENVELOPE_BYTE_CEILING,
   TICKET_SCHEMA_DESCRIPTOR,
 } from '../.agents/scripts/lib/orchestration/plan-context.js';
+import {
+  loadPlanContextEnvelope,
+  PLAN_CONTEXT_FILENAME,
+  resolvePlanContextPath,
+} from '../.agents/scripts/lib/orchestration/plan-persist/plan-context-source.js';
+import { resolveSourceTicketIds } from '../.agents/scripts/lib/orchestration/plan-persist/supersede-ops.js';
 import { buildDecomposerSystemPrompt } from '../.agents/scripts/lib/orchestration/planning/decomposer-context.js';
 import {
   renderAcceptanceSpecSystemPrompt,
@@ -628,5 +637,73 @@ describe('plan-context tickets mode — concurrent source-ticket fetch', () => {
         }),
       /ticket #202 not found/,
     );
+  });
+});
+
+describe('plan-context --out envelope capture (Story #4554)', () => {
+  const sink = { write: () => true };
+
+  // The producer half of the flagless `--tickets` supersede path: persist can
+  // only derive source ids from an envelope that actually reached disk.
+  it('writes an envelope persist can read the source ids back out of', async () => {
+    const dir = await mkdtemp(path.join(tmpdir(), 'plan-ctx-out-'));
+    const outPath = path.join(dir, PLAN_CONTEXT_FILENAME);
+
+    const envelope = await emitPlanContext({
+      mode: 'tickets',
+      ticketIds: [4525, 4526],
+      provider: buildProvider(),
+      config: {},
+      settings: {},
+      outPath,
+      stdout: sink,
+    });
+    assert.deepEqual(
+      envelope.sourceTickets.map((t) => t.id),
+      [4525, 4526],
+    );
+
+    // Round-trip through the exact reader plan-persist.js uses.
+    const loaded = await loadPlanContextEnvelope(
+      resolvePlanContextPath(null, dir),
+    );
+    assert.deepEqual(resolveSourceTicketIds({ envelope: loaded }), {
+      ids: [4525, 4526],
+      origin: 'envelope',
+    });
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it('creates missing parent directories for --out', async () => {
+    const dir = await mkdtemp(path.join(tmpdir(), 'plan-ctx-mkdir-'));
+    const outPath = path.join(dir, 'nested', 'deeper', PLAN_CONTEXT_FILENAME);
+
+    await emitPlanContext({
+      mode: 'seed-file',
+      seedFileContent: ONE_PAGER,
+      provider: buildProvider(),
+      config: {},
+      settings: {},
+      outPath,
+      stdout: sink,
+    });
+
+    const written = JSON.parse(await readFile(outPath, 'utf8'));
+    assert.equal(written.mode, 'seed-file');
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it('writes nothing when --out is omitted (stdout-only remains the default)', async () => {
+    const dir = await mkdtemp(path.join(tmpdir(), 'plan-ctx-noout-'));
+    await emitPlanContext({
+      mode: 'seed-file',
+      seedFileContent: ONE_PAGER,
+      provider: buildProvider(),
+      config: {},
+      settings: {},
+      stdout: sink,
+    });
+    assert.deepEqual(await readdir(dir), []);
+    await rm(dir, { recursive: true, force: true });
   });
 });

--- a/tests/scripts/plan-persist.flat-stories.test.js
+++ b/tests/scripts/plan-persist.flat-stories.test.js
@@ -10,6 +10,7 @@ import {
 } from '../../.agents/scripts/lib/label-constants.js';
 import { runPlanPersist } from '../../.agents/scripts/lib/orchestration/plan-persist/run-plan-persist.js';
 import { PLAN_SUMMARY_COMMENT_TYPE } from '../../.agents/scripts/lib/orchestration/plan-persist/summary.js';
+import { resolveSourceTicketIds } from '../../.agents/scripts/lib/orchestration/plan-persist/supersede-ops.js';
 import { serialize } from '../../.agents/scripts/lib/story-body/story-body.js';
 
 const VERDICT = {
@@ -460,6 +461,57 @@ describe('runPlanPersist — superseded source tickets (Story #4535)', () => {
     assert.equal(result.stories.length, 1);
     assert.equal(result.supersede.enabled, false);
     assert.equal(result.supersede.reason, 'no-source-tickets');
+    assert.equal(result.supersede.sourceTicketOrigin, 'none');
+    assert.deepEqual(provider.updates, []);
+  });
+
+  // Story #4554 — the flagless path. `--source-tickets` is never passed; the
+  // ids come off the plan-context envelope the run already emitted.
+  it('closes the source ticket when the ids were derived from the envelope, with no --source-tickets flag', async () => {
+    const provider = fakeProvider({ sources: [{ id: 4525, title: 'Old' }] });
+    const { ids, origin } = resolveSourceTicketIds({
+      envelope: {
+        mode: 'tickets',
+        sourceTickets: [{ id: 4525, title: 'Old', body: '' }],
+      },
+    });
+
+    const result = await runPlanPersist({
+      provider,
+      artifacts: {
+        stories: [supersedingTicket('solo', [4525])],
+        riskVerdict: VERDICT,
+      },
+      opts: {
+        skipCleanup: true,
+        sourceTicketIds: ids,
+        sourceTicketOrigin: origin,
+      },
+    });
+
+    assert.equal(result.supersede.sourceTicketOrigin, 'envelope');
+    assert.deepEqual(result.supersede.closed, [4525]);
+    assert.equal(provider.issues.get(4525).state, 'closed');
+  });
+
+  // The vacuous-pass hole itself: an envelope-derived source set turns a
+  // forgotten `supersedes[]` into the loud partition error it always should
+  // have been, instead of an empty-set pass that reported success.
+  it('fail-closes rather than partitioning an empty set when the envelope has sources the Stories do not claim', async () => {
+    const provider = fakeProvider({ sources: [{ id: 4525 }] });
+    const { ids } = resolveSourceTicketIds({
+      envelope: { mode: 'tickets', sourceTickets: [{ id: 4525 }] },
+    });
+
+    await assert.rejects(
+      runPlanPersist({
+        provider,
+        artifacts: { stories: [ticket('solo')], riskVerdict: VERDICT },
+        opts: { skipCleanup: true, sourceTicketIds: ids },
+      }),
+      /#4525 is not claimed by any Story/,
+    );
+    // Fail-closed means fail *before* any GitHub write.
     assert.deepEqual(provider.updates, []);
   });
 });

--- a/tests/scripts/plan-persist.source-ticket-join.test.js
+++ b/tests/scripts/plan-persist.source-ticket-join.test.js
@@ -1,0 +1,104 @@
+/**
+ * The plan-persist.js CLI join: parsed flags → envelope discovery →
+ * `runPlanPersist` opts (Story #4554).
+ *
+ * The unit tests around `resolveSourceTicketIds` prove the resolver; these
+ * prove the CLI actually *wires it up*. Without this, a regression in
+ * `buildPersistOptions` would silently un-wire `/plan --tickets` superseding
+ * while every resolver test stayed green.
+ */
+
+import assert from 'node:assert/strict';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { describe, it } from 'node:test';
+import { PLAN_CONTEXT_FILENAME } from '../../.agents/scripts/lib/orchestration/plan-persist/plan-context-source.js';
+import {
+  buildPersistOptions,
+  resolveInputPaths,
+} from '../../.agents/scripts/plan-persist.js';
+
+const TICKETS_ENVELOPE = {
+  mode: 'tickets',
+  sourceTickets: [{ id: 4525, title: 'Old idea', body: '' }],
+};
+
+/** The minimum `parseArgs` values plan-persist needs to resolve paths. */
+function values(overrides = {}) {
+  return {
+    stories: 'temp/stories.json',
+    'risk-verdict': 'temp/risk-verdict.json',
+    ...overrides,
+  };
+}
+
+async function planDirWithEnvelope(envelope = TICKETS_ENVELOPE) {
+  const dir = await mkdtemp(path.join(tmpdir(), 'persist-join-'));
+  await writeFile(
+    path.join(dir, PLAN_CONTEXT_FILENAME),
+    JSON.stringify(envelope),
+    'utf8',
+  );
+  return dir;
+}
+
+describe('plan-persist CLI join — source ticket ids (Story #4554)', () => {
+  it('resolves the envelope path from --plan-dir by convention', () => {
+    const paths = resolveInputPaths(values({ 'plan-dir': 'temp/plan-x' }));
+    assert.equal(
+      paths.planContextPath.path,
+      path.join(path.resolve('temp/plan-x'), PLAN_CONTEXT_FILENAME),
+    );
+    assert.equal(paths.planContextPath.explicit, false);
+  });
+
+  it('resolves nothing to read when neither --plan-dir nor --plan-context is given', () => {
+    assert.equal(resolveInputPaths(values()).planContextPath, null);
+  });
+
+  // The end-to-end join: --plan-dir only, no --source-tickets anywhere.
+  it('threads envelope-derived ids into the persist opts with no --source-tickets flag', async () => {
+    const dir = await planDirWithEnvelope();
+    const paths = resolveInputPaths(values({ 'plan-dir': dir }));
+    const opts = buildPersistOptions(values({ 'plan-dir': dir }), paths, {
+      ...TICKETS_ENVELOPE,
+    });
+
+    assert.deepEqual(opts.sourceTicketIds, [4525]);
+    assert.equal(opts.sourceTicketOrigin, 'envelope');
+    assert.equal(opts.closeSuperseded, true);
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it('lets --source-tickets override the envelope through the join', () => {
+    const opts = buildPersistOptions(
+      values({ 'source-tickets': '4999' }),
+      resolveInputPaths(values()),
+      TICKETS_ENVELOPE,
+    );
+    assert.deepEqual(opts.sourceTicketIds, [4999]);
+    assert.equal(opts.sourceTicketOrigin, 'flag');
+  });
+
+  it('reports origin "none" with no envelope and no flag', () => {
+    const opts = buildPersistOptions(
+      values(),
+      resolveInputPaths(values()),
+      null,
+    );
+    assert.deepEqual(opts.sourceTicketIds, []);
+    assert.equal(opts.sourceTicketOrigin, 'none');
+  });
+
+  it('keeps --no-close-superseded winning over the derived ids', () => {
+    const opts = buildPersistOptions(
+      values({ 'no-close-superseded': true }),
+      resolveInputPaths(values()),
+      TICKETS_ENVELOPE,
+    );
+    // Ids still resolve — the flag disables the close phase, not the partition.
+    assert.deepEqual(opts.sourceTicketIds, [4525]);
+    assert.equal(opts.closeSuperseded, false);
+  });
+});


### PR DESCRIPTION
Closes #4554

_Auto-opened by `/single-story-deliver`._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how GitHub source tickets are selected and closed during persist; mistakes could skip closes or fail runs, but behavior is fail-closed with warnings and broad test coverage.
> 
> **Overview**
> Fixes **`/plan --tickets`** runs that could **succeed without closing source issues** when operators omitted **`--source-tickets`** — the supersede partition then saw an empty id set and passed vacuously.
> 
> **`plan-context.js`** gains **`--out`** to persist the JSON envelope (e.g. `<plan-dir>/plan-context.json`) while keeping stdout unchanged. **`plan-persist.js`** auto-loads that file via new **`--plan-context`** or **`--plan-dir`**, with **`plan-context-source.js`** defining warn vs fatal when the envelope is missing or corrupt.
> 
> **`resolveSourceTicketIds`** picks source ids **envelope-first**, with **`--source-tickets`** as an explicit override; the persist result’s **`supersede.sourceTicketOrigin`** (`envelope` | `flag` | `none`) records which channel was used. **`plan.md`** documents capturing the envelope in step 1 and the resolution table.
> 
> Tests cover filesystem discovery, resolver/precedence, CLI wiring (`buildPersistOptions`), and end-to-end envelope-driven close vs partition fail-closed when **`supersedes[]`** is missing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7103e68895ad43af89799a7e4c42a3d60668eda0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->