### PR TITLE
refactor(orchestration): thread injectedRules seam through route composition layers

### DIFF
--- a/.agents/scripts/lib/audit-suite/audit-rules-reader.js
+++ b/.agents/scripts/lib/audit-suite/audit-rules-reader.js
@@ -1,0 +1,48 @@
+/**
+ * lib/audit-suite/audit-rules-reader.js — the one synchronous reader of the
+ * `audit-rules.json` manifest, memoized for the process lifetime.
+ *
+ * The manifest is shipped framework configuration resolved from one fixed
+ * path per process, and the shape-derivation path reads it once per Story at
+ * resolve AND persist — an un-memoized read is pure repeated I/O (measured
+ * 221 µs/op raw vs 5.5 µs seamed on the run adhoc-4722-4723 audit). Only a
+ * successful parse is cached: a read failure stays a per-call throw so a
+ * caller can observe a manifest that becomes readable later. Tests never
+ * reach this read — they inject fixture rules through the callers'
+ * `injectedRules` seam.
+ */
+
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { getPaths, PROJECT_ROOT, resolveConfig } from '../config-resolver.js';
+
+/** Process-lifetime memo of the parsed manifest (successful parses only). */
+let auditRulesCache = null;
+
+/**
+ * Read and parse the `audit-rules.json` manifest synchronously from the
+ * project's configured `schemasRoot`. Shared by the synchronous, ticket-free
+ * readers (`resolveLensTier`, `selectLocalLenses`,
+ * `selectSensitivePathClasses`) so the path resolution and read-failure
+ * handling live in one place rather than being duplicated per reader.
+ *
+ * @returns {{ audits?: Record<string, object> }} Parsed manifest.
+ * @throws {Error} When the manifest cannot be read or parsed.
+ */
+export function readAuditRulesSync() {
+  if (auditRulesCache !== null) return auditRulesCache;
+  const config = resolveConfig();
+  const rulesPath = path.join(
+    PROJECT_ROOT,
+    getPaths(config).schemasRoot,
+    'audit-rules.json',
+  );
+  try {
+    auditRulesCache = JSON.parse(readFileSync(rulesPath, 'utf8'));
+    return auditRulesCache;
+  } catch (err) {
+    throw new Error(
+      `audit-suite: failed to read audit-rules from ${rulesPath}: ${err.message}`,
+    );
+  }
+}

--- a/.agents/scripts/lib/audit-suite/selector.js
+++ b/.agents/scripts/lib/audit-suite/selector.js
@@ -26,6 +26,7 @@ import { getPaths, PROJECT_ROOT, resolveConfig } from '../config-resolver.js';
 import { softFailOrThrow } from '../degraded-mode.js';
 import { gitSpawn } from '../git-utils.js';
 import { withTimeout } from '../util/with-timeout.js';
+import { readAuditRulesSync } from './audit-rules-reader.js';
 
 const DEFAULT_GIT_TIMEOUT_MS = 30000;
 
@@ -101,32 +102,6 @@ export const LENS_TIERS = Object.freeze(['local', 'cumulative', 'global']);
  *   manifest cannot be read, or the registered entry carries a scope outside
  *   {@link LENS_TIERS}.
  */
