### PR TITLE
fix(audit-to-stories): anchor findings to their real primary file so grouping stops keying on prose mentions

### DIFF
--- a/.agents/scripts/audit-to-stories.js
+++ b/.agents/scripts/audit-to-stories.js
@@ -246,7 +246,7 @@ async function buildPlan({ glob: pattern, severity, useProvider, ledger }) {
   }
 
   const reports = readReports(reportPaths);
-  const allFindings = parseAuditReports(reports);
+  const allFindings = parseAuditReports(reports, { repoRoot: process.cwd() });
   const filtered = allFindings.filter((f) => meetsSeverity(f, severity));
   const stamped = withFingerprints(filtered);
   const { groups, edges } = groupFindings(stamped);

--- a/.agents/scripts/lib/audit-to-stories/__tests__/primary-file-anchor.test.js
+++ b/.agents/scripts/lib/audit-to-stories/__tests__/primary-file-anchor.test.js
@@ -1,0 +1,159 @@
+/**
+ * Regression tests for the finding → primary-file anchor that drives grouping.
+ *
+ * A live full-scope sweep grouped 39 unrelated documentation findings under a
+ * single `file:docs/CHANGELOG.md` key — a file only 3 of them even mentioned,
+ * and one the documentation lens explicitly excludes from semantic review. The
+ * cause was in the parser, not the grouper: `files[]` was built from a
+ * slash-only guard, so every **root-level** file (`AGENTS.md`, `README.md`,
+ * `package.json`) was discarded even when it was the finding's explicit
+ * `Location:`. Parsing then fell through to prose scraping and picked up an
+ * incidental path quoted inside the Agent Prompt, which `pickPrimaryFile`
+ * returns verbatim as the group key.
+ *
+ * These tests pin the four shapes that failure depended on.
+ */
+
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import { groupFindings } from '../group-findings.js';
+import { parseAuditReport, parseAuditReports } from '../parse-audit-md.js';
+
+const REPO_ROOT = '/repo';
+
+function report(body) {
+  return {
+    markdown: `## Detailed Findings\n\n${body}\n`,
+    sourceReport: 'temp/audits/audit-documentation-results.md',
+    repoRoot: REPO_ROOT,
+  };
+}
+
+describe('primary-file anchor', () => {
+  it('keeps a root-level Location path instead of discarding it', () => {
+    const [finding] = parseAuditReport(
+      report(
+        '### `AGENTS.md` — distribution claim contradicts the package contents\n\n' +
+          '- **Category:** Contradiction\n' +
+          '- **Severity:** High\n' +
+          '- **Location:** `AGENTS.md:28`\n' +
+          '- **Current State:** the blockquote claims only `.agents/` ships.\n',
+      ),
+    );
+
+    assert.equal(
+      finding.files[0],
+      'AGENTS.md',
+      'a root-level file must survive as the primary anchor',
+    );
+  });
+
+  it('prefers the title anchor over a path quoted in the prose', () => {
+    // The Agent Prompt quotes a `files` array; none of those paths is the
+    // finding's subject, and one of them used to win the primary slot.
+    const [finding] = parseAuditReport(
+      report(
+        '### `AGENTS.md` — distribution claim contradicts the package contents\n\n' +
+          '- **Category:** Contradiction\n' +
+          '- **Severity:** High\n' +
+          '- **Location:** `AGENTS.md:28`\n' +
+          '- **Agent Prompt:**\n' +
+          '  `package.json files is [".agents/","bin/","docs/CHANGELOG.md","lib/"] — fix AGENTS.md.`\n',
+      ),
+    );
+
+    assert.equal(finding.files[0], 'AGENTS.md');
+    assert.ok(
+      finding.files.includes('docs/CHANGELOG.md'),
+      'incidental prose paths are still captured, just never primary',
+    );
+  });
+
+  it('relativises an absolute path so it can match a repo-relative key', () => {
+    const [finding] = parseAuditReport(
+      report(
+        '### `docs/architecture.md` — Tech Stack names a retired distribution channel\n\n' +
+          '- **Category:** Stale Description\n' +
+          '- **Severity:** High\n' +
+          '- **Location:** `/repo/docs/architecture.md:349`\n',
+      ),
+    );
+
+    assert.equal(finding.files[0], 'docs/architecture.md');
+    assert.ok(
+      !finding.files.some((f) => f.startsWith('/')),
+      'no absolute path may survive into files[]',
+    );
+  });
+
+  it('drops degenerate and out-of-repo tokens', () => {
+    const [finding] = parseAuditReport(
+      report(
+        '### `knip.json` — unused-dependency rules are disabled\n\n' +
+          '- **Category:** Removal\n' +
+          '- **Severity:** Medium\n' +
+          '- **Location:** `knip.json:33`\n' +
+          '- **Current State:** compare / against /elsewhere/outside.md for context.\n',
+      ),
+    );
+
+    assert.equal(finding.files[0], 'knip.json');
+    assert.ok(!finding.files.includes('/'), 'a bare separator is not a file');
+    assert.ok(
+      !finding.files.includes('/elsewhere/outside.md'),
+      'a path outside the repo can never be a valid group key',
+    );
+  });
+
+  it('accepts a bare root-level file in a structured field but not in prose', () => {
+    // The separator guard is deliberate for prose (see the sibling suite in
+    // tests/audit-to-stories/) — it stops a word like `description.md` being
+    // read as a path. It must not apply to the mandated structured fields.
+    const [finding] = parseAuditReport(
+      report(
+        '### `package.json` — overrides pin blocks a devDependency upgrade\n\n' +
+          '- **Severity:** High\n' +
+          '- **Location:** `package.json:64`\n' +
+          '- **Current State:** covered in the release notes, not just description.md\n',
+      ),
+    );
+
+    assert.equal(finding.files[0], 'package.json');
+    assert.ok(
+      !finding.files.includes('description.md'),
+      'a bare filename in prose stays excluded',
+    );
+  });
+
+  it('groups findings under their own subject file, not a shared prose mention', () => {
+    // Both findings quote docs/CHANGELOG.md in prose; neither is about it.
+    const findings = parseAuditReports(
+      [
+        {
+          markdown:
+            '## Detailed Findings\n\n' +
+            '### `AGENTS.md` — distribution claim is wrong\n\n' +
+            '- **Severity:** High\n' +
+            '- **Location:** `AGENTS.md:28`\n' +
+            '- **Current State:** package.json ships docs/CHANGELOG.md too.\n\n' +
+            '### `README.md` — Quickstart repeats the same wrong claim\n\n' +
+            '- **Severity:** Medium\n' +
+            '- **Location:** `README.md:184`\n' +
+            '- **Current State:** package.json ships docs/CHANGELOG.md too.\n',
+          sourceReport: 'temp/audits/audit-documentation-results.md',
+        },
+      ],
+      { repoRoot: REPO_ROOT },
+    );
+
+    const { groups } = groupFindings(findings);
+    const keys = groups.map((g) => g.groupKey).sort();
+
+    assert.deepEqual(keys, ['file:AGENTS.md', 'file:README.md']);
+    assert.ok(
+      !keys.includes('file:docs/CHANGELOG.md'),
+      'a file merely mentioned in prose must never become a group key',
+    );
+  });
+});

