### PR TITLE
feat: deliver-light: make the gate's `proceed-light` answer representable, attended-only, and auditable (#4815)

### DIFF
--- a/.agents/scripts/deliver-light.js
+++ b/.agents/scripts/deliver-light.js
@@ -24,7 +24,10 @@
  *     `proceed-light` it authors the receipt Story (via the plan-persist
  *     `createStoryIssues` surface) and prints the init/close hand-off. On
  *     over-scope it prints `ask-operator` (attended) or emits an `escalated`
- *     terminal envelope (`--yes`), never landing silently.
+ *     terminal envelope (`--yes`), never landing silently. An attended
+ *     `ask-operator` is answerable **either** way: `--operator-proceed-light`
+ *     records the operator's proceed answer (Story #4815), which the gate
+ *     applies only to a coarse size prediction and never to a risk rule.
  *   - **backstop** (`--backstop --story <id>`) — re-check the ACTUAL diff of
  *     the Story branch after implementation; exit non-zero when it exceeds the
  *     light ceilings, so an over-scope diff is blocked rather than landed.
@@ -81,7 +84,7 @@ Usage:
   deliver-light.js --prompt <text> [--creates csv] [--refactors csv]
                    [--acceptance n] [--kinds csv] [--magnitude m]
                    [--uncertainty u] [--route lite|full] [--reason <text>]
-                   [--amends '#id'] [--yes]
+                   [--amends '#id'] [--operator-proceed-light <text>] [--yes]
   deliver-light.js --backstop --story <id>
 
 The thin /deliver-light entry point: suitability gate → inline receipt Story →
@@ -105,6 +108,15 @@ Gate options:
   --route <r>        Ledgered model verdict route: lite | full.
   --reason <text>    Recorded reason for a lite verdict (required for lite).
   --amends <#id>     Mark this as an amendment of an existing issue.
+  --operator-proceed-light <text>
+                     Record the operator's "proceed light" answer to an
+                     ask-operator gate, with their reason. Attended-only:
+                     refused with --yes. Waives a coarse SIZE prediction
+                     (change kinds, magnitude, uncertainty, deployable span)
+                     only — sensitivity, migration span, and an unknown
+                     footprint stay non-negotiable, the ledgered --route lite
+                     verdict is still required, and the --backstop pass still
+                     bounds the actual diff. Recorded in the receipt Story.
   --yes              Unattended: over-scope emits an escalated terminal
                      envelope and ENDS the session (no prompt, no fallback).
 
