### PR TITLE
refactor(qa): extract a shared qa-core helper and cut the stale draft-bundle path (#4666)

### DIFF
--- a/.agents/README.md
+++ b/.agents/README.md
@@ -960,7 +960,8 @@ known scenario set:
 - **`/qa-run <selector>`** — the **automated complement**: it drives a
   consumer's Gherkin `.feature` scenarios through a real browser (the
   `chrome-devtools` MCP surface), captures per-surface console/network into
-  structured `F#` findings, and drafts follow-up tickets for operator
+  structured `F#` findings, records them on the shared session ledger, and
+  triages them through the classify/route/promote core for operator
   sign-off. The end-to-end procedure is the SSOT in
   [`workflows/qa-run.md`](workflows/qa-run.md); the
   instrumentation conventions live in the

--- a/.agents/skills/skills.index.json
+++ b/.agents/skills/skills.index.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-07-16T20:44:41.281Z",
+  "generatedAt": "2026-07-21T13:21:30.156Z",
   "generator": "generate-skills-index.js@1",
   "skills": [
     {
@@ -168,7 +168,7 @@
       "category": "qa",
       "path": ".agents/skills/stack/qa/qa-harness/SKILL.md",
       "description": "Conventions for the agent-driven QA harness that drives Gherkin scenarios through a real browser. Use when executing `/qa-run` or instrumenting a live surface — covers navigation-first execution, per-surface console and network capture, design-token visual checks, and the framework-generic heuristic cards for turning signal into findings. The harness procedure lives in `.agents/workflows/qa-run.md`; this skill is the conventions reference it leans on.",
-      "policyCapsuleBullets": 8,
+      "policyCapsuleBullets": 7,
       "allowedTools": null,
       "vendor": null
     },

--- a/.agents/skills/stack/qa/qa-explore-driving/SKILL.md
+++ b/.agents/skills/stack/qa/qa-explore-driving/SKILL.md
@@ -41,29 +41,24 @@ the read-only and no-PII boundaries are inviolable per
 [`security-baseline.md`](../../../../rules/security-baseline.md). Read this
 skill before driving a live surface; read the workflow for the phase order.
 
-## 1. Navigation-First Driving (the default)
+## 1. Navigation-First Driving (the default) — one prose home
 
-The agent reaches every surface the way a real user would. This is the
-load-bearing convention — it is what makes findings reflect a user-reachable
-state rather than an artifact of a deep link.
+Navigation-first driving is the default and load-bearing convention: reach every
+surface the way a real user would so findings reflect a user-reachable state,
+not an artifact of a deep link. Its full prose statement lives once in
+[`qa-run-scenario.md`](../../../../workflows/helpers/qa-run-scenario.md) (shared
+with the known-scenario sweep) — apply it from there rather than restating it.
+In capsule:
 
-- **Drive the running app by default.** When a live runtime is reachable, drive
-  it through the browser MCP (the chrome-devtools MCP surface). This is the
-  primary method; static driving is the interim alternative (§ 2), not the
-  norm.
-- **Start at a root.** Begin each surface at the app's home or dashboard and
-  reach the surface under test by clicking nav links, menu items, and buttons —
-  the same affordances a user has.
-- **Never URL-jump.** Do not navigate directly to a deep link to establish a
-  starting state. URL-jumping bypasses the app's real authorization and routing
-  flows, which both masks access-control gaps and produces findings that no
-  user could actually trigger.
-- **Broken navigation is a finding, not a workaround.** When an affordance is
-  missing, a nav link 404s, or a guard redirect loops, that is the finding. Do
-  not route around it with a direct URL — record it and move on.
-- **Observe, do not fabricate.** Use app-provided UI affordances to reach and
-  observe a surface. Never script the runtime to manufacture an outcome the
-  exploration is meant to discover.
+- **Drive the running app by default** through the browser MCP; static (§ 2) is
+  the interim alternative, not the norm.
+- **Start at a root and never URL-jump** — reach the surface under test by
+  clicking the affordances a real user has, never by deep-linking a starting
+  state.
+- **Broken navigation is a finding, not a workaround** — a missing affordance, a
+  nav 404, or a guard redirect loop is recorded; do not route around it.
+- **Observe, do not fabricate** — never script the runtime to manufacture an
+  outcome the exploration is meant to discover.
 
 ## 2. Static Driving — the Documented Interim
 
@@ -150,6 +145,7 @@ deployed surfaces are **driven**, not statically deferred.
 ## 5. Cross-References
 
 - Run procedure (SSOT): [`qa-explore.md`](../../../../workflows/qa-explore.md).
+- Driving rules (one prose home): [`qa-run-scenario.md`](../../../../workflows/helpers/qa-run-scenario.md).
 - Known-scenario sibling sweep: [`qa-harness`](../qa-harness/SKILL.md).
 - Browser instrumentation: [`browser-testing-with-devtools`](../../../core/browser-testing-with-devtools/SKILL.md).
 - Read-only / no-PII boundary: [`security-baseline.md`](../../../../rules/security-baseline.md).

--- a/.agents/skills/stack/qa/qa-harness/SKILL.md
+++ b/.agents/skills/stack/qa/qa-harness/SKILL.md
@@ -14,13 +14,12 @@ description:
 
 ## Policy Capsule
 
-- Drive every scenario navigation-first: start at a root and reach the surface under test only via UI affordances — never URL-jump to a deep link to set up a `Given`.
-- Assert `Then` outcomes semantically against the accessibility snapshot (roles, accessible names, visible text); never via DOM/CSS/XPath selectors, HTTP status codes, response bodies, or DB rows.
+- Driving rules (navigation-first, semantic `Then`, mandatory redaction, sequential-only) live in one prose home — [`qa-run-scenario.md`](../../../../workflows/helpers/qa-run-scenario.md); apply them, do not restate them.
 - Capture console and network per surface; turn each non-allowlisted console error and each failed/error-status request into one structured `F#` finding.
 - Filter console through `qa.consoleAllowlist` via `filterConsoleMessages`; treat the allowlist as a benign-noise filter, never as a security control to silence genuine errors.
 - Spot-check surfaces against `qa.designTokens` when set; flag gross token violations (off-palette colors, off-scale spacing/typography) as findings.
 - Scrub captured console and network of tokens, session cookies, and PII before rendering any finding — findings are posted to GitHub at approval time.
-- Bundle findings by likely root cause into a draft for operator sign-off; the harness never files tickets autonomously.
+- Record findings as `QaLedgerItem`s and route them through the shared classify/route/promote core ([`qa-core.md`](../../../../workflows/helpers/qa-core.md)); the harness never files tickets autonomously.
 - Resolve the `qa` contract first and fail loudly when it is absent or malformed; there is no auto-detection fallback and no headless degrade.
 
 Guidance for executing the agent-driven QA harness through a real browser (the
@@ -35,45 +34,21 @@ live in [`testing-standards.md`](../../../../rules/testing-standards.md)
 discipline is shared with [`playwright`](../playwright/SKILL.md). Read this
 skill before instrumenting a live surface; read the workflow for the run order.
 
-## 1. Navigation-First Execution
+## 1. Driving Rules Live in One Prose Home
 
-The harness reaches every surface the way a real user would. This is the
-load-bearing convention — it is what makes findings reflect a user-reachable
-state rather than an artifact of a deep link.
-
-- **Start at a root.** After sign-in, begin each scenario at the app's home or
-  dashboard. Reach the surface under test by clicking nav links, menu items,
-  and buttons — the same affordances a user has.
-- **Never URL-jump.** Do not `navigate_page` directly to a deep link to
-  establish a `Given`. URL-jumping bypasses the app's real authorization and
-  routing flows, which both masks access-control gaps and produces findings
-  that no user could actually trigger.
-- **Broken navigation is a finding, not a workaround.** When an affordance is
-  missing, a nav link 404s, or a guard redirect loops, that is the finding.
-  Do not route around it with a direct URL — record it and move on.
-- **Map Gherkin to browser actions.** `Given` establishes state by navigating
-  from the root (sign in as the persona, walk to the starting surface, seed via
-  UI where the manifest does not pre-seed). `When` performs the single user
-  action (`click`, `fill_form`, then `wait_for` the transition). Use
-  `evaluate_script` only for app-provided hooks — never to fabricate the
-  outcome a `Then` is meant to observe.
-
-### Semantic `Then` assertion
-
-Assert every `Then` against the accessibility snapshot from `take_snapshot`,
-matching on **roles, accessible names, labels, and visible text** that express
-the user-visible outcome — "a banner with text _Invoice sent_ is visible", "a
-row for _ACME Corp_ appears in the invoices table".
-
-- **Never** assert against brittle DOM/CSS/XPath selectors.
-- **Never** assert on HTTP status codes, response bodies, or DB rows inside a
-  scenario — those are contract-tier concerns (see
-  [`testing-standards.md` § Assertion Placement](../../../../rules/testing-standards.md#assertion-placement)).
-- A `Then` that can only be expressed as a wire-shape or DB check is a signal
-  the scenario is **mis-tiered**, not a license to break the semantic rule.
-
-Record each scenario's result (pass / fail / blocked), the surface it ended on,
-and a one-line user-visible symptom for any failure.
+The driving rules the harness depends on — **navigation-first / never URL-jump**,
+**semantic `Then` assertion** against the accessibility snapshot, the Gherkin →
+browser-action mapping, the per-`When` write guard, mandatory evidence
+redaction, and the **sequential-only** browser rule — are stated once in
+[`qa-run-scenario.md`](../../../../workflows/helpers/qa-run-scenario.md), the
+single-scenario driver `/qa-run` delegates to. Apply them from there; this skill
+does not restate them. In short: reach every surface the way a real user would
+(start at a root, click affordances, never deep-link a `Given`), assert `Then`
+semantically (roles, accessible names, visible text — never DOM/CSS/XPath
+selectors, HTTP status, response bodies, or DB rows), and record each scenario's
+result (pass / fail / blocked), the surface it ended on, and a one-line symptom
+for any failure. Assertion-tier rules are in
+[`testing-standards.md` § Assertion Placement](../../../../rules/testing-standards.md#assertion-placement).
 
 ## 2. Per-Surface Console & Network Capture
 
@@ -126,7 +101,9 @@ skip this check entirely — do not invent a token source.
 ## 3. Findings — the `F#` Shape
 
 Every captured problem is normalized into the structured `F#` finding shape so
-the draft bundle stays diffable and the schema validates:
+the sweep can record it onto the shared ledger (each `F#` finding becomes one
+`QaLedgerItem` — see [`qa-core.md`](../../../../workflows/helpers/qa-core.md))
+and the schema validates:
 
 ```jsonc
 {
@@ -137,7 +114,6 @@ the draft bundle stays diffable and the schema validates:
   "likelyRootCause": null,          // heuristic card output (§4); null until enriched
   "disposition": "follow-up",       // blocker | follow-up
   "acceptance": null,               // AC this folds into, when known
-  "foldsInto": "F2",                // optional: another finding this is a duplicate facet of
   "evidence": {
     "console": [{ "level": "error", "text": "..." }],
     "network": []
@@ -172,12 +148,14 @@ and let the operator triage from the symptom.
 | `Failed to fetch` / `NetworkError` / CORS-rejected request | Misconfigured CORS allowlist, wrong origin, or a downed dependency | follow-up |
 | Hydration / mismatch warning escalated to error | Server/client render divergence | follow-up |
 | Off-palette color, off-scale spacing/typography | Design-token drift — hard-coded value bypassing the token | follow-up |
-| Repeated identical console error across many surfaces | A shared component or global bootstrap fault | fold the duplicates into one finding via `foldsInto` |
+| Repeated identical console error across many surfaces | A shared component or global bootstrap fault | record once; the shared route/dedup core collapses duplicates at triage |
 
 Heuristics for working the cards:
 
-- **Fold duplicates.** When the same error fires on many surfaces, emit one
-  finding and point the rest at it with `foldsInto` rather than filing N copies.
+- **Record once, let dedup collapse.** When the same error fires on many
+  surfaces, record it once rather than filing N copies; the shared
+  classify/route/dedup core ([`qa-core.md`](../../../../workflows/helpers/qa-core.md))
+  collapses duplicates at triage against the fingerprint footer.
 - **Blocker vs. follow-up.** A finding is a **blocker** when it breaks the
   scenario's user-visible outcome or exposes an authorization gap. Everything
   else (noise that does not break the journey, cosmetic token drift) is a
@@ -186,13 +164,15 @@ Heuristics for working the cards:
   symptom and leave `likelyRootCause: null`. A wrong guess is worse than an
   honest "unknown" the operator can triage.
 
-## 5. Draft & Sign-Off (Never File Autonomously)
+## 5. Record onto the Ledger & Triage (Never File Autonomously)
 
-Bundle findings **by likely root cause** into proposed follow-up tickets with
-`Depends-on` / `Blocks` relationships, then present the draft for operator
-approval. The harness **MUST NOT** create tickets autonomously — it stops at a
-draft. The operator-approval gate is the safety boundary against spurious
-filing.
+Record each `F#` finding as a `QaLedgerItem` on the shared session ledger under
+`temp/qa/`, then route the ledger through the shared classify → route →
+disposition → promote core — both stated once in
+[`qa-core.md`](../../../../workflows/helpers/qa-core.md). The harness **MUST
+NOT** create tickets autonomously: findings are promoted through `/plan` only
+after the operator confirms each disposition at the HITL write gate. That gate
+is the safety boundary against spurious filing.
 
 ## 6. Sign-In & Contract Discipline
 
@@ -211,6 +191,8 @@ filing.
 ## 7. Cross-References
 
 - Run procedure (SSOT): [`qa-run.md`](../../../../workflows/qa-run.md).
+- Driving rules (one prose home): [`qa-run-scenario.md`](../../../../workflows/helpers/qa-run-scenario.md).
+- Shared QA core (contract/session/redaction/ledger/triage/HITL): [`qa-core.md`](../../../../workflows/helpers/qa-core.md).
 - Console filter module: [`console-allowlist.js`](../../../../scripts/lib/qa/console-allowlist.js).
 - Assertion-tier rules: [`testing-standards.md`](../../../../rules/testing-standards.md).
 - Scenario prose: [`gherkin-authoring`](../gherkin-authoring/SKILL.md).

--- a/.agents/workflows/helpers/qa-core.md
+++ b/.agents/workflows/helpers/qa-core.md
@@ -1,0 +1,174 @@
+---
+description: >-
+  Helper — not a slash command. The shared core the three QA workflows
+  (/qa-run, /qa-explore, /qa-assist) consume: contract resolution + loud
+  failure, the session & ledger contract, redact-first, the QaLedgerItem shape,
+  the triage procedure (classify → route → disposition → promote), and the HITL
+  write gate. Each workflow states only its mode-specific phases plus a short
+  Constraints delta and points here for everything else.
+caller: qa-run.md, qa-explore.md, qa-assist.md
+---
+
+# helpers/qa-core — shared QA harness core
+
+> **Not a slash command.** This file lives in `helpers/` and is not projected
+> into the plugin command tree. It is consumed by reference from
+> [`/qa-run`](../qa-run.md), [`/qa-explore`](../qa-explore.md), and
+> [`/qa-assist`](../qa-assist.md) — it states each shared block **once** so the
+> three workflows keep only their mode-specific phases and a Constraints delta.
+
+All three QA workflows are **prose workflows**, not Node orchestrators: the
+host LLM executes the procedure; deterministic Node helpers under
+`.agents/scripts/lib/qa/` (contract, session, redaction, coverage, missing-test)
+and `.agents/scripts/lib/findings/` (classification, dedup/route, cluster/size/
+promote) own every decision. The agent never invents those decisions in prose.
+
+## Contract resolution (fail loudly when absent)
+
+Resolve the consumer's `qa` contract block **before any QA work**, through the
+single seam [`resolve-qa-contract.js`](../../scripts/lib/qa/resolve-qa-contract.js):
+
+```js
+import { resolveQaContract } from '../scripts/lib/qa/resolve-qa-contract.js';
+const contract = resolveQaContract(config); // throws loudly if unbound
+```
+
+`resolveQaContract` **throws** — there is no silent fallback to auto-detection
+— when the `qa` block is absent (no `qa` key, or an empty `qa: {}`), malformed
+(wrong-typed or unknown field, e.g. `qa.featureRoot must be a string`), or
+missing a required field (it names the first one). The absent-block message
+reads: _"qa: this project has not bound the QA harness — add a `qa` block to
+.agentrc.json (featureRoot, fixturesManifest, environments, personas) before
+invoking the QA harness."_
+
+When the resolver throws, **STOP immediately**: relay its verbatim message to
+the operator as terminal output and do not proceed. Do not invent a
+`featureRoot`, guess a sign-in seam, or fall back to any retired headless BDD
+runner. The loud failure is the contract — a consumer that has not bound the
+harness has not opted into it.
+
+The normalized contract exposes `featureRoot`, `fixturesManifest`,
+`environments` (each keyed to `{ baseUrl, signInSeam, allowWrites? }`, resolved
+to one target via [`resolveQaEnvironment`](../../scripts/lib/qa/resolve-qa-contract.js)),
+`defaultEnvironment`, `personas` (canonical name-keyed map; a name-only persona
+resolves to an empty record), `consoleAllowlist` (default `[]`), and
+`designTokens` (default `null`).
+
+## Session & ledger (temp/qa/)
+
+Resolve the session and its ledger path **once**, up front, via
+[`qa-session.js`](../../scripts/lib/qa/qa-session.js):
+
+```js
+import { resolveQaSession } from '../scripts/lib/qa/qa-session.js';
+const { sessionId, ledgerPath, reused, untriaged } = resolveQaSession({ config });
+```
+
+- The ledger is always written under **`temp/qa/<sessionId>.ndjson`**
+  (`<tempRoot>/qa/`, from `project.paths.tempRoot`), one `QaLedgerItem` per line
+  validated against [`qa-ledger.schema.json`](../../schemas/qa-ledger.schema.json).
+  **Never** write it anywhere else, and never commit it — `temp/` is gitignored
+  per [`.agents/instructions.md` § 6](../../instructions.md).
+- When `reused` is `true`, a prior session of the same id exists: **append**,
+  never overwrite, and carry the `untriaged` items forward as the rolling
+  backlog. Pass `--session-id <id>` (or `QA_SESSION_ID`) to resume a named
+  session.
+
+## Redact first
+
+Before any evidence string touches disk or GitHub, scrub it through
+[`redact-evidence.js`](../../scripts/lib/qa/redact-evidence.js):
+
+```js
+import { redactEvidence } from '../scripts/lib/qa/redact-evidence.js';
+const evidence = redactEvidence(rawObservation);
+```
+
+This is mandatory per [`security-baseline.md`](../../rules/security-baseline.md)
+(§ Data Leakage & Logging, § Secrets Management) — bearer tokens, session
+cookies, `Authorization` headers, and emails are masked. The pass is
+idempotent, so redact eagerly; captured console and network evidence is
+untrusted until scrubbed. Secrets are never echoed into chat, findings, or the
+ledger.
+
+## The QaLedgerItem shape
+
+Each observation/finding is recorded as one `QaLedgerItem` on the session
+ledger, conforming to [`qa-ledger.schema.json`](../../schemas/qa-ledger.schema.json):
+
+- **`id`** — stable `L1`, `L2`, … in append order (after any carried backlog).
+- **`evidence`** — the **redacted** symptom / observation string.
+- **`coverage`** — the surface label the item points at (or `unknown`).
+- **`class`** — the ledger class (`product-bug`, `environment-setup`,
+  `tooling-dx`, `test-gap`, `enhancement`, …); resolves to the focus/meta label
+  set Triage applies.
+- **`severity`** — the tentative severity.
+- **`missingTest`** — the lowest absent test tier's description, or `null`.
+- **`disposition`** — left **untriaged** at capture; set only in Triage.
+
+**Append** to the ledger, never overwrite; a re-run appends to the same
+session. This is the single findings channel across all three workflows — there
+is no per-workflow finding schema.
+
+## Triage — classify → route → disposition → promote
+
+Route the ledger through the shared classify/route/dedup/promote core. The
+outcome is that **every ledger item carries a class, a route decision, and an
+operator-confirmed disposition**, with each `file` item promoted via
+`promote-finding.js` into `/plan` — verified by the cluster's fingerprint
+footer landing in each seed body. For each untriaged item:
+
+1. **Classify** via
+   [`classify-finding.js`](../../scripts/lib/findings/classify-finding.js). The
+   item's `class` resolves to the focus/meta label set (`tooling-dx` carries
+   `meta::framework-gap`; `enhancement` carries `meta::consumer-improvement`).
+   The helper **throws** on an absent/unknown class — fix the item's class
+   rather than defaulting.
+2. **Dedup / route** against existing GitHub Issues (open **and** closed) via
+   [`route-finding.js`](../../scripts/lib/findings/route-finding.js) — the
+   **single** dedup implementation shared with `audit-to-stories`:
+
+   ```js
+   import { routeFinding, fingerprintFooter } from '../scripts/lib/findings/route-finding.js';
+   const { decision, matchedIssue, fingerprint } =
+     await routeFinding(finding, { searchIssues });
+   ```
+
+   `decision` is one of `new` / `update-existing` / `duplicate` /
+   `regression-of-closed`. Wire `searchIssues` to the GitHub provider and stamp
+   the `fingerprintFooter(sha)` marker into any Issue body so future runs dedup
+   against it.
+3. **Decide the disposition** with the operator (`file` / `defer` / `dismiss`)
+   and record it back onto the ledger item.
+4. **Promote the `file`-dispositioned findings through `/plan`** via
+   [`promote-finding.js`](../../scripts/lib/findings/promote-finding.js) — the
+   same cluster/size/route/file path `audit-to-stories` consumes. Never
+   hand-roll the clustering, sizing, or promotion in prose:
+
+   ```js
+   import { promoteFindings } from '../scripts/lib/findings/promote-finding.js';
+   const { promotions } = await promoteFindings(ledgerItems, {
+     searchIssues, // GitHub provider, open + closed
+     createStory, // tight cluster (≤2 surfaces): seed → /plan --seed-file
+     createPlanSeed, // broad cluster (>2 surfaces): same /plan --seed-file path (may N>1)
+   });
+   ```
+
+   `promoteFindings` runs `clusterLedgerItems` + `targetForCluster`: a cluster
+   spanning **≤2** distinct coverage surfaces routes to `createStory`, **>2** to
+   `createPlanSeed` — neither opens an Epic; both render a **redacted** plan
+   seed (redaction already ran at capture), **stamp the cluster's
+   `fingerprintFooter(sha)` verbatim into the seed body**, and chain
+   `/plan --seed-file <seed>`. Prefer one Story; split only under the
+   default-single policy. A `file` disposition **never** opens a raw GitHub
+   Issue; only `defer` and `dismiss` skip the `/plan` handoff.
+
+## The HITL write gate
+
+Capture stays read-only precisely so every state change lands in Triage,
+deliberately and confirmed. Any ticket-filing, seed write, `/plan` invocation,
+or label mutation is a **write** — present the artifact, confirm each one with
+the operator, and wait before it happens. The agent never files tickets,
+promotes findings, or mutates a label autonomously. The plan→deliver hard stop
+is preserved: each `/plan` chain pauses at its own HITL gates and never
+auto-delivers.

--- a/.agents/workflows/helpers/qa-run-scenario-reference.md
+++ b/.agents/workflows/helpers/qa-run-scenario-reference.md
@@ -1,0 +1,35 @@
+---
+description: >-
+  Reference sibling for helpers/qa-run-scenario.md — the spec-only, not-yet-
+  enabled batched sub-agent dispatch mode. Read only when turning that mode on.
+caller: qa-run-scenario.md
+---
+
+# helpers/qa-run-scenario — reference: batched sub-agent dispatch (spec-only)
+
+> **Not yet enabled.** This section specifies a future execution mode; the
+> current `/qa-run` sweep calls [`qa-run-scenario`](qa-run-scenario.md)
+> **inline**, one scenario at a time, in the orchestrator's own turn. The
+> batched mode below is documented so the contract is stable when it is turned
+> on — do not implement it as live behavior from this spec alone.
+
+In the deferred mode, the orchestrator MAY dispatch scenarios to fresh-context
+sub-agents to keep its own context window focused, under these hard rules:
+
+- **Sequential, never parallel.** Sub-agents run **one at a time**, never
+  concurrently. A live browser surface is a single shared resource; parallel
+  drivers would race on navigation and cross-contaminate evidence. (This
+  sequential-only rule is live today and stated in
+  [`qa-run-scenario.md`](qa-run-scenario.md) — it is not deferred.)
+- **One sub-agent per persona group.** Scenarios are grouped by persona and a
+  single sub-agent drives all of one persona's scenarios, so the persona is
+  signed in once per group rather than per scenario.
+- **Re-verify auth on entry.** Each sub-agent MUST re-verify the
+  authenticated-session precondition (a `take_snapshot` confirming the persona
+  badge) when it starts, because it does not share the orchestrator's live
+  session state.
+- **Same input/output contract.** Each sub-agent consumes the input contract
+  and returns the per-scenario result shape from
+  [`qa-run-scenario.md`](qa-run-scenario.md) for every scenario it drove — the
+  orchestrator aggregates identically whether the helper ran inline or via a
+  batched sub-agent.

--- a/.agents/workflows/helpers/qa-run-scenario.md
+++ b/.agents/workflows/helpers/qa-run-scenario.md
@@ -151,31 +151,17 @@ finding, it **MUST** pass
 Redaction is not optional — findings are posted to GitHub at the orchestrator's
 approval time, so unredacted secrets must never reach the `findings` output.
 
-## Deferred: batched sub-agent dispatch mode (spec-only)
+## Sequential-only driving (a live browser is a shared resource)
 
-> **Not yet enabled.** This section specifies a future execution mode; the
-> current `/qa-run` sweep calls this helper **inline**, one scenario at a time,
-> in the orchestrator's own turn. The batched mode below is documented so the
-> contract is stable when it is turned on — do not implement it as live
-> behavior from this spec alone.
-
-In the deferred mode, the orchestrator MAY dispatch scenarios to fresh-context
-sub-agents to keep its own context window focused, under these hard rules:
-
-- **Sequential, never parallel.** Sub-agents run **one at a time**, never
-  concurrently. A live browser surface is a single shared resource; parallel
-  drivers would race on navigation and cross-contaminate evidence.
-- **One sub-agent per persona group.** Scenarios are grouped by persona and a
-  single sub-agent drives all of one persona's scenarios, so the persona is
-  signed in once per group rather than per scenario.
-- **Re-verify auth on entry.** Each sub-agent MUST re-verify the
-  authenticated-session precondition (a `take_snapshot` confirming the persona
-  badge) when it starts, because it does not share the orchestrator's live
-  session state.
-- **Same input/output contract.** Each sub-agent consumes the input contract
-  above and returns the per-scenario result shape above for every scenario it
-  drove — the orchestrator aggregates identically whether the helper ran inline
-  or via a batched sub-agent.
+Scenarios are driven **one at a time, never concurrently**. A live browser
+surface is a single shared resource; parallel drivers would race on navigation
+and cross-contaminate evidence, so parallel driving is ruled out. Today the
+`/qa-run` sweep calls this helper **inline**, one scenario per turn. A future,
+**not-yet-enabled** batched sub-agent dispatch mode — which would still run
+sub-agents sequentially, one per persona group, re-verifying auth on entry and
+honoring the same input/output contract — is specified in
+[`qa-run-scenario-reference.md`](qa-run-scenario-reference.md). Do not implement
+that mode as live behavior from the spec alone.
 
 ## Constraints
 

--- a/.agents/workflows/qa-assist.md
+++ b/.agents/workflows/qa-assist.md
@@ -4,8 +4,8 @@ description: Human-led QA assist loop — set up, then ride a rolling multi-obse
 
 # /qa-assist
 
-Drive a **human-led, rolling QA-assist session**. The operator tests; the
-agent rides alongside as the QA engineer and captures what they see into a
+Drive a **human-led, rolling QA-assist session**. The operator tests; the agent
+rides alongside as the QA engineer and captures what they see into a
 high-quality, triage-ready ledger. The session has four movements:
 
 1. **Setup & Ready** (Phase 0) — load codebase context, resolve the contract,
@@ -13,32 +13,29 @@ high-quality, triage-ready ledger. The session has four movements:
    and that it is **ready for observations**.
 2. **Rolling intake** (Phases 1–3, looped) — the operator reports observations
    **in any order and any quantity**: one at a time, or a **brain dump** of many
-   at once in a single message. The agent splits a multi-observation message
-   into discrete items and runs each through **Intake → Enrich → Record**, then
-   **loops straight back** to wait for more. It **records and enriches only — it
-   never plans or fixes during intake.**
+   at once. The agent splits a multi-observation message into discrete items and
+   runs each through **Intake → Enrich → Record**, then **loops straight back**
+   for more. It **records and enriches only — it never plans or fixes during
+   intake.**
 3. **Done** — when the operator says they have finished testing, the agent does
    a final review of the **entire** ledger and asks any last clarifying
    questions.
-4. **Triage & Plan** (Phase 4) — only then does the agent route the full ledger
-   into [`/plan`](plan.md) to generate Stories.
+4. **Triage & Plan** (Phase 4) — only then does it route the full ledger through
+   [`/plan`](plan.md) to generate Stories.
 
 Unlike [`/qa-explore`](qa-explore.md) (where the *agent* drives open-ended
 exploration of a named surface), `/qa-assist` is **human-led**: the human owns
 the signal, the agent owns the enrichment. It is the front door for "I'm
-testing — ride along and capture everything well." Each observation is recorded
-as a `QaLedgerItem` against the
-[`qa-ledger.schema.json`](../schemas/qa-ledger.schema.json) contract — the same
-ledger `/qa-explore` and the triage/promotion path consume — so a `/qa-assist`
-item flows through the identical dedup, classification, and promotion machinery
-in Phase 4.
+testing — ride along and capture everything well." Each observation is a
+`QaLedgerItem` on the same ledger `/qa-explore` produces, so a `/qa-assist` item
+flows through the identical dedup, classification, and promotion machinery in
+Phase 4.
 
-This is a **prose workflow**, not a Node orchestrator: the host LLM executes
-the procedure; deterministic Node helpers under `.agents/scripts/lib/qa/` and
-`.agents/scripts/lib/findings/` do the contract resolution, session/ledger
-resolution, context hydration, redaction, coverage verdict, classification,
-dedup/route, and promotion. **The agent consumes the shared core helpers; it
-never reimplements those decisions in prose.**
+The shared machinery — contract resolution + loud failure, the session & ledger
+contract, redact-first, the `QaLedgerItem` shape, the triage procedure, and the
+HITL write gate — lives once in [`helpers/qa-core.md`](helpers/qa-core.md); this
+workflow states only the `/qa-assist`-specific phases (Intake / Enrich) plus a
+Constraints delta.
 
 > **When to run**: a developer or operator is about to test (or is mid-test) and
 > wants every bug and enhancement idea captured as a high-quality,
@@ -50,9 +47,9 @@ never reimplements those decisions in prose.**
 ## Role framing
 
 You are the quality gatekeeper for this run: value coverage, hermetic
-environments, and deterministic results. **Never invent the signal** — the
-human owns what was observed; you enrich it. Apply the QA skills; there is
-no separate persona pack.
+environments, and deterministic results. **Never invent the signal** — the human
+owns what was observed; you enrich it. Apply the QA skills; there is no separate
+persona pack.
 
 ## Slash Command
 
@@ -67,66 +64,37 @@ no separate persona pack.
 | `observation` | no       | `"sync-commands wipes .claude on a reused name"` | An optional first observation, or a brain dump of several. **Usually omitted** — the normal launch is a bare `/qa-assist`, which does Setup and then waits. If supplied, run Setup first, then feed it in as the first intake (splitting it if it carries multiple observations). |
 
 A bare `/qa-assist` is the expected entry point. **Do not** demand an
-observation up front and **do not** synthesize one — the QA Golden
-Rule forbids inventing the signal. Set up, announce ready, and wait.
+observation up front and **do not** synthesize one — the QA Golden Rule forbids
+inventing the signal. Set up, announce ready, and wait.
 
-## Project contract
+## Contract & session — persistent, resumable, rolling
 
-Resolve the consumer's `qa` contract during Setup, via
-[`resolve-qa-contract.js`](../scripts/lib/qa/resolve-qa-contract.js):
-
-```js
-import { resolveQaContract } from '../scripts/lib/qa/resolve-qa-contract.js';
-const contract = resolveQaContract(config); // throws loudly if unbound
-```
-
-The resolver fails **loudly** when the project has not bound the QA harness
-(no `qa` block in `.agentrc.json`) — there is no silent fallback. If it throws
-the "this project has not bound the QA harness" message, surface that verbatim
-to the operator and stop; do not pretend a contract exists.
-
-## Session & ledger (temp/qa/) — persistent, resumable, rolling
-
+Resolve the `qa` contract and the session per
+[`helpers/qa-core.md`](helpers/qa-core.md) during Setup — the resolver fails
+**loudly** when the harness is unbound; surface that verbatim and stop.
 `/qa-assist` **defaults to a persistent rolling session**: the same session is
 resumed across invocations so an operator can top up the same ledger across a
-working day or a multi-launch testing pass. Resolve the session and its ledger
-path **once**, during Setup, via
-[`qa-session.js`](../scripts/lib/qa/qa-session.js):
-
-```js
-import { resolveQaSession } from '../scripts/lib/qa/qa-session.js';
-const { sessionId, ledgerPath, reused, untriaged } = resolveQaSession({ config });
-```
-
-- The ledger is always written under **`temp/qa/<sessionId>.ndjson`**
-  (`<tempRoot>/qa/`, resolved from `project.paths.tempRoot`). It is one
-  `QaLedgerItem` per line (ndjson). **Never** write the ledger anywhere else,
-  and never commit it — `temp/` is gitignored per
-  [`.agents/instructions.md` § 6](../instructions.md).
-- When `reused` is `true`, a prior session of the same id exists: **append**,
-  never overwrite, and surface the carried `untriaged` items as the rolling
-  backlog so the operator sees what is still open. Pass `--session-id <id>`
-  (or `QA_SESSION_ID`) to resume or fork a named session. A `/qa-assist` run is
-  additive to the prior ledger by default — this is the resumable rolling
-  session contract.
+working day or a multi-launch pass. A reused session **appends** (never
+overwrites) and surfaces the carried `untriaged` items as the rolling backlog so
+the operator sees what is still open. Pass `--session-id <id>` (or
+`QA_SESSION_ID`) to resume or fork a named session.
 
 ## Phase gates (HITL)
 
-This is a HITL workflow, but the gating is deliberately **light during intake
-and firm at the boundary**, so the rolling loop stays fluid:
+Gating is deliberately **light during intake and firm at the boundary**, so the
+rolling loop stays fluid:
 
 - **Within a single observation, Intake → Enrich → Record is fluid.** The agent
-  restates, enriches, and appends the ledger item without a ceremony, pausing
-  only to **ask clarifying questions when the observation is ambiguous**. After
-  each append it **echoes the recorded item** so the operator can correct it,
-  then **loops back to wait for the next observation**. The agent does **not**
-  triage, route, file tickets, or invoke `/plan` during intake.
-- **Two things always require explicit operator confirmation.** First, the
-  session-level transition from rolling intake into **Phase 4 — Triage & Plan**
-  — the agent never starts planning on its own; the operator must say they are
+  restates, enriches, and appends the ledger item without ceremony, pausing only
+  to **ask clarifying questions when the observation is ambiguous**. After each
+  append it **echoes the recorded item** for correction, then **loops back** for
+  the next observation. It does **not** triage, route, file tickets, or invoke
+  `/plan` during intake.
+- **Two things always require explicit operator confirmation** (the HITL write
+  gate in [`helpers/qa-core.md`](helpers/qa-core.md)). First, the session-level
+  transition into **Phase 4 — Triage & Plan** — the operator must say they are
   done. Second, **every write that leaves the local ledger** — filing a ticket,
-  invoking `/plan`, or mutating a label. Present the artifact, ask, and wait. If
-  the operator does not confirm, hold.
+  invoking `/plan`, or mutating a label. Present the artifact, ask, and wait.
 
 In short: appending to the rolling ledger is the natural product of intake and
 needs no gate beyond the echo-back; **planning and anything that leaves the
@@ -145,88 +113,69 @@ Goal: become the operator's QA assistant before any observation arrives.
    draw on to enrich observations without guessing.
 3. **Resolve the `qa` contract and the rolling session** (above). Compute the
    ledger path and load any carried `untriaged` backlog.
-4. **Announce readiness.** Tell the operator, in one short message:
-   - which session this is (new vs. resumed) and how many items are already on
-     the ledger;
-   - what you will do with each observation (enrich bugs with repro +
-     root-cause `file:line` + coverage; enrich enhancements with analysis +
-     options + a recommendation) and that you will **record only, not plan**;
-   - that you are **ready for observations, in any order**, and that they
-     should tell you when they are **done testing** to move into triage/planning.
-5. **Wait.** Do not invent an observation. If `/qa-assist` was launched with an
-   `observation` argument, treat it as the first intake and proceed to Phase 1;
-   otherwise wait for the operator's first report.
+4. **Announce readiness.** Tell the operator, in one short message: which
+   session this is (new vs. resumed) and how many items are already on the
+   ledger; what you will do with each observation (enrich bugs with repro +
+   root-cause `file:line` + coverage; enrich enhancements with analysis +
+   options + a recommendation) and that you will **record only, not plan**; and
+   that you are **ready for observations, in any order** and they should tell you
+   when they are **done testing**.
+5. **Wait.** Do not invent an observation. If launched with an `observation`
+   argument, treat it as the first intake and proceed to Phase 1; otherwise wait
+   for the operator's first report.
 
 ---
 
 ## Phase 1 — Intake (per observation, looped)
 
 Goal: understand **exactly what the human observed** before enriching it. The
-operator's message may carry **one observation or a brain dump of many**; this
-phase first splits the message into discrete observations, then runs Intake for
-**each** of them, before returning here for the next message.
+operator's message may carry **one observation or a brain dump of many**; split
+first, then run Intake for **each** before returning for the next message.
 
-1. **Split a brain dump into discrete observations.** Parse the operator's
-   message into the distinct things they observed — one ledger item per
-   distinct symptom, surface, or idea. Use their own structure (numbered or
-   bulleted list, blank-line-separated paragraphs, "and another thing…") as the
-   split boundary; do **not** merge two unrelated symptoms into one item or
-   split a single symptom into several. **Echo the parsed list back** ("I read
-   N observations: …") and let the operator correct the split before you
-   enrich anything — this is the only confirmation intake requires. A
-   single-observation message is just the N = 1 case; skip the echo when it is
+1. **Split a brain dump into discrete observations.** Parse the message into the
+   distinct things observed — one ledger item per distinct symptom, surface, or
+   idea. Use the operator's own structure (numbered/bulleted list, blank-line
+   paragraphs, "and another thing…") as the split boundary; do **not** merge two
+   unrelated symptoms or split one symptom into several. **Echo the parsed list
+   back** ("I read N observations: …") and let the operator correct the split
+   before you enrich anything — the only confirmation intake requires. A
+   single-observation message is the N = 1 case; skip the echo when it is
    unambiguously one item.
 2. **Process each observation in turn** through the rest of this phase and
    Phases 2–3. For each one:
    - **Restate the observation** in your own words — the surface it touches, the
      action taken, the actual result, and (for a bug) the expected result, or
-     (for an enhancement) the desired improvement. This restatement is your read
-     of the signal.
-   - **Ask clarifying questions only when that observation is ambiguous.** If
-     you cannot confidently fill in the load-bearing facts, **ask** — do not
-     paper over the gap with an assumption. Typical gaps: which
-     surface/command/flow; the exact steps and whether it reproduces or is
-     intermittent; what was expected and why that is the contract; the
-     environment (OS, shell, branch, fresh vs. reused state). When the
-     observation is already clear, **do not interrogate** — move straight to
-     Enrich. Batch the questions across the brain dump into one message rather
-     than interrogating item-by-item, so the operator answers them all at once.
+     (for an enhancement) the desired improvement.
+   - **Ask clarifying questions only when that observation is ambiguous.** If you
+     cannot confidently fill in the load-bearing facts, **ask** — do not paper
+     over the gap with an assumption. Typical gaps: which surface/command/flow;
+     the exact steps and whether it reproduces; what was expected and why that is
+     the contract; the environment (OS, shell, branch, fresh vs. reused state).
+     When the observation is already clear, **do not interrogate**. Batch the
+     questions across the brain dump into one message.
 
 ---
 
 ## Phase 2 — Enrich (per observation)
 
 Goal: turn the observation into a high-quality, triage-ready finding. Delegate
-every decision to the shared core helpers; never re-derive them in prose.
+every decision to the shared helpers; never re-derive them in prose.
 
-1. **Redact first.** Before any evidence string touches disk or GitHub, scrub
-   it through [`redact-evidence.js`](../scripts/lib/qa/redact-evidence.js):
-
-   ```js
-   import { redactEvidence } from '../scripts/lib/qa/redact-evidence.js';
-   const evidence = redactEvidence(rawObservation);
-   ```
-
-   This is mandatory per [`security-baseline.md`](../rules/security-baseline.md)
-   (§ Data Leakage & Logging, § Secrets Management) — bearer tokens, session
-   cookies, and emails are masked. The pass is idempotent, so redact eagerly.
-
+1. **Redact first** (per [`helpers/qa-core.md`](helpers/qa-core.md)) — scrub the
+   evidence string through `redactEvidence` before it touches disk or GitHub.
 2. **Branch on what kind of observation it is.**
    - **Bug.** Establish a clean, minimal, deterministic **repro**. Investigate
-     the **root cause**: read the relevant code, console output, and logs for
-     errors, and pin the locus as a concrete **`file:line`** reference (say so
-     explicitly if you cannot pin it rather than inventing a locus). Then run
-     the coverage steps below.
-   - **Enhancement / suggestion.** Analyze **how** the change would be made:
-     the surfaces it touches, the **options** for implementing it, and a brief
-     **recommendation** with trade-offs. Record these notes on the ledger item.
-     Still pin the relevant `file:line` anchor(s) where the change would land.
-
+     the **root cause** (read the relevant code, console, and logs) and pin the
+     locus as a concrete **`file:line`** reference (say so explicitly if you
+     cannot pin it rather than inventing a locus). Then run the coverage steps.
+   - **Enhancement / suggestion.** Analyze **how** the change would be made: the
+     surfaces it touches, the **options**, and a brief **recommendation** with
+     trade-offs. Still pin the relevant `file:line` anchor(s) where the change
+     would land.
 3. **Hydrate the QA context** to locate code precisely, via
    [`qa-context-hydrator.js`](../scripts/lib/qa/qa-context-hydrator.js) — it
-   resolves the source ticket body, the
-   feature-file set, the surface
-   map, and recent git log:
+   resolves the source ticket body, the feature-file set, the surface map, and
+   recent git log:
 
    ```js
    import { hydrateQaContext } from '../scripts/lib/qa/qa-context-hydrator.js';
@@ -237,22 +186,18 @@ every decision to the shared core helpers; never re-derive them in prose.
    via [`coverage-verdict.js`](../scripts/lib/qa/coverage-verdict.js) — the
    deterministic seam behind the
    [`core/qa-coverage-mapping`](../skills/core/qa-coverage-mapping/SKILL.md)
-   skill. Read that skill for how to assemble the `surface` input and how to
-   read the per-tier `{present|absent}` verdict. Optionally render a
-   human-readable summary via
-   [`coverage-report.js`](../scripts/lib/qa/coverage-report.js).
-
+   skill. Read that skill for how to assemble the `surface` input and read the
+   per-tier `{present|absent}` verdict. Optionally render a human-readable
+   summary via [`coverage-report.js`](../scripts/lib/qa/coverage-report.js).
 5. **Propose the missing test** (if any) from that verdict, via
-   [`propose-missing-test.js`](../scripts/lib/qa/propose-missing-test.js). It
+   [`propose-missing-test.js`](../scripts/lib/qa/propose-missing-test.js) — it
    names the lowest absent tier, or returns `null` when every tier is covered.
-   Record the proposal's `description` as the ledger item's `missingTest`.
-
+   Record its `description` as the ledger item's `missingTest`.
 6. **Classify** the finding via
    [`classify-finding.js`](../scripts/lib/findings/classify-finding.js) so the
-   tentative `class` resolves to the correct focus/meta label set
-   (`tooling-dx` carries `meta::framework-gap`; `enhancement` carries
-   `meta::consumer-improvement`). The helper **throws** on an absent/unknown
-   class — fix the finding's class rather than defaulting.
+   tentative `class` resolves to the correct focus/meta label set. The helper
+   **throws** on an absent/unknown class — fix the finding's class rather than
+   defaulting.
 
 ---
 
@@ -262,21 +207,20 @@ Goal: persist the enriched finding to the rolling ledger and **return to
 intake**. **No triage, routing, ticket-filing, or `/plan` happens here** — that
 is Phase 4, and only after the operator says they are done.
 
-1. **Append a `QaLedgerItem`** to `temp/qa/<sessionId>.ndjson`, conforming to
-   [`qa-ledger.schema.json`](../schemas/qa-ledger.schema.json): a stable `id`
-   (`L1`, `L2`, … appended after any carried backlog), the redacted `evidence`,
-   the repro and root-cause `file:line` notes (or the enhancement
-   analysis/options/recommendation), the `coverage` label, the `class` and
-   `severity`, the `missingTest`, and a `disposition` of **untriaged** (intake
-   does not decide disposition — Phase 4 does).
+1. **Append a `QaLedgerItem`** to the ledger (shape per
+   [`helpers/qa-core.md`](helpers/qa-core.md)): a stable `id` (appended after any
+   carried backlog), the redacted `evidence`, the repro and root-cause
+   `file:line` notes (or the enhancement analysis/options/recommendation), the
+   `coverage` label, the `class` and `severity`, the `missingTest`, and a
+   `disposition` of **untriaged** (intake does not decide disposition — Phase 4
+   does).
 2. **Echo the recorded item** back in one short line — its `class`, `severity`,
-   root-cause locus or recommendation, and coverage verdict — so the operator
-   can correct it on the spot. When a brain dump produced several items, append
-   them all, then echo a **compact batch summary** (one line per new `Lx` item)
-   instead of a separate message per item.
-3. **Loop back to Phase 1** and wait for the next message. Keep doing this for
-   as many observations as the operator reports — one at a time or in batches,
-   in any order — until they say they are done testing.
+   root-cause locus or recommendation, and coverage verdict — so the operator can
+   correct it on the spot. When a brain dump produced several items, append them
+   all, then echo a **compact batch summary** (one line per new `Lx` item).
+3. **Loop back to Phase 1** and wait for the next message. Keep doing this for as
+   many observations as the operator reports — one at a time or in batches, in
+   any order — until they say they are done testing.
 
 ---
 
@@ -286,69 +230,20 @@ Goal: when the operator says they have finished testing, turn the **whole**
 ledger into a plan. This is the only phase that triages, routes, or plans, and
 its transition is **explicitly operator-gated**.
 
-1. **Final ledger review.** Read the entire rolling ledger back to the
-   operator: every item, its class/severity, root-cause or recommendation, and
-   coverage verdict. Confirm it is complete and ask any **last clarifying
-   questions** — missing repro, an item that should be split or merged, a
-   severity to adjust. Let the operator set each item's disposition
-   (`file` / `defer` / `dismiss`).
-
-2. **Dedup / route** each `file`-dispositioned finding against existing GitHub
-   Issues via [`route-finding.js`](../scripts/lib/findings/route-finding.js)
-   (the **single** dedup implementation shared with `/qa-explore` and
-   `audit-to-stories`), backed by
-   [`semantic-issue-search.js`](../scripts/lib/findings/semantic-issue-search.js):
-
-   ```js
-   import { routeFinding, fingerprintFooter } from '../scripts/lib/findings/route-finding.js';
-   const { decision, matchedIssue, fingerprint } =
-     await routeFinding(finding, { searchIssues });
-   ```
-
-   `decision` is one of `new` / `update-existing` / `duplicate` /
-   `regression-of-closed`. Stamp the `fingerprintFooter(sha)` marker into any
-   Issue body so future runs dedup against it.
-
-3. **Promote the full ledger through `/plan`** (never a raw GitHub Issue) via
-   [`promote-finding.js`](../scripts/lib/findings/promote-finding.js), which
-   clusters, sizes, routes, and files through the same ports `/qa-explore` and
-   `/audit-to-stories` consume — never hand-roll the promotion, the clustering,
-   or the sizing:
-
-   ```js
-   import { promoteFindings } from '../scripts/lib/findings/promote-finding.js';
-   const { promotions } = await promoteFindings(ledgerItems, {
-     searchIssues, // GitHub provider, open + closed
-     createStory, // tight cluster (≤2 surfaces): seed → /plan --seed-file
-     createPlanSeed, // broad cluster (>2 surfaces): same /plan --seed-file path (may N>1)
-   });
-   ```
-
-   - **Sizing is delegated, not decided in prose.** `promoteFindings` runs
-     `clusterLedgerItems` + `targetForCluster`: a cluster spanning **≤2**
-     distinct coverage surfaces routes to `createStory`; **>2** routes to
-     `createPlanSeed`. Neither port opens an Epic ticket — both chain
-     `/plan --seed-file`. Do not re-cluster, re-size, or re-dedup in the
-     workflow —
-     [`route-finding.js`](../scripts/lib/findings/route-finding.js) /
-     [`promote-finding.js`](../scripts/lib/findings/promote-finding.js) are the
-     single implementation.
-   - **`createStory` / `createPlanSeed` (`/plan --seed-file`)** — render a
-     **redacted** plan seed from the cluster (reuse the `/audit-to-stories`
-     Phase 5a seed shape; redaction already ran in Phase 2), **stamp the
-     cluster's `fingerprintFooter(sha)` verbatim into the seed body**, then
-     chain `/plan --seed-file <seed>`. Prefer one Story; split only under
-     the default-single policy. The footer must survive into the issue body
-     so a later `routeFinding` dedups the same finding instead of re-filing
-     it.
-   - **A `file` disposition never opens a raw GitHub Issue.** Every `file`
-     finding flows through `promoteFindings` → `/plan`; only `defer` (carry
-     forward as backlog) and `dismiss` (non-actionable) skip the handoff.
-
-4. **Gate:** the move into this phase, and every write inside it (seed write,
+1. **Final ledger review.** Read the entire rolling ledger back to the operator:
+   every item, its class/severity, root-cause or recommendation, and coverage
+   verdict. Confirm it is complete and ask any **last clarifying questions** —
+   missing repro, an item that should be split or merged, a severity to adjust.
+   Let the operator set each item's disposition (`file` / `defer` / `dismiss`).
+2. **Triage the ledger** through the shared classify → route → disposition →
+   promote procedure in [`helpers/qa-core.md`](helpers/qa-core.md): dedup/route
+   each `file` finding against open + closed Issues, then promote the
+   `file`-dispositioned findings through `promoteFindings` → `/plan` (never a raw
+   Issue), stamping each cluster's `fingerprintFooter(sha)` into the seed.
+   `defer` carries an item forward as backlog; `dismiss` marks it non-actionable.
+3. **Gate:** the move into this phase, and every write inside it (seed write,
    `/plan` invocation, ticket-filing, label mutation), is **operator-gated** —
-   confirm each one. The plan→deliver hard stop is preserved: each `/plan`
-   chain pauses at its own HITL gates and never auto-delivers. Redaction has
+   confirm each one. The plan→deliver hard stop is preserved; redaction has
    already run, so nothing unredacted reaches disk or GitHub.
 
 After planning, summarize: the findings recorded, the route/promotion decisions
@@ -360,60 +255,36 @@ resumed session will pick up.
 
 ## Constraints
 
+Beyond the shared core ([`helpers/qa-core.md`](helpers/qa-core.md): contract +
+loud failure, session/ledger, redact-first, QaLedgerItem, triage, HITL gate),
+the `/qa-assist`-specific deltas are:
+
 - **Human-led, rolling, multi-observation.** The operator owns the signal and
-  reports observations in any order and any quantity — one at a time or a brain
-  dump of many in a single message. The agent splits a brain dump into discrete
-  ledger items (echoing the split for correction), then enriches and records
-  each one. Never invent an observation; **ask clarifying questions** only when
-  an observation is ambiguous, batched across the dump.
-- **Record during intake; plan only on "done".** Phases 1–3 enrich and append
-  to the ledger and loop — they never triage, route, file tickets, or invoke
-  `/plan`. All of that is **Phase 4**, entered only after explicit operator
-  confirmation that testing is done.
+  reports in any order and quantity — one at a time or a brain dump. The agent
+  splits a brain dump (echoing the split for correction), then enriches and
+  records each. **Never invent an observation**; ask clarifying questions only
+  when one is ambiguous, batched across the dump.
+- **Record during intake; plan only on "done".** Phases 1–3 enrich, append, and
+  loop — never triage, route, file, or invoke `/plan`. All of that is Phase 4,
+  entered only on explicit operator confirmation that testing is done.
 - **Light intake gate, firm boundary gate.** Intake → Enrich → Record is fluid
-  (echo-back, no ceremony); the session-level move into Phase 4 and **every
-  write** that leaves the local ledger (ticket, `/plan`, label) require
-  **explicit operator confirmation**.
-- **Persistent, resumable rolling session.** `/qa-assist` defaults to resuming
-  the same session and **appending** to its ledger; a reused session carries
-  the un-triaged backlog forward via
-  [`qa-session.js`](../scripts/lib/qa/qa-session.js) and never overwrites a
-  prior ledger.
-- **The ledger lives under `temp/qa/` only**, one `QaLedgerItem` per ndjson
-  line, conforming to [`qa-ledger.schema.json`](../schemas/qa-ledger.schema.json).
-  Never commit it.
-- **Redact before persist.** Every evidence string passes through
-  [`redact-evidence.js`](../scripts/lib/qa/redact-evidence.js) before it
-  reaches disk or GitHub, per [`security-baseline.md`](../rules/security-baseline.md).
-- **Consume the shared core; never reimplement.** Context hydration
+  (echo-back, no ceremony); the move into Phase 4 and every write that leaves the
+  ledger are hard-gated.
+- **Persistent, resumable rolling session** — `/qa-assist` defaults to resuming
+  the same session and appending; a reused session carries the untriaged backlog
+  forward and never overwrites a prior ledger.
+- **Enrichment helpers are deterministic** — context hydration
   ([`qa-context-hydrator.js`](../scripts/lib/qa/qa-context-hydrator.js)),
-  coverage verdict ([`coverage-verdict.js`](../scripts/lib/qa/coverage-verdict.js)),
-  coverage report ([`coverage-report.js`](../scripts/lib/qa/coverage-report.js)),
-  missing-test ([`propose-missing-test.js`](../scripts/lib/qa/propose-missing-test.js)),
-  classification ([`classify-finding.js`](../scripts/lib/findings/classify-finding.js)),
-  dedup/route ([`route-finding.js`](../scripts/lib/findings/route-finding.js)),
-  semantic search ([`semantic-issue-search.js`](../scripts/lib/findings/semantic-issue-search.js)),
-  promotion ([`promote-finding.js`](../scripts/lib/findings/promote-finding.js)),
-  and session resolution ([`qa-session.js`](../scripts/lib/qa/qa-session.js))
-  are deterministic — never re-derive them in prose.
-- **Promote through `/plan`, never a raw Issue.** A `file`-dispositioned
-  finding is promoted via `promoteFindings`, which chains into
-  [`/plan`](plan.md) (`--seed-file` for a tight cluster, `--seed` for a broad
-  one) — mirroring [`/audit-to-stories`](audit-to-stories.md). `/qa-assist`
-  never opens a bare GitHub Issue for a `file` finding. The cluster's
-  `fingerprintFooter(sha)` is stamped verbatim into the seed so a future
-  `routeFinding` dedups it.
+  coverage verdict/report, missing-test, and classification are never re-derived
+  in prose.
 
 ## See also
 
-- [`/plan`](plan.md) — the planning pipeline `/qa-assist` chains into in
-  Phase 4 (`--seed-file` / `--seed`). The plan→deliver
-  hard stop is preserved across the handoff.
+- [`/plan`](plan.md) — the planning pipeline `/qa-assist` chains into in Phase 4.
+  The plan→deliver hard stop is preserved across the handoff.
 - [`/qa-explore`](qa-explore.md) — the agent-led sibling that drives a named
   surface and triages through the same `/plan` handoff.
 - [`/audit-to-stories`](audit-to-stories.md) — the precedent for the
   findings → `/plan` handoff and the shared fingerprint-footer dedup contract.
-- [`promote-finding.js`](../scripts/lib/findings/promote-finding.js) /
-  [`route-finding.js`](../scripts/lib/findings/route-finding.js) — the shared
-  cluster/size/promote and dedup/route/fingerprint-footer helpers. There is no
-  second clustering, sizing, or dedup implementation.
+- [`helpers/qa-core.md`](helpers/qa-core.md) — the shared contract/session/
+  redaction/QaLedgerItem/triage/HITL core.

--- a/.agents/workflows/qa-explore.md
+++ b/.agents/workflows/qa-explore.md
@@ -16,64 +16,44 @@ follow-up dispositions.
 This is the **agent-led** front-end of exploratory QA: **the agent drives, the
 operator watches and gates.** Its human-led sibling is
 [`/qa-assist`](qa-assist.md) — there the *human* drives a single observation and
-the agent scribes/enriches. No human-driven flow lives in `/qa-explore`; if you
-want to capture something *you* observed, use `/qa-assist` instead.
+the agent scribes/enriches. No human-driven flow lives in `/qa-explore`.
 
-Unlike [`/qa-run`](qa-run.md) (which steps a known set of
-Gherkin `.feature` scenarios through a browser), `/qa-explore` is **open-ended
-exploration**: the agent probes the surface for product bugs, environment-setup
-friction, tooling/DX gaps, missing tests, and enhancement ideas — each captured
-as a `QaLedgerItem` against the
-[`qa-ledger.schema.json`](../schemas/qa-ledger.schema.json) contract.
+Unlike [`/qa-run`](qa-run.md) (which steps a known set of Gherkin `.feature`
+scenarios through a browser), `/qa-explore` is **open-ended exploration**: the
+agent probes the surface for product bugs, environment-setup friction,
+tooling/DX gaps, missing tests, and enhancement ideas — each captured as a
+`QaLedgerItem`.
 
-This is a **prose workflow**, not a Node orchestrator: the host LLM executes
-the procedure; deterministic Node helpers under `.agents/scripts/lib/qa/` and
-`.agents/scripts/lib/findings/` do the contract resolution, session/ledger
-resolution, redaction, coverage verdict, missing-test proposal, classification,
-and dedup/route decisions. The agent never invents those decisions in prose.
+The shared machinery — contract resolution + loud failure, the session & ledger
+contract, redact-first, the `QaLedgerItem` shape, the triage procedure, and the
+HITL write gate — lives once in [`helpers/qa-core.md`](helpers/qa-core.md); this
+workflow states only the `/qa-explore`-specific phases (Plan / Capture) plus a
+Constraints delta.
 
 > **When to run**: ad-hoc agent-driven exploration of a freshly delivered Story
-> or Feature, a regression sweep over a risky surface before `/deliver`, or
-> a structured agent-driven bug-hunt the operator wants captured into a
-> triageable ledger.
+> or Feature, a regression sweep over a risky surface before `/deliver`, or a
+> structured agent-driven bug-hunt captured into a triageable ledger.
 >
 > **Skills**: `core/qa-coverage-mapping`, `stack/qa/qa-explore-driving`
 
 ## Role framing
 
 You are the quality gatekeeper for this run: value coverage, hermetic
-environments, and deterministic results. Do **not** invent signal — capture
-what the surface shows. Apply the QA skills below; there is no separate
-persona pack.
+environments, and deterministic results. Do **not** invent signal — capture what
+the surface shows. Apply the QA skills below; there is no separate persona pack.
 
-## Driving conventions skill
+## Driving conventions
 
 Before you drive a surface, read the
 [`stack/qa/qa-explore-driving`](../skills/stack/qa/qa-explore-driving/SKILL.md)
-skill. It is the conventions reference this procedure depends on for the
-**how** of agent-driven exploration:
-
-- **Navigation-first driving (the default).** Drive the running app through the
-  browser MCP, starting at a root and reaching each surface only via UI
-  affordances — never URL-jump to a deep link. Browser instrumentation lives in
-  [`core/browser-testing-with-devtools`](../skills/core/browser-testing-with-devtools/SKILL.md).
-- **Static driving (the documented interim).** When **no seam resolves** for the
-  target environment, walk the surface from source, route definitions, and
-  rendered markup — chosen explicitly at Plan time, never as a silent fallback.
-- **Authenticated driving follows the per-environment seam.** When the resolved
-  target environment carries a `signInSeam` — a dev `url` seam or a `skill` seam
-  with `credentialRef`-indirected sign-in — drive the authenticated surface via
-  that seam, including authenticated deployed hosts. Real credentials are never
-  typed inline: the seam consumes a persona **name** (`url`) or a stored
-  `credentialRef` (`skill`), and every evidence string passes through mandatory
-  redaction. Static is the interim **only** where the target environment
-  resolves no seam.
-- **Broken navigation is a finding, not a workaround.** A missing affordance, a
-  nav 404, or a guard redirect loop is recorded and you move on — you do not
-  route around it with a direct URL.
-
-The driving method (drive vs. static) is a **Plan-phase decision recorded in the
-ledger**; do not switch methods mid-surface without a new Plan note.
+skill — the **one** conventions reference for the *how* of agent-driven
+exploration (navigation-first driving as the default; static driving as the
+documented interim chosen at Plan time only where no seam resolves;
+authenticated driving through the resolved environment's `signInSeam`; broken
+navigation is a finding, not a workaround). The driving method (drive vs.
+static) is a **Plan-phase decision recorded in the ledger**; do not switch
+methods mid-surface without a new Plan note. Do not restate these conventions
+inline — the skill owns them.
 
 ## Slash Command
 
@@ -87,45 +67,17 @@ ledger**; do not switch methods mid-surface without a new Plan note.
 | --------- | -------- | ---------------------------------- | -------------------------------------------------------------------------------------- |
 | `surface` | yes      | `feature:login`, `area:onboarding` | A human label for the single surface to explore. Recorded as each ledger item's `coverage`. |
 
-If no `surface` is supplied, **stop and ask** the operator to name one — do
-not invent scope. `/qa-explore` is **bounded to one surface per session**:
-explore exactly the named surface, do not wander into adjacent surfaces, and
-start a fresh session for a different surface.
+If no `surface` is supplied, **stop and ask** the operator to name one — do not
+invent scope. `/qa-explore` is **bounded to one surface per session**: explore
+exactly the named surface, do not wander into adjacent surfaces, and start a
+fresh session for a different surface.
 
-## Project contract
+## Contract & session
 
-Resolve the consumer's `qa` contract before exploring, via
-[`resolve-qa-contract.js`](../scripts/lib/qa/resolve-qa-contract.js):
-
-```js
-import { resolveQaContract } from '../scripts/lib/qa/resolve-qa-contract.js';
-const contract = resolveQaContract(config); // throws loudly if unbound
-```
-
-The resolver fails **loudly** when the project has not bound the QA harness
-(no `qa` block in `.agentrc.json`) — there is no silent fallback. If it throws
-the "this project has not bound the QA harness" message, surface that verbatim
-to the operator and stop; do not pretend a contract exists.
-
-## Session & ledger (temp/qa/)
-
-Resolve the session and its ledger path **once**, up front, via
-[`qa-session.js`](../scripts/lib/qa/qa-session.js):
-
-```js
-import { resolveQaSession } from '../scripts/lib/qa/qa-session.js';
-const { sessionId, ledgerPath, reused, untriaged } = resolveQaSession({ config });
-```
-
-- The ledger is always written under **`temp/qa/<sessionId>.ndjson`**
-  (`<tempRoot>/qa/`, resolved from `project.paths.tempRoot`). It is one
-  `QaLedgerItem` per line (ndjson). **Never** write the ledger anywhere else,
-  and never commit it — `temp/` is gitignored per
-  [`.agents/instructions.md` § 6](../instructions.md).
-- When `reused` is `true`, a prior session of the same id exists: **append**,
-  never overwrite, and carry the `untriaged` items forward as the rolling
-  backlog (resume safety). Pass `--session-id <id>` (or `QA_SESSION_ID`) to
-  resume a named session.
+Resolve the `qa` contract and the session (under `temp/qa/`) per
+[`helpers/qa-core.md`](helpers/qa-core.md) before exploring — the resolver fails
+**loudly** when the project has not bound the harness; surface that verbatim and
+stop. A reused session appends and carries its `untriaged` backlog forward.
 
 ## Bounded per-surface session
 
@@ -133,9 +85,9 @@ A `/qa-explore` run is a **single bounded session over one named surface**, not
 an open-ended sweep:
 
 - **One surface.** The session explores exactly the `surface` argument. Driving
-  the named surface may legitimately touch sub-surfaces reachable from it
-  navigation-first, but the session does not pivot to a different top-level
-  surface — that is a new session.
+  it may legitimately touch sub-surfaces reachable navigation-first, but the
+  session does not pivot to a different top-level surface — that is a new
+  session.
 - **Bounded by the operator's gate.** Capture continues until the operator says
   exploration is complete (the Capture → Triage gate), not until the agent has
   exhausted the app. The agent proposes when it believes the surface is
@@ -145,12 +97,11 @@ an open-ended sweep:
 
 ## Phase gates (HITL)
 
-Every phase transition is gated on **explicit operator confirmation**. Do not
-advance Plan → Capture, or Capture → Triage, until the operator says so. State
-each gate as a question, present the artifact (the plan with its chosen driving
-method, then the captured ledger), and wait. This is a HITL workflow — the
-agent drives and captures, but it never files tickets, promotes findings, or
-advances phases autonomously. If the operator does not confirm, stop and hold.
+Every phase transition is gated on **explicit operator confirmation** (the HITL
+write gate in [`helpers/qa-core.md`](helpers/qa-core.md)). Do not advance
+Plan → Capture, or Capture → Triage, until the operator says so. State each gate
+as a question, present the artifact (the plan with its chosen driving method,
+then the captured ledger), and wait. If the operator does not confirm, hold.
 
 ---
 
@@ -159,57 +110,36 @@ advances phases autonomously. If the operator does not confirm, stop and hold.
 Goal: agree on **what** will be explored and **how the agent will drive it**
 before touching the surface.
 
-1. Re-read the
-   [`stack/qa/qa-explore-driving`](../skills/stack/qa/qa-explore-driving/SKILL.md)
-   skill, and resolve the `qa` contract and session (above).
+1. Re-read the `stack/qa/qa-explore-driving` skill and resolve the contract and
+   session (above).
 2. **Resolve the target environment** via
-   [`resolveQaEnvironment`](../scripts/lib/qa/resolve-qa-contract.js). The
-   contract's `environments` map keys each deployment target (`local`, a
-   staging host, an authenticated deployed host) to its `baseUrl`, `signInSeam`,
-   and resolved `allowWrites`:
-
-   ```js
-   import { resolveQaEnvironment } from '../scripts/lib/qa/resolve-qa-contract.js';
-   // `target` is an environment name or a raw URL; omit for the default.
-   const environment = resolveQaEnvironment(contract, target);
-   // → { name, baseUrl, signInSeam, allowWrites }
-   ```
-
-   When the operator's `surface` does not pin an unambiguous target and the
-   contract declares more than one environment, **prompt** the operator to name
-   the environment (or accept the `defaultEnvironment`) — never silently pick
-   one. The resolver throws loudly (naming the known environments) on an unknown
-   name or an unmatched URL; surface that verbatim and stop. Record the resolved
-   **environment name** on the ledger alongside the driving method.
+   [`resolveQaEnvironment`](../scripts/lib/qa/resolve-qa-contract.js) — it keys
+   each deployment target to `{ name, baseUrl, signInSeam, allowWrites }`. When
+   the operator's `surface` does not pin an unambiguous target and the contract
+   declares more than one environment, **prompt** the operator (or accept
+   `defaultEnvironment`) — never silently pick one. The resolver throws loudly
+   (naming the known environments) on an unknown name or unmatched URL; surface
+   that verbatim and stop.
 3. **Choose the driving method explicitly** for the named `surface` on the
    resolved environment:
-   - **Drive (default):** a seam resolves for the target environment, so the
-     agent will drive it through the browser MCP, navigation-first (start at a
-     root, reach the surface via UI affordances, never URL-jump). Drive is
-     available for **any** environment whose `signInSeam` resolves — including
-     authenticated deployed hosts reached via a `skill` seam.
-   - **Static (documented interim):** **no seam resolves** for the target
-     environment, so the agent will walk the surface from source, routes, and
-     rendered markup. This is a deliberate Plan-time decision with a recorded
-     reason, never a silent fallback when the browser MCP hiccups.
-
-   Record the resolved environment name, the chosen method, and the reason on
-   the ledger (e.g.
-   `environment: staging, method: drive, seam: skill` or
+   - **Drive (default):** a seam resolves, so drive through the browser MCP
+     navigation-first — including authenticated deployed hosts reached via a
+     `skill` seam (a stored `credentialRef` read by the named sign-in skill,
+     never a hand-typed secret) or a dev `url` seam (persona name substituted).
+   - **Static (documented interim):** **no seam resolves**, so walk the surface
+     from source, routes, and rendered markup — a deliberate Plan-time decision
+     with a recorded reason, never a silent fallback.
+4. Draft an **exploration plan**: the resolved target environment (name +
+   `baseUrl`), the sub-surfaces / flows / states to drive, the classes of signal
+   being hunted (the [ledger `class` enum](../schemas/qa-ledger.schema.json)),
+   the chosen method and its rationale, and any rolling backlog carried forward.
+   Record the resolved **environment name**, the chosen method, and the reason on
+   the ledger (e.g. `environment: staging, method: drive, seam: skill` or
    `environment: preview, method: static, reason: no seam resolves`).
-4. Draft an **exploration plan** for the named `surface`:
-   - the resolved target environment (name + `baseUrl`),
-   - the sub-surfaces / flows / states the agent intends to drive,
-   - the classes of signal it is hunting (product bug, environment-setup,
-     tooling-dx, test-gap, enhancement — the
-     [ledger `class` enum](../schemas/qa-ledger.schema.json)),
-   - the chosen driving method and its rationale,
-   - any rolling backlog (`untriaged`) carried forward from a resumed session.
-5. Present the plan, the resolved target environment, the chosen driving
-   method, and the resolved `ledgerPath` (under `temp/qa/`) to the operator.
-6. **Gate:** ask the operator to confirm the plan, the target environment, and
-   the driving method (or amend the surface/scope/environment/method). Do
-   **not** proceed to Capture until they confirm.
+5. Present the plan, the resolved environment, the chosen method, and the
+   resolved `ledgerPath` to the operator.
+6. **Gate:** ask the operator to confirm the plan, the environment, and the
+   method (or amend). Do **not** proceed to Capture until they confirm.
 
 ---
 
@@ -220,73 +150,42 @@ observations. **This phase is strictly read-only.**
 
 > **Read-only invariant.** The agent observes; it never mutates. Per
 > [`stack/qa/qa-explore-driving`](../skills/stack/qa/qa-explore-driving/SKILL.md)
-> § 3 (inviolable per
-> [`security-baseline.md`](../rules/security-baseline.md)), do **not** edit
-> source, run write commands, file or label GitHub issues, change tickets,
-> submit destructive forms, or alter the product under test. The only write
-> Capture performs is **appending ledger lines to
-> `temp/qa/<sessionId>.ndjson`** — session scratch, not a repository or product
-> mutation. Any action that would change state belongs in Triage (and only
-> after the operator confirms). When a surface's only path forward is a
+> § 3 (inviolable per [`security-baseline.md`](../rules/security-baseline.md)),
+> do **not** edit source, run write commands, file or label GitHub issues,
+> change tickets, submit destructive forms, or alter the product under test. The
+> only write Capture performs is **appending ledger lines to
+> `temp/qa/<sessionId>.ndjson`**. When a surface's only path forward is a
 > mutating action, record the boundary as the finding and stop — do not cross
 > it.
 
-**Drive the surface using the method chosen in Plan:**
-
-- **Drive (default):** reach the surface navigation-first through the browser
-  MCP — start at a root, click the affordances a real user would, and observe
-  the rendered state, console, and network signal. Never URL-jump to establish
-  a starting state; a broken affordance, nav 404, or guard redirect loop is
-  itself a **finding**, not a workaround. To reach an authenticated surface,
-  sign in through the resolved environment's `signInSeam` — a dev `url` seam
-  (substitute the persona name into the template) or a `skill` seam (invoke the
-  named sign-in skill, which reads a stored `credentialRef`). Never type real
-  credentials inline and never fabricate a session; the seam is the only path
-  to a logged-in surface, and all captured evidence is redacted (§ 1 below).
-- **Static (documented interim):** walk the surface from source, route
-  definitions, and rendered markup. Treat its coverage as partial and say so in
-  the ledger — a static pass does not close the same coverage a driven pass
-  would.
+Drive the surface using the method chosen in Plan (per the driving-conventions
+skill): navigation-first through the browser MCP for **drive**, signing in
+through the resolved environment's `signInSeam`; or walking source, routes, and
+rendered markup for **static** (treat its coverage as partial and say so in the
+ledger). Never URL-jump to establish a starting state, and reach an
+authenticated surface only through the resolved environment's `signInSeam`:
+**Never type real credentials inline** and never fabricate a session.
 
 For each observation the agent makes while driving:
 
-1. **Redact first.** Before any evidence string touches disk, scrub it through
-   [`redact-evidence.js`](../scripts/lib/qa/redact-evidence.js):
-
-   ```js
-   import { redactEvidence } from '../scripts/lib/qa/redact-evidence.js';
-   const evidence = redactEvidence(rawObservation);
-   ```
-
-   This is mandatory per [`security-baseline.md`](../rules/security-baseline.md)
-   (§ Data Leakage & Logging, § Secrets Management) — bearer tokens, session
-   cookies, Authorization headers, and emails are masked. The pass is
-   idempotent, so redact eagerly; captured console and network evidence is
-   untrusted until scrubbed.
-
+1. **Redact first** (per [`helpers/qa-core.md`](helpers/qa-core.md)) — scrub the
+   evidence string through `redactEvidence` before it touches disk.
 2. **Compute the coverage verdict** for the surface the observation points at,
    via [`coverage-verdict.js`](../scripts/lib/qa/coverage-verdict.js) — the
    deterministic seam behind the
    [`core/qa-coverage-mapping`](../skills/core/qa-coverage-mapping/SKILL.md)
-   skill. Read that skill for how to assemble the `surface` input (symbol +
-   the unit/contract/acceptance tests around it) and how to read the per-tier
-   `{present|absent}` verdict.
-
+   skill. Read that skill for how to assemble the `surface` input and read the
+   per-tier `{present|absent}` verdict.
 3. **Propose the missing test** (if any) from that verdict, via
-   [`propose-missing-test.js`](../scripts/lib/qa/propose-missing-test.js). It
-   names the lowest absent tier (the cheapest gap the signal leaked through),
-   or returns `null` when every tier is covered. Record the proposal's
-   `description` as the ledger item's `missingTest` (or `null`).
-
-4. **Append a `QaLedgerItem`** to `temp/qa/<sessionId>.ndjson`, conforming to
-   [`qa-ledger.schema.json`](../schemas/qa-ledger.schema.json): a stable
-   `id` (`L1`, `L2`, … in capture order), the redacted `evidence`, the
-   `coverage` label (the `surface`, or `unknown`), a tentative `class` and
-   `severity`, the `missingTest`, and `disposition` left untriaged for now.
-
+   [`propose-missing-test.js`](../scripts/lib/qa/propose-missing-test.js) — it
+   names the lowest absent tier, or returns `null` when every tier is covered.
+   Record its `description` as the ledger item's `missingTest` (or `null`).
+4. **Append a `QaLedgerItem`** to the ledger (shape per
+   [`helpers/qa-core.md`](helpers/qa-core.md)): a stable `id`, the redacted
+   `evidence`, the `coverage` label (the `surface`, or `unknown`), a tentative
+   `class` and `severity`, the `missingTest`, and `disposition` left untriaged.
 5. Continue driving until the agent believes the surface is covered, then
    propose that exploration is complete.
-
 6. **Gate:** present the captured ledger (item count, classes, the driving
    method used, the rolling backlog) and ask the operator to confirm moving to
    Triage. Do **not** triage until they confirm.
@@ -295,144 +194,54 @@ For each observation the agent makes while driving:
 
 ## Phase 3 — Triage
 
-Goal: turn the captured ledger into routed, classified, dedup'd dispositions —
-with the operator deciding each `file` / `defer` / `dismiss`.
-
-For each untriaged ledger item:
-
-1. **Classify** it via
-   [`classify-finding.js`](../scripts/lib/findings/classify-finding.js). The
-   item's `class` resolves to the focus/meta label set Triage applies when
-   promoting it (`tooling-dx` carries `meta::framework-gap`; `enhancement`
-   carries `meta::consumer-improvement`). The helper **throws** on an
-   absent/unknown class — fix the ledger item's class rather than defaulting.
-
-2. **Dedup / route** it against existing GitHub Issues via
-   [`route-finding.js`](../scripts/lib/findings/route-finding.js):
-
-   ```js
-   import { routeFinding, fingerprintFooter } from '../scripts/lib/findings/route-finding.js';
-   const { decision, matchedIssue, fingerprint } =
-     await routeFinding(finding, { searchIssues });
-   ```
-
-   `decision` is one of `new` / `update-existing` / `duplicate` /
-   `regression-of-closed`. This is the **single** dedup implementation shared
-   with `/qa-assist` and `audit-to-stories`; stamp the `fingerprintFooter(sha)`
-   marker into any Issue body so future runs dedup against it. Wire the
-   `searchIssues` port to the GitHub provider (querying both open and closed
-   Issues).
-
-3. **Decide the disposition** with the operator: `file` (promote through
-   `/plan` — never a raw GitHub Issue), `defer` (carry forward to a later
-   session as backlog), or `dismiss` (non-actionable). Record the chosen
-   `disposition` back onto the ledger item.
-
-4. **Promote the `file`-dispositioned findings through `/plan`** via
-   [`promote-finding.js`](../scripts/lib/findings/promote-finding.js) — the
-   same cluster/size/route/file path `/qa-assist` and `/audit-to-stories`
-   consume. Never hand-roll the clustering, sizing, or promotion in prose:
-
-   ```js
-   import { promoteFindings } from '../scripts/lib/findings/promote-finding.js';
-   const { promotions } = await promoteFindings(ledgerItems, {
-     searchIssues, // GitHub provider, open + closed
-     createStory, // tight cluster (≤2 surfaces): seed → /plan --seed-file
-     createPlanSeed, // broad cluster (>2 surfaces): same /plan --seed-file path (may N>1)
-   });
-   ```
-
-   - **Sizing is delegated, not decided in prose.** `promoteFindings` runs
-     `clusterLedgerItems` + `targetForCluster`: a cluster spanning **≤2**
-     distinct coverage surfaces routes to `createStory`; **>2** routes to
-     `createPlanSeed`. Neither port opens an Epic ticket — both chain
-     `/plan --seed-file`. The workflow introduces no new sizing, clustering,
-     or dedup logic — `route-finding.js` / `promote-finding.js` remain the
-     single implementation.
-   - **`createStory` / `createPlanSeed` (`/plan --seed-file`)** — render a
-     **redacted** plan seed from the cluster (reuse the `/audit-to-stories`
-     Phase 5a seed shape; redaction already ran in Capture), **stamp the
-     cluster's `fingerprintFooter(sha)` verbatim into the seed body**, then
-     chain `/plan --seed-file <seed>`. Prefer one Story; split only under
-     the default-single policy. The footer must survive into the issue body
-     so a later `routeFinding` dedups the same finding instead of re-filing
-     it.
-   - **A `file` disposition never opens a raw GitHub Issue.** Every `file`
-     finding flows through `promoteFindings` → `/plan`; only `defer` and
-     `dismiss` skip the `/plan` handoff.
-
-5. **Gate:** any ticket-filing, seed write, `/plan` invocation, or label
-   mutation is a write — confirm each one with the operator before it happens.
-   Capture stayed read-only precisely so that every state change lands here,
-   deliberately and confirmed. The plan→deliver hard stop is preserved: each
-   `/plan` chain pauses at its own HITL gates and never auto-delivers.
+Route the captured ledger through the shared classify → route → disposition →
+promote procedure in [`helpers/qa-core.md`](helpers/qa-core.md), with the
+operator deciding each `file` / `defer` / `dismiss` and every write
+operator-gated. `file` findings are promoted through `/plan` (never a raw
+Issue); `defer` carries an item forward as backlog; `dismiss` marks it
+non-actionable.
 
 After triage, write the updated dispositions back to the ledger (still under
 `temp/qa/`), and summarize: items captured, the driving method used, classes,
 routes (`new`/`update-existing`/`duplicate`/`regression-of-closed`), the
-Stories (`/plan --seed-file`) promoted, and the deferred rolling backlog
-that a resumed session will pick up.
+Stories (`/plan --seed-file`) promoted, and the deferred rolling backlog a
+resumed session will pick up.
 
 ---
 
 ## Constraints
 
+Beyond the shared core ([`helpers/qa-core.md`](helpers/qa-core.md): contract +
+loud failure, session/ledger, redact-first, QaLedgerItem, triage, HITL gate)
+and the driving conventions
+([`stack/qa/qa-explore-driving`](../skills/stack/qa/qa-explore-driving/SKILL.md)),
+the `/qa-explore`-specific deltas are:
+
 - **Agent-led, bounded per surface.** The agent drives one named surface per
-  session and proposes when it is covered; the operator gates the boundary.
-  Human-driven single-observation capture lives in
-  [`/qa-assist`](qa-assist.md) — no human-driven flow lives here.
-- **Pick the driving method at Plan time.** Drive (browser MCP,
-  navigation-first) is the default; static is the documented interim, chosen
-  explicitly with a recorded reason, never a silent fallback. Do not switch
-  methods mid-surface without a new Plan note. See
-  [`stack/qa/qa-explore-driving`](../skills/stack/qa/qa-explore-driving/SKILL.md).
+  session and proposes when it is covered; the operator gates the boundary. No
+  human-driven flow lives here — that is [`/qa-assist`](qa-assist.md).
+- **Pick the driving method at Plan time** (drive default; static the documented
+  interim, chosen with a recorded reason, never a silent fallback); do not
+  switch mid-surface without a new Plan note.
 - **Capture is read-only.** The only Capture write is appending ledger lines
-  under `temp/qa/`. No source edits, no ticket mutations, no product writes,
-  no destructive form submissions. Never type real credentials inline or
-  fabricate a session; reach an authenticated surface only through the resolved
-  environment's `signInSeam`, and where no seam resolves, record the gap and
-  fall back to static.
-- **Broken navigation is a finding, not a workaround.** Never URL-jump around a
-  missing affordance, a nav 404, or a guard redirect loop — record it and move
-  on.
-- **Every phase transition is operator-gated.** Plan → Capture and
-  Capture → Triage each require explicit confirmation. Never advance, file a
-  ticket, or mutate a label autonomously.
-- **The ledger lives under `temp/qa/` only**, one `QaLedgerItem` per ndjson
-  line, conforming to [`qa-ledger.schema.json`](../schemas/qa-ledger.schema.json).
-  Never commit it.
-- **Redact before persist.** Every evidence string passes through
-  [`redact-evidence.js`](../scripts/lib/qa/redact-evidence.js) before it
-  reaches disk or GitHub, per [`security-baseline.md`](../rules/security-baseline.md).
-- **Delegate decisions to the helpers.** Coverage verdict
-  ([`coverage-verdict.js`](../scripts/lib/qa/coverage-verdict.js)),
-  missing-test ([`propose-missing-test.js`](../scripts/lib/qa/propose-missing-test.js)),
-  classification ([`classify-finding.js`](../scripts/lib/findings/classify-finding.js)),
-  dedup/route ([`route-finding.js`](../scripts/lib/findings/route-finding.js)),
-  and cluster/size/promote
-  ([`promote-finding.js`](../scripts/lib/findings/promote-finding.js)) are
-  deterministic — never re-derive them in prose.
-- **Promote through `/plan`, never a raw Issue.** A `file`-dispositioned
-  finding is promoted via `promoteFindings`, which chains into
-  [`/plan`](plan.md) (`--seed-file` for a tight cluster, `--seed` for a broad
-  one) — mirroring [`/audit-to-stories`](audit-to-stories.md). `/qa-explore`
-  never opens a bare GitHub Issue for a `file` finding. The cluster's
-  `fingerprintFooter(sha)` is stamped verbatim into the seed so a future
-  `routeFinding` dedups it.
-- **Resume safely.** A reused session appends and carries the un-triaged
-  backlog forward via [`qa-session.js`](../scripts/lib/qa/qa-session.js); it
-  never overwrites a prior ledger.
+  under `temp/qa/`. No source edits, ticket mutations, product writes, or
+  destructive form submissions. Reach an authenticated surface only through the
+  resolved environment's `signInSeam`; where no seam resolves, record the gap
+  and fall back to static.
+- **Broken navigation is a finding, not a workaround** — never URL-jump around a
+  missing affordance, a nav 404, or a guard redirect loop.
+- **Delegate coverage decisions to the helpers.** Coverage verdict
+  ([`coverage-verdict.js`](../scripts/lib/qa/coverage-verdict.js)) and
+  missing-test ([`propose-missing-test.js`](../scripts/lib/qa/propose-missing-test.js))
+  are deterministic — never re-derive them in prose.
 
 ## See also
 
-- [`/plan`](plan.md) — the planning pipeline `/qa-explore` Triage chains into
-  for a `file`-dispositioned finding (`--seed-file` / `--seed`). The
-  plan→deliver hard stop is preserved across the handoff.
+- [`/plan`](plan.md) — the planning pipeline Triage chains into for a
+  `file`-dispositioned finding. The plan→deliver hard stop is preserved.
 - [`/qa-assist`](qa-assist.md) — the human-led sibling that enriches a single
   operator observation and triages through the same `/plan` handoff.
 - [`/audit-to-stories`](audit-to-stories.md) — the precedent for the
   findings → `/plan` handoff and the shared fingerprint-footer dedup contract.
-- [`promote-finding.js`](../scripts/lib/findings/promote-finding.js) /
-  [`route-finding.js`](../scripts/lib/findings/route-finding.js) — the shared
-  cluster/size/promote and dedup/route/fingerprint-footer helpers. There is no
-  second clustering, sizing, or dedup implementation.
+- [`helpers/qa-core.md`](helpers/qa-core.md) — the shared contract/session/
+  redaction/QaLedgerItem/triage/HITL core.

--- a/.agents/workflows/qa-run.md
+++ b/.agents/workflows/qa-run.md
@@ -6,35 +6,31 @@ description: Drive Gherkin scenarios through a real browser as an agent-driven Q
 
 Execute a consumer's Gherkin `.feature` scenarios through a **real browser**
 (the chrome-devtools MCP surface), with the agent acting as the step executor
-and a human observing. The harness resolves the consumer's `qa` contract,
-**resolves a target environment**, selects a concrete scenario set, signs in
-via the environment's configured seam, then delegates each scenario to
-[`helpers/qa-run-scenario.md`](helpers/qa-run-scenario.md) — which navigates
-**from a root** to drive each `Given/When/Then` and asserts `Then` outcomes
-**semantically** against the accessibility snapshot. Per-surface console and
-network are instrumented into structured findings; those findings are recorded
-as `QaLedgerItem`s on the shared session ledger under `temp/qa/` and routed —
-after the operator sign-off gate — through the same
-classify/route/dedup/promote core `/qa-explore` and `/qa-assist` use, so re-run
-sweeps dedup previously-filed findings instead of re-drafting them. The harness
-never files tickets autonomously.
+and a human observing. The sweep resolves a **run envelope** — a target
+environment, a concrete scenario set, and an authenticated persona session —
+then delegates each scenario to
+[`helpers/qa-run-scenario.md`](helpers/qa-run-scenario.md), which drives it
+navigation-first and asserts `Then` outcomes semantically against the
+accessibility snapshot. Per-surface console and network are captured as
+structured findings, recorded as `QaLedgerItem`s on the shared session ledger,
+and triaged — after operator sign-off — through the shared classify/route/
+dedup/promote core. The harness never files tickets autonomously.
 
-This workflow is the agent-driven successor to the framework's earlier
-headless BDD runner. It is a **prose workflow**, not a Node orchestrator: the host LLM
-executes the procedure; deterministic Node helpers under
-`.agents/scripts/lib/qa/` do contract resolution, environment resolution,
-scenario selection, console filtering, evidence redaction, and session/ledger
-resolution, and the shared findings core under `.agents/scripts/lib/findings/`
-owns classification, dedup/route, and cluster/size/promote. The agent never
-invents those decisions in prose.
+The shared machinery — contract resolution + loud failure, the session & ledger
+contract, redact-first, the `QaLedgerItem` shape, the triage procedure, and the
+HITL write gate — lives once in [`helpers/qa-core.md`](helpers/qa-core.md); this
+workflow states only the `/qa-run`-specific phases (env → scope → sign-in →
+drive) plus a Constraints delta. Deterministic Node helpers under
+`.agents/scripts/lib/qa/` own contract, environment, and scenario resolution;
+the agent never invents those decisions in prose.
 
-> **When to run**: During sprint testing to exercise a targeted slice of the
+> **When to run**: during sprint testing to exercise a targeted slice of the
 > acceptance suite (a feature, a tag expression, or a domain), for regression
 > passes before `/deliver`, or on demand while debugging a Story's
 > user-visible behavior in a live browser.
 >
-> **Persona**: `qa-engineer` · **Skills**: `stack/qa/gherkin-authoring`,
-> `stack/qa/playwright-bdd` (authoring reference; this harness owns execution)
+> **Skills**: `stack/qa/gherkin-authoring`, `stack/qa/playwright-bdd`
+> (authoring reference; this harness owns execution)
 
 ## Slash Command
 
@@ -45,33 +41,26 @@ invents those decisions in prose.
 ### Arguments
 
 Both arguments are **optional**. A bare `/qa-run` runs the interactive
-env-then-scope flow (Step 0.5); supplying the arguments skips the corresponding
-prompt.
+env-then-scope flow; supplying an argument skips the corresponding prompt.
 
 | Name       | Required | Shape / Example                              | Notes                                                                                              |
 | ---------- | -------- | -------------------------------------------- | -------------------------------------------------------------------------------------------------- |
-| `env`      | no       | `local`, `staging`, `https://staging.app.example` | Selects one of the contract's `environments` (Step 0.5a). Omit to be **prompted** for the environment. A raw URL resolves by origin match. |
-| `selector` | no       | `feature:login`, `tag:@smoke and not @wip`, `domain:billing` | Scopes the sweep to a concrete scenario set. Omit to be **prompted** for scope (Step 0.5b). One of three kinds — see below. |
-
-- **Bare `/qa-run`** → prompt for the environment (Step 0.5a), then prompt for
-  scope (Step 0.5b).
-- **`/qa-run <env> <selector>`** → **skip both prompts**; resolve `<env>`
-  directly and resolve `<selector>` directly.
+| `env`      | no       | `local`, `staging`, `https://staging.app.example` | Selects one of the contract's `environments`. Omit to be **prompted**. A raw URL resolves by origin match. |
+| `selector` | no       | `feature:login`, `tag:@smoke and not @wip`, `domain:billing` | Scopes the sweep to a concrete scenario set. Omit to be **prompted** for scope. One of three kinds — see below. |
 
 The selector is resolved by
 [`resolve-selection.js`](../scripts/lib/qa/resolve-selection.js) into a
-deterministic, `(file, line)`-sorted scenario set under the contract's
-`featureRoot`. The three kinds map to that resolver's selector shapes:
+deterministic, `(file, line)`-sorted scenario set under `featureRoot`. Its
+three kinds:
 
-- **`feature:<id>`** → `{ kind: 'feature', id }` — the single `.feature` file
-  whose `featureRoot`-relative path stem (or basename) equals the id
-  (case-insensitive). Ambiguous ids throw; qualify with a relative path.
-- **`tag:<expression>`** → `{ kind: 'tag', expression }` — the scenario set
-  whose tags satisfy the cucumber boolean expression (`@tag` atoms with
-  `and` / `or` / `not` and parentheses). Quote expressions that contain
-  spaces.
-- **`domain:<name>`** → `{ kind: 'domain', name }` — every scenario under the
-  `featureRoot`-relative subdirectory `name`.
+- **`feature:<id>`** — the single `.feature` file whose `featureRoot`-relative
+  path stem (or basename) equals the id (case-insensitive; ambiguous ids throw
+  — qualify with a relative path).
+- **`tag:<expression>`** — the scenario set whose tags satisfy the cucumber
+  boolean expression (`@tag` atoms with `and` / `or` / `not` and parentheses;
+  quote expressions containing spaces).
+- **`domain:<name>`** — every scenario under the `featureRoot`-relative
+  subdirectory `name`.
 
 ### Examples
 
@@ -83,365 +72,176 @@ deterministic, `(file, line)`-sorted scenario set under the contract's
 /qa-run https://staging.app.example domain:billing
 ```
 
-The canonical tag taxonomy — `@smoke`, `@risk-high`, `@platform-web`,
-`@platform-mobile`, `@domain-*`, and the allowed extension syntax — is defined
-in `.agents/rules/gherkin-standards.md`. Do not invent tags inside a feature
-file; add new tags to the rule first.
+The canonical tag taxonomy (`@smoke`, `@risk-high`, `@platform-*`,
+`@domain-*`, and the allowed extension syntax) is defined in
+[`.agents/rules/gherkin-standards.md`](../rules/gherkin-standards.md). Do not
+invent tags inside a feature file; add new tags to the rule first.
 
-## Step 0 — Resolve the `qa` contract (fail loudly when absent)
+## Step 0 — Resolve the run envelope
 
-The harness is meaningless without the consumer's `qa` contract block in
-`.agentrc.json`. Resolve it through the single seam
-[`resolve-qa-contract.js`](../scripts/lib/qa/resolve-qa-contract.js) **before
-any browser work**:
+The outcome of Steps 0–2 is a single resolved envelope — **`{ environment,
+scenario set, authenticated persona session }`** — that the per-scenario driver
+(Step 3) consumes. The deterministic resolvers own every decision; the agent
+narrates none of their internal return shapes. Every resolver **throws loudly**
+on bad input, and the terminal behavior is the same in every case: **relay the
+resolver's verbatim message and STOP** — never guess an environment, a
+`featureRoot`, or a sign-in seam.
 
-```bash
-node -e "import('./.agents/scripts/lib/qa/resolve-qa-contract.js').then(async (m) => { const { resolveConfig } = await import('./.agents/scripts/config-resolver.js'); const cfg = await resolveConfig(); console.log(JSON.stringify(m.resolveQaContract(cfg), null, 2)); })"
-```
+First resolve the `qa` contract and the session per
+[`helpers/qa-core.md`](helpers/qa-core.md) (contract resolution + loud failure;
+session & ledger under `temp/qa/`). Then build the rest of the envelope:
 
-(Use whatever config-resolution entry point the host exposes; the contract
-seam is `resolveQaContract(config)`.) The resolver returns the normalized
-contract:
-
-| Field                | Use                                                                       |
-| -------------------- | ------------------------------------------------------------------------- |
-| `featureRoot`        | Root passed to `resolve-selection.js` for scenario discovery.             |
-| `fixturesManifest`   | Persona → seed binding loaded before sign-in.                             |
-| `environments`       | Environment-keyed map (`{ baseUrl, signInSeam, allowWrites? }` per name). Resolved to a single target in Step 0.5a. |
-| `defaultEnvironment` | Environment name used when no `<env>` argument is supplied and the operator accepts the default. |
-| `personas`           | Canonical object map keyed by persona name (`personaNames` lists the names). Authored as a plain name array under a `urlTemplate` seam, or as a per-persona credential/skill map under a `skill` (or credential) seam — see Step 2. |
-| `consoleAllowlist`   | Inline benign-console patterns (default `[]`) — see Step 4.               |
-| `designTokens`       | Pointer to the token/style source for visual inspection (default `null`). |
-
-### Loud-failure path (no `qa` block)
-
-`resolveQaContract` **throws** — there is no silent fallback to
-auto-detection — in three cases:
-
-- **Block absent** (no `qa` key, or an empty `qa: {}` with no harness-required
-  fields): the error reads
-  _"qa: this project has not bound the QA harness — add a `qa` block to
-  .agentrc.json (featureRoot, fixturesManifest, environments, personas) before
-  invoking the QA harness."_
-- **Malformed shape** (wrong-typed field, unknown field): the error names the
-  offending field, e.g. `qa.featureRoot must be a string`.
-- **Missing required field**: the error names the first missing field.
-
-When you hit any of these, **STOP immediately**. Relay the resolver's
-verbatim message to the operator as the harness's terminal output and do not
-proceed to browser execution. Do not invent a `featureRoot`, do not guess a
-sign-in seam, and do not fall back to any retired headless BDD runner. The
-loud failure is the contract: a consumer that has not bound the harness has
-not opted into it.
-
-### MCP availability check
+### The chrome-devtools MCP surface must be available
 
 The chrome-devtools MCP surface (`navigate_page`, `take_snapshot`, `click`,
 `fill_form`, `evaluate_script`, `wait_for`, `list_console_messages`,
-`list_network_requests`) is **host-provided** — it is an external runtime
-dependency, not in-repo code. If the host does not expose it, degrade with a
-clear error ("the chrome-devtools MCP server is unavailable; the QA harness
-requires a live browser surface") and stop. Do not attempt a headless
-fallback.
+`list_network_requests`) is **host-provided** — an external runtime dependency,
+not in-repo code. If the host does not expose it, degrade with a clear error
+("the chrome-devtools MCP server is unavailable; the QA harness requires a live
+browser surface") and stop. Never attempt a headless fallback.
 
-### Session & ledger (temp/qa/)
+### Step 1 — Resolve the environment, then the scope
 
-Resolve the session and its ledger path **once**, up front, via
-[`qa-session.js`](../scripts/lib/qa/qa-session.js) — the same seam
-`/qa-explore` and `/qa-assist` use:
+**Environment** — resolve which of the contract's `environments` this sweep
+runs against via
+[`resolveQaEnvironment`](../scripts/lib/qa/resolve-qa-contract.js), yielding
+`{ name, baseUrl, signInSeam, allowWrites }` (`allowWrites` defaults to an
+explicit boolean — `true` only for the conventional `local` environment). When
+`<env>` is supplied, pass it straight through (an exact name wins; a raw URL
+matches by origin). When it is omitted (bare `/qa-run`), **prompt** the
+operator, enumerating every environment as `name → baseUrl` (marking
+`defaultEnvironment`); they answer with a name or a raw URL. On an unknown name
+or unmatched URL the resolver throws (naming the known environments) — relay it
+and stop; never silently fall back to the default.
 
-```js
-import { resolveQaSession } from '../scripts/lib/qa/qa-session.js';
-const { sessionId, ledgerPath, reused, untriaged } = resolveQaSession({ config });
-```
+**Scope** — when `<selector>` is supplied, parse it into the resolver's
+selector shape. When omitted, **prompt** the operator: enumerate the selectable
+scope under `featureRoot` via `resolve-selection.js` (domains, feature stems,
+canonical tags) as a **multi-select** the operator composes into a selector
+set. Always include a final **"No coverage here → hand off to `/qa-explore`"**
+option: when the surface has no authored `.feature` coverage, choosing it ends
+the sweep and routes to [`/qa-explore`](qa-explore.md) rather than running an
+empty selection.
 
-- The ledger is always written under **`temp/qa/<sessionId>.ndjson`**
-  (`<tempRoot>/qa/`, resolved from `project.paths.tempRoot`). It is one
-  `QaLedgerItem` per line (ndjson) validated against
-  [`qa-ledger.schema.json`](../schemas/qa-ledger.schema.json). **Never** write
-  the ledger anywhere else, and never commit it — `temp/` is gitignored per
-  [`.agents/instructions.md` § 6](../instructions.md).
-- When `reused` is `true`, a prior session of the same id exists: **append**,
-  never overwrite, and carry the `untriaged` items forward as the rolling
-  backlog. Pass `--session-id <id>` (or `QA_SESSION_ID`) to resume a named
-  session.
+**Scenario set + write guard** — pass the resolved selector(s) and `featureRoot`
+to [`resolveSelection`](../scripts/lib/qa/resolve-selection.js), which returns
+the `(file, line)`-sorted scenario set (determinism is load-bearing: the same
+selector scopes the identical set across sweeps). Load `fixturesManifest` to
+resolve each persona's seed before sign-in. An empty selection is operator
+error (a typo'd id or domain), not a passing sweep — report "no scenarios
+matched `<selector>`" and stop.
 
-The sweep's `F#` findings (Step 4) are recorded as `QaLedgerItem`s on this
-ledger, and Step 5 routes the ledger through the shared
-classify/route/dedup/promote core — there is no separate `/qa-run` finding
-schema or draft-bundle path.
+> **`allowWrites` guardrail (non-local safety).** When the resolved environment
+> has `allowWrites: false`, **exclude any mutating scenario** from the selection
+> before driving — judge a scenario mutating from its `When` steps (a `When`
+> that creates, updates, or deletes persisted state is mutating; a read-only
+> navigation/inspection `When` is not). Report the **exclusion count** ("N
+> mutating scenarios excluded on read-only `<env>`") alongside the resolved
+> count. The exclusion is overridable **only** by an explicit in-session
+> operator confirmation — never silently include mutating scenarios on a
+> read-only target, and never widen `allowWrites` by editing the contract
+> mid-sweep.
 
-## Step 0.5 — Resolve the environment, then the scope (interactive when unargued)
-
-### Step 0.5a — Resolve the target environment
-
-Resolve which of the contract's `environments` this sweep runs against through
-[`resolveQaEnvironment`](../scripts/lib/qa/resolve-qa-contract.js). It returns
-the resolved target `{ name, baseUrl, signInSeam, allowWrites }` (with
-`allowWrites` defaulted to an explicit boolean — `true` only for the
-conventional `local` environment, `false` for every other target unless the
-consumer opts in).
-
-- **`<env>` argument supplied** → pass it straight to `resolveQaEnvironment`.
-  An exact environment name wins; a raw URL resolves by **origin match**
-  against each environment's `baseUrl`. An unknown name or an unmatched URL
-  **throws** — relay the resolver's message (it names the known environments)
-  and stop; do **not** guess an environment.
-- **No `<env>` argument (bare `/qa-run`)** → **prompt the operator**. Enumerate
-  every environment as `name → baseUrl` (marking `defaultEnvironment`), and ask
-  which to run against. The operator may answer with an environment **name** or
-  paste a **raw URL** — resolve either through `resolveQaEnvironment` (a raw
-  URL matches by origin). If the answer resolves to nothing, **fail loudly**
-  with the resolver's known-environments message; do not silently fall back to
-  the default.
-
-Carry the resolved `{ name, baseUrl, allowWrites }` forward — `baseUrl` is the
-navigation root, and `allowWrites` drives the write guard (Step 1) and is part
-of the per-scenario helper's input contract (Step 3).
-
-### Step 0.5b — Select the scope
-
-- **`<selector>` argument supplied** → parse it into the resolver's selector
-  shape and proceed to Step 1.
-- **No `<selector>` argument (bare `/qa-run`)** → **prompt the operator** for
-  scope. Enumerate the selectable scope under `featureRoot` via
-  [`resolve-selection.js`](../scripts/lib/qa/resolve-selection.js): the
-  available **domains** (first-level `featureRoot` subdirectories), **feature
-  stems** (`.feature` path stems), and **canonical tags** (the tag atoms the
-  scanner collected across the tree, per the `.agents/rules/gherkin-standards.md`
-  taxonomy). Present them as a **multi-select** — the operator may pick any
-  combination of domains, feature stems, and tags, which compose into the
-  selector set. Always include an explicit final option:
-
-  > **No coverage here → hand off to `/qa-explore`.** When the surface the
-  > operator wants to test has no authored `.feature` coverage, choosing this
-  > option ends the sweep and hands off to [`/qa-explore`](qa-explore.md) for
-  > agent-led exploratory QA, rather than running an empty selection.
-
-  If the operator picks the hand-off option, stop the sweep and route to
-  `/qa-explore`. Otherwise resolve the multi-select into the concrete selector
-  set and proceed to Step 1.
-
-## Step 1 — Select the scenario set (and apply the write guard)
-
-Pass the resolved selector(s) and the contract's `featureRoot` to
-[`resolveSelection`](../scripts/lib/qa/resolve-selection.js). It returns
-`{ kind, featureRoot, files, scenarios }` where `scenarios` is the
-`(file, line)`-sorted set the sweep will execute. Determinism is load-bearing:
-re-running the same selector across sweeps scopes the identical set, so the
-evidence stays diffable.
-
-Load the `fixturesManifest` to resolve each persona's seed data before
-sign-in. If the selection is empty, report "no scenarios matched
-`<selector>`" and stop — an empty selection is operator error (a typo'd
-feature id or domain), not a passing sweep.
-
-### `allowWrites` guardrail (non-local safety)
-
-When the resolved environment has **`allowWrites: false`**, exclude any
-scenario judged **mutating** from the selection before driving. Judge a
-scenario mutating from its **`When` steps** — a `When` that creates, updates,
-or deletes persisted state (submits a form that writes, deletes a record,
-changes a setting) is mutating; a read-only navigation/inspection `When` is
-not. Report the **exclusion count** ("N mutating scenarios excluded on
-read-only `<env>`") alongside the resolved scenario count so the operator sees
-what was skipped and why. The exclusion is overridable **only** by an explicit
-in-session operator confirmation (the operator affirms, in this session, that
-writes to `<env>` are acceptable) — never silently include mutating scenarios
-on a read-only target, and never widen `allowWrites` by editing the contract
-mid-sweep.
-
-## Step 2 — Sign in via the environment's `signInSeam`
+### Step 2 — Sign in via the environment's `signInSeam`
 
 Sign in **once per persona** before driving that persona's scenarios, using the
-resolved environment's discriminated-union seam
-(`environment.signInSeam`, anchored on `environment.baseUrl`):
+resolved environment's discriminated-union seam (anchored on `baseUrl`):
 
-- **`kind: 'url'`** — substitute `{persona}` into `template` (e.g.
-  `/dev/sign-in-as/{persona}` → `/dev/sign-in-as/admin`) and `navigate_page`
-  to the resulting dev seam URL. The persona **name** (a `personaNames` entry)
-  is the **sole input** the seam consumes — per-persona auth material is
-  neither needed nor read here, so under a `urlTemplate` seam the contract is
-  authored as a plain name array (`personas: ["athlete", "coach"]`).
-- **`kind: 'skill'`** — invoke the named consumer skill for procedural
-  (multi-step or non-URL) sign-in. Read the skill's `SKILL.md` and follow it.
+- **`kind: 'url'`** — substitute the persona **name** into `template` (e.g.
+  `/dev/sign-in-as/{persona}`) and `navigate_page` there. The name is the sole
+  input; under a `urlTemplate` seam the contract is authored as a plain name
+  array and no per-persona auth material is read.
+- **`kind: 'skill'`** — invoke the named consumer sign-in skill (procedural /
+  non-URL sign-in). Real auth uses **only `credentialRef`-indirected material**
+  the skill dereferences; raw passwords, tokens, or API keys are never inlined
+  into the contract, the workflow, or chat, and captured evidence is redacted
+  per [`helpers/qa-core.md`](helpers/qa-core.md) before persistence.
 
-### Credentials under a skill seam (bounded rule)
-
-Under a `skill` seam, real sign-in is permitted but **bounded**:
-
-- Real auth uses **only `credentialRef`-indirected material** — the persona's
-  `credentialRef` names a stored credential the skill dereferences; raw
-  passwords, tokens, or API keys are never inlined into the contract, the
-  workflow, or chat.
-- **Secrets are never echoed** into chat, findings, or the ledger — do not
-  print a credential, a session token, or a cookie value at any point.
-- **Captured evidence passes `redact-evidence.js`** (`redactEvidence`) before
-  persistence, so any secret that leaks into console/network capture is
-  scrubbed before it reaches a finding (see Step 4 and the per-scenario
-  helper).
-
-Per-persona auth material (`credentialRef` / `signInSkill`, authored via the
-object-map `personas` shape) is consulted **only** under a `skill` or
-credential seam. Under a `urlTemplate` dev-impersonation seam the persona name
-is the only input, so the material is never read — author name-only personas
-there rather than fabricating `credentialRef`/`signInSkill` values the harness
-ignores. The resolver normalizes both authored shapes to one canonical object
-map keyed by persona name; a name-only persona resolves to an empty record.
-
-After sign-in, confirm the authenticated state with a `take_snapshot`
-(e.g. the user menu or persona badge is present) before driving any scenario.
-This confirmed authenticated session is the precondition the per-scenario
-helper's input contract requires (Step 3).
+**Verification (the envelope's proof).** After sign-in, confirm the
+authenticated state with a `take_snapshot` showing the persona badge (the user
+menu / persona badge is present) before driving any scenario. This confirmed
+session is the precondition the per-scenario helper re-verifies on entry.
 
 ## Step 3 — Drive each scenario via the per-scenario helper
 
 For each scenario in selection order, delegate driving, analysis, and reporting
-to [`helpers/qa-run-scenario.md`](helpers/qa-run-scenario.md). Pass its input
-contract:
+to [`helpers/qa-run-scenario.md`](helpers/qa-run-scenario.md) — the **one prose
+home** for the driving rules (navigation-first / never URL-jump, semantic
+`Then` assertion, the per-`When` write guard, mandatory evidence redaction, and
+the sequential-only browser rule). Do not restate those rules here. Pass the
+helper its input contract:
 
-- **`environment`** — the resolved `{ name, baseUrl, allowWrites }` from
-  Step 0.5a.
+- **`environment`** — the resolved `{ name, baseUrl, allowWrites }` (Step 1).
 - **`persona`** — the persona name **plus** the confirmed authenticated-session
-  precondition established in Step 2 (the helper re-verifies it on entry).
-- **`scenario`** — the scenario ref (`.feature` file path and `(file, line)`
-  locator).
+  precondition from Step 2 (the helper re-verifies it on entry).
+- **`scenario`** — the scenario ref (`.feature` file path and `(file, line)`).
 - **`consoleAllowlist`** and **`designTokens`** — from the resolved contract.
 
-The helper owns the navigation-first / never-URL-jump rule, the semantic-`Then`
-assertion against the accessibility snapshot, the per-`When` write guard under
-`allowWrites: false`, and mandatory evidence redaction. It returns **one
-structured per-scenario result** — `{ scenario, intent, verdict (pass | fail |
-blocked), surface, findings[] }`. Collect one result per scenario; the sweep
-report shape (per-scenario `intent + verdict` lines plus totals, Step 6) is
-unchanged from the inlined procedure.
+The helper returns **one structured per-scenario result** —
+`{ scenario, intent, verdict (pass | fail | blocked), surface, findings[] }`.
+Collect one result per scenario for the sweep report (Step 5).
 
-## Step 4 — Instrument & record findings onto the ledger
+## Step 4 — Record findings onto the ledger
 
 The per-scenario helper captures console and network per surface and turns
-genuine problems into structured findings, applying the contract's
+genuine problems into structured `F#` findings, applying the contract's
 `consoleAllowlist` via
 [`filterConsoleMessages`](../scripts/lib/qa/console-allowlist.js) (each
-non-allowlisted console **error** becomes one `F#` finding; allowlisted
-patterns and non-error levels are suppressed) and, when `designTokens` is set,
-spot-checking the surface against the token source. The allowlist is a **noise
-filter, not a security control** — never expand it to silence a genuine error
-signal.
+non-allowlisted console **error** becomes one finding; allowlisted patterns and
+non-error levels are suppressed) and spot-checking against `designTokens` when
+set. The allowlist is a **noise filter, not a security control** — never expand
+it to silence a genuine error signal.
 
-Each returned `F#` finding — the console/network-derived shape
-`{ id, classification, surface, symptom, likelyRootCause, disposition,
-acceptance, evidence: { console[], network[] } }`, with evidence already
-scrubbed of tokens, session cookies, and PII via
-[`redact-evidence.js`](../scripts/lib/qa/redact-evidence.js) per
-`.agents/rules/security-baseline.md` — is **recorded as a `QaLedgerItem`** on
-the session ledger resolved in Step 0 (`temp/qa/<sessionId>.ndjson`,
-[`qa-ledger.schema.json`](../schemas/qa-ledger.schema.json)). Map the finding
-onto the ledger shape: a stable `id` (`L1`, `L2`, … in append order), the
-finding's `symptom` as the scrubbed `evidence`, the finding's `surface` as
-`coverage`, a `class` (map the finding's classification onto the
-ledger `class` enum — a product defect is `product-bug`, a tooling gap is
-`tooling-dx`, etc.) and `severity`, `missingTest` (`null` when no test gap
-applies), and `disposition` left untriaged. **Append** to the ledger, never
-overwrite; a re-run appends to the same session. This is the single findings
-channel — there is no separate `/qa-run` finding schema or draft bundle.
+Record each returned `F#` finding as a `QaLedgerItem` on the session ledger
+(shape and append-never-overwrite rule per [`helpers/qa-core.md`](helpers/qa-core.md)):
+map the finding's `symptom` to the redacted `evidence`, its `surface` to
+`coverage`, its `classification` onto the ledger `class` enum (a product defect
+is `product-bug`, a tooling gap is `tooling-dx`, …) plus a `severity`,
+`missingTest` (`null` when no gap applies), and `disposition` left untriaged.
 
-## Step 5 — Triage the ledger (operator sign-off required)
+## Step 5 — Triage the ledger, then report
 
-After the sweep completes, route the ledger through the same
-classify/route/dedup/promote core `/qa-explore` Triage and `/qa-assist` use.
-The **operator sign-off gate is preserved**: the harness MUST NOT create
-tickets autonomously — present the routed dispositions and confirm each
-`file` / `defer` / `dismiss` with the operator before any write.
+Route the ledger through the shared classify → route → disposition → promote
+procedure in [`helpers/qa-core.md`](helpers/qa-core.md), under its HITL write
+gate: the harness MUST NOT create tickets autonomously — present the routed
+dispositions and confirm each `file` / `defer` / `dismiss` before any write.
 
-For each untriaged ledger item:
+Then summarize the sweep in chat with:
 
-1. **Classify** it via
-   [`classify-finding.js`](../scripts/lib/findings/classify-finding.js). The
-   item's `class` resolves to the focus/meta label set Triage applies when
-   promoting it. The helper **throws** on an absent/unknown class — fix the
-   ledger item's class rather than defaulting.
-2. **Dedup / route** it against existing GitHub Issues via
-   [`route-finding.js`](../scripts/lib/findings/route-finding.js):
-
-   ```js
-   import { routeFinding, fingerprintFooter } from '../scripts/lib/findings/route-finding.js';
-   const { decision, matchedIssue, fingerprint } =
-     await routeFinding(finding, { searchIssues });
-   ```
-
-   `decision` is one of `new` / `update-existing` / `duplicate` /
-   `regression-of-closed`. Wire the `searchIssues` port to the GitHub provider,
-   querying **both open and closed** Issues, and stamp the
-   `fingerprintFooter(sha)` marker into any Issue body so future sweeps dedup
-   against it. This is the **single** dedup implementation shared with
-   `/qa-explore`, `/qa-assist`, and `audit-to-stories`.
-3. **Decide the disposition** with the operator (`file` / `defer` / `dismiss`)
-   and record it back onto the ledger item.
-4. **Promote the `file`-dispositioned findings through `/plan`** via
-   [`promote-finding.js`](../scripts/lib/findings/promote-finding.js) — the
-   same cluster/size/route/file path `/qa-explore` and `/audit-to-stories`
-   consume (`clusterLedgerItems` + `targetForCluster`: a cluster spanning ≤2
-   coverage surfaces routes to `createStory` via `/plan --seed-file`, >2 to
-   `createPlanSeed` via `/plan --seed`, with the cluster's `fingerprintFooter(sha)`
-   stamped verbatim into the seed). A `file` disposition never opens a raw
-   GitHub Issue; only `defer` and `dismiss` skip the `/plan` handoff.
-5. **Gate:** any ticket-filing, seed write, `/plan` invocation, or label
-   mutation is a write — confirm each with the operator before it happens.
-
-## Step 6 — Report
-
-Summarize the sweep in chat with:
-
-- The resolved **environment** (`name → baseUrl`, and whether it is read-only)
-  and the selector applied.
-- The resolved scenario count, plus the **`allowWrites` exclusion count** when
-  mutating scenarios were skipped on a read-only environment.
-- Scenario totals: passed / failed / blocked.
-- Findings totals by classification, and the ledger routes
-  (`new` / `update-existing` / `duplicate` / `regression-of-closed`).
-- A per-scenario line pairing each scenario's plain-English intent with its
-  verdict (pass / fail / blocked), grouped by feature file or domain — so the
-  digest reads as "what was checked → what happened", not a tag list.
-- For each failure, the scenario name, file path, the surface it ended on, and
-  a one-line user-visible symptom.
-- The ledger path (under `temp/qa/`) and a pointer to the routed dispositions
-  awaiting operator sign-off (if any).
+- the resolved **environment** (`name → baseUrl`, and whether it is read-only)
+  and the selector applied;
+- the resolved scenario count, plus the **`allowWrites` exclusion count** when
+  mutating scenarios were skipped on a read-only environment;
+- scenario totals (passed / failed / blocked);
+- findings totals by classification and the ledger routes
+  (`new` / `update-existing` / `duplicate` / `regression-of-closed`);
+- a per-scenario line pairing each scenario's plain-English intent with its
+  verdict, grouped by feature file or domain — "what was checked → what
+  happened", not a tag list;
+- for each failure: the scenario name, file path, the surface it ended on, and
+  a one-line user-visible symptom;
+- the ledger path (under `temp/qa/`) and a pointer to any routed dispositions
+  awaiting operator sign-off.
 
 ## Constraints
 
-- **Always** resolve the `qa` contract first and **fail loudly** when it is
-  absent or malformed. There is no auto-detection fallback.
-- **Always** resolve a target environment (Step 0.5a) — prompt for it when no
-  `<env>` argument is supplied — and **fail loudly** on an unknown name or an
-  unmatched URL. Never silently fall back to the default on a bad answer.
+Beyond the shared core ([`helpers/qa-core.md`](helpers/qa-core.md): contract +
+loud failure, session/ledger, redact-first, QaLedgerItem, triage, HITL gate)
+and the driving rules ([`helpers/qa-run-scenario.md`](helpers/qa-run-scenario.md):
+navigation-first, semantic `Then`, redaction, sequential-only), the
+`/qa-run`-specific deltas are:
+
+- **Always** resolve a target environment (Step 1) — prompt when no `<env>` is
+  supplied — and **fail loudly** on an unknown name or unmatched URL; never
+  silently fall back to the default.
 - **Always** apply the `allowWrites` guardrail: on a read-only environment,
   exclude mutating scenarios and report the exclusion count; include them only
   on explicit in-session operator confirmation.
-- **Always** navigate from a root via UI affordances. **Never** URL-jump to a
-  deep link to set up a scenario.
-- **Always** assert `Then` outcomes semantically against the accessibility
-  snapshot. **Never** assert via DOM/CSS/XPath selectors, HTTP status codes,
-  response bodies, or DB rows inside a scenario — push those to the contract
-  tier per `.agents/rules/testing-standards.md`.
-- **Under a skill seam**, real sign-in uses only `credentialRef`-indirected
-  material; secrets are never echoed into chat, findings, or the ledger; and
-  captured evidence passes `redact-evidence.js` before persistence.
-- **Always** record findings as `QaLedgerItem`s on the shared session ledger
-  under `temp/qa/` ([`qa-ledger.schema.json`](../schemas/qa-ledger.schema.json))
-  and route them through the shared classify/route/dedup/promote core — there
-  is no separate `/qa-run` finding schema or draft-bundle path. Never commit
-  the ledger.
-- **Delegate Triage decisions to the helpers.** Classification
-  ([`classify-finding.js`](../scripts/lib/findings/classify-finding.js)),
-  dedup/route ([`route-finding.js`](../scripts/lib/findings/route-finding.js),
-  fingerprint-footer against open + closed issues), and cluster/size/promote
-  ([`promote-finding.js`](../scripts/lib/findings/promote-finding.js)) are
-  deterministic — never re-derive them in prose.
-- **Never** file follow-up tickets autonomously; promote `file` findings
-  through `/plan` only after operator sign-off, and never open a raw GitHub
-  Issue for a `file` finding.
-- **Never** expand `consoleAllowlist` to suppress genuine error signal — it is
-  a benign-noise filter, not a security control.
-- **Always** scrub captured evidence of secrets and PII before rendering a
-  finding.
-- **Never** fall back to a retired headless BDD-runner workflow.
+- **Always** sign in per persona through the environment's `signInSeam` and
+  confirm the authenticated state with a post-sign-in `take_snapshot` before
+  driving.
+- An **empty selection is operator error**, not a passing sweep — report it and
+  stop.
+- **Never** expand `consoleAllowlist` to suppress genuine error signal.
+- **Never** file follow-up tickets autonomously, and **never** fall back to a
+  retired headless BDD runner.

--- a/tests/qa-assist-workflow.test.js
+++ b/tests/qa-assist-workflow.test.js
@@ -46,8 +46,21 @@ const WORKFLOWS_DOC_PATH = path.join(
   'docs',
   'workflows.md',
 );
+// The shared contract/session/redaction/QaLedgerItem/triage/HITL machinery is
+// single-homed in helpers/qa-core.md (Story #4666); the workflow references it
+// by pointer. Assert wired-helper paths against the union of the two so the
+// guard stays meaningful without forcing the workflow to restate the core.
+const QA_CORE_PATH = path.join(
+  REPO_ROOT,
+  '.agents',
+  'workflows',
+  'helpers',
+  'qa-core.md',
+);
 
 const source = readFileSync(WORKFLOW_PATH, 'utf8');
+const coreSource = readFileSync(QA_CORE_PATH, 'utf8');
+const combinedSource = `${source}\n${coreSource}`;
 
 describe('qa-assist workflow contract', () => {
   it('opens with a YAML frontmatter description block so sync-commands projects it', () => {
@@ -159,11 +172,12 @@ describe('qa-assist workflow contract', () => {
     ];
     for (const ref of referencedPaths) {
       // The workflow links to siblings with `../`-relative paths; assert on the
-      // distinctive tail so the test is robust to the relative prefix.
+      // distinctive tail so the test is robust to the relative prefix. Shared-
+      // core helpers now live in helpers/qa-core.md, so check the union.
       const tail = ref.replace(/^\.agents\//, '');
       assert.ok(
-        source.includes(tail),
-        `qa-assist.md must reference ${ref} (looked for "${tail}")`,
+        combinedSource.includes(tail),
+        `qa-assist.md (or helpers/qa-core.md) must reference ${ref} (looked for "${tail}")`,
       );
     }
   });

--- a/tests/qa-explore-workflow.test.js
+++ b/tests/qa-explore-workflow.test.js
@@ -50,8 +50,21 @@ const WORKFLOW_PATH = path.join(
   'workflows',
   'qa-explore.md',
 );
+// The shared contract/session/redaction/QaLedgerItem/triage/HITL machinery is
+// single-homed in helpers/qa-core.md (Story #4666); the workflow references it
+// by pointer. Assert wired-helper paths against the union of the two so the
+// guard stays meaningful without forcing the workflow to restate the core.
+const QA_CORE_PATH = path.join(
+  REPO_ROOT,
+  '.agents',
+  'workflows',
+  'helpers',
+  'qa-core.md',
+);
 
 const source = readFileSync(WORKFLOW_PATH, 'utf8');
+const coreSource = readFileSync(QA_CORE_PATH, 'utf8');
+const combinedSource = `${source}\n${coreSource}`;
 
 describe('qa-explore workflow contract', () => {
   it('opens with a YAML frontmatter description block so sync-commands projects it', () => {
@@ -290,11 +303,12 @@ describe('qa-explore workflow contract', () => {
     ];
     for (const ref of referencedPaths) {
       // The workflow links to siblings with `../`-relative paths; assert on the
-      // distinctive tail so the test is robust to the relative prefix.
+      // distinctive tail so the test is robust to the relative prefix. Shared-
+      // core helpers now live in helpers/qa-core.md, so check the union.
       const tail = ref.replace(/^\.agents\//, '');
       assert.ok(
-        source.includes(tail),
-        `qa-explore.md must reference ${ref} (looked for "${tail}")`,
+        combinedSource.includes(tail),
+        `qa-explore.md (or helpers/qa-core.md) must reference ${ref} (looked for "${tail}")`,
       );
     }
   });


### PR DESCRIPTION
Closes #4666

_Auto-opened by `/deliver`._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and workflow prose only; behavior is aligned with existing Node helpers (`promote-finding`, `route-finding`) already used by QA workflows, with no runtime code changes in the diff.
> 
> **Overview**
> Introduces **`helpers/qa-core.md`** as the single home for contract resolution, `temp/qa/` session ledger rules, redaction, `QaLedgerItem` shape, classify → route → disposition → promote triage, and the HITL write gate. **`/qa-run`**, **`/qa-explore`**, and **`/qa-assist`** are shortened to mode-specific phases plus constraint deltas that point at that helper instead of duplicating the same prose.
> 
> **`/qa-run` and `qa-harness`** no longer describe a separate draft-bundle / operator sign-off ticket path: structured `F#` findings are recorded on the shared ledger and triaged like the exploratory workflows. Duplicate folding via `foldsInto` in the harness skill is replaced by “record once; dedup at triage.”
> 
> **Driving rules** (navigation-first, semantic `Then`, sequential-only browser use) are centralized in **`helpers/qa-run-scenario.md`**; **`qa-harness`** and **`qa-explore-driving`** link there instead of restating long sections. Future batched sub-agent dispatch is split into **`qa-run-scenario-reference.md`**.
> 
> **README** and workflow contract tests now expect the ledger + promote flow and assert helper references against the union of each workflow file and **`qa-core.md`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0494e99c1a5a62cdc6543109bb62dbbf7f963ecf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->