### PR TITLE
fix(observability): isolate test-suite emissions from real telemetry streams and guard CI against fixture pollution (#4696)

### DIFF
--- a/.agents/scripts/check-test-temp-hygiene.js
+++ b/.agents/scripts/check-test-temp-hygiene.js
@@ -1,0 +1,378 @@
+#!/usr/bin/env node
+
+/**
+ * Test-temp hygiene guard (Story #4696).
+ *
+ * The friction / lifecycle / trace NDJSON streams under `temp/` are the
+ * substrate every retro, rollup, and loop-health consumer reads. When the
+ * test suite appends fixture records to the *real* `temp/` tree (the #4555
+ * defect class, re-surfaced for the signal writers), those consumers read
+ * noise: at the time this guard shipped, 99% of friction records were
+ * test-fixture pollution.
+ *
+ * The writer-layer fix (`lib/config/temp-paths.js` scratch seam +
+ * `lib/test-env.js` bootstrap) redirects stray test writes into an absolute
+ * per-process scratch dir. This script is the regression guard that keeps
+ * the fix honest, plus a local cleanup mode for the accumulated noise:
+ *
+ *   --snapshot         Record a fingerprint (size + sha256) of every stream
+ *                      file under `temp/` to a snapshot file. Run this before
+ *                      the suite.
+ *   --assert           Re-scan and fail if any stream file was added or grew
+ *                      relative to the snapshot. Run this after the suite. A
+ *                      missing snapshot is recorded as the baseline and the
+ *                      run passes (graceful bootstrap), so a bare `--assert`
+ *                      after `npm test` still exits 0.
+ *   --clean            List stream directories whose Epic/Story id matches a
+ *                      known fixture id (report-only; nothing is deleted).
+ *   --clean --yes      Delete those directories.
+ *   --ids 1,2,3        Override the fixture-id list for --clean.
+ *   --root <dir>       Operate against <dir> instead of the repo root
+ *                      (its `temp/` subtree). Used by tests.
+ *
+ * Exit codes: 1 on an --assert failure (a new / grown stream file); 0
+ * otherwise.
+ */
+
+import { createHash } from 'node:crypto';
+import {
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { runAsCli } from './lib/cli-utils.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+
+/**
+ * Known fixture Epic/Story ids observed polluting the real `temp/` tree
+ * (Story #4696). `--clean` targets only these by default so real scratch
+ * (a genuine `run-<id>` from a live delivery) is never swept.
+ */
+export const KNOWN_FIXTURE_STORY_IDS = Object.freeze([
+  4428, 10, 4242, 5, 42, 100, 555, 2839, 4257, 4258, 4259,
+]);
+
+/** Snapshot file basename (kept directly under `temp/`, not a stream file). */
+export const SNAPSHOT_BASENAME = '.test-temp-hygiene-snapshot.json';
+
+/**
+ * Resolve the `temp/` directory for a given repo root.
+ * @param {string} repoRoot
+ * @returns {string}
+ */
+export function tempDirFor(repoRoot) {
+  return path.join(repoRoot, 'temp');
+}
+
+/**
+ * Is `rel` (a path relative to `temp/`, POSIX-normalised) a telemetry stream
+ * file we guard? Stream files are `*.ndjson` living under a `run-<id>/`
+ * subtree or the `standalone/stories/` subtree.
+ *
+ * @param {string} rel
+ * @returns {boolean}
+ */
+export function isStreamFile(rel) {
+  if (!rel.endsWith('.ndjson')) return false;
+  const first = rel.split('/')[0];
+  if (/^run-\d+$/.test(first)) return true;
+  return rel.startsWith('standalone/stories/');
+}
+
+/**
+ * Recursively list every stream file under `tempDir`, returned as
+ * POSIX-normalised paths relative to `tempDir`, sorted for determinism.
+ *
+ * @param {string} tempDir
+ * @returns {string[]}
+ */
+export function listStreamFiles(tempDir) {
+  if (!existsSync(tempDir)) return [];
+  /** @type {string[]} */
+  const out = [];
+  const walk = (absDir, relDir) => {
+    for (const ent of readdirSync(absDir, { withFileTypes: true })) {
+      const abs = path.join(absDir, ent.name);
+      const rel = relDir ? `${relDir}/${ent.name}` : ent.name;
+      if (ent.isDirectory()) {
+        walk(abs, rel);
+      } else if (ent.isFile() && isStreamFile(rel)) {
+        out.push(rel);
+      }
+    }
+  };
+  walk(tempDir, '');
+  return out.sort();
+}
+
+/**
+ * Fingerprint a single file by byte length + sha256 of its contents.
+ * @param {string} absPath
+ * @returns {{ size: number, sha256: string }}
+ */
+export function fingerprintFile(absPath) {
+  const buf = readFileSync(absPath);
+  return {
+    size: buf.length,
+    sha256: createHash('sha256').update(buf).digest('hex'),
+  };
+}
+
+/**
+ * Build a `{ [relPath]: fingerprint }` manifest of every stream file under
+ * `tempDir`.
+ * @param {string} tempDir
+ * @returns {Record<string, { size: number, sha256: string }>}
+ */
+export function buildManifest(tempDir) {
+  /** @type {Record<string, { size: number, sha256: string }>} */
+  const manifest = {};
+  for (const rel of listStreamFiles(tempDir)) {
+    manifest[rel] = fingerprintFile(path.join(tempDir, rel));
+  }
+  return manifest;
+}
+
+/**
+ * Persist the current manifest to `<temp>/<SNAPSHOT_BASENAME>`.
+ * @param {string} repoRoot
+ * @returns {{ snapshotPath: string, count: number }}
+ */
+export function writeSnapshot(repoRoot) {
+  const tempDir = tempDirFor(repoRoot);
+  mkdirSync(tempDir, { recursive: true });
+  const manifest = buildManifest(tempDir);
+  const snapshotPath = path.join(tempDir, SNAPSHOT_BASENAME);
+  writeFileSync(snapshotPath, `${JSON.stringify(manifest, null, 2)}\n`, 'utf8');
+  return { snapshotPath, count: Object.keys(manifest).length };
+}
+
+/**
+ * Load the persisted manifest, or `null` when no snapshot exists.
+ * @param {string} repoRoot
+ * @returns {Record<string, { size: number, sha256: string }> | null}
+ */
+export function readSnapshot(repoRoot) {
+  const snapshotPath = path.join(tempDirFor(repoRoot), SNAPSHOT_BASENAME);
+  if (!existsSync(snapshotPath)) return null;
+  return JSON.parse(readFileSync(snapshotPath, 'utf8'));
+}
+
+/**
+ * Diff the current stream tree against a snapshot manifest.
+ *
+ * `added`   — stream files present now but absent from the snapshot.
+ * `changed` — stream files whose size or sha256 differs from the snapshot
+ *             (i.e. a test grew or rewrote an existing stream).
+ *
+ * A file that shrank or vanished is not a pollution signal, so it is ignored.
+ *
+ * @param {string} tempDir
+ * @param {Record<string, { size: number, sha256: string }>} snapshot
+ * @returns {{ added: string[], changed: string[] }}
+ */
+export function diffAgainstSnapshot(tempDir, snapshot) {
+  const current = buildManifest(tempDir);
+  const added = [];
+  const changed = [];
+  for (const [rel, fp] of Object.entries(current)) {
+    const prior = snapshot[rel];
+    if (!prior) {
+      added.push(rel);
+    } else if (prior.size !== fp.size || prior.sha256 !== fp.sha256) {
+      changed.push(rel);
+    }
+  }
+  return { added: added.sort(), changed: changed.sort() };
+}
+
+/**
+ * Extract the fixture-matching id from a top-level `temp/` entry name, or
+ * `null` when the entry is not an id-keyed stream directory.
+ *
+ * `run-<id>` maps to `<id>`; the `standalone/stories/story-<id>` shape is
+ * handled by the caller (it recurses one level deeper).
+ *
+ * @param {string} name
+ * @returns {number|null}
+ */
+function runDirId(name) {
+  const m = /^run-(\d+)$/.exec(name);
+  return m ? Number(m[1]) : null;
+}
+
+/**
+ * Locate stream directories whose Epic/Story id is in `ids`.
+ *
+ * Two shapes are swept: `temp/run-<id>/` (Epic-scoped) and
+ * `temp/standalone/stories/story-<id>/` (standalone Story-scoped).
+ *
+ * @param {string} tempDir
+ * @param {ReadonlySet<number>} ids
+ * @returns {{ id: number, kind: 'run' | 'standalone-story', rel: string }[]}
+ */
+export function findFixtureDirs(tempDir, ids) {
+  if (!existsSync(tempDir)) return [];
+  const found = [];
+  for (const ent of readdirSync(tempDir, { withFileTypes: true })) {
+    if (!ent.isDirectory()) continue;
+    const id = runDirId(ent.name);
+    if (id !== null && ids.has(id)) {
+      found.push({ id, kind: 'run', rel: ent.name });
+    }
+  }
+  const storiesDir = path.join(tempDir, 'standalone', 'stories');
+  if (existsSync(storiesDir)) {
+    for (const ent of readdirSync(storiesDir, { withFileTypes: true })) {
+      if (!ent.isDirectory()) continue;
+      const m = /^story-(\d+)$/.exec(ent.name);
+      const id = m ? Number(m[1]) : null;
+      if (id !== null && ids.has(id)) {
+        found.push({
+          id,
+          kind: 'standalone-story',
+          rel: `standalone/stories/${ent.name}`,
+        });
+      }
+    }
+  }
+  return found.sort((a, b) => a.rel.localeCompare(b.rel));
+}
+
+/**
+ * Report (and optionally delete) fixture-id stream directories.
+ *
+ * @param {object} opts
+ * @param {string} opts.repoRoot
+ * @param {Iterable<number>} [opts.ids]
+ * @param {boolean} [opts.apply=false] delete when true; report-only otherwise.
+ * @returns {{ candidates: { id: number, kind: string, rel: string }[], removed: string[] }}
+ */
+export function cleanFixtureDirs({
+  repoRoot,
+  ids = KNOWN_FIXTURE_STORY_IDS,
+  apply = false,
+}) {
+  const tempDir = tempDirFor(repoRoot);
+  const candidates = findFixtureDirs(tempDir, new Set(ids));
+  const removed = [];
+  if (apply) {
+    for (const c of candidates) {
+      rmSync(path.join(tempDir, c.rel), { recursive: true, force: true });
+      removed.push(c.rel);
+    }
+  }
+  return { candidates, removed };
+}
+
+/**
+ * Parse the CLI argv into a normalised options object.
+ * @param {string[]} argv
+ * @returns {{ mode: 'snapshot'|'assert'|'clean', apply: boolean, ids: number[]|null, repoRoot: string }}
+ */
+export function parseArgv(argv) {
+  let mode = 'assert';
+  let apply = false;
+  let ids = null;
+  let repoRoot = REPO_ROOT;
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === '--snapshot') mode = 'snapshot';
+    else if (arg === '--assert') mode = 'assert';
+    else if (arg === '--clean') mode = 'clean';
+    else if (arg === '--yes') apply = true;
+    else if (arg === '--ids') {
+      i += 1;
+      ids = String(argv[i] ?? '')
+        .split(',')
+        .map((s) => Number(s.trim()))
+        .filter((n) => Number.isInteger(n) && n > 0);
+    } else if (arg === '--root') {
+      i += 1;
+      repoRoot = path.resolve(String(argv[i] ?? '.'));
+    }
+  }
+  return { mode, apply, ids, repoRoot };
+}
+
+/**
+ * Execute the guard for a parsed options object. Returns the process exit
+ * code (0 = clean / snapshot recorded; 1 = pollution detected under
+ * --assert). Printing is done via the injectable `log`.
+ *
+ * @param {ReturnType<typeof parseArgv>} opts
+ * @param {(line: string) => void} [log]
+ * @returns {number}
+ */
+export function runHygiene(opts, log = (l) => process.stdout.write(`${l}\n`)) {
+  const { mode, apply, ids, repoRoot } = opts;
+  if (mode === 'snapshot') {
+    const { snapshotPath, count } = writeSnapshot(repoRoot);
+    log(
+      `[test-temp-hygiene] snapshot recorded (${count} stream file(s)) → ${snapshotPath}`,
+    );
+    return 0;
+  }
+  if (mode === 'clean') {
+    const { candidates } = cleanFixtureDirs({
+      repoRoot,
+      ids: ids ?? KNOWN_FIXTURE_STORY_IDS,
+      apply,
+    });
+    if (candidates.length === 0) {
+      log('[test-temp-hygiene] no fixture-id stream directories found.');
+      return 0;
+    }
+    log(
+      `[test-temp-hygiene] ${candidates.length} fixture-id stream director(y/ies)${
+        apply ? ' removed' : ' (report-only; pass --yes to delete)'
+      }:`,
+    );
+    for (const c of candidates) {
+      log(`  - ${c.rel} (id ${c.id}, ${c.kind})`);
+    }
+    return 0;
+  }
+  // mode === 'assert'
+  const snapshot = readSnapshot(repoRoot);
+  if (snapshot === null) {
+    const { count } = writeSnapshot(repoRoot);
+    log(
+      `[test-temp-hygiene] no prior snapshot — baseline recorded (${count} stream file(s)).`,
+    );
+    return 0;
+  }
+  const { added, changed } = diffAgainstSnapshot(
+    tempDirFor(repoRoot),
+    snapshot,
+  );
+  if (added.length === 0 && changed.length === 0) {
+    log('[test-temp-hygiene] OK — no new or grown stream files under temp/.');
+    return 0;
+  }
+  log(
+    '[test-temp-hygiene] FAIL — the test suite polluted the real temp/ tree:',
+  );
+  for (const rel of added) log(`  + new    ${rel}`);
+  for (const rel of changed) log(`  ~ grew   ${rel}`);
+  log(
+    '[test-temp-hygiene] a writer bypassed the scratch seam. Inject an absolute per-test tempRoot; do not weaken this guard.',
+  );
+  return 1;
+}
+
+runAsCli(
+  import.meta.url,
+  async () => {
+    const code = runHygiene(parseArgv(process.argv.slice(2)));
+    return code;
+  },
+  { source: 'check-test-temp-hygiene', propagateExitCode: true },
+);

