### PR TITLE
feat: check-doc-links: validate relative links against the published payload boundary and give the CLI scan-root/exclude flags (#4801)

### DIFF
--- a/.agents/docs/SDLC.md
+++ b/.agents/docs/SDLC.md
@@ -528,7 +528,7 @@ new CI gate**, route the check through a `package.json` script (add it to
 transitivity. **When a workflow file genuinely must change** (a new job, a
 trigger change, a runner bump), the edit must be made by an operator with
 `Workflows: Read and write` PAT permissions — see
-[`docs/release-operations.md` § One-time PAT setup](../../docs/release-operations.md#one-time-pat-setup).
+[`docs/release-operations.md` § One-time PAT setup](https://github.com/dsj1984/mandrel/blob/main/docs/release-operations.md#one-time-pat-setup).
 
 ### Worktree config shadow
 

--- a/.agents/scripts/check-doc-links.js
+++ b/.agents/scripts/check-doc-links.js
@@ -25,6 +25,10 @@
 //      a retired token is always a non-zero exit even if a stale workflow
 //      file happens to exist.
 //
+//   4. Story #4801 — every relative link originating under `.agents/**`
+//      resolves to a target that still exists once the tree is materialized
+//      into a *consumer* project. See `escapesPayload` for the boundary rule.
+//
 // Exit codes:
 //   0  every link and slash-command token resolves cleanly.
 //   1  at least one violation; details are written to stderr (file:line).
@@ -35,6 +39,8 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { minimatch } from 'minimatch';
+import { parseStandardCliArgs } from './lib/cli/standard-args.js';
 import { runAsCli } from './lib/cli-utils.js';
 import { Logger } from './lib/Logger.js';
 
@@ -124,6 +130,63 @@ export const SLASH_ALLOWLIST = new Set([
   'main',
 ]);
 
+// --- Payload boundary (Story #4801) ----------------------------------------
+
+// `mandrel sync` materializes ONLY the package's `.agents/` payload into a
+// consumer's project, at `<projectRoot>/.agents` (see `lib/cli/sync.js`:
+// `destRoot = path.join(projectRoot, '.agents')`). `bin/` and `lib/` ship
+// inside the npm tarball but stay under `node_modules/mandrel/`, and the
+// framework's own `tests/`, `docs/` (bar the CHANGELOG) and `.claude/` trees
+// ship nowhere at all. So a relative link that escapes `.agents/` resolves
+// cleanly in THIS repo and dangles in every consumer — which is exactly why
+// the checker cannot catch this class by `fs.existsSync` alone.
+//
+// This is why the boundary is `.agents/` and NOT `package.json#files`: the
+// latter lists `lib/` and `bin/`, which are packaged but never materialized
+// at a consumer's repo root.
+export const MATERIALIZED_ROOT = '.agents';
+
+// Repo-root-relative paths OUTSIDE `.agents/` that a Mandrel *consumer*
+// legitimately owns, so a doc under `.agents/**` may still link to them.
+// Deliberately explicit rather than pattern-derived: whether a given repo-root
+// path is consumer-owned or framework-only is a judgment per path, not a rule.
+// A new escaping link fails closed until it is justified and added here.
+export const CONSUMER_OWNED_PATHS = new Set([
+  'package.json',
+  '.agentrc.json',
+  '.c8rc.cjs',
+  'docs/architecture.md',
+  'docs/decisions.md',
+]);
+
+// Directory prefixes (repo-root-relative, trailing slash) whose whole subtree
+// is consumer-owned.
+export const CONSUMER_OWNED_PREFIXES = Object.freeze(['baselines/']);
+
+/**
+ * True when `relTarget` is unreachable from a materialized consumer tree.
+ *
+ * Only links whose SOURCE lives under `.agents/**` are subject to the rule —
+ * `docs/**` is framework-repo-only, ships nowhere, and keeps today's
+ * existence-only semantics.
+ *
+ * @param {string} relFile   repo-relative POSIX path of the linking document
+ * @param {string} relTarget repo-relative POSIX path the link resolves to
+ */
+export function escapesPayload(relFile, relTarget) {
+  if (!relFile.startsWith(`${MATERIALIZED_ROOT}/`)) return false;
+  if (
+    relTarget === MATERIALIZED_ROOT ||
+    relTarget.startsWith(`${MATERIALIZED_ROOT}/`)
+  ) {
+    return false;
+  }
+  if (CONSUMER_OWNED_PATHS.has(relTarget)) return false;
+  if (CONSUMER_OWNED_PREFIXES.some((p) => relTarget.startsWith(p)))
+    return false;
+  return true;
+}
+
 // --- File discovery --------------------------------------------------------
 
 function isExcludedRelPath(relPath) {
@@ -150,14 +213,28 @@ function walkMarkdown(dirAbs, repoRoot, out) {
   }
 }
 
-export function discoverMarkdown(rootAbs, scanRoots) {
+/**
+ * Collect every non-excluded `*.md` under each `scanRoots` entry.
+ *
+ * @param {string}   rootAbs     absolute repo root
+ * @param {string[]} scanRoots   repo-relative subtrees to walk
+ * @param {string[]} [exclude]   minimatch globs; a repo-relative POSIX path
+ *                               matching any of them is dropped from the scan
+ */
+export function discoverMarkdown(rootAbs, scanRoots, exclude = []) {
   const out = [];
   for (const sub of scanRoots) {
     const subAbs = path.join(rootAbs, sub);
     if (fs.existsSync(subAbs)) walkMarkdown(subAbs, rootAbs, out);
   }
-  out.sort();
-  return out;
+  const filtered = exclude.length
+    ? out.filter((abs) => {
+        const rel = path.relative(rootAbs, abs).split(path.sep).join('/');
+        return !exclude.some((g) => minimatch(rel, g, { dot: true }));
+      })
+    : out;
+  filtered.sort();
+  return filtered;
 }
 
 // --- Region masking --------------------------------------------------------
@@ -326,6 +403,26 @@ export function checkFile(absPath, repoRoot) {
     } else {
       resolved = path.resolve(fileDir, pathOnly);
     }
+    // Payload boundary (Story #4801) takes precedence over existence: a link
+    // that escapes the materialized tree is a defect even when the target
+    // exists here, and reporting both kinds for one link would double-count.
+    const relTarget = path
+      .relative(repoRoot, resolved)
+      .split(path.sep)
+      .join('/');
+    if (escapesPayload(relFile, relTarget)) {
+      violations.push({
+        file: relFile,
+        line,
+        kind: 'payload-boundary',
+        message:
+          `link escapes the materialized payload: ${target} → ${relTarget}. ` +
+          `Only '${MATERIALIZED_ROOT}/' is materialized into a consumer project, ` +
+          'so this resolves here but dangles for every consumer. Use an absolute ' +
+          'GitHub URL or a non-link code span.',
+      });
+      continue;
+    }
     if (!fs.existsSync(resolved)) {
       violations.push({
         file: relFile,
@@ -377,6 +474,8 @@ export function checkFile(absPath, repoRoot) {
 
 // --- Public entry point ----------------------------------------------------
 
+export const DEFAULT_SCAN_ROOTS = Object.freeze(['docs', '.agents']);
+
 /**
  * Run the checker programmatically. Returns `{ exitCode, violations }`.
  * `exitCode` is 0 when every doc is clean, 1 otherwise.
@@ -384,11 +483,13 @@ export function checkFile(absPath, repoRoot) {
  * @param {object} [options]
  * @param {string} [options.repoRoot] Defaults to the framework repo root.
  * @param {string[]} [options.scanRoots] Defaults to `['docs', '.agents']`.
+ * @param {string[]} [options.exclude] minimatch globs dropped from the scan.
  */
 export function runCheck(options = {}) {
   const repoRoot = options.repoRoot ?? REPO_ROOT;
-  const scanRoots = options.scanRoots ?? ['docs', '.agents'];
-  const files = discoverMarkdown(repoRoot, scanRoots);
+  const scanRoots = options.scanRoots ?? [...DEFAULT_SCAN_ROOTS];
+  const exclude = options.exclude ?? [];
+  const files = discoverMarkdown(repoRoot, scanRoots, exclude);
   const violations = [];
   for (const abs of files) {
     const fileViolations = checkFile(abs, repoRoot);
@@ -405,8 +506,28 @@ function formatViolation(v) {
   return `${v.file}:${v.line}: [${v.kind}] ${v.message}`;
 }
 
+/**
+ * Translate argv into `runCheck` options. Repeatable `--scan-root` replaces
+ * the default scan set entirely; repeatable `--exclude` filters whatever was
+ * scanned. Absent flags reproduce the pre-#4801 defaults exactly.
+ */
+export function parseArgs(argv) {
+  const { values } = parseStandardCliArgs({
+    argv,
+    extras: {
+      'scan-root': { type: 'string-multi', alias: 'scanRoot' },
+      exclude: { type: 'string-multi', alias: 'exclude' },
+    },
+  });
+  const scanRoots = values.scanRoot?.length
+    ? values.scanRoot
+    : [...DEFAULT_SCAN_ROOTS];
+  return { scanRoots, exclude: values.exclude ?? [] };
+}
+
 async function main() {
-  const result = runCheck();
+  const { scanRoots, exclude } = parseArgs(process.argv.slice(2));
+  const result = runCheck({ scanRoots, exclude });
   if (result.violations.length === 0) {
     Logger.info(
       `[check-doc-links] OK — scanned ${result.scanned} active markdown file(s); no violations.`,
@@ -426,11 +547,22 @@ async function main() {
 runAsCli(import.meta.url, main, {
   source: 'check-doc-links',
   usage: {
-    invocation: 'node .agents/scripts/check-doc-links.js',
+    invocation:
+      'node .agents/scripts/check-doc-links.js [--scan-root <path>] [--exclude <glob>]',
     summary:
-      'Validate every relative Markdown link and /slash-command token across docs/ and .agents/, and reject mentions of retired commands.',
-    flags: [],
+      'Validate every relative Markdown link and /slash-command token across docs/ and .agents/, reject mentions of retired commands, and reject links that escape the materialized .agents/ payload.',
+    flags: [
+      [
+        '--scan-root <path>',
+        'Repeatable. Repo-relative subtree to scan. Replaces the default set (docs, .agents).',
+      ],
+      [
+        '--exclude <glob>',
+        'Repeatable. minimatch glob; matching files are dropped from the scan.',
+      ],
+    ],
     notes: [
+      'Consumers materialize only .agents/, so a relative link from .agents/**\nto a framework-repo-only path (tests/, lib/, .claude/, framework docs)\nis reported as a payload-boundary violation even though it resolves here.',
       'Exit codes:\n  0  every link and command token resolves\n  1  at least one violation (file:line on stderr)',
     ],
   },

--- a/.agents/scripts/lib/orchestration/lifecycle/listeners/README.md
+++ b/.agents/scripts/lib/orchestration/lifecycle/listeners/README.md
@@ -2,7 +2,8 @@
 
 Each listener in this directory subscribes to one or more lifecycle bus
 events and performs a single side effect. The full close-tail roster and
-event taxonomy live in [`docs/LIFECYCLE.md`](../../../../../../docs/LIFECYCLE.md)
+event taxonomy live in
+[`docs/LIFECYCLE.md`](https://github.com/dsj1984/mandrel/blob/main/docs/LIFECYCLE.md)
 — that document is the SSOT. This README only indexes the **files that still
 live in this folder**.
 

--- a/.agents/workflows/audit-performance.md
+++ b/.agents/workflows/audit-performance.md
@@ -39,8 +39,8 @@ Sequential inline execution is the fallback (see the core's Execution strategy).
 > orchestrated path grants its measurement agents a `Bash` tool restricted to a
 > **non-mutating command allowlist** (profilers, timers, bundle-stat and
 > file-size probes — never a command that writes source, installs, or mutates
-> git/labels). See the allowlist in
-> [`../../.claude/workflows/audit-performance.workflow.js`](../../.claude/workflows/audit-performance.workflow.js).
+> git/labels). See the allowlist in the harness-generated
+> `.claude/workflows/audit-performance.workflow.js`.
 
 ## Step 0: Measure before you judge (mandatory)
 

--- a/.agents/workflows/helpers/diagnose.md
+++ b/.agents/workflows/helpers/diagnose.md
@@ -113,5 +113,5 @@ pipelines and CI-step parsing.
   — the canonical contract every check module must satisfy.
 - [`.agents/scripts/diagnose.js`](../../scripts/diagnose.js) — the CLI
   implementation backing this helper.
-- [`tests/diagnose-output.test.js`](../../../tests/diagnose-output.test.js)
+- [`tests/diagnose-output.test.js`](https://github.com/dsj1984/mandrel/blob/main/tests/diagnose-output.test.js)
   — pinned output and exit-code contracts.

--- a/.agents/workflows/helpers/signals.md
+++ b/.agents/workflows/helpers/signals.md
@@ -106,7 +106,7 @@ node .agents/scripts/signals-view.js 9999
   CLI implementation backing this helper.
 - [`.agents/scripts/lib/signals/`](../../scripts/lib/signals/) — the
   shared reader + schema + span-tree barrel.
-- [`tests/signals-view.test.js`](../../../tests/signals-view.test.js) —
+- [`tests/signals-view.test.js`](https://github.com/dsj1984/mandrel/blob/main/tests/signals-view.test.js) —
   pinned output and tempRoot-honour contracts.
-- [`tests/lib/signals/span-tree.test.js`](../../../tests/lib/signals/span-tree.test.js) —
+- [`tests/lib/signals/span-tree.test.js`](https://github.com/dsj1984/mandrel/blob/main/tests/lib/signals/span-tree.test.js) —
   pure-function contract for the span-tree builder.

--- a/.agents/workflows/mandrel-update.md
+++ b/.agents/workflows/mandrel-update.md
@@ -13,7 +13,7 @@ description: >-
 # /mandrel-update
 
 > **Upgrade owner.** The mechanical upgrade is owned end to end by the
-> [`mandrel update`](../../lib/cli/update.js) CLI under the npm distribution
+> [`mandrel update`](https://github.com/dsj1984/mandrel/blob/main/lib/cli/update.js) CLI under the npm distribution
 > model. This workflow wraps that CLI: it runs
 > `npx mandrel update`, then walks the operator through the
 > **distribution-agnostic judgment steps** the CLI deliberately does **not**
@@ -66,7 +66,7 @@ envelope (`{ ok, blocked, findings[] }`) plus a human-readable report:
   the version probe.
 
 The preflight is a workflow-layer guard; it deliberately lives outside
-[`lib/cli/update.js`](../../lib/cli/update.js), which stays git-free.
+[`lib/cli/update.js`](https://github.com/dsj1984/mandrel/blob/main/lib/cli/update.js), which stays git-free.
 
 ## Step 1 — Run the updater
 
@@ -102,9 +102,9 @@ recovered and a clean re-run reports success.**
 
 Identify the failed phase (the CLI's stderr names it) and run the matching
 remedy. These commands match the hint strings
-[`lib/cli/update.js`](../../lib/cli/update.js) emits verbatim — it is the
+[`lib/cli/update.js`](https://github.com/dsj1984/mandrel/blob/main/lib/cli/update.js) emits verbatim — it is the
 single source of truth, kept in lockstep with this table by
-[`tests/bootstrap/mandrel-update-recovery-drift.test.js`](../../tests/bootstrap/mandrel-update-recovery-drift.test.js):
+[`tests/bootstrap/mandrel-update-recovery-drift.test.js`](https://github.com/dsj1984/mandrel/blob/main/tests/bootstrap/mandrel-update-recovery-drift.test.js):
 
 | Failed phase      | Manual remedy                                            |
 | ----------------- | ------------------------------------------------------- |

--- a/tests/check-doc-links.test.js
+++ b/tests/check-doc-links.test.js
@@ -5,10 +5,13 @@ import path from 'node:path';
 import { test } from 'node:test';
 import {
   checkFile,
+  DEFAULT_SCAN_ROOTS,
   discoverMarkdown,
+  escapesPayload,
   extractLinks,
   extractSlashTokens,
   maskCodeRegions,
+  parseArgs,
   RETIRED_COMMANDS,
   runCheck,
   SLASH_ALLOWLIST,
@@ -252,4 +255,156 @@ test('static constants: retired blocklist seeded with agents-bootstrap-github; a
 
 test('static constants: retired blocklist includes /mandrel (retired for generated workflows.md)', () => {
   assert.ok(RETIRED_COMMANDS.has('mandrel'));
+});
+
+// --- Payload boundary (Story #4801) ----------------------------------------
+
+test('payload-boundary: an .agents/** link to a framework-only path is a violation even though the target exists', () => {
+  const root = makeFakeRepo();
+  write(root, 'tests/diagnose-output.test.js', '// real file\n');
+  const abs = write(
+    root,
+    '.agents/workflows/helpers/diagnose.md',
+    '# diagnose\n\nSee [the test](../../../tests/diagnose-output.test.js).\n',
+  );
+  const v = checkFile(abs, root);
+  assert.equal(v.length, 1);
+  assert.equal(v[0].kind, 'payload-boundary');
+  assert.notEqual(v[0].kind, 'broken-link');
+  assert.match(v[0].message, /materialized/);
+  assert.match(v[0].message, /\.agents\//);
+});
+
+test('payload-boundary: a packaged-but-unmaterialized lib/ target still violates (package.json#files would have missed it)', () => {
+  const root = makeFakeRepo();
+  write(
+    root,
+    'lib/cli/update.js',
+    '// shipped in the tarball, not to the repo root\n',
+  );
+  const abs = write(
+    root,
+    '.agents/workflows/mandrel-update.md',
+    '# update\n\nOwned by [`lib/cli/update.js`](../../lib/cli/update.js).\n',
+  );
+  const v = checkFile(abs, root);
+  assert.equal(v.length, 1);
+  assert.equal(v[0].kind, 'payload-boundary');
+});
+
+test('payload-boundary: the rule is scoped to .agents/** sources — a docs/** link to the same path is clean', () => {
+  const root = makeFakeRepo();
+  write(root, 'tests/diagnose-output.test.js', '// real file\n');
+  const abs = write(
+    root,
+    'docs/notes.md',
+    '# notes\n\nSee [the test](../tests/diagnose-output.test.js).\n',
+  );
+  const v = checkFile(abs, root);
+  assert.equal(v.length, 0);
+});
+
+test('payload-boundary: consumer-owned escapes are allowed from .agents/**', () => {
+  const root = makeFakeRepo();
+  write(root, 'package.json', '{}\n');
+  write(root, '.agentrc.json', '{}\n');
+  write(root, 'baselines/coverage.json', '{}\n');
+  write(root, 'docs/architecture.md', '# arch\n');
+  const abs = write(
+    root,
+    '.agents/docs/quality-gates.md',
+    '# gates\n\n' +
+      'See [pkg](../../package.json), [rc](../../.agentrc.json),\n' +
+      '[cov](../../baselines/coverage.json) and [arch](../../docs/architecture.md).\n',
+  );
+  const v = checkFile(abs, root);
+  assert.deepEqual(v, []);
+});
+
+test('payload-boundary: links that stay inside .agents/ are clean', () => {
+  const root = makeFakeRepo();
+  const abs = write(
+    root,
+    '.agents/workflows/deliver.md',
+    '# deliver\n\nSee [plan](plan.md).\n',
+  );
+  const v = checkFile(abs, root);
+  assert.deepEqual(v, []);
+});
+
+test('escapesPayload: unit contract for source scoping and the allowlist', () => {
+  assert.equal(
+    escapesPayload('.agents/workflows/a.md', 'tests/x.test.js'),
+    true,
+  );
+  assert.equal(
+    escapesPayload('.agents/workflows/a.md', 'lib/cli/update.js'),
+    true,
+  );
+  assert.equal(
+    escapesPayload('.agents/workflows/a.md', '.agents/docs/b.md'),
+    false,
+  );
+  assert.equal(escapesPayload('.agents/workflows/a.md', 'package.json'), false);
+  assert.equal(
+    escapesPayload('.agents/workflows/a.md', 'baselines/crap.json'),
+    false,
+  );
+  // docs/** is framework-repo-only and keeps existence-only semantics.
+  assert.equal(escapesPayload('docs/notes.md', 'tests/x.test.js'), false);
+});
+
+test('runCheck: a consumer-shaped tree (only .agents/) scans clean', () => {
+  const root = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'check-doc-links-consumer-'),
+  );
+  fs.mkdirSync(path.join(root, '.agents', 'workflows'), { recursive: true });
+  write(root, '.agents/workflows/plan.md', '# plan\n');
+  write(
+    root,
+    '.agents/workflows/deliver.md',
+    '# deliver\n\nRun [/plan](plan.md); see the harness docs at\n' +
+      '[update](https://github.com/dsj1984/mandrel/blob/main/lib/cli/update.js).\n',
+  );
+  const result = runCheck({ repoRoot: root, scanRoots: ['.agents'] });
+  assert.deepEqual(result.violations, []);
+  assert.equal(result.exitCode, 0);
+});
+
+// --- CLI scoping flags (Story #4801) ---------------------------------------
+
+test('discoverMarkdown: --exclude globs drop matching files from the scan', () => {
+  const root = makeFakeRepo();
+  write(root, 'docs/keep.md', '# keep\n');
+  write(root, 'docs/drafts/skip.md', '# skip\n');
+  const all = discoverMarkdown(root, ['docs']).map((f) =>
+    path.relative(root, f).split(path.sep).join('/'),
+  );
+  assert.ok(all.includes('docs/drafts/skip.md'));
+  const filtered = discoverMarkdown(root, ['docs'], ['docs/drafts/**']).map(
+    (f) => path.relative(root, f).split(path.sep).join('/'),
+  );
+  assert.ok(filtered.includes('docs/keep.md'));
+  assert.equal(filtered.includes('docs/drafts/skip.md'), false);
+});
+
+test('parseArgs: no flags reproduces the pre-#4801 defaults', () => {
+  const parsed = parseArgs([]);
+  assert.deepEqual(parsed.scanRoots, [...DEFAULT_SCAN_ROOTS]);
+  assert.deepEqual(parsed.exclude, []);
+});
+
+test('parseArgs: --scan-root and --exclude are repeatable and --scan-root replaces the defaults', () => {
+  const parsed = parseArgs([
+    '--scan-root',
+    '.agents',
+    '--scan-root',
+    'handbook',
+    '--exclude',
+    '**/archive/**',
+    '--exclude',
+    '**/tmp/**',
+  ]);
+  assert.deepEqual(parsed.scanRoots, ['.agents', 'handbook']);
+  assert.deepEqual(parsed.exclude, ['**/archive/**', '**/tmp/**']);
 });


### PR DESCRIPTION
Closes #4801

_Auto-opened by `/deliver`._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs and a dev-time lint script only; behavior tightens link validation without touching runtime delivery or auth paths.
> 
> **Overview**
> **`check-doc-links`** now fails when a relative link in **`.agents/**`** points outside what `mandrel sync` materializes (e.g. `tests/`, `lib/`, framework `docs/`), even if the file exists in the framework repo. Violations use a new **`payload-boundary`** kind, with an explicit allowlist for consumer-owned targets (`package.json`, `.agentrc.json`, `baselines/`, selected `docs/*.md`). **`--scan-root`** and **`--exclude`** (minimatch) scope the scan; defaults stay `docs` + `.agents`.
> 
> Several **`.agents` workflow/docs** links that escaped the payload were converted to **absolute GitHub URLs** or non-link prose (e.g. `mandrel-update`, `diagnose`, `signals`, lifecycle listeners README, SDLC PAT note). **`audit-performance.md`** no longer links into `.claude/workflows/`.
> 
> **`tests/check-doc-links.test.js`** adds coverage for boundary rules, consumer-shaped trees, and CLI parsing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bcabcedd1e0aeab02bf63d16c523160f814bbe4e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->