### PR TITLE
feat(plan): reintroduce a per-plan-run grouping label on persisted Stories (metadata-only) (#4692)

### DIFF
--- a/.agents/instructions.md
+++ b/.agents/instructions.md
@@ -306,8 +306,9 @@ steps live inline (`acceptance[]` / `verify[]`) and the folded Tech Spec in
 `docs/`). Optional `depends_on` edges order rare multi-Story runs, resolved by
 `/deliver` from live state across plan runs and over time.
 
-- `/plan` emits one or more `type::story` issues (default N=1); there is no
-  batch label — `/deliver` takes ids and discovers the graph.
+- `/plan` emits one or more `type::story` issues (default N=1), each carrying
+  a shared `plan-run::<id>` grouping label — metadata for filtering only;
+  `/deliver` takes ids and discovers the graph, never reading the label.
 - Each Story is executed by `helpers/deliver-story` (from
   [`/deliver`](workflows/deliver.md)); the agent authors commit subjects
   directly per [`rules/git-conventions.md`](rules/git-conventions.md),

--- a/.agents/scripts/lib/orchestration/plan-persist/run-plan-persist.js
+++ b/.agents/scripts/lib/orchestration/plan-persist/run-plan-persist.js
@@ -444,7 +444,7 @@ export async function runPlanPersist({
     sourceTicketIds,
   });
 
