### PR TITLE
feat: retire the @epic-<id>-ac-N Gherkin AC tag namespace and strip stale consumer tags on upgrade (#4604)

### DIFF
--- a/.agents/rules/gherkin-standards.md
+++ b/.agents/rules/gherkin-standards.md
@@ -23,6 +23,16 @@ scenarios. Use the canonical set below; do not invent ad-hoc tags.
 - `@flaky` — operational quarantine tag. Scenarios carrying this tag are
   excluded from the gating suite and run in a dedicated non-blocking job
   until stabilized. Treat `@flaky` as a debt marker, not a permanent label.
+- `@skip` — scaffold-gating tag. Applied to scenarios scaffolded ahead of
+  their implementation (e.g. by a wave-0 BDD scaffold Story); the scenario
+  is excluded from the gating suite until the implementing Story removes
+  the tag (the "de-skip" edit). Unlike `@flaky`, `@skip` marks planned
+  not-yet-implemented behavior, never a stability problem.
+
+Retired: the `@epic-<id>-ac-N` namespaced AC tag. Its consumer
+(`acceptance-spec-reconciler.js`) was deleted in the v2 Epic removal, so
+the tag is inert — do not apply it to new scenarios. The `mandrel update`
+migration strips surviving instances from consumer feature files.
 
 Rules:
 

--- a/.agents/scripts/lib/orchestration/plan-context.js
+++ b/.agents/scripts/lib/orchestration/plan-context.js
@@ -361,17 +361,12 @@ export function buildDeliveryShapeSignal({ body } = {}) {
  * authoritative from day one); the decompose prompt reuses the existing
  * Story #4162 carrier including the risk-heuristics suffix.
  *
- * @param {{ heuristics?: string[], maxTickets?: number, epicId?: number|null }} args
+ * @param {{ heuristics?: string[], maxTickets?: number }} args
  * @returns {{ spec: string, acceptance: string, decompose: string }}
  */
-export function buildSystemPrompts({
-  heuristics = [],
-  maxTickets,
-  epicId = null,
-} = {}) {
+export function buildSystemPrompts({ heuristics = [], maxTickets } = {}) {
   const decompose = buildDecomposerSystemPrompt(heuristics, {
     maxTickets,
-    epicId,
   });
   return {
     spec: renderTechSpecSystemPrompt(),
@@ -500,7 +495,6 @@ async function buildSeedFileModeEnvelope({
     systemPrompts: buildSystemPrompts({
       heuristics,
       maxTickets: limits.maxTickets,
-      epicId: null,
     }),
     planState: null,
     // N=1 default: author one Story; skip Epic-scale decompose ceremony.
@@ -654,7 +648,6 @@ async function buildTicketsModeEnvelope({
     systemPrompts: buildSystemPrompts({
       heuristics,
       maxTickets: limits.maxTickets,
-      epicId: null,
     }),
     planState: null,
     planProfile:

--- a/.agents/scripts/lib/orchestration/planning/decomposer-context.js
+++ b/.agents/scripts/lib/orchestration/planning/decomposer-context.js
@@ -13,11 +13,10 @@ import { renderDecomposerSystemPrompt } from '../../templates/decomposer-prompts
 
 export function buildDecomposerSystemPrompt(
   heuristics = [],
-  { maxTickets, epicId } = {},
+  { maxTickets } = {},
 ) {
   const base = renderDecomposerSystemPrompt({
     maxTickets,
-    epicId,
   });
   const heuristicsStr =
     heuristics.length > 0

--- a/.agents/scripts/lib/templates/decomposer-prompts.js
+++ b/.agents/scripts/lib/templates/decomposer-prompts.js
@@ -26,9 +26,8 @@ import {
  */
 export function renderDecomposerSystemPrompt({
   maxTickets = LIMITS_DEFAULTS.maxTickets,
-  epicId = null,
 } = {}) {
-  return render2TierPrompt({ maxTickets, epicId });
+  return render2TierPrompt({ maxTickets });
 }
 
 /**
@@ -37,7 +36,7 @@ export function renderDecomposerSystemPrompt({
  * on the Story body so the executing agent has everything it needs in one
  * ticket. Thematic grouping lives as prose in the Epic body / Tech Spec.
  */
-function render2TierPrompt({ maxTickets, epicId = null }) {
+function render2TierPrompt({ maxTickets }) {
   // v2 Stage 3: default-single — emit one Story unless the split policy clears.
   // Capacity thresholds are sourced from the single DEFAULT_MODEL_CAPACITY
   // constant (ticket-validator-sizing.js) so the prompt and the validator
@@ -64,13 +63,6 @@ function render2TierPrompt({ maxTickets, epicId = null }) {
     advisoryCaveat,
     newFileContract,
   } = AUTHORING_ALTITUDE_GUIDANCE;
-  // The namespaced AC-tag token the wave-0 BDD scaffold section below must
-  // require on every scaffolded scenario (Story #4301). When the Epic ID is
-  // known at render time, interpolate the concrete tag so the author has no
-  // placeholder to get wrong; otherwise fall back to the documented pattern.
-  const acTagExample = Number.isInteger(epicId)
-    ? `@epic-${epicId}-ac-1`
-    : '@epic-<id>-ac-N';
   return `You are an expert Senior Project Manager and Orchestrator.
 Your job is to turn a plan seed / Tech Spec into a Story ticket array for an AI Agent to execute.
 
@@ -229,9 +221,8 @@ When the Acceptance Spec contains **one or more \`Disposition: new\` rows**, you
 - **goal**: contains the literal token \`bdd-scaffold\` (e.g. "bdd-scaffold: create the @skip-tagged feature files the implementation Stories verify against").
 - **depends_on**: EMPTY (\`[]\`) — it runs first, in wave 0.
 - **changes**: one entry per distinct \`.feature\` file named in a \`new\` row, each \`{ "path": "<feature file path>", "assumption": "creates" }\`.
-- **acceptance**: MUST assert (a) every new \`.feature\` file exists, (b) every new scenario within them carries an \`@skip\` tag, AND (c) every new scenario also carries its **namespaced per-Epic AC tag** \`${acTagExample}\` (one tag per AC ID the scenario satisfies — see below). Keep these observable (a grep/validate command exits 0, a file exists at a path).
-- **Namespaced AC tag is REQUIRED at scaffold time, not only at de-skip time.** Phase 7 finalize's \`acceptance-spec-reconciler.js\` matches AC IDs only against \`@epic-<id>-ac-*\` / \`@pending\` tags in \`tests/features/**\` — a bare \`@ac-N\` tag is deliberately ignored to prevent cross-Epic collision. A scaffolded scenario that carries \`@skip\` but omits \`@epic-<id>-ac-N\` reads as \`missing[]\` at finalize and aborts the close even after the implementation Story de-skips it, because the tag was never added. Tag each scenario with both \`@skip\` AND \`${acTagExample}\` (substituting the AC's own number) in this SAME wave-0 pass — do not defer the AC tag to the later de-skip edit.
-- **verify**: a grep/validate command (tier \`validate\`), NOT an e2e runner — verifying that a file exists with the required tags needs no browser/playwright run. Example: \`grep -rL '@skip' tests/features/<area>/*.feature (validate)\` paired with an existence check, AND a check that every new AC ID's namespaced tag (\`${acTagExample}\`) appears in the scaffolded files, e.g. \`grep -q '${acTagExample}' tests/features/<area>/<file>.feature (validate)\` for each new AC row.
+- **acceptance**: MUST assert (a) every new \`.feature\` file exists AND (b) every new scenario within them carries an \`@skip\` tag. Keep these observable (a grep/validate command exits 0, a file exists at a path).
+- **verify**: a grep/validate command (tier \`validate\`), NOT an e2e runner — verifying that a file exists with the required tags needs no browser/playwright run. Example: \`grep -rL '@skip' tests/features/<area>/*.feature (validate)\` paired with an existence check.
 - Each implementation Story whose \`verify[]\` references one of these scaffolded \`.feature\` paths MUST \`depends_on\` the scaffold Story (so the scaffold lands in an earlier wave). Omitting the link trips the soft \`missing-bdd-scaffold\` validator finding.
 
 When the Acceptance Spec contains **zero \`new\`-disposition rows** (every row is \`updated\` or \`unchanged\`), do NOT emit a scaffold Story — there is nothing to create.

--- a/.agents/scripts/plan-context.js
+++ b/.agents/scripts/plan-context.js
@@ -205,7 +205,6 @@ async function main() {
     {
       cli: 'plan-context',
       mode,
-      epicId: null,
       config,
     },
     () =>

--- a/lib/migrations/__tests__/index.test.js
+++ b/lib/migrations/__tests__/index.test.js
@@ -69,16 +69,18 @@ describe('migrations module exports', () => {
   });
 
   // Story #4531 added the mi-drop-knobs retirement; Story #4545 appended the
-  // verify-concurrency-cap retirement. Both graduate the tree to 2.1.0, so the
-  // registry's declaration order is what fixes their run order — pin it.
-  it('ships the two 2.1.0 knob retirements as its real steps, in order', () => {
-    assert.equal(migrations.length, 2);
+  // verify-concurrency-cap retirement (both 2.1.0); Story #4604 appended the
+  // epic-AC-tag retirement at 2.2.0. The registry's declaration order is what
+  // fixes the run order within a version — pin it.
+  it('ships the real steps in ascending version + declaration order', () => {
+    assert.equal(migrations.length, 3);
     assert.deepEqual(
       migrations.map((s) => s.version),
-      ['2.1.0', '2.1.0'],
+      ['2.1.0', '2.1.0', '2.2.0'],
     );
     assert.match(migrations[0].description, /mi|maintainability/i);
     assert.match(migrations[1].description, /concurrency/i);
+    assert.match(migrations[2].description, /epic-<id>-ac-N/);
   });
 });
 

--- a/lib/migrations/index.js
+++ b/lib/migrations/index.js
@@ -54,6 +54,7 @@
 
 import { retireMiDropKnobs } from './steps/2.1.0-retire-mi-drop-knobs.js';
 import { retireVerifyConcurrencyCap } from './steps/2.1.0-retire-verify-concurrency-cap.js';
+import { retireEpicAcTags } from './steps/2.2.0-retire-epic-ac-tags.js';
 
 /**
  * Ordered registry of migration steps. MUST stay sorted ascending by
@@ -66,7 +67,11 @@ import { retireVerifyConcurrencyCap } from './steps/2.1.0-retire-verify-concurre
  *   apply: (ctx: unknown) => void,
  * }>}
  */
-export const migrations = [retireMiDropKnobs, retireVerifyConcurrencyCap];
+export const migrations = [
+  retireMiDropKnobs,
+  retireVerifyConcurrencyCap,
+  retireEpicAcTags,
+];
 
 /**
  * Parse a dotted semver-ish string into a numeric tuple for comparison.

--- a/lib/migrations/steps/2.2.0-retire-epic-ac-tags.js
+++ b/lib/migrations/steps/2.2.0-retire-epic-ac-tags.js
@@ -1,0 +1,154 @@
+// lib/migrations/steps/2.2.0-retire-epic-ac-tags.js
+/**
+ * Story #4604 — strip the retired `@epic-<id>-ac-N` Gherkin AC tag namespace
+ * from consumer feature files.
+ *
+ * The v2 Epic removal deleted `acceptance-spec-reconciler.js`, the only
+ * consumer of the namespaced per-Epic AC tags, and the `/plan` authoring
+ * prompt no longer mandates them. Surviving tags in consumer `.feature`
+ * files are inert and violate the gherkin-standards tag taxonomy's
+ * no-ad-hoc-tags rule, so this step removes them: each `@epic-<digits>-ac-<digits>`
+ * token is deleted from tag lines, a tag line left with no tags is dropped
+ * entirely, and every other tag and line is preserved byte-for-byte. Files
+ * with no stale tags are never rewritten.
+ */
+
+import nodeFs from 'node:fs';
+import path from 'node:path';
+
+/**
+ * Mirror of `CANONICAL_FEATURE_ROOTS` in
+ * `.agents/scripts/lib/bdd-runner-detect.js`. Duplicated deliberately:
+ * `lib/` runs from the installed npm package inside a consumer project and
+ * must not import from the materialized `.agents/` payload.
+ */
+const CANONICAL_FEATURE_ROOTS = Object.freeze([
+  'tests/features',
+  'features',
+  'test/features',
+]);
+
+const EPIC_AC_TAG_RE = /@epic-\d+-ac-\d+/;
+
+/**
+ * A Gherkin tag line: optional indentation followed by one or more
+ * whitespace-separated `@tag` tokens and nothing else.
+ */
+const TAG_LINE_RE = /^(\s*)(@\S+(?:\s+@\S+)*)\s*$/;
+
+/**
+ * Recursively collect `.feature` file paths under `root`.
+ *
+ * @param {string} root
+ * @param {typeof nodeFs} fsImpl
+ * @returns {string[]}
+ */
+function collectFeatureFiles(root, fsImpl) {
+  /** @type {string[]} */
+  const found = [];
+  /** @type {string[]} */
+  const queue = [root];
+  while (queue.length > 0) {
+    const dir = queue.pop();
+    /** @type {import('node:fs').Dirent[]} */
+    let entries;
+    try {
+      entries = fsImpl.readdirSync(dir, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+    for (const entry of entries) {
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        queue.push(full);
+      } else if (entry.isFile() && entry.name.endsWith('.feature')) {
+        found.push(full);
+      }
+    }
+  }
+  return found.sort();
+}
+
+/**
+ * @param {unknown} ctx
+ * @param {typeof nodeFs} fsImpl
+ * @returns {string[]} Absolute paths of every `.feature` file under the
+ *   canonical feature roots that exist in the consumer tree.
+ */
+function resolveFeatureFiles(ctx, fsImpl) {
+  const projectRoot = ctx?.projectRoot ?? process.cwd();
+  return CANONICAL_FEATURE_ROOTS.flatMap((root) =>
+    collectFeatureFiles(path.join(projectRoot, root), fsImpl),
+  );
+}
+
+/**
+ * Strip retired `@epic-<id>-ac-<n>` tokens from one file's content.
+ * Only tag lines are touched; a tag line whose every tag was retired is
+ * dropped. Returns the original string when nothing matched.
+ *
+ * @param {string} content
+ * @returns {string}
+ */
+function stripEpicAcTags(content) {
+  if (!EPIC_AC_TAG_RE.test(content)) return content;
+  const newline = content.includes('\r\n') ? '\r\n' : '\n';
+  const lines = content.split(newline);
+  /** @type {string[]} */
+  const out = [];
+  for (const line of lines) {
+    const match = line.match(TAG_LINE_RE);
+    if (!match || !EPIC_AC_TAG_RE.test(line)) {
+      out.push(line);
+      continue;
+    }
+    const [, indent, tagBlock] = match;
+    const kept = tagBlock
+      .split(/\s+/)
+      .filter((tag) => !EPIC_AC_TAG_RE.test(tag));
+    if (kept.length === 0) continue;
+    out.push(`${indent}${kept.join(' ')}`);
+  }
+  return out.join(newline);
+}
+
+export const retireEpicAcTags = {
+  version: '2.2.0',
+  description:
+    'strip retired @epic-<id>-ac-N Gherkin AC tags from feature files ' +
+    '(their reconciler consumer was deleted in the v2 Epic removal)',
+  /**
+   * @param {{ projectRoot?: string, fs?: typeof nodeFs }} [ctx]
+   * @returns {boolean}
+   */
+  detect(ctx) {
+    const fsImpl = ctx?.fs ?? nodeFs;
+    return resolveFeatureFiles(ctx, fsImpl).some((file) => {
+      try {
+        return EPIC_AC_TAG_RE.test(fsImpl.readFileSync(file, 'utf8'));
+      } catch {
+        return false;
+      }
+    });
+  },
+  /**
+   * @param {{ projectRoot?: string, fs?: typeof nodeFs }} [ctx]
+   * @returns {void}
+   */
+  apply(ctx) {
+    const fsImpl = ctx?.fs ?? nodeFs;
+    for (const file of resolveFeatureFiles(ctx, fsImpl)) {
+      /** @type {string} */
+      let content;
+      try {
+        content = fsImpl.readFileSync(file, 'utf8');
+      } catch {
+        continue;
+      }
+      const stripped = stripEpicAcTags(content);
+      if (stripped !== content) {
+        fsImpl.writeFileSync(file, stripped);
+      }
+    }
+  },
+};

--- a/lib/migrations/steps/__tests__/2.2.0-retire-epic-ac-tags.test.js
+++ b/lib/migrations/steps/__tests__/2.2.0-retire-epic-ac-tags.test.js
@@ -1,0 +1,204 @@
+// lib/migrations/steps/__tests__/2.2.0-retire-epic-ac-tags.test.js
+/**
+ * Unit tests for the Story #4604 migration step — strips retired
+ * `@epic-<id>-ac-N` Gherkin AC tags from consumer feature files under the
+ * canonical feature roots. All tests drive `detect`/`apply` against an
+ * in-memory fake fs (testing-standards § Unit) — no real filesystem I/O.
+ */
+
+import assert from 'node:assert/strict';
+import path from 'node:path';
+import { describe, it } from 'node:test';
+
+import { retireEpicAcTags } from '../2.2.0-retire-epic-ac-tags.js';
+
+const PROJECT_ROOT = '/consumer';
+
+/**
+ * Build a ctx over an in-memory file map. Keys are project-root-relative
+ * paths; values are file contents. Directories are derived from the keys.
+ *
+ * @param {Record<string, string>} relFiles
+ * @returns {{ ctx: object, read: (rel: string) => string, writes: string[] }}
+ */
+function makeCtx(relFiles) {
+  const files = new Map(
+    Object.entries(relFiles).map(([rel, content]) => [
+      path.join(PROJECT_ROOT, rel),
+      content,
+    ]),
+  );
+  /** @type {string[]} */
+  const writes = [];
+
+  const dirChildren = (dir) => {
+    const children = new Map();
+    for (const filePath of files.keys()) {
+      if (!filePath.startsWith(`${dir}${path.sep}`)) continue;
+      const rest = filePath.slice(dir.length + 1);
+      const [head, ...tail] = rest.split(path.sep);
+      const isFile = tail.length === 0;
+      if (!children.has(head) || isFile) children.set(head, isFile);
+    }
+    return children;
+  };
+
+  const fs = {
+    readdirSync(dir, opts) {
+      const children = dirChildren(dir);
+      if (children.size === 0) {
+        const err = new Error(`ENOENT: ${dir}`);
+        err.code = 'ENOENT';
+        throw err;
+      }
+      assert.equal(opts?.withFileTypes, true);
+      return [...children.entries()].map(([name, isFile]) => ({
+        name,
+        isFile: () => isFile,
+        isDirectory: () => !isFile,
+      }));
+    },
+    readFileSync(filePath) {
+      if (!files.has(filePath)) {
+        const err = new Error(`ENOENT: ${filePath}`);
+        err.code = 'ENOENT';
+        throw err;
+      }
+      return files.get(filePath);
+    },
+    writeFileSync(filePath, contents) {
+      files.set(filePath, contents);
+      writes.push(filePath);
+    },
+  };
+
+  return {
+    ctx: { projectRoot: PROJECT_ROOT, fs },
+    read: (rel) => files.get(path.join(PROJECT_ROOT, rel)),
+    writes,
+  };
+}
+
+const TAGGED_FEATURE = [
+  'Feature: Billing export',
+  '',
+  '  @domain-billing @epic-4283-ac-1 @skip',
+  '  Scenario: export a monthly invoice',
+  '    Given a paid invoice',
+  '    Then it exports as PDF',
+  '',
+  '  @epic-4283-ac-2',
+  '  Scenario: export refuses an unpaid invoice',
+  '    Given an unpaid invoice',
+  '    Then export is refused',
+  '',
+].join('\n');
+
+describe('retireEpicAcTags — detect', () => {
+  it('detects a stale tag under each canonical feature root', () => {
+    for (const root of ['tests/features', 'features', 'test/features']) {
+      const { ctx } = makeCtx({ [`${root}/billing.feature`]: TAGGED_FEATURE });
+      assert.equal(retireEpicAcTags.detect(ctx), true, root);
+    }
+  });
+
+  it('detects tags in nested subdirectories', () => {
+    const { ctx } = makeCtx({
+      'tests/features/billing/export.feature': TAGGED_FEATURE,
+    });
+    assert.equal(retireEpicAcTags.detect(ctx), true);
+  });
+
+  it('does not detect a tree with only clean feature files', () => {
+    const { ctx } = makeCtx({
+      'tests/features/clean.feature': '@domain-auth @skip\nScenario: sign in\n',
+    });
+    assert.equal(retireEpicAcTags.detect(ctx), false);
+  });
+
+  it('does not detect stale tags outside the canonical roots', () => {
+    const { ctx } = makeCtx({ 'src/other/x.feature': TAGGED_FEATURE });
+    assert.equal(retireEpicAcTags.detect(ctx), false);
+  });
+
+  it('does not detect when no feature roots exist', () => {
+    const { ctx } = makeCtx({});
+    assert.equal(retireEpicAcTags.detect(ctx), false);
+  });
+});
+
+describe('retireEpicAcTags — apply', () => {
+  it('strips stale tokens, keeps sibling tags, and drops emptied tag lines', () => {
+    const { ctx, read } = makeCtx({
+      'tests/features/billing.feature': TAGGED_FEATURE,
+    });
+    retireEpicAcTags.apply(ctx);
+    assert.equal(
+      read('tests/features/billing.feature'),
+      [
+        'Feature: Billing export',
+        '',
+        '  @domain-billing @skip',
+        '  Scenario: export a monthly invoice',
+        '    Given a paid invoice',
+        '    Then it exports as PDF',
+        '',
+        '  Scenario: export refuses an unpaid invoice',
+        '    Given an unpaid invoice',
+        '    Then export is refused',
+        '',
+      ].join('\n'),
+    );
+  });
+
+  it('leaves prose mentioning the pattern outside tag lines untouched', () => {
+    const content = [
+      '@epic-1-ac-1',
+      'Feature: docs',
+      '  Scenario: mentions @epic-2-ac-3 in a step',
+      '    Given the docs mention @epic-2-ac-3 somewhere',
+      '',
+    ].join('\n');
+    const { ctx, read } = makeCtx({ 'features/docs.feature': content });
+    retireEpicAcTags.apply(ctx);
+    assert.equal(
+      read('features/docs.feature'),
+      [
+        'Feature: docs',
+        '  Scenario: mentions @epic-2-ac-3 in a step',
+        '    Given the docs mention @epic-2-ac-3 somewhere',
+        '',
+      ].join('\n'),
+    );
+  });
+
+  it('never rewrites files with no stale tags', () => {
+    const { ctx, writes } = makeCtx({
+      'tests/features/dirty.feature': TAGGED_FEATURE,
+      'tests/features/clean.feature': '@skip\nScenario: clean\n',
+    });
+    retireEpicAcTags.apply(ctx);
+    assert.deepEqual(writes, [
+      path.join(PROJECT_ROOT, 'tests/features/dirty.feature'),
+    ]);
+  });
+
+  it('is idempotent — detect returns false after apply', () => {
+    const { ctx } = makeCtx({
+      'tests/features/billing.feature': TAGGED_FEATURE,
+    });
+    assert.equal(retireEpicAcTags.detect(ctx), true);
+    retireEpicAcTags.apply(ctx);
+    assert.equal(retireEpicAcTags.detect(ctx), false);
+  });
+
+  it('preserves CRLF newlines', () => {
+    const crlf = '@epic-9-ac-9 @smoke\r\nScenario: windows\r\n';
+    const { ctx, read } = makeCtx({ 'features/win.feature': crlf });
+    retireEpicAcTags.apply(ctx);
+    assert.equal(
+      read('features/win.feature'),
+      '@smoke\r\nScenario: windows\r\n',
+    );
+  });
+});


### PR DESCRIPTION
Closes #4604

_Auto-opened by `/deliver`._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are documentation, planner prompt text, and an idempotent consumer upgrade that only edits `.feature` tag lines; no runtime auth or delivery gates.
> 
> **Overview**
> **Retires the `@epic-<id>-ac-N` Gherkin tag namespace** end-to-end after v2 removed the Epic reconciler that consumed it. **Gherkin standards** now document `@skip` for wave-0 scaffolds and mark the Epic AC tag as retired; **`mandrel update`** is expected to clean legacy tags from consumer repos.
> 
> **Planning prompts** no longer take `epicId` or require namespaced AC tags on BDD scaffold stories—wave-0 acceptance/verify checks only **file existence** and **`@skip`** on new scenarios.
> 
> A **2.2.0 migration** (`retireEpicAcTags`) walks canonical feature roots, removes `@epic-<digits>-ac-<digits>` from tag lines (drops emptied tag lines, leaves step text alone), and skips unchanged files; the migration registry and tests are updated for the third step.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9a16b6cb094b2f591b87e5a080a8ebb4d48ec8b5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->