### PR TITLE
chore(baselines): lock in the post-diet workflow context ceiling

### DIFF
--- a/baselines/context-budget.json
+++ b/baselines/context-budget.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://mandrel.dev/baselines/context-budget.schema.json",
-  "generatedAt": "2026-07-25T01:22:17.030Z",
+  "generatedAt": "2026-07-25T10:52:12.409Z",
   "toleranceBytes": 2048,
   "tiers": {
     "alwaysLoaded": {
@@ -54,7 +54,7 @@
       ]
     },
     "workflow": {
-      "totalBytes": 229625,
+      "totalBytes": 228277,
       "files": [
         {
           "path": ".agents/workflows/audit-accessibility.md",
@@ -86,7 +86,7 @@
         },
         {
           "path": ".agents/workflows/audit-navigability.md",
-          "bytes": 6869
+          "bytes": 6849
         },
         {
           "path": ".agents/workflows/audit-performance.md",
@@ -114,7 +114,7 @@
         },
         {
           "path": ".agents/workflows/audit-to-stories.md",
-          "bytes": 12796
+          "bytes": 12782
         },
         {
           "path": ".agents/workflows/audit-ux-ui.md",
@@ -126,11 +126,11 @@
         },
         {
           "path": ".agents/workflows/deliver.md",
-          "bytes": 8155
+          "bytes": 7940
         },
         {
           "path": ".agents/workflows/git-cleanup.md",
-          "bytes": 4428
+          "bytes": 4103
         },
         {
           "path": ".agents/workflows/git-deliver.md",
@@ -138,19 +138,19 @@
         },
         {
           "path": ".agents/workflows/helpers/deliver-digest.md",
-          "bytes": 6596
+          "bytes": 6456
         },
         {
           "path": ".agents/workflows/helpers/deliver-story.md",
-          "bytes": 8192
+          "bytes": 7976
         },
         {
           "path": ".agents/workflows/mandrel-update.md",
-          "bytes": 12392
+          "bytes": 12326
         },
         {
           "path": ".agents/workflows/plan.md",
-          "bytes": 8126
+          "bytes": 7774
         },
         {
           "path": ".agents/workflows/qa-assist.md",
@@ -189,137 +189,137 @@
     ]
   },
   "workflowClosure": {
-    "reachableTotalBytes": 371908,
+    "reachableTotalBytes": 368984,
     "entryPoints": [
       {
         "path": ".agents/workflows/audit-accessibility.md",
         "mandatoryBytes": 9456,
-        "reachableBytes": 34011
+        "reachableBytes": 33916
       },
       {
         "path": ".agents/workflows/audit-architecture.md",
         "mandatoryBytes": 13589,
-        "reachableBytes": 43699
+        "reachableBytes": 43624
       },
       {
         "path": ".agents/workflows/audit-clean-code.md",
         "mandatoryBytes": 7395,
-        "reachableBytes": 30110
+        "reachableBytes": 30035
       },
       {
         "path": ".agents/workflows/audit-data-model.md",
         "mandatoryBytes": 6801,
-        "reachableBytes": 24487
+        "reachableBytes": 24412
       },
       {
         "path": ".agents/workflows/audit-dependencies.md",
         "mandatoryBytes": 7483,
-        "reachableBytes": 25169
+        "reachableBytes": 25094
       },
       {
         "path": ".agents/workflows/audit-devops.md",
         "mandatoryBytes": 6413,
-        "reachableBytes": 24099
+        "reachableBytes": 24024
       },
       {
         "path": ".agents/workflows/audit-documentation.md",
         "mandatoryBytes": 11889,
-        "reachableBytes": 147653
+        "reachableBytes": 145359
       },
       {
         "path": ".agents/workflows/audit-navigability.md",
-        "mandatoryBytes": 6869,
-        "reachableBytes": 24555
+        "mandatoryBytes": 6849,
+        "reachableBytes": 24460
       },
       {
         "path": ".agents/workflows/audit-performance.md",
         "mandatoryBytes": 9933,
-        "reachableBytes": 27619
+        "reachableBytes": 27544
       },
       {
         "path": ".agents/workflows/audit-privacy.md",
         "mandatoryBytes": 3565,
-        "reachableBytes": 21251
+        "reachableBytes": 21176
       },
       {
         "path": ".agents/workflows/audit-quality.md",
         "mandatoryBytes": 6556,
-        "reachableBytes": 24242
+        "reachableBytes": 24167
       },
       {
         "path": ".agents/workflows/audit-security.md",
         "mandatoryBytes": 5249,
-        "reachableBytes": 22935
+        "reachableBytes": 22860
       },
       {
         "path": ".agents/workflows/audit-seo.md",
         "mandatoryBytes": 5567,
-        "reachableBytes": 23253
+        "reachableBytes": 23178
       },
       {
         "path": ".agents/workflows/audit-sre.md",
         "mandatoryBytes": 4936,
-        "reachableBytes": 40295
+        "reachableBytes": 40220
       },
       {
         "path": ".agents/workflows/audit-to-stories.md",
-        "mandatoryBytes": 12796,
-        "reachableBytes": 118078
+        "mandatoryBytes": 12782,
+        "reachableBytes": 115859
       },
       {
         "path": ".agents/workflows/audit-ux-ui.md",
         "mandatoryBytes": 5008,
-        "reachableBytes": 39019
+        "reachableBytes": 38924
       },
       {
         "path": ".agents/workflows/deliver-light.md",
         "mandatoryBytes": 6990,
-        "reachableBytes": 125068
+        "reachableBytes": 122849
       },
       {
         "path": ".agents/workflows/deliver.md",
-        "mandatoryBytes": 8155,
-        "reachableBytes": 118078
+        "mandatoryBytes": 7940,
+        "reachableBytes": 115859
       },
       {
         "path": ".agents/workflows/git-cleanup.md",
-        "mandatoryBytes": 4428,
-        "reachableBytes": 4428
+        "mandatoryBytes": 4103,
+        "reachableBytes": 4103
       },
       {
         "path": ".agents/workflows/git-deliver.md",
         "mandatoryBytes": 7640,
-        "reachableBytes": 143039
+        "reachableBytes": 140624
       },
       {
         "path": ".agents/workflows/helpers/deliver-story.md",
-        "mandatoryBytes": 14788,
-        "reachableBytes": 118078
+        "mandatoryBytes": 14432,
+        "reachableBytes": 115859
       },
       {
         "path": ".agents/workflows/mandrel-update.md",
-        "mandatoryBytes": 12392,
-        "reachableBytes": 24156
+        "mandatoryBytes": 12326,
+        "reachableBytes": 24067
       },
       {
         "path": ".agents/workflows/plan.md",
-        "mandatoryBytes": 8126,
-        "reachableBytes": 118078
+        "mandatoryBytes": 7774,
+        "reachableBytes": 115859
       },
       {
         "path": ".agents/workflows/qa-assist.md",
         "mandatoryBytes": 16561,
-        "reachableBytes": 182978
+        "reachableBytes": 180759
       },
       {
         "path": ".agents/workflows/qa-explore.md",
         "mandatoryBytes": 13422,
-        "reachableBytes": 182978
+        "reachableBytes": 180759
       },
       {
         "path": ".agents/workflows/qa-run.md",
         "mandatoryBytes": 13618,
-        "reachableBytes": 182978
+        "reachableBytes": 180759
       }
     ]
   }


### PR DESCRIPTION
## Why

Stories #4752, #4750 and #4751 landed as a chain. #4752 added the `workflow` tier to `check-context-budget.js`; #4750 and #4751 then shrank workflow prose (127 provenance citations → 2, plus the flag prose that `--help` now owns).

`check-context-budget.js` deliberately treats a **shrinking** tier as informational (`shrunk=1 (ok)`) rather than a failure, and both delivering Stories were explicitly told not to silence it. Correct at the time — but it left the enforced ceiling at the pre-diet **229,625 bytes**. The diet's gains were measured and never ratcheted, so workflow prose had ~1.3 KB of headroom to grow back without tripping anything.

## What

Refreshed through the script's own `--update` path — the JSON was never hand-edited.

| | before | after |
| --- | --- | --- |
| workflow mandatory closure (**gated**) | 229,625 B | **228,277 B** |
| workflow reachable closure (ungated drift signal) | 371,908 B | 368,984 B |

Deliberately unchanged: `alwaysLoaded` (21,314 B) and `mandatoryRead` (363,627 B) are byte-identical, and `toleranceBytes` (2048) is preserved. The pre-refresh run reported `grown=0`, so `--update` could not silently absorb a growth regression in another tier.

No other baseline file is touched — in particular `baselines/dead-exports-production.json` is left alone (it is not in `localeCompare` order and a re-sort would churn ~285 lines).

## Verification

The point of this PR is that the new ceiling actually enforces, so that was tested directly rather than assumed:

| Check | Result |
| --- | --- |
| `check-context-budget.js` (clean) | exit 0, `grown=0 shrunk=0` |
| `check-context-budget.js` (+3,011 B into a gated workflow file) | **exit 1** — `workflow: 231288 exceeds budget 228277 + tolerance 2048` |
| `check-baselines.js` | exit 0 — 0 breaches, 0 regressions |
| `check-arch-cycles.js` / `check-dead-exports.js --production` / `check-workflow-citations.js` | all exit 0 |
| `npm run lint` | exit 0 |
| `npm test` | 8602 passed, 0 failed, 4 skipped |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Baseline-only change with no runtime or auth impact; it tightens CI enforcement so workflow prose cannot silently regrow within ~1.3 KB of slack.
> 
> **Overview**
> **Ratchets the enforced workflow context budget** in `baselines/context-budget.json` to match the smaller workflow footprint after the recent prose diet, so CI can no longer pass while workflow mandatory bytes creep back toward the old ceiling.
> 
> The refresh was produced via `check-context-budget.js --update` (not hand-edited): **`workflow` mandatory total** drops **229,625 → 228,277 B**, and **`workflowClosure.reachableTotalBytes`** drops **371,908 → 368,984 B**, with per-file byte counts and entry-point `mandatoryBytes` / `reachableBytes` aligned to the slimmer workflows. **`alwaysLoaded`**, **`mandatoryRead`**, and **`toleranceBytes` (2048)** are unchanged; only `generatedAt` and the workflow-related figures move.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7124086b79c3b747aa2d035c48ad87ac594d83e2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->