### PR TITLE
fix(deliver): keep --concurrency opt-in so local cap override is honored

### DIFF
--- a/.agents/workflows/deliver.md
+++ b/.agents/workflows/deliver.md
@@ -44,7 +44,7 @@ silently dropping the offending id and under-delivering.
 
 | Flag | Meaning |
 | --- | --- |
-| `--concurrency <n>` | Ready-set fan-out cap (default **3** from `delivery.deliverRunner.concurrencyCap`; set `1` for sequential). |
+| `--concurrency <n>` | **Optional** per-run override of the ready-set fan-out cap. Omit it to honor `delivery.deliverRunner.concurrencyCap` (config default **3**, including any `.agentrc.local.json` override); pass it **only** when the operator explicitly wants a one-run cap. Set `1` for sequential. |
 | `--yes` | Suppress the multi-Story confirmation gate. |
 | `--steal` | Forwarded to `single-story-init.js` / lease steal. |
 | `--wait-merge` | Force close-and-land (the default; `delivery.routing.closeAndLand`, default `true`). |
@@ -85,9 +85,18 @@ to respect.
 
    ```bash
    node .agents/scripts/stories-wave-tick.js \
-     --stories <id,id,...> --probe-live --concurrency <n> \
+     --stories <id,id,...> --probe-live \
      --dispatched <every id you have dispatched so far>
    ```
+
+   **Do not add `--concurrency` unless the operator explicitly asked for a
+   per-run cap.** Omitting it is what lets the tick resolve the cap from
+   `delivery.deliverRunner.concurrencyCap` — including a `.agentrc.local.json`
+   override. An explicit `--concurrency <n>` wins over config for that run
+   (`resolveConcurrencyCap` returns the flag before it ever reads config), so
+   filling in a literal — e.g. the documented default `3` — silently defeats
+   the operator's configured override. Thread `--concurrency` through here
+   only when it was passed to `/deliver`.
 
    Each beat re-probes live state: it re-resolves the graph, classifies done
    (`agent::done` or a closed issue — including foreign blockers that landed

--- a/tests/deliver-epic-single.test.js
+++ b/tests/deliver-epic-single.test.js
@@ -75,6 +75,35 @@ describe('unified /deliver router', () => {
       /resolveEpicDeliveryRoute|wave-tick\.js --check-idle/,
     );
   });
+
+  it('keeps --concurrency opt-in so a local override is not silently defeated', () => {
+    // `resolveConcurrencyCap` returns the `--concurrency` flag before it ever
+    // reads config, so any explicit value outranks
+    // `delivery.deliverRunner.concurrencyCap` (including a `.agentrc.local.json`
+    // override). The canonical sequencing command must therefore NOT hardcode
+    // the flag — an executing agent that fills in `<n>` (typically the
+    // documented default 3) would defeat the operator's configured cap.
+    const md = readFileSync(DELIVER_MD, 'utf8');
+    const commandTemplate = md.match(
+      /stories-wave-tick\.js \\\n\s*--stories <id,id,\.\.\.> --probe-live[^\n]*/,
+    );
+    assert.ok(
+      commandTemplate,
+      'the sequencing command template must be present',
+    );
+    assert.doesNotMatch(
+      commandTemplate[0],
+      /--concurrency/,
+      'the default sequencing command must not hardcode --concurrency',
+    );
+    // The opt-in contract must be spelled out so the flag is threaded through
+    // only when the operator explicitly passed one.
+    assert.match(
+      md,
+      /Do not add `--concurrency` unless the operator explicitly asked/,
+    );
+    assert.match(md, /\.agentrc\.local\.json/);
+  });
 });
 
 describe('/deliver takes only Story ids (Story #4540)', () => {


### PR DESCRIPTION
## Why

Operators reported that `delivery.deliverRunner.concurrencyCap` set in `.agentrc.local.json` was ignored on some `/deliver` runs.

The **config resolution logic is correct** — `.agentrc.local.json` deep-merges over `.agentrc.json`, and `getRunners` / `resolveConcurrencyCap` return the merged value (verified end-to-end; existing tests cover config-default, config-override, and flag-precedence).

The bug was in the **workflow prompt**. `resolveConcurrencyCap()` returns the `--concurrency` CLI flag *before* it ever reads config:

```js
if (override != null) return override;   // flag wins, config never consulted
```

That precedence is intended (a per-run override). But [`deliver.md`](.agents/workflows/deliver.md) hardcoded `--concurrency <n>` into the one canonical sequencing command every agent copies, and the Flags table documented it as *"default 3"*. So an agent driving `/deliver` filled in `<n>` — usually the documented `3` — and silently outranked the operator's configured cap. The symptom was non-deterministic per run/client, with the config file untouched and no error.

## What changed

- Drop `--concurrency <n>` from the default sequencing command template.
- Document `--concurrency` as an **opt-in** per-run override, threaded through only when the operator explicitly passed one; soften the Flags-table wording so "default 3" reads as the *config* default.
- Add a workflow-prose guard in `tests/deliver-epic-single.test.js` asserting the sequencing template does not hardcode the flag and that the opt-in contract is spelled out.

No code behavior change — the flag precedence itself is correct by design.

## Verification

- `node --test tests/deliver-epic-single.test.js` — 10 pass (incl. new guard)
- `node --test tests/scripts/stories-wave-tick.test.js` — 74 pass
- `npm run lint`, doc-links, workflow-cli-lint — clean
- Confirmed the new guard fails against the pre-fix template.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and workflow-contract tests only; deliver concurrency resolution code is unchanged.
> 
> **Overview**
> Fixes `/deliver` runs ignoring `delivery.deliverRunner.concurrencyCap` (including `.agentrc.local.json`) when agents followed the workflow literally.
> 
> The canonical **`stories-wave-tick.js`** example no longer includes `--concurrency <n>`. The Flags table and sequencing step now treat **`--concurrency` as an optional per-run override** only when the operator passed it to `/deliver`, because an explicit flag wins over config in `resolveConcurrencyCap`.
> 
> Adds a **`deliver-epic-single.test.js`** guard so the default sequencing template must not hardcode `--concurrency` and the opt-in contract stays documented. **No runtime behavior change.**
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 82a1844d1b0ebbf4d4cd378e0146b4806c1fa608. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->