### PR TITLE
refactor(orchestration): extract spec-budget and story-body parse gate from ticket-validator

### DIFF
--- a/.agents/scripts/lib/orchestration/spec-budget.js
+++ b/.agents/scripts/lib/orchestration/spec-budget.js
@@ -1,0 +1,78 @@
+/**
+ * lib/orchestration/spec-budget.js — the soft `## Spec` word-budget pass
+ * (Story #4723), extracted from `ticket-validator.js` so the advisory
+ * length nudge lives beside neither the hard validators nor their error
+ * channel: everything here is `'soft'` by construction and can never fail
+ * a persist.
+ */
+
+import { parse as parseStoryBody } from '../story-body/story-body.js';
+
+/**
+ * Soft advisory word budget for a Story's inline `## Spec` (Story #4723).
+ * ~250 words is the #4707 contract-level-prose target: interfaces,
+ * invariants, and load-bearing constraints — not route-by-route behavior
+ * narration. Distinct from the hard ~1500-token fail-closed ceiling in
+ * `spec-spill.js`: this budget only warns; it never fails the persist.
+ */
+export const SPEC_SOFT_WORD_BUDGET = 250;
+
+/**
+ * Resolve a Story's Spec prose across both authoring shapes: the canonical
+ * serialized string body (parsed; `## Spec` text block) and the
+ * pre-serialize structured object body (`body.spec`). Returns `''` when
+ * absent — or when a string body does not parse: this pass is advisory, so
+ * an unreadable body contributes no finding here and is left to the hard
+ * parse gate (`assertStoryBodiesParse`) to reject.
+ *
+ * @param {object} story
+ * @returns {string}
+ */
+function resolveSpecText(story) {
+  const body = story?.body;
+  if (typeof body === 'string' && body.trim().length > 0) {
+    let spec;
+    try {
+      spec = parseStoryBody(body).body.spec;
+    } catch {
+      return '';
+    }
+    return typeof spec === 'string' ? spec : '';
+  }
+  if (body !== null && typeof body === 'object') {
+    return typeof body?.spec === 'string' ? body.spec : '';
+  }
+  return '';
+}
+
+/**
+ * Advisory `## Spec` length pass (Story #4723). Emits one `'soft'` finding
+ * per Story whose Spec prose exceeds {@link SPEC_SOFT_WORD_BUDGET} words,
+ * nudging the author toward contract-level prose (#4707). Soft only — the
+ * findings never reach the validator's `errors[]` channel, so an
+ * over-budget Spec never fails the persist.
+ *
+ * @param {{ stories: object[] }} opts
+ * @returns {object[]} Zero or more `spec-word-budget` findings.
+ */
+export function computeSpecBudgetFindings({ stories }) {
+  const findings = [];
+  for (const story of stories ?? []) {
+    const words = resolveSpecText(story).split(/\s+/).filter(Boolean).length;
+    if (words <= SPEC_SOFT_WORD_BUDGET) continue;
+    findings.push({
+      kind: 'spec-word-budget',
+      severity: 'soft',
+      ticketSlug: story.slug ?? '<unknown>',
+      words,
+      budget: SPEC_SOFT_WORD_BUDGET,
+      message:
+        `Story "${story.slug ?? '<unknown>'}" ## Spec is ~${words} words ` +
+        `(soft budget ${SPEC_SOFT_WORD_BUDGET}). Prefer contract-level prose ` +
+        '(interfaces, invariants, load-bearing constraints with their why) ' +
+        'over per-file behavior narration — advisory only; the persist ' +
+        'proceeds.',
+    });
+  }
+  return findings;
+}

