### PR TITLE
feat: state-probed deliver tick: retire host-maintained --done/--in-flight (#4594)

### DIFF
--- a/.agents/scripts/lib/wave-runner/live-probe.js
+++ b/.agents/scripts/lib/wave-runner/live-probe.js
@@ -1,0 +1,198 @@
+/**
+ * lib/wave-runner/live-probe.js — the state-probing adapter that feeds the
+ * ready-set kernel from live GitHub state.
+ *
+ * `selectReadySet` (`./ready-set.js`) is deliberately a pure, side-effect-free
+ * kernel: callers hand it the live Story records, the done set, and the
+ * in-flight count, and it decides. Until now the only adapter was the
+ * flag-driven one (`stories-wave-tick.js --dag/--done/--in-flight`), which
+ * pushed the *gathering* of those inputs onto the caller — in practice onto
+ * the host LLM following `/deliver`'s prose, re-seeding `--done` and counting
+ * `--in-flight` by hand every beat. That is hand-maintained accounting on the
+ * one correctness-critical path where a mistake silently wedges a run (a
+ * dropped foreign blocker) or double-dispatches a Story (a miscounted slot).
+ *
+ * This module closes that gap by **probing** the same facts the host was
+ * transcribing:
+ *
+ *   - **done** — an `agent::done` label OR a closed issue, the same predicate
+ *     `classifyStory` already applies, evaluated over live state rather than a
+ *     `--done` CSV the caller maintained across beats. Foreign blockers
+ *     (outside the delivered set) are resolved too, which is what makes
+ *     cross-run delivery work: a blocker that merged weeks ago in another run
+ *     is simply done.
+ *   - **in-flight** — derived from live `agent::executing` / `agent::closing`
+ *     labels rather than a `--in-flight <n>` the caller incremented.
+ *
+ * It is an **adapter, not a kernel change**: it gathers inputs and hands them
+ * to `selectReadySet` unchanged. The kernel stays pure and flag-driven, and
+ * the legacy flag mode stays byte-compatible.
+ *
+ * The graph resolution is **not** reimplemented here — it reuses
+ * `resolve-stories.js`'s machinery wholesale (body `depends_on` ∪ native
+ * `blocked_by` edges, foreign-blocker resolution, `files[]` footprints), so
+ * the probe and `/deliver`'s step-1 resolution cannot disagree about what
+ * depends on what.
+ *
+ * @module lib/wave-runner/live-probe
+ */
+
+import {
+  fetchStories,
+  readNativeEdges,
+  resolveForeignDone,
+  resolveStoriesProvider,
+} from '../../resolve-stories.js';
+import { buildStoriesEnvelope } from '../orchestration/resolve-stories.js';
+import { classifyStory } from './ready-set.js';
+
+/**
+ * Count the Stories that currently occupy a dispatch slot.
+ *
+ * `classifyStory` folds `agent::executing` and `agent::closing` into one
+ * `executing` class — both are in-flight, and neither may be re-dispatched.
+ * Deriving this from live labels (rather than a caller-maintained counter) is
+ * the whole point of probe mode: a host that miscounts a slot either
+ * over-dispatches past the cap or starves the run.
+ *
+ * @param {Array<{labels?: string[], state?: string}>} storyRecords
+ * @returns {number}
+ */
+function deriveInFlight(storyRecords) {
+  return storyRecords.filter((rec) => classifyStory(rec) === 'executing')
+    .length;
+}
+
+/**
+ * Resolve the provider + repo coordinates the probe reads through.
+ *
+ * Shares `resolve-stories.js`'s provider seam, so probe mode authenticates and
+ * targets exactly the same repo `/deliver`'s resolution step does. Tests
+ * inject a stub provider instead of calling this.
+ *
+ * @param {object} [deps]
+ * @param {Function} [deps.resolveProvider] Injection seam for tests.
+ * @returns {{ provider: object, owner: string|undefined, repo: string|undefined }}
+ */
+export function createProbeContext({
+  resolveProvider = resolveStoriesProvider,
+} = {}) {
+  const { provider, config } = resolveProvider();
+  return { provider, owner: config?.github?.owner, repo: config?.github?.repo };
+}
+
+/**
+ * Probe live state for a set of Story ids and return the exact inputs
+ * `selectReadySet` consumes.
+ *
+ * Mirrors `resolve-stories.js`'s two-pass envelope build: a provisional pass
+ * yields the DAG whose foreign dependency ids are then resolved against live
+ * issue state, and the second pass folds those satisfied foreign blockers into
+ * `done[]`. Skipping that pass would withhold any Story whose blocker landed
+ * outside the delivered set — the cross-run wedge the resolver exists to fix.
+ *
+ * @param {object} args
+ * @param {number[]} args.ids            Story ids in the run.
+ * @param {object} args.provider         GitHub provider (stubbed in tests).
+ * @param {string} [args.owner]
+ * @param {string} [args.repo]
+ * @param {boolean} [args.native=true]   Read native `blocked_by` edges.
+ * @param {(msg: string) => void} [args.warn]
+ * Each returned node carries its **live labels**. That is load-bearing, not
+ * decoration: `selectReadySet` classifies from labels, so a node stripped of
+ * them reads as `ready` and an `agent::executing` Story gets re-dispatched
+ * onto a second branch while its first run is still going. The resolver's DAG
+ * projection (`{id, dependsOn, files}`) drops labels because flag mode's
+ * caller tracked in-flight itself; probe mode must put them back.
+ *
+ * @returns {Promise<{
+ *   nodes: Array<{id: number, dependsOn: number[], files: string[], labels: string[]}>,
+ *   doneIds: Set<number>,
+ *   inFlight: number
+ * }>}
+ */
+export async function probeLiveState({
+  ids,
+  provider,
+  owner,
+  repo,
+  native = true,
+  warn,
+}) {
+  const stories = await fetchStories(provider, ids);
+  const nativeEdges = native
+    ? await readNativeEdges({ provider, stories, owner, repo })
+    : new Map();
+
+  const provisional = buildStoriesEnvelope({ stories, nativeEdges, warn });
+  const foreignDone = await resolveForeignDone({
+    provider,
+    dag: provisional.dag,
+    inSetIds: new Set(stories.map((s) => s.id)),
+  });
+  const envelope = buildStoriesEnvelope({
+    stories,
+    nativeEdges,
+    foreignDone,
+    warn: () => {},
+  });
+
+  const labelsById = new Map(stories.map((s) => [s.id, s.labels ?? []]));
+  return {
+    nodes: envelope.dag.map((node) => ({
+      ...node,
+      labels: labelsById.get(node.id) ?? [],
+    })),
+    doneIds: new Set(envelope.done),
+    inFlight: deriveInFlight(stories),
+  };
+}
+
+/**
+ * Validate the mode-selecting flags, keeping probe mode and the legacy
+ * flag mode mutually exclusive.
+ *
+ * The exclusion is not pedantry: `--probe-live` derives `done` and `in-flight`
+ * from live state, so honouring a caller-supplied `--done` alongside it would
+ * silently reintroduce the hand-maintained accounting probe mode exists to
+ * retire — and quietly disagree with reality when the two differ.
+ *
+ * @param {object} flags
+ * @param {boolean} [flags.probeLive]
+ * @param {string} [flags.stories]
+ * @param {string} [flags.dag]
+ * @param {string} [flags.dagFile]
+ * @param {string} [flags.done]
+ * @param {string} [flags.inFlight]
+ * @returns {string|null} An error message, or `null` when the flags are valid.
+ */
+export function validateProbeFlags({
+  probeLive,
+  stories,
+  dag,
+  dagFile,
+  done,
+  inFlight,
+} = {}) {
+  if (!probeLive) {
+    return stories
+      ? '--stories requires --probe-live (it names the run to probe from live state)'
+      : null;
+  }
+  const conflicting = [
+    dag ? '--dag' : null,
+    dagFile ? '--dag-file' : null,
+    done != null ? '--done' : null,
+    inFlight != null ? '--in-flight' : null,
+  ].filter(Boolean);
+  if (conflicting.length > 0) {
+    return (
+      `--probe-live is mutually exclusive with ${conflicting.join(', ')}: it resolves the graph ` +
+      `and derives done / in-flight from live state. Drop the flag(s), or use the legacy flag mode.`
+    );
+  }
+  if (!stories) {
+    return '--probe-live requires --stories <csv> of Story ids';
+  }
+  return null;
+}

--- a/.agents/scripts/stories-wave-tick.js
+++ b/.agents/scripts/stories-wave-tick.js
@@ -5,12 +5,10 @@
  * `/deliver` story-list path.
  *
  * Thin **adapter** over the path-agnostic ready-set scheduling core
- * (`lib/wave-runner/ready-set.js#selectReadySet`). It consumes an
- * operator-supplied dependency DAG of standalone Story IDs plus the live
- * progress of the run (which Stories are done, how many are in flight) and
- * emits the set of Stories safe to dispatch **on this beat** — a Story
- * becomes dispatchable the instant its own dependencies are done, under the
- * same global concurrency cap and the same file-overlap co-dispatch guard
+ * (`lib/wave-runner/ready-set.js#selectReadySet`). It emits the set of
+ * Stories safe to dispatch **on this beat** — a Story becomes dispatchable
+ * the instant its own dependencies are done, under the same global
+ * concurrency cap and the same file-overlap co-dispatch guard
  * `lib/wave-runner/ready-set.js` applies everywhere. There is no wave barrier: this no longer batches
  * Stories into fully-draining waves; it selects continuously.
  *
@@ -18,9 +16,25 @@
  * group N+1 opens, via `Graph.js#assignLayers`) is gone. The scheduling
  * kernel — adjacency derivation, the done-predicate classifier, the
  * eligibility rule, and the overlap guard — lives once in `selectReadySet`;
