### PR TITLE
feat: fold /deliver-light into /deliver and derive invocation intent instead of flags (#4760)

### DIFF
--- a/.agents/docs/workflows.md
+++ b/.agents/docs/workflows.md
@@ -32,7 +32,7 @@ by `node .agents/scripts/generate-workflows-doc.js`; `npm run docs:check`
 fails when it drifts from the on-disk workflow set. To change a command’s
 description, edit the workflow file’s front-matter and regenerate.
 
-## Commands (25)
+## Commands (24)
 
 | Command | Description |
 | --- | --- |
@@ -52,8 +52,7 @@ description, edit the workflow file’s front-matter and regenerate.
 | `/audit-sre` | "Audit production-readiness for a release candidate: SLOs, observability, runbooks, error budgets, and rollback paths." |
 | `/audit-to-stories` | Convert findings produced by the audit-\* workflows into actionable GitHub Stories. Reads temp/audits/audit-\*-results.md, groups findings cross-audit, deduplicates against existing Issues by fingerprint, and either chains into /plan --seed-file or opens standalone Stories. |
 | `/audit-ux-ui` | Audit UX/UI consistency and design system adherence |
-| `/deliver` | Unified delivery entry point. Takes a list of Story ids, resolves their dependency graph from live state, and delivers each via the single deliver-story engine — story-<id> → PR → main. |
-| `/deliver-light` | Single-session delivery for genuinely small work. Judges a prompt's predicted footprint, authors a receipt Story, then lands it through the same single-story-init / single-story-close engine — every close gate unchanged. |
+| `/deliver` | Unified delivery entry point. Takes Story ids or a plain-language prompt, derives which path the work belongs on, and lands it via the single deliver-story engine — story-<id> → PR → main. |
 | `/git-cleanup` | Tidy the local checkout in four phases: fast-forward `main`, prune stale remote-tracking refs, sweep merged branches (squash-aware), and triage `git stash` entries — each step gated by operator confirmation. |
 | `/git-deliver` | Single ad-hoc delivery command for working-tree changes. Detects the git setup and escalates to the right terminal step — commit only, commit + push, or commit + push + open a PR with native auto-merge — picking the default from observable state and letting flags pin any level explicitly. Replaces the retired git-commit-all, git-push, and git-pr-all trio. |
 | `/mandrel-update` | npm-era upgrade wraparound for a Mandrel consumer. Runs `npx mandrel update` (resolve newest published version → install → re-materialize `.agents/` → migrate → doctor → surface changelog) as the single mechanical step, then walks the operator through the judgment wraparound the CLI deliberately leaves unowned: reconcile `.agentrc.json`, install the stabilized quality-gate surface, refresh the harness permission allowlist, reconcile the consumer's `AGENTS.md` / runbooks against the surfaced changelog, and stage + commit the staged lockfile bump. |

--- a/.agents/scripts/lib/orchestration/plan-context.js
+++ b/.agents/scripts/lib/orchestration/plan-context.js
@@ -356,7 +356,7 @@ function resolveRiskHeuristics(config = {}) {
 
 /**
  * Ceilings a seed's advisory complexity signals must fit for the plan
- * workflow to **suggest** `/deliver-light` at Gate #1 (Story #4741 R3 plan-side
+ * workflow to **suggest** the light path at Gate #1 (Story #4741 R3 plan-side
  * handshake). Framework constants, not operator knobs — mirroring the
  * conservative intent of `complexity-gate.js`'s `STORY_SHAPE_CEILINGS`
  * (small, mostly-additive, non-sensitive) but read against the *seed-time*
@@ -364,9 +364,14 @@ function resolveRiskHeuristics(config = {}) {
  *
  * The suggestion is **advisory only and never an automatic reroute**: it
  * surfaces at Gate #1 for the operator to decide, and under `--yes` it is
- * recorded on the envelope while planning proceeds unchanged. `/deliver-light`
- * is a sibling Story; these ceilings define the plan side of the routing
- * handshake independently of it.
+ * recorded on the envelope while planning proceeds unchanged.
+ *
+ * These ceilings are deliberately NOT the ones the light path itself applies
+ * (Story #4760). A confirmed suggestion routes into
+ * `workflows/helpers/deliver-light.md`, whose gate re-judges the *predicted
+ * shape* against `STORY_SHAPE_CEILINGS`. Two checks at two different stages:
+ * this one screens a seed, that one decides. Collapsing them would make a
+ * confirm a bypass.
  *
  *   - `maxArtifacts`           — enumerated seed items (one artifact each).
  *   - `maxRiskHeuristicHits`   — any risk-heuristic hit disqualifies: risk
@@ -381,9 +386,9 @@ const DELIVER_LIGHT_SUGGESTION_CEILINGS = Object.freeze({
 });
 
 /**
- * Derive the advisory `/deliver-light` suggestion from a seed's complexity
- * signals (Story #4741 AC-6). Pure and total: a malformed / missing signal
- * bag fails conservative (not suggested), never throws.
+ * Derive the advisory light-path suggestion from a seed's complexity signals
+ * (Story #4741 AC-6). Pure and total: a malformed / missing signal bag fails
+ * conservative (not suggested), never throws.
  *
  * `automatic: false` is part of the contract — the suggestion is surfaced for
  * the operator, never a silent reroute of a non-interactive run.
@@ -435,16 +440,16 @@ export function buildDeliverLightSuggestion(complexitySignals) {
     ceilings,
     reasons: suggested
       ? [
-          `seed fits the /deliver-light ceilings (≤${ceilings.maxArtifacts} artifacts, ` +
+          `seed fits the light-path ceilings (≤${ceilings.maxArtifacts} artifacts, ` +
             'no risk-heuristic hits, no sensitive-path classes) — the operator ' +
-            'may prefer /deliver-light for this scope',
+            'may prefer /deliver for this scope',
         ]
       : reasons,
   };
 }
 
 /**
- * Attach the advisory `/deliver-light` suggestion to a complexity-signals bag
+ * Attach the advisory light-path suggestion to a complexity-signals bag
  * as a **nested** field (Story #4741). Nesting — rather than a new top-level
  * envelope key — keeps every existing per-mode envelope key set byte-stable
  * (AC-5): the suggestion is derived from the signals it rides on.
@@ -920,7 +925,7 @@ function extractPriorArtifacts(priorBody) {
 /**
  * Build the amendment (delta) envelope — `plan-context --amends #<id>`
  * (Story #4741 AC-4, R3-A). The heavy-amendment counterpart to routing a
- * light amendment through `/deliver-light`: instead of re-interrogating the
+ * light amendment through the light path: instead of re-interrogating the
  * repo from scratch (`buildAuthoringContext`'s codebase snapshot and the BDD /
  * memory / feedback probes), the envelope composes a DELTA from what already
  * exists — the prior Story's body, its acceptance criteria (the real

--- a/.agents/workflows/deliver.md
+++ b/.agents/workflows/deliver.md
@@ -1,63 +1,71 @@
 ---
 description:
-  Unified delivery entry point. Takes a list of Story ids, resolves their
-  dependency graph from live state, and delivers each via the single
+  Unified delivery entry point. Takes Story ids or a plain-language prompt,
+  derives which path the work belongs on, and lands it via the single
   deliver-story engine — story-<id> → PR → main.
 ---
 
-# /deliver <storyId...>
+# /deliver
 
-> **Lean spine.** Happy path + gate list. Sequencing edge cases, dispatch
-> mechanics, lite-route inline execution, checklist threading, ceremony, and
-> the per-run epilogue live in the on-demand
-> [`helpers/deliver-reference.md`](helpers/deliver-reference.md). What every
-> delivery always needs is bundled into one read:
+> **Lean spine.** Happy path + gate list. Sequencing, dispatch mechanics,
+> intent phrases, ceremony, and the epilogue live in the on-demand
+> [`helpers/deliver-reference.md`](helpers/deliver-reference.md); the unplanned
+> path in [`helpers/deliver-light.md`](helpers/deliver-light.md). What every
+> delivery always needs is one read:
 > [`helpers/deliver-digest.md`](helpers/deliver-digest.md).
 
 ## Role
 
-Single delivery path, single input shape: **a list of Story ids**. `/deliver`
-owns input resolution and sequencing only — every Story runs through
-[`helpers/deliver-story.md`](helpers/deliver-story.md).
+One delivery door. `/deliver` owns input resolution and sequencing only — every
+Story lands through [`helpers/deliver-story.md`](helpers/deliver-story.md).
 
-The dependency graph is **discovered, not declared**: `resolve-stories.js`
-reads it from live state (body edges ∪ native GitHub `blocked_by` edges, each
-blocker resolved against its real issue state). You never hand it a graph and
-there is no batch label — which is what lets you deliver Stories **across plan
-runs and over time**. `plan-run::<id>` is filter metadata, never a resolution
-input.
-Per-Story routes are **body-derived** too; `route::lite` is a hint only.
-Ahead of that: a **single-Story run runs the engine inline** whatever the
-shape — sub-agent isolation only earns its cost against a concurrent
-sibling.
+Nothing about the route is declared at the invocation; it is **derived, then
+announced, then acted on**. The dependency graph is **discovered, not
+declared** — `resolve-stories.js` reads it from live state (body edges ∪ native
+`blocked_by` edges, each blocker resolved against its real issue state), so
+there is no graph to hand it and no batch label, which is what lets you deliver
+Stories **across plan runs and over time**.
+`plan-run::<id>` is filter metadata, never a resolution input; `route::lite` is
+a body-derived hint only. Ahead of all of it, a **single-Story run runs the
+engine inline** whatever the shape — sub-agent isolation only earns its cost
+against a concurrent sibling.
 
 ## Inputs
 
-| Invocation | Behavior |
-| --- | --- |
-| `/deliver <storyId>` | Deliver one Story via `helpers/deliver-story.md`, executed **inline in this session** — no `story-worker` spawn. |
-| `/deliver <storyId> <storyId> ...` | Resolve the set with `resolve-stories.js`, then sequence by the discovered graph via `stories-wave-tick.js`, dispatching role-scoped sub-agents. Default concurrency is **3**. |
+Classify what the operator typed **before** doing anything else, and say which
+shape you read it as:
 
-Any named ticket that is not `type::story`, or still carrying an `Epic: #N`
-footer, is a **hard error** naming the id and the fix (close or re-plan as a v2
-Story). Resolution refuses the whole set rather than silently under-delivering.
+| Invocation | Shape | Behavior |
+| --- | --- | --- |
+| `/deliver` | bare | List the open `agent::ready` Stories and ask which to deliver. Deliver nothing until answered. |
+| `/deliver 4712` | ids | One Story via `helpers/deliver-story.md`, **inline in this session** — no `story-worker` spawn. |
+| `/deliver 4712 4713 …` | ids | Resolve the set, then sequence by the discovered graph via `stories-wave-tick.js`, dispatching role-scoped sub-agents. |
+| `/deliver add a --json flag to doctor` | prompt | Unplanned work: gate, author a receipt Story, land it — [`helpers/deliver-light.md`](helpers/deliver-light.md). |
 
-## Flags
+**The discriminator is lexical and total.** Every positional argument matching
+`^#?\d+$` means ids; anything else means a prompt. A **mixed** invocation (ids
+*and* prose) is a **hard error** — refuse it and ask which was meant, the way
+resolution refuses a whole set rather than under-delivering. A named ticket
+that is not `type::story`, or carries an `Epic: #N` footer, is a hard error too.
 
-| Flag | Meaning |
-| --- | --- |
-| `--concurrency <n>` | **Optional** per-run override of the fan-out cap. Omit it to honor `delivery.deliverRunner.concurrencyCap` (config default **3**, incl. any `.agentrc.local.json` override); pass **only** for a one-run cap. `1` = sequential. |
-| `--yes` | Suppress the multi-Story confirmation gate. |
-| `--steal` | Forwarded to `single-story-init.js` / lease steal. |
-| `--wait-merge` | Force close-and-land (the default; `delivery.routing.closeAndLand`). |
-| `--no-wait-merge` | Opt out; stop at `agent::closing` for a human land. |
+## Saying what you want
 
-**Operator-merge implies no-wait.** `--no-auto-merge` and
-`delivery.ci.autoMerge: "strict"` rest the Story at `agent::closing`, not
-`agent::blocked` — a genuine *arm failure* still waits and still blocks
-([`helpers/deliver-reference.md` § Operator-merge](helpers/deliver-reference.md)).
+No flags to remember: state intent — *"…but I'll merge it myself"*, *"…take the
+lease"*, *"…one at a time"* — and announce what you read before acting.
+Phrasings and the flag each fills in:
+[`helpers/deliver-reference.md` § Intent phrases](helpers/deliver-reference.md).
+
+`--yes` is **runner-set, never operator-typed**: cron, `/loop`, and headless
+dispatch set it to mean *nobody is at the keyboard*, which is what makes the
+unplanned path's over-scope stop fail closed to a terminal envelope instead of
+a question. Never offer it to an operator or add it to an attended run.
 
 ## Procedure
+
+0. **Classify and announce.** Read the invocation per § Inputs and state the
+   shape you derived. A prompt leaves for
+   [`helpers/deliver-light.md`](helpers/deliver-light.md); bare asks; ids
+   continue below.
 
 1. **Resolve the set.** One command, for one Story or many:
    `node .agents/scripts/resolve-stories.js --ids <id,id,...>`. It validates
@@ -80,15 +88,14 @@ Story). Resolution refuses the whole set rather than silently under-delivering.
 
    **Do not add `--concurrency` unless the operator explicitly asked for a
    per-run cap** — an explicit value wins over config, so a filled-in literal
-   silently defeats a `.agentrc.local.json` override (see Flags).
+   silently defeats a `.agentrc.local.json` override.
 
    Each beat re-probes live state to derive done / in-flight itself; you never
-   compute them. `--dispatched` is the one thing you must supply —
-   the append-only list of every id you spawned this run — and cross-run
+   compute them. `--dispatched` is the one thing you must supply — the
+   append-only list of every id you spawned this run — and cross-run
    de-confliction via the assignee lease is automatic
-   ([`helpers/deliver-reference.md` § Sequencing edge cases](helpers/deliver-reference.md);
-   [§ Dispatch mechanics](helpers/deliver-reference.md) covers role-scoped
-   spawn, lite-route execution, and `checklistPath`).
+   ([`helpers/deliver-reference.md`](helpers/deliver-reference.md) §§ Sequencing
+   edge cases, Dispatch mechanics).
 
    Branch on the exit code:
    - **0** — dispatch each `ready` id (already capped and overlap-free). Empty
@@ -97,64 +104,57 @@ Story). Resolution refuses the whole set rather than silently under-delivering.
    - **2** — `cycleError`: the graph is self-referential. Fix the `depends_on`
      declarations; do not retry.
    - **3** — `wedged`: nothing dispatchable, nothing in flight, undone Stories
-     waiting on blockers that are not done. The envelope names the stuck ids and
-     unmet blockers. Land the blocker or include it in `--ids`; do not retry
-     unchanged.
+     waiting on unmet blockers — both named in the envelope. Land the blocker
+     or include it in `--ids`; do not retry unchanged.
    - **4** — `blocked`: a Story carries `agent::blocked`, named in `blocked[]`
      with `blockedReason` — the protocol's HITL pause
      ([`instructions.md` § 1.J](../instructions.md)). **Stop the loop and
      surface it; do not poll.** Read the friction comment
      (`gh issue view <id> --comments`) and resume only once the operator
      unblocks it (`update-ticket-state.js --ticket <id> --state agent::ready`).
-     A blocked Story outranks a wedge but not a cycle (fix the graph first).
+     Blocked outranks a wedge but not a cycle (fix the graph first).
 
 4. **Per-run epilogue (N>1).** Once step 3 reports `epilogueDue: true`, run
    `node .agents/scripts/plan-run-epilogue.js --stories 101,102` — audit
-   roster, follow-up roll-up, sibling coherence. A single-Story run skips it.
-   Detail:
-   [`helpers/deliver-reference.md` § Per-run epilogue](helpers/deliver-reference.md).
+   roster, follow-up roll-up, sibling coherence. A single-Story run skips it
+   ([reference § Per-run epilogue](helpers/deliver-reference.md)).
 
 ## Branch model (authoritative)
 
-```text
-story-<id>  →  PR  →  main (squash + required checks)
-```
-
-Dependent Stories land sequentially so each builds on the previous merge to
-`main`.
-Ceremony depth (profiles + derived level via `ceremony-routing.js`,
-review depth reading the same level) and the mechanism table:
+`story-<id>` → PR → `main` (squash + required checks), per digest § 2.
+Dependent Stories land sequentially so each builds on the previous merge.
+Ceremony depth (profiles + derived level via `ceremony-routing.js`, review
+depth reading the same level):
 [`helpers/deliver-reference.md` § Ceremony](helpers/deliver-reference.md).
 
 ## Reading a Story's outcome
 
-Each Story's delivery ends in exactly one schema-validated terminal envelope —
-`landed` | `pending` | `blocked` | `failed`. Statuses, exits, and fields:
-[`helpers/deliver-digest.md`](helpers/deliver-digest.md) § 5, over the shipped
-[schema](../schemas/story-deliver-terminal.schema.json).
+Each Story ends in exactly one schema-validated terminal envelope — `landed` |
+`pending` | `blocked` | `failed`. Statuses, exits, and fields:
+[`helpers/deliver-digest.md`](helpers/deliver-digest.md) § 5.
 
-`pending` is **not** a failure: the bounded merge wait expired with the PR
-healthy (or a human owns the merge), nothing was mutated, and the
-`nextCommand` resumes it — run that rather than re-dispatching. The slow-CI
-`async` mode returns `pending` by design — launch its
-`nextCommand` as a background invocation (reference appendix).
+`pending` is **not** a failure: the bounded wait expired with the PR healthy
+(or a human owns the merge), nothing was mutated, and `nextCommand` resumes it
+— run that rather than re-dispatching.
 
 For a Story in an unclear state — including the merged-but-label-stale one a
-`/deliver` re-run refuses outright — probe it read-only with
+re-run refuses outright — probe it read-only with
 `node .agents/scripts/deliver-recover.js --story <storyId>`.
 
 ## Constraints
 
 - **Land or block — never a silent local build** (digest § 2). Attended
   delivers default to close-and-land (`delivery.routing.closeAndLand: true`);
-  use `--no-wait-merge` only when a human lands the PR.
-- `/deliver` never plans — tickets come from [`/plan`](plan.md). The router
-  performs no git/label mutations; `deliver-story` owns every script.
+  rest at `agent::closing` only when a human owns the merge.
+- **`/deliver` never plans.** Planned tickets come from [`/plan`](plan.md), and
+  an over-scope prompt **escalates and ends** — never invoke `/plan` in this
+  session to rescue it ([`helpers/deliver-light.md`](helpers/deliver-light.md)
+  § Escalation is terminal). The router performs no git/label mutations;
+  `deliver-story` owns every script.
 
 ## See also
 
 - [`/plan`](plan.md) — unified planning entry point.
-- [`helpers/deliver-story.md`](helpers/deliver-story.md) — the one Story
-  delivery engine.
-- [`helpers/deliver-reference.md`](helpers/deliver-reference.md) — sequencing,
-  dispatch, ceremony, and epilogue detail.
+- [`helpers/deliver-story.md`](helpers/deliver-story.md) — the one engine.
+- [`helpers/deliver-light.md`](helpers/deliver-light.md) — the unplanned
+  prompt path, shared with `/plan` Gate #1.

--- a/.agents/workflows/helpers/deliver-light.md
+++ b/.agents/workflows/helpers/deliver-light.md
@@ -1,27 +1,35 @@
 ---
 description:
-  Single-session delivery for genuinely small work. Judges a prompt's
-  predicted footprint, authors a receipt Story, then lands it through the same
-  single-story-init / single-story-close engine — every close gate unchanged.
+  The unplanned prompt path shared by /deliver and /plan Gate #1. Judges a
+  prompt's predicted footprint, authors a receipt Story, then lands it through
+  the same single-story-init / single-story-close engine — every close gate
+  unchanged.
 ---
 
-# /deliver-light "<prompt>" | --amends '#<id>' "<prompt>"
+# Unplanned delivery (the prompt path)
 
-> **Thin entry point, not a second engine.** `/deliver-light` removes the
-> `/plan` session for small work — nothing else. It runs a suitability gate,
-> authors a minimal receipt Story, then hands off to the SAME scripts
-> [`/deliver`](deliver.md) uses. Read
-> [`helpers/deliver-digest.md`](helpers/deliver-digest.md) once first — the
-> engine invariants, gates, and terminal-envelope contract below are its.
+> **A path, not a command.** There is no `/deliver-light` to type. This file is
+> reached two ways — `/deliver "<prompt>"` (an operator describing small work)
+> and `/plan` Gate #1 (a seed the suggestion says fits the light ceilings, once
+> the operator confirms). Read
+> [`deliver-digest.md`](deliver-digest.md) once first — the engine invariants,
+> gates, and terminal-envelope contract below are its.
 
 ## Role
 
 For a genuinely trivial change — a one-file fix, a small addition, a small
 amendment — the multi-session plan→deliver ceremony buys nothing the bare model
-lacks except **gates and landing**. `/deliver-light` keeps exactly those: one
-session straight to execution from an operator prompt, landing through the
-unchanged close path. It never relaxes a close gate, never bypasses the PR to
-`main`, and never lands over-scope work silently.
+lacks except **gates and landing**. This path keeps exactly those: one session
+straight to execution from a prompt, landing through the unchanged close path.
+It never relaxes a close gate, never bypasses the PR to `main`, and never lands
+over-scope work silently.
+
+Two callers, one gate: whichever door you arrived through, the suitability gate
+below is the decision. A `/plan` Gate #1 suggestion is a *suggestion* — it is
+read against seed-time signals (`DELIVER_LIGHT_SUGGESTION_CEILINGS`: artifacts,
+risk hits, sensitive-path classes), while the gate here is read against a
+predicted *shape* (`STORY_SHAPE_CEILINGS`: `maxChanges`, `maxAcceptance`). They
+are deliberately two different checks, so the gate still runs after a confirm.
 
 ## Four invariants (do not skip one)
 
@@ -64,6 +72,16 @@ unchanged close path. It never relaxes a close gate, never bypasses the PR to
    `--amends '#<id>'` is the canonical light case — shape-checked identically; a
    heavy amendment escalates to `/plan` like any other over-scope prompt.
 
+   **Entered from `/plan` Gate #1?** Fill `--creates` / `--refactors` /
+   `--acceptance` / `--reason` from the plan-context envelope's codebase
+   snapshot and `complexitySignals` rather than re-deriving them from the seed
+   text — Gate #1 has already done that work, and re-deriving throws away the
+   better signal. An `ask-operator` verdict here means the two ceiling sets
+   disagreed: **return to [`../plan.md`](../plan.md) step 2 (Author) in the same
+   session**, carrying the interrogation you already paid for. That bounce-back
+   is not an escalation and does not need a fresh session (§ Why the two
+   directions differ).
+
 2. **Init (same engine).** From the main checkout, synchronously, with the
    maximum Bash timeout:
 
@@ -72,12 +90,12 @@ unchanged close path. It never relaxes a close gate, never bypasses the PR to
    ```
 
    Capture `workCwd`; `remoteVerified: false` → flip `agent::blocked` and stop.
-   This is [`/deliver`](deliver.md)'s worktree/branch/lease/label engine,
+   This is [`/deliver`](../deliver.md)'s worktree/branch/lease/label engine,
    invoked, not reimplemented.
 
 3. **Implement + self-eval.** `cd` into `workCwd`, implement the change, run
    `npm test` once in the worktree, then run the bounded acceptance self-eval
-   loop ([`helpers/deliver-story.md`](helpers/deliver-story.md) Step 1a). Commit
+   loop ([`deliver-story.md`](deliver-story.md) Step 1a). Commit
    on `story-<id>` with `(refs #<storyId>)`.
 
 4. **Diff backstop.** Before close, re-check the ACTUAL diff:
@@ -90,14 +108,14 @@ unchanged close path. It never relaxes a close gate, never bypasses the PR to
    (file count or a sensitive-path class). STOP, flip `agent::blocked`, and
    escalate to `/plan` — do not land.
 
-5. **Close and land (same engine).** Exactly [`/deliver`](deliver.md)'s close:
+5. **Close and land (same engine).** Exactly [`/deliver`](../deliver.md)'s close:
 
    ```bash
    node .agents/scripts/single-story-close.js --story <storyId> --cwd <main-repo>
    ```
 
    Branch on the terminal envelope's `status` per
-   [`helpers/deliver-digest.md`](helpers/deliver-digest.md) § 5 — every close
+   [`deliver-digest.md`](deliver-digest.md) § 5 — every close
    gate runs byte-identical to the full path.
 
 ## Escalation is terminal {#escalation-is-terminal}
@@ -127,13 +145,40 @@ Nothing is left half-started: an escalated run creates **no receipt Story, no
 every creation call site, and `escalation.created` records all three as `false`
 in a shape the schema pins, so a later run finds nothing to trip over.
 
+## Why the two directions differ {#why-the-two-directions-differ}
+
+Traffic runs both ways between this path and `/plan`, and the two directions
+have **deliberately different session rules**. It reads like an inconsistency;
+it is not. The rule:
+
+> **The direction whose guard is model judgment must break the session. The
+> direction whose guard is mechanical need not.**
+
+**Light → `/plan` must be a fresh session.** What is being protected is
+*authoring judgment*, and the empirical finding above is that a session already
+framed as small work under-decomposes — one Story against a 3–5 contract where
+a fresh session on the identical seed authored four. The frame is the hazard,
+so only a new session removes it.
+
+**`/plan` → light may stay in-session.** Gate #1 fires **before** authoring, so
+there is no authoring to corrupt, and the frame at that point is "plan this
+seed" — the neutral one, not the small one. Everything on the receiving side is
+mechanical: `STORY_SHAPE_CEILINGS`, the ledgered verdict, the diff backstop.
+None of them degrade because the context is large, so nothing is gained by
+paying for a fresh session.
+
+Do not "fix" this into symmetry in either direction. Making `/plan` → light
+require a fresh session throws away a paid-for interrogation for no guard.
+Letting light → `/plan` run in-session reintroduces the exact failure the
+`escalated` envelope exists to prevent.
+
 ## Constraints
 
 - **Land, block, or escalate — never a silent local build.** The close push is
   the only sanctioned landing; an `escalated` terminal is the only sanctioned
   ending that delivers nothing, and it ends the session
   (§ Escalation is terminal).
-- **No parallel engine.** `/deliver-light` invokes `single-story-init.js` and
+- **No parallel engine.** This path invokes `single-story-init.js` and
   `single-story-close.js`; it never reimplements worktree, branch, PR, or merge
   mechanics.
 - **State only via `update-ticket-state.js`.** Drive every `agent::*`
@@ -141,8 +186,11 @@ in a shape the schema pins, so a later run finds nothing to trip over.
 
 ## See also
 
-- [`/deliver`](deliver.md) — the multi-Story / planned delivery entry point.
-- [`helpers/deliver-story.md`](helpers/deliver-story.md) — the one Story
-  delivery engine both entry points share.
-- [`helpers/deliver-digest.md`](helpers/deliver-digest.md) — engine invariants,
-  gates, and the terminal-envelope contract.
+- [`/deliver`](../deliver.md) — the delivery entry point; routes here on a
+  free-text prompt.
+- [`/plan`](../plan.md) — routes here from Gate #1 on a confirmed suggestion,
+  and owns the work an over-scope prompt escalates to.
+- [`deliver-story.md`](deliver-story.md) — the one Story delivery engine every
+  path shares.
+- [`deliver-digest.md`](deliver-digest.md) — engine invariants, gates, and the
+  terminal-envelope contract.

--- a/.agents/workflows/helpers/deliver-reference.md
+++ b/.agents/workflows/helpers/deliver-reference.md
@@ -125,6 +125,38 @@ execute it directly, in this turn, threading the same `docsDigestPath` /
 content, execute directly without a re-read turn. The engine, gates, and
 terminal envelope are identical either way — only the isolation differs.
 
+## Intent phrases (what replaced the flag table)
+
+`/deliver` has no operator-facing flags. The scripts still take every flag they
+always did — the workflow fills them in from what the operator said, the same
+derive-then-announce contract `/git-deliver` uses for its terminal level.
+
+| The operator says | You pass | Effect |
+| --- | --- | --- |
+| "I'll merge it myself", "don't wait", "just open the PR" | `--no-wait-merge` | Rest at `agent::closing` for a human land |
+| "wait for the merge", "land it" | `--wait-merge` | Close-and-land — already the default (`delivery.routing.closeAndLand`) |
+| "take the lease", "steal it", "it's mine, override" | `--steal` | Forwarded to `single-story-init.js` |
+| "one at a time", "sequentially", "no parallelism" | `--concurrency 1` | Serialize a multi-Story run |
+| "run <n> at once" | `--concurrency <n>` | One-run cap only |
+
+Two rules keep this honest:
+
+1. **Announce before acting.** Name the intent you read and the flag it fills
+   in. A misread phrase is then visible in one line rather than discovered at
+   the terminal envelope.
+2. **Silence means config, not a literal.** With no intent phrase, omit the
+   flag entirely so `delivery.deliverRunner.concurrencyCap` (and any
+   `.agentrc.local.json` override) wins. Filling in the config default as a
+   literal silently defeats that override — the failure this table most easily
+   causes.
+
+`--yes` is deliberately **absent** from the table. It is not an intent an
+operator expresses; it is a runner asserting *nobody is at the keyboard*, and
+it changes fail-closed behavior (it is what turns the unplanned path's
+over-scope stop into an `escalated` terminal envelope, and what auto-proceeds
+`/plan`'s gates). Cron, `/loop`, and headless dispatch set it. An attended run
+never does, however the operator phrases their impatience.
+
 ## Operator-merge implies no-wait
 
 `--no-auto-merge` and `delivery.ci.autoMerge: "strict"` leave the PR

--- a/.agents/workflows/helpers/plan-reference.md
+++ b/.agents/workflows/helpers/plan-reference.md
@@ -1,9 +1,67 @@
 # /plan — on-demand reference appendix
 
 > **Applies when:** you are executing [`/plan`](../plan.md) and hit one of the
-> situations below — shape-derived complexity routing, `--tickets` supersede
-> authoring, critic dispatch detail, a failed persist, or source-id
-> resolution. The spine stays resident; this file is read on demand.
+> situations below — input-mode derivation, the Gate #1 light handoff,
+> shape-derived complexity routing, tickets-mode supersede authoring, critic
+> dispatch detail, a failed persist, or source-id resolution. The spine stays
+> resident; this file is read on demand.
+
+## Deriving the input mode
+
+`/plan` has no operator-facing flags; the CLIs below still take every flag they
+always did. Read the invocation, **announce what you derived**, then fill in
+the flag — the same derive-then-announce contract `/git-deliver` uses for its
+terminal level.
+
+| What was typed | Mode | You pass |
+| --- | --- | --- |
+| nothing | ask | — (ask what to plan) |
+| prose | seed | `--seed "<text>"` |
+| an argument resolving to an existing file | seed-file | `--seed-file <path>` |
+| ids, none of them a delivered Story | tickets | `--tickets <ids>` |
+| one id that is an `agent::done` Story | amends | `--amends '#<id>'` |
+| "…but let me review before you file" | (any) | `--force-review` |
+
+**Order matters.** Test *file exists* before *looks like prose*, or a bare
+`notes.md` becomes a one-word seed. Test *all args are `^#?\d+$`* before
+either, or a ticket list becomes prose.
+
+**The one genuinely ambiguous case** is a bare id, between `amends` and
+`tickets`. Resolve it from live state — `agent::done` can only be amended, an
+open unplanned issue can only be planned — and ask only when the id is an open
+Story already at `agent::ready`, where both readings are live. Do not ask in
+the cases state already answers; an unnecessary question is the friction this
+whole surface exists to remove.
+
+Mixed ids and prose in one invocation is a **hard error**: refuse and ask which
+was meant, rather than guessing a mode and doing the wrong work.
+
+## Gate #1 → the light path (in-session handoff)
+
+On a confirmed `deliverLightSuggestion`, `/plan` routes into
+[`deliver-light.md`](deliver-light.md) **without ending the session**. Two
+things make that safe, and both are worth understanding before changing it:
+
+1. **The handoff carries the envelope, not the seed.** Gate #1 already holds a
+   codebase snapshot and `complexitySignals`; fill the light gate's `--creates`
+   / `--refactors` / `--acceptance` / `--reason` from those. Re-deriving from
+   raw seed text throws away the better signal and can disagree with the
+   suggestion that routed you.
+2. **The gate still runs.** The suggestion is read against seed-time ceilings
+   (`DELIVER_LIGHT_SUGGESTION_CEILINGS` — artifacts, risk hits, sensitive-path
+   classes); the light gate is read against a predicted shape
+   (`STORY_SHAPE_CEILINGS` — `maxChanges`, `maxAcceptance`). Two different
+   checks on purpose, so a confirm is not a bypass.
+
+**When the light gate answers `ask-operator`**, the two ceiling sets disagreed.
+Resume `/plan` at step 2 (Author) **in this same session** — the interrogation
+is still valid and re-paying for it buys nothing. This bounce-back is not an
+escalation.
+
+Escalation in the *other* direction — an over-scope prompt on the light path —
+is terminal and requires a fresh session. The rule that separates the two, and
+why it must not be flattened into symmetry:
+[`deliver-light.md` § Why the two directions differ](deliver-light.md).
 
 ## Shape-derived complexity routing (`complexitySignals`)
 

--- a/.agents/workflows/plan.md
+++ b/.agents/workflows/plan.md
@@ -5,49 +5,50 @@ description:
   policy.
 ---
 
-# /plan --seed "<text>" | --seed-file <path> | --tickets <ids>
+# /plan
 
 > **Lean spine.** Happy path + gate list; edge-case detail lives in on-demand
 > [`helpers/plan-reference.md`](helpers/plan-reference.md).
 
 ## Inputs
 
-Single planning path — there is no
-Epic/Story router, no scope-triage `epic|story` verdict:
+Single planning path — there is no Epic/Story router, no scope-triage
+`epic|story` verdict. **Derive the mode from what the operator typed, announce
+it, then act**; there is nothing for them to remember:
 
-| Invocation | Behavior |
-| --- | --- |
-| `/plan --seed "<text>"` / `--seed-file <path>` | Ideation from chat text or on-disk notes: interrogate → author **one Story by default** → persist. |
-| `/plan --tickets 123[,456…]` | Fetch issue(s), analyze into proper Stories (prefer N=1 rewrite). |
-| `/plan --amends #<id>` | Amend a shipped Story from a **delta envelope** (prior body + acceptance + delivered file map), not a from-scratch re-interrogation. |
+| Invocation | Mode | Behavior |
+| --- | --- | --- |
+| `/plan` | ask | Ask what to plan; nothing runs first. |
+| `/plan add a --json flag to doctor` | seed | Ideation from the prose: interrogate → author **one Story by default** → persist. |
+| `/plan temp/notes/idea.md` | seed-file | Same, from notes. An argument resolving to an existing file is a path, never prose. |
+| `/plan 4712[,4713…]` | tickets | Fetch issue(s), analyze into proper Stories (prefer N=1 rewrite). |
+| `/plan 4712`, already delivered | amends | Amend a shipped Story from a **delta envelope**, not a re-interrogation. |
 
-`--body` is **not** a `/plan` entry; persist always goes through `plan-persist.js`.
+**Resolving a bare id.** Ids alone are ambiguous between *amend* and *tickets*,
+so read live state rather than asking: `agent::done` can only be amended, an
+open unplanned issue can only be planned. **Announce the derivation** — "4712
+is `agent::done` → amending" — so a wrong read costs one correction, not a
+wasted run. Ask **only** for an open Story already at `agent::ready`.
 
-## Flags
+`--body` is **not** a `/plan` entry; persist goes through `plan-persist.js`.
 
-Workflow-level flags only — the ones that change what **you** do:
+## Saying what you want
 
-| Flag | Meaning |
-| --- | --- |
-| `--seed "<text>"` / `--seed-file <path>` | Seed text / pre-authored notes path. |
-| `--tickets <ids>` | Issue ids to analyze; closed as superseded at persist. |
-| `--amends #<id>` | Prior Story to amend; emits a delta envelope, not a full re-interrogation. |
-| `--force-review` | STOP at gate #2 for operator review — the only review gate. |
-| `--yes` | Non-interactive: auto-proceed gate #1 and gate #2 HITL waits. |
-| `--dry-run` | Author + validate without GitHub writes; run as a pre-pass. |
+No flags to remember — state intent and the workflow fills in the CLI
+([reference](helpers/plan-reference.md)). Run any script with `--help` rather
+than copying its surface here.
 
-Every other flag is a passthrough to a CLI that documents itself — run the
-command with `--help` rather than looking for a copy of its surface here.
+`--yes` is **runner-set, never operator-typed** — cron, `/loop`, and headless
+dispatch set it to mean *nobody is at the keyboard*, which is what auto-proceeds
+the gates below. Never offer it to an operator or add it to an attended run.
 
 ## Default-single split policy
 
-Author **one Story** unless the pieces have **near-zero overlap** (genuinely
-independent capabilities) or sit across an **architectural seam** (different
-deployables, migration vs consumer). Coupled work stays one Story —
-`## Slicing` intra-session checkpoints, not sibling tickets; when N>1 every
-acceptance criterion belongs to exactly one Story
-(`assertAcceptancePartition` refuses coupled splits). **N=1 is the lean
-path:** one authoring prompt, folded `## Spec`, no Epic-scale ceremony.
+Author **one Story** unless the pieces have **near-zero overlap** or sit across
+an **architectural seam** (different deployables, migration vs consumer).
+Coupled work stays one Story — `## Slicing` checkpoints, not sibling tickets;
+when N>1 every acceptance criterion belongs to exactly one Story
+(`assertAcceptancePartition` refuses coupled splits). **N=1 is the lean path.**
 
 ## Procedure
 
@@ -59,49 +60,50 @@ node .agents/scripts/plan-context.js --seed "<seed>" \
 # or: --seed-file <path>  |  --tickets 123,456  |  --amends #<id>
 ```
 
-**Always pass `--out`.** Persist auto-discovers that envelope from `--plan-dir`
-and derives source-ticket ids from its `sourceTickets[]`; the CLI also
-writes **`stories.template.json`** — the authoring skeleton step 2 starts from.
+**Always pass `--out`.** Persist auto-discovers the envelope from `--plan-dir`
+and derives source ids from its `sourceTickets[]`; the CLI also writes
+**`stories.template.json`**, the skeleton step 2 starts from.
 
 The envelope carries docs context, the codebase snapshot, the story-author
 prompt, `sourceTickets[]`, `duplicates[]` (open **Stories**, never Epics), and
-advisory `complexitySignals` (**no routing authority**). A trivial scope
-earns `--route-downgrade-reason "<why>"` at persist — shape-validated, failing
-closed to `full`
-([detail](helpers/plan-reference.md)).
-Under `--yes`, do not ask free-form operator questions — unresolved unknowns
-land in Key Assumptions.
+advisory `complexitySignals` (**no routing authority**). A trivial scope earns
+`--route-downgrade-reason "<why>"` at persist — shape-validated, failing closed
+to `full` ([detail](helpers/plan-reference.md)). Under `--yes`, do not ask
+free-form operator questions — unknowns land in Key Assumptions.
 
 **Gate #1** — STOP to confirm the sharpened plan intent and any
-duplicate-candidate review. Under `--yes`, auto-proceed. When
-`complexitySignals.deliverLightSuggestion.suggested` is `true`, surface an
-**advisory** `/deliver-light` suggestion — the operator decides; under `--yes`
-it is recorded and planning proceeds, **never an automatic reroute**.
+duplicate-candidate review. Under `--yes`, auto-proceed.
+
+When `complexitySignals.deliverLightSuggestion.suggested` is `true`, offer —
+**advisory, never an automatic reroute** — to deliver the seed instead of
+planning it. On confirm, route **in this session** into
+[`helpers/deliver-light.md`](helpers/deliver-light.md), filling its gate from
+this envelope, not the raw seed; an `ask-operator` verdict returns here to
+step 2 with the interrogation intact. Under `--yes` it is recorded and planning
+proceeds — never auto-downgraded to light.
 
 ### 2. Author
 
-**One-shot authoring.** Start from `stories.template.json`;
-author `stories.json` in one pass. Entries are pre-resolved; keep
-tiers/assumptions valid. `body` is a markdown string **or** a structured
-object; persist parses either, serializes the canonical markdown, and syncs the
-top-level `acceptance[]` / `verify[]` into it — never dual-author those lists.
+**One-shot authoring.** Start from `stories.template.json`; author
+`stories.json` in one pass. Entries are pre-resolved; keep tiers/assumptions
+valid. `body` is a markdown string **or** a structured object; persist parses
+either, serializes the canonical markdown, and syncs top-level `acceptance[]` /
+`verify[]` into it — never dual-author those lists.
 
 Each entry (the `stories.template.json` shape): `slug`
 (`^[a-z0-9][a-z0-9-]*$`), `type: "story"`, `title`, `body` (`goal`, optional
 `spec`, `changes[{path, assumption}]` — `creates|refactors-existing|deletes`,
-`non_goals`, `reason_to_exist`), top-level `acceptance[]`, `verify[]`
-(`… (unit|contract|e2e|validate)`), `depends_on[]` (N>1 only).
+`non_goals`, `reason_to_exist`), top-level `acceptance[]`, `verify[]` (`…
+(unit|contract|e2e|validate)`), `depends_on[]` (N>1 only).
 
-Artifacts under `temp/plan-<slug>/`: `stories.json`
-(**length 1 by default**; over-budget Specs fail closed — split or tighten,
-never under `docs/`); optional `techspec.md` (**N===1 only** — folded into
-`## Spec`); optional `acceptance-manifest.json` (N>1 partition list — pass as
-`--plan-acceptance`). For N=1, use the envelope `systemPrompts.story` and emit
-one cohesive Story. Split only under the policy above.
+Artifacts under `temp/plan-<slug>/`: `stories.json` (**length 1 by default**;
+over-budget Specs fail closed — split or tighten, never under `docs/`);
+optional `techspec.md` (**N===1 only** — folded into `## Spec`); optional
+`acceptance-manifest.json` (N>1 partition list — `--plan-acceptance`). For N=1
+use the envelope `systemPrompts.story`; split only under the policy above.
 
-**Tickets mode:** every Story authors a top-level `supersedes[]` claiming the
-source issues it replaces; persist refuses a partial map
-([shape](helpers/plan-reference.md)).
+**Tickets mode:** every Story authors a top-level `supersedes[]`; persist
+refuses a partial map ([shape](helpers/plan-reference.md)).
 
 ### 2.5 Critics
 
@@ -111,29 +113,28 @@ node .agents/scripts/plan-critics.js \
   [--tech-spec temp/plan-<slug>/techspec.md]
 ```
 
-Run **before** persist — the last point a finding folds into a re-author
-round. It exits 0 on **any** verdict (verdicts route work, they do not
-gate) and exits **1** only on a usage/IO error — no critic ran, no skip
-ledgered: **do not proceed to Persist**; fix and re-run.
+Run **before** persist — the last point a finding folds into a re-author round.
+It exits 0 on **any** verdict (verdicts route work, they do not gate) and exits
+**1** only on a usage/IO error — no critic ran, no skip ledgered: **do not
+proceed to Persist**; fix and re-run.
 
 - **Both `dispatch: false`** — proceed to Persist (each skip is ledgered).
 - **Either `dispatch: true`** — dispatch **one fresh-context, maker-blind
-  sub-agent per firing critic** (hand it only the draft artifacts,
-  never the authoring transcript), fold findings into Gate #2 or a
-  re-author round, re-run this step. Pre-mortem triggers (incl. the
-  external-dependency probe), folding the advisory-only
-  `textHygiene.findings[]` lints, and the role-scoped dispatch shape:
+  sub-agent per firing critic** (hand it only the draft artifacts, never the
+  authoring transcript), fold findings into Gate #2 or a re-author round, re-run
+  this step. Pre-mortem triggers (incl. the external-dependency probe), the
+  advisory-only `textHygiene.findings[]` lints, and the dispatch shape:
   [`helpers/plan-reference.md` § Critic dispatch detail](helpers/plan-reference.md).
 
 ### 3. Persist
 
-**Gate #2** — with `--force-review`, STOP for approval before persist (the
-**only** trigger). Under `--yes`, auto-proceed.
+**Gate #2** — STOP for approval before persist **only** when the operator asked
+to review (`--force-review`). Under `--yes`, auto-proceed.
 
-Run persist with `--dry-run` **first** — same command, GitHub writes
-suppressed; every gate (validator, body parse, DAG, capacity, budget,
-reachability, split/supersede partitions, Spec fold) runs before the first
-`createIssue`. Then:
+Run persist with `--dry-run` **first** — same command, GitHub writes suppressed;
+every gate (validator, body parse, DAG, capacity, budget, reachability,
+split/supersede partitions, Spec fold) runs before the first `createIssue`.
+Then:
 
 ```bash
 node .agents/scripts/plan-persist.js \
@@ -141,27 +142,28 @@ node .agents/scripts/plan-persist.js \
   --plan-dir temp/plan-<slug> \
   [--plan-acceptance temp/plan-<slug>/acceptance-manifest.json] \
   [--tech-spec temp/plan-<slug>/techspec.md] \
-  [--source-tickets 123,456] [...flags from the table above]
+  [--source-tickets 123,456]
 ```
 
 At lite shape, `--chain-on-clean` chains that dry-run into the real persist in
-one round-trip **only** when it is clean and `lite`; a full-route plan keeps
-its review round-trip.
+one round-trip **only** when it is clean and `lite`; a full plan keeps its
+review round-trip.
 
 Persist creates `type::story` issue(s) plus a `plan-run::<id>` grouping label
-(**metadata only**); N>1 `depends_on` edges become `blocked by #<id>`
-footers. `agent::ready` is the **terminal** flip after all receipts land — a
-ready Story is fully persisted. stdout is pure JSON.
+(**metadata only**); N>1 `depends_on` edges become `blocked by #<id>` footers.
+`agent::ready` is the **terminal** flip after all receipts land. stdout is pure
+JSON.
 
-In `--tickets` mode persist resolves source ids **envelope-first** and closes
-each as `not_planned` with a comment (default on;
+In tickets mode persist resolves source ids **envelope-first** and closes each
+as `not_planned` with a comment (default on;
 [detail](helpers/plan-reference.md)). On a stranded persist, re-run the same
 command — never hand-delete issues.
 
 ## Constraints
 
-- `/plan` never starts delivery. Duplicate search targets open Stories
-  (`type::story`), not Epics.
+- `/plan` starts delivery **only** through a confirmed Gate #1 light route —
+  never off its own authored Stories, which land via [`/deliver`](deliver.md).
+- Duplicate search targets open Stories (`type::story`), not Epics.
 - Deterministic gates still fail closed under `--yes`.
 
 ## See also

--- a/tests/bootstrap/workflow-invocation-surface.test.js
+++ b/tests/bootstrap/workflow-invocation-surface.test.js
@@ -1,0 +1,245 @@
+/**
+ * tests/bootstrap/workflow-invocation-surface.test.js — the operator-facing
+ * invocation surface of `/plan` and `/deliver` (Story #4760).
+ *
+ * ## What this pins
+ *
+ * Two commands an operator can type from memory. The routing decisions that
+ * used to live in the invocation — which delivery path, which plan mode, which
+ * merge behaviour — now live in the workflows, derived from argument shape and
+ * live state. These assertions exist because that surface is prose: nothing
+ * else fails when a `## Flags` table creeps back or a retired command name
+ * survives in a doc.
+ *
+ * The negative assertions are the load-bearing half. A flag table is easy to
+ * re-add "just for reference", and each one re-imposes the memory burden the
+ * change removed.
+ *
+ * Prose assertions go through `doc-assert.js` so a re-flowed 80-column
+ * paragraph cannot turn a correct edit red (and, for the negative cases, so a
+ * forbidden phrase cannot hide by straddling a line break).
+ */
+
+import assert from 'node:assert/strict';
+import { existsSync, readFileSync } from 'node:fs';
+import path from 'node:path';
+import { describe, it } from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+import {
+  assertDocMentions,
+  assertDocOmits,
+  readDoc,
+} from '../helpers/doc-assert.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+
+const rel = (p) => path.join(REPO_ROOT, p);
+
+const DELIVER = rel('.agents/workflows/deliver.md');
+const PLAN = rel('.agents/workflows/plan.md');
+const LIGHT = rel('.agents/workflows/helpers/deliver-light.md');
+const DELIVER_REF = rel('.agents/workflows/helpers/deliver-reference.md');
+const PLAN_REF = rel('.agents/workflows/helpers/plan-reference.md');
+
+describe('one delivery door (Story #4760)', () => {
+  it('retires the top-level /deliver-light workflow into helpers/', () => {
+    assert.equal(
+      existsSync(rel('.agents/workflows/deliver-light.md')),
+      false,
+      'a top-level deliver-light.md projects a /deliver-light command again — ' +
+        'the whole point is one delivery door',
+    );
+    assert.equal(
+      existsSync(LIGHT),
+      true,
+      'the prompt path must survive the move as a helper — it has two callers',
+    );
+  });
+
+  it('drops /deliver-light from the generated workflow index', () => {
+    // The index is generated from top-level workflow front-matter, so this
+    // also proves the move (not a hand-edit) did the retirement.
+    assertDocOmits(
+      readDoc(rel('.agents/docs/workflows.md')),
+      /\/deliver-light/,
+      'the generated command index still advertises a command that no longer projects',
+    );
+  });
+
+  it('documents all three /deliver input shapes and the mixed-input refusal', () => {
+    const md = readDoc(DELIVER);
+    assertDocMentions(
+      md,
+      /\^#\?\\d\+\$/,
+      'the id discriminator must be stated exactly',
+    );
+    assertDocMentions(
+      md,
+      /bare/i,
+      'a bare invocation must have a documented behaviour, not be undefined',
+    );
+    assertDocMentions(
+      md,
+      /mixed[^.]*hard error/i,
+      'mixed ids-and-prose must refuse rather than guess a shape',
+    );
+    assertDocMentions(
+      md,
+      /helpers\/deliver-light\.md/,
+      '/deliver must route the prompt shape into the shared helper',
+    );
+  });
+
+  it('keeps escalation terminal — /deliver must never rescue an over-scope prompt by planning', () => {
+    assertDocMentions(
+      readDoc(DELIVER),
+      /never invoke `\/plan` in this session/i,
+      'the in-session-planning guard is the mandrel-bench 2.13.0 finding; it must ' +
+        'survive the fold into one command',
+    );
+  });
+});
+
+describe('derived invocation intent (Story #4760)', () => {
+  for (const [label, file] of [
+    ['deliver.md', DELIVER],
+    ['plan.md', PLAN],
+  ]) {
+    it(`${label} carries no operator-facing flag table`, () => {
+      const md = readFileSync(file, 'utf8');
+      // Heading match, not prose: a `## Flags` section is a layout claim.
+      assert.doesNotMatch(
+        md,
+        /^##+\s+Flags\s*$/m,
+        `${label} reintroduced a flag table — the flags belong to the scripts, ` +
+          'which document themselves via --help',
+      );
+    });
+
+    it(`${label} documents --yes as runner-set, never operator-typed`, () => {
+      assertDocMentions(
+        readDoc(file),
+        /`--yes` is \*\*runner-set, never operator-typed\*\*/,
+        `${label} must keep --yes out of the operator's hands without deleting it: ` +
+          'it is the unattended switch the escalation guarantee depends on',
+      );
+    });
+  }
+
+  it('plan.md derives a bare id from live state and announces it', () => {
+    const md = readDoc(PLAN);
+    assertDocMentions(
+      md,
+      /`agent::done` can only be amended/,
+      'the amend-vs-tickets ambiguity must resolve from state, not a flag',
+    );
+    assertDocMentions(
+      md,
+      /Announce the derivation/i,
+      'a derived mode must be announced so a wrong read costs one correction',
+    );
+    assertDocMentions(
+      md,
+      /Ask \*\*only\*\* for an open Story already at `agent::ready`/,
+      'the one genuinely ambiguous case must still ask',
+    );
+  });
+
+  it('deliver-reference.md maps intent phrases to the flags they fill in', () => {
+    const md = readDoc(DELIVER_REF);
+    assertDocMentions(
+      md,
+      /Intent phrases/,
+      'the replacement for the flag table must exist',
+    );
+    assertDocMentions(
+      md,
+      /--no-wait-merge/,
+      'the merge-it-myself intent must name the flag it fills in',
+    );
+    assertDocMentions(
+      md,
+      /Silence means config, not a literal/,
+      'omitting --concurrency is what lets .agentrc.local.json win; filling in the ' +
+        'default as a literal silently defeats the override',
+    );
+  });
+
+  it('plan-reference.md orders the input-mode derivation unambiguously', () => {
+    assertDocMentions(
+      readDoc(PLAN_REF),
+      /Test \*file exists\* before \*looks like prose\*/,
+      'without an explicit order a bare notes.md becomes a one-word seed',
+    );
+  });
+});
+
+describe('the /plan ↔ light asymmetry (Story #4760)', () => {
+  it('states the guard rule that explains why the two directions differ', () => {
+    const md = readDoc(LIGHT);
+    // Asserted in halves: the rule sits in a blockquote, and `doc-assert`
+    // normalizes whitespace but not the `>` continuation marker a wrap
+    // introduces mid-sentence.
+    assertDocMentions(
+      md,
+      /The direction whose guard is model judgment must break the session\./,
+      'the asymmetry reads as an inconsistency; without the rule stated, someone ' +
+        'will flatten it into symmetry in one direction or the other',
+    );
+    assertDocMentions(
+      md,
+      /direction whose guard is mechanical need not\./,
+      'the permissive half of the rule is what licenses the in-session /plan → light route',
+    );
+    assertDocMentions(
+      md,
+      /Do not "fix" this into symmetry/,
+      'the rule needs an explicit do-not-change marker, not just an explanation',
+    );
+  });
+
+  it('keeps light → /plan escalation on a fresh session', () => {
+    assertDocMentions(
+      readDoc(LIGHT),
+      /Invoking `\/plan` in this same session is forbidden/,
+      'the empirical under-decomposition finding must survive the move',
+    );
+  });
+
+  it('routes /plan → light in-session, and bounces back in-session too', () => {
+    assertDocMentions(
+      readDoc(PLAN),
+      /route \*\*in this session\*\* into/,
+      'Gate #1 must hand off directly rather than printing a command to run elsewhere',
+    );
+    assertDocMentions(
+      readDoc(LIGHT),
+      /return to \[`\.\.\/plan\.md`\]\(\.\.\/plan\.md\) step 2 \(Author\) in the same\s*session/,
+      'an ask-operator verdict must resume planning without re-paying for the interrogation',
+    );
+  });
+
+  it('names both callers on the shared helper', () => {
+    const md = readDoc(LIGHT);
+    assertDocMentions(
+      md,
+      /There is no `\/deliver-light` to type/,
+      'it is a path, not a command',
+    );
+    assertDocMentions(
+      md,
+      /reached two ways/,
+      'the two-caller framing is what justifies it being a helper',
+    );
+  });
+
+  it('keeps the two ceiling sets as two distinct gates', () => {
+    assertDocMentions(
+      readDoc(LIGHT),
+      /deliberately two different checks, so the gate still runs after a confirm/,
+      'collapsing the seed-time and shape-time ceilings would make a confirm a bypass',
+    );
+  });
+});

--- a/tests/lib/orchestration/light-suitability.test.js
+++ b/tests/lib/orchestration/light-suitability.test.js
@@ -1,10 +1,13 @@
 // tests/lib/orchestration/light-suitability.test.js
 //
-// Unit tier (Story #4740): /deliver-light — a validated single-session
-// delivery path for genuinely small work that keeps every quality gate and the
+// Unit tier (Story #4740): the light path — a validated single-session
+// delivery route for genuinely small work that keeps every quality gate and the
 // landing guarantee. This suite pins the four invariants that keep the light
 // path proportional rather than a planning bypass, plus the thin-entry-point
-// contract that it reuses the shared engine scripts:
+// contract that it reuses the shared engine scripts.
+//
+// Story #4760 folded it into `/deliver` as a routed prompt path (and a second
+// caller, `/plan` Gate #1); the gate logic below is untouched by that move.
 //
 //   - AC-1: the light path lands through the unchanged single-story-close
 //           engine (buildNextCommands references it, no parallel close impl);
@@ -18,7 +21,8 @@
 //   - AC-5: a minimal receipt type::story is authored inline carrying the
 //           prompt and footprint (buildReceiptStoryTicket / createLightReceipt);
 //   - AC-6: --amends is shape-checked identically (small → light, heavy → plan);
-//   - AC-7: /deliver-light projects into the generated command tree;
+//   - AC-7: (amended by Story #4760) the light path does NOT project a command
+//           — it moved under helpers/ so `/deliver` is the one delivery door;
 //   - AC-8: the light entry contains no parallel init/close implementation.
 //
 // Story #4746 makes the escalate-plan OUTCOME terminal rather than advisory.
@@ -29,7 +33,7 @@
 
 import assert from 'node:assert/strict';
 import { spawnSync } from 'node:child_process';
-import { existsSync, mkdtempSync, readFileSync } from 'node:fs';
+import { existsSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import test, { describe } from 'node:test';
@@ -675,8 +679,11 @@ describe('the workflow states escalation is terminal (AC-3)', () => {
   // Prose assertions go through doc-assert: these claims are about what the
   // document SAYS, and a plain `assert.match` would silently also be pinning
   // where the 80-column wrap happens to fall.
+  // Story #4760 moved this from a top-level workflow to a helper: the prompt
+  // path has two callers (/deliver and /plan Gate #1) and no longer projects a
+  // command of its own. The escalation claims below are unchanged.
   const doc = readDoc(
-    path.join(REPO_ROOT, '.agents', 'workflows', 'deliver-light.md'),
+    path.join(REPO_ROOT, '.agents', 'workflows', 'helpers', 'deliver-light.md'),
   );
 
   test('names the envelope as the session terminal output', () => {
@@ -728,12 +735,25 @@ describe('the workflow states escalation is terminal (AC-3)', () => {
 });
 
 // ---------------------------------------------------------------------------
-// AC-7 — /deliver-light projects into the generated command tree
+// AC-7 (as amended by Story #4760) — the light path must NOT project a command
 // ---------------------------------------------------------------------------
+// This assertion was inverted, not deleted. #4740 shipped `/deliver-light` as
+// its own command and pinned that it projected; #4760 folded the prompt path
+// into `/deliver` precisely so an operator never has to pre-judge which door
+// to use, and a surviving `/deliver-light` command would restore that choice.
+//
+// Projection is also the whole retirement mechanism: `helpers/` is skipped by
+// the projector and the orphan-reap removes any command with no source
+// workflow, so a consumer's stale `/deliver-light` disappears on their next
+// sync with no migration step. This test is what proves that still holds.
 
-describe('/deliver-light projects via sync-claude-commands (AC-7)', () => {
-  test('the sync script writes .claude/commands/deliver-light.md', () => {
+describe('the light path does not project a command (AC-7, Story #4760)', () => {
+  test('sync-claude-commands writes no deliver-light command', () => {
     const dest = mkdtempSync(path.join(tmpdir(), 'light-cmd-'));
+    // Seed the destination with the command a pre-#4760 consumer would have,
+    // so this exercises the orphan-reap rather than merely a non-write.
+    writeFileSync(path.join(dest, 'deliver-light.md'), '# stale\n');
+
     const result = spawnSync(
       process.execPath,
       [path.join(REPO_ROOT, '.agents', 'scripts', 'sync-claude-commands.js')],
@@ -752,9 +772,15 @@ describe('/deliver-light projects via sync-claude-commands (AC-7)', () => {
       },
     );
     assert.equal(result.status, 0, result.stderr);
-    assert.ok(
+    assert.equal(
       existsSync(path.join(dest, 'deliver-light.md')),
-      'deliver-light.md was not projected into the command tree',
+      false,
+      'a stale /deliver-light command survived the sync — consumers would keep ' +
+        'a second delivery door that no workflow backs',
+    );
+    assert.ok(
+      existsSync(path.join(dest, 'deliver.md')),
+      'the one delivery door must still project',
     );
   });
 });

--- a/tests/plan-context.test.js
+++ b/tests/plan-context.test.js
@@ -1013,7 +1013,7 @@ const PRIOR_STORY_BODY = serialize({
 });
 
 describe('plan-context deliverLightSuggestion (Story #4741 AC-6)', () => {
-  it('suggests /deliver-light for a scope inside the ceilings — advisory, never automatic', () => {
+  it('suggests the light path for a scope inside the ceilings — advisory, never automatic', () => {
     const s = buildDeliverLightSuggestion({
       artifactCount: 1,
       riskHeuristicHits: [],
@@ -1023,7 +1023,10 @@ describe('plan-context deliverLightSuggestion (Story #4741 AC-6)', () => {
     // The two contract flags: advisory, and NEVER an automatic reroute.
     assert.equal(s.advisory, true);
     assert.equal(s.automatic, false);
-    assert.match(s.reasons[0], /deliver-light ceilings/);
+    assert.match(s.reasons[0], /light-path ceilings/);
+    // Story #4760 retired the /deliver-light command; the suggestion must
+    // name a command the operator can actually type.
+    assert.doesNotMatch(s.reasons[0], /\/deliver-light/);
   });
 
   it('does not suggest when the seed exceeds the artifact ceiling', () => {

--- a/tests/plan-yes-flag-workflow.test.js
+++ b/tests/plan-yes-flag-workflow.test.js
@@ -37,15 +37,29 @@ function section(headingPattern) {
 }
 
 describe('/plan --yes headless flag — single plan.md path', () => {
-  it('documents --yes in the flag table as a headless HITL auto-proceed flag', () => {
-    const flagRow = planSource
-      .split('\n')
-      .find((line) => /^\|\s*`--yes`\s*\|/.test(line));
-    assert.ok(flagRow, 'plan.md flag table must carry a `--yes` row');
-    assert.match(
-      flagRow,
-      /Non-interactive: auto-proceed gate #1 and gate #2 HITL waits/i,
-      '`--yes` row must name both HITL gates it auto-proceeds',
+  // Story #4760 removed plan.md's flag table: the operator-facing surface is
+  // now derived from what they typed, and the flags belong to the self-
+  // describing CLIs. `--yes` survives that removal deliberately — it is not an
+  // operator convenience but the *unattended* switch, and the behaviours it
+  // gates (auto-proceeding both HITL waits; failing an over-scope light prompt
+  // closed to an `escalated` terminal) still have to be stated somewhere an
+  // agent reads. So the claim is unchanged; only its home moved out of a table.
+  it('documents --yes as runner-set, naming both HITL gates it auto-proceeds', () => {
+    assertDocMentions(
+      planSource,
+      /`--yes` is \*\*runner-set, never operator-typed\*\*/,
+      'plan.md must keep --yes out of the operator surface without dropping it',
+    );
+    assertDocMentions(
+      planSource,
+      /cron, `\/loop`, and headless dispatch set it/,
+      '--yes must name who sets it, now that no operator does',
+    );
+    // Both gates still auto-proceed; each says so at its own gate.
+    assert.equal(
+      (planSource.match(/Under `--yes`, auto-proceed/g) ?? []).length,
+      2,
+      'both Gate #1 and Gate #2 must state that --yes auto-proceeds them',
     );
   });
 
@@ -96,18 +110,23 @@ describe('/plan --yes headless flag — gate #1', () => {
     );
   });
 
+  // Prose claims, so they go through doc-assert rather than assert.match:
+  // these sentences are hard-wrapped at ~80 columns, and a plain literal space
+  // in the pattern silently pins where the wrap falls. Story #4760's trim of
+  // this section moved "free-form" onto the next line and turned a correct
+  // edit red without changing what the document says.
   it('auto-proceeds under --yes without free-form operator questions', () => {
-    assert.match(
+    assertDocMentions(
       interrogate,
       /Under `--yes`, auto-proceed/i,
       'gate #1 must auto-proceed under --yes',
     );
-    assert.match(
+    assertDocMentions(
       interrogate,
       /do not ask free-form operator questions/i,
       'headless interrogation must not ask operator questions',
     );
-    assert.match(
+    assertDocMentions(
       interrogate,
       /Key Assumptions/,
       'unresolved unknowns must land in the one-pager Key Assumptions section',


### PR DESCRIPTION
Closes #4760

_Auto-opened by `/deliver`._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are workflow documentation, suggestion copy, and doc-contract tests; delivery gate logic in scripts is unchanged aside from messaging.
> 
> **Overview**
> **Unifies delivery behind `/deliver`** by retiring the top-level `/deliver-light` workflow (helper-only path, workflow index 24 commands). `/deliver` now classifies input as bare (list ready Stories), numeric ids (existing graph delivery), or free-text **prompt** (unplanned light path via `helpers/deliver-light.md`); mixed ids and prose is a hard error. Over-scope prompts must **escalate terminally**—no in-session `/plan` rescue.
> 
> **Simplifies operator surface for `/plan` and `/deliver`**: spine docs drop `## Flags` tables in favor of invocation-shape tables and **intent phrases** that map to script flags (e.g. merge/wait, steal, concurrency). `--yes` is documented as **runner-set only** (cron/loops/headless), not operator-typed.
> 
> **Documents the `/plan` ↔ light asymmetry**: Gate #1 may hand off in-session to the light path using plan-context envelope fields; light → `/plan` requires a fresh session. `plan-context.js` copy now distinguishes seed-time `DELIVER_LIGHT_SUGGESTION_CEILINGS` from shape-time `STORY_SHAPE_CEILINGS`, and suggests `/deliver` instead of `/deliver-light`.
> 
> **Adds regression tests** (`workflow-invocation-surface.test.js`) pinning one delivery door, derived modes, intent phrases, and asymmetry prose; updates light-suitability AC-7 to assert `sync-claude-commands` **orphan-reaps** stale `/deliver-light` projections.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c0cadf9a01184645c3fb5dab9dd0d6d21afc5ada. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->