### PR TITLE
docs(agents): cut the always-loaded closure and rules to contract-only prose (#4664)

### DIFF
--- a/.agents/instructions.md
+++ b/.agents/instructions.md
@@ -1,73 +1,53 @@
 # Agent Execution Protocol
 
-You are operating under the Agent Execution Protocol. Your behavior, technical
-constraints, and operational context are governed by this central instruction
-set. You MUST strictly adhere to the following rules:
+You operate under the Agent Execution Protocol — this central instruction set
+governs your behavior, constraints, and operational context, and you MUST
+strictly adhere to it.
 
 ---
 
 ## 1. System Guardrails & Initialization
 
-### A. Role Framing (no persona packs)
+### A. Role Framing
 
-v2 has **no** `.agents/personas/` packs and **no** `persona::*` GitHub labels.
 Behavioral constraints come from this file, always-on / on-demand rules, and
-skills. Role-scoped spawn contexts (when used) live under `.agents/agents/`
-via `delivery.routing.roleScopedAgents`. QA auth identities (`qa.personas`)
-are a separate fixture concept — not agent behavior packs.
-
-If a user says "act as [role]" in chat, apply the matching skill / workflow
-guidance (e.g. QA skills for verification work, security skill for threat
-modeling) rather than looking for a persona file.
+skills — there are no persona packs and no `persona::*` labels. Role-scoped
+spawn contexts (when used) live under `.agents/agents/` via
+`delivery.routing.roleScopedAgents`; QA auth identities (`qa.personas`) are a
+separate fixture concept. If a user says "act as [role]", apply the matching
+skill / workflow guidance (QA skills for verification, the security skill for
+threat modeling) rather than looking for a persona file.
 
 ### B. Skill Activation
 
-The skill library uses a **two-tier architecture**:
+The skill library is **two-tier**: **`core/`** — universal, process-driven
+skills (`core/debugging-and-error-recovery`, `core/code-review-and-quality`,
+`core/security-and-hardening`); check for one first (the **test-first**
+discipline lives in [`rules/testing-standards.md`](rules/testing-standards.md),
+not a skill). **`stack/`** — tech-stack-specific skills (`stack/qa/playwright`,
+`stack/qa/vitest`); apply when the project uses that technology, else use the
+§ 1.C live-docs lookup.
 
-- **`core/`** — Universal, process-driven skills that apply across any project
-  (e.g., `core/debugging-and-error-recovery`, `core/code-review-and-quality`,
-  `core/security-and-hardening`). Always check for a relevant core skill first.
-  The **test-first** discipline (TDD cycle, Prove-It Pattern, good-test style,
-  property-based technique) lives in
-  [`rules/testing-standards.md`](rules/testing-standards.md), not a skill.
-- **`stack/`** — Tech-stack-specific skills for concrete tools (e.g.,
-  `stack/qa/playwright`, `stack/qa/vitest`, `stack/qa/gherkin-authoring`).
-  Apply these when the project uses that specific technology. For third-party
-  library and framework knowledge not covered here, use the live-docs lookup
-  mandated in § 1.C rather than a frozen in-repo cache.
-
-When a task involves a specific domain or technology, you MUST read the
-corresponding `.agents/skills/[tier]/[category]/[skill-name]/SKILL.md` file and
-apply its constraints. A `SKILL.md` leads with its **Policy Capsule** — the
-contract, and the whole cost of activating the skill — followed by pointers
-into an on-demand `reference.md` sibling holding the long-form material
-(patterns, worked examples, checklists). This is the same split the always-on
-rules use (§ 1.F): read the capsule on activation, and open a `reference.md`
-section only when the task actually engages it. Review the skill's `examples/`
-directory or `examples.md` sibling **when present and relevant** to the task —
-most skills do not ship one, so do not probe blindly. When uncertain which skill applies,
-match the task against the one-line `description` in each skill's frontmatter
-(catalogued in `.agents/skills/skills.index.json`). Skills compose: a complete
-feature typically flows `idea-refinement` → the `/plan` workflow →
-implementation test-first (`rules/testing-standards.md`) →
-`code-review-and-quality` — not every task needs every skill. The always-on
-operating posture (surface assumptions, manage confusion, push back on flawed
-approaches, verify don't assume) is governed by § 3–4 and § 1.I of this file.
+When a task engages a domain or technology, you MUST read the corresponding
+`.agents/skills/[tier]/[category]/[skill-name]/SKILL.md` and apply its
+constraints — the **Policy Capsule** (the whole cost of activation) on
+engagement, a `reference.md` section or `examples/` only when the task needs it
+(§ 1.F's read-when-relevant split). When unsure which applies, match the task
+against the one-line `description` in each skill's frontmatter (catalogued in
+`.agents/skills/skills.index.json`). Skills compose (`idea-refinement` →
+`/plan` → test-first implementation → `code-review-and-quality`); not every
+task needs every skill. The always-on operating posture is governed by § 3–4
+and § 1.I.
 
 ### C. Proactive Documentation
 
-You MUST use the host's best available live-documentation mechanism
-proactively to prevent hallucination — for example a docs MCP server such as
-Context7 when the host has it wired in, an IDE-native docs lookup, or any
-equivalent live-docs surface the host exposes.
-
-- **Mandatory Usage:** For any code generation, project setup, or complex
-  configuration involving third-party libraries, fetch the latest official
-  documentation **before** writing code. Do not ask for permission.
-- **Fallback Order:** If no live-docs mechanism is available, fall back to (1)
-  in-repo docs and the package's bundled `README.md`/`CHANGELOG.md`, then
-  (2) the host's web fetch/search tool. Note in your work log which channel
-  you used so reviewers can spot stale references.
+You MUST use the host's best live-documentation mechanism (a docs MCP server
+such as Context7, an IDE-native lookup, or equivalent) proactively to prevent
+hallucination: for any code involving third-party libraries, fetch the latest
+official docs **before** writing code — do not ask permission. If none exists,
+fall back to (1) in-repo docs and the package's bundled `README.md` /
+`CHANGELOG.md`, then (2) the host's web fetch/search; note which channel you
+used so reviewers can spot stale references.
 
 ### D. Error Handling & Degradation
 
@@ -87,136 +67,97 @@ directly — there is no separate state-mutation MCP server to degrade from.
 
 ### E. Local Overrides
 
-If a `.agents/instructions.local.md` file or `.agentrc.local.json` is present,
-you MUST load them. They contain personal developer preferences and
-environment variables that override project defaults. The config resolver
-deep-merges `.agentrc.local.json` over `.agentrc.json` (local wins; absent
-local file is a no-op). Do not modify these local files unless requested.
+If a `.agents/instructions.local.md` or `.agentrc.local.json` is present, you
+MUST load it — the config resolver deep-merges `.agentrc.local.json` over
+`.agentrc.json` (local wins; absent is a no-op). Do not modify these files
+unless requested.
 
-**Durable slash commands.** Any `.md` file placed at
-`.agents/local/workflows/<name>.md` is automatically projected into
-`.claude/commands/<name>.md` by `sync-claude-commands.js`, making it
-invocable as `/<name>`. Because the entire `.agents/local/` subtree is
-exempt from `mandrel sync`'s prune pass, these commands survive
-`npm install`, `mandrel sync`, and `mandrel update` with no manual
-re-sync. Core payload commands of the same basename always win (the
-local copy is ignored with a `shadowed` warning).
+**Durable slash commands.** Any `.md` at `.agents/local/workflows/<name>.md` is
+projected into `.claude/commands/<name>.md` by `sync-claude-commands.js` as
+`/<name>`. The `.agents/local/` subtree is exempt from `mandrel sync`'s prune
+pass, so these commands survive `npm install` / `mandrel sync` / `mandrel
+update`; a core payload command of the same basename wins (local ignored with a
+`shadowed` warning).
 
 ### F. Modular Global Rules
 
-The `.agents/rules/` directory is split into an **always-on core** and an
-**on-demand set** — the same read-when-relevant pattern skills use (§ 1.B).
-The core loads into every session; the on-demand rules are read only when the
-task actually engages them, so a generic task (and every subagent it spawns)
-does not re-pay their bytes on every turn.
+`.agents/rules/` splits into an **always-on core** (loaded with this file) and
+an **on-demand set** (read only when the task engages it, so a generic task —
+and every subagent it spawns — does not re-pay their bytes), the same
+read-when-relevant pattern skills use (§ 1.B).
 
-- **Always-on core** (loaded alongside this file):
-  - [`rules/security-baseline.md`](rules/security-baseline.md) — inviolable
-    security MUSTs; applies to every piece of code generated.
-  - [`rules/git-conventions.md`](rules/git-conventions.md) — the always-on git
-    core (branch shapes, commit-subject format, `refs #`, push/hygiene MUSTs);
-    every commit, branch, and PR touches it.
+- **Always-on core**: [`security-baseline.md`](rules/security-baseline.md)
+  (inviolable security MUSTs) and
+  [`git-conventions.md`](rules/git-conventions.md) (branch shapes,
+  commit-subject format, `refs #`, push/hygiene MUSTs).
+- **On-demand** — read **before** the matching work; each opens with a one-line
+  "this rule applies when…" scope header:
+  [`git-conventions-reference.md`](rules/git-conventions-reference.md)
+  (git-history mechanics),
+  [`shell-conventions.md`](rules/shell-conventions.md) (shell chains,
+  cross-platform strings),
+  [`testing-standards.md`](rules/testing-standards.md) (authoring or
+  restructuring tests),
+  [`orchestration-error-handling.md`](rules/orchestration-error-handling.md)
+  (scripts under `.agents/scripts/**`),
+  [`ci-remediation.md`](rules/ci-remediation.md) (a red or slow CI check), and
+  [`api-conventions.md`](rules/api-conventions.md) /
+  [`gherkin-standards.md`](rules/gherkin-standards.md) /
+  [`changelog-style.md`](rules/changelog-style.md) /
+  [`test-seams.md`](rules/test-seams.md) (API, Gherkin, changelog, test-seam
+  work).
 
-- **On-demand** — read the file **before** doing the matching work; each opens
-  with a one-line "this rule applies when…" scope header, so skimming its first
-  paragraph confirms whether it governs the task at hand:
-  - [`rules/git-conventions-reference.md`](rules/git-conventions-reference.md)
-    — the git-history mechanics the core summarizes: hard-cutover policy, the
-    push-hook false-negative signature, shared-checkout contention, the
-    docs-freshness gate, and `meta::*` routing labels.
-  - [`rules/shell-conventions.md`](rules/shell-conventions.md) — before
-    chaining shell commands or writing cross-platform command strings.
-  - [`rules/testing-standards.md`](rules/testing-standards.md) — before
-    authoring or restructuring tests (the three-tier pyramid, assertion
-    placement, mocking/isolation MUSTs).
-  - [`rules/orchestration-error-handling.md`](rules/orchestration-error-handling.md)
-    — before writing or modifying orchestration scripts under
-    `.agents/scripts/**`.
-  - [`rules/ci-remediation.md`](rules/ci-remediation.md) — before remediating
-    a red (or repeatedly slow) CI check during delivery (the root-cause-only
-    triage decision tree, the never-rerun / never-quarantine prohibitions,
-    and the escalation criteria).
-  - [`rules/api-conventions.md`](rules/api-conventions.md),
-    [`rules/gherkin-standards.md`](rules/gherkin-standards.md),
-    [`rules/changelog-style.md`](rules/changelog-style.md),
-    [`rules/test-seams.md`](rules/test-seams.md) — when the task is in that
-    domain (API surface, Gherkin scenarios, changelog prose, test seams).
-
-When in doubt, read the rule — the read is cheap relative to shipping a
-MUST-violating change. Precedence between a rule and any other governance
-document is unchanged (§ 1.K): loading a rule on demand does not lower its
-authority.
+Read the rule when unsure — cheaper than shipping a MUST violation; loading it
+on demand does not lower its authority (§ 1.K).
 
 ### G. Structured Configuration
 
-Refer to `.agentrc.json` to understand your operational limits (e.g., allowed
-auto-run permissions, default personas). For the project's specific
-technology choices (database, ORM, API framework, auth provider, validation
-library, workspace paths), refer to the project's Tech Stack inventory: a
-dedicated `docs/tech-stack.md` when present (the single-ownership convention),
-otherwise the **Tech Stack** section of `docs/architecture.md` (a numbered or
-decorated heading such as `## 1. Tech Stack` is fine). Project-specific
-technology context is intentionally kept out of `.agentrc.json`.
+Refer to `.agentrc.json` for operational limits (auto-run permissions, etc.).
+Project technology choices (database, ORM, API framework, auth, validation,
+paths) are intentionally kept out of it — read the Tech Stack inventory:
+`docs/tech-stack.md` when present, otherwise the **Tech Stack** section of
+`docs/architecture.md`.
 
 ### H. Observability & Friction Telemetry
 
 You MUST log telemetry about operational difficulty or automation
-opportunities you hit. Friction is a **local NDJSON signal**:
-`diagnose-friction.js` appends one `kind: friction` record to the per-run/
-per-Story `signals.ndjson` stream on local disk — not posted to the ticket at
-capture time; the retro phase surfaces the aggregate as routed proposals.
+opportunities. Friction is a **local NDJSON signal**: `diagnose-friction.js`
+appends a `kind: friction` record to the per-run/per-Story `signals.ndjson`
+stream (not posted to the ticket; the retro phase surfaces the aggregate).
 
 - **Command**:
   `node .agents/scripts/diagnose-friction.js --story [STORY_ID] --cmd [FAILED_COMMAND]`
 - **When to fire**: after repeated tool-validation errors, an unrecoverable
-  command failure, ambiguity needing self-correction, or repetitive
-  boilerplate steps a workflow/skill could simplify.
+  command failure, ambiguity needing self-correction, or repetitive boilerplate
+  a workflow/skill could simplify.
 
-The schema validation, the standalone stream path, and the
-never-silently-dropped guarantee are reference detail — see
-[`docs/execution-reference.md` § Friction telemetry](docs/execution-reference.md#friction-telemetry).
-
-#### Log Level Control
-
-The orchestrator logger honors `AGENT_LOG_LEVEL` (`silent` / `info` /
-`verbose`). The per-level emission table is reference detail — see
-[`docs/execution-reference.md` § Log-level control](docs/execution-reference.md#log-level-control).
+Schema, stream path, the never-silently-dropped guarantee, and the
+`AGENT_LOG_LEVEL` (`silent`/`info`/`verbose`) emission table are reference
+detail — see [`docs/execution-reference.md`](docs/execution-reference.md#friction-telemetry).
 
 ### I. Anti-Thrashing Protocol
 
 You MUST proactively identify when you are "thrashing" or stuck in an
 infinite loop, and you MUST stop, summarize the blockers, and present a
 **Re-Plan** (or yield to the user) before consuming more tokens on a failing
-strategy. Use the qualitative cues below — there are no numeric thresholds
-because none of the framework code increments a counter or fires at a
-boundary; the call is yours to make.
+strategy. The cues are qualitative — there are no numeric thresholds; the call
+is yours to make.
 
-- **Failure cluster**: You have run a handful of tool calls in a row that
-  returned errors of the same shape. The remediation is the same each time,
-  and the next attempt is unlikely to surface new information. Stop.
-- **Research drift**: You are several steps into reading code or
-  documentation without writing or modifying anything, and the additional
-  reads are no longer narrowing the problem space. Stop and propose a plan
-  with the information you have.
-- **Same fix, same failure**: You have applied the same kind of fix more
-  than once for the same error class, and the failure mode hasn't changed.
-  Stop — the diagnosis is wrong.
+- **Failure cluster** — several tool calls in a row returning same-shape
+  errors with the same remediation. Stop.
+- **Research drift** — several reads deep with nothing written and the reads no
+  longer narrowing the problem. Stop and plan with what you have.
+- **Same fix, same failure** — the same kind of fix applied more than once for
+  one error class with no change in the failure mode. Stop; the diagnosis is
+  wrong.
 
-When you stop, write a one-paragraph summary of what you tried, what
-recurred, and what assumption you would test next, then either Re-Plan or
-hand back to the operator. Do not paper over the loop with another
-just-in-case retry.
-
-While executing as a Story delivery sub-agent (via `helpers/deliver-story`),
-if you genuinely cannot proceed you MUST transition to `agent::blocked` and
-exit non-zero — **never fall silent**. A stalled child that reports nothing
-is indistinguishable from a dead one, and the parent `/deliver` run can only
-escalate what you surface.
+When you stop, summarize in one paragraph what you tried, what recurred, and
+what you would test next, then Re-Plan or hand back — do not paper over the
+loop with another just-in-case retry.
 
 ### J. HITL Blocker Escalation (Safe Execution)
 
-Before executing any task, you MUST check the ticket labels and instructions
-for high-risk operations.
+Before any task, you MUST check the ticket labels for high-risk operations.
 
 - **`risk::high` is metadata**: treat it as planning/audit signal only. It
   does **not** create an automatic runtime pause.
@@ -258,16 +199,11 @@ Two carve-outs refine the ordering:
 
 ## 2. FinOps & Token Budgeting (Economic Guardrails)
 
-Mandrel does **not** enforce live LLM spend from response metadata, and it has
-no operator-tunable context budget. What it does bound are fixed framework
-ceilings — the `/plan` context envelope and plan-time Story sizing — and they
-**fail closed** with a message naming what to trim, rather than silently
-handing the model a truncated context. Your host runtime owns session quota and
-hard stops. The constants, the ≈4-char/token estimate, and the trim options are
-reference detail — see
-[`docs/execution-reference.md` § FinOps & token budgeting](docs/execution-reference.md#finops--token-budgeting-economic-guardrails).
-Consult it when `/plan` refused an over-ceiling envelope or an over-budget
-Story count.
+Mandrel does **not** enforce live LLM spend and has no operator-tunable context
+budget; your host runtime owns session quota. It does bound fixed framework
+ceilings — the `/plan` context envelope and plan-time Story sizing — which
+**fail closed** with a message naming what to trim. Constants and trim options:
+[`docs/execution-reference.md`](docs/execution-reference.md#finops--token-budgeting-economic-guardrails).
 
 ---
 
@@ -275,37 +211,16 @@ Story count.
 
 1. **Context First:** Before proposing any solution, understand the
    repository's tech stack, historical context, and structure.
-   - **Digest-first Reading (Story #4433)** — stated once here; it governs
-     every call site. **Never ingest the whole `project.docsContextFiles` set
-     up front.** Read the **docs digest** — a compact outline (path, byte
-     size, heading outline with line numbers, and the first paragraph under
-     each `##`) built from those files — decide which docs bear on the task at
-     hand, then **pull the full file on demand**, jumping to the section at
-     the line number the digest names. This is a hard cutover: no
-     read-every-file branch is retained on any path.
-
-     The call sites differ only in how the digest reaches you — the
-     discipline above is identical for all of them:
-     - `/plan` and interactive tasks — a file at `temp/run-<id>/docs-digest.md`
-       (`plan-context.js`, via the shared generator in
-       `.agents/scripts/lib/orchestration/docs-digest.js`).
-     - `/deliver` Story sub-agents (`helpers/deliver-story`) — the
-       `docsDigestPath` the caller threads.
-     - Standalone-Story planning (`story-plan.js --emit-context`) — inline as
-       `corpusContext.docsDigest` (no per-run directory to anchor a
-       file), alongside `corpusContext.relevantSections`.
-
-     When no digest exists for the task at hand — an ad hoc task outside
-     `/deliver`, `project.docsContextFiles` unset, or a null `docsDigestPath` —
-     there is **no mandatory docs read**: read a full doc only when the task's
-     own context points you at one.
-
-     The decisions log (`decisions.md`) may be either a single-file
-     dated-entry log or an **index** into a `decisions/` ADR directory — both
-     are first-class layouts (see
-     [`skills/core/documentation-and-adrs`](skills/core/documentation-and-adrs/SKILL.md)).
-     Treat an index like any other digested doc: link-follow the per-ADR
-     bodies on demand rather than auto-loading them.
+   - **Digest-first Reading (Story #4433).** **Never ingest the whole
+     `project.docsContextFiles` set up front.** Read the **docs digest** — a
+     compact outline (path, byte size, heading outline with line numbers, and
+     the first paragraph under each `##`) — decide which docs bear on the task,
+     then **pull the full file on demand**, jumping to the section at the line
+     number the digest names. This is a hard cutover: no read-every-file branch
+     survives. When no digest exists for the task — an ad hoc task,
+     `project.docsContextFiles` unset, or a null `docsDigestPath` — there is
+     **no mandatory docs read**: read a full doc only when the task's own
+     context points you at one.
    - **Conditional Reads**: When the task touches UI copy, layout, or
      routing and the corresponding file is present in the project, also
      read `docs/style-guide.md` and `docs/web-routes.md`. Skip both when
@@ -318,17 +233,12 @@ Story count.
      (semantic code search or focused text search) to isolate specific
      schemas or decisions before reading broad files.
 2. **Plan First:** For non-trivial tasks (3+ steps or architectural
-   decisions), enter **Plan Mode**. Update the Story's `## Spec`
-   (via `/plan`) or create a new Technical Specification document
-   in the `docs/` root (if not already handled by a ticket) before
-   touching code.
-3. **Artifacts over Chat:** Create log files for test results, build
-   outputs, or debug sessions rather than pasting large code blocks in
-   chat.
-4. **Idempotency:** Ensure scripts and commands can be run multiple times
-   without breaking the environment.
-5. **Security First:** Never hardcode secrets. Use environment variables
-   and validate with secret scanning tools.
+   decisions), update the Story's `## Spec` via `/plan` before touching code.
+3. **Artifacts over Chat:** Write log files for test/build/debug output rather
+   than pasting large blocks in chat.
+4. **Idempotency:** Scripts and commands must be safe to run repeatedly.
+5. **Security First:** Never hardcode secrets; use environment variables and
+   secret scanning.
 
 ---
 
@@ -336,36 +246,25 @@ Story count.
 
 - **Re-Plan on Failure:** If a strategy fails, **STOP** and re-plan
   immediately. Do not repeat a broken approach.
-- **Subagent Strategy:** Spawning a subagent is not free — each spawn
-  re-pays the full always-loaded context, so treat it as a cost decision,
-  not a reflex. Prefer an **inline search** (grep, a targeted read) for
-  small or localized lookups where you already know roughly where to look;
-  reach for a subagent **only when the work is large enough to justify
-  replicating context** — a broad multi-file investigation, a parallel
-  exploration front, or an isolated task that would otherwise crowd the main
-  context window. One objective per subagent. When the host exposes a
-  cheaper or faster capability, prefer it for **mechanical or read-only**
-  spawns (search, doc regeneration, lint, log triage) and keep
-  **implementation and design** work on the default capability; name no
-  specific model — let the host and operator own the concrete mapping.
-  **Depth compounds the cost.** Sub-agents now carry the `Agent` tool and
-  can nest further (verified depth 2, announced max depth 5; see
-  [#2870](https://github.com/dsj1984/mandrel/issues/2870)), so this
-  spend-per-spawn caution is not one-level — **every** nesting level
-  re-pays the full always-loaded context. Weigh the whole subtree's cost,
-  not just the immediate spawn, before opening a deeper orchestration
-  level, and stay within the supported depth envelope.
+- **Subagent Strategy:** Each spawn re-pays the full always-loaded context, so
+  treat it as a cost decision. Prefer an **inline search** (grep, a targeted
+  read) for small or localized lookups; reach for a subagent **only when the
+  work justifies replicating context** — a broad multi-file investigation, a
+  parallel exploration front, or an isolated task that would crowd the main
+  window. One objective per subagent; prefer a cheaper/faster host capability
+  for mechanical or read-only spawns and keep implementation/design on the
+  default. **Depth compounds the cost** — sub-agents carry the `Agent` tool and
+  nest further, and **every** level re-pays the context, so weigh the whole
+  subtree's cost and stay within the supported depth envelope.
 - **Anti-Laziness:** NEVER use placeholder comments like
   `// ... existing code ...`, `/* rest of file */`, or
   `// implementation here`. You MUST output the ENTIRE file or the ENTIRE
   complete function so it can be safely written to disk.
 - **No Dead Code:** Remove unused imports, commented-out code, and dead
   branches before finalizing a file.
-- **Lint Compliance:** Adhere strictly to project linters and formatters.
-  Language- and stack-specific quality rules (TypeScript strictness,
-  accessibility scans, framework conventions) live in their respective
-  `stack/` skills and `.agents/rules/` files — apply them when the relevant
-  skill is activated.
+- **Lint Compliance:** Adhere strictly to project linters and formatters;
+  language/stack-specific quality rules live in their `stack/` skills and
+  `.agents/rules/` files — apply them when the skill is activated.
 - **Verification:** Include explicit verification steps in every plan.
 
 ---
@@ -377,18 +276,11 @@ strict conventions for all Story-related Git operations. See
 [`.agents/rules/git-conventions.md`](rules/git-conventions.md) for the full
 canonical reference.
 
-### A. Branch Naming (Canonical)
+### A. Branch Naming
 
-v2 delivery uses one branch shape. The runtime creates and maintains it
-via `single-story-init.js`; agents commit on that branch only.
-
-| Purpose         | Format            | Owner                   | Notes                                                                 |
-| --------------- | ----------------- | ----------------------- | --------------------------------------------------------------------- |
-| Story execution | `story-<storyId>` | `single-story-init.js`  | Per-Story worktree at `.worktrees/story-<storyId>/`. PR target is `main` (squash + required checks). There is no `epic/<id>` integration branch and no `--no-ff` wave merge. |
-
-- **Verification**: After `single-story-init.js` returns, confirm
-  `git branch --show-current` reports `story-<storyId>` before making any
-  commits. If it does not, **STOP** and re-init.
+The canonical branch shape (`story-<storyId>` seeded and maintained by
+`single-story-init.js`, PR to `main`) and the commit-subject contract are
+owned by [`rules/git-conventions.md`](rules/git-conventions.md).
 
 ### B. Status Tracking & Commit Standards
 
@@ -402,66 +294,49 @@ prompted.
 
 ### C. History Hygiene
 
-Every Story reaches `main` via its own PR (`story-<id>` → squash + required
-checks). `helpers/deliver-story` / `single-story-close.js` open that PR;
-there is no Epic integration branch and no in-script push to `main`.
+Every Story reaches `main` via its own PR, opened by `helpers/deliver-story` /
+`single-story-close.js`; the history model is owned by
+[`rules/git-conventions.md`](rules/git-conventions.md).
 
 ### D. Ticket hierarchy (Story-only)
 
-v2 collapses the ticket model to **Story**. Acceptance criteria and
-verification steps live inline on the Story body (`acceptance[]` /
-`verify[]`); the folded Tech Spec lives inline in `## Spec` (over-budget
-Specs fail closed — split or tighten; never write under `docs/`). Optional
-`depends_on` edges order rare multi-Story runs — and, because `/deliver`
-resolves them from live state, they order Stories **across plan runs and
-over time**, not just within one batch.
+v2 collapses the ticket model to **Story**: acceptance criteria and verify
+steps live inline (`acceptance[]` / `verify[]`) and the folded Tech Spec in
+`## Spec` (over-budget Specs fail closed — split or tighten; never write under
+`docs/`). Optional `depends_on` edges order rare multi-Story runs, resolved by
+`/deliver` from live state across plan runs and over time.
 
-- `/plan` emits one or more `type::story` issues (default N=1). There is no
-  batch label: `/deliver` takes ids and discovers the graph.
-- Each Story is executed by `helpers/deliver-story` (invoked from
-  [`/deliver`](workflows/deliver.md)). There is no per-Task sub-loop; the
-  agent authors commit subjects directly per
-  [`rules/git-conventions.md`](rules/git-conventions.md) and references the
-  Story via `(refs #<storyId>)`.
-- Branch model matches Section 5.A (`story-<id>` → PR → `main`).
-- There is no `type::epic` / `type::task` label and no Epic issue form. An
-  Epic is at most an optional untyped human umbrella issue outside
-  orchestration; `/deliver` refuses tickets that still carry an
-  `Epic: #N` footer.
+- `/plan` emits one or more `type::story` issues (default N=1); there is no
+  batch label — `/deliver` takes ids and discovers the graph.
+- Each Story is executed by `helpers/deliver-story` (from
+  [`/deliver`](workflows/deliver.md)); the agent authors commit subjects
+  directly per [`rules/git-conventions.md`](rules/git-conventions.md),
+  referencing the Story via `(refs #<storyId>)`.
+- There is no `type::epic` / `type::task` label or Epic issue form; an Epic is
+  at most an optional untyped human umbrella issue outside orchestration, and
+  `/deliver` refuses tickets carrying an `Epic: #N` footer.
 
 ---
 
 ## 6. Workspace & File Hygiene (Temporary Files)
 
-To keep the repository clean and avoid polluting the Git history:
-
-- **Root Temp Directory**: All temporary files, scratch scripts, or
-  intermediate outputs MUST be stored in the `/temp/` directory located at
-  the workspace root.
-- **Git Exclusion**: The `/temp/` directory is excluded from Git by default.
-  Do NOT commit any files stored within it.
+All temporary files, scratch scripts, and intermediate outputs MUST live in the
+workspace-root `/temp/` directory, which is gitignored — do NOT commit anything
+under it.
 
 ---
 
 ## 7. Complexity-Aware Execution
 
-`/plan` sizes each Story as a **capability slice a frontier model delivers
-and self-verifies in one pass** — a broad footprint is normal when the
-change is cohesive. The session-capacity backstop lives in one place:
-`DEFAULT_MODEL_CAPACITY` in
-`.agents/scripts/lib/orchestration/ticket-validator-sizing.js` (framework
-constant — not operator-tunable). Do not re-slice a capability-sized
-Story into per-module fragments just because it touches many files.
+`/plan` sizes each Story as a **capability slice a frontier model delivers and
+self-verifies in one pass** — a broad footprint is normal when the change is
+cohesive (the backstop is `DEFAULT_MODEL_CAPACITY` in `ticket-validator-sizing.js`,
+a framework constant). Do not re-slice a capability-sized Story into per-module
+fragments just because it touches many files.
 
 ### A. When You See `⚠️ COMPLEXITY WARNING`
 
-If your task contains a complexity warning or exceeds localized scope:
-
-1. **Plan first.** Read the full instructions, then write a numbered list of
-   cohesive sub-steps in a `<!-- DECOMPOSITION -->` comment block — one
-   coherent change with one reason to exist per sub-step, not one file per
-   sub-step.
-2. **Commit incrementally.** Stage, commit, and push after each logical
-   sub-step completes successfully.
-3. **Fail fast.** If any sub-step fails validation, STOP and report the
-   failure.
+On a complexity warning or out-of-scope task: **plan first** (a numbered list of
+cohesive sub-steps — one coherent change each, not one file each — in a
+`<!-- DECOMPOSITION -->` block), **commit incrementally** after each sub-step,
+and **fail fast** — STOP and report if any sub-step fails validation.

--- a/.agents/rules/changelog-style.md
+++ b/.agents/rules/changelog-style.md
@@ -5,8 +5,8 @@ This rule governs the shape of per-release entries in the project CHANGELOG
 release entry is authored or edited — most commonly inside Story #N's
 docs sweep before `/deliver` opens the release PR.
 
-The contract is **guidance-tier** in v1: no automated gate fails a close when
-an entry drifts off-template. It still binds every author.
+The contract is **guidance-tier**: no automated gate fails a close when an
+entry drifts off-template. It still binds every author.
 
 ## Goal
 
@@ -129,71 +129,13 @@ release into grouped sub-sections over padding the bullet list. Before
 accepting a long entry, ask: which bullets are user-visible, and which
 are internal detail that migrated in from the Epic body?
 
-## Worked Example — Before/After
+## Worked Example — On-Contract
 
-The "before" reflects the style that drove the Epic #553 retro action item:
-multi-section entries where each bullet leaked internal function names,
-file paths, and implementation mechanics. The "after" applies the contract
-above.
-
-### Before (off-contract, ~48 lines)
-
-```markdown
-## [5.8.7] - 2026-04-15
-
-### Robust story→epic merge at story close
-
-Parallel wave execution kept producing conflicts — Stories branched
-early in a wave landed after peers had merged. `finalizeMerge` now:
-
-1. **Pre-merge rebase in the story worktree** onto
-   `origin/<epicBranch>`, shrinking the conflict surface to the
-   Story's real delta. Failed rebase is aborted and merge still
-   proceeds.
-2. **Conflict triage via `mergeFeatureBranch`** — same threshold-based
-   triage used at integration time (major ≥3 files or ≥20 markers =
-   abort; minor = auto-resolve by accepting Story's version with audit
-   log).
-
-### Per-worktree node_modules collapsed into shared store
-
-Per-worktree `npm install` duplicated dependencies across every story
-tree and blew out disk on parallel waves. `ensure()` now links each
-worktree's `node_modules` to a primed donor tree (junction on Windows)
-and `reap()` removes the link before `git worktree remove`.
-Auto-detected: if the configured strategy is `symlink`, the link
-applies.
-
-### Deliver tail auto-invokes pre-merge gates
-
-`/deliver` auto-invokes the code-review module (Phase 4) and
-the retro runner (Phase 5) inline instead of halting to ask the
-operator to run them separately. `--skip-code-review` available as
-an override.
-
-### Epic Health ticket closed alongside PRD/Tech Spec
-
-Step 8's closure sweep now matches any ticket carrying `type::health`
-or a title starting with `📉 Epic Health:`, in addition to
-`context::prd` / `context::tech-spec`.
-
-### Stale-lock sweep for shared `.git/` dir
-
-`WorktreeManager.sweepStaleLocks({ maxAgeMs = 30_000 })` removes
-well-known lock files (`index.lock`, `HEAD.lock`, `packed-refs.lock`,
-`config.lock`, `shallow.lock`) whose mtime exceeds the threshold.
-Fresh locks belonging to in-flight ops are skipped. Runs at
-`/deliver` start, before worktree GC.
-```
-
-Contract violations: five separate `###` sub-sections where one theme
-would do; internal function names (`finalizeMerge`, `mergeFeatureBranch`,
-`ensure()`, `reap()`, `WorktreeManager.sweepStaleLocks`); implementation
-mechanics (`BFS walker` equivalent, exact argument shapes, internal step
-numbering like "Step 1.4", "Step 8"); lock-file name list leaks
-implementation detail that operators cannot act on.
-
-### After (on-contract, ~18 lines)
+Off-contract entries — the style that drove the Epic #553 retro action item —
+pack several `###` sub-sections into one release and leak internal function
+names (`finalizeMerge`, `mergeFeatureBranch`, `ensure()`, `reap()`),
+implementation mechanics, internal step numbering, and lock-file name lists
+operators cannot act on. The on-contract version collapses all of that:
 
 ```markdown
 ## [5.8.7] - 2026-04-15

--- a/.agents/rules/ci-remediation.md
+++ b/.agents/rules/ci-remediation.md
@@ -1,127 +1,68 @@
 # CI Failure Triage & Remediation
 
 This rule applies when a delivery path is watching a pull request's CI checks
-and a required check is red (or repeatedly slow) — the `/deliver` router
-([`deliver.md`](../workflows/deliver.md)) runs each Story through the
-single-Story Step 4 CI watch + fix loop
-([`deliver-story.md`](../workflows/helpers/deliver-story.md)), which hands off
-to it. It is the single triage brain that mechanism defers to:
-the watcher (`pr-watch-with-update.js`) surfaces the failing check, the run
-link, and the failure signature; this rule decides what to do next.
+and a required check is red (or repeatedly slow). The Story Step 4 CI watch +
+fix loop ([`deliver-story.md`](../workflows/helpers/deliver-story.md)) hands off
+to it: the watcher (`pr-watch-with-update.js`) surfaces the failing check, the
+run link, and the failure signature; this rule decides what to do next.
 
-The animating principle: **a red check is a defect until proven otherwise, and
-the fix is always to remove the defect — never to hide it.** There is no
-rerun-the-failed-job path and no quarantine path in this rule, by design.
-Reruns and quarantines mask defects; a flaky test that passes on the second
-attempt is still a bug that will fail a future run for a real user or a future
-delivery. Root-cause it or file it — never re-roll the dice.
+## Goal
 
-## The triage decision tree
+**A red check is a defect until proven otherwise, and the fix is always to
+remove the defect — never to hide it.** A red required check is resolved in
+exactly one of two ways, and no others:
 
-When a required check goes red, walk this tree top to bottom. Do **not** skip
-to "fix" before you have classified the failure — an unclassified fix is a
-guess.
+1. **Remove the root cause on the branch.** Pull the failing job log and record
+   the failure signature (failing check, run id / run link, first distinctive
+   error line — the watcher writes this to
+   `temp/story-<id>-ci-digest.{json,md}`). Reproduce the failure, confirm it is
+   caused by the diff under review — **verify the same check against an
+   unmodified `main` checkout**; if it also fails on `main` the defect is
+   pre-existing and belongs in a separate change — then fix it at source,
+   commit on `story-<storyId>`, push, and re-run the watcher. Auto-merge stays
+   armed across retries. Route deterministic per-check failures (lint/format,
+   maintainability/CRAP baseline drift, test failure, coverage threshold)
+   through the fix table in
+   [`deliver-story-reference.md` § Step 4](../workflows/helpers/deliver-story-reference.md#step-4--ci-watch--fix-recovery);
+   refresh a baseline only when the diff demonstrably can't be covered.
+2. **File a `meta::framework-gap` issue** when the root cause is outside this
+   delivery's scope — a pre-existing flaky test, a runner/infra weakness, a
+   framework-level environment gap. Open the issue with the `meta::framework-gap`
+   label (see [`git-conventions.md`](git-conventions.md)) carrying **the run
+   link and the failure signature** so a later `/plan` Phase 0 sweep can act on
+   it. Remediate this delivery only if the pre-existing defect is genuinely
+   blocking it.
 
-### 1. Pull the evidence
+Infra, transient, and flaky failures are root-cause defects too — a flaky test
+that passes on a rerun is still a bug that will fail a future run. They route
+through the same two options; bisect environment (runner OS, Node version,
+concurrency, a platform-conditional branch, an external service) vs. code (an
+order-dependent test, a race, a shared-state assumption) to decide which.
 
-Fetch the failing job log and record the failure signature (the failing check
-name, the run id / run link, and the first distinctive error line). The
-watcher already writes this to `temp/story-<id>-ci-digest.{json,md}` — start
-from that digest.
+## Verifier
 
-### 2. Classify the failure
+The check is resolved only when it is **green with zero reruns of the failed
+job**, and the diff carries **no `.skip` / `.only`, no quarantine, and no
+deleted or loosened assertion** introduced to reach green. You may **not**
+re-run a failed job to "see if it goes green," and you may **not** skip,
+`.only`, or quarantine a flaky test to get a green bar. Both mask the defect
+and are prohibited by this rule.
 
-- **Deterministic (real) failure** — the check fails the same way every time,
-  and the failure is caused by the diff under review (a lint violation, a
-  broken test, a coverage regression, a baseline drift the diff genuinely
-  caused). → Go to [§ Real failures](#real-failures--route-to-the-per-check-fix-table).
-- **Infra / transient failure** — a runner died, a network fetch timed out, a
-  dependency registry 5xx'd, a step hit a platform-conditional path. → Go to
-  [§ Infra, transient, and flaky failures](#infra-transient-and-flaky-failures-are-root-cause-defects).
-- **Flaky failure** — the check fails intermittently: green on one run, red on
-  the next, with **no diff change** between them (order-dependent tests,
-  timing/race assertions, shared-state bleed, wall-clock or timezone
-  assumptions). → Go to
-  [§ Infra, transient, and flaky failures](#infra-transient-and-flaky-failures-are-root-cause-defects).
+## Escalation
 
-## Real failures — route to the per-check fix table
+Flip the ticket to `agent::blocked`, post a `friction` comment (naming the
+failing check, the run link, the failure signature, the classification you
+reached, and what you tried — **never fall silent**), and hand back to the
+operator under **any** of:
 
-A deterministic failure caused by the diff is remediated at source. Use the
-existing per-check fix table — do **not** duplicate it here:
-
-- **Story Step 4**:
-  [`deliver-story-reference.md` § Step 4 — CI watch + fix recovery](../workflows/helpers/deliver-story-reference.md#step-4--ci-watch--fix-recovery).
-
-In short: lint/format → `npm run lint` + biome apply; maintainability/crap
-baseline drift → re-run the ratcheted script and fix at source (refresh a
-baseline only when the diff demonstrably can't be covered); test failure →
-reproduce with `npm test`, fix source or test; coverage threshold → add tests.
-Commit the fix on the delivery branch (`story-<storyId>`), push, and re-run the
-watcher. Auto-merge stays armed across retries.
-
-## Infra, transient, and flaky failures ARE root-cause defects
-
-Treat every infra/transient failure **and** every flaky failure as a
-root-cause defect. The remediation sequence is the same for both — you do not
-get to wave it off because "CI was flaky."
-
-1. **Reproduce.** Run the failing check locally (or in a clean environment as
-   close to CI as you can get). Re-run it enough times to observe the
-   intermittency for a flaky failure. If you cannot reproduce it at all after a
-   genuine attempt, that itself is a finding — record it in the issue you file
-   in step 4.
-2. **Check whether it also fails on `main`.** Run the same check against an
-   unmodified `main` checkout. If it fails on `main`
-   too, the defect is **pre-existing** — it is not caused by the diff under
-   review, and the fix belongs in a separate change, not silently folded into
-   this delivery.
-3. **Bisect environment vs. code.** Determine whether the failure is driven by
-   the environment (runner OS, Node version, concurrency, a platform-
-   conditional branch, an external service) or by the code (an
-   order-dependent test, a race, a shared-state assumption). This tells you
-   where the fix has to land.
-4. **Then either fix in-scope OR file the defect.**
-   - **Fix in-scope** when the root cause is within this delivery's footprint
-     and the fix is a cohesive part of the change under review (e.g. a race in
-     a test the diff touches, a timezone assumption in code the Story owns).
-     Commit it on the delivery branch, push, and re-run the watcher.
-   - **File a `meta::framework-gap` issue** when the root cause is outside this
-     delivery's scope — a pre-existing flaky test, a runner/infra weakness, a
-     framework-level environment gap. Open the issue with the
-     `meta::framework-gap` label (see
-     [`git-conventions.md` § `meta::framework-gap`](git-conventions.md)),
-     and include **the run link and the failure signature** (failing check,
-     run id, first distinctive error line) captured in step 1 so a later
-     `/plan` Phase 0 sweep can act on it. Then remediate this delivery only if
-     the pre-existing defect is genuinely blocking it; otherwise proceed once
-     the defect is filed and the check is not caused by your diff.
-
-**There is no shortcut.** You may **not** re-run the failed job to "see if it
-goes green," and you may **not** quarantine, skip, or `.only`/`.skip` a flaky
-test to get a green bar. Both mask the defect and are prohibited by this rule.
-
-## Escalation criteria
-
-Escalate — flip the ticket to `agent::blocked`, post a `friction` comment, and
-hand back to the operator — under **any** of the following. These extend the
-existing three-strikes halt rule; they do not replace it.
-
-- **Three strikes (existing).** Three consecutive remediation iterations on the
-  same failure class without convergence. Stop; the diagnosis is likely wrong
-  (see [`instructions.md` § 1.I Anti-Thrashing](../instructions.md)).
-- **Wall-clock timebox.** Regardless of iteration count, if you have spent more
-  than **30 minutes of active remediation** on a single CI failure without a
-  green bar in sight, stop and escalate. A long grind on one red check is
-  itself a signal that the failure exceeds a single delivery turn's judgment.
-- **Clearly-environmental → escalate immediately (fast path).** When the
-  failure is unambiguously environmental and outside your control — a runner
-  provisioning failure, a persistent registry/network outage, a
-  branch-protection or CI-configuration misconfiguration, an expired
-  credential — do **not** burn iterations trying to code around it. File the
-  `meta::framework-gap` issue (with run link + signature) and escalate on the
-  first encounter. This fast path exists so an operator-side or infra-side
-  problem reaches the operator immediately instead of consuming the turn.
-
-When you escalate, name the failing check, the run link, the failure
-signature, the classification you reached, and what you tried — never fall
-silent.
+- **Three strikes.** Three consecutive remediation iterations on the same
+  failure class without convergence — the diagnosis is likely wrong (see
+  [`instructions.md` § 1.I Anti-Thrashing](../instructions.md)).
+- **Wall-clock timebox.** More than **30 minutes** of active remediation on a
+  single CI failure without a green bar in sight.
+- **Clearly-environmental → escalate immediately.** An unambiguously
+  environmental failure outside your control (runner provisioning, a persistent
+  registry/network outage, a branch-protection or CI misconfiguration, an
+  expired credential) — file the `meta::framework-gap` issue (with run link +
+  signature) and escalate on the first encounter rather than burning iterations
+  trying to code around it.

--- a/.agents/rules/gherkin-standards.md
+++ b/.agents/rules/gherkin-standards.md
@@ -29,10 +29,8 @@ scenarios. Use the canonical set below; do not invent ad-hoc tags.
   the tag (the "de-skip" edit). Unlike `@flaky`, `@skip` marks planned
   not-yet-implemented behavior, never a stability problem.
 
-Retired: the `@epic-<id>-ac-N` namespaced AC tag. Its consumer
-(`acceptance-spec-reconciler.js`) was deleted in the v2 Epic removal, so
-the tag is inert — do not apply it to new scenarios. The `mandrel update`
-migration strips surviving instances from consumer feature files.
+Retired: the `@epic-<id>-ac-N` AC tag is inert — do not apply it to new
+scenarios; `mandrel update` strips surviving instances from consumer files.
 
 Rules:
 
@@ -127,30 +125,11 @@ implementation detail.
 
 ## Step Reuse — Grep Before You Write
 
-Before authoring a new step, search the existing step-definition library for
-an equivalent phrase. New steps are a cost: they fragment the vocabulary and
-multiply step-definition maintenance.
-
-Workflow:
-
-1. Identify the verb phrase you want to write (e.g. "the user signs in as").
-2. Grep the step-definition directory for the verb stem:
-
-   ```bash
-   rg -n "signs? in" tests/steps
-   ```
-
-3. If a matching step exists, reuse it verbatim — adjust your scenario
-   phrasing to fit the existing step, not the reverse.
-4. If a near-match exists, extend the existing step (add a parameter, widen
-   the regex) rather than forking a new one. Update every call site in the
-   same PR.
-5. Only when no reasonable match exists, add a new step definition.
-   Co-locate it with related steps and follow the library's naming
-   convention.
-6. Never copy-paste a step implementation to support a paraphrased scenario.
-   Rephrase the scenario instead.
-
-Deprecations: when a step is superseded, mark the old definition deprecated
-in code and migrate all call sites in the same PR. Do not leave two
-near-identical steps live.
+Before authoring a new step, grep the step-definition library for the verb
+stem and **reuse an existing step verbatim** (adjust your scenario to fit it),
+or **extend a near-match** (add a parameter, widen the regex, updating every
+call site in the same PR) — new steps fragment the vocabulary and multiply
+maintenance. Add a new definition only when no reasonable match exists, and
+never copy-paste a step implementation to support a paraphrased scenario.
+When a step is superseded, mark it deprecated and migrate every call site in
+the same PR; do not leave two near-identical steps live.

--- a/.agents/rules/git-conventions-reference.md
+++ b/.agents/rules/git-conventions-reference.md
@@ -31,17 +31,6 @@ therefore:
    by side for a release window. If a shape changes, the old shape is
    deleted in the same PR.
 
-The codifying decision is **Epic #2646** (the "Hard-Cutover Cleanup Epic"),
-which deleted the existing compatibility shim layer across
-`config-resolver.js`, `lib/config/*.js`, `lib/baselines/`,
-`wave-session.js`, `IExecutionAdapter` / `ManualDispatchAdapter`, lifecycle
-emit shims, and duplicate progress/comment writers in one pass. The
-per-finding closing references (audit Findings #10, #11, #13, #17) live in
-the merged PRs and the Epic #2646 history; the Part 1 — Model-Evolution
-Audit analysis this section grew out of is preserved at
-`docs/roadmap.md` @ tag `mandrel-v1.94.0` (see the Historical-anchors
-table in the live [`docs/roadmap.md`](../../docs/roadmap.md)).
-
 Practical guidance when authoring a contract change:
 
 - If you are tempted to add a "legacy shape" branch in a parser or
@@ -74,63 +63,41 @@ signature is worth naming:
   (`--no-errors-on-unmatched` or equivalent) before escalating via
   `agent::blocked`.
 
-## Local checkout hygiene — full mechanics
+## Local checkout hygiene — outcome contract
 
 **Invariant (stated in the core): the delivering flow owns tidying the local
 checkout — reaping its own merged refs and fast-forwarding the base branch.
-`/git-cleanup` is a recovery tool, not a routine chore.** The mechanics behind
-that invariant:
+`/git-cleanup` is a recovery tool, not a routine chore.** The outcome every
+delivering flow (`/deliver`, `/git-deliver`) guarantees, with the mechanics
+owned by `boot-sweep.js` / `git-cleanup.js`:
 
-Every flow that lands work — `/deliver` and `/git-deliver` — is responsible
-for leaving the local checkout tidy without
-operator intervention:
+- **`main` is fast-forwarded** by the flow itself in its cleanup phase, so the
+  next init seeds from a current base. No workflow ends by telling the operator
+  to run `/git-cleanup` to catch up.
+- **Merged local refs are reaped** at the next workflow boot's protected sweep
+  (`boot-sweep.js`) — every local branch whose PR is already merged, skipping
+  any candidate with unpushed work, a dirty worktree, or a still-open parent
+  ticket. `/plan` and `/git-deliver` widen the sweep's `--include` scope beyond
+  the default `story-*` to their own branch namespaces at their boot call site.
+- **Content-merged branches are report-only.** A branch detected only via the
+  weaker content-equivalence signal (`detectedBy: 'content-merged'` — content
+  already landed in the base by another route, with no merged PR or git
+  ancestry of its own) is **never** reaped by the boot sweep; it is surfaced
+  under `contentMerged` for the operator to send to `/git-cleanup` for a
+  confirmed, eyeballed reap.
+- **`/git-cleanup` is recovery, not routine.** Run it by hand only for a state
+  the automated hygiene does not cover — triaging stashes, reaping across
+  non-standard namespaces, or `--remote` pruning after a force-push. Reaching
+  for it after every routine delivery signals the owning flow's hygiene step
+  regressed — fix the flow, do not codify the manual sweep.
 
-- **Fast-forwarding the base branch is owned by the flow.** `/deliver`
-  fast-forwards `main` itself in its cleanup phase (via
-  `git-cleanup.js --fast-forward-main --execute --yes`). No workflow ends by
-  telling the operator to "run `/git-cleanup` afterwards to catch up".
-- **Reaping merged local refs is owned by the flow's next boot.** `/plan` and
-  `/git-deliver` open with a **protected boot sweep**
-  (`boot-sweep.js`) that fast-forwards `main`, prunes stale remote-tracking
-  refs, and reaps every local branch whose PR is already merged — skipping any
-  candidate with unpushed work, a dirty worktree, or a still-open parent
-  ticket. A branch a flow leaves behind (e.g. a `/git-deliver` feature branch
-  whose PR merges out of band) is therefore reaped automatically at the next
-  workflow boot, not left for the operator to sweep by hand. `boot-sweep.js`
-  defaults its `--include` glob to `story-*` — a bare invocation only sweeps
-  Story branches; `/plan` and `/git-deliver` widen the scope to their own
-  branch namespaces (`epic/*`, `feat/*`, `fix/*`, `chore/*`, `docs/*`,
-  `refactor/*`) by passing `--include` explicitly at their boot call site.
-  A branch the planner detects only via the weaker content-equivalence
-  signal (`detectedBy: 'content-merged'`, Story #4395's
-  `git merge-tree --write-tree` probe — content already landed in the base
-  branch by another route, such as a squash-merged Epic PR, with no merged
-  PR or git ancestry of its own) is **never** reaped by the boot sweep: it
-  is report-only, surfaced under `contentMerged` in the result envelope and
-  a routing hint in the summary line (Story #4396), so the operator can
-  send it to `/git-cleanup` for a confirmed, eyeballed reap.
-- **`/git-cleanup` is recovery, not routine.** Run it by hand only to recover
-  an unusual state the automated hygiene does not cover — triaging stashes,
-  reaping across non-standard branch namespaces, or `--remote` pruning after a
-  force-push diverged a tip. It is **not** the expected way to keep `main`
-  current or to clear merged branches after a normal delivery; the delivering
-  flows already own that. If you find yourself reaching for `/git-cleanup`
-  after every routine `/deliver` or `/git-deliver` run, that is a signal the
-  owning flow's hygiene step regressed — fix the flow, do not codify the manual
-  sweep.
-
-### Shared-checkout contention (Stories #4460, #4424, #4545)
+### Shared-checkout contention
 
 **One delivery per checkout is the model.** v2 has no Epic integration branch
 and no merge phase that parks the shared checkout on someone else's branch:
 each Story works in its own worktree (`.worktrees/story-<id>/`) and lands by
-pushing `story-<id>` and opening a PR. The Epic-era collision this section used
-to describe — `story-close.js` running `git checkout <epic-branch>` in the
-shared main checkout under a per-Epic `epic-*.merge.lock` — is gone with the
-machinery that caused it (Story #4545 deleted the last of that prose; the six
-modules it named had already been removed in the v2.0.0 cutover).
-
-Two guards remain, and they cover different hazards:
+pushing `story-<id>` and opening a PR. Two guards remain, and they cover
+different hazards:
 
 - **Per-Story lease** (`lib/orchestration/single-story-lease-guard.js`). The
   standalone path has no Epic-scoped dispatch manifest to serialize two

--- a/.agents/rules/git-conventions.md
+++ b/.agents/rules/git-conventions.md
@@ -20,7 +20,7 @@ Every Story lands on a dedicated **Story branch** named `story-<storyId>`
 (e.g., `story-104`), seeded from `project.baseBranch` (`main` by default).
 The runtime owns branch creation via `single-story-init.js`; agents commit
 on that branch only. Close opens a PR against `main` (squash + required
-checks). There is **no** `epic/<id>` integration branch and no `--no-ff`
+checks). There is no `epic/<id>` integration branch and no `--no-ff`
 wave merge.
 
 > **Commit subjects.** Stories have no child tickets. Commits land on

--- a/.agents/rules/orchestration-error-handling.md
+++ b/.agents/rules/orchestration-error-handling.md
@@ -9,21 +9,11 @@ orchestrators themselves.
 ## Throw, Never Fatal
 
 Orchestration scripts MUST surface unrecoverable failures with
-`throw new Error(<message>)` rather than `Logger.fatal(<message>)`.
-
-### Why
-
-The `runAsCli` boundary catches the throw and maps it to `process.exit(1)`,
-preserving the operator-visible message verbatim while staying robust under
-a mocked `process.exit` (in tests or when the harness stubs it). By contrast,
-`Logger.fatal` falls through silently when `process.exit` is stubbed, which
-lets execution continue past the intended hard-stop and masks failures.
-
-### Precedent
-
-Story #959 converted every `Logger.fatal` call inside the story-close
-orchestrator surface to `throw` and established this rule for future
-orchestration work.
+`throw new Error(<message>)` rather than `Logger.fatal(<message>)`. The
+`runAsCli` boundary catches the throw and maps it to `process.exit(1)`,
+preserving the message verbatim and staying robust under a mocked
+`process.exit`; `Logger.fatal` falls through silently when `process.exit` is
+stubbed, letting execution continue past the intended hard-stop.
 
 ### Where it applies
 

--- a/.agents/rules/security-baseline.md
+++ b/.agents/rules/security-baseline.md
@@ -1,13 +1,10 @@
 # Application Security Baseline
 
-Non-negotiable security MUSTs that apply to every piece of code generated. This
-rule is the SSOT for security taxonomy and constraints; the companion skill
+Non-negotiable security MUSTs (the SSOT for security taxonomy and constraints)
+that apply to every piece of code generated; the companion skill
 [`core/security-and-hardening`](../skills/core/security-and-hardening/SKILL.md)
-shows **how** to apply these MUSTs with code patterns, examples, and process
-guidance. Conflicts resolve per the central ordering in
-[`.agents/instructions.md` § 1.K](../instructions.md) — this rule sits above
-the skill, and its security MUSTs are **inviolable**: no persona, skill, or
-local override may relax them. The skill is updated to match.
+shows **how** to apply them. These MUSTs are inviolable per
+[`.agents/instructions.md` § 1.K](../instructions.md).
 
 ## Input Validation
 
@@ -87,11 +84,8 @@ local override may relax them. The skill is updated to match.
 
 ## Forbidden Practices
 
+The MUSTs above are the contract; two rationalizations recur often enough to
+name explicitly (both violate a MUST above):
+
 - Committing secrets to version control.
-- Logging passwords, tokens, or full credit-card numbers.
-- Trusting client-side validation as a security boundary.
 - Disabling security headers for convenience.
-- Using `eval()` or `innerHTML` with user-provided data.
-- Storing auth tokens in client-accessible storage.
-- Exposing stack traces or internal error details to users.
-- Hardcoding fallback secrets ("default" API keys, debug bypasses) in source.

--- a/.agents/rules/shell-conventions.md
+++ b/.agents/rules/shell-conventions.md
@@ -45,19 +45,10 @@ Other PowerShell-isms agents must respect:
 
 ## Searching the Workspace
 
-When searching for strings, patterns, or files, prioritize speed and avoid
-pipeline bottlenecks or full-file reads. Use this decision tree:
-
-1. **Host grep tool first.** If the harness exposes a dedicated grep tool
-   (e.g. Claude Code's `Grep` tool, ripgrep wrappers), use it. These
-   normalize quoting, respect `.gitignore`, and stream results.
-2. **`git grep`** when the workspace is a git repo and no host tool is
-   available. Pass `-l` to list only filenames when paths are sufficient.
-3. **`rg` (ripgrep)** when installed and outside a git repo, or when you
-   need features `git grep` lacks (multiline, type filters).
-4. **Avoid full-file reads** for searches. Reading whole files into memory
-   to scan for a pattern wastes context and is slower than a streaming
-   grep.
+Prefer, in order: the host's dedicated grep tool (ripgrep-backed — normalizes
+quoting, respects `.gitignore`, streams results), then `git grep` in a git
+repo (`-l` for filenames only), then `rg` outside a git repo or when you need
+multiline / type filters. Do not read whole files to scan for a pattern.
 
 ### PowerShell-specific anti-patterns
 

--- a/.agents/rules/test-seams.md
+++ b/.agents/rules/test-seams.md
@@ -30,8 +30,8 @@ export function ensureSomething(ctx, { fsImpl = fs, spawnImpl = defaultSpawnSync
 
 ### Canonical In-Repo Reference
 
-`baseline-snapshot.js` (`forkMainToEpic` at line 135 / `commitSnapshotsToEpicBranch`
-at line 259) is the established baseline for this pattern in this codebase.
+`.agents/scripts/lib/bootstrap/project-bootstrap.js` (its exported step
+functions) is the established in-repo baseline for this pattern.
 
 ## Rules
 

--- a/.agents/rules/testing-standards.md
+++ b/.agents/rules/testing-standards.md
@@ -101,23 +101,13 @@ semantics, including:
 - Header values that carry protocol semantics (`Location`, `ETag`,
   `Retry-After`)
 
-When a reviewer finds one of the above in a `.feature` file, the required
-remediation is to delete it from the scenario and add (or extend) a
-contract test that covers the assertion. The scenario should assert the
-**user-visible outcome** only ("the invoice appears in the outbox"), not
-the wire shape that produced it.
-
-This rule is enforced bidirectionally: the companion prohibition on
-`.feature` authoring lives in
-[`gherkin-standards.md § Forbidden Patterns`](./gherkin-standards.md#forbidden-patterns),
-which forbids raw SQL, HTTP status codes, DOM selectors, URLs, and JSON
-payloads inside scenarios. That list and this section are two sides of the
-same constraint: shape and state belong in contract tests; business
-outcomes belong in acceptance scenarios.
-
-This is the pyramid's load-bearing constraint. It is why the contract
-tier exists as a distinct layer, and why acceptance scenarios stay
-readable, stable, and free of implementation churn.
+When one of the above appears in a `.feature` file, delete it from the
+scenario and add (or extend) a contract test that covers it; the scenario
+asserts the **user-visible outcome** only ("the invoice appears in the
+outbox"). The companion prohibition on `.feature` authoring lives in
+[`gherkin-standards.md § Forbidden Patterns`](./gherkin-standards.md#forbidden-patterns)
+— the two are the same constraint from both sides, and it is the pyramid's
+load-bearing one.
 
 ## Test Structure (Arrange, Act, Assert)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,9 +4,8 @@
 > protocols are defined in [`.agents/instructions.md`](.agents/instructions.md).
 > You **MUST** load and follow that file as your primary system prompt. This
 > file provides repository-level orientation only — it does not redefine any
-> rules. When two governance documents conflict, resolve by the total ordering
-> declared in
-> [`.agents/instructions.md` § 1.K — Precedence & Conflict Resolution](.agents/instructions.md).
+> rules, and conflicts resolve by the ordering in
+> [`.agents/instructions.md` § 1.K](.agents/instructions.md).
 
 ---
 
@@ -28,11 +27,6 @@ materialized into consumer projects' `.agents/` directories by
 
 > **Key distinction:** Only `.agents/` is distributed to consumers. Everything
 > else in this repository is internal development tooling.
->
-> **Ticket hierarchy** is Story-only (`type::story`). The contract is stated
-> once in [`.agents/instructions.md` § 5.D](.agents/instructions.md) — that
-> section is the source of truth and this file does not restate it. The
-> end-to-end narrative lives in [`.agents/docs/SDLC.md`](.agents/docs/SDLC.md).
 
 ---
 
@@ -42,10 +36,8 @@ materialized into consumer projects' `.agents/` directories by
 reference this file used to inline: the repository layout, the getting-started
 sequence, the development-standards and key-commands tables, slow-test
 profiling, the contribution workflow, release operations, and the
-reference-document index. Read it when you need one of those. It is linked
-rather than `@`-imported precisely because it is not needed on every task —
-the always-loaded closure is re-paid by every session and every subagent
-spawn, at every nesting level.
+reference-document index. Read it when you need one of those — it is linked,
+not `@`-imported, so it is not re-paid on every session and subagent spawn.
 
 Two orientation pointers are load-bearing often enough to keep here:
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,16 +19,3 @@
 
 @.agents/rules/security-baseline.md
 @.agents/rules/git-conventions.md
-
-> **Import order is not precedence.** The order these files are imported above
-> is for loading convenience only; when two governance documents conflict, the
-> authoritative resolution order is declared once in
-> [`.agents/instructions.md` § 1.K — Precedence & Conflict Resolution](.agents/instructions.md)
-> (local overrides → `instructions.md` → `rules/` → `skills/`, with
-> security-baseline inviolable).
->
-> **Ticket hierarchy** is Story-only (`type::story`). The contract is stated
-> once in [`.agents/instructions.md` § 5.D](.agents/instructions.md) — that
-> section is the source of truth and this file does not restate it. The
-> narrative lives in
-> [`.agents/docs/SDLC.md` § Ticket hierarchy](.agents/docs/SDLC.md).

--- a/baselines/context-budget.json
+++ b/baselines/context-budget.json
@@ -1,10 +1,10 @@
 {
   "$schema": "https://mandrel.dev/baselines/context-budget.schema.json",
-  "generatedAt": "2026-07-17T12:16:10.199Z",
+  "generatedAt": "2026-07-21T13:34:32.679Z",
   "toleranceBytes": 2048,
   "tiers": {
     "alwaysLoaded": {
-      "totalBytes": 40142,
+      "totalBytes": 30736,
       "files": [
         {
           "path": ".agentrc.json",
@@ -12,32 +12,32 @@
         },
         {
           "path": ".agents/instructions.md",
-          "bytes": 24403
+          "bytes": 16719
         },
         {
           "path": ".agents/rules/git-conventions.md",
-          "bytes": 4983
+          "bytes": 4979
         },
         {
           "path": ".agents/rules/security-baseline.md",
-          "bytes": 4500
+          "bytes": 4013
         },
         {
           "path": "AGENTS.md",
-          "bytes": 3023
+          "bytes": 2531
         },
         {
           "path": "CLAUDE.md",
-          "bytes": 1300
+          "bytes": 561
         }
       ]
     },
     "mandatoryRead": {
-      "totalBytes": 359144,
+      "totalBytes": 360282,
       "files": [
         {
           "path": "docs/architecture.md",
-          "bytes": 84556
+          "bytes": 85694
         },
         {
           "path": "docs/data-dictionary.md",
@@ -59,11 +59,11 @@
     "files": [
       {
         "path": ".agents/agents/acceptance-critic.md",
-        "bytes": 5615
+        "bytes": 6269
       },
       {
         "path": ".agents/agents/story-worker.md",
-        "bytes": 7894
+        "bytes": 7994
       }
     ]
   }


### PR DESCRIPTION
Closes #4664

_Auto-opened by `/deliver`._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and baseline ratchet only; no runtime or application code changes, though agents may rely on prose that was moved or deleted until they read on-demand rules.
> 
> **Overview**
> Shrinks the **always-loaded** agent closure so every session and subagent pays less context: **`instructions.md`** is tightened (digest-first and git sections delegate to rules; anti-thrashing no longer repeats Story sub-agent `agent::blocked` text; tables and long narratives removed). **`CLAUDE.md`** and **`AGENTS.md`** lose restated precedence and Story-hierarchy prose that already lives in `instructions.md`.
> 
> **On-demand rules** are edited the same way—**goals, verifiers, and MUSTs stay**; tutorials and history go. Notable reshapes: **`ci-remediation.md`** becomes a two-option resolution model plus verifier/escalation; **`git-conventions-reference.md`** drops Epic #2646 history and reframes checkout hygiene as outcomes; **`changelog-style.md`** drops the long off-contract “before” example; **`gherkin-standards.md`**, **`shell-conventions.md`**, **`testing-standards.md`**, and others are compressed without changing the contract. **`test-seams.md`** now points at **`project-bootstrap.js`** instead of removed epic baseline code.
> 
> **`baselines/context-budget.json`** is refreshed: **alwaysLoaded** total **40,142 → 30,736 bytes** (~23% reduction on that tier).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fce26e6336e3390852316bdf57e13464c1f06b94. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->