### PR TITLE
fix: rules: ship a known-tooling-behavior rule so measured gate quirks stop being rediscovered per session (#4825)

### DIFF
--- a/.agents/agents/story-worker.md
+++ b/.agents/agents/story-worker.md
@@ -102,11 +102,10 @@ close pipeline is the authoritative gate. The acceptance self-eval loop may
 share `lint` / `typecheck` evidence with close via `evidence-gate.js`;
 never stamp coverage / CRAP fresh that way.
 
-Before you trust a gate's output — or diagnose a red one — read
+Before trusting a gate's output — or diagnosing a red one — read
 [`known-tooling-behavior.md`](../rules/known-tooling-behavior.md): measured
-cases where this repo's own commands print something that does not mean
-what it looks like (a lint run that exits 1 under a `0 error(s)` summary, a
-locally green `check-baselines.js` that is not the `baselines` check).
+cases where a command prints what it does not mean (lint exits 1 under a
+`0 error(s)` summary; a green `check-baselines.js` is not `baselines`).
 
 ## Acceptance self-eval before close (MUST)
 

--- a/.agents/agents/story-worker.md
+++ b/.agents/agents/story-worker.md
@@ -102,6 +102,12 @@ close pipeline is the authoritative gate. The acceptance self-eval loop may
 share `lint` / `typecheck` evidence with close via `evidence-gate.js`;
 never stamp coverage / CRAP fresh that way.
 
+Before you trust a gate's output — or diagnose a red one — read
+[`known-tooling-behavior.md`](../rules/known-tooling-behavior.md): measured
+cases where this repo's own commands print something that does not mean
+what it looks like (a lint run that exits 1 under a `0 error(s)` summary, a
+locally green `check-baselines.js` that is not the `baselines` check).
+
 ## Acceptance self-eval before close (MUST)
 
 After the implementation commits land and **before** flipping to `closing`,

--- a/.agents/instructions.md
+++ b/.agents/instructions.md
@@ -64,7 +64,8 @@ read **before** the matching work (each opens with a one-line "applies
 when…" scope header): `git-conventions-reference.md`,
 `shell-conventions.md`, `testing-standards.md`,
 `orchestration-error-handling.md` (scripts under `.agents/scripts/**`),
-`ci-remediation.md`, `api-conventions.md`, `gherkin-standards.md`,
+`ci-remediation.md`, `known-tooling-behavior.md`,
+`api-conventions.md`, `gherkin-standards.md`,
 `changelog-style.md`, `test-seams.md`. Read when unsure (on-demand
 loading does not lower a rule's authority — § 1.K).
 

--- a/.agents/rules/known-tooling-behavior.md
+++ b/.agents/rules/known-tooling-behavior.md
@@ -1,0 +1,114 @@
+# Known Tooling Behavior
+
+This rule applies when you are about to trust the output of a gate, a
+baseline ratchet, or a local stand-in for a CI check — before pushing,
+before declaring a check green, and before diagnosing a red one.
+
+Each entry below records a **measured** behavior of this repository's own
+tooling: a place where a command's visible output does not mean what it
+looks like it means. Entries exist because each one has already cost a
+delivery cycle.
+
+## The entry bar
+
+- An entry states behavior that was **measured against this repo**, never
+  recalled and never assumed.
+- Every entry carries a **reproduction command** that was actually run. If
+  the command stops reproducing the behavior, **delete the entry** — do not
+  annotate it. A stale entry is worse than a missing one, because it is
+  trusted.
+- Entries describe the observable behavior and the safe move. They never
+  describe a way to bypass a gate, and recording a behavior here is not a
+  decision to keep it.
+
+## 1. `npm run lint` prints `Summary: 0 error(s)` and can still exit 1
+
+**Behavior.** `npm run lint` is `run-lint.js`, which spawns six tools
+concurrently with inherited stdio and exits with the first non-zero code.
+`Summary: 0 error(s)` is **markdownlint-cli2's own verdict**, not the
+aggregate — it is printed whether or not Biome, the lifecycle lint, the
+workflow-CLI lint, the label-vocabulary lint, or the arch-cycle ratchet
+failed. Because the tools run in parallel, that line can land anywhere in
+the output, including last, so the tail of a failing run reads green.
+Biome's format diagnostics are `error`-severity, so a file that only needs
+reformatting fails the check while emitting no lint rule name at all.
+
+**Reproduce.**
+
+```bash
+# a format-only diff is an error, not a warning
+printf 'export const x = {a:1,   b:2};\n' | npx biome check --stdin-file-path=probe.js
+echo "biome exit=$?"   # 1 — "The contents aren't fixed"
+
+# and markdownlint's Summary line is unconditional
+npm run lint 2>&1 | grep -c 'Summary: 0 error(s)'
+```
+
+**Safe move.** Trust the exit code, never the last line. When `npm run lint`
+exits non-zero and you cannot see why, re-run `npx biome ci .` on its own —
+`.agents/scripts/run-lint.js` lists every tool it fans out to. Fix formatting
+with `npm run format`; never reach for `--no-verify`.
+
+## 2. `check-baselines.js` is not the whole `baselines` check
+
+**Behavior.** `.agentrc.json` declares the `baselines` required check as
+`node .agents/scripts/check-baselines.js`, but that script only runs the
+gates configured under `delivery.quality.gates` — currently **crap,
+maintainability, and duplication**. CI's job named `baselines` in
+`.github/workflows/ci.yml` runs that script **and then five standalone
+ratchets** the script knows nothing about, so a locally green
+`check-baselines.js` is not evidence that the `baselines` check will pass.
+
+| Ratchet CI's `baselines` job runs | Covered by `check-baselines.js` | Covered by `npm run lint` | Covered by `npm run verify` |
+| --- | --- | --- | --- |
+| `.agents/scripts/check-arch-cycles.js` | no | **yes** | via `lint` |
+| `.agents/scripts/check-dead-exports.js` | no | no | **yes** |
+| `.agents/scripts/check-dead-exports.js --production` | no | no | **yes** |
+| `.agents/scripts/check-context-budget.js` | no | no | **yes** |
+| `.agents/scripts/check-workflow-citations.js` | no | no | **no** |
+
+`check-workflow-citations.js` is currently in **no** local aggregate command
+— it is reachable only as `npm run check:workflow-citations` or a direct
+invocation.
+
+**Reproduce.**
+
+```bash
+node .agents/scripts/check-baselines.js --format text   # names the 3 gates it ran
+sed -n '/name: baselines/,/windows-smoke/p' .github/workflows/ci.yml | grep 'check-'
+grep "label: '" .agents/scripts/run-verify.js            # the 7 steps verify covers
+```
+
+**Safe move.** `npm run verify` is the closest local mirror; run
+`node .agents/scripts/check-workflow-citations.js` alongside it when the
+change touches workflow prose under `.agents/workflows/`. Reproducing only
+the `.agentrc.json` command before a push is a false green.
+
+## 3. The two dead-export passes disagree, and the production pass is silent without `!`
+
+**Behavior.** `check-dead-exports.js` runs twice with two separate
+baselines. The default pass treats `tests/**` as knip entry points, so an
+export whose only importer is a test still reads as *used*; the
+`--production` pass discounts test importers and therefore sees a much
+larger surface — `baselines/dead-exports.json` carries 165 rows against
+`baselines/dead-exports-production.json`'s 667. A new export that is only
+imported by its test passes the default pass and fails the production one.
+
+The production pass depends entirely on the `!` suffix on the `entry` and
+`project` patterns in `knip.json`: `!` marks a pattern as
+production-relevant. Strip the suffixes and `knip --production` reports
+**zero** export rows and exits clean — a green that means "nothing was
+analyzed", not "nothing is dead".
+
+**Reproduce.**
+
+```bash
+node .agents/scripts/check-dead-exports.js              # default pass
+node .agents/scripts/check-dead-exports.js --production # strictly larger row set
+grep -c '!"' knip.json                                  # the production markers
+```
+
+**Safe move.** Run both passes before pushing. When an export is genuinely
+test-only, keep it and refresh the production baseline deliberately —
+`.agents/rules/test-seams.md` governs which seams are sanctioned. Never
+remove the `!` suffixes from `knip.json` to quieten the production pass.

--- a/tests/rules/known-tooling-behavior.test.js
+++ b/tests/rules/known-tooling-behavior.test.js
@@ -1,0 +1,201 @@
+/**
+ * tests/rules/known-tooling-behavior.test.js — the anti-rot ratchet for
+ * `.agents/rules/known-tooling-behavior.md` (Story #4825, AC-1 / AC-2 / AC-3).
+ *
+ * The rule's whole value is that an agent can trust it without re-measuring.
+ * That trust is only earned if two properties hold structurally rather than by
+ * review:
+ *
+ *   AC-2 — every entry carries a reproduction command, so a reader can confirm
+ *          the behavior still holds instead of taking the prose on faith.
+ *   AC-3 — every repository path an entry names still exists, so the rule
+ *          cannot decay into confident misinformation about files that were
+ *          renamed or deleted.
+ *
+ * These are structure assertions over the document, not assertions that the
+ * documented behaviors reproduce — running six gates inside a unit test would
+ * be a slow, flaky integration suite wearing a unit test's clothes. The
+ * reproduction command is the artifact under test; running it stays the
+ * reader's job.
+ */
+
+import assert from 'node:assert/strict';
+import { existsSync, readFileSync } from 'node:fs';
+import path from 'node:path';
+import { describe, it } from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+const RULE_PATH = path.join(
+  REPO_ROOT,
+  '.agents',
+  'rules',
+  'known-tooling-behavior.md',
+);
+const RULE_REL = '.agents/rules/known-tooling-behavior.md';
+
+const source = readFileSync(RULE_PATH, 'utf8');
+
+/**
+ * Split the rule into its numbered entries. An entry is an `##` section whose
+ * heading starts with a digit — the `# ` title and the `## The entry bar`
+ * preamble are deliberately excluded, because they carry policy rather than a
+ * measured behavior.
+ *
+ * @returns {Array<{ heading: string, body: string }>}
+ */
+function entries() {
+  const found = [];
+  const lines = source.split('\n');
+  let current = null;
+
+  for (const line of lines) {
+    const heading = /^## (.+)$/.exec(line);
+    if (heading) {
+      if (current) found.push(current);
+      current = /^\d/.test(heading[1])
+        ? { heading: heading[1], body: '' }
+        : null;
+      continue;
+    }
+    if (current) current.body += `${line}\n`;
+  }
+  if (current) found.push(current);
+  return found;
+}
+
+/**
+ * Extract the fenced `bash` blocks inside an entry body.
+ *
+ * @param {string} body
+ * @returns {string[]}
+ */
+function bashBlocks(body) {
+  return [...body.matchAll(/```bash\n([\s\S]*?)```/g)].map((m) => m[1]);
+}
+
+/**
+ * Repository-path tokens named anywhere in an entry (prose code spans and
+ * reproduction commands alike).
+ *
+ * A candidate must contain a `/` — a bare `probe.js` in a reproduction command
+ * is a scratch artifact the command itself creates, not a repository path, and
+ * asserting its existence would be wrong. Glob patterns are skipped for the
+ * same reason: `.agents/workflows/` wildcards name a set, not a file.
+ *
+ * The extension alternation is ordered longest-first and anchored with `\b`:
+ * an unordered `js|json` truncates `baselines/dead-exports.json` to
+ * `…/dead-exports.js` and reports a phantom missing file.
+ *
+ * @param {string} body
+ * @returns {string[]}
+ */
+function pathTokens(body) {
+  const matches =
+    body.match(
+      /(?:\.?[\w@.-]+\/)+[\w@.-]+\.(?:json|mjs|cjs|js|md|yaml|yml)\b/g,
+    ) ?? [];
+  return [...new Set(matches)].filter((token) => !token.includes('*'));
+}
+
+describe('known-tooling-behavior rule shape (Story #4825, AC-1)', () => {
+  it('opens with the on-demand scope header', () => {
+    const head = source.split('\n').slice(0, 5).join('\n');
+    assert.match(
+      head,
+      /applies when/i,
+      `${RULE_REL} must open with the standard "applies when…" scope header so a ` +
+        'reader can decide in one line whether to read on — that header is what ' +
+        'makes it an on-demand rule rather than resident context',
+    );
+  });
+
+  it('carries at least one entry', () => {
+    assert.ok(
+      entries().length > 0,
+      `${RULE_REL} has no numbered entries — an empty rule still costs a § 1.F ` +
+        'listing and teaches nothing',
+    );
+  });
+});
+
+describe('every entry carries a reproduction command (AC-2)', () => {
+  for (const entry of entries()) {
+    it(`"${entry.heading}" has a runnable bash reproduction`, () => {
+      const blocks = bashBlocks(entry.body);
+      assert.ok(
+        blocks.length >= 1,
+        `entry "${entry.heading}" in ${RULE_REL} has no \`\`\`bash block. Every entry ` +
+          'must be confirmable by running something — an entry a reader cannot ' +
+          're-measure is trusted forever and deleted never',
+      );
+      assert.ok(
+        blocks.some((block) =>
+          block
+            .split('\n')
+            .some((line) => line.trim() && !line.trim().startsWith('#')),
+        ),
+        `entry "${entry.heading}" in ${RULE_REL} has a bash block containing only ` +
+          'comments — there is no command to run',
+      );
+    });
+  }
+});
+
+describe('every path an entry names still exists (AC-3)', () => {
+  for (const entry of entries()) {
+    it(`"${entry.heading}" names only live repository paths`, () => {
+      for (const token of pathTokens(entry.body)) {
+        assert.ok(
+          existsSync(path.join(REPO_ROOT, token)),
+          `entry "${entry.heading}" in ${RULE_REL} names "${token}", which no longer ` +
+            'exists. Re-measure the behavior against the current tree and rewrite ' +
+            'the entry, or delete it — a rule that cites a dead path is confident ' +
+            'misinformation',
+        );
+      }
+    });
+  }
+});
+
+describe('the rule stays on-demand, not resident (AC-4 / AC-5 / AC-7)', () => {
+  it('is registered in the § 1.F on-demand list', () => {
+    const instructions = readFileSync(
+      path.join(REPO_ROOT, '.agents', 'instructions.md'),
+      'utf8',
+    );
+    assert.ok(
+      instructions.includes('known-tooling-behavior.md'),
+      '.agents/instructions.md § 1.F must list known-tooling-behavior.md — an ' +
+        'unlisted rule is a file nobody opens',
+    );
+  });
+
+  it('is reachable from the story-worker role context by link, not by @-import', () => {
+    const worker = readFileSync(
+      path.join(REPO_ROOT, '.agents', 'agents', 'story-worker.md'),
+      'utf8',
+    );
+    assert.ok(
+      worker.includes('known-tooling-behavior.md'),
+      '.agents/agents/story-worker.md must name the rule — role-scoped agents boot ' +
+        'without the CLAUDE.md closure, so a § 1.F listing alone never reaches the ' +
+        'agent that actually runs close-validation',
+    );
+    assert.ok(
+      !worker.includes('@../../.agents/rules/known-tooling-behavior.md'),
+      '.agents/agents/story-worker.md must link the rule, not @-import it — an ' +
+        '@-import makes it always-loaded for that agent and defeats the on-demand design',
+    );
+  });
+
+  it('is absent from the always-on CLAUDE.md closure', () => {
+    const claudeMd = readFileSync(path.join(REPO_ROOT, 'CLAUDE.md'), 'utf8');
+    assert.ok(
+      !claudeMd.includes('known-tooling-behavior'),
+      'CLAUDE.md must not @-import the rule — it is on-demand, and the always-loaded ' +
+        'closure is re-paid on every session and every subagent spawn',
+    );
+  });
+});


### PR DESCRIPTION
Closes #4825

_Auto-opened by `/deliver`._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation, agent guidance, and structural tests only—no runtime gate or CI workflow changes.
> 
> **Overview**
> Adds an on-demand agent rule that documents **measured** gate and baseline quirks so delivery agents stop misreading green-looking output.
> 
> **`known-tooling-behavior.md`** defines the entry bar (repro commands, delete when stale) and three behaviors: parallel `npm run lint` can exit 1 while markdownlint prints `Summary: 0 error(s)`; local `check-baselines.js` is narrower than CI’s `baselines` job; default vs `--production` dead-export passes disagree, and stripping `!` in `knip.json` can yield a false green.
> 
> **Wiring:** listed in `.agents/instructions.md` §1.F; **story-worker** must read it before trusting or debugging close gates (link only, not `@`-import). **`tests/rules/known-tooling-behavior.test.js`** ratchets scope header, bash repro blocks, live path references, on-demand registration, story-worker link, and absence from `CLAUDE.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7349ab571d2c1795a51caa0c0fc3947e6e9905e9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->