### PR TITLE
feat: tool-first detection for the web lenses: seo, ux-ui, and a deterministic navigability diff (#4630)

### DIFF
--- a/.agents/audit-checklists/navigability.md
+++ b/.agents/audit-checklists/navigability.md
@@ -12,3 +12,6 @@ Self-check your change against this lens's concerns before you ship:
 
 - [ ] Every route has a persona nav door.
 - [ ] No nav href is dead.
+- [ ] Dynamic-segment children of a surfaced parent
+- [ ] System routes
+- [ ] Inbound in-app references

--- a/.agents/audit-checklists/seo.md
+++ b/.agents/audit-checklists/seo.md
@@ -10,7 +10,13 @@
 
 Self-check your change against this lens's concerns before you ship:
 
+- [ ] Auth-walled / private surface
+- [ ] Publicly indexable surface
+- [ ] Mixed
+- [ ] Step 1a — Identify the meta mechanism.
+- [ ] Step 1b — Enumerate the routes.
+- [ ] Step 1c — Per-route metadata probe.
 - [ ] Traditional SEO
 - [ ] AIO & GEO (Answer Engine Optimization)
-- [ ] Core Web Vitals
+- [ ] Statically-provable Core Web Vitals defects only
 - [ ] Crawlability

--- a/.agents/audit-checklists/ux-ui.md
+++ b/.agents/audit-checklists/ux-ui.md
@@ -10,8 +10,12 @@
 
 Self-check your change against this lens's concerns before you ship:
 
+- [ ] Design tokens / theme
+- [ ] Component library
+- [ ] Documented conventions
 - [ ] Hardcoded Values
 - [ ] Component Re-implementation
+- [ ] Inline-style census
 - [ ] Interactive States
 - [ ] Typography
 - [ ] Information Hierarchy

--- a/.agents/schemas/audit-rules.json
+++ b/.agents/schemas/audit-rules.json
@@ -149,7 +149,15 @@
       "triggers": {
         "gates": ["gate2", "gate3"],
         "keywords": ["seo", "meta", "structured data", "schema.org", "sitemap"],
-        "filePatterns": ["**/*.html", "**/sitemap*", "**/robots.txt"]
+        "filePatterns": [
+          "**/*.html",
+          "**/*.astro",
+          "**/sitemap*",
+          "**/robots*",
+          "**/app/**/{page,layout,route,head,default,template,loading,error,not-found,opengraph-image,twitter-image}.{js,jsx,ts,tsx}",
+          "**/pages/**/*.{js,jsx,ts,tsx,vue}",
+          "**/routes/**/*.{jsx,tsx,vue,svelte}"
+        ]
       },
       "target": "web",
       "scope": "local",
@@ -162,7 +170,12 @@
         "filePatterns": [
           "**/components/**/*.{tsx,jsx,vue,svelte}",
           "**/styles/**",
-          "**/*.css"
+          "**/*.css",
+          "**/*.{scss,sass,less}",
+          "**/tailwind.config.{js,ts,cjs,mjs}",
+          "**/theme/**",
+          "**/tokens/**",
+          "**/design-system/**"
         ]
       },
       "target": "web",

