### PR TITLE
perf: quiet the hot-path orchestration script stdout: terse structured results to the agent, details to disk (#4685)

### DIFF
--- a/.agents/scripts/lib/observability/terse-result.js
+++ b/.agents/scripts/lib/observability/terse-result.js
@@ -1,0 +1,114 @@
+import nodeFs from 'node:fs';
+import path from 'node:path';
+
+import { Logger } from '../Logger.js';
+
+/**
+ * Terse hot-path result emission (Story #4685).
+ *
+ * The orchestration CLIs an agent invokes on every delivery turn
+ * (`single-story-init`, `single-story-close`, `single-story-confirm-merge`,
+ * `sync-branch-from-base`, the close `emit-blocked` path) historically dumped
+ * their whole result object to stdout as pretty-printed JSON:
+ *
+ *   --- STORY CLOSE RESULT ---
+ *   { ... every field, 2-space indented ... }
+ *   --- END RESULT ---
+ *
+ * That blob stays resident for the rest of the session and is re-read as
+ * cache every subsequent turn, yet the agent acts on only a handful of its
+ * fields (the machine contract is the separate terminal envelope). This helper
+ * routes the full detail to a temp log the agent can read on demand and emits
+ * a single structured summary line in its place.
+ *
+ * The escape hatch `MANDREL_RESULT_DETAIL=inline` restores the old inline
+ * pretty dump for interactive debugging.
+ */
+
+/** Env var that restores the legacy inline pretty dump when set to `inline`. */
+const RESULT_DETAIL_ENV = 'MANDREL_RESULT_DETAIL';
+
+/**
+ * Turn a human label (`STORY CLOSE RESULT`) into a filesystem-safe log
+ * basename fragment (`story-close-result`).
+ *
+ * @param {string} label
+ * @returns {string}
+ */
+function slugify(label) {
+  return (
+    String(label)
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, '-')
+      .replace(/^-+|-+$/g, '') || 'result'
+  );
+}
+
+/**
+ * The full detail block, byte-compatible with the legacy dump the hot-path
+ * scripts used to write to stdout — same markers, same pretty JSON — so a log
+ * a human opens reads exactly as the old inline dump did.
+ *
+ * @param {string} label
+ * @param {unknown} result
+ * @returns {string}
+ */
+function detailBlock(label, result) {
+  return `--- ${label} ---\n${JSON.stringify(result, null, 2)}\n--- END RESULT ---`;
+}
+
+/**
+ * Route a verbose result object off the agent's turn-resident stdout: write the
+ * full pretty detail to a temp log and emit a single-line structured summary in
+ * its place.
+ *
+ * @param {object} args
+ * @param {string} args.label Human label for the result (e.g. `STORY CLOSE RESULT`).
+ * @param {unknown} args.result The full result object; pretty-printed to the log.
+ * @param {Record<string, unknown>} [args.summary] The few fields the agent acts
+ *   on; serialized compactly onto the single summary line.
+ * @param {string|number} [args.scope] Disambiguating suffix for the log name
+ *   (typically the Story id) so concurrent deliveries don't clobber one file.
+ * @param {string} [args.logDir] Directory for the detail log. Defaults to
+ *   `<cwd>/temp/orchestration`.
+ * @param {typeof nodeFs} [args.fs] Filesystem seam (tests).
+ * @param {{ info: (m: string) => void }} [args.log] Logger seam (tests).
+ * @param {NodeJS.ProcessEnv} [args.env] Environment seam (tests).
+ * @returns {{ logPath: string|null, inline: boolean, error?: string }}
+ */
+export function emitTerseResult({
+  label,
+  result,
+  summary = {},
+  scope,
+  logDir,
+  fs = nodeFs,
+  log = Logger,
+  env = process.env,
+} = {}) {
+  const body = detailBlock(label, result);
+
+  // Escape hatch: restore the full inline pretty dump for interactive debugging.
+  if (String(env[RESULT_DETAIL_ENV] ?? '').toLowerCase() === 'inline') {
+    log.info?.(`\n${body}\n`);
+    return { logPath: null, inline: true };
+  }
+
+  const dir = logDir ?? path.join(process.cwd(), 'temp', 'orchestration');
+  const name = `${slugify(label)}${scope ? `-${scope}` : ''}.log`;
+
+  try {
+    fs.mkdirSync(dir, { recursive: true });
+    const logPath = path.join(dir, name);
+    fs.writeFileSync(logPath, `${body}\n`);
+    log.info?.(
+      `${label} · ${JSON.stringify(summary)} · full detail → ${logPath}`,
+    );
+    return { logPath, inline: false };
+  } catch (err) {
+    // Never lose detail: if the log write fails, fall back to the inline dump
+    // so the result is still recoverable from the transcript.
+    log.info?.(`\n${body}\n`);
+    return { logPath: null, inline: true, error: err?.message ?? String(err) };
+  }
+}

