### PR TITLE
docs: reconcile stale references left by #4603 (audit-lens findings)

### DIFF
--- a/.agents/workflows/helpers/code-quality-guardrails.md
+++ b/.agents/workflows/helpers/code-quality-guardrails.md
@@ -15,8 +15,10 @@ read the same numbers from here so a "high cyclomatic complexity" finding in
 
 Run [`npm run quality:preview`](../../../package.json) before committing
 on any Story that touches production source. The preview runs
-`quality-preview.js` with `--changed-since HEAD`, which exercises the
-same maintainability and CRAP engines (`escomplex` + `c8` coverage) that
+`quality-preview.js`, which scopes the diff to `HEAD` by default (the
+alias passes no `--changed-since`; the script defaults to `HEAD`) and
+exercises the same maintainability and CRAP engines (`escomplex` +
+`c8` coverage) that
 `check-baselines.js` enforces at merge time, then merges the results
 into a single per-file delta table. A clean preview means the commit
 will not bounce off the unified baselines gate. The `.husky/pre-commit`
@@ -66,8 +68,9 @@ must-refactor ceiling — any drop past it is treated as a regression that
 must be undone or offset, not absorbed. Set `tolerance` higher only when the
 project deliberately wants a looser MI-drop budget.
 
-`quality:preview --changed-since HEAD` shows the per-file MI delta in the
-working tree before the commit lands.
+`quality:preview` shows the per-file MI delta in the working tree before
+the commit lands (scoped to `HEAD` by default — the alias passes no
+`--changed-since`; the script defaults to `HEAD`).
 
 ## Rename = baseline-refresh
 

--- a/.agents/workflows/helpers/code-review.md
+++ b/.agents/workflows/helpers/code-review.md
@@ -30,7 +30,7 @@ the change set is reviewed by a process the maker cannot influence. The
 enforcing code path is
 [`runStoryScopeReview`](../../scripts/lib/orchestration/single-story-close/phases/code-review.js)
 → shared
-[`runStoryReviewCore`](../../scripts/lib/orchestration/story-close/phases/code-review.js).
+[`runStoryReviewCore`](../../scripts/lib/orchestration/story-close/phases/review-core.js).
 A future refactor MUST preserve this isolation: do not move Story-scope
 review into the maker's context or run it as a step of the delivering
 child.
@@ -122,7 +122,7 @@ The pipeline will:
 ### Step 1a — Story-scope local-lens pass (`scope: story` only, Epic #4405)
 
 When `scope === 'story'`, the shared review spine
-[`runStoryReviewCore`](../../scripts/lib/orchestration/story-close/phases/code-review.js)
+[`runStoryReviewCore`](../../scripts/lib/orchestration/story-close/phases/review-core.js)
 runs a **shift-left local-lens pass** in the same close subprocess, *before*
 returning the review envelope. It:
 

--- a/docs/ci-contract.md
+++ b/docs/ci-contract.md
@@ -36,8 +36,9 @@ authoritative verdict is the CI run on the pull request.
 >
 > Before #4549 the latter two sat in a contract hole — omitted from the mirror
 > *and* absent from the CI-only table below — reachable locally only by a direct
-> invocation or via `npm run quality:preview`, whose `--changed-since HEAD` diff
-> scoping makes it a pre-commit tool rather than a full-tree gate. That hole
+> invocation or via `npm run quality:preview`, whose `HEAD`-scoped diff (the
+> alias passes no `--changed-since`; the script defaults to `HEAD`) makes it a
+> pre-commit tool rather than a full-tree gate. That hole
 > cost Story #4531 / PR #4548 a full push → CI-red → fix → push round-trip on a
 > stray `export default` a local check would have caught in seconds.
 > `quality:preview` keeps its existing scope and gate set — the two commands


### PR DESCRIPTION
## Why

The audit-lens walk over the #4602+#4603 delivery (2026-07-17) surfaced three LOW/cosmetic stale doc references created by #4603's changes. None affects behavior — all are text pointing at a moved symbol or a dropped flag.

## Changes

- **`.agents/workflows/helpers/code-review.md`** (lines 33, 125) — repoint both `runStoryReviewCore` cross-references from `story-close/phases/code-review.js` to the new `story-close/phases/review-core.js`. #4603 moved the function there; `code-review.js` now only re-exports it.
- **`.agents/workflows/helpers/code-quality-guardrails.md`** (lines 18, 69) — soften the "`quality:preview` runs `--changed-since HEAD`" phrasing. The npm alias now passes no `--changed-since`; HEAD scoping comes from `quality-preview.js`'s in-script default (`parseChangedSinceArg(argv) ?? 'HEAD'`). Effective scope unchanged (still HEAD).
- **`docs/ci-contract.md`** (line 39) — same softening for the parenthetical describing `quality:preview`'s scope.

## Verification

`node .agents/scripts/check-doc-links.js` → exit 0 (113 files scanned, no violations). Docs-only; the delivered #4603 code itself was verified clean by the lens walk.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only edits; no code, CI, or gate behavior changes.
> 
> **Overview**
> **Docs-only follow-up** to #4603: fixes stale cross-references from an audit-lens pass. No runtime or behavior changes.
> 
> **`runStoryReviewCore` links** in `code-review.md` now point at `story-close/phases/review-core.js` instead of `code-review.js`, matching where the shared review spine lives after the extract.
> 
> **`quality:preview` wording** in `code-quality-guardrails.md` and `ci-contract.md` no longer says the npm alias runs `--changed-since HEAD`. It now states that HEAD-scoped diffs come from `quality-preview.js`’s default when the alias omits `--changed-since` — same effective scope as before.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3598332d37788705ab7368ea7431e21ebc378021. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->