- * this file only parses input, resolves the cap, and renders the envelope.
+ * this file only gathers input, resolves the cap, and renders the envelope.
+ *
+ * **Two modes, one kernel.**
+ *
+ *   - **Probe mode** (`--stories <csv> --probe-live`) is the canonical
+ *     `/deliver` beat: the graph, the done set, and the in-flight count are
+ *     resolved from **live state** via `lib/wave-runner/live-probe.js`. The
+ *     caller supplies ids and nothing else, so there is no accounting to
+ *     hand-maintain across beats — the seed-the-first-beat's-`--done` footgun
+ *     the workflow used to warn about is now structurally impossible rather
+ *     than merely documented.
+ *   - **Flag mode** (`--dag`/`--dag-file` + `--done`/`--in-flight`) keeps the
+ *     caller-supplied contract byte-compatible for tests and hand-driven
+ *     runs. The two are mutually exclusive: honouring a supplied `--done`
+ *     under `--probe-live` would silently reintroduce exactly the
+ *     hand-maintained state probe mode retires.
  *
  * Usage:
+ *   node .agents/scripts/stories-wave-tick.js --stories 101,102 --probe-live
  *   node .agents/scripts/stories-wave-tick.js --dag '<json>'
  *   node .agents/scripts/stories-wave-tick.js --dag-file <path>
  *   node .agents/scripts/stories-wave-tick.js --dag '<json>' --concurrency 5
