### PR TITLE
fix(bootstrap): honor command:false in the workflow/command parity check

### DIFF
--- a/.agents/scripts/lib/bootstrap/project-bootstrap.js
+++ b/.agents/scripts/lib/bootstrap/project-bootstrap.js
@@ -16,6 +16,7 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { pathToFileURL } from 'node:url';
+import { isCommandExcluded } from '../command-header.js';
 import { detectPackageManager as detectPm } from '../detect-package-manager.js';
 import { LEDGER_RELATIVE_PATH } from './install-ledger.js';
 import { ensureIssueForms } from './issue-forms-template.js';
@@ -512,6 +513,15 @@ export function runSyncCommands(ctx) {
  * this; this is a belt-and-braces verification that the command projection
  * covers every top-level workflow.
  *
+ * A workflow whose frontmatter carries `command: false` is deliberately NOT
+ * projected to a command — `sync-claude-commands.js` skips it via the same
+ * `isCommandExcluded` predicate used here. Such a workflow must therefore be
+ * excluded from the expected-command set, or this check would demand a
+ * command the sync is contracted never to emit (e.g. the `audit-lighthouse` /
+ * `audit-security` lenses, which are run by the audit suite, not as slash
+ * commands). Keeping the two surfaces on one predicate is what stops them
+ * drifting.
+ *
  * @param {object} ctx
  * @param {typeof fs} [ctx.fsImpl]
  */
@@ -530,7 +540,14 @@ export function checkParity(ctx) {
           .map((e) => e.name.replace(/\.md$/, ''))
           .sort()
       : [];
-  const workflows = new Set(list(workflowsDir));
+  // Expected commands = projectable workflows only. A `command: false`
+  // workflow is contracted out of the command tree, so it is not "missing" a
+  // command — it declined one.
+  const projectable = (name) =>
+    !isCommandExcluded(
+      fsImpl.readFileSync(path.join(workflowsDir, `${name}.md`), 'utf8'),
+    );
+  const workflows = new Set(list(workflowsDir).filter(projectable));
   const commands = new Set(list(commandsDir));
   const missingCommand = [...workflows].filter((n) => !commands.has(n));
   const orphanCommand = [...commands].filter((n) => !workflows.has(n));

--- a/tests/bootstrap/project-bootstrap.test.js
+++ b/tests/bootstrap/project-bootstrap.test.js
@@ -17,6 +17,7 @@ import { normalizeHandleAnswer } from '../../.agents/scripts/bootstrap.js';
 import { LEDGER_RELATIVE_PATH } from '../../.agents/scripts/lib/bootstrap/install-ledger.js';
 import {
   checkNodeVersion,
+  checkParity,
   detectPackageManager,
   ensureAgentrc,
   ensureGitignore,
@@ -331,5 +332,52 @@ describe('ensureAgentrc', () => {
       fs.readFileSync(path.join(tmpRoot, '.agentrc.json'), 'utf8'),
       before,
     );
+  });
+});
+
+describe('checkParity — command:false workflows', () => {
+  function seed({ commandFalse = true, withCommand = true } = {}) {
+    const wf = path.join(tmpRoot, '.agents', 'workflows');
+    const cmd = path.join(tmpRoot, '.claude', 'commands');
+    // A normal projectable workflow + its generated command.
+    writeFile(
+      path.join(wf, 'plan.md'),
+      '---\ndescription: Plan\n---\n# Plan\n',
+    );
+    writeFile(path.join(cmd, 'plan.md'), '# Plan\n');
+    // A lens workflow that declines a command via frontmatter.
+    writeFile(
+      path.join(wf, 'audit-lighthouse.md'),
+      `---\ndescription: Lighthouse lens\n${commandFalse ? 'command: false\n' : ''}---\n# Lighthouse\n`,
+    );
+    // Optionally give it a command too (the caller controls the failing case).
+    if (withCommand) {
+      writeFile(path.join(cmd, 'audit-lighthouse.md'), '# Lighthouse\n');
+    }
+  }
+
+  it('does not report a command:false workflow as missing a command', () => {
+    // The Install Matrix cold-start regression: audit-lighthouse /
+    // audit-security carry `command: false`, sync-claude-commands skips them,
+    // and the parity check must skip them too rather than demand a command
+    // the sync is contracted never to emit.
+    seed({ commandFalse: true, withCommand: false });
+    const result = checkParity({ projectRoot: tmpRoot });
+    assert.equal(
+      result.ok,
+      true,
+      'command:false workflow must not fail parity',
+    );
+    assert.deepEqual(result.missingCommand, []);
+    assert.deepEqual(result.orphanCommand, []);
+  });
+
+  it('still flags a projectable workflow that is genuinely missing its command', () => {
+    // Guard against over-correcting: a normal workflow with no command is a
+    // real drift the check must keep catching.
+    seed({ commandFalse: false, withCommand: false });
+    const result = checkParity({ projectRoot: tmpRoot });
+    assert.equal(result.ok, false);
+    assert.deepEqual(result.missingCommand, ['audit-lighthouse']);
   });
 });


### PR DESCRIPTION
## What / why

The nightly Install Matrix cold-start leg has failed every night since 2026-07-13:

```
Parity check failed — workflows missing commands: audit-lighthouse, audit-security
```

**Root cause:** `checkParity` (consumer bootstrap, `project-bootstrap.js`) demanded a `.claude/commands/` entry for *every* `.agents/workflows/` file. But `sync-claude-commands.js` deliberately skips workflows whose frontmatter carries `command: false` (via `isCommandExcluded`). #4486 (2026-07-12) marked the `audit-lighthouse` and `audit-security` lens workflows `command: false` — they're run by the audit suite, not as slash commands. The sync stopped emitting their commands; the parity check never learned the same exclusion, so a cold-start `mandrel init` fails.

**Why only the nightly caught it:** `checkParity` runs only inside `mandrel init`, and that cold-start leg is gated `if: schedule || workflow_dispatch` in `install-matrix.yml`. PR/push CI runs only the 2-leg required gate, so every PR stayed green while the nightly went red. First failing nightly (`2026-07-13`) is the first scheduled run after #4486 landed; not a regression from any recent PR.

## Fix

`checkParity` now filters the expected-command set through the **same** `isCommandExcluded` predicate the sync uses, so the two surfaces can't drift. A `command: false` workflow declines a command rather than "missing" one; a projectable workflow with no command is still flagged.

## Verification

- Reproduced the failure deterministically on `main` (`parity ok: false`); the fix returns `ok: true`.
- New regression tests in `tests/bootstrap/project-bootstrap.test.js`: a `command: false` workflow must not fail parity, and a projectable workflow genuinely missing its command still fails (guards against over-correcting).
- 217 bootstrap-suite tests pass; lint clean; dead-export ratchets `added=0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow bootstrap verification change with shared predicate already used by sync; tests lock behavior.
> 
> **Overview**
> Aligns bootstrap **workflow ↔ command parity** with `sync-claude-commands.js` so cold-start `mandrel init` no longer fails when lens workflows (e.g. `audit-lighthouse`, `audit-security`) opt out of slash commands via `command: false` in frontmatter.
> 
> `checkParity` now builds the expected command set from **projectable** workflows only, using the shared `isCommandExcluded` predicate instead of requiring a `.claude/commands/` file for every `.agents/workflows/*.md` entry. Workflows that genuinely should project still fail parity when their command is missing.
> 
> Regression tests cover both the excluded case and the “still flag real drift” guard.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4098407888ed304688b6e9755387bec1830e7580. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->