### PR TITLE
feat: deliver: persist the close terminal envelope to disk and teach recovery a live-close state (#4816)

### DIFF
--- a/.agents/agents/story-worker.md
+++ b/.agents/agents/story-worker.md
@@ -134,6 +134,16 @@ outside the worktree / branch / PR path — or committing it to local `main`
 — is expressly **forbidden**; the close pipeline's push
 (`single-story-close.js`) is the only sanctioned landing.
 
+## Hold the turn until the envelope arrives (MUST)
+
+Run close in the **foreground** and wait for it. Never background it,
+never delegate it to a child, and never end your turn while it is still
+running — "close is running" is not a return value. Ending early strands
+the envelope in a turn nobody reads and costs your caller a recovery
+cycle plus a full resume of you. Close does persist a copy to
+`temp/orchestration/story-deliver-terminal-<id>.json`; that is your
+caller's fallback, not your licence to return before the verdict.
+
 ## Return schema
 
 The return contract is

--- a/.agents/scripts/lib/config/temp-paths.js
+++ b/.agents/scripts/lib/config/temp-paths.js
@@ -312,6 +312,68 @@ export function orchestrationLogDir(config) {
   return path.join(anchorTempRoot(tempRootFrom(config)), ORCHESTRATION_DIRNAME);
 }
 
+/**
+ * Basename of one Story's close gate log (Story #4816 lifted it here from
+ * `single-story-close/gate-log.js`).
+ *
+ * The writer that appends this file and the reader that uses its **freshness**
+ * to tell a live close from a dead one (`deliver-recover.js`) sit in different
+ * subtrees, and the reader importing the writer is the wrong edge to draw for
+ * a filename. Both take it from the module that already owns every other
+ * tempRoot path instead.
+ *
+ * `null` is the sink's no-Story sentinel and keeps its `unknown` spelling.
+ *
+ * @param {number|null} sid
+ * @returns {string}
+ */
+function closeGateLogName(sid) {
+  return `close-gates-${sid ?? 'unknown'}.log`;
+}
+
+/**
+ * `<tempRoot>/orchestration/close-gates-<sid>.log`.
+ *
+ * @param {number|null} sid
+ * @param {object} [config]
+ * @returns {string}
+ */
+export function closeGateLogPath(sid, config) {
+  return path.join(orchestrationLogDir(config), closeGateLogName(sid));
+}
+
+/**
+ * Basename of the persisted terminal envelope for one Story (Story #4816).
+ *
+ * @param {number} sid
+ * @returns {string}
+ */
+function storyTerminalEnvelopeName(sid) {
+  return `story-deliver-terminal-${storyId(sid)}.json`;
+}
+
+/**
+ * `<tempRoot>/orchestration/story-deliver-terminal-<sid>.json` — the on-disk
+ * copy of the one terminal envelope a Story's close-and-land emits (Story
+ * #4816).
+ *
+ * Deliberately a sibling of the gate log rather than a per-Story temp dir
+ * entry: the envelope is a run artifact of the same close that writes
+ * `close-gates-<sid>.log`, and `deliver-recover.js` reads the pair together to
+ * tell a finished close from a live one. Sharing `orchestrationLogDir` also
+ * means it inherits main-checkout anchoring for free — the close runs inside
+ * `.worktrees/story-<sid>/` while the `/deliver` host reads from the main
+ * checkout, and an un-anchored path would put the envelope somewhere the
+ * router never looks.
+ *
+ * @param {number} sid
+ * @param {object} [config]
+ * @returns {string}
+ */
+export function storyTerminalEnvelopePath(sid, config) {
+  return path.join(orchestrationLogDir(config), storyTerminalEnvelopeName(sid));
+}
+
 const runId = (id) => {
   if (!Number.isInteger(id) || id <= 0) {
     throw new Error(`[temp-paths] runId must be a positive integer; got ${id}`);

--- a/.agents/scripts/lib/orchestration/deliver-recover.js
+++ b/.agents/scripts/lib/orchestration/deliver-recover.js
@@ -35,11 +35,30 @@
  * resumption speak one language instead of two dialects for one state.
  */
 
+import nodeFs from 'node:fs';
+
+import {
+  closeGateLogPath,
+  storyTerminalEnvelopePath,
+} from '../config/temp-paths.js';
 import { gh as defaultGh } from '../gh-exec.js';
 import { gitSpawn as defaultGitSpawn, getStoryBranch } from '../git-utils.js';
 import { deriveChecksStatus } from './merge-poll.js';
 import { NEXT_COMMANDS } from './story-deliver-terminal.js';
 import { STATE_LABELS } from './ticketing.js';
+
+/**
+ * How recently the gate log must have been appended for the close that writes
+ * it to count as live (Story #4816).
+ *
+ * The window is generous on purpose. Gate output arrives in bursts — a single
+ * `npm test` gate can run for a long stretch between lines — so a tight window
+ * would read a slow-but-healthy close as dead and re-open the exact
+ * misdiagnosis this exists to remove. Being wrong in the other direction is
+ * cheap: the verdict for a live close is "re-run this read-only probe", which
+ * costs nothing if the close has in fact already exited.
+ */
+const CLOSE_IN_FLIGHT_WINDOW_MS = 120_000;
 
 /**
  * Probe the ticket: state labels, issue open/closed, and the lease holder.
@@ -132,16 +151,193 @@ export async function probePr({ storyBranch, gh = defaultGh }) {
 }
 
 /**
+ * Probe the two on-disk artifacts a close leaves behind (Story #4816): the
+ * persisted terminal envelope and the gate log.
+ *
+ * These exist because the label-and-PR probes above cannot see the difference
+ * between an implementation that died and a close that is still running —
+ * both read `agent::executing` with no PR for the whole gate chain. The
+ * artifacts can: a persisted envelope means the close already reached a
+ * verdict, and a recently-appended gate log means one is mid-chain right now.
+ * Gate-log freshness is exactly the signal operators were already using by
+ * hand to tell the two apart, which is the argument for reading it here
+ * instead of expecting them to know.
+ *
+ * Never throws: an unreadable or absent artifact is a `null` reading, and the
+ * table falls back to the label-only verdict it always had.
+ *
+ * @param {{
+ *   storyId: number,
+ *   config?: object,
+ *   fsImpl?: typeof nodeFs,
+ *   nowMs?: number,
+ *   windowMs?: number,
+ * }} args
+ * @returns {{
+ *   envelope: object|null,
+ *   envelopePath: string|null,
+ *   envelopeMtimeMs: number|null,
+ *   gateLogPath: string|null,
+ *   gateLogAgeMs: number|null,
+ *   gateLogMtimeMs: number|null,
+ *   gateLogFresh: boolean,
+ * }}
+ */
+export function probeCloseArtifacts({
+  storyId,
+  config,
+  fsImpl = nodeFs,
+  nowMs = Date.now(),
+  windowMs = CLOSE_IN_FLIGHT_WINDOW_MS,
+}) {
+  const empty = {
+    envelope: null,
+    envelopePath: null,
+    envelopeMtimeMs: null,
+    gateLogPath: null,
+    gateLogAgeMs: null,
+    gateLogMtimeMs: null,
+    gateLogFresh: false,
+  };
+  let envelopePath = null;
+  let gateLogPath = null;
+  try {
+    envelopePath = storyTerminalEnvelopePath(storyId, config);
+    gateLogPath = closeGateLogPath(storyId, config);
+  } catch {
+    return empty;
+  }
+
+  let envelope = null;
+  let envelopeMtimeMs = null;
+  try {
+    const parsed = JSON.parse(fsImpl.readFileSync(envelopePath, 'utf8'));
+    // A parsed non-object (or an array) is not an envelope; treat it as
+    // absent rather than handing the table something it cannot read fields
+    // off of.
+    if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+      envelope = parsed;
+      envelopeMtimeMs = fsImpl.statSync(envelopePath).mtimeMs;
+    }
+  } catch {
+    envelope = null;
+    envelopeMtimeMs = null;
+  }
+
+  let gateLogMtimeMs = null;
+  try {
+    gateLogMtimeMs = fsImpl.statSync(gateLogPath).mtimeMs;
+  } catch {
+    gateLogMtimeMs = null;
+  }
+  const gateLogAgeMs =
+    gateLogMtimeMs === null ? null : Math.max(0, nowMs - gateLogMtimeMs);
+
+  return {
+    envelope,
+    envelopePath,
+    envelopeMtimeMs,
+    gateLogPath,
+    gateLogAgeMs,
+    gateLogMtimeMs,
+    gateLogFresh: gateLogAgeMs !== null && gateLogAgeMs <= windowMs,
+  };
+}
+
+/**
+ * Is a close running right now, outranking whatever a persisted envelope says?
+ *
+ * A persisted envelope is definitive about the close that wrote it — but a
+ * Story can be closed more than once (a `pending` wait resumed, a red gate
+ * fixed and re-run), and a *stale* envelope from the previous attempt must not
+ * out-argue a gate log the current attempt is appending to as we read. So the
+ * live signal wins whenever the gate log is both fresh and fresher than the
+ * envelope.
+ *
+ * @param {object} artifacts A {@link probeCloseArtifacts} reading.
+ * @returns {boolean}
+ */
+function closeLooksLive(artifacts) {
+  if (!artifacts?.gateLogFresh) return false;
+  if (artifacts.envelopeMtimeMs === null) return true;
+  return artifacts.gateLogMtimeMs > artifacts.envelopeMtimeMs;
+}
+
+/**
+ * The verdict for a Story whose close already finished but whose envelope
+ * never reached the caller — the orphaned-turn shape (Story #4816).
+ *
+ * Nothing is re-derived here: the envelope on disk is the same
+ * schema-validated object the close emitted, so its own `status` and
+ * `nextCommand` are relayed rather than a second opinion invented from
+ * labels. A `landed` envelope carries a null next command, and the honest
+ * follow-up for a landed-but-mislabelled Story is the idempotent confirm.
+ */
+function envelopeOnDiskVerdict({ storyId, artifacts, evidence }) {
+  const { envelope, envelopePath } = artifacts;
+  return {
+    shape: 'close-envelope-on-disk',
+    nextCommand: envelope.nextCommand ?? NEXT_COMMANDS.confirmMerge(storyId),
+    detail:
+      `The close for this Story already reached a terminal verdict — \`${envelope.status}\` ` +
+      `at phase \`${envelope.phase}\` — but the label still reads mid-flight, which is the ` +
+      `signature of a worker turn that ended before it could relay the envelope. The close ` +
+      `itself is not in doubt: read the full envelope at \`${envelopePath}\` rather than ` +
+      `re-deriving its state, and run the command below (the envelope's own \`nextCommand\`, ` +
+      `or the idempotent confirm when it landed and named none).`,
+    evidence,
+  };
+}
+
+/**
+ * The verdict for a close that is running as we probe (Story #4816).
+ *
+ * The next command is this probe again. That is not a shrug: there is no
+ * attach-to-a-running-close surface, the close needs nothing from anyone, and
+ * every *other* command an operator might reach for here is actively harmful
+ * — which is why the detail names the re-init hazard explicitly instead of
+ * leaving it implied.
+ */
+function closeInFlightVerdict({ storyId, artifacts, evidence }) {
+  const seconds = Math.round((artifacts.gateLogAgeMs ?? 0) / 1000);
+  return {
+    shape: 'close-in-flight',
+    nextCommand: NEXT_COMMANDS.recover(storyId),
+    detail:
+      `A close is RUNNING for this Story right now: \`${artifacts.gateLogPath}\` was appended ` +
+      `${seconds}s ago. \`agent::executing\` with no PR does NOT mean the work stalled here — ` +
+      `the implementation is done and the close is mid-gate-chain, before its push. ` +
+      `**Do not run \`single-story-init.js\`**: re-initializing the worktree ` +
+      `underneath a live close risks a second close racing the first on one PR (double label ` +
+      `flip, double post-land tail). Let it finish — it emits its own terminal envelope and ` +
+      `persists a copy — then re-run the command below for a settled verdict.`,
+    evidence,
+  };
+}
+
+/**
  * The decision table. Pure: every input is an already-observed probe, so the
  * mapping is testable without git, GitHub, or a clock.
  *
  * Returns exactly one `{ shape, nextCommand, evidence[], detail }` — never a
  * list of candidates.
  *
- * @param {{ storyId: number, ticket: object, branch: object, pr: object|null }} probes
+ * @param {{
+ *   storyId: number,
+ *   ticket: object,
+ *   branch: object,
+ *   pr: object|null,
+ *   closeArtifacts?: object,
+ * }} probes
  * @returns {{ shape: string, nextCommand: string|null, detail: string, evidence: string[] }}
  */
-export function decideRecovery({ storyId, ticket, branch, pr }) {
+export function decideRecovery({
+  storyId,
+  ticket,
+  branch,
+  pr,
+  closeArtifacts,
+}) {
   const evidence = [
     `label=${ticket?.stateLabel ?? 'none'}`,
     `issue=${ticket?.issueState ?? 'unknown'}`,
@@ -151,6 +347,13 @@ export function decideRecovery({ storyId, ticket, branch, pr }) {
     `branch.remote=${branch?.remote ?? false}`,
     `worktree=${branch?.worktreePath ?? 'none'}`,
     `lease=${ticket?.lease ?? 'unclaimed'}`,
+    `closeEnvelope=${closeArtifacts?.envelope ? closeArtifacts.envelope.status : 'none'}`,
+    `gateLogAge=${
+      closeArtifacts?.gateLogAgeMs === null ||
+      closeArtifacts?.gateLogAgeMs === undefined
+        ? 'none'
+        : `${Math.round(closeArtifacts.gateLogAgeMs / 1000)}s`
+    }`,
   ];
 
   const label = ticket?.stateLabel;
@@ -242,12 +445,33 @@ export function decideRecovery({ storyId, ticket, branch, pr }) {
         evidence,
       };
     }
+    // Story #4816 — the close artifacts get the first word here, and ONLY
+    // here. Every other row of this table describes a state whose evidence is
+    // already unambiguous; `executing` + no PR is the one row that reads
+    // identically for a dead implementation and for a close that is halfway
+    // through its gate chain, and answering it from labels alone is what sent
+    // operators to re-init on top of a live close.
+    if (closeLooksLive(closeArtifacts)) {
+      return closeInFlightVerdict({
+        storyId,
+        artifacts: closeArtifacts,
+        evidence,
+      });
+    }
+    if (closeArtifacts?.envelope) {
+      return envelopeOnDiskVerdict({
+        storyId,
+        artifacts: closeArtifacts,
+        evidence,
+      });
+    }
     return {
       shape: 'executing-no-pr',
       nextCommand: NEXT_COMMANDS.implement(storyId),
       detail:
-        `Story is \`agent::executing\` with no PR. Implementation never finished. Re-init ` +
-        `(idempotent — it reuses the existing branch and worktree) and resume in the ` +
+        `Story is \`agent::executing\` with no PR, and no close left an artifact behind (no ` +
+        `persisted terminal envelope, no recent gate log) — implementation never finished. ` +
+        `Re-init (idempotent — it reuses the existing branch and worktree) and resume in the ` +
         `worktree it prints.`,
       evidence,
     };
@@ -280,6 +504,11 @@ const TRANSIENT_SHAPES = new Set([
   'closing-no-pr',
   'closing-pr-pending',
   'closing-pr-red',
+  // Story #4816 — the definition of this shape is "a process is mutating this
+  // Story right now", so it is the most transient row in the table: the second
+  // probe often catches the push and PR landing and returns a settled verdict
+  // instead.
+  'close-in-flight',
 ]);
 
 /**
@@ -330,6 +559,7 @@ async function probeAndDecide({
   config,
   gh,
   gitSpawnFn,
+  fsImpl,
 }) {
   const ticket = await probeTicket({ provider, storyId });
   if (!ticket.ok) {
@@ -339,8 +569,22 @@ async function probeAndDecide({
   }
   const branch = probeBranch({ cwd, storyBranch, config, gitSpawnFn });
   const pr = await probePr({ storyBranch, gh });
-  const decision = decideRecovery({ storyId, ticket, branch, pr });
-  return { probes: { ticket, branch, pr }, decision };
+  // Re-read on every round: the whole point of the stability pass is that a
+  // second look can catch a close that has since flushed a gate line or
+  // written its envelope.
+  const closeArtifacts = probeCloseArtifacts({
+    storyId,
+    config,
+    ...(fsImpl ? { fsImpl } : {}),
+  });
+  const decision = decideRecovery({
+    storyId,
+    ticket,
+    branch,
+    pr,
+    closeArtifacts,
+  });
+  return { probes: { ticket, branch, pr, closeArtifacts }, decision };
 }
 
 /**
@@ -365,6 +609,7 @@ async function probeAndDecide({
  *   settling).
  * @param {number} [args.stabilityDelayMs] Settle window between the probes.
  * @param {Function} [args.sleepFn] Test seam for the settle wait.
+ * @param {typeof nodeFs} [args.fsImpl] Test seam for the close-artifact reads.
  * @returns {Promise<object>}
  */
 export async function recoverStory({
@@ -374,6 +619,7 @@ export async function recoverStory({
   config,
   gh = defaultGh,
   gitSpawnFn,
+  fsImpl,
   reprobe = true,
   stabilityDelayMs = STABILITY_DELAY_MS,
   sleepFn = (ms) => new Promise((resolve) => setTimeout(resolve, ms)),
@@ -387,6 +633,7 @@ export async function recoverStory({
     config,
     gh,
     gitSpawnFn,
+    fsImpl,
   };
 
   const first = await probeAndDecide(probeArgs);

--- a/.agents/scripts/lib/orchestration/single-story-close/gate-log.js
+++ b/.agents/scripts/lib/orchestration/single-story-close/gate-log.js
@@ -70,7 +70,17 @@ import { Logger, resolveLevel } from '../../Logger.js';
  */
 export const REPLAY_TAIL_LINES = 200;
 
-/** Basename of the per-Story gate log inside the temp directory. */
+/**
+ * Basename of the per-Story gate log inside the temp directory.
+ *
+ * `closeGateLogPath` in `lib/config/temp-paths.js` spells the same name for the
+ * READER — `deliver-recover.js` uses this file's freshness to tell a live close
+ * from a dead one. Deliberately not shared through an import: this sink needs
+ * the basename alone (it honours a `logDir` override the path helper knows
+ * nothing about), and calling that helper for it would drag tempRoot
+ * resolution — a git spawn and scratch-dir creation — into a filename lookup.
+ * The two spellings are pinned equal by test instead.
+ */
 function logNameFor(storyId) {
   return `close-gates-${storyId ?? 'unknown'}.log`;
 }

--- a/.agents/scripts/lib/orchestration/single-story-close/runner.js
+++ b/.agents/scripts/lib/orchestration/single-story-close/runner.js
@@ -71,7 +71,7 @@ async function emitTerminal({ terminal, result, config }) {
       },
     });
   }
-  emitTerminalEnvelope(terminal);
+  emitTerminalEnvelope(terminal, { config });
   await emitTerminalFriction({ envelope: terminal, config });
 }
 

--- a/.agents/scripts/lib/orchestration/story-deliver-terminal.js
+++ b/.agents/scripts/lib/orchestration/story-deliver-terminal.js
@@ -28,6 +28,10 @@
  * pre-#4543 pipeline collapsed by treating budget exhaustion as a block.
  */
 
+import nodeFs from 'node:fs';
+import path from 'node:path';
+import { storyTerminalEnvelopePath } from '../config/temp-paths.js';
+import { resolveConfig } from '../config-resolver.js';
 import { validateTerminalEnvelope } from './story-deliver-terminal-schema.js';
 
 // Re-exported so the schema split stays an implementation detail: every
@@ -327,7 +331,95 @@ export const TERMINAL_BEGIN_MARKER = '--- STORY DELIVER TERMINAL ---';
 export const TERMINAL_END_MARKER = '--- END TERMINAL ---';
 
 /**
- * Write a terminal envelope to stdout, between its markers.
+ * Resolve the repo config, or `undefined` when it cannot be read.
+ *
+ * An unreadable `.agentrc.json` must not cost the run its envelope copy: the
+ * path helpers fall back to the framework-default temp root, which is still a
+ * far better outcome than no artifact at all.
+ *
+ * @param {typeof resolveConfig} resolveConfigImpl
+ * @returns {object|undefined}
+ */
+function tolerantConfig(resolveConfigImpl) {
+  try {
+    return resolveConfigImpl();
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Persist a terminal envelope beside its Story's gate log (Story #4816).
+ *
+ * Stdout is a channel with exactly one reader — the turn that launched the
+ * close — and that reader is not always still listening. A `story-worker`
+ * that reports progress and ends its turn while the close it started is
+ * mid-gate-chain is behaving reasonably, but the envelope it never relayed is
+ * gone: the router then has to reconstruct the Story's state from labels, and
+ * `deliver-recover.js` used to answer that reconstruction with
+ * "Implementation never finished" — false, and its re-init suggestion can put
+ * a second close on one PR. Observed four times across three workers in one
+ * consumer run. The file is the second channel, and it outlives the turn.
+ *
+ * **Best-effort by construction.** Every failure path returns `null`: a
+ * delivery must never turn a landed PR into a crash because a temp directory
+ * was unwritable. The stdout envelope above is the contract; this is a copy.
+ *
+ * **Atomic by construction.** The payload is written to a pid-scoped
+ * temporary name and renamed into place, because the reader that matters most
+ * is a router polling during a live close — a half-written file would hand it
+ * a parse error at exactly the moment it is trying to avoid guessing.
+ *
+ * A null `storyId` (the `escalated` terminal, which by construction never
+ * authored a Story) has nowhere to be filed and writes nothing.
+ *
+ * `config` is optional and resolved lazily when absent. Two of the emit sites
+ * are `catch` blocks that crashed before any config was resolved, and those
+ * are precisely the runs whose envelope is most worth keeping — so the temp
+ * root is looked up here rather than left at the framework default, which
+ * would file the artifact where a consumer's router never looks (and where
+ * the retention purge would never reap it).
+ *
+ * @param {object} envelope A validated terminal envelope.
+ * @param {{
+ *   config?: object,
+ *   fsImpl?: typeof nodeFs,
+ *   resolveConfigImpl?: typeof resolveConfig,
+ * }} [deps]
+ * @returns {string|null} The path written, or `null` when nothing was.
+ */
+export function persistTerminalEnvelope(
+  envelope,
+  { config, fsImpl = nodeFs, resolveConfigImpl = resolveConfig } = {},
+) {
+  const storyId = envelope?.storyId;
+  if (!Number.isInteger(storyId) || storyId <= 0) return null;
+  let tmpPath = null;
+  try {
+    const resolved = config ?? tolerantConfig(resolveConfigImpl);
+    const target = storyTerminalEnvelopePath(storyId, resolved);
+    fsImpl.mkdirSync(path.dirname(target), { recursive: true });
+    tmpPath = `${target}.${process.pid}.tmp`;
+    fsImpl.writeFileSync(tmpPath, `${JSON.stringify(envelope)}\n`, 'utf8');
+    fsImpl.renameSync(tmpPath, target);
+    return target;
+  } catch {
+    // A rename that never ran leaves the scratch file behind; drop it rather
+    // than accumulating one per failed close.
+    if (tmpPath) {
+      try {
+        fsImpl.rmSync(tmpPath, { force: true });
+      } catch {
+        // Nothing left to try — this whole path is already best-effort.
+      }
+    }
+    return null;
+  }
+}
+
+/**
+ * Write a terminal envelope to stdout, between its markers, and persist a
+ * copy to disk.
  *
  * **Deliberately not `Logger.info`.** The envelope is this CLI's
  * machine-readable contract — every invocation emits exactly ONE, and a
@@ -340,16 +432,37 @@ export const TERMINAL_END_MARKER = '--- END TERMINAL ---';
  *
  * Single home for the marker format so the four emit sites (the runner's
  * terminal, the close CLI's failed-terminal catch, and both confirm-CLI
- * paths) cannot drift apart.
+ * paths) cannot drift apart — and, since Story #4816, the single home for the
+ * on-disk copy too, so no emit path can persist and another forget.
+ * {@link persistTerminalEnvelope} runs **first**: a caller that has read the
+ * markers off stdout can then rely on the file already being there.
  *
  * @param {object} envelope
- * @param {{ write?: (s: string) => void }} [opts] `write` is a test seam.
+ * @param {{
+ *   write?: (s: string) => void,
+ *   config?: object,
+ *   persist?: typeof persistTerminalEnvelope,
+ * }} [opts] `write` and `persist` are test seams; `config` resolves the
+ *   artifact's temp root and is threaded from whichever emit site holds one.
  * @returns {void}
  */
 export function emitTerminalEnvelope(
   envelope,
-  { write = (s) => process.stdout.write(s) } = {},
+  {
+    write = (s) => process.stdout.write(s),
+    config,
+    persist = persistTerminalEnvelope,
+  } = {},
 ) {
+  // Belt and braces around a copy: `persistTerminalEnvelope` already swallows
+  // its own failures, but the stdout envelope is the CONTRACT and the disk
+  // copy is a convenience. Nothing in the secondary path — including a future
+  // injected `persist` — may cost the caller the primary one.
+  try {
+    persist(envelope, { config });
+  } catch {
+    // Intentionally silent: see above.
+  }
   // Story #4685 — compact (not 2-space pretty) JSON. The envelope is a
   // machine contract callers recover with `JSON.parse`, so pretty-printing
   // only adds turn-resident bytes without helping any consumer.

--- a/.agents/scripts/lib/temp-retention.js
+++ b/.agents/scripts/lib/temp-retention.js
@@ -210,28 +210,43 @@ async function makeEntry(fsp, target, className, storyId, keep = false) {
 }
 
 /**
- * Recover the Story id a run-log basename carries. Both writers that land in
- * `orchestration/` end their name with the scope: `close-gates-4794.log` from
- * the gate sink, `sync-result-story-4794.log` from the terse-result dump.
+ * Extensions this class owns inside `orchestration/`. Story #4816 added
+ * `.json`: the persisted terminal envelope lands beside the gate log, and a
+ * `.log`-only scan would have left one immortal file per delivered Story in a
+ * directory the purge otherwise keeps clean.
+ */
+const ORCHESTRATION_EXTENSIONS = Object.freeze(['.log', '.json']);
+
+/**
+ * Recover the Story id a run-artifact basename carries. Every writer that
+ * lands in `orchestration/` ends its name with the scope: `close-gates-4794.log`
+ * from the gate sink, `sync-result-story-4794.log` from the terse-result dump,
+ * `story-deliver-terminal-4794.json` from the terminal-envelope persist.
  *
  * @param {string} name
  * @returns {number|null}
  */
 function storyIdFromLogName(name) {
-  const match = TRAILING_ID_PATTERN.exec(name.replace(/\.log$/, ''));
+  const match = TRAILING_ID_PATTERN.exec(name.replace(/\.(log|json)$/, ''));
   return match ? Number(match[1]) : null;
 }
 
 /**
- * `<tempRoot>/orchestration/*.log` — close gate transcripts and terse-result
- * detail dumps. A log whose name carries no id (there are none today, but the
- * class owns the directory) is age-floored rather than dropped from the class.
+ * `<tempRoot>/orchestration/*.{log,json}` — close gate transcripts,
+ * terse-result detail dumps, and persisted terminal envelopes. An artifact
+ * whose name carries no id (there are none today, but the class owns the
+ * directory) is age-floored rather than dropped from the class.
  */
 async function scanOrchestrationLogs(tempRoot, fsp) {
   const dir = path.join(tempRoot, ORCHESTRATION_DIRNAME);
   const entries = [];
   for (const dirent of await safeReaddir(fsp, dir)) {
-    if (!dirent.isFile() || !dirent.name.endsWith('.log')) continue;
+    if (
+      !dirent.isFile() ||
+      !ORCHESTRATION_EXTENSIONS.some((ext) => dirent.name.endsWith(ext))
+    ) {
+      continue;
+    }
     const entry = await makeEntry(
       fsp,
       path.join(dir, dirent.name),

--- a/.agents/scripts/single-story-confirm-merge.js
+++ b/.agents/scripts/single-story-confirm-merge.js
@@ -204,7 +204,7 @@ async function logConfirmResult(result, terminal, config) {
       status: terminal?.status,
     },
   });
-  emitTerminalEnvelope(terminal);
+  emitTerminalEnvelope(terminal, { config });
   await emitTerminalFriction({ envelope: terminal, config });
   return { success: terminal.status !== 'failed', result, terminal };
 }

--- a/.agents/workflows/helpers/deliver-story-reference.md
+++ b/.agents/workflows/helpers/deliver-story-reference.md
@@ -745,6 +745,39 @@ unconfirmed merge is a **contract violation** — the parent cannot distinguish
 "still working" from "done but silent". `pending` is the honest,
 machine-readable alternative: "not finished, here is exactly how to continue."
 
+### The envelope also lands on disk
+
+Stdout has exactly one reader — the turn that launched the close — and that
+reader is not always still listening. A child that reports progress and ends
+its turn while its close is mid-gate-chain is behaving reasonably, but the
+envelope it never relayed is gone, and reconstructing the Story's state from
+labels costs a recovery round trip plus a full resume of the child. Observed
+four times across three workers in a single consumer run, on unrelated
+footprints, and not new to that run.
+
+So `emitTerminalEnvelope` — the one writer behind every emit site — also
+persists the validated envelope to
+`<tempRoot>/orchestration/story-deliver-terminal-<storyId>.json`:
+
+- **It is the same object**, not a summary. Read it and branch exactly as you
+  would on stdout; the copy is written before the markers are, so a caller
+  that saw them can rely on the file.
+- **It is best-effort.** A failed write returns null and changes nothing about
+  the emitted envelope or the exit code — a landed PR must never become a
+  crash because a temp directory was unwritable.
+- **It is a fallback, not a licence.** A worker still holds its turn until the
+  envelope arrives; see [`agents/story-worker.md`](../../agents/story-worker.md).
+
+`deliver-recover.js` reads the same artifact, plus the freshness of
+`close-gates-<storyId>.log`, to split the one genuinely ambiguous row of its
+table. `agent::executing` with no PR used to answer "Implementation never
+finished" — false for the whole duration of a close, whose gates and push
+happen before any PR exists, and actively hazardous, because acting on its
+re-init suggestion can put a second close on one PR. It now answers
+`close-in-flight` (a gate log touched inside the window: wait, then re-probe)
+or `close-envelope-on-disk` (the close already reached a verdict: relay it),
+and falls back to the original verdict only when neither artifact exists.
+
 ### Exit-code compatibility note (`--no-wait-merge`)
 
 Every close flag keeps its meaning, but the **exit code** of a

--- a/.agents/workflows/helpers/deliver-story.md
+++ b/.agents/workflows/helpers/deliver-story.md
@@ -148,10 +148,13 @@ budget is exhausted. Reference § Step 7.
 
 ## Recovering a stranded Story {#recover}
 
-Unclear state (killed run, lost envelope, a re-run refusal — incl.
-merged-but-label-stale)? Do not guess — probe **read-only** with
+**Lost envelope first: read it off disk.** Close persists each to
+`temp/orchestration/story-deliver-terminal-<storyId>.json`; branch on it per
+digest § 5. Otherwise (killed run, re-run refusal, merged-but-label-stale)
+do not guess — probe **read-only** with
 `node .agents/scripts/deliver-recover.js --story <storyId>`; it prints the
-**one** next command with its evidence, never a menu.
+**one** next command with its evidence, never a menu. A live close answers
+`close-in-flight`: wait, never re-init underneath it.
 
 ## Idempotence & constraints
 

--- a/baselines/dead-exports-production.json
+++ b/baselines/dead-exports-production.json
@@ -1414,6 +1414,10 @@
     },
     {
       "file": ".agents/scripts/lib/orchestration/deliver-recover.js",
+      "symbol": "probeCloseArtifacts"
+    },
+    {
+      "file": ".agents/scripts/lib/orchestration/deliver-recover.js",
       "symbol": "probePr"
     },
     {
@@ -2027,6 +2031,10 @@
     {
       "file": ".agents/scripts/lib/orchestration/story-deliver-terminal.js",
       "symbol": "TERMINAL_STATUSES"
+    },
+    {
+      "file": ".agents/scripts/lib/orchestration/story-deliver-terminal.js",
+      "symbol": "persistTerminalEnvelope"
     },
     {
       "file": ".agents/scripts/lib/orchestration/story-deliver-terminal.js",

--- a/tests/agents/role-scoped-boot-context.test.js
+++ b/tests/agents/role-scoped-boot-context.test.js
@@ -31,6 +31,7 @@ import { fileURLToPath } from 'node:url';
 import Ajv2020 from 'ajv/dist/2020.js';
 import addFormats from 'ajv-formats';
 import { makeTempDir } from '../../.agents/scripts/lib/test-temp.js';
+import { assertDocMentions } from '../helpers/doc-assert.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = path.resolve(__dirname, '..', '..');
@@ -178,6 +179,41 @@ describe('story-worker boot context carries every delivery MUST (default-true ga
   test('enforces absolute paths (cwd may reset between calls)', () => {
     const { body } = bootContext('story-worker.md');
     assert.match(body, /[Aa]bsolute path/);
+  });
+
+  test('holds the turn until the terminal envelope arrives (#4816)', () => {
+    // The gap this closes: nothing in the boot context made holding the turn
+    // a requirement, so a worker that reported "close is running" and yielded
+    // was behaving reasonably — and its envelope died with the turn. Observed
+    // four times across three workers in one consumer run, and prompt-level
+    // warnings in the dispatch did not stop it. The rule has to live where the
+    // behaviour is decided.
+    const { body } = bootContext('story-worker.md');
+    assertDocMentions(
+      body,
+      /foreground/i,
+      'story-worker.md must require close to run in the foreground',
+    );
+    assertDocMentions(
+      body,
+      /[Nn]ever background it/,
+      'story-worker.md must forbid backgrounding the close',
+    );
+    assertDocMentions(
+      body,
+      /never delegate it to a child/i,
+      'story-worker.md must forbid delegating the close to a child',
+    );
+    assertDocMentions(
+      body,
+      /never end your turn while it is still running/i,
+      'story-worker.md must forbid returning before the envelope arrives',
+    );
+    assertDocMentions(
+      body,
+      /story-deliver-terminal-<id>\.json/,
+      'story-worker.md must name the persisted fallback the caller reads',
+    );
   });
 });
 

--- a/tests/contract/story-deliver-terminal.test.js
+++ b/tests/contract/story-deliver-terminal.test.js
@@ -27,6 +27,7 @@
 
 import assert from 'node:assert/strict';
 import fs from 'node:fs';
+import os from 'node:os';
 import path from 'node:path';
 import { describe, it, mock } from 'node:test';
 import { fileURLToPath } from 'node:url';
@@ -38,6 +39,7 @@ import {
   emitTerminalEnvelope,
   exitCodeForTerminal,
   NEXT_COMMANDS,
+  persistTerminalEnvelope,
   TERMINAL_BEGIN_MARKER,
   TERMINAL_END_MARKER,
   TERMINAL_ENVELOPE_KIND,
@@ -45,6 +47,7 @@ import {
   TERMINAL_STATUSES,
   validateTerminalEnvelope,
 } from '../../.agents/scripts/lib/orchestration/story-deliver-terminal.js';
+import { makeTempDir } from '../../.agents/scripts/lib/test-temp.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const SCHEMA = JSON.parse(
@@ -659,5 +662,183 @@ describe('emitTerminalEnvelope — the contract payload is not level-gated', () 
     } finally {
       setLevel(previous ?? 'info');
     }
+  });
+});
+
+describe('persistTerminalEnvelope — the envelope outlives its turn (#4816)', () => {
+  /**
+   * A config whose tempRoot is an absolute scratch dir, so every assertion
+   * below reads a real file without going anywhere near the repo tree.
+   */
+  function scratchConfig() {
+    const root = makeTempDir('terminal-persist-');
+    return {
+      root,
+      config: { project: { paths: { tempRoot: root } } },
+      envelopePath: (sid) =>
+        path.join(root, 'orchestration', `story-deliver-terminal-${sid}.json`),
+    };
+  }
+
+  const pending = buildTerminalEnvelope({
+    storyId: 4816,
+    status: 'pending',
+    phase: 'confirm-merge',
+    nextCommand: NEXT_COMMANDS.resumeLand(4816),
+    elapsedSeconds: 12,
+  });
+
+  it('writes the same object the stdout markers carry', () => {
+    // The whole point: an orphaned turn costs a file read, not a recovery
+    // round trip. That only holds if the file IS the envelope, byte for byte
+    // in content — not a summary of it.
+    const { config, envelopePath } = scratchConfig();
+    let out = '';
+    emitTerminalEnvelope(pending, { write: (s) => (out += s) });
+    emitTerminalEnvelope(pending, { write: (s) => (out += s), config });
+    const onDisk = JSON.parse(fs.readFileSync(envelopePath(4816), 'utf8'));
+    const onStdout = JSON.parse(
+      out.split(TERMINAL_BEGIN_MARKER).pop().split(TERMINAL_END_MARKER)[0],
+    );
+    assert.deepEqual(onDisk, onStdout);
+    assert.deepEqual(onDisk, pending);
+  });
+
+  it('returns the path it wrote and creates the directory for it', () => {
+    const { config, envelopePath } = scratchConfig();
+    const written = persistTerminalEnvelope(pending, { config });
+    assert.equal(written, envelopePath(4816));
+    assert.ok(fs.existsSync(written));
+  });
+
+  it('overwrites the previous run rather than accumulating copies', () => {
+    // A Story can be closed more than once (a `pending` wait resumed, a red
+    // gate fixed). The reader wants the CURRENT verdict, so last write wins
+    // and the directory holds exactly one file per Story.
+    const { root, config, envelopePath } = scratchConfig();
+    persistTerminalEnvelope(pending, { config });
+    const landed = buildTerminalEnvelope({
+      storyId: 4816,
+      status: 'landed',
+      phase: 'done',
+      nextCommand: null,
+      elapsedSeconds: 30,
+    });
+    persistTerminalEnvelope(landed, { config });
+    assert.equal(
+      JSON.parse(fs.readFileSync(envelopePath(4816), 'utf8')).status,
+      'landed',
+    );
+    assert.deepEqual(fs.readdirSync(path.join(root, 'orchestration')), [
+      'story-deliver-terminal-4816.json',
+    ]);
+  });
+
+  it('renames into place so a reader never parses a partial file', () => {
+    // The reader that matters most is a router polling during a live close.
+    // Handing it a truncated JSON at exactly the moment it is trying to stop
+    // guessing would be worse than handing it nothing.
+    const writes = [];
+    const renames = [];
+    const fsImpl = {
+      mkdirSync: () => {},
+      writeFileSync: (target, body) => writes.push({ target, body }),
+      renameSync: (from, to) => renames.push({ from, to }),
+      rmSync: () => {},
+    };
+    const written = persistTerminalEnvelope(pending, {
+      config: { project: { paths: { tempRoot: path.join(os.tmpdir(), 'x') } } },
+      fsImpl,
+    });
+    assert.equal(writes.length, 1);
+    assert.equal(renames.length, 1);
+    assert.notEqual(
+      writes[0].target,
+      written,
+      'the payload is written to a scratch name, never the final path',
+    );
+    assert.equal(renames[0].from, writes[0].target);
+    assert.equal(renames[0].to, written);
+  });
+
+  it('never costs a close its return when the write fails', () => {
+    // Best-effort is the contract. A landed PR must not become a crash
+    // because a temp directory was unwritable.
+    const fsImpl = {
+      mkdirSync: () => {
+        throw new Error('EACCES: read-only file system');
+      },
+      writeFileSync: () => {},
+      renameSync: () => {},
+      rmSync: () => {},
+    };
+    assert.equal(persistTerminalEnvelope(pending, { fsImpl }), null);
+
+    let out = '';
+    emitTerminalEnvelope(pending, {
+      write: (s) => (out += s),
+      persist: () => {
+        throw new Error('should never propagate');
+      },
+    });
+    assert.ok(out.includes(TERMINAL_BEGIN_MARKER));
+  });
+
+  it('cleans up the scratch file when the rename fails', () => {
+    const removed = [];
+    const fsImpl = {
+      mkdirSync: () => {},
+      writeFileSync: () => {},
+      renameSync: () => {
+        throw new Error('EXDEV');
+      },
+      rmSync: (target) => removed.push(target),
+    };
+    assert.equal(persistTerminalEnvelope(pending, { fsImpl }), null);
+    assert.equal(removed.length, 1);
+    assert.ok(removed[0].endsWith('.tmp'));
+  });
+
+  it('writes nothing for an escalated terminal, which has no Story id', () => {
+    const { root, config } = scratchConfig();
+    const escalated = buildEscalationTerminal({ prompt: 'add a --json flag' });
+    assert.equal(escalated.storyId, null);
+    assert.equal(persistTerminalEnvelope(escalated, { config }), null);
+    assert.equal(fs.existsSync(path.join(root, 'orchestration')), false);
+  });
+
+  it('degrades to the default temp root when the config cannot be read', () => {
+    // An unreadable .agentrc must not cost the run its copy: the fallback
+    // root is still far better than no artifact at all.
+    const seen = [];
+    const fsImpl = {
+      mkdirSync: (dir) => seen.push(dir),
+      writeFileSync: () => {},
+      renameSync: () => {},
+      rmSync: () => {},
+    };
+    const written = persistTerminalEnvelope(pending, {
+      fsImpl,
+      resolveConfigImpl: () => {
+        throw new Error('unparseable .agentrc.json');
+      },
+    });
+    assert.ok(written, 'a broken config still yields a persisted path');
+    assert.equal(seen.length, 1);
+    assert.ok(written.endsWith('story-deliver-terminal-4816.json'));
+  });
+
+  it('is invoked by emitTerminalEnvelope, so no emit site can forget it', () => {
+    // The single-writer property is the design: four emit sites, one place
+    // that persists. A future fifth site inherits it for free.
+    const calls = [];
+    emitTerminalEnvelope(pending, {
+      write: () => {},
+      config: { marker: true },
+      persist: (envelope, opts) => calls.push({ envelope, opts }),
+    });
+    assert.equal(calls.length, 1);
+    assert.deepEqual(calls[0].envelope, pending);
+    assert.deepEqual(calls[0].opts.config, { marker: true });
   });
 });

--- a/tests/lib/config/temp-paths.test.js
+++ b/tests/lib/config/temp-paths.test.js
@@ -15,12 +15,14 @@ import {
   _clearMainCheckoutRootCache,
   _clearTestContextScratchCache,
   anchorTempRoot,
+  closeGateLogPath,
   mainCheckoutRoot,
   runArtifactPath,
   runTempDir,
   signalsFile,
   storyManifestPath,
   storyTempDir,
+  storyTerminalEnvelopePath,
   TEST_ALLOW_REAL_TEMP_ENV,
   TEST_TEMP_ROOT_ENV,
   tempRootFrom,
@@ -591,6 +593,75 @@ describe('lib/config/temp-paths.js — direct `node --test` appends zero bytes t
       }
     } finally {
       rmSync(fixtureDir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('storyTerminalEnvelopePath — the persisted terminal envelope (#4816)', () => {
+  it('sits beside the gate log under the configured temp root', () => {
+    const config = { project: { paths: { tempRoot: 'scratch' } } };
+    assert.equal(
+      storyTerminalEnvelopePath(4816, config),
+      anchored('scratch', 'orchestration', 'story-deliver-terminal-4816.json'),
+    );
+  });
+
+  it('falls back to the framework-default temp root with no config', () => {
+    assert.equal(
+      storyTerminalEnvelopePath(4816),
+      anchored('temp', 'orchestration', 'story-deliver-terminal-4816.json'),
+    );
+  });
+
+  it('honours an absolute temp root verbatim', () => {
+    const abs = path.join(os.tmpdir(), 'mandrel-4816-abs');
+    const config = { project: { paths: { tempRoot: abs } } };
+    assert.equal(
+      storyTerminalEnvelopePath(7, config),
+      path.join(abs, 'orchestration', 'story-deliver-terminal-7.json'),
+    );
+  });
+
+  it('anchors to the MAIN checkout, not the caller cwd', () => {
+    // The load-bearing property: the close runs inside `.worktrees/story-<id>/`
+    // while the /deliver host reads from the main checkout. An un-anchored
+    // relative root would file the envelope where the router never looks.
+    const resolved = storyTerminalEnvelopePath(4816, {
+      project: { paths: { tempRoot: 'temp' } },
+    });
+    assert.equal(path.isAbsolute(resolved), Boolean(mainCheckoutRoot()));
+    assert.ok(!resolved.includes(`.worktrees${SEP}`));
+  });
+
+  it('names the basename the retention scanner parses', () => {
+    assert.equal(
+      path.basename(storyTerminalEnvelopePath(4816)),
+      'story-deliver-terminal-4816.json',
+    );
+  });
+
+  it('pairs the envelope with the gate log the recovery probe reads', () => {
+    // Both artifacts of one close, same directory, same Story scope — the
+    // retention purge takes them as a pair and the probe reads them together.
+    const config = { project: { paths: { tempRoot: 'scratch' } } };
+    assert.equal(
+      path.dirname(closeGateLogPath(4816, config)),
+      path.dirname(storyTerminalEnvelopePath(4816, config)),
+    );
+    assert.equal(
+      path.basename(closeGateLogPath(4816, config)),
+      'close-gates-4816.log',
+    );
+    assert.equal(
+      path.basename(closeGateLogPath(null, config)),
+      'close-gates-unknown.log',
+      'the sink\u2019s no-Story sentinel keeps its spelling',
+    );
+  });
+
+  it('rejects a non-positive-integer Story id rather than pathing to junk', () => {
+    for (const bad of [0, -1, 1.5, null, undefined, '4816']) {
+      assert.throws(() => storyTerminalEnvelopePath(bad), /positive integer/);
     }
   });
 });

--- a/tests/lib/orchestration/single-story-close/gate-log.test.js
+++ b/tests/lib/orchestration/single-story-close/gate-log.test.js
@@ -22,7 +22,7 @@ import assert from 'node:assert/strict';
 import nodeFs from 'node:fs';
 import path from 'node:path';
 import { after, before, beforeEach, describe, it } from 'node:test';
-
+import { closeGateLogPath } from '../../../../.agents/scripts/lib/config/temp-paths.js';
 import {
   createGateLogSink,
   REPLAY_TAIL_LINES,
@@ -232,5 +232,29 @@ describe('createGateLogSink — streaming and degradation', () => {
       'one\ntwo\n',
       'a second flush must neither truncate nor duplicate the artifact',
     );
+  });
+});
+
+describe('the sink and the recovery reader agree on the filename (#4816)', () => {
+  it('writes the basename `closeGateLogPath` resolves for the same Story', () => {
+    // The two spell the name independently — the sink needs the basename
+    // alone (it honours a `logDir` override), and making it call the path
+    // helper would drag tempRoot resolution into a filename lookup. This is
+    // the pin that keeps them from drifting: a reader that looks for a name
+    // the writer stopped using would silently see every close as dead.
+    const sink = sinkAt('name-parity');
+    assert.equal(
+      path.basename(sink.logPath),
+      path.basename(closeGateLogPath(4736)),
+    );
+  });
+
+  it('agrees on the no-Story sentinel too', () => {
+    const sink = sinkAt('name-parity-null', { storyId: null });
+    assert.equal(
+      path.basename(sink.logPath),
+      path.basename(closeGateLogPath(null)),
+    );
+    assert.match(path.basename(sink.logPath), /^close-gates-unknown\.log$/);
   });
 });

--- a/tests/lib/temp-retention.test.js
+++ b/tests/lib/temp-retention.test.js
@@ -452,3 +452,52 @@ describe('formatBytes', () => {
     assert.equal(formatBytes(3 * 1024 * 1024 * 1024), '3.0GB');
   });
 });
+
+describe('the persisted terminal envelope is reapable (#4816)', () => {
+  it('claims story-deliver-terminal-<id>.json for the orchestrationLogs class', async () => {
+    // Before this, the scanner took `*.log` only — so the envelope the close
+    // now persists would have been the one file in `orchestration/` the purge
+    // could never reap, accumulating one per delivered Story forever.
+    const root = makeRoot();
+    writeAged(
+      path.join(root, 'orchestration', 'story-deliver-terminal-4816.json'),
+    );
+
+    const { entries, unrecognized } = await collectTempEntries({
+      tempRoot: root,
+    });
+    const entry = entries.find((e) =>
+      e.path.endsWith('story-deliver-terminal-4816.json'),
+    );
+    assert.ok(entry, 'the envelope is classified, not left unrecognized');
+    assert.equal(entry.className, 'orchestrationLogs');
+    assert.equal(entry.storyId, 4816, 'the Story scope is parsed off the name');
+    assert.equal(unrecognized.length, 0);
+  });
+
+  it('keys the envelope and its gate log to the same Story', async () => {
+    // They are two artifacts of one close, so a Story-scoped purge must take
+    // both or neither.
+    const root = makeRoot();
+    writeAged(path.join(root, 'orchestration', 'close-gates-4816.log'));
+    writeAged(
+      path.join(root, 'orchestration', 'story-deliver-terminal-4816.json'),
+    );
+
+    const { entries } = await collectTempEntries({ tempRoot: root });
+    const scoped = entries.filter((e) => e.className === 'orchestrationLogs');
+    assert.equal(scoped.length, 2);
+    assert.deepEqual([...new Set(scoped.map((e) => e.storyId))], [4816]);
+  });
+
+  it('still ignores a file type the class does not own', async () => {
+    const root = makeRoot();
+    writeAged(path.join(root, 'orchestration', 'notes-4816.txt'));
+
+    const { entries } = await collectTempEntries({ tempRoot: root });
+    assert.equal(
+      entries.filter((e) => e.className === 'orchestrationLogs').length,
+      0,
+    );
+  });
+});

--- a/tests/scripts/deliver-recover.test.js
+++ b/tests/scripts/deliver-recover.test.js
@@ -27,6 +27,7 @@ import { describe, it } from 'node:test';
 import {
   decideRecovery,
   probeBranch,
+  probeCloseArtifacts,
   probePr,
   probeTicket,
   recoverStory,
@@ -552,5 +553,338 @@ describe('deliver-recover — stability re-probe (mid-flight strands)', () => {
     });
     assert.deepEqual(delays, [1234]);
     assert.equal(recovery.stability.delayMs, 1234);
+  });
+});
+
+describe('deliver-recover — a live close is not a dead implementation (#4816)', () => {
+  /**
+   * The one ambiguous row in the whole table: `agent::executing` with no PR
+   * reads identically for an implementation that died and for a close that is
+   * halfway through its gate chain. Everything below is that row.
+   */
+  const EXECUTING_NO_PR = {
+    storyId: STORY_ID,
+    ticket: ticket('agent::executing'),
+    branch: BRANCH_PRESENT,
+    pr: null,
+  };
+
+  const NOW = 1_800_000_000_000;
+
+  /**
+   * A `probeCloseArtifacts` reading, built by hand. `gateLogFresh` is stated
+   * outright rather than recomputed from the window: the table reads the flag,
+   * and the window that produces it is the probe's business (pinned in the
+   * probe suite below).
+   */
+  function artifacts({
+    envelope = null,
+    gateLogAgeMs = null,
+    gateLogFresh = gateLogAgeMs !== null,
+    envelopeAgeMs = 0,
+  }) {
+    return {
+      envelope,
+      envelopePath: '/tmp/orchestration/story-deliver-terminal-4543.json',
+      envelopeMtimeMs: envelope ? NOW - envelopeAgeMs : null,
+      gateLogPath: '/tmp/orchestration/close-gates-4543.log',
+      gateLogAgeMs,
+      gateLogMtimeMs: gateLogAgeMs === null ? null : NOW - gateLogAgeMs,
+      gateLogFresh,
+    };
+  }
+
+  it('reports close-in-flight, not "implementation never finished"', () => {
+    // The observed defect: the probe said "Implementation never finished"
+    // while the gate log had been appended one second earlier.
+    const decision = decideRecovery({
+      ...EXECUTING_NO_PR,
+      closeArtifacts: artifacts({ gateLogAgeMs: 1000 }),
+    });
+    assert.equal(decision.shape, 'close-in-flight');
+    assert.ok(!/never finished/i.test(decision.detail));
+  });
+
+  it('names the re-init hazard rather than leaving it implied', () => {
+    // Acting on the old verdict re-inits a worktree underneath a running
+    // close and risks two closes racing on one PR.
+    const { detail } = decideRecovery({
+      ...EXECUTING_NO_PR,
+      closeArtifacts: artifacts({ gateLogAgeMs: 1000 }),
+    });
+    assert.match(detail, /single-story-init\.js/);
+    assert.match(detail, /Do not run/i);
+  });
+
+  it('routes a live close back to the read-only probe, never to a mutation', () => {
+    const { nextCommand } = decideRecovery({
+      ...EXECUTING_NO_PR,
+      closeArtifacts: artifacts({ gateLogAgeMs: 1000 }),
+    });
+    assert.equal(nextCommand, NEXT_COMMANDS.recover(STORY_ID));
+    assert.notEqual(nextCommand, NEXT_COMMANDS.implement(STORY_ID));
+  });
+
+  it('treats a gate log older than the window as a dead close', () => {
+    const decision = decideRecovery({
+      ...EXECUTING_NO_PR,
+      closeArtifacts: artifacts({
+        gateLogAgeMs: 10 * 60_000,
+        gateLogFresh: false,
+      }),
+    });
+    assert.equal(decision.shape, 'executing-no-pr');
+    assert.equal(decision.nextCommand, NEXT_COMMANDS.implement(STORY_ID));
+  });
+
+  it('answers a finished-but-orphaned close from its persisted envelope', () => {
+    // The handoff gap itself: the close completed and emitted its verdict
+    // into a turn nobody was reading. The verdict is on disk — relay it
+    // rather than re-deriving a status from labels.
+    const decision = decideRecovery({
+      ...EXECUTING_NO_PR,
+      closeArtifacts: artifacts({
+        envelope: {
+          status: 'pending',
+          phase: 'confirm-merge',
+          nextCommand: NEXT_COMMANDS.resumeLand(STORY_ID),
+        },
+      }),
+    });
+    assert.equal(decision.shape, 'close-envelope-on-disk');
+    assert.equal(decision.nextCommand, NEXT_COMMANDS.resumeLand(STORY_ID));
+    assert.match(decision.detail, /story-deliver-terminal-4543\.json/);
+  });
+
+  it('falls back to the idempotent confirm for a landed envelope naming none', () => {
+    const decision = decideRecovery({
+      ...EXECUTING_NO_PR,
+      closeArtifacts: artifacts({
+        envelope: { status: 'landed', phase: 'post-land', nextCommand: null },
+      }),
+    });
+    assert.equal(decision.shape, 'close-envelope-on-disk');
+    assert.equal(decision.nextCommand, NEXT_COMMANDS.confirmMerge(STORY_ID));
+  });
+
+  it('lets a live close outrank a STALE envelope from a previous attempt', () => {
+    // A Story can be closed more than once. An envelope written before the
+    // current attempt started must not out-argue the gate log that attempt is
+    // appending to right now.
+    const decision = decideRecovery({
+      ...EXECUTING_NO_PR,
+      closeArtifacts: artifacts({
+        envelope: { status: 'blocked', phase: 'close-validation' },
+        envelopeAgeMs: 60_000,
+        gateLogAgeMs: 2_000,
+      }),
+    });
+    assert.equal(decision.shape, 'close-in-flight');
+  });
+
+  it('prefers the envelope when it is newer than the gate log', () => {
+    const decision = decideRecovery({
+      ...EXECUTING_NO_PR,
+      closeArtifacts: artifacts({
+        envelope: {
+          status: 'pending',
+          phase: 'confirm-merge',
+          nextCommand: 'x',
+        },
+        envelopeAgeMs: 1_000,
+        gateLogAgeMs: 30_000,
+      }),
+    });
+    assert.equal(decision.shape, 'close-envelope-on-disk');
+  });
+
+  it('preserves the genuinely-stranded verdict when neither artifact exists', () => {
+    const decision = decideRecovery({
+      ...EXECUTING_NO_PR,
+      closeArtifacts: artifacts({}),
+    });
+    assert.equal(decision.shape, 'executing-no-pr');
+    assert.equal(decision.nextCommand, NEXT_COMMANDS.implement(STORY_ID));
+  });
+
+  it('is inert on every other row of the table', () => {
+    // The artifacts get the first word in ONE place. A closing Story with a
+    // healthy PR is unambiguous already, and a fresh gate log must not
+    // reroute it.
+    const decision = decideRecovery({
+      storyId: STORY_ID,
+      ticket: ticket('agent::closing'),
+      branch: BRANCH_PRESENT,
+      pr: { number: 7, state: 'OPEN', checksStatus: 'pending' },
+      closeArtifacts: artifacts({ gateLogAgeMs: 1000 }),
+    });
+    assert.equal(decision.shape, 'closing-pr-pending');
+  });
+
+  it('reports both artifacts as evidence, on every shape', () => {
+    const decision = decideRecovery({
+      ...EXECUTING_NO_PR,
+      closeArtifacts: artifacts({ gateLogAgeMs: 5_000 }),
+    });
+    assert.ok(decision.evidence.includes('closeEnvelope=none'));
+    assert.ok(decision.evidence.includes('gateLogAge=5s'));
+
+    const bare = decideRecovery(EXECUTING_NO_PR);
+    assert.ok(bare.evidence.includes('gateLogAge=none'));
+  });
+});
+
+describe('probeCloseArtifacts — reading the close’s leavings (#4816)', () => {
+  const paths = {
+    envelope: /story-deliver-terminal-4543\.json$/,
+    gateLog: /close-gates-4543\.log$/,
+  };
+
+  it('reads the envelope and both mtimes when the close left them', () => {
+    const NOW = 1_800_000_000_000;
+    const fsImpl = {
+      readFileSync: () => JSON.stringify({ status: 'landed', phase: 'done' }),
+      statSync: (target) => ({
+        mtimeMs: paths.gateLog.test(target) ? NOW - 3_000 : NOW - 1_000,
+      }),
+    };
+    const probed = probeCloseArtifacts({
+      storyId: STORY_ID,
+      fsImpl,
+      nowMs: NOW,
+    });
+    assert.equal(probed.envelope.status, 'landed');
+    assert.match(probed.envelopePath, paths.envelope);
+    assert.match(probed.gateLogPath, paths.gateLog);
+    assert.equal(probed.gateLogAgeMs, 3_000);
+    assert.equal(probed.gateLogFresh, true);
+  });
+
+  it('degrades to a null reading rather than throwing on missing artifacts', () => {
+    // An absent artifact is the common case — most Stories are probed long
+    // after their close. The table must fall back to its label-only verdict,
+    // not crash the read-only CLI.
+    const fsImpl = {
+      readFileSync: () => {
+        throw new Error('ENOENT');
+      },
+      statSync: () => {
+        throw new Error('ENOENT');
+      },
+    };
+    const probed = probeCloseArtifacts({ storyId: STORY_ID, fsImpl });
+    assert.equal(probed.envelope, null);
+    assert.equal(probed.gateLogAgeMs, null);
+    assert.equal(probed.gateLogFresh, false);
+  });
+
+  it('treats an unparseable or non-object envelope as absent', () => {
+    for (const body of ['{not json', '"a string"', '[1,2]']) {
+      const probed = probeCloseArtifacts({
+        storyId: STORY_ID,
+        fsImpl: {
+          readFileSync: () => body,
+          statSync: () => ({ mtimeMs: 0 }),
+        },
+      });
+      assert.equal(probed.envelope, null, `body: ${body}`);
+    }
+  });
+
+  it('flips gateLogFresh across the default two-minute window', () => {
+    // Generous on purpose: gate output arrives in bursts, and reading a
+    // slow-but-healthy close as dead re-opens the exact misdiagnosis this
+    // exists to remove. Being wrong the other way costs one re-probe.
+    const NOW = 1_800_000_000_000;
+    const at = (ageMs) =>
+      probeCloseArtifacts({
+        storyId: STORY_ID,
+        nowMs: NOW,
+        fsImpl: {
+          readFileSync: () => {
+            throw new Error('ENOENT');
+          },
+          statSync: () => ({ mtimeMs: NOW - ageMs }),
+        },
+      }).gateLogFresh;
+    assert.equal(at(119_000), true);
+    assert.equal(at(121_000), false);
+  });
+
+  it('is re-read on every round of the stability pass', async () => {
+    // A second look is exactly how a close that has since written its
+    // envelope gets noticed — so the probe cannot be hoisted out of the loop.
+    let reads = 0;
+    const provider = {
+      getTicket: async () => ({
+        labels: ['agent::executing'],
+        state: 'open',
+        assignees: [],
+      }),
+    };
+    await recoverStory({
+      storyId: STORY_ID,
+      cwd: '/repo',
+      provider,
+      gh: { pr: { list: async () => [] } },
+      gitSpawnFn: () => ({ status: 1, stdout: '' }),
+      fsImpl: {
+        readFileSync: () => {
+          reads += 1;
+          throw new Error('ENOENT');
+        },
+        statSync: () => {
+          throw new Error('ENOENT');
+        },
+      },
+      stabilityDelayMs: 0,
+      sleepFn: async () => {},
+    });
+    assert.equal(reads, 2, 'both probe rounds read the artifacts');
+  });
+});
+
+describe('close-in-flight earns the stability re-probe (#4816)', () => {
+  it('is treated as mid-flight, not as a settled verdict', async () => {
+    // Membership in TRANSIENT_SHAPES is not directly observable, so pin the
+    // behaviour it buys: a shape whose whole definition is "a process is
+    // mutating this Story right now" must get the second look. Here the close
+    // opens its PR between the probes, and the diverging shapes report
+    // `in-transition` — proof the second round ran at all.
+    let round = 0;
+    const provider = {
+      getTicket: async () => ({
+        labels: ['agent::executing'],
+        state: 'open',
+        assignees: [],
+      }),
+    };
+    const recovery = await recoverStory({
+      storyId: STORY_ID,
+      cwd: '/repo',
+      provider,
+      gh: {
+        pr: {
+          list: async () => {
+            round += 1;
+            return round === 1
+              ? []
+              : [{ number: 9, state: 'OPEN', statusCheckRollup: [] }];
+          },
+        },
+      },
+      gitSpawnFn: () => ({ status: 1, stdout: '' }),
+      fsImpl: {
+        readFileSync: () => {
+          throw new Error('ENOENT');
+        },
+        statSync: () => ({ mtimeMs: Date.now() }),
+      },
+      stabilityDelayMs: 0,
+      sleepFn: async () => {},
+    });
+    assert.equal(recovery.stability.reprobed, true);
+    assert.equal(recovery.shape, 'in-transition');
+    assert.match(recovery.detail, /close-in-flight/);
   });
 });

