### PR TITLE
feat: audit-performance rework: measurement-first protocol, repo profiling, and the concurrency/partial-failure fold (#4631)

### DIFF
--- a/.agents/audit-checklists/performance.md
+++ b/.agents/audit-checklists/performance.md
@@ -6,17 +6,14 @@
 
 # Performance & Bottleneck Audit — authoring checklist
 
-> Audit hot paths, algorithmic complexity, and I/O bottlenecks in the tooling surface (`single-story-close`, dispatcher, gates); propose remediations.
+> Audit performance by measuring first — profile hot paths, I/O, memory, and payload against the repo's own numbers — and audit interleaving/partial-failure correctness (TOCTOU, unawaited promises, non-atomic writes) as a first-class dimension.
 
 Self-check your change against this lens's concerns before you ship:
 
-- [ ] Database/API Efficiency
-- [ ] Frontend Rendering
-- [ ] Bundle Size
-- [ ] Resource Usage
-- [ ] Network Path
-- [ ] Latency
-- [ ] Throughput
-- [ ] Efficiency
-- [ ] Scalability
-- [ ] Core Web Vitals
+- [ ] Diff against the previous baseline
+- [ ] Suppress unchanged known findings.
+- [ ] CPU & algorithmic hot paths
+- [ ] I/O & syscall efficiency
+- [ ] Memory & leaks
+- [ ] Payload & bundle (web only)
+- [ ] Interleaving & partial-failure correctness

--- a/.agents/docs/workflows.md
+++ b/.agents/docs/workflows.md
@@ -43,7 +43,7 @@ description, edit the workflow file’s front-matter and regenerate.
 | `/audit-documentation` | Audit the repository's main documentation for staleness, semantic drift, and completeness; emit a structured High/Medium/Low findings report. |
 | `/audit-lighthouse` | Run a Lighthouse audit (Performance / Accessibility / Best Practices / SEO) and produce a structured findings report |
 | `/audit-navigability` | Audit the whole route tree against the consumer's nav-registry SSOT — every route has a persona nav door and no nav href is dead. A deliberately-global lens (Epic #4131, F2/F3) exempt from the cross-epic-leak guard and routed onto route-adding change sets. |
-| `/audit-performance` | Audit hot paths, algorithmic complexity, and I/O bottlenecks in the tooling surface (`single-story-close`, dispatcher, gates); propose remediations. |
+| `/audit-performance` | Audit performance by measuring first — profile hot paths, I/O, memory, and payload against the repo's own numbers — and audit interleaving/partial-failure correctness (TOCTOU, unawaited promises, non-atomic writes) as a first-class dimension. |
 | `/audit-privacy` | Audit logs, telemetry, and persistence paths for PII leakage and retention violations; surface secrets exposure and consent gaps. |
 | `/audit-quality` | Audit test coverage gaps, flaky tests, missing assertions, and test-pyramid balance; recommend a remediation batch. |
 | `/audit-security` | Audit dependency CVEs, input-validation gaps, secrets handling, and auth boundaries; emit a structured High/Medium/Low findings report. |

--- a/.agents/schemas/audit-rules.json
+++ b/.agents/schemas/audit-rules.json
@@ -130,8 +130,27 @@
     "audit-performance": {
       "triggers": {
         "gates": ["gate1", "gate3"],
-        "keywords": ["performance", "n+1", "hot path", "latency", "throughput"],
-        "filePatterns": [".agents/scripts/**", "src/**/*.{ts,js}"]
+        "keywords": [
+          "performance",
+          "n+1",
+          "hot path",
+          "latency",
+          "throughput",
+          "concurrency",
+          "race",
+          "toctou",
+          "atomic",
+          "idempotent",
+          "bundle",
+          "memory leak"
+        ],
+        "filePatterns": [
+          ".agents/scripts/**",
+          "src/**/*.{ts,js}",
+          "**/*.html",
+          "**/*.css",
+          "**/components/**/*.js"
+        ]
       },
       "scope": "local",
       "substitutionKeys": []

--- a/.agents/scripts/lib/audit-suite/__tests__/lens-contract.test.js
+++ b/.agents/scripts/lib/audit-suite/__tests__/lens-contract.test.js
@@ -285,6 +285,86 @@ describe('lens findings contract (Story #4625)', () => {
   });
 });
 
