### PR TITLE
docs(architecture): drop the retired risk verdict from the plan-persist row (refs #4542)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -215,7 +215,7 @@ graph TB
 | Script                           | Responsibility                                                                                                                                                                              |
 | -------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `plan-context.js`                | Single authoring-envelope emitter for `/plan`: Story brief + docs digest + `codebaseSnapshot` + duplicate search + clarity + rendered system prompts. |
-| `plan-persist.js`                | Single GitHub-write surface for `/plan`: section gate, risk verdict, ticket validator + file-assumption + DAG + budget gates, Story creation, terminal `agent::ready` flip, `plan-summary` comment. |
+| `plan-persist.js`                | Single GitHub-write surface for `/plan`: section gate, ticket validator + file-assumption + DAG + budget gates, Story creation, terminal `agent::ready` flip, `plan-summary` comment. |
 | `single-story-init.js`           | Validates a standalone Story, branches from `main`, creates the worktree, flips `agent::executing`. |
 | `stories-wave-tick.js`           | Ready-set planner for multi-Story `/deliver` (shared `selectReadySet` core; default concurrency 3). |
 | `single-story-close.js`          | Close-validation gate chain, opens PR to `main` with auto-merge armed, rests Story at `agent::closing`. |


### PR DESCRIPTION
## Why

An issue was raised that `.agents/workflows/plan.md` documents a `--risk-verdict` flag that `plan-persist.js` rejects with `ERR_PARSE_ARGS_UNKNOWN_OPTION`, making the documented command fail on the first try.

That turned out to be **already fixed**: 7a7fb50f (`refactor(plan)!: derive review depth from the diff and retire the authored risk verdict`, Story #4542) removed the flag from both persist command blocks and dropped `risk-verdict.json` from the step-2 artifact list. The report was filed against a checkout predating that commit, which landed the same day. The flag's rejection is now intentional — the commit carries a `BREAKING CHANGE` footer saying so.

The one thing #4542 missed is what this PR fixes: the script-responsibility table in `docs/architecture.md` still listed "risk verdict" among the gates `plan-persist.js` runs. Persist has no such gate. Review depth and the acceptance-critic fresh-vs-inline routing are derived at close time by `review-depth.js#deriveChangeLevel` against the `sensitivePaths` classes in `audit-rules.json`; gate #2 is raised solely by `--force-review`.

## Verification

- `7a7fb50f` confirmed an ancestor of HEAD; no `--risk-verdict` remains in any `plan.md` command block (the surviving line 150 mention is deliberate prose explaining the retirement).
- `risk-verdict.schema.json` and `planning/risk-verdict.js` are gone — nothing consumes a risk verdict at plan time.
- No test asserts on the edited string; `npm run lint` passes; pre-commit quality gate reports no MI or CRAP regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only edit to a single table cell; no runtime or workflow behavior changes.
> 
> **Overview**
> Aligns **architecture docs** with the Story #4542 behavior change: `plan-persist.js` is no longer described as running a **risk verdict** gate alongside section, ticket, file-assumption, DAG, and budget checks.
> 
> The **Key Scripts** table now states that persist handles section gate, ticket validator, file-assumption, DAG, and budget gates, Story creation, terminal `agent::ready`, and `plan-summary` only. Review depth and acceptance-critic routing stay **close-time** concerns (`review-depth.js#deriveChangeLevel`, `--force-review`), not plan-persist gates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2e0bb692d64da87cf9a8e9e138a4b246b4419a50. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->