### PR TITLE
fix: deliver: stop routing a lite-shaped Story to inline dispatch when the run has concurrent siblings (#4829)

### DIFF
--- a/.agents/scripts/lib/orchestration/complexity-gate.js
+++ b/.agents/scripts/lib/orchestration/complexity-gate.js
@@ -31,15 +31,16 @@
  *      cardinality is deliberately not an axis (Story #4764).
  *   4. **Deliver re-derives.** `/deliver` computes the route from the fetched
  *      Story body via the **same** shape function at dispatch
- *      ({@link resolveStoryDispatchMode}) and honors it: a lite-shaped Story
- *      executes inline — no story-worker sub-agent boot, no fresh
- *      acceptance-critic dispatch — while every `single-story-close.js` gate
- *      runs unchanged. The `route::lite` label is a **human-visible hint
- *      only**, never the control signal: a lost label or an unread marker can
- *      no longer misroute delivery. Ahead of the shape read sits one
- *      shape-independent rule (Story #4736): a **single-Story run** is inline
- *      whatever its shape, because sub-agent isolation buys nothing when
- *      there is no concurrent sibling to isolate from.
+ *      ({@link resolveStoryDispatchMode}) and **reports** it, while the
+ *      dispatch *mode* answers a different question: may the engine run in the
+ *      router's own session? Only a **single-Story run** may (Story #4736) —
+ *      sub-agent isolation buys nothing when there is no concurrent sibling to
+ *      isolate from. Shape cannot grant that session (Story #4829): a lite body
+ *      makes work cheap, it does not conjure a second session for a sibling to
+ *      run in. The `route::lite` label is a **human-visible hint only**, never
+ *      the control signal: a lost label or an unread marker can no longer
+ *      misroute delivery. Either way every `single-story-close.js` gate runs
+ *      unchanged.
  *
  * The shape taxonomy is deliberately the one `review-depth.js` already
  * applies to the landed diff at close (`deriveChangeLevel` over the
@@ -864,27 +865,34 @@ function routeForReporting(body, opts) {
 /**
  * Decide how `/deliver` executes a Story.
  *
- * Two independent premises, checked in this order:
+ * **`inline` names one indivisible resource: the router's own session.** Two
+ * Stories cannot both own it, so exactly one premise can grant it —
+ * **run topology (Story #4736)**: a run resolving a *single* Story executes
+ * inline whatever its shape, because sub-agent isolation is load-bearing only
+ * for CONCURRENT dispatch (two workers sharing a checkout race on worktrees and
+ * branch refs) and a one-Story run has no sibling to race. It therefore pays
+ * the spawn premium (a boot is a cache WRITE at full rate, where an inline
+ * continuation is a cache read at ~10%; ~$1.43/M vs ~$1.07/M on comparable
+ * bench work) for nothing. That is a fact about the run, not about the work, so
+ * the shape gate's `enabled` switch — which governs *shape derivation* — does
+ * not reach it.
  *
- * 1. **Run topology (Story #4736).** A run delivering a *single* Story
- *    executes **inline**, whatever its shape. Sub-agent isolation is
- *    load-bearing only for CONCURRENT dispatch — two workers sharing a
- *    checkout would race on worktrees and branch refs — and a one-Story run
- *    has no sibling to race. It therefore pays the spawn premium (a boot is
- *    a cache WRITE at full rate, where an inline continuation is a cache read
- *    at ~10%; ~$1.43/M vs ~$1.07/M on comparable bench work) for nothing.
- *    This is a fact about the run, not about the work, so the shape gate's
- *    `enabled` switch — which governs *shape derivation* — does not reach it.
- * 2. **Shape (Story #4722 AC-4/AC-5).** For a multi-Story run, the decision
- *    comes **from the Story body's own shape**, never from the `route::lite`
- *    label: a lite-shaped Story executes inline; everything else — a
- *    full-shaped body, a missing/unparseable body, or the gate disabled via
- *    `planning.complexityGate.enabled=false` — dispatches as a sub-agent,
- *    the conservative default.
+ * **Shape cannot grant it (Story #4829).** The shape read used to return
+ * `inline` for any lite-shaped body in a multi-Story run, inheriting no
+ * topology guard. Measured twice on 2026-07-29: a two-Story and a three-Story
+ * run came back `inline` for *every* Story while `stories-wave-tick.js`
+ * reported the whole set ready under a concurrency cap of five — a router
+ * following both signals literally runs several engines over one session and
+ * one checkout, the precise hazard the sub-agent path exists to prevent. Both
+ * runs were completed only by an operator overriding the verdict by hand, which
+ * is an invariant held by judgment rather than by code. So this function has
+ * exactly **one** `inline` exit, guarded by the topology premise; every path
+ * below it returns `subagent`, and the derived shape is carried on `route` for
+ * reporting only. A lite shape makes the work cheap — it does not conjure a
+ * second session for a sibling to run in.
  *
- * The label is read only to report hint consistency in `reasons`: with the
- * label absent (or its write failed) a lite-shaped Story still runs inline,
- * and with the label present on a full-shaped Story the shape wins.
+ * The label is read only to report hint consistency in `reasons`; it never
+ * routes on either premise (Story #4722 AC-4/AC-5).
  *
  * Inline execution removes model-side fan-out only — it changes **where** the
  * engine runs, never **what** runs. Every deterministic
@@ -901,7 +909,8 @@ function routeForReporting(body, opts) {
  *   selectSensitivePathClassesFn?: Function,
  * }} [args] `storyCount` is the number of Stories the invoking `/deliver` run
  *   resolved. Omitted (or not a positive integer) means "unknown run size",
- *   which falls through to the shape decision — never to an assumed 1.
+ *   which cannot be shown sibling-free and therefore dispatches as a sub-agent
+ *   — never an assumed 1.
  * @returns {{ mode: 'inline'|'subagent', reasons: string[], route: ReturnType<typeof deriveStoryShape>|null }}
  */
 export function resolveStoryDispatchMode({
@@ -920,6 +929,8 @@ export function resolveStoryDispatchMode({
     ? `the ${LITE_ROUTE_LABEL} label is present (hint only — the derived shape is the control signal)`
     : `the ${LITE_ROUTE_LABEL} label is absent (hint only — the derived shape is the control signal)`;
 
+  // The ONLY `inline` exit in this function, and the guard is the whole
+  // contract: an inline verdict must mean the engine can actually run inline.
   if (storyCount === 1) {
     return {
       mode: 'inline',
@@ -956,23 +967,17 @@ export function resolveStoryDispatchMode({
     };
   }
 
+  // Past the topology guard a sibling may be dispatched concurrently, so the
+  // router's session is not available to anyone. The shape is still derived and
+  // returned on `route` — ceremony and reporting read it — but it decides
+  // nothing here: both shapes dispatch as a sub-agent.
   const route = deriveStoryRouteFromBody(body, {
     injectedRules,
     selectSensitivePathClassesFn,
   });
-  if (route.route === 'lite') {
-    return {
-      mode: 'inline',
-      reasons: [
-        `lite-shaped Story — execute deliver-story inline; no story-worker or acceptance-critic sub-agent dispatch (close gates unchanged): ${route.reasons[0]}`,
-        hintNote,
-      ],
-      route,
-    };
-  }
-  return {
-    mode: 'subagent',
-    reasons: [`full-shaped Story — ${route.reasons[0]}`, hintNote],
-    route,
-  };
+  const shapeNote =
+    route.route === 'lite'
+      ? `lite-shaped Story in a multi-Story run — the shape is inline-eligible but the router's session is not: a concurrent sibling would have to share it, racing worktrees and branch refs; sub-agent dispatch (${route.reasons[0]})`
+      : `full-shaped Story — ${route.reasons[0]}`;
+  return { mode: 'subagent', reasons: [shapeNote, hintNote], route };
 }

--- a/.agents/scripts/lib/orchestration/resolve-stories.js
+++ b/.agents/scripts/lib/orchestration/resolve-stories.js
@@ -317,21 +317,24 @@ export function buildStoriesEnvelope({
   const inSetDone = sorted.filter(isSatisfiedBlocker).map((s) => s.id);
   return {
     kind: 'stories',
-    // `dispatchMode` (Story #4722): the resolver derives the per-Story
-    // execution mode from the fetched Story BODY's own shape (the shared
-    // shape function in `complexity-gate.js`) so `/deliver` reads one field —
-    // `inline` (lite-shaped: no story-worker / acceptance-critic sub-agent
-    // boots) or `subagent` (everything else, the conservative default). The
-    // `route::lite` label is a human-visible hint only, never the control
-    // signal: a lost label cannot misroute delivery. Model-side fan-out
-    // only; close gates are untouched.
+    // `dispatchMode` (Story #4722, #4736, #4829): the resolver reports the
+    // per-Story execution mode so `/deliver` reads one field — `inline` (run
+    // deliver-story in the router's own session: no story-worker /
+    // acceptance-critic sub-agent boots) or `subagent` (the conservative
+    // default). Model-side fan-out only; close gates are untouched.
     //
-    // `storyCount` (Story #4736) carries the run's topology into that same
-    // decision: a run resolving exactly ONE Story is inline whatever its
-    // shape, because the isolation a sub-agent buys only matters against a
-    // concurrently-dispatched sibling. It is the resolved set size — not the
-    // undelivered remainder — so the mode a caller reads for a given `--ids`
-    // list never changes as siblings land mid-run.
+    // `storyCount` is the premise that decides it, and it is this call site's
+    // load-bearing argument: `inline` names the router's ONE session, so it is
+    // granted only to a run resolving exactly ONE Story, which has no
+    // concurrent sibling to share that session with. Passing the resolved set
+    // size here is therefore what makes the envelope self-consistent with the
+    // ready set `stories-wave-tick.js` computes from the same `dag`: a set of
+    // more than one can never come back with a Story claiming the session
+    // (Story #4829 — it previously could, whenever the body was lite-shaped).
+    // It is the resolved set size, NOT the undelivered remainder, so the mode
+    // a caller reads for a given `--ids` list never changes as siblings land
+    // mid-run. The `route::lite` label is a human-visible hint only, never the
+    // control signal.
     stories: sorted.map(({ id, title, body, url, labels, state }) => ({
       id,
       title,

--- a/.agents/workflows/helpers/deliver-digest.md
+++ b/.agents/workflows/helpers/deliver-digest.md
@@ -20,16 +20,18 @@ description: >-
 
 ## 1. Dispatch — where the engine runs
 
-Read `stories[].dispatchMode` from the `resolve-stories.js` envelope. Two
-rules produce it, in order:
+Read `stories[].dispatchMode` from the `resolve-stories.js` envelope.
+`inline` names one indivisible resource — **the router's own session** — so one
+rule produces it:
 
 1. **Run topology.** A run resolving **one** Story is `inline`
    whatever its shape — sub-agent isolation is load-bearing only against a
    *concurrent* sibling racing the same checkout, and a one-Story run has none.
-2. **Body shape.** In a multi-Story run, a lite-shaped body is
-   `inline`; a full-shaped body, an unparseable one, or a footprint touching a
-   sensitive-path class is `subagent`. The `route::lite` label is a
-   human-visible hint, never the control signal.
+2. **Every other run is `subagent`.** A multi-Story run dispatches every Story
+   as a sub-agent however trivial its shape: a lite body does not conjure a
+   second session for a sibling to run in, and the wave tick may hand you the
+   whole set on one beat. Shape still sets ceremony and is reported alongside;
+   the `route::lite` label is a human-visible hint, never the control signal.
 
 `inline` removes model-side fan-out only — no `story-worker` boot, no fresh
 acceptance-critic spawn. **`subagent` and `inline` run the same engine**: same

--- a/.agents/workflows/helpers/deliver-reference.md
+++ b/.agents/workflows/helpers/deliver-reference.md
@@ -61,23 +61,26 @@ a cache write at full rate; an inline continuation is a cache read at ~10%).
 retained in full for multi-Story waves, and the rule changes **where** the
 engine runs, never what runs — gates, PR, and terminal envelope are identical.
 
-**Lite-shaped Stories execute inline.** Before spawning anything,
-read the Story's `dispatchMode` from the resolver envelope
-(`stories[].dispatchMode`, derived by `resolveStoryDispatchMode` in
-`lib/orchestration/complexity-gate.js` **from the fetched Story body's own
-shape** — `changes[]` count, acceptance count, creates-vs-refactors mix, and
-sensitive-path classes; the `route::lite` label is a human-visible hint only,
-never the control signal, so a lost or never-written label cannot misroute
-delivery): a Story with `dispatchMode: "inline"` executes
-[`deliver-story.md`](deliver-story.md) **inline in this session** — no
+**Read the mode; never infer it from shape.** Before spawning
+anything, read the Story's `dispatchMode` from the resolver envelope
+(`stories[].dispatchMode`, produced by `resolveStoryDispatchMode` in
+`lib/orchestration/complexity-gate.js`). A Story with `dispatchMode: "inline"`
+executes [`deliver-story.md`](deliver-story.md) **inline in this session** — no
 `story-worker` sub-agent boot and no fresh acceptance-critic sub-agents
 (sub-agent boots are the dominant deliver-phase token cost at trivial scope) —
 threading the same `docsDigestPath` / `checklistPath` / change-set discipline
 as a spawned worker. Inline removes model-side fan-out only: every
 `single-story-close.js` gate, the PR to `main`, and the terminal envelope are
-identical. Everything else — a full-shaped body, a missing/unparseable body,
-or a footprint intersecting a sensitive-path class (sensitivity wins and
-keeps the fresh acceptance critic) — takes the standard sub-agent path.
+identical.
+
+**A trivial shape does not buy that session.** Only the
+one-Story rule above yields `inline`; every Story of a multi-Story run comes
+back `subagent` however lite its body, because the ready set below may offer
+several Stories on one beat and a session cannot be split between them. The
+Story's derived shape is still reported (it sets ceremony, and a sensitive
+footprint keeps the fresh acceptance critic), and the `route::lite` label
+remains a human-visible hint only, never the control signal — a lost or
+never-written label cannot misroute delivery.
 
 **Dispatch each `ready` Story (role-scoped by default).** When
 `delivery.routing.roleScopedAgents` is enabled (the **default**) and the host

--- a/.agents/workflows/helpers/deliver-story-reference.md
+++ b/.agents/workflows/helpers/deliver-story-reference.md
@@ -133,23 +133,25 @@ and the `rules/security-baseline.md` MUSTs all run exactly as for a
 full-ceremony Story. The lite route's `preserves` field is the machine-readable
 record of those non-negotiables; there is no lite-specific gate bypass.
 
-**Deliver derives the route from the Story body's shape.**
-Persist stamps a lite cohort's Stories with the `route::lite` label as a
-*human-visible hint only* (and ledgers the authored verdict — recorded
-reason plus per-Story shape evidence — on the `story-plan-state`
-checkpoint); the label is never the control signal. `/deliver` computes the
-route from the fetched Story body via `resolveStoryDispatchMode`
-(`lib/orchestration/complexity-gate.js`) — the same shape taxonomy
-`deriveChangeLevel` applies to the landed diff at close: `changes[]` count,
-acceptance count, creates-vs-refactors mix, sensitive-path classes. A
-lite-shaped Story executes **inline in the deliver session** — even when the
-label is absent or its write failed — with no `story-worker` sub-agent boot,
-and the Step 1a acceptance self-eval runs its critics **inline** (no
-fresh-context acceptance-critic sub-agent dispatch; sub-agent boots are the
-dominant deliver-phase token cost at trivial scope). A footprint
-intersecting a sensitive-path class derives `full` — sensitivity wins, and
-the Story keeps its fresh acceptance critic. Inline execution
-changes the isolation only: the engine, every script gate, and the
+**Deliver derives the route from the Story body's shape — and the
+dispatch mode from the run.** Persist stamps a lite cohort's Stories with the
+`route::lite` label as a *human-visible hint only* (and ledgers the authored
+verdict — recorded reason plus per-Story shape evidence — on the
+`story-plan-state` checkpoint); the label is never the control signal.
+`/deliver` computes the route from the fetched Story body via
+`resolveStoryDispatchMode` (`lib/orchestration/complexity-gate.js`) — the same
+shape taxonomy `deriveChangeLevel` applies to the landed diff at close:
+`changes[]` count, acceptance count, creates-vs-refactors mix, sensitive-path
+classes. A footprint intersecting a sensitive-path class derives `full` —
+sensitivity wins, and the Story keeps its fresh acceptance critic.
+
+That derived route sets ceremony. It does **not** set the dispatch mode,
+because `inline` names one indivisible resource — the router's own session —
+and only run topology can say whether it is free: a **single-Story run**
+executes inline, and every Story of a multi-Story run dispatches as a
+`story-worker` sub-agent whatever its shape — a lite shape makes the work
+cheap, it does not conjure a second session for a sibling. Inline
+execution changes the isolation only: the engine, every script gate, and the
 terminal envelope are byte-identical either way.
 
 ---
@@ -247,10 +249,10 @@ Resolve fresh-vs-inline acceptance critics per AC-cluster with
 floor forces `fresh`). Review depth reads the same derived level via
 `review-depth.js` inside close, so the two decisions cannot disagree.
 
-**Lite-route override.** When the Story's body derives the
-lite shape (`resolveStoryDispatchMode` → `inline`), run every
-acceptance critic **inline** — do not spawn fresh-context critic sub-agents
-regardless of what the profile would otherwise resolve. The self-eval rigor
+**Inline-dispatch override.** When the Story dispatches
+`inline` (`resolveStoryDispatchMode` → `inline`, i.e. a single-Story run), run
+every acceptance critic **inline** — do not spawn fresh-context critic
+sub-agents regardless of what the profile would otherwise resolve. The self-eval rigor
 (scoring each `acceptance[]` item against the one computed change set, with
 `verify[]` output as evidence) is unchanged; only the sub-agent boot is
 removed. Hard gates are untouched.

--- a/.agents/workflows/helpers/deliver-story.md
+++ b/.agents/workflows/helpers/deliver-story.md
@@ -22,8 +22,8 @@ mandatoryReads: [deliver-digest.md]
 
 ## Overview
 
-The **one** delivery engine in v2 — every Story (a lite-**shaped** Story
-runs inline with inline critics; engine, gates, envelope byte-identical):
+The **one** delivery engine in v2 — every Story (a **one-Story** run
+goes inline with inline critics; engine, gates, envelope byte-identical):
 
 ```text
 single-story-init.js → implement + commits → derived-level ceremony

--- a/.agents/workflows/helpers/plan-reference.md
+++ b/.agents/workflows/helpers/plan-reference.md
@@ -120,10 +120,11 @@ decision:
 lite cohort's Stories with **`route::lite`** as a *human-visible hint only* —
 `/deliver` computes the route from each fetched Story body via the same shape
 function at dispatch, so neither a lost label nor an unread marker can
-misroute delivery: a lite-shaped Story executes **inline** (no story-worker
-or acceptance-critic sub-agent boots) even with the label absent, and a
-sensitive-footprint Story routes `full` and keeps its fresh critic even with
-the label present. The `route::*` axis stays runtime-derived: hand-authored
+misroute delivery: a lite-shaped Story derives `lite` even with the label
+absent, and a sensitive-footprint Story routes `full` and keeps its fresh
+critic even with the label present. The derived route sets ceremony, not
+where the engine runs — sub-agent boots are collapsed by a **single-Story
+run**, never by a trivial shape. The `route::*` axis stays runtime-derived: hand-authored
 `route::*` entries in `labels[]` are dropped by persist.
 
 The knobs (`planning.complexityGate.{enabled, maxArtifacts}`) are documented

--- a/tests/lib/orchestration/complexity-gate.test.js
+++ b/tests/lib/orchestration/complexity-gate.test.js
@@ -193,6 +193,7 @@ describe('deriveStoryShape — the deterministic backstop (AC-1, AC-3)', () => {
         changes: [{ path: 'bin/hello.js', assumption: 'creates' }],
         acceptance: ['prints hello'],
       }),
+      storyCount: 1,
       injectedRules: RULES,
     });
     assert.equal(decision.route.route, 'lite');
@@ -509,15 +510,15 @@ describe('resolveStoryDispatchMode — body-derived dispatch (AC-4, AC-5)', () =
     acceptance: ['both sides agree'],
   });
 
-  test('AC-5: a lite-shaped Story executes inline with the route::lite label ABSENT', () => {
+  test('AC-5: a lite-shaped Story derives lite with the route::lite label ABSENT', () => {
     const decision = resolveStoryDispatchMode({
       body: liteBody,
       labels: ['type::story', 'agent::ready'],
+      storyCount: 1,
       injectedRules: RULES,
     });
     assert.equal(decision.mode, 'inline');
     assert.equal(decision.route.route, 'lite');
-    assert.match(decision.reasons[0], /close gates unchanged/i);
     assert.match(
       decision.reasons.at(-1),
       /hint only/i,
@@ -525,13 +526,19 @@ describe('resolveStoryDispatchMode — body-derived dispatch (AC-4, AC-5)', () =
     );
   });
 
-  test('the label present on a lite-shaped Story is consistent — still inline', () => {
+  test('the label present on a lite-shaped Story is consistent — the derived route is unchanged', () => {
     const decision = resolveStoryDispatchMode({
       body: liteBody,
       labels: ['type::story', LITE_ROUTE_LABEL],
+      storyCount: 2,
       injectedRules: RULES,
     });
-    assert.equal(decision.mode, 'inline');
+    assert.equal(decision.route.route, 'lite');
+    assert.equal(
+      decision.mode,
+      'subagent',
+      'the label cannot buy a session a concurrent sibling also needs',
+    );
   });
 
   test('the label NEVER routes: a full-shaped Story with route::lite dispatches subagent', () => {
@@ -688,7 +695,7 @@ describe('resolveStoryDispatchMode — run topology (Story #4736)', () => {
     );
   });
 
-  test('an unknown or non-single run size falls through to the shape decision', () => {
+  test('an unknown or non-single run size is conservative sub-agent dispatch', () => {
     for (const storyCount of [undefined, null, 0, '1', 1.5, -1]) {
       const decision = resolveStoryDispatchMode({
         body: fullBody,
@@ -701,6 +708,116 @@ describe('resolveStoryDispatchMode — run topology (Story #4736)', () => {
         `storyCount=${String(storyCount)} must never be read as a single-Story run`,
       );
     }
+  });
+});
+
+/**
+ * Story #4829 — an `inline` verdict must mean the engine can actually run
+ * inline.
+ *
+ * `inline` names the router's OWN session (deliver-digest § 1). The shape path
+ * used to return it for any lite-shaped body in a multi-Story run, inheriting
+ * none of the topology guard the one-Story rule states for itself. Measured
+ * twice on 2026-07-29 — `/deliver 4824 4825` and `/deliver 4828 4829 4830` —
+ * every Story came back `inline` while `stories-wave-tick.js` reported the
+ * whole set ready under a concurrency cap of five. A router following both
+ * literally runs two or three engines over one session and one checkout. Both
+ * runs were rescued by an operator serialising by hand, which is the invariant
+ * being held by judgment rather than by code.
+ *
+ * These tests pin the two measured cases and the general law behind them.
+ */
+describe('resolveStoryDispatchMode — inline is one session, so one Story (#4829)', () => {
+  /** The shape that used to buy `inline` unconditionally. */
+  const liteBody = storyBody({
+    changes: [{ path: 'bin/hello.js', assumption: 'creates' }],
+    acceptance: ['prints hello'],
+  });
+  const fullBody = storyBody({
+    changes: [
+      { path: 'apps/api/src/handler.js', assumption: 'refactors-existing' },
+      { path: 'apps/web/src/page.js', assumption: 'refactors-existing' },
+    ],
+    acceptance: ['both sides agree'],
+  });
+
+  test('AC-1: the measured two-Story and three-Story runs no longer claim the session', () => {
+    for (const storyCount of [2, 3]) {
+      const decision = resolveStoryDispatchMode({
+        body: liteBody,
+        labels: ['type::story', LITE_ROUTE_LABEL],
+        storyCount,
+        injectedRules: RULES,
+      });
+      assert.equal(
+        decision.mode,
+        'subagent',
+        `a lite-shaped Story in a ${storyCount}-Story run must not be told to run in the router's own session`,
+      );
+      assert.equal(
+        decision.route.route,
+        'lite',
+        'the derived shape is still reported — only its authority over dispatch is gone',
+      );
+      assert.match(
+        decision.reasons[0],
+        /concurrent sibling/i,
+        'the reason must name the premise, so a reader sees WHY a lite shape did not buy inline',
+      );
+    }
+  });
+
+  test('AC-2: the single-Story inline rule is untouched, whatever the shape', () => {
+    for (const body of [liteBody, fullBody, '   ']) {
+      const decision = resolveStoryDispatchMode({
+        body,
+        labels: ['type::story'],
+        storyCount: 1,
+        injectedRules: RULES,
+      });
+      assert.equal(decision.mode, 'inline');
+      assert.match(decision.reasons[0], /single-Story run/i);
+    }
+  });
+
+  test('AC-3: inline implies a resolved set of exactly one — no input contradicts a ready set', () => {
+    // The law, not an example: across every shape, label, gate setting and run
+    // size, an `inline` verdict can only come back for a one-Story run. A ready
+    // set of N > 1 therefore cannot coexist with a Story owning the session.
+    const bodies = [liteBody, fullBody, '', undefined];
+    const labelSets = [[], [LITE_ROUTE_LABEL], ['type::story']];
+    const configs = [
+      undefined,
+      { planning: { complexityGate: { enabled: false } } },
+    ];
+    let inlineSeen = 0;
+    for (const storyCount of [1, 2, 3, 4, 5]) {
+      for (const body of bodies) {
+        for (const labels of labelSets) {
+          for (const config of configs) {
+            const { mode } = resolveStoryDispatchMode({
+              body,
+              labels,
+              config,
+              storyCount,
+              injectedRules: RULES,
+            });
+            if (mode === 'inline') {
+              inlineSeen += 1;
+              assert.equal(
+                storyCount,
+                1,
+                `inline returned for a ${storyCount}-Story run (body=${String(body).slice(0, 24)}, labels=${labels.join('|')}) — the router cannot give one session to ${storyCount} Stories`,
+              );
+            }
+          }
+        }
+      }
+    }
+    assert.ok(
+      inlineSeen > 0,
+      'no inline verdict was produced at all — the law would hold vacuously and prove nothing',
+    );
   });
 });
 
@@ -787,7 +904,6 @@ describe('persist ↔ deliver route round-trip — one shape, two read points', 
         }),
       },
       expectedRoute: 'lite',
-      expectedMode: 'inline',
     },
     {
       name: 'an epic-scope Story routes full from both representations',
@@ -804,7 +920,6 @@ describe('persist ↔ deliver route round-trip — one shape, two read points', 
         }),
       },
       expectedRoute: 'full',
-      expectedMode: 'subagent',
     },
     {
       name: 'a sensitive-footprint Story routes full from both representations',
@@ -818,11 +933,10 @@ describe('persist ↔ deliver route round-trip — one shape, two read points', 
         }),
       },
       expectedRoute: 'full',
-      expectedMode: 'subagent',
     },
   ];
 
