### PR TITLE
feat: tool-first detection for the code-quality lenses: architecture, clean-code, quality (#4628)

### DIFF
--- a/.agents/audit-checklists/architecture.md
+++ b/.agents/audit-checklists/architecture.md
@@ -10,13 +10,12 @@
 
 Self-check your change against this lens's concerns before you ship:
 
+- [ ] Cycle detection.
+- [ ] Dead-export detection.
+- [ ] Hotspot ranking.
+- [ ] LLM triage on top.
 - [ ] Documented architecture boundaries
 - [ ] Automated boundary checks
-- [ ] Over-Engineering & Abstractions
-- [ ] Cognitive Load & Nesting
-- [ ] Dead Code & Redundancy
-- [ ] Naming & Self-Documentation
-- [ ] Coupling & Cohesion
 - [ ] Testable Surface (Humble-Object Boundary)
 - [ ] High
 - [ ] Medium

--- a/.agents/audit-checklists/clean-code.md
+++ b/.agents/audit-checklists/clean-code.md
@@ -10,6 +10,16 @@
 
 Self-check your change against this lens's concerns before you ship:
 
+- [ ] Complexity / maintainability (scoped mode).
+- [ ] Committed baselines (codebase-wide mode).
+- [ ] Duplication.
+- [ ] Dead code.
+- [ ] Entry points
+- [ ] Public API surface
+- [ ] Dynamic imports
+- [ ] Test-only seams
+- [ ] Framework/registration hooks
+- [ ] Churn-by-complexity hotspot cap.
 - [ ] Logic Complexity
 - [ ] Duplication
 - [ ] Component Health

--- a/.agents/audit-checklists/quality.md
+++ b/.agents/audit-checklists/quality.md
@@ -10,6 +10,8 @@
 
 Self-check your change against this lens's concerns before you ship:
 
+- [ ] Story-scoped mode
+- [ ] Codebase-wide mode
 - [ ] Coverage vs. Confidence
 - [ ] Test Fragility & Flakiness
 - [ ] Mocking & Stubbing Strategy

--- a/.agents/schemas/audit-rules.json
+++ b/.agents/schemas/audit-rules.json
@@ -140,7 +140,7 @@
       "triggers": {
         "gates": ["gate1", "gate3"],
         "keywords": ["test", "coverage", "flaky", "assertion"],
-        "filePatterns": ["tests/**", "**/*.test.{ts,js}", "**/*.spec.{ts,js}"]
+        "sourceWithoutSiblingTest": true
       },
       "scope": "local",
       "substitutionKeys": []

--- a/.agents/schemas/audit-rules.schema.json
+++ b/.agents/schemas/audit-rules.schema.json
@@ -95,6 +95,10 @@
           "items": { "type": "string", "minLength": 1 },
           "uniqueItems": true,
           "description": "Glob patterns matched against changed files in the diff."
+        },
+        "sourceWithoutSiblingTest": {
+          "type": "boolean",
+          "description": "Coverage-gap routing trigger (Story #4628). When true, the lens is selected whenever the change set touches a production source file whose sibling test (matched by stem, e.g. foo.js ↔ foo.test.js) is NOT also in the change set — the classic 'shipped source without a test' signal. Implemented by changeSetLacksSiblingTest() in lib/audit-suite/selector.js. Used by audit-quality in place of the backwards test-file filePatterns trigger, which fired the coverage-gap detector on test-only diffs."
         }
       }
     }

--- a/.agents/scripts/lib/audit-suite/checklist-threading.js
+++ b/.agents/scripts/lib/audit-suite/checklist-threading.js
@@ -42,7 +42,11 @@ import { AUDIT_LENSES } from '../audit-to-stories/audit-lenses.js';
 import { getPaths, PROJECT_ROOT, resolveConfig } from '../config-resolver.js';
 import { Logger } from '../Logger.js';
 import { estimateTokens } from '../orchestration/context-envelope.js';
