### PR TITLE
fix(close): require head-anchored required-check evidence before the checks-failed fail-fast (#4695)

### DIFF
--- a/.agents/scripts/lib/orchestration/merge-block-class.js
+++ b/.agents/scripts/lib/orchestration/merge-block-class.js
@@ -71,7 +71,7 @@
  * (`emit-merge-unlanded.js`).
  */
 
-import { failingChecksBlockMerge } from './merge-poll.js';
+import { requiredCheckFailedBlocksMerge } from './merge-poll.js';
 
 /**
  * Every class `classifyMergeBlock` can return. Order is the evaluation
@@ -169,12 +169,15 @@ function describeApiRaceFallback(prProbe, budget) {
  *      rejection surfaced AT arm time still routes to
  *      `branch-protection-human-required` rather than the generic
  *      `arm-failure`.
- *   1b. A red required check — `checks-failed` (Story #4543). Evaluated
- *      before every budget and probe signal because it is *definitive*:
- *      no amount of remaining budget turns a failed check green, and on a
- *      protected branch it also presents as `mergeStateStatus: 'BLOCKED'`,
- *      so leaving it to step 3 would attribute the operator's red test run
- *      to branch protection.
+ *   1b. A genuinely red required check — `checks-failed` (Story #4543,
+ *      head-anchored by Story #4695). Evaluated before every budget and
+ *      probe signal because it is *definitive*: no amount of remaining
+ *      budget turns a failed check green, and on a protected branch it also
+ *      presents as `mergeStateStatus: 'BLOCKED'`, so leaving it to step 3
+ *      would attribute the operator's red test run to branch protection.
+ *      Gated on `requiredCheckFailedBlocksMerge`: a run must have concluded
+ *      failure with none in flight — a red rollup while a required run is
+ *      merely queued is the protected-branch pending state, not this class.
  *   2. Budget exhaustion while checks were still in flight —
  *      `checks-pending-timeout`. Evaluated BEFORE the human-required
  *      probe signals because on a protected branch GitHub reports
@@ -241,23 +244,35 @@ export function classifyMergeBlock(input) {
   // `undefined` (no probe at all) keeps its budget-timeout mapping in
   // step 2 without suppressing the step-3 human-required verdict.
   const checksStatus = prProbe?.checksStatus;
+  // A required run still queued/in-progress on the head is the
+  // protected-branch pending steady state (Story #4695), so it counts as
+  // in-flight evidence exactly like a `pending`/`still-running` aggregate —
+  // keeping a red-rollup-but-required-run-in-flight probe out of the
+  // human-required verdict below and into the timeout branch on budget expiry.
   const checksPendingEvidence =
-    checksStatus === 'pending' || checksStatus === 'still-running';
+    checksStatus === 'pending' ||
+    checksStatus === 'still-running' ||
+    prProbe?.requiredRunEvidence?.requiredRunInFlight === true;
 
   // 1b. A required check is RED. Definitive — no remaining budget makes a
   // failed check pass — so this precedes both the budget branch and the
   // BLOCKED-merge-state heuristic, which would otherwise attribute the red
   // check to branch protection on any protected base.
   //
-  // Gated on `failingChecksBlockMerge` rather than the raw rollup status:
-  // `checksStatus: 'failure'` covers optional checks too, and naming an
-  // optional red check as THE block sends the operator to fix a check that
-  // was never gating the merge. A red-but-not-gating PR that still failed to
-  // land falls through to the fallback, whose reason says exactly that.
-  if (failingChecksBlockMerge(prProbe)) {
+  // Gated on `requiredCheckFailedBlocksMerge` (Story #4695), not the raw
+  // rollup status: `checksStatus: 'failure'` covers optional checks AND the
+  // protected-branch pending state where a required run is merely queued (the
+  // rollup counts a cancelled superseded run as failure). Naming either as THE
+  // block sends the operator to fix a check that was never gating the merge —
+  // on a PR that merges on its own. Only head-anchored evidence of a genuinely
+  // red required run with none in flight classifies here; anything short of
+  // that falls through, keeps polling, and — on budget expiry with checks in
+  // flight — classifies `checks-pending-timeout` as before.
+  if (requiredCheckFailedBlocksMerge(prProbe)) {
+    const evidencePath = prProbe?.evidencePath;
     return {
       blockClass: 'checks-failed',
-      reason: `a required check failed (mergeStateStatus=${prProbe?.mergeStateStatus ?? 'n/a'})`,
+      reason: `a required check failed (mergeStateStatus=${prProbe?.mergeStateStatus ?? 'n/a'}${evidencePath ? `, evidence=${evidencePath}` : ''})`,
     };
   }
 

--- a/.agents/scripts/lib/orchestration/merge-poll.js
+++ b/.agents/scripts/lib/orchestration/merge-poll.js
@@ -58,6 +58,69 @@ export function deriveChecksStatus(statusCheckRollup) {
 }
 
 /**
+ * Pure: derive HEAD-ANCHORED per-run evidence from a `statusCheckRollup`
+ * array, distinguishing a genuinely red required run from the pending /
+ * superseded noise the aggregate {@link deriveChecksStatus} folds together.
+ *
+ * {@link deriveChecksStatus} returns `failure` the instant it sees ANY
+ * non-passing conclusion — including a `CANCELLED` superseded-push run or a
+ * sibling-invalidated run — even while the real required check is still
+ * queued. Paired with `mergeStateStatus: BLOCKED` (the protected-branch steady
+ * state while required checks run), that matched a merely *pending* PR and
+ * hard-blocked Stories whose PRs merged untouched. This derivation reads the
+ * two signals the fail-fast decision actually needs:
+ *
+ *   - `requiredRunFailed`   — a run on the head concluded `FAILURE` (or a
+ *                             legacy status context is `FAILURE`/`ERROR`).
+ *                             Deliberately NOT `CANCELLED`/`TIMED_OUT`/
+ *                             `SKIPPED`: those are the superseded-push and
+ *                             sibling-invalidated runs, not a red required
+ *                             check.
+ *   - `requiredRunInFlight` — any run on the head is still QUEUED /
+ *                             IN_PROGRESS (a CheckRun whose status is not
+ *                             `COMPLETED`, or a legacy status context still
+ *                             `PENDING`/`EXPECTED`).
+ *
+ * Returns `null` when the rollup is absent or empty — the evidence is
+ * unavailable and the caller must fall back to the consecutive-probe path
+ * (a single evidence-free failing snapshot must never fail-fast).
+ *
+ * @param {Array<{status?: string, conclusion?: string, state?: string}>} statusCheckRollup
+ * @returns {{ requiredRunFailed: boolean, requiredRunInFlight: boolean } | null}
+ */
+export function deriveRequiredRunEvidence(statusCheckRollup) {
+  if (!Array.isArray(statusCheckRollup) || statusCheckRollup.length === 0) {
+    return null;
+  }
+  let requiredRunFailed = false;
+  let requiredRunInFlight = false;
+  for (const check of statusCheckRollup) {
+    const conclusion = String(check?.conclusion ?? '').toUpperCase();
+    const status = String(check?.status ?? '').toUpperCase();
+    const state = String(check?.state ?? '').toUpperCase();
+    // In flight: a CheckRun not yet COMPLETED, or a legacy StatusContext still
+    // PENDING/EXPECTED. `status` is empty on a StatusContext, so it degrades to
+    // the `state` branch rather than counting as in-flight.
+    if (status && status !== 'COMPLETED') {
+      requiredRunInFlight = true;
+    } else if (state === 'PENDING' || state === 'EXPECTED') {
+      requiredRunInFlight = true;
+    }
+    // Genuinely red: FAILURE / ERROR only. CANCELLED / TIMED_OUT / SKIPPED are
+    // the superseded / sibling-invalidated noise a bare rollup miscounts.
+    if (
+      conclusion === 'FAILURE' ||
+      conclusion === 'ERROR' ||
+      state === 'FAILURE' ||
+      state === 'ERROR'
+    ) {
+      requiredRunFailed = true;
+    }
+  }
+  return { requiredRunFailed, requiredRunInFlight };
+}
+
+/**
  * The one `mergeStateStatus` value that means GitHub itself is gating the
  * merge. See {@link failingChecksBlockMerge}.
  */
@@ -100,5 +163,39 @@ export function failingChecksBlockMerge(prProbe) {
   if (prProbe?.checksStatus !== 'failure') return false;
   return (
     String(prProbe?.mergeStateStatus ?? '').toUpperCase() === MERGE_GATED_STATE
+  );
+}
+
+/**
+ * Pure: does HEAD-ANCHORED evidence establish that a REQUIRED check is
+ * genuinely red — enough to fail-fast the merge wait as `checks-failed`?
+ *
+ * This is the single gated decision Story #4695 adds, and the named predicate
+ * a downstream async-confirm Story imports rather than reopening the poll
+ * loop's classification internals. It layers on {@link failingChecksBlockMerge}
+ * (the rollup-`failure` + `mergeStateStatus: BLOCKED` gate) the head-anchored
+ * refinement the raw gate lacked: classify `checks-failed` ONLY when a run
+ * genuinely concluded failure AND none is still in flight. A red rollup while
+ * a required run is queued/in-progress is the protected-branch pending steady
+ * state, not a failure.
+ *
+ * The evidence is read from `prProbe.requiredRunEvidence` (the
+ * {@link deriveRequiredRunEvidence} output threaded through the probe). When it
+ * is absent — older `gh`, an API error, or a probe that never carried a rollup
+ * — this returns `false`: the caller's consecutive-probe fallback owns that
+ * path, because a single evidence-free failing snapshot must never fail-fast.
+ *
+ * @param {{ checksStatus?: string, mergeStateStatus?: string,
+ *   requiredRunEvidence?: { requiredRunFailed?: boolean, requiredRunInFlight?: boolean } }} [prProbe]
+ * @returns {boolean}
+ */
+export function requiredCheckFailedBlocksMerge(prProbe) {
+  if (!failingChecksBlockMerge(prProbe)) return false;
+  const evidence = prProbe?.requiredRunEvidence;
+  if (!evidence || typeof evidence.requiredRunFailed !== 'boolean') {
+    return false;
+  }
+  return (
+    evidence.requiredRunFailed === true && evidence.requiredRunInFlight !== true
   );
 }

--- a/.agents/scripts/lib/orchestration/single-story-close/phases/confirm-merge.js
+++ b/.agents/scripts/lib/orchestration/single-story-close/phases/confirm-merge.js
@@ -87,7 +87,9 @@ import {
   DEFAULT_INTERVAL_SECONDS,
   DEFAULT_MAX_BUDGET_SECONDS,
   deriveChecksStatus,
+  deriveRequiredRunEvidence,
   failingChecksBlockMerge,
+  requiredCheckFailedBlocksMerge,
 } from '../../merge-poll.js';
 import { NEXT_COMMANDS } from '../../story-deliver-terminal.js';
 import {
@@ -164,6 +166,11 @@ export async function readPrWaitProbe({ prNumber, gh = defaultGh }) {
           ? view.reviewDecision
           : undefined,
       checksStatus: deriveChecksStatus(view?.statusCheckRollup),
+      // Head-anchored per-run evidence (Story #4695): distinguishes a
+      // genuinely red required run from the superseded / still-pending noise
+      // the aggregate `checksStatus` folds together. `null` when the rollup is
+      // absent/empty — the loop's consecutive-probe fallback owns that path.
+      requiredRunEvidence: deriveRequiredRunEvidence(view?.statusCheckRollup),
     };
   } catch (err) {
     return {
@@ -429,6 +436,12 @@ async function blockOnUnlanded({
     budget,
   });
   const elapsedSeconds = budget?.elapsedSeconds ?? 0;
+  // Which evidence path produced a `checks-failed` verdict (Story #4695):
+  // `per-run` (head-anchored required-run evidence) or `consecutive-probe`
+  // (the evidence-unavailable fallback). Named on the emitted record so the
+  // `merge.unlanded` telemetry attributes the fail-fast to the path that
+  // fired it. Absent for every other block class.
+  const evidencePath = prProbe?.evidencePath;
 
   if (Number.isInteger(prNumber) && prNumber > 0) {
     try {
@@ -439,6 +452,7 @@ async function blockOnUnlanded({
         blockClass,
         reason,
         elapsedSeconds,
+        ...(evidencePath ? { evidencePath } : {}),
       });
     } catch (err) {
       progress?.(
@@ -706,6 +720,12 @@ export async function runConfirmMergePhase({
   let anchorMs = startedAtMs;
   let updatesUsed = 0;
   let polls = 0;
+  // Consecutive failing check probes observed WITHOUT per-run evidence
+  // (Story #4695). The evidence-unavailable fallback: a single failing rollup
+  // snapshot never fail-fasts — two consecutive failing probes at least one
+  // poll interval apart are required. Reset on any non-failing (or genuinely
+  // evidenced) probe.
+  let consecutiveRequiredFailSnapshots = 0;
 
   progress?.(
     'CONFIRM',
@@ -782,32 +802,81 @@ export async function runConfirmMergePhase({
       });
     }
 
-    // Fail fast on a red REQUIRED check. No remaining budget turns a failed
-    // check green, and waiting it out is what made the pre-#4543 wait report
-    // the operator's red test run as a branch-protection block.
-    //
-    // Gated on `failingChecksBlockMerge`, not on the raw rollup: a red
-    // OPTIONAL check does not stop native auto-merge, so failing fast on it
-    // would block the Story while the PR lands anyway.
+    // Fail fast on a GENUINELY red REQUIRED check — head-anchored (Story
+    // #4695). No remaining budget turns a failed check green, and waiting it
+    // out is what made the pre-#4543 wait report the operator's red test run
+    // as a branch-protection block. But the raw `failingChecksBlockMerge` gate
+    // (rollup `failure` + `mergeStateStatus: BLOCKED`) also matched a merely
+    // *pending* PR: the aggregate rollup reads `failure` for a cancelled
+    // superseded run, and `BLOCKED` is the steady state while required checks
+    // are queued — so this fail-fast hard-blocked Stories whose PRs merged
+    // untouched. The decision is now gated on head-anchored evidence.
     if (failingChecksBlockMerge(probe)) {
-      progress?.(
-        'CONFIRM',
-        `🛑 PR #${prNumber}: a required check went red — failing fast rather than burning the budget.`,
-      );
-      return blockOnUnlanded({
-        storyId,
-        prNumber,
-        prUrl,
-        prProbe: probe,
-        budget: {
-          exhausted: false,
-          elapsedSeconds: Math.round(waitedMs / 1000),
-        },
-        provider,
-        progress,
-        classifyMergeBlockFn,
-        emitMergeUnlandedFn,
-      });
+      const evidence = probe.requiredRunEvidence;
+      if (evidence) {
+        // Per-run evidence available — decide on this single probe.
+        if (requiredCheckFailedBlocksMerge(probe)) {
+          progress?.(
+            'CONFIRM',
+            `🛑 PR #${prNumber}: a required check concluded failure with none in flight — failing fast (evidence=per-run).`,
+          );
+          return blockOnUnlanded({
+            storyId,
+            prNumber,
+            prUrl,
+            prProbe: { ...probe, evidencePath: 'per-run' },
+            budget: {
+              exhausted: false,
+              elapsedSeconds: Math.round(waitedMs / 1000),
+            },
+            provider,
+            progress,
+            classifyMergeBlockFn,
+            emitMergeUnlandedFn,
+          });
+        }
+        // A required run is still in flight (or only non-required / superseded
+        // runs are red): the protected-branch pending steady state, not a
+        // failure. Keep polling — never hard-block.
+        consecutiveRequiredFailSnapshots = 0;
+      } else {
+        // Per-run evidence unavailable (older gh / API error): require TWO
+        // consecutive failing probes at least one poll interval apart before
+        // fail-fast — a single failing rollup snapshot is never sufficient.
+        consecutiveRequiredFailSnapshots += 1;
+        if (consecutiveRequiredFailSnapshots >= 2) {
+          progress?.(
+            'CONFIRM',
+            `🛑 PR #${prNumber}: two consecutive failing check probes without per-run evidence — failing fast (evidence=consecutive-probe).`,
+          );
+          return blockOnUnlanded({
+            storyId,
+            prNumber,
+            prUrl,
+            // Synthesize the evidence the classifier's gate reads, so both
+            // paths classify `checks-failed` through the same predicate.
+            prProbe: {
+              ...probe,
+              requiredRunEvidence: {
+                requiredRunFailed: true,
+                requiredRunInFlight: false,
+              },
+              evidencePath: 'consecutive-probe',
+            },
+            budget: {
+              exhausted: false,
+              elapsedSeconds: Math.round(waitedMs / 1000),
+            },
+            provider,
+            progress,
+            classifyMergeBlockFn,
+            emitMergeUnlandedFn,
+          });
+        }
+        // First failing snapshot without evidence — keep polling.
+      }
+    } else {
+      consecutiveRequiredFailSnapshots = 0;
     }
 
     if (

--- a/tests/lib/orchestration/merge-poll.test.js
+++ b/tests/lib/orchestration/merge-poll.test.js
@@ -17,7 +17,9 @@ import { describe, it } from 'node:test';
 
 import {
   deriveChecksStatus,
+  deriveRequiredRunEvidence,
   failingChecksBlockMerge,
+  requiredCheckFailedBlocksMerge,
 } from '../../../.agents/scripts/lib/orchestration/merge-poll.js';
 
 describe('deriveChecksStatus', () => {
@@ -134,5 +136,165 @@ describe('failingChecksBlockMerge', () => {
       }),
       true,
     );
+  });
+});
+
+describe('deriveRequiredRunEvidence (Story #4695)', () => {
+  it('reports requiredRunFailed only for a genuine FAILURE/ERROR, not superseded noise', () => {
+    // A cancelled superseded run and a timed-out run are the rollup noise the
+    // aggregate `deriveChecksStatus` miscounts as failure — they are NOT a red
+    // required check.
+    assert.deepEqual(
+      deriveRequiredRunEvidence([
+        { status: 'COMPLETED', conclusion: 'CANCELLED' },
+        { status: 'COMPLETED', conclusion: 'TIMED_OUT' },
+        { status: 'COMPLETED', conclusion: 'SKIPPED' },
+        { status: 'COMPLETED', conclusion: 'SUCCESS' },
+      ]),
+      { requiredRunFailed: false, requiredRunInFlight: false },
+    );
+    assert.deepEqual(
+      deriveRequiredRunEvidence([
+        { status: 'COMPLETED', conclusion: 'FAILURE' },
+      ]),
+      { requiredRunFailed: true, requiredRunInFlight: false },
+    );
+    assert.deepEqual(
+      deriveRequiredRunEvidence([{ status: 'COMPLETED', conclusion: 'ERROR' }]),
+      { requiredRunFailed: true, requiredRunInFlight: false },
+    );
+  });
+
+  it('reports requiredRunInFlight for a QUEUED / IN_PROGRESS CheckRun', () => {
+    assert.deepEqual(
+      deriveRequiredRunEvidence([
+        { status: 'COMPLETED', conclusion: 'SUCCESS' },
+        { status: 'QUEUED' },
+      ]),
+      { requiredRunFailed: false, requiredRunInFlight: true },
+    );
+    assert.deepEqual(deriveRequiredRunEvidence([{ status: 'IN_PROGRESS' }]), {
+      requiredRunFailed: false,
+      requiredRunInFlight: true,
+    });
+  });
+
+  it('pins the false-positive shape: a cancelled run beside a still-queued required run', () => {
+    // Exactly the measured false positive — the aggregate reads `failure`, but
+    // the head still has a run in flight and nothing genuinely failed.
+    assert.deepEqual(
+      deriveRequiredRunEvidence([
+        { status: 'COMPLETED', conclusion: 'CANCELLED' },
+        { status: 'QUEUED' },
+      ]),
+      { requiredRunFailed: false, requiredRunInFlight: true },
+    );
+  });
+
+  it('handles legacy StatusContext entries via their state field', () => {
+    assert.deepEqual(deriveRequiredRunEvidence([{ state: 'PENDING' }]), {
+      requiredRunFailed: false,
+      requiredRunInFlight: true,
+    });
+    assert.deepEqual(deriveRequiredRunEvidence([{ state: 'FAILURE' }]), {
+      requiredRunFailed: true,
+      requiredRunInFlight: false,
+    });
+    assert.deepEqual(deriveRequiredRunEvidence([{ state: 'EXPECTED' }]), {
+      requiredRunFailed: false,
+      requiredRunInFlight: true,
+    });
+  });
+
+  it('returns null for an empty or non-array rollup (evidence unavailable)', () => {
+    assert.equal(deriveRequiredRunEvidence([]), null);
+    assert.equal(deriveRequiredRunEvidence(undefined), null);
+    assert.equal(deriveRequiredRunEvidence(null), null);
+  });
+});
+
+describe('requiredCheckFailedBlocksMerge (Story #4695)', () => {
+  const genuinelyRed = {
+    checksStatus: 'failure',
+    mergeStateStatus: 'BLOCKED',
+    requiredRunEvidence: {
+      requiredRunFailed: true,
+      requiredRunInFlight: false,
+    },
+  };
+
+  it('is true only when a required run failed with none in flight', () => {
+    assert.equal(requiredCheckFailedBlocksMerge(genuinelyRed), true);
+  });
+
+  it('is false when a required run is still in flight (the false positive)', () => {
+    assert.equal(
+      requiredCheckFailedBlocksMerge({
+        ...genuinelyRed,
+        requiredRunEvidence: {
+          requiredRunFailed: false,
+          requiredRunInFlight: true,
+        },
+      }),
+      false,
+    );
+    // Even a genuine failure alongside an in-flight run keeps polling — the
+    // change never converts a real failure into a wait beyond one poll.
+    assert.equal(
+      requiredCheckFailedBlocksMerge({
+        ...genuinelyRed,
+        requiredRunEvidence: {
+          requiredRunFailed: true,
+          requiredRunInFlight: true,
+        },
+      }),
+      false,
+    );
+  });
+
+  it('is false when the evidence is unavailable (older gh / API error)', () => {
+    // The consecutive-probe fallback owns this path — a single evidence-free
+    // failing snapshot must never fail-fast through this predicate.
+    assert.equal(
+      requiredCheckFailedBlocksMerge({
+        checksStatus: 'failure',
+        mergeStateStatus: 'BLOCKED',
+      }),
+      false,
+    );
+    assert.equal(
+      requiredCheckFailedBlocksMerge({
+        checksStatus: 'failure',
+        mergeStateStatus: 'BLOCKED',
+        requiredRunEvidence: null,
+      }),
+      false,
+    );
+  });
+
+  it('is false when the raw rollup gate does not hold (UNSTABLE / not red)', () => {
+    assert.equal(
+      requiredCheckFailedBlocksMerge({
+        ...genuinelyRed,
+        mergeStateStatus: 'UNSTABLE',
+      }),
+      false,
+    );
+    assert.equal(
+      requiredCheckFailedBlocksMerge({
+        checksStatus: 'success',
+        mergeStateStatus: 'BLOCKED',
+        requiredRunEvidence: {
+          requiredRunFailed: true,
+          requiredRunInFlight: false,
+        },
+      }),
+      false,
+    );
+  });
+
+  it('is false for a missing probe', () => {
+    assert.equal(requiredCheckFailedBlocksMerge(undefined), false);
+    assert.equal(requiredCheckFailedBlocksMerge(null), false);
   });
 });

--- a/tests/merge-block-class.test.js
+++ b/tests/merge-block-class.test.js
@@ -164,10 +164,57 @@ describe('merge-block-class (Story #4426)', () => {
       // `mergeStateStatus: BLOCKED` is what makes the red check REQUIRED:
       // GitHub gates the merge on it. Without that, a red check is not
       // evidence the merge is blocked at all (see the UNSTABLE cases below).
-      name: 'budget exhausted with a red required check → checks-failed',
+      // Story #4695 additionally requires HEAD-ANCHORED evidence of a
+      // genuinely failed run with none in flight — the raw rollup `failure`
+      // alone (which counts cancelled superseded runs) no longer suffices.
+      name: 'budget exhausted with a genuinely red required check (evidence) → checks-failed',
       input: {
-        prProbe: { checksStatus: 'failure', mergeStateStatus: 'BLOCKED' },
+        prProbe: {
+          checksStatus: 'failure',
+          mergeStateStatus: 'BLOCKED',
+          requiredRunEvidence: {
+            requiredRunFailed: true,
+            requiredRunInFlight: false,
+          },
+        },
         budget: { exhausted: true, elapsedSeconds: 120 },
+      },
+      expected: 'checks-failed',
+    },
+    {
+      // Story #4695 AC-1 — the false-positive shape. Rollup reads `failure`
+      // (a cancelled superseded run) and `mergeStateStatus: BLOCKED`, but a
+      // required run is still queued/in_progress on the head. This is the
+      // protected-branch PENDING steady state — NOT a red required check — so
+      // it must NOT classify `checks-failed`. Without the head-anchored gate
+      // this hard-blocked Stories whose PRs merged untouched.
+      name: 'red rollup + BLOCKED but a required run still in flight → NOT checks-failed',
+      input: {
+        prProbe: {
+          checksStatus: 'failure',
+          mergeStateStatus: 'BLOCKED',
+          requiredRunEvidence: {
+            requiredRunFailed: false,
+            requiredRunInFlight: true,
+          },
+        },
+      },
+      expected: 'api-race-other',
+    },
+    {
+      // Story #4695 AC-2 — a genuine red required check (a run concluded
+      // failure, none in flight) still classifies `checks-failed`, even with
+      // no budget signal at all (the first evidence-bearing probe).
+      name: 'genuinely red required check, none in flight, no budget → checks-failed',
+      input: {
+        prProbe: {
+          checksStatus: 'failure',
+          mergeStateStatus: 'BLOCKED',
+          requiredRunEvidence: {
+            requiredRunFailed: true,
+            requiredRunInFlight: false,
+          },
+        },
       },
       expected: 'checks-failed',
     },
@@ -201,10 +248,18 @@ describe('merge-block-class (Story #4426)', () => {
       // The same red check on a protected base, where GitHub also reports
       // BLOCKED. Without the dedicated class this classified as
       // branch-protection-human-required and sent the operator to inspect
-      // rules that were working correctly.
-      name: 'red required check on a protected base → checks-failed, not branch-protection',
+      // rules that were working correctly. Story #4695 carries the
+      // head-anchored evidence that makes it genuinely red.
+      name: 'genuinely red required check on a protected base → checks-failed, not branch-protection',
       input: {
-        prProbe: { checksStatus: 'failure', mergeStateStatus: 'BLOCKED' },
+        prProbe: {
+          checksStatus: 'failure',
+          mergeStateStatus: 'BLOCKED',
+          requiredRunEvidence: {
+            requiredRunFailed: true,
+            requiredRunInFlight: false,
+          },
+        },
       },
       expected: 'checks-failed',
     },
@@ -257,5 +312,74 @@ describe('merge-block-class (Story #4426)', () => {
       prProbe: { reviewDecision: 'REVIEW_REQUIRED' },
     });
     assert.equal(verdict.blockClass, 'arm-failure');
+  });
+});
+
+describe('head-anchored required-check gating (Story #4695)', () => {
+  // AC-1: the false-positive shape — a red rollup + BLOCKED while a required
+  // run is still in flight — must NOT classify checks-failed. Pinned here as a
+  // standalone assertion in addition to the table case above.
+  it('AC-1: a red rollup with a required run still in flight is NOT checks-failed', () => {
+    const verdict = classifyMergeBlock({
+      prProbe: {
+        checksStatus: 'failure',
+        mergeStateStatus: 'BLOCKED',
+        requiredRunEvidence: {
+          requiredRunFailed: false,
+          requiredRunInFlight: true,
+        },
+      },
+    });
+    assert.notEqual(
+      verdict.blockClass,
+      'checks-failed',
+      'a merely-pending required run must never hard-block as checks-failed',
+    );
+  });
+
+  // AC-2: a genuine red required check (a run concluded failure, none in
+  // flight) still classifies checks-failed on the first evidence-bearing
+  // probe — no budget signal required.
+  it('AC-2: a genuinely red required check with none in flight is checks-failed', () => {
+    const verdict = classifyMergeBlock({
+      prProbe: {
+        checksStatus: 'failure',
+        mergeStateStatus: 'BLOCKED',
+        requiredRunEvidence: {
+          requiredRunFailed: true,
+          requiredRunInFlight: false,
+        },
+      },
+    });
+    assert.equal(verdict.blockClass, 'checks-failed');
+    assert.equal(isValidBlockClass(verdict.blockClass), true);
+  });
+
+  it('an evidence-free failing rollup does not classify checks-failed at the classifier', () => {
+    // The classifier is single-probe: without per-run evidence it must not
+    // assert a red required check. The poll loop's consecutive-probe fallback
+    // synthesizes the evidence before handing a probe here.
+    const verdict = classifyMergeBlock({
+      prProbe: { checksStatus: 'failure', mergeStateStatus: 'BLOCKED' },
+    });
+    assert.notEqual(verdict.blockClass, 'checks-failed');
+  });
+
+  it('names the evidence path that produced a checks-failed verdict in the reason', () => {
+    for (const evidencePath of ['per-run', 'consecutive-probe']) {
+      const verdict = classifyMergeBlock({
+        prProbe: {
+          checksStatus: 'failure',
+          mergeStateStatus: 'BLOCKED',
+          requiredRunEvidence: {
+            requiredRunFailed: true,
+            requiredRunInFlight: false,
+          },
+          evidencePath,
+        },
+      });
+      assert.equal(verdict.blockClass, 'checks-failed');
+      assert.match(verdict.reason, new RegExp(`evidence=${evidencePath}`));
+    }
   });
 });

--- a/tests/single-story-close-confirm-merge.test.js
+++ b/tests/single-story-close-confirm-merge.test.js
@@ -341,7 +341,7 @@ describe('merge wait — pending (the resumable terminal)', () => {
 });
 
 describe('merge wait — blocked terminals', () => {
-  it('a red required check fails fast as checks-failed, without burning the budget', async () => {
+  it('a GENUINELY red required check fails fast as checks-failed on the first evidence-bearing probe (Story #4695 AC-2)', async () => {
     const provider = makeFakeProvider();
     const emitted = [];
     let polls = 0;
@@ -354,6 +354,11 @@ describe('merge wait — blocked terminals', () => {
           return openProbe({
             checksStatus: 'failure',
             mergeStateStatus: 'BLOCKED',
+            // Head-anchored evidence: a run concluded failure, none in flight.
+            requiredRunEvidence: {
+              requiredRunFailed: true,
+              requiredRunInFlight: false,
+            },
           });
         },
         emitMergeUnlandedFn: (rec) => emitted.push(rec),
@@ -363,8 +368,10 @@ describe('merge wait — blocked terminals', () => {
     // Not branch-protection-human-required — the pre-#4543 verdict, which
     // sent the operator to diagnose rules that were working fine.
     assert.equal(outcome.blockClass, 'checks-failed');
-    assert.equal(polls, 1, 'failed fast on the first probe');
+    assert.equal(polls, 1, 'failed fast on the first evidence-bearing probe');
     assert.equal(emitted[0].blockClass, 'checks-failed');
+    // AC-4: the emitted merge.unlanded record names the evidence path.
+    assert.equal(emitted[0].evidencePath, 'per-run');
     assert.deepEqual(provider._updates()[0].patch.labels.add, [
       'agent::blocked',
     ]);
@@ -373,6 +380,114 @@ describe('merge wait — blocked terminals', () => {
       provider._comments()[0].payload.body,
       /required check is \*\*red\*\*/,
     );
+  });
+
+  it('does NOT fail-fast the false-positive shape: a red rollup while a required run is still in flight (Story #4695 AC-1)', async () => {
+    // The measured false positive: rollup `failure` (a cancelled superseded
+    // run) + `BLOCKED` while a required run is queued. The pre-#4695 fail-fast
+    // hard-blocked this; now it keeps polling and the PR lands untouched.
+    const provider = makeFakeProvider();
+    const emitted = [];
+    let polls = 0;
+    const states = [
+      openProbe({
+        checksStatus: 'failure',
+        mergeStateStatus: 'BLOCKED',
+        requiredRunEvidence: {
+          requiredRunFailed: false,
+          requiredRunInFlight: true,
+        },
+      }),
+      { state: 'MERGED', mergedAt: 'x' },
+    ];
+    const outcome = await runConfirmMergePhase(
+      phaseArgs({
+        provider,
+        readPrWaitProbeFn: async () => {
+          polls += 1;
+          return states.shift();
+        },
+        confirmStoryMergedFn: async () => ({ action: 'done', merged: true }),
+        emitMergeUnlandedFn: (rec) => emitted.push(rec),
+      }),
+    );
+    assert.equal(outcome.terminal, 'landed');
+    assert.equal(outcome.confirmed, true);
+    assert.equal(polls, 2, 'kept polling past the pending required run');
+    assert.equal(emitted.length, 0, 'no merge.unlanded against a merged PR');
+    assert.equal(provider._updates().length, 0, 'no agent::blocked flip');
+  });
+
+  it('with per-run evidence unavailable, a single failing rollup probe never fail-fasts — two consecutive probes are required (Story #4695 AC-3)', async () => {
+    // Older gh / API error: the probe carries no requiredRunEvidence. A single
+    // failing snapshot must not hard-block; only a SECOND consecutive failing
+    // probe (one poll interval later) fail-fasts as checks-failed.
+    const provider = makeFakeProvider();
+    const emitted = [];
+    let polls = 0;
+    let sleeps = 0;
+    const outcome = await runConfirmMergePhase(
+      phaseArgs({
+        provider,
+        config: { delivery: { mergeWatch: { maxBudgetSeconds: 3600 } } },
+        // 1s per clock read keeps both the per-invocation and cumulative
+        // bounds comfortably unreached across the two probes.
+        nowMsFn: makeClock(1000),
+        sleepFn: async () => {
+          sleeps += 1;
+        },
+        readPrWaitProbeFn: async () => {
+          polls += 1;
+          // No requiredRunEvidence field → evidence unavailable.
+          return {
+            state: 'OPEN',
+            mergedAt: null,
+            createdAt: null,
+            checksStatus: 'failure',
+            mergeStateStatus: 'BLOCKED',
+          };
+        },
+        emitMergeUnlandedFn: (rec) => emitted.push(rec),
+      }),
+    );
+    assert.equal(outcome.terminal, 'blocked');
+    assert.equal(outcome.blockClass, 'checks-failed');
+    assert.equal(polls, 2, 'the second consecutive failing probe fail-fasts');
+    assert.equal(sleeps, 1, 'slept once between the two failing probes');
+    // AC-4: the fallback path is named on the emitted record.
+    assert.equal(emitted[0].evidencePath, 'consecutive-probe');
+    assert.deepEqual(provider._updates()[0].patch.labels.add, [
+      'agent::blocked',
+    ]);
+  });
+
+  it('a single failing rollup probe followed by a merge never blocks (evidence unavailable)', async () => {
+    // The complement of AC-3: one failing snapshot, then the PR merges. The
+    // single snapshot must not have hard-blocked in the meantime.
+    const provider = makeFakeProvider();
+    const emitted = [];
+    const states = [
+      {
+        state: 'OPEN',
+        mergedAt: null,
+        createdAt: null,
+        checksStatus: 'failure',
+        mergeStateStatus: 'BLOCKED',
+      },
+      { state: 'MERGED', mergedAt: 'x' },
+    ];
+    const outcome = await runConfirmMergePhase(
+      phaseArgs({
+        provider,
+        nowMsFn: makeClock(1000),
+        readPrWaitProbeFn: async () => states.shift(),
+        confirmStoryMergedFn: async () => ({ action: 'done', merged: true }),
+        emitMergeUnlandedFn: (rec) => emitted.push(rec),
+      }),
+    );
+    assert.equal(outcome.terminal, 'landed');
+    assert.equal(emitted.length, 0, 'no block from a single failing snapshot');
+    assert.equal(provider._updates().length, 0);
   });
 
   it('does not block an already-over-budget PR before waiting at all', async () => {
@@ -747,7 +862,10 @@ describe('readPrWaitProbe — one probe carries every field the loop needs', () 
               createdAt: '2026-07-16T00:00:00Z',
               mergeStateStatus: 'BEHIND',
               reviewDecision: 'APPROVED',
-              statusCheckRollup: [{ conclusion: 'SUCCESS' }],
+              statusCheckRollup: [
+                { status: 'COMPLETED', conclusion: 'SUCCESS' },
+                { status: 'IN_PROGRESS' },
+              ],
             };
           },
         },
@@ -765,6 +883,11 @@ describe('readPrWaitProbe — one probe carries every field the loop needs', () 
     }
     assert.equal(probe.mergeStateStatus, 'BEHIND');
     assert.equal(probe.createdAt, '2026-07-16T00:00:00Z');
+    // The probe carries head-anchored per-run evidence (Story #4695).
+    assert.deepEqual(probe.requiredRunEvidence, {
+      requiredRunFailed: false,
+      requiredRunInFlight: true,
+    });
   });
 
   it('degrades to a conservative pending probe when the read itself fails', async () => {


### PR DESCRIPTION
Closes #4695

_Auto-opened by `/deliver`._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes close-and-land merge-wait termination and agent::blocked attribution on protected branches; incorrect gating could still block healthy PRs or delay real failures, but behavior is heavily test-covered for the known false-positive shapes.
> 
> **Overview**
> Fixes false **`checks-failed`** / **`agent::blocked`** when CI is still running: aggregate rollup **`failure`** plus **`mergeStateStatus: BLOCKED`** (e.g. cancelled superseded runs while a required check is queued) no longer triggers immediate fail-fast.
> 
> **`deriveRequiredRunEvidence`** parses per-run rollup data to separate real **FAILURE/ERROR** from **CANCELLED/TIMED_OUT/SKIPPED** noise and to detect **requiredRunInFlight**. **`requiredCheckFailedBlocksMerge`** replaces **`failingChecksBlockMerge`** for **`checks-failed`** classification and block decisions—only when a required run has failed with none still in flight.
> 
> The confirm-merge poll threads **`requiredRunEvidence`** on each probe, keeps polling when checks are merely pending, and uses a **two consecutive failing probes** fallback when rollup evidence is missing. **`merge.unlanded`** telemetry can record **`evidencePath`** (`per-run` vs `consecutive-probe`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 65cdd01f6205da3d297502225af01407d3b33cdf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->