### PR TITLE
chore(release): pin the major at 2.x — always-bump-minor

### DIFF
--- a/docs/release-operations.md
+++ b/docs/release-operations.md
@@ -195,23 +195,54 @@ itself, only the npm artifact.
 
 ### Versioning policy
 
-`release-please-config.json` uses the default **node** versioning strategy
-(standard Conventional Commits):
+`release-please-config.json` sets **`"versioning": "always-bump-minor"`**.
+Every release bumps the **minor** — the major is pinned at `2.x` and the
+minor is effectively a serial:
 
 | Commit signal | Bump |
 | ------------- | ---- |
-| `fix:` / `perf:` (no breaking marker) | patch |
-| `feat:` (no breaking marker) | minor |
-| `BREAKING CHANGE:` footer or `feat!:` / `fix!:` | major |
+| `fix:` / `perf:` | **minor** |
+| `feat:` | **minor** |
+| `BREAKING CHANGE:` footer or `feat!:` / `fix!:` | **minor** |
+
+**This is a deliberate cap, not the Conventional Commits default.** The
+`AlwaysBumpMinor` strategy ignores commit types entirely and always returns
+a minor bump, so two things follow and both are intended:
+
+- **A breaking marker cannot cut a major.** The framework's churn is mostly
+  workflow prose and internal orchestration scripts under `.agents/`. Those
+  change shape often, but the package's actual consumer surface — the
+  `mandrel` CLI (`sync` / `update` / `doctor`) and the materialized
+  `.agents/` payload — is what a consumer imports. A `feat!:` on an operator
+  slash-command flag was cutting a major for a change no consumer's code
+  could break on. Majors are now **deliberate**, not incidental.
+- **There are no patch releases.** A one-line `fix:` cuts `2.(n+1).0`, not
+  `2.n.1`. That is the cost of the cap; the minor number is a serial, and
+  the changelog — not the version — tells you what changed.
+
+> **Keep marking breaking changes anyway.** `feat!:` / `BREAKING CHANGE:`
+> still drive the changelog's breaking section, which is how consumers learn
+> what to adjust. The cap changes the *number*, not the *signal*.
 
 v2.0.0 was cut by landing the Story-collapse work with an explicit
 `BREAKING CHANGE` changelog section and version files already at `2.0.0`.
-Subsequent releases follow the table above automatically — no
-`always-bump-minor` cap and no required `Release-As:` trailer for majors.
+Story #4540 then added the cap, after a `feat!:` retiring the `/deliver
+--run` flag proposed 3.0.0.
 
-Operators who want to **force** a specific next version (skip a bump, or
-re-cut after a mistaken tag) can still:
+#### To cut a real major (3.0.0)
 
-1. Edit `package.json`, `.release-please-manifest.json`, and
-   `docs/CHANGELOG.md` on the release PR branch, or
-2. Land a one-shot commit with `Release-As: X.Y.Z` in the trailer.
+The cap is a config line, so an intentional major is a two-step:
+
+1. Remove `"versioning": "always-bump-minor"` from
+   `release-please-config.json` (or set it to `"default"`), and
+2. Land the breaking commit — or force the number outright with a one-shot
+   `Release-As: 3.0.0` trailer, which bypasses commit analysis entirely.
+
+Re-add the cap afterwards if you want majors to stay deliberate.
+
+#### To force any specific version
+
+1. Land a one-shot commit with `Release-As: X.Y.Z` in the trailer
+   (bypasses the strategy, including this cap), or
+2. Edit `package.json`, `.release-please-manifest.json`, and
+   `docs/CHANGELOG.md` directly on the release PR branch.

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "release-type": "node",
+  "versioning": "always-bump-minor",
   "include-component-in-tag": true,
   "include-v-in-tag": true,
   "draft": false,


### PR DESCRIPTION
## Why

release-please proposed **3.0.0** (#4538). The only breaking commit since `v2.0.0` is `e9935cc3` — my `feat!:` retiring the `/deliver --run` flag — whose `BREAKING CHANGE:` footer drove the major exactly as `docs/release-operations.md` documented. **The tool was right; the policy was the thing to change.**

That flag lived in workflow *prose* and an internal orchestration script. The package's consumer surface — the `mandrel` CLI (`sync`/`update`/`doctor`) and the materialized `.agents/` payload — was unchanged, so no consumer's code could break on it. Cutting a major for that is churn, and #4542 (`refactor(plan)!`) would have done it again.

## What

```diff
  "release-type": "node",
+ "versioning": "always-bump-minor",
```

The major is pinned at `2.x`; a breaking marker can no longer cut one incidentally.

Verified against release-please's own registry ([`versioning-strategy-factory.ts`](https://github.com/googleapis/release-please/blob/main/src/factories/versioning-strategy-factory.ts)) rather than the JSON schema — the schema types `versioning` as a bare `string` with no enum, so it would have accepted a typo silently. Note the config key is **`versioning`**; `--versioning-strategy` is the CLI flag spelling only.

## Two consequences — both intended, both now documented

- **Majors become deliberate.** To cut a real 3.0.0: remove the line (or set `"default"`) and land the breaking commit, or force it with a one-shot `Release-As: 3.0.0`.
- **No more patch releases.** `AlwaysBumpMinor.determineReleaseType()` ignores commit types entirely and always returns a minor bump — a one-line `fix:` now cuts `2.(n+1).0`, not `2.n.1`. The minor becomes a serial; the changelog, not the version, says what changed.

Breaking markers are still worth writing — they drive the changelog's breaking section, which is how consumers learn what to adjust. The cap changes the *number*, not the *signal*.

## Effect on #4538

Once this lands, release-please recomputes the open release PR from **3.0.0 → 2.1.0**. Do not merge #4538 until then.

Rewrites `docs/release-operations.md` § Versioning policy, which asserted the opposite ("no `always-bump-minor` cap").

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release automation and documentation only; no runtime CLI or consumer install behavior changes.
> 
> **Overview**
> Pins **release-please** to **`always-bump-minor`** in `release-please-config.json`, so every release advances the **minor** on the `2.x` line instead of following Conventional Commits patch/minor/major bumps.
> 
> **`docs/release-operations.md`** § Versioning policy is rewritten to match: the bump table now shows all commit types (including `feat!:` / `BREAKING CHANGE`) as **minor**; it explains that majors are deliberate-only and patch releases are gone, with steps to cut a real **3.0.0** (drop the cap or `Release-As: 3.0.0`) and to force any version. Breaking markers remain for changelog signaling only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 600ff91be17e4af42cfb9f80a02ebbe9d439c666. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->