-import { matchesAnyFilePattern, resolveLensTier } from './selector.js';
+import {
+  changeSetLacksSiblingTest,
+  matchesAnyFilePattern,
+  resolveLensTier,
+} from './selector.js';
 
 /**
  * Hard cap on the assembled checklist payload, in the ≈4-char/token estimate
@@ -123,6 +127,18 @@ function filePatternsFor(rules, lens) {
 }
 
 /**
+ * The full `triggers` block a lens declares in the manifest (or `undefined`).
+ * Used to read non-glob trigger fields (e.g. `sourceWithoutSiblingTest`).
+ *
+ * @param {object} rules parsed `audit-rules.json`.
+ * @param {string} lens canonical lens name.
+ * @returns {object|undefined}
+ */
+function triggerFor(rules, lens) {
+  return rules?.audits?.[lensKeyFor(lens)]?.triggers;
+}
+
+/**
  * Normalize a predicted footprint into a clean path list. Accepts a plain
  * `string[]` (the shape the caller derives from a Story's `changes[]` /
  * `references[]` entries); drops empty and non-string entries.
@@ -175,8 +191,15 @@ export function matchLocalLenses({
     if (tier !== 'local') continue;
 
     const patterns = filePatternsFor(rules, lens);
-    if (patterns.length === 0) continue;
-    if (matchesAnyFilePattern(patterns, paths)) matched.push(lens);
+    const fileMatch =
+      patterns.length > 0 && matchesAnyFilePattern(patterns, paths);
+    // Coverage-gap routing (#4628): thread the quality checklist at write-time
+    // on the same sibling-test predicate the selector uses, so a source change
+    // that ships without a test is reminded of the quality lens up front.
+    const siblingMatch =
+      triggerFor(rules, lens)?.sourceWithoutSiblingTest === true &&
+      changeSetLacksSiblingTest(paths);
+    if (fileMatch || siblingMatch) matched.push(lens);
   }
   return matched;
 }

--- a/.agents/scripts/lib/audit-suite/selector.js
+++ b/.agents/scripts/lib/audit-suite/selector.js
@@ -500,6 +500,80 @@ export function matchesAnyFilePattern(patterns, files) {
   return files.some((file) => matchers.some((m) => m(file)));
 }
 
+/** Extensions the sibling-test predicate treats as production source code. */
+const SOURCE_CODE_EXTENSIONS = Object.freeze([
+  '.js',
+  '.mjs',
+  '.cjs',
+  '.jsx',
+  '.ts',
+  '.tsx',
+]);
+
+// biome-ignore lint/complexity/useRegexLiterals: constructor form keeps the MI walker able to score this module.
+const TEST_FILE_RE = new RegExp(String.raw`\.(test|spec)\.[cm]?[jt]sx?$`);
+// biome-ignore lint/complexity/useRegexLiterals: constructor form keeps the MI walker able to score this module.
+const TEST_DIR_RE = new RegExp(
+  String.raw`(^|/)(tests?|__tests__|spec|e2e|__mocks__)(/|$)`,
+);
+// biome-ignore lint/complexity/useRegexLiterals: constructor form keeps the MI walker able to score this module.
+const CODE_EXT_RE = new RegExp(String.raw`\.[cm]?[jt]sx?$`);
+
+/**
+ * True when `file` is a test/spec file — either by the `.test.` / `.spec.`
+ * infix or by living under a conventional test directory.
+ *
+ * @param {string} file
+ * @returns {boolean}
+ */
+function isTestFile(file) {
+  return TEST_FILE_RE.test(file) || TEST_DIR_RE.test(file);
+}
+
+/**
+ * The sibling stem of a path: its basename with any `.test` / `.spec` infix and
+ * the code extension stripped (`src/foo.test.js` and `src/foo.js` both → `foo`).
+ *
+ * @param {string} file
+ * @returns {string}
+ */
+function stemOf(file) {
+  const base = file.split('/').pop() ?? file;
+  return base.replace(TEST_FILE_RE, '').replace(CODE_EXT_RE, '');
+}
+
+/**
+ * The coverage-gap routing predicate behind the `sourceWithoutSiblingTest`
+ * trigger (Story #4628): a change set warrants the `audit-quality` lens when it
+ * touches at least one **production source** file whose **sibling test is not
+ * also in the change set**. This flips the historical (backwards) trigger that
+ * fired the coverage-gap detector on test-file changes — a diff that only edits
+ * tests has, if anything, *more* coverage, not less; the risk lives in source
+ * that shipped without a matching test.
+ *
+ * A source file's sibling is matched by stem (`src/foo.js` ↔ any changed
+ * `foo.test.js` / `foo.spec.js`, regardless of directory). Test-only diffs,
+ * doc/config-only diffs, and source diffs whose every file has a sibling test
+ * in the same change set all return `false` and route no quality lens.
+ *
+ * Pure over its input; no git, no disk.
+ *
+ * @param {string[]|null|undefined} changedFiles
+ * @returns {boolean}
+ */
+export function changeSetLacksSiblingTest(changedFiles) {
+  const files = (Array.isArray(changedFiles) ? changedFiles : []).filter(
+    (f) => typeof f === 'string' && f.length > 0,
+  );
+  const testStems = new Set(
+    files.filter((f) => isTestFile(f)).map((f) => stemOf(f)),
+  );
+  const sources = files.filter(
+    (f) => !isTestFile(f) && SOURCE_CODE_EXTENSIONS.includes(path.extname(f)),
+  );
+  return sources.some((src) => !testStems.has(stemOf(src)));
+}
+
 /**
  * Filter audits based on logic in audit-rules.json (validated against
  * audit-rules.schema.json).
@@ -711,7 +785,13 @@ export async function selectAudits({
       changedFiles,
     );
 
-    if (keywordMatch || fileMatch) {
+    // Coverage-gap routing (#4628): a lens declaring `sourceWithoutSiblingTest`
+    // fires when the change set touches source lacking a sibling test.
+    const siblingMatch =
+      triggers.sourceWithoutSiblingTest === true &&
+      changeSetLacksSiblingTest(changedFiles);
+
+    if (keywordMatch || fileMatch || siblingMatch) {
       selectedAudits.push(auditName);
     }
   }

--- a/.agents/workflows/audit-architecture.md
+++ b/.agents/workflows/audit-architecture.md
@@ -46,6 +46,56 @@ before this section existed.
   proceed with the full codebase-wide scan defined in the remaining
   steps.
 
+## Step 0: Tool-first detection (mandatory — run before any LLM dimension)
+
+Ground every structural finding in a measured instrument this repo already
+ships rather than free-associating over the source. Run the shipped checkers
+**first** and treat their output as the spine of the report; the LLM
+dimensions in Step 2 only *interpret, rank, and phrase* what the tools
+surface. Skipping this step and reasoning about boundaries from prose alone is
+the failure mode this lens exists to prevent.
+
+1. **Cycle detection.** Run the shipped circular-dependency checker:
+
+   ```bash
+   node .agents/scripts/check-arch-cycles.js
+   ```
+
+   Each reported cycle is a grounded finding under the **Automated
+   Architecture Guardrails** dimension. When the shipped checker is
+   unavailable in the consumer project, fall back to
+   `npx madge --circular <srcDir>` or
+   `npx depcruise --validate <config> <srcDir>` (dependency-cruiser).
+
+2. **Dead-export detection.** Run the shipped dead-export checker:
+
+   ```bash
+   node .agents/scripts/check-dead-exports.js
+   ```
+
+   Each unreferenced export is a grounded candidate. **Cede it** to
+   audit-clean-code's Dead Code dimension rather than re-deriving it here (see
+   the deferral in Step 2). When the shipped checker is unavailable, fall back
+   to `npx knip --production` — and heed the `!`-suffix entry-pattern caveat
+   that [`audit-clean-code`](audit-clean-code.md) documents, since
+   `knip --production` is a silent no-op without it.
+
+3. **Hotspot ranking.** Rank the modules the checkers implicate by
+   **fan-in / fan-out** (how many modules import a file versus how many it
+   imports) and by **churn** (e.g.
+   `git log --format= --name-only -n 200 | sort | uniq -c | sort -rn`). A file
+   that is both heavily depended upon and frequently churned is the
+   highest-priority structural hotspot; lead the Triage Summary with it.
+
+4. **LLM triage on top.** Only after the tools have run do you apply the Step 2
+   dimensions to interpret, rank, and phrase the findings. A structural claim
+   that no tool grounds and no Step 2 dimension covers does not belong in this
+   report — route it to the ceded clean-code dimensions instead.
+
+When a shipped checker exits non-zero or is genuinely absent, record that as an
+**Automated Architecture Guardrails** finding (the guardrail is missing or
+broken) rather than skipping the step silently.
+
 ## Step 1: Context Gathering (Read-Only Scan)
 
 > Apply [`helpers/parallel-tooling.md`](helpers/parallel-tooling.md) when batching the scan below — independent reads belong in one turn, long shells run via `run_in_background` + `Monitor`.
@@ -92,23 +142,19 @@ Structural Change can be Medium. As a loose default, Quick Wins typically land
 High (cheap to fix, real payoff) and Structural Changes Medium/High, but grade
 Impact on the risk itself rather than deriving it mechanically from Category.
 
-Evaluate the gathered context against the following clean code dimensions:
+> **Ceded to audit-clean-code.** The five clean-code-overlapping dimensions
+> this lens historically enumerated — Over-Engineering & Abstractions,
+> Cognitive Load & Nesting, Dead Code & Redundancy, Naming &
+> Self-Documentation, and Coupling & Cohesion — are now owned by
+> [`audit-clean-code`](audit-clean-code.md). Do **not** duplicate them here: a
+> smell in one of those five belongs in the clean-code report, and the
+> dead-export candidates from Step 0 flow into audit-clean-code's Dead Code
+> dimension. This lens keeps only the two structural dimensions no other lens
+> owns — the testable-surface boundary and the automated-guardrail maturity.
 
-1. **Over-Engineering & Abstractions:** Identify "dry-run" complexity, premature
-   optimizations, or interfaces/classes that add boilerplate without clear value
-   (e.g., interfaces with only one implementation).
-2. **Cognitive Load & Nesting:** Pinpoint deeply nested logic (arrow code),
-   massive functions violating the Single Responsibility Principle (SRP), or
-   excessive cyclomatic complexity.
-3. **Dead Code & Redundancy:** Locate unused exports, redundant utility
-   functions that duplicate standard library features, or obsolete commented-out
-   code blocks.
-4. **Naming & Self-Documentation:** Find poorly named variables/functions,
-   inconsistent naming conventions, or areas that rely heavily on comments to
-   explain *what* the code does rather than *why*.
-5. **Coupling & Cohesion:** Spot tight coupling between modules that should be
-   independent or god-objects handling too many concerns.
-6. **Testable Surface (Humble-Object Boundary):** Flag modules that interleave
+Evaluate the gathered context against the following architecture dimensions:
+
+1. **Testable Surface (Humble-Object Boundary):** Flag modules that interleave
    hard-to-test I/O — filesystem (`fs`), process spawning (`child_process`,
    `exec`, `spawn`), network calls, database access, or GUI/terminal
    rendering — directly with business logic. The humble-object /
@@ -145,7 +191,7 @@ Evaluate the gathered context against the following clean code dimensions:
    thin `runAsCli` shell — not the logic — owns the `process.exit` side effect,
    keeping the wrapped logic exercisable under a stubbed `process.exit`. Cite
    that precedent where it applies rather than restating it.
-7. **Automated Architecture Guardrails:** Assess whether the project encodes
+2. **Automated Architecture Guardrails:** Assess whether the project encodes
    its architectural boundaries as **deterministic, automated checks** rather
    than relying on convention or reviewer memory. When relevant to the
    consumer project's shape, evaluate enforcement for:

--- a/.agents/workflows/audit-clean-code.md
+++ b/.agents/workflows/audit-clean-code.md
@@ -45,6 +45,68 @@ it. See [`helpers/audit-dual-path.md`](helpers/audit-dual-path.md) for strategy
 selection, the forcing flags, and the read-only guarantee — read `audit-<lens>`
 there as this lens's name.
 
+## Step 0: Tool-first detection (mandatory — measure before you judge)
+
+Ground the maintainability, duplication, and dead-code findings in the exact
+instruments this repo ships, then let the LLM triage in Steps 1–2 interpret and
+rank the numbers. Do **not** eyeball complexity or "spot" dead code from prose —
+run the tools first.
+
+1. **Complexity / maintainability (scoped mode).** When a change-set is in
+   scope, run the quality preview against the base:
+
+   ```bash
+   node .agents/scripts/quality-preview.js --changed-since <base>
+   ```
+
+   It reports the per-file maintainability-index and complexity deltas the
+   `check-baselines.js` gate enforces. Treat any per-file MI drop beyond
+   `delivery.quality.gates.maintainability.tolerance` (default 0.5pt) as a
+   grounded must-fix finding, and any cyclomatic reading over the
+   `codingGuardrails` ceilings (flag > 8, must-fix > 12) as measured, not
+   guessed.
+
+2. **Committed baselines (codebase-wide mode).** Read the committed metric
+   baselines under `baselines/` — `baselines/maintainability.json`,
+   `baselines/duplication.json`, `baselines/crap.json`,
+   `baselines/dead-exports.json` — and cite the outlier rows as evidence
+   rather than re-deriving them. These are the same artifacts the delivery
+   gates read, so a finding that quotes a baseline row is reproducible.
+
+3. **Duplication.** Run the shipped duplication checker
+   (`node .agents/scripts/check-baselines.js --gate duplication`, backed by
+   jscpd) and lift its clone clusters into the DRY dimension.
+
+4. **Dead code.** Run the shipped dead-export checker
+   (`node .agents/scripts/check-dead-exports.js`); it is backed by `knip`.
+   **`knip --production` is a silent no-op unless entry points are declared
+   with `!`-suffixed patterns** — a run that reports `{"issues":[]}` without
+   `!`-suffixed entries has measured nothing, so verify the entry config before
+   trusting a clean result. Apply the **dead-code exclusion taxonomy** below so
+   the report does not drown real dead code in false positives:
+
+   - **Entry points** — CLI mains, `bin/` scripts, and files named in
+     `package.json` `main` / `exports` / `bin`: reachable by definition, never
+     dead.
+   - **Public API surface** — exports that are the package's declared
+     `exports` / barrel contract: consumed out-of-tree, so a zero in-repo
+     importer count is not death.
+   - **Dynamic imports** — symbols reached via `import()`,
+     `require(variable)`, or string-keyed dispatch tables: invisible to static
+     export-graph analysis, so exclude unless you confirm no dynamic reference.
+   - **Test-only seams** — exports consumed only by tests (the sanctioned
+     `test-seams` pattern): flag as test-only, not dead, and never as a
+     production-dead finding.
+   - **Framework/registration hooks** — decorators, lifecycle listeners, and
+     files auto-loaded by convention (globbed listener/plugin dirs): reachable
+     via the framework, not the import graph.
+
+5. **Churn-by-complexity hotspot cap.** Rank candidate hotspots by
+   **churn × complexity** (frequently-changed files that also score poorly on
+   MI/CRAP) and **cap the Detailed Findings at the top ~15 hotspots** so the
+   report stays a ranked, actionable batch rather than an exhaustive dump. Note
+   the cap in the Executive Summary when it bites.
+
 ## Step 1: Quality Scan
 
 > Apply [`helpers/parallel-tooling.md`](helpers/parallel-tooling.md) when batching the scan below — independent reads belong in one turn, long shells run via `run_in_background` + `Monitor`.

--- a/.agents/workflows/audit-quality.md
+++ b/.agents/workflows/audit-quality.md
@@ -54,11 +54,45 @@ it. See [`helpers/audit-dual-path.md`](helpers/audit-dual-path.md) for strategy
 selection, the forcing flags, and the read-only guarantee — read `audit-<lens>`
 there as this lens's name.
 
-## Step 0 - Project Context
+## Step 0 - Mode split + tool-first artifact read (mandatory)
 
-1.  Read the Story under audit — its `## Goal`, inline `acceptance[]` /
-    `verify[]`, and folded `## Spec` — to identify the target features.
-2.  Identify the target codebase paths for the audit.
+**Resolve the mode first**, then read the numbers before judging. The two modes
+do not share a Step 0 — a codebase-wide run must not try to read a Story it was
+never given.
+
+- **Story-scoped mode** (the `## Scope` block above is populated with a change
+  set): read the Story under audit — its `## Goal`, inline `acceptance[]` /
+  `verify[]`, and folded `## Spec` — to identify the target features, and scope
+  the audit to the change set and its direct dependencies.
+- **Codebase-wide mode** (the `## Scope` block renders the literal
+  `{{changedFiles}}` token): there is **no Story** — do not look for one. Audit
+  the whole test surface, ranked (below).
+
+**Read the committed test-quality artifacts as evidence** (both modes). This
+lens grounds every coverage/quality claim in the metrics the delivery gates
+already compute and commit, rather than prose-scanning the tests:
+
+- `baselines/coverage.json` — per-file line/branch coverage. Cite the covered
+  ratio for any file you flag as under-tested.
+- `baselines/crap.json` — the CRAP score (complexity × uncoveredness). A high
+  CRAP row is a measured "complex **and** under-tested" hotspot — the single
+  strongest coverage-gap signal.
+- `baselines/mutation.json` — mutation-testing survivors where present: tests
+  that execute code without asserting on it (coverage without confidence).
+
+**Rank churn-by-coverage.** Order candidate findings by **churn × coverage
+gap** — frequently-changed files (`git log --format= --name-only -n 200 | sort
+| uniq -c | sort -rn`) that also score low coverage / high CRAP are the
+highest-value gaps. Lead the report with them; cap the Detailed Findings at the
+top hotspots so the output is an actionable batch, not an exhaustive dump.
+
+**Anchor the rubric** to [`rules/testing-standards.md`](../rules/testing-standards.md):
+the three-tier pyramid, assertion-placement, and mocking/isolation MUSTs are the
+standard a finding is measured against — cite the rule the test violates rather
+than asserting a bare opinion.
+
+Reading these committed artifacts is **read-only** and explicitly permitted (see
+the Constraint) — it is not "running the suite".
 
 ## Step 1: Context Gathering (Read-Only Scan)
 
@@ -148,5 +182,9 @@ with the primary file the finding lives in:]
 
 ## Constraint
 
-Do NOT execute any code modifications, edit files, create branches, or run the
-test suite. This is strictly a read-only analysis. Output the report and stop.
+Do NOT execute any code modifications, edit files, create branches, or **run**
+the test suite (do not invoke `npm test`, a coverage run, or a mutation run —
+those mutate state and cost minutes). Reading the **committed** coverage / CRAP
+/ mutation artifacts under `baselines/` is explicitly permitted and required
+(Step 0): citing an already-computed metric is read-only analysis, not a suite
+run. Output the report and stop.

--- a/.claude/workflows/audit-architecture.workflow.js
+++ b/.claude/workflows/audit-architecture.workflow.js
@@ -103,14 +103,42 @@ const LENS_PATH = path.join(
  * The independent analysis dimensions the lens decomposes into. These names
  * map 1:1 onto the lens's Step 2 "Analysis Dimensions"; each fans out to its
  * own subagent so they run in parallel and can be cross-checked independently.
+ *
+ * Since Story #4628 the architecture lens **cedes** its five
+ * clean-code-overlapping dimensions (Over-Engineering, Cognitive Load, Dead
+ * Code, Naming, Coupling & Cohesion) to `audit-clean-code` and keeps only the
+ * two structural dimensions no other lens owns. This list is pinned against
+ * the lens markdown's Step 2 roster by the parity test in
+ * `tests/contract/architecture-report-contract.test.js`, which fails on any
+ * drift — so the orchestrated path can no longer silently diverge from its
+ * lens (the frozen-list bug that dropped Testable Surface).
+ *
+ * @type {readonly string[]}
  */
