### PR TITLE
refactor: scope the light path by effort and risk, not artifact cardinality (#4764)

### DIFF
--- a/.agents/scripts/deliver-light.js
+++ b/.agents/scripts/deliver-light.js
@@ -79,18 +79,29 @@ import { createProvider } from './lib/provider-factory.js';
 const HELP = `\
 Usage:
   deliver-light.js --prompt <text> [--creates csv] [--refactors csv]
-                   [--acceptance n] [--route lite|full] [--reason <text>]
+                   [--acceptance n] [--kinds csv] [--magnitude m]
+                   [--uncertainty u] [--route lite|full] [--reason <text>]
                    [--amends '#id'] [--yes]
   deliver-light.js --backstop --story <id>
 
 The thin /deliver-light entry point: suitability gate → inline receipt Story →
 the same single-story-init.js / single-story-close.js engine /deliver uses.
 
+The gate judges EFFORT and RISK, not artifact counts: N instances of one
+mechanical edit is one kind at N sites. It rejects only clearly-epic work; the
+--backstop pass enforces size against the actual diff.
+
 Gate options:
   --prompt <text>    Operator prompt describing the change. Required for the gate.
   --creates <csv>    Predicted NEW file paths (comma-separated).
   --refactors <csv>  Predicted edited/existing file paths (comma-separated).
-  --acceptance <n>   Predicted acceptance-criteria count (default 1).
+  --acceptance <n>   Predicted acceptance-criteria count (default 1). Not capped.
+  --kinds <csv>      Distinct KINDS of change (default: one per assumption, so
+                     N same-shaped edits count once).
+  --magnitude <m>    Coarse effort bucket: trivial | moderate | substantial
+                     (default moderate; substantial routes to /plan).
+  --uncertainty <u>  determined (the request fixes the shape) | needs-design
+                     (default determined; needs-design routes to /plan).
   --route <r>        Ledgered model verdict route: lite | full.
   --reason <text>    Recorded reason for a lite verdict (required for lite).
   --amends <#id>     Mark this as an amendment of an existing issue.
@@ -166,17 +177,25 @@ export function synthesizeAcceptance(count) {
  *   creates?: string[],
  *   refactors?: string[],
  *   acceptance?: number,
+ *   kinds?: string[],
+ *   magnitude?: string,
+ *   uncertainty?: string,
  *   route?: string,
  *   reason?: string,
  *   yes?: boolean,
  *   injectedRules?: object,
- * }} args
+ * }} args `kinds` / `magnitude` / `uncertainty` are the declared effort-and-risk
+ *   axes the gate judges (Story #4764); omitting them declares no signal, not a
+ *   small one — an unrecognized bucket fails closed.
  * @returns {{ action: string, suitability: object, outcome: object }}
  */
 export function runLightGate({
   creates = [],
   refactors = [],
   acceptance,
+  kinds,
+  magnitude,
+  uncertainty,
   route,
   reason,
   yes = false,
@@ -186,6 +205,9 @@ export function runLightGate({
   const suitability = deriveLightSuitability({
     predictedChanges,
     predictedAcceptance: synthesizeAcceptance(acceptance),
+    predictedKinds: kinds,
+    predictedMagnitude: magnitude,
+    predictedUncertainty: uncertainty,
     verdict: { route, reason },
     injectedRules,
   });
@@ -355,6 +377,9 @@ export async function runGateMode(values, deps = {}) {
     acceptance: values.acceptance
       ? Number.parseInt(String(values.acceptance), 10)
       : 1,
+    kinds: parseCsvPaths(values.kinds),
+    magnitude: values.magnitude,
+    uncertainty: values.uncertainty,
     route: values.route,
     reason: values.reason,
     yes: values.yes === true,
@@ -417,6 +442,9 @@ async function main() {
       creates: { type: 'string' },
       refactors: { type: 'string' },
       acceptance: { type: 'string' },
+      kinds: { type: 'string' },
+      magnitude: { type: 'string' },
+      uncertainty: { type: 'string' },
       route: { type: 'string' },
       reason: { type: 'string' },
       amends: { type: 'string' },

--- a/.agents/scripts/lib/orchestration/complexity-gate.js
+++ b/.agents/scripts/lib/orchestration/complexity-gate.js
@@ -24,10 +24,11 @@
  *      reason is `full`.
  *   3. **Deterministic backstop at persist.** After authoring, the work has
  *      measurable shape: {@link deriveStoryShape} reads the Story's own
- *      `changes[]` count, acceptance-criteria count, creates-vs-refactors
- *      mix, and sensitive-path classes against {@link STORY_SHAPE_CEILINGS}.
- *      A `lite` claim whose shape exceeds the ceilings **fails closed to
- *      `full`** (`run-plan-persist.js`).
+ *      effort and risk — distinct change kinds, declared magnitude,
+ *      uncertainty, deployable/migration span, and sensitive-path classes —
+ *      against {@link STORY_SHAPE_CEILINGS}. A `lite` claim whose work exceeds
+ *      them **fails closed to `full`** (`run-plan-persist.js`). Artifact
+ *      cardinality is deliberately not an axis (Story #4764).
  *   4. **Deliver re-derives.** `/deliver` computes the route from the fetched
  *      Story body via the **same** shape function at dispatch
  *      ({@link resolveStoryDispatchMode}) and honors it: a lite-shaped Story
@@ -104,34 +105,220 @@ const DEFAULT_COMPLEXITY_GATE = Object.freeze({
 export const LITE_ROUTE_LABEL = 'route::lite';
 
 /**
- * Shape ceilings a Story must fit for the `lite` route
+ * Effort/risk ceilings a Story's work must fit for the `lite` route
  * ({@link deriveStoryShape}). Framework constants, not operator knobs — a
- * ceiling an operator can widen past what the inline path can safely absorb
- * is a ceiling that fails silently. Conservative by construction: `lite` is
- * for genuinely trivial, mostly-additive, non-sensitive scopes.
+ * ceiling an operator can widen past what the inline path can safely absorb is
+ * a ceiling that fails silently.
  *
- *   - `maxChanges`          — total `changes[]` entries (e.g. one artifact
- *                             plus its test).
- *   - `maxAcceptance`       — acceptance-criteria count; more criteria means
- *                             more contract than a trivial scope carries.
- *   - `maxNonCreateChanges` — entries whose assumption is not `creates`
- *                             (refactors-existing / deletes / exists). A lite
- *                             change is mostly additive; touching existing
- *                             surfaces is where trivial-looking work stops
- *                             being trivial.
+ * ## Effort and risk, never artifact cardinality (Story #4764)
+ *
+ * These ceilings used to count the declared footprint (`maxChanges: 2`,
+ * `maxAcceptance: 3`, `maxNonCreateChanges: 1`). Cardinality is the wrong axis
+ * in both directions: three identical one-line edits across three files is
+ * trivial work with a high count, while a 200-line rewrite of one module is a
+ * single change. And the count was read off a footprint the model **declares
+ * before doing the work** — a guess, and a gameable one — so counting it
+ * rejected genuinely small work (mandrel-bench's hello-world scenario is a
+ * server create plus a `package.json` edit plus a test create, structurally
+ * over the old ceilings) while admitting whatever an optimistic declaration
+ * under-counted.
+ *
+ * So the axes are effort, risk, and uncertainty, and the **prediction** gate
+ * they form is deliberately **coarse**: it rejects clearly-epic work only.
+ * Real enforcement belongs to the diff-derived backstop, which sees ground
+ * truth instead of a declaration
+ * ({@link module:lib/orchestration/light-suitability.checkLightDiffBackstop}).
+ *
+ *   - `maxChangeKinds` — distinct change KINDS, not files. N instances of one
+ *                        mechanical edit is one kind at N sites; enumerating
+ *                        more kinds than this is a multi-capability scope.
+ *   - `maxMagnitude`   — coarse magnitude bucket, declared alongside the
+ *                        footprint: `trivial` < `moderate` < `substantial`.
+ *   - `maxUncertainty` — is the shape determined by the request
+ *                        (`determined`), or does it still need the design
+ *                        decisions `/plan` exists to resolve
+ *                        (`needs-design`)?
+ *   - `maxDeployables` — named deployable roots (`apps/<x>`, `packages/<x>`, …)
+ *                        the footprint spans; more than one is epic by
+ *                        construction.
+ *
+ * Two rules ride beside the ceilings and are not tunable at all: a footprint
+ * pairing a migration with its consumers is epic scope, and a footprint
+ * intersecting a sensitive-path class routes `full` however small or mechanical
+ * it is — the hard gate, unchanged.
  *
  * Exposed as the `ceilings` field on every {@link deriveStoryShape} decision
- * and exported directly (Story #4740) so the `/deliver-light` suitability gate
+ * and exported directly (Story #4740) so the light path's suitability gate
  * ({@link module:lib/orchestration/light-suitability}) judges a prompt's
- * predicted footprint against the **same** ceilings the plan-time shape
- * backstop applies — one source, so the light entry point and the plan path can
- * never disagree about what shape is trivial.
+ * predicted footprint against the **same** axes the plan-time shape backstop
+ * applies — one source, so the light entry point and the plan path can never
+ * disagree about what work is trivial.
  */
 export const STORY_SHAPE_CEILINGS = Object.freeze({
-  maxChanges: 2,
-  maxAcceptance: 3,
-  maxNonCreateChanges: 1,
+  maxChangeKinds: 2,
+  maxMagnitude: 'moderate',
+  maxUncertainty: 'determined',
+  maxDeployables: 1,
 });
+
+/** Coarse effort buckets, ascending. Anything past `maxMagnitude` routes full. */
+const MAGNITUDE_SCALE = Object.freeze(['trivial', 'moderate', 'substantial']);
+
+/** Coarse uncertainty buckets, ascending. */
+const UNCERTAINTY_SCALE = Object.freeze(['determined', 'needs-design']);
+
+/**
+ * Directory roots whose immediate child is a separately-deployable unit. A
+ * footprint spanning two of them is the "multiple deployables" epic signal.
+ */
+const DEPLOYABLE_ROOTS = Object.freeze([
+  'apps',
+  'packages',
+  'services',
+  'functions',
+  'workers',
+]);
+
+/** Paths that are schema migrations rather than ordinary source. */
+const MIGRATION_PATH_RE =
+  /(?:^|\/)(?:migrations?|migrate)(?:\/|$)|\.sql$|(?:^|\/)schema\.(?:prisma|rb)$/i;
+
+/**
+ * Place a declared bucket on an ordered scale. **Absent** means "not declared"
+ * — no signal, so the coarse gate reads the supplied default rather than
+ * rejecting. **Present but unrecognized** is a malformed claim, which cannot be
+ * verified as small and therefore fails closed to the worst bucket on the
+ * scale.
+ *
+ * @param {unknown} value
+ * @param {readonly string[]} scale Ascending buckets.
+ * @param {string} whenAbsent Bucket to assume when nothing was declared.
+ * @returns {string}
+ */
+function normalizeBucket(value, scale, whenAbsent) {
+  if (value === undefined || value === null || value === '') return whenAbsent;
+  const key = typeof value === 'string' ? value.trim().toLowerCase() : '';
+  return scale.includes(key) ? key : scale[scale.length - 1];
+}
+
+/**
+ * Resolve the distinct change KINDS in a footprint. An explicit `kinds[]`
+ * declaration wins; absent one, each entry's `assumption` is its kind — which
+ * is exactly the "N instances of one mechanical edit is one kind at N sites"
+ * reading, since N same-assumption entries collapse to one kind.
+ *
+ * @param {{ changes?: unknown, kinds?: unknown }} args
+ * @returns {string[]} Distinct kinds, in order of first appearance.
+ */
+function resolveChangeKinds({ changes, kinds }) {
+  const clean = (list) =>
+    list
+      .filter((k) => typeof k === 'string' && k.trim() !== '')
+      .map((k) => k.trim().toLowerCase());
+  const declared = clean(Array.isArray(kinds) ? kinds : []);
+  if (declared.length > 0) return [...new Set(declared)];
+  const derived = (Array.isArray(changes) ? changes : []).map((entry) =>
+    entry && typeof entry === 'object' && typeof entry.assumption === 'string'
+      ? entry.assumption.trim().toLowerCase() || 'unspecified'
+      : 'unspecified',
+  );
+  return [...new Set(derived)];
+}
+
+/**
+ * Named deployable roots a footprint spans (`apps/web`, `packages/core`, …).
+ * The repository root itself is deliberately **not** counted: a change to one
+ * app plus a root-level README is one deployable, not two.
+ *
+ * @param {string[]} paths
+ * @returns {string[]}
+ */
+function resolveDeployables(paths) {
+  const ids = new Set();
+  for (const p of paths) {
+    const segments = String(p)
+      .split('/')
+      .filter((s) => s !== '');
+    if (segments.length >= 3 && DEPLOYABLE_ROOTS.includes(segments[0])) {
+      ids.add(`${segments[0]}/${segments[1]}`);
+    }
+  }
+  return [...ids];
+}
+
+/**
+ * Does the footprint pair a schema migration with its consumers? A migration
+ * plus the code that reads through it is epic scope: the two have to land
+ * together and the ordering is the design work.
+ *
+ * @param {string[]} paths
+ * @returns {boolean}
+ */
+function spansMigrationAndConsumers(paths) {
+  const migrations = paths.filter((p) => MIGRATION_PATH_RE.test(String(p)));
+  return migrations.length > 0 && migrations.length < paths.length;
+}
+
+/**
+ * Ordered effort/risk rules, evaluated in order; the first hit is the recorded
+ * reason for a `full` route. Every rule names an effort, risk, or uncertainty
+ * property of the work — none counts artifacts.
+ *
+ * @type {ReadonlyArray<{
+ *   when: (shape: object, ceilings: typeof STORY_SHAPE_CEILINGS) => boolean,
+ *   reason: (shape: object, ceilings: typeof STORY_SHAPE_CEILINGS) => string,
+ * }>}
+ */
+const EFFORT_RULES = Object.freeze([
+  {
+    when: (s, c) => s.kindCount > c.maxChangeKinds,
+    reason: (s, c) =>
+      `${s.kindCount} distinct change kinds (${s.changeKinds.join(', ')}) > maxChangeKinds ${c.maxChangeKinds} — an explicit multi-capability enumeration, not one capability; full route`,
+  },
+  {
+    when: (s, c) =>
+      MAGNITUDE_SCALE.indexOf(s.magnitude) >
+      MAGNITUDE_SCALE.indexOf(c.maxMagnitude),
+    reason: (s, c) =>
+      `declared magnitude "${s.magnitude}" > maxMagnitude "${c.maxMagnitude}" — a substantial rewrite is effort a single inline pass should not absorb, however few files it touches; full route`,
+  },
+  {
+    when: (s, c) =>
+      UNCERTAINTY_SCALE.indexOf(s.uncertainty) >
+      UNCERTAINTY_SCALE.indexOf(c.maxUncertainty),
+    reason: (s) =>
+      `the shape is not determined by the request (uncertainty "${s.uncertainty}") — the design decisions /plan exists to resolve are still open; full route`,
+  },
+  {
+    when: (s, c) => s.deployables.length > c.maxDeployables,
+    reason: (s, c) =>
+      `footprint spans ${s.deployables.length} deployables (${s.deployables.join(', ')}) > maxDeployables ${c.maxDeployables} — clearly-epic scope; full route`,
+  },
+  {
+    when: (s) => s.migrationSpan,
+    reason: () =>
+      'footprint pairs a migration with its consumers — clearly-epic scope; full route',
+  },
+  {
+    when: (s) => s.sensitiveClasses.length > 0,
+    reason: (s) =>
+      `footprint intersects sensitive-path class(es) ${s.sensitiveClasses.join(', ')} — sensitivity wins over a small shape; full route (fresh acceptance critic retained)`,
+  },
+]);
+
+/**
+ * First effort/risk rule the shape violates, or `null` when it clears them all.
+ *
+ * @param {object} shape
+ * @param {typeof STORY_SHAPE_CEILINGS} ceilings
+ * @returns {string|null}
+ */
+function firstEffortViolation(shape, ceilings) {
+  for (const rule of EFFORT_RULES) {
+    if (rule.when(shape, ceilings)) return rule.reason(shape, ceilings);
+  }
+  return null;
+}
 
 /**
  * The non-negotiables the ceremony-lite path preserves (Story #4683 AC-2):
@@ -376,44 +563,98 @@ export function resolvePlannerRouteVerdict({ reason } = {}) {
 }
 
 /**
- * Derive the complexity route from an authored Story's **objective shape**
- * (Story #4722 AC-3/AC-4) — the single shape function persist's backstop and
- * `/deliver`'s dispatch derivation both read, so the two can never disagree
- * about the same body.
+ * Assemble the effort/risk shape of a footprint — the evidence
+ * {@link deriveStoryShape} decides on and carries on its result.
+ *
+ * @param {{
+ *   changes: unknown[],
+ *   paths: string[],
+ *   acceptance?: unknown,
+ *   kinds?: unknown,
+ *   magnitude?: unknown,
+ *   uncertainty?: unknown,
+ *   sensitiveClasses: string[],
+ * }} args
+ * @returns {{
+ *   siteCount: number,
+ *   changeKinds: string[],
+ *   kindCount: number,
+ *   magnitude: string,
+ *   uncertainty: string,
+ *   acceptanceCount: number,
+ *   deployables: string[],
+ *   migrationSpan: boolean,
+ *   sensitiveClasses: string[],
+ * }}
+ */
+function buildEffortShape({
+  changes,
+  paths,
+  acceptance,
+  kinds,
+  magnitude,
+  uncertainty,
+  sensitiveClasses,
+}) {
+  const changeKinds = resolveChangeKinds({ changes, kinds });
+  return {
+    siteCount: paths.length,
+    changeKinds,
+    kindCount: changeKinds.length,
+    magnitude: normalizeBucket(magnitude, MAGNITUDE_SCALE, 'moderate'),
+    uncertainty: normalizeBucket(uncertainty, UNCERTAINTY_SCALE, 'determined'),
+    acceptanceCount: Array.isArray(acceptance) ? acceptance.length : 0,
+    deployables: resolveDeployables(paths),
+    migrationSpan: spansMigrationAndConsumers(paths),
+    sensitiveClasses,
+  };
+}
+
+/**
+ * Derive the complexity route from an authored Story's **effort and risk**
+ * (Story #4722 AC-3/AC-4; re-anchored off artifact cardinality by Story #4764)
+ * — the single shape function persist's backstop and `/deliver`'s dispatch
+ * derivation both read, so the two can never disagree about the same body.
  *
  * `lite` requires **every** signal to agree, against
  * {@link STORY_SHAPE_CEILINGS}:
  *
- *   - a declared, parseable, glob-free `changes[]` footprint of at most
- *     `maxChanges` entries, at most `maxNonCreateChanges` of which touch
- *     existing surfaces (creates-vs-refactors mix);
- *   - at most `maxAcceptance` acceptance criteria (and at least one — a Story
- *     with no contract cannot be judged trivial);
+ *   - a declared, parseable, glob-free `changes[]` footprint — width is not
+ *     counted, but an unknown width cannot be judged;
+ *   - at least one acceptance criterion (a Story with no contract cannot be
+ *     judged trivial). The criteria are **not** capped: criterion count is
+ *     contract detail, not effort;
+ *   - at most `maxChangeKinds` distinct change kinds, magnitude no worse than
+ *     `maxMagnitude`, uncertainty no worse than `maxUncertainty`, and at most
+ *     `maxDeployables` deployable roots — plus no migration-with-consumers
+ *     span. These are the clearly-epic rejections, and nothing finer: the
+ *     declared footprint is a guess, so the diff-derived backstop does the real
+ *     enforcement (see {@link STORY_SHAPE_CEILINGS});
  *   - a footprint intersecting **no** sensitive-path class
  *     (`deriveChangeLevel`, the taxonomy close applies to the landed diff).
- *     Sensitivity always wins (AC-6): a sensitive footprint routes `full`,
- *     which keeps the fresh acceptance critic via `ceremony-routing.js`.
+ *     Sensitivity always wins (AC-6): a sensitive footprint routes `full`
+ *     however small or mechanical, which keeps the fresh acceptance critic via
+ *     `ceremony-routing.js`.
  *
- * Everything else — including an unknown/undeclared footprint or an
- * unreadable sensitive-path manifest — fails toward `full`. Total: never
- * throws.
+ * Everything else — an unknown/undeclared footprint, a malformed magnitude or
+ * uncertainty claim, or an unreadable sensitive-path manifest — fails toward
+ * `full`. Total: never throws.
  *
  * @param {{
  *   changes?: unknown,
  *   acceptance?: unknown,
+ *   kinds?: unknown,
+ *   magnitude?: unknown,
+ *   uncertainty?: unknown,
  *   injectedRules?: object,
  *   selectSensitivePathClassesFn?: Function,
- * }} [args]
+ * }} [args] `kinds` declares the distinct change kinds explicitly (absent, each
+ *   entry's `assumption` is its kind); `magnitude` and `uncertainty` are the
+ *   declared coarse buckets.
  * @returns {{
  *   route: ComplexityRoute,
  *   reasons: string[],
- *   shape: {
- *     changeCount: number,
- *     acceptanceCount: number,
- *     createCount: number,
- *     nonCreateCount: number,
- *     sensitiveClasses: string[],
- *   }|null,
+ *   shape: ReturnType<typeof buildEffortShape>|null,
  *   ceilings: typeof STORY_SHAPE_CEILINGS,
  *   preserves: typeof LITE_PATH_INVARIANTS,
  * }}
@@ -421,6 +662,9 @@ export function resolvePlannerRouteVerdict({ reason } = {}) {
 export function deriveStoryShape({
   changes,
   acceptance,
+  kinds,
+  magnitude,
+  uncertainty,
   injectedRules,
   selectSensitivePathClassesFn,
 } = {}) {
@@ -437,7 +681,7 @@ export function deriveStoryShape({
   if (!Array.isArray(changes) || changes.length === 0) {
     return decide(
       'full',
-      'no changes[] declared — the footprint is unknown, so the shape cannot be judged trivial; conservative full route',
+      'no changes[] declared — the footprint is unknown, so the work cannot be judged trivial; conservative full route',
     );
   }
 
@@ -451,35 +695,26 @@ export function deriveStoryShape({
     );
   }
 
-  const acceptanceList = Array.isArray(acceptance) ? acceptance : [];
-  const nonCreateCount = changes.filter(
-    (entry) =>
-      !(entry && typeof entry === 'object' && entry.assumption === 'creates'),
-  ).length;
+  const paths = entries.map((e) => e.path);
   const { level, classes } = deriveChangeLevel({
-    changedFiles: entries.map((e) => e.path),
+    changedFiles: paths,
     injectedRules,
     selectSensitivePathClassesFn,
   });
-  const shape = {
-    changeCount: changes.length,
-    acceptanceCount: acceptanceList.length,
-    createCount: changes.length - nonCreateCount,
-    nonCreateCount,
+  const shape = buildEffortShape({
+    changes,
+    paths,
+    acceptance,
+    kinds,
+    magnitude,
+    uncertainty,
     sensitiveClasses: classes,
-  };
+  });
 
   if (entries.some((e) => e.isGlob)) {
     return decide(
       'full',
       'changes[] contains a glob path — unknown footprint width; conservative full route',
-      shape,
-    );
-  }
-  if (shape.changeCount > ceilings.maxChanges) {
-    return decide(
-      'full',
-      `changes[] declares ${shape.changeCount} entries (> maxChanges ${ceilings.maxChanges}) — not a trivial footprint; full route`,
       shape,
     );
   }
@@ -490,27 +725,10 @@ export function deriveStoryShape({
       shape,
     );
   }
-  if (shape.acceptanceCount > ceilings.maxAcceptance) {
-    return decide(
-      'full',
-      `${shape.acceptanceCount} acceptance criteria (> maxAcceptance ${ceilings.maxAcceptance}) — more contract than a trivial scope carries; full route`,
-      shape,
-    );
-  }
-  if (shape.nonCreateCount > ceilings.maxNonCreateChanges) {
-    return decide(
-      'full',
-      `${shape.nonCreateCount} non-create change(s) (> maxNonCreateChanges ${ceilings.maxNonCreateChanges}) — a mostly-refactoring mix is not a trivial additive scope; full route`,
-      shape,
-    );
-  }
-  if (shape.sensitiveClasses.length > 0) {
-    return decide(
-      'full',
-      `footprint intersects sensitive-path class(es) ${shape.sensitiveClasses.join(', ')} — sensitivity wins over a small shape; full route (fresh acceptance critic retained)`,
-      shape,
-    );
-  }
+
+  const violation = firstEffortViolation(shape, ceilings);
+  if (violation !== null) return decide('full', violation, shape);
+
   if (level !== 'low') {
     // `deriveChangeLevel` degraded to its null fail-safe (unreadable
     // manifest / failed selector): there is no evidence the footprint is
@@ -524,7 +742,7 @@ export function deriveStoryShape({
 
   return decide(
     'lite',
-    `trivial shape: ${shape.changeCount} change(s) ≤ ${ceilings.maxChanges}, ${shape.acceptanceCount} acceptance criteria ≤ ${ceilings.maxAcceptance}, ${shape.nonCreateCount} non-create ≤ ${ceilings.maxNonCreateChanges}, no sensitive-path class — inline-eligible; non-negotiables preserved`,
+    `trivial shape: ${shape.kindCount} change kind(s) (${shape.changeKinds.join(', ')}) ≤ ${ceilings.maxChangeKinds} across ${shape.siteCount} site(s), magnitude ${shape.magnitude} ≤ ${ceilings.maxMagnitude}, shape ${shape.uncertainty}, no epic-scope span, no sensitive-path class — inline-eligible; non-negotiables preserved`,
     shape,
   );
 }

--- a/.agents/scripts/lib/orchestration/light-suitability.js
+++ b/.agents/scripts/lib/orchestration/light-suitability.js
@@ -22,7 +22,11 @@
  *      {@link module:lib/orchestration/complexity-gate.STORY_SHAPE_CEILINGS})
  *      **and** a ledgered model verdict carrying a recorded reason
  *      ({@link resolveLedgeredVerdict}). Both must agree on `lite`; either
- *      falling short fails closed to `full`.
+ *      falling short fails closed to `full`. The shape axes are effort and
+ *      risk — distinct change kinds, a coarse magnitude bucket, uncertainty,
+ *      and epic-scope span — never artifact counts (Story #4764), so this gate
+ *      is deliberately **coarse**: it rejects clearly-epic work, and invariant
+ *      3 below does the real enforcement against ground truth.
  *   2. **Over-scope stops, never silently proceeds ({@link
  *      resolveLightGateOutcome}).** An over-ceiling prompt does **not**
  *      hard-fail — it STOPS and asks the operator to escalate to `/plan` or
@@ -49,12 +53,13 @@ import { deriveChangeLevel } from './review-depth.js';
 
 /**
  * File-count ceiling for the **actual landed** change set the diff backstop
- * ({@link checkLightDiffBackstop}) enforces. The predicted-shape ceiling caps
- * `changes[]` at `maxChanges` (one artifact plus its test); the actual diff may
- * legitimately run a touch wider (a generated projection, a snapshot), but a
- * genuinely-light change stays small. Conservative by construction — a ceiling
- * an operator could widen past what a single session safely absorbs is a
- * ceiling that fails silently, so this is a framework constant, not a knob.
+ * ({@link checkLightDiffBackstop}) enforces. This is the light path's **only**
+ * cardinality ceiling, and deliberately so (Story #4764): the predicted
+ * footprint is a declaration — a guess, and a gameable one — so the gate that
+ * counts must be the one reading ground truth. A genuinely-light change stays
+ * small; conservative by construction, since a ceiling an operator could widen
+ * past what a single session safely absorbs is a ceiling that fails silently.
+ * A framework constant, not a knob.
  */
 export const LIGHT_DIFF_CEILINGS = Object.freeze({
   maxFiles: 4,
@@ -122,16 +127,27 @@ export function resolveLedgeredVerdict({ route, reason } = {}) {
 
 /**
  * Judge whether an operator prompt's predicted footprint is suitable for the
- * light path. The deterministic shape derivation and the ledgered model verdict
- * must **both** agree on `lite`; anything else — an over-ceiling shape, a
+ * light path. The deterministic effort/risk derivation and the ledgered model
+ * verdict must **both** agree on `lite`; anything else — clearly-epic work, a
  * sensitive-path footprint, an unledgered verdict — resolves to `full` (the
  * conservative default that routes the operator to `/plan`).
+ *
+ * The predicted axes are declared by the caller: `predictedKinds` (the distinct
+ * kinds of change; absent, each entry's `assumption` is its kind, so N
+ * instances of one mechanical edit count once), `predictedMagnitude`
+ * (`trivial` | `moderate` | `substantial`), and `predictedUncertainty`
+ * (`determined` | `needs-design`). A malformed bucket fails closed; an absent
+ * one carries no signal, because a marginal footprint must not be rejected on
+ * counts the diff backstop is the right place to enforce.
  *
  * Pure and total: never throws, never mutates its inputs.
  *
  * @param {{
  *   predictedChanges?: unknown,
  *   predictedAcceptance?: unknown,
+ *   predictedKinds?: unknown,
+ *   predictedMagnitude?: unknown,
+ *   predictedUncertainty?: unknown,
  *   verdict?: { route?: unknown, reason?: unknown },
  *   injectedRules?: object,
  *   selectSensitivePathClassesFn?: Function,
@@ -148,6 +164,9 @@ export function resolveLedgeredVerdict({ route, reason } = {}) {
 export function deriveLightSuitability({
   predictedChanges,
   predictedAcceptance,
+  predictedKinds,
+  predictedMagnitude,
+  predictedUncertainty,
   verdict,
   injectedRules,
   selectSensitivePathClassesFn,
@@ -156,6 +175,9 @@ export function deriveLightSuitability({
   const shape = deriveStoryShape({
     changes: predictedChanges,
     acceptance: predictedAcceptance,
+    kinds: predictedKinds,
+    magnitude: predictedMagnitude,
+    uncertainty: predictedUncertainty,
     injectedRules,
     selectSensitivePathClassesFn,
   });

--- a/.agents/workflows/helpers/deliver-light.md
+++ b/.agents/workflows/helpers/deliver-light.md
@@ -27,15 +27,36 @@ over-scope work silently.
 Two callers, one gate: whichever door you arrived through, the suitability gate
 below is the decision. A `/plan` Gate #1 suggestion is a *suggestion* — it is
 read against seed-time signals (`DELIVER_LIGHT_SUGGESTION_CEILINGS`: artifacts,
-risk hits, sensitive-path classes), while the gate here is read against a
-predicted *shape* (`STORY_SHAPE_CEILINGS`: `maxChanges`, `maxAcceptance`). They
-are deliberately two different checks, so the gate still runs after a confirm.
+risk hits, sensitive-path classes), while the gate here is read against the
+predicted work's *effort and risk* (`STORY_SHAPE_CEILINGS`: change kinds,
+magnitude, uncertainty, deployable span). They are deliberately two different
+checks, so the gate still runs after a confirm.
+
+## Scope by effort, not by artifact count {#scope-by-effort}
+
+**Counting the footprint is the wrong axis.** Three identical one-line edits
+across three files is trivial work with a high count; a 200-line rewrite of one
+module is a single change. The axes are therefore effort and risk: distinct
+change **kinds** (N instances of one mechanical edit is one kind at N sites), a
+coarse **magnitude** bucket, and **uncertainty** — is the shape determined by
+the request, or does it still need the design decisions `/plan` exists to
+resolve?
+
+Because the predicted footprint is a *declaration* — a guess, and a gameable one
+— this gate is deliberately **coarse**: it rejects clearly-epic work only
+(multiple deployables, a migration plus its consumers, an explicit
+multi-capability enumeration). Size is enforced where ground truth is available:
+the diff backstop in step 4. Do not talk yourself past that one.
+
+Sensitivity is the exception and stays absolute: a footprint touching an auth,
+crypto, billing, or migration class routes `full` however small or mechanical.
 
 ## Four invariants (do not skip one)
 
 1. **Suitability gate.** The prompt's predicted footprint is judged by the
-   shared shape machinery (`deriveStoryShape` / `deriveChangeLevel`) **and** a
-   ledgered model verdict with a recorded reason. Both must agree on `lite`.
+   shared effort/risk machinery (`deriveStoryShape` / `deriveChangeLevel`)
+   **and** a ledgered model verdict with a recorded reason. Both must agree on
+   `lite`.
 2. **Over-scope stops — it never hard-fails.** An over-ceiling prompt STOPS and
    asks the operator to escalate to `/plan` or proceed light. Under `--yes` it
    fails closed to an **`escalated` terminal envelope** that ends the session
@@ -50,12 +71,16 @@ are deliberately two different checks, so the gate still runs after a confirm.
 ## Procedure
 
 1. **Predict + gate.** Form the predicted footprint (new files, edited files,
-   acceptance count) and your ledgered verdict (a recorded reason for `lite`),
-   then run the gate:
+   acceptance count), judge its effort honestly (`--kinds` / `--magnitude` /
+   `--uncertainty`, per § Scope by effort), and record your ledgered verdict (a
+   recorded reason for `lite`), then run the gate — it documents every flag
+   itself, so run it with `--help` rather than guessing:
 
    ```bash
    node .agents/scripts/deliver-light.js --prompt "<prompt>" \
      --creates <csv> --refactors <csv> --acceptance <n> \
+     --kinds <csv> --magnitude trivial|moderate|substantial \
+     --uncertainty determined|needs-design \
      --route lite --reason "<why this is trivial>" [--amends '#<id>'] [--yes]
    ```
 
@@ -106,7 +131,8 @@ are deliberately two different checks, so the gate still runs after a confirm.
 
    Exit `3` (`blocked: true`) means the landed diff exceeds the light ceilings
    (file count or a sensitive-path class). STOP, flip `agent::blocked`, and
-   escalate to `/plan` — do not land.
+   escalate to `/plan` — do not land. This is the pass that actually bounds
+   size, which is why the prediction gate above can afford to be coarse.
 
 5. **Close and land (same engine).** Exactly [`/deliver`](../deliver.md)'s close:
 

--- a/.agents/workflows/helpers/plan-reference.md
+++ b/.agents/workflows/helpers/plan-reference.md
@@ -49,9 +49,9 @@ things make that safe, and both are worth understanding before changing it:
    suggestion that routed you.
 2. **The gate still runs.** The suggestion is read against seed-time ceilings
    (`DELIVER_LIGHT_SUGGESTION_CEILINGS` — artifacts, risk hits, sensitive-path
-   classes); the light gate is read against a predicted shape
-   (`STORY_SHAPE_CEILINGS` — `maxChanges`, `maxAcceptance`). Two different
-   checks on purpose, so a confirm is not a bypass.
+   classes); the light gate is read against the predicted work's effort and risk
+   (`STORY_SHAPE_CEILINGS` — change kinds, magnitude, uncertainty, deployable
+   span). Two different checks on purpose, so a confirm is not a bypass.
 
 **When the light gate answers `ask-operator`**, the two ceiling sets disagreed.
 Resume `/plan` at step 2 (Author) **in this same session** — the interrogation
@@ -85,9 +85,10 @@ decision:
   (`full`) stands.
 - **Persist backstops the claim deterministically.** After authoring, the
   work has measurable shape, so persist validates the `lite` claim against
-  each Story's own shape — `changes[]` count, acceptance-criteria count,
-  creates-vs-refactors mix, glob-free footprint, and sensitive-path classes,
-  against the framework `STORY_SHAPE_CEILINGS` — and **fails closed to
+  each Story's own shape — distinct change kinds, declared magnitude,
+  uncertainty, deployable/migration span, glob-free footprint, and
+  sensitive-path classes, against the framework `STORY_SHAPE_CEILINGS` (effort
+  and risk, never artifact counts) — and **fails closed to
   `full`** when any Story exceeds them (the refusal is ledgered on the
   checkpoint too). The lite route is **not** licence to drop a
   non-negotiable — every decision's `preserves` field enumerates what still

--- a/tests/lib/orchestration/complexity-gate.test.js
+++ b/tests/lib/orchestration/complexity-gate.test.js
@@ -156,26 +156,31 @@ describe('deriveStoryShape — the deterministic backstop (AC-1, AC-3)', () => {
     assert.equal(derived.route, 'lite');
     assert.match(derived.reasons[0], /trivial shape/i);
     assert.deepEqual(derived.shape, {
-      changeCount: 1,
+      siteCount: 1,
+      changeKinds: ['creates'],
+      kindCount: 1,
+      magnitude: 'moderate',
+      uncertainty: 'determined',
       acceptanceCount: 1,
-      createCount: 1,
-      nonCreateCount: 0,
+      deployables: [],
+      migrationSpan: false,
       sensitiveClasses: [],
     });
   });
 
-  test('AC-1: a terse Story with a wide footprint derives full — words never route', () => {
-    // Five changes, described tersely: word count would call this trivial.
+  test('AC-1: a terse Story with clearly-epic scope derives full — words never route', () => {
+    // Two deployables behind a shared contract, described in three words:
+    // word count would call this trivial.
     const derived = deriveStoryShape({
-      changes: ['a.js', 'b.js', 'c.js', 'd.js', 'e.js'].map((p) => ({
-        path: `src/${p}`,
-        assumption: 'refactors-existing',
-      })),
+      changes: [
+        { path: 'apps/api/src/handler.js', assumption: 'refactors-existing' },
+        { path: 'apps/web/src/page.js', assumption: 'refactors-existing' },
+      ],
       acceptance: ['works'],
       injectedRules: RULES,
     });
     assert.equal(derived.route, 'full');
-    assert.match(derived.reasons[0], /> maxChanges/);
+    assert.match(derived.reasons[0], /> maxDeployables/);
   });
 
   test('AC-1: a verbose-but-trivial Story derives lite — prose length is not shape', () => {
@@ -193,26 +198,26 @@ describe('deriveStoryShape — the deterministic backstop (AC-1, AC-3)', () => {
     assert.equal(decision.mode, 'inline');
   });
 
-  test('exceeding the acceptance-criteria ceiling fails to full', () => {
+  test('Story #4764: criterion count is contract detail, not effort — it no longer routes', () => {
     const derived = deriveStoryShape({
       ...TRIVIAL,
-      acceptance: ['a', 'b', 'c', 'd'],
+      acceptance: ['a', 'b', 'c', 'd', 'e'],
     });
-    assert.equal(derived.route, 'full');
-    assert.match(derived.reasons[0], /> maxAcceptance/);
+    assert.equal(derived.route, 'lite');
   });
 
-  test('a mostly-refactoring mix fails to full (creates-vs-refactors)', () => {
+  test('more distinct change KINDS than the ceiling fails to full', () => {
     const derived = deriveStoryShape({
       changes: [
         { path: 'src/one.js', assumption: 'refactors-existing' },
         { path: 'src/two.js', assumption: 'deletes' },
+        { path: 'src/three.js', assumption: 'creates' },
       ],
       acceptance: ['works'],
       injectedRules: RULES,
     });
     assert.equal(derived.route, 'full');
-    assert.match(derived.reasons[0], /> maxNonCreateChanges/);
+    assert.match(derived.reasons[0], /> maxChangeKinds/);
   });
 
   test('an unknown footprint is conservative full: empty, missing, glob, or unreadable', () => {
@@ -246,11 +251,207 @@ describe('deriveStoryShape — the deterministic backstop (AC-1, AC-3)', () => {
     const derived = deriveStoryShape(TRIVIAL);
     assert.ok(Object.isFrozen(derived.ceilings));
     assert.deepEqual(derived.ceilings, {
-      maxChanges: 2,
-      maxAcceptance: 3,
-      maxNonCreateChanges: 1,
+      maxChangeKinds: 2,
+      maxMagnitude: 'moderate',
+      maxUncertainty: 'determined',
+      maxDeployables: 1,
     });
     assert.equal(deriveStoryShape({}).ceilings, derived.ceilings);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Story #4764 — effort and risk, never artifact cardinality
+// ---------------------------------------------------------------------------
+// The old ceilings counted the DECLARED footprint (maxChanges / maxAcceptance /
+// maxNonCreateChanges). Cardinality gets triviality backwards in both
+// directions, and the count is read off a guess the model makes before doing
+// the work. These describes pin the replacement axes and — as load-bearing as
+// the new rejections — pin that marginal small work is no longer rejected.
+
+describe('effort, not artifact count (Story #4764 AC-1)', () => {
+  test('three instances of ONE mechanical edit across three files is light', () => {
+    // The case counting got backwards: high file count, trivial work. One kind
+    // at three sites, so one kind.
+    const derived = deriveStoryShape({
+      changes: [
+        { path: 'src/a.js', assumption: 'refactors-existing' },
+        { path: 'src/b.js', assumption: 'refactors-existing' },
+        { path: 'src/c.js', assumption: 'refactors-existing' },
+      ],
+      acceptance: ['every call site passes the new flag'],
+      kinds: ['add-flag-to-call-site'],
+      magnitude: 'trivial',
+      injectedRules: RULES,
+    });
+    assert.equal(derived.route, 'lite');
+    assert.equal(derived.shape.kindCount, 1);
+    assert.equal(derived.shape.siteCount, 3);
+  });
+
+  test('an explicit kinds[] declaration is unnecessary — assumptions collapse to kinds', () => {
+    const derived = deriveStoryShape({
+      changes: ['a', 'b', 'c', 'd'].map((p) => ({
+        path: `src/${p}.js`,
+        assumption: 'refactors-existing',
+      })),
+      acceptance: ['works'],
+      injectedRules: RULES,
+    });
+    assert.equal(derived.route, 'lite');
+    assert.deepEqual(derived.shape.changeKinds, ['refactors-existing']);
+  });
+
+  test('a single SUBSTANTIAL rewrite of one file is NOT light — the other direction', () => {
+    const derived = deriveStoryShape({
+      changes: [{ path: 'src/reporting.js', assumption: 'refactors-existing' }],
+      acceptance: ['the report renders identically'],
+      magnitude: 'substantial',
+      injectedRules: RULES,
+    });
+    assert.equal(derived.route, 'full');
+    assert.match(derived.reasons[0], /maxMagnitude/);
+  });
+
+  test('undeclared magnitude carries no signal; a malformed one fails closed', () => {
+    const absent = deriveStoryShape({ ...TRIVIAL, magnitude: undefined });
+    assert.equal(absent.route, 'lite');
+    assert.equal(absent.shape.magnitude, 'moderate');
+
+    // Declared but unrecognized is a claim that cannot be verified as small,
+    // so it takes the worst bucket on the scale rather than the default.
+    for (const magnitude of ['enormous', 42, {}]) {
+      assert.equal(
+        deriveStoryShape({ ...TRIVIAL, magnitude }).route,
+        'full',
+        `magnitude ${JSON.stringify(magnitude)}`,
+      );
+    }
+    // Case and padding are normalized, never rejected.
+    assert.equal(
+      deriveStoryShape({ ...TRIVIAL, magnitude: ' TRIVIAL ' }).route,
+      'lite',
+    );
+  });
+
+  test('open design decisions route full however small the footprint', () => {
+    const derived = deriveStoryShape({
+      ...TRIVIAL,
+      uncertainty: 'needs-design',
+    });
+    assert.equal(derived.route, 'full');
+    assert.match(
+      derived.reasons[0],
+      /design decisions \/plan exists to resolve/,
+    );
+  });
+});
+
+describe('the prediction gate rejects only clearly-epic work (Story #4764 AC-3)', () => {
+  test('marginal small work is no longer rejected on counts alone', () => {
+    // Five files, four acceptance criteria, all refactors: over EVERY retired
+    // ceiling (maxChanges 2, maxAcceptance 3, maxNonCreateChanges 1) and yet
+    // plainly not epic.
+    const derived = deriveStoryShape({
+      changes: ['a', 'b', 'c', 'd', 'e'].map((p) => ({
+        path: `src/widgets/${p}.js`,
+        assumption: 'refactors-existing',
+      })),
+      acceptance: ['a works', 'b works', 'c works', 'd works'],
+      injectedRules: RULES,
+    });
+    assert.equal(derived.route, 'lite');
+  });
+
+  const epicShapes = [
+    {
+      name: 'multiple deployables',
+      args: {
+        changes: [
+          { path: 'apps/web/src/page.js', assumption: 'refactors-existing' },
+          {
+            path: 'services/sync/src/job.js',
+            assumption: 'refactors-existing',
+          },
+        ],
+        acceptance: ['both sides agree'],
+      },
+      reason: /maxDeployables/,
+    },
+    {
+      name: 'a migration plus its consumers',
+      args: {
+        changes: [
+          { path: 'db/migrations/0007_add_column.sql', assumption: 'creates' },
+          { path: 'src/reports/query.js', assumption: 'refactors-existing' },
+        ],
+        acceptance: ['the report reads the new column'],
+      },
+      reason: /migration with its consumers/,
+    },
+    {
+      name: 'an explicit multi-capability enumeration',
+      args: {
+        changes: [
+          { path: 'src/one.js', assumption: 'creates' },
+          { path: 'src/two.js', assumption: 'refactors-existing' },
+          { path: 'src/three.js', assumption: 'refactors-existing' },
+        ],
+        acceptance: ['all three capabilities work'],
+        kinds: ['new-endpoint', 'schema-widening', 'telemetry-rename'],
+      },
+      reason: /multi-capability enumeration/,
+    },
+  ];
+
+  for (const { name, args, reason } of epicShapes) {
+    test(`${name} still escalates`, () => {
+      const derived = deriveStoryShape({ ...args, injectedRules: RULES });
+      assert.equal(derived.route, 'full');
+      assert.match(derived.reasons[0], reason);
+    });
+  }
+});
+
+describe('the benchmark rungs land on the right side (Story #4764 AC-5, AC-6)', () => {
+  test('AC-5: the hello-world scenario is light — one create, one edit, one test, 4 criteria', () => {
+    const derived = deriveStoryShape({
+      changes: [
+        { path: 'src/server.js', assumption: 'creates' },
+        { path: 'package.json', assumption: 'refactors-existing' },
+        { path: 'tests/server.test.js', assumption: 'creates' },
+      ],
+      acceptance: [
+        'GET / returns 200',
+        'the response body is "hello world"',
+        'the server listens on the configured port',
+        'npm test passes',
+      ],
+      magnitude: 'trivial',
+      injectedRules: RULES,
+    });
+    assert.equal(
+      derived.route,
+      'lite',
+      'the trivial bench rung must no longer sit structurally over the ceiling',
+    );
+  });
+
+  test('AC-6: the epic-scope scenario still escalates — deployables behind a shared contract', () => {
+    const derived = deriveStoryShape({
+      changes: [
+        { path: 'packages/contract/src/schema.js', assumption: 'creates' },
+        { path: 'apps/api/src/handler.js', assumption: 'refactors-existing' },
+        {
+          path: 'apps/worker/src/consumer.js',
+          assumption: 'refactors-existing',
+        },
+      ],
+      acceptance: ['both deployables validate against the shared contract'],
+      injectedRules: RULES,
+    });
+    assert.equal(derived.route, 'full');
+    assert.match(derived.reasons[0], /deployables/);
   });
 });
 
@@ -297,12 +498,14 @@ describe('resolveStoryDispatchMode — body-derived dispatch (AC-4, AC-5)', () =
     changes: [{ path: 'bin/hello.js', assumption: 'creates' }],
     acceptance: ['prints hello'],
   });
+  // Full-shaped by EFFORT, not by count (Story #4764): two deployables is
+  // clearly-epic scope however few files each side touches.
   const fullBody = storyBody({
-    changes: ['a', 'b', 'c'].map((p) => ({
-      path: `src/${p}.js`,
-      assumption: 'refactors-existing',
-    })),
-    acceptance: ['a works', 'b works', 'c works'],
+    changes: [
+      { path: 'apps/api/src/handler.js', assumption: 'refactors-existing' },
+      { path: 'apps/web/src/page.js', assumption: 'refactors-existing' },
+    ],
+    acceptance: ['both sides agree'],
   });
 
   test('AC-5: a lite-shaped Story executes inline with the route::lite label ABSENT', () => {
@@ -392,10 +595,10 @@ describe('resolveStoryDispatchMode — body-derived dispatch (AC-4, AC-5)', () =
  */
 describe('resolveStoryDispatchMode — run topology (Story #4736)', () => {
   const fullBody = storyBody({
-    changes: ['a', 'b', 'c', 'd'].map((p) => ({
-      path: `src/${p}.js`,
-      assumption: 'refactors-existing',
-    })),
+    changes: [
+      { path: 'apps/api/src/handler.js', assumption: 'refactors-existing' },
+      { path: 'apps/web/src/page.js', assumption: 'refactors-existing' },
+    ],
     acceptance: ['a works', 'b works', 'c works', 'd works'],
   });
   const sensitiveBody = storyBody({
@@ -586,17 +789,17 @@ describe('persist ↔ deliver route round-trip — one shape, two read points', 
       expectedMode: 'inline',
     },
     {
-      name: 'a refactor-mix Story routes full from both representations',
+      name: 'an epic-scope Story routes full from both representations',
       ticket: {
         slug: 'full-round-trip',
         type: 'story',
-        title: 'Refactor two modules',
+        title: 'Refactor two deployables',
         body: storyBody({
           changes: [
-            { path: 'src/one.js', assumption: 'refactors-existing' },
-            { path: 'src/two.js', assumption: 'refactors-existing' },
+            { path: 'apps/api/src/one.js', assumption: 'refactors-existing' },
+            { path: 'apps/web/src/two.js', assumption: 'refactors-existing' },
           ],
-          acceptance: ['both modules keep their contracts'],
+          acceptance: ['both deployables keep their contracts'],
         }),
       },
       expectedRoute: 'full',

--- a/tests/lib/orchestration/light-suitability.test.js
+++ b/tests/lib/orchestration/light-suitability.test.js
@@ -25,6 +25,14 @@
 //           — it moved under helpers/ so `/deliver` is the one delivery door;
 //   - AC-8: the light entry contains no parallel init/close implementation.
 //
+// Story #4764 re-anchors the suitability gate on effort and risk — distinct
+// change kinds, a coarse magnitude bucket, uncertainty, and epic-scope span —
+// instead of artifact cardinality, and makes the PREDICTION gate coarse: it
+// rejects clearly-epic work only, because the declared footprint is a guess and
+// the diff backstop is the pass that sees ground truth. The invariants above are
+// unchanged; the fixtures that used to be over-scope by count are now over-scope
+// by effort.
+//
 // Story #4746 makes the escalate-plan OUTCOME terminal rather than advisory.
 // The gate's decision is untouched (the describes above still pass verbatim);
 // what is new is that over-scope under --yes emits a schema-validated
@@ -133,12 +141,11 @@ describe('deriveLightSuitability — shape + ledgered verdict must agree (AC-2)'
     assert.equal(s.ledger.route, 'lite');
   });
 
-  test('an over-ceiling predicted footprint is not suitable (shape wins)', () => {
+  test('a clearly-epic predicted footprint is not suitable (shape wins)', () => {
     const s = deriveLightSuitability({
       predictedChanges: [
-        { path: 'a.js', assumption: 'refactors-existing' },
-        { path: 'b.js', assumption: 'refactors-existing' },
-        { path: 'c.js', assumption: 'refactors-existing' },
+        { path: 'apps/api/src/a.js', assumption: 'refactors-existing' },
+        { path: 'apps/web/src/b.js', assumption: 'refactors-existing' },
       ],
       predictedAcceptance: ['does a', 'does b', 'does c', 'does d'],
       verdict: LITE_VERDICT,
@@ -147,6 +154,79 @@ describe('deriveLightSuitability — shape + ledgered verdict must agree (AC-2)'
     assert.equal(s.suitable, false);
     assert.equal(s.route, 'full');
     assert.equal(s.shape.route, 'full');
+  });
+
+  // Story #4764 — the predicted axes are effort and risk, and the gate over
+  // them is coarse: it rejects clearly-epic work, not marginal small work.
+  test('AC-1: three instances of one mechanical edit are suitable; a substantial rewrite is not', () => {
+    const mechanical = deriveLightSuitability({
+      predictedChanges: ['a', 'b', 'c'].map((p) => ({
+        path: `src/${p}.js`,
+        assumption: 'refactors-existing',
+      })),
+      predictedAcceptance: ['every call site passes the new flag'],
+      predictedKinds: ['add-flag-to-call-site'],
+      predictedMagnitude: 'trivial',
+      verdict: LITE_VERDICT,
+      injectedRules: RULES,
+    });
+    assert.equal(mechanical.suitable, true);
+
+    const rewrite = deriveLightSuitability({
+      predictedChanges: [
+        { path: 'src/reporting.js', assumption: 'refactors-existing' },
+      ],
+      predictedAcceptance: ['the report renders identically'],
+      predictedMagnitude: 'substantial',
+      verdict: LITE_VERDICT,
+      injectedRules: RULES,
+    });
+    assert.equal(rewrite.suitable, false);
+  });
+
+  test('AC-3: marginal small work is no longer rejected on counts alone', () => {
+    const s = deriveLightSuitability({
+      predictedChanges: ['a', 'b', 'c', 'd', 'e'].map((p) => ({
+        path: `src/widgets/${p}.js`,
+        assumption: 'refactors-existing',
+      })),
+      predictedAcceptance: ['a', 'b', 'c', 'd'],
+      verdict: LITE_VERDICT,
+      injectedRules: RULES,
+    });
+    assert.equal(
+      s.suitable,
+      true,
+      'over every retired count ceiling, yet plainly not epic',
+    );
+  });
+
+  test('AC-5: the benchmark hello-world footprint is suitable', () => {
+    const s = deriveLightSuitability({
+      predictedChanges: [
+        { path: 'src/server.js', assumption: 'creates' },
+        { path: 'package.json', assumption: 'refactors-existing' },
+        { path: 'tests/server.test.js', assumption: 'creates' },
+      ],
+      predictedAcceptance: ['200', 'hello world', 'port', 'npm test passes'],
+      predictedMagnitude: 'trivial',
+      verdict: LITE_VERDICT,
+      injectedRules: RULES,
+    });
+    assert.equal(s.suitable, true);
+  });
+
+  test('AC-6: the benchmark epic-scope footprint is not suitable', () => {
+    const s = deriveLightSuitability({
+      predictedChanges: [
+        { path: 'packages/contract/src/schema.js', assumption: 'creates' },
+        { path: 'apps/api/src/handler.js', assumption: 'refactors-existing' },
+      ],
+      predictedAcceptance: ['both deployables honour the shared contract'],
+      verdict: LITE_VERDICT,
+      injectedRules: RULES,
+    });
+    assert.equal(s.suitable, false);
   });
 
   test('a sensitive-path footprint is not suitable even when small', () => {
@@ -248,6 +328,31 @@ describe('checkLightDiffBackstop — blocks over-ceiling actual diffs (AC-4)', (
     });
     assert.equal(r.blocked, true);
     assert.deepEqual(r.classes, ['security']);
+  });
+
+  test('AC-4 (Story #4764): relaxing the PREDICTION gate cannot land oversized work', () => {
+    // The same five same-kind files the prediction gate now admits: the
+    // backstop reads ground truth, so it still refuses to land them. This pair
+    // is the whole trade — coarse prediction, strict diff.
+    const files = ['a', 'b', 'c', 'd', 'e'].map((p) => `src/widgets/${p}.js`);
+    assert.equal(
+      deriveLightSuitability({
+        predictedChanges: files.map((path) => ({
+          path,
+          assumption: 'refactors-existing',
+        })),
+        predictedAcceptance: ['works'],
+        verdict: LITE_VERDICT,
+        injectedRules: RULES,
+      }).suitable,
+      true,
+    );
+    const backstop = checkLightDiffBackstop({
+      changedFiles: files,
+      injectedRules: RULES,
+    });
+    assert.equal(backstop.blocked, true);
+    assert.match(backstop.reasons.join(' '), /maxFiles/);
   });
 
   test('an empty or unknown change set is blocked (cannot verify light)', () => {
@@ -386,6 +491,34 @@ describe('runLightGate — end-to-end gate over the entry inputs (AC-3, AC-6)', 
     assert.equal(gate.action, 'proceed-light');
   });
 
+  test('the effort flags reach the gate: one kind at three sites proceeds', () => {
+    const gate = runLightGate({
+      prompt: 'pass the new flag at every call site',
+      refactors: ['src/a.js', 'src/b.js', 'src/c.js'],
+      acceptance: 2,
+      kinds: ['add-flag-to-call-site'],
+      magnitude: 'trivial',
+      uncertainty: 'determined',
+      route: 'lite',
+      reason: 'one mechanical edit repeated',
+      injectedRules: RULES,
+    });
+    assert.equal(gate.action, 'proceed-light');
+  });
+
+  test('the effort flags reach the gate: open design decisions ask the operator', () => {
+    const gate = runLightGate({
+      prompt: 'make the counter configurable somehow',
+      refactors: ['src/counter.js'],
+      acceptance: 1,
+      uncertainty: 'needs-design',
+      route: 'lite',
+      reason: 'one file, but the shape is not decided',
+      injectedRules: RULES,
+    });
+    assert.equal(gate.action, 'ask-operator');
+  });
+
   test('--amends: a HEAVY amendment escalates to /plan under --yes', () => {
     const gate = runLightGate({
       prompt: 'amend: overhaul auth and add a migration',
@@ -501,12 +634,13 @@ describe('deliver-light.js is a thin entry point, not a second engine (AC-8)', (
 // Story #4746 — escalation is TERMINAL, not advisory
 // ---------------------------------------------------------------------------
 
-/** Over-scope gate inputs: 7 predicted changes against a maxChanges of 2. */
+/**
+ * Over-scope gate inputs: a footprint spanning two deployables, which is
+ * clearly-epic scope by effort rather than by count (Story #4764).
+ */
 const OVER_SCOPE = {
   prompt: 'rework the whole reporting pipeline end to end',
-  refactors: Array.from({ length: 7 }, (_v, i) => `src/report/mod${i}.js`).join(
-    ',',
-  ),
+  refactors: 'apps/api/src/report.js,apps/web/src/report.js',
   acceptance: '5',
   route: 'lite',
   reason: 'claims small but is not',
@@ -569,7 +703,7 @@ describe('escalate-plan emits a terminal envelope and exits non-zero (AC-1)', ()
   test('the gate reasons survive verbatim into the envelope', async () => {
     const { terminals } = await driveGate({ ...OVER_SCOPE, yes: true });
     const reasons = terminals[0].escalation.reasons.join(' ');
-    assert.match(reasons, /maxChanges/);
+    assert.match(reasons, /maxDeployables/);
     assert.match(reasons, /--yes on over-scope fails closed to \/plan/);
   });
 });
@@ -730,6 +864,44 @@ describe('the workflow states escalation is terminal (AC-3)', () => {
       doc,
       /no receipt Story, no `story-<id>` branch, and no worktree/i,
       'the workflow must name all three artifacts an escalated run does not create',
+    );
+  });
+});
+
+describe('the workflow scopes by effort, not artifact count (Story #4764)', () => {
+  const doc = readDoc(
+    path.join(REPO_ROOT, '.agents', 'workflows', 'helpers', 'deliver-light.md'),
+  );
+
+  test('names the axes and rejects the cardinality reading in so many words', () => {
+    assertDocMentions(
+      doc,
+      /Counting the footprint is the wrong axis/i,
+      'the workflow must say outright that counting artifacts is the wrong axis',
+    );
+    assertDocMentions(doc, /change \*\*kinds\*\*/i);
+    assertDocMentions(doc, /magnitude/i);
+    assertDocMentions(doc, /uncertainty/i);
+  });
+
+  test('states the gate is coarse and names where size is really enforced', () => {
+    assertDocMentions(
+      doc,
+      /deliberately \*\*coarse\*\*: it rejects clearly-epic work only/i,
+      'a reader must know the prediction gate is not the size guard',
+    );
+    assertDocMentions(
+      doc,
+      /Size is enforced where ground truth is available/i,
+      'the doc must point at the diff backstop as the real enforcement',
+    );
+  });
+
+  test('keeps the sensitivity hard gate stated as absolute', () => {
+    assertDocMentions(
+      doc,
+      /Sensitivity is the exception and stays absolute/i,
+      'relaxing the count ceilings must not read as relaxing sensitivity',
     );
   });
 });

--- a/tests/scripts/plan-persist.flat-stories.test.js
+++ b/tests/scripts/plan-persist.flat-stories.test.js
@@ -858,19 +858,28 @@ describe('runPlanPersist — flat Story ops', () => {
 
 describe('runPlanPersist — shape-validated lite route (Story #4722)', () => {
   /**
-   * A ticket whose shape exceeds the lite ceilings: four refactors-existing
-   * changes (paths that exist at main, so the file-assumption gate passes)
-   * against a single acceptance criterion.
+   * A ticket whose shape exceeds the lite ceilings. Since Story #4764 the
+   * ceilings are effort/risk rather than counts, so "wide" here means an
+   * explicit multi-capability enumeration — three distinct change kinds
+   * (refactor, delete, create) — not merely several files. Existing paths carry
+   * the assumptions that require them to exist, so the file-assumption gate
+   * still passes.
    */
   function wideTicket(slug) {
     const acceptance = [`${slug} done`];
     const verify = ['npm test (validate)'];
     const changes = [
-      'tests/scripts/plan-persist.flat-stories.test.js',
-      '.agents/scripts/lib/orchestration/complexity-gate.js',
-      'README.md',
-      'package.json',
-    ].map((path) => ({ path, assumption: 'refactors-existing' }));
+      {
+        path: 'tests/scripts/plan-persist.flat-stories.test.js',
+        assumption: 'refactors-existing',
+      },
+      {
+        path: '.agents/scripts/lib/orchestration/complexity-gate.js',
+        assumption: 'refactors-existing',
+      },
+      { path: 'README.md', assumption: 'deletes' },
+      { path: 'docs/wide-fixture-note.md', assumption: 'creates' },
+    ];
     return {
       slug,
       type: 'story',

--- a/tests/scripts/resolve-stories.test.js
+++ b/tests/scripts/resolve-stories.test.js
@@ -313,8 +313,10 @@ describe('buildStoriesEnvelope — per-Story dispatchMode (Story #4722)', () => 
   });
 
   it('AC-4/AC-5: the route::lite label never routes — a full-shaped body dispatches subagent', () => {
+    // Full-shaped by EFFORT since Story #4764: two deployables is clearly-epic
+    // scope, where a mere file count no longer routes anything.
     const wide = storyBody({
-      changes: ['src/a.js', 'src/b.js', 'src/c.js', 'src/d.js'],
+      changes: ['apps/api/src/a.js', 'apps/web/src/b.js'],
     });
     const env = buildStoriesEnvelope({
       stories: [
@@ -366,8 +368,9 @@ describe('buildStoriesEnvelope — per-Story dispatchMode (Story #4722)', () => 
  * axis back in charge.
  */
 describe('buildStoriesEnvelope — single-Story runs dispatch inline (Story #4736)', () => {
+  // Full-shaped by effort (two deployables), not by file count — Story #4764.
   const wideBody = storyBody({
-    changes: ['src/a.js', 'src/b.js', 'src/c.js', 'src/d.js'],
+    changes: ['apps/api/src/a.js', 'apps/web/src/b.js'],
   });
 
   it('AC-1: a one-Story run is inline even for a full-shaped Story', () => {


### PR DESCRIPTION
Closes #4764

_Auto-opened by `/deliver`._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Routing and persist backstop logic for plan/deliver/light paths change materially; mistaken effort classification could admit epic work at prediction time, though diff backstop and sensitive-path rules still constrain landing.
> 
> **Overview**
> **Re-anchors `STORY_SHAPE_CEILINGS` and `deriveStoryShape` on effort and risk instead of declared footprint counts** (`maxChanges`, `maxAcceptance`, `maxNonCreateChanges` are gone). Lite eligibility now uses distinct change **kinds** (N same-shaped edits collapse to one kind), coarse **magnitude** and **uncertainty** buckets, **deployable** span, migration-plus-consumer pairing, and unchanged sensitive-path rules; acceptance criteria are required but no longer capped.
> 
> **`/deliver-light` gains `--kinds`, `--magnitude`, and `--uncertainty`** and passes them through `runLightGate` / `deriveLightSuitability`, with help text stating the prediction gate is coarse and **`--backstop` enforces size on the real diff** (`LIGHT_DIFF_CEILINGS.maxFiles` remains the only cardinality ceiling there).
> 
> **Workflow docs** (`deliver-light.md`, `plan-reference.md`) explain scope-by-effort, the coarse-vs-backstop split, and updated gate flags.
> 
> **Tests** are updated across `complexity-gate`, `light-suitability`, `plan-persist`, and `resolve-stories` so “full” fixtures use epic effort signals (e.g. two deployables) rather than high file counts, plus new Story #4764 coverage for bench scenarios and prediction-vs-backstop tradeoffs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 168f1939200821b8093834d30fa78f905f13d8c2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->