--- a/.agents/scripts/lib/config/temp-paths.js
+++ b/.agents/scripts/lib/config/temp-paths.js
@@ -115,6 +115,39 @@ export function _clearMainCheckoutRootCache() {
 }
 
 /**
+ * Environment variable naming an absolute per-process scratch tempRoot that
+ * every stream writer must land in during a test run (Story #4696).
+ *
+ * The shared test bootstrap (`lib/test-env.js`) sets this to a fresh
+ * `os.tmpdir()` directory before spawning the test runner, so any test that
+ * reaches a writer (`signals-writer`, the lifecycle `LedgerWriter`, etc.)
+ * *without* explicitly injecting an absolute tempRoot still resolves under
+ * scratch instead of the repo's real `temp/` tree. This is the single
+ * injection seam: because every path helper funnels a relative root through
+ * `anchorTempRoot`, one redirect here covers all writers regardless of how
+ * each one resolved its root.
+ */
+export const TEST_TEMP_ROOT_ENV = 'MANDREL_TEST_TEMP_ROOT';
+
+/**
+ * Resolve the absolute scratch tempRoot override, or `null` when none is
+ * configured. Only an **absolute** value is honoured — a relative override
+ * would re-anchor against the repo tree and defeat the isolation, so it is
+ * ignored (treated as unset).
+ *
+ * @param {NodeJS.ProcessEnv} [env=process.env]
+ * @returns {string|null}
+ */
+export function testScratchTempRoot(env = process.env) {
+  const override = env?.[TEST_TEMP_ROOT_ENV];
+  return typeof override === 'string' &&
+    override.length > 0 &&
+    path.isAbsolute(override)
+    ? override
+    : null;
+}
+
+/**
  * Anchor a resolved `tempRoot` to the main checkout root when it is a
  * relative path (Story #3900). Absolute roots are returned verbatim; a
  * relative root is joined onto the main checkout root so every caller
@@ -123,11 +156,22 @@ export function _clearMainCheckoutRootCache() {
  * root is returned unchanged so behaviour degrades to the prior
  * cwd-relative semantics rather than throwing.
  *
+ * Test isolation (Story #4696): when the scratch override
+ * (`MANDREL_TEST_TEMP_ROOT`) is set, a relative root is joined onto the
+ * scratch dir instead of the main checkout root, so a writer that reaches
+ * the default (or any relative) root under the test bootstrap lands in
+ * scratch and never pollutes the repo's real `temp/` telemetry tree. An
+ * absolute root injected by a well-behaved test still bypasses the redirect
+ * verbatim.
+ *
  * @param {string} tempRoot
+ * @param {NodeJS.ProcessEnv} [env=process.env]
  * @returns {string}
  */
