### PR TITLE
fix: fix probe mode's incomplete live classification: double-dispatch window and blocked-Story wedge (#4601)

### DIFF
--- a/.agents/scripts/lib/wave-runner/live-probe.js
+++ b/.agents/scripts/lib/wave-runner/live-probe.js
@@ -22,7 +22,18 @@
  *     cross-run delivery work: a blocker that merged weeks ago in another run
  *     is simply done.
  *   - **in-flight** — derived from live `agent::executing` / `agent::closing`
- *     labels rather than a `--in-flight <n>` the caller incremented.
+ *     labels, **unioned with the ids the host says it has dispatched**
+ *     (`--dispatched`). The label alone is not sufficient: the kernel's
+ *     contract counts "executing / closing / dispatched-not-yet-labelled" as
+ *     in-flight, and `single-story-init.js` flips `agent::executing` at step 6
+ *     of 6 — *after* a 3–6 minute worktree install. For that whole window a
+ *     dispatched Story still reads `agent::ready`, so a label-only derivation
+ *     re-emits it in the next beat's `ready[]` and the host dispatches it a
+ *     second time onto the same branch and worktree (Story #4601).
+ *   - **blocked** — the ids carrying `agent::blocked`. `classifyStory` has
+ *     always returned this class; nothing consumed it, so a blocked Story was
+ *     neither done, ready, nor in-flight and the beat reported a permanent
+ *     "waiting" (Story #4601).
  *
  * It is an **adapter, not a kernel change**: it gathers inputs and hands them
  * to `selectReadySet` unchanged. The kernel stays pure and flag-driven, and
@@ -43,24 +54,79 @@ import {
   resolveForeignDone,
   resolveStoriesProvider,
 } from '../../resolve-stories.js';
+import { AGENT_LABELS } from '../label-constants.js';
 import { buildStoriesEnvelope } from '../orchestration/resolve-stories.js';
-import { classifyStory } from './ready-set.js';
+import { classifyStory, storyIdOf } from './ready-set.js';
 
 /**
- * Count the Stories that currently occupy a dispatch slot.
+ * Identify the Stories that currently occupy a dispatch slot, as an id set.
  *
- * `classifyStory` folds `agent::executing` and `agent::closing` into one
- * `executing` class — both are in-flight, and neither may be re-dispatched.
- * Deriving this from live labels (rather than a caller-maintained counter) is
- * the whole point of probe mode: a host that miscounts a slot either
- * over-dispatches past the cap or starves the run.
+ * Two sources, unioned — which is exactly the kernel's stated contract
+ * ("executing / closing / dispatched-not-yet-labelled"):
  *
- * @param {Array<{labels?: string[], state?: string}>} storyRecords
- * @returns {number}
+ *   1. **Live labels.** `classifyStory` folds `agent::executing` and
+ *      `agent::closing` into one `executing` class — both are in-flight and
+ *      neither may be re-dispatched.
+ *   2. **`dispatched`** — ids the host has spawned. This closes the init
+ *      window: `single-story-init.js` flips `agent::executing` last, after a
+ *      3–6 minute install, so between spawn and flip a dispatched Story reads
+ *      `agent::ready` and a label-only derivation hands it back as ready.
+ *
+ * `dispatched` is deliberately **not** the `--done`-style accounting probe
+ * mode retired. Three properties keep it from becoming one:
+ *
+ *   - **It is a set union, not a counter.** Re-passing an id that has since
+ *     picked up its `agent::executing` label cannot double-count a slot.
+ *   - **Live state overrules the claim.** An id the host still lists but that
+ *     now classifies `done` (or `blocked`) is dropped, so a stale entry can
+ *     never occupy a slot forever and starve the run.
+ *   - **Therefore the host's correct strategy is monotonic append**: pass
+ *     every id you have dispatched this run and never reason about removing
+ *     one. There is no drop-a-slot decision to get wrong — the probe subtracts
+ *     reality from the claim. Forgetting an id degrades to the pre-#4601
+ *     behaviour rather than to something worse.
+ *
+ * Ids outside the probed set are ignored: they are not part of this run and
+ * must not consume its cap.
+ *
+ * @param {Array<{id?: number, number?: number, labels?: string[], state?: string}>} storyRecords
+ * @param {Iterable<number>} [dispatched] Ids the host has spawned.
+ * @returns {Set<number>} In-flight Story ids.
  */
-function deriveInFlight(storyRecords) {
-  return storyRecords.filter((rec) => classifyStory(rec) === 'executing')
-    .length;
+export function deriveInFlightIds(storyRecords, dispatched = []) {
+  const claimed = new Set(dispatched);
+  const inFlight = new Set();
+  for (const rec of storyRecords) {
+    const id = storyIdOf(rec);
+    if (id === null) continue;
+    const cls = classifyStory(rec);
+    if (cls === 'executing' || (claimed.has(id) && cls === 'ready')) {
+      inFlight.add(id);
+    }
+  }
+  return inFlight;
+}
+
+/**
+ * The ids carrying `agent::blocked`.
+ *
+ * `classifyStory` has always returned a `blocked` class, but no adapter
+ * consumed it: a blocked Story was never done, never ready, and never counted
+ * in-flight, so `detectWedge` dropped it (its "undone work with no unmet
+ * blockers would have been dispatched" invariant is precisely what probe mode
+ * broke) and the beat reported exit 0 / `ready: []` / `wedged: null` forever.
+ * `/deliver` reads that as "waiting", so the `agent::blocked` HITL pause — the
+ * one runtime gate in the protocol — was never surfaced to the operator.
+ *
+ * @param {Array<{id?: number, number?: number, labels?: string[], state?: string}>} storyRecords
+ * @returns {number[]} Blocked Story ids, ascending.
+ */
+export function deriveBlockedIds(storyRecords) {
+  return storyRecords
+    .filter((rec) => classifyStory(rec) === 'blocked')
+    .map((rec) => storyIdOf(rec))
+    .filter((id) => id !== null)
+    .sort((a, b) => a - b);
 }
 
 /**
@@ -97,6 +163,8 @@ export function createProbeContext({
  * @param {string} [args.owner]
  * @param {string} [args.repo]
  * @param {boolean} [args.native=true]   Read native `blocked_by` edges.
+ * @param {number[]} [args.dispatched=[]] Ids the host has spawned but may not
+ *   yet have observed labelled `agent::executing` (see `deriveInFlightIds`).
  * @param {(msg: string) => void} [args.warn]
  * Each returned node carries its **live labels**. That is load-bearing, not
  * decoration: `selectReadySet` classifies from labels, so a node stripped of
@@ -108,7 +176,8 @@ export function createProbeContext({
  * @returns {Promise<{
  *   nodes: Array<{id: number, dependsOn: number[], files: string[], labels: string[]}>,
  *   doneIds: Set<number>,
- *   inFlight: number
+ *   inFlight: number,
+ *   blockedIds: number[]
  * }>}
  */
 export async function probeLiveState({
@@ -117,6 +186,7 @@ export async function probeLiveState({
   owner,
   repo,
   native = true,
+  dispatched = [],
   warn,
 }) {
   const stories = await fetchStories(provider, ids);
@@ -138,14 +208,49 @@ export async function probeLiveState({
   });
 
   const labelsById = new Map(stories.map((s) => [s.id, s.labels ?? []]));
+  const inFlightIds = deriveInFlightIds(stories, dispatched);
   return {
     nodes: envelope.dag.map((node) => ({
       ...node,
-      labels: labelsById.get(node.id) ?? [],
+      labels: projectInFlightLabels(
+        labelsById.get(node.id) ?? [],
+        inFlightIds.has(node.id),
+      ),
     })),
     doneIds: new Set(envelope.done),
-    inFlight: deriveInFlight(stories),
+    inFlight: inFlightIds.size,
+    blockedIds: deriveBlockedIds(stories),
   };
+}
+
+/**
+ * Project the in-flight fact onto a node's labels, synthesizing
+ * `agent::executing` for a Story that is dispatched but not yet labelled.
+ *
+ * This is the load-bearing half of the dispatch-window fix, and it is why
+ * `inFlight` alone is not enough. The two inputs do **different** jobs inside
+ * `selectReadySet`:
+ *
+ *   - `inFlight` is only a **count**. It reserves capacity (`slots = cap −
+ *     inFlight`) and nothing more.
+ *   - **Eligibility is decided per-record by `classifyStory`**, from labels.
+ *
+ * So a dispatched-but-unlabelled Story counted only via `inFlight` still
+ * classifies `ready`, stays eligible, and — whenever a slot remains — is
+ * admitted to the very same beat that reserved a slot for it. It would be
+ * re-dispatched onto its own live branch, with the miscount merely reshaped
+ * rather than fixed. Handing the kernel the label makes it apply the rule it
+ * already has, and keeps the kernel itself untouched: the adapter's job is to
+ * supply the input the kernel's contract ("executing / closing / dispatched-
+ * not-yet-labelled") already specifies.
+ *
+ * @param {string[]} labels    The Story's live labels.
+ * @param {boolean} inFlight   Whether the Story occupies a dispatch slot.
+ * @returns {string[]} Labels, with `agent::executing` added when needed.
+ */
+function projectInFlightLabels(labels, inFlight) {
+  if (!inFlight || classifyStory({ labels }) === 'executing') return labels;
+  return [...labels, AGENT_LABELS.EXECUTING];
 }
 
 /**
@@ -157,6 +262,13 @@ export async function probeLiveState({
  * silently reintroduce the hand-maintained accounting probe mode exists to
  * retire — and quietly disagree with reality when the two differ.
  *
+ * `--dispatched` is the deliberate exception, and it is **additive rather than
+ * authoritative**: it does not replace the derived in-flight set, it is unioned
+ * into it and then filtered by live state (see `deriveInFlightIds`). It carries
+ * the one fact the host knows and GitHub does not yet — "I spawned this id, the
+ * label has not appeared yet" — so it cannot disagree with reality the way an
+ * authoritative `--in-flight <n>` could. `--in-flight` therefore stays excluded.
+ *
  * @param {object} flags
  * @param {boolean} [flags.probeLive]
  * @param {string} [flags.stories]
@@ -164,6 +276,7 @@ export async function probeLiveState({
  * @param {string} [flags.dagFile]
  * @param {string} [flags.done]
  * @param {string} [flags.inFlight]
+ * @param {string} [flags.dispatched]
  * @returns {string|null} An error message, or `null` when the flags are valid.
  */
 export function validateProbeFlags({
@@ -173,8 +286,12 @@ export function validateProbeFlags({
   dagFile,
   done,
   inFlight,
+  dispatched,
 } = {}) {
   if (!probeLive) {
+    if (dispatched != null) {
+      return '--dispatched requires --probe-live (it augments the live-derived in-flight set; flag mode uses --in-flight <n>)';
+    }
     return stories
       ? '--stories requires --probe-live (it names the run to probe from live state)'
       : null;

--- a/.agents/scripts/lib/wave-runner/live-probe.js
+++ b/.agents/scripts/lib/wave-runner/live-probe.js
@@ -93,7 +93,7 @@ import { classifyStory, storyIdOf } from './ready-set.js';
  * @param {Iterable<number>} [dispatched] Ids the host has spawned.
  * @returns {Set<number>} In-flight Story ids.
  */
-export function deriveInFlightIds(storyRecords, dispatched = []) {
+function deriveInFlightIds(storyRecords, dispatched = []) {
   const claimed = new Set(dispatched);
   const inFlight = new Set();
   for (const rec of storyRecords) {
@@ -121,7 +121,7 @@ export function deriveInFlightIds(storyRecords, dispatched = []) {
  * @param {Array<{id?: number, number?: number, labels?: string[], state?: string}>} storyRecords
  * @returns {number[]} Blocked Story ids, ascending.
  */
-export function deriveBlockedIds(storyRecords) {
+function deriveBlockedIds(storyRecords) {
   return storyRecords
     .filter((rec) => classifyStory(rec) === 'blocked')
     .map((rec) => storyIdOf(rec))

--- a/.agents/scripts/stories-wave-tick.js
+++ b/.agents/scripts/stories-wave-tick.js
@@ -20,13 +20,15 @@
  *
  * **Two modes, one kernel.**
  *
- *   - **Probe mode** (`--stories <csv> --probe-live`) is the canonical
- *     `/deliver` beat: the graph, the done set, and the in-flight count are
- *     resolved from **live state** via `lib/wave-runner/live-probe.js`. The
- *     caller supplies ids and nothing else, so there is no accounting to
- *     hand-maintain across beats — the seed-the-first-beat's-`--done` footgun
- *     the workflow used to warn about is now structurally impossible rather
- *     than merely documented.
+ *   - **Probe mode** (`--stories <csv> --probe-live [--dispatched <csv>]`) is
+ *     the canonical `/deliver` beat: the graph, the done set, and the in-flight
+ *     count are resolved from **live state** via `lib/wave-runner/live-probe.js`.
+ *     The caller supplies ids, so there is no accounting to hand-maintain
+ *     across beats — the seed-the-first-beat's-`--done` footgun the workflow
+ *     used to warn about is structurally impossible rather than merely
+ *     documented. `--dispatched` is the one fact live state cannot yet report
+ *     ("I spawned this id; its label has not appeared"); it is additive and
+ *     live-state-filtered, never authoritative (Story #4601).
  *   - **Flag mode** (`--dag`/`--dag-file` + `--done`/`--in-flight`) keeps the
  *     caller-supplied contract byte-compatible for tests and hand-driven
  *     runs. The two are mutually exclusive: honouring a supplied `--done`
@@ -55,10 +57,12 @@
  *     wedged: { reason, stories: [{ id, unmetBlockers }] } | null
  *   }
  *
- * Probe mode adds two fields the caller can no longer compute for itself:
+ * Probe mode adds fields the caller can no longer compute for itself:
  * `done: number[]` (the resolved done set, in-set ∪ satisfied foreign
- * blockers) and `epilogueDue: boolean` (true exactly when every listed Story
- * is done — the run-end signal for `plan-run-epilogue.js`).
+ * blockers), `epilogueDue: boolean` (true exactly when every listed Story
+ * is done — the run-end signal for `plan-run-epilogue.js`), and `blocked:
+ * number[]` + `blockedReason: string|null` (Story #4601 — the `agent::blocked`
+ * HITL pause, which ends the loop rather than being polled).
  *
  * The standalone loop calls this once per beat and dispatches the returned
  * `ready` set (already capped at `concurrencyCap − inFlight` by the core).
@@ -77,11 +81,15 @@
  *
  * Exit codes: 0 ok · 1 input error · 2 dependency cycle (`cycleError`) ·
  * 3 wedged (`wedged`) — ready is empty, nothing is in flight, and undone
- * Stories are waiting on blockers that are not done. A cycle is a
- * self-referential DAG the operator must fix; a wedge is a well-formed DAG
- * whose gates cannot be satisfied from the supplied `--done` set (usually a
- * blocker outside the delivered set that has not landed). Both are distinct
- * from the ordinary `ready: []` that means "waiting on in-flight work".
+ * Stories are waiting on blockers that are not done · 4 blocked (`blocked`) —
+ * a Story carries `agent::blocked`. A cycle is a self-referential DAG the
+ * operator must fix; a wedge is a well-formed DAG whose gates cannot be
+ * satisfied from the supplied `--done` set (usually a blocker outside the
+ * delivered set that has not landed); a block is the protocol's HITL pause,
+ * where a human owes a decision no beat can supply. All three are distinct
+ * from the ordinary `ready: []` that means "waiting on in-flight work" — and
+ * that distinction is the point: each of them previously presented AS that
+ * ordinary empty set, so the loop polled a state that could never improve.
  */
 
 import { readFileSync } from 'node:fs';
@@ -108,8 +116,18 @@ import { selectReadySet } from './lib/wave-runner/ready-set.js';
  */
 export const WEDGED_EXIT_CODE = 3;
 
+/**
+ * Exit code for a run holding an `agent::blocked` Story — distinct from the
+ * cycle (2) and wedge (3) exits because the remediation is categorically
+ * different: a cycle is a malformed DAG and a wedge is an unlanded blocker,
+ * whereas this is the protocol's one runtime HITL pause. A human must decide
+ * something before any beat can help. Probe-mode only: flag-mode nodes carry
+ * no labels, so nothing there can classify blocked.
+ */
+export const BLOCKED_EXIT_CODE = 4;
+
 const HELP = `Usage:
-  node .agents/scripts/stories-wave-tick.js --stories <csv> --probe-live [--concurrency <n>]
+  node .agents/scripts/stories-wave-tick.js --stories <csv> --probe-live [--dispatched <csv>] [--concurrency <n>]
   node .agents/scripts/stories-wave-tick.js --dag '<json>' | --dag-file <path> [--concurrency <n>] [--done <csv>] [--in-flight <n>]
 
 Continuous ready-set planner for standalone Story delivery. Emits the set of
@@ -137,6 +155,15 @@ Options:
                      set, and the in-flight count are resolved from live
                      state — no --done / --in-flight bookkeeping.
   --probe-live       Enable probe mode. Requires --stories.
+  --dispatched <csv> Probe mode only. Ids you have SPAWNED this run. Unioned
+                     into the live-derived in-flight set, then filtered by
+                     live state, so it closes the init window: a Story reads
+                     agent::ready for the 3-6 minutes single-story-init.js
+                     takes to flip agent::executing, and without this it is
+                     dispatched a second time onto the same branch. Append
+                     every id you dispatch and never remove one — a stale id
+                     that has since gone done is dropped automatically, so
+                     over-supplying is free and forgetting is the only error.
   --concurrency <n>  Override the per-beat concurrency cap for this run only.
                      Must be a positive integer. When omitted, the cap is
                      resolved from delivery.deliverRunner.concurrencyCap in
@@ -166,6 +193,8 @@ Exit codes:
   3 - Wedged: ready is empty, nothing is in flight, and undone Stories are
       waiting on blockers that are not done. Distinct from an ordinary empty
       ready set (which means "waiting on in-flight work") and from a cycle.
+  4 - Blocked: a Story carries agent::blocked (probe mode only). The HITL
+      pause — no beat can clear it. STOP the loop; do not poll.
 `;
 
 /**
@@ -265,15 +294,16 @@ export function parseDag(raw) {
 }
 
 /**
- * Parse a comma-separated `--done` list of Story IDs into a deduped set of
- * positive integers. Empty / absent input yields an empty set. Rejects any
- * token that is not a positive integer so a typo never silently drops a
- * dependency gate.
+ * Parse a comma-separated list of Story IDs into a deduped set of positive
+ * integers. Empty / absent input yields an empty set. Rejects any token that
+ * is not a positive integer so a typo never silently drops a dependency gate
+ * (`--done`) or a held dispatch slot (`--dispatched`).
  *
  * @param {string|undefined} raw
+ * @param {string} flag Flag name, for the error message.
  * @returns {{ ids: Set<number>|null, error: string|null }}
  */
-export function parseDoneIds(raw) {
+export function parseIdCsv(raw, flag) {
   if (raw == null || raw === '') {
     return { ids: new Set(), error: null };
   }
@@ -285,12 +315,22 @@ export function parseDoneIds(raw) {
     if (!Number.isInteger(num) || num <= 0) {
       return {
         ids: null,
-        error: `--done must be a comma-separated list of positive integers, got "${trimmed}"`,
+        error: `${flag} must be a comma-separated list of positive integers, got "${trimmed}"`,
       };
     }
     ids.add(num);
   }
   return { ids, error: null };
+}
+
+/**
+ * Parse the `--done` CSV of already-completed Story IDs (flag mode).
+ *
+ * @param {string|undefined} raw
+ * @returns {{ ids: Set<number>|null, error: string|null }}
+ */
+export function parseDoneIds(raw) {
+  return parseIdCsv(raw, '--done');
 }
 
 /**
@@ -616,15 +656,19 @@ export function runStoriesWaveTick({
  * which is what makes the `/deliver` loop's old seed-the-first-beat footgun
  * structurally impossible instead of merely documented.
  *
- * The envelope is the flag mode's, plus two probe-only fields the caller can
+ * The envelope is the flag mode's, plus three probe-only fields the caller can
  * no longer compute for itself:
  *   - `done` — the resolved done set (in-set ∪ satisfied foreign blockers).
  *   - `epilogueDue` — true exactly when every listed Story is done, which is
  *     the run-end signal for `plan-run-epilogue.js`.
+ *   - `blocked` — ids carrying `agent::blocked` (Story #4601). Non-empty means
+ *     the loop must END, not poll: see `BLOCKED_EXIT_CODE`.
  *
  * @param {object} args
  * @param {string} args.stories        Raw `--stories` CSV of Story ids.
  * @param {string|number} [args.concurrency] Raw `--concurrency` override.
+ * @param {string} [args.dispatched]   Raw `--dispatched` CSV of ids the host
+ *   has spawned but may not yet have observed labelled.
  * @param {string} [args.cwd]          Repo root for config resolution.
  * @param {object} [args.config]       Pre-resolved config (test injection).
  * @param {Function} [args.probe]      Probe seam (test injection).
@@ -634,6 +678,7 @@ export function runStoriesWaveTick({
 export async function runProbedStoriesWaveTick({
   stories,
   concurrency,
+  dispatched,
   cwd,
   config,
   probe = probeLiveState,
@@ -652,6 +697,14 @@ export async function runProbedStoriesWaveTick({
     return inputErrorResult(err.message);
   }
 
+  const { ids: dispatchedIds, error: dispatchedError } = parseIdCsv(
+    dispatched,
+    '--dispatched',
+  );
+  if (dispatchedError) {
+    return inputErrorResult(dispatchedError);
+  }
+
   const concurrencyCap = resolveConcurrencyCap({ cwd, config, override });
 
   let probed;
@@ -662,6 +715,7 @@ export async function runProbedStoriesWaveTick({
       provider,
       owner,
       repo,
+      dispatched: [...dispatchedIds],
       warn: (m) => Logger.warn(m),
     });
   } catch (err) {
@@ -674,7 +728,7 @@ export async function runProbedStoriesWaveTick({
     );
   }
 
-  const { nodes, doneIds, inFlight } = probed;
+  const { nodes, doneIds, inFlight, blockedIds = [] } = probed;
   const { envelope, exitCode } = buildReadySetEnvelope(nodes, {
     concurrencyCap,
     doneIds,
@@ -684,7 +738,42 @@ export async function runProbedStoriesWaveTick({
   const done = [...doneIds].sort((a, b) => a - b);
   const epilogueDue =
     nodes.length > 0 && nodes.every((node) => doneIds.has(node.id));
-  return { envelope: { ...envelope, done, epilogueDue }, exitCode };
+  return {
+    envelope: {
+      ...envelope,
+      done,
+      epilogueDue,
+      blocked: blockedIds,
+      blockedReason: blockedReasonFor(blockedIds),
+    },
+    // A blocked Story outranks the scheduler's own verdict — including a
+    // wedge, whose named blockers are moot while a human owes a decision.
+    // A cycle (2) does not yield: a self-referential DAG is a planning error
+    // that must be fixed before any of this run's state means anything.
+    exitCode:
+      blockedIds.length > 0 && !envelope.cycleError
+        ? BLOCKED_EXIT_CODE
+        : exitCode,
+  };
+}
+
+/**
+ * Render the operator-facing reason for a blocked run, or `null` when nothing
+ * is blocked.
+ *
+ * @param {number[]} blockedIds
+ * @returns {string|null}
+ */
+function blockedReasonFor(blockedIds) {
+  if (blockedIds.length === 0) return null;
+  const list = blockedIds.map((id) => `#${id}`).join(', ');
+  return (
+    `${blockedIds.length} Story(ies) carry agent::blocked — ${list}. ` +
+    `agent::blocked is the protocol's HITL pause: no beat can clear it and ` +
+    `the loop must stop rather than poll. Read each Story's friction comment ` +
+    `(gh issue view <id> --comments), resolve the blocker, then flip it back ` +
+    `with: node .agents/scripts/update-ticket-state.js --ticket <id> --state agent::ready`
+  );
 }
 
 async function main(argv) {
@@ -695,6 +784,7 @@ async function main(argv) {
       'dag-file': { type: 'string' },
       stories: { type: 'string' },
       'probe-live': { type: 'boolean' },
+      dispatched: { type: 'string' },
       concurrency: { type: 'string' },
       done: { type: 'string' },
       'in-flight': { type: 'string' },
@@ -716,6 +806,7 @@ async function main(argv) {
     dagFile: values['dag-file'],
     done: values.done,
     inFlight: values['in-flight'],
+    dispatched: values.dispatched,
   });
 
   const { envelope, exitCode } = flagError
@@ -724,6 +815,7 @@ async function main(argv) {
       ? await runProbedStoriesWaveTick({
           stories: values.stories,
           concurrency: values.concurrency,
+          dispatched: values.dispatched,
         })
       : runStoriesWaveTick({
           dagJson: values.dag,
@@ -737,7 +829,13 @@ async function main(argv) {
 
   if (exitCode !== 0) {
     Logger.error(
-      `stories-wave-tick: ${envelope.inputError ?? envelope.cycleError ?? 'error'}`,
+      `stories-wave-tick: ${
+        envelope.inputError ??
+        envelope.cycleError ??
+        envelope.blockedReason ??
+        envelope.wedged?.reason ??
+        'error'
+      }`,
     );
     process.exitCode = exitCode;
   }

--- a/.agents/workflows/deliver.md
+++ b/.agents/workflows/deliver.md
@@ -85,16 +85,31 @@ to respect.
 
    ```bash
    node .agents/scripts/stories-wave-tick.js \
-     --stories <id,id,...> --probe-live --concurrency <n>
+     --stories <id,id,...> --probe-live --concurrency <n> \
+     --dispatched <every id you have dispatched so far>
    ```
 
-   **Pass the ids and nothing else.** Each beat re-probes live state: it
-   re-resolves the graph, classifies done (`agent::done` or a closed issue —
-   including foreign blockers that landed in another run), and derives the
-   in-flight count from live `agent::executing` / `agent::closing` labels.
-   You never compute `done` or `in-flight`, and there is nothing to carry
-   between beats — the accounting that used to be yours to maintain by hand
-   is now read from reality every beat (Story #4594).
+   Each beat re-probes live state: it re-resolves the graph, classifies done
+   (`agent::done` or a closed issue — including foreign blockers that landed
+   in another run), and derives in-flight from live `agent::executing` /
+   `agent::closing` labels. You never compute `done` or `in-flight` — that
+   accounting is read from reality every beat (Story #4594).
+
+   **`--dispatched` is the one thing you must tell it (Story #4601).** List
+   every Story id you have spawned this run. Live state cannot report a Story
+   you dispatched ninety seconds ago: `single-story-init.js` flips
+   `agent::executing` at step 6 of 6, *after* a 3–6 minute worktree install,
+   so until then the Story still reads `agent::ready` and the next beat hands
+   it back — a second sub-agent then joins the first on the same branch and
+   worktree, interleaving commits.
+
+   The rule is **append-only: add each id as you dispatch it and never remove
+   one.** The flag is additive, not authoritative — the probe unions it into
+   the label-derived set and then filters it against live state, so an id that
+   has since gone `agent::done` is dropped for you. Re-listing an id costs
+   nothing and cannot double-count a slot; *omitting* one is the only way to
+   get this wrong. This is why `--dispatched` is not the `--done` bookkeeping
+   #4594 retired, and why `--in-flight` remains rejected under `--probe-live`.
 
    Branch on the exit code:
    - **0** — dispatch each `ready` id (the set is already capped and
@@ -108,6 +123,20 @@ to respect.
      names the stuck ids and their unmet blockers. Either land the blocker
      first or include it in `--ids`. Do not retry unchanged — the state
      cannot improve on its own.
+   - **4** — `blocked`: one or more Stories carry `agent::blocked`, named in
+     `blocked[]` with `blockedReason`. This is the protocol's HITL pause
+     ([`instructions.md` § 1.J](../instructions.md)) — **stop the loop and
+     surface it to the operator; do not poll.** No beat can clear it, because
+     a human owes a decision. Read the Story's friction comment, and resume
+     only once the operator has unblocked it:
+
+     ```bash
+     gh issue view <id> --comments
+     node .agents/scripts/update-ticket-state.js --ticket <id> --state agent::ready
+     ```
+
+     A blocked Story outranks a wedge (its blockers are moot while a human
+     owes a decision) but not a cycle (exit 2 — fix the graph first).
 
    For each `ready` Story id, read
    [`helpers/deliver-story.md`](helpers/deliver-story.md) **in full** and

--- a/tests/wave-runner/live-probe.test.js
+++ b/tests/wave-runner/live-probe.test.js
@@ -1,5 +1,5 @@
 /**
- * tests/wave-runner/live-probe.test.js — Story #4594.
+ * tests/wave-runner/live-probe.test.js — Stories #4594, #4601.
  *
  * Probe mode exists to delete hand-maintained accounting from the `/deliver`
  * beat: the host LLM used to re-seed `--done` and count `--in-flight` by
@@ -16,6 +16,16 @@
  *   3. `epilogueDue` is true exactly when every listed Story is done.
  *   4. Probe mode feeds the SAME cycle (2) / wedge (3) exits as flag mode —
  *      one kernel, two adapters.
+ *
+ * Story #4601 pins the two live states probe mode classified incompletely,
+ * both of which presented as an ordinary "waiting" beat:
+ *
+ *   5. A **dispatched-but-unlabelled** Story holds its slot and is not handed
+ *      back. `single-story-init.js` flips `agent::executing` last, so every
+ *      test here that sets the label explicitly was skipping the window where
+ *      the bug lives.
+ *   6. An **`agent::blocked`** Story ends the loop (exit 4) instead of being
+ *      polled forever.
  */
 
 import assert from 'node:assert/strict';
@@ -83,11 +93,12 @@ function issue(id, { labels = [], state = 'open', ...bodyArgs } = {}) {
 }
 
 /** Run a probe-mode tick against a stubbed provider — no network, no config. */
-function tick(issues, { ids, native, concurrency } = {}) {
+function tick(issues, { ids, native, concurrency, dispatched } = {}) {
   const provider = stubProvider(issues, { native });
   return runProbedStoriesWaveTick({
     stories: ids ?? Object.keys(issues).join(','),
     concurrency,
+    dispatched,
     config: CONFIG,
     context: () => ({ provider, owner: 'dsj1984', repo: 'mandrel' }),
   });
@@ -131,6 +142,99 @@ describe('probeLiveState — done and in-flight come from live state', () => {
 
     assert.equal(inFlight, 2);
     assert.equal(doneIds.size, 0);
+  });
+
+  it('counts a dispatched-but-unlabelled Story as in-flight (the init window)', async () => {
+    // #101 was spawned this beat; single-story-init.js flips agent::executing
+    // last, after the install, so live state still reads agent::ready.
+    const provider = stubProvider({ 101: issue(101), 102: issue(102) });
+
+    const { inFlight, nodes } = await probeLiveState({
+      ids: [101, 102],
+      provider,
+      owner: 'dsj1984',
+      repo: 'mandrel',
+      dispatched: [101],
+    });
+
+    assert.equal(inFlight, 1);
+
+    // The count alone only reserves a slot — eligibility is decided per-record
+    // from labels, so the node must carry the executing label or the kernel
+    // re-admits it to the same beat that reserved capacity for it.
+    const byId = new Map(nodes.map((n) => [n.id, n]));
+    assert.equal(byId.get(101).labels.includes('agent::executing'), true);
+    assert.equal(byId.get(102).labels.includes('agent::executing'), false);
+  });
+
+  it('does not double-count a dispatched id that has since picked up its label', async () => {
+    // The host appends monotonically and never removes, so it re-passes #101
+    // after the label lands. A union cannot double-count; a counter would.
+    const provider = stubProvider({
+      101: issue(101, { labels: ['agent::executing'] }),
+    });
+
+    const { inFlight } = await probeLiveState({
+      ids: [101],
+      provider,
+      owner: 'dsj1984',
+      repo: 'mandrel',
+      dispatched: [101],
+    });
+
+    assert.equal(inFlight, 1);
+  });
+
+  it('drops a stale dispatched id once live state says it is done', async () => {
+    // Without this, a host that never prunes its --dispatched list would hold
+    // a slot forever and starve the run — the failure mode that would make
+    // --dispatched just another --done.
+    const provider = stubProvider({
+      101: issue(101, { labels: ['agent::done'] }),
+      102: issue(102, { state: 'closed' }),
+    });
+
+    const { inFlight } = await probeLiveState({
+      ids: [101, 102],
+      provider,
+      owner: 'dsj1984',
+      repo: 'mandrel',
+      dispatched: [101, 102],
+    });
+
+    assert.equal(inFlight, 0);
+  });
+
+  it('ignores a dispatched id outside the probed set', async () => {
+    const provider = stubProvider({ 101: issue(101) });
+
+    const { inFlight } = await probeLiveState({
+      ids: [101],
+      provider,
+      owner: 'dsj1984',
+      repo: 'mandrel',
+      dispatched: [999],
+    });
+
+    assert.equal(inFlight, 0);
+  });
+
+  it('surfaces agent::blocked ids on blockedIds, counting them neither done nor in-flight', async () => {
+    const provider = stubProvider({
+      101: issue(101, { labels: ['agent::blocked'] }),
+      102: issue(102),
+    });
+
+    const { blockedIds, doneIds, inFlight } = await probeLiveState({
+      ids: [101, 102],
+      provider,
+      owner: 'dsj1984',
+      repo: 'mandrel',
+    });
+
+    assert.deepEqual(blockedIds, [101]);
+    assert.equal(doneIds.size, 0);
+    assert.equal(inFlight, 0);
   });
 
   it('unions body edges with native blocked_by edges', async () => {
@@ -232,6 +336,105 @@ describe('runProbedStoriesWaveTick — the flag-free beat', () => {
     assert.equal(complete.exitCode, 0);
     assert.deepEqual(complete.envelope.ready, []);
     assert.deepEqual(complete.envelope.done, [101, 102]);
+  });
+
+  it('does not re-emit a dispatched Story on the next beat while init is still running', async () => {
+    // The double-dispatch window (Story #4601), as the loop actually meets it.
+    // Beat 1 hands back #101; the host spawns it. single-story-init.js flips
+    // agent::executing at step 6 of 6, so for the next 3-6 minutes live state
+    // still reads agent::ready — and beat 2 lands squarely inside that window.
+    const issues = { 101: issue(101), 102: issue(102) };
+
+    const beat1 = await tick(issues, { concurrency: '1' });
+    assert.deepEqual(beat1.envelope.ready, [101], 'beat 1 offers #101');
+
+    // Beat 2: labels are unchanged (init has not reached step 6), and the host
+    // reports what it spawned. Without that, #101 comes back and a second
+    // sub-agent joins it on story-101 and .worktrees/story-101/.
+    const beat2 = await tick(issues, { concurrency: '1', dispatched: '101' });
+
+    assert.equal(beat2.envelope.inFlight, 1, '#101 holds its slot');
+    assert.deepEqual(
+      beat2.envelope.ready,
+      [],
+      '#101 must not be dispatched twice, and the cap has no room for #102',
+    );
+    assert.equal(beat2.exitCode, 0, 'in-flight work means waiting, not wedged');
+  });
+
+  it('keeps filling the remaining slots around a dispatched Story', async () => {
+    // The counterpart risk: --dispatched must hold exactly one slot, not stall
+    // the run. Cap 2 − 1 dispatched = 1 slot, so #102 still goes out.
+    const { envelope } = await tick(
+      { 101: issue(101), 102: issue(102), 103: issue(103) },
+      { concurrency: '2', dispatched: '101' },
+    );
+
+    assert.equal(envelope.inFlight, 1);
+    assert.deepEqual(envelope.ready, [102]);
+  });
+
+  it('exits 4 and names the Story when one carries agent::blocked', async () => {
+    // Before Story #4601 this was exit 0 / ready: [] / wedged: null forever:
+    // blocked is neither done nor ready nor in-flight, and detectWedge drops a
+    // Story with no unmet blockers. /deliver read that as "waiting" and polled
+    // a state no beat could ever change.
+    const { envelope, exitCode } = await tick({
+      101: issue(101, { labels: ['agent::blocked'] }),
+      102: issue(102, { blockedBy: 101 }),
+    });
+
+    assert.equal(exitCode, 4);
+    assert.deepEqual(envelope.blocked, [101]);
+    assert.match(envelope.blockedReason, /#101/);
+    assert.match(envelope.blockedReason, /HITL pause/);
+    assert.match(envelope.blockedReason, /update-ticket-state\.js/);
+    assert.deepEqual(envelope.ready, []);
+    assert.equal(envelope.epilogueDue, false);
+  });
+
+  it('reports blocked: [] and exit 0 on a healthy beat', async () => {
+    const { envelope, exitCode } = await tick({ 101: issue(101) });
+
+    assert.equal(exitCode, 0);
+    assert.deepEqual(envelope.blocked, []);
+    assert.equal(envelope.blockedReason, null);
+  });
+
+  it('lets a blocked Story outrank a wedge, but never a cycle', async () => {
+    // A wedge's named blockers are moot while a human owes a decision, so
+    // blocked wins. A cycle is a malformed graph that must be fixed before any
+    // of this run's state means anything, so it does not yield.
+    const wedgeAndBlock = await tick(
+      {
+        101: issue(101, { labels: ['agent::blocked'] }),
+        102: issue(102, { blockedBy: 999 }),
+        999: issue(999),
+      },
+      { ids: '101,102' },
+    );
+    assert.equal(wedgeAndBlock.exitCode, 4);
+    assert.deepEqual(wedgeAndBlock.envelope.blocked, [101]);
+
+    const cycleAndBlock = await tick({
+      101: issue(101, { blockedBy: 102 }),
+      102: issue(102, { blockedBy: 101 }),
+      103: issue(103, { labels: ['agent::blocked'] }),
+    });
+    assert.equal(cycleAndBlock.exitCode, 2);
+    assert.match(cycleAndBlock.envelope.cycleError, /Dependency cycle/);
+  });
+
+  it('rejects a malformed --dispatched list', async () => {
+    const { envelope, exitCode } = await runProbedStoriesWaveTick({
+      stories: '101',
+      dispatched: '101,nope',
+      config: CONFIG,
+      context: () => ({ provider: {}, owner: 'o', repo: 'r' }),
+    });
+
+    assert.equal(exitCode, 1);
+    assert.match(envelope.inputError, /--dispatched must be a comma-separated/);
   });
 
   it('exits 2 on a dependency cycle, matching flag-mode semantics', async () => {
@@ -338,6 +541,24 @@ describe('validateProbeFlags — the modes stay mutually exclusive', () => {
       /--stories requires --probe-live/,
     );
   });
+
+  it('admits --dispatched under --probe-live but not alongside flag mode', () => {
+    // --dispatched is additive and live-state-filtered, so it does not
+    // reintroduce authoritative hand-maintained accounting the way --in-flight
+    // would — which is why --in-flight stays excluded and this does not.
+    assert.equal(
+      validateProbeFlags({ probeLive: true, stories: '1', dispatched: '1' }),
+      null,
+    );
+    assert.match(
+      validateProbeFlags({ dag: '[]', dispatched: '1' }),
+      /--dispatched requires --probe-live/,
+    );
+    assert.match(
+      validateProbeFlags({ probeLive: true, stories: '1', inFlight: '1' }),
+      /mutually exclusive/,
+    );
+  });
 });
 
 describe('CLI wiring — the mode guard fires before any network read', () => {
@@ -366,6 +587,8 @@ describe('CLI wiring — the mode guard fires before any network read', () => {
     assert.equal(res.status, 0);
     assert.match(res.stdout, /--probe-live/);
     assert.match(res.stdout, /--stories <csv>/);
+    assert.match(res.stdout, /--dispatched <csv>/);
+    assert.match(res.stdout, /4 - Blocked/);
   });
 });
 


### PR DESCRIPTION
Closes #4601

_Auto-opened by `/deliver`._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the critical `/deliver` scheduling loop (in-flight accounting and new exit 4); mistakes could still wedge or mis-dispatch, but behavior is heavily tested and the scheduling kernel is unchanged.
> 
> **Overview**
> Fixes two probe-mode gaps where `/deliver` looked like a normal “waiting” beat forever: **double-dispatch during story init** and **silent polling on `agent::blocked`**.
> 
> Probe beats now accept **`--dispatched`** (probe-live only): an append-only CSV of Story ids the host has spawned. In-flight is the **union** of live `agent::executing` / `agent::closing` labels and dispatched ids that still read `agent::ready` (the gap before `single-story-init.js` flips the label). Stale or done ids are dropped so the list cannot starve the cap. For scheduling, dispatched-but-unlabelled nodes get a synthetic **`agent::executing`** label so `selectReadySet` does not re-offer them while only reserving a slot via `inFlight` count.
> 
> **`agent::blocked`** Stories are surfaced as `blocked[]` / `blockedReason` on the envelope, with **exit code 4** (over wedge, under cycle). `/deliver` is updated to pass `--dispatched` each loop and stop on exit 4 instead of polling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 80eb9634f145f0a8ecfa85e84bdd80cf577e1eb0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->