### PR TITLE
fix(deliver): keep the terminal envelope alive after the worktree reap (refs #4784)

### DIFF
--- a/.agents/scripts/lib/orchestration/single-story-close/failed-terminal.js
+++ b/.agents/scripts/lib/orchestration/single-story-close/failed-terminal.js
@@ -1,0 +1,122 @@
+/**
+ * single-story-close/failed-terminal.js — the `failed` terminal a close
+ * emits when a phase crashes, and the gate reconstruction it carries.
+ *
+ * Split out of `single-story-close.js` so the CLI entry stays an entry: it
+ * parses args, dispatches the runner, and maps a terminal onto an exit code.
+ * The reasoning about which gates had run by the time a phase died belongs
+ * with the envelope it feeds, not in the file that owns process lifetime.
+ *
+ * The runner deliberately throws rather than returning a failure (a red gate
+ * must not look like a return value), so without this the most common
+ * non-happy ending — a failing close-validation gate — would emit **no
+ * envelope at all**, exiting 1 with only a stderr line while the workflow
+ * docs promise the agent a `failed` envelope naming the phase.
+ */
+
+import { Logger } from '../../Logger.js';
+import {
+  buildTerminalEnvelope,
+  NEXT_COMMANDS,
+} from '../story-deliver-terminal.js';
+
+/**
+ * The close pipeline's phase order, as `setPhase` walks it. Only used to
+ * decide whether a gate had already run when a later phase died.
+ */
+const PHASE_ORDER = Object.freeze([
+  'init',
+  'wrong-tree-guard',
+  'close-validation',
+  'base-sync',
+  'push',
+  'pull-request',
+  'code-review',
+  'auto-merge',
+  'confirm-merge',
+  'post-land',
+  'done',
+]);
+
+/** Each reported gate and the pipeline phase that decides it. */
+const GATE_PHASES = Object.freeze([
+  ['validation', 'close-validation'],
+  ['baseSync', 'base-sync'],
+  ['codeReview', 'code-review'],
+]);
+
+/**
+ * Report every gate's outcome for a run that died at `phase`.
+ *
+ * The schema's contract: "A gate the run skipped … reports `skipped` rather
+ * than being omitted, so a missing gate is never mistaken for a passing one."
+ * The previous shape named only the gate that died and omitted the rest
+ * entirely — exactly the ambiguity the contract forbids.
+ *
+ * Reconstructed from the phase order, which is sound because the pipeline is
+ * strictly sequential: reaching phase N means every gate before it completed.
+ * A gate whose phase the run never reached is `skipped`; one the operator
+ * turned off via `--skip-validation` / `--skip-sync` is `skipped` too (it did
+ * not pass — it never ran).
+ *
+ * @param {string} phase The phase the run died in.
+ * @param {{ skipValidation?: boolean, skipSync?: boolean }} args Parsed CLI args.
+ * @returns {Record<string, 'passed'|'failed'|'skipped'>}
+ */
+export function gatesForFailedPhase(phase, args = {}) {
+  const skipped = { validation: args.skipValidation, baseSync: args.skipSync };
+  const failedAt = PHASE_ORDER.indexOf(phase);
+  const gates = {};
+  for (const [gate, gatePhase] of GATE_PHASES) {
+    const at = PHASE_ORDER.indexOf(gatePhase);
+    if (gatePhase === phase) gates[gate] = 'failed';
+    else if (failedAt < 0 || at > failedAt) gates[gate] = 'skipped';
+    else gates[gate] = skipped[gate] ? 'skipped' : 'passed';
+  }
+  return gates;
+}
+
+/**
+ * Build the `failed` terminal for a phase that crashed. Every close
+ * invocation emits exactly one envelope; this is the path that keeps that
+ * true when a phase dies.
+ *
+ * `err.closePhase` is tagged by the runner's phase tracker.
+ *
+ * **Never throws.** This runs on the path that already has one failure in
+ * hand, so a second failure here must not REPLACE the first: an
+ * envelope-build error surfacing as the run's cause sends the operator to
+ * diagnose the wrong thing entirely — a close whose PR had already merged
+ * once reported a schema `ENOENT` as its fatal error, because the worktree
+ * holding the script had been reaped mid-run. On failure this returns null
+ * and the caller rethrows the original.
+ *
+ * @param {unknown} err
+ * @param {{ storyId?: string|number, skipValidation?: boolean, skipSync?: boolean }} args
+ *   Parsed CLI args — the story id the envelope reports on, plus the skip
+ *   flags `gatesForFailedPhase` needs.
+ * @returns {object|null} A validated envelope, or null when even the story id
+ *   is unknown (a usage error — there is nothing to report an envelope about)
+ *   or the envelope itself could not be assembled.
+ */
+export function failedTerminalFor(err, args = {}) {
+  const phase = err?.closePhase ?? 'init';
+  const storyId = Number(args.storyId);
+  if (!Number.isInteger(storyId) || storyId <= 0) return null;
+  try {
+    return buildTerminalEnvelope({
+      storyId,
+      status: 'failed',
+      phase,
+      gates: gatesForFailedPhase(phase, args),
+      failure: { reason: String(err?.message ?? err) },
+      nextCommand: NEXT_COMMANDS.recover(storyId),
+      elapsedSeconds: 0,
+    });
+  } catch (buildErr) {
+    Logger.error(
+      `[single-story-close] ⚠️ Could not assemble the failed terminal envelope: ${buildErr?.message ?? buildErr}. Reporting the original failure instead.`,
+    );
+    return null;
+  }
+}

--- a/.agents/scripts/lib/orchestration/story-deliver-terminal-schema.js
+++ b/.agents/scripts/lib/orchestration/story-deliver-terminal-schema.js
@@ -1,0 +1,159 @@
+/**
+ * story-deliver-terminal-schema.js — load `story-deliver-terminal.schema.json`
+ * and validate envelopes against it.
+ *
+ * Split out of `story-deliver-terminal.js` so the envelope WRITER holds only
+ * the contract's shape and vocabulary, and this module holds the one thing
+ * the writer must never depend on at call time: the filesystem.
+ *
+ * That separation is the fix, not just tidiness. `single-story-close.js`
+ * invoked by a *worktree-relative* path runs the Story worktree's own copy of
+ * the script and then **reaps that worktree** as one of its phases. The schema
+ * used to be read lazily, on the first envelope build — which happens after
+ * the reap — so the read hit a path that no longer existed. The throw landed
+ * inside the close CLI's error path, so a Story whose PR had merged, whose
+ * label was `agent::done`, and whose post-land tail was green exited non-zero
+ * emitting NO envelope at all: the delivery engine's documented return
+ * contract lost to a success, recoverable only by a second close run from the
+ * main checkout.
+ *
+ * Two guarantees close that, and both live here:
+ *
+ *   1. The schema is read and parsed ONCE, at module load. The parsed schema
+ *      outlives the file, so what happens to the directory afterwards is
+ *      irrelevant. Compilation stays lazy — it needs no filesystem — so an
+ *      import costs one small read and nothing else.
+ *   2. An unreadable schema DEGRADES validation rather than throwing. A
+ *      schema violation still fails loudly; see {@link validateTerminalEnvelope}.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import Ajv2020 from 'ajv/dist/2020.js';
+import addFormats from 'ajv-formats';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+/** Absolute path to the shipped schema — the SSOT this module reads. */
+export const SCHEMA_PATH = path.resolve(
+  __dirname,
+  '..',
+  '..',
+  '..',
+  'schemas',
+  'story-deliver-terminal.schema.json',
+);
+
+/**
+ * Read and parse the shipped schema. Never throws: a read failure is recorded
+ * on the returned source and degrades validation downstream, because importing
+ * this module must never be what breaks a delivery.
+ *
+ * @returns {{ schema: object|null, error: string|null }}
+ */
+function loadSchemaSource() {
+  try {
+    return {
+      schema: JSON.parse(fs.readFileSync(SCHEMA_PATH, 'utf8')),
+      error: null,
+    };
+  } catch (err) {
+    return { schema: null, error: err?.message ?? String(err) };
+  }
+}
+
+/**
+ * The schema, read and parsed at module load. Deliberately eager — see the
+ * module header for the failure that made it so.
+ *
+ * @type {{ schema: object|null, error: string|null }}
+ */
+const SCHEMA_SOURCE = loadSchemaSource();
+
+/**
+ * Compiled validators keyed by the source object they came from.
+ *
+ * A `WeakMap` rather than one module-level slot so an injected `schemaSource`
+ * (the test seam) can never poison the validator the production path memoizes.
+ *
+ * @type {WeakMap<object, Function>}
+ */
+const VALIDATORS = new WeakMap();
+
+/**
+ * Compile (once per source) and return the terminal-envelope validator, or
+ * `null` when the source carries no usable schema.
+ *
+ * @param {{ schema: object|null }} source
+ * @returns {Function|null}
+ */
+function getValidator(source) {
+  if (!source?.schema) return null;
+  const cached = VALIDATORS.get(source);
+  if (cached) return cached;
+  const ajv = new Ajv2020({ allErrors: true, strict: false });
+  addFormats(ajv);
+  const validate = ajv.compile(source.schema);
+  VALIDATORS.set(source, validate);
+  return validate;
+}
+
+let _unvalidatedWarned = false;
+
+/**
+ * Announce — once per process — that an envelope is going out unvalidated.
+ *
+ * Written straight to stderr rather than through `Logger.warn` for the same
+ * reason `emitTerminalEnvelope` bypasses `Logger.info`: the envelope itself is
+ * unsuppressible, so the notice that one was not checked has to be too. Under
+ * `AGENT_LOG_LEVEL=silent` a level-gated warning would vanish and the degrade
+ * would be invisible.
+ *
+ * @param {string|null|undefined} error
+ * @returns {void}
+ */
+function warnUnvalidated(error) {
+  if (_unvalidatedWarned) return;
+  _unvalidatedWarned = true;
+  process.stderr.write(
+    `[story-deliver-terminal] ⚠️ terminal-envelope schema unavailable (${error ?? 'unknown'}) — ` +
+      `emitting the envelope UNVALIDATED. The return contract is preserved; its shape is not checked. ` +
+      `Expected at: ${SCHEMA_PATH}\n`,
+  );
+}
+
+/**
+ * Validate a candidate envelope against the shipped schema.
+ *
+ * When the schema is unavailable the result reports `validated: false` and
+ * `valid: true` — a **deliberate degrade**, not an oversight. Losing the shape
+ * check costs a guard against a malformed envelope; throwing here costs the
+ * envelope entirely, and the envelope is the documented return contract of the
+ * delivery engine. An unvalidated terminal a caller can act on beats no
+ * terminal at all, so the unreadable-schema case degrades and says so on
+ * stderr while a schema *violation* still fails loudly at the writer.
+ *
+ * @param {object} envelope
+ * @param {{ schemaSource?: { schema: object|null, error: string|null } }} [opts]
+ *   `schemaSource` is a test seam — production always uses the eagerly loaded
+ *   module-level source.
+ * @returns {{ valid: boolean, errors: string[], validated: boolean }}
+ */
+export function validateTerminalEnvelope(
+  envelope,
+  { schemaSource = SCHEMA_SOURCE } = {},
+) {
+  const validate = getValidator(schemaSource);
+  if (!validate) {
+    warnUnvalidated(schemaSource?.error);
+    return { valid: true, errors: [], validated: false };
+  }
+  const valid = validate(envelope);
+  if (valid) return { valid: true, errors: [], validated: true };
+  const errors = (validate.errors ?? []).map(
+    (e) => `${e.instancePath || '/'} ${e.message}`,
+  );
+  return { valid: false, errors, validated: true };
+}

--- a/.agents/scripts/lib/orchestration/story-deliver-terminal-schema.js
+++ b/.agents/scripts/lib/orchestration/story-deliver-terminal-schema.js
@@ -36,8 +36,15 @@ import addFormats from 'ajv-formats';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
-/** Absolute path to the shipped schema — the SSOT this module reads. */
-export const SCHEMA_PATH = path.resolve(
+/**
+ * Absolute path to the shipped schema — the SSOT this module reads.
+ *
+ * Module-private, like every other `SCHEMA_PATH` in the tree
+ * (`validation-evidence.js`, `signal-validator.js`): the path is an
+ * implementation detail of loading, and callers want the verdict, not the
+ * location.
+ */
+const SCHEMA_PATH = path.resolve(
   __dirname,
   '..',
   '..',

--- a/.agents/scripts/lib/orchestration/story-deliver-terminal.js
+++ b/.agents/scripts/lib/orchestration/story-deliver-terminal.js
@@ -234,10 +234,12 @@ export function buildTerminalEnvelope({
     timestamp,
   });
 
-  const { valid, errors } = validateTerminalEnvelope(
-    envelope,
-    schemaSource === undefined ? undefined : { schemaSource },
-  );
+  // Passing `{ schemaSource }` unconditionally is safe: an `undefined`
+  // property value is exactly what triggers the destructuring default on the
+  // other side, so production still gets the eagerly-loaded module source.
+  const { valid, errors } = validateTerminalEnvelope(envelope, {
+    schemaSource,
+  });
   if (!valid) {
     throw new TypeError(
       `buildTerminalEnvelope: assembled envelope violates story-deliver-terminal.schema.json:\n` +

--- a/.agents/scripts/lib/orchestration/story-deliver-terminal.js
+++ b/.agents/scripts/lib/orchestration/story-deliver-terminal.js
@@ -28,22 +28,12 @@
  * pre-#4543 pipeline collapsed by treating budget exhaustion as a block.
  */
 
-import { readFileSync } from 'node:fs';
-import path from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { validateTerminalEnvelope } from './story-deliver-terminal-schema.js';
 
-import Ajv2020 from 'ajv/dist/2020.js';
-import addFormats from 'ajv-formats';
-
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
-const SCHEMA_PATH = path.resolve(
-  __dirname,
-  '..',
-  '..',
-  '..',
-  'schemas',
-  'story-deliver-terminal.schema.json',
-);
+// Re-exported so the schema split stays an implementation detail: every
+// consumer still reaches the validator through the envelope module that owns
+// the contract.
+export { validateTerminalEnvelope };
 
 export const TERMINAL_ENVELOPE_KIND = 'story-deliver-terminal';
 
@@ -152,39 +142,6 @@ export const NEXT_COMMANDS = Object.freeze({
   escalateToPlan: (prompt) => `/plan "${quoteForPlan(prompt)}"`,
 });
 
-/** @type {Function|null} */
-let _validator = null;
-
-/**
- * Compile (once) and return the terminal-envelope validator.
- *
- * @returns {Function}
- */
-function getValidator() {
-  if (_validator) return _validator;
-  const schema = JSON.parse(readFileSync(SCHEMA_PATH, 'utf8'));
-  const ajv = new Ajv2020({ allErrors: true, strict: false });
-  addFormats(ajv);
-  _validator = ajv.compile(schema);
-  return _validator;
-}
-
-/**
- * Validate a candidate envelope against the shipped schema.
- *
- * @param {object} envelope
- * @returns {{ valid: boolean, errors: string[] }}
- */
-export function validateTerminalEnvelope(envelope) {
-  const validate = getValidator();
-  const valid = validate(envelope);
-  if (valid) return { valid: true, errors: [] };
-  const errors = (validate.errors ?? []).map(
-    (e) => `${e.instancePath || '/'} ${e.message}`,
-  );
-  return { valid: false, errors };
-}
-
 /**
  * Drop `undefined`-valued keys so the schema's `additionalProperties: false`
  * and its nullable unions both stay satisfiable from one optional-argument
@@ -207,8 +164,13 @@ function compact(obj) {
  * Throws a `TypeError` naming the schema violations when the assembled
  * object does not validate. That is deliberate: the whole point of the
  * envelope is that a caller can trust its status without re-probing
- * GitHub, so emitting an unvalidated one would reintroduce the ambiguity
+ * GitHub, so emitting a *malformed* one would reintroduce the ambiguity
  * this replaces.
+ *
+ * A schema that cannot be READ is the opposite case and does not throw —
+ * see {@link validateTerminalEnvelope}. "This envelope is wrong" is worth
+ * failing on; "I could not check this envelope" is not worth destroying
+ * the return contract over.
  *
  * @param {object} args
  * @param {number|null} args.storyId `null` only for an `escalated` terminal,
@@ -227,6 +189,9 @@ function compact(obj) {
  * @param {number} args.elapsedSeconds
  * @param {object|null} [args.waitBudget]
  * @param {string} [args.timestamp]
+ * @param {{ schema: object|null, error: string|null }} [args.schemaSource]
+ *   Test seam; never passed in production. Not part of the envelope — the
+ *   envelope is assembled from named fields only.
  * @returns {object} The validated envelope.
  */
 export function buildTerminalEnvelope({
@@ -245,6 +210,7 @@ export function buildTerminalEnvelope({
   elapsedSeconds = 0,
   waitBudget,
   timestamp = new Date().toISOString(),
+  schemaSource,
 }) {
   const envelope = compact({
     kind: TERMINAL_ENVELOPE_KIND,
@@ -268,7 +234,10 @@ export function buildTerminalEnvelope({
     timestamp,
   });
 
-  const { valid, errors } = validateTerminalEnvelope(envelope);
+  const { valid, errors } = validateTerminalEnvelope(
+    envelope,
+    schemaSource === undefined ? undefined : { schemaSource },
+  );
   if (!valid) {
     throw new TypeError(
       `buildTerminalEnvelope: assembled envelope violates story-deliver-terminal.schema.json:\n` +

--- a/.agents/scripts/lib/worktree/lifecycle/reap.js
+++ b/.agents/scripts/lib/worktree/lifecycle/reap.js
@@ -15,6 +15,7 @@
 
 import fs from 'node:fs';
 import { rm as fsPromisesRm } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
 import { isInsideWorktree, samePath } from '../inspector.js';
 import { sleepSync } from '../node-modules-strategy.js';
 import { checkMergeReachability } from './merge-reachability.js';
@@ -493,6 +494,52 @@ async function deleteBranchAfterReap(ctx, { branch, push }) {
   return { branchDeleted, remoteBranchDeleted };
 }
 
+/**
+ * The on-disk paths of the code currently executing: the entry script and
+ * this module itself.
+ *
+ * @returns {string[]}
+ */
+function runningCodePaths() {
+  const paths = [];
+  const entry = process.argv[1];
+  if (typeof entry === 'string' && entry !== '') paths.push(entry);
+  try {
+    paths.push(fileURLToPath(import.meta.url));
+  } catch {
+    // A non-file module URL cannot be inside a worktree; nothing to add.
+  }
+  return paths;
+}
+
+/**
+ * Return the running-code path that lives inside `wtPath`, or `null`.
+ *
+ * `escapeWorktreeCwd` already handles the *cwd* being inside the doomed
+ * tree; this is the other half — the **code** being inside it. An agent that
+ * invokes `node .agents/scripts/single-story-close.js` with its shell cwd set
+ * to the Story worktree runs the WORKTREE's copy of the script, and reaping
+ * the tree then deletes the running program out from under itself. Node has
+ * already loaded the static module graph, so the process does not die on the
+ * spot — it dies later, at the first lazy read or dynamic `import()`, in
+ * whatever phase happens to need one. That is how a close whose PR merged,
+ * whose Story flipped to `agent::done`, and whose post-land tail was green
+ * still exited non-zero with no terminal envelope.
+ *
+ * Refusing the reap is cheap: the tree survives one extra cycle and the next
+ * boot sweep takes it. Reaping it costs the run's return contract.
+ *
+ * @param {object} ctx
+ * @param {string} wtPath
+ * @returns {string|null}
+ */
+function findRunningCodeInside(ctx, wtPath) {
+  return (
+    runningCodePaths().find((p) => isInsideWorktree(p, wtPath, ctx.platform)) ??
+    null
+  );
+}
+
 function checkReapPreconditions(ctx, _storyId, opts, wtPath) {
   if (opts.force) {
     throw new Error(
@@ -507,6 +554,24 @@ function checkReapPreconditions(ctx, _storyId, opts, wtPath) {
       ok: false,
       result: { removed: false, reason: 'not-a-worktree', path: wtPath },
     };
+  const selfPath = findRunningCodeInside(ctx, wtPath);
+  if (selfPath) {
+    ctx.logger.warn(
+      `reap-skipped reason=running-from-target-tree path=${wtPath} selfPath=${selfPath} — ` +
+        `the running process was loaded from this worktree; removing it would break every ` +
+        `later lazy read and dynamic import in this run. Left for the next sweep. ` +
+        `Invoke the script by its MAIN-checkout path to reap in-run.`,
+    );
+    return {
+      ok: false,
+      result: {
+        removed: false,
+        reason: 'running-from-target-tree',
+        path: wtPath,
+        selfPath,
+      },
+    };
+  }
   // Story #4539 removed an `epic-branch-required` gate here: a
   // `story-<id>` worktree used to be unreapable unless the caller supplied
   // an Epic integration branch. v2 has no Epic branch, and the only v2

--- a/.agents/scripts/lib/worktree/lifecycle/reap.js
+++ b/.agents/scripts/lib/worktree/lifecycle/reap.js
@@ -540,38 +540,46 @@ function findRunningCodeInside(ctx, wtPath) {
   );
 }
 
+/**
+ * The refusals that disqualify a tree before any git work happens, in the
+ * order they are checked. Returns the refusal envelope, or `null` when the
+ * tree is eligible for the safety checks that follow.
+ *
+ * @param {object} ctx
+ * @param {object} opts
+ * @param {string} wtPath
+ * @returns {object|null}
+ */
+function firstReapRefusal(ctx, opts, wtPath) {
+  const known = opts.worktrees
+    ? opts.worktrees.some((r) => samePath(r.path, wtPath, ctx.platform))
+    : findByPath(ctx, wtPath) !== null;
+  if (!known) return { removed: false, reason: 'not-a-worktree', path: wtPath };
+
+  const selfPath = findRunningCodeInside(ctx, wtPath);
+  if (!selfPath) return null;
+  ctx.logger.warn(
+    `reap-skipped reason=running-from-target-tree path=${wtPath} selfPath=${selfPath} — ` +
+      `the running process was loaded from this worktree; removing it would break every ` +
+      `later lazy read and dynamic import in this run. Left for the next sweep. ` +
+      `Invoke the script by its MAIN-checkout path to reap in-run.`,
+  );
+  return {
+    removed: false,
+    reason: 'running-from-target-tree',
+    path: wtPath,
+    selfPath,
+  };
+}
+
 function checkReapPreconditions(ctx, _storyId, opts, wtPath) {
   if (opts.force) {
     throw new Error(
       'WorktreeManager.reap: --force is not permitted by the framework',
     );
   }
-  const known = opts.worktrees
-    ? opts.worktrees.some((r) => samePath(r.path, wtPath, ctx.platform))
-    : findByPath(ctx, wtPath) !== null;
-  if (!known)
-    return {
-      ok: false,
-      result: { removed: false, reason: 'not-a-worktree', path: wtPath },
-    };
-  const selfPath = findRunningCodeInside(ctx, wtPath);
-  if (selfPath) {
-    ctx.logger.warn(
-      `reap-skipped reason=running-from-target-tree path=${wtPath} selfPath=${selfPath} — ` +
-        `the running process was loaded from this worktree; removing it would break every ` +
-        `later lazy read and dynamic import in this run. Left for the next sweep. ` +
-        `Invoke the script by its MAIN-checkout path to reap in-run.`,
-    );
-    return {
-      ok: false,
-      result: {
-        removed: false,
-        reason: 'running-from-target-tree',
-        path: wtPath,
-        selfPath,
-      },
-    };
-  }
+  const refusal = firstReapRefusal(ctx, opts, wtPath);
+  if (refusal) return { ok: false, result: refusal };
   // Story #4539 removed an `epic-branch-required` gate here: a
   // `story-<id>` worktree used to be unreapable unless the caller supplied
   // an Epic integration branch. v2 has no Epic branch, and the only v2

--- a/.agents/scripts/single-story-close.js
+++ b/.agents/scripts/single-story-close.js
@@ -90,6 +90,10 @@ import { runAsCli } from './lib/cli-utils.js';
 import { formatCliError } from './lib/error-redactor.js';
 import { Logger } from './lib/Logger.js';
 import { emitTerminalFriction } from './lib/observability/runtime-friction.js';
+import {
+  failedTerminalFor,
+  gatesForFailedPhase,
+} from './lib/orchestration/single-story-close/failed-terminal.js';
 import { enableAutoMergeWith } from './lib/orchestration/single-story-close/phases/auto-merge.js';
 import {
   buildSyncFailureCommentBody,
@@ -102,10 +106,8 @@ import {
 } from './lib/orchestration/single-story-close/phases/code-review.js';
 import { ensurePullRequestWith } from './lib/orchestration/single-story-close/phases/pull-request.js';
 import {
-  buildTerminalEnvelope,
   emitTerminalEnvelope,
   exitCodeForTerminal,
-  NEXT_COMMANDS,
 } from './lib/orchestration/story-deliver-terminal.js';
 
 // Story #2990 moved the `gh`-spawn boundary into the `lib/gh-exec.js`
@@ -118,9 +120,13 @@ export const enableAutoMerge = enableAutoMergeWith;
 
 // Re-export pure helpers verbatim — they don't touch `execFileSync`
 // or any URL-mocked module, so the phase exports work unmodified.
+// `gatesForFailedPhase` now lives beside the envelope it feeds
+// (`single-story-close/failed-terminal.js`); it is re-exported here so the
+// CLI's public surface is unchanged by that move.
 export {
   buildStoryReviewCrossRefBody,
   buildSyncFailureCommentBody,
+  gatesForFailedPhase,
   handleSyncFailure,
   parsePrNumber,
   runStoryScopeReview,
@@ -135,95 +141,6 @@ export async function runSingleStoryClose(opts) {
 }
 
 /**
- * The close pipeline's phase order, as `setPhase` walks it. Only used to
- * decide whether a gate had already run when a later phase died.
- */
-const PHASE_ORDER = Object.freeze([
-  'init',
-  'wrong-tree-guard',
-  'close-validation',
-  'base-sync',
-  'push',
-  'pull-request',
-  'code-review',
-  'auto-merge',
-  'confirm-merge',
-  'post-land',
-  'done',
-]);
-
-/** Each reported gate and the pipeline phase that decides it. */
-const GATE_PHASES = Object.freeze([
-  ['validation', 'close-validation'],
-  ['baseSync', 'base-sync'],
-  ['codeReview', 'code-review'],
-]);
-
-/**
- * Report every gate's outcome for a run that died at `phase`.
- *
- * The schema's contract: "A gate the run skipped … reports `skipped` rather
- * than being omitted, so a missing gate is never mistaken for a passing one."
- * The previous shape named only the gate that died and omitted the rest
- * entirely — exactly the ambiguity the contract forbids.
- *
- * Reconstructed from the phase order, which is sound because the pipeline is
- * strictly sequential: reaching phase N means every gate before it completed.
- * A gate whose phase the run never reached is `skipped`; one the operator
- * turned off via `--skip-validation` / `--skip-sync` is `skipped` too (it did
- * not pass — it never ran).
- *
- * @param {string} phase The phase the run died in.
- * @param {{ skipValidation?: boolean, skipSync?: boolean }} args Parsed CLI args.
- * @returns {Record<string, 'passed'|'failed'|'skipped'>}
- */
-export function gatesForFailedPhase(phase, args = {}) {
-  const skipped = { validation: args.skipValidation, baseSync: args.skipSync };
-  const failedAt = PHASE_ORDER.indexOf(phase);
-  const gates = {};
-  for (const [gate, gatePhase] of GATE_PHASES) {
-    const at = PHASE_ORDER.indexOf(gatePhase);
-    if (gatePhase === phase) gates[gate] = 'failed';
-    else if (failedAt < 0 || at > failedAt) gates[gate] = 'skipped';
-    else gates[gate] = skipped[gate] ? 'skipped' : 'passed';
-  }
-  return gates;
-}
-
-/**
- * Build the `failed` terminal for a phase that crashed.
- *
- * The runner deliberately throws rather than returning a failure (a red gate
- * must not look like a return value), so without this the most common
- * non-happy ending — a failing close-validation gate — would emit **no
- * envelope at all**, exiting 1 with only a stderr line while the workflow
- * docs promise the agent a `failed` envelope naming the phase. Every close
- * invocation emits exactly one envelope; this is the path that keeps that
- * true when a phase dies.
- *
- * `err.closePhase` is tagged by the runner's phase tracker.
- *
- * @param {unknown} err
- * @returns {object|null} A validated envelope, or null when even the story id
- *   is unknown (a usage error — there is nothing to report an envelope about).
- */
-function failedTerminalFor(err) {
-  const phase = err?.closePhase ?? 'init';
-  const args = parseSprintArgs();
-  const storyId = Number(args.storyId);
-  if (!Number.isInteger(storyId) || storyId <= 0) return null;
-  return buildTerminalEnvelope({
-    storyId,
-    status: 'failed',
-    phase,
-    gates: gatesForFailedPhase(phase, args),
-    failure: { reason: String(err?.message ?? err) },
-    nextCommand: NEXT_COMMANDS.recover(storyId),
-    elapsedSeconds: 0,
-  });
-}
-
-/**
  * CLI entry — resolves the process exit code from the terminal envelope's
  * status rather than from a thrown/not-thrown distinction, so `pending`
  * (resumable) is distinguishable from `blocked` (come look) without parsing
@@ -234,7 +151,7 @@ async function main() {
     const outcome = await runSingleStoryClose();
     return exitCodeForTerminal(outcome?.terminal ?? { status: 'failed' });
   } catch (err) {
-    const terminal = failedTerminalFor(err);
+    const terminal = failedTerminalFor(err, parseSprintArgs());
     if (!terminal) throw err;
     // Mirror runAsCli's default error line (which this catch pre-empts) so the
     // human-facing failure text is unchanged, then emit the envelope.

--- a/baselines/crap.json
+++ b/baselines/crap.json
@@ -1,12 +1,12 @@
 {
   "$schema": ".agents/schemas/baselines/crap.schema.json",
   "kernelVersion": "0.1.0",
-  "generatedAt": "2026-07-26T02:47:13.697Z",
+  "generatedAt": "2026-07-26T14:13:00.471Z",
   "scoringSemantics": "coverage-join-v2",
   "rollup": {
     "*": {
       "p50": 2,
-      "p95": 11.036579789666211,
+      "p95": 11.020747599451303,
       "max": 123.75293999270504,
       "methodsAbove20": 40
     }
@@ -15571,6 +15571,18 @@
       "crap": 7.033660696112355
     },
     {
+      "path": ".agents/scripts/lib/orchestration/single-story-close/failed-terminal.js",
+      "method": "gatesForFailedPhase",
+      "startLine": 66,
+      "crap": 5
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/single-story-close/failed-terminal.js",
+      "method": "failedTerminalFor",
+      "startLine": 102,
+      "crap": 10.774538386783284
+    },
+    {
       "path": ".agents/scripts/lib/orchestration/single-story-close/gate-log.js",
       "method": "logNameFor",
       "startLine": 73,
@@ -16591,123 +16603,135 @@
       "crap": 1.0233236151603498
     },
     {
+      "path": ".agents/scripts/lib/orchestration/story-deliver-terminal-schema.js",
+      "method": "loadSchemaSource",
+      "startLine": 56,
+      "crap": 1.008
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/story-deliver-terminal-schema.js",
+      "method": "getValidator",
+      "startLine": 92,
+      "crap": 3
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/story-deliver-terminal-schema.js",
+      "method": "warnUnvalidated",
+      "startLine": 117,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/story-deliver-terminal-schema.js",
+      "method": "validateTerminalEnvelope",
+      "startLine": 144,
+      "crap": 3
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/story-deliver-terminal-schema.js",
+      "method": "<anon method-1>",
+      "startLine": 156,
+      "crap": 2
+    },
+    {
       "path": ".agents/scripts/lib/orchestration/story-deliver-terminal.js",
       "method": "quoteForPlan",
-      "startLine": 97,
+      "startLine": 87,
       "crap": 3
     },
     {
       "path": ".agents/scripts/lib/orchestration/story-deliver-terminal.js",
       "method": "<anon method-1>",
-      "startLine": 121,
+      "startLine": 111,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/orchestration/story-deliver-terminal.js",
       "method": "<anon method-2>",
-      "startLine": 124,
+      "startLine": 114,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/orchestration/story-deliver-terminal.js",
       "method": "<anon method-3>",
-      "startLine": 127,
+      "startLine": 117,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/orchestration/story-deliver-terminal.js",
       "method": "<anon method-4>",
-      "startLine": 130,
+      "startLine": 120,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/orchestration/story-deliver-terminal.js",
       "method": "<anon method-5>",
-      "startLine": 133,
+      "startLine": 123,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/orchestration/story-deliver-terminal.js",
       "method": "<anon method-6>",
-      "startLine": 136,
+      "startLine": 126,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/orchestration/story-deliver-terminal.js",
       "method": "<anon method-7>",
-      "startLine": 139,
+      "startLine": 129,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/orchestration/story-deliver-terminal.js",
       "method": "<anon method-8>",
-      "startLine": 152,
+      "startLine": 142,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/orchestration/story-deliver-terminal.js",
-      "method": "getValidator",
-      "startLine": 163,
-      "crap": 2
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/story-deliver-terminal.js",
-      "method": "validateTerminalEnvelope",
-      "startLine": 178,
-      "crap": 2
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/story-deliver-terminal.js",
-      "method": "<anon method-9>",
-      "startLine": 183,
-      "crap": 2
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/story-deliver-terminal.js",
       "method": "compact",
-      "startLine": 196,
+      "startLine": 153,
       "crap": 2
     },
     {
       "path": ".agents/scripts/lib/orchestration/story-deliver-terminal.js",
       "method": "buildTerminalEnvelope",
-      "startLine": 232,
+      "startLine": 197,
       "crap": 5
     },
     {
       "path": ".agents/scripts/lib/orchestration/story-deliver-terminal.js",
-      "method": "<anon method-10>",
-      "startLine": 275,
+      "method": "<anon method-9>",
+      "startLine": 246,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/orchestration/story-deliver-terminal.js",
       "method": "buildEscalationTerminal",
-      "startLine": 308,
+      "startLine": 279,
       "crap": 5
     },
     {
       "path": ".agents/scripts/lib/orchestration/story-deliver-terminal.js",
-      "method": "<anon method-11>",
-      "startLine": 323,
+      "method": "<anon method-10>",
+      "startLine": 294,
       "crap": 2
     },
     {
       "path": ".agents/scripts/lib/orchestration/story-deliver-terminal.js",
       "method": "exitCodeForTerminal",
-      "startLine": 350,
+      "startLine": 321,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/orchestration/story-deliver-terminal.js",
       "method": "emitTerminalEnvelope",
-      "startLine": 378,
+      "startLine": 349,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/orchestration/story-deliver-terminal.js",
       "method": "terminalFromWaitOutcome",
-      "startLine": 398,
+      "startLine": 369,
       "crap": 5
     },
     {
@@ -21135,175 +21159,199 @@
     {
       "path": ".agents/scripts/lib/worktree/lifecycle/reap.js",
       "method": "isSafeToRemove",
-      "startLine": 63,
+      "startLine": 64,
       "crap": 4
     },
     {
       "path": ".agents/scripts/lib/worktree/lifecycle/reap.js",
       "method": "isBranchMergedIntoBase",
-      "startLine": 108,
+      "startLine": 109,
       "crap": 5.084375
     },
     {
       "path": ".agents/scripts/lib/worktree/lifecycle/reap.js",
       "method": "<anon method-1>",
-      "startLine": 123,
+      "startLine": 124,
       "crap": 1.003375
     },
     {
       "path": ".agents/scripts/lib/worktree/lifecycle/reap.js",
       "method": "<anon method-2>",
-      "startLine": 126,
+      "startLine": 127,
       "crap": 1.003375
     },
     {
       "path": ".agents/scripts/lib/worktree/lifecycle/reap.js",
       "method": "collectDirtyPaths",
-      "startLine": 133,
+      "startLine": 134,
       "crap": 2
     },
     {
       "path": ".agents/scripts/lib/worktree/lifecycle/reap.js",
       "method": "<anon method-3>",
-      "startLine": 138,
+      "startLine": 139,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/worktree/lifecycle/reap.js",
       "method": "<anon method-4>",
-      "startLine": 140,
+      "startLine": 141,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/worktree/lifecycle/reap.js",
       "method": "discardWorktreeChanges",
-      "startLine": 147,
+      "startLine": 148,
       "crap": 2
     },
     {
       "path": ".agents/scripts/lib/worktree/lifecycle/reap.js",
       "method": "fsRmWithRetry",
-      "startLine": 160,
+      "startLine": 161,
       "crap": 4.018661612479954
     },
     {
       "path": ".agents/scripts/lib/worktree/lifecycle/reap.js",
       "method": "<anon method-5>",
-      "startLine": 173,
+      "startLine": 174,
       "crap": 2
     },
     {
       "path": ".agents/scripts/lib/worktree/lifecycle/reap.js",
       "method": "classifyRemoveStderr",
-      "startLine": 180,
+      "startLine": 181,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/worktree/lifecycle/reap.js",
       "method": "finalizeGitWorktreeRemove",
-      "startLine": 187,
+      "startLine": 188,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/worktree/lifecycle/reap.js",
       "method": "handleRemoveFailure",
-      "startLine": 192,
+      "startLine": 193,
       "crap": 5
     },
     {
       "path": ".agents/scripts/lib/worktree/lifecycle/reap.js",
       "method": "runGitWorktreeRemoveLoop",
-      "startLine": 213,
+      "startLine": 214,
       "crap": 8
     },
     {
       "path": ".agents/scripts/lib/worktree/lifecycle/reap.js",
       "method": "tryForceRemoveFallback",
-      "startLine": 238,
+      "startLine": 239,
       "crap": 7.006125
     },
     {
       "path": ".agents/scripts/lib/worktree/lifecycle/reap.js",
       "method": "tryStage15WindowsFsRm",
-      "startLine": 279,
+      "startLine": 280,
       "crap": 1.0314914710599212
     },
     {
       "path": ".agents/scripts/lib/worktree/lifecycle/reap.js",
       "method": "recordPendingCleanupSafe",
-      "startLine": 318,
+      "startLine": 319,
       "crap": 3.274658203125
     },
     {
       "path": ".agents/scripts/lib/worktree/lifecycle/reap.js",
       "method": "handleFsRmFailure",
-      "startLine": 335,
+      "startLine": 336,
       "crap": 5
     },
     {
       "path": ".agents/scripts/lib/worktree/lifecycle/reap.js",
       "method": "removeWorktreeWithRecovery",
-      "startLine": 387,
+      "startLine": 388,
       "crap": 8
     },
     {
       "path": ".agents/scripts/lib/worktree/lifecycle/reap.js",
       "method": "reapDeleteLocal",
-      "startLine": 458,
+      "startLine": 459,
       "crap": 6.036
     },
     {
       "path": ".agents/scripts/lib/worktree/lifecycle/reap.js",
       "method": "reapDeleteRemote",
-      "startLine": 469,
+      "startLine": 470,
       "crap": 6.141711619769646
     },
     {
       "path": ".agents/scripts/lib/worktree/lifecycle/reap.js",
       "method": "deleteBranchAfterReap",
-      "startLine": 489,
+      "startLine": 490,
       "crap": 3
     },
     {
       "path": ".agents/scripts/lib/worktree/lifecycle/reap.js",
-      "method": "checkReapPreconditions",
-      "startLine": 496,
-      "crap": 4
+      "method": "runningCodePaths",
+      "startLine": 503,
+      "crap": 3.0540946656649135
     },
     {
       "path": ".agents/scripts/lib/worktree/lifecycle/reap.js",
-      "method": "<anon method-6>",
-      "startLine": 503,
+      "method": "findRunningCodeInside",
+      "startLine": 536,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/worktree/lifecycle/reap.js",
+      "method": "<anon method-6>",
+      "startLine": 538,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/worktree/lifecycle/reap.js",
+      "method": "firstReapRefusal",
+      "startLine": 553,
+      "crap": 4
+    },
+    {
+      "path": ".agents/scripts/lib/worktree/lifecycle/reap.js",
+      "method": "<anon method-7>",
+      "startLine": 555,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/worktree/lifecycle/reap.js",
+      "method": "checkReapPreconditions",
+      "startLine": 575,
+      "crap": 3
+    },
+    {
+      "path": ".agents/scripts/lib/worktree/lifecycle/reap.js",
       "method": "ensureSafeOrForceDiscard",
-      "startLine": 525,
+      "startLine": 598,
       "crap": 7.973424840856482
     },
     {
       "path": ".agents/scripts/lib/worktree/lifecycle/reap.js",
       "method": "escapeWorktreeCwd",
-      "startLine": 574,
+      "startLine": 647,
       "crap": 3.372
     },
     {
       "path": ".agents/scripts/lib/worktree/lifecycle/reap.js",
       "method": "postRemoveBeltSweep",
-      "startLine": 585,
+      "startLine": 658,
       "crap": 3.2099125364431487
     },
     {
       "path": ".agents/scripts/lib/worktree/lifecycle/reap.js",
       "method": "buildReapSuccess",
-      "startLine": 600,
+      "startLine": 673,
       "crap": 5
     },
     {
       "path": ".agents/scripts/lib/worktree/lifecycle/reap.js",
       "method": "reap",
-      "startLine": 612,
+      "startLine": 685,
       "crap": 8.442284850448116
     },
     {
@@ -22887,25 +22935,13 @@
     {
       "path": ".agents/scripts/single-story-close.js",
       "method": "runSingleStoryClose",
-      "startLine": 129,
+      "startLine": 135,
       "crap": 1
     },
     {
       "path": ".agents/scripts/single-story-close.js",
-      "method": "gatesForFailedPhase",
-      "startLine": 180,
-      "crap": 5
-    },
-    {
-      "path": ".agents/scripts/single-story-close.js",
-      "method": "failedTerminalFor",
-      "startLine": 210,
-      "crap": 12
-    },
-    {
-      "path": ".agents/scripts/single-story-close.js",
       "method": "main",
-      "startLine": 232,
+      "startLine": 149,
       "crap": 6
     },
     {

--- a/tests/contract/story-deliver-terminal.test.js
+++ b/tests/contract/story-deliver-terminal.test.js
@@ -26,9 +26,9 @@
  */
 
 import assert from 'node:assert/strict';
-import { readFileSync } from 'node:fs';
+import fs from 'node:fs';
 import path from 'node:path';
-import { describe, it } from 'node:test';
+import { describe, it, mock } from 'node:test';
 import { fileURLToPath } from 'node:url';
 import { setLevel } from '../../.agents/scripts/lib/Logger.js';
 import { MERGE_UNLANDED_BLOCK_CLASSES } from '../../.agents/scripts/lib/orchestration/merge-block-class.js';
@@ -48,7 +48,7 @@ import {
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const SCHEMA = JSON.parse(
-  readFileSync(
+  fs.readFileSync(
     path.resolve(
       __dirname,
       '..',
@@ -460,6 +460,150 @@ describe('story-deliver-terminal — validation surface', () => {
       surpriseField: true,
     });
     assert.equal(valid, false);
+  });
+});
+
+describe('story-deliver-terminal — the schema outlives the schema FILE', () => {
+  // The regression: `single-story-close.js` invoked by a worktree-relative
+  // path runs the WORKTREE's copy of the script and then reaps that worktree
+  // as one of its own phases. The schema used to be read lazily, on the first
+  // envelope build — which happens AFTER the reap — so the read hit a path
+  // that no longer existed. It threw inside `failedTerminalFor`, meaning a
+  // Story whose PR had merged, whose label had flipped to `agent::done`, and
+  // whose post-land tail was green exited non-zero emitting NO envelope at
+  // all. The engine's documented return contract was lost to a success.
+  //
+  // Two independent guarantees close it, and this block pins both: the read
+  // happens at import (so the file's later disappearance is irrelevant), and
+  // an unusable schema degrades to an unvalidated envelope rather than to no
+  // envelope.
+
+  const LANDED = {
+    storyId: 4784,
+    status: 'landed',
+    phase: 'done',
+    storyBranch: 'story-4784',
+    baseBranch: 'main',
+    pr: {
+      number: 4788,
+      url: 'https://example.test/pull/4788',
+      state: 'MERGED',
+    },
+    tail: CLEAN_TAIL,
+    nextCommand: null,
+    elapsedSeconds: 12,
+  };
+
+  /** Break every filesystem read, the way a reaped worktree does. */
+  function withNoFilesystem(fn) {
+    mock.method(fs, 'readFileSync', () => {
+      throw new Error('ENOENT: no such file or directory (reaped worktree)');
+    });
+    try {
+      assert.throws(
+        () => fs.readFileSync('/anything'),
+        /ENOENT/,
+        'the filesystem stub must actually be in force',
+      );
+      return fn();
+    } finally {
+      mock.restoreAll();
+    }
+  }
+
+  it('validates with the filesystem gone — the schema is read at IMPORT', async () => {
+    // A FRESH instance of the module that OWNS the read, deliberately. The
+    // cached one compiled its validator during an earlier test, so it would
+    // survive a lost filesystem no matter when it read the schema — which is
+    // exactly how a lazy read hides from a suite until production reaps a
+    // worktree. Import fresh while the filesystem is healthy, break the
+    // filesystem, then validate: only an import-time read survives that
+    // sequence.
+    const fresh = await import(
+      `${
+        new URL(
+          '../../.agents/scripts/lib/orchestration/story-deliver-terminal-schema.js',
+          import.meta.url,
+        ).href
+      }?eager-schema-probe`
+    );
+    const envelope = buildTerminalEnvelope(LANDED);
+
+    withNoFilesystem(() => {
+      const result = fresh.validateTerminalEnvelope(envelope);
+      // `validated: true`, not merely `valid` — the degrade path did NOT
+      // fire, which is what proves the schema was already in memory.
+      assert.equal(
+        result.validated,
+        true,
+        'the eagerly-loaded schema is what validated this envelope',
+      );
+      assert.equal(result.valid, true);
+    });
+  });
+
+  it('builds an envelope after the filesystem stops answering', () => {
+    // The writer-level composition of the same guarantee: assembling a
+    // terminal must touch no file at all, whatever state the tree is in.
+    withNoFilesystem(() => {
+      const envelope = buildTerminalEnvelope(LANDED);
+      assert.equal(envelope.status, 'landed');
+      assert.equal(envelope.storyId, 4784);
+    });
+  });
+
+  it('degrades to an UNVALIDATED envelope when the schema cannot be read', () => {
+    // Belt to the eager-load brace: if the schema is ever unavailable anyway
+    // — a partial install, a truncated file — the run must still get its
+    // terminal. An envelope a caller can act on beats a lost contract.
+    const unreadable = {
+      schema: null,
+      error: 'ENOENT: no such file or directory',
+    };
+    const envelope = buildTerminalEnvelope({
+      ...LANDED,
+      schemaSource: unreadable,
+    });
+    assert.equal(envelope.status, 'landed');
+    assert.equal(envelope.nextCommand, null);
+
+    const degraded = validateTerminalEnvelope(envelope, {
+      schemaSource: unreadable,
+    });
+    assert.equal(
+      degraded.validated,
+      false,
+      'the degrade is reported, not hidden',
+    );
+    assert.equal(degraded.valid, true);
+
+    // And the envelope it emitted unchecked is in fact well-formed — the
+    // degrade skips the check, it does not lower the shape.
+    const rechecked = validateTerminalEnvelope(envelope);
+    assert.equal(rechecked.validated, true);
+    assert.deepEqual(rechecked.errors, []);
+    assert.equal(rechecked.valid, true);
+  });
+
+  it('still throws on a genuine schema VIOLATION — the degrade is scoped to an unreadable schema', () => {
+    // The distinction that has to hold: "I cannot check this envelope" is
+    // survivable; "this envelope is wrong" is not. Collapsing the two would
+    // trade one silent failure for another.
+    assert.throws(
+      () =>
+        buildTerminalEnvelope({
+          ...LANDED,
+          status: 'landed',
+          storyId: null,
+        }),
+      /violates story-deliver-terminal\.schema\.json/,
+    );
+  });
+
+  it('reports validated: true on the normal path', () => {
+    const result = validateTerminalEnvelope(buildTerminalEnvelope(LANDED));
+    assert.equal(result.validated, true);
+    assert.equal(result.valid, true);
   });
 });
 

--- a/tests/single-story-close-worktree-reap.test.js
+++ b/tests/single-story-close-worktree-reap.test.js
@@ -168,6 +168,89 @@ describe('reapWorktreePhase — the close-path call shape (Story #4539)', () => 
     });
   });
 
+  it('refuses to delete the tree the running script was loaded from', async () => {
+    // The #4784 failure. `node .agents/scripts/single-story-close.js` invoked
+    // with the shell cwd inside the Story worktree resolves to the
+    // WORKTREE's copy of the script — so the reap deleted the running
+    // program. Node had already loaded the static module graph, so nothing
+    // died at the reap; the run died later, at the first lazy read, in the
+    // terminal-envelope writer. Result: a Story whose PR had merged, whose
+    // label was `agent::done`, and whose post-land tail was green exited
+    // non-zero with no envelope, recoverable only by a second close run from
+    // the main checkout.
+    //
+    // The tree surviving one extra cycle costs nothing — the next boot sweep
+    // takes it. Reaping it costs the run's return contract.
+    await withWorktree(async ({ tmp, wtPath }) => {
+      const messages = [];
+      const git = makeGit({ wtPath });
+      const realArgv1 = process.argv[1];
+      process.argv[1] = path.join(
+        wtPath,
+        '.agents',
+        'scripts',
+        'single-story-close.js',
+      );
+      try {
+        const reaped = await reapWorktreePhase({
+          cwd: tmp,
+          storyId: 4539,
+          worktreePath: wtPath,
+          wtIsolation: {},
+          progress: (_tag, msg) => messages.push(msg),
+          WorktreeManager: class extends WorktreeManager {
+            constructor(args) {
+              super({ ...args, git, platform: 'linux' });
+            }
+          },
+        });
+        assert.equal(reaped, false, 'the reap is refused, not performed');
+        assert.equal(
+          git.calls.some((c) => c.startsWith('worktree remove')),
+          false,
+          'no removal may run against the tree holding the running script',
+        );
+        assert.ok(
+          messages.some((m) => /running-from-target-tree/.test(m)),
+          `the refusal names its reason; got: ${JSON.stringify(messages)}`,
+        );
+        assert.ok(
+          messages.some((m) => /not reaped/.test(m)),
+          'the phase reports the refusal rather than claiming a reap',
+        );
+      } finally {
+        process.argv[1] = realArgv1;
+      }
+    });
+  });
+
+  it('reaps normally when the running script lives outside the tree', async () => {
+    // The guard must be scoped to the actual hazard: a close driven from the
+    // main checkout — the normal case — still reaps.
+    await withWorktree(async ({ tmp, wtPath }) => {
+      const git = makeGit({ wtPath });
+      const realArgv1 = process.argv[1];
+      process.argv[1] = path.join(tmp, 'main-checkout', 'close.js');
+      try {
+        const reaped = await reapWorktreePhase({
+          cwd: tmp,
+          storyId: 4539,
+          worktreePath: wtPath,
+          wtIsolation: {},
+          progress: NOOP_PROGRESS,
+          WorktreeManager: class extends WorktreeManager {
+            constructor(args) {
+              super({ ...args, git, platform: 'linux' });
+            }
+          },
+        });
+        assert.equal(reaped, true);
+      } finally {
+        process.argv[1] = realArgv1;
+      }
+    });
+  });
+
   it('honours reapOnSuccess:false without touching git', async () => {
     await withWorktree(async ({ tmp, wtPath }) => {
       const git = makeGit({ wtPath });


### PR DESCRIPTION
## Why

Reported as a framework robustness gap during the delivery of #4784.

`single-story-close.js` invoked by a **worktree-relative** path runs the Story worktree's own copy of the script, and then reaps that worktree as one of its phases. The terminal-envelope schema was read *lazily*, on the first envelope build — which happens after the reap — so the read hit a path that no longer existed:

```
[single-story-close] Fatal error: Error: ENOENT: no such file or directory,
  open '.../.worktrees/story-4784/.agents/schemas/story-deliver-terminal.schema.json'
    at getValidator (lib/orchestration/story-deliver-terminal.js:165:29)
    at failedTerminalFor (single-story-close.js:215:10)
```

The `failedTerminalFor` frame is the *second* victim, not the first: the runner's own `landed` envelope build hit the same `ENOENT`, `main` caught it, and the catch path then threw the identical error while trying to report it. So a Story whose PR had merged, whose label was `agent::done`, and whose post-land tail was green exited non-zero emitting **no envelope at all**. The envelope is the documented return contract of the delivery engine (`helpers/deliver-digest.md` § 5), so a success became an unreportable failure — recoverable only by a second close run from the main checkout.

## What changed

Three layers, matching the three fixes suggested in the report:

**1. The schema is read at import, not at first build.** New `story-deliver-terminal-schema.js` holds the one filesystem dependency; the envelope writer keeps the contract's shape. Compilation stays lazy (it needs no filesystem), so the parsed schema outlives the file and the reap becomes irrelevant. Compiled validators move from a single module slot to a `WeakMap` keyed by source, so the test seam can't poison the production validator.

**2. `validateTerminalEnvelope` degrades on an unreadable schema** — `validated: false` plus an unsuppressible stderr notice — instead of throwing. Written straight to stderr rather than `Logger.warn` for the same reason `emitTerminalEnvelope` bypasses `Logger.info`: a level-gated warning would vanish under `AGENT_LOG_LEVEL=silent`. A schema **violation** still throws. "This envelope is wrong" is worth failing on; "I could not check this envelope" is not worth destroying the return contract over.

**3. `reap` refuses a worktree containing the running code**, reporting `running-from-target-tree`. `escapeWorktreeCwd` already handled the *cwd* being inside the doomed tree; this is the other half — the *code* being inside it. It protects the whole class (every later lazy read and dynamic `import()`), not just the schema. Refuse-the-reap over refuse-the-run: the reported run was correct end to end, and a tree surviving one extra boot sweep costs nothing. `worktree-reap.js` already surfaces refusal reasons correctly.

Also: `failedTerminalFor` no longer masks the original failure — a build error there returns `null` so the real cause propagates instead of a schema `ENOENT`. It moves to `single-story-close/failed-terminal.js` with `gatesForFailedPhase`, beside the envelope they feed; both stay re-exported from the CLI so its public surface is unchanged.

## Regression coverage

`tests/contract/story-deliver-terminal.test.js` — the load-bearing test imports a **fresh** instance of the module that owns the read, with the filesystem healthy, then breaks every `readFileSync`, then validates. Only an import-time read survives that sequence. I verified it fails against simulated lazy-read behaviour and passes with the fix; the statically-imported instance would have survived either way, which is exactly how a lazy read hides from a suite until production reaps a worktree. Plus the unreadable-schema degrade, the still-throws-on-violation boundary, and the writer-level composition.

`tests/single-story-close-worktree-reap.test.js` — the refusal driven through the phase with `process.argv[1]` inside the fixture worktree, and its complement (main-checkout invocation still reaps).

## Verification

`npm run lint` → 0 · `check-baselines` → 0 · `quality-preview --changed-since origin/main` → 0 MI regressions, 0 CRAP violations · full suite 8801 tests, 0 failures.

The second commit is the follow-up the pre-push gate asked for. Two of its three CRAP drifts were real and are now gone rather than absorbed; the third was a keying artifact — CRAP identifies anonymous functions positionally, so moving `validateTerminalEnvelope` into its own module shifted every later arrow's index by one and the baseline compared two different functions. That plus the genuinely new methods needs a recorded baseline; the refresh is diff-scoped to the five files this branch changes, and overall p95 moves down.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches delivery exit contracts, worktree reap preconditions, and schema validation semantics; behavior changes are intentional but affect every close-and-land run and failure paths.
> 
> **Overview**
> Fixes **#4784**: a successful close run from a story worktree could exit **non-zero with no terminal envelope** after the worktree reap removed the lazy-loaded schema file (and sometimes the running script).
> 
> **Terminal schema** moves to `story-deliver-terminal-schema.js`, which **loads the JSON at import** and **degrades** validation (`validated: false`, stderr notice) when the schema is missing—still **throws** on real shape violations. `story-deliver-terminal.js` delegates validation and re-exports the validator.
> 
> **Worktree reap** skips removal when **`process.argv[1]` or the reap module** lives inside the target tree (`running-from-target-tree`), so later lazy reads/imports do not hit `ENOENT` mid-run.
> 
> **Failed close path**: `failedTerminalFor` / `gatesForFailedPhase` move to `single-story-close/failed-terminal.js`; envelope assembly is wrapped so a **second** build failure returns `null` and the **original** error is reported. Contract and reap tests cover import-time schema, degrade behavior, and the running-code guard.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1310384ce774527c801a1e0fcf6fef6bc6aaa004. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->