### PR TITLE
fix(recover): stability re-probe before trusting a mid-flight strand verdict

### DIFF
--- a/.agents/scripts/deliver-recover.js
+++ b/.agents/scripts/deliver-recover.js
@@ -40,17 +40,23 @@ import {
 import { PROJECT_ROOT } from './lib/project-root.js';
 import { createProvider } from './lib/provider-factory.js';
 
-const HELP = `Usage: node .agents/scripts/deliver-recover.js --story <id> [--cwd <main-repo>] [--json]
+const HELP = `Usage: node .agents/scripts/deliver-recover.js --story <id> [--cwd <main-repo>] [--json] [--no-reprobe]
 
 Probes a Story's live delivery state — labels, lease, branch, worktree, PR
 state and checks — and prints the single next command that resumes it, with
 the evidence it was derived from. Read-only: mutates nothing.
 
+Mid-flight shapes (executing-*/closing-*) get a stability re-probe after a
+short settle window: matching shapes return the fresher verdict; diverging
+shapes report \`in-transition\` (a live delivery process is mutating the
+state) instead of a confidently wrong command.
+
 Flags:
-  --story   GitHub issue number of the Story (required).
-  --cwd     Main-repo checkout to probe (default: project root).
-  --json    Emit the full recovery envelope as JSON instead of prose.
-  --help    Show this message.
+  --story       GitHub issue number of the Story (required).
+  --cwd         Main-repo checkout to probe (default: project root).
+  --json        Emit the full recovery envelope as JSON instead of prose.
+  --no-reprobe  Skip the stability re-probe (single-probe verdict).
+  --help        Show this message.
 `;
 
 export function parseArgv(argv) {
@@ -60,6 +66,7 @@ export function parseArgv(argv) {
       story: { type: 'string' },
       cwd: { type: 'string' },
       json: { type: 'boolean', default: false },
+      'no-reprobe': { type: 'boolean', default: false },
       help: { type: 'boolean', default: false },
     },
     strict: false,
@@ -68,6 +75,7 @@ export function parseArgv(argv) {
     storyId: Number.parseInt(String(values.story ?? ''), 10),
     cwd: values.cwd ?? null,
     json: Boolean(values.json),
+    reprobe: !values['no-reprobe'],
     help: Boolean(values.help),
   };
 }
@@ -79,15 +87,22 @@ export async function runDeliverRecover({
   storyId: storyIdParam,
   cwd: cwdParam,
   json: jsonParam,
+  reprobe: reprobeParam,
   argv,
   injectedProvider,
   injectedConfig,
   injectedGh,
   injectedGitSpawn,
+  injectedSleepFn,
 } = {}) {
   const parsed =
     storyIdParam !== undefined
-      ? { storyId: storyIdParam, cwd: cwdParam ?? null, json: !!jsonParam }
+      ? {
+          storyId: storyIdParam,
+          cwd: cwdParam ?? null,
+          json: !!jsonParam,
+          reprobe: reprobeParam ?? true,
+        }
       : parseArgv(argv ?? process.argv.slice(2));
 
   if (parsed.help) {
@@ -111,6 +126,8 @@ export async function runDeliverRecover({
     config,
     gh: injectedGh,
     gitSpawnFn: injectedGitSpawn,
+    reprobe: parsed.reprobe,
+    ...(injectedSleepFn ? { sleepFn: injectedSleepFn } : {}),
   });
 
   Logger.info(

--- a/.agents/scripts/lib/orchestration/deliver-recover.js
+++ b/.agents/scripts/lib/orchestration/deliver-recover.js
@@ -264,26 +264,73 @@ export function decideRecovery({ storyId, ticket, branch, pr }) {
 }
 
 /**
- * Probe live state and resolve the single next command. Read-only.
- *
- * @param {object} args
- * @param {number} args.storyId
- * @param {string} args.cwd
- * @param {object} args.provider
- * @param {object} [args.config]
- * @param {object} [args.gh]
- * @param {Function} [args.gitSpawnFn]
- * @returns {Promise<object>}
+ * The shapes a LIVE delivery process actively mutates while it runs. A probe
+ * that lands mid-close can read `executing` + `pr=none` seconds before the
+ * push and PR-open land, and confidently misdirect the operator to re-init a
+ * Story whose close is about to open a PR (observed live on Story #4712: two
+ * probes seconds apart flipped `executing-no-pr` → `executing-with-pr`).
+ * These shapes therefore earn a stability re-probe before the verdict is
+ * trusted; the remaining shapes (`merged-label-stale`, `blocked`,
+ * `done-board-drift`, `ready`) describe settled states no live process is
+ * racing to change.
  */
-export async function recoverStory({
+const TRANSIENT_SHAPES = new Set([
+  'executing-no-pr',
+  'executing-with-pr',
+  'closing-no-pr',
+  'closing-pr-pending',
+  'closing-pr-red',
+]);
+
+/**
+ * Default settle window between the two probes of the stability pass. Long
+ * enough for an in-flight push / `gh pr create` / label flip to land (each is
+ * a single network call), short enough that the read-only CLI stays
+ * interactive.
+ */
+const STABILITY_DELAY_MS = 5000;
+
+/**
+ * Build the verdict for a state observed mid-mutation: the two probe rounds
+ * derived DIFFERENT shapes, so neither is safe to act on — acting on the
+ * first misdirects (the #4712 shape), acting on the second may race the same
+ * live process again. The one next command is the probe itself, re-run once
+ * the live process settles.
+ *
+ * @param {{ storyId: number, first: object, second: object, delayMs: number }} args
+ * @returns {{ shape: string, nextCommand: string, detail: string, evidence: string[] }}
+ */
+function buildInTransitionVerdict({ storyId, first, second, delayMs }) {
+  return {
+    shape: 'in-transition',
+    nextCommand: NEXT_COMMANDS.recover(storyId),
+    detail:
+      `Two probes ${Math.round(delayMs / 1000)}s apart derived different shapes ` +
+      `(\`${first.shape}\` → \`${second.shape}\`): a delivery process is actively ` +
+      `mutating this Story's state right now (a push, PR open, or label flip landed ` +
+      `between the probes). Acting on either verdict risks duplicating or misdirecting ` +
+      `the live run. Wait for it to finish, then re-run this probe for a settled verdict.`,
+    evidence: [
+      `probe1.shape=${first.shape}`,
+      `probe2.shape=${second.shape}`,
+      ...second.evidence,
+    ],
+  };
+}
+
+/**
+ * One full probe round: ticket + branch + PR → decision. Throws only when
+ * the ticket itself is unreadable (the probe cannot run without it).
+ */
+async function probeAndDecide({
   storyId,
+  storyBranch,
   cwd,
   provider,
   config,
-  gh = defaultGh,
+  gh,
   gitSpawnFn,
 }) {
-  const storyBranch = getStoryBranch(storyId);
   const ticket = await probeTicket({ provider, storyId });
   if (!ticket.ok) {
     throw new Error(
@@ -293,11 +340,91 @@ export async function recoverStory({
   const branch = probeBranch({ cwd, storyBranch, config, gitSpawnFn });
   const pr = await probePr({ storyBranch, gh });
   const decision = decideRecovery({ storyId, ticket, branch, pr });
+  return { probes: { ticket, branch, pr }, decision };
+}
+
+/**
+ * Probe live state and resolve the single next command. Read-only.
+ *
+ * Transient shapes (`executing-*` / `closing-*`) get a **stability re-probe**
+ * (same consecutive-evidence pattern the merge wait's fail-fast uses, Story
+ * #4695): a second probe after a short settle window. Matching shapes return
+ * the fresher verdict; diverging shapes return `in-transition` instead of a
+ * confidently wrong command. Settled shapes skip the second round — their
+ * state has no live process racing to change it.
+ *
+ * @param {object} args
+ * @param {number} args.storyId
+ * @param {string} args.cwd
+ * @param {object} args.provider
+ * @param {object} [args.config]
+ * @param {object} [args.gh]
+ * @param {Function} [args.gitSpawnFn]
+ * @param {boolean} [args.reprobe=true] Disable to skip the stability pass
+ *   (single-probe legacy behavior — for scripted callers that own their own
+ *   settling).
+ * @param {number} [args.stabilityDelayMs] Settle window between the probes.
+ * @param {Function} [args.sleepFn] Test seam for the settle wait.
+ * @returns {Promise<object>}
+ */
+export async function recoverStory({
+  storyId,
+  cwd,
+  provider,
+  config,
+  gh = defaultGh,
+  gitSpawnFn,
+  reprobe = true,
+  stabilityDelayMs = STABILITY_DELAY_MS,
+  sleepFn = (ms) => new Promise((resolve) => setTimeout(resolve, ms)),
+}) {
+  const storyBranch = getStoryBranch(storyId);
+  const probeArgs = {
+    storyId,
+    storyBranch,
+    cwd,
+    provider,
+    config,
+    gh,
+    gitSpawnFn,
+  };
+
+  const first = await probeAndDecide(probeArgs);
+  if (!reprobe || !TRANSIENT_SHAPES.has(first.decision.shape)) {
+    return {
+      storyId,
+      storyBranch,
+      probes: first.probes,
+      stability: { reprobed: false },
+      ...first.decision,
+    };
+  }
+
+  await sleepFn(stabilityDelayMs);
+  const second = await probeAndDecide(probeArgs);
+
+  if (second.decision.shape === first.decision.shape) {
+    // Stable across the settle window — trust the fresher evidence.
+    return {
+      storyId,
+      storyBranch,
+      probes: second.probes,
+      stability: { reprobed: true, stable: true, delayMs: stabilityDelayMs },
+      ...second.decision,
+    };
+  }
+
   return {
     storyId,
     storyBranch,
-    probes: { ticket, branch, pr },
-    ...decision,
+    probes: second.probes,
+    stability: { reprobed: true, stable: false, delayMs: stabilityDelayMs },
+    ...buildInTransitionVerdict({
+      storyId,
+      first: first.decision,
+      second: second.decision,
+      delayMs: stabilityDelayMs,
+    }),
   };
 }
 

--- a/tests/scripts/deliver-recover.test.js
+++ b/tests/scripts/deliver-recover.test.js
@@ -356,11 +356,18 @@ describe('deliver-recover — recoverStory', () => {
         },
       },
       gitSpawnFn: gitStub,
+      sleepFn: async () => {},
     });
     assert.equal(recovery.storyBranch, 'story-4543');
     assert.equal(recovery.shape, 'closing-pr-pending');
     assert.equal(recovery.probes.ticket.lease, 'dsj1984');
     assert.equal(recovery.nextCommand, NEXT_COMMANDS.resumeLand(STORY_ID));
+    // Transient shape, unchanged across the settle window → stable verdict.
+    assert.deepEqual(recovery.stability, {
+      reprobed: true,
+      stable: true,
+      delayMs: 5000,
+    });
   });
 
   it('throws a named error when the ticket itself is unreadable', async () => {
@@ -395,5 +402,155 @@ describe('deliver-recover — recoverStory', () => {
     assert.match(rendered, /Evidence:/);
     assert.match(rendered, /Next command:/);
     assert.match(rendered, /single-story-confirm-merge\.js --story 4543/);
+  });
+});
+
+describe('deliver-recover — stability re-probe (mid-flight strands)', () => {
+  const gitStub = (_cwd, ...args) =>
+    args[0] === 'worktree'
+      ? { status: 0, stdout: 'worktree /repo/.worktrees/story-4543\n' }
+      : { status: 0, stdout: '' };
+
+  const executingProvider = () => ({
+    calls: 0,
+    getTicket: async function () {
+      this.calls += 1;
+      return {
+        id: STORY_ID,
+        state: 'open',
+        title: 'x',
+        labels: ['agent::executing'],
+        assignees: ['dsj1984'],
+      };
+    },
+  });
+
+  it('a shape that flips between probes reports in-transition, not the first guess (the #4712 strand)', async () => {
+    // Probe 1 lands before the close's push/PR-open; probe 2 lands after.
+    let prCalls = 0;
+    const recovery = await recoverStory({
+      storyId: STORY_ID,
+      cwd: '/repo',
+      config: {},
+      provider: executingProvider(),
+      gh: {
+        pr: {
+          list: async () => {
+            prCalls += 1;
+            return prCalls === 1
+              ? []
+              : [{ number: 4715, url: 'https://x/4715', state: 'OPEN' }];
+          },
+        },
+      },
+      gitSpawnFn: gitStub,
+      sleepFn: async () => {},
+    });
+    assert.equal(recovery.shape, 'in-transition');
+    assert.equal(recovery.nextCommand, NEXT_COMMANDS.recover(STORY_ID));
+    assert.deepEqual(recovery.stability, {
+      reprobed: true,
+      stable: false,
+      delayMs: 5000,
+    });
+    assert.ok(recovery.evidence.includes('probe1.shape=executing-no-pr'));
+    assert.ok(recovery.evidence.includes('probe2.shape=executing-with-pr'));
+    assert.match(recovery.detail, /actively\s+mutating/);
+  });
+
+  it('a transient shape stable across the settle window returns the fresher verdict', async () => {
+    const provider = executingProvider();
+    let prCalls = 0;
+    const recovery = await recoverStory({
+      storyId: STORY_ID,
+      cwd: '/repo',
+      config: {},
+      provider,
+      gh: {
+        pr: {
+          list: async () => {
+            prCalls += 1;
+            return [];
+          },
+        },
+      },
+      gitSpawnFn: gitStub,
+      sleepFn: async () => {},
+    });
+    assert.equal(recovery.shape, 'executing-no-pr');
+    assert.equal(provider.calls, 2);
+    assert.equal(prCalls, 2);
+    assert.deepEqual(recovery.stability, {
+      reprobed: true,
+      stable: true,
+      delayMs: 5000,
+    });
+  });
+
+  it('a settled shape (blocked) never pays the second probe', async () => {
+    const provider = {
+      calls: 0,
+      getTicket: async function () {
+        this.calls += 1;
+        return {
+          id: STORY_ID,
+          state: 'open',
+          title: 'x',
+          labels: ['agent::blocked'],
+          assignees: ['dsj1984'],
+        };
+      },
+    };
+    const recovery = await recoverStory({
+      storyId: STORY_ID,
+      cwd: '/repo',
+      config: {},
+      provider,
+      gh: { pr: { list: async () => [] } },
+      gitSpawnFn: gitStub,
+      sleepFn: async () => {
+        throw new Error('settled shapes must not sleep');
+      },
+    });
+    assert.equal(recovery.shape, 'blocked');
+    assert.equal(provider.calls, 1);
+    assert.deepEqual(recovery.stability, { reprobed: false });
+  });
+
+  it('reprobe: false restores the single-probe verdict even for transient shapes', async () => {
+    const provider = executingProvider();
+    const recovery = await recoverStory({
+      storyId: STORY_ID,
+      cwd: '/repo',
+      config: {},
+      provider,
+      gh: { pr: { list: async () => [] } },
+      gitSpawnFn: gitStub,
+      reprobe: false,
+      sleepFn: async () => {
+        throw new Error('reprobe:false must not sleep');
+      },
+    });
+    assert.equal(recovery.shape, 'executing-no-pr');
+    assert.equal(provider.calls, 1);
+    assert.deepEqual(recovery.stability, { reprobed: false });
+  });
+
+  it('the settle window is configurable and reaches the sleep seam', async () => {
+    const delays = [];
+    const recovery = await recoverStory({
+      storyId: STORY_ID,
+      cwd: '/repo',
+      config: {},
+      provider: executingProvider(),
+      gh: { pr: { list: async () => [] } },
+      gitSpawnFn: gitStub,
+      stabilityDelayMs: 1234,
+      sleepFn: async (ms) => {
+        delays.push(ms);
+      },
+    });
+    assert.deepEqual(delays, [1234]);
+    assert.equal(recovery.stability.delayMs, 1234);
   });
 });


### PR DESCRIPTION
## Why

`deliver-recover`'s decision table assumed its probes were a snapshot of a settled state, but the `executing-*`/`closing-*` shapes are exactly the ones a live close mutates while it runs. Observed live on Story #4712: a probe that landed seconds before the close's push/PR-open confidently reported `executing-no-pr` → "re-run init" while PR #4715 was moments from existing; a second probe seconds later flipped the verdict. Acting on the first verdict misdirects the operator against a live run.

## What

- **Stability re-probe for transient shapes** (`executing-no-pr`, `executing-with-pr`, `closing-no-pr`, `closing-pr-pending`, `closing-pr-red`): a second probe after a 5s settle window — the same consecutive-evidence pattern the merge wait's `checks-failed` fail-fast adopted in #4695. Matching shapes return the fresher verdict (annotated `stability: {reprobed, stable, delayMs}`); diverging shapes return an honest **`in-transition`** verdict naming both observed shapes, whose one next command (never a menu) is the probe itself, re-run once the live process settles.
- **Settled shapes** (`merged-label-stale`, `blocked`, `done-board-drift`, `ready`) never pay the second probe.
- **`--no-reprobe`** restores single-probe behavior for scripted callers that own their own settling.
- The decision table itself is untouched — the pass wraps it; all pre-existing tests pass with one mechanical seam addition.

## Verification

- 27/27 `tests/scripts/deliver-recover.test.js` (5 new, including a regression pin of the exact #4712 flip: probe1 `executing-no-pr` → probe2 `executing-with-pr` → `in-transition`)
- `npx biome ci` clean on all touched files; `npm run lint` clean
- Both dead-exports ratchets clean (no new exports — the delay constant and shape set are module-private)
- `quality-preview --changed-since origin/main`: 0 MI regressions, 0 CRAP violations

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Read-only operator tooling with expanded tests; behavior change only affects recovery guidance, not delivery mutations.
> 
> **Overview**
> **`deliver-recover`** no longer treats a single snapshot as authoritative for mid-flight delivery shapes (`executing-*`, `closing-*`). For those transient shapes it runs a **second probe after a 5s settle window**; if the shape matches, the response includes fresher evidence and `stability: { reprobed, stable, delayMs }`. If the shape **changes between probes** (e.g. `executing-no-pr` → `executing-with-pr` while a close is opening a PR), the verdict is **`in-transition`** with guidance to re-run the probe instead of a likely-wrong “next command.”
> 
> Settled shapes (`merged-label-stale`, `blocked`, `done-board-drift`, `ready`) skip the second round. The CLI adds **`--no-reprobe`** for single-probe behavior; tests cover the #4712 flip regression and `reprobe: false` / configurable delay via injectable `sleepFn`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b5589fba5c615fc75a979eaebff810c30c7904cb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->