### PR TITLE
feat: tool-first detection for the ops/security lenses: devops, security, privacy, and an SRE rewrite (#4629)

### DIFF
--- a/.agents/audit-checklists/devops.md
+++ b/.agents/audit-checklists/devops.md
@@ -10,6 +10,10 @@
 
 Self-check your change against this lens's concerns before you ship:
 
+- [ ] Workflow static analysis (`actionlint`).
+- [ ] Workflow security posture (`zizmor`).
+- [ ] Container linting (`hadolint`), presence-gated on Dockerfiles.
+- [ ] Pipeline reliability history (`gh run list`).
 - [ ] Redundancy & Duplication
 - [ ] Performance Gaps
 - [ ] Security & Compliance

--- a/.agents/audit-checklists/privacy.md
+++ b/.agents/audit-checklists/privacy.md
@@ -10,10 +10,9 @@
 
 Self-check your change against this lens's concerns before you ship:
 
-- [ ] Log Statements
-- [ ] Storage
-- [ ] API Requests
-- [ ] Analytics
+- [ ] Enumerate the sinks.
+- [ ] Secret scan.
+- [ ] Trace PII sources to the enumerated sinks.
 - [ ] Data Minimization
 - [ ] Leaky Logging
 - [ ] Insecure Transmission

--- a/.agents/audit-checklists/security.md
+++ b/.agents/audit-checklists/security.md
@@ -10,11 +10,10 @@
 
 Self-check your change against this lens's concerns before you ship:
 
-- [ ] Input Validation
-- [ ] Injection Risks
-- [ ] Authentication/Authorization
-- [ ] Dependency Security
-- [ ] Secret Management
+- [ ] Dependency CVEs (`npm audit`).
+- [ ] Secret scanning (`gitleaks` / `trufflehog`), with a grep fallback.
+- [ ] Grep battery (deterministic fallback / augmentation).
+- [ ] Manual surface review.
 - [ ] Injection
 - [ ] Broken Access Control
 - [ ] Cryptographic Failures

--- a/.agents/audit-checklists/sre.md
+++ b/.agents/audit-checklists/sre.md
@@ -10,15 +10,17 @@
 
 Self-check your change against this lens's concerns before you ship:
 
-- [ ] Config Integrity
-- [ ] Hardcoding Scan
-- [ ] Fallback Logic
-- [ ] Secret Leaks
-- [ ] Input Sanitization
-- [ ] Dependency Risks
-- [ ] Console Hygiene
-- [ ] Error Swallowing
-- [ ] Boundary Handling
-- [ ] Dead Code
-- [ ] Complexity
-- [ ] Asset Loading
+- [ ] Run the resilience battery.
+- [ ] Rollback Path
+- [ ] Migration Reversibility
+- [ ] Feature-Flag Kill Switch
+- [ ] Structured Logging
+- [ ] Metrics & Tracing
+- [ ] Alerting & SLOs
+- [ ] Timeouts & Cancellation
+- [ ] Retry & Backoff
+- [ ] Graceful Shutdown
+- [ ] Error Boundaries
+- [ ] Runbook Coverage
+- [ ] Health & Readiness
+- [ ] On-Call Escalation

--- a/.agents/schemas/audit-rules.json
+++ b/.agents/schemas/audit-rules.json
@@ -25,7 +25,19 @@
           "password",
           "encrypt"
         ],
-        "filePatterns": ["**/*.lock", "**/auth/*.js", "**/crypto/*.js"]
+        "filePatterns": [
+          "**/*.lock",
+          "**/auth/**",
+          "**/authn/**",
+          "**/authz/**",
+          "**/middleware/**",
+          "**/crypto/**",
+          "**/session/**",
+          "**/*credential*",
+          "**/*permission*",
+          "**/*.pem",
+          "**/*.key"
+        ]
       },
       "scope": "local",
       "substitutionKeys": []
