### PR TITLE
fix: correct the always-on instruction spine and give its budget one honest definition (#4821)

### DIFF
--- a/.agents/README.md
+++ b/.agents/README.md
@@ -325,7 +325,7 @@ persists Stories with inline `acceptance[]` / `verify[]` and a folded
 `main`. There is no `type::epic` / `type::task` label, Epic issue form, or
 `epic/<id>` integration branch; a ticket carrying an `Epic: #N` footer is
 refused by `/deliver`. The execution-model contract is owned by
-[`instructions.md` § 5.D](instructions.md) and [`docs/SDLC.md`](docs/SDLC.md).
+[`instructions.md` § 5.B](instructions.md) and [`docs/SDLC.md`](docs/SDLC.md).
 
 ---
 

--- a/.agents/instructions.md
+++ b/.agents/instructions.md
@@ -14,10 +14,10 @@ and is read when the task engages it.
 ### A. Role Framing
 
 No persona packs, no `persona::*` labels — constraints come from this
-file, the rules, and skills. Role-scoped spawn contexts live under
+file, the rules, and skills; "act as [role]" means apply the matching
+skill or workflow guidance. Role-scoped spawn contexts live under
 `.agents/agents/` (`delivery.routing.roleScopedAgents`); `qa.personas`
-are a separate fixture concept. "Act as [role]" = apply the matching
-skill / workflow guidance.
+is a separate fixture concept.
 
 ### B. Skill Activation
 
@@ -32,11 +32,11 @@ Unsure? Match against the `description`s in
 
 ### C. Proactive Documentation
 
-For any code involving third-party libraries, fetch the latest official
-docs **before** writing code via the host's best live-documentation
-mechanism (docs MCP server, IDE lookup) — do not ask permission.
-Fallbacks: (1) in-repo docs and the package's bundled README/CHANGELOG,
-(2) web fetch/search. Note the channel you used.
+Before writing against a third-party API you are unsure of — or one
+that moves fast enough that recall may be stale — fetch the current
+official docs via the host's best live-documentation mechanism (docs
+MCP server, IDE lookup); do not ask permission. Fallbacks: (1) in-repo
+docs and the package's bundled README/CHANGELOG, (2) web fetch/search.
 
 ### D. Error Handling & Degradation
 
@@ -138,8 +138,6 @@ sizing) **fail closed** naming what to trim:
 3. **Artifacts over Chat.** Write test/build/debug output to log
    files, not into chat.
 4. **Idempotency.** Scripts must be safe to run repeatedly.
-5. **Security First.** Never hardcode secrets; use environment variables
-   and secret scanning.
 
 ---
 
@@ -151,11 +149,9 @@ sizing) **fail closed** naming what to trim:
   spawn only when the work justifies replicating context. One objective
   per subagent; depth compounds the cost (every nested level re-pays).
 - **Anti-Laziness / No Dead Code.** NEVER use placeholder comments like
-  `// ... existing code ...` — output the ENTIRE file or complete
-  function; remove unused imports, commented-out code, and dead branches
+  `// ... existing code ...`; every edit must leave complete, runnable
+  code. Remove unused imports, commented-out code, and dead branches
   before finalizing.
-- **Lint Compliance.** Adhere strictly to project linters and
-  formatters.
 - **Verification.** Include explicit verification steps in every plan.
 
 ---
@@ -167,7 +163,7 @@ reference: `story-<storyId>` branches seeded by `single-story-init.js`,
 every Story reaching `main` via its own PR
 (`helpers/deliver-story` / `single-story-close.js`).
 
-### B. Status Tracking & Commit Standards
+### A. Status Tracking & Commit Standards
 
 State mutations are GitHub labels (`agent::ready`, `agent::executing`,
 `agent::done`) via
