### PR TITLE
fix(retro): mark story-blocked and merge-wait-exhausted recovered at post-land, and gate merge-wait-exhausted on real budget exhaustion (#4654)

### DIFF
--- a/.agents/scripts/lib/observability/runtime-friction.js
+++ b/.agents/scripts/lib/observability/runtime-friction.js
@@ -202,16 +202,20 @@ export async function emitBlockRecoveredFriction({
 }
 
 /**
- * Emit the recovery counterpart of a `close-failed` record when a Story's
- * close ultimately lands (Story #4649).
+ * Emit the recovery counterpart of an earlier friction record in `category`
+ * when a Story ultimately lands, netting a transient incident out of the
+ * retro (generalized from the `close-failed`-only emitter of Story #4649 by
+ * Story #4654).
  *
- * A close that fails once — CI/lease contention, a transient GitHub fault —
- * and succeeds on a later attempt still fired a `close-failed` record at the
- * failed terminal, which the composer counts exactly like a close that never
- * recovered. This is the `close-failed` analogue of
- * {@link emitBlockRecoveredFriction}: same `recovered: true` discriminator,
- * same category (a distinct bucket would itself aggregate into a routable
- * proposal, re-introducing the noise).
+ * An incident that fires once — a transient block, a CI/lease/GitHub fault at
+ * close, a merge wait that outran one window — but is provably resolved by the
+ * time the Story lands still left an un-netted record on the stream, which the
+ * composer counts exactly like an incident that never recovered. This appends
+ * the companion record carrying the `recovered: true` discriminator in the
+ * **same** `category` (a distinct bucket would itself aggregate into a routable
+ * proposal, re-introducing the noise), so `netOutRecoveredIncidents` /
+ * `deriveUnresolvedBlockedEvents` in `retro-proposals.js` can cancel the whole
+ * `(category, storyId)` incident out.
  *
  * **Why this is not emitted from `frictionForTerminal`.** A `landed` terminal
  * envelope is emitted at the very END of close — *after* the post-land tail
@@ -220,39 +224,54 @@ export async function emitBlockRecoveredFriction({
  * produced it. So the emit hangs off `runPostLandTail`, which is the single
  * shared land point (reached from both the in-close land and the standalone
  * `single-story-confirm-merge.js` resume) and runs BEFORE follow-up capture.
+ * The tail runs *because* the PR merged, so every incident on the stream is
+ * provably resolved at that point.
  *
- * **Conditional on an actual failure.** The marker is appended only when the
- * Story's stream already carries an un-recovered `close-failed`. Emitting
- * unconditionally on every land would write a `close-failed` row for Stories
- * whose close never failed — a category-mislabelled record — and, because the
- * netting is per `(category, storyId)` over the cumulative stream, that
- * spurious marker would suppress the Story's `close-failed` bucket outright,
- * making the category un-routable at story scope for a Story that never had
- * a close failure at all.
+ * **Conditional on an actual incident.** The marker is appended only when the
+ * Story's stream already carries an un-recovered record in `category`. Emitting
+ * unconditionally on every land would write a category-mislabelled row for
+ * Stories that never had the incident — and, because the netting is per
+ * `(category, storyId)` over the cumulative stream, that spurious marker would
+ * suppress the Story's whole bucket for `category`, making it un-routable at
+ * story scope for a Story that never hit the incident at all.
  *
  * What this guard does NOT do is bound the netting once a *legitimate* marker
  * exists. The netting inherits the Story #4622 coarsening — per
  * `(category, storyId)` across the whole stream, not 1:1 pairing — so a
- * later, genuinely un-landed `close-failed` for a Story that already
+ * later, genuinely un-landed record in `category` for a Story that already
  * recovered once is still netted away, and does not even reach `discarded`.
  * Reaching that needs a re-close after a land (a confirm-merge resume, or a
  * close after a revert). Deliberate, inherited, and called out here rather
  * than papered over: an aggregate is a routing heuristic, not an incident
  * ledger.
  *
- * Best-effort; never throws. A read failure yields no marker (the failure
+ * Best-effort; never throws. A read failure yields no marker (the incident
  * stays counted) rather than a speculative write.
  *
  * @param {object} args
  * @param {number} args.storyId
+ * @param {string} args.category One of {@link RUNTIME_FRICTION_CATEGORIES}.
+ * @param {string} [args.tool]   Emitting surface (default `runPostLandTail`).
  * @param {object} [args.config]
  * @returns {Promise<boolean>} true when a record was appended.
  */
-export async function emitCloseRecoveredFriction({ storyId, config } = {}) {
+export async function emitRecoveredFrictionMarker({
+  storyId,
+  category,
+  tool,
+  config,
+} = {}) {
   const sid = positiveIntOrNull(storyId);
   if (sid === null) return false;
+  if (typeof category !== 'string' || category.trim() === '') {
+    Logger.warn(
+      '[runtime-friction] refusing to emit a category-less recovery marker',
+    );
+    return false;
+  }
+  const cat = category.trim();
 
-  let failed = false;
+  let incident = false;
   let recovered = false;
   try {
     await forEachLine(
@@ -260,30 +279,48 @@ export async function emitCloseRecoveredFriction({ storyId, config } = {}) {
       sid,
       (parsed) => {
         if (!parsed || typeof parsed !== 'object') return;
-        if (parsed.category !== RUNTIME_FRICTION_CATEGORIES.CLOSE_FAILED) {
-          return;
-        }
+        if (parsed.category !== cat) return;
         if (isRecoveredSignal(parsed)) recovered = true;
-        else failed = true;
+        else incident = true;
       },
       config,
     );
   } catch (err) {
     Logger.warn(
-      `[runtime-friction] close-recovery probe failed for Story #${sid}: ${
+      `[runtime-friction] ${cat} recovery probe failed for Story #${sid}: ${
         err instanceof Error ? err.message : String(err)
       }`,
     );
     return false;
   }
   // Nothing to cancel, or already cancelled — a second marker would be noise.
-  if (!failed || recovered) return false;
+  if (!incident || recovered) return false;
 
   return emitRuntimeFriction({
     storyId: sid,
-    category: RUNTIME_FRICTION_CATEGORIES.CLOSE_FAILED,
-    tool: 'runPostLandTail',
+    category: cat,
+    tool: tool || 'runPostLandTail',
     details: { recovered: true },
+    config,
+  });
+}
+
+/**
+ * Emit the recovery counterpart of a `close-failed` record when a Story's
+ * close ultimately lands (Story #4649). Thin wrapper over
+ * {@link emitRecoveredFrictionMarker} bound to the `close-failed` category —
+ * retained as its own export so the post-land seam that injects it stays
+ * stable.
+ *
+ * @param {object} args
+ * @param {number} args.storyId
+ * @param {object} [args.config]
+ * @returns {Promise<boolean>} true when a record was appended.
+ */
+export async function emitCloseRecoveredFriction({ storyId, config } = {}) {
+  return emitRecoveredFrictionMarker({
+    storyId,
+    category: RUNTIME_FRICTION_CATEGORIES.CLOSE_FAILED,
     config,
   });
 }
@@ -368,12 +405,21 @@ export function isRecoveredSignal(signal) {
  *     would count the same block twice.
  *   - `landed`   → null. Nothing happened worth a retro.
  *   - `failed`   → friction. A close that ended non-zero.
- *   - `pending`  → friction **only when a `waitBudget` was exhausted**. That
- *     is the parked worker from the report: a bounded wait expired with the
- *     PR in flight and a human must resume it. A `pending` with **no**
- *     `waitBudget` is the `--no-wait-merge` / operator-merge path, where the
- *     human deliberately owns the land and nothing is broken — flagging it
- *     would train operators to ignore the channel.
+ *   - `pending`  → friction **only when the cumulative wait budget is provably
+ *     exhausted** (`waitBudget.cumulativeSeconds >= waitBudget.maxBudgetSeconds`).
+ *     A `pending` return is reached at the per-invocation `maxWaitSeconds`
+ *     bound (`phases/confirm-merge.js`); genuine cumulative exhaustion returns
+ *     earlier as a **blocked** terminal via `blockOnUnlanded` (Story #4654).
+ *     So a routine long-CI window rollover under budget is NOT exhaustion and
+ *     emits nothing — its category name would otherwise assert an exhaustion
+ *     that did not occur. Only the residual case the merge-wait guard cannot
+ *     suppress — a merge that genuinely spends its whole budget and lands on a
+ *     later resume — reaches here. A missing or non-numeric `cumulativeSeconds`
+ *     / `maxBudgetSeconds` means exhaustion cannot be proven → emit nothing. A
+ *     `pending` with **no** `waitBudget` is the `--no-wait-merge` /
+ *     operator-merge path, where the human deliberately owns the land and
+ *     nothing is broken — flagging it would train operators to ignore the
+ *     channel.
  *
  * Deliberately **not exported**: it is this module's internal policy, and
  * `emitTerminalFriction` is the contract callers (and tests) exercise. An
@@ -398,6 +444,21 @@ function frictionForTerminal(envelope) {
   }
 
   if (status === 'pending' && waitBudget) {
+    // Only a PROVEN cumulative-budget exhaustion is friction. The `pending`
+    // return is reached at the per-invocation `maxWaitSeconds` bound, not at
+    // the cumulative `maxBudgetSeconds` (that returns a blocked terminal
+    // earlier), so a routine window rollover carries `cumulativeSeconds`
+    // still under budget — emit nothing. A missing/non-numeric field means
+    // exhaustion cannot be proven, which is likewise not a record.
+    const cumulativeSeconds = Number(waitBudget.cumulativeSeconds);
+    const maxBudgetSeconds = Number(waitBudget.maxBudgetSeconds);
+    if (
+      !Number.isFinite(cumulativeSeconds) ||
+      !Number.isFinite(maxBudgetSeconds) ||
+      cumulativeSeconds < maxBudgetSeconds
+    ) {
+      return null;
+    }
     return {
       category: RUNTIME_FRICTION_CATEGORIES.MERGE_WAIT_EXHAUSTED,
       details: {

--- a/.agents/scripts/lib/orchestration/single-story-close/phases/post-land.js
+++ b/.agents/scripts/lib/orchestration/single-story-close/phases/post-land.js
@@ -33,7 +33,11 @@ import path from 'node:path';
 
 import { gitSpawn as defaultGitSpawn } from '../../../git-utils.js';
 import { Logger } from '../../../Logger.js';
-import { emitCloseRecoveredFriction as defaultEmitCloseRecoveredFriction } from '../../../observability/runtime-friction.js';
+import {
+  emitCloseRecoveredFriction as defaultEmitCloseRecoveredFriction,
+  emitRecoveredFrictionMarker as defaultEmitRecoveredFrictionMarker,
+  RUNTIME_FRICTION_CATEGORIES,
+} from '../../../observability/runtime-friction.js';
 import { acquireLockWithWait as defaultAcquireLockWithWait } from '../../../single-story-sweep/sweep-lock.js';
 import {
   executeFastForward as defaultExecuteFastForward,
@@ -252,6 +256,7 @@ async function stepBaseFastForward({
  * @param {(tag: string, msg: string) => void} [args.progress]
  * @param {Function} [args.captureStoryFollowUpsFn] Test seam.
  * @param {Function} [args.emitCloseRecoveredFrictionFn] Test seam.
+ * @param {Function} [args.emitRecoveredFrictionMarkerFn] Test seam.
  * @param {Function} [args.reassertStatusColumnFn]  Test seam.
  * @param {Function} [args.gitSpawnFn]              Test seam.
  * @param {Function} [args.planFastForwardFn]       Test seam.
@@ -269,6 +274,7 @@ export async function runPostLandTail({
   progress,
   captureStoryFollowUpsFn = defaultCaptureStoryFollowUps,
   emitCloseRecoveredFrictionFn = defaultEmitCloseRecoveredFriction,
+  emitRecoveredFrictionMarkerFn = defaultEmitRecoveredFrictionMarker,
   reassertStatusColumnFn = defaultReassertStatusColumn,
   gitSpawnFn = defaultGitSpawn,
   planFastForwardFn = defaultPlanFastForward,
@@ -277,13 +283,31 @@ export async function runPostLandTail({
 }) {
   progress?.('POST-LAND', `🧾 Running land tail for Story #${storyId}...`);
 
-  // Story #4649 — the close landed, so any earlier `close-failed` for this
-  // Story was transient. Emit the recovery marker BEFORE follow-up capture
+  // The close landed, so every friction incident on this Story's stream is
+  // provably resolved. Emit the recovery markers BEFORE follow-up capture
   // reads the stream: the `landed` terminal envelope is emitted after this
   // whole tail, so a marker written there would arrive too late to net
-  // anything out of the very run that produced the failure. Best-effort and
-  // never throws, exactly like every other tail step.
+  // anything out of the very run that produced the incident. Each emit is
+  // conditional on an un-recovered record already present, so a Story that
+  // never hit the incident gets no spurious (and bucket-suppressing) row.
+  //   - `close-failed`         — Story #4649.
+  //   - `story-blocked`        — a Story that blocked then reached
+  //     `agent::done` (Story #4654); resolves the occurrence-1 force-file.
+  //   - `merge-wait-exhausted` — a merge that spent its whole budget and
+  //     landed on a later resume (Story #4654); the residual case the
+  //     `frictionForTerminal` budget guard cannot suppress at the source.
+  // Best-effort and never throws, exactly like every other tail step.
   await emitCloseRecoveredFrictionFn({ storyId, config });
+  await emitRecoveredFrictionMarkerFn({
+    storyId,
+    category: RUNTIME_FRICTION_CATEGORIES.STORY_BLOCKED,
+    config,
+  });
+  await emitRecoveredFrictionMarkerFn({
+    storyId,
+    category: RUNTIME_FRICTION_CATEGORIES.MERGE_WAIT_EXHAUSTED,
+    config,
+  });
 
   const followUps = await step(
     () =>

--- a/tests/lib/observability/runtime-friction.test.js
+++ b/tests/lib/observability/runtime-friction.test.js
@@ -26,6 +26,7 @@ import { afterEach, beforeEach, describe, it } from 'node:test';
 import {
   emitBlockRecoveredFriction,
   emitCloseRecoveredFriction,
+  emitRecoveredFrictionMarker,
   emitRuntimeFriction,
   emitTerminalFriction,
   isRecoveredSignal,
@@ -86,7 +87,11 @@ describe('terminal-envelope friction policy', () => {
     assert.match(row.details.reason, /lint gate exploded/);
   });
 
-  it('flags a pending terminal whose wait budget was exhausted (the parked worker)', async () => {
+  it('flags a pending terminal whose CUMULATIVE budget is exhausted (the parked worker)', async () => {
+    // AC-4 — genuine exhaustion (cumulativeSeconds >= maxBudgetSeconds) still
+    // routes, so the residual case the source-side guard cannot suppress (a
+    // merge that spends its whole budget and lands on a later resume) stays
+    // observable.
     const row = await emitAndRead({
       storyId: 8,
       status: 'pending',
@@ -95,7 +100,7 @@ describe('terminal-envelope friction policy', () => {
       waitBudget: {
         maxWaitSeconds: 600,
         waitedSeconds: 600,
-        cumulativeSeconds: 1800,
+        cumulativeSeconds: 3600,
         maxBudgetSeconds: 3600,
       },
     });
@@ -104,7 +109,57 @@ describe('terminal-envelope friction policy', () => {
       RUNTIME_FRICTION_CATEGORIES.MERGE_WAIT_EXHAUSTED,
     );
     assert.equal(row.details.prNumber, 21);
-    assert.equal(row.details.cumulativeSeconds, 1800);
+    assert.equal(row.details.cumulativeSeconds, 3600);
+  });
+
+  it('does NOT flag a pending window rollover still under cumulative budget', async () => {
+    // AC-3 — the routine long-CI rollover the category name wrongly claimed.
+    // The `pending` return is reached at the per-invocation `maxWaitSeconds`
+    // bound with `cumulativeSeconds` still under `maxBudgetSeconds`, so it is
+    // NOT exhaustion and must emit nothing.
+    assert.equal(
+      await emitAndRead({
+        storyId: 12,
+        status: 'pending',
+        phase: 'confirm-merge',
+        pr: { number: 21, checksStatus: 'PENDING' },
+        waitBudget: {
+          maxWaitSeconds: 600,
+          waitedSeconds: 600,
+          cumulativeSeconds: 1800,
+          maxBudgetSeconds: 3600,
+        },
+      }),
+      null,
+    );
+  });
+
+  it('does NOT flag a pending whose budget fields cannot prove exhaustion', async () => {
+    // A missing/non-numeric cumulativeSeconds or maxBudgetSeconds means
+    // exhaustion is unproven → emit nothing (never a speculative record).
+    assert.equal(
+      await emitAndRead({
+        storyId: 13,
+        status: 'pending',
+        phase: 'confirm-merge',
+        pr: { number: 21, checksStatus: 'PENDING' },
+        waitBudget: { maxWaitSeconds: 600, waitedSeconds: 600 },
+      }),
+      null,
+    );
+    assert.equal(
+      await emitAndRead({
+        storyId: 14,
+        status: 'pending',
+        phase: 'confirm-merge',
+        pr: { number: 21, checksStatus: 'PENDING' },
+        waitBudget: {
+          cumulativeSeconds: 'nonsense',
+          maxBudgetSeconds: 3600,
+        },
+      }),
+      null,
+    );
   });
 
   it('does NOT flag a --no-wait-merge pending (operator owns the land; nothing is broken)', async () => {
@@ -384,6 +439,84 @@ describe('close-recovery friction (Story #4649)', () => {
     assert.equal(filed.length, 1, 'no land, no netting — it still routes');
     assert.equal(filed[0].category, 'close-failed');
     assert.equal(filed[0].occurrences, 2);
+  });
+});
+
+describe('emitRecoveredFrictionMarker (generalized, Story #4654)', () => {
+  const MWE = RUNTIME_FRICTION_CATEGORIES.MERGE_WAIT_EXHAUSTED;
+  const BLOCKED = RUNTIME_FRICTION_CATEGORIES.STORY_BLOCKED;
+
+  /** Put one un-recovered record in `category` on the Story's stream. */
+  const seed = (storyId, category) =>
+    emitRuntimeFriction({
+      storyId,
+      category,
+      tool: 'test',
+      details: { reason: 'boom' },
+      config,
+    });
+
+  it('marks any category conditionally — a seeded merge-wait-exhausted nets out', async () => {
+    await seed(5401, MWE);
+    const ok = await emitRecoveredFrictionMarker({
+      storyId: 5401,
+      category: MWE,
+      config,
+    });
+    assert.equal(ok, true);
+    const rows = await readStorySignals(5401);
+    assert.equal(rows.length, 2);
+    assert.equal(rows[1].category, MWE);
+    assert.equal(rows[1].details.recovered, true);
+  });
+
+  it('writes nothing when the category never fired (keeps the bucket routable)', async () => {
+    // The conditional probe is what prevents a spurious marker from
+    // suppressing a category for a Story that never hit the incident.
+    const ok = await emitRecoveredFrictionMarker({
+      storyId: 5402,
+      category: BLOCKED,
+      config,
+    });
+    assert.equal(ok, false);
+    assert.deepEqual(await readStorySignals(5402), []);
+  });
+
+  it('does not write a second marker when one is already present (idempotent)', async () => {
+    await seed(5403, BLOCKED);
+    assert.equal(
+      await emitRecoveredFrictionMarker({
+        storyId: 5403,
+        category: BLOCKED,
+        config,
+      }),
+      true,
+    );
+    assert.equal(
+      await emitRecoveredFrictionMarker({
+        storyId: 5403,
+        category: BLOCKED,
+        config,
+      }),
+      false,
+    );
+    assert.equal((await readStorySignals(5403)).length, 2);
+  });
+
+  it('refuses an unusable story id or category rather than throwing', async () => {
+    assert.equal(
+      await emitRecoveredFrictionMarker({ storyId: 0, category: MWE, config }),
+      false,
+    );
+    assert.equal(
+      await emitRecoveredFrictionMarker({
+        storyId: 5404,
+        category: '  ',
+        config,
+      }),
+      false,
+    );
+    assert.equal(await emitRecoveredFrictionMarker(), false);
   });
 });
 

--- a/tests/lib/orchestration/story-follow-ups.test.js
+++ b/tests/lib/orchestration/story-follow-ups.test.js
@@ -12,8 +12,10 @@ import {
   composeRoutedProposals,
   deriveUnresolvedBlockedEvents,
 } from '../../../.agents/scripts/lib/orchestration/retro-proposals.js';
+import { runPostLandTail } from '../../../.agents/scripts/lib/orchestration/single-story-close/phases/post-land.js';
 import {
   buildFollowUpsCommentBody,
+  captureStoryFollowUps,
   gatherStoryFrictionSignals,
   resolveFollowUpRepos,
 } from '../../../.agents/scripts/lib/orchestration/story-follow-ups.js';
@@ -148,6 +150,116 @@ describe('gatherStoryFrictionSignals field preservation (Story #4649)', () => {
       { framework: [], consumer: [], discarded: [] },
       'a Story that blocked and self-resolved files nothing',
     );
+  });
+});
+
+describe('post-land recovery marking end-to-end (Story #4654)', () => {
+  let tempRoot;
+  let config;
+
+  beforeEach(async () => {
+    tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'post-land-recover-'));
+    // Disable auto-filing so the graduator is a no-op (no `gh` calls) and the
+    // assertions read the composed proposals, not a live GitHub filing.
+    config = {
+      project: { paths: { tempRoot } },
+      delivery: { feedbackLoop: { retroProposals: false } },
+    };
+  });
+
+  afterEach(async () => {
+    await fs.rm(tempRoot, { recursive: true, force: true });
+  });
+
+  /** A ticketing provider fake sufficient for `upsertStructuredComment`. */
+  function fakeProvider() {
+    let nextId = 1;
+    return {
+      getTicketComments: async () => [],
+      postComment: async () => ({ id: nextId++ }),
+      deleteComment: async () => {},
+    };
+  }
+
+  /**
+   * Run only the recovery-marker emits of the tail against a real temp tree:
+   * every git/GitHub/status/lock step is stubbed so the emits (defaulted to
+   * the real functions, threaded `config`) are the only side effect.
+   */
+  const landTail = (storyId) =>
+    runPostLandTail({
+      storyId,
+      storyBranch: `story-${storyId}`,
+      baseBranch: 'main',
+      cwd: tempRoot,
+      provider: {},
+      config,
+      captureStoryFollowUpsFn: async () => ({ ok: true }),
+      reassertStatusColumnFn: async () => ({ status: 'synced' }),
+      gitSpawnFn: () => ({ status: 1 }),
+      planFastForwardFn: () => ({
+        runnable: false,
+        reason: 'already-up-to-date',
+      }),
+      executeFastForwardFn: () => ({ applied: true, behind: 0 }),
+      acquireLockWithWaitFn: async () => ({
+        acquired: true,
+        release: () => {},
+        ownerId: 't',
+      }),
+    });
+
+  const seed = (storyId, category) =>
+    emitRuntimeFriction({
+      storyId,
+      category,
+      tool: 'test',
+      details: { reason: 'boom' },
+      config,
+    });
+
+  it('AC-1: a Story that blocked then landed files no story-blocked follow-up', async () => {
+    await seed(5501, RUNTIME_FRICTION_CATEGORIES.STORY_BLOCKED);
+    await landTail(5501);
+
+    const result = await captureStoryFollowUps({
+      storyId: 5501,
+      provider: fakeProvider(),
+      config,
+    });
+    assert.equal(result.ok, true);
+    const filed = [...result.proposals.framework, ...result.proposals.consumer];
+    assert.ok(
+      !filed.some((i) => i.category === 'story-blocked'),
+      'no story-blocked proposal survives the recovery marker',
+    );
+    assert.equal(result.graduated.filed.length, 0);
+  });
+
+  it('AC-2: the marker is conditional — a Story that never blocked gains no story-blocked row', async () => {
+    await landTail(5502);
+    const rows = await gatherStoryFrictionSignals(5502, config);
+    assert.deepEqual(rows, [], 'no spurious marker suppresses a clean bucket');
+  });
+
+  it('AC-5: three merge-wait-exhausted records that then land file no follow-up', async () => {
+    await seed(5503, RUNTIME_FRICTION_CATEGORIES.MERGE_WAIT_EXHAUSTED);
+    await seed(5503, RUNTIME_FRICTION_CATEGORIES.MERGE_WAIT_EXHAUSTED);
+    await seed(5503, RUNTIME_FRICTION_CATEGORIES.MERGE_WAIT_EXHAUSTED);
+    await landTail(5503);
+
+    const result = await captureStoryFollowUps({
+      storyId: 5503,
+      provider: fakeProvider(),
+      config,
+    });
+    assert.equal(result.ok, true);
+    const filed = [...result.proposals.framework, ...result.proposals.consumer];
+    assert.ok(
+      !filed.some((i) => i.category === 'merge-wait-exhausted'),
+      'genuine exhaustion clears the ≥2 threshold but is netted by the marker',
+    );
+    assert.equal(result.graduated.filed.length, 0);
   });
 });
 


### PR DESCRIPTION
Closes #4654

_Auto-opened by `/deliver`._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability and retro routing only; best-effort emits with existing guards against spurious markers. No auth, merge, or delivery control-path changes.
> 
> **Overview**
> Reduces false-positive retro friction by netting transient incidents when a Story ultimately lands, and by tightening when merge-wait exhaustion is recorded.
> 
> **Post-land recovery (Story #4654):** `emitCloseRecoveredFriction` is generalized to `emitRecoveredFrictionMarker`, which appends a `details.recovered: true` row in the **same** category only if the stream already has an un-recovered incident. `runPostLandTail` now calls this for `story-blocked` and `merge-wait-exhausted` (in addition to `close-failed`) **before** follow-up capture, so blocked-then-landed Stories and merge waits that later succeed do not file follow-ups.
> 
> **Merge-wait emission:** `frictionForTerminal` no longer treats every `pending` terminal with a `waitBudget` as `merge-wait-exhausted`. It only emits when `cumulativeSeconds >= maxBudgetSeconds`; routine per-invocation window rollovers still under the cumulative cap emit nothing, as do budgets that cannot prove exhaustion.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 96d06021c16dd275ebefc9e385f18a48adad728a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->