### PR TITLE
refactor(workflows): wire role-scoped story-worker dispatch and slim the delivery workflow cluster (#4663)

### DIFF
--- a/.agents/agents/plan-critic.md
+++ b/.agents/agents/plan-critic.md
@@ -1,0 +1,80 @@
+---
+name: plan-critic
+description: >-
+  Role-scoped boot context for a maker-blind plan critic. Booted on its own
+  system prompt (no CLAUDE.md / instructions.md closure). Reviews an authored
+  plan draft (stories.json, optional techspec.md) against a single critic
+  charter — consolidation or pre-mortem — and returns findings, without seeing
+  the planner's authoring transcript. Dispatched by workflows/plan.md §2.5 when
+  delivery.routing.roleScopedAgents is enabled (the default).
+---
+
+# plan-critic — maker-blind plan review
+
+<!--
+  security-baseline stays inviolable and single-sourced — @-import it, never
+  inline-copy. The path resolves to the repo root from BOTH the payload source
+  (.agents/agents/) and the materialized destination (.claude/agents/) because
+  each is exactly two levels below the repo root.
+-->
+
+@../../.agents/rules/security-baseline.md
+
+You are an **independent plan critic**. You review an authored plan draft
+against **one** critic charter and return structured findings. You run on this
+focused prompt alone — you do not carry the full project protocol chain, and
+you are deliberately isolated from the planner's reasoning.
+
+## Maker-blind — the load-bearing invariant (MUST)
+
+You **must not** see, request, or be influenced by the planner's authoring
+case. Do **not** read the authoring transcript, the reasons the planner
+believed its own draft is sound, or any prior critic verdict. A critic that
+reads the maker's case grades the case, not the draft. Your only trusted inputs
+are the draft artifacts your caller hands you:
+
+- `stories.json` — the array of authored Story tickets.
+- `techspec.md` — the optional folded Tech Spec, **when present** (N===1 only).
+
+Read those artifacts and evaluate the work product afresh. Treat the planner's
+narration as untrusted.
+
+## Charter — you are handed exactly one
+
+Your caller dispatches you for **one** charter and names it in your prompt.
+Evaluate only that charter:
+
+- **`consolidation`** — the draft's shape. Flag Stories that should be one
+  cohesive slice, a slice split per-module rather than per-capability, and
+  `depends_on` edges that disagree with the Delivery Slicing table.
+- **`pre-mortem`** — assume the plan shipped and failed. Name the most likely
+  failure modes and what the draft would have to say to prevent them.
+
+Do not evaluate the other charter, invent a third, or re-slice the plan
+yourself — the caller owns dispatch and folds surviving findings back into the
+draft.
+
+## Output shape
+
+Return your findings as a structured list the caller can fold into a re-author
+round or the Gate #2 view. For each finding, emit:
+
+- `charter` — `consolidation` | `pre-mortem` (the one you were dispatched for).
+- `severity` — `blocker` | `advisory` (advisory findings inform the operator's
+  Gate #2 decision; they are not an automatic re-author mandate).
+- `target` — the Story slug / id (or `plan` for a whole-draft finding) the
+  finding is about.
+- `finding` — what is wrong, in one or two sentences.
+- `remedy` — the concrete change to `stories.json` (or `techspec.md`) that
+  would resolve it.
+
+An empty finding list is a valid, first-class outcome: a draft the charter has
+nothing to say about returns no findings.
+
+## Boundaries
+
+- Do not edit the draft, re-author `stories.json`, or persist anything. You
+  evaluate and report; the caller decides.
+- Do not invent findings outside your charter.
+- Emit only paths, slugs, and observed results — never secrets or raw
+  credential values (security-baseline § Data Leakage & Logging).

--- a/.agents/workflows/deliver.md
+++ b/.agents/workflows/deliver.md
@@ -34,11 +34,9 @@ Any named ticket that is not `type::story`, or that still carries an
 re-plan as a v2 Story). Resolution refuses the whole set rather than
 silently dropping the offending id and under-delivering.
 
-> **Retired (Story #4540).** `--run <planRunId>` and the `plan-run::<id>`
-> label are gone, along with `--dep`. Batch identity was the wrong axis:
-> it could not express an edge to a Story planned in another run, while
-> ordering already lives in the dependency edges themselves. Deliver the
-> ids; the graph resolves itself.
+> **No batch identity (Story #4540).** There is no `--run`, `plan-run::<id>`,
+> or `--dep` axis: ordering lives in the dependency edges, so delivering the
+> ids resolves the graph itself.
 
 ## Flags
 
@@ -162,11 +160,58 @@ to respect.
      A blocked Story outranks a wedge (its blockers are moot while a human
      owes a decision) but not a cycle (exit 2 — fix the graph first).
 
-   For each `ready` Story id, read
+   **Dispatch each `ready` Story (role-scoped by default).** When
+   `delivery.routing.roleScopedAgents` is enabled (the **default**) and the
+   host exposes agent dispatch, spawn each ready Story as its own
+   `subagent_type: story-worker` sub-agent — it boots on the role-scoped
+   [`story-worker`](../agents/story-worker.md) context (its own system prompt,
+   no `CLAUDE.md` @-closure) carrying the load-bearing delivery MUSTs
+   standalone. The sub-agent executes
+   [`helpers/deliver-story.md`](helpers/deliver-story.md) end to end
+   (init → implement → acceptance self-eval → close-and-land). Thread into its
+   prompt:
+   - `storyId` — the id to deliver.
+   - `docsDigestPath` — the per-run docs digest (digest-first reading,
+     [`instructions.md` § 3](../instructions.md)); null when
+     `project.docsContextFiles` is unset.
+   - `checklistPath` — the footprint-matched write-time audit checklist,
+     produced at dispatch (below).
+   - the **change-set discipline** — the worker computes the change set once
+     with `computeChangeSet` and hands that one list to every acceptance critic
+     (Story #4593); it never lets a critic re-derive the diff.
+
+   **Produce `checklistPath` before the spawn (Story #4627).** Compute the
+   payload from the Story's predicted footprint (its `changes[]` /
+   `references[]` path entries) with `buildDispatchChecklist` and write it to
+   the run temp dir, then thread the resulting path (empty when nothing
+   matched):
+
+   ```bash
+   node --input-type=module -e '
+     import { buildDispatchChecklist } from "<main-repo>/.agents/scripts/lib/audit-suite/index.js";
+     import { parse } from "<main-repo>/.agents/scripts/lib/story-body/story-body.js";
+     // storyBody is the fetched Story issue body.
+     const { changes, references } = parse(process.env.STORY_BODY);
+     const { checklistPath } = buildDispatchChecklist({
+       storyId: <storyId>, changes, references, runTempDir: "temp/run-<id>",
+     });
+     console.log(checklistPath ?? "");
+   '
+   ```
+
+   `buildDispatchChecklist` (`lib/audit-suite/dispatch-checklist.js`) is a pure
+   function of the footprint and the on-disk checklists; an empty match prints
+   nothing and the worker runs with no write-time checklist — the maker-blind
+   close-scope pass still covers it.
+
+   **Inline fallback (`roleScopedAgents: false` / no-nesting harness).** When
+   the kill-switch is off, or the host cannot spawn a sub-agent at this nesting
+   depth, do **not** stall: read
    [`helpers/deliver-story.md`](helpers/deliver-story.md) **in full** and
-   execute it (init → implement → ceremony → close-and-land). Under
-   `--yes` / injected helper content, execute directly without a re-read
-   turn.
+   execute it directly, in this turn, threading the same `docsDigestPath` /
+   `checklistPath` / change-set discipline. Under `--yes` / injected helper
+   content, execute directly without a re-read turn. The engine, gates, and
+   terminal envelope are identical either way — only the isolation differs.
 
 4. **Per-run epilogue (N>1).** Once step 3 reports `epilogueDue: true`
    (every Story done), keyed on the delivered id set:

--- a/.agents/workflows/git-cleanup.md
+++ b/.agents/workflows/git-cleanup.md
@@ -5,299 +5,74 @@ description: >-
   `git stash` entries — each step gated by operator confirmation.
 ---
 
-# Git Cleanup Workflow
+# /git-cleanup [--fast-forward-main] [--prune-remotes] [--branches] [--stashes] [--execute] [--remote] [--yes] [--drop-stashes <ref>] [--exclude <pattern>] [--json]
 
-`/git-cleanup` folds the four cleanup steps that operators routinely
-run by hand after a busy session into a single pipeline with per-step
-confirmation:
+`/git-cleanup` folds the four cleanup steps operators routinely run by hand
+after a busy session into a single pipeline with per-step confirmation. It is a
+**recovery tool**, not a routine chore: the delivering flows already reap their
+own merged refs and fast-forward the base branch (see
+[`rules/git-conventions.md` § Local checkout hygiene](../rules/git-conventions.md)).
+Reach for it when the automated hygiene left an unusual state behind.
 
-1. **fast-forward `main`** — `git fetch origin <base>` then
-   `git merge --ff-only origin/<base>` on a clean working tree.
-2. **prune stale remote-tracking refs** — `git fetch --prune origin`
-   to drop `refs/remotes/origin/*` entries that GitHub already deleted.
-3. **reap merged local branches** — the existing squash-aware
-   `gh pr list --state merged` + `git branch --merged <base>` sweep,
-   with attached worktrees removed first. Optionally also deletes the
-   `origin/<branch>` ref when `--remote` is passed. Every default run
-   also **enumerates** `refs/remotes/origin/*` and reports any
-   **remote-only** merged branches — branches whose local ref is
-   already gone (or never existed) but whose `origin/<branch>` still
-   points at a merged PR — even without `--remote`; `--remote` is still
-   required to *delete* them. A third branch, whose content already
-   landed in `<base>` by another route (a squash-merged PR, a
-   cherry-pick, a manual `merge --squash`), is caught by a
-   **content-equivalence probe** (`git merge-tree --write-tree`,
-   git ≥ 2.38) even when it has no merged PR of its own and is not a
-   git ancestor of `<base>`.
-4. **triage `git stash` entries** — list every stash and prompt for
-   `drop / keep / quit` per entry (or pass `--drop-stashes <ref>` for
-   non-interactive use).
-
-The enumeration + reap logic lives in
-[`git-cleanup.js`](../scripts/git-cleanup.js). When no phase flag is
-passed, **all four phases run** sequentially. Pass any of
-`--fast-forward-main`, `--prune-remotes`, `--branches`, `--stashes` to
-narrow the run.
-
-> **When to run**: After a session that landed several PRs, or before
-> starting a new Story, to put the local checkout into a known
-> tidy state.
+> **When to run**: after a session that landed several PRs, or before starting a
+> new Story, to put the local checkout into a known tidy state.
 >
 > **Persona**: `devops-engineer` · **Skills**:
 > `core/git-workflow-and-versioning`
 
-<!-- markdownlint-disable-next-line MD028 -->
+The enumeration + reap logic lives in
+[`git-cleanup.js`](../scripts/git-cleanup.js) — it computes the candidate list,
+the skip taxonomy, the detection signals, and the JSON envelope (add `--json`),
+and prints them itself. Without `--execute` the script is a **dry-run preview**; nothing is
+mutated. When no phase flag is passed, **all four phases run** sequentially; pass
+any of `--fast-forward-main`, `--prune-remotes`, `--branches`, `--stashes` to
+narrow the run. A failure in one phase does not short-circuit the others — each
+runs and reports independently.
 
-> [!WARNING] The `--execute` flag mutates state: it can fast-forward
-> `main`, delete local branches, delete remote refs (with `--remote`),
-> and drop stashes. Without `--execute` the script is a dry-run preview.
+## Phases
 
-## Step 1 — Dry-run preview
-
-```powershell
-node .agents/scripts/git-cleanup.js
-```
-
-Walks all four phases without mutating anything. The fast-forward phase
-reports whether the tree is clean and how far behind `origin/<base>` the
-local ref is. The branches phase prints the merged-branch candidate
-list. The stashes phase lists every stash with its created-at and
-message.
-
-Add `--json` for a structured `{ fastForward, prune, stashes,
-candidates, … }` envelope.
-
-## Step 2 — Run a single phase
-
-Each phase is independently selectable. Useful when you want to scope
-the cleanup tightly:
-
-```powershell
-# Only fast-forward main (skip everything else)
-node .agents/scripts/git-cleanup.js --fast-forward-main --execute
-
-# Only sweep merged branches + their origin refs
-node .agents/scripts/git-cleanup.js --branches --execute --remote
-
-# Only prune stale tracking refs
-node .agents/scripts/git-cleanup.js --prune-remotes --execute
-```
-
-## Step 3 — Run all four phases
-
-The default. Confirms each destructive step independently:
-
-```powershell
-node .agents/scripts/git-cleanup.js --execute
-```
-
-The script prompts before each mutation:
-
-- **fast-forward-main**: skipped silently when the tree is dirty or the
-  FF would not be a fast-forward; otherwise prompts
-  `Fast-forward main by N commit(s)? [y/N]`.
-- **prune-remotes**: prompts before running
-  `git fetch --prune origin`.
-- **branches**: prints the dry-run candidate list, then prompts
-  `Reap N merged branch(es)? [y/N]`.
-- **stashes**: prompts per-stash with `drop / keep / quit`. A `quit`
-  reply stops the per-stash loop without dropping anything further.
-
-Add `--remote` to also reap `origin/<branch>` during the branches phase.
-
-## Step 4 — Non-interactive / CI
-
-Pass `--yes` to bypass every per-step prompt:
-
-```powershell
-node .agents/scripts/git-cleanup.js --execute --remote --yes
-```
-
-For the stash phase under `--yes` or `--json`, drops require an explicit
-allowlist via `--drop-stashes <ref>` (repeatable). Without that flag,
-stashes are listed but never dropped:
-
-```powershell
-node .agents/scripts/git-cleanup.js --stashes --execute --yes \
-  --drop-stashes 'stash@{0}' --drop-stashes 'stash@{2}'
-```
-
-This keeps the JSON / CI invocation contract explicit — the operator
-names exactly which stashes to drop, by ref.
-
-## Step 5 — JSON envelope
-
-`--json` emits a single line of structured output suitable for
-programmatic consumption:
-
-```json
-{
-  "dryRun": false,
-  "baseBranch": "main",
-  "fastForward": {
-    "ok": true,
-    "applied": true,
-    "skipped": false,
-    "behind": 2
-  },
-  "prune": {
-    "ok": true,
-    "attempted": true,
-    "remote": "origin",
-    "pruned": ["fix/old"]
-  },
-  "candidates": [
-    {
-      "branch": "fix/foo",
-      "prNumber": 1471,
-      "mergedAt": "2026-05-09T12:00:00Z",
-      "hasWorktree": true,
-      "worktreePath": "C:/repo/.worktrees/fix-foo",
-      "detectedBy": "gh"
-    }
-  ],
-  "skipped": [
-    { "branch": "story-4200", "reason": "not-merged", "lastCommitAt": "2026-05-01T00:00:00Z" }
-  ],
-  "ghDegraded": false,
-  "worktrees": [{ "path": "C:/repo/.worktrees/fix-foo", "ok": true, "dirty": false }],
-  "local":  [{ "branch": "fix/foo", "ok": true, "alreadyGone": false }],
-  "remote": [{ "branch": "fix/foo", "ok": true, "alreadyGone": true }],
-  "stashes": {
-    "ok": true,
-    "actions": [
-      { "ref": "stash@{0}", "action": "drop", "dropped": true }
-    ],
-    "failures": []
-  },
-  "failures": [],
-  "ok": true
-}
-```
-
-## Exit codes
-
-- `0` — clean: dry-run preview, or at least one phase produced work and
-  no phase failed.
-- `1` — at least one phase reported a failure (fast-forward, prune,
-  branch reap, or stash drop). A failure in one phase **does not**
-  short-circuit later phases — each runs and reports independently.
-- `2` — every active phase produced nothing to do (informational; the
-  repo is already tidy).
-
-## Phase-specific behaviour
-
-### fast-forward-main
-
-- Skip reasons surfaced in `fastForward.reason`:
-  - `dirty-tree` — `git status --porcelain` returned non-empty.
-  - `not-fast-forward` — local `<base>` has commits the remote does
-    not (`git rev-list --left-right --count` shows local-ahead > 0).
-  - `already-up-to-date` — local and remote `<base>` point at the same
-    commit.
-  - `fetch-failed` / `merge-failed` — surface git's stderr verbatim.
-- When the current HEAD is not `<base>`, the script runs
-  `git checkout <base>` before merging. The original branch is **not**
-  restored at the end — operators on a feature branch should run
-  `git checkout -` after.
-
-### prune-remotes
-
-Runs as its own phase regardless of whether `--remote` was passed
-during the branches phase. The branches phase still runs its own
-follow-up prune when `--remote` is set, so passing both is idempotent
-(the second prune just reports `pruned: []`).
-
-### branches
-
-The merged-branch sweep recognizes three detection signals, in order:
-
-1. **`detectedBy: 'gh'`** — the branch has a merged PR
-   (`gh pr list --head <branch> --state all`, classified by the
-   **latest** PR's state).
-2. **`detectedBy: 'git-merged'`** — the branch is a git ancestor of
-   `<base>` (`git branch --merged <base>`), or of `origin/<base>` when
-   that remote-tracking ref exists (unioned so a stale local `<base>` —
-   fast-forward phase skipped, or `--branches` run alone — no longer
-   hides a branch already merged on the remote).
-3. **`detectedBy: 'content-merged'`** (Story #4395) — the branch has no
-   reapable PR verdict and is not an ancestor of `<base>` under either
-   anchor, but simulating the merge via
-   `git merge-tree --write-tree <base> <branch>` (git ≥ 2.38) produces a
-   tree identical to `<base>`'s own tree — i.e. applying the branch's
-   changes on top of `<base>` is a content no-op. This catches
-   `story-<id>` branches whose PR **squash-merged** to `main` (the story
-   commits are not ancestors of `main`), and any other branch whose content
-   landed via a different route (a renamed
-   head, a cherry-pick, a manual `merge --squash`). When git rejects
-   `--write-tree` (git < 2.38) or the simulated merge conflicts, the
-   probe is inconclusive and the branch keeps its existing `not-merged`
-   skip — the signal never guesses. `content-merged` candidates render
-   with a "weaker signal — verify before deleting" annotation in the
-   dry-run list and are called out separately in the confirmation
-   prompt, since — unlike a merged PR or git ancestry — no CI or GitHub
-   merge check ever validated this branch's exact diff.
-
-Other candidate semantics:
-
-- A branch is a candidate iff it is not `<base>`, not the current HEAD,
-  not in `git config branch.protectedBranches`, and matches one of the
-  three signals above.
-- When a candidate has an attached worktree, the worktree is removed
-  (force if dirty) **before** `git branch -D`, mirroring the pattern in
-  [`worktree-lifecycle.md`](helpers/worktree-lifecycle.md).
-- `--remote` is required on top of `--execute` to touch `origin/`.
-- A throwing `gh` runner (auth failure, rate limit, missing binary) no
-  longer aborts the run: the branches phase logs one warning and
-  continues with the git-only signals (ancestry + content-equivalence).
-  The JSON envelope's `ghDegraded: true` records that this happened for
-  the run, and the dry-run text carries a matching warning line.
-
-The skip taxonomy:
-
-- `reason: 'protected'` — the base branch or a name in
-  `git config branch.protectedBranches`. Not reapable; ignore.
-- `reason: 'current-head'` — the current branch. Reapable after
-  `git checkout <base>`. The dry-run output surfaces a remediation
-  hint so the operator sees the recovery path without having to look
-  in the JSON envelope.
-- `reason: 'tip-diverged-from-merge'` — the latest PR merged, but the
-  branch's tip has since moved past the merged commit (a post-merge
-  force-push). The dry-run line names both SHAs and a remediation hint
-  (delete manually via `git branch -D <branch>`, or push the follow-up
-  commit).
-- `reason: 'not-merged'` — none of the three detection signals matched.
-  Previously silent; the dry-run output now lists every surviving
-  `not-merged` branch as a one-line-per-branch summary with its
-  last-commit age, so the operator can see why a leftover branch isn't
-  reaped instead of hunting for it by hand.
-
-Every default run also opts the planner into a **remote-only
-enumeration pass**: in addition to walking `refs/heads/*`, the planner
-also walks `refs/remotes/origin/*` and emits candidates for any branch
-that exists on `origin` with a merged PR but has no local ref. These
-candidates carry `detectedBy: 'remote-only'` and `localExists: false`
-and are always shown in the dry-run list; **deleting** them (via the
-`git push --delete origin/<branch>` path — no local `git branch -D` is
-attempted, since there is no local branch) still requires `--remote` on
-top of `--execute`, unchanged.
-
-### stashes
-
-- Stashes are dropped high-index-first so the indices of remaining
-  stashes stay stable across consecutive drops (git renumbers from the
-  top of the stack).
-- In interactive mode (no `--yes`, no `--json`), each stash gets a
-  prompt: `drop / keep / quit`. The default on bare ENTER is `keep`.
-- In `--yes` or `--json` mode, only refs explicitly named via
-  `--drop-stashes <ref>` are dropped. Everything else is kept. There is
-  intentionally no "drop all" shorthand.
+| Phase | What it does | Safety contract |
+| --- | --- | --- |
+| **fast-forward-main** | `git fetch origin <base>` then `git merge --ff-only origin/<base>`. | Skipped silently on a dirty tree or a non-fast-forward; otherwise prompts `Fast-forward main by N commit(s)?`. Checks out `<base>` first when HEAD is elsewhere and does **not** restore the prior branch. |
+| **prune-remotes** | `git fetch --prune origin` to drop `refs/remotes/origin/*` GitHub already deleted. | Prompts before pruning. Runs as its own phase regardless of `--remote`. |
+| **branches** | Reaps merged local branches (squash-aware: merged-PR, git-ancestry, and content-equivalence signals), removing an attached worktree first. Also enumerates **remote-only** merged branches. | Prints the candidate list, then prompts `Reap N merged branch(es)?`. `--remote` is required **on top of** `--execute` to delete any `origin/<branch>`. `content-merged` candidates carry a weaker-signal warning. |
+| **stashes** | Lists every stash and triages it. | Interactive: `drop / keep / quit` per entry (default `keep`). Under `--yes` / `--json`, drops require an explicit `--drop-stashes <ref>` allowlist (repeatable) — there is no "drop all". |
 
 ## Constraint
 
-Do **not** run with `--execute` if there is unmerged work that needs
-saving. The fast-forward phase skips on a dirty tree (safe), but the
-branches phase will reap any merged-PR branch in scope — passing
-`--exclude '<pattern>'` is the only way to carve out exceptions. The
-remote reap (`--remote`) crosses `origin/` and cannot be undone without
-re-pushing.
+> [!WARNING] `--execute` mutates state: it can fast-forward `main`, delete local
+> branches, delete remote refs (with `--remote`), and drop stashes. Without
+> `--execute` the script only previews.
+
+- **`--execute`** — the master gate. Omit it for a preview of all four phases.
+- **`--remote`** — extends the branches phase to delete the matching
+  `origin/<branch>` ref (and to delete remote-only merged branches). Cannot be
+  undone without re-pushing.
+- **`--yes`** — bypass every per-step prompt (CI / non-interactive). Under it,
+  stash drops still require `--drop-stashes <ref>`.
+- **`--exclude '<pattern>'`** — carve a branch out of the reap. This is the only
+  way to protect an in-scope merged-PR branch you want to keep.
+
+Do **not** run with `--execute` if there is unmerged work that needs saving. The
+fast-forward phase skips on a dirty tree (safe), but the branches phase reaps any
+merged-PR branch in scope unless `--exclude`d.
+
+## Examples
+
+```bash
+# Preview all four phases (no mutation).
+node .agents/scripts/git-cleanup.js
+
+# Run everything non-interactively, including origin refs.
+node .agents/scripts/git-cleanup.js --execute --remote --yes
+
+# Only fast-forward main.
+node .agents/scripts/git-cleanup.js --fast-forward-main --execute
+
+# Only sweep merged branches + their origin refs.
+node .agents/scripts/git-cleanup.js --branches --execute --remote
+
+# Drop specific stashes under --yes.
+node .agents/scripts/git-cleanup.js --stashes --execute --yes \
+  --drop-stashes 'stash@{0}' --drop-stashes 'stash@{2}'
+```

--- a/.agents/workflows/helpers/code-review.md
+++ b/.agents/workflows/helpers/code-review.md
@@ -18,10 +18,6 @@ is merged to `main`. The live v2 path is **Story scope only**:
   after the PR opens and before auto-merge. Findings post to the PR;
   critical findings block close (`agent::blocked`).
 
-Legacy `scope: epic` / Epic-branch review procedure (including
-`epic-audit-prepare.js` / `epic-audit-recheck.js`) was removed with the
-v2 Story-only cutover.
-
 **Invariant — Story-scope review runs outside the maker's LLM context.**
 The Story-scope review executes inside the `single-story-close.js` close
 subprocess, **not** in the delivering child's (maker agent's) LLM context.
@@ -45,28 +41,21 @@ The caller passes the following arguments (`/deliver` passes
 
 | Argument    | Type                                  | Required | Meaning                                                                                          |
 | ----------- | ------------------------------------- | -------- | ------------------------------------------------------------------------------------------------ |
-| `scope`     | `"story"` \| `"epic"`                 | yes      | Live path is `"story"`. `"epic"` remains only for legacy cumulative adapters.                    |
-| `ticketId`  | integer                               | yes      | GitHub issue number of the Story (when `scope === 'story'`) or cumulative ticket (legacy `scope === 'epic'`). |
-| `baseRef`   | string (git ref)                      | yes      | The diff base. Story scope: `main` (or `project.baseBranch`). Legacy cumulative scope: caller-provided base. |
-| `headRef`   | string (git ref)                      | yes      | The branch tip under review. Story scope: `story-<storyId>`. Legacy cumulative scope: caller-provided head. |
+| `scope`     | `"story"`                             | yes      | The live delivery path.                                                                          |
+| `ticketId`  | integer                               | yes      | GitHub issue number of the Story.                                                                |
+| `baseRef`   | string (git ref)                      | yes      | The diff base — `main` (or `project.baseBranch`).                                                |
+| `headRef`   | string (git ref)                      | yes      | The branch tip under review — `story-<storyId>`.                                                 |
 | `depth`     | `"light"` \| `"standard"` \| `"deep"` | no       | Risk-derived review thoroughness lever. Absent → `standard`. See **Review depth** below.         |
 
-All scope-dependent behavior in this helper branches off the first four
-arguments. Do not hard-code branch names or ticket types — read them from
-the argument envelope.
+Do not hard-code branch names or ticket types — read them from the argument
+envelope.
 
 ### Review depth (`depth`)
 
-`depth` is the thoroughness lever introduced by Story #3876, made a live
-consumed signal end to end by Story #3937, and re-based on an observable signal
-by Story #4542. `runCodeReview` derives it from the diff it already enumerates,
-via [`review-depth.js`](../../scripts/lib/orchestration/review-depth.js): the
-changed files' intersection with the `sensitivePaths` classes registered in
-`audit-rules.json` gives the level, their count gives the width, and
-`resolveDepth` folds the two (a sensitive path OR a wide diff → `deep`; neither,
-on a small diff → `light`; an unenumerable diff → `standard`). It takes no
-planner-authored input and reads no checkpoint. `runCodeReview` forwards `depth`
-to every provider's `runReview` input.
+`depth` is the thoroughness lever: `runCodeReview` derives it from the diff via
+[`review-depth.js`](../../scripts/lib/orchestration/review-depth.js) (Story #4542
+re-based it on that observable signal, so it takes no planner-authored input) and
+forwards it to every provider's `runReview` input.
 
 It is an **input-only** signal: it changes *how thorough* the review is, never
 the findings envelope (`{ status, severity, posted, report, halted,
@@ -270,8 +259,7 @@ prior baseline before merging.
 Findings are **persisted as a `verification-results` structured comment on
 the `[TICKET_ID]` issue** by `runCodeReview` (the unified findings contract of
 Story #4411; this single comment carries the
-Epic-close lens findings). The target ticket is the Story when
-`scope === 'story'` and the Epic when `scope === 'epic'`. The comment
+Story-scope lens findings). The target ticket is the Story. The comment
 is idempotent — re-runs replace the prior one — and its body includes
 severity-tier counts plus the full findings list so downstream workflows
 (notably the retro helper) can summarise blockers/high findings without

--- a/.agents/workflows/helpers/deliver-story-reference.md
+++ b/.agents/workflows/helpers/deliver-story-reference.md
@@ -194,6 +194,61 @@ behaviour and warrants pre-merge review.
 
 ## Step 4 — CI watch + fix recovery
 
+Enter this step **only** when Step 3 returned `blocked` with
+`blockClass: "checks-failed"` (a required check went red), or when a
+`--no-wait-merge` run left the PR for you to shepherd. When a required check is
+red, the agent owns the green-CI outcome, not just the push: local
+close-validation gates pass on the dev host's environment; CI runs on a
+different OS and concurrency, and coverage rounding, platform-conditional
+branches, and timing-sensitive tests routinely drift between the two.
+
+Fix the failure and push a new commit on `story-<storyId>` — auto-merge stays
+armed across retries, so you do not re-arm — then resume the land with the
+envelope's `nextCommand`.
+
+To watch the checks on the red path, drive `pr-watch-with-update.js` — the
+**single CI-watch mechanism** (Story #4358). It polls the required checks to a
+terminal state and auto-recovers from `mergeStateStatus: BEHIND`; do **not**
+fall back to a bare `gh pr checks` watch invocation:
+
+```bash
+node <agentRoot>/scripts/pr-watch-with-update.js --pr <prNumber> --story <storyId>
+```
+
+`--story` is what keys the red-path CI digest
+(`temp/story-<id>-ci-digest.{json,md}` — failing check name, run id, and a
+`gh run view --log-failed` tail). Omit it and a red check writes no digest.
+Poll cadence and caps come from `delivery.ci.watch.*` (`pollIntervalMs`,
+`maxPolls`, `maxResumes`); pass `--poll-interval-ms`, `--max-polls`, or
+`--max-resumes` to override for one run.
+
+When the watch exits, branch on the exit code:
+
+- **Exit 0 (all checks ✓)** — auto-merge will fire (or has already). The Story
+  is still at `agent::closing` with its issue OPEN. **Proceed to merge
+  confirmation (§ Step 5) within the same turn** — green CI is the *start* of
+  the merge-confirm sequence, not a terminal state.
+- **Exit 1 (a check genuinely failed)** — diagnose, fix, and push a new commit
+  on `story-<storyId>`, then re-watch. Auto-merge stays enabled across retries;
+  no need to re-arm it. The Story stays at `agent::closing` throughout, so a
+  failed/abandoned PR never strands a CLOSED issue. If the same failure class
+  recurs, hand convergence off to a self-paced host loop (`/loop`) that re-runs
+  the failing check and applies the smallest fix until it exits green.
+- **Exit 2 (still-running — slow CI, not red)** — the poll cap fired with checks
+  still pending and the watcher exhausted its resume budget with nothing red.
+  This is **never** a failure. Hand the wait off to the host's interval loop
+  rather than ending your turn: `/loop 5m` polling `gh pr checks` until the
+  checks settle.
+
+**Triage authority.** How to classify and remediate a red (or repeatedly slow)
+check — the root-cause-only decision tree for infra/transient and flaky failures
+(reproduce → check `main` → bisect env vs code → fix in-scope or file a
+`meta::framework-gap` issue), the never-rerun / never-quarantine prohibitions,
+and the escalation criteria (three-strikes, the 30-minute wall-clock timebox,
+and the clearly-environmental fast path) — is defined once in
+[`.agents/rules/ci-remediation.md`](../../rules/ci-remediation.md). Read it
+before remediating a red check.
+
 ### The auto-merge wait is an internally-blocking step
 
 This is the single most important contract of this workflow, and the seam
@@ -281,6 +336,20 @@ the watch exits clean.
 
 ## Step 5 — Merge confirmation detail
 
+> On the default path Step 3 already did this. Run it only to resume a
+> `pending` envelope, to finish a `--no-wait-merge` run, or to rescue a
+> merged-but-mislabelled Story.
+
+```bash
+node .agents/scripts/single-story-confirm-merge.js --story <storyId> --cwd <main-repo>
+```
+
+This is the **same** shared land path Step 3 reaches: it flips
+`agent::closing → agent::done` on a confirmed merge (closing the issue) and runs
+the **same** post-land tail — so the two surfaces cannot diverge. It is
+idempotent, emits the same terminal envelope, and is safe to re-run while the PR
+is still open (returns `pending`).
+
 `single-story-confirm-merge.js` re-reads the live PR state (`gh pr view
 --json state,mergedAt`, probing `gh pr list --head story-<id> --state all`
 when `--pr` is omitted) and:
@@ -301,6 +370,18 @@ The issue closes exactly when the work has merged, never at PR-open
 ---
 
 ## Step 5.5 — Re-assert Status column detail
+
+> **The land tail already ran this** (Story #4543) — it is `tail.statusResync`
+> in the terminal envelope. Run it by hand only when that step reported
+> `false`, or after a manual merge on a `--no-wait-merge` run.
+
+```bash
+node .agents/scripts/resync-status-column.js --story <storyId>
+```
+
+The helper re-fires the `ColumnSync` mutation and **polls for ~15 s** to win the
+race against the bot's late write (Story #2876). It is idempotent and
+no-op-safe (`no-project` / `not-on-project` exit 0).
 
 The GitHub Projects v2 built-in workflows `Pull request merged` and
 `Pull request linked to issue` are enabled by default on most boards
@@ -347,6 +428,30 @@ defense-in-depth against re-enabled or future workflows.
 ---
 
 ## Step 6 — Local branch cleanup detail
+
+> **The land tail already ran this** (Story #4543) — it is `tail.refCleanup` and
+> `tail.baseFastForward` in the terminal envelope, done in-process against the
+> same planners this command drives. Run it by hand only when either step
+> reported `false` (a dirty shared checkout is the common, benign cause), or
+> after a manual merge on a `--no-wait-merge` run. To prune the story ref **and**
+> fast-forward local `main` (or `project.baseBranch`):
+
+```bash
+node .agents/scripts/git-cleanup.js \
+  --execute \
+  --remote \
+  --yes \
+  --fast-forward-main \
+  --branches \
+  --include "story-<storyId>"
+```
+
+`--fast-forward-main` brings local `main` current (the next init seeds from it),
+`--branches` + `--include` reap only this Story's ref, and
+`--execute --remote --yes` run the deletes non-interactively. The sweep is
+idempotent and safe to run before `MERGED` confirms. Skip it only when the
+operator opted out via `--no-auto-merge` AND has not yet merged the PR — run the
+cleanup after the manual merge lands.
 
 GitHub deletes the **remote** branch on auto-merge (via the
 `--delete-branch` flag `single-story-close.js` passes to `gh pr merge`).
@@ -400,16 +505,10 @@ follows is the *judgement* around it, which a schema cannot express.
 
 ### `pending` is a real status — and it is not a park
 
-Earlier revisions asserted "the auto-merge wait does not produce a fourth
-status", on the reasoning that the wait is internally blocking so a run either
-merges or blocks. That was true only while the wait was unbounded — and it was
-never actually unbounded, because the host kills a tool invocation at ~10
-minutes. So a close-and-land whose CI outlived that ceiling took **no**
-terminal path at all: no event, no label, the Story parked at
-`agent::closing`. The status the model refused to name was the one that kept
-happening.
-
-`pending` names it, with its own exit code (3):
+`pending` is a real terminal status with its own exit code (3) — the honest
+name for a close-and-land whose CI outlived the host's ~10-minute
+tool-invocation ceiling, which would otherwise park the Story at
+`agent::closing` with no event and no label:
 
 - It is **resumable**: no label was mutated, no `merge.unlanded` was emitted,
   and `nextCommand` names the one command that continues it. The cumulative
@@ -419,13 +518,11 @@ happening.
   is the Story #1553 / PR #1554 failure mode wearing a schema. Return it only
   when the bound genuinely expired, or a human owns the merge.
 
-The no-park rule is therefore unchanged in substance: a turn that ends with
-prose ("I'll wait for the watch task…", "the next event will be its
-completion notification…") and an unconfirmed merge is a **contract
-violation** — the parent cannot distinguish "still working" from "done but
-silent". What changed is that there is now an honest, machine-readable way to
-say "not finished, here is exactly how to continue" instead of a choice
-between lying and blocking forever.
+The no-park rule holds: a turn that ends with prose ("I'll wait for the watch
+task…", "the next event will be its completion notification…") and an
+unconfirmed merge is a **contract violation** — the parent cannot distinguish
+"still working" from "done but silent". `pending` is the honest,
+machine-readable alternative: "not finished, here is exactly how to continue."
 
 ### Exit-code compatibility note (`--no-wait-merge`)
 

--- a/.agents/workflows/helpers/deliver-story.md
+++ b/.agents/workflows/helpers/deliver-story.md
@@ -131,32 +131,9 @@ Operator/agent responsibilities while in the worktree:
    `checklistPath` (footprint-matched **local**-lens authoring checklists),
    read it before you write and self-check as you author. When absent,
    lens-aware coverage still runs maker-blind at Story-scope review inside
-   the close subprocess.
-
-   **Producing `checklistPath` at dispatch (Story #4627).** The dispatch that
-   spawns this worker threads `checklistPath` the same way it threads
-   `docsDigestPath`. Before the spawn, compute the payload from the Story's
-   predicted footprint (its `changes[]` / `references[]` path entries) with
-   `buildDispatchChecklist` and write it to the run temp dir:
-
-   ```bash
-   node --input-type=module -e '
-     import { buildDispatchChecklist } from "<main-repo>/.agents/scripts/lib/audit-suite/index.js";
-     import { parse } from "<main-repo>/.agents/scripts/lib/story-body/story-body.js";
-     // storyBody is the fetched Story issue body.
-     const { changes, references } = parse(process.env.STORY_BODY);
-     const { checklistPath } = buildDispatchChecklist({
-       storyId: <storyId>, changes, references, runTempDir: "temp/run-<id>",
-     });
-     console.log(checklistPath ?? "");
-   '
-   ```
-
-   A non-empty `checklistPath` is threaded into this worker's prompt; an empty
-   footprint match prints nothing and the worker runs with no write-time
-   checklist (the maker-blind close-scope pass still covers it). The builder is
-   a pure function of the footprint and the on-disk checklists —
-   `buildDispatchChecklist` (`lib/audit-suite/dispatch-checklist.js`).
+   the close subprocess. The dispatch step produces `checklistPath` from the
+   Story's predicted footprint before it spawns this worker (Story #4627) — see
+   [`/deliver`](../deliver.md).
 2. Implement the changes. When the body has a `## Slicing` / Delivery
    Slicing table, walk rows as **intra-session checkpoints** (commit +
    flip each row when done) — never as sibling tickets.
@@ -364,173 +341,36 @@ Flags:
 
 ---
 
-## Step 4 — CI fix loop (**recovery-only**)
+## Steps 4–6 — Recovery router (**recovery-only**)
 
 > **Steps 4, 5, 5.5, and 6 are recovery paths, not routine choreography
 > (Story #4543).** On the default path Step 3 already polled the PR to a
 > confirmed merge, flipped `agent::done`, and ran the whole post-land tail —
 > follow-up capture, status resync, ref cleanup, base fast-forward — in one
 > process. A `landed` envelope means all of it ran; go straight to Step 7.
->
-> Enter this step **only** when Step 3 returned `blocked` with
-> `blockClass: "checks-failed"` (a required check went red), or when a
-> `--no-wait-merge` run left the PR for you to shepherd.
 
-When a required check is red, the agent owns the green-CI outcome, not just
-the push. Local close-validation gates pass on the dev host's environment;
-CI runs on a different OS and concurrency, and coverage rounding,
-platform-conditional branches, and timing-sensitive tests routinely drift
-between the two.
+Enter a recovery path **only** when Step 3's terminal envelope tells you to.
+The full procedures — commands, exit-code branches, and the
+internally-blocking-watch contract — live in
+[`deliver-story-reference.md`](deliver-story-reference.md); route by the
+envelope:
 
-Fix the failure and push a new commit on `story-<storyId>` — auto-merge stays
-armed across retries, so you do not re-arm — then resume the land with the
-envelope's `nextCommand`.
-
-> **A watch is an internally-blocking step, not a reason to end your turn.**
-> `pr-watch-with-update.js` blocks the current turn until CI resolves — that
-> IS how you wait. Ending the turn with prose and an unconfirmed merge is a
-> contract violation (the Story #1553 / PR #1554 failure mode). See
-> [`deliver-story-reference.md` § The auto-merge wait is an internally-blocking step](deliver-story-reference.md#the-auto-merge-wait-is-an-internally-blocking-step).
-
-To watch the checks on the red path, drive
-`pr-watch-with-update.js` — the **single CI-watch mechanism**
-(Story #4358). It polls the required checks to a
-terminal state and auto-recovers from `mergeStateStatus: BEHIND`; do
-**not** fall back to a bare `gh pr checks` watch invocation:
-
-```bash
-node <agentRoot>/scripts/pr-watch-with-update.js --pr <prNumber> --story <storyId>
-```
-
-`--story` is what keys the red-path CI digest
-(`temp/story-<id>-ci-digest.{json,md}` — failing check name, run id, and a
-`gh run view --log-failed` tail). Omit it and a red check writes no digest.
-
-Poll cadence and caps come from `delivery.ci.watch.*`
-(`pollIntervalMs`, `maxPolls`, `maxResumes`); pass `--poll-interval-ms`,
-`--max-polls`, or `--max-resumes` to override for one run.
-
-When the watch exits, branch on the exit code:
-
-- **Exit 0 (all checks ✓)** — auto-merge will fire (or has already). The
-  Story is still at `agent::closing` with its issue OPEN. **Proceed to
-  Step 5 within the same turn** — green CI is the *start* of the
-  merge-confirm sequence, not a terminal state.
-- **Exit 1 (a check genuinely failed)** — diagnose, fix, and push a new
-  commit on `story-<storyId>`, then re-watch. Auto-merge stays enabled
-  across retries; no need to re-arm it. The Story stays at
-  `agent::closing` throughout, so a failed/abandoned PR never strands a
-  CLOSED issue. If the same failure class recurs, hand convergence off to a
-  self-paced host loop (`/loop`) that re-runs the failing check and applies
-  the smallest fix until it exits green.
-- **Exit 2 (still-running — slow CI, not red)** — the poll cap fired with
-  checks still pending and the watcher exhausted its resume budget with
-  nothing red. This is **never** a failure. Hand the wait off to the
-  host's interval loop rather than ending your turn: `/loop 5m` polling
-  `gh pr checks` until the checks settle.
-
-> **Triage authority.** How to classify and remediate a red (or repeatedly
-> slow) check — the root-cause-only decision tree for infra/transient and
-> flaky failures (reproduce → check `main` → bisect env vs code → fix in-scope
-> or file a `meta::framework-gap` issue), the never-rerun / never-quarantine
-> prohibitions, and the escalation criteria (three-strikes, the 30-minute
-> wall-clock timebox, and the clearly-environmental fast path) — is defined
-> once in [`.agents/rules/ci-remediation.md`](../../rules/ci-remediation.md).
-> Read it before remediating a red check above.
->
-> **CI recovery procedures.** For resurrecting the worktree after
-> `reapOnSuccess`, pulling the failing job log, fixing coverage/CRAP
-> baselines without re-running close-validation, and the when-to-stop
-> Anti-Thrashing rules, see
-> [`deliver-story-reference.md` § Step 4 — CI watch + fix recovery](deliver-story-reference.md#step-4--ci-watch--fix-recovery).
-
----
-
-## Step 5 — Merge confirmation + land tail (**recovery-only**)
-
-> On the default path Step 3 already did this. Run it only to resume a
-> `pending` envelope, to finish a `--no-wait-merge` run, or to rescue a
-> merged-but-mislabelled Story.
-
-```bash
-node .agents/scripts/single-story-confirm-merge.js --story <storyId> --cwd <main-repo>
-```
-
-This is the **same** shared land path Step 3 reaches: it flips
-`agent::closing → agent::done` on a confirmed merge (closing the issue) and
-runs the **same** post-land tail — so the two surfaces cannot diverge. It is
-idempotent, emits the same terminal envelope, and is safe to re-run while
-the PR is still open (returns `pending`).
-
-> **Confirmation outcomes.** `single-story-confirm-merge.js` re-reads the
-> live PR state and flips to `agent::done` only on a confirmed `MERGED` PR;
-> it is idempotent and safe to re-run while the PR is still open (returns
-> `pending`). See
-> [`deliver-story-reference.md` § Step 5 — Merge confirmation detail](deliver-story-reference.md#step-5--merge-confirmation-detail).
-
----
-
-## Step 5.5 — Re-assert Status column (**recovery-only**)
-
-> **The land tail already ran this** (Story #4543) — it is `tail.statusResync`
-> in the terminal envelope. Run it by hand only when that step reported
-> `false`, or after a manual merge on a `--no-wait-merge` run.
-
-GitHub Projects v2 built-in workflows fire minutes *after* auto-merge lands
-and clobber the `Done` Status the confirm step set, stranding closed
-Stories at `In Progress` on the board (reproduced on Story #2813).
-Re-assert authority:
-
-```bash
-node .agents/scripts/resync-status-column.js --story <storyId>
-```
-
-The helper re-fires the `ColumnSync` mutation and **polls for ~15 s** to win
-the race against the bot's late write (Story #2876). It is idempotent and
-no-op-safe (`no-project` / `not-on-project` exit 0).
-
-> **Status-column detail + tuning flags + operator fix.** For the poll-loop
-> flags (`--poll-attempts`, `--poll-delay-ms`), the `attempts` / `drifted`
-> envelope semantics, and the canonical
-> `--reap-conflicting-workflows` operator fix, see
-> [`deliver-story-reference.md` § Step 5.5 — Re-assert Status column detail](deliver-story-reference.md#step-55--re-assert-status-column-detail).
-
----
-
-## Step 6 — Local branch cleanup (**recovery-only**)
-
-> **The land tail already ran this** (Story #4543) — it is `tail.refCleanup`
-> and `tail.baseFastForward` in the terminal envelope, done in-process
-> against the same planners this command drives. Run it by hand only when
-> either step reported `false` (a dirty shared checkout is the common,
-> benign cause), or after a manual merge on a `--no-wait-merge` run.
-
-GitHub deletes the **remote** branch on auto-merge, but the **local**
-`story-<storyId>` ref lingers in the main checkout until something prunes
-it. To prune the story ref **and** fast-forward local `main` (or
-`project.baseBranch`):
-
-```bash
-node .agents/scripts/git-cleanup.js \
-  --execute \
-  --remote \
-  --yes \
-  --fast-forward-main \
-  --branches \
-  --include "story-<storyId>"
-```
-
-`--fast-forward-main` brings local `main` current (the next init seeds from
-it), `--branches` + `--include` reap only this Story's ref, and
-`--execute --remote --yes` run the deletes non-interactively. The sweep is
-idempotent and safe to run before `MERGED` confirms. Skip Step 6 only when
-the operator opted out via `--no-auto-merge` AND has not yet merged the PR —
-run the cleanup after the manual merge lands.
-
-> **Why local `main` goes stale + per-flag behaviour.** For the stale-`main`
-> mechanism and the full `--fast-forward-main` / `--branches` / `--include`
-> flag semantics, see
-> [`deliver-story-reference.md` § Step 6 — Local branch cleanup detail](deliver-story-reference.md#step-6--local-branch-cleanup-detail).
+- **`blocked` / `blockClass: "checks-failed"`** (a required check went red) →
+  fix and push a new commit on `story-<storyId>` (auto-merge stays armed), then
+  resume with the envelope's `nextCommand`. The watch is an internally-blocking
+  step — never end your turn with prose and an unconfirmed merge (Story #1553).
+  Procedure:
+  [reference § Step 4 — CI watch + fix recovery](deliver-story-reference.md#step-4--ci-watch--fix-recovery)
+  (triage per [`rules/ci-remediation.md`](../../rules/ci-remediation.md)).
+- **`pending`** (bounded merge wait expired, PR healthy; or a `--no-wait-merge`
+  run to shepherd) → run the envelope's `nextCommand`
+  (`single-story-confirm-merge.js`) until it resolves —
+  [reference § Step 5 — Merge confirmation detail](deliver-story-reference.md#step-5--merge-confirmation-detail).
+- **`tail.statusResync: false`** → re-assert the Status column by hand —
+  [reference § Step 5.5](deliver-story-reference.md#step-55--re-assert-status-column-detail).
+- **`tail.refCleanup: false` / `tail.baseFastForward: false`** → prune the local
+  ref and fast-forward `main` by hand —
+  [reference § Step 6](deliver-story-reference.md#step-6--local-branch-cleanup-detail).
 
 ---
 

--- a/.agents/workflows/helpers/worktree-lifecycle.md
+++ b/.agents/workflows/helpers/worktree-lifecycle.md
@@ -242,73 +242,12 @@ Symlink strategy:
   specific failure up to 3 times with 250/500/1000 ms backoff. Unrelated fetch
   failures surface immediately — no retry.
 
-## Harness-worktree ⇄ consumer-lint-ignore interaction (Story #152)
+## Harness-worktree ⇄ consumer-lint-ignore interaction
 
-Mandrel's own worktree isolation (above) always roots story worktrees at
-`delivery.worktreeIsolation.root` (default `.worktrees/` at the repo root).
-That path is separate from **the host IDE/CLI harness's own worktree
-mechanism** — for example Claude Code, when it manages an agent session as a
-git worktree, nests it at `.claude/worktrees/<name>/`. A mandrel delivery
-agent can be invoked from *either* location depending on how the operator's
-harness composes with `/deliver`: mandrel's own `.worktrees/story-<id>/` when
-`worktreeIsolation.enabled` drives the checkout, or a harness-level
-`.claude/worktrees/<name>/` when the harness itself provides the isolated
-working directory mandrel runs inside.
-
-This matters because a consumer's `pre-push` (or `pre-commit`) lint step is
-commonly configured with an ignore glob that excludes noisy agent-tooling
-directories, e.g. a Biome `files.includes` entry like `"!**/.claude"`. When
-the *agent's CWD itself* resolves under `.claude/worktrees/<name>/`, a
-lint invocation scoped to `.` (`biome check .`, or equivalent) resolves
-every candidate path as living under the ignored `.claude` prefix — the glob
-matches zero files, and tools that treat zero-match as failure (Biome's
-default `check` behavior without `--no-errors-on-unmatched`) exit non-zero
-with something like `No files were processed in the specified paths`. This
-is a **false negative**: the changed files were never actually linted
-against, and the hook is not reporting a real defect. It is functionally
-distinct from a `pre-push` rejection caused by a genuine lint violation, and
-must not be treated the same way.
-
-**Do not resolve this by bypassing the push hook.**
-[`rules/git-conventions.md`](../../rules/git-conventions.md) § "Push
-Validation & Reliability" prohibits skipping hooks without explicit operator
-authorization, and that prohibition is not weakened by this interaction —
-the zero-match failure is a **consumer-tooling gap**, not a framework
-authorization the agent gets to grant itself.
-
-**Sanctioned resolution path:**
-
-1. **Recognize the signature.** A `pre-push`/`pre-commit` failure whose
-   message is a zero-match error (`No files were processed`, `0 files
-   matched`, or equivalent for the consumer's linter) — not a reported
-   violation in a specific file — combined with an agent CWD under
-   `.claude/worktrees/` (or any other harness-managed path a consumer's lint
-   config ignores) is this known interaction, not a real lint failure.
-2. **Fix it in the consumer, not the agent invocation.** The remedy lives in
-   the consumer's own lint command, mirroring what its `lint-staged` config
-   (if present) likely already does for the same reason: make the zero-match
-   case a no-op instead of a failure. For Biome:
-   `biome check --no-errors-on-unmatched .`. Other linters have an
-   equivalent flag (e.g. ESLint's `--no-error-on-unmatched-pattern`). This is
-   a one-line consumer-side change, typically to `.husky/pre-push` or the
-   `package.json` script it invokes.
-3. **Escalate through the normal HITL path**, per
-   [`.agents/instructions.md` § 1.J](../../instructions.md), if the agent
-   cannot edit the consumer's hook/lint config directly (e.g. it sits outside
-   the Story's scope). Transition to `agent::blocked`, name the zero-match
-   signature and the one-line remedy in the blocker summary, and let the
-   operator apply the consumer-side fix or explicitly authorize a one-time
-   hook-skip per [`rules/git-conventions.md`](../../rules/git-conventions.md)
-   § "Push Validation & Reliability". Explicit operator authorization is the
-   *only* circumstance under which a hook may be skipped — never as an
-   agent's unilateral default when this signature is recognized.
-4. **Do not relocate mandrel's own worktrees to work around a harness-level
-   path.** `delivery.worktreeIsolation.root` controls where *mandrel*
-   materializes `story-<id>` worktrees (default `.worktrees/`, already
-   outside `.claude/`) and is unrelated to where the host harness places its
-   own session worktree. Changing `worktreeIsolation.root` does not fix this
-   interaction when the false negative originates from the harness's path,
-   not mandrel's.
+When an agent's CWD resolves under a harness-managed worktree path the consumer's
+lint config ignores (e.g. `.claude/worktrees/`), a `.`-scoped lint can zero-match
+and fail falsely. Its signature and the sanctioned consumer-side fix (never a
+hook bypass) live in [`rules/git-conventions-reference.md` § Push Validation](../../rules/git-conventions-reference.md).
 
 ## Fallback: single-tree mode
 

--- a/.agents/workflows/mandrel-update.md
+++ b/.agents/workflows/mandrel-update.md
@@ -113,19 +113,13 @@ single source of truth, kept in lockstep with this table by
 | **migrate**       | `npx mandrel migrate --from <cur> --to <target>`        |
 | **doctor**        | `npx mandrel doctor` (then apply the per-check remedies) |
 
-The exact stderr the CLI prints per failed phase:
-
-- **sync** — the .agents/ materialization may be incomplete. Run `mandrel
-  sync` manually to restore.
-- **sync-commands** — the .claude/commands/ tree may be out of sync. Run `npm
-  run sync:commands` manually to restore.
-- **migrate** — some migrations for v\<cur\> → v\<target\> may not have
-  applied. Run `mandrel migrate --from <cur> --to <target>` manually to retry.
-- **doctor** — upgraded to v\<target\> but doctor reported failures. → Run
-  `mandrel doctor` for remedies.
-
-(`<cur>` / `<target>` are the installed and resolved-newest version strings
-the failing run reported.)
+The CLI prints the matching remedy command to stderr per failed phase; the
+workflow quotes those commands verbatim so an operator sees the same thing the
+CLI told them, and the drift gate above keys on them: Run `mandrel sync`
+manually to restore. · Run `npm run sync:commands` manually to restore. · Run
+`mandrel migrate --from <cur> --to <target>` manually to retry. · Run
+`mandrel doctor` for remedies. (`<cur>` / `<target>` are the installed and
+resolved-newest version strings the failing run reported.)
 
 Recovery sequence: run the matching remedy, then **re-run
 `npx mandrel update`** — it is idempotent (the install already landed, so a

--- a/.agents/workflows/plan.md
+++ b/.agents/workflows/plan.md
@@ -180,17 +180,21 @@ assumption, thin the Slicing checkpoint) and re-run this step. Empty
   provably have nothing for a critic to find, and each skip is recorded on the
   plan-metrics ledger so under-firing stays auditable.
 - **Either `dispatch: true`** — dispatch **one fresh-context sub-agent per
-  firing critic** (a generic sub-agent), then fold its findings into the
-  Gate #2 view or a re-author round before persist. Each critic is
+  firing critic**, then fold its findings into the Gate #2 view or a re-author
+  round before persist. When `delivery.routing.roleScopedAgents` is enabled
+  (the **default**), dispatch each firing critic with `subagent_type:
+  plan-critic` — it boots on the role-scoped
+  [`plan-critic`](../agents/plan-critic.md) context (its own system prompt, no
+  `CLAUDE.md` @-closure) that carries the maker-blind invariant, the
+  `consolidation` and `pre-mortem` charters, and the output shape standalone.
+  When the kill-switch is off (`roleScopedAgents: false`) or the host cannot
+  spawn at this depth, fall back to a generic sub-agent and hand it the same
+  charter (the `consolidation` / `pre-mortem` definitions in
+  [`plan-critic.md`](../agents/plan-critic.md)). Either way the critic is
   **maker-blind**: hand it the draft artifacts (`stories.json`, and
-  `techspec.md` when present) plus its charter below — never the authoring
-  transcript or the reasons the planner believed its own draft is sound. A
-  critic that reads the maker's case grades the case, not the draft.
-  - `consolidation` — the draft's shape: Stories that should be one cohesive
-    slice, a slice split per-module rather than per-capability, and
-    `depends_on` edges that disagree with the Delivery Slicing table.
-  - `pre-mortem` — assume the plan shipped and failed: name the most likely
-    failure modes and what the draft would have to say to prevent them.
+  `techspec.md` when present) — never the authoring transcript or the reasons
+  the planner believed its own draft is sound. A critic that reads the maker's
+  case grades the case, not the draft.
 
 Fold what survives back into `stories.json` and re-run this step. Findings are
 advisory input to the operator's Gate #2 decision, not an automatic re-author
@@ -201,11 +205,9 @@ mandate.
 **Gate #2** — when the operator passed `--force-review`, STOP for approval of
 the assembled plan before persist. Under `--yes`, auto-proceed.
 
-`--force-review` is the **only** thing that raises this gate. Story #4542
-retired the risk-derived alternative: the planner authored its own risk verdict,
-persist computed a `requiresStop` from it *after* `createStoryIssues` had already
-run, and nothing read the result — the STOP was prose executed by the same
-session that wrote the verdict. A gate a plan can lower for itself is not a gate.
+`--force-review` is the **only** thing that raises this gate — there is no
+risk-derived routing (Story #4542): a gate a plan can lower for itself is not a
+gate.
 
 #### Dry-run pre-pass (always)
 


### PR DESCRIPTION
Closes #4663

_Auto-opened by `/deliver`._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are agent workflow and markdown documentation only; delivery behavior is specified, not implemented in application runtime code in this diff.
> 
> **Overview**
> Introduces **`plan-critic`** as a role-scoped, maker-blind critic agent (consolidation / pre-mortem charters, structured findings) and documents **`delivery.routing.roleScopedAgents`** (default on) for planning and delivery.
> 
> **`/deliver`** now spawns each ready Story as a **`story-worker`** sub-agent with `docsDigestPath`, footprint-derived **`checklistPath`** (`buildDispatchChecklist` before spawn), and change-set discipline; inline execution remains when the kill-switch is off or nesting is unavailable. Retired batch axes (`--run`, `--dep`) are called out as a short note.
> 
> **`/plan` §2.5** dispatches firing critics as **`plan-critic`** sub-agents (generic sub-agent fallback otherwise), still maker-blind on draft artifacts only.
> 
> **Documentation slimming:** **`deliver-story.md`** drops duplicated Steps 4–6 and dispatch checklist prose in favor of a recovery router pointing at **`deliver-story-reference.md`** (CI watch, merge confirm, status resync, git cleanup). **`git-cleanup.md`** shrinks to phases, constraints, and examples (script owns detail). **`code-review.md`** drops legacy epic scope. **`worktree-lifecycle.md`** and **`mandrel-update.md`** defer long sections to other rule/reference files.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9c3f9f8d52729b3f7c540dab588ab90526a7c4e4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->