### PR TITLE
feat: audit-dependencies rework: implement the advertised checks, reachability-triaged vulns, and the supply-chain fold (#4632)

### DIFF
--- a/.agents/audit-checklists/dependencies.md
+++ b/.agents/audit-checklists/dependencies.md
@@ -10,5 +10,14 @@
 
 Self-check your change against this lens's concerns before you ship:
 
-- [ ] Inventory & Stale Check
-- [ ] Vulnerability Scan
+- [ ] Outdated inventory.
+- [ ] Unused dependencies.
+- [ ] Staleness.
+- [ ] Node-engine drift.
+- [ ] Two-pass audit diff.
+- [ ] Severity rubric.
+- [ ] Report shape — no flooding.
+- [ ] Enumerate the delta.
+- [ ] Provenance.
+- [ ] New install scripts.
+- [ ] Typosquat near-misses.

--- a/.agents/scripts/lib/audit-suite/__tests__/dependencies-routing.test.js
+++ b/.agents/scripts/lib/audit-suite/__tests__/dependencies-routing.test.js
@@ -1,0 +1,74 @@
+/**
+ * lib/audit-suite/__tests__/dependencies-routing.test.js — the audit-dependencies
+ * lockfile-routing selector gate (Story #4632).
+ *
+ * The reworked dependencies lens runs a supply-chain delta pass in its scoped
+ * mode, which only fires when a change set that bumps a lockfile actually
+ * selects the lens. That routing is data: the `filePatterns` on the
+ * `audit-dependencies` entry in `audit-rules.json`. This test pins the
+ * contract by driving the SAME `matchesAnyFilePattern` matcher `selectAudits`
+ * uses over the REAL on-disk manifest, so a future edit that drops the lockfile
+ * globs (or narrows them) fails here instead of silently disabling the
+ * supply-chain pass at close time.
+ */
+
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { describe, it } from 'node:test';
+import { fileURLToPath } from 'node:url';
+import { matchesAnyFilePattern } from '../selector.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const AUDIT_RULES_PATH = path.resolve(
+  __dirname,
+  '..',
+  '..',
+  '..',
+  '..',
+  'schemas',
+  'audit-rules.json',
+);
+
+/** @returns {string[]} the audit-dependencies entry's registered filePatterns. */
+function dependencyFilePatterns() {
+  const rules = JSON.parse(fs.readFileSync(AUDIT_RULES_PATH, 'utf8'));
+  const entry = rules.audits?.['audit-dependencies'];
+  assert.ok(entry, 'audit-dependencies is not registered in audit-rules.json');
+  return entry.triggers?.filePatterns ?? [];
+}
+
+describe('audit-dependencies lockfile routing (Story #4632)', () => {
+  it('selects the lens for a package-lock.json change', () => {
+    assert.equal(
+      matchesAnyFilePattern(dependencyFilePatterns(), ['package-lock.json']),
+      true,
+    );
+  });
+
+  it('selects the lens for a nested package-lock.json change', () => {
+    assert.equal(
+      matchesAnyFilePattern(dependencyFilePatterns(), [
+        'packages/api/package-lock.json',
+      ]),
+      true,
+    );
+  });
+
+  it('selects the lens for pnpm and yarn lockfiles', () => {
+    const patterns = dependencyFilePatterns();
+    assert.equal(matchesAnyFilePattern(patterns, ['pnpm-lock.yaml']), true);
+    assert.equal(matchesAnyFilePattern(patterns, ['yarn.lock']), true);
+  });
+
+  it('does not select the lens for an unrelated source-only change', () => {
+    assert.equal(
+      matchesAnyFilePattern(dependencyFilePatterns(), [
+        'src/index.js',
+        'docs/readme.md',
+      ]),
+      false,
+    );
+  });
+});

--- a/.agents/workflows/audit-dependencies.md
+++ b/.agents/workflows/audit-dependencies.md
@@ -35,23 +35,90 @@ before this section existed.
   proceed with the full codebase-wide scan defined in the remaining
   steps.
 
-## Step 1: Inventory & Stale Check
+## Step 1: Inventory, Staleness & Unused Detection
 
-> Apply [`helpers/parallel-tooling.md`](helpers/parallel-tooling.md) when batching the scan below — independent reads belong in one turn, long shells run via `run_in_background` + `Monitor`.
+> Apply [`helpers/parallel-tooling.md`](helpers/parallel-tooling.md) when batching the scans below — independent reads belong in one turn, long shells run via `run_in_background` + `Monitor`.
 
-1. Run `npm outdated` (or equivalent for the package manager) to see which
-   packages are behind.
-2. Identify "stale" dependencies (packages with no updates for >1 year).
-3. Check for "bloat" — large dependencies that could be replaced by smaller
-   alternatives or native code.
+Run each probe as a concrete, machine-readable command so the Health Summary
+counts are **exact** rather than eyeballed:
 
