### PR TITLE
feat(plan): mirror sibling depends_on into native GitHub blocked_by edges at persist (#4544)

### DIFF
--- a/.agents/scripts/lib/orchestration/plan-persist/story-ops.js
+++ b/.agents/scripts/lib/orchestration/plan-persist/story-ops.js
@@ -16,6 +16,7 @@
  */
 
 import { createHash } from 'node:crypto';
+import { applyBlockedByDependencies } from '../../../providers/github/blocked-by-add.js';
 import { Logger } from '../../Logger.js';
 import { AGENT_LABELS, TYPE_LABELS } from '../../label-constants.js';
 import {
@@ -458,6 +459,87 @@ function renderStoryBodyForCreate(story, idBySlug) {
 }
 
 /**
+ * Mirror the plan's sibling `depends_on` edges into native GitHub `blocked_by`
+ * dependency edges (Story #4544).
+ *
+ * Ordering is authored as slugs and, until now, survived persist only as
+ * `blocked by #N` prose in the body footer. That footer stays — it is what
+ * `/deliver`'s resolver falls back on — but a native edge is the durable,
+ * machine-readable form: visible in the GitHub UI, readable without parsing
+ * markdown, and settable by an operator later for cross-run order.
+ *
+ * **Non-fatal by design, and deliberately asymmetric with the read path.** A
+ * missing native edge is cosmetic here: `renderStoryBodyForCreate` has already
+ * written the footer, so ordering is not lost when the dependencies API says
+ * no. `/deliver`'s *read* of these edges is a real dispatch gate, which is why
+ * that side fails loud. Persist reports the failure and completes.
+ *
+ * Two shape hazards this crossing has to get right, both silent if missed:
+ * `applyBlockedByDependencies` indexes `slugToIssueNumber` with property
+ * access, so the `Map` the create loop builds must be flattened to a plain
+ * object — a `Map` would yield `undefined` for every lookup, skip every edge,
+ * and (being non-fatal) report success having written nothing. And it reads
+ * `dependsOn`, not the `depends_on` the assembled Story carries.
+ *
+ * @param {object} args
+ * @param {object} args.provider
+ * @param {Array<{ slug: string, depends_on: string[] }>} args.stories
+ * @param {Map<string, number>} args.idBySlug
+ * @returns {Promise<{ edgesAdded: number, edgesSkipped: number, edgesFailed: number, storiesProcessed: number }|null>}
+ *   `null` when there was nothing to mirror or no interface to mirror through.
+ */
+async function mirrorNativeDependencyEdges({ provider, stories, idBySlug }) {
+  const withEdges = stories.filter((story) => story.depends_on.length > 0);
+  if (withEdges.length === 0) return null;
+
+  if (
+    typeof provider?.getDependencyWriteContext !== 'function' ||
+    typeof provider?.getTicket !== 'function'
+  ) {
+    Logger.warn(
+      '[plan-persist] provider exposes no getDependencyWriteContext/getTicket — ' +
+        'skipping native blocked_by edges. Ordering survives in the ' +
+        '`blocked by #N` body footers.',
+    );
+    return null;
+  }
+
+  try {
+    const { gh, owner, repo } = provider.getDependencyWriteContext();
+    const summary = await applyBlockedByDependencies({
+      stories: stories.map((story) => ({
+        slug: story.slug,
+        dependsOn: story.depends_on,
+      })),
+      slugToIssueNumber: Object.fromEntries(idBySlug),
+      getTicket: (issueNumber) => provider.getTicket(issueNumber),
+      owner,
+      repo,
+      gh,
+    });
+    if (summary.edgesFailed > 0) {
+      Logger.warn(
+        `[plan-persist] ${summary.edgesFailed} native blocked_by edge(s) could ` +
+          'not be written. Ordering survives in the `blocked by #N` body ' +
+          'footers; add the edges by hand if you want them in the GitHub UI.',
+      );
+    } else {
+      Logger.info(
+        `[plan-persist] native blocked_by edges: ${summary.edgesAdded} added, ` +
+          `${summary.edgesSkipped} already present.`,
+      );
+    }
+    return summary;
+  } catch (err) {
+    Logger.warn(
+      `[plan-persist] native blocked_by mirroring failed (${err.message}) — ` +
+        'ordering survives in the `blocked by #N` body footers.',
+    );
+    return null;
+  }
+}
+
+/**
  * Create Story issues via `provider.createIssue`, resumably.
  *
  * **Stories are born without `agent::ready`** (Story #4541). They used to
@@ -480,12 +562,19 @@ function renderStoryBodyForCreate(story, idBySlug) {
  * the `blocked by #N` footers written below — which `/deliver`'s resolver
  * reads directly, alongside native GitHub edges, from live state.
  *
+ * **Sibling order is mirrored into native GitHub `blocked_by` edges** once
+ * every id is known (Story #4544), so plan-created order stops depending on
+ * prose. That pass is non-fatal — see `mirrorNativeDependencyEdges`.
+ *
  * @param {object} args
  * @param {object} args.provider
  * @param {ReturnType<typeof assemblePlanStories>['stories']} args.stories
  * @param {object} [args.opts]
  * @param {boolean} [args.opts.dryRun=false]
- * @returns {Promise<{ created: Array<{ slug: string, id: number, url?: string, title: string, adopted: boolean }> }>}
+ * @returns {Promise<{
+ *   created: Array<{ slug: string, id: number, url?: string, title: string, adopted: boolean }>,
+ *   dependencyEdges: { edgesAdded: number, edgesSkipped: number, edgesFailed: number, storiesProcessed: number }|null,
+ * }>}
  */
 export async function createStoryIssues({ provider, stories, opts = {} }) {
   if (typeof provider?.createIssue !== 'function') {
@@ -505,6 +594,7 @@ export async function createStoryIssues({ provider, stories, opts = {} }) {
         url: undefined,
         adopted: false,
       })),
+      dependencyEdges: null,
     };
   }
 
