### PR TITLE
feat: make workflow-invoked orchestration scripts self-describing via --help (#4750)

### DIFF
--- a/.agents/scripts/acceptance-eval.js
+++ b/.agents/scripts/acceptance-eval.js
@@ -302,4 +302,21 @@ export async function main(argv = process.argv.slice(2)) {
   return envelope;
 }
 
-runAsCli(import.meta.url, main, { source: 'acceptance-eval' });
+runAsCli(import.meta.url, main, {
+  source: 'acceptance-eval',
+  usage: {
+    invocation:
+      'node .agents/scripts/acceptance-eval.js --story <id> --verdict <path> [--no-signal]',
+    summary:
+      "Score an authored acceptance verdict against the Story's acceptance[] criteria and emit the bounded loop's proceed / redraft / block decision.",
+    flags: [
+      ['--story <id>', 'GitHub issue number of the Story (required).'],
+      ['--verdict <path>', 'Path to the authored verdict JSON (required).'],
+      [
+        '--no-signal',
+        "Skip appending the per-criterion signal to the Story's signals ledger.",
+      ],
+    ],
+    notes: ['Exit codes:\n  0  proceed or redraft\n  1  block'],
+  },
+});

--- a/.agents/scripts/agents-bootstrap-github.js
+++ b/.agents/scripts/agents-bootstrap-github.js
@@ -526,4 +526,25 @@ export {
   verifyApiAccess,
 };
 
-runAsCli(import.meta.url, main, { source: 'Bootstrap' });
+runAsCli(import.meta.url, main, {
+  source: 'Bootstrap',
+  usage: {
+    invocation:
+      'node .agents/scripts/agents-bootstrap-github.js [--assume-yes|--assume-no] [--approve-github-admin] [--with-project-board] [--reap-conflicting-workflows]',
+    summary:
+      'Bootstrap the GitHub side of a consumer repo: label taxonomy, issue forms, workflows, and the optional project board.',
+    flags: [
+      ['--assume-yes', 'Answer yes to every prompt (non-interactive run).'],
+      ['--assume-no', 'Answer no to every prompt (probe only).'],
+      [
+        '--approve-github-admin',
+        'Consent to admin-scoped GitHub mutations (implied by --assume-yes).',
+      ],
+      ['--with-project-board', 'Also provision the GitHub Project board.'],
+      [
+        '--reap-conflicting-workflows',
+        'Remove pre-existing workflow files that clash with the framework set.',
+      ],
+    ],
+  },
+});

--- a/.agents/scripts/apply-quality-bootstrap.js
+++ b/.agents/scripts/apply-quality-bootstrap.js
@@ -76,4 +76,10 @@ async function main() {
 runAsCli(import.meta.url, main, {
   source: 'apply-quality-bootstrap',
   propagateExitCode: true,
+  usage: {
+    invocation: 'node .agents/scripts/apply-quality-bootstrap.js',
+    summary:
+      'Install the quality-gate surface into the consumer repo (guardrails helper, pre-commit line, npm scripts, config defaults) and migrate the baselines layout. Idempotent; prints { quality, baselines } JSON to stdout.',
+    flags: [],
+  },
 });

--- a/.agents/scripts/audit-labels-bootstrap.js
+++ b/.agents/scripts/audit-labels-bootstrap.js
@@ -272,4 +272,18 @@ async function main() {
   }
 }
 
-runAsCli(import.meta.url, main, { source: 'audit-labels-bootstrap' });
+runAsCli(import.meta.url, main, {
+  source: 'audit-labels-bootstrap',
+  usage: {
+    invocation:
+      'node .agents/scripts/audit-labels-bootstrap.js [--owner <owner>] [--repo <repo>] [--force] [--dry-run]',
+    summary:
+      'Create the audit-finding label taxonomy in the target repository. Idempotent.',
+    flags: [
+      ['--owner <owner>', 'Repository owner (default: github.owner).'],
+      ['--repo <repo>', 'Repository name (default: github.repo).'],
+      ['--force', 'Update colour/description of labels that already exist.'],
+      ['--dry-run', 'Report what would be created; mutate nothing.'],
+    ],
+  },
+});

--- a/.agents/scripts/audit-to-stories.js
+++ b/.agents/scripts/audit-to-stories.js
@@ -626,4 +626,29 @@ async function main() {
   );
 }
 
-runAsCli(import.meta.url, main, { source: 'audit-to-stories' });
+runAsCli(import.meta.url, main, {
+  source: 'audit-to-stories',
+  usage: {
+    invocation:
+      'node .agents/scripts/audit-to-stories.js (--scan | --auto | --emit-plan-seed | --emit-stories) [options]',
+    summary:
+      'Turn audit-lens findings under temp/audits/ into a dedup-checked plan seed or standalone Stories.',
+    flags: [
+      ['--scan', 'Print the grouped, deduplicated plan as JSON.'],
+      ['--auto', 'Run the full scan → file pipeline and print the summary.'],
+      ['--emit-plan-seed', 'Emit a /plan --seed-file document.'],
+      ['--emit-stories', 'Emit the Story drafts as JSON.'],
+      ['--glob <pattern>', 'Override the audit-results glob.'],
+      ['--severity <level>', 'Lowest severity to include (high|medium|low).'],
+      ['--ledger <path>', 'Path to the dedup ledger.'],
+      [
+        '--plan <path>',
+        'Read a previously emitted plan instead of re-scanning.',
+      ],
+      ['--out <path>', 'Write output to a file instead of stdout.'],
+      ['--no-provider', 'Skip live GitHub dedup lookups (offline).'],
+      ['--json', 'Force JSON output.'],
+      ['--dry-run', 'Report what would be filed; create nothing.'],
+    ],
+  },
+});

--- a/.agents/scripts/boot-sweep.js
+++ b/.agents/scripts/boot-sweep.js
@@ -212,4 +212,7 @@ async function main() {
   }
 }
 
-runAsCli(import.meta.url, main, { source: 'boot-sweep' });
+runAsCli(import.meta.url, main, {
+  source: 'boot-sweep',
+  usage: HELP,
+});

