### PR TITLE
feat: make /deliver-light's escalate-plan outcome terminal and structurally enforced

### DIFF
--- a/.agents/schemas/story-deliver-terminal.schema.json
+++ b/.agents/schemas/story-deliver-terminal.schema.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://github.com/dsj1984/mandrel/blob/main/.agents/schemas/story-deliver-terminal.schema.json",
   "title": "story-deliver-terminal",
-  "description": "The single terminal envelope every Story close-and-land invocation emits (Story #4543). Before this schema, the delivery tail had two divergent prose return contracts — one in .agents/workflows/helpers/deliver-story.md, a different one in .agents/agents/story-worker.md — and neither was validated by anything, so a caller could not tell a landed Story from a parked one without re-probing GitHub. This is the SSOT both now reference rather than restate. status is exactly one of landed | pending | blocked | failed; phase names where the run ended; tail carries per-step booleans so a partial-tail degradation is visible without failing an otherwise-landed merge; nextCommand names the single command that resumes or remediates the run, drawn from the same vocabulary deliver-recover.js prints.",
+  "description": "The single terminal envelope a Story delivery invocation emits (Story #4543). Before this schema, the delivery tail had two divergent prose return contracts — one in .agents/workflows/helpers/deliver-story.md, a different one in .agents/agents/story-worker.md — and neither was validated by anything, so a caller could not tell a landed Story from a parked one without re-probing GitHub. This is the SSOT both now reference rather than restate. status is exactly one of landed | pending | blocked | failed | escalated; phase names where the run ended; tail carries per-step booleans so a partial-tail degradation is visible without failing an otherwise-landed merge; nextCommand names the single command that resumes or remediates the run, drawn from the same vocabulary deliver-recover.js prints. escalated (Story #4746) is the one status emitted BEFORE a Story exists — /deliver-light's suitability gate refusing an over-scope prompt — which is why storyId is null exactly there and non-null everywhere else.",
   "type": "object",
   "required": [
     "kind",
@@ -14,16 +14,21 @@
   ],
   "properties": {
     "kind": { "type": "string", "const": "story-deliver-terminal" },
-    "storyId": { "type": "integer", "minimum": 1 },
+    "storyId": {
+      "type": ["integer", "null"],
+      "minimum": 1,
+      "description": "The Story this envelope reports on. null ONLY for status escalated, where the run refused before authoring a receipt Story — the allOf below pins that correspondence in both directions, so an escalated envelope cannot name a Story it did not create and a landed one cannot omit the Story it landed."
+    },
     "status": {
       "type": "string",
-      "description": "landed — the PR merged, the Story is agent::done, and the post-land tail was attempted. pending — a bounded wait expired with the PR still in flight; NO label was mutated and no merge.unlanded event was emitted, so the run is resumable via nextCommand. blocked — a classified hard block; the Story carries agent::blocked and blocked.blockClass names the class. failed — a phase crashed; phase names which one.",
-      "enum": ["landed", "pending", "blocked", "failed"]
+      "description": "landed — the PR merged, the Story is agent::done, and the post-land tail was attempted. pending — a bounded wait expired with the PR still in flight; NO label was mutated and no merge.unlanded event was emitted, so the run is resumable via nextCommand. blocked — a classified hard block; the Story carries agent::blocked and blocked.blockClass names the class. failed — a phase crashed; phase names which one. escalated — the /deliver-light suitability gate refused an over-scope prompt under --yes; nothing was created and the session ENDS here, nextCommand naming the /plan invocation that owns the work instead.",
+      "enum": ["landed", "pending", "blocked", "failed", "escalated"]
     },
     "phase": {
       "type": "string",
-      "description": "The pipeline phase the run ended in. Mirrors the close pipeline's phase names so a terminal envelope is attributable to one step.",
+      "description": "The pipeline phase the run ended in. Mirrors the close pipeline's phase names so a terminal envelope is attributable to one step. suitability-gate precedes them all — it is the /deliver-light gate, the only phase that runs before a Story exists.",
       "enum": [
+        "suitability-gate",
         "init",
         "wrong-tree-guard",
         "close-validation",
@@ -130,9 +135,35 @@
       },
       "additionalProperties": false
     },
+    "escalation": {
+      "type": ["object", "null"],
+      "description": "Present iff status === \"escalated\" (Story #4746). The suitability gate's decision was already correct before this block existed — what was missing was an outcome a session could not walk past. reasons carries the gate's own words; created records, per artifact, that the run started nothing.",
+      "required": ["reasons", "created"],
+      "properties": {
+        "reasons": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "string", "minLength": 1 },
+          "description": "The gate's reasons verbatim — the same strings the ask-operator path prints, so attended and unattended over-scope explain themselves identically."
+        },
+        "created": {
+          "type": "object",
+          "description": "Per-artifact proof that an escalated run left nothing half-started for a later run to trip over. Deliberately three const-false booleans rather than one aggregate flag or a bare omission: an omitted field reads as \"not checked\", and an aggregate is exactly the shape that let the post-land tail once report an outcome it never verified. Every value is pinned false by the schema, so an escalated envelope claiming it authored a receipt Story, cut a branch, or materialized a worktree cannot be built at all.",
+          "required": ["receiptStory", "storyBranch", "worktree"],
+          "properties": {
+            "receiptStory": { "const": false },
+            "storyBranch": { "const": false },
+            "worktree": { "const": false }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
     "nextCommand": {
       "type": ["string", "null"],
-      "description": "The single command that advances this Story from where it stopped, or null when status === \"landed\" and nothing remains. Shares its vocabulary with deliver-recover.js so recovery and normal resumption speak one language."
+      "description": "The single command that advances this work from where it stopped, or null when status === \"landed\" and nothing remains. Shares its vocabulary with deliver-recover.js so recovery and normal resumption speak one language. For status escalated it is the /plan invocation the operator runs in a FRESH session — the one case where the command is a slash command rather than a script, because the work needs planning, not resumption.",
+      "minLength": 1
     },
     "elapsedSeconds": { "type": "number", "minimum": 0 },
     "waitBudget": {
@@ -148,5 +179,28 @@
     },
     "timestamp": { "type": "string", "format": "date-time" }
   },
+  "allOf": [
+    {
+      "description": "escalated is the pre-Story terminal, and the correspondence is pinned in BOTH directions. An escalated envelope MUST carry the escalation block, MUST have a null storyId (it created none), and MUST name the next command that owns the work — so a run cannot report escalation while pointing at a Story it started. Every other status MUST carry an integer storyId and MUST NOT carry an escalation block, so the new status cannot leak into the close path.",
+      "if": {
+        "properties": { "status": { "const": "escalated" } },
+        "required": ["status"]
+      },
+      "then": {
+        "required": ["escalation"],
+        "properties": {
+          "storyId": { "type": "null" },
+          "escalation": { "type": "object" },
+          "nextCommand": { "type": "string", "minLength": 1 }
+        }
+      },
+      "else": {
+        "properties": {
+          "storyId": { "type": "integer", "minimum": 1 },
+          "escalation": { "type": "null" }
+        }
+      }
+    }
+  ],
   "additionalProperties": false
 }

--- a/.agents/scripts/deliver-light.js
+++ b/.agents/scripts/deliver-light.js
@@ -23,11 +23,24 @@
  *   - **gate** (default) — judge a prompt's predicted footprint. On
  *     `proceed-light` it authors the receipt Story (via the plan-persist
  *     `createStoryIssues` surface) and prints the init/close hand-off. On
- *     over-scope it prints `ask-operator` (attended) or `escalate-plan`
- *     (`--yes`), never landing silently.
+ *     over-scope it prints `ask-operator` (attended) or emits an `escalated`
+ *     terminal envelope (`--yes`), never landing silently.
  *   - **backstop** (`--backstop --story <id>`) — re-check the ACTUAL diff of
  *     the Story branch after implementation; exit non-zero when it exceeds the
  *     light ceilings, so an over-scope diff is blocked rather than landed.
+ *
+ * ## Escalation is terminal, not advisory (Story #4746)
+ *
+ * Over-scope under `--yes` emits a schema-validated `story-deliver-terminal`
+ * envelope with status `escalated` and **ends the session**. Before that it was
+ * an ordinary gate envelope plus exit 2 — a warning a caller could walk past,
+ * and one mandrel-bench 2.13.0 light-arm run did exactly that: it read the
+ * escalation, invoked `/plan` in the same session, and delivered. In-session
+ * planning under-decomposed (ONE Story against the scenario's 3-5 contract,
+ * where a fresh `/plan` session on the identical seed authored four), so
+ * escalation silently produced the outcome the guard exists to prevent.
+ * {@link module:lib/orchestration/story-deliver-terminal.buildEscalationTerminal}
+ * carries the guarantees the schema then enforces.
  *
  * Usage:
  *   node .agents/scripts/deliver-light.js --prompt "<text>" \
@@ -36,7 +49,8 @@
  *   node .agents/scripts/deliver-light.js --backstop --story 4741
  *
  * Exit codes: 0 ok (proceed / clean backstop), 1 usage error, 2 the gate did
- * not proceed light (ask-operator / escalate-plan), 3 the diff backstop blocked.
+ * not proceed light (ask-operator, or an `escalated` terminal), 3 the diff
+ * backstop blocked.
  */
 
 import { parseArgs } from 'node:util';
@@ -55,6 +69,11 @@ import {
   assemblePlanStories,
   createStoryIssues,
 } from './lib/orchestration/plan-persist/story-ops.js';
+import {
+  buildEscalationTerminal,
+  emitTerminalEnvelope,
+  exitCodeForTerminal,
+} from './lib/orchestration/story-deliver-terminal.js';
 import { createProvider } from './lib/provider-factory.js';
 
 const HELP = `\
@@ -75,7 +94,8 @@ Gate options:
   --route <r>        Ledgered model verdict route: lite | full.
   --reason <text>    Recorded reason for a lite verdict (required for lite).
   --amends <#id>     Mark this as an amendment of an existing issue.
-  --yes              Unattended: over-scope fails closed to /plan (no prompt).
+  --yes              Unattended: over-scope emits an escalated terminal
+                     envelope and ENDS the session (no prompt, no fallback).
 
 Backstop options:
   --backstop         Re-check the ACTUAL diff after implementation.
@@ -291,10 +311,39 @@ async function runBackstopMode(values) {
 /**
  * Gate mode — judge the prompt and, on proceed, author the receipt Story.
  *
+ * The three outcomes are deliberately asymmetric in what they emit:
+ *
+ *   - **`escalate-plan`** returns a schema-validated `escalated` **terminal
+ *     envelope** and stops (Story #4746). It is placed **first**, above every
+ *     creation call site, so "nothing was started" is a property of the
+ *     control flow rather than a claim the envelope makes about itself.
+ *   - **`ask-operator`** is unchanged: the plain gate envelope and exit 2. It
+ *     is not terminal — the operator has a choice to make, and manufacturing a
+ *     terminal for it would end a session that is supposed to be waiting.
+ *   - **`proceed-light`** authors the receipt Story and prints the hand-off.
+ *
+ * The injectable seams exist so the no-side-effect guarantee is testable
+ * without a network: a test asserts the escalate path never reaches them.
+ *
  * @param {object} values Parsed CLI values.
+ * @param {{
+ *   createProviderFn?: typeof createProvider,
+ *   resolveConfigFn?: typeof resolveConfig,
+ *   createReceiptFn?: typeof createLightReceipt,
+ *   emitFn?: typeof emit,
+ *   emitTerminalFn?: typeof emitTerminalEnvelope,
+ * }} [deps]
  * @returns {Promise<number>}
  */
-async function runGateMode(values) {
+export async function runGateMode(values, deps = {}) {
+  const {
+    createProviderFn = createProvider,
+    resolveConfigFn = resolveConfig,
+    createReceiptFn = createLightReceipt,
+    emitFn = emit,
+    emitTerminalFn = emitTerminalEnvelope,
+  } = deps;
+
   if (!values.prompt || String(values.prompt).trim() === '') {
     process.stderr.write(HELP);
     throw new Error('[deliver-light] --prompt <text> is required for the gate');
@@ -311,8 +360,20 @@ async function runGateMode(values) {
     yes: values.yes === true,
   });
 
+  if (gate.action === 'escalate-plan') {
+    const envelope = buildEscalationTerminal({
+      prompt: String(values.prompt),
+      reasons: gate.outcome.reasons,
+    });
+    emitTerminalFn(envelope);
+    Logger.warn(
+      `[deliver-light] ESCALATED to /plan — this session ENDS here; run ${envelope.nextCommand} in a FRESH session: ${gate.outcome.reasons.join('; ')}`,
+    );
+    return exitCodeForTerminal(envelope);
+  }
+
   if (gate.action !== 'proceed-light') {
-    emit(
+    emitFn(
       { mode: 'gate', action: gate.action, outcome: gate.outcome },
       values.pretty,
     );
@@ -322,8 +383,8 @@ async function runGateMode(values) {
     return EXIT_NOT_PROCEED;
   }
 
-  const provider = createProvider(resolveConfig());
-  const receipt = await createLightReceipt({
+  const provider = createProviderFn(resolveConfigFn());
+  const receipt = await createReceiptFn({
     provider,
     prompt: String(values.prompt),
     changedFiles: [
@@ -332,7 +393,7 @@ async function runGateMode(values) {
     ],
     amends: values.amends ?? null,
   });
-  emit(
+  emitFn(
     {
       mode: 'gate',
       action: 'proceed-light',

--- a/.agents/scripts/lib/orchestration/story-deliver-terminal.js
+++ b/.agents/scripts/lib/orchestration/story-deliver-terminal.js
@@ -61,6 +61,15 @@ export const TERMINAL_EXIT_CODES = Object.freeze({
   pending: 3,
   blocked: 1,
   failed: 1,
+  /**
+   * `escalated` reuses **2**, the code `/deliver-light` already documents for
+   * "the gate did not proceed light" — the escalation is that outcome made
+   * terminal, not a new one, so giving it a fresh code would fork a vocabulary
+   * callers already branch on. It stays distinct from `landed` (nothing was
+   * delivered) and from `blocked`/`failed` (nothing is wrong — the work simply
+   * belongs to `/plan`).
+   */
+  escalated: 2,
 });
 
 export const TERMINAL_STATUSES = Object.freeze([
@@ -68,13 +77,38 @@ export const TERMINAL_STATUSES = Object.freeze([
   'pending',
   'blocked',
   'failed',
+  'escalated',
 ]);
+
+/** Cap on the prompt echoed into an escalation's `/plan` next command. */
+const PLAN_PROMPT_MAX = 200;
+
+/**
+ * Render an operator prompt safe to sit inside the double quotes of the
+ * `/plan "<prompt>"` next command: collapse newlines (a next command is one
+ * line by contract), escape backslashes and double quotes so the quoting
+ * cannot be broken out of, and cap the length so a long prompt does not turn
+ * the envelope into a transcript. Total — a non-string yields the empty
+ * string, which the escalation builder rejects rather than emitting.
+ *
+ * @param {unknown} prompt
+ * @returns {string}
+ */
+function quoteForPlan(prompt) {
+  const text =
+    typeof prompt === 'string' ? prompt.replace(/\s+/g, ' ').trim() : '';
+  const capped =
+    text.length > PLAN_PROMPT_MAX
+      ? `${text.slice(0, PLAN_PROMPT_MAX - 1).trimEnd()}…`
+      : text;
+  return capped.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+}
 
 /**
  * The shared next-command vocabulary. Every producer of a "what now?"
- * answer — the `pending` terminal envelope and `deliver-recover.js` —
- * builds its command from here, so the two surfaces never drift into
- * naming different commands for the same observed state.
+ * answer — the `pending` terminal envelope, an `escalated` one, and
+ * `deliver-recover.js` — builds its command from here, so the surfaces never
+ * drift into naming different commands for the same observed state.
  */
 export const NEXT_COMMANDS = Object.freeze({
   /**
@@ -104,6 +138,18 @@ export const NEXT_COMMANDS = Object.freeze({
   /** Probe a stranded Story and print its single next command. */
   recover: (storyId) =>
     `node .agents/scripts/deliver-recover.js --story ${storyId}`,
+  /**
+   * Hand over-scope work to `/plan` — the next command of an `escalated`
+   * terminal (Story #4746).
+   *
+   * The only entry here that is a slash command rather than a script, and
+   * deliberately so: the other entries resume a Story that exists, while this
+   * one names work that has no Story yet and needs planning before it can have
+   * one. It is quoted for a shell but addressed to a **fresh session** — see
+   * the workflow's escalation section for why running it in the escalating
+   * session is forbidden.
+   */
+  escalateToPlan: (prompt) => `/plan "${quoteForPlan(prompt)}"`,
 });
 
 /** @type {Function|null} */
@@ -165,8 +211,9 @@ function compact(obj) {
  * this replaces.
  *
  * @param {object} args
- * @param {number} args.storyId
- * @param {'landed'|'pending'|'blocked'|'failed'} args.status
+ * @param {number|null} args.storyId `null` only for an `escalated` terminal,
+ *   which by construction never authored a Story.
+ * @param {'landed'|'pending'|'blocked'|'failed'|'escalated'} args.status
  * @param {string} args.phase
  * @param {string} [args.storyBranch]
  * @param {string} [args.baseBranch]
@@ -175,6 +222,7 @@ function compact(obj) {
  * @param {object|null} [args.tail]
  * @param {object|null} [args.blocked]
  * @param {object|null} [args.failure]
+ * @param {object|null} [args.escalation]
  * @param {string|null} [args.nextCommand]
  * @param {number} args.elapsedSeconds
  * @param {object|null} [args.waitBudget]
@@ -192,6 +240,7 @@ export function buildTerminalEnvelope({
   tail,
   blocked,
   failure,
+  escalation,
   nextCommand,
   elapsedSeconds = 0,
   waitBudget,
@@ -199,7 +248,10 @@ export function buildTerminalEnvelope({
 }) {
   const envelope = compact({
     kind: TERMINAL_ENVELOPE_KIND,
-    storyId: Number(storyId),
+    // `Number(null)` is 0, which would quietly satisfy nothing and confuse
+    // everything — a nullish storyId stays null and lets the schema decide
+    // whether this status is allowed to omit one.
+    storyId: storyId === null || storyId === undefined ? null : Number(storyId),
     status,
     phase,
     storyBranch: storyBranch ?? null,
@@ -209,6 +261,7 @@ export function buildTerminalEnvelope({
     tail: tail ?? null,
     blocked: blocked ?? null,
     failure: failure ?? null,
+    escalation: escalation ?? null,
     nextCommand: nextCommand ?? null,
     elapsedSeconds: Math.max(0, Number(elapsedSeconds) || 0),
     waitBudget: waitBudget ?? null,
@@ -223,6 +276,69 @@ export function buildTerminalEnvelope({
     );
   }
   return envelope;
+}
+
+/**
+ * Build the `escalated` terminal — the one envelope emitted before a Story
+ * exists (Story #4746).
+ *
+ * `/deliver-light`'s suitability gate already decided correctly when it
+ * overrode a `lite` self-verdict on shape; what it lacked was an outcome a
+ * session could not walk past. A mandrel-bench 2.13.0 light-arm run did
+ * exactly that — it read the gate's `escalate-plan`, then invoked `/plan`
+ * in the same session and delivered. The continuation was not harmless:
+ * planning inside a session already framed as small work authored ONE Story
+ * against the scenario's 3-5 contract, where a fresh `/plan` session on the
+ * identical seed authored four. Escalation silently produced the very
+ * under-decomposition the guard exists to prevent.
+ *
+ * So the outcome is a validated envelope with its own exit code, naming the
+ * `/plan` command that owns the work, and asserting per artifact that nothing
+ * was started. Every guarantee here is enforced by the schema rather than by
+ * prose: `storyId` must be null, `escalation.created.*` are pinned `false`.
+ *
+ * @param {{
+ *   prompt: string,
+ *   reasons?: string[],
+ *   elapsedSeconds?: number,
+ *   timestamp?: string,
+ * }} args
+ * @returns {object} The validated `escalated` envelope.
+ */
+export function buildEscalationTerminal({
+  prompt,
+  reasons,
+  elapsedSeconds = 0,
+  timestamp,
+}) {
+  const quoted = quoteForPlan(prompt);
+  if (quoted === '') {
+    // An escalation whose next command is `/plan ""` hands the operator
+    // nothing — the same walk-past-able non-outcome in envelope clothing.
+    throw new TypeError(
+      'buildEscalationTerminal: a non-empty prompt is required — the escalated terminal exists to name the /plan invocation that owns the work',
+    );
+  }
+  const recorded = (Array.isArray(reasons) ? reasons : []).filter(
+    (r) => typeof r === 'string' && r.trim() !== '',
+  );
+  return buildTerminalEnvelope({
+    storyId: null,
+    status: 'escalated',
+    phase: 'suitability-gate',
+    escalation: {
+      reasons:
+        recorded.length > 0
+          ? recorded
+          : ['predicted scope exceeds the light ceilings — escalate to /plan'],
+      // Not computed from anything: the escalation path returns before the
+      // receipt/init call sites, so these are the assertion that it did.
+      created: { receiptStory: false, storyBranch: false, worktree: false },
+    },
+    nextCommand: NEXT_COMMANDS.escalateToPlan(prompt),
+    elapsedSeconds,
+    ...(timestamp === undefined ? {} : { timestamp }),
+  });
 }
 
 /**

--- a/.agents/workflows/deliver-light.md
+++ b/.agents/workflows/deliver-light.md
@@ -30,7 +30,8 @@ unchanged close path. It never relaxes a close gate, never bypasses the PR to
    ledgered model verdict with a recorded reason. Both must agree on `lite`.
 2. **Over-scope stops — it never hard-fails.** An over-ceiling prompt STOPS and
    asks the operator to escalate to `/plan` or proceed light. Under `--yes` it
-   fails closed to recommending `/plan`.
+   fails closed to an **`escalated` terminal envelope** that ends the session
+   (§ Escalation is terminal).
 3. **Diff-derived backstop.** After implementation the ACTUAL change set is
    re-checked — the diff is the real scope signal — and an over-ceiling diff is
    blocked rather than landed.
@@ -55,9 +56,10 @@ unchanged close path. It never relaxes a close gate, never bypasses the PR to
      `nextCommands`. Continue to step 2.
    - **`ask-operator`** — predicted scope exceeds the light ceilings. STOP and
      ask the operator to escalate to `/plan` or proceed light. Do not proceed
-     on your own.
-   - **`escalate-plan`** — over-scope under `--yes`: recommend `/plan` and stop.
-     `/deliver-light` never lands over-scope work.
+     on your own. This is a **question, not a terminal** — wait for the answer.
+   - **over-scope under `--yes`** — no `action` to branch on: the gate emits an
+     **`escalated` terminal envelope** instead (exit 2). § Escalation is
+     terminal governs; you are finished.
 
    `--amends '#<id>'` is the canonical light case — shape-checked identically; a
    heavy amendment escalates to `/plan` like any other over-scope prompt.
@@ -98,10 +100,39 @@ unchanged close path. It never relaxes a close gate, never bypasses the PR to
    [`helpers/deliver-digest.md`](helpers/deliver-digest.md) § 5 — every close
    gate runs byte-identical to the full path.
 
+## Escalation is terminal {#escalation-is-terminal}
+
+Over-scope under `--yes` emits a schema-validated `story-deliver-terminal`
+envelope with **`status: "escalated"`**, `storyId: null`, and a `nextCommand`
+naming the `/plan` invocation that owns the work.
+
+**That envelope IS this session's terminal output.** Relay it and stop. There is
+no remaining step, no degraded fallback, and no smaller version of the work to
+attempt.
+
+**Invoking `/plan` in this same session is forbidden.** Hand the operator the
+`nextCommand`; `/plan` runs in a **fresh** session.
+
+This is not style — it is the empirical finding that motivated the envelope.
+A mandrel-bench 2.13.0 light-arm run read the escalation and continued anyway:
+it invoked `/plan` in-session and delivered. The in-session plan authored **one**
+Story against the scenario's 3–5 contract, where a fresh `/plan` session on the
+identical seed authored **four**. Planning inside a session already framed as
+small work under-decomposes, so walking past the escalation silently produced
+the very outcome the guard exists to prevent. The gate's decision was right both
+times; only the outcome's finality was missing.
+
+Nothing is left half-started: an escalated run creates **no receipt Story, no
+`story-<id>` branch, and no worktree** — the escalation path returns before
+every creation call site, and `escalation.created` records all three as `false`
+in a shape the schema pins, so a later run finds nothing to trip over.
+
 ## Constraints
 
-- **Land or block — never a silent local build.** The close push is the only
-  sanctioned landing.
+- **Land, block, or escalate — never a silent local build.** The close push is
+  the only sanctioned landing; an `escalated` terminal is the only sanctioned
+  ending that delivers nothing, and it ends the session
+  (§ Escalation is terminal).
 - **No parallel engine.** `/deliver-light` invokes `single-story-init.js` and
   `single-story-close.js`; it never reimplements worktree, branch, PR, or merge
   mechanics.

--- a/tests/contract/story-deliver-terminal.test.js
+++ b/tests/contract/story-deliver-terminal.test.js
@@ -9,8 +9,12 @@
  * agree" with an enforced shape.
  *
  * It pins:
- *   - the status enum is exactly landed | pending | blocked | failed (no
- *     fifth status can be smuggled in);
+ *   - the status enum is exactly landed | pending | blocked | failed |
+ *     escalated, and the builder rejects anything else — no status can be
+ *     smuggled in without landing here first (Story #4746 added `escalated`
+ *     deliberately, and this suite is where that had to be argued);
+ *   - `escalated` is the pre-Story terminal: storyId null, an escalation block
+ *     whose `created` flags are structurally false, and its own exit code;
  *   - the builder VALIDATES and throws rather than emitting a malformed
  *     terminal — a silently-wrong terminal is the failure mode the envelope
  *     exists to eliminate;
@@ -29,6 +33,7 @@ import { fileURLToPath } from 'node:url';
 import { setLevel } from '../../.agents/scripts/lib/Logger.js';
 import { MERGE_UNLANDED_BLOCK_CLASSES } from '../../.agents/scripts/lib/orchestration/merge-block-class.js';
 import {
+  buildEscalationTerminal,
   buildTerminalEnvelope,
   emitTerminalEnvelope,
   exitCodeForTerminal,
@@ -64,12 +69,17 @@ const CLEAN_TAIL = {
 };
 
 describe('story-deliver-terminal — the status contract', () => {
-  it('the schema admits exactly four statuses, and no more', () => {
+  it('the schema admits exactly these five statuses, and no more', () => {
+    // A closed list, not a growing one. Story #4746 added `escalated` because
+    // /deliver-light needed an outcome that ends a session before a Story
+    // exists; the point of pinning the list is that the next addition has to
+    // be argued here rather than appearing in a diff nobody reads.
     assert.deepEqual(SCHEMA.properties.status.enum, [
       'landed',
       'pending',
       'blocked',
       'failed',
+      'escalated',
     ]);
     assert.deepEqual([...TERMINAL_STATUSES], SCHEMA.properties.status.enum);
   });
@@ -113,6 +123,124 @@ describe('story-deliver-terminal — the status contract', () => {
     // from "hard block, come look" without parsing stdout.
     assert.notEqual(TERMINAL_EXIT_CODES.pending, TERMINAL_EXIT_CODES.landed);
     assert.notEqual(TERMINAL_EXIT_CODES.pending, TERMINAL_EXIT_CODES.blocked);
+    // Story #4746 — escalation delivered nothing, so it must not read as a
+    // land; it is also not a block, so it must not be diagnosed as one.
+    assert.equal(TERMINAL_EXIT_CODES.escalated, 2);
+    assert.notEqual(TERMINAL_EXIT_CODES.escalated, TERMINAL_EXIT_CODES.landed);
+    assert.notEqual(TERMINAL_EXIT_CODES.escalated, TERMINAL_EXIT_CODES.blocked);
+  });
+});
+
+describe('story-deliver-terminal — escalated (Story #4746)', () => {
+  const ESCALATION_REASONS = [
+    'shape: changes[] declares 7 entries (> maxChanges 2)',
+    '--yes on over-scope fails closed to /plan (never silently proceeds light)',
+  ];
+
+  it('is the pre-Story terminal: null storyId, /plan next command, exit 2', () => {
+    const env = buildEscalationTerminal({
+      prompt: 'rework the whole billing pipeline',
+      reasons: ESCALATION_REASONS,
+      elapsedSeconds: 0.4,
+    });
+    assert.equal(env.status, 'escalated');
+    assert.equal(env.phase, 'suitability-gate');
+    assert.equal(env.storyId, null);
+    assert.equal(exitCodeForTerminal(env), 2);
+    assert.match(env.nextCommand, /^\/plan "/);
+    assert.match(env.nextCommand, /billing pipeline/);
+    assert.deepEqual(env.escalation.reasons, ESCALATION_REASONS);
+  });
+
+  it('records per artifact that nothing was started, and cannot claim otherwise', () => {
+    const env = buildEscalationTerminal({
+      prompt: 'overhaul auth',
+      reasons: ESCALATION_REASONS,
+    });
+    assert.deepEqual(env.escalation.created, {
+      receiptStory: false,
+      storyBranch: false,
+      worktree: false,
+    });
+    // The flags are pinned by the schema, not merely produced by the builder:
+    // an envelope asserting it authored a receipt Story is unbuildable.
+    const { valid } = validateTerminalEnvelope({
+      ...env,
+      escalation: {
+        ...env.escalation,
+        created: { ...env.escalation.created, receiptStory: true },
+      },
+    });
+    assert.equal(
+      valid,
+      false,
+      'an escalated run must not be able to claim it created a Story',
+    );
+  });
+
+  it('refuses to name a Story it did not create', () => {
+    const { valid } = validateTerminalEnvelope({
+      kind: TERMINAL_ENVELOPE_KIND,
+      storyId: 4746,
+      status: 'escalated',
+      phase: 'suitability-gate',
+      escalation: {
+        reasons: ESCALATION_REASONS,
+        created: { receiptStory: false, storyBranch: false, worktree: false },
+      },
+      nextCommand: '/plan "x"',
+      elapsedSeconds: 0,
+    });
+    assert.equal(valid, false);
+  });
+
+  it('keeps the escalation block out of every other status', () => {
+    const { valid } = validateTerminalEnvelope({
+      kind: TERMINAL_ENVELOPE_KIND,
+      storyId: 4746,
+      status: 'landed',
+      phase: 'post-land',
+      escalation: {
+        reasons: ['sneaking in'],
+        created: { receiptStory: false, storyBranch: false, worktree: false },
+      },
+      nextCommand: null,
+      elapsedSeconds: 1,
+    });
+    assert.equal(valid, false);
+  });
+
+  it('still requires an integer storyId for the four Story-bearing statuses', () => {
+    for (const status of ['landed', 'pending', 'blocked', 'failed']) {
+      const { valid } = validateTerminalEnvelope({
+        kind: TERMINAL_ENVELOPE_KIND,
+        storyId: null,
+        status,
+        phase: 'confirm-merge',
+        nextCommand: null,
+        elapsedSeconds: 0,
+      });
+      assert.equal(valid, false, `${status} must still name its Story`);
+    }
+  });
+
+  it('refuses an escalation with no prompt to hand /plan', () => {
+    // `/plan ""` is the walk-past-able non-outcome in envelope clothing.
+    assert.throws(
+      () =>
+        buildEscalationTerminal({ prompt: '   ', reasons: ESCALATION_REASONS }),
+      /non-empty prompt is required/,
+    );
+  });
+
+  it('quotes the prompt so it cannot break out of the next command', () => {
+    const env = buildEscalationTerminal({
+      prompt: 'add "smart" quotes\nand a \\ backslash',
+      reasons: ESCALATION_REASONS,
+    });
+    assert.equal(env.nextCommand.split('\n').length, 1);
+    assert.match(env.nextCommand, /\\"smart\\"/);
+    assert.match(env.nextCommand, /\\\\ backslash/);
   });
 });
 

--- a/tests/lib/orchestration/light-suitability.test.js
+++ b/tests/lib/orchestration/light-suitability.test.js
@@ -20,6 +20,12 @@
 //   - AC-6: --amends is shape-checked identically (small → light, heavy → plan);
 //   - AC-7: /deliver-light projects into the generated command tree;
 //   - AC-8: the light entry contains no parallel init/close implementation.
+//
+// Story #4746 makes the escalate-plan OUTCOME terminal rather than advisory.
+// The gate's decision is untouched (the describes above still pass verbatim);
+// what is new is that over-scope under --yes emits a schema-validated
+// `escalated` terminal envelope, starts nothing, and ends the session — see
+// the final three describes.
 
 import assert from 'node:assert/strict';
 import { spawnSync } from 'node:child_process';
@@ -28,13 +34,13 @@ import { tmpdir } from 'node:os';
 import path from 'node:path';
 import test, { describe } from 'node:test';
 import { fileURLToPath } from 'node:url';
-
 import {
   buildNextCommands,
   buildPredictedChanges,
   createLightReceipt,
   parseCsvPaths,
   runDiffBackstop,
+  runGateMode,
   runLightGate,
   synthesizeAcceptance,
 } from '../../../.agents/scripts/deliver-light.js';
@@ -46,6 +52,12 @@ import {
   resolveLedgeredVerdict,
   resolveLightGateOutcome,
 } from '../../../.agents/scripts/lib/orchestration/light-suitability.js';
+import {
+  TERMINAL_BEGIN_MARKER,
+  TERMINAL_END_MARKER,
+  validateTerminalEnvelope,
+} from '../../../.agents/scripts/lib/orchestration/story-deliver-terminal.js';
+import { assertDocMentions, readDoc } from '../../helpers/doc-assert.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = path.resolve(__dirname, '..', '..', '..');
@@ -478,6 +490,240 @@ describe('deliver-light.js is a thin entry point, not a second engine (AC-8)', (
         `deliver-light.js must not reimplement engine mechanics (${pat})`,
       );
     }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Story #4746 — escalation is TERMINAL, not advisory
+// ---------------------------------------------------------------------------
+
+/** Over-scope gate inputs: 7 predicted changes against a maxChanges of 2. */
+const OVER_SCOPE = {
+  prompt: 'rework the whole reporting pipeline end to end',
+  refactors: Array.from({ length: 7 }, (_v, i) => `src/report/mod${i}.js`).join(
+    ',',
+  ),
+  acceptance: '5',
+  route: 'lite',
+  reason: 'claims small but is not',
+};
+
+/**
+ * Drive `runGateMode` with every side-effecting seam replaced by a spy, so a
+ * test can assert not merely that the envelope SAYS nothing was created but
+ * that the code never reached the call sites that would create anything.
+ *
+ * @param {object} values
+ * @returns {Promise<{ code: number, terminals: object[], gateEnvelopes: object[], created: number, providers: number }>}
+ */
+async function driveGate(values) {
+  const terminals = [];
+  const gateEnvelopes = [];
+  let created = 0;
+  let providers = 0;
+  const code = await runGateMode(values, {
+    createProviderFn: () => {
+      providers += 1;
+      return {};
+    },
+    resolveConfigFn: () => ({}),
+    createReceiptFn: async () => {
+      created += 1;
+      return { storyId: 1, url: 'https://example/1', title: 't' };
+    },
+    emitFn: (envelope) => gateEnvelopes.push(envelope),
+    emitTerminalFn: (envelope) => terminals.push(envelope),
+  });
+  return { code, terminals, gateEnvelopes, created, providers };
+}
+
+describe('escalate-plan emits a terminal envelope and exits non-zero (AC-1)', () => {
+  test('the envelope is schema-valid, escalated, and names the /plan next command', async () => {
+    const { code, terminals, gateEnvelopes } = await driveGate({
+      ...OVER_SCOPE,
+      yes: true,
+    });
+
+    assert.equal(terminals.length, 1, 'exactly one terminal envelope');
+    const env = terminals[0];
+    assert.equal(validateTerminalEnvelope(env).valid, true);
+    assert.equal(env.kind, 'story-deliver-terminal');
+    assert.equal(env.status, 'escalated');
+    assert.equal(env.phase, 'suitability-gate');
+    assert.match(env.nextCommand, /^\/plan "/);
+    assert.match(env.nextCommand, /reporting pipeline/);
+
+    // Non-zero: a caller must not be able to read escalation as success.
+    assert.notEqual(code, 0);
+    assert.equal(code, 2);
+
+    // The terminal replaces the walk-past-able gate envelope; it does not
+    // accompany it. One session, one terminal output.
+    assert.equal(gateEnvelopes.length, 0);
+  });
+
+  test('the gate reasons survive verbatim into the envelope', async () => {
+    const { terminals } = await driveGate({ ...OVER_SCOPE, yes: true });
+    const reasons = terminals[0].escalation.reasons.join(' ');
+    assert.match(reasons, /maxChanges/);
+    assert.match(reasons, /--yes on over-scope fails closed to \/plan/);
+  });
+});
+
+describe('an escalated run starts nothing (AC-2)', () => {
+  test('never reaches the receipt-Story call site', async () => {
+    const { created, providers } = await driveGate({
+      ...OVER_SCOPE,
+      yes: true,
+    });
+    assert.equal(created, 0, 'no receipt Story may be authored');
+    assert.equal(
+      providers,
+      0,
+      'the escalate path must not even build a provider',
+    );
+  });
+
+  test('the envelope records no Story, no branch, and no worktree', async () => {
+    const { terminals } = await driveGate({ ...OVER_SCOPE, yes: true });
+    const env = terminals[0];
+    assert.equal(env.storyId, null, 'an escalated run names no Story');
+    assert.deepEqual(env.escalation.created, {
+      receiptStory: false,
+      storyBranch: false,
+      worktree: false,
+    });
+  });
+
+  test('end to end from a NON-repo cwd: no git, no GitHub, still terminal', () => {
+    // The strongest available pin on "nothing was started": run the real CLI
+    // somewhere with no git repository at all. Anything that cut a branch,
+    // materialized a worktree, or resolved repo config would fail here; a
+    // clean exit 2 with a valid envelope proves the path did none of it.
+    const cwd = mkdtempSync(path.join(tmpdir(), 'light-escalate-'));
+    const result = spawnSync(
+      process.execPath,
+      [
+        DELIVER_LIGHT_SRC,
+        '--prompt',
+        OVER_SCOPE.prompt,
+        '--refactors',
+        OVER_SCOPE.refactors,
+        '--acceptance',
+        OVER_SCOPE.acceptance,
+        '--route',
+        'lite',
+        '--reason',
+        OVER_SCOPE.reason,
+        '--yes',
+      ],
+      { cwd, encoding: 'utf8' },
+    );
+
+    assert.equal(result.status, 2, result.stderr);
+    assert.ok(!existsSync(path.join(cwd, '.worktrees')), 'no worktree');
+    assert.ok(!existsSync(path.join(cwd, '.git')), 'no repo touched');
+
+    const body = result.stdout
+      .split(TERMINAL_BEGIN_MARKER)[1]
+      ?.split(TERMINAL_END_MARKER)[0];
+    assert.ok(body, 'the terminal envelope must be recoverable from stdout');
+    const env = JSON.parse(body);
+    assert.equal(env.status, 'escalated');
+    assert.equal(env.storyId, null);
+    assert.equal(validateTerminalEnvelope(env).valid, true);
+  });
+});
+
+describe('the attended over-scope path is UNCHANGED (AC-4)', () => {
+  test('still asks the operator to choose, with no terminal envelope', async () => {
+    const { code, terminals, gateEnvelopes, created } = await driveGate({
+      ...OVER_SCOPE,
+      yes: false,
+    });
+
+    // A question, not a terminal — emitting one would end a session that is
+    // supposed to be waiting for the operator's answer.
+    assert.equal(terminals.length, 0);
+    assert.equal(gateEnvelopes.length, 1);
+    assert.equal(gateEnvelopes[0].action, 'ask-operator');
+    assert.deepEqual(gateEnvelopes[0].outcome.options, [
+      'escalate-plan',
+      'proceed-light',
+    ]);
+    assert.equal(code, 2);
+    assert.equal(created, 0);
+  });
+
+  test('proceed-light is likewise untouched — receipt authored, no terminal', async () => {
+    const { code, terminals, gateEnvelopes, created } = await driveGate({
+      prompt: 'add a bin/hello.js greeter',
+      creates: 'bin/hello.js',
+      acceptance: '1',
+      route: 'lite',
+      reason: 'single additive file',
+      yes: true,
+    });
+    assert.equal(code, 0);
+    assert.equal(created, 1);
+    assert.equal(terminals.length, 0);
+    assert.equal(gateEnvelopes[0].action, 'proceed-light');
+  });
+});
+
+describe('the workflow states escalation is terminal (AC-3)', () => {
+  // Prose assertions go through doc-assert: these claims are about what the
+  // document SAYS, and a plain `assert.match` would silently also be pinning
+  // where the 80-column wrap happens to fall.
+  const doc = readDoc(
+    path.join(REPO_ROOT, '.agents', 'workflows', 'deliver-light.md'),
+  );
+
+  test('names the envelope as the session terminal output', () => {
+    assertDocMentions(
+      doc,
+      /envelope IS this session's terminal output/i,
+      'the workflow must state the escalated envelope IS the terminal output',
+    );
+    assertDocMentions(doc, /status.{0,4}:.{0,4}"?escalated/i);
+  });
+
+  test('forbids invoking /plan in the same session', () => {
+    // `?` around the code span: this pins what the doc SAYS, not whether
+    // /plan happens to be code-formatted at that call site.
+    assertDocMentions(
+      doc,
+      /Invoking `?\/plan`? in this same session is forbidden/i,
+      'in-session /plan must be forbidden in so many words',
+    );
+    assertDocMentions(doc, /`?\/plan`? runs in a \*\*fresh\*\* session/i);
+  });
+
+  test('records the empirical reason so the rule reads as load-bearing', () => {
+    // Without the measurement this is style; with it, it is a finding. Pin
+    // the numbers themselves — a doc that kept the word "empirically" but
+    // dropped the 1-vs-4 comparison would have lost exactly what makes the
+    // rule persuasive to the next session reading it.
+    assertDocMentions(doc, /mandrel-bench/i);
+    assertDocMentions(
+      doc,
+      /authored \*\*one\*\* Story against the scenario's 3[–-]5 contract/i,
+      'the under-decomposition finding must name what in-session planning produced',
+    );
+    assertDocMentions(
+      doc,
+      /fresh `?\/plan`? session on the identical seed authored \*\*four\*\*/i,
+      'the finding is only load-bearing next to the fresh-session comparison',
+    );
+    assertDocMentions(doc, /under-decompos/i);
+  });
+
+  test('states that an escalated run leaves no Story, branch, or worktree', () => {
+    assertDocMentions(
+      doc,
+      /no receipt Story, no `story-<id>` branch, and no worktree/i,
+      'the workflow must name all three artifacts an escalated run does not create',
+    );
   });
 });
 


### PR DESCRIPTION
Closes #4746

_Auto-opened by `/deliver`._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes orchestration exit contracts and the shared terminal schema; behavior is heavily tested but any consumer parsing terminal statuses must accept `escalated` and null `storyId`.
> 
> **Overview**
> Over-scope `/deliver-light` under **`--yes`** no longer returns a walk-past gate JSON hint; it emits a validated **`story-deliver-terminal`** with **`status: "escalated"`** and ends the session (exit **2**).
> 
> The **`story-deliver-terminal`** contract gains **`escalated`**, phase **`suitability-gate`**, nullable **`storyId`** only for that status, an **`escalation`** block (verbatim gate reasons plus **`created`** flags pinned false for receipt Story, branch, and worktree), and schema **`allOf`** rules so escalation cannot be mixed with Story-bearing statuses. **`buildEscalationTerminal`** and **`NEXT_COMMANDS.escalateToPlan`** build a shell-safe **`/plan "<prompt>"`** **`nextCommand`** for a **fresh** session.
> 
> **`deliver-light.js`** handles **`escalate-plan`** **before** any provider or receipt creation, with injectable seams and tests proving no side effects. Attended **`ask-operator`** and **`proceed-light`** behavior is unchanged. The **`deliver-light`** workflow documents that the escalated envelope is the sole terminal output and forbids in-session **`/plan`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3785d4af304134f0c53959d2d305b4e65ffdc2d5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->