@@ -41,11 +55,17 @@
  *     wedged: { reason, stories: [{ id, unmetBlockers }] } | null
  *   }
  *
- * The standalone loop calls this once per beat: after each Story closes it
- * re-runs with the closed Story added to `--done` and the live in-flight
- * count in `--in-flight`, dispatching the returned `ready` set (already
- * capped at `concurrencyCap − inFlight` by the core). The run is complete
- * when every Story is in `--done` and `ready` is empty.
+ * Probe mode adds two fields the caller can no longer compute for itself:
+ * `done: number[]` (the resolved done set, in-set ∪ satisfied foreign
+ * blockers) and `epilogueDue: boolean` (true exactly when every listed Story
+ * is done — the run-end signal for `plan-run-epilogue.js`).
+ *
+ * The standalone loop calls this once per beat and dispatches the returned
+ * `ready` set (already capped at `concurrencyCap − inFlight` by the core).
+ * Under `--probe-live` each beat re-reads reality, so the run is complete
+ * when `epilogueDue` is true; under flag mode the caller re-supplies `--done`
+ * and `--in-flight` itself, and the run is complete when every Story is in
+ * `--done` and `ready` is empty.
  *
  * The per-beat concurrency cap is resolved from the same config seam
  * `/deliver` uses — `resolveConfig` + `getRunners` reading
@@ -72,7 +92,13 @@ import { getRunners, resolveConfig } from './lib/config-resolver.js';
 import { detectCycle } from './lib/Graph.js';
 import { Logger } from './lib/Logger.js';
 import { AGENT_LABELS } from './lib/label-constants.js';
+import { parseIds } from './lib/orchestration/resolve-stories.js';
 import { buildStoryAdjacency } from './lib/story-adjacency.js';
+import {
+  createProbeContext,
+  probeLiveState,
+  validateProbeFlags,
+} from './lib/wave-runner/live-probe.js';
 import { selectReadySet } from './lib/wave-runner/ready-set.js';
 
 /**
@@ -82,13 +108,22 @@ import { selectReadySet } from './lib/wave-runner/ready-set.js';
  */
 export const WEDGED_EXIT_CODE = 3;
 
-const HELP = `Usage: node .agents/scripts/stories-wave-tick.js --dag '<json>' | --dag-file <path> [--concurrency <n>] [--done <csv>] [--in-flight <n>]
+const HELP = `Usage:
+  node .agents/scripts/stories-wave-tick.js --stories <csv> --probe-live [--concurrency <n>]
+  node .agents/scripts/stories-wave-tick.js --dag '<json>' | --dag-file <path> [--concurrency <n>] [--done <csv>] [--in-flight <n>]
 
-Continuous ready-set planner for standalone Story delivery. Consumes a
-dependency graph of Story IDs plus the live run progress and emits the set
-of Stories safe to dispatch on this beat — a Story is dispatchable the
-instant its own dependencies are done — plus the resolved per-beat
-concurrency cap and the same file-overlap guard as selectReadySet.
+Continuous ready-set planner for standalone Story delivery. Emits the set of
+Stories safe to dispatch on this beat — a Story is dispatchable the instant
+its own dependencies are done — plus the resolved per-beat concurrency cap
+and the same file-overlap guard as selectReadySet.
+
+Two modes:
+  --probe-live  Resolve the graph and derive done / in-flight from LIVE state
+                (the canonical /deliver beat). Nothing is hand-maintained
+                across beats. Mutually exclusive with --dag/--dag-file/--done/
+                --in-flight. Adds "done" and "epilogueDue" to the envelope.
+  --dag         Legacy flag mode: the caller supplies the graph and the run
+                progress. Kept for tests and hand-driven runs.
 
 Input DAG format (JSON array):
   [{ "id": 101, "dependsOn": [] }, { "id": 102, "dependsOn": [101] }]
@@ -98,6 +133,10 @@ Each entry must include:
   dependsOn  - Array of Story IDs that must complete before this Story runs
 
 Options:
+  --stories <csv>    Story ids to deliver (probe mode). The graph, the done
+                     set, and the in-flight count are resolved from live
+                     state — no --done / --in-flight bookkeeping.
+  --probe-live       Enable probe mode. Requires --stories.
   --concurrency <n>  Override the per-beat concurrency cap for this run only.
                      Must be a positive integer. When omitted, the cap is
                      resolved from delivery.deliverRunner.concurrencyCap in