--- a/.agents/scripts/lib/audit-to-stories/parse-audit-md.js
+++ b/.agents/scripts/lib/audit-to-stories/parse-audit-md.js
@@ -31,6 +31,9 @@ const HEADING_FINDING = /^###\s+(.+?)\s*$/;
 const HEADING_SECTION = /^##\s+(.+?)\s*$/;
 const PATH_HINT =
   /(?<![\w/])([A-Za-z0-9_./\\@-]+\.(?:js|ts|tsx|jsx|mjs|cjs|md|json|yaml|yml|css|scss|html|py|go|rs|java|kt|rb|sh|ps1|tf|env))(?![\w])/g;
+const FILE_EXT =
+  /\.(?:js|ts|tsx|jsx|mjs|cjs|md|json|yaml|yml|css|scss|html|py|go|rs|java|kt|rb|sh|ps1|tf|env)$/;
+const TITLE_ANCHOR = /^\s*`([^`]+)`/;
 
 function unwrapInlineCode(value) {
   if (typeof value !== 'string') return '';
@@ -81,17 +84,81 @@ function deriveDimension(fields, fallbackDimension) {
  * @param {Record<string, string>} fields
  * @returns {string[]}
  */
-function deriveLocationFiles(fields) {
+/**
+ * Normalise a raw path token to a repo-relative path, or `null` when the
+ * token is not a usable file reference.
+ *
+ * Three shapes historically leaked through and poisoned grouping downstream:
+ * an **absolute** path (which can never match a repo-relative group key), a
+ * **degenerate** token such as a bare `/`, and — most damagingly — a
+ * **root-level** file such as `AGENTS.md`, which the old slash-only guard
+ * discarded outright even when it was the finding's explicit `Location:`.
+ *
+ * `requireSeparator` is what keeps that third fix from over-reaching. In the
+ * **structured** fields — the title anchor and `Location:` — a bare
+ * `AGENTS.md` is unambiguously a file, so the separator is not required. In
+ * free **prose**, a bare `description.md` is far more likely to be a word than
+ * a path, so the separator stays mandatory there.
+ *
+ * @param {string} raw — the token as it appeared in the report.
+ * @param {string} [repoRoot] — absolute repo root; absolute tokens beneath it
+ *   are relativised. Omitted (the pure default) leaves absolutes to be dropped.
+ * @param {{ requireSeparator?: boolean }} [options]
+ * @returns {string|null}
+ */
+function normalisePathToken(raw, repoRoot, { requireSeparator = false } = {}) {
+  if (typeof raw !== 'string') return null;
+  const stripped = raw
+    .replace(/^[`'"([]+/, '')
+    .replace(/[`'")\].,;]+$/, '')
+    .trim();
+  // `Location:` anchors appear as `:line`, `:line:col`, and `:start-end`.
+  const cleaned = stripped.replace(/:\d+(?:-\d+)?(?::\d+)?$/, '');
+  if (!cleaned || cleaned === '.' || cleaned === '..') return null;
+
+  let out = cleaned;
+  if (typeof repoRoot === 'string' && repoRoot.length > 0) {
+    for (const sep of ['/', '\\']) {
+      const root = repoRoot.endsWith(sep) ? repoRoot : `${repoRoot}${sep}`;
+      if (out.startsWith(root)) {
+        out = out.slice(root.length);
+        break;
+      }
+    }
+  }
+  // A path that is still absolute lives outside the repo — it can never be a
+  // valid group key, so drop it rather than let it become one.
+  if (out.startsWith('/') || out.startsWith('\\') || /^[A-Za-z]:/.test(out)) {
+    return null;
+  }
+  const hasSeparator = out.includes('/') || out.includes('\\');
+  if (requireSeparator && !hasSeparator) return null;
+  if (!hasSeparator && !FILE_EXT.test(out)) return null;
+  return out;
+}
+
+/**
+ * The finding-block skeleton mandates that a title lead with the primary file
+ * the finding lives in (``### `path/to/file.ext` — title``). That anchor is
+ * the most reliable primary-file signal a block carries, so it seeds `files[]`
+ * ahead of `Location:` and prose scraping — `pickPrimaryFile` takes `files[0]`.
+ */
+function deriveTitleFile(title, repoRoot) {
+  const match = TITLE_ANCHOR.exec(typeof title === 'string' ? title : '');
+  if (!match) return [];
+  const normalised = normalisePathToken(match[1], repoRoot);
+  return normalised ? [normalised] : [];
+}
+
+function deriveLocationFiles(fields, repoRoot) {
   const raw = fields.location;
   if (typeof raw !== 'string' || raw.trim().length === 0) return [];
   const cleaned = raw.replace(/[`[\]]/g, ' ');
   const out = [];
   for (const token of cleaned.split(/[\s,]+/)) {
     if (!token) continue;
-    const withoutLine = token.replace(/:\d+(?::\d+)?$/, '');
-    if (withoutLine.includes('/') || withoutLine.includes('\\')) {
-      out.push(withoutLine);
-    }
+    const normalised = normalisePathToken(token, repoRoot);
+    if (normalised) out.push(normalised);
   }
   return out;
 }
