### PR TITLE
chore(orchestration): delete the seven production-dead exports the v2 cutover stranded (#4583)

### DIFF
--- a/.agents/scripts/lib/close-validation/telemetry.js
+++ b/.agents/scripts/lib/close-validation/telemetry.js
@@ -3,7 +3,8 @@
  */
 
 import { writeFile as defaultWriteFile } from 'node:fs/promises';
-import { storyArtifactPath } from '../config/temp-paths.js';
+import path from 'node:path';
+import { storyTempDir } from '../config/temp-paths.js';
 import { getSpawnCount as defaultGetSpawnCount } from '../gh-exec.js';
 
 /**
@@ -55,7 +56,10 @@ export async function emitGhSpawnCount({
     );
     return { status: 'failed', reason: 'counter-read-failed' };
   }
-  const targetPath = storyArtifactPath(eid, sid, 'gh-spawn-count.json', config);
+  const targetPath = path.join(
+    storyTempDir(eid, sid, config),
+    'gh-spawn-count.json',
+  );
   const payload = {
     kind: 'gh-spawn-count',
     epicId: eid,

--- a/.agents/scripts/lib/config/temp-paths.js
+++ b/.agents/scripts/lib/config/temp-paths.js
@@ -304,7 +304,7 @@ export function runArtifactPath(eid, name, config) {
  * @param {object} [config]
  * @returns {string}
  */
-export function storyArtifactPath(eid, sid, name, config) {
+function storyArtifactPath(eid, sid, name, config) {
   return path.join(storyTempDir(eid, sid, config), artifactName(name));
 }
 

--- a/.agents/scripts/lib/orchestration/detectors-phase.js
+++ b/.agents/scripts/lib/orchestration/detectors-phase.js
@@ -44,8 +44,9 @@
  * @module lib/orchestration/detectors-phase
  */
 
+import path from 'node:path';
 import { getSignals } from '../config/limits.js';
-import { storyArtifactPath } from '../config/temp-paths.js';
+import { storyTempDir } from '../config/temp-paths.js';
 import { Logger } from '../Logger.js';
 import { appendSignal } from '../observability/signals-writer.js';
 import { detectRetry, detectRework } from '../signals/detectors/index.js';
@@ -164,7 +165,7 @@ export async function detectorsPhase(ctx) {
     return { rework: 0, retry: 0 };
   }
 
-  const tracesPath = storyArtifactPath(eid, sid, 'traces.ndjson', config);
+  const tracesPath = path.join(storyTempDir(eid, sid, config), 'traces.ndjson');
   const taskId = resolveLastTaskId(tasks);
   const baseArgs = { tracesPath, epicId: eid, storyId: sid, taskId };
   const common = {

--- a/.agents/scripts/lib/orchestration/ticketing.js
+++ b/.agents/scripts/lib/orchestration/ticketing.js
@@ -26,7 +26,6 @@
 export {
   __resetParentCascadeLocks,
   __setCascadeRetryDelays,
-  cascadeCompletion,
   logCascadePartialFailures,
 } from './ticketing/bulk.js';
 // Re-export the read surface.

--- a/.agents/scripts/lib/orchestration/ticketing/bulk.js
+++ b/.agents/scripts/lib/orchestration/ticketing/bulk.js
@@ -357,7 +357,7 @@ async function processCascadeParentLocked(
  *   unset so the module-level {@link Logger} is used.
  * @returns {Promise<{ cascadedTo: number[], failed: Array<{ parentId: number, error: string }> }>}
  */
-export async function cascadeCompletion(provider, ticketId, opts = {}) {
+async function cascadeCompletion(provider, ticketId, opts = {}) {
   const ticket = await provider.getTicket(ticketId);
 
   // Determine if this ticket is agent::done

--- a/baselines/dead-exports-production.json
+++ b/baselines/dead-exports-production.json
@@ -926,10 +926,6 @@
     },
     {
       "file": ".agents/scripts/lib/config/temp-paths.js",
-      "symbol": "storyArtifactPath"
-    },
-    {
-      "file": ".agents/scripts/lib/config/temp-paths.js",
       "symbol": "storyManifestPath"
     },
     {
@@ -2034,10 +2030,6 @@
     },
     {
       "file": ".agents/scripts/lib/orchestration/ticketing.js",
-      "symbol": "cascadeCompletion"
-    },
-    {
-      "file": ".agents/scripts/lib/orchestration/ticketing.js",
       "symbol": "findStructuredComment"
     },
     {
@@ -2063,10 +2055,6 @@
     {
       "file": ".agents/scripts/lib/orchestration/ticketing/bulk.js",
       "symbol": "__setCascadeRetryDelays"
-    },
-    {
-      "file": ".agents/scripts/lib/orchestration/ticketing/bulk.js",
-      "symbol": "cascadeCompletion"
     },
     {
       "file": ".agents/scripts/lib/orchestration/ticketing/bulk.js",

--- a/tests/lib/config/temp-paths.test.js
+++ b/tests/lib/config/temp-paths.test.js
@@ -14,7 +14,6 @@ import {
   runArtifactPath,
   runTempDir,
   signalsFile,
-  storyArtifactPath,
   storyManifestPath,
   storyTempDir,
   tempRootFrom,
@@ -116,20 +115,16 @@ describe('lib/config/temp-paths.js — signals + canonical artifact paths', () =
 });
 
 describe('lib/config/temp-paths.js — artifact-name guards', () => {
-  it('runArtifactPath / storyArtifactPath accept a leaf name', () => {
+  it('runArtifactPath accepts a leaf name', () => {
     assert.equal(
       runArtifactPath(1030, 'custom.md'),
       anchored('temp', 'run-1030', 'custom.md'),
-    );
-    assert.equal(
-      storyArtifactPath(1030, 1042, 'custom.txt'),
-      anchored('temp', 'run-1030', 'stories', 'story-1042', 'custom.txt'),
     );
   });
 
   it('rejects an empty / non-string artifact name', () => {
     assert.throws(() => runArtifactPath(1030, ''), /non-empty string/);
-    assert.throws(() => storyArtifactPath(1, 2, undefined), /non-empty string/);
+    assert.throws(() => runArtifactPath(1030, undefined), /non-empty string/);
     assert.throws(() => runArtifactPath(1030, 42), /non-empty string/);
   });
 
@@ -143,7 +138,7 @@ describe('lib/config/temp-paths.js — artifact-name guards', () => {
       /must not contain path separators/,
     );
     assert.throws(
-      () => storyArtifactPath(1030, 1042, 'a\\b.md'),
+      () => runArtifactPath(1030, 'a\\b.md'),
       /must not contain path separators/,
     );
   });
@@ -234,8 +229,8 @@ describe('lib/config/temp-paths.js — standalone Story routing (Story #2874)', 
     );
   });
 
-  it('storyArtifactPath(null, sid, name) routes through the standalone parent', () => {
-    const file = storyArtifactPath(null, 7, 'manifest.md');
+  it('storyManifestPath(null, sid) routes through the standalone parent', () => {
+    const file = storyManifestPath(null, 7);
     assert.equal(
       file,
       anchored('temp', 'standalone', 'stories', 'story-7', 'manifest.md'),

--- a/tests/lib/orchestration/ticketing.cascade-parallel.test.js
+++ b/tests/lib/orchestration/ticketing.cascade-parallel.test.js
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
-import { cascadeCompletion } from '../../../.agents/scripts/lib/orchestration/ticketing.js';
+import { cascadeParentState } from '../../../.agents/scripts/lib/orchestration/ticketing/bulk.js';
 
 /**
  * Build a fake ITicketingProvider for cascade scenarios. The harness:
@@ -83,7 +83,7 @@ test('cascadeCompletion sequential dispatch (Story #4017)', async (t) => {
       parentLatencyMs: { 41: 60, 42: 60 },
     });
 
-    await cascadeCompletion(provider, 100);
+    await cascadeParentState(provider, 100);
 
     const u41 = provider.updateRecords.find((r) => r.id === 41);
     const u42 = provider.updateRecords.find((r) => r.id === 42);
@@ -143,7 +143,7 @@ test('cascadeCompletion sequential dispatch (Story #4017)', async (t) => {
         parentLatencyMs: { 41: 50, 42: 50 },
       });
 
-      await cascadeCompletion(provider, 100);
+      await cascadeParentState(provider, 100);
 
       const u41 = provider.updateRecords.find((r) => r.id === 41);
       const u42 = provider.updateRecords.find((r) => r.id === 42);
@@ -203,7 +203,7 @@ test('cascadeCompletion sequential dispatch (Story #4017)', async (t) => {
         },
       };
       const provider = makeProvider({ tickets, subTicketsMap });
-      await cascadeCompletion(provider, 3, { _logger: captureLogger });
+      await cascadeParentState(provider, 3, { _logger: captureLogger });
 
       assert.deepEqual(captured, []);
 
@@ -225,7 +225,7 @@ test('cascadeCompletion sequential dispatch (Story #4017)', async (t) => {
         },
       };
       const provider2 = makeProvider({ tickets, subTicketsMap });
-      await cascadeCompletion(provider2, 3, { _logger: captureLogger2 });
+      await cascadeParentState(provider2, 3, { _logger: captureLogger2 });
       assert.deepEqual(captured2, captured);
     },
   );

--- a/tests/lib/orchestration/ticketing.cascade-resilience.test.js
+++ b/tests/lib/orchestration/ticketing.cascade-resilience.test.js
@@ -1,9 +1,9 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
+import { cascadeParentState } from '../../../.agents/scripts/lib/orchestration/ticketing/bulk.js';
 import {
   __resetParentCascadeLocks,
   __setCascadeRetryDelays,
-  cascadeCompletion,
 } from '../../../.agents/scripts/lib/orchestration/ticketing.js';
 
 /**
@@ -112,7 +112,7 @@ test('cascadeCompletion resilience (Story #1817)', async (t) => {
         error: (m) => captured.push({ level: 'error', message: m }),
       };
 
-      const result = await cascadeCompletion(provider, 100, {
+      const result = await cascadeParentState(provider, 100, {
         _logger: captureLogger,
       });
 
@@ -172,7 +172,7 @@ test('cascadeCompletion resilience (Story #1817)', async (t) => {
         error: (m) => captured.push({ level: 'error', message: m }),
       };
 
-      const result = await cascadeCompletion(provider, 100, {
+      const result = await cascadeParentState(provider, 100, {
         _logger: captureLogger,
       });
 
@@ -234,8 +234,8 @@ test('cascadeCompletion resilience (Story #1817)', async (t) => {
       // should observe `agent::done` after the first finishes and
       // short-circuit (idempotency) rather than fire a second PATCH.
       const [r1, r2] = await Promise.all([
-        cascadeCompletion(provider, 100),
-        cascadeCompletion(provider, 101),
+        cascadeParentState(provider, 100),
+        cascadeParentState(provider, 101),
       ]);
 
       // Exactly one transition must have run end-to-end.
@@ -293,7 +293,7 @@ test('cascadeCompletion resilience (Story #1817)', async (t) => {
         },
       });
 
-      const result = await cascadeCompletion(provider, 100);
+      const result = await cascadeParentState(provider, 100);
       assert.equal(attempts, 3);
       assert.deepEqual(result.cascadedTo, [41]);
     },
@@ -328,7 +328,7 @@ test('cascadeCompletion resilience (Story #1817)', async (t) => {
           },
         },
       });
-      const result = await cascadeCompletion(provider, 100);
+      const result = await cascadeParentState(provider, 100);
       assert.equal(result.failed.length, 1);
       // Truncated to ~400 chars + ellipsis marker.
       assert.ok(
@@ -381,7 +381,7 @@ test('cascadeCompletion resilience (Story #1817)', async (t) => {
           throw new Error('cache invalidation hook explodes');
         },
       };
-      const result = await cascadeCompletion(provider, 100);
+      const result = await cascadeParentState(provider, 100);
       assert.deepEqual(result.cascadedTo, [41]);
       assert.deepEqual(result.failed, []);
     },
@@ -424,7 +424,7 @@ test('cascadeCompletion resilience (Story #1817)', async (t) => {
             },
           },
         });
-        const result = await cascadeCompletion(provider, 100);
+        const result = await cascadeParentState(provider, 100);
         assert.equal(attempts, 2);
         assert.deepEqual(result.cascadedTo, [41]);
       } finally {
@@ -461,7 +461,7 @@ test('cascadeCompletion resilience (Story #1817)', async (t) => {
         },
       });
 
-      const result = await cascadeCompletion(provider, 100);
+      const result = await cascadeParentState(provider, 100);
       assert.equal(transitions, 0, 'parent already done — no transition');
       assert.deepEqual(result.cascadedTo, []);
       assert.deepEqual(result.failed, []);

--- a/tests/lib/orchestration/ticketing/bulk.test.js
+++ b/tests/lib/orchestration/ticketing/bulk.test.js
@@ -11,7 +11,6 @@ import { ITicketingProvider } from '../../../../.agents/scripts/lib/ITicketingPr
 import {
   __resetParentCascadeLocks,
   __setCascadeRetryDelays,
-  cascadeCompletion,
   cascadeParentState,
   deriveParentState,
   logCascadePartialFailures,
@@ -81,7 +80,7 @@ class MockProvider extends ITicketingProvider {
   }
 }
 
-describe('ticketing/bulk — cascadeCompletion happy path', () => {
+describe('ticketing/bulk — cascadeParentState DONE delegation happy path', () => {
   let mock;
 
   beforeEach(() => {
@@ -90,15 +89,18 @@ describe('ticketing/bulk — cascadeCompletion happy path', () => {
     __setCascadeRetryDelays({ delays: [] });
   });
 
-  it('returns empty cascade when the ticket is not agent::done', async () => {
+  it('does not close the parent when the child is not agent::done', async () => {
+    // Drive through the public entry with a non-DONE trigger: the DONE
+    // delegation (which owns completion cascade) must not fire, so the
+    // parent is never flipped to agent::done.
     mock.tickets[2].labels = ['agent::executing'];
-    const result = await cascadeCompletion(mock, 2);
-    assert.deepEqual(result.cascadedTo, []);
+    const result = await cascadeParentState(mock, 2);
     assert.deepEqual(result.failed, []);
+    assert.equal(mock.tickets[1].labels.includes(STATE_LABELS.DONE), false);
   });
 
   it('cascades the parent to agent::done when its only child closes', async () => {
-    const result = await cascadeCompletion(mock, 2);
+    const result = await cascadeParentState(mock, 2);
     assert.deepEqual(result.cascadedTo, [1]);
     assert.deepEqual(result.failed, []);
     // Parent label flipped.
@@ -122,7 +124,7 @@ describe('ticketing/bulk — cascadeCompletion happy path', () => {
       state: 'open',
     };
     mock.subTickets[1] = [mock.tickets[2], mock.tickets[3]];
-    const result = await cascadeCompletion(mock, 2);
+    const result = await cascadeParentState(mock, 2);
     assert.deepEqual(result.cascadedTo, []);
     assert.equal(mock.tickets[1].labels.includes(STATE_LABELS.DONE), false);
   });

--- a/tests/lib/ticketing.test.js
+++ b/tests/lib/ticketing.test.js
@@ -1,9 +1,9 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 import { ITicketingProvider } from '../../.agents/scripts/lib/ITicketingProvider.js';
+import { cascadeParentState } from '../../.agents/scripts/lib/orchestration/ticketing/bulk.js';
 import {
   assertValidStructuredCommentType,
-  cascadeCompletion,
   isValidStructuredCommentType,
   postStructuredComment,
   STRUCTURED_COMMENT_TYPES,
@@ -359,7 +359,7 @@ test('ticketing.js', async (t) => {
         return Promise.resolve();
       };
 
-      await cascadeCompletion(mock, 3, { notify: fakeNotify });
+      await cascadeParentState(mock, 3, { notify: fakeNotify });
       await Promise.resolve();
 
       // #2 and #1 should both have been transitioned to agent::done via
@@ -534,7 +534,7 @@ test('ticketing.js', async (t) => {
         return origGetSub(id);
       };
 
-      const result = await cascadeCompletion(mock, 3);
+      const result = await cascadeParentState(mock, 3);
 
       assert.ok(
         result.cascadedTo.length > 0,
@@ -557,7 +557,7 @@ test('ticketing.js', async (t) => {
       mock.tickets[3].labels = ['agent::done'];
 
       // Should transition 2 to agent::done and then 1 to agent::done
-      await cascadeCompletion(mock, 3);
+      await cascadeParentState(mock, 3);
 
       // Checks on cascade effects:
       assert.ok(
@@ -615,7 +615,7 @@ test('ticketing.js', async (t) => {
       mock.subTickets[21] = [];
       mock.subTickets[22] = [];
 
-      const result = await cascadeCompletion(mock, 21);
+      const result = await cascadeParentState(mock, 21);
 
       assert.equal(
         result.cascadedTo.length,
@@ -725,7 +725,7 @@ test('ticketing.js', async (t) => {
         },
       };
 
-      const result = await cascadeCompletion(fakeProvider, 31);
+      const result = await cascadeParentState(fakeProvider, 31);
 
       assert.equal(
         result.cascadedTo.length,
@@ -863,7 +863,7 @@ test('ticketing.js', async (t) => {
         },
       };
 
-      await cascadeCompletion(fakeProvider, 50);
+      await cascadeParentState(fakeProvider, 50);
 
       // Sequential semantics: the entire #41 sub-flow (toggle → fresh-read →
       // parent get → updateTicket) must complete before #42 begins.
@@ -962,7 +962,7 @@ test('ticketing.js', async (t) => {
         },
       };
 
-      await cascadeCompletion(fakeProvider, trigger.id);
+      await cascadeParentState(fakeProvider, trigger.id);
 
       assert.ok(
         maxInFlight > 0,


### PR DESCRIPTION
Closes #4583

_Auto-opened by `/deliver`._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Export-only cleanup with no production callers of the removed symbols; cascade behavior is still covered via `cascadeParentState` in tests.
> 
> **Overview**
> Removes **production-dead public exports** left after the v2 cutover: `storyArtifactPath` and `cascadeCompletion` are no longer part of the external API.
> 
> **`storyArtifactPath`** is now module-private in `temp-paths.js`. Call sites that still need ad-hoc story files (`gh-spawn-count.json`, `traces.ndjson`) build paths with `storyTempDir` + `path.join` instead of importing the helper.
> 
> **`cascadeCompletion`** is no longer exported from `ticketing.js` or `bulk.js`; **`cascadeParentState`** remains the public entry and still delegates to the internal DONE-completion path. Cascade tests and ticketing tests were updated to import `cascadeParentState` from `bulk.js` and to exercise non-DONE vs DONE behavior through that API.
> 
> The **dead-exports production baseline** drops `storyArtifactPath` and `cascadeCompletion` rows; **temp-paths** tests no longer assert the removed export.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 264f56cb936cb4b72fc03d410b2d19669743904a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->