-export function anchorTempRoot(tempRoot) {
+export function anchorTempRoot(tempRoot, env = process.env) {
   if (path.isAbsolute(tempRoot)) return tempRoot;
+  const scratch = testScratchTempRoot(env);
+  if (scratch) return path.join(scratch, tempRoot);
   const root = mainCheckoutRoot();
   return root ? path.join(root, tempRoot) : tempRoot;
 }

--- a/.agents/scripts/lib/config/temp-paths.js
+++ b/.agents/scripts/lib/config/temp-paths.js
@@ -133,12 +133,14 @@ export const TEST_TEMP_ROOT_ENV = 'MANDREL_TEST_TEMP_ROOT';
  * Resolve the absolute scratch tempRoot override, or `null` when none is
  * configured. Only an **absolute** value is honoured — a relative override
  * would re-anchor against the repo tree and defeat the isolation, so it is
- * ignored (treated as unset).
+ * ignored (treated as unset). Module-internal: the behaviour is exercised
+ * through `anchorTempRoot`, so it is deliberately not exported (keeps the
+ * public seam to `anchorTempRoot` + `TEST_TEMP_ROOT_ENV`).
  *
  * @param {NodeJS.ProcessEnv} [env=process.env]
  * @returns {string|null}
  */
-export function testScratchTempRoot(env = process.env) {
+function testScratchTempRoot(env = process.env) {
   const override = env?.[TEST_TEMP_ROOT_ENV];
   return typeof override === 'string' &&
     override.length > 0 &&

--- a/.agents/scripts/lib/test-env.js
+++ b/.agents/scripts/lib/test-env.js
@@ -1,3 +1,40 @@
+import { mkdtempSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { TEST_TEMP_ROOT_ENV } from './config/temp-paths.js';
+
+/**
+ * Ensure an absolute per-process scratch tempRoot is available for the test
+ * run and return it (Story #4696).
+ *
+ * If `baseEnv` already carries an absolute `MANDREL_TEST_TEMP_ROOT` (the
+ * common case for a child process that inherits the parent runner's env),
+ * that value is reused verbatim so every chunk / worker of a single suite
+ * run shares one scratch dir. Otherwise a fresh `os.tmpdir()` directory is
+ * created. Every stream writer that resolves a relative tempRoot then lands
+ * under this dir instead of the repo's real `temp/` telemetry tree — the
+ * regression that let 99% of friction records be test-fixture pollution.
+ *
+ * @param {NodeJS.ProcessEnv} [baseEnv=process.env]
+ * @param {{ mkdtemp?: typeof mkdtempSync }} [deps] Injectable for tests.
+ * @returns {string} absolute scratch tempRoot
+ */
+export function ensureTestScratchTempRoot(
+  baseEnv = process.env,
+  { mkdtemp = mkdtempSync } = {},
+) {
+  const existing = baseEnv?.[TEST_TEMP_ROOT_ENV];
+  if (
+    typeof existing === 'string' &&
+    existing.length > 0 &&
+    path.isAbsolute(existing)
+  ) {
+    return existing;
+  }
+  return mkdtemp(path.join(os.tmpdir(), 'mandrel-test-temp-'));
+}
+
 /**
  * Build a webhook-safe child-process environment for test runners.
  *
@@ -27,6 +64,11 @@
  *     covered by `cleanGitEnv` in `git-utils.js`; this is the same scrub
  *     for test child processes, which may spawn git directly. Tests that
  *     need a `GIT_*` variable set it explicitly on their own spawn.
+ *   - `MANDREL_TEST_TEMP_ROOT` is set to an absolute per-process scratch
+ *     dir (Story #4696). Any test that reaches a stream writer without
+ *     injecting its own absolute tempRoot lands under scratch instead of
+ *     the repo's real `temp/` telemetry tree, so the suite can no longer
+ *     append fixture records to friction / lifecycle / trace streams.
  *
  * @param {NodeJS.ProcessEnv} baseEnv
  * @returns {NodeJS.ProcessEnv}
@@ -39,5 +81,6 @@ export function buildWebhookSafeTestEnv(baseEnv = process.env) {
   if (env.MANDREL_ALLOW_TEST_WEBHOOKS !== '1') {
     delete env.NOTIFICATION_WEBHOOK_URL;
   }
+  env[TEST_TEMP_ROOT_ENV] = ensureTestScratchTempRoot(baseEnv);
   return env;
 }

--- a/.agents/scripts/lib/test-env.js
+++ b/.agents/scripts/lib/test-env.js
@@ -16,11 +16,14 @@ import { TEST_TEMP_ROOT_ENV } from './config/temp-paths.js';
  * under this dir instead of the repo's real `temp/` telemetry tree — the
  * regression that let 99% of friction records be test-fixture pollution.
  *
+ * Module-internal — the observable behaviour is asserted through
+ * `buildWebhookSafeTestEnv`, so it is deliberately not exported.
+ *
  * @param {NodeJS.ProcessEnv} [baseEnv=process.env]
  * @param {{ mkdtemp?: typeof mkdtempSync }} [deps] Injectable for tests.
  * @returns {string} absolute scratch tempRoot
  */
-export function ensureTestScratchTempRoot(
+function ensureTestScratchTempRoot(
   baseEnv = process.env,
   { mkdtemp = mkdtempSync } = {},
 ) {

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,6 +96,13 @@ jobs:
         run: |
           ( cd node_modules/node-pty && npx --yes node-gyp rebuild ) || echo "::warning::node-pty source build failed; PTY init guard will skip on this run"
 
+      - name: Snapshot temp/ stream hygiene (pre-test)
+        # Story #4696: fingerprint the friction / lifecycle / trace NDJSON
+        # streams under temp/ before the suite runs, so the post-test assert
+        # can fail the build if any test appended fixture records to the real
+        # telemetry tree (the writer-isolation regression this guards).
+        run: node .agents/scripts/check-test-temp-hygiene.js --snapshot
+
       - name: Run Tests with Coverage
         # Capture stderr too — Node's test runner and the coverage-threshold
         # gate both emit failures on stderr, and a stdout-only redirect
@@ -103,6 +110,13 @@ jobs:
         run: |
           set -o pipefail
           npm run test:coverage 2>&1 | tee test-output.txt
+
+      - name: Assert temp/ stream hygiene (post-test)
+        # Story #4696: fail the build if the suite added or grew any stream
+        # file under temp/ relative to the pre-test snapshot. A future writer
+        # that bypasses the scratch seam reds here instead of silently
+        # polluting friction / rollup / loop-health consumers.
+        run: node .agents/scripts/check-test-temp-hygiene.js --assert
 
       - name: Upload Test Results
         uses: actions/upload-artifact@v4

--- a/tests/check-test-temp-hygiene.test.js
+++ b/tests/check-test-temp-hygiene.test.js
@@ -1,0 +1,282 @@
+/**
+ * Unit tests for `.agents/scripts/check-test-temp-hygiene.js` (Story #4696).
+ *
+ * Every test builds an isolated fake repo root under `os.tmpdir()` and points
+ * the guard at it via `--root` / the `repoRoot` option, so the suite never
+ * touches the real `temp/` tree it is meant to protect.
+ */
+
+import assert from 'node:assert/strict';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import fs from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, it } from 'node:test';
+
+import {
+  buildManifest,
+  cleanFixtureDirs,
+  diffAgainstSnapshot,
+  findFixtureDirs,
+  isStreamFile,
+  KNOWN_FIXTURE_STORY_IDS,
+  listStreamFiles,
+  parseArgv,
+  readSnapshot,
+  runHygiene,
+  SNAPSHOT_BASENAME,
+  tempDirFor,
+  writeSnapshot,
+} from '../.agents/scripts/check-test-temp-hygiene.js';
+
+let repoRoot;
+
+beforeEach(() => {
+  repoRoot = mkdtempSync(path.join(tmpdir(), 'temp-hygiene-'));
+});
+afterEach(() => {
+  rmSync(repoRoot, { recursive: true, force: true });
+});
+
+/** Write a stream file at temp/<rel> with `content`, creating parents. */
+function writeStream(rel, content) {
+  const abs = path.join(tempDirFor(repoRoot), rel);
+  mkdirSync(path.dirname(abs), { recursive: true });
+  writeFileSync(abs, content, 'utf8');
+  return abs;
+}
+
+describe('check-test-temp-hygiene — isStreamFile', () => {
+  it('matches ndjson under run-<id>/ and standalone/stories/', () => {
+    assert.equal(isStreamFile('run-7/lifecycle.ndjson'), true);
+    assert.equal(isStreamFile('run-7/stories/story-8/signals.ndjson'), true);
+    assert.equal(
+      isStreamFile('standalone/stories/story-9/signals.ndjson'),
+      true,
+    );
+    assert.equal(
+      isStreamFile('standalone/stories/story-9/traces.ndjson'),
+      true,
+    );
+  });
+
+  it('rejects non-ndjson and unrelated locations', () => {
+    assert.equal(isStreamFile('run-7/manifest.md'), false);
+    assert.equal(isStreamFile('epic-runner-logs/x.ndjson'), false);
+    assert.equal(isStreamFile('loose.ndjson'), false);
+    assert.equal(isStreamFile(SNAPSHOT_BASENAME), false);
+  });
+});
+
+describe('check-test-temp-hygiene — listStreamFiles / buildManifest', () => {
+  it('lists only stream files, sorted, and fingerprints them', () => {
+    writeStream('run-1/lifecycle.ndjson', 'a\n');
+    writeStream('run-1/stories/story-2/signals.ndjson', 'bb\n');
+    writeStream('standalone/stories/story-3/traces.ndjson', 'ccc\n');
+    writeStream('run-1/manifest.md', 'ignored');
+    writeStream('loose.ndjson', 'ignored-too');
+
+    const files = listStreamFiles(tempDirFor(repoRoot));
+    assert.deepEqual(files, [
+      'run-1/lifecycle.ndjson',
+      'run-1/stories/story-2/signals.ndjson',
+      'standalone/stories/story-3/traces.ndjson',
+    ]);
+
+    const manifest = buildManifest(tempDirFor(repoRoot));
+    assert.equal(manifest['run-1/lifecycle.ndjson'].size, 2);
+    assert.equal(typeof manifest['run-1/lifecycle.ndjson'].sha256, 'string');
+  });
+
+  it('returns an empty list when temp/ does not exist', () => {
+    assert.deepEqual(listStreamFiles(tempDirFor(repoRoot)), []);
+  });
+});
+
+describe('check-test-temp-hygiene — snapshot + diff', () => {
+  it('snapshot then unchanged tree diffs clean', () => {
+    writeStream('run-1/lifecycle.ndjson', 'a\n');
+    writeSnapshot(repoRoot);
+    const snapshot = readSnapshot(repoRoot);
+    const { added, changed } = diffAgainstSnapshot(
+      tempDirFor(repoRoot),
+      snapshot,
+    );
+    assert.deepEqual(added, []);
+    assert.deepEqual(changed, []);
+  });
+
+  it('detects an added stream file', () => {
+    writeStream('run-1/lifecycle.ndjson', 'a\n');
+    writeSnapshot(repoRoot);
+    writeStream('run-2/stories/story-5/signals.ndjson', 'new\n');
+    const { added, changed } = diffAgainstSnapshot(
+      tempDirFor(repoRoot),
+      readSnapshot(repoRoot),
+    );
+    assert.deepEqual(added, ['run-2/stories/story-5/signals.ndjson']);
+    assert.deepEqual(changed, []);
+  });
+
+  it('detects a grown / rewritten stream file', () => {
+    writeStream('run-1/lifecycle.ndjson', 'a\n');
+    writeSnapshot(repoRoot);
+    writeStream('run-1/lifecycle.ndjson', 'a\nb\n');
+    const { added, changed } = diffAgainstSnapshot(
+      tempDirFor(repoRoot),
+      readSnapshot(repoRoot),
+    );
+    assert.deepEqual(added, []);
+    assert.deepEqual(changed, ['run-1/lifecycle.ndjson']);
+  });
+
+  it('readSnapshot returns null when no snapshot exists', () => {
+    assert.equal(readSnapshot(repoRoot), null);
+  });
+});
+
+describe('check-test-temp-hygiene — findFixtureDirs / cleanFixtureDirs (AC-4)', () => {
+  it('finds run-<id> and standalone story dirs matching fixture ids', () => {
+    writeStream('run-4428/lifecycle.ndjson', 'x\n');
+    writeStream('standalone/stories/story-10/signals.ndjson', 'y\n');
+    writeStream('run-999/lifecycle.ndjson', 'real\n'); // non-fixture id
+
+    const found = findFixtureDirs(
+      tempDirFor(repoRoot),
+      new Set(KNOWN_FIXTURE_STORY_IDS),
+    );
+    const rels = found.map((f) => f.rel);
+    assert.ok(rels.includes('run-4428'));
+    assert.ok(rels.includes('standalone/stories/story-10'));
+    assert.ok(!rels.includes('run-999'), 'non-fixture ids are untouched');
+  });
+
+  it('report-only clean (default) lists candidates and deletes nothing', async () => {
+    writeStream('run-4428/lifecycle.ndjson', 'x\n');
+    writeStream('standalone/stories/story-10/signals.ndjson', 'y\n');
+
+    const { candidates, removed } = cleanFixtureDirs({ repoRoot });
+    assert.equal(candidates.length, 2);
+    assert.deepEqual(removed, []);
+    // Nothing deleted.
+    await fs.stat(path.join(tempDirFor(repoRoot), 'run-4428'));
+    await fs.stat(
+      path.join(tempDirFor(repoRoot), 'standalone', 'stories', 'story-10'),
+    );
+  });
+
+  it('--yes clean deletes the fixture dirs', async () => {
+    writeStream('run-4428/lifecycle.ndjson', 'x\n');
+    writeStream('run-999/lifecycle.ndjson', 'real\n');
+
+    const { removed } = cleanFixtureDirs({ repoRoot, apply: true });
+    assert.deepEqual(removed, ['run-4428']);
+    await assert.rejects(() =>
+      fs.stat(path.join(tempDirFor(repoRoot), 'run-4428')),
+    );
+    // Non-fixture dir survives.
+    await fs.stat(path.join(tempDirFor(repoRoot), 'run-999'));
+  });
+
+  it('honours a custom fixture-id list', () => {
+    writeStream('run-777/lifecycle.ndjson', 'x\n');
+    const { candidates } = cleanFixtureDirs({ repoRoot, ids: [777] });
+    assert.equal(candidates.length, 1);
+    assert.equal(candidates[0].id, 777);
+  });
+});
+
+describe('check-test-temp-hygiene — parseArgv', () => {
+  it('defaults to assert mode', () => {
+    const opts = parseArgv([]);
+    assert.equal(opts.mode, 'assert');
+    assert.equal(opts.apply, false);
+    assert.equal(opts.ids, null);
+  });
+
+  it('parses each mode, --yes, --ids, and --root', () => {
+    assert.equal(parseArgv(['--snapshot']).mode, 'snapshot');
+    assert.equal(parseArgv(['--clean']).mode, 'clean');
+    assert.equal(parseArgv(['--clean', '--yes']).apply, true);
+    assert.deepEqual(parseArgv(['--ids', '1, 2,3']).ids, [1, 2, 3]);
+    assert.equal(
+      parseArgv(['--root', '/tmp/x']).repoRoot,
+      path.resolve('/tmp/x'),
+    );
+  });
+});
+
+describe('check-test-temp-hygiene — runHygiene', () => {
+  const collect = () => {
+    const lines = [];
+    return { lines, log: (l) => lines.push(l) };
+  };
+
+  it('snapshot mode records the baseline and returns 0', () => {
+    writeStream('run-1/lifecycle.ndjson', 'a\n');
+    const { lines, log } = collect();
+    const code = runHygiene(
+      { mode: 'snapshot', apply: false, ids: null, repoRoot },
+      log,
+    );
+    assert.equal(code, 0);
+    assert.ok(readSnapshot(repoRoot) !== null);
+    assert.ok(lines.join('\n').includes('snapshot recorded'));
+  });
+
+  it('assert with no prior snapshot baselines and returns 0', () => {
+    writeStream('run-1/lifecycle.ndjson', 'a\n');
+    const { lines, log } = collect();
+    const code = runHygiene(
+      { mode: 'assert', apply: false, ids: null, repoRoot },
+      log,
+    );
+    assert.equal(code, 0);
+    assert.ok(lines.join('\n').includes('baseline recorded'));
+  });
+
+  it('assert returns 0 when the tree is unchanged since snapshot', () => {
+    writeStream('run-1/lifecycle.ndjson', 'a\n');
+    writeSnapshot(repoRoot);
+    const code = runHygiene(
+      { mode: 'assert', apply: false, ids: null, repoRoot },
+      () => {},
+    );
+    assert.equal(code, 0);
+  });
+
+  it('assert returns 1 when a new stream file appeared', () => {
+    writeStream('run-1/lifecycle.ndjson', 'a\n');
+    writeSnapshot(repoRoot);
+    writeStream('run-2/stories/story-9/signals.ndjson', 'polluted\n');
+    const { lines, log } = collect();
+    const code = runHygiene(
+      { mode: 'assert', apply: false, ids: null, repoRoot },
+      log,
+    );
+    assert.equal(code, 1);
+    assert.ok(lines.join('\n').includes('polluted the real temp/ tree'));
+  });
+
+  it('clean mode reports candidates without deleting and returns 0', async () => {
+    writeStream('run-4428/lifecycle.ndjson', 'x\n');
+    const { lines, log } = collect();
+    const code = runHygiene(
+      { mode: 'clean', apply: false, ids: null, repoRoot },
+      log,
+    );
+    assert.equal(code, 0);
+    assert.ok(lines.join('\n').includes('run-4428'));
+    await fs.stat(path.join(tempDirFor(repoRoot), 'run-4428'));
+  });
+
+  it('clean mode with no candidates returns 0', () => {
+    const { lines, log } = collect();
+    const code = runHygiene(
+      { mode: 'clean', apply: false, ids: null, repoRoot },
+      log,
+    );
+    assert.equal(code, 0);
+    assert.ok(lines.join('\n').includes('no fixture-id stream directories'));
+  });
+});

--- a/tests/diagnose-friction.test.js
+++ b/tests/diagnose-friction.test.js
@@ -53,6 +53,12 @@ function runScript(extraArgs, extraEnv = {}) {
       ...process.env,
       GITHUB_TOKEN: 'fake-token-for-test',
       NO_NETWORK: '1',
+      // Story #4696: pin the writer's scratch tempRoot at this test's own
+      // tmpRoot so the spawned CLI lands its signal at
+      // `<tmpRoot>/temp/run-<eid>/…` (where the assertions read), instead of
+      // the shared per-process scratch dir the test bootstrap otherwise
+      // injects into the inherited env.
+      MANDREL_TEST_TEMP_ROOT: tmpRoot,
       ...extraEnv,
     },
   });

--- a/tests/lib/config/temp-paths.test.js
+++ b/tests/lib/config/temp-paths.test.js
@@ -19,7 +19,6 @@ import {
   storyTempDir,
   TEST_TEMP_ROOT_ENV,
   tempRootFrom,
-  testScratchTempRoot,
 } from '../../../.agents/scripts/lib/config/temp-paths.js';
 
 const SEP = path.sep;
@@ -328,29 +327,27 @@ describe('lib/config/temp-paths.js — main-checkout anchoring (Story #3900)', (
 describe('lib/config/temp-paths.js — scratch tempRoot seam (Story #4696)', () => {
   const SCRATCH = path.resolve(SEP, 'tmp', 'mandrel-scratch-abc');
 
-  it('testScratchTempRoot honours an absolute override', () => {
-    assert.equal(
-      testScratchTempRoot({ [TEST_TEMP_ROOT_ENV]: SCRATCH }),
-      SCRATCH,
-    );
-  });
-
-  it('testScratchTempRoot ignores an unset / empty / relative override', () => {
-    assert.equal(testScratchTempRoot({}), null);
-    assert.equal(testScratchTempRoot({ [TEST_TEMP_ROOT_ENV]: '' }), null);
-    assert.equal(
-      testScratchTempRoot({ [TEST_TEMP_ROOT_ENV]: 'temp' }),
-      null,
-      'a relative override must be rejected — it would re-anchor to the repo',
-    );
-  });
-
   it('anchorTempRoot redirects a relative root under scratch when the override is set', () => {
     const env = { [TEST_TEMP_ROOT_ENV]: SCRATCH };
     assert.equal(anchorTempRoot('temp', env), path.join(SCRATCH, 'temp'));
     assert.equal(
       anchorTempRoot(path.join('a', 'b'), env),
       path.join(SCRATCH, 'a', 'b'),
+    );
+  });
+
+  it('anchorTempRoot ignores an empty / relative override (would re-anchor to the repo)', () => {
+    // An empty or relative override is treated as unset, so a relative root
+    // falls through to main-checkout anchoring rather than the scratch join.
+    const root = mainCheckoutRoot();
+    const expected = root ? path.join(root, 'temp') : 'temp';
+    assert.equal(
+      anchorTempRoot('temp', { [TEST_TEMP_ROOT_ENV]: '' }),
+      expected,
+    );
+    assert.equal(
+      anchorTempRoot('temp', { [TEST_TEMP_ROOT_ENV]: 'temp' }),
+      expected,
     );
   });
 

--- a/tests/lib/config/temp-paths.test.js
+++ b/tests/lib/config/temp-paths.test.js
@@ -7,19 +7,37 @@
 
 import assert from 'node:assert/strict';
 import path from 'node:path';
-import { describe, it } from 'node:test';
+import { after, before, describe, it } from 'node:test';
 import {
   _clearMainCheckoutRootCache,
+  anchorTempRoot,
   mainCheckoutRoot,
   runArtifactPath,
   runTempDir,
   signalsFile,
   storyManifestPath,
   storyTempDir,
+  TEST_TEMP_ROOT_ENV,
   tempRootFrom,
+  testScratchTempRoot,
 } from '../../../.agents/scripts/lib/config/temp-paths.js';
 
 const SEP = path.sep;
+
+// The shared test bootstrap sets MANDREL_TEST_TEMP_ROOT so stray writers land
+// in scratch (Story #4696). This suite verifies the *production* main-checkout
+// anchoring, so it must run with the override cleared — otherwise every
+// relative-root assertion would resolve under scratch. Node runs each test
+// file in its own process, so mutating the env here does not leak to siblings.
+let savedScratchEnv;
+before(() => {
+  savedScratchEnv = process.env[TEST_TEMP_ROOT_ENV];
+  delete process.env[TEST_TEMP_ROOT_ENV];
+});
+after(() => {
+  if (savedScratchEnv === undefined) delete process.env[TEST_TEMP_ROOT_ENV];
+  else process.env[TEST_TEMP_ROOT_ENV] = savedScratchEnv;
+});
 
 /**
  * The directory helpers anchor a *relative* tempRoot to the main checkout
@@ -304,5 +322,49 @@ describe('lib/config/temp-paths.js — main-checkout anchoring (Story #3900)', (
     };
     const root = mainCheckoutRoot('/tmp/not-a-repo', { exec: throwingExec });
     assert.equal(root, null);
+  });
+});
+
+describe('lib/config/temp-paths.js — scratch tempRoot seam (Story #4696)', () => {
+  const SCRATCH = path.resolve(SEP, 'tmp', 'mandrel-scratch-abc');
+
+  it('testScratchTempRoot honours an absolute override', () => {
+    assert.equal(
+      testScratchTempRoot({ [TEST_TEMP_ROOT_ENV]: SCRATCH }),
+      SCRATCH,
+    );
+  });
+
+  it('testScratchTempRoot ignores an unset / empty / relative override', () => {
+    assert.equal(testScratchTempRoot({}), null);
+    assert.equal(testScratchTempRoot({ [TEST_TEMP_ROOT_ENV]: '' }), null);
+    assert.equal(
+      testScratchTempRoot({ [TEST_TEMP_ROOT_ENV]: 'temp' }),
+      null,
+      'a relative override must be rejected — it would re-anchor to the repo',
+    );
+  });
+
+  it('anchorTempRoot redirects a relative root under scratch when the override is set', () => {
+    const env = { [TEST_TEMP_ROOT_ENV]: SCRATCH };
+    assert.equal(anchorTempRoot('temp', env), path.join(SCRATCH, 'temp'));
+    assert.equal(
+      anchorTempRoot(path.join('a', 'b'), env),
+      path.join(SCRATCH, 'a', 'b'),
+    );
+  });
+
+  it('anchorTempRoot returns an absolute root verbatim even under scratch', () => {
+    const env = { [TEST_TEMP_ROOT_ENV]: SCRATCH };
+    const abs = path.resolve(SEP, 'var', 'injected');
+    assert.equal(anchorTempRoot(abs, env), abs);
+  });
+
+  it('anchorTempRoot falls back to main-checkout anchoring when no override is set', () => {
+    // With the override cleared (this suite deletes it in `before`), a
+    // relative root anchors to the real main checkout, not scratch.
+    const resolved = anchorTempRoot('temp', {});
+    const root = mainCheckoutRoot();
+    assert.equal(resolved, root ? path.join(root, 'temp') : 'temp');
   });
 });

--- a/tests/lib/observability/signals-writer.test.js
+++ b/tests/lib/observability/signals-writer.test.js
@@ -15,7 +15,11 @@ import fs from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { afterEach, beforeEach, describe, it } from 'node:test';
-
+import {
+  mainCheckoutRoot,
+  signalsFile,
+  TEST_TEMP_ROOT_ENV,
+} from '../../../.agents/scripts/lib/config/temp-paths.js';
 import {
   appendSignal,
   appendTrace,
@@ -578,5 +582,70 @@ describe('signals-writer — forEachLine reader', () => {
       seen.map((s) => s.source),
       [undefined, 'framework', 'consumer', undefined],
     );
+  });
+});
+
+// Story #4696 (AC-2): a writer invoked under the test bootstrap *without* an
+// explicit tempRoot must land in the per-process scratch root, never the
+// repo's real `temp/` telemetry tree. This is the regression guard for the
+// pollution that put 99% fixture records into friction streams.
+describe('signals-writer — scratch-root isolation under the test bootstrap (Story #4696)', () => {
+  let scratchRoot;
+  let savedScratchEnv;
+
+  beforeEach(() => {
+    scratchRoot = mkdtempSync(path.join(tmpdir(), 'signals-scratch-'));
+    savedScratchEnv = process.env[TEST_TEMP_ROOT_ENV];
+    process.env[TEST_TEMP_ROOT_ENV] = scratchRoot;
+  });
+
+  afterEach(() => {
+    if (savedScratchEnv === undefined) delete process.env[TEST_TEMP_ROOT_ENV];
+    else process.env[TEST_TEMP_ROOT_ENV] = savedScratchEnv;
+    rmSync(scratchRoot, { recursive: true, force: true });
+  });
+
+  it('appendSignal with no config writes under scratch, not the repo temp tree', async () => {
+    // No `config` argument — the writer resolves the default relative
+    // tempRoot, which the scratch seam redirects under `scratchRoot`.
+    const ok = await appendSignal({
+      epicId: 4696,
+      storyId: 4697,
+      signal: mkSignal({ epicId: 4696, storyId: 4697 }),
+    });
+    assert.equal(ok, true);
+
+    // The resolved path must sit under scratch …
+    const resolved = signalsFile(4696, 4697);
+    assert.ok(
+      resolved.startsWith(scratchRoot + path.sep),
+      `expected ${resolved} to be under scratch ${scratchRoot}`,
+    );
+    const raw = await fs.readFile(resolved, 'utf8');
+    assert.ok(raw.endsWith('\n'));
+    assert.equal(JSON.parse(raw.trim()).kind, 'friction');
+
+    // … and NOT under the repo's real temp/ tree.
+    const root = mainCheckoutRoot();
+    if (root) {
+      const repoTemp = path.join(root, 'temp');
+      assert.ok(
+        !resolved.startsWith(repoTemp + path.sep),
+        `writer must not resolve into the repo temp tree ${repoTemp}`,
+      );
+      await assert.rejects(
+        () =>
+          fs.stat(
+            path.join(
+              repoTemp,
+              'run-4696',
+              'stories',
+              'story-4697',
+              'signals.ndjson',
+            ),
+          ),
+        'no fixture stream file may appear under the repo temp tree',
+      );
+    }
   });
 });

--- a/tests/lib/observability/tool-trace-hook.test.js
+++ b/tests/lib/observability/tool-trace-hook.test.js
@@ -63,14 +63,15 @@ beforeEach(() => {
   _resetInflightForTests();
   process.env.CC_EPIC_ID = '1030';
   process.env.CC_STORY_ID = '1043';
-  // The signals-writer reads tempRoot from `resolveConfig` when no
-  // `config` arg is threaded. We point AGENTRC_PATHS_TEMPROOT at the
-  // tmpdir via the lower-level fallback: tempRootFrom() honors
-  // `config.paths.tempRoot`, but since we're calling appendTrace
-  // through the hook (no config arg), we set the env-resolved path by
-  // pointing PROJECT_ROOT-equivalent at workRoot via cwd when needed.
-  // The simplest cross-platform handle: spawn the hook into a tree
-  // where `temp/` resolves to workRoot. We do that by chdir-ing.
+  // The hook calls appendTrace/appendSignal with no `config` arg, so the
+  // writer resolves the default relative tempRoot (`'temp'`). Story #4696
+  // routes any relative root under the absolute scratch tempRoot named by
+  // MANDREL_TEST_TEMP_ROOT, so we point that at this test's workRoot: the
+  // writer then lands at `<workRoot>/temp/run-<eid>/…`, exactly where the
+  // `tracesPath` / `signalsPath` helpers read. (The chdir is retained for
+  // any cwd-sensitive hook behaviour, but it is no longer what isolates
+  // the on-disk writes.)
+  process.env.MANDREL_TEST_TEMP_ROOT = workRoot;
   process.chdir(workRoot);
 });
 


### PR DESCRIPTION
Closes #4696

_Auto-opened by `/deliver`._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes central path resolution for all telemetry writers under test; production is unaffected unless the env is set, but a bug could mis-route real writes or cause false CI failures on the hygiene gate.
> 
> **Overview**
> **Stops tests from appending friction/lifecycle/trace NDJSON into the repo’s real `temp/` tree** by routing relative `tempRoot` resolution through `MANDREL_TEST_TEMP_ROOT` in `anchorTempRoot`, and setting that env to a shared absolute scratch directory in `buildWebhookSafeTestEnv`.
> 
> **Adds `check-test-temp-hygiene.js`** to fingerprint stream files (`--snapshot`), fail on new or grown streams after the suite (`--assert`), and optionally report/delete known fixture-id directories (`--clean`). CI runs snapshot before and assert after `npm run test:coverage`.
> 
> **Test updates** cover the hygiene script, scratch anchoring in `temp-paths`, default-writer isolation in `signals-writer`, and env pinning in `diagnose-friction` / `tool-trace-hook` (with `temp-paths` tests clearing the override for production anchoring assertions).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3308cbf6bb4b5ed86a6f984903eadc963ae35376. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->