--- a/.agents/scripts/__tests__/nav-registry-diff.test.js
+++ b/.agents/scripts/__tests__/nav-registry-diff.test.js
@@ -1,0 +1,415 @@
+/**
+ * .agents/scripts/__tests__/nav-registry-diff.test.js — unit + CLI contract for
+ * the deterministic route ↔ nav-registry cross-check (Story #4630, AC-4/AC-5).
+ *
+ * The script is the mechanical half of the navigability lens: it turns the
+ * route-tree ↔ nav-registry set-difference into a runnable diff and applies the
+ * orphan-verification exemption taxonomy (dynamic children, system routes,
+ * inbound references) so the lens reports only genuine orphans.
+ */
+
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { describe, it } from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+import {
+  computeNavDiff,
+  formatDiffText,
+  isDynamicPath,
+  isDynamicSegment,
+  isSystemRoute,
+  normalizePath,
+  parentPath,
+  routeTemplateMatchesHref,
+} from '../nav-registry-diff.js';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const SCRIPT = path.resolve(HERE, '..', 'nav-registry-diff.js');
+
+describe('normalizePath', () => {
+  it('forces a single leading slash and drops a trailing slash', () => {
+    assert.equal(normalizePath('users/'), '/users');
+    assert.equal(normalizePath('/users'), '/users');
+    assert.equal(normalizePath('users/list/'), '/users/list');
+  });
+
+  it('collapses duplicate slashes and preserves root', () => {
+    assert.equal(normalizePath('//users//list'), '/users/list');
+    assert.equal(normalizePath('/'), '/');
+  });
+
+  it('returns empty string for nullish or blank input', () => {
+    assert.equal(normalizePath(''), '');
+    assert.equal(normalizePath('   '), '');
+    assert.equal(normalizePath(null), '');
+    assert.equal(normalizePath(undefined), '');
+    assert.equal(normalizePath(42), '');
+  });
+});
+
+describe('dynamic + system segment classification', () => {
+  it('recognizes dynamic segment syntaxes', () => {
+    assert.equal(isDynamicSegment(':id'), true);
+    assert.equal(isDynamicSegment('[id]'), true);
+    assert.equal(isDynamicSegment('[...slug]'), true);
+    assert.equal(isDynamicSegment('{id}'), true);
+    assert.equal(isDynamicSegment('*'), true);
+    assert.equal(isDynamicSegment('users'), false);
+  });
+
+  it('flags a path with any dynamic segment', () => {
+    assert.equal(isDynamicPath('/users/:id'), true);
+    assert.equal(isDynamicPath('/blog/[slug]/edit'), true);
+    assert.equal(isDynamicPath('/users/list'), false);
+  });
+
+  it('flags system routes by their last segment', () => {
+    assert.equal(isSystemRoute('/login'), true);
+    assert.equal(isSystemRoute('/auth/callback'), true);
+    assert.equal(isSystemRoute('/404'), true);
+    assert.equal(isSystemRoute('/unauthorized'), true);
+    assert.equal(isSystemRoute('/dashboard'), false);
+    assert.equal(isSystemRoute('/'), false);
+  });
+});
+
+describe('parentPath', () => {
+  it('strips the last segment, bottoming out at root', () => {
+    assert.equal(parentPath('/users/:id'), '/users');
+    assert.equal(parentPath('/users'), '/');
+    assert.equal(parentPath('/'), '/');
+    assert.equal(parentPath('/a/b/c'), '/a/b');
+  });
+});
+
+describe('routeTemplateMatchesHref', () => {
+  it('matches an identical static path', () => {
+    assert.equal(routeTemplateMatchesHref('/users', '/users'), true);
+    assert.equal(routeTemplateMatchesHref('/users', '/teams'), false);
+  });
+
+  it('matches a dynamic segment against any concrete segment', () => {
+    assert.equal(routeTemplateMatchesHref('/users/:id', '/users/42'), true);
+    assert.equal(routeTemplateMatchesHref('/blog/[slug]', '/blog/hello'), true);
+  });
+
+  it('rejects a length mismatch on a non-catch-all template', () => {
+    assert.equal(routeTemplateMatchesHref('/users/:id', '/users'), false);
+    assert.equal(
+      routeTemplateMatchesHref('/users/:id', '/users/42/edit'),
+      false,
+    );
+  });
+
+  it('lets a catch-all consume one or more trailing segments', () => {
+    assert.equal(routeTemplateMatchesHref('/docs/[...path]', '/docs/a'), true);
+    assert.equal(
+      routeTemplateMatchesHref('/docs/[...path]', '/docs/a/b/c'),
+      true,
+    );
+    assert.equal(routeTemplateMatchesHref('/docs/*', '/docs/a/b'), true);
+    // A catch-all still needs at least one trailing segment.
+    assert.equal(routeTemplateMatchesHref('/docs/[...path]', '/docs'), false);
+  });
+});
+
+describe('computeNavDiff — the two invariants', () => {
+  it('flags an orphaned route with no nav door', () => {
+    const diff = computeNavDiff({
+      routes: ['/dashboard', '/reports'],
+      nav: ['/dashboard'],
+    });
+    assert.deepEqual(
+      diff.orphanedRoutes.map((o) => o.path),
+      ['/reports'],
+    );
+    assert.deepEqual(diff.deadHrefs, []);
+    assert.deepEqual(diff.counts, { routes: 2, doors: 1 });
+  });
+
+  it('flags a dead nav href pointing at no route', () => {
+    const diff = computeNavDiff({
+      routes: ['/dashboard'],
+      nav: ['/dashboard', '/ghost'],
+    });
+    assert.deepEqual(
+      diff.deadHrefs.map((d) => d.href),
+      ['/ghost'],
+    );
+    assert.deepEqual(diff.orphanedRoutes, []);
+  });
+
+  it('treats a door as surfacing a dynamic route via template match', () => {
+    const diff = computeNavDiff({
+      routes: ['/users/:id'],
+      nav: ['/users/42'],
+    });
+    // The concrete href resolves to the template, so no dead href …
+    assert.deepEqual(diff.deadHrefs, []);
+    // … and the route is surfaced, so it is not orphaned.
+    assert.deepEqual(diff.orphanedRoutes, []);
+  });
+});
+
+describe('computeNavDiff — orphan-verification exemption taxonomy (AC-5)', () => {
+  it('exempts an explicitly-flagged route', () => {
+    const diff = computeNavDiff({
+      routes: [{ path: '/internal', exempt: true }],
+      nav: [],
+    });
+    assert.deepEqual(diff.orphanedRoutes, []);
+    assert.deepEqual(diff.exemptRoutes, [
+      { path: '/internal', reason: 'explicit-exempt' },
+    ]);
+  });
+
+  it('exempts a system route (login / 404)', () => {
+    const diff = computeNavDiff({
+      routes: ['/login', '/404'],
+      nav: [],
+    });
+    assert.deepEqual(diff.orphanedRoutes, []);
+    assert.deepEqual(diff.exemptRoutes.map((e) => e.reason).sort(), [
+      'system-route',
+      'system-route',
+    ]);
+  });
+
+  it('exempts a dynamic-segment child of a surfaced parent', () => {
+    const diff = computeNavDiff({
+      routes: ['/users', '/users/:id'],
+      nav: ['/users'],
+    });
+    assert.deepEqual(diff.orphanedRoutes, []);
+    assert.deepEqual(diff.exemptRoutes, [
+      { path: '/users/:id', reason: 'dynamic-child-of-surfaced-parent' },
+    ]);
+  });
+
+  it('does NOT exempt a dynamic child when the parent is itself unsurfaced', () => {
+    const diff = computeNavDiff({
+      routes: ['/users', '/users/:id'],
+      nav: [],
+    });
+    // Parent /users is orphaned; the dynamic child is a genuine orphan too.
+    assert.deepEqual(diff.orphanedRoutes.map((o) => o.path).sort(), [
+      '/users',
+      '/users/:id',
+    ]);
+  });
+
+  it('exempts a route reached only by an in-app inbound reference', () => {
+    const diff = computeNavDiff({
+      routes: ['/settings/advanced'],
+      nav: [],
+      refs: ['/settings/advanced'],
+    });
+    assert.deepEqual(diff.orphanedRoutes, []);
+    assert.deepEqual(diff.exemptRoutes, [
+      { path: '/settings/advanced', reason: 'inbound-in-app-reference' },
+    ]);
+  });
+});
+
+describe('computeNavDiff — persona entitlement', () => {
+  it('requires a persona intersection when both sides declare one', () => {
+    const diff = computeNavDiff({
+      routes: [{ path: '/admin', personas: ['admin'] }],
+      nav: [{ href: '/admin', persona: 'member' }],
+    });
+    // The door renders in the wrong persona shell → the route stays orphaned.
+    assert.deepEqual(
+      diff.orphanedRoutes.map((o) => o.path),
+      ['/admin'],
+    );
+    // …but the href still resolves to a real route, so it is not dead.
+    assert.deepEqual(diff.deadHrefs, []);
+  });
+
+  it('surfaces when the door persona is entitled', () => {
+    const diff = computeNavDiff({
+      routes: [{ path: '/admin', personas: ['admin', 'owner'] }],
+      nav: [{ href: '/admin', persona: 'owner' }],
+    });
+    assert.deepEqual(diff.orphanedRoutes, []);
+  });
+
+  it('surfaces for any persona when the door declares none', () => {
+    const diff = computeNavDiff({
+      routes: [{ path: '/admin', personas: ['admin'] }],
+      nav: [{ href: '/admin' }],
+    });
+    assert.deepEqual(diff.orphanedRoutes, []);
+  });
+});
+
+describe('input coercion', () => {
+  it('accepts bare-string and object entries interchangeably', () => {
+    const diff = computeNavDiff({
+      routes: ['/a', { path: '/b' }],
+      nav: ['/a', { href: '/b' }],
+    });
+    assert.deepEqual(diff.orphanedRoutes, []);
+    assert.deepEqual(diff.deadHrefs, []);
+  });
+
+  it('throws on a route entry with no usable path', () => {
+    assert.throws(
+      () => computeNavDiff({ routes: [{ personas: ['x'] }], nav: [] }),
+      /no usable "path"/,
+    );
+  });
+
+  it('throws on a nav entry with no usable href', () => {
+    assert.throws(
+      () => computeNavDiff({ routes: [], nav: [{ persona: 'x' }] }),
+      /no usable "href"/,
+    );
+  });
+});
+
+describe('formatDiffText', () => {
+  it('renders counts, orphans, dead hrefs, and exemptions', () => {
+    const text = formatDiffText(
+      computeNavDiff({
+        routes: ['/dashboard', '/reports', '/login', '/users/:id', '/users'],
+        nav: ['/dashboard', '/users', '/ghost'],
+      }),
+    );
+    assert.match(text, /routes: 5 {3}nav doors: 3/);
+    assert.match(text, /orphaned routes: 1/);
+    assert.match(text, /- \/reports/);
+    assert.match(text, /dead nav hrefs: 1/);
+    assert.match(text, /- \/ghost/);
+    assert.match(text, /exempt \(verified, not reported\): 2/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// CLI contract (AC-4): the script runs over a fixture route tree + nav registry,
+// prints the two-way diff, and exits 0.
+// ---------------------------------------------------------------------------
+
+/** Write JSON fixtures into an isolated temp dir; return their paths. */
+function writeFixtures({ routes, nav, refs }) {
+  const dir = mkdtempSync(path.join(tmpdir(), 'nav-registry-diff-'));
+  const routesFile = path.join(dir, 'routes.json');
+  const navFile = path.join(dir, 'nav.json');
+  writeFileSync(routesFile, JSON.stringify(routes));
+  writeFileSync(navFile, JSON.stringify(nav));
+  const out = { routesFile, navFile };
+  if (refs) {
+    out.refsFile = path.join(dir, 'refs.json');
+    writeFileSync(out.refsFile, JSON.stringify(refs));
+  }
+  return out;
+}
+
+describe('CLI', () => {
+  it('prints the two-way diff and exits 0 over a fixture (AC-4)', () => {
+    const { routesFile, navFile } = writeFixtures({
+      routes: ['/dashboard', '/reports', '/login', '/users/:id', '/users'],
+      nav: ['/dashboard', '/users', '/ghost'],
+    });
+    // execFileSync throws on a non-zero exit, so reaching the assertions proves
+    // exit 0.
+    const stdout = execFileSync('node', [
+      SCRIPT,
+      '--routes',
+      routesFile,
+      '--nav',
+      navFile,
+    ]).toString();
+    assert.match(stdout, /Route ↔ nav-registry diff/);
+    assert.match(stdout, /orphaned routes: 1/);
+    assert.match(stdout, /dead nav hrefs: 1/);
+  });
+
+  it('emits machine-readable JSON under --json', () => {
+    const { routesFile, navFile } = writeFixtures({
+      routes: ['/a', '/b'],
+      nav: ['/a'],
+    });
+    const stdout = execFileSync('node', [
+      SCRIPT,
+      '--routes',
+      routesFile,
+      '--nav',
+      navFile,
+      '--json',
+    ]).toString();
+    const parsed = JSON.parse(stdout);
+    assert.deepEqual(
+      parsed.orphanedRoutes.map((o) => o.path),
+      ['/b'],
+    );
+  });
+
+  it('exits non-zero under --strict when genuine findings remain', () => {
+    const { routesFile, navFile } = writeFixtures({
+      routes: ['/a', '/b'],
+      nav: ['/a'],
+    });
+    assert.throws(
+      () =>
+        execFileSync('node', [
+          SCRIPT,
+          '--routes',
+          routesFile,
+          '--nav',
+          navFile,
+          '--strict',
+        ]),
+      /Command failed/,
+    );
+  });
+
+  it('exits 0 under --strict when the diff is clean', () => {
+    const { routesFile, navFile } = writeFixtures({
+      routes: ['/a'],
+      nav: ['/a'],
+    });
+    const stdout = execFileSync('node', [
+      SCRIPT,
+      '--routes',
+      routesFile,
+      '--nav',
+      navFile,
+      '--strict',
+    ]).toString();
+    assert.match(stdout, /orphaned routes: 0/);
+  });
+
+  it('honours a --refs exemption file', () => {
+    const { routesFile, navFile, refsFile } = writeFixtures({
+      routes: ['/hidden'],
+      nav: [],
+      refs: ['/hidden'],
+    });
+    const stdout = execFileSync('node', [
+      SCRIPT,
+      '--routes',
+      routesFile,
+      '--nav',
+      navFile,
+      '--refs',
+      refsFile,
+      '--json',
+    ]).toString();
+    const parsed = JSON.parse(stdout);
+    assert.deepEqual(parsed.orphanedRoutes, []);
+    assert.equal(parsed.exemptRoutes[0].reason, 'inbound-in-app-reference');
+  });
+
+  it('errors when a required flag is missing', () => {
+    const { routesFile } = writeFixtures({ routes: ['/a'], nav: [] });
+    assert.throws(
+      () => execFileSync('node', [SCRIPT, '--routes', routesFile]),
+      /Command failed/,
+    );
+  });
+});

--- a/.agents/scripts/nav-registry-diff.js
+++ b/.agents/scripts/nav-registry-diff.js
@@ -1,0 +1,449 @@
+#!/usr/bin/env node
+/**
+ * .agents/scripts/nav-registry-diff.js — the deterministic route ↔ nav-registry
+ * cross-check the navigability lens (`audit-navigability.md`) runs and triages.
+ *
+ * The navigability lens asserts two symmetric invariants over a consumer's web
+ * surface:
+ *
+ *   1. **Every route has a persona nav door** — a route registered in the route
+ *      tree that no nav-registry entry surfaces for an entitled persona is an
+ *      **orphaned route**.
+ *   2. **No nav href is dead** — a nav-registry door whose target does not
+ *      resolve to a real route is a **dead nav href**.
+ *
+ * Both invariants are a set-difference over two identifier lists, not a
+ * judgement call, so they belong in a script rather than in lens prose that
+ * asks the agent to eyeball the two files. The lens enumerates the route tree
+ * (from `planning.navigation.routeGlobs`) and the nav registry (from
+ * `planning.navigation.navRegistry`), hands both to this tool, and triages the
+ * structured diff it prints.
+ *
+ * The one subtlety a naive set-difference gets wrong is **false orphans**: a
+ * dynamic detail route (`/users/:id`) is reachable through its surfaced parent,
+ * a system route (`/login`, `/404`) is reachable by construction, and a route
+ * reached only by an in-app link is not orphaned either. This tool applies that
+ * **orphan-verification exemption taxonomy** so the lens reports only genuine
+ * orphans (Story #4630, AC-5).
+ *
+ * Input is two JSON files (route tree + nav registry); a third optional file
+ * lists in-app inbound references. Route and door **identifiers only** are read
+ * — never route bodies or persona PII (the navigability lens's logging
+ * constraint). The tool prints the diff and exits 0 on a successful run; pass
+ * `--strict` to exit non-zero when genuine findings remain (a CI gate posture).
+ *
+ * This is a one-shot deterministic reporter, not an orchestrator: it takes no
+ * ticket, mutates no state, and spawns no process.
+ */
+
+import fs from 'node:fs';
+import { parseArgs } from 'node:util';
+import { runAsCli } from './lib/cli-utils.js';
+
+/**
+ * Last-segment tokens (or whole-path tokens) that mark a **system route** —
+ * reachable by construction (auth walls, error pages) rather than through a
+ * persona nav door, so their absence from the nav registry is never an orphan.
+ */
+const SYSTEM_ROUTE_TOKENS = Object.freeze([
+  'login',
+  'logout',
+  'signin',
+  'sign-in',
+  'signout',
+  'sign-out',
+  'signup',
+  'sign-up',
+  'register',
+  'auth',
+  'callback',
+  'unauthorized',
+  'forbidden',
+  'not-found',
+  'notfound',
+  '404',
+  '401',
+  '403',
+  '500',
+  'error',
+  'maintenance',
+]);
+
+/** The exemption reasons a verified non-orphan can carry, for triage clarity. */
+const EXEMPTION_REASONS = Object.freeze({
+  EXPLICIT: 'explicit-exempt',
+  SYSTEM: 'system-route',
+  DYNAMIC_CHILD: 'dynamic-child-of-surfaced-parent',
+  INBOUND: 'inbound-in-app-reference',
+});
+
+/**
+ * Normalize a route or href path for comparison: coerce to string, trim, force
+ * a single leading slash, collapse duplicate slashes, and drop a trailing slash
+ * (except for the root `/`). Returns `''` for a nullish or empty input so the
+ * caller can reject it.
+ *
+ * @param {unknown} p
+ * @returns {string}
+ */
+export function normalizePath(p) {
+  if (typeof p !== 'string') return '';
+  const trimmed = p.trim();
+  if (trimmed.length === 0) return '';
+  const withSlash = trimmed.startsWith('/') ? trimmed : `/${trimmed}`;
+  const collapsed = withSlash.replace(/\/{2,}/g, '/');
+  return collapsed.length > 1 ? collapsed.replace(/\/+$/, '') : collapsed;
+}
+
+/**
+ * Split a normalized path into its non-empty segments (`'/'` → `[]`).
+ *
+ * @param {string} normalized
+ * @returns {string[]}
+ */
+function segmentsOf(normalized) {
+  return normalized.split('/').filter(Boolean);
+}
+
+/**
+ * True when a single path segment is a **dynamic** segment: an Express/React
+ * Router `:param`, a Next.js `[param]` / `[...catchAll]`, a bare wildcard `*`,
+ * or a `{param}` template.
+ *
+ * @param {string} segment
+ * @returns {boolean}
+ */
+export function isDynamicSegment(segment) {
+  return (
+    segment.startsWith(':') ||
+    segment === '*' ||
+    (segment.startsWith('[') && segment.endsWith(']')) ||
+    (segment.startsWith('{') && segment.endsWith('}'))
+  );
+}
+
+/** True when the segment is a catch-all (`[...slug]` / `*`) that eats the rest. */
+function isCatchAllSegment(segment) {
+  return segment === '*' || segment.startsWith('[...');
+}
+
+/**
+ * True when a normalized route path contains at least one dynamic segment.
+ *
+ * @param {string} normalized
+ * @returns {boolean}
+ */
+export function isDynamicPath(normalized) {
+  return segmentsOf(normalized).some(isDynamicSegment);
+}
+
+/**
+ * True when a normalized route path is a system route (its last segment, or the
+ * whole path, is a recognized system token).
+ *
+ * @param {string} normalized
+ * @returns {boolean}
+ */
+export function isSystemRoute(normalized) {
+  const segs = segmentsOf(normalized);
+  if (segs.length === 0) return false;
+  const last = segs[segs.length - 1].toLowerCase();
+  return SYSTEM_ROUTE_TOKENS.includes(last);
+}
+
+/**
+ * The parent of a normalized path — the path with its last segment removed
+ * (`/users/:id` → `/users`, `/users` → `/`, `/` → `/`).
+ *
+ * @param {string} normalized
+ * @returns {string}
+ */
+export function parentPath(normalized) {
+  const segs = segmentsOf(normalized);
+  if (segs.length <= 1) return '/';
+  return `/${segs.slice(0, -1).join('/')}`;
+}
+
+/**
+ * True when a **route template** (which may contain dynamic segments) matches a
+ * concrete **href**. A dynamic segment matches any single href segment; a
+ * catch-all matches one-or-more trailing href segments. A template with no
+ * dynamic segment matches only an identical href.
+ *
+ * @param {string} routeNorm normalized route path (the template)
+ * @param {string} hrefNorm normalized href (the concrete target)
+ * @returns {boolean}
+ */
+export function routeTemplateMatchesHref(routeNorm, hrefNorm) {
+  const routeSegs = segmentsOf(routeNorm);
+  const hrefSegs = segmentsOf(hrefNorm);
+  for (let i = 0; i < routeSegs.length; i += 1) {
+    const rSeg = routeSegs[i];
+    if (isCatchAllSegment(rSeg)) {
+      // A catch-all consumes every remaining href segment (>= 1).
+      return hrefSegs.length >= i + 1;
+    }
+    if (i >= hrefSegs.length) return false;
+    if (isDynamicSegment(rSeg)) continue; // matches any one segment
+    if (rSeg !== hrefSegs[i]) return false;
+  }
+  return routeSegs.length === hrefSegs.length;
+}
+
+/**
+ * Coerce a route-tree entry (a bare path string or a `{ path, personas, exempt,
+ * kind }` object) into the internal route shape. Throws on an entry with no
+ * usable path so a malformed fixture fails loudly rather than silently
+ * dropping a route.
+ *
+ * @param {unknown} entry
+ * @returns {{ path: string, personas: string[], exempt: boolean }}
+ */
+export function toRoute(entry) {
+  const raw = typeof entry === 'string' ? { path: entry } : (entry ?? {});
+  const path = normalizePath(raw.path);
+  if (path === '') {
+    throw new Error(
+      `nav-registry-diff: route entry has no usable "path": ${JSON.stringify(entry)}`,
+    );
+  }
+  const personas = Array.isArray(raw.personas)
+    ? raw.personas.filter((x) => typeof x === 'string' && x.trim().length > 0)
+    : [];
+  return { path, personas, exempt: raw.exempt === true };
+}
+
+/**
+ * Coerce a nav-registry entry (a bare href string or a `{ href, persona }`
+ * object) into the internal door shape. Throws on an entry with no usable href.
+ *
+ * @param {unknown} entry
+ * @returns {{ href: string, persona: string|null }}
+ */
+export function toDoor(entry) {
+  const raw = typeof entry === 'string' ? { href: entry } : (entry ?? {});
+  const href = normalizePath(raw.href ?? raw.path);
+  if (href === '') {
+    throw new Error(
+      `nav-registry-diff: nav entry has no usable "href": ${JSON.stringify(entry)}`,
+    );
+  }
+  const persona =
+    typeof raw.persona === 'string' && raw.persona.trim().length > 0
+      ? raw.persona.trim()
+      : null;
+  return { href, persona };
+}
+
+/**
+ * True when a nav door surfaces a route: the door's href resolves to the route
+ * (identical path, or the route template matches the concrete href), AND — when
+ * both sides name personas — the door renders in a persona entitled to the
+ * route. A route with no declared personas is surfaced by any resolving door; a
+ * door with no persona surfaces for any entitled persona.
+ *
+ * @param {{ path: string, personas: string[] }} route
+ * @param {{ href: string, persona: string|null }} door
+ * @returns {boolean}
+ */
+function doorSurfacesRoute(route, door) {
+  const resolves =
+    route.path === door.href || routeTemplateMatchesHref(route.path, door.href);
+  if (!resolves) return false;
+  if (route.personas.length === 0 || door.persona === null) return true;
+  return route.personas.includes(door.persona);
+}
+
+/**
+ * Resolve why an unsurfaced route is exempt from the orphan report, or `null`
+ * when it is a genuine orphan. The taxonomy (Story #4630, AC-5): an explicitly
+ * exempt route, a system route, a dynamic-segment child of a surfaced parent,
+ * or a route reached by an in-app inbound reference.
+ *
+ * @param {{ path: string, exempt: boolean }} route
+ * @param {Set<string>} surfacedPaths route paths a door surfaces
+ * @param {Set<string>} inboundRefs normalized in-app referenced paths
+ * @returns {string|null} an {@link EXEMPTION_REASONS} value, or null
+ */
+function orphanExemption(route, surfacedPaths, inboundRefs) {
+  if (route.exempt) return EXEMPTION_REASONS.EXPLICIT;
+  if (isSystemRoute(route.path)) return EXEMPTION_REASONS.SYSTEM;
+  if (isDynamicPath(route.path) && surfacedPaths.has(parentPath(route.path))) {
+    return EXEMPTION_REASONS.DYNAMIC_CHILD;
+  }
+  if (inboundRefs.has(route.path)) return EXEMPTION_REASONS.INBOUND;
+  return null;
+}
+
+/**
+ * Compute the two-way route ↔ nav-registry diff with orphan verification.
+ *
+ * @param {{
+ *   routes?: unknown[],
+ *   nav?: unknown[],
+ *   refs?: unknown[],
+ * }} params
+ * @returns {{
+ *   counts: { routes: number, doors: number },
+ *   orphanedRoutes: { path: string, personas: string[] }[],
+ *   deadHrefs: { href: string, persona: string|null }[],
+ *   exemptRoutes: { path: string, reason: string }[],
+ * }}
+ */
+export function computeNavDiff({ routes = [], nav = [], refs = [] } = {}) {
+  const routeList = routes.map(toRoute);
+  const doorList = nav.map(toDoor);
+  const inboundRefs = new Set(refs.map(normalizePath).filter((p) => p !== ''));
+
+  // Which route paths does at least one door surface (persona-aware)?
+  const surfacedPaths = new Set();
+  for (const route of routeList) {
+    if (doorList.some((door) => doorSurfacesRoute(route, door))) {
+      surfacedPaths.add(route.path);
+    }
+  }
+
+  const orphanedRoutes = [];
+  const exemptRoutes = [];
+  for (const route of routeList) {
+    if (surfacedPaths.has(route.path)) continue;
+    const reason = orphanExemption(route, surfacedPaths, inboundRefs);
+    if (reason === null) {
+      orphanedRoutes.push({ path: route.path, personas: route.personas });
+    } else {
+      exemptRoutes.push({ path: route.path, reason });
+    }
+  }
+
+  // A door is dead when its href resolves to no route (identical or template).
+  const deadHrefs = [];
+  for (const door of doorList) {
+    const resolves = routeList.some(
+      (route) =>
+        route.path === door.href ||
+        routeTemplateMatchesHref(route.path, door.href),
+    );
+    if (!resolves) deadHrefs.push({ href: door.href, persona: door.persona });
+  }
+
+  return {
+    counts: { routes: routeList.length, doors: doorList.length },
+    orphanedRoutes,
+    deadHrefs,
+    exemptRoutes,
+  };
+}
+
+/**
+ * Read and parse a JSON array from a file, throwing a clear error when the file
+ * is unreadable, not JSON, or not an array.
+ *
+ * @param {string} label human-readable role for the error message
+ * @param {string} file
+ * @returns {unknown[]}
+ */
+function readJsonArray(label, file) {
+  let raw;
+  try {
+    raw = fs.readFileSync(file, 'utf8');
+  } catch (err) {
+    throw new Error(
+      `nav-registry-diff: cannot read ${label} file '${file}': ${err.message}`,
+    );
+  }
+  let parsed;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (err) {
+    throw new Error(
+      `nav-registry-diff: ${label} file '${file}' is not valid JSON: ${err.message}`,
+    );
+  }
+  // Accept either a bare array or a `{ routes: [...] }` / `{ nav: [...] }` wrapper.
+  const list = Array.isArray(parsed)
+    ? parsed
+    : (parsed?.routes ?? parsed?.nav ?? parsed?.entries);
+  if (!Array.isArray(list)) {
+    throw new Error(
+      `nav-registry-diff: ${label} file '${file}' must be a JSON array (or an object with a matching array field)`,
+    );
+  }
+  return list;
+}
+
+/**
+ * Render the diff as a human-readable, triage-friendly text report.
+ *
+ * @param {ReturnType<typeof computeNavDiff>} diff
+ * @returns {string}
+ */
+export function formatDiffText(diff) {
+  const lines = [
+    'Route ↔ nav-registry diff',
+    `  routes: ${diff.counts.routes}   nav doors: ${diff.counts.doors}`,
+    `  orphaned routes: ${diff.orphanedRoutes.length}`,
+  ];
+  for (const o of diff.orphanedRoutes) {
+    const personas = o.personas.length > 0 ? ` [${o.personas.join(', ')}]` : '';
+    lines.push(`    - ${o.path}${personas}`);
+  }
+  lines.push(`  dead nav hrefs: ${diff.deadHrefs.length}`);
+  for (const d of diff.deadHrefs) {
+    const persona = d.persona ? ` [${d.persona}]` : '';
+    lines.push(`    - ${d.href}${persona}`);
+  }
+  lines.push(`  exempt (verified, not reported): ${diff.exemptRoutes.length}`);
+  for (const e of diff.exemptRoutes) {
+    lines.push(`    - ${e.path} — ${e.reason}`);
+  }
+  return lines.join('\n');
+}
+
+/**
+ * @param {string[]} argv
+ * @returns {Promise<number>} process exit code
+ */
+async function main(argv = process.argv.slice(2)) {
+  const { values } = parseArgs({
+    args: argv,
+    options: {
+      routes: { type: 'string' },
+      nav: { type: 'string' },
+      refs: { type: 'string' },
+      json: { type: 'boolean', default: false },
+      strict: { type: 'boolean', default: false },
+    },
+    allowPositionals: false,
+  });
+
+  if (!values.routes || !values.nav) {
+    throw new Error(
+      'nav-registry-diff: both --routes <file> and --nav <file> are required.\n' +
+        'Usage: node .agents/scripts/nav-registry-diff.js --routes routes.json --nav nav.json [--refs refs.json] [--json] [--strict]',
+    );
+  }
+
+  const routes = readJsonArray('routes', values.routes);
+  const nav = readJsonArray('nav', values.nav);
+  const refs = values.refs ? readJsonArray('refs', values.refs) : [];
+
+  const diff = computeNavDiff({ routes, nav, refs });
+
+  // Written straight to stdout (not the orchestrator Logger) so the output is a
+  // clean, machine-parseable report the lens can pipe or `JSON.parse`.
+  const rendered = values.json
+    ? JSON.stringify(diff, null, 2)
+    : formatDiffText(diff);
+  process.stdout.write(`${rendered}\n`);
+
+  const hasFindings =
+    diff.orphanedRoutes.length > 0 || diff.deadHrefs.length > 0;
+  return values.strict && hasFindings ? 1 : 0;
+}
+
+export { main };
+
+runAsCli(import.meta.url, main, {
+  source: 'nav-registry-diff',
+  propagateExitCode: true,
+});

--- a/.agents/workflows/audit-navigability.md
+++ b/.agents/workflows/audit-navigability.md
@@ -69,17 +69,19 @@ exemption never lets a foreign Epic's change set leak into a scoped lens.
 
 Read the consumer's navigability config (resolved from `.agentrc.json`):
 
-- `delivery.quality.navigability.routeGlobs` — globs identifying the
-  route-adding files / route tree (e.g. `pages/**`, `app/**/route.ts`). Drives
-  both the route-tree enumeration here and the plan-persist draft
-  reachability gate
-  ([`plan-reachability.js`](../scripts/lib/orchestration/plan-reachability.js)).
-- `delivery.quality.navigability.navRegistry` — path(s) to the consumer's
-  nav-registry SSOT this lens reads.
+- `planning.navigation.routeGlobs` — globs identifying the route-adding files /
+  route tree (e.g. `pages/**`, `app/**/route.ts`). This is the same key the
+  plan-persist draft reachability gate
+  ([`plan-reachability.js`](../scripts/lib/orchestration/plan-reachability.js))
+  reads via `resolveNavConfig`, so the lens and the plan gate enumerate the
+  route tree from one SSOT.
+- `planning.navigation.navRegistry` — path(s) to the consumer's nav-registry
+  SSOT this lens reads.
 
-If **neither** `routeGlobs` nor `navRegistry` is present, emit a one-line
-"navigability not configured — skipped" note and exit without findings. Do
-**not** invent a route tree or guess a nav registry.
+If **neither** `routeGlobs` nor `navRegistry` is present under
+`planning.navigation`, emit a one-line "navigability not configured — skipped"
+note and exit without findings. Do **not** invent a route tree or guess a nav
+registry.
 
 ## Step 1: Enumerate the route tree
 
@@ -93,14 +95,52 @@ only** — never the full route body or any persona PII.
 Read every nav door from the `navRegistry` SSOT. Record each door's target
 path and the persona shell it renders in.
 
-## Step 3: Cross-check (the two invariants)
+## Step 3: Run the deterministic cross-check
 
-1. **Every route has a persona nav door.** For each enumerated route, assert at
-   least one nav-registry entry surfaces it for an entitled persona. A route
-   with no door for any of its personas is an **orphaned route**.
-2. **No nav href is dead.** For each nav door, assert its target resolves to a
-   real route in the route tree. A door whose target is absent is a **dead nav
-   href**.
+The two invariants are a **set-difference over two identifier lists**, not a
+judgement call — so run them mechanically rather than eyeballing the two files.
+Serialize the enumerated route tree (Step 1) and nav registry (Step 2) to two
+JSON files and run the shipped diff tool:
+
+```bash
+node .agents/scripts/nav-registry-diff.js \
+  --routes <routes.json> --nav <nav-registry.json> [--refs <inbound-refs.json>] --json
+```
+
+It prints, deterministically, the two invariants:
+
+1. **Every route has a persona nav door.** A route no door surfaces for an
+   entitled persona is an **orphaned route** (`orphanedRoutes`).
+2. **No nav href is dead.** A door whose target resolves to no route is a
+   **dead nav href** (`deadHrefs`).
+
+The tool also returns `exemptRoutes` — routes it verified are _not_ genuine
+orphans (see Step 3a). **Triage the tool's output**: promote each
+`orphanedRoutes` / `deadHrefs` entry to a Detailed Finding, and do not report
+anything the tool placed in `exemptRoutes`.
+
+## Step 3a: Orphan-verification exemption taxonomy
+
+A naive route-minus-nav set-difference over-reports. Before an unsurfaced route
+is reported as orphaned, it must survive this exemption taxonomy (the diff tool
+applies it, and you MUST apply the same reasoning to anything you assess by
+hand):
+
+- **Dynamic-segment children of a surfaced parent** — a detail route such as
+  `/users/:id` (or `/blog/[slug]`) is reached _through_ its surfaced parent
+  list, so it is exempt when its parent path has a nav door. It is **not** exempt
+  when the parent itself is unsurfaced.
+- **System routes** — `/login`, `/logout`, `/register`, `/auth/callback`,
+  `/404`, `/401`, `/403`, `/500`, `/unauthorized`, `/forbidden`, and similar are
+  reachable by construction (auth walls, error boundaries), never through a
+  persona nav door.
+- **Inbound in-app references** — a route linked from within the app (a
+  `<Link to="…">`, a programmatic `router.push`, an in-content anchor) is
+  reachable even without a top-level nav door. Grep the source for an inbound
+  reference before reporting the route as orphaned; feed the referenced paths to
+  the tool via `--refs`.
+
+Only a route that clears **all** of these is a genuine orphan worth a finding.
 
 ## Step 4: Output Requirements
 

--- a/.agents/workflows/audit-seo.md
+++ b/.agents/workflows/audit-seo.md
@@ -49,35 +49,70 @@ before this section existed.
   proceed with the full codebase-wide scan defined in the remaining
   steps.
 
-## Step 1: Context Gathering (Read-Only Scan)
+## Step 0: Indexability gate (run first)
+
+**Open every SEO audit by deciding whether the surface is meant to be indexed at
+all.** SEO findings on an auth-walled, private, or internal surface are noise —
+a login-gated dashboard is *supposed* to be invisible to crawlers, so a missing
+`<meta name="description">` there is not a defect.
+
+- **Auth-walled / private surface** (every route under the change set sits
+  behind an authentication guard, a `noindex` directive, or a `Disallow`-all
+  `robots.txt`) ⇒ record a single **"SEO not applicable — surface is not
+  indexable"** note and stop. Do not emit per-file findings.
+- **Publicly indexable surface** (marketing pages, docs, blog, product pages, a
+  public app shell) ⇒ proceed to Step 1.
+- **Mixed** ⇒ scope the remaining steps to the indexable routes only, and say so
+  in the Executive Summary.
+
+## Step 1: Framework-aware metadata detection matrix
 
 > Apply [`helpers/parallel-tooling.md`](helpers/parallel-tooling.md) when batching the scan below — independent reads belong in one turn, long shells run via `run_in_background` + `Monitor`.
 
-Before generating the report, silently scan the codebase. Pay special attention
-to:
+Modern web consumers almost never ship literal `<head><meta></head>` HTML — the
+metadata is produced by a framework mechanism. **Identify the mechanism first,
+then probe the surfaces that mechanism uses.** Reporting "no `<meta>` tags found"
+on a Next.js app that sets them through `generateMetadata` is a false finding.
 
-- Page `<head>` elements: `<title>`, `<meta name="description">`, canonical
-  tags, Open Graph, and Twitter Card tags.
-- Semantic HTML structure: heading hierarchy (`h1`–`h6`), landmark elements
-  (`<main>`, `<nav>`, `<article>`, `<section>`), and `<img alt>` attributes.
-- Structured data: JSON-LD blocks and Schema.org types in use.
-- Internal linking patterns and URL structure.
-- Content layout: answer-friendly formatting (FAQs, numbered steps, definition
-  lists) vs. dense prose.
+- **Step 1a — Identify the meta mechanism.** Determine which one (or more) of the
+  following the consumer uses, from its dependencies and source layout:
+
+  | Framework / library | Metadata mechanism | Where to probe |
+  | --- | --- | --- |
+  | Next.js (App Router) | `metadata` export / `generateMetadata()` | `app/**/{layout,page}.{js,jsx,ts,tsx}` |
+  | Next.js (Pages Router) | `next/head` `<Head>` | `pages/**/*.{js,jsx,ts,tsx}` |
+  | React (generic) | `react-helmet` / `react-helmet-async` | components importing `Helmet` |
+  | Vue / Nuxt | `@unhead/vue` / `useHead()` / `nuxt.config` `head` | `*.vue`, `nuxt.config.*` |
+  | Svelte / SvelteKit | `<svelte:head>` | `*.svelte` |
+  | Astro | frontmatter `<head>` in layouts | `*.astro` |
+  | Plain static | literal `<head>` HTML | `*.html` |
+
+- **Step 1b — Enumerate the routes.** Take the route list from the navigability
+  `routeGlobs` SSOT (the same route tree the navigability lens enumerates), not
+  from a guess. Each public route is a page whose metadata you assess.
+- **Step 1c — Per-route metadata probe.** For each indexable route, assert the
+  detected mechanism supplies: a `<title>`, a meta description, canonical URL,
+  Open Graph / Twitter Card tags, and (where relevant) JSON-LD structured data.
+  A route whose mechanism sets none of these is a real finding.
 
 ## Step 2: Analysis Dimensions
 
 Evaluate the gathered context against the following dimensions:
 
-1. **Traditional SEO:** Meta tags, semantic structure, accessibility, internal
-   linking logic, and keyword placement.
+1. **Traditional SEO:** Meta mechanism coverage (per Step 1), semantic structure,
+   heading hierarchy, `<img alt>`, internal linking logic, and canonical URLs.
 2. **AIO & GEO (Answer Engine Optimization):** Entity clarity, concise answer
    formatting, structured data (Schema.org), and token efficiency for LLM
    retrieval.
-3. **Core Web Vitals:** CLS, LCP, and INP risk factors visible from the codebase
-   (e.g., unsized images, render-blocking resources, large layout shifts).
-4. **Crawlability:** `robots.txt`, `sitemap.xml`, and any `noindex` directives
-   that may unintentionally block pages.
+3. **Statically-provable Core Web Vitals defects only:** flag *code-visible*
+   regressions — unsized images or media embeds (CLS risk), render-blocking synchronous
+   scripts, and fonts loaded without `display=swap`. **Do not estimate or score
+   measured CWV** (LCP/INP/CLS numbers): measured Core Web Vitals are owned by
+   the `audit-performance` lens — defer them there explicitly rather than
+   guessing a score from source.
+4. **Crawlability:** `robots.txt`, `sitemap.xml` (including generated
+   `sitemap.*`/`robots.*` route handlers), and any `noindex` directives that may
+   unintentionally block indexable pages.
 
 ## Step 3: Output Requirements
 

--- a/.agents/workflows/audit-ux-ui.md
+++ b/.agents/workflows/audit-ux-ui.md
@@ -42,21 +42,54 @@ before this section existed.
   proceed with the full codebase-wide scan defined in the remaining
   steps.
 
-## Step 1: Visual Consistency Check
+## Step 0: Discover the design-system SSOT (run first)
+
+**You cannot audit "adherence to the design system" until you have located the
+design system.** There is no universal baseline — a hardcoded `#3b82f6` is a
+defect only when the project defines that colour as a token. Before any
+detection, locate the consumer's design-system sources of truth and read what
+they define:
+
+- **Design tokens / theme:** a `tailwind.config.{js,ts}`, CSS custom properties
+  (`:root { --color-*, --space-* }`), a `theme/`, `tokens/`, or `design-system/`
+  directory, or a `styled-system` / CSS-in-JS theme object.
+- **Component library:** the shared component directory (`components/ui/**`,
+  a published design-system package) that raw elements are expected to defer to.
+- **Documented conventions:** `docs/style-guide.md` (and `docs/web-routes.md`
+  when routing copy is in scope) — the human-authored rules the mechanical
+  detectors below cannot infer.
+
+Record the token names, the component roster, and the style-guide rules. Every
+finding downstream is measured against *this discovered baseline*, not a generic
+ideal. If **no** design-system SSOT exists, say so and downgrade findings to
+"no baseline defined — recommend establishing tokens/components first".
+
+## Step 1: Mechanical detector battery, then LLM triage
 
 > Apply [`helpers/parallel-tooling.md`](helpers/parallel-tooling.md) when batching the scan below — independent reads belong in one turn, long shells run via `run_in_background` + `Monitor`.
 
-Scan frontend components for:
+Run the **mechanical detectors first** (cheap, deterministic greps that surface
+candidates), then apply **LLM triage** to each candidate against the Step 0
+baseline — a mechanical hit is a *candidate*, not automatically a finding.
 
-- **Hardcoded Values:** Identify "magic" hex codes, font sizes, or spacing
-  values that bypass the CSS variables/design tokens.
-- **Component Re-implementation:** Find places where custom HTML/CSS is used
-  instead of the standard component library (e.g., custom button instead of
-  `<Button />`).
-- **Interactive States:** Verify that all clickable elements have hover, focus,
-  and active states.
-- **Typography:** Ensure font families and weights are used consistently
-  according to the hierarchy.
+- **Hardcoded Values:** grep for raw `#hex` / `rgb()` colour literals and raw
+  `px` font-size / spacing literals **outside** the token/theme files. Each hit
+  is a candidate bypass of a defined token.
+- **Component Re-implementation:** census raw HTML elements (`<button>`,
+  `<input>`, `<select>`, `<a>` styled as a button) versus the design-system
+  component that should replace them; a high raw-vs-component ratio is the
+  signal.
+- **Inline-style census:** count inline `style=` / `style={{…}}` usages that
+  encode spacing, colour, or typography a token should own.
+- **Interactive States:** scan for `:hover` (or `hover:` utilities) without a
+  matching `:focus-visible` / `focus-visible:` — a hover state with no keyboard
+  focus state is a candidate accessibility-of-interaction gap.
+- **Typography:** flag font families / weights used outside the type scale.
+
+> **Detector output is candidates.** Triage each with the discovered baseline
+> before promoting it to a finding — a `px` value inside a token definition file,
+> or a raw `<button>` inside the design-system's own `Button` implementation, is
+> expected, not a defect.
 
 ## Step 2: UX Best Practices
 

--- a/tests/audit-suite/web-lens-tool-first.test.js
+++ b/tests/audit-suite/web-lens-tool-first.test.js
@@ -1,0 +1,166 @@
+/**
+ * tests/audit-suite/web-lens-tool-first.test.js — Story #4630.
+ *
+ * Locks the tool-first refactor of the three web lenses (seo, ux-ui,
+ * navigability) so a later doc-shuffle cannot silently revert them:
+ *
+ *   - AC-1: audit-seo carries the framework metadata-detection matrix
+ *           (`generateMetadata`) and opens with the indexability gate.
+ *   - AC-2: audit-rules filePatterns cover framework surfaces, so a JSX/TSX
+ *           route diff selects the seo lens (and a component/css diff the ux-ui
+ *           lens) through the real selector.
+ *   - AC-3: audit-ux-ui mandates the design-system SSOT discovery Step 0
+ *           (style-guide) and the mechanical detector battery.
+ *   - AC-4: audit-navigability instructs running + triaging nav-registry-diff.js.
+ *   - AC-5: audit-navigability enumerates the orphan-verification exemption
+ *           taxonomy (dynamic children, system routes, inbound references).
+ *   - AC-6: audit-navigability attributes the plan gate to planning.navigation
+ *           and no longer to delivery.quality.navigability.
+ */
+
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { describe, it } from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+import { selectLocalLenses } from '../../.agents/scripts/lib/audit-suite/index.js';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const WORKFLOWS = path.resolve(HERE, '..', '..', '.agents', 'workflows');
+
+/** Count non-overlapping occurrences of a literal substring. */
+function countOccurrences(haystack, needle) {
+  return haystack.split(needle).length - 1;
+}
+
+const readLens = (lens) =>
+  fs.readFileSync(path.join(WORKFLOWS, `audit-${lens}.md`), 'utf8');
+
+describe('audit-seo — framework metadata detection (AC-1)', () => {
+  const md = readLens('seo');
+
+  it('names generateMetadata in the detection matrix', () => {
+    assert.ok(countOccurrences(md, 'generateMetadata') >= 1);
+  });
+
+  it('opens with an indexability gate before the detection steps', () => {
+    const gateIdx = md.indexOf('Indexability gate');
+    const step1Idx = md.indexOf('## Step 1');
+    assert.ok(gateIdx !== -1, 'no indexability gate section');
+    assert.ok(
+      gateIdx < step1Idx,
+      'the indexability gate must precede the detection matrix',
+    );
+    assert.match(md, /SEO not applicable/);
+  });
+
+  it('names a mechanism-identification step and per-framework probes', () => {
+    assert.match(md, /Identify the meta mechanism/);
+    for (const mechanism of [
+      'next/head',
+      'react-helmet',
+      '@unhead/vue',
+      'svelte:head',
+      '.astro',
+    ]) {
+      assert.ok(
+        md.includes(mechanism),
+        `detection matrix omits the ${mechanism} probe`,
+      );
+    }
+  });
+
+  it('defers measured Core Web Vitals to the performance lens', () => {
+    assert.match(md, /audit-performance/);
+  });
+});
+
+describe('audit-ux-ui — discovered-baseline auditing (AC-3)', () => {
+  const md = readLens('ux-ui');
+
+  it('references the style-guide SSOT (grep -i style-guide >= 1)', () => {
+    assert.ok(countOccurrences(md.toLowerCase(), 'style-guide') >= 1);
+  });
+
+  it('mandates a design-system SSOT discovery Step 0 before detection', () => {
+    const step0 = md.indexOf('Discover the design-system SSOT');
+    const step1 = md.indexOf('## Step 1');
+    assert.ok(step0 !== -1, 'no design-system discovery Step 0');
+    assert.ok(step0 < step1, 'Step 0 must precede the detector battery');
+  });
+
+  it('names the mechanical detector battery', () => {
+    assert.match(md, /Mechanical detector battery/);
+    assert.match(md, /Hardcoded Values/);
+    assert.match(md, /Inline-style census/);
+    assert.match(md, /focus-visible/);
+  });
+});
+
+describe('audit-navigability — deterministic diff + exemptions (AC-4/5/6)', () => {
+  const md = readLens('navigability');
+
+  it('instructs running and triaging nav-registry-diff.js (AC-4)', () => {
+    assert.match(md, /nav-registry-diff\.js/);
+    assert.match(md, /[Tt]riage/);
+  });
+
+  it('enumerates the orphan-verification exemption taxonomy (AC-5)', () => {
+    assert.match(md, /Dynamic-segment children of a surfaced parent/);
+    assert.match(md, /System routes/);
+    assert.match(md, /Inbound in-app references/);
+  });
+
+  it('attributes the plan gate to planning.navigation (AC-6)', () => {
+    assert.ok(
+      countOccurrences(md, 'planning.navigation') >= 1,
+      'lens must name planning.navigation',
+    );
+    assert.equal(
+      countOccurrences(md, 'delivery.quality.navigability'),
+      0,
+      'lens must not attribute config to delivery.quality.navigability',
+    );
+  });
+});
+
+describe('selector routes web lenses on framework surfaces (AC-2)', () => {
+  it('selects audit-seo on a Next app-router JSX/TSX route diff', () => {
+    for (const file of [
+      'app/blog/[slug]/page.tsx',
+      'pages/about.jsx',
+      'src/routes/dashboard.tsx',
+      'app/sitemap.ts',
+    ]) {
+      const selected = selectLocalLenses({ changedFiles: [file] });
+      assert.ok(
+        selected.includes('audit-seo'),
+        `audit-seo must select on ${file}, got ${JSON.stringify(selected)}`,
+      );
+    }
+  });
+
+  it('selects audit-ux-ui on a component / design-token diff', () => {
+    for (const file of [
+      'src/components/ui/Button.tsx',
+      'src/styles/base.css',
+      'tailwind.config.ts',
+      'design-system/tokens.css',
+    ]) {
+      const selected = selectLocalLenses({ changedFiles: [file] });
+      assert.ok(
+        selected.includes('audit-ux-ui'),
+        `audit-ux-ui must select on ${file}, got ${JSON.stringify(selected)}`,
+      );
+    }
+  });
+
+  it('does not select the web lenses on a backend-only diff', () => {
+    const selected = selectLocalLenses({
+      changedFiles: ['.agents/scripts/lib/orchestration/close-pipeline.js'],
+    });
+    assert.ok(!selected.includes('audit-seo'));
+    assert.ok(!selected.includes('audit-ux-ui'));
+  });
+});


### PR DESCRIPTION
Closes #4630

_Auto-opened by `/deliver`._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to agent audit workflows, a read-only diff script, schema triggers, and tests—no runtime product or auth paths.
> 
> **Overview**
> Refactors the **SEO**, **UX/UI**, and **navigability** audit lenses so agents run deterministic checks and triage output instead of hand-waving over route trees or raw HTML.
> 
> **Navigability** adds `nav-registry-diff.js`, which compares serialized route trees and nav registries for orphaned routes and dead hrefs, applies persona-aware matching and an exemption taxonomy (dynamic children of surfaced parents, system routes, inbound refs, explicit exempt), and supports `--json` / `--strict` for CI. The workflow now points config at `planning.navigation` (aligned with the plan reachability gate) and instructs running and triaging that tool.
> 
> **SEO** opens with an **indexability gate** (skip noise on auth-walled surfaces), replaces generic `<head>` scanning with a **framework metadata matrix** (`generateMetadata`, `next/head`, etc.), and limits Core Web Vitals to statically provable defects while deferring measured CWV to `audit-performance`.
> 
> **UX/UI** adds **Step 0** to discover the consumer design-system SSOT, then a **mechanical detector battery** (hardcoded values, inline styles, focus-visible gaps) with LLM triage against that baseline.
> 
> **`audit-rules.json`** widens SEO/UX file patterns so framework routes and design-token paths actually select those lenses. Regenerated authoring checklists and regression tests lock the new workflow text and selector behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0eb55a6c92c414981e3488927c0c03931d7e9ef6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->