### PR TITLE
feat: activate the dormant shift-left audit tiers: story-close lens delivery, write-time checklist threading, sequential-path self-check (#4627)

### DIFF
--- a/.agents/scripts/lib/audit-suite/__tests__/lens-contract.test.js
+++ b/.agents/scripts/lib/audit-suite/__tests__/lens-contract.test.js
@@ -217,6 +217,18 @@ describe('lens findings contract (Story #4625)', () => {
           `audit-${lens} does not write the canonical output path`,
         );
       });
+
+      it('references the shared self-cross-check helper (Story #4627)', () => {
+        // Standing gate for the sequential-path false-positive guard: every
+        // non-retired lens must carry the self-cross-check step, so a later
+        // lens rewrite that drops it fails the suite instead of silently
+        // shipping an unguarded lens. New lenses added after this Story are
+        // covered because this assertion iterates NON_RETIRED_LENSES.
+        assert.ok(
+          md.includes('](helpers/audit-self-check.md)'),
+          `audit-${lens} does not reference the self-cross-check helper (helpers/audit-self-check.md) — the sequential-path false-positive guard is missing`,
+        );
+      });
     });
   }
 
@@ -262,6 +274,13 @@ describe('lens findings contract (Story #4625)', () => {
     assert.ok(
       fs.existsSync(path.join(HELPERS_DIR, 'audit-severity-scale.md')),
       'helpers/audit-severity-scale.md does not exist',
+    );
+  });
+
+  it('ships the shared self-cross-check helper (Story #4627)', () => {
+    assert.ok(
+      fs.existsSync(path.join(HELPERS_DIR, 'audit-self-check.md')),
+      'helpers/audit-self-check.md does not exist',
     );
   });
 });

--- a/.agents/scripts/lib/audit-suite/dispatch-checklist.js
+++ b/.agents/scripts/lib/audit-suite/dispatch-checklist.js
@@ -1,0 +1,132 @@
+/**
+ * lib/audit-suite/dispatch-checklist.js — the deliver-dispatch call site for
+ * write-time checklist threading (Story #4627, activating Epic #4405's
+ * Story #4410 machinery).
+ *
+ * `checklist-threading.js#buildChecklistPayload` was built and unit-tested but
+ * had **zero production call sites**: nothing derived a footprint, assembled
+ * the payload, or handed a `checklistPath` to the spawned Story worker. This
+ * module is that call site. Given a Story's predicted footprint (its
+ * `changes[]` / `references[]` path entries), it assembles the footprint-matched
+ * local-lens checklist payload, writes it to the run's temp dir, and returns
+ * the `checklistPath` the deliver-story spawn threads into the maker's prompt
+ * (the same way the docs digest reaches the worker as `docsDigestPath`).
+ *
+ * Pure modulo the single file write, which is an injectable seam
+ * (`writeFileFn`) so the builder is unit-testable without touching disk. No
+ * git, no provider, no network — the footprint is the planner's *prediction*,
+ * not a diff, so no repository read is involved.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { buildChecklistPayload } from './checklist-threading.js';
+
+/**
+ * Extract clean path strings from a Story's `changes[]` / `references[]`
+ * entries. Accepts both the parsed `{ path, assumption }` PathEntry shape and a
+ * bare `string`, dropping empty / non-string entries.
+ *
+ * @param {unknown} entries
+ * @returns {string[]}
+ */
+function footprintFromEntries(entries) {
+  if (!Array.isArray(entries)) return [];
+  return entries
+    .map((entry) => (typeof entry === 'string' ? entry : entry?.path))
+    .filter((p) => typeof p === 'string' && p.trim().length > 0)
+    .map((p) => p.trim());
+}
+
+/**
+ * Derive the predicted footprint the checklist matcher reads: the union of a
+ * Story's `changes[]` and `references[]` path entries, in that order.
+ *
+ * Module-local: a detail of {@link buildDispatchChecklist}, exercised through
+ * that public entry point (assert the footprint the injected payload builder
+ * received) rather than imported directly, so it adds no test-only public
+ * export the dead-export ratchet would flag.
+ *
+ * @param {{ changes?: unknown, references?: unknown }} [args]
+ * @returns {string[]}
+ */
+function deriveDispatchFootprint({ changes, references } = {}) {
+  return [
+    ...footprintFromEntries(changes),
+    ...footprintFromEntries(references),
+  ];
+}
+
+/**
+ * Default file writer: ensure the parent dir exists, then write the payload.
+ *
+ * @param {string} filePath
+ * @param {string} content
+ * @returns {void}
+ */
+function defaultWriteFile(filePath, content) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, content, 'utf8');
+}
+
+/**
+ * Build the write-time checklist payload for a Story and write it to the run's
+ * temp dir, returning the `checklistPath` the deliver-story spawn threads.
+ *
+ * When the footprint matches no local lens (the common case for a
+ * docs-only or infra-only Story), nothing is written and `checklistPath` is
+ * `null` — the worker then runs with no write-time checklist, exactly as it
+ * does today, and lens-aware coverage still runs maker-blind at Story-scope
+ * close.
+ *
+ * @param {object} args
+ * @param {number|string} args.storyId — names the payload file.
+ * @param {unknown} [args.changes] — the Story's `changes[]` path entries.
+ * @param {unknown} [args.references] — the Story's `references[]` path entries.
+ * @param {string} args.runTempDir — the run temp dir the payload is written to.
+ * @param {number} [args.tokenBudget] — override the payload cap.
+ * @param {typeof buildChecklistPayload} [args.buildPayloadFn] — injectable seam.
+ * @param {(filePath: string, content: string) => void} [args.writeFileFn] —
+ *   injectable write seam (defaults to the on-disk writer).
+ * @returns {{
+ *   checklistPath: string|null,
+ *   skipped: boolean,
+ *   matchedLenses: string[],
+ *   includedLenses: string[],
+ *   droppedLenses: string[],
+ * }}
+ */
+export function buildDispatchChecklist({
+  storyId,
+  changes,
+  references,
+  runTempDir,
+  tokenBudget,
+  buildPayloadFn = buildChecklistPayload,
+  writeFileFn = defaultWriteFile,
+}) {
+  const footprint = deriveDispatchFootprint({ changes, references });
+  const result = buildPayloadFn({
+    footprint,
+    ...(tokenBudget != null ? { tokenBudget } : {}),
+  });
+  const accounting = {
+    matchedLenses: result.matchedLenses,
+    includedLenses: result.includedLenses,
+    droppedLenses: result.droppedLenses,
+  };
+
+  if (!result.payload || result.includedLenses.length === 0) {
+    return { checklistPath: null, skipped: true, ...accounting };
+  }
+
+  if (!runTempDir) {
+    throw new TypeError(
+      'buildDispatchChecklist: runTempDir is required to write a non-empty checklist payload',
+    );
+  }
+
+  const checklistPath = path.join(runTempDir, `story-${storyId}-checklist.md`);
+  writeFileFn(checklistPath, result.payload);
+  return { checklistPath, skipped: false, ...accounting };
+}