@@ -33,8 +45,27 @@
     "audit-privacy": {
       "triggers": {
         "gates": ["gate1", "gate3"],
-        "keywords": ["privacy", "pii", "gdpr", "cookie", "tracking"],
-        "filePatterns": ["**/user-profile/**/*.js"]
+        "keywords": [
+          "privacy",
+          "pii",
+          "gdpr",
+          "cookie",
+          "tracking",
+          "telemetry",
+          "analytics",
+          "logging",
+          "consent"
+        ],
+        "filePatterns": [
+          "**/user-profile/**",
+          "**/*logger*",
+          "**/*logging*",
+          "**/logging/**",
+          "**/*telemetry*",
+          "**/telemetry/**",
+          "**/*analytics*",
+          "**/analytics/**"
+        ]
       },
       "scope": "local",
       "substitutionKeys": []
@@ -80,8 +111,30 @@
       "substitutionKeys": []
     },
     "audit-sre": {
-      "triggers": { "gates": ["gate4"] },
-      "scope": "global",
+      "triggers": {
+        "gates": ["gate3"],
+        "keywords": [
+          "sre",
+          "slo",
+          "observability",
+          "runbook",
+          "rollback",
+          "error budget",
+          "on-call",
+          "incident",
+          "resilience"
+        ],
+        "filePatterns": [
+          "**/Dockerfile",
+          "**/Dockerfile.*",
+          "**/migrations/**",
+          "**/deploy/**",
+          "**/*deploy*.sh",
+          ".github/workflows/**",
+          "**/*health*"
+        ]
+      },
+      "scope": "cumulative",
       "substitutionKeys": []
     },
     "audit-documentation": {

--- a/.agents/workflows/audit-devops.md
+++ b/.agents/workflows/audit-devops.md
@@ -36,37 +36,112 @@ before this section existed.
   proceed with the full codebase-wide scan defined in the remaining
   steps.
 
-## Step 1: Context Gathering (Read-Only Scan)
+## Step 1: Detection Battery (Read-Only, Tool-First)
 
 > Apply [`helpers/parallel-tooling.md`](helpers/parallel-tooling.md) when batching the scan below — independent reads belong in one turn, long shells run via `run_in_background` + `Monitor`.
 
-Before generating the report, silently scan the workspace for relevant
-configuration files. Pay special attention to:
+Do **not** audit CI/CD from memory. Run the deterministic battery below first
+and let its output ground every finding. Each tool is **presence-gated**: when
+the binary is absent, record the gap as a Low-severity `Standardization`
+finding (recommend adopting the scanner) and continue — a missing scanner
+degrades the audit gracefully, it never aborts it.
 
-- CI/CD pipelines (e.g., `.github/workflows/`, `.gitlab-ci.yml`,
-  `azure-pipelines.yml`).
-- Dependency manifests and script definitions (e.g., `package.json`,
-  `pnpm-workspace.yaml`).
-- Linting, formatting, and static analysis configs (e.g., `.eslintrc*`,
-  `.prettierrc*`, `biome.json`, `tsconfig.json`).
-- Git hooks and commit standards (e.g., `.husky/`, `commitlint.config.js`).
+1. **Workflow static analysis (`actionlint`).** When `.github/workflows/`
+   contains any `*.yml` / `*.yaml`, run:
+
+   ```bash
+   command -v actionlint >/dev/null 2>&1 && actionlint -color=never || \
+     echo "actionlint: not installed — recommend adding it (Standardization gap)"
+   ```
+
+   Every diagnostic `actionlint` emits is a finding (shell-quoting bugs,
+   invalid `runs-on`, undefined `needs`, mis-scoped `${{ }}` expressions).
+
+2. **Workflow security posture (`zizmor`).** Over the same
+   `.github/workflows/` set, run:
+
+   ```bash
+   command -v zizmor >/dev/null 2>&1 && zizmor --no-progress .github/workflows/ || \
+     echo "zizmor: not installed — recommend adding it (Security & Compliance gap)"
+   ```
+
+   Treat each `zizmor` finding (unpinned action refs, `pull_request_target`
+   misuse, over-broad `GITHUB_TOKEN` permissions, template-injection sinks) as
+   a Security & Compliance finding at the severity `zizmor` assigns.
+
+3. **Container linting (`hadolint`), presence-gated on Dockerfiles.** Only when
+   the change set (or repo) contains a `Dockerfile*`:
+
+   ```bash
+   command -v hadolint >/dev/null 2>&1 && hadolint <Dockerfile paths> || \
+     echo "hadolint: not installed — recommend adding it (Security & Compliance gap)"
+   ```
+
+4. **Pipeline reliability history (`gh run list`).** Cite real durations and
+   failure rates rather than guessing which steps are slow or flaky:
+
+   ```bash
+   gh run list --limit 50 --json conclusion,durationMs,workflowName,createdAt 2>/dev/null || \
+     echo "gh run history unavailable — Performance/Reliability findings degrade to config-only reasoning"
+   ```
+
+   Compute the failure rate (`failure` + `cancelled` / total) and the p50/p95
+   duration per workflow; a workflow whose recent failure rate is non-trivial
+   or whose p95 duration is an outlier is a Reliability or Performance finding
+   with the observed number cited in **Current State**.
+
+Then read the surfaces the battery flags plus the standing config set:
+CI/CD pipelines (`.github/workflows/`, `.gitlab-ci.yml`, `azure-pipelines.yml`),
+dependency/script manifests (`package.json`, `pnpm-workspace.yaml`), lint/format
+configs (`.eslintrc*`, `.prettierrc*`, `biome.json`, `tsconfig.json`), and git
+hooks / commit standards (`.husky/`, `commitlint.config.js`).
 
 ## Step 2: Analysis Dimensions
 
-Evaluate the gathered context against the following dimensions:
+Evaluate the battery output and gathered context against the following
+dimensions. The three **presence-gated sub-steps** (Dockerfile, IaC, Release
+pipeline) run only when their surface is present in the change set or repo —
+when absent, state "not present in scope" and skip.
 
 1. **Redundancy & Duplication:** Overlapping tools or conflicting rules (e.g.,
    Prettier vs. ESLint formatting, duplicated scripts in `package.json` and CI).
 2. **Performance Gaps:** Bottlenecks in CI/CD, slow caching strategies, or
-   unoptimized hooks (e.g., missing `lint-staged`).
+   unoptimized hooks (e.g., missing `lint-staged`) — cite the `gh run list`
+   durations from Step 1.
 3. **Security & Compliance:** Missing secret scanning, loose permissions (e.g.,
    `GITHUB_TOKEN` scopes), outdated or vulnerable dependency resolution
-   strategies.
+   strategies — grounded in the `zizmor` output.
 4. **Standardization & Modernization:** Opportunities to consolidate tooling
    (e.g., migrating to unified tools like Biome) or extract inline
-   configurations into dedicated dotfiles.
+   configurations into dedicated dotfiles; include any absent-scanner gaps
+   surfaced in Step 1.
 5. **Reliability & Resilience:** Fragile pipeline steps, missing error handling,
-   silent failures, or lack of retries for network-dependent tasks.
+   silent failures, or lack of retries for network-dependent tasks — cite the
+   `gh run list` failure rates from Step 1.
+
+### Sub-step A — Dockerfile hardening (gated: `Dockerfile*` present)
+
+Audit each Dockerfile for the standard hardening set: a pinned, digest-or-tag
+base image (never `:latest`), a non-root `USER`, multi-stage builds that keep
+build tooling out of the runtime image, no secrets baked into layers
+(`ARG`/`ENV` for credentials), a `HEALTHCHECK`, and `.dockerignore` coverage.
+Ground every finding in the `hadolint` output from Step 1.
+
+### Sub-step B — Infrastructure-as-Code (gated: `*.tf` / `infra/**` / k8s manifests present)
+
+Audit IaC for hardcoded secrets and account IDs, over-permissive IAM / security
+groups (`0.0.0.0/0` ingress, wildcard actions), unpinned module/provider
+versions, missing remote state locking, and resources provisioned without
+encryption-at-rest. Recommend `tflint` / `checkov` / `tfsec` where the scanner
+is absent.
+
+### Sub-step C — Release & deployment pipeline (gated: release/deploy workflow present)
+
+Audit the release path for an unpinned or mutable deployment action, missing
+environment protection rules / required reviewers on the production
+environment, absent rollback or canary strategy, and publish steps that run
+without provenance / SLSA attestation. Cite the `gh run list` history for the
+release workflow's reliability.
 
 ## Step 3: Output Requirements
 

--- a/.agents/workflows/audit-privacy.md
+++ b/.agents/workflows/audit-privacy.md
@@ -36,19 +36,41 @@ before this section existed.
   proceed with the full codebase-wide scan defined in the remaining
   steps.
 
-## Step 1: Scanning for PII Patterns
+## Step 1: Sink-First Detection
 
 > Apply [`helpers/parallel-tooling.md`](helpers/parallel-tooling.md) when batching the scan below — independent reads belong in one turn, long shells run via `run_in_background` + `Monitor`.
 
-Scan the codebase for patterns related to sensitive data. Pay attention to:
+A PII leak is a **source → sink** flow: sensitive data reaching an egress point.
+Enumerate the **sinks** first, then trace which ones receive PII. Report only
+**proven flows** — a sink that never touches a PII source is not a finding.
 
-- **Log Statements:** Search for `console.log`, `logger.info`, etc., that might
-  be outputting `user`, `email`, `password`, `token`, `address`, or `phone`.
-- **Storage:** Check `localStorage`, `sessionStorage`, and database schemas for
-  unencrypted sensitive fields.
-- **API Requests:** Review outgoing requests to ensure PII is not leaked in URLs
-  (query params) or unencrypted headers.
-- **Analytics:** Ensure third-party analytics calls are anonymized.
+1. **Enumerate the sinks.** Run these verbatim `rg` commands (they anchor every
+   finding to a real line):
+
+   ```bash
+   # Logging sinks
+   rg -n "\b(console\.(log|info|warn|error|debug)|logger\.(info|warn|error|debug|log))\s*\(" --glob '!**/*.test.*'
+   # Telemetry / analytics sinks
+   rg -n "\b(track|capture|analytics|telemetry|reportEvent|Sentry\.(captureException|captureMessage))\s*\(" --glob '!**/*.test.*'
+   # Persistence sinks
+   rg -n "\b(localStorage|sessionStorage|\.set\(|db\.(insert|update|save)|prisma\.\w+\.(create|update|upsert))\b" --glob '!**/*.test.*'
+   # Outbound-HTTP sinks (PII in URLs / bodies / headers)
+   rg -n "\b(fetch|axios|http\.request|got|ky)\s*\(" --glob '!**/*.test.*'
+   ```
+
+2. **Secret scan.** Prefer `gitleaks`; fall back to `rg`:
+
+   ```bash
+   command -v gitleaks >/dev/null 2>&1 && gitleaks detect --no-banner --redact -v || \
+     rg -n -i "(api[_-]?key|secret|password|token|salt)\s*[:=]\s*['\"][^'\"]{8,}" --glob '!**/*.test.*'
+   ```
+
+3. **Trace PII sources to the enumerated sinks.** PII source tokens to follow:
+   `email`, `password`, `token`, `phone`, `address`, `ssn`, `dob`, `ip`,
+   `fullName`, `firstName`/`lastName`, `creditCard`, `user` object spreads. For
+   each sink from step 1, decide whether a PII source reaches it (directly, or
+   via a variable/object logged whole). Only a **proven** source→sink flow
+   becomes a finding; cite both the source line and the sink line.
 
 ## Step 2: Analysis Dimensions
 

--- a/.agents/workflows/audit-security.md
+++ b/.agents/workflows/audit-security.md
@@ -45,32 +45,82 @@ it. See [`helpers/audit-dual-path.md`](helpers/audit-dual-path.md) for strategy
 selection, the forcing flags, and the read-only guarantee — read `audit-<lens>`
 there as this lens's name.
 
-## Step 1: Vulnerability Surface Analysis
+## Rubric — `rules/security-baseline.md` is the contract
+
+This lens does **not** grade against recalled OWASP lore. The authoritative
+rubric is [`../rules/security-baseline.md`](../rules/security-baseline.md) — the
+project's inviolable security MUSTs (Input Validation, Authentication,
+Authorization, Output & Rendering, Data Leakage & Logging, Transport & Headers,
+Secrets Management, Dependency Hygiene). Read it first. **Every finding MUST
+name the specific `security-baseline.md` MUST it violates** (e.g. "violates
+_Secrets Management_: 'Fallback or placeholder secrets MUST NOT be committed'").
+A finding that cannot be tied to a baseline MUST — or to a CWE where the
+baseline is silent — is out of scope for this lens.
+
+## Step 1: Detection Battery (Tool-First, Read-Only)
 
 > Apply [`helpers/parallel-tooling.md`](helpers/parallel-tooling.md) when batching the scan below — independent reads belong in one turn, long shells run via `run_in_background` + `Monitor`.
 
-Scan the codebase for:
+Ground every finding in tool output, not vibes. Run the ladder below; each rung
+is **presence-gated** — when a scanner is absent, fall through to the next rung
+and note the missing tool as a `Security Misconfiguration` finding (recommend
+adopting it).
 
-- **Input Validation:** Check where user input enters the system (API endpoints,
-  forms). Is it sanitized/validated?
-- **Injection Risks:** Search for raw SQL queries, `dangerouslySetInnerHTML`,
-  `eval()`, or command execution logic.
-- **Authentication/Authorization:** Review how sessions/tokens are handled. Are
-  there missing checks on sensitive routes?
-- **Dependency Security:** Check `package.json` for known-vulnerable versions of
-  libraries.
-- **Secret Management:** Scan for `.env` files in git, hardcoded keys, or
-  exposed credentials.
+1. **Dependency CVEs (`npm audit`).** Never recall CVEs from memory:
+
+   ```bash
+   npm audit --omit=dev --json 2>/dev/null || echo "npm audit unavailable"
+   ```
+
+   Each advisory reachable in production (`--omit=dev`) at `high` or `critical`
+   is a _Vulnerable Components_ finding citing the advisory id and the violated
+   _Dependency Hygiene_ MUST.
+
+2. **Secret scanning (`gitleaks` / `trufflehog`), with a grep fallback.** When
+   `gitleaks` is installed, prefer it:
+
+   ```bash
+   command -v gitleaks >/dev/null 2>&1 && gitleaks detect --no-banner --redact -v || \
+     command -v trufflehog >/dev/null 2>&1 && trufflehog filesystem . --no-update || \
+     echo "no secret scanner installed — running the grep battery below"
+   ```
+
+3. **Grep battery (deterministic fallback / augmentation).** Run these
+   regardless — they are cheap and catch what a scanner's ruleset may miss:
+
+   ```bash
+   # Hardcoded key material (violates Secrets Management)
+   rg -n -i "(api[_-]?key|secret|password|token)\s*[:=]\s*['\"][^'\"]{8,}" --glob '!**/*.test.*'
+   # eval / exec sinks (violates Output & Rendering)
+   rg -n "\b(eval|new Function|child_process\.exec|execSync)\s*\(" --glob '!**/*.test.*'
+   # Template-literal SQL (violates Output & Rendering — parameterize)
+   rg -n "(SELECT|INSERT|UPDATE|DELETE)\b[^;]*\$\{" -i
+   # Committed .env with real values (violates Secrets Management)
+   git ls-files | rg "(^|/)\.env($|\.)" | rg -v "\.env\.example$"
+   ```
+
+4. **Manual surface review.** Then read the surfaces the battery flags plus:
+   input-validation edges (API endpoints, form handlers — is input validated at
+   the boundary with a strict schema?), auth/session handling (token storage,
+   missing ownership checks on sensitive routes), and injection sinks
+   (`dangerouslySetInnerHTML`, raw SQL, command execution).
 
 ## Step 2: Evaluation Dimensions
 
-1. **Injection:** SQL, NoSQL, OS Command, and Cross-Site Scripting (XSS).
-2. **Broken Access Control:** Can a user access data they don't own?
+Grade each finding against the `security-baseline.md` MUST it breaks (and the
+CWE where one applies):
+
+1. **Injection:** SQL, NoSQL, OS Command, and Cross-Site Scripting (XSS) —
+   _Output & Rendering_.
+2. **Broken Access Control:** Can a user access data they don't own? —
+   _Authorization_.
 3. **Cryptographic Failures:** Is sensitive data (passwords, PII) hashed or
-   encrypted using modern standards?
+   encrypted using modern standards? — _Authentication_ / _Data Leakage &
+   Logging_.
 4. **Security Misconfiguration:** Are there default passwords, verbose error
-   messages in production, or insecure headers?
-5. **Vulnerable Components:** Are outdated libraries introducing risks?
+   messages in production, or insecure headers? — _Transport & Headers_.
+5. **Vulnerable Components:** Are outdated libraries introducing risks? —
+   _Dependency Hygiene_.
 
 ## Step 3: Output Requirements
 
@@ -98,6 +148,7 @@ each title with the primary file the vulnerability lives in:]
 - **Dimension:** [e.g., Injection | Broken Access Control]
 - **Severity:** [Critical | High | Medium | Low]
 - **CWE ID:** [e.g., CWE-89 for SQL Injection]
