### PR TITLE
fix(deliver): ground the plan-run audit roster's lens selection in the run's landed diff (#4571)

### DIFF
--- a/.agents/scripts/lib/audit-suite/selector.js
+++ b/.agents/scripts/lib/audit-suite/selector.js
@@ -308,6 +308,16 @@ export function matchesAnyFilePattern(patterns, files) {
  * @param {number} params.ticketId
  * @param {string} params.gate
  * @param {import('../ITicketingProvider.js').ITicketingProvider} params.provider
+ * @param {string[]} [params.changedFiles]
+ *   The change set to select over, when the caller already knows it. Supplying
+ *   it skips the internal `git diff` entirely and `baseBranch` / `headRef` are
+ *   then unused. Callers whose change set is NOT the working tree's
+ *   `baseBranch...headRef` MUST pass this: the plan-run epilogue runs from the
+ *   main checkout *after* its Stories have merged, where any `main...HEAD`
+ *   range is empty by construction and selection would silently degrade to
+ *   keyword-only matching (Story #4571). An empty array is honoured as
+ *   "the set is known, and it is empty" — distinct from omitting the option,
+ *   which means "derive it from git".
  * @param {string} [params.baseBranch]
  * @param {string} [params.headRef]
  *   Git ref whose diff-against-`baseBranch` defines the change set. Defaults
@@ -341,6 +351,7 @@ export async function selectAudits({
   ticketId,
   gate,
   provider,
+  changedFiles: injectedChangedFiles,
   baseBranch = 'main',
   headRef = 'HEAD',
   injectedGitSpawn,
@@ -370,6 +381,14 @@ export async function selectAudits({
 
   const runGit = injectedGitSpawn ?? (async (...args) => gitSpawn(...args));
 
+  // A caller that already knows the change set supplies it, and no git ref is
+  // consulted at all — `baseBranch` / `headRef` describe a diff that is not
+  // being taken. The plan-run epilogue is the motivating caller (Story #4571):
+  // it resolves the run's landed diff from the Stories' squash-merges, and any
+  // `main...HEAD` range it could name from the main checkout post-land is
+  // empty by construction.
+  const hasInjectedChangedFiles = Array.isArray(injectedChangedFiles);
+
   // Resolve `headRef` to a commit before diffing. A non-default `headRef`
   // (Epic-mode callers pass `refs/heads/epic/<id>`) that the repo can't
   // resolve means the requested Epic's branch is not present in this
@@ -378,7 +397,7 @@ export async function selectAudits({
   // degraded signal instead of leaking the wrong scope. `HEAD` is always
   // resolvable in a valid repo, so the default-path callers skip the probe
   // cost on the common case.
-  if (headRef !== 'HEAD') {
+  if (!hasInjectedChangedFiles && headRef !== 'HEAD') {
     let resolved;
     try {
       resolved = await withTimeout(
@@ -405,18 +424,22 @@ export async function selectAudits({
     }
   }
 
-  let changedFiles = [];
+  let changedFiles = hasInjectedChangedFiles
+    ? injectedChangedFiles.map((f) => String(f).trim()).filter(Boolean)
+    : [];
   try {
-    const diff = await withTimeout(
-      runGit(
-        process.cwd(),
-        'diff',
-        '--name-only',
-        `${baseBranch}...${headRef}`,
-      ),
-      timeoutMs,
-      { label: 'select-audits git diff' },
-    );
+    const diff = hasInjectedChangedFiles
+      ? null
+      : await withTimeout(
+          runGit(
+            process.cwd(),
+            'diff',
+            '--name-only',
+            `${baseBranch}...${headRef}`,
+          ),
+          timeoutMs,
+          { label: 'select-audits git diff' },
+        );
     if (diff?.status === 0) {
       changedFiles = diff.stdout
         .split('\n')
@@ -477,8 +500,10 @@ export async function selectAudits({
       changedFilesCount: changedFiles.length,
       // The ref the change set was actually diffed against. Epic-mode callers
       // assert this matches the requested Epic branch (Story #3362) so a
-      // mis-pinned diff never reaches the audit-lens selector silently.
-      resolvedRef: headRef,
+      // mis-pinned diff never reaches the audit-lens selector silently. `null`
+      // on the injected path: no ref was diffed, and naming one would invite
+      // exactly that assertion to pass against a diff nobody took.
+      resolvedRef: hasInjectedChangedFiles ? null : headRef,
       ticketTitle: ticket.title,
     },
   };

--- a/.agents/scripts/lib/orchestration/run-epilogue.js
+++ b/.agents/scripts/lib/orchestration/run-epilogue.js
@@ -369,6 +369,10 @@ function renderDiffLines(diff) {
       '> ⚠️ **Combined landed diff unavailable — this is NOT "zero files changed".**',
       `> The pre-run base sha could not be resolved: ${diff.reason}`,
       '> Walk the lenses below against the run diff determined by hand.',
+      '> Lens selection was **keyword-only**: with no change set, no lens',
+      '> `filePatterns` trigger could fire, so the roster below reflects the',
+      "> primary Story's prose rather than what the run touched. Treat it as a",
+      '> starting point, not a roster.',
     ];
   }
   return [
@@ -397,6 +401,7 @@ async function executeAuditRoster({
   provider,
   config,
   git,
+  selectAuditsFn,
 }) {
   const primaryId = Number(stories[0]);
   const diff = resolveCombinedDiff({
@@ -405,14 +410,19 @@ async function executeAuditRoster({
     baseRef: resolveBaseRef(config),
     git,
   });
+  // Hand `selectAudits` the change set we just resolved — never a git range for
+  // it to re-derive. This function runs in the main checkout *after* the run's
+  // Stories merged, so every range it could name (`main...HEAD`) is empty by
+  // construction; asking for one is how the roster came to select lenses from
+  // zero files while printing the correct file list beside them (Story #4571).
+  const lensGrounding = diff.resolved ? 'diff' : 'keyword-only';
   let selectedAudits = [];
   if (Number.isInteger(primaryId) && primaryId > 0) {
-    const selected = await selectAudits({
+    const selected = await selectAuditsFn({
       ticketId: primaryId,
       gate: 'gate3',
       provider,
-      baseBranch: 'main',
-      headRef: 'HEAD',
+      changedFiles: diff.resolved ? diff.changedFiles : [],
     });
     selectedAudits = Array.isArray(selected?.selectedAudits)
       ? selected.selectedAudits
@@ -432,7 +442,8 @@ async function executeAuditRoster({
     '',
     ...renderDiffLines(diff),
     '',
-    '**Selected lenses** (host MUST walk each against the combined landed diff):',
+    `**Selected lenses** (host MUST walk each against the combined landed diff) — ` +
+      `grounding: \`${lensGrounding}\`:`,
     ...(selectedAudits.length > 0
       ? selectedAudits.map((lens) => `- \`${lens}\``)
       : ['- _(none — docs-only or no matching change-set lenses)_']),
@@ -450,6 +461,7 @@ async function executeAuditRoster({
           reason: diff.reason,
         },
         changedFiles: diff.resolved ? diff.changedFiles : null,
+        lensGrounding,
         selectedAudits,
       },
       null,
@@ -468,6 +480,12 @@ async function executeAuditRoster({
   return {
     kind: 'audit-roster',
     selectedAudits,
+    // Whether the lenses above were chosen from the run's landed files
+    // (`diff`) or, with no resolvable base, from the primary Story's prose
+    // alone (`keyword-only`). The two are not interchangeable: a keyword-only
+    // roster cannot select a lens that declares no keywords, so its silence
+    // about a lens says nothing about the code.
+    lensGrounding,
     // `null` — not `0` — when unresolved: a zero count must only ever mean
     // "the run genuinely changed nothing".
     changedFileCount: diff.resolved ? diff.changedFiles.length : null,
@@ -640,6 +658,7 @@ async function executeSiblingCoherence({ planRunId, stories, provider }) {
  * @param {object} [args.config]
  * @param {string} [args.cwd]
  * @param {{ gitSpawn: Function }} [args.git] - Injection seam for tests.
+ * @param {typeof selectAudits} [args.selectAuditsFn] - Injection seam for tests.
  * @returns {Promise<object>}
  */
 export async function runPlanRunEpilogue({
@@ -649,6 +668,7 @@ export async function runPlanRunEpilogue({
   config,
   cwd = process.cwd(),
   git = { gitSpawn },
+  selectAuditsFn = selectAudits,
 } = {}) {
   const plan = planRunEpilogue({ planRunId, stories });
   if (!plan.applicable) {
@@ -671,6 +691,7 @@ export async function runPlanRunEpilogue({
             provider,
             config,
             git,
+            selectAuditsFn,
           }),
         );
       } else if (step.kind === 'follow-up-rollup') {

--- a/tests/audit-suite/selector-changedfiles.test.js
+++ b/tests/audit-suite/selector-changedfiles.test.js
@@ -166,3 +166,115 @@ test('selector: default headRef (HEAD) skips the rev-parse probe and diffs HEAD'
   assert.equal(diffCall[2], 'main...HEAD');
   assert.equal(result.context.resolvedRef, 'HEAD');
 });
+
+/**
+ * Story #4571 — the injected-`changedFiles` seam.
+ *
+ * `selectAudits` derived its own change set from `git diff baseBranch...headRef`
+ * in `process.cwd()`. The plan-run epilogue calls it from the main checkout
+ * *after* the run's Stories have merged, so that range is empty by
+ * construction — selection collapsed to keyword-matching the Story prose and
+ * every file-pattern trigger was silently dead. Callers that already know the
+ * change set pass it in; the internal diff is then not spawned at all.
+ */
+
+test('selector: injected changedFiles are used verbatim and no git diff is spawned', async () => {
+  const seen = [];
+  const fakeGitSpawn = async (_cwd, ...args) => {
+    seen.push(args);
+    return { status: 0, stdout: 'SHOULD-NOT-BE-READ.js\n', stderr: '' };
+  };
+
+  const result = await selectAudits({
+    ticketId: 500,
+    gate: 'gate1',
+    provider: makeProvider(),
+    changedFiles: ['src/auth/login.js', 'src/api/users.ts'],
+    injectedGitSpawn: fakeGitSpawn,
+  });
+
+  assert.equal(
+    seen.length,
+    0,
+    'an injected change set must short-circuit the git diff entirely',
+  );
+  assert.deepEqual(result.context.changedFiles, [
+    'src/auth/login.js',
+    'src/api/users.ts',
+  ]);
+  assert.equal(
+    result.context.changedFilesCount,
+    result.context.changedFiles.length,
+  );
+});
+
+test('selector: injected changedFiles drive file-pattern selection', async () => {
+  // `audit-clean-code` declares no keywords — it is reachable ONLY via its
+  // filePatterns. The provider's body is deliberately keyword-free, so a hit
+  // here proves selection ran over the injected files.
+  const result = await selectAudits({
+    ticketId: 500,
+    gate: 'gate3',
+    provider: makeProvider(),
+    changedFiles: ['.agents/scripts/lib/orchestration/run-epilogue.js'],
+    injectedGitSpawn: async () => {
+      throw new Error('git must not be spawned on the injected path');
+    },
+  });
+
+  assert.ok(
+    result.selectedAudits.includes('audit-clean-code'),
+    `a keyword-less, file-pattern-only lens must be reachable from an injected change set; got ${JSON.stringify(result.selectedAudits)}`,
+  );
+});
+
+test('selector: an injected EMPTY change set is honoured, not treated as absent', async () => {
+  const result = await selectAudits({
+    ticketId: 500,
+    gate: 'gate3',
+    provider: makeProvider(),
+    changedFiles: [],
+    injectedGitSpawn: async () => {
+      throw new Error('git must not be spawned on the injected path');
+    },
+  });
+
+  // `[]` is a caller saying "I know the set, and it is empty" — distinct from
+  // omitting the option, which means "derive it yourself".
+  assert.deepEqual(result.context.changedFiles, []);
+  assert.equal(result.context.changedFilesCount, 0);
+});
+
+test('selector: injected changedFiles report no resolvedRef — nothing was diffed', async () => {
+  const result = await selectAudits({
+    ticketId: 500,
+    gate: 'gate1',
+    provider: makeProvider(),
+    changedFiles: ['a.js'],
+  });
+
+  assert.equal(
+    result.context.resolvedRef,
+    null,
+    'resolvedRef names the ref the change set was diffed against; on the injected path there is none, and claiming HEAD would be a lie',
+  );
+});
+
+test('selector: omitting changedFiles still derives the set from git (unchanged)', async () => {
+  const seen = [];
+  const fakeGitSpawn = async (_cwd, ...args) => {
+    seen.push(args);
+    return { status: 0, stdout: 'derived.js\n', stderr: '' };
+  };
+
+  const result = await selectAudits({
+    ticketId: 500,
+    gate: 'gate1',
+    provider: makeProvider(),
+    injectedGitSpawn: fakeGitSpawn,
+  });
+
+  assert.ok(seen.some((a) => a[0] === 'diff'));
+  assert.deepEqual(result.context.changedFiles, ['derived.js']);
+  assert.equal(result.context.resolvedRef, 'HEAD');
+});

--- a/tests/lib/orchestration/run-epilogue.test.js
+++ b/tests/lib/orchestration/run-epilogue.test.js
@@ -287,3 +287,134 @@ describe('runPlanRunEpilogue — executor', () => {
     assert.ok(comments.some((c) => /plan-run-sibling-coherence/.test(c.body)));
   });
 });
+
+/**
+ * Story #4571 — the audit roster's LENS SELECTION must run over the run's
+ * landed diff.
+ *
+ * Story #4550 anchored the *reported* diff to the pre-run base, but the
+ * `selectAudits` call beside it still asked for `main...HEAD` — the very range
+ * that is empty by construction once the run's Stories have merged and the
+ * epilogue runs from the main checkout. The comment printed the right files
+ * while the lenses next to it were chosen from nothing: file-pattern triggers
+ * never fired, and keyword-less lenses were unreachable.
+ */
+describe('audit-roster — lens selection is grounded in the landed diff', () => {
+  function rosterProvider(comments) {
+    return {
+      getTicket: async (id) => ({
+        id,
+        title: `Story ${id}`,
+        body: '',
+        labels: ['type::story'],
+      }),
+      getTicketComments: async () => [],
+      postComment: async (ticketId, payload) => {
+        comments.push({ ticketId, body: payload.body });
+        return { commentId: comments.length };
+      },
+      deleteComment: async () => {},
+    };
+  }
+
+  /** A run whose two Stories landed as squash-merges on `origin/main`. */
+  function landedRunGit(changedFiles) {
+    return {
+      gitSpawn: (_cwd, ...args) => {
+        if (args[0] === 'log') {
+          const stdout = [
+            `ccc${US}bbb${US}fix: second (#2)`,
+            `bbb${US}aaa${US}feat: first (#1)`,
+            `aaa${US}${US}chore: pre-run base`,
+          ].join('\n');
+          return { status: 0, stdout, stderr: '' };
+        }
+        if (args[0] === 'diff') {
+          return {
+            status: 0,
+            stdout: `${changedFiles.join('\n')}\n`,
+            stderr: '',
+          };
+        }
+        return { status: 0, stdout: '', stderr: '' };
+      },
+    };
+  }
+
+  it('passes the resolved landed diff to selectAudits and reports lensGrounding: diff', async () => {
+    const comments = [];
+    const seen = [];
+    const result = await runPlanRunEpilogue({
+      planRunId: 'run-x',
+      stories: [1, 2],
+      provider: rosterProvider(comments),
+      git: landedRunGit(['src/scheduler/wave.js', 'src/scheduler/tick.js']),
+      selectAuditsFn: async (args) => {
+        seen.push(args);
+        return { selectedAudits: ['audit-clean-code'] };
+      },
+    });
+
+    const roster = result.results.find((r) => r.kind === 'audit-roster');
+    assert.deepEqual(
+      seen[0].changedFiles,
+      ['src/scheduler/wave.js', 'src/scheduler/tick.js'],
+      "the roster must select lenses over the run's landed files",
+    );
+    assert.equal(
+      seen[0].headRef,
+      undefined,
+      'the roster must not hand selectAudits a ref to diff — that range is empty by construction here',
+    );
+    assert.equal(seen[0].baseBranch, undefined);
+    assert.equal(roster.lensGrounding, 'diff');
+    assert.deepEqual(roster.selectedAudits, ['audit-clean-code']);
+  });
+
+  it('reports lensGrounding: keyword-only when the pre-run base is unresolved', async () => {
+    const comments = [];
+    const seen = [];
+    // No landed merge carries a `(#<storyId>)` marker → base unresolved.
+    const git = {
+      gitSpawn: (_cwd, ...args) => {
+        if (args[0] === 'log') {
+          return {
+            status: 0,
+            stdout: `zzz${US}yyy${US}chore: unrelated`,
+            stderr: '',
+          };
+        }
+        return { status: 0, stdout: '', stderr: '' };
+      },
+    };
+
+    const result = await runPlanRunEpilogue({
+      planRunId: 'run-y',
+      stories: [1, 2],
+      provider: rosterProvider(comments),
+      git,
+      selectAuditsFn: async (args) => {
+        seen.push(args);
+        return { selectedAudits: [] };
+      },
+    });
+
+    const roster = result.results.find((r) => r.kind === 'audit-roster');
+    assert.deepEqual(
+      seen[0].changedFiles,
+      [],
+      'an unresolved base must select over an explicitly empty set, never fall back to a git range',
+    );
+    assert.equal(
+      roster.lensGrounding,
+      'keyword-only',
+      'a roster whose lenses were NOT chosen from the diff must say so — silence is what made the original bug invisible',
+    );
+    assert.equal(roster.changedFileCount, null);
+
+    const body = comments.find((c) =>
+      c.body.includes('plan-run-audit-roster'),
+    ).body;
+    assert.match(body, /keyword-only/);
+  });
+});


### PR DESCRIPTION
Closes #4571

_Auto-opened by `/single-story-deliver`._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Orchestration and audit-selection behavior only; default `selectAudits` callers unchanged when `changedFiles` is omitted. Risk is mis-routed lenses if callers pass a wrong file list—mitigated by epilogue using the same `resolveCombinedDiff` output it already reports.
> 
> **Overview**
> Fixes a bug where the plan-run epilogue could **list the correct combined landed files** in the audit roster comment while **choosing lenses from an empty change set**—because `selectAudits` still ran `main...HEAD` on `main` after Stories had merged.
> 
> **`selectAudits`** now accepts optional **`changedFiles`**. When provided, it skips `git diff` and `headRef` resolution, uses that list for `filePatterns` matching, and sets **`context.resolvedRef` to `null`** (no ref was diffed). An injected **`[]`** means “known empty set,” not “derive from git.”
> 
> **`run-epilogue`** passes the already-resolved combined landed diff into `selectAudits` (or `[]` when the pre-run base cannot be resolved) and surfaces **`lensGrounding`** (`diff` vs `keyword-only`) in the roster comment, JSON payload, and step result. Unresolved-diff warnings now state that lens selection was keyword-only and that pattern-only lenses may be missing.
> 
> Tests cover the injection seam and epilogue wiring via **`selectAuditsFn`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0a5a37c20a9c8fe66b3d6e1dd0dab44eaa0e1edd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->