@@ -175,7 +171,7 @@ State mutations are GitHub labels (`agent::ready`, `agent::executing`,
 Do NOT manually update issue descriptions or status fields unless
 prompted.
 
-### D. Ticket hierarchy (Story-only)
+### B. Ticket hierarchy (Story-only)
 
 The v2 ticket model is Story-only: `acceptance[]` / `verify[]` live
 inline plus the folded Tech Spec in `## Spec` (over-budget Specs fail

--- a/.agents/rules/git-conventions.md
+++ b/.agents/rules/git-conventions.md
@@ -19,7 +19,7 @@ commit on that branch only. Close opens a PR against `main` (squash +
 required checks). No `epic/<id>` integration branch, no `--no-ff` wave
 merge, no child tickets: commits land on `story-<storyId>` directly, the
 subject referencing the Story via `(refs #<storyId>)` — see
-[`.agents/instructions.md` § 5.D](../instructions.md).
+[`.agents/instructions.md` § 5.B](../instructions.md).
 
 ## Conventional Commits
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,8 +45,7 @@ Two orientation pointers are load-bearing often enough to keep here:
   `github`, `planning`, `delivery`). Project-specific technology choices are
   deliberately kept out of it — the Tech Stack inventory lives under the
   **Tech Stack** heading in [`docs/architecture.md`](docs/architecture.md).
-- **Skills and rules are read on demand**, not preloaded. Each `SKILL.md`
-  leads with its Policy Capsule and points at a `reference.md` sibling for the
-  long-form material; the `.agents/rules/` set splits into an always-on core
-  and an on-demand set. See
+- **Skills and rules are read on demand**, not preloaded — each `SKILL.md`
+  leads with its Policy Capsule, and `.agents/rules/` splits into an always-on
+  core and an on-demand set. See
   [`.agents/instructions.md` § 1.B / § 1.F](.agents/instructions.md).

--- a/tests/bootstrap/always-on-closure.test.js
+++ b/tests/bootstrap/always-on-closure.test.js
@@ -16,61 +16,73 @@
  */
 
 import assert from 'node:assert/strict';
-import { readFileSync, statSync } from 'node:fs';
+import { readFileSync } from 'node:fs';
 import path from 'node:path';
 import { describe, it } from 'node:test';
 import { fileURLToPath } from 'node:url';
+import { resolveAlwaysLoadedClosure } from '../../.agents/scripts/lib/doc-tiers.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = path.resolve(__dirname, '..', '..');
 
-/** AC-1: instructions + always-on rules must fit under 16KB. */
-const CLOSURE_BUDGET_BYTES = 16 * 1024;
+/**
+ * AC-1: the whole always-loaded closure must fit under this ceiling.
+ *
+ * Story #4821 widened what this charges. The previous regex matched only
+ * `@.agents/**.md`, so `AGENTS.md` and `.agentrc.json` — both @-imported by
+ * CLAUDE.md and both re-paid on every spawn — were invisible to the ratchet
+ * and could grow for free. The ceiling rose to cover them; it is NOT slack
+ * for the files that were already charged.
+ */
+const CLOSURE_BUDGET_BYTES = 21 * 1024;
 
 /**
- * Extract the `.agents/` @-import targets from CLAUDE.md — the instruction
- * spine plus every always-on rule. Measuring what CLAUDE.md actually imports
- * (rather than a hardcoded list) means promoting a new rule into the
- * always-on core is automatically charged against the budget.
+ * The always-loaded closure, resolved by the same function the CI
+ * context-budget gate uses (`check-context-budget.js` →
+ * `resolveAlwaysLoadedClosure`). Sharing the resolver is the point: two
+ * private definitions of "always loaded" drifted ~5KB apart before #4821,
+ * and a ratchet that disagrees with the gate it backstops reports a number
+ * nobody can act on. Every `@`-import of CLAUDE.md is charged transitively —
+ * promoting a rule into the always-on core is billed automatically.
  */
-function alwaysOnClosureFiles() {
-  const claudeMd = readFileSync(path.join(REPO_ROOT, 'CLAUDE.md'), 'utf8');
-  const files = [];
-  for (const line of claudeMd.split('\n')) {
-    const m = line.match(/^@(\.agents\/\S+\.md)\s*$/);
-    if (m) files.push(m[1]);
-  }
-  return files;
+function alwaysOnClosureEntries() {
+  return resolveAlwaysLoadedClosure(REPO_ROOT);
 }
 
-describe('always-on closure budget (Story #4708, AC-1)', () => {
-  it('CLAUDE.md imports the instruction spine and the always-on rules', () => {
-    const files = alwaysOnClosureFiles();
-    assert.ok(
-      files.includes('.agents/instructions.md'),
-      'CLAUDE.md must @-import .agents/instructions.md',
-    );
+describe('always-on closure budget (Story #4708, AC-1; widened by #4821)', () => {
+  it('charges every CLAUDE.md @-import, not just the .agents/ ones', () => {
+    const files = alwaysOnClosureEntries().map((e) => e.path);
+    for (const required of [
+      'CLAUDE.md',
+      '.agents/instructions.md',
+      '.agents/rules/security-baseline.md',
+      '.agents/rules/git-conventions.md',
+      'AGENTS.md',
+      '.agentrc.json',
+    ]) {
+      assert.ok(
+        files.includes(required),
+        `${required} is @-imported by CLAUDE.md but is not charged against the closure budget — ` +
+          'it would be re-paid every spawn while growing for free',
+      );
+    }
+  });
+
+  it('keeps the security baseline resident', () => {
+    const files = alwaysOnClosureEntries().map((e) => e.path);
     assert.ok(
       files.includes('.agents/rules/security-baseline.md'),
       'CLAUDE.md must @-import the security baseline — it is always-on by contract (AC-2)',
     );
-    assert.ok(
-      files.includes('.agents/rules/git-conventions.md'),
-      'CLAUDE.md must @-import the always-on git core',
-    );
   });
 
-  it(`instructions + always-on rules total ≤ ${CLOSURE_BUDGET_BYTES} bytes`, () => {
-    const files = alwaysOnClosureFiles();
-    const sized = files.map((f) => ({
-      file: f,
-      bytes: statSync(path.join(REPO_ROOT, f)).size,
-    }));
+  it(`the always-loaded closure totals ≤ ${CLOSURE_BUDGET_BYTES} bytes`, () => {
+    const sized = alwaysOnClosureEntries();
     const total = sized.reduce((sum, s) => sum + s.bytes, 0);
     assert.ok(
       total <= CLOSURE_BUDGET_BYTES,
       `always-on closure is ${total} bytes, over the ${CLOSURE_BUDGET_BYTES}-byte budget ` +
-        `(${sized.map((s) => `${s.file}=${s.bytes}`).join(', ')}). ` +
+        `(${sized.map((s) => `${s.path}=${s.bytes}`).join(', ')}). ` +
         'This tax is re-paid every session and every subagent spawn — pay for the growth with an equivalent trim.',
     );
   });


### PR DESCRIPTION
Closes #4821

_Auto-opened by `/deliver`._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and test-ratchet alignment only; no runtime orchestration, auth, or delivery behavior changes.
> 
> **Overview**
> **Always-on context budget (#4821)** — `tests/bootstrap/always-on-closure.test.js` no longer builds the charged file list from a regex on `@.agents/**/*.md`. It uses **`resolveAlwaysLoadedClosure`** from `.agents/scripts/lib/doc-tiers.js`, the same resolver as the CI context-budget gate, so the ratchet and gate agree. The test now requires **`CLAUDE.md`**, **`AGENTS.md`**, and **`.agentrc.json`** in the closure (everything `CLAUDE.md` `@`-imports, transitively). The byte ceiling moves from **16KB to 21KB** to account for those previously uncounted imports, with comments that the extra headroom is not slack for files already in scope.
> 
> **Instruction spine edits** — `.agents/instructions.md` renumbers Git & Story subsections (**§ 5.B** ticket hierarchy, **§ 5.A** status/commits; was **§ 5.D** / **§ 5.B**), narrows proactive third-party doc fetching to uncertain or fast-moving APIs, tightens persona/skill wording, strengthens the anti-placeholder rule, and drops standalone **Security First** and **Lint Compliance** bullets from the always-on sections. **`AGENTS.md`**, **`.agents/README.md`**, and **`.agents/rules/git-conventions.md`** update cross-links to **§ 5.B** and slightly compress on-demand skills/rules orientation text.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cf1fd6bcf79edbd904f28fb3f7a5f3e37511bd1d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->