@@ -128,6 +167,32 @@ Exit codes:
       waiting on blockers that are not done. Distinct from an ordinary empty
       ready set (which means "waiting on in-flight work") and from a cycle.
 `;
+
+/**
+ * Build the exit-1 input-error result. Shared by both modes so a malformed
+ * `--concurrency` reports identically whether it arrived alongside `--dag` or
+ * `--probe-live`.
+ *
+ * @param {string} message
+ * @param {number|null} [concurrencyCap]
+ * @param {number} [inFlightValue]
+ * @returns {{ envelope: object, exitCode: 1 }}
+ */
+function inputErrorResult(message, concurrencyCap = null, inFlightValue = 0) {
+  return {
+    envelope: {
+      kind: 'stories-ready-set',
+      ready: [],
+      totalStories: 0,
+      concurrencyCap,
+      inFlight: inFlightValue,
+      cycleError: null,
+      wedged: null,
+      inputError: message,
+    },
+    exitCode: 1,
+  };
+}
 
 /**
  * Parse and validate the raw DAG input array.
@@ -371,7 +436,12 @@ export function buildReadySetEnvelope(
     const rec = {
       id: node.id,
       dependsOn: node.dependsOn,
-      labels: doneIds.has(node.id) ? [AGENT_LABELS.DONE] : [],
+      // A node's own live labels (probe mode) are preserved so the core's
+      // classifier withholds an in-flight `agent::executing` / `agent::closing`
+      // Story rather than re-dispatching it onto a second branch. Flag-mode
+      // nodes carry none — `parseDag` accepts no labels — so this is inert
+      // there and the legacy contract is unchanged.
+      labels: doneIds.has(node.id) ? [AGENT_LABELS.DONE] : (node.labels ?? []),
     };
     if (node.files !== undefined) rec.files = node.files;
     return rec;
@@ -471,37 +541,23 @@ export function runStoriesWaveTick({
   cwd,
   config,
 } = {}) {
-  const inputError = (message, concurrencyCap = null, inFlightValue = 0) => ({
-    envelope: {
-      kind: 'stories-ready-set',
-      ready: [],
-      totalStories: 0,
-      concurrencyCap,
-      inFlight: inFlightValue,
-      cycleError: null,
-      wedged: null,
-      inputError: message,
-    },
-    exitCode: 1,
-  });
-
   // Validate the --concurrency override before resolving config so an invalid
   // value fails fast with exit code 1 regardless of DAG validity.
   const { value: override, error: concurrencyError } =
     parseConcurrencyOverride(concurrency);
   if (concurrencyError) {
-    return inputError(concurrencyError);
+    return inputErrorResult(concurrencyError);
   }
 
   const { value: inFlightValue, error: inFlightError } =
     parseInFlight(inFlight);
   if (inFlightError) {
-    return inputError(inFlightError);
+    return inputErrorResult(inFlightError);
   }
 
   const { ids: doneIds, error: doneError } = parseDoneIds(done);
   if (doneError) {
-    return inputError(doneError, null, inFlightValue);
+    return inputErrorResult(doneError, null, inFlightValue);
   }
 
   const concurrencyCap = resolveConcurrencyCap({ cwd, config, override });
@@ -512,7 +568,7 @@ export function runStoriesWaveTick({
     try {
       rawJson = readFileSync(dagFile, 'utf8');
     } catch (err) {
-      return inputError(
+      return inputErrorResult(
         `Could not read DAG file "${dagFile}": ${err.message}`,
         concurrencyCap,
         inFlightValue,
@@ -521,7 +577,7 @@ export function runStoriesWaveTick({
   } else if (dagJson) {
     rawJson = dagJson;
   } else {
-    return inputError(
+    return inputErrorResult(
       'Either --dag <json> or --dag-file <path> is required',
       concurrencyCap,
       inFlightValue,
@@ -532,7 +588,7 @@ export function runStoriesWaveTick({
   try {
     parsed = JSON.parse(rawJson);
   } catch (err) {
-    return inputError(
+    return inputErrorResult(
       `Invalid JSON: ${err.message}`,
       concurrencyCap,
       inFlightValue,
@@ -541,7 +597,7 @@ export function runStoriesWaveTick({
 
   const { nodes, error: parseError } = parseDag(parsed);
   if (parseError) {
-    return inputError(parseError, concurrencyCap, inFlightValue);
+    return inputErrorResult(parseError, concurrencyCap, inFlightValue);
   }
 
   return buildReadySetEnvelope(nodes, {
@@ -551,12 +607,94 @@ export function runStoriesWaveTick({
   });
 }
 
+/**
+ * Probe mode: resolve the graph and the run's progress from **live state**,
+ * then run the same scheduling kernel the flag mode does.
+ *
+ * This is the flag-free beat. The caller supplies only the Story ids it was
+ * asked to deliver; `done` and `inFlight` are probed rather than transcribed,
+ * which is what makes the `/deliver` loop's old seed-the-first-beat footgun
+ * structurally impossible instead of merely documented.
+ *
+ * The envelope is the flag mode's, plus two probe-only fields the caller can
+ * no longer compute for itself:
+ *   - `done` — the resolved done set (in-set ∪ satisfied foreign blockers).
+ *   - `epilogueDue` — true exactly when every listed Story is done, which is
+ *     the run-end signal for `plan-run-epilogue.js`.
+ *
+ * @param {object} args
+ * @param {string} args.stories        Raw `--stories` CSV of Story ids.
+ * @param {string|number} [args.concurrency] Raw `--concurrency` override.
+ * @param {string} [args.cwd]          Repo root for config resolution.
+ * @param {object} [args.config]       Pre-resolved config (test injection).
+ * @param {Function} [args.probe]      Probe seam (test injection).
+ * @param {Function} [args.context]    Provider-context seam (test injection).
+ * @returns {Promise<{ envelope: object, exitCode: number }>}
+ */
+export async function runProbedStoriesWaveTick({
+  stories,
+  concurrency,
+  cwd,
+  config,
+  probe = probeLiveState,
+  context = createProbeContext,
+} = {}) {
+  const { value: override, error: concurrencyError } =
+    parseConcurrencyOverride(concurrency);
+  if (concurrencyError) {
+    return inputErrorResult(concurrencyError);
+  }
+
+  let ids;
+  try {
+    ids = parseIds(stories);
+  } catch (err) {
+    return inputErrorResult(err.message);
+  }
+
+  const concurrencyCap = resolveConcurrencyCap({ cwd, config, override });
+
+  let probed;
+  try {
+    const { provider, owner, repo } = context();
+    probed = await probe({
+      ids,
+      provider,
+      owner,
+      repo,
+      warn: (m) => Logger.warn(m),
+    });
+  } catch (err) {
+    // A failed probe must never degrade into "nothing is ready" — that is
+    // indistinguishable from a healthy waiting beat and would silently stall
+    // the run. Fail loud with the input-error contract instead.
+    return inputErrorResult(
+      `Could not probe live state: ${err?.message ?? err}`,
+      concurrencyCap,
+    );
+  }
+
+  const { nodes, doneIds, inFlight } = probed;
+  const { envelope, exitCode } = buildReadySetEnvelope(nodes, {
+    concurrencyCap,
+    doneIds,
+    inFlight,
+  });
+
+  const done = [...doneIds].sort((a, b) => a - b);
+  const epilogueDue =
+    nodes.length > 0 && nodes.every((node) => doneIds.has(node.id));
+  return { envelope: { ...envelope, done, epilogueDue }, exitCode };
+}
+
 async function main(argv) {
   const { values } = parseArgs({
     args: argv,
     options: {
       dag: { type: 'string' },
       'dag-file': { type: 'string' },
+      stories: { type: 'string' },
+      'probe-live': { type: 'boolean' },
       concurrency: { type: 'string' },
       done: { type: 'string' },
       'in-flight': { type: 'string' },
@@ -571,13 +709,29 @@ async function main(argv) {
     return;
   }
 
-  const { envelope, exitCode } = runStoriesWaveTick({
-    dagJson: values.dag,
+  const flagError = validateProbeFlags({
+    probeLive: values['probe-live'],
+    stories: values.stories,
+    dag: values.dag,
     dagFile: values['dag-file'],
-    concurrency: values.concurrency,
     done: values.done,
     inFlight: values['in-flight'],
   });
+
+  const { envelope, exitCode } = flagError
+    ? inputErrorResult(flagError)
+    : values['probe-live']
+      ? await runProbedStoriesWaveTick({
+          stories: values.stories,
+          concurrency: values.concurrency,
+        })
+      : runStoriesWaveTick({
+          dagJson: values.dag,
+          dagFile: values['dag-file'],
+          concurrency: values.concurrency,
+          done: values.done,
+          inFlight: values['in-flight'],
+        });
 
   process.stdout.write(`${JSON.stringify(envelope, null, 2)}\n`);
 

--- a/.agents/workflows/deliver.md
+++ b/.agents/workflows/deliver.md
@@ -67,9 +67,12 @@ to respect.
    node .agents/scripts/resolve-stories.js --ids <id,id,...>
    ```
 
