### PR TITLE
refactor(quality): floor CRAP on methodsAbove20 instead of a fitted max ceiling

### DIFF
--- a/.agentrc.json
+++ b/.agentrc.json
@@ -34,7 +34,7 @@
     "quality": {
       "gates": {
         "crap": {
-          "floors": { "*": { "max": 125 } },
+          "floors": { "*": { "methodsAbove20": 40 } },
           "targetDirs": [".agents/scripts", "bin", "lib"],
           "ignoreGlobs": [
             ".agents/scripts/lifecycle-emit.js",

--- a/.agents/docs/quality-gates.md
+++ b/.agents/docs/quality-gates.md
@@ -400,14 +400,35 @@ joinable methods, where a diff-scoped run's rate is noise. A healthy repo
 resolves ~98%; the 4–6% signature of a coordinate-system mismatch is far below
 the floor.
 
-**Re-derive your floors after adopting this.** A `crap.floors` ceiling pinned
-before the fix was pinned to a maximum computed over the minority of methods
-the join could see, so it is not a real ceiling — it is an artefact. This
-repository's own `*.max` moved from `30` to `125` on the first honest scan
-(2215 → 4058 visible methods), not because anything got worse but because the
-worst methods were previously invisible. `newMethodCeiling` is deliberately
-left at 30: the ratchet's forward pressure on *new* code is unaffected by how
-much old debt the gate can now see.
+**Re-derive your floors after adopting this — but do not re-pin `max`.** A
+`crap.floors` `max` ceiling pinned before the fix was computed over the
+minority of methods the join could see, so it is not a real ceiling — it is an
+artefact. The honest scan sees far more (in this repository, 2215 → 4058
+visible methods), and the newly-visible methods include the worst ones.
+
+The tempting response — raise `*.max` until the gate is green again — produces a
+floor fitted to the tree's current high-water mark, which **can never fire**:
+nothing breaches it until something becomes worse than the worst method already
+present. Prefer a *count* budget over a max ceiling:
+
+```jsonc
+"crap": {
+  // Number of methods allowed to score above 20. Ratchet this down; it
+  // breaches the moment the count grows, which a `max` ceiling cannot do.
+  "floors": { "*": { "methodsAbove20": 40 } }
+}
+```
+
+`max` remains available and is the right instrument when you genuinely have a
+hard per-method ceiling to hold. It is the wrong instrument for absorbing
+pre-existing debt.
+
+Note that neither choice is what protects new code. `floors` is an absolute
+tree-wide comparison against the rollup; the forward pressure lives in
+`newMethodCeiling` (a *new* method scoring above it fails, default 30) and in
+`compareCrap`'s ratchet (an *existing* method fails when it regresses against
+its own baseline row). Both are unaffected by how much old debt the gate can
+now see, and neither consults `floors`.
 
 **Old baselines are invalidated explicitly.** Rows scored by the previous join
 are not comparable to rows scored by this one, and neither `kernelVersion` nor


### PR DESCRIPTION
## Why

`crap.floors["*"].max` was raised 30 → 125 while landing #4775. The premise — that the honest coverage join made many more methods visible (2215 → 4058), so a ceiling pinned before the fix was an artefact — was correct. The response was not.

125 sits just above the tree's current worst method (`seedStoryBranchRef`, 123.75), which makes the floor **structurally unable to fire**: nothing can breach it until something becomes worse than the worst code already in the tree.

## Measured

| Floor | `check-baselines` |
| --- | --- |
| `max: 30` | exit 1, `breachCount: 1` (rollup `max` 123.75) |
| `max: 125` | exit 0 — but can never fail |
| `methodsAbove20: 40` | exit 0 |
| `methodsAbove20: 39` | exit 1 — **proves it can fire** |

Only 21 methods exceed 30 (3 above 100). They were always that bad; the broken join just could not see them.

## The raise was never load-bearing

`floors` is an absolute tree-wide comparison against the rollup. It is **not** what guards new code — that is:

- `newMethodCeiling` (default 30 at `lib/config/quality.js:81`, unchanged) — a *new* method above it fails.
- `compareCrap`'s per-row ratchet — an *existing* method fails when it regresses against its own baseline row.

Neither consults `floors`, so dropping the fitted ceiling costs no protection.

## Change

Replace the `max` ceiling with a count budget on the rollup's existing `methodsAbove20` axis, pinned at its current 40. It ratchets down over time without being pinned to a single outlier. Consumers who genuinely hold a hard per-method ceiling can still set `max` themselves.

Also rewrites the `quality-gates.md` adoption guidance, which previously told adopters to re-pin `max` after upgrading — the exact move that produces a dead floor.

## Verification

- `check-baselines` exit 0; fires at 39 (above)
- `npm run lint` exit 0
- `npm test` — 8757 pass, 0 fail, 4 skipped

Refs #4775

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config and documentation only; no runtime gate logic changes, and new-code protection via `newMethodCeiling` and per-row ratchet is unchanged.
> 
> **Overview**
> Replaces the CRAP tree-wide floor **`max: 125`** in `.agentrc.json` with **`methodsAbove20: 40`**, so the gate limits how many methods may score above 20 instead of pinning a ceiling just above the current worst method (which could never fail until something got worse than existing debt).
> 
> Updates **quality-gates.md** adoption guidance after the honest coverage join (#4775): do **not** re-pin `max` to turn the gate green; prefer a ratchetable **count** budget on `methodsAbove20`, while keeping `max` for true per-method ceilings. Clarifies that **`newMethodCeiling`** and **`compareCrap`** ratchet still guard new and regressing methods—`floors` does not.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ccaa5f8ad2be5c65b30990215ddca9b795ccbc5d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->