### PR TITLE
feat: add an operator-invoked /prototype command and an advisory UI-surface offer from /plan (#4765)

### DIFF
--- a/.agents/docs/workflows.md
+++ b/.agents/docs/workflows.md
@@ -32,7 +32,7 @@ by `node .agents/scripts/generate-workflows-doc.js`; `npm run docs:check`
 fails when it drifts from the on-disk workflow set. To change a command’s
 description, edit the workflow file’s front-matter and regenerate.
 
-## Commands (24)
+## Commands (25)
 
 | Command | Description |
 | --- | --- |
@@ -57,6 +57,7 @@ description, edit the workflow file’s front-matter and regenerate.
 | `/git-deliver` | Single ad-hoc delivery command for working-tree changes. Detects the git setup and escalates to the right terminal step — commit only, commit + push, or commit + push + open a PR with native auto-merge — picking the default from observable state and letting flags pin any level explicitly. Replaces the retired git-commit-all, git-push, and git-pr-all trio. |
 | `/mandrel-update` | npm-era upgrade wraparound for a Mandrel consumer. Runs `npx mandrel update` (resolve newest published version → install → re-materialize `.agents/` → migrate → doctor → surface changelog) as the single mechanical step, then walks the operator through the judgment wraparound the CLI deliberately leaves unowned: reconcile `.agentrc.json`, install the stabilized quality-gate surface, refresh the harness permission allowlist, reconcile the consumer's `AGENTS.md` / runbooks against the surfaced changelog, and stage + commit the staged lockfile bump. |
 | `/plan` | Unified planning entry point. Interrogate → author → persist. Emits one Story by default; splits into N>1 only under the default-single split policy. |
+| `/prototype` | Operator-invoked UI prototype pass. Discovers the consumer's design-system SSOT first, then — only after the operator confirms — writes exactly one self-contained HTML file under the gitignored workspace-root temp tree, so a layout can be reviewed before its UI acceptance criteria are authored. |
 | `/qa-assist` | Human-led QA assist loop — set up, then ride a rolling multi-observation intake session. The operator reports observations in any order; the agent enriches each (repro + root-cause file:line + coverage verdict for bugs; analysis + options + recommendation for enhancements), asks clarifying questions only when ambiguous, and appends a redacted ledger item — recording, never planning — to a persistent, resumable session under temp/qa/. Only when the operator says they are done does it review the full ledger and hand off to /plan. |
 | `/qa-explore` | Agent-led exploratory-QA loop — the agent Plans a surface with an explicit static-vs-drive method choice, drives it (browser MCP or static), and captures ledger items read-only, then Triages — a bounded per-surface session, HITL-gated at every phase transition, routed through the shared dedup/coverage/classification/missing-test/redaction/session core under temp/qa/ |
 | `/qa-run` | Drive Gherkin scenarios through a real browser as an agent-driven QA sweep |

--- a/.agents/scripts/lib/orchestration/plan-context.js
+++ b/.agents/scripts/lib/orchestration/plan-context.js
@@ -18,6 +18,11 @@
  */
 
 import { readFile } from 'node:fs/promises';
+import { readAuditRulesSync } from '../audit-suite/audit-rules-reader.js';
+import {
+  hasWebSurface,
+  matchesAnyFilePattern,
+} from '../audit-suite/selector.js';
 import { getLimits } from '../config-resolver.js';
 import { findSimilarOpenStories } from '../duplicate-search.js';
 import { Logger } from '../Logger.js';
@@ -449,18 +454,189 @@ export function buildDeliverLightSuggestion(complexitySignals) {
 }
 
 /**
- * Attach the advisory light-path suggestion to a complexity-signals bag
- * as a **nested** field (Story #4741). Nesting — rather than a new top-level
- * envelope key — keeps every existing per-mode envelope key set byte-stable
- * (AC-5): the suggestion is derived from the signals it rides on.
+ * The `audit-rules.json` lens `target` value marking a lens applicable only to
+ * a project with a rendered frontend.
+ */
+const WEB_LENS_TARGET = 'web';
+
+/**
+ * How many matched UI paths the `uiSurface` signal carries. The signal rides the
+ * `--out` stdout digest, which has a ~2KB contract, and a seed can predict up to
+ * `MAX_PREDICTED_PATHS` paths — enumerating all of them would let one UI-heavy
+ * seed blow that budget. The full count travels beside the sample as
+ * `matchedPathCount`, so nothing is silently lost.
+ */
+const UI_MATCHED_PATH_SAMPLE = 5;
+
+/**
+ * Union of the `triggers.filePatterns` globs every `target: "web"` lens
+ * registers in `audit-rules.json` — the framework's shipped declaration of
+ * "this path is part of a rendered UI surface". Read from the manifest rather
+ * than re-listed here: a second copy of the glob set would be a second thing to
+ * keep in sync, and the manifest is already the place an operator extends it.
+ *
+ * @param {{ audits?: Record<string, object> }} rules
+ * @returns {string[]} Deduplicated globs, in manifest order.
+ */
+function resolveWebFilePatterns(rules) {
+  const patterns = new Set();
+  for (const entry of Object.values(rules?.audits ?? {})) {
+    if (entry?.target !== WEB_LENS_TARGET) continue;
+    for (const glob of entry?.triggers?.filePatterns ?? []) {
+      if (typeof glob === 'string' && glob !== '') patterns.add(glob);
+    }
+  }
+  return [...patterns];
+}
+
+/**
+ * Which predicted paths sit on a UI surface, per the web lens globs.
+ *
+ * An unreadable manifest is **indeterminate**, not "no match": the signal fails
+ * OPEN in the same direction {@link hasWebSurface} does, because a spurious
+ * mention of an operator-invoked command costs nothing while a missed one costs
+ * the whole point of the offer.
+ *
+ * @param {string[]} predictedPaths
+ * @returns {{ matchedPaths: string[], indeterminate: boolean }}
+ */
+function resolveWebFootprintMatch(predictedPaths) {
+  let patterns;
+  try {
+    patterns = resolveWebFilePatterns(readAuditRulesSync());
+  } catch {
+    return { matchedPaths: [], indeterminate: true };
+  }
+  return {
+    matchedPaths: predictedPaths.filter((p) =>
+      matchesAnyFilePattern(patterns, [p]),
+    ),
+    indeterminate: false,
+  };
+}
+
+/**
+ * The one sentence a `uiSurface` signal carries — why the offer fires, or why it
+ * does not. Kept in one place so the fired and unfired shapes stay one object.
+ *
+ * @param {{
+ *   detected: boolean,
+ *   webSurface: boolean,
+ *   indeterminate: boolean,
+ *   sample: string[],
+ *   count: number,
+ * }} facts
+ * @returns {string}
+ */
+function uiSurfaceReason({
+  detected,
+  webSurface,
+  indeterminate,
+  sample,
+  count,
+}) {
+  if (!detected) {
+    return webSurface
+      ? 'no predicted path matches a web lens filePattern — nothing to prototype'
+      : 'project has no rendered web surface — nothing to prototype';
+  }
+  if (indeterminate) {
+    return 'web-capable project and the UI-path manifest could not be read — offering /prototype rather than dropping the option';
+  }
+  const elided = count - sample.length;
+  const shown =
+    elided > 0 ? `${sample.join(', ')}, +${elided} more` : sample.join(', ');
+  return `web-capable project and the predicted footprint touches ${count} UI path(s) (${shown}) — the operator may want /prototype before UI acceptance criteria are authored`;
+}
+
+/**
+ * Derive the advisory **UI-surface** signal from a seed's predicted footprint.
+ *
+ * Two observables, both already shipped, ANDed together:
+ *
+ *   1. the project is web-capable at all (`hasWebSurface` — the same
+ *      applicability predicate the `target: "web"` audit lenses gate on), and
+ *   2. at least one predicted path matches a web lens `filePattern`.
+ *
+ * No new detection surface and no new `.agentrc.json` key: both halves are
+ * derived from the consumer's own checkout, so a frontend-less project — this
+ * repository included — resolves falsey and the offer never fires.
+ *
+ * The signal carries **no routing authority** (`automatic: false`): `/plan`
+ * may say that a plan touches UI and that `/prototype` exists, and must never
+ * invoke it. Pure over its inputs and total — a malformed signal bag or an
+ * unreadable manifest degrades, never throws.
+ *
+ * @param {{
+ *   complexitySignals?: object|null,
+ *   config?: object,
+ *   cwd?: string,
+ * }} [args]
+ * @returns {{
+ *   detected: boolean,
+ *   automatic: false,
+ *   advisory: true,
+ *   webSurface: boolean,
+ *   matchedPaths: string[],
+ *   matchedPathCount: number,
+ *   reasons: string[],
+ * }} `matchedPaths` is a bounded sample
+ *   ({@link UI_MATCHED_PATH_SAMPLE}); `matchedPathCount` is the full total.
+ */
+function buildUiSurfaceSignal({ complexitySignals, config, cwd } = {}) {
+  const predictedPaths = Array.isArray(complexitySignals?.predictedPaths)
+    ? complexitySignals.predictedPaths.filter((p) => typeof p === 'string')
+    : [];
+  const projectRoot =
+    typeof cwd === 'string' && cwd !== '' ? cwd : process.cwd();
+
+  let webSurface;
+  try {
+    webSurface = hasWebSurface({ config, projectRoot });
+  } catch {
+    webSurface = true; // indeterminate ⇒ fail open
+  }
+
+  const { matchedPaths, indeterminate } =
+    resolveWebFootprintMatch(predictedPaths);
+  const detected = webSurface && (indeterminate || matchedPaths.length > 0);
+  const sample = matchedPaths.slice(0, UI_MATCHED_PATH_SAMPLE);
+
+  return {
+    detected,
+    automatic: /** @type {const} */ (false),
+    advisory: /** @type {const} */ (true),
+    webSurface,
+    matchedPaths: sample,
+    matchedPathCount: matchedPaths.length,
+    reasons: [
+      uiSurfaceReason({
+        detected,
+        webSurface,
+        indeterminate,
+        sample,
+        count: matchedPaths.length,
+      }),
+    ],
+  };
+}
+
+/**
+ * Attach the advisory routing/offer signals to a complexity-signals bag as
+ * **nested** fields (Story #4741). Nesting — rather than new top-level envelope
+ * keys — keeps every existing per-mode envelope key set byte-stable: both are
+ * derived from the signals they ride on.
  *
  * @param {object} complexitySignals
- * @returns {object} the same signals plus `deliverLightSuggestion`.
+ * @param {{ config?: object, cwd?: string }} [context]
+ * @returns {object} the same signals plus `deliverLightSuggestion` and
+ *   `uiSurface`.
  */
-function withDeliverLightSuggestion(complexitySignals) {
+function withAdvisorySignals(complexitySignals, { config, cwd } = {}) {
   return {
     ...complexitySignals,
     deliverLightSuggestion: buildDeliverLightSuggestion(complexitySignals),
+    uiSurface: buildUiSurfaceSignal({ complexitySignals, config, cwd }),
   };
 }
 
@@ -701,14 +877,16 @@ async function buildSeedFileModeEnvelope({
     // authority. The planner authors the trivial-vs-standard verdict; persist
     // validates a lite claim against the authored Story's shape. The nested
     // `deliverLightSuggestion` is the advisory plan-side routing handshake
-    // (Story #4741 AC-6) — never an automatic reroute.
-    complexitySignals: withDeliverLightSuggestion(
+    // (Story #4741 AC-6) and `uiSurface` the advisory /prototype offer —
+    // neither is ever an automatic reroute.
+    complexitySignals: withAdvisorySignals(
       buildComplexitySignals({
         seedText: content,
         config,
         riskHeuristics: heuristics,
         cwd,
       }),
+      { config, cwd },
     ),
     duplicates,
     docsContext,
@@ -863,13 +1041,14 @@ async function buildTicketsModeEnvelope({
     mode: 'tickets',
     sourceTickets,
     seed: { text: seed, path: null },
-    complexitySignals: withDeliverLightSuggestion(
+    complexitySignals: withAdvisorySignals(
       buildComplexitySignals({
         seedText: seed,
         config,
         riskHeuristics: heuristics,
         cwd,
       }),
+      { config, cwd },
     ),
     duplicates,
     docsContext,
@@ -988,13 +1167,14 @@ async function buildAmendmentModeEnvelope({
     },
     // The prior body is the seed the delta is authored against.
     seed: { text: priorBody, path: null },
-    complexitySignals: withDeliverLightSuggestion(
+    complexitySignals: withAdvisorySignals(
       buildComplexitySignals({
         seedText: priorBody,
         config,
         riskHeuristics: heuristics,
         cwd,
       }),
+      { config, cwd },
     ),
     duplicates,
     // No plan temp dir and no from-scratch repo interrogation — the prior

--- a/.agents/scripts/plan-context.js
+++ b/.agents/scripts/plan-context.js
@@ -167,7 +167,9 @@ export async function emitPlanContext({
       // Advisory only (Story #4722): signals, no route — the planner owns
       // the trivial-vs-standard verdict and persist validates it by shape.
       // The nested `deliverLightSuggestion` is the recorded plan-side routing
-      // handshake (Story #4741 AC-6) — advisory, never an automatic reroute.
+      // handshake (Story #4741 AC-6) and `uiSurface` the recorded /prototype
+      // offer — advisory, never an automatic reroute. Both ride the digest
+      // because with `--out` the digest is the only thing the planner reads.
       complexitySignals: envelope.complexitySignals
         ? {
             artifactCount: envelope.complexitySignals.artifactCount,
@@ -176,6 +178,7 @@ export async function emitPlanContext({
               envelope.complexitySignals.sensitivePathClasses,
             deliverLightSuggestion:
               envelope.complexitySignals.deliverLightSuggestion ?? null,
+            uiSurface: envelope.complexitySignals.uiSurface ?? null,
           }
         : null,
       amends: envelope.amends ? { id: envelope.amends.id } : null,

--- a/.agents/workflows/helpers/plan-reference.md
+++ b/.agents/workflows/helpers/plan-reference.md
@@ -63,6 +63,26 @@ is terminal and requires a fresh session. The rule that separates the two, and
 why it must not be flattened into symmetry:
 [`deliver-light.md` § Why the two directions differ](deliver-light.md).
 
+## Gate #1 → the `/prototype` offer (`uiSurface`)
+
+`complexitySignals.uiSurface` is the second advisory Gate #1 offer, and the
+weaker of the two on purpose: it carries **no routing authority and adds no
+gate**. Both halves are derived from observables already in the checkout — the
+`hasWebSurface` applicability predicate the `target: "web"` audit lenses gate
+on, and whether any predicted path matches a web lens `filePattern` registered
+in `audit-rules.json`. There is no configuration key to set: a project with no
+rendered frontend resolves falsey and the offer never fires.
+
+When it does fire, **name [`/prototype`](../prototype.md) and stop there.**
+`/plan` must never invoke it — operator invocation is the entire design, because
+the value is a human looking at a layout before its UI acceptance criteria are
+frozen.
+
+**Under `--yes` the offer is recorded and planning proceeds** — no reroute, no
+prototype written, no gate raised. This is exactly how `deliverLightSuggestion`
+behaves unattended, and for the same reason: an unattended run has nobody to
+review an artifact, so recording the offer is the whole of the right behaviour.
+
 ## Shape-derived complexity routing (`complexitySignals`)
 
 Complexity routes on the **objective shape of the authored work**, never on

--- a/.agents/workflows/plan.md
+++ b/.agents/workflows/plan.md
@@ -82,6 +82,9 @@ this envelope, not the raw seed; an `ask-operator` verdict returns here to
 step 2 with the interrogation intact. Under `--yes` it is recorded and planning
 proceeds — never auto-downgraded to light.
 
+A truthy `complexitySignals.uiSurface` marks a UI-touching plan: name
+[`/prototype`](prototype.md) as an operator option — never invoke it here.
+
 ### 2. Author
 
 **One-shot authoring.** Start from `stories.template.json`; author
@@ -156,8 +159,7 @@ JSON.
 
 In tickets mode persist resolves source ids **envelope-first** and closes each
 as `not_planned` with a comment (default on;
-[detail](helpers/plan-reference.md)). On a stranded persist, re-run the same
-command — never hand-delete issues.
+[detail](helpers/plan-reference.md)).
 
 ## Constraints
 

--- a/.agents/workflows/prototype.md
+++ b/.agents/workflows/prototype.md
@@ -1,0 +1,104 @@
+---
+description: >-
+  Operator-invoked UI prototype pass. Discovers the consumer's design-system
+  SSOT first, then — only after the operator confirms — writes exactly one
+  self-contained HTML file under the gitignored workspace-root temp tree, so a
+  layout can be reviewed before its UI acceptance criteria are authored.
+---
+
+# /prototype [what to prototype]
+
+UI acceptance criteria are otherwise authored blind: "the dashboard shows the
+active runs" says nothing about layout, density, or interaction, so delivery
+resolves those by taste. `/prototype` puts a reviewable artifact in front of the
+operator before the criteria are written.
+
+**Operator-invoked only.** `/plan` may report that a plan touches UI and that
+this command exists; it must never run it. No workflow, gate, or script invokes
+`/prototype` — the whole design rests on the operator asking for it.
+
+## Procedure
+
+### Step 0 — Discover the design-system SSOT (first, before anything is drawn)
+
+You cannot prototype *in the project's visual language* until you have found the
+language. Locate and read the consumer's sources of truth — the same set
+[`/audit-ux-ui`](audit-ux-ui.md) Step 0 mandates:
+
+- **Design tokens / theme** — a `tailwind.config.{js,ts}`, CSS custom properties
+  (`:root { --color-*, --space-* }`), a `theme/` / `tokens/` /
+  `design-system/` directory, or a CSS-in-JS theme object.
+- **Component roster** — the shared component directory (`components/ui/**`, a
+  published design-system package) that raw elements are expected to defer to.
+- **Documented conventions** — `docs/style-guide.md`, plus `docs/web-routes.md`
+  when the surface is a route, whenever they exist in the consumer checkout.
+
+Report what you found — token names, the component roster, the style-guide rules
+— and draw only against that discovered baseline. **No artifact is drawn until
+this step has run.**
+
+### Step 0a — When no design-system SSOT is discoverable
+
+Report the absence explicitly, then emit a **low-fidelity frame**: boxes,
+labels, and hierarchy, in the host's default typography with no colour system.
+Do **not** invent a visual language. A prototype in a palette the project never
+adopted reviews the invention rather than the layout, and the operator cannot
+tell which of the two they are approving.
+
+### Step 1 — Confirm before writing (**hard gate**)
+
+Describe the layout you intend — surfaces, hierarchy, states, and which
+discovered tokens and components it reuses — and **STOP**. Nothing is written to
+disk until the operator confirms; never write silently. This is the disk-write
+policy [`core/idea-refinement`](../skills/core/idea-refinement/SKILL.md) already
+applies to its one-pager.
+
+### Step 2 — Write exactly one self-contained HTML file
+
+On confirm, write **exactly one** self-contained `.html` file — inline CSS, no
+build step, no fetched external assets — under the **gitignored workspace-root
+temp tree** (`temp/prototypes/<slug>.html`). One file, because a prototype is a
+thing to look at, not a codebase to maintain; self-contained, because it has to
+open from disk with no server and no install.
+
+Report the path, and iterate in place on that same file.
+
+### Step 3 — Optional: publish to a host
+
+Host publishing is an **optional upgrade of that same file** and never the
+artifact of record — the file under the temp tree stays authoritative. Publish
+only when the operator asks, and keep the two identical by re-publishing the
+file rather than editing a published copy.
+
+### Step 4 — Carry the review through to the Story
+
+The **default carry-through is a fold into the Story's `## Spec`.** Delivery
+reads the Story body and never the temp tree, so a layout that exists only as a
+temp artifact is a layout delivery cannot see. Record the reviewed decisions —
+surfaces, hierarchy, states, and the named tokens and components — as contract
+prose in `## Spec`, and turn the observable ones into UI acceptance criteria.
+
+**Committing a prototype is opt-in, per Story.** Ask; never default to it. A
+prototype is wrong the moment the real UI ships, and a repository with a
+documentation-freshness gate already carries that failure mode.
+
+## Constraint
+
+- **Nothing reaches disk without a confirm.** Step 1 is a hard gate, not a
+  courtesy.
+- **One file, under the temp tree.** Never a second artifact, never outside the
+  gitignored workspace-root temp tree, and never a committed prototype
+  directory by default.
+- **Never invoked automatically.** `/plan` records the offer and proceeds with
+  planning; no workflow, gate, or script may call this command.
+- **Read-only over the codebase.** The prototype file is the only write. Do not
+  edit application source, tokens, or components to make a prototype render.
+- **Discovered baseline only.** No invented palette, type scale, or component
+  vocabulary when the project defines none.
+
+## See also
+
+- [`/audit-ux-ui`](audit-ux-ui.md) — the same design-system SSOT discovery,
+  applied as a review lens after the UI ships.
+- [`/plan`](plan.md) — where the advisory `complexitySignals.uiSurface` offer
+  surfaces. It names this command; it never runs it.

--- a/tests/plan-context.test.js
+++ b/tests/plan-context.test.js
@@ -1082,6 +1082,183 @@ describe('plan-context deliverLightSuggestion (Story #4741 AC-6)', () => {
   });
 });
 
+// Story #4765 — the advisory UI-surface offer. Two observables ANDed: the
+// project is web-capable at all, and a predicted path matches one of the
+// `target: "web"` lens filePatterns in audit-rules.json.
+//
+// The signal CANNOT fire in this repository (no rendered frontend), which is
+// the point of AC-8 — so exercising it at all needs a synthetic web-surface
+// fixture. `delivery.quality.navigability.routeGlobs` is the cheapest one:
+// `hasWebSurface` treats a configured route-glob set as a determinate web
+// signal and returns before it touches the filesystem, so the fixture needs no
+// temp tree and cannot be perturbed by the process-lifetime fs memo.
+describe('plan-context uiSurface offer (Story #4765)', () => {
+  /** Synthetic web-capable consumer config. */
+  const WEB_CONFIG = {
+    delivery: {
+      quality: { navigability: { routeGlobs: ['app/**/page.tsx'] } },
+    },
+  };
+
+  /** A seed naming paths that match the web lens filePatterns. */
+  const UI_SEED = [
+    '# Runs dashboard',
+    '',
+    '## Scope',
+    '',
+    '- render the run list in src/components/RunList.tsx',
+    '- style it from styles/dashboard.css',
+    '',
+  ].join('\n');
+
+  /** A seed whose predicted footprint is pure orchestration. */
+  const NON_UI_SEED = [
+    '# Resolve stories faster',
+    '',
+    '## Scope',
+    '',
+    '- memoize the probe in lib/orchestration/resolve-stories.js',
+    '',
+  ].join('\n');
+
+  const envelopeFor = (seedText, config) =>
+    buildPlanContext({
+      mode: 'seed',
+      seedText,
+      provider: buildProvider(),
+      config,
+      settings: {},
+    });
+
+  it('fires on a web-capable project whose predicted footprint touches UI paths (AC-5)', async () => {
+    const env = await envelopeFor(UI_SEED, WEB_CONFIG);
+    const ui = env.complexitySignals.uiSurface;
+    assert.equal(ui.detected, true);
+    assert.equal(ui.webSurface, true);
+    // Derived from the audit-rules web filePatterns via matchesAnyFilePattern —
+    // both named paths match (`**/components/**/*.{tsx,…}` and `**/*.css`).
+    assert.deepEqual(ui.matchedPaths.sort(), [
+      'src/components/RunList.tsx',
+      'styles/dashboard.css',
+    ]);
+    assert.equal(ui.matchedPathCount, 2);
+    assert.match(ui.reasons[0], /\/prototype/);
+  });
+
+  it('carries no routing authority — advisory, never automatic (AC-8)', async () => {
+    const env = await envelopeFor(UI_SEED, WEB_CONFIG);
+    const ui = env.complexitySignals.uiSurface;
+    assert.equal(ui.advisory, true);
+    assert.equal(
+      ui.automatic,
+      false,
+      'a truthy uiSurface must never reroute /plan — the operator invokes /prototype',
+    );
+    // The signal adds no gate: the enclosing signal bag is still advisory-only.
+    assert.equal(env.complexitySignals.routingAuthority, false);
+  });
+
+  it('self-disables when no predicted path matches a web filePattern', async () => {
+    const ui = (await envelopeFor(NON_UI_SEED, WEB_CONFIG)).complexitySignals
+      .uiSurface;
+    assert.equal(ui.detected, false);
+    assert.equal(ui.webSurface, true);
+    assert.deepEqual(ui.matchedPaths, []);
+    assert.match(ui.reasons[0], /no predicted path matches/);
+  });
+
+  it('resolves falsey in this frontend-less repository even for a UI-shaped seed (AC-8)', async () => {
+    // No routeGlobs, no web framework in package.json, no .html/.css/.jsx/.tsx
+    // in the tree: hasWebSurface is determinately false here, so the offer
+    // cannot fire however the seed is written.
+    const ui = (await envelopeFor(UI_SEED, {})).complexitySignals.uiSurface;
+    assert.equal(ui.webSurface, false);
+    assert.equal(
+      ui.detected,
+      false,
+      'mandrel ships no rendered frontend — the offer must be a silent no-op here',
+    );
+    assert.match(ui.reasons[0], /no rendered web surface/);
+  });
+
+  it('rides nested under complexitySignals — every mode key set stays byte-stable', async () => {
+    const env = await envelopeFor(UI_SEED, WEB_CONFIG);
+    assert.deepEqual(Object.keys(env).sort(), SEED_MODE_KEYS);
+    assert.ok(
+      !('uiSurface' in env),
+      'uiSurface must not become a top-level envelope key',
+    );
+  });
+
+  it('adds no gate: a fired and an unfired signal build the same envelope shape (AC-8)', async () => {
+    // The signal has no refusal path. A fired offer and an unfired one both
+    // resolve through the same successful build, leave every other advisory
+    // field intact, and produce an identical key set — so no /plan exit code
+    // can depend on it.
+    const fired = await envelopeFor(UI_SEED, WEB_CONFIG);
+    const unfired = await envelopeFor(UI_SEED, {});
+    assert.equal(fired.complexitySignals.uiSurface.detected, true);
+    assert.equal(unfired.complexitySignals.uiSurface.detected, false);
+    assert.deepEqual(
+      Object.keys(fired.complexitySignals).sort(),
+      Object.keys(unfired.complexitySignals).sort(),
+    );
+    assert.deepEqual(fired.complexitySignals.gate, { enabled: true });
+    assert.deepEqual(unfired.complexitySignals.gate, { enabled: true });
+  });
+
+  it('rides the --out stdout digest alongside the other advisory signals (AC-6)', async () => {
+    const dir = await mkdtemp(path.join(tmpdir(), 'plan-ctx-ui-'));
+    const outPath = path.join(dir, PLAN_CONTEXT_FILENAME);
+    let captured = '';
+    await emitPlanContext({
+      mode: 'seed',
+      seedText: UI_SEED,
+      provider: buildProvider(),
+      config: WEB_CONFIG,
+      settings: {},
+      outPath,
+      stdout: {
+        write(chunk) {
+          captured += chunk;
+          return true;
+        },
+      },
+    });
+    const line = captured.split('\n').filter((l) => l.length > 0)[0];
+    const digest = JSON.parse(line);
+    assert.equal(digest.complexitySignals.uiSurface.detected, true);
+    assert.equal(digest.complexitySignals.uiSurface.automatic, false);
+    assert.ok(
+      digest.complexitySignals.deliverLightSuggestion,
+      'the existing advisory signal must still ride the digest beside uiSurface',
+    );
+    assert.ok(
+      line.length < 2048,
+      `digest line is ${line.length} bytes — uiSurface must not blow the ~2KB output contract`,
+    );
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it('bounds the matched-path sample so a UI-heavy seed cannot blow the digest', async () => {
+    const many = Array.from(
+      { length: 20 },
+      (_, i) => `- edit src/components/Widget${i}.tsx`,
+    ).join('\n');
+    const ui = (
+      await envelopeFor(`# Many widgets\n\n## Scope\n\n${many}\n`, WEB_CONFIG)
+    ).complexitySignals.uiSurface;
+    assert.equal(ui.detected, true);
+    assert.equal(ui.matchedPathCount, 20);
+    assert.equal(
+      ui.matchedPaths.length,
+      5,
+      'the carried sample is bounded; matchedPathCount keeps the full total',
+    );
+    assert.match(ui.reasons[0], /\+15 more/);
+  });
+});
+
 describe('plan-context parseAmendsId (Story #4741 AC-4)', () => {
   it('accepts a bare id and a #-prefixed id', () => {
     assert.equal(parseAmendsId('4700'), 4700);

--- a/tests/prototype-workflow.test.js
+++ b/tests/prototype-workflow.test.js
@@ -1,0 +1,322 @@
+/**
+ * tests/prototype-workflow.test.js — the `/prototype` command contract.
+ *
+ * `/prototype` is workflow prose interpreted by the host LLM, so — like the
+ * `/plan` flag contract — this spec is a structural assertion over the authored
+ * workflow source. Four things are load-bearing enough that nothing else fails
+ * when they erode:
+ *
+ *   1. **Discovery is ordered first.** A prototype drawn before the consumer's
+ *      design-system SSOT is located reviews an invented visual language.
+ *   2. **Nothing reaches disk without a confirm**, and what does reach disk is
+ *      exactly one self-contained HTML file under the gitignored temp tree.
+ *   3. **The artifact of record never moves.** Host publishing is an upgrade of
+ *      that same file; committing a prototype is opt-in; the default
+ *      carry-through is a fold into the Story's `## Spec`, because delivery
+ *      reads the Story body and never the temp tree.
+ *   4. **`/plan` never invokes it.** The advisory `uiSurface` signal may name
+ *      the command; an instruction to run it would make the operator-invocation
+ *      design a fiction. That is the assertion most likely to erode by someone
+ *      "finishing the wiring", so it is checked negatively and structurally.
+ *
+ * Prose claims go through `doc-assert.js` so a re-flowed 80-column paragraph
+ * cannot turn a correct edit red — and so a forbidden phrase cannot hide by
+ * straddling a line break.
+ */
+
+import assert from 'node:assert/strict';
+import { existsSync } from 'node:fs';
+import path from 'node:path';
+import { describe, it } from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+import {
+  assertDocMentions,
+  assertDocOmits,
+  readDoc,
+} from './helpers/doc-assert.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, '..');
+const WORKFLOWS = path.join(REPO_ROOT, '.agents', 'workflows');
+
+const PROTOTYPE = path.join(WORKFLOWS, 'prototype.md');
+const PLAN = path.join(WORKFLOWS, 'plan.md');
+const PLAN_REF = path.join(WORKFLOWS, 'helpers', 'plan-reference.md');
+const WORKFLOW_INDEX = path.join(REPO_ROOT, '.agents', 'docs', 'workflows.md');
+
+describe('/prototype is an operator-invocable top-level command', () => {
+  it('lives at the top level, not under helpers/', () => {
+    // Top level is structural, not cosmetic: helpers are non-invocable, which
+    // would leave "the operator asks for it" resting on prose alone.
+    assert.equal(
+      existsSync(PROTOTYPE),
+      true,
+      '.agents/workflows/prototype.md must exist so /prototype projects as a command',
+    );
+    assert.equal(
+      existsSync(path.join(WORKFLOWS, 'helpers', 'prototype.md')),
+      false,
+      'a helpers/prototype.md would not project a slash command',
+    );
+  });
+
+  it('carries the front-matter description the generated index is built from', () => {
+    const md = readDoc(PROTOTYPE);
+    assert.match(
+      md,
+      /^---\n[\s\S]*?\bdescription:/,
+      'the command index is generated from front-matter `description:`',
+    );
+  });
+
+  it('appears in the generated workflow index', () => {
+    assertDocMentions(
+      readDoc(WORKFLOW_INDEX),
+      /\| `\/prototype` \|/,
+      'the generated index must list the new command — regenerate with npm run docs:gen',
+    );
+  });
+});
+
+describe('/prototype orders SSOT discovery before any artifact is drawn', () => {
+  const md = readDoc(PROTOTYPE);
+
+  it('runs design-system discovery as the first procedure step', () => {
+    const discoveryIdx = md.indexOf('### Step 0 —');
+    const writeIdx = md.indexOf('### Step 2 —');
+    assert.ok(discoveryIdx > -1, 'prototype.md must carry a Step 0');
+    assert.ok(writeIdx > -1, 'prototype.md must carry the write step');
+    assert.ok(
+      discoveryIdx < writeIdx,
+      'SSOT discovery must precede the step that writes an artifact',
+    );
+    assertDocMentions(
+      md,
+      /No artifact is drawn until this step has run/i,
+      'the ordering must be stated, not merely implied by heading order',
+    );
+  });
+
+  it('names the three SSOT sources the ux-ui lens mandates', () => {
+    assertDocMentions(md, /Design tokens/i, 'tokens/theme must be discovered');
+    assertDocMentions(
+      md,
+      /Component roster/i,
+      'the component roster must be discovered',
+    );
+    assertDocMentions(
+      md,
+      /`docs\/style-guide\.md`/,
+      'the documented conventions the detectors cannot infer must be read',
+    );
+    assertDocMentions(
+      md,
+      /`docs\/web-routes\.md`/,
+      'route surfaces must consult the routes doc when present',
+    );
+    assertDocMentions(
+      md,
+      /\(audit-ux-ui\.md\)/,
+      'the discovery step must point at the lens whose Step 0 it mirrors',
+    );
+  });
+
+  it('falls back to a low-fidelity frame rather than inventing a visual language', () => {
+    assertDocMentions(
+      md,
+      /low-fidelity frame/i,
+      'the no-SSOT fallback must emit a low-fidelity frame',
+    );
+    assertDocMentions(
+      md,
+      /Report the absence/i,
+      'the absence of a design system must be reported, not papered over',
+    );
+    assertDocMentions(
+      md,
+      /Do \*\*not\*\* invent a visual language/i,
+      'a prototype in an unadopted palette reviews the invention, not the layout',
+    );
+  });
+});
+
+describe('/prototype writes one file, and only after a confirm', () => {
+  const md = readDoc(PROTOTYPE);
+
+  it('gates every disk write behind an operator confirm', () => {
+    assertDocMentions(
+      md,
+      /Nothing is written to disk until the operator confirms/i,
+      'the confirm gate is the disk-write policy core/idea-refinement already sets',
+    );
+    assertDocMentions(
+      md,
+      /never write silently/i,
+      'silent writes are the specific failure the policy names',
+    );
+    assertDocMentions(
+      md,
+      /idea-refinement/,
+      'the confirm gate must cite the policy it inherits rather than re-deriving it',
+    );
+  });
+
+  it('writes exactly one self-contained HTML file under the gitignored temp tree', () => {
+    assertDocMentions(
+      md,
+      /\*\*exactly one\*\* self-contained `\.html` file/i,
+      'one file, self-contained — it has to open from disk with no server',
+    );
+    assertDocMentions(
+      md,
+      /gitignored workspace-root temp tree/i,
+      'the artifact must land in the gitignored workspace-root temp tree',
+    );
+    assertDocMentions(
+      md,
+      /`temp\/prototypes\/<slug>\.html`/,
+      'the concrete path keeps "under temp/" from being interpreted loosely',
+    );
+  });
+});
+
+describe('/prototype keeps the artifact of record in one place', () => {
+  const md = readDoc(PROTOTYPE);
+
+  it('treats host publishing as an optional upgrade of the same file', () => {
+    assertDocMentions(
+      md,
+      /optional upgrade of that same file/i,
+      'publishing must not fork the artifact',
+    );
+    assertDocMentions(
+      md,
+      /never the artifact of record/i,
+      'the temp-tree file stays authoritative',
+    );
+  });
+
+  it('makes committing a prototype opt-in per Story', () => {
+    assertDocMentions(
+      md,
+      /Committing a prototype is opt-in, per Story/i,
+      'a committed prototype directory must never be the default',
+    );
+    assertDocOmits(
+      md,
+      /commit the prototype by default/i,
+      'the default must not be a commit — a prototype is wrong once the UI ships',
+    );
+  });
+
+  it('defaults the carry-through to a fold into the Story ## Spec', () => {
+    assertDocMentions(
+      md,
+      /default carry-through is a fold into the Story's `## Spec`/i,
+      'delivery reads the Story body, so the reviewed layout has to land there',
+    );
+    assertDocMentions(
+      md,
+      /reads the Story body and never the temp tree/i,
+      'the reason the fold is the default must be stated, or it reads as bureaucracy',
+    );
+  });
+
+  it('states the never-automatic invariant in its own constraints', () => {
+    assertDocMentions(
+      md,
+      /Never invoked automatically/i,
+      'the command must declare that nothing calls it',
+    );
+    assertDocMentions(
+      md,
+      /Operator-invoked only/i,
+      'operator invocation is the whole design',
+    );
+  });
+});
+
+describe('/plan names the /prototype option but never invokes it', () => {
+  const planMd = readDoc(PLAN);
+
+  it('mentions the option for UI-touching plans', () => {
+    assertDocMentions(
+      planMd,
+      /`complexitySignals\.uiSurface`/,
+      'plan.md must name the signal that surfaces the offer',
+    );
+    assertDocMentions(
+      planMd,
+      /\[`\/prototype`\]\(prototype\.md\)/,
+      'plan.md must link the command so the operator can find it',
+    );
+  });
+
+  it('nowhere instructs the workflow to run it', () => {
+    // The negative half is the load-bearing one: an imperative here would make
+    // the operator-invocation design a fiction.
+    for (const forbidden of [
+      /(?:run|invoke|execute|dispatch|chain into|route into|hand off to)\s+(?:the\s+)?`?\/prototype/i,
+      /Under `--yes`[^.]*\/prototype/i,
+    ]) {
+      assertDocOmits(
+        planMd,
+        forbidden,
+        '/plan must never instruct itself to invoke /prototype',
+      );
+    }
+    assertDocMentions(
+      planMd,
+      /never invoke it here/i,
+      'the prohibition must be explicit at the point the option is named',
+    );
+  });
+
+  it('never puts /prototype in a runnable command block', () => {
+    // A fenced block is a copy-paste invitation, so this is a layout claim and
+    // deliberately does not go through the whitespace-normalizing helper.
+    const fenced = planMd.match(/```[\s\S]*?```/g) ?? [];
+    for (const block of fenced) {
+      assert.ok(
+        !block.includes('/prototype'),
+        'a fenced block naming /prototype is an instruction to run it',
+      );
+    }
+  });
+});
+
+describe('plan-reference.md records the --yes handshake', () => {
+  const md = readDoc(PLAN_REF);
+
+  it('records the offer and proceeds with planning, with no reroute', () => {
+    assertDocMentions(
+      md,
+      /Under `--yes` the offer is recorded and planning proceeds/i,
+      'an unattended run has nobody to review an artifact — record and proceed',
+    );
+    assertDocMentions(
+      md,
+      /no reroute/i,
+      'recording must be distinguished from rerouting',
+    );
+  });
+
+  it('states that the signal carries no routing authority and adds no gate', () => {
+    assertDocMentions(
+      md,
+      /no routing authority and adds no gate/i,
+      'the signal must not become a gate by documentation drift',
+    );
+    assertDocMentions(
+      md,
+      /`hasWebSurface`/,
+      'the reference must name the shipped predicate the signal reuses',
+    );
+    assertDocMentions(
+      md,
+      /a project with no rendered frontend resolves falsey/i,
+      'the self-disabling fail direction is why no config key exists',
+    );
+  });
+});


### PR DESCRIPTION
Closes #4765

_Auto-opened by `/deliver`._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are advisory planning signals, workflow documentation, and tests—no auth, persistence, or automatic execution paths.
> 
> **Overview**
> Introduces **`/prototype`**, an operator-only workflow: discover design-system SSOT first, confirm layout intent, then write **one** self-contained HTML file under `temp/prototypes/`, with optional carry-through into the Story `## Spec` (not auto-commit).
> 
> **`/plan` Gate #1** gains a second advisory signal alongside `deliverLightSuggestion`: nested **`complexitySignals.uiSurface`** fires when the repo has a web surface (`hasWebSurface`) and predicted paths match web audit lens `filePatterns` from `audit-rules.json`. It has **no routing authority** — `/plan` may name `/prototype` only; under `--yes` the offer is recorded and planning continues. `withDeliverLightSuggestion` is generalized to **`withAdvisorySignals`**; the `--out` digest includes `uiSurface` with bounded matched-path samples.
> 
> Docs index lists the new command; **`tests/plan-context.test.js`** and **`tests/prototype-workflow.test.js`** lock the signal contract and workflow prose (no automatic `/plan` invocation).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 716c28d1a4d389e84f897b01a0f7d808052f82bd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->