### PR TITLE
feat: single-owner acceptance verification + plan-template hardening (#4723)

### DIFF
--- a/.agents/scripts/acceptance-eval.js
+++ b/.agents/scripts/acceptance-eval.js
@@ -3,12 +3,16 @@
 /**
  * acceptance-eval.js — bounded per-Story acceptance self-eval gate (Story #3819).
  *
- * The Story-implementation phase runs an independent (fresh-context)
- * critic pass that scores the caller-injected change set against each
- * inline `acceptance[]` item, emitting one verdict file per round
+ * The Story-implementation phase runs ONE verdict-owner per acceptance
+ * cluster (Story #4723) — the fresh-context critic when
+ * `ceremony-routing.js` sensitivity-routes the cluster fresh, the
+ * contract-identical inline self-eval otherwise — which scores the
+ * caller-injected change set against each inline `acceptance[]` item and
+ * emits one verdict file per round
  * (`.agents/schemas/acceptance-eval-verdict.schema.json`). This CLI is the
- * deterministic substrate that turns that verdict into the loop's next
- * action:
+ * deterministic SCORER of that single authored verdict — it validates and
+ * decides, it never re-scores the criteria as an independent additional
+ * pass — turning the verdict into the loop's next action:
  *
  *   1. Validate the verdict file against the verdict JSON Schema (a
  *      malformed verdict is a hard error — the loop refuses to guess).

--- a/.agents/scripts/lib/orchestration/ceremony-routing.js
+++ b/.agents/scripts/lib/orchestration/ceremony-routing.js
@@ -35,6 +35,19 @@
  * sub-agent. This module takes the cluster index as an INPUT and returns a
  * decision for that one cluster; it has no way to add or remove clusters.
  *
+ * ## One verdict-owner per cluster (Story #4723)
+ *
+ * The resolved decision names the cluster's **single verdict owner** via
+ * `verdictOwner`: `'fresh-critic'` when the mode is `fresh`,
+ * `'inline-self-eval'` when the mode is `inline`. Exactly one pass authors
+ * the cluster's verdict — the fresh maker-blind critic OR the
+ * contract-identical inline self-eval, never both, and never an additional
+ * pre-pass self-assessment before the owner runs. `acceptance-eval.js` is
+ * the deterministic SCORER of that one authored verdict (schema validation,
+ * round cap, proceed/redraft/block) — it is not a third pass over the
+ * criteria. This removes a redundant pass only; it never removes a
+ * cluster's verdict (the M4-B floor above holds).
+ *
  * ## Tier rules (per cluster, `standard` profile)
  *
  *   - `high` level       → `fresh`   (a sensitive path was touched — a
@@ -63,9 +76,22 @@
  * `undefined` / malformed inputs degrade to `fresh` + `full` ceremony.
  *
  * @typedef {'fresh'|'inline'} CeremonyMode
+ * @typedef {'fresh-critic'|'inline-self-eval'} VerdictOwner
  * @typedef {import('./review-depth.js').ChangeLevel} ChangeLevel
  * @typedef {'minimal'|'standard'|'strict'} CeremonyProfile
  */
+
+/**
+ * Map a resolved ceremony mode to the cluster's single verdict owner
+ * (Story #4723). Total: any non-`fresh` value maps to the inline
+ * self-eval owner, mirroring how the mode itself degrades.
+ *
+ * @param {CeremonyMode} mode
+ * @returns {VerdictOwner}
+ */
+export function verdictOwnerForMode(mode) {
+  return mode === 'fresh' ? 'fresh-critic' : 'inline-self-eval';
+}
 
 /** @type {readonly CeremonyProfile[]} */
 export const CEREMONY_PROFILES = Object.freeze([
@@ -133,9 +159,28 @@ export function sampledFresh(clusterIndex, rate) {
  *   reason: string,
  *   sampled: boolean,
  *   profile: CeremonyProfile,
+ *   verdictOwner: VerdictOwner,
  * }}
  */
 export function resolveCeremonyForRisk(input = {}) {
+  const decision = resolveCeremonyDecision(input);
+  return { ...decision, verdictOwner: verdictOwnerForMode(decision.mode) };
+}
+
+/**
+ * Internal mode/reason resolution — the tier rules and sampling floor.
+ * `resolveCeremonyForRisk` decorates the result with the single
+ * `verdictOwner` derived from the mode (Story #4723).
+ *
+ * @param {Parameters<typeof resolveCeremonyForRisk>[0]} [input]
+ * @returns {{
+ *   mode: CeremonyMode,
+ *   reason: string,
+ *   sampled: boolean,
+ *   profile: CeremonyProfile,
+ * }}
+ */
+function resolveCeremonyDecision(input = {}) {
   const derivedLevel =
     input && typeof input === 'object' ? input.derivedLevel : undefined;
   const clusterIndex =

--- a/.agents/scripts/lib/orchestration/plan-context.js
+++ b/.agents/scripts/lib/orchestration/plan-context.js
@@ -145,6 +145,41 @@ export const TICKET_SCHEMA_DESCRIPTOR = Object.freeze({
 export const STORIES_TEMPLATE_FILENAME = 'stories.template.json';
 
 /**
+ * Build the template's `changes[]` entries from the envelope's advisory
+ * complexity signals (Story #4723). Each seed-predicted path is
+ * pre-resolved to its creates-vs-refactors assumption against the repo
+ * snapshot the signals already probed: a path present in the repo is a
+ * `refactors-existing`, a missing one is a `creates`. Order follows
+ * `predictedPaths` (first appearance in the seed). Falls back to the
+ * single instructive placeholder entry when the seed predicted no paths.
+ *
+ * @param {{
+ *   predictedPaths?: string[],
+ *   repoState?: { existingPaths?: string[], missingPaths?: string[] },
+ * }|null|undefined} complexitySignals
+ * @returns {Array<{ path: string, assumption: string }>}
+ */
+function buildTemplateChanges(complexitySignals) {
+  const predicted = Array.isArray(complexitySignals?.predictedPaths)
+    ? complexitySignals.predictedPaths.filter(
+        (p) => typeof p === 'string' && p.length > 0,
+      )
+    : [];
+  if (predicted.length === 0) {
+    return [{ path: 'path/to/file.ext', assumption: 'refactors-existing' }];
+  }
+  const existing = new Set(
+    Array.isArray(complexitySignals?.repoState?.existingPaths)
+      ? complexitySignals.repoState.existingPaths
+      : [],
+  );
+  return predicted.map((path) => ({
+    path,
+    assumption: existing.has(path) ? 'refactors-existing' : 'creates',
+  }));
+}
+
+/**
  * Render the ready-to-fill `stories.json` authoring template (Story #4707).
  *
  * One-shot authoring: the planner copies this file to `stories.json`, fills
@@ -158,12 +193,23 @@ export const STORIES_TEMPLATE_FILENAME = 'stories.template.json';
  * / `verify[]` live at the ticket's top level — the machine contract persist
  * syncs into the body.
  *
+ * Correct-by-construction skeleton (Story #4723): the emitted `verify[]`
+ * placeholder already ends with a valid `(tier)` tag (swap `(unit)` for
+ * `(contract)` / `(e2e)` / `(validate)` where appropriate), and when the
+ * envelope's `complexitySignals` predicted a footprint the `changes[]`
+ * entries arrive pre-resolved to creates-vs-refactors against the repo
+ * snapshot — a faithfully-filled skeleton passes the persist ticket
+ * validators without a mechanical round-trip. The persist gates stay
+ * authoritative (they probe the base branch ref, not the working tree).
+ *
  * Pure and deterministic; the output is valid JSON (parseable as-is), with
  * instructive placeholder values rather than comments.
  *
+ * @param {{ complexitySignals?: object|null }} [opts] Envelope signals to
+ *   pre-resolve the skeleton against; omit for the bare placeholder shape.
  * @returns {string} Pretty-printed JSON template content.
  */
-export function renderStoriesTemplate() {
+export function renderStoriesTemplate({ complexitySignals = null } = {}) {
   const template = [
     {
       slug: 'fill-hyphen-case-slug',
@@ -176,11 +222,9 @@ export function renderStoriesTemplate() {
           'codes, security invariants, and load-bearing constraints with ' +
           'their why. Implementation choices belong to the deliverer unless ' +
           'load-bearing. No per-file behavior paragraphs, no current-state ' +
-          'narration. Delete this field when acceptance[] carries the whole ' +
-          'contract.',
-        changes: [
-          { path: 'path/to/file.ext', assumption: 'refactors-existing' },
-        ],
+          'narration. Keep it under ~250 words (soft advisory budget). ' +
+          'Delete this field when acceptance[] carries the whole contract.',
+        changes: buildTemplateChanges(complexitySignals),
         non_goals: [],
         reason_to_exist:
           'Fill: the single coherent reason this Story exists (one sentence).',
@@ -188,7 +232,9 @@ export function renderStoriesTemplate() {
       acceptance: [
         'Fill: a testable, observable criterion (a command exits 0, a file exists, a test matches)',
       ],
-      verify: ['Fill: exact command or test path (unit|contract|e2e|validate)'],
+      verify: [
+        'Fill: exact command or test path — keep the trailing tier tag valid: unit, contract, e2e, or validate (unit)',
+      ],
       depends_on: [],
     },
   ];

--- a/.agents/scripts/lib/orchestration/ticket-validator-conflicts.js
+++ b/.agents/scripts/lib/orchestration/ticket-validator-conflicts.js
@@ -829,6 +829,12 @@ export function renderHardConflictError(finding) {
   if (finding.kind === 'missing-bdd-scaffold') {
     return `Missing BDD scaffold: Story "${finding.consumer.storySlug}" verifies against "${finding.path}" (created by Story "${finding.producer.storySlug}") via body.${finding.consumer.sourceField}, but "${finding.consumer.storySlug}" has no depends_on path to "${finding.producer.storySlug}" — the .feature file is scaffolded in the same wave (or later), so verification runs before the file exists. Add depends_on: ["${finding.producer.storySlug}"] to the consumer Story so the scaffold lands in an earlier wave.`;
   }
+  // Findings from other passes (sizing, spec-word-budget) carry their own
+  // message — render it rather than a shape-blind generic line, so the soft
+  // surface (`surfaceSoftConflictFindings`) stays legible for every kind.
+  if (typeof finding.message === 'string' && finding.message.length > 0) {
+    return finding.message;
+  }
   return `Conflict finding ${finding.kind} on path "${finding.path ?? '<unknown>'}".`;
 }
 

--- a/.agents/scripts/lib/orchestration/ticket-validator.js
+++ b/.agents/scripts/lib/orchestration/ticket-validator.js
@@ -135,6 +135,69 @@ function resolveAcceptanceLines(story) {
   return [...lines];
 }
 
+/**
+ * Soft advisory word budget for a Story's inline `## Spec` (Story #4723).
+ * ~250 words is the #4707 contract-level-prose target: interfaces,
+ * invariants, and load-bearing constraints — not route-by-route behavior
+ * narration. Distinct from the hard ~1500-token fail-closed ceiling in
+ * `spec-spill.js`: this budget only warns; it never fails the persist.
+ */
+export const SPEC_SOFT_WORD_BUDGET = 250;
+
+/**
+ * Resolve a Story's Spec prose across both authoring shapes: the canonical
+ * serialized string body (parsed; `## Spec` text block) and the
+ * pre-serialize structured object body (`body.spec`). Returns `''` when
+ * absent. Callers run after `assertStoryBodiesParse`, so a string body
+ * parses here.
+ *
+ * @param {object} story
+ * @returns {string}
+ */
+function resolveSpecText(story) {
+  const body = story?.body;
+  if (typeof body === 'string' && body.trim().length > 0) {
+    const spec = parseStoryBodyOrThrow(story).spec;
+    return typeof spec === 'string' ? spec : '';
+  }
+  if (body !== null && typeof body === 'object') {
+    return typeof body.spec === 'string' ? body.spec : '';
+  }
+  return '';
+}
+
+/**
+ * Advisory `## Spec` length pass (Story #4723). Emits one `'soft'` finding
+ * per Story whose Spec prose exceeds {@link SPEC_SOFT_WORD_BUDGET} words,
+ * nudging the author toward contract-level prose (#4707). Soft only — the
+ * findings never reach the validator's `errors[]` channel, so an
+ * over-budget Spec never fails the persist.
+ *
+ * @param {{ stories: object[] }} opts
+ * @returns {object[]} Zero or more `spec-word-budget` findings.
+ */
+function computeSpecBudgetFindings({ stories }) {
+  const findings = [];
+  for (const story of stories ?? []) {
+    const words = resolveSpecText(story).split(/\s+/).filter(Boolean).length;
+    if (words <= SPEC_SOFT_WORD_BUDGET) continue;
+    findings.push({
+      kind: 'spec-word-budget',
+      severity: 'soft',
+      ticketSlug: story.slug ?? '<unknown>',
+      words,
+      budget: SPEC_SOFT_WORD_BUDGET,
+      message:
+        `Story "${story.slug ?? '<unknown>'}" ## Spec is ~${words} words ` +
+        `(soft budget ${SPEC_SOFT_WORD_BUDGET}). Prefer contract-level prose ` +
+        '(interfaces, invariants, load-bearing constraints with their why) ' +
+        'over per-file behavior narration — advisory only; the persist ' +
+        'proceeds.',
+    });
+  }
+  return findings;
+}
+
 function collectTaskPathReferences(task) {
   const paths = new Set();
   const body = task.body;
@@ -721,7 +784,19 @@ export function validateAndNormalizeTickets(tickets, opts = {}) {
     stories,
     policy: opts.conflictPolicy,
   });
-  const findings = [...sizingFindings, ...conflictFindings];
+  // Advisory `## Spec` word-budget pass (Story #4723) — soft findings only,
+  // surfaced as warnings here and via the persist soft-finding channel;
+  // never promoted to `errors[]`, so an over-budget Spec cannot fail the
+  // persist. Runs after `assertStoryBodiesParse`, so string bodies parse.
+  const specBudgetFindings = computeSpecBudgetFindings({ stories });
+  for (const finding of specBudgetFindings) {
+    Logger.warn(`[ticket-validator] spec-word-budget: ${finding.message}`);
+  }
+  const findings = [
+    ...sizingFindings,
+    ...conflictFindings,
+    ...specBudgetFindings,
+  ];
   const CONFLICT_KINDS = new Set([
     'shared-editor',
     'implicit-cross-story-dep',

--- a/.agents/scripts/plan-context.js
+++ b/.agents/scripts/plan-context.js
@@ -124,7 +124,7 @@ export async function emitPlanContext({
     // later turn. When it is captured to disk anyway, stdout carries a
     // compact digest naming the artifact instead of the payload itself.
     await writeEnvelopeFile(outPath, json);
-    await writeStoriesTemplateFile(outPath);
+    await writeStoriesTemplateFile(outPath, envelope);
     const resolved = path.resolve(outPath);
     const digest = {
       digest: 'plan-context',
@@ -186,18 +186,27 @@ async function writeEnvelopeFile(outPath, json) {
  * requires reading `story-body.js` source. Written whenever `--out` is
  * passed, and throwing on failure for the same reason the envelope write
  * does: a silently missing template re-opens the format-discovery loop it
- * exists to close.
+ * exists to close. The envelope's advisory `complexitySignals` are threaded
+ * through so the skeleton's `changes[]` arrive pre-resolved to
+ * creates-vs-refactors against the repo snapshot (Story #4723).
  *
  * @param {string} outPath The envelope `--out` path; the template lands in
  *   the same directory as {@link STORIES_TEMPLATE_FILENAME}.
+ * @param {object} [envelope] The emitted plan-context envelope.
  */
-async function writeStoriesTemplateFile(outPath) {
+async function writeStoriesTemplateFile(outPath, envelope = {}) {
   const resolved = path.resolve(
     path.dirname(path.resolve(outPath)),
     STORIES_TEMPLATE_FILENAME,
   );
   try {
-    await writeFile(resolved, renderStoriesTemplate(), 'utf8');
+    await writeFile(
+      resolved,
+      renderStoriesTemplate({
+        complexitySignals: envelope?.complexitySignals ?? null,
+      }),
+      'utf8',
+    );
   } catch (err) {
     throw new Error(
       `[plan-context] cannot write stories template to ${resolved}: ${err.message}`,

--- a/.agents/workflows/helpers/acceptance-self-eval.md
+++ b/.agents/workflows/helpers/acceptance-self-eval.md
@@ -30,10 +30,19 @@ mid-delivery, and evaluates the actual work product.
 
 ## Per round
 
-1. **Eval pass (fresh context, independent of the author).** Run a **separate
-   critic pass** — a fresh-context sub-agent (`Agent` tool), *not* a
-   continuation of your implementing turn — so the evaluator does not grade its
-   own homework.
+1. **Eval pass — one verdict-owner per cluster (Story #4723).** Exactly
+   **one** pass authors each cluster's verdict: the **fresh-context critic**
+   when the ceremony routing below resolves `fresh` (a sub-agent via the
+   `Agent` tool, *not* a continuation of your implementing turn — the
+   evaluator does not grade its own homework), or the **inline self-eval**
+   when it resolves `inline`. The resolved decision names the owner
+   explicitly (`verdictOwner: 'fresh-critic' | 'inline-self-eval'` from
+   `resolveCeremonyForRisk`). **Never run both**, and never run a
+   preliminary self-assessment pass before dispatching the fresh critic —
+   the redundant pre-pass buys no measurable quality and roughly triples
+   the acceptance-block cost. Step 2's gate is the deterministic **scorer**
+   of the one authored verdict, not a second (or third) pass over the
+   criteria.
 
    > **Sub-agent type + derived-level ceremony (Epic #4478, M7-B).** When
    > `delivery.routing.roleScopedAgents` is enabled (the **default**), dispatch
@@ -129,7 +138,9 @@ mid-delivery, and evaluates the actual work product.
      one `{ index, criterion, verdict: met|partial|unmet, evidence,
      verifyEvidence[] }` record per acceptance item.
 2. **Decide.** Run the gate against the verdict (the caller's Step 1a names the
-   exact invocation — omit `--epic`):
+   exact invocation — omit `--epic`). The gate **scores the single verdict
+   the round's owner authored** — schema validation, round cap, decision —
+   and never re-scores the criteria itself (Story #4723):
 
    ```bash
    node <main-repo>/.agents/scripts/acceptance-eval.js \

--- a/.agents/workflows/helpers/deliver-story-reference.md
+++ b/.agents/workflows/helpers/deliver-story-reference.md
@@ -181,6 +181,20 @@ directly.
 
 ### Step 1a — self-eval mechanics
 
+**One verdict-owner per cluster (Story #4723).** The ceremony routing's
+resolved decision names each cluster's single verdict owner
+(`verdictOwner: 'fresh-critic' | 'inline-self-eval'` from
+`resolveCeremonyForRisk`): the fresh maker-blind critic when sensitivity
+routes the cluster `fresh`, the contract-identical inline self-eval when it
+routes `inline`. Exactly one pass authors the verdict — never both, and
+never a preliminary self-assessment pass before dispatching the fresh
+critic (the redundant pre-pass buys no measurable quality and roughly
+triples the acceptance-block cost). `acceptance-eval.js` is the
+deterministic **scorer** of that one authored verdict — schema validation,
+round cap, proceed / redraft / block — not an independent additional pass
+over the criteria. The M4-B floor holds: one verdict per cluster, the
+cluster count owned by `acceptance-clusters.js` alone.
+
 **Critic evidence-share (Story #4250).** When the critic runs a `verify[]`
 command that is byte-identical to a close gate (`lint` / `typecheck`), it
 records the pass into the Story evidence keyspace via `--standalone` so

--- a/.agents/workflows/helpers/deliver-story.md
+++ b/.agents/workflows/helpers/deliver-story.md
@@ -75,7 +75,7 @@ One branch, one PR to `main`, commits against the inline `acceptance[]` /
 ### Step 1a — Bounded acceptance self-eval loop (**required**)
 
 Follow the single-homed include
-[`acceptance-self-eval.md`](acceptance-self-eval.md) (fresh-context critic,
+[`acceptance-self-eval.md`](acceptance-self-eval.md) (single verdict-owner,
 `verify[]`-as-evidence, proceed / redraft / block). Gate invocation (omit
 `--epic`):
 

--- a/.agents/workflows/helpers/plan-reference.md
+++ b/.agents/workflows/helpers/plan-reference.md
@@ -53,6 +53,35 @@ in [`.agents/docs/configuration.md`](../../docs/configuration.md) under
 ceilings on `STORY_SHAPE_CEILINGS` in
 [`lib/orchestration/complexity-gate.js`](../../scripts/lib/orchestration/complexity-gate.js).
 
+## Correct-by-construction authoring template (Story #4723)
+
+`plan-context.js --out` writes `stories.template.json` as a
+**correct-by-construction** skeleton, built from the same repo snapshot the
+`complexitySignals` probed:
+
+- **`verify[]` placeholders already end with a valid `(tier)` tag.** Keep
+  every filled entry's trailing tag one of `(unit)` / `(contract)` /
+  `(e2e)` / `(validate)` (or use the `manual:<reason>` escape) — a tierless
+  entry is exactly the mechanical persist round-trip the template exists to
+  prevent.
+- **`changes[]` arrive pre-resolved to creates-vs-refactors.** Every path
+  the seed predicted is probed against the repo: an existing path is
+  emitted with `assumption: "refactors-existing"`, a missing one with
+  `assumption: "creates"`. Trust the pre-resolved assumption — verify
+  against the repo before overriding one (authoring `creates` for a file
+  that exists at base is a validator rejection). The persist gates stay
+  authoritative: they probe the base branch ref, not the working tree.
+- **Keep `## Spec` near contract-level prose.** Persist emits an
+  **advisory** warning past ~250 words (`SPEC_SOFT_WORD_BUDGET`) — it never
+  fails the persist, but it is the nudge toward the #4707 contract-level
+  Spec (interfaces, invariants, load-bearing constraints; no per-file
+  behavior narration). The hard fail-closed ceiling (~1500 tokens,
+  `spec-spill.js`) is unchanged.
+
+A faithfully-filled skeleton — placeholders replaced, pre-resolved entries
+kept, tags valid — passes the persist ticket validators with no
+round-trip.
+
 ## Tickets mode — authoring `supersedes[]`
 
 In `--tickets` mode each Story carries a top-level `supersedes` array claiming

--- a/.agents/workflows/plan.md
+++ b/.agents/workflows/plan.md
@@ -79,8 +79,9 @@ duplicate-candidate review. Under `--yes`, auto-proceed.
 
 ### 2. Author
 
-**One-shot authoring (Story #4707).** Start from `stories.template.json`
-(or the skeleton below); author `stories.json` in one pass. `body` is a
+**One-shot authoring (Story #4707).** Start from `stories.template.json`;
+author `stories.json` in one pass. Entries are pre-resolved (#4723); keep
+tiers/assumptions valid. `body` is a
 markdown string **or** a structured object; persist parses either,
 serializes the canonical markdown, and syncs the top-level `acceptance[]` /
 `verify[]` into the body — never dual-author those lists.
@@ -182,7 +183,7 @@ persist, re-run the same command; never hand-delete issues.
 
 - [`/deliver`](deliver.md) — delivery entry point.
 - [`/audit-to-stories`](audit-to-stories.md) — audit findings → plan seed.
-- [`helpers/plan-reference.md`](helpers/plan-reference.md) — routing,
-  supersede, critic, and persist-resume detail.
+- [`helpers/plan-reference.md`](helpers/plan-reference.md) — on-demand
+  detail.
 - [`core/scope-triage`](../skills/core/scope-triage/SKILL.md) — optional
   split-advisory notes only (no routing verdict).

--- a/baselines/dead-exports-production.json
+++ b/baselines/dead-exports-production.json
@@ -2042,6 +2042,10 @@
     },
     {
       "file": ".agents/scripts/lib/orchestration/ticket-validator.js",
+      "symbol": "SPEC_SOFT_WORD_BUDGET"
+    },
+    {
+      "file": ".agents/scripts/lib/orchestration/ticket-validator.js",
       "symbol": "_internal"
     },
     {

--- a/tests/lib/orchestration/ceremony-routing.test.js
+++ b/tests/lib/orchestration/ceremony-routing.test.js
@@ -20,6 +20,7 @@ import { expectedClusterCount } from '../../../.agents/scripts/lib/orchestration
 import {
   resolveCeremonyForRisk,
   sampledFresh,
+  verdictOwnerForMode,
 } from '../../../.agents/scripts/lib/orchestration/ceremony-routing.js';
 
 describe('resolveCeremonyForRisk — ceremony profiles', () => {
@@ -101,6 +102,58 @@ describe('resolveCeremonyForRisk — per-cluster tier rules', () => {
         d.mode,
         'fresh',
         `expected fresh for ${JSON.stringify(bad)}`,
+      );
+    }
+  });
+});
+
+describe('single verdict-owner per cluster (Story #4723)', () => {
+  // AC-1: acceptance verification runs ONE verdict-owner per cluster — the
+  // fresh critic when sensitivity routes it, the inline self-eval otherwise.
+  // The resolved decision names that owner explicitly, and it is always
+  // exactly one of the two authoring passes; `acceptance-eval.js` is the
+  // deterministic scorer of that verdict, never a third owner.
+  test('verdictOwnerForMode maps each mode to its single owner', () => {
+    assert.equal(verdictOwnerForMode('fresh'), 'fresh-critic');
+    assert.equal(verdictOwnerForMode('inline'), 'inline-self-eval');
+  });
+
+  test('every resolution names exactly one owner, aligned with its mode', () => {
+    const inputs = [
+      { derivedLevel: 'high', clusterIndex: 0 },
+      { derivedLevel: 'low', clusterIndex: 1, freshCriticSampleRate: 0.2 },
+      { derivedLevel: 'low', clusterIndex: 0, freshCriticSampleRate: 0.2 },
+      { derivedLevel: null, clusterIndex: 2 },
+      { derivedLevel: 'low', clusterIndex: 3, ceremonyProfile: 'minimal' },
+      { derivedLevel: 'low', clusterIndex: 4, ceremonyProfile: 'strict' },
+    ];
+    for (const input of inputs) {
+      const d = resolveCeremonyForRisk(input);
+      assert.ok(
+        d.verdictOwner === 'fresh-critic' ||
+          d.verdictOwner === 'inline-self-eval',
+        `owner must be one of the two authoring passes, got ${d.verdictOwner}`,
+      );
+      assert.equal(d.verdictOwner, verdictOwnerForMode(d.mode));
+    }
+  });
+
+  test('M4-B floor preserved: one owner per cluster at every level, count untouched', () => {
+    const count = expectedClusterCount(14, 4); // 4 clusters
+    for (const derivedLevel of ['low', 'high', undefined]) {
+      const owners = Array.from(
+        { length: count },
+        (_v, clusterIndex) =>
+          resolveCeremonyForRisk({
+            derivedLevel,
+            clusterIndex,
+            freshCriticSampleRate: 0.2,
+          }).verdictOwner,
+      );
+      // Exactly one owner per cluster — never zero, never a second pass.
+      assert.equal(owners.length, count);
+      assert.ok(
+        owners.every((o) => o === 'fresh-critic' || o === 'inline-self-eval'),
       );
     }
   });

--- a/tests/lib/orchestration/complexity-gate.test.js
+++ b/tests/lib/orchestration/complexity-gate.test.js
@@ -100,7 +100,10 @@ describe('buildComplexitySignals — signals, not routing (AC-1, AC-2)', () => {
       seedText:
         'Tweak src/auth/session.js and add the new src/widgets/list.js helper.',
       injectedRules: RULES,
-      pathExistsFn: (abs) => abs.endsWith('src/auth/session.js'),
+      // path.resolve produces platform separators — normalize before the
+      // suffix match so the probe also fires on Windows (backslash paths).
+      pathExistsFn: (abs) =>
+        abs.replaceAll('\\', '/').endsWith('src/auth/session.js'),
     });
     assert.deepEqual(signals.predictedPaths, [
       'src/auth/session.js',

--- a/tests/lib/orchestration/ticket-validator.test.js
+++ b/tests/lib/orchestration/ticket-validator.test.js
@@ -2,8 +2,10 @@ import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 import {
   _internal,
+  SPEC_SOFT_WORD_BUDGET,
   validateAndNormalizeTickets,
 } from '../../../.agents/scripts/lib/orchestration/ticket-validator.js';
+import { serialize } from '../../../.agents/scripts/lib/story-body/story-body.js';
 
 /**
  * Stories-only backlog invariant (Story #4041).
@@ -114,5 +116,62 @@ describe('assertAllTicketsAreStories unit (Story #4041)', () => {
     assert.doesNotThrow(() =>
       assertAllTicketsAreStories({ tickets, stories: tickets }),
     );
+  });
+});
+
+/**
+ * Soft `## Spec` word-budget pass (Story #4723, AC-3): an over-budget Spec
+ * produces an advisory `'soft'` finding and NEVER an error — the persist
+ * proceeds. An under-budget Spec produces no finding at all.
+ */
+describe('ticket-validator: soft ## Spec word budget (Story #4723)', () => {
+  const overBudgetSpec = Array.from(
+    { length: SPEC_SOFT_WORD_BUDGET + 50 },
+    (_v, i) => `word${i}`,
+  ).join(' ');
+
+  function specFindings(validated) {
+    return validated.findings.filter((f) => f.kind === 'spec-word-budget');
+  }
+
+  it('emits one soft finding for an over-budget object-body Spec, never an error', () => {
+    const s = story('over-budget');
+    s.body.spec = overBudgetSpec;
+    const validated = validateAndNormalizeTickets([s, story('sibling')]);
+    const findings = specFindings(validated);
+    assert.equal(findings.length, 1);
+    assert.equal(findings[0].severity, 'soft');
+    assert.equal(findings[0].ticketSlug, 'over-budget');
+    assert.equal(findings[0].budget, SPEC_SOFT_WORD_BUDGET);
+    assert.ok(findings[0].words > SPEC_SOFT_WORD_BUDGET);
+    assert.match(findings[0].message, /advisory only/);
+    // Advisory only — the soft finding never reaches the errors channel.
+    assert.deepEqual(validated.errors, []);
+  });
+
+  it('fires on the canonical serialized string-body shape too', () => {
+    const s = story('string-body');
+    s.body = serialize({
+      goal: 'Goal for string-body.',
+      spec: overBudgetSpec,
+      changes: [
+        { path: 'src/string-body.js', assumption: 'refactors-existing' },
+      ],
+      acceptance: ['String-body Story is implemented'],
+      verify: ['npm test (unit)'],
+    });
+    const validated = validateAndNormalizeTickets([s]);
+    const findings = specFindings(validated);
+    assert.equal(findings.length, 1);
+    assert.equal(findings[0].severity, 'soft');
+    assert.deepEqual(validated.errors, []);
+  });
+
+  it('emits no finding for an under-budget Spec or an absent one', () => {
+    const withSpec = story('under-budget');
+    withSpec.body.spec = 'A short contract-level spec.';
+    const withoutSpec = story('no-spec');
+    const validated = validateAndNormalizeTickets([withSpec, withoutSpec]);
+    assert.deepEqual(specFindings(validated), []);
   });
 });

--- a/tests/plan-context.test.js
+++ b/tests/plan-context.test.js
@@ -22,17 +22,26 @@
  */
 
 import assert from 'node:assert/strict';
-import { mkdtemp, readdir, readFile, rm } from 'node:fs/promises';
+import {
+  mkdir,
+  mkdtemp,
+  readdir,
+  readFile,
+  rm,
+  writeFile,
+} from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { describe, it } from 'node:test';
 import { findSimilarOpenStories } from '../.agents/scripts/lib/duplicate-search.js';
+import { buildComplexitySignals } from '../.agents/scripts/lib/orchestration/complexity-gate.js';
 import {
   buildDeliveryShapeSignal,
   buildPlanContext,
   buildScopeTriageSignal,
   buildSystemPrompts,
   PLAN_CONTEXT_ENVELOPE_BYTE_CEILING,
+  renderStoriesTemplate,
   TICKET_SCHEMA_DESCRIPTOR,
 } from '../.agents/scripts/lib/orchestration/plan-context.js';
 import {
@@ -42,6 +51,11 @@ import {
 } from '../.agents/scripts/lib/orchestration/plan-persist/plan-context-source.js';
 import { resolveSourceTicketIds } from '../.agents/scripts/lib/orchestration/plan-persist/supersede-ops.js';
 import { buildDecomposerSystemPrompt } from '../.agents/scripts/lib/orchestration/planning/decomposer-context.js';
+import {
+  VERIFY_TIER_VALUES,
+  validateTaskBodies,
+} from '../.agents/scripts/lib/orchestration/task-body-validator.js';
+import { validateAndNormalizeTickets } from '../.agents/scripts/lib/orchestration/ticket-validator.js';
 import {
   renderAcceptanceSpecSystemPrompt,
   renderTechSpecSystemPrompt,
@@ -857,6 +871,119 @@ describe('plan-context --out envelope capture (Story #4554)', () => {
       stdout: sink,
     });
     assert.deepEqual(await readdir(dir), []);
+    await rm(dir, { recursive: true, force: true });
+  });
+});
+
+// Story #4723 AC-2 — the authoring skeleton is correct-by-construction:
+// verify[] placeholders carry a valid (tier) tag, changes[] paths arrive
+// pre-resolved to creates-vs-refactors against the repo snapshot, and a
+// faithfully-filled skeleton passes the persist ticket validators with no
+// round-trip.
+describe('renderStoriesTemplate — correct-by-construction skeleton (Story #4723)', () => {
+  const sink = { write: () => true };
+  const VERIFY_TIER_RE = new RegExp(
+    `\\((?:${VERIFY_TIER_VALUES.join('|')})\\)\\s*$`,
+  );
+
+  /** Fixture repo state: exactly these paths exist. */
+  const FIXTURE_FILES = new Set(['lib/existing/module.js']);
+  const FIXTURE_ROOT = path.join(tmpdir(), 'plan-ctx-fixture-root');
+  const fixtureSignals = () =>
+    buildComplexitySignals({
+      seedText:
+        'Refactor lib/existing/module.js, add lib/new/feature.js, and pin it in tests/new/feature.test.js.',
+      cwd: FIXTURE_ROOT,
+      pathExistsFn: (abs) =>
+        [...FIXTURE_FILES].some((f) => abs === path.resolve(FIXTURE_ROOT, f)),
+    });
+
+  it('emits verify[] placeholders that already carry a valid (tier) tag', () => {
+    const template = JSON.parse(renderStoriesTemplate());
+    for (const entry of template[0].verify) {
+      assert.match(entry, VERIFY_TIER_RE);
+    }
+  });
+
+  it('pre-resolves predicted changes[] paths against the repo snapshot', () => {
+    const template = JSON.parse(
+      renderStoriesTemplate({ complexitySignals: fixtureSignals() }),
+    );
+    assert.deepEqual(template[0].body.changes, [
+      { path: 'lib/existing/module.js', assumption: 'refactors-existing' },
+      { path: 'lib/new/feature.js', assumption: 'creates' },
+      { path: 'tests/new/feature.test.js', assumption: 'creates' },
+    ]);
+  });
+
+  it('falls back to the instructive placeholder entry without predicted paths', () => {
+    const template = JSON.parse(renderStoriesTemplate());
+    assert.deepEqual(template[0].body.changes, [
+      { path: 'path/to/file.ext', assumption: 'refactors-existing' },
+    ]);
+  });
+
+  it('a faithfully-filled skeleton passes the persist ticket validators with no round-trip', () => {
+    const template = JSON.parse(
+      renderStoriesTemplate({ complexitySignals: fixtureSignals() }),
+    );
+    const story = template[0];
+    // A faithful fill replaces every "Fill:" placeholder and keeps the
+    // pre-resolved changes[] and the valid trailing tier tag.
+    story.slug = 'harden-widget-pipeline';
+    story.title = 'Harden the widget pipeline';
+    story.body.goal = 'Harden the widget pipeline against stale snapshots.';
+    story.body.spec =
+      'Contract: lib/existing/module.js keeps its exported signature.';
+    story.body.reason_to_exist =
+      'The widget pipeline mis-resolves stale snapshots.';
+    story.acceptance = [
+      'The hardened pipeline resolves the snapshot and the pinned test passes',
+    ];
+    story.verify = ['npm test (unit)'];
+
+    // Persist-shaped gates: the shared validator with a git probe that
+    // mirrors the fixture repo state, then the body-shape validator.
+    const gitRunner = ({ path: p }) => FIXTURE_FILES.has(p);
+    let validated;
+    assert.doesNotThrow(() => {
+      validated = validateAndNormalizeTickets([story], {
+        baseBranchRef: 'main',
+        gitRunner,
+      });
+      validateTaskBodies(validated);
+    });
+    assert.deepEqual(validated.errors, []);
+  });
+
+  it('emitPlanContext threads the envelope signals into the written template', async () => {
+    const dir = await mkdtemp(path.join(tmpdir(), 'plan-ctx-resolved-'));
+    const repo = path.join(dir, 'repo');
+    await mkdir(path.join(repo, 'src'), { recursive: true });
+    await writeFile(path.join(repo, 'src', 'real.js'), '// fixture\n', 'utf8');
+    const outPath = path.join(dir, PLAN_CONTEXT_FILENAME);
+
+    await emitPlanContext({
+      mode: 'seed-file',
+      seedFileContent: 'Update src/real.js and add src/missing.js.',
+      provider: buildProvider(),
+      config: {},
+      settings: {},
+      outPath,
+      cwd: repo,
+      stdout: sink,
+    });
+
+    const template = JSON.parse(
+      await readFile(path.join(dir, 'stories.template.json'), 'utf8'),
+    );
+    assert.deepEqual(template[0].body.changes, [
+      { path: 'src/real.js', assumption: 'refactors-existing' },
+      { path: 'src/missing.js', assumption: 'creates' },
+    ]);
+    for (const entry of template[0].verify) {
+      assert.match(entry, VERIFY_TIER_RE);
+    }
     await rm(dir, { recursive: true, force: true });
   });
 });


### PR DESCRIPTION
Closes #4723

_Auto-opened by `/deliver`._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes delivery ceremony semantics and plan persist warnings; behavior is mostly procedural/docs plus soft advisories, but mistaken agent interpretation could skip or duplicate eval passes.
> 
> **Overview**
> **Story delivery** now documents and encodes **one verdict author per acceptance cluster**: `resolveCeremonyForRisk` returns `verdictOwner` (`fresh-critic` | `inline-self-eval`) via new `verdictOwnerForMode`, with workflow copy forbidding a preliminary self-eval before a fresh critic and clarifying that `acceptance-eval.js` only validates/scores the single authored verdict—not a third scoring pass. Cluster count (M4-B floor) is unchanged.
> 
> **`/plan` authoring** hardens `stories.template.json`: `renderStoriesTemplate` accepts envelope `complexitySignals` to pre-fill `changes[]` as creates vs refactors from predicted paths and repo probe; `verify[]` placeholders include valid `(tier)` tags and Spec guidance cites a ~250-word soft budget. The CLI threads the envelope into template writes. Persist adds advisory `spec-word-budget` soft findings (`SPEC_SOFT_WORD_BUDGET`) and conflict rendering uses each finding’s `message` when present.
> 
> Tests cover ceremony owners, template correctness, spec budget, Windows path normalization in complexity-gate fixtures, and an end-to-end faithfully-filled skeleton passing validators.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1c8aef83982c277d5957d8ec227de20a75c5681f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->