@@ -113,14 +180,15 @@ function normaliseTitle(title) {
     .trim();
 }
 
-function extractFilePaths(text) {
+function extractFilePaths(text, repoRoot) {
   if (typeof text !== 'string') return [];
   const seen = new Set();
   for (const match of text.matchAll(PATH_HINT)) {
-    const candidate = match[1].replace(/^[`'"]+|[`'"]+$/g, '');
-    if (candidate.includes('/') || candidate.includes('\\')) {
-      seen.add(candidate);
-    }
+    // Prose: a bare `description.md` is more likely a word than a path.
+    const normalised = normalisePathToken(match[1], repoRoot, {
+      requireSeparator: true,
+    });
+    if (normalised) seen.add(normalised);
   }
   return [...seen];
 }
@@ -211,7 +279,7 @@ function parseBlockFields(bodyLines) {
  *   sourceReport: string,
  * }>}
  */
-export function parseAuditReport({ markdown, sourceReport }) {
+export function parseAuditReport({ markdown, sourceReport, repoRoot }) {
   if (typeof markdown !== 'string') {
     throw new Error('parseAuditReport: markdown must be a string');
   }
@@ -231,10 +299,11 @@ export function parseAuditReport({ markdown, sourceReport }) {
       fields['recommendation & rationale'] ?? fields.recommendation ?? '';
     const agentPrompt = fields['agent prompt'] ?? '';
     const fileSet = new Set([
-      ...deriveLocationFiles(fields),
-      ...extractFilePaths(currentState),
-      ...extractFilePaths(recommendation),
-      ...extractFilePaths(agentPrompt),
+      ...deriveTitleFile(block.title, repoRoot),
+      ...deriveLocationFiles(fields, repoRoot),
+      ...extractFilePaths(currentState, repoRoot),
+      ...extractFilePaths(recommendation, repoRoot),
+      ...extractFilePaths(agentPrompt, repoRoot),
     ]);
 
     return {
@@ -258,15 +327,17 @@ export function parseAuditReport({ markdown, sourceReport }) {
  * an audit can legitimately come back empty.
  *
  * @param {Array<{ markdown: string, sourceReport: string }>} reports
+ * @param {{ repoRoot?: string }} [options] — `repoRoot` relativises absolute
+ *   paths quoted in a report so they can match repo-relative group keys.
  * @returns {Array<ReturnType<typeof parseAuditReport>[number]>}
  */
-export function parseAuditReports(reports) {
+export function parseAuditReports(reports, { repoRoot } = {}) {
   if (!Array.isArray(reports)) {
     throw new Error('parseAuditReports: reports must be an array');
   }
   const out = [];
   for (const report of reports) {
-    out.push(...parseAuditReport(report));
+    out.push(...parseAuditReport({ ...report, repoRoot }));
   }
   return out;
 }


### PR DESCRIPTION
Resolves #4781.

## Why

A full-scope `/audit-to-stories` sweep over the performance, documentation, and dependencies reports grouped **39 unrelated documentation findings** under a single `file:docs/CHANGELOG.md` key — a file only 3 of them even mention, and one the documentation lens explicitly *excludes* from semantic review. All 5 emitted dependency edges joined on the bare path `/`.

The resulting Stories would have been unactionable, and the defect is invisible from the report side: every lens emitted a correct, well-anchored finding.

## Root cause

Not the grouper — the parser. `deriveLocationFiles` and `extractFilePaths` both gated acceptance on the token containing a slash:

```js
if (withoutLine.includes('/') || withoutLine.includes('\\')) { out.push(withoutLine); }
```

So every **root-level** file (`AGENTS.md`, `README.md`, `package.json`, `knip.json`) was discarded even when it was the finding's explicit `Location:`. Parsing fell through to prose scraping and picked up `docs/CHANGELOG.md` from a `files` array quoted inside an Agent Prompt. `pickPrimaryFile` returns `files[0]` verbatim as the group key, so that incidental path became the group.

Absolute paths compounded it: 48 entries of the form `/Users/.../docs/architecture.md` were kept verbatim and could never match a repo-relative key.

## Fix

1. Parse the title anchor (`` ### `path` — title ``) and seed `files[]` with it. The finding-block skeleton in `audit-lens-core.md` already mandates that a title lead with its primary file; nothing read it.
2. Relativise absolute paths against the repo root; drop out-of-repo paths and degenerate tokens such as a bare `/`.
3. Keep the separator guard for **prose** but drop it for the **structured** fields (title anchor, `Location:`). A bare `description.md` in prose is a word; a bare `AGENTS.md` in `Location:` is a file.

Point 3 matters: an initial version dropped the guard everywhere, and the existing assertion at `tests/audit-to-stories/parse-audit-md.test.js:123` correctly caught it. That test is right and stays green — the distinction is now explicit in the code and pinned by a new case.

## Verification

| Gate | Result |
| --- | --- |
| `npm run lint` | clean |
| `npm test` | 8763 pass · 0 fail · 4 skipped |
| `check-baselines.js` | exit 0, no churn |
| pre-commit MI gate | 0 MI regressions · 0 CRAP violations |

Re-scan of the three current reports: **10 mis-keyed groups → 16 correct ones**, all 56 findings accounted for, edges now joining on genuine shared files.

Six new regression cases in `__tests__/primary-file-anchor.test.js` pin all four failure shapes plus the prose-vs-structured distinction.

## Not in scope

The GitHub search rate-limit degradation (30 req/min) that leaves one group dedup-unchecked on a 56-finding sweep — a pre-existing throughput concern this change does not touch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes only the audit-to-stories parse/group pipeline (not runtime app code), but wrong grouping would have produced bad GitHub Stories—so correctness of path rules matters for downstream issue creation.
> 
> **Overview**
> Fixes **mis-grouped audit findings** in `/audit-to-stories` where dozens of unrelated documentation items collapsed under a single `file:docs/CHANGELOG.md` key because `files[0]` (used as the group key) came from prose scraping instead of the finding’s real subject.
> 
> **Parser changes** in `parse-audit-md.js`: seed `files[]` from the **title anchor** (``### `path` — title``) before `Location:` and prose; centralise path handling in `normalisePathToken` so root-level files like `AGENTS.md` and `package.json` are kept in structured fields, absolute paths under `repoRoot` are relativised, and junk/out-of-repo tokens are dropped. Prose scraping still requires a path separator so bare names like `description.md` are not treated as files.
> 
> **CLI wiring**: `buildPlan` passes `{ repoRoot: process.cwd() }` into `parseAuditReports`.
> 
> **Tests**: six regression cases in `primary-file-anchor.test.js` cover root-level locations, title-over-prose priority, absolutes, degenerate tokens, and end-to-end grouping keys.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 946527df61e55c5b091b1412d4fa92b7c9a3ea21. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->