--- a/.agents/scripts/bootstrap.js
+++ b/.agents/scripts/bootstrap.js
@@ -1467,4 +1467,5 @@ export async function main(argv = process.argv.slice(2), deps = {}) {
 runAsCli(import.meta.url, main, {
   source: 'Bootstrap',
   propagateExitCode: true,
+  usage: HELP,
 });

--- a/.agents/scripts/check-arch-cycles.js
+++ b/.agents/scripts/check-arch-cycles.js
@@ -381,4 +381,24 @@ runAsCli(import.meta.url, main, {
   source: 'arch-cycles',
   propagateExitCode: true,
   errorPrefix: '[arch-cycles] ❌ Fatal error',
+  usage: {
+    invocation:
+      'node .agents/scripts/check-arch-cycles.js [--baseline <path>] [--root <dir>] [--json]',
+    summary:
+      'Ratchet on module-dependency cycles: compare the live import graph against the recorded baseline and fail on any newly added cycle.',
+    flags: [
+      [
+        '--baseline <path>',
+        'Baseline file (default: baselines/arch-cycles.json).',
+      ],
+      [
+        '--root <dir>',
+        'Scan a single root instead of the distributed surface.',
+      ],
+      ['--json', 'Emit the comparison envelope as JSON.'],
+    ],
+    notes: [
+      'Exit codes:\n  0  clean, or removals only\n  1  a new cycle was detected',
+    ],
+  },
 });

--- a/.agents/scripts/check-baselines.js
+++ b/.agents/scripts/check-baselines.js
@@ -43,7 +43,10 @@ import {
   assertFloorAxesExist,
   compareToFloor,
 } from './lib/orchestration/check-baselines/phases/floors.js';
-import { parseArgs } from './lib/orchestration/check-baselines/phases/parse-args.js';
+import {
+  HELP_TEXT,
+  parseArgs,
+} from './lib/orchestration/check-baselines/phases/parse-args.js';
 import {
   runCheckBaselines,
   selectEnabledGates,
@@ -78,4 +81,7 @@ async function main() {
   process.exit(result.exitCode);
 }
 
-runAsCli(import.meta.url, main, { source: 'check-baselines' });
+runAsCli(import.meta.url, main, {
+  source: 'check-baselines',
+  usage: HELP_TEXT,
+});

--- a/.agents/scripts/check-dead-exports.js
+++ b/.agents/scripts/check-dead-exports.js
@@ -247,4 +247,25 @@ runAsCli(import.meta.url, main, {
   source: 'dead-exports',
   propagateExitCode: true,
   errorPrefix: '[dead-exports] ❌ Fatal error',
+  usage: {
+    invocation:
+      'node .agents/scripts/check-dead-exports.js [--production] [--baseline <path>] [--knip-output <path>] [--json]',
+    summary:
+      'Ratchet on unused exports reported by knip: fail when an export is added above the recorded baseline.',
+    flags: [
+      [
+        '--production',
+        'Score the production-only surface (separate baseline).',
+      ],
+      ['--baseline <path>', 'Baseline file (default: mode-specific).'],
+      [
+        '--knip-output <path>',
+        'Read a saved knip JSON envelope instead of running knip.',
+      ],
+      ['--json', 'Emit the comparison envelope as JSON.'],
+    ],
+    notes: [
+      'Exit codes:\n  0  clean, or removals only\n  1  newly added unused exports',
+    ],
+  },
 });

--- a/.agents/scripts/check-doc-links.js
+++ b/.agents/scripts/check-doc-links.js
@@ -423,4 +423,15 @@ async function main() {
   process.exit(1);
 }
 
-runAsCli(import.meta.url, main, { source: 'check-doc-links' });
+runAsCli(import.meta.url, main, {
+  source: 'check-doc-links',
+  usage: {
+    invocation: 'node .agents/scripts/check-doc-links.js',
+    summary:
+      'Validate every relative Markdown link and /slash-command token across docs/ and .agents/, and reject mentions of retired commands.',
+    flags: [],
+    notes: [
+      'Exit codes:\n  0  every link and command token resolves\n  1  at least one violation (file:line on stderr)',
+    ],
+  },
+});

--- a/.agents/scripts/check-lifecycle-doc-drift.js
+++ b/.agents/scripts/check-lifecycle-doc-drift.js
@@ -399,4 +399,13 @@ async function main() {
 await runAsCli(import.meta.url, main, {
   source: 'check-lifecycle-doc-drift',
   propagateExitCode: true,
+  usage: {
+    invocation: 'node .agents/scripts/check-lifecycle-doc-drift.js',
+    summary:
+      "Fail when the listener-model table in docs/LIFECYCLE.md drifts from the lifecycle listeners' declared subscriptions.",
+    flags: [],
+    notes: [
+      'Exit codes:\n  0  doc and code agree\n  1  drift in either direction',
+    ],
+  },
 });

--- a/.agents/scripts/deliver-light.js
+++ b/.agents/scripts/deliver-light.js
@@ -443,4 +443,5 @@ async function main() {
 runAsCli(import.meta.url, main, {
   source: 'deliver-light',
   propagateExitCode: true,
+  usage: HELP,
 });

--- a/.agents/scripts/deliver-recover.js
+++ b/.agents/scripts/deliver-recover.js
@@ -136,4 +136,7 @@ export async function runDeliverRecover({
   return { success: true, result: recovery };
 }
 
-runAsCli(import.meta.url, runDeliverRecover, { source: 'deliver-recover' });
+runAsCli(import.meta.url, runDeliverRecover, {
+  source: 'deliver-recover',
+  usage: HELP,
+});

--- a/.agents/scripts/diagnose-friction.js
+++ b/.agents/scripts/diagnose-friction.js
@@ -248,4 +248,20 @@ export async function main(args = process.argv.slice(2)) {
 
 import { runAsCli } from './lib/cli-utils.js';
 
-runAsCli(import.meta.url, main, { source: 'DiagnoseFriction' });
+runAsCli(import.meta.url, main, {
+  source: 'DiagnoseFriction',
+  usage: {
+    invocation:
+      'node .agents/scripts/diagnose-friction.js [--story <id>] [--epic <id>] --cmd <command with args...>',
+    summary:
+      'Run a command through the diagnostic interceptor: stream its output, then append a local friction signal describing the failure. Never posts to the ticket.',
+    flags: [
+      ['--story <id>', 'Story the friction belongs to.'],
+      ['--epic <id>', 'Epic the friction belongs to.'],
+      [
+        '--cmd <command...>',
+        'The command to execute; everything after it is the argv (required).',
+      ],
+    ],
+  },
+});

--- a/.agents/scripts/diagnose.js
+++ b/.agents/scripts/diagnose.js
@@ -48,6 +48,21 @@ import { runAsCli } from './lib/cli-utils.js';
 const DEFAULT_SCOPE = 'diagnose';
 
 /**
+ * The `--help` block. Single-homed here so the CLI gate in `runAsCli` and the
+ * `validateDiagnoseArgs` HELP-sentinel branch print the same bytes.
+ */
+const HELP = [
+  'Usage: diagnose [--scope <scope>] [--fail-on-blocker] [--json]',
+  '',
+  'Options:',
+  '  --scope <s>         Filter checks by scope (default: diagnose).',
+  '                      Use `all` to run every registered check.',
+  '  --fail-on-blocker   Exit 2 when at least one finding is a blocker.',
+  '  --json              Emit findings as a single line of JSON.',
+  '',
+].join('\n');
+
+/**
  * Parse the CLI argv slice (i.e. argv without the leading node/script
  * elements). Exported for direct unit testing — keeps the parse pure so
  * tests can drive it without spawning a subprocess.
@@ -203,19 +218,7 @@ export async function runDiagnose({
  */
 export function validateDiagnoseArgs(err) {
   if (err && err.message === 'HELP') {
-    return {
-      kind: 'help',
-      text: [
-        'Usage: diagnose [--scope <scope>] [--fail-on-blocker] [--json]',
-        '',
-        'Options:',
-        '  --scope <s>         Filter checks by scope (default: diagnose).',
-        '                      Use `all` to run every registered check.',
-        '  --fail-on-blocker   Exit 2 when at least one finding is a blocker.',
-        '  --json              Emit findings as a single line of JSON.',
-        '',
-      ].join('\n'),
-    };
+    return { kind: 'help', text: HELP };
   }
   const message = err?.message ? err.message : String(err);
   return { kind: 'error', text: `[diagnose] ${message}\n`, exitCode: 1 };
@@ -237,4 +240,7 @@ async function main() {
   }
 }
 
-runAsCli(import.meta.url, main, { source: 'diagnose' });
+runAsCli(import.meta.url, main, {
+  source: 'diagnose',
+  usage: HELP,
+});

--- a/.agents/scripts/drain-pending-cleanup.js
+++ b/.agents/scripts/drain-pending-cleanup.js
@@ -144,4 +144,23 @@ async function main() {
   );
 }
 
-runAsCli(import.meta.url, main, { source: 'drain-pending-cleanup' });
+runAsCli(import.meta.url, main, {
+  source: 'drain-pending-cleanup',
+  usage: {
+    invocation:
+      'node .agents/scripts/drain-pending-cleanup.js [--dry-run] [--no-escalate] [--worktree-root <path>]',
+    summary:
+      'Drain the pending-worktree-cleanup manifest, removing trees whose holders have exited.',
+    flags: [
+      ['--dry-run', 'Report each entry and its holders; remove nothing.'],
+      [
+        '--no-escalate',
+        'Do not escalate to a forced removal for stuck entries.',
+      ],
+      [
+        '--worktree-root <path>',
+        'Worktree root (default: delivery.worktreeIsolation.root).',
+      ],
+    ],
+  },
+});

--- a/.agents/scripts/evidence-gate.js
+++ b/.agents/scripts/evidence-gate.js
@@ -238,4 +238,23 @@ async function main() {
   await runEvidenceGate({ ...args, runnerArgs });
 }
 
-runAsCli(import.meta.url, main, { source: 'evidence-gate' });
+runAsCli(import.meta.url, main, {
+  source: 'evidence-gate',
+  usage: {
+    invocation:
+      'node .agents/scripts/evidence-gate.js --scope-id <id> --gate <name> [--standalone] [--no-evidence] [--cwd <path>] [--worktree <path>]',
+    summary:
+      'Run one named gate, reusing a prior evidence stamp for the same HEAD instead of re-running it.',
+    flags: [
+      ['--scope-id <id>', 'Story id the evidence is scoped to (required).'],
+      ['--gate <name>', 'Gate to run (e.g. lint, typecheck) (required).'],
+      ['--standalone', 'Run outside a close pipeline and stamp the evidence.'],
+      [
+        '--no-evidence',
+        'Ignore and do not write evidence — always run the gate.',
+      ],
+      ['--cwd <path>', 'Repository root (default: project root).'],
+      ['--worktree <path>', 'Worktree the gate runs in.'],
+    ],
+  },
+});

--- a/.agents/scripts/generate-config-docs.js
+++ b/.agents/scripts/generate-config-docs.js
@@ -608,4 +608,17 @@ export {
   spliceRegion,
 };
 
-runAsCli(import.meta.url, main, { source: 'generate-config-docs' });
+runAsCli(import.meta.url, main, {
+  source: 'generate-config-docs',
+  usage: {
+    invocation: 'node .agents/scripts/generate-config-docs.js [--check]',
+    summary:
+      'Regenerate the configuration reference from the .agentrc schema. Writes only when the generated content differs.',
+    flags: [
+      [
+        '--check',
+        'Verify the doc is current and fail if stale; write nothing.',
+      ],
+    ],
+  },
+});

--- a/.agents/scripts/generate-lifecycle-docs.js
+++ b/.agents/scripts/generate-lifecycle-docs.js
@@ -221,4 +221,17 @@ export {
   spliceRegion,
 };
 
-runAsCli(import.meta.url, main, { source: 'generate-lifecycle-docs' });
+runAsCli(import.meta.url, main, {
+  source: 'generate-lifecycle-docs',
+  usage: {
+    invocation: 'node .agents/scripts/generate-lifecycle-docs.js [--check]',
+    summary:
+      'Regenerate the lifecycle-event table in docs/LIFECYCLE.md from the event schemas. Writes only when the generated content differs.',
+    flags: [
+      [
+        '--check',
+        'Verify the doc is current and fail if stale; write nothing.',
+      ],
+    ],
+  },
+});

--- a/.agents/scripts/generate-workflows-doc.js
+++ b/.agents/scripts/generate-workflows-doc.js
@@ -198,4 +198,17 @@ async function main(argv = process.argv.slice(2)) {
 
 export { DOC_PATH, WORKFLOWS_DIR };
 
-runAsCli(import.meta.url, main, { source: 'generate-workflows-doc' });
+runAsCli(import.meta.url, main, {
+  source: 'generate-workflows-doc',
+  usage: {
+    invocation: 'node .agents/scripts/generate-workflows-doc.js [--check]',
+    summary:
+      'Regenerate the workflow catalog from .agents/workflows/. Writes only when the generated content differs.',
+    flags: [
+      [
+        '--check',
+        'Verify the doc is current and fail if stale; write nothing.',
+      ],
+    ],
+  },
+});

--- a/.agents/scripts/git-cleanup.js
+++ b/.agents/scripts/git-cleanup.js
@@ -129,4 +129,35 @@ async function main() {
   process.exit(exitCode);
 }
 
-runAsCli(import.meta.url, main, { source: 'git-cleanup' });
+runAsCli(import.meta.url, main, {
+  source: 'git-cleanup',
+  usage: {
+    invocation:
+      'node .agents/scripts/git-cleanup.js [--execute] [--yes] [--json] [phase flags] [filters]',
+    summary:
+      'Tidy the local checkout in four phases — fast-forward the base branch, prune stale remote refs, reap merged branches, triage stashes. Dry-run unless --execute.',
+    flags: [
+      ['--execute', 'Perform the mutations (default is a dry run).'],
+      ['--dry-run', 'Force a dry run even alongside --execute.'],
+      ['--yes', 'Skip the interactive confirmation prompts.'],
+      ['--json', 'Emit the plan/result envelope as JSON.'],
+      ['--remote', 'Also delete the matching remote branches.'],
+      ['--fast-forward-main', 'Run only the fast-forward-base phase.'],
+      ['--prune-remotes', 'Run only the prune-remotes phase.'],
+      ['--branches', 'Run only the merged-branch reap phase.'],
+      ['--stashes', 'Run only the stash-triage phase.'],
+      [
+        '--include <glob>',
+        'Only consider branches matching the glob (repeatable).',
+      ],
+      [
+        '--exclude <glob>',
+        'Never consider branches matching the glob (repeatable).',
+      ],
+      ['--drop-stashes <ref>', 'Stash ref approved for dropping (repeatable).'],
+      ['--base <branch>', 'Base branch (default: project.baseBranch).'],
+      ['--cwd <path>', 'Repository root (default: process cwd).'],
+    ],
+    notes: ['With no phase flag, every phase runs in order.'],
+  },
+});

--- a/.agents/scripts/lib/cli-usage.js
+++ b/.agents/scripts/lib/cli-usage.js
@@ -1,0 +1,174 @@
+/**
+ * `.agents/scripts/lib/cli-usage.js` — the one implementation of `--help` for
+ * every top-level script under `.agents/scripts/`.
+ *
+ * ## Why
+ *
+ * A script's flag contract used to live in the workflow prose that invoked it
+ * (`deliver-story.md` Step 0 restating `single-story-init.js`'s `--dry-run` /
+ * `--steal`, and so on). Two homes for one contract is a drift class: the
+ * script changes, the prose does not, and the next agent runs a flag that no
+ * longer exists. Moving the enumeration into the script's own `--help` gives
+ * the contract a single home that ships with the code that implements it.
+ *
+ * ## Contract
+ *
+ * `--help` (or `-h`) is a **query**, never an error path:
+ *
+ *   - writes non-empty text to **stdout** and exits **0**;
+ *   - performs no GitHub write, acquires no lease, mutates no working tree.
+ *
+ * stdout — not `Logger.info` — because help output must survive
+ * `AGENT_LOG_LEVEL=silent` and carry no `[Orchestrator]` decoration; this is
+ * the same `process.stdout.write` carve-out that machine-parsable envelopes
+ * use (see `tests/enforcement/no-console.test.js`).
+ *
+ * The short-circuit itself lives in `runAsCli` (`lib/cli-utils.js`), which
+ * fires this module **before** the script's `main` runs — so the "no side
+ * effects" half of the contract holds structurally rather than by each
+ * script remembering to check first.
+ *
+ * ## Usage
+ *
+ *   runAsCli(import.meta.url, main, {
+ *     source: 'my-script',
+ *     usage: {
+ *       invocation: 'node .agents/scripts/my-script.js --story <id> [--json]',
+ *       summary: 'One line on what the script does.',
+ *       flags: [
+ *         ['--story <id>', 'GitHub issue number of the Story (required).'],
+ *         ['--json', 'Emit the envelope as JSON instead of prose.'],
+ *       ],
+ *     },
+ *   });
+ *
+ * A pre-rendered string is accepted too, so a script that already shipped a
+ * hand-written `HELP` block adopts the shared gate without its observable
+ * text changing (`usage: HELP`).
+ */
+
+/** Tokens that request help. */
+export const HELP_FLAGS = Object.freeze(['--help', '-h']);
+
+/** Left column width for the flag table; longer flags wrap to their own line. */
+const FLAG_COLUMN = 22;
+
+/**
+ * Did the caller ask for help? Scans up to the `--` end-of-flags separator so
+ * a positional literally named `--help` after `--` is not mistaken for a
+ * request.
+ *
+ * @param {string[]} argv Argument vector without the node/script entries.
+ * @returns {boolean}
+ */
+export function wantsHelp(argv = []) {
+  if (!Array.isArray(argv)) return false;
+  for (const token of argv) {
+    if (token === '--') return false;
+    if (HELP_FLAGS.includes(token)) return true;
+  }
+  return false;
+}
+
+/**
+ * Normalize one flag entry into `{ flag, description }`. Accepts a
+ * `[flag, description]` pair or an object, so call sites can use whichever
+ * reads better next to their option table.
+ *
+ * @param {[string, string]|{flag: string, description?: string}} entry
+ * @returns {{ flag: string, description: string }}
+ */
+function normalizeFlag(entry) {
+  if (Array.isArray(entry)) {
+    return {
+      flag: String(entry[0] ?? ''),
+      description: String(entry[1] ?? ''),
+    };
+  }
+  return {
+    flag: String(entry?.flag ?? ''),
+    description: String(entry?.description ?? ''),
+  };
+}
+
+/**
+ * Render one `  --flag   description` row, wrapping onto a second line when
+ * the flag itself is wider than the column.
+ *
+ * @param {{ flag: string, description: string }} row
+ * @returns {string}
+ */
+function renderFlagRow({ flag, description }) {
+  if (!description) return `  ${flag}`;
+  if (flag.length >= FLAG_COLUMN) {
+    return `  ${flag}\n  ${' '.repeat(FLAG_COLUMN)}${description}`;
+  }
+  return `  ${flag.padEnd(FLAG_COLUMN)}${description}`;
+}
+
+/**
+ * Append the `--help` row unless the spec already documents it, so every
+ * rendered block is self-describing without each call site repeating it.
+ *
+ * @param {Array<{ flag: string, description: string }>} rows
+ * @returns {Array<{ flag: string, description: string }>}
+ */
+function withHelpRow(rows) {
+  const documented = rows.some((r) => r.flag.split(/[\s,]/)[0] === '--help');
+  if (documented) return rows;
+  return [...rows, { flag: '--help', description: 'Show this message.' }];
+}
+
+/**
+ * Render a usage spec into the text `--help` prints.
+ *
+ * @param {{
+ *   invocation: string,
+ *   summary?: string,
+ *   flags?: Array<[string, string]|{flag: string, description?: string}>,
+ *   notes?: string[],
+ * }} spec
+ * @returns {string} Text block, newline-terminated.
+ */
+export function formatUsage(spec) {
+  const rows = withHelpRow((spec?.flags ?? []).map(normalizeFlag));
+  const blocks = [`Usage: ${spec?.invocation ?? ''}`.trim()];
+  if (spec?.summary) blocks.push(spec.summary);
+  blocks.push(['Flags:', ...rows.map(renderFlagRow)].join('\n'));
+  for (const note of spec?.notes ?? []) blocks.push(note);
+  return `${blocks.join('\n\n')}\n`;
+}
+
+/**
+ * Coerce either accepted `usage` shape — a spec object or a pre-rendered
+ * string — into the text to print.
+ *
+ * @param {object|string} usage
+ * @returns {string}
+ */
+export function renderUsage(usage) {
+  if (typeof usage === 'string') {
+    return usage.endsWith('\n') ? usage : `${usage}\n`;
+  }
+  return formatUsage(usage);
+}
+
+/**
+ * Answer a help request. Returns `true` when help was requested (and printed),
+ * `false` when the caller should carry on with its normal path.
+ *
+ * Never throws on a missing/blank `usage`: a script whose spec renders empty
+ * still owes the contract non-empty stdout, so a minimal line is emitted
+ * rather than a silent exit that reads as a broken CLI.
+ *
+ * @param {string[]} argv
+ * @param {object|string} usage
+ * @param {{ write: (s: string) => void }} [out] Defaults to `process.stdout`.
+ * @returns {boolean}
+ */
+export function respondToHelp(argv, usage, out = process.stdout) {
+  if (!wantsHelp(argv)) return false;
+  const text = renderUsage(usage ?? '');
+  out.write(text.trim().length > 0 ? text : 'Usage: (no flags documented)\n');
+  return true;
+}

--- a/.agents/scripts/lib/cli-utils.js
+++ b/.agents/scripts/lib/cli-utils.js
@@ -16,6 +16,7 @@
 
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { respondToHelp } from './cli-usage.js';
 import { formatCliError } from './error-redactor.js';
 
 /**
@@ -37,12 +38,21 @@ export function isDirectInvocation(importMetaUrl) {
  * `main` is funnelled through either the caller-supplied `onError` callback
  * or the default handler (prefixed stderr line + `process.exit(exitCode)`).
  *
+ * A `usage` option makes the script self-describing: when the argv carries
+ * `--help` / `-h`, the rendered usage block goes to stdout and `main` is
+ * **never invoked**. That ordering is the whole point — it makes "`--help`
+ * performs no GitHub write, acquires no lease, and mutates no working tree"
+ * structurally true for every adopting script, rather than something each
+ * `main` has to remember to check before its first side effect.
+ *
  * @param {string} importMetaUrl        Caller's `import.meta.url`.
  * @param {() => Promise<unknown>} main The CLI's main function.
  * @param {object} [options]
  * @param {string} [options.source='CLI']           Prefix used in the default error message.
  * @param {number} [options.exitCode=1]             Exit code used by the default error handler.
  * @param {(err: Error) => void} [options.onError]  Full override of the error handler.
+ * @param {object|string} [options.usage]           Usage spec (or pre-rendered
+ *   text) printed for `--help`; see `lib/cli-usage.js`.
  */
 export function runAsCli(importMetaUrl, main, options = {}) {
   if (!isDirectInvocation(importMetaUrl)) return;
@@ -52,7 +62,9 @@ export function runAsCli(importMetaUrl, main, options = {}) {
     onError,
     propagateExitCode = false,
     errorPrefix,
+    usage,
   } = options;
+  if (usage && respondToHelp(process.argv.slice(2), usage)) return;
   const promise = main();
   if (propagateExitCode) {
     promise.then((code) => process.exit(code ?? 0));

--- a/.agents/scripts/mandrel-update-preflight.js
+++ b/.agents/scripts/mandrel-update-preflight.js
@@ -232,4 +232,13 @@ async function main() {
 runAsCli(import.meta.url, main, {
   source: 'mandrel-update-preflight',
   propagateExitCode: true,
+  usage: {
+    invocation: 'node .agents/scripts/mandrel-update-preflight.js',
+    summary:
+      'First-run guard for /mandrel-update: hard-stops on a non-consumer repo, warns on a dirty git index and on being offline.',
+    flags: [],
+    notes: [
+      'Exit codes:\n  0  safe to update (warnings may be present)\n  1  blocker — do not update',
+    ],
+  },
 });

--- a/.agents/scripts/nav-registry-diff.js
+++ b/.agents/scripts/nav-registry-diff.js
@@ -446,4 +446,17 @@ export { main };
 runAsCli(import.meta.url, main, {
   source: 'nav-registry-diff',
   propagateExitCode: true,
+  usage: {
+    invocation:
+      'node .agents/scripts/nav-registry-diff.js --routes <file> --nav <file> [--refs <file>] [--json] [--strict]',
+    summary:
+      'Diff a route inventory against the nav registry: report routes with no nav door and nav hrefs pointing nowhere.',
+    flags: [
+      ['--routes <file>', 'JSON array of route records (required).'],
+      ['--nav <file>', 'JSON array of nav entries (required).'],
+      ['--refs <file>', 'JSON array of additional href references.'],
+      ['--json', 'Emit the diff as JSON instead of a text report.'],
+      ['--strict', 'Exit non-zero on any finding.'],
+    ],
+  },
 });

--- a/.agents/scripts/plan-context.js
+++ b/.agents/scripts/plan-context.js
@@ -339,4 +339,20 @@ async function main() {
   );
 }
 
-runAsCli(import.meta.url, main, { source: 'plan-context' });
+runAsCli(import.meta.url, main, {
+  source: 'plan-context',
+  usage: {
+    invocation:
+      'node .agents/scripts/plan-context.js (--seed "<text>" | --seed-file <path> | --tickets <ids> | --amends <id>) [--out <path>] [--pretty]',
+    summary:
+      'Build the /plan authoring-context envelope on stdout. Exactly one entry form must be supplied.',
+    flags: [
+      ['--seed "<text>"', 'Inline seed prose.'],
+      ['--seed-file <path>', 'Seed document to read.'],
+      ['--tickets <ids>', 'Comma-separated existing ticket ids to re-plan.'],
+      ['--amends <id>', 'Amend the Spec of an existing Story.'],
+      ['--out <path>', 'Write the envelope to a file instead of stdout.'],
+      ['--pretty', 'Pretty-print the JSON envelope.'],
+    ],
+  },
+});

--- a/.agents/scripts/plan-critics.js
+++ b/.agents/scripts/plan-critics.js
@@ -312,4 +312,14 @@ async function main() {
 runAsCli(import.meta.url, main, {
   source: 'plan-critics',
   propagateExitCode: true,
+  usage: {
+    invocation:
+      'node .agents/scripts/plan-critics.js --stories <file> [--tech-spec <file>]',
+    summary:
+      'Score an authored plan draft with the maker-blind critics and print the verdict JSON on stdout.',
+    flags: [
+      ['--stories <file>', 'Authored stories.json (required).'],
+      ['--tech-spec <file>', 'Optional companion techspec.md.'],
+    ],
+  },
 });

--- a/.agents/scripts/plan-persist.js
+++ b/.agents/scripts/plan-persist.js
@@ -438,4 +438,36 @@ async function main() {
   process.stdout.write(`${JSON.stringify(result)}\n`);
 }
 
-runAsCli(import.meta.url, main, { source: 'plan-persist' });
+runAsCli(import.meta.url, main, {
+  source: 'plan-persist',
+  usage: {
+    invocation:
+      'node .agents/scripts/plan-persist.js --stories <file> [--tech-spec <file>] [--dry-run] [options]',
+    summary:
+      'Validate an authored plan and persist it as GitHub Stories. Prints the result envelope as JSON on stdout.',
+    flags: [
+      ['--stories <file>', 'Authored stories.json (required).'],
+      ['--tech-spec <file>', 'Optional companion techspec.md.'],
+      ['--plan-dir <dir>', 'Directory holding the plan artifacts.'],
+      [
+        '--plan-context <file>',
+        'The plan-context envelope this draft was authored against.',
+      ],
+      ['--plan-acceptance <file>', 'Acceptance artifact to attach.'],
+      ['--source-tickets <ids>', 'Ticket ids this plan supersedes.'],
+      [
+        '--route-downgrade-reason <text>',
+        'Why the authored route was downgraded.',
+      ],
+      ['--dry-run', 'Validate and report; create nothing.'],
+      ['--chain-on-clean', 'Persist immediately when the dry run is clean.'],
+      ['--no-close-superseded', 'Leave superseded source tickets open.'],
+      [
+        '--force-review',
+        'Require the review gate even when it would be skipped.',
+      ],
+      ['--allow-over-budget', 'Permit a Spec over the context budget.'],
+      ['--allow-large-fan-out', 'Permit a Story count above the fan-out gate.'],
+    ],
+  },
+});

--- a/.agents/scripts/plan-run-epilogue.js
+++ b/.agents/scripts/plan-run-epilogue.js
@@ -139,4 +139,15 @@ function warnOnEmptyRollup(result) {
   );
 }
 
-await runAsCli(import.meta.url, main);
+await runAsCli(import.meta.url, main, {
+  usage: {
+    invocation:
+      'node .agents/scripts/plan-run-epilogue.js --stories <id,id,...> [--cwd <path>]',
+    summary:
+      'Close out a delivery run: roll up the delivered Stories’ signals and report the run’s loop health.',
+    flags: [
+      ['--stories <ids>', 'Comma-separated delivered Story ids (required).'],
+      ['--cwd <path>', 'Repository root (default: process cwd).'],
+    ],
+  },
+});

--- a/.agents/scripts/quality-preview.js
+++ b/.agents/scripts/quality-preview.js
@@ -29,6 +29,22 @@ import {
   runCrapPreview,
   runMaintainabilityPreview,
 } from './lib/baselines/preview-gates.js';
+import { respondToHelp } from './lib/cli-usage.js';
+
+const USAGE = {
+  invocation:
+    'node .agents/scripts/quality-preview.js [--staged | --changed-since <ref>] [--json]',
+  summary:
+    'Preview the per-file maintainability and CRAP deltas for the change set, and exit non-zero on any threshold violation.',
+  flags: [
+    ['--staged', 'Score the git index only (the pre-commit-hook scope).'],
+    [
+      '--changed-since <ref>',
+      'Score the diff against <ref> (default: HEAD). Last occurrence wins.',
+    ],
+    ['--json', 'Emit both gate envelopes plus the merged table as JSON.'],
+  ],
+};
 
 /**
  * Parse `--changed-since <ref>` from argv. Defaults to `HEAD` when the flag is
@@ -327,7 +343,7 @@ const isDirect = (() => {
   }
 })();
 
-if (isDirect) {
+if (isDirect && !respondToHelp(process.argv.slice(2), USAGE)) {
   runCli().then(({ exitCode }) => {
     process.exit(exitCode);
   });

--- a/.agents/scripts/resolve-doc-tiers.js
+++ b/.agents/scripts/resolve-doc-tiers.js
@@ -80,4 +80,17 @@ runAsCli(import.meta.url, main, {
   source: 'resolve-doc-tiers',
   propagateExitCode: true,
   errorPrefix: '[resolve-doc-tiers] ❌ Fatal error',
+  usage: {
+    invocation:
+      'node .agents/scripts/resolve-doc-tiers.js [--root <dir>] [--json]',
+    summary:
+      'Print the resolved documentation tiers (always-loaded vs on-demand) as JSON.',
+    flags: [
+      [
+        '--root <dir>',
+        'Repository root to resolve against (default: project root).',
+      ],
+      ['--json', 'Accepted for symmetry; output is always JSON.'],
+    ],
+  },
 });

--- a/.agents/scripts/resolve-stories.js
+++ b/.agents/scripts/resolve-stories.js
@@ -235,4 +235,5 @@ async function main() {
 runAsCli(import.meta.url, main, {
   source: 'resolve-stories',
   propagateExitCode: true,
+  usage: HELP,
 });

--- a/.agents/scripts/resync-status-column.js
+++ b/.agents/scripts/resync-status-column.js
@@ -178,4 +178,7 @@ export async function main(argv = process.argv.slice(2)) {
   process.stdout.write(`${JSON.stringify({ ticketId, ...result })}\n`);
 }
 
-runAsCli(import.meta.url, main, { source: 'resync-status-column' });
+runAsCli(import.meta.url, main, {
+  source: 'resync-status-column',
+  usage: HELP,
+});

--- a/.agents/scripts/signals-view.js
+++ b/.agents/scripts/signals-view.js
@@ -290,6 +290,17 @@ runAsCli(
   },
   {
     source: 'signals-view',
+    usage: {
+      invocation:
+        'node .agents/scripts/signals-view.js <run-id> [--story <id>] [--temp-root <path>]',
+      summary:
+        'Render a run’s signal ledger as a tree, optionally narrowed to one Story.',
+      flags: [
+        ['<run-id>', 'Run id whose signals are read (required positional).'],
+        ['--story <id>', 'Show only signals emitted for this Story.'],
+        ['--temp-root <path>', 'Temp root holding the signal ledgers.'],
+      ],
+    },
     onError(err) {
       println(`signals-view: unexpected error: ${err?.message ?? err}`);
       process.exit(1);

--- a/.agents/scripts/single-story-close.js
+++ b/.agents/scripts/single-story-close.js
@@ -251,4 +251,28 @@ async function main() {
 runAsCli(import.meta.url, main, {
   source: 'single-story-close',
   propagateExitCode: true,
+  usage: {
+    invocation:
+      'node .agents/scripts/single-story-close.js --story <id> [--cwd <main-repo>] [options]',
+    summary:
+      'Run the whole delivery tail for one Story — close gates, base sync, push, PR to the base branch, merge wait, agent::done flip — and emit the terminal envelope.',
+    flags: [
+      ['--story <id>', 'GitHub issue number of the Story (required).'],
+      [
+        '--cwd <main-repo>',
+        'Main-repo checkout to run from (default: project root).',
+      ],
+      ['--skip-validation', 'Skip the close-validation gate chain.'],
+      ['--skip-sync', 'Skip the base-branch sync phase.'],
+      ['--no-auto-merge', 'Open the PR without arming native auto-merge.'],
+      ['--wait-merge', 'Force the in-close merge wait.'],
+      ['--no-wait-merge', 'Return as soon as the PR is open; do not wait.'],
+      ['--max-wait-seconds <n>', 'Per-invocation merge-wait bound.'],
+      ['--no-evidence', 'Do not reuse or write gate evidence stamps.'],
+      ['--dry-run', 'Report the plan; mutate nothing.'],
+    ],
+    notes: [
+      'Exit codes:\n  0  landed\n  1  blocked or failed\n  3  pending (resumable — run the envelope’s nextCommand)',
+    ],
+  },
 });

--- a/.agents/scripts/single-story-confirm-merge.js
+++ b/.agents/scripts/single-story-confirm-merge.js
@@ -538,4 +538,20 @@ async function main() {
 runAsCli(import.meta.url, main, {
   source: 'single-story-confirm-merge',
   propagateExitCode: true,
+  usage: {
+    invocation:
+      'node .agents/scripts/single-story-confirm-merge.js --story <id> [--pr <n>] [--wait] [--max-wait-seconds <n>] [--cwd <main-repo>]',
+    summary:
+      'Confirm a Story PR merged and flip the Story to agent::done. With --wait, resumes the bounded merge wait a close handed off.',
+    flags: [
+      ['--story <id>', 'GitHub issue number of the Story (required).'],
+      ['--pr <n>', 'PR number (default: resolved from the Story branch).'],
+      ['--wait', 'Resume the bounded merge wait instead of probing once.'],
+      ['--max-wait-seconds <n>', 'Per-invocation bound for the --wait path.'],
+      [
+        '--cwd <main-repo>',
+        'Main-repo checkout to run from (default: project root).',
+      ],
+    ],
+  },
 });

--- a/.agents/scripts/single-story-init.js
+++ b/.agents/scripts/single-story-init.js
@@ -831,4 +831,24 @@ export function renderSingleStoryInitComment(result) {
   ].join('\n');
 }
 
-runAsCli(import.meta.url, runSingleStoryInit, { source: 'single-story-init' });
+runAsCli(import.meta.url, runSingleStoryInit, {
+  source: 'single-story-init',
+  usage: {
+    invocation:
+      'node .agents/scripts/single-story-init.js --story <id> [--dry-run] [--steal] [--cwd <main-repo>]',
+    summary:
+      'Initialize a Story for delivery: acquire the lease, seed story-<id> from the base branch, materialize the worktree, and flip the Story to agent::executing.',
+    flags: [
+      ['--story <id>', 'GitHub issue number of the Story (required).'],
+      [
+        '--dry-run',
+        'Report what would happen; no mutations, no lease, no sweep.',
+      ],
+      ['--steal', 'Forcibly transfer a lease held by another assignee.'],
+      [
+        '--cwd <main-repo>',
+        'Main-repo checkout to run from (default: project root).',
+      ],
+    ],
+  },
+});

--- a/.agents/scripts/stories-wave-tick.js
+++ b/.agents/scripts/stories-wave-tick.js
@@ -880,4 +880,5 @@ async function main(argv) {
 
 runAsCli(import.meta.url, () => main(process.argv.slice(2)), {
   source: 'stories-wave-tick',
+  usage: HELP,
 });

--- a/.agents/scripts/sync-agentrc.js
+++ b/.agents/scripts/sync-agentrc.js
@@ -21,14 +21,26 @@
  *   0 — Config is valid (advisories may still appear).
  *   1 — Config is missing, malformed, or fails schema validation.
  *
- * Flags:
- *   --cwd <path>   Project root (defaults to process.cwd()).
- *   --quiet        Suppress advisory rows (only print the status line).
+ * The flag contract lives in `USAGE` below — `--help` is the one home for it.
  */
 
 import { fileURLToPath } from 'node:url';
+import { respondToHelp } from './lib/cli-usage.js';
 import { formatSyncReport, syncAgentrc } from './lib/config/sync-agentrc.js';
 import { Logger } from './lib/Logger.js';
+
+const USAGE = {
+  invocation: 'node .agents/scripts/sync-agentrc.js [--cwd <path>] [--quiet]',
+  summary:
+    'Validate `.agentrc.json` against the framework schema and report every project leaf that merely restates a framework default. Never writes the config.',
+  flags: [
+    ['--cwd <path>', 'Project root (default: process cwd).'],
+    ['--quiet', 'Suppress advisory rows; print only the status line.'],
+  ],
+  notes: [
+    'Exit codes:\n  0  config is valid (advisories may still appear)\n  1  config is missing, malformed, or fails schema validation',
+  ],
+};
 
 function parseArgs(argv) {
   const out = { cwd: null, quiet: false };
@@ -67,5 +79,5 @@ function trimAdvisories(report) {
 // cli-opt-out: synchronous CLI with explicit exit-code return.
 const isMain = process.argv[1] === fileURLToPath(import.meta.url);
 if (isMain) {
-  process.exit(main());
+  process.exit(respondToHelp(process.argv.slice(2), USAGE) ? 0 : main());
 }

--- a/.agents/scripts/update-ticket-state.js
+++ b/.agents/scripts/update-ticket-state.js
@@ -6,16 +6,37 @@
  */
 
 import { parseArgs } from 'node:util';
+import { respondToHelp } from './lib/cli-usage.js';
 import { resolveConfig } from './lib/config-resolver.js';
 import { Logger } from './lib/Logger.js';
 import { transitionTicketState } from './lib/orchestration/ticketing.js';
 import { createProvider } from './lib/provider-factory.js';
 
+const USAGE = {
+  invocation:
+    'node .agents/scripts/update-ticket-state.js --ticket <id> [--state <state> | --remove-label <label>]',
+  summary:
+    'The one sanctioned surface for an agent::* label transition on a ticket.',
+  flags: [
+    ['--ticket <id>', 'GitHub issue number to transition (required).'],
+    [
+      '--state <state>',
+      'Target agent state (e.g. agent::ready, agent::executing, agent::done).',
+    ],
+    [
+      '--remove-label <label>',
+      'Drop a single label without flipping the agent state.',
+    ],
+  ],
+  notes: ['Exactly one of --state or --remove-label is required.'],
+};
+
 // ── CLI Main Block ────────────────────────────────────────────────────────
 // cli-opt-out: re-export shim with a DEBUG_MAIN escape hatch for tests; runAsCli's strict path-equality guard would block the env-flag entry path.
 if (
-  process.argv[1]?.endsWith('update-ticket-state.js') ||
-  process.env.DEBUG_MAIN
+  (process.argv[1]?.endsWith('update-ticket-state.js') ||
+    process.env.DEBUG_MAIN) &&
+  !respondToHelp(process.argv.slice(2), USAGE)
 ) {
   const { values } = parseArgs({
     args: process.argv.slice(2),

--- a/.agents/workflows/git-cleanup.md
+++ b/.agents/workflows/git-cleanup.md
@@ -22,12 +22,12 @@ Reach for it when the automated hygiene left an unusual state behind.
 
 The enumeration + reap logic lives in
 [`git-cleanup.js`](../scripts/git-cleanup.js) — it computes the candidate list,
-the skip taxonomy, the detection signals, and the JSON envelope (add `--json`),
-and prints them itself. Without `--execute` the script is a **dry-run preview**; nothing is
-mutated. When no phase flag is passed, **all four phases run** sequentially; pass
-any of `--fast-forward-main`, `--prune-remotes`, `--branches`, `--stashes` to
-narrow the run. A failure in one phase does not short-circuit the others — each
-runs and reports independently.
+the skip taxonomy, the detection signals, and the JSON envelope, and prints them
+itself. Without `--execute` the script is a **dry-run preview**; nothing is
+mutated. When no phase flag is passed, **all four phases run** sequentially; a
+phase flag narrows the run. A failure in one phase does not short-circuit the
+others — each runs and reports independently. The script documents its own
+flags: `node .agents/scripts/git-cleanup.js --help`.
 
 ## Phases
 
@@ -44,14 +44,9 @@ runs and reports independently.
 > branches, delete remote refs (with `--remote`), and drop stashes. Without
 > `--execute` the script only previews.
 
-- **`--execute`** — the master gate. Omit it for a preview of all four phases.
-- **`--remote`** — extends the branches phase to delete the matching
-  `origin/<branch>` ref (and to delete remote-only merged branches). Cannot be
-  undone without re-pushing.
-- **`--yes`** — bypass every per-step prompt (CI / non-interactive). Under it,
-  stash drops still require `--drop-stashes <ref>`.
-- **`--exclude '<pattern>'`** — carve a branch out of the reap. This is the only
-  way to protect an in-scope merged-PR branch you want to keep.
+Two consequences the flag list alone does not carry: `--remote` deletions cannot
+be undone without re-pushing, and `--exclude '<pattern>'` is the **only** way to
+protect an in-scope merged-PR branch you want to keep.
 
 Do **not** run with `--execute` if there is unmerged work that needs saving. The
 fast-forward phase skips on a dirty tree (safe), but the branches phase reaps any

--- a/.agents/workflows/helpers/deliver-story-reference.md
+++ b/.agents/workflows/helpers/deliver-story-reference.md
@@ -309,29 +309,25 @@ checks pass. Under `"strict"`, the close **does not arm auto-merge** — the
 PR opens and waits for an **operator merge**, exactly as `--no-auto-merge`
 does per-run.
 
-**Close flags:**
+**When to reach for a close flag.** What each one *does* is in
+`node .agents/scripts/single-story-close.js --help`; below is only the
+judgment that help text cannot carry.
 
-- `--skip-validation` — bypass the gates. Use only when re-running close
-  after a fixed gate failure that's already known to pass.
-- `--skip-sync` — bypass the base-sync (Story #2580). Use only after a
-  hand-resolved sync, or in tests.
-- `--no-auto-merge` — disable auto-merge. Use when the PR materially changes
-  behaviour and warrants a pre-merge eyeball; the operator then merges via
-  the GitHub UI.
-- `--wait-merge` — **close-and-land** (Story #4428). Forces close to poll
-  the armed PR to merge confirmation and flip `agent::done` itself. When
-  neither land flag is passed, close defaults from
-  `delivery.routing.closeAndLand` (**true**): attended and headless delivers
-  share the land-in-one-close happy path.
-- `--no-wait-merge` — explicit opt-out that always wins. Use when the
-  operator wants the PR left at `agent::closing` for a human land (or a
-  wrapper that will invoke `single-story-confirm-merge.js` itself). Reports
-  `pending` — the work is not done, nothing is broken, and one named command
-  finishes it.
-- `--max-wait-seconds <n>` — raise the merge wait's per-invocation bound for
-  this run (Story #4543). Use from a headless caller with no host
-  tool-invocation ceiling to keep single-block semantics without editing the
-  consumer's config.
+- `--skip-validation` — only when re-running close after a fixed gate
+  failure that's already known to pass.
+- `--skip-sync` — only after a hand-resolved sync (Story #2580), or in tests.
+- `--no-auto-merge` — when the PR materially changes behaviour and warrants a
+  pre-merge eyeball; the operator then merges via the GitHub UI.
+- `--wait-merge` — **close-and-land** (Story #4428). When neither land flag
+  is passed, close defaults from `delivery.routing.closeAndLand` (**true**):
+  attended and headless delivers share the land-in-one-close happy path.
+- `--no-wait-merge` — the explicit opt-out always wins. Use when the operator
+  wants the PR left at `agent::closing` for a human land (or a wrapper that
+  will invoke `single-story-confirm-merge.js` itself). Reports `pending` —
+  the work is not done, nothing is broken, and one named command finishes it.
+- `--max-wait-seconds <n>` — from a headless caller with no host
+  tool-invocation ceiling (Story #4543), to keep single-block semantics
+  without editing the consumer's config.
 
 ---
 
@@ -636,12 +632,8 @@ then, so the bot gets the last write.
   means the bot won every attempt in the poll budget (rare; usually
   signals operator should reap the conflicting workflows).
 
-Tuning flags (rarely needed):
-
-- `--poll-attempts <n>` — total mutation attempts including the
-  initial sync. Default `4`. Pass `1` to disable the poll loop
-  (fastest, matches pre-#2876 behaviour).
-- `--poll-delay-ms <ms>` — delay between drift checks. Default `5000`.
+Tuning flags are rarely needed; the script enumerates them itself
+(`node .agents/scripts/resync-status-column.js --help`).
 
 Idempotent: re-running on a ticket whose Status already matches the
 target returns the same envelope. No-op skips (`no-project`,

--- a/.agents/workflows/helpers/deliver-story.md
+++ b/.agents/workflows/helpers/deliver-story.md
@@ -46,8 +46,8 @@ timeout — the per-tree install can take minutes; never `run_in_background`:
 node .agents/scripts/single-story-init.js --story <storyId>
 ```
 
-Flags: `--dry-run` (no mutations; skips lease + sweep), `--steal` (transfer
-a foreign lease). It validates `type::story`, **acquires the Story lease**
+Every script below documents its own flags — run it with `--help`.
+It validates `type::story`, **acquires the Story lease**
 (fails closed on a foreign assignee), fetches `origin`, seeds `story-<id>`
 from `baseBranch` (idempotent reuse), materializes a worktree, runs a
 guarded merged-`story-*` sweep, and flips `agent::executing` (reference

--- a/.agents/workflows/plan.md
+++ b/.agents/workflows/plan.md
@@ -25,18 +25,19 @@ Epic/Story router, no scope-triage `epic|story` verdict:
 
 ## Flags
 
+Workflow-level flags only — the ones that change what **you** do:
+
 | Flag | Meaning |
 | --- | --- |
 | `--seed "<text>"` / `--seed-file <path>` | Seed text / pre-authored notes path. |
 | `--tickets <ids>` | Issue ids to analyze; closed as superseded at persist. |
 | `--amends #<id>` | Prior Story to amend; emits a delta envelope, not a full re-interrogation (#4741). |
-| `--chain-on-clean` | Persist: chain a clean lite dry-run into the real persist in one round-trip; full-route plans keep the review round-trip (#4741). |
-| `--no-close-superseded` | Keep the source issues open — no supersede comment, no close. |
 | `--force-review` | STOP at gate #2 for operator review — the only review gate (#4542). |
-| `--route-downgrade-reason "<text>"` | Authored `lite` verdict + reason (#4722); shape-validated, fails closed to `full`. |
-| `--allow-over-budget` | Permit a plan exceeding `maxTickets`. |
 | `--yes` | Non-interactive: auto-proceed gate #1 and gate #2 HITL waits. |
 | `--dry-run` | Author + validate without GitHub writes; run as a pre-pass. |
+
+Every other flag is a passthrough to a CLI that documents itself — run the
+command with `--help` rather than looking for a copy of its surface here.
 
 ## Default-single split policy
 

--- a/baselines/dead-exports-production.json
+++ b/baselines/dead-exports-production.json
@@ -633,6 +633,22 @@
       "symbol": "getScopeKeys"
     },
     {
+      "file": ".agents/scripts/lib/cli-usage.js",
+      "symbol": "formatUsage"
+    },
+    {
+      "file": ".agents/scripts/lib/cli-usage.js",
+      "symbol": "HELP_FLAGS"
+    },
+    {
+      "file": ".agents/scripts/lib/cli-usage.js",
+      "symbol": "renderUsage"
+    },
+    {
+      "file": ".agents/scripts/lib/cli-usage.js",
+      "symbol": "wantsHelp"
+    },
+    {
       "file": ".agents/scripts/lib/cli-utils.js",
       "symbol": "isDirectInvocation"
     },

--- a/tests/enforcement/workflow-script-help.test.js
+++ b/tests/enforcement/workflow-script-help.test.js
@@ -1,0 +1,152 @@
+/**
+ * tests/enforcement/workflow-script-help.test.js
+ *
+ * Story #4750 — every orchestration script a workflow tells an agent to run
+ * must be self-describing.
+ *
+ * ## The rule
+ *
+ * For each `.agents/scripts/*.js` path referenced by any file under
+ * `.agents/workflows/`, `node <script> --help` must:
+ *
+ *   1. exit 0 — `--help` is a query, never an error path; and
+ *   2. write non-empty text to **stdout** (not stderr, and not swallowed by
+ *      `AGENT_LOG_LEVEL=silent`).
+ *
+ * ## Why the set is derived, not listed
+ *
+ * A hard-coded adoption list is a second place to remember, which is the exact
+ * failure this Story exists to remove: the flag contract used to live in the
+ * workflow prose that invoked the script, and drifted from the script. Grepping
+ * the workflows means a newly-invoked script fails this test until it answers
+ * `--help` — the guard grows with the corpus instead of rotting next to it.
+ *
+ * ## Why the side-effect half is structural, not asserted here
+ *
+ * "`--help` performs no GitHub write, acquires no lease, and mutates no
+ * working tree" is enforced by construction: `runAsCli` (`lib/cli-utils.js`)
+ * answers help **before** invoking `main`, so no script body runs at all. The
+ * `respondToHelp`-before-`main` ordering is unit-tested in
+ * `tests/lib/cli-usage.test.js`; here we assert the observable half plus the
+ * one thing a subprocess can see cheaply — that the run left the working tree
+ * clean.
+ */
+
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import { describe, it } from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+const WORKFLOWS_DIR = path.join(REPO_ROOT, '.agents', 'workflows');
+const SCRIPTS_DIR = path.join(REPO_ROOT, '.agents', 'scripts');
+
+/** Matches `.agents/scripts/<name>.js` — top-level CLIs only, not `lib/`. */
+const SCRIPT_REF_RE = /\.agents\/scripts\/([A-Za-z0-9_-]+)\.js/g;
+
+function listMarkdown(dir, out = []) {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) listMarkdown(full, out);
+    else if (entry.isFile() && entry.name.endsWith('.md')) out.push(full);
+  }
+  return out;
+}
+
+/**
+ * The adoption set: every top-level script named by a workflow document and
+ * present on disk. Sorted so failures read in a stable order.
+ *
+ * @returns {string[]} Script basenames, e.g. `single-story-init.js`.
+ */
+export function deriveWorkflowInvokedScripts() {
+  const names = new Set();
+  for (const doc of listMarkdown(WORKFLOWS_DIR)) {
+    const source = fs.readFileSync(doc, 'utf8');
+    for (const match of source.matchAll(SCRIPT_REF_RE)) {
+      const file = `${match[1]}.js`;
+      if (fs.existsSync(path.join(SCRIPTS_DIR, file))) names.add(file);
+    }
+  }
+  return [...names].sort();
+}
+
+const ADOPTION_SET = deriveWorkflowInvokedScripts();
+
+/** `git status --porcelain`, as a set of path entries. */
+function worktreeStatus() {
+  const status = spawnSync('git', ['status', '--porcelain'], {
+    cwd: REPO_ROOT,
+    encoding: 'utf8',
+  });
+  assert.equal(status.status, 0, 'git status failed');
+  return (status.stdout ?? '')
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0 && !line.includes(' temp/'))
+    .sort();
+}
+
+// Captured at module load — i.e. before any `--help` subprocess runs — so the
+// comparison at the end measures what the help runs did, not how dirty the
+// checkout happened to be when the suite started.
+const STATUS_BEFORE = worktreeStatus();
+
+describe('workflow-invoked scripts are self-describing', () => {
+  it('derives a non-empty adoption set from the workflow corpus', () => {
+    assert.ok(
+      ADOPTION_SET.length > 0,
+      'no .agents/scripts/*.js references found under .agents/workflows/ — the ' +
+        'grep that derives this guard has stopped matching',
+    );
+    // Spot-check the derivation rather than pinning a count: a Story that adds
+    // or retires a workflow invocation must not have to edit this test.
+    assert.ok(
+      ADOPTION_SET.includes('single-story-init.js'),
+      'expected the deliver path to still invoke single-story-init.js',
+    );
+  });
+
+  for (const script of ADOPTION_SET) {
+    it(`${script} answers --help on stdout with exit 0`, () => {
+      const result = spawnSync(
+        process.execPath,
+        [path.join(SCRIPTS_DIR, script), '--help'],
+        {
+          cwd: REPO_ROOT,
+          encoding: 'utf8',
+          timeout: 60_000,
+          // `silent` proves help does not ride on Logger.info: a script that
+          // routes its usage block through the logger prints nothing here.
+          env: { ...process.env, AGENT_LOG_LEVEL: 'silent' },
+        },
+      );
+
+      assert.equal(
+        result.status,
+        0,
+        `${script} --help exited ${result.status} (signal ${result.signal}).\n` +
+          `stderr: ${(result.stderr ?? '').slice(0, 800)}`,
+      );
+      assert.ok(
+        (result.stdout ?? '').trim().length > 0,
+        `${script} --help wrote nothing to stdout. A workflow-invoked script ` +
+          'must document its own flags — add a `usage:` spec to its runAsCli ' +
+          'call (see .agents/scripts/lib/cli-usage.js).',
+      );
+    });
+  }
+
+  it('leaves the working tree exactly as it found it', () => {
+    assert.deepEqual(
+      worktreeStatus(),
+      STATUS_BEFORE,
+      '`--help` mutated the working tree. A help branch must short-circuit ' +
+        'before any write — check that the script routes help through ' +
+        "runAsCli's `usage` option rather than a check inside main().",
+    );
+  });
+});

--- a/tests/enforcement/workflow-script-help.test.js
+++ b/tests/enforcement/workflow-script-help.test.js
@@ -38,6 +38,11 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { describe, it } from 'node:test';
 import { fileURLToPath } from 'node:url';
+import {
+  assertDocMentions,
+  assertDocOmits,
+  readDoc,
+} from '../helpers/doc-assert.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = path.resolve(__dirname, '..', '..');
@@ -139,6 +144,47 @@ describe('workflow-invoked scripts are self-describing', () => {
       );
     });
   }
+
+  it('does not re-inline a flag enumeration the script now owns', () => {
+    // Story #4750 deleted these three; each is a verbatim restatement of a
+    // flag surface `--help` prints, and each is the shape most likely to be
+    // pasted back in by a well-meaning edit. Wrap-independent by construction
+    // (`assertDocOmits` normalizes) so a re-flow cannot hide a regression.
+    const deliverStory = readDoc(
+      path.join(WORKFLOWS_DIR, 'helpers', 'deliver-story.md'),
+    );
+    assertDocOmits(
+      deliverStory,
+      /Flags: `--dry-run`/,
+      'single-story-init.js documents --dry-run / --steal itself — deliver-story.md must not restate them',
+    );
+    assertDocMentions(
+      deliverStory,
+      /documents its own flags — run it with `--help`/,
+      "deliver-story.md must point the reader at each script's own --help",
+    );
+
+    const plan = readDoc(path.join(WORKFLOWS_DIR, 'plan.md'));
+    for (const flag of [
+      '--chain-on-clean',
+      '--no-close-superseded',
+      '--route-downgrade-reason',
+      '--allow-over-budget',
+    ]) {
+      assertDocOmits(
+        plan,
+        new RegExp(`\\| \`${flag}`),
+        `plan.md's flag table must not restate plan-persist.js's ${flag} — the CLI documents it`,
+      );
+    }
+
+    const gitCleanup = readDoc(path.join(WORKFLOWS_DIR, 'git-cleanup.md'));
+    assertDocMentions(
+      gitCleanup,
+      /git-cleanup\.js --help/,
+      'git-cleanup.md must point at the script for its flag list',
+    );
+  });
 
   it('leaves the working tree exactly as it found it', () => {
     assert.deepEqual(

--- a/tests/lib/cli-usage.test.js
+++ b/tests/lib/cli-usage.test.js
@@ -1,0 +1,218 @@
+/**
+ * Unit coverage for `.agents/scripts/lib/cli-usage.js` (Story #4750) and for
+ * the `usage` short-circuit it gives `runAsCli`.
+ *
+ * The load-bearing claim is the **ordering**: help is answered before `main`
+ * runs at all. That is what makes "`--help` performs no GitHub write, acquires
+ * no lease, and mutates no working tree" true for every adopting script
+ * without each one re-implementing the guard — so it gets a direct test rather
+ * than being inferred from a subprocess's stdout.
+ */
+
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import {
+  formatUsage,
+  HELP_FLAGS,
+  renderUsage,
+  respondToHelp,
+  wantsHelp,
+} from '../../.agents/scripts/lib/cli-usage.js';
+import { runAsCli } from '../../.agents/scripts/lib/cli-utils.js';
+
+/** Collecting stdout stand-in. */
+function sink() {
+  const chunks = [];
+  return { chunks, write: (s) => chunks.push(s), text: () => chunks.join('') };
+}
+
+describe('wantsHelp', () => {
+  it('recognizes every documented help flag', () => {
+    for (const flag of HELP_FLAGS) {
+      assert.equal(wantsHelp([flag]), true, `${flag} should request help`);
+    }
+  });
+
+  it('finds the flag anywhere in the argv', () => {
+    assert.equal(wantsHelp(['--story', '42', '--help']), true);
+  });
+
+  it('is false for an argv with no help flag', () => {
+    assert.equal(wantsHelp(['--story', '42']), false);
+    assert.equal(wantsHelp([]), false);
+  });
+
+  it('ignores a help-shaped positional after the `--` separator', () => {
+    // `--cmd -- npm test --help` must run the command, not print usage.
+    assert.equal(wantsHelp(['--cmd', '--', 'npm', 'test', '--help']), false);
+  });
+
+  it('is false rather than throwing on a non-array argv', () => {
+    assert.equal(wantsHelp(undefined), false);
+    assert.equal(wantsHelp('--help'), false);
+  });
+});
+
+describe('formatUsage', () => {
+  const spec = {
+    invocation: 'node .agents/scripts/demo.js --story <id> [--json]',
+    summary: 'Do the demo thing.',
+    flags: [
+      ['--story <id>', 'GitHub issue number (required).'],
+      ['--json', 'Emit JSON.'],
+    ],
+    notes: ['Exit codes:\n  0  ok'],
+  };
+
+  it('renders the invocation, summary, flag table and notes', () => {
+    const text = formatUsage(spec);
+    assert.match(text, /^Usage: node \.agents\/scripts\/demo\.js /);
+    assert.match(text, /Do the demo thing\./);
+    assert.match(
+      text,
+      /^ {2}--story <id> {10}GitHub issue number \(required\)\.$/m,
+    );
+    assert.match(text, /Exit codes:/);
+  });
+
+  it('documents --help itself so the block is self-describing', () => {
+    assert.match(formatUsage(spec), /^ {2}--help {16}Show this message\.$/m);
+  });
+
+  it('does not duplicate a --help row the caller already supplied', () => {
+    const text = formatUsage({
+      invocation: 'node demo.js',
+      flags: [['--help', 'Print usage.']],
+    });
+    assert.equal(text.match(/--help/g).length, 1);
+    assert.match(text, /Print usage\./);
+  });
+
+  it('wraps a flag wider than the column onto its own line', () => {
+    const text = formatUsage({
+      invocation: 'node demo.js',
+      flags: [['--a-very-long-flag-name <value>', 'Described below.']],
+    });
+    assert.match(
+      text,
+      /--a-very-long-flag-name <value>\n {24}Described below\./,
+    );
+  });
+
+  it('renders a flagless script as a --help-only table', () => {
+    const text = formatUsage({ invocation: 'node demo.js', summary: 'Runs.' });
+    assert.match(text, /Flags:\n {2}--help/);
+  });
+
+  it('always terminates with a newline', () => {
+    assert.ok(formatUsage(spec).endsWith('\n'));
+  });
+});
+
+describe('renderUsage', () => {
+  it('passes a pre-rendered string through unchanged', () => {
+    assert.equal(renderUsage('Usage: demo\n'), 'Usage: demo\n');
+  });
+
+  it('newline-terminates a pre-rendered string that lacks one', () => {
+    assert.equal(renderUsage('Usage: demo'), 'Usage: demo\n');
+  });
+
+  it('formats a spec object', () => {
+    assert.match(
+      renderUsage({ invocation: 'node demo.js' }),
+      /^Usage: node demo\.js/,
+    );
+  });
+});
+
+describe('respondToHelp', () => {
+  it('writes the usage text and reports handled when help was asked for', () => {
+    const out = sink();
+    assert.equal(respondToHelp(['--help'], 'Usage: demo\n', out), true);
+    assert.equal(out.text(), 'Usage: demo\n');
+  });
+
+  it('writes nothing and reports unhandled when help was not asked for', () => {
+    const out = sink();
+    assert.equal(respondToHelp(['--story', '1'], 'Usage: demo\n', out), false);
+    assert.equal(out.text(), '');
+  });
+
+  it('still emits non-empty text when the spec renders blank', () => {
+    const out = sink();
+    respondToHelp(['--help'], '', out);
+    assert.ok(out.text().trim().length > 0);
+  });
+});
+
+describe('runAsCli — the usage short-circuit', () => {
+  const SELF = import.meta.url;
+
+  /** Run `runAsCli` as if this module were the direct CLI entry. */
+  function withArgv(argv, fn) {
+    const savedArgv = process.argv;
+    const savedWrite = process.stdout.write;
+    const written = [];
+    process.argv = [savedArgv[0], new URL(SELF).pathname, ...argv];
+    process.stdout.write = (chunk) => {
+      written.push(String(chunk));
+      return true;
+    };
+    try {
+      fn();
+    } finally {
+      process.stdout.write = savedWrite;
+      process.argv = savedArgv;
+    }
+    return written.join('');
+  }
+
+  it('answers --help without ever invoking main', () => {
+    let mainRuns = 0;
+    const out = withArgv(['--help'], () => {
+      runAsCli(
+        SELF,
+        async () => {
+          mainRuns += 1;
+        },
+        { source: 'demo', usage: { invocation: 'node demo.js --story <id>' } },
+      );
+    });
+    assert.equal(mainRuns, 0, 'main must not run on the help path');
+    assert.match(out, /^Usage: node demo\.js --story <id>/);
+  });
+
+  it('runs main normally when no help flag is present', async () => {
+    let mainRuns = 0;
+    const out = withArgv(['--story', '1'], () => {
+      runAsCli(
+        SELF,
+        async () => {
+          mainRuns += 1;
+        },
+        { source: 'demo', usage: { invocation: 'node demo.js' } },
+      );
+    });
+    assert.equal(mainRuns, 1);
+    assert.equal(out, '');
+  });
+
+  it('runs main when the caller declared no usage at all', () => {
+    let mainRuns = 0;
+    withArgv(['--help'], () => {
+      runAsCli(
+        SELF,
+        async () => {
+          mainRuns += 1;
+        },
+        { source: 'demo' },
+      );
+    });
+    assert.equal(
+      mainRuns,
+      1,
+      'a script without a usage spec keeps old behavior',
+    );
+  });
+});


### PR DESCRIPTION
Closes #4750

_Auto-opened by `/deliver`._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI and documentation changes only; help is structurally side-effect-free via early exit in `runAsCli`, with tests guarding regressions.
> 
> **Overview**
> Workflow-invoked orchestration scripts under `.agents/scripts/` now own their flag contract: a new **`lib/cli-usage.js`** renders usage from a spec (or pre-rendered string), and **`runAsCli`** answers `--help` / `-h` on **stdout** and **exits before `main`** so help cannot trigger leases, GitHub writes, or tree mutations.
> 
> Dozens of delivery/plan/audit/bootstrap CLIs pass a `usage:` block (or existing `HELP` text) into `runAsCli`; a few custom entry points (`quality-preview.js`, `sync-agentrc.js`, `update-ticket-state.js`) call `respondToHelp` directly. **`diagnose.js`** single-homes its help text so the CLI gate and `validateDiagnoseArgs` stay aligned.
> 
> Workflow markdown (**`deliver-story`**, **`plan`**, **`git-cleanup`**, close-flag reference) stops restating script flags and points operators at `node <script> --help`. **`tests/enforcement/workflow-script-help.test.js`** derives the script set from workflow references and asserts each answers `--help` with exit 0 and non-empty stdout (including under `AGENT_LOG_LEVEL=silent`); **`tests/lib/cli-usage.test.js`** covers formatting and the help-before-`main` ordering.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b7187f1234f4fe0e1d67e6c197b524ec00fe3c0c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->