### PR TITLE
fix(interleaving): stop truncating piped CLI output and stop discarding sibling audit dimensions on one rejection (#4783)

### DIFF
--- a/.agents/scripts/lib/cli-utils.js
+++ b/.agents/scripts/lib/cli-utils.js
@@ -18,6 +18,7 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { respondToHelp } from './cli-usage.js';
 import { formatCliError } from './error-redactor.js';
+import { flushStdio } from './stdio-flush.js';
 
 /**
  * Is the current module being executed directly as a CLI (as opposed to
@@ -33,10 +34,47 @@ export function isDirectInvocation(importMetaUrl) {
 }
 
 /**
+ * Settle one CLI run: await `main`, translate its outcome into an exit code,
+ * then flush stdio.
+ *
+ * **The exit is never eager** (Story #4783). This helper assigns
+ * `process.exitCode` and returns, letting Node terminate once the event loop
+ * is empty — which is *after* the pending stdout writes drain. The previous
+ * `process.exit()` call terminated first, discarding anything still queued
+ * behind a full pipe buffer, so any CLI emitting more than 64 KiB into a pipe
+ * truncated silently while still reporting success. The resulting exit code is
+ * identical for every caller: `code ?? 0` on the `propagateExitCode` path,
+ * `options.exitCode` (default 1) on the fatal-error path, and an untouched 0
+ * everywhere else.
+ *
+ * @param {() => Promise<unknown>} main
+ * @param {{ source: string, exitCode: number, onError?: (err: Error) => void,
+ *   propagateExitCode: boolean, errorPrefix?: string }} settings
+ * @returns {Promise<void>}
+ */
+async function settleCli(main, settings) {
+  const { source, exitCode, onError, propagateExitCode, errorPrefix } =
+    settings;
+  try {
+    const code = await main();
+    if (propagateExitCode) process.exitCode = code ?? 0;
+  } catch (err) {
+    if (typeof onError === 'function') {
+      onError(err);
+    } else {
+      const prefix = errorPrefix ?? `[${source}] Fatal error`;
+      console.error(`${prefix}: ${formatCliError(err)}`);
+      process.exitCode = exitCode;
+    }
+  }
+  await flushStdio();
+}
+
+/**
  * Run `main` as the CLI entry point for the caller's module. No-op when the
  * module is imported rather than invoked directly. Promise rejection from
  * `main` is funnelled through either the caller-supplied `onError` callback
- * or the default handler (prefixed stderr line + `process.exit(exitCode)`).
+ * or the default handler (prefixed stderr line + `process.exitCode`).
  *
  * A `usage` option makes the script self-describing: when the argv carries
  * `--help` / `-h`, the rendered usage block goes to stdout and `main` is
@@ -51,6 +89,9 @@ export function isDirectInvocation(importMetaUrl) {
  * @param {string} [options.source='CLI']           Prefix used in the default error message.
  * @param {number} [options.exitCode=1]             Exit code used by the default error handler.
  * @param {(err: Error) => void} [options.onError]  Full override of the error handler.
+ * @param {boolean} [options.propagateExitCode=false] Adopt `main`'s resolved
+ *   value as the process exit code.
+ * @param {string} [options.errorPrefix]            Overrides the `[source] Fatal error` prefix.
  * @param {object|string} [options.usage]           Usage spec (or pre-rendered
  *   text) printed for `--help`; see `lib/cli-usage.js`.
  */
@@ -65,17 +106,11 @@ export function runAsCli(importMetaUrl, main, options = {}) {
     usage,
   } = options;
   if (usage && respondToHelp(process.argv.slice(2), usage)) return;
-  const promise = main();
-  if (propagateExitCode) {
-    promise.then((code) => process.exit(code ?? 0));
-  }
-  promise.catch((err) => {
-    if (typeof onError === 'function') {
-      onError(err);
-      return;
-    }
-    const prefix = errorPrefix ?? `[${source}] Fatal error`;
-    console.error(`${prefix}: ${formatCliError(err)}`);
-    process.exit(exitCode);
+  void settleCli(main, {
+    source,
+    exitCode,
+    onError,
+    propagateExitCode,
+    errorPrefix,
   });
 }

--- a/.agents/scripts/lib/dynamic-workflow/audit-orchestrator.js
+++ b/.agents/scripts/lib/dynamic-workflow/audit-orchestrator.js
@@ -26,6 +26,18 @@
  * single write in the run is the report artifact, performed by the synthesis
  * agent, which is granted the read-only allowlist plus `Write`.
  *
+ * ## Partial-failure posture
+ *
+ * The per-dimension fan-out is settled, not all-or-nothing (Story #4783). One
+ * rejected dimension used to discard every sibling's completed work; the
+ * engine now partitions the settled results, flows the fulfilled dimensions on
+ * to the next phase, and records the rejected ones as an explicit
+ * degraded-coverage note in the report's Executive Summary. This mirrors the
+ * posture `close-validation/runner.js` already takes with per-gate errors:
+ * capture the failure into the result rather than rejecting the whole run.
+ * Only a *total* loss — every dimension rejected — throws, because there is
+ * then nothing to synthesise.
+ *
  * ## Report-contract self-check
  *
  * After synthesis the engine calls the caller-supplied `assertReportContract`
@@ -41,6 +53,14 @@
  * runtime.
  *
  * @module dynamic-workflow/audit-orchestrator
+ */
+
+import { withDegradedCoverageNote } from './degraded-coverage.js';
+
+/**
+ * A dimension that did not complete, as recorded by the settled fan-out.
+ *
+ * @typedef {import('./degraded-coverage.js').DimensionFailure} DimensionFailure
  */
 
 /**
@@ -82,8 +102,11 @@
  *   Compose the analysis prompt for one dimension (lens-specific).
  * @property {(dimension: string, findings: string) => string} buildCrossCheckPrompt
  *   Compose the adversarial cross-check prompt for one dimension's findings.
- * @property {(crossCheckedBlocks: string[]) => string} buildSynthesisPrompt
- *   Compose the synthesis prompt that assembles the report and writes it.
+ * @property {(crossCheckedBlocks: string[], degraded: DimensionFailure[]) => string} buildSynthesisPrompt
+ *   Compose the synthesis prompt that assembles the report and writes it. The
+ *   second argument lists the dimensions that did not complete (empty on a
+ *   full-coverage run); lenses may ignore it — the engine annotates the report
+ *   with the degraded-coverage note either way.
  * @property {(report: string) => { conformant: boolean, missingSections: string[], hasTitle: boolean }} assertReportContract
  *   Self-check the synthesised report against the lens's report contract.
  * @property {(check: { conformant: boolean, missingSections: string[], hasTitle: boolean }) => string} [formatContractError]
@@ -123,6 +146,45 @@ export function defaultContractError(check) {
 }
 
 /**
+ * Reduce a rejection reason to a single-line message.
+ *
+ * @param {unknown} reason
+ * @returns {string}
+ */
+function describeRejection(reason) {
+  if (reason instanceof Error) return reason.message;
+  return String(reason ?? 'unknown error');
+}
+
+/**
+ * Partition settled fan-out results into the values that completed and the
+ * dimensions that did not. `dimensions[i]` names the dimension behind
+ * `settled[i]`, so a rejection is always attributable.
+ *
+ * @template T
+ * @param {readonly string[]} dimensions
+ * @param {readonly PromiseSettledResult<T>[]} settled
+ * @param {string} phaseName Phase recorded on each failure.
+ * @returns {{ fulfilled: T[], failures: DimensionFailure[] }}
+ */
+function partitionSettled(dimensions, settled, phaseName) {
+  const fulfilled = [];
+  const failures = [];
+  settled.forEach((result, index) => {
+    if (result.status === 'fulfilled') {
+      fulfilled.push(result.value);
+      return;
+    }
+    failures.push({
+      dimension: dimensions[index],
+      phase: phaseName,
+      reason: describeRejection(result.reason),
+    });
+  });
+  return { fulfilled, failures };
+}
+
+/**
  * Run the shared three-phase audit-lens orchestration: parallel per-dimension
  * analysis → adversarial cross-check → synthesis + report-contract self-check.
  *
@@ -149,9 +211,10 @@ export async function runAuditOrchestration(spec) {
 
   const { agent, phase } = ctx;
 
-  // Phase 1 — parallel per-dimension analysis (read-only agents).
-  const rawFindings = await phase(ORCHESTRATION_PHASES.ANALYZE, async () =>
-    Promise.all(
+  // Phase 1 — parallel per-dimension analysis (read-only agents). Settled, not
+  // all-or-nothing: one dimension's rejection must not discard its siblings.
+  const analyzed = await phase(ORCHESTRATION_PHASES.ANALYZE, async () =>
+    Promise.allSettled(
       dimensions.map(async (dimension) => {
         const { output } = await agent({
           prompt: buildDimensionPrompt(dimension),
@@ -161,11 +224,15 @@ export async function runAuditOrchestration(spec) {
       }),
     ),
   );
+  const { fulfilled: rawFindings, failures: analyzeFailures } =
+    partitionSettled(dimensions, analyzed, 'analyze');
 
   // Phase 2 — adversarial cross-check: an independent agent re-verifies each
-  // dimension's findings and filters false positives before inclusion.
-  const crossChecked = await phase(ORCHESTRATION_PHASES.CROSS_CHECK, async () =>
-    Promise.all(
+  // surviving dimension's findings and filters false positives before
+  // inclusion. Settled for the same reason as phase 1.
+  const checkedDimensions = rawFindings.map((entry) => entry.dimension);
+  const checked = await phase(ORCHESTRATION_PHASES.CROSS_CHECK, async () =>
+    Promise.allSettled(
       rawFindings.map(async ({ dimension, findings }) => {
         const { output } = await agent({
           prompt: buildCrossCheckPrompt(dimension, findings),
@@ -175,16 +242,36 @@ export async function runAuditOrchestration(spec) {
       }),
     ),
   );
+  const { fulfilled: crossChecked, failures: crossCheckFailures } =
+    partitionSettled(checkedDimensions, checked, 'cross-check');
+
+  const degraded = [...analyzeFailures, ...crossCheckFailures];
+  if (dimensions.length > 0 && crossChecked.length === 0) {
+    // Nothing survived — there is no partial report to salvage.
+    throw new Error(
+      `every audit dimension failed: ${degraded
+        .map((f) => `${f.dimension} (${f.phase}: ${f.reason})`)
+        .join('; ')}`,
+    );
+  }
 
   // Phase 3 — synthesis: assemble the report contract and write the artifact.
-  const { output: report } = await phase(
+  const { output: synthesised } = await phase(
     ORCHESTRATION_PHASES.SYNTHESIZE,
     async () =>
       agent({
-        prompt: buildSynthesisPrompt(crossChecked),
+        prompt: buildSynthesisPrompt(crossChecked, degraded),
         // Synthesis is the one stage permitted to write the report artifact.
         allowedTools: [...readOnlyTools, SYNTHESIS_WRITE_TOOL],
       }),
+  );
+
+  // The coverage gap is annotated by the engine, never left to the synthesis
+  // agent's discretion.
+  const report = withDegradedCoverageNote(
+    synthesised,
+    degraded,
+    dimensions.length,
   );
 
   // Self-verify report-contract conformance before returning.

--- a/.agents/scripts/lib/dynamic-workflow/degraded-coverage.js
+++ b/.agents/scripts/lib/dynamic-workflow/degraded-coverage.js
@@ -1,0 +1,81 @@
+// .agents/scripts/lib/dynamic-workflow/degraded-coverage.js
+/**
+ * Degraded-coverage annotation for audit-lens reports (Story #4783).
+ *
+ * An audit lens fans out one sub-agent per analysis dimension. When one of
+ * those dimensions rejects — a sub-agent that ran out of context, a
+ * measurement command that failed, a transient runtime error — the run used to
+ * discard every sibling dimension's completed work along with it.
+ *
+ * The engine now partitions instead: the fulfilled dimensions flow on to
+ * synthesis, and the rejected ones are recorded here as an explicit note in
+ * the report's Executive Summary. A lens that covers four of five dimensions
+ * *and says which one is missing* is strictly more useful than one that yields
+ * nothing — but only if the gap is visible. An unannotated partial report is
+ * worse than no report, because it reads as complete coverage.
+ *
+ * The annotation is applied by the engine, not requested of the synthesis
+ * agent: a coverage disclaimer that depends on an LLM remembering to write it
+ * is not a disclaimer.
+ *
+ * @module dynamic-workflow/degraded-coverage
+ */
+
+/**
+ * A dimension that did not complete.
+ *
+ * @typedef {object} DimensionFailure
+ * @property {string} dimension The analysis dimension that failed.
+ * @property {string} phase     The phase it failed in (`analyze` / `cross-check`).
+ * @property {string} reason    The rejection's message.
+ */
+
+/** Matches the Executive Summary heading at any heading level. */
+const EXECUTIVE_SUMMARY_HEADING = /^#{1,6}\s+Executive Summary\b/i;
+
+/**
+ * Render the degraded-coverage note. Names every failed dimension, the phase
+ * it failed in, and the reason, so a reader can tell coverage loss apart from
+ * an absence of findings.
+ *
+ * @param {readonly DimensionFailure[]} failures
+ * @param {number} totalDimensions Dimensions the run set out to cover.
+ * @returns {string} A markdown blockquote.
+ */
+function formatDegradedCoverageNote(failures, totalDimensions) {
+  const detail = failures
+    .map((f) => `**${f.dimension}** (${f.phase}: ${f.reason})`)
+    .join('; ');
+  const noun = failures.length === 1 ? 'dimension' : 'dimensions';
+  return [
+    `> ⚠️ **Degraded coverage** — ${failures.length} of ${totalDimensions} analysis ${noun} did not complete`,
+    `> and ${failures.length === 1 ? 'is' : 'are'} unrepresented in this report: ${detail}.`,
+    '> Findings for the remaining dimensions are complete; the gap above is not evidence of their absence.',
+  ].join('\n');
+}
+
+/**
+ * Annotate a synthesised report with the degraded-coverage note, inserted
+ * directly beneath the `## Executive Summary` heading (every lens report
+ * contract requires that section). A report without the heading is prefixed
+ * instead, so the note can never be silently dropped.
+ *
+ * Returns the report unchanged when nothing failed — a full-coverage run must
+ * not carry a coverage caveat.
+ *
+ * @param {string} report
+ * @param {readonly DimensionFailure[]} failures
+ * @param {number} totalDimensions
+ * @returns {string}
+ */
+export function withDegradedCoverageNote(report, failures, totalDimensions) {
+  if (!Array.isArray(failures) || failures.length === 0) return report;
+  const note = formatDegradedCoverageNote(failures, totalDimensions);
+  const lines = String(report).split('\n');
+  const headingIndex = lines.findIndex((line) =>
+    EXECUTIVE_SUMMARY_HEADING.test(line.trim()),
+  );
+  if (headingIndex === -1) return `${note}\n\n${report}`;
+  lines.splice(headingIndex + 1, 0, '', note);
+  return lines.join('\n');
+}

--- a/.agents/scripts/lib/stdio-flush.js
+++ b/.agents/scripts/lib/stdio-flush.js
@@ -1,0 +1,71 @@
+// .agents/scripts/lib/stdio-flush.js
+/**
+ * Stdio drain helper (Story #4783).
+ *
+ * `process.stdout` / `process.stderr` are only synchronous when they point at
+ * a TTY or a regular file. On a **pipe** — every `cmd | consumer`, every
+ * `child_process` capture, every `$(...)` substitution — Node writes
+ * asynchronously once the 64 KiB kernel pipe buffer fills: `write()` returns
+ * `false` and the remaining bytes sit in the stream's internal queue until the
+ * reader drains it.
+ *
+ * `process.exit()` does not wait for that queue. Anything still buffered when
+ * the process terminates is discarded, so a CLI that emits more than a pipe
+ * buffer's worth of output and then exits eagerly silently truncates — the
+ * exit code still reads green, and the consumer parses a half-written
+ * envelope. `runAsCli` is the shared boundary where that used to happen for
+ * every `.agents/scripts` entry point.
+ *
+ * The fix is to stop exiting eagerly (set `process.exitCode` and let the loop
+ * drain naturally). This helper is the belt-and-braces half: an explicit await
+ * on the queued bytes, so the flush is complete before the CLI's last frame
+ * unwinds even when something further out terminates the process.
+ *
+ * @module stdio-flush
+ */
+
+/**
+ * Await the point at which one writable stream's queued bytes have been handed
+ * to the OS. Resolves immediately when the stream has nothing queued, is not
+ * writable, or is not a stream at all — a flush must never be the reason a
+ * process hangs.
+ *
+ * Both settle paths are covered: the zero-length `write()` callback (which
+ * fires after every previously queued chunk, since writes are ordered) and the
+ * `'drain'` event (which fires when a backed-up stream empties). Whichever
+ * lands first resolves; the other is detached.
+ *
+ * @param {NodeJS.WritableStream & { writableLength?: number, writableEnded?: boolean, destroyed?: boolean }} [stream]
+ * @returns {Promise<void>}
+ */
+function drainStream(stream) {
+  if (!stream || typeof stream.write !== 'function') return Promise.resolve();
+  if (stream.destroyed || stream.writableEnded) return Promise.resolve();
+  if ((stream.writableLength ?? 0) === 0) return Promise.resolve();
+
+  return new Promise((resolve) => {
+    let settled = false;
+    const done = () => {
+      if (settled) return;
+      settled = true;
+      stream.removeListener?.('drain', done);
+      resolve();
+    };
+    stream.once?.('drain', done);
+    // The write callback fires once this (empty) chunk — and therefore every
+    // chunk queued ahead of it — has been flushed to the underlying handle.
+    stream.write('', done);
+  });
+}
+
+/**
+ * Await the drain of the process's stdio streams. Never rejects: a stream that
+ * errored, closed, or was never writable resolves as already-flushed.
+ *
+ * @param {Array<NodeJS.WritableStream|undefined>} [streams] Defaults to
+ *   `[process.stdout, process.stderr]`.
+ * @returns {Promise<void>}
+ */
+export async function flushStdio(streams = [process.stdout, process.stderr]) {
+  await Promise.all(streams.map((stream) => drainStream(stream)));
+}

--- a/tests/cli-utils-exit-flush.test.js
+++ b/tests/cli-utils-exit-flush.test.js
@@ -1,0 +1,262 @@
+// tests/cli-utils-exit-flush.test.js
+//
+// Story #4783 — `runAsCli` must not terminate before its stdio drains.
+//
+// These run a *real* child process, because the defect only exists across a
+// real pipe: `process.stdout` is synchronous on a TTY and on a file, and only
+// goes asynchronous once the 64 KiB kernel pipe buffer fills. An in-process
+// stub of `process.exit` cannot reproduce it — the truncation is the kernel's,
+// not JavaScript's. Each fixture is a minimal CLI wired through the real
+// `runAsCli`, spawned with a piped stdout and (for the truncation test) a
+// deliberately slow reader.
+//
+// The exit-code cases are the other half of the contract: the refactor
+// replaced `process.exit(code)` with `process.exitCode = code`, and every one
+// of the ~88 consumers must observe the identical code.
+
+import assert from 'node:assert/strict';
+import { spawn } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import test, { after } from 'node:test';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(__dirname, '..');
+const CLI_UTILS = pathToFileURL(
+  path.join(ROOT, '.agents', 'scripts', 'lib', 'cli-utils.js'),
+).href;
+
+// `realpathSync` matters: on macOS `os.tmpdir()` is a symlink, and `runAsCli`
+// compares `fileURLToPath(import.meta.url)` (symlink-resolved by the loader)
+// against `path.resolve(process.argv[1])` (not resolved). Without it the
+// fixture is not recognised as a direct invocation and every assertion below
+// would pass vacuously against a CLI that never ran.
+const TMP = fs.realpathSync(
+  fs.mkdtempSync(path.join(os.tmpdir(), 'cli-exit-flush-')),
+);
+
+after(() => {
+  fs.rmSync(TMP, { recursive: true, force: true });
+});
+
+/** Bytes the bulk fixture writes — four pipe buffers' worth. */
+const BULK_BYTES = 256 * 1024;
+
+/**
+ * Write a fixture CLI that routes `body` through the real `runAsCli`.
+ *
+ * @param {string} name    Fixture basename.
+ * @param {string} body    The body of `main()`.
+ * @param {string} options `runAsCli`'s options bag, as source.
+ * @returns {string} Absolute path to the fixture.
+ */
+function writeFixture(name, body, options = '{}') {
+  const file = path.join(TMP, `${name}.mjs`);
+  fs.writeFileSync(
+    file,
+    [
+      `import { runAsCli } from ${JSON.stringify(CLI_UTILS)};`,
+      'async function main() {',
+      body,
+      '}',
+      `runAsCli(import.meta.url, main, ${options});`,
+      '',
+    ].join('\n'),
+  );
+  return file;
+}
+
+/**
+ * Run a fixture and collect its exit code plus the exact byte count that
+ * reached the reader.
+ *
+ * @param {string} fixture
+ * @param {{ slow?: boolean }} [opts] `slow` holds stdout paused while the
+ *   child fills the pipe buffer, then drains it in delayed slices.
+ * @returns {Promise<{ code: number, stdoutBytes: number, stdout: string, stderr: string }>}
+ */
+async function runFixture(fixture, { slow = false } = {}) {
+  const child = spawn(process.execPath, [fixture], {
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+
+  let stderr = '';
+  child.stderr.setEncoding('utf8');
+  child.stderr.on('data', (chunk) => {
+    stderr += chunk;
+  });
+
+  const exited = new Promise((resolve) => {
+    child.on('close', (code) => resolve(code));
+  });
+
+  let stdoutBytes = 0;
+  let stdout = '';
+  if (slow) {
+    child.stdout.pause();
+    // Let the child write past the pipe buffer and reach its exit path with
+    // bytes still queued. This is the window the old `process.exit()` lost.
+    await new Promise((resolve) => setTimeout(resolve, 300));
+  }
+  for await (const chunk of child.stdout) {
+    stdoutBytes += chunk.length;
+    stdout += chunk.toString('utf8');
+    if (slow) await new Promise((resolve) => setTimeout(resolve, 5));
+  }
+
+  const code = await exited;
+  return { code, stdoutBytes, stdout, stderr };
+}
+
+test('runAsCli: >64 KiB of piped stdout survives a slow reader intact', async () => {
+  const fixture = writeFixture(
+    'bulk',
+    [`  process.stdout.write('x'.repeat(${BULK_BYTES}));`, '  return 0;'].join(
+      '\n',
+    ),
+    '{ propagateExitCode: true }',
+  );
+
+  const { code, stdoutBytes } = await runFixture(fixture, { slow: true });
+
+  // The pre-change binary terminates with the queue still full and delivers
+  // roughly one pipe buffer (64 KiB); the contract is every byte written.
+  assert.equal(
+    stdoutBytes,
+    BULK_BYTES,
+    `expected ${BULK_BYTES} bytes, received ${stdoutBytes} — stdout truncated at the pipe boundary`,
+  );
+  assert.equal(code, 0);
+});
+
+test('runAsCli: bulk stdout survives on the fatal-error path too', async () => {
+  const fixture = writeFixture(
+    'bulk-fatal',
+    [
+      `  process.stdout.write('y'.repeat(${BULK_BYTES}));`,
+      "  throw new Error('boom after bulk output');",
+    ].join('\n'),
+    "{ source: 'bulk-fatal' }",
+  );
+
+  const { code, stdoutBytes, stderr } = await runFixture(fixture, {
+    slow: true,
+  });
+
+  assert.equal(stdoutBytes, BULK_BYTES);
+  assert.equal(code, 1);
+  assert.match(
+    stderr,
+    /\[bulk-fatal\] Fatal error: Error: boom after bulk output/,
+  );
+});
+
+test('runAsCli: propagateExitCode adopts the resolved code verbatim', async () => {
+  for (const resolved of ['0', '3', '7']) {
+    const fixture = writeFixture(
+      `code-${resolved}`,
+      `  return ${resolved};`,
+      '{ propagateExitCode: true }',
+    );
+    const { code } = await runFixture(fixture);
+    assert.equal(code, Number(resolved), `resolved ${resolved}`);
+  }
+});
+
+test('runAsCli: propagateExitCode maps an undefined resolution to 0', async () => {
+  const fixture = writeFixture(
+    'code-undefined',
+    '  return undefined;',
+    '{ propagateExitCode: true }',
+  );
+  const { code } = await runFixture(fixture);
+  assert.equal(code, 0);
+});
+
+test('runAsCli: without propagateExitCode a resolved code does not become the exit code', async () => {
+  const fixture = writeFixture('code-ignored', '  return 5;');
+  const { code } = await runFixture(fixture);
+  assert.equal(code, 0);
+});
+
+test('runAsCli: the default fatal handler exits 1 with the prefixed line', async () => {
+  const fixture = writeFixture(
+    'fatal-default',
+    "  throw new Error('kaboom');",
+    "{ source: 'my-cli' }",
+  );
+  const { code, stderr } = await runFixture(fixture);
+  assert.equal(code, 1);
+  assert.match(stderr, /\[my-cli\] Fatal error: Error: kaboom/);
+});
+
+test('runAsCli: a caller-supplied exitCode is honoured on the fatal path', async () => {
+  const fixture = writeFixture(
+    'fatal-code-2',
+    "  throw new Error('nope');",
+    "{ source: 'preflight', exitCode: 2 }",
+  );
+  const { code, stderr } = await runFixture(fixture);
+  assert.equal(code, 2);
+  assert.match(stderr, /\[preflight\] Fatal error: Error: nope/);
+});
+
+test('runAsCli: errorPrefix overrides the default prefix', async () => {
+  const fixture = writeFixture(
+    'fatal-prefix',
+    "  throw new Error('bad input');",
+    "{ errorPrefix: '❌ custom' }",
+  );
+  const { code, stderr } = await runFixture(fixture);
+  assert.equal(code, 1);
+  assert.match(stderr, /❌ custom: Error: bad input/);
+});
+
+test('runAsCli: an onError override owns the outcome (no default exit code)', async () => {
+  const fixture = writeFixture(
+    'fatal-onerror',
+    "  throw new Error('handled');",
+    "{ onError: (err) => { console.error('caught: ' + err.message); } }",
+  );
+  const { code, stderr } = await runFixture(fixture);
+  assert.equal(code, 0, 'onError declining to set a code leaves the run green');
+  assert.match(stderr, /caught: handled/);
+});
+
+test('runAsCli: a rejected main does not also raise an unhandled rejection', async () => {
+  // The old shape attached `.then()` and `.catch()` to the same promise; the
+  // `.then()` branch's derived rejection was only ever swallowed because
+  // `process.exit()` killed the process first. Without the eager exit, that
+  // would surface as an ERR_UNHANDLED_REJECTION crash (exit 1, but with a
+  // node-internal trace) instead of the framework's single prefixed line.
+  const fixture = writeFixture(
+    'reject-propagate',
+    "  throw new Error('rejected under propagateExitCode');",
+    "{ source: 'propagating', propagateExitCode: true }",
+  );
+  const { code, stderr } = await runFixture(fixture);
+  assert.equal(code, 1);
+  assert.match(stderr, /\[propagating\] Fatal error: Error: rejected under/);
+  assert.doesNotMatch(stderr, /ERR_UNHANDLED_REJECTION|unhandledRejection/);
+});
+
+test('runAsCli: the helper itself contains no process.exit call', () => {
+  // AC-1, pinned structurally: the exit-before-flush defect is a property of
+  // the source, so guard the source rather than only the behaviour.
+  const source = fs.readFileSync(
+    path.join(ROOT, '.agents', 'scripts', 'lib', 'cli-utils.js'),
+    'utf8',
+  );
+  // Strip comments: the JSDoc explains the defect it removed, and prose about
+  // `process.exit()` is not a callsite.
+  const code = source
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .replace(/(^|[^:])\/\/[^\n]*/g, '$1');
+  assert.equal(
+    /process\.exit\s*\(/.test(code),
+    false,
+    'cli-utils.js must set process.exitCode, never call process.exit()',
+  );
+});

--- a/tests/dynamic-workflow-audit-orchestrator.test.js
+++ b/tests/dynamic-workflow-audit-orchestrator.test.js
@@ -26,7 +26,7 @@ const READ_ONLY = Object.freeze(['Read', 'Grep', 'Glob']);
  * synthesis agent "writes" — defaults to a conformant report so the contract
  * self-check passes.
  */
-function makeCtx({ synthesisReport = 'CONFORMANT' } = {}) {
+function makeCtx({ synthesisReport = 'CONFORMANT', failWhen = null } = {}) {
   const agentCalls = [];
   const phaseNames = [];
   let agentSeq = 0;
@@ -39,6 +39,8 @@ function makeCtx({ synthesisReport = 'CONFORMANT' } = {}) {
       if (opts.allowedTools?.includes(SYNTHESIS_WRITE_TOOL)) {
         return { output: synthesisReport };
       }
+      const failure = failWhen?.(opts.prompt);
+      if (failure) throw new Error(failure);
       agentSeq += 1;
       return { output: `out-${agentSeq}:${opts.prompt}` };
     },
@@ -203,6 +205,157 @@ test('runAuditOrchestration: lens-supplied formatContractError phrases the throw
     ),
     /LENS-SPECIFIC MESSAGE/,
   );
+});
+
+// --- partial-failure posture (Story #4783) -----------------------------------
+//
+// One rejected dimension used to discard every sibling's completed work
+// (`Promise.all`). The fan-out is now settled and partitioned: survivors flow
+// on, casualties are named in the report.
+
+/** A conformant report skeleton with the Executive Summary the note targets. */
+const REPORT_WITH_SUMMARY = [
+  '# Audit Report',
+  '',
+  '## Executive Summary',
+  '',
+  'Everything analysed looked fine.',
+  '',
+  '## Detailed Findings',
+  '',
+  'None.',
+].join('\n');
+
+test('runAuditOrchestration: one rejected dimension does not discard its siblings', async () => {
+  const { ctx, agentCalls } = makeCtx({
+    failWhen: (prompt) =>
+      prompt === 'DIM:Beta' ? 'beta analysis blew up' : null,
+    synthesisReport: REPORT_WITH_SUMMARY,
+  });
+
+  const result = await runAuditOrchestration(
+    makeSpec(ctx, { dimensions: ['Alpha', 'Beta', 'Gamma'] }),
+  );
+
+  // Synthesis still ran, and it saw the two surviving dimensions.
+  const synth = agentCalls.find((c) => c.prompt.startsWith('SYNTH:'));
+  assert.ok(synth, 'synthesis must still run when one dimension rejects');
+  const blocks = synth.prompt.slice('SYNTH:'.length).split('|');
+  assert.equal(blocks.length, 2);
+  assert.ok(blocks.some((b) => b.includes('DIM:Alpha')));
+  assert.ok(blocks.some((b) => b.includes('DIM:Gamma')));
+  assert.ok(!blocks.some((b) => b.includes('DIM:Beta')));
+  assert.ok(result.report.includes('Detailed Findings'));
+});
+
+test('runAuditOrchestration: the rejected dimension never reaches cross-check', async () => {
+  const { ctx, agentCalls } = makeCtx({
+    failWhen: (prompt) => (prompt === 'DIM:Beta' ? 'beta failed' : null),
+    synthesisReport: REPORT_WITH_SUMMARY,
+  });
+
+  await runAuditOrchestration(makeSpec(ctx, { dimensions: ['Alpha', 'Beta'] }));
+
+  const xchecks = agentCalls.filter((c) => c.prompt.startsWith('XCHECK:'));
+  assert.equal(xchecks.length, 1);
+  assert.ok(xchecks[0].prompt.startsWith('XCHECK:Alpha:'));
+});
+
+test('runAuditOrchestration: the Executive Summary names the failed dimension', async () => {
+  const { ctx } = makeCtx({
+    failWhen: (prompt) =>
+      prompt === 'DIM:Beta' ? 'context window exhausted' : null,
+    synthesisReport: REPORT_WITH_SUMMARY,
+  });
+
+  const { report } = await runAuditOrchestration(
+    makeSpec(ctx, { dimensions: ['Alpha', 'Beta', 'Gamma'] }),
+  );
+
+  const lines = report.split('\n');
+  const summaryIndex = lines.indexOf('## Executive Summary');
+  const bodyIndex = lines.indexOf('## Detailed Findings');
+  const noteIndex = lines.findIndex((l) => l.includes('Degraded coverage'));
+
+  assert.ok(noteIndex > summaryIndex, 'note sits under the Executive Summary');
+  assert.ok(noteIndex < bodyIndex, 'note precedes the findings body');
+  assert.match(report, /Degraded coverage/);
+  assert.match(report, /1 of 3 analysis dimension did not complete/);
+  assert.match(report, /\*\*Beta\*\* \(analyze: context window exhausted\)/);
+  // The surviving dimensions must not be implicated.
+  assert.doesNotMatch(report, /\*\*Alpha\*\*/);
+});
+
+test('runAuditOrchestration: a cross-check rejection is partitioned and named too', async () => {
+  const { ctx, agentCalls } = makeCtx({
+    failWhen: (prompt) =>
+      prompt.startsWith('XCHECK:Beta:') ? 'reviewer timed out' : null,
+    synthesisReport: REPORT_WITH_SUMMARY,
+  });
+
+  const { report } = await runAuditOrchestration(
+    makeSpec(ctx, { dimensions: ['Alpha', 'Beta'] }),
+  );
+
+  const synth = agentCalls.find((c) => c.prompt.startsWith('SYNTH:'));
+  assert.equal(synth.prompt.slice('SYNTH:'.length).split('|').length, 1);
+  assert.match(report, /\*\*Beta\*\* \(cross-check: reviewer timed out\)/);
+});
+
+test('runAuditOrchestration: the degraded list is handed to buildSynthesisPrompt', async () => {
+  const { ctx } = makeCtx({
+    failWhen: (prompt) => (prompt === 'DIM:Beta' ? 'nope' : null),
+    synthesisReport: REPORT_WITH_SUMMARY,
+  });
+
+  let seen = null;
+  await runAuditOrchestration(
+    makeSpec(ctx, {
+      dimensions: ['Alpha', 'Beta'],
+      buildSynthesisPrompt: (blocks, degraded) => {
+        seen = degraded;
+        return `SYNTH:${blocks.join('|')}`;
+      },
+    }),
+  );
+
+  assert.deepEqual(seen, [
+    { dimension: 'Beta', phase: 'analyze', reason: 'nope' },
+  ]);
+});
+
+test('runAuditOrchestration: a full-coverage run carries no degraded note', async () => {
+  const { ctx } = makeCtx({ synthesisReport: REPORT_WITH_SUMMARY });
+  const { report } = await runAuditOrchestration(
+    makeSpec(ctx, { dimensions: ['Alpha', 'Beta'] }),
+  );
+  assert.equal(report, REPORT_WITH_SUMMARY);
+  assert.doesNotMatch(report, /Degraded coverage/);
+});
+
+test('runAuditOrchestration: a total loss throws rather than emitting an empty report', async () => {
+  const { ctx, agentCalls } = makeCtx({ failWhen: () => 'all agents down' });
+  await assert.rejects(
+    runAuditOrchestration(makeSpec(ctx, { dimensions: ['Alpha', 'Beta'] })),
+    /every audit dimension failed:.*Alpha.*Beta/s,
+  );
+  assert.equal(
+    agentCalls.filter((c) => c.prompt.startsWith('SYNTH:')).length,
+    0,
+    'synthesis must not run when nothing survived',
+  );
+});
+
+test('runAuditOrchestration: a report without an Executive Summary is prefixed with the note', async () => {
+  const { ctx } = makeCtx({
+    failWhen: (prompt) => (prompt === 'DIM:Beta' ? 'gone' : null),
+    synthesisReport: 'NO HEADINGS HERE',
+  });
+  const { report } = await runAuditOrchestration(
+    makeSpec(ctx, { dimensions: ['Alpha', 'Beta'] }),
+  );
+  assert.ok(report.startsWith('> ⚠️ **Degraded coverage**'));
+  assert.ok(report.endsWith('NO HEADINGS HERE'));
 });
 
 // --- default helpers ---------------------------------------------------------

--- a/tests/lib/cli-utils.test.js
+++ b/tests/lib/cli-utils.test.js
@@ -11,6 +11,7 @@ describe('cli-utils', () => {
   let origArgv1;
   let origExit;
   let origConsoleError;
+  let origExitCode;
   let exitCalls;
   let errorLines;
 
@@ -18,9 +19,13 @@ describe('cli-utils', () => {
     origArgv1 = process.argv[1];
     origExit = process.exit;
     origConsoleError = console.error;
+    origExitCode = process.exitCode;
+    process.exitCode = undefined;
     exitCalls = [];
     errorLines = [];
-    // Prevent the test from actually exiting.
+    // Story #4783: the helper must never call `process.exit` — exiting eagerly
+    // discards stdio still queued behind a full pipe buffer. This stub is a
+    // tripwire, not a shim: every assertion below expects it to stay empty.
     process.exit = (code) => {
       exitCalls.push(code);
     };
@@ -33,7 +38,16 @@ describe('cli-utils', () => {
     process.argv[1] = origArgv1;
     process.exit = origExit;
     console.error = origConsoleError;
+    // Never leak a failing code into the test runner's own exit status.
+    process.exitCode = origExitCode;
   });
+
+  /** Let `settleCli` reach its exit-code assignment. */
+  const settle = async () => {
+    await new Promise((r) => setImmediate(r));
+    await new Promise((r) => setImmediate(r));
+    await new Promise((r) => setImmediate(r));
+  };
 
   // Use a real absolute path under the project so fileURLToPath works on
   // both POSIX and Windows.
@@ -75,12 +89,13 @@ describe('cli-utils', () => {
       runAsCli(fakeUrl, async () => {
         called = true;
       });
-      await new Promise((r) => setImmediate(r));
+      await settle();
       assert.equal(called, true);
       assert.equal(exitCalls.length, 0);
+      assert.equal(process.exitCode, undefined);
     });
 
-    it('uses default handler on rejection: prefixed stderr + exit(1)', async () => {
+    it('uses default handler on rejection: prefixed stderr + exitCode 1', async () => {
       process.argv[1] = fileURLToPath(fakeUrl);
       runAsCli(
         fakeUrl,
@@ -89,10 +104,9 @@ describe('cli-utils', () => {
         },
         { source: 'TestCli' },
       );
-      await new Promise((r) => setImmediate(r));
-      await new Promise((r) => setImmediate(r));
-      assert.equal(exitCalls.length, 1);
-      assert.equal(exitCalls[0], 1);
+      await settle();
+      assert.equal(process.exitCode, 1);
+      assert.equal(exitCalls.length, 0, 'must not call process.exit');
       assert.ok(errorLines.some((l) => l.includes('[TestCli] Fatal error:')));
       assert.ok(errorLines.some((l) => l.includes('boom')));
     });
@@ -106,9 +120,24 @@ describe('cli-utils', () => {
         },
         { exitCode: 42 },
       );
-      await new Promise((r) => setImmediate(r));
-      await new Promise((r) => setImmediate(r));
-      assert.equal(exitCalls[0], 42);
+      await settle();
+      assert.equal(process.exitCode, 42);
+      assert.equal(exitCalls.length, 0);
+    });
+
+    it('adopts the resolved code under propagateExitCode', async () => {
+      process.argv[1] = fileURLToPath(fakeUrl);
+      runAsCli(fakeUrl, async () => 3, { propagateExitCode: true });
+      await settle();
+      assert.equal(process.exitCode, 3);
+      assert.equal(exitCalls.length, 0);
+    });
+
+    it('maps an undefined resolution to 0 under propagateExitCode', async () => {
+      process.argv[1] = fileURLToPath(fakeUrl);
+      runAsCli(fakeUrl, async () => undefined, { propagateExitCode: true });
+      await settle();
+      assert.equal(process.exitCode, 0);
     });
 
     it('delegates to onError when provided (no default stderr/exit)', async () => {
@@ -125,11 +154,11 @@ describe('cli-utils', () => {
           },
         },
       );
-      await new Promise((r) => setImmediate(r));
-      await new Promise((r) => setImmediate(r));
+      await settle();
       assert.equal(captured.message, 'nope');
       assert.equal(exitCalls.length, 0);
       assert.equal(errorLines.length, 0);
+      assert.equal(process.exitCode, undefined);
     });
   });
 });


### PR DESCRIPTION
Closes #4783

_Auto-opened by `/deliver`._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> `runAsCli` behavior changes for every `.agents/scripts` entry point (exit timing and stdio), and audit reports may now be partial with a new synthesis prompt argument—well covered by tests but broad blast radius.
> 
> **Overview**
> Fixes two reliability issues from Story **#4783**: shared CLIs could silently truncate large piped stdout, and audit-lens fan-out could throw away every sibling when one dimension failed.
> 
> **`runAsCli`** no longer calls `process.exit()`. A new `settleCli` path sets `process.exitCode`, awaits **`flushStdio`** so queued pipe output drains, and consolidates success/error handling so rejections under `propagateExitCode` do not surface as unhandled rejections. Integration tests spawn real child processes with slow readers to pin the >64 KiB pipe behavior and exit-code parity.
> 
> **`runAuditOrchestration`** switches analyze and cross-check from `Promise.all` to **`Promise.allSettled`** with partitioning: surviving dimensions still synthesize; failures are passed into `buildSynthesisPrompt` and **`withDegradedCoverageNote`** injects a **Degraded coverage** blockquote under Executive Summary (or prefixes the report if that heading is missing). Only an all-dimensions failure still throws.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3ca1df78f1cda416e191582d636adc805a5bf34e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->