### PR TITLE
fix(column-sync): stop two more test suites leaking into the shared meta cache

### DIFF
--- a/.agents/scripts/lib/single-story/story-merged-notify.js
+++ b/.agents/scripts/lib/single-story/story-merged-notify.js
@@ -41,7 +41,13 @@ export async function flipLabelAndNotify({
   config,
   progress,
 }) {
-  const labelFlipped = await flipLabel(provider, storyId, story, progress);
+  const labelFlipped = await flipLabel(
+    provider,
+    storyId,
+    story,
+    progress,
+    config,
+  );
   if (!labelFlipped) return;
   await fireStoryClosingNotify({
     notifyFn: notifyFn ?? defaultNotify,
@@ -55,7 +61,7 @@ export async function flipLabelAndNotify({
   });
 }
 
-async function flipLabel(provider, storyId, story, progress) {
+async function flipLabel(provider, storyId, story, progress, config) {
   try {
     // Story #3385 — flip to `agent::closing`, NOT `agent::done`. The
     // canonical mutator (`transitionTicketState`) only closes the GitHub
@@ -81,8 +87,13 @@ async function flipLabel(provider, storyId, story, progress) {
     // notification that `transitionTicketState` would dispatch is
     // redundant with the typed `story-closing` event that
     // `fireStoryClosingNotify` emits immediately afterwards.
+    //
+    // `config` is threaded so the on-disk board-metadata cache (issue #4555)
+    // lands under the project's configured `tempRoot` rather than the
+    // framework default, matching every other transition call site.
     await transitionTicketState(provider, storyId, STATE_LABELS.CLOSING, {
       ticketSnapshot: story,
+      config,
     });
     progress?.('LABELS', `🏷️  Story #${storyId} → agent::closing`);
     return true;

--- a/tests/lib/orchestration/ticketing.column-sync.test.js
+++ b/tests/lib/orchestration/ticketing.column-sync.test.js
@@ -1,5 +1,8 @@
 import assert from 'node:assert/strict';
-import { describe, it } from 'node:test';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, it } from 'node:test';
 
 import { transitionTicketState } from '../../../.agents/scripts/lib/orchestration/ticketing.js';
 
@@ -93,10 +96,32 @@ function buildFakeProvider({ throwOnMutation = false } = {}) {
 }
 
 describe('transitionTicketState — Projects v2 Status column sync', () => {
+  // Isolate the on-disk project-meta cache (issue #4555). The ColumnSync
+  // driven here reads and WRITES `<tempRoot>/cache/project-meta.json`, and a
+  // relative tempRoot anchors to the MAIN checkout — so with no config this
+  // suite wrote its `acme/42` fixture ids (`PROJ`/`FIELD`) into the cache real
+  // `/deliver` runs consume, and the throwOnMutation case invalidated that key
+  // back out again. `transitionTicketState` threads `opts.config` down to
+  // ColumnSync; an ABSOLUTE tempRoot is used verbatim
+  // (`temp-paths.js#anchorTempRoot`), so this can never reach the shared file.
+  let tempRoot;
+  let isolatedConfig;
+
+  beforeEach(() => {
+    tempRoot = mkdtempSync(path.join(tmpdir(), 'mandrel-colsync-'));
+    isolatedConfig = { project: { paths: { tempRoot } } };
+  });
+
+  afterEach(() => {
+    rmSync(tempRoot, { recursive: true, force: true });
+  });
+
   it('mirrors agent::executing onto the In Progress column via a single mutation', async () => {
     const provider = buildFakeProvider();
 
-    await transitionTicketState(provider, 321, 'agent::executing');
+    await transitionTicketState(provider, 321, 'agent::executing', {
+      config: isolatedConfig,
+    });
 
     const mutationCalls = provider.graphqlCalls.filter((c) =>
       c.query.includes('updateProjectV2ItemFieldValue'),
@@ -119,7 +144,9 @@ describe('transitionTicketState — Projects v2 Status column sync', () => {
   it('mirrors agent::blocked onto the In Progress column (label retains the granular signal)', async () => {
     const provider = buildFakeProvider();
 
-    await transitionTicketState(provider, 321, 'agent::blocked');
+    await transitionTicketState(provider, 321, 'agent::blocked', {
+      config: isolatedConfig,
+    });
 
     const mutation = provider.graphqlCalls.find((c) =>
       c.query.includes('updateProjectV2ItemFieldValue'),
@@ -136,7 +163,10 @@ describe('transitionTicketState — Projects v2 Status column sync', () => {
     // logged — the label flip outcome must not regress because the
     // board is misconfigured or the API is flapping.
     await assert.doesNotReject(
-      () => transitionTicketState(provider, 321, 'agent::executing'),
+      () =>
+        transitionTicketState(provider, 321, 'agent::executing', {
+          config: isolatedConfig,
+        }),
       'column-sync errors must be swallowed',
     );
 

--- a/tests/single-story-close-orchestration.test.js
+++ b/tests/single-story-close-orchestration.test.js
@@ -28,8 +28,10 @@
  */
 
 import assert from 'node:assert/strict';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
 import path from 'node:path';
-import { describe, it } from 'node:test';
+import { afterEach, beforeEach, describe, it } from 'node:test';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 
 const REPO_ROOT = path
@@ -147,6 +149,21 @@ function makeFakeProvider({
   };
 }
 
+// Isolate the on-disk project-meta cache (issue #4555). The close flip routes
+// through `transitionTicketState` → ColumnSync, which reads and WRITES
+// `<tempRoot>/cache/project-meta.json`; a relative tempRoot anchors to the MAIN
+// checkout, so with no config the board-sync case below wrote its `owner/1`
+// fixture ids (`PROJ`/`FIELD`) into the cache real `/deliver` runs consume. An
+// ABSOLUTE tempRoot is used verbatim (`temp-paths.js#anchorTempRoot`), so this
+// can never reach the shared file.
+let tempRoot;
+beforeEach(() => {
+  tempRoot = mkdtempSync(path.join(tmpdir(), 'mandrel-colsync-'));
+});
+afterEach(() => {
+  rmSync(tempRoot, { recursive: true, force: true });
+});
+
 function fakeConfig({
   baseBranch = 'main',
   reapOnSuccess = false,
@@ -154,7 +171,7 @@ function fakeConfig({
   autoMerge,
 } = {}) {
   return {
-    project: { baseBranch, commands: {} },
+    project: { baseBranch, commands: {}, paths: { tempRoot } },
     delivery: {
       worktreeIsolation: {
         enabled: true,


### PR DESCRIPTION
## Why

Issue #4555 isolated `tests/graphql/query-builder.test.js` from the on-disk
project-meta cache (Story #4252), but **two other suites still read and write the
same shared file**. A relative `tempRoot` anchors to the *main checkout root*, so
`<tempRoot>/cache/project-meta.json` is a single file shared across every git
worktree and every test run on the machine. Same hazard #4555 fixed — different
call sites, so its fix didn't reach them.

Both leaks were verified live against a pristine `main`:

| Suite | Key | Behaviour |
| --- | --- | --- |
| `tests/lib/orchestration/ticketing.column-sync.test.js` | `acme/42` | Written via `transitionTicketState`. Its `throwOnMutation` case calls `invalidateProjectMetaCache`, deleting the key again — so the leak is **intermittent**, depending on intra-file test order. |
| `tests/single-story-close-orchestration.test.js` | `owner/1` | Written **deterministically**, landing fixture ids (`PROJ`/`FIELD`) next to the live board's entry. |

The intermittent one is the reason this is worth closing out rather than leaving:
it's invisible on the runs where the invalidate happens to fire last, which is
exactly how it would resurface later looking like a brand-new flake.

## The production change

The close path could **not** be isolated from the test side alone.
`story-merged-notify` never threaded `config` into its `transitionTicketState`
call, so ColumnSync there always fell back to the framework-default `tempRoot`
and silently ignored the caller's configured one. Threading it through matches
every other transition call site — `config` was already in scope and already
passed to the sibling `fireStoryClosingNotify`.

This is a **no-op for repos whose configured `tempRoot` is the default**
(including this one, where `.agentrc.json` sets `"tempRoot": "temp"`).

The cache **anchoring itself is deliberate and unchanged** — it's what lets the
cold CLI processes in a single delivery share resolved board metadata.

## Verification

- Full suite **twice back-to-back**: green both times (7863 pass, 0 fail) — the
  original re-run-within-TTL failure mode.
- Shared cache holds **only** the live `dsj1984/1` entry afterward: zero fixture
  keys, where `main` leaves `owner/1`.
- `npm run verify` exits 0, including the `dead-exports` and `arch-cycles`
  ratchets (`added=0 removed=0` for both).

## Note

While verifying, the live `dsj1984/1` entry was observed being evicted mid-session
by `writeProjectMetaCache`'s unlocked read-modify-write, then re-resolving on its
own minutes later. Not addressed here — the cache is best-effort and self-healing
by design, so this is lossy but not a correctness bug. Filing separately if it
proves noisy under parallel chunks.

refs #4555

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small wiring fix plus test isolation; production impact is limited to repos with a non-default `tempRoot`, where cache paths now align with the rest of the stack.
> 
> **Overview**
> Closes remaining **#4555** leaks where column-sync tests wrote fixture project-meta into the **shared** `tempRoot/cache/project-meta.json` (relative `tempRoot` anchors to the main checkout).
> 
> **Production:** `story-merged-notify` now passes **`config`** into `transitionTicketState` on the `agent::closing` flip so ColumnSync uses the project’s configured **`tempRoot`** for the on-disk board-metadata cache, consistent with other transition call sites. No behavior change when `tempRoot` is still the default.
> 
> **Tests:** `ticketing.column-sync.test.js` and `single-story-close-orchestration.test.js` use a per-run **absolute** `tempRoot` (`mkdtemp` + teardown) and pass it via `config` / `fakeConfig`, so ColumnSync never touches the cache real delivery runs use.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7137d1fcda6e645ccb3de11b57a4dc1876ab5b1f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->