+- **Baseline MUST:** [the violated `security-baseline.md` MUST — e.g. "Secrets Management: fallback secrets MUST NOT be committed"]
 - **Location:** `path/to/primary-file.ext:line`
 - **Current State:** [Technical explanation of the flaw and its location]
 - **Recommendation & Rationale:** [Step-by-step fix and defensive hardening

--- a/.agents/workflows/audit-sre.md
+++ b/.agents/workflows/audit-sre.md
@@ -10,9 +10,10 @@ Senior Site Reliability Engineer (SRE) & Lead Developer
 
 ## Context & Objective
 
-You are conducting a rigorous, read-only final code audit for a production
-release candidate. Your goal is to surface critical risks across configuration
-integrity, security, observability, and code quality — providing a prioritized,
+You are conducting a rigorous, read-only operational-readiness audit for a
+production release candidate. Your goal is to surface critical risks across
+rollback & recovery paths, observability & instrumentation, resilience &
+failure handling, and runbooks & operational docs — providing a prioritized,
 actionable report that can be handed off for remediation before deployment.
 
 ## Scope (Story / plan-run mode)
@@ -36,63 +37,80 @@ before this section existed.
   proceed with the full codebase-wide scan defined in the remaining
   steps.
 
-## Step 1: Context Gathering (Read-Only Scan)
+## Step 1: Resilience Detection Battery (Read-Only, Tool-First)
 
 > Apply [`helpers/parallel-tooling.md`](helpers/parallel-tooling.md) when batching the scan below — independent reads belong in one turn, long shells run via `run_in_background` + `Monitor`.
 
-Before generating the report, silently scan the workspace. Pay special attention
-to:
+This lens audits **operational readiness** — can this release be observed,
+survive failure, and be rolled back? It deliberately does **not** re-audit
+secrets, injection, dead code, or complexity; those are owned by
+[`audit-security`](audit-security.md) and [`audit-clean-code`](audit-clean-code.md).
+Ground findings in the greps below, then read the operational surfaces they
+flag.
 
-- Application configuration files (e.g., `site.config.ts`, `.env.example`,
-  `wrangler.toml`, `app.config.ts`).
-- Source files for hardcoded values (strings resembling secrets, IDs, or
-  environment-specific data).
-- Error handling patterns across services, API routes, and background jobs.
-- `package.json` for unused, deprecated, or overly heavy dependencies.
-- Any debugging artifacts likely introduced during development.
+1. **Run the resilience battery.** Each grep maps to a Step 2 dimension:
+
+   ```bash
+   # Network calls without a timeout (a hung upstream stalls the whole request)
+   rg -n "\b(fetch|axios(\.\w+)?|http\.request|got|ky)\s*\(" --glob '!**/*.test.*' | \
+     rg -v -i "timeout|signal|AbortController"
+   # Graceful-shutdown handlers (their ABSENCE is the finding for long-lived processes)
+   rg -n "process\.on\(\s*['\"]SIG(TERM|INT)['\"]" || echo "no SIGTERM/SIGINT handler found"
+   # Error-swallowing empty catch blocks (silent failure — no signal to observe)
+   rg -n "catch\s*(\([^)]*\))?\s*\{\s*\}"
+   # Retry / backoff on network-dependent work (resilience to transient failure)
+   rg -n -i "retr(y|ies)|backoff|circuit.?breaker|p-retry"
+   # Health / readiness endpoints (needed for orchestrated rollout & rollback)
+   rg -n -i "/(health|healthz|readyz|livez|ping)\b|healthCheck"
+   ```
 
 ## Step 2: Analysis Dimensions
 
-Evaluate the gathered context against the following production-readiness
-criteria:
+Evaluate the release candidate against these **production-readiness** criteria.
 
-### 1. Configuration Architecture
+### 1. Rollback & Recovery Paths
 
-- **Config Integrity:** Audit the application config to ensure it defines a
-  clear schema for all variable/environment-specific data.
-- **Hardcoding Scan:** Scan components, utils, and services for any hardcoded
-  values that should come from config or environment variables (e.g., API URLs,
-  feature flags, region/locale data, identifiers).
-- **Fallback Logic:** Verify how the app behaves if a required config value is
-  missing — does it fail gracefully or crash silently?
+- **Rollback Path:** Is there a defined, tested way to revert this release —
+  a versioned deploy, blue-green/canary, or a documented `git revert` + redeploy
+  path? A release with no rollback path is a Critical finding.
+- **Migration Reversibility:** Any schema migration in scope must ship a
+  down-migration (or a documented forward-fix); an irreversible destructive
+  migration blocks the release.
+- **Feature-Flag Kill Switch:** Risky new behaviour should sit behind a flag
+  that can be disabled without a redeploy.
 
-### 2. Security & Secrets Management
+### 2. Observability & Instrumentation
 
-- **Secret Leaks:** Check for hardcoded API keys, tokens, or credentials
-  committed to source. Ensure all secrets use environment variables.
-- **Input Sanitization:** Identify potential XSS or injection vectors,
-  particularly where user input or URL parameters are reflected in the DOM or
-  database.
-- **Dependency Risks:** Flag obviously deprecated, unmaintained, or unused heavy
-  dependencies in `package.json`.
+- **Structured Logging:** Are operational events emitted through a structured
+  logger (levels, correlation ids) rather than bare `console.*`, so they are
+  queryable in production?
+- **Metrics & Tracing:** Are latency/error/throughput metrics and trace spans
+  emitted for the new code path? Missing instrumentation on a critical path is
+  a High finding.
+- **Alerting & SLOs:** Is there an SLO (or error budget) and an alert wired to
+  the signals above, so a regression pages someone?
 
-### 3. Error Handling & Observability
+### 3. Resilience & Failure Handling
 
-- **Console Hygiene:** Identify debugging artifacts (`console.log`, `debugger`,
-  commented-out test code) that must be removed before release.
-- **Error Swallowing:** Flag empty `catch` blocks or places where errors are
-  silently ignored rather than logged or re-thrown.
-- **Boundary Handling:** Ensure the app handles unexpected or invalid inputs
-  (e.g., bad URL params, missing DB records) with appropriate error responses.
+- **Timeouts & Cancellation:** Every outbound call needs a timeout /
+  `AbortSignal` (grep 1 in Step 1). A call without one is a Reliability finding.
+- **Retry & Backoff:** Transient-failure-prone calls should retry with backoff;
+  flag network work that fails hard on the first error.
+- **Graceful Shutdown:** Long-lived processes must handle `SIGTERM`/`SIGINT`
+  and drain in-flight work (grep 2). Its absence risks dropped requests on
+  every deploy.
+- **Error Boundaries:** Empty `catch` blocks (grep 3) swallow failures with no
+  signal — flag each as an Observability + Resilience finding.
 
-### 4. Code Quality & Performance
+### 4. Runbooks & Operational Docs
 
-- **Dead Code:** Identify unused variables, imports, functions, or unreachable
-  code blocks.
-- **Complexity:** Highlight logic with high cyclomatic complexity (deeply nested
-  `if/else`, massive switch statements) that violates DRY principles.
-- **Asset Loading:** Flag synchronous heavy operations or unoptimized asset
-  loading patterns that could hurt Core Web Vitals or API response times.
+- **Runbook Coverage:** Does an operational runbook exist for this
+  service/feature (how to deploy, roll back, and respond to the top failure
+  modes)? A new production surface with no runbook is a finding.
+- **Health & Readiness:** Are health/readiness endpoints (grep 5) present and
+  wired into the orchestrator so a bad rollout is caught before it takes
+  traffic?
+- **On-Call Escalation:** Is ownership / escalation for this surface documented?
 
 ## Step 3: Output Requirements
 
@@ -117,7 +135,7 @@ Lead each title with the primary file the finding lives in:]
 
 ### `path/to/primary-file.ext` — [Short title of the issue]
 