-  const { created } = await createStoryIssues({
+  const { created, planRunLabel } = await createStoryIssues({
     provider,
     stories,
     opts: { dryRun },
@@ -551,10 +551,17 @@ export async function runPlanPersist({
   Logger.info(
     `[plan-persist] Deliver with: /deliver ${created.map((s2) => s2.id).join(' ')}`,
   );
+  // Metadata only — a GitHub filter for the cohort this run authored, never
+  // a delivery-resolution input (/deliver stays ids-only, Story #4540).
+  Logger.info(
+    `[plan-persist] Cohort grouping label: ${planRunLabel} — filter with ` +
+      `label:${planRunLabel}`,
+  );
 
   return {
     stories: created,
     primaryStoryId: primary.id,
+    planRunLabel,
     forceReview,
     reachability,
     freshness,

--- a/.agents/scripts/lib/orchestration/plan-persist/story-ops.js
+++ b/.agents/scripts/lib/orchestration/plan-persist/story-ops.js
@@ -30,11 +30,82 @@ import {
   normalizeSupersedes,
 } from './supersede-ops.js';
 
-// Story #4540 removed PLAN_RUN_LABEL_PREFIX / normalizePlanRunId /
-// planRunLabel from here. They minted an opaque random-hex label per N>1
-// plan that nothing ever deleted, and their only external consumer was the
-// (now deleted) `--run` resolver. Sibling order survives in the
-// `blocked by #N` body footers this module already writes.
+/**
+ * Label prefix grouping the Stories one plan-persist run authored.
+ *
+ * Reintroduced (Story #4692) after Story #4540 retired it: #4540 was right
+ * that batch identity is the wrong axis for *ordering delivery across runs*
+ * (`/deliver` takes ids and resolves the graph from live state — that stays),
+ * but it is the correct axis for *grouping the Stories one plan run created*
+ * so a cohort is filterable and traceable in the GitHub UI. The label is
+ * metadata only; nothing in persist or delivery reads it as a
+ * delivery-resolution input.
+ */
+export const PLAN_RUN_LABEL_PREFIX = 'plan-run::';
+
+/** Stable color for the cohort grouping label (`ensureLabels`). */
+const PLAN_RUN_LABEL_COLOR = '#C5DEF5';
+
+/** Length of the derived plan-run id (hex chars). */
+const PLAN_RUN_ID_LENGTH = 8;
+
+/**
+ * Normalize a caller-supplied plan-run token. Kept shared so human-readable
+ * ids map to one canonical label shape.
+ *
+ * @param {string} id
+ * @returns {string}
+ */
+export function normalizePlanRunId(id) {
+  const token = String(id ?? '')
+    .trim()
+    .toLowerCase()
+    .replace(/^plan-run::/, '')
+    .replace(/[^a-z0-9._-]+/g, '-');
+  if (!token) {
+    throw new Error('plan-run id requires a non-empty planRunId');
+  }
+  return token;
+}
+
+/**
+ * Build a `plan-run::<id>` label from an explicit id.
+ *
+ * Unlike the pre-#4540 shape, this never mints a random token — a random id
+ * would split a resumed persist's cohort across two labels. Derive the id
+ * from the authored artifacts via {@link derivePlanRunId} instead.
+ *
+ * @param {string} id
+ * @returns {string}
+ */
+export function planRunLabel(id) {
+  return `${PLAN_RUN_LABEL_PREFIX}${normalizePlanRunId(id)}`;
+}
+
+/**
+ * Derive the deterministic plan-run id for a cohort of assembled Stories.
+ *
+ * Hashes the **sorted** set of per-Story plan fingerprints (the same
+ * content identities the resumable-create contract adopts on), so the id is
+ * a pure function of the authored artifacts: the same `stories.json` yields
+ * the same `plan-run::<id>` on every run — a persist resumed after a
+ * mid-run failure applies the identical label to the newly-created
+ * remainder that the already-created (adopted) Stories carry — while a
+ * different plan derives a different label. Sorting makes the id
+ * independent of creation order.
+ *
+ * @param {string[]} fingerprints Per-Story plan fingerprints.
+ * @returns {string} Hex id, {@link PLAN_RUN_ID_LENGTH} chars.
+ */
+export function derivePlanRunId(fingerprints) {
+  const sorted = (Array.isArray(fingerprints) ? fingerprints : [])
+    .map(String)
+    .sort();
+  return createHash('sha256')
+    .update(sorted.join(' '))
+    .digest('hex')
+    .slice(0, PLAN_RUN_ID_LENGTH);
+}
 
 /**
  * Marker prefix for the per-Story plan fingerprint appended to every
@@ -113,13 +184,16 @@ function planFingerprintMarker(fingerprint) {
 /**
  * Labels the authoring pass is never allowed to set. The `agent::*` axis is
  * the runtime's lifecycle state (persist owns the terminal `agent::ready`
- * flip itself), `type::*` is fixed to `type::story` by the v2 hierarchy, and
- * `persona::*` is a retired axis.
+ * flip itself), `type::*` is fixed to `type::story` by the v2 hierarchy,
+ * `persona::*` is a retired axis, and `plan-run::*` is the runtime-derived
+ * cohort grouping axis (Story #4692) — a hand-authored entry would compete
+ * with the deterministic label persist applies itself.
  */
 const FORBIDDEN_LABEL_PREFIXES = Object.freeze([
   'agent::',
   'type::',
   'persona::',
+  PLAN_RUN_LABEL_PREFIX,
 ]);
 
 /** GitHub's own label-name ceiling. */
@@ -608,6 +682,60 @@ async function mirrorNativeDependencyEdges({ provider, stories, idBySlug }) {
 }
 
 /**
+ * Ensure the cohort's `plan-run::<id>` grouping label exists before it is
+ * applied — GitHub's create-issue path does not auto-create unknown labels
+ * on every provider route, and an opaque per-run label never exists yet.
+ *
+ * **Non-fatal by design**, matching the native-blocked_by mirroring posture:
+ * grouping is cosmetic, never a reason to fail persist. On an ensure failure
+ * (throw, or the label reported `missing` by the post-loop reconcile) the
+ * create loop proceeds **without** the label — applying an unensured label
+ * could fail the issue create itself, and the Stories matter more than
+ * their grouping. A provider that exposes no `ensureLabels` (test fakes,
+ * minimal providers) is assumed to accept arbitrary labels on create.
+ *
+ * @param {object} args
+ * @param {object} args.provider
+ * @param {string} args.cohortLabel
+ * @returns {Promise<boolean>} Whether the create loop should apply the label.
+ */
+async function ensureCohortLabel({ provider, cohortLabel }) {
+  if (typeof provider?.ensureLabels !== 'function') {
+    return true;
+  }
+  try {
+    const result = await provider.ensureLabels([
+      {
+        name: cohortLabel,
+        color: PLAN_RUN_LABEL_COLOR,
+        description:
+          'Groups the Stories one /plan persist run authored (metadata ' +
+          'only — /deliver stays ids-only).',
+      },
+    ]);
+    if (
+      Array.isArray(result?.missing) &&
+      result.missing.includes(cohortLabel)
+    ) {
+      Logger.warn(
+        `[plan-persist] cohort label "${cohortLabel}" could not be verified ` +
+          'on the remote — creating the Stories without it. Grouping is ' +
+          'cosmetic; add the label by hand if you want the cohort filter.',
+      );
+      return false;
+    }
+    return true;
+  } catch (err) {
+    Logger.warn(
+      `[plan-persist] cohort label ensure failed (${err.message}) — ` +
+        'creating the Stories without the grouping label. Grouping is ' +
+        'cosmetic; add the label by hand if you want the cohort filter.',
+    );
+    return false;
+  }
+}
+
+/**
  * Create Story issues via `provider.createIssue`, resumably.
  *
  * **Stories are born without `agent::ready`** (Story #4541). They used to
@@ -631,11 +759,15 @@ async function mirrorNativeDependencyEdges({ provider, stories, idBySlug }) {
  * is named in a warning. Adoption never rewrites a body, so keying it on
  * anything weaker than content would silently ship a stale one.
  *
- * Story #4540 retired the `plan-run::<id>` label this used to apply when
- * N>1. Batch identity was the wrong axis to encode: it could not express an
- * edge to a Story planned in a different run, and ordering already lives in
- * the `blocked by #N` footers written below — which `/deliver`'s resolver
- * reads directly, alongside native GitHub edges, from live state.
+ * **Every created Story carries the cohort's `plan-run::<id>` grouping
+ * label** (Story #4692, metadata only). The id is deterministic over the
+ * authored artifacts ({@link derivePlanRunId}), so a resumed persist derives
+ * the identical label its adopted Stories already carry from their original
+ * create — no relabel call is needed on the resume path, and the cohort is
+ * never split across two labels. The label is ensured to exist before the
+ * first POST, **non-fatally**: grouping is cosmetic and never fails the run
+ * (see `ensureCohortLabel`). `/deliver` never reads it — delivery stays
+ * ids-only over live state (Story #4540's actual point).
  *
  * **Sibling order is mirrored into native GitHub `blocked_by` edges** once
  * every id is known (Story #4544), so plan-created order stops depending on
@@ -649,6 +781,7 @@ async function mirrorNativeDependencyEdges({ provider, stories, idBySlug }) {
  * @returns {Promise<{
  *   created: Array<{ slug: string, id: number, url?: string, title: string, adopted: boolean }>,
  *   dependencyEdges: { edgesAdded: number, edgesSkipped: number, edgesFailed: number, storiesProcessed: number }|null,
+ *   planRunLabel: string,
  * }>}
  */
 export async function createStoryIssues({ provider, stories, opts = {} }) {
@@ -660,6 +793,13 @@ export async function createStoryIssues({ provider, stories, opts = {} }) {
 
   const list = Array.isArray(stories) ? stories : [];
 
+  // Derived once for the whole cohort, before any write — a pure function of
+  // the authored artifacts, so dry-run can report it write-free and a resume
+  // re-derives the identical label.
+  const cohortLabel = planRunLabel(
+    derivePlanRunId(list.map((story) => story.fingerprint)),
+  );
+
   if (opts.dryRun) {
     return {
       created: list.map((s, i) => ({
@@ -670,8 +810,11 @@ export async function createStoryIssues({ provider, stories, opts = {} }) {
         adopted: false,
       })),
       dependencyEdges: null,
+      planRunLabel: cohortLabel,
     };
   }
+
+  const applyCohortLabel = await ensureCohortLabel({ provider, cohortLabel });
 
   const { byFingerprint, idsByTitle } = await indexExistingStories(provider);
   const created = [];
@@ -681,6 +824,9 @@ export async function createStoryIssues({ provider, stories, opts = {} }) {
     const already = byFingerprint.get(story.fingerprint);
     if (!already) warnOnDivergentSameTitleStory(story, idsByTitle);
     if (already) {
+      // Adopted Stories already carry the cohort label from their original
+      // create — the deterministic derivation guarantees it is the same
+      // label this run derived, so no relabel call is needed here.
       Logger.info(
         `[plan-persist] resuming: Story "${story.slug}" already exists as ` +
           `#${already.id} with byte-identical authored content ` +
@@ -700,7 +846,9 @@ export async function createStoryIssues({ provider, stories, opts = {} }) {
     const result = await provider.createIssue({
       title: story.title,
       body: renderStoryBodyForCreate(story, idBySlug),
-      labels: [...story.labels],
+      labels: applyCohortLabel
+        ? [...story.labels, cohortLabel]
+        : [...story.labels],
     });
     const id = result?.id ?? result?.number;
     if (!Number.isInteger(id)) {
@@ -727,7 +875,7 @@ export async function createStoryIssues({ provider, stories, opts = {} }) {
     idBySlug,
   });
 
-  return { created, dependencyEdges };
+  return { created, dependencyEdges, planRunLabel: cohortLabel };
 }
 
 /**

--- a/.agents/workflows/deliver.md
+++ b/.agents/workflows/deliver.md
@@ -34,9 +34,11 @@ Any named ticket that is not `type::story`, or that still carries an
 re-plan as a v2 Story). Resolution refuses the whole set rather than
 silently dropping the offending id and under-delivering.
 
-> **No batch identity (Story #4540).** There is no `--run`, `plan-run::<id>`,
-> or `--dep` axis: ordering lives in the dependency edges, so delivering the
-> ids resolves the graph itself.
+> **Ids-only resolution (Story #4540).** There is no `--run` or `--dep`
+> axis: ordering lives in the dependency edges, so delivering the ids
+> resolves the graph itself. The `plan-run::<id>` grouping label plan-persist
+> applies (Story #4692) is metadata for filtering/traceability only —
+> delivery never reads it as a resolution input.
 
 ## Flags
 

--- a/.agents/workflows/plan.md
+++ b/.agents/workflows/plan.md
@@ -273,10 +273,14 @@ Pass `--plan-acceptance` whenever step 2 wrote an `acceptance-manifest.json`
 — it is what `assertAcceptancePartition` checks the N>1 split against.
 
 Persist creates Story issue(s) with `type::story` (plus any sanitized
-authored `labels[]`) and, when N>1, writes each authored `depends_on` edge
-into the sibling's body as a `blocked by #<id>` footer — the ordering
-`/deliver` resolves from. No batch label is applied (Story #4540 retired
-`plan-run::<id>`). Ends by naming the exact command:
+authored `labels[]`) and a shared `plan-run::<id>` grouping label on every
+Story the run creates (N=1 and N>1) — **metadata only**, for filtering and
+traceability (Story #4692); the id is deterministic over the authored
+artifacts, so a resumed persist reuses the same label. `/deliver` still
+takes only ids and resolves the graph from live state — the label is never
+a delivery-resolution input. When N>1, each authored `depends_on` edge is
+written into the sibling's body as a `blocked by #<id>` footer — the
+ordering `/deliver` resolves from. Ends by naming the exact command:
 `/deliver <storyId> [<storyId> ...]`.
 
 stdout is a pure JSON result; all log lines go to stderr, so a headless

--- a/baselines/dead-exports-production.json
+++ b/baselines/dead-exports-production.json
@@ -1546,6 +1546,22 @@
     },
     {
       "file": ".agents/scripts/lib/orchestration/plan-persist/story-ops.js",
+      "symbol": "PLAN_RUN_LABEL_PREFIX"
+    },
+    {
+      "file": ".agents/scripts/lib/orchestration/plan-persist/story-ops.js",
+      "symbol": "derivePlanRunId"
+    },
+    {
+      "file": ".agents/scripts/lib/orchestration/plan-persist/story-ops.js",
+      "symbol": "normalizePlanRunId"
+    },
+    {
+      "file": ".agents/scripts/lib/orchestration/plan-persist/story-ops.js",
+      "symbol": "planRunLabel"
+    },
+    {
+      "file": ".agents/scripts/lib/orchestration/plan-persist/story-ops.js",
       "symbol": "foldSpecIntoStoryBody"
     },
     {

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -811,10 +811,11 @@ changing its shape (full per-field reference:
 
 The framework uses a **Story-only** GitHub Issue model with
 label-based typing. Optional `depends_on` / `blocked by #NNN` edges order
-rare multi-Story plans; there is no batch label (Story #4540 retired
-`plan-run::<id>`), because `/deliver` takes ids and resolves the graph from
-live state — which is what lets an edge point at a Story planned in an
-earlier run. The folded
+rare multi-Story plans. Each plan-persist run also applies a shared
+`plan-run::<id>` grouping label to the Stories it creates (Story #4692) —
+**metadata only**, for filtering and traceability; `/deliver` takes ids and
+resolves the graph from live state, never the label — which is what lets an
+edge point at a Story planned in an earlier run. The folded
 Tech Spec lives inline on the Story body (`## Spec` only — over-budget
 Specs fail closed as a sizing smell, never spill to `docs/`):
 

--- a/tests/lib/orchestration/plan-persist-story-ops.test.js
+++ b/tests/lib/orchestration/plan-persist-story-ops.test.js
@@ -11,8 +11,11 @@ import {
 import {
   assemblePlanStories,
   createStoryIssues,
+  derivePlanRunId,
   foldSpecIntoStoryBody,
   normalizeStoryTicket,
+  PLAN_RUN_LABEL_PREFIX,
+  planRunLabel,
 } from '../../../.agents/scripts/lib/orchestration/plan-persist/story-ops.js';
 import { DEFAULT_SPEC_BODY_TOKEN_BUDGET } from '../../../.agents/scripts/lib/orchestration/spec-spill.js';
 import {
@@ -37,10 +40,12 @@ function storyTicket(slug, overrides = {}) {
   };
 }
 
-// Story #4540 removed planRunLabel / PLAN_RUN_LABEL_PREFIX / normalizePlanRunId
-// from this module along with the label itself. Their tests went with them;
-// the createStoryIssues test below now asserts the label's ABSENCE, which is
-// the contract that replaced them.
+// Story #4692 reintroduced planRunLabel / PLAN_RUN_LABEL_PREFIX /
+// normalizePlanRunId (retired by Story #4540) as a metadata-only grouping
+// axis, with the id now DETERMINISTIC over the authored artifacts
+// (derivePlanRunId hashes the sorted per-Story plan fingerprints) instead of
+// random, so a resumed persist reuses the identical label. The
+// createStoryIssues tests below assert the label's presence and stability.
 
 describe('normalizeStoryTicket — supersedes (Story #4535)', () => {
   it('normalizes a top-level supersedes[] onto the Story', () => {
@@ -189,15 +194,16 @@ describe('assemblePlanStories', () => {
 });
 
 describe('createStoryIssues', () => {
-  it('creates issues with type::story and NO agent::ready or plan-run label, even when N>1', async () => {
-    // Story #4540: N>1 used to mint an opaque `plan-run::<hex>` label that
-    // nothing ever deleted, to express a grouping that ordering already
-    // encodes via the blocked-by footers asserted in the next test.
+  it('creates issues with type::story plus exactly one plan-run cohort label and NO agent::ready, even when N>1', async () => {
+    // Story #4692: every Story a persist run creates carries the cohort's
+    // `plan-run::<id>` grouping label — metadata only, never a delivery
+    // input. Ordering still lives in the blocked-by footers asserted in the
+    // next test.
     //
-    // Story #4541: agent::ready is no longer part of the creating POST
-    // either. `markStoriesReady` applies it as the terminal step of persist,
-    // once every checkpoint is on the ticket — so a Story labelled ready
-    // always has its risk envelope.
+    // Story #4541: agent::ready is no longer part of the creating POST.
+    // `markStoriesReady` applies it as the terminal step of persist, once
+    // every checkpoint is on the ticket — so a Story labelled ready always
+    // has its risk envelope.
     const calls = [];
     const provider = {
       createIssue: async (payload) => {
@@ -214,7 +220,10 @@ describe('createStoryIssues', () => {
     ]);
     const result = await createStoryIssues({ provider, stories });
     assert.equal(result.created.length, 2);
-    assert.equal(result.planRunLabel, undefined);
+    const expectedLabel = planRunLabel(
+      derivePlanRunId(stories.map((s) => s.fingerprint)),
+    );
+    assert.equal(result.planRunLabel, expectedLabel);
     for (const call of calls) {
       assert.ok(call.labels.includes(TYPE_LABELS.STORY));
       assert.ok(
@@ -222,11 +231,130 @@ describe('createStoryIssues', () => {
         'ready is the terminal flip, not part of the creating POST',
       );
       assert.deepEqual(
-        call.labels.filter((l) => l.startsWith('plan-run::')),
-        [],
-        'no batch label is applied',
+        call.labels.filter((l) => l.startsWith(PLAN_RUN_LABEL_PREFIX)),
+        [expectedLabel],
+        'exactly one cohort grouping label is applied',
       );
     }
+  });
+
+  it('derives the same plan-run label across a re-run and different labels for different plans', async () => {
+    // The id is a pure function of the authored artifacts (sorted per-Story
+    // fingerprints), so a persist re-run of the same stories.json derives
+    // the identical cohort label — the resumable-create contract — while a
+    // different plan derives a different one.
+    const makeProvider = () => ({
+      createIssue: async () => ({ id: Math.floor(Math.random() * 1e6) }),
+    });
+    const { stories: first } = assemblePlanStories([
+      storyTicket('a'),
+      storyTicket('b'),
+    ]);
+    const { stories: second } = assemblePlanStories([
+      storyTicket('a'),
+      storyTicket('b'),
+    ]);
+    const runA = await createStoryIssues({
+      provider: makeProvider(),
+      stories: first,
+    });
+    const runB = await createStoryIssues({
+      provider: makeProvider(),
+      stories: second,
+    });
+    assert.equal(runA.planRunLabel, runB.planRunLabel);
+    assert.match(
+      runA.planRunLabel,
+      new RegExp(`^${PLAN_RUN_LABEL_PREFIX}[0-9a-f]{8}$`),
+    );
+
+    const { stories: other } = assemblePlanStories([storyTicket('c')]);
+    const runC = await createStoryIssues({
+      provider: makeProvider(),
+      stories: other,
+    });
+    assert.notEqual(runC.planRunLabel, runA.planRunLabel);
+  });
+
+  it('is independent of fingerprint order', () => {
+    assert.equal(
+      derivePlanRunId(['bbb', 'aaa']),
+      derivePlanRunId(['aaa', 'bbb']),
+    );
+  });
+
+  it('ensures the cohort label before the first create and degrades non-fatally on ensure failure', async () => {
+    // AC-4: the label must exist before it is applied, and a label-ensure
+    // failure degrades to a warning — the Stories are still created, just
+    // without the cosmetic grouping label.
+    const events = [];
+    const okProvider = {
+      ensureLabels: async (defs) => {
+        events.push(`ensure:${defs[0].name}`);
+        return { created: [defs[0].name], skipped: [], missing: [] };
+      },
+      createIssue: async (payload) => {
+        events.push('create');
+        events.push(payload.labels.filter((l) => l.startsWith('plan-run::')));
+        return { id: 300 + events.length };
+      },
+    };
+    const { stories } = assemblePlanStories([storyTicket('a')]);
+    const ok = await createStoryIssues({ provider: okProvider, stories });
+    assert.equal(events[0], `ensure:${ok.planRunLabel}`);
+    assert.deepEqual(events[2], [ok.planRunLabel]);
+
+    const failCalls = [];
+    const failProvider = {
+      ensureLabels: async () => {
+        throw new Error('boom');
+      },
+      createIssue: async (payload) => {
+        failCalls.push(payload);
+        return { id: 400 + failCalls.length };
+      },
+    };
+    const { stories: stories2 } = assemblePlanStories([storyTicket('a')]);
+    const degraded = await createStoryIssues({
+      provider: failProvider,
+      stories: stories2,
+    });
+    assert.equal(degraded.created.length, 1, 'Stories are still created');
+    assert.deepEqual(
+      failCalls[0].labels.filter((l) => l.startsWith('plan-run::')),
+      [],
+      'the unensured label is not applied',
+    );
+    assert.equal(
+      degraded.planRunLabel,
+      ok.planRunLabel,
+      'the derived label is still reported',
+    );
+  });
+
+  it('reports the derived plan-run label under dryRun without any write', async () => {
+    let writes = 0;
+    const provider = {
+      ensureLabels: async () => {
+        writes += 1;
+        return { created: [], skipped: [], missing: [] };
+      },
+      createIssue: async () => {
+        writes += 1;
+        return { id: 1 };
+      },
+    };
+    const { stories } = assemblePlanStories([storyTicket('a')]);
+    const result = await createStoryIssues({
+      provider,
+      stories,
+      opts: { dryRun: true },
+    });
+    assert.equal(writes, 0);
+    assert.match(
+      result.planRunLabel,
+      new RegExp(`^${PLAN_RUN_LABEL_PREFIX}[0-9a-f]{8}$`),
+    );
   });
 
   it('creates dependencies first and persists numeric blocked-by edges', async () => {

--- a/tests/lib/orchestration/plan-persist-story-ops.test.js
+++ b/tests/lib/orchestration/plan-persist-story-ops.test.js
@@ -13,6 +13,7 @@ import {
   createStoryIssues,
   derivePlanRunId,
   foldSpecIntoStoryBody,
+  normalizePlanRunId,
   normalizeStoryTicket,
   PLAN_RUN_LABEL_PREFIX,
   planRunLabel,
@@ -281,6 +282,13 @@ describe('createStoryIssues', () => {
       derivePlanRunId(['bbb', 'aaa']),
       derivePlanRunId(['aaa', 'bbb']),
     );
+  });
+
+  it('normalizePlanRunId canonicalizes tokens and rejects empty ids', () => {
+    assert.equal(normalizePlanRunId('  Plan-Run::My Cohort!  '), 'my-cohort-');
+    assert.equal(normalizePlanRunId('plan-run::abc123'), 'abc123');
+    assert.equal(planRunLabel('ABC 123'), `${PLAN_RUN_LABEL_PREFIX}abc-123`);
+    assert.throws(() => normalizePlanRunId('   '), /non-empty planRunId/);
   });
 
   it('ensures the cohort label before the first create and degrades non-fatally on ensure failure', async () => {

--- a/tests/scripts/plan-persist.flat-stories.test.js
+++ b/tests/scripts/plan-persist.flat-stories.test.js
@@ -390,12 +390,14 @@ describe('runPlanPersist — flat Story ops', () => {
 
     assert.equal(result.stories.length, 1);
     assert.equal(result.primaryStoryId, result.stories[0].id);
-    // Story #4540 removed the field entirely, rather than leaving it null.
-    assert.ok(!('planRunLabel' in result));
+    // Story #4692: the cohort grouping label is applied for N=1 too, and the
+    // envelope carries it.
+    assert.match(result.planRunLabel, /^plan-run::[0-9a-f]{8}$/);
 
     const issue = provider.issues.get(result.primaryStoryId);
     assert.ok(issue.labels.includes(TYPE_LABELS.STORY));
     assert.ok(issue.labels.includes(AGENT_LABELS.READY));
+    assert.ok(issue.labels.includes(result.planRunLabel));
     assert.match(issue.body, /## Spec/);
 
     const bodies = provider.comments.map((c) => c.body).join('\n');
@@ -439,10 +441,19 @@ describe('runPlanPersist — flat Story ops', () => {
       opts: { skipCleanup: true },
     });
 
-    assert.deepEqual(
-      labelsAtCreate,
-      [[TYPE_LABELS.STORY]],
+    assert.equal(labelsAtCreate.length, 1);
+    assert.ok(
+      labelsAtCreate[0].includes(TYPE_LABELS.STORY),
+      'the creating POST carries type::story',
+    );
+    assert.ok(
+      !labelsAtCreate[0].includes(AGENT_LABELS.READY),
       'the creating POST must not carry agent::ready',
+    );
+    assert.deepEqual(
+      labelsAtCreate[0].filter((l) => l.startsWith('plan-run::')),
+      [result.planRunLabel],
+      'the creating POST carries the cohort grouping label (Story #4692)',
     );
     assert.equal(order.at(-1), 'ready', 'the ready flip must be terminal');
     assert.ok(order.includes('checkpoint'));
@@ -791,11 +802,11 @@ describe('runPlanPersist — flat Story ops', () => {
     assert.equal(provider.issues.size, 0);
   });
 
-  it('applies NO plan-run label to N>1 Stories (Story #4540)', async () => {
-    // The label grouped siblings by planning batch — an axis that could not
-    // express an edge to a Story planned in another run, while ordering
-    // already lives in the blocked-by footers. /deliver now takes ids and
-    // resolves the graph from live state.
+  it('applies exactly one shared plan-run cohort label to N>1 Stories (Story #4692)', async () => {
+    // The label groups the Stories one persist run authored — metadata only,
+    // for filtering/traceability. It is NOT a delivery input: /deliver takes
+    // ids and resolves the graph from live state, and ordering lives in the
+    // blocked-by footers.
     const provider = fakeProvider();
     const result = await runPlanPersist({
       provider,
@@ -805,12 +816,13 @@ describe('runPlanPersist — flat Story ops', () => {
       opts: { skipCleanup: true },
     });
     assert.equal(result.stories.length, 2);
-    assert.equal(result.planRunLabel, undefined);
+    assert.match(result.planRunLabel, /^plan-run::[0-9a-f]{8}$/);
     for (const s of result.stories) {
       const issue = provider.issues.get(s.id);
       assert.deepEqual(
         issue.labels.filter((l) => l.startsWith('plan-run::')),
-        [],
+        [result.planRunLabel],
+        'every Story carries the one shared cohort label',
       );
       const storyComments = provider.comments
         .filter((comment) => comment.issueNumber === s.id)
@@ -819,6 +831,28 @@ describe('runPlanPersist — flat Story ops', () => {
       assert.doesNotMatch(storyComments, /risk-verdict/);
       assert.match(storyComments, /story-plan-state/);
     }
+  });
+
+  it('drops an author-supplied plan-run:: label — the runtime owns that axis (Story #4692)', async () => {
+    const provider = fakeProvider();
+    const authored = ticket('owned');
+    authored.labels = ['type::story', 'plan-run::hand-authored', 'area::x'];
+    const result = await runPlanPersist({
+      provider,
+      artifacts: { stories: [authored] },
+      opts: { skipCleanup: true },
+    });
+    const { labels } = provider.issues.get(result.primaryStoryId);
+    assert.ok(labels.includes('area::x'), 'benign authored label survives');
+    assert.ok(
+      !labels.includes('plan-run::hand-authored'),
+      'the hand-authored plan-run label is dropped',
+    );
+    assert.deepEqual(
+      labels.filter((l) => l.startsWith('plan-run::')),
+      [result.planRunLabel],
+      'only the runtime-derived cohort label is present',
+    );
   });
 });
 


### PR DESCRIPTION
Closes #4692

_Auto-opened by `/deliver`._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive metadata on issue creation with non-fatal label-ensure fallback; delivery graph resolution is untouched.
> 
> **Overview**
> **Reintroduces the `plan-run::<id>` GitHub label** on every Story created by plan-persist (N=1 and N>1), reversing Story #4540’s removal while keeping delivery **ids-only**.
> 
> The cohort id is **deterministic**: an 8-char hash of the sorted per-Story plan fingerprints, so the same `stories.json` always yields the same label and resumed persists stay in one cohort without relabeling adopted issues. Persist **ensures** the label exists before create (non-fatal on failure—Stories still create without it), **strips** author-supplied `plan-run::*` labels, and returns/logs `planRunLabel` for filtering. **`/deliver` is unchanged** and never reads this label.
> 
> Docs (`instructions`, `plan`, `deliver`, `architecture`) and tests are updated to assert label presence and stability; the dead-exports baseline lists the new `story-ops` exports.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ebf05a144bfa5a57ccdf81f8e365c40627cc9880. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->