### PR TITLE
feat(crap): wire the baseline-refresh projection layer and add CRAP freshness + full-scope drift detection (#4776)

### DIFF
--- a/.agents/docs/quality-gates.md
+++ b/.agents/docs/quality-gates.md
@@ -419,6 +419,66 @@ system, or the unresolved-method policy changes.
 
 ---
 
+## Keeping a baseline fresh (Story #4776)
+
+Populating a baseline correctly is only half the loop. The other half is
+keeping it correct as the tree grows, and that half has two distinct holes —
+one at close time, one over the long run. Both are **advisory**:
+`check-baselines` already fails closed on a real regression, and duplicating
+that would double-gate the same defect.
+
+### Pre-merge projections — the refresh nudge at close time
+
+Close-validation projects, after its gates pass, which committed baseline rows
+the post-merge tree would breach, and names the exact remedy while the operator
+still has the branch in hand:
+
+- `lib/close-validation/projections/maintainability.js` — per-file MI.
+- `lib/close-validation/projections/crap.js` — per-method CRAP, against each
+  method's baseline row or, for methods with no row, `newMethodCeiling`.
+
+Both are wired through `projections/advisories.js`, which
+`close-validation/runner.js` calls once. Each self-skips — logging the reason,
+never erroring — when its gate is disabled, when no baseline exists, when the
+diff has no scorable files, or when the CRAP scorer finds no coverage
+artifact. A projected breach never changes the close verdict.
+
+> The maintainability projection shipped in v1 fully written and fully
+> unit-tested, and the v2 Epic-tier collapse removed its only caller. It sat
+> importable-but-unimported for the whole of v2, so its advisory never fired
+> once. `tests/lib/close-validation/runner-projections.test.js` now walks the
+> import graph and fails if **any** module under `projections/` is reachable
+> from nothing in production — the orphaning itself is the regression.
+
+### `check-baseline-drift.js` — the scheduled full-scope re-score
+
+Every per-PR enforcement site (close-validation, pre-push, CI) is
+**diff-scoped**: it compares the files a branch touched against their baseline
+rows. A file nobody touches after its row is written is therefore never
+re-scored, so drift introduced *indirectly* — a dependency getting more
+complex, coverage moving underneath a method — stays invisible indefinitely.
+Full-scope scoring on every push is far too expensive to be the answer.
+
+```bash
+node .agents/scripts/check-baseline-drift.js                     # both kinds
+node .agents/scripts/check-baseline-drift.js --gate crap         # one kind
+node .agents/scripts/check-baseline-drift.js --tolerance 1 --json
+```
+
+It re-scores full-scope through the *same* scorer that writes the baseline
+(`refresh-service.resolveDefaultScorer`) — scoring by a second implementation
+would report the two implementations' disagreement as drift — and prints a
+per-row before/after table for everything that moved beyond the gate's
+tolerance, **in either direction**. A row that silently improved is equally
+strong evidence the baseline no longer describes the tree.
+
+Exit codes: `0` no drift (or every kind skipped), `1` drift detected, `2` the
+check could not run. It is designed to be wired as a scheduled CI job;
+scheduling it is deliberately consumer-side work, and nothing in this
+repository runs it automatically.
+
+---
+
 ## Bundle-size ratchet — one-shot refresh/acknowledge (Story #151)
 
 > Baseline envelope, axes, and component model: see the

--- a/.agents/scripts/check-baseline-drift.js
+++ b/.agents/scripts/check-baseline-drift.js
@@ -1,0 +1,138 @@
+#!/usr/bin/env node
+
+// .agents/scripts/check-baseline-drift.js — scheduled full-scope baseline
+// drift check (Story #4776).
+//
+// The three per-PR enforcement sites (close-validation, pre-push, CI) are all
+// diff-scoped: they compare the files a branch touched against their committed
+// baseline rows. A file nobody touches after its row is written is therefore
+// never re-scored, so drift introduced indirectly — a dependency getting more
+// complex, coverage moving underneath a method — stays invisible indefinitely.
+//
+// This CLI is the periodic full-scope counterpart. It re-scores every target
+// directory through the same scorer that writes the baseline, prints a per-row
+// before/after table for everything that moved beyond the gate's tolerance,
+// and exits non-zero when it finds any — so a consumer can wire it as a
+// scheduled CI job without wrapping it in verdict-parsing glue. Wiring it is
+// deliberately consumer-side work; nothing in this repo schedules it.
+//
+// Exit codes:
+//   0 — no drift (or every kind skipped: disabled gate, no baseline, no scorer)
+//   1 — drift detected in at least one kind
+//   2 — the check itself could not run
+
+// Fail-fast if the framework's runtime deps are not installed — must be the
+// first import so the check runs before any third-party-importing sibling
+// module is evaluated (Story #3432).
+import './lib/runtime-deps/ensure-installed.js';
+import {
+  DRIFT_KINDS,
+  detectBaselineDrift,
+  formatDriftReport,
+} from './lib/baselines/drift-detector.js';
+import { runAsCli } from './lib/cli-utils.js';
+
+export const HELP_TEXT = `Usage: node .agents/scripts/check-baseline-drift.js [options]
+
+Re-score the configured baselines FULL-SCOPE and report every row whose
+current score has drifted from its committed baseline by more than the
+gate's tolerance — including files untouched by any recent diff, which the
+diff-scoped gates structurally cannot see.
+
+Options:
+  --gate <kind>       Restrict to one kind (repeatable). Default: ${DRIFT_KINDS.join(', ')}.
+  --tolerance <n>     Override the per-gate absolute tolerance.
+  --json              Emit the machine-readable report instead of the table.
+  -h, --help          Show this help.
+
+Exit codes: 0 no drift · 1 drift detected · 2 the check could not run.
+
+On drift, refresh with the printed \`*:update -- --full-scope\` command and
+commit the result with a \`baseline-refresh:\` tagged subject (non-empty body).`;
+
+/**
+ * Parse the CLI surface. Unknown flags are rejected so a typo'd `--gate`
+ * cannot silently widen a scheduled job's scope.
+ *
+ * @param {string[]} argv
+ * @returns {{ kinds: string[], tolerance: number|null, json: boolean }}
+ */
+export function parseArgs(argv = []) {
+  const kinds = [];
+  let tolerance = null;
+  let json = false;
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === '--gate' && argv[i + 1]) {
+      const kind = argv[i + 1];
+      if (!DRIFT_KINDS.includes(kind)) {
+        throw new Error(
+          `[drift] unknown --gate "${kind}"; expected one of ${DRIFT_KINDS.join(', ')}`,
+        );
+      }
+      kinds.push(kind);
+      i += 1;
+    } else if (arg === '--tolerance' && argv[i + 1]) {
+      const value = Number(argv[i + 1]);
+      if (!Number.isFinite(value)) {
+        throw new Error(
+          `[drift] --tolerance must be a number (got ${argv[i + 1]})`,
+        );
+      }
+      tolerance = value;
+      i += 1;
+    } else if (arg === '--json') {
+      json = true;
+    } else {
+      throw new Error(`[drift] unrecognised argument "${arg}"`);
+    }
+  }
+  return {
+    kinds: kinds.length > 0 ? kinds : [...DRIFT_KINDS],
+    tolerance,
+    json,
+  };
+}
+
+/**
+ * Run the drift check and render it. Returns the process exit code rather
+ * than exiting, so the whole path is unit-testable.
+ *
+ * @param {{ argv?: string[], cwd?: string, detect?: typeof detectBaselineDrift }} opts
+ * @returns {Promise<{ exitCode: number, output: string }>}
+ */
+export async function runCheckBaselineDrift({
+  argv = [],
+  cwd = process.cwd(),
+  detect = detectBaselineDrift,
+} = {}) {
+  const args = parseArgs(argv);
+  const run = await detect({
+    kinds: args.kinds,
+    cwd,
+    tolerance: args.tolerance,
+  });
+  const output = args.json
+    ? JSON.stringify({ schemaVersion: '1', ...run }, null, 2)
+    : formatDriftReport(run);
+  return { exitCode: run.ok ? 0 : 1, output };
+}
+
+async function main() {
+  let result;
+  try {
+    result = await runCheckBaselineDrift({ argv: process.argv.slice(2) });
+  } catch (err) {
+    process.stdout.write(`${err?.message ?? String(err)}\n`);
+    process.exit(2);
+    return;
+  }
+  process.stdout.write(`${result.output}\n`);
+  process.exit(result.exitCode);
+}
+
+runAsCli(import.meta.url, main, {
+  source: 'check-baseline-drift',
+  usage: HELP_TEXT,
+  exitCode: 2,
+});

