### PR TITLE
chore(deps): resolve high-severity npm audit advisories (brace-expansion, js-yaml)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2259,9 +2259,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
@@ -3907,9 +3907,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
## Why

`npm audit --audit-level=high` is failing on `main` (HEAD `037a1a5b`), which fails the required **Validate and Test** check on *every* open PR — it blocked delivery of Stories #4654 and #4657. Three transitive dev-dependency advisories:

- **brace-expansion** (via `minimatch`) — [GHSA-3jxr-9vmj-r5cp](https://github.com/advisories/GHSA-3jxr-9vmj-r5cp) (DoS)
- **js-yaml** (via `markdownlint-cli2`) — [GHSA-52cp-r559-cp3m](https://github.com/advisories/GHSA-52cp-r559-cp3m) (quadratic CPU)

## What

A **lockfile-only** `npm audit fix` (non-breaking): `js-yaml` dedupes to `4.3.0` — satisfying both the direct `^4.2.0` dependency and `markdownlint-cli2@0.22.1` — and `brace-expansion` to `5.0.7`. No `package.json` change and **no** markdownlint-cli2 major; npm's `--force` suggestion was unnecessary.

## Verified green

`npm audit` (0 vulnerabilities) · `npm test` (8111 pass / 0 fail) · `npm run lint` · `npm run lint:md` (110 files, 0 errors) · `check-baselines` (exit 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Transitive dev-dependency patch bumps in the lockfile only; no application or runtime dependency manifest changes.
> 
> **Overview**
> **Lockfile-only** dependency bumps to clear high-severity `npm audit` failures that were blocking CI on every PR.
> 
> `brace-expansion` moves **5.0.6 → 5.0.7** (transitive via `minimatch`, DoS advisory) and `js-yaml` **4.2.0 → 4.3.0** (transitive via `markdownlint-cli2`, quadratic CPU advisory). **`package.json` is unchanged** — this is a non-breaking `npm audit fix` with no major tooling upgrades.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b4dced87b7052afc088c77bcd0f971c0e95737b7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->