### PR TITLE
feat: /deliver-light: prompt to a validated single-session delivery with full gates (#4740)

### DIFF
--- a/.agents/docs/workflows.md
+++ b/.agents/docs/workflows.md
@@ -32,7 +32,7 @@ by `node .agents/scripts/generate-workflows-doc.js`; `npm run docs:check`
 fails when it drifts from the on-disk workflow set. To change a command’s
 description, edit the workflow file’s front-matter and regenerate.
 
-## Commands (24)
+## Commands (25)
 
 | Command | Description |
 | --- | --- |
@@ -53,6 +53,7 @@ description, edit the workflow file’s front-matter and regenerate.
 | `/audit-to-stories` | Convert findings produced by the audit-\* workflows into actionable GitHub Stories. Reads temp/audits/audit-\*-results.md, groups findings cross-audit, deduplicates against existing Issues by fingerprint, and either chains into /plan --seed-file or opens standalone Stories. |
 | `/audit-ux-ui` | Audit UX/UI consistency and design system adherence |
 | `/deliver` | Unified delivery entry point. Takes a list of Story ids, resolves their dependency graph from live state, and delivers each via the single deliver-story engine — story-<id> → PR → main. |
+| `/deliver-light` | Single-session delivery for genuinely small work. Judges a prompt's predicted footprint, authors a receipt Story, then lands it through the same single-story-init / single-story-close engine — every close gate unchanged. |
 | `/git-cleanup` | Tidy the local checkout in four phases: fast-forward `main`, prune stale remote-tracking refs, sweep merged branches (squash-aware), and triage `git stash` entries — each step gated by operator confirmation. |
 | `/git-deliver` | Single ad-hoc delivery command for working-tree changes. Detects the git setup and escalates to the right terminal step — commit only, commit + push, or commit + push + open a PR with native auto-merge — picking the default from observable state and letting flags pin any level explicitly. Replaces the retired git-commit-all, git-push, and git-pr-all trio. |
 | `/mandrel-update` | npm-era upgrade wraparound for a Mandrel consumer. Runs `npx mandrel update` (resolve newest published version → install → re-materialize `.agents/` → migrate → doctor → surface changelog) as the single mechanical step, then walks the operator through the judgment wraparound the CLI deliberately leaves unowned: reconcile `.agentrc.json`, install the Epic #1386 quality-gate surface, refresh the harness permission allowlist, reconcile the consumer's `AGENTS.md` / runbooks against the surfaced changelog, and stage + commit the staged lockfile bump. |

--- a/.agents/scripts/deliver-light.js
+++ b/.agents/scripts/deliver-light.js
@@ -1,0 +1,385 @@
+#!/usr/bin/env node
+
+/**
+ * deliver-light.js — the `/deliver-light` entry point (Story #4740).
+ *
+ * A **thin entry point, not a second delivery engine.** It runs the
+ * suitability gate, authors a minimal receipt `type::story`, and then hands off
+ * to the SAME engine scripts `/deliver` uses:
+ *
+ *   suitability gate  →  inline receipt Story  →  single-story-init.js
+ *     →  (agent implements + self-evals)  →  diff backstop
+ *     →  single-story-close.js  (close-and-land, every gate byte-identical)
+ *
+ * Worktree, branch, lease, PR, and merge mechanics are **invoked, never
+ * reimplemented** — this file contains no parallel init/close logic
+ * ({@link buildNextCommands} references the engine scripts by name). The
+ * reusable decision core lives in
+ * {@link module:lib/orchestration/light-suitability}; this module is the CLI
+ * shell plus the receipt-authoring and diff-backstop wiring.
+ *
+ * Two modes:
+ *
+ *   - **gate** (default) — judge a prompt's predicted footprint. On
+ *     `proceed-light` it authors the receipt Story (via the plan-persist
+ *     `createStoryIssues` surface) and prints the init/close hand-off. On
+ *     over-scope it prints `ask-operator` (attended) or `escalate-plan`
+ *     (`--yes`), never landing silently.
+ *   - **backstop** (`--backstop --story <id>`) — re-check the ACTUAL diff of
+ *     the Story branch after implementation; exit non-zero when it exceeds the
+ *     light ceilings, so an over-scope diff is blocked rather than landed.
+ *
+ * Usage:
+ *   node .agents/scripts/deliver-light.js --prompt "<text>" \
+ *     --creates path,path --acceptance 1 --route lite --reason "<why>"
+ *   node .agents/scripts/deliver-light.js --prompt "<text>" --amends '#123' --route lite --reason "<why>"
+ *   node .agents/scripts/deliver-light.js --backstop --story 4741
+ *
+ * Exit codes: 0 ok (proceed / clean backstop), 1 usage error, 2 the gate did
+ * not proceed light (ask-operator / escalate-plan), 3 the diff backstop blocked.
+ */
+
+import { parseArgs } from 'node:util';
+
+import { runAsCli } from './lib/cli-utils.js';
+import { resolveConfig } from './lib/config-resolver.js';
+import { Logger, routeAllOutputToStderr } from './lib/Logger.js';
+import { computeChangeSet } from './lib/orchestration/change-set.js';
+import {
+  buildReceiptStoryTicket,
+  checkLightDiffBackstop,
+  deriveLightSuitability,
+  resolveLightGateOutcome,
+} from './lib/orchestration/light-suitability.js';
+import {
+  assemblePlanStories,
+  createStoryIssues,
+} from './lib/orchestration/plan-persist/story-ops.js';
+import { createProvider } from './lib/provider-factory.js';
+
+const HELP = `\
+Usage:
+  deliver-light.js --prompt <text> [--creates csv] [--refactors csv]
+                   [--acceptance n] [--route lite|full] [--reason <text>]
+                   [--amends '#id'] [--yes]
+  deliver-light.js --backstop --story <id>
+
+The thin /deliver-light entry point: suitability gate → inline receipt Story →
+the same single-story-init.js / single-story-close.js engine /deliver uses.
+
+Gate options:
+  --prompt <text>    Operator prompt describing the change. Required for the gate.
+  --creates <csv>    Predicted NEW file paths (comma-separated).
+  --refactors <csv>  Predicted edited/existing file paths (comma-separated).
+  --acceptance <n>   Predicted acceptance-criteria count (default 1).
+  --route <r>        Ledgered model verdict route: lite | full.
+  --reason <text>    Recorded reason for a lite verdict (required for lite).
+  --amends <#id>     Mark this as an amendment of an existing issue.
+  --yes              Unattended: over-scope fails closed to /plan (no prompt).
+
+Backstop options:
+  --backstop         Re-check the ACTUAL diff after implementation.
+  --story <id>       Story issue number whose story-<id> branch to diff.
+
+  --pretty           Pretty-print the JSON envelope.
+  --help             Show this help.
+`;
+
+/** Exit code when the gate did not resolve to proceed-light. */
+const EXIT_NOT_PROCEED = 2;
+/** Exit code when the diff backstop blocked the land. */
+const EXIT_BACKSTOP_BLOCKED = 3;
+
+/**
+ * Split a comma-separated path list into trimmed, non-empty entries.
+ *
+ * @param {string|undefined} csv
+ * @returns {string[]}
+ */
+export function parseCsvPaths(csv) {
+  if (typeof csv !== 'string' || csv.trim() === '') return [];
+  return csv
+    .split(',')
+    .map((s) => s.trim())
+    .filter((s) => s !== '');
+}
+
+/**
+ * Assemble the predicted `changes[]` footprint from the declared creates /
+ * refactors lists — the input {@link deriveLightSuitability} shape-checks.
+ *
+ * @param {{ creates?: string[], refactors?: string[] }} args
+ * @returns {Array<{ path: string, assumption: string }>}
+ */
+export function buildPredictedChanges({ creates = [], refactors = [] } = {}) {
+  return [
+    ...creates.map((path) => ({ path, assumption: 'creates' })),
+    ...refactors.map((path) => ({ path, assumption: 'refactors-existing' })),
+  ];
+}
+
+/**
+ * Synthesize a predicted-acceptance array of the requested length — the shape
+ * gate reads the count, not the text, so placeholder strings suffice. A count
+ * below 1 yields a single-item array (a Story with no contract cannot be judged
+ * trivial, and the shape derivation rejects a zero-length acceptance anyway).
+ *
+ * @param {unknown} count
+ * @returns {string[]}
+ */
+export function synthesizeAcceptance(count) {
+  const n =
+    typeof count === 'number' && Number.isFinite(count) && count >= 1
+      ? Math.floor(count)
+      : 1;
+  return Array.from({ length: n }, (_v, i) => `AC-${i + 1}`);
+}
+
+/**
+ * Run the suitability gate purely — no I/O. Returns the outcome envelope the
+ * CLI serializes. The prompt text and `--amends` target are deliberately **not**
+ * inputs: routing is shape-checked identically whether or not the change is an
+ * amendment (Story #4740 R3), and the prompt's text carries no routing signal —
+ * the predicted footprint does. Both flow into the receipt Story instead.
+ *
+ * @param {{
+ *   creates?: string[],
+ *   refactors?: string[],
+ *   acceptance?: number,
+ *   route?: string,
+ *   reason?: string,
+ *   yes?: boolean,
+ *   injectedRules?: object,
+ * }} args
+ * @returns {{ action: string, suitability: object, outcome: object }}
+ */
+export function runLightGate({
+  creates = [],
+  refactors = [],
+  acceptance,
+  route,
+  reason,
+  yes = false,
+  injectedRules,
+} = {}) {
+  const predictedChanges = buildPredictedChanges({ creates, refactors });
+  const suitability = deriveLightSuitability({
+    predictedChanges,
+    predictedAcceptance: synthesizeAcceptance(acceptance),
+    verdict: { route, reason },
+    injectedRules,
+  });
+  const outcome = resolveLightGateOutcome({ suitability, yes });
+  return { action: outcome.action, suitability, outcome };
+}
+
+/**
+ * Author the receipt Story via the plan-persist creation surface (reused, not
+ * reimplemented). Injectable seams keep it unit-testable without a network.
+ *
+ * @param {{
+ *   provider: object,
+ *   prompt: string,
+ *   changedFiles?: string[],
+ *   amends?: string|number|null,
+ *   assembleFn?: typeof assemblePlanStories,
+ *   createFn?: typeof createStoryIssues,
+ * }} args
+ * @returns {Promise<{ storyId: number, url: string|undefined, title: string }>}
+ */
+export async function createLightReceipt({
+  provider,
+  prompt,
+  changedFiles = [],
+  amends = null,
+  assembleFn = assemblePlanStories,
+  createFn = createStoryIssues,
+} = {}) {
+  const ticket = buildReceiptStoryTicket({ prompt, changedFiles, amends });
+  const { stories } = assembleFn([ticket]);
+  const { created } = await createFn({ provider, stories });
+  const receipt = created[0];
+  if (!receipt || !Number.isInteger(receipt.id)) {
+    throw new Error(
+      '[deliver-light] receipt Story creation did not return a numeric id',
+    );
+  }
+  return { storyId: receipt.id, url: receipt.url, title: receipt.title };
+}
+
+/**
+ * The engine hand-off — the SAME scripts `/deliver` uses. Named here as
+ * commands, never reimplemented: this is the whole of deliver-light's
+ * relationship to worktree/branch/lease/PR/merge mechanics.
+ *
+ * @param {number} storyId
+ * @returns {{ init: string, close: string }}
+ */
+export function buildNextCommands(storyId) {
+  return {
+    init: `node .agents/scripts/single-story-init.js --story ${storyId}`,
+    close: `node .agents/scripts/single-story-close.js --story ${storyId} --cwd <main-repo>`,
+  };
+}
+
+/**
+ * Run the diff backstop against a Story branch's actual change set.
+ *
+ * @param {{
+ *   storyId: number,
+ *   baseRef?: string,
+ *   cwd?: string,
+ *   computeFn?: typeof computeChangeSet,
+ *   injectedRules?: object,
+ * }} args
+ * @returns {ReturnType<typeof checkLightDiffBackstop>}
+ */
+export function runDiffBackstop({
+  storyId,
+  baseRef = 'main',
+  cwd = process.cwd(),
+  computeFn = computeChangeSet,
+  injectedRules,
+} = {}) {
+  const { files } = computeFn({
+    baseRef,
+    headRef: `story-${storyId}`,
+    cwd,
+  });
+  return checkLightDiffBackstop({ changedFiles: files, injectedRules });
+}
+
+/**
+ * Emit a JSON envelope on stdout (the machine surface) so a headless caller can
+ * branch on it. Human-readable log lines stay on stderr.
+ *
+ * @param {object} envelope
+ * @param {boolean} pretty
+ */
+function emit(envelope, pretty) {
+  process.stdout.write(
+    pretty
+      ? `${JSON.stringify(envelope, null, 2)}\n`
+      : `${JSON.stringify(envelope)}\n`,
+  );
+}
+
+/**
+ * Backstop mode — re-check the actual diff.
+ *
+ * @param {{ story?: string, pretty: boolean }} values
+ * @returns {Promise<number>}
+ */
+async function runBackstopMode(values) {
+  const storyId = Number.parseInt(String(values.story ?? ''), 10);
+  if (!Number.isInteger(storyId) || storyId <= 0) {
+    process.stderr.write(HELP);
+    throw new Error('[deliver-light] --backstop requires --story <id>');
+  }
+  const result = runDiffBackstop({ storyId });
+  emit({ mode: 'backstop', storyId, ...result }, values.pretty);
+  if (result.blocked) {
+    Logger.warn(
+      `[deliver-light] diff backstop BLOCKED Story #${storyId}: ${result.reasons.join('; ')}`,
+    );
+    return EXIT_BACKSTOP_BLOCKED;
+  }
+  Logger.info(`[deliver-light] diff backstop clean for Story #${storyId}.`);
+  return 0;
+}
+
+/**
+ * Gate mode — judge the prompt and, on proceed, author the receipt Story.
+ *
+ * @param {object} values Parsed CLI values.
+ * @returns {Promise<number>}
+ */
+async function runGateMode(values) {
+  if (!values.prompt || String(values.prompt).trim() === '') {
+    process.stderr.write(HELP);
+    throw new Error('[deliver-light] --prompt <text> is required for the gate');
+  }
+
+  const gate = runLightGate({
+    creates: parseCsvPaths(values.creates),
+    refactors: parseCsvPaths(values.refactors),
+    acceptance: values.acceptance
+      ? Number.parseInt(String(values.acceptance), 10)
+      : 1,
+    route: values.route,
+    reason: values.reason,
+    yes: values.yes === true,
+  });
+
+  if (gate.action !== 'proceed-light') {
+    emit(
+      { mode: 'gate', action: gate.action, outcome: gate.outcome },
+      values.pretty,
+    );
+    Logger.warn(
+      `[deliver-light] gate did not proceed light (${gate.action}): ${gate.outcome.reasons.join('; ')}`,
+    );
+    return EXIT_NOT_PROCEED;
+  }
+
+  const provider = createProvider(resolveConfig());
+  const receipt = await createLightReceipt({
+    provider,
+    prompt: String(values.prompt),
+    changedFiles: [
+      ...parseCsvPaths(values.creates),
+      ...parseCsvPaths(values.refactors),
+    ],
+    amends: values.amends ?? null,
+  });
+  emit(
+    {
+      mode: 'gate',
+      action: 'proceed-light',
+      storyId: receipt.storyId,
+      url: receipt.url,
+      nextCommands: buildNextCommands(receipt.storyId),
+      outcome: gate.outcome,
+    },
+    values.pretty,
+  );
+  Logger.info(
+    `[deliver-light] receipt Story #${receipt.storyId} created — hand off to single-story-init.js.`,
+  );
+  return 0;
+}
+
+async function main() {
+  const { values } = parseArgs({
+    options: {
+      prompt: { type: 'string' },
+      creates: { type: 'string' },
+      refactors: { type: 'string' },
+      acceptance: { type: 'string' },
+      route: { type: 'string' },
+      reason: { type: 'string' },
+      amends: { type: 'string' },
+      yes: { type: 'boolean', default: false },
+      backstop: { type: 'boolean', default: false },
+      story: { type: 'string' },
+      pretty: { type: 'boolean', default: false },
+      help: { type: 'boolean', default: false },
+    },
+    allowPositionals: false,
+  });
+
+  if (values.help) {
+    process.stdout.write(HELP);
+    return 0;
+  }
+
+  // stdout is a JSON stream — keep human-readable output on stderr.
+  routeAllOutputToStderr();
+
+  return values.backstop ? runBackstopMode(values) : runGateMode(values);
+}
+
+runAsCli(import.meta.url, main, {
+  source: 'deliver-light',
+  propagateExitCode: true,
+});

--- a/.agents/scripts/lib/orchestration/complexity-gate.js
+++ b/.agents/scripts/lib/orchestration/complexity-gate.js
@@ -120,11 +120,14 @@ export const LITE_ROUTE_LABEL = 'route::lite';
  *                             surfaces is where trivial-looking work stops
  *                             being trivial.
  *
- * Module-private, exposed as the `ceilings` field on every
- * {@link deriveStoryShape} decision — so there is no test-only export to
- * leave production-dead.
+ * Exposed as the `ceilings` field on every {@link deriveStoryShape} decision
+ * and exported directly (Story #4740) so the `/deliver-light` suitability gate
+ * ({@link module:lib/orchestration/light-suitability}) judges a prompt's
+ * predicted footprint against the **same** ceilings the plan-time shape
+ * backstop applies — one source, so the light entry point and the plan path can
+ * never disagree about what shape is trivial.
  */
-const STORY_SHAPE_CEILINGS = Object.freeze({
+export const STORY_SHAPE_CEILINGS = Object.freeze({
   maxChanges: 2,
   maxAcceptance: 3,
   maxNonCreateChanges: 1,

--- a/.agents/scripts/lib/orchestration/light-suitability.js
+++ b/.agents/scripts/lib/orchestration/light-suitability.js
@@ -1,0 +1,439 @@
+/**
+ * lib/orchestration/light-suitability.js — the `/deliver-light` suitability
+ * gate and diff backstop (Story #4740).
+ *
+ * ## Why a light entry point exists
+ *
+ * mandrel-bench 2.12.0 forensics attributed the framework arm's cost to
+ * **session multiplication** — repeated cold framework boots (2 for a one-file
+ * greenfield build, 4 for a change request) — where the bare control does
+ * comparable small work in a single session, lacking only the quality gates
+ * and the landing guarantee. `/deliver-light` closes that gap: one session
+ * straight to execution from an operator prompt, landing through the
+ * **unchanged** `single-story-close.js` path. This module is the reusable
+ * decision core the light workflow drives; it owns **no** git, branch, PR, or
+ * label mutation — those stay in the shared engine scripts.
+ *
+ * ## Four invariants keep it proportional, not a planning bypass
+ *
+ *   1. **Suitability gate ({@link deriveLightSuitability}).** The prompt's
+ *      predicted footprint is judged by the **shared shape machinery**
+ *      ({@link module:lib/orchestration/complexity-gate.deriveStoryShape} over
+ *      {@link module:lib/orchestration/complexity-gate.STORY_SHAPE_CEILINGS})
+ *      **and** a ledgered model verdict carrying a recorded reason
+ *      ({@link resolveLedgeredVerdict}). Both must agree on `lite`; either
+ *      falling short fails closed to `full`.
+ *   2. **Over-scope stops, never silently proceeds ({@link
+ *      resolveLightGateOutcome}).** An over-ceiling prompt does **not**
+ *      hard-fail — it STOPS and asks the operator to escalate to `/plan` or
+ *      proceed light. Under `--yes` (unattended) it fails closed to
+ *      recommending `/plan`.
+ *   3. **Diff-derived backstop ({@link checkLightDiffBackstop}).** After
+ *      implementation the **actual** change set is re-checked with
+ *      {@link module:lib/orchestration/review-depth.deriveChangeLevel} plus a
+ *      file-count ceiling — the diff is the real scope signal — and an
+ *      over-ceiling diff is blocked rather than landed silently.
+ *   4. **Minimal receipt Story ({@link buildReceiptStoryTicket}).** A
+ *      `type::story` ticket is authored inline so `refs #`, history, telemetry,
+ *      and the `agent::executing -> agent::done` state machine survive.
+ *
+ * Every function here is pure and total: inputs in, decision out, no I/O and no
+ * throws (except {@link buildReceiptStoryTicket}, which rejects an empty
+ * prompt — a receipt with no prompt has nothing to record).
+ *
+ * @module lib/orchestration/light-suitability
+ */
+
+import { deriveStoryShape, STORY_SHAPE_CEILINGS } from './complexity-gate.js';
+import { deriveChangeLevel } from './review-depth.js';
+
+/**
+ * File-count ceiling for the **actual landed** change set the diff backstop
+ * ({@link checkLightDiffBackstop}) enforces. The predicted-shape ceiling caps
+ * `changes[]` at `maxChanges` (one artifact plus its test); the actual diff may
+ * legitimately run a touch wider (a generated projection, a snapshot), but a
+ * genuinely-light change stays small. Conservative by construction — a ceiling
+ * an operator could widen past what a single session safely absorbs is a
+ * ceiling that fails silently, so this is a framework constant, not a knob.
+ */
+export const LIGHT_DIFF_CEILINGS = Object.freeze({
+  maxFiles: 4,
+});
+
+/**
+ * Coerce a candidate `maxFiles` ceiling into a positive integer, falling back
+ * to the framework default for anything malformed — a stray `0`, `-1`, or `NaN`
+ * must never widen (or zero out) the light diff ceiling.
+ *
+ * @param {unknown} value
+ * @param {number} fallback
+ * @returns {number}
+ */
+function normalizeMaxFiles(value, fallback) {
+  if (typeof value !== 'number' || !Number.isFinite(value) || value < 1) {
+    return fallback;
+  }
+  return Math.floor(value);
+}
+
+/**
+ * Resolve the model's trivial-vs-standard verdict, held to the same ledgering
+ * contract the planner's authored verdict is
+ * ({@link module:lib/orchestration/complexity-gate.resolvePlannerRouteVerdict}):
+ * a `lite` route counts **only** with a non-empty recorded reason. A lite claim
+ * without a recorded reason, or any non-`lite` route, fails closed to `full` —
+ * an unaudited "trust me, it's small" never buys the light path.
+ *
+ * Pure and total.
+ *
+ * @param {{ route?: unknown, reason?: unknown }} [verdict]
+ * @returns {{
+ *   route: 'lite'|'full',
+ *   reason: string|null,
+ *   recorded: boolean,
+ *   note: string,
+ * }}
+ */
+export function resolveLedgeredVerdict({ route, reason } = {}) {
+  const recordedReason = typeof reason === 'string' ? reason.trim() : '';
+  if (route !== 'lite') {
+    return {
+      route: 'full',
+      reason: recordedReason || null,
+      recorded: recordedReason !== '',
+      note: 'model verdict is not lite — standard /plan route',
+    };
+  }
+  if (recordedReason === '') {
+    return {
+      route: 'full',
+      reason: null,
+      recorded: false,
+      note: 'lite claim without a recorded reason — fails closed to full (the verdict must be ledgered)',
+    };
+  }
+  return {
+    route: 'lite',
+    reason: recordedReason,
+    recorded: true,
+    note: `model verdict: lite (recorded reason): ${recordedReason}`,
+  };
+}
+
+/**
+ * Judge whether an operator prompt's predicted footprint is suitable for the
+ * light path. The deterministic shape derivation and the ledgered model verdict
+ * must **both** agree on `lite`; anything else — an over-ceiling shape, a
+ * sensitive-path footprint, an unledgered verdict — resolves to `full` (the
+ * conservative default that routes the operator to `/plan`).
+ *
+ * Pure and total: never throws, never mutates its inputs.
+ *
+ * @param {{
+ *   predictedChanges?: unknown,
+ *   predictedAcceptance?: unknown,
+ *   verdict?: { route?: unknown, reason?: unknown },
+ *   injectedRules?: object,
+ *   selectSensitivePathClassesFn?: Function,
+ * }} [args]
+ * @returns {{
+ *   suitable: boolean,
+ *   route: 'lite'|'full',
+ *   shape: ReturnType<typeof deriveStoryShape>,
+ *   ledger: ReturnType<typeof resolveLedgeredVerdict>,
+ *   ceilings: typeof STORY_SHAPE_CEILINGS,
+ *   reasons: string[],
+ * }}
+ */
+export function deriveLightSuitability({
+  predictedChanges,
+  predictedAcceptance,
+  verdict,
+  injectedRules,
+  selectSensitivePathClassesFn,
+} = {}) {
+  const ledger = resolveLedgeredVerdict(verdict ?? {});
+  const shape = deriveStoryShape({
+    changes: predictedChanges,
+    acceptance: predictedAcceptance,
+    injectedRules,
+    selectSensitivePathClassesFn,
+  });
+  const suitable = shape.route === 'lite' && ledger.route === 'lite';
+  return {
+    suitable,
+    route: suitable ? 'lite' : 'full',
+    shape,
+    ledger,
+    ceilings: STORY_SHAPE_CEILINGS,
+    reasons: [`shape: ${shape.reasons[0]}`, `verdict: ${ledger.note}`],
+  };
+}
+
+/**
+ * Resolve what the light gate does with a suitability decision (Story #4740
+ * AC-3). Over-scope never hard-fails: it STOPS and asks the operator to choose,
+ * unless the run is unattended (`--yes`), where it fails closed to recommending
+ * `/plan` rather than silently proceeding light.
+ *
+ *   - suitable          → `proceed-light`
+ *   - over-scope + attended (`yes:false`)  → `ask-operator` (escalate | proceed)
+ *   - over-scope + unattended (`yes:true`) → `escalate-plan`
+ *
+ * Pure and total.
+ *
+ * @param {{ suitability?: { suitable?: boolean, reasons?: string[] }, yes?: boolean }} [args]
+ * @returns {{ action: 'proceed-light'|'ask-operator'|'escalate-plan', options?: string[], reasons: string[] }}
+ */
+export function resolveLightGateOutcome({ suitability, yes = false } = {}) {
+  const reasons = Array.isArray(suitability?.reasons)
+    ? [...suitability.reasons]
+    : [];
+
+  if (suitability?.suitable === true) {
+    return {
+      action: 'proceed-light',
+      reasons: [
+        ...reasons,
+        'predicted shape and ledgered verdict both lite — proceed light',
+      ],
+    };
+  }
+
+  if (yes === true) {
+    return {
+      action: 'escalate-plan',
+      reasons: [
+        ...reasons,
+        '--yes on over-scope fails closed to /plan (never silently proceeds light)',
+      ],
+    };
+  }
+
+  return {
+    action: 'ask-operator',
+    options: ['escalate-plan', 'proceed-light'],
+    reasons: [
+      ...reasons,
+      'predicted scope exceeds the light ceilings — STOP and ask the operator to escalate to /plan or proceed light',
+    ],
+  };
+}
+
+/**
+ * Diff-derived backstop (Story #4740 AC-4): re-check the **actual** change set
+ * after implementation, because the diff — not the prompt — is the real scope
+ * signal. Blocks (rather than landing) when the diff intersects a sensitive-
+ * path class, exceeds the file-count ceiling, or cannot be classified. A clean
+ * result is the only path that lands light.
+ *
+ * Reuses close's own {@link module:lib/orchestration/review-depth.deriveChangeLevel}
+ * — one taxonomy, applied to the predicted shape at the gate and the actual
+ * diff here — so the two read points can never disagree about what is sensitive.
+ *
+ * Pure and total.
+ *
+ * @param {{
+ *   changedFiles?: unknown,
+ *   ceilings?: { maxFiles?: number },
+ *   injectedRules?: object,
+ *   selectSensitivePathClassesFn?: Function,
+ * }} [args]
+ * @returns {{
+ *   blocked: boolean,
+ *   level: 'low'|'high'|null,
+ *   classes: string[],
+ *   fileCount: number|null,
+ *   ceilings: { maxFiles: number },
+ *   reasons: string[],
+ * }}
+ */
+export function checkLightDiffBackstop({
+  changedFiles,
+  ceilings,
+  injectedRules,
+  selectSensitivePathClassesFn,
+} = {}) {
+  const maxFiles = normalizeMaxFiles(
+    ceilings?.maxFiles,
+    LIGHT_DIFF_CEILINGS.maxFiles,
+  );
+  const files = Array.isArray(changedFiles)
+    ? changedFiles.filter((f) => typeof f === 'string' && f.trim() !== '')
+    : null;
+
+  if (files === null || files.length === 0) {
+    return {
+      blocked: true,
+      level: null,
+      classes: [],
+      fileCount: files === null ? null : 0,
+      ceilings: { maxFiles },
+      reasons: [
+        'actual change set is unknown or empty — cannot verify the diff is light; escalate to /plan',
+      ],
+    };
+  }
+
+  const { level, classes } = deriveChangeLevel({
+    changedFiles: files,
+    injectedRules,
+    selectSensitivePathClassesFn,
+  });
+
+  const reasons = [];
+  if (classes.length > 0) {
+    reasons.push(
+      `diff intersects sensitive-path class(es) ${classes.join(', ')} — escalate to /plan (do not land light)`,
+    );
+  }
+  if (files.length > maxFiles) {
+    reasons.push(
+      `diff touches ${files.length} file(s) (> maxFiles ${maxFiles}) — escalate to /plan (do not land light)`,
+    );
+  }
+  if (level !== 'low' && classes.length === 0) {
+    reasons.push(
+      'sensitive-path classification unavailable — cannot verify the diff is non-sensitive; escalate to /plan',
+    );
+  }
+
+  const blocked = reasons.length > 0;
+  return {
+    blocked,
+    level,
+    classes,
+    fileCount: files.length,
+    ceilings: { maxFiles },
+    reasons: blocked
+      ? reasons
+      : [
+          `diff is light: ${files.length} file(s) ≤ ${maxFiles}, no sensitive-path class — safe to land`,
+        ],
+  };
+}
+
+/** Cap on a receipt slug's length — keep the branch/id readable. */
+const RECEIPT_SLUG_MAX = 48;
+
+/**
+ * Derive a stable, lowercase, hyphenated slug from a prompt.
+ *
+ * @param {string} text
+ * @returns {string}
+ */
+function slugifyPrompt(text) {
+  const slug = text
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, RECEIPT_SLUG_MAX)
+    .replace(/-+$/g, '');
+  return slug === '' ? 'light-change' : slug;
+}
+
+/** Cap on a receipt title's length. */
+const RECEIPT_TITLE_MAX = 72;
+
+/**
+ * Coerce an `--amends` argument (`#123`, `123`, or `123` as a number) into a
+ * positive integer issue number, or `null` when absent/malformed.
+ *
+ * @param {unknown} amends
+ * @returns {number|null}
+ */
+function normalizeAmends(amends) {
+  if (typeof amends === 'number' && Number.isInteger(amends) && amends > 0) {
+    return amends;
+  }
+  if (typeof amends === 'string') {
+    const match = amends.trim().match(/^#?(\d+)$/);
+    if (match) {
+      const n = Number.parseInt(match[1], 10);
+      if (Number.isInteger(n) && n > 0) return n;
+    }
+  }
+  return null;
+}
+
+/**
+ * One-line receipt title from the prompt, prefixed for an amendment.
+ *
+ * @param {string} text
+ * @param {number|null} amendsId
+ * @returns {string}
+ */
+function deriveReceiptTitle(text, amendsId) {
+  const oneLine = text.replace(/\s+/g, ' ').trim();
+  const prefix = amendsId !== null ? `Amend #${amendsId}: ` : '';
+  const room = RECEIPT_TITLE_MAX - prefix.length;
+  const body =
+    oneLine.length > room
+      ? `${oneLine.slice(0, room - 1).trimEnd()}…`
+      : oneLine;
+  return `${prefix}${body}`;
+}
+
+/**
+ * Map an actual/predicted changed-file list into `changes[]` PathEntry objects
+ * for the receipt body. Every entry is recorded as `refactors-existing` — the
+ * conservative assumption, since the light path is not asserting creates.
+ *
+ * @param {unknown} changedFiles
+ * @returns {Array<{ path: string, assumption: string }>}
+ */
+function toReceiptChanges(changedFiles) {
+  const list = Array.isArray(changedFiles) ? changedFiles : [];
+  const seen = new Set();
+  const entries = [];
+  for (const f of list) {
+    if (typeof f !== 'string' || f.trim() === '' || seen.has(f.trim()))
+      continue;
+    seen.add(f.trim());
+    entries.push({ path: f.trim(), assumption: 'refactors-existing' });
+  }
+  return entries;
+}
+
+/**
+ * Build the minimal receipt `type::story` ticket for the light path
+ * (Story #4740 AC-5) — the input `assemblePlanStories` / `createStoryIssues`
+ * consume, so the light path reuses the plan-persist story-creation surface
+ * rather than reimplementing issue authoring. The body carries the operator
+ * prompt (goal + spec) and the diff-derived footprint (`changes[]`), so history
+ * and `refs #<id>` on the commit survive.
+ *
+ * @param {{ prompt?: unknown, changedFiles?: unknown, amends?: unknown }} [args]
+ * @returns {{ slug: string, title: string, body: object, labels: string[] }}
+ */
+export function buildReceiptStoryTicket({ prompt, changedFiles, amends } = {}) {
+  const text = typeof prompt === 'string' ? prompt.trim() : '';
+  if (text === '') {
+    throw new Error(
+      '[light-suitability] a non-empty prompt is required to build a receipt Story',
+    );
+  }
+  const amendsId = normalizeAmends(amends);
+  const amendNote = amendsId !== null ? ` Amends #${amendsId}.` : '';
+  const changes = toReceiptChanges(changedFiles);
+
+  return {
+    slug: slugifyPrompt(text),
+    title: deriveReceiptTitle(text, amendsId),
+    labels: [],
+    body: {
+      goal: `${text}${amendNote}`,
+      spec:
+        `Delivered via /deliver-light as a validated single-session change — ` +
+        `the /plan session is removed for genuinely small work while every ` +
+        `single-story-close gate runs byte-identical.${amendNote} ` +
+        `Operator prompt: ${text}`,
+      changes,
+      acceptance: [
+        'The change described by the prompt is implemented and lands through ' +
+          'the unchanged single-story-close path with every close gate passing.',
+      ],
+      verify: ['npm test (unit)'],
+    },
+  };
+}

--- a/.agents/workflows/deliver-light.md
+++ b/.agents/workflows/deliver-light.md
@@ -1,0 +1,117 @@
+---
+description:
+  Single-session delivery for genuinely small work. Judges a prompt's
+  predicted footprint, authors a receipt Story, then lands it through the same
+  single-story-init / single-story-close engine — every close gate unchanged.
+---
+
+# /deliver-light "<prompt>" | --amends '#<id>' "<prompt>"
+
+> **Thin entry point, not a second engine.** `/deliver-light` removes the
+> `/plan` session for small work — nothing else. It runs a suitability gate,
+> authors a minimal receipt Story, then hands off to the SAME scripts
+> [`/deliver`](deliver.md) uses. Read
+> [`helpers/deliver-digest.md`](helpers/deliver-digest.md) once first — the
+> engine invariants, gates, and terminal-envelope contract below are its.
+
+## Role
+
+For a genuinely trivial change — a one-file fix, a small addition, a small
+amendment — the multi-session plan→deliver ceremony buys nothing the bare model
+lacks except **gates and landing**. `/deliver-light` keeps exactly those: one
+session straight to execution from an operator prompt, landing through the
+unchanged close path. It never relaxes a close gate, never bypasses the PR to
+`main`, and never lands over-scope work silently.
+
+## Four invariants (do not skip one)
+
+1. **Suitability gate.** The prompt's predicted footprint is judged by the
+   shared shape machinery (`deriveStoryShape` / `deriveChangeLevel`) **and** a
+   ledgered model verdict with a recorded reason. Both must agree on `lite`.
+2. **Over-scope stops — it never hard-fails.** An over-ceiling prompt STOPS and
+   asks the operator to escalate to `/plan` or proceed light. Under `--yes` it
+   fails closed to recommending `/plan`.
+3. **Diff-derived backstop.** After implementation the ACTUAL change set is
+   re-checked — the diff is the real scope signal — and an over-ceiling diff is
+   blocked rather than landed.
+4. **Minimal receipt Story.** A `type::story` is authored inline so `refs #`,
+   history, telemetry, and the `agent::executing → agent::done` state machine
+   all survive.
+
+## Procedure
+
+1. **Predict + gate.** Form the predicted footprint (new files, edited files,
+   acceptance count) and your ledgered verdict (a recorded reason for `lite`),
+   then run the gate:
+
+   ```bash
+   node .agents/scripts/deliver-light.js --prompt "<prompt>" \
+     --creates <csv> --refactors <csv> --acceptance <n> \
+     --route lite --reason "<why this is trivial>" [--amends '#<id>'] [--yes]
+   ```
+
+   Branch on `action` in the JSON envelope:
+   - **`proceed-light`** — the receipt Story is authored; read `storyId` and
+     `nextCommands`. Continue to step 2.
+   - **`ask-operator`** — predicted scope exceeds the light ceilings. STOP and
+     ask the operator to escalate to `/plan` or proceed light. Do not proceed
+     on your own.
+   - **`escalate-plan`** — over-scope under `--yes`: recommend `/plan` and stop.
+     `/deliver-light` never lands over-scope work.
+
+   `--amends '#<id>'` is the canonical light case — shape-checked identically; a
+   heavy amendment escalates to `/plan` like any other over-scope prompt.
+
+2. **Init (same engine).** From the main checkout, synchronously, with the
+   maximum Bash timeout:
+
+   ```bash
+   node .agents/scripts/single-story-init.js --story <storyId>
+   ```
+
+   Capture `workCwd`; `remoteVerified: false` → flip `agent::blocked` and stop.
+   This is [`/deliver`](deliver.md)'s worktree/branch/lease/label engine,
+   invoked, not reimplemented.
+
+3. **Implement + self-eval.** `cd` into `workCwd`, implement the change, run
+   `npm test` once in the worktree, then run the bounded acceptance self-eval
+   loop ([`helpers/deliver-story.md`](helpers/deliver-story.md) Step 1a). Commit
+   on `story-<id>` with `(refs #<storyId>)`.
+
+4. **Diff backstop.** Before close, re-check the ACTUAL diff:
+
+   ```bash
+   node .agents/scripts/deliver-light.js --backstop --story <storyId>
+   ```
+
+   Exit `3` (`blocked: true`) means the landed diff exceeds the light ceilings
+   (file count or a sensitive-path class). STOP, flip `agent::blocked`, and
+   escalate to `/plan` — do not land.
+
+5. **Close and land (same engine).** Exactly [`/deliver`](deliver.md)'s close:
+
+   ```bash
+   node .agents/scripts/single-story-close.js --story <storyId> --cwd <main-repo>
+   ```
+
+   Branch on the terminal envelope's `status` per
+   [`helpers/deliver-digest.md`](helpers/deliver-digest.md) § 5 — every close
+   gate runs byte-identical to the full path.
+
+## Constraints
+
+- **Land or block — never a silent local build.** The close push is the only
+  sanctioned landing.
+- **No parallel engine.** `/deliver-light` invokes `single-story-init.js` and
+  `single-story-close.js`; it never reimplements worktree, branch, PR, or merge
+  mechanics.
+- **State only via `update-ticket-state.js`.** Drive every `agent::*`
+  transition through the script; report state, not process.
+
+## See also
+
+- [`/deliver`](deliver.md) — the multi-Story / planned delivery entry point.
+- [`helpers/deliver-story.md`](helpers/deliver-story.md) — the one Story
+  delivery engine both entry points share.
+- [`helpers/deliver-digest.md`](helpers/deliver-digest.md) — engine invariants,
+  gates, and the terminal-envelope contract.

--- a/baselines/dead-exports-production.json
+++ b/baselines/dead-exports-production.json
@@ -1493,6 +1493,14 @@
       "symbol": "reduceOutcomes"
     },
     {
+      "file": ".agents/scripts/lib/orchestration/light-suitability.js",
+      "symbol": "LIGHT_DIFF_CEILINGS"
+    },
+    {
+      "file": ".agents/scripts/lib/orchestration/light-suitability.js",
+      "symbol": "resolveLedgeredVerdict"
+    },
+    {
       "file": ".agents/scripts/lib/orchestration/merge-block-class.js",
       "symbol": "BLOCK_CLASSES"
     },

--- a/tests/lib/orchestration/light-suitability.test.js
+++ b/tests/lib/orchestration/light-suitability.test.js
@@ -1,0 +1,514 @@
+// tests/lib/orchestration/light-suitability.test.js
+//
+// Unit tier (Story #4740): /deliver-light — a validated single-session
+// delivery path for genuinely small work that keeps every quality gate and the
+// landing guarantee. This suite pins the four invariants that keep the light
+// path proportional rather than a planning bypass, plus the thin-entry-point
+// contract that it reuses the shared engine scripts:
+//
+//   - AC-1: the light path lands through the unchanged single-story-close
+//           engine (buildNextCommands references it, no parallel close impl);
+//   - AC-2: the suitability gate judges the predicted footprint via the shared
+//           shape machinery plus a ledgered model verdict with a recorded
+//           reason (deriveLightSuitability / resolveLedgeredVerdict);
+//   - AC-3: over-scope STOPS and asks; under --yes it fails closed to /plan
+//           (resolveLightGateOutcome);
+//   - AC-4: a diff-derived backstop blocks over-ceiling actual diffs
+//           (checkLightDiffBackstop / runDiffBackstop);
+//   - AC-5: a minimal receipt type::story is authored inline carrying the
+//           prompt and footprint (buildReceiptStoryTicket / createLightReceipt);
+//   - AC-6: --amends is shape-checked identically (small → light, heavy → plan);
+//   - AC-7: /deliver-light projects into the generated command tree;
+//   - AC-8: the light entry contains no parallel init/close implementation.
+
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { existsSync, mkdtempSync, readFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import test, { describe } from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+import {
+  buildNextCommands,
+  buildPredictedChanges,
+  createLightReceipt,
+  parseCsvPaths,
+  runDiffBackstop,
+  runLightGate,
+  synthesizeAcceptance,
+} from '../../../.agents/scripts/deliver-light.js';
+import {
+  buildReceiptStoryTicket,
+  checkLightDiffBackstop,
+  deriveLightSuitability,
+  LIGHT_DIFF_CEILINGS,
+  resolveLedgeredVerdict,
+  resolveLightGateOutcome,
+} from '../../../.agents/scripts/lib/orchestration/light-suitability.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, '..', '..', '..');
+const DELIVER_LIGHT_SRC = path.join(
+  REPO_ROOT,
+  '.agents',
+  'scripts',
+  'deliver-light.js',
+);
+
+/** Stand-in sensitive-path manifest, mirroring the review-depth fixtures. */
+const RULES = {
+  sensitivePaths: {
+    security: { filePatterns: ['**/auth/**'] },
+    billing: { filePatterns: ['**/billing/**'] },
+  },
+};
+
+/** A ledgered lite verdict — the auditable claim the gate demands. */
+const LITE_VERDICT = { route: 'lite', reason: 'one-file additive helper' };
+
+// ---------------------------------------------------------------------------
+// resolveLedgeredVerdict (AC-2) — a lite claim counts only when ledgered
+// ---------------------------------------------------------------------------
+
+describe('resolveLedgeredVerdict — lite only with a recorded reason (AC-2)', () => {
+  test('a lite claim with a recorded reason is honored', () => {
+    const v = resolveLedgeredVerdict(LITE_VERDICT);
+    assert.equal(v.route, 'lite');
+    assert.equal(v.recorded, true);
+    assert.equal(v.reason, 'one-file additive helper');
+  });
+
+  test('a lite claim WITHOUT a recorded reason fails closed to full', () => {
+    for (const reason of ['', '   ', undefined, null, 42]) {
+      const v = resolveLedgeredVerdict({ route: 'lite', reason });
+      assert.equal(v.route, 'full', `reason ${JSON.stringify(reason)}`);
+      assert.equal(v.recorded, false);
+      assert.equal(v.reason, null);
+    }
+  });
+
+  test('a non-lite route is full regardless of reason', () => {
+    const v = resolveLedgeredVerdict({ route: 'full', reason: 'whatever' });
+    assert.equal(v.route, 'full');
+  });
+
+  test('is total: missing verdict yields a full route, never a throw', () => {
+    assert.equal(resolveLedgeredVerdict().route, 'full');
+    assert.equal(resolveLedgeredVerdict({}).route, 'full');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// deriveLightSuitability (AC-2) — shape machinery AND ledgered verdict
+// ---------------------------------------------------------------------------
+
+describe('deriveLightSuitability — shape + ledgered verdict must agree (AC-2)', () => {
+  test('a clearly-small prompt with a ledgered lite verdict is suitable', () => {
+    const s = deriveLightSuitability({
+      predictedChanges: [{ path: 'bin/hello.js', assumption: 'creates' }],
+      predictedAcceptance: ['prints hello and exits 0'],
+      verdict: LITE_VERDICT,
+      injectedRules: RULES,
+    });
+    assert.equal(s.suitable, true);
+    assert.equal(s.route, 'lite');
+    assert.equal(s.shape.route, 'lite');
+    assert.equal(s.ledger.route, 'lite');
+  });
+
+  test('an over-ceiling predicted footprint is not suitable (shape wins)', () => {
+    const s = deriveLightSuitability({
+      predictedChanges: [
+        { path: 'a.js', assumption: 'refactors-existing' },
+        { path: 'b.js', assumption: 'refactors-existing' },
+        { path: 'c.js', assumption: 'refactors-existing' },
+      ],
+      predictedAcceptance: ['does a', 'does b', 'does c', 'does d'],
+      verdict: LITE_VERDICT,
+      injectedRules: RULES,
+    });
+    assert.equal(s.suitable, false);
+    assert.equal(s.route, 'full');
+    assert.equal(s.shape.route, 'full');
+  });
+
+  test('a sensitive-path footprint is not suitable even when small', () => {
+    const s = deriveLightSuitability({
+      predictedChanges: [
+        { path: 'src/auth/session.js', assumption: 'creates' },
+      ],
+      predictedAcceptance: ['session refresh works'],
+      verdict: LITE_VERDICT,
+      injectedRules: RULES,
+    });
+    assert.equal(s.suitable, false);
+    assert.equal(s.route, 'full');
+  });
+
+  test('a small shape with an UNLEDGERED verdict is not suitable (verdict wins)', () => {
+    const s = deriveLightSuitability({
+      predictedChanges: [{ path: 'bin/hello.js', assumption: 'creates' }],
+      predictedAcceptance: ['prints hello'],
+      verdict: { route: 'lite', reason: '' },
+      injectedRules: RULES,
+    });
+    assert.equal(s.suitable, false);
+    assert.equal(s.ledger.route, 'full');
+  });
+
+  test('is total: empty args yield a non-suitable full decision, never a throw', () => {
+    const s = deriveLightSuitability();
+    assert.equal(s.suitable, false);
+    assert.equal(s.route, 'full');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveLightGateOutcome (AC-3) — over-scope stops, never lands silently
+// ---------------------------------------------------------------------------
+
+describe('resolveLightGateOutcome — over-scope STOPS and asks (AC-3)', () => {
+  test('a suitable decision proceeds light', () => {
+    const o = resolveLightGateOutcome({ suitability: { suitable: true } });
+    assert.equal(o.action, 'proceed-light');
+  });
+
+  test('over-scope attended asks the operator to escalate or proceed', () => {
+    const o = resolveLightGateOutcome({
+      suitability: { suitable: false, reasons: ['over ceiling'] },
+      yes: false,
+    });
+    assert.equal(o.action, 'ask-operator');
+    assert.deepEqual(o.options, ['escalate-plan', 'proceed-light']);
+  });
+
+  test('over-scope under --yes fails closed to /plan (never proceeds light)', () => {
+    const o = resolveLightGateOutcome({
+      suitability: { suitable: false, reasons: ['over ceiling'] },
+      yes: true,
+    });
+    assert.equal(o.action, 'escalate-plan');
+    assert.notEqual(o.action, 'proceed-light');
+  });
+
+  test('is total: missing suitability defaults to ask-operator (attended)', () => {
+    assert.equal(resolveLightGateOutcome().action, 'ask-operator');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// checkLightDiffBackstop (AC-4) — the actual diff is the real scope signal
+// ---------------------------------------------------------------------------
+
+describe('checkLightDiffBackstop — blocks over-ceiling actual diffs (AC-4)', () => {
+  test('a small non-sensitive diff is not blocked', () => {
+    const r = checkLightDiffBackstop({
+      changedFiles: ['bin/hello.js', 'tests/hello.test.js'],
+      injectedRules: RULES,
+    });
+    assert.equal(r.blocked, false);
+    assert.equal(r.level, 'low');
+    assert.equal(r.fileCount, 2);
+  });
+
+  test('a diff exceeding the file-count ceiling is blocked', () => {
+    const files = Array.from(
+      { length: LIGHT_DIFF_CEILINGS.maxFiles + 1 },
+      (_v, i) => `src/mod${i}.js`,
+    );
+    const r = checkLightDiffBackstop({
+      changedFiles: files,
+      injectedRules: RULES,
+    });
+    assert.equal(r.blocked, true);
+    assert.match(r.reasons.join(' '), /maxFiles/);
+  });
+
+  test('a diff intersecting a sensitive-path class is blocked', () => {
+    const r = checkLightDiffBackstop({
+      changedFiles: ['src/auth/session.js'],
+      injectedRules: RULES,
+    });
+    assert.equal(r.blocked, true);
+    assert.deepEqual(r.classes, ['security']);
+  });
+
+  test('an empty or unknown change set is blocked (cannot verify light)', () => {
+    for (const changedFiles of [[], null, undefined, 'x']) {
+      const r = checkLightDiffBackstop({ changedFiles });
+      assert.equal(r.blocked, true);
+    }
+  });
+
+  test('honors a caller ceiling but rejects a malformed one', () => {
+    const files = ['a.js', 'b.js', 'c.js'];
+    assert.equal(
+      checkLightDiffBackstop({
+        changedFiles: files,
+        ceilings: { maxFiles: 2 },
+        injectedRules: RULES,
+      }).blocked,
+      true,
+    );
+    // A malformed ceiling falls back to the framework default (not 0/∞).
+    assert.equal(
+      checkLightDiffBackstop({
+        changedFiles: files,
+        ceilings: { maxFiles: 0 },
+        injectedRules: RULES,
+      }).ceilings.maxFiles,
+      LIGHT_DIFF_CEILINGS.maxFiles,
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildReceiptStoryTicket (AC-5) — the minimal receipt carries prompt + footprint
+// ---------------------------------------------------------------------------
+
+describe('buildReceiptStoryTicket — minimal receipt Story (AC-5)', () => {
+  test('carries the prompt (goal + spec) and the diff-derived footprint', () => {
+    const ticket = buildReceiptStoryTicket({
+      prompt: 'Fix the footer copyright year',
+      changedFiles: ['src/footer.js', 'tests/footer.test.js'],
+    });
+    assert.match(ticket.body.goal, /footer copyright year/);
+    assert.match(ticket.body.spec, /Fix the footer copyright year/);
+    assert.deepEqual(
+      ticket.body.changes.map((c) => c.path),
+      ['src/footer.js', 'tests/footer.test.js'],
+    );
+    assert.ok(ticket.body.acceptance.length >= 1);
+    assert.ok(typeof ticket.slug === 'string' && ticket.slug.length > 0);
+  });
+
+  test('an amendment is prefixed and notes the amended issue', () => {
+    const ticket = buildReceiptStoryTicket({
+      prompt: 'tweak the label color',
+      changedFiles: ['src/label.js'],
+      amends: '#123',
+    });
+    assert.match(ticket.title, /^Amend #123:/);
+    assert.match(ticket.body.goal, /Amends #123\./);
+  });
+
+  test('rejects an empty prompt — a receipt with nothing to record', () => {
+    assert.throws(() => buildReceiptStoryTicket({ prompt: '' }), /prompt/);
+    assert.throws(() => buildReceiptStoryTicket({}), /prompt/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// deliver-light.js entry helpers — CSV / predicted-shape parsing
+// ---------------------------------------------------------------------------
+
+describe('deliver-light entry helpers', () => {
+  test('parseCsvPaths splits, trims, and drops empties', () => {
+    assert.deepEqual(parseCsvPaths(' a.js , b.js ,,'), ['a.js', 'b.js']);
+    assert.deepEqual(parseCsvPaths(''), []);
+    assert.deepEqual(parseCsvPaths(undefined), []);
+  });
+
+  test('buildPredictedChanges tags creates vs refactors', () => {
+    const changes = buildPredictedChanges({
+      creates: ['a.js'],
+      refactors: ['b.js'],
+    });
+    assert.deepEqual(changes, [
+      { path: 'a.js', assumption: 'creates' },
+      { path: 'b.js', assumption: 'refactors-existing' },
+    ]);
+  });
+
+  test('synthesizeAcceptance yields at least one criterion', () => {
+    assert.equal(synthesizeAcceptance(3).length, 3);
+    assert.equal(synthesizeAcceptance(0).length, 1);
+    assert.equal(synthesizeAcceptance(undefined).length, 1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// runLightGate + --amends (AC-3, AC-6) — shape-checked identically
+// ---------------------------------------------------------------------------
+
+describe('runLightGate — end-to-end gate over the entry inputs (AC-3, AC-6)', () => {
+  test('a small prompt with a ledgered lite verdict proceeds light', () => {
+    const gate = runLightGate({
+      prompt: 'add a bin/hello.js greeter',
+      creates: ['bin/hello.js'],
+      acceptance: 1,
+      route: 'lite',
+      reason: 'single additive file',
+      injectedRules: RULES,
+    });
+    assert.equal(gate.action, 'proceed-light');
+  });
+
+  test('a heavy prompt asks the operator (attended)', () => {
+    const gate = runLightGate({
+      prompt: 'rework the whole billing pipeline',
+      refactors: ['src/billing/a.js', 'src/billing/b.js', 'src/billing/c.js'],
+      acceptance: 5,
+      route: 'lite',
+      reason: 'claims small but is not',
+      injectedRules: RULES,
+    });
+    assert.equal(gate.action, 'ask-operator');
+  });
+
+  test('--amends: a SMALL amendment routes light', () => {
+    const gate = runLightGate({
+      prompt: 'fix the off-by-one in the counter',
+      refactors: ['src/counter.js'],
+      acceptance: 1,
+      route: 'lite',
+      reason: 'one-line fix in an existing file',
+      amends: '#4200',
+      injectedRules: RULES,
+    });
+    assert.equal(gate.action, 'proceed-light');
+  });
+
+  test('--amends: a HEAVY amendment escalates to /plan under --yes', () => {
+    const gate = runLightGate({
+      prompt: 'amend: overhaul auth and add a migration',
+      creates: ['src/auth/new.js'],
+      acceptance: 2,
+      route: 'lite',
+      reason: 'claims small but touches auth',
+      amends: '#4200',
+      yes: true,
+      injectedRules: RULES,
+    });
+    assert.equal(gate.action, 'escalate-plan');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildNextCommands + createLightReceipt (AC-1, AC-5, AC-8) — same engine
+// ---------------------------------------------------------------------------
+
+describe('buildNextCommands — hands off to the shared engine (AC-1, AC-8)', () => {
+  test('references single-story-init.js and single-story-close.js by name', () => {
+    const cmds = buildNextCommands(4741);
+    assert.match(cmds.init, /single-story-init\.js --story 4741/);
+    assert.match(cmds.close, /single-story-close\.js --story 4741/);
+  });
+});
+
+describe('createLightReceipt — authors the receipt via the plan-persist surface (AC-5)', () => {
+  test('assembles the ticket and creates it through createStoryIssues', async () => {
+    const calls = [];
+    const provider = {
+      createIssue: async (payload) => {
+        calls.push(payload);
+        return { id: 4741, url: 'https://example/4741' };
+      },
+    };
+    const receipt = await createLightReceipt({
+      provider,
+      prompt: 'add a bin/hello.js greeter',
+      changedFiles: ['bin/hello.js'],
+    });
+    assert.equal(receipt.storyId, 4741);
+    assert.equal(calls.length, 1);
+    assert.match(calls[0].body, /add a bin\/hello\.js greeter/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// runDiffBackstop (AC-4) — wraps computeChangeSet over the Story branch
+// ---------------------------------------------------------------------------
+
+describe('runDiffBackstop — re-checks the ACTUAL branch diff (AC-4)', () => {
+  test('a clean small diff is not blocked', () => {
+    const r = runDiffBackstop({
+      storyId: 4741,
+      injectedRules: RULES,
+      computeFn: () => ({ files: ['bin/hello.js'] }),
+    });
+    assert.equal(r.blocked, false);
+  });
+
+  test('an over-ceiling diff is blocked', () => {
+    const r = runDiffBackstop({
+      storyId: 4741,
+      injectedRules: RULES,
+      computeFn: () => ({
+        files: ['src/auth/a.js', 'b.js', 'c.js', 'd.js', 'e.js'],
+      }),
+    });
+    assert.equal(r.blocked, true);
+  });
+
+  test('an unenumerable diff (files: null) is blocked', () => {
+    const r = runDiffBackstop({
+      storyId: 4741,
+      computeFn: () => ({ files: null }),
+    });
+    assert.equal(r.blocked, true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AC-8 — the light entry contains NO parallel init/close implementation
+// ---------------------------------------------------------------------------
+
+describe('deliver-light.js is a thin entry point, not a second engine (AC-8)', () => {
+  const src = readFileSync(DELIVER_LIGHT_SRC, 'utf8');
+
+  test('names the shared engine scripts it hands off to', () => {
+    assert.match(src, /single-story-init\.js/);
+    assert.match(src, /single-story-close\.js/);
+  });
+
+  test('does not reimplement worktree / branch / PR / push mechanics', () => {
+    const forbidden = [
+      /worktree add/,
+      /checkout -b/,
+      /git push/,
+      /createPullRequest/,
+      /git branch /,
+    ];
+    for (const pat of forbidden) {
+      assert.doesNotMatch(
+        src,
+        pat,
+        `deliver-light.js must not reimplement engine mechanics (${pat})`,
+      );
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AC-7 — /deliver-light projects into the generated command tree
+// ---------------------------------------------------------------------------
+
+describe('/deliver-light projects via sync-claude-commands (AC-7)', () => {
+  test('the sync script writes .claude/commands/deliver-light.md', () => {
+    const dest = mkdtempSync(path.join(tmpdir(), 'light-cmd-'));
+    const result = spawnSync(
+      process.execPath,
+      [path.join(REPO_ROOT, '.agents', 'scripts', 'sync-claude-commands.js')],
+      {
+        cwd: REPO_ROOT,
+        env: {
+          ...process.env,
+          SYNC_CLAUDE_COMMANDS_SRC: path.join(
+            REPO_ROOT,
+            '.agents',
+            'workflows',
+          ),
+          SYNC_CLAUDE_COMMANDS_DEST: dest,
+        },
+        encoding: 'utf8',
+      },
+    );
+    assert.equal(result.status, 0, result.stderr);
+    assert.ok(
+      existsSync(path.join(dest, 'deliver-light.md')),
+      'deliver-light.md was not projected into the command tree',
+    );
+  });
+});


### PR DESCRIPTION
Closes #4740

_Auto-opened by `/deliver`._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New orchestration entry point that creates GitHub Stories and drives the standard close/merge path; mitigated by shared shape ceilings, diff backstop, and no duplicate git/PR logic.
> 
> **Overview**
> Adds **`/deliver-light`**, a thin workflow and CLI that skips the `/plan` session for genuinely small work while still landing through **`single-story-init.js`** and **`single-story-close.js`** unchanged.
> 
> **`light-suitability.js`** implements the decision core: predicted footprint must pass **`deriveStoryShape`** with the same **`STORY_SHAPE_CEILINGS`** now exported from **`complexity-gate.js`**, plus a ledgered `lite` verdict with a recorded reason; over-scope yields **`ask-operator`** or **`escalate-plan`** under **`--yes`**, not silent proceed. **`deliver-light.js`** runs the gate (creates a receipt Story via plan-persist **`createStoryIssues`**) or **`--backstop`** mode that blocks land when the real branch diff exceeds file/sensitive-path limits. Operator docs and the workflows index register the new slash command; unit tests cover the invariants and command projection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 51f441567158c0fc4730f3f9015c6404cf821f94. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->