--- a/.agents/scripts/lib/orchestration/story-body-gate.js
+++ b/.agents/scripts/lib/orchestration/story-body-gate.js
@@ -1,0 +1,72 @@
+/**
+ * lib/orchestration/story-body-gate.js — the Story-body parse gate
+ * (Story #4541), extracted from `ticket-validator.js`: the one place a
+ * serialized Story body is parsed with parse failures translated into the
+ * validator's operator-legible `ValidationError` shape. Both the gate that
+ * refuses a plan up front (`assertStoryBodiesParse`) and the per-call
+ * translating parser (`parseStoryBodyOrThrow`) the downstream validators
+ * lean on live here.
+ */
+
+import { ValidationError } from '../errors/index.js';
+import {
+  parse as parseStoryBody,
+  StoryBodyParseError,
+} from '../story-body/story-body.js';
+
+/**
+ * Parse a Story's serialized markdown body, translating a
+ * `StoryBodyParseError` into a `ValidationError` that names the offending
+ * **section** and **entry** (Story #4541).
+ *
+ * `StoryBodyParseError` already carries `field` (the section the parser was
+ * reading) and `raw` (the entry text that failed); this lifts both into an
+ * operator-legible message and a structured `violation` payload so an
+ * authoring loop can point at the exact bullet instead of re-deriving it
+ * from a downstream freshness miss.
+ *
+ * @param {object} story Story whose `body` is a non-empty markdown string.
+ * @returns {object} The structured body.
+ * @throws {ValidationError} `code: 'story-body-unparseable'`.
+ */
+export function parseStoryBodyOrThrow(story) {
+  try {
+    return parseStoryBody(story.body).body;
+  } catch (err) {
+    if (!(err instanceof StoryBodyParseError)) throw err;
+    const slug = story.slug ?? '<unknown>';
+    const section = err.field ?? 'body';
+    const entry = err.raw ?? null;
+    const entryLine = entry === null ? '' : `\n      entry: ${entry}`;
+    const violation = { slug, section, entry, reason: err.message };
+    const error = new ValidationError(
+      `Cross-Validation Failed: Story "${slug}" has an unparseable body — ` +
+        `the ## ${section} section could not be read: ${err.message}` +
+        `${entryLine}\n\nFix the offending entry; this is a malformed body, ` +
+        'not a stale path reference.',
+      { violations: [violation] },
+    );
+    error.code = 'story-body-unparseable';
+    error.violations = [violation];
+    throw error;
+  }
+}
+
+/**
+ * Refuse the plan when any Story's serialized body cannot be parsed, before
+ * either git-probe gate runs (Story #4541). Ordering matters: the freshness
+ * gate consults `body.changes` for its net-new whitelist, so an unparseable
+ * body used to reach the operator as a freshness miss naming declared paths.
+ *
+ * @param {{ tickets: object[] }} opts
+ * @throws {ValidationError} `code: 'story-body-unparseable'` on the first
+ *   offending Story.
+ */
+export function assertStoryBodiesParse({ tickets }) {
+  for (const story of (tickets ?? []).filter((t) => t.type === 'story')) {
+    if (typeof story.body !== 'string' || story.body.trim().length === 0) {
+      continue;
+    }
+    parseStoryBodyOrThrow(story);
+  }
+}

--- a/.agents/scripts/lib/orchestration/ticket-validator.js
+++ b/.agents/scripts/lib/orchestration/ticket-validator.js
@@ -3,11 +3,12 @@ import { detectCycle } from '../Graph.js';
 import { gitSpawn } from '../git-utils.js';
 
 import { Logger } from '../Logger.js';
-import {
-  parse as parseStoryBody,
-  StoryBodyParseError,
-} from '../story-body/story-body.js';
 import { validateStoryFileAssumptions } from './file-assumptions.js';
