### PR TITLE
feat(migration): strip retired planning.complexityGate.maxSeedWords on consumer upgrade

### DIFF
--- a/.agents/scripts/lib/orchestration/complexity-gate.js
+++ b/.agents/scripts/lib/orchestration/complexity-gate.js
@@ -164,10 +164,16 @@ function normalizeCeiling(value, fallback) {
  * `planning` bag, or the bare `complexityGate` bag, mirroring the tolerant
  * unwrap the other routing accessors use.
  *
+ * Exported for persist (`run-plan-persist.js#resolveEffectiveRoute`), which
+ * consults `enabled` to refuse a planner lite claim when the gate is off —
+ * the schema's documented contract, and the same switch dispatch reads in
+ * {@link resolveStoryDispatchMode}, so the two read points cannot disagree
+ * about whether lite routing is live.
+ *
  * @param {object | null | undefined} config
  * @returns {{ enabled: boolean, maxArtifacts: number }}
  */
-function resolveComplexityGate(config) {
+export function resolveComplexityGate(config) {
   const raw =
     config?.planning?.complexityGate ?? config?.complexityGate ?? config ?? {};
   const bag = raw && typeof raw === 'object' ? raw : {};

--- a/.agents/scripts/lib/orchestration/plan-persist/run-plan-persist.js
+++ b/.agents/scripts/lib/orchestration/plan-persist/run-plan-persist.js
@@ -47,6 +47,7 @@ import { Logger } from '../../Logger.js';
 import {
   deriveStoryShape,
   LITE_ROUTE_LABEL,
+  resolveComplexityGate,
   resolvePlannerRouteVerdict,
 } from '../complexity-gate.js';
 import {
@@ -299,6 +300,7 @@ async function renderRunScopedPlanMetricsLine({
  * @param {{
  *   stories: ReturnType<typeof assemblePlanStories>['stories'],
  *   routeDowngradeReason?: string|null,
+ *   config?: object,
  * }} args
  * @returns {{
  *   route: 'lite'|'full',
@@ -307,9 +309,31 @@ async function renderRunScopedPlanMetricsLine({
  *   shape: Array<{ slug: string, route: string, reasons: string[], shape: object|null }>,
  * }|null} `null` when the planner authored no verdict (nothing to persist).
  */
-function resolveEffectiveRoute({ stories, routeDowngradeReason = null }) {
+function resolveEffectiveRoute({
+  stories,
+  routeDowngradeReason = null,
+  config = {},
+}) {
   const verdict = resolvePlannerRouteVerdict({ reason: routeDowngradeReason });
   if (verdict.route !== 'lite') return null;
+
+  // The schema's documented contract: with the gate disabled
+  // (`planning.complexityGate.enabled=false`), persist refuses lite claims —
+  // the same switch dispatch reads (`resolveStoryDispatchMode` falls back to
+  // sub-agent), so neither read point can honor a lite claim the operator
+  // has switched off. The refusal is ledgered like any other, keeping the
+  // judgment auditable.
+  if (!resolveComplexityGate(config).enabled) {
+    return {
+      route: 'full',
+      reasons: [
+        'planner lite verdict refused: complexity routing is disabled ' +
+          '(planning.complexityGate.enabled=false)',
+      ],
+      authored: verdict.authored,
+      shape: [],
+    };
+  }
 
   const perStory = (Array.isArray(stories) ? stories : []).map((story) => {
     const derived = deriveStoryShape({
@@ -538,7 +562,11 @@ export async function runPlanPersist({
   // shape — a claim exceeding the shape ceilings fails closed to full. Lite
   // persists the `route::lite` HINT label + a checkpoint route block; a
   // refused claim ledgers the refusal (no label); no claim persists nothing.
-  const route = resolveEffectiveRoute({ stories, routeDowngradeReason });
+  const route = resolveEffectiveRoute({
+    stories,
+    routeDowngradeReason,
+    config,
+  });
   const isLiteRoute = route?.route === 'lite';
   if (isLiteRoute) {
     Logger.info(

--- a/lib/migrations/__tests__/index.test.js
+++ b/lib/migrations/__tests__/index.test.js
@@ -70,17 +70,19 @@ describe('migrations module exports', () => {
 
   // Story #4531 added the mi-drop-knobs retirement; Story #4545 appended the
   // verify-concurrency-cap retirement (both 2.1.0); Story #4604 appended the
-  // epic-AC-tag retirement at 2.2.0. The registry's declaration order is what
-  // fixes the run order within a version — pin it.
+  // epic-AC-tag retirement at 2.2.0; the Story #4722 follow-up appended the
+  // maxSeedWords retirement at 2.11.0. The registry's declaration order is
+  // what fixes the run order within a version — pin it.
   it('ships the real steps in ascending version + declaration order', () => {
-    assert.equal(migrations.length, 3);
+    assert.equal(migrations.length, 4);
     assert.deepEqual(
       migrations.map((s) => s.version),
-      ['2.1.0', '2.1.0', '2.2.0'],
+      ['2.1.0', '2.1.0', '2.2.0', '2.11.0'],
     );
     assert.match(migrations[0].description, /mi|maintainability/i);
     assert.match(migrations[1].description, /concurrency/i);
     assert.match(migrations[2].description, /epic-<id>-ac-N/);
+    assert.match(migrations[3].description, /maxSeedWords/);
   });
 });
 

--- a/lib/migrations/index.js
+++ b/lib/migrations/index.js
@@ -55,6 +55,7 @@
 import { retireMiDropKnobs } from './steps/2.1.0-retire-mi-drop-knobs.js';
 import { retireVerifyConcurrencyCap } from './steps/2.1.0-retire-verify-concurrency-cap.js';
 import { retireEpicAcTags } from './steps/2.2.0-retire-epic-ac-tags.js';
+import { retireMaxSeedWords } from './steps/2.11.0-retire-max-seed-words.js';
 
 /**
  * Ordered registry of migration steps. MUST stay sorted ascending by
@@ -71,6 +72,7 @@ export const migrations = [
   retireMiDropKnobs,
   retireVerifyConcurrencyCap,
   retireEpicAcTags,
+  retireMaxSeedWords,
 ];
 
 /**

--- a/lib/migrations/steps/2.11.0-retire-max-seed-words.js
+++ b/lib/migrations/steps/2.11.0-retire-max-seed-words.js
@@ -1,0 +1,92 @@
+// lib/migrations/steps/2.11.0-retire-max-seed-words.js
+/**
+ * Story #4722 follow-up — strip the retired
+ * `planning.complexityGate.maxSeedWords` knob from a consumer's
+ * `.agentrc.json`.
+ *
+ * #4722 (PR #4725) hard-cutover-removed word-count complexity routing:
+ * the route derives from the authored Story's shape, never from seed word
+ * count, and `maxSeedWords` was dropped from the runtime AJV schema and
+ * the published mirror. The `complexityGate` block carries
+ * `additionalProperties: false`, so a consumer whose config still sets
+ * `maxSeedWords` hits a hard validation failure on upgrade, not a
+ * warning. This step strips the key before that check runs — the same
+ * contract-cutover pattern as `2.1.0-retire-mi-drop-knobs.js`.
+ */
+
+import nodeFs from 'node:fs';
+import path from 'node:path';
+
+const AGENTRC_FILENAME = '.agentrc.json';
+
+/**
+ * @param {unknown} ctx
+ * @returns {string}
+ */
+function resolveAgentrcPath(ctx) {
+  const projectRoot = ctx?.projectRoot ?? process.cwd();
+  return path.join(projectRoot, AGENTRC_FILENAME);
+}
+
+/**
+ * @param {unknown} ctx
+ * @param {typeof nodeFs} fsImpl
+ * @returns {object | null}
+ */
+function readAgentrcConfig(ctx, fsImpl) {
+  try {
+    const raw = fsImpl.readFileSync(resolveAgentrcPath(ctx), 'utf8');
+    return JSON.parse(raw);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * @param {object | null} config
+ * @returns {boolean}
+ */
+function hasRetiredKey(config) {
+  const gate = config?.planning?.complexityGate;
+  return Boolean(gate) && Object.hasOwn(gate, 'maxSeedWords');
+}
+
+export const retireMaxSeedWords = {
+  version: '2.11.0',
+  description:
+    'strip retired planning.complexityGate.maxSeedWords from .agentrc.json ' +
+    '(complexity routes on Story shape, never seed word count — Story #4722)',
+  /**
+   * @param {{ projectRoot?: string, fs?: typeof nodeFs }} [ctx]
+   * @returns {boolean}
+   */
+  detect(ctx) {
+    const fsImpl = ctx?.fs ?? nodeFs;
+    return hasRetiredKey(readAgentrcConfig(ctx, fsImpl));
+  },
+  /**
+   * @param {{ projectRoot?: string, fs?: typeof nodeFs }} [ctx]
+   * @returns {void}
+   */
+  apply(ctx) {
+    const fsImpl = ctx?.fs ?? nodeFs;
+    const config = readAgentrcConfig(ctx, fsImpl);
+    if (!config) return;
+
+    const gate = config.planning?.complexityGate;
+    if (gate && Object.hasOwn(gate, 'maxSeedWords')) {
+      delete gate.maxSeedWords;
+      if (Object.keys(gate).length === 0) {
+        delete config.planning.complexityGate;
+        if (Object.keys(config.planning).length === 0) {
+          delete config.planning;
+        }
+      }
+    }
+
+    fsImpl.writeFileSync(
+      resolveAgentrcPath(ctx),
+      `${JSON.stringify(config, null, 2)}\n`,
+    );
+  },
+};

--- a/lib/migrations/steps/__tests__/2.11.0-retire-max-seed-words.test.js
+++ b/lib/migrations/steps/__tests__/2.11.0-retire-max-seed-words.test.js
@@ -1,0 +1,133 @@
+// lib/migrations/steps/__tests__/2.11.0-retire-max-seed-words.test.js
+/**
+ * Unit tests for the Story #4722 follow-up migration step — strips the
+ * retired `planning.complexityGate.maxSeedWords` knob from a consumer
+ * `.agentrc.json`. All tests drive `detect`/`apply` against an in-memory
+ * fake fs (testing-standards § Unit) — no real filesystem I/O.
+ */
+
+import assert from 'node:assert/strict';
+import path from 'node:path';
+import { describe, it } from 'node:test';
+
+import { retireMaxSeedWords } from '../2.11.0-retire-max-seed-words.js';
+
+const PROJECT_ROOT = '/consumer';
+const AGENTRC_PATH = path.join(PROJECT_ROOT, '.agentrc.json');
+
+/**
+ * @param {object | null} initialConfig - `null` means no file on disk.
+ * @returns {{ ctx: object, readConfig: () => object }}
+ */
+function makeCtx(initialConfig) {
+  const files = new Map();
+  if (initialConfig !== null) {
+    files.set(AGENTRC_PATH, JSON.stringify(initialConfig, null, 2));
+  }
+
+  const fs = {
+    readFileSync(filePath) {
+      if (!files.has(filePath)) {
+        const err = new Error(`ENOENT: ${filePath}`);
+        err.code = 'ENOENT';
+        throw err;
+      }
+      return files.get(filePath);
+    },
+    writeFileSync(filePath, contents) {
+      files.set(filePath, contents);
+    },
+  };
+
+  return {
+    ctx: { projectRoot: PROJECT_ROOT, fs },
+    readConfig: () => JSON.parse(files.get(AGENTRC_PATH)),
+  };
+}
+
+describe('retireMaxSeedWords — detect', () => {
+  it('detects a config carrying maxSeedWords', () => {
+    const { ctx } = makeCtx({
+      planning: { complexityGate: { maxSeedWords: 200 } },
+    });
+    assert.equal(retireMaxSeedWords.detect(ctx), true);
+  });
+
+  it('does not detect a clean complexityGate', () => {
+    const { ctx } = makeCtx({
+      planning: { complexityGate: { enabled: true, maxArtifacts: 1 } },
+    });
+    assert.equal(retireMaxSeedWords.detect(ctx), false);
+  });
+
+  it('does not detect when .agentrc.json is absent', () => {
+    const { ctx } = makeCtx(null);
+    assert.equal(retireMaxSeedWords.detect(ctx), false);
+  });
+});
+
+describe('retireMaxSeedWords — apply', () => {
+  it('strips the retired key and preserves sibling keys', () => {
+    const { ctx, readConfig } = makeCtx({
+      planning: {
+        complexityGate: { maxSeedWords: 200, enabled: true, maxArtifacts: 2 },
+        riskHeuristics: ['payment flow'],
+      },
+    });
+
+    retireMaxSeedWords.apply(ctx);
+
+    const written = readConfig();
+    assert.equal(written.planning.complexityGate.maxSeedWords, undefined);
+    assert.equal(written.planning.complexityGate.enabled, true);
+    assert.equal(written.planning.complexityGate.maxArtifacts, 2);
+    assert.deepEqual(written.planning.riskHeuristics, ['payment flow']);
+  });
+
+  it('removes an emptied complexityGate — and an emptied planning block', () => {
+    const { ctx, readConfig } = makeCtx({
+      project: { paths: { agentRoot: '.agents' } },
+      planning: { complexityGate: { maxSeedWords: 200 } },
+    });
+
+    retireMaxSeedWords.apply(ctx);
+
+    const written = readConfig();
+    assert.equal('planning' in written, false);
+    assert.deepEqual(written.project, { paths: { agentRoot: '.agents' } });
+  });
+
+  it('keeps a planning block that still has other keys', () => {
+    const { ctx, readConfig } = makeCtx({
+      planning: {
+        complexityGate: { maxSeedWords: 200 },
+        riskHeuristics: ['schema migration'],
+      },
+    });
+
+    retireMaxSeedWords.apply(ctx);
+
+    const written = readConfig();
+    assert.equal('complexityGate' in written.planning, false);
+    assert.deepEqual(written.planning.riskHeuristics, ['schema migration']);
+  });
+
+  it('is a no-op when .agentrc.json is absent', () => {
+    const { ctx } = makeCtx(null);
+    assert.doesNotThrow(() => retireMaxSeedWords.apply(ctx));
+  });
+
+  it('satisfies the idempotency contract: detect is false after apply', () => {
+    const { ctx } = makeCtx({
+      planning: { complexityGate: { maxSeedWords: 200 } },
+    });
+
+    assert.equal(retireMaxSeedWords.detect(ctx), true);
+    retireMaxSeedWords.apply(ctx);
+    assert.equal(retireMaxSeedWords.detect(ctx), false);
+
+    // A second apply must not throw or change anything further.
+    assert.doesNotThrow(() => retireMaxSeedWords.apply(ctx));
+    assert.equal(retireMaxSeedWords.detect(ctx), false);
+  });
+});

--- a/tests/config-schema-mirror-drift.test.js
+++ b/tests/config-schema-mirror-drift.test.js
@@ -208,6 +208,24 @@ describe('agentrc.schema.json mirror — drift vs runtime AJV schema', () => {
     );
   });
 
+  it('rejects the retired planning.complexityGate.maxSeedWords knob on both sides (Story #4722)', () => {
+    // Word-count complexity routing was hard-cutover-removed; both schemas
+    // carry `additionalProperties: false` on the complexityGate block, so
+    // the retired knob is rejected identically on both sides while the
+    // surviving keys stay accepted.
+    assertAgree(
+      { ...REQ, planning: { complexityGate: { maxSeedWords: 200 } } },
+      'retired planning.complexityGate.maxSeedWords knob',
+    );
+    assertAgree(
+      {
+        ...REQ,
+        planning: { complexityGate: { enabled: true, maxArtifacts: 2 } },
+      },
+      'surviving complexityGate keys',
+    );
+  });
+
   it('rejects the removed planning.maxTickets knob on both sides (Story #4163)', () => {
     // `maxTickets` collapsed to a framework constant; both the runtime AJV
     // schema and the static mirror dropped it, so `additionalProperties:

--- a/tests/config-settings-schema.test.js
+++ b/tests/config-settings-schema.test.js
@@ -244,6 +244,20 @@ describe('planning.* shape', () => {
     );
   });
 
+  it('rejects the retired planning.complexityGate.maxSeedWords knob (Story #4722)', () => {
+    // Word-count routing was hard-cutover-removed: the route derives from
+    // the authored Story's shape. `additionalProperties: false` on the
+    // complexityGate block rejects the retired key (the
+    // 2.11.0-retire-max-seed-words migration strips it on consumer upgrade).
+    expectErrors(
+      {
+        ...REQ,
+        planning: { complexityGate: { maxSeedWords: 200 } },
+      },
+      /additional propert/i,
+    );
+  });
+
   it('rejects the retired planning.taskSizing key (v2 Stage 2)', () => {
     // File/AC ceilings were replaced by DEFAULT_MODEL_CAPACITY; additionalProperties
     // false on the planning block rejects the retired key.

--- a/tests/scripts/plan-persist.flat-stories.test.js
+++ b/tests/scripts/plan-persist.flat-stories.test.js
@@ -956,6 +956,38 @@ describe('runPlanPersist — shape-validated lite route (Story #4722)', () => {
     assert.match(checkpoint, /planner believes this is trivial/);
   });
 
+  it('a lite claim is refused when the gate is disabled — persist matches dispatch (Story #4722)', async () => {
+    // The schema documents that `planning.complexityGate.enabled=false`
+    // makes persist refuse lite claims (dispatch already falls back to
+    // sub-agent when disabled). Pin the persist side of that contract: the
+    // claim fails closed to full with the disabled gate as the ledgered
+    // reason, and no route hint is persisted.
+    const labelsAtCreate = [];
+    const provider = fakeProvider({
+      createHook: ({ labels }) => labelsAtCreate.push([...labels]),
+    });
+    const result = await runPlanPersist({
+      provider,
+      artifacts: { stories: [ticket('solo')] },
+      config: { planning: { complexityGate: { enabled: false } } },
+      opts: {
+        skipCleanup: true,
+        routeDowngradeReason: 'planner believes this is trivial',
+      },
+    });
+
+    assert.equal(result.route.route, 'full');
+    assert.match(result.route.reasons[0], /disabled/);
+    assert.deepEqual(result.route.authored, {
+      route: 'lite',
+      reason: 'planner believes this is trivial',
+    });
+    assert.ok(
+      labelsAtCreate[0].every((l) => !l.startsWith('route::')),
+      'a refused claim persists no route hint',
+    );
+  });
+
   it('absent a recorded reason there is no claim — standard full, nothing ledgered (AC-2)', async () => {
     for (const routeDowngradeReason of [undefined, null, '', '   ']) {
       const labelsAtCreate = [];


### PR DESCRIPTION
Story #4722 (PR #4725) hard-cutover-removed word-count complexity routing but shipped no consumer-upgrade migration step, so a consumer whose `.agentrc.json` still sets `planning.complexityGate.maxSeedWords` hits a hard AJV rejection on upgrade. Flagged by the run-level documentation audit for plan run adhoc-4722-4723 (its single Medium finding); the persist/`enabled` divergence below by the performance lens.

- Adds the `2.11.0-retire-max-seed-words` migration step (mirrors the `2.1.0-retire-mi-drop-knobs` precedent: idempotent `detect`/`apply` against an injected fs, empty-parent cleanup) and registers it.
- Pins the retired-knob rejection in the runtime AJV schema test, and agreement between the runtime schema and the published mirror in the mirror-drift test.
- Makes persist honor `planning.complexityGate.enabled=false`: the schema documents that persist refuses lite claims when the gate is off, but `resolveEffectiveRoute` never consulted it — it now refuses the claim with the disabled gate as the ledgered reason, matching dispatch. Pinned by test.

The `feat(migration):` type also makes the removal visible in the next release-please changelog — the original squash title left it invisible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches consumer upgrade config and plan-time routing ledgering; behavior is contract-aligned and heavily tested, but misconfiguration could surprise operators expecting lite persist with the gate off.
> 
> **Overview**
> Adds a **2.11.0 consumer migration** that removes retired `planning.complexityGate.maxSeedWords` from `.agentrc.json` before AJV validation, so upgrades do not hard-fail on the removed knob (Story #4722 follow-up).
> 
> **Plan persist** now honors `planning.complexityGate.enabled=false`: a planner lite verdict is refused and ledgered as **full** (no `route::lite` hint), matching **`resolveStoryDispatchMode`** — via exported **`resolveComplexityGate`** for a single config read.
> 
> Tests cover the migration step, registry order, schema rejection of `maxSeedWords` (runtime + mirror), and persist behavior when the gate is disabled.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 41354f1950f7e8c774a87f6e3663655a53a9ad7e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->