--- a/.agents/scripts/lib/orchestration/single-story-close/runner.js
+++ b/.agents/scripts/lib/orchestration/single-story-close/runner.js
@@ -7,6 +7,7 @@ import { resolveConfig } from '../../config-resolver.js';
 import { getStoryBranch, gitSync } from '../../git-utils.js';
 import { Logger } from '../../Logger.js';
 import { emitTerminalFriction } from '../../observability/runtime-friction.js';
+import { emitTerseResult } from '../../observability/terse-result.js';
 import { createProvider } from '../../provider-factory.js';
 import { flipLabelAndNotify } from '../../single-story/story-merged-notify.js';
 import { WorktreeManager } from '../../worktree-manager.js';
@@ -53,12 +54,22 @@ const progress = Logger.createProgress('single-story-close', { stderr: true });
  * The emit is best-effort internally and cannot throw.
  */
 async function emitTerminal({ terminal, result, config }) {
-  // The human-facing result dump stays level-gated; the terminal envelope is
-  // the machine contract and must survive AGENT_LOG_LEVEL=silent.
+  // Story #4685 — the human-facing result dump goes to a temp log; the agent
+  // acts on the (separate, unsuppressible) terminal envelope emitted below.
+  // The single summary line keeps the fields worth an at-a-glance read.
   if (result) {
-    Logger.info(
-      `\n--- STORY CLOSE RESULT ---\n${JSON.stringify(result, null, 2)}\n--- END RESULT ---\n`,
-    );
+    emitTerseResult({
+      label: 'STORY CLOSE RESULT',
+      result,
+      scope: result.storyId,
+      summary: {
+        storyId: result.storyId,
+        action: result.action,
+        reason: result.reason,
+        prNumber: result.prNumber,
+        status: terminal?.status,
+      },
+    });
   }
   emitTerminalEnvelope(terminal);
   await emitTerminalFriction({ envelope: terminal, config });

--- a/.agents/scripts/lib/orchestration/story-close/emit-blocked.js
+++ b/.agents/scripts/lib/orchestration/story-close/emit-blocked.js
@@ -5,6 +5,7 @@
  */
 
 import { Logger } from '../../Logger.js';
+import { emitTerseResult } from '../../observability/terse-result.js';
 
 /**
  * Best-effort `story.blocked` lifecycle emit. The bus is optional and emit
@@ -41,9 +42,14 @@ export async function emitBlockedCloseResult({
 }) {
   const result = { success: false, status: 'blocked', phase, reason, ...extra };
   await emitStoryBlockedSafe({ bus, storyId, reason, logger });
-  logger.info?.(
-    `\n--- STORY CLOSE RESULT ---\n${JSON.stringify(result, null, 2)}\n--- END RESULT ---\n`,
-  );
+  // Story #4685 — full detail to a temp log; single summary line in its place.
+  emitTerseResult({
+    label: 'STORY CLOSE RESULT',
+    result,
+    scope: storyId,
+    summary: { storyId, status: 'blocked', phase, reason },
+    log: logger,
+  });
   progress('BLOCKED', blockedMessage);
   return result;
 }

--- a/.agents/scripts/lib/orchestration/story-deliver-terminal.js
+++ b/.agents/scripts/lib/orchestration/story-deliver-terminal.js
@@ -263,8 +263,11 @@ export function emitTerminalEnvelope(
   envelope,
   { write = (s) => process.stdout.write(s) } = {},
 ) {
+  // Story #4685 — compact (not 2-space pretty) JSON. The envelope is a
+  // machine contract callers recover with `JSON.parse`, so pretty-printing
+  // only adds turn-resident bytes without helping any consumer.
   write(
-    `\n${TERMINAL_BEGIN_MARKER}\n${JSON.stringify(envelope, null, 2)}\n${TERMINAL_END_MARKER}\n`,
+    `\n${TERMINAL_BEGIN_MARKER}\n${JSON.stringify(envelope)}\n${TERMINAL_END_MARKER}\n`,
   );
 }
 

--- a/.agents/scripts/single-story-confirm-merge.js
+++ b/.agents/scripts/single-story-confirm-merge.js
@@ -44,6 +44,7 @@ import { gh as defaultGh } from './lib/gh-exec.js';
 import { getStoryBranch } from './lib/git-utils.js';
 import { Logger } from './lib/Logger.js';
 import { emitTerminalFriction } from './lib/observability/runtime-friction.js';
+import { emitTerseResult } from './lib/observability/terse-result.js';
 import { MERGED_FLIP_FAILED_BLOCK_CLASS } from './lib/orchestration/lifecycle/emit-merge-flip-failed.js';
 import { parsePrNumber } from './lib/orchestration/single-story-close/phases/code-review.js';
 import { runConfirmMergePhase as defaultRunConfirmMergePhase } from './lib/orchestration/single-story-close/phases/confirm-merge.js';
@@ -142,11 +143,19 @@ async function resolvePrNumber({ cwd, storyBranch, gh }) {
  * exits via `process.exit` the moment `main` resolves.
  */
 async function logConfirmResult(result, terminal, config) {
-  // Human-facing dump stays level-gated; the envelope is the machine
-  // contract and must survive AGENT_LOG_LEVEL=silent.
-  Logger.info(
-    `\n--- CONFIRM MERGE RESULT ---\n${JSON.stringify(result, null, 2)}\n--- END RESULT ---\n`,
-  );
+  // Story #4685 — full detail to a temp log; the agent acts on the terminal
+  // envelope emitted below. The summary line keeps the at-a-glance fields.
+  emitTerseResult({
+    label: 'CONFIRM MERGE RESULT',
+    result,
+    scope: result?.storyId,
+    summary: {
+      storyId: result?.storyId,
+      action: result?.action,
+      reason: result?.reason,
+      status: terminal?.status,
+    },
+  });
   emitTerminalEnvelope(terminal);
   await emitTerminalFriction({ envelope: terminal, config });
   return { success: terminal.status !== 'failed', result, terminal };

--- a/.agents/scripts/single-story-init.js
+++ b/.agents/scripts/single-story-init.js
@@ -55,6 +55,7 @@ import { getStoryBranch, gitSpawn, gitSync } from './lib/git-utils.js';
 import { Logger } from './lib/Logger.js';
 import { TYPE_LABELS } from './lib/label-constants.js';
 import { setActiveStoryEnv } from './lib/observability/active-story-env.js';
+import { emitTerseResult } from './lib/observability/terse-result.js';
 import {
   executeFastForward,
   planFastForward,
@@ -769,9 +770,24 @@ export async function runSingleStoryInit({
     }
   }
 
-  Logger.info('\n--- STORY INIT RESULT ---');
-  Logger.info(JSON.stringify(result, null, 2));
-  Logger.info('--- END RESULT ---\n');
+  // Story #4685 — route the full result to a temp log and emit a single-line
+  // summary carrying the fields the orchestrating agent acts on (workCwd,
+  // remoteVerified). The `## Spec` names this the hot-path stdout to quiet.
+  emitTerseResult({
+    label: 'STORY INIT RESULT',
+    result,
+    scope: storyId,
+    logDir: path.join(cwd, 'temp', 'orchestration'),
+    summary: {
+      storyId,
+      storyBranch,
+      workCwd,
+      worktreeCreated,
+      dependenciesInstalled,
+      remoteVerified: result.remoteVerified,
+      dryRun,
+    },
+  });
   progress(
     'DONE',
     dryRun

--- a/.agents/scripts/sync-branch-from-base.js
+++ b/.agents/scripts/sync-branch-from-base.js
@@ -34,6 +34,7 @@ import { runAsCli } from './lib/cli-utils.js';
 import { syncBranchFromBase } from './lib/git/sync-from-base.js';
 import { gitSpawn, gitSync } from './lib/git-utils.js';
 import { Logger } from './lib/Logger.js';
+import { emitTerseResult } from './lib/observability/terse-result.js';
 import { PROJECT_ROOT } from './lib/project-root.js';
 
 const progress = Logger.createProgress('sync-branch-from-base', {
@@ -93,9 +94,14 @@ export async function runSyncBranchFromBase(opts = {}) {
     gitSpawn,
   });
 
-  Logger.info(
-    `\n--- SYNC RESULT ---\n${JSON.stringify(result, null, 2)}\n--- END RESULT ---\n`,
-  );
+  // Story #4685 — full detail to a temp log; emit a single summary line.
+  emitTerseResult({
+    label: 'SYNC RESULT',
+    result,
+    scope: branch,
+    logDir: path.join(cwd, 'temp', 'orchestration'),
+    summary: { branch, base, synced: result.synced, kind: result.kind },
+  });
 
   if (!result.synced) {
     const detail =

--- a/tests/contract/story-deliver-terminal.test.js
+++ b/tests/contract/story-deliver-terminal.test.js
@@ -353,6 +353,9 @@ describe('emitTerminalEnvelope — the contract payload is not level-gated', () 
       .split(TERMINAL_BEGIN_MARKER)[1]
       .split(TERMINAL_END_MARKER)[0];
     assert.deepEqual(JSON.parse(body), envelope);
+    // Story #4685 — the contract payload is compact (single-line), not the
+    // former 2-space pretty JSON, so it stops paying per-turn cache rent.
+    assert.equal(body.trim().split('\n').length, 1, 'envelope JSON is compact');
   });
 
   it('still emits under AGENT_LOG_LEVEL=silent', () => {

--- a/tests/observability/hot-path-terse-wiring.test.js
+++ b/tests/observability/hot-path-terse-wiring.test.js
@@ -1,0 +1,50 @@
+/**
+ * tests/observability/hot-path-terse-wiring.test.js — Story #4685.
+ *
+ * Per-script guard: every hot-path orchestration script an agent invokes on a
+ * delivery turn routes its result dump through `emitTerseResult` (single-line
+ * summary + detail-to-disk) rather than dumping pretty JSON straight to
+ * stdout. A regression that reintroduces an inline
+ * `--- … RESULT ---\n${JSON.stringify(x, null, 2)}` dump on the hot path fails
+ * here, keeping the "terse by default" contract from silently rotting.
+ */
+
+import assert from 'node:assert/strict';
+import nodeFs from 'node:fs';
+import path from 'node:path';
+import { describe, it } from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+const REPO_ROOT = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '../..',
+);
+
+/** Hot-path scripts that previously dumped a verbose result to stdout. */
+const HOT_PATH_SCRIPTS = [
+  '.agents/scripts/single-story-init.js',
+  '.agents/scripts/single-story-confirm-merge.js',
+  '.agents/scripts/sync-branch-from-base.js',
+  '.agents/scripts/lib/orchestration/single-story-close/runner.js',
+  '.agents/scripts/lib/orchestration/story-close/emit-blocked.js',
+];
+
+/** An inline pretty-printed result dump straight to a logger — the anti-pattern. */
+const INLINE_DUMP =
+  /--- [A-Z ]*RESULT ---[\s\S]*?JSON\.stringify\([^,]+,\s*null,\s*2\)/;
+
+describe('hot-path scripts emit terse results by default', () => {
+  for (const rel of HOT_PATH_SCRIPTS) {
+    it(`${rel} routes its result dump through emitTerseResult`, () => {
+      const src = nodeFs.readFileSync(path.join(REPO_ROOT, rel), 'utf8');
+      assert.ok(
+        src.includes('emitTerseResult'),
+        `${rel} must call emitTerseResult`,
+      );
+      assert.ok(
+        !INLINE_DUMP.test(src),
+        `${rel} must not dump a pretty result envelope inline to stdout`,
+      );
+    });
+  }
+});

--- a/tests/observability/terse-result.test.js
+++ b/tests/observability/terse-result.test.js
@@ -1,0 +1,164 @@
+/**
+ * tests/observability/terse-result.test.js — Story #4685.
+ *
+ * The hot-path orchestration CLIs route their verbose result dumps through
+ * `emitTerseResult`: full pretty detail to a temp log, a single structured
+ * summary line to the agent's stdout in its place. This locks that contract
+ * (single-line default, detail-to-disk, inline escape hatch, byte reduction).
+ */
+
+import assert from 'node:assert/strict';
+import nodeFs from 'node:fs';
+import nodeOs from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, it } from 'node:test';
+
+import { emitTerseResult } from '../../.agents/scripts/lib/observability/terse-result.js';
+
+/** The env var that restores the legacy inline pretty dump (module-private). */
+const RESULT_DETAIL_ENV = 'MANDREL_RESULT_DETAIL';
+
+/** Capture Logger-shaped output into an array. */
+function captureLog() {
+  const lines = [];
+  return { lines, info: (m) => lines.push(m) };
+}
+
+const SAMPLE = {
+  storyId: 4685,
+  action: 'noop',
+  reason: 'already-closed',
+  nested: { a: 1, b: [2, 3], c: 'deep' },
+  padding: 'x'.repeat(400),
+};
+
+describe('emitTerseResult', () => {
+  let tmpDir;
+
+  beforeEach(() => {
+    tmpDir = nodeFs.mkdtempSync(path.join(nodeOs.tmpdir(), 'terse-result-'));
+  });
+
+  afterEach(() => {
+    nodeFs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('emits exactly one summary line to stdout by default', () => {
+    const log = captureLog();
+    emitTerseResult({
+      label: 'STORY CLOSE RESULT',
+      result: SAMPLE,
+      summary: { storyId: 4685, action: 'noop', status: 'landed' },
+      logDir: tmpDir,
+      log,
+      env: {},
+    });
+
+    assert.equal(log.lines.length, 1, 'exactly one line emitted');
+    const [line] = log.lines;
+    assert.ok(!line.includes('\n'), 'the summary is a single line');
+    // The fields the agent acts on are present, verbatim JSON.
+    assert.ok(line.includes('"status":"landed"'));
+    assert.ok(line.includes('STORY CLOSE RESULT'));
+    assert.ok(line.includes('full detail'));
+  });
+
+  it('writes the full pretty detail to a temp log the agent can read', () => {
+    const log = captureLog();
+    const { logPath, inline } = emitTerseResult({
+      label: 'STORY INIT RESULT',
+      result: SAMPLE,
+      scope: 4685,
+      logDir: tmpDir,
+      log,
+      env: {},
+    });
+
+    assert.equal(inline, false);
+    assert.ok(logPath, 'a log path is returned');
+    assert.ok(logPath.includes('4685'), 'scope disambiguates the filename');
+    const detail = nodeFs.readFileSync(logPath, 'utf8');
+    assert.ok(detail.includes('--- STORY INIT RESULT ---'));
+    assert.ok(detail.includes('--- END RESULT ---'));
+    // Full fidelity: every field survives to disk, pretty-printed.
+    assert.deepEqual(
+      JSON.parse(
+        detail
+          .split('--- STORY INIT RESULT ---')[1]
+          .split('--- END RESULT ---')[0],
+      ),
+      SAMPLE,
+    );
+    assert.ok(detail.includes('\n  '), 'detail log is 2-space pretty JSON');
+  });
+
+  it('materially reduces the bytes the agent sees vs the inline dump', () => {
+    const inlineLog = captureLog();
+    emitTerseResult({
+      label: 'STORY CLOSE RESULT',
+      result: SAMPLE,
+      summary: { storyId: 4685, status: 'landed' },
+      logDir: tmpDir,
+      log: inlineLog,
+      env: { [RESULT_DETAIL_ENV]: 'inline' },
+    });
+    const terseLog = captureLog();
+    emitTerseResult({
+      label: 'STORY CLOSE RESULT',
+      result: SAMPLE,
+      summary: { storyId: 4685, status: 'landed' },
+      logDir: tmpDir,
+      log: terseLog,
+      env: {},
+    });
+
+    const inlineBytes = inlineLog.lines.join('\n').length;
+    const terseBytes = terseLog.lines.join('\n').length;
+    assert.ok(
+      terseBytes < inlineBytes / 2,
+      `terse (${terseBytes}B) should be well under half of inline (${inlineBytes}B)`,
+    );
+  });
+
+  it('restores the inline pretty dump under MANDREL_RESULT_DETAIL=inline', () => {
+    const log = captureLog();
+    const { logPath, inline } = emitTerseResult({
+      label: 'SYNC RESULT',
+      result: SAMPLE,
+      logDir: tmpDir,
+      log,
+      env: { [RESULT_DETAIL_ENV]: 'inline' },
+    });
+
+    assert.equal(inline, true);
+    assert.equal(logPath, null, 'no temp log written in inline mode');
+    assert.equal(log.lines.length, 1);
+    assert.ok(log.lines[0].includes('--- SYNC RESULT ---'));
+    assert.ok(log.lines[0].includes('--- END RESULT ---'));
+  });
+
+  it('falls back to the inline dump when the log write fails (detail never lost)', () => {
+    const log = captureLog();
+    const failingFs = {
+      mkdirSync() {
+        throw new Error('EACCES: read-only temp');
+      },
+      writeFileSync() {
+        throw new Error('should not be reached');
+      },
+    };
+    const { logPath, inline, error } = emitTerseResult({
+      label: 'CONFIRM MERGE RESULT',
+      result: SAMPLE,
+      logDir: tmpDir,
+      fs: failingFs,
+      log,
+      env: {},
+    });
+
+    assert.equal(inline, true);
+    assert.equal(logPath, null);
+    assert.ok(error && error.includes('EACCES'));
+    assert.ok(log.lines[0].includes('--- CONFIRM MERGE RESULT ---'));
+  });
+});


### PR DESCRIPTION
Closes #4685

_Auto-opened by `/deliver`._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Stdout/logging-only change with inline and write-failure fallbacks; the terminal envelope contract and parsing behavior are preserved aside from removing pretty-printing.
> 
> **Overview**
> **Reduces agent session bloat** on every delivery turn by stopping hot-path orchestration CLIs from printing large pretty-printed `--- … RESULT ---` JSON blocks to stdout.
> 
> Adds **`emitTerseResult`**, which writes the legacy full detail block to `temp/orchestration/*.log` and logs **one summary line** (label + compact `summary` JSON + path to the log). **`MANDREL_RESULT_DETAIL=inline`** restores the old inline dump; failed log writes fall back to inline so nothing is lost.
> 
> **Wired on:** `single-story-init`, `single-story-close` (runner + blocked path), `single-story-confirm-merge`, and `sync-branch-from-base`.
> 
> **Terminal envelope** output is now **single-line compact JSON** (same markers, still `process.stdout.write`) so the machine contract also avoids pretty-print cache rent.
> 
> **Tests:** unit coverage for `emitTerseResult`, a hot-path wiring guard against reintroducing inline dumps, and a contract assertion that envelope JSON stays one line.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2e5208597743c5c6a2ef7e256c3ff759b4321eda. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->