### PR TITLE
fix: land tail: tolerate/pre-empt a worktree-held story branch so a merged PR is never stranded at agent::blocked (#4681)

### DIFF
--- a/.agents/scripts/lib/orchestration/single-story-close/phases/auto-merge.js
+++ b/.agents/scripts/lib/orchestration/single-story-close/phases/auto-merge.js
@@ -92,12 +92,14 @@ const LOCAL_CLEANUP_FAILURE =
  * Whether a non-zero `gh pr merge` exit is attributable solely to local
  * branch cleanup, leaving the remote merge/arm itself intact.
  *
- * Pure — exported for tests.
+ * Module-private on purpose: `enableAutoMergeWith` is the only caller and the
+ * only surface worth pinning, so the classification is asserted through it
+ * rather than through a test-only export.
  *
  * @param {string|undefined|null} stderr
  * @returns {boolean}
  */
-export function isLocalCleanupOnlyFailure(stderr) {
+function isLocalCleanupOnlyFailure(stderr) {
   return LOCAL_CLEANUP_FAILURE.test(String(stderr ?? ''));
 }
 

--- a/.agents/scripts/lib/orchestration/single-story-close/phases/auto-merge.js
+++ b/.agents/scripts/lib/orchestration/single-story-close/phases/auto-merge.js
@@ -23,6 +23,21 @@
  * no-op. `--delete-branch` is preserved verbatim, so the PR head branch is
  * still deleted on merge without depending on the repo's auto-delete
  * setting. Resolution is non-fatal — it degrades to the original cwd.
+ *
+ * Story #4681 made the arm survive a LOCAL-ONLY cleanup failure. Against an
+ * already-mergeable PR, `gh pr merge --auto --squash --delete-branch` merges
+ * immediately and then shells out to local `git` to drop the head branch.
+ * When the per-Story worktree still holds `story-<id>`, that local delete
+ * fails (`Cannot delete branch 'story-<id>' used by worktree at …`) and `gh`
+ * exits non-zero — even though the REMOTE merge already landed. Reporting
+ * that as an arm failure sent close's confirm phase straight to
+ * `blockOnUnlanded`, flipping a merged Story to a stale `agent::blocked` that
+ * only a hand-run `single-story-confirm-merge.js` could undo. The failure is
+ * now classified: a local-cleanup-only signature reports the arm as ENABLED
+ * with `localCleanupDeferred: true`, so the confirm phase polls the PR
+ * (observes MERGED) and the post-land tail reaps the local ref. Every other
+ * non-zero exit — a genuinely refused REMOTE merge — keeps the pre-existing
+ * `enabled: false` → blocked behaviour verbatim.
  */
 
 import { gh as defaultGh } from '../../../gh-exec.js';
@@ -53,6 +68,40 @@ export function isOperatorMergeReason(reason) {
 }
 
 /**
+ * Signatures of a `gh pr merge --delete-branch` failure whose ONLY casualty
+ * is the LOCAL head-branch cleanup that runs *after* the remote merge has
+ * already been performed (or auto-merge already armed).
+ *
+ * Each pattern is emitted by local `git` (or `gh`'s wrapper around it) and
+ * names branch DELETION specifically:
+ *   - `Cannot delete branch '<name>' used by worktree at …` — `git branch -D`
+ *     refusing a ref another worktree has checked out (the Story #4681 report).
+ *   - `failed to delete local branch …` — `gh`'s own wrapper wording.
+ *
+ * Deliberately narrow on two fronts. A genuinely refused REMOTE merge ("Pull
+ * request is not mergeable", a required status check, branch protection)
+ * matches neither pattern and keeps the existing blocked path. Nor does the
+ * bare `fatal: '<base>' is already used by worktree` checkout collision Story
+ * #4282 defends against: that one aborts `gh` *before* the branch delete and
+ * carries no evidence the merge stands, so it must keep failing the arm.
+ */
+const LOCAL_CLEANUP_FAILURE =
+  /cannot delete branch[^\n]*used by worktree|failed to delete (?:the )?local branch/i;
+
+/**
+ * Whether a non-zero `gh pr merge` exit is attributable solely to local
+ * branch cleanup, leaving the remote merge/arm itself intact.
+ *
+ * Pure — exported for tests.
+ *
+ * @param {string|undefined|null} stderr
+ * @returns {boolean}
+ */
+export function isLocalCleanupOnlyFailure(stderr) {
+  return LOCAL_CLEANUP_FAILURE.test(String(stderr ?? ''));
+}
+
+/**
  * Enable GitHub native auto-merge on the PR. Non-fatal.
  *
  * @param {{
@@ -62,7 +111,7 @@ export function isOperatorMergeReason(reason) {
  *   runner?: (args: string[], opts: object) => ({ status: number, stdout?: string, stderr?: string } | Promise<{ status: number, stdout?: string, stderr?: string }>),
  *   resolveArmCwd?: (cwd: string) => string,
  * }} opts
- * @returns {Promise<{ enabled: boolean, reason?: string }>}
+ * @returns {Promise<{ enabled: boolean, reason?: string, localCleanupDeferred?: boolean }>}
  */
 export async function enableAutoMergeWith({
   cwd,
@@ -89,10 +138,15 @@ export async function enableAutoMergeWith({
       { cwd: armCwd },
     );
     if (result.status === 0) return { enabled: true };
-    return {
-      enabled: false,
-      reason: `gh-exit-${result.status}: ${(result.stderr ?? '').trim().slice(0, 200)}`,
-    };
+    const detail = `gh-exit-${result.status}: ${(result.stderr ?? '').trim().slice(0, 200)}`;
+    if (isLocalCleanupOnlyFailure(result.stderr)) {
+      // The remote side stands; only the local head-branch cleanup failed.
+      // Report ENABLED so the confirm phase polls the real PR state instead
+      // of blocking a merge that already landed, and flag the deferred
+      // cleanup for the land tail's `git branch -D` to finish.
+      return { enabled: true, localCleanupDeferred: true, reason: detail };
+    }
+    return { enabled: false, reason: detail };
   } catch (err) {
     return { enabled: false, reason: `gh-spawn-error: ${err?.message ?? err}` };
   }
@@ -167,7 +221,9 @@ function makeDefaultGhAutoMergeRunner(gh) {
  *   gh?: ReturnType<typeof import('../../../gh-exec.js').createGh>,
  *   progress: (tag: string, msg: string) => void,
  * }} args
- * @returns {Promise<{ autoMergeEnabled: boolean, autoMergeReason: string|null }>}
+ * @returns {Promise<{ autoMergeEnabled: boolean, autoMergeReason: string|null, localCleanupDeferred?: boolean }>}
+ *   `localCleanupDeferred` is true when the arm stands but `gh`'s local
+ *   head-branch delete failed (Story #4681) — the land tail owns the reap.
  */
 export async function runAutoMergePhase({
   cwd,
@@ -211,15 +267,37 @@ export async function runAutoMergePhase({
   }
   const result = await enableAutoMergeWith({ cwd, prNumber, gh });
   if (result.enabled) {
+    if (result.localCleanupDeferred) {
+      // Warning, never a block (Story #4681): the merge/arm stands and the
+      // land tail reaps the local ref once the worktree releases it.
+      progress(
+        'PR',
+        `⚠️ Auto-merge armed on PR #${prNumber}, but gh's LOCAL branch cleanup failed ` +
+          `(${result.reason}) — deferring the local ref reap to the land tail; the merge stands.`,
+      );
+      return {
+        autoMergeEnabled: true,
+        autoMergeReason: null,
+        localCleanupDeferred: true,
+      };
+    }
     progress(
       'PR',
       `✅ Auto-merge enabled on PR #${prNumber} (squash, delete-branch).`,
     );
-    return { autoMergeEnabled: true, autoMergeReason: null };
+    return {
+      autoMergeEnabled: true,
+      autoMergeReason: null,
+      localCleanupDeferred: false,
+    };
   }
   progress(
     'PR',
     `⚠️ Auto-merge enablement failed (${result.reason}) — operator can merge manually.`,
   );
-  return { autoMergeEnabled: false, autoMergeReason: result.reason };
+  return {
+    autoMergeEnabled: false,
+    autoMergeReason: result.reason,
+    localCleanupDeferred: false,
+  };
 }

--- a/.agents/scripts/lib/orchestration/single-story-close/runner.js
+++ b/.agents/scripts/lib/orchestration/single-story-close/runner.js
@@ -311,6 +311,7 @@ function closeResult({
   autoMergeReason,
   worktreeReaped,
   leaseReleased,
+  localCleanupDeferred = false,
   waitedForMerge = false,
   merged = false,
 }) {
@@ -326,6 +327,10 @@ function closeResult({
     autoMergeReason,
     worktreeReaped,
     leaseReleased,
+    // Story #4681 — `gh`'s local head-branch delete failed while the remote
+    // merge/arm stood. Surfaced so the land is auditable as
+    // merged-with-deferred-cleanup rather than silently degraded.
+    localCleanupDeferred,
     waitedForMerge,
     merged,
     note: waitedForMerge
@@ -486,16 +491,35 @@ async function runClosePipeline({
       }),
     leaseArgs,
   );
-  setPhase('auto-merge');
-  const { autoMergeEnabled, autoMergeReason } = await runAutoMergePhase({
+  // Reap the per-Story worktree BEFORE the arm (Story #4681). Arming runs
+  // `gh pr merge --auto --squash --delete-branch`, which — against an
+  // already-mergeable PR — merges immediately and then shells out to local
+  // `git` to drop `story-<id>`. A live worktree still holding that ref makes
+  // the local delete fail, `gh` exit non-zero, and the arm read as failed,
+  // which used to strand a genuinely merged PR at `agent::blocked`.
+  // Pre-empting the hold is the ordering half of the fix (the tolerate half
+  // lives in `phases/auto-merge.js`); it is safe here because push and PR
+  // creation already made the work durable off-machine, and `isSafeToRemove`
+  // still refuses a dirty tree.
+  const worktreeReaped = await reapWorktreePhase({
     cwd: options.cwd,
-    prNumber,
-    prUrl,
-    noAutoMerge: options.noAutoMerge,
-    autoMergePolicy: getCiDelivery(config).autoMerge,
-    gh: injectedGh,
+    storyId: options.storyId,
+    worktreePath,
+    wtIsolation: config.delivery?.worktreeIsolation,
     progress,
+    WorktreeManager,
   });
+  setPhase('auto-merge');
+  const { autoMergeEnabled, autoMergeReason, localCleanupDeferred } =
+    await runAutoMergePhase({
+      cwd: options.cwd,
+      prNumber,
+      prUrl,
+      noAutoMerge: options.noAutoMerge,
+      autoMergePolicy: getCiDelivery(config).autoMerge,
+      gh: injectedGh,
+      progress,
+    });
   await flipLabelAndNotify({
     provider,
     notifyFn: injectedNotify,
@@ -506,14 +530,6 @@ async function runClosePipeline({
     autoMergeReason,
     config,
     progress,
-  });
-  const worktreeReaped = await reapWorktreePhase({
-    cwd: options.cwd,
-    storyId: options.storyId,
-    worktreePath,
-    wtIsolation: config.delivery?.worktreeIsolation,
-    progress,
-    WorktreeManager,
   });
   const leaseReleased = await releaseLease(leaseArgs);
 
@@ -589,6 +605,7 @@ async function runClosePipeline({
       autoMergeReason,
       worktreeReaped,
       leaseReleased,
+      localCleanupDeferred,
       waitedForMerge: true,
       merged: waitOutcome.confirmed === true,
     });
@@ -625,6 +642,7 @@ async function runClosePipeline({
     autoMergeReason,
     worktreeReaped,
     leaseReleased,
+    localCleanupDeferred,
   });
   // `--no-wait-merge` / operator-merge: the PR is open and the human owns
   // the land. That is a `pending` terminal by definition — the work is not

--- a/tests/single-story-close-confirm-merge.test.js
+++ b/tests/single-story-close-confirm-merge.test.js
@@ -25,6 +25,10 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 import {
+  isLocalCleanupOnlyFailure,
+  runAutoMergePhase,
+} from '../.agents/scripts/lib/orchestration/single-story-close/phases/auto-merge.js';
+import {
   DEFAULT_MAX_WAIT_SECONDS,
   DEFAULT_UPDATE_ATTEMPTS,
   MIN_POLLS_BEFORE_BUDGET_BLOCK,
@@ -840,5 +844,164 @@ describe('parseCloseOptions / resolveWaitForMerge — flag compatibility', () =>
       waitForMerge: true,
       reason: 'config-close-and-land',
     });
+  });
+});
+
+/**
+ * Story #4681 — a merged PR must never be stranded at `agent::blocked`
+ * because `gh`'s LOCAL head-branch delete lost a race with the per-Story
+ * worktree that still holds `story-<id>`.
+ *
+ * The observed cohort failure: `gh pr merge --auto --squash --delete-branch`
+ * merged the PR, then failed its local `git branch -D story-1` with
+ * "Cannot delete branch 'story-1' used by worktree at …" and exited 1. The
+ * arm read as failed, so the confirm phase took the never-armed branch and
+ * blocked a Story whose code was already on `main`.
+ */
+describe('Story #4681 — local branch-delete failure never blocks a landed merge', () => {
+  const WORKTREE_HELD_STDERR =
+    "error: Cannot delete branch 'story-4681' used by worktree at " +
+    "'/repo/.worktrees/story-4681'";
+
+  /** A `gh` facade whose `pr.merge` fails with `stderr` at exit code 1. */
+  function ghFailingMergeWith(stderr) {
+    return {
+      pr: {
+        merge: async () => {
+          const err = new Error('gh pr merge failed');
+          err.code = 1;
+          err.stderr = stderr;
+          throw err;
+        },
+      },
+    };
+  }
+
+  it('AC-1: reports the arm as armed-with-deferred-cleanup, and the wait lands the Story instead of blocking', async () => {
+    const armed = await runAutoMergePhase({
+      cwd: '/repo',
+      prNumber: 99,
+      prUrl: 'https://github.com/o/r/pull/99',
+      noAutoMerge: false,
+      gh: ghFailingMergeWith(WORKTREE_HELD_STDERR),
+      progress: NOOP_PROGRESS,
+    });
+    assert.equal(armed.autoMergeEnabled, true);
+    assert.equal(armed.autoMergeReason, null);
+    assert.equal(
+      armed.localCleanupDeferred,
+      true,
+      'the deferred local ref cleanup must be reported, not swallowed',
+    );
+
+    // Feed the arm outcome into the wait exactly as the runner does. The PR
+    // is MERGED, so the terminal is `landed` and the tail owns the ref reap.
+    const provider = makeFakeProvider();
+    const tailCalls = [];
+    const outcome = await runConfirmMergePhase(
+      phaseArgs({
+        provider,
+        autoMergeEnabled: armed.autoMergeEnabled,
+        autoMergeReason: armed.autoMergeReason,
+        readPrWaitProbeFn: async () => ({
+          state: 'MERGED',
+          mergedAt: '2026-07-21T00:00:00Z',
+          createdAt: null,
+          checksStatus: 'success',
+        }),
+        // The real `confirmStoryMerged` drives the label flip; only its PR
+        // read is stubbed so the suite never touches GitHub.
+        readPrMergeStateFn: async () => ({
+          state: 'MERGED',
+          mergedAt: '2026-07-21T00:00:00Z',
+        }),
+        injectedNotify: async () => {},
+        runPostLandTailFn: async (args) => {
+          tailCalls.push(args);
+          return {
+            followUps: true,
+            statusResync: true,
+            refCleanup: true,
+            baseFastForward: true,
+            details: {},
+          };
+        },
+      }),
+    );
+
+    assert.equal(outcome.terminal, 'landed');
+    assert.equal(outcome.confirmed, true);
+    assert.ok(
+      provider._story().labels.includes('agent::done'),
+      'the merged Story must reach agent::done, not agent::blocked',
+    );
+    assert.deepEqual(
+      provider
+        ._comments()
+        .map((c) => c.payload?.kind ?? c.payload?.type ?? null)
+        .filter(Boolean),
+      [],
+      'no friction comment: nothing about this run is blocked',
+    );
+    assert.equal(
+      tailCalls.length,
+      1,
+      'the post-land tail runs and performs the deferred local ref cleanup',
+    );
+    assert.equal(tailCalls[0].storyBranch, 'story-4428');
+  });
+
+  it('AC-3: a genuinely refused REMOTE merge still fails the arm and blocks', async () => {
+    const armed = await runAutoMergePhase({
+      cwd: '/repo',
+      prNumber: 99,
+      prUrl: 'https://github.com/o/r/pull/99',
+      noAutoMerge: false,
+      gh: ghFailingMergeWith(
+        'Pull request is not mergeable: the base branch policy prohibits the merge.',
+      ),
+      progress: NOOP_PROGRESS,
+    });
+    assert.equal(armed.autoMergeEnabled, false);
+    assert.match(armed.autoMergeReason, /gh-exit-1/);
+    assert.equal(armed.localCleanupDeferred, false);
+
+    const provider = makeFakeProvider();
+    const outcome = await runConfirmMergePhase(
+      phaseArgs({
+        provider,
+        autoMergeEnabled: armed.autoMergeEnabled,
+        autoMergeReason: armed.autoMergeReason,
+        readPrWaitProbeFn: async () => {
+          throw new Error('an un-armed PR must never be polled');
+        },
+      }),
+    );
+
+    assert.equal(outcome.terminal, 'blocked');
+    assert.ok(
+      provider._story().labels.includes('agent::blocked'),
+      'the existing blocked behaviour for a real merge failure is preserved',
+    );
+    assert.equal(provider._comments().length, 1);
+  });
+
+  it('classifies only the branch-DELETE signature — the #4282 checkout collision still fails the arm', () => {
+    assert.equal(isLocalCleanupOnlyFailure(WORKTREE_HELD_STDERR), true);
+    assert.equal(
+      isLocalCleanupOnlyFailure('failed to delete local branch story-4681'),
+      true,
+    );
+    assert.equal(
+      isLocalCleanupOnlyFailure(
+        "failed to run git: fatal: 'main' is already used by worktree at '/repo'",
+      ),
+      false,
+    );
+    assert.equal(
+      isLocalCleanupOnlyFailure('Pull request is not mergeable'),
+      false,
+    );
+    assert.equal(isLocalCleanupOnlyFailure(undefined), false);
   });
 });

--- a/tests/single-story-close-confirm-merge.test.js
+++ b/tests/single-story-close-confirm-merge.test.js
@@ -25,7 +25,7 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 import {
-  isLocalCleanupOnlyFailure,
+  enableAutoMergeWith,
   runAutoMergePhase,
 } from '../.agents/scripts/lib/orchestration/single-story-close/phases/auto-merge.js';
 import {
@@ -986,22 +986,36 @@ describe('Story #4681 — local branch-delete failure never blocks a landed merg
     assert.equal(provider._comments().length, 1);
   });
 
-  it('classifies only the branch-DELETE signature — the #4282 checkout collision still fails the arm', () => {
-    assert.equal(isLocalCleanupOnlyFailure(WORKTREE_HELD_STDERR), true);
-    assert.equal(
-      isLocalCleanupOnlyFailure('failed to delete local branch story-4681'),
-      true,
-    );
-    assert.equal(
-      isLocalCleanupOnlyFailure(
-        "failed to run git: fatal: 'main' is already used by worktree at '/repo'",
-      ),
-      false,
-    );
-    assert.equal(
-      isLocalCleanupOnlyFailure('Pull request is not mergeable'),
-      false,
-    );
-    assert.equal(isLocalCleanupOnlyFailure(undefined), false);
+  it('classifies only the branch-DELETE signature — the #4282 checkout collision still fails the arm', async () => {
+    // Asserted through the public arm surface: the classifier itself is
+    // module-private, so its contract is the arm outcome it produces.
+    const armWith = (stderr) =>
+      enableAutoMergeWith({
+        cwd: '/repo',
+        prNumber: 99,
+        runner: () => ({ status: 1, stdout: '', stderr }),
+        resolveArmCwd: (cwd) => cwd,
+      });
+
+    for (const stderr of [
+      WORKTREE_HELD_STDERR,
+      'failed to delete local branch story-4681',
+    ]) {
+      const result = await armWith(stderr);
+      assert.equal(result.enabled, true, stderr);
+      assert.equal(result.localCleanupDeferred, true, stderr);
+    }
+
+    for (const stderr of [
+      // Story #4282: `gh` aborted BEFORE the branch delete, so there is no
+      // evidence the merge stands — this must keep failing the arm.
+      "failed to run git: fatal: 'main' is already used by worktree at '/repo'",
+      'Pull request is not mergeable',
+      '',
+    ]) {
+      const result = await armWith(stderr);
+      assert.equal(result.enabled, false, stderr);
+      assert.equal(result.localCleanupDeferred, undefined, stderr);
+    }
   });
 });

--- a/tests/single-story-close-orchestration.test.js
+++ b/tests/single-story-close-orchestration.test.js
@@ -28,7 +28,7 @@
  */
 
 import assert from 'node:assert/strict';
-import { mkdtempSync, rmSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { afterEach, beforeEach, describe, it } from 'node:test';
@@ -747,6 +747,74 @@ describe('runSingleStoryClose orchestration', () => {
     assert.equal(result.prNumber, 55);
     assert.equal(result.autoMergeEnabled, false);
     assert.match(result.autoMergeReason ?? '', /gh-exit-22/);
+  });
+
+  it("Story #4681 — reaps the per-Story worktree BEFORE arming auto-merge, so gh's local branch delete is never blocked by a live worktree", async (t) => {
+    // `gh pr merge --auto --squash --delete-branch` shells out to local
+    // `git branch -D story-<id>` after merging. A worktree still holding the
+    // ref makes that delete fail, gh exit non-zero, and the arm read as
+    // failed — which used to block a merged Story. Pre-empting the hold is
+    // the ordering half of the fix, so the order is the contract.
+    const order = [];
+    const worktreeRoot = '.worktrees';
+    mkdirSync(path.join(tempRoot, worktreeRoot, 'story-4681'), {
+      recursive: true,
+    });
+    const gh = makeFakeGh((args) => {
+      if (args[1] === 'list') return [];
+      if (args[1] === 'create') {
+        return 'https://github.com/owner/repo/pull/77\n';
+      }
+      if (args[1] === 'merge') {
+        order.push('arm');
+        return 'ok';
+      }
+      throw new Error(`unexpected gh: ${args.join(' ')}`);
+    });
+    t.mock.module(GIT_UTILS_URL, defaultGitUtilsMock());
+    mockCloseValidation(t, defaultCloseValidationMock());
+    t.mock.module(WORKTREE_MANAGER_URL, {
+      namedExports: {
+        WorktreeManager: class {
+          async reap() {
+            order.push('reap');
+            return { removed: true };
+          }
+        },
+        parseWorktreePorcelain: (..._args) => [],
+      },
+    });
+
+    const { runSingleStoryClose } = await import(
+      `${SUT_URL}?t=reap-before-arm`
+    );
+    const { result } = await runSingleStoryClose({
+      storyId: 4681,
+      cwd: tempRoot,
+      skipValidation: true,
+      skipSync: true,
+      noWaitForMerge: true,
+      injectedProvider: makeFakeProvider({
+        initialStory: {
+          id: 4681,
+          state: 'open',
+          title: 'Reap before arm',
+          labels: ['agent::executing'],
+        },
+      }),
+      injectedConfig: fakeConfig({ reapOnSuccess: true, worktreeRoot }),
+      injectedRunCodeReview: noopReview(),
+      injectedGh: gh,
+    });
+
+    assert.deepEqual(
+      order,
+      ['reap', 'arm'],
+      'the worktree reap must precede the auto-merge arm',
+    );
+    assert.equal(result.worktreeReaped, true);
+    assert.equal(result.autoMergeEnabled, true);
+    assert.equal(result.localCleanupDeferred, false);
   });
 
   it('runs the validation gate when skipValidation is false (happy path)', async (t) => {


### PR DESCRIPTION
Closes #4681

_Auto-opened by `/deliver`._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes single-story close ordering and auto-merge success criteria; mistakes could block valid merges or skip blocking real failures, but behavior is narrow regex-gated and heavily tested.
> 
> **Overview**
> Fixes **Story #4681**: when `gh pr merge --auto --squash --delete-branch` merges on GitHub but local `git branch -D` fails because the per-story worktree still holds `story-<id>`, close no longer treats that as a failed arm and blocks at `agent::blocked`.
> 
> **Tolerate:** `enableAutoMergeWith` classifies stderr matching local-only branch-delete failures (worktree-held ref, `failed to delete local branch`) and returns **`enabled: true`** with **`localCleanupDeferred: true`** so confirm-merge still polls and lands; real remote merge failures stay **`enabled: false`**. The Story #4282 checkout-collision pattern is explicitly **not** treated as success.
> 
> **Pre-empt:** `runSingleStoryClose` runs **worktree reap before** the auto-merge arm so `gh`'s post-merge local delete is less likely to hit a live worktree.
> 
> Close results expose **`localCleanupDeferred`** for auditability. Tests cover the full land path, remote merge refusal, classifier boundaries, and reap-before-arm ordering.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 749fbb53bba5cb630c362b8bbd5b3d4e39349e42. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->