--- a/.agents/scripts/lib/audit-suite/index.js
+++ b/.agents/scripts/lib/audit-suite/index.js
@@ -19,6 +19,7 @@ export {
   matchLocalLenses,
   readAuditRules,
 } from './checklist-threading.js';
+export { buildDispatchChecklist } from './dispatch-checklist.js';
 export { runAuditSuite } from './runner.js';
 export {
   GLOBAL_LENS_ALLOWLIST,

--- a/.agents/scripts/lib/orchestration/story-close/phases/__tests__/local-lens-review-delivery.test.js
+++ b/.agents/scripts/lib/orchestration/story-close/phases/__tests__/local-lens-review-delivery.test.js
@@ -1,0 +1,167 @@
+/**
+ * local-lens-review-delivery.test.js — contract test for the Story-scope
+ * lens-delivery activation (Story #4627, AC-1).
+ *
+ * Before this Story the Story-scope lens pass selected and materialized lenses
+ * but delivered their content to no reader: `runLocalLensReview` invoked
+ * `runAuditSuite` with neither substitutions nor an `artifactPrefix`, so the
+ * `{{changedFiles}}` token never resolved and no artifact was written. This
+ * gate pins the delivery contract:
+ *
+ *   - the lens pass threads the resolved `{{changedFiles}}` / `{{ticketId}}`
+ *     substitutions and a Story-scoped `artifactPrefix` into `runAuditSuite`;
+ *   - the close's stdout names each materialized artifact path under a
+ *     host-MUST-walk contract, so the default (non-reading) review provider no
+ *     longer renders the pass inert.
+ */
+
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { runLocalLensReview } from '../local-lens-review.js';
+
+/** A `runAuditSuite` spy that records its args and returns a fixed envelope. */
+function auditSuiteSpy(envelope) {
+  const calls = [];
+  const fn = async (args) => {
+    calls.push(args);
+    return envelope;
+  };
+  fn.calls = calls;
+  return fn;
+}
+
+/** Collect the `(tag, msg)` progress lines a run emits. */
+function progressCollector() {
+  const lines = [];
+  const progress = (tag, msg) => lines.push({ tag, msg });
+  progress.lines = lines;
+  progress.joined = () => lines.map((l) => l.msg).join('\n');
+  return progress;
+}
+
+test('delivers substituted lens prompts: resolved changedFiles token + Story-scoped artifactPrefix', async () => {
+  const runAuditSuiteFn = auditSuiteSpy({
+    metadata: {},
+    findings: [],
+    workflows: [
+      {
+        audit: 'audit-clean-code',
+        artifactPath: 'temp/audits/audit-story-4627-audit-clean-code.md',
+      },
+    ],
+  });
+
+  await runLocalLensReview({
+    baseRef: 'main',
+    headRef: 'story-4627',
+    changedFiles: ['.agents/scripts/a.js', '.agents/scripts/b.js'],
+    storyId: 4627,
+    progress: progressCollector(),
+    selectLocalLensesFn: () => ['audit-clean-code'],
+    runAuditSuiteFn,
+  });
+
+  assert.equal(runAuditSuiteFn.calls.length, 1);
+  const call = runAuditSuiteFn.calls[0];
+  // The {{changedFiles}} token resolves to the newline-joined diff the lens
+  // `## Scope` block reads, and {{ticketId}} resolves to the Story id.
+  assert.equal(
+    call.substitutions.changedFiles,
+    '.agents/scripts/a.js\n.agents/scripts/b.js',
+  );
+  assert.equal(call.substitutions.ticketId, '4627');
+  // Artifacts are scoped to the Story so concurrent closes cannot clobber.
+  assert.equal(call.artifactPrefix, 'story-4627');
+});
+
+test('names each materialized artifact path under a host-MUST-walk contract', async () => {
+  const runAuditSuiteFn = auditSuiteSpy({
+    metadata: {},
+    findings: [],
+    workflows: [
+      {
+        audit: 'audit-clean-code',
+        artifactPath: 'temp/audits/audit-story-4627-audit-clean-code.md',
+      },
+      {
+        audit: 'audit-quality',
+        artifactPath: 'temp/audits/audit-story-4627-audit-quality.md',
+      },
+    ],
+  });
+  const progress = progressCollector();
+
+  const out = await runLocalLensReview({
+    baseRef: 'main',
+    headRef: 'story-4627',
+    changedFiles: ['.agents/scripts/a.js'],
+    storyId: 4627,
+    progress,
+    selectLocalLensesFn: () => ['audit-clean-code', 'audit-quality'],
+    runAuditSuiteFn,
+  });
+
+  const stdout = progress.joined();
+  assert.match(stdout, /host MUST read\/walk each/);
+  assert.match(stdout, /audit-story-4627-audit-clean-code\.md/);
+  assert.match(stdout, /audit-story-4627-audit-quality\.md/);
+  // The paths are also carried on the returned envelope for the caller.
+  assert.deepEqual(out.artifactPaths, [
+    'temp/audits/audit-story-4627-audit-clean-code.md',
+    'temp/audits/audit-story-4627-audit-quality.md',
+  ]);
+});
+
+test('emits no roster when no lens matched (nothing to walk)', async () => {
+  const runAuditSuiteFn = auditSuiteSpy({
+    metadata: {},
+    findings: [],
+    workflows: [],
+  });
+  const progress = progressCollector();
+
+  await runLocalLensReview({
+    baseRef: 'main',
+    headRef: 'story-4627',
+    changedFiles: ['docs/unrelated.md'],
+    storyId: 4627,
+    progress,
+    selectLocalLensesFn: () => [],
+    runAuditSuiteFn,
+  });
+
+  assert.equal(runAuditSuiteFn.calls.length, 0);
+  assert.doesNotMatch(progress.joined(), /host MUST/);
+});
+
+test('the roster lists only lenses that actually wrote an artifact', async () => {
+  const runAuditSuiteFn = auditSuiteSpy({
+    metadata: {},
+    findings: [],
+    workflows: [
+      { audit: 'a', artifactPath: 'temp/audits/audit-story-4627-a.md' },
+      { audit: 'b', artifactPath: null },
+      { audit: 'c', artifactPath: 'temp/audits/audit-story-4627-c.md' },
+    ],
+  });
+  const progress = progressCollector();
+  const out = await runLocalLensReview({
+    baseRef: 'main',
+    headRef: 'story-4627',
+    changedFiles: ['.agents/scripts/a.js'],
+    storyId: 4627,
+    progress,
+    selectLocalLensesFn: () => ['a', 'b', 'c'],
+    runAuditSuiteFn,
+  });
+  const stdout = progress.joined();
+  assert.match(stdout, /audit-story-4627-a\.md/);
+  assert.match(stdout, /audit-story-4627-c\.md/);
+  assert.doesNotMatch(stdout, /audit-story-4627-b\.md/);
+  // A lens whose materialization wrote no artifact contributes no path.
+  assert.deepEqual(out.artifactPaths, [
+    'temp/audits/audit-story-4627-a.md',
+    'temp/audits/audit-story-4627-c.md',
+  ]);
+});

--- a/.agents/scripts/lib/orchestration/story-close/phases/local-lens-review.js
+++ b/.agents/scripts/lib/orchestration/story-close/phases/local-lens-review.js
@@ -31,6 +31,58 @@ import { computeChangeSet } from '../../change-set.js';
 const STORY_SCOPE_LENS_DEPTH = 'light';
 
 /**
+ * Render the host-MUST-walk roster of materialized lens-prompt artifacts
+ * (Story #4627). The Story-scope lens pass materializes each matched lens's
+ * substituted prompt body to a scoped artifact file; the default review
+ * provider is a mechanical sweep that never reads them, so the artifacts are
+ * inert unless the close's stdout tells the host to walk them. This mirrors
+ * the plan-run audit-roster comment's "host MUST walk each" contract
+ * (`run-epilogue.js`): the close names each artifact path and the host reads
+ * each one against the diff.
+ *
+ * Pure: derives the block from the `runAuditSuite` envelope's `workflows[]`,
+ * keeping only entries that actually wrote an artifact. Returns `null` when no
+ * artifact was written (nothing to walk), so the caller emits nothing.
+ *
+ * Module-local: an implementation detail of {@link runLocalLensReview}, whose
+ * host-MUST-walk output rides out on the `progress` stream. Exercised through
+ * that public entry point (assert the progress lines name each artifact path)
+ * rather than imported directly, so it adds no production-dead public export.
+ *
+ * @param {object|null} materialized the `runAuditSuite` result envelope.
+ * @returns {string|null} the roster block, or `null` when there is nothing to walk.
+ */
+function renderLensArtifactRoster(materialized) {
+  const paths = (materialized?.workflows ?? [])
+    .map((w) => w?.artifactPath)
+    .filter((p) => typeof p === 'string' && p.length > 0);
+  if (paths.length === 0) return null;
+  return [
+    `Lens prompts materialized (host MUST read/walk each against the Story diff):`,
+    ...paths.map((p) => `  - ${p}`),
+  ].join('\n');
+}
+
+/**
+ * Build the `runAuditSuite` substitutions for the Story-scope lens pass
+ * (Story #4627). Resolves the `{{changedFiles}}` token from the actual Story
+ * diff (newline-joined, the shape the lens templates' `## Scope` block reads)
+ * and the `{{ticketId}}` token from the Story id when known. Both are built-in
+ * substitution keys (`substitutions.js#BUILT_IN_SUBSTITUTION_KEYS`), so the
+ * runner accepts them without a per-lens `substitutionKeys` declaration.
+ *
+ * @param {{ changedFiles: string[], storyId?: number|string|null }} args
+ * @returns {Record<string, string>}
+ */
+function buildLensSubstitutions({ changedFiles, storyId }) {
+  const substitutions = { changedFiles: changedFiles.join('\n') };
+  if (storyId != null && `${storyId}`.length > 0) {
+    substitutions.ticketId = String(storyId);
+  }
+  return substitutions;
+}
+
+/**
  * Enumerate the files changed in the `baseRef...headRef` diff. Thin adapter over
  * the shared {@link computeChangeSet} enumerator (Story #4593) that flattens its
  * `files: string[]|null` envelope to this phase's historical `[]`-on-failure
@@ -120,10 +172,20 @@ function resolveLensChangeSet({
  * for standalone callers that supply no list; see {@link resolveLensChangeSet}
  * for the three-state contract.
  *
+ * Story #4627 — the pass now delivers lens **content** to a reader. It threads
+ * `{{changedFiles}}` / `{{ticketId}}` substitutions and an `artifactPrefix`
+ * into `runAuditSuite` so each matched lens's substituted prompt body is
+ * written to a scoped artifact under the run's audit output dir, then emits a
+ * host-MUST-walk roster of those artifact paths to the close's stdout. Before
+ * this the default review provider dropped the materialized envelope, so the
+ * pass was a progress log line with no reader.
+ *
  * @param {{
  *   baseRef: string,
  *   headRef: string,
  *   changedFiles?: string[]|null,
+ *   storyId?: number|string|null,
+ *   artifactPrefix?: string,
  *   progress: (tag: string, msg: string) => void,
  *   progressTag?: string,
  *   gitSpawnFn?: import('../../change-set.js').GitSpawnFn,
@@ -135,12 +197,15 @@ function resolveLensChangeSet({
  *   lenses: string[],
  *   skipped: boolean,
  *   materialized: object|null,
+ *   artifactPaths: string[],
  * }>}
  */
 export async function runLocalLensReview({
   baseRef,
   headRef,
   changedFiles: injectedChangedFiles,
+  storyId,
+  artifactPrefix,
   progress,
   progressTag = 'CODE-REVIEW',
   gitSpawnFn = gitSpawn,
@@ -152,6 +217,7 @@ export async function runLocalLensReview({
     lenses: [],
     skipped: true,
     materialized: null,
+    artifactPaths: [],
   };
   try {
     const changedFiles = resolveLensChangeSet({
@@ -168,16 +234,30 @@ export async function runLocalLensReview({
       );
       return empty;
     }
-    const materialized = await runAuditSuiteFn({ auditWorkflows: lenses });
+    // Scope the artifact filenames to this Story so concurrent closes on a
+    // shared audit output dir cannot clobber each other's prompts.
+    const effectivePrefix =
+      artifactPrefix ?? (storyId != null ? `story-${storyId}` : 'story-scope');
+    const materialized = await runAuditSuiteFn({
+      auditWorkflows: lenses,
+      substitutions: buildLensSubstitutions({ changedFiles, storyId }),
+      artifactPrefix: effectivePrefix,
+    });
     progress(
       progressTag,
       `Ran ${lenses.length} local lens(es) at ${STORY_SCOPE_LENS_DEPTH} depth: ${lenses.join(', ')}.`,
     );
+    const roster = renderLensArtifactRoster(materialized);
+    if (roster) progress(progressTag, roster);
+    const artifactPaths = (materialized?.workflows ?? [])
+      .map((w) => w?.artifactPath)
+      .filter((p) => typeof p === 'string' && p.length > 0);
     return {
       depth: STORY_SCOPE_LENS_DEPTH,
       lenses,
       skipped: false,
       materialized,
+      artifactPaths,
     };
   } catch (err) {
     // The lens pass is advisory: a git or materialization failure must not

--- a/.agents/scripts/lib/orchestration/story-close/phases/review-core.js
+++ b/.agents/scripts/lib/orchestration/story-close/phases/review-core.js
@@ -110,6 +110,7 @@ export async function runStoryReviewCore({
     baseRef,
     headRef,
     changedFiles: changeSet.files,
+    storyId: storyIdNum,
     progress,
     progressTag,
     gitSpawnFn,

--- a/.agents/workflows/audit-architecture.md
+++ b/.agents/workflows/audit-architecture.md
@@ -326,3 +326,13 @@ with the primary file the finding lives in:]
 Do NOT execute any code modifications, edit files, create branches, or implement
 changes. This is strictly a read-only analysis. Ensure all recommendations
 preserve existing functionality and external APIs. Output the report and stop.
+
+## Self-cross-check (mandatory — filter false positives before you finalize)
+
+Before you write the report artifact from the previous step, run the shared
+adversarial self-cross-check over your Detailed Findings — see
+[`helpers/audit-self-check.md`](helpers/audit-self-check.md). It defines the
+per-finding evidence bar, the exclusion list, and the final re-open-and-drop
+pass whose `kept <k> / dropped <d>` counts you record in the Executive
+Summary, so the sequential single-pass path filters unverified findings just as
+the orchestrated path's adversarial reviewer does.

--- a/.agents/workflows/audit-clean-code.md
+++ b/.agents/workflows/audit-clean-code.md
@@ -201,3 +201,13 @@ standards.]
 
 This workflow is **read-only**. Provide the analysis and the roadmap, but do not
 apply changes.
+
+## Self-cross-check (mandatory — filter false positives before you finalize)
+
+Before you write the report artifact from the previous step, run the shared
+adversarial self-cross-check over your Detailed Findings — see
+[`helpers/audit-self-check.md`](helpers/audit-self-check.md). It defines the
+per-finding evidence bar, the exclusion list, and the final re-open-and-drop
+pass whose `kept <k> / dropped <d>` counts you record in the Executive
+Summary, so the sequential single-pass path filters unverified findings just as
+the orchestrated path's adversarial reviewer does.

--- a/.agents/workflows/audit-dependencies.md
+++ b/.agents/workflows/audit-dependencies.md
@@ -94,3 +94,13 @@ structure. Lead each title with the manifest the dependency lives in:]
 
 This is a **read-only** evaluation. Do not run `npm install` or `npm update`
 unless explicitly requested by the user after reviewing this report.
+
+## Self-cross-check (mandatory — filter false positives before you finalize)
+
+Before you write the report artifact from the previous step, run the shared
+adversarial self-cross-check over your Detailed Findings — see
+[`helpers/audit-self-check.md`](helpers/audit-self-check.md). It defines the
+per-finding evidence bar, the exclusion list, and the final re-open-and-drop
+pass whose `kept <k> / dropped <d>` counts you record in the Executive
+Summary, so the sequential single-pass path filters unverified findings just as
+the orchestrated path's adversarial reviewer does.

--- a/.agents/workflows/audit-devops.md
+++ b/.agents/workflows/audit-devops.md
@@ -114,3 +114,13 @@ Phase 3: Modernization / Tech Debt.]
 
 Do NOT execute any code modifications, edit files, create branches, or install
 packages. This is strictly a read-only analysis. Output the report and stop.
+
+## Self-cross-check (mandatory — filter false positives before you finalize)
+
+Before you write the report artifact from the previous step, run the shared
+adversarial self-cross-check over your Detailed Findings — see
+[`helpers/audit-self-check.md`](helpers/audit-self-check.md). It defines the
+per-finding evidence bar, the exclusion list, and the final re-open-and-drop
+pass whose `kept <k> / dropped <d>` counts you record in the Executive
+Summary, so the sequential single-pass path filters unverified findings just as
+the orchestrated path's adversarial reviewer does.

--- a/.agents/workflows/audit-documentation.md
+++ b/.agents/workflows/audit-documentation.md
@@ -263,3 +263,13 @@ This workflow is **read-only** with respect to the repository: run the
 deterministic checkers in `--check` mode only, and do not edit any
 documentation or code. The single write is the report artifact. Provide the
 analysis and remediation prompts; do not apply changes.
+
+## Self-cross-check (mandatory — filter false positives before you finalize)
+
+Before you write the report artifact from the previous step, run the shared
+adversarial self-cross-check over your Detailed Findings — see
+[`helpers/audit-self-check.md`](helpers/audit-self-check.md). It defines the
+per-finding evidence bar, the exclusion list, and the final re-open-and-drop
+pass whose `kept <k> / dropped <d>` counts you record in the Executive
+Summary, so the sequential single-pass path filters unverified findings just as
+the orchestrated path's adversarial reviewer does.

--- a/.agents/workflows/audit-navigability.md
+++ b/.agents/workflows/audit-navigability.md
@@ -144,3 +144,13 @@ finding lives in:]
 This is a **read-only** audit. Provide the critique and the nav-registry fixes,
 but do not modify the route tree or the nav registry. Log route and door
 identifiers only — never full route bodies, source contents, or persona data.
+
+## Self-cross-check (mandatory — filter false positives before you finalize)
+
+Before you write the report artifact from the previous step, run the shared
+adversarial self-cross-check over your Detailed Findings — see
+[`helpers/audit-self-check.md`](helpers/audit-self-check.md). It defines the
+per-finding evidence bar, the exclusion list, and the final re-open-and-drop
+pass whose `kept <k> / dropped <d>` counts you record in the Executive
+Summary, so the sequential single-pass path filters unverified findings just as
+the orchestrated path's adversarial reviewer does.

--- a/.agents/workflows/audit-performance.md
+++ b/.agents/workflows/audit-performance.md
@@ -117,3 +117,13 @@ This is a **read-only** audit. Note: This workflow differs from
 and findings) by focusing on deep architectural and logic bottlenecks across
 the whole stack — backend, data access, and runtime hot paths — rather than
 the page-load surface Lighthouse measures.
+
+## Self-cross-check (mandatory — filter false positives before you finalize)
+
+Before you write the report artifact from the previous step, run the shared
+adversarial self-cross-check over your Detailed Findings — see
+[`helpers/audit-self-check.md`](helpers/audit-self-check.md). It defines the
+per-finding evidence bar, the exclusion list, and the final re-open-and-drop
+pass whose `kept <k> / dropped <d>` counts you record in the Executive
+Summary, so the sequential single-pass path filters unverified findings just as
+the orchestrated path's adversarial reviewer does.

--- a/.agents/workflows/audit-privacy.md
+++ b/.agents/workflows/audit-privacy.md
@@ -108,3 +108,13 @@ with the primary file the finding lives in:]
 
 This is a **read-only** audit. Do not modify any code. Focus on identifying
 risks and providing clear remediation steps.
+
+## Self-cross-check (mandatory — filter false positives before you finalize)
+
+Before you write the report artifact from the previous step, run the shared
+adversarial self-cross-check over your Detailed Findings — see
+[`helpers/audit-self-check.md`](helpers/audit-self-check.md). It defines the
+per-finding evidence bar, the exclusion list, and the final re-open-and-drop
+pass whose `kept <k> / dropped <d>` counts you record in the Executive
+Summary, so the sequential single-pass path filters unverified findings just as
+the orchestrated path's adversarial reviewer does.

--- a/.agents/workflows/audit-quality.md
+++ b/.agents/workflows/audit-quality.md
@@ -188,3 +188,13 @@ those mutate state and cost minutes). Reading the **committed** coverage / CRAP
 / mutation artifacts under `baselines/` is explicitly permitted and required
 (Step 0): citing an already-computed metric is read-only analysis, not a suite
 run. Output the report and stop.
+
+## Self-cross-check (mandatory — filter false positives before you finalize)
+
+Before you write the report artifact from the previous step, run the shared
+adversarial self-cross-check over your Detailed Findings — see
+[`helpers/audit-self-check.md`](helpers/audit-self-check.md). It defines the
+per-finding evidence bar, the exclusion list, and the final re-open-and-drop
+pass whose `kept <k> / dropped <d>` counts you record in the Executive
+Summary, so the sequential single-pass path filters unverified findings just as
+the orchestrated path's adversarial reviewer does.

--- a/.agents/workflows/audit-security.md
+++ b/.agents/workflows/audit-security.md
@@ -116,3 +116,13 @@ each title with the primary file the vulnerability lives in:]
 
 This is a **read-only** audit. Your priority is accuracy and clear impact
 assessment. Do not attempt to exploit the system or modify code.
