### PR TITLE
feat: pre-empt deterministic authoring-format lints in the story-author prompt (and auto-fix mechanical ones) instead of fail-retry persist round-trips (#4684)

### DIFF
--- a/.agents/scripts/lib/orchestration/task-body-validator.js
+++ b/.agents/scripts/lib/orchestration/task-body-validator.js
@@ -53,6 +53,10 @@
  */
 
 import {
+  suggestPathEntryFix,
+  suggestVerifyFix,
+} from '../story-body/body-format-lints.js';
+import {
   parse as parseStoryBody,
   StoryBodyParseError,
 } from '../story-body/story-body.js';
@@ -72,44 +76,6 @@ export const VERIFY_TIER_VALUES = Object.freeze([
   'e2e',
   'validate',
 ]);
-
-const PATH_LIKE_RE = /[/.][\w@\-./*]+|\*\*?\/?\*?\.\w+|[a-z][\w-]*\/[\w-./*]+/i;
-const VAGUE_VERBS = [
-  'clean up',
-  'refactor',
-  'improve',
-  'polish',
-  'tighten',
-  'tidy',
-  'simplify',
-];
-
-/**
- * @param {string} bullet
- * @returns {boolean}
- */
-function bulletNamesPath(bullet) {
-  const colonIdx = bullet.indexOf(':');
-  if (colonIdx <= 0) return PATH_LIKE_RE.test(bullet);
-  const head = bullet.slice(0, colonIdx);
-  // The conventional shape is "<path>: <verb> <object>" — head is the path.
-  return PATH_LIKE_RE.test(head) || PATH_LIKE_RE.test(bullet);
-}
-
-/**
- * @param {string} bullet
- * @returns {string|null} reason if the bullet uses a vague verb without a named target, else null.
- */
-function vagueVerbWithoutTarget(bullet) {
-  const lower = bullet.toLowerCase();
-  for (const verb of VAGUE_VERBS) {
-    if (!lower.includes(verb)) continue;
-    if (!bulletNamesPath(bullet)) {
-      return verb;
-    }
-  }
-  return null;
-}
 
 /**
  * Predicate: should the validator skip this ticket entirely? Skip when:
@@ -297,8 +263,13 @@ function collectChangesErrors(prefix, rawChanges) {
   }
   for (const entry of changes) {
     if (typeof entry === 'string') {
+      const fix = suggestPathEntryFix(entry);
+      const fixIt =
+        fix === null
+          ? ''
+          : ` Suggested fix: ${fix} (adjust the assumption to creates|deletes if this is a new file or a removal).`;
       errors.push(
-        `${prefix}: body.changes entry must be a { path, assumption } object; plain string bullets are no longer accepted: "${entry}".`,
+        `${prefix}: body.changes entry must be a { path, assumption } object; plain string bullets are no longer accepted: "${entry}".${fixIt}`,
       );
       continue;
     }
@@ -385,8 +356,10 @@ function collectVerifyErrors(prefix, rawVerify) {
       continue;
     }
     if (!VERIFY_TIER_RE.test(v)) {
+      const fix = suggestVerifyFix(v);
+      const fixIt = fix === null ? '' : ` Suggested fix: "${fix}".`;
       errors.push(
-        `${prefix}: body.verify entry must end with a tier in parentheses — one of (${VERIFY_TIER_VALUES.join('|')}). Got: "${v}".`,
+        `${prefix}: body.verify entry must end with a tier in parentheses — one of (${VERIFY_TIER_VALUES.join('|')}). Got: "${v}".${fixIt}`,
       );
     }
   }

--- a/.agents/scripts/lib/story-body/body-format-lints.js
+++ b/.agents/scripts/lib/story-body/body-format-lints.js
@@ -1,0 +1,215 @@
+/**
+ * body-format-lints.js — SSOT for the deterministic body-format lints that can
+ * REJECT an authored Story body at persist time, plus the mechanical auto-fix
+ * inference a failing dry-run surfaces (Story #4684).
+ *
+ * The problem this closes: deterministic format rules (structured `## Changes`
+ * bullet shape, verify-tier suffixes) used to be discovered only as persist
+ * dry-run failures — every miss cost a full re-author round-trip at
+ * resident-context prices. This module is the single home for two remedies:
+ *
+ *   1. `BODY_FORMAT_LINTS` — the enumerated rejecting lints, each carrying a
+ *      concrete good/bad example. `templates/decomposer-prompts.js` renders
+ *      them into the story-author system prompt so the first draft is
+ *      lint-clean by construction; a test enumerates the registry against the
+ *      rendered prompt (Story #4684 AC-1).
+ *   2. `suggestPathEntryFix` / `suggestVerifyFix` — the mechanical rewrites.
+ *      `story-body.js` (`parsePathEntry`) and `task-body-validator.js`
+ *      (`collectChangesErrors` / `collectVerifyErrors`) call them so a failing
+ *      lint emits the corrected form ready to paste rather than a bare reject
+ *      (AC-2).
+ *
+ * Import hygiene: this module imports only the cycle-free
+ * `file-assumption-enum.js` leaf. It must NOT import `story-body.js` or
+ * `task-body-validator.js` — both import this module, and either back-edge
+ * would introduce a cycle (see the note in `file-assumption-enum.js`).
+ */
+
+import { FILE_ASSUMPTION_VALUES } from '../orchestration/file-assumption-enum.js';
+
+/**
+ * Canonical testing-tier vocabulary an inferred verify suffix may name. Kept in
+ * sync with `task-body-validator.js`'s `VERIFY_TIER_VALUES` by a test rather
+ * than an import (importing that module here would create a cycle).
+ *
+ * @type {readonly ['unit','contract','e2e','validate']}
+ */
+const INFERABLE_VERIFY_TIERS = Object.freeze([
+  'unit',
+  'contract',
+  'e2e',
+  'validate',
+]);
+
+/**
+ * The default assumption a mechanical `## Changes` auto-fix proposes. Most
+ * bare-path bullets an author drops are in-place edits, so `refactors-existing`
+ * is the safe default — the fix-it text tells the author to switch it to
+ * `creates` / `deletes` when the edit is net-new or a removal.
+ */
+const DEFAULT_SUGGESTED_ASSUMPTION = 'refactors-existing';
+
+// A token that looks like a file path / glob / module id: it carries a `/` or a
+// `.`-separated segment. Deliberately loose — the suggestion is best-effort, and
+// a false positive only produces an unhelpful (still-valid) fix-it string.
+const PATH_LIKE_RE = /[\w@*-]*[/.][\w@./*-]+/;
+
+/**
+ * Infer the testing tier a bare `verify[]` command implies, when it is
+ * unambiguous. Returns `null` when no confident inference is possible (the
+ * author must then choose the tier themselves — the lint still fires, just
+ * without a fix-it).
+ *
+ * @param {unknown} command
+ * @returns {'unit'|'contract'|'e2e'|'validate'|null}
+ */
+function inferVerifyTier(command) {
+  if (typeof command !== 'string') return null;
+  const c = command.toLowerCase();
+  if (/\bvalidate\b/.test(c)) return 'validate';
+  if (/playwright|\.spec\.|\be2e\b/.test(c)) return 'e2e';
+  if (/\.test\.|node --test|node:test|\bvitest\b|\bjest\b/.test(c)) {
+    return 'unit';
+  }
+  if (/\bcontract\b/.test(c)) return 'contract';
+  return null;
+}
+
+/**
+ * Propose the corrected form of a `verify[]` entry that is missing its tier
+ * suffix, when the tier is inferable from the command. Returns `null` when the
+ * entry is a `manual:` escape, is empty, or the tier cannot be inferred.
+ *
+ * @param {unknown} entry
+ * @returns {string|null} e.g. `"npm run validate (validate)"`.
+ */
+export function suggestVerifyFix(entry) {
+  if (typeof entry !== 'string') return null;
+  const trimmed = entry.trim();
+  if (trimmed === '' || trimmed.startsWith('manual:')) return null;
+  const tier = inferVerifyTier(trimmed);
+  if (tier === null) return null;
+  // Drop any trailing (…) — a wrong/partial tier suffix — before appending the
+  // inferred one, so `npm test (smoke)` becomes `npm test (unit)` not a double.
+  const base = trimmed.replace(/\s*\([^)]*\)\s*$/, '').trim();
+  if (base === '') return null;
+  return `${base} (${tier})`;
+}
+
+/**
+ * Propose the canonical `{ path, assumption }` object form for a `## Changes` /
+ * `## References` bullet an author wrote as a bare path string (or a humanized
+ * bullet with a bad assumption). Returns `null` when no path-shaped token can
+ * be salvaged.
+ *
+ * The returned string is inline-JSON that round-trips cleanly back through the
+ * story-body parser, so it is paste-ready.
+ *
+ * @param {unknown} raw
+ * @returns {string|null} e.g. `{"path":"src/app.js","assumption":"refactors-existing"}`.
+ */
+export function suggestPathEntryFix(raw) {
+  if (typeof raw !== 'string') return null;
+  // Strip a leading markdown bullet marker.
+  let s = raw
+    .trim()
+    .replace(/^[-*]\s+/, '')
+    .trim();
+  // Take the segment before any humanized "— assumption" tail.
+  s = s.split('—')[0].trim();
+  // Peel surrounding backticks / quotes.
+  s = s
+    .replace(/^[`'"]+/, '')
+    .replace(/[`'"]+$/, '')
+    .trim();
+  if (s === '' || !PATH_LIKE_RE.test(s)) return null;
+  return JSON.stringify({ path: s, assumption: DEFAULT_SUGGESTED_ASSUMPTION });
+}
+
+/**
+ * A single deterministic body-format lint the persist path enforces.
+ *
+ * @typedef {object} BodyFormatLint
+ * @property {string}  id          Stable identifier (also the prompt anchor).
+ * @property {string}  summary     One-line statement of the requirement.
+ * @property {string}  badExample  A form the lint rejects.
+ * @property {string}  goodExample The lint-clean form to author instead.
+ * @property {boolean} autoFixable Whether a failing dry-run emits a fix-it.
+ */
+
+/**
+ * The enumerated deterministic lints that can reject an authored Story body at
+ * persist time. Each carries a concrete example so the story-author prompt can
+ * state the requirement example-first (Story #4684 AC-1). The two `autoFixable`
+ * lints are the mechanical rewrites whose dry-run failure carries the corrected
+ * form (AC-2).
+ *
+ * @type {ReadonlyArray<BodyFormatLint>}
+ */
+export const BODY_FORMAT_LINTS = Object.freeze([
+  {
+    id: 'body-is-string',
+    summary:
+      'The Story `body` MUST be the serialized markdown string produced by `serialize()`, never a JSON object.',
+    badExample: '"body": { "goal": "…" }',
+    goodExample: '"body": "## Goal\\n…"',
+    autoFixable: false,
+  },
+  {
+    id: 'goal-non-empty',
+    summary: 'The body MUST open with a non-empty `## Goal` sentence.',
+    badExample: '## Goal\n\n## Spec',
+    goodExample:
+      '## Goal\nExchange short-lived JWTs so sessions survive a restart.',
+    autoFixable: false,
+  },
+  {
+    id: 'changes-path-entry-shape',
+    summary:
+      'Every `## Changes` / `## References` bullet MUST be a `{ path, assumption }` object (assumption ∈ ' +
+      `${FILE_ASSUMPTION_VALUES.join(' | ')}); plain path strings are rejected.`,
+    badExample: '- src/app.js',
+    goodExample: '- {"path": "src/app.js", "assumption": "refactors-existing"}',
+    autoFixable: true,
+  },
+  {
+    id: 'changes-non-empty',
+    summary: 'A Story MUST declare at least one `## Changes` bullet.',
+    badExample: '## Changes\n\n## Acceptance',
+    goodExample: '- {"path": "src/app.js", "assumption": "creates"}',
+    autoFixable: false,
+  },
+  {
+    id: 'verify-tier-suffix',
+    summary:
+      'Every `verify[]` entry MUST end with a tier in parentheses — one of ' +
+      `(${INFERABLE_VERIFY_TIERS.join(' | ')}) — or be a \`manual:<reason>\` escape.`,
+    badExample: 'npm test -- src/app.test.js',
+    goodExample: 'npm test -- src/app.test.js (unit)',
+    autoFixable: true,
+  },
+  {
+    id: 'verify-non-empty',
+    summary:
+      'A Story MUST list at least one `verify[]` entry (use `manual:<reason>` only when truly unverifiable in isolation).',
+    badExample: '"verify": []',
+    goodExample: '"verify": ["npm run validate (validate)"]',
+    autoFixable: false,
+  },
+  {
+    id: 'verify-manual-reason',
+    summary:
+      'A `manual:` verify entry MUST carry a reason after the colon; a bare `manual:` is rejected.',
+    badExample: 'manual:',
+    goodExample: 'manual: copy-only edit an auditor eyeballs',
+    autoFixable: false,
+  },
+  {
+    id: 'acceptance-non-empty',
+    summary:
+      'A Story MUST list at least one observable `acceptance[]` criterion.',
+    badExample: '"acceptance": []',
+    goodExample: '"acceptance": ["`npm run build` exits 0"]',
+    autoFixable: false,
+  },
+]);

--- a/.agents/scripts/lib/story-body/story-body.js
+++ b/.agents/scripts/lib/story-body/story-body.js
@@ -48,6 +48,7 @@ import {
   authoredMarkerLine,
 } from '../framework-version.js';
 import { FILE_ASSUMPTION_VALUES } from '../orchestration/file-assumption-enum.js';
+import { suggestPathEntryFix } from './body-format-lints.js';
 
 // ---------------------------------------------------------------------------
 // Public types (JSDoc only — no runtime schema file)
@@ -229,7 +230,7 @@ function parsePathEntry(raw, warnings) {
     }
     // Recognized the humanized shape but the fields are invalid: fail closed.
     throw new StoryBodyParseError(
-      `changes/references entry is a humanized bullet but not a valid PathEntry: ${str.slice(0, 120)}`,
+      `changes/references entry is a humanized bullet but not a valid PathEntry: ${str.slice(0, 120)}${pathEntryFixIt(str)}`,
       { field: 'changes', raw: str },
     );
   }
@@ -261,9 +262,24 @@ function parsePathEntry(raw, warnings) {
   }
 
   throw new StoryBodyParseError(
-    `changes/references entry must be a { path, assumption } object; plain string bullets are no longer accepted: ${str.slice(0, 120)}`,
+    `changes/references entry must be a { path, assumption } object; plain string bullets are no longer accepted: ${str.slice(0, 120)}${pathEntryFixIt(str)}`,
     { field: 'changes', raw: str },
   );
+}
+
+/**
+ * Build the ` Suggested fix: …` suffix for a rejected changes/references
+ * bullet, when a `{ path, assumption }` object can be salvaged from it. Returns
+ * an empty string when nothing is inferable, so callers can append it
+ * unconditionally (Story #4684 — mechanical auto-fix in the failure output).
+ *
+ * @param {string} raw The rejected bullet text.
+ * @returns {string}
+ */
+function pathEntryFixIt(raw) {
+  const suggestion = suggestPathEntryFix(raw);
+  if (suggestion === null) return '';
+  return ` — Suggested fix: ${suggestion} (adjust the assumption to creates|deletes if this is a new file or a removal).`;
 }
 
 /**

--- a/.agents/scripts/lib/templates/decomposer-prompts.js
+++ b/.agents/scripts/lib/templates/decomposer-prompts.js
@@ -5,6 +5,7 @@ import {
   DELIVERABLE_GRANULARITY_GUIDANCE,
   resolveCapacityCeilings,
 } from '../orchestration/ticket-validator-sizing.js';
+import { BODY_FORMAT_LINTS } from '../story-body/body-format-lints.js';
 
 /**
  * Sole source of truth for the prompt's `maxTickets` cap is the resolved
@@ -63,6 +64,15 @@ function render2TierPrompt({ maxTickets }) {
     advisoryCaveat,
     newFileContract,
   } = AUTHORING_ALTITUDE_GUIDANCE;
+  // The deterministic body-format lints (structured `## Changes` bullet shape,
+  // verify-tier suffixes, …) rendered example-first from their single source
+  // (`lib/story-body/body-format-lints.js`) so an authored draft is lint-clean
+  // by construction rather than discovered as a persist dry-run failure and
+  // re-authored at resident-context prices (Story #4684).
+  const bodyFormatLintChecklist = BODY_FORMAT_LINTS.map(
+    (lint) =>
+      `- **${lint.id}** — ${lint.summary} Example: \`${lint.goodExample}\``,
+  ).join('\n');
   return `You are an expert Senior Project Manager and Orchestrator.
 Your job is to turn a plan seed / Tech Spec into a Story ticket array for an AI Agent to execute.
 
@@ -151,6 +161,12 @@ The serialized \`body\` string renders these markdown sections (in order):
 - **Slicing checkpoints are one line each.** Each \`## Slicing\` checkpoint is a single line naming the checkpoint; implementation detail lives in \`## Spec\`, never duplicated into Slicing. A Slicing section outweighing its Spec is a defect the text-hygiene lint flags.
 - **Bodies record decisions, never questions to the operator.** Never persist an open question ("Flag if…", "TBD", "confirm with the operator") into a Story body — the executing sub-agent is non-interactive and cannot answer it. Resolve the unknown before authoring, or restate it as a declarative Key Assumption the agent can act on.
 - **non_goals** (OPTIONAL, in body string as the \`## Non-Goals\` section): A short list of capabilities or changes this Story explicitly does NOT deliver — an advisory negative-scope bound that fences the executing agent away from adjacent work. It is **advisory and NON-GATING**: the validator does not require, count, or reject on it, and an absent or empty section renders nothing. Use the EXACT single-word hyphenated heading spelling \`## Non-Goals\` (a space-separated heading like \`## Out of Scope\` is NOT recognized by the parser and will be dropped). Reach for it when a Story's negative boundary is non-obvious from its \`acceptance[]\` alone; omit it otherwise.
+
+#### DETERMINISTIC BODY-FORMAT LINTS — author lint-clean by construction:
+
+Persist enforces the deterministic body-format rules below and **rejects** an authored body that violates any of them. Author every Story to satisfy all of them on the FIRST draft — each rule is stated example-first so there is nothing to discover by trial-and-error. The two auto-fixable rules (\`changes-path-entry-shape\`, \`verify-tier-suffix\`) also emit the corrected form in the dry-run failure output, but authoring them right up front avoids the round-trip entirely.
+
+${bodyFormatLintChecklist}
 
 #### AUTHORING ALTITUDE — BINDING ACCEPTANCE vs ADVISORY CHANGES:
 

--- a/tests/lib/story-body/body-format-lints.test.js
+++ b/tests/lib/story-body/body-format-lints.test.js
@@ -1,0 +1,259 @@
+/**
+ * body-format-lints — the deterministic body-format lint registry, the
+ * mechanical auto-fix helpers, and their two contracts (Story #4684):
+ *   AC-1: every enumerated rejecting lint has an example-carrying instruction
+ *         in the story-author (decomposer) system prompt.
+ *   AC-2: the mechanical rewrites (Changes bullet shape, inferable verify tier)
+ *         surface the corrected form in the failing dry-run/validation output.
+ */
+
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import {
+  VERIFY_TIER_VALUES,
+  validateTaskBodyShape,
+} from '../../../.agents/scripts/lib/orchestration/task-body-validator.js';
+import {
+  BODY_FORMAT_LINTS,
+  suggestPathEntryFix,
+  suggestVerifyFix,
+} from '../../../.agents/scripts/lib/story-body/body-format-lints.js';
+import {
+  parse,
+  StoryBodyParseError,
+} from '../../../.agents/scripts/lib/story-body/story-body.js';
+import { renderDecomposerSystemPrompt } from '../../../.agents/scripts/lib/templates/decomposer-prompts.js';
+
+describe('BODY_FORMAT_LINTS registry', () => {
+  it('is non-empty and each entry is fully specified', () => {
+    assert.ok(BODY_FORMAT_LINTS.length >= 5);
+    for (const lint of BODY_FORMAT_LINTS) {
+      for (const field of ['id', 'summary', 'badExample', 'goodExample']) {
+        assert.equal(
+          typeof lint[field],
+          'string',
+          `lint ${lint.id} missing ${field}`,
+        );
+        assert.ok(
+          lint[field].trim().length > 0,
+          `lint ${lint.id}.${field} empty`,
+        );
+      }
+      assert.equal(typeof lint.autoFixable, 'boolean');
+    }
+  });
+
+  it('covers the known rejecting lints, including the two auto-fixable ones', () => {
+    const ids = new Set(BODY_FORMAT_LINTS.map((l) => l.id));
+    for (const required of [
+      'changes-path-entry-shape',
+      'verify-tier-suffix',
+      'verify-non-empty',
+      'acceptance-non-empty',
+    ]) {
+      assert.ok(ids.has(required), `registry is missing lint "${required}"`);
+    }
+    const autoFixable = BODY_FORMAT_LINTS.filter((l) => l.autoFixable).map(
+      (l) => l.id,
+    );
+    assert.deepEqual(autoFixable.sort(), [
+      'changes-path-entry-shape',
+      'verify-tier-suffix',
+    ]);
+  });
+
+  it('only ever infers tiers the validator actually accepts', () => {
+    // The tier inference lives in body-format-lints to avoid an import cycle
+    // with the validator, so pin every tier it can emit to the validator
+    // vocabulary through the public suggestVerifyFix surface.
+    const commands = [
+      'npm run validate',
+      'node --test tests/x.test.js',
+      'npx playwright test',
+      'run the contract suite',
+    ];
+    for (const cmd of commands) {
+      const fixed = suggestVerifyFix(cmd);
+      const tier = fixed?.match(/\(([^)]+)\)\s*$/)?.[1];
+      assert.ok(tier, `no tier inferred for "${cmd}"`);
+      assert.ok(
+        VERIFY_TIER_VALUES.includes(tier),
+        `inferred tier "${tier}" is not a valid verify tier`,
+      );
+    }
+  });
+});
+
+describe('AC-1: every rejecting lint is stated example-first in the author prompt', () => {
+  const prompt = renderDecomposerSystemPrompt();
+
+  it('names each lint id and renders each good example verbatim', () => {
+    for (const lint of BODY_FORMAT_LINTS) {
+      assert.ok(
+        prompt.includes(lint.id),
+        `prompt does not name lint "${lint.id}"`,
+      );
+      assert.ok(
+        prompt.includes(lint.goodExample),
+        `prompt does not carry the example for lint "${lint.id}"`,
+      );
+    }
+  });
+
+  it('renders the checklist bullet for each lint into the prompt', () => {
+    for (const lint of BODY_FORMAT_LINTS) {
+      assert.ok(
+        prompt.includes(`**${lint.id}** — ${lint.summary}`),
+        `prompt is missing the checklist bullet for "${lint.id}"`,
+      );
+    }
+  });
+});
+
+describe('AC-2: suggestVerifyFix infers the tier from the command', () => {
+  it('appends the inferred tier to a bare command', () => {
+    assert.equal(
+      suggestVerifyFix('npm run validate'),
+      'npm run validate (validate)',
+    );
+    assert.equal(
+      suggestVerifyFix('node --test tests/x.test.js'),
+      'node --test tests/x.test.js (unit)',
+    );
+    assert.equal(suggestVerifyFix('npx vitest run'), 'npx vitest run (unit)');
+    assert.equal(
+      suggestVerifyFix('npx playwright test'),
+      'npx playwright test (e2e)',
+    );
+    assert.equal(
+      suggestVerifyFix('run tests/e2e/login.spec.ts'),
+      'run tests/e2e/login.spec.ts (e2e)',
+    );
+  });
+
+  it('returns null when no confident tier inference is possible', () => {
+    assert.equal(suggestVerifyFix('do the thing'), null);
+    assert.equal(suggestVerifyFix(''), null);
+    assert.equal(suggestVerifyFix(42), null);
+  });
+
+  it('replaces a wrong/partial tier suffix rather than doubling it', () => {
+    assert.equal(
+      suggestVerifyFix('npx vitest run (smoke)'),
+      'npx vitest run (unit)',
+    );
+  });
+
+  it('declines manual entries and non-inferable commands', () => {
+    assert.equal(suggestVerifyFix('manual: reviewer eyeballs it'), null);
+    assert.equal(suggestVerifyFix('do the thing'), null);
+  });
+});
+
+describe('AC-2: suggestPathEntryFix', () => {
+  it('proposes a paste-ready { path, assumption } object that round-trips', () => {
+    const fix = suggestPathEntryFix('- src/app.js');
+    assert.equal(
+      fix,
+      '{"path":"src/app.js","assumption":"refactors-existing"}',
+    );
+    // Round-trip: the suggestion parses cleanly back through the story body.
+    const body = [
+      '## Goal',
+      'G',
+      '',
+      '## Changes',
+      `- ${fix}`,
+      '',
+      '## Acceptance',
+      '- [ ] x',
+      '',
+      '## Verify',
+      '- npm run validate (validate)',
+    ].join('\n');
+    const { body: parsed } = parse(body);
+    assert.deepEqual(parsed.changes, [
+      { path: 'src/app.js', assumption: 'refactors-existing' },
+    ]);
+  });
+
+  it('salvages the path from a humanized bullet with a bad assumption', () => {
+    assert.equal(
+      suggestPathEntryFix('`src/app.js` — modified'),
+      '{"path":"src/app.js","assumption":"refactors-existing"}',
+    );
+  });
+
+  it('returns null when there is no path-shaped token', () => {
+    assert.equal(suggestPathEntryFix('clean up the code'), null);
+    assert.equal(suggestPathEntryFix(''), null);
+  });
+});
+
+describe('AC-2: the failing lint output carries the corrected form', () => {
+  it('story-body parser rejects a bare Changes bullet WITH a suggested fix', () => {
+    const body = [
+      '## Goal',
+      'G',
+      '',
+      '## Changes',
+      '- src/app.js',
+      '',
+      '## Acceptance',
+      '- [ ] x',
+      '',
+      '## Verify',
+      '- npm run validate (validate)',
+    ].join('\n');
+    assert.throws(
+      () => parse(body),
+      (err) => {
+        assert.ok(err instanceof StoryBodyParseError);
+        assert.match(err.message, /Suggested fix:/);
+        assert.match(err.message, /"path":"src\/app\.js"/);
+        assert.match(err.message, /"assumption":"refactors-existing"/);
+        return true;
+      },
+    );
+  });
+
+  it('validator rejects a tier-less verify entry WITH a suggested fix', () => {
+    const errors = validateTaskBodyShape({
+      type: 'story',
+      slug: 'demo',
+      title: 'Demo',
+      body: {
+        goal: 'G',
+        changes: [{ path: 'src/app.js', assumption: 'refactors-existing' }],
+        acceptance: ['x'],
+        verify: ['npm run validate'],
+      },
+    });
+    const verifyError = errors.find((e) => e.includes('body.verify entry'));
+    assert.ok(
+      verifyError,
+      `expected a verify error, got: ${errors.join('\n')}`,
+    );
+    assert.match(verifyError, /Suggested fix: "npm run validate \(validate\)"/);
+  });
+
+  it('validator rejects a string Changes bullet WITH a suggested fix', () => {
+    const errors = validateTaskBodyShape({
+      type: 'story',
+      slug: 'demo',
+      title: 'Demo',
+      body: {
+        goal: 'G',
+        changes: ['src/app.js'],
+        acceptance: ['x'],
+        verify: ['npm run validate (validate)'],
+      },
+    });
+    const changesError = errors.find((e) => e.includes('body.changes entry'));
+    assert.ok(
+      changesError,
+      `expected a changes error, got: ${errors.join('\n')}`,
+    );
+    assert.match(changesError, /Suggested fix: \{"path":"src\/app\.js"/);
+  });
+});

--- a/tests/scripts/plan-persist.author-lint-clean.test.js
+++ b/tests/scripts/plan-persist.author-lint-clean.test.js
@@ -1,0 +1,107 @@
+/**
+ * AC-3 (Story #4684): a Story body hand-authored following only the
+ * story-author system prompt — the deterministic body-format lints stated
+ * example-first — passes `plan-persist --dry-run` on the FIRST attempt, with no
+ * fail-retry round-trip. The dry-run exercises the same validator / parser /
+ * assemble gates a real persist runs, write-free.
+ */
+
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import { runPlanPersist } from '../../.agents/scripts/lib/orchestration/plan-persist/run-plan-persist.js';
+
+/** Minimal write-capturing provider — dry-run must touch none of it. */
+function fakeProvider() {
+  const created = [];
+  return {
+    created,
+    async createIssue(args) {
+      created.push(args);
+      return { id: 9000 + created.length, url: 'https://example.test/x' };
+    },
+    async updateTicket() {},
+    async postComment() {
+      return { commentId: 1, id: 1 };
+    },
+    async getTicket(id) {
+      return { id, state: 'open', body: '', labels: [] };
+    },
+    async listIssuesByLabel() {
+      return [];
+    },
+    async getTicketComments() {
+      return [];
+    },
+  };
+}
+
+/**
+ * A Story authored exactly as the prompt prescribes: `acceptance[]` / `verify[]`
+ * at top level, a `body` string with `## Goal` + object-form `## Changes`
+ * bullets + a `reason_to_exist` meta, and the matching body sections omitted so
+ * persist syncs them in. Every deterministic lint is satisfied up front.
+ */
+function promptAuthoredStory() {
+  const body = [
+    '## Goal',
+    'Exchange short-lived JWTs so a session survives a server restart.',
+    '',
+    '## Spec',
+    'Add a token-exchange seam behind the existing auth boundary.',
+    '',
+    '## Changes',
+    '- {"path": "tests/scripts/plan-persist.flat-stories.test.js", "assumption": "refactors-existing"}',
+    '',
+    '<!-- meta: {"reason_to_exist": "One coherent JWT-exchange capability (b: isolates the token-exchange cutover)"} -->',
+  ].join('\n');
+
+  return {
+    slug: 'jwt-exchange',
+    type: 'story',
+    title: 'Implement JWT token exchange',
+    acceptance: ['`npm run validate` exits 0 after the exchange lands'],
+    verify: ['npm run validate (validate)'],
+    body,
+  };
+}
+
+describe('AC-3: a prompt-authored Story passes dry-run on the first attempt', () => {
+  it('assembles and validates write-free without throwing', async () => {
+    const provider = fakeProvider();
+    const result = await runPlanPersist({
+      provider,
+      artifacts: { stories: [promptAuthoredStory()] },
+      config: {},
+      opts: { dryRun: true, skipCleanup: true },
+    });
+
+    assert.equal(result.stories.length, 1);
+    // Dry-run never writes: the fake provider's createIssue is untouched.
+    assert.equal(provider.created.length, 0);
+  });
+
+  it('is the format that fails when the two mechanical lints are violated (control)', async () => {
+    // Same Story, but authored the way the bench evidence captured: a bare-path
+    // Changes bullet and a tier-less verify entry. Persist must reject it —
+    // proving the dry-run above passes because the format is correct, not
+    // because the gates are inert.
+    const broken = promptAuthoredStory();
+    broken.verify = ['npm run validate'];
+    broken.body = broken.body.replace(
+      '- {"path": "tests/scripts/plan-persist.flat-stories.test.js", "assumption": "refactors-existing"}',
+      '- tests/scripts/plan-persist.flat-stories.test.js',
+    );
+
+    await assert.rejects(
+      () =>
+        runPlanPersist({
+          provider: fakeProvider(),
+          artifacts: { stories: [broken] },
+          config: {},
+          opts: { dryRun: true, skipCleanup: true },
+        }),
+      /Suggested fix/,
+    );
+  });
+});


### PR DESCRIPTION
Closes #4684

_Auto-opened by `/deliver`._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to orchestration authoring/validation and prompt text, with broad test coverage and no runtime auth or data-path impact.
> 
> **Overview**
> Adds **`body-format-lints.js`** as the single source for persist-time Story body rules (`BODY_FORMAT_LINTS`) and for **`suggestPathEntryFix`** / **`suggestVerifyFix`**, so authors get paste-ready corrections instead of bare rejections.
> 
> The **decomposer system prompt** now renders that registry example-first so first drafts aim to be lint-clean. **`story-body.js`** and **`task-body-validator.js`** call the suggest helpers on **`## Changes`** string bullets and **tier-less `verify[]`** entries, appending **Suggested fix** text to parse/validation errors. Local path/vague-verb helpers were removed from the validator in favor of the shared module (cycle-safe imports).
> 
> **Tests** lock AC-1 (every lint id + good example in the prompt), AC-2 (suggestions in failure output), and AC-3 (prompt-shaped Story passes **`plan-persist --dry-run`** on the first try).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bc674dbdf9639923ec55ca876d3dd54ee2eab5c5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->