### PR TITLE
feat: human-readable Story bodies: numbered ACs, humanized Changes rendering, visible wide rationale (#4600)

### DIFF
--- a/.agents/scripts/lib/story-body/story-body.js
+++ b/.agents/scripts/lib/story-body/story-body.js
@@ -165,13 +165,35 @@ function stripListMarker(line) {
   return line.replace(/^-\s+(?:\[\s*[xX ]?\s*\]\s+)?/, '').trim();
 }
 
+// Humanized PathEntry bullet (Story #4600): `path` — assumption. This is the
+// shape serialize() now emits for `## Changes` / `## References`; the legacy
+// inline-JSON object bullet remains accepted at parse time indefinitely (live
+// issue bodies are never rewritten).
+const HUMANIZED_PATH_ENTRY_RE = /^`([^`]+)`\s+—\s+(\S+)$/;
+
+// AC-<n> presentation prefix on acceptance checkboxes (Story #4600). The
+// numbering is a stable 1-based human handle only — parse() strips it so the
+// top-level acceptance[] machine contract round-trips byte-identical.
+const AC_PREFIX_RE = /^AC-\d+:\s+/;
+
+// Visible wide-rationale line (Story #4600): `> **Wide:** <reason>` rendered
+// under `## Goal`. Presentation only — the `<!-- meta -->` block stays the
+// canonical machine carrier, so the parser skips this line wherever it
+// appears (same treatment as the authored-provenance marker).
+const WIDE_MARKER_LINE_RE = /^>\s*\*\*Wide:\*\*/;
+
 /**
  * Parse a single `changes` / `references` bullet into a `PathEntry`.
  *
- * Object form: `{ path: "...", assumption: "creates" }` (stored as
- * `- { "path": "...", "assumption": "..." }` or just recognized from the
- * structured body directly — when deserializing from a structured object
- * that was never serialized to markdown, the entry arrives as-is).
+ * Accepted markdown shapes (both parsed indefinitely — live issue bodies
+ * are never rewritten):
+ *   - Humanized bullet (canonical serialize() output since Story #4600):
+ *     `` `src/x.js` — refactors-existing ``
+ *   - Legacy inline-JSON object bullet:
+ *     `- { "path": "...", "assumption": "..." }`
+ *
+ * A structured object entry (from a parsed JSON body that was never
+ * serialized to markdown) arrives as-is and is validated directly.
  *
  * @param {string|object} raw
  * @param {string[]} warnings
@@ -196,6 +218,21 @@ function parsePathEntry(raw, warnings) {
 
   const str = typeof raw === 'string' ? raw.trim() : String(raw).trim();
   if (str.length === 0) return null;
+
+  // Humanized bullet shape (the canonical serialize() output since
+  // Story #4600): `path` — assumption.
+  const humanized = str.match(HUMANIZED_PATH_ENTRY_RE);
+  if (humanized) {
+    const path = humanized[1].trim();
+    if (path.length > 0 && FILE_ASSUMPTION_VALUES.includes(humanized[2])) {
+      return { path, assumption: humanized[2] };
+    }
+    // Recognized the humanized shape but the fields are invalid: fail closed.
+    throw new StoryBodyParseError(
+      `changes/references entry is a humanized bullet but not a valid PathEntry: ${str.slice(0, 120)}`,
+      { field: 'changes', raw: str },
+    );
+  }
 
   // Try to detect inline JSON object shape: `{ "path": "...", "assumption": "..." }`
   if (str.startsWith('{')) {
@@ -433,6 +470,14 @@ function splitSections(markdown) {
       continue;
     }
 
+    // The visible `> **Wide:** <reason>` rationale line is presentation only
+    // (Story #4600): the meta block remains the canonical carrier for
+    // `wide.reason`, so this line must not bleed into the goal (or any other)
+    // section. Skip it wherever it appears.
+    if (WIDE_MARKER_LINE_RE.test(line)) {
+      continue;
+    }
+
     if (inPreamble) {
       preambleLines.push(line);
     } else if (currentSection !== null) {
@@ -637,7 +682,11 @@ export function parse(input) {
     sections.get('changes') ?? [],
     warnings,
   );
-  const acceptance = parseTextListSection(sections.get('acceptance') ?? []);
+  // The AC-<n> checkbox prefix is presentation-only (Story #4600): strip it
+  // so acceptance[] round-trips byte-identical to the authored array.
+  const acceptance = parseTextListSection(sections.get('acceptance') ?? []).map(
+    (a) => a.replace(AC_PREFIX_RE, ''),
+  );
   const verify = parseTextListSection(sections.get('verify') ?? []);
   const references = parsePathEntrySection(
     sections.get('references') ?? [],
@@ -820,8 +869,10 @@ function parseStructuredObject(obj) {
  */
 function serializePathEntry(entry) {
   if (typeof entry === 'string') return entry;
-  // Canonical object form: render as JSON inline for round-trip fidelity.
-  return JSON.stringify({ path: entry.path, assumption: entry.assumption });
+  // Canonical object form (Story #4600): render as a human-readable bullet —
+  // path in backticks, em-dash, assumption. parsePathEntry recognizes this
+  // shape (and the legacy inline-JSON shape) for round-trip fidelity.
+  return `\`${entry.path}\` — ${entry.assumption}`;
 }
 
 /**
@@ -844,6 +895,18 @@ const SERIALIZE_SECTIONS = [
       typeof goal === 'string' && goal.trim().length > 0
         ? `## Goal\n${goal.trim()}`
         : null,
+  },
+  {
+    // Visible wide-rationale line (Story #4600), rendered directly under
+    // `## Goal`. Presentation only: the `<!-- meta -->` block remains the
+    // canonical machine carrier and the parser skips this line, so `wide`
+    // round-trips through the meta block alone. Absent/invalid wide emits
+    // nothing, keeping every non-wide body byte-identical to before.
+    field: 'wide',
+    render: (wide) => {
+      const normalized = normalizeWide(wide);
+      return normalized === null ? null : `> **Wide:** ${normalized.reason}`;
+    },
   },
   {
     // Optional v2 intra-Story delivery slice plan. Single-token `## Slicing`
@@ -873,10 +936,14 @@ const SERIALIZE_SECTIONS = [
         : null,
   },
   {
+    // Each checkbox carries a stable 1-based `AC-<n>:` handle (Story #4600)
+    // so humans and reviewers can reference criteria by number. The prefix
+    // is presentation-only — parse() strips it, and validators compare the
+    // top-level acceptance[] array, so numbering never affects gating.
     field: 'acceptance',
     render: (acceptance) =>
       Array.isArray(acceptance) && acceptance.length > 0
-        ? `## Acceptance\n${acceptance.map((a) => `- [ ] ${a}`).join('\n')}`
+        ? `## Acceptance\n${acceptance.map((a, i) => `- [ ] AC-${i + 1}: ${a}`).join('\n')}`
         : null,
   },
   {

--- a/tests/lib/story-body/story-body.test.js
+++ b/tests/lib/story-body/story-body.test.js
@@ -38,6 +38,24 @@ const CANONICAL_MARKDOWN = `## Goal
 Create the shared canonical Story-body parser/serializer.
 
 ## Changes
+- \`.agents/scripts/lib/story-body/story-body.js\` — creates
+- \`tests/lib/story-body/story-body.test.js\` — creates
+
+## Acceptance
+- [ ] AC-1: parse() returns a StoryBody with all sections populated
+- [ ] AC-2: serialize(parse(md)) round-trips cleanly
+
+## Verify
+- npm test -- tests/lib/story-body/story-body.test.js (unit)`;
+
+// Pre-cutover (Story #4600) body shape: `## Changes` / `## References` as raw
+// inline-JSON object bullets and unnumbered acceptance checkboxes. Live issue
+// bodies in this shape are never rewritten, so parse() must accept it
+// indefinitely.
+const LEGACY_JSON_BULLET_MARKDOWN = `## Goal
+Create the shared canonical Story-body parser/serializer.
+
+## Changes
 - ${JSON.stringify({ path: '.agents/scripts/lib/story-body/story-body.js', assumption: 'creates' })}
 - ${JSON.stringify({ path: 'tests/lib/story-body/story-body.test.js', assumption: 'creates' })}
 
@@ -46,7 +64,10 @@ Create the shared canonical Story-body parser/serializer.
 - [ ] serialize(parse(md)) round-trips cleanly
 
 ## Verify
-- npm test -- tests/lib/story-body/story-body.test.js (unit)`;
+- npm test -- tests/lib/story-body/story-body.test.js (unit)
+
+## References
+- ${JSON.stringify({ path: 'docs/architecture.md', assumption: 'exists' })}`;
 
 const CANONICAL_BODY = {
   goal: 'Create the shared canonical Story-body parser/serializer.',
@@ -349,9 +370,10 @@ describe('serialize()', () => {
     assert.ok(out.includes('docs/arch.md'));
   });
 
-  it('emits acceptance items with `- [ ]` prefix', () => {
+  it('emits acceptance items with `- [ ] AC-<n>:` prefix', () => {
     const out = serialize(CANONICAL_BODY);
-    assert.ok(out.includes('- [ ] parse() returns'));
+    assert.ok(out.includes('- [ ] AC-1: parse() returns'));
+    assert.ok(out.includes('- [ ] AC-2: serialize(parse(md)) round-trips'));
   });
 
   it('includes footer when opts.includeFooter = true', () => {
@@ -874,5 +896,140 @@ Use the existing repository.
     });
     assert.equal(body.spec, 'Use the existing story-body serializer.');
     assert.equal(info.hasSpecSection, true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Story #4600 — human-readable rendering (numbered ACs, humanized bullets,
+// visible wide rationale)
+// ---------------------------------------------------------------------------
+
+describe('Story #4600 — numbered AC-<n> acceptance handles', () => {
+  it('serialize() renders stable 1-based AC-<n> prefixes and parse() strips them (round-trip)', () => {
+    const acceptance = [
+      'first observable outcome',
+      'second observable outcome',
+      'third observable outcome',
+    ];
+    const body = { ...CANONICAL_BODY, acceptance };
+    const md = serialize(body);
+    assert.ok(md.includes('- [ ] AC-1: first observable outcome'));
+    assert.ok(md.includes('- [ ] AC-2: second observable outcome'));
+    assert.ok(md.includes('- [ ] AC-3: third observable outcome'));
+    const { body: reparsed } = parse(md);
+    assert.deepEqual(reparsed.acceptance, acceptance);
+  });
+
+  it('parse() leaves an unnumbered legacy acceptance checkbox unchanged', () => {
+    const { body } = parse(LEGACY_JSON_BULLET_MARKDOWN);
+    assert.deepEqual(body.acceptance, [
+      'parse() returns a StoryBody with all sections populated',
+      'serialize(parse(md)) round-trips cleanly',
+    ]);
+  });
+
+  it('does not strip AC-like prose that is not a leading handle', () => {
+    const body = {
+      ...CANONICAL_BODY,
+      acceptance: ['the AC-3: marker mid-sentence survives'],
+    };
+    const { body: reparsed } = parse(serialize(body));
+    assert.deepEqual(reparsed.acceptance, body.acceptance);
+  });
+});
+
+describe('Story #4600 — humanized Changes / References bullets', () => {
+  it('serialize() emits prose bullets with no raw JSON and parse() recovers identical entries', () => {
+    const body = {
+      ...CANONICAL_BODY,
+      references: [{ path: 'docs/architecture.md', assumption: 'exists' }],
+    };
+    const md = serialize(body);
+    assert.ok(!md.includes('{"path":'));
+    assert.ok(
+      md.includes('- `.agents/scripts/lib/story-body/story-body.js` — creates'),
+    );
+    assert.ok(md.includes('- `docs/architecture.md` — exists'));
+    const { body: reparsed } = parse(md);
+    assert.deepEqual(reparsed.changes, body.changes);
+    assert.deepEqual(reparsed.references, body.references);
+  });
+
+  it('parse() still accepts the legacy JSON-object bullet shape (never rewritten)', () => {
+    const { body: legacy } = parse(LEGACY_JSON_BULLET_MARKDOWN);
+    // The legacy fixture parses to the same changes[]/references[] as its
+    // humanized re-serialization.
+    const { body: rehumanized } = parse(serialize(legacy));
+    assert.deepEqual(rehumanized.changes, legacy.changes);
+    assert.deepEqual(rehumanized.references, legacy.references);
+    assert.deepEqual(legacy.changes, [
+      {
+        path: '.agents/scripts/lib/story-body/story-body.js',
+        assumption: 'creates',
+      },
+      {
+        path: 'tests/lib/story-body/story-body.test.js',
+        assumption: 'creates',
+      },
+    ]);
+    assert.deepEqual(legacy.references, [
+      { path: 'docs/architecture.md', assumption: 'exists' },
+    ]);
+  });
+
+  it('fails closed on a humanized bullet with an invalid assumption', () => {
+    const md = `## Goal
+g
+
+## Changes
+- \`src/foo.js\` — not-an-assumption
+
+## Acceptance
+- [ ] x`;
+    assert.throws(
+      () => parse(md),
+      (err) => {
+        assert.ok(err instanceof StoryBodyParseError);
+        assert.match(err.message, /humanized bullet but not a valid PathEntry/);
+        return true;
+      },
+    );
+  });
+});
+
+describe('Story #4600 — visible wide rationale line', () => {
+  it('renders one visible `> **Wide:**` line under ## Goal and round-trips wide.reason', () => {
+    const body = {
+      ...CANONICAL_BODY,
+      wide: { reason: 'mechanical sweep across every consumer site' },
+    };
+    const md = serialize(body);
+    // The visible line sits between the Goal text and the next section,
+    // outside any HTML comment.
+    assert.match(
+      md,
+      /## Goal\nCreate the shared canonical Story-body parser\/serializer\.\n\n> \*\*Wide:\*\* mechanical sweep across every consumer site\n\n## Changes/,
+    );
+    const withoutComments = md.replace(/<!--[\s\S]*?-->/g, '');
+    assert.ok(withoutComments.includes('> **Wide:** mechanical sweep'));
+    // The meta block stays the canonical machine carrier.
+    assert.ok(
+      md.includes(
+        '"wide":{"reason":"mechanical sweep across every consumer site"}',
+      ),
+    );
+    const { body: reparsed } = parse(md);
+    assert.deepEqual(reparsed.wide, body.wide);
+    // The visible line never bleeds into the goal text.
+    assert.equal(reparsed.goal, CANONICAL_BODY.goal);
+    // Byte-identical serialize → parse → serialize round-trip.
+    assert.equal(serialize(reparsed), md);
+  });
+
+  it('renders no wide line when wide is absent', () => {
+    const md = serialize(CANONICAL_BODY);
+    assert.doesNotMatch(md, /\*\*Wide:\*\*/);
+    const { body: reparsed } = parse(md);
+    assert.equal(reparsed.wide, null);
   });
 });


### PR DESCRIPTION
Closes #4600

_Auto-opened by `/deliver`._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the canonical Story-body parser/serializer used across delivery and orchestration; behavior is backward-compatible for legacy markdown, but any parse/serialize mismatch could affect issue bodies and downstream gating that reads `acceptance[]` and `changes[]`.
> 
> **Overview**
> Story issue bodies get **presentation-only** markdown improvements while the structured `StoryBody` contract stays the same.
> 
> **Serialization** now emits **`AC-<n>:`** prefixes on acceptance checkboxes, **humanized** Changes/References bullets (`` `path` — assumption ``) instead of inline JSON, and a visible **`> **Wide:**`** line under **Goal** when `wide` is set (the `<!-- meta -->` block still carries `wide` for machines).
> 
> **Parsing** accepts the new shapes, **strips** `AC-<n>:` so `acceptance[]` round-trips unchanged, recognizes humanized path bullets (invalid assumptions still **fail closed**), and **skips** the Wide line so it does not pollute **Goal**. **Legacy** JSON path bullets and unnumbered acceptance items remain supported indefinitely.
> 
> Tests add fixtures and coverage for round-trips, legacy compatibility, and wide-line placement.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a1f33c3b11ab35d2dece9a2812bc6f78ced75234. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->