+
+## Self-cross-check (mandatory — filter false positives before you finalize)
+
+Before you write the report artifact from the previous step, run the shared
+adversarial self-cross-check over your Detailed Findings — see
+[`helpers/audit-self-check.md`](helpers/audit-self-check.md). It defines the
+per-finding evidence bar, the exclusion list, and the final re-open-and-drop
+pass whose `kept <k> / dropped <d>` counts you record in the Executive
+Summary, so the sequential single-pass path filters unverified findings just as
+the orchestrated path's adversarial reviewer does.

--- a/.agents/workflows/audit-seo.md
+++ b/.agents/workflows/audit-seo.md
@@ -136,3 +136,13 @@ finding lives in:]
 
 Do NOT rewrite or modify any files. Do NOT implement the changes. Focus strictly
 on analyzing the code. Output the report and stop.
+
+## Self-cross-check (mandatory — filter false positives before you finalize)
+
+Before you write the report artifact from the previous step, run the shared
+adversarial self-cross-check over your Detailed Findings — see
+[`helpers/audit-self-check.md`](helpers/audit-self-check.md). It defines the
+per-finding evidence bar, the exclusion list, and the final re-open-and-drop
+pass whose `kept <k> / dropped <d>` counts you record in the Executive
+Summary, so the sequential single-pass path filters unverified findings just as
+the orchestrated path's adversarial reviewer does.

