### PR TITLE
test(quality): cover the 21 CRAP methods above 30 behind extracted seams and ratchet methodsAbove20 to 19 (#4780)

### DIFF
--- a/.agentrc.json
+++ b/.agentrc.json
@@ -34,7 +34,7 @@
     "quality": {
       "gates": {
         "crap": {
-          "floors": { "*": { "methodsAbove20": 40 } },
+          "floors": { "*": { "methodsAbove20": 13 } },
           "targetDirs": [".agents/scripts", "bin", "lib"],
           "ignoreGlobs": [
             ".agents/scripts/lifecycle-emit.js",

--- a/.agents/scripts/acceptance-eval.js
+++ b/.agents/scripts/acceptance-eval.js
@@ -82,10 +82,14 @@ const VERDICT_SCHEMA_PATH = path.resolve(
   'acceptance-eval-verdict.schema.json',
 );
 
-let cachedValidator = null;
-
 /**
- * Compile (and cache) the Ajv2020 validator for the verdict schema.
+ * Compile the Ajv2020 validator for the verdict schema.
+ *
+ * Deliberately **not** memoised in a module-level variable: a module-level
+ * cache is reset only on re-import, so it silently defeats the `io` seam below
+ * (the second caller's injected reader is never consulted) and makes parallel
+ * test isolation impossible — `.agents/rules/test-seams.md` rule 3. The gate
+ * compiles the schema once per CLI run, so there is nothing to memoise.
  *
  * @param {string} [schemaPath]
  * @param {{ readFileSync: typeof readFileSync }} [io]
@@ -95,12 +99,10 @@ function getVerdictValidator(
   schemaPath = VERDICT_SCHEMA_PATH,
   io = { readFileSync },
 ) {
-  if (cachedValidator) return cachedValidator;
   const ajv = new Ajv2020({ allErrors: true, strict: false });
   addFormats(ajv);
   const schema = JSON.parse(io.readFileSync(schemaPath, 'utf8'));
-  cachedValidator = ajv.compile(schema);
-  return cachedValidator;
+  return ajv.compile(schema);
 }
 
 /**
@@ -235,7 +237,37 @@ export async function runAcceptanceEval(
   return { envelope, exitCode };
 }
 
-export async function main(argv = process.argv.slice(2)) {
+/**
+ * The gate's CLI core: argv → verdict read → schema validation → decision →
+ * envelope. Extracted from the `main` shell so the whole error table (missing
+ * flags, unreadable verdict, non-JSON verdict, storyId mismatch, block) is
+ * reachable without spawning the CLI or writing a real verdict file.
+ *
+ * Every seam on the optional final `deps` parameter defaults to the real
+ * implementation (`.agents/rules/test-seams.md` rules 1-2, 4), so `main` and
+ * every production invocation are unchanged.
+ *
+ * @param {string[]} [argv]
+ * @param {{
+ *   readFileSyncImpl?: typeof readFileSync,
+ *   resolveConfigImpl?: typeof resolveConfig,
+ *   validateVerdictImpl?: typeof validateVerdict,
+ *   runAcceptanceEvalImpl?: typeof runAcceptanceEval,
+ *   logger?: { info: Function },
+ * }} [deps]
+ * @returns {Promise<object>} the emitted envelope.
+ */
+export async function runAcceptanceEvalCli(
+  argv = process.argv.slice(2),
+  deps = {},
+) {
+  const {
+    readFileSyncImpl = readFileSync,
+    resolveConfigImpl = resolveConfig,
+    validateVerdictImpl = validateVerdict,
+    runAcceptanceEvalImpl = runAcceptanceEval,
+    logger = Logger,
+  } = deps;
   const { storyId, verdictPath, emitSignal } = parseCliArgs(argv);
 
   if (!storyId) {
@@ -249,7 +281,7 @@ export async function main(argv = process.argv.slice(2)) {
 
   let raw;
   try {
-    raw = readFileSync(path.resolve(verdictPath), 'utf8');
+    raw = readFileSyncImpl(path.resolve(verdictPath), 'utf8');
   } catch (err) {
     throw new Error(
       `acceptance-eval: cannot read verdict file at ${verdictPath}: ${
@@ -269,7 +301,7 @@ export async function main(argv = process.argv.slice(2)) {
     );
   }
 
-  const verdict = validateVerdict(parsed);
+  const verdict = validateVerdictImpl(parsed);
 
   // A verdict whose embedded storyId disagrees with the CLI flag is a
   // wiring error worth failing on, not a silent mismatch.
@@ -279,15 +311,15 @@ export async function main(argv = process.argv.slice(2)) {
     );
   }
 
-  const config = resolveConfig();
-  const { envelope, exitCode } = await runAcceptanceEval({
+  const config = resolveConfigImpl();
+  const { envelope, exitCode } = await runAcceptanceEvalImpl({
     storyId,
     verdict,
     config,
     emitSignal,
   });
 
-  Logger.info(JSON.stringify(envelope));
+  logger.info(JSON.stringify(envelope));
 
   if (exitCode !== 0) {
     const names = envelope.unmetCriteria
@@ -300,6 +332,14 @@ export async function main(argv = process.argv.slice(2)) {
   }
 
   return envelope;
+}
+
+/**
+ * @param {string[]} [argv]
+ * @returns {Promise<object>}
+ */
+export async function main(argv = process.argv.slice(2)) {
+  return runAcceptanceEvalCli(argv);
 }
 
 runAsCli(import.meta.url, main, {

--- a/.agents/scripts/audit-to-stories.js
+++ b/.agents/scripts/audit-to-stories.js
@@ -224,8 +224,38 @@ function dedupDegradedWarning(entries) {
   );
 }
 
-async function buildPlan({ glob: pattern, severity, useProvider, ledger }) {
-  const reportPaths = await collectReportPaths(pattern ?? DEFAULT_GLOB);
+/**
+ * Scan → group → dedup → (optionally) reconcile the cross-run ledger, and
+ * return the plan envelope.
+ *
+ * Every seam on the optional final `deps` parameter defaults to the real
+ * implementation (`.agents/rules/test-seams.md` rules 1-2, 4), so `main`,
+ * `runAuto`, and every production caller are unchanged.
+ *
+ * @param {{ glob?: string, severity?: string, useProvider?: boolean, ledger?: object }} params
+ * @param {{
+ *   collectReportPathsImpl?: typeof collectReportPaths,
+ *   readReportsImpl?: typeof readReports,
+ *   loadProviderImpl?: typeof loadProvider,
+ *   classifyGroupsImpl?: typeof classifyGroupsAgainstGitHub,
+ *   reconcileScanLedgerImpl?: typeof reconcileScanLedger,
+ *   logger?: { warn: Function },
+ * }} [deps]
+ * @returns {Promise<object>} the plan envelope.
+ */
+async function buildPlan(
+  { glob: pattern, severity, useProvider, ledger },
+  deps = {},
+) {
+  const {
+    collectReportPathsImpl = collectReportPaths,
+    readReportsImpl = readReports,
+    loadProviderImpl = loadProvider,
+    classifyGroupsImpl = classifyGroupsAgainstGitHub,
+    reconcileScanLedgerImpl = reconcileScanLedger,
+    logger = Logger,
+  } = deps;
+  const reportPaths = await collectReportPathsImpl(pattern ?? DEFAULT_GLOB);
   if (reportPaths.length === 0) {
     return {
       generatedAt: new Date().toISOString(),
@@ -245,7 +275,7 @@ async function buildPlan({ glob: pattern, severity, useProvider, ledger }) {
     };
   }
 
-  const reports = readReports(reportPaths);
+  const reports = readReportsImpl(reportPaths);
   const allFindings = parseAuditReports(reports, { repoRoot: process.cwd() });
   const filtered = allFindings.filter((f) => meetsSeverity(f, severity));
   const stamped = withFingerprints(filtered);
@@ -261,9 +291,9 @@ async function buildPlan({ glob: pattern, severity, useProvider, ledger }) {
   let dedupApplied = false;
 
   if (useProvider) {
-    const provider = await loadProvider();
+    const provider = await loadProviderImpl();
     if (provider) {
-      const result = await classifyGroupsAgainstGitHub({
+      const result = await classifyGroupsImpl({
         groups,
         provider,
         searchCandidates: provider.searchCandidates,
@@ -275,19 +305,19 @@ async function buildPlan({ glob: pattern, severity, useProvider, ledger }) {
       // the --scan JSON on stdout stays clean) naming the groups that degraded
       // to create because their lookup could not complete (Story #4678).
       if (summary.dedupDegraded?.count > 0) {
-        Logger.warn(dedupDegradedWarning(summary.dedupDegraded.groups));
+        logger.warn(dedupDegradedWarning(summary.dedupDegraded.groups));
       }
     } else {
       // The provider could not resolve a searchIssues port — the dedup gate
       // is silently a no-op without this. Surface it loudly (stderr, so the
       // --scan JSON on stdout stays clean) so the operator does not read a
       // create-only plan as "no duplicates found".
-      Logger.warn(dedupSkippedWarning('no-provider-port'));
+      logger.warn(dedupSkippedWarning('no-provider-port'));
     }
   } else {
     // Operator explicitly opted out via --no-provider. Still warn so a
     // duplicate-opening re-run is never a surprise.
-    Logger.warn(dedupSkippedWarning('disabled'));
+    logger.warn(dedupSkippedWarning('disabled'));
   }
 
   // Cross-run ledger (Story #4626): fold this scan onto the committed memory,
@@ -296,7 +326,7 @@ async function buildPlan({ glob: pattern, severity, useProvider, ledger }) {
   // --scan path leaves it untouched so it never mutates a committed file.
   let ledgerSummary;
   if (ledger) {
-    const suppressed = reconcileScanLedger({
+    const suppressed = reconcileScanLedgerImpl({
       ledgerPath: ledger.path ?? DEFAULT_LEDGER_PATH,
       findings: stamped,
       classifications,
@@ -546,9 +576,42 @@ export const __testing = {
   issueStatesFromClassifications,
 };
 
-async function main() {
+/**
+ * The CLI core: dispatch one of the four sub-commands and persist its output.
+ * Extracted from the `main` shell so the whole sub-command table (including
+ * the no-sub-command usage throw) is reachable without spawning the CLI.
+ *
+ * Every seam on the optional final `deps` parameter defaults to the real
+ * implementation (`.agents/rules/test-seams.md` rules 1-2, 4), so `main` and
+ * every production invocation are unchanged.
+ *
+ * @param {string[]} [argv]
+ * @param {{
+ *   buildPlanImpl?: typeof buildPlan,
+ *   runAutoImpl?: typeof runAuto,
+ *   loadPlanImpl?: typeof loadPlan,
+ *   buildAndGateStoriesImpl?: typeof buildAndGateStories,
+ *   buildPlanSeedMarkdownImpl?: typeof buildPlanSeedMarkdown,
+ *   persistImpl?: typeof persist,
+ *   stdout?: { write: (s: string) => void },
+ * }} [deps]
+ * @returns {Promise<void>}
+ */
+export async function runAuditToStories(
+  argv = process.argv.slice(2),
+  deps = {},
+) {
+  const {
+    buildPlanImpl = buildPlan,
+    runAutoImpl = runAuto,
+    loadPlanImpl = loadPlan,
+    buildAndGateStoriesImpl = buildAndGateStories,
+    buildPlanSeedMarkdownImpl = buildPlanSeedMarkdown,
+    persistImpl = persist,
+    stdout = process.stdout,
+  } = deps;
   const { values } = parseArgs({
-    args: process.argv.slice(2),
+    args: argv,
     options: {
       scan: { type: 'boolean' },
       auto: { type: 'boolean' },
@@ -567,47 +630,47 @@ async function main() {
   });
 
   if (values.auto) {
-    const { summary } = await runAuto({
+    const { summary } = await runAutoImpl({
       glob: values.glob,
       severity: values.severity,
       dryRun: values['dry-run'],
       useProvider: !values['no-provider'],
       ledgerPath: values.ledger,
     });
-    persist(JSON.stringify(summary, null, 2), values.out);
-    if (!values.out) process.stdout.write('\n');
+    persistImpl(JSON.stringify(summary, null, 2), values.out);
+    if (!values.out) stdout.write('\n');
     return;
   }
 
   if (values.scan) {
-    const plan = await buildPlan({
+    const plan = await buildPlanImpl({
       glob: values.glob,
       severity: values.severity,
       useProvider: !values['no-provider'],
     });
     const out = JSON.stringify(plan, null, 2);
-    persist(out, values.out);
-    if (!values.out) process.stdout.write('\n');
+    persistImpl(out, values.out);
+    if (!values.out) stdout.write('\n');
     return;
   }
 
   if (values['emit-plan-seed']) {
-    const plan = loadPlan(values.plan);
-    const md = buildPlanSeedMarkdown({
+    const plan = loadPlanImpl(values.plan);
+    const md = buildPlanSeedMarkdownImpl({
       groups: plan.groups ?? [],
       findings: plan.findings ?? [],
       sourceReports: plan.sourceReports ?? [],
     });
-    persist(md, values.out);
+    persistImpl(md, values.out);
     return;
   }
 
   if (values['emit-stories']) {
-    const plan = loadPlan(values.plan);
+    const plan = loadPlanImpl(values.plan);
     const eligible = (plan.classifications ?? [])
       .filter((c) => c.action === 'create')
       .map((c) => c.group);
-    const built = buildAndGateStories(eligible, plan.edges ?? []);
+    const built = buildAndGateStoriesImpl(eligible, plan.edges ?? []);
     const out = values.json
       ? JSON.stringify(built, null, 2)
       : built
@@ -616,14 +679,18 @@ async function main() {
               `--- story ${i + 1} ---\nTitle: ${s.title}\nLabels: ${s.labels.join(', ')}\n\n${s.body}\n`,
           )
           .join('\n');
-    persist(out, values.out);
-    if (!values.out) process.stdout.write('\n');
+    persistImpl(out, values.out);
+    if (!values.out) stdout.write('\n');
     return;
   }
 
   throw new Error(
     'Usage: node audit-to-stories.js (--scan | --emit-plan-seed | --emit-stories) [options]',
   );
+}
+
+async function main() {
+  await runAuditToStories();
 }
 
 runAsCli(import.meta.url, main, {

--- a/.agents/scripts/boot-sweep.js
+++ b/.agents/scripts/boot-sweep.js
@@ -176,8 +176,25 @@ export function buildSummaryLine(result) {
   return `[boot-sweep] reaped ${result.localDeleted} local + ${result.remoteDeleted} remote; protected ${protectedCount}${contentMergedSuffix}.`;
 }
 
-async function main() {
+/**
+ * The CLI core: parse argv, run the sweep, render the report. Extracted from
+ * the `main` shell so the argv → render decision table is reachable without
+ * spawning a real sweep against a real git tree.
+ *
+ * Both seams on the optional final `deps` parameter default to the real
+ * implementation (`.agents/rules/test-seams.md` rules 1-2), so `main` and any
+ * production caller are unchanged.
+ *
+ * @param {string[]} [argv]
+ * @param {{ runBootSweepImpl?: typeof runBootSweep, logger?: { info: Function } }} [deps]
+ * @returns {Promise<object>} the sweep envelope that was rendered.
+ */
+export async function runBootSweepCli(
+  argv = process.argv.slice(2),
+  { runBootSweepImpl = runBootSweep, logger = Logger } = {},
+) {
   const { values } = parseArgs({
+    args: argv,
     options: {
       base: { type: 'string' },
       cwd: { type: 'string' },
@@ -192,11 +209,11 @@ async function main() {
   });
 
   if (values.help) {
-    Logger.info(HELP);
-    return;
+    logger.info(HELP);
+    return undefined;
   }
 
-  const result = await runBootSweep({
+  const result = await runBootSweepImpl({
     cwd: typeof values.cwd === 'string' ? values.cwd : undefined,
     base: typeof values.base === 'string' ? values.base : undefined,
     include: Array.isArray(values.include) ? values.include : [],
@@ -206,10 +223,15 @@ async function main() {
   });
 
   if (values.json) {
-    Logger.info(JSON.stringify(result, null, 2));
+    logger.info(JSON.stringify(result, null, 2));
   } else {
-    Logger.info(buildSummaryLine(result));
+    logger.info(buildSummaryLine(result));
   }
+  return result;
+}
+
+async function main() {
+  await runBootSweepCli();
 }
 
 runAsCli(import.meta.url, main, {

--- a/.agents/scripts/coverage-capture.js
+++ b/.agents/scripts/coverage-capture.js
@@ -23,6 +23,7 @@
  */
 import path from 'node:path';
 import { getChangedFiles } from './lib/changed-files.js';
+import { isDirectInvocation } from './lib/cli-utils.js';
 import { getQuality, resolveConfig } from './lib/config-resolver.js';
 import {
   anyChangedUnderTargets,
@@ -35,7 +36,13 @@ import {
 import { Logger } from './lib/Logger.js';
 import { hasNpmScript, readPackageScripts } from './lib/npm-scripts.js';
 
-function parseArgs(argv) {
+/**
+ * Parse the full `process.argv` (index 2 onward) into the capture options.
+ *
+ * @param {string[]} argv
+ * @returns {{ skipWhenNoCrapFiles: boolean, ref: string, cwd: string }}
+ */
+export function parseArgs(argv) {
   const out = {
     skipWhenNoCrapFiles: false,
     ref: 'main',
@@ -50,13 +57,50 @@ function parseArgs(argv) {
   return out;
 }
 
-function main() {
-  const args = parseArgs(process.argv);
-  const config = resolveConfig({ cwd: args.cwd });
-  const { crap, coverage } = getQuality(config);
+/**
+ * The capture decision core, extracted from the CLI shell so the whole
+ * decision table (disabled gate, missing npm script, changed-file skip,
+ * freshness skip, capture + stamp) is reachable without spawning
+ * `npm run test:coverage` or touching the real filesystem.
+ *
+ * Every seam on the optional final `deps` parameter defaults to the real
+ * implementation (`.agents/rules/test-seams.md` rules 1-2, 4), so the CLI
+ * shell below and any production caller are unchanged.
+ *
+ * @param {string[]} [argv] Full `process.argv`-shaped array.
+ * @param {{
+ *   resolveConfigImpl?: typeof resolveConfig,
+ *   getQualityImpl?: typeof getQuality,
+ *   getChangedFilesImpl?: typeof getChangedFiles,
+ *   readPackageScriptsImpl?: typeof readPackageScripts,
+ *   hasNpmScriptImpl?: typeof hasNpmScript,
+ *   isCoverageFreshImpl?: typeof isCoverageFresh,
+ *   runCaptureImpl?: typeof runCapture,
+ *   computeContentDigestImpl?: typeof computeContentDigest,
+ *   writeCaptureStampImpl?: typeof writeCaptureStamp,
+ *   logger?: { info: Function, warn: Function, error: Function },
+ * }} [deps]
+ * @returns {number} process exit code
+ */
+export function runCoverageCapture(argv = process.argv, deps = {}) {
+  const {
+    resolveConfigImpl = resolveConfig,
+    getQualityImpl = getQuality,
+    getChangedFilesImpl = getChangedFiles,
+    readPackageScriptsImpl = readPackageScripts,
+    hasNpmScriptImpl = hasNpmScript,
+    isCoverageFreshImpl = isCoverageFresh,
+    runCaptureImpl = runCapture,
+    computeContentDigestImpl = computeContentDigest,
+    writeCaptureStampImpl = writeCaptureStamp,
+    logger = Logger,
+  } = deps;
+  const args = parseArgs(argv);
+  const config = resolveConfigImpl({ cwd: args.cwd });
+  const { crap, coverage } = getQualityImpl(config);
 
   if (crap.enabled === false) {
-    Logger.info('[coverage-capture] CRAP gate disabled — skipping capture.');
+    logger.info('[coverage-capture] CRAP gate disabled — skipping capture.');
     return 0;
   }
 
@@ -67,8 +111,8 @@ function main() {
   // defined it. Surface a one-line, fix-naming diagnostic instead of
   // spawning `npm run test:coverage` only to propagate npm's opaque
   // "Missing script" exit code.
-  if (!hasNpmScript(readPackageScripts(args.cwd), 'test:coverage')) {
-    Logger.error(
+  if (!hasNpmScriptImpl(readPackageScriptsImpl(args.cwd), 'test:coverage')) {
+    logger.error(
       '[coverage-capture] ✖ No "test:coverage" script in package.json. ' +
         'Add one (e.g. "test:coverage": "node --test --experimental-test-coverage") ' +
         'or disable the CRAP gate via delivery.quality.gates.crap.enabled=false.',
@@ -79,45 +123,45 @@ function main() {
   if (args.skipWhenNoCrapFiles) {
     let changed;
     try {
-      changed = getChangedFiles({ ref: args.ref, cwd: args.cwd });
+      changed = getChangedFilesImpl({ ref: args.ref, cwd: args.cwd });
     } catch (err) {
       // A bad ref must not silently relax the gate. Fall through to the
       // freshness check so coverage still gets captured if needed.
-      Logger.warn(
+      logger.warn(
         `[coverage-capture] ⚠ ${err?.message ?? err} — falling back to freshness check.`,
       );
       changed = null;
     }
     if (changed && !anyChangedUnderTargets(changed, crap.targetDirs)) {
-      Logger.info(
+      logger.info(
         `[coverage-capture] No changed files under [${crap.targetDirs.join(', ')}] — skipping capture.`,
       );
       return 0;
     }
   }
 
-  const freshness = isCoverageFresh({
+  const freshness = isCoverageFreshImpl({
     coveragePath: crap.coveragePath,
     targetDirs: crap.targetDirs,
     cwd: args.cwd,
   });
   if (freshness.fresh) {
-    Logger.info(
+    logger.info(
       `[coverage-capture] Coverage at ${path.resolve(args.cwd, crap.coveragePath)} is ${freshness.reason} — skipping capture.`,
     );
     return 0;
   }
 
-  Logger.info(
+  logger.info(
     `[coverage-capture] Coverage at ${crap.coveragePath} is ${freshness.reason}; running npm run test:coverage…`,
   );
-  const code = runCapture({
+  const code = runCaptureImpl({
     cwd: args.cwd,
     timeoutMs: coverage?.timeoutMs,
-    log: (m) => Logger.info(m),
+    log: (m) => logger.info(m),
   });
   if (code !== 0) {
-    Logger.error(
+    logger.error(
       `[coverage-capture] ✖ npm run test:coverage exited ${code}. Fix failing tests or coverage-threshold breaches before re-running the CRAP gate.`,
     );
     return code;
@@ -127,24 +171,29 @@ function main() {
   // freshness checks are content-aware (mtime churn from branch switches no
   // longer invalidates). Best-effort — a missing stamp just means the next
   // check falls back to the mtime heuristic.
-  const digest = computeContentDigest(args.cwd, crap.targetDirs);
+  const digest = computeContentDigestImpl(args.cwd, crap.targetDirs);
   if (
     digest &&
-    writeCaptureStamp({
+    writeCaptureStampImpl({
       cwd: args.cwd,
       coveragePath: crap.coveragePath,
       digest,
     })
   ) {
-    Logger.info('[coverage-capture] Wrote content-digest capture stamp.');
+    logger.info('[coverage-capture] Wrote content-digest capture stamp.');
   }
   return code;
 }
 
 // cli-opt-out: synchronous main returns an exit code that is forwarded via process.exit(code); runAsCli's async-main signature does not preserve the result code.
-try {
-  process.exit(main());
-} catch (err) {
-  Logger.error('[coverage-capture] unexpected error:', err);
-  process.exit(1);
+// The direct-invocation guard keeps `import`ing this module (from the unit
+// tests that drive `runCoverageCapture` with injected seams) side-effect free;
+// invoked as a CLI the behaviour — exit code and log lines — is unchanged.
+if (isDirectInvocation(import.meta.url)) {
+  try {
+    process.exit(runCoverageCapture());
+  } catch (err) {
+    Logger.error('[coverage-capture] unexpected error:', err);
+    process.exit(1);
+  }
 }

--- a/.agents/scripts/deliver-recover.js
+++ b/.agents/scripts/deliver-recover.js
@@ -82,19 +82,44 @@ export function parseArgv(argv) {
 
 /**
  * Probe and report. Exported for testing.
+ *
+ * The optional final `deps` parameter is the module's injectable seam
+ * (`.agents/rules/test-seams.md` rules 1-2): config resolution, provider
+ * construction, the probe itself, the renderer, and the log sink each default
+ * to the real implementation, so the CLI path and every production caller are
+ * unchanged. The pre-existing `injected*` fields on the first argument stay
+ * supported for callers already threading a resolved provider/config.
+ *
+ * @param {object} [args]
+ * @param {{
+ *   resolveConfigImpl?: typeof resolveConfig,
+ *   createProviderImpl?: typeof createProvider,
+ *   recoverStoryImpl?: typeof recoverStory,
+ *   renderRecoveryImpl?: typeof renderRecovery,
+ *   logger?: { info: Function },
+ * }} [deps]
  */
-export async function runDeliverRecover({
-  storyId: storyIdParam,
-  cwd: cwdParam,
-  json: jsonParam,
-  reprobe: reprobeParam,
-  argv,
-  injectedProvider,
-  injectedConfig,
-  injectedGh,
-  injectedGitSpawn,
-  injectedSleepFn,
-} = {}) {
+export async function runDeliverRecover(
+  {
+    storyId: storyIdParam,
+    cwd: cwdParam,
+    json: jsonParam,
+    reprobe: reprobeParam,
+    argv,
+    injectedProvider,
+    injectedConfig,
+    injectedGh,
+    injectedGitSpawn,
+    injectedSleepFn,
+  } = {},
+  {
+    resolveConfigImpl = resolveConfig,
+    createProviderImpl = createProvider,
+    recoverStoryImpl = recoverStory,
+    renderRecoveryImpl = renderRecovery,
+    logger = Logger,
+  } = {},
+) {
   const parsed =
     storyIdParam !== undefined
       ? {
@@ -106,7 +131,7 @@ export async function runDeliverRecover({
       : parseArgv(argv ?? process.argv.slice(2));
 
   if (parsed.help) {
-    Logger.info(HELP);
+    logger.info(HELP);
     return { success: true, result: null };
   }
   if (!Number.isInteger(parsed.storyId) || parsed.storyId <= 0) {
@@ -116,10 +141,10 @@ export async function runDeliverRecover({
   }
 
   const cwd = parsed.cwd ?? PROJECT_ROOT;
-  const config = injectedConfig || resolveConfig({ cwd });
-  const provider = injectedProvider || createProvider(config);
+  const config = injectedConfig || resolveConfigImpl({ cwd });
+  const provider = injectedProvider || createProviderImpl(config);
 
-  const recovery = await recoverStory({
+  const recovery = await recoverStoryImpl({
     storyId: parsed.storyId,
     cwd,
     provider,
@@ -130,8 +155,10 @@ export async function runDeliverRecover({
     ...(injectedSleepFn ? { sleepFn: injectedSleepFn } : {}),
   });
 
-  Logger.info(
-    parsed.json ? JSON.stringify(recovery, null, 2) : renderRecovery(recovery),
+  logger.info(
+    parsed.json
+      ? JSON.stringify(recovery, null, 2)
+      : renderRecoveryImpl(recovery),
   );
   return { success: true, result: recovery };
 }

--- a/.agents/scripts/drain-pending-cleanup.js
+++ b/.agents/scripts/drain-pending-cleanup.js
@@ -39,8 +39,44 @@ const progress = Logger.createProgress('drain-pending-cleanup', {
   stderr: false,
 });
 
-async function main() {
+/**
+ * The drain core, extracted from the CLI shell so the whole decision table —
+ * empty manifest, dry-run report, drain + escalate reporting — is reachable
+ * without a real worktree ledger or a real process kill.
+ *
+ * Every seam on the optional final `deps` parameter defaults to the real
+ * implementation (`.agents/rules/test-seams.md` rules 1-2, 4), so `main` and
+ * every production caller are unchanged.
+ *
+ * @param {string[]} [argv]
+ * @param {{
+ *   resolveConfigImpl?: typeof resolveConfig,
+ *   readManifestImpl?: typeof readManifest,
+ *   findHoldersInPathImpl?: typeof findHoldersInPath,
+ *   forceDrainImpl?: typeof forceDrainPendingCleanup,
+ *   gitImpl?: typeof gitUtils,
+ *   projectRoot?: string,
+ *   progressImpl?: (phase: string, message: string) => void,
+ *   logger?: { error: Function },
+ * }} [deps]
+ * @returns {Promise<{ drained: number[], remaining: number } | { remaining: number }>}
+ */
+export async function runDrainPendingCleanup(
+  argv = process.argv.slice(2),
+  deps = {},
+) {
+  const {
+    resolveConfigImpl = resolveConfig,
+    readManifestImpl = readManifest,
+    findHoldersInPathImpl = findHoldersInPath,
+    forceDrainImpl = forceDrainPendingCleanup,
+    gitImpl = gitUtils,
+    projectRoot = PROJECT_ROOT,
+    progressImpl = progress,
+    logger = Logger,
+  } = deps;
   const { values } = parseArgs({
+    args: argv,
     options: {
       escalate: { type: 'boolean', default: true },
       'dry-run': { type: 'boolean', default: false },
@@ -49,20 +85,23 @@ async function main() {
     strict: false,
   });
 
-  const config = resolveConfig();
+  const config = resolveConfigImpl();
   const wtConfig = config.delivery?.worktreeIsolation;
   const worktreeRoot = path.resolve(
-    PROJECT_ROOT,
+    projectRoot,
     values['worktree-root'] ?? wtConfig?.root ?? '.worktrees',
   );
 
-  const before = readManifest(worktreeRoot);
+  const before = readManifestImpl(worktreeRoot);
   if (before.length === 0) {
-    progress('SCAN', 'pending-cleanup manifest is empty — nothing to drain.');
-    return;
+    progressImpl(
+      'SCAN',
+      'pending-cleanup manifest is empty — nothing to drain.',
+    );
+    return { remaining: 0 };
   }
 
-  progress(
+  progressImpl(
     'SCAN',
     `pending-cleanup manifest has ${before.length} entry(ies): ${before
       .map((e) => `story-${e.storyId}(attempts=${e.attempts ?? 0})`)
@@ -71,8 +110,8 @@ async function main() {
 
   if (values['dry-run']) {
     for (const entry of before) {
-      const holders = findHoldersInPath(entry.path);
-      progress(
+      const holders = findHoldersInPathImpl(entry.path);
+      progressImpl(
         'DRY-RUN',
         `story-${entry.storyId} path=${entry.path} holders=${holders.length}` +
           (holders.length > 0
@@ -80,23 +119,23 @@ async function main() {
             : ''),
       );
     }
-    return;
+    return { remaining: before.length };
   }
 
-  const result = await forceDrainPendingCleanup({
-    repoRoot: PROJECT_ROOT,
+  const result = await forceDrainImpl({
+    repoRoot: projectRoot,
     worktreeRoot,
-    git: gitUtils,
+    git: gitImpl,
     escalate: values.escalate,
     logger: {
-      info: (m) => progress('DRAIN', m),
-      warn: (m) => progress('DRAIN', `⚠️ ${m}`),
-      error: (m) => Logger.error(`[drain-pending-cleanup] ${m}`),
+      info: (m) => progressImpl('DRAIN', m),
+      warn: (m) => progressImpl('DRAIN', `⚠️ ${m}`),
+      error: (m) => logger.error(`[drain-pending-cleanup] ${m}`),
     },
   });
 
   if (result.drained.length > 0) {
-    progress(
+    progressImpl(
       'DRAIN',
       `✅ drained ${result.drained.length} entry(ies): ${result.drained
         .map((id) => `story-${id}`)
@@ -107,10 +146,10 @@ async function main() {
     const summary = result.escalated
       .map((id) => `story-${id}=[${(result.killedPids[id] ?? []).join(',')}]`)
       .join(', ');
-    progress('ESCALATE', `terminated holders: ${summary}`);
+    progressImpl('ESCALATE', `terminated holders: ${summary}`);
   }
   if (result.noHolders && result.noHolders.length > 0) {
-    progress(
+    progressImpl(
       'ESCALATE',
       `⚠️ no user-mode holders for: ${result.noHolders
         .map((id) => `story-${id}`)
@@ -120,7 +159,7 @@ async function main() {
     );
   }
   if (result.persistent.length > 0) {
-    progress(
+    progressImpl(
       'PERSIST',
       `⚠️ persistent-lock remains on: ${result.persistent
         .map((id) => `story-${id}`)
@@ -128,7 +167,7 @@ async function main() {
     );
   }
   if (result.stillPending.length > 0) {
-    progress(
+    progressImpl(
       'STILL-PENDING',
       `⚠️ still-pending (below threshold): ${result.stillPending
         .map((id) => `story-${id}`)
@@ -136,12 +175,17 @@ async function main() {
     );
   }
 
-  const after = readManifest(worktreeRoot);
-  progress(
+  const after = readManifestImpl(worktreeRoot);
+  progressImpl(
     'DONE',
     `pending-cleanup manifest now has ${after.length} entry(ies). ` +
       `Drained=${result.drained.length}, escalated=${result.escalated.length}, persistent=${result.persistent.length}.`,
   );
+  return { drained: result.drained, remaining: after.length };
+}
+
+async function main() {
+  await runDrainPendingCleanup();
 }
 
 runAsCli(import.meta.url, main, {

--- a/.agents/scripts/generate-lens-checklists.js
+++ b/.agents/scripts/generate-lens-checklists.js
@@ -83,16 +83,21 @@ export function planChecklists(lenses, workflowExists, readWorkflow) {
  *   content; `missing` lists lenses with no `audit-<lens>.md`; `strays` lists
  *   on-disk checklist basenames that map to no current lens.
  */
-export function buildExpected() {
-  const workflowPath = (lens) => path.join(WORKFLOWS_DIR, `audit-${lens}.md`);
+export function buildExpected({
+  fsImpl = fs,
+  lenses = AUDIT_LENSES,
+  workflowsDir = WORKFLOWS_DIR,
+  checklistsDir = CHECKLISTS_DIR,
+} = {}) {
+  const workflowPath = (lens) => path.join(workflowsDir, `audit-${lens}.md`);
   const { expected, missing } = planChecklists(
-    AUDIT_LENSES,
-    (lens) => fs.existsSync(workflowPath(lens)),
-    (lens) => fs.readFileSync(workflowPath(lens), 'utf8'),
+    lenses,
+    (lens) => fsImpl.existsSync(workflowPath(lens)),
+    (lens) => fsImpl.readFileSync(workflowPath(lens), 'utf8'),
   );
 
-  const onDisk = fs.existsSync(CHECKLISTS_DIR)
-    ? fs.readdirSync(CHECKLISTS_DIR).filter((name) => name.endsWith('.md'))
+  const onDisk = fsImpl.existsSync(checklistsDir)
+    ? fsImpl.readdirSync(checklistsDir).filter((name) => name.endsWith('.md'))
     : [];
   const strays = onDisk.filter((name) => !expected.has(name));
 
@@ -101,29 +106,69 @@ export function buildExpected() {
 
 /**
  * @param {string} basename — e.g. `security.md`
+ * @param {string} [checklistsDir]
+ * @param {string} [projectRoot]
  * @returns {string} repo-relative POSIX path for messages.
  */
-function relChecklist(basename) {
+function relChecklist(
+  basename,
+  checklistsDir = CHECKLISTS_DIR,
+  projectRoot = PROJECT_ROOT,
+) {
   return path
-    .relative(PROJECT_ROOT, path.join(CHECKLISTS_DIR, basename))
+    .relative(projectRoot, path.join(checklistsDir, basename))
     .split(path.sep)
     .join('/');
 }
 
 /**
- * @param {string[]} argv
+ * The generator core, extracted from the CLI shell so both modes — the
+ * `--check` drift gate and the write/prune pass — are reachable without
+ * touching the real `.agents/audit-checklists` tree.
+ *
+ * Every seam on the optional final `deps` parameter defaults to the real
+ * implementation (`.agents/rules/test-seams.md` rules 1-2, 4), so `main` and
+ * `npm run docs:check` are unchanged.
+ *
+ * @param {string[]} [argv]
+ * @param {{
+ *   fsImpl?: typeof fs,
+ *   lenses?: ReadonlyArray<string>,
+ *   workflowsDir?: string,
+ *   checklistsDir?: string,
+ *   projectRoot?: string,
+ *   logger?: { info: Function },
+ * }} [deps]
+ * @returns {Promise<{ wrote: number, pruned: number, checked?: boolean }>}
  */
-async function main(argv = process.argv.slice(2)) {
+export async function runGenerateLensChecklists(
+  argv = process.argv.slice(2),
+  deps = {},
+) {
+  const {
+    fsImpl = fs,
+    lenses = AUDIT_LENSES,
+    workflowsDir = WORKFLOWS_DIR,
+    checklistsDir = CHECKLISTS_DIR,
+    projectRoot = PROJECT_ROOT,
+    logger = Logger,
+  } = deps;
   const { values } = parseArgs({
     args: argv,
     options: { check: { type: 'boolean', default: false } },
     allowPositionals: false,
   });
 
-  const { expected, missing, strays } = buildExpected();
+  const { expected, missing, strays } = buildExpected({
+    fsImpl,
+    lenses,
+    workflowsDir,
+    checklistsDir,
+  });
+  const rel = (basename) => relChecklist(basename, checklistsDir, projectRoot);
 
   if (missing.length > 0) {
-    Logger.info(
+    logger.info(
       `generate-lens-checklists: no audit-<lens>.md for: ${missing.join(', ')} — no checklist emitted.`,
     );
   }
@@ -131,21 +176,21 @@ async function main(argv = process.argv.slice(2)) {
   if (values.check) {
     const drifted = [];
     for (const [basename, content] of expected) {
-      const target = path.join(CHECKLISTS_DIR, basename);
-      const original = fs.existsSync(target)
-        ? fs.readFileSync(target, 'utf8')
+      const target = path.join(checklistsDir, basename);
+      const original = fsImpl.existsSync(target)
+        ? fsImpl.readFileSync(target, 'utf8')
         : null;
-      if (original !== content) drifted.push(relChecklist(basename));
+      if (original !== content) drifted.push(rel(basename));
     }
     if (drifted.length === 0 && strays.length === 0) {
-      Logger.info(
+      logger.info(
         `generate-lens-checklists: ${expected.size} checklist(s) up to date.`,
       );
-      return;
+      return { wrote: 0, pruned: 0, checked: true };
     }
     const problems = [
       ...drifted.map((p) => `out of date: ${p}`),
-      ...strays.map((s) => `stray (no lens): ${relChecklist(s)}`),
+      ...strays.map((s) => `stray (no lens): ${rel(s)}`),
     ];
     throw new Error(
       `Lens checklists are out of sync:\n  ${problems.join('\n  ')}\n` +
@@ -153,26 +198,32 @@ async function main(argv = process.argv.slice(2)) {
     );
   }
 
-  fs.mkdirSync(CHECKLISTS_DIR, { recursive: true });
+  fsImpl.mkdirSync(checklistsDir, { recursive: true });
   let wrote = 0;
   for (const [basename, content] of expected) {
-    const target = path.join(CHECKLISTS_DIR, basename);
-    const original = fs.existsSync(target)
-      ? fs.readFileSync(target, 'utf8')
+    const target = path.join(checklistsDir, basename);
+    const original = fsImpl.existsSync(target)
+      ? fsImpl.readFileSync(target, 'utf8')
       : null;
     if (original === content) continue;
-    fs.writeFileSync(target, content, 'utf8');
+    fsImpl.writeFileSync(target, content, 'utf8');
     wrote += 1;
   }
   for (const stray of strays) {
-    fs.rmSync(path.join(CHECKLISTS_DIR, stray));
-    Logger.info(
-      `generate-lens-checklists: pruned stray ${relChecklist(stray)}`,
-    );
+    fsImpl.rmSync(path.join(checklistsDir, stray));
+    logger.info(`generate-lens-checklists: pruned stray ${rel(stray)}`);
   }
-  Logger.info(
+  logger.info(
     `generate-lens-checklists: wrote ${wrote} of ${expected.size} checklist(s) (${strays.length} pruned).`,
   );
+  return { wrote, pruned: strays.length };
+}
+
+/**
+ * @param {string[]} [argv]
+ */
+async function main(argv = process.argv.slice(2)) {
+  await runGenerateLensChecklists(argv);
 }
 
 export { CHECKLISTS_DIR, WORKFLOWS_DIR };

--- a/.agents/scripts/lib/checks/story-init-not-backgrounded.js
+++ b/.agents/scripts/lib/checks/story-init-not-backgrounded.js
@@ -26,7 +26,7 @@
  * fan-out target, or `&` shell backgrounding) within a small line window.
  */
 
-import { readdirSync, readFileSync } from 'node:fs';
+import nodeFs from 'node:fs';
 import path from 'node:path';
 
 const SCAN_ROOT_DEFAULT = '.agents';
@@ -54,14 +54,20 @@ const BACKGROUND_TOKENS = [
  * and `.md` sources. Skips `node_modules`, `.worktrees`, and directories
  * starting with `.git`.
  *
+ * The optional final `fsImpl` parameter defaults to the real `node:fs`
+ * (`.agents/rules/test-seams.md` rule 1) and is forwarded to the recursive
+ * call rather than re-acquired there (rule 4), so a test drives the whole walk
+ * through a plain stub object instead of module mocking (rule 5).
+ *
  * @param {string} dir
+ * @param {typeof nodeFs} [fsImpl]
  * @returns {string[]}
  */
-function walkSources(dir) {
+export function walkSources(dir, fsImpl = nodeFs) {
   const out = [];
   let entries;
   try {
-    entries = readdirSync(dir, { withFileTypes: true });
+    entries = fsImpl.readdirSync(dir, { withFileTypes: true });
   } catch {
     return out;
   }
@@ -75,7 +81,7 @@ function walkSources(dir) {
       ) {
         continue;
       }
-      out.push(...walkSources(full));
+      out.push(...walkSources(full, fsImpl));
       continue;
     }
     if (!entry.isFile()) continue;
@@ -94,11 +100,14 @@ function walkSources(dir) {
  * any dedicated check module (this file): the source-of-truth
  * implementation legitimately mentions itself.
  *
+ * Pure: it is handed the already-read source, so it needs no filesystem seam
+ * of its own.
+ *
  * @param {string} file
  * @param {string} src
  * @returns {Array<{ line: number, kind: string }>}
  */
-function scanFile(file, src) {
+export function scanFile(file, src) {
   const offences = [];
   // Don't flag the actual story-init script, self-references, or the
   // parallel-tooling helper — the helper documents both Rule 2
@@ -149,15 +158,21 @@ export default {
   scope: ['story-close', 'retro'],
   autoCorrect: 'refuse-and-print',
 
-  detect(state) {
+  /**
+   * @param {{ cwd?: string, scanRoot?: string, scope?: string }} [state]
+   * @param {typeof nodeFs} [fsImpl] Optional final filesystem seam; defaults
+   *   to the real `node:fs` (`.agents/rules/test-seams.md` rule 1) and is
+   *   forwarded to {@link walkSources} rather than re-acquired (rule 4).
+   */
+  detect(state, fsImpl = nodeFs) {
     const cwd = state?.cwd ?? process.cwd();
     const root = state?.scanRoot ?? path.join(cwd, SCAN_ROOT_DEFAULT);
-    const files = walkSources(root);
+    const files = walkSources(root, fsImpl);
     const offences = [];
     for (const file of files) {
       let src;
       try {
-        src = readFileSync(file, 'utf8');
+        src = fsImpl.readFileSync(file, 'utf8');
       } catch {
         continue;
       }

--- a/.agents/scripts/lib/git-branch-lifecycle.js
+++ b/.agents/scripts/lib/git-branch-lifecycle.js
@@ -134,16 +134,22 @@ export function classifyBranchSeed({ localHas, remoteHas }) {
  *
  * Caller-specific log lines and error text are passed in as the `messages`
  * data bag so behaviour stays byte-identical to the pre-extraction switches.
- * The git seams (`spawn`, `existsLocally`, `existsRemotely`) are injected so
- * each caller can bind its own cwd (and tests can mock them).
+ * The git seams (`spawn`, `existsLocally`, `existsRemotely`) are injectable so
+ * each caller can bind its own cwd (and tests can substitute stubs through the
+ * parameter rather than by module mocking). Per
+ * `.agents/rules/test-seams.md` rule 1 each seam **defaults to the real
+ * implementation** bound to `cwd`, so a caller that only knows its checkout
+ * passes `cwd` and nothing else; `single-story-init.js` keeps passing its own
+ * pre-bound seams and is unaffected.
  *
  * @param {object} opts
  * @param {string} opts.storyBranch
  * @param {string} opts.baseRef            Ref to branch from on `create`.
+ * @param {string} [opts.cwd]              Checkout the default seams bind to.
  * @param {boolean} [opts.swallowCreateRace=false]
- * @param {(args: string[]) => { status: number, stdout?: string, stderr?: string }} opts.spawn
- * @param {(branch: string) => boolean} opts.existsLocally
- * @param {(branch: string) => boolean} opts.existsRemotely
+ * @param {(args: string[]) => { status: number, stdout?: string, stderr?: string }} [opts.spawn]
+ * @param {(branch: string) => boolean} [opts.existsLocally]
+ * @param {(branch: string) => boolean} [opts.existsRemotely]
  * @param {(level: string, message: string) => void} [opts.progress]
  * @param {object} opts.messages
  * @param {(b: string) => string} opts.messages.reuse
@@ -158,10 +164,11 @@ export function classifyBranchSeed({ localHas, remoteHas }) {
 export function seedStoryBranchRef({
   storyBranch,
   baseRef,
+  cwd,
   swallowCreateRace = false,
-  spawn,
-  existsLocally,
-  existsRemotely,
+  spawn = (args) => gitSpawn(cwd, ...args),
+  existsLocally = (branch) => branchExistsLocally(branch, cwd),
+  existsRemotely = (branch) => branchExistsViaTrackingRef(branch, cwd),
   progress = () => {},
   messages,
 }) {

--- a/.agents/scripts/lib/orchestration/ticket-validator-conflicts.js
+++ b/.agents/scripts/lib/orchestration/ticket-validator-conflicts.js
@@ -449,15 +449,29 @@ function computeMissingBddScaffoldFindings(stories, reach, severity) {
  * Tasks satisfy (a) or (b). When ≥2 such Stories sit in the same wave (no
  * transitive `depends_on` between them), emit a single finding keyed by the
  * registry path.
+ *
+ * Reached from the module's `_internal` named export. The pass is pure — it
+ * performs no filesystem I/O and spawns no process — so its optional final
+ * `deps` parameter seams the three collaborating predicates rather than a
+ * built-in; each entry defaults to the real implementation
+ * (`.agents/rules/test-seams.md` rules 1-3: the defaults live on the function,
+ * never on a module-level mutable variable).
+ *
+ * @param {object} input
+ * @param {{
+ *   isRegistryPathImpl?: typeof isRegistryPath,
+ *   inSameWaveImpl?: typeof inSameWave,
+ *   registryRegistryImpl?: typeof registryRegistry,
+ * }} [deps]
  */
-function computeRegistryFindings({
-  stories,
-  reach,
-  patterns,
-  producers,
-  assumptionEntries,
-  severity,
-}) {
+function computeRegistryFindings(
+  { stories, reach, patterns, producers, assumptionEntries, severity },
+  {
+    isRegistryPathImpl = isRegistryPath,
+    inSameWaveImpl = inSameWave,
+    registryRegistryImpl = registryRegistry,
+  } = {},
+) {
   const findings = [];
   // Build the matching registry path set from producer & creator paths.
   const registryHits = new Map(); // registryPath -> Map<storySlug, producers[]>
@@ -474,7 +488,7 @@ function computeRegistryFindings({
   // (a) direct registry edits — object-form `{ path, assumption }` entries
   // from `indexAssumptionEntries` (and the producer index built from them).
   for (const [path, entries] of producers.entries()) {
-    if (!isRegistryPath(path, patterns)) continue;
+    if (!isRegistryPathImpl(path, patterns)) continue;
     for (const e of entries) {
       bump(path, {
         storySlug: e.storySlug,
@@ -485,7 +499,7 @@ function computeRegistryFindings({
     }
   }
   for (const e of assumptionEntries) {
-    if (!isRegistryPath(e.path, patterns)) continue;
+    if (!isRegistryPathImpl(e.path, patterns)) continue;
     bump(e.path, {
       storySlug: e.storySlug,
       taskSlug: e.taskSlug,
@@ -510,7 +524,7 @@ function computeRegistryFindings({
         continue;
       const childParent = parentDirOf(change.path);
       if (!childParent) continue;
-      for (const reg of registryRegistry(
+      for (const reg of registryRegistryImpl(
         producers,
         assumptionEntries,
         patterns,
@@ -532,7 +546,7 @@ function computeRegistryFindings({
     const cluster = new Set();
     for (let i = 0; i < stories.length; i += 1) {
       for (let j = i + 1; j < stories.length; j += 1) {
-        if (inSameWave(reach, stories[i], stories[j])) {
+        if (inSameWaveImpl(reach, stories[i], stories[j])) {
           cluster.add(stories[i]);
           cluster.add(stories[j]);
         }

--- a/.agents/scripts/nav-registry-diff.js
+++ b/.agents/scripts/nav-registry-diff.js
@@ -340,12 +340,13 @@ export function computeNavDiff({ routes = [], nav = [], refs = [] } = {}) {
  *
  * @param {string} label human-readable role for the error message
  * @param {string} file
+ * @param {typeof fs} [fsImpl] filesystem seam; defaults to the real `node:fs`.
  * @returns {unknown[]}
  */
-function readJsonArray(label, file) {
+function readJsonArray(label, file, fsImpl = fs) {
   let raw;
   try {
-    raw = fs.readFileSync(file, 'utf8');
+    raw = fsImpl.readFileSync(file, 'utf8');
   } catch (err) {
     throw new Error(
       `nav-registry-diff: cannot read ${label} file '${file}': ${err.message}`,
@@ -400,10 +401,23 @@ export function formatDiffText(diff) {
 }
 
 /**
- * @param {string[]} argv
+ * The reporter core, extracted from the CLI shell so the argv → read → diff →
+ * render → exit-code path is reachable without touching the real filesystem or
+ * the real stdout.
+ *
+ * Both seams on the optional final `deps` parameter default to the real
+ * implementation (`.agents/rules/test-seams.md` rules 1-2, 4 — `readJsonArray`
+ * forwards `fsImpl` rather than re-acquiring `fs`), so `main` and every
+ * production invocation are unchanged.
+ *
+ * @param {string[]} [argv]
+ * @param {{ fsImpl?: typeof fs, stdout?: { write: (s: string) => void } }} [deps]
  * @returns {Promise<number>} process exit code
  */
-async function main(argv = process.argv.slice(2)) {
+export async function runNavRegistryDiff(
+  argv = process.argv.slice(2),
+  { fsImpl = fs, stdout = process.stdout } = {},
+) {
   const { values } = parseArgs({
     args: argv,
     options: {
@@ -423,9 +437,9 @@ async function main(argv = process.argv.slice(2)) {
     );
   }
 
-  const routes = readJsonArray('routes', values.routes);
-  const nav = readJsonArray('nav', values.nav);
-  const refs = values.refs ? readJsonArray('refs', values.refs) : [];
+  const routes = readJsonArray('routes', values.routes, fsImpl);
+  const nav = readJsonArray('nav', values.nav, fsImpl);
+  const refs = values.refs ? readJsonArray('refs', values.refs, fsImpl) : [];
 
   const diff = computeNavDiff({ routes, nav, refs });
 
@@ -434,11 +448,19 @@ async function main(argv = process.argv.slice(2)) {
   const rendered = values.json
     ? JSON.stringify(diff, null, 2)
     : formatDiffText(diff);
-  process.stdout.write(`${rendered}\n`);
+  stdout.write(`${rendered}\n`);
 
   const hasFindings =
     diff.orphanedRoutes.length > 0 || diff.deadHrefs.length > 0;
   return values.strict && hasFindings ? 1 : 0;
+}
+
+/**
+ * @param {string[]} [argv]
+ * @returns {Promise<number>} process exit code
+ */
+async function main(argv = process.argv.slice(2)) {
+  return runNavRegistryDiff(argv);
 }
 
 export { main };

--- a/.agents/scripts/plan-run-epilogue.js
+++ b/.agents/scripts/plan-run-epilogue.js
@@ -27,9 +27,23 @@ const CLI_OPTIONS = {
 
 /**
  * @param {string[]} [argv]
+ * @param {{
+ *   resolveConfigImpl?: typeof resolveConfig,
+ *   createProviderImpl?: typeof createProvider,
+ *   runPlanRunEpilogueImpl?: typeof runPlanRunEpilogue,
+ *   logger?: { info: Function, warn: Function },
+ * }} [deps] Injectable seams; every entry defaults to the real
+ *   implementation (`.agents/rules/test-seams.md` rules 1-2), so the CLI path
+ *   and every production caller are unchanged.
  * @returns {Promise<object>}
  */
-export async function main(argv = process.argv.slice(2)) {
+export async function main(argv = process.argv.slice(2), deps = {}) {
+  const {
+    resolveConfigImpl = resolveConfig,
+    createProviderImpl = createProvider,
+    runPlanRunEpilogueImpl = runPlanRunEpilogue,
+    logger = Logger,
+  } = deps;
   const { values } = parseArgs({
     args: argv,
     options: CLI_OPTIONS,
@@ -44,8 +58,8 @@ export async function main(argv = process.argv.slice(2)) {
     typeof values.cwd === 'string' && values.cwd.trim()
       ? values.cwd.trim()
       : process.cwd();
-  const config = resolveConfig({ cwd });
-  const provider = createProvider(config);
+  const config = resolveConfigImpl({ cwd });
+  const provider = createProviderImpl(config);
 
   // Story #4540 retired the `--run <planRunId>` label-resolution branch
   // along with the label itself. The epilogue is keyed on the delivered id
@@ -58,16 +72,16 @@ export async function main(argv = process.argv.slice(2)) {
 
   const planRunId = `adhoc-${[...stories].sort((a, b) => a - b).join('-')}`;
 
-  const result = await runPlanRunEpilogue({
+  const result = await runPlanRunEpilogueImpl({
     planRunId,
     stories,
     provider,
     config,
     cwd,
   });
-  warnOnUnresolvedBase(result);
-  warnOnEmptyRollup(result);
-  Logger.info(JSON.stringify(result));
+  warnOnUnresolvedBase(result, logger);
+  warnOnEmptyRollup(result, logger);
+  logger.info(JSON.stringify(result));
   if (result.errors?.length) {
     process.exitCode = 1;
   }
@@ -84,15 +98,16 @@ export async function main(argv = process.argv.slice(2)) {
  * roster is still useful.
  *
  * @param {object} result - `runPlanRunEpilogue` envelope.
+ * @param {{ warn: Function }} [logger]
  * @returns {void}
  */
-function warnOnUnresolvedBase(result) {
+function warnOnUnresolvedBase(result, logger = Logger) {
   const roster = (result?.results ?? []).find(
     (r) => r?.kind === 'audit-roster',
   );
   const base = roster?.baseResolution;
   if (base?.resolved !== false) return;
-  Logger.warn(
+  logger.warn(
     `⚠️  Combined landed diff unavailable — the pre-run base sha could not be ` +
       `resolved against \`${base.baseRef}\`: ${base.reason}\n` +
       `    changedFiles is null (NOT an empty set). Determine the run diff by ` +
@@ -117,14 +132,15 @@ function warnOnUnresolvedBase(result) {
  * rather than asserting either reading.
  *
  * @param {object} result - `runPlanRunEpilogue` envelope.
+ * @param {{ warn: Function }} [logger]
  * @returns {void}
  */
-function warnOnEmptyRollup(result) {
+function warnOnEmptyRollup(result, logger = Logger) {
   const rollup = (result?.results ?? []).find(
     (r) => r?.kind === 'follow-up-rollup',
   );
   if (!rollup?.emptyRollupSuspect) return;
-  Logger.warn(
+  logger.warn(
     `⚠️  0 friction signals across ${rollup.storyCount} Stories — telemetry may not ` +
       `have fired.\n` +
       `    An empty roll-up is NOT evidence of a clean run: it is the same output a ` +

--- a/.agents/scripts/resolve-doc-tiers.js
+++ b/.agents/scripts/resolve-doc-tiers.js
@@ -50,24 +50,34 @@ export function parseArgv(argv = []) {
  * Top-level CLI entry. Exported so tests can drive it against a fixture root
  * with an injected sink and config.
  *
+ * The optional final `deps` parameter is the module's injectable seam
+ * (`.agents/rules/test-seams.md` rules 1-2): every entry defaults to the real
+ * implementation, so the CLI path below — and any production caller — needs no
+ * configuration change.
+ *
  * @param {{
  *   argv?: string[],
  *   config?: object,
  *   root?: string,
  *   stdout?: { write: (s: string) => void },
  * }} [opts]
+ * @param {{
+ *   resolveConfigImpl?: typeof resolveConfig,
+ *   resolveDocTiersImpl?: typeof resolveDocTiers,
+ * }} [deps]
  * @returns {Promise<number>} always 0
  */
-export async function runCli({
-  argv = process.argv.slice(2),
-  config,
-  root,
-  stdout = process.stdout,
-} = {}) {
+export async function runCli(
+  { argv = process.argv.slice(2), config, root, stdout = process.stdout } = {},
+  {
+    resolveConfigImpl = resolveConfig,
+    resolveDocTiersImpl = resolveDocTiers,
+  } = {},
+) {
   const { rootPath } = parseArgv(argv);
-  const resolvedConfig = config ?? resolveConfig();
+  const resolvedConfig = config ?? resolveConfigImpl();
   const resolvedRoot = root ?? rootPath ?? PROJECT_ROOT;
-  const result = resolveDocTiers(resolvedConfig, { root: resolvedRoot });
+  const result = resolveDocTiersImpl(resolvedConfig, { root: resolvedRoot });
   stdout.write(`${JSON.stringify(result, null, 2)}\n`);
   return 0;
 }

--- a/baselines/crap.json
+++ b/baselines/crap.json
@@ -1,64 +1,70 @@
 {
   "$schema": ".agents/schemas/baselines/crap.schema.json",
   "kernelVersion": "0.1.0",
-  "generatedAt": "2026-07-26T02:47:13.697Z",
+  "generatedAt": "2026-07-26T14:29:55.493Z",
   "scoringSemantics": "coverage-join-v2",
   "rollup": {
     "*": {
       "p50": 2,
-      "p95": 11.036579789666211,
-      "max": 123.75293999270504,
-      "methodsAbove20": 40
+      "p95": 10.58179012345679,
+      "max": 30,
+      "methodsAbove20": 13
     }
   },
   "rows": [
     {
       "path": ".agents/scripts/acceptance-eval.js",
       "method": "getVerdictValidator",
-      "startLine": 94,
-      "crap": 2
+      "startLine": 98,
+      "crap": 1
     },
     {
       "path": ".agents/scripts/acceptance-eval.js",
       "method": "validateVerdict",
-      "startLine": 116,
+      "startLine": 118,
       "crap": 2
     },
     {
       "path": ".agents/scripts/acceptance-eval.js",
       "method": "<anon method-1>",
-      "startLine": 123,
+      "startLine": 125,
       "crap": 2
     },
     {
       "path": ".agents/scripts/acceptance-eval.js",
       "method": "parseCliArgs",
-      "startLine": 132,
-      "crap": 12
+      "startLine": 134,
+      "crap": 3
     },
     {
       "path": ".agents/scripts/acceptance-eval.js",
       "method": "runAcceptanceEval",
-      "startLine": 170,
+      "startLine": 172,
       "crap": 6
     },
     {
       "path": ".agents/scripts/acceptance-eval.js",
       "method": "<anon method-2>",
-      "startLine": 222,
+      "startLine": 224,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/acceptance-eval.js",
+      "method": "runAcceptanceEvalCli",
+      "startLine": 260,
+      "crap": 8
+    },
+    {
+      "path": ".agents/scripts/acceptance-eval.js",
+      "method": "<anon method-3>",
+      "startLine": 326,
       "crap": 1
     },
     {
       "path": ".agents/scripts/acceptance-eval.js",
       "method": "main",
-      "startLine": 238,
-      "crap": 69.13476361410247
-    },
-    {
-      "path": ".agents/scripts/acceptance-eval.js",
-      "method": "<anon method-3>",
-      "startLine": 294,
-      "crap": 1.955230681470351
+      "startLine": 341,
+      "crap": 1.2962962962962963
     },
     {
       "path": ".agents/scripts/apply-quality-bootstrap.js",
@@ -124,31 +130,31 @@
       "path": ".agents/scripts/audit-to-stories.js",
       "method": "meetsSeverity",
       "startLine": 57,
-      "crap": 12
+      "crap": 3
     },
     {
       "path": ".agents/scripts/audit-to-stories.js",
       "method": "collectReportPaths",
       "startLine": 64,
-      "crap": 6
+      "crap": 2
     },
     {
       "path": ".agents/scripts/audit-to-stories.js",
       "method": "readReports",
       "startLine": 73,
-      "crap": 2
+      "crap": 1
     },
     {
       "path": ".agents/scripts/audit-to-stories.js",
       "method": "<anon method-1>",
       "startLine": 74,
-      "crap": 2
+      "crap": 1
     },
     {
       "path": ".agents/scripts/audit-to-stories.js",
       "method": "tallyBySeverity",
       "startLine": 80,
-      "crap": 6
+      "crap": 2.0078125
     },
     {
       "path": ".agents/scripts/audit-to-stories.js",
@@ -178,156 +184,162 @@
       "path": ".agents/scripts/audit-to-stories.js",
       "method": "dedupSkippedWarning",
       "startLine": 183,
-      "crap": 6
+      "crap": 2
     },
     {
       "path": ".agents/scripts/audit-to-stories.js",
       "method": "dedupDegradedWarning",
       "startLine": 217,
-      "crap": 2
+      "crap": 1
     },
     {
       "path": ".agents/scripts/audit-to-stories.js",
       "method": "<anon method-4>",
       "startLine": 218,
-      "crap": 2
+      "crap": 1
     },
     {
       "path": ".agents/scripts/audit-to-stories.js",
       "method": "buildPlan",
-      "startLine": 227,
-      "crap": 110
+      "startLine": 246,
+      "crap": 10
     },
     {
       "path": ".agents/scripts/audit-to-stories.js",
       "method": "<anon method-5>",
-      "startLine": 250,
-      "crap": 2
+      "startLine": 280,
+      "crap": 1
     },
     {
       "path": ".agents/scripts/audit-to-stories.js",
       "method": "<anon method-6>",
-      "startLine": 254,
-      "crap": 2
+      "startLine": 284,
+      "crap": 1
     },
     {
       "path": ".agents/scripts/audit-to-stories.js",
       "method": "<anon method-7>",
-      "startLine": 310,
-      "crap": 2
+      "startLine": 340,
+      "crap": 1
     },
     {
       "path": ".agents/scripts/audit-to-stories.js",
       "method": "reconcileScanLedger",
-      "startLine": 353,
-      "crap": 6
+      "startLine": 383,
+      "crap": 2
     },
     {
       "path": ".agents/scripts/audit-to-stories.js",
       "method": "<anon method-8>",
-      "startLine": 364,
-      "crap": 2
+      "startLine": 394,
+      "crap": 1
     },
     {
       "path": ".agents/scripts/audit-to-stories.js",
       "method": "<anon method-9>",
-      "startLine": 365,
-      "crap": 2
+      "startLine": 395,
+      "crap": 1
     },
     {
       "path": ".agents/scripts/audit-to-stories.js",
       "method": "issueStatesFromClassifications",
-      "startLine": 375,
-      "crap": 12
+      "startLine": 405,
+      "crap": 3.059326171875
     },
     {
       "path": ".agents/scripts/audit-to-stories.js",
       "method": "loadPlan",
-      "startLine": 392,
+      "startLine": 422,
       "crap": 6
     },
     {
       "path": ".agents/scripts/audit-to-stories.js",
       "method": "resolveSeverityFloor",
-      "startLine": 408,
-      "crap": 20
-    },
-    {
-      "path": ".agents/scripts/audit-to-stories.js",
-      "method": "runAuto",
-      "startLine": 436,
-      "crap": 42
-    },
-    {
-      "path": ".agents/scripts/audit-to-stories.js",
-      "method": "<anon method-10>",
-      "startLine": 458,
-      "crap": 2
-    },
-    {
-      "path": ".agents/scripts/audit-to-stories.js",
-      "method": "<anon method-11>",
-      "startLine": 477,
-      "crap": 2
-    },
-    {
-      "path": ".agents/scripts/audit-to-stories.js",
-      "method": "<anon method-12>",
-      "startLine": 478,
-      "crap": 2
-    },
-    {
-      "path": ".agents/scripts/audit-to-stories.js",
-      "method": "<anon method-13>",
-      "startLine": 479,
-      "crap": 2
-    },
-    {
-      "path": ".agents/scripts/audit-to-stories.js",
-      "method": "buildAndGateStories",
-      "startLine": 502,
-      "crap": 42
-    },
-    {
-      "path": ".agents/scripts/audit-to-stories.js",
-      "method": "<anon method-14>",
-      "startLine": 503,
-      "crap": 2
-    },
-    {
-      "path": ".agents/scripts/audit-to-stories.js",
-      "method": "<anon method-15>",
-      "startLine": 517,
-      "crap": 2
-    },
-    {
-      "path": ".agents/scripts/audit-to-stories.js",
-      "method": "persist",
-      "startLine": 526,
+      "startLine": 438,
       "crap": 6
     },
     {
       "path": ".agents/scripts/audit-to-stories.js",
-      "method": "main",
-      "startLine": 549,
-      "crap": 90
+      "method": "runAuto",
+      "startLine": 466,
+      "crap": 6.008261863679249
+    },
+    {
+      "path": ".agents/scripts/audit-to-stories.js",
+      "method": "<anon method-10>",
+      "startLine": 488,
+      "crap": 1.0002294962133125
+    },
+    {
+      "path": ".agents/scripts/audit-to-stories.js",
+      "method": "<anon method-11>",
+      "startLine": 507,
+      "crap": 1.0002294962133125
+    },
+    {
+      "path": ".agents/scripts/audit-to-stories.js",
+      "method": "<anon method-12>",
+      "startLine": 508,
+      "crap": 1.0002294962133125
+    },
+    {
+      "path": ".agents/scripts/audit-to-stories.js",
+      "method": "<anon method-13>",
+      "startLine": 509,
+      "crap": 1.0002294962133125
+    },
+    {
+      "path": ".agents/scripts/audit-to-stories.js",
+      "method": "buildAndGateStories",
+      "startLine": 532,
+      "crap": 7.5149173995233
+    },
+    {
+      "path": ".agents/scripts/audit-to-stories.js",
+      "method": "<anon method-14>",
+      "startLine": 533,
+      "crap": 1.0420810388756472
+    },
+    {
+      "path": ".agents/scripts/audit-to-stories.js",
+      "method": "<anon method-15>",
+      "startLine": 547,
+      "crap": 1.0420810388756472
+    },
+    {
+      "path": ".agents/scripts/audit-to-stories.js",
+      "method": "persist",
+      "startLine": 556,
+      "crap": 6
+    },
+    {
+      "path": ".agents/scripts/audit-to-stories.js",
+      "method": "runAuditToStories",
+      "startLine": 600,
+      "crap": 9
     },
     {
       "path": ".agents/scripts/audit-to-stories.js",
       "method": "<anon method-16>",
-      "startLine": 608,
-      "crap": 2
+      "startLine": 671,
+      "crap": 1
     },
     {
       "path": ".agents/scripts/audit-to-stories.js",
       "method": "<anon method-17>",
-      "startLine": 609,
-      "crap": 2
+      "startLine": 672,
+      "crap": 1
     },
     {
       "path": ".agents/scripts/audit-to-stories.js",
       "method": "<anon method-18>",
-      "startLine": 615,
+      "startLine": 678,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/audit-to-stories.js",
+      "method": "main",
+      "startLine": 692,
       "crap": 2
     },
     {
@@ -356,9 +368,15 @@
     },
     {
       "path": ".agents/scripts/boot-sweep.js",
+      "method": "runBootSweepCli",
+      "startLine": 192,
+      "crap": 8
+    },
+    {
+      "path": ".agents/scripts/boot-sweep.js",
       "method": "main",
-      "startLine": 179,
-      "crap": 72
+      "startLine": 233,
+      "crap": 2
     },
     {
       "path": ".agents/scripts/bootstrap.js",
@@ -1695,19 +1713,19 @@
     {
       "path": ".agents/scripts/coverage-capture.js",
       "method": "parseArgs",
-      "startLine": 38,
-      "crap": 5.009110787172012
+      "startLine": 45,
+      "crap": 5
     },
     {
       "path": ".agents/scripts/coverage-capture.js",
-      "method": "main",
-      "startLine": 53,
-      "crap": 42.69245541838134
+      "method": "runCoverageCapture",
+      "startLine": 85,
+      "crap": 10
     },
     {
       "path": ".agents/scripts/coverage-capture.js",
       "method": "<anon method-1>",
-      "startLine": 117,
+      "startLine": 161,
       "crap": 1
     },
     {
@@ -1810,13 +1828,13 @@
       "path": ".agents/scripts/deliver-recover.js",
       "method": "parseArgv",
       "startLine": 62,
-      "crap": 1.8573749999999998
+      "crap": 1
     },
     {
       "path": ".agents/scripts/deliver-recover.js",
       "method": "runDeliverRecover",
-      "startLine": 86,
-      "crap": 85.41621387118798
+      "startLine": 102,
+      "crap": 9
     },
     {
       "path": ".agents/scripts/diagnose.js",
@@ -1892,68 +1910,74 @@
     },
     {
       "path": ".agents/scripts/drain-pending-cleanup.js",
-      "method": "main",
-      "startLine": 42,
-      "crap": 110
+      "method": "runDrainPendingCleanup",
+      "startLine": 64,
+      "crap": 10
     },
     {
       "path": ".agents/scripts/drain-pending-cleanup.js",
       "method": "<anon method-1>",
-      "startLine": 68,
-      "crap": 2
+      "startLine": 107,
+      "crap": 1
     },
     {
       "path": ".agents/scripts/drain-pending-cleanup.js",
       "method": "<anon method-2>",
-      "startLine": 79,
-      "crap": 2
+      "startLine": 118,
+      "crap": 1
     },
     {
       "path": ".agents/scripts/drain-pending-cleanup.js",
       "method": "<anon method-3>",
-      "startLine": 92,
-      "crap": 2
+      "startLine": 131,
+      "crap": 1
     },
     {
       "path": ".agents/scripts/drain-pending-cleanup.js",
       "method": "<anon method-4>",
-      "startLine": 93,
-      "crap": 2
+      "startLine": 132,
+      "crap": 1
     },
     {
       "path": ".agents/scripts/drain-pending-cleanup.js",
       "method": "<anon method-5>",
-      "startLine": 94,
-      "crap": 2
+      "startLine": 133,
+      "crap": 1
     },
     {
       "path": ".agents/scripts/drain-pending-cleanup.js",
       "method": "<anon method-6>",
-      "startLine": 102,
-      "crap": 2
+      "startLine": 141,
+      "crap": 1
     },
     {
       "path": ".agents/scripts/drain-pending-cleanup.js",
       "method": "<anon method-7>",
-      "startLine": 108,
-      "crap": 2
+      "startLine": 147,
+      "crap": 1
     },
     {
       "path": ".agents/scripts/drain-pending-cleanup.js",
       "method": "<anon method-8>",
-      "startLine": 116,
-      "crap": 2
+      "startLine": 155,
+      "crap": 1
     },
     {
       "path": ".agents/scripts/drain-pending-cleanup.js",
       "method": "<anon method-9>",
-      "startLine": 126,
-      "crap": 2
+      "startLine": 165,
+      "crap": 1
     },
     {
       "path": ".agents/scripts/drain-pending-cleanup.js",
       "method": "<anon method-10>",
-      "startLine": 134,
+      "startLine": 173,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/drain-pending-cleanup.js",
+      "method": "main",
+      "startLine": 187,
       "crap": 2
     },
     {
@@ -2193,55 +2217,67 @@
     {
       "path": ".agents/scripts/generate-lens-checklists.js",
       "method": "<anon method-1>",
-      "startLine": 87,
+      "startLine": 92,
       "crap": 1
     },
     {
       "path": ".agents/scripts/generate-lens-checklists.js",
       "method": "<anon method-2>",
-      "startLine": 90,
-      "crap": 1
-    },
-    {
-      "path": ".agents/scripts/generate-lens-checklists.js",
-      "method": "<anon method-3>",
-      "startLine": 91,
-      "crap": 1
-    },
-    {
-      "path": ".agents/scripts/generate-lens-checklists.js",
-      "method": "<anon method-4>",
       "startLine": 95,
       "crap": 1
     },
     {
       "path": ".agents/scripts/generate-lens-checklists.js",
+      "method": "<anon method-3>",
+      "startLine": 96,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/generate-lens-checklists.js",
+      "method": "<anon method-4>",
+      "startLine": 100,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/generate-lens-checklists.js",
       "method": "<anon method-5>",
-      "startLine": 97,
+      "startLine": 102,
       "crap": 1
     },
     {
       "path": ".agents/scripts/generate-lens-checklists.js",
       "method": "relChecklist",
-      "startLine": 106,
-      "crap": 2
+      "startLine": 113,
+      "crap": 1
     },
     {
       "path": ".agents/scripts/generate-lens-checklists.js",
-      "method": "main",
-      "startLine": 116,
-      "crap": 90
+      "method": "runGenerateLensChecklists",
+      "startLine": 144,
+      "crap": 9
     },
     {
       "path": ".agents/scripts/generate-lens-checklists.js",
       "method": "<anon method-6>",
-      "startLine": 147,
-      "crap": 2
+      "startLine": 168,
+      "crap": 1
     },
     {
       "path": ".agents/scripts/generate-lens-checklists.js",
       "method": "<anon method-7>",
-      "startLine": 148,
+      "startLine": 192,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/generate-lens-checklists.js",
+      "method": "<anon method-8>",
+      "startLine": 193,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/generate-lens-checklists.js",
+      "method": "main",
+      "startLine": 225,
       "crap": 2
     },
     {
@@ -6249,20 +6285,20 @@
     {
       "path": ".agents/scripts/lib/checks/story-init-not-backgrounded.js",
       "method": "walkSources",
-      "startLine": 60,
-      "crap": 21.518518518518523
+      "startLine": 66,
+      "crap": 7
     },
     {
       "path": ".agents/scripts/lib/checks/story-init-not-backgrounded.js",
       "method": "scanFile",
-      "startLine": 101,
-      "crap": 72
+      "startLine": 110,
+      "crap": 8
     },
     {
       "path": ".agents/scripts/lib/checks/story-init-not-backgrounded.js",
       "method": "<anon method-1>",
-      "startLine": 176,
-      "crap": 1.2282235939643347
+      "startLine": 191,
+      "crap": 1
     },
     {
       "path": ".agents/scripts/lib/checks/subagent-agent-tool-required.js",
@@ -9861,31 +9897,31 @@
     {
       "path": ".agents/scripts/lib/git-branch-lifecycle.js",
       "method": "seedStoryBranchRef",
-      "startLine": 158,
-      "crap": 123.75293999270504
+      "startLine": 164,
+      "crap": 11
     },
     {
       "path": ".agents/scripts/lib/git-branch-lifecycle.js",
       "method": "checkoutStoryBranch",
-      "startLine": 212,
+      "startLine": 219,
       "crap": 7
     },
     {
       "path": ".agents/scripts/lib/git-branch-lifecycle.js",
       "method": "<anon method-1>",
-      "startLine": 219,
+      "startLine": 226,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/git-branch-lifecycle.js",
       "method": "ensureLocalBranch",
-      "startLine": 267,
+      "startLine": 274,
       "crap": 2
     },
     {
       "path": ".agents/scripts/lib/git-branch-lifecycle.js",
       "method": "<anon method-2>",
-      "startLine": 269,
+      "startLine": 276,
       "crap": 1
     },
     {
@@ -17091,73 +17127,73 @@
     {
       "path": ".agents/scripts/lib/orchestration/ticket-validator-conflicts.js",
       "method": "computeRegistryFindings",
-      "startLine": 453,
-      "crap": 58.14679107874375
+      "startLine": 467,
+      "crap": 16
     },
     {
       "path": ".agents/scripts/lib/orchestration/ticket-validator-conflicts.js",
       "method": "bump",
-      "startLine": 464,
-      "crap": 4.916
+      "startLine": 478,
+      "crap": 2
     },
     {
       "path": ".agents/scripts/lib/orchestration/ticket-validator-conflicts.js",
       "method": "registryRegistry",
-      "startLine": 566,
-      "crap": 7.226851851851852
+      "startLine": 580,
+      "crap": 7
     },
     {
       "path": ".agents/scripts/lib/orchestration/ticket-validator-conflicts.js",
       "method": "normalizeFanOutProbe",
-      "startLine": 600,
+      "startLine": 614,
       "crap": 6.216378662659654
     },
     {
       "path": ".agents/scripts/lib/orchestration/ticket-validator-conflicts.js",
       "method": "indexCreatedBasenames",
-      "startLine": 616,
+      "startLine": 630,
       "crap": 3
     },
     {
       "path": ".agents/scripts/lib/orchestration/ticket-validator-conflicts.js",
       "method": "computeFanOutFindings",
-      "startLine": 646,
+      "startLine": 660,
       "crap": 9
     },
     {
       "path": ".agents/scripts/lib/orchestration/ticket-validator-conflicts.js",
       "method": "computeConflictFindings",
-      "startLine": 703,
+      "startLine": 717,
       "crap": 8
     },
     {
       "path": ".agents/scripts/lib/orchestration/ticket-validator-conflicts.js",
       "method": "renderFanOutEvidence",
-      "startLine": 768,
+      "startLine": 782,
       "crap": 5
     },
     {
       "path": ".agents/scripts/lib/orchestration/ticket-validator-conflicts.js",
       "method": "renderFanOutRemedy",
-      "startLine": 791,
+      "startLine": 805,
       "crap": 3
     },
     {
       "path": ".agents/scripts/lib/orchestration/ticket-validator-conflicts.js",
       "method": "renderHardConflictError",
-      "startLine": 810,
+      "startLine": 824,
       "crap": 9.21362962962963
     },
     {
       "path": ".agents/scripts/lib/orchestration/ticket-validator-conflicts.js",
       "method": "<anon method-8>",
-      "startLine": 812,
+      "startLine": 826,
       "crap": 1.018962962962963
     },
     {
       "path": ".agents/scripts/lib/orchestration/ticket-validator-conflicts.js",
       "method": "<anon method-9>",
-      "startLine": 819,
+      "startLine": 833,
       "crap": 1.018962962962963
     },
     {
@@ -21496,25 +21532,25 @@
       "path": ".agents/scripts/nav-registry-diff.js",
       "method": "normalizePath",
       "startLine": 89,
-      "crap": 21.748046875
+      "crap": 5
     },
     {
       "path": ".agents/scripts/nav-registry-diff.js",
       "method": "segmentsOf",
       "startLine": 104,
-      "crap": 2
+      "crap": 1
     },
     {
       "path": ".agents/scripts/nav-registry-diff.js",
       "method": "isDynamicSegment",
       "startLine": 116,
-      "crap": 30.1171875
+      "crap": 6
     },
     {
       "path": ".agents/scripts/nav-registry-diff.js",
       "method": "isCatchAllSegment",
       "startLine": 126,
-      "crap": 6
+      "crap": 2
     },
     {
       "path": ".agents/scripts/nav-registry-diff.js",
@@ -21526,91 +21562,97 @@
       "path": ".agents/scripts/nav-registry-diff.js",
       "method": "isSystemRoute",
       "startLine": 147,
-      "crap": 4.314814814814815
+      "crap": 2
     },
     {
       "path": ".agents/scripts/nav-registry-diff.js",
       "method": "parentPath",
       "startLine": 161,
-      "crap": 4.048
+      "crap": 2
     },
     {
       "path": ".agents/scripts/nav-registry-diff.js",
       "method": "routeTemplateMatchesHref",
       "startLine": 177,
-      "crap": 35.269333333333336
+      "crap": 6
     },
     {
       "path": ".agents/scripts/nav-registry-diff.js",
       "method": "toRoute",
       "startLine": 202,
-      "crap": 16.584433318161132
+      "crap": 4
     },
     {
       "path": ".agents/scripts/nav-registry-diff.js",
       "method": "<anon method-1>",
       "startLine": 211,
-      "crap": 5.146108329540283
+      "crap": 2
     },
     {
       "path": ".agents/scripts/nav-registry-diff.js",
       "method": "toDoor",
       "startLine": 223,
-      "crap": 25.01639941690962
+      "crap": 5
     },
     {
       "path": ".agents/scripts/nav-registry-diff.js",
       "method": "doorSurfacesRoute",
       "startLine": 249,
-      "crap": 30
+      "crap": 5
     },
     {
       "path": ".agents/scripts/nav-registry-diff.js",
       "method": "orphanExemption",
       "startLine": 268,
-      "crap": 42
+      "crap": 6
     },
     {
       "path": ".agents/scripts/nav-registry-diff.js",
       "method": "computeNavDiff",
       "startLine": 293,
-      "crap": 28.29606198196385
+      "crap": 5
     },
     {
       "path": ".agents/scripts/nav-registry-diff.js",
       "method": "<anon method-2>",
       "startLine": 296,
-      "crap": 1.931842479278554
+      "crap": 1
     },
     {
       "path": ".agents/scripts/nav-registry-diff.js",
       "method": "<anon method-3>",
       "startLine": 301,
-      "crap": 1.931842479278554
+      "crap": 1
     },
     {
       "path": ".agents/scripts/nav-registry-diff.js",
       "method": "<anon method-4>",
       "startLine": 322,
-      "crap": 5.727369917114216
+      "crap": 2
     },
     {
       "path": ".agents/scripts/nav-registry-diff.js",
       "method": "readJsonArray",
-      "startLine": 345,
-      "crap": 12
+      "startLine": 346,
+      "crap": 3
     },
     {
       "path": ".agents/scripts/nav-registry-diff.js",
       "method": "formatDiffText",
-      "startLine": 380,
-      "crap": 10.774538386783284
+      "startLine": 381,
+      "crap": 3
+    },
+    {
+      "path": ".agents/scripts/nav-registry-diff.js",
+      "method": "runNavRegistryDiff",
+      "startLine": 417,
+      "crap": 8
     },
     {
       "path": ".agents/scripts/nav-registry-diff.js",
       "method": "main",
-      "startLine": 406,
-      "crap": 72
+      "startLine": 462,
+      "crap": 2
     },
     {
       "path": ".agents/scripts/plan-context.js",
@@ -21795,50 +21837,50 @@
     {
       "path": ".agents/scripts/plan-run-epilogue.js",
       "method": "main",
-      "startLine": 32,
-      "crap": 39.60081705484598
+      "startLine": 40,
+      "crap": 6
     },
     {
       "path": ".agents/scripts/plan-run-epilogue.js",
       "method": "<anon method-1>",
-      "startLine": 56,
-      "crap": 1.9333560293012773
+      "startLine": 70,
+      "crap": 1
     },
     {
       "path": ".agents/scripts/plan-run-epilogue.js",
       "method": "<anon method-2>",
-      "startLine": 57,
-      "crap": 5.733424117205109
+      "startLine": 71,
+      "crap": 2
     },
     {
       "path": ".agents/scripts/plan-run-epilogue.js",
       "method": "<anon method-3>",
-      "startLine": 59,
-      "crap": 1.9333560293012773
+      "startLine": 73,
+      "crap": 1
     },
     {
       "path": ".agents/scripts/plan-run-epilogue.js",
       "method": "warnOnUnresolvedBase",
-      "startLine": 89,
-      "crap": 6
+      "startLine": 104,
+      "crap": 2
     },
     {
       "path": ".agents/scripts/plan-run-epilogue.js",
       "method": "<anon method-4>",
-      "startLine": 91,
-      "crap": 2
+      "startLine": 106,
+      "crap": 1
     },
     {
       "path": ".agents/scripts/plan-run-epilogue.js",
       "method": "warnOnEmptyRollup",
-      "startLine": 122,
-      "crap": 6
+      "startLine": 138,
+      "crap": 2
     },
     {
       "path": ".agents/scripts/plan-run-epilogue.js",
       "method": "<anon method-5>",
-      "startLine": 124,
-      "crap": 2
+      "startLine": 140,
+      "crap": 1
     },
     {
       "path": ".agents/scripts/pr-watch-with-update.js",
@@ -22618,18 +22660,18 @@
       "path": ".agents/scripts/resolve-doc-tiers.js",
       "method": "parseArgv",
       "startLine": 31,
-      "crap": 36.013433747201304
+      "crap": 6
     },
     {
       "path": ".agents/scripts/resolve-doc-tiers.js",
       "method": "runCli",
-      "startLine": 61,
-      "crap": 1.7865270823850707
+      "startLine": 70,
+      "crap": 1
     },
     {
       "path": ".agents/scripts/resolve-doc-tiers.js",
       "method": "main",
-      "startLine": 75,
+      "startLine": 85,
       "crap": 2
     },
     {
@@ -24201,37 +24243,37 @@
     {
       "path": "lib/cli/version-helpers.js",
       "method": "parseVersion",
-      "startLine": 34,
+      "startLine": 41,
       "crap": 4
     },
     {
       "path": "lib/cli/version-helpers.js",
       "method": "compareVersions",
-      "startLine": 51,
+      "startLine": 58,
       "crap": 3
     },
     {
       "path": "lib/cli/version-helpers.js",
       "method": "crossesMajor",
-      "startLine": 69,
-      "crap": 1.2962962962962963
+      "startLine": 76,
+      "crap": 1
     },
     {
       "path": "lib/cli/version-helpers.js",
       "method": "satisfiesPinSpec",
-      "startLine": 98,
-      "crap": 60.734375
+      "startLine": 105,
+      "crap": 8
     },
     {
       "path": "lib/cli/version-helpers.js",
       "method": "resolveConsumerPinSpec",
-      "startLine": 135,
-      "crap": 3.0052083333333335
+      "startLine": 142,
+      "crap": 3
     },
     {
       "path": "lib/cli/version-helpers.js",
       "method": "resolveConsumerPinVersion",
-      "startLine": 188,
+      "startLine": 195,
       "crap": 1
     },
     {
@@ -24327,38 +24369,38 @@
     {
       "path": "lib/migrations/steps/2.2.0-retire-epic-ac-tags.js",
       "method": "collectFeatureFiles",
-      "startLine": 46,
-      "crap": 30
+      "startLine": 47,
+      "crap": 5
     },
     {
       "path": "lib/migrations/steps/2.2.0-retire-epic-ac-tags.js",
       "method": "resolveFeatureFiles",
-      "startLine": 78,
-      "crap": 2
+      "startLine": 81,
+      "crap": 1
     },
     {
       "path": "lib/migrations/steps/2.2.0-retire-epic-ac-tags.js",
       "method": "<anon method-1>",
-      "startLine": 80,
-      "crap": 2
+      "startLine": 83,
+      "crap": 1
     },
     {
       "path": "lib/migrations/steps/2.2.0-retire-epic-ac-tags.js",
       "method": "stripEpicAcTags",
-      "startLine": 93,
-      "crap": 42
+      "startLine": 96,
+      "crap": 6
     },
     {
       "path": "lib/migrations/steps/2.2.0-retire-epic-ac-tags.js",
       "method": "<anon method-2>",
-      "startLine": 108,
-      "crap": 2
+      "startLine": 111,
+      "crap": 1
     },
     {
       "path": "lib/migrations/steps/2.2.0-retire-epic-ac-tags.js",
       "method": "<anon method-3>",
-      "startLine": 126,
-      "crap": 1.512
+      "startLine": 131,
+      "crap": 1
     }
   ]
 }

--- a/baselines/crap.json
+++ b/baselines/crap.json
@@ -1,64 +1,70 @@
 {
   "$schema": ".agents/schemas/baselines/crap.schema.json",
   "kernelVersion": "0.1.0",
-  "generatedAt": "2026-07-26T14:13:00.471Z",
+  "generatedAt": "2026-07-26T14:44:02.481Z",
   "scoringSemantics": "coverage-join-v2",
   "rollup": {
     "*": {
       "p50": 2,
-      "p95": 11.020747599451303,
-      "max": 123.75293999270504,
-      "methodsAbove20": 40
+      "p95": 10.58179012345679,
+      "max": 30,
+      "methodsAbove20": 13
     }
   },
   "rows": [
     {
       "path": ".agents/scripts/acceptance-eval.js",
       "method": "getVerdictValidator",
-      "startLine": 94,
-      "crap": 2
+      "startLine": 98,
+      "crap": 1
     },
     {
       "path": ".agents/scripts/acceptance-eval.js",
       "method": "validateVerdict",
-      "startLine": 116,
+      "startLine": 118,
       "crap": 2
     },
     {
       "path": ".agents/scripts/acceptance-eval.js",
       "method": "<anon method-1>",
-      "startLine": 123,
+      "startLine": 125,
       "crap": 2
     },
     {
       "path": ".agents/scripts/acceptance-eval.js",
       "method": "parseCliArgs",
-      "startLine": 132,
-      "crap": 12
+      "startLine": 134,
+      "crap": 3
     },
     {
       "path": ".agents/scripts/acceptance-eval.js",
       "method": "runAcceptanceEval",
-      "startLine": 170,
+      "startLine": 172,
       "crap": 6
     },
     {
       "path": ".agents/scripts/acceptance-eval.js",
       "method": "<anon method-2>",
-      "startLine": 222,
+      "startLine": 224,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/acceptance-eval.js",
+      "method": "runAcceptanceEvalCli",
+      "startLine": 260,
+      "crap": 8
+    },
+    {
+      "path": ".agents/scripts/acceptance-eval.js",
+      "method": "<anon method-3>",
+      "startLine": 326,
       "crap": 1
     },
     {
       "path": ".agents/scripts/acceptance-eval.js",
       "method": "main",
-      "startLine": 238,
-      "crap": 69.13476361410247
-    },
-    {
-      "path": ".agents/scripts/acceptance-eval.js",
-      "method": "<anon method-3>",
-      "startLine": 294,
-      "crap": 1.955230681470351
+      "startLine": 341,
+      "crap": 1.2962962962962963
     },
     {
       "path": ".agents/scripts/apply-quality-bootstrap.js",
@@ -124,31 +130,31 @@
       "path": ".agents/scripts/audit-to-stories.js",
       "method": "meetsSeverity",
       "startLine": 57,
-      "crap": 12
+      "crap": 3
     },
     {
       "path": ".agents/scripts/audit-to-stories.js",
       "method": "collectReportPaths",
       "startLine": 64,
-      "crap": 6
+      "crap": 2
     },
     {
       "path": ".agents/scripts/audit-to-stories.js",
       "method": "readReports",
       "startLine": 73,
-      "crap": 2
+      "crap": 1
     },
     {
       "path": ".agents/scripts/audit-to-stories.js",
       "method": "<anon method-1>",
       "startLine": 74,
-      "crap": 2
+      "crap": 1
     },
     {
       "path": ".agents/scripts/audit-to-stories.js",
       "method": "tallyBySeverity",
       "startLine": 80,
-      "crap": 6
+      "crap": 2.0078125
     },
     {
       "path": ".agents/scripts/audit-to-stories.js",
@@ -178,156 +184,162 @@
       "path": ".agents/scripts/audit-to-stories.js",
       "method": "dedupSkippedWarning",
       "startLine": 183,
-      "crap": 6
+      "crap": 2
     },
     {
       "path": ".agents/scripts/audit-to-stories.js",
       "method": "dedupDegradedWarning",
       "startLine": 217,
-      "crap": 2
+      "crap": 1
     },
     {
       "path": ".agents/scripts/audit-to-stories.js",
       "method": "<anon method-4>",
       "startLine": 218,
-      "crap": 2
+      "crap": 1
     },
     {
       "path": ".agents/scripts/audit-to-stories.js",
       "method": "buildPlan",
-      "startLine": 227,
-      "crap": 110
+      "startLine": 246,
+      "crap": 10
     },
     {
       "path": ".agents/scripts/audit-to-stories.js",
       "method": "<anon method-5>",
-      "startLine": 250,
-      "crap": 2
+      "startLine": 280,
+      "crap": 1
     },
     {
       "path": ".agents/scripts/audit-to-stories.js",
       "method": "<anon method-6>",
-      "startLine": 254,
-      "crap": 2
+      "startLine": 284,
+      "crap": 1
     },
     {
       "path": ".agents/scripts/audit-to-stories.js",
       "method": "<anon method-7>",
-      "startLine": 310,
-      "crap": 2
+      "startLine": 340,
+      "crap": 1
     },
     {
       "path": ".agents/scripts/audit-to-stories.js",
       "method": "reconcileScanLedger",
-      "startLine": 353,
-      "crap": 6
+      "startLine": 383,
+      "crap": 2
     },
     {
       "path": ".agents/scripts/audit-to-stories.js",
       "method": "<anon method-8>",
-      "startLine": 364,
-      "crap": 2
+      "startLine": 394,
+      "crap": 1
     },
     {
       "path": ".agents/scripts/audit-to-stories.js",
       "method": "<anon method-9>",
-      "startLine": 365,
-      "crap": 2
+      "startLine": 395,
+      "crap": 1
     },
     {
       "path": ".agents/scripts/audit-to-stories.js",
       "method": "issueStatesFromClassifications",
-      "startLine": 375,
-      "crap": 12
+      "startLine": 405,
+      "crap": 3.059326171875
     },
     {
       "path": ".agents/scripts/audit-to-stories.js",
       "method": "loadPlan",
-      "startLine": 392,
+      "startLine": 422,
       "crap": 6
     },
     {
       "path": ".agents/scripts/audit-to-stories.js",
       "method": "resolveSeverityFloor",
-      "startLine": 408,
-      "crap": 20
-    },
-    {
-      "path": ".agents/scripts/audit-to-stories.js",
-      "method": "runAuto",
-      "startLine": 436,
-      "crap": 42
-    },
-    {
-      "path": ".agents/scripts/audit-to-stories.js",
-      "method": "<anon method-10>",
-      "startLine": 458,
-      "crap": 2
-    },
-    {
-      "path": ".agents/scripts/audit-to-stories.js",
-      "method": "<anon method-11>",
-      "startLine": 477,
-      "crap": 2
-    },
-    {
-      "path": ".agents/scripts/audit-to-stories.js",
-      "method": "<anon method-12>",
-      "startLine": 478,
-      "crap": 2
-    },
-    {
-      "path": ".agents/scripts/audit-to-stories.js",
-      "method": "<anon method-13>",
-      "startLine": 479,
-      "crap": 2
-    },
-    {
-      "path": ".agents/scripts/audit-to-stories.js",
-      "method": "buildAndGateStories",
-      "startLine": 502,
-      "crap": 42
-    },
-    {
-      "path": ".agents/scripts/audit-to-stories.js",
-      "method": "<anon method-14>",
-      "startLine": 503,
-      "crap": 2
-    },
-    {
-      "path": ".agents/scripts/audit-to-stories.js",
-      "method": "<anon method-15>",
-      "startLine": 517,
-      "crap": 2
-    },
-    {
-      "path": ".agents/scripts/audit-to-stories.js",
-      "method": "persist",
-      "startLine": 526,
+      "startLine": 438,
       "crap": 6
     },
     {
       "path": ".agents/scripts/audit-to-stories.js",
-      "method": "main",
-      "startLine": 549,
-      "crap": 90
+      "method": "runAuto",
+      "startLine": 466,
+      "crap": 6.008261863679249
+    },
+    {
+      "path": ".agents/scripts/audit-to-stories.js",
+      "method": "<anon method-10>",
+      "startLine": 488,
+      "crap": 1.0002294962133125
+    },
+    {
+      "path": ".agents/scripts/audit-to-stories.js",
+      "method": "<anon method-11>",
+      "startLine": 507,
+      "crap": 1.0002294962133125
+    },
+    {
+      "path": ".agents/scripts/audit-to-stories.js",
+      "method": "<anon method-12>",
+      "startLine": 508,
+      "crap": 1.0002294962133125
+    },
+    {
+      "path": ".agents/scripts/audit-to-stories.js",
+      "method": "<anon method-13>",
+      "startLine": 509,
+      "crap": 1.0002294962133125
+    },
+    {
+      "path": ".agents/scripts/audit-to-stories.js",
+      "method": "buildAndGateStories",
+      "startLine": 532,
+      "crap": 7.5149173995233
+    },
+    {
+      "path": ".agents/scripts/audit-to-stories.js",
+      "method": "<anon method-14>",
+      "startLine": 533,
+      "crap": 1.0420810388756472
+    },
+    {
+      "path": ".agents/scripts/audit-to-stories.js",
+      "method": "<anon method-15>",
+      "startLine": 547,
+      "crap": 1.0420810388756472
+    },
+    {
+      "path": ".agents/scripts/audit-to-stories.js",
+      "method": "persist",
+      "startLine": 556,
+      "crap": 6
+    },
+    {
+      "path": ".agents/scripts/audit-to-stories.js",
+      "method": "runAuditToStories",
+      "startLine": 600,
+      "crap": 9
     },
     {
       "path": ".agents/scripts/audit-to-stories.js",
       "method": "<anon method-16>",
-      "startLine": 608,
-      "crap": 2
+      "startLine": 671,
+      "crap": 1
     },
     {
       "path": ".agents/scripts/audit-to-stories.js",
       "method": "<anon method-17>",
-      "startLine": 609,
-      "crap": 2
+      "startLine": 672,
+      "crap": 1
     },
     {
       "path": ".agents/scripts/audit-to-stories.js",
       "method": "<anon method-18>",
-      "startLine": 615,
+      "startLine": 678,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/audit-to-stories.js",
+      "method": "main",
+      "startLine": 692,
       "crap": 2
     },
     {
@@ -356,9 +368,15 @@
     },
     {
       "path": ".agents/scripts/boot-sweep.js",
+      "method": "runBootSweepCli",
+      "startLine": 192,
+      "crap": 8
+    },
+    {
+      "path": ".agents/scripts/boot-sweep.js",
       "method": "main",
-      "startLine": 179,
-      "crap": 72
+      "startLine": 233,
+      "crap": 2
     },
     {
       "path": ".agents/scripts/bootstrap.js",
@@ -1695,19 +1713,19 @@
     {
       "path": ".agents/scripts/coverage-capture.js",
       "method": "parseArgs",
-      "startLine": 38,
-      "crap": 5.009110787172012
+      "startLine": 45,
+      "crap": 5
     },
     {
       "path": ".agents/scripts/coverage-capture.js",
-      "method": "main",
-      "startLine": 53,
-      "crap": 42.69245541838134
+      "method": "runCoverageCapture",
+      "startLine": 85,
+      "crap": 10
     },
     {
       "path": ".agents/scripts/coverage-capture.js",
       "method": "<anon method-1>",
-      "startLine": 117,
+      "startLine": 161,
       "crap": 1
     },
     {
@@ -1810,13 +1828,13 @@
       "path": ".agents/scripts/deliver-recover.js",
       "method": "parseArgv",
       "startLine": 62,
-      "crap": 1.8573749999999998
+      "crap": 1
     },
     {
       "path": ".agents/scripts/deliver-recover.js",
       "method": "runDeliverRecover",
-      "startLine": 86,
-      "crap": 85.41621387118798
+      "startLine": 102,
+      "crap": 9
     },
     {
       "path": ".agents/scripts/diagnose.js",
@@ -1892,68 +1910,74 @@
     },
     {
       "path": ".agents/scripts/drain-pending-cleanup.js",
-      "method": "main",
-      "startLine": 42,
-      "crap": 110
+      "method": "runDrainPendingCleanup",
+      "startLine": 64,
+      "crap": 10
     },
     {
       "path": ".agents/scripts/drain-pending-cleanup.js",
       "method": "<anon method-1>",
-      "startLine": 68,
-      "crap": 2
+      "startLine": 107,
+      "crap": 1
     },
     {
       "path": ".agents/scripts/drain-pending-cleanup.js",
       "method": "<anon method-2>",
-      "startLine": 79,
-      "crap": 2
+      "startLine": 118,
+      "crap": 1
     },
     {
       "path": ".agents/scripts/drain-pending-cleanup.js",
       "method": "<anon method-3>",
-      "startLine": 92,
-      "crap": 2
+      "startLine": 131,
+      "crap": 1
     },
     {
       "path": ".agents/scripts/drain-pending-cleanup.js",
       "method": "<anon method-4>",
-      "startLine": 93,
-      "crap": 2
+      "startLine": 132,
+      "crap": 1
     },
     {
       "path": ".agents/scripts/drain-pending-cleanup.js",
       "method": "<anon method-5>",
-      "startLine": 94,
-      "crap": 2
+      "startLine": 133,
+      "crap": 1
     },
     {
       "path": ".agents/scripts/drain-pending-cleanup.js",
       "method": "<anon method-6>",
-      "startLine": 102,
-      "crap": 2
+      "startLine": 141,
+      "crap": 1
     },
     {
       "path": ".agents/scripts/drain-pending-cleanup.js",
       "method": "<anon method-7>",
-      "startLine": 108,
-      "crap": 2
+      "startLine": 147,
+      "crap": 1
     },
     {
       "path": ".agents/scripts/drain-pending-cleanup.js",
       "method": "<anon method-8>",
-      "startLine": 116,
-      "crap": 2
+      "startLine": 155,
+      "crap": 1
     },
     {
       "path": ".agents/scripts/drain-pending-cleanup.js",
       "method": "<anon method-9>",
-      "startLine": 126,
-      "crap": 2
+      "startLine": 165,
+      "crap": 1
     },
     {
       "path": ".agents/scripts/drain-pending-cleanup.js",
       "method": "<anon method-10>",
-      "startLine": 134,
+      "startLine": 173,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/drain-pending-cleanup.js",
+      "method": "main",
+      "startLine": 187,
       "crap": 2
     },
     {
@@ -2193,55 +2217,67 @@
     {
       "path": ".agents/scripts/generate-lens-checklists.js",
       "method": "<anon method-1>",
-      "startLine": 87,
+      "startLine": 92,
       "crap": 1
     },
     {
       "path": ".agents/scripts/generate-lens-checklists.js",
       "method": "<anon method-2>",
-      "startLine": 90,
-      "crap": 1
-    },
-    {
-      "path": ".agents/scripts/generate-lens-checklists.js",
-      "method": "<anon method-3>",
-      "startLine": 91,
-      "crap": 1
-    },
-    {
-      "path": ".agents/scripts/generate-lens-checklists.js",
-      "method": "<anon method-4>",
       "startLine": 95,
       "crap": 1
     },
     {
       "path": ".agents/scripts/generate-lens-checklists.js",
+      "method": "<anon method-3>",
+      "startLine": 96,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/generate-lens-checklists.js",
+      "method": "<anon method-4>",
+      "startLine": 100,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/generate-lens-checklists.js",
       "method": "<anon method-5>",
-      "startLine": 97,
+      "startLine": 102,
       "crap": 1
     },
     {
       "path": ".agents/scripts/generate-lens-checklists.js",
       "method": "relChecklist",
-      "startLine": 106,
-      "crap": 2
+      "startLine": 113,
+      "crap": 1
     },
     {
       "path": ".agents/scripts/generate-lens-checklists.js",
-      "method": "main",
-      "startLine": 116,
-      "crap": 90
+      "method": "runGenerateLensChecklists",
+      "startLine": 144,
+      "crap": 9
     },
     {
       "path": ".agents/scripts/generate-lens-checklists.js",
       "method": "<anon method-6>",
-      "startLine": 147,
-      "crap": 2
+      "startLine": 168,
+      "crap": 1
     },
     {
       "path": ".agents/scripts/generate-lens-checklists.js",
       "method": "<anon method-7>",
-      "startLine": 148,
+      "startLine": 192,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/generate-lens-checklists.js",
+      "method": "<anon method-8>",
+      "startLine": 193,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/generate-lens-checklists.js",
+      "method": "main",
+      "startLine": 225,
       "crap": 2
     },
     {
@@ -6249,20 +6285,20 @@
     {
       "path": ".agents/scripts/lib/checks/story-init-not-backgrounded.js",
       "method": "walkSources",
-      "startLine": 60,
-      "crap": 21.518518518518523
+      "startLine": 66,
+      "crap": 7
     },
     {
       "path": ".agents/scripts/lib/checks/story-init-not-backgrounded.js",
       "method": "scanFile",
-      "startLine": 101,
-      "crap": 72
+      "startLine": 110,
+      "crap": 8
     },
     {
       "path": ".agents/scripts/lib/checks/story-init-not-backgrounded.js",
       "method": "<anon method-1>",
-      "startLine": 176,
-      "crap": 1.2282235939643347
+      "startLine": 191,
+      "crap": 1
     },
     {
       "path": ".agents/scripts/lib/checks/subagent-agent-tool-required.js",
@@ -9861,31 +9897,31 @@
     {
       "path": ".agents/scripts/lib/git-branch-lifecycle.js",
       "method": "seedStoryBranchRef",
-      "startLine": 158,
-      "crap": 123.75293999270504
+      "startLine": 164,
+      "crap": 11
     },
     {
       "path": ".agents/scripts/lib/git-branch-lifecycle.js",
       "method": "checkoutStoryBranch",
-      "startLine": 212,
+      "startLine": 219,
       "crap": 7
     },
     {
       "path": ".agents/scripts/lib/git-branch-lifecycle.js",
       "method": "<anon method-1>",
-      "startLine": 219,
+      "startLine": 226,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/git-branch-lifecycle.js",
       "method": "ensureLocalBranch",
-      "startLine": 267,
+      "startLine": 274,
       "crap": 2
     },
     {
       "path": ".agents/scripts/lib/git-branch-lifecycle.js",
       "method": "<anon method-2>",
-      "startLine": 269,
+      "startLine": 276,
       "crap": 1
     },
     {
@@ -17115,73 +17151,73 @@
     {
       "path": ".agents/scripts/lib/orchestration/ticket-validator-conflicts.js",
       "method": "computeRegistryFindings",
-      "startLine": 453,
-      "crap": 58.14679107874375
+      "startLine": 467,
+      "crap": 16
     },
     {
       "path": ".agents/scripts/lib/orchestration/ticket-validator-conflicts.js",
       "method": "bump",
-      "startLine": 464,
-      "crap": 4.916
+      "startLine": 478,
+      "crap": 2
     },
     {
       "path": ".agents/scripts/lib/orchestration/ticket-validator-conflicts.js",
       "method": "registryRegistry",
-      "startLine": 566,
-      "crap": 7.226851851851852
+      "startLine": 580,
+      "crap": 7
     },
     {
       "path": ".agents/scripts/lib/orchestration/ticket-validator-conflicts.js",
       "method": "normalizeFanOutProbe",
-      "startLine": 600,
+      "startLine": 614,
       "crap": 6.216378662659654
     },
     {
       "path": ".agents/scripts/lib/orchestration/ticket-validator-conflicts.js",
       "method": "indexCreatedBasenames",
-      "startLine": 616,
+      "startLine": 630,
       "crap": 3
     },
     {
       "path": ".agents/scripts/lib/orchestration/ticket-validator-conflicts.js",
       "method": "computeFanOutFindings",
-      "startLine": 646,
+      "startLine": 660,
       "crap": 9
     },
     {
       "path": ".agents/scripts/lib/orchestration/ticket-validator-conflicts.js",
       "method": "computeConflictFindings",
-      "startLine": 703,
+      "startLine": 717,
       "crap": 8
     },
     {
       "path": ".agents/scripts/lib/orchestration/ticket-validator-conflicts.js",
       "method": "renderFanOutEvidence",
-      "startLine": 768,
+      "startLine": 782,
       "crap": 5
     },
     {
       "path": ".agents/scripts/lib/orchestration/ticket-validator-conflicts.js",
       "method": "renderFanOutRemedy",
-      "startLine": 791,
+      "startLine": 805,
       "crap": 3
     },
     {
       "path": ".agents/scripts/lib/orchestration/ticket-validator-conflicts.js",
       "method": "renderHardConflictError",
-      "startLine": 810,
+      "startLine": 824,
       "crap": 9.21362962962963
     },
     {
       "path": ".agents/scripts/lib/orchestration/ticket-validator-conflicts.js",
       "method": "<anon method-8>",
-      "startLine": 812,
+      "startLine": 826,
       "crap": 1.018962962962963
     },
     {
       "path": ".agents/scripts/lib/orchestration/ticket-validator-conflicts.js",
       "method": "<anon method-9>",
-      "startLine": 819,
+      "startLine": 833,
       "crap": 1.018962962962963
     },
     {
@@ -21544,25 +21580,25 @@
       "path": ".agents/scripts/nav-registry-diff.js",
       "method": "normalizePath",
       "startLine": 89,
-      "crap": 21.748046875
+      "crap": 5
     },
     {
       "path": ".agents/scripts/nav-registry-diff.js",
       "method": "segmentsOf",
       "startLine": 104,
-      "crap": 2
+      "crap": 1
     },
     {
       "path": ".agents/scripts/nav-registry-diff.js",
       "method": "isDynamicSegment",
       "startLine": 116,
-      "crap": 30.1171875
+      "crap": 6
     },
     {
       "path": ".agents/scripts/nav-registry-diff.js",
       "method": "isCatchAllSegment",
       "startLine": 126,
-      "crap": 6
+      "crap": 2
     },
     {
       "path": ".agents/scripts/nav-registry-diff.js",
@@ -21574,91 +21610,97 @@
       "path": ".agents/scripts/nav-registry-diff.js",
       "method": "isSystemRoute",
       "startLine": 147,
-      "crap": 4.314814814814815
+      "crap": 2
     },
     {
       "path": ".agents/scripts/nav-registry-diff.js",
       "method": "parentPath",
       "startLine": 161,
-      "crap": 4.048
+      "crap": 2
     },
     {
       "path": ".agents/scripts/nav-registry-diff.js",
       "method": "routeTemplateMatchesHref",
       "startLine": 177,
-      "crap": 35.269333333333336
+      "crap": 6
     },
     {
       "path": ".agents/scripts/nav-registry-diff.js",
       "method": "toRoute",
       "startLine": 202,
-      "crap": 16.584433318161132
+      "crap": 4
     },
     {
       "path": ".agents/scripts/nav-registry-diff.js",
       "method": "<anon method-1>",
       "startLine": 211,
-      "crap": 5.146108329540283
+      "crap": 2
     },
     {
       "path": ".agents/scripts/nav-registry-diff.js",
       "method": "toDoor",
       "startLine": 223,
-      "crap": 25.01639941690962
+      "crap": 5
     },
     {
       "path": ".agents/scripts/nav-registry-diff.js",
       "method": "doorSurfacesRoute",
       "startLine": 249,
-      "crap": 30
+      "crap": 5
     },
     {
       "path": ".agents/scripts/nav-registry-diff.js",
       "method": "orphanExemption",
       "startLine": 268,
-      "crap": 42
+      "crap": 6
     },
     {
       "path": ".agents/scripts/nav-registry-diff.js",
       "method": "computeNavDiff",
       "startLine": 293,
-      "crap": 28.29606198196385
+      "crap": 5
     },
     {
       "path": ".agents/scripts/nav-registry-diff.js",
       "method": "<anon method-2>",
       "startLine": 296,
-      "crap": 1.931842479278554
+      "crap": 1
     },
     {
       "path": ".agents/scripts/nav-registry-diff.js",
       "method": "<anon method-3>",
       "startLine": 301,
-      "crap": 1.931842479278554
+      "crap": 1
     },
     {
       "path": ".agents/scripts/nav-registry-diff.js",
       "method": "<anon method-4>",
       "startLine": 322,
-      "crap": 5.727369917114216
+      "crap": 2
     },
     {
       "path": ".agents/scripts/nav-registry-diff.js",
       "method": "readJsonArray",
-      "startLine": 345,
-      "crap": 12
+      "startLine": 346,
+      "crap": 3
     },
     {
       "path": ".agents/scripts/nav-registry-diff.js",
       "method": "formatDiffText",
-      "startLine": 380,
-      "crap": 10.774538386783284
+      "startLine": 381,
+      "crap": 3
+    },
+    {
+      "path": ".agents/scripts/nav-registry-diff.js",
+      "method": "runNavRegistryDiff",
+      "startLine": 417,
+      "crap": 8
     },
     {
       "path": ".agents/scripts/nav-registry-diff.js",
       "method": "main",
-      "startLine": 406,
-      "crap": 72
+      "startLine": 462,
+      "crap": 2
     },
     {
       "path": ".agents/scripts/plan-context.js",
@@ -21843,50 +21885,50 @@
     {
       "path": ".agents/scripts/plan-run-epilogue.js",
       "method": "main",
-      "startLine": 32,
-      "crap": 39.60081705484598
+      "startLine": 40,
+      "crap": 6
     },
     {
       "path": ".agents/scripts/plan-run-epilogue.js",
       "method": "<anon method-1>",
-      "startLine": 56,
-      "crap": 1.9333560293012773
+      "startLine": 70,
+      "crap": 1
     },
     {
       "path": ".agents/scripts/plan-run-epilogue.js",
       "method": "<anon method-2>",
-      "startLine": 57,
-      "crap": 5.733424117205109
+      "startLine": 71,
+      "crap": 2
     },
     {
       "path": ".agents/scripts/plan-run-epilogue.js",
       "method": "<anon method-3>",
-      "startLine": 59,
-      "crap": 1.9333560293012773
+      "startLine": 73,
+      "crap": 1
     },
     {
       "path": ".agents/scripts/plan-run-epilogue.js",
       "method": "warnOnUnresolvedBase",
-      "startLine": 89,
-      "crap": 6
+      "startLine": 104,
+      "crap": 2
     },
     {
       "path": ".agents/scripts/plan-run-epilogue.js",
       "method": "<anon method-4>",
-      "startLine": 91,
-      "crap": 2
+      "startLine": 106,
+      "crap": 1
     },
     {
       "path": ".agents/scripts/plan-run-epilogue.js",
       "method": "warnOnEmptyRollup",
-      "startLine": 122,
-      "crap": 6
+      "startLine": 138,
+      "crap": 2
     },
     {
       "path": ".agents/scripts/plan-run-epilogue.js",
       "method": "<anon method-5>",
-      "startLine": 124,
-      "crap": 2
+      "startLine": 140,
+      "crap": 1
     },
     {
       "path": ".agents/scripts/pr-watch-with-update.js",
@@ -22666,18 +22708,18 @@
       "path": ".agents/scripts/resolve-doc-tiers.js",
       "method": "parseArgv",
       "startLine": 31,
-      "crap": 36.013433747201304
+      "crap": 6
     },
     {
       "path": ".agents/scripts/resolve-doc-tiers.js",
       "method": "runCli",
-      "startLine": 61,
-      "crap": 1.7865270823850707
+      "startLine": 70,
+      "crap": 1
     },
     {
       "path": ".agents/scripts/resolve-doc-tiers.js",
       "method": "main",
-      "startLine": 75,
+      "startLine": 85,
       "crap": 2
     },
     {
@@ -24237,37 +24279,37 @@
     {
       "path": "lib/cli/version-helpers.js",
       "method": "parseVersion",
-      "startLine": 34,
+      "startLine": 41,
       "crap": 4
     },
     {
       "path": "lib/cli/version-helpers.js",
       "method": "compareVersions",
-      "startLine": 51,
+      "startLine": 58,
       "crap": 3
     },
     {
       "path": "lib/cli/version-helpers.js",
       "method": "crossesMajor",
-      "startLine": 69,
-      "crap": 1.2962962962962963
+      "startLine": 76,
+      "crap": 1
     },
     {
       "path": "lib/cli/version-helpers.js",
       "method": "satisfiesPinSpec",
-      "startLine": 98,
-      "crap": 60.734375
+      "startLine": 105,
+      "crap": 8
     },
     {
       "path": "lib/cli/version-helpers.js",
       "method": "resolveConsumerPinSpec",
-      "startLine": 135,
-      "crap": 3.0052083333333335
+      "startLine": 142,
+      "crap": 3
     },
     {
       "path": "lib/cli/version-helpers.js",
       "method": "resolveConsumerPinVersion",
-      "startLine": 188,
+      "startLine": 195,
       "crap": 1
     },
     {
@@ -24363,38 +24405,38 @@
     {
       "path": "lib/migrations/steps/2.2.0-retire-epic-ac-tags.js",
       "method": "collectFeatureFiles",
-      "startLine": 46,
-      "crap": 30
+      "startLine": 47,
+      "crap": 5
     },
     {
       "path": "lib/migrations/steps/2.2.0-retire-epic-ac-tags.js",
       "method": "resolveFeatureFiles",
-      "startLine": 78,
-      "crap": 2
+      "startLine": 81,
+      "crap": 1
     },
     {
       "path": "lib/migrations/steps/2.2.0-retire-epic-ac-tags.js",
       "method": "<anon method-1>",
-      "startLine": 80,
-      "crap": 2
+      "startLine": 83,
+      "crap": 1
     },
     {
       "path": "lib/migrations/steps/2.2.0-retire-epic-ac-tags.js",
       "method": "stripEpicAcTags",
-      "startLine": 93,
-      "crap": 42
+      "startLine": 96,
+      "crap": 6
     },
     {
       "path": "lib/migrations/steps/2.2.0-retire-epic-ac-tags.js",
       "method": "<anon method-2>",
-      "startLine": 108,
-      "crap": 2
+      "startLine": 111,
+      "crap": 1
     },
     {
       "path": "lib/migrations/steps/2.2.0-retire-epic-ac-tags.js",
       "method": "<anon method-3>",
-      "startLine": 126,
-      "crap": 1.512
+      "startLine": 131,
+      "crap": 1
     }
   ]
 }

--- a/lib/cli/version-helpers.js
+++ b/lib/cli/version-helpers.js
@@ -16,6 +16,13 @@
  * Builtins only — this module is imported from both the CLI surface
  * (`lib/cli/`) and the doctor registry which runs before third-party
  * packages are guaranteed to be present.
+ *
+ * The two filesystem-touching helpers below take the module's injectable
+ * seam as their optional final `fsImpl` parameter, defaulting to the real
+ * `node:fs` (`.agents/rules/test-seams.md` rules 1-2);
+ * `resolveConsumerPinVersion` forwards that seam to
+ * `resolveConsumerPinSpec` rather than re-acquiring `fs` itself (rule 4).
+ * Every other export here is pure, so it needs no seam of its own.
  */
 
 import nodeFs from 'node:fs';

--- a/lib/migrations/steps/2.2.0-retire-epic-ac-tags.js
+++ b/lib/migrations/steps/2.2.0-retire-epic-ac-tags.js
@@ -40,10 +40,11 @@ const TAG_LINE_RE = /^(\s*)(@\S+(?:\s+@\S+)*)\s*$/;
  * Recursively collect `.feature` file paths under `root`.
  *
  * @param {string} root
- * @param {typeof nodeFs} fsImpl
+ * @param {typeof nodeFs} [fsImpl] Filesystem seam; defaults to the real
+ *   `node:fs` per `.agents/rules/test-seams.md` rule 1.
  * @returns {string[]}
  */
-function collectFeatureFiles(root, fsImpl) {
+function collectFeatureFiles(root, fsImpl = nodeFs) {
   /** @type {string[]} */
   const found = [];
   /** @type {string[]} */
@@ -71,11 +72,13 @@ function collectFeatureFiles(root, fsImpl) {
 
 /**
  * @param {unknown} ctx
- * @param {typeof nodeFs} fsImpl
+ * @param {typeof nodeFs} [fsImpl] Filesystem seam; forwarded to
+ *   {@link collectFeatureFiles} rather than re-acquired there
+ *   (`.agents/rules/test-seams.md` rule 4).
  * @returns {string[]} Absolute paths of every `.feature` file under the
  *   canonical feature roots that exist in the consumer tree.
  */
-function resolveFeatureFiles(ctx, fsImpl) {
+function resolveFeatureFiles(ctx, fsImpl = nodeFs) {
   const projectRoot = ctx?.projectRoot ?? process.cwd();
   return CANONICAL_FEATURE_ROOTS.flatMap((root) =>
     collectFeatureFiles(path.join(projectRoot, root), fsImpl),
@@ -119,10 +122,12 @@ export const retireEpicAcTags = {
     '(their reconciler consumer was deleted in the v2 Epic removal)',
   /**
    * @param {{ projectRoot?: string, fs?: typeof nodeFs }} [ctx]
+   * @param {typeof nodeFs} [fsImpl] Optional final filesystem seam; defaults
+   *   to `ctx.fs` when the migration runner threads one, else the real
+   *   `node:fs` (`.agents/rules/test-seams.md` rule 1).
    * @returns {boolean}
    */
-  detect(ctx) {
-    const fsImpl = ctx?.fs ?? nodeFs;
+  detect(ctx, fsImpl = ctx?.fs ?? nodeFs) {
     return resolveFeatureFiles(ctx, fsImpl).some((file) => {
       try {
         return EPIC_AC_TAG_RE.test(fsImpl.readFileSync(file, 'utf8'));
@@ -133,10 +138,12 @@ export const retireEpicAcTags = {
   },
   /**
    * @param {{ projectRoot?: string, fs?: typeof nodeFs }} [ctx]
+   * @param {typeof nodeFs} [fsImpl] Optional final filesystem seam; defaults
+   *   to `ctx.fs` when the migration runner threads one, else the real
+   *   `node:fs` (`.agents/rules/test-seams.md` rule 1).
    * @returns {void}
    */
-  apply(ctx) {
-    const fsImpl = ctx?.fs ?? nodeFs;
+  apply(ctx, fsImpl = ctx?.fs ?? nodeFs) {
     for (const file of resolveFeatureFiles(ctx, fsImpl)) {
       /** @type {string} */
       let content;

--- a/tests/acceptance-eval.test.js
+++ b/tests/acceptance-eval.test.js
@@ -1,0 +1,227 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import {
+  runAcceptanceEvalCli,
+  validateVerdict,
+} from '../.agents/scripts/acceptance-eval.js';
+
+/**
+ * Story #4780 — `main` scored CRAP 69.1: the gate's whole error table
+ * (missing flags, unreadable verdict, non-JSON verdict, storyId mismatch,
+ * block) was unreached, on the CLI that decides whether a Story may close.
+ *
+ * The verdict reader, config resolver, decision core, and log sink are
+ * injected through the optional final `deps` parameter
+ * (`.agents/rules/test-seams.md` rules 1 and 5) — no file is written, no
+ * signal is appended, and nothing is module-mocked.
+ */
+
+const verdictFixture = (overrides = {}) => ({
+  storyId: 4780,
+  schemaVersion: 1,
+  round: 1,
+  criteria: [
+    {
+      index: 0,
+      criterion: 'AC-1 holds',
+      verdict: 'met',
+      evidence: 'npm test exits 0',
+    },
+  ],
+  ...overrides,
+});
+
+function harness({ verdict = verdictFixture(), envelope, exitCode = 0 } = {}) {
+  const infos = [];
+  const seen = [];
+  return {
+    infos,
+    seen,
+    deps: {
+      readFileSyncImpl: () => JSON.stringify(verdict),
+      resolveConfigImpl: () => ({
+        delivery: { acceptanceEval: { maxRounds: 2 } },
+      }),
+      validateVerdictImpl: (v) => v,
+      runAcceptanceEvalImpl: async (args) => {
+        seen.push(args);
+        return {
+          envelope: envelope ?? {
+            storyId: args.storyId,
+            decision: 'proceed',
+            round: 1,
+            cap: 2,
+            unmetCriteria: [],
+          },
+          exitCode,
+        };
+      },
+      logger: { info: (m) => infos.push(m) },
+    },
+  };
+}
+
+describe('validateVerdict', () => {
+  it('returns the same reference for a well-formed verdict', () => {
+    const verdict = verdictFixture();
+    assert.equal(validateVerdict(verdict), verdict);
+  });
+
+  it('throws a detailed schema error for a malformed verdict', () => {
+    assert.throws(
+      () => validateVerdict({ storyId: 'not-a-number' }),
+      /verdict failed schema validation/,
+    );
+  });
+
+  it('reads the schema through the injected io seam', () => {
+    assert.throws(
+      () =>
+        validateVerdict(verdictFixture(), {
+          schemaPath: '/fake/schema.json',
+          io: { readFileSync: () => JSON.stringify({ type: 'string' }) },
+        }),
+      /verdict failed schema validation/,
+    );
+  });
+
+  it('does not memoise the compiled validator across differing schemas', () => {
+    // A module-level cache would make this second call reuse the first
+    // schema and pass — the regression guard for test-seams rule 3.
+    validateVerdict(verdictFixture());
+    assert.throws(
+      () =>
+        validateVerdict(verdictFixture(), {
+          schemaPath: '/fake/schema.json',
+          io: { readFileSync: () => JSON.stringify({ type: 'array' }) },
+        }),
+      /verdict failed schema validation/,
+    );
+  });
+});
+
+describe('runAcceptanceEvalCli', () => {
+  it('refuses a missing or non-numeric --story', async () => {
+    for (const argv of [
+      ['--verdict', 'v.json'],
+      ['--story', 'x', '--verdict', 'v.json'],
+    ]) {
+      await assert.rejects(
+        () => runAcceptanceEvalCli(argv, harness().deps),
+        /Usage: node acceptance-eval\.js --story <id> --verdict <path>/,
+      );
+    }
+  });
+
+  it('refuses a missing --verdict', async () => {
+    await assert.rejects(
+      () => runAcceptanceEvalCli(['--story', '4780'], harness().deps),
+      /--verdict <path> is required/,
+    );
+  });
+
+  it('names the unreadable verdict file', async () => {
+    const h = harness();
+    h.deps.readFileSyncImpl = () => {
+      throw new Error('ENOENT: no such file');
+    };
+    await assert.rejects(
+      () =>
+        runAcceptanceEvalCli(
+          ['--story', '4780', '--verdict', 'v.json'],
+          h.deps,
+        ),
+      /cannot read verdict file at v\.json: ENOENT/,
+    );
+  });
+
+  it('names a verdict file that is not valid JSON', async () => {
+    const h = harness();
+    h.deps.readFileSyncImpl = () => '{ not json';
+    await assert.rejects(
+      () =>
+        runAcceptanceEvalCli(
+          ['--story', '4780', '--verdict', 'v.json'],
+          h.deps,
+        ),
+      /verdict file is not valid JSON/,
+    );
+  });
+
+  it('refuses a verdict whose embedded storyId disagrees with --story', async () => {
+    const h = harness({ verdict: verdictFixture({ storyId: 1234 }) });
+    await assert.rejects(
+      () =>
+        runAcceptanceEvalCli(
+          ['--story', '4780', '--verdict', 'v.json'],
+          h.deps,
+        ),
+      /verdict storyId \(1234\) does not match --story 4780/,
+    );
+  });
+
+  it('tolerates a verdict with no embedded storyId', async () => {
+    const h = harness({ verdict: verdictFixture({ storyId: undefined }) });
+    const envelope = await runAcceptanceEvalCli(
+      ['--story', '4780', '--verdict', 'v.json'],
+      h.deps,
+    );
+    assert.equal(envelope.decision, 'proceed');
+  });
+
+  it('prints the envelope as one JSON line and returns it on proceed', async () => {
+    const h = harness();
+    const envelope = await runAcceptanceEvalCli(
+      ['--story', '4780', '--verdict', 'v.json'],
+      h.deps,
+    );
+    assert.equal(h.infos.length, 1);
+    assert.deepEqual(JSON.parse(h.infos[0]), envelope);
+    assert.equal(h.seen[0].emitSignal, true);
+  });
+
+  it('suppresses the signal emit under --no-signal', async () => {
+    const h = harness();
+    await runAcceptanceEvalCli(
+      ['--story', '4780', '--verdict', 'v.json', '--no-signal'],
+      h.deps,
+    );
+    assert.equal(h.seen[0].emitSignal, false);
+  });
+
+  it('throws naming every unmet criterion when the decision is block', async () => {
+    const h = harness({
+      exitCode: 1,
+      envelope: {
+        storyId: 4780,
+        decision: 'block',
+        round: 2,
+        cap: 2,
+        unmetCriteria: [
+          { index: 3, criterion: 'AC-3', verdict: 'not-met', evidence: null },
+          { index: 5, criterion: 'AC-5', verdict: 'unclear', evidence: null },
+        ],
+      },
+    });
+    await assert.rejects(
+      () =>
+        runAcceptanceEvalCli(
+          ['--story', '4780', '--verdict', 'v.json'],
+          h.deps,
+        ),
+      (err) => {
+        assert.match(
+          err.message,
+          /round cap \(2\) reached with criteria still unmet/,
+        );
+        assert.match(err.message, /#3 \(not-met\), #5 \(unclear\)/);
+        assert.match(err.message, /Transition the Story to agent::blocked/);
+        return true;
+      },
+    );
+    // The envelope is still printed before the throw — the loop's record of
+    // why it blocked must survive the non-zero exit.
+    assert.equal(JSON.parse(h.infos[0]).decision, 'block');
+  });
+});

--- a/tests/audit-to-stories/build-plan.test.js
+++ b/tests/audit-to-stories/build-plan.test.js
@@ -1,0 +1,328 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { after, before, describe, it } from 'node:test';
+
+import { __testing } from '../../.agents/scripts/audit-to-stories.js';
+
+/**
+ * Story #4780, AC-6 — `buildPlan` scored CRAP 110 despite 21 audit-to-stories
+ * test files existing: not one of them reached the function that turns audit
+ * findings into a dedup-checked plan. This file closes that gap, and covers
+ * the two passes that hang off it (`runAuto`, `buildAndGateStories`).
+ *
+ * The provider, the classifier, and the ledger reconciler are injected
+ * through `buildPlan`'s optional final `deps` parameter
+ * (`.agents/rules/test-seams.md` rules 1 and 5) — plain functions, no module
+ * mocking — so no GitHub lookup happens and no committed ledger is written.
+ * The report glob and the report reads run against a real temp directory, so
+ * `collectReportPaths` and `readReports` are exercised for real.
+ */
+
+const { buildPlan, buildAndGateStories, runAuto, meetsSeverity } = __testing;
+
+const FIXTURES = path.join(import.meta.dirname, 'fixtures');
+
+let workspace;
+let reportGlob;
+let emptyGlob;
+
+before(() => {
+  workspace = fs.mkdtempSync(path.join(tmpdir(), 'audit-build-plan-'));
+  const reports = path.join(workspace, 'audits');
+  fs.mkdirSync(reports, { recursive: true });
+  for (const name of fs.readdirSync(FIXTURES)) {
+    fs.copyFileSync(path.join(FIXTURES, name), path.join(reports, name));
+  }
+  // The fan-out report is deliberately excluded by `collectReportPaths`.
+  fs.writeFileSync(
+    path.join(reports, 'audit-fan-out-results.md'),
+    '# Fan-out\n',
+  );
+  reportGlob = path.join(reports, 'audit-*-results.md');
+  emptyGlob = path.join(workspace, 'nowhere', 'audit-*-results.md');
+});
+
+after(() => {
+  fs.rmSync(workspace, { recursive: true, force: true });
+});
+
+const silent = { logger: { warn: () => {} } };
+
+describe('buildPlan', () => {
+  it('returns a zero envelope when the glob matches no report', async () => {
+    const plan = await buildPlan(
+      { glob: emptyGlob, useProvider: false },
+      silent,
+    );
+    assert.deepEqual(plan.sourceReports, []);
+    assert.deepEqual(plan.findings, []);
+    assert.deepEqual(plan.groups, []);
+    assert.deepEqual(plan.classifications, []);
+    assert.equal(plan.severityThreshold, 'all');
+    assert.deepEqual(plan.summary, {
+      totalFindings: 0,
+      filtered: 0,
+      create: 0,
+      skipOpen: 0,
+      skipReoccurring: 0,
+    });
+  });
+
+  it('parses every report under the glob, excluding the fan-out report', async () => {
+    const plan = await buildPlan(
+      { glob: reportGlob, useProvider: false },
+      silent,
+    );
+    assert.ok(plan.sourceReports.length >= 3);
+    assert.equal(
+      plan.sourceReports.some((p) => p.endsWith('audit-fan-out-results.md')),
+      false,
+    );
+    assert.ok(plan.summary.totalFindings > 0);
+    assert.ok(plan.groups.length > 0);
+  });
+
+  it('stamps every finding with a fingerprint and tallies by severity', async () => {
+    const plan = await buildPlan(
+      { glob: reportGlob, useProvider: false },
+      silent,
+    );
+    for (const finding of plan.findings) {
+      assert.equal(typeof finding.fingerprint?.full, 'string');
+    }
+    const tally = plan.summary.tally;
+    assert.equal(
+      tally.critical + tally.high + tally.medium + tally.low + tally.unknown,
+      plan.summary.filtered,
+    );
+  });
+
+  it('filters findings below the severity threshold', async () => {
+    const all = await buildPlan(
+      { glob: reportGlob, useProvider: false },
+      silent,
+    );
+    const high = await buildPlan(
+      { glob: reportGlob, severity: 'high', useProvider: false },
+      silent,
+    );
+    assert.equal(high.severityThreshold, 'high');
+    assert.ok(high.summary.filtered <= all.summary.filtered);
+    assert.equal(high.summary.totalFindings, all.summary.totalFindings);
+    for (const finding of high.findings) {
+      assert.ok(meetsSeverity(finding, 'high'));
+    }
+  });
+
+  it('classifies every group as create and warns loudly under --no-provider', async () => {
+    const warns = [];
+    const plan = await buildPlan(
+      { glob: reportGlob, useProvider: false },
+      { logger: { warn: (m) => warns.push(m) } },
+    );
+    assert.equal(plan.summary.dedupApplied, false);
+    assert.ok(plan.classifications.every((c) => c.action === 'create'));
+    assert.match(warns[0], /dedup skipped \(--no-provider\)/);
+    assert.match(warns[0], /may open\s+duplicates/);
+  });
+
+  it('warns loudly when the provider exposes no search port', async () => {
+    const warns = [];
+    const plan = await buildPlan(
+      { glob: reportGlob, useProvider: true },
+      {
+        loadProviderImpl: async () => null,
+        logger: { warn: (m) => warns.push(m) },
+      },
+    );
+    assert.equal(plan.summary.dedupApplied, false);
+    assert.match(warns[0], /dedup skipped \(no provider port\)/);
+    assert.match(warns[0], /WILL open duplicates/);
+  });
+
+  it('adopts the classifier verdict when a provider resolves', async () => {
+    const plan = await buildPlan(
+      { glob: reportGlob, useProvider: true },
+      {
+        ...silent,
+        loadProviderImpl: async () => ({ searchCandidates: async () => [] }),
+        classifyGroupsImpl: async ({ groups }) => ({
+          classifications: groups.map((g) => ({
+            group: g,
+            action: 'skip-open',
+            matchedIssues: [{ number: 42, state: 'open' }],
+            matchedFingerprints: [],
+          })),
+          summary: { create: 0, skipOpen: groups.length, skipReoccurring: 0 },
+        }),
+      },
+    );
+    assert.equal(plan.summary.dedupApplied, true);
+    assert.equal(plan.summary.skipOpen, plan.groups.length);
+    assert.ok(plan.classifications.every((c) => c.action === 'skip-open'));
+  });
+
+  it('names every group whose dedup lookup degraded', async () => {
+    const warns = [];
+    await buildPlan(
+      { glob: reportGlob, useProvider: true },
+      {
+        loadProviderImpl: async () => ({}),
+        classifyGroupsImpl: async ({ groups }) => ({
+          classifications: groups.map((g) => ({ group: g, action: 'create' })),
+          summary: {
+            create: groups.length,
+            skipOpen: 0,
+            skipReoccurring: 0,
+            dedupDegraded: {
+              count: 1,
+              groups: [{ group: 'auth', reason: 'HTTP 422' }],
+            },
+          },
+        }),
+        logger: { warn: (m) => warns.push(m) },
+      },
+    );
+    assert.match(warns[0], /dedup degraded for 1 group\(s\)/);
+    assert.match(warns[0], /- auth: HTTP 422/);
+  });
+
+  it('reports the ledger and flips fully-suppressed groups to skip-accepted-risk', async () => {
+    const reconcileCalls = [];
+    const plan = await buildPlan(
+      { glob: reportGlob, useProvider: false, ledger: { path: '/led.json' } },
+      {
+        ...silent,
+        reconcileScanLedgerImpl: (args) => {
+          reconcileCalls.push(args);
+          return new Set(
+            args.findings.map((f) => f.fingerprint?.full).filter(Boolean),
+          );
+        },
+      },
+    );
+    assert.equal(reconcileCalls[0].ledgerPath, '/led.json');
+    assert.equal(reconcileCalls[0].write, true);
+    assert.equal(plan.summary.ledger.path, '/led.json');
+    assert.ok(plan.summary.ledger.suppressed > 0);
+    assert.ok(
+      plan.classifications.every((c) => c.action === 'skip-accepted-risk'),
+    );
+  });
+
+  it('leaves classifications alone when the ledger suppresses nothing', async () => {
+    const plan = await buildPlan(
+      { glob: reportGlob, useProvider: false, ledger: { write: false } },
+      { ...silent, reconcileScanLedgerImpl: () => new Set() },
+    );
+    assert.equal(plan.summary.ledger.suppressed, 0);
+    assert.ok(plan.classifications.every((c) => c.action === 'create'));
+  });
+
+  it('honours ledger.write === false as a read-only reconcile', async () => {
+    let seen;
+    await buildPlan(
+      { glob: reportGlob, useProvider: false, ledger: { write: false } },
+      {
+        ...silent,
+        reconcileScanLedgerImpl: (args) => {
+          seen = args;
+          return new Set();
+        },
+      },
+    );
+    assert.equal(seen.write, false);
+  });
+
+  it('omits the ledger summary entirely when no ledger is requested', async () => {
+    const plan = await buildPlan(
+      { glob: reportGlob, useProvider: false },
+      silent,
+    );
+    assert.equal('ledger' in plan.summary, false);
+  });
+});
+
+describe('buildAndGateStories', () => {
+  it('builds one gated Story per eligible group', async () => {
+    const plan = await buildPlan(
+      { glob: reportGlob, useProvider: false },
+      silent,
+    );
+    const stories = buildAndGateStories(
+      plan.classifications.map((c) => c.group),
+      plan.edges ?? [],
+    );
+    assert.equal(stories.length, plan.classifications.length);
+    for (const story of stories) {
+      assert.equal(typeof story.title, 'string');
+      assert.ok(Array.isArray(story.labels));
+      assert.match(story.body, /## Acceptance/);
+    }
+  });
+
+  it('accepts an empty batch', () => {
+    assert.deepEqual(buildAndGateStories([], []), []);
+  });
+});
+
+describe('runAuto', () => {
+  it('resolves the floor, reports totals, and files nothing under --dry-run', async () => {
+    const { summary, stories } = await runAuto({
+      glob: reportGlob,
+      severity: 'high',
+      dryRun: true,
+      useProvider: false,
+      ledgerPath: path.join(workspace, 'ledger.json'),
+    });
+    assert.equal(summary.mode, 'auto');
+    assert.equal(summary.dryRun, true);
+    assert.equal(summary.severityFloor, 'high');
+    assert.deepEqual(stories, []);
+    assert.equal(summary.totals.create, summary.totals.groups);
+    assert.equal(summary.totals.skipOpen, 0);
+    assert.deepEqual(summary.reDetected, []);
+    assert.equal(
+      fs.existsSync(path.join(workspace, 'ledger.json')),
+      false,
+      'a dry run must not write the ledger',
+    );
+  });
+
+  it('returns the create-eligible Story payloads outside --dry-run', async () => {
+    const { summary, stories } = await runAuto({
+      glob: reportGlob,
+      severity: 'low',
+      dryRun: false,
+      useProvider: false,
+      ledgerPath: path.join(workspace, 'ledger-write.json'),
+    });
+    assert.equal(summary.dryRun, false);
+    assert.equal(stories.length, summary.totals.create);
+    assert.equal(
+      fs.existsSync(path.join(workspace, 'ledger-write.json')),
+      true,
+    );
+  });
+
+  it('reports an empty run without throwing', async () => {
+    const { summary, stories } = await runAuto({
+      glob: emptyGlob,
+      severity: 'high',
+      dryRun: true,
+      useProvider: false,
+    });
+    assert.deepEqual(summary.totals, {
+      findings: 0,
+      filtered: 0,
+      groups: 0,
+      create: 0,
+      skipOpen: 0,
+      skipReoccurring: 0,
+      suppressedByLedger: 0,
+    });
+    assert.deepEqual(stories, []);
+  });
+});

--- a/tests/audit-to-stories/build-plan.test.js
+++ b/tests/audit-to-stories/build-plan.test.js
@@ -4,7 +4,10 @@ import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { after, before, describe, it } from 'node:test';
 
-import { __testing } from '../../.agents/scripts/audit-to-stories.js';
+import {
+  __testing,
+  runAuditToStories,
+} from '../../.agents/scripts/audit-to-stories.js';
 
 /**
  * Story #4780, AC-6 — `buildPlan` scored CRAP 110 despite 21 audit-to-stories
@@ -324,5 +327,152 @@ describe('runAuto', () => {
       suppressedByLedger: 0,
     });
     assert.deepEqual(stories, []);
+  });
+});
+
+describe('runAuditToStories (sub-command dispatch)', () => {
+  function harness() {
+    const persisted = [];
+    const written = [];
+    const seen = {};
+    return {
+      persisted,
+      written,
+      seen,
+      deps: {
+        buildPlanImpl: async (params) => {
+          seen.buildPlan = params;
+          return {
+            groups: ['g'],
+            findings: ['f'],
+            sourceReports: ['r'],
+            edges: [],
+          };
+        },
+        runAutoImpl: async (params) => {
+          seen.runAuto = params;
+          return { summary: { mode: 'auto' }, stories: [] };
+        },
+        loadPlanImpl: (planPath) => {
+          seen.loadPlan = planPath;
+          return {
+            groups: ['g'],
+            findings: ['f'],
+            sourceReports: ['r'],
+            edges: [{ fromGroupKey: 'a', toGroupKey: 'b' }],
+            classifications: [
+              { action: 'create', group: 'g1' },
+              { action: 'skip-open', group: 'g2' },
+            ],
+          };
+        },
+        buildAndGateStoriesImpl: (eligible, edges) => {
+          seen.gate = { eligible, edges };
+          return [{ title: 'T', labels: ['a', 'b'], body: 'BODY' }];
+        },
+        buildPlanSeedMarkdownImpl: (args) => {
+          seen.seed = args;
+          return '# seed\n';
+        },
+        persistImpl: (text, outPath) => persisted.push({ text, outPath }),
+        stdout: { write: (s) => written.push(s) },
+      },
+    };
+  }
+
+  it('throws the usage error when no sub-command is given', async () => {
+    await assert.rejects(
+      () => runAuditToStories([], harness().deps),
+      /Usage: node audit-to-stories\.js \(--scan \| --emit-plan-seed \| --emit-stories\)/,
+    );
+  });
+
+  it('--auto persists the summary and adds a trailing newline on stdout', async () => {
+    const h = harness();
+    await runAuditToStories(
+      [
+        '--auto',
+        '--dry-run',
+        '--glob',
+        'g/*.md',
+        '--severity',
+        'high',
+        '--ledger',
+        'l.json',
+      ],
+      h.deps,
+    );
+    assert.deepEqual(h.seen.runAuto, {
+      glob: 'g/*.md',
+      severity: 'high',
+      dryRun: true,
+      useProvider: true,
+      ledgerPath: 'l.json',
+    });
+    assert.deepEqual(JSON.parse(h.persisted[0].text), { mode: 'auto' });
+    assert.equal(h.persisted[0].outPath, undefined);
+    assert.deepEqual(h.written, ['\n']);
+  });
+
+  it('--auto with --out writes to the file and skips the stdout newline', async () => {
+    const h = harness();
+    await runAuditToStories(['--auto', '--out', 'summary.json'], h.deps);
+    assert.equal(h.persisted[0].outPath, 'summary.json');
+    assert.deepEqual(h.written, []);
+  });
+
+  it('--scan persists the plan envelope and honours --no-provider', async () => {
+    const h = harness();
+    await runAuditToStories(['--scan', '--no-provider'], h.deps);
+    assert.equal(h.seen.buildPlan.useProvider, false);
+    assert.equal(JSON.parse(h.persisted[0].text).groups.length, 1);
+    assert.deepEqual(h.written, ['\n']);
+  });
+
+  it('--emit-plan-seed renders the seed document from a loaded plan', async () => {
+    const h = harness();
+    await runAuditToStories(
+      ['--emit-plan-seed', '--plan', 'plan.json', '--out', 'seed.md'],
+      h.deps,
+    );
+    assert.equal(h.seen.loadPlan, 'plan.json');
+    assert.deepEqual(h.seen.seed, {
+      groups: ['g'],
+      findings: ['f'],
+      sourceReports: ['r'],
+    });
+    assert.deepEqual(h.persisted[0], { text: '# seed\n', outPath: 'seed.md' });
+    assert.deepEqual(h.written, []);
+  });
+
+  it('--emit-stories gates only the create-eligible groups and renders prose by default', async () => {
+    const h = harness();
+    await runAuditToStories(['--emit-stories', '--plan', 'plan.json'], h.deps);
+    assert.deepEqual(h.seen.gate.eligible, ['g1']);
+    assert.deepEqual(h.seen.gate.edges, [
+      { fromGroupKey: 'a', toGroupKey: 'b' },
+    ]);
+    assert.match(
+      h.persisted[0].text,
+      /--- story 1 ---\nTitle: T\nLabels: a, b\n\nBODY/,
+    );
+  });
+
+  it('--emit-stories --json emits the raw Story objects', async () => {
+    const h = harness();
+    await runAuditToStories(
+      ['--emit-stories', '--plan', 'plan.json', '--json'],
+      h.deps,
+    );
+    assert.deepEqual(JSON.parse(h.persisted[0].text), [
+      { title: 'T', labels: ['a', 'b'], body: 'BODY' },
+    ]);
+  });
+
+  it('--auto takes precedence over --scan when both are present', async () => {
+    const h = harness();
+    await runAuditToStories(['--auto', '--scan'], h.deps);
+    assert.ok(h.seen.runAuto);
+    assert.equal(h.seen.buildPlan, undefined);
   });
 });

--- a/tests/boot-sweep.test.js
+++ b/tests/boot-sweep.test.js
@@ -1,0 +1,187 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import {
+  buildSummaryLine,
+  runBootSweep,
+  runBootSweepCli,
+} from '../.agents/scripts/boot-sweep.js';
+
+/**
+ * Story #4780 — the boot sweep's CLI shell scored CRAP 72: the argv →
+ * sweep → render path (the one `/deliver` and `/plan` call at boot) was
+ * unreached, so a flag that silently stopped reaching the engine would have
+ * shipped green.
+ *
+ * The sweep engine and the log sink are injected through the optional final
+ * `deps` parameter (`.agents/rules/test-seams.md` rules 1 and 5), so no real
+ * branch is ever reaped by this suite.
+ */
+
+function harness(result = {}) {
+  const infos = [];
+  const calls = [];
+  return {
+    infos,
+    calls,
+    deps: {
+      runBootSweepImpl: async (args) => {
+        calls.push(args);
+        return {
+          ok: true,
+          localDeleted: 0,
+          remoteDeleted: 0,
+          protected: [],
+          contentMerged: [],
+          ...result,
+        };
+      },
+      logger: { info: (m) => infos.push(m) },
+    },
+  };
+}
+
+describe('buildSummaryLine', () => {
+  it('stays silent about content-merged branches when there are none', () => {
+    assert.equal(
+      buildSummaryLine({ localDeleted: 2, remoteDeleted: 1, protected: ['a'] }),
+      '[boot-sweep] reaped 2 local + 1 remote; protected 1.',
+    );
+  });
+
+  it('appends the /git-cleanup routing hint when content-merged branches exist', () => {
+    assert.match(
+      buildSummaryLine({
+        localDeleted: 0,
+        remoteDeleted: 0,
+        contentMerged: ['x', 'y'],
+      }),
+      /2 content-merged branch\(es\) left for \/git-cleanup/,
+    );
+  });
+
+  it('treats missing protected/contentMerged arrays as zero', () => {
+    assert.equal(
+      buildSummaryLine({ localDeleted: 0, remoteDeleted: 0 }),
+      '[boot-sweep] reaped 0 local + 0 remote; protected 0.',
+    );
+  });
+});
+
+describe('runBootSweepCli', () => {
+  it('prints HELP and runs no sweep under --help', async () => {
+    const h = harness();
+    const result = await runBootSweepCli(['--help'], h.deps);
+    assert.equal(result, undefined);
+    assert.equal(h.calls.length, 0);
+    assert.match(h.infos[0], /Usage: node \.agents\/scripts\/boot-sweep\.js/);
+  });
+
+  it('honours the -h short flag', async () => {
+    const h = harness();
+    await runBootSweepCli(['-h'], h.deps);
+    assert.equal(h.calls.length, 0);
+  });
+
+  it('defaults to a fast-forwarding sweep with no include/exclude overrides', async () => {
+    const h = harness();
+    await runBootSweepCli([], h.deps);
+    assert.deepEqual(h.calls[0], {
+      cwd: undefined,
+      base: undefined,
+      include: [],
+      exclude: [],
+      current: undefined,
+      fastForward: true,
+    });
+  });
+
+  it('threads --cwd, --base, --current and repeated --include/--exclude', async () => {
+    const h = harness();
+    await runBootSweepCli(
+      [
+        '--cwd',
+        '/repo',
+        '--base',
+        'trunk',
+        '--current',
+        'story-1',
+        '--include',
+        'story-*',
+        '--include',
+        'fix-*',
+        '--exclude',
+        'story-9',
+      ],
+      h.deps,
+    );
+    assert.deepEqual(h.calls[0], {
+      cwd: '/repo',
+      base: 'trunk',
+      include: ['story-*', 'fix-*'],
+      exclude: ['story-9'],
+      current: 'story-1',
+      fastForward: true,
+    });
+  });
+
+  it('turns the fast-forward off under --no-fast-forward', async () => {
+    const h = harness();
+    await runBootSweepCli(['--no-fast-forward'], h.deps);
+    assert.equal(h.calls[0].fastForward, false);
+  });
+
+  it('renders the one-line summary by default', async () => {
+    const h = harness({ localDeleted: 3, remoteDeleted: 2 });
+    const result = await runBootSweepCli([], h.deps);
+    assert.equal(
+      h.infos[0],
+      '[boot-sweep] reaped 3 local + 2 remote; protected 0.',
+    );
+    assert.equal(result.localDeleted, 3);
+  });
+
+  it('renders the full envelope under --json', async () => {
+    const h = harness({ localDeleted: 1 });
+    await runBootSweepCli(['--json'], h.deps);
+    assert.equal(JSON.parse(h.infos[0]).localDeleted, 1);
+  });
+});
+
+describe('runBootSweep', () => {
+  it('swallows a throwing sweep and returns the skipped envelope (host continues)', async () => {
+    const warns = [];
+    const result = await runBootSweep({
+      cwd: '/repo',
+      injectedConfig: { project: { baseBranch: 'main' } },
+      injectedProvider: {},
+      injectedSweep: () => {
+        throw new Error('lock contention');
+      },
+      logger: { info: () => {}, warn: (m) => warns.push(m) },
+    });
+    assert.equal(result.ok, false);
+    assert.equal(result.skipped, true);
+    assert.equal(result.error, 'lock contention');
+    assert.match(warns[0], /sweep threw \(host continues\): lock contention/);
+  });
+
+  it('defaults the include glob to story-* and appends --current to the excludes', async () => {
+    let seen;
+    await runBootSweep({
+      cwd: '/repo',
+      current: 'story-4780',
+      injectedConfig: { project: { baseBranch: 'main' } },
+      injectedProvider: {},
+      injectedSweep: async (args) => {
+        seen = args;
+        return { ok: true };
+      },
+      logger: { info: () => {}, warn: () => {} },
+    });
+    assert.deepEqual(seen.include, ['story-*']);
+    assert.deepEqual(seen.exclude, ['story-4780']);
+    assert.equal(seen.baseBranch, 'main');
+    assert.equal(seen.logTag, '[boot-sweep]');
+  });
+});

--- a/tests/coverage-capture.test.js
+++ b/tests/coverage-capture.test.js
@@ -1,0 +1,218 @@
+import assert from 'node:assert/strict';
+import path from 'node:path';
+import { describe, it } from 'node:test';
+
+import {
+  parseArgs,
+  runCoverageCapture,
+} from '../.agents/scripts/coverage-capture.js';
+
+/**
+ * Story #4780 — `main` scored CRAP 42.7: the gate that decides whether
+ * `npm run test:coverage` runs before the CRAP gate fires had no unit test,
+ * because the module used to `process.exit()` on import. It is now guarded by
+ * a direct-invocation check, and its decision table is driven entirely
+ * through the optional final `deps` parameter (`.agents/rules/test-seams.md`
+ * rules 1 and 5) — no suite is ever spawned by this file.
+ */
+
+const CRAP = {
+  enabled: true,
+  targetDirs: ['.agents/scripts', 'lib'],
+  coveragePath: 'coverage/coverage-final.json',
+};
+
+function harness({
+  crap = CRAP,
+  fresh = { fresh: true, reason: 'fresh' },
+  changed = ['.agents/scripts/a.js'],
+  captureCode = 0,
+  hasScript = true,
+  digest = 'deadbeef',
+  stampWritten = true,
+} = {}) {
+  const log = { info: [], warn: [], error: [] };
+  const calls = { capture: [], stamp: [], changed: [], fresh: [] };
+  return {
+    log,
+    calls,
+    deps: {
+      resolveConfigImpl: (args) => ({ cwdSeen: args.cwd }),
+      getQualityImpl: () => ({ crap, coverage: { timeoutMs: 1234 } }),
+      readPackageScriptsImpl: () => ({ 'test:coverage': 'node --test' }),
+      hasNpmScriptImpl: () => hasScript,
+      getChangedFilesImpl: (args) => {
+        calls.changed.push(args);
+        if (changed === 'throw') throw new Error('bad ref');
+        return changed;
+      },
+      isCoverageFreshImpl: (args) => {
+        calls.fresh.push(args);
+        return fresh;
+      },
+      runCaptureImpl: (args) => {
+        calls.capture.push(args);
+        args.log('capture says hello');
+        return captureCode;
+      },
+      computeContentDigestImpl: () => digest,
+      writeCaptureStampImpl: (args) => {
+        calls.stamp.push(args);
+        return stampWritten;
+      },
+      logger: {
+        info: (m) => log.info.push(m),
+        warn: (m) => log.warn.push(m),
+        error: (m) => log.error.push(m),
+      },
+    },
+  };
+}
+
+const argv = (...flags) => ['node', 'coverage-capture.js', ...flags];
+
+describe('coverage-capture parseArgs', () => {
+  it('defaults to a non-skipping capture against main in the cwd', () => {
+    const parsed = parseArgs(argv());
+    assert.equal(parsed.skipWhenNoCrapFiles, false);
+    assert.equal(parsed.ref, 'main');
+    assert.equal(parsed.cwd, process.cwd());
+  });
+
+  it('reads --skip-when-no-crap-files, --ref and --cwd', () => {
+    const parsed = parseArgs(
+      argv('--skip-when-no-crap-files', '--ref', 'develop', '--cwd', '/repo'),
+    );
+    assert.deepEqual(parsed, {
+      skipWhenNoCrapFiles: true,
+      ref: 'develop',
+      cwd: '/repo',
+    });
+  });
+
+  it('keeps the defaults when a value-taking flag has no value', () => {
+    const parsed = parseArgs(argv('--ref'));
+    assert.equal(parsed.ref, 'main');
+  });
+});
+
+describe('runCoverageCapture', () => {
+  it('exits 0 immediately when the CRAP gate is disabled', () => {
+    const h = harness({ crap: { ...CRAP, enabled: false } });
+    assert.equal(runCoverageCapture(argv(), h.deps), 0);
+    assert.equal(h.calls.capture.length, 0);
+    assert.match(h.log.info[0], /CRAP gate disabled — skipping capture/);
+  });
+
+  it('fails with a fix-naming diagnostic when there is no test:coverage script', () => {
+    const h = harness({ hasScript: false });
+    assert.equal(runCoverageCapture(argv(), h.deps), 1);
+    assert.match(h.log.error[0], /No "test:coverage" script in package\.json/);
+    assert.equal(h.calls.capture.length, 0);
+  });
+
+  it('skips the capture when no changed file lives under the target dirs', () => {
+    const h = harness({ changed: ['README.md'] });
+    assert.equal(
+      runCoverageCapture(argv('--skip-when-no-crap-files'), h.deps),
+      0,
+    );
+    assert.equal(h.calls.fresh.length, 0);
+    assert.match(
+      h.log.info[0],
+      /No changed files under \[\.agents\/scripts, lib\]/,
+    );
+  });
+
+  it('proceeds to the freshness check when a target-dir file changed', () => {
+    const h = harness({ changed: ['.agents/scripts/a.js'] });
+    assert.equal(
+      runCoverageCapture(argv('--skip-when-no-crap-files'), h.deps),
+      0,
+    );
+    assert.equal(h.calls.fresh.length, 1);
+  });
+
+  it('never consults changed files without the skip flag', () => {
+    const h = harness();
+    runCoverageCapture(argv(), h.deps);
+    assert.equal(h.calls.changed.length, 0);
+  });
+
+  it('warns and falls back to the freshness check when the ref is bad', () => {
+    const h = harness({ changed: 'throw' });
+    assert.equal(
+      runCoverageCapture(
+        argv('--skip-when-no-crap-files', '--ref', 'nope'),
+        h.deps,
+      ),
+      0,
+    );
+    assert.match(h.log.warn[0], /bad ref — falling back to freshness check/);
+    assert.equal(h.calls.fresh.length, 1);
+  });
+
+  it('skips the capture when coverage is already fresh', () => {
+    const h = harness({ fresh: { fresh: true, reason: 'content-identical' } });
+    assert.equal(runCoverageCapture(argv('--cwd', '/repo'), h.deps), 0);
+    assert.equal(h.calls.capture.length, 0);
+    assert.match(
+      h.log.info[0],
+      new RegExp(
+        `Coverage at ${path.resolve('/repo', CRAP.coveragePath).replace(/\\/g, '\\\\')} is content-identical`,
+      ),
+    );
+  });
+
+  it('captures, stamps, and returns 0 when coverage is stale', () => {
+    const h = harness({ fresh: { fresh: false, reason: 'stale' } });
+    assert.equal(runCoverageCapture(argv('--cwd', '/repo'), h.deps), 0);
+    assert.deepEqual(h.calls.capture[0].cwd, '/repo');
+    assert.equal(h.calls.capture[0].timeoutMs, 1234);
+    assert.deepEqual(h.calls.stamp[0], {
+      cwd: '/repo',
+      coveragePath: CRAP.coveragePath,
+      digest: 'deadbeef',
+    });
+    assert.ok(h.log.info.includes('capture says hello'));
+    assert.ok(
+      h.log.info.some((m) => /Wrote content-digest capture stamp/.test(m)),
+    );
+  });
+
+  it('propagates a failing capture and never writes a stamp', () => {
+    const h = harness({
+      fresh: { fresh: false, reason: 'missing' },
+      captureCode: 2,
+    });
+    assert.equal(runCoverageCapture(argv(), h.deps), 2);
+    assert.equal(h.calls.stamp.length, 0);
+    assert.match(h.log.error[0], /npm run test:coverage exited 2/);
+  });
+
+  it('treats an unavailable digest as a best-effort skip, not a failure', () => {
+    const h = harness({
+      fresh: { fresh: false, reason: 'missing' },
+      digest: null,
+    });
+    assert.equal(runCoverageCapture(argv(), h.deps), 0);
+    assert.equal(h.calls.stamp.length, 0);
+    assert.equal(
+      h.log.info.some((m) => /capture stamp/.test(m)),
+      false,
+    );
+  });
+
+  it('stays silent when the stamp write itself fails', () => {
+    const h = harness({
+      fresh: { fresh: false, reason: 'missing' },
+      stampWritten: false,
+    });
+    assert.equal(runCoverageCapture(argv(), h.deps), 0);
+    assert.equal(h.calls.stamp.length, 1);
+    assert.equal(
+      h.log.info.some((m) => /capture stamp/.test(m)),
+      false,
+    );
+  });
+});

--- a/tests/deliver-recover.test.js
+++ b/tests/deliver-recover.test.js
@@ -1,0 +1,204 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import {
+  parseArgv,
+  runDeliverRecover,
+} from '../.agents/scripts/deliver-recover.js';
+
+/**
+ * Story #4780 — `runDeliverRecover` scored CRAP 85.4: the read-only probe an
+ * operator reaches for when a Story is stranded had no test file, so its
+ * argument contract (the one that decides whether it prints a command or
+ * refuses) was unverified.
+ *
+ * Config resolution, provider construction, the probe, the renderer, and the
+ * log sink are all injected through the optional final `deps` parameter
+ * (`.agents/rules/test-seams.md` rules 1 and 5): no GitHub call, no git
+ * spawn, no module mocking.
+ */
+
+function harness(
+  recovery = { shape: 'merged-label-stale', nextCommand: 'gh x' },
+) {
+  const infos = [];
+  const probes = [];
+  return {
+    infos,
+    probes,
+    recovery,
+    deps: {
+      resolveConfigImpl: (args) => ({ resolvedFor: args?.cwd }),
+      createProviderImpl: (config) => ({ providerFor: config.resolvedFor }),
+      recoverStoryImpl: async (args) => {
+        probes.push(args);
+        return recovery;
+      },
+      renderRecoveryImpl: (r) => `PROSE:${r.shape}`,
+      logger: { info: (m) => infos.push(m) },
+    },
+  };
+}
+
+describe('deliver-recover parseArgv', () => {
+  it('parses a full argv', () => {
+    assert.deepEqual(
+      parseArgv([
+        '--story',
+        '4780',
+        '--cwd',
+        '/repo',
+        '--json',
+        '--no-reprobe',
+      ]),
+      { storyId: 4780, cwd: '/repo', json: true, reprobe: false, help: false },
+    );
+  });
+
+  it('defaults cwd to null, json to false, and reprobe to true', () => {
+    assert.deepEqual(parseArgv(['--story', '12']), {
+      storyId: 12,
+      cwd: null,
+      json: false,
+      reprobe: true,
+      help: false,
+    });
+  });
+
+  it('yields NaN for a missing or non-numeric --story', () => {
+    assert.ok(Number.isNaN(parseArgv([]).storyId));
+    assert.ok(Number.isNaN(parseArgv(['--story', 'abc']).storyId));
+  });
+
+  it('records --help', () => {
+    assert.equal(parseArgv(['--help']).help, true);
+  });
+});
+
+describe('runDeliverRecover', () => {
+  it('prints the help text and probes nothing under --help', async () => {
+    const h = harness();
+    const result = await runDeliverRecover({ argv: ['--help'] }, h.deps);
+    assert.deepEqual(result, { success: true, result: null });
+    assert.equal(h.probes.length, 0);
+    assert.match(
+      h.infos[0],
+      /Usage: node \.agents\/scripts\/deliver-recover\.js/,
+    );
+    assert.match(h.infos[0], /Read-only: mutates nothing/);
+  });
+
+  it('refuses a missing, non-numeric, zero, or negative story id', async () => {
+    for (const argv of [
+      [],
+      ['--story', 'abc'],
+      ['--story', '0'],
+      ['--story', '-3'],
+    ]) {
+      const h = harness();
+      await assert.rejects(
+        () => runDeliverRecover({ argv }, h.deps),
+        /Usage: node deliver-recover\.js --story <STORY_ID>/,
+      );
+      assert.equal(h.probes.length, 0);
+    }
+  });
+
+  it('probes the parsed story and renders prose by default', async () => {
+    const h = harness();
+    const result = await runDeliverRecover(
+      { argv: ['--story', '4780', '--cwd', '/repo'] },
+      h.deps,
+    );
+    assert.equal(result.success, true);
+    assert.equal(h.probes[0].storyId, 4780);
+    assert.equal(h.probes[0].cwd, '/repo');
+    assert.equal(h.probes[0].reprobe, true);
+    assert.equal(h.infos[0], 'PROSE:merged-label-stale');
+  });
+
+  it('emits the full envelope as JSON under --json', async () => {
+    const h = harness();
+    await runDeliverRecover({ argv: ['--story', '1', '--json'] }, h.deps);
+    assert.deepEqual(JSON.parse(h.infos[0]), h.recovery);
+  });
+
+  it('takes the direct-argument path over argv when storyId is supplied', async () => {
+    const h = harness();
+    await runDeliverRecover(
+      {
+        storyId: 99,
+        cwd: '/other',
+        json: true,
+        reprobe: false,
+        argv: ['--story', '1'],
+      },
+      h.deps,
+    );
+    assert.equal(h.probes[0].storyId, 99);
+    assert.equal(h.probes[0].cwd, '/other');
+    assert.equal(h.probes[0].reprobe, false);
+    assert.deepEqual(JSON.parse(h.infos[0]), h.recovery);
+  });
+
+  it('defaults cwd, json and reprobe on the direct-argument path', async () => {
+    const h = harness();
+    await runDeliverRecover({ storyId: 7 }, h.deps);
+    assert.equal(h.probes[0].reprobe, true);
+    assert.equal(h.infos[0], 'PROSE:merged-label-stale');
+    assert.equal(typeof h.probes[0].cwd, 'string');
+  });
+
+  it('turns the stability re-probe off under --no-reprobe', async () => {
+    const h = harness();
+    await runDeliverRecover({ argv: ['--story', '1', '--no-reprobe'] }, h.deps);
+    assert.equal(h.probes[0].reprobe, false);
+  });
+
+  it('prefers an injected config and provider over the resolver seams', async () => {
+    const h = harness();
+    await runDeliverRecover(
+      {
+        argv: ['--story', '1'],
+        injectedConfig: { injected: true },
+        injectedProvider: { injectedProvider: true },
+      },
+      h.deps,
+    );
+    assert.deepEqual(h.probes[0].config, { injected: true });
+    assert.deepEqual(h.probes[0].provider, { injectedProvider: true });
+  });
+
+  it('builds config and provider from the seams when none are injected', async () => {
+    const h = harness();
+    await runDeliverRecover(
+      { argv: ['--story', '1', '--cwd', '/repo'] },
+      h.deps,
+    );
+    assert.deepEqual(h.probes[0].config, { resolvedFor: '/repo' });
+    assert.deepEqual(h.probes[0].provider, { providerFor: '/repo' });
+  });
+
+  it('threads the gh, git-spawn and sleep seams to the probe only when given', async () => {
+    const h = harness();
+    const gh = () => {};
+    const gitSpawn = () => {};
+    const sleepFn = async () => {};
+    await runDeliverRecover(
+      {
+        storyId: 1,
+        injectedGh: gh,
+        injectedGitSpawn: gitSpawn,
+        injectedSleepFn: sleepFn,
+      },
+      h.deps,
+    );
+    assert.equal(h.probes[0].gh, gh);
+    assert.equal(h.probes[0].gitSpawnFn, gitSpawn);
+    assert.equal(h.probes[0].sleepFn, sleepFn);
+
+    const bare = harness();
+    await runDeliverRecover({ storyId: 1 }, bare.deps);
+    assert.equal('sleepFn' in bare.probes[0], false);
+  });
+});

--- a/tests/drain-pending-cleanup.test.js
+++ b/tests/drain-pending-cleanup.test.js
@@ -1,0 +1,177 @@
+import assert from 'node:assert/strict';
+import path from 'node:path';
+import { describe, it } from 'node:test';
+
+import { runDrainPendingCleanup } from '../.agents/scripts/drain-pending-cleanup.js';
+
+/**
+ * Story #4780 — the force-drain CLI scored CRAP 110, the worst untested
+ * entrypoint in the repo: every reporting branch (dry-run, escalation,
+ * kernel-held locks, persistent locks, still-pending) was unreached, on a
+ * tool whose escalation path terminates processes.
+ *
+ * Everything it touches — config, the manifest reader, the holder probe, the
+ * drain engine, git, and the progress sink — is injected through the optional
+ * final `deps` parameter (`.agents/rules/test-seams.md` rules 1 and 5).
+ */
+
+const ROOT = path.resolve(path.sep, 'repo');
+
+function harness({ before = [], after = [], result = {}, holders = [] } = {}) {
+  const progress = [];
+  const errors = [];
+  const drainArgs = [];
+  let readCount = 0;
+  return {
+    progress,
+    errors,
+    drainArgs,
+    deps: {
+      resolveConfigImpl: () => ({ delivery: { worktreeIsolation: {} } }),
+      readManifestImpl: () => {
+        readCount += 1;
+        return readCount === 1 ? before : after;
+      },
+      findHoldersInPathImpl: () => holders,
+      forceDrainImpl: async (args) => {
+        drainArgs.push(args);
+        args.logger.info('engine says hello');
+        args.logger.warn('engine is worried');
+        args.logger.error('engine failed a step');
+        return {
+          drained: [],
+          escalated: [],
+          killedPids: {},
+          noHolders: [],
+          persistent: [],
+          stillPending: [],
+          ...result,
+        };
+      },
+      gitImpl: { marker: 'git-utils' },
+      projectRoot: ROOT,
+      progressImpl: (phase, message) => progress.push(`${phase}: ${message}`),
+      logger: { error: (m) => errors.push(m) },
+    },
+  };
+}
+
+describe('runDrainPendingCleanup', () => {
+  it('short-circuits on an empty manifest without invoking the engine', async () => {
+    const h = harness();
+    const result = await runDrainPendingCleanup([], h.deps);
+    assert.deepEqual(result, { remaining: 0 });
+    assert.equal(h.drainArgs.length, 0);
+    assert.equal(
+      h.progress[0],
+      'SCAN: pending-cleanup manifest is empty — nothing to drain.',
+    );
+  });
+
+  it('reports every entry and its holders under --dry-run, removing nothing', async () => {
+    const h = harness({
+      before: [{ storyId: 11, path: '/w/story-11', attempts: 2 }],
+      holders: [{ pid: 42, name: 'node' }],
+    });
+    const result = await runDrainPendingCleanup(['--dry-run'], h.deps);
+    assert.deepEqual(result, { remaining: 1 });
+    assert.equal(h.drainArgs.length, 0);
+    assert.match(
+      h.progress[0],
+      /manifest has 1 entry\(ies\): story-11\(attempts=2\)/,
+    );
+    assert.match(
+      h.progress[1],
+      /DRY-RUN: story-11 path=\/w\/story-11 holders=1 \(pid=42\/node\)/,
+    );
+  });
+
+  it('omits the holder list in dry-run when nothing holds the path', async () => {
+    const h = harness({ before: [{ storyId: 11, path: '/w/story-11' }] });
+    await runDrainPendingCleanup(['--dry-run'], h.deps);
+    assert.match(h.progress[0], /attempts=0/);
+    assert.equal(h.progress[1], 'DRY-RUN: story-11 path=/w/story-11 holders=0');
+  });
+
+  it('resolves the worktree root against the project root and the config default', async () => {
+    const h = harness({ before: [{ storyId: 1, path: '/w' }] });
+    await runDrainPendingCleanup([], h.deps);
+    assert.equal(h.drainArgs[0].worktreeRoot, path.resolve(ROOT, '.worktrees'));
+    assert.equal(h.drainArgs[0].repoRoot, ROOT);
+    assert.deepEqual(h.drainArgs[0].git, { marker: 'git-utils' });
+    assert.equal(h.drainArgs[0].escalate, true);
+  });
+
+  it('honours --worktree-root', async () => {
+    const h = harness({ before: [{ storyId: 1, path: '/w' }] });
+    await runDrainPendingCleanup(['--worktree-root', 'custom-trees'], h.deps);
+    assert.equal(
+      h.drainArgs[0].worktreeRoot,
+      path.resolve(ROOT, 'custom-trees'),
+    );
+  });
+
+  it('escalates unless `escalate` is explicitly parsed false', async () => {
+    // Characterisation, not endorsement: `node:util.parseArgs` only honours a
+    // `--no-<flag>` spelling when `allowNegative` is set, which this CLI does
+    // not set. `--no-escalate` therefore lands in `values['no-escalate']` and
+    // leaves `values.escalate` at its `true` default — the documented
+    // passive-drain flag is inert. Pinned here so the pre-existing gap is
+    // visible rather than silently re-introduced; changing it would be an
+    // observable CLI behaviour change, which this Story explicitly excludes.
+    const h = harness({ before: [{ storyId: 1, path: '/w' }] });
+    await runDrainPendingCleanup(['--no-escalate'], h.deps);
+    assert.equal(h.drainArgs[0].escalate, true);
+
+    const explicit = harness({ before: [{ storyId: 1, path: '/w' }] });
+    await runDrainPendingCleanup(['--escalate=false'], explicit.deps);
+    assert.equal(explicit.drainArgs[0].escalate, 'false');
+  });
+
+  it('routes the engine logger through progress and the error sink', async () => {
+    const h = harness({ before: [{ storyId: 1, path: '/w' }] });
+    await runDrainPendingCleanup([], h.deps);
+    assert.ok(h.progress.includes('DRAIN: engine says hello'));
+    assert.ok(h.progress.includes('DRAIN: ⚠️ engine is worried'));
+    assert.deepEqual(h.errors, [
+      '[drain-pending-cleanup] engine failed a step',
+    ]);
+  });
+
+  it('reports drained, escalated, kernel-held, persistent and still-pending entries', async () => {
+    const h = harness({
+      before: [{ storyId: 1, path: '/w' }],
+      after: [{ storyId: 4, path: '/w4' }],
+      result: {
+        drained: [1],
+        escalated: [2],
+        killedPids: { 2: [101, 102] },
+        noHolders: [3],
+        persistent: [4],
+        stillPending: [5],
+      },
+    });
+    const result = await runDrainPendingCleanup([], h.deps);
+    const joined = h.progress.join('\n');
+    assert.match(joined, /DRAIN: ✅ drained 1 entry\(ies\): story-1/);
+    assert.match(joined, /ESCALATE: terminated holders: story-2=\[101,102\]/);
+    assert.match(joined, /no user-mode holders for: story-3/);
+    assert.match(joined, /persistent-lock remains on: story-4/);
+    assert.match(joined, /still-pending \(below threshold\): story-5/);
+    assert.match(
+      joined,
+      /DONE: pending-cleanup manifest now has 1 entry\(ies\)/,
+    );
+    assert.deepEqual(result, { drained: [1], remaining: 1 });
+  });
+
+  it('omits every optional report line when the engine drained nothing', async () => {
+    const h = harness({ before: [{ storyId: 1, path: '/w' }] });
+    await runDrainPendingCleanup([], h.deps);
+    const joined = h.progress.join('\n');
+    assert.doesNotMatch(joined, /drained/);
+    assert.doesNotMatch(joined, /terminated holders/);
+    assert.doesNotMatch(joined, /persistent-lock/);
+    assert.match(joined, /DONE:/);
+  });
+});

--- a/tests/generate-lens-checklists.test.js
+++ b/tests/generate-lens-checklists.test.js
@@ -1,0 +1,260 @@
+import assert from 'node:assert/strict';
+import path from 'node:path';
+import { describe, it } from 'node:test';
+
+import {
+  buildExpected,
+  planChecklists,
+  runGenerateLensChecklists,
+} from '../.agents/scripts/generate-lens-checklists.js';
+
+/**
+ * Story #4780 — the generator's CLI shell scored CRAP 90: neither the
+ * `--check` drift gate (wired into `npm run docs:check`) nor the write/prune
+ * pass had a single test, so a drift gate that stopped detecting drift would
+ * have looked green.
+ *
+ * The filesystem, the lens taxonomy, and both directories are injected
+ * through the optional final `deps` parameter (`.agents/rules/test-seams.md`
+ * rules 1 and 5) — a plain stub object, never a module mock, so the real
+ * `.agents/audit-checklists` tree is untouched.
+ */
+
+const ROOT = path.resolve(path.sep, 'repo');
+const WORKFLOWS = path.join(ROOT, '.agents', 'workflows');
+const CHECKLISTS = path.join(ROOT, '.agents', 'audit-checklists');
+
+/**
+ * @param {Record<string, string>} files absolute path → content
+ */
+function makeFsStub(files) {
+  const writes = {};
+  const removed = [];
+  const mkdirs = [];
+  return {
+    writes,
+    removed,
+    mkdirs,
+    existsSync: (p) =>
+      p in files ||
+      Object.keys(files).some((f) => f.startsWith(`${p}${path.sep}`)),
+    readFileSync: (p) => {
+      if (!(p in files)) throw new Error(`ENOENT: ${p}`);
+      return files[p];
+    },
+    readdirSync: (dir) =>
+      Object.keys(files)
+        .filter((f) => path.dirname(f) === dir)
+        .map((f) => path.basename(f)),
+    mkdirSync: (dir) => mkdirs.push(dir),
+    writeFileSync: (p, content) => {
+      writes[p] = content;
+      files[p] = content;
+    },
+    rmSync: (p) => {
+      removed.push(p);
+      delete files[p];
+    },
+  };
+}
+
+const deps = (files, lenses) => ({
+  fsImpl: makeFsStub(files),
+  lenses,
+  workflowsDir: WORKFLOWS,
+  checklistsDir: CHECKLISTS,
+  projectRoot: ROOT,
+  logger: { info: () => {} },
+});
+
+const workflowBody = (lens) =>
+  [
+    '---',
+    `description: The ${lens} lens.`,
+    '---',
+    '',
+    `# /audit-${lens}`,
+    '',
+    '## Dimensions',
+    '',
+    `- Something the ${lens} lens checks.`,
+    '',
+  ].join('\n');
+
+describe('planChecklists', () => {
+  it('records a lens with no workflow as missing rather than skipping it', () => {
+    const { expected, missing } = planChecklists(
+      ['present', 'absent'],
+      (lens) => lens === 'present',
+      () => workflowBody('present'),
+    );
+    assert.deepEqual([...expected.keys()], ['present.md']);
+    assert.deepEqual(missing, ['absent']);
+  });
+
+  it('returns an empty plan for an empty taxonomy', () => {
+    const { expected, missing } = planChecklists(
+      [],
+      () => true,
+      () => '',
+    );
+    assert.equal(expected.size, 0);
+    assert.deepEqual(missing, []);
+  });
+});
+
+describe('buildExpected', () => {
+  it('reports on-disk files that map to no current lens as strays', () => {
+    const files = {
+      [path.join(WORKFLOWS, 'audit-alpha.md')]: workflowBody('alpha'),
+      [path.join(CHECKLISTS, 'alpha.md')]: 'stale',
+      [path.join(CHECKLISTS, 'retired.md')]: 'stray',
+      [path.join(CHECKLISTS, 'notes.txt')]: 'ignored — not markdown',
+    };
+    const d = deps(files, ['alpha']);
+    const { expected, missing, strays } = buildExpected(d);
+    assert.deepEqual([...expected.keys()], ['alpha.md']);
+    assert.deepEqual(missing, []);
+    assert.deepEqual(strays, ['retired.md']);
+  });
+
+  it('reports no strays when the checklist directory does not exist yet', () => {
+    const d = deps(
+      { [path.join(WORKFLOWS, 'audit-alpha.md')]: workflowBody('alpha') },
+      ['alpha'],
+    );
+    assert.deepEqual(buildExpected(d).strays, []);
+  });
+});
+
+describe('runGenerateLensChecklists --check', () => {
+  it('passes when every checklist matches and no stray exists', async () => {
+    const files = {
+      [path.join(WORKFLOWS, 'audit-alpha.md')]: workflowBody('alpha'),
+    };
+    const d = deps(files, ['alpha']);
+    // Seed the on-disk file with exactly what the generator would write.
+    const generated = buildExpected(d).expected.get('alpha.md');
+    files[path.join(CHECKLISTS, 'alpha.md')] = generated;
+
+    const result = await runGenerateLensChecklists(['--check'], d);
+    assert.deepEqual(result, { wrote: 0, pruned: 0, checked: true });
+    assert.deepEqual(d.fsImpl.writes, {});
+  });
+
+  it('throws naming the out-of-date checklist', async () => {
+    const files = {
+      [path.join(WORKFLOWS, 'audit-alpha.md')]: workflowBody('alpha'),
+      [path.join(CHECKLISTS, 'alpha.md')]: 'drifted content',
+    };
+    await assert.rejects(
+      () => runGenerateLensChecklists(['--check'], deps(files, ['alpha'])),
+      (err) => {
+        assert.match(err.message, /Lens checklists are out of sync/);
+        assert.match(
+          err.message,
+          /out of date: \.agents\/audit-checklists\/alpha\.md/,
+        );
+        assert.match(
+          err.message,
+          /Run `node \.agents\/scripts\/generate-lens-checklists\.js`/,
+        );
+        return true;
+      },
+    );
+  });
+
+  it('throws naming a checklist that is missing entirely', async () => {
+    const files = {
+      [path.join(WORKFLOWS, 'audit-alpha.md')]: workflowBody('alpha'),
+    };
+    await assert.rejects(
+      () => runGenerateLensChecklists(['--check'], deps(files, ['alpha'])),
+      /out of date: \.agents\/audit-checklists\/alpha\.md/,
+    );
+  });
+
+  it('throws naming a stray that maps to no lens', async () => {
+    const files = {
+      [path.join(WORKFLOWS, 'audit-alpha.md')]: workflowBody('alpha'),
+      [path.join(CHECKLISTS, 'retired.md')]: 'stray',
+    };
+    const d = deps(files, ['alpha']);
+    files[path.join(CHECKLISTS, 'alpha.md')] =
+      buildExpected(d).expected.get('alpha.md');
+    await assert.rejects(
+      () => runGenerateLensChecklists(['--check'], d),
+      /stray \(no lens\): \.agents\/audit-checklists\/retired\.md/,
+    );
+  });
+
+  it('reports a lens with no workflow instead of silently skipping it', async () => {
+    const infos = [];
+    const files = {
+      [path.join(WORKFLOWS, 'audit-alpha.md')]: workflowBody('alpha'),
+    };
+    const d = {
+      ...deps(files, ['alpha', 'ghost']),
+      logger: { info: (m) => infos.push(m) },
+    };
+    files[path.join(CHECKLISTS, 'alpha.md')] =
+      buildExpected(d).expected.get('alpha.md');
+    await runGenerateLensChecklists(['--check'], d);
+    assert.match(
+      infos[0],
+      /no audit-<lens>\.md for: ghost — no checklist emitted/,
+    );
+  });
+});
+
+describe('runGenerateLensChecklists (write mode)', () => {
+  it('writes every missing checklist and creates the directory', async () => {
+    const files = {
+      [path.join(WORKFLOWS, 'audit-alpha.md')]: workflowBody('alpha'),
+      [path.join(WORKFLOWS, 'audit-beta.md')]: workflowBody('beta'),
+    };
+    const d = deps(files, ['alpha', 'beta']);
+    const result = await runGenerateLensChecklists([], d);
+    assert.deepEqual(result, { wrote: 2, pruned: 0 });
+    assert.deepEqual(d.fsImpl.mkdirs, [CHECKLISTS]);
+    assert.deepEqual(Object.keys(d.fsImpl.writes).sort(), [
+      path.join(CHECKLISTS, 'alpha.md'),
+      path.join(CHECKLISTS, 'beta.md'),
+    ]);
+  });
+
+  it('is idempotent: an up-to-date checklist is not rewritten', async () => {
+    const files = {
+      [path.join(WORKFLOWS, 'audit-alpha.md')]: workflowBody('alpha'),
+    };
+    const first = deps(files, ['alpha']);
+    await runGenerateLensChecklists([], first);
+    const second = deps(files, ['alpha']);
+    const result = await runGenerateLensChecklists([], second);
+    assert.deepEqual(result, { wrote: 0, pruned: 0 });
+    assert.deepEqual(second.fsImpl.writes, {});
+  });
+
+  it('prunes strays and reports each one', async () => {
+    const infos = [];
+    const files = {
+      [path.join(WORKFLOWS, 'audit-alpha.md')]: workflowBody('alpha'),
+      [path.join(CHECKLISTS, 'retired.md')]: 'stray',
+    };
+    const d = {
+      ...deps(files, ['alpha']),
+      logger: { info: (m) => infos.push(m) },
+    };
+    const result = await runGenerateLensChecklists([], d);
+    assert.equal(result.pruned, 1);
+    assert.deepEqual(d.fsImpl.removed, [path.join(CHECKLISTS, 'retired.md')]);
+    assert.ok(
+      infos.some((m) =>
+        /pruned stray \.agents\/audit-checklists\/retired\.md/.test(m),
+      ),
+    );
+    assert.ok(
+      infos.some((m) => /wrote 1 of 1 checklist\(s\) \(1 pruned\)/.test(m)),
+    );
+  });
+});

--- a/tests/lib/checks/story-init-not-backgrounded.test.js
+++ b/tests/lib/checks/story-init-not-backgrounded.test.js
@@ -1,0 +1,258 @@
+import assert from 'node:assert/strict';
+import path from 'node:path';
+import { describe, it } from 'node:test';
+
+import check, {
+  scanFile,
+  walkSources,
+} from '../../../.agents/scripts/lib/checks/story-init-not-backgrounded.js';
+
+/**
+ * Story #4780 — `scanFile` scored CRAP 72 and `walkSources` 21.5 with no test
+ * file at all: the blocker check that stops `single-story-init.js` from being
+ * backgrounded had none of its own detection rules verified.
+ *
+ * The filesystem is injected as a plain stub through the optional final
+ * `fsImpl` parameter (`.agents/rules/test-seams.md` rules 1, 4 and 5). No
+ * module mocking, and the seam lives on the functions — never on a
+ * module-level variable.
+ */
+
+const ROOT = path.resolve(path.sep, 'repo', '.agents');
+const at = (...parts) => path.join(ROOT, ...parts);
+
+/**
+ * In-memory `node:fs` stub over a `{ '<abs path>': '<content>' }` map.
+ * Directories are inferred from the keys.
+ *
+ * @param {Record<string, string>} files
+ * @param {{ unreadable?: string[] }} [opts]
+ */
+function makeFsStub(files, { unreadable = [] } = {}) {
+  const dirs = new Set();
+  for (const file of Object.keys(files)) {
+    let dir = path.dirname(file);
+    while (dir && dir !== path.dirname(dir)) {
+      dirs.add(dir);
+      dir = path.dirname(dir);
+    }
+  }
+  return {
+    readdirSync(dir) {
+      if (!dirs.has(dir)) throw new Error(`ENOENT: ${dir}`);
+      const names = new Map();
+      for (const file of Object.keys(files)) {
+        if (path.dirname(file) === dir) {
+          names.set(path.basename(file), false);
+          continue;
+        }
+        if (!file.startsWith(`${dir}${path.sep}`)) continue;
+        names.set(file.slice(dir.length + 1).split(path.sep)[0], true);
+      }
+      return [...names].map(([name, isDir]) => ({
+        name,
+        isDirectory: () => isDir,
+        isFile: () => !isDir,
+      }));
+    },
+    readFileSync(file) {
+      if (unreadable.includes(file)) throw new Error(`EACCES: ${file}`);
+      if (!(file in files)) throw new Error(`ENOENT: ${file}`);
+      return files[file];
+    },
+  };
+}
+
+describe('walkSources', () => {
+  it('collects .js and .md sources recursively', () => {
+    const fsImpl = makeFsStub({
+      [at('workflows', 'deliver.md')]: '',
+      [at('scripts', 'a.js')]: '',
+      [at('scripts', 'nested', 'b.mjs')]: '',
+      [at('scripts', 'nested', 'c.cjs')]: '',
+    });
+    assert.deepEqual(
+      walkSources(ROOT, fsImpl).sort(),
+      [
+        at('scripts', 'a.js'),
+        at('scripts', 'nested', 'b.mjs'),
+        at('scripts', 'nested', 'c.cjs'),
+        at('workflows', 'deliver.md'),
+      ].sort(),
+    );
+  });
+
+  it('ignores files whose extension is not a source extension', () => {
+    const fsImpl = makeFsStub({
+      [at('data.json')]: '',
+      [at('notes.txt')]: '',
+      [at('real.js')]: '',
+    });
+    assert.deepEqual(walkSources(ROOT, fsImpl), [at('real.js')]);
+  });
+
+  it('skips node_modules, .worktrees, and .git* directories', () => {
+    const fsImpl = makeFsStub({
+      [at('node_modules', 'dep.js')]: '',
+      [at('.worktrees', 'story-1', 'x.js')]: '',
+      [at('.github', 'w.md')]: '',
+      [at('kept.js')]: '',
+    });
+    assert.deepEqual(walkSources(ROOT, fsImpl), [at('kept.js')]);
+  });
+
+  it('returns an empty array when the root cannot be read', () => {
+    assert.deepEqual(walkSources(at('missing'), makeFsStub({})), []);
+  });
+});
+
+describe('scanFile', () => {
+  const withWindow = (token) =>
+    ['node .agents/scripts/single-story-init.js --story 1', token].join('\n');
+
+  it('flags run_in_background: true near a story-init.js reference', () => {
+    const offences = scanFile(
+      at('workflows', 'x.md'),
+      withWindow('Bash(run_in_background: true)'),
+    );
+    assert.equal(offences.length, 1);
+    assert.equal(offences[0].line, 1);
+    assert.match(offences[0].kind, /run_in_background/);
+  });
+
+  it('flags detached: true near a story-init.js reference', () => {
+    const offences = scanFile(
+      at('x.js'),
+      withWindow('spawn(cmd, { detached: true })'),
+    );
+    assert.equal(offences.length, 1);
+    assert.match(offences[0].kind, /detached/);
+  });
+
+  it('flags POSIX `&` backgrounding on the invocation line itself', () => {
+    const offences = scanFile(
+      at('x.md'),
+      'node .agents/scripts/single-story-init.js --story 1 &',
+    );
+    assert.equal(offences.length, 1);
+  });
+
+  it('reports at most one offence per line even when two tokens match', () => {
+    const offences = scanFile(
+      at('x.md'),
+      [
+        'node single-story-init.js --story 1',
+        'run_in_background: true',
+        'detached: true',
+      ].join('\n'),
+    );
+    assert.equal(offences.length, 1);
+  });
+
+  it('does not flag a story-init reference with no backgrounding token nearby', () => {
+    assert.deepEqual(
+      scanFile(at('x.md'), 'node single-story-init.js --story 1\nthen wait.'),
+      [],
+    );
+  });
+
+  it('does not flag a backgrounding token more than the window away', () => {
+    const lines = ['node single-story-init.js --story 1'];
+    for (let i = 0; i < 25; i += 1) lines.push(`filler ${i}`);
+    lines.push('run_in_background: true');
+    assert.deepEqual(scanFile(at('x.md'), lines.join('\n')), []);
+  });
+
+  it('reports one offence per referencing line', () => {
+    const src = [
+      'node single-story-init.js --story 1',
+      'run_in_background: true',
+      'node single-story-init.js --story 2',
+    ].join('\n');
+    assert.deepEqual(
+      scanFile(at('x.md'), src).map((o) => o.line),
+      [1, 3],
+    );
+  });
+
+  for (const exempt of [
+    'single-story-init.js',
+    'story-init-not-backgrounded.js',
+    'story-init-not-backgrounded.test.js',
+    'parallel-tooling.md',
+  ]) {
+    it(`never flags ${exempt} (self-reference / documentation carve-out)`, () => {
+      assert.deepEqual(
+        scanFile(at(exempt), withWindow('run_in_background: true')),
+        [],
+      );
+    });
+  }
+});
+
+describe('check.detect', () => {
+  it('returns null when the tree is clean', () => {
+    const fsImpl = makeFsStub({
+      [at('workflows', 'ok.md')]: 'node single-story-init.js --story 1\n',
+    });
+    assert.equal(check.detect({ scanRoot: ROOT }, fsImpl), null);
+  });
+
+  it('returns a blocker finding naming file, line, and token', () => {
+    const fsImpl = makeFsStub({
+      [at('workflows', 'bad.md')]:
+        'node single-story-init.js --story 1\nrun_in_background: true\n',
+    });
+    const finding = check.detect({ scanRoot: ROOT }, fsImpl);
+    assert.equal(finding.id, 'story-init-not-backgrounded');
+    assert.equal(finding.severity, 'blocker');
+    assert.equal(finding.autoCorrectable, false);
+    assert.equal(finding.scope, 'story-close');
+    assert.match(finding.summary, /1 orchestration call site/);
+    assert.match(finding.detail, /workflows\/bad\.md:1/);
+    assert.match(finding.fixCommand, /timeout: 600000/);
+  });
+
+  it('honours an explicit scope in the state', () => {
+    const fsImpl = makeFsStub({
+      [at('bad.md')]:
+        'node single-story-init.js --story 1\nrun_in_background: true\n',
+    });
+    assert.equal(
+      check.detect({ scanRoot: ROOT, scope: 'retro' }, fsImpl).scope,
+      'retro',
+    );
+  });
+
+  it('skips files that never mention story-init.js without scanning them', () => {
+    const fsImpl = makeFsStub({
+      [at('unrelated.md')]: 'run_in_background: true\n',
+    });
+    assert.equal(check.detect({ scanRoot: ROOT }, fsImpl), null);
+  });
+
+  it('skips an unreadable file rather than failing the whole check', () => {
+    const fsImpl = makeFsStub(
+      {
+        [at('unreadable.md')]:
+          'node single-story-init.js --story 1\nrun_in_background: true\n',
+      },
+      { unreadable: [at('unreadable.md')] },
+    );
+    assert.equal(check.detect({ scanRoot: ROOT }, fsImpl), null);
+  });
+
+  it('derives the scan root from state.cwd when no scanRoot is given', () => {
+    const cwd = path.resolve(path.sep, 'repo');
+    const fsImpl = makeFsStub({
+      [at('bad.md')]:
+        'node single-story-init.js --story 1\nrun_in_background: true\n',
+    });
+    assert.equal(check.detect({ cwd }, fsImpl).summary.startsWith('1 '), true);
+  });
+
+  it('declares the refuse-and-print contract the workflow relies on', () => {
+    assert.equal(check.autoCorrect, 'refuse-and-print');
+    assert.deepEqual(check.scope, ['story-close', 'retro']);
+  });
+});

--- a/tests/lib/cli/version-helpers.test.js
+++ b/tests/lib/cli/version-helpers.test.js
@@ -1,0 +1,189 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import {
+  compareVersions,
+  crossesMajor,
+  parseVersion,
+  resolveConsumerPinSpec,
+  resolveConsumerPinVersion,
+  satisfiesPinSpec,
+} from '../../../lib/cli/version-helpers.js';
+
+/**
+ * Story #4780 — `satisfiesPinSpec` scored CRAP 60.7 because nothing reached
+ * it: the caret/tilde/exact range table is what `mandrel doctor`'s
+ * `pin-current` check decides on, and it was entirely unexercised.
+ *
+ * The filesystem-touching pair below is driven through the module's
+ * `fsImpl` seam (`.agents/rules/test-seams.md` rules 1 and 5) — a plain stub
+ * object passed as the final parameter, never a module mock.
+ */
+
+describe('parseVersion / compareVersions / crossesMajor', () => {
+  it('coerces missing and non-numeric segments to 0', () => {
+    assert.deepEqual(parseVersion('2.16.3'), [2, 16, 3]);
+    assert.deepEqual(parseVersion('2.16'), [2, 16, 0]);
+    assert.deepEqual(parseVersion('x.y.z'), [0, 0, 0]);
+  });
+
+  it('orders on major, then minor, then patch', () => {
+    assert.ok(compareVersions('2.0.0', '1.9.9') > 0);
+    assert.ok(compareVersions('1.2.3', '1.3.0') < 0);
+    assert.equal(compareVersions('1.2.3', '1.2.3'), 0);
+  });
+
+  it('crossesMajor is true only when the major axis advances', () => {
+    assert.equal(crossesMajor('2.16.0', '3.0.0'), true);
+    assert.equal(crossesMajor('2.16.0', '2.99.9'), false);
+    assert.equal(crossesMajor('3.0.0', '2.0.0'), false);
+  });
+});
+
+describe('satisfiesPinSpec', () => {
+  it('rejects anything below the spec version regardless of operator', () => {
+    assert.equal(
+      satisfiesPinSpec('1.2.2', { operator: '^', version: '1.2.3' }),
+      false,
+    );
+    assert.equal(
+      satisfiesPinSpec('1.2.2', { operator: '~', version: '1.2.3' }),
+      false,
+    );
+    assert.equal(
+      satisfiesPinSpec('1.2.2', { operator: '', version: '1.2.3' }),
+      false,
+    );
+  });
+
+  it('~1.2.3 admits the patch axis only', () => {
+    const spec = { operator: '~', version: '1.2.3' };
+    assert.equal(satisfiesPinSpec('1.2.3', spec), true);
+    assert.equal(satisfiesPinSpec('1.2.99', spec), true);
+    assert.equal(satisfiesPinSpec('1.3.0', spec), false);
+    assert.equal(satisfiesPinSpec('2.2.3', spec), false);
+  });
+
+  it('^1.2.3 admits the whole 1.x line', () => {
+    const spec = { operator: '^', version: '1.2.3' };
+    assert.equal(satisfiesPinSpec('1.2.3', spec), true);
+    assert.equal(satisfiesPinSpec('1.99.0', spec), true);
+    assert.equal(satisfiesPinSpec('2.0.0', spec), false);
+  });
+
+  it('^0.2.3 pins the minor axis (0.x: minor is the API axis)', () => {
+    const spec = { operator: '^', version: '0.2.3' };
+    assert.equal(satisfiesPinSpec('0.2.3', spec), true);
+    assert.equal(satisfiesPinSpec('0.2.99', spec), true);
+    assert.equal(satisfiesPinSpec('0.3.0', spec), false);
+    assert.equal(satisfiesPinSpec('1.0.0', spec), false);
+  });
+
+  it('^0.0.3 pins the patch axis exactly', () => {
+    const spec = { operator: '^', version: '0.0.3' };
+    assert.equal(satisfiesPinSpec('0.0.3', spec), true);
+    assert.equal(satisfiesPinSpec('0.0.4', spec), false);
+    assert.equal(satisfiesPinSpec('0.1.0', spec), false);
+  });
+
+  it('an empty operator is an exact match', () => {
+    const spec = { operator: '', version: '2.16.0' };
+    assert.equal(satisfiesPinSpec('2.16.0', spec), true);
+    assert.equal(satisfiesPinSpec('2.16.1', spec), false);
+  });
+
+  it('ignores prerelease tags on both sides (numeric-tuple contract)', () => {
+    assert.equal(
+      satisfiesPinSpec('2.16.0-rc.1', { operator: '^', version: '2.16.0' }),
+      true,
+    );
+  });
+});
+
+describe('resolveConsumerPinSpec / resolveConsumerPinVersion', () => {
+  /** @param {string} json */
+  const fsStub = (json) => ({
+    readFileSync: () => {
+      if (json === null) throw new Error('ENOENT');
+      return json;
+    },
+  });
+
+  it('reads the dependencies entry, splitting operator from base version', () => {
+    const fsImpl = fsStub(
+      JSON.stringify({ dependencies: { mandrel: '^2.16.0' } }),
+    );
+    assert.deepEqual(resolveConsumerPinSpec('/consumer', fsImpl), {
+      operator: '^',
+      version: '2.16.0',
+    });
+    assert.equal(resolveConsumerPinVersion('/consumer', fsImpl), '2.16.0');
+  });
+
+  it('falls back to devDependencies', () => {
+    const fsImpl = fsStub(
+      JSON.stringify({ devDependencies: { mandrel: '~1.4.2' } }),
+    );
+    assert.deepEqual(resolveConsumerPinSpec('/consumer', fsImpl), {
+      operator: '~',
+      version: '1.4.2',
+    });
+  });
+
+  it('returns null for an unreadable package.json', () => {
+    assert.equal(resolveConsumerPinSpec('/consumer', fsStub(null)), null);
+    assert.equal(resolveConsumerPinVersion('/consumer', fsStub(null)), null);
+  });
+
+  it('returns null when package.json is not JSON', () => {
+    assert.equal(
+      resolveConsumerPinSpec('/consumer', fsStub('{ not json')),
+      null,
+    );
+  });
+
+  it('returns null when there is no mandrel entry at all', () => {
+    assert.equal(
+      resolveConsumerPinSpec(
+        '/consumer',
+        fsStub(JSON.stringify({ dependencies: {} })),
+      ),
+      null,
+    );
+  });
+
+  it('returns null for a non-semver specifier (workspace:/latest/range)', () => {
+    for (const declared of [
+      'workspace:*',
+      'latest',
+      '>=2.0.0 <3.0.0',
+      'file:../m',
+    ]) {
+      assert.equal(
+        resolveConsumerPinSpec(
+          '/consumer',
+          fsStub(JSON.stringify({ dependencies: { mandrel: declared } })),
+        ),
+        null,
+        `expected null for ${declared}`,
+      );
+    }
+  });
+
+  it('accepts an exact pin and a prerelease pin', () => {
+    assert.deepEqual(
+      resolveConsumerPinSpec(
+        '/consumer',
+        fsStub(JSON.stringify({ dependencies: { mandrel: '2.16.0' } })),
+      ),
+      { operator: '', version: '2.16.0' },
+    );
+    assert.deepEqual(
+      resolveConsumerPinSpec(
+        '/consumer',
+        fsStub(JSON.stringify({ dependencies: { mandrel: '^2.17.0-rc.1' } })),
+      ),
+      { operator: '^', version: '2.17.0-rc.1' },
+    );
+  });
+});

--- a/tests/lib/git-branch-lifecycle.test.js
+++ b/tests/lib/git-branch-lifecycle.test.js
@@ -1,5 +1,8 @@
 import assert from 'node:assert/strict';
 import { execFileSync, spawnSync } from 'node:child_process';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
 import { afterEach, describe, it } from 'node:test';
 
 import {
@@ -7,8 +10,10 @@ import {
   branchExistsRemotely,
   branchExistsViaTrackingRef,
   checkoutStoryBranch,
+  classifyBranchSeed,
   currentBranch,
   ensureLocalBranch,
+  seedStoryBranchRef,
 } from '../../.agents/scripts/lib/git-branch-lifecycle.js';
 import { __setGitRunners } from '../../.agents/scripts/lib/git-utils.js';
 
@@ -172,6 +177,202 @@ describe('checkoutStoryBranch', () => {
     const r = installScriptedRunner([OK('main'), FAIL(), OK('')]);
     await checkoutStoryBranch('story-100', 'epic/1', '/cwd');
     assert.deepEqual(r.execCalls[0], ['checkout', '-b', 'story-100', 'epic/1']);
+  });
+});
+
+/**
+ * Story #4780 — `seedStoryBranchRef` scored CRAP 123.8, the worst method in
+ * the repo: the single-homed story-branch seed switch that every `/deliver`
+ * run goes through had no test at all.
+ *
+ * Its git seams are supplied through the function's own parameters — plain
+ * stubs, never a module mock (`.agents/rules/test-seams.md` rules 3 and 5) —
+ * and the defaults-bind-to-cwd contract (rule 1) is proven against a real
+ * throwaway repository rather than by mocking.
+ */
+describe('classifyBranchSeed', () => {
+  it('maps the (local, remote) presence matrix onto the three actions', () => {
+    assert.equal(
+      classifyBranchSeed({ localHas: true, remoteHas: true }),
+      'local',
+    );
+    assert.equal(
+      classifyBranchSeed({ localHas: true, remoteHas: false }),
+      'local',
+    );
+    assert.equal(
+      classifyBranchSeed({ localHas: false, remoteHas: true }),
+      'fetch',
+    );
+    assert.equal(
+      classifyBranchSeed({ localHas: false, remoteHas: false }),
+      'create',
+    );
+  });
+});
+
+describe('seedStoryBranchRef', () => {
+  const messages = {
+    reuse: (b) => `reuse ${b}`,
+    fetch: (b) => `fetch ${b}`,
+    create: (b, ref) => `create ${b} from ${ref}`,
+    createRace: (b) => `race ${b}`,
+    createError: (b, ref, stderr) => `createError ${b} ${ref} ${stderr}`,
+    fetchError: (b, stderr) => `fetchError ${b} ${stderr}`,
+  };
+
+  /**
+   * @param {{ local?: boolean, remote?: boolean, spawnResult?: object }} opts
+   */
+  function seams({ local = false, remote = false, spawnResult = OK() } = {}) {
+    const spawned = [];
+    const progressed = [];
+    return {
+      spawned,
+      progressed,
+      args: {
+        storyBranch: 'story-4780',
+        baseRef: 'main',
+        spawn: (a) => {
+          spawned.push(a);
+          return typeof spawnResult === 'function'
+            ? spawnResult(a)
+            : spawnResult;
+        },
+        existsLocally: () => local,
+        existsRemotely: () => remote,
+        progress: (level, message) => progressed.push(`${level}:${message}`),
+        messages,
+      },
+    };
+  }
+
+  it('reuses an existing local ref without spawning git', () => {
+    const s = seams({ local: true, remote: true });
+    seedStoryBranchRef(s.args);
+    assert.deepEqual(s.spawned, []);
+    assert.deepEqual(s.progressed, ['GIT:reuse story-4780']);
+  });
+
+  it('materialises a remote-only ref with a fetch', () => {
+    const s = seams({ remote: true });
+    seedStoryBranchRef(s.args);
+    assert.deepEqual(s.spawned, [['fetch', 'origin', 'story-4780:story-4780']]);
+    assert.deepEqual(s.progressed, ['GIT:fetch story-4780']);
+  });
+
+  it('throws the caller-supplied fetch error when the fetch fails', () => {
+    const s = seams({ remote: true, spawnResult: FAIL('no such ref') });
+    assert.throws(
+      () => seedStoryBranchRef(s.args),
+      /fetchError story-4780 no such ref/,
+    );
+  });
+
+  it('reports "(no stderr)" when a failing fetch says nothing', () => {
+    const s = seams({
+      remote: true,
+      spawnResult: { status: 1, stdout: '', stderr: '' },
+    });
+    assert.throws(
+      () => seedStoryBranchRef(s.args),
+      /fetchError story-4780 \(no stderr\)/,
+    );
+  });
+
+  it('does not inspect the fetch exit status when no fetchError message is given', () => {
+    const s = seams({ remote: true, spawnResult: FAIL('ignored') });
+    s.args.messages = { ...messages, fetchError: undefined };
+    assert.doesNotThrow(() => seedStoryBranchRef(s.args));
+  });
+
+  it('creates the branch from the base ref when neither side has it', () => {
+    const s = seams();
+    seedStoryBranchRef(s.args);
+    assert.deepEqual(s.spawned, [['branch', 'story-4780', 'main']]);
+    assert.deepEqual(s.progressed, ['GIT:create story-4780 from main']);
+  });
+
+  it('throws the caller-supplied create error when the create fails', () => {
+    const s = seams({ spawnResult: FAIL('fatal: bad object') });
+    assert.throws(
+      () => seedStoryBranchRef(s.args),
+      /createError story-4780 main fatal: bad object/,
+    );
+  });
+
+  it('falls back to stdout when a failing create wrote nothing to stderr', () => {
+    const s = seams({
+      spawnResult: { status: 1, stdout: 'on stdout', stderr: '' },
+    });
+    assert.throws(
+      () => seedStoryBranchRef(s.args),
+      /createError story-4780 main on stdout/,
+    );
+  });
+
+  it('swallows an "already exists" create race only when asked to', () => {
+    const racing = seams({
+      spawnResult: FAIL('fatal: a branch named ... already exists'),
+    });
+    racing.args.swallowCreateRace = true;
+    assert.doesNotThrow(() => seedStoryBranchRef(racing.args));
+    assert.equal(racing.progressed.at(-1), 'GIT:race story-4780');
+
+    const strict = seams({
+      spawnResult: FAIL('fatal: a branch named ... already exists'),
+    });
+    assert.throws(() => seedStoryBranchRef(strict.args), /createError/);
+  });
+
+  it('still throws under swallowCreateRace for any other create failure', () => {
+    const s = seams({ spawnResult: FAIL('fatal: not a valid object name') });
+    s.args.swallowCreateRace = true;
+    assert.throws(() => seedStoryBranchRef(s.args), /createError/);
+  });
+
+  it('uses a no-op progress sink when none is supplied', () => {
+    const s = seams({ local: true });
+    delete s.args.progress;
+    assert.doesNotThrow(() => seedStoryBranchRef(s.args));
+  });
+
+  it('defaults its git seams to the real implementation bound to cwd', () => {
+    const repo = mkdtempSync(path.join(tmpdir(), 'seed-story-branch-'));
+    try {
+      const env = Object.fromEntries(
+        Object.entries(process.env).filter(([k]) => !k.startsWith('GIT_')),
+      );
+      const git = (...args) =>
+        execFileSync('git', args, { cwd: repo, env, encoding: 'utf8' });
+      git('init', '--initial-branch=main');
+      git('config', 'user.email', 'test@example.com');
+      git('config', 'user.name', 'Test');
+      git('commit', '--allow-empty', '-m', 'root');
+
+      // No spawn / existsLocally / existsRemotely passed: the defaults must
+      // reach real git in `cwd` and create the branch.
+      seedStoryBranchRef({
+        storyBranch: 'story-4780',
+        baseRef: 'main',
+        cwd: repo,
+        messages,
+      });
+      assert.match(git('branch', '--list', 'story-4780'), /story-4780/);
+
+      // Re-running is a no-op: the local ref now exists, so the classifier
+      // returns `local` and nothing is re-created.
+      assert.doesNotThrow(() =>
+        seedStoryBranchRef({
+          storyBranch: 'story-4780',
+          baseRef: 'main',
+          cwd: repo,
+          messages,
+        }),
+      );
+    } finally {
+      rmSync(repo, { recursive: true, force: true });
+    }
   });
 });
 

--- a/tests/lib/migrations/retire-epic-ac-tags.test.js
+++ b/tests/lib/migrations/retire-epic-ac-tags.test.js
@@ -1,0 +1,215 @@
+import assert from 'node:assert/strict';
+import path from 'node:path';
+import { describe, it } from 'node:test';
+
+import { retireEpicAcTags } from '../../../lib/migrations/steps/2.2.0-retire-epic-ac-tags.js';
+
+/**
+ * Story #4780 — `stripEpicAcTags` (CRAP 42) and `collectFeatureFiles`
+ * (CRAP 30) were unreached: the migration step had no test at all, so the
+ * tag-line rewrite rules it encodes were unverified.
+ *
+ * Every stub below is a plain object passed through the step's optional final
+ * `fsImpl` parameter (`.agents/rules/test-seams.md` rules 1 and 5) — no
+ * module mocking, no module-level seam state.
+ */
+
+/**
+ * Build an in-memory `node:fs` stub over a `{ '<abs path>': '<content>' }`
+ * map. Directory structure is derived from the keys, so a fixture is declared
+ * by its files alone.
+ *
+ * @param {Record<string, string>} files
+ */
+function makeFsStub(files) {
+  const writes = {};
+  const dirs = new Set();
+  for (const file of Object.keys(files)) {
+    let dir = path.dirname(file);
+    while (dir && dir !== path.dirname(dir)) {
+      dirs.add(dir);
+      dir = path.dirname(dir);
+    }
+  }
+  return {
+    writes,
+    readdirSync(dir, _opts) {
+      if (!dirs.has(dir)) {
+        const err = new Error(`ENOENT: ${dir}`);
+        throw err;
+      }
+      const names = new Map();
+      for (const file of Object.keys(files)) {
+        if (path.dirname(file) === dir) {
+          names.set(path.basename(file), false);
+          continue;
+        }
+        if (!file.startsWith(`${dir}${path.sep}`)) continue;
+        const rest = file.slice(dir.length + 1);
+        names.set(rest.split(path.sep)[0], true);
+      }
+      return [...names].map(([name, isDir]) => ({
+        name,
+        isDirectory: () => isDir,
+        isFile: () => !isDir,
+      }));
+    },
+    readFileSync(file) {
+      if (!(file in files)) throw new Error(`ENOENT: ${file}`);
+      return files[file];
+    },
+    writeFileSync(file, content) {
+      writes[file] = content;
+      files[file] = content;
+    },
+  };
+}
+
+const ROOT = path.resolve(path.sep, 'consumer');
+const featurePath = (...parts) =>
+  path.join(ROOT, 'tests', 'features', ...parts);
+
+describe('retireEpicAcTags.detect', () => {
+  it('is false when no feature file carries a retired tag', () => {
+    const fsImpl = makeFsStub({
+      [featurePath('login.feature')]: '@smoke\nFeature: Login\n',
+    });
+    assert.equal(retireEpicAcTags.detect({ projectRoot: ROOT }, fsImpl), false);
+  });
+
+  it('is true when any feature file carries a retired tag', () => {
+    const fsImpl = makeFsStub({
+      [featurePath('login.feature')]: '@smoke\nFeature: Login\n',
+      [featurePath('nested', 'billing.feature')]:
+        '@epic-4604-ac-2\nFeature: Billing\n',
+    });
+    assert.equal(retireEpicAcTags.detect({ projectRoot: ROOT }, fsImpl), true);
+  });
+
+  it('is false when there are no feature roots at all', () => {
+    const fsImpl = makeFsStub({});
+    assert.equal(retireEpicAcTags.detect({ projectRoot: ROOT }, fsImpl), false);
+  });
+
+  it('skips a file whose read throws rather than propagating', () => {
+    const fsImpl = makeFsStub({
+      [featurePath('ok.feature')]: 'Feature: Fine\n',
+    });
+    const throwing = {
+      ...fsImpl,
+      readFileSync: () => {
+        throw new Error('EACCES');
+      },
+    };
+    assert.equal(
+      retireEpicAcTags.detect({ projectRoot: ROOT }, throwing),
+      false,
+    );
+  });
+
+  it('honours ctx.fs when no explicit fsImpl is passed', () => {
+    const fsImpl = makeFsStub({
+      [featurePath('a.feature')]: '@epic-1-ac-1\nFeature: A\n',
+    });
+    assert.equal(
+      retireEpicAcTags.detect({ projectRoot: ROOT, fs: fsImpl }),
+      true,
+    );
+  });
+});
+
+describe('retireEpicAcTags.apply', () => {
+  it('drops a retired tag but keeps the rest of the tag line and its indent', () => {
+    const files = {
+      [featurePath('a.feature')]:
+        '  @smoke @epic-4604-ac-2 @wip\nFeature: A\n  Scenario: s\n',
+    };
+    const fsImpl = makeFsStub(files);
+    retireEpicAcTags.apply({ projectRoot: ROOT }, fsImpl);
+    assert.equal(
+      fsImpl.writes[featurePath('a.feature')],
+      '  @smoke @wip\nFeature: A\n  Scenario: s\n',
+    );
+  });
+
+  it('removes a tag line whose every tag was retired', () => {
+    const files = {
+      [featurePath('a.feature')]: '@epic-1-ac-1 @epic-1-ac-2\nFeature: A\n',
+    };
+    const fsImpl = makeFsStub(files);
+    retireEpicAcTags.apply({ projectRoot: ROOT }, fsImpl);
+    assert.equal(fsImpl.writes[featurePath('a.feature')], 'Feature: A\n');
+  });
+
+  it('never rewrites a file with no retired tags', () => {
+    const fsImpl = makeFsStub({
+      [featurePath('a.feature')]: '@smoke\nFeature: A\n',
+    });
+    retireEpicAcTags.apply({ projectRoot: ROOT }, fsImpl);
+    assert.deepEqual(fsImpl.writes, {});
+  });
+
+  it('leaves a non-tag line mentioning the tag byte-for-byte intact', () => {
+    const original = [
+      '@smoke',
+      'Feature: A',
+      '  # historical note: @epic-1-ac-1 used to live here',
+      '',
+    ].join('\n');
+    const fsImpl = makeFsStub({ [featurePath('a.feature')]: original });
+    retireEpicAcTags.apply({ projectRoot: ROOT }, fsImpl);
+    assert.deepEqual(fsImpl.writes, {});
+  });
+
+  it('preserves CRLF line endings', () => {
+    const fsImpl = makeFsStub({
+      [featurePath('a.feature')]: '@smoke @epic-9-ac-9\r\nFeature: A\r\n',
+    });
+    retireEpicAcTags.apply({ projectRoot: ROOT }, fsImpl);
+    assert.equal(
+      fsImpl.writes[featurePath('a.feature')],
+      '@smoke\r\nFeature: A\r\n',
+    );
+  });
+
+  it('walks nested directories and every canonical feature root', () => {
+    const nested = path.join(ROOT, 'features', 'deep', 'nest', 'b.feature');
+    const files = {
+      [featurePath('a.feature')]: '@epic-1-ac-1 @keep\nFeature: A\n',
+      [nested]: '@epic-2-ac-2 @also\nFeature: B\n',
+      [path.join(ROOT, 'test', 'features', 'c.feature')]:
+        '@epic-3-ac-3 @third\nFeature: C\n',
+    };
+    const fsImpl = makeFsStub(files);
+    retireEpicAcTags.apply({ projectRoot: ROOT }, fsImpl);
+    assert.deepEqual(
+      Object.keys(fsImpl.writes).sort(),
+      [
+        path.join(ROOT, 'features', 'deep', 'nest', 'b.feature'),
+        path.join(ROOT, 'test', 'features', 'c.feature'),
+        featurePath('a.feature'),
+      ].sort(),
+    );
+  });
+
+  it('skips an unreadable file rather than aborting the migration', () => {
+    const files = { [featurePath('a.feature')]: '@epic-1-ac-1\nFeature: A\n' };
+    const base = makeFsStub(files);
+    const throwing = {
+      ...base,
+      readFileSync: () => {
+        throw new Error('EACCES');
+      },
+      writeFileSync: base.writeFileSync,
+    };
+    assert.doesNotThrow(() =>
+      retireEpicAcTags.apply({ projectRoot: ROOT }, throwing),
+    );
+    assert.deepEqual(base.writes, {});
+  });
+
+  it('exposes a stable version/description contract', () => {
+    assert.equal(retireEpicAcTags.version, '2.2.0');
+    assert.match(retireEpicAcTags.description, /@epic-<id>-ac-N/);
+  });
+});

--- a/tests/lib/orchestration/ticket-validator-conflicts.test.js
+++ b/tests/lib/orchestration/ticket-validator-conflicts.test.js
@@ -963,3 +963,274 @@ test('string body: a depends_on chain still serialises string-body writers (no s
   const shared = result.findings.filter((f) => f.kind === 'shared-editor');
   assert.deepEqual(shared, []);
 });
+
+/**
+ * Story #4780 — `computeRegistryFindings` scored CRAP 58.1: the
+ * cross-cutting-registry pass was reachable only incidentally through
+ * `computeConflictFindings`, leaving its sibling-create scope resolution and
+ * its same-wave clustering rules unverified.
+ *
+ * The pass is pure — no filesystem, no child process — so its optional final
+ * `deps` parameter seams the three collaborating predicates, each defaulting
+ * to the real implementation. Every stub below goes through that parameter
+ * (`.agents/rules/test-seams.md` rules 1, 3 and 5); nothing is module-mocked.
+ */
+const REGISTRY = 'lib/orchestration/lifecycle/listeners/index.js';
+
+/** Build a `reach` map where every listed pair is explicitly ordered. */
+function makeReach(edges = {}) {
+  return new Map(
+    Object.entries(edges).map(([slug, reachable]) => [
+      slug,
+      new Set(reachable),
+    ]),
+  );
+}
+
+/** Build the `producers` index shape: `Map<path, Array<{storySlug, taskSlug}>>`. */
+function makeProducers(entries) {
+  const map = new Map();
+  for (const [path, slugs] of Object.entries(entries)) {
+    map.set(
+      path,
+      slugs.map((storySlug) => ({ storySlug, taskSlug: storySlug })),
+    );
+  }
+  return map;
+}
+
+const registryInput = (overrides = {}) => ({
+  stories: [],
+  reach: makeReach(),
+  patterns: [REGISTRY, '**/handlers/index.js'],
+  producers: new Map(),
+  assumptionEntries: [],
+  severity: 'soft',
+  ...overrides,
+});
+
+test('registry pass: no hits at all yields no findings', () => {
+  assert.deepEqual(
+    _internal.computeRegistryFindings(
+      registryInput({
+        producers: makeProducers({ 'src/unrelated.js': ['s-a'] }),
+      }),
+    ),
+    [],
+  );
+});
+
+test('registry pass: two same-wave Stories editing the registry cluster into one finding', () => {
+  const findings = _internal.computeRegistryFindings(
+    registryInput({ producers: makeProducers({ [REGISTRY]: ['s-a', 's-b'] }) }),
+  );
+  assert.equal(findings.length, 1);
+  assert.equal(findings[0].kind, 'cross-cutting-registries');
+  assert.equal(findings[0].registryPath, REGISTRY);
+  assert.equal(findings[0].severity, 'soft');
+  assert.deepEqual(findings[0].storySlugs, ['s-a', 's-b']);
+  assert.deepEqual(
+    findings[0].producers.map((p) => p.reason),
+    ['edits-registry', 'edits-registry'],
+  );
+});
+
+test('registry pass: a depends_on chain between the editors suppresses the finding', () => {
+  assert.deepEqual(
+    _internal.computeRegistryFindings(
+      registryInput({
+        producers: makeProducers({ [REGISTRY]: ['s-a', 's-b'] }),
+        reach: makeReach({ 's-b': ['s-a'] }),
+      }),
+    ),
+    [],
+  );
+});
+
+test('registry pass: a single editing Story is never a conflict', () => {
+  assert.deepEqual(
+    _internal.computeRegistryFindings(
+      registryInput({ producers: makeProducers({ [REGISTRY]: ['s-a'] }) }),
+    ),
+    [],
+  );
+});
+
+test('registry pass: the severity flag is carried onto the finding', () => {
+  const findings = _internal.computeRegistryFindings(
+    registryInput({
+      producers: makeProducers({ [REGISTRY]: ['s-a', 's-b'] }),
+      severity: 'hard',
+    }),
+  );
+  assert.equal(findings[0].severity, 'hard');
+});
+
+test('registry pass: assumption entries touching the registry count as editors', () => {
+  const findings = _internal.computeRegistryFindings(
+    registryInput({
+      assumptionEntries: [
+        { path: REGISTRY, storySlug: 's-a', taskSlug: 's-a' },
+        { path: REGISTRY, storySlug: 's-b', taskSlug: 's-b' },
+        { path: 'src/other.js', storySlug: 's-c', taskSlug: 's-c' },
+      ],
+    }),
+  );
+  assert.equal(findings.length, 1);
+  assert.deepEqual(findings[0].storySlugs, ['s-a', 's-b']);
+});
+
+test('registry pass: a sibling create in the registry directory collides with an editor', () => {
+  const findings = _internal.computeRegistryFindings(
+    registryInput({
+      producers: makeProducers({ [REGISTRY]: ['s-a'] }),
+      stories: [
+        {
+          slug: 's-b',
+          body: {
+            changes: [
+              {
+                path: 'lib/orchestration/lifecycle/listeners/new-listener.js',
+                assumption: 'creates',
+              },
+            ],
+          },
+        },
+      ],
+    }),
+  );
+  assert.equal(findings.length, 1);
+  assert.deepEqual(findings[0].storySlugs, ['s-a', 's-b']);
+  assert.deepEqual(findings[0].producers.map((p) => p.reason).sort(), [
+    'creates-sibling',
+    'edits-registry',
+  ]);
+});
+
+test('registry pass: a create in a different directory is out of the registration scope', () => {
+  assert.deepEqual(
+    _internal.computeRegistryFindings(
+      registryInput({
+        producers: makeProducers({ [REGISTRY]: ['s-a'] }),
+        stories: [
+          {
+            slug: 's-b',
+            body: {
+              changes: [
+                { path: 'lib/elsewhere/new.js', assumption: 'creates' },
+              ],
+            },
+          },
+        ],
+      }),
+    ),
+    [],
+  );
+});
+
+test('registry pass: a glob pattern is only in scope once some path matches it', () => {
+  const withoutMatch = _internal.computeRegistryFindings(
+    registryInput({
+      patterns: ['**/handlers/index.js'],
+      stories: [
+        {
+          slug: 's-b',
+          body: {
+            changes: [{ path: 'src/handlers/new.js', assumption: 'creates' }],
+          },
+        },
+      ],
+    }),
+  );
+  assert.deepEqual(withoutMatch, []);
+
+  const withMatch = _internal.computeRegistryFindings(
+    registryInput({
+      patterns: ['**/handlers/index.js'],
+      producers: makeProducers({ 'src/handlers/index.js': ['s-a'] }),
+      stories: [
+        {
+          slug: 's-b',
+          body: {
+            changes: [{ path: 'src/handlers/new.js', assumption: 'creates' }],
+          },
+        },
+      ],
+    }),
+  );
+  assert.equal(withMatch.length, 1);
+  assert.equal(withMatch[0].registryPath, 'src/handlers/index.js');
+});
+
+test('registry pass: a glob pattern is in scope via an assumption entry too', () => {
+  const findings = _internal.computeRegistryFindings(
+    registryInput({
+      patterns: ['**/handlers/index.js'],
+      assumptionEntries: [
+        { path: 'src/handlers/index.js', storySlug: 's-a', taskSlug: 's-a' },
+      ],
+      stories: [
+        {
+          slug: 's-b',
+          body: {
+            changes: [{ path: 'src/handlers/new.js', assumption: 'creates' }],
+          },
+        },
+      ],
+    }),
+  );
+  assert.equal(findings.length, 1);
+  assert.deepEqual(findings[0].storySlugs, ['s-a', 's-b']);
+});
+
+test('registry pass: malformed Stories and change entries are skipped, not thrown on', () => {
+  assert.doesNotThrow(() =>
+    _internal.computeRegistryFindings(
+      registryInput({
+        producers: makeProducers({ [REGISTRY]: ['s-a'] }),
+        stories: [
+          { slug: 'no-body' },
+          { slug: 'string-body', body: 'not an object' },
+          { slug: 'no-changes', body: {} },
+          {
+            slug: 's-b',
+            body: {
+              changes: [
+                null,
+                'a string change',
+                { path: 'lib/x.js', assumption: 'refactors-existing' },
+                { assumption: 'creates' },
+                { path: 'top-level.js', assumption: 'creates' },
+              ],
+            },
+          },
+        ],
+      }),
+    ),
+  );
+});
+
+test('registry pass: every collaborating predicate is injectable through the final deps parameter', () => {
+  const seen = { registryPaths: [], waveChecks: 0 };
+  const findings = _internal.computeRegistryFindings(
+    registryInput({
+      producers: makeProducers({ 'anything/at/all.js': ['s-a', 's-b'] }),
+    }),
+    {
+      // Declare every path a registry — the pass must consult the seam, not
+      // the module-level predicate.
+      isRegistryPathImpl: (p) => {
+        seen.registryPaths.push(p);
+        return true;
+      },
+      inSameWaveImpl: () => {
+        seen.waveChecks += 1;
+        return true;
+      },
+    },
+  );
+  assert.deepEqual(seen.registryPaths, ['anything/at/all.js']);
+  assert.equal(seen.waveChecks, 1);
+  assert.equal(findings.length, 1);
+  assert.equal(findings[0].registryPath, 'anything/at/all.js');
+});

--- a/tests/nav-registry-diff.test.js
+++ b/tests/nav-registry-diff.test.js
@@ -1,0 +1,392 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import {
+  computeNavDiff,
+  formatDiffText,
+  isDynamicPath,
+  isDynamicSegment,
+  isSystemRoute,
+  normalizePath,
+  parentPath,
+  routeTemplateMatchesHref,
+  runNavRegistryDiff,
+  toDoor,
+  toRoute,
+} from '../.agents/scripts/nav-registry-diff.js';
+
+/**
+ * Story #4780 — the navigability cross-check had no test file, leaving
+ * `main` (CRAP 72), `orphanExemption` (42), `routeTemplateMatchesHref` (35)
+ * and `isDynamicSegment` (30) unreached. These are the rules that decide
+ * whether a route is reported as an orphan, so an unverified branch here is
+ * a silently wrong lens verdict.
+ *
+ * `runNavRegistryDiff`'s filesystem and stdout are injected through its
+ * optional final `deps` parameter (`.agents/rules/test-seams.md` rules 1, 4
+ * and 5) — plain stub objects, no module mocking.
+ */
+
+describe('normalizePath', () => {
+  it('returns empty string for non-strings and blanks', () => {
+    for (const input of [null, undefined, 42, {}, '', '   ']) {
+      assert.equal(normalizePath(input), '');
+    }
+  });
+
+  it('forces a leading slash and trims', () => {
+    assert.equal(normalizePath('  users  '), '/users');
+  });
+
+  it('collapses duplicate slashes', () => {
+    assert.equal(normalizePath('//a///b'), '/a/b');
+  });
+
+  it('drops a trailing slash except at the root', () => {
+    assert.equal(normalizePath('/a/b/'), '/a/b');
+    assert.equal(normalizePath('/'), '/');
+    assert.equal(normalizePath('///'), '/');
+  });
+});
+
+describe('isDynamicSegment / isDynamicPath', () => {
+  it('recognises every dynamic syntax', () => {
+    assert.equal(isDynamicSegment(':id'), true);
+    assert.equal(isDynamicSegment('*'), true);
+    assert.equal(isDynamicSegment('[id]'), true);
+    assert.equal(isDynamicSegment('[...slug]'), true);
+    assert.equal(isDynamicSegment('{id}'), true);
+  });
+
+  it('rejects static segments and half-open brackets', () => {
+    assert.equal(isDynamicSegment('users'), false);
+    assert.equal(isDynamicSegment('[id'), false);
+    assert.equal(isDynamicSegment('id]'), false);
+    assert.equal(isDynamicSegment('{id'), false);
+    assert.equal(isDynamicSegment('id}'), false);
+  });
+
+  it('isDynamicPath is true when any segment is dynamic', () => {
+    assert.equal(isDynamicPath('/users/:id'), true);
+    assert.equal(isDynamicPath('/users'), false);
+    assert.equal(isDynamicPath('/'), false);
+  });
+});
+
+describe('isSystemRoute / parentPath', () => {
+  it('treats a recognised last segment as a system route', () => {
+    assert.equal(isSystemRoute('/login'), true);
+    assert.equal(isSystemRoute('/auth/CALLBACK'), true);
+    assert.equal(isSystemRoute('/404'), true);
+    assert.equal(isSystemRoute('/dashboard'), false);
+    assert.equal(isSystemRoute('/'), false);
+  });
+
+  it('parentPath drops the last segment, bottoming out at the root', () => {
+    assert.equal(parentPath('/users/:id'), '/users');
+    assert.equal(parentPath('/users'), '/');
+    assert.equal(parentPath('/'), '/');
+    assert.equal(parentPath('/a/b/c'), '/a/b');
+  });
+});
+
+describe('routeTemplateMatchesHref', () => {
+  it('matches an identical static template', () => {
+    assert.equal(routeTemplateMatchesHref('/users', '/users'), true);
+  });
+
+  it('rejects a static template of a different length', () => {
+    assert.equal(routeTemplateMatchesHref('/users', '/users/1'), false);
+    assert.equal(routeTemplateMatchesHref('/users/1', '/users'), false);
+  });
+
+  it('rejects a differing static segment', () => {
+    assert.equal(routeTemplateMatchesHref('/users/new', '/users/edit'), false);
+  });
+
+  it('lets a dynamic segment match exactly one href segment', () => {
+    assert.equal(routeTemplateMatchesHref('/users/:id', '/users/42'), true);
+    assert.equal(
+      routeTemplateMatchesHref('/users/:id', '/users/42/edit'),
+      false,
+    );
+  });
+
+  it('lets a catch-all consume one or more trailing segments', () => {
+    assert.equal(routeTemplateMatchesHref('/docs/[...slug]', '/docs/a'), true);
+    assert.equal(
+      routeTemplateMatchesHref('/docs/[...slug]', '/docs/a/b/c'),
+      true,
+    );
+    assert.equal(routeTemplateMatchesHref('/docs/[...slug]', '/docs'), false);
+    assert.equal(routeTemplateMatchesHref('/*', '/anything'), true);
+  });
+
+  it('rejects an href shorter than the template', () => {
+    assert.equal(routeTemplateMatchesHref('/a/b/:c', '/a'), false);
+  });
+
+  it('matches the root against the root', () => {
+    assert.equal(routeTemplateMatchesHref('/', '/'), true);
+  });
+});
+
+describe('toRoute / toDoor', () => {
+  it('accepts a bare string', () => {
+    assert.deepEqual(toRoute('/users'), {
+      path: '/users',
+      personas: [],
+      exempt: false,
+    });
+    assert.deepEqual(toDoor('/users'), { href: '/users', persona: null });
+  });
+
+  it('keeps only non-blank string personas', () => {
+    assert.deepEqual(
+      toRoute({ path: '/x', personas: ['admin', '', '  ', 7, null] }).personas,
+      ['admin'],
+    );
+    assert.deepEqual(toRoute({ path: '/x', personas: 'admin' }).personas, []);
+  });
+
+  it('carries the explicit exempt flag', () => {
+    assert.equal(toRoute({ path: '/x', exempt: true }).exempt, true);
+    assert.equal(toRoute({ path: '/x', exempt: 'yes' }).exempt, false);
+  });
+
+  it('accepts a door declared with path instead of href', () => {
+    assert.deepEqual(toDoor({ path: '/x' }), { href: '/x', persona: null });
+  });
+
+  it('trims a persona and nulls a blank one', () => {
+    assert.equal(toDoor({ href: '/x', persona: '  admin ' }).persona, 'admin');
+    assert.equal(toDoor({ href: '/x', persona: '   ' }).persona, null);
+    assert.equal(toDoor({ href: '/x', persona: 5 }).persona, null);
+  });
+
+  it('throws loudly on an entry with no usable identifier', () => {
+    assert.throws(() => toRoute({ personas: ['a'] }), /no usable "path"/);
+    assert.throws(() => toRoute(null), /no usable "path"/);
+    assert.throws(() => toDoor({ persona: 'a' }), /no usable "href"/);
+  });
+});
+
+describe('computeNavDiff', () => {
+  it('reports nothing for an empty inventory', () => {
+    assert.deepEqual(computeNavDiff(), {
+      counts: { routes: 0, doors: 0 },
+      orphanedRoutes: [],
+      deadHrefs: [],
+      exemptRoutes: [],
+    });
+  });
+
+  it('reports a route no door surfaces as an orphan', () => {
+    const diff = computeNavDiff({ routes: ['/reports'], nav: ['/home'] });
+    assert.deepEqual(diff.orphanedRoutes, [{ path: '/reports', personas: [] }]);
+    assert.deepEqual(diff.deadHrefs, [{ href: '/home', persona: null }]);
+    assert.deepEqual(diff.counts, { routes: 1, doors: 1 });
+  });
+
+  it('treats a door with no persona as surfacing any entitled route', () => {
+    const diff = computeNavDiff({
+      routes: [{ path: '/admin', personas: ['admin'] }],
+      nav: ['/admin'],
+    });
+    assert.deepEqual(diff.orphanedRoutes, []);
+  });
+
+  it('requires an entitled persona when both sides declare one', () => {
+    const diff = computeNavDiff({
+      routes: [{ path: '/admin', personas: ['admin'] }],
+      nav: [{ href: '/admin', persona: 'viewer' }],
+    });
+    assert.deepEqual(diff.orphanedRoutes, [
+      { path: '/admin', personas: ['admin'] },
+    ]);
+    assert.deepEqual(diff.deadHrefs, []);
+  });
+
+  it('exempts an explicitly exempt route', () => {
+    const diff = computeNavDiff({
+      routes: [{ path: '/internal', exempt: true }],
+      nav: [],
+    });
+    assert.deepEqual(diff.exemptRoutes, [
+      { path: '/internal', reason: 'explicit-exempt' },
+    ]);
+  });
+
+  it('exempts a system route', () => {
+    const diff = computeNavDiff({ routes: ['/login'], nav: [] });
+    assert.deepEqual(diff.exemptRoutes, [
+      { path: '/login', reason: 'system-route' },
+    ]);
+  });
+
+  it('exempts a dynamic child of a surfaced parent', () => {
+    const diff = computeNavDiff({
+      routes: ['/users', '/users/:id'],
+      nav: ['/users'],
+    });
+    assert.deepEqual(diff.exemptRoutes, [
+      { path: '/users/:id', reason: 'dynamic-child-of-surfaced-parent' },
+    ]);
+    assert.deepEqual(diff.orphanedRoutes, []);
+  });
+
+  it('does NOT exempt a dynamic child whose parent is itself unsurfaced', () => {
+    const diff = computeNavDiff({ routes: ['/users/:id'], nav: [] });
+    assert.deepEqual(diff.orphanedRoutes, [
+      { path: '/users/:id', personas: [] },
+    ]);
+  });
+
+  it('exempts a route reached only by an in-app inbound reference', () => {
+    const diff = computeNavDiff({
+      routes: ['/reports'],
+      nav: [],
+      refs: ['/reports', '', null],
+    });
+    assert.deepEqual(diff.exemptRoutes, [
+      { path: '/reports', reason: 'inbound-in-app-reference' },
+    ]);
+  });
+
+  it('resolves a door against a template route, so it is not dead', () => {
+    const diff = computeNavDiff({ routes: ['/users/:id'], nav: ['/users/7'] });
+    assert.deepEqual(diff.deadHrefs, []);
+  });
+});
+
+describe('formatDiffText', () => {
+  it('renders counts, orphans, dead hrefs, and exemptions', () => {
+    const text = formatDiffText(
+      computeNavDiff({
+        routes: ['/reports', { path: '/admin', personas: ['admin'] }, '/login'],
+        nav: [{ href: '/nowhere', persona: 'admin' }],
+      }),
+    );
+    assert.match(text, /routes: 3 {3}nav doors: 1/);
+    assert.match(text, /- \/admin \[admin\]/);
+    assert.match(text, /- \/nowhere \[admin\]/);
+    assert.match(text, /- \/login — system-route/);
+  });
+});
+
+describe('runNavRegistryDiff', () => {
+  const fsStub = (files) => ({
+    readFileSync: (file) => {
+      if (!(file in files)) throw new Error(`ENOENT: ${file}`);
+      return files[file];
+    },
+  });
+
+  const sink = () => {
+    const chunks = [];
+    return { chunks, write: (s) => chunks.push(s) };
+  };
+
+  it('requires both --routes and --nav', async () => {
+    await assert.rejects(
+      () => runNavRegistryDiff([], { fsImpl: fsStub({}), stdout: sink() }),
+      /both --routes <file> and --nav <file> are required/,
+    );
+    await assert.rejects(
+      () =>
+        runNavRegistryDiff(['--routes', 'r.json'], {
+          fsImpl: fsStub({}),
+          stdout: sink(),
+        }),
+      /both --routes <file> and --nav <file> are required/,
+    );
+  });
+
+  it('prints the text report and exits 0 when there are findings but no --strict', async () => {
+    const out = sink();
+    const code = await runNavRegistryDiff(
+      ['--routes', 'r.json', '--nav', 'n.json'],
+      {
+        fsImpl: fsStub({
+          'r.json': JSON.stringify(['/reports']),
+          'n.json': JSON.stringify([]),
+        }),
+        stdout: out,
+      },
+    );
+    assert.equal(code, 0);
+    assert.match(out.chunks.join(''), /orphaned routes: 1/);
+  });
+
+  it('exits 1 under --strict when a finding remains', async () => {
+    const code = await runNavRegistryDiff(
+      ['--routes', 'r.json', '--nav', 'n.json', '--strict'],
+      {
+        fsImpl: fsStub({
+          'r.json': JSON.stringify(['/reports']),
+          'n.json': JSON.stringify([]),
+        }),
+        stdout: sink(),
+      },
+    );
+    assert.equal(code, 1);
+  });
+
+  it('exits 0 under --strict when the inventories agree', async () => {
+    const code = await runNavRegistryDiff(
+      ['--routes', 'r.json', '--nav', 'n.json', '--strict'],
+      {
+        fsImpl: fsStub({
+          'r.json': JSON.stringify(['/home']),
+          'n.json': JSON.stringify(['/home']),
+        }),
+        stdout: sink(),
+      },
+    );
+    assert.equal(code, 0);
+  });
+
+  it('emits JSON under --json and folds in the optional --refs file', async () => {
+    const out = sink();
+    await runNavRegistryDiff(
+      ['--routes', 'r.json', '--nav', 'n.json', '--refs', 'f.json', '--json'],
+      {
+        fsImpl: fsStub({
+          'r.json': JSON.stringify({ routes: ['/reports'] }),
+          'n.json': JSON.stringify({ nav: [] }),
+          'f.json': JSON.stringify({ entries: ['/reports'] }),
+        }),
+        stdout: out,
+      },
+    );
+    const parsed = JSON.parse(out.chunks.join(''));
+    assert.deepEqual(parsed.orphanedRoutes, []);
+    assert.deepEqual(parsed.exemptRoutes, [
+      { path: '/reports', reason: 'inbound-in-app-reference' },
+    ]);
+  });
+
+  it('names the unreadable file, the bad JSON, and the non-array shape', async () => {
+    const base = ['--routes', 'r.json', '--nav', 'n.json'];
+    await assert.rejects(
+      () => runNavRegistryDiff(base, { fsImpl: fsStub({}), stdout: sink() }),
+      /cannot read routes file 'r\.json'/,
+    );
+    await assert.rejects(
+      () =>
+        runNavRegistryDiff(base, {
+          fsImpl: fsStub({ 'r.json': '{ not json' }),
+          stdout: sink(),
+        }),
+      /routes file 'r\.json' is not valid JSON/,
+    );
+    await assert.rejects(
+      () =>
+        runNavRegistryDiff(base, {
+          fsImpl: fsStub({ 'r.json': '{"unexpected":1}' }),
+          stdout: sink(),
+        }),
+      /routes file 'r\.json' must be a JSON array/,
+    );
+  });
+});

--- a/tests/plan-run-epilogue.test.js
+++ b/tests/plan-run-epilogue.test.js
@@ -1,0 +1,144 @@
+import assert from 'node:assert/strict';
+import { afterEach, describe, it } from 'node:test';
+
+import { main } from '../.agents/scripts/plan-run-epilogue.js';
+
+/**
+ * Story #4780 — `main` scored CRAP 39.6: the per-run closeout's id parsing,
+ * its synthesized `adhoc-<ids>` run id, and both loud operator warnings (the
+ * unresolvable landed diff and the suspiciously-empty friction roll-up) were
+ * unreached.
+ *
+ * Config, provider, epilogue engine and log sink are injected through the
+ * optional final `deps` parameter (`.agents/rules/test-seams.md` rules 1 and
+ * 5) — no GitHub call, no module mocking.
+ */
+
+const originalExitCode = process.exitCode;
+afterEach(() => {
+  process.exitCode = originalExitCode;
+});
+
+function harness(result = { results: [] }) {
+  const info = [];
+  const warn = [];
+  const calls = [];
+  return {
+    info,
+    warn,
+    calls,
+    deps: {
+      resolveConfigImpl: (args) => ({ resolvedFor: args.cwd }),
+      createProviderImpl: (config) => ({ providerFor: config.resolvedFor }),
+      runPlanRunEpilogueImpl: async (args) => {
+        calls.push(args);
+        return result;
+      },
+      logger: { info: (m) => info.push(m), warn: (m) => warn.push(m) },
+    },
+  };
+}
+
+describe('plan-run-epilogue main', () => {
+  it('refuses an invocation with no --stories', async () => {
+    for (const argv of [[], ['--stories', '   ']]) {
+      await assert.rejects(
+        () => main(argv, harness().deps),
+        /Usage: node plan-run-epilogue\.js --stories 1,2,3/,
+      );
+    }
+  });
+
+  it('synthesizes a sorted adhoc run id from the delivered ids', async () => {
+    const h = harness();
+    await main(['--stories', '30,4,12'], h.deps);
+    assert.equal(h.calls[0].planRunId, 'adhoc-4-12-30');
+    assert.deepEqual(h.calls[0].stories, [30, 4, 12]);
+  });
+
+  it('drops non-integer and non-positive ids', async () => {
+    const h = harness();
+    await main(['--stories', '5, abc ,0,-2, 7 '], h.deps);
+    assert.deepEqual(h.calls[0].stories, [5, 7]);
+    assert.equal(h.calls[0].planRunId, 'adhoc-5-7');
+  });
+
+  it('defaults cwd to the process cwd and threads --cwd when given', async () => {
+    const bare = harness();
+    await main(['--stories', '1'], bare.deps);
+    assert.equal(bare.calls[0].cwd, process.cwd());
+
+    const explicit = harness();
+    await main(['--stories', '1', '--cwd', '  /repo  '], explicit.deps);
+    assert.equal(explicit.calls[0].cwd, '/repo');
+    assert.deepEqual(explicit.calls[0].config, { resolvedFor: '/repo' });
+    assert.deepEqual(explicit.calls[0].provider, { providerFor: '/repo' });
+  });
+
+  it('prints the envelope as a single JSON line and leaves the exit code alone', async () => {
+    const h = harness({ results: [], ok: true });
+    const result = await main(['--stories', '1'], h.deps);
+    assert.deepEqual(JSON.parse(h.info[0]), result);
+    assert.equal(process.exitCode, originalExitCode);
+  });
+
+  it('sets a non-zero exit code when the epilogue reports errors', async () => {
+    const h = harness({ results: [], errors: ['boom'] });
+    await main(['--stories', '1'], h.deps);
+    assert.equal(process.exitCode, 1);
+  });
+
+  it('warns loudly when the combined landed diff could not be resolved', async () => {
+    const h = harness({
+      results: [
+        {
+          kind: 'audit-roster',
+          baseResolution: {
+            resolved: false,
+            baseRef: 'main',
+            reason: 'no merge base',
+          },
+        },
+      ],
+    });
+    await main(['--stories', '1'], h.deps);
+    assert.match(h.warn[0], /Combined landed diff unavailable/);
+    assert.match(h.warn[0], /changedFiles is null \(NOT an empty set\)/);
+  });
+
+  it('stays quiet when the base resolved', async () => {
+    const h = harness({
+      results: [{ kind: 'audit-roster', baseResolution: { resolved: true } }],
+    });
+    await main(['--stories', '1'], h.deps);
+    assert.deepEqual(h.warn, []);
+  });
+
+  it('warns loudly on a zero-signal roll-up over a multi-Story run', async () => {
+    const h = harness({
+      results: [
+        { kind: 'follow-up-rollup', emptyRollupSuspect: true, storyCount: 7 },
+      ],
+    });
+    await main(['--stories', '1,2'], h.deps);
+    assert.match(h.warn[0], /0 friction signals across 7 Stories/);
+    assert.match(h.warn[0], /An empty roll-up is NOT evidence of a clean run/);
+  });
+
+  it('stays quiet when the roll-up is not suspect', async () => {
+    const h = harness({
+      results: [
+        { kind: 'follow-up-rollup', emptyRollupSuspect: false, storyCount: 2 },
+      ],
+    });
+    await main(['--stories', '1,2'], h.deps);
+    assert.deepEqual(h.warn, []);
+  });
+
+  it('tolerates an envelope with no results array at all', async () => {
+    const h = harness({});
+    await main(['--stories', '1'], h.deps);
+    assert.deepEqual(h.warn, []);
+    assert.equal(h.info.length, 1);
+  });
+});

--- a/tests/resolve-doc-tiers.test.js
+++ b/tests/resolve-doc-tiers.test.js
@@ -1,0 +1,129 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import { parseArgv, runCli } from '../.agents/scripts/resolve-doc-tiers.js';
+
+/**
+ * Story #4780 — `parseArgv` scored CRAP 36 with no test file: the `--root`
+ * lookahead rules (the flag that decides which tree the context-budget
+ * ratchet and the documentation lens read) were unverified.
+ *
+ * `runCli`'s collaborators are injected through its optional final `deps`
+ * parameter (`.agents/rules/test-seams.md` rules 1 and 5) — plain functions,
+ * no module mocking.
+ */
+
+describe('resolve-doc-tiers parseArgv', () => {
+  it('defaults to no root and no json flag', () => {
+    assert.deepEqual(parseArgv([]), { rootPath: null, json: false });
+    assert.deepEqual(parseArgv(), { rootPath: null, json: false });
+  });
+
+  it('reads --root <path>', () => {
+    assert.deepEqual(parseArgv(['--root', '/repo']), {
+      rootPath: '/repo',
+      json: false,
+    });
+  });
+
+  it('ignores a --root with no value', () => {
+    assert.deepEqual(parseArgv(['--root']), { rootPath: null, json: false });
+  });
+
+  it('ignores a --root immediately followed by another flag', () => {
+    assert.deepEqual(parseArgv(['--root', '--json']), {
+      rootPath: null,
+      json: true,
+    });
+  });
+
+  it('reads --json', () => {
+    assert.deepEqual(parseArgv(['--json']), { rootPath: null, json: true });
+  });
+
+  it('reads both flags in either order and ignores unknown tokens', () => {
+    assert.deepEqual(parseArgv(['--json', '--root', '/r', 'stray']), {
+      rootPath: '/r',
+      json: true,
+    });
+    assert.deepEqual(parseArgv(['--root', '/r', '--json']), {
+      rootPath: '/r',
+      json: true,
+    });
+  });
+
+  it('does not treat the consumed --root value as a flag on the next pass', () => {
+    assert.deepEqual(parseArgv(['--root', '--weird-but-valued']), {
+      rootPath: null,
+      json: false,
+    });
+  });
+});
+
+describe('resolve-doc-tiers runCli', () => {
+  const TIERS = {
+    tiers: { alwaysLoaded: [], onDemand: [{ path: 'a.md', bytes: 1 }] },
+  };
+
+  function harness() {
+    const written = [];
+    const seen = [];
+    return {
+      written,
+      seen,
+      stdout: { write: (s) => written.push(s) },
+      deps: {
+        resolveConfigImpl: () => ({ resolved: true }),
+        resolveDocTiersImpl: (config, opts) => {
+          seen.push({ config, opts });
+          return TIERS;
+        },
+      },
+    };
+  }
+
+  it('prints the tier map as pretty JSON and exits 0', async () => {
+    const h = harness();
+    const code = await runCli({ argv: [], stdout: h.stdout }, h.deps);
+    assert.equal(code, 0);
+    assert.deepEqual(JSON.parse(h.written.join('')), TIERS);
+    assert.equal(h.written.join('').endsWith('\n'), true);
+  });
+
+  it('resolves the config through the injected seam by default', async () => {
+    const h = harness();
+    await runCli({ argv: [], stdout: h.stdout }, h.deps);
+    assert.deepEqual(h.seen[0].config, { resolved: true });
+  });
+
+  it('prefers an explicit config over the resolver', async () => {
+    const h = harness();
+    await runCli(
+      { argv: [], stdout: h.stdout, config: { explicit: true } },
+      h.deps,
+    );
+    assert.deepEqual(h.seen[0].config, { explicit: true });
+  });
+
+  it('prefers an explicit root over --root', async () => {
+    const h = harness();
+    await runCli(
+      { argv: ['--root', '/from-argv'], stdout: h.stdout, root: '/explicit' },
+      h.deps,
+    );
+    assert.equal(h.seen[0].opts.root, '/explicit');
+  });
+
+  it('falls back to the --root argv value', async () => {
+    const h = harness();
+    await runCli({ argv: ['--root', '/from-argv'], stdout: h.stdout }, h.deps);
+    assert.equal(h.seen[0].opts.root, '/from-argv');
+  });
+
+  it('falls back to the project root when neither is supplied', async () => {
+    const h = harness();
+    await runCli({ argv: [], stdout: h.stdout }, h.deps);
+    assert.equal(typeof h.seen[0].opts.root, 'string');
+    assert.ok(h.seen[0].opts.root.length > 0);
+  });
+});


### PR DESCRIPTION
Closes #4780

_Auto-opened by `/deliver`._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactors are mostly extraction plus dependency injection with production defaults unchanged; risk is limited to subtle CLI wiring regressions, mitigated by new tests and updated CRAP baselines.
> 
> **Overview**
> Story **#4780** drives down untested complexity on agent delivery scripts by **extracting injectable CLI cores** (`runAcceptanceEvalCli`, `runAuditToStories`, `runBootSweepCli`, `runCoverageCapture`, `runDrainPendingCleanup`, `runGenerateLensChecklists`, `runNavRegistryDiff`, etc.) with optional `deps` defaults per test-seams rules, so tests can hit full error/decision tables without spawning CLIs or touching real git/worktrees.
> 
> **Behavioral tweak:** `getVerdictValidator` no longer module-level caches the Ajv compiler (avoids breaking injected `io` and parallel test isolation).
> 
> **Supporting seam work** on `buildPlan`, `runDeliverRecover`, `plan-run-epilogue`, `resolve-doc-tiers`, `story-init-not-backgrounded`, `seedStoryBranchRef`, `computeRegistryFindings`, `version-helpers`, and epic AC tag migration — all defaulting to real implementations.
> 
> **Quality gate:** `.agentrc.json` and `baselines/crap.json` ratchet `methodsAbove20` from **40 → 13** with refreshed rollup metrics after complexity drops on the refactored methods.
> 
> **Tests:** New/expanded suites under `tests/` for acceptance-eval, audit-to-stories build-plan, boot-sweep, coverage-capture, deliver-recover, drain-pending-cleanup, lens checklists, story-init check, version-helpers, git-branch-lifecycle seeding, registry conflict pass, and retire-epic-ac-tags migration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f85e45696eeccb48865143c88e40da7b74e58706. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->