--- a/.agents/scripts/lib/baselines/drift-detector.js
+++ b/.agents/scripts/lib/baselines/drift-detector.js
@@ -1,0 +1,343 @@
+// .agents/scripts/lib/baselines/drift-detector.js
+/**
+ * drift-detector.js — full-scope baseline drift detection (Story #4776).
+ *
+ * Every enforcement site for the maintainability and CRAP baselines is
+ * **diff-scoped**: close-validation, the pre-push hook and CI all compare
+ * the files a branch touched against their committed rows. That is the
+ * right per-PR trade — full-scope scoring on every push would be far too
+ * expensive — but it has a structural blind spot. A file that is never
+ * modified after its baseline row is written is never re-scored, so a
+ * regression introduced *indirectly* (a dependency getting more complex, a
+ * test deletion moving coverage underneath it) is invisible for as long as
+ * nobody happens to touch that file.
+ *
+ * This module closes that hole with the check that is too expensive to run
+ * per-PR and cheap enough to run on a schedule: re-score every target
+ * directory in full, and report every row whose current score has moved
+ * away from its baseline by more than the gate's tolerance — **in either
+ * direction**. Drift, not regression: a row that silently improved is
+ * equally strong evidence that the committed baseline no longer describes
+ * the tree, and leaving it stale means the ratchet is anchored to a number
+ * that no longer exists.
+ *
+ * Re-scoring routes through `refresh-service.resolveDefaultScorer` — the
+ * same scorer that writes the baseline — so the detector cannot report two
+ * implementations disagreeing with each other as drift in the tree.
+ *
+ * Pure-ish: the scorer and the baseline loader are both injectable, and the
+ * module never writes anything, exits, or emits friction.
+ */
+
+import { getQuality } from '../config/quality.js';
+import { resolveConfig } from '../config-resolver.js';
+import { getKindModule } from './kernel.js';
+import { load as loadBaseline } from './reader.js';
+import { resolveDefaultScorer } from './refresh-service.js';
+
+/** The kinds whose rows carry a per-file/per-method score worth re-scoring. */
+export const DRIFT_KINDS = Object.freeze(['maintainability', 'crap']);
+
+/**
+ * Per-kind identity, metric axis, and refresh remedy. `identity` must match
+ * the granularity the kind's baseline rows are keyed at, or unchanged rows
+ * masquerade as added/removed pairs.
+ */
+const KIND_SPECS = Object.freeze({
+  maintainability: Object.freeze({
+    metric: 'mi',
+    identity: (row) => row.path,
+    label: (row) => row.path,
+    refreshCommand: 'npm run maintainability:update -- --full-scope',
+    defaultTolerance: 0.5,
+  }),
+  crap: Object.freeze({
+    metric: 'crap',
+    identity: (row) => `${row.path}::${row.method}@${row.startLine}`,
+    label: (row) => `${row.path}::${row.method} (line ${row.startLine})`,
+    refreshCommand: 'npm run crap:update -- --full-scope',
+    defaultTolerance: 0.001,
+  }),
+});
+
+/**
+ * Resolve the absolute drift tolerance for a kind: an explicit override
+ * wins, then the gate's configured `tolerance.value`, then the per-kind
+ * default.
+ *
+ * @param {string} kind
+ * @param {object|undefined} gate resolved `delivery.quality.gates.<kind>`
+ * @param {number|null|undefined} override
+ * @returns {number}
+ */
+export function resolveTolerance(kind, gate, override) {
+  if (typeof override === 'number' && Number.isFinite(override)) {
+    return Math.abs(override);
+  }
+  const configured = gate?.tolerance;
+  if (configured?.kind === 'absolute') {
+    const value = Number(configured.value);
+    if (Number.isFinite(value)) return Math.abs(value);
+  }
+  return KIND_SPECS[kind].defaultTolerance;
+}
+
+/**
+ * Normalise a scorer's raw rows into the kind's canonical on-disk row
+ * shape, so scored rows and baseline rows are directly comparable. The
+ * per-kind `projectRow` is the same projection the writer applies, which is
+ * what makes the two sides comparable at all (it also reconciles the CRAP
+ * scorer's `file` key with the envelope's `path`).
+ *
+ * @param {string} kind
+ * @param {Array<object>} rows
+ * @returns {Array<object>}
+ */
+export function projectScoredRows(kind, rows) {
+  const mod = getKindModule(kind);
+  const out = [];
+  for (const row of rows ?? []) {
+    try {
+      out.push(mod.projectRow(row));
+    } catch {
+      // A row the writer itself would refuse is not evidence of drift.
+    }
+  }
+  return out;
+}
+
+/**
+ * Diff two row sets by the kind's identity, classifying each key as
+ * drifted / added / removed. Pure.
+ *
+ * @param {{ kind: string, baselineRows: Array<object>, currentRows: Array<object>, tolerance: number }} opts
+ * @returns {{ drifted: Array<object>, added: Array<object>, removed: Array<object> }}
+ */
+export function diffRows({ kind, baselineRows, currentRows, tolerance }) {
+  const spec = KIND_SPECS[kind];
+  const baseByKey = new Map();
+  for (const row of baselineRows ?? []) baseByKey.set(spec.identity(row), row);
+
+  const drifted = [];
+  const added = [];
+  const seen = new Set();
+
+  for (const row of currentRows ?? []) {
+    const key = spec.identity(row);
+    seen.add(key);
+    const base = baseByKey.get(key);
+    if (!base) {
+      added.push({ key, label: spec.label(row), current: row[spec.metric] });
+      continue;
+    }
+    const before = Number(base[spec.metric] ?? 0);
+    const after = Number(row[spec.metric] ?? 0);
+    const delta = after - before;
+    if (Math.abs(delta) <= tolerance) continue;
+    drifted.push({
+      key,
+      label: spec.label(row),
+      baseline: before,
+      current: after,
+      delta,
+    });
+  }
+
+  const removed = [];
+  for (const [key, row] of baseByKey) {
+    if (seen.has(key)) continue;
+    removed.push({ key, label: spec.label(row), baseline: row[spec.metric] });
+  }
+
+  return { drifted, added, removed };
+}
+
+/**
+ * Re-score one kind full-scope and diff the result against its committed
+ * baseline.
+ *
+ * Returns `{ ok: true, skipped: '<reason>' }` when the kind cannot be
+ * checked (gate disabled, no baseline on disk, no scorer registered, the
+ * scorer produced nothing) — an unscorable kind is not drift, and a
+ * scheduled job must not go red because coverage happened to be absent.
+ *
+ * @param {{
+ *   kind: string,
+ *   cwd?: string,
+ *   quality?: object,
+ *   tolerance?: number|null,
+ *   loadBaselineRows?: (kind: string, cwd: string) => Array<object>|null,
+ *   scoreFullScope?: (kind: string, cwd: string) => Promise<Array<object>|null>|Array<object>|null,
+ * }} opts
+ * @returns {Promise<object>}
+ */
+export async function detectKindDrift({
+  kind,
+  cwd = process.cwd(),
+  quality,
+  tolerance = null,
+  loadBaselineRows = defaultLoadBaselineRows,
+  scoreFullScope = defaultScoreFullScope,
+}) {
+  if (!Object.hasOwn(KIND_SPECS, kind)) {
+    throw new Error(
+      `[drift] unknown kind "${kind}"; expected one of ${DRIFT_KINDS.join(', ')}`,
+    );
+  }
+  const gate = quality?.[kind];
+  const spec = KIND_SPECS[kind];
+  const base = { kind, refreshCommand: spec.refreshCommand };
+  if (gate?.enabled === false) {
+    return { ...base, ok: true, skipped: 'gate-disabled' };
+  }
+
+  const baselineRows = loadBaselineRows(kind, cwd);
+  if (!Array.isArray(baselineRows) || baselineRows.length === 0) {
+    return { ...base, ok: true, skipped: 'no-baseline' };
+  }
+
+  const raw = await scoreFullScope(kind, cwd);
+  if (raw === null || raw === undefined) {
+    return { ...base, ok: true, skipped: 'no-scorer' };
+  }
+  const currentRows = projectScoredRows(kind, raw);
+  if (currentRows.length === 0) {
+    return { ...base, ok: true, skipped: 'no-scored-rows' };
+  }
+
+  const resolvedTolerance = resolveTolerance(kind, gate, tolerance);
+  const { drifted, added, removed } = diffRows({
+    kind,
+    baselineRows,
+    currentRows,
+    tolerance: resolvedTolerance,
+  });
+
+  return {
+    ...base,
+    ok: drifted.length === 0,
+    tolerance: resolvedTolerance,
+    scanned: currentRows.length,
+    baselineRows: baselineRows.length,
+    drifted,
+    added,
+    removed,
+  };
+}
+
+/**
+ * Run the drift check across several kinds.
+ *
+ * @param {{ kinds?: string[], cwd?: string, tolerance?: number|null, quality?: object }} opts
+ * @returns {Promise<{ ok: boolean, results: Array<object> }>}
+ */
+export async function detectBaselineDrift({
+  kinds = DRIFT_KINDS,
+  cwd = process.cwd(),
+  tolerance = null,
+  quality,
+  ...seams
+} = {}) {
+  let resolvedQuality = quality;
+  if (!resolvedQuality) {
+    try {
+      resolvedQuality = getQuality(resolveConfig({ cwd })) ?? {};
+    } catch {
+      resolvedQuality = {};
+    }
+  }
+  const results = [];
+  for (const kind of kinds) {
+    results.push(
+      await detectKindDrift({
+        kind,
+        cwd,
+        tolerance,
+        quality: resolvedQuality,
+        ...seams,
+      }),
+    );
+  }
+  return { ok: results.every((r) => r.ok), results };
+}
+
+/**
+ * Default baseline loader — reads and schema-validates the committed
+ * envelope. Returns `null` when it cannot be read, which the caller maps to
+ * the `no-baseline` skip.
+ */
+function defaultLoadBaselineRows(kind, cwd) {
+  try {
+    return loadBaseline(kind, { cwd }).rows;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Default full-scope scorer — the same scorer `refreshBaseline` uses, run
+ * with `fullScope: true` so it walks every configured target directory
+ * rather than a diff-derived file list.
+ */
+async function defaultScoreFullScope(kind, cwd) {
+  const scorer = resolveDefaultScorer(kind, { cwd });
+  if (typeof scorer !== 'function') return null;
+  return await scorer(null, { fullScope: true, cwd });
+}
+
+/**
+ * Render one kind's result as an operator-facing block: a per-row
+ * before/after table plus the refresh remedy. Returns a string always —
+ * a clean kind reports one line so a scheduled job's log shows it ran.
+ *
+ * @param {object} result
+ * @returns {string}
+ */
+export function formatKindDrift(result) {
+  if (result.skipped) {
+    return `[drift] ⏭ ${result.kind}: skipped (${result.skipped})`;
+  }
+  if (result.ok) {
+    return `[drift] ✓ ${result.kind}: ${result.scanned} row(s) re-scored full-scope, no drift beyond ±${result.tolerance}`;
+  }
+  const width = Math.max(
+    12,
+    ...result.drifted.map((d) => String(d.label).length),
+  );
+  const lines = [
+    `[drift] ✖ ${result.kind}: ${result.drifted.length} row(s) drifted beyond ±${result.tolerance} (${result.scanned} re-scored, ${result.baselineRows} in baseline)`,
+    `  ${'ROW'.padEnd(width)}  ${'BASELINE'.padStart(10)}  ${'CURRENT'.padStart(10)}  ${'DELTA'.padStart(10)}`,
+  ];
+  for (const d of result.drifted) {
+    lines.push(
+      `  ${String(d.label).padEnd(width)}  ${d.baseline.toFixed(2).padStart(10)}  ${d.current
+        .toFixed(2)
+        .padStart(
+          10,
+        )}  ${(d.delta > 0 ? `+${d.delta.toFixed(2)}` : d.delta.toFixed(2)).padStart(10)}`,
+    );
+  }
+  if (result.added.length > 0 || result.removed.length > 0) {
+    lines.push(
+      `  (${result.added.length} row(s) absent from baseline, ${result.removed.length} baseline row(s) absent from the tree)`,
+    );
+  }
+  lines.push(
+    `  Remedy: run \`${result.refreshCommand}\` and commit the refreshed baseline with a \`baseline-refresh:\` tagged subject (non-empty body).`,
+  );
+  return lines.join('\n');
+}
+
+/**
+ * Render the whole run.
+ *
+ * @param {{ ok: boolean, results: Array<object> }} run
+ * @returns {string}
+ */
+export function formatDriftReport(run) {
+  const body = run.results.map(formatKindDrift).join('\n');
+  const tail = run.ok
+    ? '[drift] ✅ No baseline drift detected.'
+    : '[drift] ❌ Baseline drift detected — the committed baselines no longer describe the tree.';
+  return `${body}\n${tail}`;
+}

--- a/.agents/scripts/lib/baselines/drift-detector.js
+++ b/.agents/scripts/lib/baselines/drift-detector.js
@@ -27,6 +27,14 @@
  *
  * Pure-ish: the scorer and the baseline loader are both injectable, and the
  * module never writes anything, exits, or emits friction.
+ *
+ * The public surface is deliberately the three symbols the CLI actually
+ * uses — `DRIFT_KINDS`, `detectBaselineDrift`, `formatDriftReport`. Every
+ * internal helper below stays module-local and is exercised through them
+ * (`detectBaselineDrift` forwards its `loadBaselineRows` / `scoreFullScope`
+ * seams straight down). Exporting the helpers so tests could reach them
+ * directly would ship five entry points nothing in production reaches —
+ * exactly the orphaning this Story exists to stop.
  */
 
 import { getQuality } from '../config/quality.js';
@@ -70,7 +78,7 @@ const KIND_SPECS = Object.freeze({
  * @param {number|null|undefined} override
  * @returns {number}
  */
-export function resolveTolerance(kind, gate, override) {
+function resolveTolerance(kind, gate, override) {
   if (typeof override === 'number' && Number.isFinite(override)) {
     return Math.abs(override);
   }
@@ -93,7 +101,7 @@ export function resolveTolerance(kind, gate, override) {
  * @param {Array<object>} rows
  * @returns {Array<object>}
  */
-export function projectScoredRows(kind, rows) {
+function projectScoredRows(kind, rows) {
   const mod = getKindModule(kind);
   const out = [];
   for (const row of rows ?? []) {
@@ -113,7 +121,7 @@ export function projectScoredRows(kind, rows) {
  * @param {{ kind: string, baselineRows: Array<object>, currentRows: Array<object>, tolerance: number }} opts
  * @returns {{ drifted: Array<object>, added: Array<object>, removed: Array<object> }}
  */
-export function diffRows({ kind, baselineRows, currentRows, tolerance }) {
+function diffRows({ kind, baselineRows, currentRows, tolerance }) {
   const spec = KIND_SPECS[kind];
   const baseByKey = new Map();
   for (const row of baselineRows ?? []) baseByKey.set(spec.identity(row), row);
@@ -171,7 +179,7 @@ export function diffRows({ kind, baselineRows, currentRows, tolerance }) {
  * }} opts
  * @returns {Promise<object>}
  */
-export async function detectKindDrift({
+async function detectKindDrift({
   kind,
   cwd = process.cwd(),
   quality,
@@ -293,7 +301,7 @@ async function defaultScoreFullScope(kind, cwd) {
  * @param {object} result
  * @returns {string}
  */
-export function formatKindDrift(result) {
+function formatKindDrift(result) {
   if (result.skipped) {
     return `[drift] ⏭ ${result.kind}: skipped (${result.skipped})`;
   }

--- a/.agents/scripts/lib/baselines/refresh-service.js
+++ b/.agents/scripts/lib/baselines/refresh-service.js
@@ -355,11 +355,17 @@ const KIND_SCORER_BUILDERS = Object.freeze({
  * rather than crashing the refresh. The production crap/maintainability paths
  * never rely on this fallback — they inject an explicit, configured scorer.
  *
+ * Exported since Story #4776 so the full-scope drift detector
+ * (`check-baseline-drift.js`) re-scores through the *same* scorer that
+ * writes the baseline. A drift check scoring by a second, parallel
+ * implementation would report the two implementations' disagreement as
+ * drift, which is exactly the false signal it exists to rule out.
+ *
  * @param {string} kind
  * @param {{ cwd: string }} opts
  * @returns {((files: string[], opts: object) => Promise<object[]> | object[]) | undefined}
  */
-function resolveDefaultScorer(kind, { cwd } = {}) {
+export function resolveDefaultScorer(kind, { cwd } = {}) {
   const builder = KIND_SCORER_BUILDERS[kind];
   if (typeof builder !== 'function') return undefined;
   const effectiveCwd = cwd ?? process.cwd();

--- a/.agents/scripts/lib/close-validation/projections/advisories.js
+++ b/.agents/scripts/lib/close-validation/projections/advisories.js
@@ -1,0 +1,184 @@
+// .agents/scripts/lib/close-validation/projections/advisories.js
+/**
+ * advisories.js — the projection layer's single call site (Story #4776).
+ *
+ * `projections/maintainability.js` shipped fully written, fully unit-tested
+ * and imported by nothing: the v2 Epic-tier collapse removed its caller and
+ * left the module behind. The practical consequence was that the advisory
+ * telling an operator to run `npm run maintainability:update` and commit a
+ * `baseline-refresh:` subject had never fired in v2 — consumers refreshed
+ * their baselines by hand or not at all.
+ *
+ * This module is that caller, for both projections. It is deliberately the
+ * only door: `close-validation/runner.js` invokes `runProjectionAdvisories`
+ * once, after the gate chain has passed, and every per-kind concern (gate
+ * enablement, baseline path resolution, scorer construction, formatting)
+ * lives here rather than being re-derived at the runner boundary.
+ *
+ * **Advisory, always.** Nothing in here can fail a close. `check-baselines`
+ * already fails closed on a real regression; the projections add the refresh
+ * half of the loop, not a second gate. Every projection is wrapped so a
+ * throw becomes a logged skip.
+ */
+
+import path from 'node:path';
+import { getQuality } from '../../config/quality.js';
+import {
+  createCrapScorer,
+  formatCrapProjection,
+  projectCrapBreaches,
+} from './crap.js';
+import {
+  formatMaintainabilityProjection,
+  projectMaintainabilityRegressions,
+} from './maintainability.js';
+
+/** Default on-disk baseline locations, mirroring the per-gate defaults. */
+const DEFAULT_BASELINE_PATHS = Object.freeze({
+  maintainability: 'baselines/maintainability.json',
+  crap: 'baselines/crap.json',
+});
+
+/**
+ * Resolve a gate's baseline file to an absolute path.
+ *
+ * @param {string} kind
+ * @param {object} gate resolved `delivery.quality.gates.<kind>` block
+ * @param {string} cwd
+ * @returns {string}
+ */
+function resolveBaselinePath(kind, gate, cwd) {
+  const rel =
+    typeof gate?.baselinePath === 'string' && gate.baselinePath.length > 0
+      ? gate.baselinePath
+      : DEFAULT_BASELINE_PATHS[kind];
+  return path.isAbsolute(rel) ? rel : path.resolve(cwd, rel);
+}
+
+/**
+ * A gate is projected unless it is explicitly disabled. An absent gate
+ * block means "framework defaults", which enable it — the same reading
+ * `buildDefaultGates` applies.
+ *
+ * @param {object|undefined} gate
+ * @returns {boolean}
+ */
+function isEnabled(gate) {
+  return gate?.enabled !== false;
+}
+
+/**
+ * Run one projection with its formatter, swallowing every failure into a
+ * logged skip. Returns the projection result (or `null` when it threw) so
+ * callers and tests can inspect what happened without parsing log lines.
+ *
+ * @param {{ kind: string, log: (m: string) => void, run: () => Promise<object>|object, format: (r: object) => string|null }} opts
+ * @returns {Promise<object|null>}
+ */
+async function runOne({ kind, log, run, format }) {
+  let result;
+  try {
+    result = await run();
+  } catch (err) {
+    log(
+      `[close-validation]   ⚠ ${kind} projection skipped (errored): ${err?.message ?? err}`,
+    );
+    return null;
+  }
+  if (result?.skipped) {
+    log(
+      `[close-validation] ⏭ ${kind} projection skipped (${result.skipped}${
+        result.detail ? `: ${result.detail}` : ''
+      })`,
+    );
+    return result;
+  }
+  const advisory = format(result);
+  if (advisory) log(advisory);
+  return result;
+}
+
+/**
+ * Run the maintainability and CRAP pre-merge projections and log their
+ * advisories. Never throws; never affects the close verdict.
+ *
+ * @param {{
+ *   cwd: string,
+ *   baseBranch: string,
+ *   storyBranch: string,
+ *   config?: object,
+ *   quality?: object,
+ *   log?: (m: string) => void,
+ *   projectMaintainability?: typeof projectMaintainabilityRegressions,
+ *   formatMaintainability?: typeof formatMaintainabilityProjection,
+ *   projectCrap?: typeof projectCrapBreaches,
+ *   formatCrap?: typeof formatCrapProjection,
+ * }} opts
+ * @returns {Promise<{ maintainability: object|null, crap: object|null }>}
+ */
+export async function runProjectionAdvisories({
+  cwd,
+  baseBranch,
+  storyBranch,
+  config,
+  quality,
+  log = () => {},
+  projectMaintainability = projectMaintainabilityRegressions,
+  formatMaintainability = formatMaintainabilityProjection,
+  projectCrap = projectCrapBreaches,
+  formatCrap = formatCrapProjection,
+} = {}) {
+  const out = { maintainability: null, crap: null };
+  let gates;
+  try {
+    gates = quality ?? getQuality(config) ?? {};
+  } catch {
+    gates = {};
+  }
+
+  const miGate = gates.maintainability;
+  if (isEnabled(miGate)) {
+    out.maintainability = await runOne({
+      kind: 'maintainability',
+      log,
+      format: formatMaintainability,
+      run: () =>
+        projectMaintainability({
+          cwd,
+          baseBranch,
+          storyBranch,
+          baselinePath: resolveBaselinePath('maintainability', miGate, cwd),
+        }),
+    });
+  } else {
+    log('[close-validation] ⏭ maintainability projection skipped (disabled)');
+  }
+
+  const crapGate = gates.crap;
+  if (isEnabled(crapGate)) {
+    out.crap = await runOne({
+      kind: 'crap',
+      log,
+      format: formatCrap,
+      run: () =>
+        projectCrap({
+          cwd,
+          baseBranch,
+          storyBranch,
+          baselinePath: resolveBaselinePath('crap', crapGate, cwd),
+          newMethodCeiling: crapGate?.newMethodCeiling,
+          scoreFiles: createCrapScorer({
+            cwd,
+            targetDirs: crapGate?.targetDirs,
+            ignoreGlobs: crapGate?.ignoreGlobs,
+            requireCoverage: crapGate?.requireCoverage,
+            coveragePath: crapGate?.coveragePath,
+          }),
+        }),
+    });
+  } else {
+    log('[close-validation] ⏭ crap projection skipped (disabled)');
+  }
+
+  return out;
+}

--- a/.agents/scripts/lib/close-validation/projections/crap.js
+++ b/.agents/scripts/lib/close-validation/projections/crap.js
@@ -69,10 +69,15 @@ function normaliseSkipReason(reason) {
  * Returns `[]` when the baseline is absent or unreadable — the caller maps
  * that to the `no-baseline` skip.
  *
+ * Deliberately module-local: `projectCrapBreaches`'s `loadBaseline` default
+ * is the single production door to it, and tests inject their own loader.
+ * Exporting it would add a second entry point nothing in production reaches
+ * — which is precisely the orphaning this Story exists to stop.
+ *
  * @param {string} baselinePath absolute path to `baselines/crap.json`
  * @returns {Array<{file: string, method: string, startLine: number, crap: number}>}
  */
-export function loadCrapBaselineRows(baselinePath) {
+function loadCrapBaselineRows(baselinePath) {
   let envelope;
   try {
     envelope = loadBaselineFile(baselinePath, { kind: 'crap' });

--- a/.agents/scripts/lib/close-validation/projections/crap.js
+++ b/.agents/scripts/lib/close-validation/projections/crap.js
@@ -1,0 +1,298 @@
+// .agents/scripts/lib/close-validation/projections/crap.js
+/**
+ * crap.js — pre-merge CRAP ceiling projection helper (Story #4776).
+ *
+ * The CRAP analogue of `projections/maintainability.js`. Both answer the
+ * same operator question before the merge runs: *given what this branch
+ * changed, which committed baseline rows would the post-merge tree breach,
+ * and what is the exact remedy?*
+ *
+ * Advisory only. `check-baselines` already fails close-validation closed on
+ * a real regression; duplicating that here would double-gate the same
+ * defect. What this projection adds is the **refresh** half of the loop —
+ * naming the breaching methods and the `npm run crap:update` +
+ * `baseline-refresh:` remedy while the operator still has the branch in
+ * hand, so a corrected baseline does not rot back into staleness.
+ *
+ * The helper never throws and never mutates anything. Every failure path
+ * resolves to `{ ok: true, breaches: [], skipped: '<reason>' }` so the
+ * caller can treat the advisory as best-effort.
+ *
+ * Post-merge approximation: CRAP needs a coverage join, so — unlike the MI
+ * projection, which scores a `git show` blob — the scorer reads the working
+ * tree. Close-validation runs inside the Story worktree at the branch tip,
+ * which is exactly the content a squash-merge lands, so the approximation is
+ * exact whenever the merge applies cleanly.
+ */
+
+import path from 'node:path';
+import {
+  compareCrap,
+  filterRowsByFileScope,
+} from '../../baselines/kinds/crap.js';
+import { loadFile as loadBaselineFile } from '../../baselines/reader.js';
+import { diffNameOnly } from '../../changed-files.js';
+import { loadCoverage } from '../../coverage-utils.js';
+import { scanAndScore } from '../../crap-utils.js';
+import { cachedGitFetchSync } from '../../git/cached-fetch.js';
+import { gitSpawn as defaultGitSpawn } from '../../git-utils.js';
+import { MISSING_ARG_REASONS, validateProjectionInputs } from './inputs.js';
+
+/**
+ * Default absolute tolerance on a projected CRAP score, shared with
+ * `check-crap`'s regression arm: floating-point noise must not register as
+ * a breach.
+ */
+export const DEFAULT_CRAP_TOLERANCE = 0.001;
+
+/** Framework default for the new-method ceiling (`gates.crap.newMethodCeiling`). */
+export const DEFAULT_NEW_METHOD_CEILING = 30;
+
+/** Extensions the CRAP scanner can score. */
+const SCORABLE = /\.(?:js|mjs|cjs|ts|tsx)$/;
+
+/**
+ * Map the shared predicate's fine-grained `missing-*` reason onto the
+ * `missing-args` skipped-reason the sibling MI projection reports, so both
+ * projections speak one vocabulary at the advisory boundary.
+ *
+ * @param {string} reason
+ * @returns {string}
+ */
+function normaliseSkipReason(reason) {
+  return MISSING_ARG_REASONS.has(reason) ? 'missing-args' : reason;
+}
+
+/**
+ * Read the committed CRAP baseline and re-key its rows onto the `file`
+ * field `compareCrap` matches on (the on-disk v2 envelope keys on `path`).
+ * Returns `[]` when the baseline is absent or unreadable — the caller maps
+ * that to the `no-baseline` skip.
+ *
+ * @param {string} baselinePath absolute path to `baselines/crap.json`
+ * @returns {Array<{file: string, method: string, startLine: number, crap: number}>}
+ */
+export function loadCrapBaselineRows(baselinePath) {
+  let envelope;
+  try {
+    envelope = loadBaselineFile(baselinePath, { kind: 'crap' });
+  } catch {
+    return [];
+  }
+  const rows = Array.isArray(envelope?.rows) ? envelope.rows : [];
+  return rows.map((row) => ({
+    file: row.path,
+    method: row.method,
+    startLine: row.startLine,
+    crap: row.crap,
+  }));
+}
+
+/**
+ * Build the default working-tree CRAP scorer. Returns an async callable
+ * `(files) => rows | null`; `null` signals "coverage artifact missing under
+ * `requireCoverage`", which the projection reports as the `no-coverage`
+ * skip rather than as a clean run.
+ *
+ * @param {{
+ *   cwd: string,
+ *   targetDirs?: string[],
+ *   ignoreGlobs?: string[],
+ *   requireCoverage?: boolean,
+ *   coveragePath?: string,
+ * }} opts
+ * @returns {(files: string[]) => Promise<Array<object>|null>}
+ */
+export function createCrapScorer({
+  cwd,
+  targetDirs = [],
+  ignoreGlobs = [],
+  requireCoverage = true,
+  coveragePath = 'coverage/coverage-final.json',
+} = {}) {
+  return async (files) => {
+    const abs = path.isAbsolute(coveragePath)
+      ? coveragePath
+      : path.resolve(cwd, coveragePath);
+    const coverage = loadCoverage(abs);
+    if (!coverage && requireCoverage) return null;
+    const { rows } = await scanAndScore({
+      targetDirs,
+      coverage,
+      requireCoverage,
+      cwd,
+      ignoreGlobs,
+      scopeFiles: files,
+    });
+    return rows ?? [];
+  };
+}
+
+/**
+ * Refresh `origin/<baseBranch>` so the diff range resolves even when close
+ * has not reached its own base-sync step. Routed through the shared fetch
+ * cache so a story-init fetch in the same run satisfies it for free.
+ *
+ * @param {string} cwd
+ * @param {string} baseBranch
+ * @param {{ gitSpawn: typeof defaultGitSpawn }} git
+ * @returns {{ ok: true } | { ok: false, detail: string }}
+ */
+function refreshBaseRef(cwd, baseBranch, git) {
+  const res = cachedGitFetchSync(cwd, baseBranch, { gitSpawn: git.gitSpawn });
+  if (res.status !== 0) {
+    return {
+      ok: false,
+      detail: res.stderr || res.stdout || `exit ${res.status}`,
+    };
+  }
+  return { ok: true };
+}
+
+/**
+ * Enumerate the Story branch's changed files, narrowed to the extensions
+ * the CRAP scanner can score.
+ *
+ * @param {{ cwd: string, baseBranch: string, storyBranch: string, git: { gitSpawn: typeof defaultGitSpawn } }} opts
+ * @returns {{ ok: true, files: string[] } | { ok: false, detail: string }}
+ */
+function diffScorableFiles({ cwd, baseBranch, storyBranch, git }) {
+  try {
+    const files = diffNameOnly({
+      range: `origin/${baseBranch}...${storyBranch}`,
+      cwd,
+      gitSpawn: git.gitSpawn,
+    });
+    return { ok: true, files: files.filter((f) => SCORABLE.test(f)) };
+  } catch (err) {
+    return { ok: false, detail: err.message };
+  }
+}
+
+/**
+ * Project the post-merge CRAP scores for every file changed on the Story
+ * branch and return the subset of methods that would breach either their
+ * committed baseline row or, for methods with no baseline row, the
+ * configured `newMethodCeiling`.
+ *
+ * Baseline rows are narrowed to the changed-file set before the compare so
+ * every untouched file's rows are not spuriously reported as removed.
+ *
+ * @param {{
+ *   cwd: string,
+ *   baseBranch: string,
+ *   storyBranch: string,
+ *   baselinePath: string,
+ *   newMethodCeiling?: number,
+ *   tolerance?: number,
+ *   git?: { gitSpawn: typeof defaultGitSpawn },
+ *   loadBaseline?: (path: string) => Array<object>,
+ *   scoreFiles?: (files: string[]) => Promise<Array<object>|null>|Array<object>|null,
+ * }} opts
+ * @returns {Promise<{
+ *   ok: boolean,
+ *   breaches: Array<object>,
+ *   skipped?: string,
+ *   detail?: string,
+ * }>}
+ */
+export async function projectCrapBreaches({
+  cwd,
+  baseBranch,
+  storyBranch,
+  baselinePath,
+  newMethodCeiling = DEFAULT_NEW_METHOD_CEILING,
+  tolerance = DEFAULT_CRAP_TOLERANCE,
+  git = { gitSpawn: defaultGitSpawn },
+  loadBaseline = loadCrapBaselineRows,
+  scoreFiles,
+} = {}) {
+  const skip = (reason, detail) => ({
+    ok: true,
+    breaches: [],
+    skipped: reason,
+    ...(detail === undefined ? {} : { detail }),
+  });
+
+  const validation = validateProjectionInputs({
+    cwd,
+    baseBranch,
+    storyBranch,
+    baselinePath,
+  });
+  if (!validation.ok) return skip(normaliseSkipReason(validation.reason));
+
+  const baselineRows = loadBaseline(baselinePath);
+  if (!Array.isArray(baselineRows) || baselineRows.length === 0) {
+    return skip('no-baseline');
+  }
+
+  const fetched = refreshBaseRef(cwd, baseBranch, git);
+  if (!fetched.ok) return skip('fetch-failed', fetched.detail);
+
+  const diffed = diffScorableFiles({ cwd, baseBranch, storyBranch, git });
+  if (!diffed.ok) return skip('diff-failed', diffed.detail);
+  if (diffed.files.length === 0) return skip('no-scorable-files');
+
+  const scorer =
+    typeof scoreFiles === 'function' ? scoreFiles : createCrapScorer({ cwd });
+  let currentRows;
+  try {
+    currentRows = await scorer(diffed.files);
+  } catch (err) {
+    return skip('score-failed', err?.message ?? String(err));
+  }
+  if (currentRows === null || currentRows === undefined) {
+    return skip('no-coverage');
+  }
+  if (currentRows.length === 0) return skip('no-scored-methods');
+
+  const scopeSet = new Set(diffed.files);
+  const result = compareCrap({
+    currentRows,
+    baselineRows: filterRowsByFileScope(baselineRows, scopeSet),
+    newMethodCeiling,
+    tolerance,
+  });
+  const breaches = result.violations ?? [];
+  return { ok: breaches.length === 0, breaches };
+}
+
+/**
+ * Render one breach as an advisory bullet. New-method breaches name the
+ * ceiling they cleared; regressions name the baseline row they exceeded.
+ *
+ * @param {object} b
+ * @returns {string}
+ */
+function formatBreach(b) {
+  const where = `${b.file}::${b.method} (line ${b.startLine})`;
+  const projected = Number(b.crap ?? 0).toFixed(2);
+  if (b.kind === 'new') {
+    return `  • ${where}  projected=${projected}  ceiling=${b.ceiling}  [new method]`;
+  }
+  const baseline = Number(b.baseline ?? 0).toFixed(2);
+  return `  • ${where}  projected=${projected}  baseline=${baseline}  [${b.kind}]`;
+}
+
+/**
+ * Render the pre-merge CRAP advisory as a human-readable multi-line log
+ * block, naming every breaching method and the exact refresh remedy.
+ * Returns `null` when there is nothing to surface so callers can `if` past
+ * the log call without a string-empty check.
+ *
+ * @param {Awaited<ReturnType<typeof projectCrapBreaches>>} result
+ * @returns {string | null}
+ */
+export function formatCrapProjection(result) {
+  if (!result || !Array.isArray(result.breaches)) return null;
+  if (result.breaches.length === 0) return null;
+  const lines = [
+    `[close-validation] ⚠ Pre-merge CRAP projection: ${result.breaches.length} method(s) would breach post-merge:`,
+  ];
+  for (const b of result.breaches) lines.push(formatBreach(b));
+  lines.push(
+    '[close-validation]   To land cleanly, run `npm run crap:update` and commit the refreshed baseline with a `baseline-refresh:` tagged subject (non-empty body) on the story branch before re-running close.',
+  );
+  return lines.join('\n');
+}

--- a/.agents/scripts/lib/close-validation/runner.js
+++ b/.agents/scripts/lib/close-validation/runner.js
@@ -19,6 +19,7 @@ import {
 } from './commands.js';
 import { DEFAULT_GATES, partitionGates } from './gates.js';
 import { defaultGateRunner } from './process.js';
+import { runProjectionAdvisories as defaultRunProjections } from './projections/advisories.js';
 import { defaultGetHeadSha } from './projections/head-sha.js';
 
 /** @typedef {import('./gates.js').Gate} Gate */
@@ -90,10 +91,23 @@ function applyChangedFileScope({ gate, spawnCwd, log }) {
  * story-close uses it to drive `phaseTimer.mark(...)` for per-gate
  * wall-clock telemetry. Errors thrown from the hook propagate.
  *
+ * Projection advisories (Story #4776): when `baseBranch` and `storyBranch`
+ * are both supplied and every gate passed, the maintainability and CRAP
+ * pre-merge projections run through `projections/advisories.js` and log
+ * their advisories to the same `log` sink the gates use. They are advisory
+ * by construction — the returned `ok` is decided entirely by the gates, so
+ * a projected breach never fails a close. They are skipped after a gate
+ * failure, where the operator needs the failing gate's evidence, not a
+ * baseline-refresh nudge.
+ *
  * @param {{
  *   cwd: string,
  *   worktreePath?: string,
  *   gates?: Gate[],
+ *   baseBranch?: string|null,
+ *   storyBranch?: string|null,
+ *   config?: object|null,
+ *   runProjections?: typeof defaultRunProjections,
  *   runner?: (cmd: string, args: string[], opts: { cwd: string, signal?: AbortSignal, gateName?: string, log?: (m: string) => void }) => Promise<{ status: number }> | { status: number },
  *   log?: (m: string) => void,
  *   onGateStart?: (gate: Gate) => void,
@@ -114,6 +128,10 @@ export async function runCloseValidation({
   runner = defaultGateRunner,
   log = () => {},
   onGateStart,
+  baseBranch = null,
+  storyBranch = null,
+  config = null,
+  runProjections = defaultRunProjections,
   storyId = null,
   standalone = false,
   useEvidence = true,
@@ -346,5 +364,55 @@ export async function runCloseValidation({
     );
   }
 
+  // ── Phase 3: advisory projections ───────────────────────────────────
+  // Story #4776 — the projection layer's live call site. Deliberately
+  // outside the `ok` computation: a projected breach informs, it never
+  // fails a close.
+  if (failed.length === 0) {
+    await runAdvisoryProjections({
+      runProjections,
+      cwd: spawnCwd,
+      baseBranch,
+      storyBranch,
+      config,
+      log,
+    });
+  }
+
   return { ok: failed.length === 0, failed, skipped };
+}
+
+/**
+ * Phase 3 helper — run the advisory projections, absorbing every failure.
+ *
+ * No-ops without a branch pair to diff (resume / legacy callers), and can
+ * never influence the close verdict: the caller has already decided `ok`
+ * before this runs, and a throw here is logged, not propagated.
+ *
+ * @param {{
+ *   runProjections: typeof defaultRunProjections,
+ *   cwd: string,
+ *   baseBranch: string|null,
+ *   storyBranch: string|null,
+ *   config: object|null,
+ *   log: (m: string) => void,
+ * }} opts
+ * @returns {Promise<void>}
+ */
+async function runAdvisoryProjections({
+  runProjections,
+  cwd,
+  baseBranch,
+  storyBranch,
+  config,
+  log,
+}) {
+  if (!(baseBranch && storyBranch)) return;
+  try {
+    await runProjections({ cwd, baseBranch, storyBranch, config, log });
+  } catch (err) {
+    log(
+      `[close-validation]   ⚠ projection advisories skipped: ${err?.message ?? err}`,
+    );
+  }
 }

--- a/.agents/scripts/lib/orchestration/single-story-close/phases/close-validation.js
+++ b/.agents/scripts/lib/orchestration/single-story-close/phases/close-validation.js
@@ -33,6 +33,13 @@
  * needs the evidence in front of them. `AGENT_LOG_LEVEL=verbose` restores
  * live streaming.
  *
+ * Projection advisories (Story #4776). `baseBranch`, `storyBranch` and the
+ * resolved `config` are forwarded to `runCloseValidation` so its projection
+ * phase can run. They surface, after the gates pass, which committed
+ * baseline rows the post-merge tree would breach and the exact
+ * `*:update` + `baseline-refresh:` remedy — advisory only, so the close
+ * verdict is unchanged.
+ *
  * `runCloseValidation`, `buildDefaultGates`, and `runScopedFormatAutofix`
  * are accepted as injected dependencies so the parent CLI's cache-busted
  * bindings win in tests that mock the upstream module URLs.
@@ -154,6 +161,13 @@ export async function runCloseValidationPhase({
       // epicId; the standalone flag routes the cache to
       // temp/standalone/stories/story-<id>/validation-evidence.json.
       standalone: true,
+      // Story #4776 — the branch pair and resolved config the advisory
+      // projections need. Without them the runner skips the projection
+      // phase entirely, which is the correct behaviour for resume/legacy
+      // callers that have no story branch to diff.
+      baseBranch,
+      storyBranch,
+      config,
     });
   } finally {
     // Story #4766 — gate lines are buffered to an async stream so the drain

--- a/tests/lib/baselines/drift-detector.test.js
+++ b/tests/lib/baselines/drift-detector.test.js
@@ -6,6 +6,12 @@
  * cannot see: a file nobody has touched since its baseline row was written.
  * The centrepiece test below therefore drifts ONLY an untouched row and
  * asserts it is still caught.
+ *
+ * Everything is driven through the module's public surface — the three
+ * symbols the CLI uses. The internals are deliberately not exported (a
+ * test-only export is an orphan by another name, which is the defect this
+ * Story is about), so they are reached the way production reaches them:
+ * through `detectBaselineDrift`'s injectable loader/scorer seams.
  */
 
 import assert from 'node:assert/strict';
@@ -17,12 +23,7 @@ import {
 import {
   DRIFT_KINDS,
   detectBaselineDrift,
-  detectKindDrift,
-  diffRows,
   formatDriftReport,
-  formatKindDrift,
-  projectScoredRows,
-  resolveTolerance,
 } from '../../../.agents/scripts/lib/baselines/drift-detector.js';
 
 const MI_BASELINE = [
@@ -30,116 +31,105 @@ const MI_BASELINE = [
   { path: 'src/untouched.js', mi: 75 },
 ];
 
-function miSeams({ rows, baseline = MI_BASELINE }) {
-  return {
+/**
+ * Drive one kind through the public entry point with injected seams.
+ *
+ * @returns {Promise<object>} that kind's result record
+ */
+async function detectOne({
+  kind = 'maintainability',
+  rows,
+  baseline = MI_BASELINE,
+  quality = {},
+  tolerance = null,
+}) {
+  const run = await detectBaselineDrift({
+    kinds: [kind],
+    quality,
+    tolerance,
     loadBaselineRows: () => baseline,
     scoreFullScope: async () => rows,
-  };
+  });
+  assert.equal(run.results.length, 1);
+  assert.equal(run.ok, run.results[0].ok);
+  return run.results[0];
 }
 
-describe('resolveTolerance', () => {
-  it('prefers an explicit override, as an absolute value', () => {
-    assert.equal(resolveTolerance('maintainability', {}, -2), 2);
+describe('detectBaselineDrift — tolerance resolution', () => {
+  it('prefers an explicit override over the gate config', async () => {
+    const rows = [
+      { path: 'src/touched.js', mi: 80 },
+      { path: 'src/untouched.js', mi: 73 },
+    ];
+    const tight = await detectOne({ rows, tolerance: 0.5 });
+    assert.equal(tight.ok, false);
+    assert.equal(tight.tolerance, 0.5);
+
+    const loose = await detectOne({ rows, tolerance: 5 });
+    assert.equal(loose.ok, true);
+    assert.equal(loose.tolerance, 5);
   });
 
-  it("falls back to the gate's configured absolute tolerance", () => {
-    const gate = { tolerance: { kind: 'absolute', value: 1.25 } };
-    assert.equal(resolveTolerance('maintainability', gate, null), 1.25);
-  });
-
-  it('falls back to the per-kind default when nothing is configured', () => {
-    assert.equal(resolveTolerance('maintainability', undefined, null), 0.5);
-    assert.equal(resolveTolerance('crap', undefined, null), 0.001);
-  });
-});
-
-describe('projectScoredRows', () => {
-  it("reconciles the CRAP scorer's `file` key with the envelope's `path`", () => {
-    const rows = projectScoredRows('crap', [
-      { file: 'src/a.js', method: 'go', startLine: 3, crap: 9 },
-    ]);
-    assert.deepEqual(rows, [
-      { path: 'src/a.js', method: 'go', startLine: 3, crap: 9 },
-    ]);
-  });
-
-  it('drops rows the writer itself would refuse rather than throwing', () => {
-    const rows = projectScoredRows('maintainability', [
-      { path: 'src/a.js', mi: 70 },
-      { path: '/absolute/is/not/canonical.js', mi: 70 },
-    ]);
-    assert.equal(rows.length, 1);
-    assert.equal(rows[0].path, 'src/a.js');
-  });
-});
-
-describe('diffRows', () => {
-  it('classifies drift in both directions, plus added and removed rows', () => {
-    const out = diffRows({
-      kind: 'maintainability',
-      baselineRows: MI_BASELINE,
-      currentRows: [
-        { path: 'src/touched.js', mi: 84 },
-        { path: 'src/brand-new.js', mi: 90 },
-      ],
-      tolerance: 0.5,
+  it("falls back to the gate's configured absolute tolerance", async () => {
+    const result = await detectOne({
+      rows: MI_BASELINE,
+      quality: {
+        maintainability: { tolerance: { kind: 'absolute', value: 1.25 } },
+      },
     });
-    assert.equal(out.drifted.length, 1);
-    assert.equal(out.drifted[0].delta, 4);
-    assert.deepEqual(
-      out.added.map((a) => a.label),
-      ['src/brand-new.js'],
-    );
-    assert.deepEqual(
-      out.removed.map((r) => r.label),
-      ['src/untouched.js'],
-    );
+    assert.equal(result.tolerance, 1.25);
   });
 
-  it('holds rows within tolerance', () => {
-    const out = diffRows({
-      kind: 'maintainability',
-      baselineRows: MI_BASELINE,
-      currentRows: [
-        { path: 'src/touched.js', mi: 80.4 },
-        { path: 'src/untouched.js', mi: 75 },
-      ],
-      tolerance: 0.5,
-    });
-    assert.deepEqual(out.drifted, []);
-  });
+  it('falls back to the per-kind default when nothing is configured', async () => {
+    const mi = await detectOne({ rows: MI_BASELINE });
+    assert.equal(mi.tolerance, 0.5);
 
-  it('keys CRAP rows per method, not per file', () => {
-    const out = diffRows({
+    const crap = await detectOne({
       kind: 'crap',
-      baselineRows: [
-        { path: 'src/a.js', method: 'one', startLine: 1, crap: 5 },
-        { path: 'src/a.js', method: 'two', startLine: 9, crap: 5 },
-      ],
-      currentRows: [
-        { path: 'src/a.js', method: 'one', startLine: 1, crap: 5 },
-        { path: 'src/a.js', method: 'two', startLine: 9, crap: 22 },
-      ],
-      tolerance: 0.001,
+      baseline: [{ path: 'src/a.js', method: 'go', startLine: 1, crap: 5 }],
+      rows: [{ file: 'src/a.js', method: 'go', startLine: 1, crap: 5 }],
     });
-    assert.equal(out.drifted.length, 1);
-    assert.equal(out.drifted[0].key, 'src/a.js::two@9');
+    assert.equal(crap.tolerance, 0.001);
   });
 });
 
-describe('detectKindDrift (AC-6)', () => {
+describe('detectBaselineDrift — row projection', () => {
+  it("reconciles the CRAP scorer's `file` key with the envelope's `path`", async () => {
+    // The scorer emits `file`; the baseline keys on `path`. If the two were
+    // not reconciled every row would look added AND removed at once.
+    const result = await detectOne({
+      kind: 'crap',
+      baseline: [{ path: 'src/a.js', method: 'go', startLine: 3, crap: 9 }],
+      rows: [{ file: 'src/a.js', method: 'go', startLine: 3, crap: 9 }],
+    });
+    assert.equal(result.ok, true);
+    assert.deepEqual(result.added, []);
+    assert.deepEqual(result.removed, []);
+    assert.equal(result.scanned, 1);
+  });
+
+  it('drops rows the writer itself would refuse rather than throwing', async () => {
+    const result = await detectOne({
+      rows: [
+        { path: 'src/touched.js', mi: 80 },
+        { path: 'src/untouched.js', mi: 75 },
+        { path: '/absolute/is/not/canonical.js', mi: 70 },
+      ],
+    });
+    assert.equal(result.ok, true);
+    assert.equal(result.scanned, 2);
+  });
+});
+
+describe('detectBaselineDrift — classification (AC-6)', () => {
   it('catches drift on a file untouched by any recent diff', async () => {
-    const result = await detectKindDrift({
-      kind: 'maintainability',
-      quality: {},
-      ...miSeams({
-        rows: [
-          // The file the branch changed is unchanged in score; only the
-          // never-touched one moved. A diff-scoped gate sees nothing here.
-          { path: 'src/touched.js', mi: 80 },
-          { path: 'src/untouched.js', mi: 61 },
-        ],
-      }),
+    const result = await detectOne({
+      rows: [
+        // The file the branch changed is unchanged in score; only the
+        // never-touched one moved. A diff-scoped gate sees nothing here.
+        { path: 'src/touched.js', mi: 80 },
+        { path: 'src/untouched.js', mi: 61 },
+      ],
     });
     assert.equal(result.ok, false);
     assert.equal(result.drifted.length, 1);
@@ -149,87 +139,105 @@ describe('detectKindDrift (AC-6)', () => {
     assert.equal(result.drifted[0].delta, -14);
   });
 
-  it('is clean when every re-scored row matches its baseline', async () => {
-    const result = await detectKindDrift({
-      kind: 'maintainability',
-      quality: {},
-      ...miSeams({ rows: MI_BASELINE }),
+  it('reports improvement as drift too — a stale baseline either way', async () => {
+    const result = await detectOne({
+      rows: [
+        { path: 'src/touched.js', mi: 80 },
+        { path: 'src/untouched.js', mi: 91 },
+      ],
     });
+    assert.equal(result.ok, false);
+    assert.equal(result.drifted[0].delta, 16);
+  });
+
+  it('separates added and removed rows from drift', async () => {
+    const result = await detectOne({
+      rows: [
+        { path: 'src/touched.js', mi: 84 },
+        { path: 'src/brand-new.js', mi: 90 },
+      ],
+    });
+    assert.equal(result.drifted.length, 1);
+    assert.deepEqual(
+      result.added.map((a) => a.label),
+      ['src/brand-new.js'],
+    );
+    assert.deepEqual(
+      result.removed.map((r) => r.label),
+      ['src/untouched.js'],
+    );
+  });
+
+  it('holds rows within tolerance', async () => {
+    const result = await detectOne({
+      rows: [
+        { path: 'src/touched.js', mi: 80.4 },
+        { path: 'src/untouched.js', mi: 75 },
+      ],
+    });
+    assert.equal(result.ok, true);
+    assert.deepEqual(result.drifted, []);
+  });
+
+  it('keys CRAP rows per method, not per file', async () => {
+    const result = await detectOne({
+      kind: 'crap',
+      baseline: [
+        { path: 'src/a.js', method: 'one', startLine: 1, crap: 5 },
+        { path: 'src/a.js', method: 'two', startLine: 9, crap: 5 },
+      ],
+      rows: [
+        { file: 'src/a.js', method: 'one', startLine: 1, crap: 5 },
+        { file: 'src/a.js', method: 'two', startLine: 9, crap: 22 },
+      ],
+    });
+    assert.equal(result.drifted.length, 1);
+    assert.equal(result.drifted[0].key, 'src/a.js::two@9');
+  });
+
+  it('is clean when every re-scored row matches its baseline', async () => {
+    const result = await detectOne({ rows: MI_BASELINE });
     assert.equal(result.ok, true);
     assert.deepEqual(result.drifted, []);
     assert.equal(result.scanned, 2);
   });
+});
 
-  it('honours an explicit tolerance override', async () => {
-    const seams = miSeams({
-      rows: [
-        { path: 'src/touched.js', mi: 80 },
-        { path: 'src/untouched.js', mi: 73 },
-      ],
-    });
-    const tight = await detectKindDrift({
-      kind: 'maintainability',
-      quality: {},
-      tolerance: 0.5,
-      ...seams,
-    });
-    assert.equal(tight.ok, false);
-    const loose = await detectKindDrift({
-      kind: 'maintainability',
-      quality: {},
-      tolerance: 5,
-      ...seams,
-    });
-    assert.equal(loose.ok, true);
-  });
-
+describe('detectBaselineDrift — skips and fan-out', () => {
   it('skips a disabled gate, a missing baseline, and a missing scorer', async () => {
-    const disabled = await detectKindDrift({
+    const disabled = await detectOne({
       kind: 'crap',
+      rows: [],
       quality: { crap: { enabled: false } },
-      ...miSeams({ rows: [] }),
     });
     assert.equal(disabled.ok, true);
     assert.equal(disabled.skipped, 'gate-disabled');
 
-    const noBaseline = await detectKindDrift({
-      kind: 'maintainability',
-      quality: {},
-      loadBaselineRows: () => null,
-      scoreFullScope: async () => [],
-    });
+    const noBaseline = await detectOne({ rows: [], baseline: null });
     assert.equal(noBaseline.ok, true);
     assert.equal(noBaseline.skipped, 'no-baseline');
 
-    const noScorer = await detectKindDrift({
-      kind: 'maintainability',
-      quality: {},
-      loadBaselineRows: () => MI_BASELINE,
-      scoreFullScope: async () => null,
-    });
+    const noScorer = await detectOne({ rows: null });
     assert.equal(noScorer.ok, true);
     assert.equal(noScorer.skipped, 'no-scorer');
   });
 
   it('rejects an unknown kind', async () => {
     await assert.rejects(
-      () => detectKindDrift({ kind: 'bogus', quality: {} }),
+      () => detectBaselineDrift({ kinds: ['bogus'], quality: {} }),
       /unknown kind "bogus"/,
     );
   });
-});
 
-describe('detectBaselineDrift', () => {
   it('is red when any single kind drifts', async () => {
     const run = await detectBaselineDrift({
       kinds: ['maintainability', 'crap'],
       quality: { crap: { enabled: false } },
-      ...miSeams({
-        rows: [
-          { path: 'src/touched.js', mi: 80 },
-          { path: 'src/untouched.js', mi: 40 },
-        ],
-      }),
+      loadBaselineRows: () => MI_BASELINE,
+      scoreFullScope: async () => [
+        { path: 'src/touched.js', mi: 80 },
+        { path: 'src/untouched.js', mi: 40 },
+      ],
     });
     assert.equal(run.ok, false);
     assert.equal(run.results.length, 2);
@@ -242,60 +250,54 @@ describe('detectBaselineDrift', () => {
 });
 
 describe('drift report rendering (AC-7)', () => {
-  const drifted = {
-    kind: 'maintainability',
-    ok: false,
-    tolerance: 0.5,
-    scanned: 2,
-    baselineRows: 2,
-    refreshCommand: 'npm run maintainability:update -- --full-scope',
-    drifted: [
-      {
-        key: 'src/untouched.js',
-        label: 'src/untouched.js',
-        baseline: 75,
-        current: 61,
-        delta: -14,
-      },
-    ],
-    added: [],
-    removed: [],
-  };
+  async function driftedRun() {
+    return await detectBaselineDrift({
+      kinds: ['maintainability'],
+      quality: {},
+      loadBaselineRows: () => MI_BASELINE,
+      scoreFullScope: async () => [
+        { path: 'src/touched.js', mi: 80 },
+        { path: 'src/untouched.js', mi: 61 },
+      ],
+    });
+  }
 
-  it('prints a per-row before/after table', () => {
-    const text = formatKindDrift(drifted);
+  it('prints a per-row before/after table', async () => {
+    const text = formatDriftReport(await driftedRun());
     assert.match(text, /BASELINE/);
     assert.match(text, /CURRENT/);
     assert.match(text, /DELTA/);
     assert.match(text, /src\/untouched\.js\s+75\.00\s+61\.00\s+-14\.00/);
   });
 
-  it('names the refresh remedy', () => {
-    const text = formatKindDrift(drifted);
+  it('names the refresh remedy', async () => {
+    const text = formatDriftReport(await driftedRun());
     assert.match(text, /npm run maintainability:update -- --full-scope/);
     assert.match(text, /baseline-refresh:/);
+    assert.match(text, /Baseline drift detected/);
   });
 
-  it('reports a clean or skipped kind on one line', () => {
-    assert.match(
-      formatKindDrift({ kind: 'crap', skipped: 'no-baseline' }),
-      /⏭ crap: skipped \(no-baseline\)/,
+  it('reports a clean or skipped kind on one line', async () => {
+    const skipped = formatDriftReport(
+      await detectBaselineDrift({
+        kinds: ['crap'],
+        quality: {},
+        loadBaselineRows: () => null,
+        scoreFullScope: async () => [],
+      }),
     );
-    assert.match(
-      formatKindDrift({ kind: 'crap', ok: true, scanned: 9, tolerance: 0.001 }),
-      /✓ crap: 9 row\(s\) re-scored full-scope/,
-    );
-  });
+    assert.match(skipped, /⏭ crap: skipped \(no-baseline\)/);
+    assert.match(skipped, /No baseline drift detected/);
 
-  it('summarises the whole run', () => {
-    assert.match(
-      formatDriftReport({ ok: true, results: [] }),
-      /No baseline drift detected/,
+    const clean = formatDriftReport(
+      await detectBaselineDrift({
+        kinds: ['maintainability'],
+        quality: {},
+        loadBaselineRows: () => MI_BASELINE,
+        scoreFullScope: async () => MI_BASELINE,
+      }),
     );
-    assert.match(
-      formatDriftReport({ ok: false, results: [drifted] }),
-      /Baseline drift detected/,
-    );
+    assert.match(clean, /✓ maintainability: 2 row\(s\) re-scored full-scope/);
   });
 });
 
@@ -308,11 +310,7 @@ describe('check-baseline-drift CLI (AC-7)', () => {
     });
     assert.deepEqual(
       parseArgs(['--gate', 'crap', '--tolerance', '2', '--json']),
-      {
-        kinds: ['crap'],
-        tolerance: 2,
-        json: true,
-      },
+      { kinds: ['crap'], tolerance: 2, json: true },
     );
   });
 
@@ -324,41 +322,42 @@ describe('check-baseline-drift CLI (AC-7)', () => {
 
   it('exits non-zero on drift and zero when clean', async () => {
     const red = await runCheckBaselineDrift({
-      argv: [],
-      detect: async () => ({
-        ok: false,
-        results: [
-          {
-            kind: 'crap',
-            ok: false,
-            tolerance: 0.001,
-            scanned: 1,
-            baselineRows: 1,
-            refreshCommand: 'npm run crap:update -- --full-scope',
-            drifted: [
-              {
-                key: 'src/a.js::go@1',
-                label: 'src/a.js::go (line 1)',
-                baseline: 5,
-                current: 40,
-                delta: 35,
-              },
-            ],
-            added: [],
-            removed: [],
-          },
-        ],
-      }),
+      argv: ['--gate', 'crap'],
+      detect: async (opts) =>
+        await detectBaselineDrift({
+          ...opts,
+          quality: {},
+          loadBaselineRows: () => [
+            { path: 'src/a.js', method: 'go', startLine: 1, crap: 5 },
+          ],
+          scoreFullScope: async () => [
+            { file: 'src/a.js', method: 'go', startLine: 1, crap: 40 },
+          ],
+        }),
     });
     assert.equal(red.exitCode, 1);
     assert.match(red.output, /src\/a\.js::go \(line 1\)/);
     assert.match(red.output, /\+35\.00/);
+    assert.match(red.output, /npm run crap:update -- --full-scope/);
 
     const green = await runCheckBaselineDrift({
       argv: [],
       detect: async () => ({ ok: true, results: [] }),
     });
     assert.equal(green.exitCode, 0);
+  });
+
+  it('forwards the parsed kinds and tolerance to the detector', async () => {
+    let seen = null;
+    await runCheckBaselineDrift({
+      argv: ['--gate', 'crap', '--tolerance', '3'],
+      detect: async (opts) => {
+        seen = opts;
+        return { ok: true, results: [] };
+      },
+    });
+    assert.deepEqual(seen.kinds, ['crap']);
+    assert.equal(seen.tolerance, 3);
   });
 
   it('emits a machine-readable report under --json', async () => {

--- a/tests/lib/baselines/drift-detector.test.js
+++ b/tests/lib/baselines/drift-detector.test.js
@@ -1,0 +1,375 @@
+// tests/lib/baselines/drift-detector.test.js
+/**
+ * Story #4776 — full-scope baseline drift detection.
+ *
+ * The point of this module is the case the diff-scoped gates structurally
+ * cannot see: a file nobody has touched since its baseline row was written.
+ * The centrepiece test below therefore drifts ONLY an untouched row and
+ * asserts it is still caught.
+ */
+
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import {
+  parseArgs,
+  runCheckBaselineDrift,
+} from '../../../.agents/scripts/check-baseline-drift.js';
+import {
+  DRIFT_KINDS,
+  detectBaselineDrift,
+  detectKindDrift,
+  diffRows,
+  formatDriftReport,
+  formatKindDrift,
+  projectScoredRows,
+  resolveTolerance,
+} from '../../../.agents/scripts/lib/baselines/drift-detector.js';
+
+const MI_BASELINE = [
+  { path: 'src/touched.js', mi: 80 },
+  { path: 'src/untouched.js', mi: 75 },
+];
+
+function miSeams({ rows, baseline = MI_BASELINE }) {
+  return {
+    loadBaselineRows: () => baseline,
+    scoreFullScope: async () => rows,
+  };
+}
+
+describe('resolveTolerance', () => {
+  it('prefers an explicit override, as an absolute value', () => {
+    assert.equal(resolveTolerance('maintainability', {}, -2), 2);
+  });
+
+  it("falls back to the gate's configured absolute tolerance", () => {
+    const gate = { tolerance: { kind: 'absolute', value: 1.25 } };
+    assert.equal(resolveTolerance('maintainability', gate, null), 1.25);
+  });
+
+  it('falls back to the per-kind default when nothing is configured', () => {
+    assert.equal(resolveTolerance('maintainability', undefined, null), 0.5);
+    assert.equal(resolveTolerance('crap', undefined, null), 0.001);
+  });
+});
+
+describe('projectScoredRows', () => {
+  it("reconciles the CRAP scorer's `file` key with the envelope's `path`", () => {
+    const rows = projectScoredRows('crap', [
+      { file: 'src/a.js', method: 'go', startLine: 3, crap: 9 },
+    ]);
+    assert.deepEqual(rows, [
+      { path: 'src/a.js', method: 'go', startLine: 3, crap: 9 },
+    ]);
+  });
+
+  it('drops rows the writer itself would refuse rather than throwing', () => {
+    const rows = projectScoredRows('maintainability', [
+      { path: 'src/a.js', mi: 70 },
+      { path: '/absolute/is/not/canonical.js', mi: 70 },
+    ]);
+    assert.equal(rows.length, 1);
+    assert.equal(rows[0].path, 'src/a.js');
+  });
+});
+
+describe('diffRows', () => {
+  it('classifies drift in both directions, plus added and removed rows', () => {
+    const out = diffRows({
+      kind: 'maintainability',
+      baselineRows: MI_BASELINE,
+      currentRows: [
+        { path: 'src/touched.js', mi: 84 },
+        { path: 'src/brand-new.js', mi: 90 },
+      ],
+      tolerance: 0.5,
+    });
+    assert.equal(out.drifted.length, 1);
+    assert.equal(out.drifted[0].delta, 4);
+    assert.deepEqual(
+      out.added.map((a) => a.label),
+      ['src/brand-new.js'],
+    );
+    assert.deepEqual(
+      out.removed.map((r) => r.label),
+      ['src/untouched.js'],
+    );
+  });
+
+  it('holds rows within tolerance', () => {
+    const out = diffRows({
+      kind: 'maintainability',
+      baselineRows: MI_BASELINE,
+      currentRows: [
+        { path: 'src/touched.js', mi: 80.4 },
+        { path: 'src/untouched.js', mi: 75 },
+      ],
+      tolerance: 0.5,
+    });
+    assert.deepEqual(out.drifted, []);
+  });
+
+  it('keys CRAP rows per method, not per file', () => {
+    const out = diffRows({
+      kind: 'crap',
+      baselineRows: [
+        { path: 'src/a.js', method: 'one', startLine: 1, crap: 5 },
+        { path: 'src/a.js', method: 'two', startLine: 9, crap: 5 },
+      ],
+      currentRows: [
+        { path: 'src/a.js', method: 'one', startLine: 1, crap: 5 },
+        { path: 'src/a.js', method: 'two', startLine: 9, crap: 22 },
+      ],
+      tolerance: 0.001,
+    });
+    assert.equal(out.drifted.length, 1);
+    assert.equal(out.drifted[0].key, 'src/a.js::two@9');
+  });
+});
+
+describe('detectKindDrift (AC-6)', () => {
+  it('catches drift on a file untouched by any recent diff', async () => {
+    const result = await detectKindDrift({
+      kind: 'maintainability',
+      quality: {},
+      ...miSeams({
+        rows: [
+          // The file the branch changed is unchanged in score; only the
+          // never-touched one moved. A diff-scoped gate sees nothing here.
+          { path: 'src/touched.js', mi: 80 },
+          { path: 'src/untouched.js', mi: 61 },
+        ],
+      }),
+    });
+    assert.equal(result.ok, false);
+    assert.equal(result.drifted.length, 1);
+    assert.equal(result.drifted[0].label, 'src/untouched.js');
+    assert.equal(result.drifted[0].baseline, 75);
+    assert.equal(result.drifted[0].current, 61);
+    assert.equal(result.drifted[0].delta, -14);
+  });
+
+  it('is clean when every re-scored row matches its baseline', async () => {
+    const result = await detectKindDrift({
+      kind: 'maintainability',
+      quality: {},
+      ...miSeams({ rows: MI_BASELINE }),
+    });
+    assert.equal(result.ok, true);
+    assert.deepEqual(result.drifted, []);
+    assert.equal(result.scanned, 2);
+  });
+
+  it('honours an explicit tolerance override', async () => {
+    const seams = miSeams({
+      rows: [
+        { path: 'src/touched.js', mi: 80 },
+        { path: 'src/untouched.js', mi: 73 },
+      ],
+    });
+    const tight = await detectKindDrift({
+      kind: 'maintainability',
+      quality: {},
+      tolerance: 0.5,
+      ...seams,
+    });
+    assert.equal(tight.ok, false);
+    const loose = await detectKindDrift({
+      kind: 'maintainability',
+      quality: {},
+      tolerance: 5,
+      ...seams,
+    });
+    assert.equal(loose.ok, true);
+  });
+
+  it('skips a disabled gate, a missing baseline, and a missing scorer', async () => {
+    const disabled = await detectKindDrift({
+      kind: 'crap',
+      quality: { crap: { enabled: false } },
+      ...miSeams({ rows: [] }),
+    });
+    assert.equal(disabled.ok, true);
+    assert.equal(disabled.skipped, 'gate-disabled');
+
+    const noBaseline = await detectKindDrift({
+      kind: 'maintainability',
+      quality: {},
+      loadBaselineRows: () => null,
+      scoreFullScope: async () => [],
+    });
+    assert.equal(noBaseline.ok, true);
+    assert.equal(noBaseline.skipped, 'no-baseline');
+
+    const noScorer = await detectKindDrift({
+      kind: 'maintainability',
+      quality: {},
+      loadBaselineRows: () => MI_BASELINE,
+      scoreFullScope: async () => null,
+    });
+    assert.equal(noScorer.ok, true);
+    assert.equal(noScorer.skipped, 'no-scorer');
+  });
+
+  it('rejects an unknown kind', async () => {
+    await assert.rejects(
+      () => detectKindDrift({ kind: 'bogus', quality: {} }),
+      /unknown kind "bogus"/,
+    );
+  });
+});
+
+describe('detectBaselineDrift', () => {
+  it('is red when any single kind drifts', async () => {
+    const run = await detectBaselineDrift({
+      kinds: ['maintainability', 'crap'],
+      quality: { crap: { enabled: false } },
+      ...miSeams({
+        rows: [
+          { path: 'src/touched.js', mi: 80 },
+          { path: 'src/untouched.js', mi: 40 },
+        ],
+      }),
+    });
+    assert.equal(run.ok, false);
+    assert.equal(run.results.length, 2);
+    assert.equal(run.results[1].skipped, 'gate-disabled');
+  });
+
+  it('defaults to every drift kind', () => {
+    assert.deepEqual([...DRIFT_KINDS], ['maintainability', 'crap']);
+  });
+});
+
+describe('drift report rendering (AC-7)', () => {
+  const drifted = {
+    kind: 'maintainability',
+    ok: false,
+    tolerance: 0.5,
+    scanned: 2,
+    baselineRows: 2,
+    refreshCommand: 'npm run maintainability:update -- --full-scope',
+    drifted: [
+      {
+        key: 'src/untouched.js',
+        label: 'src/untouched.js',
+        baseline: 75,
+        current: 61,
+        delta: -14,
+      },
+    ],
+    added: [],
+    removed: [],
+  };
+
+  it('prints a per-row before/after table', () => {
+    const text = formatKindDrift(drifted);
+    assert.match(text, /BASELINE/);
+    assert.match(text, /CURRENT/);
+    assert.match(text, /DELTA/);
+    assert.match(text, /src\/untouched\.js\s+75\.00\s+61\.00\s+-14\.00/);
+  });
+
+  it('names the refresh remedy', () => {
+    const text = formatKindDrift(drifted);
+    assert.match(text, /npm run maintainability:update -- --full-scope/);
+    assert.match(text, /baseline-refresh:/);
+  });
+
+  it('reports a clean or skipped kind on one line', () => {
+    assert.match(
+      formatKindDrift({ kind: 'crap', skipped: 'no-baseline' }),
+      /⏭ crap: skipped \(no-baseline\)/,
+    );
+    assert.match(
+      formatKindDrift({ kind: 'crap', ok: true, scanned: 9, tolerance: 0.001 }),
+      /✓ crap: 9 row\(s\) re-scored full-scope/,
+    );
+  });
+
+  it('summarises the whole run', () => {
+    assert.match(
+      formatDriftReport({ ok: true, results: [] }),
+      /No baseline drift detected/,
+    );
+    assert.match(
+      formatDriftReport({ ok: false, results: [drifted] }),
+      /Baseline drift detected/,
+    );
+  });
+});
+
+describe('check-baseline-drift CLI (AC-7)', () => {
+  it('parses gates, tolerance and --json', () => {
+    assert.deepEqual(parseArgs([]), {
+      kinds: ['maintainability', 'crap'],
+      tolerance: null,
+      json: false,
+    });
+    assert.deepEqual(
+      parseArgs(['--gate', 'crap', '--tolerance', '2', '--json']),
+      {
+        kinds: ['crap'],
+        tolerance: 2,
+        json: true,
+      },
+    );
+  });
+
+  it('rejects an unknown gate, a non-numeric tolerance, and stray argv', () => {
+    assert.throws(() => parseArgs(['--gate', 'bogus']), /unknown --gate/);
+    assert.throws(() => parseArgs(['--tolerance', 'x']), /must be a number/);
+    assert.throws(() => parseArgs(['--wat']), /unrecognised argument/);
+  });
+
+  it('exits non-zero on drift and zero when clean', async () => {
+    const red = await runCheckBaselineDrift({
+      argv: [],
+      detect: async () => ({
+        ok: false,
+        results: [
+          {
+            kind: 'crap',
+            ok: false,
+            tolerance: 0.001,
+            scanned: 1,
+            baselineRows: 1,
+            refreshCommand: 'npm run crap:update -- --full-scope',
+            drifted: [
+              {
+                key: 'src/a.js::go@1',
+                label: 'src/a.js::go (line 1)',
+                baseline: 5,
+                current: 40,
+                delta: 35,
+              },
+            ],
+            added: [],
+            removed: [],
+          },
+        ],
+      }),
+    });
+    assert.equal(red.exitCode, 1);
+    assert.match(red.output, /src\/a\.js::go \(line 1\)/);
+    assert.match(red.output, /\+35\.00/);
+
+    const green = await runCheckBaselineDrift({
+      argv: [],
+      detect: async () => ({ ok: true, results: [] }),
+    });
+    assert.equal(green.exitCode, 0);
+  });
+
+  it('emits a machine-readable report under --json', async () => {
+    const res = await runCheckBaselineDrift({
+      argv: ['--json'],
+      detect: async () => ({ ok: true, results: [] }),
+    });
+    assert.deepEqual(JSON.parse(res.output), {
+      schemaVersion: '1',
+      ok: true,
+      results: [],
+    });
+  });
+});

--- a/tests/lib/close-validation/projections/crap.test.js
+++ b/tests/lib/close-validation/projections/crap.test.js
@@ -1,0 +1,268 @@
+// tests/lib/close-validation/projections/crap.test.js
+/**
+ * Story #4776 — unit tests for the pre-merge CRAP projection.
+ *
+ * The sibling maintainability projection shipped fully tested and never
+ * called; these tests pin the CRAP analogue's contract at the module
+ * boundary AND the properties that make it safe to wire into
+ * close-validation: it never throws, it self-skips on every unscorable
+ * input, and its advisory names the exact refresh remedy.
+ */
+
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import {
+  DEFAULT_CRAP_TOLERANCE,
+  DEFAULT_NEW_METHOD_CEILING,
+  formatCrapProjection,
+  projectCrapBreaches,
+} from '../../../../.agents/scripts/lib/close-validation/projections/crap.js';
+
+function makeFakeGit({ files = [], fetchOk = true, diffOk = true } = {}) {
+  return {
+    gitSpawn: (_cwd, ...args) => {
+      const [cmd] = args;
+      if (cmd === 'fetch') {
+        return fetchOk
+          ? { status: 0, stdout: '', stderr: '' }
+          : { status: 1, stdout: '', stderr: 'fetch boom' };
+      }
+      if (cmd === 'diff') {
+        return diffOk
+          ? { status: 0, stdout: files.join('\n'), stderr: '' }
+          : { status: 1, stdout: '', stderr: 'diff boom' };
+      }
+      return { status: 0, stdout: '', stderr: '' };
+    },
+  };
+}
+
+const BASELINE = [
+  { file: 'src/a.js', method: 'wide', startLine: 10, crap: 12 },
+  { file: 'src/a.js', method: 'calm', startLine: 40, crap: 4 },
+];
+
+const baseOpts = {
+  cwd: '/repo',
+  baseBranch: 'main',
+  storyBranch: 'story-4776',
+  baselinePath: '/repo/baselines/crap.json',
+  loadBaseline: () => BASELINE,
+};
+
+function scorer(rows) {
+  return async () => rows;
+}
+
+describe('projectCrapBreaches', () => {
+  it('exports the tolerance and ceiling constants', () => {
+    assert.equal(typeof DEFAULT_CRAP_TOLERANCE, 'number');
+    assert.ok(DEFAULT_CRAP_TOLERANCE > 0);
+    assert.equal(DEFAULT_NEW_METHOD_CEILING, 30);
+  });
+
+  it('reports "missing-args" for any missing required option', async () => {
+    for (const key of ['cwd', 'baseBranch', 'storyBranch', 'baselinePath']) {
+      const opts = { ...baseOpts, [key]: undefined };
+      const res = await projectCrapBreaches(opts);
+      assert.equal(res.ok, true, `${key} must not fail the projection`);
+      assert.equal(res.skipped, 'missing-args');
+      assert.deepEqual(res.breaches, []);
+    }
+  });
+
+  it('self-skips with "no-baseline" when the baseline is absent or empty', async () => {
+    const res = await projectCrapBreaches({
+      ...baseOpts,
+      loadBaseline: () => [],
+      git: makeFakeGit({ files: ['src/a.js'] }),
+    });
+    assert.equal(res.ok, true);
+    assert.equal(res.skipped, 'no-baseline');
+  });
+
+  it('self-skips on a fetch failure, carrying the detail', async () => {
+    const res = await projectCrapBreaches({
+      ...baseOpts,
+      git: makeFakeGit({ fetchOk: false }),
+    });
+    assert.equal(res.ok, true);
+    assert.equal(res.skipped, 'fetch-failed');
+    assert.match(res.detail, /fetch boom/);
+  });
+
+  it('self-skips on a diff failure', async () => {
+    const res = await projectCrapBreaches({
+      ...baseOpts,
+      git: makeFakeGit({ diffOk: false }),
+    });
+    assert.equal(res.ok, true);
+    assert.equal(res.skipped, 'diff-failed');
+  });
+
+  it('self-skips when the diff contains no scorable files', async () => {
+    const res = await projectCrapBreaches({
+      ...baseOpts,
+      git: makeFakeGit({ files: ['docs/readme.md', 'baselines/crap.json'] }),
+    });
+    assert.equal(res.ok, true);
+    assert.equal(res.skipped, 'no-scorable-files');
+  });
+
+  it('self-skips with "no-coverage" when the scorer reports no coverage artifact', async () => {
+    const res = await projectCrapBreaches({
+      ...baseOpts,
+      git: makeFakeGit({ files: ['src/a.js'] }),
+      scoreFiles: async () => null,
+    });
+    assert.equal(res.ok, true);
+    assert.equal(res.skipped, 'no-coverage');
+  });
+
+  it('self-skips rather than throwing when the scorer blows up', async () => {
+    const res = await projectCrapBreaches({
+      ...baseOpts,
+      git: makeFakeGit({ files: ['src/a.js'] }),
+      scoreFiles: async () => {
+        throw new Error('escomplex exploded');
+      },
+    });
+    assert.equal(res.ok, true);
+    assert.equal(res.skipped, 'score-failed');
+    assert.match(res.detail, /escomplex exploded/);
+  });
+
+  it('reports no breach when every scored method holds its baseline', async () => {
+    const res = await projectCrapBreaches({
+      ...baseOpts,
+      git: makeFakeGit({ files: ['src/a.js'] }),
+      scoreFiles: scorer([
+        {
+          file: 'src/a.js',
+          method: 'wide',
+          startLine: 10,
+          cyclomatic: 6,
+          coverage: 0.9,
+          crap: 11,
+        },
+      ]),
+    });
+    assert.equal(res.ok, true);
+    assert.equal(res.skipped, undefined);
+    assert.deepEqual(res.breaches, []);
+    assert.equal(formatCrapProjection(res), null);
+  });
+
+  it('names a method that would breach its committed baseline row', async () => {
+    const res = await projectCrapBreaches({
+      ...baseOpts,
+      git: makeFakeGit({ files: ['src/a.js'] }),
+      scoreFiles: scorer([
+        {
+          file: 'src/a.js',
+          method: 'wide',
+          startLine: 10,
+          cyclomatic: 9,
+          coverage: 0.4,
+          crap: 44,
+        },
+      ]),
+    });
+    assert.equal(res.ok, false);
+    assert.equal(res.breaches.length, 1);
+    assert.equal(res.breaches[0].method, 'wide');
+    assert.equal(res.breaches[0].kind, 'regression');
+    assert.equal(res.breaches[0].baseline, 12);
+  });
+
+  it('names a NEW method that would breach the newMethodCeiling', async () => {
+    const res = await projectCrapBreaches({
+      ...baseOpts,
+      newMethodCeiling: 30,
+      git: makeFakeGit({ files: ['src/a.js'] }),
+      scoreFiles: scorer([
+        {
+          file: 'src/a.js',
+          method: 'freshlyAdded',
+          startLine: 200,
+          cyclomatic: 12,
+          coverage: 0.1,
+          crap: 133,
+        },
+      ]),
+    });
+    assert.equal(res.ok, false);
+    assert.equal(res.breaches.length, 1);
+    assert.equal(res.breaches[0].kind, 'new');
+    assert.equal(res.breaches[0].ceiling, 30);
+  });
+
+  it('narrows baseline rows to the changed files so untouched rows are not compared', async () => {
+    const res = await projectCrapBreaches({
+      ...baseOpts,
+      loadBaseline: () => [
+        ...BASELINE,
+        { file: 'src/untouched.js', method: 'legacy', startLine: 1, crap: 99 },
+      ],
+      git: makeFakeGit({ files: ['src/a.js'] }),
+      scoreFiles: scorer([
+        {
+          file: 'src/a.js',
+          method: 'calm',
+          startLine: 40,
+          cyclomatic: 2,
+          coverage: 1,
+          crap: 4,
+        },
+      ]),
+    });
+    assert.equal(res.ok, true);
+    assert.deepEqual(res.breaches, []);
+  });
+});
+
+describe('formatCrapProjection', () => {
+  const breachResult = {
+    ok: false,
+    breaches: [
+      {
+        file: 'src/a.js',
+        method: 'wide',
+        startLine: 10,
+        crap: 44,
+        baseline: 12,
+        kind: 'regression',
+      },
+      {
+        file: 'src/a.js',
+        method: 'freshlyAdded',
+        startLine: 200,
+        crap: 133,
+        ceiling: 30,
+        kind: 'new',
+      },
+    ],
+  };
+
+  it('returns null when there is nothing to surface', () => {
+    assert.equal(formatCrapProjection(null), null);
+    assert.equal(formatCrapProjection({ ok: true, breaches: [] }), null);
+    assert.equal(formatCrapProjection({ ok: true }), null);
+  });
+
+  it('names every breaching method with its projected and target score', () => {
+    const text = formatCrapProjection(breachResult);
+    assert.match(text, /src\/a\.js::wide \(line 10\)/);
+    assert.match(text, /projected=44\.00/);
+    assert.match(text, /baseline=12\.00/);
+    assert.match(text, /src\/a\.js::freshlyAdded \(line 200\)/);
+    assert.match(text, /ceiling=30/);
+  });
+
+  it('names the remedy explicitly — crap:update, baseline-refresh:, non-empty body', () => {
+    const text = formatCrapProjection(breachResult);
+    assert.match(text, /npm run crap:update/);
+    assert.match(text, /baseline-refresh:/);
+    assert.match(text, /non-empty body/);
+  });
+});

--- a/tests/lib/close-validation/runner-projections.test.js
+++ b/tests/lib/close-validation/runner-projections.test.js
@@ -1,0 +1,376 @@
+// tests/lib/close-validation/runner-projections.test.js
+/**
+ * Story #4776 — the projection layer's wiring, asserted at the seam that
+ * was missing.
+ *
+ * `projections/maintainability.js` was fully written, fully unit-tested and
+ * imported by nothing: the v2 Epic-tier collapse removed its caller. Unit
+ * tests on a module cannot catch that — only a test at the CALLER can. So
+ * this file asserts three things a green `maintainability.test.js` was
+ * structurally unable to see:
+ *
+ *   1. `runCloseValidation` actually invokes the projections, and their
+ *      advisory reaches close-validation's output (the regression fixture
+ *      that previously produced no advisory now produces one).
+ *   2. The advisory is advisory: a projected breach with every gate green
+ *      still exits 0.
+ *   3. No module under `projections/` is importable-but-unimported — the
+ *      orphaning itself is now a test failure, for every projection, not
+ *      just the one that happened to rot.
+ */
+
+import assert from 'node:assert/strict';
+import { readdirSync, readFileSync } from 'node:fs';
+import path from 'node:path';
+import { describe, it } from 'node:test';
+import { fileURLToPath } from 'node:url';
+import { runProjectionAdvisories } from '../../../.agents/scripts/lib/close-validation/projections/advisories.js';
+import { runCloseValidation } from '../../../.agents/scripts/lib/close-validation/runner.js';
+
+const REPO_ROOT = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '../../..',
+);
+const PROJECTIONS_DIR = path.join(
+  REPO_ROOT,
+  '.agents/scripts/lib/close-validation/projections',
+);
+
+const GREEN_GATE = { name: 'lint', cmd: 'true', args: [] };
+const RED_GATE = { name: 'lint', cmd: 'false', args: [] };
+
+function capture() {
+  const lines = [];
+  return { lines, log: (m) => lines.push(m) };
+}
+
+const passingRunner = () => ({ status: 0 });
+const failingRunner = () => ({ status: 1 });
+
+describe('runCloseValidation — projection wiring (AC-1)', () => {
+  it('invokes the projections with the branch pair and the gate log sink', async () => {
+    const seen = [];
+    const { log } = capture();
+    await runCloseValidation({
+      cwd: '/repo',
+      gates: [GREEN_GATE],
+      runner: passingRunner,
+      log,
+      baseBranch: 'main',
+      storyBranch: 'story-4776',
+      config: { marker: true },
+      runProjections: async (opts) => {
+        seen.push(opts);
+        return {};
+      },
+    });
+    assert.equal(seen.length, 1);
+    assert.equal(seen[0].baseBranch, 'main');
+    assert.equal(seen[0].storyBranch, 'story-4776');
+    assert.deepEqual(seen[0].config, { marker: true });
+    assert.equal(typeof seen[0].log, 'function');
+  });
+
+  it("runs the projections in the WORKTREE, not the main checkout's cwd", async () => {
+    let seen = null;
+    await runCloseValidation({
+      cwd: '/repo',
+      worktreePath: '/repo/.worktrees/story-4776',
+      gates: [GREEN_GATE],
+      runner: passingRunner,
+      baseBranch: 'main',
+      storyBranch: 'story-4776',
+      runProjections: async (opts) => {
+        seen = opts;
+      },
+    });
+    assert.equal(seen.cwd, '/repo/.worktrees/story-4776');
+  });
+
+  it("the projection's advisory reaches close-validation's output", async () => {
+    const { lines, log } = capture();
+    await runCloseValidation({
+      cwd: '/repo',
+      gates: [GREEN_GATE],
+      runner: passingRunner,
+      log,
+      baseBranch: 'main',
+      storyBranch: 'story-4776',
+      runProjections: async (opts) => {
+        opts.log('[close-validation] ⚠ Pre-merge MI projection: 1 file(s)');
+      },
+    });
+    assert.ok(
+      lines.some((l) => l.includes('Pre-merge MI projection')),
+      `advisory absent from close-validation output: ${JSON.stringify(lines)}`,
+    );
+  });
+
+  it('skips the projections when there is no story branch to diff', async () => {
+    let called = false;
+    await runCloseValidation({
+      cwd: '/repo',
+      gates: [GREEN_GATE],
+      runner: passingRunner,
+      baseBranch: 'main',
+      runProjections: async () => {
+        called = true;
+      },
+    });
+    assert.equal(called, false);
+  });
+
+  it('skips the projections after a gate failure', async () => {
+    let called = false;
+    const result = await runCloseValidation({
+      cwd: '/repo',
+      gates: [RED_GATE],
+      runner: failingRunner,
+      baseBranch: 'main',
+      storyBranch: 'story-4776',
+      runProjections: async () => {
+        called = true;
+      },
+    });
+    assert.equal(result.ok, false);
+    assert.equal(called, false);
+  });
+});
+
+describe('projections are advisory (AC-4)', () => {
+  it('a projected breach with every gate green leaves the verdict ok', async () => {
+    const { lines, log } = capture();
+    const result = await runCloseValidation({
+      cwd: '/repo',
+      gates: [GREEN_GATE],
+      runner: passingRunner,
+      log,
+      baseBranch: 'main',
+      storyBranch: 'story-4776',
+      runProjections: async (opts) => {
+        opts.log('[close-validation] ⚠ Pre-merge CRAP projection: 3 method(s)');
+        return { crap: { ok: false, breaches: [{}, {}, {}] } };
+      },
+    });
+    assert.equal(result.ok, true);
+    assert.deepEqual(result.failed, []);
+    assert.ok(lines.some((l) => l.includes('Pre-merge CRAP projection')));
+  });
+
+  it('a throwing projection is logged, not propagated', async () => {
+    const { lines, log } = capture();
+    const result = await runCloseValidation({
+      cwd: '/repo',
+      gates: [GREEN_GATE],
+      runner: passingRunner,
+      log,
+      baseBranch: 'main',
+      storyBranch: 'story-4776',
+      runProjections: async () => {
+        throw new Error('projection exploded');
+      },
+    });
+    assert.equal(result.ok, true);
+    assert.ok(lines.some((l) => l.includes('projection exploded')));
+  });
+});
+
+describe('runProjectionAdvisories — gate enablement and no-baseline (AC-5)', () => {
+  const branch = {
+    cwd: '/repo',
+    baseBranch: 'main',
+    storyBranch: 'story-4776',
+  };
+
+  it('self-skips both projections when their gates are disabled', async () => {
+    const { lines, log } = capture();
+    let ran = false;
+    const out = await runProjectionAdvisories({
+      ...branch,
+      log,
+      quality: {
+        maintainability: { enabled: false },
+        crap: { enabled: false },
+      },
+      projectMaintainability: async () => {
+        ran = true;
+        return {};
+      },
+      projectCrap: async () => {
+        ran = true;
+        return {};
+      },
+    });
+    assert.equal(ran, false);
+    assert.equal(out.maintainability, null);
+    assert.equal(out.crap, null);
+    assert.ok(
+      lines.some((l) => l.includes('maintainability projection skipped')),
+    );
+    assert.ok(lines.some((l) => l.includes('crap projection skipped')));
+  });
+
+  it('runs both projections when the gate blocks are absent (framework default)', async () => {
+    const ran = [];
+    await runProjectionAdvisories({
+      ...branch,
+      quality: {},
+      projectMaintainability: async () => {
+        ran.push('maintainability');
+        return { ok: true, regressions: [] };
+      },
+      projectCrap: async () => {
+        ran.push('crap');
+        return { ok: true, breaches: [] };
+      },
+    });
+    assert.deepEqual(ran.sort(), ['crap', 'maintainability']);
+  });
+
+  it('reports a no-baseline skip without erroring or emitting an advisory', async () => {
+    const { lines, log } = capture();
+    const out = await runProjectionAdvisories({
+      ...branch,
+      log,
+      quality: {},
+      projectMaintainability: async () => ({
+        ok: true,
+        regressions: [],
+        skipped: 'no-baseline',
+      }),
+      projectCrap: async () => ({
+        ok: true,
+        breaches: [],
+        skipped: 'no-baseline',
+      }),
+    });
+    assert.equal(out.maintainability.skipped, 'no-baseline');
+    assert.equal(out.crap.skipped, 'no-baseline');
+    assert.equal(
+      lines.filter((l) => l.includes('no-baseline')).length,
+      2,
+      `expected one skip line per kind: ${JSON.stringify(lines)}`,
+    );
+    assert.equal(
+      lines.filter((l) => l.includes('⚠ Pre-merge')).length,
+      0,
+      'a skip must not emit a breach advisory',
+    );
+  });
+
+  it('swallows a throwing projection into a logged skip', async () => {
+    const { lines, log } = capture();
+    const out = await runProjectionAdvisories({
+      ...branch,
+      log,
+      quality: {},
+      projectMaintainability: async () => {
+        throw new Error('MI scorer died');
+      },
+      projectCrap: async () => ({ ok: true, breaches: [] }),
+    });
+    assert.equal(out.maintainability, null);
+    assert.ok(lines.some((l) => l.includes('MI scorer died')));
+  });
+
+  it('resolves each gate baseline path against cwd and forwards it', async () => {
+    let miOpts = null;
+    let crapOpts = null;
+    await runProjectionAdvisories({
+      ...branch,
+      quality: {
+        maintainability: { baselinePath: 'custom/mi.json' },
+        crap: { newMethodCeiling: 42 },
+      },
+      projectMaintainability: async (o) => {
+        miOpts = o;
+        return { ok: true, regressions: [] };
+      },
+      projectCrap: async (o) => {
+        crapOpts = o;
+        return { ok: true, breaches: [] };
+      },
+    });
+    assert.equal(miOpts.baselinePath, path.resolve('/repo', 'custom/mi.json'));
+    assert.equal(
+      crapOpts.baselinePath,
+      path.resolve('/repo', 'baselines/crap.json'),
+    );
+    assert.equal(crapOpts.newMethodCeiling, 42);
+    assert.equal(typeof crapOpts.scoreFiles, 'function');
+  });
+});
+
+describe('no orphaned projection modules (AC-8)', () => {
+  /**
+   * Collect every `.js` file under `.agents/scripts/**` that is NOT itself
+   * inside `projections/`, so a projection importing a sibling projection
+   * cannot count as its own non-test importer.
+   */
+  function productionSources(dir, acc = []) {
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      const abs = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        if (entry.name === 'node_modules' || entry.name === '__tests__') {
+          continue;
+        }
+        productionSources(abs, acc);
+        continue;
+      }
+      if (!entry.name.endsWith('.js')) continue;
+      if (entry.name.endsWith('.test.js')) continue;
+      acc.push(abs);
+    }
+    return acc;
+  }
+
+  /** Resolve every relative `import ... from '<spec>'` in a source file. */
+  function importsOf(abs) {
+    const src = readFileSync(abs, 'utf8');
+    const out = [];
+    for (const m of src.matchAll(/from\s+'(\.[^']+)'/g)) {
+      out.push(path.resolve(path.dirname(abs), m[1]));
+    }
+    return out;
+  }
+
+  it('every module under projections/ has a non-test importer', () => {
+    const projections = readdirSync(PROJECTIONS_DIR)
+      .filter((f) => f.endsWith('.js') && !f.endsWith('.test.js'))
+      .map((f) => path.join(PROJECTIONS_DIR, f));
+    assert.ok(projections.length > 0, 'no projection modules found');
+
+    const sources = productionSources(path.join(REPO_ROOT, '.agents/scripts'));
+    const outsideProjections = sources.filter(
+      (abs) => !abs.startsWith(`${PROJECTIONS_DIR}${path.sep}`),
+    );
+
+    // Reachability, not a bare grep: a projection imported only by another
+    // projection is still orphaned if that whole cluster is unreachable from
+    // production. Seed from every production module OUTSIDE projections/ and
+    // walk the import graph inward.
+    const reachable = new Set();
+    const queue = [];
+    for (const abs of outsideProjections) {
+      for (const target of importsOf(abs)) {
+        if (target.startsWith(`${PROJECTIONS_DIR}${path.sep}`))
+          queue.push(target);
+      }
+    }
+    while (queue.length > 0) {
+      const next = queue.pop();
+      if (reachable.has(next)) continue;
+      reachable.add(next);
+      for (const target of importsOf(next)) queue.push(target);
+    }
+
+    const orphans = projections
+      .filter((abs) => !reachable.has(abs))
+      .map((abs) => path.basename(abs));
+    assert.deepEqual(
+      orphans,
+      [],
+      `orphaned projection module(s) — written, tested, and reachable from nothing in production: ${orphans.join(', ')}`,
+    );
+  });
+});


### PR DESCRIPTION
Closes #4776

_Auto-opened by `/deliver`._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are advisory close-validation logging and an opt-in drift CLI; they do not alter gate exit codes or auto-schedule jobs. Risk is mainly regression in close-validation orchestration, mitigated by extensive tests.
> 
> **Overview**
> Adds **Story #4776** baseline-freshness tooling: advisory pre-merge projections at story close and a scheduled full-scope drift CLI.
> 
> **Close-validation (advisory only)** — After all gates pass, `runCloseValidation` runs maintainability and CRAP projections via new `projections/advisories.js`, re-wiring the previously orphaned MI module and adding `projections/crap.js`. Projections flag which baseline rows the post-merge tree would breach and print the `*:update` + `baseline-refresh:` remedy; they never change the close verdict. Single-story close forwards `baseBranch`, `storyBranch`, and `config` into the runner.
> 
> **Full-scope drift** — New `check-baseline-drift.js` and `drift-detector.js` re-score maintainability and CRAP across the whole tree (using exported `resolveDefaultScorer`), report rows that moved beyond tolerance in either direction, and exit `1` on drift. Documented in `quality-gates.md`.
> 
> **Tests** — Coverage for drift detection/CLI, CRAP projection, and `runner-projections.test.js` (wiring, advisory semantics, import-graph guard against orphaned projection modules).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e5405bdb5b32ef38269a7b7abeeaa752b3b881a3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->