### PR TITLE
fix(crap): join per-method coverage in original-source coordinates — TS scoring resolves ~5% of methods (#4775)

### DIFF
--- a/.agentrc.json
+++ b/.agentrc.json
@@ -34,7 +34,7 @@
     "quality": {
       "gates": {
         "crap": {
-          "floors": { "*": { "max": 30 } },
+          "floors": { "*": { "max": 125 } },
           "targetDirs": [".agents/scripts", "bin", "lib"],
           "ignoreGlobs": [
             ".agents/scripts/lifecycle-emit.js",

--- a/.agents/docs/configuration.md
+++ b/.agents/docs/configuration.md
@@ -174,6 +174,7 @@ top-level keys are validation errors.
 | `quality.gates.crap.targetDirs` | No | `string[]` or `{ append?, prepend? }` | — | Directories whose JS sources the CRAP gate scores. Mandrel ships a `src/`-centric default; projects whose executable code lives elsewhere (e.g. this repo's `.agents/scripts/`) override here. The framework default is intentionally not auto-discovered, so an override is the explicit, auditable signal. |
 | `quality.gates.crap.newMethodCeiling` | No | `integer` | — | — |
 | `quality.gates.crap.requireCoverage` | No | `boolean` | — | — |
+| `quality.gates.crap.minMethodResolutionRate` | No | `number` | — | Fail-closed floor on the per-method coverage JOIN (Story #4775): the fraction of methods that must resolve a coverage entry, counted only over files that HAVE one, before `update-crap-baseline.js` will persist. A broken join is silent by construction — unresolved methods are simply absent — so the updater refuses rather than writing a thin baseline and logging it as success. Not enforced below 25 joinable methods, where a diff-scoped run's rate is noise. Default 0.75; a healthy repo resolves ~98%. |
 | `quality.gates.crap.friction` | No | `object` | — | Nested configuration block. |
 | `quality.gates.crap.friction.markerKey` | No | `string` | — | — |
 | `quality.gates.crap.refreshTag` | No | `string` | — | — |

--- a/.agents/docs/quality-gates.md
+++ b/.agents/docs/quality-gates.md
@@ -400,6 +400,15 @@ joinable methods, where a diff-scoped run's rate is noise. A healthy repo
 resolves ~98%; the 4–6% signature of a coordinate-system mismatch is far below
 the floor.
 
+**Re-derive your floors after adopting this.** A `crap.floors` ceiling pinned
+before the fix was pinned to a maximum computed over the minority of methods
+the join could see, so it is not a real ceiling — it is an artefact. This
+repository's own `*.max` moved from `30` to `125` on the first honest scan
+(2215 → 4058 visible methods), not because anything got worse but because the
+worst methods were previously invisible. `newMethodCeiling` is deliberately
+left at 30: the ratchet's forward pressure on *new* code is unaffected by how
+much old debt the gate can now see.
+
 **Old baselines are invalidated explicitly.** Rows scored by the previous join
 are not comparable to rows scored by this one, and neither `kernelVersion` nor
 `escomplexVersion` moves (both track the same upstream package). The envelope

--- a/.agents/docs/quality-gates.md
+++ b/.agents/docs/quality-gates.md
@@ -361,6 +361,53 @@ There is no CI guardrail rejecting unlabeled baseline edits; the convention is
 preserved so the operator can grep refresh commits in a PR diff, but
 self-policing is the operator's job during `/deliver`'s watch loop.
 
+### The per-method coverage join (Story #4775)
+
+CRAP is the only gate that joins two independently-produced artifacts: the
+per-method complexity escomplex derives from the source, and the per-function
+coverage istanbul derives from the test run. Everything below exists because
+that join is silent when it fails — an unresolved method is simply absent from
+the baseline, so a broken join looks exactly like a small repo.
+
+**One coordinate system.** For a TS/TSX source, escomplex parses the
+*transpiled* output and reports each method's `lineStart` in transpiled
+coordinates, while `coverage-final.json` is keyed against the *original*
+source. The scorer therefore asks `transpileIfNeeded` for a source map
+(`{ withLineMap: true }`, backed by Node's built-in `SourceMap` — no extra
+runtime dependency) and remaps each method start into original coordinates
+before the lookup. JavaScript is a passthrough: its coordinates already are
+original coordinates, so no map is computed and nothing changes. The
+maintainability path never requests a map, and the emitted code is
+byte-identical either way, so MI scores are unaffected.
+
+**Tolerant matching.** Remapping alone is insufficient: escomplex's method
+start and istanbul's `decl.start.line` disagree by a line when a decorator, a
+leading `export`, or a wrapped parameter list sits between them. The lookup is
+exact-line first (so every already-resolving row keeps its exact prior value),
+then innermost containment, then nearest declaration within ±1.
+
+**`requireCoverage: false` means score it.** A method with no coverage entry
+scores as 0% covered — `crap = c² + c`, the formula's own treatment of
+untested code — and lands in the baseline. It used to be dropped individually
+regardless of the flag, which made the flag a no-op for baseline population.
+`requireCoverage: true` still skips and counts it.
+
+**The updater fails closed on a thin result.** `update-crap-baseline.js`
+reports `resolved/joinable` over files that *have* coverage and refuses to
+persist below `delivery.quality.gates.crap.minMethodResolutionRate` (default
+`0.75`), naming the worst unresolved files. The floor is not enforced below 25
+joinable methods, where a diff-scoped run's rate is noise. A healthy repo
+resolves ~98%; the 4–6% signature of a coordinate-system mismatch is far below
+the floor.
+
+**Old baselines are invalidated explicitly.** Rows scored by the previous join
+are not comparable to rows scored by this one, and neither `kernelVersion` nor
+`escomplexVersion` moves (both track the same upstream package). The envelope
+therefore carries a `scoringSemantics` stamp; `check-baselines` fails closed on
+a mismatch with the exact re-baseline command rather than comparing across the
+boundary. Bump the stamp whenever the coverage join, the line coordinate
+system, or the unresolved-method policy changes.
+
 ---
 
 ## Bundle-size ratchet — one-shot refresh/acknowledge (Story #151)

--- a/.agents/schemas/agentrc.schema.json
+++ b/.agents/schemas/agentrc.schema.json
@@ -774,6 +774,12 @@
         "requireCoverage": {
           "type": "boolean"
         },
+        "minMethodResolutionRate": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 1,
+          "description": "Fail-closed floor on the per-method coverage JOIN (Story #4775): the fraction of methods that must resolve a coverage entry, counted only over files that HAVE one, before `update-crap-baseline.js` will persist. A broken join is silent by construction — unresolved methods are simply absent — so the updater refuses rather than writing a thin baseline and logging it as success. Not enforced below 25 joinable methods, where a diff-scoped run's rate is noise. Default 0.75; a healthy repo resolves ~98%."
+        },
         "friction": {
           "type": "object",
           "properties": {

--- a/.agents/schemas/baselines/baseline-envelope.schema.json
+++ b/.agents/schemas/baselines/baseline-envelope.schema.json
@@ -21,6 +21,10 @@
       "format": "date-time",
       "description": "ISO-8601 timestamp of the baseline run. Used for stale-baseline detection and audit trails."
     },
+    "scoringSemantics": {
+      "type": "string",
+      "description": "Optional per-kind stamp identifying the SCORING SEMANTICS that produced these rows — the dimension kernelVersion cannot express, because a kind's own scoring can change while the upstream package it stamps does not. A baseline whose stamp differs from the running scorer's is incomparable and the gate fails closed with re-baseline guidance rather than comparing across the boundary."
+    },
     "rollup": {
       "type": "object",
       "description": "Aggregate metrics keyed by component. The '*' key is reserved for the whole-repo rollup and is REQUIRED; additional keys MAY be present, one per declared component.",

--- a/.agents/schemas/baselines/crap.schema.json
+++ b/.agents/schemas/baselines/crap.schema.json
@@ -6,6 +6,10 @@
   "allOf": [{ "$ref": "baseline-envelope.schema.json" }],
   "type": "object",
   "properties": {
+    "scoringSemantics": {
+      "type": "string",
+      "description": "Identifier for the per-method coverage-join semantics that produced these rows (Story #4775). Deliberately NOT constrained to the current value here: an old-semantics baseline must reach the gate's compat axis, which fails it closed with an explicit re-baseline command, rather than being rejected with a raw schema error."
+    },
     "rollup": {
       "type": "object",
       "required": ["*"],

--- a/.agents/scripts/lib/baselines/envelope.js
+++ b/.agents/scripts/lib/baselines/envelope.js
@@ -133,6 +133,7 @@ function resolveGeneratedAt(explicit) {
  *   rows: Array<object>,
  *   kernelVersion: string,
  *   generatedAt?: string,
+ *   extras?: Record<string, unknown>,
  * }} params
  * @returns {{
  *   $schema: string,
@@ -148,6 +149,7 @@ export function buildEnvelope({
   rows,
   kernelVersion,
   generatedAt,
+  extras,
 } = {}) {
   if (typeof kind !== 'string' || !KNOWN_KINDS.includes(kind)) {
     throw new TypeError(
@@ -176,10 +178,15 @@ export function buildEnvelope({
     throw new TypeError('envelope.buildEnvelope: rows must be an array');
   }
 
+  // Per-kind envelope-level stamps (Story #4775). A kind whose SCORING
+  // SEMANTICS can change independently of its kernel version contributes them
+  // here; `assertEnvelope` still validates the result against the kind's
+  // schema, so an unrecognised extra fails closed rather than being persisted.
   return {
     $schema: schemaRefFor(kind),
     kernelVersion,
     generatedAt: resolveGeneratedAt(generatedAt),
+    ...(extras && typeof extras === 'object' ? extras : {}),
     rollup,
     rows,
   };

--- a/.agents/scripts/lib/baselines/kernel.js
+++ b/.agents/scripts/lib/baselines/kernel.js
@@ -50,7 +50,9 @@ import {
 } from './kinds/coverage.js';
 import {
   applyEpsilon as crapApplyEpsilon,
+  assertBaselineCompatible as crapAssertBaselineCompatible,
   compare as crapCompare,
+  envelopeExtras as crapEnvelopeExtras,
   kernelVersion as crapKernelVersion,
   keyField as crapKeyField,
   mergeRows as crapMergeRows,
@@ -139,6 +141,12 @@ function bindKindModule(members) {
     compare: members.compare,
     applyEpsilon: members.applyEpsilon,
     mergeRows: members.mergeRows,
+    // Optional per-kind hooks (Story #4775). `envelopeExtras` contributes
+    // envelope-level stamps the shared writer would not otherwise know about;
+    // `assertBaselineCompatible` lets a kind refuse a loaded baseline whose
+    // scoring semantics predate the running scorer.
+    envelopeExtras: members.envelopeExtras,
+    assertBaselineCompatible: members.assertBaselineCompatible,
   });
 }
 
@@ -179,6 +187,8 @@ const KIND_MODULES = Object.freeze({
     compare: crapCompare,
     applyEpsilon: crapApplyEpsilon,
     mergeRows: crapMergeRows,
+    envelopeExtras: crapEnvelopeExtras,
+    assertBaselineCompatible: crapAssertBaselineCompatible,
   }),
   maintainability: bindKindModule({
     name: maintainabilityName,
@@ -268,6 +278,27 @@ export function getKindModule(kind) {
  */
 export function currentKernelVersion(kind) {
   return getKindModule(kind).kernelVersion();
+}
+
+/**
+ * Ask a kind whether a loaded baseline is compatible with the running
+ * scorer's SEMANTICS — a dimension `kernelVersion` cannot express, because a
+ * kind's scoring can change while the upstream package it stamps does not
+ * (Story #4775). Kinds without the hook always answer "compatible".
+ *
+ * @param {string} kind
+ * @param {object|null} baseline
+ * @returns {string|null} Operator-facing message, or null when compatible.
+ */
+export function checkBaselineSemantics(kind, baseline) {
+  let mod;
+  try {
+    mod = getKindModule(kind);
+  } catch {
+    return null;
+  }
+  if (typeof mod.assertBaselineCompatible !== 'function') return null;
+  return mod.assertBaselineCompatible(baseline);
 }
 
 /**

--- a/.agents/scripts/lib/baselines/kinds/crap.js
+++ b/.agents/scripts/lib/baselines/kinds/crap.js
@@ -92,8 +92,13 @@ export function kernelVersion() {
  * The stamp makes the boundary explicit and fails closed. Bump it whenever
  * the coverage join, the line coordinate system, or the unresolved-method
  * policy changes.
+ *
+ * Deliberately module-local: `envelopeExtras()` is the single production door
+ * to this value, so exporting the bare constant would add a second entry
+ * point that nothing in production reaches. Callers and tests that need the
+ * string read it off `envelopeExtras().scoringSemantics`.
  */
-export const SCORING_SEMANTICS = 'coverage-join-v2';
+const SCORING_SEMANTICS = 'coverage-join-v2';
 
 /**
  * Envelope-level stamps this kind contributes beyond the shared envelope

--- a/.agents/scripts/lib/baselines/kinds/crap.js
+++ b/.agents/scripts/lib/baselines/kinds/crap.js
@@ -75,6 +75,36 @@ export function kernelVersion() {
   return '0.0.0';
 }
 
+/**
+ * Scoring-semantics stamp (Story #4775, fix part 5).
+ *
+ * `kernelVersion()` above tracks the `typhonjs-escomplex` package and
+ * `escomplexVersion` tracks the same dependency — so a change in how THIS
+ * repo joins escomplex methods to istanbul coverage moves neither. Rows
+ * scored by the pre-#4775 join (exact transpiled-line equality, methods
+ * dropped when unresolved) are not comparable to rows scored by the join
+ * that replaced it (original-source coordinates, containment matching,
+ * honest `requireCoverage: false`): the same method can carry a different
+ * `crap`, a different `startLine`, or exist in one baseline and not the
+ * other. Comparing across that boundary produces phantom regressions and,
+ * worse, phantom passes.
+ *
+ * The stamp makes the boundary explicit and fails closed. Bump it whenever
+ * the coverage join, the line coordinate system, or the unresolved-method
+ * policy changes.
+ */
+export const SCORING_SEMANTICS = 'coverage-join-v2';
+
+/**
+ * Envelope-level stamps this kind contributes beyond the shared envelope
+ * keys. Consumed by `writer.write` via the kind-module protocol.
+ *
+ * @returns {{scoringSemantics: string}}
+ */
+export function envelopeExtras() {
+  return { scoringSemantics: SCORING_SEMANTICS };
+}
+
 export function projectRow(row) {
   return {
     path: canonicalise(row.path ?? row.file),
@@ -373,6 +403,23 @@ export const CRAP_COMPAT_AXES = [
   },
   kernelDriftAxis('CRAP'),
   {
+    name: 'scoring-semantics-drift',
+    severity: 'fatal',
+    check: ({ baseline }) => {
+      if (!baseline) return null;
+      const stamped = baseline.scoringSemantics ?? null;
+      if (stamped === SCORING_SEMANTICS) return null;
+      return (
+        `[CRAP] scoring semantics changed: baseline=${stamped ?? '<unstamped>'} ` +
+        `running=${SCORING_SEMANTICS}. Rows scored by the previous per-method ` +
+        'coverage join are not comparable to rows scored by the current one, ' +
+        'so this baseline cannot be compared — it must be re-derived. Run ' +
+        "'npm run test:coverage' then 'npm run crap:update -- --full-scope' " +
+        "and commit the result with a 'baseline-refresh:' subject."
+      );
+    },
+  },
+  {
     name: 'ts-transpiler-drift',
     severity: 'warn',
     check: ({ baseline, runningTsTranspilerVersion }) => {
@@ -399,6 +446,30 @@ export const CRAP_COMPAT_AXES = [
  */
 export function evaluateBaselineCompatibility(ctx) {
   return reduceCompatAxes(CRAP_COMPAT_AXES, ctx);
+}
+
+/**
+ * Kind-module hook (Story #4775): the subset of the compat table that a
+ * *loaded* v2 envelope can be judged against on its own, with no running
+ * dependency versions to compare. The unified `check-baselines` gate calls it
+ * straight after `reader.load` and turns a message into a fail-closed
+ * schema-class error, so a baseline written by the previous scoring semantics
+ * can never be silently compared against new-semantics scores.
+ *
+ * The version-drift axes stay out: the v2 envelope does not carry
+ * `escomplexVersion` / `tsTranspilerVersion`, and running those checks against
+ * an absent field would compare `undefined` to `undefined` and pass
+ * vacuously — worse than not running them.
+ *
+ * @param {object|null} baseline A loaded v2 baseline envelope.
+ * @returns {string|null} Operator-facing message, or null when compatible.
+ */
+export function assertBaselineCompatible(baseline) {
+  if (!baseline) return null;
+  const axis = CRAP_COMPAT_AXES.find(
+    (a) => a.name === 'scoring-semantics-drift',
+  );
+  return axis ? axis.check({ baseline }) : null;
 }
 
 /**

--- a/.agents/scripts/lib/baselines/reader.js
+++ b/.agents/scripts/lib/baselines/reader.js
@@ -18,7 +18,8 @@
 //      hand-edited while inside a story worktree — so downstream
 //      consumers see canonical repo-relative paths.
 //   5. Returns the envelope's headline fields plus rows/rollup as a
-//      narrow contract: `{ rollup, rows, kernelVersion, generatedAt }`.
+//      narrow contract: `{ rollup, rows, kernelVersion, generatedAt,
+//      scoringSemantics }`.
 //
 // Reader-only: the writer side lives in a sibling module (Story #1891).
 // No I/O happens here beyond reading the JSON file itself.
@@ -215,6 +216,11 @@ function readAndShape(kind, absolutePath) {
     rows,
     kernelVersion: parsed.kernelVersion,
     generatedAt: parsed.generatedAt,
+    // Story #4775 — carry the per-kind scoring-semantics stamp through the
+    // narrowing. The gate's compat check reads it off the LOADED envelope, so
+    // dropping it here would make every baseline look unstamped and fail the
+    // whole repo closed on a stamp that is actually present on disk.
+    scoringSemantics: parsed.scoringSemantics,
   };
 }
 
@@ -303,6 +309,11 @@ export function loadFile(absolutePath, opts = {}) {
     rows,
     kernelVersion: parsed.kernelVersion,
     generatedAt: parsed.generatedAt,
+    // Story #4775 — carry the per-kind scoring-semantics stamp through the
+    // narrowing. The gate's compat check reads it off the LOADED envelope, so
+    // dropping it here would make every baseline look unstamped and fail the
+    // whole repo closed on a stamp that is actually present on disk.
+    scoringSemantics: parsed.scoringSemantics,
   };
 }
 

--- a/.agents/scripts/lib/baselines/writer.js
+++ b/.agents/scripts/lib/baselines/writer.js
@@ -184,6 +184,8 @@ export function write({
     rollup,
     kernelVersion: kernelVersion ?? currentKernelVersion(kind),
     generatedAt,
+    extras:
+      typeof mod.envelopeExtras === 'function' ? mod.envelopeExtras() : null,
   });
   assertEnvelope(envelope);
   return envelope;

--- a/.agents/scripts/lib/baselines/writer.js
+++ b/.agents/scripts/lib/baselines/writer.js
@@ -260,10 +260,18 @@ export function writeFile(absPath, envelope, opts = {}) {
   // Canonical key order on the top-level envelope keeps diffs stable
   // across runs and platforms. Per-kind row keys retain their natural
   // declaration order; the row sort is done by `sortRows()`.
+  //
+  // Story #4775: the projection is deliberately explicit, so any per-kind
+  // envelope stamp (`scoringSemantics`) must be carried through by name or it
+  // is silently dropped on the way to disk — the stamp would then be present
+  // in memory, validated, and absent from the file it exists to protect.
   const canonical = {
     $schema: envelope.$schema,
     kernelVersion: envelope.kernelVersion,
     generatedAt: envelope.generatedAt,
+    ...(envelope.scoringSemantics === undefined
+      ? {}
+      : { scoringSemantics: envelope.scoringSemantics }),
     rollup: envelope.rollup,
     rows: envelope.rows,
   };

--- a/.agents/scripts/lib/config/gates/crap.schema.js
+++ b/.agents/scripts/lib/config/gates/crap.schema.js
@@ -13,6 +13,13 @@ export const CRAP_GATE = {
     targetDirs: LIST_OR_EXTENDER_OF_STRINGS,
     newMethodCeiling: { type: 'integer', minimum: 1 },
     requireCoverage: { type: 'boolean' },
+    // Story #4775 — fail-closed floor on the per-method coverage JOIN: the
+    // fraction of methods that must resolve a coverage entry, counted only
+    // over files that HAVE one, before `update-crap-baseline.js` will
+    // persist. A broken join is silent by construction (unresolved methods
+    // are simply absent), so the updater refuses rather than writing a thin
+    // baseline and logging it as success. Default 0.75.
+    minMethodResolutionRate: { type: 'number', minimum: 0, maximum: 1 },
     friction: {
       type: 'object',
       properties: { markerKey: { type: 'string', minLength: 1 } },

--- a/.agents/scripts/lib/config/quality.js
+++ b/.agents/scripts/lib/config/quality.js
@@ -88,6 +88,15 @@ export const CRAP_GATE_DEFAULTS = Object.freeze({
   // semantics.
   refreshTimeoutMs: 60_000,
   ignoreGlobs: Object.freeze([]),
+  // Story #4775 — fail-closed floor on the per-method coverage JOIN. The
+  // fraction of methods that must resolve a coverage entry, counted only over
+  // files that HAVE one, before `update-crap-baseline.js` will persist. A
+  // broken join is silent by construction (unresolved methods are simply
+  // absent from the baseline), so the updater refuses rather than writing a
+  // thin baseline and logging it as success. 0.75 sits far above a healthy
+  // run (a repo with fresh coverage resolves ~98%) and far below the 4–6%
+  // signature of a coordinate-system mismatch.
+  minMethodResolutionRate: 0.75,
 });
 
 /** Framework defaults for the coverage gate. */
@@ -121,6 +130,15 @@ export const MAINTAINABILITY_GATE_DEFAULTS = Object.freeze({
   // spawned by the baseline-attribution refresh path. Defaults to 60 s.
   refreshTimeoutMs: 60_000,
   ignoreGlobs: Object.freeze([]),
+  // Story #4775 — fail-closed floor on the per-method coverage JOIN. The
+  // fraction of methods that must resolve a coverage entry, counted only over
+  // files that HAVE one, before `update-crap-baseline.js` will persist. A
+  // broken join is silent by construction (unresolved methods are simply
+  // absent from the baseline), so the updater refuses rather than writing a
+  // thin baseline and logging it as success. 0.75 sits far above a healthy
+  // run (a repo with fresh coverage resolves ~98%) and far below the 4–6%
+  // signature of a coordinate-system mismatch.
+  minMethodResolutionRate: 0.75,
 });
 
 /**
@@ -144,6 +162,7 @@ const CRAP_GATE_KEYS = new Set([
   'refreshTag',
   'refreshTimeoutMs',
   'ignoreGlobs',
+  'minMethodResolutionRate',
 ]);
 
 const COVERAGE_GATE_KEYS = new Set([
@@ -205,6 +224,22 @@ function warnUnknownKeys(userBlock, knownKeys, blockLabel) {
  * @param {{ coveragePath: string }} coverageGate resolved coverage gate
  * @returns {object} flattened legacy-bag view that existing callers read
  */
+/**
+ * Clamp a user-supplied method-resolution floor into `[0, 1]`. A
+ * non-numeric, non-finite, or out-of-range value falls back to the framework
+ * default rather than silently disabling the guard (a floor of `NaN` would
+ * compare false against every rate and never fire).
+ *
+ * @param {unknown} value
+ * @param {number} fallback
+ * @returns {number}
+ */
+function resolveResolutionRate(value, fallback) {
+  if (typeof value !== 'number' || !Number.isFinite(value)) return fallback;
+  if (value < 0 || value > 1) return fallback;
+  return value;
+}
+
 export function resolveMaintainabilityCrap(
   userCrap,
   gateScoping,
@@ -227,6 +262,7 @@ export function resolveMaintainabilityCrap(
         DEFAULT_CRAP_TOLERANCE.value,
       ),
       requireCoverage: defaults.requireCoverage,
+      minMethodResolutionRate: defaults.minMethodResolutionRate,
       friction: { ...defaults.friction },
       refreshTag: defaults.refreshTag,
       refreshTimeoutMs: defaults.refreshTimeoutMs,
@@ -248,6 +284,10 @@ export function resolveMaintainabilityCrap(
       toleranceScalar(defaults.tolerance, DEFAULT_CRAP_TOLERANCE.value),
     ),
     requireCoverage: userCrap.requireCoverage ?? defaults.requireCoverage,
+    minMethodResolutionRate: resolveResolutionRate(
+      userCrap.minMethodResolutionRate,
+      defaults.minMethodResolutionRate,
+    ),
     friction: { ...defaults.friction, ...(userCrap.friction ?? {}) },
     refreshTag: userCrap.refreshTag ?? defaults.refreshTag,
     refreshTimeoutMs: resolvePositiveIntegerMs(

--- a/.agents/scripts/lib/coverage-utils.js
+++ b/.agents/scripts/lib/coverage-utils.js
@@ -121,6 +121,8 @@ export function hasCoverageFor(map, relPath) {
  *   raw `fnMap` entry — so callers may key by the escomplex `lineStart`
  *   (which can match either, depending on producer).
  * - `fnLocByStartLine`: same keying, value is `{fnStart, fnEnd}` derived once.
+ * - `fnRanges`: every function's `{fnStart, fnEnd, declLine}` triple, used by
+ *   the containment / nearest-decl fallbacks when exact-line keying misses.
  * - `statementsByLine`: `Map<line, {total, covered}>` so range scans don't
  *   re-walk the full statement map.
  *
@@ -129,9 +131,10 @@ export function hasCoverageFor(map, relPath) {
 export function buildEntryIndex(entry) {
   const fnByStartLine = new Map();
   const fnLocByStartLine = new Map();
+  const fnRanges = [];
   const statementsByLine = new Map();
   if (!entry || typeof entry !== 'object') {
-    return { fnByStartLine, fnLocByStartLine, statementsByLine };
+    return { fnByStartLine, fnLocByStartLine, fnRanges, statementsByLine };
   }
   const fnMap = entry.fnMap ?? {};
   const statementMap = entry.statementMap ?? {};
@@ -152,6 +155,13 @@ export function buildEntryIndex(entry) {
       fnByStartLine.set(locLine, f);
       fnLocByStartLine.set(locLine, loc);
     }
+    if (fnStart !== null && fnEnd !== null) {
+      fnRanges.push({
+        fnStart,
+        fnEnd,
+        declLine: typeof declLine === 'number' ? declLine : fnStart,
+      });
+    }
   }
 
   for (const stmtId of Object.keys(statementMap)) {
@@ -167,7 +177,76 @@ export function buildEntryIndex(entry) {
     if ((statementHits[stmtId] ?? 0) > 0) bucket.covered += 1;
   }
 
-  return { fnByStartLine, fnLocByStartLine, statementsByLine };
+  return { fnByStartLine, fnLocByStartLine, fnRanges, statementsByLine };
+}
+
+/**
+ * How far from a `fnMap` declaration line a method start may sit and still
+ * be considered the same function.
+ *
+ * Even after remapping to original-source coordinates (Story #4775), a
+ * method's start and istanbul's `decl.start.line` do not always agree on the
+ * token: escomplex anchors on the function node, istanbul on the declaration
+ * it instruments, and a decorator, a leading `export`, or a multi-line
+ * parameter list puts them one line apart. One line of slack absorbs that
+ * without letting an unrelated neighbouring function be claimed.
+ */
+const DECL_MATCH_WINDOW = 1;
+
+/**
+ * Resolve the `{fnStart, fnEnd}` range of the function a method start line
+ * belongs to, in the coordinate system of the coverage entry.
+ *
+ * Three strategies, most precise first:
+ *
+ *   1. **Exact** — the line keys a `fnMap` `decl.start.line` or
+ *      `loc.start.line`. This is the pre-#4775 behaviour and still wins, so
+ *      every already-resolving row keeps its exact prior value.
+ *   2. **Containment** — the innermost function whose `loc` range contains
+ *      the line. Smallest span wins, so a nested callback is preferred over
+ *      the enclosing function that also contains the line.
+ *   3. **Nearest declaration** — the closest `decl` line within
+ *      `DECL_MATCH_WINDOW`, which absorbs the ±1 token disagreement between
+ *      escomplex's method start and istanbul's declaration line.
+ *
+ * Returns `null` when none of the three finds a function — the caller
+ * surfaces that as "no data" rather than "tested zero times."
+ *
+ * @param {{fnByStartLine: Map, fnLocByStartLine: Map, fnRanges: Array}} idx
+ * @param {number} startLine
+ * @returns {{fnStart: number, fnEnd: number}|null}
+ */
+function resolveFnRangeForLine(idx, startLine) {
+  if (typeof startLine !== 'number') return null;
+  if (idx.fnByStartLine.has(startLine)) {
+    const loc = idx.fnLocByStartLine.get(startLine);
+    if (loc && loc.fnStart !== null && loc.fnEnd !== null) return loc;
+  }
+  const ranges = idx.fnRanges ?? [];
+  let innermost = null;
+  let innermostSpan = Number.POSITIVE_INFINITY;
+  for (const range of ranges) {
+    if (startLine < range.fnStart || startLine > range.fnEnd) continue;
+    const span = range.fnEnd - range.fnStart;
+    if (span < innermostSpan) {
+      innermostSpan = span;
+      innermost = range;
+    }
+  }
+  if (innermost) return { fnStart: innermost.fnStart, fnEnd: innermost.fnEnd };
+
+  let nearest = null;
+  let nearestDist = Number.POSITIVE_INFINITY;
+  for (const range of ranges) {
+    const dist = Math.abs(range.declLine - startLine);
+    if (dist > DECL_MATCH_WINDOW) continue;
+    if (dist < nearestDist) {
+      nearestDist = dist;
+      nearest = range;
+    }
+  }
+  if (nearest) return { fnStart: nearest.fnStart, fnEnd: nearest.fnEnd };
+  return null;
 }
 
 function getEntryIndex(entry) {
@@ -193,22 +272,26 @@ function getEntryIndex(entry) {
  * returns 0. A missing / malformed entry or no matching function returns
  * `null` so the caller can distinguish "no data" from "tested zero times."
  *
+ * `startLine` MUST be in the coverage entry's own (original-source)
+ * coordinate system. Callers scoring transpiled TypeScript remap escomplex's
+ * transpiled `lineStart` first — see `transpileIfNeeded`'s `withLineMap`
+ * option (Story #4775). Matching is exact-then-containment-then-nearest-decl;
+ * see `resolveFnRangeForLine`.
+ *
  * The first call on a given entry builds and caches a per-entry index via a
  * non-enumerable Symbol property; consecutive method lookups in the same
  * file pay the build cost exactly once.
  *
  * @param {object|null} entry One inner value from a `coverage-final.json` map.
- * @param {number} startLine The escomplex `lineStart` for the method.
+ * @param {number} startLine The method's start line, in entry coordinates.
  * @returns {number|null}
  */
 export function coverageForMethodInEntry(entry, startLine) {
   if (!entry || typeof entry !== 'object') return null;
   const idx = getEntryIndex(entry);
-  if (!idx.fnByStartLine.has(startLine)) return null;
-  const loc = idx.fnLocByStartLine.get(startLine);
-  if (!loc) return null;
-  const { fnStart, fnEnd } = loc;
-  if (fnStart === null || fnEnd === null) return null;
+  const range = resolveFnRangeForLine(idx, startLine);
+  if (!range) return null;
+  const { fnStart, fnEnd } = range;
 
   let total = 0;
   let covered = 0;
@@ -228,7 +311,7 @@ export function coverageForMethodInEntry(entry, startLine) {
  *
  * @param {object|null} map Parsed `coverage-final.json`.
  * @param {string} relPath Repo-relative path of the source file.
- * @param {number} startLine The escomplex `lineStart` for the method.
+ * @param {number} startLine The method's start line, in entry coordinates.
  * @returns {number|null} Coverage in [0, 1], or null when the file or method
  *   is absent.
  */

--- a/.agents/scripts/lib/crap-engine.js
+++ b/.agents/scripts/lib/crap-engine.js
@@ -2,6 +2,108 @@ import escomplex from 'typhonjs-escomplex';
 import { coverageForMethodInEntry } from './coverage-utils.js';
 
 /**
+ * Derive the raw per-method CRAP rows from an escomplex report.
+ *
+ * Single-sourced between `calculateCrapForSource` (CRAP-only path) and
+ * `analyzeOnce` (combined MI + CRAP path) so the two cannot drift on how a
+ * method's line is remapped or its coverage joined — the parity the
+ * combined-parity suite asserts.
+ *
+ * **Coordinates (Story #4775).** `mapLine` translates escomplex's
+ * `lineStart` — which is in *transpiled* coordinates for a TS/TSX source —
+ * into the *original source* coordinates istanbul's `fnMap` uses. Without it
+ * the join compares two different coordinate systems and either misses or,
+ * worse, collides with an unrelated function. A `null` mapper means the two
+ * coordinate systems already coincide (plain JavaScript), and a line the map
+ * cannot resolve falls back to the un-remapped value rather than dropping the
+ * method outright. The remapped line is also what the row reports, so a
+ * persisted row points at a line the reader can actually open.
+ *
+ * @param {object|null} report An `escomplex.analyzeModule` report.
+ * @param {object|null} coverageForFile Istanbul coverage entry for this file.
+ * @param {((line: number) => number|null)|null} [mapLine]
+ * @returns {Array<{
+ *   method: string,
+ *   startLine: number,
+ *   cyclomatic: number,
+ *   coverage: number|null,
+ *   crap: number|null,
+ * }>}
+ */
+export function methodRowsFromReport(report, coverageForFile, mapLine = null) {
+  const methods = report?.methods ?? [];
+  const rows = [];
+  for (const m of methods) {
+    const rawStartLine = m?.lineStart;
+    if (typeof rawStartLine !== 'number') continue;
+    const mapped = typeof mapLine === 'function' ? mapLine(rawStartLine) : null;
+    const startLine = typeof mapped === 'number' ? mapped : rawStartLine;
+    const cyclomatic = m?.cyclomatic ?? 0;
+    const coverage = coverageForFile
+      ? coverageForMethodInEntry(coverageForFile, startLine)
+      : null;
+    const crap = coverage === null ? null : crapFormula(cyclomatic, coverage);
+    rows.push({ method: m.name, startLine, cyclomatic, coverage, crap });
+  }
+  return rows;
+}
+
+/**
+ * Apply the scanner's `requireCoverage` policy to raw method rows and report
+ * how much of the coverage join actually landed.
+ *
+ * Two policies, one honest each way (Story #4775, fix part 3):
+ *
+ *   - `requireCoverage: true` — an unresolved method is skipped and counted,
+ *     exactly as before. The baseline stays a record of measured code.
+ *   - `requireCoverage: false` — an unresolved method scores as **0%
+ *     covered** (`crap = c² + c`, the formula's own treatment of untested
+ *     code) and lands in the baseline. Previously the flag only stopped
+ *     whole *files* being skipped while each individual method was still
+ *     dropped, which made it a no-op for baseline population — the caller
+ *     asked for "score it anyway" and got silence.
+ *
+ * `resolvedMethods` / `totalMethods` count the *join*, not the fill: a
+ * method scored 0% because its coverage was unresolved counts as
+ * unresolved. That is what makes them usable as a health signal for the
+ * updater's fail-closed resolution-rate floor.
+ *
+ * @param {Array<object>} rawRows Rows from `methodRowsFromReport`.
+ * @param {{requireCoverage?: boolean}} [opts]
+ * @returns {{
+ *   rows: Array<object>,
+ *   skippedMethodsNoCoverage: number,
+ *   resolvedMethods: number,
+ *   totalMethods: number,
+ * }}
+ */
+export function finalizeMethodRows(rawRows, { requireCoverage = true } = {}) {
+  const rows = [];
+  let skippedMethodsNoCoverage = 0;
+  let resolvedMethods = 0;
+  let totalMethods = 0;
+  for (const mr of rawRows ?? []) {
+    totalMethods += 1;
+    const unresolved = mr.crap === null || mr.coverage === null;
+    if (!unresolved) resolvedMethods += 1;
+    if (unresolved && requireCoverage) {
+      skippedMethodsNoCoverage += 1;
+      continue;
+    }
+    const coverage = unresolved ? 0 : mr.coverage;
+    const crap = unresolved ? crapFormula(mr.cyclomatic, 0) : mr.crap;
+    rows.push({
+      method: mr.method,
+      startLine: mr.startLine,
+      cyclomatic: mr.cyclomatic,
+      coverage,
+      crap,
+    });
+  }
+  return { rows, skippedMethodsNoCoverage, resolvedMethods, totalMethods };
+}
+
+/**
  * Score each method in a JavaScript source for Change Risk Anti-Patterns
  * (CRAP): `c² · (1 − cov)³ + c`, where `c` is cyclomatic complexity and `cov`
  * is the per-method statement-coverage ratio in [0, 1].
@@ -11,15 +113,17 @@ import { coverageForMethodInEntry } from './coverage-utils.js';
  *     `analyzeModule`).
  *   - Methods whose coverage cannot be resolved from `coverageForFile`
  *     produce `coverage: null` and `crap: null`. Callers apply their own
- *     `requireCoverage` policy at the scanner level; this kernel never
- *     decides to skip.
+ *     `requireCoverage` policy at the scanner level (`finalizeMethodRows`);
+ *     this kernel never decides to skip.
  *   - A parse error returns an empty array — the file is unscorable, not
  *     zero-complexity.
  *
- * @param {string} source JavaScript source text.
+ * @param {string} source JavaScript source text (possibly transpiled).
  * @param {object|null} coverageForFile The inner value from a
  *   `coverage-final.json` map keyed by this file's path, or null when no
  *   coverage data is available for this file.
+ * @param {((line: number) => number|null)|null} [mapLine] Transpiled →
+ *   original line resolver; see `methodRowsFromReport`.
  * @returns {Array<{
  *   method: string,
  *   startLine: number,
@@ -28,32 +132,18 @@ import { coverageForMethodInEntry } from './coverage-utils.js';
  *   crap: number|null,
  * }>}
  */
-export function calculateCrapForSource(source, coverageForFile) {
+export function calculateCrapForSource(
+  source,
+  coverageForFile,
+  mapLine = null,
+) {
   let report;
   try {
     report = escomplex.analyzeModule(source);
   } catch {
     return [];
   }
-  const methods = report?.methods ?? [];
-  const rows = [];
-  for (const m of methods) {
-    const startLine = m?.lineStart;
-    if (typeof startLine !== 'number') continue;
-    const cyclomatic = m?.cyclomatic ?? 0;
-    const coverage = coverageForFile
-      ? coverageForMethodInEntry(coverageForFile, startLine)
-      : null;
-    const crap = coverage === null ? null : crapFormula(cyclomatic, coverage);
-    rows.push({
-      method: m.name,
-      startLine,
-      cyclomatic,
-      coverage,
-      crap,
-    });
-  }
-  return rows;
+  return methodRowsFromReport(report, coverageForFile, mapLine);
 }
 
 /**

--- a/.agents/scripts/lib/crap-utils.js
+++ b/.agents/scripts/lib/crap-utils.js
@@ -2,15 +2,15 @@ import fs from 'node:fs';
 import path from 'node:path';
 import escomplex from 'typhonjs-escomplex';
 import { canonicalise as canonicalisePath } from './baselines/path-canon.js';
-import {
-  coverageForMethodInEntry,
-  findCoverageEntry,
-} from './coverage-utils.js';
+import { findCoverageEntry } from './coverage-utils.js';
 import { POOL_SERIAL_THRESHOLD, runOnPool } from './cpu-pool.js';
-import { crapFormula } from './crap-engine.js';
+import { finalizeMethodRows, methodRowsFromReport } from './crap-engine.js';
 import { Logger } from './Logger.js';
 import { scanDirectory } from './maintainability-utils.js';
-import { resolveTsTranspilerVersion, transpileIfNeeded } from './transpile.js';
+import {
+  prepareSourceForScoring,
+  resolveTsTranspilerVersion,
+} from './transpile.js';
 
 const CRAP_WORKER_URL = new URL('./workers/crap-worker.js', import.meta.url);
 const COMBINED_MI_CRAP_WORKER_URL = new URL(
@@ -202,6 +202,103 @@ export function buildBaselineEnvelope({
 }
 
 /**
+ * How many files to name when reporting the worst unresolved offenders. Long
+ * enough to point at a pattern, short enough to stay a readable CLI message.
+ */
+const WORST_OFFENDER_LIMIT = 5;
+
+/**
+ * Method-resolution telemetry (Story #4775, fix part 4).
+ *
+ * The updater used to persist a 100-row baseline built from 5023 dropped
+ * methods and log it as success — the rot that let a broken coverage join
+ * sit undetected for five weeks across three repos. These three helpers
+ * carry the counters that make a thin result *visible* and therefore
+ * refusable.
+ *
+ * The rate is deliberately measured over files that **do** have a coverage
+ * entry: a file the test run never touched has no join to fail, so counting
+ * it would dilute the signal the floor is meant to catch.
+ */
+function newResolutionAccumulator() {
+  return { resolved: 0, total: 0, byFile: [] };
+}
+
+function accumulateResolution(acc, relPath, result) {
+  if (result?.hasCoverageEntry !== true) return;
+  const total = result.totalMethods ?? 0;
+  if (total === 0) return;
+  const resolved = result.resolvedMethods ?? 0;
+  acc.resolved += resolved;
+  acc.total += total;
+  if (resolved < total) {
+    acc.byFile.push({ file: relPath, unresolved: total - resolved, total });
+  }
+}
+
+function summarizeResolution(acc) {
+  const worstFiles = [...acc.byFile]
+    .sort((a, b) => b.unresolved - a.unresolved || a.file.localeCompare(b.file))
+    .slice(0, WORST_OFFENDER_LIMIT);
+  return {
+    resolvedMethods: acc.resolved,
+    joinableMethods: acc.total,
+    rate: acc.total === 0 ? 1 : acc.resolved / acc.total,
+    worstFiles,
+  };
+}
+
+/**
+ * Minimum number of joinable methods before the resolution-rate floor is
+ * enforced. A diff-scoped run can legitimately touch a handful of methods,
+ * where one unresolved method is a 50% rate and says nothing about the health
+ * of the join. Below this sample the rate is reported, never enforced.
+ */
+const MIN_RESOLUTION_SAMPLE = 25;
+
+/**
+ * Fail-closed guard on the per-method coverage join (Story #4775, fix part 4).
+ *
+ * The updater used to persist a 100-row baseline distilled from 5023 dropped
+ * methods and log it as a success — which is exactly how a broken join stayed
+ * invisible for five weeks across three repositories. A thin result is now a
+ * refusal: the caller throws before anything is written, and the message names
+ * the rate, the counts, and the files carrying the most unresolved methods so
+ * the operator can tell "my tests do not cover that" apart from "the join is
+ * broken".
+ *
+ * Returns `null` when the run may proceed, or the operator-facing message when
+ * it must not.
+ *
+ * @param {{resolvedMethods: number, joinableMethods: number, rate: number,
+ *   worstFiles: Array<{file: string, unresolved: number, total: number}>}
+ *   | undefined} resolution
+ * @param {number} floor
+ * @returns {string|null}
+ */
+export function checkResolutionFloor(resolution, floor) {
+  if (!resolution) return null;
+  const { joinableMethods = 0, resolvedMethods = 0, rate = 1 } = resolution;
+  if (joinableMethods < MIN_RESOLUTION_SAMPLE) return null;
+  if (rate >= floor) return null;
+  const worst = (resolution.worstFiles ?? [])
+    .map((w) => `         - ${w.file} (${w.unresolved}/${w.total} unresolved)`)
+    .join('\n');
+  return (
+    `[CRAP] Refusing to persist: only ${resolvedMethods}/${joinableMethods} ` +
+    `method(s) (${(rate * 100).toFixed(1)}%) resolved a coverage entry in files ` +
+    `that HAVE coverage — below the ${(floor * 100).toFixed(1)}% floor ` +
+    '(delivery.quality.gates.crap.minMethodResolutionRate).\n' +
+    '       A baseline built from a broken join is not sparse, it is wrong: ' +
+    'unresolved methods are absent and coincidental line collisions are ' +
+    'mis-attributed.\n' +
+    (worst ? `       Worst unresolved files:\n${worst}\n` : '') +
+    "       Regenerate coverage ('npm run test:coverage') and re-run; if the " +
+    'rate stays low the coverage artifact and the scanned tree disagree.'
+  );
+}
+
+/**
  * Parse `source` exactly once with escomplex and derive both the
  * maintainability score and the raw CRAP method rows from that single report.
  *
@@ -216,6 +313,10 @@ export function buildBaselineEnvelope({
  *
  * @param {string} source Prepared (possibly transpiled) JavaScript source text.
  * @param {object|null} coverageForFile Istanbul coverage entry for this file.
+ * @param {((line: number) => number|null)|null} [mapLine] Transpiled →
+ *   original-source line resolver from `transpileIfNeeded(…, {withLineMap:
+ *   true})`; `null` for JavaScript, whose coordinates already match the
+ *   coverage entry's.
  * @returns {{
  *   report: object,
  *   miScore: number,
@@ -229,7 +330,7 @@ export function buildBaselineEnvelope({
  *   parseError: boolean,
  * }}
  */
-export function analyzeOnce(source, coverageForFile) {
+export function analyzeOnce(source, coverageForFile, mapLine = null) {
   let report;
   try {
     report = escomplex.analyzeModule(source);
@@ -238,18 +339,7 @@ export function analyzeOnce(source, coverageForFile) {
   }
   const miScore =
     typeof report.maintainability === 'number' ? report.maintainability : 0;
-  const methods = report?.methods ?? [];
-  const crapRows = [];
-  for (const m of methods) {
-    const startLine = m?.lineStart;
-    if (typeof startLine !== 'number') continue;
-    const cyclomatic = m?.cyclomatic ?? 0;
-    const coverage = coverageForFile
-      ? coverageForMethodInEntry(coverageForFile, startLine)
-      : null;
-    const crap = coverage === null ? null : crapFormula(cyclomatic, coverage);
-    crapRows.push({ method: m.name, startLine, cyclomatic, coverage, crap });
-  }
+  const crapRows = methodRowsFromReport(report, coverageForFile, mapLine);
   return { report, miScore, crapRows, parseError: false };
 }
 
@@ -348,6 +438,7 @@ export async function scanAndScore({
   const rows = [];
   let skippedFilesNoCoverage = 0;
   let skippedMethodsNoCoverage = 0;
+  const resolution = newResolutionAccumulator();
   for (const { item, result } of perFile) {
     if (!result) continue; // unrecoverable per-file failure: drop silently to match pre-pool semantics
     if (result.skippedFileNoCoverage) {
@@ -366,6 +457,7 @@ export async function scanAndScore({
       continue;
     }
     skippedMethodsNoCoverage += result.skippedMethodsNoCoverage ?? 0;
+    accumulateResolution(resolution, item.relPath, result);
     for (const mr of result.rows) {
       rows.push({
         file: item.relPath,
@@ -390,6 +482,7 @@ export async function scanAndScore({
     scannedFiles,
     skippedFilesNoCoverage,
     skippedMethodsNoCoverage,
+    resolution: summarizeResolution(resolution),
   };
 }
 
@@ -408,50 +501,33 @@ function scoreFileSerial({ abs, relPath, requireCoverage }, coverage) {
       skippedFileNoCoverage: true,
       rows: [],
       skippedMethodsNoCoverage: 0,
+      hasCoverageEntry: false,
+      resolvedMethods: 0,
+      totalMethods: 0,
     };
   }
-  let source;
-  try {
-    source = fs.readFileSync(abs, 'utf-8');
-  } catch {
-    return {
-      skippedFileNoCoverage: false,
-      rows: null,
-      skippedMethodsNoCoverage: 0,
-    };
-  }
-  const prepared = transpileIfNeeded(abs, source);
-  if (prepared === null) {
-    return {
-      skippedFileNoCoverage: false,
-      rows: null,
-      skippedMethodsNoCoverage: 0,
-    };
-  }
-  const { crapRows, parseError } = analyzeOnce(prepared, entry);
-  if (parseError) {
-    return {
-      skippedFileNoCoverage: false,
-      rows: null,
-      skippedMethodsNoCoverage: 0,
-    };
-  }
-  const rows = [];
-  let skippedMethodsNoCoverage = 0;
-  for (const mr of crapRows) {
-    if (mr.crap === null || mr.coverage === null) {
-      skippedMethodsNoCoverage += 1;
-      continue;
-    }
-    rows.push({
-      method: mr.method,
-      startLine: mr.startLine,
-      cyclomatic: mr.cyclomatic,
-      coverage: mr.coverage,
-      crap: mr.crap,
-    });
-  }
-  return { skippedFileNoCoverage: false, rows, skippedMethodsNoCoverage };
+  const dropped = {
+    skippedFileNoCoverage: false,
+    rows: null,
+    skippedMethodsNoCoverage: 0,
+    hasCoverageEntry: entry !== null,
+    resolvedMethods: 0,
+    totalMethods: 0,
+  };
+  const prepared = prepareSourceForScoring(abs);
+  if (prepared.error) return dropped;
+  const { crapRows, parseError } = analyzeOnce(
+    prepared.code,
+    entry,
+    prepared.mapLine,
+  );
+  if (parseError) return dropped;
+  const finalized = finalizeMethodRows(crapRows, { requireCoverage });
+  return {
+    skippedFileNoCoverage: false,
+    hasCoverageEntry: entry !== null,
+    ...finalized,
+  };
 }
 
 async function scoreFilesViaPool(queue, coverage) {
@@ -494,33 +570,24 @@ async function scoreFilesViaPool(queue, coverage) {
  */
 function scoreFileCombinedSerial({ abs, relPath, requireCoverage }, coverage) {
   const entry = findCoverageEntry(coverage, relPath);
-  let source;
-  try {
-    source = fs.readFileSync(abs, 'utf-8');
-  } catch {
+  const prepared = prepareSourceForScoring(abs);
+  if (prepared.error) {
     return {
       relPath,
-      miScore: null,
+      miScore: prepared.error === 'read' ? null : 0,
       skippedFileNoCoverage: false,
       crapRows: null,
       skippedMethodsNoCoverage: 0,
-    };
-  }
-  const prepared = transpileIfNeeded(abs, source);
-  if (prepared === null) {
-    return {
-      relPath,
-      miScore: 0,
-      skippedFileNoCoverage: false,
-      crapRows: null,
-      skippedMethodsNoCoverage: 0,
+      hasCoverageEntry: entry !== null,
+      resolvedMethods: 0,
+      totalMethods: 0,
     };
   }
   const {
     miScore,
     crapRows: rawCrapRows,
     parseError,
-  } = analyzeOnce(prepared, entry);
+  } = analyzeOnce(prepared.code, entry, prepared.mapLine);
   if (parseError) {
     return {
       relPath,
@@ -528,6 +595,9 @@ function scoreFileCombinedSerial({ abs, relPath, requireCoverage }, coverage) {
       skippedFileNoCoverage: false,
       crapRows: null,
       skippedMethodsNoCoverage: 0,
+      hasCoverageEntry: entry !== null,
+      resolvedMethods: 0,
+      totalMethods: 0,
     };
   }
   if (requireCoverage && entry === null) {
@@ -537,29 +607,22 @@ function scoreFileCombinedSerial({ abs, relPath, requireCoverage }, coverage) {
       skippedFileNoCoverage: true,
       crapRows: [],
       skippedMethodsNoCoverage: 0,
+      hasCoverageEntry: false,
+      resolvedMethods: 0,
+      totalMethods: 0,
     };
   }
-  const crapRows = [];
-  let skippedMethodsNoCoverage = 0;
-  for (const mr of rawCrapRows) {
-    if (mr.crap === null || mr.coverage === null) {
-      skippedMethodsNoCoverage += 1;
-      continue;
-    }
-    crapRows.push({
-      method: mr.method,
-      startLine: mr.startLine,
-      cyclomatic: mr.cyclomatic,
-      coverage: mr.coverage,
-      crap: mr.crap,
-    });
-  }
+  const { rows, skippedMethodsNoCoverage, resolvedMethods, totalMethods } =
+    finalizeMethodRows(rawCrapRows, { requireCoverage });
   return {
     relPath,
     miScore,
     skippedFileNoCoverage: false,
-    crapRows,
+    crapRows: rows,
     skippedMethodsNoCoverage,
+    hasCoverageEntry: entry !== null,
+    resolvedMethods,
+    totalMethods,
   };
 }
 
@@ -693,6 +756,7 @@ export async function scanAndScoreCombined({
   const crapRows = [];
   let skippedFilesNoCoverage = 0;
   let skippedMethodsNoCoverage = 0;
+  const resolution = newResolutionAccumulator();
 
   for (const { item, result } of perFile) {
     if (!result) continue; // unrecoverable per-file failure: drop silently
@@ -716,6 +780,7 @@ export async function scanAndScoreCombined({
       continue;
     }
     skippedMethodsNoCoverage += result.skippedMethodsNoCoverage ?? 0;
+    accumulateResolution(resolution, item.relPath, result);
     for (const mr of result.crapRows) {
       crapRows.push({
         file: item.relPath,
@@ -750,6 +815,7 @@ export async function scanAndScoreCombined({
       scannedFiles,
       skippedFilesNoCoverage,
       skippedMethodsNoCoverage,
+      resolution: summarizeResolution(resolution),
     },
   };
 }

--- a/.agents/scripts/lib/orchestration/check-baselines/phases/compare.js
+++ b/.agents/scripts/lib/orchestration/check-baselines/phases/compare.js
@@ -12,6 +12,7 @@
 import { readBaseFromGit } from '../../../baselines/git-base.js';
 import { getKindModule } from '../../../baselines/kernel.js';
 import { resolveScope } from '../../../baselines/scope.js';
+import { Logger } from '../../../Logger.js';
 import { DEFAULT_BASELINE_PATHS } from './parse-args.js';
 
 function baselineRelativePath(kind, gateBlock) {
@@ -67,6 +68,29 @@ export async function evaluateCompare({ kind, gateBlock, scope, cwd }) {
   return { baseRef: scope.ref, baseRead: true, basePayload, kindModule };
 }
 
+/**
+ * Is the base baseline comparable to the head baseline (Story #4775)?
+ *
+ * A kind can change its SCORING SEMANTICS — how it derives a row's metric —
+ * without moving `kernelVersion`. Across that boundary the same row can carry
+ * a different score for reasons that have nothing to do with the branch's
+ * changes, so a head-vs-base diff manufactures phantom regressions (and can
+ * hide real ones behind them).
+ *
+ * The head-side stamp is already a fail-closed gate: a stale HEAD baseline
+ * never reaches this point. What reaches here is the opposite and legitimate
+ * case — a branch that DOES carry a re-derived baseline, compared against a
+ * base that predates the change. The only honest verdict is "no comparison";
+ * floors still run, so a genuine ceiling breach is still caught, and once the
+ * refreshed baseline is the base the ratchet returns to full strength on the
+ * very next run without anything to remember to reset.
+ */
+function baseIsComparable(headBaseline, basePayload) {
+  const head = headBaseline?.scoringSemantics ?? null;
+  const base = basePayload?.scoringSemantics ?? null;
+  return head === base;
+}
+
 export function runCompareStage(headBaseline, cmp) {
   const empty = {
     regressions: [],
@@ -75,6 +99,17 @@ export function runCompareStage(headBaseline, cmp) {
     additions: [],
   };
   if (!cmp.baseRead || !cmp.basePayload || !cmp.kindModule) return empty;
+  if (!baseIsComparable(headBaseline, cmp.basePayload)) {
+    Logger.warn(
+      `[${cmp.kindModule.name}] ⚠ base baseline was scored under different ` +
+        `semantics (base=${cmp.basePayload.scoringSemantics ?? '<unstamped>'} ` +
+        `head=${headBaseline?.scoringSemantics ?? '<unstamped>'}); its rows are ` +
+        'not comparable, so the head-vs-base compare is skipped for this run. ' +
+        'Floors still enforced. The ratchet resumes once the re-derived ' +
+        'baseline is the base.',
+    );
+    return empty;
+  }
   try {
     const baseRows = Array.isArray(cmp.basePayload.rows)
       ? cmp.basePayload.rows

--- a/.agents/scripts/lib/orchestration/check-baselines/phases/evaluate.js
+++ b/.agents/scripts/lib/orchestration/check-baselines/phases/evaluate.js
@@ -13,6 +13,7 @@ import {
 } from '../../../baselines/env-overrides.js';
 import { readRangeSubjectsTouchingFile } from '../../../baselines/git-base.js';
 import {
+  checkBaselineSemantics,
   checkKernelVersion,
   getKindModule,
 } from '../../../baselines/kernel.js';
@@ -247,6 +248,18 @@ export async function evaluateKind({
   const headLoad = loadHeadBaseline(kind, cwd, configPath);
   if (headLoad.schemaError) return { kind, schemaError: headLoad.schemaError };
   const baseline = headLoad.baseline;
+  // Story #4775 — scoring-semantics gate. A baseline whose rows were produced
+  // by superseded scoring semantics is structurally valid but semantically
+  // incomparable, so schema validation alone would wave it through. Fail
+  // closed on the `semantics` tag rather than compare across the boundary;
+  // the message names the exact re-baseline command.
+  const semanticsError = checkBaselineSemantics(kind, baseline);
+  if (semanticsError) {
+    return {
+      kind,
+      schemaError: { tag: 'semantics', message: semanticsError },
+    };
+  }
   const floorRollup = rollupExcludingIgnored({
     kind,
     baseline,

--- a/.agents/scripts/lib/transpile.js
+++ b/.agents/scripts/lib/transpile.js
@@ -1,4 +1,5 @@
-import { createRequire } from 'node:module';
+import fs from 'node:fs';
+import { createRequire, SourceMap } from 'node:module';
 import path from 'node:path';
 import { Logger } from './Logger.js';
 
@@ -40,6 +41,71 @@ function isTypeScriptPath(filePath) {
 }
 
 /**
+ * Trailing `//# sourceMappingURL=…` comment `ts.transpileModule` appends
+ * when `sourceMap: true` is requested. Stripping it makes the emitted code
+ * byte-identical to the `sourceMap: false` emit, which is what keeps the
+ * maintainability path — and every MI score in the committed baseline —
+ * untouched by the CRAP path opting into a map.
+ */
+const SOURCE_MAPPING_URL_RE = /\n?\/\/# sourceMappingURL=[^\n]*\n?$/;
+
+/**
+ * Build a `transpiledLine → originalLine` resolver over a raw
+ * `sourceMapText` payload, using Node's built-in `SourceMap` (no new
+ * runtime dependency).
+ *
+ * `SourceMap#findEntry(line, column)` is 0-based and returns the mapping at
+ * or before the requested position, so a bare `findEntry(line, 0)` can
+ * silently answer with a *previous* line's mapping when the requested line
+ * carries no mapping at column 0. The resolver therefore walks the columns
+ * of the generated line and accepts only an entry that actually originates
+ * on that generated line; a line with no mapping at all resolves to `null`
+ * and the caller falls back to the un-remapped coordinate.
+ *
+ * Results are memoised per generated line — a file's methods are looked up
+ * once each, but the same line is often probed by several callers.
+ *
+ * @param {string} sourceMapText Raw JSON source map emitted by TypeScript.
+ * @param {string} code The generated (transpiled) code the map describes.
+ * @returns {((line: number) => number|null)|null}
+ */
+function buildLineMapper(sourceMapText, code) {
+  let sourceMap;
+  try {
+    sourceMap = new SourceMap(JSON.parse(sourceMapText));
+  } catch {
+    return null;
+  }
+  const lines = String(code).split('\n');
+  const memo = new Map();
+  return function mapLine(generatedLine) {
+    if (typeof generatedLine !== 'number' || generatedLine < 1) return null;
+    if (memo.has(generatedLine)) return memo.get(generatedLine);
+    const zeroBased = generatedLine - 1;
+    const lineText = lines[zeroBased] ?? '';
+    let resolved = null;
+    for (let column = 0; column <= lineText.length; column += 1) {
+      let entry;
+      try {
+        entry = sourceMap.findEntry(zeroBased, column);
+      } catch {
+        break;
+      }
+      if (
+        entry &&
+        entry.generatedLine === zeroBased &&
+        typeof entry.originalLine === 'number'
+      ) {
+        resolved = entry.originalLine + 1;
+        break;
+      }
+    }
+    memo.set(generatedLine, resolved);
+    return resolved;
+  };
+}
+
+/**
  * Pre-transpile TypeScript or TSX sources to JavaScript that the
  * Esprima-based escomplex kernel can parse. Returns the input unchanged
  * for `.js` / `.mjs` / `.cjs` paths.
@@ -54,12 +120,33 @@ function isTypeScriptPath(filePath) {
  * On transpile failure the helper returns `null` — callers treat that
  * as "skip this file" rather than crashing the scan.
  *
+ * **Line coordinates (Story #4775).** The transpile does not preserve line
+ * numbers: interface elision and the injected JSX-runtime import shift the
+ * emitted code relative to the original source. escomplex then reports each
+ * method's `lineStart` in *transpiled* coordinates while istanbul's `fnMap`
+ * is in *original source* coordinates — so a per-method coverage join keyed
+ * on the raw `lineStart` cannot match. Callers that need to join against
+ * coverage pass `{ withLineMap: true }` and receive
+ * `{ code, mapLine }`, where `mapLine(transpiledLine)` returns the original
+ * source line (or `null` when the line has no mapping).
+ *
+ * `withLineMap` is opt-in precisely so the maintainability path — which is
+ * module-level and never joins coverage — keeps paying nothing for a map it
+ * would not read, and keeps emitting byte-identical scores. A JavaScript
+ * input is a passthrough in both modes: `mapLine` is `null` because the
+ * coordinates already *are* original-source coordinates, so no remap is
+ * needed and none is computed.
+ *
  * @param {string} filePath
  * @param {string} source
- * @returns {string|null}
+ * @param {{withLineMap?: boolean}} [opts]
+ * @returns {string|null|{code: string, mapLine: ((line: number) => number|null)|null}}
  */
-export function transpileIfNeeded(filePath, source) {
-  if (!isTypeScriptPath(filePath)) return source;
+export function transpileIfNeeded(filePath, source, opts = {}) {
+  const withLineMap = opts?.withLineMap === true;
+  if (!isTypeScriptPath(filePath)) {
+    return withLineMap ? { code: source, mapLine: null } : source;
+  }
   const ts = loadTypeScript();
   if (!ts) {
     Logger.warn(
@@ -78,16 +165,56 @@ export function transpileIfNeeded(filePath, source) {
         importHelpers: false,
         removeComments: false,
         jsx: ts.JsxEmit.ReactJSX,
-        sourceMap: false,
+        sourceMap: withLineMap,
       },
       fileName: path.basename(filePath),
       reportDiagnostics: false,
     });
-    return result.outputText;
+    if (!withLineMap) return result.outputText;
+    const code = result.outputText.replace(SOURCE_MAPPING_URL_RE, '\n');
+    const mapLine =
+      typeof result.sourceMapText === 'string'
+        ? buildLineMapper(result.sourceMapText, code)
+        : null;
+    return { code, mapLine };
   } catch (err) {
     Logger.warn(
       `[Maintainability] ⚠ TS transpile failed for ${filePath}: ${err?.message ?? err}; skipping.`,
     );
     return null;
   }
+}
+
+/**
+ * Prepare a source file for scoring: read it, transpile TS/TSX with a
+ * line map, and hand back the JavaScript escomplex will parse alongside the
+ * transpiled → original-source line resolver the coverage join needs
+ * (Story #4775).
+ *
+ * Failure is reported as `{error: 'read'}` or `{error: 'transpile'}` rather
+ * than a bare null: CRAP drops the file either way, but the combined MI path
+ * distinguishes them (a read failure drops the MI score, a transpile failure
+ * scores it 0 — matching `calculateForFile`).
+ *
+ * @param {string} abs Absolute path of the source file.
+ * @param {{readFile?: (p: string) => string, transpile?: Function}} [deps]
+ * @returns {{code: string, mapLine: ((line: number) => number|null)|null}
+ *   | {error: 'read'|'transpile'}}
+ */
+export function prepareSourceForScoring(abs, deps = {}) {
+  const readFile = deps.readFile ?? ((p) => fs.readFileSync(p, 'utf-8'));
+  const transpile = deps.transpile ?? transpileIfNeeded;
+  let source;
+  try {
+    source = readFile(abs);
+  } catch {
+    return { error: 'read' };
+  }
+  const prepared = transpile(abs, source, { withLineMap: true });
+  if (prepared === null || prepared === undefined)
+    return { error: 'transpile' };
+  // Tolerate a `deps.transpile` stub that still returns a bare string.
+  if (typeof prepared === 'string') return { code: prepared, mapLine: null };
+  if (typeof prepared.code !== 'string') return { error: 'transpile' };
+  return { code: prepared.code, mapLine: prepared.mapLine ?? null };
 }

--- a/.agents/scripts/lib/workers/combined-mi-crap-worker.js
+++ b/.agents/scripts/lib/workers/combined-mi-crap-worker.js
@@ -32,6 +32,9 @@
  *           skippedFileNoCoverage: boolean,
  *           crapRows: Array<{ method, startLine, cyclomatic, coverage, crap }> | null,
  *           skippedMethodsNoCoverage: number,
+ *           hasCoverageEntry: boolean,
+ *           resolvedMethods: number,
+ *           totalMethods: number,
  *         } }
  *
  * A read/transpile/parse failure surfaces as `crapRows: null` so the host
@@ -40,10 +43,10 @@
  * `miScore` is `null`; on a transpile/parse failure `miScore` is `0`.
  */
 
-import fs from 'node:fs';
 import { parentPort } from 'node:worker_threads';
+import { finalizeMethodRows } from '../crap-engine.js';
 import { analyzeOnce } from '../crap-utils.js';
-import { transpileIfNeeded } from '../transpile.js';
+import { prepareSourceForScoring } from '../transpile.js';
 
 /**
  * Pure handler for a single inbound worker message. Exported so unit tests
@@ -58,8 +61,9 @@ import { transpileIfNeeded } from '../transpile.js';
  * @param {unknown} msg
  * @param {{
  *   readFile?: (abs: string) => string,
- *   transpile?: (abs: string, source: string) => string | null,
- *   analyze?: (source: string, entry: object|null) => {
+ *   transpile?: (abs: string, source: string, opts?: object) => unknown,
+ *   prepare?: (abs: string, deps: object) => object,
+ *   analyze?: (source: string, entry: object|null, mapLine: Function|null) => {
  *     miScore: number,
  *     crapRows: Array<object>,
  *     parseError: boolean,
@@ -85,8 +89,7 @@ export function handleCombinedMiCrapWorkerMessage(msg, deps = {}) {
     };
   }
   const { abs, relPath, requireCoverage } = item;
-  const readFile = deps.readFile ?? ((p) => fs.readFileSync(p, 'utf-8'));
-  const transpile = deps.transpile ?? transpileIfNeeded;
+  const prepare = deps.prepare ?? prepareSourceForScoring;
   const analyze = deps.analyze ?? analyzeOnce;
 
   // Coverage entry is pre-resolved on the host and attached to the item.
@@ -94,47 +97,33 @@ export function handleCombinedMiCrapWorkerMessage(msg, deps = {}) {
   // coverage, or `undefined` when the caller did not supply it (treat as null).
   const entry = item.coverageEntry ?? null;
 
-  // Read the source once. A read failure means neither MI nor CRAP can be
-  // computed — MI drops (null), CRAP drops (rows null) — matching the two
-  // passes' read-failure contracts (calculateAll → score null; crap worker
-  // → rows null).
-  let source;
-  try {
-    source = readFile(abs);
-  } catch {
-    return {
-      kind: 'reply',
-      message: {
-        ok: true,
-        result: {
-          relPath,
-          miScore: null,
-          skippedFileNoCoverage: false,
-          crapRows: null,
-          skippedMethodsNoCoverage: 0,
-        },
+  const reply = (result) => ({
+    kind: 'reply',
+    message: {
+      ok: true,
+      result: {
+        relPath,
+        skippedFileNoCoverage: false,
+        skippedMethodsNoCoverage: 0,
+        hasCoverageEntry: entry !== null,
+        resolvedMethods: 0,
+        totalMethods: 0,
+        ...result,
       },
-    };
-  }
+    },
+  });
 
-  // TS/TSX → strip-then-analyze. A transpile failure yields miScore 0
-  // (calculateForFile returns 0 when transpileIfNeeded returns null) and a
-  // null CRAP contribution (crap worker returns rows: null).
-  const prepared = transpile(abs, source);
-  if (prepared === null) {
-    return {
-      kind: 'reply',
-      message: {
-        ok: true,
-        result: {
-          relPath,
-          miScore: 0,
-          skippedFileNoCoverage: false,
-          crapRows: null,
-          skippedMethodsNoCoverage: 0,
-        },
-      },
-    };
+  // Read + transpile once, carrying the transpiled -> original-source line
+  // map the per-method coverage join needs (Story #4775). A read failure
+  // means neither MI nor CRAP can be computed (MI drops as null, matching
+  // `calculateAll`'s filter); a transpile failure scores MI 0 (matching
+  // `calculateForFile`). CRAP drops the file either way.
+  const prepared = prepare(abs, deps);
+  if (prepared.error) {
+    return reply({
+      miScore: prepared.error === 'read' ? null : 0,
+      crapRows: null,
+    });
   }
 
   // ONE parse: analyzeOnce derives both the module MI score and the raw
@@ -144,24 +133,12 @@ export function handleCombinedMiCrapWorkerMessage(msg, deps = {}) {
     miScore,
     crapRows: rawCrapRows,
     parseError,
-  } = analyze(prepared, entry);
+  } = analyze(prepared.code, entry, prepared.mapLine);
   if (parseError) {
-    // Parse error: MI scores 0 (parity with calculateForSource's catch →
+    // Parse error: MI scores 0 (parity with calculateForSource's catch ->
     // returns 0), CRAP drops the file (rows null, parity with the crap
     // worker's calculateCrap-throw branch).
-    return {
-      kind: 'reply',
-      message: {
-        ok: true,
-        result: {
-          relPath,
-          miScore: 0,
-          skippedFileNoCoverage: false,
-          crapRows: null,
-          skippedMethodsNoCoverage: 0,
-        },
-      },
-    };
+    return reply({ miScore: 0, crapRows: null });
   }
 
   // CRAP coverage gate runs AFTER the parse so the MI score is always
@@ -169,49 +146,18 @@ export function handleCombinedMiCrapWorkerMessage(msg, deps = {}) {
   // pass would have skipped it at the file level (no rows, counted) — but the
   // MI pass would still have scored it, so miScore is returned regardless.
   if (requireCoverage && entry === null) {
-    return {
-      kind: 'reply',
-      message: {
-        ok: true,
-        result: {
-          relPath,
-          miScore,
-          skippedFileNoCoverage: true,
-          crapRows: [],
-          skippedMethodsNoCoverage: 0,
-        },
-      },
-    };
+    return reply({ miScore, skippedFileNoCoverage: true, crapRows: [] });
   }
 
-  const crapRows = [];
-  let skippedMethodsNoCoverage = 0;
-  for (const mr of rawCrapRows) {
-    if (mr.crap === null || mr.coverage === null) {
-      skippedMethodsNoCoverage += 1;
-      continue;
-    }
-    crapRows.push({
-      method: mr.method,
-      startLine: mr.startLine,
-      cyclomatic: mr.cyclomatic,
-      coverage: mr.coverage,
-      crap: mr.crap,
-    });
-  }
-  return {
-    kind: 'reply',
-    message: {
-      ok: true,
-      result: {
-        relPath,
-        miScore,
-        skippedFileNoCoverage: false,
-        crapRows,
-        skippedMethodsNoCoverage,
-      },
-    },
-  };
+  const { rows, skippedMethodsNoCoverage, resolvedMethods, totalMethods } =
+    finalizeMethodRows(rawCrapRows, { requireCoverage });
+  return reply({
+    miScore,
+    crapRows: rows,
+    skippedMethodsNoCoverage,
+    resolvedMethods,
+    totalMethods,
+  });
 }
 
 if (parentPort) {

--- a/.agents/scripts/lib/workers/crap-worker.js
+++ b/.agents/scripts/lib/workers/crap-worker.js
@@ -18,6 +18,9 @@
  *           skippedFileNoCoverage: boolean,
  *           rows: Array<{ method, startLine, cyclomatic, coverage, crap }>,
  *           skippedMethodsNoCoverage: number,
+ *           hasCoverageEntry: boolean,
+ *           resolvedMethods: number,
+ *           totalMethods: number,
  *         } }
  *
  * A truly unrecoverable per-file failure (read error, transpile null)
@@ -26,10 +29,9 @@
  * aborts the whole scan.
  */
 
-import fs from 'node:fs';
 import { parentPort } from 'node:worker_threads';
-import { calculateCrapForSource } from '../crap-engine.js';
-import { transpileIfNeeded } from '../transpile.js';
+import { calculateCrapForSource, finalizeMethodRows } from '../crap-engine.js';
+import { prepareSourceForScoring } from '../transpile.js';
 
 /**
  * Pure handler for a single inbound worker message. Exported so unit
@@ -42,7 +44,10 @@ import { transpileIfNeeded } from '../transpile.js';
  *   - `{ kind: 'reply', message }`   — caller should `postMessage(message)`.
  *
  * Side effects (fs, transpile, escomplex) are wired through `deps` so
- * tests pass deterministic stubs.
+ * tests pass deterministic stubs. `readFile` / `transpile` are forwarded to
+ * `prepareSourceForScoring`, which also derives the transpiled →
+ * original-source line map the coverage join needs (Story #4775); a
+ * `transpile` stub that still returns a bare string is tolerated.
  *
  * Coverage is supplied via `item.coverageEntry` (pre-resolved on the host),
  * not via a whole-map `coverage` argument. The second parameter is kept as
@@ -52,8 +57,9 @@ import { transpileIfNeeded } from '../transpile.js';
  * @param {object|null} _coverage - Unused. Coverage is in `item.coverageEntry`.
  * @param {{
  *   readFile?: (abs: string) => string,
- *   transpile?: (abs: string, source: string) => string | null,
- *   calculateCrap?: (source: string, entry: object|null) => Array<object>,
+ *   transpile?: (abs: string, source: string, opts?: object) => unknown,
+ *   prepare?: (abs: string, deps: object) => object,
+ *   calculateCrap?: (source: string, entry: object|null, mapLine: Function|null) => Array<object>,
  * }} [deps]
  * @returns {{kind: 'exit'} | {kind: 'reply', message: object}}
  */
@@ -75,9 +81,6 @@ export function handleCrapWorkerMessage(msg, _coverage, deps = {}) {
     };
   }
   const { abs, relPath, requireCoverage } = item;
-  const readFile = deps.readFile ?? ((p) => fs.readFileSync(p, 'utf-8'));
-  const transpile = deps.transpile ?? transpileIfNeeded;
-  const calculateCrap = deps.calculateCrap ?? calculateCrapForSource;
 
   // Coverage entry is pre-resolved on the host and attached to the item.
   // `item.coverageEntry` may be explicitly `null` when the file has no
@@ -93,84 +96,54 @@ export function handleCrapWorkerMessage(msg, _coverage, deps = {}) {
           skippedFileNoCoverage: true,
           rows: [],
           skippedMethodsNoCoverage: 0,
+          hasCoverageEntry: false,
+          resolvedMethods: 0,
+          totalMethods: 0,
         },
       },
     };
   }
 
-  let source;
-  try {
-    source = readFile(abs);
-  } catch {
-    return {
-      kind: 'reply',
-      message: {
-        ok: true,
-        result: {
-          relPath,
-          skippedFileNoCoverage: false,
-          rows: null,
-          skippedMethodsNoCoverage: 0,
-        },
+  const dropped = (error) => ({
+    kind: 'reply',
+    message: {
+      ok: true,
+      result: {
+        relPath,
+        skippedFileNoCoverage: false,
+        rows: null,
+        skippedMethodsNoCoverage: 0,
+        hasCoverageEntry: entry !== null,
+        resolvedMethods: 0,
+        totalMethods: 0,
+        ...(error ? { error } : {}),
       },
-    };
-  }
+    },
+  });
 
-  // TS/TSX → strip-then-analyze. Coverage lookup above used the original
-  // source path (vitest's coverage-final.json keys on the .ts file, not
-  // transpiled output); the transpile is purely about making the code
-  // parseable by the Esprima-based escomplex kernel.
-  const prepared = transpile(abs, source);
-  if (prepared === null) {
-    return {
-      kind: 'reply',
-      message: {
-        ok: true,
-        result: {
-          relPath,
-          skippedFileNoCoverage: false,
-          rows: null,
-          skippedMethodsNoCoverage: 0,
-        },
-      },
-    };
-  }
+  // TS/TSX -> transpile-then-analyze, carrying the source map. The coverage
+  // lookup above used the ORIGINAL source path (vitest's coverage-final.json
+  // keys on the .ts file, not transpiled output) and the per-method join
+  // below uses ORIGINAL source *lines*, remapped from escomplex's transpiled
+  // coordinates via `prepared.mapLine` (Story #4775).
+  const prepare = deps.prepare ?? prepareSourceForScoring;
+  const prepared = prepare(abs, deps);
+  if (prepared.error) return dropped(null);
 
   let methodRows;
   try {
-    methodRows = calculateCrap(prepared, entry);
+    methodRows = (deps.calculateCrap ?? calculateCrapForSource)(
+      prepared.code,
+      entry,
+      prepared.mapLine,
+    );
   } catch (err) {
-    return {
-      kind: 'reply',
-      message: {
-        ok: true,
-        result: {
-          relPath,
-          skippedFileNoCoverage: false,
-          rows: null,
-          skippedMethodsNoCoverage: 0,
-          error:
-            err && typeof err.message === 'string' ? err.message : String(err),
-        },
-      },
-    };
+    return dropped(
+      err && typeof err.message === 'string' ? err.message : String(err),
+    );
   }
 
-  const rows = [];
-  let skippedMethodsNoCoverage = 0;
-  for (const mr of methodRows) {
-    if (mr.crap === null || mr.coverage === null) {
-      skippedMethodsNoCoverage += 1;
-      continue;
-    }
-    rows.push({
-      method: mr.method,
-      startLine: mr.startLine,
-      cyclomatic: mr.cyclomatic,
-      coverage: mr.coverage,
-      crap: mr.crap,
-    });
-  }
+  const finalized = finalizeMethodRows(methodRows, { requireCoverage });
   return {
     kind: 'reply',
     message: {
@@ -178,8 +151,8 @@ export function handleCrapWorkerMessage(msg, _coverage, deps = {}) {
       result: {
         relPath,
         skippedFileNoCoverage: false,
-        rows,
-        skippedMethodsNoCoverage,
+        hasCoverageEntry: entry !== null,
+        ...finalized,
       },
     },
   };

--- a/.agents/scripts/update-crap-baseline.js
+++ b/.agents/scripts/update-crap-baseline.js
@@ -13,6 +13,7 @@ import {
 } from './lib/config-resolver.js';
 import { loadCoverage } from './lib/coverage-utils.js';
 import {
+  checkResolutionFloor,
   resolveEscomplexVersion,
   resolveTsTranspilerVersion,
   scanAndScore,
@@ -71,6 +72,7 @@ async function main() {
   const crap = getQuality(config).crap;
   const targetDirs = Array.isArray(crap.targetDirs) ? crap.targetDirs : [];
   const requireCoverage = crap.requireCoverage !== false;
+  const minMethodResolutionRate = crap.minMethodResolutionRate ?? 0.75;
   const coveragePath =
     args.coveragePath ?? crap.coveragePath ?? 'coverage/coverage-final.json';
   const baselinePath = args.baselinePath ?? getBaselines(config).crap.path;
@@ -117,6 +119,7 @@ async function main() {
       scannedFiles,
       skippedFilesNoCoverage,
       skippedMethodsNoCoverage,
+      resolution,
     } = await scanAndScore({
       targetDirs,
       coverage,
@@ -137,6 +140,16 @@ async function main() {
         `[CRAP] Skipped ${skippedMethodsNoCoverage} method(s) whose per-method coverage was unresolved.`,
       );
     }
+    if (resolution) {
+      Logger.info(
+        `[CRAP] Method resolution: ${resolution.resolvedMethods}/${resolution.joinableMethods} ` +
+          `(${(resolution.rate * 100).toFixed(1)}%) in files with coverage.`,
+      );
+    }
+    // Fail closed BEFORE the service persists anything — a thin baseline is
+    // never written and then apologised for.
+    const refusal = checkResolutionFloor(resolution, minMethodResolutionRate);
+    if (refusal) throw new Error(refusal);
 
     return (rows ?? []).filter(
       (r) => typeof r?.crap === 'number' && Number.isFinite(r.crap),

--- a/baselines/crap.json
+++ b/baselines/crap.json
@@ -1,236 +1,1167 @@
 {
   "$schema": ".agents/schemas/baselines/crap.schema.json",
   "kernelVersion": "0.1.0",
-  "generatedAt": "2026-07-15T01:10:26.908Z",
+  "generatedAt": "2026-07-26T02:47:13.697Z",
+  "scoringSemantics": "coverage-join-v2",
   "rollup": {
     "*": {
-      "p50": 3,
-      "p95": 12,
-      "max": 30,
-      "methodsAbove20": 13
+      "p50": 2,
+      "p95": 11.036579789666211,
+      "max": 123.75293999270504,
+      "methodsAbove20": 40
     }
   },
   "rows": [
     {
-      "path": ".agents/scripts/analyze-execution.js",
-      "method": "resolveConcurrencyCap",
-      "startLine": 87,
-      "crap": 3
+      "path": ".agents/scripts/acceptance-eval.js",
+      "method": "getVerdictValidator",
+      "startLine": 94,
+      "crap": 2
     },
     {
-      "path": ".agents/scripts/analyze-execution.js",
-      "method": "resolveVerifyConcurrencyCap",
-      "startLine": 97,
-      "crap": 3
-    },
-    {
-      "path": ".agents/scripts/analyze-execution.js",
-      "method": "runStoryMode",
+      "path": ".agents/scripts/acceptance-eval.js",
+      "method": "validateVerdict",
       "startLine": 116,
-      "crap": 2.015056241426612
+      "crap": 2
     },
     {
-      "path": ".agents/scripts/analyze-execution.js",
-      "method": "runEpicMode",
-      "startLine": 180,
-      "crap": 8.074646449919813
+      "path": ".agents/scripts/acceptance-eval.js",
+      "method": "<anon method-1>",
+      "startLine": 123,
+      "crap": 2
     },
     {
-      "path": ".agents/scripts/analyze-execution.js",
-      "method": "parseCli",
-      "startLine": 295,
-      "crap": 10
+      "path": ".agents/scripts/acceptance-eval.js",
+      "method": "parseCliArgs",
+      "startLine": 132,
+      "crap": 12
     },
     {
-      "path": ".agents/scripts/analyze-execution.js",
+      "path": ".agents/scripts/acceptance-eval.js",
+      "method": "runAcceptanceEval",
+      "startLine": 170,
+      "crap": 6
+    },
+    {
+      "path": ".agents/scripts/acceptance-eval.js",
+      "method": "<anon method-2>",
+      "startLine": 222,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/acceptance-eval.js",
       "method": "main",
-      "startLine": 323,
-      "crap": 3.131456790123457
+      "startLine": 238,
+      "crap": 69.13476361410247
+    },
+    {
+      "path": ".agents/scripts/acceptance-eval.js",
+      "method": "<anon method-3>",
+      "startLine": 294,
+      "crap": 1.955230681470351
+    },
+    {
+      "path": ".agents/scripts/apply-quality-bootstrap.js",
+      "method": "applyBootstrapAndMigration",
+      "startLine": 53,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/apply-quality-bootstrap.js",
+      "method": "main",
+      "startLine": 66,
+      "crap": 2
     },
     {
       "path": ".agents/scripts/audit-labels-bootstrap.js",
       "method": "labelExists",
-      "startLine": 89,
+      "startLine": 111,
       "crap": 2.0240420736288502
     },
     {
       "path": ".agents/scripts/audit-labels-bootstrap.js",
+      "method": "<anon method-2>",
+      "startLine": 117,
+      "crap": 1.0060105184072126
+    },
+    {
+      "path": ".agents/scripts/audit-labels-bootstrap.js",
       "method": "createLabel",
-      "startLine": 101,
+      "startLine": 123,
       "crap": 4
     },
     {
       "path": ".agents/scripts/audit-labels-bootstrap.js",
       "method": "bootstrapAuditLabels",
-      "startLine": 129,
+      "startLine": 151,
       "crap": 10.031696093163035
     },
     {
       "path": ".agents/scripts/audit-labels-bootstrap.js",
       "method": "resolveOwnerRepo",
-      "startLine": 184,
+      "startLine": 206,
       "crap": 3
     },
     {
       "path": ".agents/scripts/audit-labels-bootstrap.js",
       "method": "formatBootstrapReport",
-      "startLine": 203,
+      "startLine": 225,
       "crap": 4
     },
     {
       "path": ".agents/scripts/audit-labels-bootstrap.js",
+      "method": "<anon method-3>",
+      "startLine": 236,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/audit-labels-bootstrap.js",
       "method": "main",
-      "startLine": 224,
+      "startLine": 246,
       "crap": 12
+    },
+    {
+      "path": ".agents/scripts/audit-to-stories.js",
+      "method": "meetsSeverity",
+      "startLine": 57,
+      "crap": 12
+    },
+    {
+      "path": ".agents/scripts/audit-to-stories.js",
+      "method": "collectReportPaths",
+      "startLine": 64,
+      "crap": 6
+    },
+    {
+      "path": ".agents/scripts/audit-to-stories.js",
+      "method": "readReports",
+      "startLine": 73,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/audit-to-stories.js",
+      "method": "<anon method-1>",
+      "startLine": 74,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/audit-to-stories.js",
+      "method": "tallyBySeverity",
+      "startLine": 80,
+      "crap": 6
+    },
+    {
+      "path": ".agents/scripts/audit-to-stories.js",
+      "method": "loadFixtureProvider",
+      "startLine": 98,
+      "crap": 2.0185185185185186
+    },
+    {
+      "path": ".agents/scripts/audit-to-stories.js",
+      "method": "loadProvider",
+      "startLine": 105,
+      "crap": 3.009963508138915
+    },
+    {
+      "path": ".agents/scripts/audit-to-stories.js",
+      "method": "<anon method-2>",
+      "startLine": 130,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/audit-to-stories.js",
+      "method": "<anon method-3>",
+      "startLine": 149,
+      "crap": 3
+    },
+    {
+      "path": ".agents/scripts/audit-to-stories.js",
+      "method": "dedupSkippedWarning",
+      "startLine": 183,
+      "crap": 6
+    },
+    {
+      "path": ".agents/scripts/audit-to-stories.js",
+      "method": "dedupDegradedWarning",
+      "startLine": 217,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/audit-to-stories.js",
+      "method": "<anon method-4>",
+      "startLine": 218,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/audit-to-stories.js",
+      "method": "buildPlan",
+      "startLine": 227,
+      "crap": 110
+    },
+    {
+      "path": ".agents/scripts/audit-to-stories.js",
+      "method": "<anon method-5>",
+      "startLine": 250,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/audit-to-stories.js",
+      "method": "<anon method-6>",
+      "startLine": 254,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/audit-to-stories.js",
+      "method": "<anon method-7>",
+      "startLine": 310,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/audit-to-stories.js",
+      "method": "reconcileScanLedger",
+      "startLine": 353,
+      "crap": 6
+    },
+    {
+      "path": ".agents/scripts/audit-to-stories.js",
+      "method": "<anon method-8>",
+      "startLine": 364,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/audit-to-stories.js",
+      "method": "<anon method-9>",
+      "startLine": 365,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/audit-to-stories.js",
+      "method": "issueStatesFromClassifications",
+      "startLine": 375,
+      "crap": 12
+    },
+    {
+      "path": ".agents/scripts/audit-to-stories.js",
+      "method": "loadPlan",
+      "startLine": 392,
+      "crap": 6
+    },
+    {
+      "path": ".agents/scripts/audit-to-stories.js",
+      "method": "resolveSeverityFloor",
+      "startLine": 408,
+      "crap": 20
+    },
+    {
+      "path": ".agents/scripts/audit-to-stories.js",
+      "method": "runAuto",
+      "startLine": 436,
+      "crap": 42
+    },
+    {
+      "path": ".agents/scripts/audit-to-stories.js",
+      "method": "<anon method-10>",
+      "startLine": 458,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/audit-to-stories.js",
+      "method": "<anon method-11>",
+      "startLine": 477,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/audit-to-stories.js",
+      "method": "<anon method-12>",
+      "startLine": 478,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/audit-to-stories.js",
+      "method": "<anon method-13>",
+      "startLine": 479,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/audit-to-stories.js",
+      "method": "buildAndGateStories",
+      "startLine": 502,
+      "crap": 42
+    },
+    {
+      "path": ".agents/scripts/audit-to-stories.js",
+      "method": "<anon method-14>",
+      "startLine": 503,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/audit-to-stories.js",
+      "method": "<anon method-15>",
+      "startLine": 517,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/audit-to-stories.js",
+      "method": "persist",
+      "startLine": 526,
+      "crap": 6
+    },
+    {
+      "path": ".agents/scripts/audit-to-stories.js",
+      "method": "main",
+      "startLine": 549,
+      "crap": 90
+    },
+    {
+      "path": ".agents/scripts/audit-to-stories.js",
+      "method": "<anon method-16>",
+      "startLine": 608,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/audit-to-stories.js",
+      "method": "<anon method-17>",
+      "startLine": 609,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/audit-to-stories.js",
+      "method": "<anon method-18>",
+      "startLine": 615,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/boot-sweep.js",
+      "method": "runBootSweep",
+      "startLine": 92,
+      "crap": 6
+    },
+    {
+      "path": ".agents/scripts/boot-sweep.js",
+      "method": "<anon method-1>",
+      "startLine": 136,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/boot-sweep.js",
+      "method": "<anon method-2>",
+      "startLine": 137,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/boot-sweep.js",
+      "method": "buildSummaryLine",
+      "startLine": 169,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/boot-sweep.js",
+      "method": "main",
+      "startLine": 179,
+      "crap": 72
+    },
+    {
+      "path": ".agents/scripts/bootstrap.js",
+      "method": "bareRepoName",
+      "startLine": 126,
+      "crap": 6
+    },
+    {
+      "path": ".agents/scripts/bootstrap.js",
+      "method": "normalizeHandleAnswer",
+      "startLine": 146,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/bootstrap.js",
+      "method": "safeList",
+      "startLine": 152,
+      "crap": 1.0233236151603498
+    },
+    {
+      "path": ".agents/scripts/bootstrap.js",
+      "method": "resolveOwnerForPicker",
+      "startLine": 161,
+      "crap": 7
+    },
+    {
+      "path": ".agents/scripts/bootstrap.js",
+      "method": "confirmYesNo",
+      "startLine": 179,
+      "crap": 10.08854060655404
+    },
+    {
+      "path": ".agents/scripts/bootstrap.js",
+      "method": "runGit",
+      "startLine": 203,
+      "crap": 4
+    },
+    {
+      "path": ".agents/scripts/bootstrap.js",
+      "method": "logGhError",
+      "startLine": 219,
+      "crap": 4
+    },
+    {
+      "path": ".agents/scripts/bootstrap.js",
+      "method": "gitIdentityArgs",
+      "startLine": 237,
+      "crap": 5
+    },
+    {
+      "path": ".agents/scripts/bootstrap.js",
+      "method": "ensureGitInitialized",
+      "startLine": 257,
+      "crap": 9.034820690905915
+    },
+    {
+      "path": ".agents/scripts/bootstrap.js",
+      "method": "ensureGitRemote",
+      "startLine": 321,
+      "crap": 7.179647999999999
+    },
+    {
+      "path": ".agents/scripts/bootstrap.js",
+      "method": "repoExists",
+      "startLine": 355,
+      "crap": 2.0240420736288502
+    },
+    {
+      "path": ".agents/scripts/bootstrap.js",
+      "method": "ensureProjectLinked",
+      "startLine": 375,
+      "crap": 3.1172399755750053
+    },
+    {
+      "path": ".agents/scripts/bootstrap.js",
+      "method": "resolveRepoVisibility",
+      "startLine": 405,
+      "crap": 4
+    },
+    {
+      "path": ".agents/scripts/bootstrap.js",
+      "method": "createGithubRepo",
+      "startLine": 420,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/bootstrap.js",
+      "method": "findExistingProjectNumber",
+      "startLine": 456,
+      "crap": 9.021751535698701
+    },
+    {
+      "path": ".agents/scripts/bootstrap.js",
+      "method": "createGithubProject",
+      "startLine": 498,
+      "crap": 3.001125
+    },
+    {
+      "path": ".agents/scripts/bootstrap.js",
+      "method": "buildQuestions",
+      "startLine": 550,
+      "crap": 3.0010601126263654
+    },
+    {
+      "path": ".agents/scripts/bootstrap.js",
+      "method": "<anon method-1>",
+      "startLine": 558,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/bootstrap.js",
+      "method": "<anon method-2>",
+      "startLine": 574,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/bootstrap.js",
+      "method": "<anon method-3>",
+      "startLine": 586,
+      "crap": 4.125
+    },
+    {
+      "path": ".agents/scripts/bootstrap.js",
+      "method": "<anon method-4>",
+      "startLine": 601,
+      "crap": 4
+    },
+    {
+      "path": ".agents/scripts/bootstrap.js",
+      "method": "<anon method-5>",
+      "startLine": 608,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/bootstrap.js",
+      "method": "<anon method-6>",
+      "startLine": 618,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/bootstrap.js",
+      "method": "<anon method-7>",
+      "startLine": 635,
+      "crap": 4.0466472303206995
+    },
+    {
+      "path": ".agents/scripts/bootstrap.js",
+      "method": "<anon method-8>",
+      "startLine": 645,
+      "crap": 6
+    },
+    {
+      "path": ".agents/scripts/bootstrap.js",
+      "method": "resolveSilentAccept",
+      "startLine": 673,
+      "crap": 5
+    },
+    {
+      "path": ".agents/scripts/bootstrap.js",
+      "method": "runGithubBootstrap",
+      "startLine": 689,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/bootstrap.js",
+      "method": "githubSubMutationsSucceeded",
+      "startLine": 723,
+      "crap": 3
+    },
+    {
+      "path": ".agents/scripts/bootstrap.js",
+      "method": "resolveAppliedGroups",
+      "startLine": 730,
+      "crap": 6
+    },
+    {
+      "path": ".agents/scripts/bootstrap.js",
+      "method": "parseAndValidate",
+      "startLine": 769,
+      "crap": 9
+    },
+    {
+      "path": ".agents/scripts/bootstrap.js",
+      "method": "prepareContext",
+      "startLine": 813,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/bootstrap.js",
+      "method": "runPreflightPhase",
+      "startLine": 839,
+      "crap": 6
+    },
+    {
+      "path": ".agents/scripts/bootstrap.js",
+      "method": "renderAnswerSummary",
+      "startLine": 885,
+      "crap": 5
+    },
+    {
+      "path": ".agents/scripts/bootstrap.js",
+      "method": "detectCreation",
+      "startLine": 918,
+      "crap": 7.226851851851852
+    },
+    {
+      "path": ".agents/scripts/bootstrap.js",
+      "method": "resolveProjectDisplay",
+      "startLine": 937,
+      "crap": 23.713952471205715
+    },
+    {
+      "path": ".agents/scripts/bootstrap.js",
+      "method": "<anon method-9>",
+      "startLine": 944,
+      "crap": 1.49205423531127
+    },
+    {
+      "path": ".agents/scripts/bootstrap.js",
+      "method": "<anon method-10>",
+      "startLine": 945,
+      "crap": 1.49205423531127
+    },
+    {
+      "path": ".agents/scripts/bootstrap.js",
+      "method": "collectAndConfirm",
+      "startLine": 963,
+      "crap": 18.1875
+    },
+    {
+      "path": ".agents/scripts/bootstrap.js",
+      "method": "<anon method-11>",
+      "startLine": 972,
+      "crap": 1.0005787037037037
+    },
+    {
+      "path": ".agents/scripts/bootstrap.js",
+      "method": "<anon method-12>",
+      "startLine": 975,
+      "crap": 1.0005787037037037
+    },
+    {
+      "path": ".agents/scripts/bootstrap.js",
+      "method": "renderDryRunPlan",
+      "startLine": 1090,
+      "crap": 6
+    },
+    {
+      "path": ".agents/scripts/bootstrap.js",
+      "method": "<anon method-13>",
+      "startLine": 1093,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/bootstrap.js",
+      "method": "dryRunPlan",
+      "startLine": 1115,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/bootstrap.js",
+      "method": "provisionResources",
+      "startLine": 1148,
+      "crap": 11
+    },
+    {
+      "path": ".agents/scripts/bootstrap.js",
+      "method": "executeBootstrap",
+      "startLine": 1216,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/bootstrap.js",
+      "method": "persistProjectNumber",
+      "startLine": 1241,
+      "crap": 3
+    },
+    {
+      "path": ".agents/scripts/bootstrap.js",
+      "method": "executeGithubBootstrap",
+      "startLine": 1271,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/bootstrap.js",
+      "method": "recordLedger",
+      "startLine": 1295,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/bootstrap.js",
+      "method": "<anon method-14>",
+      "startLine": 1305,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/bootstrap.js",
+      "method": "offerCommitPush",
+      "startLine": 1354,
+      "crap": 9.582154833066046
+    },
+    {
+      "path": ".agents/scripts/bootstrap.js",
+      "method": "runPipeline",
+      "startLine": 1413,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/bootstrap.js",
+      "method": "main",
+      "startLine": 1423,
+      "crap": 3
+    },
+    {
+      "path": ".agents/scripts/bootstrap.js",
+      "method": "<anon method-15>",
+      "startLine": 1428,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/bootstrap.js",
+      "method": "<anon method-16>",
+      "startLine": 1429,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/bootstrap.js",
+      "method": "<anon method-17>",
+      "startLine": 1430,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/bootstrap.js",
+      "method": "<anon method-18>",
+      "startLine": 1431,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/bootstrap.js",
+      "method": "<anon method-19>",
+      "startLine": 1432,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/bootstrap.js",
+      "method": "<anon method-20>",
+      "startLine": 1433,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/bootstrap.js",
+      "method": "<anon method-21>",
+      "startLine": 1434,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/bootstrap.js",
+      "method": "<anon method-22>",
+      "startLine": 1435,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/bootstrap.js",
+      "method": "<anon method-23>",
+      "startLine": 1436,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/bootstrap.js",
+      "method": "<anon method-24>",
+      "startLine": 1437,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/bootstrap.js",
+      "method": "<anon method-25>",
+      "startLine": 1438,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/check-action-pinning.js",
+      "method": "parseArgv",
+      "startLine": 48,
+      "crap": 6
+    },
+    {
+      "path": ".agents/scripts/check-action-pinning.js",
+      "method": "isFullSha",
+      "startLine": 72,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/check-action-pinning.js",
+      "method": "isFirstParty",
+      "startLine": 88,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/check-action-pinning.js",
+      "method": "scanWorkflowText",
+      "startLine": 108,
+      "crap": 12
+    },
+    {
+      "path": ".agents/scripts/check-action-pinning.js",
+      "method": "listWorkflowFiles",
+      "startLine": 160,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/check-action-pinning.js",
+      "method": "<anon method-1>",
+      "startLine": 168,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/check-action-pinning.js",
+      "method": "<anon method-2>",
+      "startLine": 169,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/check-action-pinning.js",
+      "method": "renderReport",
+      "startLine": 181,
+      "crap": 3
+    },
+    {
+      "path": ".agents/scripts/check-action-pinning.js",
+      "method": "runCli",
+      "startLine": 204,
+      "crap": 4.001232867476378
+    },
+    {
+      "path": ".agents/scripts/check-action-pinning.js",
+      "method": "main",
+      "startLine": 252,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/check-arch-cycles.js",
+      "method": "parseArgv",
+      "startLine": 58,
+      "crap": 9
+    },
+    {
+      "path": ".agents/scripts/check-arch-cycles.js",
+      "method": "collectJsFiles",
+      "startLine": 90,
+      "crap": 1.0007513148009015
+    },
+    {
+      "path": ".agents/scripts/check-arch-cycles.js",
+      "method": "<anon method-1>",
+      "startLine": 92,
+      "crap": 5.0407083248524325
+    },
+    {
+      "path": ".agents/scripts/check-arch-cycles.js",
+      "method": "parseRelativeImports",
+      "startLine": 121,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/check-arch-cycles.js",
+      "method": "buildGraph",
+      "startLine": 140,
+      "crap": 3.01382567137005
+    },
+    {
+      "path": ".agents/scripts/check-arch-cycles.js",
+      "method": "<anon method-2>",
+      "startLine": 141,
+      "crap": 1.0015361857077834
+    },
+    {
+      "path": ".agents/scripts/check-arch-cycles.js",
+      "method": "<anon method-3>",
+      "startLine": 142,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/check-arch-cycles.js",
+      "method": "normalizeCycle",
+      "startLine": 176,
+      "crap": 4
+    },
+    {
+      "path": ".agents/scripts/check-arch-cycles.js",
+      "method": "findCycles",
+      "startLine": 194,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/check-arch-cycles.js",
+      "method": "<anon method-4>",
+      "startLine": 205,
+      "crap": 5
+    },
+    {
+      "path": ".agents/scripts/check-arch-cycles.js",
+      "method": "<anon method-5>",
+      "startLine": 240,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/check-arch-cycles.js",
+      "method": "loadBaseline",
+      "startLine": 252,
+      "crap": 4
+    },
+    {
+      "path": ".agents/scripts/check-arch-cycles.js",
+      "method": "diffCycles",
+      "startLine": 272,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/check-arch-cycles.js",
+      "method": "<anon method-6>",
+      "startLine": 273,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/check-arch-cycles.js",
+      "method": "<anon method-7>",
+      "startLine": 276,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/check-arch-cycles.js",
+      "method": "<anon method-8>",
+      "startLine": 277,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/check-arch-cycles.js",
+      "method": "<anon method-9>",
+      "startLine": 278,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/check-arch-cycles.js",
+      "method": "renderDiff",
+      "startLine": 290,
+      "crap": 3
+    },
+    {
+      "path": ".agents/scripts/check-arch-cycles.js",
+      "method": "<anon method-10>",
+      "startLine": 292,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/check-arch-cycles.js",
+      "method": "runCli",
+      "startLine": 319,
+      "crap": 8
+    },
+    {
+      "path": ".agents/scripts/check-arch-cycles.js",
+      "method": "<anon method-11>",
+      "startLine": 331,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/check-arch-cycles.js",
+      "method": "<anon method-12>",
+      "startLine": 338,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/check-arch-cycles.js",
+      "method": "<anon method-13>",
+      "startLine": 345,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/check-arch-cycles.js",
+      "method": "main",
+      "startLine": 376,
+      "crap": 2
     },
     {
       "path": ".agents/scripts/check-baselines.js",
       "method": "main",
-      "startLine": 65,
+      "startLine": 68,
       "crap": 1.1016296296296297
+    },
+    {
+      "path": ".agents/scripts/check-context-budget.js",
+      "method": "agentBootOverflow",
+      "startLine": 94,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/check-context-budget.js",
+      "method": "<anon method-1>",
+      "startLine": 97,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/check-context-budget.js",
+      "method": "<anon method-2>",
+      "startLine": 98,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/check-context-budget.js",
+      "method": "parseArgv",
+      "startLine": 108,
+      "crap": 10
+    },
+    {
+      "path": ".agents/scripts/check-context-budget.js",
+      "method": "loadBaseline",
+      "startLine": 143,
+      "crap": 4.128
+    },
+    {
+      "path": ".agents/scripts/check-context-budget.js",
+      "method": "buildBaseline",
+      "startLine": 162,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/check-context-budget.js",
+      "method": "diffBudget",
+      "startLine": 203,
+      "crap": 7
+    },
+    {
+      "path": ".agents/scripts/check-context-budget.js",
+      "method": "renderDiff",
+      "startLine": 246,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/check-context-budget.js",
+      "method": "renderReachable",
+      "startLine": 274,
+      "crap": 3
+    },
+    {
+      "path": ".agents/scripts/check-context-budget.js",
+      "method": "runCli",
+      "startLine": 298,
+      "crap": 19.455350394125908
+    },
+    {
+      "path": ".agents/scripts/check-context-budget.js",
+      "method": "<anon method-3>",
+      "startLine": 366,
+      "crap": 1.0134974624770543
+    },
+    {
+      "path": ".agents/scripts/check-context-budget.js",
+      "method": "main",
+      "startLine": 404,
+      "crap": 1
     },
     {
       "path": ".agents/scripts/check-dead-exports.js",
       "method": "parseArgv",
-      "startLine": 42,
-      "crap": 9
+      "startLine": 53,
+      "crap": 10
     },
     {
       "path": ".agents/scripts/check-dead-exports.js",
       "method": "loadBaseline",
-      "startLine": 75,
+      "startLine": 89,
       "crap": 4
     },
     {
       "path": ".agents/scripts/check-dead-exports.js",
-      "method": "extractRowsFromKnip",
-      "startLine": 97,
-      "crap": 14
-    },
-    {
-      "path": ".agents/scripts/check-dead-exports.js",
       "method": "diffRows",
-      "startLine": 131,
+      "startLine": 115,
       "crap": 1
     },
     {
       "path": ".agents/scripts/check-dead-exports.js",
       "method": "<anon method-1>",
-      "startLine": 132,
+      "startLine": 116,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/check-dead-exports.js",
+      "method": "<anon method-2>",
+      "startLine": 119,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/check-dead-exports.js",
+      "method": "<anon method-3>",
+      "startLine": 120,
       "crap": 1
     },
     {
       "path": ".agents/scripts/check-dead-exports.js",
       "method": "<anon method-4>",
-      "startLine": 138,
+      "startLine": 122,
       "crap": 2
     },
     {
       "path": ".agents/scripts/check-dead-exports.js",
       "method": "renderDiff",
-      "startLine": 157,
+      "startLine": 145,
       "crap": 2
     },
     {
       "path": ".agents/scripts/check-dead-exports.js",
-      "method": "runKnip",
-      "startLine": 180,
-      "crap": 27.323832749072807
-    },
-    {
-      "path": ".agents/scripts/check-dead-exports.js",
-      "method": "readKnipOutput",
-      "startLine": 215,
-      "crap": 1.0233236151603498
-    },
-    {
-      "path": ".agents/scripts/check-dead-exports.js",
       "method": "runCli",
-      "startLine": 237,
-      "crap": 10.000364132908512
+      "startLine": 170,
+      "crap": 10.000279399068484
     },
     {
       "path": ".agents/scripts/check-dead-exports.js",
       "method": "main",
-      "startLine": 303,
+      "startLine": 242,
       "crap": 2
     },
     {
       "path": ".agents/scripts/check-doc-links.js",
       "method": "isExcludedRelPath",
-      "startLine": 126,
+      "startLine": 129,
       "crap": 2
     },
     {
       "path": ".agents/scripts/check-doc-links.js",
       "method": "walkMarkdown",
-      "startLine": 131,
+      "startLine": 134,
       "crap": 7.06721536351166
     },
     {
       "path": ".agents/scripts/check-doc-links.js",
       "method": "discoverMarkdown",
-      "startLine": 150,
+      "startLine": 153,
       "crap": 2
     },
     {
       "path": ".agents/scripts/check-doc-links.js",
       "method": "maskCodeRegions",
-      "startLine": 167,
+      "startLine": 170,
       "crap": 6
     },
     {
       "path": ".agents/scripts/check-doc-links.js",
+      "method": "<anon method-1>",
+      "startLine": 199,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/check-doc-links.js",
       "method": "offsetToLine",
-      "startLine": 204,
+      "startLine": 207,
       "crap": 3
     },
     {
       "path": ".agents/scripts/check-doc-links.js",
       "method": "extractLinks",
-      "startLine": 218,
+      "startLine": 221,
       "crap": 2
     },
     {
       "path": ".agents/scripts/check-doc-links.js",
       "method": "isExternalOrInternalAnchor",
-      "startLine": 232,
+      "startLine": 235,
       "crap": 4
     },
     {
       "path": ".agents/scripts/check-doc-links.js",
       "method": "stripAnchorAndQuery",
-      "startLine": 239,
+      "startLine": 242,
       "crap": 3
     },
     {
       "path": ".agents/scripts/check-doc-links.js",
       "method": "extractSlashTokens",
-      "startLine": 270,
+      "startLine": 273,
       "crap": 2
     },
     {
       "path": ".agents/scripts/check-doc-links.js",
       "method": "checkFile",
-      "startLine": 286,
+      "startLine": 289,
       "crap": 12.00169045830203
     },
     {
       "path": ".agents/scripts/check-doc-links.js",
       "method": "runCheck",
-      "startLine": 385,
+      "startLine": 388,
       "crap": 2
     },
     {
       "path": ".agents/scripts/check-doc-links.js",
       "method": "formatViolation",
-      "startLine": 401,
+      "startLine": 404,
       "crap": 2
     },
     {
       "path": ".agents/scripts/check-doc-links.js",
       "method": "main",
-      "startLine": 405,
+      "startLine": 408,
       "crap": 6
     },
     {
@@ -247,9 +1178,21 @@
     },
     {
       "path": ".agents/scripts/check-gherkin-placeholders.js",
+      "method": "<anon method-1>",
+      "startLine": 100,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/check-gherkin-placeholders.js",
       "method": "discoverStepDefs",
       "startLine": 107,
       "crap": 2
+    },
+    {
+      "path": ".agents/scripts/check-gherkin-placeholders.js",
+      "method": "<anon method-2>",
+      "startLine": 114,
+      "crap": 1
     },
     {
       "path": ".agents/scripts/check-gherkin-placeholders.js",
@@ -271,6 +1214,18 @@
     },
     {
       "path": ".agents/scripts/check-gherkin-placeholders.js",
+      "method": "<anon method-3>",
+      "startLine": 221,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/check-gherkin-placeholders.js",
+      "method": "<anon method-4>",
+      "startLine": 222,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/check-gherkin-placeholders.js",
       "method": "parseStepDefs",
       "startLine": 250,
       "crap": 6
@@ -280,6 +1235,18 @@
       "method": "readHandlerParams",
       "startLine": 284,
       "crap": 4.175582990397805
+    },
+    {
+      "path": ".agents/scripts/check-gherkin-placeholders.js",
+      "method": "<anon method-5>",
+      "startLine": 299,
+      "crap": 1.010973936899863
+    },
+    {
+      "path": ".agents/scripts/check-gherkin-placeholders.js",
+      "method": "<anon method-6>",
+      "startLine": 300,
+      "crap": 1.010973936899863
     },
     {
       "path": ".agents/scripts/check-gherkin-placeholders.js",
@@ -327,6 +1294,12 @@
       "path": ".agents/scripts/check-gherkin-placeholders.js",
       "method": "substitutePlaceholders",
       "startLine": 468,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/check-gherkin-placeholders.js",
+      "method": "<anon method-7>",
+      "startLine": 470,
       "crap": 1
     },
     {
@@ -379,6 +1352,12 @@
     },
     {
       "path": ".agents/scripts/check-lifecycle-doc-drift.js",
+      "method": "<anon method-1>",
+      "startLine": 102,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/check-lifecycle-doc-drift.js",
       "method": "extractCodeEvents",
       "startLine": 119,
       "crap": 8
@@ -394,6 +1373,12 @@
       "method": "parseListenerTable",
       "startLine": 190,
       "crap": 11
+    },
+    {
+      "path": ".agents/scripts/check-lifecycle-doc-drift.js",
+      "method": "<anon method-2>",
+      "startLine": 208,
+      "crap": 1
     },
     {
       "path": ".agents/scripts/check-lifecycle-doc-drift.js",
@@ -415,6 +1400,12 @@
     },
     {
       "path": ".agents/scripts/check-lifecycle-doc-drift.js",
+      "method": "<anon method-3>",
+      "startLine": 322,
+      "crap": 1.015625
+    },
+    {
+      "path": ".agents/scripts/check-lifecycle-doc-drift.js",
       "method": "formatFinding",
       "startLine": 371,
       "crap": 17.945380063723256
@@ -426,28 +1417,268 @@
       "crap": 2.116522530723714
     },
     {
-      "path": ".agents/scripts/check-prepush-recovery.js",
-      "method": "parsePrePushLocalRefs",
-      "startLine": 42,
+      "path": ".agents/scripts/check-test-temp-hygiene.js",
+      "method": "tempDirFor",
+      "startLine": 74,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/check-test-temp-hygiene.js",
+      "method": "defaultBaselinePath",
+      "startLine": 90,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/check-test-temp-hygiene.js",
+      "method": "checkedBaselinePath",
+      "startLine": 111,
       "crap": 3
     },
     {
-      "path": ".agents/scripts/check-prepush-recovery.js",
-      "method": "shouldSkipCoverageGate",
-      "startLine": 60,
+      "path": ".agents/scripts/check-test-temp-hygiene.js",
+      "method": "isStreamFile",
+      "startLine": 130,
+      "crap": 3
+    },
+    {
+      "path": ".agents/scripts/check-test-temp-hygiene.js",
+      "method": "listStreamFiles",
+      "startLine": 144,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/check-test-temp-hygiene.js",
+      "method": "<anon method-1>",
+      "startLine": 148,
+      "crap": 5
+    },
+    {
+      "path": ".agents/scripts/check-test-temp-hygiene.js",
+      "method": "fingerprintFile",
+      "startLine": 168,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/check-test-temp-hygiene.js",
+      "method": "buildManifest",
+      "startLine": 182,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/check-test-temp-hygiene.js",
+      "method": "writeSnapshot",
+      "startLine": 198,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/check-test-temp-hygiene.js",
+      "method": "readSnapshot",
+      "startLine": 215,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/check-test-temp-hygiene.js",
+      "method": "diffAgainstSnapshot",
+      "startLine": 237,
       "crap": 4
     },
     {
-      "path": ".agents/scripts/check-prepush-recovery.js",
-      "method": "readStdin",
-      "startLine": 66,
+      "path": ".agents/scripts/check-test-temp-hygiene.js",
+      "method": "runDirId",
+      "startLine": 262,
       "crap": 2
     },
     {
-      "path": ".agents/scripts/check-prepush-recovery.js",
-      "method": "main",
-      "startLine": 74,
+      "path": ".agents/scripts/check-test-temp-hygiene.js",
+      "method": "findFixtureDirs",
+      "startLine": 277,
+      "crap": 10
+    },
+    {
+      "path": ".agents/scripts/check-test-temp-hygiene.js",
+      "method": "<anon method-2>",
+      "startLine": 302,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/check-test-temp-hygiene.js",
+      "method": "cleanFixtureDirs",
+      "startLine": 314,
       "crap": 2
+    },
+    {
+      "path": ".agents/scripts/check-test-temp-hygiene.js",
+      "method": "parseArgv",
+      "startLine": 336,
+      "crap": 9
+    },
+    {
+      "path": ".agents/scripts/check-test-temp-hygiene.js",
+      "method": "<anon method-3>",
+      "startLine": 352,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/check-test-temp-hygiene.js",
+      "method": "<anon method-4>",
+      "startLine": 353,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/check-test-temp-hygiene.js",
+      "method": "runHygiene",
+      "startLine": 374,
+      "crap": 8
+    },
+    {
+      "path": ".agents/scripts/check-test-temp-hygiene.js",
+      "method": "<anon method-5>",
+      "startLine": 433,
+      "crap": 1.125
+    },
+    {
+      "path": ".agents/scripts/check-workflow-citations.js",
+      "method": "parseArgv",
+      "startLine": 59,
+      "crap": 9
+    },
+    {
+      "path": ".agents/scripts/check-workflow-citations.js",
+      "method": "collectMarkdownFiles",
+      "startLine": 92,
+      "crap": 1.0013717421124828
+    },
+    {
+      "path": ".agents/scripts/check-workflow-citations.js",
+      "method": "<anon method-1>",
+      "startLine": 94,
+      "crap": 4.058261265361857
+    },
+    {
+      "path": ".agents/scripts/check-workflow-citations.js",
+      "method": "countCitations",
+      "startLine": 117,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/check-workflow-citations.js",
+      "method": "tallyCitations",
+      "startLine": 131,
+      "crap": 2.004
+    },
+    {
+      "path": ".agents/scripts/check-workflow-citations.js",
+      "method": "<anon method-2>",
+      "startLine": 132,
+      "crap": 1.001
+    },
+    {
+      "path": ".agents/scripts/check-workflow-citations.js",
+      "method": "<anon method-3>",
+      "startLine": 149,
+      "crap": 1.001
+    },
+    {
+      "path": ".agents/scripts/check-workflow-citations.js",
+      "method": "loadBaseline",
+      "startLine": 160,
+      "crap": 3
+    },
+    {
+      "path": ".agents/scripts/check-workflow-citations.js",
+      "method": "diffTally",
+      "startLine": 178,
+      "crap": 3
+    },
+    {
+      "path": ".agents/scripts/check-workflow-citations.js",
+      "method": "<anon method-4>",
+      "startLine": 182,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/check-workflow-citations.js",
+      "method": "<anon method-5>",
+      "startLine": 185,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/check-workflow-citations.js",
+      "method": "<anon method-6>",
+      "startLine": 190,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/check-workflow-citations.js",
+      "method": "renderDiff",
+      "startLine": 206,
+      "crap": 5
+    },
+    {
+      "path": ".agents/scripts/check-workflow-citations.js",
+      "method": "runCli",
+      "startLine": 235,
+      "crap": 7
+    },
+    {
+      "path": ".agents/scripts/check-workflow-citations.js",
+      "method": "main",
+      "startLine": 306,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/check-workflow-cli-lint.js",
+      "method": "stripFences",
+      "startLine": 85,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/check-workflow-cli-lint.js",
+      "method": "<anon method-1>",
+      "startLine": 88,
+      "crap": 3
+    },
+    {
+      "path": ".agents/scripts/check-workflow-cli-lint.js",
+      "method": "toParagraphs",
+      "startLine": 105,
+      "crap": 6
+    },
+    {
+      "path": ".agents/scripts/check-workflow-cli-lint.js",
+      "method": "lintFlagTables",
+      "startLine": 147,
+      "crap": 12
+    },
+    {
+      "path": ".agents/scripts/check-workflow-cli-lint.js",
+      "method": "<anon method-2>",
+      "startLine": 168,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/check-workflow-cli-lint.js",
+      "method": "lintWorkflowSource",
+      "startLine": 205,
+      "crap": 5.307237141556668
+    },
+    {
+      "path": ".agents/scripts/check-workflow-cli-lint.js",
+      "method": "collectMarkdown",
+      "startLine": 251,
+      "crap": 3
+    },
+    {
+      "path": ".agents/scripts/check-workflow-cli-lint.js",
+      "method": "runCheck",
+      "startLine": 269,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/check-workflow-cli-lint.js",
+      "method": "main",
+      "startLine": 280,
+      "crap": 6
     },
     {
       "path": ".agents/scripts/cleanup-repo-test-temp.js",
@@ -464,85 +1695,295 @@
     {
       "path": ".agents/scripts/coverage-capture.js",
       "method": "parseArgs",
-      "startLine": 33,
+      "startLine": 38,
       "crap": 5.009110787172012
     },
     {
       "path": ".agents/scripts/coverage-capture.js",
       "method": "main",
-      "startLine": 48,
-      "crap": 16.50852894007873
+      "startLine": 53,
+      "crap": 42.69245541838134
     },
     {
       "path": ".agents/scripts/coverage-capture.js",
       "method": "<anon method-1>",
-      "startLine": 96,
+      "startLine": 117,
       "crap": 1
+    },
+    {
+      "path": ".agents/scripts/deliver-light.js",
+      "method": "parseCsvPaths",
+      "startLine": 130,
+      "crap": 3
+    },
+    {
+      "path": ".agents/scripts/deliver-light.js",
+      "method": "<anon method-1>",
+      "startLine": 134,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/deliver-light.js",
+      "method": "<anon method-2>",
+      "startLine": 135,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/deliver-light.js",
+      "method": "buildPredictedChanges",
+      "startLine": 145,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/deliver-light.js",
+      "method": "<anon method-3>",
+      "startLine": 147,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/deliver-light.js",
+      "method": "<anon method-4>",
+      "startLine": 148,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/deliver-light.js",
+      "method": "synthesizeAcceptance",
+      "startLine": 161,
+      "crap": 4
+    },
+    {
+      "path": ".agents/scripts/deliver-light.js",
+      "method": "<anon method-5>",
+      "startLine": 166,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/deliver-light.js",
+      "method": "runLightGate",
+      "startLine": 192,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/deliver-light.js",
+      "method": "createLightReceipt",
+      "startLine": 232,
+      "crap": 3.0839772561597902
+    },
+    {
+      "path": ".agents/scripts/deliver-light.js",
+      "method": "buildNextCommands",
+      "startLine": 260,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/deliver-light.js",
+      "method": "runDiffBackstop",
+      "startLine": 279,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/deliver-light.js",
+      "method": "emit",
+      "startLine": 301,
+      "crap": 6
+    },
+    {
+      "path": ".agents/scripts/deliver-light.js",
+      "method": "runBackstopMode",
+      "startLine": 315,
+      "crap": 20
+    },
+    {
+      "path": ".agents/scripts/deliver-light.js",
+      "method": "runGateMode",
+      "startLine": 360,
+      "crap": 6.002129090339581
+    },
+    {
+      "path": ".agents/scripts/deliver-light.js",
+      "method": "main",
+      "startLine": 438,
+      "crap": 3.007415771484375
+    },
+    {
+      "path": ".agents/scripts/deliver-recover.js",
+      "method": "parseArgv",
+      "startLine": 62,
+      "crap": 1.8573749999999998
+    },
+    {
+      "path": ".agents/scripts/deliver-recover.js",
+      "method": "runDeliverRecover",
+      "startLine": 86,
+      "crap": 85.41621387118798
     },
     {
       "path": ".agents/scripts/diagnose.js",
       "method": "parseArgs",
-      "startLine": 58,
+      "startLine": 73,
       "crap": 9.009402069035563
     },
     {
       "path": ".agents/scripts/diagnose.js",
       "method": "renderTable",
-      "startLine": 113,
+      "startLine": 128,
       "crap": 2
     },
     {
       "path": ".agents/scripts/diagnose.js",
+      "method": "<anon method-1>",
+      "startLine": 130,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/diagnose.js",
+      "method": "<anon method-2>",
+      "startLine": 137,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/diagnose.js",
+      "method": "<anon method-3>",
+      "startLine": 138,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/diagnose.js",
       "method": "<anon method-4>",
-      "startLine": 125,
+      "startLine": 140,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/diagnose.js",
+      "method": "<anon method-5>",
+      "startLine": 141,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/diagnose.js",
+      "method": "<anon method-6>",
+      "startLine": 143,
       "crap": 1
     },
     {
       "path": ".agents/scripts/diagnose.js",
       "method": "runDiagnose",
-      "startLine": 153,
+      "startLine": 168,
       "crap": 5
     },
     {
       "path": ".agents/scripts/diagnose.js",
+      "method": "<anon method-7>",
+      "startLine": 194,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/diagnose.js",
       "method": "validateDiagnoseArgs",
-      "startLine": 204,
+      "startLine": 219,
       "crap": 4
     },
     {
       "path": ".agents/scripts/diagnose.js",
       "method": "main",
-      "startLine": 224,
+      "startLine": 227,
       "crap": 12
+    },
+    {
+      "path": ".agents/scripts/drain-pending-cleanup.js",
+      "method": "main",
+      "startLine": 42,
+      "crap": 110
+    },
+    {
+      "path": ".agents/scripts/drain-pending-cleanup.js",
+      "method": "<anon method-1>",
+      "startLine": 68,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/drain-pending-cleanup.js",
+      "method": "<anon method-2>",
+      "startLine": 79,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/drain-pending-cleanup.js",
+      "method": "<anon method-3>",
+      "startLine": 92,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/drain-pending-cleanup.js",
+      "method": "<anon method-4>",
+      "startLine": 93,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/drain-pending-cleanup.js",
+      "method": "<anon method-5>",
+      "startLine": 94,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/drain-pending-cleanup.js",
+      "method": "<anon method-6>",
+      "startLine": 102,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/drain-pending-cleanup.js",
+      "method": "<anon method-7>",
+      "startLine": 108,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/drain-pending-cleanup.js",
+      "method": "<anon method-8>",
+      "startLine": 116,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/drain-pending-cleanup.js",
+      "method": "<anon method-9>",
+      "startLine": 126,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/drain-pending-cleanup.js",
+      "method": "<anon method-10>",
+      "startLine": 134,
+      "crap": 2
     },
     {
       "path": ".agents/scripts/evidence-gate.js",
       "method": "splitOnDashDash",
-      "startLine": 65,
+      "startLine": 52,
       "crap": 2
     },
     {
       "path": ".agents/scripts/evidence-gate.js",
       "method": "parseWrapperArgs",
-      "startLine": 79,
-      "crap": 5
+      "startLine": 66,
+      "crap": 3
     },
     {
       "path": ".agents/scripts/evidence-gate.js",
       "method": "resolveHeadShaDefault",
-      "startLine": 104,
+      "startLine": 90,
       "crap": 4
     },
     {
       "path": ".agents/scripts/evidence-gate.js",
       "method": "runEvidenceGate",
-      "startLine": 139,
+      "startLine": 127,
       "crap": 13
     },
     {
       "path": ".agents/scripts/evidence-gate.js",
       "method": "main",
-      "startLine": 229,
+      "startLine": 235,
       "crap": 2
     },
     {
@@ -571,123 +2012,399 @@
     },
     {
       "path": ".agents/scripts/generate-config-docs.js",
+      "method": "renderArrayType",
+      "startLine": 153,
+      "crap": 7
+    },
+    {
+      "path": ".agents/scripts/generate-config-docs.js",
+      "method": "renderObjectType",
+      "startLine": 180,
+      "crap": 3
+    },
+    {
+      "path": ".agents/scripts/generate-config-docs.js",
+      "method": "<anon method-1>",
+      "startLine": 204,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/generate-config-docs.js",
+      "method": "<anon method-2>",
+      "startLine": 205,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/generate-config-docs.js",
+      "method": "<anon method-3>",
+      "startLine": 208,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/generate-config-docs.js",
+      "method": "<anon method-4>",
+      "startLine": 209,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/generate-config-docs.js",
+      "method": "<anon method-5>",
+      "startLine": 210,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/generate-config-docs.js",
+      "method": "<anon method-6>",
+      "startLine": 213,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/generate-config-docs.js",
+      "method": "<anon method-7>",
+      "startLine": 214,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/generate-config-docs.js",
+      "method": "<anon method-8>",
+      "startLine": 214,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/generate-config-docs.js",
+      "method": "<anon method-9>",
+      "startLine": 217,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/generate-config-docs.js",
+      "method": "<anon method-10>",
+      "startLine": 221,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/generate-config-docs.js",
+      "method": "<anon method-11>",
+      "startLine": 225,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/generate-config-docs.js",
+      "method": "<anon method-12>",
+      "startLine": 226,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/generate-config-docs.js",
       "method": "renderType",
-      "startLine": 155,
-      "crap": 17.00245645946842
+      "startLine": 241,
+      "crap": 4
+    },
+    {
+      "path": ".agents/scripts/generate-config-docs.js",
+      "method": "<anon method-13>",
+      "startLine": 244,
+      "crap": 1
     },
     {
       "path": ".agents/scripts/generate-config-docs.js",
       "method": "renderDefault",
-      "startLine": 212,
+      "startLine": 255,
       "crap": 6.131087847064179
     },
     {
       "path": ".agents/scripts/generate-config-docs.js",
       "method": "escapeCell",
-      "startLine": 232,
+      "startLine": 275,
       "crap": 1
     },
     {
       "path": ".agents/scripts/generate-config-docs.js",
+      "method": "nestedObjectRows",
+      "startLine": 289,
+      "crap": 6
+    },
+    {
+      "path": ".agents/scripts/generate-config-docs.js",
+      "method": "arrayOfObjectsRows",
+      "startLine": 316,
+      "crap": 9
+    },
+    {
+      "path": ".agents/scripts/generate-config-docs.js",
+      "method": "leafRow",
+      "startLine": 348,
+      "crap": 3
+    },
+    {
+      "path": ".agents/scripts/generate-config-docs.js",
       "method": "flattenObject",
-      "startLine": 253,
-      "crap": 21
+      "startLine": 384,
+      "crap": 7
     },
     {
       "path": ".agents/scripts/generate-config-docs.js",
       "method": "renderSection",
-      "startLine": 326,
+      "startLine": 421,
       "crap": 9.2949476558944
     },
     {
       "path": ".agents/scripts/generate-config-docs.js",
+      "method": "<anon method-14>",
+      "startLine": 449,
+      "crap": 1.003641329085116
+    },
+    {
+      "path": ".agents/scripts/generate-config-docs.js",
       "method": "renderRegion",
-      "startLine": 372,
+      "startLine": 467,
       "crap": 1
     },
     {
       "path": ".agents/scripts/generate-config-docs.js",
       "method": "spliceRegion",
-      "startLine": 399,
+      "startLine": 494,
       "crap": 13.0517578125
     },
     {
       "path": ".agents/scripts/generate-config-docs.js",
       "method": "buildExpected",
-      "startLine": 455,
+      "startLine": 550,
       "crap": 2.032
     },
     {
       "path": ".agents/scripts/generate-config-docs.js",
       "method": "main",
-      "startLine": 469,
+      "startLine": 564,
       "crap": 4.496699708454811
+    },
+    {
+      "path": ".agents/scripts/generate-lens-checklists.js",
+      "method": "planChecklists",
+      "startLine": 60,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/generate-lens-checklists.js",
+      "method": "buildExpected",
+      "startLine": 86,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/generate-lens-checklists.js",
+      "method": "<anon method-1>",
+      "startLine": 87,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/generate-lens-checklists.js",
+      "method": "<anon method-2>",
+      "startLine": 90,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/generate-lens-checklists.js",
+      "method": "<anon method-3>",
+      "startLine": 91,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/generate-lens-checklists.js",
+      "method": "<anon method-4>",
+      "startLine": 95,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/generate-lens-checklists.js",
+      "method": "<anon method-5>",
+      "startLine": 97,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/generate-lens-checklists.js",
+      "method": "relChecklist",
+      "startLine": 106,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/generate-lens-checklists.js",
+      "method": "main",
+      "startLine": 116,
+      "crap": 90
+    },
+    {
+      "path": ".agents/scripts/generate-lens-checklists.js",
+      "method": "<anon method-6>",
+      "startLine": 147,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/generate-lens-checklists.js",
+      "method": "<anon method-7>",
+      "startLine": 148,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/generate-lifecycle-docs.js",
+      "method": "readLifecycleSchemas",
+      "startLine": 59,
+      "crap": 12
+    },
+    {
+      "path": ".agents/scripts/generate-lifecycle-docs.js",
+      "method": "<anon method-1>",
+      "startLine": 65,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/generate-lifecycle-docs.js",
+      "method": "<anon method-2>",
+      "startLine": 70,
+      "crap": 20
+    },
+    {
+      "path": ".agents/scripts/generate-lifecycle-docs.js",
+      "method": "escapeCell",
+      "startLine": 95,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/generate-lifecycle-docs.js",
+      "method": "renderTable",
+      "startLine": 106,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/generate-lifecycle-docs.js",
+      "method": "<anon method-3>",
+      "startLine": 109,
+      "crap": 12
+    },
+    {
+      "path": ".agents/scripts/generate-lifecycle-docs.js",
+      "method": "<anon method-4>",
+      "startLine": 116,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/generate-lifecycle-docs.js",
+      "method": "spliceRegion",
+      "startLine": 133,
+      "crap": 20
+    },
+    {
+      "path": ".agents/scripts/generate-lifecycle-docs.js",
+      "method": "buildExpected",
+      "startLine": 165,
+      "crap": 6
+    },
+    {
+      "path": ".agents/scripts/generate-lifecycle-docs.js",
+      "method": "main",
+      "startLine": 179,
+      "crap": 20
     },
     {
       "path": ".agents/scripts/generate-skills-index.js",
       "method": "defaultRepoRoot",
-      "startLine": 44,
+      "startLine": 50,
       "crap": 1
     },
     {
       "path": ".agents/scripts/generate-skills-index.js",
       "method": "parseArgs",
-      "startLine": 54,
+      "startLine": 60,
+      "crap": 2.011661807580175
+    },
+    {
+      "path": ".agents/scripts/generate-skills-index.js",
+      "method": "<anon method-1>",
+      "startLine": 61,
       "crap": 2.011661807580175
     },
     {
       "path": ".agents/scripts/generate-skills-index.js",
       "method": "projectEntry",
-      "startLine": 78,
+      "startLine": 84,
       "crap": 3
     },
     {
       "path": ".agents/scripts/generate-skills-index.js",
       "method": "buildManifestBody",
-      "startLine": 100,
+      "startLine": 106,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/generate-skills-index.js",
+      "method": "<anon method-2>",
+      "startLine": 108,
       "crap": 1
     },
     {
       "path": ".agents/scripts/generate-skills-index.js",
       "method": "buildManifest",
-      "startLine": 115,
+      "startLine": 121,
       "crap": 1
     },
     {
       "path": ".agents/scripts/generate-skills-index.js",
       "method": "serializeManifest",
-      "startLine": 129,
+      "startLine": 141,
       "crap": 1
     },
     {
       "path": ".agents/scripts/generate-skills-index.js",
       "method": "readOnDiskManifest",
-      "startLine": 138,
+      "startLine": 150,
       "crap": 2.2109375
     },
     {
       "path": ".agents/scripts/generate-skills-index.js",
       "method": "diffManifestsIgnoringTimestamp",
-      "startLine": 159,
+      "startLine": 171,
       "crap": 5.177799271734183
     },
     {
       "path": ".agents/scripts/generate-skills-index.js",
       "method": "resolveOutPath",
-      "startLine": 190,
+      "startLine": 202,
       "crap": 2
     },
     {
       "path": ".agents/scripts/generate-skills-index.js",
       "method": "run",
-      "startLine": 201,
-      "crap": 7.333333333333334
+      "startLine": 213,
+      "crap": 7.014876304758774
     },
     {
       "path": ".agents/scripts/generate-skills-index.js",
       "method": "main",
-      "startLine": 244,
+      "startLine": 260,
       "crap": 2.0932944606413995
+    },
+    {
+      "path": ".agents/scripts/generate-workflows-doc.js",
+      "method": "cellEscape",
+      "startLine": 60,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/generate-workflows-doc.js",
+      "method": "renderWorkflowsDoc",
+      "startLine": 76,
+      "crap": 2.0054869684499312
+    },
+    {
+      "path": ".agents/scripts/generate-workflows-doc.js",
+      "method": "buildExpected",
+      "startLine": 154,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/generate-workflows-doc.js",
+      "method": "main",
+      "startLine": 167,
+      "crap": 4
     },
     {
       "path": ".agents/scripts/install-matrix-assert.js",
@@ -715,6 +2432,12 @@
     },
     {
       "path": ".agents/scripts/install-matrix-assert.js",
+      "method": "<anon method-2>",
+      "startLine": 161,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/install-matrix-assert.js",
       "method": "checkDoctorReady",
       "startLine": 188,
       "crap": 3
@@ -726,9 +2449,93 @@
       "crap": 7.032218295389168
     },
     {
+      "path": ".agents/scripts/install-matrix-assert.js",
+      "method": "<anon method-3>",
+      "startLine": 270,
+      "crap": 1.000657516232432
+    },
+    {
+      "path": ".agents/scripts/lib/audit-suite/audit-rules-reader.js",
+      "method": "readAuditRulesSync",
+      "startLine": 32,
+      "crap": 2.0521066558111136
+    },
+    {
+      "path": ".agents/scripts/lib/audit-suite/checklist-threading.js",
+      "method": "lensKeyFor",
+      "startLine": 74,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/audit-suite/checklist-threading.js",
+      "method": "checklistsDir",
+      "startLine": 88,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/audit-suite/checklist-threading.js",
+      "method": "readAuditRules",
+      "startLine": 105,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/audit-suite/checklist-threading.js",
+      "method": "filePatternsFor",
+      "startLine": 125,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/audit-suite/checklist-threading.js",
+      "method": "triggerFor",
+      "startLine": 137,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/audit-suite/checklist-threading.js",
+      "method": "normalizeFootprint",
+      "startLine": 149,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/audit-suite/checklist-threading.js",
+      "method": "<anon method-1>",
+      "startLine": 152,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/audit-suite/checklist-threading.js",
+      "method": "<anon method-2>",
+      "startLine": 153,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/audit-suite/checklist-threading.js",
+      "method": "matchLocalLenses",
+      "startLine": 175,
+      "crap": 7
+    },
+    {
+      "path": ".agents/scripts/lib/audit-suite/checklist-threading.js",
+      "method": "readChecklistFile",
+      "startLine": 216,
+      "crap": 1.015625
+    },
+    {
+      "path": ".agents/scripts/lib/audit-suite/checklist-threading.js",
+      "method": "buildChecklistPayload",
+      "startLine": 260,
+      "crap": 5.048828125
+    },
+    {
       "path": ".agents/scripts/lib/audit-suite/cli.js",
       "method": "parseAuditList",
       "startLine": 35,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/audit-suite/cli.js",
+      "method": "<anon method-1>",
+      "startLine": 38,
       "crap": 1
     },
     {
@@ -738,10 +2545,88 @@
       "crap": 1
     },
     {
+      "path": ".agents/scripts/lib/audit-suite/dispatch-checklist.js",
+      "method": "footprintFromEntries",
+      "startLine": 33,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/audit-suite/dispatch-checklist.js",
+      "method": "<anon method-1>",
+      "startLine": 36,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/audit-suite/dispatch-checklist.js",
+      "method": "<anon method-2>",
+      "startLine": 37,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/audit-suite/dispatch-checklist.js",
+      "method": "<anon method-3>",
+      "startLine": 38,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/audit-suite/dispatch-checklist.js",
+      "method": "deriveDispatchFootprint",
+      "startLine": 53,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/audit-suite/dispatch-checklist.js",
+      "method": "defaultWriteFile",
+      "startLine": 67,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/audit-suite/dispatch-checklist.js",
+      "method": "buildDispatchChecklist",
+      "startLine": 99,
+      "crap": 5
+    },
+    {
       "path": ".agents/scripts/lib/audit-suite/findings.js",
       "method": "aggregateSummary",
       "startLine": 28,
       "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/audit-suite/findings.js",
+      "method": "hasSurvivingCritical",
+      "startLine": 57,
+      "crap": 3.2099125364431487
+    },
+    {
+      "path": ".agents/scripts/lib/audit-suite/findings.js",
+      "method": "<anon method-1>",
+      "startLine": 59,
+      "crap": 1.0233236151603498
+    },
+    {
+      "path": ".agents/scripts/lib/audit-suite/findings.js",
+      "method": "resolveRollup",
+      "startLine": 78,
+      "crap": 4.592592592592593
+    },
+    {
+      "path": ".agents/scripts/lib/audit-suite/findings.js",
+      "method": "diffAxes",
+      "startLine": 104,
+      "crap": 8
+    },
+    {
+      "path": ".agents/scripts/lib/audit-suite/findings.js",
+      "method": "aggregateBaselineDelta",
+      "startLine": 144,
+      "crap": 4
+    },
+    {
+      "path": ".agents/scripts/lib/audit-suite/findings.js",
+      "method": "<anon method-2>",
+      "startLine": 180,
+      "crap": 3
     },
     {
       "path": ".agents/scripts/lib/audit-suite/frontmatter-lint.js",
@@ -774,112 +2659,352 @@
       "crap": 2
     },
     {
+      "path": ".agents/scripts/lib/audit-suite/lens-checklist.js",
+      "method": "extractLensConcerns",
+      "startLine": 76,
+      "crap": 11
+    },
+    {
+      "path": ".agents/scripts/lib/audit-suite/lens-checklist.js",
+      "method": "resolveDescription",
+      "startLine": 126,
+      "crap": 7.042328042328042
+    },
+    {
+      "path": ".agents/scripts/lib/audit-suite/lens-checklist.js",
+      "method": "<anon method-1>",
+      "startLine": 135,
+      "crap": 1.0008638375985315
+    },
+    {
+      "path": ".agents/scripts/lib/audit-suite/lens-checklist.js",
+      "method": "dedupePreserveOrder",
+      "startLine": 154,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/audit-suite/lens-checklist.js",
+      "method": "renderLensChecklist",
+      "startLine": 176,
+      "crap": 6
+    },
+    {
+      "path": ".agents/scripts/lib/audit-suite/lens-checklist.js",
+      "method": "<anon method-2>",
+      "startLine": 205,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/audit-suite/lens-checklist.js",
+      "method": "<anon method-3>",
+      "startLine": 208,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/audit-suite/lens-diff-floor.js",
+      "method": "resolveLensDiffFloor",
+      "startLine": 49,
+      "crap": 4
+    },
+    {
+      "path": ".agents/scripts/lib/audit-suite/lens-diff-floor.js",
+      "method": "countChangedLines",
+      "startLine": 74,
+      "crap": 12
+    },
+    {
+      "path": ".agents/scripts/lib/audit-suite/lens-diff-floor.js",
+      "method": "evaluateLensDiffFloor",
+      "startLine": 138,
+      "crap": 13
+    },
+    {
+      "path": ".agents/scripts/lib/audit-suite/lens-diff-floor.js",
+      "method": "<anon method-1>",
+      "startLine": 150,
+      "crap": 1
+    },
+    {
       "path": ".agents/scripts/lib/audit-suite/runner.js",
       "method": "loadRules",
-      "startLine": 27,
+      "startLine": 29,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/audit-suite/runner.js",
       "method": "rejectUnknownKeys",
-      "startLine": 37,
-      "crap": 2
+      "startLine": 39,
+      "crap": 2.375657400450789
+    },
+    {
+      "path": ".agents/scripts/lib/audit-suite/runner.js",
+      "method": "<anon method-1>",
+      "startLine": 41,
+      "crap": 1.0939143501126973
     },
     {
       "path": ".agents/scripts/lib/audit-suite/runner.js",
       "method": "emptyEnvelope",
-      "startLine": 49,
+      "startLine": 51,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/audit-suite/runner.js",
       "method": "notDefinedFinding",
-      "startLine": 62,
-      "crap": 1
+      "startLine": 64,
+      "crap": 2
     },
     {
       "path": ".agents/scripts/lib/audit-suite/runner.js",
       "method": "notFoundFinding",
-      "startLine": 73,
-      "crap": 1
+      "startLine": 75,
+      "crap": 2
     },
     {
       "path": ".agents/scripts/lib/audit-suite/runner.js",
       "method": "processAudit",
-      "startLine": 84,
-      "crap": 3
+      "startLine": 86,
+      "crap": 12
     },
     {
       "path": ".agents/scripts/lib/audit-suite/runner.js",
       "method": "reduceResults",
-      "startLine": 115,
-      "crap": 4
+      "startLine": 117,
+      "crap": 10.154770848985725
     },
     {
       "path": ".agents/scripts/lib/audit-suite/runner.js",
       "method": "runAuditSuite",
-      "startLine": 181,
-      "crap": 2
+      "startLine": 183,
+      "crap": 2.0058034484843192
+    },
+    {
+      "path": ".agents/scripts/lib/audit-suite/runner.js",
+      "method": "<anon method-2>",
+      "startLine": 214,
+      "crap": 1.0014508621210798
     },
     {
       "path": ".agents/scripts/lib/audit-suite/selector.js",
       "method": "isGlobalLens",
-      "startLine": 61,
+      "startLine": 65,
       "crap": 1.2962962962962963
     },
     {
       "path": ".agents/scripts/lib/audit-suite/selector.js",
-      "method": "readAuditRulesSync",
-      "startLine": 111,
-      "crap": 1.018962962962963
-    },
-    {
-      "path": ".agents/scripts/lib/audit-suite/selector.js",
       "method": "resolveLensTier",
-      "startLine": 127,
+      "startLine": 105,
       "crap": 3.0839772561597902
     },
     {
       "path": ".agents/scripts/lib/audit-suite/selector.js",
       "method": "selectLocalLenses",
-      "startLine": 180,
+      "startLine": 158,
       "crap": 5
     },
     {
       "path": ".agents/scripts/lib/audit-suite/selector.js",
+      "method": "selectSensitivePathClasses",
+      "startLine": 205,
+      "crap": 4
+    },
+    {
+      "path": ".agents/scripts/lib/audit-suite/selector.js",
       "method": "resolveNavigabilityRouteGlobs",
-      "startLine": 211,
-      "crap": 3.6875
+      "startLine": 233,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/audit-suite/selector.js",
+      "method": "<anon method-1>",
+      "startLine": 235,
+      "crap": 1
     },
     {
       "path": ".agents/scripts/lib/audit-suite/selector.js",
       "method": "routesNavigabilityLens",
-      "startLine": 231,
+      "startLine": 253,
       "crap": 4.048
     },
     {
       "path": ".agents/scripts/lib/audit-suite/selector.js",
+      "method": "_resetWebSurfaceCache",
+      "startLine": 322,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/audit-suite/selector.js",
+      "method": "declaresWebFramework",
+      "startLine": 336,
+      "crap": 2.002048
+    },
+    {
+      "path": ".agents/scripts/lib/audit-suite/selector.js",
+      "method": "<anon method-2>",
+      "startLine": 354,
+      "crap": 1.000512
+    },
+    {
+      "path": ".agents/scripts/lib/audit-suite/selector.js",
+      "method": "<anon method-3>",
+      "startLine": 358,
+      "crap": 1.000512
+    },
+    {
+      "path": ".agents/scripts/lib/audit-suite/selector.js",
+      "method": "scanForWebAssets",
+      "startLine": 377,
+      "crap": 10.022261179285973
+    },
+    {
+      "path": ".agents/scripts/lib/audit-suite/selector.js",
+      "method": "hasWebSurface",
+      "startLine": 441,
+      "crap": 5
+    },
+    {
+      "path": ".agents/scripts/lib/audit-suite/selector.js",
+      "method": "_resetPersistenceLayerCache",
+      "startLine": 511,
+      "crap": 1.2962962962962963
+    },
+    {
+      "path": ".agents/scripts/lib/audit-suite/selector.js",
+      "method": "declaresOrmDependency",
+      "startLine": 525,
+      "crap": 2.032
+    },
+    {
+      "path": ".agents/scripts/lib/audit-suite/selector.js",
+      "method": "<anon method-4>",
+      "startLine": 543,
+      "crap": 1.008
+    },
+    {
+      "path": ".agents/scripts/lib/audit-suite/selector.js",
+      "method": "<anon method-5>",
+      "startLine": 547,
+      "crap": 1.008
+    },
+    {
+      "path": ".agents/scripts/lib/audit-suite/selector.js",
+      "method": "scanForPersistenceArtifacts",
+      "startLine": 566,
+      "crap": 10.735168038408778
+    },
+    {
+      "path": ".agents/scripts/lib/audit-suite/selector.js",
+      "method": "hasPersistenceLayer",
+      "startLine": 631,
+      "crap": 4
+    },
+    {
+      "path": ".agents/scripts/lib/audit-suite/selector.js",
       "method": "matchesFilePattern",
-      "startLine": 242,
+      "startLine": 652,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/audit-suite/selector.js",
       "method": "matchesAnyFilePattern",
-      "startLine": 250,
+      "startLine": 660,
       "crap": 3
     },
     {
       "path": ".agents/scripts/lib/audit-suite/selector.js",
-      "method": "selectAudits",
-      "startLine": 293,
-      "crap": 16.27762282882239
+      "method": "<anon method-6>",
+      "startLine": 662,
+      "crap": 1
     },
     {
       "path": ".agents/scripts/lib/audit-suite/selector.js",
-      "method": "<anon method-5>",
-      "startLine": 324,
+      "method": "<anon method-7>",
+      "startLine": 663,
       "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/audit-suite/selector.js",
+      "method": "<anon method-8>",
+      "startLine": 663,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/audit-suite/selector.js",
+      "method": "isTestFile",
+      "startLine": 692,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/audit-suite/selector.js",
+      "method": "stemOf",
+      "startLine": 703,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/audit-suite/selector.js",
+      "method": "changeSetLacksSiblingTest",
+      "startLine": 727,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/audit-suite/selector.js",
+      "method": "<anon method-9>",
+      "startLine": 729,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/audit-suite/selector.js",
+      "method": "<anon method-10>",
+      "startLine": 732,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/audit-suite/selector.js",
+      "method": "<anon method-11>",
+      "startLine": 732,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/audit-suite/selector.js",
+      "method": "<anon method-12>",
+      "startLine": 735,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/audit-suite/selector.js",
+      "method": "<anon method-13>",
+      "startLine": 737,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/audit-suite/selector.js",
+      "method": "selectAudits",
+      "startLine": 790,
+      "crap": 25.263671875
+    },
+    {
+      "path": ".agents/scripts/lib/audit-suite/selector.js",
+      "method": "<anon method-14>",
+      "startLine": 824,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/audit-suite/selector.js",
+      "method": "<anon method-15>",
+      "startLine": 870,
+      "crap": 1.000421875
+    },
+    {
+      "path": ".agents/scripts/lib/audit-suite/selector.js",
+      "method": "<anon method-16>",
+      "startLine": 888,
+      "crap": 1.000421875
+    },
+    {
+      "path": ".agents/scripts/lib/audit-suite/selector.js",
+      "method": "<anon method-17>",
+      "startLine": 917,
+      "crap": 3
     },
     {
       "path": ".agents/scripts/lib/audit-suite/substitutions.js",
@@ -924,58 +3049,274 @@
       "crap": 1
     },
     {
-      "path": ".agents/scripts/lib/audit-to-stories/build-story-body.js",
-      "method": "uniq",
-      "startLine": 26,
+      "path": ".agents/scripts/lib/audit-to-stories/audit-lenses.js",
+      "method": "isCanonicalLens",
+      "startLine": 52,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/audit-to-stories/audit-lenses.js",
+      "method": "lensFromSourceReport",
+      "startLine": 71,
+      "crap": 5.150262960180315
+    },
+    {
+      "path": ".agents/scripts/lib/audit-to-stories/audit-lenses.js",
+      "method": "auditLabelsForFindings",
+      "startLine": 93,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/audit-to-stories/audit-lenses.js",
+      "method": "<anon method-1>",
+      "startLine": 99,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/audit-to-stories/build-story-body.js",
-      "method": "summaryFromGroup",
-      "startLine": 30,
+      "method": "uniq",
+      "startLine": 44,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/audit-to-stories/build-story-body.js",
       "method": "goalFromGroup",
-      "startLine": 41,
+      "startLine": 58,
       "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/audit-to-stories/build-story-body.js",
+      "method": "changesFromGroup",
+      "startLine": 74,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/audit-to-stories/build-story-body.js",
+      "method": "<anon method-1>",
+      "startLine": 76,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/audit-to-stories/build-story-body.js",
+      "method": "<anon method-2>",
+      "startLine": 81,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/audit-to-stories/build-story-body.js",
+      "method": "<anon method-3>",
+      "startLine": 84,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/audit-to-stories/build-story-body.js",
+      "method": "acceptanceItemFromFinding",
+      "startLine": 101,
+      "crap": 4
     },
     {
       "path": ".agents/scripts/lib/audit-to-stories/build-story-body.js",
       "method": "acceptanceCriteriaFromGroup",
-      "startLine": 47,
+      "startLine": 111,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/audit-to-stories/build-story-body.js",
+      "method": "sequencingDepsForGroup",
+      "startLine": 126,
+      "crap": 5.197265625
+    },
+    {
+      "path": ".agents/scripts/lib/audit-to-stories/build-story-body.js",
+      "method": "<anon method-4>",
+      "startLine": 129,
+      "crap": 2.9765625
+    },
+    {
+      "path": ".agents/scripts/lib/audit-to-stories/build-story-body.js",
+      "method": "<anon method-5>",
+      "startLine": 130,
+      "crap": 1.244140625
+    },
+    {
+      "path": ".agents/scripts/lib/audit-to-stories/build-story-body.js",
+      "method": "<anon method-6>",
+      "startLine": 131,
+      "crap": 2.9765625
+    },
+    {
+      "path": ".agents/scripts/lib/audit-to-stories/build-story-body.js",
+      "method": "sequencingSection",
+      "startLine": 148,
+      "crap": 2.2560000000000002
+    },
+    {
+      "path": ".agents/scripts/lib/audit-to-stories/build-story-body.js",
+      "method": "<anon method-7>",
+      "startLine": 150,
+      "crap": 1.064
+    },
+    {
+      "path": ".agents/scripts/lib/audit-to-stories/build-story-body.js",
       "method": "agentPromptsSection",
-      "startLine": 54,
+      "startLine": 154,
       "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/audit-to-stories/build-story-body.js",
+      "method": "<anon method-8>",
+      "startLine": 157,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/audit-to-stories/build-story-body.js",
+      "method": "<anon method-9>",
+      "startLine": 159,
+      "crap": 1
     },
     {
       "path": ".agents/scripts/lib/audit-to-stories/build-story-body.js",
       "method": "contextLinksFromGroup",
-      "startLine": 63,
+      "startLine": 163,
       "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/audit-to-stories/build-story-body.js",
+      "method": "<anon method-10>",
+      "startLine": 166,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/audit-to-stories/build-story-body.js",
+      "method": "<anon method-11>",
+      "startLine": 167,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/audit-to-stories/build-story-body.js",
+      "method": "<anon method-12>",
+      "startLine": 170,
+      "crap": 1
     },
     {
       "path": ".agents/scripts/lib/audit-to-stories/build-story-body.js",
       "method": "labelsForGroup",
-      "startLine": 73,
+      "startLine": 173,
       "crap": 2
     },
     {
       "path": ".agents/scripts/lib/audit-to-stories/build-story-body.js",
+      "method": "<anon method-13>",
+      "startLine": 184,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/audit-to-stories/build-story-body.js",
       "method": "buildStoryBody",
-      "startLine": 90,
-      "crap": 3
+      "startLine": 199,
+      "crap": 4
+    },
+    {
+      "path": ".agents/scripts/lib/audit-to-stories/dedupe-against-github.js",
+      "method": "describeDegradeReason",
+      "startLine": 45,
+      "crap": 20
+    },
+    {
+      "path": ".agents/scripts/lib/audit-to-stories/dedupe-against-github.js",
+      "method": "groupLabel",
+      "startLine": 62,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/audit-to-stories/dedupe-against-github.js",
+      "method": "classifyOneGroup",
+      "startLine": 77,
+      "crap": 12
+    },
+    {
+      "path": ".agents/scripts/lib/audit-to-stories/dedupe-against-github.js",
+      "method": "<anon method-1>",
+      "startLine": 95,
+      "crap": 1
     },
     {
       "path": ".agents/scripts/lib/audit-to-stories/dedupe-against-github.js",
       "method": "classifyGroupsAgainstGitHub",
-      "startLine": 34,
-      "crap": 13
+      "startLine": 140,
+      "crap": 8.216
+    },
+    {
+      "path": ".agents/scripts/lib/audit-to-stories/dedupe-against-github.js",
+      "method": "<anon method-2>",
+      "startLine": 159,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/audit-to-stories/finding-adapter.js",
+      "method": "toCanonicalFinding",
+      "startLine": 35,
+      "crap": 4
+    },
+    {
+      "path": ".agents/scripts/lib/audit-to-stories/finding-adapter.js",
+      "method": "fingerprintAuditFinding",
+      "startLine": 56,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/audit-to-stories/finding-adapter.js",
+      "method": "semanticKeyForAuditFinding",
+      "startLine": 68,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/audit-to-stories/finding-adapter.js",
+      "method": "withFingerprints",
+      "startLine": 81,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/audit-to-stories/finding-adapter.js",
+      "method": "<anon method-1>",
+      "startLine": 85,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/audit-to-stories/finding-adapter.js",
+      "method": "renderFingerprintFooter",
+      "startLine": 99,
+      "crap": 2.0438957475994513
+    },
+    {
+      "path": ".agents/scripts/lib/audit-to-stories/finding-adapter.js",
+      "method": "<anon method-2>",
+      "startLine": 104,
+      "crap": 1.010973936899863
+    },
+    {
+      "path": ".agents/scripts/lib/audit-to-stories/finding-adapter.js",
+      "method": "<anon method-3>",
+      "startLine": 105,
+      "crap": 2.0438957475994513
+    },
+    {
+      "path": ".agents/scripts/lib/audit-to-stories/finding-adapter.js",
+      "method": "renderSemanticKeyFooter",
+      "startLine": 119,
+      "crap": 2.014565316340464
+    },
+    {
+      "path": ".agents/scripts/lib/audit-to-stories/finding-adapter.js",
+      "method": "<anon method-4>",
+      "startLine": 126,
+      "crap": 1.003641329085116
+    },
+    {
+      "path": ".agents/scripts/lib/audit-to-stories/finding-adapter.js",
+      "method": "<anon method-5>",
+      "startLine": 127,
+      "crap": 2.014565316340464
     },
     {
       "path": ".agents/scripts/lib/audit-to-stories/group-findings.js",
@@ -1000,6 +3341,12 @@
       "method": "tokenisePhrase",
       "startLine": 69,
       "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/audit-to-stories/group-findings.js",
+      "method": "<anon method-1>",
+      "startLine": 77,
+      "crap": 1
     },
     {
       "path": ".agents/scripts/lib/audit-to-stories/group-findings.js",
@@ -1044,51 +3391,111 @@
       "crap": 15.2014736256683
     },
     {
+      "path": ".agents/scripts/lib/audit-to-stories/group-findings.js",
+      "method": "<anon method-2>",
+      "startLine": 252,
+      "crap": 1.0008954383363036
+    },
+    {
+      "path": ".agents/scripts/lib/audit-to-stories/group-findings.js",
+      "method": "<anon method-3>",
+      "startLine": 253,
+      "crap": 1.0008954383363036
+    },
+    {
       "path": ".agents/scripts/lib/audit-to-stories/seed-from-findings.js",
       "method": "tallySeverities",
-      "startLine": 37,
+      "startLine": 42,
       "crap": 2
     },
     {
       "path": ".agents/scripts/lib/audit-to-stories/seed-from-findings.js",
       "method": "tallyDimensions",
-      "startLine": 45,
+      "startLine": 50,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/audit-to-stories/seed-from-findings.js",
       "method": "formatProblemStatement",
-      "startLine": 53,
+      "startLine": 58,
       "crap": 2
     },
     {
       "path": ".agents/scripts/lib/audit-to-stories/seed-from-findings.js",
-      "method": "formatRecommendedDirection",
+      "method": "<anon method-1>",
+      "startLine": 61,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/audit-to-stories/seed-from-findings.js",
+      "method": "<anon method-2>",
+      "startLine": 62,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/audit-to-stories/seed-from-findings.js",
+      "method": "<anon method-3>",
+      "startLine": 65,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/audit-to-stories/seed-from-findings.js",
+      "method": "<anon method-4>",
       "startLine": 67,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/audit-to-stories/seed-from-findings.js",
+      "method": "formatRecommendedDirection",
+      "startLine": 72,
       "crap": 4
     },
     {
       "path": ".agents/scripts/lib/audit-to-stories/seed-from-findings.js",
       "method": "formatMVPScope",
-      "startLine": 82,
+      "startLine": 87,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/audit-to-stories/seed-from-findings.js",
+      "method": "<anon method-5>",
+      "startLine": 89,
+      "crap": 3
+    },
+    {
+      "path": ".agents/scripts/lib/audit-to-stories/seed-from-findings.js",
+      "method": "<anon method-6>",
+      "startLine": 103,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/audit-to-stories/seed-from-findings.js",
       "method": "formatKeyFiles",
-      "startLine": 92,
+      "startLine": 110,
       "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/audit-to-stories/seed-from-findings.js",
+      "method": "<anon method-7>",
+      "startLine": 116,
+      "crap": 1
     },
     {
       "path": ".agents/scripts/lib/audit-to-stories/seed-from-findings.js",
       "method": "formatKeyAssumptions",
-      "startLine": 102,
+      "startLine": 120,
       "crap": 2
     },
     {
       "path": ".agents/scripts/lib/audit-to-stories/seed-from-findings.js",
+      "method": "<anon method-8>",
+      "startLine": 123,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/audit-to-stories/seed-from-findings.js",
       "method": "buildPlanSeedMarkdown",
-      "startLine": 115,
+      "startLine": 133,
       "crap": 6
     },
     {
@@ -1112,7 +3519,7 @@
     {
       "path": ".agents/scripts/lib/baseline-schema-registry.js",
       "method": "buildBaselineSchemaAjv",
-      "startLine": 59,
+      "startLine": 60,
       "crap": 1
     },
     {
@@ -1177,6 +3584,12 @@
     },
     {
       "path": ".agents/scripts/lib/baselines/diff-scope-cli.js",
+      "method": "<anon method-1>",
+      "startLine": 145,
+      "crap": 12
+    },
+    {
+      "path": ".agents/scripts/lib/baselines/diff-scope-cli.js",
       "method": "readPriorBaselineRows",
       "startLine": 149,
       "crap": 8.208333333333336
@@ -1195,92 +3608,104 @@
     },
     {
       "path": ".agents/scripts/lib/baselines/env-overrides.js",
+      "method": "resolveBundleSizeEnvOverrides",
+      "startLine": 110,
+      "crap": 3
+    },
+    {
+      "path": ".agents/scripts/lib/baselines/env-overrides.js",
+      "method": "resolveMaintainabilityRefreshOverrides",
+      "startLine": 143,
+      "crap": 3
+    },
+    {
+      "path": ".agents/scripts/lib/baselines/env-overrides.js",
       "method": "resolveMaintainabilityEnvOverrides",
-      "startLine": 100,
+      "startLine": 168,
       "crap": 8
     },
     {
       "path": ".agents/scripts/lib/baselines/envelope.js",
       "method": "schemaRefFor",
-      "startLine": 82,
+      "startLine": 83,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/baselines/envelope.js",
       "method": "kernelVersionPattern",
-      "startLine": 86,
+      "startLine": 87,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/baselines/envelope.js",
       "method": "isoTimestampPattern",
-      "startLine": 90,
+      "startLine": 91,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/baselines/envelope.js",
       "method": "resolveGeneratedAt",
-      "startLine": 112,
+      "startLine": 113,
       "crap": 5
     },
     {
       "path": ".agents/scripts/lib/baselines/envelope.js",
       "method": "buildEnvelope",
-      "startLine": 144,
-      "crap": 10.291545189504374
+      "startLine": 146,
+      "crap": 12.28125
     },
     {
       "path": ".agents/scripts/lib/baselines/envelope.js",
       "method": "getAjv",
-      "startLine": 194,
+      "startLine": 202,
       "crap": 2
     },
     {
       "path": ".agents/scripts/lib/baselines/envelope.js",
       "method": "getValidator",
-      "startLine": 209,
+      "startLine": 217,
       "crap": 2
     },
     {
       "path": ".agents/scripts/lib/baselines/envelope.js",
       "method": "missingBaselineAxis",
-      "startLine": 260,
+      "startLine": 268,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/baselines/envelope.js",
       "method": "<anon method-1>",
-      "startLine": 264,
+      "startLine": 272,
       "crap": 3
     },
     {
       "path": ".agents/scripts/lib/baselines/envelope.js",
       "method": "kernelDriftAxis",
-      "startLine": 280,
+      "startLine": 288,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/baselines/envelope.js",
       "method": "<anon method-2>",
-      "startLine": 284,
+      "startLine": 292,
       "crap": 3
     },
     {
       "path": ".agents/scripts/lib/baselines/envelope.js",
       "method": "reduceCompatAxes",
-      "startLine": 306,
+      "startLine": 314,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/baselines/envelope.js",
       "method": "<anon method-3>",
-      "startLine": 308,
+      "startLine": 316,
       "crap": 4
     },
     {
       "path": ".agents/scripts/lib/baselines/envelope.js",
       "method": "assertEnvelope",
-      "startLine": 336,
+      "startLine": 344,
       "crap": 9.158203125
     },
     {
@@ -1321,38 +3746,74 @@
     },
     {
       "path": ".agents/scripts/lib/baselines/git-base.js",
+      "method": "<anon method-1>",
+      "startLine": 125,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/baselines/git-base.js",
       "method": "readBaseFromGit",
       "startLine": 144,
       "crap": 10
     },
     {
       "path": ".agents/scripts/lib/baselines/git-base.js",
+      "method": "readRangeSubjectsTouchingFile",
+      "startLine": 219,
+      "crap": 8.020993070646602
+    },
+    {
+      "path": ".agents/scripts/lib/baselines/git-base.js",
+      "method": "<anon method-2>",
+      "startLine": 245,
+      "crap": 1.000328016728853
+    },
+    {
+      "path": ".agents/scripts/lib/baselines/git-base.js",
+      "method": "<anon method-3>",
+      "startLine": 246,
+      "crap": 1.000328016728853
+    },
+    {
+      "path": ".agents/scripts/lib/baselines/git-base.js",
       "method": "__cacheSize",
-      "startLine": 200,
+      "startLine": 255,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/baselines/kernel.js",
+      "method": "bindKindModule",
+      "startLine": 133,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/baselines/kernel.js",
       "method": "getKindModule",
-      "startLine": 61,
+      "startLine": 261,
       "crap": 2
     },
     {
       "path": ".agents/scripts/lib/baselines/kernel.js",
       "method": "currentKernelVersion",
-      "startLine": 79,
+      "startLine": 279,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/baselines/kernel.js",
+      "method": "checkBaselineSemantics",
+      "startLine": 293,
+      "crap": 2.108
+    },
+    {
+      "path": ".agents/scripts/lib/baselines/kernel.js",
       "method": "checkKernelVersion",
-      "startLine": 92,
+      "startLine": 313,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/baselines/kernel.js",
       "method": "listKinds",
-      "startLine": 107,
+      "startLine": 328,
       "crap": 1
     },
     {
@@ -1375,6 +3836,18 @@
     },
     {
       "path": ".agents/scripts/lib/baselines/kinds/_shared-metric.js",
+      "method": "<anon method-1>",
+      "startLine": 89,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/baselines/kinds/_shared-metric.js",
+      "method": "<anon method-2>",
+      "startLine": 89,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/baselines/kinds/_shared-metric.js",
       "method": "makeRollup",
       "startLine": 112,
       "crap": 1.027
@@ -1383,6 +3856,12 @@
       "path": ".agents/scripts/lib/baselines/kinds/_shared-metric.js",
       "method": "rollup",
       "startLine": 113,
+      "crap": 1.052734375
+    },
+    {
+      "path": ".agents/scripts/lib/baselines/kinds/_shared-metric.js",
+      "method": "<anon method-3>",
+      "startLine": 116,
       "crap": 1.052734375
     },
     {
@@ -1410,6 +3889,12 @@
       "crap": 5
     },
     {
+      "path": ".agents/scripts/lib/baselines/kinds/_shared-metric.js",
+      "method": "<anon method-4>",
+      "startLine": 212,
+      "crap": 3
+    },
+    {
       "path": ".agents/scripts/lib/baselines/kinds/bundle-size.js",
       "method": "kernelVersion",
       "startLine": 14,
@@ -1425,6 +3910,12 @@
       "path": ".agents/scripts/lib/baselines/kinds/bundle-size.js",
       "method": "sortRows",
       "startLine": 31,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/baselines/kinds/bundle-size.js",
+      "method": "<anon method-1>",
+      "startLine": 32,
       "crap": 1
     },
     {
@@ -1447,9 +3938,21 @@
     },
     {
       "path": ".agents/scripts/lib/baselines/kinds/bundle-size.js",
+      "method": "<anon method-2>",
+      "startLine": 99,
+      "crap": 2.5
+    },
+    {
+      "path": ".agents/scripts/lib/baselines/kinds/bundle-size.js",
       "method": "applyEpsilon",
       "startLine": 117,
       "crap": 5
+    },
+    {
+      "path": ".agents/scripts/lib/baselines/kinds/bundle-size.js",
+      "method": "<anon method-3>",
+      "startLine": 123,
+      "crap": 3
     },
     {
       "path": ".agents/scripts/lib/baselines/kinds/bundle-size.js",
@@ -1465,74 +3968,32 @@
     },
     {
       "path": ".agents/scripts/lib/baselines/kinds/coverage.js",
-      "method": "kernelVersion",
-      "startLine": 20,
-      "crap": 1
-    },
-    {
-      "path": ".agents/scripts/lib/baselines/kinds/coverage.js",
       "method": "projectRow",
-      "startLine": 24,
+      "startLine": 27,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/baselines/kinds/coverage.js",
       "method": "roundPct",
-      "startLine": 33,
+      "startLine": 36,
       "crap": 3
     },
     {
       "path": ".agents/scripts/lib/baselines/kinds/coverage.js",
-      "method": "sortRows",
-      "startLine": 38,
+      "method": "meanOf",
+      "startLine": 41,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/baselines/kinds/coverage.js",
       "method": "aggregate",
-      "startLine": 42,
+      "startLine": 47,
       "crap": 3
     },
     {
       "path": ".agents/scripts/lib/baselines/kinds/coverage.js",
-      "method": "rollup",
-      "startLine": 61,
-      "crap": 1.052734375
-    },
-    {
-      "path": ".agents/scripts/lib/baselines/kinds/coverage.js",
-      "method": "compare",
-      "startLine": 88,
-      "crap": 5
-    },
-    {
-      "path": ".agents/scripts/lib/baselines/kinds/coverage.js",
       "method": "perfectCoverageRow",
-      "startLine": 115,
-      "crap": 1
-    },
-    {
-      "path": ".agents/scripts/lib/baselines/kinds/coverage.js",
-      "method": "classifyCoverage",
-      "startLine": 119,
-      "crap": 5
-    },
-    {
-      "path": ".agents/scripts/lib/baselines/kinds/coverage.js",
-      "method": "applyEpsilon",
-      "startLine": 157,
-      "crap": 5
-    },
-    {
-      "path": ".agents/scripts/lib/baselines/kinds/coverage.js",
-      "method": "mergeRows",
-      "startLine": 187,
-      "crap": 1
-    },
-    {
-      "path": ".agents/scripts/lib/baselines/kinds/coverage.js",
-      "method": "<anon method-4>",
-      "startLine": 192,
+      "startLine": 58,
       "crap": 1
     },
     {
@@ -1543,188 +4004,296 @@
     },
     {
       "path": ".agents/scripts/lib/baselines/kinds/crap.js",
+      "method": "envelopeExtras",
+      "startLine": 104,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/baselines/kinds/crap.js",
       "method": "projectRow",
-      "startLine": 78,
+      "startLine": 108,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/baselines/kinds/crap.js",
       "method": "sortRows",
-      "startLine": 87,
+      "startLine": 117,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/baselines/kinds/crap.js",
+      "method": "<anon method-1>",
+      "startLine": 118,
+      "crap": 3
+    },
+    {
+      "path": ".agents/scripts/lib/baselines/kinds/crap.js",
       "method": "<anon method-2>",
-      "startLine": 104,
+      "startLine": 134,
       "crap": 2
     },
     {
       "path": ".agents/scripts/lib/baselines/kinds/crap.js",
+      "method": "<anon method-3>",
+      "startLine": 136,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/baselines/kinds/crap.js",
       "method": "<anon method-4>",
-      "startLine": 138,
+      "startLine": 168,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/baselines/kinds/crap.js",
       "method": "crapRowKey",
-      "startLine": 141,
+      "startLine": 171,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/baselines/kinds/crap.js",
       "method": "mergeRows",
-      "startLine": 173,
+      "startLine": 203,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/baselines/kinds/crap.js",
       "method": "<anon method-5>",
-      "startLine": 178,
+      "startLine": 208,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/baselines/kinds/crap.js",
       "method": "<anon method-6>",
-      "startLine": 179,
+      "startLine": 209,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/baselines/kinds/crap.js",
       "method": "filterRowsByFileScope",
-      "startLine": 203,
+      "startLine": 233,
       "crap": 3.6875
     },
     {
       "path": ".agents/scripts/lib/baselines/kinds/crap.js",
+      "method": "<anon method-7>",
+      "startLine": 235,
+      "crap": 1.421875
+    },
+    {
+      "path": ".agents/scripts/lib/baselines/kinds/crap.js",
       "method": "checkCrapRegression",
-      "startLine": 228,
+      "startLine": 258,
       "crap": 3
     },
     {
       "path": ".agents/scripts/lib/baselines/kinds/crap.js",
       "method": "compareCrap",
-      "startLine": 254,
+      "startLine": 284,
       "crap": 12
     },
     {
       "path": ".agents/scripts/lib/baselines/kinds/crap.js",
       "method": "<anon method-8>",
-      "startLine": 369,
+      "startLine": 399,
       "crap": 3
     },
     {
       "path": ".agents/scripts/lib/baselines/kinds/crap.js",
       "method": "<anon method-9>",
-      "startLine": 378,
+      "startLine": 408,
+      "crap": 3
+    },
+    {
+      "path": ".agents/scripts/lib/baselines/kinds/crap.js",
+      "method": "<anon method-10>",
+      "startLine": 425,
       "crap": 4
     },
     {
       "path": ".agents/scripts/lib/baselines/kinds/crap.js",
       "method": "evaluateBaselineCompatibility",
-      "startLine": 400,
+      "startLine": 447,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/baselines/kinds/crap.js",
+      "method": "assertBaselineCompatible",
+      "startLine": 467,
+      "crap": 3
+    },
+    {
+      "path": ".agents/scripts/lib/baselines/kinds/crap.js",
+      "method": "<anon method-11>",
+      "startLine": 470,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/baselines/kinds/crap.js",
       "method": "loadCrapBaseline",
-      "startLine": 414,
+      "startLine": 485,
       "crap": 9.021751535698701
     },
     {
       "path": ".agents/scripts/lib/baselines/kinds/crap.js",
       "method": "buildCrapReport",
-      "startLine": 455,
+      "startLine": 526,
       "crap": 3
+    },
+    {
+      "path": ".agents/scripts/lib/baselines/kinds/crap.js",
+      "method": "<anon method-12>",
+      "startLine": 537,
+      "crap": 4
     },
     {
       "path": ".agents/scripts/lib/baselines/kinds/crap.js",
       "method": "printSummaryHeader",
-      "startLine": 512,
-      "crap": 2
+      "startLine": 583,
+      "crap": 5.20262390670554
     },
     {
       "path": ".agents/scripts/lib/baselines/kinds/crap.js",
       "method": "printViolation",
-      "startLine": 527,
-      "crap": 3
+      "startLine": 598,
+      "crap": 10.503358436800326
     },
     {
       "path": ".agents/scripts/lib/baselines/kinds/crap.js",
       "method": "printRemovedRows",
-      "startLine": 545,
+      "startLine": 616,
+      "crap": 5.005259203606311
+    },
+    {
+      "path": ".agents/scripts/lib/baselines/kinds/duplication.js",
+      "method": "projectRow",
+      "startLine": 34,
+      "crap": 3
+    },
+    {
+      "path": ".agents/scripts/lib/baselines/kinds/duplication.js",
+      "method": "aggregate",
+      "startLine": 55,
+      "crap": 4
+    },
+    {
+      "path": ".agents/scripts/lib/baselines/kinds/duplication.js",
+      "method": "computePercentage",
+      "startLine": 80,
+      "crap": 3
+    },
+    {
+      "path": ".agents/scripts/lib/baselines/kinds/duplication.js",
+      "method": "roundTo2",
+      "startLine": 85,
       "crap": 2
     },
     {
-      "path": ".agents/scripts/lib/baselines/kinds/lighthouse.js",
-      "method": "kernelVersion",
-      "startLine": 16,
+      "path": ".agents/scripts/lib/baselines/kinds/duplication.js",
+      "method": "<anon method-1>",
+      "startLine": 106,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/baselines/kinds/kind-factory.js",
+      "method": "makeBaselineKind",
+      "startLine": 67,
+      "crap": 2.000053989849908
+    },
+    {
+      "path": ".agents/scripts/lib/baselines/kinds/kind-factory.js",
+      "method": "<anon method-1>",
+      "startLine": 77,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/baselines/kinds/kind-factory.js",
+      "method": "<anon method-2>",
+      "startLine": 79,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/baselines/kinds/kind-factory.js",
+      "method": "sortRows",
+      "startLine": 81,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/baselines/kinds/kind-factory.js",
+      "method": "<anon method-3>",
+      "startLine": 82,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/baselines/kinds/kind-factory.js",
+      "method": "rollup",
+      "startLine": 85,
+      "crap": 1.052734375
+    },
+    {
+      "path": ".agents/scripts/lib/baselines/kinds/kind-factory.js",
+      "method": "<anon method-4>",
+      "startLine": 88,
+      "crap": 1.052734375
+    },
+    {
+      "path": ".agents/scripts/lib/baselines/kinds/kind-factory.js",
+      "method": "classify",
+      "startLine": 94,
+      "crap": 7
+    },
+    {
+      "path": ".agents/scripts/lib/baselines/kinds/kind-factory.js",
+      "method": "compare",
+      "startLine": 109,
+      "crap": 9
+    },
+    {
+      "path": ".agents/scripts/lib/baselines/kinds/kind-factory.js",
+      "method": "applyEpsilon",
+      "startLine": 157,
+      "crap": 5
+    },
+    {
+      "path": ".agents/scripts/lib/baselines/kinds/kind-factory.js",
+      "method": "<anon method-5>",
+      "startLine": 163,
+      "crap": 4
+    },
+    {
+      "path": ".agents/scripts/lib/baselines/kinds/kind-factory.js",
+      "method": "mergeRows",
+      "startLine": 175,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/baselines/kinds/lighthouse.js",
       "method": "canonRoute",
-      "startLine": 20,
+      "startLine": 23,
       "crap": 4.03125
     },
     {
       "path": ".agents/scripts/lib/baselines/kinds/lighthouse.js",
       "method": "projectRow",
-      "startLine": 29,
+      "startLine": 32,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/baselines/kinds/lighthouse.js",
-      "method": "sortRows",
-      "startLine": 39,
+      "method": "meanOf",
+      "startLine": 42,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/baselines/kinds/lighthouse.js",
       "method": "aggregate",
-      "startLine": 43,
+      "startLine": 48,
       "crap": 3
     },
     {
       "path": ".agents/scripts/lib/baselines/kinds/lighthouse.js",
-      "method": "rollup",
-      "startLine": 62,
-      "crap": 1.052734375
-    },
-    {
-      "path": ".agents/scripts/lib/baselines/kinds/lighthouse.js",
-      "method": "compare",
-      "startLine": 86,
-      "crap": 4
-    },
-    {
-      "path": ".agents/scripts/lib/baselines/kinds/lighthouse.js",
       "method": "perfectLighthouseRow",
-      "startLine": 108,
-      "crap": 1
-    },
-    {
-      "path": ".agents/scripts/lib/baselines/kinds/lighthouse.js",
-      "method": "classify",
-      "startLine": 118,
-      "crap": 5
-    },
-    {
-      "path": ".agents/scripts/lib/baselines/kinds/lighthouse.js",
-      "method": "applyEpsilon",
-      "startLine": 142,
-      "crap": 5
-    },
-    {
-      "path": ".agents/scripts/lib/baselines/kinds/lighthouse.js",
-      "method": "mergeRows",
-      "startLine": 178,
-      "crap": 1
-    },
-    {
-      "path": ".agents/scripts/lib/baselines/kinds/lighthouse.js",
-      "method": "<anon method-4>",
-      "startLine": 183,
+      "startLine": 60,
       "crap": 1
     },
     {
@@ -1753,6 +4322,12 @@
     },
     {
       "path": ".agents/scripts/lib/baselines/kinds/lint.js",
+      "method": "<anon method-1>",
+      "startLine": 71,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/baselines/kinds/lint.js",
       "method": "compare",
       "startLine": 89,
       "crap": 11.020747599451303
@@ -1762,6 +4337,12 @@
       "method": "applyEpsilon",
       "startLine": 138,
       "crap": 5
+    },
+    {
+      "path": ".agents/scripts/lib/baselines/kinds/lint.js",
+      "method": "<anon method-2>",
+      "startLine": 144,
+      "crap": 3
     },
     {
       "path": ".agents/scripts/lib/baselines/kinds/lint.js",
@@ -1778,97 +4359,109 @@
     {
       "path": ".agents/scripts/lib/baselines/kinds/maintainability.js",
       "method": "filterExcludedRows",
-      "startLine": 110,
+      "startLine": 99,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/baselines/kinds/maintainability.js",
+      "method": "<anon method-1>",
+      "startLine": 102,
       "crap": 2
     },
     {
       "path": ".agents/scripts/lib/baselines/kinds/maintainability.js",
       "method": "projectRow",
-      "startLine": 117,
+      "startLine": 106,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/baselines/kinds/maintainability.js",
       "method": "aggregate",
-      "startLine": 124,
+      "startLine": 113,
       "crap": 3
     },
     {
       "path": ".agents/scripts/lib/baselines/kinds/maintainability.js",
+      "method": "<anon method-2>",
+      "startLine": 115,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/baselines/kinds/maintainability.js",
+      "method": "<anon method-3>",
+      "startLine": 115,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/baselines/kinds/maintainability.js",
       "method": "<anon method-4>",
-      "startLine": 152,
+      "startLine": 141,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/baselines/kinds/maintainability.js",
       "method": "buildMaintainabilityReport",
-      "startLine": 180,
+      "startLine": 169,
       "crap": 3
     },
     {
       "path": ".agents/scripts/lib/baselines/kinds/maintainability.js",
+      "method": "<anon method-5>",
+      "startLine": 171,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/baselines/kinds/maintainability.js",
       "method": "loadMaintainabilityBaseline",
-      "startLine": 206,
+      "startLine": 195,
       "crap": 13.913106866890216
     },
     {
       "path": ".agents/scripts/lib/baselines/kinds/maintainability.js",
       "method": "<anon method-6>",
-      "startLine": 217,
-      "crap": 1
-    },
-    {
-      "path": ".agents/scripts/lib/baselines/kinds/mutation.js",
-      "method": "kernelVersion",
-      "startLine": 17,
+      "startLine": 206,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/baselines/kinds/mutation.js",
       "method": "projectRow",
-      "startLine": 21,
-      "crap": 1
-    },
-    {
-      "path": ".agents/scripts/lib/baselines/kinds/mutation.js",
-      "method": "sortRows",
-      "startLine": 30,
+      "startLine": 20,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/baselines/kinds/mutation.js",
       "method": "aggregate",
-      "startLine": 34,
+      "startLine": 29,
       "crap": 3
     },
     {
       "path": ".agents/scripts/lib/baselines/kinds/mutation.js",
-      "method": "rollup",
-      "startLine": 54,
-      "crap": 1.052734375
-    },
-    {
-      "path": ".agents/scripts/lib/baselines/kinds/mutation.js",
-      "method": "compare",
-      "startLine": 78,
-      "crap": 8.015625
-    },
-    {
-      "path": ".agents/scripts/lib/baselines/kinds/mutation.js",
-      "method": "applyEpsilon",
-      "startLine": 121,
-      "crap": 5
-    },
-    {
-      "path": ".agents/scripts/lib/baselines/kinds/mutation.js",
-      "method": "mergeRows",
-      "startLine": 146,
+      "method": "<anon method-1>",
+      "startLine": 65,
       "crap": 1
     },
     {
-      "path": ".agents/scripts/lib/baselines/kinds/mutation.js",
-      "method": "<anon method-4>",
-      "startLine": 151,
+      "path": ".agents/scripts/lib/baselines/maintainability-baseline-io.js",
+      "method": "projectMaintainabilityEnvelopeToFlat",
+      "startLine": 12,
+      "crap": 9
+    },
+    {
+      "path": ".agents/scripts/lib/baselines/maintainability-baseline-io.js",
+      "method": "getBaseline",
+      "startLine": 41,
+      "crap": 5
+    },
+    {
+      "path": ".agents/scripts/lib/baselines/maintainability-baseline-save.js",
+      "method": "saveBaseline",
+      "startLine": 21,
+      "crap": 4
+    },
+    {
+      "path": ".agents/scripts/lib/baselines/maintainability-baseline-save.js",
+      "method": "<anon method-1>",
+      "startLine": 31,
       "crap": 1
     },
     {
@@ -1881,6 +4474,12 @@
       "path": ".agents/scripts/lib/baselines/path-canon.js",
       "method": "hasTraversal",
       "startLine": 78,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/baselines/path-canon.js",
+      "method": "<anon method-1>",
+      "startLine": 80,
       "crap": 1
     },
     {
@@ -1898,175 +4497,331 @@
     {
       "path": ".agents/scripts/lib/baselines/path-canon.js",
       "method": "canonicalizeBaselinePath",
-      "startLine": 225,
+      "startLine": 234,
       "crap": 6
     },
     {
       "path": ".agents/scripts/lib/baselines/preview-gates.js",
+      "method": "resolvePreviewTolerance",
+      "startLine": 63,
+      "crap": 3
+    },
+    {
+      "path": ".agents/scripts/lib/baselines/preview-gates.js",
       "method": "compareScores",
-      "startLine": 53,
+      "startLine": 82,
       "crap": 9.309057806099226
     },
     {
       "path": ".agents/scripts/lib/baselines/preview-gates.js",
       "method": "resolveBaselineRows",
-      "startLine": 88,
+      "startLine": 117,
       "crap": 6
     },
     {
       "path": ".agents/scripts/lib/baselines/preview-gates.js",
       "method": "hasCrapRegressions",
-      "startLine": 101,
+      "startLine": 130,
       "crap": 6
     },
     {
       "path": ".agents/scripts/lib/baselines/preview-gates.js",
       "method": "applyDiffScopeMi",
-      "startLine": 105,
+      "startLine": 134,
       "crap": 2.116522530723714
     },
     {
       "path": ".agents/scripts/lib/baselines/preview-gates.js",
+      "method": "<anon method-1>",
+      "startLine": 138,
+      "crap": 1.0291306326809286
+    },
+    {
+      "path": ".agents/scripts/lib/baselines/preview-gates.js",
+      "method": "<anon method-2>",
+      "startLine": 143,
+      "crap": 1.0291306326809286
+    },
+    {
+      "path": ".agents/scripts/lib/baselines/preview-gates.js",
       "method": "runMaintainabilityPreview",
-      "startLine": 129,
-      "crap": 6.087818616294948
+      "startLine": 158,
+      "crap": 6.0703125
     },
     {
       "path": ".agents/scripts/lib/baselines/preview-gates.js",
       "method": "runCrapPreview",
-      "startLine": 185,
-      "crap": 7.632414510735905
+      "startLine": 218,
+      "crap": 7.528398442904398
     },
     {
       "path": ".agents/scripts/lib/baselines/reader.js",
       "method": "ajv",
-      "startLine": 65,
+      "startLine": 67,
       "crap": 2
     },
     {
       "path": ".agents/scripts/lib/baselines/reader.js",
       "method": "resolveBaselinePath",
-      "startLine": 79,
-      "crap": 6.184509409979909
+      "startLine": 81,
+      "crap": 6.0703125
     },
     {
       "path": ".agents/scripts/lib/baselines/reader.js",
       "method": "canonicaliseRowPath",
-      "startLine": 121,
+      "startLine": 118,
       "crap": 3
     },
     {
       "path": ".agents/scripts/lib/baselines/reader.js",
       "method": "canonicaliseRow",
-      "startLine": 136,
+      "startLine": 133,
       "crap": 7
     },
     {
       "path": ".agents/scripts/lib/baselines/reader.js",
       "method": "validate",
-      "startLine": 161,
+      "startLine": 158,
       "crap": 5.024
     },
     {
       "path": ".agents/scripts/lib/baselines/reader.js",
+      "method": "<anon method-1>",
+      "startLine": 176,
+      "crap": 2.2560000000000002
+    },
+    {
+      "path": ".agents/scripts/lib/baselines/reader.js",
       "method": "readAndShape",
-      "startLine": 195,
+      "startLine": 192,
       "crap": 2.0932944606413995
     },
     {
       "path": ".agents/scripts/lib/baselines/reader.js",
+      "method": "<anon method-2>",
+      "startLine": 211,
+      "crap": 1.0233236151603498
+    },
+    {
+      "path": ".agents/scripts/lib/baselines/reader.js",
       "method": "inferKindFromSchema",
-      "startLine": 233,
+      "startLine": 230,
       "crap": 3
     },
     {
       "path": ".agents/scripts/lib/baselines/reader.js",
       "method": "load",
-      "startLine": 251,
+      "startLine": 248,
       "crap": 2
     },
     {
       "path": ".agents/scripts/lib/baselines/reader.js",
       "method": "loadFile",
-      "startLine": 272,
+      "startLine": 269,
       "crap": 6
+    },
+    {
+      "path": ".agents/scripts/lib/baselines/reader.js",
+      "method": "<anon method-3>",
+      "startLine": 299,
+      "crap": 1
     },
     {
       "path": ".agents/scripts/lib/baselines/refresh-service.js",
       "method": "<anon method-1>",
-      "startLine": 120,
+      "startLine": 125,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/baselines/refresh-service.js",
       "method": "<anon method-2>",
-      "startLine": 121,
+      "startLine": 126,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/baselines/refresh-service.js",
       "method": "<anon method-3>",
-      "startLine": 122,
+      "startLine": 127,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/baselines/refresh-service.js",
+      "method": "resolveQualityBlock",
+      "startLine": 145,
+      "crap": 5
+    },
+    {
+      "path": ".agents/scripts/lib/baselines/refresh-service.js",
       "method": "buildDefaultCrapScorer",
-      "startLine": 136,
-      "crap": 4.8919313762264816
+      "startLine": 167,
+      "crap": 3
+    },
+    {
+      "path": ".agents/scripts/lib/baselines/refresh-service.js",
+      "method": "<anon method-4>",
+      "startLine": 179,
+      "crap": 5
+    },
+    {
+      "path": ".agents/scripts/lib/baselines/refresh-service.js",
+      "method": "<anon method-5>",
+      "startLine": 200,
+      "crap": 2
     },
     {
       "path": ".agents/scripts/lib/baselines/refresh-service.js",
       "method": "buildDefaultCoverageScorer",
-      "startLine": 185,
-      "crap": 1.7563347050754459
+      "startLine": 216,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/baselines/refresh-service.js",
+      "method": "<anon method-6>",
+      "startLine": 217,
+      "crap": 20
+    },
+    {
+      "path": ".agents/scripts/lib/baselines/refresh-service.js",
+      "method": "<anon method-7>",
+      "startLine": 252,
+      "crap": 6
+    },
+    {
+      "path": ".agents/scripts/lib/baselines/refresh-service.js",
+      "method": "<anon method-8>",
+      "startLine": 253,
+      "crap": 2
     },
     {
       "path": ".agents/scripts/lib/baselines/refresh-service.js",
       "method": "buildDefaultMaintainabilityScorer",
-      "startLine": 238,
-      "crap": 3.5030785670669653
+      "startLine": 273,
+      "crap": 3
+    },
+    {
+      "path": ".agents/scripts/lib/baselines/refresh-service.js",
+      "method": "<anon method-9>",
+      "startLine": 277,
+      "crap": 4
+    },
+    {
+      "path": ".agents/scripts/lib/baselines/refresh-service.js",
+      "method": "<anon method-10>",
+      "startLine": 279,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/baselines/refresh-service.js",
+      "method": "<anon method-11>",
+      "startLine": 293,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/baselines/refresh-service.js",
+      "method": "<anon method-12>",
+      "startLine": 311,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/baselines/refresh-service.js",
+      "method": "resolveDefaultScorer",
+      "startLine": 362,
+      "crap": 2
     },
     {
       "path": ".agents/scripts/lib/baselines/refresh-service.js",
       "method": "refreshBaseline",
-      "startLine": 316,
-      "crap": 6.015046002466852
+      "startLine": 404,
+      "crap": 6.010937840286881
+    },
+    {
+      "path": ".agents/scripts/lib/baselines/refresh-service.js",
+      "method": "<anon method-13>",
+      "startLine": 469,
+      "crap": 1.0003038288968578
+    },
+    {
+      "path": ".agents/scripts/lib/baselines/refresh-service.js",
+      "method": "assertRequiredScopeRows",
+      "startLine": 524,
+      "crap": 6
+    },
+    {
+      "path": ".agents/scripts/lib/baselines/refresh-service.js",
+      "method": "<anon method-14>",
+      "startLine": 535,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/baselines/refresh-service.js",
+      "method": "<anon method-15>",
+      "startLine": 541,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/baselines/refresh-service.js",
+      "method": "<anon method-16>",
+      "startLine": 542,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/baselines/refresh-service.js",
+      "method": "<anon method-17>",
+      "startLine": 544,
+      "crap": 1
     },
     {
       "path": ".agents/scripts/lib/baselines/refresh-service.js",
       "method": "defaultGitDiff",
-      "startLine": 433,
+      "startLine": 562,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/baselines/refresh-service.js",
+      "method": "<anon method-18>",
+      "startLine": 572,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/baselines/refresh-service.js",
+      "method": "<anon method-19>",
+      "startLine": 573,
       "crap": 2
     },
     {
       "path": ".agents/scripts/lib/baselines/refresh-service.js",
       "method": "deriveScopeFromDiff",
-      "startLine": 474,
+      "startLine": 603,
       "crap": 5
     },
     {
       "path": ".agents/scripts/lib/baselines/refresh-service.js",
       "method": "fileFilterFor",
-      "startLine": 502,
+      "startLine": 631,
       "crap": 2
     },
     {
       "path": ".agents/scripts/lib/baselines/refresh-service.js",
       "method": "resolveScope",
-      "startLine": 524,
+      "startLine": 653,
       "crap": 3
     },
     {
       "path": ".agents/scripts/lib/baselines/refresh-service.js",
+      "method": "<anon method-20>",
+      "startLine": 668,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/baselines/refresh-service.js",
       "method": "readPriorEnvelope",
-      "startLine": 562,
+      "startLine": 691,
       "crap": 7.226851851851852
     },
     {
       "path": ".agents/scripts/lib/baselines/refresh-service.js",
       "method": "validateOptions",
-      "startLine": 591,
+      "startLine": 720,
       "crap": 9
     },
     {
@@ -2089,6 +4844,18 @@
     },
     {
       "path": ".agents/scripts/lib/baselines/scope.js",
+      "method": "<anon method-1>",
+      "startLine": 96,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/baselines/scope.js",
+      "method": "<anon method-2>",
+      "startLine": 100,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/baselines/scope.js",
       "method": "resolveScope",
       "startLine": 129,
       "crap": 13
@@ -2100,87 +4867,171 @@
       "crap": 9.011809301647471
     },
     {
+      "path": ".agents/scripts/lib/baselines/scope.js",
+      "method": "<anon method-3>",
+      "startLine": 281,
+      "crap": 1.0001457938474996
+    },
+    {
+      "path": ".agents/scripts/lib/baselines/scope.js",
+      "method": "<anon method-4>",
+      "startLine": 285,
+      "crap": 1.0001457938474996
+    },
+    {
+      "path": ".agents/scripts/lib/baselines/scope.js",
+      "method": "<anon method-5>",
+      "startLine": 287,
+      "crap": 2.0005831753899987
+    },
+    {
       "path": ".agents/scripts/lib/baselines/writer.js",
       "method": "write",
       "startLine": 101,
-      "crap": 9.192
+      "crap": 10.221911728445797
+    },
+    {
+      "path": ".agents/scripts/lib/baselines/writer.js",
+      "method": "<anon method-1>",
+      "startLine": 120,
+      "crap": 1.002219117284458
+    },
+    {
+      "path": ".agents/scripts/lib/baselines/writer.js",
+      "method": "<anon method-2>",
+      "startLine": 136,
+      "crap": 1.002219117284458
     },
     {
       "path": ".agents/scripts/lib/baselines/writer.js",
       "method": "resolvePriorEnvelope",
-      "startLine": 200,
+      "startLine": 202,
       "crap": 13
     },
     {
       "path": ".agents/scripts/lib/baselines/writer.js",
       "method": "writeFile",
-      "startLine": 246,
-      "crap": 4
-    },
-    {
-      "path": ".agents/scripts/lib/baselines/writer.js",
-      "method": "scopeMergeRows",
-      "startLine": 283,
-      "crap": 4
+      "startLine": 248,
+      "crap": 5
     },
     {
       "path": ".agents/scripts/lib/baselines/writer.js",
       "method": "stabiliseRows",
-      "startLine": 299,
+      "startLine": 309,
       "crap": 8
     },
     {
       "path": ".agents/scripts/lib/bdd-runner-detect.js",
       "method": "verifyBddRunnerPendingTag",
-      "startLine": 121,
+      "startLine": 117,
       "crap": 4.000208426623244
     },
     {
       "path": ".agents/scripts/lib/bdd-runner-detect.js",
+      "method": "<anon method-2>",
+      "startLine": 119,
+      "crap": 1.0000130266639529
+    },
+    {
+      "path": ".agents/scripts/lib/bdd-runner-detect.js",
       "method": "defaultListWorkspacePkgPaths",
-      "startLine": 223,
+      "startLine": 219,
       "crap": 2
     },
     {
       "path": ".agents/scripts/lib/bdd-runner-detect.js",
       "method": "readWorkspacePatterns",
-      "startLine": 230,
+      "startLine": 226,
       "crap": 8.328016728853171
     },
     {
       "path": ".agents/scripts/lib/bdd-runner-detect.js",
+      "method": "<anon method-3>",
+      "startLine": 233,
+      "crap": 1.0051252613883308
+    },
+    {
+      "path": ".agents/scripts/lib/bdd-runner-detect.js",
+      "method": "<anon method-4>",
+      "startLine": 246,
+      "crap": 1.0051252613883308
+    },
+    {
+      "path": ".agents/scripts/lib/bdd-runner-detect.js",
+      "method": "<anon method-5>",
+      "startLine": 249,
+      "crap": 1.0051252613883308
+    },
+    {
+      "path": ".agents/scripts/lib/bdd-runner-detect.js",
       "method": "expandWorkspacePatterns",
-      "startLine": 268,
+      "startLine": 264,
       "crap": 7.294515401953419
     },
     {
       "path": ".agents/scripts/lib/bdd-runner-detect.js",
+      "method": "<anon method-6>",
+      "startLine": 265,
+      "crap": 1.0060105184072126
+    },
+    {
+      "path": ".agents/scripts/lib/bdd-runner-detect.js",
+      "method": "<anon method-7>",
+      "startLine": 267,
+      "crap": 1.0060105184072126
+    },
+    {
+      "path": ".agents/scripts/lib/bdd-runner-detect.js",
+      "method": "<anon method-8>",
+      "startLine": 268,
+      "crap": 1.0060105184072126
+    },
+    {
+      "path": ".agents/scripts/lib/bdd-runner-detect.js",
+      "method": "<anon method-9>",
+      "startLine": 269,
+      "crap": 1.0060105184072126
+    },
+    {
+      "path": ".agents/scripts/lib/bdd-runner-detect.js",
+      "method": "<anon method-10>",
+      "startLine": 278,
+      "crap": 1.0060105184072126
+    },
+    {
+      "path": ".agents/scripts/lib/bdd-runner-detect.js",
       "method": "walkPackages",
-      "startLine": 313,
+      "startLine": 309,
       "crap": 9.158203125
     },
     {
       "path": ".agents/scripts/lib/bdd-runner-detect.js",
+      "method": "<anon method-11>",
+      "startLine": 332,
+      "crap": 1.001953125
+    },
+    {
+      "path": ".agents/scripts/lib/bdd-runner-detect.js",
       "method": "hasGlobChar",
-      "startLine": 354,
+      "startLine": 350,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/bdd-runner-detect.js",
       "method": "toPosix",
-      "startLine": 358,
+      "startLine": 354,
       "crap": 2
     },
     {
       "path": ".agents/scripts/lib/bdd-runner-detect.js",
       "method": "existsSyncDir",
-      "startLine": 362,
+      "startLine": 358,
       "crap": 2.5
     },
     {
       "path": ".agents/scripts/lib/bdd-runner-detect.js",
       "method": "resolveFeatureRoots",
-      "startLine": 399,
+      "startLine": 395,
       "crap": 3.16401807843709
     },
     {
@@ -2227,6 +5078,12 @@
     },
     {
       "path": ".agents/scripts/lib/bootstrap/branch-protection.js",
+      "method": "<anon method-1>",
+      "startLine": 74,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/bootstrap/branch-protection.js",
       "method": "isBehaviorShifting",
       "startLine": 86,
       "crap": 3.0262390670553936
@@ -2238,10 +5095,52 @@
       "crap": 12.006059669598093
     },
     {
+      "path": ".agents/scripts/lib/bootstrap/branch-protection.js",
+      "method": "<anon method-2>",
+      "startLine": 135,
+      "crap": 1.0000420810388757
+    },
+    {
+      "path": ".agents/scripts/lib/bootstrap/branch-protection.js",
+      "method": "<anon method-3>",
+      "startLine": 136,
+      "crap": 2.0001683241555024
+    },
+    {
       "path": ".agents/scripts/lib/bootstrap/ci-workflow-template.js",
       "method": "renderCiWorkflow",
-      "startLine": 50,
+      "startLine": 57,
       "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/bootstrap/ci-workflow-template.js",
+      "method": "ensureCiWorkflow",
+      "startLine": 196,
+      "crap": 4
+    },
+    {
+      "path": ".agents/scripts/lib/bootstrap/commit-push.js",
+      "method": "resolveStagePaths",
+      "startLine": 86,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/bootstrap/commit-push.js",
+      "method": "<anon method-1>",
+      "startLine": 87,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/bootstrap/commit-push.js",
+      "method": "buildManualInstructions",
+      "startLine": 105,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/bootstrap/commit-push.js",
+      "method": "stageBootstrapFiles",
+      "startLine": 132,
+      "crap": 5.024
     },
     {
       "path": ".agents/scripts/lib/bootstrap/gh-list.js",
@@ -2257,9 +5156,21 @@
     },
     {
       "path": ".agents/scripts/lib/bootstrap/gh-list.js",
+      "method": "<anon method-1>",
+      "startLine": 62,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/bootstrap/gh-list.js",
       "method": "listRepos",
       "startLine": 76,
       "crap": 5
+    },
+    {
+      "path": ".agents/scripts/lib/bootstrap/gh-list.js",
+      "method": "<anon method-2>",
+      "startLine": 89,
+      "crap": 3
     },
     {
       "path": ".agents/scripts/lib/bootstrap/gh-list.js",
@@ -2268,82 +5179,214 @@
       "crap": 9.006241391599165
     },
     {
+      "path": ".agents/scripts/lib/bootstrap/gh-list.js",
+      "method": "<anon method-3>",
+      "startLine": 140,
+      "crap": 7.0037756566464076
+    },
+    {
+      "path": ".agents/scripts/lib/bootstrap/gh-list.js",
+      "method": "<anon method-4>",
+      "startLine": 152,
+      "crap": 1.0000770542172737
+    },
+    {
       "path": ".agents/scripts/lib/bootstrap/gh-preflight.js",
       "method": "defaultGhRunner",
-      "startLine": 63,
+      "startLine": 65,
       "crap": 12
     },
     {
       "path": ".agents/scripts/lib/bootstrap/gh-preflight.js",
       "method": "parseGhVersion",
-      "startLine": 81,
+      "startLine": 83,
       "crap": 3
     },
     {
       "path": ".agents/scripts/lib/bootstrap/gh-preflight.js",
       "method": "compareSemver",
-      "startLine": 95,
+      "startLine": 97,
       "crap": 3
     },
     {
       "path": ".agents/scripts/lib/bootstrap/gh-preflight.js",
+      "method": "<anon method-1>",
+      "startLine": 100,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/bootstrap/gh-preflight.js",
+      "method": "<anon method-2>",
+      "startLine": 103,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/bootstrap/gh-preflight.js",
       "method": "preflightGh",
-      "startLine": 134,
-      "crap": 9.780173949895495
+      "startLine": 136,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/bootstrap/gh-preflight.js",
+      "method": "resolveGhVersion",
+      "startLine": 152,
+      "crap": 6.189364674940412
+    },
+    {
+      "path": ".agents/scripts/lib/bootstrap/gh-preflight.js",
+      "method": "assertGhVersionFloor",
+      "startLine": 182,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/bootstrap/gh-preflight.js",
+      "method": "assertGhAuth",
+      "startLine": 197,
+      "crap": 3.576
+    },
+    {
+      "path": ".agents/scripts/lib/bootstrap/gh-preflight.js",
+      "method": "checkProjectScopes",
+      "startLine": 239,
+      "crap": 3
+    },
+    {
+      "path": ".agents/scripts/lib/bootstrap/gh-preflight.js",
+      "method": "classifyProjectScopes",
+      "startLine": 253,
+      "crap": 3
     },
     {
       "path": ".agents/scripts/lib/bootstrap/gh-preflight.js",
       "method": "preflightRuntimeDeps",
-      "startLine": 198,
+      "startLine": 287,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/bootstrap/gh-preflight.js",
+      "method": "<anon method-3>",
+      "startLine": 289,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/bootstrap/hitl-confirm.js",
+      "method": "confirm",
+      "startLine": 47,
+      "crap": 4
+    },
+    {
+      "path": ".agents/scripts/lib/bootstrap/hitl-confirm.js",
+      "method": "<anon method-1>",
+      "startLine": 78,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/bootstrap/install-ledger.js",
+      "method": "resolveExecutedAction",
+      "startLine": 83,
+      "crap": 4
+    },
+    {
+      "path": ".agents/scripts/lib/bootstrap/install-ledger.js",
+      "method": "ledgerPath",
+      "startLine": 97,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/bootstrap/install-ledger.js",
+      "method": "buildLedgerRecord",
+      "startLine": 123,
+      "crap": 3
+    },
+    {
+      "path": ".agents/scripts/lib/bootstrap/install-ledger.js",
+      "method": "<anon method-1>",
+      "startLine": 132,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/bootstrap/install-ledger.js",
+      "method": "writeInstallLedger",
+      "startLine": 155,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/bootstrap/install-ledger.js",
+      "method": "readInstallLedger",
+      "startLine": 170,
       "crap": 2
     },
     {
       "path": ".agents/scripts/lib/bootstrap/issue-forms-template.js",
       "method": "yamlQuote",
-      "startLine": 151,
+      "startLine": 157,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/bootstrap/issue-forms-template.js",
       "method": "renderFieldBlock",
-      "startLine": 167,
+      "startLine": 173,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/bootstrap/issue-forms-template.js",
       "method": "renderDependsOnBlock",
-      "startLine": 188,
+      "startLine": 194,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/bootstrap/issue-forms-template.js",
       "method": "renderIssueForm",
-      "startLine": 233,
+      "startLine": 239,
       "crap": 3
     },
     {
       "path": ".agents/scripts/lib/bootstrap/issue-forms-template.js",
       "method": "assembleBodyFromFormValues",
-      "startLine": 277,
+      "startLine": 283,
       "crap": 6
     },
     {
       "path": ".agents/scripts/lib/bootstrap/issue-forms-template.js",
+      "method": "<anon method-1>",
+      "startLine": 296,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/bootstrap/issue-forms-template.js",
+      "method": "<anon method-2>",
+      "startLine": 298,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/bootstrap/issue-forms-template.js",
+      "method": "<anon method-3>",
+      "startLine": 300,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/bootstrap/issue-forms-template.js",
       "method": "renderConformanceWorkflow",
-      "startLine": 318,
+      "startLine": 324,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/bootstrap/issue-forms-template.js",
       "method": "ensureIssueForms",
-      "startLine": 383,
+      "startLine": 389,
       "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/bootstrap/issue-forms-template.js",
+      "method": "<anon method-4>",
+      "startLine": 410,
+      "crap": 4
     },
     {
       "path": ".agents/scripts/lib/bootstrap/manifest.js",
       "method": "buildMutationManifest",
       "startLine": 107,
-      "crap": 7
+      "crap": 5.094343207879483
     },
     {
       "path": ".agents/scripts/lib/bootstrap/manifest.js",
@@ -2354,19 +5397,19 @@
     {
       "path": ".agents/scripts/lib/bootstrap/manifest.js",
       "method": "previewMutationManifest",
-      "startLine": 271,
-      "crap": 2
+      "startLine": 289,
+      "crap": 4.809327846364883
     },
     {
       "path": ".agents/scripts/lib/bootstrap/merge-methods.js",
       "method": "diffMergeMethods",
-      "startLine": 39,
+      "startLine": 42,
       "crap": 3
     },
     {
       "path": ".agents/scripts/lib/bootstrap/merge-methods.js",
       "method": "applyMergeMethods",
-      "startLine": 60,
+      "startLine": 63,
       "crap": 4
     },
     {
@@ -2402,265 +5445,409 @@
     {
       "path": ".agents/scripts/lib/bootstrap/preflight.js",
       "method": "checkGh",
-      "startLine": 115,
+      "startLine": 119,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/bootstrap/preflight.js",
       "method": "runPreflight",
-      "startLine": 139,
-      "crap": 3
+      "startLine": 154,
+      "crap": 5.602743484224965
+    },
+    {
+      "path": ".agents/scripts/lib/bootstrap/preflight.js",
+      "method": "<anon method-2>",
+      "startLine": 196,
+      "crap": 1.0241097393689986
     },
     {
       "path": ".agents/scripts/lib/bootstrap/project-bootstrap.js",
       "method": "readJsonIfExists",
-      "startLine": 74,
+      "startLine": 105,
       "crap": 2
     },
     {
       "path": ".agents/scripts/lib/bootstrap/project-bootstrap.js",
       "method": "writeJson",
-      "startLine": 88,
+      "startLine": 119,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/bootstrap/project-bootstrap.js",
       "method": "satisfiesNodeEngine",
-      "startLine": 103,
+      "startLine": 150,
       "crap": 9
     },
     {
       "path": ".agents/scripts/lib/bootstrap/project-bootstrap.js",
       "method": "checkNodeVersion",
-      "startLine": 123,
+      "startLine": 170,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/bootstrap/project-bootstrap.js",
       "method": "detectPackageManager",
-      "startLine": 138,
-      "crap": 3
+      "startLine": 190,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/bootstrap/project-bootstrap.js",
+      "method": "<anon method-1>",
+      "startLine": 191,
+      "crap": 1
     },
     {
       "path": ".agents/scripts/lib/bootstrap/project-bootstrap.js",
       "method": "ensurePackageJson",
-      "startLine": 156,
-      "crap": 10
+      "startLine": 205,
+      "crap": 14
     },
     {
       "path": ".agents/scripts/lib/bootstrap/project-bootstrap.js",
       "method": "ensureDependenciesInstalled",
-      "startLine": 216,
+      "startLine": 283,
       "crap": 27.415952988338194
     },
     {
       "path": ".agents/scripts/lib/bootstrap/project-bootstrap.js",
       "method": "ensureAgentrc",
-      "startLine": 272,
-      "crap": 7
+      "startLine": 327,
+      "crap": 5
     },
     {
       "path": ".agents/scripts/lib/bootstrap/project-bootstrap.js",
       "method": "validateAgentrc",
-      "startLine": 316,
-      "crap": 17.821401576503614
-    },
-    {
-      "path": ".agents/scripts/lib/bootstrap/project-bootstrap.js",
-      "method": "ensureClaudeSettings",
-      "startLine": 351,
-      "crap": 4
+      "startLine": 365,
+      "crap": 18.00246568587162
     },
     {
       "path": ".agents/scripts/lib/bootstrap/project-bootstrap.js",
       "method": "ensureGitignore",
-      "startLine": 392,
+      "startLine": 411,
       "crap": 6
     },
     {
       "path": ".agents/scripts/lib/bootstrap/project-bootstrap.js",
+      "method": "ensureIssueFormsPhase",
+      "startLine": 451,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/bootstrap/project-bootstrap.js",
       "method": "runSyncCommands",
-      "startLine": 424,
-      "crap": 5.478963185574756
+      "startLine": 473,
+      "crap": 5.6758401920438954
     },
     {
       "path": ".agents/scripts/lib/bootstrap/project-bootstrap.js",
       "method": "checkParity",
-      "startLine": 456,
-      "crap": 5.538943999999999
+      "startLine": 528,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/bootstrap/project-bootstrap.js",
+      "method": "<anon method-2>",
+      "startLine": 535,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/bootstrap/project-bootstrap.js",
+      "method": "<anon method-3>",
+      "startLine": 539,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/bootstrap/project-bootstrap.js",
+      "method": "<anon method-4>",
+      "startLine": 540,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/bootstrap/project-bootstrap.js",
+      "method": "<anon method-5>",
+      "startLine": 546,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/bootstrap/project-bootstrap.js",
+      "method": "<anon method-6>",
+      "startLine": 552,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/bootstrap/project-bootstrap.js",
+      "method": "<anon method-7>",
+      "startLine": 553,
+      "crap": 1
     },
     {
       "path": ".agents/scripts/lib/bootstrap/project-bootstrap.js",
       "method": "ensureSystemPromptWiring",
-      "startLine": 503,
+      "startLine": 582,
       "crap": 5
     },
     {
       "path": ".agents/scripts/lib/bootstrap/project-bootstrap.js",
       "method": "checkWindowsGitPerf",
-      "startLine": 532,
+      "startLine": 611,
       "crap": 10.921223958333334
     },
     {
       "path": ".agents/scripts/lib/bootstrap/project-bootstrap.js",
       "method": "<anon method-8>",
-      "startLine": 587,
+      "startLine": 666,
       "crap": 2
     },
     {
       "path": ".agents/scripts/lib/bootstrap/project-bootstrap.js",
       "method": "<anon method-9>",
-      "startLine": 592,
+      "startLine": 671,
       "crap": 2
     },
     {
       "path": ".agents/scripts/lib/bootstrap/project-bootstrap.js",
       "method": "<anon method-10>",
-      "startLine": 601,
+      "startLine": 680,
       "crap": 4
     },
     {
       "path": ".agents/scripts/lib/bootstrap/project-bootstrap.js",
       "method": "<anon method-11>",
-      "startLine": 625,
+      "startLine": 704,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/bootstrap/project-bootstrap.js",
       "method": "<anon method-12>",
-      "startLine": 632,
+      "startLine": 711,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/bootstrap/project-bootstrap.js",
       "method": "<anon method-13>",
-      "startLine": 636,
+      "startLine": 715,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/bootstrap/project-bootstrap.js",
       "method": "<anon method-14>",
-      "startLine": 641,
+      "startLine": 720,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/bootstrap/project-bootstrap.js",
       "method": "<anon method-15>",
-      "startLine": 646,
+      "startLine": 725,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/bootstrap/project-bootstrap.js",
       "method": "<anon method-16>",
-      "startLine": 653,
+      "startLine": 732,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/bootstrap/project-bootstrap.js",
       "method": "<anon method-17>",
-      "startLine": 658,
+      "startLine": 737,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/bootstrap/project-bootstrap.js",
       "method": "<anon method-18>",
-      "startLine": 663,
-      "crap": 1
+      "startLine": 742,
+      "crap": 2.5
     },
     {
       "path": ".agents/scripts/lib/bootstrap/project-bootstrap.js",
       "method": "<anon method-19>",
-      "startLine": 668,
+      "startLine": 750,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/bootstrap/project-bootstrap.js",
       "method": "<anon method-20>",
-      "startLine": 673,
+      "startLine": 755,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/bootstrap/project-bootstrap.js",
       "method": "<anon method-21>",
-      "startLine": 680,
+      "startLine": 762,
       "crap": 2.5
     },
     {
       "path": ".agents/scripts/lib/bootstrap/project-bootstrap.js",
       "method": "<anon method-22>",
-      "startLine": 687,
+      "startLine": 769,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/bootstrap/project-bootstrap.js",
       "method": "isPhaseApproved",
-      "startLine": 703,
+      "startLine": 785,
       "crap": 3
     },
     {
       "path": ".agents/scripts/lib/bootstrap/project-bootstrap.js",
       "method": "throwIfFatal",
-      "startLine": 719,
+      "startLine": 801,
       "crap": 4
     },
     {
       "path": ".agents/scripts/lib/bootstrap/project-bootstrap.js",
       "method": "runPhases",
-      "startLine": 743,
+      "startLine": 825,
       "crap": 2
     },
     {
       "path": ".agents/scripts/lib/bootstrap/project-bootstrap.js",
       "method": "applyProjectBootstrap",
-      "startLine": 791,
-      "crap": 2.0625
+      "startLine": 873,
+      "crap": 3.6875
+    },
+    {
+      "path": ".agents/scripts/lib/bootstrap/prompt.js",
+      "method": "parseFlags",
+      "startLine": 60,
+      "crap": 10.04551661356395
+    },
+    {
+      "path": ".agents/scripts/lib/bootstrap/prompt.js",
+      "method": "parseGitRemoteUrl",
+      "startLine": 95,
+      "crap": 5
+    },
+    {
+      "path": ".agents/scripts/lib/bootstrap/prompt.js",
+      "method": "runGit",
+      "startLine": 110,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/bootstrap/prompt.js",
+      "method": "inferStoredProjectNumber",
+      "startLine": 131,
+      "crap": 4
+    },
+    {
+      "path": ".agents/scripts/lib/bootstrap/prompt.js",
+      "method": "inferDefaults",
+      "startLine": 158,
+      "crap": 4
+    },
+    {
+      "path": ".agents/scripts/lib/bootstrap/prompt.js",
+      "method": "resolveFromFlag",
+      "startLine": 216,
+      "crap": 3
+    },
+    {
+      "path": ".agents/scripts/lib/bootstrap/prompt.js",
+      "method": "resolveFromEnv",
+      "startLine": 229,
+      "crap": 4
+    },
+    {
+      "path": ".agents/scripts/lib/bootstrap/prompt.js",
+      "method": "resolveFromSilent",
+      "startLine": 245,
+      "crap": 4
+    },
+    {
+      "path": ".agents/scripts/lib/bootstrap/prompt.js",
+      "method": "resolveFromPicker",
+      "startLine": 279,
+      "crap": 12
+    },
+    {
+      "path": ".agents/scripts/lib/bootstrap/prompt.js",
+      "method": "<anon method-1>",
+      "startLine": 294,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/bootstrap/prompt.js",
+      "method": "normalizePickerChoice",
+      "startLine": 329,
+      "crap": 3
+    },
+    {
+      "path": ".agents/scripts/lib/bootstrap/prompt.js",
+      "method": "askOnce",
+      "startLine": 348,
+      "crap": 4
+    },
+    {
+      "path": ".agents/scripts/lib/bootstrap/prompt.js",
+      "method": "resolveInteractive",
+      "startLine": 363,
+      "crap": 7
+    },
+    {
+      "path": ".agents/scripts/lib/bootstrap/prompt.js",
+      "method": "resolveAssumeYes",
+      "startLine": 386,
+      "crap": 4
+    },
+    {
+      "path": ".agents/scripts/lib/bootstrap/prompt.js",
+      "method": "collectAnswers",
+      "startLine": 430,
+      "crap": 5
+    },
+    {
+      "path": ".agents/scripts/lib/bootstrap/prompt.js",
+      "method": "<anon method-2>",
+      "startLine": 444,
+      "crap": 1
     },
     {
       "path": ".agents/scripts/lib/bootstrap/quality-bootstrap.js",
       "method": "readJsonIfExists",
-      "startLine": 103,
+      "startLine": 101,
       "crap": 2
     },
     {
       "path": ".agents/scripts/lib/bootstrap/quality-bootstrap.js",
       "method": "writeJson",
-      "startLine": 109,
+      "startLine": 107,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/bootstrap/quality-bootstrap.js",
       "method": "ensureGuardrailsHelper",
-      "startLine": 126,
+      "startLine": 124,
       "crap": 3
     },
     {
       "path": ".agents/scripts/lib/bootstrap/quality-bootstrap.js",
       "method": "ensurePreCommitHook",
-      "startLine": 169,
+      "startLine": 167,
       "crap": 4
     },
     {
       "path": ".agents/scripts/lib/bootstrap/quality-bootstrap.js",
       "method": "ensureQualityNpmScripts",
-      "startLine": 212,
+      "startLine": 210,
       "crap": 6
     },
     {
       "path": ".agents/scripts/lib/bootstrap/quality-bootstrap.js",
       "method": "mergeMissingKeys",
-      "startLine": 259,
+      "startLine": 257,
       "crap": 13.057391173104255
     },
     {
       "path": ".agents/scripts/lib/bootstrap/quality-bootstrap.js",
       "method": "ensureQualityConfigDefaults",
-      "startLine": 312,
+      "startLine": 310,
       "crap": 7.000765625
     },
     {
       "path": ".agents/scripts/lib/bootstrap/quality-bootstrap.js",
       "method": "applyQualityBootstrap",
-      "startLine": 363,
+      "startLine": 361,
       "crap": 1
     },
     {
@@ -2691,36 +5878,42 @@
       "path": ".agents/scripts/lib/bootstrap/summary.js",
       "method": "printSummary",
       "startLine": 52,
-      "crap": 2
+      "crap": 1
     },
     {
       "path": ".agents/scripts/lib/bootstrap/workflow-audit.js",
       "method": "classifyWorkflow",
-      "startLine": 99,
+      "startLine": 101,
       "crap": 5
     },
     {
       "path": ".agents/scripts/lib/bootstrap/workflow-audit.js",
       "method": "auditProjectWorkflows",
-      "startLine": 129,
+      "startLine": 131,
       "crap": 8
     },
     {
       "path": ".agents/scripts/lib/bootstrap/workflow-audit.js",
       "method": "reapConflictingWorkflows",
-      "startLine": 180,
+      "startLine": 182,
       "crap": 6
     },
     {
       "path": ".agents/scripts/lib/bootstrap/workflow-audit.js",
+      "method": "<anon method-1>",
+      "startLine": 203,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/bootstrap/workflow-audit.js",
       "method": "resolveProjectIdByNumber",
-      "startLine": 220,
-      "crap": 5
+      "startLine": 231,
+      "crap": 5.014467592592593
     },
     {
       "path": ".agents/scripts/lib/bootstrap/workflow-audit.js",
       "method": "formatAuditSummary",
-      "startLine": 250,
+      "startLine": 263,
       "crap": 1
     },
     {
@@ -2740,6 +5933,24 @@
       "method": "parseNameOnlyStdout",
       "startLine": 14,
       "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/changed-files.js",
+      "method": "<anon method-1>",
+      "startLine": 18,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/changed-files.js",
+      "method": "<anon method-2>",
+      "startLine": 19,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/changed-files.js",
+      "method": "<anon method-3>",
+      "startLine": 20,
+      "crap": 1
     },
     {
       "path": ".agents/scripts/lib/changed-files.js",
@@ -2767,6 +5978,12 @@
     },
     {
       "path": ".agents/scripts/lib/checks/baseline-drift-main-checkout.js",
+      "method": "<anon method-1>",
+      "startLine": 51,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/checks/baseline-drift-main-checkout.js",
       "method": "isStoryBranch",
       "startLine": 82,
       "crap": 2
@@ -2780,80 +5997,128 @@
     {
       "path": ".agents/scripts/lib/checks/index.js",
       "method": "clearRegistryCache",
-      "startLine": 107,
+      "startLine": 108,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/checks/index.js",
       "method": "loadRegistry",
-      "startLine": 123,
-      "crap": 6.131087847064179
+      "startLine": 124,
+      "crap": 6.310726748596571
     },
     {
       "path": ".agents/scripts/lib/checks/index.js",
       "method": "getCheck",
-      "startLine": 172,
+      "startLine": 173,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/checks/index.js",
+      "method": "<anon method-1>",
+      "startLine": 175,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/checks/index.js",
       "method": "runChecks",
-      "startLine": 193,
+      "startLine": 194,
       "crap": 10
     },
     {
       "path": ".agents/scripts/lib/checks/index.js",
+      "method": "<anon method-2>",
+      "startLine": 206,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/checks/index.js",
+      "method": "<anon method-3>",
+      "startLine": 216,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/checks/index.js",
       "method": "isValidCheck",
-      "startLine": 268,
+      "startLine": 269,
       "crap": 12.99514091350826
     },
     {
       "path": ".agents/scripts/lib/checks/loop-health.js",
       "method": "resolveEpicTempTree",
-      "startLine": 60,
+      "startLine": 61,
       "crap": 6.009667349199423
     },
     {
       "path": ".agents/scripts/lib/checks/loop-health.js",
       "method": "findSignalStreams",
-      "startLine": 100,
+      "startLine": 101,
       "crap": 4
     },
     {
       "path": ".agents/scripts/lib/checks/loop-health.js",
       "method": "<anon method-1>",
-      "startLine": 104,
+      "startLine": 105,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/checks/loop-health.js",
       "method": "sampleStreamInvalidCount",
-      "startLine": 137,
+      "startLine": 138,
       "crap": 2
     },
     {
       "path": ".agents/scripts/lib/checks/loop-health.js",
+      "method": "<anon method-2>",
+      "startLine": 154,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/checks/loop-health.js",
       "method": "readRejectTally",
-      "startLine": 178,
+      "startLine": 179,
       "crap": 3
     },
     {
       "path": ".agents/scripts/lib/checks/loop-health.js",
       "method": "scanRetroMirror",
-      "startLine": 200,
+      "startLine": 201,
       "crap": 9
     },
     {
       "path": ".agents/scripts/lib/checks/loop-health.js",
       "method": "<anon method-3>",
-      "startLine": 208,
+      "startLine": 209,
       "crap": 4
     },
     {
       "path": ".agents/scripts/lib/checks/loop-health.js",
       "method": "detectLoopHealth",
-      "startLine": 251,
+      "startLine": 252,
       "crap": 7
+    },
+    {
+      "path": ".agents/scripts/lib/checks/loop-health.js",
+      "method": "<anon method-4>",
+      "startLine": 312,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/checks/push-hook-parity.js",
+      "method": "<anon method-1>",
+      "startLine": 54,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/checks/push-hook-parity.js",
+      "method": "<anon method-2>",
+      "startLine": 56,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/checks/push-hook-parity.js",
+      "method": "<anon method-3>",
+      "startLine": 69,
+      "crap": 1
     },
     {
       "path": ".agents/scripts/lib/checks/push-hook-parity.js",
@@ -2863,195 +6128,213 @@
     },
     {
       "path": ".agents/scripts/lib/checks/push-hook-parity.js",
+      "method": "<anon method-4>",
+      "startLine": 90,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/checks/push-hook-parity.js",
       "method": "indent",
       "startLine": 101,
       "crap": 1
     },
     {
+      "path": ".agents/scripts/lib/checks/push-hook-parity.js",
+      "method": "<anon method-5>",
+      "startLine": 104,
+      "crap": 1
+    },
+    {
       "path": ".agents/scripts/lib/checks/state.js",
       "method": "clearStateCache",
-      "startLine": 99,
+      "startLine": 95,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/checks/state.js",
       "method": "defaultGitProbe",
-      "startLine": 112,
+      "startLine": 108,
       "crap": 3
     },
     {
       "path": ".agents/scripts/lib/checks/state.js",
       "method": "defaultFsProbe",
-      "startLine": 126,
+      "startLine": 122,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/checks/state.js",
       "method": "defaultEnvProbe",
-      "startLine": 137,
+      "startLine": 133,
       "crap": 2
     },
     {
       "path": ".agents/scripts/lib/checks/state.js",
-      "method": "defaultLockProbe",
-      "startLine": 153,
-      "crap": 12
-    },
-    {
-      "path": ".agents/scripts/lib/checks/state.js",
-      "method": "validatePidProbeInputs",
-      "startLine": 186,
-      "crap": 6
-    },
-    {
-      "path": ".agents/scripts/lib/checks/state.js",
-      "method": "defaultPidLivenessProbe",
-      "startLine": 202,
-      "crap": 12
-    },
-    {
-      "path": ".agents/scripts/lib/checks/state.js",
       "method": "probeHeadRef",
-      "startLine": 222,
+      "startLine": 146,
       "crap": 2
     },
     {
       "path": ".agents/scripts/lib/checks/state.js",
       "method": "parseBranchList",
-      "startLine": 234,
+      "startLine": 158,
       "crap": 3
     },
     {
       "path": ".agents/scripts/lib/checks/state.js",
-      "method": "probeEpicBranches",
-      "startLine": 251,
+      "method": "<anon method-1>",
+      "startLine": 162,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/checks/state.js",
       "method": "probeLocalBranches",
-      "startLine": 266,
+      "startLine": 176,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/checks/state.js",
       "method": "probeCoreBare",
-      "startLine": 280,
+      "startLine": 190,
       "crap": 2
     },
     {
       "path": ".agents/scripts/lib/checks/state.js",
-      "method": "probeEpicBranchSync",
-      "startLine": 314,
-      "crap": 13
-    },
-    {
-      "path": ".agents/scripts/lib/checks/state.js",
       "method": "<anon method-2>",
-      "startLine": 373,
+      "startLine": 205,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/checks/state.js",
       "method": "<anon method-3>",
-      "startLine": 374,
+      "startLine": 206,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/checks/state.js",
       "method": "<anon method-4>",
-      "startLine": 375,
-      "crap": 1
-    },
-    {
-      "path": ".agents/scripts/lib/checks/state.js",
-      "method": "<anon method-5>",
-      "startLine": 376,
-      "crap": 1
-    },
-    {
-      "path": ".agents/scripts/lib/checks/state.js",
-      "method": "<anon method-6>",
-      "startLine": 377,
+      "startLine": 207,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/checks/state.js",
       "method": "probeGit",
-      "startLine": 392,
+      "startLine": 219,
       "crap": 3
     },
     {
       "path": ".agents/scripts/lib/checks/state.js",
       "method": "probeFs",
-      "startLine": 415,
-      "crap": 7
+      "startLine": 239,
+      "crap": 5
     },
     {
       "path": ".agents/scripts/lib/checks/state.js",
       "method": "probeEnv",
-      "startLine": 470,
+      "startLine": 262,
       "crap": 2
     },
     {
       "path": ".agents/scripts/lib/checks/state.js",
       "method": "assembleState",
-      "startLine": 500,
-      "crap": 9
+      "startLine": 292,
+      "crap": 5
     },
     {
       "path": ".agents/scripts/lib/checks/state.js",
       "method": "getScopeKeys",
-      "startLine": 556,
+      "startLine": 325,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/checks/story-init-not-backgrounded.js",
       "method": "walkSources",
-      "startLine": 58,
-      "crap": 7.019915663262714
+      "startLine": 60,
+      "crap": 21.518518518518523
     },
     {
       "path": ".agents/scripts/lib/checks/story-init-not-backgrounded.js",
       "method": "scanFile",
-      "startLine": 99,
-      "crap": 8
+      "startLine": 101,
+      "crap": 72
+    },
+    {
+      "path": ".agents/scripts/lib/checks/story-init-not-backgrounded.js",
+      "method": "<anon method-1>",
+      "startLine": 176,
+      "crap": 1.2282235939643347
     },
     {
       "path": ".agents/scripts/lib/checks/subagent-agent-tool-required.js",
       "method": "listWorkflowFiles",
-      "startLine": 69,
+      "startLine": 68,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/checks/subagent-agent-tool-required.js",
+      "method": "<anon method-1>",
+      "startLine": 76,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/checks/subagent-agent-tool-required.js",
+      "method": "<anon method-2>",
+      "startLine": 77,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/checks/subagent-agent-tool-required.js",
       "method": "splitFrontmatter",
-      "startLine": 88,
+      "startLine": 87,
       "crap": 4
     },
     {
       "path": ".agents/scripts/lib/checks/subagent-agent-tool-required.js",
       "method": "isSubAgentWorkflow",
-      "startLine": 110,
+      "startLine": 109,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/checks/subagent-agent-tool-required.js",
       "method": "findAgentToolDeclaration",
-      "startLine": 124,
+      "startLine": 123,
       "crap": 12
     },
     {
       "path": ".agents/scripts/lib/checks/subagent-agent-tool-required.js",
       "method": "parseDeclaredDepth",
-      "startLine": 166,
+      "startLine": 165,
       "crap": 3
     },
     {
       "path": ".agents/scripts/lib/checks/subagent-agent-tool-required.js",
       "method": "resolveCeiling",
-      "startLine": 187,
+      "startLine": 186,
       "crap": 3
+    },
+    {
+      "path": ".agents/scripts/lib/checks/subagent-agent-tool-required.js",
+      "method": "<anon method-3>",
+      "startLine": 244,
+      "crap": 1.0000877914951989
+    },
+    {
+      "path": ".agents/scripts/lib/checks/worktree-bootstrap-env.js",
+      "method": "<anon method-1>",
+      "startLine": 38,
+      "crap": 3
+    },
+    {
+      "path": ".agents/scripts/lib/checks/worktree-bootstrap-env.js",
+      "method": "<anon method-2>",
+      "startLine": 44,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/checks/worktree-bootstrap-env.js",
+      "method": "<anon method-3>",
+      "startLine": 47,
+      "crap": 1
     },
     {
       "path": ".agents/scripts/lib/checks/worktree-bootstrap-env.js",
@@ -3061,9 +6344,21 @@
     },
     {
       "path": ".agents/scripts/lib/checks/worktree-residue-biome.js",
+      "method": "<anon method-1>",
+      "startLine": 29,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/checks/worktree-residue-biome.js",
       "method": "buildFixCommand",
       "startLine": 50,
       "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/checks/worktree-residue-biome.js",
+      "method": "<anon method-2>",
+      "startLine": 54,
+      "crap": 1
     },
     {
       "path": ".agents/scripts/lib/cli-args.js",
@@ -3079,99 +6374,129 @@
     },
     {
       "path": ".agents/scripts/lib/cli-args.js",
+      "method": "optionalBooleanFlag",
+      "startLine": 44,
+      "crap": 2.0625
+    },
+    {
+      "path": ".agents/scripts/lib/cli-args.js",
+      "method": "parsePositiveInt",
+      "startLine": 59,
+      "crap": 5.2
+    },
+    {
+      "path": ".agents/scripts/lib/cli-args.js",
       "method": "parseSprintArgs",
-      "startLine": 49,
+      "startLine": 71,
       "crap": 4
     },
     {
       "path": ".agents/scripts/lib/cli-args.js",
       "method": "camelCase",
-      "startLine": 118,
+      "startLine": 148,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/cli-args.js",
+      "method": "<anon method-1>",
+      "startLine": 149,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/cli-args.js",
       "method": "initialValueFor",
-      "startLine": 122,
+      "startLine": 152,
       "crap": 4
     },
     {
       "path": ".agents/scripts/lib/cli-args.js",
       "method": "coerceValue",
-      "startLine": 129,
+      "startLine": 159,
       "crap": 4.074074074074074
     },
     {
       "path": ".agents/scripts/lib/cli-args.js",
       "method": "validateSpec",
-      "startLine": 161,
+      "startLine": 191,
       "crap": 2
     },
     {
       "path": ".agents/scripts/lib/cli-args.js",
       "method": "initParserState",
-      "startLine": 171,
+      "startLine": 201,
       "crap": 2
     },
     {
       "path": ".agents/scripts/lib/cli-args.js",
       "method": "classifyToken",
-      "startLine": 184,
+      "startLine": 214,
       "crap": 6
     },
     {
       "path": ".agents/scripts/lib/cli-args.js",
       "method": "assignFlagValue",
-      "startLine": 198,
+      "startLine": 228,
       "crap": 2
     },
     {
       "path": ".agents/scripts/lib/cli-args.js",
       "method": "readValuedFlag",
-      "startLine": 206,
+      "startLine": 236,
       "crap": 6
     },
     {
       "path": ".agents/scripts/lib/cli-args.js",
       "method": "parseTokens",
-      "startLine": 222,
+      "startLine": 252,
       "crap": 8.040303206997084
     },
     {
       "path": ".agents/scripts/lib/cli-args.js",
       "method": "isAbsentValue",
-      "startLine": 258,
+      "startLine": 288,
       "crap": 3
     },
     {
       "path": ".agents/scripts/lib/cli-args.js",
       "method": "applyEnvFallbacks",
-      "startLine": 264,
+      "startLine": 294,
       "crap": 6
     },
     {
       "path": ".agents/scripts/lib/cli-args.js",
       "method": "applyDefaults",
-      "startLine": 277,
+      "startLine": 307,
       "crap": 4
     },
     {
       "path": ".agents/scripts/lib/cli-args.js",
       "method": "defineFlags",
-      "startLine": 288,
+      "startLine": 318,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/cli-utils.js",
       "method": "isDirectInvocation",
-      "startLine": 28,
+      "startLine": 29,
       "crap": 2
     },
     {
       "path": ".agents/scripts/lib/cli-utils.js",
       "method": "runAsCli",
-      "startLine": 47,
-      "crap": 3
+      "startLine": 57,
+      "crap": 5
+    },
+    {
+      "path": ".agents/scripts/lib/cli-utils.js",
+      "method": "<anon method-1>",
+      "startLine": 70,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/cli-utils.js",
+      "method": "<anon method-2>",
+      "startLine": 72,
+      "crap": 2
     },
     {
       "path": ".agents/scripts/lib/cli/parse-numeric.js",
@@ -3188,80 +6513,314 @@
     {
       "path": ".agents/scripts/lib/cli/standard-args.js",
       "method": "camelCase",
+      "startLine": 96,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/cli/standard-args.js",
+      "method": "<anon method-1>",
       "startLine": 97,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/cli/standard-args.js",
       "method": "normaliseCallSignature",
-      "startLine": 110,
+      "startLine": 107,
       "crap": 4
     },
     {
       "path": ".agents/scripts/lib/cli/standard-args.js",
       "method": "buildDefineFlagsSpec",
-      "startLine": 128,
+      "startLine": 123,
       "crap": 3
     },
     {
       "path": ".agents/scripts/lib/cli/standard-args.js",
       "method": "knownFlagNames",
-      "startLine": 146,
+      "startLine": 141,
       "crap": 2
     },
     {
       "path": ".agents/scripts/lib/cli/standard-args.js",
       "method": "findUnknownFlag",
-      "startLine": 155,
+      "startLine": 150,
       "crap": 7
     },
     {
       "path": ".agents/scripts/lib/cli/standard-args.js",
       "method": "validateSchema",
-      "startLine": 172,
+      "startLine": 167,
       "crap": 5.048828125
     },
     {
       "path": ".agents/scripts/lib/cli/standard-args.js",
       "method": "validateExtras",
-      "startLine": 194,
+      "startLine": 189,
       "crap": 8.56681290745828
     },
     {
       "path": ".agents/scripts/lib/cli/standard-args.js",
       "method": "isAbsent",
-      "startLine": 228,
+      "startLine": 223,
       "crap": 14.25
     },
     {
       "path": ".agents/scripts/lib/cli/standard-args.js",
       "method": "throwMissing",
-      "startLine": 237,
+      "startLine": 232,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/cli/standard-args.js",
       "method": "enforceRequired",
-      "startLine": 250,
+      "startLine": 245,
       "crap": 5
     },
     {
       "path": ".agents/scripts/lib/cli/standard-args.js",
       "method": "enforceExtrasRequired",
-      "startLine": 262,
+      "startLine": 257,
       "crap": 5
     },
     {
       "path": ".agents/scripts/lib/cli/standard-args.js",
       "method": "normaliseValues",
-      "startLine": 279,
+      "startLine": 274,
       "crap": 18.2669677734375
     },
     {
       "path": ".agents/scripts/lib/cli/standard-args.js",
       "method": "parseStandardCliArgs",
-      "startLine": 320,
+      "startLine": 314,
       "crap": 3
+    },
+    {
+      "path": ".agents/scripts/lib/cli/standard-args.js",
+      "method": "<anon method-2>",
+      "startLine": 326,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/close-validation/commands.js",
+      "method": "buildFormatHint",
+      "startLine": 30,
+      "crap": 3
+    },
+    {
+      "path": ".agents/scripts/lib/close-validation/commands.js",
+      "method": "resolveCommandWithFallback",
+      "startLine": 47,
+      "crap": 3.0262390670553936
+    },
+    {
+      "path": ".agents/scripts/lib/close-validation/commands.js",
+      "method": "resolveTypecheckCommand",
+      "startLine": 71,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/close-validation/commands.js",
+      "method": "resolveFormatCheckCommand",
+      "startLine": 83,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/close-validation/commands.js",
+      "method": "resolveFormatWriteCommand",
+      "startLine": 99,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/close-validation/commands.js",
+      "method": "listChangedFilesForFormatGate",
+      "startLine": 117,
+      "crap": 10.921223958333334
+    },
+    {
+      "path": ".agents/scripts/lib/close-validation/commands.js",
+      "method": "<anon method-1>",
+      "startLine": 123,
+      "crap": 1.8801359953703705
+    },
+    {
+      "path": ".agents/scripts/lib/close-validation/commands.js",
+      "method": "isFormatterEligible",
+      "startLine": 176,
+      "crap": 10.078743741465637
+    },
+    {
+      "path": ".agents/scripts/lib/close-validation/gates.js",
+      "method": "buildChangedFileScope",
+      "startLine": 45,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/close-validation/gates.js",
+      "method": "buildBaselinesGateEnv",
+      "startLine": 70,
+      "crap": 3
+    },
+    {
+      "path": ".agents/scripts/lib/close-validation/gates.js",
+      "method": "isCrapGateEnabled",
+      "startLine": 89,
+      "crap": 4
+    },
+    {
+      "path": ".agents/scripts/lib/close-validation/gates.js",
+      "method": "buildTestGateEntry",
+      "startLine": 118,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/close-validation/gates.js",
+      "method": "enabledBaselineKinds",
+      "startLine": 136,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/close-validation/gates.js",
+      "method": "<anon method-1>",
+      "startLine": 138,
+      "crap": 3
+    },
+    {
+      "path": ".agents/scripts/lib/close-validation/gates.js",
+      "method": "baselinesRequiredByConfig",
+      "startLine": 154,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/close-validation/gates.js",
+      "method": "toKindSet",
+      "startLine": 158,
+      "crap": 3.072
+    },
+    {
+      "path": ".agents/scripts/lib/close-validation/gates.js",
+      "method": "probeBaselinesGate",
+      "startLine": 190,
+      "crap": 5
+    },
+    {
+      "path": ".agents/scripts/lib/close-validation/gates.js",
+      "method": "<anon method-2>",
+      "startLine": 201,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/close-validation/gates.js",
+      "method": "buildDefaultGates",
+      "startLine": 286,
+      "crap": 9
+    },
+    {
+      "path": ".agents/scripts/lib/close-validation/gates.js",
+      "method": "partitionGates",
+      "startLine": 405,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/close-validation/process.js",
+      "method": "pipePrefixed",
+      "startLine": 33,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/close-validation/process.js",
+      "method": "<anon method-1>",
+      "startLine": 36,
+      "crap": 3
+    },
+    {
+      "path": ".agents/scripts/lib/close-validation/process.js",
+      "method": "<anon method-2>",
+      "startLine": 47,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/close-validation/process.js",
+      "method": "<anon method-3>",
+      "startLine": 55,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/close-validation/process.js",
+      "method": "attachGateAbortHandler",
+      "startLine": 59,
+      "crap": 3
+    },
+    {
+      "path": ".agents/scripts/lib/close-validation/process.js",
+      "method": "<anon method-4>",
+      "startLine": 60,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/close-validation/process.js",
+      "method": "<anon method-5>",
+      "startLine": 61,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/close-validation/process.js",
+      "method": "<anon method-6>",
+      "startLine": 70,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/close-validation/process.js",
+      "method": "<anon method-7>",
+      "startLine": 73,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/close-validation/process.js",
+      "method": "gateExitCode",
+      "startLine": 77,
+      "crap": 3
+    },
+    {
+      "path": ".agents/scripts/lib/close-validation/process.js",
+      "method": "isBiomeNoFilesProcessed",
+      "startLine": 116,
+      "crap": 4.048
+    },
+    {
+      "path": ".agents/scripts/lib/close-validation/process.js",
+      "method": "defaultGateRunner",
+      "startLine": 149,
+      "crap": 5.330127723516153
+    },
+    {
+      "path": ".agents/scripts/lib/close-validation/process.js",
+      "method": "<anon method-8>",
+      "startLine": 162,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/close-validation/process.js",
+      "method": "<anon method-9>",
+      "startLine": 168,
+      "crap": 4.048
+    },
+    {
+      "path": ".agents/scripts/lib/close-validation/process.js",
+      "method": "<anon method-10>",
+      "startLine": 177,
+      "crap": 1.0132051089406462
+    },
+    {
+      "path": ".agents/scripts/lib/close-validation/process.js",
+      "method": "<anon method-11>",
+      "startLine": 182,
+      "crap": 4.211281743050338
+    },
+    {
+      "path": ".agents/scripts/lib/close-validation/process.js",
+      "method": "<anon method-12>",
+      "startLine": 198,
+      "crap": 1.0132051089406462
     },
     {
       "path": ".agents/scripts/lib/close-validation/projections/head-sha.js",
@@ -3324,21 +6883,75 @@
       "crap": 4
     },
     {
+      "path": ".agents/scripts/lib/close-validation/runner.js",
+      "method": "applyChangedFileScope",
+      "startLine": 26,
+      "crap": 5.592315839874638
+    },
+    {
+      "path": ".agents/scripts/lib/close-validation/runner.js",
+      "method": "runCloseValidation",
+      "startLine": 110,
+      "crap": 18.952739131450485
+    },
+    {
+      "path": ".agents/scripts/lib/close-validation/runner.js",
+      "method": "<anon method-1>",
+      "startLine": 143,
+      "crap": 11.442524417731029
+    },
+    {
+      "path": ".agents/scripts/lib/close-validation/runner.js",
+      "method": "<anon method-2>",
+      "startLine": 166,
+      "crap": 5.13508260447036
+    },
+    {
+      "path": ".agents/scripts/lib/close-validation/runner.js",
+      "method": "<anon method-3>",
+      "startLine": 199,
+      "crap": 6
+    },
+    {
+      "path": ".agents/scripts/lib/close-validation/runner.js",
+      "method": "<anon method-4>",
+      "startLine": 228,
+      "crap": 10.254291742087759
+    },
+    {
+      "path": ".agents/scripts/lib/close-validation/telemetry.js",
+      "method": "emitGhSpawnCount",
+      "startLine": 37,
+      "crap": 5.000314437722465
+    },
+    {
+      "path": ".agents/scripts/lib/command-header.js",
+      "method": "applyHeader",
+      "startLine": 27,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/command-header.js",
+      "method": "isCommandExcluded",
+      "startLine": 49,
+      "crap": 2
+    },
+    {
       "path": ".agents/scripts/lib/config-resolver.js",
       "method": "applyGithubDefaults",
-      "startLine": 77,
+      "startLine": 79,
       "crap": 2
     },
     {
       "path": ".agents/scripts/lib/config-resolver.js",
       "method": "applyCommandsDefaults",
-      "startLine": 90,
+      "startLine": 92,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/config-resolver.js",
       "method": "applyDeliveryDefaults",
-      "startLine": 100,
+      "startLine": 102,
       "crap": 1
     },
     {
@@ -3366,6 +6979,30 @@
       "crap": 14
     },
     {
+      "path": ".agents/scripts/lib/config-resolver.js",
+      "method": "<anon method-1>",
+      "startLine": 276,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/config/acceptance-eval.js",
+      "method": "clampRounds",
+      "startLine": 78,
+      "crap": 5
+    },
+    {
+      "path": ".agents/scripts/lib/config/acceptance-eval.js",
+      "method": "clampClusterCeiling",
+      "startLine": 99,
+      "crap": 5
+    },
+    {
+      "path": ".agents/scripts/lib/config/acceptance-eval.js",
+      "method": "getAcceptanceEval",
+      "startLine": 126,
+      "crap": 1
+    },
+    {
       "path": ".agents/scripts/lib/config/baselines.js",
       "method": "getBaselines",
       "startLine": 28,
@@ -3378,16 +7015,10 @@
       "crap": 1
     },
     {
-      "path": ".agents/scripts/lib/config/baselines.js",
-      "method": "resolveBaselines",
-      "startLine": 49,
-      "crap": 1.7702546296296295
-    },
-    {
       "path": ".agents/scripts/lib/config/ci.js",
       "method": "getCiDelivery",
-      "startLine": 33,
-      "crap": 7
+      "startLine": 27,
+      "crap": 5
     },
     {
       "path": ".agents/scripts/lib/config/commands.js",
@@ -3398,49 +7029,79 @@
     {
       "path": ".agents/scripts/lib/config/defaults.js",
       "method": "getAgentrcDefaults",
-      "startLine": 52,
+      "startLine": 56,
       "crap": 3
     },
     {
       "path": ".agents/scripts/lib/config/defaults.js",
       "method": "deepFreeze",
-      "startLine": 62,
+      "startLine": 66,
       "crap": 3
     },
     {
       "path": ".agents/scripts/lib/config/defaults.js",
       "method": "iterDefaultLeaves",
-      "startLine": 75,
+      "startLine": 79,
       "crap": 9.648
     },
     {
       "path": ".agents/scripts/lib/config/defaults.js",
       "method": "lookupPath",
-      "startLine": 98,
+      "startLine": 102,
       "crap": 7.06721536351166
+    },
+    {
+      "path": ".agents/scripts/lib/config/delivery-routing.js",
+      "method": "clampSampleRate",
+      "startLine": 54,
+      "crap": 5
+    },
+    {
+      "path": ".agents/scripts/lib/config/delivery-routing.js",
+      "method": "normalizeCeremonyProfile",
+      "startLine": 69,
+      "crap": 4.592592592592593
+    },
+    {
+      "path": ".agents/scripts/lib/config/delivery-routing.js",
+      "method": "getDeliveryRouting",
+      "startLine": 90,
+      "crap": 3
     },
     {
       "path": ".agents/scripts/lib/config/explain.js",
       "method": "isSecretKey",
-      "startLine": 277,
+      "startLine": 290,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/config/explain.js",
+      "method": "<anon method-1>",
+      "startLine": 293,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/config/explain.js",
+      "method": "<anon method-2>",
+      "startLine": 294,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/config/explain.js",
       "method": "meaningFor",
-      "startLine": 291,
+      "startLine": 304,
       "crap": 7
     },
     {
       "path": ".agents/scripts/lib/config/explain.js",
       "method": "attribute",
-      "startLine": 320,
+      "startLine": 333,
       "crap": 2
     },
     {
       "path": ".agents/scripts/lib/config/explain.js",
       "method": "explainConfig",
-      "startLine": 343,
+      "startLine": 356,
       "crap": 3
     },
     {
@@ -3452,31 +7113,31 @@
     {
       "path": ".agents/scripts/lib/config/limits.js",
       "method": "mergeSignals",
-      "startLine": 70,
+      "startLine": 73,
       "crap": 5
     },
     {
       "path": ".agents/scripts/lib/config/limits.js",
       "method": "resolveLimits",
       "startLine": 101,
-      "crap": 11
+      "crap": 7
     },
     {
       "path": ".agents/scripts/lib/config/limits.js",
       "method": "getLimits",
-      "startLine": 141,
+      "startLine": 128,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/config/limits.js",
       "method": "getSignals",
-      "startLine": 154,
+      "startLine": 141,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/config/limits.js",
       "method": "resolveLeaseTtlMs",
-      "startLine": 175,
+      "startLine": 162,
       "crap": 4
     },
     {
@@ -3494,103 +7155,115 @@
     {
       "path": ".agents/scripts/lib/config/quality.js",
       "method": "toleranceScalar",
-      "startLine": 170,
+      "startLine": 197,
       "crap": 5
     },
     {
       "path": ".agents/scripts/lib/config/quality.js",
       "method": "warnUnknownKeys",
-      "startLine": 182,
-      "crap": 2.0932944606413995
+      "startLine": 209,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/config/quality.js",
+      "method": "resolveResolutionRate",
+      "startLine": 237,
+      "crap": 5.2
     },
     {
       "path": ".agents/scripts/lib/config/quality.js",
       "method": "resolveMaintainabilityCrap",
-      "startLine": 200,
+      "startLine": 243,
       "crap": 4
     },
     {
       "path": ".agents/scripts/lib/config/quality.js",
       "method": "resolveMaintainabilityQuality",
-      "startLine": 262,
-      "crap": 5
+      "startLine": 310,
+      "crap": 7
     },
     {
       "path": ".agents/scripts/lib/config/quality.js",
       "method": "resolvePositiveIntegerMs",
-      "startLine": 308,
+      "startLine": 361,
       "crap": 4.592592592592593
     },
     {
       "path": ".agents/scripts/lib/config/quality.js",
       "method": "resolveFormatAutofix",
-      "startLine": 324,
+      "startLine": 377,
       "crap": 4.405097860719162
     },
     {
       "path": ".agents/scripts/lib/config/quality.js",
       "method": "resolveCoverageGate",
-      "startLine": 339,
+      "startLine": 392,
       "crap": 6
     },
     {
       "path": ".agents/scripts/lib/config/quality.js",
       "method": "resolveCodingGuardrails",
-      "startLine": 382,
+      "startLine": 440,
       "crap": 4
     },
     {
       "path": ".agents/scripts/lib/config/quality.js",
       "method": "resolveAutoRefresh",
-      "startLine": 414,
-      "crap": 14.25
+      "startLine": 471,
+      "crap": 10.700438722374841
     },
     {
       "path": ".agents/scripts/lib/config/quality.js",
       "method": "resolveBaselinesFromGates",
-      "startLine": 459,
+      "startLine": 509,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/config/quality.js",
       "method": "mergeFloorsWithDefaults",
-      "startLine": 495,
+      "startLine": 545,
       "crap": 5
     },
     {
       "path": ".agents/scripts/lib/config/quality.js",
       "method": "resolveGatesWithFloors",
-      "startLine": 534,
+      "startLine": 584,
       "crap": 4
     },
     {
       "path": ".agents/scripts/lib/config/quality.js",
       "method": "resolveQuality",
-      "startLine": 548,
+      "startLine": 598,
       "crap": 5
     },
     {
       "path": ".agents/scripts/lib/config/quality.js",
       "method": "assertEpsilonValue",
-      "startLine": 608,
+      "startLine": 660,
       "crap": 4
     },
     {
       "path": ".agents/scripts/lib/config/quality.js",
       "method": "resolveBaselineEpsilon",
-      "startLine": 619,
+      "startLine": 671,
       "crap": 4
     },
     {
       "path": ".agents/scripts/lib/config/quality.js",
       "method": "getBaselineEpsilon",
-      "startLine": 644,
+      "startLine": 696,
       "crap": 2
     },
     {
       "path": ".agents/scripts/lib/config/quality.js",
       "method": "getQuality",
-      "startLine": 661,
+      "startLine": 713,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/config/runners.js",
+      "method": "getRunners",
+      "startLine": 59,
       "crap": 1
     },
     {
@@ -3636,141 +7309,159 @@
       "crap": 2
     },
     {
+      "path": ".agents/scripts/lib/config/sync-agentrc.js",
+      "method": "syncAgentrc",
+      "startLine": 61,
+      "crap": 4
+    },
+    {
+      "path": ".agents/scripts/lib/config/sync-agentrc.js",
+      "method": "<anon method-1>",
+      "startLine": 95,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/config/sync-agentrc.js",
+      "method": "collectRedundantAdvisories",
+      "startLine": 131,
+      "crap": 5
+    },
+    {
+      "path": ".agents/scripts/lib/config/sync-agentrc.js",
+      "method": "isLeafSchemaRemovable",
+      "startLine": 176,
+      "crap": 11
+    },
+    {
+      "path": ".agents/scripts/lib/config/sync-agentrc.js",
+      "method": "formatSyncReport",
+      "startLine": 204,
+      "crap": 4
+    },
+    {
+      "path": ".agents/scripts/lib/config/sync-agentrc.js",
+      "method": "<anon method-2>",
+      "startLine": 216,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/config/sync-agentrc.js",
+      "method": "previewValue",
+      "startLine": 234,
+      "crap": 3.072
+    },
+    {
       "path": ".agents/scripts/lib/config/temp-paths.js",
       "method": "mainCheckoutRoot",
-      "startLine": 84,
+      "startLine": 85,
       "crap": 6
     },
     {
       "path": ".agents/scripts/lib/config/temp-paths.js",
       "method": "_clearMainCheckoutRootCache",
-      "startLine": 114,
+      "startLine": 115,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/config/temp-paths.js",
+      "method": "testScratchTempRoot",
+      "startLine": 145,
+      "crap": 4
+    },
+    {
+      "path": ".agents/scripts/lib/config/temp-paths.js",
+      "method": "_clearTestContextScratchCache",
+      "startLine": 175,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/config/temp-paths.js",
+      "method": "inNodeTestContext",
+      "startLine": 190,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/config/temp-paths.js",
       "method": "anchorTempRoot",
-      "startLine": 130,
-      "crap": 3
+      "startLine": 230,
+      "crap": 8
     },
     {
       "path": ".agents/scripts/lib/config/temp-paths.js",
       "method": "tempRootFrom",
-      "startLine": 149,
+      "startLine": 268,
       "crap": 5
     },
     {
       "path": ".agents/scripts/lib/config/temp-paths.js",
       "method": "<anon method-1>",
-      "startLine": 158,
+      "startLine": 277,
       "crap": 3
     },
     {
       "path": ".agents/scripts/lib/config/temp-paths.js",
       "method": "<anon method-2>",
-      "startLine": 174,
+      "startLine": 291,
       "crap": 4
     },
     {
       "path": ".agents/scripts/lib/config/temp-paths.js",
       "method": "<anon method-3>",
-      "startLine": 184,
+      "startLine": 301,
       "crap": 3
     },
     {
       "path": ".agents/scripts/lib/config/temp-paths.js",
       "method": "<anon method-4>",
-      "startLine": 193,
+      "startLine": 310,
       "crap": 6
     },
     {
       "path": ".agents/scripts/lib/config/temp-paths.js",
       "method": "runTempDir",
-      "startLine": 215,
-      "crap": 1
-    },
-    {
-      "path": ".agents/scripts/lib/config/temp-paths.js",
-      "method": "epicTempDir",
-      "startLine": 220,
+      "startLine": 332,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/config/temp-paths.js",
       "method": "storyTempDir",
-      "startLine": 244,
+      "startLine": 356,
       "crap": 2
     },
     {
       "path": ".agents/scripts/lib/config/temp-paths.js",
       "method": "signalsFile",
-      "startLine": 262,
+      "startLine": 374,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/config/temp-paths.js",
       "method": "<anon method-5>",
-      "startLine": 287,
+      "startLine": 399,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/config/temp-paths.js",
-      "method": "epicArtifactPath",
-      "startLine": 301,
+      "method": "runArtifactPath",
+      "startLine": 413,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/config/temp-paths.js",
       "method": "storyArtifactPath",
-      "startLine": 316,
+      "startLine": 427,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/config/temp-paths.js",
       "method": "<anon method-6>",
-      "startLine": 322,
+      "startLine": 444,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/config/temp-paths.js",
       "method": "<anon method-7>",
-      "startLine": 324,
-      "crap": 1
-    },
-    {
-      "path": ".agents/scripts/lib/config/temp-paths.js",
-      "method": "<anon method-8>",
-      "startLine": 326,
-      "crap": 1
-    },
-    {
-      "path": ".agents/scripts/lib/config/temp-paths.js",
-      "method": "<anon method-9>",
-      "startLine": 328,
-      "crap": 1
-    },
-    {
-      "path": ".agents/scripts/lib/config/temp-paths.js",
-      "method": "<anon method-10>",
-      "startLine": 344,
-      "crap": 1
-    },
-    {
-      "path": ".agents/scripts/lib/config/temp-paths.js",
-      "method": "<anon method-11>",
-      "startLine": 360,
-      "crap": 1
-    },
-    {
-      "path": ".agents/scripts/lib/config/temp-paths.js",
-      "method": "<anon method-12>",
-      "startLine": 365,
-      "crap": 1
-    },
-    {
-      "path": ".agents/scripts/lib/config/temp-paths.js",
-      "method": "<anon method-13>",
-      "startLine": 367,
+      "startLine": 449,
       "crap": 1
     },
     {
@@ -3781,9 +7472,15 @@
     },
     {
       "path": ".agents/scripts/lib/config/worktree-isolation.js",
+      "method": "defaultNodeModulesStrategy",
+      "startLine": 25,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/config/worktree-isolation.js",
       "method": "getWorktreeIsolation",
-      "startLine": 32,
-      "crap": 7
+      "startLine": 61,
+      "crap": 6
     },
     {
       "path": ".agents/scripts/lib/coverage-baseline.js",
@@ -3808,6 +7505,12 @@
       "method": "<anon method-2>",
       "startLine": 51,
       "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/coverage-baseline.js",
+      "method": "<anon method-3>",
+      "startLine": 52,
+      "crap": 2
     },
     {
       "path": ".agents/scripts/lib/coverage-baseline.js",
@@ -3865,6 +7568,12 @@
     },
     {
       "path": ".agents/scripts/lib/coverage-baseline.js",
+      "method": "<anon method-5>",
+      "startLine": 198,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/coverage-baseline.js",
       "method": "writeEnvelopeViaFsImpl",
       "startLine": 209,
       "crap": 1
@@ -3902,31 +7611,97 @@
     {
       "path": ".agents/scripts/lib/coverage-capture.js",
       "method": "newestSourceMtime",
-      "startLine": 30,
+      "startLine": 31,
       "crap": 2.0054869684499312
     },
     {
       "path": ".agents/scripts/lib/coverage-capture.js",
       "method": "<anon method-1>",
-      "startLine": 35,
+      "startLine": 36,
       "crap": 8.296296296296296
     },
     {
       "path": ".agents/scripts/lib/coverage-capture.js",
+      "method": "captureStampPath",
+      "startLine": 79,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/coverage-capture.js",
+      "method": "computeContentDigest",
+      "startLine": 103,
+      "crap": 4.001404663923182
+    },
+    {
+      "path": ".agents/scripts/lib/coverage-capture.js",
+      "method": "<anon method-2>",
+      "startLine": 107,
+      "crap": 2.0003511659807955
+    },
+    {
+      "path": ".agents/scripts/lib/coverage-capture.js",
+      "method": "<anon method-3>",
+      "startLine": 111,
+      "crap": 4
+    },
+    {
+      "path": ".agents/scripts/lib/coverage-capture.js",
+      "method": "<anon method-4>",
+      "startLine": 123,
+      "crap": 1.0000877914951989
+    },
+    {
+      "path": ".agents/scripts/lib/coverage-capture.js",
+      "method": "<anon method-5>",
+      "startLine": 130,
+      "crap": 1.0000877914951989
+    },
+    {
+      "path": ".agents/scripts/lib/coverage-capture.js",
+      "method": "writeCaptureStamp",
+      "startLine": 162,
+      "crap": 3
+    },
+    {
+      "path": ".agents/scripts/lib/coverage-capture.js",
       "method": "isCoverageFresh",
-      "startLine": 83,
-      "crap": 4.006503073718437
+      "startLine": 206,
+      "crap": 10.007705421727364
     },
     {
       "path": ".agents/scripts/lib/coverage-capture.js",
       "method": "anyChangedUnderTargets",
-      "startLine": 123,
+      "startLine": 266,
       "crap": 5
     },
     {
       "path": ".agents/scripts/lib/coverage-capture.js",
+      "method": "<anon method-6>",
+      "startLine": 270,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/coverage-capture.js",
+      "method": "<anon method-7>",
+      "startLine": 271,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/coverage-capture.js",
+      "method": "<anon method-8>",
+      "startLine": 272,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/coverage-capture.js",
+      "method": "<anon method-9>",
+      "startLine": 274,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/coverage-capture.js",
       "method": "runCapture",
-      "startLine": 163,
+      "startLine": 306,
       "crap": 5
     },
     {
@@ -3974,25 +7749,31 @@
     {
       "path": ".agents/scripts/lib/coverage-utils.js",
       "method": "buildEntryIndex",
-      "startLine": 129,
-      "crap": 10
+      "startLine": 131,
+      "crap": 13
+    },
+    {
+      "path": ".agents/scripts/lib/coverage-utils.js",
+      "method": "resolveFnRangeForLine",
+      "startLine": 219,
+      "crap": 13
     },
     {
       "path": ".agents/scripts/lib/coverage-utils.js",
       "method": "getEntryIndex",
-      "startLine": 173,
+      "startLine": 252,
       "crap": 4
     },
     {
       "path": ".agents/scripts/lib/coverage-utils.js",
       "method": "coverageForMethodInEntry",
-      "startLine": 204,
-      "crap": 10
+      "startLine": 289,
+      "crap": 7
     },
     {
       "path": ".agents/scripts/lib/coverage-utils.js",
       "method": "coverageByMethod",
-      "startLine": 235,
+      "startLine": 318,
       "crap": 2
     },
     {
@@ -4004,116 +7785,260 @@
     {
       "path": ".agents/scripts/lib/cpu-pool.js",
       "method": "runOnPool",
-      "startLine": 75,
+      "startLine": 89,
       "crap": 3.00079012345679
     },
     {
       "path": ".agents/scripts/lib/cpu-pool.js",
       "method": "runWorker",
-      "startLine": 89,
+      "startLine": 103,
       "crap": 9.015113702623907
     },
     {
       "path": ".agents/scripts/lib/cpu-pool.js",
+      "method": "<anon method-2>",
+      "startLine": 112,
+      "crap": 1.0001865889212829
+    },
+    {
+      "path": ".agents/scripts/lib/cpu-pool.js",
+      "method": "<anon method-3>",
+      "startLine": 152,
+      "crap": 2.000746355685131
+    },
+    {
+      "path": ".agents/scripts/lib/cpu-pool.js",
+      "method": "<anon method-4>",
+      "startLine": 162,
+      "crap": 1.0001865889212829
+    },
+    {
+      "path": ".agents/scripts/lib/cpu-pool.js",
+      "method": "<anon method-5>",
+      "startLine": 174,
+      "crap": 1.0000877914951989
+    },
+    {
+      "path": ".agents/scripts/lib/cpu-pool.js",
       "method": "dispatchOne",
-      "startLine": 172,
+      "startLine": 186,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/cpu-pool.js",
+      "method": "<anon method-6>",
+      "startLine": 187,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/cpu-pool.js",
       "method": "<anon method-7>",
-      "startLine": 174,
+      "startLine": 188,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/cpu-pool.js",
       "method": "<anon method-8>",
-      "startLine": 179,
+      "startLine": 193,
       "crap": 6
     },
     {
       "path": ".agents/scripts/lib/cpu-pool.js",
       "method": "<anon method-9>",
-      "startLine": 199,
+      "startLine": 213,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/cpu-pool.js",
       "method": "<anon method-10>",
-      "startLine": 203,
+      "startLine": 217,
       "crap": 2
     },
     {
       "path": ".agents/scripts/lib/crap-engine.js",
+      "method": "methodRowsFromReport",
+      "startLine": 33,
+      "crap": 6
+    },
+    {
+      "path": ".agents/scripts/lib/crap-engine.js",
+      "method": "finalizeMethodRows",
+      "startLine": 80,
+      "crap": 7.017857142857143
+    },
+    {
+      "path": ".agents/scripts/lib/crap-engine.js",
       "method": "calculateCrapForSource",
-      "startLine": 31,
-      "crap": 4
+      "startLine": 135,
+      "crap": 1
     },
     {
       "path": ".agents/scripts/lib/crap-engine.js",
       "method": "crapFormula",
-      "startLine": 67,
+      "startLine": 157,
       "crap": 3
     },
     {
       "path": ".agents/scripts/lib/crap-engine.js",
       "method": "deriveFixGuidance",
-      "startLine": 98,
+      "startLine": 188,
       "crap": 6
     },
     {
       "path": ".agents/scripts/lib/crap-utils.js",
       "method": "resolveEscomplexVersion",
-      "startLine": 43,
+      "startLine": 42,
       "crap": 7.019915663262714
     },
     {
       "path": ".agents/scripts/lib/crap-utils.js",
       "method": "resolveBaselinePath",
-      "startLine": 71,
+      "startLine": 70,
       "crap": 5.5026296018031555
     },
     {
       "path": ".agents/scripts/lib/crap-utils.js",
       "method": "projectCrapEnvelopeToLegacy",
-      "startLine": 107,
+      "startLine": 106,
       "crap": 6.662000000000001
     },
     {
       "path": ".agents/scripts/lib/crap-utils.js",
+      "method": "<anon method-1>",
+      "startLine": 118,
+      "crap": 1.166375
+    },
+    {
+      "path": ".agents/scripts/lib/crap-utils.js",
       "method": "getCrapBaseline",
-      "startLine": 128,
+      "startLine": 127,
       "crap": 10.872684714024018
     },
     {
       "path": ".agents/scripts/lib/crap-utils.js",
       "method": "buildBaselineEnvelope",
-      "startLine": 179,
+      "startLine": 178,
       "crap": 3
     },
     {
       "path": ".agents/scripts/lib/crap-utils.js",
+      "method": "<anon method-2>",
+      "startLine": 188,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/crap-utils.js",
+      "method": "<anon method-3>",
+      "startLine": 194,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/crap-utils.js",
+      "method": "newResolutionAccumulator",
+      "startLine": 223,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/crap-utils.js",
+      "method": "accumulateResolution",
+      "startLine": 227,
+      "crap": 4.096168294515402
+    },
+    {
+      "path": ".agents/scripts/lib/crap-utils.js",
+      "method": "summarizeResolution",
+      "startLine": 239,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/crap-utils.js",
+      "method": "<anon method-4>",
+      "startLine": 241,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/crap-utils.js",
+      "method": "checkResolutionFloor",
+      "startLine": 279,
+      "crap": 5.025
+    },
+    {
+      "path": ".agents/scripts/lib/crap-utils.js",
+      "method": "<anon method-5>",
+      "startLine": 285,
+      "crap": 1.001
+    },
+    {
+      "path": ".agents/scripts/lib/crap-utils.js",
       "method": "analyzeOnce",
-      "startLine": 233,
-      "crap": 5.0164379058107995
+      "startLine": 333,
+      "crap": 2.0196520000000002
     },
     {
       "path": ".agents/scripts/lib/crap-utils.js",
       "method": "scanAndScore",
-      "startLine": 300,
-      "crap": 14.48671242042824
+      "startLine": 389,
+      "crap": 14.962948
     },
     {
       "path": ".agents/scripts/lib/crap-utils.js",
-      "method": "scoreFileSerial",
-      "startLine": 405,
-      "crap": 9.03237369139736
+      "method": "<anon method-6>",
+      "startLine": 435,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/crap-utils.js",
+      "method": "<anon method-7>",
+      "startLine": 473,
+      "crap": 6.627343392775492
     },
     {
       "path": ".agents/scripts/lib/crap-utils.js",
       "method": "scoreFilesViaPool",
-      "startLine": 458,
-      "crap": 1.0117392937640872
+      "startLine": 533,
+      "crap": 1.032768
+    },
+    {
+      "path": ".agents/scripts/lib/crap-utils.js",
+      "method": "<anon method-8>",
+      "startLine": 537,
+      "crap": 1.032768
+    },
+    {
+      "path": ".agents/scripts/lib/crap-utils.js",
+      "method": "<anon method-9>",
+      "startLine": 544,
+      "crap": 3.294912
+    },
+    {
+      "path": ".agents/scripts/lib/crap-utils.js",
+      "method": "scanAndScoreCombined",
+      "startLine": 700,
+      "crap": 19.201693172062658
+    },
+    {
+      "path": ".agents/scripts/lib/dead-exports-knip.js",
+      "method": "runKnip",
+      "startLine": 33,
+      "crap": 7.0760588790028285
+    },
+    {
+      "path": ".agents/scripts/lib/dead-exports-knip.js",
+      "method": "readKnipOutput",
+      "startLine": 70,
+      "crap": 1.0233236151603498
+    },
+    {
+      "path": ".agents/scripts/lib/dead-exports-knip.js",
+      "method": "extractRowsFromKnip",
+      "startLine": 87,
+      "crap": 14
+    },
+    {
+      "path": ".agents/scripts/lib/dead-exports-mode.js",
+      "method": "resolveDeadExportsMode",
+      "startLine": 43,
+      "crap": 2
     },
     {
       "path": ".agents/scripts/lib/degraded-mode.js",
@@ -4142,139 +8067,301 @@
     {
       "path": ".agents/scripts/lib/dependency-parser.js",
       "method": "parseBlockedBy",
-      "startLine": 16,
+      "startLine": 17,
       "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/dependency-parser.js",
+      "method": "<anon method-1>",
+      "startLine": 20,
+      "crap": 1
     },
     {
       "path": ".agents/scripts/lib/dependency-parser.js",
       "method": "parseBlocks",
-      "startLine": 29,
+      "startLine": 30,
       "crap": 2
     },
     {
       "path": ".agents/scripts/lib/dependency-parser.js",
+      "method": "<anon method-2>",
+      "startLine": 33,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/dependency-parser.js",
       "method": "extractEpicIdFromBody",
-      "startLine": 45,
+      "startLine": 46,
       "crap": 3
     },
     {
       "path": ".agents/scripts/lib/dependency-parser.js",
       "method": "isSafeBranchComponent",
-      "startLine": 58,
+      "startLine": 59,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/dependency-parser.js",
       "method": "parseTaskMetadata",
-      "startLine": 90,
+      "startLine": 91,
       "crap": 6
     },
     {
       "path": ".agents/scripts/lib/dependency-parser.js",
       "method": "extractField",
-      "startLine": 106,
+      "startLine": 107,
       "crap": 3
     },
     {
       "path": ".agents/scripts/lib/dependency-parser.js",
       "method": "extractList",
-      "startLine": 112,
+      "startLine": 113,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/dependency-parser.js",
+      "method": "<anon method-4>",
+      "startLine": 118,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/detect-package-manager.js",
+      "method": "detectPackageManager",
+      "startLine": 42,
+      "crap": 6
+    },
+    {
+      "path": ".agents/scripts/lib/detect-package-manager.js",
+      "method": "detectPackageManagerWithWorkspace",
+      "startLine": 64,
       "crap": 2
     },
     {
       "path": ".agents/scripts/lib/doc-tiers.js",
       "method": "parseImportSpecifiers",
-      "startLine": 98,
+      "startLine": 107,
       "crap": 5
     },
     {
       "path": ".agents/scripts/lib/doc-tiers.js",
       "method": "toRepoRel",
-      "startLine": 118,
+      "startLine": 127,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/doc-tiers.js",
       "method": "fileEntry",
-      "startLine": 131,
+      "startLine": 140,
       "crap": 2.0240420736288502
     },
     {
       "path": ".agents/scripts/lib/doc-tiers.js",
       "method": "resolveAlwaysLoadedClosure",
-      "startLine": 155,
+      "startLine": 164,
       "crap": 7.0077389295796895
     },
     {
       "path": ".agents/scripts/lib/doc-tiers.js",
+      "method": "<anon method-1>",
+      "startLine": 199,
+      "crap": 1.0001579373383611
+    },
+    {
+      "path": ".agents/scripts/lib/doc-tiers.js",
       "method": "docsContextPaths",
-      "startLine": 202,
+      "startLine": 211,
       "crap": 3
     },
     {
       "path": ".agents/scripts/lib/doc-tiers.js",
+      "method": "<anon method-2>",
+      "startLine": 220,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/doc-tiers.js",
       "method": "resolveDocTiers",
-      "startLine": 228,
+      "startLine": 250,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/doc-tiers.js",
       "method": "<anon method-3>",
-      "startLine": 233,
+      "startLine": 255,
       "crap": 3
     },
     {
       "path": ".agents/scripts/lib/doc-tiers.js",
+      "method": "<anon method-4>",
+      "startLine": 264,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/doc-tiers.js",
+      "method": "<anon method-5>",
+      "startLine": 279,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/doc-tiers.js",
+      "method": "<anon method-6>",
+      "startLine": 295,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/doc-tiers.js",
+      "method": "<anon method-7>",
+      "startLine": 296,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/doc-tiers.js",
       "method": "listAgentDefs",
-      "startLine": 281,
+      "startLine": 324,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/doc-tiers.js",
+      "method": "<anon method-8>",
+      "startLine": 333,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/doc-tiers.js",
+      "method": "<anon method-9>",
+      "startLine": 334,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/doc-tiers.js",
       "method": "listOnDemandRules",
-      "startLine": 304,
+      "startLine": 347,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/doc-tiers.js",
+      "method": "<anon method-10>",
+      "startLine": 356,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/doc-tiers.js",
+      "method": "<anon method-11>",
+      "startLine": 357,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/doc-tiers.js",
       "method": "tierTotalBytes",
-      "startLine": 324,
+      "startLine": 367,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/doc-tiers.js",
+      "method": "<anon method-12>",
+      "startLine": 368,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/duplicate-search.js",
       "method": "tokenize",
-      "startLine": 85,
+      "startLine": 111,
       "crap": 3
+    },
+    {
+      "path": ".agents/scripts/lib/duplicate-search.js",
+      "method": "<anon method-1>",
+      "startLine": 117,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/duplicate-search.js",
+      "method": "pickSearchTokens",
+      "startLine": 129,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/duplicate-search.js",
+      "method": "<anon method-2>",
+      "startLine": 132,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/duplicate-search.js",
+      "method": "buildOpenStorySearchQuery",
+      "startLine": 143,
+      "crap": 1
     },
     {
       "path": ".agents/scripts/lib/duplicate-search.js",
       "method": "overlapScore",
-      "startLine": 102,
+      "startLine": 155,
       "crap": 7
     },
     {
       "path": ".agents/scripts/lib/duplicate-search.js",
-      "method": "buildEpicUrl",
-      "startLine": 118,
-      "crap": 5.048828125
+      "method": "buildIssueUrl",
+      "startLine": 171,
+      "crap": 5
     },
     {
       "path": ".agents/scripts/lib/duplicate-search.js",
-      "method": "findSimilarOpenEpics",
-      "startLine": 141,
-      "crap": 11
+      "method": "normalizeIssue",
+      "startLine": 186,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/duplicate-search.js",
+      "method": "rankOpenStoryDuplicates",
+      "startLine": 210,
+      "crap": 11.090909090909092
+    },
+    {
+      "path": ".agents/scripts/lib/duplicate-search.js",
+      "method": "<anon method-3>",
+      "startLine": 230,
+      "crap": 1.0007513148009015
+    },
+    {
+      "path": ".agents/scripts/lib/duplicate-search.js",
+      "method": "<anon method-4>",
+      "startLine": 230,
+      "crap": 1.0007513148009015
+    },
+    {
+      "path": ".agents/scripts/lib/duplicate-search.js",
+      "method": "<anon method-5>",
+      "startLine": 251,
+      "crap": 1.0007513148009015
+    },
+    {
+      "path": ".agents/scripts/lib/duplicate-search.js",
+      "method": "fetchOpenStoriesViaSearch",
+      "startLine": 262,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/duplicate-search.js",
+      "method": "fetchOpenStoriesViaList",
+      "startLine": 275,
+      "crap": 3.262175694128357
+    },
+    {
+      "path": ".agents/scripts/lib/duplicate-search.js",
+      "method": "fetchOpenStoryCandidates",
+      "startLine": 305,
+      "crap": 10.022261179285973
+    },
+    {
+      "path": ".agents/scripts/lib/duplicate-search.js",
+      "method": "findSimilarOpenStories",
+      "startLine": 354,
+      "crap": 4
     },
     {
       "path": ".agents/scripts/lib/dynamic-workflow/architecture-report-contract.js",
       "method": "assertReportContract",
-      "startLine": 63,
-      "crap": 3
-    },
-    {
-      "path": ".agents/scripts/lib/dynamic-workflow/architecture-report-contract.js",
-      "method": "escapeRegExp",
-      "startLine": 82,
+      "startLine": 65,
       "crap": 1
     },
     {
@@ -4296,6 +8383,36 @@
       "crap": 1
     },
     {
+      "path": ".agents/scripts/lib/dynamic-workflow/audit-orchestrator.js",
+      "method": "<anon method-2>",
+      "startLine": 153,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/dynamic-workflow/audit-orchestrator.js",
+      "method": "<anon method-3>",
+      "startLine": 155,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/dynamic-workflow/audit-orchestrator.js",
+      "method": "<anon method-4>",
+      "startLine": 167,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/dynamic-workflow/audit-orchestrator.js",
+      "method": "<anon method-5>",
+      "startLine": 169,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/dynamic-workflow/audit-orchestrator.js",
+      "method": "<anon method-6>",
+      "startLine": 182,
+      "crap": 1
+    },
+    {
       "path": ".agents/scripts/lib/dynamic-workflow/capability.js",
       "method": "isFlagSet",
       "startLine": 121,
@@ -4312,6 +8429,12 @@
       "method": "<anon method-1>",
       "startLine": 136,
       "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/dynamic-workflow/capability.js",
+      "method": "<anon method-2>",
+      "startLine": 142,
+      "crap": 2
     },
     {
       "path": ".agents/scripts/lib/dynamic-workflow/capability.js",
@@ -4346,49 +8469,49 @@
     {
       "path": ".agents/scripts/lib/dynamic-workflow/clean-code-report-contract.js",
       "method": "assertReportContract",
-      "startLine": 73,
-      "crap": 3
+      "startLine": 75,
+      "crap": 1
     },
     {
-      "path": ".agents/scripts/lib/dynamic-workflow/clean-code-report-contract.js",
-      "method": "escapeRegExp",
-      "startLine": 92,
+      "path": ".agents/scripts/lib/dynamic-workflow/documentation-report-contract.js",
+      "method": "assertReportContract",
+      "startLine": 82,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/dynamic-workflow/performance-report-contract.js",
       "method": "assertReportContract",
-      "startLine": 65,
-      "crap": 3
-    },
-    {
-      "path": ".agents/scripts/lib/dynamic-workflow/performance-report-contract.js",
-      "method": "escapeRegExp",
-      "startLine": 84,
+      "startLine": 69,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/dynamic-workflow/quality-report-contract.js",
       "method": "assertReportContract",
-      "startLine": 83,
+      "startLine": 85,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/dynamic-workflow/report-contract-core.js",
+      "method": "assertSectionsContract",
+      "startLine": 23,
       "crap": 3
     },
     {
-      "path": ".agents/scripts/lib/dynamic-workflow/quality-report-contract.js",
+      "path": ".agents/scripts/lib/dynamic-workflow/report-contract-core.js",
+      "method": "<anon method-1>",
+      "startLine": 30,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/dynamic-workflow/report-contract-core.js",
       "method": "escapeRegExp",
-      "startLine": 102,
+      "startLine": 41,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/dynamic-workflow/security-report-contract.js",
       "method": "assertReportContract",
-      "startLine": 76,
-      "crap": 3
-    },
-    {
-      "path": ".agents/scripts/lib/dynamic-workflow/security-report-contract.js",
-      "method": "escapeRegExp",
-      "startLine": 95,
+      "startLine": 78,
       "crap": 1
     },
     {
@@ -4396,6 +8519,12 @@
       "method": "loadEnv",
       "startLine": 8,
       "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/env-loader.js",
+      "method": "<anon method-1>",
+      "startLine": 30,
+      "crap": 9
     },
     {
       "path": ".agents/scripts/lib/error-redactor.js",
@@ -4434,52 +8563,418 @@
       "crap": 2
     },
     {
+      "path": ".agents/scripts/lib/feedback-loop/audit-results-graduator.js",
+      "method": "metaSourceLabel",
+      "startLine": 88,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/feedback-loop/audit-results-graduator.js",
+      "method": "buildIdempotencyMarker",
+      "startLine": 108,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/feedback-loop/audit-results-graduator.js",
+      "method": "buildContentMarker",
+      "startLine": 126,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/feedback-loop/audit-results-graduator.js",
+      "method": "toCanonicalFinding",
+      "startLine": 149,
+      "crap": 5
+    },
+    {
+      "path": ".agents/scripts/lib/feedback-loop/audit-results-graduator.js",
+      "method": "canonicalFingerprintFooter",
+      "startLine": 170,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/feedback-loop/audit-results-graduator.js",
+      "method": "parseFindings",
+      "startLine": 198,
+      "crap": 13
+    },
+    {
+      "path": ".agents/scripts/lib/feedback-loop/audit-results-graduator.js",
+      "method": "graduateAuditResults",
+      "startLine": 276,
+      "crap": 1.125
+    },
+    {
+      "path": ".agents/scripts/lib/feedback-loop/audit-results-graduator.js",
+      "method": "<anon method-1>",
+      "startLine": 288,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/feedback-loop/audit-results-graduator.js",
+      "method": "<anon method-2>",
+      "startLine": 292,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/feedback-loop/audit-results-graduator.js",
+      "method": "<anon method-3>",
+      "startLine": 301,
+      "crap": 1.823974609375
+    },
+    {
+      "path": ".agents/scripts/lib/feedback-loop/graduator-core.js",
+      "method": "contentFingerprint",
+      "startLine": 111,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/feedback-loop/graduator-core.js",
+      "method": "<anon method-1>",
+      "startLine": 112,
+      "crap": 3
+    },
+    {
+      "path": ".agents/scripts/lib/feedback-loop/graduator-core.js",
+      "method": "runChild",
+      "startLine": 143,
+      "crap": 1.000056895766955
+    },
+    {
+      "path": ".agents/scripts/lib/feedback-loop/graduator-core.js",
+      "method": "<anon method-2>",
+      "startLine": 150,
+      "crap": 3.0005120619025942
+    },
+    {
+      "path": ".agents/scripts/lib/feedback-loop/graduator-core.js",
+      "method": "<anon method-3>",
+      "startLine": 172,
+      "crap": 3
+    },
+    {
+      "path": ".agents/scripts/lib/feedback-loop/graduator-core.js",
+      "method": "<anon method-4>",
+      "startLine": 179,
+      "crap": 1.000056895766955
+    },
+    {
+      "path": ".agents/scripts/lib/feedback-loop/graduator-core.js",
+      "method": "<anon method-5>",
+      "startLine": 207,
+      "crap": 1.000056895766955
+    },
+    {
+      "path": ".agents/scripts/lib/feedback-loop/graduator-core.js",
+      "method": "<anon method-6>",
+      "startLine": 210,
+      "crap": 1.000056895766955
+    },
+    {
+      "path": ".agents/scripts/lib/feedback-loop/graduator-core.js",
+      "method": "<anon method-7>",
+      "startLine": 213,
+      "crap": 1.000056895766955
+    },
+    {
+      "path": ".agents/scripts/lib/feedback-loop/graduator-core.js",
+      "method": "<anon method-8>",
+      "startLine": 216,
+      "crap": 1.000056895766955
+    },
+    {
+      "path": ".agents/scripts/lib/feedback-loop/graduator-core.js",
+      "method": "makeIsAutoFileEnabled",
+      "startLine": 231,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/feedback-loop/graduator-core.js",
+      "method": "isAutoFileEnabled",
+      "startLine": 232,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/feedback-loop/graduator-core.js",
+      "method": "probePathStatus",
+      "startLine": 256,
+      "crap": 3
+    },
+    {
+      "path": ".agents/scripts/lib/feedback-loop/graduator-core.js",
+      "method": "normalizeMarkerQuery",
+      "startLine": 291,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/feedback-loop/graduator-core.js",
+      "method": "probeMarkerExists",
+      "startLine": 305,
+      "crap": 6.009667349199423
+    },
+    {
+      "path": ".agents/scripts/lib/feedback-loop/graduator-core.js",
+      "method": "confirmMarkerFiled",
+      "startLine": 364,
+      "crap": 6.0056857441809965
+    },
+    {
+      "path": ".agents/scripts/lib/feedback-loop/graduator-core.js",
+      "method": "<anon method-9>",
+      "startLine": 395,
+      "crap": 2.000631749353444
+    },
+    {
+      "path": ".agents/scripts/lib/feedback-loop/graduator-core.js",
+      "method": "createFollowUpIssue",
+      "startLine": 408,
+      "crap": 7
+    },
+    {
+      "path": ".agents/scripts/lib/feedback-loop/graduator-core.js",
+      "method": "checkGraduatePreconditions",
+      "startLine": 452,
+      "crap": 10.119744
+    },
+    {
+      "path": ".agents/scripts/lib/feedback-loop/graduator-core.js",
+      "method": "loadGraduateFindings",
+      "startLine": 484,
+      "crap": 4.010520259718912
+    },
+    {
+      "path": ".agents/scripts/lib/feedback-loop/graduator-core.js",
+      "method": "<anon method-10>",
+      "startLine": 496,
+      "crap": 2.002630064929728
+    },
+    {
+      "path": ".agents/scripts/lib/feedback-loop/graduator-core.js",
+      "method": "resolveAlreadyFiled",
+      "startLine": 516,
+      "crap": 5
+    },
+    {
+      "path": ".agents/scripts/lib/feedback-loop/graduator-core.js",
+      "method": "<anon method-11>",
+      "startLine": 527,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/feedback-loop/graduator-core.js",
+      "method": "processGraduateFinding",
+      "startLine": 559,
+      "crap": 14.006708167865193
+    },
+    {
+      "path": ".agents/scripts/lib/feedback-loop/graduator-core.js",
+      "method": "<anon method-12>",
+      "startLine": 578,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/feedback-loop/graduator-core.js",
+      "method": "renderCrossRepoDeferredBody",
+      "startLine": 720,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/feedback-loop/graduator-core.js",
+      "method": "<anon method-13>",
+      "startLine": 724,
+      "crap": 3
+    },
+    {
+      "path": ".agents/scripts/lib/feedback-loop/graduator-core.js",
+      "method": "persistCrossRepoDeferred",
+      "startLine": 743,
+      "crap": 2.0210405194378236
+    },
+    {
+      "path": ".agents/scripts/lib/feedback-loop/graduator-core.js",
+      "method": "graduate",
+      "startLine": 818,
+      "crap": 6
+    },
+    {
+      "path": ".agents/scripts/lib/feedback-loop/graduator-core.js",
+      "method": "<anon method-14>",
+      "startLine": 840,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/feedback-loop/memory-freshness.js",
+      "method": "armProbeWatchdog",
+      "startLine": 89,
+      "crap": 3.007774538386783
+    },
+    {
+      "path": ".agents/scripts/lib/feedback-loop/memory-freshness.js",
+      "method": "<anon method-1>",
+      "startLine": 92,
+      "crap": 3
+    },
+    {
+      "path": ".agents/scripts/lib/feedback-loop/memory-freshness.js",
+      "method": "<anon method-2>",
+      "startLine": 99,
+      "crap": 1.0008638375985315
+    },
+    {
       "path": ".agents/scripts/lib/feedback-loop/memory-freshness.js",
       "method": "parseFrontmatter",
-      "startLine": 59,
+      "startLine": 132,
       "crap": 16.746355685131196
     },
     {
       "path": ".agents/scripts/lib/feedback-loop/memory-freshness.js",
       "method": "renderFrontmatter",
-      "startLine": 117,
+      "startLine": 190,
+      "crap": 3
+    },
+    {
+      "path": ".agents/scripts/lib/feedback-loop/memory-freshness.js",
+      "method": "<anon method-3>",
+      "startLine": 203,
       "crap": 3
     },
     {
       "path": ".agents/scripts/lib/feedback-loop/memory-freshness.js",
       "method": "extractReferences",
-      "startLine": 147,
-      "crap": 7.087263822801013
+      "startLine": 220,
+      "crap": 7.010907977850127
+    },
+    {
+      "path": ".agents/scripts/lib/feedback-loop/memory-freshness.js",
+      "method": "classifyGhFailure",
+      "startLine": 264,
+      "crap": 3.0146549969468754
     },
     {
       "path": ".agents/scripts/lib/feedback-loop/memory-freshness.js",
       "method": "probeIssue",
-      "startLine": 189,
-      "crap": 1.0193119658739715
+      "startLine": 293,
+      "crap": 1.0075790360787171
+    },
+    {
+      "path": ".agents/scripts/lib/feedback-loop/memory-freshness.js",
+      "method": "<anon method-4>",
+      "startLine": 299,
+      "crap": 2.030316144314869
+    },
+    {
+      "path": ".agents/scripts/lib/feedback-loop/memory-freshness.js",
+      "method": "<anon method-5>",
+      "startLine": 323,
+      "crap": 1.0075790360787171
+    },
+    {
+      "path": ".agents/scripts/lib/feedback-loop/memory-freshness.js",
+      "method": "<anon method-6>",
+      "startLine": 326,
+      "crap": 1.0075790360787171
+    },
+    {
+      "path": ".agents/scripts/lib/feedback-loop/memory-freshness.js",
+      "method": "<anon method-7>",
+      "startLine": 329,
+      "crap": 1.0075790360787171
+    },
+    {
+      "path": ".agents/scripts/lib/feedback-loop/memory-freshness.js",
+      "method": "<anon method-8>",
+      "startLine": 330,
+      "crap": 4.121264577259475
     },
     {
       "path": ".agents/scripts/lib/feedback-loop/memory-freshness.js",
       "method": "probeLabel",
-      "startLine": 238,
+      "startLine": 360,
+      "crap": 1.0090422453703705
+    },
+    {
+      "path": ".agents/scripts/lib/feedback-loop/memory-freshness.js",
+      "method": "<anon method-9>",
+      "startLine": 368,
+      "crap": 4.144675925925926
+    },
+    {
+      "path": ".agents/scripts/lib/feedback-loop/memory-freshness.js",
+      "method": "<anon method-10>",
+      "startLine": 392,
+      "crap": 1.0090422453703705
+    },
+    {
+      "path": ".agents/scripts/lib/feedback-loop/memory-freshness.js",
+      "method": "<anon method-11>",
+      "startLine": 393,
+      "crap": 1.0090422453703705
+    },
+    {
+      "path": ".agents/scripts/lib/feedback-loop/memory-freshness.js",
+      "method": "<anon method-12>",
+      "startLine": 396,
+      "crap": 1.0090422453703705
+    },
+    {
+      "path": ".agents/scripts/lib/feedback-loop/memory-freshness.js",
+      "method": "<anon method-13>",
+      "startLine": 397,
+      "crap": 2.0361689814814814
+    },
+    {
+      "path": ".agents/scripts/lib/feedback-loop/memory-freshness.js",
+      "method": "verifyReferences",
+      "startLine": 424,
+      "crap": 9
+    },
+    {
+      "path": ".agents/scripts/lib/feedback-loop/memory-freshness.js",
+      "method": "stripStaleKeys",
+      "startLine": 502,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/feedback-loop/memory-freshness.js",
+      "method": "<anon method-14>",
+      "startLine": 505,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/feedback-loop/memory-freshness.js",
+      "method": "isStale",
+      "startLine": 515,
       "crap": 2
     },
     {
       "path": ".agents/scripts/lib/feedback-loop/memory-freshness.js",
-      "method": "findFirstDeadReason",
-      "startLine": 283,
-      "crap": 7.820292552856982
+      "method": "scanMemoryFreshness",
+      "startLine": 544,
+      "crap": 6.363045944893224
     },
     {
       "path": ".agents/scripts/lib/feedback-loop/memory-freshness.js",
-      "method": "scanMemoryFreshness",
-      "startLine": 346,
-      "crap": 6.33590902463916
+      "method": "<anon method-15>",
+      "startLine": 582,
+      "crap": 1.0100846095803673
     },
     {
       "path": ".agents/scripts/lib/feedback-loop/prior-feedback-fetcher.js",
       "method": "extractRecurringDefectClasses",
       "startLine": 55,
-      "crap": 11
+      "crap": 18.11642661179698
+    },
+    {
+      "path": ".agents/scripts/lib/feedback-loop/prior-feedback-fetcher.js",
+      "method": "<anon method-1>",
+      "startLine": 85,
+      "crap": 1.0588134430727023
+    },
+    {
+      "path": ".agents/scripts/lib/feedback-loop/prior-feedback-fetcher.js",
+      "method": "<anon method-2>",
+      "startLine": 88,
+      "crap": 2.2352537722908092
     },
     {
       "path": ".agents/scripts/lib/feedback-loop/prior-feedback-fetcher.js",
@@ -4501,9 +8996,27 @@
     },
     {
       "path": ".agents/scripts/lib/feedback-loop/prior-feedback-fetcher.js",
+      "method": "<anon method-3>",
+      "startLine": 149,
+      "crap": 3
+    },
+    {
+      "path": ".agents/scripts/lib/feedback-loop/prior-feedback-fetcher.js",
+      "method": "<anon method-4>",
+      "startLine": 150,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/feedback-loop/prior-feedback-fetcher.js",
       "method": "fetchByLabel",
       "startLine": 168,
       "crap": 6.060738581146745
+    },
+    {
+      "path": ".agents/scripts/lib/feedback-loop/prior-feedback-fetcher.js",
+      "method": "<anon method-5>",
+      "startLine": 201,
+      "crap": 1.0016871828096319
     },
     {
       "path": ".agents/scripts/lib/feedback-loop/prior-feedback-fetcher.js",
@@ -4512,52 +9025,478 @@
       "crap": 10
     },
     {
+      "path": ".agents/scripts/lib/feedback-loop/retro-proposals-graduator.js",
+      "method": "buildContentMarker",
+      "startLine": 65,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/feedback-loop/retro-proposals-graduator.js",
+      "method": "metaSourceLabel",
+      "startLine": 86,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/feedback-loop/retro-proposals-graduator.js",
+      "method": "makeSpec",
+      "startLine": 100,
+      "crap": 1.0007513148009015
+    },
+    {
+      "path": ".agents/scripts/lib/feedback-loop/retro-proposals-graduator.js",
+      "method": "<anon method-1>",
+      "startLine": 109,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/feedback-loop/retro-proposals-graduator.js",
+      "method": "<anon method-2>",
+      "startLine": 112,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/feedback-loop/retro-proposals-graduator.js",
+      "method": "<anon method-3>",
+      "startLine": 117,
+      "crap": 1.216
+    },
+    {
+      "path": ".agents/scripts/lib/feedback-loop/retro-proposals-graduator.js",
+      "method": "<anon method-4>",
+      "startLine": 122,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/feedback-loop/retro-proposals-graduator.js",
+      "method": "toFinding",
+      "startLine": 143,
+      "crap": 6
+    },
+    {
+      "path": ".agents/scripts/lib/feedback-loop/retro-proposals-graduator.js",
+      "method": "graduateRetroProposals",
+      "startLine": 189,
+      "crap": 7
+    },
+    {
+      "path": ".agents/scripts/lib/feedback-loop/retro-proposals-graduator.js",
+      "method": "<anon method-5>",
+      "startLine": 238,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/feedback-loop/retro-proposals-graduator.js",
+      "method": "<anon method-6>",
+      "startLine": 247,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/feedback-loop/retro-proposals-graduator.js",
+      "method": "issueNumberFromUrl",
+      "startLine": 275,
+      "crap": 3
+    },
+    {
+      "path": ".agents/scripts/lib/feedback-loop/retro-proposals-graduator.js",
+      "method": "enrichRoutedProposalsWithFilings",
+      "startLine": 292,
+      "crap": 8.010107989655104
+    },
+    {
+      "path": ".agents/scripts/lib/feedback-loop/retro-proposals-graduator.js",
+      "method": "<anon method-7>",
+      "startLine": 317,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/feedback-loop/retro-proposals-graduator.js",
+      "method": "<anon method-8>",
+      "startLine": 318,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/feedback-loop/retro-proposals-graduator.js",
+      "method": "parseRepoSlug",
+      "startLine": 337,
+      "crap": 5
+    },
+    {
+      "path": ".agents/scripts/lib/feedback-loop/retro-proposals-graduator.js",
+      "method": "fileRetroProposals",
+      "startLine": 370,
+      "crap": 3.1352169503628433
+    },
+    {
+      "path": ".agents/scripts/lib/feedback-loop/retro-proposals-graduator.js",
+      "method": "<anon method-9>",
+      "startLine": 384,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/findings/classify-finding.js",
+      "method": "resolveSeverity",
+      "startLine": 105,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/findings/classify-finding.js",
+      "method": "resolveSecuritySignal",
+      "startLine": 117,
+      "crap": 5
+    },
+    {
+      "path": ".agents/scripts/lib/findings/classify-finding.js",
+      "method": "<anon method-1>",
+      "startLine": 128,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/findings/classify-finding.js",
+      "method": "<anon method-2>",
+      "startLine": 129,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/findings/classify-finding.js",
+      "method": "<anon method-3>",
+      "startLine": 130,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/findings/classify-finding.js",
+      "method": "resolveClass",
+      "startLine": 142,
+      "crap": 6
+    },
+    {
+      "path": ".agents/scripts/lib/findings/classify-finding.js",
+      "method": "classifyFinding",
+      "startLine": 181,
+      "crap": 1
+    },
+    {
       "path": ".agents/scripts/lib/findings/promote-finding.js",
       "method": "isPromotable",
-      "startLine": 58,
+      "startLine": 67,
       "crap": 7
     },
     {
       "path": ".agents/scripts/lib/findings/promote-finding.js",
       "method": "clusterKeyFor",
-      "startLine": 81,
+      "startLine": 90,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/findings/promote-finding.js",
       "method": "highestSeverity",
-      "startLine": 97,
+      "startLine": 106,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/findings/promote-finding.js",
+      "method": "<anon method-1>",
+      "startLine": 107,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/findings/promote-finding.js",
       "method": "clusterLedgerItems",
-      "startLine": 119,
+      "startLine": 128,
       "crap": 5
     },
     {
       "path": ".agents/scripts/lib/findings/promote-finding.js",
+      "method": "<anon method-2>",
+      "startLine": 147,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/findings/promote-finding.js",
       "method": "targetForCluster",
-      "startLine": 168,
+      "startLine": 177,
       "crap": 3
     },
     {
       "path": ".agents/scripts/lib/findings/promote-finding.js",
       "method": "clusterToFinding",
-      "startLine": 186,
+      "startLine": 195,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/findings/promote-finding.js",
       "method": "routedToLink",
-      "startLine": 210,
+      "startLine": 219,
       "crap": 3
     },
     {
       "path": ".agents/scripts/lib/findings/promote-finding.js",
       "method": "promoteFindings",
-      "startLine": 270,
+      "startLine": 279,
       "crap": 8
+    },
+    {
+      "path": ".agents/scripts/lib/findings/promote-finding.js",
+      "method": "<anon method-3>",
+      "startLine": 338,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/findings/promote-finding.js",
+      "method": "<anon method-4>",
+      "startLine": 343,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/findings/promote-finding.js",
+      "method": "<anon method-5>",
+      "startLine": 350,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/findings/route-finding.js",
+      "method": "normaliseField",
+      "startLine": 47,
+      "crap": 3
+    },
+    {
+      "path": ".agents/scripts/lib/findings/route-finding.js",
+      "method": "normaliseLabels",
+      "startLine": 57,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/findings/route-finding.js",
+      "method": "<anon method-1>",
+      "startLine": 60,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/findings/route-finding.js",
+      "method": "<anon method-2>",
+      "startLine": 61,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/findings/route-finding.js",
+      "method": "fingerprintComponents",
+      "startLine": 71,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/findings/route-finding.js",
+      "method": "fingerprintFinding",
+      "startLine": 87,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/findings/route-finding.js",
+      "method": "semanticKeyFor",
+      "startLine": 117,
+      "crap": 4
+    },
+    {
+      "path": ".agents/scripts/lib/findings/route-finding.js",
+      "method": "semanticKeyFooter",
+      "startLine": 135,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/findings/route-finding.js",
+      "method": "<anon method-3>",
+      "startLine": 137,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/findings/route-finding.js",
+      "method": "<anon method-4>",
+      "startLine": 138,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/findings/route-finding.js",
+      "method": "<anon method-5>",
+      "startLine": 139,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/findings/route-finding.js",
+      "method": "parseSemanticKeyFooter",
+      "startLine": 151,
+      "crap": 3
+    },
+    {
+      "path": ".agents/scripts/lib/findings/route-finding.js",
+      "method": "<anon method-6>",
+      "startLine": 157,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/findings/route-finding.js",
+      "method": "<anon method-7>",
+      "startLine": 158,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/findings/route-finding.js",
+      "method": "fingerprintFooter",
+      "startLine": 174,
+      "crap": 4
+    },
+    {
+      "path": ".agents/scripts/lib/findings/route-finding.js",
+      "method": "parseFingerprintFooter",
+      "startLine": 192,
+      "crap": 3
+    },
+    {
+      "path": ".agents/scripts/lib/findings/route-finding.js",
+      "method": "<anon method-8>",
+      "startLine": 198,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/findings/route-finding.js",
+      "method": "<anon method-9>",
+      "startLine": 199,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/findings/route-finding.js",
+      "method": "issueCarriesFingerprint",
+      "startLine": 211,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/findings/route-finding.js",
+      "method": "issueCarriesSemanticKey",
+      "startLine": 226,
+      "crap": 3
+    },
+    {
+      "path": ".agents/scripts/lib/findings/route-finding.js",
+      "method": "decisionForIssue",
+      "startLine": 236,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/findings/route-finding.js",
+      "method": "decideFromConfirmed",
+      "startLine": 252,
+      "crap": 4
+    },
+    {
+      "path": ".agents/scripts/lib/findings/route-finding.js",
+      "method": "<anon method-10>",
+      "startLine": 257,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/findings/route-finding.js",
+      "method": "confirmCandidates",
+      "startLine": 292,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/findings/route-finding.js",
+      "method": "<anon method-11>",
+      "startLine": 295,
+      "crap": 5
+    },
+    {
+      "path": ".agents/scripts/lib/findings/route-finding.js",
+      "method": "routeFinding",
+      "startLine": 343,
+      "crap": 5
+    },
+    {
+      "path": ".agents/scripts/lib/findings/semantic-issue-search.js",
+      "method": "normaliseText",
+      "startLine": 39,
+      "crap": 3
+    },
+    {
+      "path": ".agents/scripts/lib/findings/semantic-issue-search.js",
+      "method": "tokenize",
+      "startLine": 53,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/findings/semantic-issue-search.js",
+      "method": "<anon method-1>",
+      "startLine": 57,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/findings/semantic-issue-search.js",
+      "method": "jaccard",
+      "startLine": 68,
+      "crap": 5
+    },
+    {
+      "path": ".agents/scripts/lib/findings/semantic-issue-search.js",
+      "method": "basename",
+      "startLine": 86,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/findings/semantic-issue-search.js",
+      "method": "buildQuery",
+      "startLine": 104,
+      "crap": 3
+    },
+    {
+      "path": ".agents/scripts/lib/findings/semantic-issue-search.js",
+      "method": "<anon method-2>",
+      "startLine": 106,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/findings/semantic-issue-search.js",
+      "method": "<anon method-3>",
+      "startLine": 107,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/findings/semantic-issue-search.js",
+      "method": "scoreIssue",
+      "startLine": 131,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/findings/semantic-issue-search.js",
+      "method": "dedupeByNumber",
+      "startLine": 142,
+      "crap": 3
+    },
+    {
+      "path": ".agents/scripts/lib/findings/semantic-issue-search.js",
+      "method": "searchSemanticCandidates",
+      "startLine": 178,
+      "crap": 6
+    },
+    {
+      "path": ".agents/scripts/lib/findings/semantic-issue-search.js",
+      "method": "<anon method-4>",
+      "startLine": 204,
+      "crap": 3
+    },
+    {
+      "path": ".agents/scripts/lib/findings/semantic-issue-search.js",
+      "method": "<anon method-5>",
+      "startLine": 211,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/findings/semantic-issue-search.js",
+      "method": "<anon method-6>",
+      "startLine": 212,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/findings/semantic-issue-search.js",
+      "method": "<anon method-7>",
+      "startLine": 213,
+      "crap": 1
     },
     {
       "path": ".agents/scripts/lib/findings/severity.js",
@@ -4572,40 +9511,22 @@
       "crap": 2
     },
     {
-      "path": ".agents/scripts/lib/framework-version.js",
-      "method": "defaultPkgPath",
-      "startLine": 63,
+      "path": ".agents/scripts/lib/format-generated-json.js",
+      "method": "fallback",
+      "startLine": 38,
       "crap": 1
     },
     {
-      "path": ".agents/scripts/lib/framework-version.js",
-      "method": "resolveFrameworkVersion",
-      "startLine": 76,
-      "crap": 4
-    },
-    {
-      "path": ".agents/scripts/lib/framework-version.js",
-      "method": "formatAuthoredDate",
-      "startLine": 95,
-      "crap": 3
+      "path": ".agents/scripts/lib/format-generated-json.js",
+      "method": "formatGeneratedJson",
+      "startLine": 69,
+      "crap": 7.016072819713806
     },
     {
       "path": ".agents/scripts/lib/framework-version.js",
       "method": "authoredMarkerLine",
-      "startLine": 109,
+      "startLine": 37,
       "crap": 1
-    },
-    {
-      "path": ".agents/scripts/lib/framework-version.js",
-      "method": "extractFrameworkStamp",
-      "startLine": 122,
-      "crap": 11.070023148148149
-    },
-    {
-      "path": ".agents/scripts/lib/framework-version.js",
-      "method": "stampFrameworkVersion",
-      "startLine": 164,
-      "crap": 11.009944933015534
     },
     {
       "path": ".agents/scripts/lib/gates/baseline-store.js",
@@ -4634,8 +9555,8 @@
     {
       "path": ".agents/scripts/lib/gates/friction.js",
       "method": "emitFrictionSignal",
-      "startLine": 10,
-      "crap": 3.0146549969468754
+      "startLine": 14,
+      "crap": 6.0703125
     },
     {
       "path": ".agents/scripts/lib/gh-exec.js",
@@ -4705,6 +9626,36 @@
     },
     {
       "path": ".agents/scripts/lib/gh-exec.js",
+      "method": "<anon method-7>",
+      "startLine": 315,
+      "crap": 4.001024
+    },
+    {
+      "path": ".agents/scripts/lib/gh-exec.js",
+      "method": "<anon method-8>",
+      "startLine": 333,
+      "crap": 1.000064
+    },
+    {
+      "path": ".agents/scripts/lib/gh-exec.js",
+      "method": "<anon method-9>",
+      "startLine": 336,
+      "crap": 1.000064
+    },
+    {
+      "path": ".agents/scripts/lib/gh-exec.js",
+      "method": "<anon method-10>",
+      "startLine": 340,
+      "crap": 2.000256
+    },
+    {
+      "path": ".agents/scripts/lib/gh-exec.js",
+      "method": "<anon method-11>",
+      "startLine": 346,
+      "crap": 8.004096
+    },
+    {
+      "path": ".agents/scripts/lib/gh-exec.js",
       "method": "createGh",
       "startLine": 415,
       "crap": 1.0000960815198316
@@ -4720,6 +9671,12 @@
       "method": "api",
       "startLine": 436,
       "crap": 8.032768
+    },
+    {
+      "path": ".agents/scripts/lib/gh-exec.js",
+      "method": "<anon method-13>",
+      "startLine": 452,
+      "crap": 1.000512
     },
     {
       "path": ".agents/scripts/lib/gh-exec.js",
@@ -4784,37 +9741,43 @@
     {
       "path": ".agents/scripts/lib/gh-exec.js",
       "method": "<anon method-22>",
-      "startLine": 508,
+      "startLine": 514,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/gh-exec.js",
       "method": "<anon method-23>",
-      "startLine": 515,
+      "startLine": 516,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/gh-exec.js",
       "method": "<anon method-24>",
-      "startLine": 517,
+      "startLine": 523,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/gh-exec.js",
       "method": "<anon method-25>",
-      "startLine": 519,
+      "startLine": 525,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/gh-exec.js",
       "method": "<anon method-26>",
-      "startLine": 526,
-      "crap": 2
+      "startLine": 527,
+      "crap": 1
     },
     {
       "path": ".agents/scripts/lib/gh-exec.js",
       "method": "<anon method-27>",
-      "startLine": 532,
+      "startLine": 534,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/gh-exec.js",
+      "method": "<anon method-28>",
+      "startLine": 540,
       "crap": 3.1851851851851856
     },
     {
@@ -4838,223 +9801,247 @@
     {
       "path": ".agents/scripts/lib/git-branch-cleanup.js",
       "method": "assertBatchedScope",
-      "startLine": 151,
+      "startLine": 142,
       "crap": 3
     },
     {
       "path": ".agents/scripts/lib/git-branch-cleanup.js",
       "method": "runBatchedLocalDelete",
-      "startLine": 159,
+      "startLine": 150,
       "crap": 2
     },
     {
       "path": ".agents/scripts/lib/git-branch-cleanup.js",
       "method": "runBatchedRemoteDelete",
-      "startLine": 164,
+      "startLine": 155,
       "crap": 3
     },
     {
       "path": ".agents/scripts/lib/git-branch-cleanup.js",
       "method": "perRefFallback",
-      "startLine": 175,
+      "startLine": 166,
       "crap": 3
     },
     {
       "path": ".agents/scripts/lib/git-branch-cleanup.js",
       "method": "deleteBranchesBatched",
-      "startLine": 189,
+      "startLine": 180,
       "crap": 5
     },
     {
       "path": ".agents/scripts/lib/git-branch-lifecycle.js",
       "method": "currentBranch",
-      "startLine": 24,
+      "startLine": 25,
       "crap": 3
     },
     {
       "path": ".agents/scripts/lib/git-branch-lifecycle.js",
       "method": "branchExistsLocally",
-      "startLine": 37,
+      "startLine": 38,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/git-branch-lifecycle.js",
       "method": "branchExistsRemotely",
-      "startLine": 55,
+      "startLine": 56,
       "crap": 2
     },
     {
       "path": ".agents/scripts/lib/git-branch-lifecycle.js",
       "method": "branchExistsViaTrackingRef",
-      "startLine": 75,
+      "startLine": 76,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/git-branch-lifecycle.js",
       "method": "classifyBranchSeed",
-      "startLine": 111,
+      "startLine": 110,
       "crap": 3
     },
     {
       "path": ".agents/scripts/lib/git-branch-lifecycle.js",
-      "method": "ensureEpicBranch",
-      "startLine": 126,
-      "crap": 9
-    },
-    {
-      "path": ".agents/scripts/lib/git-branch-lifecycle.js",
-      "method": "_assertOnBranch",
-      "startLine": 190,
-      "crap": 2
+      "method": "seedStoryBranchRef",
+      "startLine": 158,
+      "crap": 123.75293999270504
     },
     {
       "path": ".agents/scripts/lib/git-branch-lifecycle.js",
       "method": "checkoutStoryBranch",
-      "startLine": 211,
+      "startLine": 212,
       "crap": 7
     },
     {
       "path": ".agents/scripts/lib/git-branch-lifecycle.js",
-      "method": "planEnsureEpicBranchRefAction",
-      "startLine": 282,
-      "crap": 4
-    },
-    {
-      "path": ".agents/scripts/lib/git-branch-lifecycle.js",
-      "method": "ensureEpicBranchRef",
-      "startLine": 287,
-      "crap": 5
+      "method": "<anon method-1>",
+      "startLine": 219,
+      "crap": 1
     },
     {
       "path": ".agents/scripts/lib/git-branch-lifecycle.js",
       "method": "ensureLocalBranch",
-      "startLine": 340,
+      "startLine": 267,
       "crap": 2
     },
     {
-      "path": ".agents/scripts/lib/git-utils.js",
-      "method": "cleanGitEnv",
-      "startLine": 59,
+      "path": ".agents/scripts/lib/git-branch-lifecycle.js",
+      "method": "<anon method-2>",
+      "startLine": 269,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/git-utils.js",
-      "method": "__setGitRunners",
+      "method": "cleanGitEnv",
+      "startLine": 74,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/git-utils.js",
+      "method": "<anon method-1>",
       "startLine": 78,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/git-utils.js",
+      "method": "__resetCleanGitEnv",
+      "startLine": 88,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/git-utils.js",
+      "method": "__setGitRunners",
+      "startLine": 105,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/git-utils.js",
       "method": "gitSync",
-      "startLine": 91,
+      "startLine": 118,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/git-utils.js",
       "method": "gitSpawn",
-      "startLine": 109,
+      "startLine": 136,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/git-utils.js",
       "method": "createGitInterface",
-      "startLine": 138,
+      "startLine": 165,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/git-utils.js",
+      "method": "<anon method-2>",
+      "startLine": 169,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/git-utils.js",
+      "method": "<anon method-3>",
+      "startLine": 169,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/git-utils.js",
       "method": "<anon method-4>",
-      "startLine": 145,
+      "startLine": 172,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/git-utils.js",
       "method": "<anon method-5>",
-      "startLine": 154,
+      "startLine": 181,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/git-utils.js",
       "method": "runWithRetry",
-      "startLine": 169,
+      "startLine": 196,
       "crap": 4
     },
     {
       "path": ".agents/scripts/lib/git-utils.js",
       "method": "<anon method-6>",
-      "startLine": 189,
+      "startLine": 216,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/git-utils.js",
       "method": "<anon method-7>",
-      "startLine": 190,
+      "startLine": 217,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/git-utils.js",
       "method": "isPackedRefsContention",
-      "startLine": 208,
+      "startLine": 235,
       "crap": 2
     },
     {
       "path": ".agents/scripts/lib/git-utils.js",
+      "method": "<anon method-8>",
+      "startLine": 237,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/git-utils.js",
       "method": "<anon method-10>",
-      "startLine": 219,
+      "startLine": 246,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/git-utils.js",
       "method": "<anon method-9>",
-      "startLine": 219,
+      "startLine": 246,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/git-utils.js",
       "method": "__setSleep",
-      "startLine": 228,
+      "startLine": 255,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/git-utils.js",
-      "method": "gitFetchWithRetry",
-      "startLine": 246,
+      "method": "gitWithContentionRetry",
+      "startLine": 276,
       "crap": 4
     },
     {
       "path": ".agents/scripts/lib/git-utils.js",
-      "method": "gitPullWithRetry",
-      "startLine": 272,
-      "crap": 5.33984375
-    },
-    {
-      "path": ".agents/scripts/lib/git-utils.js",
-      "method": "getEpicBranch",
-      "startLine": 295,
-      "crap": 4.373177842565598
-    },
-    {
-      "path": ".agents/scripts/lib/git-utils.js",
-      "method": "slugify",
-      "startLine": 311,
+      "method": "gitFetchWithRetry",
+      "startLine": 301,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/git-utils.js",
-      "method": "getStoryBranch",
+      "method": "gitPullWithRetry",
+      "startLine": 314,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/git-utils.js",
+      "method": "slugify",
       "startLine": 326,
+      "crap": 1.6297376093294462
+    },
+    {
+      "path": ".agents/scripts/lib/git-utils.js",
+      "method": "getStoryBranch",
+      "startLine": 340,
       "crap": 4.25
     },
     {
       "path": ".agents/scripts/lib/git-utils.js",
       "method": "parseStoryBranch",
-      "startLine": 349,
+      "startLine": 363,
       "crap": 3
     },
     {
       "path": ".agents/scripts/lib/git-utils.js",
       "method": "isStoryBranch",
-      "startLine": 361,
+      "startLine": 375,
       "crap": 1
     },
     {
@@ -5086,6 +10073,18 @@
       "method": "syncBranchFromBase",
       "startLine": 75,
       "crap": 11
+    },
+    {
+      "path": ".agents/scripts/lib/git/sync-from-base.js",
+      "method": "<anon method-1>",
+      "startLine": 146,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/git/sync-from-base.js",
+      "method": "<anon method-2>",
+      "startLine": 147,
+      "crap": 1
     },
     {
       "path": ".agents/scripts/lib/github-url.js",
@@ -5137,6 +10136,12 @@
     },
     {
       "path": ".agents/scripts/lib/Graph.js",
+      "method": "<anon method-1>",
+      "startLine": 185,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/Graph.js",
       "method": "computeReachability",
       "startLine": 197,
       "crap": 1
@@ -5155,15 +10160,39 @@
     },
     {
       "path": ".agents/scripts/lib/Graph.js",
+      "method": "<anon method-2>",
+      "startLine": 255,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/Graph.js",
+      "method": "<anon method-3>",
+      "startLine": 256,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/Graph.js",
+      "method": "<anon method-4>",
+      "startLine": 257,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/Graph.js",
       "method": "computeWaves",
       "startLine": 308,
       "crap": 4
     },
     {
+      "path": ".agents/scripts/lib/Graph.js",
+      "method": "<anon method-5>",
+      "startLine": 321,
+      "crap": 1
+    },
+    {
       "path": ".agents/scripts/lib/install-cmd-parser.js",
       "method": "parseInstallCmd",
       "startLine": 20,
-      "crap": 2
+      "crap": 5.146108329540283
     },
     {
       "path": ".agents/scripts/lib/install-cmd-parser.js",
@@ -5174,13 +10203,13 @@
     {
       "path": ".agents/scripts/lib/json-utils.js",
       "method": "isObject",
-      "startLine": 24,
+      "startLine": 23,
       "crap": 3
     },
     {
       "path": ".agents/scripts/lib/json-utils.js",
       "method": "deepEqual",
-      "startLine": 37,
+      "startLine": 36,
       "crap": 14
     },
     {
@@ -5192,91 +10221,97 @@
     {
       "path": ".agents/scripts/lib/Logger.js",
       "method": "resolveLevel",
-      "startLine": 55,
+      "startLine": 52,
       "crap": 2
     },
     {
       "path": ".agents/scripts/lib/Logger.js",
       "method": "setLevel",
-      "startLine": 74,
+      "startLine": 71,
       "crap": 4
     },
     {
       "path": ".agents/scripts/lib/Logger.js",
       "method": "debugEnabled",
-      "startLine": 87,
-      "crap": 2
+      "startLine": 84,
+      "crap": 1
     },
     {
       "path": ".agents/scripts/lib/Logger.js",
       "method": "infoEnabled",
-      "startLine": 92,
+      "startLine": 88,
       "crap": 2
     },
     {
       "path": ".agents/scripts/lib/Logger.js",
       "method": "<anon method-1>",
-      "startLine": 101,
+      "startLine": 97,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/Logger.js",
       "method": "<anon method-2>",
-      "startLine": 102,
+      "startLine": 98,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/Logger.js",
       "method": "<anon method-3>",
-      "startLine": 103,
+      "startLine": 99,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/Logger.js",
       "method": "routeAllOutputToStderr",
-      "startLine": 114,
+      "startLine": 110,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/Logger.js",
       "method": "<anon method-4>",
-      "startLine": 115,
+      "startLine": 111,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/Logger.js",
       "method": "<anon method-5>",
-      "startLine": 116,
+      "startLine": 112,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/Logger.js",
       "method": "<anon method-6>",
-      "startLine": 117,
+      "startLine": 113,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/Logger.js",
+      "method": "<anon method-7>",
+      "startLine": 148,
+      "crap": 3
+    },
+    {
+      "path": ".agents/scripts/lib/Logger.js",
       "method": "<anon method-8>",
-      "startLine": 190,
+      "startLine": 186,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/Logger.js",
       "method": "<anon method-9>",
-      "startLine": 191,
+      "startLine": 187,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/Logger.js",
       "method": "<anon method-10>",
-      "startLine": 192,
+      "startLine": 188,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/Logger.js",
       "method": "<anon method-11>",
-      "startLine": 193,
+      "startLine": 189,
       "crap": 1
     },
     {
@@ -5299,6 +10334,24 @@
     },
     {
       "path": ".agents/scripts/lib/maintainability-engine.js",
+      "method": "<anon method-1>",
+      "startLine": 73,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/maintainability-engine.js",
+      "method": "<anon method-2>",
+      "startLine": 82,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/maintainability-engine.js",
+      "method": "<anon method-3>",
+      "startLine": 86,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/maintainability-engine.js",
       "method": "calculateReportForFile",
       "startLine": 113,
       "crap": 3.9718172983479105
@@ -5311,111 +10364,147 @@
     },
     {
       "path": ".agents/scripts/lib/maintainability-utils.js",
-      "method": "loadTypeScript",
-      "startLine": 34,
-      "crap": 3.182569496619083
-    },
-    {
-      "path": ".agents/scripts/lib/maintainability-utils.js",
-      "method": "resolveTsTranspilerVersion",
-      "startLine": 54,
-      "crap": 3.072
-    },
-    {
-      "path": ".agents/scripts/lib/maintainability-utils.js",
-      "method": "isTypeScriptPath",
-      "startLine": 60,
-      "crap": 1
-    },
-    {
-      "path": ".agents/scripts/lib/maintainability-utils.js",
-      "method": "transpileIfNeeded",
-      "startLine": 83,
-      "crap": 3.0540946656649135
-    },
-    {
-      "path": ".agents/scripts/lib/maintainability-utils.js",
       "method": "isSupportedSourceFile",
-      "startLine": 120,
+      "startLine": 25,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/maintainability-utils.js",
-      "method": "projectMaintainabilityEnvelopeToFlat",
-      "startLine": 141,
-      "crap": 9
-    },
-    {
-      "path": ".agents/scripts/lib/maintainability-utils.js",
-      "method": "getBaseline",
-      "startLine": 160,
-      "crap": 5
-    },
-    {
-      "path": ".agents/scripts/lib/maintainability-utils.js",
-      "method": "saveBaseline",
-      "startLine": 194,
+      "method": "isIgnoredByGlobs",
+      "startLine": 58,
       "crap": 4
     },
     {
       "path": ".agents/scripts/lib/maintainability-utils.js",
+      "method": "<anon method-1>",
+      "startLine": 66,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/maintainability-utils.js",
       "method": "scanDirectory",
-      "startLine": 239,
-      "crap": 9
+      "startLine": 86,
+      "crap": 7
     },
     {
       "path": ".agents/scripts/lib/maintainability-utils.js",
       "method": "calculateAll",
-      "startLine": 294,
+      "startLine": 134,
+      "crap": 3.124416
+    },
+    {
+      "path": ".agents/scripts/lib/maintainability-utils.js",
+      "method": "<anon method-2>",
+      "startLine": 136,
+      "crap": 1.013824
+    },
+    {
+      "path": ".agents/scripts/lib/maintainability-utils.js",
+      "method": "<anon method-3>",
+      "startLine": 143,
+      "crap": 1.013824
+    },
+    {
+      "path": ".agents/scripts/lib/maintainability-utils.js",
+      "method": "<anon method-4>",
+      "startLine": 156,
+      "crap": 1.013824
+    },
+    {
+      "path": ".agents/scripts/lib/maintainability-utils.js",
+      "method": "<anon method-5>",
+      "startLine": 158,
+      "crap": 5.3456
+    },
+    {
+      "path": ".agents/scripts/lib/maintainability-utils.js",
+      "method": "<anon method-6>",
+      "startLine": 173,
       "crap": 3.124416
     },
     {
       "path": ".agents/scripts/lib/mandrel-catalog.js",
       "method": "extractDescription",
-      "startLine": 42,
+      "startLine": 45,
       "crap": 11
     },
     {
       "path": ".agents/scripts/lib/mandrel-catalog.js",
       "method": "isVagueDescription",
-      "startLine": 98,
+      "startLine": 101,
       "crap": 3
     },
     {
       "path": ".agents/scripts/lib/mandrel-catalog.js",
       "method": "buildCatalog",
-      "startLine": 112,
+      "startLine": 115,
       "crap": 5
     },
     {
       "path": ".agents/scripts/lib/mandrel-catalog.js",
+      "method": "<anon method-1>",
+      "startLine": 139,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/mandrel-catalog.js",
+      "method": "buildLoopCatalog",
+      "startLine": 157,
+      "crap": 18.262606629953567
+    },
+    {
+      "path": ".agents/scripts/lib/mandrel-catalog.js",
+      "method": "<anon method-2>",
+      "startLine": 175,
+      "crap": 1.5305042651981426
+    },
+    {
+      "path": ".agents/scripts/lib/mandrel-catalog.js",
       "method": "renderCatalog",
-      "startLine": 148,
+      "startLine": 188,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/mandrel-catalog.js",
+      "method": "<anon method-3>",
+      "startLine": 192,
       "crap": 2
     },
     {
       "path": ".agents/scripts/lib/mutation/baseline-snapshot.js",
       "method": "readBaseline",
-      "startLine": 65,
+      "startLine": 66,
       "crap": 4
     },
     {
       "path": ".agents/scripts/lib/mutation/baseline-snapshot.js",
       "method": "writeBaseline",
-      "startLine": 101,
+      "startLine": 102,
       "crap": 8.664715251690458
     },
     {
       "path": ".agents/scripts/lib/mutation/baseline-snapshot.js",
+      "method": "<anon method-1>",
+      "startLine": 105,
+      "crap": 1.0103861758076633
+    },
+    {
+      "path": ".agents/scripts/lib/mutation/baseline-snapshot.js",
       "method": "validateBaseline",
-      "startLine": 167,
+      "startLine": 168,
       "crap": 17.147968
     },
     {
       "path": ".agents/scripts/lib/mutation/baseline-snapshot.js",
       "method": "canonicaliseWorkspaces",
-      "startLine": 226,
+      "startLine": 227,
       "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/mutation/baseline-snapshot.js",
+      "method": "<anon method-2>",
+      "startLine": 229,
+      "crap": 3
     },
     {
       "path": ".agents/scripts/lib/mutation/config-detector.js",
@@ -5434,6 +10523,12 @@
       "method": "runStryker",
       "startLine": 70,
       "crap": 15.033554814675682
+    },
+    {
+      "path": ".agents/scripts/lib/mutation/stryker-runner.js",
+      "method": "<anon method-1>",
+      "startLine": 79,
+      "crap": 1.0001491325096696
     },
     {
       "path": ".agents/scripts/lib/mutation/stryker-runner.js",
@@ -5458,6 +10553,12 @@
       "method": "enumerateSurvivors",
       "startLine": 70,
       "crap": 16
+    },
+    {
+      "path": ".agents/scripts/lib/mutation/survivor-report.js",
+      "method": "<anon method-1>",
+      "startLine": 115,
+      "crap": 2
     },
     {
       "path": ".agents/scripts/lib/mutation/survivor-report.js",
@@ -5490,352 +10591,214 @@
       "crap": 2
     },
     {
+      "path": ".agents/scripts/lib/npm-scripts.js",
+      "method": "readPackageScripts",
+      "startLine": 30,
+      "crap": 6
+    },
+    {
+      "path": ".agents/scripts/lib/npm-scripts.js",
+      "method": "hasNpmScript",
+      "startLine": 52,
+      "crap": 2
+    },
+    {
       "path": ".agents/scripts/lib/observability/active-story-env.js",
       "method": "renderActiveStoryEnvFile",
-      "startLine": 60,
-      "crap": 2
+      "startLine": 70,
+      "crap": 1
     },
     {
       "path": ".agents/scripts/lib/observability/active-story-env.js",
       "method": "setActiveStoryEnv",
-      "startLine": 92,
-      "crap": 11
+      "startLine": 96,
+      "crap": 7.246857142857142
     },
     {
       "path": ".agents/scripts/lib/observability/active-story-env.js",
       "method": "clearActiveStoryEnv",
-      "startLine": 154,
+      "startLine": 142,
       "crap": 6.318832260445283
     },
     {
-      "path": ".agents/scripts/lib/observability/baseline-refresh-rate.js",
-      "method": "toEpochMs",
-      "startLine": 45,
-      "crap": 4
-    },
-    {
-      "path": ".agents/scripts/lib/observability/baseline-refresh-rate.js",
-      "method": "classifySubject",
-      "startLine": 65,
-      "crap": 5
-    },
-    {
-      "path": ".agents/scripts/lib/observability/baseline-refresh-rate.js",
-      "method": "computeCutoffMs",
-      "startLine": 76,
+      "path": ".agents/scripts/lib/observability/metrics-ledger.js",
+      "method": "planMetricsPath",
+      "startLine": 83,
       "crap": 3
     },
     {
-      "path": ".agents/scripts/lib/observability/baseline-refresh-rate.js",
-      "method": "computeBaselineRefreshRate",
-      "startLine": 127,
-      "crap": 14
+      "path": ".agents/scripts/lib/observability/metrics-ledger.js",
+      "method": "rotateIfNeeded",
+      "startLine": 104,
+      "crap": 2
     },
     {
-      "path": ".agents/scripts/lib/observability/baseline-refresh-rate.js",
+      "path": ".agents/scripts/lib/observability/metrics-ledger.js",
+      "method": "appendLedgerRecord",
+      "startLine": 133,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/observability/metrics-ledger.js",
+      "method": "appendFindingsYield",
+      "startLine": 163,
+      "crap": 13.454545454545453
+    },
+    {
+      "path": ".agents/scripts/lib/observability/metrics-ledger.js",
+      "method": "<anon method-1>",
+      "startLine": 190,
+      "crap": 3.182569496619083
+    },
+    {
+      "path": ".agents/scripts/lib/observability/metrics-ledger.js",
       "method": "<anon method-2>",
-      "startLine": 140,
-      "crap": 2
+      "startLine": 191,
+      "crap": 3.182569496619083
     },
     {
-      "path": ".agents/scripts/lib/observability/baseline-refresh-rate.js",
-      "method": "roundRate",
-      "startLine": 210,
-      "crap": 2
-    },
-    {
-      "path": ".agents/scripts/lib/observability/hook-heartbeat.js",
-      "method": "resolveHeartbeatTarget",
-      "startLine": 68,
-      "crap": 10
-    },
-    {
-      "path": ".agents/scripts/lib/observability/hook-heartbeat.js",
-      "method": "heartbeatMarkerName",
-      "startLine": 102,
+      "path": ".agents/scripts/lib/observability/runtime-friction.js",
+      "method": "preview",
+      "startLine": 87,
       "crap": 1
     },
     {
-      "path": ".agents/scripts/lib/observability/hook-heartbeat.js",
-      "method": "shouldEmitHeartbeat",
-      "startLine": 114,
+      "path": ".agents/scripts/lib/observability/runtime-friction.js",
+      "method": "positiveIntOrNull",
+      "startLine": 95,
+      "crap": 3
+    },
+    {
+      "path": ".agents/scripts/lib/observability/runtime-friction.js",
+      "method": "emitRuntimeFriction",
+      "startLine": 116,
+      "crap": 8.455166135639509
+    },
+    {
+      "path": ".agents/scripts/lib/observability/runtime-friction.js",
+      "method": "emitBlockRecoveredFriction",
+      "startLine": 192,
       "crap": 1
     },
     {
-      "path": ".agents/scripts/lib/observability/hook-heartbeat.js",
-      "method": "touchMarker",
-      "startLine": 135,
-      "crap": 1.015625
+      "path": ".agents/scripts/lib/observability/runtime-friction.js",
+      "method": "emitRecoveredFrictionMarker",
+      "startLine": 265,
+      "crap": 8.1865889212828
     },
     {
-      "path": ".agents/scripts/lib/observability/hook-heartbeat.js",
-      "method": "emitHeartbeatFromHook",
-      "startLine": 156,
-      "crap": 4.028494309486045
+      "path": ".agents/scripts/lib/observability/runtime-friction.js",
+      "method": "<anon method-1>",
+      "startLine": 287,
+      "crap": 5.072886297376093
     },
     {
-      "path": ".agents/scripts/lib/observability/perf-aggregator.js",
-      "method": "nonNegativeInt",
-      "startLine": 58,
-      "crap": 3
+      "path": ".agents/scripts/lib/observability/runtime-friction.js",
+      "method": "emitCloseRecoveredFriction",
+      "startLine": 327,
+      "crap": 1
     },
     {
-      "path": ".agents/scripts/lib/observability/perf-aggregator.js",
-      "method": "nonNegativeNumber",
-      "startLine": 64,
-      "crap": 3
-    },
-    {
-      "path": ".agents/scripts/lib/observability/perf-aggregator.js",
-      "method": "frictionByCategory",
-      "startLine": 77,
-      "crap": 5
-    },
-    {
-      "path": ".agents/scripts/lib/observability/perf-aggregator.js",
-      "method": "topSlowPhasesVsBaseline",
-      "startLine": 101,
-      "crap": 11.009944933015534
-    },
-    {
-      "path": ".agents/scripts/lib/observability/perf-aggregator.js",
-      "method": "reworkScore",
-      "startLine": 134,
+      "path": ".agents/scripts/lib/observability/runtime-friction.js",
+      "method": "normalizeGatheredSignal",
+      "startLine": 355,
       "crap": 9
     },
     {
-      "path": ".agents/scripts/lib/observability/perf-aggregator.js",
-      "method": "retryDensity",
-      "startLine": 170,
-      "crap": 6
-    },
-    {
-      "path": ".agents/scripts/lib/observability/perf-aggregator.js",
-      "method": "phaseTimingsMs",
-      "startLine": 192,
-      "crap": 6
-    },
-    {
-      "path": ".agents/scripts/lib/observability/perf-aggregator.js",
-      "method": "computeStoryPerfSummary",
-      "startLine": 212,
-      "crap": 10.013486404018948
-    },
-    {
-      "path": ".agents/scripts/lib/observability/perf-aggregator.js",
-      "method": "collectValidStorySamples",
-      "startLine": 277,
-      "crap": 4
-    },
-    {
-      "path": ".agents/scripts/lib/observability/perf-aggregator.js",
-      "method": "buildSignalCounts",
-      "startLine": 296,
-      "crap": 6
-    },
-    {
-      "path": ".agents/scripts/lib/observability/perf-aggregator.js",
-      "method": "aggregateTopHotspots",
-      "startLine": 334,
-      "crap": 4
-    },
-    {
-      "path": ".agents/scripts/lib/observability/perf-aggregator.js",
-      "method": "tsOf",
-      "startLine": 377,
-      "crap": 1
-    },
-    {
-      "path": ".agents/scripts/lib/observability/perf-aggregator.js",
-      "method": "tsToMs",
-      "startLine": 381,
-      "crap": 3
-    },
-    {
-      "path": ".agents/scripts/lib/observability/perf-aggregator.js",
-      "method": "storyIdOf",
+      "path": ".agents/scripts/lib/observability/runtime-friction.js",
+      "method": "isRecoveredSignal",
       "startLine": 387,
-      "crap": 3
+      "crap": 7
     },
     {
-      "path": ".agents/scripts/lib/observability/perf-aggregator.js",
-      "method": "materialiseTimedEvents",
-      "startLine": 403,
-      "crap": 3
+      "path": ".agents/scripts/lib/observability/runtime-friction.js",
+      "method": "frictionForTerminal",
+      "startLine": 439,
+      "crap": 9
     },
     {
-      "path": ".agents/scripts/lib/observability/perf-aggregator.js",
-      "method": "indexStoryWindows",
-      "startLine": 423,
-      "crap": 13.013890030410126
+      "path": ".agents/scripts/lib/observability/runtime-friction.js",
+      "method": "emitTerminalFriction",
+      "startLine": 494,
+      "crap": 2
     },
     {
-      "path": ".agents/scripts/lib/observability/perf-aggregator.js",
-      "method": "bucketWaves",
-      "startLine": 456,
-      "crap": 13.097800925925926
+      "path": ".agents/scripts/lib/observability/signal-validator.js",
+      "method": "buildValidator",
+      "startLine": 58,
+      "crap": 2.4065185185185185
     },
     {
-      "path": ".agents/scripts/lib/observability/perf-aggregator.js",
-      "method": "maxInWindow",
-      "startLine": 504,
-      "crap": 5
+      "path": ".agents/scripts/lib/observability/signal-validator.js",
+      "method": "violatingFieldOf",
+      "startLine": 84,
+      "crap": 12.544270303277019
     },
     {
-      "path": ".agents/scripts/lib/observability/perf-aggregator.js",
-      "method": "fillMissingWaveEnds",
-      "startLine": 534,
-      "crap": 8
+      "path": ".agents/scripts/lib/observability/signal-validator.js",
+      "method": "validateSignal",
+      "startLine": 112,
+      "crap": 6.058619987787503
     },
     {
-      "path": ".agents/scripts/lib/observability/perf-aggregator.js",
-      "method": "computeWaveParallelismRows",
-      "startLine": 601,
-      "crap": 13
+      "path": ".agents/scripts/lib/observability/signal-validator.js",
+      "method": "recordSignalReject",
+      "startLine": 140,
+      "crap": 9.583984375
     },
     {
-      "path": ".agents/scripts/lib/observability/perf-aggregator.js",
-      "method": "clamp",
-      "startLine": 671,
-      "crap": 4
-    },
-    {
-      "path": ".agents/scripts/lib/observability/perf-aggregator.js",
-      "method": "coerceWaveParallelismRow",
-      "startLine": 698,
-      "crap": 4
-    },
-    {
-      "path": ".agents/scripts/lib/observability/perf-aggregator.js",
-      "method": "computeEpicPerfReport",
-      "startLine": 713,
-      "crap": 9.001889212827988
-    },
-    {
-      "path": ".agents/scripts/lib/observability/perf-aggregator.js",
-      "method": "computeStoryPerfSummaryFromStore",
-      "startLine": 809,
-      "crap": 3.009
-    },
-    {
-      "path": ".agents/scripts/lib/observability/perf-aggregator.js",
-      "method": "computeEpicPerfReportFromStore",
-      "startLine": 848,
-      "crap": 3.0146549969468754
-    },
-    {
-      "path": ".agents/scripts/lib/observability/perf-report-readers.js",
-      "method": "readEpicLifecycleEvents",
-      "startLine": 34,
-      "crap": 5.024
-    },
-    {
-      "path": ".agents/scripts/lib/observability/perf-report-readers.js",
-      "method": "readStorySignals",
-      "startLine": 55,
-      "crap": 1
-    },
-    {
-      "path": ".agents/scripts/lib/observability/perf-report-readers.js",
-      "method": "readPhaseTimings",
-      "startLine": 74,
-      "crap": 6.141711619769646
-    },
-    {
-      "path": ".agents/scripts/lib/observability/perf-report-readers.js",
-      "method": "readGhSpawnCount",
-      "startLine": 102,
-      "crap": 6.189364674940412
-    },
-    {
-      "path": ".agents/scripts/lib/observability/perf-report-readers.js",
-      "method": "collectStorySummaries",
-      "startLine": 134,
-      "crap": 7.151973017939815
-    },
-    {
-      "path": ".agents/scripts/lib/observability/perf-report-readers.js",
-      "method": "gatherEpicCommitsFromGit",
-      "startLine": 194,
-      "crap": 4.184216709744554
-    },
-    {
-      "path": ".agents/scripts/lib/observability/perf-report-readers.js",
-      "method": "aggregateBaselineFrictionFromSignals",
-      "startLine": 242,
-      "crap": 2.000067432020095
-    },
-    {
-      "path": ".agents/scripts/lib/observability/perf-report-render.js",
-      "method": "renderStoryBody",
-      "startLine": 37,
-      "crap": 3
-    },
-    {
-      "path": ".agents/scripts/lib/observability/perf-report-render.js",
-      "method": "renderQualityGateFrictionBlock",
-      "startLine": 82,
-      "crap": 4
-    },
-    {
-      "path": ".agents/scripts/lib/observability/perf-report-render.js",
-      "method": "renderBaselineRefreshRateRow",
-      "startLine": 107,
-      "crap": 4
-    },
-    {
-      "path": ".agents/scripts/lib/observability/perf-report-render.js",
-      "method": "renderEpicBody",
-      "startLine": 126,
-      "crap": 4
-    },
-    {
-      "path": ".agents/scripts/lib/observability/perf-report-render.js",
-      "method": "extractStoryPerfSummaryFromComment",
-      "startLine": 175,
-      "crap": 5
+      "path": ".agents/scripts/lib/observability/signal-validator.js",
+      "method": "readSignalRejectCount",
+      "startLine": 189,
+      "crap": 5.048828125
     },
     {
       "path": ".agents/scripts/lib/observability/signals-writer.js",
       "method": "tracesFile",
-      "startLine": 55,
+      "startLine": 51,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/observability/signals-writer.js",
       "method": "tagSignalSource",
-      "startLine": 81,
-      "crap": 6
+      "startLine": 80,
+      "crap": 9
+    },
+    {
+      "path": ".agents/scripts/lib/observability/signals-writer.js",
+      "method": "validateOrDrop",
+      "startLine": 118,
+      "crap": 2
     },
     {
       "path": ".agents/scripts/lib/observability/signals-writer.js",
       "method": "appendOne",
-      "startLine": 116,
-      "crap": 3
+      "startLine": 137,
+      "crap": 3.1756372325898954
     },
     {
       "path": ".agents/scripts/lib/observability/signals-writer.js",
       "method": "appendSignal",
-      "startLine": 153,
-      "crap": 2
-    },
-    {
-      "path": ".agents/scripts/lib/observability/signals-writer.js",
-      "method": "appendEpicSignal",
-      "startLine": 178,
-      "crap": 2.4065185185185185
+      "startLine": 174,
+      "crap": 4
     },
     {
       "path": ".agents/scripts/lib/observability/signals-writer.js",
       "method": "appendTrace",
-      "startLine": 201,
-      "crap": 2
+      "startLine": 204,
+      "crap": 4
+    },
+    {
+      "path": ".agents/scripts/lib/observability/signals-writer.js",
+      "method": "forEachLineIn",
+      "startLine": 242,
+      "crap": 5.045899242662496
     },
     {
       "path": ".agents/scripts/lib/observability/signals-writer.js",
       "method": "forEachLine",
-      "startLine": 231,
-      "crap": 7.036814425244177
+      "startLine": 304,
+      "crap": 3
     },
     {
       "path": ".agents/scripts/lib/observability/source-classifier.js",
@@ -5856,6 +10819,24 @@
       "crap": 3
     },
     {
+      "path": ".agents/scripts/lib/observability/terse-result.js",
+      "method": "slugify",
+      "startLine": 38,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/observability/terse-result.js",
+      "method": "detailBlock",
+      "startLine": 56,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/observability/terse-result.js",
+      "method": "emitTerseResult",
+      "startLine": 79,
+      "crap": 3
+    },
+    {
       "path": ".agents/scripts/lib/observability/tool-trace-hook.js",
       "method": "hashTarget",
       "startLine": 84,
@@ -5866,6 +10847,12 @@
       "method": "normaliseBashCommand",
       "startLine": 124,
       "crap": 6
+    },
+    {
+      "path": ".agents/scripts/lib/observability/tool-trace-hook.js",
+      "method": "<anon method-1>",
+      "startLine": 135,
+      "crap": 1
     },
     {
       "path": ".agents/scripts/lib/observability/tool-trace-hook.js",
@@ -5889,36 +10876,42 @@
       "path": ".agents/scripts/lib/observability/tool-trace-hook.js",
       "method": "buildDetails",
       "startLine": 226,
-      "crap": 13
+      "crap": 15
+    },
+    {
+      "path": ".agents/scripts/lib/observability/tool-trace-hook.js",
+      "method": "extractExitCode",
+      "startLine": 297,
+      "crap": 3
     },
     {
       "path": ".agents/scripts/lib/observability/tool-trace-hook.js",
       "method": "handlePre",
-      "startLine": 286,
+      "startLine": 323,
       "crap": 2
     },
     {
       "path": ".agents/scripts/lib/observability/tool-trace-hook.js",
       "method": "handlePost",
-      "startLine": 305,
+      "startLine": 342,
       "crap": 4
     },
     {
       "path": ".agents/scripts/lib/observability/tool-trace-hook.js",
       "method": "main",
-      "startLine": 344,
-      "crap": 6.422614575507137
+      "startLine": 382,
+      "crap": 7.5034108654557405
     },
     {
       "path": ".agents/scripts/lib/observability/tool-trace-hook.js",
       "method": "runFromStdin",
-      "startLine": 377,
+      "startLine": 416,
       "crap": 10.65242746756087
     },
     {
       "path": ".agents/scripts/lib/observability/tool-trace-hook.js",
       "method": "_resetInflightForTests",
-      "startLine": 415,
+      "startLine": 454,
       "crap": 1
     },
     {
@@ -5926,6 +10919,12 @@
       "method": "formatMissingList",
       "startLine": 52,
       "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/onboard/init-tail.js",
+      "method": "<anon method-1>",
+      "startLine": 54,
+      "crap": 1
     },
     {
       "path": ".agents/scripts/lib/onboard/init-tail.js",
@@ -5946,16 +10945,154 @@
       "crap": 1.216
     },
     {
-      "path": ".agents/scripts/lib/orchestration/audit-lens-routing.js",
-      "method": "resolveAuditLenses",
-      "startLine": 82,
+      "path": ".agents/scripts/lib/onboard/scaffold-docs.js",
+      "method": "genericStub",
+      "startLine": 43,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/onboard/scaffold-docs.js",
+      "method": "<anon method-1>",
+      "startLine": 48,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/onboard/scaffold-docs.js",
+      "method": "stubContentFor",
+      "startLine": 69,
+      "crap": 3
+    },
+    {
+      "path": ".agents/scripts/lib/onboard/scaffold-docs.js",
+      "method": "scaffoldDocs",
+      "startLine": 101,
+      "crap": 4
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/acceptance-clusters.js",
+      "method": "clusterAcceptanceCriteria",
+      "startLine": 53,
+      "crap": 7
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/acceptance-clusters.js",
+      "method": "<anon method-1>",
+      "startLine": 55,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/acceptance-clusters.js",
+      "method": "expectedClusterCount",
+      "startLine": 86,
+      "crap": 7
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/acceptance-clusters.js",
+      "method": "clusterAcceptanceForConfig",
+      "startLine": 106,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/acceptance-eval-decision.js",
+      "method": "effectiveCap",
+      "startLine": 65,
+      "crap": 4
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/acceptance-eval-decision.js",
+      "method": "partitionCriteria",
+      "startLine": 83,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/acceptance-eval-decision.js",
+      "method": "<anon method-1>",
+      "startLine": 87,
+      "crap": 6
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/acceptance-eval-decision.js",
+      "method": "decideAcceptanceEval",
+      "startLine": 127,
       "crap": 5
     },
     {
-      "path": ".agents/scripts/lib/orchestration/audit-lens-routing.js",
-      "method": "planAuditLenses",
-      "startLine": 111,
+      "path": ".agents/scripts/lib/orchestration/acceptance-eval-decision.js",
+      "method": "buildAcceptanceEvalSignal",
+      "startLine": 169,
+      "crap": 3
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/acceptance-eval-decision.js",
+      "method": "<anon method-2>",
+      "startLine": 195,
       "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/acceptance-eval-decision.js",
+      "method": "deriveAcceptanceEvalRound",
+      "startLine": 226,
+      "crap": 11.000968
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/auto-merge-cwd.js",
+      "method": "parseWorktreeList",
+      "startLine": 58,
+      "crap": 6
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/auto-merge-cwd.js",
+      "method": "pickPrimaryWorktreePath",
+      "startLine": 92,
+      "crap": 6
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/auto-merge-cwd.js",
+      "method": "resolveAutoMergeArmCwd",
+      "startLine": 112,
+      "crap": 6
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/ceremony-routing.js",
+      "method": "verdictOwnerForMode",
+      "startLine": 92,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/ceremony-routing.js",
+      "method": "normalizeCeremonyProfile",
+      "startLine": 110,
+      "crap": 4
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/ceremony-routing.js",
+      "method": "sampledFresh",
+      "startLine": 131,
+      "crap": 8
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/ceremony-routing.js",
+      "method": "resolveCeremonyForRisk",
+      "startLine": 165,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/ceremony-routing.js",
+      "method": "resolveCeremonyDecision",
+      "startLine": 183,
+      "crap": 14
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/change-set.js",
+      "method": "normalizeFileList",
+      "startLine": 51,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/change-set.js",
+      "method": "computeChangeSet",
+      "startLine": 74,
+      "crap": 8
     },
     {
       "path": ".agents/scripts/lib/orchestration/check-baselines/phases/compare.js",
@@ -5997,13 +11134,31 @@
       "path": ".agents/scripts/lib/orchestration/check-baselines/phases/compare.js",
       "method": "tolerantNumericFields",
       "startLine": 97,
-      "crap": 12
+      "crap": 3
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/check-baselines/phases/compare.js",
+      "method": "<anon method-1>",
+      "startLine": 101,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/check-baselines/phases/compare.js",
+      "method": "<anon method-2>",
+      "startLine": 103,
+      "crap": 1
     },
     {
       "path": ".agents/scripts/lib/orchestration/check-baselines/phases/compare.js",
       "method": "regressionExceedsTolerance",
       "startLine": 106,
-      "crap": 6
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/check-baselines/phases/compare.js",
+      "method": "<anon method-3>",
+      "startLine": 109,
+      "crap": 1
     },
     {
       "path": ".agents/scripts/lib/orchestration/check-baselines/phases/compare.js",
@@ -6013,74 +11168,134 @@
     },
     {
       "path": ".agents/scripts/lib/orchestration/check-baselines/phases/evaluate.js",
+      "method": "rollupExcludingIgnored",
+      "startLine": 59,
+      "crap": 8.042081038875647
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/check-baselines/phases/evaluate.js",
+      "method": "<anon method-1>",
+      "startLine": 72,
+      "crap": 2.002630064929728
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/check-baselines/phases/evaluate.js",
       "method": "loadHeadBaseline",
-      "startLine": 15,
+      "startLine": 83,
       "crap": 2
     },
     {
       "path": ".agents/scripts/lib/orchestration/check-baselines/phases/evaluate.js",
+      "method": "applyBundleSizeAcknowledgment",
+      "startLine": 103,
+      "crap": 4
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/check-baselines/phases/evaluate.js",
+      "method": "resolveMaintainabilityRefreshTrigger",
+      "startLine": 141,
+      "crap": 8
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/check-baselines/phases/evaluate.js",
+      "method": "<anon method-2>",
+      "startLine": 161,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/check-baselines/phases/evaluate.js",
+      "method": "applyMaintainabilityAcknowledgment",
+      "startLine": 183,
+      "crap": 4
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/check-baselines/phases/evaluate.js",
       "method": "buildGateReport",
-      "startLine": 25,
+      "startLine": 207,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/orchestration/check-baselines/phases/evaluate.js",
       "method": "evaluateKind",
-      "startLine": 56,
-      "crap": 2
+      "startLine": 240,
+      "crap": 4.011388483965015
     },
     {
       "path": ".agents/scripts/lib/orchestration/check-baselines/phases/floors.js",
       "method": "axisDirection",
       "startLine": 13,
-      "crap": 7
+      "crap": 8
     },
     {
       "path": ".agents/scripts/lib/orchestration/check-baselines/phases/floors.js",
       "method": "compareToFloor",
-      "startLine": 28,
+      "startLine": 29,
       "crap": 9
     },
     {
       "path": ".agents/scripts/lib/orchestration/check-baselines/phases/floors.js",
       "method": "suggestAxis",
-      "startLine": 47,
+      "startLine": 48,
       "crap": 4
     },
     {
       "path": ".agents/scripts/lib/orchestration/check-baselines/phases/floors.js",
       "method": "buildAxisMismatchError",
-      "startLine": 57,
+      "startLine": 58,
       "crap": 3
     },
     {
       "path": ".agents/scripts/lib/orchestration/check-baselines/phases/floors.js",
+      "method": "<anon method-1>",
+      "startLine": 59,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/check-baselines/phases/floors.js",
       "method": "assertFloorAxesExist",
-      "startLine": 80,
+      "startLine": 81,
       "crap": 8
     },
     {
       "path": ".agents/scripts/lib/orchestration/check-baselines/phases/floors.js",
       "method": "collectComponentNames",
-      "startLine": 93,
+      "startLine": 94,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/orchestration/check-baselines/phases/floors.js",
       "method": "evaluateComponentFloor",
-      "startLine": 101,
+      "startLine": 102,
       "crap": 3
     },
     {
       "path": ".agents/scripts/lib/orchestration/check-baselines/phases/floors.js",
       "method": "applyFloors",
-      "startLine": 113,
+      "startLine": 114,
       "crap": 2
     },
     {
       "path": ".agents/scripts/lib/orchestration/check-baselines/phases/floors.js",
+      "method": "<anon method-2>",
+      "startLine": 120,
+      "crap": 3
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/check-baselines/phases/floors.js",
       "method": "flattenBreaches",
-      "startLine": 127,
+      "startLine": 128,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/check-baselines/phases/floors.js",
+      "method": "<anon method-3>",
+      "startLine": 129,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/check-baselines/phases/floors.js",
+      "method": "<anon method-4>",
+      "startLine": 130,
       "crap": 1
     },
     {
@@ -6146,20 +11361,32 @@
     {
       "path": ".agents/scripts/lib/orchestration/check-baselines/phases/parse-args.js",
       "method": "helpReport",
-      "startLine": 52,
+      "startLine": 68,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/orchestration/check-baselines/phases/parse-args.js",
       "method": "flattenGateTokens",
-      "startLine": 67,
+      "startLine": 83,
       "crap": 6
     },
     {
       "path": ".agents/scripts/lib/orchestration/check-baselines/phases/parse-args.js",
       "method": "parseArgs",
-      "startLine": 101,
+      "startLine": 117,
       "crap": 10.007705421727364
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/check-baselines/phases/parse-args.js",
+      "method": "<anon method-1>",
+      "startLine": 120,
+      "crap": 2.0003082168690947
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/check-baselines/phases/parse-args.js",
+      "method": "<anon method-2>",
+      "startLine": 136,
+      "crap": 2.0003082168690947
     },
     {
       "path": ".agents/scripts/lib/orchestration/check-baselines/phases/pipeline.js",
@@ -6181,8 +11408,20 @@
     },
     {
       "path": ".agents/scripts/lib/orchestration/check-baselines/phases/pipeline.js",
+      "method": "<anon method-1>",
+      "startLine": 54,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/check-baselines/phases/pipeline.js",
       "method": "dispatchPerKind",
       "startLine": 57,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/check-baselines/phases/pipeline.js",
+      "method": "<anon method-2>",
+      "startLine": 59,
       "crap": 1
     },
     {
@@ -6231,121 +11470,355 @@
       "path": ".agents/scripts/lib/orchestration/check-baselines/phases/report.js",
       "method": "formatGateLine",
       "startLine": 24,
-      "crap": 3
+      "crap": 4
     },
     {
       "path": ".agents/scripts/lib/orchestration/check-baselines/phases/report.js",
       "method": "formatViolationLine",
-      "startLine": 33,
+      "startLine": 34,
       "crap": 2
     },
     {
       "path": ".agents/scripts/lib/orchestration/check-baselines/phases/report.js",
       "method": "appendGateText",
-      "startLine": 38,
+      "startLine": 39,
       "crap": 2
     },
     {
       "path": ".agents/scripts/lib/orchestration/check-baselines/phases/report.js",
       "method": "formatReport",
-      "startLine": 48,
+      "startLine": 49,
       "crap": 2.0438957475994513
     },
     {
       "path": ".agents/scripts/lib/orchestration/code-review.js",
-      "method": "countChangedFiles",
-      "startLine": 73,
-      "crap": 4.018661612479954
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/code-review.js",
-      "method": "buildCodeReviewEndPayload",
-      "startLine": 108,
-      "crap": 7
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/code-review.js",
       "method": "resolveConfigBase",
-      "startLine": 133,
+      "startLine": 72,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/orchestration/code-review.js",
       "method": "resolveCommentTargetId",
-      "startLine": 140,
+      "startLine": 77,
       "crap": 3
     },
     {
       "path": ".agents/scripts/lib/orchestration/code-review.js",
       "method": "resolveStoryScope",
-      "startLine": 159,
-      "crap": 30
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/code-review.js",
-      "method": "resolveEpicScope",
-      "startLine": 198,
-      "crap": 3
+      "startLine": 95,
+      "crap": 5.150262960180315
     },
     {
       "path": ".agents/scripts/lib/orchestration/code-review.js",
       "method": "resolveScopeEnvelope",
-      "startLine": 222,
-      "crap": 2
+      "startLine": 123,
+      "crap": 1
     },
     {
       "path": ".agents/scripts/lib/orchestration/code-review.js",
       "method": "resolveProviderName",
-      "startLine": 297,
-      "crap": 6
+      "startLine": 188,
+      "crap": 5
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/code-review.js",
+      "method": "<anon method-1>",
+      "startLine": 197,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/code-review.js",
+      "method": "resolveInjectedChangedFiles",
+      "startLine": 215,
+      "crap": 3
     },
     {
       "path": ".agents/scripts/lib/orchestration/code-review.js",
       "method": "buildReviewInput",
-      "startLine": 322,
+      "startLine": 231,
       "crap": 3
     },
     {
       "path": ".agents/scripts/lib/orchestration/code-review.js",
       "method": "resolvePromptMessages",
-      "startLine": 350,
+      "startLine": 261,
       "crap": 3.0885568513119535
     },
     {
       "path": ".agents/scripts/lib/orchestration/code-review.js",
       "method": "postReviewComment",
-      "startLine": 370,
+      "startLine": 281,
       "crap": 3.002416837299856
     },
     {
       "path": ".agents/scripts/lib/orchestration/code-review.js",
       "method": "executeReviewPipeline",
-      "startLine": 408,
-      "crap": 4.00003948433459
+      "startLine": 319,
+      "crap": 3.002776242275877
     },
     {
       "path": ".agents/scripts/lib/orchestration/code-review.js",
       "method": "runCodeReview",
-      "startLine": 483,
-      "crap": 8
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/code-review.js",
-      "method": "<anon method-3>",
-      "startLine": 504,
-      "crap": 3
+      "startLine": 394,
+      "crap": 1
     },
     {
       "path": ".agents/scripts/lib/orchestration/column-sync.js",
       "method": "columnForLabels",
-      "startLine": 55,
+      "startLine": 61,
       "crap": 7
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/complexity-gate.js",
+      "method": "normalizeBucket",
+      "startLine": 198,
+      "crap": 6
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/complexity-gate.js",
+      "method": "resolveChangeKinds",
+      "startLine": 213,
+      "crap": 4
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/complexity-gate.js",
+      "method": "<anon method-1>",
+      "startLine": 214,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/complexity-gate.js",
+      "method": "<anon method-2>",
+      "startLine": 216,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/complexity-gate.js",
+      "method": "<anon method-3>",
+      "startLine": 217,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/complexity-gate.js",
+      "method": "<anon method-4>",
+      "startLine": 220,
+      "crap": 5
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/complexity-gate.js",
+      "method": "resolveDeployables",
+      "startLine": 236,
+      "crap": 3
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/complexity-gate.js",
+      "method": "<anon method-5>",
+      "startLine": 241,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/complexity-gate.js",
+      "method": "spansMigrationAndConsumers",
+      "startLine": 257,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/complexity-gate.js",
+      "method": "<anon method-6>",
+      "startLine": 258,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/complexity-gate.js",
+      "method": "<anon method-7>",
+      "startLine": 274,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/complexity-gate.js",
+      "method": "<anon method-8>",
+      "startLine": 275,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/complexity-gate.js",
+      "method": "<anon method-9>",
+      "startLine": 279,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/complexity-gate.js",
+      "method": "<anon method-10>",
+      "startLine": 282,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/complexity-gate.js",
+      "method": "<anon method-11>",
+      "startLine": 286,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/complexity-gate.js",
+      "method": "<anon method-12>",
+      "startLine": 289,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/complexity-gate.js",
+      "method": "<anon method-13>",
+      "startLine": 293,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/complexity-gate.js",
+      "method": "<anon method-14>",
+      "startLine": 294,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/complexity-gate.js",
+      "method": "<anon method-15>",
+      "startLine": 298,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/complexity-gate.js",
+      "method": "<anon method-16>",
+      "startLine": 299,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/complexity-gate.js",
+      "method": "<anon method-17>",
+      "startLine": 303,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/complexity-gate.js",
+      "method": "<anon method-18>",
+      "startLine": 304,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/complexity-gate.js",
+      "method": "firstEffortViolation",
+      "startLine": 316,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/complexity-gate.js",
+      "method": "normalizeCeiling",
+      "startLine": 346,
+      "crap": 4
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/complexity-gate.js",
+      "method": "resolveComplexityGate",
+      "startLine": 369,
+      "crap": 4
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/complexity-gate.js",
+      "method": "countSeedArtifacts",
+      "startLine": 392,
+      "crap": 3
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/complexity-gate.js",
+      "method": "<anon method-19>",
+      "startLine": 396,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/complexity-gate.js",
+      "method": "extractPredictedPaths",
+      "startLine": 410,
+      "crap": 5
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/complexity-gate.js",
+      "method": "buildComplexitySignals",
+      "startLine": 467,
+      "crap": 6.00182898948331
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/complexity-gate.js",
+      "method": "<anon method-20>",
+      "startLine": 483,
+      "crap": 3.0004572473708278
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/complexity-gate.js",
+      "method": "resolvePlannerRouteVerdict",
+      "startLine": 545,
+      "crap": 3
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/complexity-gate.js",
+      "method": "buildEffortShape",
+      "startLine": 590,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/complexity-gate.js",
+      "method": "deriveStoryShape",
+      "startLine": 662,
+      "crap": 7
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/complexity-gate.js",
+      "method": "<anon method-21>",
+      "startLine": 673,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/complexity-gate.js",
+      "method": "<anon method-22>",
+      "startLine": 698,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/complexity-gate.js",
+      "method": "<anon method-23>",
+      "startLine": 714,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/complexity-gate.js",
+      "method": "deriveStoryRouteFromBody",
+      "startLine": 764,
+      "crap": 1.0939143501126973
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/complexity-gate.js",
+      "method": "routeForReporting",
+      "startLine": 797,
+      "crap": 3
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/complexity-gate.js",
+      "method": "resolveStoryDispatchMode",
+      "startLine": 845,
+      "crap": 8
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/complexity-gate.js",
+      "method": "<anon method-24>",
+      "startLine": 854,
+      "crap": 1
     },
     {
       "path": ".agents/scripts/lib/orchestration/consolidation-precondition.js",
       "method": "splitTableRow",
       "startLine": 50,
       "crap": 3
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/consolidation-precondition.js",
+      "method": "<anon method-1>",
+      "startLine": 54,
+      "crap": 1
     },
     {
       "path": ".agents/scripts/lib/orchestration/consolidation-precondition.js",
@@ -6361,6 +11834,18 @@
     },
     {
       "path": ".agents/scripts/lib/orchestration/consolidation-precondition.js",
+      "method": "<anon method-2>",
+      "startLine": 91,
+      "crap": 1.0001714677640603
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/consolidation-precondition.js",
+      "method": "<anon method-3>",
+      "startLine": 107,
+      "crap": 1.0001714677640603
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/consolidation-precondition.js",
       "method": "isBddScaffoldStory",
       "startLine": 135,
       "crap": 2
@@ -6370,6 +11855,12 @@
       "method": "evaluateConsolidationPrecondition",
       "startLine": 161,
       "crap": 11
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/consolidation-precondition.js",
+      "method": "<anon method-4>",
+      "startLine": 180,
+      "crap": 1
     },
     {
       "path": ".agents/scripts/lib/orchestration/context-envelope.js",
@@ -6387,6 +11878,12 @@
       "path": ".agents/scripts/lib/orchestration/context-envelope.js",
       "method": "totalSectionTokens",
       "startLine": 118,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/context-envelope.js",
+      "method": "<anon method-1>",
+      "startLine": 119,
       "crap": 1
     },
     {
@@ -6409,92 +11906,146 @@
     },
     {
       "path": ".agents/scripts/lib/orchestration/context-envelope.js",
+      "method": "<anon method-2>",
+      "startLine": 185,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/context-envelope.js",
+      "method": "<anon method-3>",
+      "startLine": 196,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/context-envelope.js",
+      "method": "<anon method-4>",
+      "startLine": 202,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/context-envelope.js",
       "method": "envelopeToPrompt",
       "startLine": 248,
       "crap": 5.007407407407407
     },
     {
-      "path": ".agents/scripts/lib/orchestration/dependency-analyzer.js",
-      "method": "rollUpStoryFocus",
-      "startLine": 15,
+      "path": ".agents/scripts/lib/orchestration/context-envelope.js",
+      "method": "<anon method-5>",
+      "startLine": 250,
+      "crap": 1.0002962962962962
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/context-envelope.js",
+      "method": "<anon method-6>",
+      "startLine": 256,
+      "crap": 1.0002962962962962
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/deliver-recover.js",
+      "method": "probeTicket",
+      "startLine": 49,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/deliver-recover.js",
+      "method": "<anon method-1>",
+      "startLine": 54,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/deliver-recover.js",
+      "method": "probeBranch",
+      "startLine": 75,
       "crap": 4
     },
     {
-      "path": ".agents/scripts/lib/orchestration/dependency-analyzer.js",
-      "method": "isFocusOverlapEdgeEligible",
-      "startLine": 76,
-      "crap": 5
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/dependency-analyzer.js",
-      "method": "hasUsableFocus",
-      "startLine": 99,
-      "crap": 3
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/dependency-analyzer.js",
-      "method": "focusBagsOverlap",
-      "startLine": 113,
+      "path": ".agents/scripts/lib/orchestration/deliver-recover.js",
+      "method": "probePr",
+      "startLine": 114,
       "crap": 4
     },
     {
-      "path": ".agents/scripts/lib/orchestration/dependency-analyzer.js",
-      "method": "eitherDirectionAlreadyReachable",
-      "startLine": 131,
-      "crap": 3
+      "path": ".agents/scripts/lib/orchestration/deliver-recover.js",
+      "method": "decideRecovery",
+      "startLine": 144,
+      "crap": 12
     },
     {
-      "path": ".agents/scripts/lib/orchestration/dependency-analyzer.js",
-      "method": "pickEdgeDirection",
-      "startLine": 146,
-      "crap": 5
+      "path": ".agents/scripts/lib/orchestration/deliver-recover.js",
+      "method": "buildInTransitionVerdict",
+      "startLine": 303,
+      "crap": 1
     },
     {
-      "path": ".agents/scripts/lib/orchestration/dependency-analyzer.js",
-      "method": "addFocusOverlapEdges",
-      "startLine": 153,
-      "crap": 5
+      "path": ".agents/scripts/lib/orchestration/deliver-recover.js",
+      "method": "probeAndDecide",
+      "startLine": 325,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/deliver-recover.js",
+      "method": "recoverStory",
+      "startLine": 370,
+      "crap": 4
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/deliver-recover.js",
+      "method": "renderRecovery",
+      "startLine": 439,
+      "crap": 2.006513331976389
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/deliver-recover.js",
+      "method": "<anon method-2>",
+      "startLine": 446,
+      "crap": 1.0016283329940974
     },
     {
       "path": ".agents/scripts/lib/orchestration/dependency-analyzer.js",
       "method": "computeStoryWaves",
-      "startLine": 216,
-      "crap": 7.031392226003526
+      "startLine": 35,
+      "crap": 7
     },
     {
       "path": ".agents/scripts/lib/orchestration/detectors-phase.js",
       "method": "reapPhaseLogger",
-      "startLine": 48,
+      "startLine": 54,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/detectors-phase.js",
+      "method": "<anon method-1>",
+      "startLine": 55,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/orchestration/detectors-phase.js",
       "method": "resolveLastTaskId",
-      "startLine": 52,
+      "startLine": 58,
       "crap": 5
     },
     {
       "path": ".agents/scripts/lib/orchestration/detectors-phase.js",
       "method": "persistDetectorEvents",
-      "startLine": 59,
+      "startLine": 65,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/orchestration/detectors-phase.js",
       "method": "runOneDetector",
-      "startLine": 82,
+      "startLine": 88,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/orchestration/detectors-phase.js",
       "method": "isValidIdPair",
-      "startLine": 111,
+      "startLine": 117,
       "crap": 4
     },
     {
       "path": ".agents/scripts/lib/orchestration/detectors-phase.js",
       "method": "detectorsPhase",
-      "startLine": 131,
+      "startLine": 137,
       "crap": 2.0025626306941655
     },
     {
@@ -6502,6 +12053,12 @@
       "method": "readDocFiles",
       "startLine": 15,
       "crap": 4
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/doc-reader.js",
+      "method": "<anon method-1>",
+      "startLine": 19,
+      "crap": 2
     },
     {
       "path": ".agents/scripts/lib/orchestration/docs-digest.js",
@@ -6540,148 +12097,208 @@
       "crap": 2
     },
     {
-      "path": ".agents/scripts/lib/orchestration/error-journal.js",
-      "method": "serializeError",
-      "startLine": 108,
-      "crap": 5.034293552812072
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/error-journal.js",
-      "method": "emitMasksFor",
-      "startLine": 118,
-      "crap": 9.20539068369647
-    },
-    {
       "path": ".agents/scripts/lib/orchestration/file-assumptions.js",
       "method": "defaultGitRunner",
-      "startLine": 43,
-      "crap": 1
+      "startLine": 69,
+      "crap": 2
     },
     {
       "path": ".agents/scripts/lib/orchestration/file-assumptions.js",
       "method": "collectStoryAssumptionEntries",
-      "startLine": 66,
+      "startLine": 92,
       "crap": 9.021064696647178
     },
     {
       "path": ".agents/scripts/lib/orchestration/file-assumptions.js",
       "method": "hasLegacyChangeBullets",
-      "startLine": 123,
+      "startLine": 149,
       "crap": 4
     },
     {
       "path": ".agents/scripts/lib/orchestration/file-assumptions.js",
+      "method": "<anon method-1>",
+      "startLine": 153,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/file-assumptions.js",
       "method": "renderMismatch",
-      "startLine": 137,
-      "crap": 2
+      "startLine": 173,
+      "crap": 4
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/file-assumptions.js",
+      "method": "renderNormalization",
+      "startLine": 201,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/file-assumptions.js",
+      "method": "indexPathMutations",
+      "startLine": 217,
+      "crap": 7
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/file-assumptions.js",
+      "method": "predecessorMutator",
+      "startLine": 254,
+      "crap": 3
     },
     {
       "path": ".agents/scripts/lib/orchestration/file-assumptions.js",
       "method": "validateStoryFileAssumptions",
-      "startLine": 171,
-      "crap": 8
+      "startLine": 295,
+      "crap": 13
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/file-assumptions.js",
+      "method": "<anon method-2>",
+      "startLine": 302,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/file-assumptions.js",
+      "method": "concurrentCoCreator",
+      "startLine": 425,
+      "crap": 6
     },
     {
       "path": ".agents/scripts/lib/orchestration/file-assumptions.js",
       "method": "checkAssumption",
-      "startLine": 239,
-      "crap": 9.149767843645394
+      "startLine": 456,
+      "crap": 12.186027190112403
     },
     {
       "path": ".agents/scripts/lib/orchestration/git-cleanup/phases/branches-reap.js",
       "method": "reapWorktree",
-      "startLine": 26,
-      "crap": 5
+      "startLine": 56,
+      "crap": 7
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/git-cleanup/phases/branches-reap.js",
+      "method": "recordDeferredWorktree",
+      "startLine": 107,
+      "crap": 4.021947873799726
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/git-cleanup/phases/branches-reap.js",
+      "method": "storyIdFromBranch",
+      "startLine": 149,
+      "crap": 2
     },
     {
       "path": ".agents/scripts/lib/orchestration/git-cleanup/phases/branches-reap.js",
       "method": "reapLocalRef",
-      "startLine": 58,
+      "startLine": 154,
       "crap": 3
     },
     {
       "path": ".agents/scripts/lib/orchestration/git-cleanup/phases/branches-reap.js",
       "method": "reapRemoteRef",
-      "startLine": 80,
+      "startLine": 176,
       "crap": 2
     },
     {
       "path": ".agents/scripts/lib/orchestration/git-cleanup/phases/branches-reap.js",
       "method": "buildPruneSummary",
-      "startLine": 105,
+      "startLine": 201,
       "crap": 2
     },
     {
       "path": ".agents/scripts/lib/orchestration/git-cleanup/phases/branches.js",
       "method": "skipEntryFromVerdict",
-      "startLine": 36,
+      "startLine": 44,
       "crap": 4
     },
     {
       "path": ".agents/scripts/lib/orchestration/git-cleanup/phases/branches.js",
-      "method": "evaluateLocalBranch",
-      "startLine": 44,
-      "crap": 6
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/git-cleanup/phases/branches.js",
-      "method": "collectRemoteOnlyCandidates",
-      "startLine": 94,
-      "crap": 6
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/git-cleanup/phases/branches.js",
-      "method": "planCleanup",
-      "startLine": 157,
+      "method": "evaluateContentEquivalence",
+      "startLine": 60,
       "crap": 3
     },
     {
       "path": ".agents/scripts/lib/orchestration/git-cleanup/phases/branches.js",
+      "method": "evaluateLocalBranch",
+      "startLine": 80,
+      "crap": 7
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/git-cleanup/phases/branches.js",
+      "method": "collectRemoteOnlyCandidates",
+      "startLine": 141,
+      "crap": 6
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/git-cleanup/phases/branches.js",
+      "method": "buildGuardedPrProbe",
+      "startLine": 221,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/git-cleanup/phases/branches.js",
       "method": "<anon method-1>",
-      "startLine": 170,
+      "startLine": 229,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/git-cleanup/phases/branches.js",
+      "method": "planCleanup",
+      "startLine": 240,
+      "crap": 4
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/git-cleanup/phases/branches.js",
+      "method": "<anon method-2>",
+      "startLine": 256,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/orchestration/git-cleanup/phases/branches.js",
       "method": "<anon method-3>",
-      "startLine": 179,
+      "startLine": 263,
       "crap": 2
     },
     {
       "path": ".agents/scripts/lib/orchestration/git-cleanup/phases/branches.js",
       "method": "<anon method-4>",
-      "startLine": 184,
+      "startLine": 275,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/orchestration/git-cleanup/phases/branches.js",
+      "method": "worktreeRootFor",
+      "startLine": 335,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/git-cleanup/phases/branches.js",
       "method": "executeCleanup",
-      "startLine": 231,
-      "crap": 6
+      "startLine": 353,
+      "crap": 5
     },
     {
       "path": ".agents/scripts/lib/orchestration/git-cleanup/phases/branches.js",
       "method": "<anon method-5>",
-      "startLine": 237,
+      "startLine": 359,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/orchestration/git-cleanup/phases/branches.js",
       "method": "<anon method-6>",
-      "startLine": 238,
+      "startLine": 360,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/orchestration/git-cleanup/phases/branches.js",
       "method": "<anon method-7>",
-      "startLine": 239,
+      "startLine": 361,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/orchestration/git-cleanup/phases/cli.js",
       "method": "resolveBaseBranch",
       "startLine": 25,
-      "crap": 15.237311385459531
+      "crap": 9.320987654320987
     },
     {
       "path": ".agents/scripts/lib/orchestration/git-cleanup/phases/cli.js",
@@ -6709,14 +12326,20 @@
     },
     {
       "path": ".agents/scripts/lib/orchestration/git-cleanup/phases/fast-forward.js",
+      "method": "restoreBranchIfMoved",
+      "startLine": 79,
+      "crap": 4
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/git-cleanup/phases/fast-forward.js",
       "method": "maybeCheckout",
-      "startLine": 62,
+      "startLine": 92,
       "crap": 6.374109505393854
     },
     {
       "path": ".agents/scripts/lib/orchestration/git-cleanup/phases/fast-forward.js",
       "method": "executeFastForward",
-      "startLine": 81,
+      "startLine": 111,
       "crap": 4
     },
     {
@@ -6739,6 +12362,12 @@
     },
     {
       "path": ".agents/scripts/lib/orchestration/git-cleanup/phases/filters.js",
+      "method": "<anon method-3>",
+      "startLine": 19,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/git-cleanup/phases/filters.js",
       "method": "computeProtectedSet",
       "startLine": 25,
       "crap": 4
@@ -6751,57 +12380,111 @@
     },
     {
       "path": ".agents/scripts/lib/orchestration/git-cleanup/phases/git-probes-ff.js",
+      "method": "isWorktreeLockFailure",
+      "startLine": 31,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/git-cleanup/phases/git-probes-ff.js",
       "method": "isWorkingTreeClean",
-      "startLine": 15,
-      "crap": 4.048
+      "startLine": 36,
+      "crap": 1
     },
     {
       "path": ".agents/scripts/lib/orchestration/git-cleanup/phases/git-probes-ff.js",
       "method": "fetchRef",
-      "startLine": 22,
-      "crap": 4.048
+      "startLine": 41,
+      "crap": 1.2962962962962963
     },
     {
       "path": ".agents/scripts/lib/orchestration/git-cleanup/phases/git-probes-ff.js",
       "method": "canFastForward",
-      "startLine": 29,
-      "crap": 26.434374999999996
+      "startLine": 46,
+      "crap": 1.2962962962962963
     },
     {
       "path": ".agents/scripts/lib/orchestration/git-cleanup/phases/git-probes-ff.js",
       "method": "checkoutBranch",
       "startLine": 51,
-      "crap": 4.048
+      "crap": 1.2962962962962963
     },
     {
       "path": ".agents/scripts/lib/orchestration/git-cleanup/phases/git-probes-ff.js",
       "method": "mergeFastForward",
-      "startLine": 58,
-      "crap": 4.048
+      "startLine": 56,
+      "crap": 1.2962962962962963
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/git-cleanup/phases/git-probes-ff.js",
+      "method": "makeFfProbes",
+      "startLine": 81,
+      "crap": 1.279528903049613
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/git-cleanup/phases/git-probes-ff.js",
+      "method": "<anon method-1>",
+      "startLine": 83,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/git-cleanup/phases/git-probes-ff.js",
+      "method": "<anon method-2>",
+      "startLine": 87,
+      "crap": 4.125
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/git-cleanup/phases/git-probes-ff.js",
+      "method": "<anon method-3>",
+      "startLine": 91,
+      "crap": 3.1851851851851856
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/git-cleanup/phases/git-probes-ff.js",
+      "method": "<anon method-4>",
+      "startLine": 97,
+      "crap": 23.78287002253944
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/git-cleanup/phases/git-probes-ff.js",
+      "method": "<anon method-5>",
+      "startLine": 119,
+      "crap": 3.1851851851851856
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/git-cleanup/phases/git-probes-ff.js",
+      "method": "<anon method-6>",
+      "startLine": 125,
+      "crap": 3.1851851851851856
     },
     {
       "path": ".agents/scripts/lib/orchestration/git-cleanup/phases/git-probes-ff.js",
       "method": "removeWorktree",
-      "startLine": 65,
-      "crap": 15.237311385459531
+      "startLine": 139,
+      "crap": 17.008592592592592
     },
     {
       "path": ".agents/scripts/lib/orchestration/git-cleanup/phases/git-probes-ff.js",
       "method": "pruneRemoteTracking",
-      "startLine": 76,
-      "crap": 4.048
+      "startLine": 171,
+      "crap": 2
     },
     {
       "path": ".agents/scripts/lib/orchestration/git-cleanup/phases/git-probes-ff.js",
       "method": "dropStash",
-      "startLine": 83,
+      "startLine": 178,
       "crap": 4.048
     },
     {
       "path": ".agents/scripts/lib/orchestration/git-cleanup/phases/git-probes.js",
       "method": "listLocalBranches",
       "startLine": 33,
-      "crap": 5.146108329540283
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/git-cleanup/phases/git-probes.js",
+      "method": "<anon method-1>",
+      "startLine": 43,
+      "crap": 1
     },
     {
       "path": ".agents/scripts/lib/orchestration/git-cleanup/phases/git-probes.js",
@@ -6811,27 +12494,57 @@
     },
     {
       "path": ".agents/scripts/lib/orchestration/git-cleanup/phases/git-probes.js",
+      "method": "<anon method-2>",
+      "startLine": 59,
+      "crap": 1.823974609375
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/git-cleanup/phases/git-probes.js",
+      "method": "<anon method-3>",
+      "startLine": 61,
+      "crap": 5.2958984375
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/git-cleanup/phases/git-probes.js",
+      "method": "<anon method-4>",
+      "startLine": 62,
+      "crap": 5.2958984375
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/git-cleanup/phases/git-probes.js",
       "method": "listMergedBranches",
       "startLine": 66,
-      "crap": 5.20262390670554
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/git-cleanup/phases/git-probes.js",
+      "method": "<anon method-5>",
+      "startLine": 77,
+      "crap": 1
     },
     {
       "path": ".agents/scripts/lib/orchestration/git-cleanup/phases/git-probes.js",
       "method": "currentBranch",
       "startLine": 82,
-      "crap": 7.608000000000001
+      "crap": 3
     },
     {
       "path": ".agents/scripts/lib/orchestration/git-cleanup/phases/git-probes.js",
       "method": "readProtectedConfig",
       "startLine": 89,
-      "crap": 4.6796875
+      "crap": 2.5
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/git-cleanup/phases/git-probes.js",
+      "method": "<anon method-6>",
+      "startLine": 94,
+      "crap": 1.125
     },
     {
       "path": ".agents/scripts/lib/orchestration/git-cleanup/phases/git-probes.js",
       "method": "worktreesByBranch",
       "startLine": 99,
-      "crap": 16.021036814425244
+      "crap": 4
     },
     {
       "path": ".agents/scripts/lib/orchestration/git-cleanup/phases/git-probes.js",
@@ -6871,14 +12584,50 @@
     },
     {
       "path": ".agents/scripts/lib/orchestration/git-cleanup/phases/git-probes.js",
+      "method": "<anon method-7>",
+      "startLine": 315,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/git-cleanup/phases/git-probes.js",
       "method": "branchTipSha",
       "startLine": 333,
       "crap": 16.584433318161132
     },
     {
       "path": ".agents/scripts/lib/orchestration/git-cleanup/phases/git-probes.js",
-      "method": "classifyLatestPr",
+      "method": "refExists",
+      "startLine": 353,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/git-cleanup/phases/git-probes.js",
+      "method": "branchLastCommitAt",
+      "startLine": 361,
+      "crap": 3
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/git-cleanup/phases/git-probes.js",
+      "method": "firstStdoutLine",
       "startLine": 381,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/git-cleanup/phases/git-probes.js",
+      "method": "<anon method-8>",
+      "startLine": 384,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/git-cleanup/phases/git-probes.js",
+      "method": "probeContentEquivalent",
+      "startLine": 408,
+      "crap": 5
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/git-cleanup/phases/git-probes.js",
+      "method": "classifyLatestPr",
+      "startLine": 465,
       "crap": 9
     },
     {
@@ -6896,73 +12645,97 @@
     {
       "path": ".agents/scripts/lib/orchestration/git-cleanup/phases/phase-drivers.js",
       "method": "emitDryRunHuman",
-      "startLine": 43,
+      "startLine": 44,
       "crap": 1.2962962962962963
     },
     {
       "path": ".agents/scripts/lib/orchestration/git-cleanup/phases/phase-drivers.js",
       "method": "emitExecutionHuman",
-      "startLine": 48,
-      "crap": 9.932291666666666
+      "startLine": 49,
+      "crap": 10.317333333333334
     },
     {
       "path": ".agents/scripts/lib/orchestration/git-cleanup/phases/phase-drivers.js",
       "method": "decideFastForwardPhase",
-      "startLine": 80,
+      "startLine": 84,
       "crap": 4
     },
     {
       "path": ".agents/scripts/lib/orchestration/git-cleanup/phases/phase-drivers.js",
       "method": "executeFastForwardPhase",
-      "startLine": 130,
+      "startLine": 134,
       "crap": 24.256365740740737
     },
     {
       "path": ".agents/scripts/lib/orchestration/git-cleanup/phases/phase-drivers.js",
       "method": "runFastForwardPhase",
-      "startLine": 144,
+      "startLine": 148,
       "crap": 16.324074074074073
     },
     {
       "path": ".agents/scripts/lib/orchestration/git-cleanup/phases/phase-drivers.js",
       "method": "runPrunePhase",
-      "startLine": 162,
+      "startLine": 166,
       "crap": 17.915852742299023
     },
     {
       "path": ".agents/scripts/lib/orchestration/git-cleanup/phases/phase-drivers.js",
-      "method": "decideBranchPhase",
+      "method": "countActionableCandidates",
       "startLine": 203,
-      "crap": 5
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/git-cleanup/phases/phase-drivers.js",
+      "method": "<anon method-1>",
+      "startLine": 206,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/git-cleanup/phases/phase-drivers.js",
+      "method": "decideBranchPhase",
+      "startLine": 223,
+      "crap": 6
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/git-cleanup/phases/phase-drivers.js",
+      "method": "<anon method-2>",
+      "startLine": 242,
+      "crap": 1
     },
     {
       "path": ".agents/scripts/lib/orchestration/git-cleanup/phases/phase-drivers.js",
       "method": "executeBranchPhase",
-      "startLine": 232,
+      "startLine": 263,
       "crap": 16.584433318161132
     },
     {
       "path": ".agents/scripts/lib/orchestration/git-cleanup/phases/phase-drivers.js",
       "method": "runBranchPhase",
-      "startLine": 247,
-      "crap": 10.876386948302788
+      "startLine": 278,
+      "crap": 11.036579789666211
     },
     {
       "path": ".agents/scripts/lib/orchestration/git-cleanup/phases/phase-drivers.js",
       "method": "decideStashPhase",
-      "startLine": 290,
+      "startLine": 325,
       "crap": 5
     },
     {
       "path": ".agents/scripts/lib/orchestration/git-cleanup/phases/phase-drivers.js",
+      "method": "<anon method-3>",
+      "startLine": 339,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/git-cleanup/phases/phase-drivers.js",
       "method": "executeStashPhase",
-      "startLine": 325,
+      "startLine": 360,
       "crap": 25.84266232444535
     },
     {
       "path": ".agents/scripts/lib/orchestration/git-cleanup/phases/phase-drivers.js",
       "method": "runStashPhase",
-      "startLine": 344,
+      "startLine": 379,
       "crap": 10.58179012345679
     },
     {
@@ -6979,8 +12752,32 @@
     },
     {
       "path": ".agents/scripts/lib/orchestration/git-cleanup/phases/prompts.js",
+      "method": "<anon method-1>",
+      "startLine": 46,
+      "crap": 1.800655976676385
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/git-cleanup/phases/prompts.js",
+      "method": "<anon method-2>",
+      "startLine": 47,
+      "crap": 1.800655976676385
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/git-cleanup/phases/prompts.js",
       "method": "promptStashDecision",
       "startLine": 56,
+      "crap": 1.833706492977814
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/git-cleanup/phases/prompts.js",
+      "method": "<anon method-3>",
+      "startLine": 62,
+      "crap": 1.833706492977814
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/git-cleanup/phases/prompts.js",
+      "method": "<anon method-4>",
+      "startLine": 65,
       "crap": 1.833706492977814
     },
     {
@@ -7003,51 +12800,93 @@
     },
     {
       "path": ".agents/scripts/lib/orchestration/git-cleanup/phases/render.js",
+      "method": "formatCommitAge",
+      "startLine": 25,
+      "crap": 5
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/git-cleanup/phases/render.js",
+      "method": "renderNotMergedSkipLine",
+      "startLine": 45,
+      "crap": 3
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/git-cleanup/phases/render.js",
+      "method": "contentMergedNote",
+      "startLine": 58,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/git-cleanup/phases/render.js",
       "method": "renderDryRun",
-      "startLine": 14,
-      "crap": 8
+      "startLine": 65,
+      "crap": 10
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/git-cleanup/phases/render.js",
+      "method": "<anon method-1>",
+      "startLine": 83,
+      "crap": 1
     },
     {
       "path": ".agents/scripts/lib/orchestration/git-cleanup/phases/render.js",
       "method": "renderLatestPrSkipLine",
-      "startLine": 55,
-      "crap": 9.094474413179764
+      "startLine": 118,
+      "crap": 9.060856498873028
     },
     {
       "path": ".agents/scripts/lib/orchestration/git-cleanup/phases/render.js",
       "method": "renderExecutionLine",
-      "startLine": 76,
+      "startLine": 142,
       "crap": 6
     },
     {
       "path": ".agents/scripts/lib/orchestration/git-cleanup/phases/render.js",
       "method": "renderPruneLine",
-      "startLine": 90,
+      "startLine": 156,
       "crap": 4
     },
     {
       "path": ".agents/scripts/lib/orchestration/git-cleanup/phases/render.js",
-      "method": "renderExecutionSummary",
-      "startLine": 103,
+      "method": "<anon method-2>",
+      "startLine": 164,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/git-cleanup/phases/render.js",
+      "method": "renderDeferredLine",
+      "startLine": 179,
       "crap": 3
     },
     {
       "path": ".agents/scripts/lib/orchestration/git-cleanup/phases/render.js",
+      "method": "renderExecutionSummary",
+      "startLine": 188,
+      "crap": 4
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/git-cleanup/phases/render.js",
       "method": "buildJsonEnvelope",
-      "startLine": 123,
+      "startLine": 214,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/orchestration/git-cleanup/phases/render.js",
       "method": "legacyExitCode",
-      "startLine": 149,
+      "startLine": 242,
       "crap": 4
     },
     {
       "path": ".agents/scripts/lib/orchestration/git-cleanup/phases/render.js",
       "method": "computeExitCode",
-      "startLine": 163,
+      "startLine": 256,
       "crap": 18
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/git-cleanup/phases/render.js",
+      "method": "<anon method-3>",
+      "startLine": 278,
+      "crap": 2
     },
     {
       "path": ".agents/scripts/lib/orchestration/git-cleanup/phases/stashes.js",
@@ -7081,6 +12920,12 @@
     },
     {
       "path": ".agents/scripts/lib/orchestration/git-cleanup/phases/stashes.js",
+      "method": "<anon method-1>",
+      "startLine": 67,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/git-cleanup/phases/stashes.js",
       "method": "applyDecision",
       "startLine": 70,
       "crap": 4
@@ -7090,6 +12935,12 @@
       "method": "executeStashes",
       "startLine": 110,
       "crap": 3
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/git-cleanup/phases/stashes.js",
+      "method": "<anon method-2>",
+      "startLine": 118,
+      "crap": 1
     },
     {
       "path": ".agents/scripts/lib/orchestration/label-transitions.js",
@@ -7102,6 +12953,18 @@
       "method": "toDone",
       "startLine": 36,
       "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/lease-guard-shared.js",
+      "method": "resolveOperatorFromCandidates",
+      "startLine": 71,
+      "crap": 3.003279883381924
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/lease-guard-shared.js",
+      "method": "acquireLeaseFailClosed",
+      "startLine": 114,
+      "crap": 5
     },
     {
       "path": ".agents/scripts/lib/orchestration/lifecycle/bus.js",
@@ -7117,33 +12980,63 @@
     },
     {
       "path": ".agents/scripts/lib/orchestration/lifecycle/bus.js",
+      "method": "<anon method-1>",
+      "startLine": 66,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/lifecycle/bus.js",
       "method": "createBus",
       "startLine": 307,
       "crap": 1
     },
     {
+      "path": ".agents/scripts/lib/orchestration/lifecycle/emit-ledger-event.js",
+      "method": "getValidator",
+      "startLine": 57,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/lifecycle/emit-ledger-event.js",
+      "method": "assertMergeTerminalFields",
+      "startLine": 77,
+      "crap": 14.808414725770099
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/lifecycle/emit-ledger-event.js",
+      "method": "appendLedgerEvent",
+      "startLine": 114,
+      "crap": 2.020501045553323
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/lifecycle/emit-ledger-event.js",
+      "method": "<anon method-1>",
+      "startLine": 126,
+      "crap": 2.020501045553323
+    },
+    {
       "path": ".agents/scripts/lib/orchestration/lifecycle/emit-loop-tick.js",
       "method": "decomposeLedgerPath",
-      "startLine": 81,
+      "startLine": 79,
       "crap": 2.116522530723714
     },
     {
       "path": ".agents/scripts/lib/orchestration/lifecycle/emit-loop-tick.js",
       "method": "emitLoopTick",
-      "startLine": 115,
+      "startLine": 113,
       "crap": 15.310807314259273
     },
     {
-      "path": ".agents/scripts/lib/orchestration/lifecycle/emit-merge-unlanded.js",
-      "method": "getValidator",
-      "startLine": 82,
-      "crap": 2
+      "path": ".agents/scripts/lib/orchestration/lifecycle/emit-merge-flip-failed.js",
+      "method": "emitMergeFlipFailed",
+      "startLine": 48,
+      "crap": 1.9250324516596704
     },
     {
       "path": ".agents/scripts/lib/orchestration/lifecycle/emit-merge-unlanded.js",
       "method": "emitMergeUnlanded",
-      "startLine": 115,
-      "crap": 16.862330464138353
+      "startLine": 83,
+      "crap": 2.002809327846365
     },
     {
       "path": ".agents/scripts/lib/orchestration/lifecycle/ledger-writer.js",
@@ -7164,124 +13057,106 @@
       "crap": 1
     },
     {
-      "path": ".agents/scripts/lib/orchestration/lifecycle/listeners/merge-watcher.js",
-      "method": "ghPrViewMerge",
-      "startLine": 66,
-      "crap": 1.7702546296296295
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/lifecycle/listeners/merge-watcher.js",
-      "method": "parseMergeView",
-      "startLine": 85,
-      "crap": 10.437988000328758
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/lifecycle/listeners/merge-watcher.js",
-      "method": "resolveLedgerPath",
-      "startLine": 113,
-      "crap": 1
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/lifecycle/listeners/merge-watcher.js",
-      "method": "readPriorAttempts",
-      "startLine": 122,
-      "crap": 8
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/lifecycle/listeners/merge-watcher.js",
-      "method": "appendAttempt",
-      "startLine": 156,
-      "crap": 1
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/lifecycle/listeners/merge-watcher.js",
-      "method": "defaultSleep",
-      "startLine": 172,
-      "crap": 1.2962962962962963
-    },
-    {
       "path": ".agents/scripts/lib/orchestration/lifecycle/listeners/watcher.js",
       "method": "normalizeCheckState",
-      "startLine": 87,
+      "startLine": 88,
       "crap": 17.47058823529412
     },
     {
       "path": ".agents/scripts/lib/orchestration/lifecycle/listeners/watcher.js",
       "method": "ghPrChecks",
-      "startLine": 141,
+      "startLine": 142,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/orchestration/lifecycle/listeners/watcher.js",
       "method": "ghPrView",
-      "startLine": 166,
+      "startLine": 167,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/orchestration/lifecycle/listeners/watcher.js",
       "method": "parseMergeStateStatus",
-      "startLine": 186,
+      "startLine": 187,
       "crap": 3.0416666666666665
     },
     {
       "path": ".agents/scripts/lib/orchestration/lifecycle/listeners/watcher.js",
       "method": "ghPrUpdateBranch",
-      "startLine": 204,
+      "startLine": 205,
       "crap": 2
     },
     {
       "path": ".agents/scripts/lib/orchestration/lifecycle/listeners/watcher.js",
       "method": "allGreen",
-      "startLine": 234,
+      "startLine": 235,
       "crap": 3
     },
     {
       "path": ".agents/scripts/lib/orchestration/lifecycle/listeners/watcher.js",
       "method": "parseGhPrChecks",
-      "startLine": 252,
+      "startLine": 253,
+      "crap": 3
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/lifecycle/listeners/watcher.js",
+      "method": "<anon method-1>",
+      "startLine": 260,
       "crap": 3
     },
     {
       "path": ".agents/scripts/lib/orchestration/lifecycle/listeners/watcher.js",
       "method": "reduceOutcomes",
-      "startLine": 274,
+      "startLine": 275,
       "crap": 3
     },
     {
       "path": ".agents/scripts/lib/orchestration/lifecycle/listeners/watcher.js",
       "method": "allTerminal",
-      "startLine": 290,
+      "startLine": 291,
       "crap": 2
     },
     {
       "path": ".agents/scripts/lib/orchestration/lifecycle/listeners/watcher.js",
       "method": "promotePendingToStillRunning",
-      "startLine": 314,
+      "startLine": 315,
       "crap": 2
     },
     {
       "path": ".agents/scripts/lib/orchestration/lifecycle/listeners/watcher.js",
       "method": "hasFailingCheck",
-      "startLine": 329,
+      "startLine": 330,
       "crap": 3
     },
     {
       "path": ".agents/scripts/lib/orchestration/lifecycle/listeners/watcher.js",
       "method": "defaultSleep",
-      "startLine": 340,
+      "startLine": 341,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/lifecycle/listeners/watcher.js",
+      "method": "<anon method-2>",
+      "startLine": 342,
       "crap": 2
     },
     {
       "path": ".agents/scripts/lib/orchestration/lifecycle/listeners/watcher.js",
       "method": "pollUntilTerminal",
-      "startLine": 366,
+      "startLine": 367,
       "crap": 6
     },
     {
       "path": ".agents/scripts/lib/orchestration/lifecycle/listeners/watcher.js",
       "method": "watchPrToTerminal",
-      "startLine": 454,
+      "startLine": 455,
       "crap": 17.013165087463555
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/lifecycle/listeners/watcher.js",
+      "method": "<anon method-3>",
+      "startLine": 494,
+      "crap": 1.0000455539358601
     },
     {
       "path": ".agents/scripts/lib/orchestration/lifecycle/trace-logger.js",
@@ -7292,56 +13167,200 @@
     {
       "path": ".agents/scripts/lib/orchestration/lifecycle/trace-logger.js",
       "method": "phaseFor",
-      "startLine": 64,
+      "startLine": 51,
       "crap": 3.006761833208114
     },
     {
       "path": ".agents/scripts/lib/orchestration/lifecycle/trace-logger.js",
+      "method": "<anon method-1>",
+      "startLine": 54,
+      "crap": 1.0007513148009015
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/lifecycle/trace-logger.js",
       "method": "summarizePayload",
-      "startLine": 82,
-      "crap": 9
+      "startLine": 69,
+      "crap": 11.187000000000001
     },
     {
       "path": ".agents/scripts/lib/orchestration/lifecycle/trace-logger.js",
       "method": "parseLedger",
-      "startLine": 108,
+      "startLine": 95,
       "crap": 4
     },
     {
       "path": ".agents/scripts/lib/orchestration/lifecycle/trace-logger.js",
-      "method": "render",
-      "startLine": 141,
-      "crap": 24
+      "method": "indexLedgerRecords",
+      "startLine": 133,
+      "crap": 6
     },
     {
       "path": ".agents/scripts/lib/orchestration/lifecycle/trace-logger.js",
-      "method": "createTraceLogger",
-      "startLine": 322,
+      "method": "formatDurationChunk",
+      "startLine": 149,
+      "crap": 5.034293552812072
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/lifecycle/trace-logger.js",
+      "method": "formatEventLine",
+      "startLine": 162,
+      "crap": 3
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/lifecycle/trace-logger.js",
+      "method": "buildPhaseLines",
+      "startLine": 178,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/lifecycle/trace-logger.js",
+      "method": "computePhaseSpanMs",
+      "startLine": 200,
+      "crap": 9
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/lifecycle/trace-logger.js",
+      "method": "buildSummaryLines",
+      "startLine": 221,
+      "crap": 3
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/lifecycle/trace-logger.js",
+      "method": "<anon method-2>",
+      "startLine": 224,
       "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/lifecycle/trace-logger.js",
+      "method": "render",
+      "startLine": 245,
+      "crap": 3
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/light-suitability.js",
+      "method": "normalizeMaxFiles",
+      "startLine": 77,
+      "crap": 4
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/light-suitability.js",
+      "method": "resolveLedgeredVerdict",
+      "startLine": 102,
+      "crap": 5
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/light-suitability.js",
+      "method": "deriveLightSuitability",
+      "startLine": 164,
+      "crap": 3
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/light-suitability.js",
+      "method": "resolveLightGateOutcome",
+      "startLine": 210,
+      "crap": 4
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/light-suitability.js",
+      "method": "checkLightDiffBackstop",
+      "startLine": 273,
+      "crap": 10.0244140625
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/light-suitability.js",
+      "method": "<anon method-1>",
+      "startLine": 284,
+      "crap": 2.0009765625
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/light-suitability.js",
+      "method": "slugifyPrompt",
+      "startLine": 347,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/light-suitability.js",
+      "method": "normalizeAmends",
+      "startLine": 367,
+      "crap": 8.233045061447429
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/light-suitability.js",
+      "method": "deriveReceiptTitle",
+      "startLine": 388,
+      "crap": 3
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/light-suitability.js",
+      "method": "toReceiptChanges",
+      "startLine": 407,
+      "crap": 5
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/light-suitability.js",
+      "method": "buildReceiptStoryTicket",
+      "startLine": 431,
+      "crap": 4
     },
     {
       "path": ".agents/scripts/lib/orchestration/merge-block-class.js",
       "method": "isValidBlockClass",
-      "startLine": 65,
+      "startLine": 119,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/orchestration/merge-block-class.js",
       "method": "textIncludesAny",
-      "startLine": 82,
+      "startLine": 136,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/merge-block-class.js",
+      "method": "<anon method-1>",
+      "startLine": 138,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/orchestration/merge-block-class.js",
       "method": "describeApiRaceFallback",
-      "startLine": 92,
-      "crap": 4
+      "startLine": 146,
+      "crap": 5.059259259259259
     },
     {
       "path": ".agents/scripts/lib/orchestration/merge-block-class.js",
       "method": "classifyMergeBlock",
-      "startLine": 144,
-      "crap": 14
+      "startLine": 227,
+      "crap": 18
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/merge-poll.js",
+      "method": "deriveChecksStatus",
+      "startLine": 56,
+      "crap": 6
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/merge-poll.js",
+      "method": "deriveRequiredRunEvidence",
+      "startLine": 116,
+      "crap": 11
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/merge-poll.js",
+      "method": "failingChecksBlockMerge",
+      "startLine": 187,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/merge-poll.js",
+      "method": "requiredCheckFailedBlocksMerge",
+      "startLine": 234,
+      "crap": 6
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/merge-poll.js",
+      "method": "decideMergeWaitFailFast",
+      "startLine": 275,
+      "crap": 6
     },
     {
       "path": ".agents/scripts/lib/orchestration/model-attribution.js",
@@ -7363,32 +13382,74 @@
     },
     {
       "path": ".agents/scripts/lib/orchestration/model-attribution.js",
+      "method": "validateKind",
+      "startLine": 162,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/model-attribution.js",
+      "method": "validateTicketId",
+      "startLine": 168,
+      "crap": 3
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/model-attribution.js",
+      "method": "validateModel",
+      "startLine": 174,
+      "crap": 9.13189497252188
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/model-attribution.js",
+      "method": "validateSource",
+      "startLine": 192,
+      "crap": 3
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/model-attribution.js",
+      "method": "validateRecordedAt",
+      "startLine": 198,
+      "crap": 3
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/model-attribution.js",
+      "method": "validateSdkMetadata",
+      "startLine": 205,
+      "crap": 5
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/model-attribution.js",
       "method": "validateModelAttributionPayload",
-      "startLine": 170,
-      "crap": 24.027696468820437
+      "startLine": 240,
+      "crap": 5
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/model-attribution.js",
+      "method": "<anon method-1>",
+      "startLine": 248,
+      "crap": 1
     },
     {
       "path": ".agents/scripts/lib/orchestration/model-attribution.js",
       "method": "renderModelAttributionBody",
-      "startLine": 235,
+      "startLine": 263,
       "crap": 4
     },
     {
       "path": ".agents/scripts/lib/orchestration/model-attribution.js",
       "method": "emitModelAttribution",
-      "startLine": 264,
+      "startLine": 292,
       "crap": 6.0641121963436015
     },
     {
       "path": ".agents/scripts/lib/orchestration/model-attribution.js",
       "method": "parseModelAttributionComment",
-      "startLine": 310,
+      "startLine": 338,
       "crap": 4
     },
     {
       "path": ".agents/scripts/lib/orchestration/model-attribution.js",
       "method": "rollupModelAttribution",
-      "startLine": 347,
+      "startLine": 375,
       "crap": 8.020285499624343
     },
     {
@@ -7404,178 +13465,898 @@
       "crap": 5
     },
     {
+      "path": ".agents/scripts/lib/orchestration/parked-follow-ons.js",
+      "method": "<anon method-1>",
+      "startLine": 133,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/parked-follow-ons.js",
+      "method": "<anon method-2>",
+      "startLine": 138,
+      "crap": 1
+    },
+    {
       "path": ".agents/scripts/lib/orchestration/phase-runner.js",
       "method": "pickLogger",
-      "startLine": 29,
+      "startLine": 30,
       "crap": 4
     },
     {
       "path": ".agents/scripts/lib/orchestration/phase-runner.js",
       "method": "runPhase",
-      "startLine": 55,
+      "startLine": 56,
       "crap": 3
     },
     {
       "path": ".agents/scripts/lib/orchestration/phase-runner.js",
       "method": "runSafely",
-      "startLine": 78,
+      "startLine": 79,
       "crap": 2
     },
     {
-      "path": ".agents/scripts/lib/orchestration/plan-context.js",
-      "method": "<anon method-2>",
-      "startLine": 225,
+      "path": ".agents/scripts/lib/orchestration/plan-critic-conditions.js",
+      "method": "evaluateConsolidationDispatch",
+      "startLine": 80,
+      "crap": 8
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/plan-critic-conditions.js",
+      "method": "uniquePreserveOrder",
+      "startLine": 143,
       "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/plan-critic-conditions.js",
+      "method": "quoteList",
+      "startLine": 148,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/plan-critic-conditions.js",
+      "method": "<anon method-1>",
+      "startLine": 149,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/plan-critic-conditions.js",
+      "method": "matchExternalScopedPackages",
+      "startLine": 160,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/plan-critic-conditions.js",
+      "method": "<anon method-2>",
+      "startLine": 163,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/plan-critic-conditions.js",
+      "method": "<anon method-3>",
+      "startLine": 164,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/plan-critic-conditions.js",
+      "method": "matchCrossRepoRefs",
+      "startLine": 182,
+      "crap": 7
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/plan-critic-conditions.js",
+      "method": "matchExternalServicePrereqs",
+      "startLine": 207,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/plan-critic-conditions.js",
+      "method": "evaluateExternalDependencyProbe",
+      "startLine": 231,
+      "crap": 5
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/plan-critic-conditions.js",
+      "method": "evaluatePremortemDispatch",
+      "startLine": 286,
+      "crap": 8
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/plan-critic-conditions.js",
+      "method": "<anon method-4>",
+      "startLine": 310,
+      "crap": 3
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/plan-critic-conditions.js",
+      "method": "<anon method-5>",
+      "startLine": 317,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/plan-critics-evaluate.js",
+      "method": "resolveRiskHeuristics",
+      "startLine": 38,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/plan-critics-evaluate.js",
+      "method": "resolveOwnerRepo",
+      "startLine": 52,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/plan-critics-evaluate.js",
+      "method": "evaluatePlanCritics",
+      "startLine": 96,
+      "crap": 4.054
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/plan-metrics.js",
+      "method": "appendPlanMetric",
+      "startLine": 87,
+      "crap": 9
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/plan-metrics.js",
+      "method": "appendCriticSkip",
+      "startLine": 147,
+      "crap": 8
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/plan-metrics.js",
+      "method": "<anon method-1>",
+      "startLine": 165,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/plan-metrics.js",
+      "method": "recordPlanInvocation",
+      "startLine": 195,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/plan-metrics.js",
+      "method": "readPlanMetrics",
+      "startLine": 228,
+      "crap": 5
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/plan-metrics.js",
+      "method": "recordTimestamp",
+      "startLine": 300,
+      "crap": 3
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/plan-metrics.js",
+      "method": "summarizePlanMetrics",
+      "startLine": 305,
+      "crap": 19
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/plan-metrics.js",
+      "method": "<anon method-2>",
+      "startLine": 313,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/plan-metrics.js",
+      "method": "renderPlanMetricsSummaryLine",
+      "startLine": 387,
+      "crap": 7
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/plan-metrics.js",
+      "method": "<anon method-3>",
+      "startLine": 390,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/plan-metrics.js",
+      "method": "<anon method-4>",
+      "startLine": 403,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/plan-metrics.js",
+      "method": "formatSpan",
+      "startLine": 418,
+      "crap": 3.0987654320987654
     },
     {
       "path": ".agents/scripts/lib/orchestration/plan-persist/fan-out-gate.js",
       "method": "enforceFanOutGate",
-      "startLine": 16,
-      "crap": 6.417483291647874
+      "startLine": 20,
+      "crap": 7.131708454810496
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/plan-persist/fan-out-gate.js",
+      "method": "<anon method-1>",
+      "startLine": 25,
+      "crap": 1.4590787172011663
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/plan-persist/fan-out-gate.js",
+      "method": "<anon method-2>",
+      "startLine": 40,
+      "crap": 1.4590787172011663
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/plan-persist/fan-out-gate.js",
+      "method": "<anon method-3>",
+      "startLine": 49,
+      "crap": 1.4590787172011663
     },
     {
       "path": ".agents/scripts/lib/orchestration/plan-persist/fan-out-gate.js",
       "method": "surfaceSoftConflictFindings",
-      "startLine": 50,
+      "startLine": 60,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/plan-persist/fan-out-gate.js",
+      "method": "<anon method-4>",
+      "startLine": 62,
       "crap": 2
     },
     {
       "path": ".agents/scripts/lib/orchestration/plan-persist/persist-helpers.js",
+      "method": "escapeRegExp",
+      "startLine": 33,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/plan-persist/persist-helpers.js",
+      "method": "specifierTails",
+      "startLine": 48,
+      "crap": 5
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/plan-persist/persist-helpers.js",
+      "method": "<anon method-1>",
+      "startLine": 57,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/plan-persist/persist-helpers.js",
+      "method": "buildProbePattern",
+      "startLine": 66,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/plan-persist/persist-helpers.js",
+      "method": "specifierResolvesTo",
+      "startLine": 84,
+      "crap": 6
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/plan-persist/persist-helpers.js",
+      "method": "shellQuote",
+      "startLine": 106,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/plan-persist/persist-helpers.js",
+      "method": "parseGrepLine",
+      "startLine": 114,
+      "crap": 4
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/plan-persist/persist-helpers.js",
       "method": "makeDefaultFanOutCounter",
-      "startLine": 29,
-      "crap": 1.5305042651981426
+      "startLine": 150,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/plan-persist/persist-helpers.js",
+      "method": "<anon method-2>",
+      "startLine": 152,
+      "crap": 6
     },
     {
       "path": ".agents/scripts/lib/orchestration/plan-persist/persist-helpers.js",
       "method": "resolveConflictPolicy",
-      "startLine": 54,
+      "startLine": 181,
       "crap": 3.385875
     },
     {
       "path": ".agents/scripts/lib/orchestration/plan-persist/persist-helpers.js",
+      "method": "resolveBaseBranchRef",
+      "startLine": 219,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/plan-persist/persist-helpers.js",
       "method": "validateTickets",
-      "startLine": 75,
-      "crap": 2.0002893518518516
+      "startLine": 223,
+      "crap": 2.000328758116216
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/plan-persist/plan-context-source.js",
+      "method": "resolvePlanContextPath",
+      "startLine": 36,
+      "crap": 3
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/plan-persist/plan-context-source.js",
+      "method": "loadPlanContextEnvelope",
+      "startLine": 80,
+      "crap": 4
     },
     {
       "path": ".agents/scripts/lib/orchestration/plan-persist/run-plan-persist.js",
       "method": "writeCheckpointV2",
-      "startLine": 68,
+      "startLine": 94,
       "crap": 2.0030052592036065
     },
     {
       "path": ".agents/scripts/lib/orchestration/plan-persist/run-plan-persist.js",
       "method": "enforceTicketValidation",
-      "startLine": 91,
-      "crap": 4.2720466472303205
+      "startLine": 136,
+      "crap": 4.025155017797175
     },
     {
       "path": ".agents/scripts/lib/orchestration/plan-persist/run-plan-persist.js",
-      "method": "riskVerdictCommentBody",
-      "startLine": 127,
+      "method": "<anon method-1>",
+      "startLine": 138,
+      "crap": 1.0015721886123234
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/plan-persist/run-plan-persist.js",
+      "method": "<anon method-2>",
+      "startLine": 142,
+      "crap": 1.0015721886123234
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/plan-persist/run-plan-persist.js",
+      "method": "<anon method-3>",
+      "startLine": 147,
+      "crap": 1.0015721886123234
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/plan-persist/run-plan-persist.js",
+      "method": "<anon method-4>",
+      "startLine": 170,
+      "crap": 1.0015721886123234
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/plan-persist/run-plan-persist.js",
+      "method": "runSupersedePhase",
+      "startLine": 190,
+      "crap": 1.4614012021036813
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/plan-persist/run-plan-persist.js",
+      "method": "<anon method-5>",
+      "startLine": 205,
+      "crap": 1.4614012021036813
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/plan-persist/run-plan-persist.js",
+      "method": "renderRunScopedPlanMetricsLine",
+      "startLine": 240,
+      "crap": 2.0044282258395176
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/plan-persist/run-plan-persist.js",
+      "method": "resolveEffectiveRoute",
+      "startLine": 313,
+      "crap": 5
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/plan-persist/run-plan-persist.js",
+      "method": "<anon method-6>",
+      "startLine": 340,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/orchestration/plan-persist/run-plan-persist.js",
+      "method": "<anon method-7>",
+      "startLine": 353,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/plan-persist/run-plan-persist.js",
+      "method": "<anon method-8>",
+      "startLine": 360,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/plan-persist/run-plan-persist.js",
+      "method": "reapStalePlanDirs",
+      "startLine": 399,
+      "crap": 8.011941690962098
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/plan-persist/run-plan-persist.js",
       "method": "runPlanPersist",
-      "startLine": 163,
-      "crap": 18.57507132604907
+      "startLine": 465,
+      "crap": 19.196954412986514
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/plan-persist/run-plan-persist.js",
+      "method": "<anon method-9>",
+      "startLine": 599,
+      "crap": 1.0005455800913754
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/plan-persist/run-plan-persist.js",
+      "method": "<anon method-10>",
+      "startLine": 640,
+      "crap": 1.0005455800913754
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/plan-persist/run-plan-persist.js",
+      "method": "<anon method-11>",
+      "startLine": 689,
+      "crap": 1.0005455800913754
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/plan-persist/run-plan-persist.js",
+      "method": "<anon method-12>",
+      "startLine": 693,
+      "crap": 1.0005455800913754
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/plan-persist/run-plan-persist.js",
+      "method": "<anon method-13>",
+      "startLine": 701,
+      "crap": 1.0005455800913754
     },
     {
       "path": ".agents/scripts/lib/orchestration/plan-persist/story-ops.js",
       "method": "normalizePlanRunId",
-      "startLine": 38,
+      "startLine": 66,
       "crap": 2
     },
     {
       "path": ".agents/scripts/lib/orchestration/plan-persist/story-ops.js",
       "method": "planRunLabel",
-      "startLine": 57,
-      "crap": 3
+      "startLine": 88,
+      "crap": 1
     },
     {
       "path": ".agents/scripts/lib/orchestration/plan-persist/story-ops.js",
-      "method": "bodyObjectFromTicket",
-      "startLine": 65,
-      "crap": 4.144675925925926
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/plan-persist/story-ops.js",
-      "method": "normalizeDependsOn",
-      "startLine": 90,
-      "crap": 3
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/plan-persist/story-ops.js",
-      "method": "arraysEqual",
-      "startLine": 97,
+      "method": "derivePlanRunId",
+      "startLine": 107,
       "crap": 2
     },
     {
       "path": ".agents/scripts/lib/orchestration/plan-persist/story-ops.js",
+      "method": "planStoryFingerprint",
+      "startLine": 172,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/plan-persist/story-ops.js",
+      "method": "planFingerprintMarker",
+      "startLine": 187,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/plan-persist/story-ops.js",
+      "method": "sanitizeAuthoredLabels",
+      "startLine": 225,
+      "crap": 7
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/plan-persist/story-ops.js",
+      "method": "<anon method-1>",
+      "startLine": 235,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/plan-persist/story-ops.js",
+      "method": "bodyObjectFromTicket",
+      "startLine": 250,
+      "crap": 4.03125
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/plan-persist/story-ops.js",
+      "method": "normalizeDependsOn",
+      "startLine": 275,
+      "crap": 3
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/plan-persist/story-ops.js",
+      "method": "<anon method-2>",
+      "startLine": 277,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/plan-persist/story-ops.js",
+      "method": "arraysEqual",
+      "startLine": 282,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/plan-persist/story-ops.js",
+      "method": "<anon method-3>",
+      "startLine": 283,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/plan-persist/story-ops.js",
       "method": "syncContractFieldFromTopLevel",
-      "startLine": 111,
+      "startLine": 296,
       "crap": 5
     },
     {
       "path": ".agents/scripts/lib/orchestration/plan-persist/story-ops.js",
       "method": "normalizeStoryTicket",
-      "startLine": 132,
-      "crap": 9
+      "startLine": 321,
+      "crap": 8.78652708238507
     },
     {
       "path": ".agents/scripts/lib/orchestration/plan-persist/story-ops.js",
       "method": "foldSpecIntoStoryBody",
-      "startLine": 170,
+      "startLine": 361,
       "crap": 7
     },
     {
       "path": ".agents/scripts/lib/orchestration/plan-persist/story-ops.js",
       "method": "assembleOnePlanStory",
-      "startLine": 196,
+      "startLine": 387,
       "crap": 2
     },
     {
       "path": ".agents/scripts/lib/orchestration/plan-persist/story-ops.js",
       "method": "assertSharedSpecAllowed",
-      "startLine": 221,
+      "startLine": 419,
       "crap": 4
     },
     {
       "path": ".agents/scripts/lib/orchestration/plan-persist/story-ops.js",
       "method": "assemblePlanStories",
-      "startLine": 241,
-      "crap": 3.0839772561597902
+      "startLine": 443,
+      "crap": 3.072
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/plan-persist/story-ops.js",
+      "method": "<anon method-4>",
+      "startLine": 453,
+      "crap": 1.008
     },
     {
       "path": ".agents/scripts/lib/orchestration/plan-persist/story-ops.js",
       "method": "orderStoriesByDependencies",
-      "startLine": 261,
+      "startLine": 464,
       "crap": 5.065603345770635
     },
     {
       "path": ".agents/scripts/lib/orchestration/plan-persist/story-ops.js",
+      "method": "<anon method-5>",
+      "startLine": 466,
+      "crap": 1.0026241338308253
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/plan-persist/story-ops.js",
+      "method": "<anon method-6>",
+      "startLine": 468,
+      "crap": 1.0026241338308253
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/plan-persist/story-ops.js",
+      "method": "<anon method-7>",
+      "startLine": 479,
+      "crap": 1.0026241338308253
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/plan-persist/story-ops.js",
+      "method": "<anon method-8>",
+      "startLine": 480,
+      "crap": 1.0026241338308253
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/plan-persist/story-ops.js",
+      "method": "<anon method-9>",
+      "startLine": 484,
+      "crap": 1.0026241338308253
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/plan-persist/story-ops.js",
+      "method": "indexExistingStories",
+      "startLine": 517,
+      "crap": 6.079888222240487
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/plan-persist/story-ops.js",
+      "method": "warnOnDivergentSameTitleStory",
+      "startLine": 578,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/plan-persist/story-ops.js",
+      "method": "<anon method-10>",
+      "startLine": 583,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/plan-persist/story-ops.js",
+      "method": "renderStoryBodyForCreate",
+      "startLine": 599,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/plan-persist/story-ops.js",
+      "method": "<anon method-11>",
+      "startLine": 601,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/plan-persist/story-ops.js",
+      "method": "mirrorNativeDependencyEdges",
+      "startLine": 643,
+      "crap": 5.0432
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/plan-persist/story-ops.js",
+      "method": "<anon method-12>",
+      "startLine": 644,
+      "crap": 1.001728
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/plan-persist/story-ops.js",
+      "method": "<anon method-13>",
+      "startLine": 662,
+      "crap": 1.001728
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/plan-persist/story-ops.js",
+      "method": "<anon method-14>",
+      "startLine": 667,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/plan-persist/story-ops.js",
+      "method": "ensurePersistLabel",
+      "startLine": 719,
+      "crap": 4.16748046875
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/plan-persist/story-ops.js",
       "method": "createStoryIssues",
-      "startLine": 303,
-      "crap": 9.817362047726398
+      "startLine": 815,
+      "crap": 13.045382833741733
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/plan-persist/story-ops.js",
+      "method": "<anon method-15>",
+      "startLine": 832,
+      "crap": 1.0002685374777618
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/plan-persist/story-ops.js",
+      "method": "<anon method-16>",
+      "startLine": 837,
+      "crap": 1.0002685374777618
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/plan-persist/story-ops.js",
+      "method": "markStoriesReady",
+      "startLine": 956,
+      "crap": 4.125
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/plan-persist/story-ops.js",
+      "method": "<anon method-17>",
+      "startLine": 979,
+      "crap": 1.125
     },
     {
       "path": ".agents/scripts/lib/orchestration/plan-persist/summary.js",
       "method": "buildWaveTable",
-      "startLine": 24,
+      "startLine": 29,
       "crap": 4
     },
     {
       "path": ".agents/scripts/lib/orchestration/plan-persist/summary.js",
+      "method": "<anon method-1>",
+      "startLine": 38,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/plan-persist/summary.js",
+      "method": "<anon method-2>",
+      "startLine": 49,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/plan-persist/summary.js",
+      "method": "<anon method-3>",
+      "startLine": 50,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/plan-persist/summary.js",
       "method": "renderWaveTableLines",
-      "startLine": 52,
-      "crap": 3.072
+      "startLine": 57,
+      "crap": 3
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/plan-persist/summary.js",
+      "method": "<anon method-4>",
+      "startLine": 62,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/plan-persist/summary.js",
+      "method": "<anon method-5>",
+      "startLine": 63,
+      "crap": 1
     },
     {
       "path": ".agents/scripts/lib/orchestration/plan-persist/summary.js",
       "method": "buildPlanSummaryCommentBody",
-      "startLine": 69,
-      "crap": 11
+      "startLine": 74,
+      "crap": 12
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/plan-persist/summary.js",
+      "method": "<anon method-6>",
+      "startLine": 104,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/plan-persist/summary.js",
+      "method": "<anon method-7>",
+      "startLine": 118,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/plan-persist/supersede-ops.js",
+      "method": "normalizeSupersedeEntry",
+      "startLine": 66,
+      "crap": 10
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/plan-persist/supersede-ops.js",
+      "method": "normalizeSupersedes",
+      "startLine": 98,
+      "crap": 5
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/plan-persist/supersede-ops.js",
+      "method": "<anon method-1>",
+      "startLine": 107,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/plan-persist/supersede-ops.js",
+      "method": "normalizeSourceTicketIds",
+      "startLine": 128,
+      "crap": 8
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/plan-persist/supersede-ops.js",
+      "method": "<anon method-2>",
+      "startLine": 134,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/plan-persist/supersede-ops.js",
+      "method": "<anon method-3>",
+      "startLine": 135,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/plan-persist/supersede-ops.js",
+      "method": "extractEnvelopeSourceTicketIds",
+      "startLine": 160,
+      "crap": 3
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/plan-persist/supersede-ops.js",
+      "method": "<anon method-4>",
+      "startLine": 164,
+      "crap": 3
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/plan-persist/supersede-ops.js",
+      "method": "sameIdSet",
+      "startLine": 171,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/plan-persist/supersede-ops.js",
+      "method": "<anon method-5>",
+      "startLine": 172,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/plan-persist/supersede-ops.js",
+      "method": "resolveSourceTicketIds",
+      "startLine": 197,
+      "crap": 5
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/plan-persist/supersede-ops.js",
+      "method": "<anon method-6>",
+      "startLine": 208,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/plan-persist/supersede-ops.js",
+      "method": "<anon method-7>",
+      "startLine": 210,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/plan-persist/supersede-ops.js",
+      "method": "<anon method-8>",
+      "startLine": 220,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/plan-persist/supersede-ops.js",
+      "method": "describeStoryIds",
+      "startLine": 228,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/plan-persist/supersede-ops.js",
+      "method": "<anon method-9>",
+      "startLine": 229,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/plan-persist/supersede-ops.js",
+      "method": "assertSupersedePartition",
+      "startLine": 241,
+      "crap": 6
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/plan-persist/supersede-ops.js",
+      "method": "<anon method-10>",
+      "startLine": 285,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/plan-persist/supersede-ops.js",
+      "method": "buildSupersedeCommentBody",
+      "startLine": 300,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/plan-persist/supersede-ops.js",
+      "method": "probeSourceTicket",
+      "startLine": 330,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/plan-persist/supersede-ops.js",
+      "method": "closeOneSupersededTicket",
+      "startLine": 345,
+      "crap": 3
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/plan-persist/supersede-ops.js",
+      "method": "emptyReport",
+      "startLine": 395,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/plan-persist/supersede-ops.js",
+      "method": "closeSupersededTickets",
+      "startLine": 424,
+      "crap": 8
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/plan-persist/supersede-ops.js",
+      "method": "<anon method-11>",
+      "startLine": 441,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/plan-persist/supersede-ops.js",
+      "method": "logSupersedeReport",
+      "startLine": 484,
+      "crap": 3
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/plan-persist/supersede-ops.js",
+      "method": "<anon method-12>",
+      "startLine": 497,
+      "crap": 1
     },
     {
       "path": ".agents/scripts/lib/orchestration/plan-reachability.js",
@@ -7585,15 +14366,51 @@
     },
     {
       "path": ".agents/scripts/lib/orchestration/plan-reachability.js",
+      "method": "<anon method-1>",
+      "startLine": 82,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/plan-reachability.js",
+      "method": "<anon method-2>",
+      "startLine": 86,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/plan-reachability.js",
+      "method": "<anon method-3>",
+      "startLine": 89,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/plan-reachability.js",
+      "method": "<anon method-4>",
+      "startLine": 89,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/plan-reachability.js",
+      "method": "<anon method-5>",
+      "startLine": 91,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/plan-reachability.js",
+      "method": "<anon method-6>",
+      "startLine": 106,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/plan-reachability.js",
       "method": "renderReachabilityOrphans",
       "startLine": 144,
       "crap": 1
     },
     {
-      "path": ".agents/scripts/lib/orchestration/plan-review-routing.js",
-      "method": "resolveReviewRouting",
-      "startLine": 37,
-      "crap": 3
+      "path": ".agents/scripts/lib/orchestration/plan-reachability.js",
+      "method": "<anon method-7>",
+      "startLine": 147,
+      "crap": 1
     },
     {
       "path": ".agents/scripts/lib/orchestration/plan-runner/worktree-sweep.js",
@@ -7620,202 +14437,88 @@
       "crap": 3
     },
     {
-      "path": ".agents/scripts/lib/orchestration/planning-context-budget.js",
-      "method": "byteLen",
-      "startLine": 39,
-      "crap": 2
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/planning-context-budget.js",
-      "method": "extractHeadings",
-      "startLine": 44,
-      "crap": 3
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/planning-context-budget.js",
-      "method": "splitSections",
-      "startLine": 60,
-      "crap": 3
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/planning-context-budget.js",
-      "method": "firstParagraph",
-      "startLine": 80,
-      "crap": 5
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/planning-context-budget.js",
-      "method": "summarizeDoc",
-      "startLine": 107,
-      "crap": 4
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/planning-context-budget.js",
-      "method": "normalizeItems",
-      "startLine": 139,
-      "crap": 2
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/planning-context-budget.js",
-      "method": "totalBytes",
-      "startLine": 149,
+      "path": ".agents/scripts/lib/orchestration/plan-text-hygiene.js",
+      "method": "stripCodeSpans",
+      "startLine": 82,
       "crap": 1
     },
     {
-      "path": ".agents/scripts/lib/orchestration/planning-context-budget.js",
-      "method": "buildFullItems",
-      "startLine": 155,
+      "path": ".agents/scripts/lib/orchestration/plan-text-hygiene.js",
+      "method": "splitSentences",
+      "startLine": 93,
       "crap": 1
     },
     {
-      "path": ".agents/scripts/lib/orchestration/planning-context-budget.js",
-      "method": "buildSummaryItems",
-      "startLine": 163,
-      "crap": 2
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/planning-context-budget.js",
-      "method": "applyBudget",
-      "startLine": 186,
-      "crap": 6
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/planning-risk.js",
+      "path": ".agents/scripts/lib/orchestration/plan-text-hygiene.js",
       "method": "<anon method-1>",
-      "startLine": 75,
-      "crap": 1
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/planning-risk.js",
-      "method": "<anon method-2>",
-      "startLine": 83,
-      "crap": 1
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/planning-risk.js",
-      "method": "<anon method-3>",
-      "startLine": 89,
-      "crap": 1
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/planning-risk.js",
-      "method": "<anon method-4>",
       "startLine": 96,
       "crap": 1
     },
     {
-      "path": ".agents/scripts/lib/orchestration/planning-risk.js",
-      "method": "<anon method-5>",
-      "startLine": 103,
-      "crap": 1
+      "path": ".agents/scripts/lib/orchestration/plan-text-hygiene.js",
+      "method": "excerpt",
+      "startLine": 106,
+      "crap": 2
     },
     {
-      "path": ".agents/scripts/lib/orchestration/planning-risk.js",
-      "method": "<anon method-6>",
-      "startLine": 109,
-      "crap": 1
+      "path": ".agents/scripts/lib/orchestration/plan-text-hygiene.js",
+      "method": "findDanglingCitations",
+      "startLine": 120,
+      "crap": 4
     },
     {
-      "path": ".agents/scripts/lib/orchestration/planning-risk.js",
-      "method": "<anon method-7>",
-      "startLine": 116,
-      "crap": 1
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/planning-risk.js",
-      "method": "<anon method-8>",
+      "path": ".agents/scripts/lib/orchestration/plan-text-hygiene.js",
+      "method": "<anon method-2>",
       "startLine": 123,
       "crap": 1
     },
     {
-      "path": ".agents/scripts/lib/orchestration/planning-risk.js",
-      "method": "<anon method-9>",
-      "startLine": 130,
-      "crap": 1
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/planning-risk.js",
-      "method": "<anon method-10>",
-      "startLine": 136,
-      "crap": 1
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/planning-risk.js",
-      "method": "trimSnippet",
-      "startLine": 158,
-      "crap": 2.032
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/planning-risk.js",
-      "method": "firstMatchSnippet",
-      "startLine": 169,
+      "path": ".agents/scripts/lib/orchestration/plan-text-hygiene.js",
+      "method": "findOpenQuestions",
+      "startLine": 149,
       "crap": 3
     },
     {
-      "path": ".agents/scripts/lib/orchestration/planning-risk.js",
-      "method": "resolveOverallLevel",
-      "startLine": 181,
-      "crap": 2
+      "path": ".agents/scripts/lib/orchestration/plan-text-hygiene.js",
+      "method": "<anon method-3>",
+      "startLine": 153,
+      "crap": 1
     },
     {
-      "path": ".agents/scripts/lib/orchestration/planning-risk.js",
-      "method": "resolveAcceptanceDisposition",
-      "startLine": 203,
-      "crap": 9.073411432983116
+      "path": ".agents/scripts/lib/orchestration/plan-text-hygiene.js",
+      "method": "findSlicingMass",
+      "startLine": 177,
+      "crap": 6
     },
     {
-      "path": ".agents/scripts/lib/orchestration/planning-risk.js",
-      "method": "resolveRequiresReview",
-      "startLine": 240,
-      "crap": 4.460555972952667
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/planning-risk.js",
-      "method": "classifyPlanningRisk",
-      "startLine": 258,
-      "crap": 9.222264000000001
+      "path": ".agents/scripts/lib/orchestration/plan-text-hygiene.js",
+      "method": "evaluateTextHygiene",
+      "startLine": 205,
+      "crap": 6
     },
     {
       "path": ".agents/scripts/lib/orchestration/planning/authoring-context.js",
       "method": "resolveMemoryDir",
-      "startLine": 44,
+      "startLine": 43,
       "crap": 5
     },
     {
       "path": ".agents/scripts/lib/orchestration/planning/authoring-context.js",
       "method": "buildPlanningDocsContext",
-      "startLine": 78,
+      "startLine": 77,
       "crap": 4
     },
     {
       "path": ".agents/scripts/lib/orchestration/planning/authoring-context.js",
       "method": "buildAuthoringContext",
-      "startLine": 110,
-      "crap": 7.002536134039381
+      "startLine": 118,
+      "crap": 5.001478534958043
     },
     {
       "path": ".agents/scripts/lib/orchestration/planning/decomposer-context.js",
       "method": "buildDecomposerSystemPrompt",
       "startLine": 14,
       "crap": 3
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/planning/risk-verdict.js",
-      "method": "getRiskVerdictValidator",
-      "startLine": 41,
-      "crap": 2
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/planning/risk-verdict.js",
-      "method": "validateRiskVerdict",
-      "startLine": 61,
-      "crap": 2.4065185185185185
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/planning/risk-verdict.js",
-      "method": "loadRiskVerdict",
-      "startLine": 85,
-      "crap": 1.8573749999999998
     },
     {
       "path": ".agents/scripts/lib/orchestration/planning/spec-authoring-grounding.js",
@@ -7831,195 +14534,69 @@
     },
     {
       "path": ".agents/scripts/lib/orchestration/planning/spec-authoring-grounding.js",
+      "method": "<anon method-1>",
+      "startLine": 99,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/planning/spec-authoring-grounding.js",
       "method": "buildAuthoringGrounding",
       "startLine": 130,
       "crap": 1
     },
     {
-      "path": ".agents/scripts/lib/orchestration/post-merge/phases/branch-cleanup.js",
-      "method": "reapPhaseLogger",
-      "startLine": 13,
-      "crap": 1
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/post-merge/phases/branch-cleanup.js",
-      "method": "branchCleanupPhase",
-      "startLine": 17,
-      "crap": 7
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/post-merge/phases/dashboard-refresh.js",
-      "method": "reapPhaseLogger",
-      "startLine": 8,
-      "crap": 1
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/post-merge/phases/dashboard-refresh.js",
-      "method": "dashboardRefreshPhase",
-      "startLine": 12,
-      "crap": 2
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/post-merge/phases/notification.js",
-      "method": "reapPhaseLogger",
-      "startLine": 14,
-      "crap": 1
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/post-merge/phases/notification.js",
-      "method": "notificationPhase",
-      "startLine": 18,
-      "crap": 4
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/post-merge/phases/temp-cleanup.js",
-      "method": "reapPhaseLogger",
-      "startLine": 14,
-      "crap": 1
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/post-merge/phases/temp-cleanup.js",
-      "method": "tempCleanupPhase",
-      "startLine": 18,
-      "crap": 2
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/post-merge/phases/ticket-closure.js",
-      "method": "reapPhaseLogger",
-      "startLine": 25,
-      "crap": 1
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/post-merge/phases/ticket-closure.js",
-      "method": "ticketClosurePhase",
-      "startLine": 29,
-      "crap": 6.242617283950617
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/post-merge/phases/worktree-reap.js",
-      "method": "isWindowsReapLockFailure",
-      "startLine": 43,
-      "crap": 2
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/post-merge/phases/worktree-reap.js",
-      "method": "findStillRegisteredEntry",
-      "startLine": 47,
-      "crap": 2
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/post-merge/phases/worktree-reap.js",
-      "method": "resolveWorktreeRoot",
-      "startLine": 57,
-      "crap": 2
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/post-merge/phases/worktree-reap.js",
-      "method": "retryPruneUntilCleared",
-      "startLine": 63,
-      "crap": 4.0092592592592595
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/post-merge/phases/worktree-reap.js",
-      "method": "reapPhaseLogger",
-      "startLine": 88,
-      "crap": 1
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/post-merge/phases/worktree-reap.js",
-      "method": "createWorktreeReapState",
-      "startLine": 92,
-      "crap": 1
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/post-merge/phases/worktree-reap.js",
-      "method": "emitReapFailureFriction",
-      "startLine": 105,
-      "crap": 3.0134344023323614
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/post-merge/phases/worktree-reap.js",
-      "method": "resolveSkipState",
-      "startLine": 141,
-      "crap": 3
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/post-merge/phases/worktree-reap.js",
-      "method": "resolveInitialReapStatus",
-      "startLine": 153,
-      "crap": 3
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/post-merge/phases/worktree-reap.js",
-      "method": "initialReapState",
-      "startLine": 159,
-      "crap": 3
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/post-merge/phases/worktree-reap.js",
-      "method": "logReapOutcome",
-      "startLine": 175,
-      "crap": 4
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/post-merge/phases/worktree-reap.js",
-      "method": "detectStillRegistered",
-      "startLine": 211,
-      "crap": 3
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/post-merge/phases/worktree-reap.js",
-      "method": "escalateStillRegistered",
-      "startLine": 226,
-      "crap": 1
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/post-merge/phases/worktree-reap.js",
-      "method": "logStaleRegistryEntry",
-      "startLine": 254,
-      "crap": 1
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/post-merge/phases/worktree-reap.js",
-      "method": "worktreeReapPhase",
-      "startLine": 264,
-      "crap": 6.000104956268221
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/post-merge/phases/worktree-reap.js",
-      "method": "applyStillRegisteredState",
-      "startLine": 350,
-      "crap": 5.015410843454726
-    },
-    {
       "path": ".agents/scripts/lib/orchestration/pr-base-guard.js",
       "method": "assertStoryPrBaseAllowed",
-      "startLine": 37,
+      "startLine": 25,
+      "crap": 3
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/project-meta-cache.js",
+      "method": "projectMetaCachePath",
+      "startLine": 67,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/project-meta-cache.js",
+      "method": "projectMetaCacheKey",
+      "startLine": 83,
       "crap": 4
     },
     {
-      "path": ".agents/scripts/lib/orchestration/preflight-cache.js",
-      "method": "preflightCachePath",
-      "startLine": 45,
-      "crap": 3.7901234567901234
+      "path": ".agents/scripts/lib/orchestration/project-meta-cache.js",
+      "method": "readCacheFile",
+      "startLine": 98,
+      "crap": 3
     },
     {
-      "path": ".agents/scripts/lib/orchestration/preflight-cache.js",
-      "method": "computeBaseSha",
-      "startLine": 67,
-      "crap": 6.131087847064179
+      "path": ".agents/scripts/lib/orchestration/project-meta-cache.js",
+      "method": "readProjectMetaCache",
+      "startLine": 124,
+      "crap": 22.5
     },
     {
-      "path": ".agents/scripts/lib/orchestration/preflight-cache.js",
-      "method": "readPreflightCache",
-      "startLine": 92,
-      "crap": 12.865514650638616
+      "path": ".agents/scripts/lib/orchestration/project-meta-cache.js",
+      "method": "writeProjectMetaCache",
+      "startLine": 173,
+      "crap": 6.058619987787503
     },
     {
-      "path": ".agents/scripts/lib/orchestration/preflight-cache.js",
-      "method": "writePreflightCache",
-      "startLine": 122,
-      "crap": 11.795527437835663
+      "path": ".agents/scripts/lib/orchestration/project-meta-cache.js",
+      "method": "invalidateProjectMetaCache",
+      "startLine": 224,
+      "crap": 10.317333333333334
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/project-meta-resolver.js",
+      "method": "buildScopedQuery",
+      "startLine": 53,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/project-meta-resolver.js",
+      "method": "resolveProjectMeta",
+      "startLine": 95,
+      "crap": 9
     },
     {
       "path": ".agents/scripts/lib/orchestration/reassert-status-column.js",
@@ -8029,9 +14606,15 @@
     },
     {
       "path": ".agents/scripts/lib/orchestration/reassert-status-column.js",
+      "method": "<anon method-1>",
+      "startLine": 58,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/reassert-status-column.js",
       "method": "reassertStatusColumn",
-      "startLine": 95,
-      "crap": 15.877522005029721
+      "startLine": 96,
+      "crap": 15.853590923446502
     },
     {
       "path": ".agents/scripts/lib/orchestration/recut.js",
@@ -8052,58 +14635,160 @@
       "crap": 4
     },
     {
-      "path": ".agents/scripts/lib/orchestration/resolve-plan-run.js",
-      "method": "normalizePlanRunLabel",
-      "startLine": 21,
+      "path": ".agents/scripts/lib/orchestration/remote-verifier.js",
+      "method": "runProbe",
+      "startLine": 37,
       "crap": 1
     },
     {
-      "path": ".agents/scripts/lib/orchestration/resolve-plan-run.js",
-      "method": "planRunIdFromLabel",
-      "startLine": 32,
-      "crap": 1
+      "path": ".agents/scripts/lib/orchestration/remote-verifier.js",
+      "method": "verifyRemote",
+      "startLine": 71,
+      "crap": 6
     },
     {
-      "path": ".agents/scripts/lib/orchestration/resolve-plan-run.js",
-      "method": "normalizeIssueLabels",
-      "startLine": 42,
-      "crap": 2
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/resolve-plan-run.js",
-      "method": "toStoryRecord",
-      "startLine": 54,
-      "crap": 4
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/resolve-plan-run.js",
-      "method": "storiesToDag",
-      "startLine": 73,
-      "crap": 1
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/resolve-plan-run.js",
-      "method": "buildPlanRunEnvelope",
-      "startLine": 88,
-      "crap": 2
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/resolve-plan-run.js",
-      "method": "resolvePlanRunFromIssues",
-      "startLine": 121,
-      "crap": 1
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/resolve-plan-run.js",
-      "method": "fetchPlanRunIssues",
+      "path": ".agents/scripts/lib/orchestration/remote-verifier.js",
+      "method": "probeRemoteBranch",
       "startLine": 134,
-      "crap": 9.029296875
+      "crap": 6
     },
     {
-      "path": ".agents/scripts/lib/orchestration/resolve-plan-run.js",
-      "method": "assertIssueState",
-      "startLine": 147,
-      "crap": 4.809327846364883
+      "path": ".agents/scripts/lib/orchestration/resolve-stories.js",
+      "method": "normalizeIssueLabels",
+      "startLine": 50,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/resolve-stories.js",
+      "method": "<anon method-1>",
+      "startLine": 54,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/resolve-stories.js",
+      "method": "<anon method-2>",
+      "startLine": 55,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/resolve-stories.js",
+      "method": "toStoryRecord",
+      "startLine": 68,
+      "crap": 7.052866703754278
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/resolve-stories.js",
+      "method": "<anon method-3>",
+      "startLine": 103,
+      "crap": 2.0043156492860636
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/resolve-stories.js",
+      "method": "isSatisfiedBlocker",
+      "startLine": 114,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/resolve-stories.js",
+      "method": "storyFootprintPaths",
+      "startLine": 155,
+      "crap": 1.010973936899863
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/resolve-stories.js",
+      "method": "<anon method-4>",
+      "startLine": 171,
+      "crap": 1.010973936899863
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/resolve-stories.js",
+      "method": "<anon method-5>",
+      "startLine": 172,
+      "crap": 2.0438957475994513
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/resolve-stories.js",
+      "method": "<anon method-6>",
+      "startLine": 173,
+      "crap": 1.010973936899863
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/resolve-stories.js",
+      "method": "storiesToDag",
+      "startLine": 193,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/resolve-stories.js",
+      "method": "<anon method-7>",
+      "startLine": 194,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/resolve-stories.js",
+      "method": "<anon method-8>",
+      "startLine": 207,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/resolve-stories.js",
+      "method": "nativeBlockedByNumbers",
+      "startLine": 232,
+      "crap": 7
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/resolve-stories.js",
+      "method": "readNativeBlockedBy",
+      "startLine": 267,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/resolve-stories.js",
+      "method": "buildStoriesEnvelope",
+      "startLine": 308,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/resolve-stories.js",
+      "method": "<anon method-9>",
+      "startLine": 316,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/resolve-stories.js",
+      "method": "<anon method-10>",
+      "startLine": 317,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/resolve-stories.js",
+      "method": "<anon method-11>",
+      "startLine": 335,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/resolve-stories.js",
+      "method": "<anon method-12>",
+      "startLine": 350,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/resolve-stories.js",
+      "method": "parseIds",
+      "startLine": 360,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/resolve-stories.js",
+      "method": "<anon method-13>",
+      "startLine": 363,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/resolve-stories.js",
+      "method": "<anon method-14>",
+      "startLine": 365,
+      "crap": 4
     },
     {
       "path": ".agents/scripts/lib/orchestration/resolves-token.js",
@@ -8130,477 +14815,585 @@
       "crap": 1
     },
     {
-      "path": ".agents/scripts/lib/orchestration/retro-perf-heuristics.js",
-      "method": "isObject",
-      "startLine": 53,
-      "crap": 3
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/retro-perf-heuristics.js",
-      "method": "clampUnit",
-      "startLine": 57,
-      "crap": 5
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/retro-perf-heuristics.js",
-      "method": "positiveInt",
-      "startLine": 67,
-      "crap": 5
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/retro-perf-heuristics.js",
-      "method": "resolvePerfThresholds",
-      "startLine": 81,
-      "crap": 2
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/retro-perf-heuristics.js",
-      "method": "extractRows",
-      "startLine": 107,
-      "crap": 3
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/retro-perf-heuristics.js",
-      "method": "detectLowUtilisation",
-      "startLine": 138,
-      "crap": 2
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/retro-perf-heuristics.js",
-      "method": "sumBootstrapMs",
-      "startLine": 159,
-      "crap": 9
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/retro-perf-heuristics.js",
-      "method": "detectHighBootstrapShare",
-      "startLine": 182,
-      "crap": 4
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/retro-perf-heuristics.js",
-      "method": "detectCapBindingRuns",
-      "startLine": 205,
-      "crap": 8.70233196159122
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/retro-perf-heuristics.js",
-      "method": "classifyPerfSignals",
-      "startLine": 256,
-      "crap": 2
-    },
-    {
       "path": ".agents/scripts/lib/orchestration/retro-proposals.js",
       "method": "emptyResult",
-      "startLine": 78,
+      "startLine": 100,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/orchestration/retro-proposals.js",
       "method": "asString",
-      "startLine": 88,
+      "startLine": 110,
       "crap": 2
     },
     {
       "path": ".agents/scripts/lib/orchestration/retro-proposals.js",
+      "method": "incidentKey",
+      "startLine": 122,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/retro-proposals.js",
+      "method": "netOutRecoveredIncidents",
+      "startLine": 152,
+      "crap": 4
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/retro-proposals.js",
+      "method": "<anon method-1>",
+      "startLine": 160,
+      "crap": 4
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/retro-proposals.js",
+      "method": "deriveUnresolvedBlockedEvents",
+      "startLine": 186,
+      "crap": 11
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/retro-proposals.js",
+      "method": "<anon method-2>",
+      "startLine": 216,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/retro-proposals.js",
       "method": "aggregateByCategory",
-      "startLine": 109,
+      "startLine": 235,
       "crap": 6
     },
     {
       "path": ".agents/scripts/lib/orchestration/retro-proposals.js",
       "method": "dominantSource",
-      "startLine": 140,
+      "startLine": 266,
       "crap": 3
     },
     {
       "path": ".agents/scripts/lib/orchestration/retro-proposals.js",
       "method": "formatAnchor",
-      "startLine": 152,
-      "crap": 3
+      "startLine": 278,
+      "crap": 3.072
     },
     {
       "path": ".agents/scripts/lib/orchestration/retro-proposals.js",
       "method": "isActionableFriction",
-      "startLine": 159,
-      "crap": 3
+      "startLine": 292,
+      "crap": 2
     },
     {
       "path": ".agents/scripts/lib/orchestration/retro-proposals.js",
       "method": "renderIssueBody",
-      "startLine": 178,
+      "startLine": 310,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/orchestration/retro-proposals.js",
       "method": "renderIssueCommand",
-      "startLine": 213,
+      "startLine": 345,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/orchestration/retro-proposals.js",
       "method": "buildRoutedItem",
-      "startLine": 238,
+      "startLine": 370,
       "crap": 3
     },
     {
       "path": ".agents/scripts/lib/orchestration/retro-proposals.js",
       "method": "normalizeAnchorKind",
-      "startLine": 283,
-      "crap": 4
+      "startLine": 415,
+      "crap": 3
     },
     {
       "path": ".agents/scripts/lib/orchestration/retro-proposals.js",
       "method": "normaliseInput",
-      "startLine": 287,
+      "startLine": 419,
       "crap": 9
     },
     {
       "path": ".agents/scripts/lib/orchestration/retro-proposals.js",
       "method": "blockedForceMap",
-      "startLine": 307,
+      "startLine": 439,
       "crap": 6
     },
     {
       "path": ".agents/scripts/lib/orchestration/retro-proposals.js",
       "method": "pushRouted",
-      "startLine": 322,
+      "startLine": 454,
       "crap": 2
     },
     {
       "path": ".agents/scripts/lib/orchestration/retro-proposals.js",
       "method": "routeCategoryBuckets",
-      "startLine": 327,
+      "startLine": 459,
       "crap": 4
     },
     {
       "path": ".agents/scripts/lib/orchestration/retro-proposals.js",
+      "method": "<anon method-3>",
+      "startLine": 507,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/retro-proposals.js",
+      "method": "<anon method-4>",
+      "startLine": 508,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/retro-proposals.js",
+      "method": "<anon method-5>",
+      "startLine": 509,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/retro-proposals.js",
       "method": "composeRoutedProposals",
-      "startLine": 394,
+      "startLine": 526,
       "crap": 2
     },
     {
       "path": ".agents/scripts/lib/orchestration/review-depth.js",
+      "method": "deriveChangeLevel",
+      "startLine": 101,
+      "crap": 7
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/review-depth.js",
       "method": "normalizeChangedFileCount",
-      "startLine": 60,
+      "startLine": 129,
       "crap": 4
     },
     {
       "path": ".agents/scripts/lib/orchestration/review-depth.js",
       "method": "resolveDepth",
-      "startLine": 79,
+      "startLine": 148,
       "crap": 13
     },
     {
       "path": ".agents/scripts/lib/orchestration/review-providers/codex.js",
       "method": "defaultProbeCodexCommand",
-      "startLine": 74,
+      "startLine": 76,
       "crap": 2
     },
     {
       "path": ".agents/scripts/lib/orchestration/review-providers/codex.js",
       "method": "buildCodexUnavailableError",
-      "startLine": 95,
+      "startLine": 97,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/orchestration/review-providers/codex.js",
       "method": "mapCodexSeverity",
-      "startLine": 146,
+      "startLine": 148,
       "crap": 2
     },
     {
       "path": ".agents/scripts/lib/orchestration/review-providers/codex.js",
       "method": "parseCodexFindings",
-      "startLine": 174,
-      "crap": 29
+      "startLine": 176,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/review-providers/codex.js",
+      "method": "buildCodexReviewPrompt",
+      "startLine": 197,
+      "crap": 1.5787037037037037
     },
     {
       "path": ".agents/scripts/lib/orchestration/review-providers/codex.js",
       "method": "defaultInvokeCodexReview",
-      "startLine": 250,
+      "startLine": 217,
       "crap": 1.813037037037037
     },
     {
       "path": ".agents/scripts/lib/orchestration/review-providers/codex.js",
       "method": "createCodexProvider",
-      "startLine": 282,
+      "startLine": 249,
       "crap": 9.018589193278311
     },
     {
       "path": ".agents/scripts/lib/orchestration/review-providers/codex.js",
       "method": "createCodexProviderForRegistry",
-      "startLine": 339,
+      "startLine": 306,
       "crap": 1.2962962962962963
     },
     {
       "path": ".agents/scripts/lib/orchestration/review-providers/findings-renderer.js",
       "method": "countBySeverity",
-      "startLine": 55,
+      "startLine": 54,
       "crap": 3
     },
     {
       "path": ".agents/scripts/lib/orchestration/review-providers/findings-renderer.js",
       "method": "renderFinding",
-      "startLine": 78,
+      "startLine": 77,
       "crap": 3
     },
     {
       "path": ".agents/scripts/lib/orchestration/review-providers/findings-renderer.js",
       "method": "renderManualPromptsSection",
-      "startLine": 99,
+      "startLine": 98,
       "crap": 3
     },
     {
       "path": ".agents/scripts/lib/orchestration/review-providers/findings-renderer.js",
+      "method": "<anon method-1>",
+      "startLine": 100,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/review-providers/findings-renderer.js",
       "method": "renderFindings",
-      "startLine": 130,
-      "crap": 6
+      "startLine": 128,
+      "crap": 5
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/review-providers/findings-renderer.js",
+      "method": "<anon method-2>",
+      "startLine": 148,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/review-providers/findings-renderer.js",
+      "method": "<anon method-3>",
+      "startLine": 161,
+      "crap": 2
     },
     {
       "path": ".agents/scripts/lib/orchestration/review-providers/findings-renderer.js",
       "method": "buildAttribution",
-      "startLine": 199,
+      "startLine": 189,
       "crap": 4
     },
     {
       "path": ".agents/scripts/lib/orchestration/review-providers/native.js",
       "method": "parseLintOutput",
-      "startLine": 80,
+      "startLine": 95,
       "crap": 3.011069606413994
     },
     {
       "path": ".agents/scripts/lib/orchestration/review-providers/native.js",
       "method": "partitionFilesForLint",
-      "startLine": 117,
+      "startLine": 132,
       "crap": 3
     },
     {
       "path": ".agents/scripts/lib/orchestration/review-providers/native.js",
-      "method": "resolveCurrentSha",
-      "startLine": 128,
-      "crap": 4
+      "method": "readHeadSource",
+      "startLine": 167,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/review-providers/native.js",
+      "method": "scoreSourceReport",
+      "startLine": 186,
+      "crap": 2.9321802457897133
     },
     {
       "path": ".agents/scripts/lib/orchestration/review-providers/native.js",
       "method": "spawnLintRunner",
-      "startLine": 135,
+      "startLine": 200,
       "crap": 2
     },
     {
       "path": ".agents/scripts/lib/orchestration/review-providers/native.js",
       "method": "runScopedLint",
-      "startLine": 158,
+      "startLine": 223,
       "crap": 14.28854351985499
     },
     {
       "path": ".agents/scripts/lib/orchestration/review-providers/native.js",
-      "method": "buildLintEvidenceConfig",
-      "startLine": 198,
-      "crap": 3
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/review-providers/native.js",
       "method": "classifyChangedFile",
-      "startLine": 220,
+      "startLine": 263,
       "crap": 6
     },
     {
       "path": ".agents/scripts/lib/orchestration/review-providers/native.js",
       "method": "accumulateClassified",
-      "startLine": 281,
+      "startLine": 323,
       "crap": 4
     },
     {
       "path": ".agents/scripts/lib/orchestration/review-providers/native.js",
       "method": "isJsMaintainabilityFile",
-      "startLine": 289,
+      "startLine": 331,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/orchestration/review-providers/native.js",
       "method": "analyzeChangedFiles",
-      "startLine": 315,
-      "crap": 8
+      "startLine": 368,
+      "crap": 13
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/review-providers/native.js",
+      "method": "<anon method-1>",
+      "startLine": 393,
+      "crap": 2
     },
     {
       "path": ".agents/scripts/lib/orchestration/review-providers/native.js",
       "method": "<anon method-2>",
-      "startLine": 370,
+      "startLine": 401,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/review-providers/native.js",
+      "method": "<anon method-3>",
+      "startLine": 413,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/review-providers/native.js",
+      "method": "<anon method-4>",
+      "startLine": 451,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/orchestration/review-providers/native.js",
       "method": "buildLintFindings",
-      "startLine": 388,
+      "startLine": 471,
       "crap": 7
     },
     {
       "path": ".agents/scripts/lib/orchestration/review-providers/native.js",
       "method": "_emptyResults",
-      "startLine": 430,
+      "startLine": 500,
       "crap": 2
     },
     {
       "path": ".agents/scripts/lib/orchestration/review-providers/native.js",
-      "method": "tryEvidenceSkip",
-      "startLine": 440,
-      "crap": 8.833819241982507
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/review-providers/native.js",
-      "method": "maybeRecordLintEvidence",
-      "startLine": 476,
-      "crap": 11.68114285714286
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/review-providers/native.js",
       "method": "runLintPhase",
-      "startLine": 512,
-      "crap": 3.1044620727177468
+      "startLine": 510,
+      "crap": 2.568094024821238
     },
     {
       "path": ".agents/scripts/lib/orchestration/review-providers/native.js",
       "method": "createNativeProvider",
-      "startLine": 587,
-      "crap": 9.000755795305437
+      "startLine": 552,
+      "crap": 8.00617746784049
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/review-providers/native.js",
+      "method": "<anon method-5>",
+      "startLine": 600,
+      "crap": 1.0001658768715886
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/review-providers/native.js",
+      "method": "<anon method-6>",
+      "startLine": 654,
+      "crap": 1.0001658768715886
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/review-providers/native.js",
+      "method": "<anon method-7>",
+      "startLine": 656,
+      "crap": 1.0001658768715886
     },
     {
       "path": ".agents/scripts/lib/orchestration/review-providers/native.js",
       "method": "createNativeProviderForRegistry",
-      "startLine": 690,
+      "startLine": 669,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/review-providers/parse-findings.js",
+      "method": "unwrapEnvelope",
+      "startLine": 49,
+      "crap": 11
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/review-providers/parse-findings.js",
+      "method": "coerceString",
+      "startLine": 71,
+      "crap": 3
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/review-providers/parse-findings.js",
+      "method": "buildFinding",
+      "startLine": 94,
+      "crap": 14
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/review-providers/parse-findings.js",
+      "method": "parseProviderFindings",
+      "startLine": 135,
+      "crap": 3
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/review-providers/parse-findings.js",
+      "method": "<anon method-1>",
+      "startLine": 151,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/review-providers/review-depth.js",
+      "method": "normalizeDepth",
+      "startLine": 57,
+      "crap": 3
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/review-providers/review-depth.js",
+      "method": "renderDepthDirective",
+      "startLine": 72,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/orchestration/review-providers/review-provider-factory.js",
       "method": "buildGate",
-      "startLine": 88,
+      "startLine": 81,
       "crap": 8.074646449919813
     },
     {
       "path": ".agents/scripts/lib/orchestration/review-providers/review-provider-factory.js",
       "method": "<anon method-1>",
-      "startLine": 89,
+      "startLine": 82,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/orchestration/review-providers/review-provider-factory.js",
+      "method": "<anon method-2>",
+      "startLine": 85,
+      "crap": 2.004665403119988
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/review-providers/review-provider-factory.js",
+      "method": "<anon method-3>",
+      "startLine": 88,
+      "crap": 1.001166350779997
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/review-providers/review-provider-factory.js",
+      "method": "<anon method-4>",
+      "startLine": 90,
+      "crap": 7.057151188219857
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/review-providers/review-provider-factory.js",
+      "method": "<anon method-5>",
+      "startLine": 94,
+      "crap": 1.001166350779997
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/review-providers/review-provider-factory.js",
       "method": "isScopeApplicable",
-      "startLine": 118,
+      "startLine": 111,
       "crap": 3
     },
     {
       "path": ".agents/scripts/lib/orchestration/review-providers/review-provider-factory.js",
       "method": "createReviewProvider",
-      "startLine": 149,
-      "crap": 8
+      "startLine": 139,
+      "crap": 4
     },
     {
       "path": ".agents/scripts/lib/orchestration/review-providers/review-provider-factory.js",
       "method": "buildProviderChain",
-      "startLine": 209,
+      "startLine": 174,
       "crap": 12.157083248524323
     },
     {
       "path": ".agents/scripts/lib/orchestration/review-providers/review-provider-factory.js",
       "method": "<anon method-6>",
-      "startLine": 228,
+      "startLine": 193,
       "crap": 2
     },
     {
       "path": ".agents/scripts/lib/orchestration/review-providers/review-provider-factory.js",
       "method": "createChainProvider",
-      "startLine": 291,
+      "startLine": 256,
       "crap": 6.0703125
     },
     {
       "path": ".agents/scripts/lib/orchestration/review-providers/review-provider-factory.js",
       "method": "listRegisteredProviders",
-      "startLine": 370,
+      "startLine": 335,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/orchestration/review-providers/review-provider-factory.js",
       "method": "listInlineProviders",
-      "startLine": 385,
+      "startLine": 350,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/orchestration/review-providers/review-provider-factory.js",
       "method": "listPromptProviders",
-      "startLine": 394,
+      "startLine": 359,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/orchestration/review-providers/security-review.js",
       "method": "defaultProbeClaudeCli",
-      "startLine": 60,
+      "startLine": 62,
       "crap": 1.7865270823850707
     },
     {
       "path": ".agents/scripts/lib/orchestration/review-providers/security-review.js",
       "method": "buildSecurityReviewUnavailableError",
-      "startLine": 81,
+      "startLine": 83,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/orchestration/review-providers/security-review.js",
       "method": "mapSecurityReviewSeverity",
-      "startLine": 120,
+      "startLine": 122,
       "crap": 2
     },
     {
       "path": ".agents/scripts/lib/orchestration/review-providers/security-review.js",
       "method": "parseSecurityReviewFindings",
-      "startLine": 139,
-      "crap": 29.10003921033038
+      "startLine": 141,
+      "crap": 1
     },
     {
       "path": ".agents/scripts/lib/orchestration/review-providers/security-review.js",
       "method": "buildSecurityReviewPrompt",
-      "startLine": 230,
-      "crap": 6
+      "startLine": 187,
+      "crap": 5
     },
     {
       "path": ".agents/scripts/lib/orchestration/review-providers/security-review.js",
       "method": "defaultInvokeSecurityReview",
-      "startLine": 253,
+      "startLine": 211,
       "crap": 1.7865270823850707
     },
     {
       "path": ".agents/scripts/lib/orchestration/review-providers/security-review.js",
       "method": "buildUnparseableFallbackFinding",
-      "startLine": 274,
+      "startLine": 232,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/orchestration/review-providers/security-review.js",
       "method": "createSecurityReviewProvider",
-      "startLine": 297,
+      "startLine": 255,
       "crap": 9.054672692812364
     },
     {
       "path": ".agents/scripts/lib/orchestration/review-providers/security-review.js",
       "method": "createSecurityReviewProviderForRegistry",
-      "startLine": 361,
+      "startLine": 319,
       "crap": 1.2962962962962963
     },
     {
       "path": ".agents/scripts/lib/orchestration/review-providers/ultrareview.js",
       "method": "buildUltrareviewMessage",
-      "startLine": 48,
-      "crap": 4
+      "startLine": 57,
+      "crap": 3
     },
     {
       "path": ".agents/scripts/lib/orchestration/review-providers/ultrareview.js",
       "method": "createUltrareviewProvider",
-      "startLine": 70,
+      "startLine": 80,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/orchestration/review-providers/ultrareview.js",
       "method": "createUltrareviewProviderForRegistry",
-      "startLine": 95,
+      "startLine": 105,
       "crap": 1
     },
     {
@@ -8622,64 +15415,304 @@
       "crap": 5
     },
     {
+      "path": ".agents/scripts/lib/orchestration/run-epilogue.js",
+      "method": "<anon method-1>",
+      "startLine": 106,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/run-epilogue.js",
+      "method": "readFirstParentHistory",
+      "startLine": 158,
+      "crap": 3
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/run-epilogue.js",
+      "method": "<anon method-2>",
+      "startLine": 185,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/run-epilogue.js",
+      "method": "<anon method-3>",
+      "startLine": 187,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/run-epilogue.js",
+      "method": "trailingMarkerIds",
+      "startLine": 231,
+      "crap": 3
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/run-epilogue.js",
+      "method": "resolveRunBaseSha",
+      "startLine": 269,
+      "crap": 7
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/run-epilogue.js",
+      "method": "<anon method-4>",
+      "startLine": 278,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/run-epilogue.js",
+      "method": "<anon method-5>",
+      "startLine": 298,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/run-epilogue.js",
+      "method": "<anon method-6>",
+      "startLine": 321,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/run-epilogue.js",
+      "method": "listChangedFiles",
+      "startLine": 333,
+      "crap": 3.474609375
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/run-epilogue.js",
+      "method": "<anon method-7>",
+      "startLine": 353,
+      "crap": 1.052734375
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/run-epilogue.js",
+      "method": "resolveCombinedDiff",
+      "startLine": 365,
+      "crap": 3.129528359623319
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/run-epilogue.js",
+      "method": "renderDiffLines",
+      "startLine": 410,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/run-epilogue.js",
+      "method": "resolveBaseRef",
+      "startLine": 432,
+      "crap": 3
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/run-epilogue.js",
+      "method": "executeAuditRoster",
+      "startLine": 441,
+      "crap": 14.000169312169312
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/run-epilogue.js",
+      "method": "<anon method-8>",
+      "startLine": 492,
+      "crap": 1.0000008638375986
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/run-epilogue.js",
+      "method": "executeFollowUpRollup",
+      "startLine": 547,
+      "crap": 5.002574920654297
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/run-epilogue.js",
+      "method": "<anon method-9>",
+      "startLine": 578,
+      "crap": 1.0001029968261719
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/run-epilogue.js",
+      "method": "extractSection",
+      "startLine": 612,
+      "crap": 3
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/run-epilogue.js",
+      "method": "executeSiblingCoherence",
+      "startLine": 622,
+      "crap": 11
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/run-epilogue.js",
+      "method": "<anon method-10>",
+      "startLine": 636,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/run-epilogue.js",
+      "method": "<anon method-11>",
+      "startLine": 639,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/run-epilogue.js",
+      "method": "<anon method-12>",
+      "startLine": 640,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/run-epilogue.js",
+      "method": "<anon method-13>",
+      "startLine": 656,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/run-epilogue.js",
+      "method": "<anon method-14>",
+      "startLine": 668,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/run-epilogue.js",
+      "method": "runPlanRunEpilogue",
+      "startLine": 703,
+      "crap": 7.033660696112355
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/single-story-close/gate-log.js",
+      "method": "logNameFor",
+      "startLine": 73,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/single-story-close/gate-log.js",
+      "method": "createArtifactWriter",
+      "startLine": 178,
+      "crap": 1.0011070564598794
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/single-story-close/gate-log.js",
+      "method": "<anon method-3>",
+      "startLine": 180,
+      "crap": 1.0011070564598794
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/single-story-close/gate-log.js",
+      "method": "<anon method-4>",
+      "startLine": 185,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/single-story-close/gate-log.js",
+      "method": "<anon method-5>",
+      "startLine": 193,
+      "crap": 1.0046296296296295
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/single-story-close/gate-log.js",
+      "method": "<anon method-6>",
+      "startLine": 194,
+      "crap": 1.0046296296296295
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/single-story-close/gate-log.js",
+      "method": "<anon method-7>",
+      "startLine": 195,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/single-story-close/gate-log.js",
+      "method": "createGateLogSink",
+      "startLine": 222,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/single-story-close/gate-log.js",
+      "method": "<anon method-8>",
+      "startLine": 230,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/single-story-close/gate-log.js",
+      "method": "<anon method-9>",
+      "startLine": 248,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/single-story-close/phases/auto-merge.js",
+      "method": "isOperatorMergeReason",
+      "startLine": 87,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/single-story-close/phases/auto-merge.js",
+      "method": "isLocalCleanupOnlyFailure",
+      "startLine": 123,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/single-story-close/phases/auto-merge.js",
+      "method": "isAutoMergeUnavailable",
+      "startLine": 159,
+      "crap": 6
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/single-story-close/phases/auto-merge.js",
+      "method": "directMergeFallback",
+      "startLine": 186,
+      "crap": 3
+    },
+    {
       "path": ".agents/scripts/lib/orchestration/single-story-close/phases/auto-merge.js",
       "method": "enableAutoMergeWith",
-      "startLine": 30,
-      "crap": 2
+      "startLine": 220,
+      "crap": 4
     },
     {
       "path": ".agents/scripts/lib/orchestration/single-story-close/phases/auto-merge.js",
       "method": "makeDefaultGhAutoMergeRunner",
-      "startLine": 64,
+      "startLine": 279,
       "crap": 1.0000939143501126
     },
     {
       "path": ".agents/scripts/lib/orchestration/single-story-close/phases/auto-merge.js",
       "method": "defaultGhAutoMergeRunner",
-      "startLine": 65,
+      "startLine": 280,
       "crap": 6.003887269193392
     },
     {
       "path": ".agents/scripts/lib/orchestration/single-story-close/phases/auto-merge.js",
       "method": "runAutoMergePhase",
-      "startLine": 124,
-      "crap": 4
+      "startLine": 344,
+      "crap": 8
     },
     {
       "path": ".agents/scripts/lib/orchestration/single-story-close/phases/base-sync.js",
       "method": "runBaseSyncPhase",
-      "startLine": 41,
+      "startLine": 45,
       "crap": 4.000201240142378
     },
     {
       "path": ".agents/scripts/lib/orchestration/single-story-close/phases/base-sync.js",
       "method": "<anon method-1>",
-      "startLine": 60,
+      "startLine": 64,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/orchestration/single-story-close/phases/base-sync.js",
       "method": "handleSyncFailure",
-      "startLine": 99,
-      "crap": 1.0000117392937642
+      "startLine": 103,
+      "crap": 1.000013497462477
     },
     {
       "path": ".agents/scripts/lib/orchestration/single-story-close/phases/base-sync.js",
       "method": "buildSyncFailureCommentBody",
-      "startLine": 151,
+      "startLine": 153,
       "crap": 5
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/single-story-close/phases/base-sync.js",
+      "method": "<anon method-2>",
+      "startLine": 165,
+      "crap": 1
     },
     {
       "path": ".agents/scripts/lib/orchestration/single-story-close/phases/close-validation.js",
       "method": "runCloseValidationPhase",
-      "startLine": 44,
-      "crap": 5
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/single-story-close/phases/close-validation.js",
-      "method": "<anon method-1>",
-      "startLine": 66,
-      "crap": 1
+      "startLine": 76,
+      "crap": 9.004884998982291
     },
     {
       "path": ".agents/scripts/lib/orchestration/single-story-close/phases/code-review.js",
@@ -8691,193 +15724,583 @@
       "path": ".agents/scripts/lib/orchestration/single-story-close/phases/code-review.js",
       "method": "invokeStoryReviewCore",
       "startLine": 75,
-      "crap": 2
+      "crap": 3
     },
     {
       "path": ".agents/scripts/lib/orchestration/single-story-close/phases/code-review.js",
       "method": "postStoryReviewCrossRef",
-      "startLine": 107,
+      "startLine": 103,
       "crap": 4.054
     },
     {
       "path": ".agents/scripts/lib/orchestration/single-story-close/phases/code-review.js",
       "method": "runStoryScopeReview",
-      "startLine": 185,
+      "startLine": 181,
       "crap": 2.0008141664970487
     },
     {
       "path": ".agents/scripts/lib/orchestration/single-story-close/phases/confirm-merge.js",
       "method": "defaultSleep",
-      "startLine": 52,
+      "startLine": 159,
       "crap": 2
     },
     {
       "path": ".agents/scripts/lib/orchestration/single-story-close/phases/confirm-merge.js",
-      "method": "resolveMergeWatchCadence",
-      "startLine": 63,
-      "crap": 5
+      "method": "<anon method-1>",
+      "startLine": 160,
+      "crap": 2
     },
     {
       "path": ".agents/scripts/lib/orchestration/single-story-close/phases/confirm-merge.js",
-      "method": "formatUnlandedFriction",
-      "startLine": 82,
+      "method": "withGhTimeout",
+      "startLine": 192,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/single-story-close/phases/confirm-merge.js",
+      "method": "<anon method-2>",
+      "startLine": 194,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/single-story-close/phases/confirm-merge.js",
+      "method": "<anon method-3>",
+      "startLine": 195,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/single-story-close/phases/confirm-merge.js",
+      "method": "<anon method-4>",
+      "startLine": 201,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/single-story-close/phases/confirm-merge.js",
+      "method": "<anon method-5>",
+      "startLine": 202,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/single-story-close/phases/confirm-merge.js",
+      "method": "readPrWaitProbe",
+      "startLine": 221,
+      "crap": 6
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/single-story-close/phases/confirm-merge.js",
+      "method": "resolveMergeWaitConfig",
+      "startLine": 288,
       "crap": 4
     },
     {
       "path": ".agents/scripts/lib/orchestration/single-story-close/phases/confirm-merge.js",
+      "method": "<anon method-6>",
+      "startLine": 290,
+      "crap": 3
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/single-story-close/phases/confirm-merge.js",
+      "method": "resolveBudgetAnchorMs",
+      "startLine": 341,
+      "crap": 4
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/single-story-close/phases/confirm-merge.js",
+      "method": "formatUnlandedFriction",
+      "startLine": 351,
+      "crap": 5
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/single-story-close/phases/confirm-merge.js",
+      "method": "formatFlipFailedFriction",
+      "startLine": 388,
+      "crap": 4
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/single-story-close/phases/confirm-merge.js",
+      "method": "postFriction",
+      "startLine": 423,
+      "crap": 2.1481481481481484
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/single-story-close/phases/confirm-merge.js",
+      "method": "blockOnFlipFailed",
+      "startLine": 448,
+      "crap": 3.0286230409118664
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/single-story-close/phases/confirm-merge.js",
       "method": "blockOnUnlanded",
-      "startLine": 115,
-      "crap": 3.002776242275877
+      "startLine": 523,
+      "crap": 4.071658808526337
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/single-story-close/phases/confirm-merge.js",
+      "method": "maybeUpdateBehindPr",
+      "startLine": 622,
+      "crap": 3
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/single-story-close/phases/confirm-merge.js",
+      "method": "onMergeObserved",
+      "startLine": 663,
+      "crap": 3
     },
     {
       "path": ".agents/scripts/lib/orchestration/single-story-close/phases/confirm-merge.js",
       "method": "runConfirmMergePhase",
-      "startLine": 217,
-      "crap": 6
+      "startLine": 780,
+      "crap": 14
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/single-story-close/phases/normalize-pr-title.js",
+      "method": "isConventionalSubject",
+      "startLine": 102,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/single-story-close/phases/normalize-pr-title.js",
+      "method": "parseConventionalType",
+      "startLine": 114,
+      "crap": 7.608000000000001
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/single-story-close/phases/normalize-pr-title.js",
+      "method": "pickDominantType",
+      "startLine": 128,
+      "crap": 4.518950437317785
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/single-story-close/phases/normalize-pr-title.js",
+      "method": "deriveTypeFromBranchCommits",
+      "startLine": 151,
+      "crap": 3.072
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/single-story-close/phases/normalize-pr-title.js",
+      "method": "<anon method-1>",
+      "startLine": 170,
+      "crap": 1.008
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/single-story-close/phases/normalize-pr-title.js",
+      "method": "normalizePrTitle",
+      "startLine": 203,
+      "crap": 6.004855105446821
     },
     {
       "path": ".agents/scripts/lib/orchestration/single-story-close/phases/options.js",
       "method": "resolveFlag",
-      "startLine": 25,
+      "startLine": 27,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/orchestration/single-story-close/phases/options.js",
       "method": "resolveWaitForMerge",
-      "startLine": 41,
-      "crap": 3
+      "startLine": 61,
+      "crap": 4.016
     },
     {
       "path": ".agents/scripts/lib/orchestration/single-story-close/phases/options.js",
       "method": "parseCloseOptions",
-      "startLine": 59,
+      "startLine": 93,
+      "crap": 5
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/single-story-close/phases/post-land.js",
+      "method": "postLandLockPath",
+      "startLine": 60,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/single-story-close/phases/post-land.js",
+      "method": "step",
+      "startLine": 74,
       "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/single-story-close/phases/post-land.js",
+      "method": "stepFollowUps",
+      "startLine": 101,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/single-story-close/phases/post-land.js",
+      "method": "stepStatusResync",
+      "startLine": 130,
+      "crap": 3.0052083333333335
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/single-story-close/phases/post-land.js",
+      "method": "<anon method-1>",
+      "startLine": 142,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/single-story-close/phases/post-land.js",
+      "method": "<anon method-2>",
+      "startLine": 143,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/single-story-close/phases/post-land.js",
+      "method": "stepRefCleanup",
+      "startLine": 163,
+      "crap": 3.010497157019974
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/single-story-close/phases/post-land.js",
+      "method": "stepBaseFastForward",
+      "startLine": 193,
+      "crap": 4.003561788685755
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/single-story-close/phases/post-land.js",
+      "method": "<anon method-3>",
+      "startLine": 210,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/single-story-close/phases/post-land.js",
+      "method": "<anon method-4>",
+      "startLine": 211,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/single-story-close/phases/post-land.js",
+      "method": "runPostLandTail",
+      "startLine": 267,
+      "crap": 4
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/single-story-close/phases/post-land.js",
+      "method": "<anon method-5>",
+      "startLine": 313,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/single-story-close/phases/post-land.js",
+      "method": "<anon method-6>",
+      "startLine": 325,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/single-story-close/phases/post-land.js",
+      "method": "<anon method-7>",
+      "startLine": 358,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/single-story-close/phases/post-land.js",
+      "method": "<anon method-8>",
+      "startLine": 362,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/single-story-close/phases/post-land.js",
+      "method": "<anon method-9>",
+      "startLine": 389,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/single-story-close/phases/post-land.js",
+      "method": "<anon method-10>",
+      "startLine": 390,
+      "crap": 1
     },
     {
       "path": ".agents/scripts/lib/orchestration/single-story-close/phases/pull-request.js",
       "method": "ensurePullRequestWith",
-      "startLine": 38,
-      "crap": 5
+      "startLine": 39,
+      "crap": 4
     },
     {
       "path": ".agents/scripts/lib/orchestration/single-story-close/phases/push.js",
       "method": "pushStoryBranch",
-      "startLine": 27,
+      "startLine": 37,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/orchestration/single-story-close/phases/review-block.js",
       "method": "handleCriticalReviewBlock",
-      "startLine": 9,
-      "crap": 1.001953125
+      "startLine": 12,
+      "crap": 1.0017808943428779
     },
     {
       "path": ".agents/scripts/lib/orchestration/single-story-close/phases/worktree-reap.js",
       "method": "reapWorktreePhase",
-      "startLine": 31,
-      "crap": 4.048322789188373
+      "startLine": 42,
+      "crap": 4.012584433318161
     },
     {
       "path": ".agents/scripts/lib/orchestration/single-story-close/phases/worktree-reap.js",
       "method": "<anon method-1>",
-      "startLine": 47,
-      "crap": 2
+      "startLine": 58,
+      "crap": 1
     },
     {
       "path": ".agents/scripts/lib/orchestration/single-story-close/phases/worktree-reap.js",
       "method": "<anon method-2>",
-      "startLine": 48,
-      "crap": 2
+      "startLine": 59,
+      "crap": 1
     },
     {
       "path": ".agents/scripts/lib/orchestration/single-story-close/phases/worktree-reap.js",
       "method": "<anon method-3>",
-      "startLine": 49,
-      "crap": 2
+      "startLine": 60,
+      "crap": 1
     },
     {
       "path": ".agents/scripts/lib/orchestration/single-story-close/phases/worktree-reap.js",
       "method": "<anon method-4>",
-      "startLine": 66,
+      "startLine": 99,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/orchestration/single-story-close/phases/wrong-tree-guard.js",
       "method": "parsePorcelainStatus",
-      "startLine": 45,
+      "startLine": 63,
       "crap": 3
     },
     {
       "path": ".agents/scripts/lib/orchestration/single-story-close/phases/wrong-tree-guard.js",
+      "method": "<anon method-1>",
+      "startLine": 65,
+      "crap": 3
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/single-story-close/phases/wrong-tree-guard.js",
+      "method": "<anon method-2>",
+      "startLine": 69,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/single-story-close/phases/wrong-tree-guard.js",
+      "method": "<anon method-3>",
+      "startLine": 70,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/single-story-close/phases/wrong-tree-guard.js",
+      "method": "<anon method-4>",
+      "startLine": 71,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/single-story-close/phases/wrong-tree-guard.js",
       "method": "collectStrayTrackedPaths",
-      "startLine": 79,
+      "startLine": 104,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/single-story-close/phases/wrong-tree-guard.js",
+      "method": "<anon method-5>",
+      "startLine": 106,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/single-story-close/phases/wrong-tree-guard.js",
+      "method": "<anon method-6>",
+      "startLine": 107,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/single-story-close/phases/wrong-tree-guard.js",
+      "method": "parseDiffNameOnly",
+      "startLine": 118,
+      "crap": 3
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/single-story-close/phases/wrong-tree-guard.js",
+      "method": "<anon method-7>",
+      "startLine": 122,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/orchestration/single-story-close/phases/wrong-tree-guard.js",
       "method": "guardApplies",
-      "startLine": 98,
+      "startLine": 137,
       "crap": 2
     },
     {
       "path": ".agents/scripts/lib/orchestration/single-story-close/phases/wrong-tree-guard.js",
-      "method": "formatWrongTreeFinding",
-      "startLine": 109,
+      "method": "collectStoryDiffPaths",
+      "startLine": 155,
+      "crap": 7.005687671391883
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/single-story-close/phases/wrong-tree-guard.js",
+      "method": "intersectPaths",
+      "startLine": 206,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/orchestration/single-story-close/phases/wrong-tree-guard.js",
+      "method": "<anon method-8>",
+      "startLine": 208,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/single-story-close/phases/wrong-tree-guard.js",
+      "method": "formatWrongTreeFinding",
+      "startLine": 218,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/single-story-close/phases/wrong-tree-guard.js",
+      "method": "<anon method-9>",
+      "startLine": 219,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/single-story-close/phases/wrong-tree-guard.js",
+      "method": "formatWrongTreeDowngradeFinding",
+      "startLine": 248,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/single-story-close/phases/wrong-tree-guard.js",
+      "method": "<anon method-10>",
+      "startLine": 253,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/single-story-close/phases/wrong-tree-guard.js",
+      "method": "abortWrongTree",
+      "startLine": 282,
+      "crap": 1.0041958980900272
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/single-story-close/phases/wrong-tree-guard.js",
+      "method": "reportDisjointDirt",
+      "startLine": 327,
+      "crap": 1.008
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/single-story-close/phases/wrong-tree-guard.js",
+      "method": "probeMainCheckoutStray",
+      "startLine": 363,
+      "crap": 4
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/single-story-close/phases/wrong-tree-guard.js",
       "method": "runWrongTreeGuardPhase",
-      "startLine": 152,
-      "crap": 6.011104969103508
+      "startLine": 412,
+      "crap": 7.001405664306539
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/single-story-close/runner.js",
+      "method": "emitTerminal",
+      "startLine": 56,
+      "crap": 2
     },
     {
       "path": ".agents/scripts/lib/orchestration/single-story-close/runner.js",
       "method": "alreadyClosedResult",
-      "startLine": 28,
-      "crap": 1
+      "startLine": 92,
+      "crap": 2
     },
     {
       "path": ".agents/scripts/lib/orchestration/single-story-close/runner.js",
       "method": "resolveWorktreePath",
-      "startLine": 40,
+      "startLine": 136,
       "crap": 2
     },
     {
       "path": ".agents/scripts/lib/orchestration/single-story-close/runner.js",
       "method": "runPrePushPhases",
-      "startLine": 46,
+      "startLine": 142,
       "crap": 3
     },
     {
       "path": ".agents/scripts/lib/orchestration/single-story-close/runner.js",
       "method": "openAndReviewPr",
-      "startLine": 99,
+      "startLine": 199,
       "crap": 2
     },
     {
       "path": ".agents/scripts/lib/orchestration/single-story-close/runner.js",
       "method": "releaseLease",
-      "startLine": 147,
+      "startLine": 251,
       "crap": 2
     },
     {
       "path": ".agents/scripts/lib/orchestration/single-story-close/runner.js",
       "method": "releaseLeaseOnBlock",
-      "startLine": 198,
+      "startLine": 306,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/orchestration/single-story-close/runner.js",
       "method": "closeResult",
-      "startLine": 207,
+      "startLine": 315,
       "crap": 3
     },
     {
       "path": ".agents/scripts/lib/orchestration/single-story-close/runner.js",
       "method": "runSingleStoryClose",
-      "startLine": 242,
-      "crap": 7.663433882913989
+      "startLine": 361,
+      "crap": 5.006103515625
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/single-story-close/runner.js",
+      "method": "<anon method-1>",
+      "startLine": 402,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/single-story-close/runner.js",
+      "method": "runClosePipeline",
+      "startLine": 431,
+      "crap": 15.100364399607761
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/single-story-close/runner.js",
+      "method": "<anon method-2>",
+      "startLine": 481,
+      "crap": 1.0215303083306095
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/single-story-close/runner.js",
+      "method": "<anon method-3>",
+      "startLine": 497,
+      "crap": 1.0215303083306095
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/single-story-lease-guard.js",
+      "method": "resolveOperator",
+      "startLine": 64,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/single-story-lease-guard.js",
+      "method": "acquireStoryLease",
+      "startLine": 96,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/single-story-lease-guard.js",
+      "method": "<anon method-1>",
+      "startLine": 117,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/single-story-lease-guard.js",
+      "method": "releaseStoryLease",
+      "startLine": 138,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/spec-budget.js",
+      "method": "resolveSpecText",
+      "startLine": 31,
+      "crap": 7.095703125
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/spec-budget.js",
+      "method": "computeSpecBudgetFindings",
+      "startLine": 58,
+      "crap": 2
     },
     {
       "path": ".agents/scripts/lib/orchestration/spec-freshness.js",
@@ -8910,16 +16333,16 @@
       "crap": 1
     },
     {
+      "path": ".agents/scripts/lib/orchestration/spec-section-validator.js",
+      "method": "<anon method-2>",
+      "startLine": 114,
+      "crap": 1
+    },
+    {
       "path": ".agents/scripts/lib/orchestration/spec-spill.js",
       "method": "assertSpecWithinBudget",
       "startLine": 40,
       "crap": 5
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/spec-spill.js",
-      "method": "spillSpecIfOverBudget",
-      "startLine": 72,
-      "crap": 1
     },
     {
       "path": ".agents/scripts/lib/orchestration/split-policy-validator.js",
@@ -8941,6 +16364,12 @@
     },
     {
       "path": ".agents/scripts/lib/orchestration/split-policy-validator.js",
+      "method": "<anon method-1>",
+      "startLine": 90,
+      "crap": 4
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/split-policy-validator.js",
       "method": "formatViolation",
       "startLine": 158,
       "crap": 4.25
@@ -8952,172 +16381,430 @@
       "crap": 2
     },
     {
+      "path": ".agents/scripts/lib/orchestration/split-policy-validator.js",
+      "method": "<anon method-2>",
+      "startLine": 185,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/story-body-gate.js",
+      "method": "parseStoryBodyOrThrow",
+      "startLine": 32,
+      "crap": 3
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/story-body-gate.js",
+      "method": "assertStoryBodiesParse",
+      "startLine": 65,
+      "crap": 3
+    },
+    {
       "path": ".agents/scripts/lib/orchestration/story-close/emit-blocked.js",
       "method": "emitStoryBlockedSafe",
-      "startLine": 14,
+      "startLine": 15,
       "crap": 2.116522530723714
     },
     {
       "path": ".agents/scripts/lib/orchestration/story-close/emit-blocked.js",
       "method": "emitBlockedCloseResult",
-      "startLine": 32,
+      "startLine": 33,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/orchestration/story-close/format-autofix.js",
-      "method": "runFormatAutofix",
-      "startLine": 84,
-      "crap": 8
+      "method": "listDirtyPaths",
+      "startLine": 66,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/story-close/format-autofix.js",
+      "method": "<anon method-1>",
+      "startLine": 74,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/story-close/format-autofix.js",
+      "method": "<anon method-2>",
+      "startLine": 75,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/story-close/format-autofix.js",
+      "method": "resolveFormatterCmd",
+      "startLine": 94,
+      "crap": 3
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/story-close/format-autofix.js",
+      "method": "currentBranch",
+      "startLine": 119,
+      "crap": 3.0262390670553936
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/story-close/format-autofix.js",
+      "method": "commitDirtyPaths",
+      "startLine": 146,
+      "crap": 1
     },
     {
       "path": ".agents/scripts/lib/orchestration/story-close/format-autofix.js",
       "method": "resolveFormatTimeoutMs",
-      "startLine": 195,
+      "startLine": 167,
       "crap": 7.124248685199098
     },
     {
-      "path": ".agents/scripts/lib/orchestration/story-close/phases/code-review.js",
-      "method": "enumerateChangedFiles",
-      "startLine": 64,
-      "crap": 4
+      "path": ".agents/scripts/lib/orchestration/story-close/format-autofix.js",
+      "method": "runFormatAutofix",
+      "startLine": 230,
+      "crap": 8
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/story-close/format-autofix.js",
+      "method": "<anon method-3>",
+      "startLine": 241,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/story-close/format-autofix.js",
+      "method": "listChangedFiles",
+      "startLine": 342,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/story-close/format-autofix.js",
+      "method": "<anon method-4>",
+      "startLine": 344,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/story-close/format-autofix.js",
+      "method": "runScopedFormatAutofix",
+      "startLine": 419,
+      "crap": 9.004884998982291
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/story-close/format-autofix.js",
+      "method": "<anon method-5>",
+      "startLine": 441,
+      "crap": 1.000060308629411
     },
     {
       "path": ".agents/scripts/lib/orchestration/story-close/phases/code-review.js",
-      "method": "runLocalLensReview",
-      "startLine": 118,
-      "crap": 2
+      "method": "resolveSeverity",
+      "startLine": 52,
+      "crap": 1.125
     },
     {
       "path": ".agents/scripts/lib/orchestration/story-close/phases/code-review.js",
       "method": "buildCodeReviewBlockedExtra",
-      "startLine": 175,
-      "crap": 1.018962962962963
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/story-close/phases/code-review.js",
-      "method": "runStoryReviewCore",
-      "startLine": 234,
-      "crap": 3.0006119899021666
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/story-close/phases/code-review.js",
-      "method": "<anon method-2>",
-      "startLine": 254,
+      "startLine": 69,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/orchestration/story-close/phases/code-review.js",
-      "method": "<anon method-3>",
-      "startLine": 255,
+      "method": "formatReviewSummary",
+      "startLine": 86,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/story-close/phases/code-review.js",
+      "method": "invokeReviewCore",
+      "startLine": 101,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/story-close/phases/code-review.js",
+      "method": "emitCriticalBlock",
+      "startLine": 124,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/orchestration/story-close/phases/code-review.js",
       "method": "runStoryCodeReview",
-      "startLine": 316,
+      "startLine": 167,
+      "crap": 3
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/story-close/phases/local-lens-review.js",
+      "method": "renderLensArtifactRoster",
+      "startLine": 62,
+      "crap": 2.2560000000000002
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/story-close/phases/local-lens-review.js",
+      "method": "<anon method-1>",
+      "startLine": 64,
+      "crap": 1.064
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/story-close/phases/local-lens-review.js",
+      "method": "<anon method-2>",
+      "startLine": 65,
+      "crap": 2.2560000000000002
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/story-close/phases/local-lens-review.js",
+      "method": "<anon method-3>",
+      "startLine": 69,
+      "crap": 1.064
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/story-close/phases/local-lens-review.js",
+      "method": "buildLensSubstitutions",
+      "startLine": 84,
+      "crap": 3
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/story-close/phases/local-lens-review.js",
+      "method": "enumerateChangedFiles",
+      "startLine": 115,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/story-close/phases/local-lens-review.js",
+      "method": "resolveLensChangeSet",
+      "startLine": 151,
       "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/story-close/phases/local-lens-review.js",
+      "method": "runLocalLensReview",
+      "startLine": 225,
+      "crap": 6.000170903754483
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/story-close/phases/local-lens-review.js",
+      "method": "<anon method-4>",
+      "startLine": 309,
+      "crap": 1.0000047473265135
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/story-close/phases/local-lens-review.js",
+      "method": "<anon method-5>",
+      "startLine": 310,
+      "crap": 2.000018989306054
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/story-close/phases/local-lens-review.js",
+      "method": "safeResolveConfig",
+      "startLine": 353,
+      "crap": 1.0233236151603498
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/story-deliver-terminal.js",
+      "method": "quoteForPlan",
+      "startLine": 97,
+      "crap": 3
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/story-deliver-terminal.js",
+      "method": "<anon method-1>",
+      "startLine": 121,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/story-deliver-terminal.js",
+      "method": "<anon method-2>",
+      "startLine": 124,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/story-deliver-terminal.js",
+      "method": "<anon method-3>",
+      "startLine": 127,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/story-deliver-terminal.js",
+      "method": "<anon method-4>",
+      "startLine": 130,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/story-deliver-terminal.js",
+      "method": "<anon method-5>",
+      "startLine": 133,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/story-deliver-terminal.js",
+      "method": "<anon method-6>",
+      "startLine": 136,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/story-deliver-terminal.js",
+      "method": "<anon method-7>",
+      "startLine": 139,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/story-deliver-terminal.js",
+      "method": "<anon method-8>",
+      "startLine": 152,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/story-deliver-terminal.js",
+      "method": "getValidator",
+      "startLine": 163,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/story-deliver-terminal.js",
+      "method": "validateTerminalEnvelope",
+      "startLine": 178,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/story-deliver-terminal.js",
+      "method": "<anon method-9>",
+      "startLine": 183,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/story-deliver-terminal.js",
+      "method": "compact",
+      "startLine": 196,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/story-deliver-terminal.js",
+      "method": "buildTerminalEnvelope",
+      "startLine": 232,
+      "crap": 5
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/story-deliver-terminal.js",
+      "method": "<anon method-10>",
+      "startLine": 275,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/story-deliver-terminal.js",
+      "method": "buildEscalationTerminal",
+      "startLine": 308,
+      "crap": 5
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/story-deliver-terminal.js",
+      "method": "<anon method-11>",
+      "startLine": 323,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/story-deliver-terminal.js",
+      "method": "exitCodeForTerminal",
+      "startLine": 350,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/story-deliver-terminal.js",
+      "method": "emitTerminalEnvelope",
+      "startLine": 378,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/story-deliver-terminal.js",
+      "method": "terminalFromWaitOutcome",
+      "startLine": 398,
+      "crap": 5
     },
     {
       "path": ".agents/scripts/lib/orchestration/story-follow-ups.js",
       "method": "resolveFollowUpRepos",
-      "startLine": 25,
+      "startLine": 29,
       "crap": 9
     },
     {
       "path": ".agents/scripts/lib/orchestration/story-follow-ups.js",
       "method": "gatherStoryFrictionSignals",
-      "startLine": 53,
-      "crap": 1.863837598531476
+      "startLine": 71,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/story-follow-ups.js",
+      "method": "<anon method-1>",
+      "startLine": 76,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/story-follow-ups.js",
+      "method": "gatherRunFrictionSignals",
+      "startLine": 101,
+      "crap": 3
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/story-follow-ups.js",
+      "method": "renderEmptyRollupLines",
+      "startLine": 138,
+      "crap": 2
     },
     {
       "path": ".agents/scripts/lib/orchestration/story-follow-ups.js",
       "method": "buildFollowUpsCommentBody",
-      "startLine": 83,
-      "crap": 14.218480996665146
+      "startLine": 164,
+      "crap": 18.264607304014742
     },
     {
       "path": ".agents/scripts/lib/orchestration/story-follow-ups.js",
-      "method": "captureFollowUpsAfterConfirm",
-      "startLine": 167,
-      "crap": 3.6875
+      "method": "<anon method-2>",
+      "startLine": 222,
+      "crap": 1.014509365795621
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/story-follow-ups.js",
+      "method": "<anon method-3>",
+      "startLine": 223,
+      "crap": 1.014509365795621
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/story-follow-ups.js",
+      "method": "<anon method-4>",
+      "startLine": 224,
+      "crap": 1.014509365795621
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/story-follow-ups.js",
+      "method": "<anon method-5>",
+      "startLine": 225,
+      "crap": 1.014509365795621
     },
     {
       "path": ".agents/scripts/lib/orchestration/story-follow-ups.js",
       "method": "captureStoryFollowUps",
-      "startLine": 172,
-      "crap": 11.59707613323316
+      "startLine": 269,
+      "crap": 3.001679300291545
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/story-follow-ups.js",
+      "method": "<anon method-6>",
+      "startLine": 300,
+      "crap": 1.0001865889212829
     },
     {
       "path": ".agents/scripts/lib/orchestration/story-init-remote.js",
       "method": "handleRemoteVerificationFailure",
-      "startLine": 10,
-      "crap": 3.0839772561597902
+      "startLine": 13,
+      "crap": 3.077681687149143
     },
     {
       "path": ".agents/scripts/lib/orchestration/story-plan-state.js",
       "method": "readStoryPlanState",
-      "startLine": 8,
+      "startLine": 21,
       "crap": 3
     },
     {
-      "path": ".agents/scripts/lib/orchestration/story-plan-state.js",
-      "method": "readStoryPlanningRisk",
-      "startLine": 22,
-      "crap": 1
+      "path": ".agents/scripts/lib/orchestration/story-reachability.js",
+      "method": "computeStoryReachability",
+      "startLine": 29,
+      "crap": 6
     },
     {
-      "path": ".agents/scripts/lib/orchestration/story-plan-state.js",
-      "method": "readStoryPlanningRiskSafe",
-      "startLine": 27,
-      "crap": 1
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/story-plan-state.js",
-      "method": "resolveStoryPlanningRisk",
+      "path": ".agents/scripts/lib/orchestration/story-reachability.js",
+      "method": "<anon method-1>",
       "startLine": 40,
-      "crap": 2
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/story-progress/story-run-progress-writer.js",
-      "method": "defaultStoryPhases",
-      "startLine": 98,
       "crap": 1
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/story-progress/story-run-progress-writer.js",
-      "method": "normalizeStoryPhase",
-      "startLine": 115,
-      "crap": 7.025088
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/story-progress/story-run-progress-writer.js",
-      "method": "normalizeTask",
-      "startLine": 149,
-      "crap": 8.042081038875647
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/story-progress/story-run-progress-writer.js",
-      "method": "renderStoryRunProgressBody",
-      "startLine": 194,
-      "crap": 8
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/story-progress/story-run-progress-writer.js",
-      "method": "renderTasksBody",
-      "startLine": 247,
-      "crap": 2
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/story-progress/story-run-progress-writer.js",
-      "method": "renderPhasesBody",
-      "startLine": 303,
-      "crap": 2
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/story-progress/story-run-progress-writer.js",
-      "method": "upsertStoryRunProgress",
-      "startLine": 372,
-      "crap": 5
     },
     {
       "path": ".agents/scripts/lib/orchestration/structured-comment-parser.js",
@@ -9133,422 +16820,698 @@
     },
     {
       "path": ".agents/scripts/lib/orchestration/task-body-validator.js",
-      "method": "bulletNamesPath",
-      "startLine": 79,
-      "crap": 3
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/task-body-validator.js",
-      "method": "vagueVerbWithoutTarget",
-      "startLine": 91,
-      "crap": 3
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/task-body-validator.js",
       "method": "shouldSkipTicket",
-      "startLine": 122,
+      "startLine": 101,
       "crap": 6
     },
     {
       "path": ".agents/scripts/lib/orchestration/task-body-validator.js",
-      "method": "validateTaskBodyShape",
-      "startLine": 146,
+      "method": "resolveStructuredBody",
+      "startLine": 124,
+      "crap": 3.628332994097293
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/task-body-validator.js",
+      "method": "resolveContractFieldsFromTopLevel",
+      "startLine": 163,
       "crap": 5
     },
     {
       "path": ".agents/scripts/lib/orchestration/task-body-validator.js",
+      "method": "validateTaskBodyShape",
+      "startLine": 191,
+      "crap": 6.031098153547133
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/task-body-validator.js",
       "method": "isObjectPathEntry",
-      "startLine": 179,
+      "startLine": 223,
       "crap": 6
     },
     {
       "path": ".agents/scripts/lib/orchestration/task-body-validator.js",
       "method": "isMalformedObjectPathEntry",
-      "startLine": 195,
+      "startLine": 239,
       "crap": 4
     },
     {
       "path": ".agents/scripts/lib/orchestration/task-body-validator.js",
       "method": "collectChangesErrors",
-      "startLine": 208,
+      "startLine": 252,
       "crap": 7
     },
     {
       "path": ".agents/scripts/lib/orchestration/task-body-validator.js",
       "method": "<anon method-1>",
-      "startLine": 216,
-      "crap": 2
+      "startLine": 258,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/task-body-validator.js",
+      "method": "<anon method-2>",
+      "startLine": 259,
+      "crap": 1
     },
     {
       "path": ".agents/scripts/lib/orchestration/task-body-validator.js",
       "method": "collectReferencesErrors",
-      "startLine": 249,
+      "startLine": 290,
       "crap": 5
     },
     {
       "path": ".agents/scripts/lib/orchestration/task-body-validator.js",
       "method": "collectAcceptanceErrors",
-      "startLine": 273,
+      "startLine": 314,
       "crap": 3
     },
     {
       "path": ".agents/scripts/lib/orchestration/task-body-validator.js",
       "method": "collectVerifyErrors",
-      "startLine": 296,
+      "startLine": 338,
       "crap": 8
     },
     {
       "path": ".agents/scripts/lib/orchestration/task-body-validator.js",
       "method": "collectTaskBodyErrors",
-      "startLine": 335,
+      "startLine": 377,
       "crap": 2
     },
     {
       "path": ".agents/scripts/lib/orchestration/task-body-validator.js",
       "method": "validateTaskBodies",
-      "startLine": 351,
+      "startLine": 393,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/task-body-validator.js",
+      "method": "<anon method-3>",
+      "startLine": 397,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/ticket-lease.js",
+      "method": "normalizeOperatorHandle",
+      "startLine": 88,
+      "crap": 4
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/ticket-lease.js",
+      "method": "isClaimLive",
+      "startLine": 119,
+      "crap": 3
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/ticket-lease.js",
+      "method": "currentOwner",
+      "startLine": 134,
+      "crap": 3
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/ticket-lease.js",
+      "method": "normaliseOpts",
+      "startLine": 146,
+      "crap": 9
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/ticket-lease.js",
+      "method": "describeLease",
+      "startLine": 185,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/ticket-lease.js",
+      "method": "acquireLease",
+      "startLine": 241,
+      "crap": 7
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/ticket-lease.js",
+      "method": "claimAndVerify",
+      "startLine": 319,
+      "crap": 3
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/ticket-lease.js",
+      "method": "<anon method-1>",
+      "startLine": 330,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/ticket-lease.js",
+      "method": "<anon method-2>",
+      "startLine": 341,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/ticket-lease.js",
+      "method": "releaseLease",
+      "startLine": 371,
       "crap": 2
     },
     {
       "path": ".agents/scripts/lib/orchestration/ticket-validator-conflicts.js",
+      "method": "normalizeStoryBody",
+      "startLine": 33,
+      "crap": 3.0416666666666665
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/ticket-validator-conflicts.js",
       "method": "matchRegistryPattern",
-      "startLine": 72,
+      "startLine": 118,
       "crap": 3
     },
     {
       "path": ".agents/scripts/lib/orchestration/ticket-validator-conflicts.js",
       "method": "isRegistryPath",
-      "startLine": 80,
+      "startLine": 126,
       "crap": 2
     },
     {
       "path": ".agents/scripts/lib/orchestration/ticket-validator-conflicts.js",
       "method": "parentDirOf",
-      "startLine": 85,
+      "startLine": 131,
       "crap": 2
     },
     {
       "path": ".agents/scripts/lib/orchestration/ticket-validator-conflicts.js",
-      "method": "extractChangeBulletPath",
-      "startLine": 98,
-      "crap": 4
+      "method": "collectStoryProducerPaths",
+      "startLine": 157,
+      "crap": 3
     },
     {
       "path": ".agents/scripts/lib/orchestration/ticket-validator-conflicts.js",
       "method": "storySlugOf",
-      "startLine": 112,
+      "startLine": 174,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/orchestration/ticket-validator-conflicts.js",
       "method": "indexProducers",
-      "startLine": 125,
-      "crap": 7
+      "startLine": 188,
+      "crap": 2
     },
     {
       "path": ".agents/scripts/lib/orchestration/ticket-validator-conflicts.js",
       "method": "indexConsumers",
-      "startLine": 157,
+      "startLine": 212,
       "crap": 8
     },
     {
       "path": ".agents/scripts/lib/orchestration/ticket-validator-conflicts.js",
-      "method": "computeStoryReachability",
-      "startLine": 194,
-      "crap": 6
+      "method": "<anon method-1>",
+      "startLine": 216,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/ticket-validator-conflicts.js",
+      "method": "<anon method-2>",
+      "startLine": 224,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/ticket-validator-conflicts.js",
+      "method": "<anon method-3>",
+      "startLine": 228,
+      "crap": 1
     },
     {
       "path": ".agents/scripts/lib/orchestration/ticket-validator-conflicts.js",
       "method": "inSameWave",
-      "startLine": 214,
+      "startLine": 241,
       "crap": 4
     },
     {
       "path": ".agents/scripts/lib/orchestration/ticket-validator-conflicts.js",
       "method": "computeSharedEditorFindings",
-      "startLine": 229,
+      "startLine": 256,
       "crap": 6
     },
     {
       "path": ".agents/scripts/lib/orchestration/ticket-validator-conflicts.js",
+      "method": "<anon method-4>",
+      "startLine": 259,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/ticket-validator-conflicts.js",
       "method": "computeImplicitDepFindings",
-      "startLine": 264,
+      "startLine": 291,
       "crap": 3
     },
     {
       "path": ".agents/scripts/lib/orchestration/ticket-validator-conflicts.js",
-      "method": "indexAssumptionEntries",
+      "method": "<anon method-5>",
       "startLine": 298,
-      "crap": 8
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/ticket-validator-conflicts.js",
-      "method": "computeRegistryFindings",
-      "startLine": 338,
-      "crap": 16.16121282798834
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/ticket-validator-conflicts.js",
-      "method": "bump",
-      "startLine": 349,
       "crap": 2
     },
     {
       "path": ".agents/scripts/lib/orchestration/ticket-validator-conflicts.js",
+      "method": "indexAssumptionEntries",
+      "startLine": 325,
+      "crap": 8
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/ticket-validator-conflicts.js",
+      "method": "computeMissingBddScaffoldFindings",
+      "startLine": 376,
+      "crap": 19
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/ticket-validator-conflicts.js",
+      "method": "<anon method-6>",
+      "startLine": 403,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/ticket-validator-conflicts.js",
+      "method": "<anon method-7>",
+      "startLine": 412,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/ticket-validator-conflicts.js",
+      "method": "computeRegistryFindings",
+      "startLine": 453,
+      "crap": 58.14679107874375
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/ticket-validator-conflicts.js",
+      "method": "bump",
+      "startLine": 464,
+      "crap": 4.916
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/ticket-validator-conflicts.js",
       "method": "registryRegistry",
-      "startLine": 452,
-      "crap": 8.215784143518519
+      "startLine": 566,
+      "crap": 7.226851851851852
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/ticket-validator-conflicts.js",
+      "method": "normalizeFanOutProbe",
+      "startLine": 600,
+      "crap": 6.216378662659654
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/ticket-validator-conflicts.js",
+      "method": "indexCreatedBasenames",
+      "startLine": 616,
+      "crap": 3
     },
     {
       "path": ".agents/scripts/lib/orchestration/ticket-validator-conflicts.js",
       "method": "computeFanOutFindings",
-      "startLine": 492,
-      "crap": 7
+      "startLine": 646,
+      "crap": 9
     },
     {
       "path": ".agents/scripts/lib/orchestration/ticket-validator-conflicts.js",
       "method": "computeConflictFindings",
-      "startLine": 541,
-      "crap": 7
+      "startLine": 703,
+      "crap": 8
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/ticket-validator-conflicts.js",
+      "method": "renderFanOutEvidence",
+      "startLine": 768,
+      "crap": 5
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/ticket-validator-conflicts.js",
+      "method": "renderFanOutRemedy",
+      "startLine": 791,
+      "crap": 3
     },
     {
       "path": ".agents/scripts/lib/orchestration/ticket-validator-conflicts.js",
       "method": "renderHardConflictError",
-      "startLine": 588,
-      "crap": 5.137390596376959
+      "startLine": 810,
+      "crap": 9.21362962962963
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/ticket-validator-conflicts.js",
+      "method": "<anon method-8>",
+      "startLine": 812,
+      "crap": 1.018962962962963
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/ticket-validator-conflicts.js",
+      "method": "<anon method-9>",
+      "startLine": 819,
+      "crap": 1.018962962962963
     },
     {
       "path": ".agents/scripts/lib/orchestration/ticket-validator-sizing.js",
       "method": "resolveStoryBody",
-      "startLine": 48,
+      "startLine": 42,
       "crap": 5.091033227127902
     },
     {
       "path": ".agents/scripts/lib/orchestration/ticket-validator-sizing.js",
       "method": "resolveAcceptance",
-      "startLine": 70,
+      "startLine": 64,
       "crap": 3
     },
     {
       "path": ".agents/scripts/lib/orchestration/ticket-validator-sizing.js",
       "method": "resolveVerify",
-      "startLine": 83,
+      "startLine": 77,
       "crap": 3
     },
     {
       "path": ".agents/scripts/lib/orchestration/ticket-validator-sizing.js",
       "method": "resolveDependsOn",
-      "startLine": 95,
+      "startLine": 89,
       "crap": 3
     },
     {
       "path": ".agents/scripts/lib/orchestration/ticket-validator-sizing.js",
+      "method": "<anon method-1>",
+      "startLine": 94,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/ticket-validator-sizing.js",
       "method": "resolveCapacityCeilings",
-      "startLine": 140,
-      "crap": 4
+      "startLine": 126,
+      "crap": 1
     },
     {
       "path": ".agents/scripts/lib/orchestration/ticket-validator-sizing.js",
       "method": "makeUnanchoredConstant",
-      "startLine": 202,
+      "startLine": 176,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/orchestration/ticket-validator-sizing.js",
       "method": "computeUnanchoredConstantFindings",
-      "startLine": 212,
+      "startLine": 186,
       "crap": 3
     },
     {
       "path": ".agents/scripts/lib/orchestration/ticket-validator-sizing.js",
+      "method": "<anon method-2>",
+      "startLine": 192,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/ticket-validator-sizing.js",
       "method": "makeMissingReasonToExist",
-      "startLine": 228,
+      "startLine": 202,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/orchestration/ticket-validator-sizing.js",
       "method": "computeMissingReasonToExistFinding",
-      "startLine": 238,
+      "startLine": 212,
       "crap": 3
     },
     {
       "path": ".agents/scripts/lib/orchestration/ticket-validator-sizing.js",
       "method": "makeMergeCandidate",
-      "startLine": 245,
+      "startLine": 219,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/ticket-validator-sizing.js",
+      "method": "<anon method-3>",
+      "startLine": 220,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/orchestration/ticket-validator-sizing.js",
       "method": "isGlobBullet",
-      "startLine": 260,
+      "startLine": 234,
       "crap": 2
     },
     {
       "path": ".agents/scripts/lib/orchestration/ticket-validator-sizing.js",
       "method": "extractChangeBulletPath",
-      "startLine": 268,
-      "crap": 6
+      "startLine": 242,
+      "crap": 5.048828125
     },
     {
       "path": ".agents/scripts/lib/orchestration/ticket-validator-sizing.js",
       "method": "analyseChanges",
-      "startLine": 280,
-      "crap": 5
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/ticket-validator-sizing.js",
-      "method": "estimateStorySessionMass",
-      "startLine": 313,
+      "startLine": 254,
       "crap": 4
     },
     {
       "path": ".agents/scripts/lib/orchestration/ticket-validator-sizing.js",
+      "method": "estimateStorySessionMass",
+      "startLine": 288,
+      "crap": 4
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/ticket-validator-sizing.js",
+      "method": "<anon method-4>",
+      "startLine": 302,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/ticket-validator-sizing.js",
+      "method": "<anon method-5>",
+      "startLine": 303,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/ticket-validator-sizing.js",
+      "method": "<anon method-6>",
+      "startLine": 306,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/ticket-validator-sizing.js",
       "method": "makeOversized",
-      "startLine": 353,
+      "startLine": 320,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/orchestration/ticket-validator-sizing.js",
       "method": "makeSoftSessionPressure",
-      "startLine": 364,
+      "startLine": 331,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/orchestration/ticket-validator-sizing.js",
       "method": "isDeclaredWide",
-      "startLine": 379,
+      "startLine": 346,
       "crap": 4
     },
     {
       "path": ".agents/scripts/lib/orchestration/ticket-validator-sizing.js",
       "method": "computeMergeCandidateFinding",
-      "startLine": 388,
+      "startLine": 355,
       "crap": 4
     },
     {
       "path": ".agents/scripts/lib/orchestration/ticket-validator-sizing.js",
       "method": "computeStorySizingFindings",
-      "startLine": 399,
+      "startLine": 366,
       "crap": 7
     },
     {
       "path": ".agents/scripts/lib/orchestration/ticket-validator-sizing.js",
       "method": "computeSizingFindings",
-      "startLine": 456,
+      "startLine": 422,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/orchestration/ticket-validator-sizing.js",
       "method": "renderHardFindingError",
-      "startLine": 480,
+      "startLine": 438,
       "crap": 2.0185185185185186
     },
     {
       "path": ".agents/scripts/lib/orchestration/ticket-validator.js",
       "method": "collectPathsFromText",
-      "startLine": 31,
+      "startLine": 35,
       "crap": 4
     },
     {
       "path": ".agents/scripts/lib/orchestration/ticket-validator.js",
+      "method": "resolveAcceptanceLines",
+      "startLine": 64,
+      "crap": 7
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/ticket-validator.js",
       "method": "collectTaskPathReferences",
-      "startLine": 46,
+      "startLine": 82,
       "crap": 7
     },
     {
       "path": ".agents/scripts/lib/orchestration/ticket-validator.js",
       "method": "collectTaskChangesPaths",
-      "startLine": 94,
-      "crap": 17.205704491618075
+      "startLine": 130,
+      "crap": 17.001560534145458
     },
     {
       "path": ".agents/scripts/lib/orchestration/ticket-validator.js",
       "method": "defaultGitRunner",
-      "startLine": 159,
+      "startLine": 196,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/orchestration/ticket-validator.js",
       "method": "makeMemoizedGitRunner",
-      "startLine": 179,
+      "startLine": 216,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/orchestration/ticket-validator.js",
       "method": "memoizedGitRunner",
-      "startLine": 181,
+      "startLine": 218,
       "crap": 2
     },
     {
       "path": ".agents/scripts/lib/orchestration/ticket-validator.js",
       "method": "validateAcFreshness",
-      "startLine": 208,
+      "startLine": 245,
       "crap": 7
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/ticket-validator.js",
+      "method": "<anon method-1>",
+      "startLine": 256,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/ticket-validator.js",
+      "method": "<anon method-2>",
+      "startLine": 287,
+      "crap": 1
     },
     {
       "path": ".agents/scripts/lib/orchestration/ticket-validator.js",
       "method": "validateAcceptanceSubjectPrefix",
-      "startLine": 323,
-      "crap": 7
+      "startLine": 365,
+      "crap": 4
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/ticket-validator.js",
+      "method": "<anon method-3>",
+      "startLine": 367,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/ticket-validator.js",
+      "method": "<anon method-4>",
+      "startLine": 393,
+      "crap": 1
     },
     {
       "path": ".agents/scripts/lib/orchestration/ticket-validator.js",
       "method": "renderMissLine",
-      "startLine": 373,
+      "startLine": 411,
       "crap": 2
     },
     {
       "path": ".agents/scripts/lib/orchestration/ticket-validator.js",
       "method": "indexTicketsBySlug",
-      "startLine": 412,
+      "startLine": 449,
       "crap": 4
     },
     {
       "path": ".agents/scripts/lib/orchestration/ticket-validator.js",
       "method": "assertAllTicketsAreStories",
-      "startLine": 437,
+      "startLine": 474,
       "crap": 3
     },
     {
       "path": ".agents/scripts/lib/orchestration/ticket-validator.js",
+      "method": "<anon method-5>",
+      "startLine": 475,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/ticket-validator.js",
+      "method": "<anon method-6>",
+      "startLine": 478,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/ticket-validator.js",
       "method": "hasInlineAcceptanceAndVerify",
-      "startLine": 467,
+      "startLine": 504,
       "crap": 6
     },
     {
       "path": ".agents/scripts/lib/orchestration/ticket-validator.js",
       "method": "assertEveryStoryHasInlineContract",
-      "startLine": 478,
+      "startLine": 515,
       "crap": 2
     },
     {
       "path": ".agents/scripts/lib/orchestration/ticket-validator.js",
+      "method": "<anon method-7>",
+      "startLine": 522,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/ticket-validator.js",
+      "method": "<anon method-8>",
+      "startLine": 524,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/ticket-validator.js",
       "method": "assertNoUnknownDeps",
-      "startLine": 493,
+      "startLine": 530,
       "crap": 3
     },
     {
       "path": ".agents/scripts/lib/orchestration/ticket-validator.js",
+      "method": "<anon method-9>",
+      "startLine": 541,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/ticket-validator.js",
       "method": "assertAcyclic",
-      "startLine": 511,
+      "startLine": 548,
       "crap": 2
     },
     {
       "path": ".agents/scripts/lib/orchestration/ticket-validator.js",
       "method": "attachFindingsAndErrors",
-      "startLine": 520,
+      "startLine": 557,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/orchestration/ticket-validator.js",
       "method": "validateAndNormalizeTickets",
-      "startLine": 535,
-      "crap": 6.000189364674941
+      "startLine": 572,
+      "crap": 6.025854244039326
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/ticket-validator.js",
+      "method": "<anon method-10>",
+      "startLine": 637,
+      "crap": 1.0007181734455368
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/ticket-validator.js",
+      "method": "<anon method-11>",
+      "startLine": 689,
+      "crap": 1.0007181734455368
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/ticket-validator.js",
+      "method": "<anon method-12>",
+      "startLine": 690,
+      "crap": 2.0028726937821473
     },
     {
       "path": ".agents/scripts/lib/orchestration/ticketing/bulk.js",
       "method": "<anon method-1>",
       "startLine": 39,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/ticketing/bulk.js",
+      "method": "<anon method-2>",
+      "startLine": 40,
       "crap": 1
     },
     {
@@ -9562,6 +17525,18 @@
       "method": "withParentCascadeLock",
       "startLine": 80,
       "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/ticketing/bulk.js",
+      "method": "<anon method-3>",
+      "startLine": 83,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/ticketing/bulk.js",
+      "method": "<anon method-4>",
+      "startLine": 84,
+      "crap": 1
     },
     {
       "path": ".agents/scripts/lib/orchestration/ticketing/bulk.js",
@@ -9601,9 +17576,27 @@
     },
     {
       "path": ".agents/scripts/lib/orchestration/ticketing/bulk.js",
+      "method": "<anon method-5>",
+      "startLine": 230,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/ticketing/bulk.js",
       "method": "processCascadeParentLocked",
       "startLine": 243,
       "crap": 4
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/ticketing/bulk.js",
+      "method": "<anon method-6>",
+      "startLine": 288,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/ticketing/bulk.js",
+      "method": "<anon method-7>",
+      "startLine": 297,
+      "crap": 1
     },
     {
       "path": ".agents/scripts/lib/orchestration/ticketing/bulk.js",
@@ -9615,181 +17608,283 @@
       "path": ".agents/scripts/lib/orchestration/ticketing/bulk.js",
       "method": "cascadeCompletion",
       "startLine": 360,
-      "crap": 10.020354162426216
+      "crap": 4
     },
     {
       "path": ".agents/scripts/lib/orchestration/ticketing/bulk.js",
       "method": "deriveParentState",
-      "startLine": 448,
+      "startLine": 419,
       "crap": 6
     },
     {
       "path": ".agents/scripts/lib/orchestration/ticketing/bulk.js",
+      "method": "<anon method-9>",
+      "startLine": 421,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/ticketing/bulk.js",
       "method": "<anon method-10>",
-      "startLine": 450,
+      "startLine": 422,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/ticketing/bulk.js",
+      "method": "<anon method-11>",
+      "startLine": 426,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/ticketing/bulk.js",
+      "method": "<anon method-12>",
+      "startLine": 430,
       "crap": 2
     },
     {
       "path": ".agents/scripts/lib/orchestration/ticketing/bulk.js",
       "method": "cascadeParentState",
-      "startLine": 494,
+      "startLine": 465,
       "crap": 7
     },
     {
       "path": ".agents/scripts/lib/orchestration/ticketing/bulk.js",
+      "method": "<anon method-13>",
+      "startLine": 482,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/ticketing/bulk.js",
       "method": "resolveParentIds",
-      "startLine": 549,
-      "crap": 4
+      "startLine": 520,
+      "crap": 2
     },
     {
       "path": ".agents/scripts/lib/orchestration/ticketing/bulk.js",
       "method": "processStateCascadeParent",
-      "startLine": 565,
+      "startLine": 532,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/ticketing/bulk.js",
+      "method": "<anon method-14>",
+      "startLine": 534,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/orchestration/ticketing/bulk.js",
       "method": "processStateCascadeParentLocked",
-      "startLine": 577,
-      "crap": 8.475511659807957
+      "startLine": 544,
+      "crap": 7.929185185185186
     },
     {
       "path": ".agents/scripts/lib/orchestration/ticketing/bulk.js",
-      "method": "<anon method-20>",
-      "startLine": 642,
+      "method": "<anon method-15>",
+      "startLine": 577,
+      "crap": 2.075851851851852
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/ticketing/bulk.js",
+      "method": "<anon method-16>",
+      "startLine": 591,
+      "crap": 1.018962962962963
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/ticketing/bulk.js",
+      "method": "<anon method-17>",
+      "startLine": 600,
+      "crap": 1.018962962962963
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/ticketing/bulk.js",
+      "method": "<anon method-18>",
+      "startLine": 609,
       "crap": 1.2962962962962963
     },
     {
       "path": ".agents/scripts/lib/orchestration/ticketing/reads.js",
       "method": "isValidStructuredCommentType",
-      "startLine": 211,
+      "startLine": 198,
       "crap": 6
     },
     {
       "path": ".agents/scripts/lib/orchestration/ticketing/reads.js",
       "method": "assertValidStructuredCommentType",
-      "startLine": 228,
+      "startLine": 215,
       "crap": 2
     },
     {
       "path": ".agents/scripts/lib/orchestration/ticketing/reads.js",
       "method": "structuredCommentMarker",
-      "startLine": 254,
+      "startLine": 241,
       "crap": 5
     },
     {
       "path": ".agents/scripts/lib/orchestration/ticketing/reads.js",
       "method": "buildStorylessTicketSnapshot",
-      "startLine": 312,
+      "startLine": 299,
       "crap": 3
     },
     {
       "path": ".agents/scripts/lib/orchestration/ticketing/reads.js",
       "method": "getProviderCommentCache",
-      "startLine": 323,
+      "startLine": 310,
       "crap": 4
     },
     {
       "path": ".agents/scripts/lib/orchestration/ticketing/reads.js",
       "method": "structuredCommentCacheKey",
-      "startLine": 342,
+      "startLine": 329,
       "crap": 3
     },
     {
       "path": ".agents/scripts/lib/orchestration/ticketing/reads.js",
+      "method": "<anon method-1>",
+      "startLine": 335,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/ticketing/reads.js",
       "method": "getProviderRawCommentsCache",
-      "startLine": 382,
+      "startLine": 369,
       "crap": 4
     },
     {
       "path": ".agents/scripts/lib/orchestration/ticketing/reads.js",
       "method": "invalidateRawCommentsCache",
-      "startLine": 400,
+      "startLine": 387,
       "crap": 4
     },
     {
       "path": ".agents/scripts/lib/orchestration/ticketing/reads.js",
       "method": "_resetRawCommentsCache",
-      "startLine": 413,
+      "startLine": 400,
       "crap": 3
     },
     {
       "path": ".agents/scripts/lib/orchestration/ticketing/reads.js",
       "method": "_resetStructuredCommentCache",
-      "startLine": 432,
+      "startLine": 419,
       "crap": 3
     },
     {
       "path": ".agents/scripts/lib/orchestration/ticketing/reads.js",
       "method": "_peekStructuredCommentCache",
-      "startLine": 446,
+      "startLine": 433,
       "crap": 3.0416666666666665
     },
     {
       "path": ".agents/scripts/lib/orchestration/ticketing/reads.js",
       "method": "findStructuredComment",
-      "startLine": 475,
+      "startLine": 462,
       "crap": 4
     },
     {
-      "path": ".agents/scripts/lib/orchestration/ticketing/state.js",
-      "method": "_resetColumnSyncCache",
-      "startLine": 75,
-      "crap": 1
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/ticketing/state.js",
-      "method": "validateTransitionInputs",
-      "startLine": 94,
+      "path": ".agents/scripts/lib/orchestration/ticketing/reads.js",
+      "method": "<anon method-2>",
+      "startLine": 488,
       "crap": 2
     },
     {
       "path": ".agents/scripts/lib/orchestration/ticketing/state.js",
-      "method": "loadTicketSnapshot",
-      "startLine": 112,
-      "crap": 5.1574074074074066
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/ticketing/state.js",
-      "method": "syncProjectStatusColumn",
-      "startLine": 157,
-      "crap": 3
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/ticketing/state.js",
-      "method": "dispatchTransitionNotification",
-      "startLine": 205,
-      "crap": 6
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/ticketing/state.js",
-      "method": "transitionTicketState",
-      "startLine": 295,
-      "crap": 5
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/ticketing/state.js",
       "method": "transitionStoryDirect",
-      "startLine": 404,
-      "crap": 1
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/ticketing/state.js",
-      "method": "toggleTasklistCheckbox",
-      "startLine": 428,
-      "crap": 6
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/ticketing/state.js",
-      "method": "postStructuredComment",
-      "startLine": 470,
+      "startLine": 86,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/orchestration/ticketing/state.js",
       "method": "upsertStructuredComment",
-      "startLine": 501,
+      "startLine": 115,
       "crap": 6.011218284245225
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/ticketing/transition.js",
+      "method": "<anon method-1>",
+      "startLine": 62,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/ticketing/transition.js",
+      "method": "registerCascadeRunner",
+      "startLine": 73,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/ticketing/transition.js",
+      "method": "_resetColumnSyncCache",
+      "startLine": 100,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/ticketing/transition.js",
+      "method": "validateTransitionInputs",
+      "startLine": 119,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/ticketing/transition.js",
+      "method": "loadTicketSnapshot",
+      "startLine": 153,
+      "crap": 5.636067575819255
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/ticketing/transition.js",
+      "method": "syncProjectStatusColumn",
+      "startLine": 203,
+      "crap": 3
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/ticketing/transition.js",
+      "method": "dispatchTransitionNotification",
+      "startLine": 257,
+      "crap": 6
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/ticketing/transition.js",
+      "method": "<anon method-2>",
+      "startLine": 260,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/ticketing/transition.js",
+      "method": "<anon method-3>",
+      "startLine": 301,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/ticketing/transition.js",
+      "method": "emitBlockedFriction",
+      "startLine": 342,
+      "crap": 4
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/ticketing/transition.js",
+      "method": "transitionTicketState",
+      "startLine": 411,
+      "crap": 5
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/ticketing/transition.js",
+      "method": "<anon method-4>",
+      "startLine": 419,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/ticketing/transition.js",
+      "method": "<anon method-5>",
+      "startLine": 438,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/ticketing/transition.js",
+      "method": "toggleTasklistCheckbox",
+      "startLine": 526,
+      "crap": 6
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/ticketing/transition.js",
+      "method": "postStructuredComment",
+      "startLine": 579,
+      "crap": 1
     },
     {
       "path": ".agents/scripts/lib/path-security.js",
@@ -9800,44 +17895,26 @@
     {
       "path": ".agents/scripts/lib/plan-phase-cleanup.js",
       "method": "resolvePhaseTempPaths",
-      "startLine": 64,
+      "startLine": 68,
+      "crap": 2.0016257684296095
+    },
+    {
+      "path": ".agents/scripts/lib/plan-phase-cleanup.js",
+      "method": "<anon method-1>",
+      "startLine": 84,
       "crap": 2.0016257684296095
     },
     {
       "path": ".agents/scripts/lib/plan-phase-cleanup.js",
       "method": "cleanupPhaseTempFiles",
-      "startLine": 105,
-      "crap": 2
-    },
-    {
-      "path": ".agents/scripts/lib/planning-corpus.js",
-      "method": "rankCandidateEpics",
-      "startLine": 84,
-      "crap": 7
-    },
-    {
-      "path": ".agents/scripts/lib/planning-corpus.js",
-      "method": "fetchCandidateBodies",
-      "startLine": 137,
-      "crap": 7
-    },
-    {
-      "path": ".agents/scripts/lib/planning-corpus.js",
-      "method": "extractScoreableExcerpt",
-      "startLine": 183,
-      "crap": 2
-    },
-    {
-      "path": ".agents/scripts/lib/planning-corpus.js",
-      "method": "extractRelevantSections",
-      "startLine": 204,
-      "crap": 8.014247154743023
+      "startLine": 109,
+      "crap": 2.0001481481481482
     },
     {
       "path": ".agents/scripts/lib/planning-corpus.js",
       "method": "buildCorpusContext",
-      "startLine": 260,
-      "crap": 4
+      "startLine": 34,
+      "crap": 1
     },
     {
       "path": ".agents/scripts/lib/preflight-runner.js",
@@ -9865,15 +17942,39 @@
     },
     {
       "path": ".agents/scripts/lib/preflight-runner.js",
+      "method": "<anon method-4>",
+      "startLine": 99,
+      "crap": 1.0042643081357472
+    },
+    {
+      "path": ".agents/scripts/lib/preflight-runner.js",
+      "method": "<anon method-5>",
+      "startLine": 103,
+      "crap": 1.0042643081357472
+    },
+    {
+      "path": ".agents/scripts/lib/preflight-runner.js",
       "method": "pick",
       "startLine": 114,
       "crap": 3.0416666666666665
     },
     {
       "path": ".agents/scripts/lib/preflight-runner.js",
+      "method": "<anon method-6>",
+      "startLine": 116,
+      "crap": 1.0046296296296295
+    },
+    {
+      "path": ".agents/scripts/lib/preflight-runner.js",
+      "method": "<anon method-7>",
+      "startLine": 118,
+      "crap": 1.0046296296296295
+    },
+    {
+      "path": ".agents/scripts/lib/preflight-runner.js",
       "method": "logFixes",
       "startLine": 127,
-      "crap": 1
+      "crap": 1.669921875
     },
     {
       "path": ".agents/scripts/lib/preflight-runner.js",
@@ -9913,6 +18014,12 @@
     },
     {
       "path": ".agents/scripts/lib/qa/console-allowlist.js",
+      "method": "<anon method-1>",
+      "startLine": 79,
+      "crap": 3
+    },
+    {
+      "path": ".agents/scripts/lib/qa/console-allowlist.js",
       "method": "buildFinding",
       "startLine": 97,
       "crap": 1
@@ -9924,28 +18031,406 @@
       "crap": 4
     },
     {
+      "path": ".agents/scripts/lib/qa/coverage-report.js",
+      "method": "tierHeader",
+      "startLine": 34,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/qa/coverage-report.js",
+      "method": "cell",
+      "startLine": 42,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/qa/coverage-report.js",
+      "method": "resolveMatrix",
+      "startLine": 57,
+      "crap": 5
+    },
+    {
+      "path": ".agents/scripts/lib/qa/coverage-report.js",
+      "method": "renderCoverageReport",
+      "startLine": 81,
+      "crap": 8
+    },
+    {
+      "path": ".agents/scripts/lib/qa/coverage-report.js",
+      "method": "<anon method-1>",
+      "startLine": 88,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/qa/coverage-report.js",
+      "method": "<anon method-2>",
+      "startLine": 89,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/qa/coverage-report.js",
+      "method": "<anon method-3>",
+      "startLine": 108,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/qa/coverage-report.js",
+      "method": "<anon method-4>",
+      "startLine": 111,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/qa/coverage-report.js",
+      "method": "reportPathFor",
+      "startLine": 146,
+      "crap": 4
+    },
+    {
+      "path": ".agents/scripts/lib/qa/coverage-report.js",
+      "method": "writeCoverageReport",
+      "startLine": 171,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/qa/coverage-verdict.js",
+      "method": "hasSkipTag",
+      "startLine": 53,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/qa/coverage-verdict.js",
+      "method": "hasRunnerSkipMarker",
+      "startLine": 59,
+      "crap": 3
+    },
+    {
+      "path": ".agents/scripts/lib/qa/coverage-verdict.js",
+      "method": "isSkipped",
+      "startLine": 79,
+      "crap": 12
+    },
+    {
+      "path": ".agents/scripts/lib/qa/coverage-verdict.js",
+      "method": "<anon method-1>",
+      "startLine": 89,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/qa/coverage-verdict.js",
+      "method": "<anon method-2>",
+      "startLine": 101,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/qa/coverage-verdict.js",
+      "method": "classifyTest",
+      "startLine": 122,
+      "crap": 16
+    },
+    {
+      "path": ".agents/scripts/lib/qa/coverage-verdict.js",
+      "method": "<anon method-3>",
+      "startLine": 165,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/qa/coverage-verdict.js",
+      "method": "<anon method-4>",
+      "startLine": 166,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/qa/coverage-verdict.js",
+      "method": "<anon method-5>",
+      "startLine": 167,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/qa/coverage-verdict.js",
+      "method": "coverageVerdict",
+      "startLine": 184,
+      "crap": 9
+    },
+    {
+      "path": ".agents/scripts/lib/qa/coverage-verdict.js",
+      "method": "normalizeOne",
+      "startLine": 226,
+      "crap": 11.121
+    },
+    {
+      "path": ".agents/scripts/lib/qa/coverage-verdict.js",
+      "method": "normalizeCriteria",
+      "startLine": 256,
+      "crap": 4
+    },
+    {
+      "path": ".agents/scripts/lib/qa/coverage-verdict.js",
+      "method": "<anon method-6>",
+      "startLine": 258,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/qa/coverage-verdict.js",
+      "method": "<anon method-7>",
+      "startLine": 261,
+      "crap": 4
+    },
+    {
+      "path": ".agents/scripts/lib/qa/coverage-verdict.js",
+      "method": "acceptanceMatrix",
+      "startLine": 288,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/qa/coverage-verdict.js",
+      "method": "<anon method-8>",
+      "startLine": 290,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/qa/propose-missing-test.js",
+      "method": "<anon method-1>",
+      "startLine": 35,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/qa/propose-missing-test.js",
+      "method": "<anon method-2>",
+      "startLine": 37,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/qa/propose-missing-test.js",
+      "method": "<anon method-3>",
+      "startLine": 39,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/qa/propose-missing-test.js",
+      "method": "noteFor",
+      "startLine": 50,
+      "crap": 3
+    },
+    {
+      "path": ".agents/scripts/lib/qa/propose-missing-test.js",
+      "method": "isAbsent",
+      "startLine": 62,
+      "crap": 3
+    },
+    {
+      "path": ".agents/scripts/lib/qa/propose-missing-test.js",
+      "method": "proposeMissingTest",
+      "startLine": 77,
+      "crap": 4
+    },
+    {
+      "path": ".agents/scripts/lib/qa/qa-context-hydrator.js",
+      "method": "collectFeatureFiles",
+      "startLine": 75,
+      "crap": 3
+    },
+    {
+      "path": ".agents/scripts/lib/qa/qa-context-hydrator.js",
+      "method": "<anon method-1>",
+      "startLine": 80,
+      "crap": 4
+    },
+    {
+      "path": ".agents/scripts/lib/qa/qa-context-hydrator.js",
+      "method": "verifySurfaceMap",
+      "startLine": 111,
+      "crap": 6
+    },
+    {
+      "path": ".agents/scripts/lib/qa/qa-context-hydrator.js",
+      "method": "hydrateQaContext",
+      "startLine": 163,
+      "crap": 9
+    },
+    {
+      "path": ".agents/scripts/lib/qa/qa-context-hydrator.js",
+      "method": "<anon method-2>",
+      "startLine": 206,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/qa/qa-context-hydrator.js",
+      "method": "<anon method-3>",
+      "startLine": 207,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/qa/qa-session.js",
+      "method": "isUntriaged",
+      "startLine": 57,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/qa/qa-session.js",
+      "method": "slugifySessionId",
+      "startLine": 71,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/qa/qa-session.js",
+      "method": "deriveSessionId",
+      "startLine": 86,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/qa/qa-session.js",
+      "method": "resolveSessionId",
+      "startLine": 102,
+      "crap": 5
+    },
+    {
+      "path": ".agents/scripts/lib/qa/qa-session.js",
+      "method": "ledgerPathFor",
+      "startLine": 121,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/qa/qa-session.js",
+      "method": "parseLine",
+      "startLine": 134,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/qa/qa-session.js",
+      "method": "readLedger",
+      "startLine": 155,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/qa/qa-session.js",
+      "method": "resolveQaSession",
+      "startLine": 187,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/qa/redact-evidence.js",
+      "method": "buildCookiePattern",
+      "startLine": 79,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/qa/redact-evidence.js",
+      "method": "isCreditCard",
+      "startLine": 102,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/qa/redact-evidence.js",
+      "method": "<anon method-1>",
+      "startLine": 135,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/qa/redact-evidence.js",
+      "method": "<anon method-2>",
+      "startLine": 146,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/qa/redact-evidence.js",
+      "method": "<anon method-3>",
+      "startLine": 156,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/qa/redact-evidence.js",
+      "method": "<anon method-4>",
+      "startLine": 165,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/qa/redact-evidence.js",
+      "method": "<anon method-5>",
+      "startLine": 175,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/qa/redact-evidence.js",
+      "method": "<anon method-6>",
+      "startLine": 185,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/qa/redact-evidence.js",
+      "method": "<anon method-7>",
+      "startLine": 193,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/qa/redact-evidence.js",
+      "method": "<anon method-8>",
+      "startLine": 200,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/qa/redact-evidence.js",
+      "method": "redactEvidence",
+      "startLine": 224,
+      "crap": 2
+    },
+    {
       "path": ".agents/scripts/lib/qa/resolve-qa-contract.js",
       "method": "getQaValidator",
-      "startLine": 56,
+      "startLine": 73,
       "crap": 2
     },
     {
       "path": ".agents/scripts/lib/qa/resolve-qa-contract.js",
       "method": "normalizePersonas",
-      "startLine": 79,
+      "startLine": 96,
       "crap": 2
     },
     {
       "path": ".agents/scripts/lib/qa/resolve-qa-contract.js",
       "method": "describeError",
-      "startLine": 101,
+      "startLine": 118,
       "crap": 4
     },
     {
       "path": ".agents/scripts/lib/qa/resolve-qa-contract.js",
       "method": "resolveQaContract",
-      "startLine": 138,
-      "crap": 11
+      "startLine": 156,
+      "crap": 12
+    },
+    {
+      "path": ".agents/scripts/lib/qa/resolve-qa-contract.js",
+      "method": "<anon method-1>",
+      "startLine": 168,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/qa/resolve-qa-contract.js",
+      "method": "<anon method-2>",
+      "startLine": 183,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/qa/resolve-qa-contract.js",
+      "method": "toOrigin",
+      "startLine": 237,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/qa/resolve-qa-contract.js",
+      "method": "resolveQaEnvironment",
+      "startLine": 271,
+      "crap": 11.086125409985423
+    },
+    {
+      "path": ".agents/scripts/lib/qa/resolve-qa-contract.js",
+      "method": "<anon method-3>",
+      "startLine": 285,
+      "crap": 1.0007117802478134
+    },
+    {
+      "path": ".agents/scripts/lib/qa/resolve-qa-contract.js",
+      "method": "<anon method-4>",
+      "startLine": 301,
+      "crap": 1.0007117802478134
     },
     {
       "path": ".agents/scripts/lib/qa/resolve-selection.js",
@@ -10027,8 +18512,26 @@
     },
     {
       "path": ".agents/scripts/lib/qa/resolve-selection.js",
+      "method": "<anon method-5>",
+      "startLine": 200,
+      "crap": 1.0012299562682216
+    },
+    {
+      "path": ".agents/scripts/lib/qa/resolve-selection.js",
+      "method": "<anon method-6>",
+      "startLine": 214,
+      "crap": 1.0012299562682216
+    },
+    {
+      "path": ".agents/scripts/lib/qa/resolve-selection.js",
       "method": "tagSetOf",
       "startLine": 235,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/qa/resolve-selection.js",
+      "method": "<anon method-7>",
+      "startLine": 236,
       "crap": 1
     },
     {
@@ -10036,6 +18539,12 @@
       "method": "sortScenarios",
       "startLine": 249,
       "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/qa/resolve-selection.js",
+      "method": "<anon method-8>",
+      "startLine": 252,
+      "crap": 3
     },
     {
       "path": ".agents/scripts/lib/qa/resolve-selection.js",
@@ -10051,8 +18560,38 @@
     },
     {
       "path": ".agents/scripts/lib/qa/resolve-selection.js",
+      "method": "<anon method-9>",
+      "startLine": 306,
+      "crap": 2.0857338820301785
+    },
+    {
+      "path": ".agents/scripts/lib/qa/resolve-selection.js",
+      "method": "<anon method-10>",
+      "startLine": 320,
+      "crap": 1.0214334705075445
+    },
+    {
+      "path": ".agents/scripts/lib/qa/resolve-selection.js",
+      "method": "<anon method-11>",
+      "startLine": 325,
+      "crap": 1.0214334705075445
+    },
+    {
+      "path": ".agents/scripts/lib/qa/resolve-selection.js",
       "method": "resolveTag",
       "startLine": 334,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/qa/resolve-selection.js",
+      "method": "<anon method-12>",
+      "startLine": 337,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/qa/resolve-selection.js",
+      "method": "<anon method-13>",
+      "startLine": 338,
       "crap": 1
     },
     {
@@ -10060,6 +18599,18 @@
       "method": "resolveDomain",
       "startLine": 347,
       "crap": 4.052024589747498
+    },
+    {
+      "path": ".agents/scripts/lib/qa/resolve-selection.js",
+      "method": "<anon method-14>",
+      "startLine": 359,
+      "crap": 1.0032515368592185
+    },
+    {
+      "path": ".agents/scripts/lib/qa/resolve-selection.js",
+      "method": "<anon method-15>",
+      "startLine": 366,
+      "crap": 1.0032515368592185
     },
     {
       "path": ".agents/scripts/lib/runtime-deps/ensure-installed.js",
@@ -10094,8 +18645,8 @@
     {
       "path": ".agents/scripts/lib/runtime-deps/preflight.js",
       "method": "detectPackageManager",
-      "startLine": 48,
-      "crap": 3
+      "startLine": 50,
+      "crap": 1
     },
     {
       "path": ".agents/scripts/lib/runtime-deps/preflight.js",
@@ -10158,6 +18709,18 @@
       "crap": 5
     },
     {
+      "path": ".agents/scripts/lib/signals/detectors/common.js",
+      "method": "validateDetectorArgs",
+      "startLine": 78,
+      "crap": 20
+    },
+    {
+      "path": ".agents/scripts/lib/signals/detectors/common.js",
+      "method": "<anon method-1>",
+      "startLine": 98,
+      "crap": 1
+    },
+    {
       "path": ".agents/scripts/lib/signals/detectors/retry.js",
       "method": "resolveIdentity",
       "startLine": 114,
@@ -10166,20 +18729,32 @@
     {
       "path": ".agents/scripts/lib/signals/detectors/retry.js",
       "method": "isFailedBash",
-      "startLine": 138,
+      "startLine": 139,
       "crap": 2
     },
     {
       "path": ".agents/scripts/lib/signals/detectors/retry.js",
       "method": "tallyFailuresByIdentity",
-      "startLine": 150,
+      "startLine": 151,
       "crap": 9.024
     },
     {
       "path": ".agents/scripts/lib/signals/detectors/retry.js",
       "method": "detectRetry",
-      "startLine": 222,
-      "crap": 14
+      "startLine": 223,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/signals/detectors/retry.js",
+      "method": "<anon method-1>",
+      "startLine": 236,
+      "crap": 3
+    },
+    {
+      "path": ".agents/scripts/lib/signals/detectors/retry.js",
+      "method": "<anon method-2>",
+      "startLine": 239,
+      "crap": 1
     },
     {
       "path": ".agents/scripts/lib/signals/detectors/rework.js",
@@ -10191,7 +18766,19 @@
       "path": ".agents/scripts/lib/signals/detectors/rework.js",
       "method": "detectRework",
       "startLine": 142,
-      "crap": 14.050166568685087
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/signals/detectors/rework.js",
+      "method": "<anon method-1>",
+      "startLine": 155,
+      "crap": 3
+    },
+    {
+      "path": ".agents/scripts/lib/signals/detectors/rework.js",
+      "method": "<anon method-2>",
+      "startLine": 158,
+      "crap": 1
     },
     {
       "path": ".agents/scripts/lib/signals/read.js",
@@ -10219,9 +18806,15 @@
     },
     {
       "path": ".agents/scripts/lib/signals/read.js",
-      "method": "listEpicStorySignalsFiles",
+      "method": "listRunStorySignalsFiles",
       "startLine": 162,
-      "crap": 10.007233796296296
+      "crap": 10.128421139146873
+    },
+    {
+      "path": ".agents/scripts/lib/signals/read.js",
+      "method": "<anon method-1>",
+      "startLine": 197,
+      "crap": 1.0012842113914688
     },
     {
       "path": ".agents/scripts/lib/signals/read.js",
@@ -10232,104 +18825,20 @@
     {
       "path": ".agents/scripts/lib/signals/schema.js",
       "method": "isTimestamp",
-      "startLine": 135,
+      "startLine": 150,
       "crap": 2
     },
     {
       "path": ".agents/scripts/lib/signals/schema.js",
       "method": "hasCommonEnvelope",
-      "startLine": 149,
-      "crap": 6
+      "startLine": 165,
+      "crap": 8
     },
     {
       "path": ".agents/scripts/lib/signals/schema.js",
       "method": "isValidSignal",
-      "startLine": 169,
+      "startLine": 193,
       "crap": 4
-    },
-    {
-      "path": ".agents/scripts/lib/signals/schema.js",
-      "method": "<anon method-1>",
-      "startLine": 188,
-      "crap": 2
-    },
-    {
-      "path": ".agents/scripts/lib/signals/schema.js",
-      "method": "<anon method-2>",
-      "startLine": 194,
-      "crap": 1
-    },
-    {
-      "path": ".agents/scripts/lib/signals/schema.js",
-      "method": "<anon method-3>",
-      "startLine": 195,
-      "crap": 1
-    },
-    {
-      "path": ".agents/scripts/lib/signals/schema.js",
-      "method": "<anon method-4>",
-      "startLine": 196,
-      "crap": 1
-    },
-    {
-      "path": ".agents/scripts/lib/signals/schema.js",
-      "method": "<anon method-5>",
-      "startLine": 197,
-      "crap": 1
-    },
-    {
-      "path": ".agents/scripts/lib/signals/schema.js",
-      "method": "<anon method-6>",
-      "startLine": 198,
-      "crap": 1
-    },
-    {
-      "path": ".agents/scripts/lib/signals/schema.js",
-      "method": "<anon method-7>",
-      "startLine": 199,
-      "crap": 1
-    },
-    {
-      "path": ".agents/scripts/lib/signals/schema.js",
-      "method": "<anon method-8>",
-      "startLine": 201,
-      "crap": 1
-    },
-    {
-      "path": ".agents/scripts/lib/signals/schema.js",
-      "method": "<anon method-9>",
-      "startLine": 203,
-      "crap": 1
-    },
-    {
-      "path": ".agents/scripts/lib/signals/schema.js",
-      "method": "<anon method-10>",
-      "startLine": 205,
-      "crap": 1
-    },
-    {
-      "path": ".agents/scripts/lib/signals/schema.js",
-      "method": "<anon method-11>",
-      "startLine": 206,
-      "crap": 1
-    },
-    {
-      "path": ".agents/scripts/lib/signals/schema.js",
-      "method": "<anon method-12>",
-      "startLine": 207,
-      "crap": 1
-    },
-    {
-      "path": ".agents/scripts/lib/signals/schema.js",
-      "method": "<anon method-13>",
-      "startLine": 208,
-      "crap": 1
-    },
-    {
-      "path": ".agents/scripts/lib/signals/schema.js",
-      "method": "<anon method-14>",
-      "startLine": 209,
-      "crap": 1
     },
     {
       "path": ".agents/scripts/lib/signals/span-tree.js",
@@ -10340,169 +18849,271 @@
     {
       "path": ".agents/scripts/lib/signals/span-tree.js",
       "method": "epicOf",
-      "startLine": 58,
+      "startLine": 59,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/signals/span-tree.js",
       "method": "storyOf",
-      "startLine": 62,
+      "startLine": 63,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/signals/span-tree.js",
       "method": "taskOf",
-      "startLine": 66,
+      "startLine": 67,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/signals/span-tree.js",
       "method": "cmpTs",
-      "startLine": 79,
+      "startLine": 80,
       "crap": 6.0703125
     },
     {
       "path": ".agents/scripts/lib/signals/span-tree.js",
       "method": "diffMs",
-      "startLine": 88,
+      "startLine": 89,
       "crap": 5
     },
     {
       "path": ".agents/scripts/lib/signals/span-tree.js",
       "method": "isStoryLifecycle",
-      "startLine": 96,
+      "startLine": 97,
       "crap": 4
     },
     {
       "path": ".agents/scripts/lib/signals/span-tree.js",
       "method": "isStoryStart",
-      "startLine": 105,
+      "startLine": 106,
       "crap": 2
     },
     {
       "path": ".agents/scripts/lib/signals/span-tree.js",
       "method": "isStoryEnd",
-      "startLine": 109,
+      "startLine": 110,
       "crap": 2
     },
     {
       "path": ".agents/scripts/lib/signals/span-tree.js",
       "method": "emptyTaskNode",
-      "startLine": 113,
+      "startLine": 114,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/signals/span-tree.js",
       "method": "emptyStoryNode",
-      "startLine": 123,
+      "startLine": 124,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/signals/span-tree.js",
       "method": "storyKeyOf",
-      "startLine": 134,
+      "startLine": 135,
       "crap": 2
     },
     {
       "path": ".agents/scripts/lib/signals/span-tree.js",
       "method": "getOrCreateStory",
-      "startLine": 138,
+      "startLine": 139,
       "crap": 2
     },
     {
       "path": ".agents/scripts/lib/signals/span-tree.js",
       "method": "getOrCreateTask",
-      "startLine": 149,
+      "startLine": 150,
       "crap": 2
     },
     {
       "path": ".agents/scripts/lib/signals/span-tree.js",
       "method": "updateStoryLifecycle",
-      "startLine": 160,
+      "startLine": 161,
       "crap": 8
     },
     {
       "path": ".agents/scripts/lib/signals/span-tree.js",
       "method": "widenTaskWindow",
-      "startLine": 173,
+      "startLine": 174,
       "crap": 6
     },
     {
       "path": ".agents/scripts/lib/signals/span-tree.js",
       "method": "bootstrapStoryWindow",
-      "startLine": 183,
+      "startLine": 184,
       "crap": 4
     },
     {
       "path": ".agents/scripts/lib/signals/span-tree.js",
       "method": "ingestEvent",
-      "startLine": 198,
+      "startLine": 199,
       "crap": 7
     },
     {
       "path": ".agents/scripts/lib/signals/span-tree.js",
       "method": "compareNodeIds",
-      "startLine": 232,
+      "startLine": 233,
       "crap": 6.049382716049383
     },
     {
       "path": ".agents/scripts/lib/signals/span-tree.js",
       "method": "finalizeTask",
-      "startLine": 242,
+      "startLine": 243,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/signals/span-tree.js",
+      "method": "<anon method-1>",
+      "startLine": 244,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/signals/span-tree.js",
       "method": "finalizeStory",
-      "startLine": 247,
+      "startLine": 248,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/signals/span-tree.js",
+      "method": "<anon method-2>",
+      "startLine": 253,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/signals/span-tree.js",
       "method": "buildSpanTree",
-      "startLine": 266,
+      "startLine": 267,
       "crap": 3
     },
     {
       "path": ".agents/scripts/lib/single-story-sweep.js",
-      "method": "sweepMergedStoryBranches",
-      "startLine": 68,
-      "crap": 10.002056465398685
+      "method": "sweepMergedBranches",
+      "startLine": 101,
+      "crap": 11.001420454545455
     },
     {
       "path": ".agents/scripts/lib/single-story-sweep.js",
       "method": "<anon method-1>",
-      "startLine": 82,
+      "startLine": 120,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/single-story-sweep.js",
       "method": "<anon method-2>",
-      "startLine": 83,
+      "startLine": 121,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/single-story-sweep.js",
       "method": "<anon method-3>",
-      "startLine": 96,
+      "startLine": 134,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/single-story-sweep.js",
+      "method": "sweepMergedStoryBranches",
+      "startLine": 213,
+      "crap": 3
+    },
+    {
+      "path": ".agents/scripts/lib/single-story-sweep.js",
+      "method": "partitionContentMerged",
+      "startLine": 237,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/single-story-sweep.js",
       "method": "runSweepUnderLock",
-      "startLine": 147,
-      "crap": 8
+      "startLine": 257,
+      "crap": 4
+    },
+    {
+      "path": ".agents/scripts/lib/single-story-sweep.js",
+      "method": "<anon method-4>",
+      "startLine": 286,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/single-story-sweep.js",
+      "method": "executeReap",
+      "startLine": 346,
+      "crap": 4
+    },
+    {
+      "path": ".agents/scripts/lib/single-story-sweep.js",
+      "method": "<anon method-5>",
+      "startLine": 375,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/single-story-sweep.js",
+      "method": "<anon method-6>",
+      "startLine": 376,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/single-story-sweep.js",
+      "method": "<anon method-7>",
+      "startLine": 377,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/single-story-sweep.js",
+      "method": "<anon method-8>",
+      "startLine": 381,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/single-story-sweep.js",
+      "method": "runFastForwardStep",
+      "startLine": 412,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/single-story-sweep.js",
+      "method": "<anon method-9>",
+      "startLine": 427,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/single-story-sweep.js",
+      "method": "<anon method-10>",
+      "startLine": 428,
+      "crap": 1
     },
     {
       "path": ".agents/scripts/lib/single-story-sweep.js",
       "method": "partitionCandidates",
-      "startLine": 276,
-      "crap": 3.09519594898507
+      "startLine": 458,
+      "crap": 3.102515625
     },
     {
       "path": ".agents/scripts/lib/single-story-sweep.js",
       "method": "zeroResult",
-      "startLine": 318,
+      "startLine": 499,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/single-story-sweep/protection-ctx.js",
+      "method": "makeGhRunner",
+      "startLine": 35,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/single-story-sweep/protection-ctx.js",
+      "method": "<anon method-1>",
+      "startLine": 36,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/single-story-sweep/protection-ctx.js",
+      "method": "buildProtectionCtx",
+      "startLine": 68,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/single-story-sweep/protection-ctx.js",
+      "method": "<anon method-2>",
+      "startLine": 73,
       "crap": 1
     },
     {
@@ -10602,6 +19213,24 @@
       "crap": 1
     },
     {
+      "path": ".agents/scripts/lib/single-story-sweep/sweep-lock.js",
+      "method": "defaultSleep",
+      "startLine": 181,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/single-story-sweep/sweep-lock.js",
+      "method": "<anon method-3>",
+      "startLine": 182,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/single-story-sweep/sweep-lock.js",
+      "method": "acquireLockWithWait",
+      "startLine": 215,
+      "crap": 4
+    },
+    {
       "path": ".agents/scripts/lib/single-story/confirm-merge.js",
       "method": "readPrMergeState",
       "startLine": 52,
@@ -10634,49 +19263,49 @@
     {
       "path": ".agents/scripts/lib/single-story/story-merged-notify.js",
       "method": "flipLabel",
-      "startLine": 58,
+      "startLine": 64,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/single-story/story-merged-notify.js",
       "method": "fireStoryClosingNotify",
-      "startLine": 97,
+      "startLine": 108,
       "crap": 2
     },
     {
       "path": ".agents/scripts/lib/skills/parse-skill.js",
       "method": "resolveRepoRoot",
-      "startLine": 40,
+      "startLine": 42,
       "crap": 3.0540946656649135
     },
     {
       "path": ".agents/scripts/lib/skills/parse-skill.js",
       "method": "toPosix",
-      "startLine": 52,
+      "startLine": 54,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/skills/parse-skill.js",
       "method": "splitLines",
-      "startLine": 61,
+      "startLine": 63,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/skills/parse-skill.js",
       "method": "extractFrontmatterBlock",
-      "startLine": 69,
+      "startLine": 71,
       "crap": 5.626074074074074
     },
     {
       "path": ".agents/scripts/lib/skills/parse-skill.js",
       "method": "findPolicyCapsule",
-      "startLine": 91,
-      "crap": 9
+      "startLine": 99,
+      "crap": 11
     },
     {
       "path": ".agents/scripts/lib/skills/parse-skill.js",
       "method": "parseSkill",
-      "startLine": 134,
+      "startLine": 147,
       "crap": 12.010699859060178
     },
     {
@@ -10692,207 +19321,345 @@
       "crap": 1
     },
     {
+      "path": ".agents/scripts/lib/skills/walk-skill-files.js",
+      "method": "<anon method-1>",
+      "startLine": 51,
+      "crap": 3
+    },
+    {
+      "path": ".agents/scripts/lib/story-adjacency.js",
+      "method": "buildStoryAdjacency",
+      "startLine": 55,
+      "crap": 4
+    },
+    {
+      "path": ".agents/scripts/lib/story-adjacency.js",
+      "method": "<anon method-1>",
+      "startLine": 57,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/story-adjacency.js",
+      "method": "<anon method-2>",
+      "startLine": 70,
+      "crap": 4
+    },
+    {
+      "path": ".agents/scripts/lib/story-body/body-format-lints.js",
+      "method": "inferVerifyTier",
+      "startLine": 66,
+      "crap": 6
+    },
+    {
+      "path": ".agents/scripts/lib/story-body/body-format-lints.js",
+      "method": "suggestVerifyFix",
+      "startLine": 86,
+      "crap": 6
+    },
+    {
+      "path": ".agents/scripts/lib/story-body/body-format-lints.js",
+      "method": "suggestPathEntryFix",
+      "startLine": 111,
+      "crap": 4
+    },
+    {
       "path": ".agents/scripts/lib/story-body/story-body.js",
       "method": "stripListMarker",
-      "startLine": 169,
+      "startLine": 165,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/story-body/story-body.js",
       "method": "parsePathEntry",
-      "startLine": 188,
-      "crap": 14
+      "startLine": 203,
+      "crap": 17
+    },
+    {
+      "path": ".agents/scripts/lib/story-body/story-body.js",
+      "method": "pathEntryFixIt",
+      "startLine": 279,
+      "crap": 2
     },
     {
       "path": ".agents/scripts/lib/story-body/story-body.js",
       "method": "extractBlockedBy",
-      "startLine": 248,
+      "startLine": 292,
       "crap": 2
     },
     {
       "path": ".agents/scripts/lib/story-body/story-body.js",
       "method": "extractMeta",
-      "startLine": 279,
-      "crap": 9.046875
+      "startLine": 326,
+      "crap": 10.210725062796069
     },
     {
       "path": ".agents/scripts/lib/story-body/story-body.js",
       "method": "normalizeReasonToExist",
-      "startLine": 326,
+      "startLine": 376,
       "crap": 3
     },
     {
       "path": ".agents/scripts/lib/story-body/story-body.js",
       "method": "normalizeWide",
-      "startLine": 341,
+      "startLine": 391,
       "crap": 5
     },
     {
       "path": ".agents/scripts/lib/story-body/story-body.js",
       "method": "splitSections",
-      "startLine": 362,
-      "crap": 14
+      "startLine": 412,
+      "crap": 15
     },
     {
       "path": ".agents/scripts/lib/story-body/story-body.js",
-      "method": "parseLegacyStringBody",
-      "startLine": 467,
+      "method": "parseUnstructuredBody",
+      "startLine": 525,
       "crap": 2
     },
     {
       "path": ".agents/scripts/lib/story-body/story-body.js",
       "method": "parseGoalSection",
-      "startLine": 512,
+      "startLine": 570,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/story-body/story-body.js",
+      "method": "<anon method-1>",
+      "startLine": 572,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/story-body/story-body.js",
       "method": "parseTextBlockSection",
-      "startLine": 528,
+      "startLine": 586,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/story-body/story-body.js",
+      "method": "<anon method-2>",
+      "startLine": 588,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/story-body/story-body.js",
       "method": "parsePathEntrySection",
-      "startLine": 545,
+      "startLine": 602,
       "crap": 3
     },
     {
       "path": ".agents/scripts/lib/story-body/story-body.js",
       "method": "parseTextListSection",
-      "startLine": 563,
+      "startLine": 620,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/story-body/story-body.js",
+      "method": "<anon method-3>",
+      "startLine": 621,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/story-body/story-body.js",
       "method": "parse",
-      "startLine": 589,
+      "startLine": 646,
       "crap": 11
     },
     {
       "path": ".agents/scripts/lib/story-body/story-body.js",
+      "method": "<anon method-4>",
+      "startLine": 704,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/story-body/story-body.js",
       "method": "parseStructuredObject",
-      "startLine": 710,
+      "startLine": 771,
       "crap": 18
     },
     {
       "path": ".agents/scripts/lib/story-body/story-body.js",
-      "method": "serializePathEntry",
-      "startLine": 825,
+      "method": "<anon method-5>",
+      "startLine": 792,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/story-body/story-body.js",
+      "method": "<anon method-6>",
+      "startLine": 797,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/story-body/story-body.js",
+      "method": "<anon method-7>",
+      "startLine": 810,
       "crap": 2
     },
     {
       "path": ".agents/scripts/lib/story-body/story-body.js",
       "method": "<anon method-8>",
-      "startLine": 847,
-      "crap": 3
+      "startLine": 819,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/story-body/story-body.js",
+      "method": "serializePathEntry",
+      "startLine": 886,
+      "crap": 2
     },
     {
       "path": ".agents/scripts/lib/story-body/story-body.js",
       "method": "<anon method-9>",
-      "startLine": 858,
+      "startLine": 910,
       "crap": 3
     },
     {
       "path": ".agents/scripts/lib/story-body/story-body.js",
       "method": "<anon method-10>",
-      "startLine": 867,
-      "crap": 3
+      "startLine": 922,
+      "crap": 2
     },
     {
       "path": ".agents/scripts/lib/story-body/story-body.js",
       "method": "<anon method-11>",
-      "startLine": 874,
+      "startLine": 933,
+      "crap": 3
+    },
+    {
+      "path": ".agents/scripts/lib/story-body/story-body.js",
+      "method": "<anon method-12>",
+      "startLine": 942,
       "crap": 3
     },
     {
       "path": ".agents/scripts/lib/story-body/story-body.js",
       "method": "<anon method-13>",
-      "startLine": 881,
+      "startLine": 949,
       "crap": 3
+    },
+    {
+      "path": ".agents/scripts/lib/story-body/story-body.js",
+      "method": "<anon method-14>",
+      "startLine": 951,
+      "crap": 1
     },
     {
       "path": ".agents/scripts/lib/story-body/story-body.js",
       "method": "<anon method-15>",
-      "startLine": 888,
+      "startLine": 960,
       "crap": 3
+    },
+    {
+      "path": ".agents/scripts/lib/story-body/story-body.js",
+      "method": "<anon method-16>",
+      "startLine": 962,
+      "crap": 1
     },
     {
       "path": ".agents/scripts/lib/story-body/story-body.js",
       "method": "<anon method-17>",
-      "startLine": 895,
+      "startLine": 967,
       "crap": 3
+    },
+    {
+      "path": ".agents/scripts/lib/story-body/story-body.js",
+      "method": "<anon method-18>",
+      "startLine": 969,
+      "crap": 1
     },
     {
       "path": ".agents/scripts/lib/story-body/story-body.js",
       "method": "<anon method-19>",
-      "startLine": 907,
+      "startLine": 974,
       "crap": 3
     },
     {
       "path": ".agents/scripts/lib/story-body/story-body.js",
+      "method": "<anon method-20>",
+      "startLine": 976,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/story-body/story-body.js",
+      "method": "<anon method-21>",
+      "startLine": 986,
+      "crap": 3
+    },
+    {
+      "path": ".agents/scripts/lib/story-body/story-body.js",
+      "method": "<anon method-22>",
+      "startLine": 988,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/story-body/story-body.js",
       "method": "serializeMetaBlock",
-      "startLine": 929,
+      "startLine": 1008,
       "crap": 9
     },
     {
       "path": ".agents/scripts/lib/story-body/story-body.js",
       "method": "serializeAuthoredMarker",
-      "startLine": 963,
+      "startLine": 1042,
       "crap": 5
     },
     {
       "path": ".agents/scripts/lib/story-body/story-body.js",
       "method": "serializeFooter",
-      "startLine": 980,
-      "crap": 5
+      "startLine": 1059,
+      "crap": 4
     },
     {
       "path": ".agents/scripts/lib/story-body/story-body.js",
       "method": "serialize",
-      "startLine": 1009,
+      "startLine": 1090,
       "crap": 4
     },
     {
       "path": ".agents/scripts/lib/story-body/story-body.js",
       "method": "extractChangePaths",
-      "startLine": 1045,
+      "startLine": 1126,
       "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/story-body/story-body.js",
+      "method": "<anon method-23>",
+      "startLine": 1128,
+      "crap": 4
     },
     {
       "path": ".agents/scripts/lib/story-lifecycle.js",
       "method": "resolveStoryHierarchy",
-      "startLine": 29,
+      "startLine": 38,
       "crap": 3
     },
     {
       "path": ".agents/scripts/lib/story-lifecycle.js",
       "method": "fetchChildTickets",
-      "startLine": 64,
+      "startLine": 72,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/story-lifecycle.js",
       "method": "isRetryableError",
-      "startLine": 76,
+      "startLine": 84,
       "crap": 9
     },
     {
       "path": ".agents/scripts/lib/story-lifecycle.js",
       "method": "batchTransitionTickets",
-      "startLine": 111,
-      "crap": 2.00007289692375
+      "startLine": 119,
+      "crap": 2.0005831753899987
     },
     {
       "path": ".agents/scripts/lib/story-lifecycle.js",
       "method": "<anon method-1>",
-      "startLine": 126,
-      "crap": 9.00460855712335
+      "startLine": 134,
+      "crap": 9.0368684569868
     },
     {
       "path": ".agents/scripts/lib/story-lifecycle.js",
       "method": "<anon method-2>",
-      "startLine": 166,
+      "startLine": 174,
       "crap": 1
     },
     {
@@ -10900,6 +19667,12 @@
       "method": "rankDuplicateCandidates",
       "startLine": 54,
       "crap": 8.014247154743023
+    },
+    {
+      "path": ".agents/scripts/lib/story-plan.js",
+      "method": "<anon method-1>",
+      "startLine": 84,
+      "crap": 1.0002226117928597
     },
     {
       "path": ".agents/scripts/lib/story-plan.js",
@@ -10946,14 +19719,20 @@
     {
       "path": ".agents/scripts/lib/templates/decomposer-prompts.js",
       "method": "renderDecomposerSystemPrompt",
-      "startLine": 37,
+      "startLine": 28,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/templates/decomposer-prompts.js",
       "method": "render2TierPrompt",
-      "startLine": 51,
-      "crap": 2
+      "startLine": 40,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/templates/decomposer-prompts.js",
+      "method": "<anon method-1>",
+      "startLine": 73,
+      "crap": 1
     },
     {
       "path": ".agents/scripts/lib/templates/spec-author-prompts.js",
@@ -10969,9 +19748,27 @@
     },
     {
       "path": ".agents/scripts/lib/test-env.js",
+      "method": "_clearTestScratchTempRootCache",
+      "startLine": 18,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/test-env.js",
+      "method": "ensureTestScratchTempRoot",
+      "startLine": 42,
+      "crap": 5
+    },
+    {
+      "path": ".agents/scripts/lib/test-env.js",
       "method": "buildWebhookSafeTestEnv",
-      "startLine": 24,
+      "startLine": 98,
       "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/test-env.js",
+      "method": "<anon method-1>",
+      "startLine": 100,
+      "crap": 1
     },
     {
       "path": ".agents/scripts/lib/test-isolate/list-files.js",
@@ -10998,6 +19795,30 @@
       "crap": 1
     },
     {
+      "path": ".agents/scripts/lib/test-isolate/list-files.js",
+      "method": "<anon method-2>",
+      "startLine": 60,
+      "crap": 1.0233236151603498
+    },
+    {
+      "path": ".agents/scripts/lib/test-isolate/list-files.js",
+      "method": "<anon method-3>",
+      "startLine": 75,
+      "crap": 1.0233236151603498
+    },
+    {
+      "path": ".agents/scripts/lib/test-isolate/list-files.js",
+      "method": "<anon method-4>",
+      "startLine": 80,
+      "crap": 1.0233236151603498
+    },
+    {
+      "path": ".agents/scripts/lib/test-isolate/list-files.js",
+      "method": "<anon method-5>",
+      "startLine": 89,
+      "crap": 1.0233236151603498
+    },
+    {
       "path": ".agents/scripts/lib/test-isolate/parse-tap.js",
       "method": "parseSuiteTap",
       "startLine": 15,
@@ -11013,6 +19834,36 @@
       "path": ".agents/scripts/lib/test-isolate/runner.js",
       "method": "runFileIsolated",
       "startLine": 61,
+      "crap": 1.0000480841472577
+    },
+    {
+      "path": ".agents/scripts/lib/test-isolate/runner.js",
+      "method": "<anon method-1>",
+      "startLine": 68,
+      "crap": 4.000769346356123
+    },
+    {
+      "path": ".agents/scripts/lib/test-isolate/runner.js",
+      "method": "<anon method-2>",
+      "startLine": 93,
+      "crap": 1.0000480841472577
+    },
+    {
+      "path": ".agents/scripts/lib/test-isolate/runner.js",
+      "method": "<anon method-3>",
+      "startLine": 96,
+      "crap": 1.0000480841472577
+    },
+    {
+      "path": ".agents/scripts/lib/test-isolate/runner.js",
+      "method": "<anon method-4>",
+      "startLine": 99,
+      "crap": 1.0000480841472577
+    },
+    {
+      "path": ".agents/scripts/lib/test-isolate/runner.js",
+      "method": "<anon method-5>",
+      "startLine": 102,
       "crap": 1.0000480841472577
     },
     {
@@ -11059,15 +19910,69 @@
     },
     {
       "path": ".agents/scripts/lib/test-isolate/runner.js",
+      "method": "<anon method-7>",
+      "startLine": 205,
+      "crap": 2.020501045553323
+    },
+    {
+      "path": ".agents/scripts/lib/test-isolate/runner.js",
+      "method": "<anon method-8>",
+      "startLine": 226,
+      "crap": 1.0051252613883308
+    },
+    {
+      "path": ".agents/scripts/lib/test-isolate/runner.js",
+      "method": "<anon method-9>",
+      "startLine": 229,
+      "crap": 1.0051252613883308
+    },
+    {
+      "path": ".agents/scripts/lib/test-isolate/runner.js",
+      "method": "<anon method-10>",
+      "startLine": 232,
+      "crap": 1.0051252613883308
+    },
+    {
+      "path": ".agents/scripts/lib/test-isolate/runner.js",
+      "method": "<anon method-11>",
+      "startLine": 235,
+      "crap": 1.0051252613883308
+    },
+    {
+      "path": ".agents/scripts/lib/test-isolate/runner.js",
+      "method": "<anon method-12>",
+      "startLine": 240,
+      "crap": 2.020501045553323
+    },
+    {
+      "path": ".agents/scripts/lib/test-isolate/runner.js",
       "method": "runIsolatedPool",
       "startLine": 269,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/test-isolate/runner.js",
+      "method": "<anon method-13>",
+      "startLine": 281,
+      "crap": 4
+    },
+    {
+      "path": ".agents/scripts/lib/test-isolate/runner.js",
       "method": "bisectFlipper",
       "startLine": 318,
       "crap": 8.669921875
+    },
+    {
+      "path": ".agents/scripts/lib/test-isolate/runner.js",
+      "method": "<anon method-14>",
+      "startLine": 339,
+      "crap": 1.010467529296875
+    },
+    {
+      "path": ".agents/scripts/lib/test-isolate/runner.js",
+      "method": "<anon method-15>",
+      "startLine": 357,
+      "crap": 1.010467529296875
     },
     {
       "path": ".agents/scripts/lib/test-isolate/runner.js",
@@ -11080,6 +19985,42 @@
       "method": "<anon method-16>",
       "startLine": 414,
       "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/test-isolate/runner.js",
+      "method": "<anon method-17>",
+      "startLine": 431,
+      "crap": 1.0049525145567242
+    },
+    {
+      "path": ".agents/scripts/lib/test-isolate/runner.js",
+      "method": "<anon method-18>",
+      "startLine": 432,
+      "crap": 1.0049525145567242
+    },
+    {
+      "path": ".agents/scripts/lib/test-isolate/runner.js",
+      "method": "<anon method-19>",
+      "startLine": 434,
+      "crap": 2.019810058226897
+    },
+    {
+      "path": ".agents/scripts/lib/test-isolate/runner.js",
+      "method": "<anon method-20>",
+      "startLine": 443,
+      "crap": 1.0049525145567242
+    },
+    {
+      "path": ".agents/scripts/lib/test-isolate/runner.js",
+      "method": "<anon method-21>",
+      "startLine": 458,
+      "crap": 4.079240232907588
+    },
+    {
+      "path": ".agents/scripts/lib/test-isolate/runner.js",
+      "method": "<anon method-22>",
+      "startLine": 465,
+      "crap": 1.0049525145567242
     },
     {
       "path": ".agents/scripts/lib/test-profile/parse-tap.js",
@@ -11100,6 +20041,12 @@
       "crap": 1
     },
     {
+      "path": ".agents/scripts/lib/test-profile/parse-tap.js",
+      "method": "<anon method-1>",
+      "startLine": 134,
+      "crap": 1
+    },
+    {
       "path": ".agents/scripts/lib/test-profile/render-report.js",
       "method": "renderProfileReport",
       "startLine": 8,
@@ -11108,20 +20055,44 @@
     {
       "path": ".agents/scripts/lib/test-tiers.js",
       "method": "walkTestFiles",
-      "startLine": 35,
+      "startLine": 60,
       "crap": 5
     },
     {
       "path": ".agents/scripts/lib/test-tiers.js",
       "method": "listTestFilesForTier",
-      "startLine": 58,
+      "startLine": 83,
       "crap": 3
     },
     {
       "path": ".agents/scripts/lib/test-tiers.js",
+      "method": "<anon method-1>",
+      "startLine": 84,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/test-tiers.js",
+      "method": "<anon method-2>",
+      "startLine": 90,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/test-tiers.js",
+      "method": "<anon method-3>",
+      "startLine": 95,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/test-tiers.js",
       "method": "parseTierArgv",
-      "startLine": 81,
+      "startLine": 104,
       "crap": 4
+    },
+    {
+      "path": ".agents/scripts/lib/test-tiers.js",
+      "method": "<anon method-4>",
+      "startLine": 115,
+      "crap": 2
     },
     {
       "path": ".agents/scripts/lib/ticket-body-sections.js",
@@ -11143,39 +20114,87 @@
     },
     {
       "path": ".agents/scripts/lib/ticket-body-sections.js",
-      "method": "extractTicketSection",
-      "startLine": 118,
-      "crap": 2
-    },
-    {
-      "path": ".agents/scripts/lib/ticket-body-sections.js",
       "method": "upsertTicketSection",
-      "startLine": 139,
+      "startLine": 125,
       "crap": 7
     },
     {
       "path": ".agents/scripts/lib/ticket-body-sections.js",
       "method": "stripTicketSection",
-      "startLine": 182,
+      "startLine": 168,
       "crap": 3
     },
     {
       "path": ".agents/scripts/lib/ticket-body-sections.js",
       "method": "hasTechSpecContent",
-      "startLine": 199,
+      "startLine": 185,
       "crap": 3
     },
     {
       "path": ".agents/scripts/lib/ticket-body-sections.js",
       "method": "sliceTicketBodyForDelivery",
-      "startLine": 239,
+      "startLine": 225,
       "crap": 8
     },
     {
       "path": ".agents/scripts/lib/ticket-body-sections.js",
+      "method": "<anon method-1>",
+      "startLine": 268,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/ticket-body-sections.js",
       "method": "stripPlanningArtifactsSection",
-      "startLine": 301,
+      "startLine": 287,
       "crap": 6
+    },
+    {
+      "path": ".agents/scripts/lib/transpile.js",
+      "method": "loadTypeScript",
+      "startLine": 13,
+      "crap": 3.182569496619083
+    },
+    {
+      "path": ".agents/scripts/lib/transpile.js",
+      "method": "resolveTsTranspilerVersion",
+      "startLine": 33,
+      "crap": 3.072
+    },
+    {
+      "path": ".agents/scripts/lib/transpile.js",
+      "method": "isTypeScriptPath",
+      "startLine": 39,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/transpile.js",
+      "method": "buildLineMapper",
+      "startLine": 72,
+      "crap": 1.0014927113702623
+    },
+    {
+      "path": ".agents/scripts/lib/transpile.js",
+      "method": "mapLine",
+      "startLine": 81,
+      "crap": 8.032768
+    },
+    {
+      "path": ".agents/scripts/lib/transpile.js",
+      "method": "transpileIfNeeded",
+      "startLine": 145,
+      "crap": 6.104956268221574
+    },
+    {
+      "path": ".agents/scripts/lib/transpile.js",
+      "method": "prepareSourceForScoring",
+      "startLine": 204,
+      "crap": 5
+    },
+    {
+      "path": ".agents/scripts/lib/transpile.js",
+      "method": "<anon method-1>",
+      "startLine": 205,
+      "crap": 1
     },
     {
       "path": ".agents/scripts/lib/util/concurrent-map.js",
@@ -11221,6 +20240,24 @@
     },
     {
       "path": ".agents/scripts/lib/util/phase-timer.js",
+      "method": "<anon method-1>",
+      "startLine": 81,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/util/phase-timer.js",
+      "method": "<anon method-2>",
+      "startLine": 94,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/util/phase-timer.js",
+      "method": "<anon method-3>",
+      "startLine": 100,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/util/phase-timer.js",
       "method": "closeCurrent",
       "startLine": 111,
       "crap": 2
@@ -11239,9 +20276,27 @@
     },
     {
       "path": ".agents/scripts/lib/util/phase-timer.js",
+      "method": "<anon method-4>",
+      "startLine": 145,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/util/phase-timer.js",
       "method": "snapshot",
       "startLine": 150,
       "crap": 3
+    },
+    {
+      "path": ".agents/scripts/lib/util/phase-timer.js",
+      "method": "<anon method-5>",
+      "startLine": 154,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/util/phase-timer.js",
+      "method": "<anon method-6>",
+      "startLine": 157,
+      "crap": 1
     },
     {
       "path": ".agents/scripts/lib/util/poll-loop.js",
@@ -11257,6 +20312,12 @@
     },
     {
       "path": ".agents/scripts/lib/util/poll-loop.js",
+      "method": "<anon method-1>",
+      "startLine": 74,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/util/poll-loop.js",
       "method": "<anon method-2>",
       "startLine": 79,
       "crap": 1
@@ -11268,64 +20329,202 @@
       "crap": 1
     },
     {
+      "path": ".agents/scripts/lib/util/with-timeout.js",
+      "method": "<anon method-1>",
+      "startLine": 22,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/util/with-timeout.js",
+      "method": "<anon method-2>",
+      "startLine": 23,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/util/with-timeout.js",
+      "method": "<anon method-3>",
+      "startLine": 29,
+      "crap": 1
+    },
+    {
       "path": ".agents/scripts/lib/validation-evidence.js",
       "method": "getEvidenceValidator",
-      "startLine": 62,
+      "startLine": 59,
       "crap": 2
     },
     {
       "path": ".agents/scripts/lib/validation-evidence.js",
       "method": "resolveOpts",
-      "startLine": 79,
+      "startLine": 76,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/validation-evidence.js",
+      "method": "<anon method-1>",
+      "startLine": 81,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/validation-evidence.js",
       "method": "requirePositiveInt",
-      "startLine": 88,
+      "startLine": 85,
       "crap": 5.404663923182442
     },
     {
       "path": ".agents/scripts/lib/validation-evidence.js",
       "method": "evidencePath",
-      "startLine": 117,
+      "startLine": 115,
       "crap": 3
     },
     {
       "path": ".agents/scripts/lib/validation-evidence.js",
       "method": "hashCommandConfig",
-      "startLine": 142,
+      "startLine": 148,
       "crap": 3
     },
     {
       "path": ".agents/scripts/lib/validation-evidence.js",
       "method": "emptyDoc",
-      "startLine": 151,
+      "startLine": 157,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/validation-evidence.js",
       "method": "loadEvidence",
-      "startLine": 171,
+      "startLine": 178,
       "crap": 4
     },
     {
       "path": ".agents/scripts/lib/validation-evidence.js",
       "method": "recordPass",
-      "startLine": 206,
-      "crap": 9.097521743736937
+      "startLine": 217,
+      "crap": 9.081
+    },
+    {
+      "path": ".agents/scripts/lib/validation-evidence.js",
+      "method": "<anon method-2>",
+      "startLine": 252,
+      "crap": 1.001
+    },
+    {
+      "path": ".agents/scripts/lib/validation-evidence.js",
+      "method": "<anon method-3>",
+      "startLine": 257,
+      "crap": 2.004
     },
     {
       "path": ".agents/scripts/lib/validation-evidence.js",
       "method": "shouldSkip",
-      "startLine": 267,
+      "startLine": 283,
       "crap": 13
     },
     {
       "path": ".agents/scripts/lib/validation-evidence.js",
+      "method": "<anon method-4>",
+      "startLine": 291,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/validation-evidence.js",
       "method": "forceClear",
-      "startLine": 307,
+      "startLine": 324,
       "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/wave-runner/live-probe.js",
+      "method": "deriveInFlightIds",
+      "startLine": 108,
+      "crap": 5
+    },
+    {
+      "path": ".agents/scripts/lib/wave-runner/live-probe.js",
+      "method": "deriveBlockedIds",
+      "startLine": 136,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/wave-runner/live-probe.js",
+      "method": "<anon method-1>",
+      "startLine": 138,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/wave-runner/live-probe.js",
+      "method": "<anon method-2>",
+      "startLine": 139,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/wave-runner/live-probe.js",
+      "method": "<anon method-3>",
+      "startLine": 140,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/wave-runner/live-probe.js",
+      "method": "<anon method-4>",
+      "startLine": 141,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/wave-runner/live-probe.js",
+      "method": "deriveForeignHeld",
+      "startLine": 171,
+      "crap": 6
+    },
+    {
+      "path": ".agents/scripts/lib/wave-runner/live-probe.js",
+      "method": "createProbeContext",
+      "startLine": 203,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/wave-runner/live-probe.js",
+      "method": "probeLiveState",
+      "startLine": 256,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/wave-runner/live-probe.js",
+      "method": "<anon method-5>",
+      "startLine": 275,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/wave-runner/live-probe.js",
+      "method": "<anon method-6>",
+      "startLine": 281,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/wave-runner/live-probe.js",
+      "method": "<anon method-7>",
+      "startLine": 284,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/wave-runner/live-probe.js",
+      "method": "<anon method-8>",
+      "startLine": 293,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/wave-runner/live-probe.js",
+      "method": "<anon method-9>",
+      "startLine": 303,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/wave-runner/live-probe.js",
+      "method": "projectInFlightLabels",
+      "startLine": 332,
+      "crap": 3
+    },
+    {
+      "path": ".agents/scripts/lib/wave-runner/live-probe.js",
+      "method": "validateProbeFlags",
+      "startLine": 363,
+      "crap": 10
     },
     {
       "path": ".agents/scripts/lib/wave-runner/ready-set.js",
@@ -11353,27 +20552,69 @@
     },
     {
       "path": ".agents/scripts/lib/wave-runner/ready-set.js",
+      "method": "isGlobPath",
+      "startLine": 167,
+      "crap": 3
+    },
+    {
+      "path": ".agents/scripts/lib/wave-runner/ready-set.js",
       "method": "storiesOverlap",
-      "startLine": 173,
-      "crap": 4
+      "startLine": 195,
+      "crap": 6
     },
     {
       "path": ".agents/scripts/lib/wave-runner/ready-set.js",
       "method": "selectReadySet",
-      "startLine": 227,
+      "startLine": 267,
       "crap": 14
+    },
+    {
+      "path": ".agents/scripts/lib/wave-runner/ready-set.js",
+      "method": "<anon method-2>",
+      "startLine": 308,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/wave-runner/ready-set.js",
+      "method": "<anon method-3>",
+      "startLine": 317,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/workers/combined-mi-crap-worker.js",
+      "method": "handleCombinedMiCrapWorkerMessage",
+      "startLine": 74,
+      "crap": 11
+    },
+    {
+      "path": ".agents/scripts/lib/workers/combined-mi-crap-worker.js",
+      "method": "<anon method-1>",
+      "startLine": 100,
+      "crap": 1
     },
     {
       "path": ".agents/scripts/lib/workers/crap-worker.js",
       "method": "handleCrapWorkerMessage",
-      "startLine": 60,
-      "crap": 13
+      "startLine": 66,
+      "crap": 11
+    },
+    {
+      "path": ".agents/scripts/lib/workers/crap-worker.js",
+      "method": "<anon method-1>",
+      "startLine": 107,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/workers/maintainability-report-worker.js",
+      "method": "reportFromSource",
+      "startLine": 54,
+      "crap": 2.9321802457897133
     },
     {
       "path": ".agents/scripts/lib/workers/maintainability-report-worker.js",
       "method": "handleMaintainabilityReportWorkerMessage",
-      "startLine": 41,
-      "crap": 7
+      "startLine": 77,
+      "crap": 12
     },
     {
       "path": ".agents/scripts/lib/workers/maintainability-worker.js",
@@ -11382,28 +20623,178 @@
       "crap": 7
     },
     {
+      "path": ".agents/scripts/lib/workflow-closure.js",
+      "method": "unquote",
+      "startLine": 99,
+      "crap": 6
+    },
+    {
+      "path": ".agents/scripts/lib/workflow-closure.js",
+      "method": "toPosix",
+      "startLine": 114,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/workflow-closure.js",
+      "method": "frontmatterBlock",
+      "startLine": 124,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/workflow-closure.js",
+      "method": "blockSequence",
+      "startLine": 137,
+      "crap": 5.091033227127902
+    },
+    {
+      "path": ".agents/scripts/lib/workflow-closure.js",
+      "method": "flowSequence",
+      "startLine": 157,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/workflow-closure.js",
+      "method": "<anon method-1>",
+      "startLine": 162,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/workflow-closure.js",
+      "method": "parseMandatoryReads",
+      "startLine": 173,
+      "crap": 4
+    },
+    {
+      "path": ".agents/scripts/lib/workflow-closure.js",
+      "method": "<anon method-2>",
+      "startLine": 175,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/workflow-closure.js",
+      "method": "parseLinkTargets",
+      "startLine": 189,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/workflow-closure.js",
+      "method": "resolveSpec",
+      "startLine": 208,
+      "crap": 5
+    },
+    {
+      "path": ".agents/scripts/lib/workflow-closure.js",
+      "method": "mandatoryEdges",
+      "startLine": 225,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/workflow-closure.js",
+      "method": "walkMandatory",
+      "startLine": 250,
+      "crap": 3
+    },
+    {
+      "path": ".agents/scripts/lib/workflow-closure.js",
+      "method": "walkReachable",
+      "startLine": 276,
+      "crap": 5
+    },
+    {
+      "path": ".agents/scripts/lib/workflow-closure.js",
+      "method": "listMarkdown",
+      "startLine": 301,
+      "crap": 3
+    },
+    {
+      "path": ".agents/scripts/lib/workflow-closure.js",
+      "method": "loadDocs",
+      "startLine": 324,
+      "crap": 1.0016283329940974
+    },
+    {
+      "path": ".agents/scripts/lib/workflow-closure.js",
+      "method": "isEntryPoint",
+      "startLine": 353,
+      "crap": 3
+    },
+    {
+      "path": ".agents/scripts/lib/workflow-closure.js",
+      "method": "toEntries",
+      "startLine": 366,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/workflow-closure.js",
+      "method": "<anon method-3>",
+      "startLine": 368,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/workflow-closure.js",
+      "method": "<anon method-4>",
+      "startLine": 369,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/workflow-closure.js",
+      "method": "sumBytes",
+      "startLine": 379,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/workflow-closure.js",
+      "method": "resolveWorkflowClosures",
+      "startLine": 402,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/workflow-closure.js",
+      "method": "<anon method-5>",
+      "startLine": 422,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/workflow-closure.js",
+      "method": "<anon method-6>",
+      "startLine": 425,
+      "crap": 1
+    },
+    {
       "path": ".agents/scripts/lib/workspace-provisioner.js",
       "method": "resolveWorkspaceFiles",
-      "startLine": 38,
+      "startLine": 54,
       "crap": 3
     },
     {
       "path": ".agents/scripts/lib/workspace-provisioner.js",
       "method": "invalidNameReason",
-      "startLine": 56,
+      "startLine": 72,
       "crap": 6
     },
     {
       "path": ".agents/scripts/lib/workspace-provisioner.js",
       "method": "provision",
-      "startLine": 77,
+      "startLine": 93,
       "crap": 10.048246903528808
     },
     {
       "path": ".agents/scripts/lib/workspace-provisioner.js",
       "method": "verify",
-      "startLine": 142,
+      "startLine": 158,
       "crap": 9.019775390625
+    },
+    {
+      "path": ".agents/scripts/lib/workspace-provisioner.js",
+      "method": "<anon method-1>",
+      "startLine": 175,
+      "crap": 1.000244140625
+    },
+    {
+      "path": ".agents/scripts/lib/workspace-provisioner.js",
+      "method": "<anon method-2>",
+      "startLine": 176,
+      "crap": 1.000244140625
     },
     {
       "path": ".agents/scripts/lib/worktree/bootstrapper.js",
@@ -11474,13 +20865,19 @@
     {
       "path": ".agents/scripts/lib/worktree/lifecycle/creation.js",
       "method": "ensure",
-      "startLine": 23,
-      "crap": 14.079913616377388
+      "startLine": 24,
+      "crap": 13.683075784342195
     },
     {
       "path": ".agents/scripts/lib/worktree/lifecycle/creation.js",
       "method": "<anon method-1>",
-      "startLine": 40,
+      "startLine": 41,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/worktree/lifecycle/creation.js",
+      "method": "<anon method-2>",
+      "startLine": 50,
       "crap": 2
     },
     {
@@ -11497,27 +20894,99 @@
     },
     {
       "path": ".agents/scripts/lib/worktree/lifecycle/force-drain.js",
+      "method": "<anon method-1>",
+      "startLine": 41,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/worktree/lifecycle/force-drain.js",
+      "method": "<anon method-2>",
+      "startLine": 41,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/worktree/lifecycle/force-drain.js",
       "method": "findHoldersInPath",
       "startLine": 66,
       "crap": 8.003251536859219
     },
     {
       "path": ".agents/scripts/lib/worktree/lifecycle/force-drain.js",
+      "method": "<anon method-3>",
+      "startLine": 111,
+      "crap": 3.0004572473708278
+    },
+    {
+      "path": ".agents/scripts/lib/worktree/lifecycle/force-drain.js",
+      "method": "<anon method-4>",
+      "startLine": 112,
+      "crap": 4.000812884214804
+    },
+    {
+      "path": ".agents/scripts/lib/worktree/lifecycle/force-drain.js",
+      "method": "computeProtectedPids",
+      "startLine": 132,
+      "crap": 8
+    },
+    {
+      "path": ".agents/scripts/lib/worktree/lifecycle/force-drain.js",
+      "method": "fetchProcessTable",
+      "startLine": 161,
+      "crap": 6.0703125
+    },
+    {
+      "path": ".agents/scripts/lib/worktree/lifecycle/force-drain.js",
+      "method": "<anon method-5>",
+      "startLine": 187,
+      "crap": 2.0078125
+    },
+    {
+      "path": ".agents/scripts/lib/worktree/lifecycle/force-drain.js",
+      "method": "<anon method-6>",
+      "startLine": 188,
+      "crap": 2.0078125
+    },
+    {
+      "path": ".agents/scripts/lib/worktree/lifecycle/force-drain.js",
       "method": "terminateHolders",
-      "startLine": 126,
-      "crap": 11.324181241426611
+      "startLine": 205,
+      "crap": 12.173371988865666
     },
     {
       "path": ".agents/scripts/lib/worktree/lifecycle/force-drain.js",
       "method": "forceDrainPendingCleanup",
-      "startLine": 178,
+      "startLine": 268,
       "crap": 7.05049989745429
+    },
+    {
+      "path": ".agents/scripts/lib/worktree/lifecycle/force-drain.js",
+      "method": "<anon method-7>",
+      "startLine": 297,
+      "crap": 1.0010306101521285
+    },
+    {
+      "path": ".agents/scripts/lib/worktree/lifecycle/force-drain.js",
+      "method": "<anon method-8>",
+      "startLine": 352,
+      "crap": 1.0010306101521285
+    },
+    {
+      "path": ".agents/scripts/lib/worktree/lifecycle/force-drain.js",
+      "method": "<anon method-9>",
+      "startLine": 352,
+      "crap": 1.0010306101521285
     },
     {
       "path": ".agents/scripts/lib/worktree/lifecycle/gc.js",
       "method": "gc",
       "startLine": 15,
       "crap": 5
+    },
+    {
+      "path": ".agents/scripts/lib/worktree/lifecycle/gc.js",
+      "method": "<anon method-1>",
+      "startLine": 16,
+      "crap": 1
     },
     {
       "path": ".agents/scripts/lib/worktree/lifecycle/merge-reachability.js",
@@ -11542,6 +21011,18 @@
       "method": "hasRebasedEquivalents",
       "startLine": 131,
       "crap": 4
+    },
+    {
+      "path": ".agents/scripts/lib/worktree/lifecycle/merge-reachability.js",
+      "method": "<anon method-1>",
+      "startLine": 136,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/worktree/lifecycle/merge-reachability.js",
+      "method": "<anon method-2>",
+      "startLine": 139,
+      "crap": 1
     },
     {
       "path": ".agents/scripts/lib/worktree/lifecycle/merge-reachability.js",
@@ -11575,8 +21056,26 @@
     },
     {
       "path": ".agents/scripts/lib/worktree/lifecycle/pending-cleanup.js",
+      "method": "<anon method-1>",
+      "startLine": 76,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/worktree/lifecycle/pending-cleanup.js",
+      "method": "<anon method-2>",
+      "startLine": 98,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/worktree/lifecycle/pending-cleanup.js",
       "method": "removePendingCleanup",
       "startLine": 101,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/worktree/lifecycle/pending-cleanup.js",
+      "method": "<anon method-3>",
+      "startLine": 103,
       "crap": 1
     },
     {
@@ -11636,146 +21135,176 @@
     {
       "path": ".agents/scripts/lib/worktree/lifecycle/reap.js",
       "method": "isSafeToRemove",
-      "startLine": 70,
+      "startLine": 63,
       "crap": 4
     },
     {
       "path": ".agents/scripts/lib/worktree/lifecycle/reap.js",
-      "method": "isStoryAlreadyMergedIntoEpic",
-      "startLine": 87,
-      "crap": 3
+      "method": "isBranchMergedIntoBase",
+      "startLine": 108,
+      "crap": 5.084375
+    },
+    {
+      "path": ".agents/scripts/lib/worktree/lifecycle/reap.js",
+      "method": "<anon method-1>",
+      "startLine": 123,
+      "crap": 1.003375
+    },
+    {
+      "path": ".agents/scripts/lib/worktree/lifecycle/reap.js",
+      "method": "<anon method-2>",
+      "startLine": 126,
+      "crap": 1.003375
     },
     {
       "path": ".agents/scripts/lib/worktree/lifecycle/reap.js",
       "method": "collectDirtyPaths",
-      "startLine": 103,
+      "startLine": 133,
       "crap": 2
     },
     {
       "path": ".agents/scripts/lib/worktree/lifecycle/reap.js",
+      "method": "<anon method-3>",
+      "startLine": 138,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/worktree/lifecycle/reap.js",
+      "method": "<anon method-4>",
+      "startLine": 140,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/worktree/lifecycle/reap.js",
       "method": "discardWorktreeChanges",
-      "startLine": 117,
+      "startLine": 147,
       "crap": 2
     },
     {
       "path": ".agents/scripts/lib/worktree/lifecycle/reap.js",
       "method": "fsRmWithRetry",
-      "startLine": 130,
-      "crap": 3
+      "startLine": 160,
+      "crap": 4.018661612479954
     },
     {
       "path": ".agents/scripts/lib/worktree/lifecycle/reap.js",
-      "method": "<anon method-3>",
-      "startLine": 143,
-      "crap": 1
+      "method": "<anon method-5>",
+      "startLine": 173,
+      "crap": 2
     },
     {
       "path": ".agents/scripts/lib/worktree/lifecycle/reap.js",
       "method": "classifyRemoveStderr",
-      "startLine": 150,
+      "startLine": 180,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/worktree/lifecycle/reap.js",
       "method": "finalizeGitWorktreeRemove",
-      "startLine": 161,
+      "startLine": 187,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/worktree/lifecycle/reap.js",
       "method": "handleRemoveFailure",
-      "startLine": 166,
-      "crap": 7
+      "startLine": 192,
+      "crap": 5
     },
     {
       "path": ".agents/scripts/lib/worktree/lifecycle/reap.js",
       "method": "runGitWorktreeRemoveLoop",
-      "startLine": 196,
+      "startLine": 213,
       "crap": 8
     },
     {
       "path": ".agents/scripts/lib/worktree/lifecycle/reap.js",
       "method": "tryForceRemoveFallback",
-      "startLine": 221,
-      "crap": 7.0066083379692845
+      "startLine": 238,
+      "crap": 7.006125
     },
     {
       "path": ".agents/scripts/lib/worktree/lifecycle/reap.js",
       "method": "tryStage15WindowsFsRm",
-      "startLine": 261,
-      "crap": 1.034114465085977
+      "startLine": 279,
+      "crap": 1.0314914710599212
     },
     {
       "path": ".agents/scripts/lib/worktree/lifecycle/reap.js",
       "method": "recordPendingCleanupSafe",
-      "startLine": 299,
+      "startLine": 318,
       "crap": 3.274658203125
     },
     {
       "path": ".agents/scripts/lib/worktree/lifecycle/reap.js",
       "method": "handleFsRmFailure",
-      "startLine": 316,
+      "startLine": 335,
       "crap": 5
     },
     {
       "path": ".agents/scripts/lib/worktree/lifecycle/reap.js",
       "method": "removeWorktreeWithRecovery",
-      "startLine": 366,
-      "crap": 6
+      "startLine": 387,
+      "crap": 8
     },
     {
       "path": ".agents/scripts/lib/worktree/lifecycle/reap.js",
       "method": "reapDeleteLocal",
-      "startLine": 430,
+      "startLine": 458,
       "crap": 6.036
     },
     {
       "path": ".agents/scripts/lib/worktree/lifecycle/reap.js",
       "method": "reapDeleteRemote",
-      "startLine": 441,
+      "startLine": 469,
       "crap": 6.141711619769646
     },
     {
       "path": ".agents/scripts/lib/worktree/lifecycle/reap.js",
       "method": "deleteBranchAfterReap",
-      "startLine": 461,
+      "startLine": 489,
       "crap": 3
     },
     {
       "path": ".agents/scripts/lib/worktree/lifecycle/reap.js",
       "method": "checkReapPreconditions",
-      "startLine": 468,
-      "crap": 6
+      "startLine": 496,
+      "crap": 4
+    },
+    {
+      "path": ".agents/scripts/lib/worktree/lifecycle/reap.js",
+      "method": "<anon method-6>",
+      "startLine": 503,
+      "crap": 1
     },
     {
       "path": ".agents/scripts/lib/worktree/lifecycle/reap.js",
       "method": "ensureSafeOrForceDiscard",
-      "startLine": 491,
-      "crap": 8.45304232804233
+      "startLine": 525,
+      "crap": 7.973424840856482
     },
     {
       "path": ".agents/scripts/lib/worktree/lifecycle/reap.js",
       "method": "escapeWorktreeCwd",
-      "startLine": 534,
+      "startLine": 574,
       "crap": 3.372
     },
     {
       "path": ".agents/scripts/lib/worktree/lifecycle/reap.js",
       "method": "postRemoveBeltSweep",
-      "startLine": 545,
+      "startLine": 585,
       "crap": 3.2099125364431487
     },
     {
       "path": ".agents/scripts/lib/worktree/lifecycle/reap.js",
       "method": "buildReapSuccess",
-      "startLine": 560,
+      "startLine": 600,
       "crap": 5
     },
     {
       "path": ".agents/scripts/lib/worktree/lifecycle/reap.js",
       "method": "reap",
-      "startLine": 572,
-      "crap": 4.149292899839627
+      "startLine": 612,
+      "crap": 8.442284850448116
     },
     {
       "path": ".agents/scripts/lib/worktree/lifecycle/registry-sync.js",
@@ -11799,6 +21328,12 @@
       "path": ".agents/scripts/lib/worktree/lifecycle/registry-sync.js",
       "method": "findByPath",
       "startLine": 78,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/worktree/lifecycle/registry-sync.js",
+      "method": "<anon method-1>",
+      "startLine": 80,
       "crap": 1
     },
     {
@@ -11833,6 +21368,12 @@
     },
     {
       "path": ".agents/scripts/lint-issue-body.js",
+      "method": "<anon method-1>",
+      "startLine": 62,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lint-issue-body.js",
       "method": "evaluateIssueBody",
       "startLine": 86,
       "crap": 10.799999999999999
@@ -11842,6 +21383,18 @@
       "method": "renderConformanceComment",
       "startLine": 154,
       "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lint-issue-body.js",
+      "method": "<anon method-2>",
+      "startLine": 163,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lint-issue-body.js",
+      "method": "<anon method-3>",
+      "startLine": 173,
+      "crap": 1
     },
     {
       "path": ".agents/scripts/lint-issue-body.js",
@@ -11863,182 +21416,572 @@
     },
     {
       "path": ".agents/scripts/lint-issue-body.js",
+      "method": "<anon method-4>",
+      "startLine": 241,
+      "crap": 1.0000102736911318
+    },
+    {
+      "path": ".agents/scripts/lint-issue-body.js",
       "method": "main",
       "startLine": 275,
       "crap": 6
     },
     {
+      "path": ".agents/scripts/lint-issue-body.js",
+      "method": "<anon method-5>",
+      "startLine": 277,
+      "crap": 6
+    },
+    {
       "path": ".agents/scripts/lint-label-vocabulary.js",
       "method": "walkMd",
-      "startLine": 79,
+      "startLine": 78,
       "crap": 5.325666598819459
     },
     {
       "path": ".agents/scripts/lint-label-vocabulary.js",
       "method": "resolveTargets",
-      "startLine": 102,
+      "startLine": 101,
       "crap": 7.084672
     },
     {
       "path": ".agents/scripts/lint-label-vocabulary.js",
       "method": "findVocabularyViolations",
-      "startLine": 141,
+      "startLine": 140,
       "crap": 6
     },
     {
       "path": ".agents/scripts/lint-label-vocabulary.js",
       "method": "lintLabelVocabulary",
-      "startLine": 204,
+      "startLine": 203,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lint-label-vocabulary.js",
       "method": "main",
-      "startLine": 218,
+      "startLine": 217,
       "crap": 2.2560000000000002
+    },
+    {
+      "path": ".agents/scripts/mandrel-update-preflight.js",
+      "method": "makeProbes",
+      "startLine": 61,
+      "crap": 5.793145529258664
+    },
+    {
+      "path": ".agents/scripts/mandrel-update-preflight.js",
+      "method": "runMandrelUpdatePreflight",
+      "startLine": 131,
+      "crap": 10
+    },
+    {
+      "path": ".agents/scripts/mandrel-update-preflight.js",
+      "method": "<anon method-1>",
+      "startLine": 183,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/mandrel-update-preflight.js",
+      "method": "reportPreflight",
+      "startLine": 194,
+      "crap": 5
+    },
+    {
+      "path": ".agents/scripts/mandrel-update-preflight.js",
+      "method": "main",
+      "startLine": 220,
+      "crap": 6
+    },
+    {
+      "path": ".agents/scripts/nav-registry-diff.js",
+      "method": "normalizePath",
+      "startLine": 89,
+      "crap": 21.748046875
+    },
+    {
+      "path": ".agents/scripts/nav-registry-diff.js",
+      "method": "segmentsOf",
+      "startLine": 104,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/nav-registry-diff.js",
+      "method": "isDynamicSegment",
+      "startLine": 116,
+      "crap": 30.1171875
+    },
+    {
+      "path": ".agents/scripts/nav-registry-diff.js",
+      "method": "isCatchAllSegment",
+      "startLine": 126,
+      "crap": 6
+    },
+    {
+      "path": ".agents/scripts/nav-registry-diff.js",
+      "method": "isDynamicPath",
+      "startLine": 136,
+      "crap": 1.2962962962962963
+    },
+    {
+      "path": ".agents/scripts/nav-registry-diff.js",
+      "method": "isSystemRoute",
+      "startLine": 147,
+      "crap": 4.314814814814815
+    },
+    {
+      "path": ".agents/scripts/nav-registry-diff.js",
+      "method": "parentPath",
+      "startLine": 161,
+      "crap": 4.048
+    },
+    {
+      "path": ".agents/scripts/nav-registry-diff.js",
+      "method": "routeTemplateMatchesHref",
+      "startLine": 177,
+      "crap": 35.269333333333336
+    },
+    {
+      "path": ".agents/scripts/nav-registry-diff.js",
+      "method": "toRoute",
+      "startLine": 202,
+      "crap": 16.584433318161132
+    },
+    {
+      "path": ".agents/scripts/nav-registry-diff.js",
+      "method": "<anon method-1>",
+      "startLine": 211,
+      "crap": 5.146108329540283
+    },
+    {
+      "path": ".agents/scripts/nav-registry-diff.js",
+      "method": "toDoor",
+      "startLine": 223,
+      "crap": 25.01639941690962
+    },
+    {
+      "path": ".agents/scripts/nav-registry-diff.js",
+      "method": "doorSurfacesRoute",
+      "startLine": 249,
+      "crap": 30
+    },
+    {
+      "path": ".agents/scripts/nav-registry-diff.js",
+      "method": "orphanExemption",
+      "startLine": 268,
+      "crap": 42
+    },
+    {
+      "path": ".agents/scripts/nav-registry-diff.js",
+      "method": "computeNavDiff",
+      "startLine": 293,
+      "crap": 28.29606198196385
+    },
+    {
+      "path": ".agents/scripts/nav-registry-diff.js",
+      "method": "<anon method-2>",
+      "startLine": 296,
+      "crap": 1.931842479278554
+    },
+    {
+      "path": ".agents/scripts/nav-registry-diff.js",
+      "method": "<anon method-3>",
+      "startLine": 301,
+      "crap": 1.931842479278554
+    },
+    {
+      "path": ".agents/scripts/nav-registry-diff.js",
+      "method": "<anon method-4>",
+      "startLine": 322,
+      "crap": 5.727369917114216
+    },
+    {
+      "path": ".agents/scripts/nav-registry-diff.js",
+      "method": "readJsonArray",
+      "startLine": 345,
+      "crap": 12
+    },
+    {
+      "path": ".agents/scripts/nav-registry-diff.js",
+      "method": "formatDiffText",
+      "startLine": 380,
+      "crap": 10.774538386783284
+    },
+    {
+      "path": ".agents/scripts/nav-registry-diff.js",
+      "method": "main",
+      "startLine": 406,
+      "crap": 72
+    },
+    {
+      "path": ".agents/scripts/plan-context.js",
+      "method": "parseTicketIds",
+      "startLine": 75,
+      "crap": 17.18359375
+    },
+    {
+      "path": ".agents/scripts/plan-context.js",
+      "method": "<anon method-1>",
+      "startLine": 81,
+      "crap": 1.823974609375
+    },
+    {
+      "path": ".agents/scripts/plan-context.js",
+      "method": "<anon method-2>",
+      "startLine": 83,
+      "crap": 1.823974609375
+    },
+    {
+      "path": ".agents/scripts/plan-context.js",
+      "method": "<anon method-3>",
+      "startLine": 84,
+      "crap": 5.2958984375
+    },
+    {
+      "path": ".agents/scripts/plan-context.js",
+      "method": "parseAmendsId",
+      "startLine": 98,
+      "crap": 5
+    },
+    {
+      "path": ".agents/scripts/plan-context.js",
+      "method": "emitPlanContext",
+      "startLine": 118,
+      "crap": 5
+    },
+    {
+      "path": ".agents/scripts/plan-context.js",
+      "method": "<anon method-4>",
+      "startLine": 165,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/plan-context.js",
+      "method": "writeEnvelopeFile",
+      "startLine": 204,
+      "crap": 1.037037037037037
+    },
+    {
+      "path": ".agents/scripts/plan-context.js",
+      "method": "writeStoriesTemplateFile",
+      "startLine": 232,
+      "crap": 1.008
+    },
+    {
+      "path": ".agents/scripts/plan-context.js",
+      "method": "main",
+      "startLine": 253,
+      "crap": 15.78350546929221
+    },
+    {
+      "path": ".agents/scripts/plan-context.js",
+      "method": "<anon method-5>",
+      "startLine": 329,
+      "crap": 4.632529648832028
+    },
+    {
+      "path": ".agents/scripts/plan-critics.js",
+      "method": "collectPackageIdentity",
+      "startLine": 80,
+      "crap": 4
+    },
+    {
+      "path": ".agents/scripts/plan-critics.js",
+      "method": "readJsonIfPresent",
+      "startLine": 91,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/plan-critics.js",
+      "method": "workspacePatterns",
+      "startLine": 100,
+      "crap": 3
+    },
+    {
+      "path": ".agents/scripts/plan-critics.js",
+      "method": "resolveWorkspaceManifestPaths",
+      "startLine": 116,
+      "crap": 4.010520259718912
+    },
+    {
+      "path": ".agents/scripts/plan-critics.js",
+      "method": "collectRepoPackages",
+      "startLine": 150,
+      "crap": 3
+    },
+    {
+      "path": ".agents/scripts/plan-critics.js",
+      "method": "loadCriticArtifacts",
+      "startLine": 172,
+      "crap": 3
+    },
+    {
+      "path": ".agents/scripts/plan-critics.js",
+      "method": "recordCriticSkips",
+      "startLine": 204,
+      "crap": 5
+    },
+    {
+      "path": ".agents/scripts/plan-critics.js",
+      "method": "evaluateCriticArtifacts",
+      "startLine": 267,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/plan-critics.js",
+      "method": "main",
+      "startLine": 288,
+      "crap": 3
     },
     {
       "path": ".agents/scripts/plan-persist.js",
       "method": "readOptional",
-      "startLine": 87,
+      "startLine": 138,
       "crap": 12
     },
     {
       "path": ".agents/scripts/plan-persist.js",
       "method": "readJsonFile",
-      "startLine": 96,
+      "startLine": 147,
       "crap": 2
     },
     {
       "path": ".agents/scripts/plan-persist.js",
       "method": "resolveInputPaths",
-      "startLine": 107,
-      "crap": 20
+      "startLine": 164,
+      "crap": 4
     },
     {
       "path": ".agents/scripts/plan-persist.js",
       "method": "loadArtifacts",
-      "startLine": 121,
+      "startLine": 179,
       "crap": 12
     },
     {
       "path": ".agents/scripts/plan-persist.js",
       "method": "buildPersistOptions",
-      "startLine": 134,
+      "startLine": 211,
       "crap": 2
     },
     {
       "path": ".agents/scripts/plan-persist.js",
       "method": "runPersistInvocation",
-      "startLine": 146,
-      "crap": 6
+      "startLine": 236,
+      "crap": 3
+    },
+    {
+      "path": ".agents/scripts/plan-persist.js",
+      "method": "<anon method-1>",
+      "startLine": 260,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/plan-persist.js",
+      "method": "runPersistChain",
+      "startLine": 299,
+      "crap": 2
     },
     {
       "path": ".agents/scripts/plan-persist.js",
       "method": "attachPlanMetrics",
-      "startLine": 172,
+      "startLine": 363,
       "crap": 6
     },
     {
       "path": ".agents/scripts/plan-persist.js",
       "method": "main",
-      "startLine": 184,
-      "crap": 8.740740740740742
+      "startLine": 377,
+      "crap": 8.593024511391858
+    },
+    {
+      "path": ".agents/scripts/plan-run-epilogue.js",
+      "method": "main",
+      "startLine": 32,
+      "crap": 39.60081705484598
+    },
+    {
+      "path": ".agents/scripts/plan-run-epilogue.js",
+      "method": "<anon method-1>",
+      "startLine": 56,
+      "crap": 1.9333560293012773
+    },
+    {
+      "path": ".agents/scripts/plan-run-epilogue.js",
+      "method": "<anon method-2>",
+      "startLine": 57,
+      "crap": 5.733424117205109
+    },
+    {
+      "path": ".agents/scripts/plan-run-epilogue.js",
+      "method": "<anon method-3>",
+      "startLine": 59,
+      "crap": 1.9333560293012773
+    },
+    {
+      "path": ".agents/scripts/plan-run-epilogue.js",
+      "method": "warnOnUnresolvedBase",
+      "startLine": 89,
+      "crap": 6
+    },
+    {
+      "path": ".agents/scripts/plan-run-epilogue.js",
+      "method": "<anon method-4>",
+      "startLine": 91,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/plan-run-epilogue.js",
+      "method": "warnOnEmptyRollup",
+      "startLine": 122,
+      "crap": 6
+    },
+    {
+      "path": ".agents/scripts/plan-run-epilogue.js",
+      "method": "<anon method-5>",
+      "startLine": 124,
+      "crap": 2
     },
     {
       "path": ".agents/scripts/pr-watch-with-update.js",
       "method": "parsePositiveInt",
-      "startLine": 63,
+      "startLine": 64,
       "crap": 4
     },
     {
       "path": ".agents/scripts/pr-watch-with-update.js",
       "method": "resolveWatchKnobs",
-      "startLine": 81,
+      "startLine": 82,
       "crap": 1
     },
     {
       "path": ".agents/scripts/pr-watch-with-update.js",
       "method": "<anon method-1>",
-      "startLine": 83,
+      "startLine": 84,
       "crap": 3
     },
     {
       "path": ".agents/scripts/pr-watch-with-update.js",
       "method": "classifyFailure",
-      "startLine": 109,
-      "crap": 21.748046875
+      "startLine": 110,
+      "crap": 5.048828125
     },
     {
       "path": ".agents/scripts/pr-watch-with-update.js",
       "method": "ghRunLogTail",
-      "startLine": 125,
+      "startLine": 126,
       "crap": 12
     },
     {
       "path": ".agents/scripts/pr-watch-with-update.js",
       "method": "resolveRunId",
-      "startLine": 145,
+      "startLine": 146,
       "crap": 20
     },
     {
       "path": ".agents/scripts/pr-watch-with-update.js",
+      "method": "<anon method-2>",
+      "startLine": 155,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/pr-watch-with-update.js",
+      "method": "resolveDigestScope",
+      "startLine": 176,
+      "crap": 5
+    },
+    {
+      "path": ".agents/scripts/pr-watch-with-update.js",
       "method": "writeCiDigest",
-      "startLine": 180,
-      "crap": 6.0052485785099865
+      "startLine": 201,
+      "crap": 5
+    },
+    {
+      "path": ".agents/scripts/pr-watch-with-update.js",
+      "method": "<anon method-3>",
+      "startLine": 245,
+      "crap": 1
     },
     {
       "path": ".agents/scripts/pr-watch-with-update.js",
       "method": "runPrWatch",
-      "startLine": 266,
-      "crap": 14.341240913919147
+      "startLine": 287,
+      "crap": 14.333658062993122
+    },
+    {
+      "path": ".agents/scripts/pr-watch-with-update.js",
+      "method": "<anon method-4>",
+      "startLine": 370,
+      "crap": 1.0017023370560874
+    },
+    {
+      "path": ".agents/scripts/pr-watch-with-update.js",
+      "method": "<anon method-5>",
+      "startLine": 371,
+      "crap": 1.0017023370560874
+    },
+    {
+      "path": ".agents/scripts/pr-watch-with-update.js",
+      "method": "<anon method-6>",
+      "startLine": 389,
+      "crap": 4.027237392897398
+    },
+    {
+      "path": ".agents/scripts/pr-watch-with-update.js",
+      "method": "<anon method-7>",
+      "startLine": 395,
+      "crap": 1.0017023370560874
+    },
+    {
+      "path": ".agents/scripts/pr-watch-with-update.js",
+      "method": "<anon method-8>",
+      "startLine": 396,
+      "crap": 1.0017023370560874
     },
     {
       "path": ".agents/scripts/pr-watch-with-update.js",
       "method": "safeResolveConfig",
-      "startLine": 401,
+      "startLine": 423,
       "crap": 1.125
     },
     {
       "path": ".agents/scripts/pr-watch-with-update.js",
       "method": "main",
-      "startLine": 412,
+      "startLine": 434,
       "crap": 2
     },
     {
       "path": ".agents/scripts/providers/github.js",
       "method": "<anon method-1>",
-      "startLine": 136,
-      "crap": 1
-    },
-    {
-      "path": ".agents/scripts/providers/github.js",
-      "method": "<anon method-2>",
-      "startLine": 142,
-      "crap": 1
-    },
-    {
-      "path": ".agents/scripts/providers/github.js",
-      "method": "<anon method-3>",
-      "startLine": 145,
-      "crap": 1
-    },
-    {
-      "path": ".agents/scripts/providers/github.js",
-      "method": "<anon method-4>",
       "startLine": 148,
       "crap": 1
     },
     {
       "path": ".agents/scripts/providers/github.js",
+      "method": "<anon method-2>",
+      "startLine": 154,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/providers/github.js",
+      "method": "<anon method-3>",
+      "startLine": 157,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/providers/github.js",
+      "method": "<anon method-4>",
+      "startLine": 160,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/providers/github.js",
       "method": "<anon method-5>",
-      "startLine": 151,
+      "startLine": 163,
       "crap": 1
     },
     {
       "path": ".agents/scripts/providers/github.js",
       "method": "<anon method-6>",
-      "startLine": 154,
+      "startLine": 166,
       "crap": 1
     },
     {
@@ -12072,9 +22015,63 @@
       "crap": 3
     },
     {
+      "path": ".agents/scripts/providers/github/blocked-by-add.js",
+      "method": "fetchExistingBlockedBy",
+      "startLine": 44,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/providers/github/blocked-by-add.js",
+      "method": "<anon method-1>",
+      "startLine": 52,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/providers/github/blocked-by-add.js",
+      "method": "<anon method-2>",
+      "startLine": 52,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/providers/github/blocked-by-add.js",
+      "method": "addBlockedByEdges",
+      "startLine": 77,
+      "crap": 2.000203221053701
+    },
+    {
+      "path": ".agents/scripts/providers/github/blocked-by-add.js",
+      "method": "<anon method-3>",
+      "startLine": 99,
+      "crap": 1.0000508052634254
+    },
+    {
+      "path": ".agents/scripts/providers/github/blocked-by-add.js",
+      "method": "<anon method-4>",
+      "startLine": 104,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/providers/github/blocked-by-add.js",
+      "method": "applyBlockedByDependencies",
+      "startLine": 159,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/providers/github/blocked-by-add.js",
+      "method": "<anon method-5>",
+      "startLine": 179,
+      "crap": 7
+    },
+    {
+      "path": ".agents/scripts/providers/github/board-add.js",
+      "method": "addIssueToBoard",
+      "startLine": 37,
+      "crap": 7
+    },
+    {
       "path": ".agents/scripts/providers/github/branch-protection.js",
       "method": "isNotFoundError",
-      "startLine": 31,
+      "startLine": 32,
       "crap": 7
     },
     {
@@ -12110,13 +22107,13 @@
     {
       "path": ".agents/scripts/providers/github/compose.js",
       "method": "<anon method-3>",
-      "startLine": 45,
+      "startLine": 50,
       "crap": 1
     },
     {
       "path": ".agents/scripts/providers/github/compose.js",
       "method": "<anon method-4>",
-      "startLine": 51,
+      "startLine": 54,
       "crap": 1
     },
     {
@@ -12140,19 +22137,19 @@
     {
       "path": ".agents/scripts/providers/github/compose.js",
       "method": "<anon method-8>",
-      "startLine": 58,
+      "startLine": 62,
       "crap": 1
     },
     {
       "path": ".agents/scripts/providers/github/compose.js",
       "method": "<anon method-9>",
-      "startLine": 63,
+      "startLine": 70,
       "crap": 1
     },
     {
       "path": ".agents/scripts/providers/github/compose.js",
       "method": "<anon method-10>",
-      "startLine": 71,
+      "startLine": 78,
       "crap": 1
     },
     {
@@ -12176,7 +22173,7 @@
     {
       "path": ".agents/scripts/providers/github/compose.js",
       "method": "<anon method-14>",
-      "startLine": 82,
+      "startLine": 105,
       "crap": 1
     },
     {
@@ -12186,70 +22183,76 @@
       "crap": 1
     },
     {
-      "path": ".agents/scripts/providers/github/compose.js",
-      "method": "<anon method-16>",
-      "startLine": 107,
+      "path": ".agents/scripts/providers/github/errors.js",
+      "method": "isTransientNetworkError",
+      "startLine": 72,
       "crap": 1
     },
     {
       "path": ".agents/scripts/providers/github/errors.js",
       "method": "matchesAny",
-      "startLine": 51,
+      "startLine": 85,
       "crap": 2
     },
     {
       "path": ".agents/scripts/providers/github/errors.js",
       "method": "extractErrorFields",
-      "startLine": 62,
+      "startLine": 96,
       "crap": 4
     },
     {
       "path": ".agents/scripts/providers/github/errors.js",
       "method": "isTransientStatus",
-      "startLine": 72,
+      "startLine": 106,
       "crap": 3
     },
     {
       "path": ".agents/scripts/providers/github/errors.js",
       "method": "isTransientByCodeOrMessage",
-      "startLine": 78,
+      "startLine": 112,
       "crap": 2
     },
     {
       "path": ".agents/scripts/providers/github/errors.js",
       "method": "isPermissionSignal",
-      "startLine": 84,
+      "startLine": 118,
       "crap": 3
     },
     {
       "path": ".agents/scripts/providers/github/errors.js",
       "method": "classifyGithubError",
-      "startLine": 89,
-      "crap": 7
+      "startLine": 123,
+      "crap": 8
     },
     {
       "path": ".agents/scripts/providers/github/errors.js",
       "method": "withTransientRetry",
-      "startLine": 153,
+      "startLine": 204,
       "crap": 5.000762939453125
     },
     {
       "path": ".agents/scripts/providers/github/errors.js",
       "method": "<anon method-1>",
-      "startLine": 162,
+      "startLine": 213,
       "crap": 1
     },
     {
       "path": ".agents/scripts/providers/github/errors.js",
       "method": "<anon method-2>",
-      "startLine": 162,
+      "startLine": 213,
       "crap": 1
+    },
+    {
+      "path": ".agents/scripts/providers/github/issues.js",
+      "method": "classifySearchRetry",
+      "startLine": 46,
+      "crap": 6
     },
     {
       "path": ".agents/scripts/providers/github/labels.js",
       "method": "isLabelAlreadyExistsError",
-      "startLine": 35,
-      "crap": 8.162283996994741
+      "startLine": 37,
+      "crap": 8.110592
     },
     {
       "path": ".agents/scripts/providers/github/mappers.js",
@@ -12259,111 +22262,189 @@
     },
     {
       "path": ".agents/scripts/providers/github/mappers.js",
+      "method": "<anon method-1>",
+      "startLine": 18,
+      "crap": 1.0007513148009015
+    },
+    {
+      "path": ".agents/scripts/providers/github/mappers.js",
+      "method": "<anon method-2>",
+      "startLine": 21,
+      "crap": 2.0030052592036065
+    },
+    {
+      "path": ".agents/scripts/providers/github/mappers.js",
       "method": "issueToTicket",
       "startLine": 26,
       "crap": 1
     },
     {
       "path": ".agents/scripts/providers/github/mappers.js",
+      "method": "<anon method-3>",
+      "startLine": 36,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/providers/github/mappers.js",
       "method": "issueToEpic",
-      "startLine": 41,
+      "startLine": 46,
       "crap": 1
     },
     {
       "path": ".agents/scripts/providers/github/mappers.js",
       "method": "subIssueNodeToTicket",
-      "startLine": 54,
+      "startLine": 59,
       "crap": 3
     },
     {
       "path": ".agents/scripts/providers/github/mappers.js",
+      "method": "<anon method-4>",
+      "startLine": 77,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/providers/github/mappers.js",
       "method": "subIssueNodesToTickets",
-      "startLine": 89,
+      "startLine": 94,
       "crap": 3
     },
     {
       "path": ".agents/scripts/providers/github/mappers.js",
       "method": "issueToListItem",
-      "startLine": 99,
+      "startLine": 104,
       "crap": 1
     },
     {
       "path": ".agents/scripts/providers/github/projects-v2-graphql.js",
       "method": "<anon method-1>",
-      "startLine": 12,
+      "startLine": 17,
       "crap": 1
     },
     {
       "path": ".agents/scripts/providers/github/projects-v2-graphql.js",
       "method": "<anon method-2>",
-      "startLine": 24,
+      "startLine": 19,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/providers/github/projects-v2-graphql.js",
+      "method": "<anon method-3>",
+      "startLine": 29,
       "crap": 2
     },
     {
       "path": ".agents/scripts/providers/github/projects-v2-graphql.js",
       "method": "readGhCliToken",
-      "startLine": 31,
+      "startLine": 36,
       "crap": 6
     },
     {
       "path": ".agents/scripts/providers/github/projects-v2-graphql.js",
       "method": "readEnvToken",
-      "startLine": 44,
+      "startLine": 49,
       "crap": 12
     },
     {
       "path": ".agents/scripts/providers/github/projects-v2-graphql.js",
       "method": "memoizeEnvToken",
-      "startLine": 48,
+      "startLine": 53,
       "crap": 6
     },
     {
       "path": ".agents/scripts/providers/github/projects-v2-graphql.js",
       "method": "resolveToken",
-      "startLine": 52,
+      "startLine": 57,
       "crap": 12
     },
     {
       "path": ".agents/scripts/providers/github/projects-v2-graphql.js",
-      "method": "<anon method-3>",
-      "startLine": 65,
+      "method": "<anon method-4>",
+      "startLine": 70,
       "crap": 2
     },
     {
       "path": ".agents/scripts/providers/github/projects-v2-graphql.js",
-      "method": "<anon method-4>",
-      "startLine": 68,
+      "method": "<anon method-5>",
+      "startLine": 73,
       "crap": 3
     },
     {
       "path": ".agents/scripts/providers/github/projects-v2-graphql.js",
       "method": "gql",
-      "startLine": 71,
+      "startLine": 76,
+      "crap": 2.0018206645425582
+    },
+    {
+      "path": ".agents/scripts/providers/github/projects-v2-graphql.js",
+      "method": "<anon method-6>",
+      "startLine": 77,
       "crap": 3.0059176460918877
     },
     {
       "path": ".agents/scripts/providers/github/projects-v2-graphql.js",
+      "method": "<anon method-7>",
+      "startLine": 91,
+      "crap": 1.000657516232432
+    },
+    {
+      "path": ".agents/scripts/providers/github/projects-v2-graphql.js",
       "method": "lookupProject",
-      "startLine": 95,
-      "crap": 7
+      "startLine": 103,
+      "crap": 7.049
+    },
+    {
+      "path": ".agents/scripts/providers/github/projects-v2-graphql.js",
+      "method": "resolveOwnerId",
+      "startLine": 131,
+      "crap": 4.096168294515402
     },
     {
       "path": ".agents/scripts/providers/github/projects-v2-graphql.js",
       "method": "resolveOrCreateProject",
-      "startLine": 114,
-      "crap": 8.814814814814815
+      "startLine": 154,
+      "crap": 9.82608236288505
     },
     {
       "path": ".agents/scripts/providers/github/projects-v2-graphql.js",
       "method": "ensureStatusField",
-      "startLine": 160,
-      "crap": 7.135469483187809
+      "startLine": 199,
+      "crap": 7.100333137370175
     },
     {
       "path": ".agents/scripts/providers/github/projects-v2-graphql.js",
-      "method": "ensureProjectViews",
-      "startLine": 218,
-      "crap": 5
+      "method": "<anon method-8>",
+      "startLine": 217,
+      "crap": 1.0020476150483708
+    },
+    {
+      "path": ".agents/scripts/providers/github/projects-v2-graphql.js",
+      "method": "<anon method-9>",
+      "startLine": 227,
+      "crap": 1.0020476150483708
+    },
+    {
+      "path": ".agents/scripts/providers/github/projects-v2-graphql.js",
+      "method": "<anon method-10>",
+      "startLine": 238,
+      "crap": 1.0020476150483708
+    },
+    {
+      "path": ".agents/scripts/providers/github/projects-v2-graphql.js",
+      "method": "<anon method-11>",
+      "startLine": 240,
+      "crap": 1.0020476150483708
+    },
+    {
+      "path": ".agents/scripts/providers/github/projects-v2-graphql.js",
+      "method": "<anon method-12>",
+      "startLine": 244,
+      "crap": 1.0020476150483708
+    },
+    {
+      "path": ".agents/scripts/providers/github/projects-v2-graphql.js",
+      "method": "<anon method-13>",
+      "startLine": 247,
+      "crap": 1.0020476150483708
     },
     {
       "path": ".agents/scripts/providers/github/projects-v2-graphql.js",
@@ -12373,8 +22454,20 @@
     },
     {
       "path": ".agents/scripts/providers/github/projects-v2-graphql.js",
+      "method": "<anon method-14>",
+      "startLine": 271,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/providers/github/projects-v2-graphql.js",
+      "method": "<anon method-15>",
+      "startLine": 287,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/providers/github/projects-v2-graphql.js",
       "method": "addItemToProject",
-      "startLine": 291,
+      "startLine": 296,
       "crap": 3
     },
     {
@@ -12402,76 +22495,226 @@
       "crap": 1
     },
     {
-      "path": ".agents/scripts/providers/github/tickets.js",
-      "method": "composeStoryBody",
-      "startLine": 83,
-      "crap": 6
+      "path": ".agents/scripts/providers/github/search-budget.js",
+      "method": "createSearchBudget",
+      "startLine": 49,
+      "crap": 1.0291306326809286
+    },
+    {
+      "path": ".agents/scripts/providers/github/search-budget.js",
+      "method": "refill",
+      "startLine": 61,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/providers/github/search-budget.js",
+      "method": "take",
+      "startLine": 70,
+      "crap": 3.628332994097293
+    },
+    {
+      "path": ".agents/scripts/providers/github/search-budget.js",
+      "method": "noteRateLimited",
+      "startLine": 88,
+      "crap": 15.664000000000001
+    },
+    {
+      "path": ".agents/scripts/providers/github/search-budget.js",
+      "method": "parseRateLimitResetMs",
+      "startLine": 119,
+      "crap": 4.314814814814815
+    },
+    {
+      "path": ".agents/scripts/providers/github/search-query.js",
+      "method": "composeBoundedQuery",
+      "startLine": 33,
+      "crap": 4.0879299816812535
+    },
+    {
+      "path": ".agents/scripts/providers/github/search-query.js",
+      "method": "fitTokens",
+      "startLine": 61,
+      "crap": 12
     },
     {
       "path": ".agents/scripts/quality-preview.js",
       "method": "parseChangedSinceArg",
-      "startLine": 41,
+      "startLine": 65,
       "crap": 5
     },
     {
       "path": ".agents/scripts/quality-preview.js",
       "method": "parseJsonFlag",
-      "startLine": 60,
+      "startLine": 83,
       "crap": 1
     },
     {
       "path": ".agents/scripts/quality-preview.js",
       "method": "parseStagedFlag",
-      "startLine": 73,
+      "startLine": 96,
       "crap": 1
     },
     {
       "path": ".agents/scripts/quality-preview.js",
       "method": "mergeEnvelopes",
-      "startLine": 112,
+      "startLine": 135,
       "crap": 12
     },
     {
       "path": ".agents/scripts/quality-preview.js",
       "method": "<anon method-1>",
-      "startLine": 115,
+      "startLine": 138,
       "crap": 2
     },
     {
       "path": ".agents/scripts/quality-preview.js",
+      "method": "<anon method-2>",
+      "startLine": 180,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/quality-preview.js",
+      "method": "<anon method-3>",
+      "startLine": 181,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/quality-preview.js",
       "method": "computeExitCode",
-      "startLine": 187,
+      "startLine": 210,
       "crap": 6
     },
     {
       "path": ".agents/scripts/quality-preview.js",
       "method": "renderTable",
-      "startLine": 205,
+      "startLine": 228,
       "crap": 2
     },
     {
       "path": ".agents/scripts/quality-preview.js",
-      "method": "runCli",
-      "startLine": 246,
-      "crap": 7.100333137370175
-    },
-    {
-      "path": ".agents/scripts/resolve-plan-run.js",
-      "method": "writeEnvelope",
-      "startLine": 52,
-      "crap": 6
-    },
-    {
-      "path": ".agents/scripts/resolve-plan-run.js",
-      "method": "resolvePlanRunProvider",
-      "startLine": 68,
+      "method": "<anon method-4>",
+      "startLine": 237,
       "crap": 1
     },
     {
-      "path": ".agents/scripts/resolve-plan-run.js",
+      "path": ".agents/scripts/quality-preview.js",
+      "method": "runCli",
+      "startLine": 269,
+      "crap": 7.100333137370175
+    },
+    {
+      "path": ".agents/scripts/quality-preview.js",
+      "method": "<anon method-5>",
+      "startLine": 282,
+      "crap": 1.0020476150483708
+    },
+    {
+      "path": ".agents/scripts/quality-preview.js",
+      "method": "<anon method-6>",
+      "startLine": 288,
+      "crap": 1.0020476150483708
+    },
+    {
+      "path": ".agents/scripts/resolve-doc-tiers.js",
+      "method": "parseArgv",
+      "startLine": 31,
+      "crap": 36.013433747201304
+    },
+    {
+      "path": ".agents/scripts/resolve-doc-tiers.js",
+      "method": "runCli",
+      "startLine": 61,
+      "crap": 1.7865270823850707
+    },
+    {
+      "path": ".agents/scripts/resolve-doc-tiers.js",
       "method": "main",
-      "startLine": 76,
-      "crap": 20
+      "startLine": 75,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/resolve-stories.js",
+      "method": "resolveStoriesProvider",
+      "startLine": 78,
+      "crap": 1.6297376093294462
+    },
+    {
+      "path": ".agents/scripts/resolve-stories.js",
+      "method": "fetchStories",
+      "startLine": 94,
+      "crap": 1.003641329085116
+    },
+    {
+      "path": ".agents/scripts/resolve-stories.js",
+      "method": "<anon method-1>",
+      "startLine": 97,
+      "crap": 2.0932944606413995
+    },
+    {
+      "path": ".agents/scripts/resolve-stories.js",
+      "method": "readNativeEdges",
+      "startLine": 113,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/resolve-stories.js",
+      "method": "<anon method-2>",
+      "startLine": 116,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/resolve-stories.js",
+      "method": "resolveForeignDone",
+      "startLine": 143,
+      "crap": 2.055296
+    },
+    {
+      "path": ".agents/scripts/resolve-stories.js",
+      "method": "<anon method-3>",
+      "startLine": 146,
+      "crap": 1.013824
+    },
+    {
+      "path": ".agents/scripts/resolve-stories.js",
+      "method": "<anon method-4>",
+      "startLine": 146,
+      "crap": 1.013824
+    },
+    {
+      "path": ".agents/scripts/resolve-stories.js",
+      "method": "<anon method-5>",
+      "startLine": 152,
+      "crap": 2.5
+    },
+    {
+      "path": ".agents/scripts/resolve-stories.js",
+      "method": "<anon method-6>",
+      "startLine": 166,
+      "crap": 1.013824
+    },
+    {
+      "path": ".agents/scripts/resolve-stories.js",
+      "method": "main",
+      "startLine": 169,
+      "crap": 30
+    },
+    {
+      "path": ".agents/scripts/resolve-stories.js",
+      "method": "<anon method-7>",
+      "startLine": 207,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/resolve-stories.js",
+      "method": "<anon method-8>",
+      "startLine": 211,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/resolve-stories.js",
+      "method": "<anon method-9>",
+      "startLine": 223,
+      "crap": 2
     },
     {
       "path": ".agents/scripts/resync-status-column.js",
@@ -12495,19 +22738,43 @@
       "path": ".agents/scripts/resync-status-column.js",
       "method": "buildReassertOptions",
       "startLine": 124,
-      "crap": 3
+      "crap": 4
     },
     {
       "path": ".agents/scripts/resync-status-column.js",
       "method": "writeUsageErrors",
-      "startLine": 141,
+      "startLine": 145,
       "crap": 1
     },
     {
       "path": ".agents/scripts/resync-status-column.js",
       "method": "main",
-      "startLine": 148,
-      "crap": 11.036579789666211
+      "startLine": 152,
+      "crap": 11.06974307580175
+    },
+    {
+      "path": ".agents/scripts/run-coverage.js",
+      "method": "buildCoverageTestArgs",
+      "startLine": 71,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/run-coverage.js",
+      "method": "runCoveragePipeline",
+      "startLine": 86,
+      "crap": 12
+    },
+    {
+      "path": ".agents/scripts/run-coverage.js",
+      "method": "<anon method-1>",
+      "startLine": 100,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/run-coverage.js",
+      "method": "<anon method-2>",
+      "startLine": 104,
+      "crap": 2
     },
     {
       "path": ".agents/scripts/run-test-profile.js",
@@ -12530,13 +22797,13 @@
     {
       "path": ".agents/scripts/run-verify.js",
       "method": "runVerifySteps",
-      "startLine": 39,
+      "startLine": 68,
       "crap": 3.006761833208114
     },
     {
       "path": ".agents/scripts/run-verify.js",
       "method": "<anon method-1>",
-      "startLine": 64,
+      "startLine": 93,
       "crap": 3.1851851851851856
     },
     {
@@ -12565,6 +22832,12 @@
     },
     {
       "path": ".agents/scripts/signals-view.js",
+      "method": "<anon method-1>",
+      "startLine": 99,
+      "crap": 1.00393643388249
+    },
+    {
+      "path": ".agents/scripts/signals-view.js",
       "method": "formatDuration",
       "startLine": 153,
       "crap": 5
@@ -12583,6 +22856,12 @@
     },
     {
       "path": ".agents/scripts/signals-view.js",
+      "method": "<anon method-2>",
+      "startLine": 185,
+      "crap": 1.0013717421124828
+    },
+    {
+      "path": ".agents/scripts/signals-view.js",
       "method": "buildConfig",
       "startLine": 209,
       "crap": 2
@@ -12595,57 +22874,393 @@
     },
     {
       "path": ".agents/scripts/signals-view.js",
+      "method": "<anon method-3>",
+      "startLine": 264,
+      "crap": 1.0132051089406462
+    },
+    {
+      "path": ".agents/scripts/signals-view.js",
       "method": "<anon method-4>",
-      "startLine": 288,
+      "startLine": 287,
       "crap": 2.5
     },
     {
       "path": ".agents/scripts/single-story-close.js",
       "method": "runSingleStoryClose",
-      "startLine": 89,
+      "startLine": 129,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/single-story-close.js",
+      "method": "gatesForFailedPhase",
+      "startLine": 180,
+      "crap": 5
+    },
+    {
+      "path": ".agents/scripts/single-story-close.js",
+      "method": "failedTerminalFor",
+      "startLine": 210,
+      "crap": 12
+    },
+    {
+      "path": ".agents/scripts/single-story-close.js",
+      "method": "main",
+      "startLine": 232,
+      "crap": 6
+    },
+    {
+      "path": ".agents/scripts/single-story-confirm-merge.js",
+      "method": "readPrFlag",
+      "startLine": 95,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/single-story-confirm-merge.js",
+      "method": "readWaitFlag",
+      "startLine": 117,
+      "crap": 1.0046296296296295
+    },
+    {
+      "path": ".agents/scripts/single-story-confirm-merge.js",
+      "method": "readMaxWaitSecondsFlag",
+      "startLine": 143,
+      "crap": 3.0327719617660445
+    },
+    {
+      "path": ".agents/scripts/single-story-confirm-merge.js",
+      "method": "resolvePrNumber",
+      "startLine": 166,
+      "crap": 30
+    },
+    {
+      "path": ".agents/scripts/single-story-confirm-merge.js",
+      "method": "logConfirmResult",
+      "startLine": 193,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/single-story-confirm-merge.js",
+      "method": "buildConfirmTerminal",
+      "startLine": 227,
+      "crap": 17.012826302666397
+    },
+    {
+      "path": ".agents/scripts/single-story-confirm-merge.js",
+      "method": "resolveConfirmPrNumber",
+      "startLine": 296,
+      "crap": 5.390625
+    },
+    {
+      "path": ".agents/scripts/single-story-confirm-merge.js",
+      "method": "runConfirmMerge",
+      "startLine": 308,
+      "crap": 8.254695163749226
+    },
+    {
+      "path": ".agents/scripts/single-story-confirm-merge.js",
+      "method": "main",
+      "startLine": 504,
+      "crap": 20
+    },
+    {
+      "path": ".agents/scripts/stories-wave-tick.js",
+      "method": "inputErrorResult",
+      "startLine": 210,
       "crap": 1
     },
     {
       "path": ".agents/scripts/stories-wave-tick.js",
       "method": "parseDag",
-      "startLine": 68,
-      "crap": 12.226395160174576
+      "startLine": 239,
+      "crap": 15.160150555758017
     },
     {
       "path": ".agents/scripts/stories-wave-tick.js",
-      "method": "runStoriesWaveTick",
-      "startLine": 204,
+      "method": "<anon method-1>",
+      "startLine": 282,
+      "crap": 1.0007117802478134
+    },
+    {
+      "path": ".agents/scripts/stories-wave-tick.js",
+      "method": "parseIdCsv",
+      "startLine": 306,
+      "crap": 6
+    },
+    {
+      "path": ".agents/scripts/stories-wave-tick.js",
+      "method": "parseDoneIds",
+      "startLine": 332,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/stories-wave-tick.js",
+      "method": "parseInFlight",
+      "startLine": 343,
       "crap": 5
     },
     {
       "path": ".agents/scripts/stories-wave-tick.js",
-      "method": "main",
-      "startLine": 270,
+      "method": "parseConcurrencyOverride",
+      "startLine": 366,
+      "crap": 5
+    },
+    {
+      "path": ".agents/scripts/stories-wave-tick.js",
+      "method": "resolveConcurrencyCap",
+      "startLine": 397,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/stories-wave-tick.js",
+      "method": "buildReadySetEnvelope",
+      "startLine": 435,
+      "crap": 4
+    },
+    {
+      "path": ".agents/scripts/stories-wave-tick.js",
+      "method": "<anon method-2>",
+      "startLine": 475,
       "crap": 3
+    },
+    {
+      "path": ".agents/scripts/stories-wave-tick.js",
+      "method": "<anon method-3>",
+      "startLine": 495,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/stories-wave-tick.js",
+      "method": "detectWedge",
+      "startLine": 526,
+      "crap": 5
+    },
+    {
+      "path": ".agents/scripts/stories-wave-tick.js",
+      "method": "<anon method-4>",
+      "startLine": 528,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/stories-wave-tick.js",
+      "method": "<anon method-5>",
+      "startLine": 532,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/stories-wave-tick.js",
+      "method": "<anon method-6>",
+      "startLine": 534,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/stories-wave-tick.js",
+      "method": "<anon method-7>",
+      "startLine": 536,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/stories-wave-tick.js",
+      "method": "<anon method-8>",
+      "startLine": 544,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/stories-wave-tick.js",
+      "method": "<anon method-9>",
+      "startLine": 544,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/stories-wave-tick.js",
+      "method": "runStoriesWaveTick",
+      "startLine": 575,
+      "crap": 7
+    },
+    {
+      "path": ".agents/scripts/stories-wave-tick.js",
+      "method": "runProbedStoriesWaveTick",
+      "startLine": 678,
+      "crap": 6.000358049970349
+    },
+    {
+      "path": ".agents/scripts/stories-wave-tick.js",
+      "method": "<anon method-10>",
+      "startLine": 720,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/stories-wave-tick.js",
+      "method": "<anon method-11>",
+      "startLine": 745,
+      "crap": 1.0000099458325098
+    },
+    {
+      "path": ".agents/scripts/stories-wave-tick.js",
+      "method": "<anon method-12>",
+      "startLine": 747,
+      "crap": 1.0000099458325098
+    },
+    {
+      "path": ".agents/scripts/stories-wave-tick.js",
+      "method": "blockedReasonFor",
+      "startLine": 779,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/stories-wave-tick.js",
+      "method": "<anon method-13>",
+      "startLine": 781,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/stories-wave-tick.js",
+      "method": "foreignHeldReasonFor",
+      "startLine": 803,
+      "crap": 3
+    },
+    {
+      "path": ".agents/scripts/stories-wave-tick.js",
+      "method": "<anon method-14>",
+      "startLine": 806,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/stories-wave-tick.js",
+      "method": "main",
+      "startLine": 816,
+      "crap": 5.048828125
+    },
+    {
+      "path": ".agents/scripts/stories-wave-tick.js",
+      "method": "<anon method-15>",
+      "startLine": 881,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/story-plan.js",
+      "method": "resolveSeed",
+      "startLine": 69,
+      "crap": 5
+    },
+    {
+      "path": ".agents/scripts/story-plan.js",
+      "method": "fetchOpenStories",
+      "startLine": 85,
+      "crap": 3.820664542558033
+    },
+    {
+      "path": ".agents/scripts/story-plan.js",
+      "method": "<anon method-1>",
+      "startLine": 91,
+      "crap": 1.4551661356395083
+    },
+    {
+      "path": ".agents/scripts/story-plan.js",
+      "method": "renderGhArgv",
+      "startLine": 104,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/story-plan.js",
+      "method": "extractTitle",
+      "startLine": 116,
+      "crap": 2
     },
     {
       "path": ".agents/scripts/story-plan.js",
       "method": "runEmitContext",
-      "startLine": 120,
+      "startLine": 121,
       "crap": 4
+    },
+    {
+      "path": ".agents/scripts/story-plan.js",
+      "method": "runPersist",
+      "startLine": 183,
+      "crap": 6.275106436263461
+    },
+    {
+      "path": ".agents/scripts/story-plan.js",
+      "method": "main",
+      "startLine": 251,
+      "crap": 5.487881201638598
+    },
+    {
+      "path": ".agents/scripts/story-plan.js",
+      "method": "<anon method-2>",
+      "startLine": 288,
+      "crap": 1.0195152480655438
+    },
+    {
+      "path": ".agents/scripts/story-plan.js",
+      "method": "<anon method-3>",
+      "startLine": 295,
+      "crap": 1.0195152480655438
+    },
+    {
+      "path": ".agents/scripts/sync-agentrc.js",
+      "method": "parseArgs",
+      "startLine": 45,
+      "crap": 30
+    },
+    {
+      "path": ".agents/scripts/sync-agentrc.js",
+      "method": "main",
+      "startLine": 58,
+      "crap": 24.663177059626765
+    },
+    {
+      "path": ".agents/scripts/sync-agentrc.js",
+      "method": "trimAdvisories",
+      "startLine": 72,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/sync-agentrc.js",
+      "method": "<anon method-1>",
+      "startLine": 75,
+      "crap": 2
     },
     {
       "path": ".agents/scripts/sync-branch-from-base.js",
       "method": "runSyncBranchFromBase",
-      "startLine": 55,
-      "crap": 8.019943616435954
+      "startLine": 56,
+      "crap": 8.015625
     },
     {
       "path": ".agents/scripts/sync-branch-from-base.js",
       "method": "<anon method-1>",
-      "startLine": 92,
+      "startLine": 93,
       "crap": 1
     },
     {
       "path": ".agents/scripts/sync-branch-from-base.js",
       "method": "parseArgv",
-      "startLine": 119,
+      "startLine": 125,
       "crap": 1
+    },
+    {
+      "path": ".agents/scripts/sync-claude-agents.js",
+      "method": "dirExists",
+      "startLine": 77,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/sync-claude-agents.js",
+      "method": "<anon method-1>",
+      "startLine": 88,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/sync-claude-agents.js",
+      "method": "listExistingAgents",
+      "startLine": 121,
+      "crap": 1.0233236151603498
+    },
+    {
+      "path": ".agents/scripts/sync-claude-agents.js",
+      "method": "<anon method-4>",
+      "startLine": 123,
+      "crap": 1.0233236151603498
     },
     {
       "path": ".agents/scripts/sync-claude-commands.js",
@@ -12668,44 +23283,62 @@
     {
       "path": ".agents/scripts/sync-claude-commands.js",
       "method": "<anon method-2>",
-      "startLine": 164,
+      "startLine": 162,
       "crap": 2
     },
     {
       "path": ".agents/scripts/sync-claude-commands.js",
       "method": "enumerateLoopUnits",
-      "startLine": 177,
+      "startLine": 175,
       "crap": 2
     },
     {
       "path": ".agents/scripts/sync-claude-commands.js",
+      "method": "<anon method-3>",
+      "startLine": 181,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/sync-claude-commands.js",
       "method": "listExistingCommands",
-      "startLine": 228,
+      "startLine": 233,
       "crap": 2
     },
     {
-      "path": ".agents/scripts/update-maintainability-baseline.js",
-      "method": "parseFullScopeFlag",
-      "startLine": 53,
+      "path": ".agents/scripts/sync-claude-commands.js",
+      "method": "<anon method-6>",
+      "startLine": 236,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/sync-claude-commands.js",
+      "method": "<anon method-7>",
+      "startLine": 237,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/sync-claude-commands.js",
+      "method": "<anon method-8>",
+      "startLine": 242,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/sync-claude-commands.js",
+      "method": "<anon method-9>",
+      "startLine": 243,
       "crap": 1
     },
     {
       "path": ".agents/scripts/update-maintainability-baseline.js",
-      "method": "buildMaintainabilityScorer",
-      "startLine": 71,
-      "crap": 1.0690503885770157
-    },
-    {
-      "path": ".agents/scripts/update-maintainability-baseline.js",
-      "method": "maintainabilityScorer",
-      "startLine": 72,
-      "crap": 5.293822675853355
+      "method": "parseFullScopeFlag",
+      "startLine": 56,
+      "crap": 1
     },
     {
       "path": ".agents/scripts/update-maintainability-baseline.js",
       "method": "main",
-      "startLine": 111,
-      "crap": 8.71817344553685
+      "startLine": 60,
+      "crap": 8.951621501359146
     },
     {
       "path": ".agents/scripts/validate-skills.js",
@@ -12717,6 +23350,12 @@
       "path": ".agents/scripts/validate-skills.js",
       "method": "parseArgs",
       "startLine": 43,
+      "crap": 2.014565316340464
+    },
+    {
+      "path": ".agents/scripts/validate-skills.js",
+      "method": "<anon method-1>",
+      "startLine": 47,
       "crap": 2.014565316340464
     },
     {
@@ -12757,6 +23396,18 @@
     },
     {
       "path": ".agents/scripts/validate-skills.js",
+      "method": "<anon method-2>",
+      "startLine": 140,
+      "crap": 1.037037037037037
+    },
+    {
+      "path": ".agents/scripts/validate-skills.js",
+      "method": "<anon method-3>",
+      "startLine": 141,
+      "crap": 1.037037037037037
+    },
+    {
+      "path": ".agents/scripts/validate-skills.js",
       "method": "validateManifestSchema",
       "startLine": 160,
       "crap": 4.786458333333332
@@ -12781,6 +23432,12 @@
     },
     {
       "path": ".agents/scripts/validate-skills.js",
+      "method": "<anon method-4>",
+      "startLine": 262,
+      "crap": 1.046656
+    },
+    {
+      "path": ".agents/scripts/validate-skills.js",
       "method": "main",
       "startLine": 270,
       "crap": 2.0932944606413995
@@ -12788,31 +23445,37 @@
     {
       "path": "bin/mandrel.js",
       "method": "installedVersion",
-      "startLine": 109,
-      "crap": 1
-    },
-    {
-      "path": "bin/mandrel.js",
-      "method": "printHelp",
       "startLine": 120,
       "crap": 1
     },
     {
       "path": "bin/mandrel.js",
+      "method": "printHelp",
+      "startLine": 131,
+      "crap": 1
+    },
+    {
+      "path": "bin/mandrel.js",
       "method": "suggest",
-      "startLine": 141,
+      "startLine": 152,
       "crap": 2
     },
     {
       "path": "bin/mandrel.js",
       "method": "levenshtein",
-      "startLine": 156,
+      "startLine": 167,
       "crap": 6
     },
     {
       "path": "bin/mandrel.js",
+      "method": "<anon method-1>",
+      "startLine": 170,
+      "crap": 1
+    },
+    {
+      "path": "bin/mandrel.js",
       "method": "findUnknownFlag",
-      "startLine": 193,
+      "startLine": 204,
       "crap": 6
     },
     {
@@ -12842,37 +23505,43 @@
     {
       "path": "lib/cli/doctor.js",
       "method": "padName",
-      "startLine": 42,
+      "startLine": 46,
       "crap": 2
     },
     {
       "path": "lib/cli/doctor.js",
       "method": "formatResult",
-      "startLine": 56,
+      "startLine": 60,
       "crap": 4
     },
     {
       "path": "lib/cli/doctor.js",
       "method": "formatSummary",
-      "startLine": 73,
+      "startLine": 77,
+      "crap": 2
+    },
+    {
+      "path": "lib/cli/doctor.js",
+      "method": "formatClosureReport",
+      "startLine": 101,
       "crap": 2
     },
     {
       "path": "lib/cli/doctor.js",
       "method": "writeDoctorResultCache",
-      "startLine": 99,
+      "startLine": 137,
       "crap": 1
     },
     {
       "path": "lib/cli/doctor.js",
       "method": "runDoctor",
-      "startLine": 130,
+      "startLine": 169,
       "crap": 4
     },
     {
       "path": "lib/cli/doctor.js",
       "method": "run",
-      "startLine": 164,
+      "startLine": 208,
       "crap": 1.2962962962962963
     },
     {
@@ -12985,6 +23654,18 @@
     },
     {
       "path": "lib/cli/migrate.js",
+      "method": "<anon method-1>",
+      "startLine": 178,
+      "crap": 2.6576398454836854
+    },
+    {
+      "path": "lib/cli/migrate.js",
+      "method": "<anon method-2>",
+      "startLine": 182,
+      "crap": 1.1644099613709213
+    },
+    {
+      "path": "lib/cli/migrate.js",
       "method": "run",
       "startLine": 258,
       "crap": 1
@@ -12992,188 +23673,410 @@
     {
       "path": "lib/cli/registry.js",
       "method": "spawn",
-      "startLine": 52,
+      "startLine": 57,
       "crap": 12
     },
     {
       "path": "lib/cli/registry.js",
       "method": "runNodeVersion",
-      "startLine": 70,
+      "startLine": 75,
       "crap": 2
     },
     {
       "path": "lib/cli/registry.js",
       "method": "runGitAvailable",
-      "startLine": 89,
+      "startLine": 94,
       "crap": 6
     },
     {
       "path": "lib/cli/registry.js",
       "method": "runGhAvailable",
-      "startLine": 110,
+      "startLine": 115,
       "crap": 6
     },
     {
       "path": "lib/cli/registry.js",
       "method": "runGithubToken",
-      "startLine": 145,
+      "startLine": 150,
       "crap": 8
     },
     {
       "path": "lib/cli/registry.js",
       "method": "runGhAuth",
-      "startLine": 186,
+      "startLine": 191,
       "crap": 7.355275083078783
     },
     {
       "path": "lib/cli/registry.js",
       "method": "runCommandsInSync",
-      "startLine": 245,
-      "crap": 5.0633921863260705
+      "startLine": 263,
+      "crap": 8.0480841472577
+    },
+    {
+      "path": "lib/cli/registry.js",
+      "method": "<anon method-1>",
+      "startLine": 264,
+      "crap": 1.0007513148009015
+    },
+    {
+      "path": "lib/cli/registry.js",
+      "method": "<anon method-2>",
+      "startLine": 268,
+      "crap": 1.0007513148009015
+    },
+    {
+      "path": "lib/cli/registry.js",
+      "method": "<anon method-3>",
+      "startLine": 270,
+      "crap": 1.0007513148009015
+    },
+    {
+      "path": "lib/cli/registry.js",
+      "method": "<anon method-4>",
+      "startLine": 277,
+      "crap": 1.0007513148009015
+    },
+    {
+      "path": "lib/cli/registry.js",
+      "method": "<anon method-5>",
+      "startLine": 308,
+      "crap": 1.0007513148009015
+    },
+    {
+      "path": "lib/cli/registry.js",
+      "method": "<anon method-6>",
+      "startLine": 312,
+      "crap": 1.0007513148009015
+    },
+    {
+      "path": "lib/cli/registry.js",
+      "method": "<anon method-7>",
+      "startLine": 313,
+      "crap": 1.0007513148009015
+    },
+    {
+      "path": "lib/cli/registry.js",
+      "method": "readJsonSafe",
+      "startLine": 343,
+      "crap": 2
+    },
+    {
+      "path": "lib/cli/registry.js",
+      "method": "resolveRoleScopedAgentsFlag",
+      "startLine": 371,
+      "crap": 2
+    },
+    {
+      "path": "lib/cli/registry.js",
+      "method": "runAgentsInSync",
+      "startLine": 437,
+      "crap": 9.048883661021874
+    },
+    {
+      "path": "lib/cli/registry.js",
+      "method": "<anon method-8>",
+      "startLine": 444,
+      "crap": 1.0006035019879245
+    },
+    {
+      "path": "lib/cli/registry.js",
+      "method": "<anon method-9>",
+      "startLine": 448,
+      "crap": 1.0006035019879245
+    },
+    {
+      "path": "lib/cli/registry.js",
+      "method": "<anon method-10>",
+      "startLine": 450,
+      "crap": 1.0006035019879245
+    },
+    {
+      "path": "lib/cli/registry.js",
+      "method": "<anon method-11>",
+      "startLine": 460,
+      "crap": 1.0006035019879245
+    },
+    {
+      "path": "lib/cli/registry.js",
+      "method": "<anon method-12>",
+      "startLine": 463,
+      "crap": 1.0006035019879245
+    },
+    {
+      "path": "lib/cli/registry.js",
+      "method": "<anon method-13>",
+      "startLine": 491,
+      "crap": 1.0006035019879245
+    },
+    {
+      "path": "lib/cli/registry.js",
+      "method": "<anon method-14>",
+      "startLine": 492,
+      "crap": 1.0006035019879245
     },
     {
       "path": "lib/cli/registry.js",
       "method": "runRuntimeDeps",
-      "startLine": 315,
-      "crap": 6.276287301534021
+      "startLine": 534,
+      "crap": 5.9259259259259265
     },
     {
       "path": "lib/cli/registry.js",
       "method": "runAgentsMaterialized",
-      "startLine": 410,
+      "startLine": 636,
       "crap": 3.003525775888336
     },
     {
       "path": "lib/cli/registry.js",
+      "method": "<anon method-15>",
+      "startLine": 637,
+      "crap": 1.0003917528764819
+    },
+    {
+      "path": "lib/cli/registry.js",
+      "method": "<anon method-16>",
+      "startLine": 638,
+      "crap": 1.0003917528764819
+    },
+    {
+      "path": "lib/cli/registry.js",
+      "method": "<anon method-17>",
+      "startLine": 648,
+      "crap": 1.0003917528764819
+    },
+    {
+      "path": "lib/cli/registry.js",
+      "method": "payloadFileDrifted",
+      "startLine": 709,
+      "crap": 3
+    },
+    {
+      "path": "lib/cli/registry.js",
       "method": "runAgentsDrift",
-      "startLine": 486,
+      "startLine": 750,
       "crap": 5
     },
     {
       "path": "lib/cli/registry.js",
+      "method": "<anon method-18>",
+      "startLine": 751,
+      "crap": 1
+    },
+    {
+      "path": "lib/cli/registry.js",
+      "method": "runPinCurrent",
+      "startLine": 886,
+      "crap": 29.000120920774684
+    },
+    {
+      "path": "lib/cli/registry.js",
+      "method": "<anon method-19>",
+      "startLine": 887,
+      "crap": 1.9600048368309873
+    },
+    {
+      "path": "lib/cli/registry.js",
       "method": "defaultInstalledVersion",
-      "startLine": 572,
+      "startLine": 977,
       "crap": 1
     },
     {
       "path": "lib/cli/registry.js",
       "method": "defaultVersionCachePath",
-      "startLine": 593,
+      "startLine": 998,
       "crap": 2
     },
     {
       "path": "lib/cli/registry.js",
       "method": "runVersionCurrent",
-      "startLine": 632,
+      "startLine": 1037,
       "crap": 4
     },
     {
       "path": "lib/cli/registry.js",
-      "method": "<anon method-12>",
-      "startLine": 683,
-      "crap": 1
-    },
-    {
-      "path": "lib/cli/registry.js",
-      "method": "<anon method-13>",
-      "startLine": 687,
-      "crap": 1
-    },
-    {
-      "path": "lib/cli/registry.js",
-      "method": "<anon method-14>",
-      "startLine": 691,
-      "crap": 1
-    },
-    {
-      "path": "lib/cli/registry.js",
-      "method": "<anon method-15>",
-      "startLine": 695,
-      "crap": 1
-    },
-    {
-      "path": "lib/cli/registry.js",
-      "method": "<anon method-16>",
-      "startLine": 699,
-      "crap": 1
-    },
-    {
-      "path": "lib/cli/registry.js",
-      "method": "<anon method-17>",
-      "startLine": 703,
-      "crap": 1
-    },
-    {
-      "path": "lib/cli/registry.js",
-      "method": "<anon method-18>",
-      "startLine": 707,
-      "crap": 1
-    },
-    {
-      "path": "lib/cli/registry.js",
-      "method": "<anon method-19>",
-      "startLine": 711,
-      "crap": 1
-    },
-    {
-      "path": "lib/cli/registry.js",
       "method": "<anon method-20>",
-      "startLine": 715,
+      "startLine": 1088,
       "crap": 1
     },
     {
       "path": "lib/cli/registry.js",
       "method": "<anon method-21>",
-      "startLine": 722,
+      "startLine": 1092,
+      "crap": 1
+    },
+    {
+      "path": "lib/cli/registry.js",
+      "method": "<anon method-22>",
+      "startLine": 1096,
+      "crap": 1
+    },
+    {
+      "path": "lib/cli/registry.js",
+      "method": "<anon method-23>",
+      "startLine": 1100,
+      "crap": 1
+    },
+    {
+      "path": "lib/cli/registry.js",
+      "method": "<anon method-24>",
+      "startLine": 1104,
+      "crap": 1
+    },
+    {
+      "path": "lib/cli/registry.js",
+      "method": "<anon method-25>",
+      "startLine": 1108,
+      "crap": 1
+    },
+    {
+      "path": "lib/cli/registry.js",
+      "method": "<anon method-26>",
+      "startLine": 1112,
+      "crap": 1
+    },
+    {
+      "path": "lib/cli/registry.js",
+      "method": "<anon method-27>",
+      "startLine": 1116,
+      "crap": 1
+    },
+    {
+      "path": "lib/cli/registry.js",
+      "method": "<anon method-28>",
+      "startLine": 1120,
+      "crap": 1
+    },
+    {
+      "path": "lib/cli/registry.js",
+      "method": "<anon method-29>",
+      "startLine": 1124,
+      "crap": 1
+    },
+    {
+      "path": "lib/cli/registry.js",
+      "method": "<anon method-30>",
+      "startLine": 1131,
+      "crap": 1
+    },
+    {
+      "path": "lib/cli/registry.js",
+      "method": "<anon method-31>",
+      "startLine": 1138,
+      "crap": 1
+    },
+    {
+      "path": "lib/cli/sync-agents.js",
+      "method": "resolveOwnPackageVersion",
+      "startLine": 74,
+      "crap": 1
+    },
+    {
+      "path": "lib/cli/sync-agents.js",
+      "method": "run",
+      "startLine": 111,
+      "crap": 5
+    },
+    {
+      "path": "lib/cli/sync-agents.js",
+      "method": "<anon method-1>",
+      "startLine": 137,
+      "crap": 1
+    },
+    {
+      "path": "lib/cli/sync-commands.js",
+      "method": "resolveOwnPackageVersion",
+      "startLine": 75,
       "crap": 1
     },
     {
       "path": "lib/cli/sync-commands.js",
       "method": "run",
-      "startLine": 40,
+      "startLine": 113,
+      "crap": 5
+    },
+    {
+      "path": "lib/cli/sync-commands.js",
+      "method": "<anon method-1>",
+      "startLine": 139,
+      "crap": 1
+    },
+    {
+      "path": "lib/cli/sync.js",
+      "method": "toManagedZoneRelative",
+      "startLine": 116,
+      "crap": 4.125
+    },
+    {
+      "path": "lib/cli/sync.js",
+      "method": "resolvePackageVersion",
+      "startLine": 177,
+      "crap": 1
+    },
+    {
+      "path": "lib/cli/sync.js",
+      "method": "readVersionMarker",
+      "startLine": 193,
       "crap": 2
     },
     {
       "path": "lib/cli/sync.js",
       "method": "defaultResolvePackageRoot",
-      "startLine": 83,
+      "startLine": 217,
       "crap": 1
     },
     {
       "path": "lib/cli/sync.js",
       "method": "listFiles",
-      "startLine": 107,
+      "startLine": 241,
       "crap": 6
     },
     {
       "path": "lib/cli/sync.js",
       "method": "listDestFiles",
-      "startLine": 144,
-      "crap": 8.064
+      "startLine": 288,
+      "crap": 10.062973760932945
     },
     {
       "path": "lib/cli/sync.js",
       "method": "runSync",
-      "startLine": 195,
-      "crap": 4.006400933080624
+      "startLine": 344,
+      "crap": 4.004356551338718
+    },
+    {
+      "path": "lib/cli/sync.js",
+      "method": "<anon method-1>",
+      "startLine": 389,
+      "crap": 1.00027228445867
+    },
+    {
+      "path": "lib/cli/sync.js",
+      "method": "<anon method-2>",
+      "startLine": 419,
+      "crap": 1.00027228445867
     },
     {
       "path": "lib/cli/sync.js",
       "method": "run",
-      "startLine": 297,
+      "startLine": 459,
       "crap": 1
     },
     {
       "path": "lib/cli/uninstall.js",
       "method": "resolveProjectRoot",
       "startLine": 90,
-      "crap": 2
+      "crap": 1
     },
     {
       "path": "lib/cli/uninstall.js",
       "method": "revertClaudeMd",
       "startLine": 140,
       "crap": 7.3919999999999995
+    },
+    {
+      "path": "lib/cli/uninstall.js",
+      "method": "<anon method-1>",
+      "startLine": 169,
+      "crap": 1.008
     },
     {
       "path": "lib/cli/uninstall.js",
@@ -13189,9 +24092,33 @@
     },
     {
       "path": "lib/cli/uninstall.js",
+      "method": "<anon method-3>",
+      "startLine": 234,
+      "crap": 1.0001348640401895
+    },
+    {
+      "path": "lib/cli/uninstall.js",
+      "method": "<anon method-4>",
+      "startLine": 236,
+      "crap": 1.0001348640401895
+    },
+    {
+      "path": "lib/cli/uninstall.js",
+      "method": "<anon method-5>",
+      "startLine": 238,
+      "crap": 1.0001348640401895
+    },
+    {
+      "path": "lib/cli/uninstall.js",
       "method": "revertClaudeCommands",
       "startLine": 286,
       "crap": 2.055296
+    },
+    {
+      "path": "lib/cli/uninstall.js",
+      "method": "<anon method-6>",
+      "startLine": 294,
+      "crap": 1.013824
     },
     {
       "path": "lib/cli/uninstall.js",
@@ -13216,6 +24143,12 @@
       "method": "revertPreCommitHook",
       "startLine": 491,
       "crap": 4.03125
+    },
+    {
+      "path": "lib/cli/uninstall.js",
+      "method": "<anon method-7>",
+      "startLine": 514,
+      "crap": 1.001953125
     },
     {
       "path": "lib/cli/uninstall.js",
@@ -13245,7 +24178,7 @@
       "path": "lib/cli/uninstall.js",
       "method": "run",
       "startLine": 826,
-      "crap": 1.512
+      "crap": 1
     },
     {
       "path": "lib/cli/version-check.js",
@@ -13268,38 +24201,164 @@
     {
       "path": "lib/cli/version-helpers.js",
       "method": "parseVersion",
-      "startLine": 22,
+      "startLine": 34,
       "crap": 4
     },
     {
       "path": "lib/cli/version-helpers.js",
       "method": "compareVersions",
-      "startLine": 39,
+      "startLine": 51,
       "crap": 3
     },
     {
       "path": "lib/cli/version-helpers.js",
       "method": "crossesMajor",
-      "startLine": 57,
+      "startLine": 69,
       "crap": 1.2962962962962963
+    },
+    {
+      "path": "lib/cli/version-helpers.js",
+      "method": "satisfiesPinSpec",
+      "startLine": 98,
+      "crap": 60.734375
+    },
+    {
+      "path": "lib/cli/version-helpers.js",
+      "method": "resolveConsumerPinSpec",
+      "startLine": 135,
+      "crap": 3.0052083333333335
+    },
+    {
+      "path": "lib/cli/version-helpers.js",
+      "method": "resolveConsumerPinVersion",
+      "startLine": 188,
+      "crap": 1
     },
     {
       "path": "lib/migrations/index.js",
       "method": "parseVersion",
-      "startLine": 75,
+      "startLine": 86,
       "crap": 4
     },
     {
       "path": "lib/migrations/index.js",
       "method": "compareVersions",
-      "startLine": 93,
+      "startLine": 104,
       "crap": 3.017578125
     },
     {
       "path": "lib/migrations/index.js",
       "method": "runMigrations",
-      "startLine": 133,
+      "startLine": 144,
       "crap": 2
+    },
+    {
+      "path": "lib/migrations/index.js",
+      "method": "<anon method-1>",
+      "startLine": 153,
+      "crap": 2
+    },
+    {
+      "path": "lib/migrations/index.js",
+      "method": "<anon method-2>",
+      "startLine": 157,
+      "crap": 1
+    },
+    {
+      "path": "lib/migrations/steps/2.1.0-retire-mi-drop-knobs.js",
+      "method": "resolveAgentrcPath",
+      "startLine": 25,
+      "crap": 2
+    },
+    {
+      "path": "lib/migrations/steps/2.1.0-retire-mi-drop-knobs.js",
+      "method": "readAgentrcConfig",
+      "startLine": 35,
+      "crap": 2
+    },
+    {
+      "path": "lib/migrations/steps/2.1.0-retire-mi-drop-knobs.js",
+      "method": "hasRetiredKey",
+      "startLine": 48,
+      "crap": 20
+    },
+    {
+      "path": "lib/migrations/steps/2.1.0-retire-verify-concurrency-cap.js",
+      "method": "resolveAgentrcPath",
+      "startLine": 33,
+      "crap": 2
+    },
+    {
+      "path": "lib/migrations/steps/2.1.0-retire-verify-concurrency-cap.js",
+      "method": "readAgentrcConfig",
+      "startLine": 44,
+      "crap": 2
+    },
+    {
+      "path": "lib/migrations/steps/2.1.0-retire-verify-concurrency-cap.js",
+      "method": "hasRetiredKey",
+      "startLine": 57,
+      "crap": 6
+    },
+    {
+      "path": "lib/migrations/steps/2.1.0-retire-verify-concurrency-cap.js",
+      "method": "<anon method-1>",
+      "startLine": 76,
+      "crap": 1.2962962962962963
+    },
+    {
+      "path": "lib/migrations/steps/2.11.0-retire-max-seed-words.js",
+      "method": "resolveAgentrcPath",
+      "startLine": 26,
+      "crap": 2
+    },
+    {
+      "path": "lib/migrations/steps/2.11.0-retire-max-seed-words.js",
+      "method": "readAgentrcConfig",
+      "startLine": 36,
+      "crap": 2
+    },
+    {
+      "path": "lib/migrations/steps/2.11.0-retire-max-seed-words.js",
+      "method": "hasRetiredKey",
+      "startLine": 49,
+      "crap": 6
+    },
+    {
+      "path": "lib/migrations/steps/2.2.0-retire-epic-ac-tags.js",
+      "method": "collectFeatureFiles",
+      "startLine": 46,
+      "crap": 30
+    },
+    {
+      "path": "lib/migrations/steps/2.2.0-retire-epic-ac-tags.js",
+      "method": "resolveFeatureFiles",
+      "startLine": 78,
+      "crap": 2
+    },
+    {
+      "path": "lib/migrations/steps/2.2.0-retire-epic-ac-tags.js",
+      "method": "<anon method-1>",
+      "startLine": 80,
+      "crap": 2
+    },
+    {
+      "path": "lib/migrations/steps/2.2.0-retire-epic-ac-tags.js",
+      "method": "stripEpicAcTags",
+      "startLine": 93,
+      "crap": 42
+    },
+    {
+      "path": "lib/migrations/steps/2.2.0-retire-epic-ac-tags.js",
+      "method": "<anon method-2>",
+      "startLine": 108,
+      "crap": 2
+    },
+    {
+      "path": "lib/migrations/steps/2.2.0-retire-epic-ac-tags.js",
+      "method": "<anon method-3>",
+      "startLine": 126,
+      "crap": 1.512
     }
   ]
 }

--- a/baselines/dead-exports-production.json
+++ b/baselines/dead-exports-production.json
@@ -137,6 +137,10 @@
       "symbol": "resolveDescription"
     },
     {
+      "file": ".agents/scripts/lib/audit-suite/lens-diff-floor.js",
+      "symbol": "DEFAULT_LENS_DIFF_FLOOR"
+    },
+    {
       "file": ".agents/scripts/lib/audit-suite/selector.js",
       "symbol": "GLOBAL_LENS_ALLOWLIST"
     },
@@ -154,11 +158,11 @@
     },
     {
       "file": ".agents/scripts/lib/audit-suite/selector.js",
-      "symbol": "hasPersistenceLayer"
+      "symbol": "_resetWebSurfaceCache"
     },
     {
       "file": ".agents/scripts/lib/audit-suite/selector.js",
-      "symbol": "_resetWebSurfaceCache"
+      "symbol": "hasPersistenceLayer"
     },
     {
       "file": ".agents/scripts/lib/audit-suite/selector.js",
@@ -634,11 +638,11 @@
     },
     {
       "file": ".agents/scripts/lib/cli-usage.js",
-      "symbol": "formatUsage"
+      "symbol": "HELP_FLAGS"
     },
     {
       "file": ".agents/scripts/lib/cli-usage.js",
-      "symbol": "HELP_FLAGS"
+      "symbol": "formatUsage"
     },
     {
       "file": ".agents/scripts/lib/cli-usage.js",
@@ -1035,6 +1039,10 @@
     {
       "file": ".agents/scripts/lib/coverage-utils.js",
       "symbol": "hasCoverageFor"
+    },
+    {
+      "file": ".agents/scripts/lib/crap-engine.js",
+      "symbol": "crapFormula"
     },
     {
       "file": ".agents/scripts/lib/crap-utils.js",
@@ -1538,6 +1546,10 @@
     },
     {
       "file": ".agents/scripts/lib/orchestration/plan-context.js",
+      "symbol": "buildDeliverLightSuggestion"
+    },
+    {
+      "file": ".agents/scripts/lib/orchestration/plan-context.js",
       "symbol": "buildDeliveryShapeSignal"
     },
     {
@@ -1547,10 +1559,6 @@
     {
       "file": ".agents/scripts/lib/orchestration/plan-context.js",
       "symbol": "buildSystemPrompts"
-    },
-    {
-      "file": ".agents/scripts/lib/orchestration/plan-context.js",
-      "symbol": "buildDeliverLightSuggestion"
     },
     {
       "file": ".agents/scripts/lib/orchestration/plan-critic-conditions.js",
@@ -1590,19 +1598,19 @@
     },
     {
       "file": ".agents/scripts/lib/orchestration/plan-persist/story-ops.js",
-      "symbol": "normalizePlanRunId"
-    },
-    {
-      "file": ".agents/scripts/lib/orchestration/plan-persist/story-ops.js",
-      "symbol": "planRunLabel"
-    },
-    {
-      "file": ".agents/scripts/lib/orchestration/plan-persist/story-ops.js",
       "symbol": "foldSpecIntoStoryBody"
     },
     {
       "file": ".agents/scripts/lib/orchestration/plan-persist/story-ops.js",
+      "symbol": "normalizePlanRunId"
+    },
+    {
+      "file": ".agents/scripts/lib/orchestration/plan-persist/story-ops.js",
       "symbol": "normalizeStoryTicket"
+    },
+    {
+      "file": ".agents/scripts/lib/orchestration/plan-persist/story-ops.js",
+      "symbol": "planRunLabel"
     },
     {
       "file": ".agents/scripts/lib/orchestration/plan-persist/story-ops.js",
@@ -1969,6 +1977,10 @@
       "symbol": "resolveOperator"
     },
     {
+      "file": ".agents/scripts/lib/orchestration/spec-budget.js",
+      "symbol": "SPEC_SOFT_WORD_BUDGET"
+    },
+    {
       "file": ".agents/scripts/lib/orchestration/spec-spill.js",
       "symbol": "DEFAULT_SPEC_BODY_TOKEN_BUDGET"
     },
@@ -2067,10 +2079,6 @@
     {
       "file": ".agents/scripts/lib/orchestration/ticket-validator-sizing.js",
       "symbol": "estimateStorySessionMass"
-    },
-    {
-      "file": ".agents/scripts/lib/orchestration/spec-budget.js",
-      "symbol": "SPEC_SOFT_WORD_BUDGET"
     },
     {
       "file": ".agents/scripts/lib/orchestration/ticket-validator.js",
@@ -2599,10 +2607,6 @@
     {
       "file": ".agents/scripts/providers/github/search-budget.js",
       "symbol": "createSearchBudget"
-    },
-    {
-      "file": ".agents/scripts/lib/audit-suite/lens-diff-floor.js",
-      "symbol": "DEFAULT_LENS_DIFF_FLOOR"
     }
   ]
 }

--- a/baselines/maintainability.json
+++ b/baselines/maintainability.json
@@ -1,18 +1,18 @@
 {
   "$schema": ".agents/schemas/baselines/maintainability.schema.json",
   "kernelVersion": "0.1.0",
-  "generatedAt": "2026-07-23T20:39:17.851Z",
+  "generatedAt": "2026-07-26T02:47:20.953Z",
   "rollup": {
     "*": {
       "min": 74.146,
       "p50": 98.065,
-      "p95": 126.964
+      "p95": 126.637
     }
   },
   "rows": [
     {
       "path": ".agents/scripts/acceptance-eval.js",
-      "mi": 88.489
+      "mi": 87.896
     },
     {
       "path": ".agents/scripts/agents-bootstrap-github.js",
@@ -20,7 +20,7 @@
     },
     {
       "path": ".agents/scripts/apply-quality-bootstrap.js",
-      "mi": 112.652
+      "mi": 109.526
     },
     {
       "path": ".agents/scripts/audit-labels-bootstrap.js",
@@ -48,7 +48,7 @@
     },
     {
       "path": ".agents/scripts/check-baselines.js",
-      "mi": 106.627
+      "mi": 105.768
     },
     {
       "path": ".agents/scripts/check-context-budget.js",
@@ -56,7 +56,7 @@
     },
     {
       "path": ".agents/scripts/check-dead-exports.js",
-      "mi": 92.947
+      "mi": 92.322
     },
     {
       "path": ".agents/scripts/check-doc-links.js",
@@ -79,6 +79,10 @@
       "mi": 95.062
     },
     {
+      "path": ".agents/scripts/check-workflow-citations.js",
+      "mi": 95.345
+    },
+    {
       "path": ".agents/scripts/check-workflow-cli-lint.js",
       "mi": 89.165
     },
@@ -89,6 +93,10 @@
     {
       "path": ".agents/scripts/coverage-capture.js",
       "mi": 85.592
+    },
+    {
+      "path": ".agents/scripts/deliver-light.js",
+      "mi": 93.198
     },
     {
       "path": ".agents/scripts/deliver-recover.js",
@@ -104,7 +112,7 @@
     },
     {
       "path": ".agents/scripts/drain-pending-cleanup.js",
-      "mi": 106.26
+      "mi": 105.381
     },
     {
       "path": ".agents/scripts/evidence-gate.js",
@@ -128,15 +136,19 @@
     },
     {
       "path": ".agents/scripts/generate-workflows-doc.js",
-      "mi": 91.197
+      "mi": 90.422
     },
     {
       "path": ".agents/scripts/git-cleanup.js",
-      "mi": 131.94
+      "mi": 116.866
     },
     {
       "path": ".agents/scripts/install-matrix-assert.js",
       "mi": 89.263
+    },
+    {
+      "path": ".agents/scripts/lib/audit-suite/audit-rules-reader.js",
+      "mi": 111.662
     },
     {
       "path": ".agents/scripts/lib/audit-suite/checklist-threading.js",
@@ -268,7 +280,7 @@
     },
     {
       "path": ".agents/scripts/lib/baselines/kinds/crap.js",
-      "mi": 94.757
+      "mi": 96.235
     },
     {
       "path": ".agents/scripts/lib/baselines/kinds/duplication.js",
@@ -324,7 +336,7 @@
     },
     {
       "path": ".agents/scripts/lib/baselines/writer.js",
-      "mi": 94.752
+      "mi": 93.855
     },
     {
       "path": ".agents/scripts/lib/bdd-runner-detect.js",
@@ -460,7 +472,7 @@
     },
     {
       "path": ".agents/scripts/lib/cli-utils.js",
-      "mi": 112.427
+      "mi": 109.326
     },
     {
       "path": ".agents/scripts/lib/cli/parse-numeric.js",
@@ -480,7 +492,7 @@
     },
     {
       "path": ".agents/scripts/lib/close-validation/process.js",
-      "mi": 113.248
+      "mi": 112.269
     },
     {
       "path": ".agents/scripts/lib/close-validation/projections/head-sha.js",
@@ -640,7 +652,7 @@
     },
     {
       "path": ".agents/scripts/lib/coverage-utils.js",
-      "mi": 90.902
+      "mi": 87.488
     },
     {
       "path": ".agents/scripts/lib/cpu-pool.js",
@@ -648,11 +660,11 @@
     },
     {
       "path": ".agents/scripts/lib/crap-engine.js",
-      "mi": 92.895
+      "mi": 90.698
     },
     {
       "path": ".agents/scripts/lib/crap-utils.js",
-      "mi": 83.935
+      "mi": 87.082
     },
     {
       "path": ".agents/scripts/lib/dead-exports-knip.js",
@@ -948,7 +960,7 @@
     },
     {
       "path": ".agents/scripts/lib/orchestration/check-baselines/phases/evaluate.js",
-      "mi": 87.782
+      "mi": 86.936
     },
     {
       "path": ".agents/scripts/lib/orchestration/check-baselines/phases/floors.js",
@@ -980,7 +992,7 @@
     },
     {
       "path": ".agents/scripts/lib/orchestration/complexity-gate.js",
-      "mi": 92.192
+      "mi": 100.304
     },
     {
       "path": ".agents/scripts/lib/orchestration/consolidation-precondition.js",
@@ -1111,6 +1123,10 @@
       "mi": 94.692
     },
     {
+      "path": ".agents/scripts/lib/orchestration/light-suitability.js",
+      "mi": 91.282
+    },
+    {
       "path": ".agents/scripts/lib/orchestration/lint-baseline-service.js",
       "mi": 96.762
     },
@@ -1133,10 +1149,6 @@
     {
       "path": ".agents/scripts/lib/orchestration/phase-runner.js",
       "mi": 105.908
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/plan-context.js",
-      "mi": 89.629
     },
     {
       "path": ".agents/scripts/lib/orchestration/plan-critic-conditions.js",
@@ -1283,6 +1295,10 @@
       "mi": 87.009
     },
     {
+      "path": ".agents/scripts/lib/orchestration/single-story-close/gate-log.js",
+      "mi": 112.677
+    },
+    {
       "path": ".agents/scripts/lib/orchestration/single-story-close/phases/auto-merge.js",
       "mi": 90.534
     },
@@ -1292,7 +1308,7 @@
     },
     {
       "path": ".agents/scripts/lib/orchestration/single-story-close/phases/close-validation.js",
-      "mi": 97.919
+      "mi": 81.997
     },
     {
       "path": ".agents/scripts/lib/orchestration/single-story-close/phases/code-review.js",
@@ -1384,7 +1400,7 @@
     },
     {
       "path": ".agents/scripts/lib/orchestration/story-deliver-terminal.js",
-      "mi": 102.568
+      "mi": 101.19
     },
     {
       "path": ".agents/scripts/lib/orchestration/story-follow-ups.js",
@@ -1656,7 +1672,7 @@
     },
     {
       "path": ".agents/scripts/lib/transpile.js",
-      "mi": 101.416
+      "mi": 93.208
     },
     {
       "path": ".agents/scripts/lib/util/concurrent-map.js",
@@ -1692,11 +1708,11 @@
     },
     {
       "path": ".agents/scripts/lib/workers/combined-mi-crap-worker.js",
-      "mi": 80.901
+      "mi": 88.83
     },
     {
       "path": ".agents/scripts/lib/workers/crap-worker.js",
-      "mi": 81.404
+      "mi": 87.712
     },
     {
       "path": ".agents/scripts/lib/workers/maintainability-report-worker.js",
@@ -1705,6 +1721,10 @@
     {
       "path": ".agents/scripts/lib/workers/maintainability-worker.js",
       "mi": 95.936
+    },
+    {
+      "path": ".agents/scripts/lib/workflow-closure.js",
+      "mi": 97.938
     },
     {
       "path": ".agents/scripts/lib/workspace-provisioner.js",
@@ -1784,7 +1804,7 @@
     },
     {
       "path": ".agents/scripts/mandrel-update-preflight.js",
-      "mi": 89.455
+      "mi": 88.701
     },
     {
       "path": ".agents/scripts/nav-registry-diff.js",
@@ -1796,7 +1816,7 @@
     },
     {
       "path": ".agents/scripts/plan-context.js",
-      "mi": 91.889
+      "mi": 89.701
     },
     {
       "path": ".agents/scripts/plan-critics.js",
@@ -1804,11 +1824,11 @@
     },
     {
       "path": ".agents/scripts/plan-persist.js",
-      "mi": 90.426
+      "mi": 87.007
     },
     {
       "path": ".agents/scripts/plan-run-epilogue.js",
-      "mi": 106.311
+      "mi": 105.213
     },
     {
       "path": ".agents/scripts/post-structured-comment.js",
@@ -1904,11 +1924,11 @@
     },
     {
       "path": ".agents/scripts/quality-preview.js",
-      "mi": 95.317
+      "mi": 94.696
     },
     {
       "path": ".agents/scripts/resolve-doc-tiers.js",
-      "mi": 104.744
+      "mi": 102.67
     },
     {
       "path": ".agents/scripts/resolve-stories.js",
@@ -1944,7 +1964,7 @@
     },
     {
       "path": ".agents/scripts/single-story-close.js",
-      "mi": 94.232
+      "mi": 92.831
     },
     {
       "path": ".agents/scripts/single-story-confirm-merge.js",
@@ -1964,7 +1984,7 @@
     },
     {
       "path": ".agents/scripts/sync-agentrc.js",
-      "mi": 105.583
+      "mi": 102.354
     },
     {
       "path": ".agents/scripts/sync-branch-from-base.js",
@@ -1992,7 +2012,7 @@
     },
     {
       "path": ".agents/scripts/update-crap-baseline.js",
-      "mi": 88.413
+      "mi": 86.599
     },
     {
       "path": ".agents/scripts/update-duplication-baseline.js",
@@ -2004,7 +2024,7 @@
     },
     {
       "path": ".agents/scripts/update-ticket-state.js",
-      "mi": 94.799
+      "mi": 91.705
     },
     {
       "path": ".agents/scripts/validate-docs-freshness.js",

--- a/tests/baselines/crap-compat-axes.test.js
+++ b/tests/baselines/crap-compat-axes.test.js
@@ -1,8 +1,10 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 import {
+  assertBaselineCompatible,
   CRAP_COMPAT_AXES,
   evaluateBaselineCompatibility,
+  SCORING_SEMANTICS,
 } from '../../.agents/scripts/lib/baselines/kinds/crap.js';
 
 // ---------------------------------------------------------------------------
@@ -24,6 +26,7 @@ const VALID_BASELINE = {
   escomplexVersion: '0.8.0',
   kernelVersion: '0.8.0',
   tsTranspilerVersion: '5.4.0',
+  scoringSemantics: SCORING_SEMANTICS,
   rows: [],
 };
 
@@ -152,5 +155,67 @@ describe('evaluateBaselineCompatibility — reduce semantics', () => {
     assert.equal(out.ok, true);
     assert.equal(out.warnings.length, 1);
     assert.match(out.warnings[0], /baseline=0\.0\.0 running=5\.4\.0/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Story #4775 — scoring-semantics stamp. `kernelVersion` and
+// `escomplexVersion` both track the SAME upstream package, so a change to how
+// this repo joins escomplex methods to istanbul coverage moves neither. The
+// stamp is the only axis that can catch it, and it must fail CLOSED: rows
+// scored by the old join are not comparable to rows scored by the new one, so
+// an unstamped baseline is a re-baseline, never a silent comparison.
+// ---------------------------------------------------------------------------
+
+describe('scoring-semantics-drift axis', () => {
+  it('is fatal, not a warning', () => {
+    assert.equal(axis('scoring-semantics-drift').severity, 'fatal');
+  });
+
+  it('passes when the stamp matches the running semantics', () => {
+    assert.equal(axis('scoring-semantics-drift').check(VALID_CTX), null);
+    assert.equal(assertBaselineCompatible(VALID_BASELINE), null);
+  });
+
+  it('fires on an UNSTAMPED baseline (written by the previous scorer)', () => {
+    const legacy = { ...VALID_BASELINE };
+    delete legacy.scoringSemantics;
+    const message = assertBaselineCompatible(legacy);
+    assert.match(message, /scoring semantics changed/);
+    assert.match(message, /<unstamped>/);
+    assert.match(message, new RegExp(SCORING_SEMANTICS));
+  });
+
+  it('fires on a baseline stamped with different semantics', () => {
+    const message = assertBaselineCompatible({
+      ...VALID_BASELINE,
+      scoringSemantics: 'coverage-join-v1',
+    });
+    assert.match(message, /coverage-join-v1/);
+  });
+
+  it('names the exact re-baseline command in its guidance', () => {
+    const legacy = { ...VALID_BASELINE };
+    delete legacy.scoringSemantics;
+    const message = assertBaselineCompatible(legacy);
+    assert.match(message, /npm run test:coverage/);
+    assert.match(message, /crap:update -- --full-scope/);
+    assert.match(message, /baseline-refresh:/);
+  });
+
+  it('fails the whole reduce closed, not as a warning', () => {
+    const legacy = { ...VALID_BASELINE };
+    delete legacy.scoringSemantics;
+    const out = evaluateBaselineCompatibility({
+      ...VALID_CTX,
+      baseline: legacy,
+    });
+    assert.equal(out.ok, false);
+    assert.equal(out.exitCode, 1);
+    assert.equal(out.kind, 'scoring-semantics-drift');
+  });
+
+  it('treats a null baseline as the missing-baseline axis job, not its own', () => {
+    assert.equal(assertBaselineCompatible(null), null);
   });
 });

--- a/tests/baselines/crap-compat-axes.test.js
+++ b/tests/baselines/crap-compat-axes.test.js
@@ -3,9 +3,14 @@ import { describe, it } from 'node:test';
 import {
   assertBaselineCompatible,
   CRAP_COMPAT_AXES,
+  envelopeExtras,
   evaluateBaselineCompatibility,
-  SCORING_SEMANTICS,
 } from '../../.agents/scripts/lib/baselines/kinds/crap.js';
+
+// The stamp is read through the production door the writer uses, not a
+// second exported constant — so a drift between what the writer stamps and
+// what the compat axis expects would fail this suite rather than hide.
+const SCORING_SEMANTICS = envelopeExtras().scoringSemantics;
 
 // ---------------------------------------------------------------------------
 // crap-compat-axes.test.js — Story #2467 / Task #2491.

--- a/tests/baselines/writer.test.js
+++ b/tests/baselines/writer.test.js
@@ -210,6 +210,10 @@ describe('writeFile()', () => {
         $schema: env.$schema,
         kernelVersion: env.kernelVersion,
         generatedAt: env.generatedAt,
+        // Story #4775 — the crap kind stamps its scoring semantics, and the
+        // disk projection must carry it through by name or the stamp exists
+        // only in memory.
+        scoringSemantics: env.scoringSemantics,
         rollup: env.rollup,
         rows: env.rows,
       },
@@ -217,6 +221,7 @@ describe('writeFile()', () => {
       2,
     )}\n`;
     assert.equal(onDisk, expected);
+    assert.equal(typeof env.scoringSemantics, 'string');
   });
 
   it('terminates the file with a trailing newline', () => {

--- a/tests/crap-utils.tsx-coverage-keying.test.js
+++ b/tests/crap-utils.tsx-coverage-keying.test.js
@@ -13,16 +13,23 @@ import { scanAndScore } from '../.agents/scripts/lib/crap-utils.js';
  * the source file, never the transpiled output, so the original path is
  * what the lookup must use.
  *
- * Note on line numbers: `ts.transpileModule` does NOT preserve line
- * numbers verbatim. JSX runtime imports add a line at the top of TSX
- * output, and interface elision shifts subsequent code in plain TS. So
- * escomplex's per-method `lineStart` will not generally match the
- * source line number recorded in the coverage entry. The per-method
- * lookup absorbs the drift via `compareCrap`'s line-drift fallback
- * (same file + method, nearest startLine wins). For this test we lay
- * the coverage entry at the TRANSPILED line number escomplex actually
- * reports, so we can verify the end-to-end path resolves a non-null
- * coverage value.
+ * Line numbers (Story #4775): `ts.transpileModule` does NOT preserve line
+ * numbers. JSX runtime imports add a line at the top of TSX output and
+ * interface elision shifts subsequent code in plain TS, so escomplex's
+ * per-method `lineStart` is in TRANSPILED coordinates while the coverage
+ * entry is in ORIGINAL SOURCE coordinates. The scorer closes that gap at
+ * scoring time by remapping each method start through the transpile's
+ * source map before the coverage lookup.
+ *
+ * This fixture therefore lays its coverage entry at the REAL source line
+ * — the line a reader opening `Greeting.tsx` would see — which is the only
+ * configuration a real `coverage-final.json` can contain. The previous
+ * revision of this file laid the entry at the transpiled line instead and
+ * asserted that `compareCrap`'s line-drift fallback absorbed the
+ * difference; it does not. `compareCrap` reconciles CURRENT rows against
+ * BASELINE rows at comparison time, long after an unresolved method has
+ * already been dropped at scoring time — which is precisely how the
+ * production path stayed broken while this test stayed green.
  */
 
 function mkTmp() {
@@ -52,7 +59,7 @@ export function Greeting({ name, count }: Props): JSX.Element {
 
 /**
  * Build a coverage-final.json entry whose statements map covers the body
- * of `Greeting` (declared at line 3 in TSX_SOURCE). The entry uses the
+ * of `Greeting`, keyed at its REAL line in `TSX_SOURCE`. The entry uses the
  * absolute file path as its key field — vitest writes absolute paths in
  * `coverage-final.json` by default; the loader/resolver normalises by
  * suffix match.
@@ -98,11 +105,18 @@ test('scanAndScore — TSX source resolves coverage keyed on original .tsx path'
     const tsxPath = path.join(dir, 'Greeting.tsx');
     fs.writeFileSync(tsxPath, TSX_SOURCE);
 
-    // After ts.transpileModule with JsxEmit.ReactJSX, Greeting moves
-    // from source line 3 to transpiled line 2 (the runtime import is
-    // injected at line 1). Lay the coverage entry at line 2 so the
-    // per-method lookup actually matches what escomplex reports.
-    const coverage = coverageEntryForGreeting(tsxPath, 2);
+    // `Greeting` is declared at line 3 of TSX_SOURCE. After
+    // ts.transpileModule with JsxEmit.ReactJSX it lands at transpiled line 2
+    // (the interface is elided, the JSX runtime import injected). The
+    // coverage entry is laid at the SOURCE line — 3 — exactly as a real
+    // coverage-final.json would; the scorer remaps 2 → 3 before the lookup.
+    const GREETING_SOURCE_LINE = 3;
+    assert.match(
+      TSX_SOURCE.split('\n')[GREETING_SOURCE_LINE - 1],
+      /export function Greeting/,
+      'fixture drift: Greeting is no longer on the asserted source line',
+    );
+    const coverage = coverageEntryForGreeting(tsxPath, GREETING_SOURCE_LINE);
 
     const result = await scanAndScore({
       targetDirs: [dir],
@@ -129,6 +143,14 @@ test('scanAndScore — TSX source resolves coverage keyed on original .tsx path'
       );
       assert.ok(row.coverage >= 0 && row.coverage <= 1);
     }
+    // Every method resolved — nothing was silently dropped for want of a
+    // coordinate remap (Story #4775, AC-2).
+    assert.strictEqual(result.skippedMethodsNoCoverage, 0);
+    assert.strictEqual(result.resolution.rate, 1);
+    // And the persisted startLine is a line a reader can open in the .tsx.
+    const greeting = result.rows.find((r) => r.method === 'Greeting');
+    assert.ok(greeting, 'Greeting must be scored');
+    assert.strictEqual(greeting.startLine, GREETING_SOURCE_LINE);
   } finally {
     rmTmp(dir);
   }

--- a/tests/lib/coverage-utils.test.js
+++ b/tests/lib/coverage-utils.test.js
@@ -175,14 +175,41 @@ test('coverageForMethodInEntry — statements outside function loc are ignored',
   assert.strictEqual(coverageForMethodInEntry(entry, 10), 1);
 });
 
-test('coverageForMethodInEntry — off-line-number returns null', () => {
+test('coverageForMethodInEntry — a line inside the function body resolves by containment', () => {
+  // Story #4775: exact `decl`/`loc` start-line equality is not sufficient —
+  // after remapping a transpiled method start to original coordinates it can
+  // land a line or two into the function. Containment picks the function
+  // whose `loc` range holds the line instead of dropping the method.
   const entry = makeEntry({
     fnStart: 10,
     fnEnd: 14,
     statements: [{ line: 11, hits: 1 }],
   });
+  assert.strictEqual(coverageForMethodInEntry(entry, 11), 1);
+  assert.strictEqual(coverageForMethodInEntry(entry, 14), 1);
+});
+
+test('coverageForMethodInEntry — a declaration one line off still resolves', () => {
+  // The ±1 token disagreement between escomplex's method start and istanbul's
+  // `decl.start.line` (a leading `export`, a decorator, a wrapped parameter
+  // list) is absorbed by the nearest-decl fallback.
+  const entry = makeEntry({
+    fnStart: 10,
+    fnEnd: 14,
+    statements: [{ line: 11, hits: 1 }],
+  });
+  assert.strictEqual(coverageForMethodInEntry(entry, 9), 1);
+});
+
+test('coverageForMethodInEntry — a line outside every function returns null', () => {
+  const entry = makeEntry({
+    fnStart: 10,
+    fnEnd: 14,
+    statements: [{ line: 11, hits: 1 }],
+  });
+  // Beyond the containment range AND beyond the ±1 decl window: no data.
   assert.strictEqual(coverageForMethodInEntry(entry, 7), null);
-  assert.strictEqual(coverageForMethodInEntry(entry, 11), null);
+  assert.strictEqual(coverageForMethodInEntry(entry, 40), null);
 });
 
 test('coverageForMethodInEntry — empty / missing entry returns null', () => {

--- a/tests/lib/crap-engine.test.js
+++ b/tests/lib/crap-engine.test.js
@@ -152,8 +152,12 @@ export function b() { return 2; }
 });
 
 test('calculateCrapForSource — method without coverage record gets null, others scored', () => {
+  // `unscored` sits far below the covered function's `loc` range so neither
+  // containment nor the ±1 decl window can claim it (Story #4775) — it is
+  // genuinely uninstrumented, not merely mis-keyed.
   const source = `
 export function scored(x) { return x + 1; }
+${'\n'.repeat(40)}
 export function unscored(x) { return x * 2; }
 `;
   // Only provide coverage for the first method (startLine=2).

--- a/tests/lib/crap-utils.combined-parity.test.js
+++ b/tests/lib/crap-utils.combined-parity.test.js
@@ -4,6 +4,7 @@ import os from 'node:os';
 import path from 'node:path';
 import { afterEach, beforeEach, describe, it } from 'node:test';
 
+import { POOL_SERIAL_THRESHOLD } from '../../.agents/scripts/lib/cpu-pool.js';
 import {
   scanAndScore,
   scanAndScoreCombined,
@@ -298,5 +299,212 @@ export function classify(x) {
       () => scanAndScoreCombined({ targetDirs: 'nope', coverage: null }),
       /targetDirs must be an array/,
     );
+  });
+});
+
+/**
+ * Story #4775 — parity across the WORKER-POOL path, on TypeScript.
+ *
+ * The suite above proves two-pass-vs-single-pass parity, but its fixture tree
+ * is all JavaScript (`mapLine` is null, so the remap is a no-op) and sits
+ * below `POOL_SERIAL_THRESHOLD`, so every scan takes the serial branch. That
+ * leaves the two axes this Story actually changed uncovered: the transpiled ->
+ * original line remap, and the worker-pool scorer that has to reproduce it in
+ * another thread.
+ *
+ * This fixture is TypeScript (interfaces are elided, so transpiled and source
+ * coordinates genuinely diverge) and deliberately large enough to cross the
+ * pool threshold. The serial reference is reconstructed by scanning the same
+ * files in sub-threshold batches, which is the only way to force the serial
+ * branch over a file set the pool would otherwise claim.
+ */
+const TS_FILE_COUNT = POOL_SERIAL_THRESHOLD + 1;
+
+function tsFixture(index) {
+  // Leading interface + type alias guarantee the transpile shifts every
+  // method's line, so a missing remap cannot pass by coincidence.
+  return `interface Input${index} {
+  value: number;
+  label: string;
+}
+
+type Out${index} = { ok: boolean; n: number };
+
+export function classify${index}(input: Input${index}): Out${index} {
+  if (input.value > 10) {
+    return { ok: true, n: input.value };
+  }
+  if (input.value < 0) {
+    return { ok: false, n: 0 };
+  }
+  return { ok: input.value === 0, n: input.value };
+}
+
+export function total${index}(items: Input${index}[]): number {
+  let sum = 0;
+  for (const item of items) {
+    if (item.value > 0) {
+      sum += item.value;
+    }
+  }
+  return sum;
+}
+`;
+}
+
+/** The 1-based source lines the two exported functions occupy. */
+const TS_FN_RANGES = [
+  { start: 8, end: 16 },
+  { start: 18, end: 26 },
+];
+
+/**
+ * Coverage entry keyed at the REAL source lines of `tsFixture` — the only
+ * shape a real `coverage-final.json` can carry. A scan that fails to remap
+ * looks these up in transpiled coordinates and resolves nothing.
+ */
+function tsCoverageEntry() {
+  const fnMap = {};
+  const statementMap = {};
+  const s = {};
+  let stmtId = 0;
+  TS_FN_RANGES.forEach((range, i) => {
+    fnMap[String(i)] = {
+      name: `fn${i}`,
+      decl: { start: { line: range.start }, end: { line: range.start } },
+      loc: {
+        start: { line: range.start },
+        end: { line: range.end },
+      },
+    };
+    for (let line = range.start + 1; line < range.end; line += 1) {
+      statementMap[String(stmtId)] = { start: { line }, end: { line } };
+      s[String(stmtId)] = 1;
+      stmtId += 1;
+    }
+  });
+  return { fnMap, statementMap, s };
+}
+
+/**
+ * Score `files` through the SERIAL branch by feeding `scanAndScore`
+ * sub-threshold batches and merging, then re-sorting exactly as the scanner
+ * does. Merging is sound because the per-file scorers are independent — the
+ * only thing batching changes is which branch runs.
+ */
+async function scoreSerialInBatches({ targetDirs, coverage, cwd, files }) {
+  const batchSize = POOL_SERIAL_THRESHOLD - 1;
+  const merged = {
+    rows: [],
+    scannedFiles: 0,
+    skippedFilesNoCoverage: 0,
+    skippedMethodsNoCoverage: 0,
+  };
+  for (let i = 0; i < files.length; i += batchSize) {
+    const batch = files.slice(i, i + batchSize);
+    const out = await scanAndScore({
+      targetDirs,
+      coverage,
+      requireCoverage: true,
+      cwd,
+      preScannedFiles: batch,
+    });
+    merged.rows.push(...out.rows);
+    merged.scannedFiles += out.scannedFiles;
+    merged.skippedFilesNoCoverage += out.skippedFilesNoCoverage;
+    merged.skippedMethodsNoCoverage += out.skippedMethodsNoCoverage;
+  }
+  merged.rows.sort((a, b) => {
+    if (a.file !== b.file) return a.file < b.file ? -1 : 1;
+    if (a.startLine !== b.startLine) return a.startLine - b.startLine;
+    return a.method < b.method ? -1 : a.method > b.method ? 1 : 0;
+  });
+  return merged;
+}
+
+describe('worker-pool parity on TypeScript — the remap survives the thread boundary', () => {
+  let tmpDir;
+  let files;
+  let coverage;
+  let targetDirs;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'crap-pool-ts-parity-'));
+    files = [];
+    coverage = {};
+    for (let i = 0; i < TS_FILE_COUNT; i += 1) {
+      const abs = mkFixtureFile(tmpDir, `src/mod${i}.ts`, tsFixture(i));
+      files.push(abs);
+      coverage[abs] = tsCoverageEntry();
+    }
+    targetDirs = [path.join(tmpDir, 'src')];
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('the fixture actually crosses the pool threshold', () => {
+    assert.ok(
+      files.length >= POOL_SERIAL_THRESHOLD,
+      `fixture must force the pool branch (${files.length} < ${POOL_SERIAL_THRESHOLD})`,
+    );
+  });
+
+  it('pool-scored rows are byte-identical to serially-scored rows', async () => {
+    const pooled = await scanAndScore({
+      targetDirs,
+      coverage,
+      requireCoverage: true,
+      cwd: tmpDir,
+    });
+    const serial = await scoreSerialInBatches({
+      targetDirs,
+      coverage,
+      cwd: tmpDir,
+      files,
+    });
+
+    assert.deepEqual(pooled.rows, serial.rows);
+    assert.equal(pooled.skippedMethodsNoCoverage, 0);
+    assert.equal(serial.skippedMethodsNoCoverage, 0);
+    // Both functions in every file resolved — proving the remap ran on BOTH
+    // sides. Without it the lookups land in transpiled coordinates and the
+    // rows vanish, which would make the two sides agree on emptiness.
+    assert.equal(pooled.rows.length, TS_FILE_COUNT * TS_FN_RANGES.length);
+    assert.equal(pooled.resolution.rate, 1);
+  });
+
+  it('rows carry ORIGINAL source coordinates on the pool path', async () => {
+    const pooled = await scanAndScore({
+      targetDirs,
+      coverage,
+      requireCoverage: true,
+      cwd: tmpDir,
+    });
+    const starts = new Set(pooled.rows.map((r) => r.startLine));
+    assert.deepEqual(
+      [...starts].sort((a, b) => a - b),
+      TS_FN_RANGES.map((r) => r.start),
+    );
+  });
+
+  it('the combined single-pass scan matches the two-pass scan on the pool path', async () => {
+    const twoPass = await scanAndScore({
+      targetDirs,
+      coverage,
+      requireCoverage: true,
+      cwd: tmpDir,
+    });
+    const { crap, miScores } = await scanAndScoreCombined({
+      targetDirs,
+      coverage,
+      requireCoverage: true,
+      cwd: tmpDir,
+    });
+    assert.deepEqual(crap, twoPass);
+    // The combined worker must still emit an MI score per file — the remap
+    // opt-in must not have disturbed the maintainability half.
+    assert.equal(Object.keys(miScores).length, TS_FILE_COUNT);
   });
 });

--- a/tests/lib/crap-utils.sourcemap-join.test.js
+++ b/tests/lib/crap-utils.sourcemap-join.test.js
@@ -1,0 +1,400 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { describe, it, test } from 'node:test';
+import { coverageForMethodInEntry } from '../../.agents/scripts/lib/coverage-utils.js';
+import { finalizeMethodRows } from '../../.agents/scripts/lib/crap-engine.js';
+import {
+  checkResolutionFloor,
+  scanAndScore,
+} from '../../.agents/scripts/lib/crap-utils.js';
+import {
+  prepareSourceForScoring,
+  transpileIfNeeded,
+} from '../../.agents/scripts/lib/transpile.js';
+
+/**
+ * Story #4775 — the per-method coverage join, in ONE coordinate system.
+ *
+ * escomplex reports each method's `lineStart` against the code it parsed,
+ * which for a TypeScript source is the TRANSPILED output. istanbul's `fnMap`
+ * is keyed against the ORIGINAL source. Before this Story the join compared
+ * the two by exact equality, so a TS repo resolved ~5% of its methods — and
+ * the ~5% that did "resolve" were numeric collisions joining a method to an
+ * unrelated function's coverage. Both halves of the fix are required and are
+ * asserted separately here:
+ *
+ *   1. **Remap** — `transpileIfNeeded(…, {withLineMap: true})` returns a
+ *      transpiled → original line resolver, so the lookup happens in the
+ *      coverage entry's own coordinates.
+ *   2. **Tolerant match** — remapped starts land within ±1 of the `fnMap`
+ *      declaration line, so equality is replaced by containment with a
+ *      bounded nearest-decl fallback.
+ */
+
+function mkTmp() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'crap_smjoin_'));
+}
+
+function rmTmp(dir) {
+  try {
+    fs.rmSync(dir, { recursive: true, force: true });
+  } catch {
+    /* noop */
+  }
+}
+
+// Two interfaces and a type alias ahead of the code: elision guarantees the
+// transpiled coordinates diverge from the source's by several lines, which is
+// exactly the condition the old exact-equality join could not survive.
+const TS_SOURCE = `interface Options {
+  retries: number;
+  verbose: boolean;
+}
+
+type Result = { ok: boolean };
+
+export function classify(n: number): Result {
+  if (n > 10) {
+    return { ok: true };
+  }
+  if (n < 0) {
+    return { ok: false };
+  }
+  return { ok: n === 0 };
+}
+
+export function retry(opts: Options): number {
+  let count = 0;
+  while (count < opts.retries) {
+    count += 1;
+  }
+  return count;
+}
+`;
+
+const CLASSIFY_SOURCE_LINE = 8;
+const RETRY_SOURCE_LINE = 18;
+
+/**
+ * Build a coverage entry keyed at REAL source lines — the only thing a real
+ * `coverage-final.json` can contain. `declOffset` shifts every `decl` line by
+ * a fixed amount so the ±1 disagreement between escomplex's method start and
+ * istanbul's declaration line can be exercised deliberately.
+ */
+function coverageEntry(absPath, { declOffset = 0 } = {}) {
+  const statementMap = {};
+  const s = {};
+  let id = 0;
+  const addStatements = (from, to, hit) => {
+    for (let line = from; line <= to; line += 1) {
+      statementMap[String(id)] = {
+        start: { line, column: 0 },
+        end: { line, column: 20 },
+      };
+      s[String(id)] = hit ? 1 : 0;
+      id += 1;
+    }
+  };
+  // classify: fully covered. retry: entirely uncovered.
+  addStatements(CLASSIFY_SOURCE_LINE + 1, CLASSIFY_SOURCE_LINE + 7, true);
+  addStatements(RETRY_SOURCE_LINE + 1, RETRY_SOURCE_LINE + 5, false);
+
+  const fn = (name, startLine, endLine) => ({
+    name,
+    decl: { start: { line: startLine + declOffset, column: 0 } },
+    loc: {
+      start: { line: startLine, column: 0 },
+      end: { line: endLine, column: 1 },
+    },
+  });
+
+  return {
+    [absPath]: {
+      path: absPath,
+      fnMap: {
+        0: fn('classify', CLASSIFY_SOURCE_LINE, CLASSIFY_SOURCE_LINE + 8),
+        1: fn('retry', RETRY_SOURCE_LINE, RETRY_SOURCE_LINE + 6),
+      },
+      f: { 0: 1, 1: 0 },
+      statementMap,
+      s,
+      branchMap: {},
+      b: {},
+    },
+  };
+}
+
+async function scanFixture(dir, coverage) {
+  return scanAndScore({
+    targetDirs: [dir],
+    coverage,
+    requireCoverage: true,
+    cwd: dir,
+  });
+}
+
+describe('transpileIfNeeded — line mapping (AC-1)', () => {
+  it('returns an original-source line mapping for a TS input', () => {
+    const prepared = transpileIfNeeded('mod.ts', TS_SOURCE, {
+      withLineMap: true,
+    });
+    assert.equal(typeof prepared.code, 'string');
+    assert.equal(typeof prepared.mapLine, 'function');
+    // The interfaces are elided, so the transpiled coordinates MUST differ
+    // from the source's — otherwise this fixture proves nothing.
+    const transpiledClassify =
+      prepared.code
+        .split('\n')
+        .findIndex((l) => l.includes('function classify')) + 1;
+    assert.notEqual(transpiledClassify, CLASSIFY_SOURCE_LINE);
+    assert.equal(prepared.mapLine(transpiledClassify), CLASSIFY_SOURCE_LINE);
+  });
+
+  it('leaves JS a passthrough with no map and no behaviour change', () => {
+    const js = 'export function a(x) { return x + 1; }\n';
+    assert.equal(transpileIfNeeded('mod.js', js), js);
+    const prepared = transpileIfNeeded('mod.js', js, { withLineMap: true });
+    assert.equal(prepared.code, js);
+    assert.equal(
+      prepared.mapLine,
+      null,
+      'JS coordinates ARE original coordinates — no remap, no mapping cost',
+    );
+  });
+
+  it('emits code byte-identical to the map-less transpile', () => {
+    // The MI path never asks for a map. If requesting one changed the emitted
+    // code by so much as the trailing sourceMappingURL comment, every
+    // maintainability score for a TS tree would move (AC-9).
+    const withMap = transpileIfNeeded('mod.ts', TS_SOURCE, {
+      withLineMap: true,
+    });
+    assert.equal(withMap.code, transpileIfNeeded('mod.ts', TS_SOURCE));
+  });
+
+  it('resolves an unmappable line to null rather than guessing', () => {
+    const prepared = transpileIfNeeded('mod.ts', TS_SOURCE, {
+      withLineMap: true,
+    });
+    assert.equal(prepared.mapLine(100_000), null);
+    assert.equal(prepared.mapLine(0), null);
+  });
+});
+
+describe('prepareSourceForScoring', () => {
+  it('distinguishes a read failure from a transpile failure', () => {
+    const readFail = prepareSourceForScoring('/nope/missing.ts');
+    assert.equal(readFail.error, 'read');
+    const transpileFail = prepareSourceForScoring('/x/a.ts', {
+      readFile: () => 'source',
+      transpile: () => null,
+    });
+    assert.equal(transpileFail.error, 'transpile');
+  });
+
+  it('tolerates a transpile stub that returns a bare string', () => {
+    const prepared = prepareSourceForScoring('/x/a.ts', {
+      readFile: () => 'ignored',
+      transpile: () => 'export const a = 1;',
+    });
+    assert.equal(prepared.code, 'export const a = 1;');
+    assert.equal(prepared.mapLine, null);
+  });
+});
+
+test('scanAndScore — a TS fixture keyed at real source lines resolves 100% of its methods (AC-2)', async () => {
+  const dir = mkTmp();
+  try {
+    const tsPath = path.join(dir, 'mod.ts');
+    fs.writeFileSync(tsPath, TS_SOURCE);
+    const result = await scanFixture(dir, coverageEntry(tsPath));
+
+    assert.equal(result.skippedFilesNoCoverage, 0);
+    assert.equal(
+      result.skippedMethodsNoCoverage,
+      0,
+      'no method may be dropped for want of a coordinate remap',
+    );
+    assert.equal(result.resolution.rate, 1);
+    assert.equal(result.resolution.resolvedMethods, 2);
+    assert.deepEqual(result.resolution.worstFiles, []);
+
+    const byMethod = Object.fromEntries(result.rows.map((r) => [r.method, r]));
+    // classify is fully covered → crap collapses to c.
+    assert.equal(byMethod.classify.coverage, 1);
+    assert.equal(byMethod.classify.crap, byMethod.classify.cyclomatic);
+    // retry is instrumented but never executed → the full c² + c penalty.
+    assert.equal(byMethod.retry.coverage, 0);
+    assert.equal(
+      byMethod.retry.crap,
+      byMethod.retry.cyclomatic ** 2 + byMethod.retry.cyclomatic,
+    );
+    // And the persisted coordinates are the ones a reader can open.
+    assert.equal(byMethod.classify.startLine, CLASSIFY_SOURCE_LINE);
+    assert.equal(byMethod.retry.startLine, RETRY_SOURCE_LINE);
+  } finally {
+    rmTmp(dir);
+  }
+});
+
+test('scanAndScore — a remapped start one line off the fnMap decl still resolves (AC-3)', async () => {
+  const dir = mkTmp();
+  try {
+    const tsPath = path.join(dir, 'mod.ts');
+    fs.writeFileSync(tsPath, TS_SOURCE);
+    // Every decl line sits one BELOW the loc start, so the remapped method
+    // start never equals a decl line. Only containment can join these.
+    const result = await scanFixture(
+      dir,
+      coverageEntry(tsPath, { declOffset: 1 }),
+    );
+
+    assert.equal(result.skippedMethodsNoCoverage, 0);
+    assert.equal(result.resolution.rate, 1);
+    const byMethod = Object.fromEntries(result.rows.map((r) => [r.method, r]));
+    assert.equal(byMethod.classify.coverage, 1);
+    assert.equal(byMethod.retry.coverage, 0);
+  } finally {
+    rmTmp(dir);
+  }
+});
+
+test('the remap is load-bearing — the raw transpiled line mis-attributes coverage', () => {
+  // Guards the fix against silent regression. Without the remap, `retry`'s
+  // transpiled start falls inside `classify`'s fnMap range: the join does not
+  // merely miss, it MATCHES THE WRONG FUNCTION and reports an untested method
+  // as fully covered. That is the Story's central claim — a coincidental
+  // match across two coordinate systems is a mis-attribution, so consumer
+  // baselines pinned to it are wrong, not merely sparse.
+  const entry = coverageEntry('/abs/mod.ts')['/abs/mod.ts'];
+  const prepared = transpileIfNeeded('mod.ts', TS_SOURCE, {
+    withLineMap: true,
+  });
+  const transpiledRetry =
+    prepared.code.split('\n').findIndex((l) => l.includes('function retry')) +
+    1;
+
+  assert.notEqual(
+    transpiledRetry,
+    RETRY_SOURCE_LINE,
+    'fixture drift: the transpile no longer shifts retry',
+  );
+  assert.equal(prepared.mapLine(transpiledRetry), RETRY_SOURCE_LINE);
+
+  // Correct coordinates: retry is instrumented and never executed → 0.
+  assert.equal(coverageForMethodInEntry(entry, RETRY_SOURCE_LINE), 0);
+  // Raw transpiled coordinates: silently answers with classify's coverage.
+  assert.equal(coverageForMethodInEntry(entry, transpiledRetry), 1);
+});
+
+describe('finalizeMethodRows — requireCoverage policy (AC-5)', () => {
+  const raw = [
+    { method: 'covered', startLine: 1, cyclomatic: 3, coverage: 1, crap: 3 },
+    {
+      method: 'unresolved',
+      startLine: 9,
+      cyclomatic: 4,
+      coverage: null,
+      crap: null,
+    },
+  ];
+
+  it('skips and counts an unresolved method under requireCoverage: true', () => {
+    const out = finalizeMethodRows(raw, { requireCoverage: true });
+    assert.equal(out.rows.length, 1);
+    assert.equal(out.rows[0].method, 'covered');
+    assert.equal(out.skippedMethodsNoCoverage, 1);
+  });
+
+  it('scores an unresolved method as 0% covered under requireCoverage: false', () => {
+    const out = finalizeMethodRows(raw, { requireCoverage: false });
+    assert.equal(out.rows.length, 2);
+    assert.equal(out.skippedMethodsNoCoverage, 0);
+    const unresolved = out.rows.find((r) => r.method === 'unresolved');
+    assert.equal(unresolved.coverage, 0);
+    // c² + c — the formula's own treatment of untested code, not a drop.
+    assert.equal(unresolved.crap, 4 ** 2 + 4);
+  });
+
+  it('counts the JOIN, not the fill, in the resolution telemetry', () => {
+    // A method scored 0% because its coverage was UNRESOLVED must still count
+    // as unresolved — otherwise `requireCoverage: false` would report a
+    // perfect resolution rate and the updater's floor could never fire.
+    const out = finalizeMethodRows(raw, { requireCoverage: false });
+    assert.equal(out.totalMethods, 2);
+    assert.equal(out.resolvedMethods, 1);
+  });
+});
+
+describe('checkResolutionFloor — fail closed on a thin result (AC-6)', () => {
+  const worstFiles = [
+    { file: 'src/a.ts', unresolved: 40, total: 40 },
+    { file: 'src/b.ts', unresolved: 12, total: 20 },
+  ];
+  const thin = {
+    resolvedMethods: 100,
+    joinableMethods: 1618,
+    rate: 100 / 1618,
+    worstFiles,
+  };
+
+  it('refuses a 6% resolution rate', () => {
+    const message = checkResolutionFloor(thin, 0.75);
+    assert.ok(message, 'a 6% join must be refused, not persisted');
+    assert.match(message, /Refusing to persist/);
+  });
+
+  it('prints resolved/total and the worst unresolved files', () => {
+    const message = checkResolutionFloor(thin, 0.75);
+    assert.match(message, /100\/1618/);
+    assert.match(message, /6\.2%/);
+    assert.match(message, /src\/a\.ts \(40\/40 unresolved\)/);
+    assert.match(message, /src\/b\.ts \(12\/20 unresolved\)/);
+  });
+
+  it('names the configuration knob so the floor is tunable, not mysterious', () => {
+    assert.match(
+      checkResolutionFloor(thin, 0.75),
+      /delivery\.quality\.gates\.crap\.minMethodResolutionRate/,
+    );
+  });
+
+  it('passes a healthy rate', () => {
+    assert.equal(
+      checkResolutionFloor(
+        { resolvedMethods: 3995, joinableMethods: 4084, rate: 0.978 },
+        0.75,
+      ),
+      null,
+    );
+  });
+
+  it('passes at exactly the floor (the floor is a minimum, not a strict bound)', () => {
+    assert.equal(
+      checkResolutionFloor(
+        { resolvedMethods: 75, joinableMethods: 100, rate: 0.75 },
+        0.75,
+      ),
+      null,
+    );
+  });
+
+  it('does not fire below the minimum sample — a diff-scoped run is not evidence', () => {
+    // One unresolved method out of four is a 75%-breaching 50% rate but says
+    // nothing about the health of the join; enforcing it would make every
+    // small diff-scoped refresh a coin flip.
+    assert.equal(
+      checkResolutionFloor(
+        { resolvedMethods: 2, joinableMethods: 4, rate: 0.5, worstFiles: [] },
+        0.75,
+      ),
+      null,
+    );
+  });
+
+  it('is a no-op when the scan reported no telemetry at all', () => {
+    assert.equal(checkResolutionFloor(undefined, 0.75), null);
+  });
+});

--- a/tests/lib/crap-utils.test.js
+++ b/tests/lib/crap-utils.test.js
@@ -282,12 +282,19 @@ test('scanAndScore — scores uncovered files when requireCoverage=false', async
       requireCoverage: false,
       cwd,
     });
-    // File produces a method row in the kernel, but crap is null without
-    // coverage → it is filtered out of scanAndScore rows (no silent zeros).
+    // Story #4775 (AC-5): `requireCoverage: false` means "score it anyway".
+    // A method with no coverage entry is untested code, so it scores at 0%
+    // coverage — crap = c² + c — and lands in the baseline. Previously the
+    // flag only stopped whole FILES being skipped while each method was
+    // still dropped individually, making it a no-op for baseline population.
     assert.strictEqual(result.scannedFiles, 1);
     assert.strictEqual(result.skippedFilesNoCoverage, 0);
-    assert.ok(result.skippedMethodsNoCoverage >= 1);
-    assert.deepStrictEqual(result.rows, []);
+    assert.strictEqual(result.skippedMethodsNoCoverage, 0);
+    assert.strictEqual(result.rows.length, 1);
+    const [row] = result.rows;
+    assert.strictEqual(row.method, 'a');
+    assert.strictEqual(row.coverage, 0);
+    assert.strictEqual(row.crap, row.cyclomatic ** 2 + row.cyclomatic);
   } finally {
     rmTmp(cwd);
   }

--- a/tests/lib/workers/combined-mi-crap-worker.test.js
+++ b/tests/lib/workers/combined-mi-crap-worker.test.js
@@ -21,6 +21,13 @@ const okItem = {
   coverageEntry: STUB_ENTRY,
 };
 
+// One resolved method and two the coverage join could not resolve.
+const UNRESOLVED_ROWS = [
+  { method: 'a', startLine: 5, cyclomatic: 2, coverage: 1, crap: 2 },
+  { method: 'b', startLine: 9, cyclomatic: 1, coverage: null, crap: null },
+  { method: 'c', startLine: 12, cyclomatic: 3, coverage: 0.8, crap: null },
+];
+
 function stubDeps({
   readFile = () => 'export const x = 1;',
   transpile = (_abs, src) => src,
@@ -157,20 +164,43 @@ describe('handleCombinedMiCrapWorkerMessage — success rows', () => {
     assert.equal(out.message.result.skippedMethodsNoCoverage, 0);
   });
 
-  it('skips methods with null crap or null coverage and counts them', () => {
-    const rawRows = [
-      { method: 'a', startLine: 5, cyclomatic: 2, coverage: 1, crap: 2 },
-      { method: 'b', startLine: 9, cyclomatic: 1, coverage: null, crap: null },
-      { method: 'c', startLine: 12, cyclomatic: 3, coverage: 0.8, crap: null },
-    ];
+  it('skips methods with null crap or null coverage under requireCoverage', () => {
     const out = handleCombinedMiCrapWorkerMessage(
-      { item: okItem },
+      { item: { ...okItem, requireCoverage: true } },
       stubDeps({
-        analyze: () => ({ miScore: 50, crapRows: rawRows, parseError: false }),
+        analyze: () => ({
+          miScore: 50,
+          crapRows: UNRESOLVED_ROWS,
+          parseError: false,
+        }),
       }),
     );
     assert.equal(out.message.result.crapRows.length, 1);
     assert.equal(out.message.result.skippedMethodsNoCoverage, 2);
     assert.equal(out.message.result.miScore, 50);
+    assert.equal(out.message.result.resolvedMethods, 1);
+    assert.equal(out.message.result.totalMethods, 3);
+  });
+
+  it('scores unresolved methods at 0% when requireCoverage is false', () => {
+    // Story #4775 (AC-5) — same policy as the CRAP-only worker; the combined
+    // path must not diverge, which is what the parity suite pins.
+    const out = handleCombinedMiCrapWorkerMessage(
+      { item: { ...okItem, requireCoverage: false } },
+      stubDeps({
+        analyze: () => ({
+          miScore: 50,
+          crapRows: UNRESOLVED_ROWS,
+          parseError: false,
+        }),
+      }),
+    );
+    assert.equal(out.message.result.crapRows.length, 3);
+    assert.equal(out.message.result.skippedMethodsNoCoverage, 0);
+    const b = out.message.result.crapRows.find((r) => r.method === 'b');
+    assert.equal(b.coverage, 0);
+    assert.equal(b.crap, b.cyclomatic ** 2 + b.cyclomatic);
+    assert.equal(out.message.result.resolvedMethods, 1);
+    assert.equal(out.message.result.totalMethods, 3);
   });
 });

--- a/tests/lib/workers/crap-worker.test.js
+++ b/tests/lib/workers/crap-worker.test.js
@@ -13,6 +13,14 @@ const okItem = {
   coverageEntry: STUB_ENTRY,
 };
 
+// One resolved method and two the coverage join could not resolve — `b` has
+// no coverage at all, `c` resolved a ratio but no crap (a malformed row).
+const UNRESOLVED_METHODS = [
+  { method: 'a', startLine: 5, cyclomatic: 2, coverage: 1, crap: 2 },
+  { method: 'b', startLine: 9, cyclomatic: 1, coverage: null, crap: null },
+  { method: 'c', startLine: 12, cyclomatic: 3, coverage: 0.8, crap: null },
+];
+
 function stubDeps({
   readFile = () => 'export const x = 1;',
   transpile = (_abs, src) => src,
@@ -155,18 +163,35 @@ describe('handleCrapWorkerMessage — success rows', () => {
     assert.equal(out.message.result.skippedMethodsNoCoverage, 0);
   });
 
-  it('skips methods with null crap or null coverage and counts them', () => {
-    const methods = [
-      { method: 'a', startLine: 5, cyclomatic: 2, coverage: 1, crap: 2 },
-      { method: 'b', startLine: 9, cyclomatic: 1, coverage: null, crap: null },
-      { method: 'c', startLine: 12, cyclomatic: 3, coverage: 0.8, crap: null },
-    ];
+  it('skips methods with null crap or null coverage under requireCoverage', () => {
     const out = handleCrapWorkerMessage(
-      { item: okItem },
+      { item: { ...okItem, requireCoverage: true } },
       null,
-      stubDeps({ calculateCrap: () => methods }),
+      stubDeps({ calculateCrap: () => UNRESOLVED_METHODS }),
     );
     assert.equal(out.message.result.rows.length, 1);
     assert.equal(out.message.result.skippedMethodsNoCoverage, 2);
+    assert.equal(out.message.result.resolvedMethods, 1);
+    assert.equal(out.message.result.totalMethods, 3);
+  });
+
+  it('scores unresolved methods at 0% when requireCoverage is false', () => {
+    // Story #4775 (AC-5): the flag means "score it anyway". Dropping the
+    // method individually made it a no-op for baseline population.
+    const out = handleCrapWorkerMessage(
+      { item: { ...okItem, requireCoverage: false } },
+      null,
+      stubDeps({ calculateCrap: () => UNRESOLVED_METHODS }),
+    );
+    assert.equal(out.message.result.rows.length, 3);
+    assert.equal(out.message.result.skippedMethodsNoCoverage, 0);
+    for (const name of ['b', 'c']) {
+      const row = out.message.result.rows.find((r) => r.method === name);
+      assert.equal(row.coverage, 0);
+      assert.equal(row.crap, row.cyclomatic ** 2 + row.cyclomatic);
+    }
+    // The telemetry still reports the JOIN, not the fill.
+    assert.equal(out.message.result.resolvedMethods, 1);
+    assert.equal(out.message.result.totalMethods, 3);
   });
 });


### PR DESCRIPTION
Closes #4775

_Auto-opened by `/deliver`._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches quality-gate scoring, baseline persistence, and compare semantics across close/CI; misconfiguration could block updates until re-baseline, but behavior is intentionally fail-closed rather than silent wrong scores.
> 
> **Overview**
> Fixes the **CRAP per-method coverage join** so TypeScript/TSX methods resolve against istanbul in **original-source line coordinates**, with guards so thin or incomparable baselines cannot slip through.
> 
> **Scoring path:** TS transpile can opt into `{ withLineMap: true }` (Node `SourceMap`); method `lineStart` is remapped before lookup. Coverage matching is **exact line → innermost containing function → nearest decl within ±1**. Shared helpers (`methodRowsFromReport`, `finalizeMethodRows`, `prepareSourceForScoring`) keep serial, pool, and worker paths aligned. With `requireCoverage: false`, unresolved methods now score as **0% covered** instead of being dropped.
> 
> **Updater & config:** `update-crap-baseline.js` refuses to persist when join health is below **`minMethodResolutionRate`** (default 0.75, skipped under 25 joinable methods), with worst-file telemetry. Dogfood **`crap.floors.*.max`** moves **30 → 125** to reflect an honest rollup after more methods become visible.
> 
> **Baseline semantics:** CRAP envelopes stamp **`scoringSemantics: coverage-join-v2`**. `check-baselines` **fails closed** on stamp mismatch; head-vs-base compare is **skipped** when base and head semantics differ (floors still apply).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b8222382bae1c53aad225f239831a0ca83c7d375. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->