-const DIMENSIONS = Object.freeze([
-  'Over-Engineering & Abstractions',
-  'Cognitive Load & Nesting',
-  'Dead Code & Redundancy',
-  'Naming & Self-Documentation',
-  'Coupling & Cohesion',
+export const DIMENSIONS = Object.freeze([
+  'Testable Surface (Humble-Object Boundary)',
   'Automated Architecture Guardrails',
+]);
+
+/**
+ * The per-finding field labels the dimension prompt instructs each analysis
+ * agent to emit, in template order. Derived from the lens markdown's Step 3
+ * `### <finding>` structure and pinned by the parity test so the orchestrated
+ * path can never omit a mandated field again — notably **Impact** and
+ * **Location**, which the pre-#4628 frozen prompt dropped, leaving orchestrated
+ * findings severity-less and unanchored.
+ *
+ * @type {readonly string[]}
+ */
+export const DIMENSION_FINDING_FIELDS = Object.freeze([
+  'Impact',
+  'Category',
+  'Dimension',
+  'Location',
+  'Current State',
+  'Recommendation & Rationale',
+  'Acceptance signal',
+  'Agent Prompt',
 ]);
 
 /** Read-only tool allowlist for analysis agents — no write/edit/shell. */
@@ -171,8 +199,9 @@ export function buildDimensionPrompt(dimension, lensSpec, scopeClause) {
     '',
     `Return ONLY the findings for the "${dimension}" dimension, each as a`,
     '`### <Short Title>` block using the exact field structure from the lens',
-    'Step 3 template (Category, Dimension, Current State, Recommendation &',
-    'Rationale, Agent Prompt). For the "Automated Architecture Guardrails"',
+    `Step 3 template (${DIMENSION_FINDING_FIELDS.join(', ')}). Grade Impact on`,
+    'the Critical | High | Medium | Low scale and anchor Location to a',
+    '`path:line`. For the "Automated Architecture Guardrails"',
     'dimension, also return the Architecture Guardrail Coverage assessment',
     "using the lens's Maturity Rubric (Current Maturity, Documented",
     'Boundaries, Automated Checks Found, CI Enforcement, Axes Covered,',

--- a/tests/audit-suite/checklist-threading.test.js
+++ b/tests/audit-suite/checklist-threading.test.js
@@ -53,13 +53,28 @@ function makeLoggerSpy() {
   };
 }
 
-test('matchLocalLenses: footprint matching a local lens returns that lens', () => {
-  // `tests/**` and `**/*.test.{ts,js}` are the `audit-quality` (local)
-  // triggers. `audit-clean-code` (local, universal `**/*` pattern) also
-  // matches every footprint, so it is threaded alongside — both in stable
-  // AUDIT_LENSES order (clean-code precedes quality).
+test('matchLocalLenses: a test-only footprint threads only the universal clean-code lens', () => {
+  // Since Story #4628 `audit-quality` routes on `sourceWithoutSiblingTest`, not
+  // a test-file glob: a diff that only touches tests has, if anything, *more*
+  // coverage, so quality must NOT thread. `audit-clean-code` (local, universal
+  // `**/*` pattern) still matches every footprint.
   const matched = matchLocalLenses({ footprint: ['tests/foo.test.js'] });
+  assert.deepEqual(matched, ['clean-code']);
+});
+
+test('matchLocalLenses: source lacking a sibling test threads the quality lens', () => {
+  // The coverage-gap trigger: `src/foo.js` with no `foo.test.js` in the change
+  // set threads `audit-quality` (alongside the universal clean-code lens), in
+  // stable AUDIT_LENSES order (clean-code precedes quality).
+  const matched = matchLocalLenses({ footprint: ['app/service.js'] });
   assert.deepEqual(matched, ['clean-code', 'quality']);
+});
+
+test('matchLocalLenses: source WITH its sibling test does not thread the quality lens', () => {
+  const matched = matchLocalLenses({
+    footprint: ['app/service.js', 'tests/service.test.js'],
+  });
+  assert.deepEqual(matched, ['clean-code']);
 });
 
 test('matchLocalLenses: the universal clean-code lens matches EVERY footprint', () => {
@@ -83,9 +98,9 @@ test('matchLocalLenses: the universal clean-code lens matches EVERY footprint', 
 });
 
 test('buildChecklistPayload: local-lens footprint returns that checklist', () => {
-  const result = buildChecklistPayload({ footprint: ['tests/foo.test.js'] });
-  // The universal clean-code lens is threaded alongside the footprint-matched
-  // quality lens, in AUDIT_LENSES order.
+  // `src/foo.js` lacks a sibling test, so the coverage-gap quality lens threads
+  // alongside the universal clean-code lens, in AUDIT_LENSES order.
+  const result = buildChecklistPayload({ footprint: ['app/service.js'] });
   assert.deepEqual(result.matchedLenses, ['clean-code', 'quality']);
   assert.deepEqual(result.includedLenses, ['clean-code', 'quality']);
   assert.deepEqual(result.droppedLenses, []);
@@ -139,8 +154,9 @@ test('buildChecklistPayload: empty / absent footprint returns nothing', () => {
 
 test('buildChecklistPayload: over-budget match is truncated deterministically and logged', () => {
   // This footprint matches multiple LOCAL lenses: lighthouse (**/*.html),
-  // performance (src/**/*.js), quality (tests/**), security (**/auth/*.js),
-  // seo (**/*.html) — in AUDIT_LENSES order.
+  // performance (src/**/*.js), security (**/auth/*.js), seo (**/*.html), plus
+  // the universal clean-code — in AUDIT_LENSES order. (Quality does NOT match:
+  // src/auth/login.js has its sibling tests/login.test.js in the same set.)
   const footprint = [
     'app/index.html',
     'src/auth/login.js',
@@ -207,9 +223,9 @@ test('buildChecklistPayload: default budget is generous enough to never truncate
   const footprint = [
     'app/index.html', // lighthouse, seo
     'app/styles/main.css', // ux-ui, lighthouse
-    'src/auth/login.js', // security, performance
-    'src/user-profile/settings.js', // privacy
-    'tests/login.test.js', // quality
+    'src/auth/login.js', // security, performance (sibling test present)
+    'src/user-profile/settings.js', // privacy, quality (no sibling test)
+    'tests/login.test.js', // login.js's sibling
   ];
   const result = buildChecklistPayload({ footprint });
   assert.equal(result.tokenBudget, DEFAULT_CHECKLIST_TOKEN_BUDGET);

--- a/tests/audit-suite/selector-sibling-test.test.js
+++ b/tests/audit-suite/selector-sibling-test.test.js
@@ -1,0 +1,129 @@
+/**
+ * tests/audit-suite/selector-sibling-test.test.js — Story #4628.
+ *
+ * Pins the coverage-gap routing trigger that replaced audit-quality's backwards
+ * test-file `filePatterns` with the `sourceWithoutSiblingTest` predicate:
+ *
+ *   - `changeSetLacksSiblingTest` is a pure predicate over a fixture diff: it
+ *     is true iff the change set touches a production source file whose sibling
+ *     test (matched by stem) is absent from the same change set.
+ *   - `selectAudits` fires `audit-quality` on a source-without-sibling diff and
+ *     does NOT fire it on a test-only diff (the old, backwards behaviour) when
+ *     the ticket prose carries none of the lens's keywords.
+ */
+
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  changeSetLacksSiblingTest,
+  selectAudits,
+} from '../../.agents/scripts/lib/audit-suite/selector.js';
+import { MockProvider } from '../fixtures/mock-provider.js';
+
+// --- the pure predicate over fixture diffs ---------------------------------
+
+test('changeSetLacksSiblingTest: source without any test fires', () => {
+  assert.equal(changeSetLacksSiblingTest(['src/checkout.js']), true);
+});
+
+test('changeSetLacksSiblingTest: source with its sibling test does not fire', () => {
+  assert.equal(
+    changeSetLacksSiblingTest(['src/checkout.js', 'tests/checkout.test.js']),
+    false,
+  );
+});
+
+test('changeSetLacksSiblingTest: a test-only diff never fires (the coverage-gap flip)', () => {
+  assert.equal(changeSetLacksSiblingTest(['tests/checkout.test.js']), false);
+  assert.equal(changeSetLacksSiblingTest(['src/a.spec.ts']), false);
+});
+
+test('changeSetLacksSiblingTest: a doc/config-only diff never fires', () => {
+  assert.equal(
+    changeSetLacksSiblingTest([
+      'README.md',
+      '.agents/schemas/audit-rules.json',
+    ]),
+    false,
+  );
+});
+
+test('changeSetLacksSiblingTest: one uncovered source among many covered fires', () => {
+  assert.equal(
+    changeSetLacksSiblingTest([
+      'src/a.js',
+      'tests/a.test.js',
+      'src/b.js', // no b.test.js in the set
+    ]),
+    true,
+  );
+});
+
+test('changeSetLacksSiblingTest: matches sibling by stem across directories', () => {
+  assert.equal(
+    changeSetLacksSiblingTest([
+      'src/deep/nested/parser.ts',
+      'tests/unit/parser.test.ts',
+    ]),
+    false,
+  );
+});
+
+test('changeSetLacksSiblingTest: tolerates null / non-string entries', () => {
+  assert.equal(changeSetLacksSiblingTest(null), false);
+  assert.equal(changeSetLacksSiblingTest([null, 42, 'src/x.js']), true);
+});
+
+// --- selectAudits routes audit-quality on the flipped trigger --------------
+
+/** Keyword-free ticket so audit-quality can only be selected via the trigger. */
+function makeProvider() {
+  return new MockProvider({
+    tickets: {
+      900: {
+        id: 900,
+        title: 'Refactor the dispatcher module',
+        body: 'Restructure the module boundaries; no behavioural change.',
+        labels: [],
+      },
+    },
+  });
+}
+
+async function select(changedFiles) {
+  const result = await selectAudits({
+    ticketId: 900,
+    gate: 'gate3',
+    provider: makeProvider(),
+    changedFiles,
+  });
+  return result.selectedAudits;
+}
+
+test('selectAudits: fires audit-quality on source lacking a sibling test', async () => {
+  const selected = await select(['src/dispatcher.js']);
+  assert.ok(
+    selected.includes('audit-quality'),
+    `audit-quality must fire on uncovered source: ${selected.join(', ')}`,
+  );
+});
+
+test('selectAudits: does NOT fire audit-quality on a test-only diff', async () => {
+  const selected = await select(['tests/dispatcher.test.js']);
+  assert.ok(
+    !selected.includes('audit-quality'),
+    `audit-quality must not fire on a test-only diff: ${selected.join(', ')}`,
+  );
+});
+
+test('selectAudits: does NOT fire audit-quality when every source has a sibling test', async () => {
+  const selected = await select([
+    'src/dispatcher.js',
+    'tests/dispatcher.test.js',
+  ]);
+  assert.ok(
+    !selected.includes('audit-quality'),
+    `audit-quality must not fire when source is covered: ${selected.join(', ')}`,
+  );
+});

--- a/tests/contract/architecture-report-contract.test.js
+++ b/tests/contract/architecture-report-contract.test.js
@@ -28,6 +28,8 @@ import {
 import {
   buildScopeClause,
   buildSynthesisPrompt,
+  DIMENSION_FINDING_FIELDS,
+  DIMENSIONS,
 } from '../../.claude/workflows/audit-architecture.workflow.js';
 
 const REPO_ROOT = path.resolve(
@@ -139,6 +141,67 @@ test('buildScopeClause: a real file list → scoped analysis', () => {
   assert.match(clause, /Restrict analysis/i);
   assert.ok(clause.includes('src/a.js'));
   assert.ok(clause.includes('src/b.js'));
+});
+
+// --- dimension/field parity: the orchestrated path cannot drift (Story #4628)
+
+/**
+ * Extract the bold lead-in label of every top-level numbered item under the
+ * lens's `## Step 2: Analysis Dimensions` section — the canonical dimension
+ * roster the orchestrated `DIMENSIONS` export must mirror. Sub-bullets
+ * (`- **High** —`) are `-` items, never numbered, so they are not harvested.
+ *
+ * @param {string} md
+ * @returns {string[]}
+ */
+function lensAnalysisDimensions(md) {
+  const lines = md.split(/\r?\n/);
+  const start = lines.findIndex((l) =>
+    /^## Step 2: Analysis Dimensions/.test(l),
+  );
+  assert.ok(
+    start !== -1,
+    'lens is missing its "## Step 2: Analysis Dimensions" section',
+  );
+  const dims = [];
+  for (let i = start + 1; i < lines.length; i += 1) {
+    if (/^## /.test(lines[i])) break; // next top-level section ends Step 2
+    const m = /^\d+\.\s+\*\*(.+?):\*\*/.exec(lines[i]);
+    if (m) dims.push(m[1].trim());
+  }
+  return dims;
+}
+
+test('DIMENSIONS mirrors the lens Step 2 roster exactly (no orchestrated drift)', () => {
+  assert.deepEqual([...DIMENSIONS], lensAnalysisDimensions(LENS));
+});
+
+test('the pinned roster keeps Testable Surface after ceding the clean-code dimensions', () => {
+  assert.ok(
+    DIMENSIONS.includes('Testable Surface (Humble-Object Boundary)'),
+    `DIMENSIONS dropped Testable Surface: ${DIMENSIONS.join(', ')}`,
+  );
+  // The five ceded dimensions must NOT reappear in the orchestrated roster.
+  for (const ceded of [
+    'Over-Engineering & Abstractions',
+    'Cognitive Load & Nesting',
+    'Dead Code & Redundancy',
+    'Naming & Self-Documentation',
+    'Coupling & Cohesion',
+  ]) {
+    assert.ok(
+      !DIMENSIONS.includes(ceded),
+      `ceded dimension "${ceded}" must not appear in the orchestrated roster`,
+    );
+  }
+});
+
+test('the dimension prompt field list includes Impact (was dropped by the frozen list)', () => {
+  assert.ok(
+    DIMENSION_FINDING_FIELDS.includes('Impact'),
+    `DIMENSION_FINDING_FIELDS omits Impact: ${DIMENSION_FINDING_FIELDS.join(', ')}`,
+  );
+  assert.ok(DIMENSION_FINDING_FIELDS.includes('Location'));
 });
 
 // --- downstream consumer parity --------------------------------------------


### PR DESCRIPTION
Closes #4628

_Auto-opened by `/deliver`._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes audit lens selection and write-time checklist threading used during delivery; behavior is well-tested but mis-routed quality audits could affect gate coverage until caught in review.
> 
> **Overview**
> **Tool-first audit lenses.** `audit-architecture`, `audit-clean-code`, and `audit-quality` now require **Step 0** to run shipped checkers and read committed `baselines/` artifacts before LLM analysis; architecture **cedes** five clean-code dimensions to `audit-clean-code` and keeps only **Testable Surface** and **Automated Architecture Guardrails**. Generated authoring checklists reflect the new steps.
> 
> **Coverage-gap routing (#4628).** `audit-quality` drops test-file `filePatterns` in favor of `sourceWithoutSiblingTest`, implemented by `changeSetLacksSiblingTest()` in `selector.js` (stem-matched sibling tests across dirs). The same predicate is wired into **write-time** checklist threading so makers see the quality checklist when shipping uncovered source.
> 
> **Orchestrated architecture parity.** `audit-architecture.workflow.js` shrinks `DIMENSIONS` to match the lens markdown, exports `DIMENSION_FINDING_FIELDS` (including **Impact** and **Location**), and contract tests pin roster/field parity so the dynamic-workflow path cannot drift again.
> 
> **Tests.** New `selector-sibling-test.test.js` and updated checklist-threading expectations document the flipped quality trigger.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a50a29f831618119dd354a7d0575745f29b6e3c6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->