@@ -551,7 +641,16 @@ export async function createStoryIssues({ provider, stories, opts = {} }) {
     idBySlug.set(story.slug, id);
   }
 
-  return { created };
+  // Every id is known now — including the adopted ones a resumed run reused —
+  // so a re-run mirrors the whole cohort's edges, not just the Stories this
+  // invocation happened to POST. Re-application is idempotent.
+  const dependencyEdges = await mirrorNativeDependencyEdges({
+    provider,
+    stories: list,
+    idBySlug,
+  });
+
+  return { created, dependencyEdges };
 }
 
 /**

--- a/.agents/scripts/providers/github.js
+++ b/.agents/scripts/providers/github.js
@@ -85,6 +85,25 @@ export class GitHubProvider extends ITicketingProvider {
     return this.getEpics(filters);
   }
 
+  /**
+   * The identifiers a native dependency-edge writer needs, handed over as an
+   * explicit interface (Story #4544).
+   *
+   * `providers/github/blocked-by-add.js` talks to the dependencies REST API
+   * directly, so it needs the `gh` facade plus `owner`/`repo` — none of which
+   * the `ITicketingProvider` surface exposes. Its caller lives in the
+   * orchestration layer (`plan-persist/story-ops.js`), and the alternative was
+   * for that caller to reach through `provider._gh` — a private-by-convention
+   * field — from outside this module. Naming the hand-off here keeps the
+   * coupling declared and greppable instead of incidental: the provider
+   * decides what it lends out, and the field stays private.
+   *
+   * @returns {{ gh: object, owner: string, repo: string }}
+   */
+  getDependencyWriteContext() {
+    return { gh: this._gh, owner: this.owner, repo: this.repo };
+  }
+
   static isInsufficientScopes(err) {
     return projects.isInsufficientScopes(err);
   }

--- a/tests/lib/orchestration/plan-persist-story-ops.test.js
+++ b/tests/lib/orchestration/plan-persist-story-ops.test.js
@@ -271,3 +271,207 @@ describe('createStoryIssues', () => {
     assert.equal(writes, 0);
   });
 });