--- a/tests/workflows/deliver-digest.test.js
+++ b/tests/workflows/deliver-digest.test.js
@@ -27,6 +27,8 @@ import path from 'node:path';
 import { describe, it } from 'node:test';
 import { fileURLToPath } from 'node:url';
 
+import { assertDocMentions } from '../helpers/doc-assert.js';
+
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = path.resolve(__dirname, '..', '..');
 const WORKFLOWS = path.join(REPO_ROOT, '.agents', 'workflows');
@@ -93,6 +95,40 @@ describe('helpers/deliver-digest.md — the one bundled deliver read (AC-5)', ()
     assert.ok(
       spine.includes('digest § 5'),
       'deliver-story.md must route Step 3 / Step 7 at the digest, not carry its own copy of the status table',
+    );
+  });
+});
+
+describe('helpers/deliver-story.md — the orphaned-envelope fallback (#4816)', () => {
+  const read = (p) => readFileSync(p, 'utf8');
+  const spine = () => read(path.join(WORKFLOWS, 'helpers', 'deliver-story.md'));
+
+  it('sends an envelope-less child turn to the persisted file first', () => {
+    // Persisting the envelope buys nothing unless the router is told to read
+    // it: the whole cost this removes is the recovery round trip a caller
+    // pays when a worker's turn ended before it could relay.
+    assertDocMentions(
+      spine(),
+      /temp\/orchestration\/story-deliver-terminal-<storyId>\.json/,
+      'deliver-story.md must name the persisted envelope path',
+    );
+    assertDocMentions(
+      spine(),
+      /[Ll]ost envelope first: read it off disk/,
+      'the fallback must come BEFORE the recovery probe, not as a footnote to it',
+    );
+  });
+
+  it('warns that a live close must not be re-initialized underneath', () => {
+    assertDocMentions(
+      spine(),
+      /close-in-flight/,
+      'deliver-story.md must name the shape the probe now returns for a live close',
+    );
+    assertDocMentions(
+      spine(),
+      /never re-init underneath it/i,
+      'the hazard (two closes racing one PR) must be stated where the operator reads it',
     );
   });
 });


