### PR TITLE
feat(plan): external-dependency pre-mortem trigger so N=1 plans get a viability check (#4700)

### DIFF
--- a/.agents/scripts/lib/orchestration/plan-critic-conditions.js
+++ b/.agents/scripts/lib/orchestration/plan-critic-conditions.js
@@ -20,10 +20,23 @@
  *     to catch a distorted shape without a dedicated sub-agent.
  *   - **Pre-mortem**: dispatch when the ticket count is at least half
  *     of `maxTickets`, OR any configured `planning.riskHeuristics` phrase
- *     matches the plan text (case-insensitive substring). Story #4542 removed
- *     its third condition — the authored risk verdict's overall level — along
- *     with the verdict itself; both surviving conditions read the plan's own
- *     observable text and shape rather than a self-assessment.
+ *     matches the plan text (case-insensitive substring), OR the
+ *     **external-dependency probe** (Story #4700) finds an out-of-repo marker
+ *     in the plan text. Story #4542 removed the authored-risk-verdict condition
+ *     along with the verdict itself; every surviving condition reads the plan's
+ *     own observable text and shape rather than a self-assessment.
+ *
+ * The external-dependency probe (Story #4700) is what gives the default N=1
+ * path a cheap viability check: on that path the size condition is unreachable
+ * (`count*2 >= maxTickets` never holds at one ticket) and a repo whose resolved
+ * `planning.riskHeuristics` is empty has no phrase to match, so a plan-time
+ * discoverable blocker — a scoped package the plan names that no manifest
+ * declares, a cross-repo reference, an external service prerequisite — reached
+ * delivery unquestioned (the swarm-os #757 shape). The probe is deliberately
+ * **conservative**: it matches only explicit markers (npm scoped-package specs,
+ * `github.com/<owner>/<repo>` URLs, prerequisite-keyword-anchored endpoints),
+ * never NLP guesswork, so a plan with no such marker dispatches exactly as it
+ * did before.
  *
  * Under-firing risk (design PR6 note): the persist validators are
  * unchanged hard gates and G2's cohort re-measures plan quality; every
@@ -107,8 +120,150 @@ export function evaluateConsolidationDispatch({ draftStories, specText }) {
 }
 
 /**
- * Decide the pre-mortem dispatch: size ≥ ½ budget, or a risk-heuristic
- * phrase match.
+ * Explicit npm scoped-package marker: `@scope/name`. Requires the leading `@`
+ * and an interior `/`, so bare GitHub handles (`@dsj1984`) and the
+ * `@[USERNAME]` operator-handle placeholder never match.
+ */
+const SCOPED_PACKAGE_MARKER = /@[a-z0-9][a-z0-9._-]*\/[a-z0-9][a-z0-9._-]*/gi;
+
+/** Explicit cross-repo marker: a `github.com/<owner>/<repo>` URL. */
+const GITHUB_REPO_MARKER =
+  /github\.com\/([a-z0-9][a-z0-9._-]*)\/([a-z0-9][a-z0-9._-]*)/gi;
+
+/**
+ * Explicit external-service prerequisite marker: a prerequisite keyword
+ * followed, within the same clause, by an http(s) endpoint. The keyword gate
+ * is what keeps casual documentation links from matching — only an endpoint
+ * named as a precondition counts.
+ */
+const SERVICE_PREREQ_MARKER =
+  /\b(?:requires?|required|prerequisite|provision(?:ed|ing)?|depends?\s+on|credentials?\s+for)\b[^.\n]*?\bhttps?:\/\/([a-z0-9][a-z0-9.-]*)/gi;
+
+/** Order-preserving de-duplication. */
+function uniquePreserveOrder(values) {
+  return [...new Set(values)];
+}
+
+/** Quote each item for an evidence reason string. */
+function quoteList(values) {
+  return values.map((v) => `"${v}"`).join(', ');
+}
+
+/**
+ * Scoped packages named in the plan that no repo manifest declares.
+ *
+ * @param {string} planText
+ * @param {string[]} knownPackages - Package specifiers the repo's own
+ *   manifests declare (own name + dependency maps + workspace package names).
+ * @returns {string[]}
+ */
+function matchExternalScopedPackages(planText, knownPackages) {
+  const known = new Set(
+    knownPackages
+      .filter((n) => typeof n === 'string')
+      .map((n) => n.trim().toLowerCase()),
+  );
+  const matches = [];
+  for (const m of planText.matchAll(SCOPED_PACKAGE_MARKER)) {
+    if (!known.has(m[0].toLowerCase())) matches.push(m[0]);
+  }
+  return uniquePreserveOrder(matches);
+}
+
+/**
+ * `github.com/<owner>/<repo>` references outside the configured repo. When the
+ * owner is unknown (no `github.owner` configured) the arm stays silent rather
+ * than flag every URL as foreign.
+ *
+ * @param {string} planText
+ * @param {{ owner?: string|null, repo?: string|null }|null} ownerRepo
+ * @returns {string[]}
+ */
+function matchCrossRepoRefs(planText, ownerRepo) {
+  const owner =
+    typeof ownerRepo?.owner === 'string'
+      ? ownerRepo.owner.trim().toLowerCase()
+      : '';
+  if (!owner) return [];
+  const repo =
+    typeof ownerRepo?.repo === 'string'
+      ? ownerRepo.repo.trim().toLowerCase()
+      : '';
+  const matches = [];
+  for (const m of planText.matchAll(GITHUB_REPO_MARKER)) {
+    const internal =
+      m[1].toLowerCase() === owner && (!repo || m[2].toLowerCase() === repo);
+    if (!internal) matches.push(`${m[1]}/${m[2]}`);
+  }
+  return uniquePreserveOrder(matches);
+}
+
+/**
+ * Endpoints named as prerequisites in the plan text.
+ *
+ * @param {string} planText
+ * @returns {string[]}
+ */
+function matchExternalServicePrereqs(planText) {
+  const matches = [];
+  for (const m of planText.matchAll(SERVICE_PREREQ_MARKER)) {
+    matches.push(m[1]);
+  }
+  return uniquePreserveOrder(matches);
+}
+
+/**
+ * The external-dependency probe (Story #4700): a conservative, marker-only
+ * scan of the draft plan text for artifacts outside the current repo that the
+ * plan depends on. A match is the pre-mortem's third dispatch condition; a
+ * no-match plan behaves exactly as it did before this probe existed.
+ *
+ * @param {object} input
+ * @param {string} [input.planText] - Concatenated plan text (tech spec +
+ *   serialized tickets).
+ * @param {string[]} [input.knownPackages] - Package specifiers the repo's own
+ *   manifests declare, used to tell an external scoped package from a local one.
+ * @param {{ owner?: string|null, repo?: string|null }|null} [input.ownerRepo] -
+ *   The configured `github.owner`/`github.repo` a cross-repo reference is
+ *   measured against.
+ * @returns {{ matched: boolean, reasons: string[] }}
+ */
+export function evaluateExternalDependencyProbe({
+  planText = '',
+  knownPackages = [],
+  ownerRepo = null,
+}) {
+  const text = String(planText);
+  const packages = matchExternalScopedPackages(text, knownPackages);
+  const crossRepo = matchCrossRepoRefs(text, ownerRepo);
+  const services = matchExternalServicePrereqs(text);
+
+  const reasons = [];
+  if (packages.length > 0) {
+    reasons.push(
+      `External-dependency probe: scoped package(s) named in the plan but absent from the repo's own manifests: ${quoteList(packages)}.`,
+    );
+  }
+  if (crossRepo.length > 0) {
+    const scope = ownerRepo.repo
+      ? `${ownerRepo.owner}/${ownerRepo.repo}`
+      : ownerRepo.owner;
+    reasons.push(
+      `External-dependency probe: cross-repo reference(s) outside ${scope}: ${quoteList(crossRepo)}.`,
+    );
+  }
+  if (services.length > 0) {
+    reasons.push(
+      `External-dependency probe: external service prerequisite endpoint(s): ${quoteList(services)}.`,
+    );
+  }
+
+  return { matched: reasons.length > 0, reasons };
+}
+
+/**
+ * Decide the pre-mortem dispatch: size ≥ ½ budget, a risk-heuristic phrase
+ * match, or an external-dependency probe match (Story #4700).
  *
  * @param {object} input
  * @param {number} input.ticketCount - Draft ticket count (0 in the
@@ -117,8 +272,15 @@ export function evaluateConsolidationDispatch({ draftStories, specText }) {
  *   (`getLimits(config).maxTickets`).
  * @param {string[]} [input.riskHeuristics] - `planning.riskHeuristics`
  *   phrases from the resolved config.
- * @param {string} [input.planText] - Concatenated plan text the heuristics
- *   match against (tech spec + serialized tickets).
+ * @param {string} [input.planText] - Concatenated plan text the heuristics and
+ *   the external-dependency probe match against (tech spec + serialized
+ *   tickets).
+ * @param {string[]} [input.knownPackages] - Package specifiers the repo's own
+ *   manifests declare (own name + dependency maps + workspace package names),
+ *   passed to the external-dependency probe.
+ * @param {{ owner?: string|null, repo?: string|null }|null} [input.ownerRepo] -
+ *   The configured `github.owner`/`github.repo`, passed to the
+ *   external-dependency probe's cross-repo arm.
  * @returns {CriticDispatchDecision}
  */
 export function evaluatePremortemDispatch({
@@ -126,6 +288,8 @@ export function evaluatePremortemDispatch({
   maxTickets,
   riskHeuristics = [],
   planText = '',
+  knownPackages = [],
+  ownerRepo = null,
 }) {
   if (!Number.isInteger(maxTickets) || maxTickets <= 0) {
     throw new TypeError(
@@ -154,6 +318,15 @@ export function evaluatePremortemDispatch({
     );
   }
 
+  const externalDeps = evaluateExternalDependencyProbe({
+    planText,
+    knownPackages,
+    ownerRepo,
+  });
+  if (externalDeps.matched) {
+    reasons.push(...externalDeps.reasons);
+  }
+
   if (reasons.length > 0) {
     return { critic: 'pre-mortem', dispatch: true, reasons };
   }
@@ -162,7 +335,7 @@ export function evaluatePremortemDispatch({
     critic: 'pre-mortem',
     dispatch: false,
     reasons: [
-      `Ticket count ${count} is under half the budget (maxTickets ${maxTickets}) and no planning.riskHeuristics phrase matches the plan text.`,
+      `Ticket count ${count} is under half the budget (maxTickets ${maxTickets}), no planning.riskHeuristics phrase matches the plan text, and the external-dependency probe found no out-of-repo markers.`,
     ],
   };
 }

--- a/.agents/scripts/lib/orchestration/plan-critics-evaluate.js
+++ b/.agents/scripts/lib/orchestration/plan-critics-evaluate.js
@@ -43,6 +43,20 @@ function resolveRiskHeuristics(config = {}) {
 }
 
 /**
+ * Resolve the `{ owner, repo }` the external-dependency probe's cross-repo arm
+ * (Story #4700) measures references against, from the canonical `github` block.
+ *
+ * @param {object} config
+ * @returns {{ owner: string|null, repo: string|null }}
+ */
+function resolveOwnerRepo(config = {}) {
+  return {
+    owner: config.github?.owner ?? null,
+    repo: config.github?.repo ?? null,
+  };
+}
+
+/**
  * Evaluate the consolidation + pre-mortem critic dispatch conditions over
  * the authored planning artifacts (#4474 PR6 conditions, unchanged):
  *
@@ -50,8 +64,12 @@ function resolveRiskHeuristics(config = {}) {
  *     single-delivery shape authors no draft tickets); otherwise the
  *     deterministic precondition + size/divergence conditions.
  *   - Pre-mortem: ticket count at least half `maxTickets`, OR any
- *     `planning.riskHeuristics` phrase matching the plan text. Story #4542
- *     retired its authored-risk-level condition with the verdict itself.
+ *     `planning.riskHeuristics` phrase matching the plan text, OR the
+ *     external-dependency probe (Story #4700) matching an out-of-repo marker
+ *     — a scoped package absent from `knownPackages`, a cross-repo
+ *     `github.com/<owner>/<repo>` reference, or a named external service
+ *     prerequisite. Story #4542 retired its authored-risk-level condition with
+ *     the verdict itself.
  *   - Text hygiene (Story #4599, advisory-only): deterministic body lints
  *     (dangling-citation / open-question / slicing-mass) over the draft
  *     stories. It has no `dispatch` semantics and spawns nothing — its
@@ -62,7 +80,13 @@ function resolveRiskHeuristics(config = {}) {
  *   techSpecContent: string,
  *   tickets?: Array<object>|null,
  *   config?: object,
+ *   knownPackages?: string[],
  * }} args
+ * @param {string[]} [args.knownPackages] - Package specifiers the repo's own
+ *   manifests declare, forwarded to the pre-mortem external-dependency probe
+ *   (Story #4700). The caller (the `plan-critics.js` CLI) owns the file I/O
+ *   that gathers them; this module stays pure. Empty when unresolved, which
+ *   only widens what the probe treats as external.
  * @returns {{
  *   consolidation: { critic: string, dispatch: boolean, reasons: string[] },
  *   premortem: { critic: string, dispatch: boolean, reasons: string[] },
@@ -73,6 +97,7 @@ export function evaluatePlanCritics({
   techSpecContent,
   tickets = null,
   config = {},
+  knownPackages = [],
 }) {
   const ticketList = Array.isArray(tickets) ? tickets : null;
   const consolidation =
@@ -97,6 +122,8 @@ export function evaluatePlanCritics({
       techSpecContent ?? '',
       ticketList ? JSON.stringify(ticketList) : '',
     ].join('\n'),
+    knownPackages,
+    ownerRepo: resolveOwnerRepo(config),
   });
 
   const textHygiene = {

--- a/.agents/scripts/plan-critics.js
+++ b/.agents/scripts/plan-critics.js
@@ -9,6 +9,11 @@
  * act on it — dispatching a fresh-context critic sub-agent and folding its
  * findings into a re-author round **before** the plan is persisted.
  *
+ * The pre-mortem's external-dependency arm (Story #4700) needs the repo's own
+ * manifests to tell an external scoped package from a local one, so this CLI
+ * reads them (`collectRepoPackages`) and passes the specifier set down — the
+ * pure evaluation modules never touch the filesystem.
+ *
  * Why here and nowhere else. The evaluation used to run inside
  * `run-plan-persist.js`, after authoring was finished and immediately before
  * `createStoryIssues` — the one point in the flow where nothing can act on a
@@ -43,7 +48,7 @@
  * Exit codes: 0 success (any verdict); 1 usage/IO error.
  */
 
-import { readFile } from 'node:fs/promises';
+import { readdir, readFile } from 'node:fs/promises';
 import path from 'node:path';
 import { parseArgs } from 'node:util';
 
@@ -62,6 +67,101 @@ const USAGE = 'Usage: plan-critics.js --stories <file> [--tech-spec <file>]';
 
 /** The `cli` discriminator every ledger record from this surface carries. */
 export const PLAN_CRITICS_CLI = 'plan-critics';
+
+/** Dependency maps a manifest can declare a package under. */
+const DEP_MAP_KEYS = [
+  'dependencies',
+  'devDependencies',
+  'optionalDependencies',
+  'peerDependencies',
+];
+
+/** Add a manifest's own name and every declared dependency to `names`. */
+function collectPackageIdentity(names, pkg) {
+  if (typeof pkg?.name === 'string') names.add(pkg.name);
+  for (const key of DEP_MAP_KEYS) {
+    const map = pkg?.[key];
+    if (map && typeof map === 'object') {
+      for (const dep of Object.keys(map)) names.add(dep);
+    }
+  }
+}
+
+/** Best-effort JSON read: a missing or malformed file yields `null`. */
+async function readJsonIfPresent(filePath) {
+  try {
+    return JSON.parse(await readFile(filePath, 'utf8'));
+  } catch {
+    return null;
+  }
+}
+
+/** Normalize the `workspaces` field (array or `{ packages: [] }`) to a list. */
+function workspacePatterns(pkg) {
+  const ws = pkg?.workspaces;
+  if (Array.isArray(ws)) return ws;
+  if (Array.isArray(ws?.packages)) return ws.packages;
+  return [];
+}
+
+/**
+ * Resolve `workspaces` patterns to child `package.json` paths. Handles the two
+ * common shapes — a `dir/*` glob (expanded one level) and a literal path — and
+ * never throws: an unreadable base directory is skipped.
+ *
+ * @param {string} rootDir
+ * @param {string[]} patterns
+ * @returns {Promise<string[]>}
+ */
+async function resolveWorkspaceManifestPaths(rootDir, patterns) {
+  const paths = [];
+  for (const pattern of patterns) {
+    if (typeof pattern !== 'string') continue;
+    if (!pattern.endsWith('/*')) {
+      paths.push(path.resolve(rootDir, pattern, 'package.json'));
+      continue;
+    }
+    const base = path.resolve(rootDir, pattern.slice(0, -2));
+    let entries;
+    try {
+      entries = await readdir(base, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+    for (const entry of entries) {
+      if (entry.isDirectory()) {
+        paths.push(path.join(base, entry.name, 'package.json'));
+      }
+    }
+  }
+  return paths;
+}
+
+/**
+ * Gather the package specifiers the repo's own manifests declare — the set the
+ * pre-mortem external-dependency probe (Story #4700) measures a scoped-package
+ * reference against. Includes the root manifest's own name and dependency maps
+ * plus every workspace manifest's. Best-effort: a repo with no `package.json`
+ * yields `[]`, which only widens what the probe treats as external.
+ *
+ * @param {{ rootDir?: string }} [opts]
+ * @returns {Promise<string[]>}
+ */
+export async function collectRepoPackages({ rootDir = process.cwd() } = {}) {
+  const root = await readJsonIfPresent(path.join(rootDir, 'package.json'));
+  if (!root) return [];
+  const names = new Set();
+  collectPackageIdentity(names, root);
+  const wsPaths = await resolveWorkspaceManifestPaths(
+    rootDir,
+    workspacePatterns(root),
+  );
+  for (const wsPath of wsPaths) {
+    const pkg = await readJsonIfPresent(wsPath);
+    if (pkg) collectPackageIdentity(names, pkg);
+  }
+  return [...names];
+}
 
 /**
  * Read the draft artifacts the critics evaluate.
@@ -155,21 +255,32 @@ export async function recordCriticSkips(
  *   storiesPath: string,
  *   techSpecPath?: string|null,
  *   config?: object,
+ *   knownPackages?: string[],
  *   append?: typeof appendCriticSkip,
  * }} args
+ * @param {string[]} [args.knownPackages] - Package specifiers the repo's own
+ *   manifests declare, forwarded to the pre-mortem external-dependency probe
+ *   (Story #4700). `main()` resolves them via `collectRepoPackages`; tests may
+ *   pass an explicit set or omit it (defaults to `[]`).
  * @returns {Promise<{ consolidation: object, premortem: object, textHygiene: object }>}
  */
 export async function evaluateCriticArtifacts({
   storiesPath,
   techSpecPath = null,
   config = {},
+  knownPackages = [],
   append = appendCriticSkip,
 }) {
   const { tickets, techSpecContent } = await loadCriticArtifacts({
     storiesPath,
     techSpecPath,
   });
-  const verdict = evaluatePlanCritics({ techSpecContent, tickets, config });
+  const verdict = evaluatePlanCritics({
+    techSpecContent,
+    tickets,
+    config,
+    knownPackages,
+  });
   await recordCriticSkips(verdict, config, { append });
   return verdict;
 }
@@ -191,6 +302,7 @@ async function main() {
       ? path.resolve(values['tech-spec'])
       : null,
     config: resolveConfig(),
+    knownPackages: await collectRepoPackages(),
   });
 
   process.stdout.write(`${JSON.stringify(verdict, null, 2)}\n`);

--- a/.agents/workflows/plan.md
+++ b/.agents/workflows/plan.md
@@ -184,6 +184,17 @@ error (an unreadable or malformed `--stories` / `--tech-spec` path). That is
 not an advisory "proceed": no critic ran and no skip was ledgered, so **do
 not proceed to Persist** — fix the path and re-run:
 
+The **pre-mortem** critic fires on any of three deterministic triggers: the
+draft ticket count reaching half the reviewability budget, a
+`planning.riskHeuristics` phrase matching the plan text, or the
+**external-dependency** probe (Story #4700) finding an out-of-repo marker — a
+scoped package the plan names that no repo manifest declares, a cross-repo
+`github.com/<owner>/<repo>` reference, or an endpoint named as a service
+prerequisite. That third trigger is what gives the default N=1 plan a cheap
+viability check, since the size trigger is unreachable at one ticket and this
+repo's resolved `riskHeuristics` is empty. The probe is conservative — explicit
+markers only, so a plan naming no such artifact dispatches exactly as before.
+
 ```jsonc
 {
   "consolidation": { "critic": "consolidation", "dispatch": false, "reasons": ["…"] },

--- a/baselines/dead-exports-production.json
+++ b/baselines/dead-exports-production.json
@@ -1509,6 +1509,10 @@
       "symbol": "CONSOLIDATION_STORY_THRESHOLD"
     },
     {
+      "file": ".agents/scripts/lib/orchestration/plan-critic-conditions.js",
+      "symbol": "evaluateExternalDependencyProbe"
+    },
+    {
       "file": ".agents/scripts/lib/orchestration/plan-metrics.js",
       "symbol": "MAX_LEDGER_BYTES"
     },

--- a/tests/plan-critic-conditions.test.js
+++ b/tests/plan-critic-conditions.test.js
@@ -20,6 +20,7 @@ import { evaluateConsolidationPrecondition } from '../.agents/scripts/lib/orches
 import {
   CONSOLIDATION_STORY_THRESHOLD,
   evaluateConsolidationDispatch,
+  evaluateExternalDependencyProbe,
   evaluatePremortemDispatch,
 } from '../.agents/scripts/lib/orchestration/plan-critic-conditions.js';
 
@@ -280,5 +281,144 @@ describe('pre-mortem dispatch — condition matrix (PR6)', () => {
         }),
       TypeError,
     );
+  });
+});
+
+describe('pre-mortem external-dependency probe (Story #4700)', () => {
+  const ownerRepo = { owner: 'dsj1984', repo: 'mandrel' };
+
+  describe('evaluateExternalDependencyProbe — the marker matchers', () => {
+    it('flags a scoped package absent from the repo manifests', () => {
+      const probe = evaluateExternalDependencyProbe({
+        planText: 'Depends on @beestera/assets and @beestera/icons upstream.',
+        knownPackages: ['mandrel', 'ajv'],
+      });
+      assert.equal(probe.matched, true);
+      assert.match(probe.reasons.join(' '), /@beestera\/assets/);
+      assert.match(probe.reasons.join(' '), /@beestera\/icons/);
+    });
+
+    it('does not flag a scoped package the repo manifests declare', () => {
+      const probe = evaluateExternalDependencyProbe({
+        planText: 'Uses @scope/local-pkg from this workspace.',
+        knownPackages: ['@scope/local-pkg'],
+      });
+      assert.equal(probe.matched, false);
+    });
+
+    it('ignores bare handles and the operator-handle placeholder', () => {
+      // No interior slash → not an npm scoped-package spec.
+      const probe = evaluateExternalDependencyProbe({
+        planText: 'Ping @dsj1984 and set operatorHandle to @[USERNAME].',
+        knownPackages: [],
+      });
+      assert.equal(probe.matched, false);
+    });
+
+    it('flags a cross-repo github.com reference outside the configured repo', () => {
+      const probe = evaluateExternalDependencyProbe({
+        planText:
+          'Pulls fixtures from https://github.com/beestera/swarm-os here.',
+        ownerRepo,
+      });
+      assert.equal(probe.matched, true);
+      assert.match(probe.reasons.join(' '), /beestera\/swarm-os/);
+    });
+
+    it('does not flag the configured repo itself', () => {
+      const probe = evaluateExternalDependencyProbe({
+        planText: 'See github.com/dsj1984/mandrel for the source.',
+        ownerRepo,
+      });
+      assert.equal(probe.matched, false);
+    });
+
+    it('stays silent on cross-repo when the owner is unknown', () => {
+      const probe = evaluateExternalDependencyProbe({
+        planText: 'See github.com/anyone/anything for the source.',
+        ownerRepo: { owner: null, repo: null },
+      });
+      assert.equal(probe.matched, false);
+    });
+
+    it('flags an endpoint named as a service prerequisite', () => {
+      const probe = evaluateExternalDependencyProbe({
+        planText: 'This step requires https://api.stripe.com to be reachable.',
+      });
+      assert.equal(probe.matched, true);
+      assert.match(probe.reasons.join(' '), /api\.stripe\.com/);
+    });
+
+    it('does not flag a casual documentation URL with no prerequisite keyword', () => {
+      const probe = evaluateExternalDependencyProbe({
+        planText:
+          'Background reading: https://nodejs.org/api/test.html is handy.',
+      });
+      assert.equal(probe.matched, false);
+    });
+
+    it('returns matched=false with no reasons on empty plan text', () => {
+      const probe = evaluateExternalDependencyProbe({ planText: '' });
+      assert.equal(probe.matched, false);
+      assert.equal(probe.reasons.length, 0);
+    });
+  });
+
+  // AC-1: a scoped package absent from the repo's own manifests dispatches the
+  // pre-mortem with the match surfaced in reasons[].
+  it('AC-1: dispatches the pre-mortem on an external scoped package, match in reasons[]', () => {
+    const decision = evaluatePremortemDispatch({
+      ticketCount: 1,
+      maxTickets: 80,
+      planText: 'The plan installs @beestera/assets before it can build.',
+      knownPackages: ['mandrel', 'ajv', 'minimatch'],
+      ownerRepo,
+    });
+    assert.equal(decision.critic, 'pre-mortem');
+    assert.equal(decision.dispatch, true);
+    assert.match(decision.reasons.join(' '), /@beestera\/assets/);
+    assert.match(decision.reasons.join(' '), /external-dependency probe/i);
+  });
+
+  // AC-2: no external-dependency markers and no size/heuristic trigger still
+  // skips, and the skip carries the non-empty audit trail the plan-metrics
+  // ledger records (the module's documented skip-is-ledgered contract).
+  it('AC-2: skips (ledgerable) when no marker and no size/heuristic trigger fires', () => {
+    const decision = evaluatePremortemDispatch({
+      ticketCount: 1,
+      maxTickets: 80,
+      planText:
+        'A local-only change to lib/orchestration with no outside deps.',
+      knownPackages: ['mandrel'],
+      ownerRepo,
+    });
+    assert.equal(decision.dispatch, false);
+    assert.ok(
+      decision.reasons.length > 0,
+      'a skip carries the audit trail the ledger records',
+    );
+    assert.match(decision.reasons.join(' '), /external-dependency probe/i);
+  });
+
+  it('an external marker fires even when size and heuristics do not', () => {
+    const decision = evaluatePremortemDispatch({
+      ticketCount: 2,
+      maxTickets: 80,
+      riskHeuristics: ['billing'],
+      planText: 'Requires https://api.example.com provisioned first.',
+      ownerRepo,
+    });
+    assert.equal(decision.dispatch, true);
+    assert.match(decision.reasons.join(' '), /prerequisite endpoint/i);
+  });
+
+  it('a no-marker plan behaves exactly as before the probe existed', () => {
+    // Same shape as the legacy "no condition fires → skip" row: absent
+    // knownPackages/ownerRepo, no markers → identical skip decision.
+    const decision = evaluatePremortemDispatch({
+      ticketCount: 3,
+      maxTickets: 80,
+    });
+    assert.equal(decision.dispatch, false);
   });
 });

--- a/tests/plan-critics-workflow.test.js
+++ b/tests/plan-critics-workflow.test.js
@@ -22,6 +22,7 @@ import { fileURLToPath } from 'node:url';
 
 import { renderDecomposerSystemPrompt } from '../.agents/scripts/lib/templates/decomposer-prompts.js';
 import {
+  collectRepoPackages,
   evaluateCriticArtifacts,
   loadCriticArtifacts,
   PLAN_CRITICS_CLI,
@@ -129,6 +130,12 @@ describe('/plan critic workflow — the live pre-persist critic step (#4592)', (
     assert.match(critics, /usage\/IO\s+error/i);
     assert.doesNotMatch(critics, /always\s+exits\s+0/i);
     assert.match(critics, /\*\*do\s+not\s+proceed\s+to\s+Persist\*\*/i);
+  });
+
+  it('names the external-dependency pre-mortem trigger (#4700)', () => {
+    const critics = section('### 2\\.5 Critics');
+    assert.match(critics, /external-dependency/);
+    assert.match(critics, /pre-mortem/i);
   });
 
   it('names textHygiene findings as re-author input in the critic step (#4599)', () => {
@@ -296,6 +303,109 @@ describe('plan-critics.js CLI — verdict contract', () => {
     const res = runCli([]);
     assert.notEqual(res.status, 0);
     assert.match(res.stderr, /--stories/);
+  });
+
+  // AC-3 (Story #4700): the external-dependency trigger surfaces end-to-end.
+  // The CLI reads the repo's own manifests (mandrel's, at cwd=REPO_ROOT) to
+  // tell a local scoped package from an external one, so a single-story draft
+  // that names @beestera/assets — a scope no mandrel manifest declares — fires
+  // the pre-mortem even though the size and heuristic conditions do not.
+  it('fires the pre-mortem on an external scoped-package reference', () => {
+    const storiesPath = writeFixture('stories-extdep.json', [
+      {
+        slug: 'ext-dep',
+        depends_on: [],
+        body: '## Goal\nBuild the UI once @beestera/assets is published upstream.\n',
+      },
+    ]);
+
+    const res = runCli(['--stories', storiesPath]);
+    const verdict = JSON.parse(res.stdout);
+
+    assert.equal(res.status, 0, `stderr=${res.stderr}`);
+    assert.equal(verdict.premortem.dispatch, true);
+    assert.match(verdict.premortem.reasons.join(' '), /@beestera\/assets/);
+  });
+});
+
+describe('plan-critics.js — repo manifest package collection (#4700)', () => {
+  it('returns [] when the root has no package.json', async () => {
+    const empty = fs.mkdtempSync(path.join(os.tmpdir(), 'plan-critics-nopkg-'));
+    try {
+      assert.deepEqual(await collectRepoPackages({ rootDir: empty }), []);
+    } finally {
+      fs.rmSync(empty, { recursive: true, force: true });
+    }
+  });
+
+  it('collects the own name and every dependency map', async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'plan-critics-deps-'));
+    try {
+      fs.writeFileSync(
+        path.join(root, 'package.json'),
+        JSON.stringify({
+          name: '@acme/root',
+          dependencies: { '@acme/a': '1.0.0' },
+          devDependencies: { '@acme/b': '1.0.0' },
+          optionalDependencies: { '@acme/c': '1.0.0' },
+          peerDependencies: { '@acme/d': '1.0.0' },
+        }),
+      );
+      const names = await collectRepoPackages({ rootDir: root });
+      for (const expected of [
+        '@acme/root',
+        '@acme/a',
+        '@acme/b',
+        '@acme/c',
+        '@acme/d',
+      ]) {
+        assert.ok(names.includes(expected), `expected ${expected} in ${names}`);
+      }
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('resolves a `dir/*` workspace glob one level down', async () => {
+    // Fresh root so the glob resolution is the only source of names.
+    const glob = fs.mkdtempSync(path.join(os.tmpdir(), 'plan-critics-ws-'));
+    try {
+      fs.writeFileSync(
+        path.join(glob, 'package.json'),
+        JSON.stringify({ name: 'root', workspaces: ['packages/*'] }),
+      );
+      fs.mkdirSync(path.join(glob, 'packages', 'ui'), { recursive: true });
+      fs.writeFileSync(
+        path.join(glob, 'packages', 'ui', 'package.json'),
+        JSON.stringify({ name: '@acme/ui' }),
+      );
+      const names = await collectRepoPackages({ rootDir: glob });
+      assert.ok(names.includes('@acme/ui'));
+    } finally {
+      fs.rmSync(glob, { recursive: true, force: true });
+    }
+  });
+
+  it('resolves a literal workspace path and its `{ packages: [] }` shape', async () => {
+    const lit = fs.mkdtempSync(path.join(os.tmpdir(), 'plan-critics-lit-'));
+    try {
+      fs.writeFileSync(
+        path.join(lit, 'package.json'),
+        JSON.stringify({
+          name: 'root',
+          workspaces: { packages: ['tools/cli'] },
+        }),
+      );
+      fs.mkdirSync(path.join(lit, 'tools', 'cli'), { recursive: true });
+      fs.writeFileSync(
+        path.join(lit, 'tools', 'cli', 'package.json'),
+        JSON.stringify({ name: '@acme/cli' }),
+      );
+      const names = await collectRepoPackages({ rootDir: lit });
+      assert.ok(names.includes('@acme/cli'));
+    } finally {
+      fs.rmSync(lit, { recursive: true, force: true });
+    }
   });
 });
 


### PR DESCRIPTION
Closes #4700

_Auto-opened by `/deliver`._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when the pre-mortem critic dispatches for all `/plan` runs (including N=1), though behavior is conservative and marker-only with broad test coverage.
> 
> **Overview**
> Adds a **third deterministic pre-mortem trigger** so default single-story plans can still route to a viability check when size and empty `riskHeuristics` would otherwise skip the critic.
> 
> **`evaluateExternalDependencyProbe`** scans draft plan text (tech spec + serialized tickets) for explicit out-of-repo markers only: `@scope/pkg` not declared in repo manifests, `github.com/owner/repo` outside configured `github.owner`/`github.repo`, and http(s) endpoints tied to prerequisite keywords (not casual doc links). A match sets `premortem.dispatch: true` with evidence in `reasons[]`; no markers preserve prior skip behavior.
> 
> **`plan-critics.js`** now **`collectRepoPackages`** (root + workspace `package.json` names and dependency keys) and passes that set plus config-derived owner/repo into **`evaluatePlanCritics`**. Pure evaluation modules stay sync and filesystem-free.
> 
> **`/plan` workflow docs** describe the third trigger. Tests cover matchers, acceptance criteria, CLI end-to-end for `@beestera/assets`, and package collection; dead-exports baseline lists the new export.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit de6f244b31a7c516ce6bf70ab6751acfc2bffce2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->