### PR TITLE
feat: harden cross-run Story-delivery de-confliction: lease-aware probe, executing-label refusal, race-verified lease acquire, early claim publication (#4620)

### DIFF
--- a/.agents/scripts/lib/orchestration/resolve-stories.js
+++ b/.agents/scripts/lib/orchestration/resolve-stories.js
@@ -62,7 +62,7 @@ function normalizeIssueLabels(issue) {
  *
  * @param {object} issue
  * @param {number} [requestedId] The id the operator asked for, for error text.
- * @returns {{ id, title, body, url, labels, state }}
+ * @returns {{ id, title, body, url, labels, state, assignees }}
  */
 export function toStoryRecord(issue, requestedId) {
   const id = Number(issue?.number ?? issue?.id ?? requestedId);
@@ -93,6 +93,14 @@ export function toStoryRecord(issue, requestedId) {
     url: issue?.html_url ?? issue?.url ?? null,
     labels,
     state: String(issue?.state ?? 'open').toLowerCase(),
+    // The assignee list carries the Story lease (`ticket-lease.js`): its sole
+    // assignee is the operator that owns the in-flight run. The probe reads it
+    // to withhold a Story another operator holds (`live-probe.js`), so it is
+    // threaded onto the record here rather than dropped. `issueToTicket`
+    // already reduces assignees to bare login strings; keep only those.
+    assignees: Array.isArray(issue?.assignees)
+      ? issue.assignees.filter((a) => typeof a === 'string' && a.length > 0)
+      : [],
   };
 }
 

--- a/.agents/scripts/lib/orchestration/ticket-lease.js
+++ b/.agents/scripts/lib/orchestration/ticket-lease.js
@@ -211,6 +211,16 @@ export async function describeLease(opts) {
  *                                     `reason: 'reclaimed'`.
  *   - Foreign claim + `steal:true` → reassign operator, `acquired: true`,
  *                                     `reason: 'stolen'`.
+ *   - Lost a write race            → a foreign login co-assigned between our
+ *                                     PATCH and the verify re-read; back the
+ *                                     operator out, `acquired: false`,
+ *                                     `owner: <foreign>`, `reason: 'lost-race'`.
+ *
+ * Every claiming write is verified: GitHub's assignee PATCH is not a
+ * compare-and-set, so two runs that both read the ticket unassigned will both
+ * write themselves. {@link claimAndVerify} re-reads after the write and refuses
+ * (fail-closed) when a foreign login is present, so the loser of a simultaneous
+ * claim never proceeds as though it holds the lease.
  *
  * @param {object} opts
  * @param {object} opts.provider              Ticketing provider.
@@ -225,7 +235,7 @@ export async function describeLease(opts) {
  *   acquired: boolean,
  *   owner: string,
  *   previousOwner: string|null,
- *   reason: 'unclaimed'|'already-held'|'reclaimed'|'stolen'|'held',
+ *   reason: 'unclaimed'|'already-held'|'reclaimed'|'stolen'|'held'|'lost-race',
  * }>}
  */
 export async function acquireLease(opts) {
@@ -240,13 +250,13 @@ export async function acquireLease(opts) {
 
   // Unclaimed → take it.
   if (owner === null) {
-    await provider.updateTicket(ticketId, { assignees: [operator] });
-    return {
-      acquired: true,
-      owner: operator,
+    return claimAndVerify({
+      provider,
+      ticketId,
+      operator,
       previousOwner: null,
       reason: 'unclaimed',
-    };
+    });
   }
 
   // Already ours → no write needed.
@@ -270,12 +280,70 @@ export async function acquireLease(opts) {
     };
   }
 
-  await provider.updateTicket(ticketId, { assignees: [operator] });
-  return {
-    acquired: true,
-    owner: operator,
+  return claimAndVerify({
+    provider,
+    ticketId,
+    operator,
     previousOwner: owner,
     reason: steal && live ? 'stolen' : 'reclaimed',
+  });
+}
+
+/**
+ * Write the operator to a ticket's assignees, then re-read to confirm the
+ * claim actually stuck before reporting success.
+ *
+ * The assignee write is not atomic — GitHub offers no compare-and-set on the
+ * assignees surface — so two runs that both observed the ticket unassigned (or
+ * a stale foreign claim) will both PATCH themselves in. Without a check the
+ * loser of that race returns `acquired: true` and marches into the worktree
+ * the winner is already building. The verify closes that window: it re-reads
+ * with `fresh: true` (bypassing any provider cache so it sees the other run's
+ * write, not our own), and if a foreign login is present it concedes — removes
+ * the operator from the assignee set so no phantom co-owner lingers, and
+ * returns `acquired: false` / `reason: 'lost-race'` so the fail-closed caller
+ * refuses. A clean read (assignees exactly `[operator]`) confirms the claim.
+ *
+ * It does not eliminate the race — two writes still happen — but it makes the
+ * outcome deterministic: exactly one operator survives as the sole assignee,
+ * and the other is told it lost.
+ *
+ * @param {object} args
+ * @param {object} args.provider              Ticketing provider.
+ * @param {number} args.ticketId              Ticket being claimed.
+ * @param {string} args.operator              Operator acquiring the lease.
+ * @param {string|null} args.previousOwner    Owner before this write (for the result).
+ * @param {string} args.reason                Success reason when the claim holds.
+ * @returns {Promise<{ acquired: boolean, owner: string, previousOwner: string|null, reason: string }>}
+ */
+async function claimAndVerify({
+  provider,
+  ticketId,
+  operator,
+  previousOwner,
+  reason,
+}) {
+  await provider.updateTicket(ticketId, { assignees: [operator] });
+
+  const after = await provider.getTicket(ticketId, { fresh: true });
+  const assignees = Array.isArray(after?.assignees) ? after.assignees : [];
+  const foreign = assignees.filter((login) => login !== operator);
+
+  if (foreign.length === 0) {
+    return { acquired: true, owner: operator, previousOwner, reason };
+  }
+
+  // A foreign login co-assigned after our write — we lost a simultaneous
+  // claim. Back ourselves out so the winner is the sole assignee, and report
+  // the loss so the fail-closed caller refuses rather than double-delivering.
+  await provider
+    .updateTicket(ticketId, { assignees: foreign })
+    .catch(() => undefined);
+  return {
+    acquired: false,
+    owner: foreign[0],
+    previousOwner,
+    reason: 'lost-race',
   };
 }
 

--- a/.agents/scripts/lib/wave-runner/live-probe.js
+++ b/.agents/scripts/lib/wave-runner/live-probe.js
@@ -25,11 +25,16 @@
  *     labels, **unioned with the ids the host says it has dispatched**
  *     (`--dispatched`). The label alone is not sufficient: the kernel's
  *     contract counts "executing / closing / dispatched-not-yet-labelled" as
- *     in-flight, and `single-story-init.js` flips `agent::executing` at step 6
- *     of 6 — *after* a 3–6 minute worktree install. For that whole window a
- *     dispatched Story still reads `agent::ready`, so a label-only derivation
- *     re-emits it in the next beat's `ready[]` and the host dispatches it a
- *     second time onto the same branch and worktree (Story #4601).
+ *     in-flight, and there is still a window between the host spawning a
+ *     sub-agent and that sub-agent's `single-story-init.js` publishing the
+ *     `agent::executing` label. Story #4620 shrank that window sharply — the
+ *     flip now lands before the multi-minute worktree install rather than
+ *     after it — but it is not zero (init still runs the lease acquire and a
+ *     branch fetch first), so a label-only derivation could still re-emit a
+ *     just-dispatched Story in the next beat's `ready[]` and dispatch it a
+ *     second time onto the same branch (Story #4601). `--dispatched` closes
+ *     the residual window; foreign runs are covered by the assignee lease
+ *     (see `deriveForeignHeld`).
  *   - **blocked** — the ids carrying `agent::blocked`. `classifyStory` has
  *     always returned this class; nothing consumed it, so a blocked Story was
  *     neither done, ready, nor in-flight and the beat reported a permanent
@@ -56,6 +61,10 @@ import {
 } from '../../resolve-stories.js';
 import { AGENT_LABELS } from '../label-constants.js';
 import { buildStoriesEnvelope } from '../orchestration/resolve-stories.js';
+import {
+  currentOwner,
+  normalizeOperatorHandle,
+} from '../orchestration/ticket-lease.js';
 import { classifyStory, storyIdOf } from './ready-set.js';
 
 /**
@@ -67,10 +76,13 @@ import { classifyStory, storyIdOf } from './ready-set.js';
  *   1. **Live labels.** `classifyStory` folds `agent::executing` and
  *      `agent::closing` into one `executing` class — both are in-flight and
  *      neither may be re-dispatched.
- *   2. **`dispatched`** — ids the host has spawned. This closes the init
- *      window: `single-story-init.js` flips `agent::executing` last, after a
- *      3–6 minute install, so between spawn and flip a dispatched Story reads
- *      `agent::ready` and a label-only derivation hands it back as ready.
+ *   2. **`dispatched`** — ids the host has spawned. This closes the residual
+ *      init window: between the host spawning a sub-agent and that agent's
+ *      `single-story-init.js` publishing `agent::executing`, a dispatched Story
+ *      still reads `agent::ready` and a label-only derivation hands it back as
+ *      ready. Story #4620 moved the flip ahead of the worktree install, so the
+ *      window is now short rather than minutes-long, but `--dispatched` still
+ *      covers it deterministically.
  *
  * `dispatched` is deliberately **not** the `--done`-style accounting probe
  * mode retired. Three properties keep it from becoming one:
@@ -130,6 +142,54 @@ function deriveBlockedIds(storyRecords) {
 }
 
 /**
+ * Identify Stories claimed by a **different** operator's lease.
+ *
+ * The Story lease rides the ticket's assignees (`ticket-lease.js`): the sole
+ * assignee is the operator driving that Story's run. `single-story-init.js`
+ * takes the lease at init, but flips `agent::executing` only after a 3–6 minute
+ * worktree install — so for that whole window a Story another operator is
+ * actively delivering still reads `agent::ready` with no in-flight label. A
+ * label-only probe classifies it `ready` and hands it to this run, which then
+ * dispatches into a guaranteed init failure (the fail-closed lease refuses a
+ * foreign assignee) mid-batch. Reading the assignee lets the probe withhold it
+ * up front and report who holds it instead.
+ *
+ * Only Stories that would otherwise be `ready` are considered — a `done`,
+ * `blocked`, or already-`executing` Story is handled by its own class, and a
+ * self-held assignee is this run's own claim and never withholds.
+ *
+ * When `self` is unresolved (no `github.operatorHandle`), foreign cannot be
+ * told from self, so this returns empty and warns once: the probe is a
+ * read-only path that must not fail closed, and init's lease acquire remains
+ * the backstop.
+ *
+ * @param {Array<{id?: number, number?: number, labels?: string[], state?: string, assignees?: string[]}>} storyRecords
+ * @param {string|null|undefined} self  Resolved bare operator login for this run.
+ * @param {(msg: string) => void} [warn]
+ * @returns {Map<number, string>} Foreign-held Story id → holder login.
+ */
+function deriveForeignHeld(storyRecords, self, warn) {
+  const held = new Map();
+  if (!self) {
+    warn?.(
+      '[live-probe] github.operatorHandle is unset (or the shipped ' +
+        '@[USERNAME] placeholder), so a foreign lease cannot be told from ' +
+        'this run’s own claim — skipping assignee-based withholding. ' +
+        'Set your handle in .agentrc.local.json to de-conflict concurrent ' +
+        'runs at probe time; init’s lease still refuses a foreign claim.',
+    );
+    return held;
+  }
+  for (const rec of storyRecords) {
+    const id = storyIdOf(rec);
+    if (id === null || classifyStory(rec) !== 'ready') continue;
+    const owner = currentOwner(rec.assignees);
+    if (owner && owner !== self) held.set(id, owner);
+  }
+  return held;
+}
+
+/**
  * Resolve the provider + repo coordinates the probe reads through.
  *
  * Shares `resolve-stories.js`'s provider seam, so probe mode authenticates and
@@ -138,13 +198,21 @@ function deriveBlockedIds(storyRecords) {
  *
  * @param {object} [deps]
  * @param {Function} [deps.resolveProvider] Injection seam for tests.
- * @returns {{ provider: object, owner: string|undefined, repo: string|undefined }}
+ * @returns {{ provider: object, owner: string|undefined, repo: string|undefined, self: string|null }}
  */
 export function createProbeContext({
   resolveProvider = resolveStoriesProvider,
 } = {}) {
   const { provider, config } = resolveProvider();
-  return { provider, owner: config?.github?.owner, repo: config?.github?.repo };
+  return {
+    provider,
+    owner: config?.github?.owner,
+    repo: config?.github?.repo,
+    // Bare login this run claims leases under. Normalised (leading `@` stripped,
+    // `@[USERNAME]` placeholder → null) so it compares against the bare assignee
+    // logins GitHub returns; `null` disables assignee-based withholding.
+    self: normalizeOperatorHandle(config?.github?.operatorHandle),
+  };
 }
 
 /**
@@ -165,6 +233,10 @@ export function createProbeContext({
  * @param {boolean} [args.native=true]   Read native `blocked_by` edges.
  * @param {number[]} [args.dispatched=[]] Ids the host has spawned but may not
  *   yet have observed labelled `agent::executing` (see `deriveInFlightIds`).
+ * @param {string|null} [args.self]     Resolved bare operator login for this
+ *   run, used to withhold Stories another operator's lease holds
+ *   (`deriveForeignHeld`). Absent/unresolved → assignee-based withholding is
+ *   skipped (the probe never fails closed).
  * @param {(msg: string) => void} [args.warn]
  * Each returned node carries its **live labels**. That is load-bearing, not
  * decoration: `selectReadySet` classifies from labels, so a node stripped of
@@ -177,7 +249,8 @@ export function createProbeContext({
  *   nodes: Array<{id: number, dependsOn: number[], files: string[], labels: string[]}>,
  *   doneIds: Set<number>,
  *   inFlight: number,
- *   blockedIds: number[]
+ *   blockedIds: number[],
+ *   foreignHeld: Array<{id: number, holder: string}>
  * }>}
  */
 export async function probeLiveState({
@@ -187,6 +260,7 @@ export async function probeLiveState({
   repo,
   native = true,
   dispatched = [],
+  self,
   warn,
 }) {
   const stories = await fetchStories(provider, ids);
@@ -209,6 +283,12 @@ export async function probeLiveState({
 
   const labelsById = new Map(stories.map((s) => [s.id, s.labels ?? []]));
   const inFlightIds = deriveInFlightIds(stories, dispatched);
+  // A Story another operator's lease holds occupies a (global) dispatch slot
+  // just like an in-flight one: fold it into the in-flight set so it is both
+  // withheld (via the projected label) and excluded from a false wedge, but
+  // never dispatched by this run.
+  const foreignHeld = deriveForeignHeld(stories, self, warn);
+  for (const id of foreignHeld.keys()) inFlightIds.add(id);
   return {
     nodes: envelope.dag.map((node) => ({
       ...node,
@@ -220,6 +300,7 @@ export async function probeLiveState({
     doneIds: new Set(envelope.done),
     inFlight: inFlightIds.size,
     blockedIds: deriveBlockedIds(stories),
+    foreignHeld: [...foreignHeld].map(([id, holder]) => ({ id, holder })),
   };
 }
 

--- a/.agents/scripts/single-story-init.js
+++ b/.agents/scripts/single-story-init.js
@@ -11,14 +11,19 @@
  *
  * What this script does:
  *   1. Validate the Story (type::story, not closed).
- *   2. Fetch origin.
- *   3. Create the Story branch from `project.baseBranch` (default
+ *   2. Acquire the assignee lease, then refuse a Story already labelled
+ *      `agent::executing` this run does not hold (unless `--steal`).
+ *   3. Flip the Story to `agent::executing` — BEFORE provisioning, so the
+ *      claim is label-visible to concurrent operators' probes during the
+ *      multi-minute install window (Story #4620). A provisioning failure after
+ *      this reverts the label and releases the lease.
+ *   4. Fetch origin.
+ *   5. Create the Story branch from `project.baseBranch` (default
  *      `main`) — local-only, no remote push at this stage.
- *   4. Materialise a worktree at `.worktrees/story-<id>/` when worktree
+ *   6. Materialise a worktree at `.worktrees/story-<id>/` when worktree
  *      isolation is enabled; otherwise check out the branch in-place.
- *   5. Upsert a `story-init` structured comment carrying
+ *   7. Upsert a `story-init` structured comment carrying
  *      `standalone: true`.
- *   6. Flip the Story to `agent::executing`.
  *
  * What this script does NOT do:
  *   - Child-Task transitions — a Story is atomic (one branch, one
@@ -55,7 +60,10 @@ import {
   planFastForward,
 } from './lib/orchestration/git-cleanup/phases/fast-forward.js';
 import { verifyRemote } from './lib/orchestration/remote-verifier.js';
-import { acquireStoryLease } from './lib/orchestration/single-story-lease-guard.js';
+import {
+  acquireStoryLease,
+  releaseStoryLease,
+} from './lib/orchestration/single-story-lease-guard.js';
 import { handleRemoteVerificationFailure } from './lib/orchestration/story-init-remote.js';
 import {
   STATE_LABELS,
@@ -123,6 +131,127 @@ export function assertDeliverableStory(story, storyId) {
     throw new Error(
       `Story #${storyId} still declares an Epic/Parent footer. ` +
         'v2 delivery is Story-only — re-plan as a standalone Story before /deliver.',
+    );
+  }
+}
+
+/**
+ * Defense-in-depth refusal for a Story already labelled `agent::executing`
+ * that this run does not already hold.
+ *
+ * The assignee lease is the primary cross-run guard, but the label and the
+ * assignee can drift apart: a prior run that crashed *after* the early
+ * `agent::executing` flip but *before* (or without) taking/holding the lease
+ * leaves the Story labelled executing with no live foreign lease to trip the
+ * lease preflight. Left unchecked, a fresh run would seed the branch and
+ * worktree straight over that drift. Refuse unless the caller already holds the
+ * lease (`reason === 'already-held'`, i.e. a legitimate idempotent re-init) or
+ * passed `--steal`.
+ *
+ * Runs *after* the lease acquire (so it can read the acquire's reason) but
+ * *before* any git mutation. On refusal it releases the lease this run just
+ * took so the ticket is left exactly as found — a clean state for the operator
+ * to inspect before re-running with `--steal`.
+ *
+ * @param {object} args
+ * @param {{ labels?: string[] }} args.story        Fetched Story ticket.
+ * @param {{ reason: string, previousOwner: string|null }} args.lease  Acquire result.
+ * @param {boolean} args.stealRequested
+ * @param {number} args.storyId
+ * @param {object} args.provider
+ * @param {object} args.config
+ */
+export async function assertNotForeignExecuting({
+  story,
+  lease,
+  stealRequested,
+  storyId,
+  provider,
+  config,
+}) {
+  const labelled =
+    Array.isArray(story?.labels) &&
+    story.labels.includes(STATE_LABELS.EXECUTING);
+  if (!labelled || stealRequested || lease.reason === 'already-held') return;
+
+  // Back out the lease we just took so the refusal leaves the ticket unchanged.
+  try {
+    await releaseStoryLease({ provider, storyId, config });
+  } catch (err) {
+    Logger.error(
+      `[single-story-init] ⚠️ Failed to release lease during executing-refusal: ${err?.message ?? err}`,
+    );
+  }
+  throw new Error(
+    `Story #${storyId} is already labelled agent::executing` +
+      (lease.previousOwner
+        ? ` (assignee @${lease.previousOwner})`
+        : ' with no assignee') +
+      '. Another /deliver run may already own it. Confirm that run is dead, ' +
+      'then re-run with --steal to take it.',
+  );
+}
+
+/**
+ * Publish this run's claim as the `agent::executing` label **before** the
+ * multi-minute worktree install, so a concurrent operator's probe sees the
+ * claim during the install window instead of reading `agent::ready` and
+ * dispatching the Story a second time.
+ *
+ * Best-effort: the assignee lease is the real guard, so a failed flip logs and
+ * proceeds rather than aborting init. Routes through `transitionTicketState`
+ * so the Projects v2 Status column follows the label (Story #2548).
+ *
+ * @param {object} provider
+ * @param {number} storyId
+ * @param {object} story  Prefetched snapshot (round-trip elimination).
+ * @returns {Promise<void>}
+ */
+async function flipStoryToExecuting(provider, storyId, story) {
+  try {
+    await transitionTicketState(provider, storyId, STATE_LABELS.EXECUTING, {
+      ticketSnapshot: story,
+      cascade: false,
+    });
+    progress('LABELS', `🏷️  Story #${storyId} → agent::executing`);
+  } catch (err) {
+    Logger.error(
+      `[single-story-init] ⚠️ Failed to flip Story labels: ${err?.message ?? err}`,
+    );
+  }
+}
+
+/**
+ * Undo this run's claim when provisioning fails after the early
+ * `agent::executing` flip: revert the label to `agent::ready` and release the
+ * lease, both best-effort. Without this a crashed init would strand the Story
+ * as phantom-executing — claimed and labelled in-flight but with no live run —
+ * which every other operator's probe would then withhold indefinitely.
+ *
+ * @param {object} provider
+ * @param {number} storyId
+ * @param {object} config
+ * @returns {Promise<void>}
+ */
+async function rollbackClaimOnInitFailure(provider, storyId, config) {
+  try {
+    await transitionTicketState(provider, storyId, STATE_LABELS.READY, {
+      cascade: false,
+    });
+    progress(
+      'ROLLBACK',
+      `↩️  Reverted Story #${storyId} → agent::ready after init failure`,
+    );
+  } catch (err) {
+    Logger.error(
+      `[single-story-init] ⚠️ Failed to revert label after init failure: ${err?.message ?? err}`,
+    );
+  }
+  try {
+    await releaseStoryLease({ provider, storyId, config });
+  } catch (err) {
+    Logger.error(
+      `[single-story-init] ⚠️ Failed to release lease after init failure: ${err?.message ?? err}`,
     );
   }
 }
@@ -449,6 +578,11 @@ export async function runSingleStoryInit({
   steal = false,
   leaseNow,
   injectedVerifyRemote,
+  // Story #4620: swap the git-touching provisioning steps so the
+  // early-flip-then-rollback ordering is unit-testable without a real worktree.
+  injectedMaterialize = materializeBaseBranch,
+  injectedSeedBranch = seedStoryBranch,
+  injectedProvisionWorktree = provisionWorktree,
 } = {}) {
   const parsed =
     storyIdParam !== undefined
@@ -523,6 +657,10 @@ export async function runSingleStoryInit({
   // assignee is treated as a live claim and aborts init (naming the current
   // owner) unless --steal forcibly transfers it. Unclaimed / self-held claims
   // proceed. Skipped under --dry-run (no assignee mutation).
+  let workCwd = cwd;
+  let worktreeCreated = false;
+  let installStatus = { status: 'skipped', reason: 'dry-run' };
+
   if (!dryRun) {
     const acquire = injectedAcquireLease ?? acquireStoryLease;
     const lease = await acquire({
@@ -536,31 +674,51 @@ export async function runSingleStoryInit({
       'LEASE',
       `🔒 Story #${storyId} lease ${lease.reason} (owner=@${lease.owner}).`,
     );
-  }
 
-  let workCwd = cwd;
-  let worktreeCreated = false;
-  let installStatus = { status: 'skipped', reason: 'dry-run' };
-
-  if (!dryRun) {
-    await materializeBaseBranch({
-      cwd,
-      baseBranch,
-      storyBranch,
-      config,
-      provider,
-      injectedSweep,
-      progress,
-    });
-    seedStoryBranch({ cwd, storyBranch, baseBranch, progress });
-    ({ workCwd, worktreeCreated, installStatus } = await provisionWorktree({
-      runtime,
-      cwd,
+    // Defense in depth: refuse a Story already labelled agent::executing that
+    // this run does not hold (label/assignee drift the lease alone misses).
+    // Runs before any git mutation; releases the just-taken lease on refusal.
+    await assertNotForeignExecuting({
+      story,
+      lease,
+      stealRequested,
       storyId,
-      storyBranch,
+      provider,
       config,
-      progress,
-    }));
+    });
+
+    // Publish the claim as agent::executing BEFORE the multi-minute worktree
+    // install (not after), so a concurrent operator's probe sees it during the
+    // install window instead of reading agent::ready and double-dispatching.
+    await flipStoryToExecuting(provider, storyId, story);
+
+    // Any failure from here on leaves a claimed, executing-labelled Story with
+    // no live run behind it — revert the label and release the lease so the
+    // Story is not stranded as phantom-executing.
+    try {
+      await injectedMaterialize({
+        cwd,
+        baseBranch,
+        storyBranch,
+        config,
+        provider,
+        injectedSweep,
+        progress,
+      });
+      injectedSeedBranch({ cwd, storyBranch, baseBranch, progress });
+      ({ workCwd, worktreeCreated, installStatus } =
+        await injectedProvisionWorktree({
+          runtime,
+          cwd,
+          storyId,
+          storyBranch,
+          config,
+          progress,
+        }));
+    } catch (err) {
+      await rollbackClaimOnInitFailure(provider, storyId, config);
+      throw err;
+    }
   }
 
   const dependenciesInstalled =
@@ -589,8 +747,9 @@ export async function runSingleStoryInit({
     remoteProbe: { remoteUrl: remote.remoteUrl, detail: remote.detail },
   };
 
-  // Upsert the `story-init` structured comment + flip Story to executing.
-  // Both are no-ops under --dry-run.
+  // Upsert the `story-init` structured comment (no-op under --dry-run). The
+  // `agent::executing` flip already happened above, before provisioning, so the
+  // claim is label-visible during the install window (see `flipStoryToExecuting`).
   if (!dryRun) {
     try {
       await upsertStructuredComment(
@@ -606,27 +765,6 @@ export async function runSingleStoryInit({
     } catch (err) {
       Logger.error(
         `[single-story-init] ⚠️ Failed to upsert story-init structured comment: ${err?.message ?? err}`,
-      );
-    }
-
-    try {
-      // Route through the canonical state mutator so the Projects v2
-      // Status column mirrors the label flip (Story #2548 wires column-
-      // sync inside `transitionTicketState`). A direct
-      // `provider.updateTicket({ labels })` would skip the board update
-      // and leave the Story on its prior status column for the entire
-      // run. `cascade: false` is correct — a standalone Story has no
-      // parent chain — and threading the prefetched `story` as
-      // `ticketSnapshot` preserves the round-trip elimination from
-      // Story #1795.
-      await transitionTicketState(provider, storyId, STATE_LABELS.EXECUTING, {
-        ticketSnapshot: story,
-        cascade: false,
-      });
-      progress('LABELS', `🏷️  Story #${storyId} → agent::executing`);
-    } catch (err) {
-      Logger.error(
-        `[single-story-init] ⚠️ Failed to flip Story labels: ${err?.message ?? err}`,
       );
     }
   }

--- a/.agents/scripts/stories-wave-tick.js
+++ b/.agents/scripts/stories-wave-tick.js
@@ -709,12 +709,13 @@ export async function runProbedStoriesWaveTick({
 
   let probed;
   try {
-    const { provider, owner, repo } = context();
+    const { provider, owner, repo, self } = context();
     probed = await probe({
       ids,
       provider,
       owner,
       repo,
+      self,
       dispatched: [...dispatchedIds],
       warn: (m) => Logger.warn(m),
     });
@@ -728,7 +729,13 @@ export async function runProbedStoriesWaveTick({
     );
   }
 
-  const { nodes, doneIds, inFlight, blockedIds = [] } = probed;
+  const {
+    nodes,
+    doneIds,
+    inFlight,
+    blockedIds = [],
+    foreignHeld = [],
+  } = probed;
   const { envelope, exitCode } = buildReadySetEnvelope(nodes, {
     concurrencyCap,
     doneIds,
@@ -745,6 +752,11 @@ export async function runProbedStoriesWaveTick({
       epilogueDue,
       blocked: blockedIds,
       blockedReason: blockedReasonFor(blockedIds),
+      // Stories another operator's lease holds — withheld from dispatch this
+      // beat (folded into in-flight) and surfaced so the run can report
+      // "#<id> held by @<holder>" instead of dispatching into an init refusal.
+      foreignHeld,
+      foreignHeldReason: foreignHeldReasonFor(foreignHeld),
     },
     // A blocked Story outranks the scheduler's own verdict — including a
     // wedge, whose named blockers are moot while a human owes a decision.
@@ -773,6 +785,31 @@ function blockedReasonFor(blockedIds) {
     `the loop must stop rather than poll. Read each Story's friction comment ` +
     `(gh issue view <id> --comments), resolve the blocker, then flip it back ` +
     `with: node .agents/scripts/update-ticket-state.js --ticket <id> --state agent::ready`
+  );
+}
+
+/**
+ * Render the operator-facing note for Stories held by another operator's
+ * lease, or `null` when none are held.
+ *
+ * These are not errors and not a wedge: the holder's run is progressing
+ * normally, this run simply must not join it on the same branch. The Story
+ * stays withheld and re-probes each beat, so it dispatches on its own the
+ * moment the holder's lease clears (their run lands or is stolen).
+ *
+ * @param {Array<{id: number, holder: string}>} foreignHeld
+ * @returns {string|null}
+ */
+function foreignHeldReasonFor(foreignHeld) {
+  if (!Array.isArray(foreignHeld) || foreignHeld.length === 0) return null;
+  const list = foreignHeld
+    .map((h) => `#${h.id} held by @${h.holder}`)
+    .join(', ');
+  return (
+    `${foreignHeld.length} Story(ies) are held by another operator's lease — ` +
+    `${list}. They are withheld this beat, not failed: the holder's run owns ` +
+    `the branch and worktree. This run picks each up automatically once that ` +
+    `lease clears (their run lands, or you --steal it after confirming it is dead).`
   );
 }
 

--- a/.agents/workflows/deliver.md
+++ b/.agents/workflows/deliver.md
@@ -105,12 +105,27 @@ to respect.
    accounting is read from reality every beat (Story #4594).
 
    **`--dispatched` is the one thing you must tell it (Story #4601).** List
-   every Story id you have spawned this run. Live state cannot report a Story
-   you dispatched ninety seconds ago: `single-story-init.js` flips
-   `agent::executing` at step 6 of 6, *after* a 3–6 minute worktree install,
-   so until then the Story still reads `agent::ready` and the next beat hands
-   it back — a second sub-agent then joins the first on the same branch and
-   worktree, interleaving commits.
+   every Story id you have spawned this run. Live state cannot instantly report
+   a Story you dispatched moments ago: `single-story-init.js` publishes
+   `agent::executing` before the worktree install (Story #4620 moved it ahead
+   of the multi-minute install, so the window is now short rather than
+   minutes-long), but it is not zero — until the label lands the Story still
+   reads `agent::ready` and, without `--dispatched`, the next beat would hand
+   it back and a second sub-agent would join the first on the same branch and
+   worktree, interleaving commits. `--dispatched` closes that residual
+   same-run window.
+
+   **Cross-run de-confliction is automatic (Story #4620).** A Story another
+   operator is delivering is withheld without any bookkeeping from you: the
+   probe reads the Story's assignee lease and, when it belongs to a different
+   operator, withholds the Story and reports it in the envelope's
+   `foreignHeld: [{ id, holder }]` (with `foreignHeldReason`). That is not a
+   failure or a wedge — the holder's run owns the branch, and this run picks
+   the Story up automatically once their lease clears. Init is the backstop:
+   it refuses a Story already labelled `agent::executing`, or one whose lease a
+   different operator holds, unless you pass `--steal`. Assignee-based
+   withholding needs `github.operatorHandle` set (in `.agentrc.local.json`);
+   without it the probe logs a warning and leans on init's lease refusal alone.
 
    The rule is **append-only: add each id as you dispatch it and never remove
    one.** The flag is additive, not authoritative — the probe unions it into

--- a/tests/lib/orchestration/ticket-lease.test.js
+++ b/tests/lib/orchestration/ticket-lease.test.js
@@ -339,6 +339,93 @@ describe('ticket-lease — acquireLease', () => {
   });
 });
 
+describe('ticket-lease — acquireLease verify-after-write (lost-race, Story #4620)', () => {
+  /**
+   * Simulate a simultaneous claim: the ticket reads unassigned before our
+   * write, but the post-write verify re-read shows a foreign login that raced
+   * in. `reads` is a queue consumed one entry per getTicket call.
+   *
+   * @param {string[][]} reads  Assignee lists returned by successive getTicket calls.
+   */
+  function racingProvider(reads) {
+    const state = { assignees: [...(reads[0] ?? [])] };
+    const updateCalls = [];
+    let call = 0;
+    return {
+      state,
+      updateCalls,
+      async getTicket() {
+        const at = Math.min(call, reads.length - 1);
+        call += 1;
+        return { assignees: [...reads[at]] };
+      },
+      async updateTicket(id, mutations) {
+        updateCalls.push({ id, mutations });
+        if (Array.isArray(mutations?.assignees)) {
+          state.assignees = [...mutations.assignees];
+        }
+      },
+    };
+  }
+
+  it('confirms the claim when the verify re-read shows only the operator', async () => {
+    // read #1 (pre-write): unassigned; read #2 (verify): our own write stuck.
+    const provider = racingProvider([[], ['alice']]);
+
+    const result = await acquireLease({
+      provider,
+      ticketId: 42,
+      operator: 'alice',
+      ttlMs: 5000,
+      now: NOW,
+    });
+
+    assert.equal(result.acquired, true);
+    assert.equal(result.reason, 'unclaimed');
+    // one claiming write only — the happy path does not back anything out.
+    assert.equal(provider.updateCalls.length, 1);
+  });
+
+  it('detects a lost race and backs the operator out when a foreign co-assignee appears', async () => {
+    // read #1 (pre-write): unassigned → we PATCH ['alice'];
+    // read #2 (verify): ['bob','alice'] — bob raced in and we lost.
+    const provider = racingProvider([[], ['bob', 'alice']]);
+
+    const result = await acquireLease({
+      provider,
+      ticketId: 42,
+      operator: 'alice',
+      ttlMs: 5000,
+      now: NOW,
+    });
+
+    assert.equal(result.acquired, false);
+    assert.equal(result.reason, 'lost-race');
+    assert.equal(result.owner, 'bob');
+    // Two writes: the claiming PATCH, then the back-off that removes us so the
+    // winner is the sole assignee.
+    assert.equal(provider.updateCalls.length, 2);
+    assert.deepEqual(provider.updateCalls[1].mutations, { assignees: ['bob'] });
+  });
+
+  it('reports lost-race when the verify re-read shows the operator fully replaced', async () => {
+    // read #2 (verify): ['bob'] only — bob's write clobbered ours entirely.
+    const provider = racingProvider([[], ['bob']]);
+
+    const result = await acquireLease({
+      provider,
+      ticketId: 42,
+      operator: 'alice',
+      ttlMs: 5000,
+      now: NOW,
+    });
+
+    assert.equal(result.acquired, false);
+    assert.equal(result.reason, 'lost-race');
+    assert.equal(result.owner, 'bob');
+  });
+});
+
 describe('ticket-lease — releaseLease', () => {
   // AC5: clears the assignment when the operator still holds it
   it('clears the assignment when the operator still holds the lease', async () => {

--- a/tests/scripts/single-story-init-remote.test.js
+++ b/tests/scripts/single-story-init-remote.test.js
@@ -1,7 +1,11 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 
-import { handleRemoteVerificationFailure } from '../../.agents/scripts/single-story-init.js';
+import {
+  assertNotForeignExecuting,
+  handleRemoteVerificationFailure,
+  runSingleStoryInit,
+} from '../../.agents/scripts/single-story-init.js';
 
 describe('single-story-init remote verification', () => {
   it('blocks the Story and throws before delivery mutation', async () => {
@@ -62,5 +66,190 @@ describe('single-story-init remote verification', () => {
       storyId: 42,
       remote: { remoteVerified: true },
     });
+  });
+});
+
+describe('single-story-init — executing-label refusal (Story #4620)', () => {
+  it('refuses an already-executing Story this run does not hold and releases the just-taken lease', async () => {
+    const writes = [];
+    const provider = {
+      // The lease we just took reads as self-held on release.
+      async getTicket() {
+        return { assignees: ['dsj1984'] };
+      },
+      async updateTicket(_id, mutations) {
+        writes.push(mutations);
+      },
+    };
+
+    await assert.rejects(
+      () =>
+        assertNotForeignExecuting({
+          story: { labels: ['type::story', 'agent::executing'] },
+          lease: { reason: 'unclaimed', previousOwner: null },
+          stealRequested: false,
+          storyId: 42,
+          provider,
+          config: { github: { operatorHandle: '@dsj1984' } },
+        }),
+      /already labelled agent::executing.*--steal/s,
+    );
+
+    // The refusal backs the lease out so the ticket is left as found.
+    assert.equal(writes.length, 1);
+    assert.deepEqual(writes[0].assignees, []);
+  });
+
+  it('proceeds (no throw) when the lease is self-held — an idempotent re-init', async () => {
+    await assertNotForeignExecuting({
+      story: { labels: ['agent::executing'] },
+      lease: { reason: 'already-held', previousOwner: 'dsj1984' },
+      stealRequested: false,
+      storyId: 42,
+      provider: null,
+      config: {},
+    });
+  });
+
+  it('proceeds when --steal was passed', async () => {
+    await assertNotForeignExecuting({
+      story: { labels: ['agent::executing'] },
+      lease: { reason: 'stolen', previousOwner: 'bob' },
+      stealRequested: true,
+      storyId: 42,
+      provider: null,
+      config: {},
+    });
+  });
+
+  it('is a no-op when the Story is not labelled executing', async () => {
+    await assertNotForeignExecuting({
+      story: { labels: ['type::story', 'agent::ready'] },
+      lease: { reason: 'unclaimed', previousOwner: null },
+      stealRequested: false,
+      storyId: 42,
+      provider: null,
+      config: {},
+    });
+  });
+});
+
+describe('single-story-init — early claim publication + rollback (Story #4620)', () => {
+  /**
+   * A provider that records every label transition (the `labels.add[0]` of each
+   * updateTicket call) and every assignee write, and always reads back the
+   * operator as the sole assignee so `releaseStoryLease` writes.
+   */
+  function recordingProvider() {
+    const transitions = [];
+    const assigneeWrites = [];
+    return {
+      transitions,
+      assigneeWrites,
+      async getTicket() {
+        return {
+          labels: ['type::story', 'agent::ready'],
+          assignees: ['dsj1984'],
+          state: 'open',
+        };
+      },
+      async updateTicket(_id, mutations) {
+        if (mutations?.labels?.add) transitions.push(mutations.labels.add[0]);
+        if (Array.isArray(mutations?.assignees)) {
+          assigneeWrites.push(mutations.assignees);
+        }
+      },
+    };
+  }
+
+  const CONFIG = {
+    project: { baseBranch: 'main' },
+    github: { operatorHandle: '@dsj1984' },
+  };
+
+  function baseArgs(provider, overrides = {}) {
+    return {
+      storyId: 4620,
+      injectedProvider: provider,
+      injectedConfig: CONFIG,
+      injectedVerifyRemote: () => ({
+        remoteVerified: true,
+        remoteUrl: 'https://github.com/dsj1984/mandrel.git',
+        detail: 'ok',
+      }),
+      injectedAcquireLease: async () => ({
+        acquired: true,
+        owner: 'dsj1984',
+        previousOwner: null,
+        reason: 'unclaimed',
+      }),
+      injectedMaterialize: async () => {},
+      injectedSeedBranch: () => {},
+      ...overrides,
+    };
+  }
+
+  it('flips agent::executing BEFORE provisioning, then reverts to agent::ready when provisioning fails', async () => {
+    const provider = recordingProvider();
+    provider.getTicket = async () => ({
+      // assertDeliverableStory + the transitions read this snapshot.
+      labels: ['type::story', 'agent::ready'],
+      title: 'Story 4620',
+      body: '## Goal\nx',
+      assignees: ['dsj1984'],
+      state: 'open',
+    });
+
+    await assert.rejects(
+      () =>
+        runSingleStoryInit(
+          baseArgs(provider, {
+            injectedProvisionWorktree: async () => {
+              throw new Error('worktree boom');
+            },
+          }),
+        ),
+      /worktree boom/,
+    );
+
+    // The claim was published before provisioning (executing first), then
+    // rolled back to ready after the failure.
+    assert.deepEqual(provider.transitions, [
+      'agent::executing',
+      'agent::ready',
+    ]);
+    // The lease was released on rollback (assignees cleared).
+    assert.deepEqual(provider.assigneeWrites.at(-1), []);
+  });
+
+  it('on the happy path flips agent::executing before provisioning and does not roll back', async () => {
+    const provider = recordingProvider();
+    provider.getTicket = async () => ({
+      labels: ['type::story', 'agent::ready'],
+      title: 'Story 4620',
+      body: '## Goal\nx',
+      assignees: ['dsj1984'],
+      state: 'open',
+    });
+
+    const provisionOrder = [];
+    const { success } = await runSingleStoryInit(
+      baseArgs(provider, {
+        injectedProvisionWorktree: async () => {
+          // At provisioning time the executing flip has already happened.
+          provisionOrder.push([...provider.transitions]);
+          return {
+            workCwd: '/tmp/wt',
+            worktreeCreated: true,
+            installStatus: { status: 'skipped', reason: 'test' },
+          };
+        },
+      }),
+    );
+
+    assert.equal(success, true);
+    // executing was flipped before provisioning ran, and no ready-rollback.
+    assert.deepEqual(provisionOrder[0], ['agent::executing']);
+    assert.deepEqual(provider.transitions, ['agent::executing']);
   });
 });

--- a/tests/wave-runner/live-probe.test.js
+++ b/tests/wave-runner/live-probe.test.js
@@ -21,7 +21,9 @@
  * both of which presented as an ordinary "waiting" beat:
  *
  *   5. A **dispatched-but-unlabelled** Story holds its slot and is not handed
- *      back. `single-story-init.js` flips `agent::executing` last, so every
+ *      back. There is a window between the host spawning a sub-agent and that
+ *      agent publishing `agent::executing` (Story #4620 shrank it by flipping
+ *      before the install rather than after, but it is non-zero), so every
  *      test here that sets the label explicitly was skipping the window where
  *      the bug lives.
  *   6. An **`agent::blocked`** Story ends the loop (exit 4) instead of being
@@ -82,25 +84,29 @@ function stubProvider(issues, { native = {} } = {}) {
   };
 }
 
-function issue(id, { labels = [], state = 'open', ...bodyArgs } = {}) {
+function issue(
+  id,
+  { labels = [], state = 'open', assignees = [], ...bodyArgs } = {},
+) {
   return {
     number: id,
     title: `Story ${id}`,
     body: storyBody(bodyArgs),
     labels: [{ name: 'type::story' }, ...labels.map((name) => ({ name }))],
     state,
+    assignees,
   };
 }
 
 /** Run a probe-mode tick against a stubbed provider — no network, no config. */
-function tick(issues, { ids, native, concurrency, dispatched } = {}) {
+function tick(issues, { ids, native, concurrency, dispatched, self } = {}) {
   const provider = stubProvider(issues, { native });
   return runProbedStoriesWaveTick({
     stories: ids ?? Object.keys(issues).join(','),
     concurrency,
     dispatched,
     config: CONFIG,
-    context: () => ({ provider, owner: 'dsj1984', repo: 'mandrel' }),
+    context: () => ({ provider, owner: 'dsj1984', repo: 'mandrel', self }),
   });
 }
 
@@ -145,8 +151,8 @@ describe('probeLiveState — done and in-flight come from live state', () => {
   });
 
   it('counts a dispatched-but-unlabelled Story as in-flight (the init window)', async () => {
-    // #101 was spawned this beat; single-story-init.js flips agent::executing
-    // last, after the install, so live state still reads agent::ready.
+    // #101 was spawned this beat but its init has not yet published
+    // agent::executing, so live state still reads agent::ready.
     const provider = stubProvider({ 101: issue(101), 102: issue(102) });
 
     const { inFlight, nodes } = await probeLiveState({
@@ -605,5 +611,107 @@ describe('createProbeContext — shares the resolver provider seam', () => {
     assert.equal(ctx.provider, provider);
     assert.equal(ctx.owner, 'dsj1984');
     assert.equal(ctx.repo, 'mandrel');
+  });
+
+  it('resolves `self` from operatorHandle, stripping @ and the placeholder', () => {
+    const provider = { getTicket: async () => null };
+    const withHandle = createProbeContext({
+      resolveProvider: () => ({
+        provider,
+        config: { github: { operatorHandle: '@dsj1984' } },
+      }),
+    });
+    assert.equal(withHandle.self, 'dsj1984');
+
+    const placeholder = createProbeContext({
+      resolveProvider: () => ({
+        provider,
+        config: { github: { operatorHandle: '@[USERNAME]' } },
+      }),
+    });
+    assert.equal(placeholder.self, null);
+  });
+});
+
+describe('probeLiveState — foreign-lease withholding (Story #4620)', () => {
+  it('withholds a Story assigned to another operator and names the holder', async () => {
+    // #101 is otherwise ready but bob holds its lease — his init flips the
+    // label only after a multi-minute install, so live labels still read ready.
+    const provider = stubProvider({
+      101: issue(101, { assignees: ['bob'] }),
+      102: issue(102),
+    });
+
+    const { nodes, inFlight, foreignHeld } = await probeLiveState({
+      ids: [101, 102],
+      provider,
+      owner: 'dsj1984',
+      repo: 'mandrel',
+      self: 'dsj1984',
+    });
+
+    // Withheld via a projected executing label — not dispatched — and folded
+    // into in-flight so it neither races nor triggers a false wedge.
+    const byId = new Map(nodes.map((n) => [n.id, n]));
+    assert.equal(byId.get(101).labels.includes('agent::executing'), true);
+    assert.equal(byId.get(102).labels.includes('agent::executing'), false);
+    assert.equal(inFlight, 1);
+    assert.deepEqual(foreignHeld, [{ id: 101, holder: 'bob' }]);
+  });
+
+  it('does not withhold a Story this operator holds', async () => {
+    const provider = stubProvider({
+      101: issue(101, { assignees: ['dsj1984'] }),
+    });
+
+    const { nodes, inFlight, foreignHeld } = await probeLiveState({
+      ids: [101],
+      provider,
+      owner: 'dsj1984',
+      repo: 'mandrel',
+      self: 'dsj1984',
+    });
+
+    assert.equal(nodes[0].labels.includes('agent::executing'), false);
+    assert.equal(inFlight, 0);
+    assert.deepEqual(foreignHeld, []);
+  });
+
+  it('degrades open with a warning when `self` is unresolved', async () => {
+    const provider = stubProvider({ 101: issue(101, { assignees: ['bob'] }) });
+    const warnings = [];
+
+    const { nodes, foreignHeld } = await probeLiveState({
+      ids: [101],
+      provider,
+      owner: 'dsj1984',
+      repo: 'mandrel',
+      // self omitted — operatorHandle unset / placeholder
+      warn: (m) => warnings.push(m),
+    });
+
+    // No assignee-based withholding: the node stays ready and nothing is held.
+    assert.equal(nodes[0].labels.includes('agent::executing'), false);
+    assert.deepEqual(foreignHeld, []);
+    assert.equal(
+      warnings.some((m) => /operatorHandle/.test(m)),
+      true,
+    );
+  });
+
+  it('surfaces foreignHeld + reason through the probed tick envelope', async () => {
+    const { envelope, exitCode } = await tick(
+      {
+        101: issue(101, { assignees: ['bob'] }),
+        102: issue(102),
+      },
+      { self: 'dsj1984' },
+    );
+
+    // Only #102 is dispatchable; #101 is withheld and reported.
+    assert.deepEqual(envelope.ready, [102]);
+    assert.deepEqual(envelope.foreignHeld, [{ id: 101, holder: 'bob' }]);
+    assert.match(envelope.foreignHeldReason, /#101 held by @bob/);
+    assert.equal(exitCode, 0);
   });
 });


### PR DESCRIPTION
Closes #4620

_Auto-opened by `/deliver`._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes orchestration timing and GitHub assignee/label mutations on the critical delivery path; behavior is fail-closed with new tests, but misconfigured `operatorHandle` only warns and defers to init.
> 
> **Overview**
> Hardens **v2 `/deliver`** so concurrent operators and simultaneous lease claims are less likely to **double-dispatch** the same Story or both believe they hold the lease.
> 
> **Lease acquire** now **verify-after-write**: after patching assignees, a fresh re-read must show only this operator; otherwise the run backs off assignees and returns **`lost-race`** / `acquired: false` instead of proceeding.
> 
> **Live probe** threads **assignees** on Story records and, when `github.operatorHandle` is set, **withholds** otherwise-ready Stories whose assignee lease belongs to another operator—folded into in-flight and surfaced as **`foreignHeld`** / `foreignHeldReason` on the wave-tick envelope.
> 
> **`single-story-init`** reorders init: acquire lease → refuse **`agent::executing`** when label/assignee drift (unless `--steal` / already-held) → flip **`agent::executing` before** git/worktree provisioning → **rollback** label + lease if provisioning fails. **`deliver.md`** documents the shorter same-run `--dispatched` window and automatic cross-run withholding.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f091458ac3cd56f0bf3735b1b2a0b586be784ab7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->