### PR TITLE
fix(git-cleanup): report the refs the prune phase actually dropped (refs #4772)

### DIFF
--- a/.agents/scripts/lib/orchestration/git-cleanup/phases/git-probes-ff.js
+++ b/.agents/scripts/lib/orchestration/git-cleanup/phases/git-probes-ff.js
@@ -152,9 +152,24 @@ export function removeWorktree(worktreePath, cwd) {
   };
 }
 
+/**
+ * Prune the clone's stale remote-tracking refs and report which ones went.
+ *
+ * The fetch MUST NOT be `--quiet` (Story #4772). `--quiet` still prunes, but
+ * suppresses the `- [deleted] (none) -> <remote>/<ref>` progress lines that
+ * are the *only* record of what was dropped — `parsePruneFn` then reports an
+ * empty list for work that really happened, and `computeExitCode` reads the
+ * run as "nothing to do" (exit 2). The output is captured, not shown, so
+ * `--quiet` bought nothing to begin with.
+ *
+ * @param {string} cwd
+ * @param {string} remoteName
+ * @param {(output: string, remoteName: string) => string[]} parsePruneFn
+ * @returns {{ ok: boolean, pruned: string[], stderr?: string }}
+ */
 /* node:coverage ignore next */
 export function pruneRemoteTracking(cwd, remoteName, parsePruneFn) {
-  const res = gitSpawn(cwd, 'fetch', '--prune', '--quiet', remoteName);
+  const res = gitSpawn(cwd, 'fetch', '--prune', remoteName);
   if (res.status !== 0) return { ok: false, pruned: [], stderr: res.stderr };
   return { ok: true, pruned: parsePruneFn(res.stderr, remoteName) };
 }

--- a/tests/lib/orchestration/git-cleanup-prune-report.integration.test.js
+++ b/tests/lib/orchestration/git-cleanup-prune-report.integration.test.js
@@ -1,0 +1,161 @@
+// tests/lib/orchestration/git-cleanup-prune-report.integration.test.js
+//
+// Real-git round-trip tests for the prune-remotes reporting contract
+// (Story #4772). `pruneRemoteTracking` reads the short ref names it reports
+// out of `git fetch --prune`'s own progress output, so the *argv* and the
+// parser are one contract: a `--quiet` fetch still prunes, but prints
+// nothing, and the phase reports `pruned: []` for work it actually did.
+// Only a real git can prove the two halves still meet — a mocked spawn
+// asserts whatever stderr the test author writes into it.
+//
+// These spawn real git processes against a tmp two-clone fixture and take
+// longer than the mocked unit suite in tests/scripts/git-cleanup.test.js;
+// excluded from `test:quick`, run under `test:integration` / `npm test`.
+
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, it } from 'node:test';
+
+import { pruneRemoteTracking } from '../../../.agents/scripts/lib/orchestration/git-cleanup/phases/git-probes-ff.js';
+import {
+  executePrune,
+  parsePrunedRefs,
+} from '../../../.agents/scripts/lib/orchestration/git-cleanup/phases/prune.js';
+import {
+  buildJsonEnvelope,
+  computeExitCode,
+} from '../../../.agents/scripts/lib/orchestration/git-cleanup/phases/render.js';
+
+// Strip every GIT_* env var so the tmpdir cwd wins even when this suite
+// runs inside a git hook (husky pre-push exports GIT_DIR / GIT_WORK_TREE /
+// etc that would otherwise override execFileSync's `cwd`).
+const CLEAN_ENV = Object.fromEntries(
+  Object.entries(process.env).filter(([k]) => !k.startsWith('GIT_')),
+);
+
+const SILENT_LOGGER = { info() {}, warn() {} };
+
+function run(cwd, ...args) {
+  return execFileSync('git', args, {
+    cwd,
+    encoding: 'utf8',
+    stdio: ['pipe', 'pipe', 'pipe'],
+    env: CLEAN_ENV,
+  });
+}
+
+/**
+ * Remote-tracking refs the clone currently holds, e.g. `origin/fix/old`.
+ * `refs/remotes/origin/HEAD` shortens to the bare `origin`, so that entry is
+ * the clone's symbolic default-branch pointer, not a branch.
+ */
+function remoteRefs(clone) {
+  return run(
+    clone,
+    'for-each-ref',
+    '--format=%(refname:short)',
+    'refs/remotes/origin',
+  )
+    .split('\n')
+    .map((l) => l.trim())
+    .filter(Boolean);
+}
+
+describe('git-cleanup prune reporting (real git, Story #4772)', () => {
+  let base;
+  let origin;
+  let clone;
+
+  beforeEach(() => {
+    base = fs.realpathSync.native(
+      fs.mkdtempSync(path.join(os.tmpdir(), 'git-cleanup-prune-')),
+    );
+    origin = path.join(base, 'origin');
+    clone = path.join(base, 'clone');
+
+    fs.mkdirSync(origin);
+    run(origin, 'init', '-b', 'main');
+    run(origin, 'config', 'user.email', 'test@example.com');
+    run(origin, 'config', 'user.name', 'Test');
+    fs.writeFileSync(path.join(origin, 'README.md'), 'root\n');
+    run(origin, 'add', '.');
+    run(origin, 'commit', '-m', 'init');
+    // Two side branches the clone will pick up as remote-tracking refs.
+    run(origin, 'branch', 'fix/old');
+    run(origin, 'branch', 'story-319');
+
+    run(base, 'clone', origin, clone);
+    run(clone, 'config', 'user.email', 'test@example.com');
+    run(clone, 'config', 'user.name', 'Test');
+
+    // GitHub's auto-delete-on-merge, simulated: the branches vanish from the
+    // origin while the clone still tracks them.
+    run(origin, 'branch', '-D', 'fix/old');
+    run(origin, 'branch', '-D', 'story-319');
+  });
+
+  afterEach(() => {
+    fs.rmSync(base, { recursive: true, force: true });
+  });
+
+  it('reports the short names of the refs it pruned', () => {
+    assert.deepEqual(remoteRefs(clone).sort(), [
+      'origin',
+      'origin/fix/old',
+      'origin/main',
+      'origin/story-319',
+    ]);
+
+    const res = pruneRemoteTracking(clone, 'origin', parsePrunedRefs);
+
+    assert.equal(res.ok, true);
+    assert.deepEqual(
+      [...res.pruned].sort(),
+      ['fix/old', 'story-319'],
+      'pruneRemoteTracking must report the refs it dropped — a silent fetch ' +
+        'prunes the refs but leaves `pruned` empty',
+    );
+    // The refs really are gone: reporting and effect agree.
+    assert.deepEqual(remoteRefs(clone).sort(), ['origin', 'origin/main']);
+  });
+
+  it('populates prune.pruned in the --json envelope and exits 0 for a prune-only run', () => {
+    const prune = executePrune({
+      cwd: clone,
+      remoteName: 'origin',
+      logger: SILENT_LOGGER,
+    });
+
+    const envelope = buildJsonEnvelope({
+      dryRun: false,
+      baseBranch: 'main',
+      plan: { candidates: [], skipped: [] },
+      prune,
+    });
+    assert.deepEqual([...envelope.prune.pruned].sort(), [
+      'fix/old',
+      'story-319',
+    ]);
+
+    // A `--prune-remotes --execute` run: prune is the only active phase and
+    // it dropped stale refs, so the run did work — exit 0, not 2.
+    assert.equal(computeExitCode({ prune }), 0);
+  });
+
+  it('reports an empty prune and exits 2 when the clone is already tidy', () => {
+    executePrune({ cwd: clone, remoteName: 'origin', logger: SILENT_LOGGER });
+
+    const second = executePrune({
+      cwd: clone,
+      remoteName: 'origin',
+      logger: SILENT_LOGGER,
+    });
+
+    assert.equal(second.ok, true);
+    assert.deepEqual(second.pruned, []);
+    assert.equal(computeExitCode({ prune: second }), 2);
+  });
+});


