### PR TITLE
refactor: compute the Story change-set once and thread it through delivery (#4593)

### DIFF
--- a/.agents/agents/acceptance-critic.md
+++ b/.agents/agents/acceptance-critic.md
@@ -34,7 +34,15 @@ verdicts, their commit-message justifications-as-proof, or any prior verdict
 file they authored. You grade the **work product**, not the homework the maker
 turned in about it. Your only trusted inputs are:
 
-- the working **diff** (`git diff origin/<baseBranch>...HEAD`),
+- the **change set** your caller hands you: the list of files this Story
+  touched, computed **once** per delivery by the shared `computeChangeSet`
+  enumerator (`.agents/scripts/lib/orchestration/change-set.js`) and threaded
+  into your spawn context. Read those files and inspect their changes to see
+  the work product. Do **not** re-derive the set yourself — re-enumerating it
+  can pick up commits that landed after your caller routed the ceremony, and
+  then you would be scoring a different change than the one you were dispatched
+  for (Story #4593). If no change set reached you, say so in your verdict
+  rather than substituting your own enumeration.
 - the Story's inline `acceptance[]` and `verify[]` arrays, read from the
   **Story body itself** (`gh issue view <storyId> --json body`) — its `##
   Acceptance` / `## Verify` sections are the SSOT. The `story-init` structured
@@ -58,7 +66,8 @@ given.
 
 For each acceptance item in your cluster:
 
-1. **Inspect the diff** for the change that would satisfy the criterion.
+1. **Inspect the change set** — read the files your caller named and look for
+   the change that would satisfy the criterion.
 2. **Run the relevant `verify[]` commands** and consume their output as
    **required evidence**. A criterion cannot be scored `met` without the
    supporting `verify[]` evidence where a `verify[]` command is relevant to it.

--- a/.agents/scripts/lib/orchestration/change-set.js
+++ b/.agents/scripts/lib/orchestration/change-set.js
@@ -1,0 +1,103 @@
+/**
+ * lib/orchestration/change-set.js — the **one** Story change-set enumerator
+ * (Story #4593).
+ *
+ * ## Why this exists
+ *
+ * A single Story delivery used to enumerate `git diff --name-only
+ * <base>...<head>` three to four separate times: once for the ceremony
+ * derivation in `helpers/deliver-story`, once inside `runCodeReview` (to derive
+ * the review depth), once for the Story-scope local-lens roster, and once more
+ * per fresh acceptance critic. Every one of those consumers must agree about
+ * *what changed* — ceremony level and review depth both flow from
+ * `deriveChangeLevel`, so two enumerations straddling a commit could route the
+ * same Story two different ways. Computing the set once and injecting it closes
+ * that window and drops the redundant git calls.
+ *
+ * ## Contract
+ *
+ * {@link computeChangeSet} is **total**: it never throws. A diff it cannot
+ * enumerate (git failure, missing ref, spawn error) yields
+ * `{ files: null, enumerated: false }` — the neutral "diff unknown" signal that
+ * `deriveChangeLevel` / `resolveDepth` already fail safe on (`standard` depth, a
+ * `fresh` critic). `null` is deliberately distinct from `[]`: an empty array is
+ * the *fact* that nothing changed, whereas `null` is the *absence* of evidence,
+ * and only the latter must never buy a change less checking.
+ *
+ * The returned `files` are trimmed, de-duplicated, and sorted, so two consumers
+ * comparing the same change set compare byte-identical lists. The refs the set
+ * was computed against ride along on the envelope so a downstream consumer can
+ * report (or assert) its provenance rather than re-deriving it.
+ *
+ * @typedef {{
+ *   baseRef: string,
+ *   headRef: string,
+ *   files: string[]|null,
+ *   enumerated: boolean,
+ * }} ChangeSet
+ *
+ * @typedef {typeof gitSpawn} GitSpawnFn
+ */
+
+import { gitSpawn } from '../git-utils.js';
+
+/**
+ * Trim, drop empties, de-duplicate, and sort raw `git diff --name-only` output.
+ * Pure.
+ *
+ * @param {string} stdout
+ * @returns {string[]}
+ */
+function normalizeFileList(stdout) {
+  const seen = new Set();
+  for (const line of stdout.split('\n')) {
+    const file = line.trim();
+    if (file.length > 0) seen.add(file);
+  }
+  return [...seen].sort();
+}
+
+/**
+ * Compute the change set for the `baseRef...headRef` diff **once**, for every
+ * consumer that needs to know what a Story touched.
+ *
+ * Total — never throws; see the module header for the `null` vs `[]` contract.
+ *
+ * @param {{
+ *   baseRef: string,
+ *   headRef: string,
+ *   cwd?: string,
+ *   gitSpawnFn?: typeof gitSpawn,
+ * }} args
+ * @returns {ChangeSet}
+ */
+export function computeChangeSet({
+  baseRef,
+  headRef,
+  cwd = process.cwd(),
+  gitSpawnFn = gitSpawn,
+} = {}) {
+  const unknown = { baseRef, headRef, files: null, enumerated: false };
+  if (typeof baseRef !== 'string' || baseRef.length === 0) return unknown;
+  if (typeof headRef !== 'string' || headRef.length === 0) return unknown;
+
+  try {
+    const result = gitSpawnFn(
+      cwd,
+      'diff',
+      '--name-only',
+      `${baseRef}...${headRef}`,
+    );
+    if (!result || result.status !== 0 || typeof result.stdout !== 'string') {
+      return unknown;
+    }
+    return {
+      baseRef,
+      headRef,
+      files: normalizeFileList(result.stdout),
+      enumerated: true,
+    };
+  } catch {
+    return unknown;
+  }
+}

--- a/.agents/scripts/lib/orchestration/code-review.js
+++ b/.agents/scripts/lib/orchestration/code-review.js
@@ -41,7 +41,7 @@
 
 import { hasSurvivingCritical } from '../audit-suite/findings.js';
 import { resolveConfig } from '../config-resolver.js';
-import { gitSpawn } from '../git-utils.js';
+import { computeChangeSet } from './change-set.js';
 import { deriveChangeLevel, resolveDepth } from './review-depth.js';
 import {
   countBySeverity,
@@ -64,36 +64,6 @@ import { upsertStructuredComment } from './ticketing.js';
  *
  * @typedef {import('./review-depth.js').ReviewDepth} ReviewDepth
  */
-
-/**
- * Enumerate the files changed in the `baseRef...headRef` diff via
- * `git diff --name-only`. Returns the file list, or `null` when the diff
- * cannot be enumerated (git failure, missing ref). A `null` list is the neutral
- * "diff unknown" signal both {@link deriveChangeLevel} and {@link resolveDepth}
- * tolerate by failing safe to `standard`. Best-effort — never throws.
- *
- * @param {{ baseRef: string, headRef: string, gitSpawnFn?: typeof gitSpawn }} args
- * @returns {string[]|null}
- */
-function listChangedFiles({ baseRef, headRef, gitSpawnFn = gitSpawn }) {
-  try {
-    const result = gitSpawnFn(
-      process.cwd(),
-      'diff',
-      `${baseRef}...${headRef}`,
-      '--name-only',
-    );
-    if (!result || result.status !== 0 || typeof result.stdout !== 'string') {
-      return null;
-    }
-    return result.stdout
-      .split('\n')
-      .map((line) => line.trim())
-      .filter((line) => line.length > 0);
-  } catch {
-    return null;
-  }
-}
 
 /**
  * Resolve the project base branch fallback used when a caller omits
@@ -192,7 +162,7 @@ function resolveScopeEnvelope(opts, config) {
  *   changedFileCount?: number|null,
  *   storyId?: number|null,
  *   reviewProvider?: { runReview: Function },
- *   gitSpawnFn?: typeof gitSpawn,
+ *   gitSpawnFn?: import('./change-set.js').GitSpawnFn,
  *   resolveConfigFn?: typeof resolveConfig,
  *   createReviewProviderFn?: typeof createReviewProvider,
  *   upsertCommentFn?: typeof upsertStructuredComment,
@@ -230,6 +200,27 @@ function resolveProviderName(codeReviewConfig) {
 }
 
 /**
+ * Resolve the change set the depth derivation reads (Story #4593).
+ *
+ * `opts.changedFiles` is an injection with three distinct states,
+ * and the difference is load-bearing: an **array** is the change set to use
+ * verbatim; an explicit **null** is a caller (`runStoryReviewCore`) reporting
+ * that it already tried and the diff is unenumerable — re-running git here would
+ * only fail again, so it degrades straight to the fail-safe tier; **absent**
+ * means no caller enumerated at all, so the shared {@link computeChangeSet}
+ * enumerator runs as the fallback (standalone CLI use). On the close path the
+ * spine always injects, so the diff is enumerated exactly once per delivery and
+ * this pillar can never disagree with the lens pass about what changed.
+ */
+function resolveInjectedChangedFiles({ opts, baseRef, headRef }) {
+  if (opts.changedFiles === undefined) {
+    return computeChangeSet({ baseRef, headRef, gitSpawnFn: opts.gitSpawnFn })
+      .files;
+  }
+  return Array.isArray(opts.changedFiles) ? opts.changedFiles : null;
+}
+
+/**
  * Build the provider `runReview` input, resolving the review depth from the
  * diff under review: its changed files derive the change level (sensitive path
  * touched or not — Story #4542) and their count supplies the width. The depth
@@ -238,9 +229,7 @@ function resolveProviderName(codeReviewConfig) {
  * Story #4075 — extracted from `runCodeReview`.
  */
 function buildReviewInput({ opts, scope, ticketId, baseRef, headRef }) {
-  const changedFiles = Array.isArray(opts.changedFiles)
-    ? opts.changedFiles
-    : listChangedFiles({ baseRef, headRef, gitSpawnFn: opts.gitSpawnFn });
+  const changedFiles = resolveInjectedChangedFiles({ opts, baseRef, headRef });
   const changedFileCount =
     typeof opts.changedFileCount === 'number'
       ? opts.changedFileCount

--- a/.agents/scripts/lib/orchestration/story-close/phases/code-review.js
+++ b/.agents/scripts/lib/orchestration/story-close/phases/code-review.js
@@ -40,6 +40,7 @@ import {
 } from '../../../audit-suite/index.js';
 import { gitSpawn } from '../../../git-utils.js';
 import { Logger } from '../../../Logger.js';
+import { computeChangeSet } from '../../change-set.js';
 import { runCodeReview } from '../../code-review.js';
 import { emitBlockedCloseResult } from '../emit-blocked.js';
 
@@ -53,14 +54,22 @@ import { emitBlockedCloseResult } from '../emit-blocked.js';
 export const STORY_SCOPE_LENS_DEPTH = 'light';
 
 /**
- * Enumerate the files changed in the `baseRef...headRef` diff via
- * `git diff --name-only`. Best-effort: returns `[]` when the diff cannot be
- * enumerated (git failure, missing ref) and never throws, mirroring the
- * advisory posture of the surrounding review phase. Synchronous `gitSpawn`
- * (returns `{ status, stdout }`) is the same seam `code-review.js#countChangedFiles`
- * uses.
+ * Enumerate the files changed in the `baseRef...headRef` diff. Thin adapter over
+ * the shared {@link computeChangeSet} enumerator (Story #4593) that flattens its
+ * `files: string[]|null` envelope to this phase's historical `[]`-on-failure
+ * contract: the lens roster treats "nothing changed" and "diff unknown"
+ * identically, because an unknown diff matches no `filePatterns` and therefore
+ * adds no lens work either way.
  *
- * @param {{ baseRef: string, headRef: string, gitSpawnFn?: typeof gitSpawn }} args
+ * Best-effort and total — never throws, mirroring the advisory posture of the
+ * surrounding review phase. Retained as the self-enumeration fallback for
+ * {@link runLocalLensReview} when no change set is injected.
+ *
+ * @param {{
+ *   baseRef: string,
+ *   headRef: string,
+ *   gitSpawnFn?: import('../../change-set.js').GitSpawnFn,
+ * }} args
  * @returns {string[]} Changed file paths, or `[]` on any failure.
  */
 export function enumerateChangedFiles({
@@ -68,23 +77,7 @@ export function enumerateChangedFiles({
   headRef,
   gitSpawnFn = gitSpawn,
 }) {
-  try {
-    const result = gitSpawnFn(
-      process.cwd(),
-      'diff',
-      '--name-only',
-      `${baseRef}...${headRef}`,
-    );
-    if (!result || result.status !== 0 || typeof result.stdout !== 'string') {
-      return [];
-    }
-    return result.stdout
-      .split('\n')
-      .map((f) => f.trim())
-      .filter(Boolean);
-  } catch {
-    return [];
-  }
+  return computeChangeSet({ baseRef, headRef, gitSpawnFn }).files ?? [];
 }
 
 /**
@@ -101,12 +94,18 @@ export function enumerateChangedFiles({
  * logged via `progress`, matching the advisory posture the review phase already
  * takes for provider/transport failures.
  *
+ * Story #4593 — `changedFiles` is injected by {@link runStoryReviewCore}, which
+ * computes the change set once per close run and hands the same list to this
+ * pass and to `runCodeReview`. Self-enumeration is the **fallback only**, kept
+ * for standalone callers that supply no list.
+ *
  * @param {{
  *   baseRef: string,
  *   headRef: string,
+ *   changedFiles?: string[]|null,
  *   progress: (tag: string, msg: string) => void,
  *   progressTag?: string,
- *   gitSpawnFn?: typeof gitSpawn,
+ *   gitSpawnFn?: import('../../change-set.js').GitSpawnFn,
  *   selectLocalLensesFn?: typeof selectLocalLenses,
  *   runAuditSuiteFn?: typeof runAuditSuite,
  * }} args
@@ -120,6 +119,7 @@ export function enumerateChangedFiles({
 export async function runLocalLensReview({
   baseRef,
   headRef,
+  changedFiles: injectedChangedFiles,
   progress,
   progressTag = 'CODE-REVIEW',
   gitSpawnFn = gitSpawn,
@@ -134,11 +134,9 @@ export async function runLocalLensReview({
   };
   let lenses;
   try {
-    const changedFiles = enumerateChangedFiles({
-      baseRef,
-      headRef,
-      gitSpawnFn,
-    });
+    const changedFiles = Array.isArray(injectedChangedFiles)
+      ? injectedChangedFiles
+      : enumerateChangedFiles({ baseRef, headRef, gitSpawnFn });
     lenses = selectLocalLensesFn({ changedFiles });
     if (lenses.length === 0) {
       progress(
@@ -205,12 +203,20 @@ function buildCodeReviewBlockedExtra({ storyId, reviewResult }) {
  *     `refresh.js`).
  *   - Standalone close: propagates throws (a review failure stops the close).
  *
- * Review depth is not passed in: `runCodeReview` derives it entirely from the
- * `baseRef...headRef` diff it enumerates itself — the changed files' sensitive-
- * path intersection plus their count (Story #4542, which retired the
- * planner-authored risk envelope this spine used to forward). Depth remains an
- * **input-only** signal: it tells the provider how thorough to be and never
- * alters the review's output envelope or the posted structured-comment body.
+ * Review depth is not passed in: `runCodeReview` derives it from the changed
+ * files — their sensitive-path intersection plus their count (Story #4542, which
+ * retired the planner-authored risk envelope this spine used to forward). Depth
+ * remains an **input-only** signal: it tells the provider how thorough to be and
+ * never alters the review's output envelope or the posted structured-comment
+ * body.
+ *
+ * Story #4593 — this spine is the **single injection point** for the change set.
+ * It enumerates `baseRef...headRef` exactly once via {@link computeChangeSet}
+ * and threads the resulting list into both the local-lens pass and
+ * `runCodeReview`, which otherwise each enumerated the diff for themselves. Both
+ * consumers ultimately route through `deriveChangeLevel`, so feeding them one
+ * list is what makes the lens roster and the review depth provably agree about
+ * what changed — even when a commit lands between the two calls.
  *
  * @param {{
  *   storyId: number|string,
@@ -220,14 +226,17 @@ function buildCodeReviewBlockedExtra({ storyId, reviewResult }) {
  *   provider: object,
  *   progress: (tag: string, msg: string) => void,
  *   progressTag?: string,
+ *   gitSpawnFn?: import('../../change-set.js').GitSpawnFn,
+ *   computeChangeSetFn?: typeof computeChangeSet,
  *   runCodeReviewFn?: typeof runCodeReview,
  *   runLocalLensReviewFn?: typeof runLocalLensReview,
  * }} args
  * @returns {Promise<object>} Raw result envelope from `runCodeReview`, augmented
  *   with a `localLensReview` field carrying the Story-scope local-lens pass
- *   outcome (Epic #4405, Story #4409). Both close entry points reach the lens
- *   pass through this single spine, so it runs on the Epic-attached and
- *   standalone paths alike and always inside the close subprocess.
+ *   outcome (Epic #4405, Story #4409) and the `changeSet` this run computed
+ *   (Story #4593). Both close entry points reach the lens pass through this
+ *   single spine, so it runs on the Epic-attached and standalone paths alike and
+ *   always inside the close subprocess.
  */
 export async function runStoryReviewCore({
   storyId,
@@ -237,16 +246,25 @@ export async function runStoryReviewCore({
   provider,
   progress,
   progressTag = 'CODE-REVIEW',
+  gitSpawnFn = gitSpawn,
+  computeChangeSetFn = computeChangeSet,
   runCodeReviewFn = runCodeReview,
   runLocalLensReviewFn = runLocalLensReview,
 }) {
   const storyIdNum = Number(storyId);
+
+  // The one enumeration per close run. Every consumer below is injected from
+  // this list; none of them re-derives the diff.
+  const changeSet = computeChangeSetFn({ baseRef, headRef, gitSpawnFn });
+
   const opts = {
     scope: 'story',
     ticketId: storyIdNum,
     baseRef,
     headRef,
     provider,
+    changedFiles: changeSet.files,
+    gitSpawnFn,
     logger: {
       info: (m) => progress(progressTag, m),
       warn: (m) => progress(progressTag, `⚠️ ${m}`),
@@ -264,12 +282,14 @@ export async function runStoryReviewCore({
   const localLensReview = await runLocalLensReviewFn({
     baseRef,
     headRef,
+    changedFiles: changeSet.files,
     progress,
     progressTag,
+    gitSpawnFn,
   });
 
   const result = await runCodeReviewFn(opts);
-  return { ...result, localLensReview };
+  return { ...result, localLensReview, changeSet };
 }
 
 /**

--- a/.agents/workflows/helpers/acceptance-self-eval.md
+++ b/.agents/workflows/helpers/acceptance-self-eval.md
@@ -46,7 +46,10 @@ mid-delivery, and evaluates the actual work product.
    > — the same signal `review-depth.js` resolves depth from, so the two
    > decisions cannot disagree. Derive it with `deriveChangeLevel` from
    > [`review-depth.js`](../../scripts/lib/orchestration/review-depth.js) over
-   > the Story's changed files (`git diff --name-only main...story-<id>`), then
+   > the **change set your caller computed once** for this Story (Story #4593 —
+   > `computeChangeSet` from
+   > [`change-set.js`](../../scripts/lib/orchestration/change-set.js); see
+   > [`deliver-story.md`](deliver-story.md) Step 2), then
    > resolve the ceremony per cluster with `resolveCeremonyForRisk` from
    > [`ceremony-routing.js`](../../scripts/lib/orchestration/ceremony-routing.js)
    > using that `derivedLevel` and `delivery.routing.freshCriticSampleRate`:
@@ -87,8 +90,12 @@ mid-delivery, and evaluates the actual work product.
    > comment (if you block) that the inline fallback was used.
 
    The critic:
-   - Inspects the working diff (`git diff origin/<baseBranch>...HEAD`) and the
-     Story's inline `acceptance[]` / `verify[]` arrays.
+   - Inspects the **change set handed to it in its spawn context** — the one
+     list computed above — and the Story's inline `acceptance[]` / `verify[]`
+     arrays. Pass the file list explicitly when you dispatch the critic; it
+     does not re-enumerate the diff for itself (Story #4593), so a commit
+     landing mid-ceremony cannot leave the critic scoring a different change
+     than the one that routed it.
    - **Runs the `verify[]` commands** and consumes their output as **required
      evidence** when scoring the relevant acceptance items. `verify[]` is not
      optional advisory pre-flight — a criterion cannot be scored `met` without

--- a/.agents/workflows/helpers/deliver-story.md
+++ b/.agents/workflows/helpers/deliver-story.md
@@ -205,12 +205,28 @@ Story-path specifics:
 Per-Story ceremony is selected by `delivery.routing.ceremonyProfile`
 (`minimal` | `standard` | `strict`, default `standard`) and the Story's
 **derived change level** — not a planner-authored verdict (Story #4542 retired
-that). Derive the level with
-[`deriveChangeLevel`](../../scripts/lib/orchestration/review-depth.js) over the
-Story's changed files (`git diff --name-only main...story-<id>`): a diff
-touching a sensitive path registered in `.agents/schemas/audit-rules.json`
-derives `high`, one touching none derives `low`, and an unenumerable diff
-derives `null`.
+that).
+
+**Compute the change set once** (Story #4593) with the shared enumerator
+[`computeChangeSet`](../../scripts/lib/orchestration/change-set.js) — the same
+module close uses — and reuse that one list for everything downstream:
+
+```bash
+node --input-type=module -e '
+  import { computeChangeSet } from "<main-repo>/.agents/scripts/lib/orchestration/change-set.js";
+  const { files } = computeChangeSet({ baseRef: "main", headRef: "story-<storyId>" });
+  console.log(JSON.stringify(files));
+'
+```
+
+Then derive the level with
+[`deriveChangeLevel`](../../scripts/lib/orchestration/review-depth.js) over that
+list: a diff touching a sensitive path registered in
+`.agents/schemas/audit-rules.json` derives `high`, one touching none derives
+`low`, and an unenumerable diff (`files === null`) derives `null`. Hand the
+**same** list to every acceptance critic you spawn (Step 1a) — a critic that
+re-ran its own `git diff` could score against a different set than the one that
+routed it.
 
 Resolve fresh-vs-inline acceptance critics per AC-cluster with
 [`resolveCeremonyForRisk`](../../scripts/lib/orchestration/ceremony-routing.js)

--- a/tests/audit-suite/story-scope-lens-review.test.js
+++ b/tests/audit-suite/story-scope-lens-review.test.js
@@ -266,6 +266,147 @@ function cleanReviewStub() {
   });
 }
 
+// ---------------------------------------------------------------------------
+// The change set is computed ONCE per close run and injected (Story #4593).
+// ---------------------------------------------------------------------------
+
+test('runStoryReviewCore enumerates the diff exactly once and injects it into both consumers', async () => {
+  // One gitSpawn spy threaded into every seam that could enumerate: the spine's
+  // own computeChangeSet, the lens pass, and runCodeReview. If either consumer
+  // ever re-derived the diff for itself, this count would climb.
+  const diffCalls = [];
+  const gitSpawnFn = (cwd, ...args) => {
+    if (args[0] === 'diff') diffCalls.push(args);
+    return { status: 0, stdout: 'b.js\n.agents/scripts/a.js\n', stderr: '' };
+  };
+
+  const lensCalls = [];
+  const reviewCalls = [];
+  const result = await runStoryReviewCore({
+    storyId: 4593,
+    baseRef: 'main',
+    headRef: 'story-4593',
+    provider: {},
+    progress: noopProgress,
+    gitSpawnFn,
+    runLocalLensReviewFn: async (args) => {
+      lensCalls.push(args);
+      return { depth: 'light', lenses: [], skipped: true, materialized: null };
+    },
+    runCodeReviewFn: async (opts) => {
+      reviewCalls.push(opts);
+      return {
+        status: 'ok',
+        severity: { critical: 0, high: 0, medium: 0, suggestion: 0 },
+        posted: false,
+        postedCommentId: null,
+        halted: false,
+        blockerReason: null,
+      };
+    },
+  });
+
+  assert.equal(
+    diffCalls.length,
+    1,
+    `the diff must be enumerated exactly once per close run, got ${diffCalls.length}`,
+  );
+  assert.deepEqual(diffCalls[0], ['diff', '--name-only', 'main...story-4593']);
+
+  // Both consumers received the SAME (sorted, de-duplicated) list.
+  const expected = ['.agents/scripts/a.js', 'b.js'];
+  assert.deepEqual(lensCalls[0].changedFiles, expected);
+  assert.deepEqual(reviewCalls[0].changedFiles, expected);
+  assert.deepEqual(result.changeSet.files, expected);
+  assert.equal(result.changeSet.baseRef, 'main');
+  assert.equal(result.changeSet.headRef, 'story-4593');
+});
+
+test('runStoryReviewCore injects an explicit null when the diff is unenumerable', async () => {
+  // The fail-safe signal must reach both consumers as "unknown", not as a
+  // deceptively-empty list, and must not trigger a retry enumeration.
+  const diffCalls = [];
+  const lensCalls = [];
+  const reviewCalls = [];
+  await runStoryReviewCore({
+    storyId: 4593,
+    baseRef: 'main',
+    headRef: 'story-4593',
+    provider: {},
+    progress: noopProgress,
+    gitSpawnFn: (_cwd, ...args) => {
+      if (args[0] === 'diff') diffCalls.push(args);
+      return { status: 128, stdout: '', stderr: 'bad ref' };
+    },
+    runLocalLensReviewFn: async (args) => {
+      lensCalls.push(args);
+      return { depth: 'light', lenses: [], skipped: true, materialized: null };
+    },
+    runCodeReviewFn: async (opts) => {
+      reviewCalls.push(opts);
+      return {
+        status: 'ok',
+        severity: { critical: 0, high: 0, medium: 0, suggestion: 0 },
+        posted: false,
+        postedCommentId: null,
+        halted: false,
+        blockerReason: null,
+      };
+    },
+  });
+  assert.equal(diffCalls.length, 1);
+  assert.equal(lensCalls[0].changedFiles, null);
+  assert.equal(reviewCalls[0].changedFiles, null);
+});
+
+test('runLocalLensReview selects from the injected change set without enumerating', async () => {
+  let enumerated = false;
+  const selectCalls = [];
+  const out = await runLocalLensReview({
+    baseRef: 'main',
+    headRef: 'story-4593',
+    changedFiles: ['.agents/scripts/injected.js'],
+    progress: noopProgress,
+    gitSpawnFn: () => {
+      enumerated = true;
+      return { status: 0, stdout: 'some/other/file.js', stderr: '' };
+    },
+    selectLocalLensesFn: (args) => {
+      selectCalls.push(args);
+      return ['audit-performance'];
+    },
+    runAuditSuiteFn: spy({ metadata: {}, findings: [], workflows: [] }),
+  });
+  assert.equal(enumerated, false, 'an injected list must short-circuit git');
+  assert.deepEqual(selectCalls[0].changedFiles, [
+    '.agents/scripts/injected.js',
+  ]);
+  assert.deepEqual(out.lenses, ['audit-performance']);
+});
+
+test('runLocalLensReview falls back to self-enumeration only when no list is injected', async () => {
+  let enumerated = false;
+  const selectCalls = [];
+  await runLocalLensReview({
+    baseRef: 'main',
+    headRef: 'story-4593',
+    progress: noopProgress,
+    gitSpawnFn: () => {
+      enumerated = true;
+      return { status: 0, stdout: '.agents/scripts/enumerated.js', stderr: '' };
+    },
+    selectLocalLensesFn: (args) => {
+      selectCalls.push(args);
+      return [];
+    },
+    runAuditSuiteFn: spy({ metadata: {}, findings: [], workflows: [] }),
+  });
+  assert.equal(enumerated, true, 'no injected list → the CLI fallback runs');
+  assert.deepEqual(selectCalls[0].changedFiles, [
+    '.agents/scripts/enumerated.js',
+  ]);
+});
+
 test('runStoryReviewCore invokes the lens pass and attaches localLensReview', async () => {
   const lensReview = {
     depth: 'light',

--- a/tests/change-set.test.js
+++ b/tests/change-set.test.js
@@ -1,0 +1,161 @@
+/**
+ * tests/change-set.test.js — Story #4593.
+ *
+ * `change-set.js` is the one Story change-set enumerator every delivery
+ * consumer injects from. Its whole value is that two consumers handed the same
+ * envelope compare identical lists, so these tests pin the normalization
+ * (trimmed / de-duplicated / sorted), the ref provenance that rides along, and
+ * the `null` vs `[]` distinction that keeps an unenumerable diff from ever
+ * looking like a safe empty one.
+ *
+ * Unit tier: no real git — the `gitSpawn` seam is injected throughout.
+ */
+
+import assert from 'node:assert/strict';
+import test, { describe } from 'node:test';
+
+import { computeChangeSet } from '../.agents/scripts/lib/orchestration/change-set.js';
+
+/** A `gitSpawn` stub returning `stdout` for a successful diff. */
+function gitOk(stdout) {
+  return () => ({ status: 0, stdout, stderr: '' });
+}
+
+const REFS = { baseRef: 'main', headRef: 'story-4593' };
+
+describe('computeChangeSet — normalization', () => {
+  test('parses git diff --name-only output into a file list', () => {
+    const { files } = computeChangeSet({
+      ...REFS,
+      gitSpawnFn: gitOk('a.js\nb.js\n'),
+    });
+    assert.deepEqual(files, ['a.js', 'b.js']);
+  });
+
+  test('trims whitespace and drops blank lines', () => {
+    const { files } = computeChangeSet({
+      ...REFS,
+      gitSpawnFn: gitOk('  a.js  \n\n\t b.js\n   \n'),
+    });
+    assert.deepEqual(files, ['a.js', 'b.js']);
+  });
+
+  test('de-duplicates repeated paths', () => {
+    const { files } = computeChangeSet({
+      ...REFS,
+      gitSpawnFn: gitOk('a.js\nb.js\na.js\n a.js \n'),
+    });
+    assert.deepEqual(files, ['a.js', 'b.js']);
+  });
+
+  test('sorts the output so two consumers compare identical lists', () => {
+    const { files } = computeChangeSet({
+      ...REFS,
+      gitSpawnFn: gitOk('z.js\nm/b.js\na.js\n'),
+    });
+    assert.deepEqual(files, ['a.js', 'm/b.js', 'z.js']);
+  });
+
+  test('a genuinely empty diff is [] — the fact that nothing changed', () => {
+    const set = computeChangeSet({ ...REFS, gitSpawnFn: gitOk('') });
+    assert.deepEqual(set.files, []);
+    assert.equal(set.enumerated, true);
+  });
+});
+
+describe('computeChangeSet — ref reporting', () => {
+  test('reports the refs the set was computed against', () => {
+    const set = computeChangeSet({
+      baseRef: 'main',
+      headRef: 'story-4593',
+      gitSpawnFn: gitOk('a.js'),
+    });
+    assert.equal(set.baseRef, 'main');
+    assert.equal(set.headRef, 'story-4593');
+    assert.equal(set.enumerated, true);
+  });
+
+  test('asks git for the three-dot diff between the supplied refs', () => {
+    const calls = [];
+    computeChangeSet({
+      baseRef: 'main',
+      headRef: 'story-4593',
+      cwd: '/repo',
+      gitSpawnFn: (cwd, ...args) => {
+        calls.push({ cwd, args });
+        return { status: 0, stdout: '', stderr: '' };
+      },
+    });
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0].cwd, '/repo');
+    assert.deepEqual(calls[0].args, [
+      'diff',
+      '--name-only',
+      'main...story-4593',
+    ]);
+  });
+
+  test('reports the refs even when the diff could not be enumerated', () => {
+    const set = computeChangeSet({
+      ...REFS,
+      gitSpawnFn: () => ({ status: 128, stdout: '', stderr: 'bad ref' }),
+    });
+    assert.equal(set.baseRef, 'main');
+    assert.equal(set.headRef, 'story-4593');
+  });
+});
+
+describe('computeChangeSet — total, and null is not empty', () => {
+  test('a git failure yields files: null, not [] (absence of evidence)', () => {
+    const set = computeChangeSet({
+      ...REFS,
+      gitSpawnFn: () => ({ status: 128, stdout: '', stderr: 'bad ref' }),
+    });
+    assert.equal(set.files, null);
+    assert.equal(set.enumerated, false);
+  });
+
+  test('a spawn throw degrades to the unknown envelope rather than throwing', () => {
+    const set = computeChangeSet({
+      ...REFS,
+      gitSpawnFn: () => {
+        throw new Error('spawn failed');
+      },
+    });
+    assert.equal(set.files, null);
+    assert.equal(set.enumerated, false);
+  });
+
+  test('a non-string stdout degrades to the unknown envelope', () => {
+    const set = computeChangeSet({
+      ...REFS,
+      gitSpawnFn: () => ({ status: 0, stdout: undefined, stderr: '' }),
+    });
+    assert.equal(set.files, null);
+  });
+
+  test('missing/blank refs never reach git', () => {
+    let called = false;
+    const gitSpawnFn = () => {
+      called = true;
+      return { status: 0, stdout: 'a.js', stderr: '' };
+    };
+    for (const args of [
+      { baseRef: '', headRef: 'story-1' },
+      { baseRef: 'main', headRef: '' },
+      { baseRef: 'main' },
+      {},
+    ]) {
+      const set = computeChangeSet({ ...args, gitSpawnFn });
+      assert.equal(set.files, null);
+      assert.equal(set.enumerated, false);
+    }
+    assert.equal(called, false, 'git must not be spawned for unusable refs');
+  });
+
+  test('called with no arguments at all, it still returns the envelope', () => {
+    const set = computeChangeSet();
+    assert.equal(set.files, null);
+    assert.equal(set.enumerated, false);
+  });
+});

--- a/tests/code-review.test.js
+++ b/tests/code-review.test.js
@@ -137,6 +137,25 @@ test('runCodeReview: enumerates the diff via the injected gitSpawn', async () =>
   assert.equal(captured.input.depth, 'deep');
 });
 
+test('runCodeReview: an explicit null changedFiles threads standard without re-enumerating', async () => {
+  // Story #4593 — `null` is the spine reporting "I already tried; the diff is
+  // unenumerable". Re-running git here would only fail again, so the fail-safe
+  // tier must be reached without a second enumeration.
+  const captured = {};
+  let enumerated = false;
+  const opts = buildOpts({
+    captured,
+    changedFiles: null,
+    gitSpawnFn: () => {
+      enumerated = true;
+      return { status: 0, stdout: 'src/auth/token.js', stderr: '' };
+    },
+  });
+  await runCodeReview(opts);
+  assert.equal(enumerated, false, 'an explicit null must not re-enumerate');
+  assert.equal(captured.input.depth, 'standard');
+});
+
 test('runCodeReview: derives the sensitive-path level from the enumerated diff', async () => {
   // No changedFiles injected: the level must come from what git reports.
   const captured = {};


### PR DESCRIPTION
Closes #4593

_Auto-opened by `/deliver`._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches ceremony routing, review depth, and acceptance-critic inputs; behavior is mostly consolidation with fail-safe semantics preserved and strong unit coverage, but mis-injection could still mis-route checks.
> 
> **Overview**
> Introduces shared **`computeChangeSet`** (`.agents/scripts/lib/orchestration/change-set.js`) as the single enumerator for `git diff --name-only <base>...<head>`, with normalized sorted file lists and a deliberate **`files: null`** (unknown diff) vs **`[]`** (empty diff) contract so fail-safe routing cannot treat “couldn’t enumerate” as “nothing changed.”
> 
> **Close path:** **`runStoryReviewCore`** now enumerates once per run and injects the same list into the local-lens pass and **`runCodeReview`**, returning **`changeSet`** on the envelope; redundant per-consumer git diffs are removed from **`code-review.js`** (via **`resolveInjectedChangedFiles`**, including “explicit `null` → don’t retry git”).
> 
> **Delivery / critics:** Workflow and **`acceptance-critic`** docs require computing the change set once in **`deliver-story`** Step 2 and passing that list into spawned critics so ceremony level, review depth, and acceptance scoring cannot diverge if a commit lands mid-ceremony.
> 
> Tests cover normalization, single-enumeration injection, and null handling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a172945b2b24101e26133352db8992814664b5a6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->