### PR TITLE
fix: context-budget: correct the stale agentBoot baseline row and surface rows that drift from the tree (#4830)

### DIFF
--- a/.agents/scripts/check-context-budget.js
+++ b/.agents/scripts/check-context-budget.js
@@ -25,6 +25,21 @@
  * ratchet — each role def is a standalone system prompt a converted spawn boots
  * on, and adding another role def is legitimate.
  *
+ * The recorded `agentBoot` rows are additionally held **in sync with the tree**
+ * (Story #4830), because those rows are what an author sizes an edit against.
+ * The two drift directions are deliberately asymmetric:
+ *
+ *   - **permissive** (the row understates the file, or no row exists) — the row
+ *     promises headroom that does not exist, the gate stays green, and the
+ *     shortfall only lands as a ceiling failure once the edit is written. This
+ *     fails the gate.
+ *   - **restrictive** (the row overstates the file) — an author under-spends
+ *     and the ceiling is never surprised, so it is self-correcting. Reported as
+ *     a `-` line; exit stays 0.
+ *
+ * Each row also records its `headroomBytes` under the ceiling, so the budget an
+ * author reads is stated rather than re-derived.
+ *
  * A read-tier that resolves **empty** is skipped silently (the `docsContextFiles`
  * half skips when unconfigured / its files are absent), so a repo with no
  * `CLAUDE.md` and no context docs is a clean no-op.
@@ -99,6 +114,100 @@ export function agentBootOverflow(tierMap, ceiling = AGENT_BOOT_CEILING_BYTES) {
 }
 
 /**
+ * Classify one agent-boot file against its recorded baseline row (#4830).
+ * Returns `null` when the row already agrees with the tree.
+ *
+ * `permissive` drift is the failure class this gate exists for: the row
+ * understates the file (or is missing entirely), so the headroom an author
+ * computes from it is larger than the headroom that exists, and the shortfall
+ * only surfaces as a ceiling failure *after* the edit is written.
+ * `restrictive` drift is the benign mirror — the row overstates the file, so an
+ * author under-spends and the ceiling gate is never surprised.
+ *
+ * @param {{ path: string, bytes: number }} file live file measurement
+ * @param {{ bytes?: number, headroomBytes?: number } | undefined} row recorded row
+ * @param {number} ceiling
+ * @returns {{ path: string, recorded: number|null, actual: number, delta: number,
+ *   direction: 'permissive'|'restrictive', recordedHeadroom: number|null,
+ *   headroomBytes: number } | null}
+ */
+function classifyBootRow(file, row, ceiling) {
+  const actual = file.bytes;
+  const headroomBytes = ceiling - actual;
+  const recorded = Number.isFinite(row?.bytes) ? row.bytes : null;
+  const recordedHeadroom = Number.isFinite(row?.headroomBytes)
+    ? row.headroomBytes
+    : recorded === null
+      ? null
+      : ceiling - recorded;
+  // A row is in sync only when both the byte count and the headroom it
+  // advertises match the tree — a stale headroom misleads on its own.
+  if (recorded === actual && recordedHeadroom === headroomBytes) return null;
+  const permissive =
+    recorded === null ||
+    recorded < actual ||
+    (recordedHeadroom !== null && recordedHeadroom > headroomBytes);
+  return {
+    path: file.path,
+    recorded,
+    actual,
+    delta: recorded === null ? actual : actual - recorded,
+    direction: permissive ? 'permissive' : 'restrictive',
+    recordedHeadroom,
+    headroomBytes,
+  };
+}
+
+/**
+ * Compare every recorded `agentBoot` row against the tree it describes.
+ *
+ * @param {{ tiers: Record<string, Array<{ path: string, bytes: number }>> }} tierMap
+ * @param {{ agentBoot?: { ceilingBytes?: number, files?: Array<{ path: string, bytes: number, headroomBytes?: number }> } } | null} baseline
+ * @param {number} [ceiling]
+ * @returns {Array<ReturnType<typeof classifyBootRow>>} drift rows (empty = in sync)
+ */
+export function agentBootDrift(tierMap, baseline, ceiling) {
+  const recordedCeiling = Number.isFinite(baseline?.agentBoot?.ceilingBytes)
+    ? baseline.agentBoot.ceilingBytes
+    : AGENT_BOOT_CEILING_BYTES;
+  const effective = Number.isFinite(ceiling) ? ceiling : recordedCeiling;
+  const rows = new Map(
+    (baseline?.agentBoot?.files ?? []).map((f) => [f.path, f]),
+  );
+  const drift = [];
+  for (const file of tierMap?.tiers?.agentBoot ?? []) {
+    if (!Number.isFinite(file?.bytes)) continue;
+    const row = classifyBootRow(file, rows.get(file.path), effective);
+    if (row) drift.push(row);
+  }
+  return drift;
+}
+
+/**
+ * Render the agent-boot drift lines. `+` lines are permissive drift (gate
+ * fail); `-` lines are restrictive drift (informational). Each line states the
+ * **real** remaining headroom, so the author sizing the next edit reads the
+ * true number rather than re-deriving it from a row that just proved stale.
+ *
+ * @param {Array<ReturnType<typeof classifyBootRow>>} drift
+ * @returns {string[]}
+ */
+export function renderBootDrift(drift) {
+  return drift.map((d) => {
+    const marker = d.direction === 'permissive' ? '+' : '-';
+    const recorded =
+      d.recorded === null
+        ? 'has no recorded row'
+        : `records ${d.recorded} bytes but the file is ${d.actual}`;
+    const note =
+      d.direction === 'permissive'
+        ? 'the row overstates the headroom an author would size an edit against'
+        : 'the row is conservative — refresh at leisure';
+    return `${marker} agentBoot drift: ${d.path} ${recorded} — ${note} (real headroom ${d.headroomBytes})`;
+  });
+}
+
+/**
  * Parse argv for `--baseline <path>`, `--root <path>`, `--update`, `--json`.
  * Exported so unit tests can pin the parser.
  *
@@ -168,7 +277,14 @@ export function buildBaseline(tierMap, toleranceBytes) {
   // The agent-boot tier is recorded top-level (not under `tiers`) because it is
   // gated by a per-file ceiling, not the total-byte ratchet the `tiers` entries
   // use — keeping it out of `tiers` keeps the ratchet diff loop unambiguous.
-  const agentBootFiles = tierMap.tiers.agentBoot ?? [];
+  // Each row carries the headroom it leaves under the ceiling, so an author
+  // sizing an edit reads the remaining budget straight off the row (#4830)
+  // instead of re-deriving it — and `agentBootDrift` keeps both numbers honest.
+  const agentBootFiles = (tierMap.tiers.agentBoot ?? []).map((f) => ({
+    path: f.path,
+    bytes: f.bytes,
+    headroomBytes: AGENT_BOOT_CEILING_BYTES - f.bytes,
+  }));
   return {
     $schema: 'https://mandrel.dev/baselines/context-budget.schema.json',
     generatedAt: new Date().toISOString(),
@@ -353,7 +469,14 @@ export async function runCli({
     ? baseline.agentBoot.ceilingBytes
     : AGENT_BOOT_CEILING_BYTES;
   const bootOverflow = agentBootOverflow(tierMap, ceiling);
-  const exitCode = diff.grown.length > 0 || bootOverflow.length > 0 ? 1 : 0;
+  const bootDrift = agentBootDrift(tierMap, baseline, ceiling);
+  const permissiveDrift = bootDrift.filter((d) => d.direction === 'permissive');
+  const exitCode =
+    diff.grown.length > 0 ||
+    bootOverflow.length > 0 ||
+    permissiveDrift.length > 0
+      ? 1
+      : 0;
 
   if (json) {
     const envelope = {
@@ -370,6 +493,7 @@ export async function runCli({
       skipped: diff.skipped,
       agentBootCeilingBytes: ceiling,
       agentBootOverflow: bootOverflow,
+      agentBootDrift: bootDrift,
       workflowReachableBytes: tierMap.workflowClosure?.reachableTotalBytes ?? 0,
       exitCode,
     };
@@ -384,7 +508,15 @@ export async function runCli({
         `+ agentBoot: ${o.path} is ${o.bytes} bytes, over the ${o.ceiling}-byte per-agent ceiling\n`,
       );
     }
+    for (const line of renderBootDrift(bootDrift)) {
+      stdout.write(`${line}\n`);
+    }
     if (exitCode === 1) {
+      if (permissiveDrift.length > 0) {
+        stderr.write(
+          `[context-budget] ❌ a recorded agentBoot row understates the file it describes, so it overstates the headroom an author would size an edit against — refresh it with \`node .agents/scripts/check-context-budget.js --update\` (the ceiling is unchanged)\n`,
+        );
+      }
       if (bootOverflow.length > 0) {
         stderr.write(
           `[context-budget] ❌ a role-agent boot context exceeds the ${ceiling}-byte per-agent ceiling — trim the role def (the ceiling is a hard cap, not a starve target)\n`,

--- a/baselines/context-budget.json
+++ b/baselines/context-budget.json
@@ -172,19 +172,23 @@
     "files": [
       {
         "path": ".agents/agents/acceptance-critic.md",
-        "bytes": 7854
+        "bytes": 7854,
+        "headroomBytes": 338
       },
       {
         "path": ".agents/agents/auditor.md",
-        "bytes": 7945
+        "bytes": 7945,
+        "headroomBytes": 247
       },
       {
         "path": ".agents/agents/plan-critic.md",
-        "bytes": 5158
+        "bytes": 5158,
+        "headroomBytes": 3034
       },
       {
         "path": ".agents/agents/story-worker.md",
-        "bytes": 7317
+        "bytes": 8143,
+        "headroomBytes": 49
       }
     ]
   },

--- a/tests/check-context-budget.test.js
+++ b/tests/check-context-budget.test.js
@@ -6,6 +6,7 @@ import { test } from 'node:test';
 import { fileURLToPath } from 'node:url';
 import {
   AGENT_BOOT_CEILING_BYTES,
+  agentBootDrift,
   agentBootOverflow,
   buildBaseline,
   diffBudget,
@@ -209,9 +210,124 @@ test('buildBaseline records the agentBoot ceiling + files top-level (not under t
   // agentBoot MUST NOT leak into the ratcheted `tiers` set.
   assert.deepEqual(Object.keys(envelope.tiers).sort(), [...GATED_TIERS].sort());
   assert.equal(envelope.agentBoot.ceilingBytes, 8192);
+  // The recorded row carries the headroom an author sizing an edit needs, so
+  // reading the row does not require re-deriving it against the ceiling.
   assert.deepEqual(envelope.agentBoot.files, [
-    { path: '.agents/agents/retro.md', bytes: 1800 },
+    {
+      path: '.agents/agents/retro.md',
+      bytes: 1800,
+      headroomBytes: AGENT_BOOT_CEILING_BYTES - 1800,
+    },
   ]);
+});
+
+// ---------------------------------------------------------------------------
+// agentBootDrift — a recorded row that disagrees with the tree (Story #4830)
+// ---------------------------------------------------------------------------
+
+/** Build a `{ tierMap, baseline }` pair from `[path, recorded, actual]` rows. */
+function driftFixture(rows) {
+  return {
+    tierMap: {
+      tiers: {
+        agentBoot: rows.map(([p, , actual]) => ({ path: p, bytes: actual })),
+      },
+    },
+    baseline: {
+      agentBoot: {
+        ceilingBytes: AGENT_BOOT_CEILING_BYTES,
+        files: rows
+          .filter(([, recorded]) => recorded !== null)
+          .map(([p, recorded]) => ({
+            path: p,
+            bytes: recorded,
+            headroomBytes: AGENT_BOOT_CEILING_BYTES - recorded,
+          })),
+      },
+    },
+  };
+}
+
+test('agentBootDrift is empty when every recorded row matches the tree', () => {
+  const { tierMap, baseline } = driftFixture([
+    ['.agents/agents/a.md', 4000, 4000],
+    ['.agents/agents/b.md', 1234, 1234],
+  ]);
+  assert.deepEqual(agentBootDrift(tierMap, baseline), []);
+});
+
+test('agentBootDrift calls a row that understates its file permissive and reports the real headroom', () => {
+  const { tierMap, baseline } = driftFixture([
+    ['.agents/agents/story-worker.md', 7317, 8143],
+  ]);
+  const drift = agentBootDrift(tierMap, baseline);
+  assert.equal(drift.length, 1);
+  assert.deepEqual(drift[0], {
+    path: '.agents/agents/story-worker.md',
+    recorded: 7317,
+    actual: 8143,
+    delta: 826,
+    direction: 'permissive',
+    recordedHeadroom: AGENT_BOOT_CEILING_BYTES - 7317,
+    headroomBytes: AGENT_BOOT_CEILING_BYTES - 8143,
+  });
+});
+
+test('agentBootDrift calls a row that overstates its file restrictive — self-correcting, never a gate fail', () => {
+  const { tierMap, baseline } = driftFixture([
+    ['.agents/agents/a.md', 5000, 4000],
+  ]);
+  const drift = agentBootDrift(tierMap, baseline);
+  assert.equal(drift.length, 1);
+  assert.equal(drift[0].direction, 'restrictive');
+  assert.equal(drift[0].delta, -1000);
+});
+
+test('agentBootDrift treats an unrecorded boot context as permissive — no row promises unbounded headroom', () => {
+  const { tierMap, baseline } = driftFixture([
+    ['.agents/agents/new.md', null, 3000],
+  ]);
+  const drift = agentBootDrift(tierMap, baseline);
+  assert.equal(drift.length, 1);
+  assert.equal(drift[0].direction, 'permissive');
+  assert.equal(drift[0].recorded, null);
+  assert.equal(drift[0].recordedHeadroom, null);
+});
+
+test('agentBootDrift catches a stale recorded headroom even when the byte count agrees', () => {
+  const drift = agentBootDrift(
+    { tiers: { agentBoot: [{ path: '.agents/agents/a.md', bytes: 4000 }] } },
+    {
+      agentBoot: {
+        ceilingBytes: AGENT_BOOT_CEILING_BYTES,
+        files: [
+          { path: '.agents/agents/a.md', bytes: 4000, headroomBytes: 9999 },
+        ],
+      },
+    },
+  );
+  assert.equal(drift.length, 1);
+  assert.equal(drift[0].direction, 'permissive');
+  assert.equal(drift[0].headroomBytes, AGENT_BOOT_CEILING_BYTES - 4000);
+});
+
+test('the committed baseline carries no agentBoot drift against this repo tree', () => {
+  const repoRoot = path.resolve(
+    path.dirname(fileURLToPath(import.meta.url)),
+    '..',
+  );
+  const baseline = loadBaseline(
+    path.join(repoRoot, 'baselines', 'context-budget.json'),
+  );
+  const tierMap = {
+    tiers: {
+      agentBoot: (baseline.agentBoot?.files ?? []).map((f) => ({
+        path: f.path,
+        bytes: fs.statSync(path.join(repoRoot, f.path)).size,
+      })),
+    },
+  };
+  assert.deepEqual(agentBootDrift(tierMap, baseline), []);
 });
 
 // ---------------------------------------------------------------------------
@@ -313,6 +429,63 @@ test('runCli passes when role-agent boot contexts are within the ceiling', async
     stderr: makeSink(),
   });
   assert.equal(code, 0);
+});
+
+test('runCli exits 1 when a recorded row understates its boot context, even though the file is under the ceiling', async () => {
+  const { root, config } = makeRepo();
+  const bootFile = path.join(root, '.agents', 'agents', 'ok.md');
+  fs.mkdirSync(path.dirname(bootFile), { recursive: true });
+  fs.writeFileSync(bootFile, 'x'.repeat(4000));
+  await runCli({
+    argv: ['--update'],
+    cwd: root,
+    config,
+    stdout: makeSink(),
+    stderr: makeSink(),
+  });
+
+  // Grow the boot context by 1000 bytes — still far below the 8192 ceiling, so
+  // the overflow gate stays silent and only the drift check can see it.
+  fs.appendFileSync(bootFile, 'y'.repeat(1000));
+
+  const stdout = makeSink();
+  const stderr = makeSink();
+  const code = await runCli({ argv: [], cwd: root, config, stdout, stderr });
+  assert.equal(code, 1);
+  assert.match(stdout.text(), /\+ agentBoot drift: \.agents\/agents\/ok\.md/);
+  assert.match(stdout.text(), /records 4000 bytes but the file is 5000/);
+  // The real remaining headroom is stated, not left to the reader.
+  assert.match(stdout.text(), /real headroom 3192/);
+  assert.match(stderr.text(), /overstates the headroom/);
+});
+
+test('runCli exits 0 with an informational marker when a recorded row overstates its boot context', async () => {
+  const { root, config } = makeRepo();
+  const bootFile = path.join(root, '.agents', 'agents', 'ok.md');
+  fs.mkdirSync(path.dirname(bootFile), { recursive: true });
+  fs.writeFileSync(bootFile, 'x'.repeat(4000));
+  await runCli({
+    argv: ['--update'],
+    cwd: root,
+    config,
+    stdout: makeSink(),
+    stderr: makeSink(),
+  });
+
+  // The file shrank: the row is now conservative, and a conservative row can
+  // only make an author under-spend — it never buys headroom that is not there.
+  fs.writeFileSync(bootFile, 'x'.repeat(3000));
+
+  const stdout = makeSink();
+  const code = await runCli({
+    argv: [],
+    cwd: root,
+    config,
+    stdout,
+    stderr: makeSink(),
+  });
+  assert.equal(code, 0);
+  assert.match(stdout.text(), /- agentBoot drift: \.agents\/agents\/ok\.md/);
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #4830

_Auto-opened by `/deliver`._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to the context-budget CI script, its baseline JSON, and tests; no runtime product or auth paths.
> 
> **Overview**
> The context-budget checker now keeps **`agentBoot` baseline rows aligned with on-disk role defs**, so authors do not trust stale byte counts or headroom when sizing edits.
> 
> **`buildBaseline` / `baselines/context-budget.json`** add **`headroomBytes`** per boot file and refresh **`story-worker.md`** (7317 → 8143 bytes). New **`agentBootDrift`** treats **permissive** drift (missing row, understated size, or stale headroom) as a **gate failure** even when the file is still under the 8192-byte ceiling; **restrictive** drift prints a `-` line and stays exit 0. CLI and **`--json`** output include drift lines and **`real headroom`** in messages.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6b095f1548b7ab78300544e3a534bfa0b975820f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->