### PR TITLE
feat: check-baselines: generalize the one-shot baseline-refresh acknowledgment across every ratcheted kind (#4802)

### DIFF
--- a/.agents/scripts/lib/baselines/env-overrides.js
+++ b/.agents/scripts/lib/baselines/env-overrides.js
@@ -90,10 +90,13 @@ export function resolveCrapEnvOverrides(crapConfig, env) {
  * Story #4731) are exactly what this rule produces, so generalizing kept
  * both working unchanged.
  *
+ * Module-local: `resolveKindRefreshOverrides` is the public surface, and the
+ * naming rule is pinned through it rather than exported for its own sake.
+ *
  * @param {string} kind
  * @returns {string|null} null when `kind` is not a usable kind name
  */
-export function kindRefreshEnvVar(kind) {
+function kindRefreshEnvVar(kind) {
   if (typeof kind !== 'string' || kind.length === 0) return null;
   return `${kind.toUpperCase().replace(/-/g, '_')}_REFRESH`;
 }

--- a/.agents/scripts/lib/baselines/env-overrides.js
+++ b/.agents/scripts/lib/baselines/env-overrides.js
@@ -83,69 +83,58 @@ export function resolveCrapEnvOverrides(crapConfig, env) {
 }
 
 /**
- * Pure helper: resolve the one-shot bundle-size refresh/acknowledge flag
- * (Story #151). Unlike `coverage` / `crap` / `maintainability`, the
- * bundle-size gate has no scorer of its own — the measured sizes come from
- * a build step the operator already runs, not a source-tree rescan — so
- * there is no `refreshBaseline({ kind: 'bundle-size', ... })` path to
- * regenerate a "corrected" baseline. Instead, `BUNDLE_SIZE_REFRESH=1`
- * (mirroring `CRAP_TOLERANCE`'s env-override precedent) tells
- * `check-baselines --gate bundle-size` to treat this run's head
- * measurements as the newly acknowledged baseline: head-vs-base
- * regressions are demoted to `unchanged` for this invocation only. Floors
- * still apply — an acknowledged PR can still fail on an absolute budget
- * breach, only the ratchet-vs-`origin/main` comparison is suspended.
+ * The env var that acknowledges a deliberate baseline refresh for `kind`.
+ * Upper-snakes the kind name, so `bundle-size` → `BUNDLE_SIZE_REFRESH` and
+ * `coverage` → `COVERAGE_REFRESH`. The two names that predate the generic
+ * mechanism (`BUNDLE_SIZE_REFRESH`, Story #151; `MAINTAINABILITY_REFRESH`,
+ * Story #4731) are exactly what this rule produces, so generalizing kept
+ * both working unchanged.
  *
- * The flag is **not persisted** anywhere (no config write, no committed
- * tag): the very next `check-baselines` invocation without the env var —
- * i.e. the next PR — reverts to full strict enforcement automatically, so
- * there is no lingering loosened tolerance to remember to reset (AC-3).
- *
- * Accepted truthy values: `1`, `true` (case-insensitive). Anything else
- * (including unset/empty) resolves to `acknowledged: false`.
- *
- * @param {NodeJS.ProcessEnv} env
- * @returns {{ acknowledged: boolean, overrides: string[] }}
+ * @param {string} kind
+ * @returns {string|null} null when `kind` is not a usable kind name
  */
-export function resolveBundleSizeEnvOverrides(env) {
-  const raw = env?.BUNDLE_SIZE_REFRESH;
-  const acknowledged =
-    typeof raw === 'string' && /^(1|true)$/i.test(raw.trim());
-  const overrides = acknowledged
-    ? [`acknowledged=true (BUNDLE_SIZE_REFRESH=${raw})`]
-    : [];
-  return { acknowledged, overrides };
+export function kindRefreshEnvVar(kind) {
+  if (typeof kind !== 'string' || kind.length === 0) return null;
+  return `${kind.toUpperCase().replace(/-/g, '_')}_REFRESH`;
 }
 
 /**
- * Pure helper: resolve the one-shot maintainability refresh/acknowledge flag
- * (Story #4731). This is the env-parity sibling of
- * `resolveBundleSizeEnvOverrides`: `MAINTAINABILITY_REFRESH=1` (or `true`,
- * case-insensitive) tells `check-baselines --gate maintainability` to demote
- * this run's head-vs-base maintainability regressions to `unchanged` for this
- * invocation only. Floors still apply — an acknowledged run can still fail on
- * an absolute floor breach (e.g. a row below `min` 70); only the
- * ratchet-vs-base regression comparison is suspended.
+ * Pure helper: resolve the one-shot baseline refresh/acknowledge flag for any
+ * ratcheted kind (Story #4802, generalizing Story #151 / Story #4731).
  *
- * Unlike bundle-size, maintainability also has a **commit-tagged** trigger
- * (a `baseline-refresh:`-tagged commit in the compared range that touches the
- * maintainability baseline file) resolved in the evaluate phase — this env
- * flag is the manual override the two share by shape. Neither is persisted:
- * the next run without the flag / tag re-enforces the ratchet at full
- * strength automatically.
+ * `<KIND>_REFRESH=1` tells `check-baselines --gate <kind>` to demote this
+ * run's head-vs-base regressions to `unchanged` for this invocation only.
+ * Floors still apply — an acknowledged run can still fail on an absolute
+ * floor breach; only the ratchet-vs-base comparison is suspended.
  *
- * Accepted truthy values: `1`, `true` (case-insensitive). Anything else
- * (including unset/empty) resolves to `acknowledged: false`.
+ * Why every kind needs this: a diff-scope baseline is an accretion of many
+ * partial runs, not one measurement. Replacing it with a single full-scope
+ * measurement necessarily produces row deltas in both directions that are
+ * arithmetic, not behavioural — so without an acknowledgment path the gate
+ * blocks precisely the correction it should encourage.
  *
+ * The flag is **not persisted** anywhere (no config write, no committed tag):
+ * the very next invocation without the env var reverts to full strict
+ * enforcement automatically, so there is no lingering loosened tolerance to
+ * remember to reset. The evaluate phase pairs this with a commit-tagged
+ * trigger that is likewise one-shot by construction.
+ *
+ * Accepted truthy values: `1`, `true` (case-insensitive), with surrounding
+ * whitespace trimmed. Anything else — including unset, empty, `0`, `false`,
+ * and non-string values — resolves to `acknowledged: false`.
+ *
+ * @param {string} kind
  * @param {NodeJS.ProcessEnv} env
  * @returns {{ acknowledged: boolean, overrides: string[] }}
  */
-export function resolveMaintainabilityRefreshOverrides(env) {
-  const raw = env?.MAINTAINABILITY_REFRESH;
+export function resolveKindRefreshOverrides(kind, env) {
+  const varName = kindRefreshEnvVar(kind);
+  if (!varName) return { acknowledged: false, overrides: [] };
+  const raw = env?.[varName];
   const acknowledged =
     typeof raw === 'string' && /^(1|true)$/i.test(raw.trim());
   const overrides = acknowledged
-    ? [`acknowledged=true (MAINTAINABILITY_REFRESH=${raw})`]
+    ? [`acknowledged=true (${varName}=${raw})`]
     : [];
   return { acknowledged, overrides };
 }

--- a/.agents/scripts/lib/orchestration/check-baselines/phases/evaluate.js
+++ b/.agents/scripts/lib/orchestration/check-baselines/phases/evaluate.js
@@ -7,10 +7,7 @@
  * @module lib/orchestration/check-baselines/phases/evaluate
  */
 
-import {
-  resolveBundleSizeEnvOverrides,
-  resolveMaintainabilityRefreshOverrides,
-} from '../../../baselines/env-overrides.js';
+import { resolveKindRefreshOverrides } from '../../../baselines/env-overrides.js';
 import { readRangeSubjectsTouchingFile } from '../../../baselines/git-base.js';
 import {
   checkBaselineSemantics,
@@ -91,57 +88,34 @@ function loadHeadBaseline(kind, cwd, configPath) {
 }
 
 /**
- * One-shot bundle-size refresh/acknowledge (Story #151). When
- * `BUNDLE_SIZE_REFRESH=1` is set, demote every `bundle-size` regression to
- * `unchanged` for this run only — floors still apply, so a genuine budget
- * breach is still caught. The flag is read fresh on every invocation and
- * never persisted, so the ratchet returns to full strength automatically on
- * the very next run (no lingering loosened tolerance to remember to reset).
+ * Resolve the one-shot refresh trigger for any ratcheted kind (Story #4802,
+ * generalizing Story #151's bundle-size env flag and Story #4731's
+ * maintainability env-or-commit-tag pair). Two paths, either of which
+ * acknowledges:
  *
- * No-op for every other kind.
- */
-function applyBundleSizeAcknowledgment(kind, compareOutput, env) {
-  if (kind !== 'bundle-size') return { compareOutput, acknowledged: false };
-  const { acknowledged, overrides } = resolveBundleSizeEnvOverrides(env);
-  if (!acknowledged || compareOutput.regressions.length === 0) {
-    return { compareOutput, acknowledged: false };
-  }
-  Logger.warn(
-    `[bundle-size] ⚠ ${overrides.join(', ')} — ` +
-      `${compareOutput.regressions.length} regression(s) acknowledged for this run only; ` +
-      'floors still enforced. This does not persist: the next run without ' +
-      'BUNDLE_SIZE_REFRESH re-enforces the ratchet at full strength.',
-  );
-  return {
-    acknowledged: true,
-    compareOutput: {
-      ...compareOutput,
-      regressions: [],
-      unchanged: [...compareOutput.unchanged, ...compareOutput.regressions],
-    },
-  };
-}
-
-/**
- * Resolve the maintainability refresh trigger (Story #4731). Two paths, either
- * of which acknowledges — mirroring the bundle-size acknowledge but adding the
- * commit-tagged trigger the breach message already documents:
- *
- *   1. Env parity: `MAINTAINABILITY_REFRESH=1` (the manual override).
+ *   1. Env parity: `<KIND>_REFRESH=1` (the manual override) — upper-snaked,
+ *      so the two pre-existing names (`BUNDLE_SIZE_REFRESH`,
+ *      `MAINTAINABILITY_REFRESH`) keep working unchanged.
  *   2. Commit tag: a commit in the compared range `<baseRef>..HEAD` whose
- *      subject contains the configured `refreshTag` AND whose diff touches the
- *      maintainability baseline file. One-shot by construction — once merged,
- *      the refreshed baseline becomes the base and the tag leaves the range.
+ *      subject contains the configured `refreshTag` AND whose diff touches
+ *      that kind's baseline file. One-shot by construction — once merged, the
+ *      refreshed baseline becomes the base and the tag leaves the range.
  *
  * The tag is matched as a plain substring of a conventional commit subject, so
  * commitlint stays satisfied (e.g. `chore(baselines): baseline-refresh: …`).
  *
+ * Fails closed: a kind whose baseline path is neither configured nor present
+ * in `DEFAULT_BASELINE_PATHS` simply skips the commit-tag path rather than
+ * throwing, leaving the run un-acknowledged.
+ *
  * @returns {{ triggered: boolean, reasons: string[] }}
  */
-function resolveMaintainabilityRefreshTrigger({ gateBlock, cmp, cwd, env }) {
+function resolveRefreshTrigger({ kind, gateBlock, cmp, cwd, env }) {
   const reasons = [];
-  const { acknowledged: envAck, overrides } =
-    resolveMaintainabilityRefreshOverrides(env);
+  const { acknowledged: envAck, overrides } = resolveKindRefreshOverrides(
+    kind,
+    env,
+  );
   if (envAck) reasons.push(...overrides);
 
   const baseRef = cmp?.baseRef ?? null;
@@ -154,15 +128,17 @@ function resolveMaintainabilityRefreshTrigger({ gateBlock, cmp, cwd, env }) {
       typeof gateBlock?.baselinePath === 'string' &&
       gateBlock.baselinePath.length
         ? gateBlock.baselinePath
-        : DEFAULT_BASELINE_PATHS.maintainability;
-    const subjects = readRangeSubjectsTouchingFile(baseRef, baselinePath, {
-      cwd,
-    });
-    const match = subjects.find((s) => s.includes(refreshTag));
-    if (match) {
-      reasons.push(
-        `refresh commit "${match}" (subject contains ${JSON.stringify(refreshTag)}, touches ${baselinePath})`,
-      );
+        : DEFAULT_BASELINE_PATHS[kind];
+    if (typeof baselinePath === 'string' && baselinePath.length) {
+      const subjects = readRangeSubjectsTouchingFile(baseRef, baselinePath, {
+        cwd,
+      });
+      const match = subjects.find((s) => s.includes(refreshTag));
+      if (match) {
+        reasons.push(
+          `refresh commit "${match}" (subject contains ${JSON.stringify(refreshTag)}, touches ${baselinePath})`,
+        );
+      }
     }
   }
 
@@ -170,26 +146,24 @@ function resolveMaintainabilityRefreshTrigger({ gateBlock, cmp, cwd, env }) {
 }
 
 /**
- * One-shot maintainability refresh/acknowledge (Story #4731). When triggered
- * (env flag OR a `baseline-refresh:`-tagged range commit touching the baseline),
- * demote every maintainability head-vs-base regression to `unchanged` for this
- * run only — floors still apply, so a row below its `min` floor still breaches.
- * The trigger is read fresh every run and never persisted: post-merge the
- * refreshed baseline is the new base and the tag leaves the range, so the
- * ratchet returns to full strength automatically.
+ * One-shot baseline refresh/acknowledge for any ratcheted kind (Story #4802).
+ * When triggered (env flag OR a `baseline-refresh:`-tagged range commit
+ * touching that kind's baseline), demote every head-vs-base regression to
+ * `unchanged` for this run only — floors still apply, so a row below its floor
+ * still breaches. The trigger is read fresh every run and never persisted:
+ * post-merge the refreshed baseline is the new base and the tag leaves the
+ * range, so the ratchet returns to full strength automatically.
  *
- * No-op for every other kind.
+ * A no-op absent a trigger, so an unacknowledged run of any kind reports its
+ * regressions exactly as before.
  */
-function applyMaintainabilityAcknowledgment(kind, compareOutput, ctx) {
-  if (kind !== 'maintainability') {
-    return { compareOutput, acknowledged: false };
-  }
-  const { triggered, reasons } = resolveMaintainabilityRefreshTrigger(ctx);
+function applyRefreshAcknowledgment(kind, compareOutput, ctx) {
+  const { triggered, reasons } = resolveRefreshTrigger({ ...ctx, kind });
   if (!triggered || compareOutput.regressions.length === 0) {
     return { compareOutput, acknowledged: false };
   }
   Logger.warn(
-    `[maintainability] ⚠ ${reasons.join('; ')} — ` +
+    `[${kind}] ⚠ ${reasons.join('; ')} — ` +
       `${compareOutput.regressions.length} regression(s) acknowledged for this run only; ` +
       'floors still enforced. This does not persist: once the refresh is the ' +
       'new base the ratchet re-enforces at full strength.',
@@ -274,14 +248,14 @@ export async function evaluateKind({
     rawCompare,
     gateBlock.tolerance ?? null,
   );
-  const bundleAck = applyBundleSizeAcknowledgment(kind, toleratedCompare, env);
-  const miAck = applyMaintainabilityAcknowledgment(
-    kind,
-    bundleAck.compareOutput,
-    { gateBlock, cmp, cwd, env },
-  );
-  const compareOutput = miAck.compareOutput;
-  const acknowledged = bundleAck.acknowledged || miAck.acknowledged;
+  const ack = applyRefreshAcknowledgment(kind, toleratedCompare, {
+    gateBlock,
+    cmp,
+    cwd,
+    env,
+  });
+  const compareOutput = ack.compareOutput;
+  const acknowledged = ack.acknowledged;
   return buildGateReport({
     kind,
     gateBlock,

--- a/.agents/scripts/lib/orchestration/check-baselines/phases/parse-args.js
+++ b/.agents/scripts/lib/orchestration/check-baselines/phases/parse-args.js
@@ -44,18 +44,26 @@ compare) over every configured gate, with centralised friction emission and
 aggregated exit codes.
 
 Env vars:
-  BUNDLE_SIZE_REFRESH=1  One-shot acknowledge for an intentional bundle-size
-                         growth: demotes bundle-size regressions to
-                         "unchanged" for this run only (floors still
-                         enforced). Never persisted — the next run without
-                         this flag re-enforces the ratchet.
-  MAINTAINABILITY_REFRESH=1
-                         One-shot acknowledge for a deliberate maintainability
-                         baseline refresh: demotes maintainability head-vs-base
-                         regressions to "unchanged" for this run only (floors
-                         still enforced). Env-parity override for the
-                         'baseline-refresh:'-tagged range commit that touches
-                         baselines/maintainability.json. Never persisted.
+  <KIND>_REFRESH=1       One-shot acknowledge for a deliberate baseline
+                         refresh of that kind: demotes its head-vs-base
+                         regressions to "unchanged" for this run only. Floors
+                         are STILL enforced, so a genuine breach is still
+                         caught. The kind name is upper-snaked, e.g.
+                         COVERAGE_REFRESH, CRAP_REFRESH, DUPLICATION_REFRESH,
+                         MAINTAINABILITY_REFRESH, BUNDLE_SIZE_REFRESH.
+                         Never persisted — the next run without the flag
+                         re-enforces the ratchet at full strength.
+
+                         Equivalent commit-tagged trigger: a commit in the
+                         compared range whose subject contains the gate's
+                         'refreshTag' (default 'baseline-refresh:') AND whose
+                         diff touches that kind's baseline file. One-shot by
+                         construction — once merged the refreshed baseline is
+                         the new base and the tag leaves the range.
+
+                         Use these when replacing a diff-scope baseline with a
+                         full-scope measurement: the resulting row deltas are
+                         arithmetic, not behavioural.
 
 Exit codes:
   0  every enabled gate passes

--- a/tests/check-baselines-generic-refresh-ack.test.js
+++ b/tests/check-baselines-generic-refresh-ack.test.js
@@ -1,0 +1,268 @@
+// tests/check-baselines-generic-refresh-ack.test.js
+//
+// Story #4802 — the one-shot baseline refresh/acknowledge is now kind-generic.
+//
+// Stories #151 (bundle-size, env only) and #4731 (maintainability, env OR a
+// `baseline-refresh:`-tagged range commit) each shipped their own
+// `if (kind !== '<literal>') return ...` function. Every other ratcheted kind
+// had no escape at all, which made a deliberate full-scope baseline rewrite
+// unlandable: a diff-scope baseline is an accretion of many partial runs, so
+// replacing it with a single full-scope measurement produces row deltas in
+// both directions that are arithmetic, not behavioural.
+//
+// These tests pin the generalized contract on `coverage` (the kind the gap was
+// reported against) and assert the mechanism reaches every kind, that floors
+// are never suppressed, that nothing persists, and that an unusable baseline
+// path fails closed instead of throwing.
+
+import assert from 'node:assert/strict';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, it } from 'node:test';
+
+import { runCheckBaselines } from '../.agents/scripts/check-baselines.js';
+import {
+  __resetForTests,
+  __setSpawnRunner,
+} from '../.agents/scripts/lib/baselines/git-base.js';
+import { currentKernelVersion } from '../.agents/scripts/lib/baselines/kernel.js';
+
+const COV_BASELINE_REL = 'baselines/coverage.json';
+
+function writeJson(p, value) {
+  writeFileSync(p, JSON.stringify(value, null, 2));
+}
+
+function covEnvelope({ rows, rollup } = {}) {
+  return {
+    $schema: 'coverage.schema.json',
+    kernelVersion: currentKernelVersion('coverage'),
+    generatedAt: '2026-01-01T00:00:00.000Z',
+    rollup: rollup ?? { '*': { lines: 90, branches: 85, functions: 90 } },
+    rows: rows ?? [],
+  };
+}
+
+function setupTmpRepo({ floors } = {}) {
+  const root = mkdtempSync(path.join(tmpdir(), 'check-baselines-generic-'));
+  mkdirSync(path.join(root, 'baselines'), { recursive: true });
+  writeJson(path.join(root, '.agentrc.json'), {
+    project: {
+      baseBranch: 'main',
+      paths: { agentRoot: '.agents', docsRoot: 'docs', tempRoot: 'temp' },
+      docsContextFiles: [],
+      commands: { lintBaseline: 'echo', test: 'echo', typecheck: 'echo' },
+    },
+    github: { owner: 'x', repo: 'y', operatorHandle: '@ci' },
+    delivery: {
+      quality: {
+        gateScoping: { scope: 'diff', diffRef: 'main' },
+        gates: {
+          coverage: {
+            enabled: true,
+            baselinePath: COV_BASELINE_REL,
+            tolerance: { kind: 'absolute', value: 0.5 },
+            floors: floors ?? { '*': { lines: 50 } },
+          },
+        },
+      },
+    },
+  });
+  return root;
+}
+
+function installGitStub({ baseRows, baseRollup, subjects = [] }) {
+  const baseJson = JSON.stringify(
+    covEnvelope({ rows: baseRows, rollup: baseRollup }),
+  );
+  __setSpawnRunner({
+    spawn: (_cmd, args) => {
+      const verb = args?.[0];
+      if (verb === 'show') {
+        const spec = args?.[1] ?? '';
+        if (spec.endsWith(`:${COV_BASELINE_REL}`)) {
+          return { status: 0, stdout: baseJson, stderr: '' };
+        }
+        return { status: 128, stdout: '', stderr: 'no base' };
+      }
+      if (verb === 'log') {
+        return { status: 0, stdout: `${subjects.join('\n')}\n`, stderr: '' };
+      }
+      return { status: 128, stdout: '', stderr: 'unexpected' };
+    },
+  });
+}
+
+/** Head baseline whose row regressed vs base but whose rollup clears the floor. */
+function writeRegressedHead(root) {
+  writeJson(
+    path.join(root, 'baselines', 'coverage.json'),
+    covEnvelope({
+      rollup: { '*': { lines: 90, branches: 85, functions: 90 } },
+      rows: [{ path: 'src/a.js', lines: 70, branches: 70, functions: 70 }],
+    }),
+  );
+}
+
+const REGRESSED_BASE = [
+  { path: 'src/a.js', lines: 95, branches: 95, functions: 95 },
+];
+
+describe('check-baselines — generic refresh acknowledgment (#4802)', () => {
+  let root;
+
+  beforeEach(() => {
+    __resetForTests();
+  });
+
+  afterEach(() => {
+    __resetForTests();
+    if (root) rmSync(root, { recursive: true, force: true });
+    root = undefined;
+  });
+
+  // The reported gap: coverage had no acknowledgment path at all.
+  it('COVERAGE_REFRESH=1 demotes coverage head-vs-base regressions (no EXIT_REGRESSION)', async () => {
+    root = setupTmpRepo();
+    writeRegressedHead(root);
+    installGitStub({ baseRows: REGRESSED_BASE });
+    const res = await runCheckBaselines({
+      argv: ['--no-friction'],
+      cwd: root,
+      env: { COVERAGE_REFRESH: '1' },
+    });
+    assert.equal(res.exitCode, 0);
+    const gate = res.report.gates.find((g) => g.kind === 'coverage');
+    assert.equal(gate.acknowledged, true, 'gate names itself acknowledged');
+    assert.equal(gate.regressionCount, 0, 'regressions demoted');
+  });
+
+  // Floors are never suppressed by an acknowledgment.
+  it('a floor breach still fails under COVERAGE_REFRESH=1', async () => {
+    root = setupTmpRepo({ floors: { '*': { lines: 95 } } });
+    writeRegressedHead(root); // rollup lines 90 < floor 95
+    installGitStub({ baseRows: REGRESSED_BASE });
+    const res = await runCheckBaselines({
+      argv: ['--no-friction'],
+      cwd: root,
+      env: { COVERAGE_REFRESH: '1' },
+    });
+    assert.notEqual(res.exitCode, 0, 'floor breach still fails the run');
+    const gate = res.report.gates.find((g) => g.kind === 'coverage');
+    assert.ok(gate.breachCount >= 1, 'floor breach reported');
+  });
+
+  // The commit-tag trigger generalizes too — previously maintainability-only.
+  it('a baseline-refresh:-tagged range commit touching baselines/coverage.json acknowledges with no env var', async () => {
+    root = setupTmpRepo();
+    writeRegressedHead(root);
+    installGitStub({
+      baseRows: REGRESSED_BASE,
+      subjects: [
+        'chore(baselines): baseline-refresh: regenerate coverage full-scope',
+      ],
+    });
+    const res = await runCheckBaselines({ argv: ['--no-friction'], cwd: root });
+    assert.equal(res.exitCode, 0);
+    const gate = res.report.gates.find((g) => g.kind === 'coverage');
+    assert.equal(gate.acknowledged, true);
+    assert.equal(gate.regressionCount, 0);
+  });
+
+  // No trigger → the generic path is a no-op, exactly as before #4802.
+  it('an unacknowledged run reports the regression exactly as before (exit 4)', async () => {
+    root = setupTmpRepo();
+    writeRegressedHead(root);
+    installGitStub({
+      baseRows: REGRESSED_BASE,
+      subjects: ['fix(x): an untagged commit'],
+    });
+    const res = await runCheckBaselines({ argv: ['--no-friction'], cwd: root });
+    assert.equal(res.exitCode, 4);
+    const gate = res.report.gates.find((g) => g.kind === 'coverage');
+    assert.equal(gate.acknowledged, false);
+    assert.ok(gate.regressionCount >= 1, 'regression preserved');
+  });
+
+  // One kind's flag must not acknowledge another's.
+  it('MAINTAINABILITY_REFRESH does not acknowledge the coverage gate', async () => {
+    root = setupTmpRepo();
+    writeRegressedHead(root);
+    installGitStub({ baseRows: REGRESSED_BASE });
+    const res = await runCheckBaselines({
+      argv: ['--no-friction'],
+      cwd: root,
+      env: { MAINTAINABILITY_REFRESH: '1' },
+    });
+    assert.equal(res.exitCode, 4);
+    const gate = res.report.gates.find((g) => g.kind === 'coverage');
+    assert.equal(gate.acknowledged, false);
+  });
+
+  // Nothing is persisted: the acknowledgment is re-derived every run.
+  it('acknowledgment does not persist — the next run without the flag reports again', async () => {
+    root = setupTmpRepo();
+    writeRegressedHead(root);
+    installGitStub({ baseRows: REGRESSED_BASE });
+
+    const acked = await runCheckBaselines({
+      argv: ['--no-friction'],
+      cwd: root,
+      env: { COVERAGE_REFRESH: '1' },
+    });
+    assert.equal(acked.exitCode, 0);
+
+    __resetForTests();
+    installGitStub({ baseRows: REGRESSED_BASE });
+    const again = await runCheckBaselines({
+      argv: ['--no-friction'],
+      cwd: root,
+    });
+    assert.equal(again.exitCode, 4, 'ratchet back at full strength');
+    const gate = again.report.gates.find((g) => g.kind === 'coverage');
+    assert.equal(gate.acknowledged, false);
+  });
+
+  // The commit-tag probe resolves its baseline path from DEFAULT_BASELINE_PATHS
+  // when the gate block omits one. (The complementary guard — a kind with
+  // neither a configured path nor a DEFAULT_BASELINE_PATHS entry — is defensive
+  // depth only: KNOWN_KINDS gates CLI input and every member has a default, so
+  // that branch is unreachable from here. Its no-throw contract is pinned at
+  // the resolver level in tests/check-bundle-size-env-overrides.test.js.)
+  it('the commit-tag probe falls back to DEFAULT_BASELINE_PATHS when the gate block omits baselinePath', async () => {
+    root = mkdtempSync(path.join(tmpdir(), 'check-baselines-generic-'));
+    mkdirSync(path.join(root, 'baselines'), { recursive: true });
+    writeJson(path.join(root, '.agentrc.json'), {
+      project: {
+        baseBranch: 'main',
+        paths: { agentRoot: '.agents', docsRoot: 'docs', tempRoot: 'temp' },
+        docsContextFiles: [],
+        commands: { lintBaseline: 'echo', test: 'echo', typecheck: 'echo' },
+      },
+      github: { owner: 'x', repo: 'y', operatorHandle: '@ci' },
+      delivery: {
+        quality: {
+          gateScoping: { scope: 'diff', diffRef: 'main' },
+          gates: {
+            // No baselinePath — the default (baselines/coverage.json) applies.
+            coverage: {
+              enabled: true,
+              tolerance: { kind: 'absolute', value: 0.5 },
+              floors: { '*': { lines: 50 } },
+            },
+          },
+        },
+      },
+    });
+    writeRegressedHead(root);
+    installGitStub({
+      baseRows: REGRESSED_BASE,
+      subjects: ['chore(baselines): baseline-refresh: regenerate coverage'],
+    });
+    const res = await runCheckBaselines({ argv: ['--no-friction'], cwd: root });
+    assert.equal(res.exitCode, 0, 'tag probe found the default baseline path');
+    const gate = res.report.gates.find((g) => g.kind === 'coverage');
+    assert.equal(gate.acknowledged, true);
+  });
+});

--- a/tests/check-bundle-size-env-overrides.test.js
+++ b/tests/check-bundle-size-env-overrides.test.js
@@ -1,6 +1,15 @@
 import assert from 'node:assert';
 import { test } from 'node:test';
-import { resolveBundleSizeEnvOverrides } from '../.agents/scripts/lib/baselines/env-overrides.js';
+import {
+  kindRefreshEnvVar,
+  resolveKindRefreshOverrides,
+} from '../.agents/scripts/lib/baselines/env-overrides.js';
+
+// Story #4802 generalized the per-kind resolvers into one kind-keyed helper.
+// This shim keeps every original bundle-size assertion below byte-identical
+// while driving the generic function, so the #151 contract is still pinned.
+const resolveBundleSizeEnvOverrides = (env) =>
+  resolveKindRefreshOverrides('bundle-size', env);
 
 /**
  * Tests for `resolveBundleSizeEnvOverrides` (Story #151 upstream port,
@@ -94,4 +103,61 @@ test('resolveBundleSizeEnvOverrides — other env vars present do not interfere'
   });
   assert.strictEqual(result.acknowledged, true);
   assert.strictEqual(result.overrides.length, 1);
+});
+
+// --- Kind-generic surface (Story #4802) ------------------------------------
+
+test('kindRefreshEnvVar — upper-snakes the kind, reproducing both legacy names', () => {
+  assert.strictEqual(kindRefreshEnvVar('bundle-size'), 'BUNDLE_SIZE_REFRESH');
+  assert.strictEqual(
+    kindRefreshEnvVar('maintainability'),
+    'MAINTAINABILITY_REFRESH',
+  );
+  assert.strictEqual(kindRefreshEnvVar('coverage'), 'COVERAGE_REFRESH');
+  assert.strictEqual(kindRefreshEnvVar('crap'), 'CRAP_REFRESH');
+  assert.strictEqual(kindRefreshEnvVar('duplication'), 'DUPLICATION_REFRESH');
+});
+
+test('kindRefreshEnvVar — a non-usable kind yields null rather than a bogus var name', () => {
+  assert.strictEqual(kindRefreshEnvVar(''), null);
+  assert.strictEqual(kindRefreshEnvVar(undefined), null);
+  assert.strictEqual(kindRefreshEnvVar(null), null);
+  assert.strictEqual(kindRefreshEnvVar(42), null);
+});
+
+test('resolveKindRefreshOverrides — COVERAGE_REFRESH=1 acknowledges the coverage kind (the #4802 gap)', () => {
+  const result = resolveKindRefreshOverrides('coverage', {
+    COVERAGE_REFRESH: '1',
+  });
+  assert.strictEqual(result.acknowledged, true);
+  assert.ok(result.overrides[0].includes('COVERAGE_REFRESH=1'));
+});
+
+test('resolveKindRefreshOverrides — crap and duplication gain the same escape', () => {
+  assert.strictEqual(
+    resolveKindRefreshOverrides('crap', { CRAP_REFRESH: '1' }).acknowledged,
+    true,
+  );
+  assert.strictEqual(
+    resolveKindRefreshOverrides('duplication', { DUPLICATION_REFRESH: 'true' })
+      .acknowledged,
+    true,
+  );
+});
+
+test('resolveKindRefreshOverrides — a kind is not acknowledged by another kind flag', () => {
+  const result = resolveKindRefreshOverrides('coverage', {
+    MAINTAINABILITY_REFRESH: '1',
+    BUNDLE_SIZE_REFRESH: '1',
+  });
+  assert.strictEqual(result.acknowledged, false);
+  assert.deepStrictEqual(result.overrides, []);
+});
+
+test('resolveKindRefreshOverrides — an unusable kind is a no-op, not a throw', () => {
+  const result = resolveKindRefreshOverrides(undefined, {
+    COVERAGE_REFRESH: '1',
+  });
+  assert.strictEqual(result.acknowledged, false);
+  assert.deepStrictEqual(result.overrides, []);
 });

--- a/tests/check-bundle-size-env-overrides.test.js
+++ b/tests/check-bundle-size-env-overrides.test.js
@@ -1,9 +1,6 @@
 import assert from 'node:assert';
 import { test } from 'node:test';
-import {
-  kindRefreshEnvVar,
-  resolveKindRefreshOverrides,
-} from '../.agents/scripts/lib/baselines/env-overrides.js';
+import { resolveKindRefreshOverrides } from '../.agents/scripts/lib/baselines/env-overrides.js';
 
 // Story #4802 generalized the per-kind resolvers into one kind-keyed helper.
 // This shim keeps every original bundle-size assertion below byte-identical
@@ -107,22 +104,35 @@ test('resolveBundleSizeEnvOverrides — other env vars present do not interfere'
 
 // --- Kind-generic surface (Story #4802) ------------------------------------
 
-test('kindRefreshEnvVar — upper-snakes the kind, reproducing both legacy names', () => {
-  assert.strictEqual(kindRefreshEnvVar('bundle-size'), 'BUNDLE_SIZE_REFRESH');
-  assert.strictEqual(
-    kindRefreshEnvVar('maintainability'),
-    'MAINTAINABILITY_REFRESH',
-  );
-  assert.strictEqual(kindRefreshEnvVar('coverage'), 'COVERAGE_REFRESH');
-  assert.strictEqual(kindRefreshEnvVar('crap'), 'CRAP_REFRESH');
-  assert.strictEqual(kindRefreshEnvVar('duplication'), 'DUPLICATION_REFRESH');
+// The env-var naming rule is pinned through the public resolver: each kind is
+// acknowledged by its upper-snaked name and by nothing else. That is a
+// stronger assertion than reading the name back, since it also proves the
+// resolver actually reads that variable.
+test('env-var naming — each kind is acknowledged by its upper-snaked name, incl. both legacy names', () => {
+  const cases = [
+    ['bundle-size', 'BUNDLE_SIZE_REFRESH'],
+    ['maintainability', 'MAINTAINABILITY_REFRESH'],
+    ['coverage', 'COVERAGE_REFRESH'],
+    ['crap', 'CRAP_REFRESH'],
+    ['duplication', 'DUPLICATION_REFRESH'],
+  ];
+  for (const [kind, varName] of cases) {
+    const result = resolveKindRefreshOverrides(kind, { [varName]: '1' });
+    assert.strictEqual(result.acknowledged, true, `${kind} via ${varName}`);
+    assert.ok(result.overrides[0].includes(`${varName}=1`));
+  }
 });
 
-test('kindRefreshEnvVar — a non-usable kind yields null rather than a bogus var name', () => {
-  assert.strictEqual(kindRefreshEnvVar(''), null);
-  assert.strictEqual(kindRefreshEnvVar(undefined), null);
-  assert.strictEqual(kindRefreshEnvVar(null), null);
-  assert.strictEqual(kindRefreshEnvVar(42), null);
+test('env-var naming — a non-usable kind is a no-op rather than reading a bogus var', () => {
+  for (const kind of ['', undefined, null, 42]) {
+    const result = resolveKindRefreshOverrides(kind, {
+      _REFRESH: '1',
+      REFRESH: '1',
+      '42_REFRESH': '1',
+    });
+    assert.strictEqual(result.acknowledged, false, `kind=${String(kind)}`);
+    assert.deepStrictEqual(result.overrides, []);
+  }
 });
 
 test('resolveKindRefreshOverrides — COVERAGE_REFRESH=1 acknowledges the coverage kind (the #4802 gap)', () => {


### PR DESCRIPTION
Closes #4802

_Auto-opened by `/deliver`._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CI gate behavior for all ratcheted kinds (broader acknowledgment surface), but semantics are intentionally preserved for bundle-size/maintainability and floors remain enforced; risk is mainly accidental misuse of refresh flags or commit tags rather than security.
> 
> **Overview**
> **Generalizes** the one-shot baseline refresh/acknowledge path so every ratcheted gate kind can suspend head-vs-base regressions for a single run while **floors still apply**.
> 
> `resolveBundleSizeEnvOverrides` and `resolveMaintainabilityRefreshOverrides` are replaced by **`resolveKindRefreshOverrides(kind, env)`**, which maps kind names to env vars via upper-snaking (`coverage` → `COVERAGE_REFRESH`, `bundle-size` → `BUNDLE_SIZE_REFRESH`), preserving the legacy names. In the evaluate phase, separate **`applyBundleSizeAcknowledgment`** / **`applyMaintainabilityAcknowledgment`** handlers become **`applyRefreshAcknowledgment`**: env flag **or** a range commit whose subject contains the gate’s `refreshTag` and whose diff touches that kind’s baseline file (commit-tag path was maintainability-only before; it now applies per kind with `DEFAULT_BASELINE_PATHS[kind]`).
> 
> CLI help documents the generic **`<KIND>_REFRESH=1`** contract. New integration tests cover coverage (including commit-tag and non-persistence); existing bundle-size env tests are routed through the generic resolver via a shim.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 471408c44a7ad3bd5eb2c13201a9163cb3788e4f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->