-- **Category:** [Configuration | Security | Observability | Code Quality]
+- **Category:** [Rollback & Recovery | Observability | Resilience | Runbooks]
 - **Severity:** [Critical | High | Medium | Low]
 - **Location:** `path/to/primary-file.ext:line`
 - **Current State:** [What exists and why it's a risk]
@@ -128,12 +146,12 @@ Lead each title with the primary file the finding lives in:]
 
 ## Release Readiness Checklist
 
-| Category                | Status                     |
-| ----------------------- | -------------------------- |
-| Configuration Integrity | ✅ Clear / ⚠️ Issues Found |
-| Security & Secrets      | ✅ Clear / ⚠️ Issues Found |
-| Error Handling          | ✅ Clear / ⚠️ Issues Found |
-| Code Quality            | ✅ Clear / ⚠️ Issues Found |
+| Category             | Status                     |
+| -------------------- | -------------------------- |
+| Rollback & Recovery  | ✅ Clear / ⚠️ Issues Found |
+| Observability        | ✅ Clear / ⚠️ Issues Found |
+| Resilience           | ✅ Clear / ⚠️ Issues Found |
+| Runbooks             | ✅ Clear / ⚠️ Issues Found |
 ```
 
 ---

--- a/tests/audit-suite/checklist-threading.test.js
+++ b/tests/audit-suite/checklist-threading.test.js
@@ -131,8 +131,8 @@ test('buildChecklistPayload: a cumulative-only footprint threads only the univer
 });
 
 test('buildChecklistPayload: a global-only footprint threads only the universal clean-code lens', () => {
-  // `audit-navigability` / `audit-sre` (global) are never threaded at
-  // write-time. A route-ish path matches no other local lens's filePattern,
+  // `audit-navigability` (global) / `audit-sre` (cumulative) are never threaded
+  // at write-time. A route-ish path matches no other local lens's filePattern,
   // so only the universal `audit-clean-code` is threaded.
   const result = buildChecklistPayload({
     footprint: ['app/routes/registry.config'],

--- a/tests/audit-suite/resolve-lens-tier.test.js
+++ b/tests/audit-suite/resolve-lens-tier.test.js
@@ -6,8 +6,9 @@
  *   - `resolveLensTier` (imported from the audit-suite SDK barrel) returns one
  *     of `local | cumulative | global` for every lens registered in
  *     `audit-rules.json`, and throws on an unknown lens.
- *   - `audit-rules.json` declares a scope on all 14 lenses (including the
- *     gate4-only `audit-sre`) and no longer carries `alwaysRun`.
+ *   - `audit-rules.json` declares a scope on all 14 lenses (including
+ *     `audit-sre`, re-homed from the dead gate4-only state to gate3 with ops
+ *     filePatterns by Story #4629) and no longer carries `alwaysRun`.
  *   - `audit-rules.schema.json` requires the `scope` enum and no longer
  *     permits `alwaysRun` (a fixture rule carrying it fails validation).
  */
@@ -55,8 +56,8 @@ const EXPECTED_TIERS = {
   'audit-dependencies': 'cumulative',
   'audit-devops': 'cumulative',
   'audit-documentation': 'cumulative',
+  'audit-sre': 'cumulative',
   'audit-navigability': 'global',
-  'audit-sre': 'global',
 };
 
 test('LENS_TIERS is the frozen local|cumulative|global tuple', () => {
@@ -79,10 +80,24 @@ test('audit-rules.json registers all 14 lenses, each with a scope in the enum', 
   }
 });
 
-test('the gate4-only audit-sre lens carries a scope', () => {
+test('audit-sre is re-homed from the dead gate4 state to gate3 with ops filePatterns (Story #4629)', () => {
+  const sre = rules.audits['audit-sre'];
+  assert.ok(LENS_TIERS.includes(sre?.scope), 'audit-sre must declare a scope');
+  const gates = sre?.triggers?.gates ?? [];
   assert.ok(
-    LENS_TIERS.includes(rules.audits['audit-sre']?.scope),
-    'audit-sre must declare a scope even though it is not wired into the delivery gates',
+    gates.includes('gate3'),
+    `audit-sre must route at gate3 so a production caller reaches it; got ${JSON.stringify(gates)}`,
+  );
+  assert.ok(
+    !gates.includes('gate4'),
+    'audit-sre must no longer be pinned to the dead gate4-only state',
+  );
+  const patterns = sre?.triggers?.filePatterns ?? [];
+  assert.ok(
+    patterns.includes('.github/workflows/**') &&
+      patterns.some((p) => p.includes('Dockerfile')) &&
+      patterns.includes('**/migrations/**'),
+    `audit-sre must carry ops filePatterns (workflows, Dockerfile, migrations); got ${JSON.stringify(patterns)}`,
   );
 });
 

--- a/tests/audit-suite/selector-ops-security-routing.test.js
+++ b/tests/audit-suite/selector-ops-security-routing.test.js
@@ -1,0 +1,119 @@
+/**
+ * tests/audit-suite/selector-ops-security-routing.test.js — Story #4629.
+ *
+ * Pins the routing broadenings for the ops/security lenses so a silent
+ * narrowing is a test failure, not a quiet coverage gap. All cases drive the
+ * REAL `audit-rules.json` through `selectAudits` on the injected-`changedFiles`
+ * path (no git spawn), with a deliberately keyword-free provider body so a hit
+ * proves *file-pattern* routing — not accidental prose keyword matching.
+ *
+ *   - AC-3: `audit-security` routes on TypeScript consumers — nested `.ts`/`.tsx`
+ *     under auth / middleware directories (it previously matched only a narrow
+ *     JS-only auth/crypto glob set).
+ *   - AC-4: `audit-privacy` routes on a logging / telemetry file (its close-lens
+ *     routing was effectively dead — it matched only a `user-profile` dir).
+ *   - AC-6: `audit-sre` participates in automated runs — it routes at gate3 with
+ *     ops filePatterns (workflows, Dockerfiles, migrations) and is NOT reachable
+ *     from the dead gate4-only state.
+ */
+
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { selectAudits } from '../../.agents/scripts/lib/audit-suite/selector.js';
+import { MockProvider } from '../fixtures/mock-provider.js';
+
+/** A keyword-free ticket so routing is proven by filePatterns alone. */
+function makeProvider() {
+  return new MockProvider({
+    tickets: {
+      900: {
+        id: 900,
+        title: 'Refactor the widget module',
+        body: 'Neutral body prose with no audit-rules.json trigger terms.',
+        labels: [],
+      },
+    },
+  });
+}
+
+/**
+ * Run `selectAudits` over an injected change set with the web-surface probe
+ * pinned off (deterministic; no filesystem scan) and no git spawn.
+ *
+ * @param {string} gate
+ * @param {string[]} changedFiles
+ * @returns {Promise<string[]>} the selected audit lens ids.
+ */
+async function select(gate, changedFiles) {
+  const result = await selectAudits({
+    ticketId: 900,
+    gate,
+    provider: makeProvider(),
+    changedFiles,
+    hasWebSurfaceFn: () => false,
+    injectedGitSpawn: async () => {
+      throw new Error('git must not be spawned on the injected path');
+    },
+  });
+  return result.selectedAudits;
+}
+
+test('AC-3: audit-security routes on nested TypeScript auth/middleware files', async () => {
+  const selected = await select('gate1', [
+    'src/auth/login.ts',
+    'src/api/middleware/guard.tsx',
+  ]);
+  assert.ok(
+    selected.includes('audit-security'),
+    `a TS auth/middleware diff must route audit-security; got ${JSON.stringify(selected)}`,
+  );
+});
+
+test('AC-3: audit-security still ignores an unrelated non-sensitive TS file', async () => {
+  const selected = await select('gate1', ['docs/notes.md']);
+  assert.ok(
+    !selected.includes('audit-security'),
+    `a docs-only diff must not route audit-security; got ${JSON.stringify(selected)}`,
+  );
+});
+
+test('AC-4: audit-privacy routes on a logging sink file', async () => {
+  const selected = await select('gate1', ['src/lib/logger.ts']);
+  assert.ok(
+    selected.includes('audit-privacy'),
+    `a logging-file diff must route audit-privacy; got ${JSON.stringify(selected)}`,
+  );
+});
+
+test('AC-4: audit-privacy routes on a telemetry directory file', async () => {
+  const selected = await select('gate1', ['src/telemetry/emit.ts']);
+  assert.ok(
+    selected.includes('audit-privacy'),
+    `a telemetry-file diff must route audit-privacy; got ${JSON.stringify(selected)}`,
+  );
+});
+
+test('AC-6: audit-sre routes at gate3 on a CI workflow change', async () => {
+  const selected = await select('gate3', ['.github/workflows/ci.yml']);
+  assert.ok(
+    selected.includes('audit-sre'),
+    `a workflow diff at gate3 must route audit-sre; got ${JSON.stringify(selected)}`,
+  );
+});
+
+test('AC-6: audit-sre routes at gate3 on a migration change', async () => {
+  const selected = await select('gate3', ['db/migrations/001_init.sql']);
+  assert.ok(
+    selected.includes('audit-sre'),
+    `a migration diff at gate3 must route audit-sre; got ${JSON.stringify(selected)}`,
+  );
+});
+
+test('AC-6: audit-sre is not reachable at gate1 (re-homed off the dead gate4 state, gate3-only)', async () => {
+  const selected = await select('gate1', ['.github/workflows/ci.yml']);
+  assert.ok(
+    !selected.includes('audit-sre'),
+    `audit-sre must route only at gate3, not gate1; got ${JSON.stringify(selected)}`,
+  );
+});


### PR DESCRIPTION
Closes #4629

_Auto-opened by `/deliver`._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to agent workflow docs, audit routing config, and tests; no production runtime or auth code paths are modified.
> 
> **Overview**
> **Replaces ad-hoc scanning with deterministic, presence-gated tool batteries** for the DevOps, security, and privacy audit workflows, and **narrows the SRE lens to operational readiness** while fixing when it runs in the selector.
> 
> The **DevOps** workflow now mandates `actionlint`, `zizmor`, `hadolint`, and `gh run list` before analysis, with gated Dockerfile/IaC/release sub-steps. **Security** findings must cite `security-baseline.md` MUSTs and run `npm audit`, secret scanners, and a fixed `rg` battery. **Privacy** uses sink-first `rg` enumeration and only reports proven PII source→sink flows.
> 
> **`audit-sre`** drops config/secrets/code-quality overlap (delegated to other lenses), adds a resilience grep battery, and retargets categories to rollback, observability, resilience, and runbooks. In **`audit-rules.json`**, **`audit-sre`** moves from dead **gate4** / **global** to **gate3** / **cumulative** with ops file patterns; **security** and **privacy** triggers broaden to TS auth/middleware and logging/telemetry paths.
> 
> Generated checklists mirror the workflows. New **`selector-ops-security-routing`** tests plus updates to **`resolve-lens-tier`** and checklist-threading comments lock in the routing changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d82a94b361006aed7411d4e2988c1c126a31518f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->