+import { computeSpecBudgetFindings } from './spec-budget.js';
+import {
+  assertStoryBodiesParse,
+  parseStoryBodyOrThrow,
+} from './story-body-gate.js';
 import {
   computeConflictFindings,
   renderHardConflictError,
@@ -47,63 +48,6 @@ function collectPathsFromText(text, paths) {
 }
 
 /**
- * Parse a Story's serialized markdown body, translating a
- * `StoryBodyParseError` into a `ValidationError` that names the offending
- * **section** and **entry** (Story #4541).
- *
- * `StoryBodyParseError` already carries `field` (the section the parser was
- * reading) and `raw` (the entry text that failed); this lifts both into an
- * operator-legible message and a structured `violation` payload so an
- * authoring loop can point at the exact bullet instead of re-deriving it
- * from a downstream freshness miss.
- *
- * @param {object} story Story whose `body` is a non-empty markdown string.
- * @returns {object} The structured body.
- * @throws {ValidationError} `code: 'story-body-unparseable'`.
- */
-function parseStoryBodyOrThrow(story) {
-  try {
-    return parseStoryBody(story.body).body;
-  } catch (err) {
-    if (!(err instanceof StoryBodyParseError)) throw err;
-    const slug = story.slug ?? '<unknown>';
-    const section = err.field ?? 'body';
-    const entry = err.raw ?? null;
-    const entryLine = entry === null ? '' : `\n      entry: ${entry}`;
-    const violation = { slug, section, entry, reason: err.message };
-    const error = new ValidationError(
-      `Cross-Validation Failed: Story "${slug}" has an unparseable body — ` +
-        `the ## ${section} section could not be read: ${err.message}` +
-        `${entryLine}\n\nFix the offending entry; this is a malformed body, ` +
-        'not a stale path reference.',
-      { violations: [violation] },
-    );
-    error.code = 'story-body-unparseable';
-    error.violations = [violation];
-    throw error;
-  }
-}
-
-/**
- * Refuse the plan when any Story's serialized body cannot be parsed, before
- * either git-probe gate runs (Story #4541). Ordering matters: the freshness
- * gate consults `body.changes` for its net-new whitelist, so an unparseable
- * body used to reach the operator as a freshness miss naming declared paths.
- *
- * @param {{ tickets: object[] }} opts
- * @throws {ValidationError} `code: 'story-body-unparseable'` on the first
- *   offending Story.
- */
-function assertStoryBodiesParse({ tickets }) {
-  for (const story of (tickets ?? []).filter((t) => t.type === 'story')) {
-    if (typeof story.body !== 'string' || story.body.trim().length === 0) {
-      continue;
-    }
-    parseStoryBodyOrThrow(story);
-  }
-}
-
-/**
  * Resolve every acceptance line a Story declares, across both authoring
  * shapes (Story #4541).
  *
@@ -133,69 +77,6 @@ function resolveAcceptanceLines(story) {
     for (const item of bodyAcceptance) lines.add(String(item ?? ''));
   }
   return [...lines];
-}
-
-/**
- * Soft advisory word budget for a Story's inline `## Spec` (Story #4723).
- * ~250 words is the #4707 contract-level-prose target: interfaces,
- * invariants, and load-bearing constraints — not route-by-route behavior
- * narration. Distinct from the hard ~1500-token fail-closed ceiling in
- * `spec-spill.js`: this budget only warns; it never fails the persist.
- */
-export const SPEC_SOFT_WORD_BUDGET = 250;
-
-/**
- * Resolve a Story's Spec prose across both authoring shapes: the canonical
- * serialized string body (parsed; `## Spec` text block) and the
- * pre-serialize structured object body (`body.spec`). Returns `''` when
- * absent. Callers run after `assertStoryBodiesParse`, so a string body
- * parses here.
- *
- * @param {object} story
- * @returns {string}
- */
-function resolveSpecText(story) {
-  const body = story?.body;
-  if (typeof body === 'string' && body.trim().length > 0) {
-    const spec = parseStoryBodyOrThrow(story).spec;
-    return typeof spec === 'string' ? spec : '';
-  }
-  if (body !== null && typeof body === 'object') {
-    return typeof body.spec === 'string' ? body.spec : '';
-  }
-  return '';
-}
-
-/**
- * Advisory `## Spec` length pass (Story #4723). Emits one `'soft'` finding
- * per Story whose Spec prose exceeds {@link SPEC_SOFT_WORD_BUDGET} words,
- * nudging the author toward contract-level prose (#4707). Soft only — the
- * findings never reach the validator's `errors[]` channel, so an
- * over-budget Spec never fails the persist.
- *
- * @param {{ stories: object[] }} opts
- * @returns {object[]} Zero or more `spec-word-budget` findings.
- */
-function computeSpecBudgetFindings({ stories }) {
-  const findings = [];
-  for (const story of stories ?? []) {
-    const words = resolveSpecText(story).split(/\s+/).filter(Boolean).length;
-    if (words <= SPEC_SOFT_WORD_BUDGET) continue;
-    findings.push({
-      kind: 'spec-word-budget',
-      severity: 'soft',
-      ticketSlug: story.slug ?? '<unknown>',
-      words,
-      budget: SPEC_SOFT_WORD_BUDGET,
-      message:
-        `Story "${story.slug ?? '<unknown>'}" ## Spec is ~${words} words ` +
-        `(soft budget ${SPEC_SOFT_WORD_BUDGET}). Prefer contract-level prose ` +
-        '(interfaces, invariants, load-bearing constraints with their why) ' +
-        'over per-file behavior narration — advisory only; the persist ' +
-        'proceeds.',
-    });
-  }
-  return findings;
 }
 
 function collectTaskPathReferences(task) {

--- a/baselines/dead-exports-production.json
+++ b/baselines/dead-exports-production.json
@@ -2041,7 +2041,7 @@
       "symbol": "estimateStorySessionMass"
     },
     {
-      "file": ".agents/scripts/lib/orchestration/ticket-validator.js",
+      "file": ".agents/scripts/lib/orchestration/spec-budget.js",
       "symbol": "SPEC_SOFT_WORD_BUDGET"
     },
     {

--- a/tests/lib/orchestration/ticket-validator.test.js
+++ b/tests/lib/orchestration/ticket-validator.test.js
@@ -1,8 +1,8 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
+import { SPEC_SOFT_WORD_BUDGET } from '../../../.agents/scripts/lib/orchestration/spec-budget.js';
 import {
   _internal,
-  SPEC_SOFT_WORD_BUDGET,
   validateAndNormalizeTickets,
 } from '../../../.agents/scripts/lib/orchestration/ticket-validator.js';
 import { serialize } from '../../../.agents/scripts/lib/story-body/story-body.js';


### PR DESCRIPTION
The #4723 Spec word-budget additions dropped `ticket-validator.js` maintainability 0.63pt base→head, past the repo's 0.5pt per-file tolerance (run-level clean-code audit for plan run adhoc-4722-4723, its Medium finding). Fix is the known remedy — extraction to lib modules:

- `spec-budget.js` owns `SPEC_SOFT_WORD_BUDGET` + the advisory `spec-word-budget` pass. As an advisory pass it soft-fails an unparseable body to no-finding instead of throwing; the hard parse gate still rejects such bodies upstream.
- `story-body-gate.js` owns `parseStoryBodyOrThrow` + `assertStoryBodiesParse` (the Story #4541 parse gate), imported back by the validator.
- Measured MI: `ticket-validator.js` 93.706 → 94.654 (+0.95, more than reversing the audited regression); the new modules score 100.7 / 103.6.
- The dead-exports-production baseline row for `SPEC_SOFT_WORD_BUDGET` moves to its new home (still test-only by design).

Behavior unchanged — pinned by the existing spec-budget and validator suites, which pass unchanged in expectation (only the constant's import path moved).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Structural refactor of agent orchestration validators with existing test coverage; only nuanced change is advisory spec-budget skipping unparseable bodies instead of throwing.
> 
> **Overview**
> Splits **maintainability-heavy** logic out of `ticket-validator.js` into two orchestration modules so the validator stays a thin coordinator.
> 
> **`spec-budget.js`** now owns `SPEC_SOFT_WORD_BUDGET` and `computeSpecBudgetFindings` (soft `## Spec` word-budget warnings). Spec text resolution on string bodies uses a **local parse try/catch** instead of `parseStoryBodyOrThrow`, so a malformed body yields **no advisory finding** rather than surfacing through the throwing parser; hard rejection still comes from `assertStoryBodiesParse` upstream.
> 
> **`story-body-gate.js`** owns `parseStoryBodyOrThrow` and `assertStoryBodiesParse` (Story #4541 parse gate), re-exported to the validator and `_internal` for tests.
> 
> Tests import `SPEC_SOFT_WORD_BUDGET` from `spec-budget.js`; the dead-exports baseline row for that symbol moves to the new file.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 730e8dd90f199be79ddf8af027b53dff6e9fe2c8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->