### PR TITLE
fix(test): resolve Windows drive-letter path bug in quality-preview test

### DIFF
--- a/tests/quality-preview.test.js
+++ b/tests/quality-preview.test.js
@@ -3,6 +3,7 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { test } from 'node:test';
+import { fileURLToPath } from 'node:url';
 import {
   computeExitCode,
   mergeEnvelopes,
@@ -92,11 +93,10 @@ test('quality:preview npm script keeps quality-preview.js LAST (passthrough reac
   //
   // Any command appended AFTER quality-preview.js re-breaks this. Keep the
   // flag-consuming gate last.
-  const pkgPath = path.join(
-    path.dirname(new URL(import.meta.url).pathname),
-    '..',
-    'package.json',
-  );
+  // fileURLToPath (not `new URL(...).pathname`) so the drive letter resolves
+  // correctly on Windows — the raw pathname is `/D:/…`, and path.join would
+  // yield a doubled-drive `D:\D:\…` that ENOENTs. See Windows Smoke CI.
+  const pkgPath = fileURLToPath(new URL('../package.json', import.meta.url));
   const script = JSON.parse(fs.readFileSync(pkgPath, 'utf-8')).scripts[
     'quality:preview'
   ];


### PR DESCRIPTION
## Why

CI run [29593461481](https://github.com/dsj1984/mandrel/actions/runs/29593461481) turned **Windows Smoke → Fast Test Slice** red on `main` right after #4610 squash-merged.

**Failure signature:**
```
not ok 729 - quality:preview npm script keeps quality-preview.js LAST (passthrough reachability)
error: "ENOENT: no such file or directory, open 'D:\D:\a\mandrel\mandrel\package.json'"
  tests/quality-preview.test.js:100
```

## Root cause

The passthrough-reachability test added in #4610 built its `package.json` path with:

```js
path.dirname(new URL(import.meta.url).pathname)
```

On Windows, `new URL(import.meta.url).pathname` is `/D:/a/mandrel/mandrel/tests/…` (leading slash before the drive letter). `path.join(..., '..', 'package.json')` yields a root-relative `\D:\a\mandrel\mandrel\package.json`, which `readFileSync` then resolves against cwd — producing the doubled-drive `D:\D:\…` that ENOENTs. POSIX runners are unaffected, so the bug only surfaced on Windows Smoke.

Notably the two production callers of the same idiom (`quality-preview.js`, `quality-watch.js`) already strip the leading slash via a `normalizedSelf` guard; the new test simply omitted that normalization.

## Fix

Switch to `fileURLToPath(new URL('../package.json', import.meta.url))` — the repo's established cross-platform pattern (used across `single-story-close-review.test.js`, `diagnose-friction.test.js`, etc.). Resolves the drive letter correctly on every platform.

Deterministic, real, diff-caused failure — root-caused and fixed at source per `ci-remediation.md`; no rerun/quarantine.

## Verification

- `node --test tests/quality-preview.test.js` → 22 pass, 0 fail (macOS)
- `npx biome check tests/quality-preview.test.js` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only path resolution change; no production or gate behavior changes.
> 
> **Overview**
> Fixes **Windows Smoke CI** failure in the passthrough-reachability test that reads `package.json` to assert `quality-preview.js` stays last in `quality:preview`.
> 
> The test no longer builds paths from `new URL(import.meta.url).pathname` plus `path.join` (which on Windows produces a doubled drive like `D:\D:\…` and ENOENT). It now uses **`fileURLToPath(new URL('../package.json', import.meta.url))`**, matching other tests in the repo. A short comment documents why.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 76aec5f6882b73e31e7db6df340b936a35ea1504. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->