### PR TITLE
fix: serialize single-story-close post-land checkout mutations under concurrent delivery (#4622)

### DIFF
--- a/.agents/scripts/lib/observability/runtime-friction.js
+++ b/.agents/scripts/lib/observability/runtime-friction.js
@@ -160,6 +160,68 @@ export async function emitRuntimeFriction({
 }
 
 /**
+ * Emit the recovery counterpart of a `story-blocked` record when a Story
+ * leaves `agent::blocked` for an active state (Story #4622).
+ *
+ * A transient block that self-resolves — lease contention or a stale label
+ * read under concurrent shared-checkout pressure (swarm-os friction #581) —
+ * still fired a `story-blocked` record at the block flip, which the retro
+ * composer counts toward the `story-blocked` recurrence total exactly like a
+ * terminal block. This emits a companion `story-blocked` record carrying the
+ * `details.recovered: true` discriminator, so the composer can net the whole
+ * incident out (see `retro-proposals.js`). The category is deliberately kept
+ * as `story-blocked` rather than a new bucket: a distinct category would
+ * itself aggregate into a routable proposal, re-introducing the noise.
+ *
+ * Best-effort; never throws.
+ *
+ * @param {object} args
+ * @param {number} args.storyId
+ * @param {string} [args.fromState] The state parked at (`agent::blocked`).
+ * @param {string} [args.toState]   The active state recovered into.
+ * @param {object} [args.config]
+ * @returns {Promise<boolean>} true when a record was appended.
+ */
+export async function emitBlockRecoveredFriction({
+  storyId,
+  fromState,
+  toState,
+  config,
+} = {}) {
+  return emitRuntimeFriction({
+    storyId,
+    category: RUNTIME_FRICTION_CATEGORIES.STORY_BLOCKED,
+    tool: 'transitionTicketState',
+    details: {
+      recovered: true,
+      fromState: fromState ?? null,
+      toState: toState ?? null,
+    },
+    config,
+  });
+}
+
+/**
+ * Pure predicate: is this signal a recovery-marked `story-blocked` record?
+ * Shared with the retro composer so the "recovered" discriminator is read
+ * from one place. A record is a recovery marker when its category is
+ * `story-blocked` and `details.recovered === true`.
+ *
+ * @param {object} signal
+ * @returns {boolean}
+ */
+export function isRecoveredBlockSignal(signal) {
+  return (
+    signal !== null &&
+    typeof signal === 'object' &&
+    signal.category === RUNTIME_FRICTION_CATEGORIES.STORY_BLOCKED &&
+    signal.details !== null &&
+    typeof signal.details === 'object' &&
+    signal.details.recovered === true
+  );
+}
+
+/**
  * Decide whether a `story-deliver-terminal` envelope is worth a friction
  * record, and describe it. **Pure** — no I/O — so the (interesting) policy
  * is unit-testable without touching disk.

--- a/.agents/scripts/lib/orchestration/retro-proposals.js
+++ b/.agents/scripts/lib/orchestration/retro-proposals.js
@@ -34,6 +34,11 @@
  * @typedef {Object} FrictionSignal
  * @property {string} category   Free-form bucket (e.g. `"lint-loop"`).
  * @property {"framework"|"consumer"} source
+ * @property {number} [storyId]  Emitting Story id (used to net out recovered
+ *                               `story-blocked` incidents — Story #4622).
+ * @property {object} [details]  Kind-specific payload; a `story-blocked`
+ *                               record with `details.recovered === true` is a
+ *                               recovery marker.
  *
  * @typedef {Object} BlockedEvent
  * @property {number} ticketId
@@ -68,6 +73,11 @@
  * @property {DiscardedItem[]}  discarded
  */
 
+import {
+  isRecoveredBlockSignal,
+  RUNTIME_FRICTION_CATEGORIES,
+} from '../observability/runtime-friction.js';
+
 /**
  * Empty result helper — returned for zero-input callers so the consumer
  * never needs to defensively spread undefineds.
@@ -87,6 +97,44 @@ function emptyResult() {
 function asString(value) {
   if (typeof value !== 'string') return '';
   return value.trim();
+}
+
+/**
+ * Net transient (self-resolved) blocks out of the signal stream before it is
+ * aggregated (Story #4622).
+ *
+ * A `blocked → active` recovery emits a `story-blocked` record carrying
+ * `details.recovered === true`. When a Story has such a marker, its block was
+ * transient — lease contention or a stale label read under concurrent
+ * shared-checkout pressure (swarm-os friction #581) that cleared on a later
+ * beat — not a terminal HITL pause. This drops **every** `story-blocked`
+ * record for such a Story (both the original block and its recovery marker),
+ * so the retro counts only Stories still parked at `agent::blocked`.
+ *
+ * The netting is by `storyId`, not 1:1 pairing: a Story that ever recovered
+ * from a block in the run is treated as non-terminal for the whole run. That
+ * is a deliberate coarsening — the aggregate is a routing heuristic, not an
+ * incident ledger, and the signal stream carries no reliable ordering to
+ * reconstruct interleaved block/recover cycles. Non-`story-blocked` records
+ * and Stories with no recovery marker pass through untouched.
+ *
+ * @param {FrictionSignal[]} signals
+ * @returns {FrictionSignal[]}
+ */
+function netOutRecoveredBlocks(signals) {
+  const recoveredStoryIds = new Set();
+  for (const sig of signals) {
+    if (isRecoveredBlockSignal(sig) && Number.isInteger(sig.storyId)) {
+      recoveredStoryIds.add(sig.storyId);
+    }
+  }
+  if (recoveredStoryIds.size === 0) return signals;
+  return signals.filter((sig) => {
+    if (sig === null || typeof sig !== 'object') return true;
+    const isBlocked =
+      sig.category === RUNTIME_FRICTION_CATEGORIES.STORY_BLOCKED;
+    return !(isBlocked && recoveredStoryIds.has(sig.storyId));
+  });
 }
 
 /**
@@ -403,7 +451,7 @@ export function composeRoutedProposals(input) {
   } = normalised;
 
   return routeCategoryBuckets({
-    byCategory: aggregateByCategory(signals),
+    byCategory: aggregateByCategory(netOutRecoveredBlocks(signals)),
     blockedForceActionable: blockedForceMap(unresolvedBlockedEvents),
     anchorId,
     anchorKind,

--- a/.agents/scripts/lib/orchestration/single-story-close/phases/post-land.js
+++ b/.agents/scripts/lib/orchestration/single-story-close/phases/post-land.js
@@ -29,14 +29,32 @@
  * is best-effort and records its own reason.
  */
 
+import path from 'node:path';
+
 import { gitSpawn as defaultGitSpawn } from '../../../git-utils.js';
 import { Logger } from '../../../Logger.js';
+import { acquireLockWithWait as defaultAcquireLockWithWait } from '../../../single-story-sweep/sweep-lock.js';
 import {
   executeFastForward as defaultExecuteFastForward,
   planFastForward as defaultPlanFastForward,
 } from '../../git-cleanup/phases/fast-forward.js';
 import { reassertStatusColumn as defaultReassertStatusColumn } from '../../reassert-status-column.js';
 import { captureStoryFollowUps as defaultCaptureStoryFollowUps } from '../../story-follow-ups.js';
+
+/**
+ * Lockfile that serializes the local-checkout git mutations of the land tail
+ * across concurrent closes. Keyed on the **main checkout** (never a
+ * worktree): every concurrent `single-story-close` runs its tail against the
+ * same `cwd`, so anchoring the lock under that checkout's `.git` directory
+ * makes them all contend on one file. `.git` is always present, is one per
+ * checkout, and is never itself tracked, so it is a safe rendezvous home.
+ *
+ * @param {string} cwd Main checkout root.
+ * @returns {string}
+ */
+function postLandLockPath(cwd) {
+  return path.join(cwd, '.git', 'mandrel-post-land-tail.lock');
+}
 
 /**
  * Run one tail step, converting any throw into a `false` + reason. Keeps
@@ -210,6 +228,19 @@ async function stepBaseFastForward({
  * after the ref reap so `git branch -D` is not fighting a checkout that just
  * moved HEAD.
  *
+ * **Cross-process serialization (Story #4622).** The two local-checkout
+ * mutations — `stepRefCleanup` (`git branch -D`) and `stepBaseFastForward`
+ * (fast-forward `baseBranch`) — run inside a best-effort cross-process lock
+ * keyed on the main checkout. Under concurrent delivery (multiple
+ * story-workers closing against one shared checkout + per-Story worktrees),
+ * an unserialized tail races on the `main` ref and the worktree registry —
+ * the `refCleanup:false` ("used by worktree") / `baseFastForward:false`
+ * ("not-fast-forward") signature reported in swarm-os friction #579. The
+ * GitHub-touching steps stay OUTSIDE the lock so a contended checkout never
+ * delays them. The lock is never load-bearing: on sustained contention the
+ * bounded wait expires and the mutations run anyway (proceeding is the same
+ * best-effort contract every tail step already has).
+ *
  * @param {object} args
  * @param {number} args.storyId
  * @param {string} args.storyBranch
@@ -223,6 +254,7 @@ async function stepBaseFastForward({
  * @param {Function} [args.gitSpawnFn]              Test seam.
  * @param {Function} [args.planFastForwardFn]       Test seam.
  * @param {Function} [args.executeFastForwardFn]    Test seam.
+ * @param {Function} [args.acquireLockWithWaitFn]   Test seam.
  * @returns {Promise<{ followUps: boolean, statusResync: boolean, refCleanup: boolean, baseFastForward: boolean, details: Record<string, string|null> }>}
  */
 export async function runPostLandTail({
@@ -238,6 +270,7 @@ export async function runPostLandTail({
   gitSpawnFn = defaultGitSpawn,
   planFastForwardFn = defaultPlanFastForward,
   executeFastForwardFn = defaultExecuteFastForward,
+  acquireLockWithWaitFn = defaultAcquireLockWithWait,
 }) {
   progress?.('POST-LAND', `🧾 Running land tail for Story #${storyId}...`);
 
@@ -264,21 +297,46 @@ export async function runPostLandTail({
       }),
     { name: 'status-column resync', progress },
   );
-  const refCleanup = await step(
-    () => stepRefCleanup({ cwd, storyBranch, progress, gitSpawnFn }),
-    { name: 'local ref cleanup', progress },
-  );
-  const baseFastForward = await step(
-    () =>
-      stepBaseFastForward({
-        cwd,
-        baseBranch,
-        progress,
-        planFastForwardFn,
-        executeFastForwardFn,
-      }),
-    { name: 'base fast-forward', progress },
-  );
+  // Local-checkout mutations: serialized behind a best-effort cross-process
+  // lock (Story #4622). Acquire once, run both steps, release in `finally`.
+  const lockCfg = config?.delivery?.postLandLock ?? {};
+  const lock = await acquireLockWithWaitFn({
+    lockPath: postLandLockPath(cwd),
+    waitMs: lockCfg.waitMs,
+    pollMs: lockCfg.pollMs,
+    timeoutMs: lockCfg.timeoutMs,
+    ownerId: `post-land-${storyId}`,
+  });
+  if (!lock.acquired) {
+    // Never load-bearing: proceed anyway. The bounded wait already gave the
+    // concurrent holder its window; blocking the land on a lock we could not
+    // take would turn a best-effort damper into a false negative.
+    progress?.(
+      'POST-LAND',
+      `⚠️ post-land lock not acquired (${lock.reason}); proceeding unserialized.`,
+    );
+  }
+  let refCleanup;
+  let baseFastForward;
+  try {
+    refCleanup = await step(
+      () => stepRefCleanup({ cwd, storyBranch, progress, gitSpawnFn }),
+      { name: 'local ref cleanup', progress },
+    );
+    baseFastForward = await step(
+      () =>
+        stepBaseFastForward({
+          cwd,
+          baseBranch,
+          progress,
+          planFastForwardFn,
+          executeFastForwardFn,
+        }),
+      { name: 'base fast-forward', progress },
+    );
+  } finally {
+    if (lock.acquired) lock.release();
+  }
 
   const tail = {
     followUps: followUps.ok,

--- a/.agents/scripts/lib/orchestration/ticketing/transition.js
+++ b/.agents/scripts/lib/orchestration/ticketing/transition.js
@@ -38,6 +38,7 @@ import {
   renderTransitionMessage,
 } from '../../notifications/notifier.js';
 import {
+  emitBlockRecoveredFriction,
   emitRuntimeFriction,
   RUNTIME_FRICTION_CATEGORIES,
 } from '../../observability/runtime-friction.js';
@@ -123,19 +124,40 @@ function validateTransitionInputs(newState) {
 }
 
 /**
+ * Active states a `agent::blocked` Story can recover into (Story #4622). A
+ * `blocked → {executing|ready}` transition is a self-resolved block; every
+ * other target (`done`, `closing`) is a real terminal outcome, not a
+ * recovery.
+ */
+const BLOCK_RECOVERY_TARGETS = [STATE_LABELS.EXECUTING, STATE_LABELS.READY];
+
+/**
  * Resolve the pre-transition ticket snapshot that drives the notify
  * payload and the provider's label-merge path. Honors the caller-supplied
  * `opts.ticketSnapshot` (Story #1795) when present; otherwise issues a
  * best-effort `getTicket` and returns `null` on transient failure.
  *
+ * The snapshot is loaded when a caller threads `notify` (its `fromState`
+ * feeds the notification payload) OR when `needFromState` is set — Story
+ * #4622's recovery detection needs the *prior* state, and `getTicket` after
+ * `updateTicket` would already read the new label. Bounding the extra read
+ * to recovery-target transitions keeps every other flip on the snapshot-free
+ * fast path.
+ *
  * @param {object} provider
  * @param {{ notify?: Function, ticketSnapshot?: object|null }} opts
  * @param {number} ticketId
+ * @param {boolean} [needFromState]
  * @returns {Promise<object|null>}
  */
-async function loadTicketSnapshot(provider, opts, ticketId) {
+async function loadTicketSnapshot(provider, opts, ticketId, needFromState) {
   if (opts.ticketSnapshot) return opts.ticketSnapshot;
-  if (!opts.notify || typeof provider.getTicket !== 'function') return null;
+  if (
+    (!opts.notify && !needFromState) ||
+    typeof provider.getTicket !== 'function'
+  ) {
+    return null;
+  }
   try {
     return await provider.getTicket(ticketId);
   } catch (err) {
@@ -301,26 +323,50 @@ function dispatchTransitionNotification(args) {
  * (see `frictionForTerminal`): the two would otherwise count one incident
  * twice.
  *
- * Best-effort and awaited: `emitRuntimeFriction` swallows its own failures
- * and resolves `false`, so this can neither throw nor block the transition.
+ * Story #4622 extends the hook to the inverse edge: a `blocked → active`
+ * transition emits a recovery marker so a transient block that self-resolved
+ * can be netted out of the retro's `story-blocked` recurrence total.
+ *
+ * Best-effort and awaited: the friction emitters swallow their own failures
+ * and resolve `false`, so this can neither throw nor block the transition.
  * It is awaited rather than fire-and-forget because CLI entry points exit
  * via `process.exit` as soon as `main` resolves (`cli-utils.runAsCli` with
  * `propagateExitCode`), which would discard a still-pending append.
  *
  * @param {number} ticketId
+ * @param {string|null} fromState  Prior state label, or null.
  * @param {string} newState
  * @param {{ config?: object }} opts
  * @returns {Promise<void>}
  */
-async function emitBlockedFriction(ticketId, newState, opts) {
-  if (newState !== STATE_LABELS.BLOCKED) return;
-  await emitRuntimeFriction({
-    storyId: ticketId,
-    category: RUNTIME_FRICTION_CATEGORIES.STORY_BLOCKED,
-    tool: 'transitionTicketState',
-    details: { toState: newState },
-    config: opts?.config,
-  });
+async function emitBlockedFriction(ticketId, fromState, newState, opts) {
+  if (newState === STATE_LABELS.BLOCKED) {
+    await emitRuntimeFriction({
+      storyId: ticketId,
+      category: RUNTIME_FRICTION_CATEGORIES.STORY_BLOCKED,
+      tool: 'transitionTicketState',
+      details: { toState: newState },
+      config: opts?.config,
+    });
+    return;
+  }
+  // Story #4622 — a transition *out* of `agent::blocked` into an active state
+  // is a recovery: the earlier block self-resolved. Emit its recovery marker
+  // so the retro composer can net the transient block out of the
+  // `story-blocked` recurrence total (swarm-os friction #581). Only a genuine
+  // block→active recovery qualifies; blocked→done/closing is a real
+  // terminal outcome, not a recovery, so it is left counted.
+  if (
+    fromState === STATE_LABELS.BLOCKED &&
+    BLOCK_RECOVERY_TARGETS.includes(newState)
+  ) {
+    await emitBlockRecoveredFriction({
+      storyId: ticketId,
+      fromState,
+      toState: newState,
+      config: opts?.config,
+    });
+  }
 }
 
 /**
@@ -382,7 +428,12 @@ export async function transitionTicketState(
   // snapshot is also forwarded to `provider.updateTicket` so the label
   // merge path skips its own `getTicket` call (the second of the two
   // round-trips this seam eliminates).
-  const ticketSnapshot = await loadTicketSnapshot(provider, opts, ticketId);
+  const ticketSnapshot = await loadTicketSnapshot(
+    provider,
+    opts,
+    ticketId,
+    BLOCK_RECOVERY_TARGETS.includes(newState),
+  );
   const fromState =
     ticketSnapshot?.labels?.find((l) => ALL_STATES.includes(l)) ?? null;
 
@@ -406,8 +457,9 @@ export async function transitionTicketState(
   });
 
   // Story #4578 — derive a friction signal from the block, at the point the
-  // runtime already knows. Best-effort; never blocks the transition.
-  await emitBlockedFriction(ticketId, newState, opts);
+  // runtime already knows. Story #4622 also emits the recovery marker on the
+  // inverse block→active transition. Best-effort; never blocks the transition.
+  await emitBlockedFriction(ticketId, fromState, newState, opts);
 
   // Story #2548 — mirror the new state onto the Projects v2 Status
   // column. Best-effort; never blocks the transition.

--- a/.agents/scripts/lib/single-story-sweep/sweep-lock.js
+++ b/.agents/scripts/lib/single-story-sweep/sweep-lock.js
@@ -167,3 +167,76 @@ function buildAcquired(lockPath, ownerId, fsImpl) {
   }
   return { acquired: true, release, ownerId };
 }
+
+const DEFAULT_WAIT_MS = 8_000;
+const DEFAULT_POLL_MS = 150;
+
+/**
+ * Promise-based delay. Injectable so tests can drive the wait loop on a fake
+ * clock without a real timer.
+ *
+ * @param {number} ms
+ * @returns {Promise<void>}
+ */
+function defaultSleep(ms) {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}
+
+/**
+ * Bounded-wait wrapper over {@link acquireSweepLock}.
+ *
+ * `acquireSweepLock` is single-attempt on purpose: a *skipped* sweep is
+ * harmless, so the sweep caller proceeds immediately on contention. The
+ * post-land tail is the opposite case — proceeding immediately IS the race
+ * two concurrent closes hit on a shared main checkout — so this wrapper
+ * polls the primitive with short backoff up to `waitMs` before giving up.
+ *
+ * It is still **never load-bearing**: on `waitMs` exhaustion it returns
+ * `{ acquired: false, reason: 'contended-after-wait' }` and the caller is
+ * expected to proceed anyway. The bounded wait is a best-effort collision
+ * damper, not a mutual-exclusion guarantee. A hard I/O error short-circuits
+ * the loop (spinning would just re-hit it).
+ *
+ * @param {object} opts
+ * @param {string} opts.lockPath
+ * @param {number} [opts.waitMs]     Max total time to wait for the lock.
+ * @param {number} [opts.pollMs]     Delay between acquire attempts.
+ * @param {number} [opts.timeoutMs]  Stale-lock expiry, forwarded to the
+ *                                   underlying acquire.
+ * @param {string} [opts.ownerId]
+ * @param {() => number} [opts.nowFn]
+ * @param {(ms: number) => Promise<void>} [opts.sleepFn]
+ * @param {object} [opts.fsImpl]
+ * @returns {Promise<{ acquired: true, release: () => void, ownerId: string }
+ *          | { acquired: false, reason: 'contended-after-wait' | 'error', detail?: string }>}
+ */
+export async function acquireLockWithWait({
+  lockPath,
+  waitMs = DEFAULT_WAIT_MS,
+  pollMs = DEFAULT_POLL_MS,
+  timeoutMs = DEFAULT_TIMEOUT_MS,
+  ownerId,
+  nowFn = Date.now,
+  sleepFn = defaultSleep,
+  fsImpl = fs,
+} = {}) {
+  const deadline = nowFn() + Math.max(0, waitMs);
+  for (;;) {
+    const res = acquireSweepLock({
+      lockPath,
+      timeoutMs,
+      ownerId,
+      nowFn,
+      fsImpl,
+    });
+    if (res.acquired) return res;
+    // A hard error will not resolve by retrying — surface it immediately.
+    if (res.reason === 'error') return res;
+    if (nowFn() >= deadline) {
+      return { acquired: false, reason: 'contended-after-wait' };
+    }
+    await sleepFn(Math.max(0, pollMs));
+  }
+}

--- a/tests/lib/observability/runtime-friction.test.js
+++ b/tests/lib/observability/runtime-friction.test.js
@@ -24,8 +24,10 @@ import os from 'node:os';
 import path from 'node:path';
 import { afterEach, beforeEach, describe, it } from 'node:test';
 import {
+  emitBlockRecoveredFriction,
   emitRuntimeFriction,
   emitTerminalFriction,
+  isRecoveredBlockSignal,
   RUNTIME_FRICTION_CATEGORIES,
 } from '../../../.agents/scripts/lib/observability/runtime-friction.js';
 import { forEachLine } from '../../../.agents/scripts/lib/observability/signals-writer.js';
@@ -248,5 +250,74 @@ describe('emitRuntimeFriction (write path)', () => {
       config: { project: { paths: { tempRoot: filePath } } },
     });
     assert.equal(ok, false);
+  });
+});
+
+describe('block-recovery friction (Story #4622)', () => {
+  it('emits a story-blocked record carrying the recovered discriminator', async () => {
+    const ok = await emitBlockRecoveredFriction({
+      storyId: 4622,
+      fromState: 'agent::blocked',
+      toState: 'agent::executing',
+      config,
+    });
+    assert.equal(ok, true);
+
+    const rows = await readStorySignals(4622);
+    assert.equal(rows.length, 1);
+    const rec = rows[0];
+    assert.equal(rec.kind, 'friction');
+    assert.equal(rec.category, RUNTIME_FRICTION_CATEGORIES.STORY_BLOCKED);
+    assert.equal(rec.details.recovered, true);
+    assert.equal(rec.details.fromState, 'agent::blocked');
+    assert.equal(rec.details.toState, 'agent::executing');
+  });
+
+  it('keeps the category as story-blocked so it does not open a new routable bucket', async () => {
+    await emitBlockRecoveredFriction({ storyId: 4623, config });
+    const rows = await readStorySignals(4623);
+    assert.equal(rows[0].category, 'story-blocked');
+    assert.equal(rows[0].details.fromState, null);
+    assert.equal(rows[0].details.toState, null);
+  });
+});
+
+describe('isRecoveredBlockSignal (Story #4622)', () => {
+  const STORY_BLOCKED = RUNTIME_FRICTION_CATEGORIES.STORY_BLOCKED;
+
+  it('is true only for a story-blocked record with details.recovered === true', () => {
+    assert.equal(
+      isRecoveredBlockSignal({
+        category: STORY_BLOCKED,
+        details: { recovered: true },
+      }),
+      true,
+    );
+  });
+
+  it('is false for a plain (terminal) story-blocked record', () => {
+    assert.equal(
+      isRecoveredBlockSignal({
+        category: STORY_BLOCKED,
+        details: { toState: 'agent::blocked' },
+      }),
+      false,
+    );
+  });
+
+  it('is false for a recovered flag on a different category', () => {
+    assert.equal(
+      isRecoveredBlockSignal({
+        category: 'close-failed',
+        details: { recovered: true },
+      }),
+      false,
+    );
+  });
+
+  it('is false for null / non-object / detail-less input', () => {
+    assert.equal(isRecoveredBlockSignal(null), false);
+    assert.equal(isRecoveredBlockSignal('nope'), false);
+    assert.equal(isRecoveredBlockSignal({ category: STORY_BLOCKED }), false);
   });
 });

--- a/tests/lib/orchestration/post-land-lock.test.js
+++ b/tests/lib/orchestration/post-land-lock.test.js
@@ -1,0 +1,243 @@
+/**
+ * Story #4622 — the post-land tail serializes its local-checkout git
+ * mutations (`stepRefCleanup` + `stepBaseFastForward`) behind a best-effort
+ * cross-process lock keyed on the main checkout.
+ *
+ * Under concurrent delivery (multiple story-workers closing against one
+ * shared checkout with per-Story worktrees), an unserialized tail races on
+ * the `main` ref and the worktree registry — the swarm-os friction #579
+ * signature (`refCleanup:false` "used by worktree" / `baseFastForward:false`
+ * "not-fast-forward"). These tests pin three properties:
+ *
+ *   1. The lock wraps ONLY the two git mutations; the GitHub-touching
+ *      follow-up-capture and status-resync steps run outside it.
+ *   2. The lock is never load-bearing: a failed acquire still runs the
+ *      mutations (proceeding is the same best-effort contract every tail
+ *      step has).
+ *   3. Two concurrent tails against one real lockfile never interleave their
+ *      critical sections.
+ */
+
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, it } from 'node:test';
+
+import { runPostLandTail } from '../../../.agents/scripts/lib/orchestration/single-story-close/phases/post-land.js';
+
+/** A gitSpawn stub: story-branch exists, deletes cleanly. */
+function fakeGitSpawn(trace) {
+  return (_cwd, ...args) => {
+    if (args[0] === 'show-ref') return { status: 0 };
+    if (args[0] === 'branch' && args[1] === '-D') {
+      trace?.push('refCleanup');
+      return { status: 0 };
+    }
+    return { status: 0 };
+  };
+}
+
+/** Base seams that let both git mutations run to a clean success. */
+function baseSeams(trace) {
+  return {
+    captureStoryFollowUpsFn: async () => {
+      trace?.push('followUps');
+      return { ok: true };
+    },
+    reassertStatusColumnFn: async () => {
+      trace?.push('statusResync');
+      return { status: 'synced' };
+    },
+    gitSpawnFn: fakeGitSpawn(trace),
+    planFastForwardFn: () => ({ runnable: true, reason: null }),
+    executeFastForwardFn: () => {
+      trace?.push('baseFastForward');
+      return { applied: true, behind: 1 };
+    },
+  };
+}
+
+let tmpDir;
+beforeEach(() => {
+  // A `.git` dir must exist for the lockfile's parent to be writable.
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'post-land-lock-'));
+  fs.mkdirSync(path.join(tmpDir, '.git'), { recursive: true });
+});
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe('runPostLandTail — lock scope (Story #4622)', () => {
+  it('acquires before the git mutations and releases after, with GitHub steps outside', async () => {
+    const events = [];
+    let released = false;
+    const acquireLockWithWaitFn = async () => {
+      events.push('acquire');
+      return {
+        acquired: true,
+        release: () => {
+          released = true;
+          events.push('release');
+        },
+        ownerId: 'test',
+      };
+    };
+
+    const tail = await runPostLandTail({
+      storyId: 4622,
+      storyBranch: 'story-4622',
+      baseBranch: 'main',
+      cwd: tmpDir,
+      provider: {},
+      ...baseSeams(events),
+      acquireLockWithWaitFn,
+    });
+
+    assert.deepEqual(tail, {
+      followUps: true,
+      statusResync: true,
+      refCleanup: true,
+      baseFastForward: true,
+      details: {
+        followUps: null,
+        statusResync: null,
+        refCleanup: null,
+        baseFastForward: null,
+      },
+    });
+    assert.ok(released, 'the lock is released');
+    // GitHub steps precede the lock; both mutations are inside it.
+    assert.deepEqual(events, [
+      'followUps',
+      'statusResync',
+      'acquire',
+      'refCleanup',
+      'baseFastForward',
+      'release',
+    ]);
+  });
+
+  it('keys the lockfile on the main checkout .git dir', async () => {
+    let seenLockPath = null;
+    await runPostLandTail({
+      storyId: 4622,
+      storyBranch: 'story-4622',
+      baseBranch: 'main',
+      cwd: tmpDir,
+      provider: {},
+      ...baseSeams(),
+      acquireLockWithWaitFn: async ({ lockPath }) => {
+        seenLockPath = lockPath;
+        return { acquired: true, release: () => {}, ownerId: 't' };
+      },
+    });
+    assert.equal(
+      seenLockPath,
+      path.join(tmpDir, '.git', 'mandrel-post-land-tail.lock'),
+    );
+  });
+
+  it('still runs both mutations when the lock is never acquired (not load-bearing)', async () => {
+    const trace = [];
+    const tail = await runPostLandTail({
+      storyId: 4622,
+      storyBranch: 'story-4622',
+      baseBranch: 'main',
+      cwd: tmpDir,
+      provider: {},
+      ...baseSeams(trace),
+      acquireLockWithWaitFn: async () => ({
+        acquired: false,
+        reason: 'contended-after-wait',
+      }),
+    });
+    assert.equal(tail.refCleanup, true, 'ref cleanup still ran');
+    assert.equal(tail.baseFastForward, true, 'fast-forward still ran');
+    assert.ok(
+      trace.includes('refCleanup') && trace.includes('baseFastForward'),
+    );
+  });
+
+  it('releases the lock even when a git mutation throws', async () => {
+    let released = false;
+    const seams = baseSeams();
+    seams.gitSpawnFn = () => {
+      throw new Error('git exploded');
+    };
+    const tail = await runPostLandTail({
+      storyId: 4622,
+      storyBranch: 'story-4622',
+      baseBranch: 'main',
+      cwd: tmpDir,
+      provider: {},
+      ...seams,
+      acquireLockWithWaitFn: async () => ({
+        acquired: true,
+        release: () => {
+          released = true;
+        },
+        ownerId: 't',
+      }),
+    });
+    // The step wrapper converts the throw to a degraded boolean (never
+    // throws), and the `finally` still releases the lock.
+    assert.equal(tail.refCleanup, false);
+    assert.ok(released, 'the lock is released despite the throw');
+  });
+});
+
+describe('runPostLandTail — real cross-process serialization (Story #4622)', () => {
+  it('two concurrent tails never interleave their critical sections', async () => {
+    // Real lock (default acquireLockWithWaitFn). The critical section spans
+    // an `await step()` boundary between the ref-delete (enter) and the
+    // fast-forward (leave), so without the lock two concurrent tails DO
+    // interleave — verified separately to reach maxConcurrent 2. The lock
+    // must pin it at 1.
+    let inside = 0;
+    let maxConcurrent = 0;
+    const yieldTick = () => new Promise((r) => setImmediate(r));
+
+    const seams = () => ({
+      captureStoryFollowUpsFn: async () => ({ ok: true }),
+      reassertStatusColumnFn: async () => ({ status: 'synced' }),
+      gitSpawnFn: (_cwd, ...args) => {
+        if (args[0] === 'show-ref') return { status: 0 };
+        if (args[0] === 'branch' && args[1] === '-D') {
+          inside += 1;
+          maxConcurrent = Math.max(maxConcurrent, inside);
+          return { status: 0 };
+        }
+        return { status: 0 };
+      },
+      planFastForwardFn: () => ({ runnable: true, reason: null }),
+      executeFastForwardFn: () => {
+        inside -= 1;
+        return { applied: true, behind: 1 };
+      },
+    });
+
+    const run = (storyId) =>
+      runPostLandTail({
+        storyId,
+        storyBranch: `story-${storyId}`,
+        baseBranch: 'main',
+        cwd: tmpDir,
+        provider: {},
+        ...seams(),
+      });
+
+    await Promise.all([
+      run(1),
+      yieldTick().then(() => run(2)),
+      run(3),
+      yieldTick().then(() => run(4)),
+    ]);
+
+    assert.equal(
+      maxConcurrent,
+      1,
+      'the lock kept every critical section mutually exclusive',
+    );
+  });
+});

--- a/tests/lib/orchestration/retro-proposals.test.js
+++ b/tests/lib/orchestration/retro-proposals.test.js
@@ -257,3 +257,66 @@ test('composeRoutedProposals: skips malformed signal records without crashing', 
   assert.equal(out.framework.length, 1);
   assert.equal(out.framework[0].category, 'good');
 });
+
+// --- Story #4622: net out transient (self-resolved) blocks ---------------
+
+const blk = (storyId, extra = {}) => ({
+  category: 'story-blocked',
+  source: 'consumer',
+  storyId,
+  details: {},
+  ...extra,
+});
+const recovered = (storyId) =>
+  blk(storyId, { details: { recovered: true, toState: 'agent::executing' } });
+
+test('netOutRecoveredBlocks: a recovered block drops the whole incident (no proposal)', () => {
+  const out = composeRoutedProposals(
+    baseInput({
+      // Two Stories, each blocked then recovered → 4 story-blocked records,
+      // all transient. Nothing should route or even be discarded.
+      signals: [blk(1), recovered(1), blk(2), recovered(2)],
+    }),
+  );
+  assert.deepEqual(out, { framework: [], consumer: [], discarded: [] });
+});
+
+test('netOutRecoveredBlocks: terminal blocks (no recovery) still count', () => {
+  const out = composeRoutedProposals(baseInput({ signals: [blk(3), blk(4)] }));
+  const blocked = out.consumer.find((i) => i.category === 'story-blocked');
+  assert.ok(blocked, 'two terminal blocks route as an actionable proposal');
+  assert.equal(blocked.occurrences, 2);
+});
+
+test('netOutRecoveredBlocks: only the recovered Story is netted out; terminal peers remain', () => {
+  const out = composeRoutedProposals(
+    baseInput({
+      // Story 5 recovered; Stories 6 and 7 stayed blocked.
+      signals: [blk(5), recovered(5), blk(6), blk(7)],
+    }),
+  );
+  const blocked = out.consumer.find((i) => i.category === 'story-blocked');
+  assert.ok(blocked, 'the two terminal peers still route');
+  assert.equal(blocked.occurrences, 2, 'Story 5 (block + marker) is excluded');
+});
+
+test('netOutRecoveredBlocks: does not touch other categories', () => {
+  const out = composeRoutedProposals(
+    baseInput({
+      signals: [
+        blk(8),
+        recovered(8),
+        { category: 'lint-loop', source: 'framework', storyId: 8 },
+        { category: 'lint-loop', source: 'framework', storyId: 9 },
+      ],
+    }),
+  );
+  const lint = out.framework.find((i) => i.category === 'lint-loop');
+  assert.ok(lint, 'lint-loop is untouched by block netting');
+  assert.equal(lint.occurrences, 2);
+  assert.equal(
+    out.consumer.find((i) => i.category === 'story-blocked'),
+    undefined,
+    'the recovered block contributes nothing',
+  );
+});

--- a/tests/lib/orchestration/ticketing.blocked-friction.test.js
+++ b/tests/lib/orchestration/ticketing.blocked-friction.test.js
@@ -41,12 +41,12 @@ afterEach(async () => {
   await fs.rm(tempRoot, { recursive: true, force: true });
 });
 
-function buildFakeProvider() {
+function buildFakeProvider(labels = ['agent::executing']) {
   const updates = [];
   return {
     updates,
     async getTicket(id) {
-      return { id, title: 'fixture', labels: ['agent::executing'], body: '' };
+      return { id, title: 'fixture', labels: [...labels], body: '' };
     },
     async updateTicket(id, mutations) {
       updates.push({ id, mutations });
@@ -114,5 +114,45 @@ describe('agent::blocked → friction signal (Story #4578)', () => {
     assert.deepEqual(provider.updates[0].mutations.labels.add, [
       STATE_LABELS.BLOCKED,
     ]);
+  });
+});
+
+describe('agent::blocked → active recovery marker (Story #4622)', () => {
+  for (const target of [STATE_LABELS.EXECUTING, STATE_LABELS.READY]) {
+    it(`emits a recovered story-blocked marker on blocked → ${target}`, async () => {
+      const provider = buildFakeProvider(['agent::blocked']);
+      await transitionTicketState(provider, 4622, target, {
+        config,
+        cascade: false,
+        _makeColumnSync: noopColumnSync,
+      });
+
+      const rows = await readSignals(4622);
+      assert.equal(rows.length, 1, 'exactly one recovery marker');
+      assert.equal(rows[0].category, RUNTIME_FRICTION_CATEGORIES.STORY_BLOCKED);
+      assert.equal(rows[0].details.recovered, true);
+      assert.equal(rows[0].details.fromState, STATE_LABELS.BLOCKED);
+      assert.equal(rows[0].details.toState, target);
+    });
+  }
+
+  it('does NOT emit a recovery marker on blocked → done (a terminal outcome, not a recovery)', async () => {
+    const provider = buildFakeProvider(['agent::blocked']);
+    await transitionTicketState(provider, 4624, STATE_LABELS.DONE, {
+      config,
+      cascade: false,
+      _makeColumnSync: noopColumnSync,
+    });
+    assert.equal((await readSignals(4624)).length, 0);
+  });
+
+  it('does NOT emit a recovery marker when the prior state was not blocked', async () => {
+    const provider = buildFakeProvider(['agent::executing']);
+    await transitionTicketState(provider, 4625, STATE_LABELS.READY, {
+      config,
+      cascade: false,
+      _makeColumnSync: noopColumnSync,
+    });
+    assert.equal((await readSignals(4625)).length, 0);
   });
 });

--- a/tests/lib/orchestration/ticketing.ticket-snapshot.test.js
+++ b/tests/lib/orchestration/ticketing.ticket-snapshot.test.js
@@ -80,14 +80,39 @@ describe('transitionTicketState — opts.ticketSnapshot seam', () => {
     assert.deepEqual(provider.getTicketCalls, [42]);
   });
 
-  it('makes zero getTicket calls when neither notify nor ticketSnapshot is set', async () => {
+  it('makes zero getTicket calls for a non-recovery target when neither notify nor ticketSnapshot is set', async () => {
+    // `agent::closing` is not a block-recovery target, so Story #4622's
+    // recovery-detection read does not fire and the snapshot-free fast path
+    // is preserved.
     const provider = makeRecordingProvider({
       ticket: { id: 5, labels: [], body: '' },
     });
-    await transitionTicketState(provider, 5, 'agent::executing', {
+    await transitionTicketState(provider, 5, 'agent::closing', {
       cascade: false,
     });
     assert.equal(provider.getTicketCalls.length, 0);
+  });
+
+  it('loads the snapshot once for a block-recovery target and threads it into updateTicket (Story #4622)', async () => {
+    // A `→ agent::executing|ready` transition needs the *prior* state to
+    // detect a block→active recovery. The snapshot is loaded once and
+    // forwarded as `_ticketSnapshot`, so the provider's label-merge path
+    // reuses it rather than issuing its own read — net-neutral in production.
+    for (const target of ['agent::executing', 'agent::ready']) {
+      const ticket = { id: 5, labels: ['agent::blocked'], body: '' };
+      const provider = makeRecordingProvider({ ticket });
+      await transitionTicketState(provider, 5, target, { cascade: false });
+      assert.equal(
+        provider.getTicketCalls.length,
+        1,
+        `expected exactly one snapshot read for ${target}`,
+      );
+      assert.equal(
+        provider.updateCalls[0].mutations._ticketSnapshot,
+        ticket,
+        'the snapshot must be threaded into updateTicket for reuse',
+      );
+    }
   });
 
   it('derives fromState from the supplied ticketSnapshot for the notify payload', async () => {

--- a/tests/scripts/single-story-sweep-lock.test.js
+++ b/tests/scripts/single-story-sweep-lock.test.js
@@ -5,6 +5,7 @@ import path from 'node:path';
 import { afterEach, beforeEach, describe, it } from 'node:test';
 
 import {
+  acquireLockWithWait,
   acquireSweepLock,
   isLockStale,
   readLockMtime,
@@ -119,5 +120,84 @@ describe('acquireSweepLock', () => {
     const body = fs.readFileSync(lockPath, 'utf-8');
     assert.match(body, /test-owner-42/);
     result.release();
+  });
+});
+
+describe('acquireLockWithWait (Story #4622)', () => {
+  it('acquires immediately when the lock is free', async () => {
+    const lockPath = path.join(tmpDir, 'wait.lock');
+    let slept = 0;
+    const res = await acquireLockWithWait({
+      lockPath,
+      waitMs: 1_000,
+      pollMs: 50,
+      sleepFn: async () => {
+        slept += 1;
+      },
+    });
+    assert.equal(res.acquired, true);
+    assert.equal(slept, 0, 'no wait when the lock is free');
+    res.release();
+  });
+
+  it('polls until a contended lock is released, then acquires', async () => {
+    const lockPath = path.join(tmpDir, 'wait.lock');
+    const holder = acquireSweepLock({ lockPath });
+    assert.equal(holder.acquired, true);
+
+    let now = 0;
+    const nowFn = () => now;
+    // Release the holder on the second poll so the wrapper's retry succeeds.
+    let sleeps = 0;
+    const sleepFn = async (ms) => {
+      now += ms;
+      sleeps += 1;
+      if (sleeps === 2) holder.release();
+    };
+
+    const res = await acquireLockWithWait({
+      lockPath,
+      waitMs: 10_000,
+      pollMs: 100,
+      nowFn,
+      sleepFn,
+    });
+    assert.equal(res.acquired, true, 'acquires once the holder releases');
+    assert.ok(sleeps >= 2, 'waited across at least two polls');
+    res.release();
+  });
+
+  it('gives up with contended-after-wait when the deadline passes (never load-bearing)', async () => {
+    const lockPath = path.join(tmpDir, 'wait.lock');
+    const holder = acquireSweepLock({ lockPath });
+    assert.equal(holder.acquired, true);
+
+    let now = 0;
+    const res = await acquireLockWithWait({
+      lockPath,
+      waitMs: 300,
+      pollMs: 100,
+      // A fresh mtime every check so the lock never reads stale.
+      timeoutMs: 60_000,
+      nowFn: () => now,
+      sleepFn: async (ms) => {
+        now += ms;
+      },
+    });
+    assert.equal(res.acquired, false);
+    assert.equal(res.reason, 'contended-after-wait');
+    holder.release();
+  });
+
+  it('short-circuits on a hard error instead of spinning', async () => {
+    const res = await acquireLockWithWait({
+      lockPath: '',
+      waitMs: 1_000,
+      sleepFn: async () => {
+        throw new Error('sleep should never be called on a hard error');
+      },
+    });
+    assert.equal(res.acquired, false);
+    assert.equal(res.reason, 'error');
   });
 });


### PR DESCRIPTION
Closes #4622

_Auto-opened by `/deliver`._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes shared-checkout git mutation ordering under concurrency and extends ticket transition friction/retro aggregation; behavior is best-effort and heavily tested but affects delivery tail reliability and retro signal routing.
> 
> **Overview**
> Concurrent **single-story-close** runs against one shared main checkout could race during the post-land tail (**local branch delete** + **base fast-forward**), producing degraded `refCleanup` / `baseFastForward` outcomes. This PR wraps only those two git steps in a **best-effort cross-process lock** (`.git/mandrel-post-land-tail.lock`) via new **`acquireLockWithWait`** polling on the existing sweep lock; GitHub follow-up capture and status resync stay outside the lock, and the tail still runs if the lock is not acquired after the wait.
> 
> Separately, **transient** `agent::blocked` flips that recover to **executing** or **ready** no longer inflate retro **`story-blocked`** counts: transitions emit a companion friction record with **`details.recovered: true`**, and **`composeRoutedProposals`** nets out all `story-blocked` signals for any story that ever had a recovery marker (by `storyId`). Blocked→done/closing is unchanged and still counts as terminal.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0e5b7b978e64738f65f8f095721a8585c67ade79. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->