### PR TITLE
fix(deps): bump brace-expansion to 5.0.8 for GHSA-mh99-v99m-4gvg

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2259,15 +2259,15 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/braces": {


### PR DESCRIPTION
## Why

`npm audit --audit-level=high` went red on `main` without any code change — [GHSA-mh99-v99m-4gvg](https://github.com/advisories/GHSA-mh99-v99m-4gvg) (high-severity DoS in `brace-expansion <=5.0.7`) was published after main's last green run (`cb898533`).

Two reasons this blocks work rather than being cosmetic:

1. **It is production-reachable.** The chain is `mandrel@2.14.0 → minimatch@10.2.5 → brace-expansion`, and `minimatch` is a `dependencies` entry. `.agents/rules/security-baseline.md` § Dependency Hygiene makes remediating production-reachable high-severity findings a MUST.
2. **It gates CI.** `.github/workflows/ci.yml` runs `npm audit --audit-level=high` with no `continue-on-error`, so every open PR fails until this lands.

Found during `/deliver` pre-flight for the #4752 → #4750 → #4751 chain, which would otherwise have burned three PR cycles against a red gate.

## What

Lockfile-only. `minimatch` is already at latest (10.2.5), so no direct dependency moves — only the transitive `brace-expansion` pin, 5.0.7 → 5.0.8.

## Verification

| Gate | Result |
| --- | --- |
| `npm audit --audit-level=high` | exit 0 (was exit 1) |
| `npm run lint` | exit 0 |
| `node .agents/scripts/check-baselines.js` | 0 breaches, 0 regressions |
| `npm test` | 8502 passed, 0 failed, 4 skipped |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Transitive dependency version bump only; no runtime or application logic changes, with low blast radius beyond restored audit compliance.
> 
> **Overview**
> **Lockfile-only** security fix: bumps transitive **`brace-expansion`** from **5.0.7** to **5.0.8** in `package-lock.json` to address [GHSA-mh99-v99m-4gvg](https://github.com/advisories/GHSA-mh99-v99m-4gvg) (high-severity DoS). No `package.json` or application code changes—`minimatch` stays at 10.2.5 and still pulls `brace-expansion` via its dependency range.
> 
> The updated lock entry also reflects upstream’s **`engines`** change for `brace-expansion` (**`20 || >=22`** instead of **`18 || 20 || >=22`**). This should clear **`npm audit --audit-level=high`** on CI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 35408974967447befd5c5bd20255e41dc654d09e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->