-/**
- * Read and parse the `audit-rules.json` manifest synchronously from the
- * project's configured `schemasRoot`. Shared by the synchronous, ticket-free
- * readers ({@link resolveLensTier}, {@link selectLocalLenses}) so the path
- * resolution and read-failure handling live in one place rather than being
- * duplicated per reader.
- *
- * @returns {{ audits?: Record<string, object> }} Parsed manifest.
- * @throws {Error} When the manifest cannot be read or parsed.
- */
-function readAuditRulesSync() {
-  const config = resolveConfig();
-  const rulesPath = path.join(
-    PROJECT_ROOT,
-    getPaths(config).schemasRoot,
-    'audit-rules.json',
-  );
-  try {
-    return JSON.parse(readFileSync(rulesPath, 'utf8'));
-  } catch (err) {
-    throw new Error(
-      `audit-suite: failed to read audit-rules from ${rulesPath}: ${err.message}`,
-    );
-  }
-}
-
 export function resolveLensTier(lens) {
   const rulesData = readAuditRulesSync();
 

--- a/.agents/scripts/lib/orchestration/plan-persist/run-plan-persist.js
+++ b/.agents/scripts/lib/orchestration/plan-persist/run-plan-persist.js
@@ -301,6 +301,7 @@ async function renderRunScopedPlanMetricsLine({
  *   stories: ReturnType<typeof assemblePlanStories>['stories'],
  *   routeDowngradeReason?: string|null,
  *   config?: object,
+ *   injectedRules?: object,
  * }} args
  * @returns {{
  *   route: 'lite'|'full',
@@ -313,6 +314,7 @@ function resolveEffectiveRoute({
   stories,
   routeDowngradeReason = null,
   config = {},
+  injectedRules,
 }) {
   const verdict = resolvePlannerRouteVerdict({ reason: routeDowngradeReason });
   if (verdict.route !== 'lite') return null;
@@ -339,6 +341,7 @@ function resolveEffectiveRoute({
     const derived = deriveStoryShape({
       changes: story.bodyObject?.changes,
       acceptance: story.acceptance,
+      injectedRules,
     });
     return {
       slug: story.slug,
@@ -455,6 +458,7 @@ export async function reapStalePlanDirs({
  *     sourceTicketOrigin?: 'flag'|'envelope'|'none',
  *     closeSuperseded?: boolean,
  *     routeDowngradeReason?: string|null,
+ *     injectedRules?: object,
  *   },
  * }} input
  */
@@ -483,6 +487,7 @@ export async function runPlanPersist({
     sourceTicketOrigin = 'none',
     closeSuperseded = true,
     routeDowngradeReason = null,
+    injectedRules = undefined,
   } = opts;
 
   // Boundary for the plan-metrics summary below: everything this invocation
@@ -566,6 +571,7 @@ export async function runPlanPersist({
     stories,
     routeDowngradeReason,
     config,
+    injectedRules,
   });
   const isLiteRoute = route?.route === 'lite';
   if (isLiteRoute) {

--- a/.agents/scripts/lib/orchestration/resolve-stories.js
+++ b/.agents/scripts/lib/orchestration/resolve-stories.js
@@ -300,6 +300,9 @@ export async function readNativeBlockedBy({
  * @param {Map<number, number[]>} nativeEdges
  * @param {number[]} foreignDone Ids outside the set already satisfied.
  * @param {(msg: string) => void} [warn]
+ * @param {object} [injectedRules] Test seam forwarded to the shape
+ *   derivation — skips the `audit-rules.json` disk read. Production callers
+ *   omit it (the real manifest, memoized per process, is the default).
  * @returns {{ kind: string, stories: object[], dag: object[], done: number[] }}
  */
 export function buildStoriesEnvelope({
@@ -308,6 +311,7 @@ export function buildStoriesEnvelope({
   foreignDone = [],
   warn,
   config,
+  injectedRules,
 }) {
   const sorted = [...stories].sort((a, b) => a.id - b.id);
   const inSetDone = sorted.filter(isSatisfiedBlocker).map((s) => s.id);
@@ -327,7 +331,12 @@ export function buildStoriesEnvelope({
       url,
       labels,
       state,
-      dispatchMode: resolveStoryDispatchMode({ body, labels, config }).mode,
+      dispatchMode: resolveStoryDispatchMode({
+        body,
+        labels,
+        config,
+        injectedRules,
+      }).mode,
     })),
     dag: storiesToDag(sorted, nativeEdges, warn),
     done: [...new Set([...inSetDone, ...foreignDone])].sort((a, b) => a - b),

--- a/tests/lib/orchestration/complexity-gate.test.js
+++ b/tests/lib/orchestration/complexity-gate.test.js
@@ -442,3 +442,87 @@ describe('lite-shaped Stories land through the unchanged persist engine', () => 
     assert.ok(!calls[0].labels.includes(AGENT_LABELS.READY));
   });
 });
+
+// Persist and deliver read the SAME Story through two representations:
+// persist feeds `deriveStoryShape` the assembled objects
+// (`bodyObject.changes` / `acceptance`), deliver feeds
+// `resolveStoryDispatchMode` the serialized body markdown and re-parses it.
+// The docstring's claim that the two read points can never disagree is a
+// contract, not a hope — pin it round-trip: assemble once, derive both ways,
+// assert one route.
+describe('persist ↔ deliver route round-trip — one shape, two read points', () => {
+  const cases = [
+    {
+      name: 'a lite-shaped Story routes lite from both representations',
+      ticket: {
+        slug: 'lite-round-trip',
+        type: 'story',
+        title: 'Add a helper',
+        body: storyBody({
+          changes: [{ path: 'bin/helper.js', assumption: 'creates' }],
+          acceptance: ['helper prints and exits 0'],
+        }),
+      },
+      expectedRoute: 'lite',
+      expectedMode: 'inline',
+    },
+    {
+      name: 'a refactor-mix Story routes full from both representations',
+      ticket: {
+        slug: 'full-round-trip',
+        type: 'story',
+        title: 'Refactor two modules',
+        body: storyBody({
+          changes: [
+            { path: 'src/one.js', assumption: 'refactors-existing' },
+            { path: 'src/two.js', assumption: 'refactors-existing' },
+          ],
+          acceptance: ['both modules keep their contracts'],
+        }),
+      },
+      expectedRoute: 'full',
+      expectedMode: 'subagent',
+    },
+    {
+      name: 'a sensitive-footprint Story routes full from both representations',
+      ticket: {
+        slug: 'sensitive-round-trip',
+        type: 'story',
+        title: 'Add an auth banner',
+        body: storyBody({
+          changes: [{ path: 'src/auth/banner.js', assumption: 'creates' }],
+          acceptance: ['banner shows on the login page'],
+        }),
+      },
+      expectedRoute: 'full',
+      expectedMode: 'subagent',
+    },
+  ];
+
+  for (const { name, ticket, expectedRoute, expectedMode } of cases) {
+    test(name, () => {
+      const { stories } = assemblePlanStories([ticket]);
+
+      // Persist's read point: the assembled objects.
+      const persistSide = deriveStoryShape({
+        changes: stories[0].bodyObject.changes,
+        acceptance: stories[0].acceptance,
+        injectedRules: RULES,
+      });
+      // Deliver's read point: the serialized body markdown, re-parsed.
+      const deliverSide = resolveStoryDispatchMode({
+        body: stories[0].body,
+        labels: [],
+        injectedRules: RULES,
+      });
+
+      assert.equal(persistSide.route, expectedRoute);
+      assert.equal(
+        deliverSide.route.route,
+        persistSide.route,
+        'persist and deliver derived different routes from the same Story',
+      );
+      assert.equal(deliverSide.mode, expectedMode);
+    });
+  }
+});

--- a/tests/scripts/plan-persist.flat-stories.test.js
+++ b/tests/scripts/plan-persist.flat-stories.test.js
@@ -887,6 +887,15 @@ describe('runPlanPersist — shape-validated lite route (Story #4722)', () => {
     };
   }
 
+  /**
+   * Stand-in sensitive-path manifest for the shape backstop — injected so
+   * these tests never read the repo's live `audit-rules.json` (whose
+   * operator-editable globs would otherwise decide the routes asserted
+   * below). Empty: no fixture path is sensitive; the wide claim fails on
+   * the shape ceilings alone.
+   */
+  const NO_SENSITIVE_RULES = { sensitivePaths: {} };
+
   it('an upheld lite claim persists the route::lite hint and ledgers the verdict (AC-2, AC-3)', async () => {
     const labelsAtCreate = [];
     const provider = fakeProvider({
@@ -901,6 +910,7 @@ describe('runPlanPersist — shape-validated lite route (Story #4722)', () => {
       opts: {
         skipCleanup: true,
         routeDowngradeReason: 'single trivial artifact despite verbose seed',
+        injectedRules: NO_SENSITIVE_RULES,
       },
     });
 
@@ -939,6 +949,7 @@ describe('runPlanPersist — shape-validated lite route (Story #4722)', () => {
       opts: {
         skipCleanup: true,
         routeDowngradeReason: 'planner believes this is trivial',
+        injectedRules: NO_SENSITIVE_RULES,
       },
     });
 
@@ -998,7 +1009,11 @@ describe('runPlanPersist — shape-validated lite route (Story #4722)', () => {
         provider,
         artifacts: { stories: [ticket('solo')] },
         config: {},
-        opts: { skipCleanup: true, routeDowngradeReason },
+        opts: {
+          skipCleanup: true,
+          routeDowngradeReason,
+          injectedRules: NO_SENSITIVE_RULES,
+        },
       });
       assert.equal(result.route, null);
       assert.ok(labelsAtCreate[0].every((l) => !l.startsWith('route::')));

--- a/tests/scripts/resolve-stories.test.js
+++ b/tests/scripts/resolve-stories.test.js
@@ -37,6 +37,17 @@ import { parseDag } from '../../.agents/scripts/stories-wave-tick.js';
 
 const REPO = { owner: 'dsj1984', repo: 'mandrel', issueNumber: 4534 };
 
+/**
+ * Stand-in sensitive-path manifest for the dispatchMode shape derivation —
+ * injected so no test reads the repo's live `audit-rules.json` (whose
+ * operator-editable globs would otherwise decide these assertions).
+ */
+const RULES = {
+  sensitivePaths: {
+    security: { filePatterns: ['**/auth/**'] },
+  },
+};
+
 function storyBody({
   changes = ['.agents/scripts/a.js'],
   blockedBy = null,
@@ -157,6 +168,7 @@ describe('the resolver envelope composes with the scheduler adapter', () => {
   it('parseDag accepts the resolver output verbatim (run-breaker #1)', () => {
     const env = buildStoriesEnvelope({
       stories: [toStoryRecord(issue())],
+      injectedRules: RULES,
     });
     assert.ok(env.dag[0].files.every((f) => typeof f === 'string'));
     const { nodes, error } = parseDag(env.dag);
@@ -286,6 +298,7 @@ describe('buildStoriesEnvelope — per-Story dispatchMode (Story #4722)', () => 
     // lite-shaped body. No label anywhere — the shape is the control signal.
     const env = buildStoriesEnvelope({
       stories: [toStoryRecord(issue({ number: 1 }))],
+      injectedRules: RULES,
     });
     assert.equal(env.stories[0].dispatchMode, 'inline');
   });
@@ -304,6 +317,7 @@ describe('buildStoriesEnvelope — per-Story dispatchMode (Story #4722)', () => 
           }),
         ),
       ],
+      injectedRules: RULES,
     });
     assert.equal(env.stories[0].dispatchMode, 'subagent');
   });
@@ -319,6 +333,7 @@ describe('buildStoriesEnvelope — per-Story dispatchMode (Story #4722)', () => 
           }),
         ),
       ],
+      injectedRules: RULES,
     });
     assert.equal(env.stories[0].dispatchMode, 'subagent');
   });
@@ -327,6 +342,7 @@ describe('buildStoriesEnvelope — per-Story dispatchMode (Story #4722)', () => 
     const env = buildStoriesEnvelope({
       stories: [toStoryRecord(issue({ number: 1 }))],
       config: { planning: { complexityGate: { enabled: false } } },
+      injectedRules: RULES,
     });
     assert.equal(env.stories[0].dispatchMode, 'subagent');
   });
@@ -339,6 +355,7 @@ describe('buildStoriesEnvelope — done[] is what unlocks cross-run delivery', (
         toStoryRecord(issue({ number: 1, state: 'closed' })),
         toStoryRecord(issue({ number: 2 })),
       ],
+      injectedRules: RULES,
     });
     assert.deepEqual(env.done, [1]);
   });
