### PR TITLE
feat: rewire the /plan critics into a live pre-persist gate (#4592)

### DIFF
--- a/.agents/scripts/lib/orchestration/plan-critic-conditions.js
+++ b/.agents/scripts/lib/orchestration/plan-critic-conditions.js
@@ -2,15 +2,15 @@
  * plan-critic-conditions.js — size/heuristic-conditional dispatch decisions for
  * the /plan author-step critics (Epic #4474 PR6, design §4).
  *
- * The collapsed plan flow keeps the consolidation (8.3) and pre-mortem
- * (8.5) critics as fresh-context sub-agent dispatches, but makes each
- * dispatch **conditional** instead of unconditional — the dominant plan
- * cost is turns × standing context, and an unconditional critic pays a
- * full sub-agent spawn even when it provably has nothing to find. This
- * module computes those decisions deterministically so the workflow never
- * judges its own dispatch conditions:
+ * The collapsed plan flow keeps the consolidation and pre-mortem critics as
+ * fresh-context sub-agent dispatches, but makes each dispatch
+ * **conditional** instead of unconditional — the dominant plan cost is
+ * turns × standing context, and an unconditional critic pays a full
+ * sub-agent spawn even when it provably has nothing to find. This module
+ * computes those decisions deterministically so the workflow never judges
+ * its own dispatch conditions:
  *
- *   - **Consolidation (8.3)**: dispatch only when the existing
+ *   - **Consolidation**: dispatch only when the existing
  *     `evaluateConsolidationPrecondition` gate says `dispatch: true` AND
  *     (the draft has more than `CONSOLIDATION_STORY_THRESHOLD` stories OR
  *     the precondition confirmed a divergence from the Delivery Slicing
@@ -18,7 +18,7 @@
  *     small draft is NOT a confirmed divergence — it skips, because a
  *     ≤-threshold draft is small enough for gate #2's single-view review
  *     to catch a distorted shape without a dedicated sub-agent.
- *   - **Pre-mortem (8.5)**: dispatch when the ticket count is at least half
+ *   - **Pre-mortem**: dispatch when the ticket count is at least half
  *     of `maxTickets`, OR any configured `planning.riskHeuristics` phrase
  *     matches the plan text (case-insensitive substring). Story #4542 removed
  *     its third condition — the authored risk verdict's overall level — along
@@ -28,18 +28,19 @@
  * Under-firing risk (design PR6 note): the persist validators are
  * unchanged hard gates and G2's cohort re-measures plan quality; every
  * skip decision this module produces is logged to the plan-metrics ledger
- * (`appendCriticSkip`) by the callers so under-firing is auditable.
+ * (`appendCriticSkip`) by the caller so under-firing is auditable.
  *
- * Pure, synchronous, no I/O — the folded pre-write phase inside
- * `plan-persist.js` owns reading the authored artifacts and the resolved
- * config.
+ * Pure, synchronous, no I/O. The single caller is `plan-critics-evaluate.js`,
+ * driven by the `plan-critics.js` CLI that `/plan` runs between Author and
+ * Persist (Story #4592); the CLI owns reading the authored artifacts and the
+ * resolved config.
  */
 
 import { evaluateConsolidationPrecondition } from './consolidation-precondition.js';
 
 /**
  * Draft-story count above which the consolidation critic fires even
- * without a confirmed slicing divergence (design §6 PR6: "> 5 stories").
+ * without a confirmed slicing divergence (#4474 PR6: "> 5 stories").
  */
 export const CONSOLIDATION_STORY_THRESHOLD = 5;
 
@@ -53,7 +54,7 @@ export const CONSOLIDATION_STORY_THRESHOLD = 5;
  */
 
 /**
- * Decide the 8.3 consolidation dispatch: precondition AND size/divergence.
+ * Decide the consolidation dispatch: precondition AND size/divergence.
  *
  * @param {object} input
  * @param {object[]} input.draftStories - The draft `tickets.json` array
@@ -106,7 +107,7 @@ export function evaluateConsolidationDispatch({ draftStories, specText }) {
 }
 
 /**
- * Decide the 8.5 pre-mortem dispatch: size ≥ ½ budget, or a risk-heuristic
+ * Decide the pre-mortem dispatch: size ≥ ½ budget, or a risk-heuristic
  * phrase match.
  *
  * @param {object} input

--- a/.agents/scripts/lib/orchestration/plan-critics-evaluate.js
+++ b/.agents/scripts/lib/orchestration/plan-critics-evaluate.js
@@ -1,20 +1,22 @@
 /**
  * plan-critics-evaluate.js — shared critic-dispatch evaluation for the
- * collapsed /plan flow (#4496 fix 6; extracted from the `plan-critics.js`
- * CLI so the persist surface folds the same evaluation in as a pre-write
- * phase).
+ * collapsed /plan flow (#4496 fix 6).
  *
- * Two consumers:
- *   - `plan-persist.js` (via `runPlanPersist`) — evaluates the dispatch
- *     conditions as a deterministic pre-write phase, prints the verdicts,
- *     and records every skip on the plan-metrics ledger, so the headless
- *     path never pays a standalone CLI turn for the same decision.
- *   - `plan-critics.js` — the standalone CLI survives one release as a
- *     thin shim over this module for the attended pre-gate evaluation
- *     (the verdict folds into gate #2's view before the persist runs).
+ * One consumer: the `plan-critics.js` CLI, which `/plan` runs between its
+ * Author and Persist steps. The CLI loads the draft artifacts, calls this
+ * module, prints the verdict as JSON, and records every skip on the
+ * plan-metrics ledger; the workflow dispatches a fresh-context critic
+ * sub-agent on a `dispatch: true` verdict and folds the findings into a
+ * re-author round before persist.
+ *
+ * Story #4592 moved that evaluation here from `run-plan-persist.js`, which
+ * ran it after authoring was finished and immediately before
+ * `createStoryIssues` — the one point where a `dispatch: true` verdict has
+ * no re-author loop to route to. Persist no longer evaluates critics; this
+ * module has exactly one evaluation point.
  *
  * Pure evaluation: no file I/O, no GitHub calls, no ledger writes — the
- * callers own artifact loading and skip recording.
+ * caller owns artifact loading and skip recording.
  *
  * @module lib/orchestration/plan-critics-evaluate
  */
@@ -41,8 +43,7 @@ function resolveRiskHeuristics(config = {}) {
 
 /**
  * Evaluate the consolidation + pre-mortem critic dispatch conditions over
- * the authored planning artifacts (design §4 / #4474 PR6 conditions,
- * unchanged):
+ * the authored planning artifacts (#4474 PR6 conditions, unchanged):
  *
  *   - Consolidation: skipped outright when `tickets` is null/absent (the
  *     single-delivery shape authors no draft tickets); otherwise the

--- a/.agents/scripts/lib/orchestration/plan-persist/run-plan-persist.js
+++ b/.agents/scripts/lib/orchestration/plan-persist/run-plan-persist.js
@@ -44,7 +44,6 @@ import { anchorTempRoot, tempRootFrom } from '../../config/temp-paths.js';
 import { getLimits, PROJECT_ROOT } from '../../config-resolver.js';
 import { gitSpawn } from '../../git-utils.js';
 import { Logger } from '../../Logger.js';
-import { evaluatePlanCritics } from '../plan-critics-evaluate.js';
 import {
   appendCriticSkip,
   readPlanMetrics,
@@ -438,29 +437,6 @@ export async function runPlanPersist({
     );
   }
 
-  const critics = evaluatePlanCritics({
-    techSpecContent: techSpecContent ?? '',
-    tickets: rawStories,
-    config,
-  });
-  for (const decision of [critics.consolidation, critics.premortem]) {
-    Logger.info(
-      `[plan-persist] critic ${decision.critic}: ` +
-        `${decision.dispatch ? 'dispatch' : 'skip'} — ` +
-        decision.reasons.join('; '),
-    );
-    if (!decision.dispatch) {
-      await appendCriticSkip(
-        {
-          critic: decision.critic,
-          reasons: decision.reasons,
-          cli: 'plan-persist',
-        },
-        config,
-      );
-    }
-  }
-
   // Split policy + inline Spec fold (over-budget Specs fail closed — no docs/).
   const { stories } = assemblePlanStories(rawStories, {
     sharedSpec: techSpecContent,
@@ -580,7 +556,6 @@ export async function runPlanPersist({
     stories: created,
     primaryStoryId: primary.id,
     forceReview,
-    critics,
     reachability,
     freshness,
     waveTable,

--- a/.agents/scripts/plan-critics.js
+++ b/.agents/scripts/plan-critics.js
@@ -1,0 +1,178 @@
+#!/usr/bin/env node
+
+/**
+ * plan-critics.js — the /plan critic-dispatch verdict CLI (Story #4592).
+ *
+ * `/plan` step 2.5 (between Author and Persist) runs this against the draft
+ * `stories.json`. It evaluates the consolidation + pre-mortem dispatch
+ * conditions and prints the verdict as JSON on stdout so the workflow can
+ * act on it — dispatching a fresh-context critic sub-agent and folding its
+ * findings into a re-author round **before** the plan is persisted.
+ *
+ * Why here and nowhere else. The evaluation used to run inside
+ * `run-plan-persist.js`, after authoring was finished and immediately before
+ * `createStoryIssues` — the one point in the flow where nothing can act on a
+ * `dispatch: true` verdict, because the artifacts are about to become live
+ * issues. It logged the verdict and moved on. This CLI is now the **single**
+ * evaluation point, sited where a re-author loop actually exists.
+ *
+ * Advisory by contract: a `dispatch: true` verdict routes work to the
+ * workflow, it does not gate the run. This CLI exits 0 on any verdict; only a
+ * usage/IO error is a failure. Every `dispatch: false` decision is recorded to
+ * the plan-metrics ledger (`appendCriticSkip`) so under-firing stays auditable.
+ *
+ * CLI:
+ *   --stories <file>     Required. The draft Story ticket array (JSON).
+ *   --tech-spec <file>   Optional. Shared Tech Spec carrying the
+ *                        `## Delivery Slicing` table the consolidation
+ *                        precondition reads.
+ *
+ * stdout is reserved for the verdict JSON (Story #2278 discipline):
+ *
+ *   {
+ *     "consolidation": { "critic": "consolidation", "dispatch": false, "reasons": [...] },
+ *     "premortem":     { "critic": "pre-mortem",    "dispatch": true,  "reasons": [...] }
+ *   }
+ *
+ * Human-readable log lines go to stderr, matching the sibling `plan-persist`.
+ *
+ * Exit codes: 0 success (any verdict); 1 usage/IO error.
+ */
+
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import { parseArgs } from 'node:util';
+
+import { runAsCli } from './lib/cli-utils.js';
+import { resolveConfig } from './lib/config-resolver.js';
+import { Logger, routeAllOutputToStderr } from './lib/Logger.js';
+import { evaluatePlanCritics } from './lib/orchestration/plan-critics-evaluate.js';
+import { appendCriticSkip } from './lib/orchestration/plan-metrics.js';
+
+const CLI_OPTIONS = {
+  stories: { type: 'string' },
+  'tech-spec': { type: 'string' },
+};
+
+const USAGE = 'Usage: plan-critics.js --stories <file> [--tech-spec <file>]';
+
+/** The `cli` discriminator every ledger record from this surface carries. */
+export const PLAN_CRITICS_CLI = 'plan-critics';
+
+/**
+ * Read the draft artifacts the critics evaluate.
+ *
+ * @param {{ storiesPath: string, techSpecPath?: string|null }} paths
+ * @returns {Promise<{ tickets: object[], techSpecContent: string }>}
+ */
+export async function loadCriticArtifacts({
+  storiesPath,
+  techSpecPath = null,
+}) {
+  const raw = await readFile(storiesPath, 'utf8');
+  let tickets;
+  try {
+    tickets = JSON.parse(raw);
+  } catch (err) {
+    throw new Error(
+      `Failed to parse stories file "${storiesPath}" as JSON: ${err.message}`,
+    );
+  }
+  if (!Array.isArray(tickets)) {
+    throw new Error(`Stories file "${storiesPath}" must contain a JSON array.`);
+  }
+  const techSpecContent = techSpecPath
+    ? await readFile(techSpecPath, 'utf8')
+    : '';
+  return { tickets, techSpecContent };
+}
+
+/**
+ * Log each decision and record every skip on the plan-metrics ledger. The
+ * ledger write is best-effort by `appendCriticSkip`'s own contract — it can
+ * never fail the plan step.
+ *
+ * @param {{ consolidation: object, premortem: object }} verdict
+ * @param {object} config
+ * @param {{ append?: typeof appendCriticSkip }} [deps]
+ * @returns {Promise<void>}
+ */
+export async function recordCriticSkips(
+  verdict,
+  config,
+  { append = appendCriticSkip } = {},
+) {
+  for (const decision of [verdict.consolidation, verdict.premortem]) {
+    Logger.info(
+      `[plan-critics] critic ${decision.critic}: ` +
+        `${decision.dispatch ? 'dispatch' : 'skip'} — ` +
+        decision.reasons.join('; '),
+    );
+    if (!decision.dispatch) {
+      await append(
+        {
+          critic: decision.critic,
+          reasons: decision.reasons,
+          cli: PLAN_CRITICS_CLI,
+        },
+        config,
+      );
+    }
+  }
+}
+
+/**
+ * Load the artifacts, evaluate both critics, record the skips, and return the
+ * verdict. Exported as the CLI's whole body so tests drive it in-process with
+ * an explicit config and ledger seam.
+ *
+ * @param {{
+ *   storiesPath: string,
+ *   techSpecPath?: string|null,
+ *   config?: object,
+ *   append?: typeof appendCriticSkip,
+ * }} args
+ * @returns {Promise<{ consolidation: object, premortem: object }>}
+ */
+export async function evaluateCriticArtifacts({
+  storiesPath,
+  techSpecPath = null,
+  config = {},
+  append = appendCriticSkip,
+}) {
+  const { tickets, techSpecContent } = await loadCriticArtifacts({
+    storiesPath,
+    techSpecPath,
+  });
+  const verdict = evaluatePlanCritics({ techSpecContent, tickets, config });
+  await recordCriticSkips(verdict, config, { append });
+  return verdict;
+}
+
+async function main() {
+  const { values } = parseArgs({ options: CLI_OPTIONS });
+
+  if (!values.stories) {
+    throw new Error(USAGE);
+  }
+
+  // stdout is reserved for the verdict JSON — flip every Logger sink that
+  // could land on stdout to stderr before any evaluation runs.
+  routeAllOutputToStderr();
+
+  const verdict = await evaluateCriticArtifacts({
+    storiesPath: path.resolve(values.stories),
+    techSpecPath: values['tech-spec']
+      ? path.resolve(values['tech-spec'])
+      : null,
+    config: resolveConfig(),
+  });
+
+  process.stdout.write(`${JSON.stringify(verdict, null, 2)}\n`);
+  return 0;
+}
+
+runAsCli(import.meta.url, main, {
+  source: 'plan-critics',
+  propagateExitCode: true,
+});

--- a/.agents/workflows/plan.md
+++ b/.agents/workflows/plan.md
@@ -141,6 +141,48 @@ total by default — an authored map is the only thing that can say
 `#4525-#4528 → #4530` while `#4529 → #4531`, which a blanket "superseded by
 this plan-run" reference could not.
 
+### 2.5 Critics
+
+Evaluate the critic-dispatch conditions against the authored draft — here,
+**before** persist, because this is the last point where a finding can still
+be folded into a re-author round rather than into live issues:
+
+```bash
+node .agents/scripts/plan-critics.js \
+  --stories temp/plan-<slug>/stories.json \
+  [--tech-spec temp/plan-<slug>/techspec.md]
+```
+
+It prints a verdict on stdout and always exits 0 — the verdict routes work,
+it does not gate the run:
+
+```jsonc
+{
+  "consolidation": { "critic": "consolidation", "dispatch": false, "reasons": ["…"] },
+  "premortem": { "critic": "pre-mortem", "dispatch": true, "reasons": ["…"] }
+}
+```
+
+- **Both `dispatch: false`** — proceed straight to Persist. The conditions
+  provably have nothing for a critic to find, and each skip is recorded on the
+  plan-metrics ledger so under-firing stays auditable.
+- **Either `dispatch: true`** — dispatch **one fresh-context sub-agent per
+  firing critic** (a generic sub-agent), then fold its findings into the
+  Gate #2 view or a re-author round before persist. Each critic is
+  **maker-blind**: hand it the draft artifacts (`stories.json`, and
+  `techspec.md` when present) plus its charter below — never the authoring
+  transcript or the reasons the planner believed its own draft is sound. A
+  critic that reads the maker's case grades the case, not the draft.
+  - `consolidation` — the draft's shape: Stories that should be one cohesive
+    slice, a slice split per-module rather than per-capability, and
+    `depends_on` edges that disagree with the Delivery Slicing table.
+  - `pre-mortem` — assume the plan shipped and failed: name the most likely
+    failure modes and what the draft would have to say to prevent them.
+
+Fold what survives back into `stories.json` and re-run this step. Findings are
+advisory input to the operator's Gate #2 decision, not an automatic re-author
+mandate.
+
 ### 3. Persist
 
 **Gate #2** — when the operator passed `--force-review`, STOP for approval of

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -216,6 +216,7 @@ graph TB
 | Script                           | Responsibility                                                                                                                                                                              |
 | -------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `plan-context.js`                | Single authoring-envelope emitter for `/plan`: Story brief + docs digest + `codebaseSnapshot` + duplicate search + clarity + rendered system prompts. |
+| `plan-critics.js`                | Single critic-dispatch evaluation point for `/plan`, run between Author and Persist: prints the consolidation + pre-mortem verdict as JSON (advisory — always exits 0) and ledgers every skip. |
 | `plan-persist.js`                | Single GitHub-write surface for `/plan`: section gate, ticket validator + file-assumption + DAG + budget gates, Story creation, terminal `agent::ready` flip, `plan-summary` comment. |
 | `single-story-init.js`           | Validates a standalone Story, branches from `main`, creates the worktree, flips `agent::executing`. |
 | `stories-wave-tick.js`           | Ready-set planner for multi-Story `/deliver` (shared `selectReadySet` core; default concurrency 3). |

--- a/tests/plan-critic-conditions.test.js
+++ b/tests/plan-critic-conditions.test.js
@@ -2,9 +2,9 @@
  * plan-critic-conditions.test.js — table-driven condition matrix for the
  * #4474 PR6 conditional-critic dispatch layer:
  *
- *   - consolidation (8.3): precondition AND (>5 stories OR confirmed
+ *   - consolidation: precondition AND (>5 stories OR confirmed
  *     divergence) — a fail-open precondition on a small draft skips;
- *   - pre-mortem (8.5): ticket count ≥ ½ maxTickets, OR a
+ *   - pre-mortem: ticket count ≥ ½ maxTickets, OR a
  *     planning.riskHeuristics phrase match (case-insensitive). Story #4542
  *     retired the third condition — the authored risk verdict's overall level —
  *     with the verdict itself, so both surviving conditions read the plan's own

--- a/tests/plan-critics-workflow.test.js
+++ b/tests/plan-critics-workflow.test.js
@@ -1,27 +1,44 @@
 /**
- * v2 Stage 3 planning-fork cutover guards.
+ * plan-critics-workflow.test.js — the /plan critic contract, both halves.
  *
- * The deleted `helpers/plan-epic.md` workflow used to host fresh-context
- * planning critics. Stage 3 collapses `/plan` to one `plan.md` path and
- * removes that fork. These structural assertions make sure the old critic
- * dispatch surface does not reappear through stale prose while the single
- * deterministic persist gate remains documented.
+ * Structural half: the deleted `helpers/plan-epic.md` workflow used to host
+ * the planning critics; Stage 3 collapsed `/plan` to one `plan.md` path and
+ * removed that fork. These assertions keep the old helper surface from
+ * reappearing through stale prose.
+ *
+ * Live half (Story #4592): the critic step is real again, and it sits between
+ * Author and Persist — the last point where a finding can be folded into a
+ * re-author round instead of into live issues. The `plan-critics.js` CLI is
+ * the single evaluation point; persist no longer evaluates critics at all.
  */
 
 import assert from 'node:assert/strict';
-import { readFileSync } from 'node:fs';
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
 import path from 'node:path';
-import { describe, it } from 'node:test';
+import { after, before, describe, it } from 'node:test';
 import { fileURLToPath } from 'node:url';
+
+import {
+  evaluateCriticArtifacts,
+  loadCriticArtifacts,
+  PLAN_CRITICS_CLI,
+} from '../.agents/scripts/plan-critics.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const REPO_ROOT = path.resolve(__dirname, '..');
+const CLI_PATH = path.join(REPO_ROOT, '.agents', 'scripts', 'plan-critics.js');
 
-const planSource = readFileSync(
-  path.join(REPO_ROOT, '.agents', 'workflows', 'plan.md'),
-  'utf8',
-);
+const planSource = readWorkflow();
+
+function readWorkflow() {
+  return fs.readFileSync(
+    path.join(REPO_ROOT, '.agents', 'workflows', 'plan.md'),
+    'utf8',
+  );
+}
 
 function section(headingPattern) {
   return (
@@ -31,7 +48,23 @@ function section(headingPattern) {
   );
 }
 
-describe('/plan critic workflow cutover — retired helper surface', () => {
+/** A draft Story with no `depends_on`. */
+function story(slug) {
+  return { slug, depends_on: [], body: `## Goal\n${slug}.` };
+}
+
+/** A `## Delivery Slicing` table matching `stories` 1:1 (all independent). */
+function slicingTableFor(stories) {
+  return [
+    '## Delivery Slicing',
+    '',
+    '| Slice | What ships | Independent? |',
+    '| --- | --- | --- |',
+    ...stories.map((s) => `| ${s.slug} | ships ${s.slug} | Yes |`),
+  ].join('\n');
+}
+
+describe('/plan critic workflow — retired helper surface stays gone', () => {
   it('uses plan.md as the sole planning workflow source', () => {
     assert.match(planSource, /Single planning path/i);
     assert.match(planSource, /no\s*\n?Epic\/Story router/i);
@@ -48,41 +81,265 @@ describe('/plan critic workflow cutover — retired helper surface', () => {
     }
   });
 
-  it('does not wire the retired fresh-context critic sub-agent section', () => {
-    assert.doesNotMatch(planSource, /Conditional critics/i);
-    assert.doesNotMatch(planSource, /fresh-context sub-agents/i);
+  it('does not resurrect the retired epic-scoped critic sub-agents', () => {
     assert.doesNotMatch(planSource, /epic-plan-premortem/);
     assert.doesNotMatch(planSource, /epic-plan-consolidate/);
-    assert.doesNotMatch(planSource, /plan-critics\.js/);
   });
 });
 
-describe('/plan critic workflow cutover — deterministic persist gate remains', () => {
-  const author = section('### 2\\. Author');
-  const persist = section('### 3\\. Persist');
+describe('/plan critic workflow — the live pre-persist critic step (#4592)', () => {
+  it('runs the plan-critics.js CLI as a real workflow step', () => {
+    assert.match(planSource, /node \.agents\/scripts\/plan-critics\.js/);
+  });
 
-  it('keeps authoring on stories.json and the default-single split policy', () => {
-    assert.ok(author, 'plan.md must carry the author step');
-    assert.match(author, /`stories\.json`/);
-    assert.match(author, /\*\*length 1 by default\*\*/i);
-    assert.match(author, /Split only under the\s*\n?policy above/i);
+  it('sites the critic step between the Author and Persist sections', () => {
+    const authorIdx = planSource.indexOf('### 2. Author');
+    const criticIdx = planSource.indexOf('### 2.5 Critics');
+    const persistIdx = planSource.indexOf('### 3. Persist');
+
+    assert.ok(authorIdx > -1, 'plan.md must carry the author step');
+    assert.ok(criticIdx > -1, 'plan.md must carry the critic step');
+    assert.ok(persistIdx > -1, 'plan.md must carry the persist step');
+    assert.ok(
+      authorIdx < criticIdx && criticIdx < persistIdx,
+      'the critic step must sit between Author and Persist — after persist ' +
+        'there is no re-author loop for a dispatch verdict to route to.',
+    );
+  });
+
+  it('routes a dispatch verdict to a maker-blind fresh-context sub-agent', () => {
+    const critics = section('### 2\\.5 Critics');
+    assert.match(critics, /dispatch/);
+    assert.match(critics, /maker-blind/i);
+    assert.match(critics, /never the authoring\s*\n?\s*transcript/i);
+    // Advisory, not a mechanical gate: the CLI always exits 0.
+    assert.match(critics, /always exits 0/i);
+  });
+});
+
+describe('/plan critic workflow — persist no longer evaluates critics', () => {
+  const persistSource = fs.readFileSync(
+    path.join(
+      REPO_ROOT,
+      '.agents',
+      'scripts',
+      'lib',
+      'orchestration',
+      'plan-persist',
+      'run-plan-persist.js',
+    ),
+    'utf8',
+  );
+
+  it('has no evaluatePlanCritics call left in the persist pipeline', () => {
+    assert.doesNotMatch(persistSource, /evaluatePlanCritics/);
   });
 
   it('keeps the --force-review gate #2 before plan-persist writes', () => {
-    // Story #4542 retired the risk-derived review routing: `--force-review`
-    // is the only thing that raises gate #2 now.
-    assert.ok(persist, 'plan.md must carry the persist step');
+    const persist = section('### 3\\. Persist');
     assert.match(persist, /\*\*Gate #2\*\*/);
     assert.match(persist, /`--force-review`/);
     assert.match(persist, /before persist/i);
-    assert.doesNotMatch(persist, /risk routing/i);
     assert.match(persist, /node \.agents\/scripts\/plan-persist\.js/);
   });
+});
 
-  it('keeps deterministic gates fail-closed under --yes', () => {
-    assert.match(
-      planSource,
-      /Deterministic gates[\s\S]*still fail closed under `--yes`/i,
+describe('plan-critics.js CLI — verdict contract', () => {
+  let fixtureDir;
+
+  /** Run the CLI against a fixture, isolated onto its own temp ledger root. */
+  function runCli(args) {
+    return spawnSync(process.execPath, [CLI_PATH, ...args], {
+      encoding: 'utf8',
+      cwd: REPO_ROOT,
+      env: { ...process.env, AP_AGENTRC_CWD: fixtureDir, CI: '1' },
+      timeout: 20_000,
+    });
+  }
+
+  function writeFixture(name, contents) {
+    const filePath = path.join(fixtureDir, name);
+    fs.writeFileSync(
+      filePath,
+      typeof contents === 'string' ? contents : JSON.stringify(contents),
+    );
+    return filePath;
+  }
+
+  before(() => {
+    fixtureDir = fs.mkdtempSync(path.join(os.tmpdir(), 'plan-critics-'));
+    // An absolute tempRoot inside the fixture dir keeps every ledger write
+    // this suite makes out of the real checkout's temp/ (the shared-cache
+    // poisoning class that blocked Story #4555).
+    fs.writeFileSync(
+      path.join(fixtureDir, '.agentrc.json'),
+      JSON.stringify({
+        project: {
+          paths: {
+            agentRoot: '.agents',
+            docsRoot: 'docs',
+            tempRoot: path.join(fixtureDir, 'temp'),
+          },
+        },
+      }),
+    );
+  });
+
+  after(() => {
+    if (fixtureDir) fs.rmSync(fixtureDir, { recursive: true, force: true });
+  });
+
+  it('prints a pure-JSON verdict on stdout and exits 0', () => {
+    const storiesPath = writeFixture('stories-dispatch.json', [
+      story('s1'),
+      story('s2'),
+      story('s3'),
+      story('s4'),
+      story('s5'),
+      story('s6'),
+    ]);
+
+    const res = runCli(['--stories', storiesPath]);
+
+    assert.equal(res.status, 0, `stderr=${res.stderr}`);
+    // Pure JSON: no interleaved log lines. A headless caller parses stdout
+    // unconditionally, so this must not need stripping.
+    const verdict = JSON.parse(res.stdout);
+    assert.equal(typeof verdict.consolidation.dispatch, 'boolean');
+    assert.equal(typeof verdict.premortem.dispatch, 'boolean');
+    assert.ok(Array.isArray(verdict.consolidation.reasons));
+    assert.ok(Array.isArray(verdict.premortem.reasons));
+    assert.ok(verdict.consolidation.reasons.length > 0);
+  });
+
+  it('fires consolidation on a draft above the story threshold', () => {
+    const storiesPath = writeFixture('stories-over.json', [
+      story('s1'),
+      story('s2'),
+      story('s3'),
+      story('s4'),
+      story('s5'),
+      story('s6'),
+    ]);
+
+    const verdict = JSON.parse(runCli(['--stories', storiesPath]).stdout);
+
+    assert.equal(verdict.consolidation.dispatch, true);
+    assert.match(verdict.consolidation.reasons.join(' '), /6 stories/);
+  });
+
+  it('skips consolidation on a small draft matching its slicing table', () => {
+    const draft = [story('only-slice')];
+    const storiesPath = writeFixture('stories-match.json', draft);
+    const techSpecPath = writeFixture('techspec.md', slicingTableFor(draft));
+
+    const res = runCli(['--stories', storiesPath, '--tech-spec', techSpecPath]);
+    const verdict = JSON.parse(res.stdout);
+
+    assert.equal(res.status, 0, `stderr=${res.stderr}`);
+    assert.equal(verdict.consolidation.dispatch, false);
+    assert.equal(verdict.premortem.dispatch, false);
+    assert.match(verdict.consolidation.reasons.join(' '), /1:1/);
+  });
+
+  it('exits non-zero on a missing --stories flag', () => {
+    const res = runCli([]);
+    assert.notEqual(res.status, 0);
+    assert.match(res.stderr, /--stories/);
+  });
+});
+
+describe('plan-critics.js — artifact loading + skip ledger', () => {
+  let dir;
+
+  before(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'plan-critics-unit-'));
+  });
+
+  after(() => {
+    if (dir) fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  function write(name, contents) {
+    const filePath = path.join(dir, name);
+    fs.writeFileSync(
+      filePath,
+      typeof contents === 'string' ? contents : JSON.stringify(contents),
+    );
+    return filePath;
+  }
+
+  it('loads stories with an absent tech spec as empty spec text', async () => {
+    const storiesPath = write('stories.json', [story('a')]);
+    const loaded = await loadCriticArtifacts({ storiesPath });
+
+    assert.equal(loaded.tickets.length, 1);
+    assert.equal(loaded.techSpecContent, '');
+  });
+
+  it('rejects a stories file that is not a JSON array', async () => {
+    const storiesPath = write('object.json', { slug: 'not-an-array' });
+
+    await assert.rejects(() => loadCriticArtifacts({ storiesPath }), {
+      message: /must contain a JSON array/,
+    });
+  });
+
+  it('rejects an unparseable stories file naming the path', async () => {
+    const storiesPath = write('broken.json', '{ not json');
+
+    await assert.rejects(() => loadCriticArtifacts({ storiesPath }), {
+      message: /Failed to parse .*broken\.json.* as JSON/,
+    });
+  });
+
+  it('records every skipped critic on the ledger under the CLI name', async () => {
+    const draft = [story('solo')];
+    const storiesPath = write('match-stories.json', draft);
+    const techSpecPath = write('match-spec.md', slicingTableFor(draft));
+    const appended = [];
+
+    const verdict = await evaluateCriticArtifacts({
+      storiesPath,
+      techSpecPath,
+      config: {},
+      append: async (entry) => {
+        appended.push(entry);
+        return true;
+      },
+    });
+
+    assert.equal(verdict.consolidation.dispatch, false);
+    assert.equal(verdict.premortem.dispatch, false);
+    assert.deepEqual(
+      appended.map((e) => e.critic),
+      ['consolidation', 'pre-mortem'],
+    );
+    for (const entry of appended) {
+      assert.equal(entry.cli, PLAN_CRITICS_CLI);
+      assert.ok(entry.reasons.length > 0);
+    }
+  });
+
+  it('records no skip for a critic that fires', async () => {
+    const storiesPath = write('risky-stories.json', [story('a')]);
+    const appended = [];
+
+    const verdict = await evaluateCriticArtifacts({
+      storiesPath,
+      // A risk-heuristic phrase match is the pre-mortem's other condition;
+      // the absent slicing table fails the consolidation precondition open.
+      config: { planning: { riskHeuristics: ['## Goal'] } },
+      append: async (entry) => {
+        appended.push(entry);
+        return true;
+      },
+    });
+
+    assert.equal(verdict.premortem.dispatch, true);
+    assert.equal(
+      appended.some((e) => e.critic === 'pre-mortem'),
+      false,
     );
   });
 });

--- a/tests/scripts/plan-persist.flat-stories.test.js
+++ b/tests/scripts/plan-persist.flat-stories.test.js
@@ -650,8 +650,13 @@ describe('runPlanPersist — flat Story ops', () => {
         `plan-metrics line missing from summary:\n${summary.body}`,
       );
       // This run's own critic skips ARE counted — the line describes work
-      // that just happened, which is the point.
-      assert.match(line, /3 critic skip/);
+      // that just happened, which is the point. Reachability is the only
+      // skip persist still records: Story #4592 moved the consolidation +
+      // pre-mortem evaluation out to the `plan-critics.js` CLI, which runs
+      // between Author and Persist where a dispatch verdict still has a
+      // re-author loop to route to.
+      assert.match(line, /1 critic skip/);
+      assert.match(line, /reachability ×1/);
       // The run being summarized counts itself. `recordPlanInvocation`
       // appends its record in a `finally` that fires only once runPlanPersist
       // resolves — long after this comment body is composed — so reading the


### PR DESCRIPTION
Closes #4592

_Auto-opened by `/deliver`._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when and how `/plan` routes optional critic work relative to persist, but verdict logic is unchanged and the step remains advisory (non-blocking exit 0); regression risk is mainly workflow integration and metrics attribution.
> 
> **Overview**
> Moves **consolidation** and **pre-mortem** critic dispatch out of `run-plan-persist.js` into a new **`plan-critics.js`** CLI so `/plan` can act on verdicts before GitHub writes.
> 
> **`/plan` step 2.5 (Critics)** runs between Author and Persist: the CLI loads draft `stories.json` (and optional `techspec.md`), evaluates the same #4474 PR6 conditions via `evaluatePlanCritics`, prints a **pure JSON verdict on stdout** (always exit 0), and records each `dispatch: false` skip on the plan-metrics ledger as `cli: plan-critics`. When either critic fires, the workflow dispatches maker-blind fresh-context sub-agents and may re-author before persist.
> 
> **Persist** no longer calls `evaluatePlanCritics` or returns `critics` from `runPlanPersist`; only **reachability** skips are still ledgered there. Docs (`plan.md`, `architecture.md`) and module comments now describe this single evaluation point.
> 
> Tests lock the workflow ordering, CLI contract, artifact loading, skip ledger behavior, and the updated plan-summary critic-skip line (1 reachability skip vs 3).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2d50751aa96418927aa247836b275516bade2c71. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->