+
+/**
+ * Build a provider fake that speaks the `getDependencyWriteContext` interface
+ * (Story #4544) and records both the created-issue payloads and the raw
+ * dependencies-API traffic.
+ *
+ * `createIssue` hands back ids from 201 upward in call order, and `getTicket`
+ * maps an issue number to a distinct REST database id (`90000 + number`) —
+ * distinct because the dependencies API takes the database id, not the issue
+ * number, and a fake that conflated them would let that bug through.
+ *
+ * @param {{ existingBlockedBy?: Array<{ id: number }>, postShouldFail?: boolean }} [opts]
+ */
+function makeMirrorProvider({
+  existingBlockedBy = [],
+  postShouldFail = false,
+} = {}) {
+  const createPayloads = [];
+  const ghCalls = [];
+  return {
+    createPayloads,
+    ghCalls,
+    createIssue: async (payload) => {
+      createPayloads.push(payload);
+      return { id: 200 + createPayloads.length };
+    },
+    getTicket: async (issueNumber) => ({ internalId: 90000 + issueNumber }),
+    getDependencyWriteContext: () => ({
+      owner: 'org',
+      repo: 'repo',
+      gh: {
+        api: async ({ method, endpoint, body }) => {
+          ghCalls.push({ method, endpoint, body });
+          if (method === 'GET') {
+            return {
+              stdout: JSON.stringify(existingBlockedBy),
+              stderr: '',
+              code: 0,
+            };
+          }
+          if (postShouldFail) {
+            throw new Error('dependencies API rejected the edge');
+          }
+          return { stdout: JSON.stringify({ id: 1 }), stderr: '', code: 0 };
+        },
+      },
+    }),
+  };
+}
+
+/** A two-Story plan carrying exactly one edge: consumer depends on migration. */
+function orderedPair() {
+  return assemblePlanStories([
+    storyTicket('consumer', { depends_on: ['migration'] }),
+    storyTicket('migration'),
+  ]).stories;
+}
+
+describe('createStoryIssues — native blocked_by mirroring (Story #4544)', () => {
+  it('mirrors each authored depends_on edge into exactly one native blocked_by POST', async () => {
+    // The count is asserted exactly, not as ">= 0" or mere completion,
+    // precisely because the mirroring contract is non-fatal: a wiring mistake
+    // (e.g. handing the writer the create loop's `Map` where it does property
+    // access) skips every edge, adds zero, and still reports success.
+    const provider = makeMirrorProvider();
+    const { created, dependencyEdges } = await createStoryIssues({
+      provider,
+      stories: orderedPair(),
+    });
+
+    assert.deepEqual(
+      created.map((s) => s.slug),
+      ['migration', 'consumer'],
+    );
+    assert.deepEqual(dependencyEdges, {
+      edgesAdded: 1,
+      edgesSkipped: 0,
+      edgesFailed: 0,
+      storiesProcessed: 1,
+    });
+
+    const posts = provider.ghCalls.filter((c) => c.method === 'POST');
+    assert.equal(posts.length, 1);
+    assert.equal(
+      posts[0].endpoint,
+      '/repos/org/repo/issues/202/dependencies/blocked_by',
+      'the edge is written on the dependent Story (consumer, #202)',
+    );
+    assert.deepEqual(
+      posts[0].body,
+      { issue_id: 90201 },
+      "the payload carries the blocker's REST database id, not its issue number",
+    );
+  });
+
+  it('is idempotent: an edge that already exists is skipped, not duplicated', async () => {
+    const provider = makeMirrorProvider({
+      existingBlockedBy: [{ id: 90201 }],
+    });
+    const { dependencyEdges } = await createStoryIssues({
+      provider,
+      stories: orderedPair(),
+    });
+
+    assert.deepEqual(dependencyEdges, {
+      edgesAdded: 0,
+      edgesSkipped: 1,
+      edgesFailed: 0,
+      storiesProcessed: 1,
+    });
+    assert.deepEqual(
+      provider.ghCalls.filter((c) => c.method === 'POST'),
+      [],
+      're-applying an existing edge writes nothing',
+    );
+  });
+
+  it('completes the persist when the dependencies API rejects, and reports the failure', async () => {
+    // Non-fatal is the right call here — and only because the ordering has a
+    // second home. A dropped edge is cosmetic: the `blocked by #N` footer is
+    // already in the created body, and that is what /deliver's resolver reads.
+    const provider = makeMirrorProvider({ postShouldFail: true });
+    const { created, dependencyEdges } = await createStoryIssues({
+      provider,
+      stories: orderedPair(),
+    });
+
+    assert.equal(created.length, 2, 'persist completes rather than throwing');
+    assert.equal(dependencyEdges.edgesAdded, 0);
+    assert.equal(
+      dependencyEdges.edgesFailed,
+      1,
+      'the failure is counted and returned, not swallowed',
+    );
+    assert.deepEqual(
+      parse(provider.createPayloads[1].body).body.depends_on,
+      ['#201'],
+      'ordering survives in the body footer',
+    );
+  });
+
+  it('never reaches into provider internals when no interface is offered', async () => {
+    // A provider exposing only the private `_gh` field must yield no edges —
+    // if this ever starts writing, something has gone back to reaching through
+    // the provider's internals from the orchestration layer.
+    const ghCalls = [];
+    let n = 0;
+    const provider = {
+      createIssue: async () => ({ id: 200 + ++n }),
+      getTicket: async () => ({ internalId: 1 }),
+      _gh: {
+        api: async (call) => {
+          ghCalls.push(call);
+          return { stdout: '[]', stderr: '', code: 0 };
+        },
+      },
+    };
+
+    const { created, dependencyEdges } = await createStoryIssues({
+      provider,
+      stories: orderedPair(),
+    });
+
+    assert.equal(created.length, 2);
+    assert.equal(dependencyEdges, null);
+    assert.deepEqual(ghCalls, []);
+  });
+
+  it('does not touch the dependencies API for a plan with no edges', async () => {
+    const provider = makeMirrorProvider();
+    const { dependencyEdges } = await createStoryIssues({
+      provider,
+      stories: assemblePlanStories([storyTicket('solo')]).stories,
+    });
+    assert.equal(dependencyEdges, null);
+    assert.deepEqual(provider.ghCalls, []);
+  });
+
+  it('mirrors edges on a resumed run whose Stories were already created', async () => {
+    // The adopted branch skips the POST but still records the id, so a re-run
+    // after a mid-creation failure completes the cohort's edges too.
+    const provider = makeMirrorProvider();
+    provider.listIssuesByLabel = async () =>
+      orderedPair().map((story, i) => ({
+        number: 201 + (story.slug === 'migration' ? 0 : 1),
+        title: story.title,
+        body: `<!-- plan-story: ${story.fingerprint} -->`,
+        html_url: `https://example/${i}`,
+      }));
+
+    const { created, dependencyEdges } = await createStoryIssues({
+      provider,
+      stories: orderedPair(),
+    });
+
+    assert.deepEqual(
+      created.map((s) => s.adopted),
+      [true, true],
+      'both Stories are adopted, not re-created',
+    );
+    assert.deepEqual(provider.createPayloads, []);
+    assert.equal(dependencyEdges.edgesAdded, 1);
+  });
+});