-  for (const { name, ticket, expectedRoute, expectedMode } of cases) {
+  for (const { name, ticket, expectedRoute } of cases) {
     test(name, () => {
       const { stories } = assemblePlanStories([ticket]);
 
@@ -836,6 +950,7 @@ describe('persist ↔ deliver route round-trip — one shape, two read points', 
       const deliverSide = resolveStoryDispatchMode({
         body: stories[0].body,
         labels: [],
+        storyCount: 2,
         injectedRules: RULES,
       });
 
@@ -845,7 +960,10 @@ describe('persist ↔ deliver route round-trip — one shape, two read points', 
         persistSide.route,
         'persist and deliver derived different routes from the same Story',
       );
-      assert.equal(deliverSide.mode, expectedMode);
+      // The ROUTE is what round-trips. The MODE is not a function of shape at
+      // all (Story #4829): in a two-Story run every shape dispatches as a
+      // sub-agent, because the router has one session and two Stories.
+      assert.equal(deliverSide.mode, 'subagent');
     });
   }
 });

--- a/tests/scripts/resolve-stories.test.js
+++ b/tests/scripts/resolve-stories.test.js
@@ -302,14 +302,17 @@ describe('buildStoriesEnvelope — per-Story dispatchMode (Story #4722)', () => 
       issue({ number: 99, body: storyBody({ changes: ['src/filler.js'] }) }),
     );
 
