### PR TITLE
fix: stop close-validation gate capture from stalling the child's stdout pipe (#4766)

### DIFF
--- a/.agents/scripts/lib/close-validation/process.js
+++ b/.agents/scripts/lib/close-validation/process.js
@@ -11,22 +11,48 @@ import { spawn } from 'node:child_process';
  * Pipe a child stream's output line-by-line through `emit`, prepending
  * `prefix` to each line. Tail bytes without a trailing newline flush on
  * `end` so the operator never loses the last line of a gate's output.
+ *
+ * ## The drain must stay cheap (Story #4766)
+ *
+ * This handler runs on the reader side of the child's stdout/stderr pipe.
+ * Every microsecond spent here is a microsecond the pipe is not being read,
+ * and once the OS pipe buffer fills, the child's own write blocks — or, on a
+ * non-blocking pipe, fails outright with `EAGAIN`. A gate child is not
+ * obliged to survive that: Biome's `biome_console` `.unwrap()`s the error and
+ * aborts the process with exit 101, so a green lint verdict presents as a
+ * failed close. Two consequences bind everything on this path:
+ *
+ *   1. Splitting is O(chunk), not O(chunk × lines) — the scan advances a
+ *      `start` index instead of re-slicing the buffer once per line, so a
+ *      64KB chunk carrying 500 lines does not copy 16MB.
+ *   2. **`emit` MUST NOT block.** A synchronous per-line file write is
+ *      exactly the stall this path cannot afford; the close path's capture
+ *      sink (`single-story-close/gate-log.js`) buffers to an async stream for
+ *      that reason.
  */
 function pipePrefixed(stream, prefix, emit) {
   let buf = '';
   stream.setEncoding('utf8');
   stream.on('data', (chunk) => {
     buf += chunk;
-    while (true) {
-      const nl = buf.indexOf('\n');
-      if (nl === -1) break;
-      emit(prefix + buf.slice(0, nl));
-      buf = buf.slice(nl + 1);
+    let start = 0;
+    let nl = buf.indexOf('\n', start);
+    while (nl !== -1) {
+      emit(prefix + buf.slice(start, nl));
+      start = nl + 1;
+      nl = buf.indexOf('\n', start);
     }
+    if (start > 0) buf = buf.slice(start);
   });
   stream.on('end', () => {
-    if (buf.length > 0) emit(prefix + buf);
+    if (buf.length > 0) {
+      emit(prefix + buf);
+      buf = '';
+    }
   });
+  // A pipe-level error (EIO on a vanished child) must not become an
+  // unhandled 'error' event that takes the whole close down.
+  stream.on('error', () => {});
 }
 
 /** Wire the AbortSignal so an abort kills the child. Returns the cleanup fn. */
@@ -69,6 +95,18 @@ const BIOME_NO_FILES_PROCESSED =
   'No files were processed in the specified paths';
 
 /**
+ * How many trailing gate lines the "No files were processed" probe retains.
+ *
+ * The marker only ever appears when biome processed nothing, and in that case
+ * its whole output is a handful of lines — so a bounded tail always contains
+ * it when it is there at all. Retaining a tail rather than the full transcript
+ * keeps the drain path's per-line work O(1) in the volume of gate output
+ * (Story #4766): the previous `captured += line` grew a string without limit,
+ * on the one gate (biome/format) whose output is the loudest.
+ */
+const MARKER_PROBE_TAIL_LINES = 32;
+
+/**
  * Whether biome's combined gate output carries the "No files were processed"
  * marker. Pure function — no I/O. Exported for unit coverage (Story #4292).
  *
@@ -85,8 +123,11 @@ export function isBiomeNoFilesProcessed(output) {
  * Default async gate runner — used by `runCloseValidation` when no `runner`
  * is injected. Spawns the gate via `child_process.spawn`, prefixes every
  * stdout/stderr line with `[gate-name] ` (so concurrent gates don't bleed
- * into each other in the operator's terminal), and resolves only when the
- * child exits.
+ * into each other in the operator's terminal), and resolves only once the
+ * child has exited and both stdio pipes are drained.
+ *
+ * `opts.log` is the drain sink and **must not block** — see `pipePrefixed`
+ * above for what a synchronous per-line write costs the child (Story #4766).
  *
  * Honours `opts.signal`: a TERM is delivered to the child the moment the
  * signal fires, so a sibling gate's failure aborts the rest of the wave
@@ -119,13 +160,14 @@ export function defaultGateRunner(cmd, args, opts = {}) {
   const prefix = gateName ? `[${gateName}] ` : '';
   const emit =
     typeof log === 'function' ? log : (m) => process.stdout.write(`${m}\n`);
-  // Capture the combined output only when we may need to inspect it for the
-  // biome "No files were processed" marker — otherwise the stream is purely
-  // piped through to the operator (no retained buffer).
-  let captured = '';
+  // Retain a bounded tail only when we may need to inspect it for the biome
+  // "No files were processed" marker — otherwise the stream is purely piped
+  // through to the operator (no retained buffer).
+  const recent = [];
   const tap = tolerateNoFilesProcessed
     ? (line) => {
-        captured += `${line}\n`;
+        recent.push(line);
+        if (recent.length > MARKER_PROBE_TAIL_LINES) recent.shift();
         emit(line);
       }
     : emit;
@@ -133,13 +175,17 @@ export function defaultGateRunner(cmd, args, opts = {}) {
   pipePrefixed(child.stderr, prefix, tap);
   const detach = attachGateAbortHandler(child, signal);
   return new Promise((resolve) => {
-    child.on('exit', (code, sig) => {
+    // 'close', not 'exit' (Story #4766): 'close' fires only once the child has
+    // exited AND both stdio pipes have been fully drained and closed, so no
+    // gate ever reports its status while lines are still in flight. Resolving
+    // on 'exit' raced the tail of a high-volume gate's output.
+    child.on('close', (code, sig) => {
       detach();
       const status = gateExitCode(code, sig);
       if (
         status !== 0 &&
         tolerateNoFilesProcessed &&
-        isBiomeNoFilesProcessed(captured)
+        isBiomeNoFilesProcessed(recent.join('\n'))
       ) {
         emit(
           `${prefix}↳ biome processed zero files (all changed paths are config-ignored); treating as a clean skip`,

--- a/.agents/scripts/lib/orchestration/single-story-close/gate-log.js
+++ b/.agents/scripts/lib/orchestration/single-story-close/gate-log.js
@@ -36,6 +36,24 @@
  * The sink never throws. A log directory that cannot be written degrades to
  * inline streaming — losing the size bound is strictly better than losing the
  * gate output that says why a close failed.
+ *
+ * ## Why the artifact is written asynchronously (Story #4766)
+ *
+ * This sink is the `log` callable that `close-validation/process.js` invokes
+ * from inside the gate child's stdout/stderr `'data'` handler — once per line.
+ * The first cut wrote each line with `fs.writeSync`, which blocks the event
+ * loop while the child keeps writing: the OS pipe buffer fills, the child's
+ * write fails with `EAGAIN`, and a child that does not tolerate that dies. On
+ * a clean `main` `biome ci .` already emits ~625 lines, and it aborts with
+ * exit 101 (a `biome_console` panic, not a lint violation) when it happens —
+ * so the first gate of any close could die on plumbing while its verdict was
+ * green.
+ *
+ * So the write path buffers into an async stream instead: per-line work is
+ * O(1) and never touches a syscall on the drain path. The cost is that the
+ * artifact is not on disk the instant a line is logged, which is why the sink
+ * exposes {@link GateLogSink#flush} — callers await it before reading,
+ * replaying, or naming the artifact as final.
  */
 
 import nodeFs from 'node:fs';
@@ -65,9 +83,9 @@ function logNameFor(storyId) {
  */
 class GateLogSink {
   /**
-   * @param {{ logPath: string|null, streamInline: boolean, write: (line: string) => void, emit: (line: string) => void }} args
+   * @param {{ logPath: string|null, streamInline: boolean, write: (line: string) => void, flush?: () => Promise<void>, emit: (line: string) => void }} args
    */
-  constructor({ logPath, streamInline, write, emit }) {
+  constructor({ logPath, streamInline, write, flush, emit }) {
     /** Absolute path of the artifact, or `null` when capture is unavailable. */
     this.logPath = logPath;
     /** Whether lines are ALSO echoed inline as they arrive. */
@@ -75,6 +93,7 @@ class GateLogSink {
     /** Number of lines captured so far. */
     this.lineCount = 0;
     this._write = write;
+    this._flush = flush ?? (() => Promise.resolve());
     this._emit = emit;
     this._tail = [];
   }
@@ -94,6 +113,19 @@ class GateLogSink {
       this._write(line);
       if (this.streamInline) this._emit(line);
     };
+  }
+
+  /**
+   * Settle the artifact: wait for every buffered line to reach disk and close
+   * the file. Idempotent, never throws, and a no-op on the degraded (no
+   * artifact) path. Await it before reading {@link GateLogSink#logPath} or
+   * handing the path to anyone — the write path is async precisely so it never
+   * stalls a gate child's pipe.
+   *
+   * @returns {Promise<void>}
+   */
+  flush() {
+    return this._flush();
   }
 
   /**
@@ -130,6 +162,50 @@ class GateLogSink {
 }
 
 /**
+ * Wrap an already-open artifact fd in a non-blocking line writer.
+ *
+ * `write` hands the line to a `fs.WriteStream` — O(1), no syscall on the
+ * caller's stack — and `flush` ends the stream, resolving once every buffered
+ * line has reached disk (or the stream has errored; a half-written artifact is
+ * still better than a dead close). Both are best-effort by construction: the
+ * stream's `'error'` is absorbed, so nothing here can abort a close.
+ *
+ * @param {typeof nodeFs} fs
+ * @param {string} logPath
+ * @param {number} handle
+ * @returns {{ write: (line: string) => void, flush: () => Promise<void> }}
+ */
+function createArtifactWriter(fs, logPath, handle) {
+  const stream = fs.createWriteStream(logPath, { fd: handle, autoClose: true });
+  stream.on('error', () => {
+    /* best-effort: a mid-run write failure must not abort the close */
+  });
+  let ending = null;
+  return {
+    write: (line) => {
+      if (ending) return;
+      try {
+        stream.write(`${line}\n`);
+      } catch {
+        /* best-effort: see above */
+      }
+    },
+    flush: () => {
+      ending ??= new Promise((resolve) => {
+        const settle = () => resolve();
+        stream.once('error', settle);
+        try {
+          stream.end(settle);
+        } catch {
+          settle();
+        }
+      });
+      return ending;
+    },
+  };
+}
+
+/**
  * Build the gate-output sink for one close run.
  *
  * @param {{
@@ -155,14 +231,14 @@ export function createGateLogSink({
   const verbose = (level ?? resolveLevel()) === 'verbose';
   const dir = logDir ?? path.join(cwd, 'temp', 'orchestration');
 
-  let handle = null;
+  let writer = null;
   let logPath = null;
   try {
     fs.mkdirSync(dir, { recursive: true });
     logPath = path.join(dir, logNameFor(storyId));
     // Truncate: each close run owns its artifact outright, so a re-run never
     // hands the reader a file interleaving two runs' gates.
-    handle = fs.openSync(logPath, 'w');
+    writer = createArtifactWriter(fs, logPath, fs.openSync(logPath, 'w'));
   } catch {
     // No artifact — fall back to inline streaming rather than dropping the
     // gate output on the floor.
@@ -174,13 +250,11 @@ export function createGateLogSink({
     });
   }
 
-  const write = (line) => {
-    try {
-      fs.writeSync(handle, `${line}\n`);
-    } catch {
-      /* best-effort: a mid-run write failure must not abort the close */
-    }
-  };
-
-  return new GateLogSink({ logPath, streamInline: verbose, write, emit });
+  return new GateLogSink({
+    logPath,
+    streamInline: verbose,
+    write: writer.write,
+    flush: writer.flush,
+    emit,
+  });
 }

--- a/.agents/scripts/lib/orchestration/single-story-close/phases/close-validation.js
+++ b/.agents/scripts/lib/orchestration/single-story-close/phases/close-validation.js
@@ -137,22 +137,31 @@ export async function runCloseValidationPhase({
   // Story #4736 — one sink for both `log` seams (gate construction and gate
   // execution), so nothing in the chain can route around the artifact.
   const gateLog = createGateLogSink({ storyId, cwd });
-  const validation = await runCloseValidation({
-    cwd,
-    worktreePath,
-    gates: buildDefaultGates({
-      config,
-      baseBranch,
-      cwd: worktreePath || cwd,
+  let validation;
+  try {
+    validation = await runCloseValidation({
+      cwd,
+      worktreePath,
+      gates: buildDefaultGates({
+        config,
+        baseBranch,
+        cwd: worktreePath || cwd,
+        log: gateLog.log,
+      }),
       log: gateLog.log,
-    }),
-    log: gateLog.log,
-    storyId,
-    // Story #4250 — standalone storyId-anchored evidence keyspace. No
-    // epicId; the standalone flag routes the cache to
-    // temp/standalone/stories/story-<id>/validation-evidence.json.
-    standalone: true,
-  });
+      storyId,
+      // Story #4250 — standalone storyId-anchored evidence keyspace. No
+      // epicId; the standalone flag routes the cache to
+      // temp/standalone/stories/story-<id>/validation-evidence.json.
+      standalone: true,
+    });
+  } finally {
+    // Story #4766 — gate lines are buffered to an async stream so the drain
+    // never blocks a gate child's pipe. Settle the artifact before anything
+    // reads it, replays from it, or reports its path — including on the throw
+    // path, where the artifact is the only surviving record.
+    await gateLog.flush();
+  }
   if (!validation.ok) {
     const [first] = validation.failed;
     const { gate, status, cwd: gateCwd } = first;

--- a/tests/close-validation-gate-output-volume.test.js
+++ b/tests/close-validation-gate-output-volume.test.js
@@ -1,0 +1,263 @@
+/**
+ * tests/close-validation-gate-output-volume.test.js — Story #4766.
+ *
+ * The close path's gate drain under volume. `runCloseValidation` reads each
+ * gate child's stdout/stderr line-by-line and hands every line to the capture
+ * sink; the first cut of that sink wrote each line with `fs.writeSync`, which
+ * blocks the event loop while the child keeps writing. The pipe buffer fills,
+ * the child's non-blocking write returns `EAGAIN`, and a child that treats
+ * that as fatal dies — Biome's `biome_console` `.unwrap()`s it and aborts with
+ * exit 101, so a green lint verdict presented as a failed close. `biome ci .`
+ * already emits ~625 lines on a clean `main`, so any close could hit it.
+ *
+ * The panic itself is Rust-side and not reproducible from a Node child (node
+ * retries `EAGAIN` internally, and the child end of a spawned pipe is blocking
+ * on this platform), so these tests pin the *cause* instead of the symptom:
+ *
+ *   - the drain performs no synchronous artifact write, at any volume — the
+ *     assertion that fails against the pre-fix `fs.writeSync` path (AC-2/AC-8);
+ *   - a high-volume child still completes with a zero status and every line
+ *     intact in the artifact, trailing unterminated line included (AC-1/AC-3);
+ *   - per-gate `[gate-name] ` attribution survives concurrent gates (AC-4);
+ *   - a non-zero gate still propagates its exit code after the full drain
+ *     (AC-5), and the digest still accounts for every captured line (AC-6).
+ */
+
+import assert from 'node:assert/strict';
+import nodeFs from 'node:fs';
+import nodeOs from 'node:os';
+import path from 'node:path';
+import { after, before, describe, it } from 'node:test';
+
+import { defaultGateRunner } from '../.agents/scripts/lib/close-validation/process.js';
+import { createGateLogSink } from '../.agents/scripts/lib/orchestration/single-story-close/gate-log.js';
+
+/**
+ * `defaultGateRunner` routes through `cmd.exe` on win32 (`shell: true`), which
+ * cannot be handed `process.execPath` verbatim — the interpreter path contains
+ * a space. The sink-level invariant below is platform-agnostic and carries the
+ * regression; the spawn-based tests are POSIX-only.
+ */
+const POSIX_ONLY = { skip: process.platform === 'win32' };
+
+/** Fat enough that a per-line syscall is unmistakably the dominant cost. */
+const FAT = 'x'.repeat(120);
+
+let tmpDir;
+const quietLogger = { info: () => {} };
+
+before(() => {
+  tmpDir = nodeFs.mkdtempSync(path.join(nodeOs.tmpdir(), 'gate-volume-'));
+});
+
+after(() => {
+  nodeFs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+/**
+ * A child that writes `lines` newline-terminated lines to stdout, optionally a
+ * final line with no terminating newline, then exits with `exitCode`. Written
+ * to disk rather than passed with `-e` so the spawn shape matches a real gate.
+ */
+function writeEmitterScript(name) {
+  const scriptPath = path.join(tmpDir, `${name}.js`);
+  nodeFs.writeFileSync(
+    scriptPath,
+    [
+      'const [, , countArg, exitArg, trailing] = process.argv;',
+      `const fat = '${FAT}';`,
+      'const count = Number(countArg);',
+      'for (let i = 0; i < count; i += 1) {',
+      "  process.stdout.write(fat + ' line ' + i + '\\n');",
+      '}',
+      "if (trailing === 'trailing') process.stdout.write('UNTERMINATED TAIL');",
+      'process.exitCode = Number(exitArg);',
+    ].join('\n'),
+  );
+  return scriptPath;
+}
+
+/** A sink over the real implementation, rooted in this run's temp dir. */
+function realSink(name, fs = nodeFs) {
+  return createGateLogSink({
+    storyId: 4766,
+    logDir: path.join(tmpDir, name),
+    logger: quietLogger,
+    level: 'info',
+    fs,
+  });
+}
+
+describe('gate drain — no synchronous per-line write (AC-2, AC-8)', () => {
+  const VOLUME_LINES = 50_000;
+
+  it('captures 50k lines without a single fs.writeSync on the drain path', async () => {
+    let writeSyncCalls = 0;
+    const sink = realSink('no-writesync', {
+      ...nodeFs,
+      writeSync: (...args) => {
+        writeSyncCalls += 1;
+        return nodeFs.writeSync(...args);
+      },
+    });
+
+    // One uninterrupted synchronous burst — exactly the shape of a `'data'`
+    // handler draining a chatty child, with no chance to yield to the loop.
+    let expectedBytes = 0;
+    for (let i = 0; i < VOLUME_LINES; i += 1) {
+      const line = `[format] ${FAT} line ${i}`;
+      expectedBytes += Buffer.byteLength(line, 'utf8') + 1;
+      sink.log(line);
+    }
+    const onDiskDuringBurst = nodeFs.statSync(sink.logPath).size;
+    await sink.flush();
+
+    assert.equal(
+      writeSyncCalls,
+      0,
+      'the drain path must never perform a synchronous file write — this is the pre-fix behaviour that killed the gate child',
+    );
+    assert.ok(
+      onDiskDuringBurst < expectedBytes / 2,
+      `the burst must not have been flushed synchronously (${onDiskDuringBurst}B of ${expectedBytes}B reached disk before flush())`,
+    );
+
+    const written = nodeFs.readFileSync(sink.logPath, 'utf8');
+    assert.equal(
+      written.split('\n').filter(Boolean).length,
+      VOLUME_LINES,
+      'every captured line must survive into the artifact',
+    );
+    assert.ok(
+      written.endsWith(`[format] ${FAT} line ${VOLUME_LINES - 1}\n`),
+      'the last line must be present and terminated',
+    );
+    assert.equal(sink.lineCount, VOLUME_LINES);
+    assert.ok(
+      sink.digest().includes(String(VOLUME_LINES)),
+      'the success digest must account for every captured line (AC-6)',
+    );
+  });
+});
+
+describe('gate drain — high-volume child through the real sink (AC-1, AC-3)', () => {
+  const CHILD_LINES = 20_000;
+
+  it(
+    'a child an order of magnitude above the biome baseline exits 0 with no lost lines',
+    POSIX_ONLY,
+    async () => {
+      const script = writeEmitterScript('volume');
+      const sink = realSink('child-volume');
+
+      const { status } = await defaultGateRunner(
+        process.execPath,
+        [script, String(CHILD_LINES), '0', 'trailing'],
+        { cwd: tmpDir, gateName: 'format', log: sink.log },
+      );
+      await sink.flush();
+
+      assert.equal(
+        status,
+        0,
+        'the gate child must not be killed by the output plumbing',
+      );
+      assert.equal(
+        sink.lineCount,
+        CHILD_LINES + 1,
+        'every emitted line, plus the unterminated tail, must reach the sink',
+      );
+
+      const lines = nodeFs
+        .readFileSync(sink.logPath, 'utf8')
+        .split('\n')
+        .filter(Boolean);
+      assert.equal(lines.length, CHILD_LINES + 1);
+      assert.equal(lines[0], `[format] ${FAT} line 0`);
+      assert.equal(
+        lines[CHILD_LINES - 1],
+        `[format] ${FAT} line ${CHILD_LINES - 1}`,
+      );
+      assert.equal(
+        lines.at(-1),
+        '[format] UNTERMINATED TAIL',
+        'a trailing line with no terminating newline must still be captured',
+      );
+    },
+  );
+
+  it(
+    'still propagates a non-zero gate exit code after the full drain (AC-5)',
+    POSIX_ONLY,
+    async () => {
+      const script = writeEmitterScript('volume-red');
+      const sink = realSink('child-red');
+
+      const { status } = await defaultGateRunner(
+        process.execPath,
+        [script, String(CHILD_LINES), '3', 'trailing'],
+        { cwd: tmpDir, gateName: 'lint', log: sink.log },
+      );
+      await sink.flush();
+
+      assert.equal(status, 3, 'the gate exit code must propagate verbatim');
+      assert.equal(
+        sink.lineCount,
+        CHILD_LINES + 1,
+        'a red gate must not resolve while its evidence is still in flight',
+      );
+      assert.ok(
+        sink.replay() > 0,
+        'the failure path must still have a captured tail to replay (AC-6)',
+      );
+    },
+  );
+});
+
+describe('gate drain — per-gate attribution under concurrency (AC-4)', () => {
+  const CONCURRENT_LINES = 5_000;
+
+  it(
+    'concurrent gates stay distinguishable by their [gate-name] prefix',
+    POSIX_ONLY,
+    async () => {
+      const script = writeEmitterScript('concurrent');
+      const sink = realSink('concurrent');
+
+      const results = await Promise.all(
+        ['gate-a', 'gate-b'].map((gateName) =>
+          defaultGateRunner(
+            process.execPath,
+            [script, String(CONCURRENT_LINES), '0'],
+            { cwd: tmpDir, gateName, log: sink.log },
+          ),
+        ),
+      );
+      await sink.flush();
+
+      assert.deepEqual(
+        results.map((r) => r.status),
+        [0, 0],
+      );
+
+      const lines = nodeFs
+        .readFileSync(sink.logPath, 'utf8')
+        .split('\n')
+        .filter(Boolean);
+      const counts = { 'gate-a': 0, 'gate-b': 0, unattributed: 0 };
+      for (const line of lines) {
+        if (line.startsWith('[gate-a] ')) counts['gate-a'] += 1;
+        else if (line.startsWith('[gate-b] ')) counts['gate-b'] += 1;
+        else counts.unattributed += 1;
+      }
+
+      assert.equal(
+        counts.unattributed,
+        0,
+        'no interleaved line may lose its gate attribution',
+      );
+      assert.equal(counts['gate-a'], CONCURRENT_LINES);
+      assert.equal(counts['gate-b'], CONCURRENT_LINES);
+    },
+  );
+});

--- a/tests/lib/orchestration/single-story-close/gate-log.test.js
+++ b/tests/lib/orchestration/single-story-close/gate-log.test.js
@@ -11,6 +11,11 @@
  *   - an unwritable artifact degrades to streaming rather than dropping the
  *     gate output, because losing the size bound beats losing the reason a
  *     close failed.
+ *
+ * Story #4766 made the artifact write asynchronous (a synchronous per-line
+ * write stalls the gate child's pipe), so every assertion that reads the
+ * artifact now awaits `sink.flush()` first. The volume regression that forced
+ * that change lives in `tests/close-validation-gate-output-volume.test.js`.
  */
 
 import assert from 'node:assert/strict';
@@ -52,10 +57,11 @@ function sinkAt(name, opts = {}) {
 }
 
 describe('createGateLogSink — success path (AC-3)', () => {
-  it('captures gate output to the artifact and emits nothing inline', () => {
+  it('captures gate output to the artifact and emits nothing inline', async () => {
     const sink = sinkAt('quiet');
     for (let i = 0; i < 500; i += 1)
       sink.log(`[test] line ${i} ${'x'.repeat(80)}`);
+    await sink.flush();
 
     assert.deepEqual(emitted, [], 'no gate line may reach the inline sink');
     assert.equal(sink.lineCount, 500);
@@ -83,7 +89,7 @@ describe('createGateLogSink — success path (AC-3)', () => {
     );
   });
 
-  it('truncates the artifact per run so a re-run never interleaves two runs', () => {
+  it('truncates the artifact per run so a re-run never interleaves two runs', async () => {
     const dir = path.join(tmpDir, 'rerun');
     const first = createGateLogSink({
       storyId: 4736,
@@ -92,6 +98,7 @@ describe('createGateLogSink — success path (AC-3)', () => {
       level: 'info',
     });
     first.log('FIRST RUN');
+    await first.flush();
     const second = createGateLogSink({
       storyId: 4736,
       logDir: dir,
@@ -99,6 +106,7 @@ describe('createGateLogSink — success path (AC-3)', () => {
       level: 'info',
     });
     second.log('SECOND RUN');
+    await second.flush();
 
     const written = nodeFs.readFileSync(second.logPath, 'utf8');
     assert.equal(first.logPath, second.logPath, 'both runs key on the storyId');
@@ -124,10 +132,11 @@ describe('createGateLogSink — failure path (AC-4)', () => {
     ]);
   });
 
-  it('bounds the replay to the tail and says how much it omitted', () => {
+  it('bounds the replay to the tail and says how much it omitted', async () => {
     const sink = sinkAt('replay-tail');
     const total = REPLAY_TAIL_LINES + 40;
     for (let i = 0; i < total; i += 1) sink.log(`line ${i}`);
+    await sink.flush();
 
     assert.equal(sink.replay(), REPLAY_TAIL_LINES);
     assert.equal(emitted.length, REPLAY_TAIL_LINES + 1, 'tail plus one notice');
@@ -145,9 +154,10 @@ describe('createGateLogSink — failure path (AC-4)', () => {
 });
 
 describe('createGateLogSink — streaming and degradation', () => {
-  it('AGENT_LOG_LEVEL=verbose streams inline AND still writes the artifact', () => {
+  it('AGENT_LOG_LEVEL=verbose streams inline AND still writes the artifact', async () => {
     const sink = sinkAt('verbose', { level: 'verbose' });
     sink.log('gate line');
+    await sink.flush();
 
     assert.deepEqual(emitted, ['gate line']);
     assert.ok(nodeFs.readFileSync(sink.logPath, 'utf8').includes('gate line'));
@@ -177,7 +187,9 @@ describe('createGateLogSink — streaming and degradation', () => {
     assert.match(sink.digest(), /no artifact could be written/);
   });
 
-  it('survives a mid-run write failure without aborting the close', () => {
+  it('survives a mid-run write failure without aborting the close', async () => {
+    // Story #4766 — the artifact is now a stream, so the failure mode under
+    // test is a throwing/erroring `stream.write`, not a throwing `writeSync`.
     let calls = 0;
     const sink = createGateLogSink({
       storyId: 4736,
@@ -187,15 +199,38 @@ describe('createGateLogSink — streaming and degradation', () => {
       fs: {
         mkdirSync() {},
         openSync: () => 7,
-        writeSync() {
-          calls += 1;
-          throw new Error('ENOSPC: no space left on device');
-        },
+        createWriteStream: () => ({
+          on() {},
+          once() {},
+          write() {
+            calls += 1;
+            throw new Error('ENOSPC: no space left on device');
+          },
+          end(cb) {
+            cb?.();
+          },
+        }),
       },
     });
 
     assert.doesNotThrow(() => sink.log('gate line'));
     assert.equal(calls, 1);
     assert.equal(sink.lineCount, 1, 'the line is still counted and replayable');
+    await assert.doesNotReject(() => sink.flush());
+    assert.equal(sink.replay(), 1, 'the line is still replayable inline');
+  });
+
+  it('flush is idempotent and drops nothing after a second call', async () => {
+    const sink = sinkAt('flush-twice');
+    sink.log('one');
+    sink.log('two');
+    await sink.flush();
+    await sink.flush();
+
+    assert.equal(
+      nodeFs.readFileSync(sink.logPath, 'utf8'),
+      'one\ntwo\n',
+      'a second flush must neither truncate nor duplicate the artifact',
+    );
   });
 });


### PR DESCRIPTION
Closes #4766

_Auto-opened by `/deliver`._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core close-validation I/O plumbing used on every story close; behavior change is intentional (async artifact, close vs exit) but well-tested with volume regressions.
> 
> **Overview**
> Fixes close-validation failing when chatty gates (e.g. Biome) emit hundreds of lines: **synchronous per-line artifact writes** in the gate log sink blocked the event loop, filled the child's stdout pipe, and could kill an otherwise green gate (e.g. Biome exit 101).
> 
> **Gate log sink** now buffers lines through an async `fs.WriteStream` instead of `fs.writeSync`, and exposes **`flush()`** so callers await a complete artifact before read/replay. **Close-validation phase** wraps gate runs in `try/finally` and always `await gateLog.flush()`.
> 
> **Gate runner (`process.js`)** resolves on child **`close`** (not `exit`) so status is reported only after stdio is drained; **`pipePrefixed`** uses an O(chunk) line scan and swallows stream errors; the Biome "no files processed" probe keeps a **32-line tail** instead of unbounded string growth.
> 
> Adds **volume regression tests** (50k lines, no `writeSync` on drain path; high-volume spawn; concurrent gate prefixes) and updates existing gate-log tests for async flush.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f50ed9cb50dba79e1e422f2f06369eb589ef354b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->