### PR TITLE
test(audit): make dispatch-checklist path assertions platform-agnostic (refs #4627)

### DIFF
--- a/tests/audit-suite/dispatch-checklist.test.js
+++ b/tests/audit-suite/dispatch-checklist.test.js
@@ -14,6 +14,7 @@
  */
 
 import assert from 'node:assert/strict';
+import path from 'node:path';
 import test from 'node:test';
 
 import { buildDispatchChecklist } from '../../.agents/scripts/lib/audit-suite/index.js';
@@ -92,11 +93,17 @@ test('writes the payload to <runTempDir>/story-<id>-checklist.md and returns the
     writeFileFn: (filePath, content) => writes.push({ filePath, content }),
   });
 
-  assert.equal(out.checklistPath, 'temp/run-abc/story-4627-checklist.md');
+  assert.equal(
+    out.checklistPath,
+    path.join('temp/run-abc', 'story-4627-checklist.md'),
+  );
   assert.equal(out.skipped, false);
   assert.deepEqual(out.includedLenses, ['clean-code']);
   assert.equal(writes.length, 1);
-  assert.equal(writes[0].filePath, 'temp/run-abc/story-4627-checklist.md');
+  assert.equal(
+    writes[0].filePath,
+    path.join('temp/run-abc', 'story-4627-checklist.md'),
+  );
   assert.equal(writes[0].content, '# checklist\n\n- do the thing');
 });
 
@@ -142,7 +149,10 @@ test('integration: real payload builder assembles a footprint-matched checklist'
     writeFileFn: (filePath, content) => writes.push({ filePath, content }),
   });
 
-  assert.equal(out.checklistPath, 'temp/run-int/story-4627-checklist.md');
+  assert.equal(
+    out.checklistPath,
+    path.join('temp/run-int', 'story-4627-checklist.md'),
+  );
   assert.equal(out.skipped, false);
   assert.ok(
     out.includedLenses.length >= 1,


### PR DESCRIPTION
## Why

The advisory **Windows Smoke** CI leg ([run 29700256177](https://github.com/dsj1984/mandrel/actions/runs/29700256177)) failed two assertions in `tests/audit-suite/dispatch-checklist.test.js` — a test added by Story #4627 (write-time checklist threading). All 1096 tests *passed*, but a `node --test` chunk exited non-zero on two path-separator mismatches:

```
expected: 'temp/run-abc/story-4627-checklist.md'   (hardcoded POSIX literal)
actual:   'temp\run-abc\story-4627-checklist.md'   (path.join output on Windows)
```

The production code is correct: [`dispatch-checklist.js:129`](.agents/scripts/lib/audit-suite/dispatch-checklist.js) builds `checklistPath` with `path.join(runTempDir, ...)`, which yields native separators — a local temp path the same host writes and the worker reads. The bug was in the test, which hardcoded forward slashes in three assertions, so it passed on the Linux/macOS legs and failed only on Windows. Because Windows Smoke is an *advisory* (non-required) check, this slipped through the audit-suite Stories' auto-merges.

## What

Build the expected value with `path.join(...)` too, so it normalizes identically on every platform. Test-only change; no production behavior change.

## Verify

- `node --test tests/audit-suite/dispatch-checklist.test.js` → 6/6 pass (unchanged on macOS)
- `npx biome ci tests/audit-suite/dispatch-checklist.test.js` → clean
- Fixes the Windows Smoke `Fast Test Slice` failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only assertion updates with no runtime or production behavior change.
> 
> **Overview**
> Fixes **Windows Smoke** failures in `dispatch-checklist.test.js` where three assertions compared `checklistPath` and write `filePath` against hardcoded POSIX strings (`temp/run-abc/...`) while production already builds those paths with `path.join`.
> 
> The test now imports `node:path` and builds expected paths with `path.join(runTempDir, 'story-4627-checklist.md')` in the write-path and integration cases, so expectations match native separators on Windows and Unix. **No production code changes.**
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 30e1a882ea8d181b77727f0b43446e404930a354. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->