### PR TITLE
fix(tests): resolve cli-usage argv[1] with fileURLToPath for Windows

### DIFF
--- a/tests/lib/cli-usage.test.js
+++ b/tests/lib/cli-usage.test.js
@@ -11,6 +11,7 @@
 
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
+import { fileURLToPath } from 'node:url';
 import {
   formatUsage,
   HELP_FLAGS,
@@ -154,7 +155,13 @@ describe('runAsCli — the usage short-circuit', () => {
     const savedArgv = process.argv;
     const savedWrite = process.stdout.write;
     const written = [];
-    process.argv = [savedArgv[0], new URL(SELF).pathname, ...argv];
+    // fileURLToPath (not `new URL(...).pathname`) so the drive letter resolves
+    // correctly on Windows — the raw pathname is `/D:/…`, which path.resolve
+    // turns into a doubled-drive path that never equals runAsCli's own
+    // fileURLToPath(import.meta.url). isDirectInvocation would then return
+    // false, runAsCli would return before writing usage, and every assertion
+    // here would see ''. See Windows Smoke CI.
+    process.argv = [savedArgv[0], fileURLToPath(SELF), ...argv];
     process.stdout.write = (chunk) => {
       written.push(String(chunk));
       return true;


### PR DESCRIPTION
## Why

Windows Smoke has been red on `main` since `922c278e` (Story #4750). It is not a required check, so #4751, #4757 and #4758 all merged over the top of it.

Three failures, all in `tests/lib/cli-usage.test.js` → `runAsCli — the usage short-circuit`, each reporting `actual: ''`.

## Root cause

`withArgv` built the fake `process.argv[1]` from `new URL(SELF).pathname`. On Windows that yields `/D:/a/…` — a leading slash before the drive letter.

`runAsCli` gates on `isDirectInvocation`, which compares `fileURLToPath(import.meta.url)` against `path.resolve(process.argv[1])`:

```
path.win32.resolve('/D:/a/…/cli-usage.test.js')  ->  \D:\a\…\cli-usage.test.js
fileURLToPath(SELF)                              ->   D:\a\…\cli-usage.test.js
                                                      ^ never equal
```

So the guard returned false, `runAsCli` returned before writing usage or invoking `main`, and every assertion in the suite saw an empty string.

## Scope: test-only

Production `--help` on Windows was never broken:

- `.agents/scripts/lib/cli-utils.js:32` already uses `fileURLToPath(importMetaUrl) === path.resolve(entry)`.
- `quality-preview.js` / `quality-watch.js` use `new URL(...).pathname` but normalise the drive letter by hand (`/^\/[A-Za-z]:/ ? self.slice(1)`), and are annotated as Windows-aware main-guards.

This is a known bug class in this repo — the same fix and rationale are already documented at `tests/quality-preview.test.js:96`, which cites Windows Smoke CI by name. This change brings `cli-usage.test.js` in line with that precedent.

## Verification

| Check | Result |
| --- | --- |
| `node --test tests/lib/cli-usage.test.js` | 20 pass / 0 fail |
| `npm test` | 8602 passed, 0 failed, 4 skipped |
| `npm run lint` | exit 0 |
| `npx biome ci tests/lib/cli-usage.test.js` | exit 0 |
| `check-baselines.js` / `check-context-budget.js` | exit 0 |

**Note on what POSIX can prove:** this test passed locally both before and after — the defect only manifests on Windows. The mismatch is demonstrated above via `path.win32.resolve`. **Windows Smoke on this PR is the real verification.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only test harness path construction changes; no production CLI or runtime behavior is modified.
> 
> **Overview**
> Fixes **Windows Smoke** failures in `runAsCli — the usage short-circuit` where assertions saw empty stdout because `isDirectInvocation` never matched.
> 
> The test helper `withArgv` now sets fake `process.argv[1]` via **`fileURLToPath(import.meta.url)`** instead of `new URL(...).pathname`, so it aligns with how `runAsCli` compares paths in `cli-utils.js`. On Windows, the old pathname form (`/D:/…`) resolved differently and caused the help short-circuit to skip before writing usage.
> 
> **Test-only** — production `--help` behavior is unchanged. Comments point at the same pattern already used in `quality-preview.test.js`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8a7e753e06938a009ff40c5e5c14147ecf2e2438. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->