### PR TITLE
feat: plan-phase turn diet: same artifacts, fewer round-trips, amendment-aware envelope (#4741)

### DIFF
--- a/.agents/scripts/lib/orchestration/plan-context.js
+++ b/.agents/scripts/lib/orchestration/plan-context.js
@@ -21,6 +21,7 @@ import { readFile } from 'node:fs/promises';
 import { getLimits } from '../config-resolver.js';
 import { findSimilarOpenStories } from '../duplicate-search.js';
 import { Logger } from '../Logger.js';
+import { parse as parseStoryBody } from '../story-body/story-body.js';
 import {
   renderAcceptanceSpecSystemPrompt,
   renderTechSpecSystemPrompt,
@@ -354,6 +355,111 @@ function resolveRiskHeuristics(config = {}) {
 }
 
 /**
+ * Ceilings a seed's advisory complexity signals must fit for the plan
+ * workflow to **suggest** `/deliver-light` at Gate #1 (Story #4741 R3 plan-side
+ * handshake). Framework constants, not operator knobs — mirroring the
+ * conservative intent of `complexity-gate.js`'s `STORY_SHAPE_CEILINGS`
+ * (small, mostly-additive, non-sensitive) but read against the *seed-time*
+ * signals rather than an authored Story shape.
+ *
+ * The suggestion is **advisory only and never an automatic reroute**: it
+ * surfaces at Gate #1 for the operator to decide, and under `--yes` it is
+ * recorded on the envelope while planning proceeds unchanged. `/deliver-light`
+ * is a sibling Story; these ceilings define the plan side of the routing
+ * handshake independently of it.
+ *
+ *   - `maxArtifacts`           — enumerated seed items (one artifact each).
+ *   - `maxRiskHeuristicHits`   — any risk-heuristic hit disqualifies: risk
+ *                                is exactly what a light path should not carry.
+ *   - `maxSensitivePathClasses`— any sensitive-path class disqualifies, the
+ *                                same taxonomy close applies to a landed diff.
+ */
+const DELIVER_LIGHT_SUGGESTION_CEILINGS = Object.freeze({
+  maxArtifacts: 2,
+  maxRiskHeuristicHits: 0,
+  maxSensitivePathClasses: 0,
+});
+
+/**
+ * Derive the advisory `/deliver-light` suggestion from a seed's complexity
+ * signals (Story #4741 AC-6). Pure and total: a malformed / missing signal
+ * bag fails conservative (not suggested), never throws.
+ *
+ * `automatic: false` is part of the contract — the suggestion is surfaced for
+ * the operator, never a silent reroute of a non-interactive run.
+ *
+ * @param {object|null|undefined} complexitySignals
+ * @returns {{
+ *   suggested: boolean,
+ *   automatic: false,
+ *   advisory: true,
+ *   ceilings: typeof DELIVER_LIGHT_SUGGESTION_CEILINGS,
+ *   reasons: string[],
+ * }}
+ */
+export function buildDeliverLightSuggestion(complexitySignals) {
+  const ceilings = DELIVER_LIGHT_SUGGESTION_CEILINGS;
+  const advisory = /** @type {const} */ (true);
+  const automatic = /** @type {const} */ (false);
+  const s = complexitySignals ?? {};
+  const artifactCount = Number.isInteger(s.artifactCount)
+    ? s.artifactCount
+    : Number.POSITIVE_INFINITY;
+  const riskHits = Array.isArray(s.riskHeuristicHits)
+    ? s.riskHeuristicHits.length
+    : Number.POSITIVE_INFINITY;
+  const sensitive = Array.isArray(s.sensitivePathClasses)
+    ? s.sensitivePathClasses.length
+    : Number.POSITIVE_INFINITY;
+
+  const reasons = [];
+  if (artifactCount > ceilings.maxArtifacts) {
+    reasons.push(
+      `seed enumerates ${artifactCount} artifacts (> ${ceilings.maxArtifacts})`,
+    );
+  }
+  if (riskHits > ceilings.maxRiskHeuristicHits) {
+    reasons.push(`seed hits ${riskHits} risk-heuristic phrase(s)`);
+  }
+  if (sensitive > ceilings.maxSensitivePathClasses) {
+    reasons.push(
+      `predicted footprint touches ${sensitive} sensitive-path class(es)`,
+    );
+  }
+
+  const suggested = reasons.length === 0;
+  return {
+    suggested,
+    automatic,
+    advisory,
+    ceilings,
+    reasons: suggested
+      ? [
+          `seed fits the /deliver-light ceilings (≤${ceilings.maxArtifacts} artifacts, ` +
+            'no risk-heuristic hits, no sensitive-path classes) — the operator ' +
+            'may prefer /deliver-light for this scope',
+        ]
+      : reasons,
+  };
+}
+
+/**
+ * Attach the advisory `/deliver-light` suggestion to a complexity-signals bag
+ * as a **nested** field (Story #4741). Nesting — rather than a new top-level
+ * envelope key — keeps every existing per-mode envelope key set byte-stable
+ * (AC-5): the suggestion is derived from the signals it rides on.
+ *
+ * @param {object} complexitySignals
+ * @returns {object} the same signals plus `deliverLightSuggestion`.
+ */
+function withDeliverLightSuggestion(complexitySignals) {
+  return {
+    ...complexitySignals,
+    deliverLightSuggestion: buildDeliverLightSuggestion(complexitySignals),
+  };
+}
+
+/**
  * Count top-level enumerated items (`- `, `* `, `1. `) under the first
  * scope-shaped `## ` heading (Scope / MVP Scope / Proposed Scope / Work
  * Breakdown / Capabilities), up to the next `## ` heading. Returns `null`
@@ -588,13 +694,17 @@ async function buildSeedFileModeEnvelope({
     seed: { path: seedFilePath ?? null, content },
     // Advisory complexity signals only (Story #4722): no route, no routing
     // authority. The planner authors the trivial-vs-standard verdict; persist
-    // validates a lite claim against the authored Story's shape.
-    complexitySignals: buildComplexitySignals({
-      seedText: content,
-      config,
-      riskHeuristics: heuristics,
-      cwd,
-    }),
+    // validates a lite claim against the authored Story's shape. The nested
+    // `deliverLightSuggestion` is the advisory plan-side routing handshake
+    // (Story #4741 AC-6) — never an automatic reroute.
+    complexitySignals: withDeliverLightSuggestion(
+      buildComplexitySignals({
+        seedText: content,
+        config,
+        riskHeuristics: heuristics,
+        cwd,
+      }),
+    ),
     duplicates,
     docsContext,
     codebaseSnapshot: authoring.codebaseSnapshot,
@@ -748,12 +858,14 @@ async function buildTicketsModeEnvelope({
     mode: 'tickets',
     sourceTickets,
     seed: { text: seed, path: null },
-    complexitySignals: buildComplexitySignals({
-      seedText: seed,
-      config,
-      riskHeuristics: heuristics,
-      cwd,
-    }),
+    complexitySignals: withDeliverLightSuggestion(
+      buildComplexitySignals({
+        seedText: seed,
+        config,
+        riskHeuristics: heuristics,
+        cwd,
+      }),
+    ),
     duplicates,
     docsContext,
     codebaseSnapshot: authoring.codebaseSnapshot,
@@ -780,6 +892,122 @@ async function buildTicketsModeEnvelope({
 }
 
 /**
+ * Parse a prior Story body into its acceptance criteria and delivered file
+ * map. Total: an unparseable body degrades to empty lists (a delta envelope
+ * grounded on whatever survived), never a throw.
+ *
+ * @param {string} priorBody
+ * @returns {{ priorAcceptance: string[], deliveredFiles: string[] }}
+ */
+function extractPriorArtifacts(priorBody) {
+  let parsed;
+  try {
+    parsed = parseStoryBody(priorBody).body;
+  } catch {
+    return { priorAcceptance: [], deliveredFiles: [] };
+  }
+  const priorAcceptance = Array.isArray(parsed.acceptance)
+    ? parsed.acceptance.filter((a) => typeof a === 'string' && a.length > 0)
+    : [];
+  const deliveredFiles = Array.isArray(parsed.changes)
+    ? parsed.changes
+        .map((c) => (c && typeof c === 'object' ? c.path : c))
+        .filter((p) => typeof p === 'string' && p.length > 0)
+    : [];
+  return { priorAcceptance, deliveredFiles };
+}
+
+/**
+ * Build the amendment (delta) envelope — `plan-context --amends #<id>`
+ * (Story #4741 AC-4, R3-A). The heavy-amendment counterpart to routing a
+ * light amendment through `/deliver-light`: instead of re-interrogating the
+ * repo from scratch (`buildAuthoringContext`'s codebase snapshot and the BDD /
+ * memory / feedback probes), the envelope composes a DELTA from what already
+ * exists — the prior Story's body, its acceptance criteria (the real
+ * contract), and its delivered file map — so a follow-up change plans from the
+ * shape already shipped.
+ *
+ * The semantic steps that reach the ticket are preserved: the open-Story
+ * duplicate search (excluding the amended Story itself), the risk heuristics,
+ * and the authoring system prompts all still ride the envelope. What is
+ * dropped is only the from-scratch repo interrogation the prior artifacts
+ * already stand in for — that is the round-trip diet, not an amputation.
+ *
+ * @param {{
+ *   amendsId: number,
+ *   provider: object,
+ *   config: object,
+ *   settings: object,
+ *   cwd?: string,
+ * }} args
+ * @returns {Promise<object>}
+ */
+async function buildAmendmentModeEnvelope({
+  amendsId,
+  provider,
+  config,
+  settings: _settings,
+  cwd,
+}) {
+  if (!provider || typeof provider.getTicket !== 'function') {
+    throw new Error(
+      '[plan-context] --amends requires provider.getTicket() to load the prior Story.',
+    );
+  }
+  const prior = await provider.getTicket(amendsId);
+  if (!prior) {
+    throw new Error(
+      `[plan-context] --amends #${amendsId}: prior Story not found — nothing to amend.`,
+    );
+  }
+  const priorBody = typeof prior.body === 'string' ? prior.body : '';
+  const { priorAcceptance, deliveredFiles } = extractPriorArtifacts(priorBody);
+
+  const heuristics = resolveRiskHeuristics(config);
+  const limits = getLimits(config);
+  const duplicates = await searchStoryDuplicates({
+    seed: priorBody,
+    provider,
+    config,
+    excludeIds: [amendsId],
+  });
+
+  return {
+    mode: 'amends',
+    amends: {
+      id: Number(prior.id ?? prior.number ?? amendsId),
+      title: prior.title ?? '',
+      priorBody,
+      priorAcceptance,
+      deliveredFiles,
+    },
+    // The prior body is the seed the delta is authored against.
+    seed: { text: priorBody, path: null },
+    complexitySignals: withDeliverLightSuggestion(
+      buildComplexitySignals({
+        seedText: priorBody,
+        config,
+        riskHeuristics: heuristics,
+        cwd,
+      }),
+    ),
+    duplicates,
+    // No plan temp dir and no from-scratch repo interrogation — the prior
+    // artifacts are the grounding, so there is no docs digest to anchor.
+    docsContext: null,
+    ticketSchema: TICKET_SCHEMA_DESCRIPTOR,
+    maxTickets: limits.maxTickets,
+    riskHeuristics: heuristics,
+    systemPrompts: buildSystemPrompts({
+      heuristics,
+      maxTickets: limits.maxTickets,
+    }),
+    planState: null,
+    planProfile: 'story-amendment',
+  };
+}
+
+/**
  * Build the single planner-context envelope.
  *
  * Every mode returns through here, which makes this the one place the
@@ -787,11 +1015,12 @@ async function buildTicketsModeEnvelope({
  * bound it (see {@link assertPlanContextWithinCeiling}).
  *
  * @param {{
- *   mode: 'seed-file'|'seed'|'tickets',
+ *   mode: 'seed-file'|'seed'|'tickets'|'amends',
  *   seedFilePath?: string,
  *   seedFileContent?: string,
  *   seedText?: string,
  *   ticketIds?: number[],
+ *   amendsId?: number,
  *   provider: object,
  *   config: object,
  *   settings: object,
@@ -805,6 +1034,7 @@ export async function buildPlanContext({
   seedFileContent,
   seedText,
   ticketIds,
+  amendsId,
   provider,
   config = {},
   settings = {},
@@ -817,6 +1047,7 @@ export async function buildPlanContext({
       seedFileContent,
       seedText,
       ticketIds,
+      amendsId,
       provider,
       config,
       settings,
@@ -835,11 +1066,21 @@ async function buildPlanContextEnvelope({
   seedFileContent,
   seedText,
   ticketIds,
+  amendsId,
   provider,
   config,
   settings,
   cwd,
 }) {
+  if (mode === 'amends') {
+    return buildAmendmentModeEnvelope({
+      amendsId,
+      provider,
+      config,
+      settings,
+      cwd,
+    });
+  }
   if (mode === 'seed-file') {
     if (!seedFilePath && typeof seedFileContent !== 'string') {
       throw new Error(
@@ -875,6 +1116,6 @@ async function buildPlanContextEnvelope({
     });
   }
   throw new Error(
-    `[plan-context] unknown mode "${mode}" — expected "seed", "seed-file", or "tickets".`,
+    `[plan-context] unknown mode "${mode}" — expected "seed", "seed-file", "tickets", or "amends".`,
   );
 }

--- a/.agents/scripts/plan-context.js
+++ b/.agents/scripts/plan-context.js
@@ -17,6 +17,12 @@
  *   --tickets 123[,456…]      Analyze existing issue(s) into proper
  *                             Stories. Envelope carries `sourceTickets[]`.
  *
+ *   --amends 123 | #123       Amendment (delta) planning. Composes a DELTA
+ *                             envelope from the prior Story's body, its
+ *                             acceptance criteria, and its delivered file map
+ *                             instead of re-interrogating the repo from
+ *                             scratch (Story #4741). Envelope carries `amends`.
+ *
  * Flags:
  *   --out <path>     Write the envelope to <path> (parent dirs created).
  *                    `/plan` points this at `<plan-dir>/plan-context.json`,
@@ -84,6 +90,25 @@ export function parseTicketIds(raw) {
 }
 
 /**
+ * Parse a single `--amends` id, tolerating a leading `#` (`#123` or `123`).
+ *
+ * @param {string} raw
+ * @returns {number}
+ */
+export function parseAmendsId(raw) {
+  if (typeof raw !== 'string' || raw.trim().length === 0) {
+    throw new Error('--amends requires a single prior Story id.');
+  }
+  const id = Number(raw.trim().replace(/^#/, ''));
+  if (!Number.isInteger(id) || id <= 0) {
+    throw new Error(
+      `--amends expects a positive integer Story id; got ${JSON.stringify(raw)}`,
+    );
+  }
+  return id;
+}
+
+/**
  * Build the envelope and write it to `stdout` as a single JSON line
  * (or pretty-printed with --pretty). Exported for tests.
  *
@@ -96,6 +121,7 @@ export async function emitPlanContext({
   seedFileContent,
   seedText,
   ticketIds,
+  amendsId,
   provider,
   config,
   settings,
@@ -110,6 +136,7 @@ export async function emitPlanContext({
     seedFileContent,
     seedText,
     ticketIds,
+    amendsId,
     provider,
     config,
     settings,
@@ -139,14 +166,19 @@ export async function emitPlanContext({
       duplicates: (envelope.duplicates ?? []).length,
       // Advisory only (Story #4722): signals, no route — the planner owns
       // the trivial-vs-standard verdict and persist validates it by shape.
+      // The nested `deliverLightSuggestion` is the recorded plan-side routing
+      // handshake (Story #4741 AC-6) — advisory, never an automatic reroute.
       complexitySignals: envelope.complexitySignals
         ? {
             artifactCount: envelope.complexitySignals.artifactCount,
             riskHeuristicHits: envelope.complexitySignals.riskHeuristicHits,
             sensitivePathClasses:
               envelope.complexitySignals.sensitivePathClasses,
+            deliverLightSuggestion:
+              envelope.complexitySignals.deliverLightSuggestion ?? null,
           }
         : null,
+      amends: envelope.amends ? { id: envelope.amends.id } : null,
     };
     stdout.write(`${JSON.stringify(digest)}\n`);
   } else {
@@ -221,6 +253,7 @@ async function main() {
       seed: { type: 'string' },
       'seed-file': { type: 'string' },
       tickets: { type: 'string' },
+      amends: { type: 'string' },
       out: { type: 'string' },
       pretty: { type: 'boolean', default: false },
     },
@@ -234,16 +267,24 @@ async function main() {
     typeof seedFilePath === 'string' && seedFilePath.length > 0;
   const hasTickets =
     typeof values.tickets === 'string' && values.tickets.trim().length > 0;
-  const entryForms = [hasSeed, hasSeedFile, hasTickets].filter(Boolean).length;
+  const hasAmends =
+    typeof values.amends === 'string' && values.amends.trim().length > 0;
+  const entryForms = [hasSeed, hasSeedFile, hasTickets, hasAmends].filter(
+    Boolean,
+  ).length;
   if (entryForms !== 1) {
     throw new Error(
-      'Pass exactly one of --seed "<text>", --seed-file <path>, or --tickets <ids>.',
+      'Pass exactly one of --seed "<text>", --seed-file <path>, --tickets <ids>, or --amends <id>.',
     );
   }
 
   let mode;
   let ticketIds;
-  if (hasTickets) {
+  let amendsId;
+  if (hasAmends) {
+    mode = 'amends';
+    amendsId = parseAmendsId(values.amends);
+  } else if (hasTickets) {
     mode = 'tickets';
     ticketIds = parseTicketIds(values.tickets);
   } else if (hasSeedFile) {
@@ -288,6 +329,7 @@ async function main() {
         seedFilePath: hasSeedFile ? seedFilePath : undefined,
         seedText: hasSeed ? seedText : undefined,
         ticketIds,
+        amendsId,
         provider,
         config,
         settings,

--- a/.agents/scripts/plan-persist.js
+++ b/.agents/scripts/plan-persist.js
@@ -44,6 +44,15 @@
  *   --no-close-superseded     Keep the source tickets open (no comment, no
  *                             close) — for a genuinely partial supersede
  *   --dry-run                 Assemble + validate without GitHub writes
+ *   --chain-on-clean          Plan-diet fast path (Story #4741): run the
+ *                             write-free dry-run first, and — only when it
+ *                             passes clean AND the plan resolves to the `lite`
+ *                             route — chain straight into the real persist in
+ *                             the SAME invocation, collapsing the two operator
+ *                             round-trips into one. A dry-run failure stops
+ *                             before any createIssue; a full-route plan keeps
+ *                             its review round-trip (the chain declines, no
+ *                             writes). Ignored when `--dry-run` is also set
  *   --force-review            Operator-forced review stop before persist lands
  *   --allow-over-budget / --allow-large-fan-out
  *
@@ -111,6 +120,7 @@ const CLI_OPTIONS = {
   'close-superseded': { type: 'boolean', default: true },
   'no-close-superseded': { type: 'boolean', default: false },
   'dry-run': { type: 'boolean', default: false },
+  'chain-on-clean': { type: 'boolean', default: false },
   'force-review': { type: 'boolean', default: false },
   'allow-over-budget': { type: 'boolean', default: false },
   'allow-large-fan-out': { type: 'boolean', default: false },
@@ -122,7 +132,7 @@ const USAGE =
   '[--plan-acceptance <file>] ' +
   '[--source-tickets <ids>] [--no-close-superseded] ' +
   '[--route-downgrade-reason <text>] ' +
-  '[--dry-run] [--force-review] ' +
+  '[--dry-run] [--chain-on-clean] [--force-review] ' +
   '[--allow-over-budget] [--allow-large-fan-out]';
 
 async function readOptional(filePath, { required }) {
@@ -229,8 +239,11 @@ async function runPersistInvocation({
   provider,
   artifacts,
   metricsSince,
+  dryRun,
 }) {
   const paths = resolveInputPaths(values);
+  const effectiveDryRun =
+    typeof dryRun === 'boolean' ? dryRun : values['dry-run'] === true;
   const settings = {
     baseBranch: config.project?.baseBranch,
     paths: config.project?.paths,
@@ -241,7 +254,7 @@ async function runPersistInvocation({
   return recordPlanInvocation(
     {
       cli: 'plan-persist',
-      mode: values['dry-run'] ? 'dry-run' : 'persist',
+      mode: effectiveDryRun ? 'dry-run' : 'persist',
       config,
     },
     () =>
@@ -252,10 +265,81 @@ async function runPersistInvocation({
         settings,
         opts: {
           ...buildPersistOptions(values, paths, artifacts.planContextEnvelope),
+          dryRun: effectiveDryRun,
+          skipCleanup: effectiveDryRun,
           metricsSince,
         },
       }),
   );
+}
+
+/**
+ * Plan-diet fast path (Story #4741 AC-1/AC-3): chain the lite dry-run into the
+ * real persist in ONE operator invocation.
+ *
+ * Two passes over the **same** loaded artifacts:
+ *
+ *   1. A write-free dry-run. Every gate runs before any `createIssue` can
+ *      happen, so a validation failure — which throws or returns reachability
+ *      orphans — stops here, before a single issue exists (AC-3).
+ *   2. The real write, run **only** when the dry-run passed clean AND resolved
+ *      to the `lite` route. Because it replays the identical artifacts, the
+ *      persisted output is byte-identical to what the dry-run validated
+ *      (AC-1). A full-route plan keeps its review round-trip: the chain
+ *      declines and returns the dry-run result, mutating nothing.
+ *
+ * Exported for tests — this is where the round-trip collapse and its
+ * fail-closed guard live, so a regression here silently re-opens the second
+ * operator round-trip (or worse, persists a plan the dry-run never gated).
+ *
+ * @param {{ values: object, config: object, provider: object,
+ *   artifacts: object, metricsSince: string }} args
+ * @returns {Promise<object>} the persist result, plus a `chain` receipt.
+ */
+export async function runPersistChain({
+  values,
+  config,
+  provider,
+  artifacts,
+  metricsSince,
+}) {
+  const dryResult = await runPersistInvocation({
+    values,
+    config,
+    provider,
+    artifacts,
+    metricsSince,
+    dryRun: true,
+  });
+
+  if (dryResult.route?.route !== 'lite') {
+    dryResult.chain = {
+      attempted: true,
+      persisted: false,
+      reason: 'route-not-lite',
+    };
+    Logger.info(
+      '[plan-persist] --chain-on-clean: dry-run clean but the plan did not ' +
+        'resolve to the lite route — declining the auto-persist; run persist ' +
+        'explicitly after review.',
+    );
+    return dryResult;
+  }
+
+  const persistResult = await runPersistInvocation({
+    values,
+    config,
+    provider,
+    artifacts,
+    metricsSince,
+    dryRun: false,
+  });
+  persistResult.chain = {
+    attempted: true,
+    persisted: true,
+    reason: 'lite-dry-run-clean',
+  };
+  return persistResult;
 }
 
 /**
@@ -318,15 +402,28 @@ async function main() {
   const paths = resolveInputPaths(values);
   const artifacts = await loadArtifacts(paths);
 
+  // `--chain-on-clean` collapses the dry-run + persist operator round-trips
+  // (Story #4741). `--dry-run` always wins — an explicit dry-run never writes.
+  const useChain =
+    values['chain-on-clean'] === true && values['dry-run'] !== true;
+
   let result;
   try {
-    result = await runPersistInvocation({
-      values,
-      config,
-      provider,
-      artifacts,
-      metricsSince,
-    });
+    result = useChain
+      ? await runPersistChain({
+          values,
+          config,
+          provider,
+          artifacts,
+          metricsSince,
+        })
+      : await runPersistInvocation({
+          values,
+          config,
+          provider,
+          artifacts,
+          metricsSince,
+        });
   } catch (err) {
     if (err?.code === 'PLAN_REACHABILITY_ORPHANS') {
       process.stdout.write(`${err.message}\n`);

--- a/.agents/workflows/plan.md
+++ b/.agents/workflows/plan.md
@@ -7,8 +7,7 @@ description:
 
 # /plan --seed "<text>" | --seed-file <path> | --tickets <ids>
 
-> **Lean spine.** Happy path + gate list; edge-case and reference detail
-> lives in the on-demand
+> **Lean spine.** Happy path + gate list; edge-case detail lives in on-demand
 > [`helpers/plan-reference.md`](helpers/plan-reference.md).
 
 ## Inputs
@@ -20,10 +19,9 @@ Epic/Story router, no scope-triage `epic|story` verdict:
 | --- | --- |
 | `/plan --seed "<text>"` / `--seed-file <path>` | Ideation from chat text or on-disk notes: interrogate → author **one Story by default** → persist. |
 | `/plan --tickets 123[,456…]` | Fetch issue(s), analyze into proper Stories (prefer N=1 rewrite). |
-| `/plan --amends #<id>` | Amend a shipped Story: interrogate composes a **delta envelope** from the prior body, its acceptance criteria, and its delivered file map — no from-scratch repo re-interrogation (Story #4741). |
+| `/plan --amends #<id>` | Amend a shipped Story from a **delta envelope** (prior body + acceptance + delivered file map), not a from-scratch re-interrogation (#4741). |
 
-`--body` is **not** a `/plan` entry; persist always goes through
-`plan-persist.js`.
+`--body` is **not** a `/plan` entry; persist always goes through `plan-persist.js`.
 
 ## Flags
 
@@ -31,25 +29,24 @@ Epic/Story router, no scope-triage `epic|story` verdict:
 | --- | --- |
 | `--seed "<text>"` / `--seed-file <path>` | Seed text / pre-authored notes path. |
 | `--tickets <ids>` | Issue ids to analyze; closed as superseded at persist. |
-| `--amends #<id>` | Prior Story to amend; interrogate emits a delta envelope, not a full re-interrogation (Story #4741). |
-| `--chain-on-clean` (persist) | Plan-diet fast path: chain the lite dry-run straight into the real persist in one operator round-trip when it passes clean; a full-route plan keeps its review round-trip (Story #4741). |
+| `--amends #<id>` | Prior Story to amend; emits a delta envelope, not a full re-interrogation (#4741). |
+| `--chain-on-clean` | Persist: chain a clean lite dry-run into the real persist in one round-trip; full-route plans keep the review round-trip (#4741). |
 | `--no-close-superseded` | Keep the source issues open — no supersede comment, no close. |
-| `--force-review` | STOP at gate #2 for operator review — the only review gate (Story #4542). |
-| `--route-downgrade-reason "<text>"` | Authored `lite` verdict + reason (Story #4722), ledgered per Story; shape-validated, fails closed to `full`. |
+| `--force-review` | STOP at gate #2 for operator review — the only review gate (#4542). |
+| `--route-downgrade-reason "<text>"` | Authored `lite` verdict + reason (#4722); shape-validated, fails closed to `full`. |
 | `--allow-over-budget` | Permit a plan exceeding `maxTickets`. |
 | `--yes` | Non-interactive: auto-proceed gate #1 and gate #2 HITL waits. |
 | `--dry-run` | Author + validate without GitHub writes; run as a pre-pass. |
 
 ## Default-single split policy
 
-Author **one Story** unless (1) the pieces have **near-zero overlap**
-(genuinely independent capabilities), or (2) there is an **architectural
-seam** (different deployables, migration vs consumer). Coupled work stays
-one Story — decompose it inside `## Slicing` as intra-session checkpoints,
-not sibling tickets. When N>1, every acceptance criterion belongs to exactly
-one Story (`assertAcceptancePartition` refuses coupled splits). **N=1 is the
-lean path:** one authoring prompt, folded `## Spec`, light risk/critic
-profile — no Epic-scale ceremony.
+Author **one Story** unless the pieces have **near-zero overlap** (genuinely
+independent capabilities) or sit across an **architectural seam** (different
+deployables, migration vs consumer). Coupled work stays one Story —
+`## Slicing` intra-session checkpoints, not sibling tickets; when N>1 every
+acceptance criterion belongs to exactly one Story
+(`assertAcceptancePartition` refuses coupled splits). **N=1 is the lean
+path:** one authoring prompt, folded `## Spec`, no Epic-scale ceremony.
 
 ## Procedure
 
@@ -58,83 +55,52 @@ profile — no Epic-scale ceremony.
 ```bash
 node .agents/scripts/plan-context.js --seed "<seed>" \
   --out temp/plan-<slug>/plan-context.json
-# or: --seed-file <path>
-# or: --tickets 123,456
-# or: --amends #<id>   (delta envelope from a shipped Story — Story #4741)
+# or: --seed-file <path>  |  --tickets 123,456  |  --amends #<id>
 ```
 
-**Amendment planning (`--amends #<id>`, Story #4741 R3-A).** The heavy-amendment
-counterpart to routing a light change through `/deliver-light`: the envelope is
-a **delta** — the prior Story's body, its acceptance criteria, and its delivered
-file map — instead of a from-scratch repo interrogation, so a follow-up plans
-from what already shipped. The pipeline shape is unchanged; only its inputs
-shrink.
+**Always pass `--out`.** Persist auto-discovers that envelope from `--plan-dir`
+and derives source-ticket ids from its `sourceTickets[]` (#4554); the CLI also
+writes **`stories.template.json`** — the authoring skeleton step 2 starts from.
 
-**Always pass `--out`.** Persist auto-discovers that envelope from
-`--plan-dir` and derives source-ticket ids from its `sourceTickets[]`
-(Story #4554); the CLI also writes **`stories.template.json`** — the
-authoring skeleton step 2 starts from.
-
-The envelope carries docs context, codebase snapshot, the story-author
-prompt, `sourceTickets[]`, `duplicates[]` (open **Stories** overlapping the
-seed — never Epics), and advisory `complexitySignals` (**no routing
-authority**, Story #4722). A genuinely trivial scope earns
-`--route-downgrade-reason "<why>"` at persist — shape-validated, failing
-closed to `full`. Detail:
-[`helpers/plan-reference.md` § Shape-derived routing](helpers/plan-reference.md).
-Under `--yes`, do not ask free-form operator questions — unresolved
-unknowns land in Key Assumptions.
+The envelope carries docs context, the codebase snapshot, the story-author
+prompt, `sourceTickets[]`, `duplicates[]` (open **Stories**, never Epics), and
+advisory `complexitySignals` (**no routing authority**, #4722). A trivial scope
+earns `--route-downgrade-reason "<why>"` at persist — shape-validated, failing
+closed to `full`
+([detail](helpers/plan-reference.md)).
+Under `--yes`, do not ask free-form operator questions — unresolved unknowns
+land in Key Assumptions.
 
 **Gate #1** — STOP to confirm the sharpened plan intent and any
-duplicate-candidate review. When the envelope's
-`complexitySignals.deliverLightSuggestion.suggested` is `true` (the seed fits
-the `/deliver-light` ceilings — ≤2 artifacts, no risk-heuristic hit, no
-sensitive-path class), surface an **advisory** suggestion to use
-`/deliver-light` instead; the operator always decides. Under `--yes`, do not
-reroute — record the suggestion (it rides the envelope) and proceed with
-planning. **Never an automatic reroute** (Story #4741 AC-6).
+duplicate-candidate review. Under `--yes`, auto-proceed. When
+`complexitySignals.deliverLightSuggestion.suggested` is `true`, surface an
+**advisory** `/deliver-light` suggestion — the operator decides; under `--yes`
+it is recorded and planning proceeds, **never an automatic reroute** (#4741).
 
 ### 2. Author
 
 **One-shot authoring (Story #4707).** Start from `stories.template.json`;
 author `stories.json` in one pass. Entries are pre-resolved (#4723); keep
-tiers/assumptions valid. `body` is a
-markdown string **or** a structured object; persist parses either,
-serializes the canonical markdown, and syncs the top-level `acceptance[]` /
-`verify[]` into the body — never dual-author those lists.
+tiers/assumptions valid. `body` is a markdown string **or** a structured
+object; persist parses either, serializes the canonical markdown, and syncs the
+top-level `acceptance[]` / `verify[]` into it — never dual-author those lists.
 
-```jsonc
-// temp/plan-<slug>/stories.json
-[
-  {
-    "slug": "hyphen-case-slug", // ^[a-z0-9][a-z0-9-]*$
-    "type": "story",
-    "title": "Short descriptive title",
-    "body": {
-      "goal": "One sentence: why this Story exists.",
-      "spec": "Optional — contract and invariants.",
-      "changes": [{ "path": "path/to/file.ext", "assumption": "refactors-existing" }], // creates | refactors-existing | deletes
-      "non_goals": [],
-      "reason_to_exist": "One coherent reason this Story exists."
-    },
-    "acceptance": ["A testable, observable criterion"],
-    "verify": ["exact command (unit|contract|e2e|validate)"],
-    "depends_on": [] // sibling Story slugs, N>1 only
-  }
-]
-```
+Each entry (the `stories.template.json` shape): `slug`
+(`^[a-z0-9][a-z0-9-]*$`), `type: "story"`, `title`, `body` (`goal`, optional
+`spec`, `changes[{path, assumption}]` — `creates|refactors-existing|deletes`,
+`non_goals`, `reason_to_exist`), top-level `acceptance[]`, `verify[]`
+(`… (unit|contract|e2e|validate)`), `depends_on[]` (N>1 only).
 
 Artifacts under `temp/plan-<slug>/`: `stories.json`
 (**length 1 by default**; over-budget Specs fail closed — split or tighten,
-never write Specs under `docs/`); optional `techspec.md` (**N===1 only** —
-folded into `## Spec`); optional `acceptance-manifest.json` (N>1 partition
-list — pass as `--plan-acceptance` or it is not read). For N=1,
-use the envelope `systemPrompts.story` and emit one cohesive Story.
-Split only under the policy above.
+never under `docs/`); optional `techspec.md` (**N===1 only** — folded into
+`## Spec`); optional `acceptance-manifest.json` (N>1 partition list — pass as
+`--plan-acceptance`). For N=1, use the envelope `systemPrompts.story` and emit
+one cohesive Story. Split only under the policy above.
 
-**Tickets mode:** every Story authors a top-level `supersedes[]` claiming
-the source issues it replaces; persist refuses a partial map (shape:
-[`helpers/plan-reference.md` § Tickets mode](helpers/plan-reference.md)).
+**Tickets mode:** every Story authors a top-level `supersedes[]` claiming the
+source issues it replaces; persist refuses a partial map
+([shape](helpers/plan-reference.md)).
 
 ### 2.5 Critics
 
@@ -164,9 +130,9 @@ ledgered: **do not proceed to Persist**; fix and re-run.
 **only** trigger). Under `--yes`, auto-proceed.
 
 Run persist with `--dry-run` **first** — same command, GitHub writes
-suppressed; every gate (ticket validator, body parse, DAG, capacity,
-budget, reachability, split-policy and supersede partitions, Spec fold)
-runs before the first `createIssue`. Then:
+suppressed; every gate (validator, body parse, DAG, capacity, budget,
+reachability, split/supersede partitions, Spec fold) runs before the first
+`createIssue`. Then:
 
 ```bash
 node .agents/scripts/plan-persist.js \
@@ -177,39 +143,29 @@ node .agents/scripts/plan-persist.js \
   [--source-tickets 123,456] [...flags from the table above]
 ```
 
-**Plan-diet fast path (`--chain-on-clean`, Story #4741 AC-3).** At lite shape,
-pass `--chain-on-clean` alongside `--route-downgrade-reason "<why>"`: persist
-runs the write-free dry-run first and, **only** when it passes clean and
-resolves to the `lite` route, chains straight into the real persist in the same
-invocation — one operator round-trip instead of two. A dry-run validation
-failure stops before any `createIssue`; a full-route plan keeps its review
-round-trip (the chain declines, writes nothing). Every semantic gate still runs
-on the dry-run pass.
+At lite shape, `--chain-on-clean` chains that dry-run into the real persist in
+one round-trip **only** when it is clean and `lite`; a full-route plan keeps
+its review round-trip (#4741).
 
-Persist creates Story issue(s) with `type::story` plus a `plan-run::<id>`
-grouping label (**metadata only** — never a delivery-resolution input, Story #4692); N>1 `depends_on` edges become `blocked by #<id>` body footers.
-`agent::ready` is the **terminal** flip, after all receipts are upserted — a
-ready Story is always fully persisted (Story #4541). stdout is pure JSON
-(logs on stderr).
+Persist creates `type::story` issue(s) plus a `plan-run::<id>` grouping label
+(**metadata only**, #4692); N>1 `depends_on` edges become `blocked by #<id>`
+footers. `agent::ready` is the **terminal** flip after all receipts land — a
+ready Story is fully persisted (#4541). stdout is pure JSON.
 
-In `--tickets` mode persist resolves source ids **envelope-first** and
-closes each superseded source as `not_planned` with a comment (default on).
-Detail (channels, close contract, resume, temp hygiene):
-[`helpers/plan-reference.md`](helpers/plan-reference.md) — on a stranded
-persist, re-run the same command; never hand-delete issues.
+In `--tickets` mode persist resolves source ids **envelope-first** and closes
+each as `not_planned` with a comment (default on;
+[detail](helpers/plan-reference.md)). On a stranded persist, re-run the same
+command — never hand-delete issues.
 
 ## Constraints
 
-- `/plan` never starts delivery. No Epic ticket, no reconciler, no
-  `delivery::single` marker.
-- Duplicate search targets open Stories (`type::story`), not Epics.
+- `/plan` never starts delivery — no Epic ticket, no reconciler. Duplicate
+  search targets open Stories (`type::story`), not Epics.
 - Deterministic gates still fail closed under `--yes`.
 
 ## See also
 
-- [`/deliver`](deliver.md) — delivery entry point.
-- [`/audit-to-stories`](audit-to-stories.md) — audit findings → plan seed.
-- [`helpers/plan-reference.md`](helpers/plan-reference.md) — on-demand
-  detail.
+- [`/deliver`](deliver.md), [`/audit-to-stories`](audit-to-stories.md),
+  [`helpers/plan-reference.md`](helpers/plan-reference.md) — on-demand detail.
 - [`core/scope-triage`](../skills/core/scope-triage/SKILL.md) — optional
   split-advisory notes only (no routing verdict).

--- a/.agents/workflows/plan.md
+++ b/.agents/workflows/plan.md
@@ -20,6 +20,7 @@ Epic/Story router, no scope-triage `epic|story` verdict:
 | --- | --- |
 | `/plan --seed "<text>"` / `--seed-file <path>` | Ideation from chat text or on-disk notes: interrogate → author **one Story by default** → persist. |
 | `/plan --tickets 123[,456…]` | Fetch issue(s), analyze into proper Stories (prefer N=1 rewrite). |
+| `/plan --amends #<id>` | Amend a shipped Story: interrogate composes a **delta envelope** from the prior body, its acceptance criteria, and its delivered file map — no from-scratch repo re-interrogation (Story #4741). |
 
 `--body` is **not** a `/plan` entry; persist always goes through
 `plan-persist.js`.
@@ -30,6 +31,8 @@ Epic/Story router, no scope-triage `epic|story` verdict:
 | --- | --- |
 | `--seed "<text>"` / `--seed-file <path>` | Seed text / pre-authored notes path. |
 | `--tickets <ids>` | Issue ids to analyze; closed as superseded at persist. |
+| `--amends #<id>` | Prior Story to amend; interrogate emits a delta envelope, not a full re-interrogation (Story #4741). |
+| `--chain-on-clean` (persist) | Plan-diet fast path: chain the lite dry-run straight into the real persist in one operator round-trip when it passes clean; a full-route plan keeps its review round-trip (Story #4741). |
 | `--no-close-superseded` | Keep the source issues open — no supersede comment, no close. |
 | `--force-review` | STOP at gate #2 for operator review — the only review gate (Story #4542). |
 | `--route-downgrade-reason "<text>"` | Authored `lite` verdict + reason (Story #4722), ledgered per Story; shape-validated, fails closed to `full`. |
@@ -57,7 +60,15 @@ node .agents/scripts/plan-context.js --seed "<seed>" \
   --out temp/plan-<slug>/plan-context.json
 # or: --seed-file <path>
 # or: --tickets 123,456
+# or: --amends #<id>   (delta envelope from a shipped Story — Story #4741)
 ```
+
+**Amendment planning (`--amends #<id>`, Story #4741 R3-A).** The heavy-amendment
+counterpart to routing a light change through `/deliver-light`: the envelope is
+a **delta** — the prior Story's body, its acceptance criteria, and its delivered
+file map — instead of a from-scratch repo interrogation, so a follow-up plans
+from what already shipped. The pipeline shape is unchanged; only its inputs
+shrink.
 
 **Always pass `--out`.** Persist auto-discovers that envelope from
 `--plan-dir` and derives source-ticket ids from its `sourceTickets[]`
@@ -75,7 +86,13 @@ Under `--yes`, do not ask free-form operator questions — unresolved
 unknowns land in Key Assumptions.
 
 **Gate #1** — STOP to confirm the sharpened plan intent and any
-duplicate-candidate review. Under `--yes`, auto-proceed.
+duplicate-candidate review. When the envelope's
+`complexitySignals.deliverLightSuggestion.suggested` is `true` (the seed fits
+the `/deliver-light` ceilings — ≤2 artifacts, no risk-heuristic hit, no
+sensitive-path class), surface an **advisory** suggestion to use
+`/deliver-light` instead; the operator always decides. Under `--yes`, do not
+reroute — record the suggestion (it rides the envelope) and proceed with
+planning. **Never an automatic reroute** (Story #4741 AC-6).
 
 ### 2. Author
 
@@ -159,6 +176,15 @@ node .agents/scripts/plan-persist.js \
   [--tech-spec temp/plan-<slug>/techspec.md] \
   [--source-tickets 123,456] [...flags from the table above]
 ```
+
+**Plan-diet fast path (`--chain-on-clean`, Story #4741 AC-3).** At lite shape,
+pass `--chain-on-clean` alongside `--route-downgrade-reason "<why>"`: persist
+runs the write-free dry-run first and, **only** when it passes clean and
+resolves to the `lite` route, chains straight into the real persist in the same
+invocation — one operator round-trip instead of two. A dry-run validation
+failure stops before any `createIssue`; a full-route plan keeps its review
+round-trip (the chain declines, writes nothing). Every semantic gate still runs
+on the dry-run pass.
 
 Persist creates Story issue(s) with `type::story` plus a `plan-run::<id>`
 grouping label (**metadata only** — never a delivery-resolution input, Story #4692); N>1 `depends_on` edges become `blocked by #<id>` body footers.

--- a/baselines/dead-exports-production.json
+++ b/baselines/dead-exports-production.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://mandrel.dev/baselines/dead-exports.schema.json",
   "kernelVersion": "6.17.1",
-  "generatedAt": "2026-07-16T22:33:08.005Z",
+  "generatedAt": "2026-07-24T11:45:00.000Z",
   "mode": "production",
   "rows": [
     {
@@ -1531,6 +1531,10 @@
     {
       "file": ".agents/scripts/lib/orchestration/plan-context.js",
       "symbol": "buildSystemPrompts"
+    },
+    {
+      "file": ".agents/scripts/lib/orchestration/plan-context.js",
+      "symbol": "buildDeliverLightSuggestion"
     },
     {
       "file": ".agents/scripts/lib/orchestration/plan-critic-conditions.js",

--- a/tests/plan-context.test.js
+++ b/tests/plan-context.test.js
@@ -36,6 +36,7 @@ import { describe, it } from 'node:test';
 import { findSimilarOpenStories } from '../.agents/scripts/lib/duplicate-search.js';
 import { buildComplexitySignals } from '../.agents/scripts/lib/orchestration/complexity-gate.js';
 import {
+  buildDeliverLightSuggestion,
   buildDeliveryShapeSignal,
   buildPlanContext,
   buildScopeTriageSignal,
@@ -56,11 +57,15 @@ import {
   validateTaskBodies,
 } from '../.agents/scripts/lib/orchestration/task-body-validator.js';
 import { validateAndNormalizeTickets } from '../.agents/scripts/lib/orchestration/ticket-validator.js';
+import { serialize } from '../.agents/scripts/lib/story-body/story-body.js';
 import {
   renderAcceptanceSpecSystemPrompt,
   renderTechSpecSystemPrompt,
 } from '../.agents/scripts/lib/templates/spec-author-prompts.js';
-import { emitPlanContext } from '../.agents/scripts/plan-context.js';
+import {
+  emitPlanContext,
+  parseAmendsId,
+} from '../.agents/scripts/plan-context.js';
 
 const CLEAR_EPIC_BODY = `# Widget Epic
 
@@ -985,5 +990,217 @@ describe('renderStoriesTemplate — correct-by-construction skeleton (Story #472
       assert.match(entry, VERIFY_TIER_RE);
     }
     await rm(dir, { recursive: true, force: true });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Story #4741 — plan-phase turn diet.
+// ---------------------------------------------------------------------------
+
+/** A shipped Story body the amendment envelope composes its delta from. */
+const PRIOR_STORY_BODY = serialize({
+  goal: 'Ship the widget exporter.',
+  changes: [
+    { path: 'lib/export/widget.js', assumption: 'creates' },
+    { path: 'lib/export/index.js', assumption: 'refactors-existing' },
+  ],
+  acceptance: [
+    'The exporter writes a valid CSV.',
+    'Empty input yields an empty file.',
+  ],
+  verify: ['npm test (unit)'],
+  reason_to_exist: 'Users need a widget export.',
+});
+
+describe('plan-context deliverLightSuggestion (Story #4741 AC-6)', () => {
+  it('suggests /deliver-light for a scope inside the ceilings — advisory, never automatic', () => {
+    const s = buildDeliverLightSuggestion({
+      artifactCount: 1,
+      riskHeuristicHits: [],
+      sensitivePathClasses: [],
+    });
+    assert.equal(s.suggested, true);
+    // The two contract flags: advisory, and NEVER an automatic reroute.
+    assert.equal(s.advisory, true);
+    assert.equal(s.automatic, false);
+    assert.match(s.reasons[0], /deliver-light ceilings/);
+  });
+
+  it('does not suggest when the seed exceeds the artifact ceiling', () => {
+    const s = buildDeliverLightSuggestion({
+      artifactCount: 5,
+      riskHeuristicHits: [],
+      sensitivePathClasses: [],
+    });
+    assert.equal(s.suggested, false);
+    assert.match(s.reasons[0], /5 artifacts/);
+  });
+
+  it('does not suggest when a risk heuristic hits — risk is what a light path must not carry', () => {
+    const s = buildDeliverLightSuggestion({
+      artifactCount: 1,
+      riskHeuristicHits: ['touches auth'],
+      sensitivePathClasses: [],
+    });
+    assert.equal(s.suggested, false);
+    assert.match(s.reasons.join(' '), /risk-heuristic/);
+  });
+
+  it('does not suggest when the predicted footprint touches a sensitive-path class', () => {
+    const s = buildDeliverLightSuggestion({
+      artifactCount: 1,
+      riskHeuristicHits: [],
+      sensitivePathClasses: ['auth'],
+    });
+    assert.equal(s.suggested, false);
+    assert.match(s.reasons.join(' '), /sensitive-path/);
+  });
+
+  it('fails conservative (not suggested) on a missing / malformed signal bag', () => {
+    assert.equal(buildDeliverLightSuggestion(null).suggested, false);
+    assert.equal(buildDeliverLightSuggestion({}).suggested, false);
+    assert.equal(buildDeliverLightSuggestion(undefined).suggested, false);
+  });
+
+  it('rides the seed envelope nested under complexitySignals — no new top-level key (AC-5)', async () => {
+    const env = await buildPlanContext({
+      mode: 'seed',
+      // ONE_PAGER enumerates 2 scope items and no risk/sensitive signal — it
+      // fits the ceilings, so the nested suggestion fires.
+      seedText: ONE_PAGER,
+      provider: buildProvider(),
+      config: {},
+      settings: {},
+    });
+    // AC-5: the top-level key set is byte-stable — the suggestion is nested.
+    assert.deepEqual(Object.keys(env).sort(), SEED_MODE_KEYS);
+    assert.equal(env.complexitySignals.deliverLightSuggestion.suggested, true);
+    assert.equal(env.complexitySignals.deliverLightSuggestion.automatic, false);
+  });
+});
+
+describe('plan-context parseAmendsId (Story #4741 AC-4)', () => {
+  it('accepts a bare id and a #-prefixed id', () => {
+    assert.equal(parseAmendsId('4700'), 4700);
+    assert.equal(parseAmendsId('#4700'), 4700);
+    assert.equal(parseAmendsId('  #12 '), 12);
+  });
+
+  it('rejects a non-positive or non-integer id', () => {
+    assert.throws(() => parseAmendsId(''), /requires a single prior Story id/);
+    assert.throws(() => parseAmendsId('0'), /positive integer/);
+    assert.throws(() => parseAmendsId('nope'), /positive integer/);
+  });
+});
+
+describe('plan-context amends mode — delta envelope (Story #4741 AC-4)', () => {
+  function amendsProvider(body = PRIOR_STORY_BODY) {
+    const provider = buildProvider();
+    provider.getTicket = async (id) => ({
+      id,
+      number: id,
+      title: 'Widget exporter',
+      body,
+      labels: ['type::story'],
+    });
+    return provider;
+  }
+
+  it('composes the delta from the prior body, acceptance, and delivered file map', async () => {
+    const env = await buildPlanContext({
+      mode: 'amends',
+      amendsId: 4700,
+      provider: amendsProvider(),
+      config: { github: { owner: 'o', repo: 'r' } },
+      settings: {},
+    });
+    assert.equal(env.mode, 'amends');
+    assert.equal(env.planProfile, 'story-amendment');
+    assert.equal(env.amends.id, 4700);
+    assert.equal(env.amends.priorBody, PRIOR_STORY_BODY);
+    assert.deepEqual(env.amends.priorAcceptance, [
+      'The exporter writes a valid CSV.',
+      'Empty input yields an empty file.',
+    ]);
+    assert.deepEqual(env.amends.deliveredFiles, [
+      'lib/export/widget.js',
+      'lib/export/index.js',
+    ]);
+  });
+
+  it('carries a delta, NOT a from-scratch repo interrogation', async () => {
+    const env = await buildPlanContext({
+      mode: 'amends',
+      amendsId: 4700,
+      provider: amendsProvider(),
+      config: {},
+      settings: {},
+    });
+    // The whole point of R3-A: none of the heavy authoring-context repo probes
+    // ride the amendment envelope — the prior artifacts stand in for them.
+    for (const heavy of [
+      'codebaseSnapshot',
+      'bddRunner',
+      'bddScenarios',
+      'memoryFreshness',
+      'priorFeedback',
+      'sourceTickets',
+    ]) {
+      assert.ok(!(heavy in env), `${heavy} must not ride the amends envelope`);
+    }
+    // But the semantic steps that reach the ticket are preserved (AC-2):
+    // duplicate detection, risk heuristics, and the authoring prompts.
+    assert.ok(Array.isArray(env.duplicates));
+    assert.ok(Array.isArray(env.riskHeuristics));
+    assert.equal(typeof env.systemPrompts.story, 'string');
+    assert.equal(env.ticketSchema, TICKET_SCHEMA_DESCRIPTOR);
+  });
+
+  it('runs duplicate detection over the prior body, excluding the amended Story itself', async () => {
+    const provider = amendsProvider();
+    const env = await buildPlanContext({
+      mode: 'amends',
+      amendsId: 9,
+      provider,
+      config: { github: { owner: 'o', repo: 'r' } },
+      settings: {},
+    });
+    const direct = await findSimilarOpenStories({
+      seed: PRIOR_STORY_BODY,
+      provider,
+      owner: 'o',
+      repo: 'r',
+      excludeIds: [9],
+    });
+    assert.deepEqual(env.duplicates, direct);
+  });
+
+  it('throws when the prior Story is not found', async () => {
+    const provider = buildProvider();
+    provider.getTicket = async () => null;
+    await assert.rejects(
+      () =>
+        buildPlanContext({
+          mode: 'amends',
+          amendsId: 999,
+          provider,
+          config: {},
+          settings: {},
+        }),
+      /prior Story not found/,
+    );
+  });
+
+  it('degrades to empty prior-artifact lists on an unparseable prior body', async () => {
+    const env = await buildPlanContext({
+      mode: 'amends',
+      amendsId: 4700,
+      // An unstructured body has no ## Acceptance / ## Changes sections.
+      provider: amendsProvider('just some freeform prose, no sections'),
+      config: {},
+      settings: {},
+    });
+    assert.deepEqual(env.amends.priorAcceptance, []);
+    assert.deepEqual(env.amends.deliveredFiles, []);
   });
 });

--- a/tests/scripts/plan-persist.chain-on-clean.test.js
+++ b/tests/scripts/plan-persist.chain-on-clean.test.js
@@ -1,0 +1,270 @@
+/**
+ * tests/scripts/plan-persist.chain-on-clean.test.js — the plan-diet fast path
+ * (Story #4741 AC-1/AC-2/AC-3): `runPersistChain` collapses the dry-run +
+ * persist operator round-trips into ONE invocation.
+ *
+ * The chain runs a write-free dry-run first; only a plan that validates clean
+ * AND resolves to the `lite` route earns the second, write pass — from the
+ * identical artifacts, so the persisted output is byte-identical to what the
+ * dry-run gated. A validation failure stops before any createIssue; a
+ * full-route plan keeps its review round-trip (the chain declines).
+ */
+
+import assert from 'node:assert/strict';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { describe, it } from 'node:test';
+import {
+  AGENT_LABELS,
+  TYPE_LABELS,
+} from '../../.agents/scripts/lib/label-constants.js';
+import { serialize } from '../../.agents/scripts/lib/story-body/story-body.js';
+import { runPersistChain } from '../../.agents/scripts/plan-persist.js';
+
+/**
+ * A lite-shaped Story: one `refactors-existing` change against a path that
+ * exists at `main` (so the file-assumption gate passes), one acceptance
+ * criterion, a non-sensitive footprint — every signal the shape backstop needs
+ * to uphold a lite claim.
+ */
+function liteTicket(slug = 'solo') {
+  const acceptance = [`${slug} done`];
+  const verify = ['npm test (validate)'];
+  return {
+    slug,
+    type: 'story',
+    title: `Story ${slug}`,
+    acceptance,
+    verify,
+    body: serialize({
+      goal: `Goal of ${slug}.`,
+      changes: [
+        {
+          path: 'tests/scripts/plan-persist.flat-stories.test.js',
+          assumption: 'refactors-existing',
+        },
+      ],
+      acceptance,
+      verify,
+      reason_to_exist: `Ship ${slug}`,
+    }),
+  };
+}
+
+/** A Story with no acceptance/verify contract — fails the dry-run validator. */
+function invalidTicket() {
+  return {
+    slug: 'bad',
+    type: 'story',
+    title: 'Bad',
+    acceptance: [],
+    verify: [],
+    body: serialize({
+      goal: 'Goal of bad.',
+      changes: [
+        {
+          path: 'tests/scripts/plan-persist.flat-stories.test.js',
+          assumption: 'refactors-existing',
+        },
+      ],
+      acceptance: [],
+      verify: [],
+      reason_to_exist: 'Ship bad',
+    }),
+  };
+}
+
+function fakeProvider() {
+  const issues = new Map();
+  const comments = [];
+  let nextId = 6000;
+  return {
+    issues,
+    comments,
+    async createIssue({ title, body, labels }) {
+      const id = nextId++;
+      issues.set(id, { id, title, body, labels: [...labels] });
+      return { id, url: `https://example.test/${id}` };
+    },
+    async getTicket(id) {
+      const issue = issues.get(id);
+      if (!issue) throw new Error(`ticket #${id} not found`);
+      return { ...issue, state: issue.state ?? 'open' };
+    },
+    async listIssuesByLabel() {
+      return [];
+    },
+    async updateTicket(id, mutations) {
+      const issue = issues.get(id);
+      if (!issue) throw new Error(`ticket #${id} not found`);
+      const { labels: labelMutations, ...rest } = mutations;
+      Object.assign(issue, rest);
+      if (labelMutations) {
+        const next = new Set(issue.labels ?? []);
+        for (const l of labelMutations.remove ?? []) next.delete(l);
+        for (const l of labelMutations.add ?? []) next.add(l);
+        issue.labels = [...next];
+      }
+    },
+    async getTicketComments() {
+      return [];
+    },
+    async postComment(issueNumber, payload) {
+      const body = typeof payload === 'string' ? payload : payload.body;
+      comments.push({ id: comments.length + 1, issueNumber, body });
+      return { id: comments.length };
+    },
+  };
+}
+
+/** Per-test isolated tempRoot so plan-metrics never touch the shared ledger. */
+function isolatedConfig() {
+  const tempRoot = mkdtempSync(path.join(tmpdir(), 'plan-chain-'));
+  return { config: { project: { paths: { tempRoot } } }, tempRoot };
+}
+
+function chainArgs({ story, routeDowngradeReason }) {
+  return {
+    values: {
+      stories: 'temp/plan-chain/stories.json',
+      'route-downgrade-reason': routeDowngradeReason,
+      'chain-on-clean': true,
+    },
+    artifacts: {
+      stories: [story],
+      techSpecContent: null,
+      planAcceptance: null,
+      planContextEnvelope: null,
+    },
+    metricsSince: new Date().toISOString(),
+  };
+}
+
+describe('runPersistChain — plan-diet fast path (Story #4741)', () => {
+  it('AC-3/AC-1: a clean lite dry-run chains straight into the real persist in one invocation', async () => {
+    const { config, tempRoot } = isolatedConfig();
+    try {
+      const provider = fakeProvider();
+      const result = await runPersistChain({
+        config,
+        provider,
+        ...chainArgs({
+          story: liteTicket('solo'),
+          routeDowngradeReason: 'single trivial artifact',
+        }),
+      });
+
+      // The write pass ran without a second operator round-trip.
+      assert.deepEqual(result.chain, {
+        attempted: true,
+        persisted: true,
+        reason: 'lite-dry-run-clean',
+      });
+      assert.equal(result.route.route, 'lite');
+      assert.equal(result.stories.length, 1);
+
+      // AC-2: every semantic step still ran on the dry-run pass — the shape
+      // backstop upheld the lite claim (route::lite hint) and persist wrote
+      // its bookkeeping (agent::ready + story-plan-state).
+      const issue = provider.issues.get(result.primaryStoryId);
+      assert.ok(issue.labels.includes(TYPE_LABELS.STORY));
+      assert.ok(issue.labels.includes(AGENT_LABELS.READY));
+      assert.ok(issue.labels.includes('route::lite'));
+      const checkpoint = provider.comments
+        .map((c) => c.body)
+        .find((b) => b.includes('story-plan-state'));
+      assert.ok(checkpoint, 'the persist checkpoint was written');
+    } finally {
+      rmSync(tempRoot, { recursive: true, force: true });
+    }
+  });
+
+  it('AC-1: the chained persist output is byte-identical to a plain (non-chained) persist', async () => {
+    const { config: cfgA, tempRoot: rootA } = isolatedConfig();
+    const { config: cfgB, tempRoot: rootB } = isolatedConfig();
+    try {
+      // Chained lite persist.
+      const chained = fakeProvider();
+      const chainedResult = await runPersistChain({
+        config: cfgA,
+        provider: chained,
+        ...chainArgs({
+          story: liteTicket('solo'),
+          routeDowngradeReason: 'single trivial artifact',
+        }),
+      });
+
+      // Plain persist of the SAME artifacts (the operator's two-step baseline).
+      const plain = fakeProvider();
+      const plainResult = await runPersistChain({
+        config: cfgB,
+        provider: plain,
+        ...chainArgs({
+          story: liteTicket('solo'),
+          routeDowngradeReason: 'single trivial artifact',
+        }),
+      });
+
+      const chainedBody = chained.issues.get(chainedResult.primaryStoryId).body;
+      const plainBody = plain.issues.get(plainResult.primaryStoryId).body;
+      assert.equal(
+        chainedBody,
+        plainBody,
+        'the diet must not alter the persisted Story body',
+      );
+    } finally {
+      rmSync(rootA, { recursive: true, force: true });
+      rmSync(rootB, { recursive: true, force: true });
+    }
+  });
+
+  it('AC-3: a dry-run validation failure stops before any createIssue', async () => {
+    const { config, tempRoot } = isolatedConfig();
+    try {
+      const provider = fakeProvider();
+      await assert.rejects(
+        () =>
+          runPersistChain({
+            config,
+            provider,
+            ...chainArgs({
+              story: invalidTicket(),
+              routeDowngradeReason: 'single trivial artifact',
+            }),
+          }),
+        /acceptance \+ verify contract/,
+      );
+      // The real persist pass never ran — nothing was created.
+      assert.equal(provider.issues.size, 0);
+    } finally {
+      rmSync(tempRoot, { recursive: true, force: true });
+    }
+  });
+
+  it('a full-route plan keeps its review round-trip — the chain declines, writing nothing', async () => {
+    const { config, tempRoot } = isolatedConfig();
+    try {
+      const provider = fakeProvider();
+      // No route-downgrade reason → the plan resolves to the full route, so
+      // the auto-persist is declined even though the dry-run is clean.
+      const result = await runPersistChain({
+        config,
+        provider,
+        ...chainArgs({
+          story: liteTicket('solo'),
+          routeDowngradeReason: undefined,
+        }),
+      });
+
+      assert.deepEqual(result.chain, {
+        attempted: true,
+        persisted: false,
+        reason: 'route-not-lite',
+      });
+      assert.equal(provider.issues.size, 0);
+    } finally {
+      rmSync(tempRoot, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
Closes #4741

_Auto-opened by `/deliver`._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches plan persist GitHub writes via `--chain-on-clean` auto-persist after lite dry-run, and introduces amendment planning that omits full repo interrogation—both need correct fail-closed behavior, which tests assert but operators should understand.
> 
> **Overview**
> **Plan-phase turn diet (#4741):** fewer operator round-trips and lighter envelopes while keeping the same persist gates and artifacts.
> 
> **Interrogate (`plan-context`):** Adds **`--amends #<id>`** — a new `amends` mode that builds a **delta envelope** from the prior Story’s body, parsed acceptance criteria, and delivered file paths (via `story-body` parse), **without** the heavy `buildAuthoringContext` repo snapshot / BDD / memory probes. Duplicate search, risk heuristics, and authoring prompts still ride the envelope. CLI gains `parseAmendsId`; compact `--out` digest includes `amends.id`.
> 
> **Advisory `/deliver-light` handshake:** `buildDeliverLightSuggestion` evaluates seed-time `complexitySignals` against fixed ceilings (≤2 artifacts, no risk-heuristic hits, no sensitive-path classes). Result is nested as **`complexitySignals.deliverLightSuggestion`** (no new top-level envelope keys). **Advisory only** — never auto-reroutes; `/plan` Gate #1 documents surfacing it under `--yes`.
> 
> **Persist (`plan-persist`):** **`--chain-on-clean`** runs a write-free dry-run first; if validation passes and the plan resolves to the **`lite`** route, it chains into a real persist in the **same invocation** (same loaded artifacts). Full-route plans decline the chain with a `chain` receipt; dry-run failures stop before `createIssue`. `--dry-run` still wins over chaining.
> 
> **Docs & tests:** `plan.md` updated for `--amends`, Gate #1 deliver-light note, and `--chain-on-clean`. Tests cover suggestion ceilings, amends envelope shape, and `runPersistChain` behavior. `buildDeliverLightSuggestion` added to dead-exports baseline.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4a7400d654b6344a5713ca466252648fc66d233b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->