### PR TITLE
test(workflows): decouple doc-prose assertions from markdown line wrapping

### DIFF
--- a/tests/deliver-epic-single.test.js
+++ b/tests/deliver-epic-single.test.js
@@ -16,6 +16,8 @@ import path from 'node:path';
 import { describe, it } from 'node:test';
 import { fileURLToPath } from 'node:url';
 
+import { assertDocMentions, assertDocOmits } from './helpers/doc-assert.js';
+
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = path.resolve(__dirname, '..');
 const DELIVER_MD = path.join(REPO_ROOT, '.agents', 'workflows', 'deliver.md');
@@ -40,16 +42,20 @@ describe('unified /deliver router', () => {
 
   it('hard-errors on Epic-attached or non-Story tickets', () => {
     const md = readFileSync(DELIVER_MD, 'utf8');
-    assert.match(md, /not `type::story`/);
-    assert.match(md, /Epic: #N/);
-    assert.match(md, /hard error/);
+    assertDocMentions(md, /not `type::story`/, 'must name the refused type');
+    assertDocMentions(md, /Epic: #N/, 'must name the v1 footer it refuses');
+    assertDocMentions(md, /hard error/, 'refusal must be a hard error');
   });
 
   it('the Story helper documents the direct PR-to-main branch model', () => {
     const md = readFileSync(DELIVER_STORY_MD, 'utf8');
     assert.match(md, /type::story/);
-    assert.match(md, /PR against main|PR to `main`|Merge target \| `main`/);
-    assert.match(md, /no `epic\/<id>`/i);
+    assertDocMentions(
+      md,
+      /PR against main|PR to `main`|Merge target \| `main`/,
+      'the helper must document the direct PR-to-main merge target',
+    );
+    assertDocMentions(md, /no `epic\/<id>`/i, 'no Epic integration branch');
   });
 
   it('deliver-story stays on the single-story init/close path (no epic/ wave merge)', () => {
@@ -61,8 +67,12 @@ describe('unified /deliver router', () => {
     // `single-story-close.js` (the live v2 path until Stage 5 merges pairs).
     assert.doesNotMatch(md, /(?<!single-)story-init\.js/);
     assert.doesNotMatch(md, /(?<!single-)story-close\.js/);
-    assert.match(md, /no `--no-ff` wave merge/);
-    assert.doesNotMatch(md, /helpers\/deliver-epic|git merge --no-ff/);
+    assertDocMentions(md, /no `--no-ff` wave merge/, 'no wave merge in v2');
+    assertDocOmits(
+      md,
+      /helpers\/deliver-epic|git merge --no-ff/,
+      'the Epic-era helper and wave merge must not reappear',
+    );
   });
 
   it('sequences N>1 via resolve-stories + stories-wave-tick + the epilogue', () => {
@@ -70,9 +80,10 @@ describe('unified /deliver router', () => {
     assert.match(md, /resolve-stories\.js/);
     assert.match(md, /stories-wave-tick\.js/);
     assert.match(md, /plan-run-epilogue\.js/);
-    assert.doesNotMatch(
+    assertDocOmits(
       md,
       /resolveEpicDeliveryRoute|wave-tick\.js --check-idle/,
+      'the Epic-era route resolver and idle check are retired',
     );
   });
 
@@ -98,9 +109,10 @@ describe('unified /deliver router', () => {
     );
     // The opt-in contract must be spelled out so the flag is threaded through
     // only when the operator explicitly passed one.
-    assert.match(
+    assertDocMentions(
       md,
       /Do not add `--concurrency` unless the operator explicitly asked/,
+      'the opt-in contract for --concurrency must be spelled out',
     );
     assert.match(md, /\.agentrc\.local\.json/);
   });
@@ -114,7 +126,7 @@ describe('/deliver takes only Story ids (Story #4540)', () => {
       /> \*\*Retired \(Story #4540\)\.\*\*[\s\S]*?\n\n/,
       '',
     );
-    assert.doesNotMatch(
+    assertDocOmits(
       withoutTombstone,
       /`--run <planRunId>`|\| `--run`|--dep <from>/,
       'the ids-only entry point must not advertise --run or --dep',
@@ -128,12 +140,16 @@ describe('/deliver takes only Story ids (Story #4540)', () => {
 
   it('never instructs the host to read depends_on from bodies by hand', () => {
     const md = readFileSync(DELIVER_MD, 'utf8');
-    assert.doesNotMatch(
+    assertDocOmits(
       md,
       /read `depends_on` \/ `blocked by` from each body/,
       'the graph is resolved from live state, not transcribed by the host',
     );
-    assert.match(md, /discovered, not declared|resolved.*from live state/i);
+    assertDocMentions(
+      md,
+      /discovered, not declared|resolved.*from live state/i,
+      'the doc must say the graph is discovered from live state',
+    );
   });
 
   it('drives the beat from live state rather than hand-maintained flags (Story #4594)', () => {
@@ -149,12 +165,12 @@ describe('/deliver takes only Story ids (Story #4540)', () => {
     // tests/wave-runner/live-probe.test.js) instead of by operator prose.
     const md = readFileSync(DELIVER_MD, 'utf8');
     assert.match(md, /--stories <id,id,\.\.\.> --probe-live/);
-    assert.doesNotMatch(
+    assertDocOmits(
       md,
       /Seed the first beat/,
       'the seed footgun is structurally impossible — it must not be re-documented',
     );
-    assert.doesNotMatch(
+    assertDocOmits(
       md,
       /--done <csv> --in-flight <n>/,
       'the loop must not ask the host to maintain done / in-flight by hand',

--- a/tests/deliver-integration-gate.test.js
+++ b/tests/deliver-integration-gate.test.js
@@ -13,11 +13,12 @@
  * track the mechanism that actually runs.
  */
 
-import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 import path from 'node:path';
 import { describe, it } from 'node:test';
 import { fileURLToPath } from 'node:url';
+
+import { assertDocMentions, assertDocOmits } from './helpers/doc-assert.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -41,12 +42,12 @@ const configDoc = readFileSync(CONFIG_DOC_PATH, 'utf8');
 
 describe('/deliver navigability journey-suite contract (Epic #4131 F1/F4)', () => {
   it('keeps navigability journey-suite config tied to the per-Story ceremony', () => {
-    assert.match(
+    assertDocMentions(
       configDoc,
-      /quality\.navigability[\s\S]*per-Story ceremony/,
+      /quality\.navigability.*per-Story ceremony/,
       'configuration docs must tie navigability to the per-Story ceremony',
     );
-    assert.match(
+    assertDocMentions(
       configDoc,
       /journey suite|journeySuite/,
       'configuration docs must still name the journey suite',
@@ -54,12 +55,12 @@ describe('/deliver navigability journey-suite contract (Epic #4131 F1/F4)', () =
   });
 
   it('documents the per-Story derived-level ceremony in /deliver', () => {
-    assert.match(
+    assertDocMentions(
       source,
-      /derived level[\s\S]*review depth/i,
+      /derived level.*review depth/i,
       '/deliver must name the derived-level ceremony it actually runs',
     );
-    assert.match(
+    assertDocMentions(
       source,
       /ceremony-routing\.js/,
       '/deliver must name the routing mechanism for the ceremony',
@@ -70,7 +71,15 @@ describe('/deliver navigability journey-suite contract (Epic #4131 F1/F4)', () =
     // Story #4542: three shipped docs claimed `resolveAuditLenses` ran inside
     // close while it had zero callers. Deleting the module without this guard
     // would let the claim creep back.
-    assert.doesNotMatch(source, /resolveAuditLenses|audit-lens-routing/);
-    assert.doesNotMatch(source, /risk-routed/i);
+    assertDocOmits(
+      source,
+      /resolveAuditLenses|audit-lens-routing/,
+      '/deliver must not advertise the deleted risk-routed audit-lens router',
+    );
+    assertDocOmits(
+      source,
+      /risk-routed/i,
+      'ceremony is routed off the derived change level, never a risk verdict',
+    );
   });
 });

--- a/tests/doc-assert-helper.test.js
+++ b/tests/doc-assert-helper.test.js
@@ -1,0 +1,117 @@
+/**
+ * tests/doc-assert-helper.test.js — the line-wrap-independent doc assertions.
+ *
+ * The helper exists to remove a defect class from the workflow-doc suite, so
+ * the tests that matter are the two the old `assert.match` got wrong:
+ *
+ *   1. a **positive** claim about prose fails when the phrase re-wraps, even
+ *      though the document still says it — a false red on a correct edit;
+ *   2. a **negative** guard against a forbidden phrase passes when the phrase
+ *      re-wraps — a false green, which is the dangerous direction.
+ *
+ * Both are pinned below against `assert.match` / `assert.doesNotMatch`
+ * behaviour, so this file also documents *why* the plain assertions were
+ * replaced rather than merely that they were.
+ */
+
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import {
+  assertDocMentions,
+  assertDocOmits,
+  normalizeProse,
+} from './helpers/doc-assert.js';
+
+/** A doc hard-wrapped exactly where the phrase under test straddles a line. */
+const WRAPPED = [
+  'Ceremony depth (profiles + derived level via `ceremony-routing.js`, review',
+  'depth reading the same level) and the mechanism table follow.',
+  '',
+  'Never reintroduce the `git merge --no-ff` wave merge: dependent Stories land',
+  'sequentially instead.',
+].join('\n');
+
+describe('normalizeProse', () => {
+  it('collapses every whitespace run — newlines included — to one space', () => {
+    assert.equal(
+      normalizeProse('a\n  b\t\tc\r\n\r\nd'),
+      'a b c d',
+      'a pattern written as one sentence must see one sentence',
+    );
+  });
+
+  it('is null-safe and trims the ends', () => {
+    assert.equal(normalizeProse('  padded\n'), 'padded');
+    assert.equal(normalizeProse(undefined), '');
+    assert.equal(normalizeProse(null), '');
+  });
+});
+
+describe('assertDocMentions — the false red it removes', () => {
+  it('matches a phrase that markdown wrapped across two lines', () => {
+    // The exact failure this helper was written for: the doc says "review
+    // depth", the wrap puts a newline in the middle, and the literal space in
+    // the pattern stops matching.
+    assert.throws(
+      () => assert.match(WRAPPED, /derived level.*review depth/i),
+      /AssertionError/,
+      'baseline: plain assert.match is the thing that goes red here',
+    );
+    assert.doesNotThrow(() =>
+      assertDocMentions(
+        WRAPPED,
+        /derived level.*review depth/i,
+        'the doc must document the derived-level ceremony',
+      ),
+    );
+  });
+
+  it('still fails when the document genuinely does not say it', () => {
+    assert.throws(
+      () =>
+        assertDocMentions(
+          WRAPPED,
+          /planner-authored risk verdict/i,
+          'the doc must name the risk verdict',
+        ),
+      (err) =>
+        err.message.includes('the doc must name the risk verdict') &&
+        err.message.includes('expected to find') &&
+        // The whole document must NOT be dumped into the failure output.
+        !err.message.includes('mechanism table'),
+      'a real content gap must still fail, with a short message',
+    );
+  });
+});
+
+describe('assertDocOmits — the false green it removes', () => {
+  it('catches a forbidden phrase that hid by straddling a line break', () => {
+    const straddled = 'Dependent Stories use a git merge\n--no-ff wave merge.';
+    assert.doesNotThrow(
+      () => assert.doesNotMatch(straddled, /git merge --no-ff/),
+      'baseline: plain assert.doesNotMatch passes — the guard silently misses',
+    );
+    assert.throws(
+      () =>
+        assertDocOmits(
+          straddled,
+          /git merge --no-ff/,
+          'the v2 engine has no --no-ff wave merge',
+        ),
+      /has no --no-ff wave merge/,
+      'the normalized guard must catch what the wrap hid',
+    );
+  });
+
+  it('passes when the phrase is genuinely absent, and quotes the hit when not', () => {
+    assert.doesNotThrow(() =>
+      assertDocOmits(WRAPPED, /resolveAuditLenses/, 'router was deleted'),
+    );
+    assert.throws(
+      () => assertDocOmits(WRAPPED, /wave merge/, 'no wave merge'),
+      /matched: "wave merge"/,
+      'a negative failure must show what it found',
+    );
+  });
+});

--- a/tests/helpers/doc-assert.js
+++ b/tests/helpers/doc-assert.js
@@ -1,0 +1,124 @@
+/**
+ * tests/helpers/doc-assert.js — line-wrap-independent assertions over
+ * markdown prose.
+ *
+ * ## Why
+ *
+ * The workflow-doc tests assert that a shipped `.md` says a thing — for
+ * example that `deliver.md` matches "derived level", any run of characters,
+ * then "review depth".
+ *
+ * That reads as a claim about **content**, but it is silently a claim about
+ * **layout**: the docs are hard-wrapped at ~80 columns, so the moment a
+ * paragraph re-flows and puts "review" at the end of one line and "depth" at
+ * the start of the next, the literal space in the pattern stops matching and a
+ * correct edit goes red. The remedy the failure suggests — move a word to the
+ * previous line — protects nothing and teaches nothing.
+ *
+ * The workaround had already leaked into the suite by hand, inconsistently:
+ * patterns that spell the gap as an explicit whitespace class ("never the
+ * authoring", `\s*\n?\s*`, "transcript") instead of a plain space. Each of
+ * those is one author remembering the trap; every plain-spaced pattern next to
+ * them is one who did not, and is waiting to fire on the next doc trim.
+ *
+ * Negative assertions carry the same bug pointing the other way, which is
+ * worse: `assert.doesNotMatch(md, /git merge --no-ff/)` is a guard against a
+ * forbidden phrase creeping back, and it **misses** an occurrence that happens
+ * to straddle a wrap. Normalising makes those guards strictly stronger.
+ *
+ * ## What this does
+ *
+ * Match against a copy of the source whose whitespace runs are collapsed to
+ * single spaces, so a pattern can be written the way the sentence reads. And
+ * fail with the pattern and a short message rather than `assert.match`'s
+ * whole-file dump — an 8KB blob in the terminal buries the one line that
+ * matters.
+ *
+ * ## When NOT to use it
+ *
+ * Whenever the whitespace **is** the assertion: fenced code blocks, indented
+ * command examples, table column layout, or a heading that must sit at the
+ * start of a line. Normalising flattens exactly the structure those tests
+ * exist to pin. Keep plain `assert.match` there — this helper is for prose.
+ */
+
+import { AssertionError } from 'node:assert';
+import { readFileSync } from 'node:fs';
+
+/**
+ * Collapse every whitespace run (including newlines) to a single space and
+ * trim the ends, so a pattern written as one sentence matches prose however
+ * the markdown happens to be wrapped.
+ *
+ * @param {string} source Raw document text.
+ * @returns {string}
+ */
+export function normalizeProse(source) {
+  return String(source ?? '')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+/** Read a doc from disk. Convenience so a call site needs one import. */
+export function readDoc(filePath) {
+  return readFileSync(filePath, 'utf8');
+}
+
+/**
+ * Short, quotable context for a failure message — never the whole document.
+ *
+ * @param {string} normalized
+ * @param {RegExp} pattern
+ * @returns {string}
+ */
+function contextFor(normalized, pattern) {
+  // For a negative assertion the match is what the caller needs to see; for a
+  // positive one there is nothing to show, so report the size instead so a
+  // truncated/empty read is distinguishable from a genuine content gap.
+  const hit = normalized.match(pattern);
+  return hit
+    ? `matched: "${hit[0].slice(0, 160)}"`
+    : `(searched ${normalized.length} chars of normalized prose)`;
+}
+
+/**
+ * Assert that `source` contains `pattern`, ignoring how it is line-wrapped.
+ *
+ * Signature-compatible with `assert.match`, so migrating a call site is a
+ * rename.
+ *
+ * @param {string} source Raw document text.
+ * @param {RegExp} pattern Written as the sentence reads — plain spaces.
+ * @param {string} [message] What the document is supposed to be saying, and
+ *   why it matters. Shown verbatim on failure.
+ */
+export function assertDocMentions(source, pattern, message) {
+  const normalized = normalizeProse(source);
+  if (pattern.test(normalized)) return;
+  throw new AssertionError({
+    message: `${message ?? 'document is missing required content'}\n  expected to find: ${pattern}\n  ${contextFor(normalized, pattern)}`,
+    operator: 'assertDocMentions',
+    stackStartFn: assertDocMentions,
+  });
+}
+
+/**
+ * Assert that `source` does NOT contain `pattern`, ignoring line wrapping —
+ * so a forbidden phrase cannot hide by straddling a line break.
+ *
+ * Signature-compatible with `assert.doesNotMatch`, so migrating a call site is
+ * a rename.
+ *
+ * @param {string} source Raw document text.
+ * @param {RegExp} pattern The phrase that must not appear.
+ * @param {string} [message] Why the phrase is forbidden.
+ */
+export function assertDocOmits(source, pattern, message) {
+  const normalized = normalizeProse(source);
+  if (!pattern.test(normalized)) return;
+  throw new AssertionError({
+    message: `${message ?? 'document contains forbidden content'}\n  expected NOT to find: ${pattern}\n  ${contextFor(normalized, pattern)}`,
+    operator: 'assertDocOmits',
+    stackStartFn: assertDocOmits,
+  });
+}

--- a/tests/plan-critics-workflow.test.js
+++ b/tests/plan-critics-workflow.test.js
@@ -27,6 +27,7 @@ import {
   loadCriticArtifacts,
   PLAN_CRITICS_CLI,
 } from '../.agents/scripts/plan-critics.js';
+import { assertDocMentions, assertDocOmits } from './helpers/doc-assert.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -68,8 +69,16 @@ function slicingTableFor(stories) {
 
 describe('/plan critic workflow — retired helper surface stays gone', () => {
   it('uses plan.md as the sole planning workflow source', () => {
-    assert.match(planSource, /Single planning path/i);
-    assert.match(planSource, /no\s*\n?Epic\/Story router/i);
+    assertDocMentions(
+      planSource,
+      /Single planning path/i,
+      'plan.md is the sole planning workflow',
+    );
+    assertDocMentions(
+      planSource,
+      /no Epic\/Story router/i,
+      'the Epic/Story planning fork is retired',
+    );
   });
 
   it('does not reference deleted planning-fork helper files', () => {
@@ -113,9 +122,17 @@ describe('/plan critic workflow — the live pre-persist critic step (#4592)', (
     const critics = section('### 2\\.5 Critics');
     assert.match(critics, /dispatch/);
     assert.match(critics, /maker-blind/i);
-    assert.match(critics, /never the authoring\s*\n?\s*transcript/i);
+    assertDocMentions(
+      critics,
+      /never the authoring transcript/i,
+      'the critic is maker-blind — it never sees the authoring transcript',
+    );
     // Advisory, not a mechanical gate: the CLI exits 0 on any verdict.
-    assert.match(critics, /exits 0 on \*\*any\*\* verdict/i);
+    assertDocMentions(
+      critics,
+      /exits 0 on \*\*any\*\* verdict/i,
+      'the critic CLI exits 0 on any verdict',
+    );
   });
 
   it('names the exit-1 usage/IO case and forbids proceeding to Persist on it', () => {
@@ -124,12 +141,26 @@ describe('/plan critic workflow — the live pre-persist critic step (#4592)', (
     // exits 0" (Story #4602) read as "advisory, proceed", so a mistyped
     // --stories path silently persisted with both critics skipped.
     const critics = section('### 2\\.5 Critics');
-    // Whitespace-tolerant: prose reflows across line breaks, and an assertion
-    // that a newline can defeat is a false green.
-    assert.match(critics, /exits\s+\*\*1\*\*/i);
-    assert.match(critics, /usage\/IO\s+error/i);
-    assert.doesNotMatch(critics, /always\s+exits\s+0/i);
-    assert.match(critics, /\*\*do\s+not\s+proceed\s+to\s+Persist\*\*/i);
+    assertDocMentions(
+      critics,
+      /exits \*\*1\*\*/i,
+      'a usage/IO error must exit 1',
+    );
+    assertDocMentions(
+      critics,
+      /usage\/IO error/i,
+      'the exit-1 case must be named as a usage/IO error',
+    );
+    assertDocOmits(
+      critics,
+      /always exits 0/i,
+      'the CLI does not ALWAYS exit 0 — a usage/IO error exits 1',
+    );
+    assertDocMentions(
+      critics,
+      /\*\*do not proceed to Persist\*\*/i,
+      'a blocking verdict must stop the run before Persist',
+    );
   });
 
   it('names the external-dependency pre-mortem trigger (#4700)', () => {
@@ -144,7 +175,11 @@ describe('/plan critic workflow — the live pre-persist critic step (#4592)', (
     const critics = section('### 2\\.5 Critics');
     assert.match(critics, /textHygiene/);
     assert.match(critics, /textHygiene\.findings\[\]/);
-    assert.match(critics, /re-author round/i);
+    assertDocMentions(
+      critics,
+      /re-author round/i,
+      'textHygiene findings drive a re-author round',
+    );
     assert.match(critics, /advisory-only/i);
   });
 });
@@ -153,21 +188,45 @@ describe('story-author prompt — codified text-hygiene conventions (#4599)', ()
   const prompt = renderDecomposerSystemPrompt();
 
   it('mandates the "Current state (verified <date>)" preamble for observed-behavior claims', () => {
-    assert.match(prompt, /Current state \(verified <date>\)/);
+    assertDocMentions(
+      prompt,
+      /Current state \(verified <date>\)/,
+      'the prompt must carry the verified-state template',
+    );
   });
 
   it('mandates the intent-then-proxy acceptance shape', () => {
-    assert.match(prompt, /state the intent clause before the proxy check/i);
+    assertDocMentions(
+      prompt,
+      /state the intent clause before the proxy check/i,
+      'acceptance criteria lead with intent, not the proxy',
+    );
   });
 
   it('mandates one-line Slicing checkpoints with detail in Spec', () => {
-    assert.match(prompt, /Slicing checkpoints are one line each/i);
-    assert.match(prompt, /detail lives in `## Spec`/i);
+    assertDocMentions(
+      prompt,
+      /Slicing checkpoints are one line each/i,
+      'Slicing rows stay one line each',
+    );
+    assertDocMentions(
+      prompt,
+      /detail lives in `## Spec`/i,
+      'detail belongs in the folded Spec, not the Slicing rows',
+    );
   });
 
   it('mandates decisions-not-questions bodies with declarative Key Assumptions', () => {
-    assert.match(prompt, /record decisions, never questions to the operator/i);
-    assert.match(prompt, /declarative Key Assumption/i);
+    assertDocMentions(
+      prompt,
+      /record decisions, never questions to the operator/i,
+      'assumptions record decisions, not open questions',
+    );
+    assertDocMentions(
+      prompt,
+      /declarative Key Assumption/i,
+      'Key Assumptions are declarative',
+    );
   });
 });
 
@@ -193,7 +252,11 @@ describe('/plan critic workflow — persist no longer evaluates critics', () => 
     const persist = section('### 3\\. Persist');
     assert.match(persist, /\*\*Gate #2\*\*/);
     assert.match(persist, /`--force-review`/);
-    assert.match(persist, /before persist/i);
+    assertDocMentions(
+      persist,
+      /before persist/i,
+      'Gate #2 runs before persist',
+    );
     assert.match(persist, /node \.agents\/scripts\/plan-persist\.js/);
   });
 });

--- a/tests/plan-yes-flag-workflow.test.js
+++ b/tests/plan-yes-flag-workflow.test.js
@@ -19,6 +19,7 @@ import { readFileSync } from 'node:fs';
 import path from 'node:path';
 import { describe, it } from 'node:test';
 import { fileURLToPath } from 'node:url';
+import { assertDocMentions, assertDocOmits } from './helpers/doc-assert.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -49,17 +50,17 @@ describe('/plan --yes headless flag — single plan.md path', () => {
   });
 
   it('states that /plan is a single path and no longer routes by scope verdict', () => {
-    assert.match(
+    assertDocMentions(
       planSource,
       /Single planning path/i,
       'plan.md must declare a single planning path',
     );
-    assert.match(
+    assertDocMentions(
       planSource,
-      /there is no\s*\n?Epic\/Story router/i,
+      /there is no Epic\/Story router/i,
       'plan.md must reject the retired Epic/Story router',
     );
-    assert.match(
+    assertDocMentions(
       planSource,
       /no scope-triage `epic\|story` verdict/i,
       'plan.md must reject scope-triage routing verdicts',
@@ -67,9 +68,9 @@ describe('/plan --yes headless flag — single plan.md path', () => {
   });
 
   it('defines the three-step Interrogate -> Author -> Persist ceremony', () => {
-    assert.match(planSource, /### 1\. Interrogate/);
-    assert.match(planSource, /### 2\. Author/);
-    assert.match(planSource, /### 3\. Persist/);
+    assertDocMentions(planSource, /### 1\. Interrogate/);
+    assertDocMentions(planSource, /### 2\. Author/);
+    assertDocMentions(planSource, /### 3\. Persist/);
   });
 });
 
@@ -121,26 +122,26 @@ describe('/plan --yes headless flag — gate #2', () => {
     // Story #4542: gate #2 is raised solely by --force-review — the
     // risk-derived routing that used to raise it is gone.
     assert.ok(persist, 'plan.md must carry the persist step');
-    assert.match(
+    assertDocMentions(
       persist,
       /\*\*Gate #2\*\*/,
       'gate #2 must anchor the persist step',
     );
-    assert.doesNotMatch(persist, /risk routing/i, 'gate #2 is not risk-routed');
-    assert.match(
+    assertDocOmits(persist, /risk routing/i, 'gate #2 is not risk-routed');
+    assertDocMentions(
       persist,
       /`--force-review`/,
       'gate #2 must be raised by --force-review',
     );
-    assert.match(
+    assertDocMentions(
       persist,
-      /before\s*\n?persist/i,
+      /before persist/i,
       'gate #2 must happen before persist',
     );
   });
 
   it('auto-proceeds gate #2 under --yes', () => {
-    assert.match(
+    assertDocMentions(
       persist,
       /Under `--yes`, auto-proceed/i,
       'gate #2 must auto-proceed under --yes',
@@ -150,7 +151,7 @@ describe('/plan --yes headless flag — gate #2', () => {
 
 describe('/plan --yes headless flag — v2 Stage 3 cutover guards', () => {
   it('keeps --yes scoped to HITL waits; deterministic gates still fail closed', () => {
-    assert.match(
+    assertDocMentions(
       planSource,
       /Deterministic gates[\s\S]*still fail closed under `--yes`/i,
       'plan.md must state --yes is not a validation override',
@@ -160,19 +161,19 @@ describe('/plan --yes headless flag — v2 Stage 3 cutover guards', () => {
   it('uses the story author prompt and default-single policy instead of deliveryShape routing', () => {
     const author = section('### 2\\. Author');
     assert.ok(author, 'plan.md must carry the author step');
-    assert.match(
+    assertDocMentions(
       author,
       /`stories\.json`[\s\S]*\*\*length 1 by default\*\*/i,
       'authoring must default to one Story',
     );
-    assert.match(
+    assertDocMentions(
       author,
       /Use the envelope `systemPrompts\.story`/i,
       'authoring must consume the story prompt from the envelope',
     );
-    assert.match(
+    assertDocMentions(
       author,
-      /Split only under the\s*\n?policy above/i,
+      /Split only under the policy above/i,
       'splitting must be controlled by the default-single policy',
     );
   });
@@ -181,8 +182,8 @@ describe('/plan --yes headless flag — v2 Stage 3 cutover guards', () => {
     // The authored risk verdict — and the deliveryShape field it once carried
     // — are retired. The author step must name neither artifact.
     const author = section('### 2\\. Author');
-    assert.doesNotMatch(author, /risk-verdict/i);
-    assert.doesNotMatch(author, /deliveryShape/i);
+    assertDocOmits(author, /risk-verdict/i);
+    assertDocOmits(author, /deliveryShape/i);
   });
 
   it('does not link to the deleted planning helpers', () => {
@@ -192,14 +193,14 @@ describe('/plan --yes headless flag — v2 Stage 3 cutover guards', () => {
       'helpers/scope-triage-gate.md',
       'helpers/plan-epic-reference.md',
     ]) {
-      assert.doesNotMatch(planSource, new RegExp(deleted.replace('.', '\\.')));
+      assertDocOmits(planSource, new RegExp(deleted.replace('.', '\\.')));
     }
   });
 
   it('keeps scope-triage as optional split-advisory notes only', () => {
-    assert.match(
+    assertDocMentions(
       planSource,
-      /optional\s*\n?\s*split-advisory notes only \(no routing verdict\)/i,
+      /optional split-advisory notes only \(no routing verdict\)/i,
       'scope-triage skill link must be advisory-only',
     );
   });

--- a/tests/qa-assist-workflow.test.js
+++ b/tests/qa-assist-workflow.test.js
@@ -29,6 +29,7 @@ import { readFileSync } from 'node:fs';
 import path from 'node:path';
 import { describe, it } from 'node:test';
 import { fileURLToPath } from 'node:url';
+import { assertDocMentions, assertDocOmits } from './helpers/doc-assert.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -74,18 +75,30 @@ describe('qa-assist workflow contract', () => {
   });
 
   it('defines Intake, Enrich, and Record phases', () => {
-    assert.match(source, /##\s+Phase 1 — Intake/, 'missing Intake section');
-    assert.match(source, /##\s+Phase 2 — Enrich/, 'missing Enrich section');
-    assert.match(source, /##\s+Phase 3 — Record/, 'missing Record section');
+    assertDocMentions(
+      source,
+      /##\s+Phase 1 — Intake/,
+      'missing Intake section',
+    );
+    assertDocMentions(
+      source,
+      /##\s+Phase 2 — Enrich/,
+      'missing Enrich section',
+    );
+    assertDocMentions(
+      source,
+      /##\s+Phase 3 — Record/,
+      'missing Record section',
+    );
   });
 
   it('frames the agent as a quality gatekeeper without a persona pack', () => {
-    assert.match(
+    assertDocMentions(
       source,
       /quality gatekeeper/i,
       'workflow must frame QA role in prose',
     );
-    assert.doesNotMatch(
+    assertDocOmits(
       source,
       /personas\/qa-engineer\.md/,
       'workflow must not reference deleted persona files',
@@ -93,17 +106,17 @@ describe('qa-assist workflow contract', () => {
   });
 
   it('is human-led: ingests a human observation and asks clarifying questions when ambiguous', () => {
-    assert.match(
+    assertDocMentions(
       source,
       /human-led/i,
       'workflow must declare itself human-led',
     );
-    assert.match(
+    assertDocMentions(
       source,
       /observation/i,
       'workflow must ingest a human observation',
     );
-    assert.match(
+    assertDocMentions(
       source,
       /clarifying questions[\s\S]*?ambiguous/i,
       'workflow must ask clarifying questions when the observation is ambiguous',
@@ -111,14 +124,14 @@ describe('qa-assist workflow contract', () => {
   });
 
   it('enriches with repro, root-cause file:line, and a coverage verdict', () => {
-    assert.match(source, /repro/i, 'must establish a repro');
-    assert.match(source, /root[\s-]cause/i, 'must locate a root cause');
-    assert.match(
+    assertDocMentions(source, /repro/i, 'must establish a repro');
+    assertDocMentions(source, /root[\s-]cause/i, 'must locate a root cause');
+    assertDocMentions(
       source,
       /file:line/i,
       'must name the root cause as a file:line locus',
     );
-    assert.match(
+    assertDocMentions(
       source,
       /coverage verdict/i,
       'must compute a coverage verdict',
@@ -126,32 +139,40 @@ describe('qa-assist workflow contract', () => {
   });
 
   it('defaults to a persistent, resumable rolling session', () => {
-    assert.match(source, /persistent/i, 'must default to a persistent session');
-    assert.match(source, /resumable|resume/i, 'must be resumable');
-    assert.match(source, /rolling/i, 'must be a rolling session');
+    assertDocMentions(
+      source,
+      /persistent/i,
+      'must default to a persistent session',
+    );
+    assertDocMentions(source, /resumable|resume/i, 'must be resumable');
+    assertDocMentions(source, /rolling/i, 'must be a rolling session');
   });
 
   it('gates every phase transition and every write on explicit operator confirmation (HITL)', () => {
-    assert.match(
+    assertDocMentions(
       source,
       /Intake\s*→\s*Enrich/,
       'must name the Intake → Enrich gate',
     );
-    assert.match(
+    assertDocMentions(
       source,
       /Enrich\s*→\s*Record/,
       'must name the Enrich → Record gate',
     );
-    assert.match(
+    assertDocMentions(
       source,
       /explicit operator confirmation/i,
       'transitions must require explicit operator confirmation',
     );
-    assert.match(source, /every write/i, 'every write must be operator-gated');
+    assertDocMentions(
+      source,
+      /every write/i,
+      'every write must be operator-gated',
+    );
   });
 
   it('redacts before any evidence reaches disk or GitHub', () => {
-    assert.match(
+    assertDocMentions(
       source,
       /[Rr]edact[\s\S]*?(disk|GitHub|persist)/,
       'must redact before evidence reaches disk or GitHub',
@@ -183,7 +204,7 @@ describe('qa-assist workflow contract', () => {
   });
 
   it('writes its ledger under temp/qa/', () => {
-    assert.match(
+    assertDocMentions(
       source,
       /temp\/qa\//,
       'workflow must write its ledger under temp/qa/',

--- a/tests/qa-explore-workflow.test.js
+++ b/tests/qa-explore-workflow.test.js
@@ -39,6 +39,7 @@ import { readFileSync } from 'node:fs';
 import path from 'node:path';
 import { describe, it } from 'node:test';
 import { fileURLToPath } from 'node:url';
+import { assertDocMentions, assertDocOmits } from './helpers/doc-assert.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -88,18 +89,26 @@ describe('qa-explore workflow contract', () => {
   });
 
   it('defines Plan, Capture, and Triage sections', () => {
-    assert.match(source, /##\s+Phase 1 — Plan/, 'missing Plan section');
-    assert.match(source, /##\s+Phase 2 — Capture/, 'missing Capture section');
-    assert.match(source, /##\s+Phase 3 — Triage/, 'missing Triage section');
+    assertDocMentions(source, /##\s+Phase 1 — Plan/, 'missing Plan section');
+    assertDocMentions(
+      source,
+      /##\s+Phase 2 — Capture/,
+      'missing Capture section',
+    );
+    assertDocMentions(
+      source,
+      /##\s+Phase 3 — Triage/,
+      'missing Triage section',
+    );
   });
 
   it('frames the agent as a quality gatekeeper without a persona pack', () => {
-    assert.match(
+    assertDocMentions(
       source,
       /quality gatekeeper/i,
       'workflow must frame QA role in prose',
     );
-    assert.doesNotMatch(
+    assertDocOmits(
       source,
       /personas\/qa-engineer\.md/,
       'workflow must not reference deleted persona files',
@@ -107,18 +116,18 @@ describe('qa-explore workflow contract', () => {
   });
 
   it('is agent-led: the agent drives the surface itself', () => {
-    assert.match(
+    assertDocMentions(
       source,
       /agent-led/i,
       'workflow must declare itself agent-led',
     );
-    assert.match(
+    assertDocMentions(
       source,
       /agent drives/i,
       'workflow must state that the agent drives the surface (not the human)',
     );
     // The Capture phase header must signal that the agent drives there.
-    assert.match(
+    assertDocMentions(
       source,
       /##\s+Phase 2 — Capture \(agent drives, READ-ONLY\)/,
       'Capture phase header must declare the agent drives, read-only',
@@ -129,17 +138,17 @@ describe('qa-explore workflow contract', () => {
     // The Plan phase must offer both driving methods as an explicit choice.
     const planSection =
       source.match(/##\s+Phase 1 — Plan([\s\S]*?)(?:\r?\n---\r?\n)/)?.[1] ?? '';
-    assert.match(
+    assertDocMentions(
       planSection,
       /Choose the driving method explicitly/i,
       'Plan phase must make the driving method an explicit choice',
     );
-    assert.match(
+    assertDocMentions(
       planSection,
       /Drive \(default\)/,
       'Plan phase must offer driving the running app as the default method',
     );
-    assert.match(
+    assertDocMentions(
       planSection,
       /Static \(documented interim\)/,
       'Plan phase must offer static driving as the documented interim method',
@@ -147,17 +156,17 @@ describe('qa-explore workflow contract', () => {
   });
 
   it('drives via the browser MCP by default and static as the documented interim', () => {
-    assert.match(
+    assertDocMentions(
       source,
       /browser MCP/i,
       'workflow must name the browser MCP as the default driving channel',
     );
-    assert.match(
+    assertDocMentions(
       source,
       /navigation-first/i,
       'driving must be navigation-first',
     );
-    assert.match(
+    assertDocMentions(
       source,
       /static driving|Static \(documented interim\)/i,
       'workflow must document static driving as the interim method',
@@ -165,12 +174,12 @@ describe('qa-explore workflow contract', () => {
   });
 
   it('runs as a bounded per-surface session', () => {
-    assert.match(
+    assertDocMentions(
       source,
       /bounded[\s\S]*?per-surface|per-surface[\s\S]*?bounded/i,
       'workflow must describe a bounded per-surface session',
     );
-    assert.match(
+    assertDocMentions(
       source,
       /one surface per session|single bounded session over one named surface/i,
       'workflow must bound the session to a single named surface',
@@ -178,12 +187,12 @@ describe('qa-explore workflow contract', () => {
   });
 
   it('removes the human-driven flow and points to /qa-assist for it', () => {
-    assert.match(
+    assertDocMentions(
       source,
       /qa-assist/,
       'workflow must reference /qa-assist as the human-led sibling',
     );
-    assert.match(
+    assertDocMentions(
       source,
       /No human-driven flow lives in `\/qa-explore`|no human-driven flow lives here/i,
       'workflow must declare that no human-driven flow remains in qa-explore',
@@ -191,7 +200,7 @@ describe('qa-explore workflow contract', () => {
   });
 
   it('declares the Capture phase read-only', () => {
-    assert.match(
+    assertDocMentions(
       source,
       /Capture[\s\S]*?read-only/i,
       'Capture phase must be declared read-only',
@@ -199,17 +208,17 @@ describe('qa-explore workflow contract', () => {
   });
 
   it('holds the read-only capture invariant while the agent drives', () => {
-    assert.match(
+    assertDocMentions(
       source,
       /Read-only invariant/i,
       'workflow must state the read-only capture invariant',
     );
-    assert.match(
+    assertDocMentions(
       source,
       /Never type real credentials inline/i,
       'driving must never type real credentials inline for an authenticated surface',
     );
-    assert.match(
+    assertDocMentions(
       source,
       /finding, not a workaround/i,
       'broken navigation must be recorded as a finding, not routed around',
@@ -219,17 +228,17 @@ describe('qa-explore workflow contract', () => {
   it('resolves the target environment via resolveQaEnvironment at Plan time', () => {
     const planSection =
       source.match(/##\s+Phase 1 — Plan([\s\S]*?)(?:\r?\n---\r?\n)/)?.[1] ?? '';
-    assert.match(
+    assertDocMentions(
       planSection,
       /resolveQaEnvironment/,
       'Plan phase must resolve the target environment via resolveQaEnvironment',
     );
-    assert.match(
+    assertDocMentions(
       planSection,
       /prompt/i,
       'Plan phase must prompt the operator when the target environment is ambiguous',
     );
-    assert.match(
+    assertDocMentions(
       planSection,
       /record the resolved\s+\*\*environment name\*\*/i,
       'Plan phase must record the resolved environment name on the ledger alongside the driving method',
@@ -239,24 +248,24 @@ describe('qa-explore workflow contract', () => {
   it('re-scopes static as the interim only where no seam resolves, not a forced authenticated fallback', () => {
     // The retired forced-fallback wording must be gone: exploratory QA can now
     // drive authenticated deployed surfaces through the per-environment seam.
-    assert.doesNotMatch(
+    assertDocOmits(
       source,
       /does not deliver/i,
       'the forced authenticated-driving fallback wording must be retired',
     );
     // Authenticated driving is now seam-based, including deployed hosts.
-    assert.match(
+    assertDocMentions(
       source,
       /signInSeam/,
       'authenticated driving must reference the per-environment signInSeam',
     );
-    assert.match(
+    assertDocMentions(
       source,
       /credentialRef/,
       'the skill seam must reference credentialRef-indirected sign-in',
     );
     // Static is now scoped to the no-seam case, not the authenticated case.
-    assert.match(
+    assertDocMentions(
       source,
       /no seam resolves/i,
       'static must be documented as the interim only where no seam resolves',
@@ -271,17 +280,17 @@ describe('qa-explore workflow contract', () => {
   });
 
   it('gates every phase transition on explicit operator confirmation (HITL)', () => {
-    assert.match(
+    assertDocMentions(
       source,
       /Plan\s*→\s*Capture/,
       'must name the Plan → Capture gate',
     );
-    assert.match(
+    assertDocMentions(
       source,
       /Capture\s*→\s*Triage/,
       'must name the Capture → Triage gate',
     );
-    assert.match(
+    assertDocMentions(
       source,
       /explicit operator confirmation/i,
       'transitions must require explicit operator confirmation',
@@ -314,7 +323,7 @@ describe('qa-explore workflow contract', () => {
   });
 
   it('writes its ledger under temp/qa/', () => {
-    assert.match(
+    assertDocMentions(
       source,
       /temp\/qa\//,
       'workflow must write its ledger under temp/qa/',


### PR DESCRIPTION
## Why

The workflow-doc tests assert that a shipped `.md` *says* a thing — but did it with literal spaces against hard-wrapped markdown, so they were silently asserting **layout**, not content. Re-flowing a correct paragraph turns them red, and the remedy the failure suggests (move a word to the previous line) protects nothing and teaches nothing.

Hit for real while trimming `deliver.md` under its 8192-byte spine budget in #4737: `"review depth"` wrapped across a line, and `/derived level.*review depth/` stopped matching.

The negative guards carry the same bug pointing the other way, which is worse:

```js
assert.doesNotMatch(md, /git merge --no-ff/)   // MISSES a wrapped occurrence
```

That's a guard against a forbidden phrase creeping back, and a wrap makes it silently pass. Normalizing makes those strictly stronger.

## What

- **`tests/helpers/doc-assert.js`** — `assertDocMentions` / `assertDocOmits` match against a whitespace-normalized copy, and fail with the pattern plus a short message instead of `assert.match`'s whole-file dump (those were 8KB blobs). Signature-compatible with `assert.match` / `assert.doesNotMatch`, so migrating a call site is a rename.
- **Migrated the prose assertions** across six workflow-doc test files, dropping the **12 hand-rolled `\s*\n?\s*` / `\s+` workarounds** that had leaked in inconsistently — one author per site remembering the trap, every plain-spaced pattern beside them waiting to fire.
- **`tests/doc-assert-helper.test.js`** pins *both* failure modes against the plain assertions, so the reason for the change is executable rather than only described.

## Deliberately not migrated

Assertions where whitespace **is** the contract keep plain `assert.match`: YAML frontmatter anchors (`/^---\r?\n.../`), the fenced sequencing-command template, and table-row patterns. Normalizing flattens exactly the structure those exist to pin — the helper's doc comment says so explicitly.

Also unchanged: the 8192-byte spine budget and the phrase pins themselves. That collision is the gate working as intended — the budget forces trimming, the pins declare what may not be trimmed. Only the false-failure mode was wrong.

## Verification

- `npm test` — 8432 pass / 0 fail (+6 new)
- `npm run lint` — 0 errors
- `check-baselines`, `check-dead-exports` (default + `--production`), `check-arch-cycles` — all clean, `added=0`
- Re-wrapped `deliver.md` so `"review depth"` straddles a line break and re-ran the test that broke this morning: **passes**, then reverted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change to assertion helpers and workflow-doc specs; no runtime or workflow markdown behavior changes.
> 
> **Overview**
> Workflow-doc tests were matching **layout** (literal spaces across hard-wrapped lines) instead of **content**, causing false failures on correct doc edits and false passes when forbidden phrases straddle line breaks.
> 
> This PR adds **`tests/helpers/doc-assert.js`** with `normalizeProse`, **`assertDocMentions`**, and **`assertDocOmits`** (drop-in replacements for `assert.match` / `assert.doesNotMatch` on prose, with shorter failure messages). **`tests/doc-assert-helper.test.js`** pins both failure modes against the old assertions.
> 
> **Six** workflow contract specs (`deliver-epic-single`, `deliver-integration-gate`, `plan-critics`, `plan-yes-flag`, `qa-assist`, `qa-explore`) now use the helpers for prose checks and drop inconsistent `\s*\n?\s*` workarounds. Assertions where whitespace is the contract (YAML frontmatter anchors, fenced command templates, table rows) stay on plain `assert.match`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0b060814760c637ffde4fc957f62c89212c96c6f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->