@@ -352,7 +369,11 @@ describe('buildStoriesEnvelope — done[] is what unlocks cross-run delivery', (
         issue({ number: 4534, body: storyBody({ blockedBy: 4530 }) }),
       ),
     ];
-    const env = buildStoriesEnvelope({ stories, foreignDone: [4530] });
+    const env = buildStoriesEnvelope({
+      stories,
+      foreignDone: [4530],
+      injectedRules: RULES,
+    });
     assert.deepEqual(env.dag[0].dependsOn, [4530]);
     assert.deepEqual(env.done, [4530]);
   });
@@ -363,6 +384,7 @@ describe('buildStoriesEnvelope — done[] is what unlocks cross-run delivery', (
         toStoryRecord(issue({ number: 9, state: 'closed' })),
         toStoryRecord(issue({ number: 3, state: 'closed' })),
       ],
+      injectedRules: RULES,
     });
     assert.deepEqual(
       env.stories.map((s) => s.id),


### PR DESCRIPTION
Rebuilds the injectedRules-seam change (originally on the abandoned `refactor/injected-rules-seam`, stranded behind the maintainability-baseline deadlock now fixed by #4732) onto current `main`.

Three run-level audit lenses (architecture, quality, performance) for plan run adhoc-4722-4723 converged: #4722's two routing composition layers — `buildStoriesEnvelope` (resolve-stories) and `resolveEffectiveRoute` (plan-persist) — hard-bind to the shipped `audit-rules.json` via an un-memoized per-Story `readFileSync` (measured 221 µs/op vs 5.5 µs injected), while the leaf functions they call already expose the `injectedRules` seam. Several new unit tests were therefore silently reading the live manifest (a testing-standards isolation violation and latent flake).

- Extracts the manifest read to `audit-rules-reader.js` and memoizes the successful parse for the process lifetime (read failures stay per-call throws).
- Threads `injectedRules` through `buildStoriesEnvelope` and `runPlanPersist` opts → `resolveEffectiveRoute`, composing cleanly with #4729's `config`/`enabled` threading of the same function.
- Injects fixture rules in the affected route tests so no unit test reads the live manifest.
- Pins the persist ↔ deliver round-trip contract: one assembled Story derives the same route from `bodyObject.changes`/`acceptance` (persist) and the re-parsed serialized body (deliver).

Verified: 115 directly-affected tests pass, lint / `check-baselines` / dead-exports:production / biome ci all clean. Full `npm test` shows a pre-existing e2e consumer-sync pollution flake (a different test each run, all pass in isolation), disjoint from this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Orchestration and test-isolation refactor around manifest I/O and an existing injectedRules seam; routing behavior is unchanged in production aside from memoizing successful manifest reads.
> 
> **Overview**
> Centralizes synchronous **`audit-rules.json`** reads in **`audit-rules-reader.js`** with **process-lifetime memoization** (failed reads are not cached), and **`selector.js`** drops its duplicated inline reader in favor of that module.
> 
> **`injectedRules`** is threaded through **`buildStoriesEnvelope`** → **`resolveStoryDispatchMode`** and **`runPlanPersist`** opts → **`resolveEffectiveRoute`** → **`deriveStoryShape`**, so plan persist and story resolve can use the same test seam the complexity gate already exposed instead of hitting disk on every Story.
> 
> Route-related unit tests now pass **fixture manifests** so assertions do not depend on the live operator-editable **`audit-rules.json`**. New tests **pin the persist ↔ deliver round-trip**: the same assembled Story must agree on lite/full routing from assembled objects vs re-parsed body markdown.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 73fdc7c243821f6ce1d7e7e21f617be6a16a5e12. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->