--- a/.agents/workflows/audit-sre.md
+++ b/.agents/workflows/audit-sre.md
@@ -142,3 +142,13 @@ Lead each title with the primary file the finding lives in:]
 
 Do NOT generate code fixes, edit files, or create branches. This is strictly a
 read-only analysis. Output the report and stop.
+
+## Self-cross-check (mandatory — filter false positives before you finalize)
+
+Before you write the report artifact from the previous step, run the shared
+adversarial self-cross-check over your Detailed Findings — see
+[`helpers/audit-self-check.md`](helpers/audit-self-check.md). It defines the
+per-finding evidence bar, the exclusion list, and the final re-open-and-drop
+pass whose `kept <k> / dropped <d>` counts you record in the Executive
+Summary, so the sequential single-pass path filters unverified findings just as
+the orchestrated path's adversarial reviewer does.

--- a/.agents/workflows/audit-ux-ui.md
+++ b/.agents/workflows/audit-ux-ui.md
@@ -112,3 +112,13 @@ structure. Lead each title with the primary file the finding lives in:]
 
 This is a **read-only** audit. Provide the critique and implementation
 suggestions, but do not modify styles or components.
+
+## Self-cross-check (mandatory — filter false positives before you finalize)
+
+Before you write the report artifact from the previous step, run the shared
+adversarial self-cross-check over your Detailed Findings — see
+[`helpers/audit-self-check.md`](helpers/audit-self-check.md). It defines the
+per-finding evidence bar, the exclusion list, and the final re-open-and-drop
+pass whose `kept <k> / dropped <d>` counts you record in the Executive
+Summary, so the sequential single-pass path filters unverified findings just as
+the orchestrated path's adversarial reviewer does.