--- a/tests/providers/github/blocked-by-add.test.js
+++ b/tests/providers/github/blocked-by-add.test.js
@@ -426,3 +426,28 @@ describe('providers/github/blocked-by-add.js — applyBlockedByDependencies', ()
     });
   });
 });
+
+describe('GitHubProvider — dependency-write interface (Story #4544)', () => {
+  it('hands the writer exactly the identifiers it needs, without exposing internals', async () => {
+    // `applyBlockedByDependencies` needs the `gh` facade plus owner/repo —
+    // none of which the ITicketingProvider surface carries. This method is the
+    // declared hand-off, so its shape is a contract between the two modules:
+    // if it drifts, the orchestration caller silently mirrors zero edges.
+    const { GitHubProvider } = await import(
+      pathToFileURL(
+        path.join(ROOT, '.agents', 'scripts', 'providers', 'github.js'),
+      ).href
+    );
+    const gh = { api: async () => ({ stdout: '[]', stderr: '', code: 0 }) };
+    const provider = new GitHubProvider(
+      { owner: 'octo', repo: 'widget' },
+      { gh, token: 'test-token' },
+    );
+
+    assert.deepEqual(provider.getDependencyWriteContext(), {
+      gh,
+      owner: 'octo',
+      repo: 'widget',
+    });
+  });
+});


### PR DESCRIPTION
Closes #4544

_Auto-opened by `/single-story-deliver`._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes plan-persist behavior and GitHub dependency writes, but failures are non-fatal and ordering remains in issue bodies; mis-wiring could silently skip native edges until caught by tests.
> 
> **Overview**
> After all Story issues exist (including on a resumed persist), **plan persist** now mirrors authored sibling `depends_on` into **native GitHub `blocked_by` dependency edges** via `applyBlockedByDependencies`, while keeping the existing `blocked by #N` body footers as the fallback ordering source.
> 
> **`GitHubProvider`** gains **`getDependencyWriteContext()`** (`gh`, `owner`, `repo`) so orchestration can call the dependencies REST API without reaching into private `_gh`. Mirroring is **non-fatal**: API or wiring failures log and return counts; persist still completes. **`createStoryIssues`** now also returns a **`dependencyEdges`** summary (or `null` when skipped).
> 
> Tests cover POST shape (dependent issue, blocker database id), idempotency, API failure, missing interface, no-edge plans, and resumed/adopted runs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4dc05891034c271ca79385ccdac279b127b50c75. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->