### PR DESCRIPTION
Closes #4816

_Auto-opened by `/deliver`._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches delivery orchestration (close emit, recovery routing, worker contract); misclassification could still misdirect operators, but changes are read-only on recovery and best-effort on persist so landed delivery should not fail on write errors.
> 
> **Overview**
> Fixes **orphaned terminal envelopes** when a story worker ends its turn while close is still running: `emitTerminalEnvelope` now **best-effort persists** the validated envelope to `temp/orchestration/story-deliver-terminal-<storyId>.json` (atomic write, before stdout markers), with paths centralized in `temp-paths.js` beside `close-gates-<sid>.log`.
> 
> **`deliver-recover.js`** probes those artifacts for the ambiguous `agent::executing` + no PR case: fresh gate log → **`close-in-flight`** (re-probe, warn against re-init); persisted envelope → **`close-envelope-on-disk`** (relay `nextCommand`); otherwise unchanged **implement** path. `close-in-flight` joins transient shapes for the stability re-probe.
> 
> **Docs/tests:** `story-worker.md` requires foreground close until the envelope arrives; deliver workflow docs point operators at the on-disk fallback first; temp retention reaps `.json` orchestration artifacts; contract and recovery tests cover persist and decision table behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 704e32f219c79119153ff48e8f6e23549a7424c6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->