### PR DESCRIPTION
Resolves #4772.

## Why

`pruneRemoteTracking` ran `git fetch --prune --quiet`, but the short ref names it
reports are parsed out of that command's own progress output. `--quiet` suppresses
the `- [deleted]  (none)  -> origin/<ref>` lines that `parsePrunedRefs` matches, so
stale refs were pruned and `pruned` came back empty on every run. The output is
captured, never shown to the operator, so `--quiet` bought nothing.

Two consequences:

1. `prune.pruned` in the `--json` envelope was unconditionally `[]` — the documented
   `"pruned": ["fix/old"]` shape could never be populated.
2. `computeExitCode` uses `(prune.pruned?.length ?? 0) > 0` as the prune phase's only
   "did work" signal, so a `--prune-remotes --execute` run that really dropped stale
   refs exited **2** ("nothing to do") instead of 0. A CI consumer read "already tidy"
   while work had silently been performed.

Observed live in a consumer on 2026-07-25: a run pruned 4 stale tracking refs
(`story-319`, `story-320`, `story-325`,
`release-please--branches--main--components--mandrel-platform` — all left by GitHub
auto-delete-on-merge) and logged `✅ prune origin (no stale refs)`.

`.agents/workflows/git-cleanup.md` already documented the command as
`git fetch --prune origin`; the code had drifted from its own doc.

## What

- Drop `--quiet` from the prune fetch, with a docblock naming the coupling so it is
  not re-added as a "harmless" tidy-up.
- New real-git regression suite `tests/lib/orchestration/git-cleanup-prune-report.integration.test.js`
  (two-clone fixture, branches deleted on the origin), covering all four ACs: the
  reported names, the refs really being gone, the `--json` envelope, exit 0 for a
  prune-only run that did work, and exit 2 when the clone was already tidy.

### Why the guard is integration-tier

The existing unit tests — `parsePrunedRefs` for both output forms
(`tests/scripts/git-cleanup.test.js:945`) and `computeExitCode` returning 0 when
prune reported refs (`:1750`) — were **green the whole time this shipped**. Both are
pure and never see the argv, so neither could catch it. The argv and the parser are a
single contract; only a real git proves the two halves still meet. A mocked spawn just
asserts whatever stderr the test author typed into it.

## Verification

- `node --test tests/lib/orchestration/git-cleanup-prune-report.integration.test.js` —
  red before the fix (`pruned: []` on both reporting assertions), green after.
- `npm test` — 8672 pass / 0 fail / 4 skipped.
- `npm run lint`, `npm run verify` — exit 0.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small behavioral fix to git-cleanup orchestration with integration coverage; no auth, data, or broad API surface changes.
> 
> **Overview**
> **Fixes stale remote-tracking prune reporting** so `pruneRemoteTracking` no longer runs `git fetch --prune --quiet`. Pruned ref names are parsed from fetch progress on stderr; quiet mode still prunes but hides those lines, so `pruned` stayed empty, `--json` `prune.pruned` never populated, and prune-only runs could exit **2** (“nothing to do”) even after refs were dropped.
> 
> Adds a docblock on `pruneRemoteTracking` documenting that coupling so `--quiet` is not reintroduced. New real-git integration tests (`git-cleanup-prune-report.integration.test.js`) assert reported ref names, JSON envelope, exit **0** when work happened, and exit **2** when already tidy.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ba05a7a8e35ee1d6c3c18625f04541f1f371e8b7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->