### PR TITLE
fix: root-cause and fix: second-touch change-request deliveries complete but their PR never lands (#4682)

### DIFF
--- a/.agents/scripts/lib/orchestration/single-story-close/phases/auto-merge.js
+++ b/.agents/scripts/lib/orchestration/single-story-close/phases/auto-merge.js
@@ -146,13 +146,17 @@ function isLocalCleanupOnlyFailure(stderr) {
  *
  * Only these classes fall through to the direct-merge fallback; everything
  * else (an unmatched non-zero exit) keeps the `enabled: false` → blocked path.
- * Matched case-insensitively. Exported so the marker set is reviewable and
- * unit-testable in isolation.
+ * Matched case-insensitively.
+ *
+ * Module-private on purpose (mirroring {@link isLocalCleanupOnlyFailure}):
+ * `enableAutoMergeWith` is the only caller, so the marker set is asserted
+ * through it rather than through a test-only export the production dead-export
+ * ratchet would then flag.
  *
  * @param {string|undefined|null} stderr
  * @returns {boolean}
  */
-export function isAutoMergeUnavailable(stderr) {
+function isAutoMergeUnavailable(stderr) {
   const text = String(stderr ?? '').toLowerCase();
   return (
     text.includes('auto merge is not allowed') ||

--- a/.agents/scripts/lib/orchestration/single-story-close/phases/auto-merge.js
+++ b/.agents/scripts/lib/orchestration/single-story-close/phases/auto-merge.js
@@ -38,6 +38,27 @@
  * (observes MERGED) and the post-land tail reaps the local ref. Every other
  * non-zero exit — a genuinely refused REMOTE merge — keeps the pre-existing
  * `enabled: false` → blocked behaviour verbatim.
+ *
+ * Story #4682 restored the direct-merge fallback the v2.0.0 Story-only cutover
+ * dropped (originally PR #4480 / Story #4472, in the retired `AutomergeArmer`).
+ * GitHub native auto-merge (`gh pr merge --auto`) can only be QUEUED on a repo
+ * that has the "Allow auto-merge" setting enabled — which in practice requires
+ * branch protection. A repo with NO required checks and NO branch protection
+ * (every mandrel-bench sandbox, many real consumer repos) refuses the `--auto`
+ * arm: either "auto-merge is not allowed for this repository", or — once the
+ * PR has settled to an immediately-mergeable state, which the SECOND delivery
+ * into a warm repo reaches faster than the first into a cold one — the
+ * `enablePullRequestAutoMerge` "Pull request is in clean status" refusal. The
+ * close gates and Story-scope review have already cleared the merge by the
+ * time the arm runs, so the safe, must-land-satisfying response is a direct
+ * immediate squash-merge (no `--auto`). When the `--auto` failure matches the
+ * narrow {@link isAutoMergeUnavailable} signature, `enableAutoMergeWith`
+ * retries `gh pr merge --squash --delete-branch` and reports
+ * `{ enabled: true, directMerged: true }` on success — so the confirm phase
+ * polls the PR, observes MERGED, and lands it instead of blocking a PR that
+ * would never merge on its own. Every OTHER `--auto` failure — a genuine
+ * conflict, a red required check, an auth fault — matches neither the
+ * local-cleanup nor the unavailable signature and keeps blocking verbatim.
  */
 
 import { gh as defaultGh } from '../../../gh-exec.js';
@@ -104,6 +125,83 @@ function isLocalCleanupOnlyFailure(stderr) {
 }
 
 /**
+ * Pure: does a `gh pr merge --auto` stderr indicate that GitHub native
+ * auto-merge is UNAVAILABLE on this repository / PR — as opposed to a genuine
+ * arm failure (a merge conflict, a red required check, an auth fault)?
+ *
+ * Two distinct refusals both mean "there is no queued auto-merge for this repo,
+ * merge it directly instead", and both are safe to retry as an immediate
+ * squash-merge:
+ *
+ *   - **"auto-merge is not allowed for this repository"** — the repo has no
+ *     "Allow auto-merge" setting (no branch protection). Constant per repo.
+ *   - **"Pull request is in clean status"** — the `enablePullRequestAutoMerge`
+ *     GraphQL mutation refuses to queue a merge on a PR that is ALREADY
+ *     immediately mergeable with nothing to wait for (no required checks
+ *     pending). This is the second-delivery wedge (Story #4682): the first
+ *     delivery into a cold sandbox arms while GitHub is still computing the
+ *     fresh PR's mergeability (the arm queues, then merges); the second
+ *     delivery into the now-warm repo hits an instantly-clean PR, so the arm
+ *     is refused here.
+ *
+ * Only these classes fall through to the direct-merge fallback; everything
+ * else (an unmatched non-zero exit) keeps the `enabled: false` → blocked path.
+ * Matched case-insensitively. Exported so the marker set is reviewable and
+ * unit-testable in isolation.
+ *
+ * @param {string|undefined|null} stderr
+ * @returns {boolean}
+ */
+export function isAutoMergeUnavailable(stderr) {
+  const text = String(stderr ?? '').toLowerCase();
+  return (
+    text.includes('auto merge is not allowed') ||
+    text.includes('auto-merge is not allowed') ||
+    text.includes('enablepullrequestautomerge') ||
+    text.includes('clean status') ||
+    (text.includes('auto') && text.includes('not enabled'))
+  );
+}
+
+/**
+ * Direct (non-`--auto`) squash-merge fallback (Story #4682, restoring PR
+ * #4480 / Story #4472). Reached only when the `--auto` arm was refused with
+ * the {@link isAutoMergeUnavailable} signature — a repo with no native
+ * auto-merge, or an already-clean PR with nothing to queue behind. Omitting
+ * `--auto` makes `gh` merge synchronously; the same `--squash --delete-branch`
+ * shape and the same `armCwd` re-point are preserved so the trailing local
+ * `--delete-branch` housekeeping runs from the primary worktree (Story #4282).
+ *
+ * A local-cleanup-only grumble on the direct merge (Story #4681) still means
+ * the REMOTE merge landed, so it reports `directMerged` with
+ * `localCleanupDeferred`. Any other non-zero exit is a genuine failure the
+ * caller escalates.
+ *
+ * @returns {Promise<{ enabled: boolean, directMerged?: boolean, localCleanupDeferred?: boolean, reason?: string }>}
+ */
+async function directMergeFallback({ exec, prNumber, armCwd, autoReason }) {
+  const direct = await exec(
+    ['pr', 'merge', String(prNumber), '--squash', '--delete-branch'],
+    { cwd: armCwd },
+  );
+  if (direct.status === 0) {
+    return { enabled: true, directMerged: true, reason: autoReason };
+  }
+  if (isLocalCleanupOnlyFailure(direct.stderr)) {
+    return {
+      enabled: true,
+      directMerged: true,
+      localCleanupDeferred: true,
+      reason: autoReason,
+    };
+  }
+  return {
+    enabled: false,
+    reason: `direct-merge fallback failed after auto-merge unavailable (${autoReason}); gh-exit-${direct.status}: ${(direct.stderr ?? '').trim().slice(0, 160)}`,
+  };
+}
+
+/**
  * Enable GitHub native auto-merge on the PR. Non-fatal.
  *
  * @param {{
@@ -113,7 +211,7 @@ function isLocalCleanupOnlyFailure(stderr) {
  *   runner?: (args: string[], opts: object) => ({ status: number, stdout?: string, stderr?: string } | Promise<{ status: number, stdout?: string, stderr?: string }>),
  *   resolveArmCwd?: (cwd: string) => string,
  * }} opts
- * @returns {Promise<{ enabled: boolean, reason?: string, localCleanupDeferred?: boolean }>}
+ * @returns {Promise<{ enabled: boolean, reason?: string, localCleanupDeferred?: boolean, directMerged?: boolean }>}
  */
 export async function enableAutoMergeWith({
   cwd,
@@ -147,6 +245,16 @@ export async function enableAutoMergeWith({
       // of blocking a merge that already landed, and flag the deferred
       // cleanup for the land tail's `git branch -D` to finish.
       return { enabled: true, localCleanupDeferred: true, reason: detail };
+    }
+    if (isAutoMergeUnavailable(result.stderr)) {
+      // No native auto-merge on this repo (or nothing to queue behind an
+      // already-clean PR): merge directly so the PR still lands (Story #4682).
+      return directMergeFallback({
+        exec,
+        prNumber,
+        armCwd,
+        autoReason: detail,
+      });
     }
     return { enabled: false, reason: detail };
   } catch (err) {
@@ -223,9 +331,11 @@ function makeDefaultGhAutoMergeRunner(gh) {
  *   gh?: ReturnType<typeof import('../../../gh-exec.js').createGh>,
  *   progress: (tag: string, msg: string) => void,
  * }} args
- * @returns {Promise<{ autoMergeEnabled: boolean, autoMergeReason: string|null, localCleanupDeferred?: boolean }>}
+ * @returns {Promise<{ autoMergeEnabled: boolean, autoMergeReason: string|null, localCleanupDeferred?: boolean, directMerged?: boolean }>}
  *   `localCleanupDeferred` is true when the arm stands but `gh`'s local
  *   head-branch delete failed (Story #4681) — the land tail owns the reap.
+ *   `directMerged` is true when native auto-merge was unavailable and the PR
+ *   was landed by a direct squash-merge instead (Story #4682).
  */
 export async function runAutoMergePhase({
   cwd,
@@ -269,6 +379,25 @@ export async function runAutoMergePhase({
   }
   const result = await enableAutoMergeWith({ cwd, prNumber, gh });
   if (result.enabled) {
+    if (result.directMerged) {
+      // No native auto-merge on this repo — the PR was merged directly
+      // instead of queued (Story #4682). The confirm phase polls the PR,
+      // observes MERGED, and runs the land tail; `localCleanupDeferred`
+      // still defers a local-ref reap when gh's `--delete-branch` grumbled.
+      progress(
+        'PR',
+        `✅ Native auto-merge unavailable on PR #${prNumber} — direct squash-merge landed it` +
+          (result.localCleanupDeferred
+            ? " (gh's LOCAL branch cleanup deferred to the land tail; the merge stands)."
+            : '.'),
+      );
+      return {
+        autoMergeEnabled: true,
+        autoMergeReason: null,
+        directMerged: true,
+        localCleanupDeferred: Boolean(result.localCleanupDeferred),
+      };
+    }
     if (result.localCleanupDeferred) {
       // Warning, never a block (Story #4681): the merge/arm stands and the
       // land tail reaps the local ref once the worktree releases it.

--- a/.agents/scripts/lib/orchestration/single-story-close/runner.js
+++ b/.agents/scripts/lib/orchestration/single-story-close/runner.js
@@ -312,6 +312,7 @@ function closeResult({
   worktreeReaped,
   leaseReleased,
   localCleanupDeferred = false,
+  directMerged = false,
   waitedForMerge = false,
   merged = false,
 }) {
@@ -331,6 +332,11 @@ function closeResult({
     // merge/arm stood. Surfaced so the land is auditable as
     // merged-with-deferred-cleanup rather than silently degraded.
     localCleanupDeferred,
+    // Story #4682 — native auto-merge was unavailable (no branch protection /
+    // an already-clean PR), so the PR was landed by a direct squash-merge.
+    // Surfaced so a checks-less land is auditable rather than looking like a
+    // queued auto-merge that never fired.
+    directMerged,
     waitedForMerge,
     merged,
     note: waitedForMerge
@@ -510,16 +516,20 @@ async function runClosePipeline({
     WorktreeManager,
   });
   setPhase('auto-merge');
-  const { autoMergeEnabled, autoMergeReason, localCleanupDeferred } =
-    await runAutoMergePhase({
-      cwd: options.cwd,
-      prNumber,
-      prUrl,
-      noAutoMerge: options.noAutoMerge,
-      autoMergePolicy: getCiDelivery(config).autoMerge,
-      gh: injectedGh,
-      progress,
-    });
+  const {
+    autoMergeEnabled,
+    autoMergeReason,
+    localCleanupDeferred,
+    directMerged,
+  } = await runAutoMergePhase({
+    cwd: options.cwd,
+    prNumber,
+    prUrl,
+    noAutoMerge: options.noAutoMerge,
+    autoMergePolicy: getCiDelivery(config).autoMerge,
+    gh: injectedGh,
+    progress,
+  });
   await flipLabelAndNotify({
     provider,
     notifyFn: injectedNotify,
@@ -606,6 +616,7 @@ async function runClosePipeline({
       worktreeReaped,
       leaseReleased,
       localCleanupDeferred,
+      directMerged,
       waitedForMerge: true,
       merged: waitOutcome.confirmed === true,
     });
@@ -643,6 +654,7 @@ async function runClosePipeline({
     worktreeReaped,
     leaseReleased,
     localCleanupDeferred,
+    directMerged,
   });
   // `--no-wait-merge` / operator-merge: the PR is open and the human owns
   // the land. That is a `pending` terminal by definition — the work is not

--- a/tests/single-story-close-second-delivery.test.js
+++ b/tests/single-story-close-second-delivery.test.js
@@ -33,7 +33,6 @@ import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 import {
   enableAutoMergeWith,
-  isAutoMergeUnavailable,
   runAutoMergePhase,
 } from '../.agents/scripts/lib/orchestration/single-story-close/phases/auto-merge.js';
 import { runConfirmMergePhase } from '../.agents/scripts/lib/orchestration/single-story-close/phases/confirm-merge.js';
@@ -57,48 +56,11 @@ function scriptedRunner(responses) {
   return runner;
 }
 
-describe('isAutoMergeUnavailable — the fallback classifier', () => {
-  it('matches a repo without native auto-merge', () => {
-    assert.equal(
-      isAutoMergeUnavailable(
-        'failed to run git: Auto-merge is not allowed for this repository',
-      ),
-      true,
-    );
-    assert.equal(
-      isAutoMergeUnavailable('GraphQL: Auto merge is not allowed for ...'),
-      true,
-    );
-  });
-
-  it('matches the already-clean-PR refusal (the second-delivery wedge)', () => {
-    assert.equal(
-      isAutoMergeUnavailable('GraphQL: Pull request is in clean status'),
-      true,
-    );
-    assert.equal(
-      isAutoMergeUnavailable(
-        'Something something enablePullRequestAutoMerge failed',
-      ),
-      true,
-    );
-  });
-
-  it('does NOT match a genuine arm failure (conflict / red required check)', () => {
-    assert.equal(
-      isAutoMergeUnavailable('Pull request is not mergeable'),
-      false,
-    );
-    assert.equal(
-      isAutoMergeUnavailable('merge conflict between base and head'),
-      false,
-    );
-    assert.equal(isAutoMergeUnavailable(''), false);
-    assert.equal(isAutoMergeUnavailable(null), false);
-  });
-});
-
 describe('enableAutoMergeWith — direct-merge fallback (Story #4682)', () => {
+  // The `isAutoMergeUnavailable` classifier is module-private (mirroring
+  // `isLocalCleanupOnlyFailure`), so its marker set is asserted behaviourally
+  // through the fallback path below rather than through a test-only export the
+  // production dead-export ratchet would flag.
   it('leaves the exit-0 happy path untouched (single --auto call)', async () => {
     const runner = scriptedRunner([{ status: 0, stdout: 'ok', stderr: '' }]);
     const result = await enableAutoMergeWith({
@@ -152,6 +114,40 @@ describe('enableAutoMergeWith — direct-merge fallback (Story #4682)', () => {
     });
     assert.equal(result.enabled, true);
     assert.equal(result.directMerged, true);
+  });
+
+  it('falls back on the enablePullRequestAutoMerge GraphQL refusal', async () => {
+    const runner = scriptedRunner([
+      {
+        status: 1,
+        stderr: 'GraphQL: enablePullRequestAutoMerge is not available',
+      },
+      { status: 0, stdout: 'Merged', stderr: '' },
+    ]);
+    const result = await enableAutoMergeWith({
+      cwd: '/repo',
+      prNumber: 14,
+      runner,
+      resolveArmCwd: (c) => c,
+    });
+    assert.equal(result.enabled, true);
+    assert.equal(result.directMerged, true);
+  });
+
+  it('does NOT fall back on an empty / unclassified stderr', async () => {
+    const runner = scriptedRunner([{ status: 1, stderr: '' }]);
+    const result = await enableAutoMergeWith({
+      cwd: '/repo',
+      prNumber: 15,
+      runner,
+      resolveArmCwd: (c) => c,
+    });
+    assert.equal(result.enabled, false);
+    assert.equal(
+      runner.calls.length,
+      1,
+      'no fallback without a known signature',
+    );
   });
 
   it('reports directMerged even when only the LOCAL branch cleanup grumbles', async () => {

--- a/tests/single-story-close-second-delivery.test.js
+++ b/tests/single-story-close-second-delivery.test.js
@@ -1,0 +1,326 @@
+/**
+ * tests/single-story-close-second-delivery.test.js — regression coverage for
+ * Story #4682: a change-request delivery into a repo that already contains a
+ * previously merged Story must land its PR as reliably as the first delivery.
+ *
+ * ## Root cause (the specific failing step)
+ *
+ * The v2.0.0 Story-only cutover's `enableAutoMergeWith`
+ * (`single-story-close/phases/auto-merge.js`) dropped the direct-merge
+ * fallback the retired `AutomergeArmer` carried (PR #4480 / Story #4472).
+ * GitHub native auto-merge (`gh pr merge --auto`) can only be QUEUED on a repo
+ * with "Allow auto-merge" enabled — which in practice needs branch protection.
+ * A repo with no required checks and no branch protection (every mandrel-bench
+ * sandbox) refuses the `--auto` arm two ways:
+ *
+ *   - "auto-merge is not allowed for this repository" — a repo-level refusal,
+ *     constant per repo;
+ *   - "Pull request is in clean status" — the `enablePullRequestAutoMerge`
+ *     mutation refusing to queue on an already-immediately-mergeable PR. This
+ *     is the second-delivery wedge: the first delivery into a COLD sandbox
+ *     arms while GitHub is still computing the fresh PR's mergeability (arm
+ *     queues, then merges); the second delivery into the now-WARM repo hits an
+ *     instantly-clean PR, so the arm is refused and — without the fallback —
+ *     the PR is left open, unmerged, `origin/main` unchanged.
+ *
+ * These tests pin the restored fallback at the unit/contract level (no live
+ * sandbox): the arm classifier, the direct-merge retry, the phase report, and
+ * the fact that a directly-merged PR reaches the `landed` terminal — while a
+ * genuine (non-fallback) arm failure still blocks, never silently succeeds.
+ */
+
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import {
+  enableAutoMergeWith,
+  isAutoMergeUnavailable,
+  runAutoMergePhase,
+} from '../.agents/scripts/lib/orchestration/single-story-close/phases/auto-merge.js';
+import { runConfirmMergePhase } from '../.agents/scripts/lib/orchestration/single-story-close/phases/confirm-merge.js';
+
+const NOOP_PROGRESS = () => {};
+
+/**
+ * A scripted `gh pr merge` runner. Each element of `responses` answers the
+ * next call; the args of every call are captured so tests can assert whether a
+ * `--auto` arm or a direct (no-`--auto`) merge was issued.
+ */
+function scriptedRunner(responses) {
+  const calls = [];
+  const runner = (args, opts) => {
+    calls.push({ args, opts });
+    const next = responses[calls.length - 1];
+    if (!next) throw new Error(`unexpected gh call #${calls.length}`);
+    return next;
+  };
+  runner.calls = calls;
+  return runner;
+}
+
+describe('isAutoMergeUnavailable — the fallback classifier', () => {
+  it('matches a repo without native auto-merge', () => {
+    assert.equal(
+      isAutoMergeUnavailable(
+        'failed to run git: Auto-merge is not allowed for this repository',
+      ),
+      true,
+    );
+    assert.equal(
+      isAutoMergeUnavailable('GraphQL: Auto merge is not allowed for ...'),
+      true,
+    );
+  });
+
+  it('matches the already-clean-PR refusal (the second-delivery wedge)', () => {
+    assert.equal(
+      isAutoMergeUnavailable('GraphQL: Pull request is in clean status'),
+      true,
+    );
+    assert.equal(
+      isAutoMergeUnavailable(
+        'Something something enablePullRequestAutoMerge failed',
+      ),
+      true,
+    );
+  });
+
+  it('does NOT match a genuine arm failure (conflict / red required check)', () => {
+    assert.equal(
+      isAutoMergeUnavailable('Pull request is not mergeable'),
+      false,
+    );
+    assert.equal(
+      isAutoMergeUnavailable('merge conflict between base and head'),
+      false,
+    );
+    assert.equal(isAutoMergeUnavailable(''), false);
+    assert.equal(isAutoMergeUnavailable(null), false);
+  });
+});
+
+describe('enableAutoMergeWith — direct-merge fallback (Story #4682)', () => {
+  it('leaves the exit-0 happy path untouched (single --auto call)', async () => {
+    const runner = scriptedRunner([{ status: 0, stdout: 'ok', stderr: '' }]);
+    const result = await enableAutoMergeWith({
+      cwd: '/repo',
+      prNumber: 7,
+      runner,
+      resolveArmCwd: (c) => c,
+    });
+    assert.deepEqual(result, { enabled: true });
+    assert.equal(runner.calls.length, 1, 'no fallback on a clean arm');
+    assert.ok(runner.calls[0].args.includes('--auto'));
+  });
+
+  it('falls back to a DIRECT squash-merge when native auto-merge is not allowed', async () => {
+    const runner = scriptedRunner([
+      {
+        status: 1,
+        stderr: 'Auto-merge is not allowed for this repository',
+      },
+      { status: 0, stdout: 'Merged', stderr: '' },
+    ]);
+    const result = await enableAutoMergeWith({
+      cwd: '/repo',
+      prNumber: 8,
+      runner,
+      resolveArmCwd: (c) => c,
+    });
+    assert.equal(result.enabled, true);
+    assert.equal(result.directMerged, true);
+    assert.equal(runner.calls.length, 2, 'the direct merge was attempted');
+    // Second call is a direct merge: squash + delete-branch, but NOT --auto.
+    const directArgs = runner.calls[1].args;
+    assert.ok(directArgs.includes('--squash'));
+    assert.ok(directArgs.includes('--delete-branch'));
+    assert.ok(
+      !directArgs.includes('--auto'),
+      'the fallback merge must be synchronous (no --auto)',
+    );
+  });
+
+  it('falls back on the already-clean-PR refusal (second-delivery wedge)', async () => {
+    const runner = scriptedRunner([
+      { status: 1, stderr: 'GraphQL: Pull request is in clean status' },
+      { status: 0, stdout: 'Merged', stderr: '' },
+    ]);
+    const result = await enableAutoMergeWith({
+      cwd: '/repo',
+      prNumber: 9,
+      runner,
+      resolveArmCwd: (c) => c,
+    });
+    assert.equal(result.enabled, true);
+    assert.equal(result.directMerged, true);
+  });
+
+  it('reports directMerged even when only the LOCAL branch cleanup grumbles', async () => {
+    const runner = scriptedRunner([
+      { status: 1, stderr: 'Auto-merge is not allowed for this repository' },
+      {
+        status: 1,
+        stderr:
+          "Cannot delete branch 'story-9' used by worktree at '/repo/.worktrees/story-9'",
+      },
+    ]);
+    const result = await enableAutoMergeWith({
+      cwd: '/repo',
+      prNumber: 9,
+      runner,
+      resolveArmCwd: (c) => c,
+    });
+    assert.equal(result.enabled, true);
+    assert.equal(result.directMerged, true);
+    assert.equal(result.localCleanupDeferred, true);
+  });
+
+  it('blocks (never silently succeeds) when the direct merge genuinely fails', async () => {
+    const runner = scriptedRunner([
+      { status: 1, stderr: 'Auto-merge is not allowed for this repository' },
+      { status: 1, stderr: 'Pull request is not mergeable' },
+    ]);
+    const result = await enableAutoMergeWith({
+      cwd: '/repo',
+      prNumber: 10,
+      runner,
+      resolveArmCwd: (c) => c,
+    });
+    assert.equal(result.enabled, false);
+    assert.match(result.reason, /direct-merge fallback failed/);
+    assert.match(result.reason, /not mergeable/);
+  });
+
+  it('does NOT attempt a direct merge for a genuine (non-fallback) arm failure', async () => {
+    const runner = scriptedRunner([
+      { status: 1, stderr: 'merge conflict between base and head' },
+    ]);
+    const result = await enableAutoMergeWith({
+      cwd: '/repo',
+      prNumber: 11,
+      runner,
+      resolveArmCwd: (c) => c,
+    });
+    assert.equal(result.enabled, false);
+    assert.equal(
+      runner.calls.length,
+      1,
+      'a real conflict must not be force-merged by the fallback',
+    );
+  });
+});
+
+describe('runAutoMergePhase — checks-less repo reporting (AC-3)', () => {
+  it('reports autoMergeEnabled + directMerged when the fallback lands the PR', async () => {
+    // Inject the runner via a gh facade shim so the phase uses the fallback.
+    const responses = [
+      { status: 1, stderr: 'Auto-merge is not allowed for this repository' },
+      { status: 0, stdout: 'Merged', stderr: '' },
+    ];
+    let call = 0;
+    const gh = {
+      pr: {
+        merge: async () => {
+          const r = responses[call++];
+          if (r.status === 0) return { stdout: r.stdout, stderr: r.stderr };
+          const err = new Error('gh failed');
+          err.code = r.status;
+          err.stderr = r.stderr;
+          throw err;
+        },
+      },
+    };
+    const out = await runAutoMergePhase({
+      cwd: '/repo',
+      prNumber: 12,
+      prUrl: 'https://github.com/o/r/pull/12',
+      noAutoMerge: false,
+      autoMergePolicy: 'trust-ci',
+      gh,
+      progress: NOOP_PROGRESS,
+    });
+    assert.equal(out.autoMergeEnabled, true);
+    assert.equal(out.directMerged, true);
+    assert.equal(out.autoMergeReason, null);
+  });
+
+  it('reports autoMergeEnabled:false (→ labeled block, not silent) when the fallback also fails', async () => {
+    const gh = {
+      pr: {
+        merge: async () => {
+          const err = new Error('gh failed');
+          err.code = 1;
+          err.stderr = 'Auto-merge is not allowed for this repository';
+          throw err;
+        },
+      },
+    };
+    // Both the --auto arm and the direct merge fail with the same stderr; the
+    // direct merge's non-cleanup failure => enabled:false.
+    const out = await runAutoMergePhase({
+      cwd: '/repo',
+      prNumber: 13,
+      prUrl: 'https://github.com/o/r/pull/13',
+      noAutoMerge: false,
+      autoMergePolicy: 'trust-ci',
+      gh,
+      progress: NOOP_PROGRESS,
+    });
+    assert.equal(out.autoMergeEnabled, false);
+    // A false arm on the default path routes confirm-merge to blockOnUnlanded —
+    // an explicit `agent::blocked`, never a silent success with an open PR.
+    assert.ok(out.autoMergeReason);
+  });
+});
+
+describe('second delivery reaches the landed state (AC-2)', () => {
+  it('a directly-merged PR is confirmed as landed by the confirm phase', async () => {
+    // The direct-merge fallback has already landed the PR remotely
+    // (autoMergeEnabled:true). The confirm phase's first probe observes
+    // MERGED and drives the shared confirmStoryMerged flip + land tail.
+    let confirmCalls = 0;
+    let tailRan = false;
+    const outcome = await runConfirmMergePhase({
+      cwd: '/repo',
+      storyId: 4682,
+      storyBranch: 'story-4682',
+      baseBranch: 'main',
+      prNumber: 12,
+      prUrl: 'https://github.com/o/r/pull/12',
+      autoMergeEnabled: true,
+      autoMergeReason: null,
+      provider: {
+        getTicket: async () => ({ id: 4682, labels: ['agent::closing'] }),
+        updateTicket: async () => {},
+        postComment: async () => ({ id: 'c1' }),
+      },
+      config: {},
+      progress: NOOP_PROGRESS,
+      sleepFn: async () => {},
+      nowMsFn: () => 0,
+      readPrWaitProbeFn: async () => ({
+        state: 'MERGED',
+        mergedAt: '2026-07-21T00:00:00Z',
+      }),
+      confirmStoryMergedFn: async () => {
+        confirmCalls += 1;
+        return { storyId: 4682, action: 'done', merged: true };
+      },
+      runPostLandTailFn: async () => {
+        tailRan = true;
+        return {
+          followUps: true,
+          statusResync: true,
+          refCleanup: true,
+          baseFastForward: true,
+          details: {},
+        };
+      },
+      emitMergeUnlandedFn: () => {},
+      emitMergeFlipFailedFn: () => {},
+    });
+    assert.equal(outcome.confirmed, true);
+    assert.equal(outcome.terminal, 'landed');
+    assert.equal(confirmCalls, 1);
+    assert.equal(tailRan, true);
+  });
+});


### PR DESCRIPTION
Closes #4682

_Auto-opened by `/deliver`._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the single-story close merge path on failure of native auto-merge; scope is limited to classified stderr patterns, but mistaken classification could merge when auto-merge should have been blocked.
> 
> **Overview**
> Fixes **second-touch deliveries** (and other checks-less repos) where `gh pr merge --auto` fails but the PR should still land: close now **retries with a synchronous squash-merge** (`--squash --delete-branch`, no `--auto`) when stderr matches a narrow **auto-merge unavailable** signature (e.g. repo disallows auto-merge, or **“Pull request is in clean status”** on an already-mergeable PR).
> 
> **`enableAutoMergeWith`** gains `isAutoMergeUnavailable` + `directMergeFallback`; conflicts, red checks, and other arm failures still return **`enabled: false`** and block as before. **`runAutoMergePhase`** and the close **result envelope** expose **`directMerged`** (alongside existing **`localCleanupDeferred`**) so direct lands are auditable; confirm-merge still polls **MERGED** and reaches **`landed`**.
> 
> Adds **`tests/single-story-close-second-delivery.test.js`** for the fallback, phase reporting, and confirm path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 08160bbe5bda01b90eea9477160508938a901cab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->