+describe('audit-performance lens rework (Story #4631)', () => {
+  const md = readLens('performance');
+
+  it('AC-1: measures before judging — mandates cpu-prof and an Evidence field', () => {
+    assert.ok(
+      md.includes('cpu-prof'),
+      'performance lens names no `node --cpu-prof` measurement command',
+    );
+    assert.ok(
+      /##\s+Step 0/.test(md) && /measure/i.test(md),
+      'performance lens has no mandatory measurement Step 0',
+    );
+    assert.ok(
+      md.includes('**Evidence:**'),
+      'performance lens template has no per-finding Evidence field',
+    );
+    assert.ok(
+      /measured/.test(md) && /estimated/.test(md),
+      'performance lens does not require a measured-or-estimated tag',
+    );
+  });
+
+  it('AC-2: interleaving is a first-class dimension covering the concurrency defect classes', () => {
+    assert.ok(
+      /TOCTOU/i.test(md),
+      'performance lens does not cover TOCTOU / check-then-act',
+    );
+    for (const concern of [
+      /unawaited|floating/i,
+      /read-modify-write/i,
+      /temp-file/i,
+      /idempoten/i,
+      /shared-cache poisoning/i,
+    ]) {
+      assert.ok(
+        concern.test(md),
+        `performance lens omits a required concurrency concern: ${concern}`,
+      );
+    }
+  });
+
+  it('AC-3: dimensions adapt to the detected repo profile', () => {
+    assert.ok(
+      /profile/i.test(md) && /inapplicable/i.test(md),
+      'performance lens does not branch on repo profile / declare inapplicable dimensions',
+    );
+    // Web-only dimension must be gated, not universal.
+    assert.ok(
+      /web only/i.test(md),
+      'performance lens does not gate the payload/bundle dimension to web repos',
+    );
+  });
+
+  it('AC-4: runs trend instead of amnesia — per-run baseline + delta reporting', () => {
+    assert.ok(
+      /perf-baseline\.json/.test(md),
+      'performance lens does not mandate a per-run perf baseline artifact',
+    );
+    assert.ok(
+      /(delta|diff)/i.test(md) && /baseline/i.test(md),
+      'performance lens does not report deltas vs the previous baseline',
+    );
+    assert.ok(
+      /suppress/i.test(md) && /unchanged/i.test(md),
+      'performance lens does not suppress unchanged known findings',
+    );
+    assert.ok(
+      /regress/i.test(md) && /High/.test(md),
+      'performance lens does not make a regression vs baseline an automatic High',
+    );
+  });
+
+  it("re-homes lighthouse's measured CWV material into the web branch", () => {
+    assert.ok(
+      /median-of-3/i.test(md) && /per-route/i.test(md),
+      'performance lens web branch does not carry the per-route / median-of-3 CWV protocol',
+    );
+  });
+});
+
 describe('parseAuditReport findings-contract units (Story #4625)', () => {
   const wrap = (block) => `# Report\n\n## Detailed Findings\n\n${block}\n`;
 

--- a/.agents/scripts/lib/dynamic-workflow/performance-report-contract.js
+++ b/.agents/scripts/lib/dynamic-workflow/performance-report-contract.js
@@ -12,9 +12,10 @@ import { assertSectionsContract } from './report-contract-core.js';
  * contract-tier test assert report conformance against one definition rather
  * than re-deriving headings from prose in two places.
  *
- * Changing the report contract is explicitly **out of scope** for this Story —
- * this module documents the existing shape already declared by the lens
- * markdown's Step 3 template, it does not introduce a new one.
+ * The report shape is declared by the lens markdown's Step 4 template. Story
+ * #4631 added the mandatory per-finding **Evidence** field (a repro command
+ * plus a `measured`/`estimated` tag) so measurement-first evidence is part of
+ * the contract both paths must emit, not just prose in the lens.
  *
  * @module dynamic-workflow/performance-report-contract
  */
@@ -48,6 +49,7 @@ export const REPORT_TITLE = 'Performance Audit Report';
 export const FINDING_FIELDS = Object.freeze([
   'Dimension',
   'Impact',
+  'Evidence',
   'Current State',
   'Recommendation & Rationale',
   'Agent Prompt',

--- a/.agents/workflows/audit-performance.md
+++ b/.agents/workflows/audit-performance.md
@@ -1,5 +1,5 @@
 ---
-description: Audit hot paths, algorithmic complexity, and I/O bottlenecks in the tooling surface (`single-story-close`, dispatcher, gates); propose remediations.
+description: Audit performance by measuring first — profile hot paths, I/O, memory, and payload against the repo's own numbers — and audit interleaving/partial-failure correctness (TOCTOU, unawaited promises, non-atomic writes) as a first-class dimension.
 ---
 
 # Performance & Bottleneck Audit
@@ -10,9 +10,23 @@ Performance Engineer & Systems Architect
 
 ## Context & Objective
 
-Analyze the application for performance regressions, bottlenecks, and efficiency
-gaps. Your goal is to identify why a system is slow or where it might fail under
-load.
+Find where a system is slow, wasteful, or unsafe under concurrency — and prove
+it with numbers, not opinions. This lens has three standing commitments that
+separate it from a prose read-through:
+
+1. **Measure before you judge.** A performance claim that is not backed by a
+   profile, a timing, or a byte count is a hypothesis, not a finding. Step 0
+   times the repo's own suite and entry points and produces the evidence every
+   finding must cite.
+2. **Adapt to the repo profile.** A CLI/tooling repo has no bundle and no Core
+   Web Vitals; a frontend app does. Step 1 detects the target profile and
+   activates only the dimensions that apply, declaring the rest inapplicable
+   rather than fabricating findings for a surface that does not exist.
+3. **Interleaving correctness is a performance concern.** The most expensive
+   defects this repo has shipped were not slow loops — they were races
+   (check-then-act on a lease, non-atomic checkout mutation under concurrent
+   close, shared-cache poisoning). Step 2 treats interleaving & partial-failure
+   correctness as a first-class dimension, statically and repo-observably.
 
 ## Scope (Story / plan-run mode)
 
@@ -38,72 +52,189 @@ before this section existed.
 ## Execution strategy (dual-path)
 
 This lens runs along one of two execution paths (orchestrated dynamic-workflow
-or sequential single-pass). Both emit the **identical** Step 3 report contract;
+or sequential single-pass). Both emit the **identical** Step 4 report contract;
 downstream consumers (`audit-to-stories`) are agnostic to which path produced
 it. See [`helpers/audit-dual-path.md`](helpers/audit-dual-path.md) for strategy
 selection, the forcing flags, and the read-only guarantee — read `audit-<lens>`
 there as this lens's name.
 
-## Step 1: Bottleneck Discovery
+> **Measurement is non-mutating, not forbidden.** This lens is read-only with
+> respect to source, but it MUST be allowed to *run* measurements. The
+> orchestrated path grants its measurement agents a `Bash` tool restricted to a
+> **non-mutating command allowlist** (profilers, timers, bundle-stat and
+> file-size probes — never a command that writes source, installs, or mutates
+> git/labels). See the allowlist in
+> [`.claude/workflows/audit-performance.workflow.js`](../../.claude/workflows/audit-performance.workflow.js).
 
-> Apply [`helpers/parallel-tooling.md`](helpers/parallel-tooling.md) when batching the scan below — independent reads belong in one turn, long shells run via `run_in_background` + `Monitor`.
+## Step 0: Measure before you judge (mandatory)
 
-Investigate the following areas:
+Produce evidence first; every finding in Step 4 carries an **Evidence** field
+that cites a repro command and tags itself `measured` or `estimated`. Run the
+measurements that apply to the repo (Step 1 tells you which), preferring the
+repo's own scripts over invented ones.
 
-- **Database/API Efficiency:** Look for N+1 query patterns, missing indexes, or
-  oversized JSON payloads.
-- **Frontend Rendering:** Identify unnecessary re-renders (in React/Vue), large
-  DOM trees, or layout thrashing.
-- **Bundle Size:** Check for heavy dependencies, missing code-splitting, or
-  unoptimized assets.
-- **Resource Usage:** Identify potential memory leaks or high CPU usage logic
-  (e.g., synchronous loops over large datasets).
-- **Network Path:** Check for excessive round-trips or lack of caching headers.
+**Timing (all repos).** Time the project's own test suite and any CLI entry
+points. Prefer `hyperfine` for stable multi-run statistics; fall back to
+`/usr/bin/time -v` (or `time`) when it is absent:
 
-## Step 2: Evaluation Dimensions
+```bash
+hyperfine --warmup 1 'npm test'            # suite wall-clock + variance
+hyperfine --warmup 1 'node bin/<entry>.js --help'   # CLI cold-start cost
+/usr/bin/time -v node bin/<entry>.js <args> 2>&1 | tail -n 20   # fallback + RSS
+```
 
-1. **Latency:** How long does it take for a user action to complete?
-2. **Throughput:** How many concurrent operations can the system handle before
-   degrading?
-3. **Efficiency:** Is the code using the minimum amount of CPU/Memory/Network
-   required?
-4. **Scalability:** Does the performance hold as the data size or user count
-   increases?
-5. **Core Web Vitals:** (For frontend) LCP, FID, and CLS metrics.
+**CPU profile (all repos).** Profile a detected entry script with the V8
+sampling profiler and read the hottest self-time frames:
 
-## Step 3: Output Requirements
+```bash
+node --cpu-prof --cpu-prof-dir=temp/audits/cpuprof bin/<entry>.js <args>
+```
+
+Then inspect the emitted `.cpuprofile` (the top self-time nodes) for the real
+hot path.
+
+**Payload / bundle (web repos only).** Emit build stats and size the shipped
+payload; do not estimate what the bundler will tell you exactly:
+
+```bash
+npx vite build --profile        # or the repo's own build script
+du -sh dist/ && find dist -name '*.js' -exec wc -c {} + | sort -n | tail
+```
+
+**Evidence discipline.** A finding tagged `measured` names the command above
+whose output produced its number. A finding tagged `estimated` (e.g. a
+Big-O argument read off the code without a runnable repro) says so plainly and
+is graded no higher than **Medium** unless a measurement upgrades it. Attach
+the repro command to the finding so the operator can reproduce it in one paste.
+
+### Step 0b: Perf baseline artifact + diff-aware trend
+
+Write a per-run baseline capturing the Step 0 numbers to
+`{{auditOutputDir}}/perf-baseline.json` (suite time, per-entry cold-start, RSS,
+bundle bytes where applicable, and the hot-frame list). On every run:
+
+- **Diff against the previous baseline** when one exists. A metric that
+  regressed past the previous run's value is an **automatic High** finding with
+  the delta (old → new, absolute and %) as its Evidence.
+- **Suppress unchanged known findings.** A finding whose measured value is
+  within noise of the prior baseline is reported as *unchanged* in a trend
+  summary line, not re-litigated as a fresh finding. New or regressed metrics
+  are what the run surfaces.
+- Record the baseline path and the trend verdict (`first-run` /
+  `improved` / `unchanged` / `regressed`) in the Executive Summary.
+
+## Step 1: Repo profile & active dimensions
+
+Detect the target profile from repo-observable markers, then activate only the
+dimensions that apply. Declare the inapplicable ones explicitly in the report
+(so a reader knows they were considered and ruled out, not forgotten).
+
+Detection signals:
+
+- A **CLI / tooling / library** repo — a `bin` field or executable entry
+  scripts, no framework marker, no frontend directory: bundle and Core Web
+  Vitals are **inapplicable**.
+- A **web / frontend** repo — a framework marker (`react`, `vue`, `svelte`,
+  `next`, `vite`, `webpack`) and/or a frontend surface (`src/components/**`,
+  `*.html`, `*.css`, a `dist/` build): payload/bundle and CWV **apply**.
+- A **service / backend** repo — server entry, route/controller/API surface:
+  I/O and interleaving dominate; bundle is **inapplicable**.
+
+The interleaving & partial-failure dimension and the CPU / I/O / memory
+dimensions apply to **every** profile. Only payload/bundle (and its re-homed
+CWV material) is web-gated.
+
+## Step 2: Analysis dimensions (orthogonal set)
+
+The historically overlapping ten dimensions collapse to four orthogonal
+resource dimensions plus one correctness dimension. Audit each *active*
+dimension (per Step 1) against measured evidence from Step 0.
+
+- **CPU & algorithmic hot paths:** super-linear complexity on a path that runs
+  under load, redundant recomputation, synchronous work blocking the event
+  loop. Ground every claim in a `--cpu-prof` hot frame or a timed repro.
+- **I/O & syscall efficiency:** N+1 queries/reads, unbatched network or
+  filesystem round-trips, missing caching, oversized payloads crossing a
+  boundary, chatty `fs` calls in a loop. Cite the call site and a timing.
+- **Memory & leaks:** unbounded caches/arrays, retained closures, listeners
+  never removed, growth across a repeated operation. Cite RSS from Step 0 or a
+  heap delta.
+- **Payload & bundle (web only):** heavy or duplicated dependencies, missing
+  code-splitting, unoptimized assets, render-blocking resources. Re-homed from
+  the retired lighthouse lens: capture a **per-route Core-Web-Vitals score
+  baseline** and measure with a **median-of-3** protocol (three runs, report
+  the median LCP/CLS/INP/TBT per route) so single-run variance never drives a
+  finding. Inapplicable — and omitted — on non-web repos.
+- **Interleaving & partial-failure correctness:** the concurrency dimension.
+  Statically, repo-observably, look for: unawaited / floating promises;
+  `Promise.all` over independently-failing branches where `allSettled` is
+  required; **check-then-act (TOCTOU)** on files, locks, labels, or uniqueness
+  constraints; non-atomic read-modify-write; in-place writes where
+  temp-file-plus-rename is required for crash-atomicity; missing
+  transaction/compensation around a multi-step write; non-idempotent retried
+  side effects; and shared-cache poisoning (one run writing state a concurrent
+  run reads). **Speculative races are the known failure mode of this
+  dimension** — a claimed race with no concrete interleaving and no
+  repo-observable shared-state path is a false positive; lean hard on the
+  self-cross-check to drop it.
+
+## Step 3: Severity rubric (performance-anchored)
+
+Grade every finding on the shared
+[`Critical | High | Medium | Low` scale](helpers/audit-severity-scale.md),
+anchored to performance/correctness cost rather than gut feel:
+
+- Grade **Critical** for a guaranteed data-loss or corruption path under normal
+  concurrency (e.g. a lost-update TOCTOU on persisted state), or a hang/outage
+  under expected load.
+- Grade **High** for a measured regression past the previous baseline (delta is
+  the Evidence), or a hot-path cost (frequency × per-call cost) on a path proven
+  to run under load, or a race with a concrete losing interleaving.
+- Grade **Medium** for a real but bounded cost: an `estimated`-only algorithmic
+  concern, a cold-path inefficiency, or a concurrency smell with a plausible but
+  unproven interleaving.
+- Grade **Low** for minor or opportunistic issues; fix when nearby.
+
+Latency thresholds, when a user-facing route is in scope, follow the CWV bands
+in the payload/bundle dimension (LCP ≤2.5s good / ≤4.0s needs-improvement).
+
+## Step 4: Output Requirements
 
 Generate and save a highly structured Markdown audit report to
 `{{auditOutputDir}}/audit-performance-results.md`, using the exact template
 below.
-
-> Grade every finding's severity on the shared
-> [`Critical | High | Medium | Low` scale](helpers/audit-severity-scale.md).
 
 ```markdown
 # Performance Audit Report
 
 ## Executive Summary
 
-[Overview of performance summary vs target benchmarks.]
+[Overview of performance posture vs the Step 0 measurements. State the repo
+profile detected (Step 1) and which dimensions were inapplicable. State the
+baseline trend verdict (first-run / improved / unchanged / regressed) and the
+`perf-baseline.json` path. Close with the self-cross-check `kept k / dropped d`
+line.]
 
 ## Detailed Findings
 
-[For every bottleneck identified, use the following strict structure. Lead each
-title with the primary file the bottleneck lives in:]
+[For every bottleneck or correctness defect identified, use the following
+strict structure. Lead each title with the primary file it lives in:]
 
-### `path/to/primary-file.ext` — [Short title of the bottleneck]
+### `path/to/primary-file.ext` — [Short title of the finding]
 
-- **Dimension:** [e.g., Latency | Throughput | Efficiency]
+- **Dimension:** [CPU & algorithmic | I/O | Memory & leaks | Payload & bundle | Interleaving & partial-failure]
 - **Impact:** [Critical | High | Medium | Low]
 - **Location:** `path/to/primary-file.ext:line`
-- **Current State:** [Technical explanation of where and why the bottleneck
-  occurs]
-- **Recommendation & Rationale:** [Specific optimization tactic and expected
-  performance gain]
-- **Acceptance signal:** [the command or observable that proves this finding is remediated — e.g. a benchmark below the target threshold, or a re-run of this lens]
+- **Evidence:** [A repro command from Step 0 (or a quoted code path) and a
+  `measured` or `estimated` tag — e.g. "`measured`: `hyperfine 'npm test'` →
+  regressed 8.1s → 11.4s (+40%) vs perf-baseline.json"]
+- **Current State:** [Technical explanation of where and why the bottleneck or
+  race occurs]
+- **Recommendation & Rationale:** [Specific optimization/fix tactic and the
+  expected gain or the interleaving it closes]
+- **Acceptance signal:** [the command or observable that proves this finding is remediated — e.g. a benchmark below the target threshold, a re-run of this lens showing the baseline no longer regressed, or a test exercising the losing interleaving]
 - **Agent Prompt:**
-  `[A copy-pasteable, highly specific prompt to execute this optimization independently]`
+  `[A copy-pasteable, highly specific prompt to execute this fix independently]`
 
 ## Low-Hanging Fruit
 
@@ -112,11 +243,13 @@ title with the primary file the bottleneck lives in:]
 
 ## Constraint
 
-This is a **read-only** audit. Note: This workflow differs from
-`audit-lighthouse.md` (which runs Lighthouse and reports per-category scores
-and findings) by focusing on deep architectural and logic bottlenecks across
-the whole stack — backend, data access, and runtime hot paths — rather than
-the page-load surface Lighthouse measures.
+This is a **read-only** audit **with respect to source**: it does not edit,
+create, or delete application code, dependencies, or configuration. It **does**
+run non-mutating measurements (Step 0) and writes exactly two artifacts — the
+report and `perf-baseline.json`. Note: this lens supersedes the retired
+`audit-lighthouse` lens by folding its measured Core-Web-Vitals material (the
+per-route score baseline and median-of-3 protocol) into the web branch of the
+payload/bundle dimension.
 
 ## Self-cross-check (mandatory — filter false positives before you finalize)
 
@@ -126,4 +259,6 @@ adversarial self-cross-check over your Detailed Findings — see
 per-finding evidence bar, the exclusion list, and the final re-open-and-drop
 pass whose `kept <k> / dropped <d>` counts you record in the Executive
 Summary, so the sequential single-pass path filters unverified findings just as
-the orchestrated path's adversarial reviewer does.
+the orchestrated path's adversarial reviewer does. The **interleaving**
+dimension leans on this pass hardest: drop every claimed race that lacks a
+concrete losing interleaving over a repo-observable shared-state path.

--- a/.claude/workflows/audit-performance.workflow.js
+++ b/.claude/workflows/audit-performance.workflow.js
@@ -48,13 +48,19 @@
  * the performance report-contract self-check — and delegates the fan-out
  * plumbing to the engine.
  *
- * ## Read-only guarantee
+ * ## Measurement allowlist (read source, run non-mutating measurements)
  *
- * The lens is read-only. Dynamic-workflow subagents run in `acceptEdits` and
- * inherit the session tool allowlist, but the engine grants the analysis
- * agents NO write/edit/shell-mutation tools — they receive only read/search
- * tools (`Read`, `Grep`, `Glob`). The single write in the run is the final
- * report artifact, performed by the synthesis stage.
+ * The lens is read-only **with respect to source** — the engine grants the
+ * analysis agents no write/edit tools and no source-mutating shell. But this
+ * lens must *measure* before it judges (the lens Step 0), so instead of
+ * stripping execution entirely it grants a `Bash` tool restricted to the
+ * {@link MEASUREMENT_COMMAND_ALLOWLIST}: profilers, timers, and size probes
+ * that read the repo's own numbers without mutating source, installing
+ * packages, or touching git/labels. The analysis agents receive
+ * {@link MEASUREMENT_TOOLS} (`Read`, `Grep`, `Glob`, `Bash`); the allowlist
+ * itself is embedded in every dimension prompt so the agent knows exactly which
+ * commands it may run. The single source *write* in the run is the final report
+ * artifact, performed by the synthesis stage.
  *
  * ## Scope parity
  *
@@ -98,26 +104,67 @@ const LENS_PATH = path.join(
 );
 
 /**
- * The independent analysis dimensions the lens decomposes into. These names
- * map 1:1 onto the lens's Step 1 "Bottleneck Discovery" bullets and Step 2
- * "Evaluation Dimensions"; each fans out to its own subagent so they run in
- * parallel and can be cross-checked independently.
+ * The orthogonal analysis dimensions the lens decomposes into. These map 1:1
+ * onto the lens's Step 2 "Analysis dimensions (orthogonal set)": the four
+ * resource dimensions plus the interleaving/partial-failure correctness
+ * dimension. Each fans out to its own subagent so they run in parallel and can
+ * be cross-checked independently. The historically overlapping ten dimensions
+ * (Latency / Throughput / Efficiency / Scalability / …) collapsed into these —
+ * Step 1 of the lens gates the web-only "Payload & bundle" dimension by repo
+ * profile.
  */
-const DIMENSIONS = Object.freeze([
-  'Latency',
-  'Throughput',
-  'Efficiency',
-  'Scalability',
-  'Database/API Efficiency',
-  'Frontend Rendering',
-  'Bundle Size',
-  'Resource Usage',
-  'Network Path',
-  'Core Web Vitals',
+export const DIMENSIONS = Object.freeze([
+  'CPU & algorithmic hot paths',
+  'I/O & syscall efficiency',
+  'Memory & leaks',
+  'Payload & bundle (web only)',
+  'Interleaving & partial-failure correctness',
 ]);
 
-/** Read-only tool allowlist for analysis agents — no write/edit/shell. */
-const READ_ONLY_TOOLS = Object.freeze(['Read', 'Grep', 'Glob']);
+/**
+ * Read/search tool allowlist for analysis agents — no write/edit, no shell.
+ * The measurement agents additionally receive `Bash` (see
+ * {@link MEASUREMENT_TOOLS}) constrained to {@link MEASUREMENT_COMMAND_ALLOWLIST}.
+ */
+export const READ_ONLY_TOOLS = Object.freeze(['Read', 'Grep', 'Glob']);
+
+/**
+ * The restricted, **non-mutating** shell command allowlist granted to the
+ * measurement agents. Each entry is a command prefix the agent may run to
+ * produce the Step 0 evidence every finding must cite. The set is deliberately
+ * narrow: profilers, timers, and size/stat probes that read the repo's own
+ * numbers. It grants nothing that writes source, installs dependencies, or
+ * mutates git refs / issue labels.
+ *
+ * The distinction the lens turns on: this list replaces the old
+ * "strip execution entirely" posture — the agent can now *measure*, but only
+ * with these commands.
+ */
+export const MEASUREMENT_COMMAND_ALLOWLIST = Object.freeze([
+  'hyperfine', // stable multi-run timing statistics
+  'time', // /usr/bin/time -v fallback timing + RSS
+  'node --cpu-prof', // V8 sampling profiler on an entry script
+  'node --prof', // legacy V8 profiler
+  'npm test', // time the repo's own suite (non-mutating to source)
+  'npm run test', // suite alias
+  'npx vite build --profile', // web bundle stats
+  'du', // directory / artifact size
+  'wc', // byte counts
+  'find', // enumerate + size shipped assets
+  'ls', // list build output
+  'stat', // file size / mtime probe
+  'cat', // read a profile / stats file
+  'git log', // read-only history (churn on a hot path)
+  'git diff', // read-only diff (never a mutation)
+]);
+
+/**
+ * The tool allowlist granted to the measurement (analysis) and cross-check
+ * agents: the read/search tools plus `Bash`. `Bash` is only useful in concert
+ * with {@link MEASUREMENT_COMMAND_ALLOWLIST}, which every dimension prompt
+ * embeds so the agent stays inside the non-mutating set.
+ */
+export const MEASUREMENT_TOOLS = Object.freeze([...READ_ONLY_TOOLS, 'Bash']);
 
 /**
  * Load the authoritative lens markdown so per-dimension prompts derive from
@@ -162,7 +209,13 @@ export function buildDimensionPrompt(dimension, lensSpec, scopeClause) {
   return [
     `You are auditing the codebase for the "${dimension}" performance`,
     'dimension only.',
-    'You are READ-ONLY: do not edit, create, or run mutating commands.',
+    'You do NOT edit, create, or delete source. You MAY run measurements, but',
+    'ONLY these non-mutating commands (Step 0 of the lens spec):',
+    ...MEASUREMENT_COMMAND_ALLOWLIST.map((cmd) => `  - ${cmd}`),
+    'Any other shell command is out of bounds — never install, write source,',
+    'or mutate git refs / issue labels. Every finding you return MUST carry an',
+    'Evidence field naming the repro command above whose output produced it,',
+    'tagged `measured` or `estimated`.',
     '',
     scopeClause,
     '',
@@ -173,10 +226,10 @@ export function buildDimensionPrompt(dimension, lensSpec, scopeClause) {
     lensSpec,
     '--- END LENS SPEC ---',
     '',
-    `Return ONLY the bottleneck findings for the "${dimension}" dimension,`,
-    'each as a `### <Short Title of the Bottleneck>` block using the exact',
-    'field structure from the lens Step 3 template (Dimension, Impact,',
-    'Current State, Recommendation & Rationale, Agent Prompt). Where the',
+    `Return ONLY the findings for the "${dimension}" dimension, each as a`,
+    '`### <Short Title>` block using the exact field structure from the lens',
+    'Step 4 template (Dimension, Impact, Location, Evidence, Current State,',
+    'Recommendation & Rationale, Acceptance signal, Agent Prompt). Where the',
     'bottleneck has a cheap, immediate remediation, also note it as a',
     'candidate quick win so the synthesis stage can populate the',
     '"Low-Hanging Fruit" section.',
@@ -228,8 +281,10 @@ export function buildSynthesisPrompt(crossCheckedBlocks, auditOutputDir) {
     `The report MUST open with "# ${REPORT_TITLE}" and contain these "##"`,
     `sections in order: ${REQUIRED_SECTIONS.join(', ')}.`,
     'Place each cross-checked `### <title>` finding under "## Detailed',
-    'Findings"; summarise overall performance posture vs target benchmarks',
-    'and the primary themes in "## Executive Summary"; and list 3 quick',
+    'Findings", preserving its Evidence field (repro command + measured/',
+    'estimated tag) verbatim; summarise overall performance posture vs the',
+    'Step 0 measurements, the detected repo profile, and the baseline trend',
+    'verdict in "## Executive Summary"; and list 3 quick',
     'changes that provide immediate performance gains under "## Low-Hanging',
     'Fruit". Sum the per-dimension `CROSS-CHECK: kept/dropped` lines and note',
     'the total dropped count in the Executive Summary so the benchmark can',
@@ -266,7 +321,7 @@ export default async function auditPerformanceWorkflow(ctx) {
   await runAuditOrchestration({
     ctx,
     dimensions: DIMENSIONS,
-    readOnlyTools: READ_ONLY_TOOLS,
+    readOnlyTools: MEASUREMENT_TOOLS,
     buildDimensionPrompt: (dimension) =>
       buildDimensionPrompt(dimension, lensSpec, scopeClause),
     buildCrossCheckPrompt,

--- a/tests/contract/performance-report-contract.test.js
+++ b/tests/contract/performance-report-contract.test.js
@@ -26,8 +26,12 @@ import {
   REQUIRED_SECTIONS,
 } from '../../.agents/scripts/lib/dynamic-workflow/performance-report-contract.js';
 import {
+  buildDimensionPrompt,
   buildScopeClause,
   buildSynthesisPrompt,
+  MEASUREMENT_COMMAND_ALLOWLIST,
+  MEASUREMENT_TOOLS,
+  READ_ONLY_TOOLS,
 } from '../../.claude/workflows/audit-performance.workflow.js';
 
 const REPO_ROOT = path.resolve(
@@ -145,6 +149,64 @@ test('buildScopeClause: a real file list → scoped analysis', () => {
   assert.match(clause, /Restrict analysis/i);
   assert.ok(clause.includes('src/a.js'));
   assert.ok(clause.includes('src/b.js'));
+});
+
+// --- AC-5: the orchestrated path can EXECUTE measurements -------------------
+
+test('measurement agents are granted Bash on top of the read-only trio', () => {
+  assert.ok(
+    MEASUREMENT_TOOLS.includes('Bash'),
+    'measurement agents must be granted Bash to run Step 0 measurements',
+  );
+  for (const tool of READ_ONLY_TOOLS) {
+    assert.ok(
+      MEASUREMENT_TOOLS.includes(tool),
+      `measurement allowlist dropped read-only tool ${tool}`,
+    );
+  }
+});
+
+test('the command allowlist is non-empty and holds only non-mutating commands', () => {
+  assert.ok(
+    MEASUREMENT_COMMAND_ALLOWLIST.length > 0,
+    'measurement command allowlist is empty — execution was stripped, not restricted',
+  );
+  // The measurement toolkit the lens Step 0 names must be present.
+  for (const cmd of ['hyperfine', 'node --cpu-prof']) {
+    assert.ok(
+      MEASUREMENT_COMMAND_ALLOWLIST.includes(cmd),
+      `measurement allowlist omits the Step 0 command "${cmd}"`,
+    );
+  }
+  // No mutating command may leak into a "non-mutating" allowlist.
+  const joined = MEASUREMENT_COMMAND_ALLOWLIST.join('\n');
+  for (const forbidden of [
+    'rm ',
+    'git commit',
+    'git push',
+    'git checkout',
+    'npm install',
+    'npm ci',
+    'sed -i',
+    'mv ',
+  ]) {
+    assert.ok(
+      !joined.includes(forbidden),
+      `measurement allowlist must not contain the mutating command "${forbidden.trim()}"`,
+    );
+  }
+});
+
+test('every dimension prompt embeds the allowlist and the Evidence requirement', () => {
+  const prompt = buildDimensionPrompt('CPU & algorithmic hot paths', LENS, '');
+  for (const cmd of MEASUREMENT_COMMAND_ALLOWLIST) {
+    assert.ok(
+      prompt.includes(cmd),
+      `dimension prompt does not surface allowlisted command "${cmd}"`,
+    );
+  }
+  assert.match(prompt, /Evidence field/i);
+  assert.match(prompt, /measured|estimated/i);
 });
 
 // --- downstream consumer parity --------------------------------------------


### PR DESCRIPTION
Closes #4631

_Auto-opened by `/deliver`._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to agent workflows, audit contracts, and tests; runtime product behavior is unchanged aside from broader audit triggers and agents being able to run allowlisted shell measurements during performance audits.
> 
> **Overview**
> **Reworks `/audit-performance`** from a prose bottleneck scan into a measurement-first protocol with repo profiling, baseline trending, and concurrency as a first-class audit dimension.
> 
> **Mandatory Step 0** requires timings (`hyperfine`, `node --cpu-prof`), optional web bundle probes, and a mandatory per-finding **Evidence** field (`measured` vs `estimated`, with estimated-only capped at Medium). Each run writes **`perf-baseline.json`**; regressions vs the prior baseline are automatic **High** findings and unchanged metrics are suppressed instead of re-litigated.
> 
> **Analysis collapses** the old ten overlapping dimensions into five orthogonal ones (CPU, I/O, memory, web-only payload/CWV with median-of-3, and **interleaving & partial-failure** covering TOCTOU, races, non-atomic writes). **Step 1** gates dimensions by detected repo profile (CLI vs web vs service).
> 
> The **orchestrated workflow** now grants analysis agents **`Bash`** under a **non-mutating command allowlist** (replacing read-only-only execution) so Step 0 can run in the dynamic path. **`performance-report-contract`** and generated docs/checklists/tests are updated to match; **`audit-rules.json`** gains broader performance/concurrency triggers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 800dc7f8c12dd8f197b68b542abdce31fa0bad4a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->