-  it('AC-5: derives inline from the BODY shape with the route::lite label absent', () => {
+  it('AC-5: a lite-shaped body in a multi-Story set dispatches subagent (#4829)', () => {
     // One refactor + one acceptance criterion, no sensitive path: a
-    // lite-shaped body. No label anywhere — the shape is the control signal.
+    // lite-shaped body — which USED to come back `inline` here. It cannot:
+    // `inline` means the router's own session, and this set has a sibling that
+    // may be dispatched on the same beat. The shape still decides ceremony;
+    // it no longer decides where the engine runs.
     const env = buildStoriesEnvelope({
       stories: [toStoryRecord(issue({ number: 1 })), filler()],
       injectedRules: RULES,
     });
-    assert.equal(env.stories[0].dispatchMode, 'inline');
+    assert.equal(env.stories[0].dispatchMode, 'subagent');
   });
 
   it('AC-4/AC-5: the route::lite label never routes — a full-shaped body dispatches subagent', () => {
@@ -415,6 +418,77 @@ describe('buildStoriesEnvelope — single-Story runs dispatch inline (Story #473
       injectedRules: RULES,
     });
     assert.equal(env.stories[0].dispatchMode, 'subagent');
+  });
+});
+
+/**
+ * Story #4829 — the resolver's dispatch modes and the wave tick's ready set
+ * are two answers to one run, and they must not contradict each other.
+ *
+ * Measured twice on 2026-07-29 (`/deliver 4824 4825`, `/deliver 4828 4829
+ * 4830`): every Story resolved `inline` while the tick reported the whole set
+ * ready under a cap of five. `inline` means the router's own session, so that
+ * pair of answers instructs one session to run two — then three — engines over
+ * one checkout. This asserts them TOGETHER, from one envelope, because
+ * asserting either alone is exactly how the contradiction survived.
+ */
+describe('buildStoriesEnvelope ↔ ready set — one run, one consistent answer', () => {
+  /** A lite-shaped body per Story, with a disjoint footprint so the
+   *  overlap guard never masks the result by serialising the beat itself. */
+  const liteStory = (number) =>
+    toStoryRecord(
+      issue({
+        number,
+        body: storyBody({ changes: [`src/feature-${number}.js`] }),
+      }),
+    );
+
+  for (const ids of [
+    [4824, 4825],
+    [4828, 4829, 4830],
+  ]) {
+    it(`the measured ${ids.length}-Story run: no Story claims the session the tick fans out from`, () => {
+      const stories = ids.map(liteStory);
+      const env = buildStoriesEnvelope({ stories, injectedRules: RULES });
+
+      // The tick's view of the same run: every Story ready, cap 5 — the
+      // reported condition, reproduced rather than assumed.
+      const ready = selectReadySet({
+        stories: stories.map((s) => ({
+          id: s.id,
+          dependsOn: [],
+          files: [`src/feature-${s.id}.js`],
+        })),
+        doneIds: new Set(),
+        inFlight: 0,
+        globalCap: 5,
+      }).map((s) => s.id);
+      assert.deepEqual(ready, ids, 'the measured ready set must reproduce');
+
+      const inline = env.stories.filter((s) => s.dispatchMode === 'inline');
+      assert.deepEqual(
+        inline,
+        [],
+        `${ready.length} Stories are dispatchable on one beat, so none of them may be told to run in the router's single session`,
+      );
+    });
+  }
+
+  it('a one-Story run keeps inline — and its ready set is the one Story', () => {
+    const stories = [liteStory(4829)];
+    const env = buildStoriesEnvelope({ stories, injectedRules: RULES });
+    const ready = selectReadySet({
+      stories: [{ id: 4829, dependsOn: [], files: ['src/feature-4829.js'] }],
+      doneIds: new Set(),
+      inFlight: 0,
+      globalCap: 5,
+    });
+    assert.equal(ready.length, 1);
+    assert.equal(
+      env.stories[0].dispatchMode,
+      'inline',
+      'a ready set of one and an inline verdict agree — that is the rule being preserved, not narrowed',
+    );
   });
 });
 


