### PR TITLE
feat: gate the workflow read-tier with a transitive mandatory-closure ratchet (#4752)

### DIFF
--- a/.agents/scripts/check-context-budget.js
+++ b/.agents/scripts/check-context-budget.js
@@ -11,6 +11,13 @@
  *   - `alwaysLoaded`  — the `CLAUDE.md` `@`-import closure re-paid on every
  *                       session and every subagent spawn (instructions.md § 4).
  *   - `mandatoryRead` — the resolved `project.docsContextFiles` set.
+ *   - `workflow`      — the workflow **mandatory closure** (Story #4752): every
+ *                       `.agents/workflows/**` entry point plus the transitive
+ *                       closure of its `mandatoryReads:` frontmatter edges. The
+ *                       companion **reachable** closure (per entry point) is
+ *                       recorded under the top-level `workflowClosure` key as a
+ *                       drift signal and never gates — growth there is a
+ *                       reading-cost signal, not a contract violation.
  *
  * It additionally enforces a **per-file** ceiling on the role-scoped agent-boot
  * tier (`.agents/agents/*.md`, #4478): no single boot context may exceed
@@ -52,12 +59,12 @@ import { resolveConfig } from './lib/config-resolver.js';
 import { resolveDocTiers, tierTotalBytes } from './lib/doc-tiers.js';
 
 /**
- * The tiers this ratchet gates (in report order). `digestVisible` and
- * `onDemand` are resolved by the tier map for the lens, but the byte budget
- * intentionally gates only the two tiers the Epic AC names.
- * @type {Array<'alwaysLoaded' | 'mandatoryRead'>}
+ * The tiers this ratchet gates (in report order). `digestVisible`, `onDemand`
+ * and `workflowOnDemand` are resolved by the tier map for the lens, but the
+ * byte budget intentionally gates only the tiers a session is *forced* to read.
+ * @type {Array<'alwaysLoaded' | 'mandatoryRead' | 'workflow'>}
  */
-export const GATED_TIERS = ['alwaysLoaded', 'mandatoryRead'];
+export const GATED_TIERS = ['alwaysLoaded', 'mandatoryRead', 'workflow'];
 
 /**
  * Default tolerance (bytes) seeded into a fresh baseline by `--update` when the
@@ -171,6 +178,12 @@ export function buildBaseline(tierMap, toleranceBytes) {
       ceilingBytes: AGENT_BOOT_CEILING_BYTES,
       files: agentBootFiles,
     },
+    // Recorded, never gated (#4752): the total reachable closure per workflow
+    // entry point. It is a drift signal — the gate is `tiers.workflow`.
+    workflowClosure: {
+      reachableTotalBytes: tierMap.workflowClosure?.reachableTotalBytes ?? 0,
+      entryPoints: tierMap.workflowClosure?.entryPoints ?? [],
+    },
   };
 }
 
@@ -247,6 +260,25 @@ export function renderDiff(diff) {
     `[context-budget] grown=${diff.grown.length} shrunk=${diff.shrunk.length} skipped=${diff.skipped.length} ${tag}`,
   );
   return lines.join('\n');
+}
+
+/**
+ * Render the workflow **reachable** closure line — recorded, never gated
+ * (Story #4752). Returns `''` when there is no workflow tier to report, so the
+ * caller can stay a one-liner.
+ *
+ * @param {{ workflowClosure?: { reachableTotalBytes?: number, entryPoints?: unknown[] } }} tierMap
+ * @param {{ workflowClosure?: { reachableTotalBytes?: number } } | null} [baseline]
+ * @returns {string}
+ */
+export function renderReachable(tierMap, baseline) {
+  const closure = tierMap?.workflowClosure;
+  const current = closure?.reachableTotalBytes ?? 0;
+  if (current <= 0) return '';
+  const recorded = baseline?.workflowClosure?.reachableTotalBytes;
+  const against = Number.isFinite(recorded) ? ` (recorded ${recorded})` : '';
+  const entries = closure.entryPoints?.length ?? 0;
+  return `  workflow reachable closure: ${current} bytes across ${entries} entry points${against} — drift signal, never gated`;
 }
 
 /**
@@ -338,12 +370,15 @@ export async function runCli({
       skipped: diff.skipped,
       agentBootCeilingBytes: ceiling,
       agentBootOverflow: bootOverflow,
+      workflowReachableBytes: tierMap.workflowClosure?.reachableTotalBytes ?? 0,
       exitCode,
     };
     stdout.write(`${JSON.stringify(envelope, null, 2)}\n`);
   } else {
     stdout.write(`\n--- context-budget preview ---\n`);
     stdout.write(`${renderDiff(diff)}\n`);
+    const reachable = renderReachable(tierMap, baseline);
+    if (reachable) stdout.write(`${reachable}\n`);
     for (const o of bootOverflow) {
       stdout.write(
         `+ agentBoot: ${o.path} is ${o.bytes} bytes, over the ${o.ceiling}-byte per-agent ceiling\n`,

--- a/.agents/scripts/lib/doc-tiers.js
+++ b/.agents/scripts/lib/doc-tiers.js
@@ -29,11 +29,19 @@
  *                       converted spawn boots on **instead of** the always-loaded
  *                       closure, so it is budgeted independently (per-file ≤8KB
  *                       ceiling gated by `check-context-budget.js`).
+ *   - `workflow` /    — the `.agents/workflows/**` read-tier (Story #4752),
+ *     `workflowOnDemand` resolved as each entry point's transitive
+ *                       markdown-link closure by
+ *                       [`workflow-closure.js`](workflow-closure.js): the files
+ *                       an entry point's `mandatoryReads:` frontmatter forces
+ *                       you to read (`workflow`, gated) versus the reachable
+ *                       remainder (`workflowOnDemand`, recorded only).
  *
  * A file that could appear in more than one tier is kept in its **highest**
  * tier only (alwaysLoaded > mandatoryRead > digestVisible > onDemand), so the
  * arrays partition the doc set with no double-counting. `agentBoot` is disjoint
- * from the read-tiers (it lives under `.agents/agents/`, not the doc/rules set).
+ * from the read-tiers (it lives under `.agents/agents/`, not the doc/rules set),
+ * and so are the workflow tiers (confined to `.agents/workflows/`).
  *
  * The closure is discovered by parsing `@`-import references and following
  * them recursively (cycle-safe via a visited set). A candidate `@`-token only
@@ -47,6 +55,7 @@
 
 import nodeFs from 'node:fs';
 import path from 'node:path';
+import { resolveWorkflowClosures } from './workflow-closure.js';
 
 /**
  * Basename of the always-loaded entry document (the root of the closure).
@@ -212,18 +221,31 @@ export function docsContextPaths(config) {
 }
 
 /**
- * Resolve the four documentation read-tiers, each entry `{ path, bytes }`,
+ * Resolve the documentation read-tiers, each entry `{ path, bytes }`,
  * partitioned so no path appears in more than one tier (highest tier wins).
+ * `workflowClosure` rides alongside the tiers as the per-entry-point workflow
+ * measurement (Story #4752) — its `reachableTotalBytes` is a recorded drift
+ * signal, never a gate.
  *
  * @param {object} config resolved config (`resolveConfig()` output)
  * @param {{ root?: string, fs?: FsLike }} [opts]
- * @returns {{ tiers: {
- *   alwaysLoaded: Array<{ path: string, bytes: number }>,
- *   mandatoryRead: Array<{ path: string, bytes: number }>,
- *   digestVisible: Array<{ path: string, bytes: number }>,
- *   onDemand: Array<{ path: string, bytes: number }>,
- *   agentBoot: Array<{ path: string, bytes: number }>,
- * } }}
+ * @returns {{
+ *   tiers: {
+ *     alwaysLoaded: Array<{ path: string, bytes: number }>,
+ *     mandatoryRead: Array<{ path: string, bytes: number }>,
+ *     digestVisible: Array<{ path: string, bytes: number }>,
+ *     onDemand: Array<{ path: string, bytes: number }>,
+ *     agentBoot: Array<{ path: string, bytes: number }>,
+ *     workflow: Array<{ path: string, bytes: number }>,
+ *     workflowOnDemand: Array<{ path: string, bytes: number }>,
+ *   },
+ *   workflowClosure: {
+ *     mandatoryTotalBytes: number,
+ *     reachableTotalBytes: number,
+ *     entryPoints: Array<{ path: string, mandatoryBytes: number, reachableBytes: number }>,
+ *   },
+ * }}
+ * @throws {Error} on an unresolvable `mandatoryReads` entry or a mandatory cycle
  */
 export function resolveDocTiers(
   config,
@@ -265,8 +287,29 @@ export function resolveDocTiers(
   //    are standalone system prompts, disjoint from the doc read-tiers.
   const agentBoot = collect(listAgentDefs(root, fs));
 
+  // 6. workflow: each entry point's transitive markdown-link closure (#4752),
+  //    split into the gated mandatory set and the recorded on-demand remainder.
+  //    The walk is confined to `.agents/workflows/**`, and `collect` still
+  //    de-dupes, so no path is counted against two tiers.
+  const closure = resolveWorkflowClosures(root, { fs });
+  const workflow = collect(closure.mandatoryFiles.map((e) => e.path));
+  const workflowOnDemand = collect(closure.onDemandFiles.map((e) => e.path));
+
   return {
-    tiers: { alwaysLoaded, mandatoryRead, digestVisible, onDemand, agentBoot },
+    tiers: {
+      alwaysLoaded,
+      mandatoryRead,
+      digestVisible,
+      onDemand,
+      agentBoot,
+      workflow,
+      workflowOnDemand,
+    },
+    workflowClosure: {
+      mandatoryTotalBytes: closure.mandatoryTotalBytes,
+      reachableTotalBytes: closure.reachableTotalBytes,
+      entryPoints: closure.entryPoints,
+    },
   };
 }
 

--- a/.agents/scripts/lib/workflow-closure.js
+++ b/.agents/scripts/lib/workflow-closure.js
@@ -1,0 +1,431 @@
+/**
+ * Workflow read-tier closure resolver (Story #4752).
+ *
+ * `.agents/workflows/**` is the largest body of instruction Mandrel ships, and
+ * until this module it sat in none of the five doc read-tiers `doc-tiers.js`
+ * resolves — measured only by a per-file spine ceiling that is satisfied by
+ * moving prose into a linked helper. Workflows are a **graph**, not a flat set,
+ * so this module resolves each entry point's transitive markdown-link closure
+ * into two numbers:
+ *
+ *   - **mandatory closure** — the entry point plus the transitive closure of
+ *     its `mandatoryReads:` frontmatter edges. This is what a session is
+ *     *forced* to read, and it is what `check-context-budget.js` ratchets.
+ *   - **reachable closure** — the entry point plus every workflow markdown file
+ *     transitively linked from it. Recorded as a drift signal, never gated.
+ *
+ * **The marker is source-side and per-edge.** A workflow declares the reads it
+ * requires in its own frontmatter (`mandatoryReads: [path, …]`, flow or block
+ * style, resolved relative to the declaring file). Tier is not intrinsic to a
+ * helper — the same file is mandatory from one workflow and on-demand from
+ * another — so it cannot live in the target. The key is optional: an absent
+ * key means zero mandatory edges and is never an error. Every reachable link
+ * not named in `mandatoryReads` is classified on-demand.
+ *
+ * **Entry points** are the workflows a session can be invoked on: every
+ * top-level `.agents/workflows/*.md`, plus any `helpers/*.md` whose H1 declares
+ * a slash command named after the file itself (`helpers/deliver-story.md` →
+ * `# /deliver-story …`) — a command-shaped helper is invoked directly, so it
+ * owns a closure of its own. Plain helpers and appendices are reachable, never
+ * entry points; counting every file as an entry point would collapse the
+ * mandatory/on-demand distinction into "all workflow bytes".
+ *
+ * **Failure modes are loud** — a ratchet that silently shrinks its own closure
+ * is worse than none:
+ *   - a `mandatoryReads` entry that does not resolve to a workflow markdown
+ *     file throws, naming the declaring workflow and the offending path;
+ *   - a cycle among `mandatoryReads` edges throws, naming the cycle.
+ * The **reachable** walk is deliberately cycle-*tolerant* rather than fatal:
+ * bidirectional prose cross-references are normal and correct authoring (a
+ * spine points at its digest, the digest points back at the spine), so that
+ * walk terminates via a visited set and counts each file exactly once — it
+ * neither loops nor truncates. Only the gated mandatory graph, where a loop is
+ * a genuine authoring error, fails closed.
+ *
+ * The walk is confined to `.agents/workflows/**`: links out to
+ * `.agents/rules/**` or `.agents/skills/**` are neither followed nor recorded,
+ * because those are already tiered as flat sets by `doc-tiers.js` and
+ * following them would double-count them.
+ *
+ * Security (security-baseline § Data Leakage & Logging): every value returned
+ * or thrown is a repo-relative path or a byte count — never file contents.
+ */
+
+import nodeFs from 'node:fs';
+import path from 'node:path';
+
+/**
+ * Repo-relative root of the workflow tree. The closure never escapes it.
+ * @type {string}
+ */
+const WORKFLOWS_ROOT = '.agents/workflows';
+
+/** Path-segment count of a top-level workflow (`.agents/workflows/x.md`). */
+const TOP_LEVEL_DEPTH = 3;
+
+// All RegExp instances are built via the constructor (rather than literal
+// `/.../`) so the maintainability engine's AST walker (typhonjs-escomplex) can
+// score this file — it crashes on `RegExpLiteral` nodes. Same workaround as
+// lib/audit-suite/frontmatter.js.
+// biome-ignore-start lint/complexity/useRegexLiterals: typhonjs-escomplex MI workaround
+const FRONTMATTER_RE = new RegExp(String.raw`^---\r?\n([\s\S]*?)\r?\n---`);
+const NEWLINE_RE = new RegExp(String.raw`\r?\n`);
+const MANDATORY_KEY_RE = new RegExp(String.raw`^mandatoryReads\s*:(.*)$`);
+const BLOCK_ITEM_RE = new RegExp(String.raw`^\s*-\s*(.+)$`);
+const MD_LINK_RE = new RegExp(String.raw`\]\(\s*([^)\s]+)`, 'g');
+const COMMAND_H1_RE = new RegExp(String.raw`^#\s+/([A-Za-z0-9._-]+)`, 'm');
+// biome-ignore-end lint/complexity/useRegexLiterals: typhonjs-escomplex MI workaround
+
+/**
+ * Default fs surface — the same injectable subset `doc-tiers.js` uses.
+ * @typedef {{
+ *   readdirSync: (p: string, o?: object) => any[],
+ *   readFileSync: (p: string, enc: string) => string,
+ *   statSync: (p: string) => { size: number },
+ * }} FsLike
+ */
+
+/**
+ * A loaded workflow document.
+ * @typedef {{ rel: string, bytes: number, source: string }} WorkflowDoc
+ */
+
+/**
+ * Strip surrounding quotes and whitespace from a scalar YAML value.
+ *
+ * @param {string} value
+ * @returns {string}
+ */
+function unquote(value) {
+  const t = String(value ?? '').trim();
+  const quoted =
+    t.length >= 2 &&
+    ((t.startsWith('"') && t.endsWith('"')) ||
+      (t.startsWith("'") && t.endsWith("'")));
+  return quoted ? t.slice(1, -1).trim() : t;
+}
+
+/**
+ * Convert a path to posix separators.
+ *
+ * @param {string} p
+ * @returns {string}
+ */
+function toPosix(p) {
+  return p.split(path.sep).join('/');
+}
+
+/**
+ * Return the raw frontmatter block of a markdown source (`''` when absent).
+ *
+ * @param {string} source
+ * @returns {string}
+ */
+function frontmatterBlock(source) {
+  const m = FRONTMATTER_RE.exec(String(source ?? ''));
+  return m ? m[1] : '';
+}
+
+/**
+ * Collect a YAML block-sequence (`- item`) starting at `start`. Blank lines are
+ * skipped; the first non-item, non-blank line ends the sequence.
+ *
+ * @param {string[]} lines
+ * @param {number} start
+ * @returns {string[]}
+ */
+function blockSequence(lines, start) {
+  const out = [];
+  for (let i = start; i < lines.length; i += 1) {
+    const item = BLOCK_ITEM_RE.exec(lines[i]);
+    if (item) {
+      const value = unquote(item[1]);
+      if (value) out.push(value);
+    } else if (lines[i].trim() !== '') {
+      break;
+    }
+  }
+  return out;
+}
+
+/**
+ * Split a YAML flow sequence (`[a.md, b.md]`) into its scalar items.
+ *
+ * @param {string} inline
+ * @returns {string[]}
+ */
+function flowSequence(inline) {
+  const body = inline.replace('[', '').replace(']', '');
+  return body
+    .split(',')
+    .map(unquote)
+    .filter((v) => v.length > 0);
+}
+
+/**
+ * Parse the optional `mandatoryReads:` frontmatter list from a workflow source.
+ * Supports the flow (`[a.md, b.md]`), block (`- a.md` lines), and single-scalar
+ * forms. An absent key resolves to `[]` — zero mandatory edges, never an error.
+ *
+ * @param {string} source
+ * @returns {string[]} raw specifiers, relative to the declaring file
+ */
+function parseMandatoryReads(source) {
+  const lines = frontmatterBlock(source).split(NEWLINE_RE);
+  const idx = lines.findIndex((line) => MANDATORY_KEY_RE.test(line));
+  if (idx < 0) return [];
+  const inline = unquote(MANDATORY_KEY_RE.exec(lines[idx])[1]);
+  if (inline.startsWith('[')) return flowSequence(inline);
+  if (inline.length > 0) return [inline];
+  return blockSequence(lines, idx + 1);
+}
+
+/**
+ * Harvest every markdown link target in a source, anchors stripped.
+ *
+ * @param {string} source
+ * @returns {string[]}
+ */
+function parseLinkTargets(source) {
+  const out = [];
+  for (const m of String(source ?? '').matchAll(MD_LINK_RE)) {
+    const target = m[1].split('#')[0].trim();
+    if (target.length > 0) out.push(target);
+  }
+  return out;
+}
+
+/**
+ * Resolve a link/`mandatoryReads` specifier declared in `fromRel` to a known
+ * workflow doc, or `null` when it is external, non-markdown, or outside the
+ * workflow tree.
+ *
+ * @param {string} fromRel repo-relative posix path of the declaring file
+ * @param {string} spec
+ * @param {Map<string, WorkflowDoc>} docs
+ * @returns {string | null}
+ */
+function resolveSpec(fromRel, spec, docs) {
+  if (!spec.endsWith('.md')) return null;
+  if (spec.includes('://') || spec.startsWith('mailto:')) return null;
+  const rel = path.posix.join(path.posix.dirname(fromRel), spec);
+  return docs.has(rel) ? rel : null;
+}
+
+/**
+ * Resolve a workflow's declared mandatory edges. Throws when an entry does not
+ * resolve to a workflow markdown file — a mandatory read pointing at nothing is
+ * a silent hole in the ratchet, so it fails loudly, naming both the declaring
+ * workflow and the offending path.
+ *
+ * @param {WorkflowDoc} doc
+ * @param {Map<string, WorkflowDoc>} docs
+ * @returns {string[]}
+ */
+function mandatoryEdges(doc, docs) {
+  const out = [];
+  for (const spec of parseMandatoryReads(doc.source)) {
+    const rel = resolveSpec(doc.rel, spec, docs);
+    if (!rel) {
+      throw new Error(
+        `[workflow-closure] ${doc.rel} declares mandatoryReads "${spec}", which does not resolve to a markdown file under ${WORKFLOWS_ROOT}`,
+      );
+    }
+    out.push(rel);
+  }
+  return out;
+}
+
+/**
+ * Depth-first walk of the mandatory-edge graph. Cycle-fatal: a `mandatoryReads`
+ * loop is an authoring error, so it throws naming the cycle rather than looping
+ * or silently truncating the closure.
+ *
+ * @param {string} rel
+ * @param {Map<string, WorkflowDoc>} docs
+ * @param {string[]} stack in-progress DFS path
+ * @param {Set<string>} seen finished nodes
+ * @returns {Set<string>} `seen`
+ */
+function walkMandatory(rel, docs, stack, seen) {
+  if (stack.includes(rel)) {
+    throw new Error(
+      `[workflow-closure] mandatoryReads cycle: ${[...stack, rel].join(' -> ')}`,
+    );
+  }
+  if (seen.has(rel)) return seen;
+  seen.add(rel);
+  stack.push(rel);
+  for (const next of mandatoryEdges(docs.get(rel), docs)) {
+    walkMandatory(next, docs, stack, seen);
+  }
+  stack.pop();
+  return seen;
+}
+
+/**
+ * Breadth-first walk of the markdown-link graph. Cycle-tolerant by design:
+ * bidirectional cross-references between a spine and its helper are correct
+ * authoring, so the visited set makes the walk terminate with each file counted
+ * exactly once.
+ *
+ * @param {string} rel
+ * @param {Map<string, WorkflowDoc>} docs
+ * @returns {Set<string>}
+ */
+function walkReachable(rel, docs) {
+  const seen = new Set();
+  const queue = [rel];
+  while (queue.length > 0) {
+    const current = queue.shift();
+    if (seen.has(current)) continue;
+    seen.add(current);
+    for (const spec of parseLinkTargets(docs.get(current).source)) {
+      const next = resolveSpec(current, spec, docs);
+      if (next && !seen.has(next)) queue.push(next);
+    }
+  }
+  return seen;
+}
+
+/**
+ * Recursively collect repo-relative posix paths of every `.md` file under an
+ * absolute directory. An unreadable directory yields nothing (silent skip).
+ *
+ * @param {FsLike} fs
+ * @param {string} dirAbs
+ * @param {string} root
+ * @param {string[]} out
+ * @returns {string[]} `out`
+ */
+function listMarkdown(fs, dirAbs, root, out) {
+  let dirents;
+  try {
+    dirents = fs.readdirSync(dirAbs, { withFileTypes: true });
+  } catch {
+    return out;
+  }
+  for (const dirent of dirents) {
+    const abs = path.join(dirAbs, dirent.name);
+    if (dirent.isDirectory()) listMarkdown(fs, abs, root, out);
+    else if (dirent.name.endsWith('.md'))
+      out.push(toPosix(path.relative(root, abs)));
+  }
+  return out;
+}
+
+/**
+ * Load every workflow markdown file into a `rel -> { rel, bytes, source }` map.
+ *
+ * @param {string} root absolute repo root
+ * @param {FsLike} fs
+ * @returns {Map<string, WorkflowDoc>}
+ */
+function loadDocs(root, fs) {
+  const dirAbs = path.resolve(root, WORKFLOWS_ROOT);
+  const docs = new Map();
+  for (const rel of listMarkdown(fs, dirAbs, root, []).sort()) {
+    const abs = path.resolve(root, rel);
+    try {
+      docs.set(rel, {
+        rel,
+        bytes: fs.statSync(abs).size,
+        source: fs.readFileSync(abs, 'utf8'),
+      });
+    } catch {
+      // Unreadable file — skipped silently, like the sibling tier resolvers.
+    }
+  }
+  return docs;
+}
+
+/**
+ * True when a workflow is invocable in its own right: a top-level workflow, or
+ * a helper whose H1 declares a slash command **named after the file itself**
+ * (`helpers/deliver-story.md` → `# /deliver-story …`). The self-naming test is
+ * what separates an invocable helper from an appendix that merely titles itself
+ * after the command it documents (`helpers/deliver-reference.md` →
+ * `# /deliver — reference appendix`), which is read on demand, never invoked.
+ *
+ * @param {WorkflowDoc} doc
+ * @returns {boolean}
+ */
+function isEntryPoint(doc) {
+  if (doc.rel.split('/').length === TOP_LEVEL_DEPTH) return true;
+  const h1 = COMMAND_H1_RE.exec(doc.source);
+  return h1 ? h1[1] === path.posix.basename(doc.rel, '.md') : false;
+}
+
+/**
+ * Materialize a path set as sorted `{ path, bytes }` entries.
+ *
+ * @param {Iterable<string>} rels
+ * @param {Map<string, WorkflowDoc>} docs
+ * @returns {Array<{ path: string, bytes: number }>}
+ */
+function toEntries(rels, docs) {
+  return [...rels]
+    .map((rel) => ({ path: rel, bytes: docs.get(rel)?.bytes ?? 0 }))
+    .sort((a, b) => a.path.localeCompare(b.path));
+}
+
+/**
+ * Sum the on-disk bytes of a path set.
+ *
+ * @param {Iterable<string>} rels
+ * @param {Map<string, WorkflowDoc>} docs
+ * @returns {number}
+ */
+function sumBytes(rels, docs) {
+  let total = 0;
+  for (const rel of rels) total += docs.get(rel)?.bytes ?? 0;
+  return total;
+}
+
+/**
+ * Resolve the workflow tier: every entry point's transitive markdown-link
+ * closure, partitioned into the gated mandatory set and the recorded on-demand
+ * remainder. Returns empty collections when `.agents/workflows` is absent — an
+ * entry point resolving empty is skipped silently.
+ *
+ * @param {string} root absolute repo root
+ * @param {{ fs?: FsLike }} [opts]
+ * @returns {{
+ *   entryPoints: Array<{ path: string, mandatoryBytes: number, reachableBytes: number }>,
+ *   mandatoryFiles: Array<{ path: string, bytes: number }>,
+ *   onDemandFiles: Array<{ path: string, bytes: number }>,
+ *   mandatoryTotalBytes: number,
+ *   reachableTotalBytes: number,
+ * }}
+ * @throws {Error} on an unresolvable `mandatoryReads` entry or a mandatory cycle
+ */
+export function resolveWorkflowClosures(root, { fs = nodeFs } = {}) {
+  const docs = loadDocs(root, fs);
+  const entryPoints = [];
+  const mandatoryUnion = new Set();
+  const reachableUnion = new Set();
+
+  for (const doc of docs.values()) {
+    if (!isEntryPoint(doc)) continue;
+    const mandatory = walkMandatory(doc.rel, docs, [], new Set());
+    const reachable = walkReachable(doc.rel, docs);
+    for (const rel of mandatory) mandatoryUnion.add(rel);
+    for (const rel of reachable) reachableUnion.add(rel);
+    entryPoints.push({
+      path: doc.rel,
+      mandatoryBytes: sumBytes(mandatory, docs),
+      reachableBytes: sumBytes(reachable, docs),
+    });
+  }
+
+  const onDemandUnion = [...reachableUnion].filter(
+    (rel) => !mandatoryUnion.has(rel),
+  );
+  return {
+    entryPoints: entryPoints.sort((a, b) => a.path.localeCompare(b.path)),
+    mandatoryFiles: toEntries(mandatoryUnion, docs),
+    onDemandFiles: toEntries(onDemandUnion, docs),
+    mandatoryTotalBytes: sumBytes(mandatoryUnion, docs),
+    reachableTotalBytes: sumBytes(reachableUnion, docs),
+  };
+}

--- a/.agents/workflows/helpers/deliver-story.md
+++ b/.agents/workflows/helpers/deliver-story.md
@@ -3,6 +3,7 @@ description:
   Execute one Story end-to-end. Creates story-<id> from main, implements in a
   worktree (optional ## Slicing checkpoints), runs derived-level ceremony,
   opens a PR against main, and lands.
+mandatoryReads: [deliver-digest.md]
 ---
 
 # /deliver-story #[Story ID]

--- a/baselines/context-budget.json
+++ b/baselines/context-budget.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://mandrel.dev/baselines/context-budget.schema.json",
-  "generatedAt": "2026-07-25T01:10:44.589Z",
+  "generatedAt": "2026-07-25T01:22:17.030Z",
   "toleranceBytes": 2048,
   "tiers": {
     "alwaysLoaded": {
@@ -33,15 +33,15 @@
       ]
     },
     "mandatoryRead": {
-      "totalBytes": 360398,
+      "totalBytes": 363627,
       "files": [
         {
           "path": "docs/architecture.md",
-          "bytes": 85810
+          "bytes": 88546
         },
         {
           "path": "docs/data-dictionary.md",
-          "bytes": 37161
+          "bytes": 37654
         },
         {
           "path": "docs/decisions.md",

--- a/baselines/context-budget.json
+++ b/baselines/context-budget.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://mandrel.dev/baselines/context-budget.schema.json",
-  "generatedAt": "2026-07-23T14:47:38.792Z",
+  "generatedAt": "2026-07-25T01:10:44.589Z",
   "toleranceBytes": 2048,
   "tiers": {
     "alwaysLoaded": {
@@ -52,6 +52,119 @@
           "bytes": 52468
         }
       ]
+    },
+    "workflow": {
+      "totalBytes": 229625,
+      "files": [
+        {
+          "path": ".agents/workflows/audit-accessibility.md",
+          "bytes": 9456
+        },
+        {
+          "path": ".agents/workflows/audit-architecture.md",
+          "bytes": 13589
+        },
+        {
+          "path": ".agents/workflows/audit-clean-code.md",
+          "bytes": 7395
+        },
+        {
+          "path": ".agents/workflows/audit-data-model.md",
+          "bytes": 6801
+        },
+        {
+          "path": ".agents/workflows/audit-dependencies.md",
+          "bytes": 7483
+        },
+        {
+          "path": ".agents/workflows/audit-devops.md",
+          "bytes": 6413
+        },
+        {
+          "path": ".agents/workflows/audit-documentation.md",
+          "bytes": 11889
+        },
+        {
+          "path": ".agents/workflows/audit-navigability.md",
+          "bytes": 6869
+        },
+        {
+          "path": ".agents/workflows/audit-performance.md",
+          "bytes": 9933
+        },
+        {
+          "path": ".agents/workflows/audit-privacy.md",
+          "bytes": 3565
+        },
+        {
+          "path": ".agents/workflows/audit-quality.md",
+          "bytes": 6556
+        },
+        {
+          "path": ".agents/workflows/audit-security.md",
+          "bytes": 5249
+        },
+        {
+          "path": ".agents/workflows/audit-seo.md",
+          "bytes": 5567
+        },
+        {
+          "path": ".agents/workflows/audit-sre.md",
+          "bytes": 4936
+        },
+        {
+          "path": ".agents/workflows/audit-to-stories.md",
+          "bytes": 12796
+        },
+        {
+          "path": ".agents/workflows/audit-ux-ui.md",
+          "bytes": 5008
+        },
+        {
+          "path": ".agents/workflows/deliver-light.md",
+          "bytes": 6990
+        },
+        {
+          "path": ".agents/workflows/deliver.md",
+          "bytes": 8155
+        },
+        {
+          "path": ".agents/workflows/git-cleanup.md",
+          "bytes": 4428
+        },
+        {
+          "path": ".agents/workflows/git-deliver.md",
+          "bytes": 7640
+        },
+        {
+          "path": ".agents/workflows/helpers/deliver-digest.md",
+          "bytes": 6596
+        },
+        {
+          "path": ".agents/workflows/helpers/deliver-story.md",
+          "bytes": 8192
+        },
+        {
+          "path": ".agents/workflows/mandrel-update.md",
+          "bytes": 12392
+        },
+        {
+          "path": ".agents/workflows/plan.md",
+          "bytes": 8126
+        },
+        {
+          "path": ".agents/workflows/qa-assist.md",
+          "bytes": 16561
+        },
+        {
+          "path": ".agents/workflows/qa-explore.md",
+          "bytes": 13422
+        },
+        {
+          "path": ".agents/workflows/qa-run.md",
+          "bytes": 13618
+        }
+      ]
     }
   },
   "agentBoot": {
@@ -72,6 +185,141 @@
       {
         "path": ".agents/agents/story-worker.md",
         "bytes": 7317
+      }
+    ]
+  },
+  "workflowClosure": {
+    "reachableTotalBytes": 371908,
+    "entryPoints": [
+      {
+        "path": ".agents/workflows/audit-accessibility.md",
+        "mandatoryBytes": 9456,
+        "reachableBytes": 34011
+      },
+      {
+        "path": ".agents/workflows/audit-architecture.md",
+        "mandatoryBytes": 13589,
+        "reachableBytes": 43699
+      },
+      {
+        "path": ".agents/workflows/audit-clean-code.md",
+        "mandatoryBytes": 7395,
+        "reachableBytes": 30110
+      },
+      {
+        "path": ".agents/workflows/audit-data-model.md",
+        "mandatoryBytes": 6801,
+        "reachableBytes": 24487
+      },
+      {
+        "path": ".agents/workflows/audit-dependencies.md",
+        "mandatoryBytes": 7483,
+        "reachableBytes": 25169
+      },
+      {
+        "path": ".agents/workflows/audit-devops.md",
+        "mandatoryBytes": 6413,
+        "reachableBytes": 24099
+      },
+      {
+        "path": ".agents/workflows/audit-documentation.md",
+        "mandatoryBytes": 11889,
+        "reachableBytes": 147653
+      },
+      {
+        "path": ".agents/workflows/audit-navigability.md",
+        "mandatoryBytes": 6869,
+        "reachableBytes": 24555
+      },
+      {
+        "path": ".agents/workflows/audit-performance.md",
+        "mandatoryBytes": 9933,
+        "reachableBytes": 27619
+      },
+      {
+        "path": ".agents/workflows/audit-privacy.md",
+        "mandatoryBytes": 3565,
+        "reachableBytes": 21251
+      },
+      {
+        "path": ".agents/workflows/audit-quality.md",
+        "mandatoryBytes": 6556,
+        "reachableBytes": 24242
+      },
+      {
+        "path": ".agents/workflows/audit-security.md",
+        "mandatoryBytes": 5249,
+        "reachableBytes": 22935
+      },
+      {
+        "path": ".agents/workflows/audit-seo.md",
+        "mandatoryBytes": 5567,
+        "reachableBytes": 23253
+      },
+      {
+        "path": ".agents/workflows/audit-sre.md",
+        "mandatoryBytes": 4936,
+        "reachableBytes": 40295
+      },
+      {
+        "path": ".agents/workflows/audit-to-stories.md",
+        "mandatoryBytes": 12796,
+        "reachableBytes": 118078
+      },
+      {
+        "path": ".agents/workflows/audit-ux-ui.md",
+        "mandatoryBytes": 5008,
+        "reachableBytes": 39019
+      },
+      {
+        "path": ".agents/workflows/deliver-light.md",
+        "mandatoryBytes": 6990,
+        "reachableBytes": 125068
+      },
+      {
+        "path": ".agents/workflows/deliver.md",
+        "mandatoryBytes": 8155,
+        "reachableBytes": 118078
+      },
+      {
+        "path": ".agents/workflows/git-cleanup.md",
+        "mandatoryBytes": 4428,
+        "reachableBytes": 4428
+      },
+      {
+        "path": ".agents/workflows/git-deliver.md",
+        "mandatoryBytes": 7640,
+        "reachableBytes": 143039
+      },
+      {
+        "path": ".agents/workflows/helpers/deliver-story.md",
+        "mandatoryBytes": 14788,
+        "reachableBytes": 118078
+      },
+      {
+        "path": ".agents/workflows/mandrel-update.md",
+        "mandatoryBytes": 12392,
+        "reachableBytes": 24156
+      },
+      {
+        "path": ".agents/workflows/plan.md",
+        "mandatoryBytes": 8126,
+        "reachableBytes": 118078
+      },
+      {
+        "path": ".agents/workflows/qa-assist.md",
+        "mandatoryBytes": 16561,
+        "reachableBytes": 182978
+      },
+      {
+        "path": ".agents/workflows/qa-explore.md",
+        "mandatoryBytes": 13422,
+        "reachableBytes": 182978
+      },
+      {
+        "path": ".agents/workflows/qa-run.md",
+        "mandatoryBytes": 13618,
+        "reachableBytes": 182978
       }
     ]
   }

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -876,49 +876,38 @@ workflow narrative that wires them together lives in
 
 ### Workflow read-tier (transitive closure)
 
-Workflows are the largest body of instruction Mandrel ships, and unlike every
-other read-tier they form a **graph** rather than a flat list. `lib/doc-tiers.js`
-delegates to `lib/workflow-closure.js`, which walks each entry point's
-transitive markdown-link closure and splits it in two:
-
-| Measure                | Definition                                                                     | Gated? |
-| ---------------------- | ------------------------------------------------------------------------------ | ------ |
-| **Mandatory closure**  | the entry point plus the transitive closure of its `mandatoryReads:` edges     | Yes — the `workflow` tier in `baselines/context-budget.json` |
-| **Reachable closure**  | the entry point plus every workflow markdown file transitively linked from it  | No — recorded per entry point under `workflowClosure` as a drift signal |
+Workflows are the largest instruction body Mandrel ships and, unlike every other
+read-tier, form a **graph**. `lib/doc-tiers.js` delegates to
+`lib/workflow-closure.js`, which walks each entry point's transitive
+markdown-link closure and splits it in two: the **mandatory closure** (the entry
+point plus the transitive closure of its `mandatoryReads:` edges) is gated as the
+`workflow` tier in `baselines/context-budget.json`; the **reachable closure**
+(every workflow file transitively linked from it) is recorded per entry point
+under `workflowClosure` as a drift signal and never gates.
 
 **Entry points** are the workflows a session can be invoked on: every top-level
 `.agents/workflows/*.md`, plus any `helpers/*.md` whose H1 declares a slash
 command named after the file itself (`helpers/deliver-story.md` →
-`# /deliver-story …`). An appendix that merely titles itself after the command
-it documents (`helpers/deliver-reference.md` → `# /deliver — reference
-appendix`) is reachable, never an entry point.
+`# /deliver-story …`). An appendix merely titled after the command it documents
+(`helpers/deliver-reference.md` → `# /deliver — reference appendix`) is
+reachable, never an entry point.
 
-**The marker is source-side and per-edge.** A workflow declares the reads it
-requires in its own frontmatter:
+**The marker is source-side and per-edge** — `mandatoryReads: [deliver-digest.md]`
+in the declaring workflow's own frontmatter, paths relative to that file, flow or
+block YAML. Tier is not intrinsic to a helper (the same file is mandatory from
+one workflow and on-demand from another), so it cannot live in the target. The
+key is **optional**: an absent key means zero mandatory edges and is never an
+error, and every reachable link not named in it is classified on-demand.
 
-```yaml
-mandatoryReads: [deliver-digest.md]
-```
-
-Paths resolve relative to the declaring file; flow and block YAML sequences are
-both accepted. Tier is not intrinsic to a helper — the same file is mandatory
-from one workflow and on-demand from another — which is why the marker cannot
-live in the target. The key is **optional**: an absent key means zero mandatory
-edges and is never an error, and every reachable link not named in
-`mandatoryReads` is classified on-demand.
-
-Two authoring errors fail loudly, because a ratchet that silently shrinks its
-own closure is worse than none: a `mandatoryReads` entry that does not resolve
-to a workflow markdown file, and a cycle among `mandatoryReads` edges. The
-*reachable* walk is deliberately cycle-tolerant — a spine pointing at its digest
-while the digest points back is correct authoring — so it terminates via a
-visited set with each file counted exactly once.
-
-The walk never leaves `.agents/workflows/**`: links out to `.agents/rules/**` or
-`.agents/skills/**` are neither followed nor recorded, because those are already
-tiered as flat sets and following them would double-count them. The per-file
-8 KB spine ceiling in `tests/bootstrap/workflow-spine-budget.test.js` remains a
-complementary guard — it catches a fat file, this ratchet catches a fat *read*.
+Two authoring errors fail loudly, because a ratchet that silently shrinks its own
+closure is worse than none: a `mandatoryReads` entry that does not resolve to a
+workflow markdown file, and a cycle among `mandatoryReads` edges. The *reachable*
+walk is deliberately cycle-tolerant — a spine pointing at its digest while the
+digest points back is correct authoring — so it terminates via a visited set with
+each file counted once. The walk never leaves `.agents/workflows/**`; rules and
+skills are already tiered as flat sets, and following them would double-count
+them. The per-file 8 KB ceiling in `workflow-spine-budget.test.js` remains a
+complementary guard: it catches a fat file, this ratchet catches a fat *read*.
 
 ### Worktree Isolation
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -874,6 +874,52 @@ setup/meta. The canonical reference is
 workflow narrative that wires them together lives in
 [`.agents/docs/SDLC.md`](../.agents/docs/SDLC.md).
 
+### Workflow read-tier (transitive closure)
+
+Workflows are the largest body of instruction Mandrel ships, and unlike every
+other read-tier they form a **graph** rather than a flat list. `lib/doc-tiers.js`
+delegates to `lib/workflow-closure.js`, which walks each entry point's
+transitive markdown-link closure and splits it in two:
+
+| Measure                | Definition                                                                     | Gated? |
+| ---------------------- | ------------------------------------------------------------------------------ | ------ |
+| **Mandatory closure**  | the entry point plus the transitive closure of its `mandatoryReads:` edges     | Yes — the `workflow` tier in `baselines/context-budget.json` |
+| **Reachable closure**  | the entry point plus every workflow markdown file transitively linked from it  | No — recorded per entry point under `workflowClosure` as a drift signal |
+
+**Entry points** are the workflows a session can be invoked on: every top-level
+`.agents/workflows/*.md`, plus any `helpers/*.md` whose H1 declares a slash
+command named after the file itself (`helpers/deliver-story.md` →
+`# /deliver-story …`). An appendix that merely titles itself after the command
+it documents (`helpers/deliver-reference.md` → `# /deliver — reference
+appendix`) is reachable, never an entry point.
+
+**The marker is source-side and per-edge.** A workflow declares the reads it
+requires in its own frontmatter:
+
+```yaml
+mandatoryReads: [deliver-digest.md]
+```
+
+Paths resolve relative to the declaring file; flow and block YAML sequences are
+both accepted. Tier is not intrinsic to a helper — the same file is mandatory
+from one workflow and on-demand from another — which is why the marker cannot
+live in the target. The key is **optional**: an absent key means zero mandatory
+edges and is never an error, and every reachable link not named in
+`mandatoryReads` is classified on-demand.
+
+Two authoring errors fail loudly, because a ratchet that silently shrinks its
+own closure is worse than none: a `mandatoryReads` entry that does not resolve
+to a workflow markdown file, and a cycle among `mandatoryReads` edges. The
+*reachable* walk is deliberately cycle-tolerant — a spine pointing at its digest
+while the digest points back is correct authoring — so it terminates via a
+visited set with each file counted exactly once.
+
+The walk never leaves `.agents/workflows/**`: links out to `.agents/rules/**` or
+`.agents/skills/**` are neither followed nor recorded, because those are already
+tiered as flat sets and following them would double-count them. The per-file
+8 KB spine ceiling in `tests/bootstrap/workflow-spine-budget.test.js` remains a
+complementary guard — it catches a fat file, this ratchet catches a fat *read*.
+
 ### Worktree Isolation
 
 When `delivery.worktreeIsolation.enabled` is `true`, each dispatched

--- a/tests/check-context-budget.test.js
+++ b/tests/check-context-budget.test.js
@@ -12,6 +12,7 @@ import {
   loadBaseline,
   parseArgv,
   renderDiff,
+  renderReachable,
   runCli,
 } from '../.agents/scripts/check-context-budget.js';
 
@@ -40,6 +41,7 @@ function makeSink() {
 function makeRepo({
   withClaude = true,
   docsContextFiles = ['architecture.md'],
+  withWorkflows = false,
 } = {}) {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), 'ctx-budget-'));
   const write = (rel, body) => {
@@ -51,11 +53,19 @@ function makeRepo({
     write('CLAUDE.md', '@AGENTS.md\n');
     write('AGENTS.md', 'onboarding context\n');
   }
+  if (withWorkflows) {
+    write(
+      '.agents/workflows/deliver.md',
+      '---\ndescription: fixture\nmandatoryReads: [helpers/digest.md]\n---\n\n# /deliver\n\n[digest](helpers/digest.md) [appendix](helpers/appendix.md)\n',
+    );
+    write('.agents/workflows/helpers/digest.md', '# Digest\n');
+    write('.agents/workflows/helpers/appendix.md', '# Appendix\n');
+  }
   write('docs/architecture.md', 'architecture doc body\n');
   const config = {
     project: { paths: { docsRoot: 'docs' }, docsContextFiles },
   };
-  return { root, config };
+  return { root, config, write };
 }
 
 // ---------------------------------------------------------------------------
@@ -301,6 +311,192 @@ test('runCli passes when role-agent boot contexts are within the ceiling', async
     stderr: makeSink(),
   });
   assert.equal(code, 0);
+});
+
+// ---------------------------------------------------------------------------
+// Workflow mandatory-closure ratchet (Story #4752)
+// ---------------------------------------------------------------------------
+
+test('the workflow mandatory closure is a gated tier', () => {
+  assert.ok(GATED_TIERS.includes('workflow'));
+});
+
+test('--update records the workflow tier and the per-entry-point reachable closure', async () => {
+  const { root, config } = makeRepo({ withWorkflows: true });
+  await runCli({
+    argv: ['--update'],
+    cwd: root,
+    config,
+    stdout: makeSink(),
+    stderr: makeSink(),
+  });
+  const baseline = loadBaseline(
+    path.join(root, 'baselines', 'context-budget.json'),
+  );
+  assert.ok(baseline.tiers.workflow.totalBytes > 0);
+  assert.deepEqual(
+    baseline.tiers.workflow.files.map((f) => f.path),
+    ['.agents/workflows/deliver.md', '.agents/workflows/helpers/digest.md'],
+  );
+  // Reachable is recorded alongside the gated tiers, never inside them.
+  assert.ok(
+    baseline.workflowClosure.reachableTotalBytes >
+      baseline.tiers.workflow.totalBytes,
+  );
+  assert.deepEqual(
+    baseline.workflowClosure.entryPoints.map((e) => e.path),
+    ['.agents/workflows/deliver.md'],
+  );
+  assert.ok(baseline.workflowClosure.entryPoints[0].reachableBytes > 0);
+});
+
+test('runCli exits 1 when a mandatory workflow read grows beyond tolerance', async () => {
+  const { root, config } = makeRepo({ withWorkflows: true });
+  await runCli({
+    argv: ['--update'],
+    cwd: root,
+    config,
+    stdout: makeSink(),
+    stderr: makeSink(),
+  });
+  const baseline = loadBaseline(
+    path.join(root, 'baselines', 'context-budget.json'),
+  );
+  fs.appendFileSync(
+    path.join(root, '.agents', 'workflows', 'helpers', 'digest.md'),
+    'x'.repeat(baseline.toleranceBytes + 1000),
+  );
+  const stdout = makeSink();
+  const stderr = makeSink();
+  const code = await runCli({ argv: [], cwd: root, config, stdout, stderr });
+  assert.equal(code, 1);
+  assert.match(stdout.text(), /\+ workflow:/);
+  assert.match(stderr.text(), /grew beyond tolerance/);
+});
+
+test('a promoted on-demand read trips the ratchet — the marker, not the bytes, is the signal', async () => {
+  const { root, config, write } = makeRepo({ withWorkflows: true });
+  await runCli({
+    argv: ['--update'],
+    cwd: root,
+    config,
+    stdout: makeSink(),
+    stderr: makeSink(),
+  });
+  // Same bytes on disk; the appendix is merely re-declared as a mandatory read.
+  write(
+    '.agents/workflows/helpers/appendix.md',
+    `---\ndescription: appendix\n---\n\n# Appendix\n${'y'.repeat(4000)}\n`,
+  );
+  await runCli({
+    argv: ['--update'],
+    cwd: root,
+    config,
+    stdout: makeSink(),
+    stderr: makeSink(),
+  });
+  write(
+    '.agents/workflows/deliver.md',
+    '---\ndescription: fixture\nmandatoryReads: [helpers/digest.md, helpers/appendix.md]\n---\n\n# /deliver\n\n[digest](helpers/digest.md) [appendix](helpers/appendix.md)\n',
+  );
+  const stdout = makeSink();
+  const code = await runCli({
+    argv: [],
+    cwd: root,
+    config,
+    stdout,
+    stderr: makeSink(),
+  });
+  assert.equal(code, 1);
+  assert.match(stdout.text(), /\+ workflow:/);
+});
+
+test('growth in the reachable-only closure is reported but never gates', async () => {
+  const { root, config } = makeRepo({ withWorkflows: true });
+  await runCli({
+    argv: ['--update'],
+    cwd: root,
+    config,
+    stdout: makeSink(),
+    stderr: makeSink(),
+  });
+  // The appendix is reachable but not mandatory — bloat it far past tolerance.
+  fs.appendFileSync(
+    path.join(root, '.agents', 'workflows', 'helpers', 'appendix.md'),
+    'z'.repeat(50_000),
+  );
+  const stdout = makeSink();
+  const code = await runCli({
+    argv: [],
+    cwd: root,
+    config,
+    stdout,
+    stderr: makeSink(),
+  });
+  assert.equal(code, 0);
+  assert.match(stdout.text(), /workflow reachable closure: \d+ bytes/);
+  assert.match(stdout.text(), /never gated/);
+});
+
+test('a shrunken workflow closure prints the informational marker and still exits 0', async () => {
+  const { root, config, write } = makeRepo({ withWorkflows: true });
+  write('.agents/workflows/helpers/digest.md', `# Digest\n${'q'.repeat(3000)}`);
+  await runCli({
+    argv: ['--update'],
+    cwd: root,
+    config,
+    stdout: makeSink(),
+    stderr: makeSink(),
+  });
+  write('.agents/workflows/helpers/digest.md', '# Digest\n');
+  const stdout = makeSink();
+  const code = await runCli({
+    argv: [],
+    cwd: root,
+    config,
+    stdout,
+    stderr: makeSink(),
+  });
+  assert.equal(code, 0);
+  assert.match(stdout.text(), /- workflow: \d+ bytes below baseline/);
+});
+
+test('renderReachable is silent without a workflow closure and cites the recorded total with one', () => {
+  assert.equal(renderReachable({}, null), '');
+  assert.equal(
+    renderReachable({ workflowClosure: { reachableTotalBytes: 0 } }),
+    '',
+  );
+  assert.match(
+    renderReachable(
+      {
+        workflowClosure: {
+          reachableTotalBytes: 900,
+          entryPoints: [{ path: 'a' }, { path: 'b' }],
+        },
+      },
+      { workflowClosure: { reachableTotalBytes: 800 } },
+    ),
+    /900 bytes across 2 entry points \(recorded 800\) — drift signal, never gated/,
+  );
+});
+
+test('runCli propagates a loud workflow-closure failure instead of degrading', async () => {
+  const { root, config, write } = makeRepo({ withWorkflows: true });
+  write(
+    '.agents/workflows/deliver.md',
+    '---\ndescription: fixture\nmandatoryReads: [helpers/gone.md]\n---\n\n# /deliver\n',
+  );
+  await assert.rejects(
+    runCli({
+      argv: [],
+      cwd: root,
+      config,
+      stdout: makeSink(),
+      stderr: makeSink(),
+    }),
+    /helpers\/gone\.md/,
+  );
 });
 
 test('runCli is a no-op (exit 0) when the baseline is absent', async () => {

--- a/tests/check-context-budget.test.js
+++ b/tests/check-context-budget.test.js
@@ -1,8 +1,10 @@
 import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { test } from 'node:test';
+import { fileURLToPath } from 'node:url';
 import {
   AGENT_BOOT_CEILING_BYTES,
   agentBootOverflow,
@@ -479,6 +481,55 @@ test('renderReachable is silent without a workflow closure and cites the recorde
     ),
     /900 bytes across 2 entry points \(recorded 800\) — drift signal, never gated/,
   );
+});
+
+/**
+ * Run the real CLI as a subprocess against a fixture root, so the assertion is
+ * on the **process exit code** rather than the in-process return value.
+ */
+function runScript(root) {
+  const script = path.join(
+    path.dirname(fileURLToPath(import.meta.url)),
+    '..',
+    '.agents',
+    'scripts',
+    'check-context-budget.js',
+  );
+  return spawnSync(process.execPath, [script, '--root', root], {
+    encoding: 'utf8',
+  });
+}
+
+test('the CLI exits non-zero naming the workflow and path when a mandatoryReads entry is missing', () => {
+  const { root, write } = makeRepo({ withWorkflows: true });
+  write(
+    '.agents/workflows/deliver.md',
+    '---\ndescription: fixture\nmandatoryReads: [helpers/gone.md]\n---\n\n# /deliver\n',
+  );
+  const result = runScript(root);
+  assert.notEqual(result.status, 0);
+  const output = `${result.stdout}${result.stderr}`;
+  assert.match(output, /\.agents\/workflows\/deliver\.md/);
+  assert.match(output, /helpers\/gone\.md/);
+});
+
+test('the CLI exits non-zero naming the cycle when mandatoryReads edges loop', () => {
+  const { root, write } = makeRepo({ withWorkflows: true });
+  write(
+    '.agents/workflows/deliver.md',
+    '---\ndescription: fixture\nmandatoryReads: [helpers/digest.md]\n---\n\n# /deliver\n',
+  );
+  write(
+    '.agents/workflows/helpers/digest.md',
+    '---\ndescription: fixture\nmandatoryReads: [appendix.md]\n---\n\n# Digest\n',
+  );
+  write(
+    '.agents/workflows/helpers/appendix.md',
+    '---\ndescription: fixture\nmandatoryReads: [digest.md]\n---\n\n# Appendix\n',
+  );
+  const result = runScript(root);
+  assert.notEqual(result.status, 0);
+  assert.match(`${result.stdout}${result.stderr}`, /cycle/);
 });
 
 test('runCli propagates a loud workflow-closure failure instead of degrading', async () => {

--- a/tests/lib/doc-tiers.test.js
+++ b/tests/lib/doc-tiers.test.js
@@ -214,6 +214,61 @@ test('resolveDocTiers yields an empty agentBoot tier when the dir is absent', ()
   assert.deepEqual(tiers.agentBoot, []);
 });
 
+test('resolveDocTiers adds the workflow tiers without double-counting any path (Story #4752)', () => {
+  const root = makeRepo({
+    'CLAUDE.md': '@AGENTS.md\n@.agents/rules/git-conventions.md\n',
+    'AGENTS.md': 'onboarding\n',
+    '.agents/rules/git-conventions.md': 'always-on rule\n',
+    '.agents/rules/testing-standards.md': 'on-demand rule\n',
+    '.agents/workflows/deliver.md':
+      '---\ndescription: fixture\nmandatoryReads: [helpers/digest.md]\n---\n\n# /deliver\n\n[digest](helpers/digest.md) [appendix](helpers/appendix.md) [rule](../rules/testing-standards.md)\n',
+    '.agents/workflows/helpers/digest.md': '# Digest\n',
+    '.agents/workflows/helpers/appendix.md': '# Appendix\n',
+  });
+  const { tiers, workflowClosure } = resolveDocTiers({ project: {} }, { root });
+
+  assert.deepEqual(
+    tiers.workflow.map((e) => e.path),
+    ['.agents/workflows/deliver.md', '.agents/workflows/helpers/digest.md'],
+  );
+  assert.deepEqual(
+    tiers.workflowOnDemand.map((e) => e.path),
+    ['.agents/workflows/helpers/appendix.md'],
+  );
+  // The rule the workflow links to stays in the on-demand *rules* tier — the
+  // closure never re-counts an already-tiered flat set.
+  assert.deepEqual(
+    tiers.onDemand.map((e) => e.path),
+    ['.agents/rules/testing-standards.md'],
+  );
+
+  // Every tier is disjoint: the union has no duplicate paths.
+  const all = Object.values(tiers).flatMap((t) => t.map((e) => e.path));
+  assert.equal(all.length, new Set(all).size);
+
+  assert.equal(
+    workflowClosure.mandatoryTotalBytes,
+    tierTotalBytes(tiers.workflow),
+  );
+  assert.equal(
+    workflowClosure.reachableTotalBytes,
+    tierTotalBytes(tiers.workflow) + tierTotalBytes(tiers.workflowOnDemand),
+  );
+  assert.deepEqual(
+    workflowClosure.entryPoints.map((e) => e.path),
+    ['.agents/workflows/deliver.md'],
+  );
+});
+
+test('resolveDocTiers yields empty workflow tiers when the workflow tree is absent', () => {
+  const root = makeRepo({ 'CLAUDE.md': '@AGENTS.md\n', 'AGENTS.md': 'x\n' });
+  const { tiers, workflowClosure } = resolveDocTiers({ project: {} }, { root });
+  assert.deepEqual(tiers.workflow, []);
+  assert.deepEqual(tiers.workflowOnDemand, []);
+  assert.deepEqual(workflowClosure.entryPoints, []);
+  assert.equal(workflowClosure.reachableTotalBytes, 0);
+});
+
 test('resolveDocTiers skips absent context / conditional docs silently', () => {
   const root = makeRepo({
     'CLAUDE.md': '@AGENTS.md\n',

--- a/tests/lib/workflow-closure.test.js
+++ b/tests/lib/workflow-closure.test.js
@@ -1,0 +1,236 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { test } from 'node:test';
+import { resolveWorkflowClosures } from '../../.agents/scripts/lib/workflow-closure.js';
+
+/**
+ * Unit coverage for the workflow read-tier closure resolver (Story #4752).
+ *
+ * Drives `resolveWorkflowClosures` against tmpdir fixtures: entry-point
+ * selection, the optional source-side `mandatoryReads:` marker in both YAML
+ * shapes, the mandatory/on-demand partition, the two loud failure modes
+ * (unresolvable mandatory entry, mandatory cycle), and the cycle-tolerant
+ * reachable walk.
+ */
+
+// ---------------------------------------------------------------------------
+// Fixture helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Materialize a fixture repo under a fresh tmpdir. `files` maps repo-relative
+ * paths to string contents. Returns the absolute root.
+ */
+function makeRepo(files) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'wf-closure-'));
+  for (const [rel, body] of Object.entries(files)) {
+    const abs = path.join(root, rel);
+    fs.mkdirSync(path.dirname(abs), { recursive: true });
+    fs.writeFileSync(abs, body);
+  }
+  return root;
+}
+
+/** Frontmatter block carrying an optional `mandatoryReads` line. */
+function frontmatter(mandatoryReads) {
+  const line = mandatoryReads ? `${mandatoryReads}\n` : '';
+  return `---\ndescription: fixture\n${line}---\n\n`;
+}
+
+const paths = (entries) => entries.map((e) => e.path);
+
+// ---------------------------------------------------------------------------
+// Entry-point selection
+// ---------------------------------------------------------------------------
+
+test('every top-level workflow is an entry point; plain helpers are not', () => {
+  const root = makeRepo({
+    '.agents/workflows/plan.md': `${frontmatter()}# /plan\n\n[helper](helpers/notes.md)\n`,
+    '.agents/workflows/deliver.md': `${frontmatter()}# Deliver\n`,
+    '.agents/workflows/helpers/notes.md': '# Notes (helper)\n',
+  });
+  const closure = resolveWorkflowClosures(root);
+  assert.deepEqual(paths(closure.entryPoints), [
+    '.agents/workflows/deliver.md',
+    '.agents/workflows/plan.md',
+  ]);
+});
+
+test('a helper whose H1 declares its own slash command is an entry point, an appendix titled after another command is not', () => {
+  const root = makeRepo({
+    '.agents/workflows/deliver.md': `${frontmatter()}# /deliver\n`,
+    '.agents/workflows/helpers/deliver-story.md':
+      '# /deliver-story #[Story ID]\n',
+    '.agents/workflows/helpers/deliver-reference.md':
+      '# /deliver — reference appendix (on-demand)\n',
+  });
+  const closure = resolveWorkflowClosures(root);
+  assert.deepEqual(paths(closure.entryPoints), [
+    '.agents/workflows/deliver.md',
+    '.agents/workflows/helpers/deliver-story.md',
+  ]);
+});
+
+// ---------------------------------------------------------------------------
+// mandatoryReads marker
+// ---------------------------------------------------------------------------
+
+test('an absent mandatoryReads key is not an error — the closure is the entry point alone', () => {
+  const root = makeRepo({
+    '.agents/workflows/plan.md': `${frontmatter()}# /plan\n\n[ref](helpers/ref.md)\n`,
+    '.agents/workflows/helpers/ref.md': '# Ref\n',
+  });
+  const closure = resolveWorkflowClosures(root);
+  assert.deepEqual(paths(closure.mandatoryFiles), [
+    '.agents/workflows/plan.md',
+  ]);
+  assert.equal(
+    closure.entryPoints[0].mandatoryBytes,
+    closure.mandatoryTotalBytes,
+  );
+});
+
+test('a flow-style mandatoryReads list resolves transitively', () => {
+  const root = makeRepo({
+    '.agents/workflows/deliver.md': `${frontmatter('mandatoryReads: [helpers/digest.md]')}# /deliver\n`,
+    '.agents/workflows/helpers/digest.md': `${frontmatter('mandatoryReads: [nested.md]')}# Digest\n`,
+    '.agents/workflows/helpers/nested.md': '# Nested\n',
+  });
+  const closure = resolveWorkflowClosures(root);
+  assert.deepEqual(paths(closure.mandatoryFiles), [
+    '.agents/workflows/deliver.md',
+    '.agents/workflows/helpers/digest.md',
+    '.agents/workflows/helpers/nested.md',
+  ]);
+});
+
+test('a block-style mandatoryReads list resolves, and quoted entries are unwrapped', () => {
+  const root = makeRepo({
+    '.agents/workflows/plan.md': `---\ndescription: fixture\nmandatoryReads:\n  - helpers/a.md\n  - "helpers/b.md"\n---\n\n# /plan\n`,
+    '.agents/workflows/helpers/a.md': '# A\n',
+    '.agents/workflows/helpers/b.md': '# B\n',
+  });
+  const closure = resolveWorkflowClosures(root);
+  assert.deepEqual(paths(closure.mandatoryFiles), [
+    '.agents/workflows/helpers/a.md',
+    '.agents/workflows/helpers/b.md',
+    '.agents/workflows/plan.md',
+  ]);
+});
+
+test('every reachable link not named in mandatoryReads is classified on-demand', () => {
+  const root = makeRepo({
+    '.agents/workflows/deliver.md': `${frontmatter('mandatoryReads: [helpers/digest.md]')}# /deliver\n\n[digest](helpers/digest.md) [appendix](helpers/appendix.md#step-3)\n`,
+    '.agents/workflows/helpers/digest.md': '# Digest\n',
+    '.agents/workflows/helpers/appendix.md': '# Appendix\n',
+  });
+  const closure = resolveWorkflowClosures(root);
+  assert.deepEqual(paths(closure.mandatoryFiles), [
+    '.agents/workflows/deliver.md',
+    '.agents/workflows/helpers/digest.md',
+  ]);
+  assert.deepEqual(paths(closure.onDemandFiles), [
+    '.agents/workflows/helpers/appendix.md',
+  ]);
+  assert.equal(
+    closure.reachableTotalBytes,
+    closure.mandatoryTotalBytes +
+      closure.onDemandFiles.reduce((sum, e) => sum + e.bytes, 0),
+  );
+});
+
+// ---------------------------------------------------------------------------
+// Loud failure modes
+// ---------------------------------------------------------------------------
+
+test('a mandatoryReads entry naming a missing file throws, naming the workflow and the path', () => {
+  const root = makeRepo({
+    '.agents/workflows/deliver.md': `${frontmatter('mandatoryReads: [helpers/gone.md]')}# /deliver\n`,
+  });
+  assert.throws(
+    () => resolveWorkflowClosures(root),
+    (err) => {
+      assert.match(err.message, /\.agents\/workflows\/deliver\.md/);
+      assert.match(err.message, /helpers\/gone\.md/);
+      return true;
+    },
+  );
+});
+
+test('a mandatoryReads entry pointing outside the workflow tree throws rather than silently dropping', () => {
+  const root = makeRepo({
+    '.agents/workflows/deliver.md': `${frontmatter('mandatoryReads: [../rules/testing-standards.md]')}# /deliver\n`,
+    '.agents/rules/testing-standards.md': '# Rules\n',
+  });
+  assert.throws(() => resolveWorkflowClosures(root), /testing-standards\.md/);
+});
+
+test('a cycle among mandatoryReads edges throws, naming the cycle', () => {
+  const root = makeRepo({
+    '.agents/workflows/deliver.md': `${frontmatter('mandatoryReads: [helpers/a.md]')}# /deliver\n`,
+    '.agents/workflows/helpers/a.md': `${frontmatter('mandatoryReads: [b.md]')}# A\n`,
+    '.agents/workflows/helpers/b.md': `${frontmatter('mandatoryReads: [a.md]')}# B\n`,
+  });
+  assert.throws(
+    () => resolveWorkflowClosures(root),
+    (err) => {
+      assert.match(err.message, /cycle/);
+      assert.match(err.message, /helpers\/a\.md/);
+      assert.match(err.message, /helpers\/b\.md/);
+      return true;
+    },
+  );
+});
+
+// ---------------------------------------------------------------------------
+// Reachable walk
+// ---------------------------------------------------------------------------
+
+test('a cycle in the prose link graph terminates and counts each file exactly once', () => {
+  const root = makeRepo({
+    '.agents/workflows/deliver.md': `${frontmatter()}# /deliver\n\n[spine](helpers/spine.md)\n`,
+    '.agents/workflows/helpers/spine.md': '# Spine\n\n[digest](digest.md)\n',
+    '.agents/workflows/helpers/digest.md':
+      '# Digest\n\n[back to the spine](spine.md)\n',
+  });
+  const closure = resolveWorkflowClosures(root);
+  const reachable = [
+    ...paths(closure.mandatoryFiles),
+    ...paths(closure.onDemandFiles),
+  ];
+  assert.deepEqual(reachable.sort(), [
+    '.agents/workflows/deliver.md',
+    '.agents/workflows/helpers/digest.md',
+    '.agents/workflows/helpers/spine.md',
+  ]);
+  const sizes = reachable.map((rel) => fs.statSync(path.join(root, rel)).size);
+  assert.equal(
+    closure.reachableTotalBytes,
+    sizes.reduce((a, b) => a + b, 0),
+  );
+});
+
+test('links outside the workflow tree and non-markdown links are neither followed nor recorded', () => {
+  const root = makeRepo({
+    '.agents/workflows/deliver.md': `${frontmatter()}# /deliver\n\n[rule](../rules/git.md) [schema](../schemas/x.json) [web](https://example.com/a.md)\n`,
+    '.agents/rules/git.md': '# Git rules\n',
+    '.agents/schemas/x.json': '{}\n',
+  });
+  const closure = resolveWorkflowClosures(root);
+  assert.deepEqual(paths(closure.mandatoryFiles), [
+    '.agents/workflows/deliver.md',
+  ]);
+  assert.deepEqual(closure.onDemandFiles, []);
+});
+
+test('an absent workflow tree resolves empty and silently', () => {
+  const root = makeRepo({ 'CLAUDE.md': '# root\n' });
+  const closure = resolveWorkflowClosures(root);
+  assert.deepEqual(closure.entryPoints, []);
+  assert.deepEqual(closure.mandatoryFiles, []);
+  assert.deepEqual(closure.onDemandFiles, []);
+  assert.equal(closure.mandatoryTotalBytes, 0);
+  assert.equal(closure.reachableTotalBytes, 0);
+});


### PR DESCRIPTION
Closes #4752

_Auto-opened by `/deliver`._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CI context-budget gating and baseline semantics; mis-authored `mandatoryReads` or baseline drift can fail builds, but there is no runtime auth or data-path impact.
> 
> **Overview**
> Introduces **workflow read-tier measurement** for `.agents/workflows/**`: a new `workflow-closure.js` resolver walks each entry point’s markdown links and splits files into **mandatory** (transitive `mandatoryReads:` frontmatter) vs **on-demand** (reachable but not declared mandatory). Invalid mandatory paths and mandatory-edge cycles fail the checker; reachable link cycles are tolerated.
> 
> **`doc-tiers.js`** wires this into `workflow` / `workflowOnDemand` tiers; **`check-context-budget.js`** adds **`workflow`** to the gated tiers (alongside `alwaysLoaded` and `mandatoryRead`), persists per-entry-point **reachable** totals under `workflowClosure` in `baselines/context-budget.json` (report-only), and prints a reachable drift line in preview output.
> 
> **`deliver-story.md`** declares `mandatoryReads: [deliver-digest.md]` as the authoring pattern. **`docs/architecture.md`** documents entry points, markers, and failure modes. Baseline and tests cover gating, promotion via `mandatoryReads` without byte changes, reachable-only growth not failing CI, and loud CLI errors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e0bc4f5d37d65901c726abfe624bbfe39f105526. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->