-   Capture `stories[]`, `dag[]`, and `done[]` from the envelope. Do **not**
-   rebuild the graph by hand — it is discovered from live state, including
-   edges a body does not spell out and blockers outside the delivered set.
+   This validates the set and shows the operator what will run: read
+   `stories[]`, `dag[]`, and `done[]` to present the order in step 2. You do
+   **not** thread them into step 3 — the tick re-resolves the graph itself
+   from the same machinery, every beat. Do **not** rebuild the graph by hand;
+   it is discovered from live state, including edges a body does not spell
+   out and blockers outside the delivered set.
 
    Resolution hard-errors (exit 1) on a named id that is not a Story, still
    carries an `Epic: #N` footer, or whose native dependency edges cannot be
@@ -78,23 +81,26 @@ to respect.
 
 2. **Confirm (N>1).** Present the order and wait unless `--yes`.
 
-3. **Sequence.** Loop until every Story is done:
+3. **Sequence.** Loop until the tick reports `epilogueDue: true`:
 
    ```bash
    node .agents/scripts/stories-wave-tick.js \
-     --dag '<dag from step 1>' --done <csv> --in-flight <n> --concurrency <n>
+     --stories <id,id,...> --probe-live --concurrency <n>
    ```
 
-   **Seed the first beat's `--done` from the resolver's `done[]`** — not from
-   an empty string. That array carries the blockers that have already landed,
-   including foreign ones outside the delivered set. Seeding it empty
-   discards exactly the cross-run resolution this step exists for, and the
-   run wedges on a blocker that finished weeks ago. On later beats, `--done`
-   is `done[]` plus every Story that has since closed.
+   **Pass the ids and nothing else.** Each beat re-probes live state: it
+   re-resolves the graph, classifies done (`agent::done` or a closed issue —
+   including foreign blockers that landed in another run), and derives the
+   in-flight count from live `agent::executing` / `agent::closing` labels.
+   You never compute `done` or `in-flight`, and there is nothing to carry
+   between beats — the accounting that used to be yours to maintain by hand
+   is now read from reality every beat (Story #4594).
 
    Branch on the exit code:
-   - **0** — dispatch each `ready` id. An empty `ready` with work in flight
-     means "waiting"; keep looping.
+   - **0** — dispatch each `ready` id (the set is already capped and
+     overlap-free). An empty `ready` with work in flight means "waiting";
+     keep looping. `epilogueDue: true` means every Story is done — leave the
+     loop and go to step 4.
    - **2** — `cycleError`: the graph is self-referential. Fix the
      `depends_on` declarations; do not retry.
    - **3** — `wedged`: nothing is dispatchable, nothing is in flight, and
@@ -109,8 +115,8 @@ to respect.
    `--yes` / injected helper content, execute directly without a re-read
    turn.
 
-4. **Per-run epilogue (N>1).** After the last Story lands, keyed on the
-   delivered id set:
+4. **Per-run epilogue (N>1).** Once step 3 reports `epilogueDue: true`
+   (every Story done), keyed on the delivered id set:
 
    ```bash
    node .agents/scripts/plan-run-epilogue.js --stories 101,102

--- a/tests/deliver-epic-single.test.js
+++ b/tests/deliver-epic-single.test.js
@@ -107,12 +107,29 @@ describe('/deliver takes only Story ids (Story #4540)', () => {
     assert.match(md, /discovered, not declared|resolved.*from live state/i);
   });
 
-  it('mandates seeding the first beat --done from the resolver envelope', () => {
-    // The acceptance-#4-to-#5 handoff: selectReadySet satisfies a foreign
-    // gate only via the done set, so seeding it empty silently discards
-    // the cross-run resolution and wedges the run.
+  it('drives the beat from live state rather than hand-maintained flags (Story #4594)', () => {
+    // Was: "mandates seeding the first beat --done from the resolver
+    // envelope". That prose existed because selectReadySet satisfies a
+    // foreign gate only via the done set, so a host that seeded it empty
+    // silently discarded the cross-run resolution and wedged the run.
+    //
+    // Probe mode retires the instruction rather than restating it: the tick
+    // resolves the graph and derives done / in-flight itself, every beat, so
+    // there is no seed to get wrong. The invariant is now enforced by
+    // `lib/wave-runner/live-probe.js` (and pinned in
+    // tests/wave-runner/live-probe.test.js) instead of by operator prose.
     const md = readFileSync(DELIVER_MD, 'utf8');
-    assert.match(md, /Seed the first beat's `--done` from the resolver/);
+    assert.match(md, /--stories <id,id,\.\.\.> --probe-live/);
+    assert.doesNotMatch(
+      md,
+      /Seed the first beat/,
+      'the seed footgun is structurally impossible — it must not be re-documented',
+    );
+    assert.doesNotMatch(
+      md,
+      /--done <csv> --in-flight <n>/,
+      'the loop must not ask the host to maintain done / in-flight by hand',
+    );
   });
 
   it('documents the wedged verdict as distinct from waiting and from a cycle', () => {

--- a/tests/wave-runner/live-probe.test.js
+++ b/tests/wave-runner/live-probe.test.js
@@ -1,0 +1,386 @@
+/**
+ * tests/wave-runner/live-probe.test.js — Story #4594.
+ *
+ * Probe mode exists to delete hand-maintained accounting from the `/deliver`
+ * beat: the host LLM used to re-seed `--done` and count `--in-flight` by
+ * following prose, and every one of those transcriptions was a chance to
+ * silently wedge a run or double-dispatch a Story.
+ *
+ * These tests pin the properties that make the footgun structurally
+ * impossible rather than merely documented:
+ *
+ *   1. `done` and `inFlight` are DERIVED from live labels / issue state, with
+ *      no `--done` / `--in-flight` supplied.
+ *   2. A foreign blocker that already landed lands in `done[]` (the cross-run
+ *      resolution), while an open one keeps gating (`dropForeign: false`).
+ *   3. `epilogueDue` is true exactly when every listed Story is done.
+ *   4. Probe mode feeds the SAME cycle (2) / wedge (3) exits as flag mode —
+ *      one kernel, two adapters.
+ */
+
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { describe, it } from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+import {
+  createProbeContext,
+  probeLiveState,
+  validateProbeFlags,
+} from '../../.agents/scripts/lib/wave-runner/live-probe.js';
+import { runProbedStoriesWaveTick } from '../../.agents/scripts/stories-wave-tick.js';
+
+const CONFIG = { delivery: { deliverRunner: { concurrencyCap: 3 } } };
+
+function storyBody({ changes = [], blockedBy = null } = {}) {
+  const lines = [
+    '## Goal',
+    'Do the thing.',
+    '',
+    '## Changes',
+    ...changes.map(
+      (p) => `- {"path":"${p}","assumption":"refactors-existing"}`,
+    ),
+    '',
+    '## Acceptance',
+    '- [ ] it works',
+    '',
+    '## Verify',
+    '- npm test (unit)',
+  ];
+  if (blockedBy) lines.push('', '---', `blocked by #${blockedBy}`);
+  return lines.join('\n');
+}
+
+/**
+ * Build a stub provider over a plain `{ id: issue }` map.
+ *
+ * `native: []` keeps the dependencies API out of the way so each test states
+ * its edges in exactly one place (the body footer) unless it is specifically
+ * exercising native-edge union.
+ */
+function stubProvider(issues, { native = {} } = {}) {
+  return {
+    getTicket: async (id) => issues[id] ?? null,
+    _gh: {
+      api: async ({ endpoint }) => {
+        const match = endpoint.match(/\/issues\/(\d+)\/dependencies/);
+        const edges = native[match?.[1]] ?? [];
+        return { stdout: JSON.stringify(edges) };
+      },
+    },
+  };
+}
+
+function issue(id, { labels = [], state = 'open', ...bodyArgs } = {}) {
+  return {
+    number: id,
+    title: `Story ${id}`,
+    body: storyBody(bodyArgs),
+    labels: [{ name: 'type::story' }, ...labels.map((name) => ({ name }))],
+    state,
+  };
+}
+
+/** Run a probe-mode tick against a stubbed provider — no network, no config. */
+function tick(issues, { ids, native, concurrency } = {}) {
+  const provider = stubProvider(issues, { native });
+  return runProbedStoriesWaveTick({
+    stories: ids ?? Object.keys(issues).join(','),
+    concurrency,
+    config: CONFIG,
+    context: () => ({ provider, owner: 'dsj1984', repo: 'mandrel' }),
+  });
+}
+
+describe('probeLiveState — done and in-flight come from live state', () => {
+  it('derives done from an agent::done label and from a closed issue', async () => {
+    const provider = stubProvider({
+      101: issue(101, { labels: ['agent::done'] }),
+      102: issue(102, { state: 'closed' }),
+      103: issue(103),
+    });
+
+    const { doneIds, inFlight } = await probeLiveState({
+      ids: [101, 102, 103],
+      provider,
+      owner: 'dsj1984',
+      repo: 'mandrel',
+    });
+
+    assert.deepEqual(
+      [...doneIds].sort((a, b) => a - b),
+      [101, 102],
+    );
+    assert.equal(inFlight, 0);
+  });
+
+  it('counts agent::executing and agent::closing as in-flight', async () => {
+    const provider = stubProvider({
+      101: issue(101, { labels: ['agent::executing'] }),
+      102: issue(102, { labels: ['agent::closing'] }),
+      103: issue(103),
+    });
+
+    const { inFlight, doneIds } = await probeLiveState({
+      ids: [101, 102, 103],
+      provider,
+      owner: 'dsj1984',
+      repo: 'mandrel',
+    });
+
+    assert.equal(inFlight, 2);
+    assert.equal(doneIds.size, 0);
+  });
+
+  it('unions body edges with native blocked_by edges', async () => {
+    const provider = stubProvider(
+      {
+        101: issue(101),
+        102: issue(102, { blockedBy: 101 }),
+        103: issue(103),
+      },
+      { native: { 103: [{ number: 101 }] } },
+    );
+
+    const { nodes } = await probeLiveState({
+      ids: [101, 102, 103],
+      provider,
+      owner: 'dsj1984',
+      repo: 'mandrel',
+    });
+
+    const byId = new Map(nodes.map((n) => [n.id, n]));
+    assert.deepEqual(byId.get(102).dependsOn, [101], 'body edge');
+    assert.deepEqual(byId.get(103).dependsOn, [101], 'native edge');
+  });
+
+  it('threads the declared files[] footprint through to the kernel', async () => {
+    const provider = stubProvider({
+      101: issue(101, { changes: ['.agents/scripts/a.js'] }),
+    });
+
+    const { nodes } = await probeLiveState({
+      ids: [101],
+      provider,
+      owner: 'dsj1984',
+      repo: 'mandrel',
+    });
+
+    assert.deepEqual(nodes[0].files, ['.agents/scripts/a.js']);
+  });
+});
+
+describe('runProbedStoriesWaveTick — the flag-free beat', () => {
+  it('emits a stories-ready-set envelope with no --done/--in-flight supplied', async () => {
+    const { envelope, exitCode } = await tick({
+      101: issue(101),
+      102: issue(102, { blockedBy: 101 }),
+    });
+
+    assert.equal(exitCode, 0);
+    assert.equal(envelope.kind, 'stories-ready-set');
+    // #102 is gated by #101, which is not done: only #101 dispatches.
+    assert.deepEqual(envelope.ready, [101]);
+    assert.equal(envelope.totalStories, 2);
+    assert.equal(envelope.concurrencyCap, 3);
+    assert.equal(envelope.inFlight, 0);
+    assert.deepEqual(envelope.done, []);
+    assert.equal(envelope.cycleError, null);
+    assert.equal(envelope.wedged, null);
+  });
+
+  it('opens a dependent the instant its blocker reads done, and never re-dispatches the blocker', async () => {
+    const { envelope, exitCode } = await tick({
+      101: issue(101, { labels: ['agent::done'] }),
+      102: issue(102, { blockedBy: 101 }),
+    });
+
+    assert.equal(exitCode, 0);
+    assert.deepEqual(envelope.ready, [102]);
+    assert.deepEqual(envelope.done, [101]);
+    assert.equal(envelope.epilogueDue, false);
+  });
+
+  it('subtracts live in-flight Stories from the cap', async () => {
+    const { envelope } = await tick(
+      {
+        101: issue(101, { labels: ['agent::executing'] }),
+        102: issue(102),
+        103: issue(103),
+      },
+      { concurrency: '2' },
+    );
+
+    // Cap 2 − 1 in-flight = 1 slot; #101 is in-flight so only #102 admits.
+    assert.equal(envelope.inFlight, 1);
+    assert.deepEqual(envelope.ready, [102]);
+  });
+
+  it('reports epilogueDue exactly when every listed Story is done', async () => {
+    const partial = await tick({
+      101: issue(101, { labels: ['agent::done'] }),
+      102: issue(102),
+    });
+    assert.equal(partial.envelope.epilogueDue, false);
+
+    const complete = await tick({
+      101: issue(101, { labels: ['agent::done'] }),
+      102: issue(102, { state: 'closed' }),
+    });
+    assert.equal(complete.envelope.epilogueDue, true);
+    assert.equal(complete.exitCode, 0);
+    assert.deepEqual(complete.envelope.ready, []);
+    assert.deepEqual(complete.envelope.done, [101, 102]);
+  });
+
+  it('exits 2 on a dependency cycle, matching flag-mode semantics', async () => {
+    const { envelope, exitCode } = await tick({
+      101: issue(101, { blockedBy: 102 }),
+      102: issue(102, { blockedBy: 101 }),
+    });
+
+    assert.equal(exitCode, 2);
+    assert.match(envelope.cycleError, /Dependency cycle detected/);
+    assert.deepEqual(envelope.ready, []);
+  });
+
+  it('exits 3 on a wedge — an open foreign blocker keeps gating', async () => {
+    // #999 is foreign (not in --stories) and OPEN, so it must keep gating:
+    // dropForeign is false. Nothing is ready, nothing is in flight → wedge.
+    const { envelope, exitCode } = await tick(
+      {
+        101: issue(101, { blockedBy: 999 }),
+        999: issue(999),
+      },
+      { ids: '101' },
+    );
+
+    assert.equal(exitCode, 3);
+    assert.equal(envelope.wedged.reason.includes('#101'), true);
+    assert.deepEqual(envelope.wedged.stories, [
+      { id: 101, unmetBlockers: [999] },
+    ]);
+  });
+
+  it('resolves a landed foreign blocker into done[] rather than wedging', async () => {
+    // The cross-run case: #999 merged weeks ago in another run. Probing it
+    // live is what makes #101 simply ready.
+    const { envelope, exitCode } = await tick(
+      {
+        101: issue(101, { blockedBy: 999 }),
+        999: issue(999, { state: 'closed' }),
+      },
+      { ids: '101' },
+    );
+
+    assert.equal(exitCode, 0);
+    assert.deepEqual(envelope.ready, [101]);
+    assert.deepEqual(envelope.done, [999]);
+    assert.equal(envelope.wedged, null);
+  });
+
+  it('fails loud rather than degrading a broken probe into an empty ready set', async () => {
+    const { envelope, exitCode } = await runProbedStoriesWaveTick({
+      stories: '101',
+      config: CONFIG,
+      context: () => ({ provider: {}, owner: 'o', repo: 'r' }),
+      probe: async () => {
+        throw new Error('dependencies API disabled');
+      },
+    });
+
+    assert.equal(exitCode, 1);
+    assert.match(envelope.inputError, /Could not probe live state/);
+    assert.match(envelope.inputError, /dependencies API disabled/);
+  });
+
+  it('rejects a malformed --stories list', async () => {
+    const { envelope, exitCode } = await runProbedStoriesWaveTick({
+      stories: 'not-an-id',
+      config: CONFIG,
+      context: () => ({ provider: {}, owner: 'o', repo: 'r' }),
+    });
+
+    assert.equal(exitCode, 1);
+    assert.match(envelope.inputError, /positive issue numbers/);
+  });
+});
+
+describe('validateProbeFlags — the modes stay mutually exclusive', () => {
+  it('accepts each mode on its own', () => {
+    assert.equal(validateProbeFlags({ probeLive: true, stories: '1,2' }), null);
+    assert.equal(validateProbeFlags({ dag: '[]', done: '1' }), null);
+  });
+
+  it('rejects hand-maintained accounting alongside --probe-live', () => {
+    // The whole point: a supplied --done under --probe-live would silently
+    // reintroduce the state probe mode exists to retire.
+    for (const conflict of [
+      { dag: '[]' },
+      { dagFile: '/tmp/d.json' },
+      { done: '101' },
+      { inFlight: '1' },
+    ]) {
+      const err = validateProbeFlags({
+        probeLive: true,
+        stories: '1',
+        ...conflict,
+      });
+      assert.match(err, /mutually exclusive/);
+    }
+  });
+
+  it('requires --stories under --probe-live, and --probe-live under --stories', () => {
+    assert.match(validateProbeFlags({ probeLive: true }), /requires --stories/);
+    assert.match(
+      validateProbeFlags({ stories: '1,2' }),
+      /--stories requires --probe-live/,
+    );
+  });
+});
+
+describe('CLI wiring — the mode guard fires before any network read', () => {
+  const SCRIPT = fileURLToPath(
+    new URL('../../.agents/scripts/stories-wave-tick.js', import.meta.url),
+  );
+
+  it('refuses --probe-live alongside --done without touching GitHub', () => {
+    const res = spawnSync(
+      process.execPath,
+      [SCRIPT, '--stories', '101', '--probe-live', '--done', '101'],
+      { encoding: 'utf8' },
+    );
+
+    assert.equal(res.status, 1);
+    const envelope = JSON.parse(res.stdout);
+    assert.match(envelope.inputError, /mutually exclusive/);
+    assert.equal(envelope.kind, 'stories-ready-set');
+  });
+
+  it('documents probe mode in --help', () => {
+    const res = spawnSync(process.execPath, [SCRIPT, '--help'], {
+      encoding: 'utf8',
+    });
+
+    assert.equal(res.status, 0);
+    assert.match(res.stdout, /--probe-live/);
+    assert.match(res.stdout, /--stories <csv>/);
+  });
+});
+
+describe('createProbeContext — shares the resolver provider seam', () => {
+  it('projects the provider and repo coordinates from resolved config', () => {
+    const provider = { getTicket: async () => null };
+    const ctx = createProbeContext({
+      resolveProvider: () => ({
+        provider,
+        config: { github: { owner: 'dsj1984', repo: 'mandrel' } },
+      }),
+    });
+
+    assert.equal(ctx.provider, provider);
+    assert.equal(ctx.owner, 'dsj1984');
+    assert.equal(ctx.repo, 'mandrel');
+  });
+});


### PR DESCRIPTION
Closes #4594

_Auto-opened by `/deliver`._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the canonical multi-story delivery loop and adds GitHub-dependent probing on every beat; mistakes could wedge runs or mis-dispatch, though behavior is heavily tested and probe failures exit loud instead of stalling silently.
> 
> **Overview**
> Adds **probe mode** to `stories-wave-tick.js` (`--stories` + `--probe-live`) so each `/deliver` beat reads the graph, done set, and in-flight count from **live GitHub state** instead of the host re-supplying `--dag`, `--done`, and `--in-flight`.
> 
> New `lib/wave-runner/live-probe.js` reuses `resolve-stories.js` (DAG, foreign blockers, `files[]`) and derives done from `agent::done`/closed issues and in-flight from `agent::executing`/`agent::closing`. Probe output adds **`done`** and **`epilogueDue`**; legacy flag mode stays unchanged. `buildReadySetEnvelope` now keeps **live labels** on nodes so in-flight stories are not double-dispatched.
> 
> `/deliver` is updated to loop on probe ticks until `epilogueDue`; tests cover cross-run foreign blockers, wedge/cycle exits, and mutual exclusion of probe vs hand-maintained flags.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1ab43f2948be981ab79f19d02bf85350a16c6904. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->