### PR TITLE
fix(feedback-loop): repair the graduator idempotency probe — an HTML-comment-wrapped search query never matches, so every rollup re-files (#4657)

### DIFF
--- a/.agents/scripts/lib/feedback-loop/audit-results-graduator.js
+++ b/.agents/scripts/lib/feedback-loop/audit-results-graduator.js
@@ -97,7 +97,9 @@ function metaSourceLabel(source) {
  * ({@link buildContentMarker}) at the Story #4415 cutover, but still
  * probed for so follow-ups filed before the cutover are recognized and
  * not re-filed. An HTML comment so it survives markdown rendering without
- * leaking into the visible body, but stays indexable via `gh search`.
+ * leaking into the visible body; the idempotency probe strips the comment
+ * delimiters before querying `gh search` (the raw `<!-- … -->` form never
+ * matches the index — Story #4657).
  *
  * @param {number} epicId
  * @param {number} index — zero-based finding ordinal within the Epic.
@@ -112,7 +114,10 @@ export function buildIdempotencyMarker(epicId, index) {
  * follow-up bodies. Derived from the finding's `lens|path|summary` triple
  * so the marker is stable across sibling insert/remove/reorder churn in
  * the source `audit-results` comment (Story #4415). An HTML comment so it
- * survives markdown rendering but stays indexable via `gh search`.
+ * survives markdown rendering without leaking into the visible body; the
+ * idempotency probe strips the comment delimiters before querying
+ * `gh search` (the raw `<!-- … -->` form never matches the index —
+ * Story #4657).
  *
  * @param {number} epicId
  * @param {{ lens?: string, path?: string, summary?: string }} finding

--- a/.agents/scripts/lib/feedback-loop/graduator-core.js
+++ b/.agents/scripts/lib/feedback-loop/graduator-core.js
@@ -288,7 +288,7 @@ export async function probePathStatus({
  * @param {string} marker
  * @returns {string}
  */
-export function normalizeMarkerQuery(marker) {
+function normalizeMarkerQuery(marker) {
   if (typeof marker !== 'string') return '';
   return marker.replaceAll('<!--', '').replaceAll('-->', '').trim();
 }
@@ -361,7 +361,7 @@ export async function probeMarkerExists({
  * @param {number} [opts.timeoutMs]
  * @returns {Promise<boolean>}
  */
-export async function confirmMarkerFiled({
+async function confirmMarkerFiled({
   marker,
   owner,
   repo,

--- a/.agents/scripts/lib/feedback-loop/graduator-core.js
+++ b/.agents/scripts/lib/feedback-loop/graduator-core.js
@@ -274,11 +274,33 @@ export async function probePathStatus({
 }
 
 /**
+ * Normalize an idempotency marker into a `gh search issues` query. Markers
+ * are HTML comments (`<!-- … -->`) so they survive markdown rendering
+ * without leaking into the visible body, but the `<` / `>` delimiters are
+ * NOT index-safe as a query: GitHub full-text search DOES index the text
+ * inside an HTML comment, yet a query that carries the `<!--` / `-->`
+ * delimiters never matches that indexed text (measured against this repo,
+ * Story #4657). Stripping the delimiters and trimming yields the bare marker
+ * text — `retro-proposal-followup: epic-1-<fp>` — which the index matches.
+ * The caller-facing marker is left untouched; normalization is the probe's
+ * own concern.
+ *
+ * @param {string} marker
+ * @returns {string}
+ */
+export function normalizeMarkerQuery(marker) {
+  if (typeof marker !== 'string') return '';
+  return marker.replaceAll('<!--', '').replaceAll('-->', '').trim();
+}
+
+/**
  * Probe whether a follow-up issue carrying the given idempotency marker
  * already exists in the routed repo. Uses `gh search issues` so we hit
- * the body field directly. Returns `true` when at least one match is
- * present; degrades to `false` on any spawn/parse error (better to risk
- * a duplicate than swallow the finding entirely).
+ * the body field directly, querying the delimiter-stripped marker text
+ * (see {@link normalizeMarkerQuery}) — the raw `<!-- … -->` form never
+ * matches the index. Returns `true` when at least one match is present;
+ * degrades to `false` on any spawn/parse error (better to risk a duplicate
+ * than swallow the finding entirely).
  */
 export async function probeMarkerExists({
   marker,
@@ -292,7 +314,7 @@ export async function probeMarkerExists({
   const args = [
     'search',
     'issues',
-    marker,
+    normalizeMarkerQuery(marker),
     '--repo',
     `${owner}/${repo}`,
     '--json',
@@ -307,6 +329,71 @@ export async function probeMarkerExists({
   try {
     const parsed = JSON.parse(res.stdout || '[]');
     return Array.isArray(parsed) && parsed.length > 0;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Strongly-consistent confirmation that a follow-up carrying `marker`
+ * already exists, run ONLY on the would-file path as the last gate before
+ * creating. `gh search issues` reads an eventually-consistent index whose
+ * catch-up latency (measured under 20s against this repo, Story #4657) is
+ * exactly wide enough to miss a byte-identical duplicate filed seconds
+ * earlier in the same rollup. A label-scoped `gh issue list … --state all`
+ * is strongly consistent, so it closes that window. The list is narrowed by
+ * the follow-up's own labels (supplied by the same `spec.buildFollowUp` that
+ * writes the marker, so the two agree by construction) to keep the read
+ * bounded, and the marker is matched as a substring of each returned body.
+ *
+ * Degrades to `false` (i.e. proceed to file) on any spawn/parse error — the
+ * deliberate degrade-toward-filing posture: an undecidable probe risks a
+ * duplicate rather than swallowing the finding.
+ *
+ * @param {object} opts
+ * @param {string} opts.marker — the content-hash marker embedded in the body.
+ * @param {string} opts.owner
+ * @param {string} opts.repo
+ * @param {string[]} [opts.labels] — the follow-up's labels; scopes the list.
+ * @param {string} [opts.ghPath]
+ * @param {Function} [opts.spawnImpl]
+ * @param {string} [opts.cwd]
+ * @param {number} [opts.timeoutMs]
+ * @returns {Promise<boolean>}
+ */
+export async function confirmMarkerFiled({
+  marker,
+  owner,
+  repo,
+  labels,
+  ghPath,
+  spawnImpl,
+  cwd,
+  timeoutMs,
+}) {
+  const args = [
+    'issue',
+    'list',
+    '--repo',
+    `${owner}/${repo}`,
+    '--state',
+    'all',
+    '--json',
+    'number,body',
+  ];
+  for (const label of Array.isArray(labels) ? labels : []) {
+    args.push('--label', label);
+  }
+  const res = await runChild({ cmd: ghPath, args, spawnImpl, cwd, timeoutMs });
+  if (res.spawnError || (typeof res.code === 'number' && res.code !== 0)) {
+    return false;
+  }
+  try {
+    const parsed = JSON.parse(res.stdout || '[]');
+    if (!Array.isArray(parsed)) return false;
+    return parsed.some(
+      (issue) => typeof issue?.body === 'string' && issue.body.includes(marker),
+    );
   } catch {
     return false;
   }
@@ -421,21 +508,22 @@ async function loadGraduateFindings({ epicId, provider, spec }) {
 /**
  * Probe whether a finding was already filed, checking both the current
  * content-hash marker AND the legacy `(epicId, parse-index)` marker so
- * findings filed before the fingerprint cutover are not re-filed. Returns
- * the content-hash marker (embedded in a freshly filed body) alongside the
- * `alreadyFiled` decision.
+ * findings filed before the fingerprint cutover are not re-filed. The
+ * content-hash marker is passed in precomputed so a caller can consult an
+ * in-process memo before spending a spawn. Returns the `alreadyFiled`
+ * decision.
  */
 async function resolveAlreadyFiled({
   finding,
   epicId,
   routedRepo,
+  contentMarker,
   ghPath,
   spawnImpl,
   cwd,
   timeoutMs,
   spec,
 }) {
-  const contentMarker = spec.buildContentMarker(epicId, finding);
   const probe = (marker) =>
     probeMarkerExists({
       marker,
@@ -448,17 +536,17 @@ async function resolveAlreadyFiled({
     });
 
   if (await probe(contentMarker)) {
-    return { alreadyFiled: true, contentMarker };
+    return { alreadyFiled: true };
   }
   // Legacy recognition — a pre-cutover follow-up carries the ordinal
   // marker, not the content hash. Skip re-filing when it is present.
   if (typeof spec.buildLegacyMarker === 'function') {
     const legacyMarker = spec.buildLegacyMarker(epicId, finding.index);
     if (legacyMarker && (await probe(legacyMarker))) {
-      return { alreadyFiled: true, contentMarker };
+      return { alreadyFiled: true };
     }
   }
-  return { alreadyFiled: false, contentMarker };
+  return { alreadyFiled: false };
 }
 
 /**
@@ -483,6 +571,7 @@ async function processGraduateFinding({
   timeoutMs,
   maxFilingsPerRun,
   crossRepoDeferred,
+  filedMarkers,
   logger,
   spec,
 }) {
@@ -531,10 +620,20 @@ async function processGraduateFinding({
     return skip('cross-repo-deferred');
   }
 
-  const { alreadyFiled, contentMarker } = await resolveAlreadyFiled({
+  const contentMarker = spec.buildContentMarker(epicId, finding);
+
+  // In-process memo (Story #4657): a marker already filed earlier in THIS
+  // invocation — e.g. the framework bucket of a retro rollup that also has
+  // the same category in the consumer bucket — short-circuits a repeat in a
+  // later bucket without spending a single spawn, and closes the same-rollup
+  // race the eventually-consistent search index cannot.
+  if (filedMarkers?.has(contentMarker)) return skip('already-filed');
+
+  const { alreadyFiled } = await resolveAlreadyFiled({
     finding,
     epicId,
     routedRepo,
+    contentMarker,
     ghPath,
     spawnImpl,
     cwd,
@@ -548,12 +647,37 @@ async function processGraduateFinding({
   // a re-run picks it up next time.
   if (envelope.filed.length >= maxFilingsPerRun) return skip('cap-reached');
 
+  // Resolve the follow-up (title/body/labels) BEFORE the dedup decision so
+  // the strong read can scope its `gh issue list` by the very labels this
+  // filing would carry (they agree with the marker by construction).
   const { title, body, labels } = spec.buildFollowUp({
     finding,
     source,
     epicId,
     idMarker: contentMarker,
   });
+
+  // Strong read (would-file path only, Story #4657): the search probe reads
+  // an eventually-consistent index that can miss a byte-identical duplicate
+  // filed seconds earlier. Confirm against a strongly-consistent,
+  // label-scoped `gh issue list` before creating. Skipped entirely on the
+  // already-filed path above, so it never fires when the search probe
+  // already matched.
+  const confirmed = await confirmMarkerFiled({
+    marker: contentMarker,
+    owner: routedRepo.owner,
+    repo: routedRepo.repo,
+    labels,
+    ghPath,
+    spawnImpl,
+    cwd,
+    timeoutMs,
+  });
+  if (confirmed) {
+    filedMarkers?.add(contentMarker);
+    return skip('already-filed');
+  }
+
   const created = await createFollowUpIssue({
     owner: routedRepo.owner,
     repo: routedRepo.repo,
@@ -571,6 +695,7 @@ async function processGraduateFinding({
     );
     return;
   }
+  filedMarkers?.add(contentMarker);
   envelope.filed.push(
     decorate(
       {
@@ -681,6 +806,11 @@ async function persistCrossRepoDeferred({
  * @param {Array<object>} [opts.findings] — pre-parsed findings; when
  *   provided, the structured-comment read/parse is bypassed (the retro
  *   auto-filer seam).
+ * @param {Set<string>} [opts.filedMarkers] — in-process memo of content
+ *   markers filed so far. Pass a shared Set across multiple `graduate()`
+ *   calls in one logical invocation (e.g. the retro graduator's two source
+ *   buckets) so a marker filed in one call short-circuits a repeat in the
+ *   next without a spawn. Defaults to a fresh per-call Set.
  * @param {{info?: Function, warn?: Function, debug?: Function}} [opts.logger]
  * @param {object} opts.spec — the per-graduator behaviour bundle
  * @returns {Promise<{ filed: object[], skipped: object[], errors: string[] }>}
@@ -699,6 +829,7 @@ export async function graduate({
   timeoutMs = DEFAULT_RUN_CHILD_TIMEOUT_MS,
   maxFilingsPerRun = DEFAULT_MAX_FILINGS_PER_RUN,
   findings: preParsedFindings,
+  filedMarkers = new Set(),
   logger,
   spec,
 }) {
@@ -745,6 +876,7 @@ export async function graduate({
       timeoutMs,
       maxFilingsPerRun,
       crossRepoDeferred,
+      filedMarkers,
       logger,
       spec,
     });

--- a/.agents/scripts/lib/feedback-loop/retro-proposals-graduator.js
+++ b/.agents/scripts/lib/feedback-loop/retro-proposals-graduator.js
@@ -54,7 +54,9 @@ export const isAutoFileEnabled = makeIsAutoFileEnabled('retroProposals');
  * are path-less and the rendered title embeds a mutable recurrence count)
  * so the marker is stable across sibling insert/remove/reorder churn AND
  * across re-runs that change the count. An HTML comment so it survives
- * markdown rendering but stays indexable via `gh search`.
+ * markdown rendering without leaking into the visible body; the idempotency
+ * probe strips the comment delimiters before querying `gh search` (the raw
+ * `<!-- … -->` form never matches the index — Story #4657).
  *
  * @param {number} epicId
  * @param {{ category?: string, title?: string }} finding
@@ -223,6 +225,13 @@ export async function graduateRetroProposals({
     { source: 'consumer', items: consumer },
   ];
 
+  // One memo of content markers filed so far, SHARED across both buckets: the
+  // two scopes mint an identical marker for the same category by construction
+  // (Story #4657), so without it the framework and consumer buckets could each
+  // file the same category. The shared set makes the second bucket short-
+  // circuit the repeat with no spawn.
+  const filedMarkers = new Set();
+
   let remaining = maxFilingsPerRun;
   for (const { source, items } of buckets) {
     if (items.length === 0) continue;
@@ -242,6 +251,7 @@ export async function graduateRetroProposals({
       timeoutMs,
       maxFilingsPerRun: Math.max(0, remaining),
       findings,
+      filedMarkers,
       logger,
       spec: makeSpec(source),
     });

--- a/tests/lib/feedback-loop/graduator-core.test.js
+++ b/tests/lib/feedback-loop/graduator-core.test.js
@@ -17,11 +17,9 @@ import { EventEmitter } from 'node:events';
 import { describe, it } from 'node:test';
 
 import {
-  confirmMarkerFiled,
   createFollowUpIssue,
   graduate,
   makeIsAutoFileEnabled,
-  normalizeMarkerQuery,
   probeMarkerExists,
   probePathStatus,
   runChild,
@@ -339,23 +337,12 @@ describe('graduate (parametrized walk)', () => {
 /**
  * Story #4657 — the idempotency probe repair. The wrapped `<!-- … -->`
  * marker form never matched the search index; these pin the delimiter
- * normalization, the strong-read confirmation on the would-file path, and
- * the preserved degrade-toward-filing posture.
+ * normalization (via the exported `probeMarkerExists` seam), the strong-read
+ * confirmation on the would-file path, and the preserved degrade-toward-
+ * filing posture (via the exported `graduate` seam). The delimiter stripper
+ * and the strong-read helper are internal to the module and exercised
+ * through those two public seams rather than imported directly.
  */
-describe('normalizeMarkerQuery (Story #4657)', () => {
-  it('strips the HTML-comment delimiters and trims', () => {
-    assert.equal(
-      normalizeMarkerQuery('<!-- retro-proposal-followup: epic-1-abc -->'),
-      'retro-proposal-followup: epic-1-abc',
-    );
-  });
-
-  it('is a no-op string for a non-string input', () => {
-    assert.equal(normalizeMarkerQuery(undefined), '');
-    assert.equal(normalizeMarkerQuery(null), '');
-  });
-});
-
 describe('probeMarkerExists — query normalization (AC-1)', () => {
   it('never sends comment delimiters to the search index', async () => {
     const spawnImpl = makeSpawnStub({
@@ -380,52 +367,6 @@ describe('probeMarkerExists — query normalization (AC-1)', () => {
     assert.ok(
       searchCall.args.includes('retro-proposal-followup: epic-1-abc'),
       'the undelimited marker text is the query',
-    );
-  });
-});
-
-describe('confirmMarkerFiled — strong read (Story #4657)', () => {
-  it('matches the marker as a substring of a returned body and scopes by label', async () => {
-    const marker = '<!-- audit-results-followup: epic-1-abc -->';
-    const spawnImpl = makeSpawnStub({
-      ghList: () => ({
-        stdout: JSON.stringify([{ number: 9, body: `head\n${marker}\ntail` }]),
-        code: 0,
-      }),
-    });
-    const found = await confirmMarkerFiled({
-      marker,
-      owner: 'o',
-      repo: 'r',
-      labels: ['meta::audit-finding', 'audit-results::low'],
-      ghPath: 'gh',
-      spawnImpl,
-    });
-    assert.equal(found, true);
-    const listCall = spawnImpl.calls.find(
-      (c) => c.args[0] === 'issue' && c.args[1] === 'list',
-    );
-    // The list is strongly consistent (--state all) and label-scoped.
-    assert.ok(listCall.args.includes('--state'));
-    assert.ok(listCall.args.includes('all'));
-    assert.ok(listCall.args.includes('--label'));
-    assert.ok(listCall.args.includes('meta::audit-finding'));
-  });
-
-  it('degrades to false (proceed to file) on a spawn error', async () => {
-    const spawnImpl = () => {
-      throw new Error('gh missing');
-    };
-    assert.equal(
-      await confirmMarkerFiled({
-        marker: 'm',
-        owner: 'o',
-        repo: 'r',
-        labels: [],
-        ghPath: 'gh',
-        spawnImpl,
-      }),
-      false,
     );
   });
 });
@@ -527,6 +468,18 @@ describe('graduate — dedup dispatch (Story #4657)', () => {
     assert.ok(
       !spawnImpl.calls.some((c) => c.args[1] === 'create'),
       'createFollowUpIssue was never spawned',
+    );
+    // The strong read is a strongly-consistent (`--state all`), label-scoped
+    // `gh issue list` — scoped by the labels the follow-up would carry.
+    const listCall = spawnImpl.calls.find(
+      (c) => c.args[0] === 'issue' && c.args[1] === 'list',
+    );
+    assert.ok(listCall, 'a gh issue list strong read ran');
+    assert.ok(
+      listCall.args.includes('--state') && listCall.args.includes('all'),
+    );
+    assert.ok(
+      listCall.args.includes('--label') && listCall.args.includes('lbl'),
     );
   });
 

--- a/tests/lib/feedback-loop/graduator-core.test.js
+++ b/tests/lib/feedback-loop/graduator-core.test.js
@@ -17,9 +17,11 @@ import { EventEmitter } from 'node:events';
 import { describe, it } from 'node:test';
 
 import {
+  confirmMarkerFiled,
   createFollowUpIssue,
   graduate,
   makeIsAutoFileEnabled,
+  normalizeMarkerQuery,
   probeMarkerExists,
   probePathStatus,
   runChild,
@@ -45,6 +47,10 @@ function makeSpawnStub(routes) {
     } else if (args[0] === 'search') {
       result = routes.ghSearch
         ? routes.ghSearch(args)
+        : { stdout: '[]', stderr: '', code: 0 };
+    } else if (args[0] === 'issue' && args[1] === 'list') {
+      result = routes.ghList
+        ? routes.ghList(args)
         : { stdout: '[]', stderr: '', code: 0 };
     } else if (args[0] === 'issue' && args[1] === 'create') {
       result = routes.ghCreate
@@ -327,5 +333,253 @@ describe('graduate (parametrized walk)', () => {
     });
     assert.equal(env.filed.length, 0);
     assert.match(env.errors[0], /provider down/);
+  });
+});
+
+/**
+ * Story #4657 — the idempotency probe repair. The wrapped `<!-- … -->`
+ * marker form never matched the search index; these pin the delimiter
+ * normalization, the strong-read confirmation on the would-file path, and
+ * the preserved degrade-toward-filing posture.
+ */
+describe('normalizeMarkerQuery (Story #4657)', () => {
+  it('strips the HTML-comment delimiters and trims', () => {
+    assert.equal(
+      normalizeMarkerQuery('<!-- retro-proposal-followup: epic-1-abc -->'),
+      'retro-proposal-followup: epic-1-abc',
+    );
+  });
+
+  it('is a no-op string for a non-string input', () => {
+    assert.equal(normalizeMarkerQuery(undefined), '');
+    assert.equal(normalizeMarkerQuery(null), '');
+  });
+});
+
+describe('probeMarkerExists — query normalization (AC-1)', () => {
+  it('never sends comment delimiters to the search index', async () => {
+    const spawnImpl = makeSpawnStub({
+      ghSearch: () => ({ stdout: '[]', code: 0 }),
+    });
+    await probeMarkerExists({
+      marker: '<!-- retro-proposal-followup: epic-1-abc -->',
+      owner: 'o',
+      repo: 'r',
+      ghPath: 'gh',
+      spawnImpl,
+    });
+    const searchCall = spawnImpl.calls.find((c) => c.args[0] === 'search');
+    assert.ok(searchCall, 'a gh search issues call was made');
+    for (const arg of searchCall.args) {
+      assert.ok(
+        !arg.includes('<!--') && !arg.includes('-->'),
+        `no search arg carries comment delimiters: ${arg}`,
+      );
+    }
+    // And the query is the bare marker text the index actually matches.
+    assert.ok(
+      searchCall.args.includes('retro-proposal-followup: epic-1-abc'),
+      'the undelimited marker text is the query',
+    );
+  });
+});
+
+describe('confirmMarkerFiled — strong read (Story #4657)', () => {
+  it('matches the marker as a substring of a returned body and scopes by label', async () => {
+    const marker = '<!-- audit-results-followup: epic-1-abc -->';
+    const spawnImpl = makeSpawnStub({
+      ghList: () => ({
+        stdout: JSON.stringify([{ number: 9, body: `head\n${marker}\ntail` }]),
+        code: 0,
+      }),
+    });
+    const found = await confirmMarkerFiled({
+      marker,
+      owner: 'o',
+      repo: 'r',
+      labels: ['meta::audit-finding', 'audit-results::low'],
+      ghPath: 'gh',
+      spawnImpl,
+    });
+    assert.equal(found, true);
+    const listCall = spawnImpl.calls.find(
+      (c) => c.args[0] === 'issue' && c.args[1] === 'list',
+    );
+    // The list is strongly consistent (--state all) and label-scoped.
+    assert.ok(listCall.args.includes('--state'));
+    assert.ok(listCall.args.includes('all'));
+    assert.ok(listCall.args.includes('--label'));
+    assert.ok(listCall.args.includes('meta::audit-finding'));
+  });
+
+  it('degrades to false (proceed to file) on a spawn error', async () => {
+    const spawnImpl = () => {
+      throw new Error('gh missing');
+    };
+    assert.equal(
+      await confirmMarkerFiled({
+        marker: 'm',
+        owner: 'o',
+        repo: 'r',
+        labels: [],
+        ghPath: 'gh',
+        spawnImpl,
+      }),
+      false,
+    );
+  });
+});
+
+describe('graduate — dedup dispatch (Story #4657)', () => {
+  const currentRepo = { owner: 'o', repo: 'r' };
+
+  // The content marker the minimal spec embeds, in wrapped form.
+  const wrappedMarker = (epicId, index) => `<!-- f-${epicId}-${index} -->`;
+
+  it('AC-2: identifies the marker via the undelimited search query', async () => {
+    const provider = {
+      getTicketComments: async () => [{ body: '<!-- test-marker --> FIND' }],
+    };
+    // Match ONLY on the undelimited marker text — a wrapped query never hits.
+    const spawnImpl = makeSpawnStub({
+      git: () => ({ code: 0 }),
+      ghSearch: (args) => ({
+        stdout: args[2] === 'f-42-0' ? '[{"number":3}]' : '[]',
+        code: 0,
+      }),
+    });
+    const env = await graduate({
+      epicId: 42,
+      provider,
+      currentRepo,
+      classifier: () => 'consumer',
+      spawnImpl,
+      spec: makeSpec(),
+    });
+    assert.equal(env.filed.length, 0, 'no filing when already present');
+    assert.equal(env.skipped[0]?.reason, 'already-filed');
+    // The search query carried no delimiters.
+    const searchCall = spawnImpl.calls.find((c) => c.args[0] === 'search');
+    assert.equal(searchCall.args[2], 'f-42-0');
+    // No create was attempted.
+    assert.ok(!spawnImpl.calls.some((c) => c.args[1] === 'create'));
+  });
+
+  it('AC-3: legacy ordinal markers get the same normalization', async () => {
+    const provider = {
+      getTicketComments: async () => [{ body: '<!-- test-marker --> FIND' }],
+    };
+    // Content marker absent; the legacy marker is present — matched only in
+    // its undelimited form.
+    const spawnImpl = makeSpawnStub({
+      git: () => ({ code: 0 }),
+      ghSearch: (args) => ({
+        stdout: args[2] === 'legacy-f-1-0' ? '[{"number":4}]' : '[]',
+        code: 0,
+      }),
+    });
+    const env = await graduate({
+      epicId: 1,
+      provider,
+      currentRepo,
+      classifier: () => 'consumer',
+      spawnImpl,
+      spec: makeSpec(),
+    });
+    assert.equal(env.filed.length, 0);
+    assert.equal(env.skipped[0]?.reason, 'already-filed');
+    const legacySearch = spawnImpl.calls.find(
+      (c) => c.args[0] === 'search' && c.args[2] === 'legacy-f-1-0',
+    );
+    assert.ok(legacySearch, 'the legacy marker was probed undelimited');
+    assert.ok(
+      !legacySearch.args.some((a) => a.includes('<!--') || a.includes('-->')),
+      'the legacy query carried no delimiters',
+    );
+  });
+
+  it('AC-4: a duplicate inside the search-index window is caught by the strong read', async () => {
+    const provider = {
+      getTicketComments: async () => [{ body: '<!-- test-marker --> FIND' }],
+    };
+    // Search index misses it (empty), but the strongly-consistent issue list
+    // returns a body carrying the marker.
+    const spawnImpl = makeSpawnStub({
+      git: () => ({ code: 0 }),
+      ghSearch: () => ({ stdout: '[]', code: 0 }),
+      ghList: () => ({
+        stdout: JSON.stringify([
+          { number: 7, body: `x ${wrappedMarker(42, 0)} y` },
+        ]),
+        code: 0,
+      }),
+    });
+    const env = await graduate({
+      epicId: 42,
+      provider,
+      currentRepo,
+      classifier: () => 'consumer',
+      spawnImpl,
+      spec: makeSpec(),
+    });
+    assert.equal(env.filed.length, 0, 'the window duplicate is not re-filed');
+    assert.equal(env.skipped[0]?.reason, 'already-filed');
+    assert.ok(
+      !spawnImpl.calls.some((c) => c.args[1] === 'create'),
+      'createFollowUpIssue was never spawned',
+    );
+  });
+
+  it('AC-5: the strong read runs only on the would-file path', async () => {
+    const provider = {
+      getTicketComments: async () => [{ body: '<!-- test-marker --> FIND' }],
+    };
+    // Search already reports a match → no gh issue list spawn.
+    const spawnImpl = makeSpawnStub({
+      git: () => ({ code: 0 }),
+      ghSearch: () => ({ stdout: '[{"number":1}]', code: 0 }),
+    });
+    const env = await graduate({
+      epicId: 42,
+      provider,
+      currentRepo,
+      classifier: () => 'consumer',
+      spawnImpl,
+      spec: makeSpec(),
+    });
+    assert.equal(env.skipped[0]?.reason, 'already-filed');
+    assert.ok(
+      !spawnImpl.calls.some(
+        (c) => c.args[0] === 'issue' && c.args[1] === 'list',
+      ),
+      'no gh issue list spawn when the search probe already matched',
+    );
+  });
+
+  it('AC-7: an undecidable probe still files rather than swallowing', async () => {
+    const provider = {
+      getTicketComments: async () => [{ body: '<!-- test-marker --> FIND' }],
+    };
+    // Both read probes error; only the create succeeds.
+    const spawnImpl = makeSpawnStub({
+      git: () => ({ code: 0 }),
+      ghSearch: () => {
+        throw new Error('search down');
+      },
+      ghList: () => {
+        throw new Error('list down');
+      },
+      ghCreate: () => ({ stdout: 'https://x/issues/11', code: 0 }),
+    });
+    const env = await graduate({
+      epicId: 42,
+      provider,
+      currentRepo,
+      classifier: () => 'consumer',
+      spawnImpl,
+      spec: makeSpec(),
+    });
+    assert.equal(env.filed.length, 1, 'degrade-toward-filing preserved');
+    assert.equal(env.filed[0].url, 'https://x/issues/11');
   });
 });

--- a/tests/lib/graduator-hardening.test.js
+++ b/tests/lib/graduator-hardening.test.js
@@ -291,9 +291,12 @@ describe('AC5 — legacy (epicId, parse-index) marker recognition', () => {
     const spawnImpl = makeSpawnStub({
       git: () => ({ code: 0 }),
       ghSearch: (args) => {
-        const marker = args[2];
-        // Content marker not found; the legacy `-finding-<idx>` marker is.
-        if (/-finding-\d+ -->/.test(marker)) {
+        // The probe now queries the delimiter-stripped marker text
+        // (Story #4657), so the query ends with `-finding-<idx>` and carries
+        // no trailing `-->`. Content marker not found; the legacy
+        // `-finding-<idx>` marker is.
+        const query = args[2];
+        if (/-finding-\d+$/.test(query)) {
           return { stdout: '[{"number":88}]', code: 0 };
         }
         return { stdout: '[]', code: 0 };

--- a/tests/lib/retro-proposals-graduator.test.js
+++ b/tests/lib/retro-proposals-graduator.test.js
@@ -30,14 +30,18 @@ import {
 } from '../../.agents/scripts/lib/feedback-loop/retro-proposals-graduator.js';
 
 /**
- * Route a spawn by command / first args to a responder. `gh search` returns
- * the set of previously-created markers (so idempotency re-probes hit), and
- * `gh issue create` records the marker embedded in the `--body` arg and
- * returns a fresh issue URL. `git` is never expected (path-less findings).
+ * Route a spawn by command / first args to a responder. Faithful to the
+ * corrected search semantics (Story #4657): GitHub full-text search indexes
+ * the text INSIDE an HTML comment, so `gh search` matches any created issue
+ * whose body contains the (delimiter-free) query as a substring; the raw
+ * `<!-- … -->` form the probe used to send never matched. `gh issue list`
+ * models the strongly-consistent read (optionally narrowed by `--label`).
+ * `gh issue create` records the body + labels and returns a fresh URL. `git`
+ * is never expected (path-less findings).
  */
 function makeSpawnStub() {
   const calls = [];
-  const filedMarkers = new Set();
+  const issues = []; // { number, body, labels }
   let nextIssue = 100;
   const fn = function spawnImpl(cmd, args) {
     calls.push({ cmd, args });
@@ -51,22 +55,80 @@ function makeSpawnStub() {
       // trips the assertions below.
       result = { stdout: '', code: 1 };
     } else if (args[0] === 'search') {
-      const marker = args[2];
+      // The query is the delimiter-stripped marker text; a body carrying the
+      // wrapped marker contains that text as a substring.
+      const query = args[2];
+      const hit = issues.find((i) => i.body.includes(query));
       result = {
-        stdout: filedMarkers.has(marker) ? '[{"number":1}]' : '[]',
+        stdout: hit ? `[{"number":${hit.number}}]` : '[]',
+        code: 0,
+      };
+    } else if (args[0] === 'issue' && args[1] === 'list') {
+      const wantLabels = [];
+      for (let i = 0; i < args.length; i += 1) {
+        if (args[i] === '--label') wantLabels.push(args[i + 1]);
+      }
+      const matched = issues.filter((i) =>
+        wantLabels.every((l) => i.labels.includes(l)),
+      );
+      result = {
+        stdout: JSON.stringify(
+          matched.map((i) => ({ number: i.number, body: i.body })),
+        ),
         code: 0,
       };
     } else if (args[0] === 'issue' && args[1] === 'create') {
       const bodyIdx = args.indexOf('--body');
       const body = bodyIdx >= 0 ? args[bodyIdx + 1] : '';
-      const m = body.match(/<!-- retro-proposal-followup:[^>]+-->/);
-      if (m) filedMarkers.add(m[0]);
-      const num = nextIssue++;
-      result = { stdout: `https://github.com/o/r/issues/${num}`, code: 0 };
+      const labels = [];
+      for (let i = 0; i < args.length; i += 1) {
+        if (args[i] === '--label') labels.push(args[i + 1]);
+      }
+      const number = nextIssue++;
+      issues.push({ number, body, labels });
+      result = { stdout: `https://github.com/o/r/issues/${number}`, code: 0 };
     }
     queueMicrotask(() => {
       if (result.stdout) child.stdout.emit('data', Buffer.from(result.stdout));
       if (result.stderr) child.stderr.emit('data', Buffer.from(result.stderr));
+      child.emit('close', result.code ?? 0);
+    });
+    return child;
+  };
+  fn.calls = calls;
+  return fn;
+}
+
+/**
+ * A "blind probes" spawn stub: both read probes (`gh search`, `gh issue
+ * list`) always report empty, so the ONLY dedup mechanism left is the
+ * in-process filed-marker memo. `gh issue create` still records + counts.
+ * Story #4657 AC-6 uses this to prove the shared memo — not the network
+ * probes — catches a cross-bucket same-category duplicate.
+ */
+function makeBlindProbeSpawnStub() {
+  const calls = [];
+  let nextIssue = 200;
+  const fn = function spawnImpl(cmd, args) {
+    calls.push({ cmd, args });
+    const child = new EventEmitter();
+    child.stdout = new EventEmitter();
+    child.stderr = new EventEmitter();
+    let result = { stdout: '', code: 0 };
+    if (cmd !== 'gh') {
+      result = { stdout: '', code: 1 };
+    } else if (args[0] === 'search') {
+      result = { stdout: '[]', code: 0 };
+    } else if (args[0] === 'issue' && args[1] === 'list') {
+      result = { stdout: '[]', code: 0 };
+    } else if (args[0] === 'issue' && args[1] === 'create') {
+      result = {
+        stdout: `https://github.com/o/r/issues/${nextIssue++}`,
+        code: 0,
+      };
+    }
+    queueMicrotask(() => {
+      if (result.stdout) child.stdout.emit('data', Buffer.from(result.stdout));
       child.emit('close', result.code ?? 0);
     });
     return child;
@@ -316,6 +378,46 @@ describe('AC4 — rendered body lists filed issue references and the cap is resp
       res.skipped.filter((s) => s.reason === 'cap-reached').length,
       2,
       'the two over-cap proposals record cap-reached',
+    );
+  });
+});
+
+describe('AC-6 — the shared memo blocks a cross-bucket duplicate (Story #4657)', () => {
+  it('files a category present in BOTH buckets exactly once, via the memo', async () => {
+    const spawnImpl = makeBlindProbeSpawnStub();
+    const provider = makeProvider();
+    // Same category in framework and consumer: by construction the two scopes
+    // mint an identical content marker. With both network probes blind, only
+    // the shared in-process memo can stop the second bucket re-filing.
+    const routedProposals = {
+      framework: [mkItem('dup-cat', 'framework')],
+      consumer: [mkItem('dup-cat', 'consumer')],
+      discarded: [],
+    };
+
+    const res = await graduateRetroProposals({
+      epicId: 4406,
+      provider,
+      config: {},
+      currentRepo: REPO,
+      frameworkRepo: REPO,
+      routedProposals,
+      spawnImpl,
+    });
+
+    const createCalls = spawnImpl.calls.filter(
+      (c) => c.cmd === 'gh' && c.args[0] === 'issue' && c.args[1] === 'create',
+    );
+    assert.equal(
+      createCalls.length,
+      1,
+      'exactly one gh issue create for the shared category',
+    );
+    assert.equal(res.filed.length, 1, 'one filing recorded');
+    assert.equal(
+      res.skipped.filter((s) => s.reason === 'already-filed').length,
+      1,
+      'the second bucket skips as already-filed via the memo',
     );
   });
 });


### PR DESCRIPTION
Closes #4657

_Auto-opened by `/deliver`._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes dedup behavior for all graduator follow-up filing (search query shape plus an extra gh list before create); mistakes could cause missed skips or extra API load, but failures still prefer filing over silent drops.
> 
> **Overview**
> Fixes feedback-loop graduators that **re-filed follow-ups on every rollup** because `gh search issues` was queried with the full HTML-comment marker (`<!-- … -->`), which GitHub’s index does not match; probes now search the **delimiter-stripped** marker text while bodies still embed the wrapped comment.
> 
> On the **would-file** path only, adds a **label-scoped `gh issue list --state all`** check so duplicates filed seconds earlier in the same run are caught when search is still eventually consistent. Probe failures still **degrade toward filing** (duplicate risk over dropping findings).
> 
> **Retro proposals** pass a **shared in-process `filedMarkers` set** across framework and consumer buckets so the same category cannot create two issues in one invocation when markers collide. Tests cover normalization, strong read, memo dedup, and legacy marker probing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 622cc2e1c72e096589f70dd57a27a7c40ba219da. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->