### PR TITLE
fix(docs): re-sync the reference docs to the contracts the code actually implements (#4785)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,8 +25,8 @@ materialized into consumer projects' `.agents/` directories by
   [`package.json`](package.json) (run `npm ls mandrel` in a consumer project)
 - **License:** MIT
 
-> **Key distinction:** Only `.agents/` is distributed to consumers. Everything
-> else in this repository is internal development tooling.
+> **Key distinction:** the package ships `.agents/`, `bin/`, `lib/` — the rest
+> of this repository is internal development tooling.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -181,10 +181,14 @@ dimensions, run model, and how to benchmark a new version.
 
 ## Contributors
 
-Only `.agents/` is distributed to consumers — it ships inside the
-`mandrel` npm package and is materialized into a consumer's
-`./.agents/` directory by `mandrel sync`. Everything else in this
-repository is internal development tooling.
+The published `mandrel` package ships three directories — `.agents/`, `bin/`,
+and `lib/` (see the `files` array in [`package.json`](package.json)).
+`.agents/` is the payload `mandrel sync` materializes into a consumer's
+`./.agents/` directory; `bin/mandrel.js` and its `lib/` implementation stay
+inside `node_modules/mandrel/` and back the `npx mandrel …` CLI used
+throughout this README. Everything else in this repository — `docs/`,
+`tests/`, `.github/`, the root tooling configs — is internal development
+tooling and is not published.
 
 Common commands while developing the framework itself:
 
@@ -204,8 +208,12 @@ Deeper reference material lives in `docs/` rather than inline here:
 - [`.agents/docs/workflows.md`](.agents/docs/workflows.md) — slash-command
   index (auto-generated from the workflow set).
 - [`docs/CHANGELOG.md`](docs/CHANGELOG.md) — release history.
-- [`AGENTS.md`](AGENTS.md) — repository onboarding, the single-package release
-  topology, PAT / npm-token setup, and major-version policy. Releases are
+- [`AGENTS.md`](AGENTS.md) — the repository-level orientation pointer; it
+  links on to [`docs/onboarding.md`](docs/onboarding.md) for the layout,
+  commands, and development standards.
+- [`docs/release-operations.md`](docs/release-operations.md) — the Release
+  Checklist, the Install Matrix release gate, the single-package release
+  topology, PAT / npm-token setup, and the major-version policy. Releases are
   automated by `release-please`: land Conventional Commits on `main` and it
   opens a combined `chore: release main` PR that squash-merges itself once
   CI is green, tags `main`, and publishes `mandrel` to npm.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -74,12 +74,13 @@ graph TB
 
 ## Repository Layout
 
-The repository has a clear separation between the **distributed product**
-(`.agents/`) and **development tooling** (root-level files).
+The **distributed product** is the three directories in `package.json`'s
+`files` array — `.agents/`, `bin/`, `lib/`; only `.agents/` is *materialized*
+into a consumer tree (`mandrel sync`). The rest is **dev tooling**.
 
 ```text
 mandrel/
-├── .agents/                  ← Distributed bundle (the "product")
+├── .agents/                  ← Distributed + materialized (the "product")
 │   ├── instructions.md       ← Primary system prompt (all agent rules)
 │   ├── README.md             ← Consumer documentation
 │   ├── starter-agentrc.json ← Bootstrap delta-seed (copy to .agentrc.json)
@@ -99,6 +100,9 @@ mandrel/
 │       ├── SDLC.md           ←   End-to-end workflow guide
 │       ├── configuration.md  ←   Every .agentrc.json key (shipped)
 │       └── agentrc-reference.json ← Exhaustive editor reference
+│
+├── bin/                      ← Distributed: mandrel.js, postinstall.js
+├── lib/                      ← Distributed: cli/ (subcommands) + migrations/
 │
 ├── .agentrc.json             ← Runtime configuration (dogfooding)
 ├── .github/workflows/        ← CI/CD pipeline (ci.yml)
@@ -247,26 +251,20 @@ import them.
 | `lib/wave-runner/live-probe.js` | State-probing adapter feeding the pure `selectReadySet` kernel from live GitHub state (done / in-flight / foreign blockers) instead of caller-transcribed flags. |
 | `dependency-parser.js`        | Parse `depends_on` / `blocked by #N` edges from Story bodies. |
 
-#### ErrorJournal
+#### Failure auditability
 
-`ErrorJournal` (`lib/orchestration/error-journal.js`) writes structured
-JSONL to `temp/run-<id>-errors.log` via
-`errorJournal?.record({ phase, error, context })`, so failure sites that
-would otherwise be silent `catch (err) { logger.warn(...) }` blocks stay
-auditable after a run completes. See [`docs/patterns.md`](patterns.md)
-for the pattern and the `errorJournal?.record(...)` idiom. The typed
-context classes that once threaded it through an in-process runner
-(`OrchestrationContext` / `EpicRunnerContext` / `PlanRunnerContext` in
-`lib/orchestration/context.js`) were deleted with the dead in-process
-epic-runner stratum (#3908) — the host LLM drives the CLIs directly.
+There is **no** `ErrorJournal` and no `lib/orchestration/error-journal.js`. It
+was an in-process-runner concept threaded through the typed context classes in
+`lib/orchestration/context.js`, and died with them and the epic-runner stratum
+(#3908) — do not write `errorJournal?.record(...)`; nothing can inject it. Two
+file-based surfaces replace it: the append-only signals stream
+(`lib/observability/signals-writer.js`, written by `diagnose-friction.js`) and
+the per-script logs under `temp/orchestration/`.
 
-Progress reporting for the deleted in-process epic-runner stratum
-(`lib/orchestration/epic-runner/progress-reporter/`, consumed by
-`epic-execute-record-wave.js`) was removed in PR #3936 / #3908. Live
-Story progress surfaces via lifecycle ledger events and structured
-comments (`story-init`, `friction`, `verification-results`, `follow-ups`)
-posted by the single-story init/close path — the host LLM drives those
-CLIs directly.
+The epic-runner progress reporter went with the same stratum (#3908). Live
+Story progress surfaces via lifecycle ledger events and structured comments
+(`story-init`, `friction`, `verification-results`, `follow-ups`) posted by the
+single-story init/close path.
 
 #### Codebase snapshot (Phase 7)
 
@@ -300,12 +298,10 @@ envelope so Phase 7 stays non-blocking.
 | `lib/observability/signals-writer.js`               | Append-only NDJSON writer for `friction` / trace records under `temp/run-<eid>/stories/story-<sid>/signals.ndjson` (standalone Stories: `temp/standalone/stories/story-<sid>/`). The single producer for the telemetry pipeline; the reader is the `read()` async generator in `lib/signals/read.js`. |
 | `lib/orchestration/column-sync.js`                  | Drives the Projects v2 Status column from `agent::` labels (best-effort). Invoked from inside `transitionTicketState` (Story #2548) so every label flip mirrors onto the board.                  |
 
-The earlier `CommitAssertion` post-wave guard was epic-runner-scoped and
-was deleted with the in-process epic-runner stratum (#3908); its
-successor (`verifySingleResult` in the wave-record layer) went with the
-wave machinery in v2. The guard against a Story being reported "done"
-without verifiable completion is now structural: `agent::done` follows
-the confirmed squash-merge of the Story's own PR.
+The `CommitAssertion` post-wave guard and its `verifySingleResult` successor
+both went with the epic-runner / wave machinery. The guard against a Story
+being reported "done" without verifiable completion is now structural:
+`agent::done` follows the confirmed squash-merge of the Story's own PR.
 
 #### Throughput primitives
 
@@ -321,14 +317,13 @@ the confirmed squash-merge of the Story's own PR.
 The fan-out cap is resolved deterministically by
 `resolveConcurrencyCap` in `stories-wave-tick.js`
 (from `delivery.deliverRunner.concurrencyCap`) and surfaced on the
-ready-set envelopes the same script emits. The epic-runner-era concurrency surface —
-`wave-gate.js`, `lib/orchestration/concurrency.js`
-(`DEFAULT_CONCURRENCY` / `resolveConcurrency`), `CommitAssertion`, and
-the `ProgressReporter` listener class — was deleted with the dead
-in-process stratum (#3908); do not confuse the surviving
-`resolveConcurrencyCap` with the deleted `resolveConcurrency`. Story #4545 deleted the perf-summary surface that
-used to report throughput; the local `signals.ndjson` stream and the retro's
-aggregate over it are what remain.
+ready-set envelopes the same script emits. The whole epic-runner-era
+concurrency surface (`DEFAULT_CONCURRENCY` / `resolveConcurrency`,
+`CommitAssertion`, the `ProgressReporter` listener) went with the dead
+in-process stratum (#3908) — do not confuse the surviving
+`resolveConcurrencyCap` with the deleted `resolveConcurrency`. Story #4545
+deleted the perf-summary throughput surface; the local `signals.ndjson`
+stream and the retro's aggregate over it are what remain.
 
 #### Direct CLIs (no MCP server)
 
@@ -344,24 +339,28 @@ time (`GITHUB_TOKEN` and `NOTIFICATION_WEBHOOK_URL` read only from
 Scripts in the Mandrel framework divide into two non-overlapping sets. The
 partition is determined by **who invokes the script**:
 
-| Partition     | Invocation context                                       | Resident path                    |
-| ------------- | -------------------------------------------------------- | -------------------------------- |
-| **Lifecycle** | Human operators (CLI, one-time setup, consumer sync)     | `bin/` (mandrel CLI subcommands) |
-| **Runtime**   | Agent sessions, git hooks, CI pipelines                  | `.agents/scripts/`               |
+| Partition     | Invocation context                                    | Resident path       |
+| ------------- | ----------------------------------------------------- | ------------------- |
+| **Lifecycle** | Human operators (CLI, one-time setup, consumer sync)  | `.agents/scripts/`  |
+| **Runtime**   | Agent sessions, git hooks, CI pipelines               | `.agents/scripts/`  |
+
+It is a boundary of **who invokes**, not of where the file lives: both sets
+resolve under `.agents/scripts/`. `bin/` holds exactly two files
+(`bin/mandrel.js`, the subcommand dispatcher, and `bin/postinstall.js`), with
+the implementations in `lib/cli/`. The Epic #3435 plan to relocate the
+lifecycle set into `bin/` was **not** carried out — `lib/cli/`'s `sync`,
+`sync-commands`, and `sync-agents` delegate back into the engines below.
 
 **Lifecycle scripts** are invoked only by human operators — never by agent
-sessions, git hooks, or CI pipelines. They were moved to the `mandrel` CLI
-bin (under `bin/`) as part of Epic #3435 to make the boundary explicit and
-machine-enforceable:
+sessions, git hooks, or CI. Every one is still at `.agents/scripts/<name>`:
 
-- `bootstrap.js` — one-time consumer onboarding
-- `agents-bootstrap-github.js` — GitHub-side bootstrap (labels, branch
-  protection)
-- `sync-claude-commands.js` — projects `.agents/workflows/` into the flat
-  Claude Code `.claude/commands/` tree (invoked as `/<name>`)
-- `sync-agentrc.js` — merges upstream `starter-agentrc.json` deltas into the
-  consumer's `.agentrc.json`
-- `check-windows-git-perf.js` — one-time Windows git performance diagnostic
+- `bootstrap.js` / `agents-bootstrap-github.js` — consumer and GitHub-side
+  onboarding (via `mandrel init`)
+- `sync-claude-commands.js` / `sync-claude-agents.js` — project
+  `.agents/workflows/` and `.agents/agents/` into `.claude/commands/` and
+  `.claude/agents/` (via `mandrel sync-commands` / `sync-agents`)
+- `sync-agentrc.js` — merges `starter-agentrc.json` deltas into `.agentrc.json`
+- `check-windows-git-perf.js` — one-time Windows git perf diagnostic
 - `lib/bootstrap/*` — shared bootstrap helper modules
 
 **Runtime orchestration scripts** are invoked by agent sessions, git hooks,
@@ -374,19 +373,11 @@ or CI pipelines and must remain at their `.agents/scripts/<name>` paths
 - `update-ticket-state.js` — GitHub label transitions
 - And all other scripts under `.agents/scripts/` not listed above
 
-**The rule:** a script is *lifecycle* if it is only ever invoked by a human
-operator at the terminal; it is *runtime* if it is invoked by an agent
-session, a git hook, or a CI step via the `.agents/scripts/<name>` path.
-Moving a lifecycle script to `bin/` without updating the hook or CI
-invocation site breaks the calling surface; moving a runtime script away
-from `.agents/scripts/` breaks agent sessions and git hooks.
-
-This partition is enforced by the invariant test at
-`tests/cli/partition.test.js`: it asserts that `.claude/settings.json`'s
-`UserPromptSubmit` hook no longer contains a bare
-`node .agents/scripts/sync-claude-commands.js` invocation — evidence that
-the hook migration from Story #3451 has taken effect and the lifecycle
-script is now correctly invoked through the `mandrel` CLI.
+**The rule:** *lifecycle* = only ever invoked by a human at the terminal;
+*runtime* = invoked by an agent session, git hook, or CI step via the
+`.agents/scripts/<name>` path — moving one off that path breaks both. The
+invariant test `tests/cli/partition.test.js` enforces it: `.claude/settings.json`'s
+`UserPromptSubmit` hook must not call `sync-claude-commands.js` directly.
 
 ---
 
@@ -528,11 +519,15 @@ The `Graph.js` module provides the mathematical foundation for task scheduling:
 | `computeWaves()`          | Layer-grouped wave partitioning            | O(V+E)     |
 | `topologicalSort()`       | Kahn's algorithm (deterministic tie-break) | O(V+E)     |
 | `transitiveReduction()`   | DFS-based edge pruning                     | O(V·(V+E)) |
-| `autoSerializeOverlaps()` | Focus-area conflict serialization          | O(N²+V·E)  |
 | `computeReachability()`   | Memoized DFS transitive closure            | O(V·(V+E)) |
+| `computeChatDependencies()` | Session-level edge rollup + reduction    | O(V+E)     |
 
-The auto-serialization pass prevents file-level merge conflicts by injecting
-synthetic dependency edges between tasks with overlapping `focusAreas`.
+That is the complete live export surface — in particular there is **no**
+`autoSerializeOverlaps()`. The focus-area auto-serialization pass it named is
+gone; its job now happens at *selection* time via `storiesOverlap()` in
+`lib/wave-runner/ready-set.js`, where `selectReadySet` skips a Story whose
+**declared** footprint overlaps an already-selected peer — de-conflicting
+within one tick only, reserving nothing against a later one.
 
 ---
 
@@ -806,13 +801,16 @@ changing its shape (full per-field reference:
   default `true`: non-blocking code-review / audit findings may be
   auto-filed as follow-up issues (routed via `lib/feedback-loop/`). Set
   `false` to keep findings only in structured comments.
-- **`delivery.ci.skipForStoryPushes`** — default `true`: pre-push
-  tooling appends `[skip ci]` to Story-branch commit subjects so
-  intermediate pushes don't stampede CI; the final PR to `main` never
-  carries the marker for the merge commit GitHub creates.
+- **`delivery.ci`** — exactly two keys (`additionalProperties: false`, so a
+  third fails AJV validation): `autoMerge` (`"trust-ci"` default arms once
+  every *required* check is green; `"strict"` restores the clean-sprint
+  predicate) and `watch` (the merge-wait budget). Required-check contexts come
+  off the live ruleset, never off `.agentrc.json` —
+  [`ci-contract.md`](ci-contract.md).
 - **`delivery.routing.closeAndLand`** — default `true`: `single-story-close`
   arms auto-merge and may poll to confirmation; set `false` to stop at
   PR-open for operator-driven merge.
+
 ---
 
 ## Ticket Hierarchy
@@ -1081,15 +1079,20 @@ automatic staleness check.
 
 ### Performance-Signal Telemetry
 
-The framework emits a closed taxonomy of NDJSON record kinds — the
-active detectors `friction`, `hotspot`, `rework`, `retry`, plus the raw
-`trace` (schema:
-[`signal-event.schema.json`](../.agents/schemas/signal-event.schema.json)).
-The schema also reserves `churn` and `idle` slots for future use; their
-detectors and config keys were dropped under Epic #1721 (see ADR in
-[`docs/decisions.md`](decisions.md)) but the names remain in
-`EVENT_KINDS` so a future re-introduction does not need a schema bump.
-Records are written **append-only to local disk** under
+The framework emits a closed taxonomy of **thirteen** NDJSON record kinds —
+`EVENT_KINDS` (`lib/signals/schema.js`), mirrored by the `kind` enum in
+[`signal-event.schema.json`](../.agents/schemas/signal-event.schema.json).
+
+Enumerated ≠ produced: only **two** detector modules ship
+(`lib/signals/detectors/`: `rework.js`, `retry.js`), beside the
+`diagnose-friction.js` writer and the raw `trace` hook. `hotspot`, `churn`,
+`idle` are **reserved names with no detector** — `churn`/`idle` dropped under
+Epic #1721, `hotspot` retired with its detector under Epic #4406 (ADR in
+[`docs/decisions.md`](decisions.md)). The names stay so a re-introduction
+needs no schema bump, but the config keys are gone: `SIGNALS_DEFAULTS`
+(`lib/config/limits.js`) carries `rework` and `retry` only under an
+`additionalProperties: false` block, so `delivery.signals.hotspot` fails AJV
+validation. Records are written **append-only to local disk** under
 `temp/run-<eid>/stories/story-<sid>/signals.ndjson` (and a sibling
 `traces.ndjson` for `kind: trace`; standalone Stories use
 `temp/standalone/stories/story-<sid>/`). GitHub tickets receive **summaries
@@ -1106,29 +1109,27 @@ The model has three layers:
    not lose their tail. The per-Story directory is created lazily on the
    first write; `epicId` / `storyId` must be positive integers.
 2. **Detectors — `diagnose-friction.js` and the per-detector pure
-   modules under `lib/signals/detectors/` (`rework.js`, `retry.js`,
-   `hotspot.js`).** Signals are aggregated by the retro's signal-gathering
-   phase (`lib/orchestration/retro/phases/gather-signals.js`).
-   Each call site resolves thresholds via `getSignals(config)`
-   (defaults: `hotspot.p95Multiplier=1.25`, `rework.editsPerFile=5`,
-   `retry.repeatCount=3`). Operators override individual keys in
-   `.agentrc.json` under `delivery.signals.*`; the resolver shallow-
-   merges per detector, so a re-tuned `hotspot.p95Multiplier` does not
-   require re-listing the others.
+   modules under `lib/signals/detectors/` (`rework.js`, `retry.js`).**
+   Signals are read back by `read()` in `lib/signals/read.js` and composed
+   into routed proposals by `lib/orchestration/retro-proposals.js`, called
+   from `run-epilogue.js` and `story-follow-ups.js`. Thresholds resolve via
+   `getSignals(config)` — the whole surviving surface is two keys,
+   `rework.editsPerFile` (default 5) and `retry.repeatCount` (default 3),
+   overridable under `delivery.signals.*`. The resolver shallow-merges per
+   detector, so re-tuning one does not require re-listing the other.
 3. **Analyzers — the retro.** Story #4545 deleted the perf-summary /
-   perf-report analyzers (`analyze-execution.js` and the
-   `lib/observability/perf-*` modules it exclusively owned): the CLI
-   hard-failed without an Epic id, read signals from a path a standalone
-   Story can never produce, and no workflow invoked it. The surviving
-   consumer of the stream is the retro's signal-gathering phase, which routes
-   recurring friction into proposals. Nothing writes a
+   perf-report analyzers: the CLI hard-failed without an Epic id, read
+   signals from a path a standalone Story can never produce, and no workflow
+   invoked it. The surviving consumer is the retro proposal composer
+   (`lib/orchestration/retro-proposals.js`), which routes recurring friction
+   into framework / consumer / discarded proposals. Nothing writes a
    `structured:story-perf-summary` or `structured:epic-perf-report` comment.
 
-The split — events local, summaries on tickets — keeps the GitHub
-comment surface bounded and keeps the raw stream cheap enough that detectors
-can fire on every tool-call without rate-limiting or batching. The per-Epic temp tree is
-reaped together with the worktree on `WorktreeManager.reap`. See
-[`docs/decisions.md`](decisions.md) ADR for the architectural rationale.
+The split — events local, summaries on tickets — keeps the comment surface
+bounded and the raw stream cheap enough that detectors can fire on every
+tool-call without rate-limiting. The temp tree is reaped with the worktree on
+`WorktreeManager.reap`. Rationale: the ADR in
+[`docs/decisions.md`](decisions.md).
 
 ### Log Levels
 
@@ -1143,34 +1144,37 @@ reaped together with the worktree on `WorktreeManager.reap`. See
 
 ### Notification System
 
-| Event               | Severity | Channel            |
-| ------------------- | -------- | ------------------ |
-| `task-complete`     | INFO     | GitHub @mention    |
-| `feature-complete`  | INFO     | GitHub @mention    |
-| `epic-complete`     | INFO     | @mention + webhook |
-| `review-needed`     | ACTION   | @mention + webhook |
-| `approval-required` | ACTION   | Webhook            |
-| `blocked`           | ACTION   | Webhook            |
+The vocabulary is an **allowlist per channel**, not a severity routing table.
+Both lists are declared once in `lib/config-settings-schema.js` as enums, so
+an event name outside its channel's list is an AJV validation failure, not a
+silently-dropped subscription. `github.notifications` gates the two channels
+independently — `commentEvents` for ticket comments, `webhookEvents` for
+`NOTIFICATION_WEBHOOK_URL` — with no fallback chain between them.
 
-`github.notifications` carries two independent per-channel gates,
-both using the same event-name-allowlist model: `commentEvents` filters
-GitHub-ticket comment posting; `webhookEvents` filters
-`NOTIFICATION_WEBHOOK_URL` deliveries. There is no fallback chain;
-raising or lowering one channel never affects the other. The default
-comment allowlist is `state-transition`, `story-merged`,
-`operator-message`; the default webhook allowlist is the curated
-`epic-*` vocabulary — `epic-started`, `epic-progress`, `epic-blocked`,
-`epic-unblocked`, `epic-complete` — so Slack consumers see the epic
-narrative (% progress + blockers) without the per-story firehose.
-`transitionTicketState` suppresses the `notify()` dispatch entirely
-for low-severity transitions (non-terminal story / epic
-flips) so the comment channel sees only the medium-severity
-story-level events operators expect. Severity is carried as envelope
-metadata and still drives `@mention` behavior on the comment channel
-but is no longer a routing factor for either channel. Webhook
-subscribers receive a typed envelope
-(`{ text, severity, ticketId, event?, level?, epicId?, phase? }`) so
-allowlisted events stay routable by event name and hierarchy level.
+| Event name          | `webhookEvents` | `commentEvents` |
+| ------------------- | :-------------: | :-------------: |
+| `state-transition`  | ✅              | ✅              |
+| `story-merged`      | ✅              | ✅              |
+| `operator-message`  | ✅              | ✅              |
+| `story-closing`     | ✅              | ✅              |
+| `merge.unlanded`    | ✅              | —               |
+| `merge.flip-failed` | ✅              | —               |
+| `loop.tick`         | ✅              | —               |
+
+Shipped defaults: every webhook event, and the first three comment events.
+
+The comment list is narrower on an axis of **ticket scope, not importance**:
+a comment lands on a Story issue, so only Story-scoped narrative belongs
+there, and `notify()` drops a comment for any dispatch without a resolvable
+ticket id anyway. `story-closing` is allowlistable for comments but absent
+from the shipped `NOTIFICATIONS_DEFAULTS` (`lib/config/github.js`).
+
+`transitionTicketState` skips the dispatch for low-severity transitions
+(`eventSeverity` rates only a Story/Epic reaching `agent::done` as `medium`;
+everything else is `low`). Severity — `low` | `medium` | `high` — is envelope
+metadata driving `@mention` behavior (`high` always; `medium` when
+`mentionOperator` is set), never routing. Webhook subscribers receive
+`{ text, severity, ticketId?, event?, level?, epicId?, phase? }`.
 
 ---
 
@@ -1306,27 +1310,34 @@ live LLM metering:
 
 ### Budget protocol
 
-- **`delivery.maxTokenBudget`**: caps assembled context envelopes. The
-  envelope builders estimate tokens (≈4 characters per token) and elide
-  sections when the envelope exceeds the cap (`elideEnvelope` in
-  `lib/orchestration/context-envelope.js`).
-- **`delivery.preflight.*`** (optional): preflight helpers compare
-  estimates (Stories, install time, GitHub API calls, Claude quota
-  tokens) to configured ceilings before `/deliver` fan-out. Live entry
-  is via `single-story-init.js` / `helpers/deliver-story` (the pre-v2
-  `epic-deliver-preflight.js` entry is deleted).
-- **Host runtime**: session quota and billing hard stops are enforced by the
-  operator's editor / CLI provider, not by Mandrel scripts.
+**There is no operator-configurable token budget.** The two keys this section
+used to document — `delivery.maxTokenBudget` and `delivery.preflight.*` — are
+on the "Dropped entirely" list in `lib/config/limits.js`, and the delivery
+schema is `additionalProperties: false`, so writing either now fails AJV
+validation. The surviving ceilings are **fixed framework constants**:
+
+- **Estimator:** `estimateTokens` (≈4 chars/token) in
+  `lib/orchestration/context-envelope.js`, shared by everything below (its
+  sibling `elideEnvelope` is exported but has no live caller).
+- **`PLAN_CONTEXT_ENVELOPE_BYTE_CEILING`** (`lib/orchestration/plan-context.js`,
+  256,000 bytes) — the `/plan` authoring envelope bound; fails closed.
+- **`DEFAULT_MODEL_CAPACITY`** (`lib/orchestration/ticket-validator-sizing.js`)
+  — plan-time Story sizing over **authored prose only**; never read from
+  `.agentrc.json`. `spec-spill.js` and `checklist-threading.js` use the same
+  estimator for their own payloads.
+- **Host runtime:** quota and billing hard stops are the operator's editor /
+  CLI provider's job, not Mandrel's.
 
 ---
 
 ## Distribution Model
 
 Mandrel is distributed as the
-[`mandrel`](https://www.npmjs.com/package/mandrel) npm package.
-The package payload is materialized into the consumer's `./.agents/` directory
-as plain regular files by `mandrel sync` (run best-effort from the package
-`postinstall`, or invoked directly):
+[`mandrel`](https://www.npmjs.com/package/mandrel) npm package, whose `files`
+array publishes `.agents/`, `bin/`, and `lib/`. Only **`.agents/`** is
+materialized into the consumer's `./.agents/` directory as plain regular files
+by `mandrel sync` (best-effort from `postinstall`, or invoked directly);
+`bin/` + `lib/` stay in `node_modules/mandrel/`, reached via `npx mandrel`:
 
 ```text
 Consumer Project/
@@ -1407,11 +1418,10 @@ conventions to follow.
 - **Config resolution:** `.agents/scripts/lib/config-resolver.js` +
   `config-schema.js` (shell-metacharacter injection guards built in)
 - **Operator scripts catalog:**
-  [`.agents/scripts/README.md`](../.agents/scripts/README.md) documents
-  the optional operator-only CLIs (`loc-delta.js`,
-  `validate-docs-freshness.js`,
-  `update-mutation-baseline.js`) that are not wired into `npm` /
-  Husky / CI.
+  [`.agents/scripts/README.md`](../.agents/scripts/README.md) documents the
+  optional operator-only CLIs not wired into `npm` / Husky / CI — today just
+  `validate-docs-freshness.js` (`loc-delta.js` and
+  `update-mutation-baseline.js` no longer exist).
 
 ### Ticketing & CI
 

--- a/docs/ci-contract.md
+++ b/docs/ci-contract.md
@@ -31,9 +31,9 @@ authoritative verdict is the CI run on the pull request.
 > | --- | --- |
 > | `check-arch-cycles.js` | Via the `lint` step — `run-lint.js` has run it since Story #3991. Deliberately **not** repeated in `run-verify.js`; doing so would double-pay the gate. |
 > | `check-dead-exports.js` | Its own `dead-exports` step (Story #4549). |
-| `check-dead-exports.js --production` | Its own `dead-exports-production` step — added when the production-mode pass (#4582) joined CI's baselines job. |
+> | `check-dead-exports.js --production` | Its own `dead-exports-production` step — added when the production-mode pass (#4582) joined CI's baselines job. |
 > | `check-context-budget.js` | Its own `context-budget` step (Story #4549). |
-| `check-workflow-citations.js` | Via the `test` step — `tests/check-workflow-citations.test.js` runs the same ratchet against the committed baseline, so a regression fails the suite. Deliberately **not** a separate `run-verify.js` step; doing so would double-pay the gate. |
+> | `check-workflow-citations.js` | Via the `test` step — `tests/check-workflow-citations.test.js` runs the same ratchet against the committed baseline, so a regression fails the suite. Deliberately **not** a separate `run-verify.js` step; doing so would double-pay the gate. |
 >
 > Before #4549 the latter two sat in a contract hole — omitted from the mirror
 > *and* absent from the CI-only table below — reachable locally only by a direct
@@ -67,9 +67,34 @@ CI gate** in front of the arm. Green-with-nothing-to-be-green is treated as
 armable, mirroring GitHub's own "no required checks = nothing to gate"
 semantics.
 
-Operators running `trust-ci` unattended MUST therefore keep at least the
-live required-check set (`lint`, `test`, `baselines`) configured on the base
-branch. Consumers who cannot guarantee that should set
+Operators running `trust-ci` unattended MUST therefore keep a non-empty
+required-status-check set configured on the base branch. In **this**
+repository that set is the four contexts declared in
+[`.github/ruleset.json`](../.github/ruleset.json):
+
+| Required check context     | Produced by                                                    |
+| -------------------------- | -------------------------------------------------------------- |
+| `Validate and Test`        | the `validate` job of `.github/workflows/ci.yml`               |
+| `baselines`                | the `baselines` job of `.github/workflows/ci.yml`              |
+| `install (npm / ubuntu-latest)`   | the Gate profile of `.github/workflows/install-matrix.yml` |
+| `install (yarn / windows-latest)` | the Gate profile of `.github/workflows/install-matrix.yml` |
+
+> **`.agentrc.json` `requiredChecks` names are NOT check contexts.** The
+> `github.branchProtection.requiredChecks` entries are `{ name, cmd }` pairs —
+> `name` is a **local label** for a command the bootstrap/verification path
+> runs on your machine (`lint` → `npm run lint`, `test` → `npm test`,
+> `baselines` → `node .agents/scripts/check-baselines.js`). GitHub reports a
+> status under the *job's display name*, which is a different string:
+> `npm run lint` and `npm test` both run **inside** the job GitHub reports as
+> `Validate and Test`, so there is no `lint` context and no `test` context to
+> require. Configuring branch protection from the `.agentrc.json` names would
+> register up to two contexts that no workflow ever reports — GitHub would
+> hold every PR forever, or, if the ruleset were removed to unstick it, leave
+> the `trust-ci` arm with nothing to gate. Read the contexts off the live
+> ruleset (`gh api repos/{owner}/{repo}/rulesets`) or the job `name:` fields
+> in `.github/workflows/`, never off `.agentrc.json`.
+
+Consumers who cannot guarantee a live required-check set should set
 `delivery.ci.autoMerge: "strict"`, which restores the prior clean-sprint
 predicate (zero interventions, zero 🔴/🟠 findings, clean-sprint retro) as the
 arming gate regardless of the required-check configuration.

--- a/docs/data-dictionary.md
+++ b/docs/data-dictionary.md
@@ -10,9 +10,7 @@ Mandrel orchestration engine.
 One newline-terminated JSON object emitted by `signals-writer.appendSignal`
 to `temp/run-<eid>/stories/story-<sid>/signals.ndjson` (standalone Stories:
 `temp/standalone/stories/story-<sid>/signals.ndjson`; and a sibling
-`traces.ndjson` for `kind: trace`). Closed taxonomy of seven record kinds —
-`friction`, `hotspot`, `rework`, `churn`, `idle`, `retry`, `trace` — defined
-by Epic #1030. Schema lives at
+`traces.ndjson` for `kind: trace`). Schema lives at
 [`signal-event.schema.json`](../.agents/schemas/signal-event.schema.json);
 the table below mirrors that schema — update both together. See
 [`docs/architecture.md`](architecture.md#performance-signal-telemetry) for
@@ -20,26 +18,33 @@ the producer / detector / analyzer flow and the ADR in
 [`docs/decisions.md`](decisions.md) for the events-local /
 summaries-on-tickets rationale.
 
+**Only `ts` and `kind` are required** (the envelope is
+`additionalProperties: true`); the Required column mirrors the schema, not
+usage. The `kind` enum holds **thirteen** values, mirrored by `EVENT_KINDS`
+(`lib/signals/schema.js`): `friction`, `trace`, `wave-start`, `wave-end`,
+`wave-complete`, `state-transition`, `hotspot`, `rework`, `churn`, `idle`,
+`retry`, `acceptance-eval`, `notification.emitted` — `hotspot`/`churn`/`idle`
+being reserved names with no shipped detector.
+
 | Field      | Type                | Required | Description                                                                                                                |
 | ---------- | ------------------- | -------- | -------------------------------------------------------------------------------------------------------------------------- |
-| `ts`       | `ISO8601 date-time` | Yes      | Event timestamp in UTC.                                                                                                    |
-| `kind`     | `enum`              | Yes      | One of `friction`, `hotspot`, `rework`, `churn`, `idle`, `retry`, `trace`. Drives detector dispatch and analyzer rollup.   |
-| `source`   | `object`            | Yes      | `{ tool: string, script?: string }`. `tool` is the originating surface (`Bash`, `Edit`, `Write`, `Read`, `Grep`, `Glob`, or a script name for derived signals). |
-| `epicId`   | `integer ≥ 1`       | Yes      | Run / parent id the event belongs to (field name retained for schema compat). Pins the on-disk path to `temp/run-<epicId>/` (standalone Stories: `temp/standalone/`). |
-| `storyId`  | `integer ≥ 1`       | Yes      | Story the event was sampled inside. Pins the on-disk path to `story-<storyId>/`.                                           |
+| `ts`       | `ISO8601 date-time` | **Yes**  | Event timestamp in UTC. The single canonical timestamp key — the legacy `timestamp` alias is gone.                          |
+| `kind`     | `enum` (13 values)  | **Yes**  | One of the thirteen kinds listed above. Drives detector dispatch and analyzer rollup.                                       |
+| `source`   | `string` enum       | No       | **`framework` \| `consumer` only** — the classifier tag from `tagSignalSource` (`signals-writer.js`). **Not** a provenance object; the pre-#4406 `source: { tool }` shape was deleted outright. |
+| `emitter`  | `object`            | No       | Provenance — `{ tool?, command? }`, where the old `source.tool` went. `tool` is the originating surface (`Bash`, `Edit`, a script name); `command` is the line blamed. |
+| `epicId`   | `integer ≥ 1` \| `null` | No   | Run / parent id the event belongs to (field name retained for schema compat). Pins the on-disk path to `temp/run-<epicId>/` (standalone Stories: `temp/standalone/`). |
+| `storyId`  | `integer ≥ 1` \| `null` | No   | Story the event was sampled inside. Pins the on-disk path to `story-<storyId>/`.                                            |
 | `taskId`   | `integer ≥ 1` \| `null` | No   | Legacy field name; GitHub issue number when the event is scoped below Epic level. `null` for Story-wide events.              |
 | `phase`    | `string` \| `null`  | No       | Execution phase the event was sampled inside (`bootstrap`, `implement`, `test`, `close`, …). `null` for raw traces outside a phase boundary. |
-| `details`  | `object`            | No       | Kind-specific payload (free-form for forward compatibility). Common keys: `category`, `command`, `elapsedMs`, `targetHash`. |
+| `details`  | `object`            | No       | Kind-specific payload — always an object, never a bare string. Free-form; common keys `errorPreview`, `command`, `commandHash`, `targetHash`, `exitCode`, `elapsedMs`. |
 
 ---
 
 ## StoryPerfSummary / EpicPerfReport — removed (Story #4545)
 
 Both payloads and their schemas were deleted with the execution-analysis
-surface that produced them: the analyzer hard-failed without an Epic id, read
-signals from a path a standalone Story can never produce, and no workflow
-invoked it. Nothing writes a `structured:story-perf-summary` or
-`structured:epic-perf-report` comment, and neither kind is a valid structured
+surface that produced them. Nothing writes a `structured:story-perf-summary`
+or `structured:epic-perf-report` comment, and neither is a valid structured
 comment type any more.
 
 ## FrictionEvent (`friction` NDJSON signal)
@@ -201,14 +206,11 @@ readers should not re-implement the fence-extraction logic inline.
 
 ## Dispatch Manifest (historical)
 
-> **Historical.** The dispatch manifest
-> (`temp/dispatch-manifest-<epicId>.json`, the `dispatch-manifest`
-> structured comment on the Epic, and its renderer
-> `render-manifest.js`) was deleted with the Epic tier in v2.0.0. No
-> producer writes it, and the live structured-comment table above omits
-> it. The dispatch record in v2 is the Story's own GitHub surface —
-> labels, structured comments, and the `story-<id>` PR. Manifests on
-> historical Epics remain readable as plain comments.
+> **Historical.** The dispatch manifest (`temp/dispatch-manifest-<epicId>.json`,
+> its structured comment, and its renderer `render-manifest.js`) was deleted
+> with the Epic tier in v2.0.0 — nothing writes it. The v2 dispatch record is
+> the Story's own GitHub surface: labels, structured comments, and the
+> `story-<id>` PR.
 
 ---
 
@@ -247,15 +249,6 @@ readers should not re-implement the fence-extraction logic inline.
 
 ---
 
-## Wave Marker Regex
-
-The wave structured-comment marker regex is
-`/^wave-([0-9]{1,3})-(start|end)$/` — up to 999 waves. `wave-1000-start` is
-rejected; downstream wave-index consumers (`manifest-builder`) tolerate
-rejected indices gracefully.
-
----
-
 ## CRAP Analysis Artefacts
 
 Per-method complexity × coverage risk gate, sibling to the maintainability
@@ -263,14 +256,15 @@ ratchet.
 
 | Term                                                | Kind               | Definition                                                                                                                                                                                                                                                                                                                                                                  |
 | --------------------------------------------------- | ------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `baselines/crap.json`                               | Repo-root artefact | `{ kernelVersion, escomplexVersion, rows: [{ file, method, startLine, crap }] }`. Rows deterministically sorted by `(file, startLine)`; alphabetized keys; trailing newline. `kernelVersion` bumps when the inline CRAP formula changes; `escomplexVersion` bumps with the `typhonjs-escomplex` dependency. A baseline whose stamps don't match the running scorer fails closed. |
-| `delivery.quality.gates.crap`                       | Config block       | `{ enabled, targetDirs, newMethodCeiling, coveragePath, tolerance, requireCoverage, friction.markerKey, refreshTag }`. Defaults: `enabled: true`, `targetDirs: ["src"]`, `newMethodCeiling: 30`, `coveragePath: "coverage/coverage-final.json"`, `tolerance: 0.05`, `requireCoverage: true`, `refreshTag: "baseline-refresh:"`. List-valued keys accept `{ append }` / `{ prepend }`. |
+| `baselines/crap.json`                               | Repo-root artefact | Envelope-shaped ([`crap.schema.json`](../.agents/schemas/baselines/crap.schema.json) over [`baseline-envelope.schema.json`](../.agents/schemas/baselines/baseline-envelope.schema.json), `additionalProperties: false`): `{ $schema, kernelVersion, generatedAt, scoringSemantics, rollup, rows }`. **There is no `escomplexVersion` key** — the envelope forbids one; that stamp belongs to the legacy flat `crap-baseline.schema.json`. Rows are `{ path, method, startLine, crap }` — keyed on **`path`**, not `file` — sorted by `(path, startLine)`; alphabetized keys; trailing newline. The gate compares two stamps: `scoringSemantics` (e.g. `"coverage-join-v2"`) names the coverage-join semantics that produced the rows (#4775), and a baseline stamped differently from the running scorer is **incomparable** — it fails closed with re-baseline guidance; `rollup` is required, keyed by component (`"*"` = whole repo), each entry carrying exactly `{ p50, p95, max, methodsAbove20 }`, the axes `floors` check. |
+| `delivery.quality.gates.crap`                       | Config block       | `{ enabled, baselinePath, tolerance, floors, components, targetDirs, newMethodCeiling, requireCoverage, minMethodResolutionRate, friction.markerKey, refreshTag, refreshTimeoutMs, ignoreGlobs }` — `additionalProperties: false` (first five from the shared `GATE_BASE`). Defaults in `CRAP_GATE_DEFAULTS` (`lib/config/quality.js`): `tolerance: { kind: "absolute", value: 0.05 }`, `floors: { "*": { max: 30, p95: 20, methodsAbove20: 50 } }`, `targetDirs: ["src"]`, `newMethodCeiling: 30`, `minMethodResolutionRate: 0.75`, `refreshTag: "baseline-refresh:"`. List-valued keys accept `{ append }` / `{ prepend }`. |
+| `coveragePath` — **on the coverage gate**           | Config key         | `delivery.quality.gates.coverage.coveragePath` (default `"coverage/coverage-final.json"`). Moved off the CRAP gate in #1737; CRAP reads it from there. Both schemas are `additionalProperties: false`, so putting it back under `crap` is a hard AJV failure, not a no-op. |
 | Hybrid enforcement                                  | Decision contract  | `compareCrap()` resolves each scanned row through four match paths: exact `(file, method, startLine)`, line-drift fallback (same `(file, method)`, shifted `startLine`), new (no match → ceiling check), removed (baseline row absent → reported, never a failure).                                                                                                          |
 | `fixGuidance`                                       | Report field       | Per-violation block in the `--json` envelope: `{ crapCeiling, minComplexityAt100Cov, minCoverageAtCurrentComplexity }`. Derived deterministically from the formula; `null` when unachievable at current complexity. Round-trip property: applying either single-axis fix re-scores under target.                                                                              |
-| `--changed-since <ref>`                             | CLI flag           | On `quality-preview.js` (defaults to `HEAD` when omitted). Limits scoring + comparison to files changed relative to `<ref>`. For the unified gate (`check-baselines.js`), diff scoping is config-driven via `delivery.quality.gateScoping` rather than a CLI flag.                                                                                                            |
-| `--json` / `--format json`                          | CLI flag           | `quality-preview.js` takes boolean `--json` (emits the merged machine-readable envelope on stdout); `check-baselines.js` takes `--format json\|text` and emits the JSON report on stdout. The standalone per-gate `--json <path>` file writers went away with `check-crap.js` / `check-maintainability.js` — per-kind gate logic now lives in `lib/baselines/kinds/`.        |
-| `CRAP_NEW_METHOD_CEILING` / `CRAP_TOLERANCE` / `CRAP_REFRESH_TAG` | Env vars | Override `crap.newMethodCeiling`, `crap.tolerance`, and `crap.refreshTag` respectively at runtime. Malformed values warn and fall back to config — a typo must never silently relax the gate. Originally consumed by the (since-removed) baseline-refresh CI guardrail; still available for local re-runs that need to force base-branch values.                                |
-| `refreshTag` (commit-message convention)            | Operator convention | A baseline edit should land in a commit whose subject starts with the configured `refreshTag` (default `baseline-refresh:`) and whose body is non-empty. The CI guardrail that mechanically enforced this was removed in 5.42; the operator is now the gate during `/deliver` Phase 7.                                                                                  |
+| `--changed-since <ref>`                             | CLI flag           | On `quality-preview.js` (defaults to `HEAD`). Limits scoring + comparison to files changed relative to `<ref>`. The unified gate (`check-baselines.js`) scopes via `delivery.quality.gateScoping` instead. |
+| `--json` / `--format json`                          | CLI flag           | `quality-preview.js` takes boolean `--json` (emits the merged machine-readable envelope on stdout); `check-baselines.js` takes `--format json\|text`. The standalone per-gate `--json <path>` writers went away with `check-crap.js` / `check-maintainability.js`; per-kind logic now lives in `lib/baselines/kinds/`. |
+| `CRAP_NEW_METHOD_CEILING` / `CRAP_TOLERANCE` / `CRAP_REFRESH_TAG` | Env vars | Override `crap.newMethodCeiling`, `crap.tolerance`, and `crap.refreshTag` respectively at runtime. Malformed values warn and fall back to config — a typo must never silently relax the gate. Available for local re-runs that need base-branch values. |
+| `refreshTag` (commit-message convention)            | Operator convention | A baseline edit should land in a commit whose subject starts with the configured `refreshTag` (default `baseline-refresh:`) and whose body is non-empty. No CI guardrail enforces it; the operator is the gate. |
 
 ---
 
@@ -306,7 +300,7 @@ authoritative SDK.
 | Term                                       | Kind     | Definition                                                                                                                                                         |
 | ------------------------------------------ | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `post-structured-comment.js`               | CLI      | `--ticket <id> --marker <key> --body-file <path>`. Wraps `upsertStructuredComment(provider, ticketId, marker, body)` from `lib/orchestration/ticketing.js`; idempotent by marker. |
-| `select-audits.js` / `run-audit-suite.js`  | CLI      | Selection reads `audit-rules.json` (manifest schema: `audit-rules.schema.json`); suite execution loads the selected workflow prompts.                              |
+| `lib/audit-suite/index.js`                 | SDK barrel | `selectAudits()` / `runAuditSuite()`. Selection reads `audit-rules.json` (schema `audit-rules.schema.json`); execution loads the selected prompts. Imported by `run-epilogue.js` and the Story-close review phases — the `select-audits.js` / `run-audit-suite.js` entry scripts were deleted, so there is no audit-suite CLI. |
 | `update-ticket-state.js`                   | CLI      | Covers ticket state transitions and cascade-completion. Cascade runs inline at the SDK layer when a Story reaches `agent::done`.                                    |
 | `dispatcher.js`                            | CLI      | **Deleted in v2.** Pre-v2 DAG / wave / dispatch-manifest CLI. Multi-Story ordering now uses `stories-wave-tick.js` + `lib/wave-runner/ready-set.js`. |
 | `process.env`-only secrets resolution      | Contract | `notifier.js` `resolveWebhookUrl()` and the GitHub provider's `GITHUB_TOKEN` lookup read **only** from `process.env`. `.mcp.json` is not consulted as a secrets backstop.       |
@@ -375,10 +369,10 @@ before it reaches disk.
 
 ## Retro Heuristic (historical)
 
-> **Removed in v2.** The `epic-retro` helper and `lib/orchestration/retro-heuristics.js`
-> (`isCleanManifest`) were deleted with the Epic delivery path. Compact vs full
-> retro branching no longer applies; keep this section only as a glossary for
-> archived docs that still name the predicate.
+> **Removed in v2.** The `epic-retro` helper and
+> `lib/orchestration/retro-heuristics.js` (`isCleanManifest`) were deleted with
+> the Epic delivery path; compact-vs-full retro branching no longer applies.
+> Kept as a glossary for archived docs that still name the predicate.
 
 | Term                       | Kind     | Definition                                                                                                                                                |
 | -------------------------- | -------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -17,7 +17,7 @@ authoritative system prompt.
 
 ```text
 mandrel/
-├── .agents/                  # Distributed bundle (the "product")
+├── .agents/                  # Distributed: the materialized payload
 │   ├── instructions.md       # ★ Primary system prompt — load this first
 │   ├── agents/               # Role-scoped spawn boot contexts (optional)
 │   ├── rules/                # Domain-agnostic coding/ops rules
@@ -29,14 +29,20 @@ mandrel/
 │   ├── docs/                 # Shipped consumer reference docs (SDLC.md, configuration.md, agentrc-reference.json)
 │   ├── starter-agentrc.json  # Bootstrap delta-seed — consumers copy to project root
 │   └── README.md             # Detailed consumer user guide
+├── bin/                      # Distributed: mandrel.js (CLI dispatcher) + postinstall.js
+├── lib/                      # Distributed: cli/ subcommand impls + migrations/
 ├── .agentrc.json             # Root config for this repo (dogfooding)
 ├── docs/                     # Implementation plans and changelog
 ├── tests/                    # Framework tests
 ├── package.json              # Tooling: biome, markdownlint, husky
 ```
 
-> **Key distinction:** Only `.agents/` is distributed to consumers. Everything
-> else is internal development tooling.
+> **Key distinction:** the published package ships exactly the three
+> directories marked *Distributed* above — `.agents/`, `bin/`, and `lib/`, per
+> the `files` array in [`package.json`](../package.json). Only `.agents/` is
+> *materialized* into the consumer's working tree (by `mandrel sync`); `bin/`
+> and `lib/` stay in `node_modules/mandrel/` and back the `npx mandrel …` CLI.
+> Everything else in this repository is internal development tooling.
 
 ---
 
@@ -106,9 +112,10 @@ touched git/orchestration hooks, and `npm run verify` when you want pre-PR
 confidence (audit + lint + full tests + baselines + the dead-exports and
 context-budget ratchets; the arch-cycles ratchet rides along inside `lint`).
 `npm run verify` is a **true CI mirror** for the gates it can prove locally,
-but a small set of CI gates (action pinning, the TruffleHog secret scan, and
-the push-scoped `BASELINE_SCOPE=full` maintainability run) cannot be
-reproduced from a local working tree — those are catalogued in
+but a small set of CI gates (action pinning, the TruffleHog secret scan, the
+push-scoped `BASELINE_SCOPE=full` maintainability run, and the
+`check-test-temp-hygiene.js` snapshot/assert bracket around the test run)
+cannot be reproduced from a local working tree — those are catalogued in
 [`ci-contract.md`](ci-contract.md), so a local green is necessary but not
 sufficient. Pre-push runs only diff-scoped quality preview plus coverage/CRAP
 ratchet; it does not run full lint or `npm test`. CI always runs the full
@@ -133,7 +140,9 @@ the same machine before and after an optimization. Optional flags:
 ## Contribution Workflow
 
 1. Branch from `main`.
-2. Make changes inside `.agents/` (the distributed product).
+2. Make the change. Framework behaviour lives under `.agents/`; the operator
+   CLI lives under `bin/` + `lib/` — both ship, so both carry the same
+   quality gates.
 3. Commit — Husky will auto-lint and format staged `.md` files.
 4. Open a PR against `main`. CI validates the change; once merged,
    release-please cuts the release that publishes `mandrel` to npm.

--- a/docs/release-operations.md
+++ b/docs/release-operations.md
@@ -54,8 +54,11 @@ The **Install Matrix** workflow
 proves the published-package consumer contract end to end (pack → install →
 `mandrel sync` / `sync-commands` → assert materialization, a clean consumer
 manifest, and a `mandrel doctor` ready verdict). It gates releases the same
-way `lint` / `test` / `baselines` do — through **branch protection on the
-release PR**, not through `release-please.yml`. To avoid the classic
+way the `Validate and Test` and `baselines` contexts do — through **branch
+protection on the release PR**, not through `release-please.yml`. (Those two
+strings are the CI job *display names*, which is what GitHub reports a status
+under; they are not the `.agentrc.json` `requiredChecks` labels — see
+[`ci-contract.md`](ci-contract.md).) To avoid the classic
 required-check + path-filter deadlock, the workflow splits into two profiles:
 
 - **Gate (required, always reports):** a 2-leg diagonal that runs on **every**

--- a/tests/contract/docs-reference-sync.test.js
+++ b/tests/contract/docs-reference-sync.test.js
@@ -1,0 +1,521 @@
+// tests/contract/docs-reference-sync.test.js
+//
+// Story #4785 — keeps the reference documentation honest about the contracts
+// the code actually implements.
+//
+// The docs in scope are read by every agent that works in this repo, and two
+// of them (`architecture.md`, `data-dictionary.md`) are mandatory reads. A doc
+// that instructs a `.agentrc.json` key the AJV schema rejects, or points at a
+// module that no longer exists, does not merely mislead — it costs a full
+// failed round-trip. These are the three machine-checkable axes:
+//
+//   1. Every `.agentrc.json` key quoted in a doc in scope is REACHABLE in the
+//      live AGENTRC_SCHEMA. Reachability (not a full instance round-trip) is
+//      the right assertion because every block in that schema is
+//      `additionalProperties: false`: an unreachable key is a guaranteed
+//      validation failure whatever value you give it, and a reachable one
+//      cannot be rejected for existing. Keys the docs deliberately name as
+//      RETIRED are listed below and are asserted to be genuinely unreachable,
+//      so the allowlist cannot rot into cover for a live key.
+//
+//   2. Every backticked path in a doc in scope resolves on disk. Paths the
+//      docs deliberately name as deleted history (or that are gitignored /
+//      runtime-generated / external) are listed below with a reason, and each
+//      entry is asserted to be genuinely absent so the list cannot rot either.
+//
+//   3. The `data-dictionary.md` rows for SignalEvent and `baselines/crap.json`
+//      match the live JSON Schemas field-by-field — that file declares itself
+//      a schema mirror, so drift is a contract break, not a typo.
+
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { describe, it } from 'node:test';
+import { fileURLToPath } from 'node:url';
+import { COVERAGE_GATE } from '../../.agents/scripts/lib/config/gates/coverage.schema.js';
+import { CRAP_GATE } from '../../.agents/scripts/lib/config/gates/crap.schema.js';
+import { AGENTRC_SCHEMA } from '../../.agents/scripts/lib/config-settings-schema.js';
+import { EVENT_KINDS } from '../../.agents/scripts/lib/signals/schema.js';
+
+const repoRoot = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '..',
+  '..',
+);
+
+/** The documentation partition this Story owns. */
+const DOCS_IN_SCOPE = Object.freeze([
+  'docs/architecture.md',
+  'docs/data-dictionary.md',
+  'docs/ci-contract.md',
+  'docs/onboarding.md',
+  'docs/claude-coupling-review.md',
+  'docs/release-operations.md',
+  'AGENTS.md',
+  'README.md',
+]);
+
+const read = (rel) => readFileSync(path.join(repoRoot, rel), 'utf8');
+
+/**
+ * Yield `{ doc, line, token }` for every backticked token in the docs in
+ * scope. Tokens containing whitespace are skipped — those are prose or
+ * command lines, not identifiers.
+ *
+ * @returns {Array<{doc: string, line: number, token: string}>}
+ */
+function backtickedTokens() {
+  const out = [];
+  for (const doc of DOCS_IN_SCOPE) {
+    read(doc)
+      .split('\n')
+      .forEach((line, idx) => {
+        for (const m of line.matchAll(/`([^`\n]+)`/g)) {
+          const token = m[1].trim();
+          if (!token || /\s/.test(token)) continue;
+          out.push({ doc, line: idx + 1, token });
+        }
+      });
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// 1. `.agentrc.json` keys quoted in the docs must be reachable in the schema
+// ---------------------------------------------------------------------------
+
+const AGENTRC_ROOTS = new Set([
+  'project',
+  'github',
+  'planning',
+  'delivery',
+  'qa',
+]);
+
+/**
+ * Keys the docs in scope name **because they were retired** — each is
+ * mentioned only to warn that writing it now fails AJV validation. The test
+ * below asserts every entry really is unreachable, so this list can never
+ * quietly excuse a live key that a future refactor moves.
+ */
+const DOCUMENTED_AS_RETIRED = Object.freeze([
+  'delivery.maxTokenBudget',
+  'delivery.preflight.*',
+  'delivery.signals.hotspot',
+]);
+
+/**
+ * Walk a dotted config path through the live AJV schema. Returns the first
+ * segment that cannot be reached, or `null` when the whole path resolves.
+ *
+ * `additionalProperties` that is `true` or an object schema means the level
+ * accepts arbitrary keys, so traversal continues; `false` (the repo-wide
+ * default) means an unlisted key is a hard rejection.
+ *
+ * @param {string} dotted
+ * @returns {string|null} the unreachable segment, or null
+ */
+function unreachableSegment(dotted) {
+  let node = AGENTRC_SCHEMA;
+  for (const seg of dotted.split('.')) {
+    if (seg === '' || seg === '*') continue;
+    while (
+      node &&
+      !node.properties &&
+      (node.oneOf || node.allOf || node.anyOf)
+    ) {
+      node = (node.oneOf || node.allOf || node.anyOf).find((s) => s.properties);
+    }
+    if (!node || typeof node !== 'object') return seg;
+    if (node.properties && Object.hasOwn(node.properties, seg)) {
+      node = node.properties[seg];
+      continue;
+    }
+    const extra = node.additionalProperties;
+    if (extra === true) {
+      node = {};
+      continue;
+    }
+    if (extra && typeof extra === 'object') {
+      node = extra;
+      continue;
+    }
+    return seg;
+  }
+  return null;
+}
+
+describe('docs in scope — every quoted .agentrc.json key validates (Story #4785)', () => {
+  it('names no config key the live AGENTRC_SCHEMA would reject', () => {
+    const retired = new Set(DOCUMENTED_AS_RETIRED);
+    const offenders = [];
+    for (const { doc, line, token } of backtickedTokens()) {
+      if (!token.includes('.')) continue;
+      if (!/^[A-Za-z][A-Za-z0-9_.*-]*$/.test(token)) continue;
+      if (!AGENTRC_ROOTS.has(token.split('.')[0])) continue;
+      if (retired.has(token)) continue;
+      const bad = unreachableSegment(token);
+      if (bad)
+        offenders.push(
+          `${doc}:${line} — \`${token}\` (unreachable at "${bad}")`,
+        );
+    }
+    assert.deepEqual(
+      offenders,
+      [],
+      `docs quote .agentrc.json keys the schema rejects:\n  ${offenders.join('\n  ')}`,
+    );
+  });
+
+  it('keeps DOCUMENTED_AS_RETIRED honest — every entry is genuinely unreachable', () => {
+    for (const key of DOCUMENTED_AS_RETIRED) {
+      assert.ok(
+        unreachableSegment(key),
+        `\`${key}\` is reachable in AGENTRC_SCHEMA — drop it from DOCUMENTED_AS_RETIRED and document it as live`,
+      );
+    }
+  });
+
+  it('pins delivery.ci to its two live keys (the skipForStoryPushes guard)', () => {
+    const ci = AGENTRC_SCHEMA.properties.delivery.properties.ci;
+    assert.deepEqual(Object.keys(ci.properties).sort(), ['autoMerge', 'watch']);
+    assert.equal(ci.additionalProperties, false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. Every backticked path in the docs in scope resolves on disk
+// ---------------------------------------------------------------------------
+
+/** Path-ish suffixes worth resolving. Bare extensions (`.js`) are excluded. */
+const PATH_SUFFIX = /[^./]\.(js|mjs|cjs|ts|tsx|json|md|yml|yaml|ndjson)$/;
+
+/** Roots a bare path may be relative to. */
+const PATH_PREFIXES = Object.freeze([
+  '',
+  '.agents/scripts/',
+  '.agents/',
+  'docs/',
+  'lib/',
+  'bin/',
+  'tests/',
+  '.github/workflows/',
+]);
+
+/**
+ * Paths the docs in scope name that deliberately do NOT exist on disk. Every
+ * entry carries the reason it is absent; the second test asserts each really
+ * is absent, so a resurrected module cannot hide behind this list.
+ */
+const UNRESOLVED_BY_DESIGN = Object.freeze({
+  // --- Named as deleted history (the doc says so in the same breath) -------
+  'dispatch-engine.js': 'pre-v2 entry script, deleted in the v2 cutover',
+  'dispatcher.js': 'pre-v2 DAG/wave CLI, deleted in the v2 cutover',
+  'epic-execute-record-wave.js':
+    'in-process epic-runner stratum, deleted (#3908)',
+  'wave-gate.js': 'epic-runner-era concurrency surface, deleted (#3908)',
+  'lib/orchestration/concurrency.js':
+    'epic-runner-era concurrency surface, deleted (#3908)',
+  'lib/orchestration/context.js':
+    'typed runner context classes, deleted (#3908)',
+  'lib/orchestration/error-journal.js':
+    'ErrorJournal, deleted with the in-process runner (#3908)',
+  'analyze-execution.js': 'execution-analysis surface, deleted (Story #4545)',
+  'epic-audit-prepare.js':
+    'Epic audit CLI, deleted in the v2 Story-only cutover',
+  'epic-audit-recheck.js':
+    'Epic audit CLI, deleted in the v2 Story-only cutover',
+  'render-manifest.js':
+    'dispatch-manifest renderer, deleted with the Epic tier',
+  'lib/orchestration/retro-heuristics.js':
+    'epic-retro predicate, deleted with the Epic path',
+  'check-crap.js': 'per-kind gate CLI, folded into lib/baselines/kinds/',
+  'check-maintainability.js':
+    'per-kind gate CLI, folded into lib/baselines/kinds/',
+  'select-audits.js':
+    'audit entry script, folded into lib/audit-suite/index.js',
+  'run-audit-suite.js':
+    'audit entry script, folded into lib/audit-suite/index.js',
+  'loc-delta.js': 'operator CLI removed; the scripts README no longer lists it',
+  'update-mutation-baseline.js':
+    'operator CLI removed; the scripts README no longer lists it',
+  // --- Gitignored local overrides / runtime artifacts ----------------------
+  '.agentrc.local.json': 'gitignored local config override',
+  '.mcp.json': 'gitignored local MCP config',
+  'traces.ndjson': 'runtime artifact written under temp/',
+  'temp/test-profile.tap': 'runtime artifact written under temp/ (gitignored)',
+  // --- Not this repository's files ----------------------------------------
+  'src/index.ts': 'file in release-please-action v5.0.0, an external repo',
+  'pnpm-lock.yaml': "a consumer project's lockfile, not this repo's",
+});
+
+describe('docs in scope — every backticked path resolves (Story #4785)', () => {
+  const tracked = execFileSync('git', ['ls-files'], {
+    cwd: repoRoot,
+    encoding: 'utf8',
+  })
+    .split('\n')
+    .filter(Boolean);
+  const trackedSet = new Set(tracked);
+  const trackedBasenames = new Set(tracked.map((p) => path.posix.basename(p)));
+
+  // Resolution is against the **tracked** tree, not the working directory: a
+  // gitignored local override (`.agentrc.local.json`, `.mcp.json`) that
+  // happens to exist on this machine must not make a doc reference look
+  // resolved for everyone else.
+  const resolves = (token) =>
+    PATH_PREFIXES.some((prefix) =>
+      trackedSet.has(path.posix.normalize(prefix + token)),
+    ) || trackedBasenames.has(path.posix.basename(token));
+
+  it('points at no module, script, or schema that is absent from the repo', () => {
+    const offenders = [];
+    const seen = new Set();
+    for (const { doc, line, token } of backtickedTokens()) {
+      // Skip glob/brace/placeholder forms and `@`-import directives.
+      if (/[*{}<>@]/.test(token)) continue;
+      if (!PATH_SUFFIX.test(token)) continue;
+      const clean = token.replace(/[.,;:)]+$/, '').replace(/:\d+$/, '');
+      if (Object.hasOwn(UNRESOLVED_BY_DESIGN, clean)) continue;
+      const key = `${doc}|${clean}`;
+      if (seen.has(key)) continue;
+      seen.add(key);
+      if (!resolves(clean)) offenders.push(`${doc}:${line} — \`${clean}\``);
+    }
+    assert.deepEqual(
+      offenders,
+      [],
+      `docs point at paths that do not resolve on disk:\n  ${offenders.join('\n  ')}`,
+    );
+  });
+
+  it('keeps UNRESOLVED_BY_DESIGN honest — every entry is genuinely absent', () => {
+    for (const [token, reason] of Object.entries(UNRESOLVED_BY_DESIGN)) {
+      assert.equal(
+        resolves(token),
+        false,
+        `\`${token}\` now resolves on disk (${reason}) — drop it from UNRESOLVED_BY_DESIGN`,
+      );
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. data-dictionary.md mirrors the live schemas
+// ---------------------------------------------------------------------------
+
+const dataDictionary = () => read('docs/data-dictionary.md');
+
+const signalEventSchema = () =>
+  JSON.parse(read('.agents/schemas/signal-event.schema.json'));
+
+const crapSchema = () =>
+  JSON.parse(read('.agents/schemas/baselines/crap.schema.json'));
+
+const baselineEnvelopeSchema = () =>
+  JSON.parse(read('.agents/schemas/baselines/baseline-envelope.schema.json'));
+
+describe('data-dictionary.md — SignalEvent row mirrors the live schema (Story #4785)', () => {
+  it('documents `source` as the framework|consumer string enum, not an object', () => {
+    const schema = signalEventSchema();
+    assert.equal(schema.properties.source.type, 'string');
+    assert.deepEqual(schema.properties.source.enum, ['framework', 'consumer']);
+
+    const md = dataDictionary();
+    const row = md.split('\n').find((l) => l.trim().startsWith('| `source`'));
+    assert.ok(row, 'no `source` row found in data-dictionary.md');
+    assert.match(
+      row,
+      /`string` enum/,
+      '`source` row must document a string enum',
+    );
+    assert.match(
+      row,
+      /`framework`/,
+      '`source` row must name the framework value',
+    );
+    assert.match(
+      row,
+      /`consumer`/,
+      '`source` row must name the consumer value',
+    );
+    assert.doesNotMatch(
+      row,
+      /`\{ tool: string/,
+      '`source` row still documents the deleted `{ tool }` provenance object',
+    );
+  });
+
+  it('documents `emitter` as the provenance object that replaced `source.tool`', () => {
+    const schema = signalEventSchema();
+    assert.equal(schema.properties.emitter.type, 'object');
+    assert.ok(Object.hasOwn(schema.properties.emitter.properties, 'tool'));
+
+    const md = dataDictionary();
+    const row = md.split('\n').find((l) => l.trim().startsWith('| `emitter`'));
+    assert.ok(row, 'data-dictionary.md omits the `emitter` field entirely');
+    assert.match(row, /`object`/);
+    assert.match(row, /tool/);
+  });
+
+  it('states the kind-enum count that the schema and EVENT_KINDS agree on', () => {
+    const schemaKinds = signalEventSchema().properties.kind.enum;
+    const constantKinds = Object.values(EVENT_KINDS);
+    assert.deepEqual(
+      [...schemaKinds].sort(),
+      [...constantKinds].sort(),
+      'signal-event.schema.json and EVENT_KINDS have drifted apart',
+    );
+    assert.equal(
+      schemaKinds.length,
+      13,
+      'kind enum size changed — update the doc',
+    );
+
+    const md = dataDictionary();
+    assert.match(
+      md,
+      /kind` enum holds \*\*thirteen\*\* values/,
+      'data-dictionary.md must state the live kind-enum count (thirteen)',
+    );
+    for (const kind of schemaKinds) {
+      assert.ok(
+        md.includes(`\`${kind}\``),
+        `data-dictionary.md never names the \`${kind}\` kind`,
+      );
+    }
+    assert.doesNotMatch(
+      md,
+      /taxonomy of seven record kinds/,
+      'data-dictionary.md still undercounts the kind taxonomy as seven',
+    );
+  });
+
+  it('marks Required exactly for the schema-required fields (ts, kind)', () => {
+    const required = signalEventSchema().required;
+    assert.deepEqual([...required].sort(), ['kind', 'ts']);
+
+    // Every SignalEvent row in the table, keyed by field name.
+    const md = dataDictionary();
+    const section = md.slice(
+      md.indexOf('## SignalEvent'),
+      md.indexOf('## StoryPerfSummary'),
+    );
+    // Cells may carry escaped pipes inside a type expression, which would
+    // shift every column index if split naively. The Required column never
+    // contains one, so neutralising them before the split is enough.
+    const rows = section
+      .split('\n')
+      .filter((l) => /^\|\s*`\w/.test(l.trim()))
+      .map((l) =>
+        l
+          .replace(/\\\|/g, '/')
+          .split('|')
+          .map((c) => c.trim()),
+      );
+
+    assert.ok(rows.length >= 8, 'SignalEvent table looks truncated');
+    for (const cells of rows) {
+      const field = cells[1].replace(/`/g, '');
+      const requiredCell = cells[3].replace(/\*/g, '');
+      const expected = required.includes(field) ? 'Yes' : 'No';
+      assert.equal(
+        requiredCell,
+        expected,
+        `SignalEvent row \`${field}\`: doc says Required=${requiredCell}, schema says ${expected}`,
+      );
+    }
+  });
+});
+
+describe('data-dictionary.md — crap.json row mirrors the live schema (Story #4785)', () => {
+  it('names the two stamps the floors gate compares against', () => {
+    assert.ok(Object.hasOwn(crapSchema().properties, 'scoringSemantics'));
+    assert.ok(Object.hasOwn(crapSchema().properties, 'rollup'));
+
+    const md = dataDictionary();
+    assert.match(
+      md,
+      /`scoringSemantics`/,
+      'crap.json row omits `scoringSemantics`',
+    );
+    assert.match(md, /`rollup`/, 'crap.json row omits `rollup`');
+  });
+
+  it('documents the rollup axes the floors are checked against', () => {
+    const axes = crapSchema().properties.rollup.properties['*'].required;
+    assert.deepEqual([...axes].sort(), ['max', 'methodsAbove20', 'p50', 'p95']);
+    const md = dataDictionary();
+    for (const axis of axes) {
+      assert.ok(
+        md.includes(axis),
+        `crap.json row never names the \`${axis}\` rollup axis`,
+      );
+    }
+  });
+
+  it('keys rows on `path` — the artefact has no `file` key', () => {
+    const rowProps = Object.keys(crapSchema().properties.rows.items.properties);
+    assert.deepEqual(rowProps.sort(), ['crap', 'method', 'path', 'startLine']);
+    assert.equal(
+      crapSchema().properties.rows.items.additionalProperties,
+      false,
+    );
+
+    const md = dataDictionary();
+    const row = md.split('\n').find((l) => l.includes('`baselines/crap.json`'));
+    assert.ok(row, 'no `baselines/crap.json` row found');
+    assert.match(row, /`\{ path, method, startLine, crap \}`/);
+    assert.doesNotMatch(
+      row,
+      /\{ file, method, startLine, crap \}/,
+      'crap.json row still keys rows on the non-existent `file` property',
+    );
+  });
+
+  it('does not claim an `escomplexVersion` key the envelope forbids', () => {
+    const envelope = baselineEnvelopeSchema();
+    assert.equal(envelope.additionalProperties, false);
+    assert.ok(!Object.hasOwn(envelope.properties, 'escomplexVersion'));
+    assert.ok(!Object.hasOwn(crapSchema().properties, 'escomplexVersion'));
+
+    const md = dataDictionary();
+    const row = md.split('\n').find((l) => l.includes('`baselines/crap.json`'));
+    assert.match(
+      row,
+      /no `escomplexVersion` key/,
+      'the crap.json row must say the envelope has no `escomplexVersion`',
+    );
+  });
+
+  it('puts coveragePath on the coverage gate, not the crap gate', () => {
+    // The live gate schemas are the authority: both are additionalProperties:
+    // false, so the key exists on exactly one of them.
+    assert.ok(!Object.hasOwn(CRAP_GATE.properties, 'coveragePath'));
+    assert.equal(CRAP_GATE.additionalProperties, false);
+    assert.ok(Object.hasOwn(COVERAGE_GATE.properties, 'coveragePath'));
+
+    const md = dataDictionary();
+    const crapConfigRow = md
+      .split('\n')
+      .find((l) => l.includes('`delivery.quality.gates.crap`'));
+    assert.ok(crapConfigRow, 'no `delivery.quality.gates.crap` row found');
+    assert.doesNotMatch(
+      crapConfigRow,
+      /coveragePath/,
+      'the gates.crap config row still lists the retired `coveragePath` key',
+    );
+    for (const key of Object.keys(CRAP_GATE.properties)) {
+      assert.ok(
+        crapConfigRow.includes(`${key}`),
+        `the gates.crap config row omits the live \`${key}\` key`,
+      );
+    }
+    assert.match(
+      md,
+      /gates\.coverage\.coveragePath/,
+      'data-dictionary.md must say coveragePath lives on the coverage gate',
+    );
+  });
+});

--- a/tests/contract/docs-reference-sync.test.js
+++ b/tests/contract/docs-reference-sync.test.js
@@ -519,3 +519,105 @@ describe('data-dictionary.md — crap.json row mirrors the live schema (Story #4
     );
   });
 });
+
+// ---------------------------------------------------------------------------
+// 4. ci-contract.md names the LIVE required-check contexts
+// ---------------------------------------------------------------------------
+
+describe('ci-contract.md — required-check contexts match the ruleset (Story #4785)', () => {
+  const liveContexts = () => {
+    const ruleset = JSON.parse(read('.github/ruleset.json'));
+    const rule = ruleset.rules.find((r) => r.type === 'required_status_checks');
+    return rule.parameters.required_status_checks.map((c) => c.context);
+  };
+
+  it('names every live context and no context the ruleset does not declare', () => {
+    const md = read('docs/ci-contract.md');
+    for (const context of liveContexts()) {
+      assert.ok(
+        md.includes(`\`${context}\``),
+        `ci-contract.md never names the live required check \`${context}\``,
+      );
+    }
+  });
+
+  it('does not present the .agentrc.json requiredChecks names as contexts', () => {
+    // The failure this guards is the one that motivated Story #4785: telling an
+    // operator to require `lint` / `test` produces contexts no workflow reports,
+    // and removing the ruleset to unstick it leaves `trust-ci` ungated.
+    const agentrc = JSON.parse(read('.agentrc.json'));
+    const localLabels = agentrc.github.branchProtection.requiredChecks.map(
+      (c) => c.name,
+    );
+    const contexts = new Set(liveContexts());
+    const notContexts = localLabels.filter((name) => !contexts.has(name));
+    assert.ok(
+      notContexts.length > 0,
+      'expected at least one requiredChecks label that is not a live context',
+    );
+
+    const md = read('docs/ci-contract.md');
+    assert.match(
+      md,
+      /`requiredChecks` names are NOT check contexts/,
+      'ci-contract.md must state outright that the .agentrc.json names are local labels',
+    );
+    for (const label of notContexts) {
+      assert.ok(
+        md.includes(`there is no \`${label}\` context`) ||
+          md.includes(`no \`${label}\` context`),
+        `ci-contract.md must say there is no \`${label}\` check context`,
+      );
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 5. The distribution surface is stated identically in all three doors
+// ---------------------------------------------------------------------------
+
+describe('distribution surface — one claim, three docs (Story #4785)', () => {
+  /** Directory entries of package.json `files`, minus the negated patterns. */
+  const shippedDirs = () =>
+    JSON.parse(read('package.json'))
+      .files.filter((f) => !f.startsWith('!'))
+      .filter((f) => f.endsWith('/'))
+      .map((f) => f.replace(/\/$/, ''));
+
+  it('publishes exactly .agents/, bin/, lib/ — the set the docs must agree on', () => {
+    assert.deepEqual(shippedDirs().sort(), ['.agents', 'bin', 'lib']);
+  });
+
+  it('is claimed identically by AGENTS.md, README.md, and onboarding.md', () => {
+    for (const doc of ['AGENTS.md', 'README.md', 'docs/onboarding.md']) {
+      const md = read(doc);
+      for (const dir of shippedDirs()) {
+        assert.ok(
+          md.includes(`\`${dir}/\``),
+          `${doc} never names the shipped directory \`${dir}/\``,
+        );
+      }
+      assert.doesNotMatch(
+        md,
+        /Only `\.agents\/` is distributed to consumers/,
+        `${doc} still claims only .agents/ ships, contradicting package.json files`,
+      );
+    }
+  });
+
+  it('lists bin/ and lib/ in both repository-layout trees', () => {
+    for (const doc of ['docs/architecture.md', 'docs/onboarding.md']) {
+      const md = read(doc);
+      // The layout tree is the fenced block that opens with the repo root.
+      const start = md.indexOf('\nmandrel/\n');
+      assert.ok(start > 0, `${doc} has no repository-layout tree`);
+      const tree = md.slice(start, md.indexOf('\n```', start));
+      for (const dir of ['bin/', 'lib/']) {
+        assert.ok(
+          tree.includes(`├── ${dir}`),
+          `${doc}'s repository-layout tree omits a top-level ${dir} entry`,
+        );
+      }
+    }
+  });
+});


### PR DESCRIPTION
Closes #4785

_Auto-opened by `/deliver`._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and contract tests only; no changes to orchestration scripts, CLI behavior, or published runtime code paths.
> 
> **Overview**
> **Docs now match what ships and what the code enforces.** Orientation files (`AGENTS.md`, `README.md`, `docs/onboarding.md`, `docs/architecture.md`) no longer say only `.agents/` is published—they describe the npm `files` surface (`.agents/`, `bin/`, `lib/`) and that only `.agents/` is materialized by `mandrel sync`. Large corrections in `docs/architecture.md` cover removed epic-runner pieces (`ErrorJournal`, `autoSerializeOverlaps`, token/preflight config), current lifecycle vs runtime invocation (both under `.agents/scripts/`), signals/retro/notifications, and fixed FinOps ceilings.
> 
> **Operator-facing contracts are spelled out.** `docs/ci-contract.md` ties `trust-ci` to the four **GitHub job display names** from `.github/ruleset.json` and warns that `.agentrc.json` `requiredChecks` labels are local commands, not status contexts. `docs/data-dictionary.md` updates **SignalEvent** (`source`/`emitter`, 13 kinds) and **CRAP baseline** shape (`path`, `scoringSemantics`, `coveragePath` on the coverage gate). `docs/onboarding.md` / `docs/release-operations.md` pick up the same distribution story and CI-only gates (e.g. test-temp hygiene).
> 
> **Regression guard:** new `tests/contract/docs-reference-sync.test.js` fails if in-scope docs quote unreachable `.agentrc` keys, broken backticked paths, or drift from live schemas/ruleset/distribution claims.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c0d4588560230ca2bbc7e0b5d65d0a1952a32934. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->