### PR DESCRIPTION
Closes #4829

_Auto-opened by `/deliver`._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes orchestration dispatch semantics for multi-Story `/deliver` waves (more sub-agent spawns, fewer false inline paths); behavior is well-tested but affects concurrent delivery routing.
> 
> **Overview**
> Fixes a dispatch bug where **lite-shaped Stories in multi-Story runs** were marked `dispatchMode: "inline"` even when the wave tick could hand several Stories on one beat—inviting multiple engines on one session and checkout (#4829).
> 
> **`resolveStoryDispatchMode`** now has a single `inline` exit: `storyCount === 1`. For two or more Stories, every Story returns `subagent` regardless of body shape; derived **lite/full route** is still computed on `route` for ceremony and reporting only. Unknown or invalid `storyCount` stays conservative (`subagent`), not shape-based inline.
> 
> Workflow helpers (`deliver-digest`, `deliver-reference`, `deliver-story-reference`, `plan-reference`, `deliver-story`) are updated so operators read **`dispatchMode` from the resolver** and do not infer inline from a trivial shape; acceptance critic inline override is tied to **inline dispatch** (single-Story), not lite route alone.
> 
> Tests add Story **#4829** coverage (measured 2/3-Story cases, combinatorial “inline ⇒ storyCount 1”) and adjust envelope/wave-tick integration so a ready set of N>1 never includes `inline`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 907148e47e911acd7f811b26e43016fec8a54df9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->