### PR TITLE
feat: harden /audit-to-stories dedup search: budget the fan-out, bound the query, soft-fail instead of aborting (#4678)

### DIFF
--- a/.agents/scripts/audit-to-stories.js
+++ b/.agents/scripts/audit-to-stories.js
@@ -31,6 +31,7 @@ import fs from 'node:fs';
 import { glob } from 'node:fs/promises';
 import path from 'node:path';
 import process from 'node:process';
+import { pathToFileURL } from 'node:url';
 import { parseArgs } from 'node:util';
 import { buildStoryBody } from './lib/audit-to-stories/build-story-body.js';
 import { classifyGroupsAgainstGitHub } from './lib/audit-to-stories/dedupe-against-github.js';
@@ -85,12 +86,30 @@ function tallyBySeverity(findings) {
   return t;
 }
 
+/**
+ * Test-only seam: when `AUDIT_TO_STORIES_PROVIDER_FIXTURE` names a module, load
+ * its default export as the dedup provider (ports) instead of the live GitHub
+ * provider. This lets the soft-fail contract be exercised end-to-end through
+ * the real `--scan` CLI with a search port that fails for a subset of groups
+ * (Story #4678, AC-8), with no network. Returns null when the env var is unset.
+ *
+ * @returns {Promise<object|null>}
+ */
+async function loadFixtureProvider() {
+  const fixturePath = process.env.AUDIT_TO_STORIES_PROVIDER_FIXTURE;
+  if (!fixturePath) return null;
+  const mod = await import(pathToFileURL(fixturePath).href);
+  return mod.default ?? null;
+}
+
 async function loadProvider({ createProviderImpl, resolveConfigImpl } = {}) {
   // The provider is optional — when missing, the dedupe step emits a
   // create-only classification and the workflow operator is informed. The
   // `createProviderImpl` / `resolveConfigImpl` seams let a contract test drive
   // this exact adapter (fingerprint + semantic-candidate ports) with an
   // in-memory issue store instead of the live GitHub provider.
+  const fixture = await loadFixtureProvider();
+  if (fixture) return fixture;
   try {
     const resolveConfig =
       resolveConfigImpl ??
@@ -180,6 +199,31 @@ function dedupSkippedWarning(reason) {
   );
 }
 
+/**
+ * Render the loud, operator-visible warning emitted when Phase 6 dedup ran but
+ * one or more groups' lookups could not complete (an HTTP 422, or a rate limit
+ * still exhausted after the endpoint budget's cooldown). Those groups degrade
+ * to `create` rather than aborting the whole scan (Story #4678); this warning
+ * names each affected group so the operator knows exactly which to check by
+ * hand. Mirrors the `dedupSkippedWarning` shape so a partially-checked plan
+ * reads as clearly as a wholly-unchecked one.
+ *
+ * Pure: returns the message string so `buildPlan` owns the single `Logger.warn`
+ * write site (stderr) and the text stays unit-testable.
+ *
+ * @param {Array<{ group: string, reason: string }>} entries
+ * @returns {string}
+ */
+function dedupDegradedWarning(entries) {
+  const lines = (entries ?? []).map((e) => `  - ${e.group}: ${e.reason}`);
+  return (
+    `dedup degraded for ${lines.length} group(s): their GitHub lookup could ` +
+    'not complete, so they are classified "create" WITHOUT a dedup check. A ' +
+    'run that creates Stories from this plan may open duplicates of these ' +
+    `groups — verify each by hand before opening:\n${lines.join('\n')}`
+  );
+}
+
 async function buildPlan({ glob: pattern, severity, useProvider, ledger }) {
   const reportPaths = await collectReportPaths(pattern ?? DEFAULT_GLOB);
   if (reportPaths.length === 0) {
@@ -227,6 +271,12 @@ async function buildPlan({ glob: pattern, severity, useProvider, ledger }) {
       classifications = result.classifications;
       summary = result.summary;
       dedupApplied = true;
+      // A partially-checked plan is a useful result — warn loudly (stderr, so
+      // the --scan JSON on stdout stays clean) naming the groups that degraded
+      // to create because their lookup could not complete (Story #4678).
+      if (summary.dedupDegraded?.count > 0) {
+        Logger.warn(dedupDegradedWarning(summary.dedupDegraded.groups));
+      }
     } else {
       // The provider could not resolve a searchIssues port — the dedup gate
       // is silently a no-op without this. Surface it loudly (stderr, so the
@@ -488,6 +538,7 @@ export const __testing = {
   buildPlan,
   loadProvider,
   dedupSkippedWarning,
+  dedupDegradedWarning,
   buildAndGateStories,
   runAuto,
   resolveSeverityFloor,

--- a/.agents/scripts/lib/audit-to-stories/__tests__/dedup-degrade.test.js
+++ b/.agents/scripts/lib/audit-to-stories/__tests__/dedup-degrade.test.js
@@ -1,0 +1,107 @@
+/**
+ * Soft-fail dedup: a lookup that cannot complete degrades one group to
+ * `create` instead of aborting the whole scan (Story #4678, AC-6 / AC-7).
+ *
+ * `classifyGroupsAgainstGitHub` stays pure orchestration — it accepts an
+ * optional `onDegraded` sink and reports `summary.dedupDegraded`. A search port
+ * that throws HTTP 422 for one group must not stop the remaining groups from
+ * keeping their real classifications.
+ */
+
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import { __testing as auditCli } from '../../../audit-to-stories.js';
+import { classifyGroupsAgainstGitHub } from '../dedupe-against-github.js';
+import {
+  renderFingerprintFooter,
+  withFingerprints,
+} from '../finding-adapter.js';
+
+const { dedupDegradedWarning } = auditCli;
+
+function auditFinding(dimension, normalisedTitle, file) {
+  return { dimension, normalisedTitle, files: file ? [file] : [] };
+}
+function fakeGroup(key, findings) {
+  const stamped = withFingerprints(findings);
+  return { groupKey: key, findings: stamped };
+}
+function footerFor(finding) {
+  return renderFingerprintFooter(withFingerprints([finding]));
+}
+
+const OPEN_FINDING = auditFinding('security', 'sqli in login', 'src/a.js');
+const BAD_FINDING = auditFinding('perf', 'n+1 in report', 'src/b.js');
+
+/**
+ * A provider whose fingerprint lookup throws for the finding in `failGroupSha`
+ * (simulating an HTTP 422 the endpoint budget could not absorb) and otherwise
+ * resolves against an in-memory issue set carrying `footerFor(OPEN_FINDING)`.
+ */
+function partiallyFailingProvider(failSha) {
+  const openBody = `body\n${footerFor(OPEN_FINDING)}\n`;
+  return {
+    async findIssuesByFingerprint(sha) {
+      if (sha === failSha) {
+        const err = new Error('Validation Failed: query too long');
+        err.status = 422;
+        throw err;
+      }
+      return [{ number: 4182, state: 'OPEN', body: openBody }].filter((i) =>
+        i.body.includes(sha),
+      );
+    },
+  };
+}
+
+describe('classifyGroupsAgainstGitHub soft-fail', () => {
+  it('AC-6: a 422 for one group degrades it to create, others keep their classification', async () => {
+    const openGroup = fakeGroup('g-open', [OPEN_FINDING]);
+    const badGroup = fakeGroup('g-bad', [BAD_FINDING]);
+    const badSha = badGroup.findings[0].fingerprint.full;
+
+    const degraded = [];
+    const { classifications, summary } = await classifyGroupsAgainstGitHub({
+      groups: [openGroup, badGroup],
+      provider: partiallyFailingProvider(badSha),
+      onDegraded: (entry) => degraded.push(entry),
+    });
+
+    const byKey = Object.fromEntries(
+      classifications.map((c) => [c.group.groupKey, c.action]),
+    );
+    assert.equal(byKey['g-open'], 'skip-open', 'healthy group keeps its match');
+    assert.equal(byKey['g-bad'], 'create', 'failed group degrades to create');
+    assert.equal(summary.skipOpen, 1);
+    assert.equal(summary.create, 1);
+    // AC-7: the degrade is reported, not silent.
+    assert.equal(summary.dedupDegraded.count, 1);
+    assert.equal(summary.dedupDegraded.groups[0].group, 'g-bad');
+    assert.match(summary.dedupDegraded.groups[0].reason, /422/);
+    assert.equal(degraded.length, 1, 'onDegraded sink fired once');
+    assert.equal(degraded[0].group.groupKey, 'g-bad');
+  });
+
+  it('reports zero degradations when every lookup completes', async () => {
+    const openGroup = fakeGroup('g-open', [OPEN_FINDING]);
+    const { summary } = await classifyGroupsAgainstGitHub({
+      groups: [openGroup],
+      provider: partiallyFailingProvider('never-matches'),
+    });
+    assert.equal(summary.dedupDegraded.count, 0);
+    assert.deepEqual(summary.dedupDegraded.groups, []);
+  });
+});
+
+describe('dedupDegradedWarning (loud, operator-visible)', () => {
+  it('names each affected group and its reason and warns of possible duplicates', () => {
+    const msg = dedupDegradedWarning([
+      { group: 'g-bad', reason: 'search query rejected (HTTP 422)' },
+    ]);
+    assert.match(msg, /dedup degraded for 1 group/i);
+    assert.match(msg, /g-bad/);
+    assert.match(msg, /422/);
+    assert.match(msg, /duplicate/i);
+  });
+});

--- a/.agents/scripts/lib/audit-to-stories/__tests__/fixtures/failing-subset-provider.js
+++ b/.agents/scripts/lib/audit-to-stories/__tests__/fixtures/failing-subset-provider.js
@@ -1,0 +1,25 @@
+/**
+ * Test fixture (Story #4678, AC-8): a dedup provider whose fingerprint lookup
+ * throws an HTTP 422 for a deterministic subset of calls and resolves to no
+ * match otherwise. Loaded via the `AUDIT_TO_STORIES_PROVIDER_FIXTURE` seam so
+ * the real `--scan` CLI exercises the soft-fail path end-to-end without any
+ * network. The scan must still exit 0.
+ */
+
+const state = { calls: 0 };
+
+export default {
+  async findIssuesByFingerprint() {
+    state.calls += 1;
+    // Fail on every other lookup so the run always covers a genuine subset:
+    // some groups degrade to create, the rest classify normally.
+    if (state.calls % 2 === 0) {
+      const err = new Error(
+        'Validation Failed: the search is longer than 256 characters',
+      );
+      err.status = 422;
+      throw err;
+    }
+    return [];
+  },
+};

--- a/.agents/scripts/lib/audit-to-stories/__tests__/scan-soft-fail.test.js
+++ b/.agents/scripts/lib/audit-to-stories/__tests__/scan-soft-fail.test.js
@@ -1,0 +1,105 @@
+/**
+ * AC-8 (Story #4678): `audit-to-stories.js --scan` exits 0 on a fixture set
+ * whose search port fails for a subset of groups.
+ *
+ * Driven as a real subprocess so the "soft-fail, never fatal" contract is
+ * exercised end-to-end through the CLI. A failing-subset provider is injected
+ * via the `AUDIT_TO_STORIES_PROVIDER_FIXTURE` seam. The scan must exit 0, keep
+ * stdout as parseable JSON, carry `summary.dedupDegraded`, and route the
+ * operator warning to stderr.
+ */
+
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { after, before, test } from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(HERE, '../../../../..');
+const CLI = path.join(REPO_ROOT, '.agents/scripts/audit-to-stories.js');
+const FIXTURE_PROVIDER = path.join(HERE, 'fixtures/failing-subset-provider.js');
+
+const FIXTURE = `# Audit: Security
+
+## Detailed Findings
+
+### SQLi in login handler
+- **Severity:** High
+- **Location:** \`src/auth/login.js:42\`
+- **Dimension:** security
+- **Current State:** The login query concatenates user input.
+- **Recommendation:** Parameterise the query.
+
+### Missing authz check on report export
+- **Severity:** High
+- **Location:** \`src/report/export.js:19\`
+- **Dimension:** security
+- **Current State:** No ownership check before export.
+- **Recommendation:** Verify ownership server-side.
+
+### Unbounded fan-out in scheduler
+- **Severity:** High
+- **Location:** \`src/sched/core.js:88\`
+- **Dimension:** performance
+- **Current State:** The scheduler issues one call per item with no budget.
+- **Recommendation:** Add a budget.
+
+### Non-atomic write in ledger
+- **Severity:** High
+- **Location:** \`src/ledger/write.js:5\`
+- **Dimension:** performance
+- **Current State:** Write is not atomic.
+- **Recommendation:** Write-then-rename.
+`;
+
+let workDir;
+
+before(() => {
+  workDir = fs.mkdtempSync(path.join(os.tmpdir(), 'audit-scan-softfail-'));
+  const auditsDir = path.join(workDir, 'audits');
+  fs.mkdirSync(auditsDir, { recursive: true });
+  fs.writeFileSync(path.join(auditsDir, 'audit-security-results.md'), FIXTURE);
+});
+
+after(() => {
+  if (workDir) fs.rmSync(workDir, { recursive: true, force: true });
+});
+
+test('AC-8: --scan exits 0 and soft-fails the degraded subset', () => {
+  // execFileSync throws on a non-zero exit, so reaching the assertions IS the
+  // exit-0 proof. stderr is captured separately so we can confirm stdout stays
+  // pure JSON.
+  const stdout = execFileSync(
+    process.execPath,
+    [CLI, '--scan', '--severity', 'all', '--glob', 'audits/*.md'],
+    {
+      cwd: workDir,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+      env: {
+        ...process.env,
+        AUDIT_TO_STORIES_PROVIDER_FIXTURE: FIXTURE_PROVIDER,
+      },
+    },
+  );
+
+  // stdout is parseable JSON (the warning went to stderr).
+  const plan = JSON.parse(stdout);
+  assert.ok(plan.summary, 'plan carries a summary');
+  assert.ok(
+    plan.summary.dedupApplied,
+    'dedup ran against the fixture provider',
+  );
+  assert.ok(
+    plan.summary.dedupDegraded.count >= 1,
+    'at least one group degraded to create',
+  );
+  assert.ok(
+    Array.isArray(plan.summary.dedupDegraded.groups) &&
+      plan.summary.dedupDegraded.groups.every((g) => g.group && g.reason),
+    'each degraded entry names a group and a reason',
+  );
+});

--- a/.agents/scripts/lib/audit-to-stories/dedupe-against-github.js
+++ b/.agents/scripts/lib/audit-to-stories/dedupe-against-github.js
@@ -37,6 +37,92 @@ import { toCanonicalFinding } from './finding-adapter.js';
  */
 
 /**
+ * Render a short, operator-legible reason from a dedup-lookup failure. Pure —
+ * no imports, no I/O — so the module stays pure orchestration (Story #4678).
+ * @param {unknown} err
+ * @returns {string}
+ */
+function describeDegradeReason(err) {
+  const status = err?.status;
+  const message = err?.message ?? String(err);
+  if (status === 422 || /\b422\b/.test(message)) {
+    return 'search query rejected (HTTP 422)';
+  }
+  if (/rate limit/i.test(message)) {
+    return 'rate limit still exhausted after cooldown';
+  }
+  return `dedup lookup failed: ${message}`;
+}
+
+/**
+ * Stable operator-facing label for a group in a degrade report.
+ * @param {object} group
+ * @returns {string}
+ */
+function groupLabel(group) {
+  return group?.groupKey ?? group?.title ?? '(unlabelled group)';
+}
+
+/**
+ * Route every finding in one group and fold the per-finding decisions up to a
+ * group action. Extracted so the top-level loop can wrap it in one try/catch:
+ * a search failure that survives the endpoint budget (an HTTP 422, or a rate
+ * limit still exhausted after the cooldown) throws out of here and is caught
+ * once per group rather than aborting the whole scan (Story #4678).
+ *
+ * @param {object} group
+ * @param {object} routing — `{ searchIssues, semanticPort, routeOptions }`.
+ * @returns {Promise<{ action: string, matchedIssues: Array, matchedFingerprints: string[] }>}
+ */
+async function classifyOneGroup(
+  group,
+  { searchIssues, semanticPort, routeOptions },
+) {
+  const findings = group.findings ?? [];
+  const matchedIssues = [];
+  const matchedFingerprints = [];
+  let sawOpen = false;
+  let sawClosed = false;
+
+  for (const finding of findings) {
+    const sha = finding?.fingerprint?.full;
+    if (typeof sha !== 'string' || sha.length !== 40) continue;
+
+    const canonical = toCanonicalFinding(finding);
+    const { decision, matchedIssue, fingerprint } = await routeFinding(
+      canonical,
+      semanticPort
+        ? { searchIssues, searchCandidates: () => semanticPort(canonical) }
+        : { searchIssues },
+      routeOptions,
+    );
+
+    if (decision === 'new') continue;
+
+    if (matchedIssue) {
+      matchedIssues.push({
+        number: matchedIssue.number,
+        state: matchedIssue.state,
+      });
+    }
+    if (!matchedFingerprints.includes(fingerprint)) {
+      matchedFingerprints.push(fingerprint);
+    }
+    if (decision === 'update-existing' || decision === 'duplicate') {
+      sawOpen = true;
+    } else if (decision === 'regression-of-closed') {
+      sawClosed = true;
+    }
+  }
+
+  let action = 'create';
+  if (sawOpen) action = 'skip-open';
+  else if (sawClosed) action = 'skip-reoccurring';
+
+  return { action, matchedIssues, matchedFingerprints };
+}
+
+/**
  * @param {object} params
  * @param {Array<object>} params.groups — output of `groupFindings`.
  * @param {{ findIssuesByFingerprint: (sha: string) => Promise<Array<{ number: number, state: string, body?: string }>> }} params.provider
@@ -44,12 +130,18 @@ import { toCanonicalFinding } from './finding-adapter.js';
  *   Optional meaning-first candidate search (production: `semantic-issue-search.js`).
  *   When supplied, routing runs the Stage-1 semantic pass and opts into
  *   location-based semantic-key confirmation.
- * @returns {Promise<{ classifications: GroupClassification[], summary: { create: number, skipOpen: number, skipReoccurring: number } }>}
+ * @param {(entry: { group: object, reason: string }) => void} [params.onDegraded]
+ *   Optional sink notified once per group whose dedup lookup could not complete
+ *   (Story #4678). The group is then classified `create` — a soft-fail, never
+ *   fatal. Pure orchestration: this module performs no network I/O and swallows
+ *   no failure silently.
+ * @returns {Promise<{ classifications: GroupClassification[], summary: { create: number, skipOpen: number, skipReoccurring: number, dedupDegraded: { count: number, groups: Array<{ group: string, reason: string }> } } }>}
  */
 export async function classifyGroupsAgainstGitHub({
   groups,
   provider,
   searchCandidates,
+  onDegraded,
 }) {
   if (!Array.isArray(groups)) {
     throw new Error('classifyGroupsAgainstGitHub: groups must be an array');
@@ -67,67 +159,40 @@ export async function classifyGroupsAgainstGitHub({
   const searchIssues = (sha) => provider.findIssuesByFingerprint(sha);
   const semanticPort =
     typeof searchCandidates === 'function' ? searchCandidates : undefined;
-  const routeOptions = { semanticKeyConfirm: Boolean(semanticPort) };
+  const routing = {
+    searchIssues,
+    semanticPort,
+    routeOptions: { semanticKeyConfirm: Boolean(semanticPort) },
+  };
 
   const classifications = [];
-  const summary = { create: 0, skipOpen: 0, skipReoccurring: 0 };
+  const summary = {
+    create: 0,
+    skipOpen: 0,
+    skipReoccurring: 0,
+    dedupDegraded: { count: 0, groups: [] },
+  };
 
   for (const group of groups) {
-    const findings = group.findings ?? [];
-
-    const matchedIssues = [];
-    const matchedFingerprints = [];
-    let sawOpen = false;
-    let sawClosed = false;
-
-    for (const finding of findings) {
-      const sha = finding?.fingerprint?.full;
-      if (typeof sha !== 'string' || sha.length !== 40) continue;
-
-      const canonical = toCanonicalFinding(finding);
-      const { decision, matchedIssue, fingerprint } = await routeFinding(
-        canonical,
-        semanticPort
-          ? { searchIssues, searchCandidates: () => semanticPort(canonical) }
-          : { searchIssues },
-        routeOptions,
-      );
-
-      if (decision === 'new') continue;
-
-      if (matchedIssue) {
-        matchedIssues.push({
-          number: matchedIssue.number,
-          state: matchedIssue.state,
-        });
-      }
-      if (!matchedFingerprints.includes(fingerprint)) {
-        matchedFingerprints.push(fingerprint);
-      }
-      if (decision === 'update-existing' || decision === 'duplicate') {
-        sawOpen = true;
-      } else if (decision === 'regression-of-closed') {
-        sawClosed = true;
-      }
+    let result;
+    try {
+      result = await classifyOneGroup(group, routing);
+    } catch (err) {
+      // A dedup lookup that cannot complete degrades this group to `create`
+      // with a recorded reason — never aborts the whole scan.
+      const reason = describeDegradeReason(err);
+      const entry = { group: groupLabel(group), reason };
+      summary.dedupDegraded.count += 1;
+      summary.dedupDegraded.groups.push(entry);
+      if (typeof onDegraded === 'function') onDegraded({ group, reason });
+      result = { action: 'create', matchedIssues: [], matchedFingerprints: [] };
     }
 
-    let action = 'create';
-    if (sawOpen) {
-      action = 'skip-open';
-      summary.skipOpen += 1;
-    } else if (sawClosed) {
-      action = 'skip-reoccurring';
-      summary.skipReoccurring += 1;
-    } else {
-      summary.create += 1;
-    }
+    if (result.action === 'skip-open') summary.skipOpen += 1;
+    else if (result.action === 'skip-reoccurring') summary.skipReoccurring += 1;
+    else summary.create += 1;
 
-    classifications.push({
-      group,
-      action,
-      matchedIssues,
-      matchedFingerprints,
-    });
+    classifications.push({ group, ...result });
   }
 
   return { classifications, summary };

--- a/.agents/scripts/lib/findings/__tests__/build-query.test.js
+++ b/.agents/scripts/lib/findings/__tests__/build-query.test.js
@@ -1,0 +1,58 @@
+/**
+ * Unit tests for `buildQuery` bounding (Story #4678, AC-4).
+ *
+ * The query is filled highest-signal-first (title, area, primaryFile basename)
+ * up to a character budget on a whole-token boundary, so a long title over a
+ * deep path never exceeds GitHub Search's length limit — and it carries the
+ * file basename, not the full mangled path.
+ */
+
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import { buildQuery } from '../semantic-issue-search.js';
+
+describe('buildQuery bounding', () => {
+  it('keeps a short finding query intact and uses the primaryFile basename', () => {
+    const q = buildQuery({
+      title: 'SQLi in login',
+      area: 'security',
+      primaryFile: 'src/auth/login.js',
+    });
+    assert.equal(q, 'sqli in login security login js');
+  });
+
+  it('bounds a long title over a deep path to the budget, on a token boundary', () => {
+    const longTitle = Array.from({ length: 80 }, (_, i) => `word${i}`).join(
+      ' ',
+    );
+    const budget = 100;
+    const q = buildQuery(
+      {
+        title: longTitle,
+        area: 'clean-code',
+        primaryFile: 'src/very/deeply/nested/mangled/path/module-name.js',
+      },
+      { budget },
+    );
+
+    assert.ok(
+      q.length <= budget,
+      `q is ${q.length} chars, must be <= ${budget}`,
+    );
+    // Whole-token boundary: every kept token is intact (no partial `wordNN`).
+    for (const tok of q.split(' ')) {
+      assert.match(tok, /^word\d+$/, `token "${tok}" is whole`);
+    }
+  });
+
+  it('emits the file basename rather than the full path', () => {
+    const q = buildQuery({
+      title: 'race in scheduler',
+      area: '',
+      primaryFile: 'a/b/c/d/scheduler-core.js',
+    });
+    assert.ok(q.includes('scheduler'), 'basename token present');
+    assert.ok(!q.includes('a b c d'), 'the full path segments are absent');
+  });
+});

--- a/.agents/scripts/lib/findings/semantic-issue-search.js
+++ b/.agents/scripts/lib/findings/semantic-issue-search.js
@@ -24,6 +24,13 @@
 const DEFAULT_LIMIT = 25;
 
 /**
+ * Character budget for the query {@link buildQuery} emits. Default 200 leaves
+ * headroom under GitHub Search's 256-char limit for the `repo:` / `type:`
+ * qualifiers `searchIssues` appends (Story #4678).
+ */
+const DEFAULT_QUERY_BUDGET = 200;
+
+/**
  * Normalise a free-text string for token comparison: lowercased, trimmed,
  * punctuation collapsed to spaces.
  * @param {unknown} value
@@ -69,17 +76,48 @@ function jaccard(a, b) {
 }
 
 /**
- * Build the search query text for a finding. The title carries the strongest
- * signal; area and primaryFile sharpen it. This is the text both the
- * (production) full-text search port and the local relevance scorer key on.
- * @param {object} finding
+ * The trailing path segment of a slash-or-backslash-delimited path. A deep
+ * `primaryFile` like `src/very/deep/module.js` contributes only `module.js`
+ * to the query — the basename carries the discriminating signal while the
+ * mangled path spends the character budget for nothing (Story #4678).
+ * @param {unknown} value
  * @returns {string}
  */
-export function buildQuery(finding) {
-  return [finding?.title, finding?.area, finding?.primaryFile]
+function basename(value) {
+  const str = String(value ?? '');
+  const cut = str.split(/[\\/]/).filter(Boolean);
+  return cut.length > 0 ? cut[cut.length - 1] : '';
+}
+
+/**
+ * Build the search query text for a finding. The title carries the strongest
+ * signal; area and the primaryFile **basename** sharpen it. This is the text
+ * both the (production) full-text search port and the local relevance scorer
+ * key on. The result is filled highest-signal-first (title, then area, then
+ * basename) up to `budget` characters on a whole-token boundary so a long title
+ * over a deep path never blows GitHub Search's length limit (Story #4678).
+ * @param {object} finding
+ * @param {object} [options]
+ * @param {number} [options.budget] — max query length in characters.
+ * @returns {string}
+ */
+export function buildQuery(finding, { budget = DEFAULT_QUERY_BUDGET } = {}) {
+  const tokens = [finding?.title, finding?.area, basename(finding?.primaryFile)]
     .map((v) => normaliseText(v))
     .filter((v) => v.length > 0)
-    .join(' ');
+    .join(' ')
+    .split(' ')
+    .filter(Boolean);
+
+  const kept = [];
+  let length = 0;
+  for (const token of tokens) {
+    const cost = kept.length === 0 ? token.length : token.length + 1;
+    if (length + cost > budget) break;
+    kept.push(token);
+    length += cost;
+  }
+  return kept.join(' ');
 }
 
 /**

--- a/.agents/scripts/providers/github/__tests__/issues-search-budget.test.js
+++ b/.agents/scripts/providers/github/__tests__/issues-search-budget.test.js
@@ -1,0 +1,83 @@
+/**
+ * `IssuesGateway#searchIssues` budget + rate-limit wiring (Story #4678).
+ *
+ * AC-1: `searchIssues` awaits the shared search budget before every
+ *       `/search/issues` call.
+ * AC-3: a rate-limit error no longer burns transient retries at the search
+ *       call site — `gh api` is invoked exactly once for a `GhRateLimitError`
+ *       (the budget, not `withTransientRetry`, owns the wait), while
+ *       `classifyGithubError` still classifies that same error as transient.
+ */
+
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import { GhRateLimitError } from '../../../lib/gh-exec.js';
+import { classifyGithubError } from '../errors.js';
+import { IssuesGateway } from '../issues.js';
+
+/** A budget stub that records the order of `take()` vs the wrapped call. */
+function recordingBudget(events) {
+  return {
+    take: async () => {
+      events.push('take');
+    },
+    noteRateLimited: (resetAtMs) => {
+      events.push(`noteRateLimited:${resetAtMs}`);
+    },
+  };
+}
+
+describe('searchIssues budget wiring', () => {
+  it('AC-1: awaits the search budget before issuing the /search/issues call', async () => {
+    const events = [];
+    const gh = {
+      api: async () => {
+        events.push('api');
+        return { stdout: JSON.stringify({ items: [] }) };
+      },
+    };
+    const gateway = new IssuesGateway({
+      gh,
+      owner: 'o',
+      repo: 'r',
+      searchBudget: recordingBudget(events),
+    });
+
+    await gateway.searchIssues({ query: 'abc' });
+
+    assert.deepEqual(events, ['take', 'api'], 'budget taken before the call');
+  });
+
+  it('AC-3: invokes gh api exactly once for a rate-limit error and notes the budget', async () => {
+    const events = [];
+    let apiCalls = 0;
+    const rateLimitErr = new GhRateLimitError(
+      'gh-exec: gh API rate limit exceeded',
+      { stderr: 'x-ratelimit-reset: 1704067200' },
+    );
+    const gh = {
+      api: async () => {
+        apiCalls += 1;
+        throw rateLimitErr;
+      },
+    };
+    const gateway = new IssuesGateway({
+      gh,
+      owner: 'o',
+      repo: 'r',
+      searchBudget: recordingBudget(events),
+    });
+
+    await assert.rejects(
+      () => gateway.searchIssues({ query: 'abc' }),
+      (err) => err instanceof GhRateLimitError,
+    );
+
+    assert.equal(apiCalls, 1, 'no transient-retry re-issue at the call site');
+    assert.deepEqual(events, ['take', 'noteRateLimited:1704067200000']);
+    // The global classifier is deliberately unchanged: other endpoints still
+    // retry a rate-limit error.
+    assert.equal(classifyGithubError(rateLimitErr), 'transient');
+  });
+});

--- a/.agents/scripts/providers/github/__tests__/search-budget.test.js
+++ b/.agents/scripts/providers/github/__tests__/search-budget.test.js
@@ -1,0 +1,117 @@
+/**
+ * Unit tests for the `/search/issues` token-bucket budget (Story #4678).
+ *
+ * The bucket is pure and injectable: `now` and `sleep` are driven off a mutable
+ * fake clock so the tests exercise the throttle and the rate-limit pause with
+ * zero wall-clock time.
+ */
+
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import { createSearchBudget, parseRateLimitResetMs } from '../search-budget.js';
+
+/**
+ * A deterministic clock: `now()` reads the current value; `sleep(ms)` advances
+ * it and records the delay. No real timers.
+ */
+function fakeClock(start = 0) {
+  let current = start;
+  const sleeps = [];
+  return {
+    now: () => current,
+    sleep: async (ms) => {
+      sleeps.push(ms);
+      current += ms;
+    },
+    advance: (ms) => {
+      current += ms;
+    },
+    sleeps,
+  };
+}
+
+describe('createSearchBudget', () => {
+  it('lets a burst up to capacity through without any wait', async () => {
+    const clock = fakeClock();
+    const budget = createSearchBudget({
+      capacity: 3,
+      windowMs: 1000,
+      now: clock.now,
+      sleep: clock.sleep,
+    });
+
+    await budget.take();
+    await budget.take();
+    await budget.take();
+
+    assert.deepEqual(clock.sleeps, [], 'no wait while tokens remain');
+  });
+
+  it('makes the caller wait for a token to accrue once the burst is spent', async () => {
+    const clock = fakeClock();
+    const budget = createSearchBudget({
+      capacity: 2,
+      windowMs: 1000, // 1 token accrues every 500ms
+      now: clock.now,
+      sleep: clock.sleep,
+    });
+
+    await budget.take();
+    await budget.take();
+    await budget.take(); // must wait for the third token
+
+    assert.equal(clock.sleeps.length, 1, 'the over-capacity call waited once');
+    assert.ok(clock.sleeps[0] >= 500, 'waited at least one refill interval');
+  });
+
+  it('pauses the whole batch once until the reported reset after a rate limit', async () => {
+    const clock = fakeClock(1_000);
+    const budget = createSearchBudget({
+      capacity: 5,
+      windowMs: 1000,
+      now: clock.now,
+      sleep: clock.sleep,
+    });
+
+    await budget.take(); // one request goes out
+    const resetAt = 1_000 + 30_000;
+    budget.noteRateLimited(resetAt); // window is empty until reset
+
+    await budget.take(); // the next call must pause until the reset
+
+    assert.equal(clock.sleeps.length, 1, 'paused exactly once');
+    assert.equal(clock.sleeps[0], 30_000, 'waited precisely until the reset');
+    assert.equal(clock.now(), resetAt, 'clock advanced to the reset window');
+  });
+
+  it('falls back to a fixed cooldown when no reset time is reported', async () => {
+    const clock = fakeClock(0);
+    const budget = createSearchBudget({
+      capacity: 5,
+      windowMs: 1000,
+      cooldownMs: 60_000,
+      now: clock.now,
+      sleep: clock.sleep,
+    });
+
+    budget.noteRateLimited(undefined);
+    await budget.take();
+
+    assert.equal(clock.sleeps[0], 60_000, 'waited the fixed cooldown');
+  });
+});
+
+describe('parseRateLimitResetMs', () => {
+  it('extracts an x-ratelimit-reset epoch from stderr as milliseconds', () => {
+    const err = { stderr: 'HTTP 403\nx-ratelimit-reset: 1704067200\n' };
+    assert.equal(parseRateLimitResetMs(err), 1_704_067_200 * 1000);
+  });
+
+  it('returns undefined when no reset header is present', () => {
+    assert.equal(
+      parseRateLimitResetMs({ message: 'rate limit exceeded' }),
+      undefined,
+    );
+  });
+});

--- a/.agents/scripts/providers/github/__tests__/search-query.test.js
+++ b/.agents/scripts/providers/github/__tests__/search-query.test.js
@@ -9,13 +9,11 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 
-import {
-  composeBoundedQuery,
-  fitTokens,
-  GITHUB_SEARCH_MAX_QUERY,
-} from '../search-query.js';
+import { composeBoundedQuery } from '../search-query.js';
 
 const QUALIFIERS = ['repo:dsj1984/mandrel', 'type:issue'];
+/** GitHub Search's documented maximum query length, in characters. */
+const GITHUB_SEARCH_MAX_QUERY = 256;
 
 describe('composeBoundedQuery', () => {
   it('leaves a short query untouched', () => {
@@ -46,14 +44,11 @@ describe('composeBoundedQuery', () => {
     const q = composeBoundedQuery(hugeToken, QUALIFIERS);
     assert.equal(q, 'repo:dsj1984/mandrel type:issue');
   });
-});
 
-describe('fitTokens', () => {
-  it('keeps as many leading tokens as fit on a whole-token boundary', () => {
-    assert.equal(fitTokens(['aa', 'bb', 'cc'], 5), 'aa bb');
-  });
-
-  it('returns empty when the first token overflows the budget', () => {
-    assert.equal(fitTokens(['toolong'], 3), '');
+  it('keeps as many leading whole tokens as the remaining budget allows', () => {
+    // Budget is tight enough that only the first token survives alongside the
+    // qualifiers — proving truncation counts the qualifier reservation.
+    const q = composeBoundedQuery('alpha beta gamma', QUALIFIERS, 38);
+    assert.equal(q, 'alpha repo:dsj1984/mandrel type:issue');
   });
 });

--- a/.agents/scripts/providers/github/__tests__/search-query.test.js
+++ b/.agents/scripts/providers/github/__tests__/search-query.test.js
@@ -1,0 +1,59 @@
+/**
+ * Unit tests for the composed `/search/issues` query bound (Story #4678, AC-5).
+ *
+ * The guard lives where the qualifiers are known: it truncates the free-text
+ * portion on a whole-token boundary so the whole composed `q` fits GitHub
+ * Search's 256-character limit, and never drops the load-bearing qualifiers.
+ */
+
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import {
+  composeBoundedQuery,
+  fitTokens,
+  GITHUB_SEARCH_MAX_QUERY,
+} from '../search-query.js';
+
+const QUALIFIERS = ['repo:dsj1984/mandrel', 'type:issue'];
+
+describe('composeBoundedQuery', () => {
+  it('leaves a short query untouched', () => {
+    const q = composeBoundedQuery('sqli login', QUALIFIERS);
+    assert.equal(q, 'sqli login repo:dsj1984/mandrel type:issue');
+  });
+
+  it('bounds an over-long free text to at most 256 chars, keeping the qualifiers', () => {
+    const longFree = Array.from({ length: 60 }, (_, i) => `token${i}`).join(
+      ' ',
+    );
+    const q = composeBoundedQuery(longFree, QUALIFIERS);
+
+    assert.ok(
+      q.length <= GITHUB_SEARCH_MAX_QUERY,
+      `composed q is ${q.length} chars, must be <= ${GITHUB_SEARCH_MAX_QUERY}`,
+    );
+    assert.ok(q.endsWith('repo:dsj1984/mandrel type:issue'), 'qualifiers kept');
+    // Truncated on a whole-token boundary: no partial `tokenNN` fragment.
+    const free = q.replace(' repo:dsj1984/mandrel type:issue', '');
+    for (const tok of free.split(/\s+/).filter(Boolean)) {
+      assert.match(tok, /^token\d+$/, `token "${tok}" is whole`);
+    }
+  });
+
+  it('returns just the qualifiers when even the first token cannot fit', () => {
+    const hugeToken = 'x'.repeat(300);
+    const q = composeBoundedQuery(hugeToken, QUALIFIERS);
+    assert.equal(q, 'repo:dsj1984/mandrel type:issue');
+  });
+});
+
+describe('fitTokens', () => {
+  it('keeps as many leading tokens as fit on a whole-token boundary', () => {
+    assert.equal(fitTokens(['aa', 'bb', 'cc'], 5), 'aa bb');
+  });
+
+  it('returns empty when the first token overflows the budget', () => {
+    assert.equal(fitTokens(['toolong'], 3), '');
+  });
+});

--- a/.agents/scripts/providers/github/issues.js
+++ b/.agents/scripts/providers/github/issues.js
@@ -15,16 +15,38 @@
  * @see Story #2462 — Split GitHubProvider god class into seven composed gateways.
  */
 
+import { GhRateLimitError } from '../../lib/gh-exec.js';
 import { Logger } from '../../lib/Logger.js';
 import { concurrentMap } from '../../lib/util/concurrent-map.js';
 import { isNotFoundError } from './branch-protection.js';
-import { withTransientRetry } from './errors.js';
+import { classifyGithubError, withTransientRetry } from './errors.js';
 import { issueToEpic } from './mappers.js';
 import {
   defaultRetryWarn,
   paginateRest,
   parseApiJson,
 } from './request-helpers.js';
+import {
+  searchBudget as defaultSearchBudget,
+  parseRateLimitResetMs,
+} from './search-budget.js';
+import { composeBoundedQuery } from './search-query.js';
+
+/**
+ * Retry classifier for the `searchIssues` call site. A rate-limit error is
+ * non-transient **here** — the shared search budget (not `withTransientRetry`)
+ * owns the wait, so the call must fail fast rather than burn its retry budget
+ * re-issuing into an empty window. Every other error keeps the global
+ * classification, so a 5xx/network blip still retries. `classifyGithubError`
+ * itself is unchanged: other endpoints legitimately retry on rate-limit.
+ *
+ * @param {unknown} err
+ * @returns {string}
+ */
+function classifySearchRetry(err) {
+  if (err instanceof GhRateLimitError) return 'rate-limited';
+  return classifyGithubError(err);
+}
 
 /**
  * Concurrency budget for the `getSubTickets` fan-out — preserved from
@@ -51,11 +73,15 @@ export class IssuesGateway {
    *   },
    * }} deps
    */
-  constructor({ gh, owner, repo, hooks = {} } = {}) {
+  constructor({ gh, owner, repo, hooks = {}, searchBudget } = {}) {
     this._gh = gh;
     this.owner = owner;
     this.repo = repo;
     this._hooks = hooks;
+    // The `/search/issues` fan-out budget. Defaults to the process-wide
+    // singleton so every gateway instance shares one 30/min window; injectable
+    // so unit tests drive it deterministically (Story #4678).
+    this._searchBudget = searchBudget ?? defaultSearchBudget;
   }
 
   /**
@@ -132,14 +158,35 @@ export class IssuesGateway {
     // Constrain the search to this repo and to issues (not PRs). The
     // fingerprint sha is the free-text term; GitHub matches it against the
     // issue body where the `<!-- audit-fingerprints: ... -->` footer lives.
+    // The composed `q` is bounded to GitHub Search's 256-char limit here — the
+    // only place that knows both the free text and the qualifiers it appends —
+    // truncating the free-text portion on a whole-token boundary (Story #4678).
     const qualifiers = [`repo:${scopeOwner}/${scopeRepo}`, 'type:issue'];
-    const q = `${query.trim()} ${qualifiers.join(' ')}`;
+    const q = composeBoundedQuery(query, qualifiers);
     const params = new URLSearchParams({ q, per_page: '100' });
     const endpoint = `/search/issues?${params}`;
-    const result = await withTransientRetry(
-      () => this._gh.api({ method: 'GET', endpoint }),
-      { label: `searchIssues ${query}`, onRetry: defaultRetryWarn },
-    );
+    // Await the shared 30/min budget before every call so the whole scan's
+    // fan-out is throttled at the endpoint, not per caller (Story #4678).
+    await this._searchBudget.take();
+    let result;
+    try {
+      result = await withTransientRetry(
+        () => this._gh.api({ method: 'GET', endpoint }),
+        {
+          label: `searchIssues ${query}`,
+          onRetry: defaultRetryWarn,
+          classify: classifySearchRetry,
+        },
+      );
+    } catch (err) {
+      // A rate limit means the window is empty: drain the budget until the
+      // reported reset so the *next* call pauses once, rather than every call
+      // retrying independently into the exhausted window.
+      if (err instanceof GhRateLimitError) {
+        this._searchBudget.noteRateLimited(parseRateLimitResetMs(err));
+      }
+      throw err;
+    }
     const json = parseApiJson(result);
     const items = Array.isArray(json?.items) ? json.items : [];
     return items.map((item) => ({

--- a/.agents/scripts/providers/github/search-budget.js
+++ b/.agents/scripts/providers/github/search-budget.js
@@ -21,7 +21,7 @@
  * Search API cap. When a rate limit is reported with no readable reset, the
  * bucket pauses for one full window before the next `take()` resolves.
  */
-export const SEARCH_BUDGET_DEFAULTS = Object.freeze({
+const SEARCH_BUDGET_DEFAULTS = Object.freeze({
   capacity: 30,
   windowMs: 60_000,
   cooldownMs: 60_000,

--- a/.agents/scripts/providers/github/search-budget.js
+++ b/.agents/scripts/providers/github/search-budget.js
@@ -1,0 +1,124 @@
+/**
+ * GitHub Provider — `/search/issues` fan-out budget (Story #4678).
+ *
+ * The 30-requests-per-minute cap is a property of GitHub's `/search/issues`
+ * endpoint, not of any one caller. A single audit-to-stories scan issues ~2
+ * search calls per finding; a 22-group scan therefore blows well past the cap
+ * with no throttle of any kind, and every exhausted call then spends its whole
+ * transient-retry budget re-issuing a request against an already-empty window.
+ *
+ * This module owns the throttle at the endpoint seam: a pure, injectable token
+ * bucket that `IssuesGateway#searchIssues` awaits before every call, so every
+ * caller (audit-to-stories dedup, `lib/duplicate-search.js`, the tickets
+ * gateway's `_searchIssues`) inherits one shared budget for free.
+ *
+ * `now` and `sleep` are injected so unit tests drive the bucket deterministically
+ * without wall-clock time.
+ */
+
+/**
+ * Default budget: 30 tokens per 60s window, matching GitHub's authenticated
+ * Search API cap. When a rate limit is reported with no readable reset, the
+ * bucket pauses for one full window before the next `take()` resolves.
+ */
+export const SEARCH_BUDGET_DEFAULTS = Object.freeze({
+  capacity: 30,
+  windowMs: 60_000,
+  cooldownMs: 60_000,
+});
+
+/**
+ * Create a token-bucket search budget.
+ *
+ * `take()` resolves once a token is available, consuming it; it awaits an
+ * accruing token (and any active rate-limit cooldown) rather than failing.
+ * `noteRateLimited(resetAtMs)` drains the bucket and blocks every subsequent
+ * `take()` until the reported reset (or a fixed cooldown when no reset is
+ * readable), so the whole batch pauses **once** instead of each call retrying
+ * independently into the empty window.
+ *
+ * @param {object} [opts]
+ * @param {number} [opts.capacity] — max tokens (and burst size).
+ * @param {number} [opts.windowMs] — window over which `capacity` tokens accrue.
+ * @param {number} [opts.cooldownMs] — pause applied when a rate limit reports
+ *   no readable reset time.
+ * @param {() => number} [opts.now] — millisecond clock (injected for tests).
+ * @param {(ms: number) => Promise<void>} [opts.sleep] — delay primitive.
+ * @returns {{ take: () => Promise<void>, noteRateLimited: (resetAtMs?: number) => void }}
+ */
+export function createSearchBudget({
+  capacity = SEARCH_BUDGET_DEFAULTS.capacity,
+  windowMs = SEARCH_BUDGET_DEFAULTS.windowMs,
+  cooldownMs = SEARCH_BUDGET_DEFAULTS.cooldownMs,
+  now = () => Date.now(),
+  sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms)),
+} = {}) {
+  const refillPerMs = capacity / windowMs;
+  let tokens = capacity;
+  let lastRefillAt = now();
+  let blockedUntil = 0;
+
+  function refill() {
+    const at = now();
+    const elapsed = at - lastRefillAt;
+    if (elapsed > 0) {
+      tokens = Math.min(capacity, tokens + elapsed * refillPerMs);
+      lastRefillAt = at;
+    }
+  }
+
+  async function take() {
+    for (;;) {
+      const at = now();
+      if (blockedUntil > at) {
+        await sleep(blockedUntil - at);
+        continue;
+      }
+      refill();
+      if (tokens >= 1) {
+        tokens -= 1;
+        return;
+      }
+      // Sleep just long enough for one token to accrue, then re-check.
+      const waitMs = Math.max(1, Math.ceil((1 - tokens) / refillPerMs));
+      await sleep(waitMs);
+    }
+  }
+
+  function noteRateLimited(resetAtMs) {
+    const at = now();
+    tokens = 0;
+    lastRefillAt = at;
+    const until =
+      typeof resetAtMs === 'number' && resetAtMs > at
+        ? resetAtMs
+        : at + cooldownMs;
+    if (until > blockedUntil) blockedUntil = until;
+  }
+
+  return { take, noteRateLimited };
+}
+
+/**
+ * Process-wide singleton shared by every `searchIssues` caller. Per-process,
+ * matching the one-scan-per-checkout model — there is deliberately no
+ * cross-process budget.
+ */
+export const searchBudget = createSearchBudget();
+
+/**
+ * Best-effort extract of a rate-limit reset time (epoch ms) from a thrown
+ * error's stderr. GitHub surfaces the reset as an `x-ratelimit-reset` epoch
+ * (seconds) header; `gh` echoes response headers onto stderr on failure.
+ * Returns `undefined` when no reset is readable so the bucket falls back to a
+ * fixed cooldown. Pure — no I/O.
+ *
+ * @param {unknown} err
+ * @returns {number|undefined} reset time in epoch milliseconds, or undefined.
+ */
+export function parseRateLimitResetMs(err) {
+  const haystack = [err?.stderr, err?.message].filter(Boolean).join('\n');
+  const match = haystack.match(/x-ratelimit-reset:\s*(\d{10})/i);
+  if (!match) return undefined;
+  return Number.parseInt(match[1], 10) * 1000;
+}

--- a/.agents/scripts/providers/github/search-query.js
+++ b/.agents/scripts/providers/github/search-query.js
@@ -1,0 +1,66 @@
+/**
+ * GitHub Provider — composed `/search/issues` query bound (Story #4678).
+ *
+ * `IssuesGateway#searchIssues` is the only place that knows the *composed* `q`
+ * — the caller's free text plus the `repo:<owner>/<repo> type:issue` qualifiers
+ * it appends. GitHub Search rejects a query over 256 characters with HTTP 422,
+ * which is neither transient nor caught, so an over-long title over a deep path
+ * would abort the whole scan. This module owns the defensive guard: it truncates
+ * the free-text portion on a whole-token boundary until the composed `q` fits.
+ *
+ * Pure and unit-testable — no I/O.
+ */
+
+/** GitHub Search's documented maximum query length, in characters. */
+export const GITHUB_SEARCH_MAX_QUERY = 256;
+
+/**
+ * Compose a `/search/issues` query from free text plus fixed qualifiers,
+ * truncating the free-text portion on a whole-token boundary so the whole
+ * composed string is at most `max` characters. Qualifiers are never dropped —
+ * they are the load-bearing scope (`repo:` / `type:`) — so when even the
+ * qualifiers alone exceed the budget the qualifier string is returned as-is.
+ *
+ * @param {string} freeText — the caller's free-text search term(s).
+ * @param {string[]} qualifiers — fixed qualifier tokens (e.g. `repo:o/r`).
+ * @param {number} [max] — character ceiling for the composed query.
+ * @returns {string} the composed query, at most `max` characters.
+ */
+export function composeBoundedQuery(
+  freeText,
+  qualifiers,
+  max = GITHUB_SEARCH_MAX_QUERY,
+) {
+  const quals = qualifiers.join(' ');
+  const free = String(freeText ?? '').trim();
+  const full = `${free} ${quals}`.trim();
+  if (full.length <= max) return full;
+
+  // Reserve space for the qualifiers (and the joining space) and fit as many
+  // leading free-text tokens as the remaining budget allows.
+  const reserve = quals.length + (quals.length > 0 ? 1 : 0);
+  const budget = max - reserve;
+  const bounded = fitTokens(free.split(/\s+/).filter(Boolean), budget);
+  return bounded.length > 0 ? `${bounded} ${quals}`.trim() : quals;
+}
+
+/**
+ * Join as many leading `tokens` as fit within `budget` characters, on a
+ * whole-token boundary (space-separated). Returns '' when the budget cannot fit
+ * even the first token.
+ *
+ * @param {string[]} tokens
+ * @param {number} budget
+ * @returns {string}
+ */
+export function fitTokens(tokens, budget) {
+  const kept = [];
+  let length = 0;
+  for (const token of tokens) {
+    const cost = kept.length === 0 ? token.length : token.length + 1;
+    if (length + cost > budget) break;
+    kept.push(token);
+    length += cost;
+  }
+  return kept.join(' ');
+}

--- a/.agents/scripts/providers/github/search-query.js
+++ b/.agents/scripts/providers/github/search-query.js
@@ -11,8 +11,12 @@
  * Pure and unit-testable — no I/O.
  */
 
-/** GitHub Search's documented maximum query length, in characters. */
-export const GITHUB_SEARCH_MAX_QUERY = 256;
+/**
+ * GitHub Search's documented maximum query length, in characters. Module-private
+ * — `composeBoundedQuery` is the only supported way to apply it, so the bound
+ * cannot drift between call sites.
+ */
+const GITHUB_SEARCH_MAX_QUERY = 256;
 
 /**
  * Compose a `/search/issues` query from free text plus fixed qualifiers,
@@ -47,13 +51,14 @@ export function composeBoundedQuery(
 /**
  * Join as many leading `tokens` as fit within `budget` characters, on a
  * whole-token boundary (space-separated). Returns '' when the budget cannot fit
- * even the first token.
+ * even the first token. Module-private — exercised through
+ * {@link composeBoundedQuery}, the only caller.
  *
  * @param {string[]} tokens
  * @param {number} budget
  * @returns {string}
  */
-export function fitTokens(tokens, budget) {
+function fitTokens(tokens, budget) {
   const kept = [];
   let length = 0;
   for (const token of tokens) {

--- a/baselines/dead-exports-production.json
+++ b/baselines/dead-exports-production.json
@@ -2527,6 +2527,10 @@
     {
       "file": ".agents/scripts/providers/github/request-helpers.js",
       "symbol": "DEFAULT_PER_PAGE"
+    },
+    {
+      "file": ".agents/scripts/providers/github/search-budget.js",
+      "symbol": "createSearchBudget"
     }
   ]
 }

--- a/baselines/dead-exports.json
+++ b/baselines/dead-exports.json
@@ -658,6 +658,10 @@
     {
       "file": ".agents/scripts/providers/github/request-helpers.js",
       "symbol": "DEFAULT_PER_PAGE"
+    },
+    {
+      "file": ".agents/scripts/providers/github/search-budget.js",
+      "symbol": "createSearchBudget"
     }
   ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -3134,9 +3134,9 @@
       }
     },
     "node_modules/fast-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
       "funding": [
         {
           "type": "github",
@@ -4089,9 +4089,9 @@
       "license": "MIT"
     },
     "node_modules/linkify-it": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.1.tgz",
-      "integrity": "sha512-wVoTjP4Q6R0NW5hiZkVJaFZPWgtXfoGF+6LucL3/FtiNjmcHhYjEr5f1Kqjirc1nBW07J/ZuRFumqr2oqccEWg==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.2.tgz",
+      "integrity": "sha512-ONTm2jCMAVZjgQa/Fy1kScXsuOoF5NPTsoFBdE1KVIZ2vAh/r9+Bqo+0jINCBYnavTPQZz38QzFTme79ENoN3Q==",
       "dev": true,
       "funding": [
         {

--- a/tests/audit-to-stories/dedupe-against-github.test.js
+++ b/tests/audit-to-stories/dedupe-against-github.test.js
@@ -122,7 +122,14 @@ test('classifyGroupsAgainstGitHub summary tallies multiple groups', async () => 
     { number: 2, state: 'CLOSED', body: footerFor(FINDING_B) },
   ]);
   const { summary } = await classifyGroupsAgainstGitHub({ groups, provider });
-  assert.deepEqual(summary, { create: 1, skipOpen: 1, skipReoccurring: 1 });
+  // `dedupDegraded` is always reported alongside the counters (Story #4678):
+  // zero degradations when every lookup completes.
+  assert.deepEqual(summary, {
+    create: 1,
+    skipOpen: 1,
+    skipReoccurring: 1,
+    dedupDegraded: { count: 0, groups: [] },
+  });
 });
 
 test('classifyGroupsAgainstGitHub throws on missing provider', async () => {


### PR DESCRIPTION
Closes #4678

_Auto-opened by `/deliver`._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes shared `searchIssues` behavior (throttling and rate-limit retry policy) for all callers in-process, and degraded dedup can classify groups as `create` without a real duplicate check—operators must heed stderr warnings before opening stories.
> 
> **Overview**
> Hardens **audit-to-stories** Phase 6 dedup so large scans no longer trip GitHub `/search/issues` rate limits or 256-character query rejections, and so a single bad lookup does not kill the whole `--scan`.
> 
> **GitHub search path:** Adds a shared **token-bucket** (`search-budget.js`, ~30/min) that `IssuesGateway#searchIssues` awaits before every call; on rate limit it records the reset and **does not** retry the search through `withTransientRetry`. Composed queries are capped with `composeBoundedQuery` so `repo:` / `type:issue` qualifiers are always kept. Semantic `buildQuery` now uses file **basenames** and a character budget on whole-token boundaries.
> 
> **Dedup behavior:** Per-group classification is wrapped so HTTP 422 / exhausted rate limits **degrade** that group to `create` while other groups keep real classifications. The plan JSON gains `summary.dedupDegraded`; stderr gets a loud `dedupDegradedWarning` listing affected groups. Tests add a fixture provider seam (`AUDIT_TO_STORIES_PROVIDER_FIXTURE`) and subprocess coverage that `--scan` still exits 0 with parseable stdout JSON.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0d3b24c21593769805d55a33faaf35b37fcc4f8c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->