-## Step 2: Vulnerability Scan
+1. **Outdated inventory.** Run `npm outdated --json` (or the package
+   manager's equivalent). Every key is a behind package with its `current`,
+   `wanted`, and `latest` fields; the count of keys is the exact **Outdated
+   Packages** figure — never hand-count from prose.
+2. **Unused dependencies.** Run `npx knip --production` to find declared
+   dependencies with no import reachable from a production entry point.
+   ⚠️ **`knip --production` silent-no-op gotcha:** knip's `--production`
+   mode analyses nothing **unless the project's `entry` patterns carry a
+   `!` suffix** — without the bang-suffixed production entries it reports
+   `{"issues":[]}` and looks green while scanning zero files. Confirm the
+   consumer's knip config uses `!`-suffixed entries before trusting a clean
+   result; when it does not, fall back to `npx depcheck --json` and record
+   the config gap itself as a finding. Report each genuinely-unused
+   dependency as a `Removal` finding.
+3. **Staleness.** For each critical or outdated dependency, probe its last
+   publish with `npm view <pkg> time.modified` and flag any package with no
+   release in over a year as **stale** (unmaintained-supply-chain risk),
+   independent of whether a newer version exists.
+4. **Node-engine drift.** Compare the Node version declared across every
+   source of truth and flag any mismatch between them:
+   - `package.json` `engines.node`,
+   - `.nvmrc`,
+   - the CI matrix `node-version` entries under `.github/workflows/**`,
+   - the locally observed `node --version`.
+   A drift between any two (e.g. `.nvmrc` pinning `20` while the CI matrix
+   still tests `18`) is a finding: the floor the code is actually tested
+   against has diverged from the floor it advertises.
 
-1. Run `npm audit` to find security vulnerabilities.
-2. Cross-reference critical dependencies with known CVE databases if necessary.
-3. Highlight any peer dependency conflicts that might arise from upgrades.
+## Step 2: Reachability-triaged Vulnerability Scan
 
-## Step 3: Output Requirements
+A vulnerability in a build-only devDependency is not the same risk as one that
+ships to production. Triage every advisory by **production reachability**
+before grading it — this mirrors the security baseline's "reachable in
+production code" standard.
+
+1. **Two-pass audit diff.** Run `npm audit --json` (the full tree) **and**
+   `npm audit --json --omit=dev` (production-reachable only). An advisory
+   present in the full run but absent from the `--omit=dev` run is
+   **dev-only**; one present in both is **production-reachable**.
+2. **Severity rubric.** Grade each advisory on the shared
+   [`Critical | High | Medium | Low` scale](helpers/audit-severity-scale.md)
+   as a function of the advisory's own CVSS band, its reachability
+   (production-reachable escalates; dev-only caps at Medium), and its
+   dependency position (a direct dependency whose version you control is more
+   actionable than a deep transitive one).
+3. **Report shape — no flooding.** Emit **one finding per
+   production-reachable Critical or High advisory** — these are the ones that
+   gate a release. Collapse **all dev-only advisories into a single aggregate
+   finding** ("N dev-only advisories, no production reachability") rather than
+   one block per advisory, so dev-only noise never drowns the production
+   signal.
+
+## Step 3: Supply-chain scoped mode (lockfile-delta)
+
+When the `## Scope` block above resolved to a change-set file list **and that
+list contains a lockfile** (`package-lock.json`, `pnpm-lock.yaml`, or
+`yarn.lock`), run this lens as a **supply-chain delta pass** instead of a
+whole-manifest re-scan. The close-time question is not "what is stale across
+the whole repo" — it is "what just entered the dependency tree, and is it
+safe". Diff the lockfile against the base branch and analyse only the delta:
+
+1. **Enumerate the delta.** Run `git diff <base>...HEAD -- <lockfile>` and
+   list every **added** package and every **version-bumped** package the
+   change introduces. These are the only packages in scope for this pass.
+2. **Provenance.** Run `npm audit signatures` to verify the registry
+   signatures / provenance attestations of the installed tree, and flag any
+   added package that fails signature verification.
+3. **New install scripts.** Flag any added or bumped package that declares a
+   `preinstall`, `install`, or `postinstall` lifecycle script — arbitrary
+   code that runs at `npm install` time is the classic supply-chain execution
+   vector and warrants an explicit eyeball.
+4. **Typosquat near-misses.** Compare each **added** package name against the
+   existing dependency set and well-known package names for a near-miss
+   (single-character edits, dropped scopes, hyphen/underscore swaps) that
+   suggests a typosquat, and flag it.
+
+## Step 4: Output Requirements
 
 Generate and save a highly structured Markdown audit report to
 `{{auditOutputDir}}/audit-dependencies-results.md`, using the exact template
@@ -59,34 +126,67 @@ below.
 
 > Grade every finding's severity on the shared
 > [`Critical | High | Medium | Low` scale](helpers/audit-severity-scale.md).
+>
+> **Version-free titles (mandatory).** A finding title MUST NOT embed a
+> concrete version number — write ``### `package.json` — lodash unused``, not
+> ``… — lodash@4.17.20 unused``. Periodic re-runs of this lens re-detect the
+> same issue at a drifted version; a version-free title keeps the finding's
+> fingerprint stable so `audit-to-stories` dedupes it against the existing
+> Story instead of filing a fresh duplicate on every bump.
 
 ```markdown
 # Dependency Audit Report
 
 ## Health Summary
 
-- **Outdated Packages:** [Count]
-- **Vulnerabilities:** [Critical: #, High: #, Mod: #]
+- **Outdated Packages:** [exact count from `npm outdated --json`]
+- **Unused Dependencies:** [exact count from `npx knip --production` / `depcheck`]
+- **Vulnerabilities:** [Critical: #, High: #, Mod: #] (production-reachable / dev-only split)
+- **Node-engine drift:** [None | describe the mismatch across engines / .nvmrc / CI matrix]
 
 ## Detailed Findings
 
-[For every security fix or major update identified, use the following strict
-structure. Lead each title with the manifest the dependency lives in:]
+[For every production-reachable Critical/High advisory, unused dependency, or
+Node-engine drift, use the strict structure below. Lead each title with the
+manifest the dependency lives in, and keep the title version-free:]
 
-### `path/to/package.json` — [Package name update]
+### `path/to/package.json` — [Package name — issue, no version]
 
-- **Dimension:** [Security Fix | Major Upgrade | Removal]
+- **Dimension:** [Security Fix | Removal | Engine Drift | Major Upgrade | Supply-chain]
 - **Impact:** [Critical | High | Medium | Low]
 - **Location:** `path/to/package.json:line`
-- **Current State:** [Current vs Target version and reason for update]
-- **Recommendation & Rationale:** [How to perform the update and potential
-  breaking changes to watch for]
-- **Acceptance signal:** [the command or observable that proves this finding is remediated — e.g. `npm audit` reporting zero for this advisory, or a re-run of this lens]
+- **Current State:** [Current vs target, the reachability verdict (production-reachable | dev-only), and the reason for the change]
+- **Recommendation & Rationale:** [How to remediate and the breaking changes to watch for]
+- **Acceptance signal:** [the command or observable that proves this finding is remediated — e.g. `npm audit --omit=dev` reporting zero for this advisory, or `npx knip --production` no longer listing the package]
 - **Agent Prompt:**
-  `[A copy-pasteable, highly specific prompt to execute this update independently (e.g., npm install package@version)]`
+  `[A copy-pasteable, highly specific prompt to execute this update independently (e.g., npm install package@latest)]`
+
+### Dev-only advisories (aggregate)
+
+- **Dimension:** Security Fix
+- **Impact:** [Low | Medium]
+- **Location:** `package-lock.json`
+- **Current State:** [N dev-only advisories with no production reachability; not release-gating]
+- **Recommendation & Rationale:** [Batch-remediate on the next dependency-maintenance pass — do not block the release on these]
+- **Acceptance signal:** `npm audit --json` dev-only advisory count returns to zero.
+
+## Upgrade Batches
+
+Group the safe upgrade path into batches so a maintainer can act on them as
+discrete units. Each batch carries its own acceptance signal:
+
+- **Batch: patch + minor bumps** — every non-breaking `npm outdated` entry
+  whose `wanted` satisfies the declared range, grouped into ONE batch.
+  - **Acceptance signal:** `npm outdated` reports no remaining patch/minor
+    drift and the test suite passes after the bump.
+- **Batch: `<package>` major upgrade** — one batch **per** major bump (each
+  crosses a breaking boundary and lands independently).
+  - **Acceptance signal:** `<package>` at the new major with its migration
+    notes applied and the test suite green.
 
 ## Recommended Removals/Replacements
 
+- Remove `[unused-package]` — no production import per `npx knip --production`.
 - Replace `[heavy-library]` with `[light-library]` or native `[browser-api]`.
 ```
 


### PR DESCRIPTION
Closes #4632

_Auto-opened by `/deliver`._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and agent-workflow guidance only, with a manifest routing test; no application runtime or install behavior changes.
> 
> **Overview**
> **Reworks the `audit-dependencies` agent workflow** so the lens matches its advertised scope: machine-readable inventory (outdated JSON counts, `knip`/`depcheck` unused deps, publish staleness, Node engine drift), **production-reachability–triaged** `npm audit` (full vs `--omit=dev`, per-advisory vs aggregated dev-only noise), and a **scoped lockfile-delta supply-chain pass** (diff delta, signatures, install scripts, typosquat checks) when close-time changes include a lockfile.
> 
> The **report template and checklist** are expanded accordingly—health summary fields, version-free finding titles for dedupe, upgrade batches, and new finding dimensions—plus a **routing contract test** that asserts `audit-dependencies` in `audit-rules.json` still selects on npm/pnpm/yarn lockfile paths via `matchesAnyFilePattern`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 65e67d8392ea55b248a338d70f47640b28b24b72. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->