@@ -182,11 +194,14 @@ export function synthesizeAcceptance(count) {
  *   uncertainty?: string,
  *   route?: string,
  *   reason?: string,
+ *   operatorProceedLight?: string,
  *   yes?: boolean,
  *   injectedRules?: object,
  * }} args `kinds` / `magnitude` / `uncertainty` are the declared effort-and-risk
  *   axes the gate judges (Story #4764); omitting them declares no signal, not a
- *   small one — an unrecognized bucket fails closed.
+ *   small one — an unrecognized bucket fails closed. `operatorProceedLight`
+ *   carries the operator's recorded answer to an `ask-operator` outcome
+ *   (Story #4815) and is adjudicated inside the gate, never applied here.
  * @returns {{ action: string, suitability: object, outcome: object }}
  */
 export function runLightGate({
@@ -198,6 +213,7 @@ export function runLightGate({
   uncertainty,
   route,
   reason,
+  operatorProceedLight,
   yes = false,
   injectedRules,
 } = {}) {
@@ -211,7 +227,11 @@ export function runLightGate({
     verdict: { route, reason },
     injectedRules,
   });
-  const outcome = resolveLightGateOutcome({ suitability, yes });
+  const outcome = resolveLightGateOutcome({
+    suitability,
+    yes,
+    operatorOverride: operatorProceedLight,
+  });
   return { action: outcome.action, suitability, outcome };
 }
 
@@ -224,9 +244,11 @@ export function runLightGate({
  *   prompt: string,
  *   changedFiles?: string[],
  *   amends?: string|number|null,
+ *   override?: object|null,
  *   assembleFn?: typeof assemblePlanStories,
  *   createFn?: typeof createStoryIssues,
- * }} args
+ * }} args `override` is the applied operator scope override (Story #4815),
+ *   recorded in the receipt body so the decision is auditable from the ticket.
  * @returns {Promise<{ storyId: number, url: string|undefined, title: string }>}
  */
 export async function createLightReceipt({
@@ -234,10 +256,16 @@ export async function createLightReceipt({
   prompt,
   changedFiles = [],
   amends = null,
+  override = null,
   assembleFn = assemblePlanStories,
   createFn = createStoryIssues,
 } = {}) {
-  const ticket = buildReceiptStoryTicket({ prompt, changedFiles, amends });
+  const ticket = buildReceiptStoryTicket({
+    prompt,
+    changedFiles,
+    amends,
+    override,
+  });
   const { stories } = assembleFn([ticket]);
   const { created } = await createFn({ provider, stories });
   const receipt = created[0];
@@ -292,6 +320,19 @@ export function runDiffBackstop({
 }
 
 /**
+ * Was a non-blank `--operator-proceed-light` supplied? The gate core decides
+ * whether it *applies*; this only asks whether the operator typed one, so the
+ * attended-only refusal can fire before any adjudication.
+ *
+ * @param {{ 'operator-proceed-light'?: unknown }} values Parsed CLI values.
+ * @returns {boolean}
+ */
+export function hasOperatorOverride(values = {}) {
+  const raw = values['operator-proceed-light'];
+  return typeof raw === 'string' && raw.trim() !== '';
+}
+
+/**
  * Emit a JSON envelope on stdout (the machine surface) so a headless caller can
  * branch on it. Human-readable log lines stay on stderr.
  *
@@ -341,8 +382,10 @@ async function runBackstopMode(values) {
  *     control flow rather than a claim the envelope makes about itself.
  *   - **`ask-operator`** is unchanged: the plain gate envelope and exit 2. It
  *     is not terminal — the operator has a choice to make, and manufacturing a
- *     terminal for it would end a session that is supposed to be waiting.
- *   - **`proceed-light`** authors the receipt Story and prints the hand-off.
+ *     terminal for it would end a session that is supposed to be waiting. The
+ *     operator's proceed answer comes back as `--operator-proceed-light`.
+ *   - **`proceed-light`** authors the receipt Story and prints the hand-off,
+ *     carrying any applied `override` into both the receipt and the envelope.
  *
  * The injectable seams exist so the no-side-effect guarantee is testable
  * without a network: a test asserts the escalate path never reaches them.
@@ -371,6 +414,17 @@ export async function runGateMode(values, deps = {}) {
     throw new Error('[deliver-light] --prompt <text> is required for the gate');
   }
 
+  // Attended-only, enforced loudly (Story #4815). Silently ignoring the flag
+  // under --yes would let an automated caller pass it as a hopeful no-op and
+  // read the resulting escalation as a bug; a usage error says which of the
+  // two the caller has to give up.
+  if (values.yes === true && hasOperatorOverride(values)) {
+    process.stderr.write(HELP);
+    throw new Error(
+      '[deliver-light] --operator-proceed-light is attended-only and cannot be combined with --yes: an unattended run has no operator whose answer this is, and over-scope must fail closed to /plan',
+    );
+  }
+
   const gate = runLightGate({
     creates: parseCsvPaths(values.creates),
     refactors: parseCsvPaths(values.refactors),
@@ -382,6 +436,7 @@ export async function runGateMode(values, deps = {}) {
     uncertainty: values.uncertainty,
     route: values.route,
     reason: values.reason,
+    operatorProceedLight: values['operator-proceed-light'],
     yes: values.yes === true,
   });
 
@@ -408,6 +463,7 @@ export async function runGateMode(values, deps = {}) {
     return EXIT_NOT_PROCEED;
   }
 
+  const override = gate.outcome.override ?? null;
   const provider = createProviderFn(resolveConfigFn());
   const receipt = await createReceiptFn({
     provider,
@@ -417,6 +473,7 @@ export async function runGateMode(values, deps = {}) {
       ...parseCsvPaths(values.refactors),
     ],
     amends: values.amends ?? null,
+    override,
   });
   emitFn(
     {
@@ -424,11 +481,17 @@ export async function runGateMode(values, deps = {}) {
       action: 'proceed-light',
       storyId: receipt.storyId,
       url: receipt.url,
+      ...(override === null ? {} : { override }),
       nextCommands: buildNextCommands(receipt.storyId),
       outcome: gate.outcome,
     },
     values.pretty,
   );
+  if (override !== null) {
+    Logger.warn(
+      `[deliver-light] operator scope override recorded on Story #${receipt.storyId}: waived "${override.overriddenCode}" — ${override.recordedReason}`,
+    );
+  }
   Logger.info(
     `[deliver-light] receipt Story #${receipt.storyId} created — hand off to single-story-init.js.`,
   );
@@ -448,6 +511,7 @@ async function main() {
       route: { type: 'string' },
       reason: { type: 'string' },
       amends: { type: 'string' },
+      'operator-proceed-light': { type: 'string' },
       yes: { type: 'boolean', default: false },
       backstop: { type: 'boolean', default: false },
       story: { type: 'string' },

--- a/.agents/scripts/lib/orchestration/complexity-gate.js
+++ b/.agents/scripts/lib/orchestration/complexity-gate.js
@@ -260,22 +260,64 @@ function spansMigrationAndConsumers(paths) {
 }
 
 /**
+ * Stable machine-readable identifiers for every reason a shape routes `full` —
+ * the `code` field on a {@link deriveStoryShape} decision (Story #4815).
+ *
+ * The prose in `reasons[]` is written for a human reading a gate envelope and
+ * is free to be re-worded; a caller that must **branch** on *which* rule
+ * objected reads this code instead. That distinction is load-bearing for the
+ * light path's operator override
+ * ({@link module:lib/orchestration/light-suitability.OVERRIDABLE_SHAPE_CODES}),
+ * which may waive a size *prediction* but never a risk rule: keying that
+ * decision off reason text would make a copy-edit a security change.
+ *
+ * Split three ways, and the grouping is the contract:
+ *
+ *   - **Ceiling rules** — `change-kinds`, `magnitude`, `uncertainty`,
+ *     `deployable-span`. Coarse predictions about size, enforced for real
+ *     against ground truth by the diff backstop.
+ *   - **Absolute rules** — `migration-span`, `sensitive-path`. Risk, not size.
+ *   - **Unknown-footprint rejections** — `no-changes`, `unreadable-changes`,
+ *     `glob-footprint`, `no-acceptance`, `classification-unavailable`,
+ *     `unparseable-body`. Nothing was judged, so there is nothing to waive.
+ *
+ * A `lite` route carries `code: null`.
+ */
+export const SHAPE_CODES = Object.freeze({
+  CHANGE_KINDS: 'change-kinds',
+  MAGNITUDE: 'magnitude',
+  UNCERTAINTY: 'uncertainty',
+  DEPLOYABLE_SPAN: 'deployable-span',
+  MIGRATION_SPAN: 'migration-span',
+  SENSITIVE_PATH: 'sensitive-path',
+  NO_CHANGES: 'no-changes',
+  UNREADABLE_CHANGES: 'unreadable-changes',
+  GLOB_FOOTPRINT: 'glob-footprint',
+  NO_ACCEPTANCE: 'no-acceptance',
+  CLASSIFICATION_UNAVAILABLE: 'classification-unavailable',
+  UNPARSEABLE_BODY: 'unparseable-body',
+});
+
+/**
  * Ordered effort/risk rules, evaluated in order; the first hit is the recorded
  * reason for a `full` route. Every rule names an effort, risk, or uncertainty
  * property of the work — none counts artifacts.
  *
  * @type {ReadonlyArray<{
+ *   code: string,
  *   when: (shape: object, ceilings: typeof STORY_SHAPE_CEILINGS) => boolean,
  *   reason: (shape: object, ceilings: typeof STORY_SHAPE_CEILINGS) => string,
  * }>}
  */
 const EFFORT_RULES = Object.freeze([
   {
+    code: SHAPE_CODES.CHANGE_KINDS,
     when: (s, c) => s.kindCount > c.maxChangeKinds,
     reason: (s, c) =>
       `${s.kindCount} distinct change kinds (${s.changeKinds.join(', ')}) > maxChangeKinds ${c.maxChangeKinds} — an explicit multi-capability enumeration, not one capability; full route`,
   },
   {
+    code: SHAPE_CODES.MAGNITUDE,
     when: (s, c) =>
       MAGNITUDE_SCALE.indexOf(s.magnitude) >
       MAGNITUDE_SCALE.indexOf(c.maxMagnitude),
@@ -283,6 +325,7 @@ const EFFORT_RULES = Object.freeze([
       `declared magnitude "${s.magnitude}" > maxMagnitude "${c.maxMagnitude}" — a substantial rewrite is effort a single inline pass should not absorb, however few files it touches; full route`,
   },
   {
+    code: SHAPE_CODES.UNCERTAINTY,
     when: (s, c) =>
       UNCERTAINTY_SCALE.indexOf(s.uncertainty) >
       UNCERTAINTY_SCALE.indexOf(c.maxUncertainty),
@@ -290,16 +333,19 @@ const EFFORT_RULES = Object.freeze([
       `the shape is not determined by the request (uncertainty "${s.uncertainty}") — the design decisions /plan exists to resolve are still open; full route`,
   },
   {
+    code: SHAPE_CODES.DEPLOYABLE_SPAN,
     when: (s, c) => s.deployables.length > c.maxDeployables,
     reason: (s, c) =>
       `footprint spans ${s.deployables.length} deployables (${s.deployables.join(', ')}) > maxDeployables ${c.maxDeployables} — clearly-epic scope; full route`,
   },
   {
+    code: SHAPE_CODES.MIGRATION_SPAN,
     when: (s) => s.migrationSpan,
     reason: () =>
       'footprint pairs a migration with its consumers — clearly-epic scope; full route',
   },
   {
+    code: SHAPE_CODES.SENSITIVE_PATH,
     when: (s) => s.sensitiveClasses.length > 0,
     reason: (s) =>
       `footprint intersects sensitive-path class(es) ${s.sensitiveClasses.join(', ')} — sensitivity wins over a small shape; full route (fresh acceptance critic retained)`,
@@ -307,15 +353,18 @@ const EFFORT_RULES = Object.freeze([
 ]);
 
 /**
- * First effort/risk rule the shape violates, or `null` when it clears them all.
+ * First effort/risk rule the shape violates as a `{ code, reason }` pair, or
+ * `null` when it clears them all.
  *
  * @param {object} shape
  * @param {typeof STORY_SHAPE_CEILINGS} ceilings
- * @returns {string|null}
+ * @returns {{ code: string, reason: string }|null}
  */
 function firstEffortViolation(shape, ceilings) {
   for (const rule of EFFORT_RULES) {
-    if (rule.when(shape, ceilings)) return rule.reason(shape, ceilings);
+    if (rule.when(shape, ceilings)) {
+      return { code: rule.code, reason: rule.reason(shape, ceilings) };
+    }
   }
   return null;
 }
@@ -654,10 +703,13 @@ function buildEffortShape({
  * @returns {{
  *   route: ComplexityRoute,
  *   reasons: string[],
+ *   code: string|null,
  *   shape: ReturnType<typeof buildEffortShape>|null,
  *   ceilings: typeof STORY_SHAPE_CEILINGS,
  *   preserves: typeof LITE_PATH_INVARIANTS,
- * }}
+ * }} `code` is the stable {@link SHAPE_CODES} identifier for the rule that
+ *   rejected the shape (`null` on `lite`) — the field a caller branches on,
+ *   since `reasons[]` is human prose and free to be re-worded.
  */
 export function deriveStoryShape({
   changes,
@@ -670,9 +722,10 @@ export function deriveStoryShape({
 } = {}) {
   const ceilings = STORY_SHAPE_CEILINGS;
   const preserves = LITE_PATH_INVARIANTS;
-  const decide = (route, reason, shape = null) => ({
+  const decide = (route, code, reason, shape = null) => ({
     route,
     reasons: [reason],
+    code,
     shape,
     ceilings,
     preserves,
@@ -681,6 +734,7 @@ export function deriveStoryShape({
   if (!Array.isArray(changes) || changes.length === 0) {
     return decide(
       'full',
+      SHAPE_CODES.NO_CHANGES,
       'no changes[] declared — the footprint is unknown, so the work cannot be judged trivial; conservative full route',
     );
   }
@@ -691,6 +745,7 @@ export function deriveStoryShape({
   } catch (err) {
     return decide(
       'full',
+      SHAPE_CODES.UNREADABLE_CHANGES,
       `changes[] could not be read (${err?.message ?? err}) — unknown footprint; conservative full route`,
     );
   }
@@ -714,6 +769,7 @@ export function deriveStoryShape({
   if (entries.some((e) => e.isGlob)) {
     return decide(
       'full',
+      SHAPE_CODES.GLOB_FOOTPRINT,
       'changes[] contains a glob path — unknown footprint width; conservative full route',
       shape,
     );
@@ -721,13 +777,16 @@ export function deriveStoryShape({
   if (shape.acceptanceCount === 0) {
     return decide(
       'full',
+      SHAPE_CODES.NO_ACCEPTANCE,
       'no acceptance criteria — the contract cannot be judged trivial; conservative full route',
       shape,
     );
   }
 
   const violation = firstEffortViolation(shape, ceilings);
-  if (violation !== null) return decide('full', violation, shape);
+  if (violation !== null) {
+    return decide('full', violation.code, violation.reason, shape);
+  }
 
   if (level !== 'low') {
     // `deriveChangeLevel` degraded to its null fail-safe (unreadable
@@ -735,6 +794,7 @@ export function deriveStoryShape({
     // non-sensitive, and a classification failure must never buy lite.
     return decide(
       'full',
+      SHAPE_CODES.CLASSIFICATION_UNAVAILABLE,
       'sensitive-path classification unavailable — cannot verify the footprint is non-sensitive; conservative full route',
       shape,
     );
@@ -742,6 +802,7 @@ export function deriveStoryShape({
 
   return decide(
     'lite',
+    null,
     `trivial shape: ${shape.kindCount} change kind(s) (${shape.changeKinds.join(', ')}) ≤ ${ceilings.maxChangeKinds} across ${shape.siteCount} site(s), magnitude ${shape.magnitude} ≤ ${ceilings.maxMagnitude}, shape ${shape.uncertainty}, no epic-scope span, no sensitive-path class — inline-eligible; non-negotiables preserved`,
     shape,
   );
@@ -771,6 +832,7 @@ function deriveStoryRouteFromBody(body, opts = {}) {
       reasons: [
         `Story body is unparseable (${err?.message ?? err}) — shape unknown; conservative full route`,
       ],
+      code: SHAPE_CODES.UNPARSEABLE_BODY,
       shape: null,
       ceilings: STORY_SHAPE_CEILINGS,
       preserves: LITE_PATH_INVARIANTS,

--- a/.agents/scripts/lib/orchestration/light-suitability.js
+++ b/.agents/scripts/lib/orchestration/light-suitability.js
@@ -30,8 +30,10 @@
  *   2. **Over-scope stops, never silently proceeds ({@link
  *      resolveLightGateOutcome}).** An over-ceiling prompt does **not**
  *      hard-fail — it STOPS and asks the operator to escalate to `/plan` or
- *      proceed light. Under `--yes` (unattended) it fails closed to
- *      recommending `/plan`.
+ *      proceed light. Both answers are executable: `proceed-light` is recorded
+ *      through {@link resolveOperatorOverride}, which waives a *size
+ *      prediction* only, never a risk rule, and only with a human present.
+ *      Under `--yes` (unattended) it fails closed to recommending `/plan`.
  *   3. **Diff-derived backstop ({@link checkLightDiffBackstop}).** After
  *      implementation the **actual** change set is re-checked with
  *      {@link module:lib/orchestration/review-depth.deriveChangeLevel} plus a
@@ -48,8 +50,33 @@
  * @module lib/orchestration/light-suitability
  */
 
-import { deriveStoryShape, STORY_SHAPE_CEILINGS } from './complexity-gate.js';
+import {
+  deriveStoryShape,
+  SHAPE_CODES,
+  STORY_SHAPE_CEILINGS,
+} from './complexity-gate.js';
 import { deriveChangeLevel } from './review-depth.js';
+
+/**
+ * The shape objections an attended operator may waive (Story #4815) — an
+ * **allowlist**, deliberately, so a rule added to
+ * {@link module:lib/orchestration/complexity-gate.SHAPE_CODES} later is
+ * non-negotiable until someone decides otherwise here. A denylist would make
+ * every new rule silently overridable.
+ *
+ * These four are the *size predictions*: coarse by design (§ Scope by effort),
+ * and already bounded for real by {@link checkLightDiffBackstop} against the
+ * landed diff. Everything absent is absent on purpose — `migration-span` and
+ * `sensitive-path` are **risk**, not size, and the unknown-footprint codes
+ * describe a shape that was never judged, so there is no false positive to
+ * appeal.
+ */
+export const OVERRIDABLE_SHAPE_CODES = Object.freeze([
+  SHAPE_CODES.CHANGE_KINDS,
+  SHAPE_CODES.MAGNITUDE,
+  SHAPE_CODES.UNCERTAINTY,
+  SHAPE_CODES.DEPLOYABLE_SPAN,
+]);
 
 /**
  * File-count ceiling for the **actual landed** change set the diff backstop
@@ -193,6 +220,88 @@ export function deriveLightSuitability({
 }
 
 /**
+ * Adjudicate an operator's recorded `proceed-light` answer to the gate's own
+ * question (Story #4815). The gate has always *offered* `proceed-light` as one
+ * of two options; before this there was no input that could carry the answer,
+ * so the only way past a coarse prediction was to re-shape the declaration
+ * until the gate stopped objecting — precisely the under-declaring the coarse
+ * design anticipates.
+ *
+ * Applying it takes **all** of:
+ *
+ *   1. **The gate actually objected.** An override cannot pre-authorize a
+ *      scope nothing rejected.
+ *   2. **The run is attended.** `--yes` means nobody is at the keyboard, so
+ *      there is no operator whose answer this could be (§ Escalation is
+ *      terminal). Checked here as well as at the CLI, so the pure core carries
+ *      the guarantee rather than the shell.
+ *   3. **The objection is a size prediction** — a code in
+ *      {@link OVERRIDABLE_SHAPE_CODES}. Sensitivity and migration span are
+ *      risk and stay absolute however small the change.
+ *   4. **The ledgered verdict is already `lite`.** The override substitutes for
+ *      the *shape* half of the conjunction only; an unaudited "trust me, it's
+ *      small" buys nothing it did not buy before.
+ *
+ * A refusal is reported, never silent — an operator who typed the flag must
+ * learn why it did not take. Pure and total.
+ *
+ * @param {{
+ *   suitability?: object,
+ *   yes?: boolean,
+ *   operatorOverride?: unknown,
+ * }} [args] `operatorOverride` is the operator's recorded reason; blank or
+ *   absent means no override was requested.
+ * @returns {{
+ *   applied: boolean,
+ *   record: { recordedReason: string, overriddenCode: string, overriddenReason: string }|null,
+ *   note: string|null,
+ * }}
+ */
+export function resolveOperatorOverride({
+  suitability,
+  yes = false,
+  operatorOverride,
+} = {}) {
+  const recordedReason =
+    typeof operatorOverride === 'string' ? operatorOverride.trim() : '';
+  const refuse = (note) => ({ applied: false, record: null, note });
+
+  if (recordedReason === '') return refuse(null);
+  if (suitability?.suitable === true) {
+    return refuse(
+      'operator override ignored — the gate raised no objection to override',
+    );
+  }
+  if (yes === true) {
+    return refuse(
+      'operator override refused — it is attended-only, and --yes means nobody is at the keyboard; over-scope still fails closed to /plan',
+    );
+  }
+
+  const code = suitability?.shape?.code ?? null;
+  if (!OVERRIDABLE_SHAPE_CODES.includes(code)) {
+    return refuse(
+      `operator override refused — "${code ?? 'unknown'}" is not an overridable size prediction (overridable: ${OVERRIDABLE_SHAPE_CODES.join(', ')}); risk rules and unknown footprints are non-negotiable`,
+    );
+  }
+  if (suitability?.ledger?.route !== 'lite') {
+    return refuse(
+      'operator override refused — it substitutes for the predicted shape only; the model verdict must still be a ledgered lite with a recorded reason',
+    );
+  }
+
+  return {
+    applied: true,
+    record: {
+      recordedReason,
+      overriddenCode: code,
+      overriddenReason: suitability?.shape?.reasons?.[0] ?? '',
+    },
+    note: `operator override applied — proceeding light despite "${code}"; recorded reason: ${recordedReason}. The diff backstop still bounds the actual change set.`,
+  };
+}
+
+/**
  * Resolve what the light gate does with a suitability decision (Story #4740
  * AC-3). Over-scope never hard-fails: it STOPS and asks the operator to choose,
  * unless the run is unattended (`--yes`), where it fails closed to recommending
@@ -200,17 +309,43 @@ export function deriveLightSuitability({
  *
  *   - suitable          → `proceed-light`
  *   - over-scope + attended (`yes:false`)  → `ask-operator` (escalate | proceed)
+ *   - over-scope + attended + an applied operator override (Story #4815)
+ *                                          → `proceed-light`, carrying the
+ *                                            decision in `override`
  *   - over-scope + unattended (`yes:true`) → `escalate-plan`
+ *
+ * The override is adjudicated by {@link resolveOperatorOverride} and cannot
+ * reach the unattended branch: `escalate-plan` is resolved first and the
+ * override refuses itself under `yes` anyway.
  *
  * Pure and total.
  *
- * @param {{ suitability?: { suitable?: boolean, reasons?: string[] }, yes?: boolean }} [args]
- * @returns {{ action: 'proceed-light'|'ask-operator'|'escalate-plan', options?: string[], reasons: string[] }}
+ * @param {{
+ *   suitability?: { suitable?: boolean, reasons?: string[] },
+ *   yes?: boolean,
+ *   operatorOverride?: unknown,
+ * }} [args]
+ * @returns {{
+ *   action: 'proceed-light'|'ask-operator'|'escalate-plan',
+ *   options?: string[],
+ *   override?: object,
+ *   reasons: string[],
+ * }}
  */
-export function resolveLightGateOutcome({ suitability, yes = false } = {}) {
+export function resolveLightGateOutcome({
+  suitability,
+  yes = false,
+  operatorOverride,
+} = {}) {
+  const override = resolveOperatorOverride({
+    suitability,
+    yes,
+    operatorOverride,
+  });
   const reasons = Array.isArray(suitability?.reasons)
     ? [...suitability.reasons]
     : [];
+  if (override.note !== null) reasons.push(override.note);
 
   if (suitability?.suitable === true) {
     return {
@@ -228,6 +363,17 @@ export function resolveLightGateOutcome({ suitability, yes = false } = {}) {
       reasons: [
         ...reasons,
         '--yes on over-scope fails closed to /plan (never silently proceeds light)',
+      ],
+    };
+  }
+
+  if (override.applied) {
+    return {
+      action: 'proceed-light',
+      override: override.record,
+      reasons: [
+        ...reasons,
+        'predicted scope exceeded a light ceiling and the operator answered proceed-light — proceeding on the recorded override',
       ],
     };
   }
@@ -418,17 +564,52 @@ function toReceiptChanges(changedFiles) {
 }
 
 /**
+ * Render an applied operator override as an audit paragraph for the receipt
+ * body (Story #4815). An override that leaves no trace on the ticket is an
+ * invisible decision: the whole point of routing it through the receipt is
+ * that a later reader can see the gate objected, on what grounds, and who
+ * decided to proceed anyway.
+ *
+ * @param {unknown} override The `record` from {@link resolveOperatorOverride}.
+ * @returns {string} A leading-space-prefixed sentence, or `''` when absent.
+ */
+function renderOverrideNote(override) {
+  if (!override || typeof override !== 'object') return '';
+  const { overriddenCode, overriddenReason, recordedReason } = override;
+  if (typeof recordedReason !== 'string' || recordedReason.trim() === '') {
+    return '';
+  }
+  return (
+    ` OPERATOR SCOPE OVERRIDE: the suitability gate objected on ` +
+    `"${overriddenCode}" (${overriddenReason}) and the operator answered ` +
+    `proceed-light — recorded reason: ${recordedReason.trim()}. The ` +
+    `prediction was waived, not the diff backstop, which still bounds the ` +
+    `landed change set.`
+  );
+}
+
+/**
  * Build the minimal receipt `type::story` ticket for the light path
  * (Story #4740 AC-5) — the input `assemblePlanStories` / `createStoryIssues`
  * consume, so the light path reuses the plan-persist story-creation surface
  * rather than reimplementing issue authoring. The body carries the operator
- * prompt (goal + spec) and the diff-derived footprint (`changes[]`), so history
- * and `refs #<id>` on the commit survive.
+ * prompt (goal + spec), the diff-derived footprint (`changes[]`), and any
+ * operator scope override, so history and `refs #<id>` on the commit survive.
  *
- * @param {{ prompt?: unknown, changedFiles?: unknown, amends?: unknown }} [args]
+ * @param {{
+ *   prompt?: unknown,
+ *   changedFiles?: unknown,
+ *   amends?: unknown,
+ *   override?: unknown,
+ * }} [args]
  * @returns {{ slug: string, title: string, body: object, labels: string[] }}
  */
-export function buildReceiptStoryTicket({ prompt, changedFiles, amends } = {}) {
+export function buildReceiptStoryTicket({
+  prompt,
+  changedFiles,
+  amends,
+  override,
+} = {}) {
   const text = typeof prompt === 'string' ? prompt.trim() : '';
   if (text === '') {
     throw new Error(
@@ -438,6 +619,7 @@ export function buildReceiptStoryTicket({ prompt, changedFiles, amends } = {}) {
   const amendsId = normalizeAmends(amends);
   const amendNote = amendsId !== null ? ` Amends #${amendsId}.` : '';
   const changes = toReceiptChanges(changedFiles);
+  const overrideNote = renderOverrideNote(override);
 
   return {
     slug: slugifyPrompt(text),
@@ -448,7 +630,8 @@ export function buildReceiptStoryTicket({ prompt, changedFiles, amends } = {}) {
       spec:
         `Delivered via /deliver-light as a validated single-session change — ` +
         `the /plan session is removed for genuinely small work while every ` +
-        `single-story-close gate runs byte-identical.${amendNote} ` +
+        `single-story-close gate runs byte-identical.${amendNote}` +
+        `${overrideNote} ` +
         `Operator prompt: ${text}`,
       changes,
       acceptance: [

--- a/.agents/workflows/helpers/deliver-light.md
+++ b/.agents/workflows/helpers/deliver-light.md
@@ -49,7 +49,9 @@ multi-capability enumeration). Size is enforced where ground truth is available:
 the diff backstop in step 4. Do not talk yourself past that one.
 
 Sensitivity is the exception and stays absolute: a footprint touching an auth,
-crypto, billing, or migration class routes `full` however small or mechanical.
+crypto, billing, or migration class routes `full` however small or mechanical —
+and unlike a ceiling, it is **not overridable** (§ Recording a proceed-light
+answer).
 
 ## Four invariants (do not skip one)
 
@@ -58,9 +60,11 @@ crypto, billing, or migration class routes `full` however small or mechanical.
    **and** a ledgered model verdict with a recorded reason. Both must agree on
    `lite`.
 2. **Over-scope stops — it never hard-fails.** An over-ceiling prompt STOPS and
-   asks the operator to escalate to `/plan` or proceed light. Under `--yes` it
-   fails closed to an **`escalated` terminal envelope** that ends the session
-   (§ Escalation is terminal).
+   asks the operator to escalate to `/plan` or proceed light. **Both answers
+   are executable** — `--operator-proceed-light` records the second one
+   (§ Recording a proceed-light answer). Under `--yes` it fails closed to an
+   **`escalated` terminal envelope** that ends the session (§ Escalation is
+   terminal).
 3. **Diff-derived backstop.** After implementation the ACTUAL change set is
    re-checked — the diff is the real scope signal — and an over-ceiling diff is
    blocked rather than landed.
@@ -89,7 +93,10 @@ crypto, billing, or migration class routes `full` however small or mechanical.
      `nextCommands`. Continue to step 2.
    - **`ask-operator`** — predicted scope exceeds the light ceilings. STOP and
      ask the operator to escalate to `/plan` or proceed light. Do not proceed
-     on your own. This is a **question, not a terminal** — wait for the answer.
+     on your own. This is a **question, not a terminal** — wait for the answer,
+     then act on it: *escalate* leaves for `/plan`, *proceed light* re-runs the
+     same command with `--operator-proceed-light "<their reason>"`
+     (§ Recording a proceed-light answer).
    - **over-scope under `--yes`** — no `action` to branch on: the gate emits an
      **`escalated` terminal envelope** instead (exit 2). § Escalation is
      terminal governs; you are finished.
@@ -143,6 +150,39 @@ crypto, billing, or migration class routes `full` however small or mechanical.
    Branch on the terminal envelope's `status` per
    [`deliver-digest.md`](deliver-digest.md) § 5 — every close
    gate runs byte-identical to the full path.
+
+## Recording a proceed-light answer {#recording-a-proceed-light-answer}
+
+The gate offers the operator two options, so **both** have to be executable.
+Re-run the identical gate command with their answer appended:
+
+```bash
+node .agents/scripts/deliver-light.js --prompt "<prompt>" … \
+  --operator-proceed-light "<the operator's reason, in their words>"
+```
+
+The gate then proceeds light, records the decision in the receipt Story, and
+returns it on the envelope's `override`. Do **not** instead re-shape the
+prediction — shrinking `--refactors` until the gate stops objecting is
+under-declaring the footprint, which is the one thing the coarse design must
+not reward.
+
+It is deliberately narrow, and a refusal is printed rather than silent:
+
+- **Only a size prediction is waivable** — change kinds, magnitude,
+  uncertainty, deployable span. A sensitive-path class, a
+  migration-with-consumers span, and an unknown footprint (undeclared, glob,
+  no acceptance, unclassifiable) are refused: those are risk, not size, and
+  § Scope by effort keeps them absolute.
+- **The ledgered verdict still stands on its own.** The override substitutes
+  for the predicted *shape* only; `--route lite --reason "<why>"` is still
+  required.
+- **Attended-only.** With `--yes` it is a usage error, not a quiet no-op —
+  an unattended run has no operator whose answer this could be, and over-scope
+  there still fails closed (§ Escalation is terminal).
+
+What licenses this at all is step 4: the operator waives a *guess*, never the
+diff backstop, which re-checks the actual change set against ground truth.
 
 ## Escalation is terminal {#escalation-is-terminal}
 

--- a/baselines/dead-exports-production.json
+++ b/baselines/dead-exports-production.json
@@ -1522,7 +1522,15 @@
     },
     {
       "file": ".agents/scripts/lib/orchestration/light-suitability.js",
+      "symbol": "OVERRIDABLE_SHAPE_CODES"
+    },
+    {
+      "file": ".agents/scripts/lib/orchestration/light-suitability.js",
       "symbol": "resolveLedgeredVerdict"
+    },
+    {
+      "file": ".agents/scripts/lib/orchestration/light-suitability.js",
+      "symbol": "resolveOperatorOverride"
     },
     {
       "file": ".agents/scripts/lib/orchestration/merge-block-class.js",

--- a/tests/bootstrap/workflow-invocation-surface.test.js
+++ b/tests/bootstrap/workflow-invocation-surface.test.js
@@ -174,6 +174,24 @@ describe('derived invocation intent (Story #4760)', () => {
       'without an explicit order a bare notes.md becomes a one-word seed',
     );
   });
+
+  // Story #4815 added --operator-proceed-light to the light gate. It is an
+  // answer the AGENT relays on the operator's behalf inside the helper, not
+  // something an operator types at the door — and a gate flag surfacing on the
+  // invocation surface is how the retired flag table grew the first time.
+  it('keeps the light gate flags off the two operator-facing doors', () => {
+    for (const [label, file] of [
+      ['deliver.md', DELIVER],
+      ['plan.md', PLAN],
+    ]) {
+      assert.doesNotMatch(
+        readFileSync(file, 'utf8'),
+        /--operator-proceed-light/,
+        `${label} names a deliver-light gate flag — the suitability gate's flags ` +
+          "belong to helpers/deliver-light.md and the script's own --help",
+      );
+    }
+  });
 });
 
 describe('the /plan ↔ light asymmetry (Story #4760)', () => {

--- a/tests/lib/orchestration/complexity-gate.test.js
+++ b/tests/lib/orchestration/complexity-gate.test.js
@@ -28,6 +28,7 @@ import {
   LITE_ROUTE_LABEL,
   resolvePlannerRouteVerdict,
   resolveStoryDispatchMode,
+  SHAPE_CODES,
 } from '../../../.agents/scripts/lib/orchestration/complexity-gate.js';
 import {
   assemblePlanStories,
@@ -847,4 +848,107 @@ describe('persist ↔ deliver route round-trip — one shape, two read points', 
       assert.equal(deliverSide.mode, expectedMode);
     });
   }
+});
+
+// ---------------------------------------------------------------------------
+// Story #4815 — every decision carries a stable machine-readable `code`
+// ---------------------------------------------------------------------------
+
+describe('deriveStoryShape — a stable code names WHICH rule objected', () => {
+  /** Minimal args that clear every rule, so a fixture varies one thing. */
+  const LITE_ARGS = {
+    changes: [{ path: 'src/one.ts', assumption: 'refactors-existing' }],
+    acceptance: ['it works'],
+    injectedRules: RULES,
+  };
+
+  test('a lite route carries no code — there is nothing to name', () => {
+    const derived = deriveStoryShape(LITE_ARGS);
+    assert.equal(derived.route, 'lite');
+    assert.equal(derived.code, null);
+  });
+
+  const CASES = [
+    [
+      SHAPE_CODES.CHANGE_KINDS,
+      { kinds: ['add-endpoint', 'migrate-schema', 'rewrite-client'] },
+    ],
+    [SHAPE_CODES.MAGNITUDE, { magnitude: 'substantial' }],
+    [SHAPE_CODES.UNCERTAINTY, { uncertainty: 'needs-design' }],
+    [
+      SHAPE_CODES.DEPLOYABLE_SPAN,
+      {
+        changes: [
+          { path: 'apps/web/a.ts', assumption: 'refactors-existing' },
+          { path: 'apps/api/b.ts', assumption: 'refactors-existing' },
+        ],
+      },
+    ],
+    [
+      SHAPE_CODES.MIGRATION_SPAN,
+      {
+        changes: [
+          { path: 'db/migrations/001.sql', assumption: 'creates' },
+          { path: 'src/reader.ts', assumption: 'refactors-existing' },
+        ],
+      },
+    ],
+    [
+      SHAPE_CODES.SENSITIVE_PATH,
+      { changes: [{ path: 'src/auth/session.ts', assumption: 'creates' }] },
+    ],
+    [SHAPE_CODES.NO_CHANGES, { changes: [] }],
+    [
+      SHAPE_CODES.GLOB_FOOTPRINT,
+      { changes: [{ path: 'src/**/*.ts', assumption: 'creates' }] },
+    ],
+    [SHAPE_CODES.NO_ACCEPTANCE, { acceptance: [] }],
+    [
+      SHAPE_CODES.CLASSIFICATION_UNAVAILABLE,
+      {
+        selectSensitivePathClassesFn: () => {
+          throw new Error('unreadable sensitive-path manifest');
+        },
+      },
+    ],
+  ];
+
+  for (const [code, overrides] of CASES) {
+    test(`routes full with code "${code}"`, () => {
+      const derived = deriveStoryShape({ ...LITE_ARGS, ...overrides });
+      assert.equal(derived.route, 'full');
+      assert.equal(derived.code, code);
+    });
+  }
+
+  test('the code is the branch surface, not the prose', () => {
+    // The reason text is written for a human reading a gate envelope and is
+    // free to be re-worded; a caller keying off it would break on a copy-edit.
+    // This is why the light path's operator override reads `code` instead.
+    const derived = deriveStoryShape({
+      ...LITE_ARGS,
+      changes: [
+        { path: 'apps/web/a.ts', assumption: 'refactors-existing' },
+        { path: 'apps/api/b.ts', assumption: 'refactors-existing' },
+      ],
+    });
+    assert.equal(derived.code, SHAPE_CODES.DEPLOYABLE_SPAN);
+    assert.equal(derived.reasons.length, 1);
+    assert.match(derived.reasons[0], /maxDeployables/);
+  });
+
+  test('adding the code left every pre-existing field intact', () => {
+    const derived = deriveStoryShape(LITE_ARGS);
+    assert.deepEqual(Object.keys(derived).sort(), [
+      'ceilings',
+      'code',
+      'preserves',
+      'reasons',
+      'route',
+      'shape',
+    ]);
+    assert.equal(derived.ceilings.maxDeployables, 1);
+    assert.equal(derived.preserves.repoGates, true);
+    assert.equal(derived.shape.siteCount, 1);
+  });
 });

--- a/tests/lib/orchestration/light-suitability.test.js
+++ b/tests/lib/orchestration/light-suitability.test.js
@@ -60,8 +60,10 @@ import {
   checkLightDiffBackstop,
   deriveLightSuitability,
   LIGHT_DIFF_CEILINGS,
+  OVERRIDABLE_SHAPE_CODES,
   resolveLedgeredVerdict,
   resolveLightGateOutcome,
+  resolveOperatorOverride,
 } from '../../../.agents/scripts/lib/orchestration/light-suitability.js';
 import {
   TERMINAL_BEGIN_MARKER,
@@ -652,11 +654,12 @@ const OVER_SCOPE = {
  * that the code never reached the call sites that would create anything.
  *
  * @param {object} values
- * @returns {Promise<{ code: number, terminals: object[], gateEnvelopes: object[], created: number, providers: number }>}
+ * @returns {Promise<{ code: number, terminals: object[], gateEnvelopes: object[], created: number, providers: number, receiptArgs: object[] }>}
  */
 async function driveGate(values) {
   const terminals = [];
   const gateEnvelopes = [];
+  const receiptArgs = [];
   let created = 0;
   let providers = 0;
   const code = await runGateMode(values, {
@@ -665,14 +668,15 @@ async function driveGate(values) {
       return {};
     },
     resolveConfigFn: () => ({}),
-    createReceiptFn: async () => {
+    createReceiptFn: async (args) => {
       created += 1;
+      receiptArgs.push(args);
       return { storyId: 1, url: 'https://example/1', title: 't' };
     },
     emitFn: (envelope) => gateEnvelopes.push(envelope),
     emitTerminalFn: (envelope) => terminals.push(envelope),
   });
-  return { code, terminals, gateEnvelopes, created, providers };
+  return { code, terminals, gateEnvelopes, created, providers, receiptArgs };
 }
 
 describe('escalate-plan emits a terminal envelope and exits non-zero (AC-1)', () => {
@@ -953,6 +957,464 @@ describe('the light path does not project a command (AC-7, Story #4760)', () => 
     assert.ok(
       existsSync(path.join(dest, 'deliver.md')),
       'the one delivery door must still project',
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Story #4815 — the operator's proceed-light answer is representable
+// ---------------------------------------------------------------------------
+
+/**
+ * A footprint whose ONLY objection is a size prediction (two deployables), with
+ * the ledgered lite verdict already in place. This is the consumer shape that
+ * motivated the Story: one mechanical constant bump at sites that happen to
+ * straddle two apps.
+ */
+const OVERRIDABLE_SCOPE = Object.freeze({
+  predictedChanges: [
+    { path: 'apps/web/playwright.config.ts', assumption: 'refactors-existing' },
+    {
+      path: 'apps/staff/playwright.config.ts',
+      assumption: 'refactors-existing',
+    },
+  ],
+  predictedAcceptance: ['the boot timeout is raised at every call site'],
+  predictedKinds: ['one-mechanical-edit'],
+  predictedMagnitude: 'trivial',
+  predictedUncertainty: 'determined',
+  verdict: LITE_VERDICT,
+  injectedRules: RULES,
+});
+
+/** The operator's answer, in their words. */
+const OPERATOR_REASON = 'approved: one constant, three identical call sites';
+
+/**
+ * Suitability for a footprint blocked by `code`, so a refusal can be asserted
+ * per objection class without hand-building a whole decision object.
+ *
+ * @param {object} overrides Fields merged over {@link OVERRIDABLE_SCOPE}.
+ * @returns {ReturnType<typeof deriveLightSuitability>}
+ */
+const suitabilityFor = (overrides) =>
+  deriveLightSuitability({ ...OVERRIDABLE_SCOPE, ...overrides });
+
+describe('OVERRIDABLE_SHAPE_CODES — an allowlist of size predictions (AC-3)', () => {
+  test('is exactly the four ceiling rules, and frozen', () => {
+    assert.deepEqual([...OVERRIDABLE_SHAPE_CODES].sort(), [
+      'change-kinds',
+      'deployable-span',
+      'magnitude',
+      'uncertainty',
+    ]);
+    assert.equal(Object.isFrozen(OVERRIDABLE_SHAPE_CODES), true);
+  });
+
+  test('omits every risk rule and every unknown-footprint rejection', () => {
+    for (const code of [
+      'migration-span',
+      'sensitive-path',
+      'no-changes',
+      'unreadable-changes',
+      'glob-footprint',
+      'no-acceptance',
+      'classification-unavailable',
+      'unparseable-body',
+    ]) {
+      assert.equal(
+        OVERRIDABLE_SHAPE_CODES.includes(code),
+        false,
+        `${code} must never be waivable by an operator`,
+      );
+    }
+  });
+});
+
+describe('resolveOperatorOverride — the answer applies only when earned (AC-1..AC-5)', () => {
+  test('applies to an overridable ceiling, recording what was waived', () => {
+    const o = resolveOperatorOverride({
+      suitability: suitabilityFor({}),
+      operatorOverride: OPERATOR_REASON,
+    });
+    assert.equal(o.applied, true);
+    assert.equal(o.record.overriddenCode, 'deployable-span');
+    assert.equal(o.record.recordedReason, OPERATOR_REASON);
+    assert.match(o.record.overriddenReason, /maxDeployables/);
+  });
+
+  test('an absent, blank, or non-string answer is simply no override', () => {
+    for (const operatorOverride of ['', '   ', undefined, null, 42, {}]) {
+      const o = resolveOperatorOverride({
+        suitability: suitabilityFor({}),
+        operatorOverride,
+      });
+      assert.equal(o.applied, false, JSON.stringify(operatorOverride));
+      assert.equal(o.record, null);
+      assert.equal(
+        o.note,
+        null,
+        'no answer was given, so there is nothing to report',
+      );
+    }
+  });
+
+  test('is inert when the gate raised no objection at all', () => {
+    const suitability = suitabilityFor({
+      predictedChanges: [
+        { path: 'src/one.ts', assumption: 'refactors-existing' },
+      ],
+    });
+    assert.equal(suitability.suitable, true);
+    const o = resolveOperatorOverride({
+      suitability,
+      operatorOverride: OPERATOR_REASON,
+    });
+    assert.equal(o.applied, false, 'nothing to pre-authorize');
+    assert.equal(o.record, null);
+    assert.match(o.note, /raised no objection/);
+  });
+
+  test('refuses every non-negotiable objection, naming the code', () => {
+    const cases = [
+      [
+        'sensitive-path',
+        {
+          predictedChanges: [{ path: 'src/auth/x.ts', assumption: 'creates' }],
+        },
+      ],
+      [
+        'migration-span',
+        {
+          predictedChanges: [
+            { path: 'db/migrations/001.sql', assumption: 'creates' },
+            { path: 'src/reader.ts', assumption: 'refactors-existing' },
+          ],
+        },
+      ],
+      ['no-changes', { predictedChanges: [] }],
+      [
+        'glob-footprint',
+        { predictedChanges: [{ path: 'src/**/*.ts', assumption: 'creates' }] },
+      ],
+      ['no-acceptance', { predictedAcceptance: [] }],
+      [
+        'classification-unavailable',
+        {
+          // A single-deployable footprint, so the ceiling rules all clear and
+          // the unreadable manifest is the only thing left to object.
+          predictedChanges: [
+            { path: 'src/one.ts', assumption: 'refactors-existing' },
+          ],
+          selectSensitivePathClassesFn: () => {
+            throw new Error('unreadable sensitive-path manifest');
+          },
+        },
+      ],
+    ];
+    for (const [code, overrides] of cases) {
+      const suitability = suitabilityFor(overrides);
+      assert.equal(suitability.shape.code, code, `fixture yields ${code}`);
+      const o = resolveOperatorOverride({
+        suitability,
+        operatorOverride: OPERATOR_REASON,
+      });
+      assert.equal(o.applied, false, `${code} must not be overridable`);
+      assert.equal(o.record, null);
+      assert.match(o.note, new RegExp(`"${code}" is not an overridable`));
+    }
+  });
+
+  test('refuses an unrecognized code — the allowlist fails closed', () => {
+    // A rule added to SHAPE_CODES later, before anyone decides it is waivable.
+    const o = resolveOperatorOverride({
+      suitability: {
+        suitable: false,
+        shape: { code: 'some-future-rule', reasons: ['…'] },
+        ledger: { route: 'lite' },
+      },
+      operatorOverride: OPERATOR_REASON,
+    });
+    assert.equal(o.applied, false);
+    assert.match(o.note, /"some-future-rule" is not an overridable/);
+  });
+
+  test('refuses under --yes: there is no operator to have answered', () => {
+    const o = resolveOperatorOverride({
+      suitability: suitabilityFor({}),
+      yes: true,
+      operatorOverride: OPERATOR_REASON,
+    });
+    assert.equal(o.applied, false);
+    assert.match(o.note, /attended-only/);
+  });
+
+  test('does not rescue the ledgered half of the conjunction', () => {
+    for (const verdict of [
+      { route: 'full', reason: 'not small' },
+      { route: 'lite', reason: '' },
+      undefined,
+    ]) {
+      const o = resolveOperatorOverride({
+        suitability: suitabilityFor({ verdict }),
+        operatorOverride: OPERATOR_REASON,
+      });
+      assert.equal(o.applied, false, JSON.stringify(verdict));
+      assert.match(o.note, /model verdict must still be a ledgered lite/);
+    }
+  });
+
+  test('is total: no arguments yields a refusal, never a throw', () => {
+    assert.equal(resolveOperatorOverride().applied, false);
+    assert.equal(resolveOperatorOverride({}).record, null);
+  });
+});
+
+describe('resolveLightGateOutcome — the override changes the ACTION, not the verdict (AC-1, AC-2)', () => {
+  test('an applied override turns ask-operator into proceed-light', () => {
+    const suitability = suitabilityFor({});
+    const without = resolveLightGateOutcome({ suitability });
+    assert.equal(without.action, 'ask-operator');
+    assert.equal(without.override, undefined);
+
+    const withOverride = resolveLightGateOutcome({
+      suitability,
+      operatorOverride: OPERATOR_REASON,
+    });
+    assert.equal(withOverride.action, 'proceed-light');
+    assert.equal(withOverride.override.overriddenCode, 'deployable-span');
+    assert.match(
+      withOverride.reasons.join(' '),
+      /the operator answered proceed-light/,
+    );
+  });
+
+  test('the honest suitability verdict is untouched by the answer', () => {
+    // The override waives what the gate DOES about the objection, never the
+    // objection itself — a downstream reader must still see route: full.
+    const suitability = suitabilityFor({});
+    resolveLightGateOutcome({ suitability, operatorOverride: OPERATOR_REASON });
+    assert.equal(suitability.suitable, false);
+    assert.equal(suitability.route, 'full');
+    assert.equal(suitability.shape.route, 'full');
+  });
+
+  test('--yes still escalates, and says why the override did not apply', () => {
+    const outcome = resolveLightGateOutcome({
+      suitability: suitabilityFor({}),
+      yes: true,
+      operatorOverride: OPERATOR_REASON,
+    });
+    assert.equal(outcome.action, 'escalate-plan');
+    assert.equal(outcome.override, undefined);
+    assert.match(outcome.reasons.join(' '), /attended-only/);
+  });
+
+  test('a refused override still asks — and the refusal is reported', () => {
+    const outcome = resolveLightGateOutcome({
+      suitability: suitabilityFor({
+        predictedChanges: [{ path: 'src/auth/x.ts', assumption: 'creates' }],
+      }),
+      operatorOverride: OPERATOR_REASON,
+    });
+    assert.equal(outcome.action, 'ask-operator');
+    assert.equal(outcome.override, undefined);
+    assert.match(outcome.reasons.join(' '), /not an overridable/);
+  });
+});
+
+describe('buildReceiptStoryTicket — an override is auditable from the ticket (AC-6)', () => {
+  const OVERRIDE_RECORD = {
+    recordedReason: OPERATOR_REASON,
+    overriddenCode: 'deployable-span',
+    overriddenReason: 'footprint spans 2 deployables (apps/web, apps/staff)',
+  };
+
+  test('records the code, the gate reason, and the operator reason', () => {
+    const ticket = buildReceiptStoryTicket({
+      prompt: 'raise the boot timeout',
+      changedFiles: ['apps/web/playwright.config.ts'],
+      override: OVERRIDE_RECORD,
+    });
+    assert.match(ticket.body.spec, /OPERATOR SCOPE OVERRIDE/);
+    assert.match(ticket.body.spec, /"deployable-span"/);
+    assert.match(ticket.body.spec, /apps\/web, apps\/staff/);
+    assert.match(ticket.body.spec, new RegExp(OPERATOR_REASON));
+    assert.match(ticket.body.spec, /not the diff backstop/);
+  });
+
+  test('an absent or malformed override leaves the receipt byte-identical', () => {
+    const baseline = buildReceiptStoryTicket({
+      prompt: 'raise the boot timeout',
+      changedFiles: ['apps/web/playwright.config.ts'],
+    });
+    for (const override of [
+      null,
+      undefined,
+      {},
+      'nope',
+      { recordedReason: '  ' },
+    ]) {
+      const ticket = buildReceiptStoryTicket({
+        prompt: 'raise the boot timeout',
+        changedFiles: ['apps/web/playwright.config.ts'],
+        override,
+      });
+      assert.deepEqual(ticket, baseline, JSON.stringify(override));
+    }
+  });
+});
+
+describe('deliver-light.js CLI — the answer has a flag to carry it (AC-1, AC-4, AC-6)', () => {
+  /** The issue's own repro, as CLI values. */
+  const REPRO = Object.freeze({
+    prompt: 'raise the webServer boot timeout',
+    refactors: 'apps/web/playwright.config.ts,apps/staff/playwright.config.ts',
+    kinds: 'one-mechanical-edit',
+    magnitude: 'trivial',
+    uncertainty: 'determined',
+    acceptance: '1',
+    route: 'lite',
+    reason: 'one constant, three identical call sites',
+  });
+
+  test('without the flag the repro still stops at ask-operator', async () => {
+    const { code, gateEnvelopes, created } = await driveGate({ ...REPRO });
+    assert.equal(code, 2);
+    assert.equal(created, 0);
+    assert.equal(gateEnvelopes[0].action, 'ask-operator');
+  });
+
+  test('with the flag it proceeds, and the receipt carries the override', async () => {
+    const { code, gateEnvelopes, created, receiptArgs } = await driveGate({
+      ...REPRO,
+      'operator-proceed-light': OPERATOR_REASON,
+    });
+    assert.equal(code, 0);
+    assert.equal(created, 1);
+    assert.equal(gateEnvelopes[0].action, 'proceed-light');
+    assert.equal(gateEnvelopes[0].override.overriddenCode, 'deployable-span');
+    assert.equal(gateEnvelopes[0].override.recordedReason, OPERATOR_REASON);
+    assert.equal(
+      receiptArgs[0].override.recordedReason,
+      OPERATOR_REASON,
+      'the receipt Story is where the decision becomes auditable',
+    );
+  });
+
+  test('a proceed-light that needed no override carries no override field', async () => {
+    const { gateEnvelopes, receiptArgs } = await driveGate({
+      prompt: 'add a bin/hello.js greeter',
+      creates: 'bin/hello.js',
+      acceptance: '1',
+      route: 'lite',
+      reason: 'single additive file',
+      'operator-proceed-light': OPERATOR_REASON,
+    });
+    assert.equal(gateEnvelopes[0].action, 'proceed-light');
+    assert.equal(
+      Object.hasOwn(gateEnvelopes[0], 'override'),
+      false,
+      'an unearned override must not appear as a recorded decision',
+    );
+    assert.equal(receiptArgs[0].override, null);
+  });
+
+  test('combining it with --yes is a usage error, not a quiet no-op', async () => {
+    await assert.rejects(
+      () => driveGate({ ...REPRO, 'operator-proceed-light': 'x', yes: true }),
+      /attended-only and cannot be combined with --yes/,
+    );
+  });
+
+  test('--help documents the flag, so an operator can find it', () => {
+    const result = spawnSync(process.execPath, [DELIVER_LIGHT_SRC, '--help'], {
+      encoding: 'utf8',
+    });
+    assert.equal(result.status, 0, result.stderr);
+    assert.match(result.stdout, /--operator-proceed-light/);
+    assert.match(result.stdout, /[Aa]ttended-only/);
+  });
+
+  test('end to end: the real CLI refuses the flag under --yes (exit 1)', () => {
+    const cwd = makeTempDir('light-override-');
+    const result = spawnSync(
+      process.execPath,
+      [
+        DELIVER_LIGHT_SRC,
+        '--prompt',
+        REPRO.prompt,
+        '--refactors',
+        REPRO.refactors,
+        '--route',
+        'lite',
+        '--reason',
+        REPRO.reason,
+        '--operator-proceed-light',
+        OPERATOR_REASON,
+        '--yes',
+      ],
+      { cwd, encoding: 'utf8' },
+    );
+    assert.equal(result.status, 1, result.stdout);
+    assert.match(result.stderr, /attended-only/);
+    assert.equal(
+      result.stdout.includes(TERMINAL_BEGIN_MARKER),
+      false,
+      'a usage error is not an escalated terminal',
+    );
+  });
+});
+
+describe('the workflow tells the agent how to act on the answer (AC-8)', () => {
+  const doc = readDoc(
+    path.join(REPO_ROOT, '.agents', 'workflows', 'helpers', 'deliver-light.md'),
+  );
+
+  test('the ask-operator branch names the executable proceed answer', () => {
+    assertDocMentions(
+      doc,
+      /--operator-proceed-light/,
+      'an option the agent cannot act on is the defect this Story fixes',
+    );
+    assertDocMentions(
+      doc,
+      /wait for the answer,\s*then act on it/,
+      'the branch must say the answer is acted on, not merely awaited',
+    );
+  });
+
+  test('it forbids re-shaping the prediction instead', () => {
+    assertDocMentions(
+      doc,
+      /under-declaring the footprint, which is the one thing the coarse design must\s*not reward/,
+      'without this, the documented workaround is the gaming the gate anticipates',
+    );
+  });
+
+  test('it keeps sensitivity and risk non-negotiable', () => {
+    assertDocMentions(
+      doc,
+      /Only a size prediction is waivable/,
+      'the override must read as narrow, not as a general bypass',
+    );
+    assertDocMentions(
+      doc,
+      /it is \*\*not overridable\*\*/,
+      '§ Scope by effort must say sensitivity survives the new flag',
+    );
+  });
+
+  test('it states the attended-only rule and what still bounds size', () => {
+    assertDocMentions(
+      doc,
+      /With `--yes` it is a usage error, not a quiet no-op/,
+      'an unattended run has no operator whose answer this could be',
+    );
+    assertDocMentions(
+      doc,
+      /the operator waives a \*guess\*, never the\s*diff backstop/,
+      'the backstop is what licenses waiving the prediction at all',
     );
   });
 });


### PR DESCRIPTION
Closes #4815

_Auto-opened by `/deliver`._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes orchestration gate behavior and who can bypass predicted scope; safeguards (allowlist, ledgered lite, attended-only, backstop) are explicit and heavily tested, but mistaken operator override could still authorize borderline light delivery.
> 
> **Overview**
> Adds **`--operator-proceed-light`** so an attended run can answer **`ask-operator`** with “proceed light” instead of only reshaping the predicted footprint or escalating to `/plan`.
> 
> **Shape routing** now exposes stable **`SHAPE_CODES`** on `deriveStoryShape` (plus a `code` field on decisions). **`resolveOperatorOverride`** applies the operator answer only when the gate already objected, the run is not `--yes`, the objection is one of four **size** codes (`change-kinds`, `magnitude`, `uncertainty`, `deployable-span`), and the ledgered verdict is still `lite`. Risk rules (e.g. `sensitive-path`, `migration-span`) and unknown-footprint codes stay non-negotiable.
> 
> When an override applies, **`resolveLightGateOutcome`** returns **`proceed-light`** with an **`override`** record; the CLI writes it into the receipt Story spec and the gate JSON envelope. **`--operator-proceed-light` with `--yes`** is a hard usage error.
> 
> Docs in **`helpers/deliver-light.md`** describe re-running the gate with the flag; tests cover codes, override adjudication, CLI, and keeping the flag off top-level `deliver.md` / `plan.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 11bdd1d935d49dad5dc3a8281a8219c32076a105. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->