--- a/.agents/workflows/helpers/audit-self-check.md
+++ b/.agents/workflows/helpers/audit-self-check.md
@@ -1,0 +1,70 @@
+# Audit finding self-cross-check (shared)
+
+> **Single source of truth for the sequential-path false-positive guard
+> (Story #4627).** Every non-retired audit lens references this file and runs
+> this pass over its Detailed Findings before finalizing its report. The
+> orchestrated dynamic-workflow path already fans out an independent
+> adversarial reviewer; this pass gives the **sequential single-pass** path —
+> the one consumer runs take, where the npm payload ships no per-lens
+> `*.workflow.js` — the same false-positive filter, so a lens cannot report an
+> unverified finding just because it ran single-pass.
+
+You are your own adversarial reviewer. After you have drafted the Detailed
+Findings but **before** you write the report artifact, re-open every finding
+and hold it to the bar below. This pass is **read-only** — it filters and
+tightens the findings you already have; it never invents new ones.
+
+## Per-finding evidence bar (keep or drop)
+
+Keep a finding only when **all** of the following hold. Drop it otherwise.
+
+- **Grounded location** — it names a concrete `path:line` (or a concrete
+  symbol / config key) that you have actually read, not a hypothetical or a
+  "somewhere in the codebase" claim.
+- **Reproducible evidence** — the problem is backed by an observable: a tool
+  reading (a baseline row, a complexity/MI/duplication number, a failing
+  command), a quoted code snippet, or a specific standard it violates. A
+  finding whose entire basis is "this looks wrong" does not clear the bar.
+- **In-scope** — when a change-set scope filter was supplied (the `Scope`
+  block resolved to a file list), the finding lives in that scope or a direct
+  dependency the lens explicitly reasons across. A finding outside the scope
+  filter is dropped, not reported.
+- **Actionable** — the recommendation is specific enough to execute. Drop
+  vague exhortations ("improve error handling generally") that carry no
+  concrete change.
+
+## Exclusion list (never a finding)
+
+Treat the following as **out of scope by construction** and drop any finding
+that rests on one of them:
+
+- **Sanctioned test seams** — exports consumed only by tests, and other
+  patterns the `test-seams` rule blesses. Never a production defect.
+- **Entry points & public API surface** — CLI mains, `bin/` scripts, declared
+  `exports` / `bin` / `main`, and barrel contracts consumed out-of-tree. A
+  zero in-repo consumer count is not death.
+- **Dynamic / framework reachability** — symbols reached via `import()`,
+  string-keyed dispatch, decorators, lifecycle listeners, or convention-loaded
+  plugin directories. Invisible to static analysis, not dead.
+- **Intentional, documented deviations** — a pattern an in-tree comment, ADR,
+  or config explicitly sanctions. Cite it and drop the finding.
+- **Style-only nits already enforced by a formatter/linter** — do not
+  re-litigate what the committed tooling already governs.
+
+## Final re-open-and-drop pass (mandatory)
+
+1. Walk your Detailed Findings once more, applying the bar and the exclusion
+   list above. Remove every finding that fails.
+2. Count what you kept (`k`) and what you dropped (`d`).
+3. Record the outcome in the report's **Executive Summary** as a single line:
+
+   ```text
+   Self-cross-check: kept <k> / dropped <d>.
+   ```
+
+   When `d > 0`, name the dropped findings (title + the bar/exclusion reason)
+   in one short list under that line, so the filtering is auditable and never
+   silent.
+
+A lens that keeps every finding still records `dropped 0` — the line's absence
+is itself a defect (it means the pass did not run).

--- a/.agents/workflows/helpers/deliver-story.md
+++ b/.agents/workflows/helpers/deliver-story.md
@@ -132,6 +132,31 @@ Operator/agent responsibilities while in the worktree:
    read it before you write and self-check as you author. When absent,
    lens-aware coverage still runs maker-blind at Story-scope review inside
    the close subprocess.
+
+   **Producing `checklistPath` at dispatch (Story #4627).** The dispatch that
+   spawns this worker threads `checklistPath` the same way it threads
+   `docsDigestPath`. Before the spawn, compute the payload from the Story's
+   predicted footprint (its `changes[]` / `references[]` path entries) with
+   `buildDispatchChecklist` and write it to the run temp dir:
+
+   ```bash
+   node --input-type=module -e '
+     import { buildDispatchChecklist } from "<main-repo>/.agents/scripts/lib/audit-suite/index.js";
+     import { parse } from "<main-repo>/.agents/scripts/lib/story-body/story-body.js";
+     // storyBody is the fetched Story issue body.
+     const { changes, references } = parse(process.env.STORY_BODY);
+     const { checklistPath } = buildDispatchChecklist({
+       storyId: <storyId>, changes, references, runTempDir: "temp/run-<id>",
+     });
+     console.log(checklistPath ?? "");
+   '
+   ```
+
+   A non-empty `checklistPath` is threaded into this worker's prompt; an empty
+   footprint match prints nothing and the worker runs with no write-time
+   checklist (the maker-blind close-scope pass still covers it). The builder is
+   a pure function of the footprint and the on-disk checklists —
+   `buildDispatchChecklist` (`lib/audit-suite/dispatch-checklist.js`).
 2. Implement the changes. When the body has a `## Slicing` / Delivery
    Slicing table, walk rows as **intra-session checkpoints** (commit +
    flip each row when done) — never as sibling tickets.

--- a/baselines/dead-exports-production.json
+++ b/baselines/dead-exports-production.json
@@ -57,6 +57,10 @@
       "symbol": "readAuditRules"
     },
     {
+      "file": ".agents/scripts/lib/audit-suite/dispatch-checklist.js",
+      "symbol": "buildDispatchChecklist"
+    },
+    {
       "file": ".agents/scripts/lib/audit-suite/findings.js",
       "symbol": "aggregateBaselineDelta"
     },
@@ -83,6 +87,10 @@
     {
       "file": ".agents/scripts/lib/audit-suite/index.js",
       "symbol": "buildChecklistPayload"
+    },
+    {
+      "file": ".agents/scripts/lib/audit-suite/index.js",
+      "symbol": "buildDispatchChecklist"
     },
     {
       "file": ".agents/scripts/lib/audit-suite/index.js",

--- a/tests/audit-suite/dispatch-checklist.test.js
+++ b/tests/audit-suite/dispatch-checklist.test.js
@@ -1,0 +1,156 @@
+/**
+ * tests/audit-suite/dispatch-checklist.test.js — unit test for the
+ * deliver-dispatch checklist builder (Story #4627, AC-2).
+ *
+ * Pins the write-time checklist threading call site: the deliver dispatch
+ * derives a footprint from the Story's `changes[]` / `references[]` entries,
+ * assembles the footprint-matched local-lens checklist payload, writes it to
+ * the run temp dir, and returns the `checklistPath` the spawned Story worker
+ * receives. An empty match writes nothing and threads a null path.
+ *
+ * Imported from the audit-suite barrel — the same entry point the deliver
+ * dispatch (`helpers/deliver-story.md`) imports — so this is a real consumer of
+ * the public export, not a colocated project file.
+ */
+
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { buildDispatchChecklist } from '../../.agents/scripts/lib/audit-suite/index.js';
+
+/** A payload-builder spy that records the footprint it received. */
+function payloadSpy(returnValue) {
+  const calls = [];
+  const fn = (args) => {
+    calls.push(args);
+    return returnValue;
+  };
+  fn.calls = calls;
+  return fn;
+}
+
+const nonEmptyPayload = {
+  payload: '# checklist\n\n- do the thing',
+  includedLenses: ['clean-code'],
+  droppedLenses: [],
+  matchedLenses: ['clean-code'],
+  estimatedTokens: 5,
+  tokenBudget: 4000,
+};
+
+const emptyPayload = {
+  payload: '',
+  includedLenses: [],
+  droppedLenses: [],
+  matchedLenses: [],
+  estimatedTokens: 0,
+  tokenBudget: 4000,
+};
+
+test('derives the footprint as the union of changes[] and references[] path entries', () => {
+  const buildPayloadFn = payloadSpy(emptyPayload);
+  buildDispatchChecklist({
+    storyId: 4627,
+    changes: [
+      { path: '.agents/scripts/a.js', assumption: 'x' },
+      { path: '  .agents/scripts/b.js  ' },
+    ],
+    references: [{ path: '.agents/scripts/lib/c.js' }, 'bare/string.js'],
+    runTempDir: 'temp/run-abc',
+    buildPayloadFn,
+    writeFileFn: () => {},
+  });
+  assert.deepEqual(buildPayloadFn.calls[0].footprint, [
+    '.agents/scripts/a.js',
+    '.agents/scripts/b.js',
+    '.agents/scripts/lib/c.js',
+    'bare/string.js',
+  ]);
+});
+
+test('drops empty / non-string / missing footprint entries', () => {
+  const buildPayloadFn = payloadSpy(emptyPayload);
+  buildDispatchChecklist({
+    storyId: 4627,
+    changes: [{ path: '' }, { path: '   ' }, { assumption: 'no path' }, 42],
+    references: null,
+    runTempDir: 'temp/run-abc',
+    buildPayloadFn,
+    writeFileFn: () => {},
+  });
+  assert.deepEqual(buildPayloadFn.calls[0].footprint, []);
+});
+
+test('writes the payload to <runTempDir>/story-<id>-checklist.md and returns the path', () => {
+  const writes = [];
+  const out = buildDispatchChecklist({
+    storyId: 4627,
+    changes: [{ path: '.agents/scripts/x.js' }],
+    references: [],
+    runTempDir: 'temp/run-abc',
+    buildPayloadFn: payloadSpy(nonEmptyPayload),
+    writeFileFn: (filePath, content) => writes.push({ filePath, content }),
+  });
+
+  assert.equal(out.checklistPath, 'temp/run-abc/story-4627-checklist.md');
+  assert.equal(out.skipped, false);
+  assert.deepEqual(out.includedLenses, ['clean-code']);
+  assert.equal(writes.length, 1);
+  assert.equal(writes[0].filePath, 'temp/run-abc/story-4627-checklist.md');
+  assert.equal(writes[0].content, '# checklist\n\n- do the thing');
+});
+
+test('threads a null checklistPath and writes nothing when no lens matched', () => {
+  const writes = [];
+  const out = buildDispatchChecklist({
+    storyId: 4627,
+    changes: [{ path: 'docs/unrelated.md' }],
+    runTempDir: 'temp/run-abc',
+    buildPayloadFn: payloadSpy(emptyPayload),
+    writeFileFn: (filePath, content) => writes.push({ filePath, content }),
+  });
+
+  assert.equal(out.checklistPath, null);
+  assert.equal(out.skipped, true);
+  assert.equal(writes.length, 0);
+});
+
+test('throws when a non-empty payload has no runTempDir to write to', () => {
+  assert.throws(
+    () =>
+      buildDispatchChecklist({
+        storyId: 4627,
+        changes: [{ path: '.agents/scripts/x.js' }],
+        runTempDir: undefined,
+        buildPayloadFn: payloadSpy(nonEmptyPayload),
+        writeFileFn: () => {},
+      }),
+    /runTempDir is required/,
+  );
+});
+
+test('integration: real payload builder assembles a footprint-matched checklist', () => {
+  const writes = [];
+  const out = buildDispatchChecklist({
+    storyId: 4627,
+    // `.agents/scripts/**` matches at least one real LOCAL lens
+    // (audit-performance) plus the universal clean-code lens, so the payload is
+    // non-empty.
+    changes: [{ path: '.agents/scripts/lib/foo.js' }],
+    references: [],
+    runTempDir: 'temp/run-int',
+    writeFileFn: (filePath, content) => writes.push({ filePath, content }),
+  });
+
+  assert.equal(out.checklistPath, 'temp/run-int/story-4627-checklist.md');
+  assert.equal(out.skipped, false);
+  assert.ok(
+    out.includedLenses.length >= 1,
+    `expected >= 1 matched local lens, got ${JSON.stringify(out.includedLenses)}`,
+  );
+  assert.equal(writes.length, 1);
+  assert.ok(
+    writes[0].content.length > 0,
+    'the assembled checklist payload must be non-empty',
+  );
+});


### PR DESCRIPTION
Closes #4627

_Auto-opened by `/deliver`._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the advisory story-close review spine and many audit workflow contracts; behavior changes are gated by tests but dispatch checklist wiring is documented rather than added to a JS spawn path in this diff.
> 
> **Overview**
> Activates three previously dormant **shift-left audit** paths so lens output and checklists actually reach readers instead of dying in materialization.
> 
> **Story-close lens delivery.** `runLocalLensReview` now calls `runAuditSuite` with resolved `{{changedFiles}}` / `{{ticketId}}` substitutions and a story-scoped `artifactPrefix`, writes substituted lens prompts to disk, returns `artifactPaths`, and prints a **host MUST read/walk each** roster on close progress. `runStoryReviewCore` passes `storyId` into that pass. Contract tests lock this behavior.
> 
> **Write-time checklist threading.** Adds `buildDispatchChecklist` (footprint from Story `changes[]` / `references[]` → `buildChecklistPayload` → `story-<id>-checklist.md` in the run temp dir, or `null` when no lens matches). Exported from the audit-suite barrel; `deliver-story.md` documents how dispatch should thread `checklistPath` like `docsDigestPath`.
> 
> **Sequential-path false-positive guard.** New shared `helpers/audit-self-check.md`; every non-retired audit workflow gains a mandatory self-cross-check section. `lens-contract.test.js` asserts each lens references the helper and that the helper file exists.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b88100df45327fafa7227ea2c7732f369bb61a29. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->