### PR TITLE
perf: deliver-path cost: inline single-Story dispatch, bounded close output, bundled framework reads (#4736)

### DIFF
--- a/.agents/rules/orchestration-error-handling.md
+++ b/.agents/rules/orchestration-error-handling.md
@@ -46,8 +46,16 @@ success output is a per-turn tax on the whole session — not a one-time cost.
   their drivers — emit them single-line (`JSON.stringify(x)`), never
   pretty-printed (`null, 2` only adds resident bytes). Pretty output is
   reserved for explicit opt-in flags (`--pretty`).
+- **Streamed child output counts too (Story #4736).** A script that pipes a
+  child process's stdout/stderr through to the caller is emitting that output
+  as its own. `single-story-close.js` streamed every close-validation gate —
+  the whole of `npm test` included — and blew the budget by ~25× on a *passing*
+  close. Capture it to an artifact instead
+  ([`single-story-close/gate-log.js`](../scripts/lib/orchestration/single-story-close/gate-log.js)),
+  emit the digest, and **replay the tail inline on failure** — the bound is a
+  success-path bound, and a red gate's evidence belongs in front of the caller.
 - **Escape hatch.** `MANDREL_RESULT_DETAIL=inline` restores inline full
   detail for interactive debugging; scripts using `emitTerseResult` honor it
-  automatically.
+  automatically. `AGENT_LOG_LEVEL=verbose` restores live gate streaming.
 - **stdout purity is unchanged.** Scripts whose stdout is a machine contract
   (Story #2278) keep logs on stderr; the digest is the *only* stdout line.

--- a/.agents/scripts/lib/orchestration/complexity-gate.js
+++ b/.agents/scripts/lib/orchestration/complexity-gate.js
@@ -35,7 +35,10 @@
  *      acceptance-critic dispatch — while every `single-story-close.js` gate
  *      runs unchanged. The `route::lite` label is a **human-visible hint
  *      only**, never the control signal: a lost label or an unread marker can
- *      no longer misroute delivery.
+ *      no longer misroute delivery. Ahead of the shape read sits one
+ *      shape-independent rule (Story #4736): a **single-Story run** is inline
+ *      whatever its shape, because sub-agent isolation buys nothing when
+ *      there is no concurrent sibling to isolate from.
  *
  * The shape taxonomy is deliberately the one `review-depth.js` already
  * applies to the landed diff at close (`deriveChangeLevel` over the
@@ -561,37 +564,68 @@ function deriveStoryRouteFromBody(body, opts = {}) {
 }
 
 /**
- * Decide how `/deliver` executes a Story — **from the Story body's own
- * shape**, never from the `route::lite` label (Story #4722 AC-4/AC-5).
+ * Best-effort route derivation for reporting, when the *mode* is already
+ * pinned by run topology and only `route` remains to be filled in. A body
+ * that will not parse yields `null` rather than throwing — the caller is not
+ * asking the shape to decide anything.
  *
- * A lite-shaped Story executes **inline** in the deliver session — no
- * story-worker sub-agent boot and no fresh acceptance-critic dispatch
- * (sub-agent boots are the dominant deliver-phase token cost at trivial
- * scope). Everything else — a full-shaped body, a missing/unparseable body,
- * or the gate disabled via `planning.complexityGate.enabled=false` —
- * dispatches as a sub-agent: the conservative default.
+ * @param {unknown} body
+ * @param {{ injectedRules?: object, selectSensitivePathClassesFn?: Function }} opts
+ * @returns {ReturnType<typeof deriveStoryShape>|null}
+ */
+function routeForReporting(body, opts) {
+  if (typeof body !== 'string' || body.trim() === '') return null;
+  return deriveStoryRouteFromBody(body, opts);
+}
+
+/**
+ * Decide how `/deliver` executes a Story.
+ *
+ * Two independent premises, checked in this order:
+ *
+ * 1. **Run topology (Story #4736).** A run delivering a *single* Story
+ *    executes **inline**, whatever its shape. Sub-agent isolation is
+ *    load-bearing only for CONCURRENT dispatch — two workers sharing a
+ *    checkout would race on worktrees and branch refs — and a one-Story run
+ *    has no sibling to race. It therefore pays the spawn premium (a boot is
+ *    a cache WRITE at full rate, where an inline continuation is a cache read
+ *    at ~10%; ~$1.43/M vs ~$1.07/M on comparable bench work) for nothing.
+ *    This is a fact about the run, not about the work, so the shape gate's
+ *    `enabled` switch — which governs *shape derivation* — does not reach it.
+ * 2. **Shape (Story #4722 AC-4/AC-5).** For a multi-Story run, the decision
+ *    comes **from the Story body's own shape**, never from the `route::lite`
+ *    label: a lite-shaped Story executes inline; everything else — a
+ *    full-shaped body, a missing/unparseable body, or the gate disabled via
+ *    `planning.complexityGate.enabled=false` — dispatches as a sub-agent,
+ *    the conservative default.
  *
  * The label is read only to report hint consistency in `reasons`: with the
  * label absent (or its write failed) a lite-shaped Story still runs inline,
  * and with the label present on a full-shaped Story the shape wins.
  *
- * Inline execution removes model-side fan-out only. Every deterministic
- * `single-story-close.js` gate runs unchanged regardless of mode — see the
+ * Inline execution removes model-side fan-out only — it changes **where** the
+ * engine runs, never **what** runs. Every deterministic
+ * `single-story-close.js` gate, the PR to `main`, and the
+ * `story-deliver-terminal` envelope are identical in both modes; see the
  * module header's non-negotiables.
  *
  * @param {{
  *   body?: unknown,
  *   labels?: unknown,
  *   config?: object,
+ *   storyCount?: unknown,
  *   injectedRules?: object,
  *   selectSensitivePathClassesFn?: Function,
- * }} [args]
+ * }} [args] `storyCount` is the number of Stories the invoking `/deliver` run
+ *   resolved. Omitted (or not a positive integer) means "unknown run size",
+ *   which falls through to the shape decision — never to an assumed 1.
  * @returns {{ mode: 'inline'|'subagent', reasons: string[], route: ReturnType<typeof deriveStoryShape>|null }}
  */
 export function resolveStoryDispatchMode({
   body,
   labels,
   config,
+  storyCount,
   injectedRules,
   selectSensitivePathClassesFn,
 } = {}) {
@@ -602,6 +636,20 @@ export function resolveStoryDispatchMode({
   const hintNote = hasHint
     ? `the ${LITE_ROUTE_LABEL} label is present (hint only — the derived shape is the control signal)`
     : `the ${LITE_ROUTE_LABEL} label is absent (hint only — the derived shape is the control signal)`;
+
+  if (storyCount === 1) {
+    return {
+      mode: 'inline',
+      reasons: [
+        'single-Story run — execute deliver-story inline; sub-agent isolation is load-bearing only for concurrent dispatch, and a one-Story run has no sibling to race (close gates, PR, and terminal envelope unchanged)',
+        hintNote,
+      ],
+      route: routeForReporting(body, {
+        injectedRules,
+        selectSensitivePathClassesFn,
+      }),
+    };
+  }
 
   const gate = resolveComplexityGate(config);
   if (!gate.enabled) {

--- a/.agents/scripts/lib/orchestration/resolve-stories.js
+++ b/.agents/scripts/lib/orchestration/resolve-stories.js
@@ -325,6 +325,13 @@ export function buildStoriesEnvelope({
     // `route::lite` label is a human-visible hint only, never the control
     // signal: a lost label cannot misroute delivery. Model-side fan-out
     // only; close gates are untouched.
+    //
+    // `storyCount` (Story #4736) carries the run's topology into that same
+    // decision: a run resolving exactly ONE Story is inline whatever its
+    // shape, because the isolation a sub-agent buys only matters against a
+    // concurrently-dispatched sibling. It is the resolved set size — not the
+    // undelivered remainder — so the mode a caller reads for a given `--ids`
+    // list never changes as siblings land mid-run.
     stories: sorted.map(({ id, title, body, url, labels, state }) => ({
       id,
       title,
@@ -335,6 +342,7 @@ export function buildStoriesEnvelope({
         body,
         labels,
         config,
+        storyCount: sorted.length,
         injectedRules,
       }).mode,
     })),

--- a/.agents/scripts/lib/orchestration/single-story-close/gate-log.js
+++ b/.agents/scripts/lib/orchestration/single-story-close/gate-log.js
@@ -1,0 +1,186 @@
+/**
+ * single-story-close/gate-log.js — bounded gate output for the close path
+ * (Story #4736).
+ *
+ * ## Why
+ *
+ * `runCloseValidation` streams every child gate's stdout/stderr line through
+ * an injected `log`, and the close phase used to hand it `Logger.info` — whose
+ * default sink is `console.log`. A single successful close therefore wrote the
+ * whole of `npm test`, the linter, and the baseline checks onto the invoking
+ * agent's stdout: ~50KB, over the host's inline tool-result ceiling. The caller
+ * got a truncated preview, had to open the persisted file anyway, and re-ran
+ * close for a clean envelope — burning the run's most expensive stretch to
+ * re-derive output it already had.
+ *
+ * Story #4708 set the contract this restores compliance with (see
+ * `rules/orchestration-error-handling.md` § Output Contract): compact digest
+ * plus an on-disk artifact path, ≤ ~2KB on the **default success path**.
+ *
+ * ## The shape
+ *
+ * A sink captures every gate line to a log under the gitignored temp tree and
+ * emits nothing inline. What happens next depends on the outcome, because the
+ * two outcomes want opposite things:
+ *
+ *   - **success** — the caller wants the verdict, not the evidence.
+ *     {@link GateLogSink#digest} is one line: the pass count and the log path.
+ *   - **failure** — the evidence IS the point, and making the caller open a
+ *     file to see why a gate went red just moves the cost.
+ *     {@link GateLogSink#replay} puts the captured tail back inline.
+ *
+ * `AGENT_LOG_LEVEL=verbose` opts back into live inline streaming (the
+ * "existing log-level control"): the capture still happens, so the artifact is
+ * written either way.
+ *
+ * The sink never throws. A log directory that cannot be written degrades to
+ * inline streaming — losing the size bound is strictly better than losing the
+ * gate output that says why a close failed.
+ */
+
+import nodeFs from 'node:fs';
+import path from 'node:path';
+
+import { Logger, resolveLevel } from '../../Logger.js';
+
+/**
+ * How many trailing captured lines {@link GateLogSink#replay} puts back
+ * inline. A failed gate's actionable evidence — the assertion, the stack, the
+ * summary counts — sits at the end of its output; the head is startup noise.
+ * The full text is always in the artifact regardless.
+ */
+export const REPLAY_TAIL_LINES = 200;
+
+/** Basename of the per-Story gate log inside the temp directory. */
+function logNameFor(storyId) {
+  return `close-gates-${storyId ?? 'unknown'}.log`;
+}
+
+/**
+ * A capturing sink for close-validation gate output.
+ *
+ * Not exported as a constructor — {@link createGateLogSink} owns the
+ * degradation decision, so every instance in the wild has already resolved
+ * whether it has a writable artifact.
+ */
+class GateLogSink {
+  /**
+   * @param {{ logPath: string|null, streamInline: boolean, write: (line: string) => void, emit: (line: string) => void }} args
+   */
+  constructor({ logPath, streamInline, write, emit }) {
+    /** Absolute path of the artifact, or `null` when capture is unavailable. */
+    this.logPath = logPath;
+    /** Whether lines are ALSO echoed inline as they arrive. */
+    this.streamInline = streamInline;
+    /** Number of lines captured so far. */
+    this.lineCount = 0;
+    this._write = write;
+    this._emit = emit;
+    this._tail = [];
+  }
+
+  /**
+   * The `log` callable handed to `runCloseValidation` / `buildDefaultGates`.
+   * Bound, because it is passed by reference into the gate machinery.
+   *
+   * @type {(message: string) => void}
+   */
+  get log() {
+    return (message) => {
+      const line = String(message ?? '');
+      this.lineCount += 1;
+      this._tail.push(line);
+      if (this._tail.length > REPLAY_TAIL_LINES) this._tail.shift();
+      this._write(line);
+      if (this.streamInline) this._emit(line);
+    };
+  }
+
+  /**
+   * The success-path digest: one line, no gate output. Names the artifact so
+   * the caller can open it on demand rather than carrying it all session.
+   *
+   * @returns {string}
+   */
+  digest() {
+    const where = this.logPath
+      ? `full gate output → ${this.logPath}`
+      : 'full gate output was streamed inline (no artifact could be written)';
+    return `${this.lineCount} line(s) of gate output captured; ${where}`;
+  }
+
+  /**
+   * Put the captured tail back inline — the failure path, where the evidence
+   * is what the caller came for. A no-op when the lines were already streamed
+   * inline (verbose, or degraded capture), so nothing is ever printed twice.
+   *
+   * @returns {number} Lines replayed.
+   */
+  replay() {
+    if (this.streamInline || this._tail.length === 0) return 0;
+    const dropped = this.lineCount - this._tail.length;
+    if (dropped > 0) {
+      this._emit(
+        `[close-validation] … ${dropped} earlier line(s) omitted; full output → ${this.logPath}`,
+      );
+    }
+    for (const line of this._tail) this._emit(line);
+    return this._tail.length;
+  }
+}
+
+/**
+ * Build the gate-output sink for one close run.
+ *
+ * @param {{
+ *   storyId: number|null,
+ *   cwd?: string,
+ *   logDir?: string,
+ *   fs?: typeof nodeFs,
+ *   logger?: { info: (m: string) => void },
+ *   level?: string,
+ * }} [args] `logDir` defaults to `<cwd>/temp/orchestration`; `level` defaults
+ *   to the live Logger level so `AGENT_LOG_LEVEL=verbose` restores streaming.
+ * @returns {GateLogSink}
+ */
+export function createGateLogSink({
+  storyId = null,
+  cwd = process.cwd(),
+  logDir,
+  fs = nodeFs,
+  logger = Logger,
+  level,
+} = {}) {
+  const emit = (line) => logger.info?.(line);
+  const verbose = (level ?? resolveLevel()) === 'verbose';
+  const dir = logDir ?? path.join(cwd, 'temp', 'orchestration');
+
+  let handle = null;
+  let logPath = null;
+  try {
+    fs.mkdirSync(dir, { recursive: true });
+    logPath = path.join(dir, logNameFor(storyId));
+    // Truncate: each close run owns its artifact outright, so a re-run never
+    // hands the reader a file interleaving two runs' gates.
+    handle = fs.openSync(logPath, 'w');
+  } catch {
+    // No artifact — fall back to inline streaming rather than dropping the
+    // gate output on the floor.
+    return new GateLogSink({
+      logPath: null,
+      streamInline: true,
+      write: () => {},
+      emit,
+    });
+  }
+
+  const write = (line) => {
+    try {
+      fs.writeSync(handle, `${line}\n`);
+    } catch {
+      /* best-effort: a mid-run write failure must not abort the close */
+    }
+  };
+
+  return new GateLogSink({ logPath, streamInline: verbose, write, emit });
+}

--- a/.agents/scripts/lib/orchestration/single-story-close/phases/close-validation.js
+++ b/.agents/scripts/lib/orchestration/single-story-close/phases/close-validation.js
@@ -24,6 +24,15 @@
  * the same, with `baseBranch` as the diff anchor and the Story worktree as
  * the commit target.
  *
+ * Bounded gate output (Story #4736). Every gate line goes to the run's
+ * `gate-log.js` sink — an artifact under the gitignored temp tree — instead
+ * of straight to the agent's stdout, where a passing `npm test` alone once
+ * pushed a successful close past the host's inline tool-result ceiling. A
+ * clean run reports one digest line naming the artifact; a failing gate
+ * replays its captured tail inline, because that is exactly when the caller
+ * needs the evidence in front of them. `AGENT_LOG_LEVEL=verbose` restores
+ * live streaming.
+ *
  * `runCloseValidation`, `buildDefaultGates`, and `runScopedFormatAutofix`
  * are accepted as injected dependencies so the parent CLI's cache-busted
  * bindings win in tests that mock the upstream module URLs.
@@ -33,6 +42,7 @@ import { buildDefaultGates as defaultBuildDefaultGates } from '../../../close-va
 import { runCloseValidation as defaultRunCloseValidation } from '../../../close-validation/runner.js';
 import { Logger } from '../../../Logger.js';
 import { runScopedFormatAutofix as defaultRunScopedFormatAutofix } from '../../story-close/format-autofix.js';
+import { createGateLogSink as defaultCreateGateLogSink } from '../gate-log.js';
 
 /**
  * Run the close-validation gate chain. Throws on first gate failure.
@@ -60,6 +70,7 @@ import { runScopedFormatAutofix as defaultRunScopedFormatAutofix } from '../../s
  *   runCloseValidation?: typeof defaultRunCloseValidation,
  *   buildDefaultGates?: typeof defaultBuildDefaultGates,
  *   runScopedFormatAutofix?: typeof defaultRunScopedFormatAutofix,
+ *   createGateLogSink?: typeof defaultCreateGateLogSink,
  * }} args
  */
 export async function runCloseValidationPhase({
@@ -73,6 +84,7 @@ export async function runCloseValidationPhase({
   runCloseValidation = defaultRunCloseValidation,
   buildDefaultGates = defaultBuildDefaultGates,
   runScopedFormatAutofix = defaultRunScopedFormatAutofix,
+  createGateLogSink = defaultCreateGateLogSink,
 }) {
   // Story #4250 — format-autofix self-heal before the check-only gates.
   // Mirrors the Epic path (story-close/phases/gates.js): the formatter is
@@ -122,6 +134,9 @@ export async function runCloseValidationPhase({
     'VALIDATE',
     `Running close-validation gates against baseline ${baseBranch}${worktreePath ? ` in ${worktreePath}` : ''}...`,
   );
+  // Story #4736 — one sink for both `log` seams (gate construction and gate
+  // execution), so nothing in the chain can route around the artifact.
+  const gateLog = createGateLogSink({ storyId, cwd });
   const validation = await runCloseValidation({
     cwd,
     worktreePath,
@@ -129,9 +144,9 @@ export async function runCloseValidationPhase({
       config,
       baseBranch,
       cwd: worktreePath || cwd,
-      log: (m) => Logger.info(m),
+      log: gateLog.log,
     }),
-    log: (m) => Logger.info(m),
+    log: gateLog.log,
     storyId,
     // Story #4250 — standalone storyId-anchored evidence keyspace. No
     // epicId; the standalone flag routes the cache to
@@ -141,10 +156,13 @@ export async function runCloseValidationPhase({
   if (!validation.ok) {
     const [first] = validation.failed;
     const { gate, status, cwd: gateCwd } = first;
+    // The evidence is the point on this path: replay the captured tail inline
+    // rather than making the caller open a file to learn why close stopped.
+    gateLog.replay();
     throw new Error(
       `[single-story-close] Gate failed: ${gate.name} (exit ${status})${gateCwd ? ` in ${gateCwd}` : ''}.` +
         (gate.hint ? ` ${gate.hint}` : ''),
     );
   }
-  progress('VALIDATE', '✅ All gates passed.');
+  progress('VALIDATE', `✅ All gates passed. ${gateLog.digest()}`);
 }

--- a/.agents/workflows/deliver.md
+++ b/.agents/workflows/deliver.md
@@ -10,7 +10,9 @@ description:
 > **Lean spine.** Happy path + gate list. Sequencing edge cases, dispatch
 > mechanics, lite-route inline execution, checklist threading, ceremony, and
 > the per-run epilogue live in the on-demand
-> [`helpers/deliver-reference.md`](helpers/deliver-reference.md).
+> [`helpers/deliver-reference.md`](helpers/deliver-reference.md). What every
+> delivery always needs is bundled into one read:
+> [`helpers/deliver-digest.md`](helpers/deliver-digest.md) (Story #4736).
 
 ## Role
 
@@ -20,20 +22,22 @@ owns input resolution and sequencing only — every Story runs through
 `epic/<id>` integration branch, no `--no-ff` wave merges.
 
 The dependency graph is **discovered, not declared**: `resolve-stories.js`
-reads it from live state (body edges ∪ native GitHub `blocked_by` edges, every
-blocker resolved against its real issue state). You never hand it a graph, and
+reads it from live state (body edges ∪ native GitHub `blocked_by` edges, each
+blocker resolved against its real issue state). You never hand it a graph and
 there is no batch label — which is what lets you deliver Stories **across plan
-runs and over time**. The `plan-run::<id>` grouping label is filter metadata
-only — never a resolution input (there is no `--run` or `--dep` axis).
+runs and over time**. `plan-run::<id>` is filter metadata, never a resolution
+input.
 Per-Story routes are **body-derived** too (#4722); `route::lite` is a hint
-only.
+only. Ahead of that: a **single-Story run runs the engine inline** whatever the
+shape (#4736) — sub-agent isolation only earns its cost against a concurrent
+sibling.
 
 ## Inputs
 
 | Invocation | Behavior |
 | --- | --- |
-| `/deliver <storyId>` | Deliver one Story via `helpers/deliver-story.md`. |
-| `/deliver <storyId> <storyId> ...` | Resolve the set with `resolve-stories.js`, then sequence by the discovered graph via `stories-wave-tick.js`. Default concurrency is **3**. |
+| `/deliver <storyId>` | Deliver one Story via `helpers/deliver-story.md`, executed **inline in this session** — no `story-worker` spawn. |
+| `/deliver <storyId> <storyId> ...` | Resolve the set with `resolve-stories.js`, then sequence by the discovered graph via `stories-wave-tick.js`, dispatching role-scoped sub-agents. Default concurrency is **3**. |
 
 Any named ticket that is not `type::story`, or still carrying an `Epic: #N`
 footer, is a **hard error** naming the id and the fix (close or re-plan as a v2
@@ -43,18 +47,16 @@ Story). Resolution refuses the whole set rather than silently under-delivering.
 
 | Flag | Meaning |
 | --- | --- |
-| `--concurrency <n>` | **Optional** per-run override of the fan-out cap. Omit it to honor `delivery.deliverRunner.concurrencyCap` (config default **3**, including any `.agentrc.local.json` override); pass it **only** for a one-run cap. `1` = sequential. |
+| `--concurrency <n>` | **Optional** per-run override of the fan-out cap. Omit it to honor `delivery.deliverRunner.concurrencyCap` (config default **3**, incl. any `.agentrc.local.json` override); pass **only** for a one-run cap. `1` = sequential. |
 | `--yes` | Suppress the multi-Story confirmation gate. |
 | `--steal` | Forwarded to `single-story-init.js` / lease steal. |
 | `--wait-merge` | Force close-and-land (the default; `delivery.routing.closeAndLand`). |
 | `--no-wait-merge` | Opt out; stop at `agent::closing` for a human land. |
 
 **Operator-merge implies no-wait.** `--no-auto-merge` and
-`delivery.ci.autoMerge: "strict"` leave the PR un-armed: the Story rests at
-`agent::closing` for the human merge and is **not** flipped to `agent::blocked`
-(`--wait-merge` does not override this). A genuine *arm failure* differs — it
-still waits and still blocks, because that is a fault to report, not an operator
-decision to respect.
+`delivery.ci.autoMerge: "strict"` rest the Story at `agent::closing`, not
+`agent::blocked` — a genuine *arm failure* still waits and still blocks
+([`helpers/deliver-reference.md` § Operator-merge](helpers/deliver-reference.md)).
 
 ## Procedure
 
@@ -64,8 +66,8 @@ decision to respect.
    present the order in step 2. You do **not** thread them into step 3 — the
    tick re-resolves the graph itself every beat. Resolution hard-errors
    (exit 1) on a named id that is not a Story, carries an `Epic: #N` footer, or
-   whose native edges cannot be read — a missing gate would co-dispatch a Story
-   against an unlanded blocker.
+   whose native edges cannot be read — a missing gate would co-dispatch against
+   an unlanded blocker.
 
 2. **Confirm (N>1).** Present the order; wait unless `--yes`.
 
@@ -78,10 +80,8 @@ decision to respect.
    ```
 
    **Do not add `--concurrency` unless the operator explicitly asked for a
-   per-run cap.** Omitting it lets the tick resolve the cap from
-   `delivery.deliverRunner.concurrencyCap` — including a `.agentrc.local.json`
-   override. An explicit `--concurrency <n>` wins over config for that run, so a
-   filled-in literal (e.g. `3`) silently defeats the operator's override.
+   per-run cap** — an explicit value wins over config, so a filled-in literal
+   silently defeats a `.agentrc.local.json` override (see Flags).
 
    Each beat re-probes live state to derive done / in-flight itself; you never
    compute them (Story #4594). `--dispatched` is the one thing you must supply —
@@ -129,10 +129,10 @@ review depth reading the same level) and the mechanism table:
 
 ## Reading a Story's outcome
 
-Each Story's delivery ends in exactly one schema-validated terminal envelope
-([`story-deliver-terminal.schema.json`](../schemas/story-deliver-terminal.schema.json),
-Story #4543) — `landed` | `pending` | `blocked` | `failed`, the SSOT for the
-shape; this workflow does not restate its fields.
+Each Story's delivery ends in exactly one schema-validated terminal envelope —
+`landed` | `pending` | `blocked` | `failed`. Statuses, exits, and fields:
+[`helpers/deliver-digest.md`](helpers/deliver-digest.md) § 5, over the shipped
+[schema](../schemas/story-deliver-terminal.schema.json) (Story #4543).
 
 `pending` is **not** a failure: the bounded merge wait expired with the PR
 healthy (or a human owns the merge), nothing was mutated, and the
@@ -146,11 +146,9 @@ For a Story in an unclear state — including the merged-but-label-stale one a
 
 ## Constraints
 
-- **Land or block — never a silent local build.** Worktrees, `story-<id>`
-  branches, close-validation, and PR-to-`main` are the only sanctioned delivery
-  mechanism. Attended delivers default to close-and-land
-  (`delivery.routing.closeAndLand: true`); use `--no-wait-merge` only when a
-  human lands the PR.
+- **Land or block — never a silent local build** (digest § 2). Attended
+  delivers default to close-and-land (`delivery.routing.closeAndLand: true`);
+  use `--no-wait-merge` only when a human lands the PR.
 - `/deliver` never plans — tickets come from [`/plan`](plan.md). The router
   performs no git/label mutations; `deliver-story` owns every script.
 

--- a/.agents/workflows/helpers/deliver-digest.md
+++ b/.agents/workflows/helpers/deliver-digest.md
@@ -1,0 +1,126 @@
+---
+description: >-
+  The deliver path's one bundled framework read (Story #4736). Carries what
+  every Story delivery always needs — dispatch decision, engine invariants,
+  the change-set/ceremony incantation, the acceptance-eval gate, and the
+  terminal envelope contract — so the engine reads one file instead of
+  re-reading the helper/schema set each session.
+---
+
+# Deliver digest (read once per session)
+
+> **Bundle, not a procedure.** [`deliver-story.md`](deliver-story.md) is still
+> the steps. This file is the material those steps referenced across five
+> separate files and a JSON schema — bundled so one read covers the whole happy
+> path. Situational material (lease preflight, recovery routers, merge-wait
+> budgets, CI remediation) stays on demand in
+> [`deliver-story-reference.md`](deliver-story-reference.md) and
+> [`deliver-reference.md`](deliver-reference.md); read those **only** when an
+> envelope or a failure routes you there.
+
+## 1. Dispatch — where the engine runs
+
+Read `stories[].dispatchMode` from the `resolve-stories.js` envelope. Two
+rules produce it, in order:
+
+1. **Run topology (#4736).** A run resolving **one** Story is `inline`
+   whatever its shape — sub-agent isolation is load-bearing only against a
+   *concurrent* sibling racing the same checkout, and a one-Story run has none.
+2. **Body shape (#4722).** In a multi-Story run, a lite-shaped body is
+   `inline`; a full-shaped body, an unparseable one, or a footprint touching a
+   sensitive-path class is `subagent`. The `route::lite` label is a
+   human-visible hint, never the control signal.
+
+`inline` removes model-side fan-out only — no `story-worker` boot, no fresh
+acceptance-critic spawn. **`subagent` and `inline` run the same engine**: same
+gates, same PR to `main`, same terminal envelope, byte for byte.
+
+## 2. Engine invariants
+
+| Trait | Contract |
+| --- | --- |
+| Ticket type | `type::story` only; an `Epic: #N` footer means **stop and re-plan** |
+| Branch | `story-<id>`, seeded from `project.baseBranch` (`main`) |
+| Merge target | `main` via PR (squash + required checks) — never a direct push |
+| Integration branch | **None** — no `epic/<id>`, no `--no-ff` wave merge |
+| Gates | Every close gate runs regardless of route; no route bypasses one |
+| State | Only via `update-ticket-state.js --ticket <id> --state <state>` |
+| Paths | Prefix every path-based tool with the absolute `workCwd` — `cd` does not scope them |
+
+**Land or block.** Worktree → `story-<id>` → close-validation → PR to `main` is
+the only sanctioned landing. A silent local build is not a delivery.
+
+## 3. Change set — computed once, handed to everyone
+
+One enumeration per Story (#4593). A critic that re-runs its own `git diff`
+can score a different set than the one that routed it:
+
+```bash
+node --input-type=module -e '
+  import { computeChangeSet } from "<main-repo>/.agents/scripts/lib/orchestration/change-set.js";
+  const { files } = computeChangeSet({ baseRef: "main", headRef: "story-<storyId>" });
+  console.log(JSON.stringify(files));
+'
+```
+
+Derive the level with `deriveChangeLevel`
+([`review-depth.js`](../../scripts/lib/orchestration/review-depth.js)) over
+that one list: a sensitive path registered in `audit-rules.json` → `high`, none
+→ `low`, an unenumerable diff (`files === null`) → `null`. Resolve
+fresh-vs-inline critics with `resolveCeremonyForRisk`
+([`ceremony-routing.js`](../../scripts/lib/orchestration/ceremony-routing.js)):
+`minimal` → always inline, `strict` → always fresh, `standard` → `high`/`null`
+→ fresh and `low` → inline unless the `freshCriticSampleRate` floor forces
+fresh. An `inline` dispatch mode overrides all of it to inline critics. Close's
+`review-depth.js` reads the same derived level, so the two cannot disagree.
+
+## 4. Acceptance self-eval (Step 1a, required)
+
+**One verdict-owner per cluster** (#4723) — the fresh critic *or* the inline
+self-eval, named by `verdictOwner`, never both and never a warm-up pass. It
+scores each `acceptance[]` item against the change set above, with `verify[]`
+output as evidence. Bounded by `delivery.acceptanceEval.maxRounds` (default 2).
+Then score the authored verdict:
+
+```bash
+node <main-repo>/.agents/scripts/acceptance-eval.js \
+  --story <storyId> --verdict <verdict-path>
+```
+
+`proceed` → close. `redraft` → one more round inside the cap. `block` → **do
+not close**: post a `friction` comment and flip `agent::blocked`.
+Per-round mechanics: [`acceptance-self-eval.md`](acceptance-self-eval.md).
+
+## 5. Terminal envelope — the return contract
+
+`single-story-close.js` emits exactly one envelope on stdout between
+`--- STORY DELIVER TERMINAL ---` markers, schema-validated against
+[`story-deliver-terminal.schema.json`](../../schemas/story-deliver-terminal.schema.json)
+(#4543 — the SSOT; read the JSON only when you need a field this table omits).
+Relay it verbatim; never hand-compose one, never substitute prose.
+
+| `status` | Exit | Meaning | You do |
+| --- | --- | --- | --- |
+| `landed` | 0 | PR merged, `agent::done`, tail ran (`tail.*: false` degrades the report, not the land) | Relay it. Done. |
+| `pending` | 3 | **Resumable, not a failure** — the bounded wait expired healthy, or a human owns the merge. Nothing was mutated. | Run `nextCommand`. |
+| `blocked` | 1 | Hard block; `blocked.blockClass` names it | `checks-failed` → fix + resume; else relay |
+| `failed` | 1 | A phase crashed; `phase` names which | Diagnose, fix, re-run close |
+
+Required fields: `kind` (`story-deliver-terminal`), `storyId`, `status`,
+`phase`, `elapsedSeconds`, `nextCommand`. `phase` is one of `init`,
+`wrong-tree-guard`, `close-validation`, `base-sync`, `push`, `pull-request`,
+`code-review`, `auto-merge`, `confirm-merge`, `post-land`, `done`. `gates`
+reports every gate as `passed` / `failed` / `skipped` — a skipped gate is
+reported, never omitted, so a missing gate is never read as a passing one.
+
+**Gate output is captured, not streamed (#4736).** Close writes gate lines to
+`temp/orchestration/close-gates-<storyId>.log` and reports a one-line digest on
+success; a failed gate replays its tail inline. `AGENT_LOG_LEVEL=verbose`
+restores live streaming.
+
+## 6. When to leave this file
+
+- Unclear state / a re-run refusal → `deliver-recover.js --story <id>` (read-only).
+- Lease, sweep, worktree-scope detail → [`deliver-story-reference.md`](deliver-story-reference.md).
+- CI red after the PR opens → [`rules/ci-remediation.md`](../../rules/ci-remediation.md).
+- Sequencing, epilogue, checklist threading → [`deliver-reference.md`](deliver-reference.md).

--- a/.agents/workflows/helpers/deliver-reference.md
+++ b/.agents/workflows/helpers/deliver-reference.md
@@ -51,6 +51,16 @@ probe logs a warning and leans on init's lease refusal alone.
 
 ## Dispatch mechanics (role-scoped by default)
 
+**A single-Story run executes inline (Story #4736).** Sub-agent isolation is
+load-bearing only for **concurrent** dispatch — two workers sharing a checkout
+would race on worktrees and branch refs — so a run resolving exactly one Story
+has no sibling to isolate from and pays the spawn premium for nothing (a boot is
+a cache write at full rate; an inline continuation is a cache read at ~10%).
+`resolve-stories.js` already reports it: a one-id run comes back with
+`dispatchMode: "inline"` whatever the Story's shape. Role-scoped spawning is
+retained in full for multi-Story waves, and the rule changes **where** the
+engine runs, never what runs — gates, PR, and terminal envelope are identical.
+
 **Lite-shaped Stories execute inline (Story #4722).** Before spawning anything,
 read the Story's `dispatchMode` from the resolver envelope
 (`stories[].dispatchMode`, derived by `resolveStoryDispatchMode` in
@@ -113,6 +123,17 @@ execute it directly, in this turn, threading the same `docsDigestPath` /
 `checklistPath` / change-set discipline. Under `--yes` / injected helper
 content, execute directly without a re-read turn. The engine, gates, and
 terminal envelope are identical either way — only the isolation differs.
+
+## Operator-merge implies no-wait
+
+`--no-auto-merge` and `delivery.ci.autoMerge: "strict"` leave the PR
+deliberately un-armed: there is nothing for close to land, so the Story rests
+at `agent::closing` for the human merge and is **not** flipped to
+`agent::blocked` — `--wait-merge` does not override this, because the operator
+owning the merge is a decision to respect, not a fault to report. A genuine
+*arm failure* is the opposite case: nobody chose it, so close still waits and
+still blocks. That asymmetry is what keeps the must-land contract intact
+without misfiling deliberate human merges as blocks.
 
 ## Per-run epilogue (N>1)
 

--- a/.agents/workflows/helpers/deliver-story-reference.md
+++ b/.agents/workflows/helpers/deliver-story-reference.md
@@ -341,6 +341,12 @@ The `single-story-close.js` script, in order:
 
 1. Runs the close-validation gates against `baseBranch` as the baseline.
    On any gate failure it throws — the operator fixes and re-runs close.
+   **Gate output is captured, not streamed (Story #4736).** Every gate line
+   goes to `temp/orchestration/close-gates-<storyId>.log`; a clean run reports
+   one digest line naming that artifact, and a **failed** gate replays its
+   captured tail inline so the evidence is in front of you without opening a
+   file. Read the artifact when you need the full text — or re-run under
+   `AGENT_LOG_LEVEL=verbose` for live streaming.
 1a. **Syncs the Story branch from `origin/<baseBranch>`** before push
    (Story #2580). Runs `git fetch origin <baseBranch>` followed by
    `git merge --no-edit origin/<baseBranch>` inside the worktree. This

--- a/.agents/workflows/helpers/deliver-story.md
+++ b/.agents/workflows/helpers/deliver-story.md
@@ -11,6 +11,13 @@ description:
 > reference detail lives in
 > [`deliver-story-reference.md`](deliver-story-reference.md) ("reference"
 > below); consult on demand. Invoked by [`/deliver`](../deliver.md).
+>
+> **Read [`deliver-digest.md`](deliver-digest.md) once, first.** It is the
+> one bundled read of what every delivery needs — dispatch decision, engine
+> invariants, the change-set/ceremony incantation, the acceptance-eval gate,
+> and the terminal-envelope contract — replacing the per-session re-reads of
+> the helper set and `story-deliver-terminal.schema.json` (Story #4736). The
+> steps below cite it as "digest § N" rather than restating it.
 
 ## Overview
 
@@ -74,15 +81,10 @@ One branch, one PR to `main`, commits against the inline `acceptance[]` /
 
 ### Step 1a — Bounded acceptance self-eval loop (**required**)
 
-Follow the single-homed include
-[`acceptance-self-eval.md`](acceptance-self-eval.md) (single verdict-owner,
-`verify[]`-as-evidence, proceed / redraft / block). Gate invocation (omit
-`--epic`):
-
-```bash
-node <main-repo>/.agents/scripts/acceptance-eval.js \
-  --story <storyId> --verdict <verdict-path>
-```
+Run the loop and score it with `acceptance-eval.js` — **digest § 4** carries
+the invocation and the proceed / redraft / block contract; per-round critic
+mechanics live in the single-homed include
+[`acceptance-self-eval.md`](acceptance-self-eval.md).
 
 **`proceed`** → Step 2 then Step 3. **`block`** → **do not close**: post a
 `friction` comment and flip `agent::blocked` — commands and the
@@ -92,16 +94,12 @@ node <main-repo>/.agents/scripts/acceptance-eval.js \
 ## Step 2 — Ceremony (profile + derived level)
 
 Ceremony is `delivery.routing.ceremonyProfile` × the **derived change
-level** — never a planner-authored verdict (Story #4542).
-**Compute the change set once** (Story #4593) with the shared enumerator
-[`computeChangeSet`](../../scripts/lib/orchestration/change-set.js) — the
-same module close uses — and hand that one list to every critic. Derive the
-level with `deriveChangeLevel`, resolve fresh-vs-inline critics with
-`resolveCeremonyForRisk` (`ceremony-routing.js`); a lite Story runs inline
-regardless (exact incantation and routing rules: reference § Step 2).
-Hard gates (lint / test / format / coverage / CRAP / maintainability)
-always run in Step 3 — the derived level never disables them; do **not**
-pre-run the full close chain here.
+level** — never a planner-authored verdict (Story #4542). **Digest § 3** is
+the incantation: compute the change set once (Story #4593), derive the level,
+resolve fresh-vs-inline critics with `ceremony-routing.js`; a lite Story runs
+inline regardless (routing edge cases: reference § Step 2). Hard gates always
+run in Step 3 — the derived level never disables them; do **not** pre-run the
+close chain here.
 
 ## Step 3 — Close and land (`single-story-close.js`)
 
@@ -110,15 +108,12 @@ node <main-repo>/.agents/scripts/single-story-close.js --story <storyId> --cwd <
 ```
 
 **The whole delivery tail** — gates, PR, merge wait, `agent::done` flip,
-post-land tail in one process. Run it and **branch on the terminal
-envelope's `status`** (Story #4543):
-
-| `status` | Exit | Meaning | You do |
-| --- | --- | --- | --- |
-| `landed` | 0 | PR merged, `agent::done`, tail ran (`tail.*: false` degrades the report, not the land). | Relay the envelope (Step 7). |
-| `pending` | 3 | **Resumable, not a failure** — wait expired healthy, or a human owns the merge. | Run `nextCommand` until resolved. |
-| `blocked` | 1 | Hard block; `blocked.blockClass` names it. | `checks-failed` → Step 4; else relay. |
-| `failed` | 1 | A phase crashed; `phase` names which. | Diagnose, fix, re-run close. |
+post-land tail in one process. Run it and **branch on the terminal envelope's
+`status`** per the table in **digest § 5** (`landed` → Step 7; `pending` → run
+`nextCommand`; `blocked`/`checks-failed` → Step 4; `failed` → diagnose and
+re-run). Gate output is captured to
+`temp/orchestration/close-gates-<storyId>.log` — a clean run prints a digest
+line, a red gate replays its tail inline (Story #4736).
 
 Internals (gate order, base-sync, auto-merge arming), the merge-wait
 budgets, the slow-CI **async** confirm mode (Story #4698 — launch the
@@ -143,13 +138,13 @@ recovery path **only** when the envelope routes you there:
 
 ## Step 7 — Return contract (**required as a sub-agent**) {#return-contract}
 
-The contract is the shipped schema
-[`story-deliver-terminal.schema.json`](../../schemas/story-deliver-terminal.schema.json)
-— the SSOT for every field (Story #4543). End your turn by relaying the
-validated envelope close emits between its `--- STORY DELIVER TERMINAL ---`
-markers — never free-form prose, never a hand-composed object. `pending` is
-the only sanctioned no-merge ending, returned only when your own budget is
-exhausted (Story #1553). Reference § Step 7.
+End your turn by relaying the validated envelope close emits between its
+`--- STORY DELIVER TERMINAL ---` markers — never free-form prose, never a
+hand-composed object. Statuses, exits, and required fields: **digest § 5**
+(whose SSOT is the shipped
+[schema](../../schemas/story-deliver-terminal.schema.json), Story #4543).
+`pending` is the only sanctioned no-merge ending, returned only when your own
+budget is exhausted (Story #1553). Reference § Step 7.
 
 ## Recovering a stranded Story {#recover}
 
@@ -175,6 +170,7 @@ reuses an open PR).
 
 ## See also
 
+- [`deliver-digest.md`](deliver-digest.md) — the one bundled framework read.
 - [`/deliver`](../deliver.md) — unified entry point.
 - [`deliver-story-reference.md`](deliver-story-reference.md) — all on-demand
   detail.

--- a/tests/lib/orchestration/complexity-gate.test.js
+++ b/tests/lib/orchestration/complexity-gate.test.js
@@ -381,6 +381,125 @@ describe('resolveStoryDispatchMode — body-derived dispatch (AC-4, AC-5)', () =
   });
 });
 
+/**
+ * Story #4736 — run topology decides ahead of shape.
+ *
+ * The premise under test: sub-agent isolation is load-bearing only against a
+ * CONCURRENTLY-dispatched sibling (two workers sharing a checkout race on
+ * worktrees and branch refs). A one-Story run has no sibling, so the spawn
+ * premium buys nothing — and that is a fact about the run, not the work, which
+ * is why it sits ahead of every shape read including the gate kill-switch.
+ */
+describe('resolveStoryDispatchMode — run topology (Story #4736)', () => {
+  const fullBody = storyBody({
+    changes: ['a', 'b', 'c', 'd'].map((p) => ({
+      path: `src/${p}.js`,
+      assumption: 'refactors-existing',
+    })),
+    acceptance: ['a works', 'b works', 'c works', 'd works'],
+  });
+  const sensitiveBody = storyBody({
+    changes: [{ path: 'src/billing/banner.js', assumption: 'creates' }],
+    acceptance: ['shows the banner'],
+  });
+
+  test('AC-1: a single-Story run is inline even for a full-shaped Story', () => {
+    const decision = resolveStoryDispatchMode({
+      body: fullBody,
+      labels: ['type::story'],
+      storyCount: 1,
+      injectedRules: RULES,
+    });
+    assert.equal(decision.mode, 'inline');
+    assert.match(decision.reasons[0], /single-Story run/i);
+    assert.match(
+      decision.reasons[0],
+      /concurrent/i,
+      'the reason must name the premise — isolation only matters against a concurrent sibling',
+    );
+  });
+
+  test('AC-1: a multi-Story run still dispatches sub-agents for full-shaped Stories', () => {
+    for (const storyCount of [2, 3, 12]) {
+      const decision = resolveStoryDispatchMode({
+        body: fullBody,
+        labels: ['type::story'],
+        storyCount,
+        injectedRules: RULES,
+      });
+      assert.equal(
+        decision.mode,
+        'subagent',
+        `a ${storyCount}-Story run must retain role-scoped sub-agent dispatch`,
+      );
+    }
+  });
+
+  test('AC-2: the derived route is still reported inline, so ceremony reads the same shape', () => {
+    const decision = resolveStoryDispatchMode({
+      body: fullBody,
+      storyCount: 1,
+      injectedRules: RULES,
+    });
+    assert.equal(
+      decision.route.route,
+      'full',
+      'inline changes WHERE the engine runs, never what the shape says about it',
+    );
+
+    const sensitive = resolveStoryDispatchMode({
+      body: sensitiveBody,
+      storyCount: 1,
+      injectedRules: RULES,
+    });
+    assert.equal(sensitive.mode, 'inline');
+    assert.equal(
+      sensitive.route.route,
+      'full',
+      'a sensitive footprint still derives full — inline dispatch does not launder it to lite',
+    );
+  });
+
+  test('a single-Story run is inline with an unparseable body (route reports null)', () => {
+    const decision = resolveStoryDispatchMode({
+      body: '   ',
+      storyCount: 1,
+      injectedRules: RULES,
+    });
+    assert.equal(decision.mode, 'inline');
+    assert.equal(decision.route, null);
+  });
+
+  test('the shape kill-switch does not reach the topology rule', () => {
+    const decision = resolveStoryDispatchMode({
+      body: fullBody,
+      storyCount: 1,
+      config: { planning: { complexityGate: { enabled: false } } },
+      injectedRules: RULES,
+    });
+    assert.equal(
+      decision.mode,
+      'inline',
+      'planning.complexityGate governs shape derivation, not run topology',
+    );
+  });
+
+  test('an unknown or non-single run size falls through to the shape decision', () => {
+    for (const storyCount of [undefined, null, 0, '1', 1.5, -1]) {
+      const decision = resolveStoryDispatchMode({
+        body: fullBody,
+        storyCount,
+        injectedRules: RULES,
+      });
+      assert.equal(
+        decision.mode,
+        'subagent',
+        `storyCount=${String(storyCount)} must never be read as a single-Story run`,
+      );
+    }
+  });
+});
+
 // The lite path forks no delivery code: a lite-shaped Story is an ordinary
 // `type::story` ticket that `/deliver` picks up and `single-story-close.js`
 // PRs to `main` and gates unchanged. Driving a lite-shaped Story through the

--- a/tests/lib/orchestration/single-story-close/close-validation-phase.test.js
+++ b/tests/lib/orchestration/single-story-close/close-validation-phase.test.js
@@ -1,5 +1,8 @@
 import assert from 'node:assert/strict';
-import { describe, it } from 'node:test';
+import nodeFs from 'node:fs';
+import nodeOs from 'node:os';
+import path from 'node:path';
+import { after, before, describe, it } from 'node:test';
 
 import { runCloseValidationPhase } from '../../../../.agents/scripts/lib/orchestration/single-story-close/phases/close-validation.js';
 
@@ -160,6 +163,121 @@ describe('runCloseValidationPhase — standalone parity (Story #4250)', () => {
         err instanceof Error &&
         err.message.includes('lint') &&
         err.message.includes('fix lint'),
+    );
+  });
+});
+
+/**
+ * Story #4736 — the success path's stdout bound.
+ *
+ * A passing `npm test` alone used to put ~50KB of gate output on the invoking
+ * agent's stdout, past the host's inline tool-result ceiling: the caller got a
+ * truncated preview, read the persisted file anyway, and re-ran close for a
+ * clean envelope. These tests pin the fix at the real wiring — no injected
+ * sink, so a future change that routes gate output back to `Logger.info`
+ * fails here.
+ */
+describe('runCloseValidationPhase — bounded gate output (Story #4736)', () => {
+  const GATE_LINE = `[test] ${'x'.repeat(120)}`;
+  const GATE_LINES = 2_000;
+  const STDOUT_BOUND_BYTES = 2048;
+
+  let tmpDir;
+  let stdout;
+  let realLog;
+
+  before(() => {
+    tmpDir = nodeFs.mkdtempSync(path.join(nodeOs.tmpdir(), 'close-gate-out-'));
+  });
+
+  after(() => {
+    if (realLog) console.log = realLog;
+    nodeFs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  /**
+   * Run the phase with a validation stub that streams `GATE_LINES` fat lines
+   * through the phase's own `log` seam, capturing everything the default
+   * Logger routes to stdout.
+   */
+  async function runCapturing({ ok }) {
+    stdout = [];
+    realLog = console.log;
+    console.log = (m) => stdout.push(String(m));
+    try {
+      const args = {
+        cwd: tmpDir,
+        worktreePath: null,
+        config: {},
+        baseBranch: 'main',
+        storyBranch: 'story-4736',
+        storyId: 4736,
+        progress: () => {},
+        runCloseValidation: ({ log }) => {
+          for (let i = 0; i < GATE_LINES; i += 1) log(`${GATE_LINE} ${i}`);
+          return ok
+            ? { ok: true, failed: [], skipped: [] }
+            : {
+                ok: false,
+                failed: [
+                  {
+                    gate: { name: 'test', hint: 'fix it' },
+                    status: 1,
+                    cwd: tmpDir,
+                  },
+                ],
+                skipped: [],
+              };
+        },
+        buildDefaultGates: () => [],
+        runScopedFormatAutofix: () => ({ ran: false, committed: false }),
+      };
+      if (ok) await runCloseValidationPhase(args);
+      else await assert.rejects(() => runCloseValidationPhase(args));
+    } finally {
+      console.log = realLog;
+      realLog = null;
+    }
+    return stdout.join('\n');
+  }
+
+  it('keeps a successful close under ~2KB of stdout and persists the full output (AC-3)', async () => {
+    const captured = await runCapturing({ ok: true });
+    const bytes = Buffer.byteLength(captured, 'utf8');
+
+    assert.ok(
+      bytes <= STDOUT_BOUND_BYTES,
+      `a successful close must emit ≤ ~${STDOUT_BOUND_BYTES}B to stdout (was ${bytes}B): ${captured.slice(0, 400)}`,
+    );
+    assert.ok(
+      !captured.includes(GATE_LINE),
+      'no raw gate line may reach stdout on the success path',
+    );
+
+    const artifact = path.join(
+      tmpDir,
+      'temp',
+      'orchestration',
+      'close-gates-4736.log',
+    );
+    const written = nodeFs.readFileSync(artifact, 'utf8');
+    assert.equal(
+      written.split('\n').filter(Boolean).length,
+      GATE_LINES,
+      'every gate line must survive in the artifact under the temp tree',
+    );
+  });
+
+  it('replays gate evidence inline when a gate fails (AC-4)', async () => {
+    const captured = await runCapturing({ ok: false });
+
+    assert.ok(
+      captured.includes(GATE_LINE),
+      'a failed close must put the gate evidence back in front of the caller',
+    );
+    assert.ok(
+      Buffer.byteLength(captured, 'utf8') > STDOUT_BOUND_BYTES,
+      'the size bound is deliberately success-path-only — the diagnostic tail is not truncated to fit it',
     );
   });
 });

--- a/tests/lib/orchestration/single-story-close/gate-log.test.js
+++ b/tests/lib/orchestration/single-story-close/gate-log.test.js
@@ -1,0 +1,201 @@
+/**
+ * tests/lib/orchestration/single-story-close/gate-log.test.js — Story #4736.
+ *
+ * The close path's gate-output sink. The contract under test is the asymmetry
+ * that makes the ~2KB success bound safe to adopt:
+ *
+ *   - a clean run says how much output there was and where it went, and emits
+ *     none of it inline;
+ *   - a red run puts the evidence back in front of the caller;
+ *   - `AGENT_LOG_LEVEL=verbose` restores live streaming;
+ *   - an unwritable artifact degrades to streaming rather than dropping the
+ *     gate output, because losing the size bound beats losing the reason a
+ *     close failed.
+ */
+
+import assert from 'node:assert/strict';
+import nodeFs from 'node:fs';
+import nodeOs from 'node:os';
+import path from 'node:path';
+import { after, before, beforeEach, describe, it } from 'node:test';
+
+import {
+  createGateLogSink,
+  REPLAY_TAIL_LINES,
+} from '../../../../.agents/scripts/lib/orchestration/single-story-close/gate-log.js';
+
+let tmpDir;
+let emitted;
+const logger = { info: (m) => emitted.push(m) };
+
+before(() => {
+  tmpDir = nodeFs.mkdtempSync(path.join(nodeOs.tmpdir(), 'gate-log-'));
+});
+
+after(() => {
+  nodeFs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+beforeEach(() => {
+  emitted = [];
+});
+
+/** A sink rooted in the per-run temp dir, with the logger captured. */
+function sinkAt(name, opts = {}) {
+  return createGateLogSink({
+    storyId: 4736,
+    logDir: path.join(tmpDir, name),
+    logger,
+    level: 'info',
+    ...opts,
+  });
+}
+
+describe('createGateLogSink — success path (AC-3)', () => {
+  it('captures gate output to the artifact and emits nothing inline', () => {
+    const sink = sinkAt('quiet');
+    for (let i = 0; i < 500; i += 1)
+      sink.log(`[test] line ${i} ${'x'.repeat(80)}`);
+
+    assert.deepEqual(emitted, [], 'no gate line may reach the inline sink');
+    assert.equal(sink.lineCount, 500);
+    const written = nodeFs.readFileSync(sink.logPath, 'utf8');
+    assert.ok(
+      written.includes('line 499'),
+      'the artifact must hold the full output, including the last line',
+    );
+    assert.equal(written.split('\n').filter(Boolean).length, 500);
+  });
+
+  it('digests to a single short line naming the artifact', () => {
+    const sink = sinkAt('digest');
+    for (let i = 0; i < 5_000; i += 1) sink.log(`gate output line ${i}`);
+
+    const digest = sink.digest();
+    assert.ok(digest.includes('5000'), 'the digest reports the line count');
+    assert.ok(
+      digest.includes(sink.logPath),
+      'the digest names the artifact path so the caller can open it on demand',
+    );
+    assert.ok(
+      Buffer.byteLength(digest, 'utf8') < 2048,
+      `the digest itself must stay well inside the ~2KB bound (was ${Buffer.byteLength(digest, 'utf8')}B)`,
+    );
+  });
+
+  it('truncates the artifact per run so a re-run never interleaves two runs', () => {
+    const dir = path.join(tmpDir, 'rerun');
+    const first = createGateLogSink({
+      storyId: 4736,
+      logDir: dir,
+      logger,
+      level: 'info',
+    });
+    first.log('FIRST RUN');
+    const second = createGateLogSink({
+      storyId: 4736,
+      logDir: dir,
+      logger,
+      level: 'info',
+    });
+    second.log('SECOND RUN');
+
+    const written = nodeFs.readFileSync(second.logPath, 'utf8');
+    assert.equal(first.logPath, second.logPath, 'both runs key on the storyId');
+    assert.ok(written.includes('SECOND RUN'));
+    assert.ok(
+      !written.includes('FIRST RUN'),
+      'the previous run’s output must not survive into this run’s artifact',
+    );
+  });
+});
+
+describe('createGateLogSink — failure path (AC-4)', () => {
+  it('replays the captured tail inline so the evidence stays in front of the caller', () => {
+    const sink = sinkAt('replay');
+    sink.log('assertion failed: expected 1 to equal 2');
+    sink.log('  at tests/example.test.js:14');
+
+    const replayed = sink.replay();
+    assert.equal(replayed, 2);
+    assert.deepEqual(emitted, [
+      'assertion failed: expected 1 to equal 2',
+      '  at tests/example.test.js:14',
+    ]);
+  });
+
+  it('bounds the replay to the tail and says how much it omitted', () => {
+    const sink = sinkAt('replay-tail');
+    const total = REPLAY_TAIL_LINES + 40;
+    for (let i = 0; i < total; i += 1) sink.log(`line ${i}`);
+
+    assert.equal(sink.replay(), REPLAY_TAIL_LINES);
+    assert.equal(emitted.length, REPLAY_TAIL_LINES + 1, 'tail plus one notice');
+    assert.match(emitted[0], /40 earlier line\(s\) omitted/);
+    assert.ok(
+      emitted[0].includes(sink.logPath),
+      'the omission notice must point at the artifact holding the rest',
+    );
+    assert.equal(emitted.at(-1), `line ${total - 1}`);
+    assert.ok(
+      nodeFs.readFileSync(sink.logPath, 'utf8').includes('line 0'),
+      'the artifact still holds every line, including those not replayed',
+    );
+  });
+});
+
+describe('createGateLogSink — streaming and degradation', () => {
+  it('AGENT_LOG_LEVEL=verbose streams inline AND still writes the artifact', () => {
+    const sink = sinkAt('verbose', { level: 'verbose' });
+    sink.log('gate line');
+
+    assert.deepEqual(emitted, ['gate line']);
+    assert.ok(nodeFs.readFileSync(sink.logPath, 'utf8').includes('gate line'));
+    assert.equal(
+      sink.replay(),
+      0,
+      'replay must not double-print what streaming already emitted',
+    );
+  });
+
+  it('degrades to inline streaming when the artifact cannot be opened', () => {
+    const sink = createGateLogSink({
+      storyId: 4736,
+      logDir: path.join(tmpDir, 'unwritable'),
+      logger,
+      level: 'info',
+      fs: {
+        mkdirSync() {
+          throw new Error('EACCES: permission denied');
+        },
+      },
+    });
+    sink.log('gate line that must not be lost');
+
+    assert.equal(sink.logPath, null);
+    assert.deepEqual(emitted, ['gate line that must not be lost']);
+    assert.match(sink.digest(), /no artifact could be written/);
+  });
+
+  it('survives a mid-run write failure without aborting the close', () => {
+    let calls = 0;
+    const sink = createGateLogSink({
+      storyId: 4736,
+      logDir: path.join(tmpDir, 'flaky'),
+      logger,
+      level: 'info',
+      fs: {
+        mkdirSync() {},
+        openSync: () => 7,
+        writeSync() {
+          calls += 1;
+          throw new Error('ENOSPC: no space left on device');
+        },
+      },
+    });
+
+    assert.doesNotThrow(() => sink.log('gate line'));
+    assert.equal(calls, 1);
+    assert.equal(sink.lineCount, 1, 'the line is still counted and replayable');
+  });
+});

--- a/tests/scripts/resolve-stories.test.js
+++ b/tests/scripts/resolve-stories.test.js
@@ -293,11 +293,20 @@ describe('storiesToDag — body and native edges union into one graph', () => {
 });
 
 describe('buildStoriesEnvelope — per-Story dispatchMode (Story #4722)', () => {
+  // Story #4736 put a run-topology rule ahead of the shape read: a run
+  // resolving ONE Story is inline whatever its shape. Every assertion about
+  // the shape axis therefore needs a multi-Story set to reach that axis at
+  // all — this filler Story is the second element, never the subject.
+  const filler = () =>
+    toStoryRecord(
+      issue({ number: 99, body: storyBody({ changes: ['src/filler.js'] }) }),
+    );
+
   it('AC-5: derives inline from the BODY shape with the route::lite label absent', () => {
     // One refactor + one acceptance criterion, no sensitive path: a
     // lite-shaped body. No label anywhere — the shape is the control signal.
     const env = buildStoriesEnvelope({
-      stories: [toStoryRecord(issue({ number: 1 }))],
+      stories: [toStoryRecord(issue({ number: 1 })), filler()],
       injectedRules: RULES,
     });
     assert.equal(env.stories[0].dispatchMode, 'inline');
@@ -316,6 +325,7 @@ describe('buildStoriesEnvelope — per-Story dispatchMode (Story #4722)', () => 
             labels: [{ name: 'type::story' }, { name: 'route::lite' }],
           }),
         ),
+        filler(),
       ],
       injectedRules: RULES,
     });
@@ -332,6 +342,7 @@ describe('buildStoriesEnvelope — per-Story dispatchMode (Story #4722)', () => 
             labels: [{ name: 'type::story' }, { name: 'route::lite' }],
           }),
         ),
+        filler(),
       ],
       injectedRules: RULES,
     });
@@ -340,8 +351,64 @@ describe('buildStoriesEnvelope — per-Story dispatchMode (Story #4722)', () => 
 
   it('planning.complexityGate.enabled=false forces subagent dispatch', () => {
     const env = buildStoriesEnvelope({
-      stories: [toStoryRecord(issue({ number: 1 }))],
+      stories: [toStoryRecord(issue({ number: 1 })), filler()],
       config: { planning: { complexityGate: { enabled: false } } },
+      injectedRules: RULES,
+    });
+    assert.equal(env.stories[0].dispatchMode, 'subagent');
+  });
+});
+
+/**
+ * Story #4736 — the resolver is where `/deliver` reads the dispatch decision,
+ * so this is where the run-topology rule has to be true end to end: a
+ * one-Story `--ids` list yields `inline`, and adding a sibling puts the shape
+ * axis back in charge.
+ */
+describe('buildStoriesEnvelope — single-Story runs dispatch inline (Story #4736)', () => {
+  const wideBody = storyBody({
+    changes: ['src/a.js', 'src/b.js', 'src/c.js', 'src/d.js'],
+  });
+
+  it('AC-1: a one-Story run is inline even for a full-shaped Story', () => {
+    const env = buildStoriesEnvelope({
+      stories: [toStoryRecord(issue({ number: 1, body: wideBody }))],
+      injectedRules: RULES,
+    });
+    assert.equal(env.stories.length, 1);
+    assert.equal(env.stories[0].dispatchMode, 'inline');
+  });
+
+  it('AC-1: the same Story in a two-Story run goes back to sub-agent dispatch', () => {
+    const env = buildStoriesEnvelope({
+      stories: [
+        toStoryRecord(issue({ number: 1, body: wideBody })),
+        toStoryRecord(issue({ number: 2, body: wideBody })),
+      ],
+      injectedRules: RULES,
+    });
+    assert.deepEqual(
+      env.stories.map((s) => s.dispatchMode),
+      ['subagent', 'subagent'],
+      'concurrent siblings share a checkout — that is what the sub-agent isolates',
+    );
+  });
+
+  it('counts the resolved set, not the undelivered remainder', () => {
+    // A sibling that already landed still counts: the mode a caller reads for
+    // a given `--ids` list must not flip mid-run as siblings finish.
+    const env = buildStoriesEnvelope({
+      stories: [
+        toStoryRecord(issue({ number: 1, body: wideBody })),
+        toStoryRecord(
+          issue({
+            number: 2,
+            body: wideBody,
+            state: 'closed',
+            labels: [{ name: 'type::story' }, { name: 'agent::done' }],
+          }),
+        ),
+      ],
       injectedRules: RULES,
     });
     assert.equal(env.stories[0].dispatchMode, 'subagent');

--- a/tests/workflows/deliver-digest.test.js
+++ b/tests/workflows/deliver-digest.test.js
@@ -1,0 +1,98 @@
+/**
+ * tests/workflows/deliver-digest.test.js — Story #4736, AC-5.
+ *
+ * The deliver path used to re-read the same helper/schema set every session —
+ * nine separate reads on one measured delivery, each one growing the resident
+ * context every later turn re-pays. `helpers/deliver-digest.md` is the single
+ * bundled read that replaces them.
+ *
+ * A digest only earns its existence if two things stay true, and neither is
+ * self-enforcing:
+ *
+ *   1. It **covers** what the engine always needs. A digest missing the
+ *      terminal statuses or the acceptance gate sends the reader back to the
+ *      files it was meant to replace — worse than no digest, because it is
+ *      paid for AND bypassed.
+ *   2. It stays **bounded**. The failure mode for a bundle is accretion: it
+ *      absorbs situational material until it is as expensive as the reads it
+ *      replaced. The ceiling makes that regression a red test rather than a
+ *      slow drift.
+ *
+ * And the spine files must actually point at it, or nothing routes through it.
+ */
+
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { describe, it } from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+const WORKFLOWS = path.join(REPO_ROOT, '.agents', 'workflows');
+const DIGEST = path.join(WORKFLOWS, 'helpers', 'deliver-digest.md');
+
+/**
+ * Ceiling for the bundle. Comfortably above what the always-needed material
+ * costs today and far below the ~5× that re-reading the individual files did.
+ */
+const DIGEST_BUDGET_BYTES = 8 * 1024;
+
+const read = (p) => readFileSync(p, 'utf8');
+
+describe('helpers/deliver-digest.md — the one bundled deliver read (AC-5)', () => {
+  it('covers every always-needed surface the engine would otherwise re-read', () => {
+    const digest = read(DIGEST);
+    /** [what the reader came for, a token that proves it is actually here] */
+    const coverage = [
+      ['the dispatch decision', 'dispatchMode'],
+      ['the single-Story inline rule', 'one-Story run'],
+      ['the branch/merge invariants', 'story-<id>'],
+      ['the change-set-once discipline', 'computeChangeSet'],
+      ['the ceremony resolution', 'resolveCeremonyForRisk'],
+      ['the acceptance gate invocation', 'acceptance-eval.js'],
+      ['the terminal envelope marker', '--- STORY DELIVER TERMINAL ---'],
+      ['the state-transition command', 'update-ticket-state.js'],
+    ];
+    for (const [surface, token] of coverage) {
+      assert.ok(
+        digest.includes(token),
+        `the digest no longer covers ${surface} (missing "${token}") — a reader hitting that gap falls back to the per-file reads the digest exists to replace`,
+      );
+    }
+    for (const status of ['landed', 'pending', 'blocked', 'failed']) {
+      assert.ok(
+        digest.includes(`\`${status}\``),
+        `the digest omits the "${status}" terminal status, so a caller cannot branch on the envelope without opening the schema`,
+      );
+    }
+  });
+
+  it('stays inside its byte budget', () => {
+    const bytes = Buffer.byteLength(read(DIGEST), 'utf8');
+    assert.ok(
+      bytes <= DIGEST_BUDGET_BYTES,
+      `deliver-digest.md is ${bytes} bytes, over the ${DIGEST_BUDGET_BYTES}-byte budget — situational material belongs in deliver-story-reference.md / deliver-reference.md, not the always-read bundle`,
+    );
+  });
+
+  it('is reachable from both deliver spines', () => {
+    for (const spine of [
+      path.join(WORKFLOWS, 'deliver.md'),
+      path.join(WORKFLOWS, 'helpers', 'deliver-story.md'),
+    ]) {
+      assert.ok(
+        read(spine).includes('deliver-digest.md'),
+        `${path.relative(REPO_ROOT, spine)} does not link the digest — an unreferenced bundle is paid for by nobody and read by nobody`,
+      );
+    }
+  });
+
+  it('the spine cites the digest instead of restating the terminal table', () => {
+    const spine = read(path.join(WORKFLOWS, 'helpers', 'deliver-story.md'));
+    assert.ok(
+      spine.includes('digest § 5'),
+      'deliver-story.md must route Step 3 / Step 7 at the digest, not carry its own copy of the status table',
+    );
+  });
+});


### PR DESCRIPTION
Closes #4736

_Auto-opened by `/deliver`._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default `/deliver` execution for one-Story runs and close-validation logging behavior agents rely on; gates and landing semantics are unchanged but dispatch and observability paths shift.
> 
> **Overview**
> **Deliver-path cost reduction (#4736)** in three areas: dispatch topology, close stdout, and agent documentation.
> 
> **Single-Story runs always dispatch inline.** `resolveStoryDispatchMode` now checks `storyCount === 1` *before* body-shape routing: one resolved Story runs `deliver-story` in the parent session (no `story-worker` spawn), including full-shaped or sensitive footprints—sub-agent isolation only matters when concurrent siblings share a checkout. `resolve-stories.js` passes `storyCount: sorted.length` (resolved set size, not undelivered remainder). Shape-derived `route` is still reported via `routeForReporting` for ceremony; `planning.complexityGate.enabled=false` does not override the topology rule.
> 
> **Close-validation output stays under the ~2KB success budget.** New `gate-log.js` captures all gate lines to `temp/orchestration/close-gates-<storyId>.log`, wires one sink through `close-validation.js`, prints a one-line digest on pass, and **replays the last 200 lines inline on failure**. `AGENT_LOG_LEVEL=verbose` restores live streaming; unwritable artifacts degrade to streaming instead of dropping output. Orchestration error-handling docs describe streamed child output as counting toward the budget.
> 
> **Bundled deliver read.** New `helpers/deliver-digest.md` consolidates dispatch rules, invariants, change-set/ceremony, acceptance-eval, and terminal envelope; `deliver.md` and `deliver-story.md` link it and defer duplicated tables to "digest § N". Reference docs gain single-Story inline and operator-merge sections.
> 
> Tests cover topology dispatch, gate-log behavior, close-validation stdout bounds, resolver envelopes, and digest coverage/budget/linkage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3902c57c73b06e046bd6c4c5e2d09751049ae6b5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->