### PR TITLE
fix: feedback-loop: make the roll-up file its actionable proposals, and make an all-empty result legible (#4828)

### DIFF
--- a/.agents/scripts/lib/feedback-loop/graduator-core.js
+++ b/.agents/scripts/lib/feedback-loop/graduator-core.js
@@ -47,6 +47,7 @@
 import { spawn as defaultSpawn } from 'node:child_process';
 import { createHash } from 'node:crypto';
 
+import { LABEL_COLORS } from '../label-constants.js';
 import { classifyPathSource as defaultClassifier } from '../observability/source-classifier.js';
 import {
   structuredCommentMarker,
@@ -399,6 +400,185 @@ async function confirmMarkerFiled({
   }
 }
 
+/** Prefix of the per-category friction axis the feedback loop mints. */
+const FRICTION_LABEL_PREFIX = 'friction::';
+
+/**
+ * Resolve the color + description for a label the feedback loop is about to
+ * mint. Only two axes reach this path — `meta::*` (routing) and
+ * `friction::<category>` (the telemetry bucket) — so the mapping is a
+ * two-branch lookup rather than a registry.
+ *
+ * @param {string} name
+ * @returns {{ color: string, description: string }}
+ */
+function describeMintedLabel(name) {
+  if (name.startsWith(FRICTION_LABEL_PREFIX)) {
+    return {
+      color: LABEL_COLORS.FRICTION,
+      description: `Recurring friction category "${name.slice(FRICTION_LABEL_PREFIX.length)}" (minted by the feedback loop)`,
+    };
+  }
+  return {
+    color: LABEL_COLORS.META,
+    description: 'Feedback-loop routing axis (minted by the feedback loop)',
+  };
+}
+
+/**
+ * Read the routed repo's live label names once per repo, memoized in
+ * `labelCache`. Returns `null` when the set could not be established —
+ * "verification unavailable", which is deliberately NOT the same as "the repo
+ * has no labels": an unreadable set must not be read as proof that every
+ * label is missing.
+ *
+ * @returns {Promise<{ known: Set<string>|null, error: string|null }>}
+ */
+async function readLiveLabelNames({
+  owner,
+  repo,
+  labelCache,
+  ghPath,
+  spawnImpl,
+  cwd,
+  timeoutMs,
+}) {
+  const key = `${owner}/${repo}`;
+  const cached = labelCache?.get(key);
+  if (cached) return { known: cached, error: null };
+  const res = await runChild({
+    cmd: ghPath,
+    args: ['label', 'list', '--repo', key, '--limit', '500', '--json', 'name'],
+    spawnImpl,
+    cwd,
+    timeoutMs,
+  });
+  if (res.spawnError || (typeof res.code === 'number' && res.code !== 0)) {
+    return {
+      known: null,
+      error: `gh label list ${key} failed: ${res.spawnError?.message ?? (res.stderr || '').trim()}`,
+    };
+  }
+  let parsed;
+  try {
+    parsed = JSON.parse(res.stdout || '[]');
+  } catch {
+    return {
+      known: null,
+      error: `gh label list ${key} returned unparseable JSON`,
+    };
+  }
+  if (!Array.isArray(parsed)) {
+    return { known: null, error: `gh label list ${key} returned a non-array` };
+  }
+  const known = new Set();
+  for (const row of parsed) {
+    if (row && typeof row.name === 'string') known.add(row.name);
+  }
+  labelCache?.set(key, known);
+  return { known, error: null };
+}
+
+/**
+ * Mint any of `labels` the routed repo does not already carry, so
+ * `gh issue create --label …` can attach them (Story #4828).
+ *
+ * **Why this exists.** `gh issue create` resolves every `--label` name against
+ * the repo before it creates anything, and fails the whole call when one is
+ * absent. The feedback loop mints two axes that no bootstrap can enumerate
+ * ahead of time — `meta::consumer-improvement` is absent from `LABEL_TAXONOMY`
+ * outright, and `friction::<category>` names come from live telemetry — so on
+ * a repo that never had them, *every* filing failed. The failure landed in the
+ * graduator's `errors[]`, which the run epilogue did not surface, so a
+ * hard-failing feedback loop rendered as `filed: 0`: indistinguishable from
+ * "nothing was actionable".
+ *
+ * Degrades rather than blocks: when the live set cannot be read, this returns
+ * no `missing` entries so the caller still attempts the filing (the old
+ * behaviour) instead of refusing on an unproven premise.
+ *
+ * @param {object} opts
+ * @param {string} opts.owner
+ * @param {string} opts.repo
+ * @param {string[]} opts.labels
+ * @param {Map<string, Set<string>>} [opts.labelCache] — per-repo live-set memo.
+ * @param {string} [opts.ghPath]
+ * @param {Function} [opts.spawnImpl]
+ * @param {string} [opts.cwd]
+ * @param {number} [opts.timeoutMs]
+ * @returns {Promise<{ created: string[], missing: string[], errors: string[] }>}
+ */
+async function ensureIssueLabels({
+  owner,
+  repo,
+  labels,
+  labelCache,
+  ghPath = 'gh',
+  spawnImpl,
+  cwd,
+  timeoutMs,
+}) {
+  const wanted = (Array.isArray(labels) ? labels : []).filter(
+    (name) => typeof name === 'string' && name.trim().length > 0,
+  );
+  if (wanted.length === 0) return { created: [], missing: [], errors: [] };
+
+  const { known, error } = await readLiveLabelNames({
+    owner,
+    repo,
+    labelCache,
+    ghPath,
+    spawnImpl,
+    cwd,
+    timeoutMs,
+  });
+  // Verification unavailable — attempt the filing anyway rather than refuse.
+  if (!known) return { created: [], missing: [], errors: error ? [error] : [] };
+
+  const created = [];
+  const missing = [];
+  const errors = [];
+  for (const name of wanted) {
+    if (known.has(name)) continue;
+    const { color, description } = describeMintedLabel(name);
+    const res = await runChild({
+      cmd: ghPath,
+      args: [
+        'label',
+        'create',
+        name,
+        '--repo',
+        `${owner}/${repo}`,
+        '--color',
+        color.replace(/^#/, ''),
+        '--description',
+        description,
+      ],
+      spawnImpl,
+      cwd,
+      timeoutMs,
+    });
+    const failed =
+      Boolean(res.spawnError) ||
+      (typeof res.code === 'number' && res.code !== 0);
+    // A concurrent roll-up may have minted it between the list and the create;
+    // that is the idempotent outcome, not a failure.
+    const raced = /label\b[\s\S]*?already exists/i.test(
+      `${res.stderr ?? ''}${res.spawnError?.message ?? ''}`,
+    );
+    if (!failed || raced) {
+      known.add(name);
+      if (!raced) created.push(name);
+      continue;
+    }
+    missing.push(name);
+    errors.push(
+      `gh label create "${name}" in ${owner}/${repo} failed: ${res.spawnError?.message ?? (res.stderr || '').trim()}`,
+    );
+  }
+  return { created, missing, errors };
+}
+
 /**
  * File a new follow-up issue via `gh issue create` and resolve to
  * `{ url, error }`. On success `url` is the trimmed stdout and `error` is
@@ -572,6 +752,7 @@ async function processGraduateFinding({
   maxFilingsPerRun,
   crossRepoDeferred,
   filedMarkers,
+  labelCache,
   logger,
   spec,
 }) {
@@ -656,6 +837,27 @@ async function processGraduateFinding({
     epicId,
     idMarker: contentMarker,
   });
+
+  // Mint any routing label the repo does not carry yet (Story #4828). This
+  // runs BEFORE the strong read as well as before the create: `gh issue list
+  // --label <absent>` exits 0 with `[]`, so an absent label silently degrades
+  // the dedup confirm too, not just the filing.
+  const ensured = await ensureIssueLabels({
+    owner: routedRepo.owner,
+    repo: routedRepo.repo,
+    labels,
+    labelCache,
+    ghPath,
+    spawnImpl,
+    cwd,
+    timeoutMs,
+  });
+  envelope.errors.push(...ensured.errors);
+  if (ensured.missing.length > 0) {
+    // `gh issue create` would reject the whole call on the absent name; say
+    // which label blocked it rather than replaying an opaque CLI failure.
+    return skip('label-ensure-failed');
+  }
 
   // Strong read (would-file path only, Story #4657): the search probe reads
   // an eventually-consistent index that can miss a byte-identical duplicate
@@ -811,6 +1013,10 @@ async function persistCrossRepoDeferred({
  *   calls in one logical invocation (e.g. the retro graduator's two source
  *   buckets) so a marker filed in one call short-circuits a repeat in the
  *   next without a spawn. Defaults to a fresh per-call Set.
+ * @param {Map<string, Set<string>>} [opts.labelCache] — per-repo memo of the
+ *   live label set, so the just-in-time label mint (Story #4828) costs one
+ *   `gh label list` per routed repo rather than one per finding. Share it
+ *   across the calls of one logical invocation, like `filedMarkers`.
  * @param {{info?: Function, warn?: Function, debug?: Function}} [opts.logger]
  * @param {object} opts.spec — the per-graduator behaviour bundle
  * @returns {Promise<{ filed: object[], skipped: object[], errors: string[] }>}
@@ -830,6 +1036,7 @@ export async function graduate({
   maxFilingsPerRun = DEFAULT_MAX_FILINGS_PER_RUN,
   findings: preParsedFindings,
   filedMarkers = new Set(),
+  labelCache = new Map(),
   logger,
   spec,
 }) {
@@ -877,6 +1084,7 @@ export async function graduate({
       maxFilingsPerRun,
       crossRepoDeferred,
       filedMarkers,
+      labelCache,
       logger,
       spec,
     });

--- a/.agents/scripts/lib/feedback-loop/retro-proposals-graduator.js
+++ b/.agents/scripts/lib/feedback-loop/retro-proposals-graduator.js
@@ -232,6 +232,11 @@ export async function graduateRetroProposals({
   // circuit the repeat with no spawn.
   const filedMarkers = new Set();
 
+  // One live-label-set read per routed repo across both buckets (Story #4828):
+  // the two buckets file into at most two repos, and every finding in a bucket
+  // wants the same `meta::*` name.
+  const labelCache = new Map();
+
   let remaining = maxFilingsPerRun;
   for (const { source, items } of buckets) {
     if (items.length === 0) continue;
@@ -252,6 +257,7 @@ export async function graduateRetroProposals({
       maxFilingsPerRun: Math.max(0, remaining),
       findings,
       filedMarkers,
+      labelCache,
       logger,
       spec: makeSpec(source),
     });

--- a/.agents/scripts/lib/label-constants.js
+++ b/.agents/scripts/lib/label-constants.js
@@ -135,11 +135,22 @@ export const PLANNING_LABELS = {
  */
 export const PLANNING_HEALTHCHECK_WAIVED = 'planning::healthcheck-waived';
 
-/** Palette for the taxonomy; consumed by label-taxonomy.js. */
+/**
+ * Palette for the taxonomy; consumed by label-taxonomy.js and by the
+ * feedback loop's just-in-time label mint (`graduator-core.ensureIssueLabels`).
+ *
+ * `META` and `FRICTION` are not in `LABEL_TAXONOMY`: the bootstrap runs once
+ * at repo setup, but `friction::<category>` names are minted from live
+ * telemetry and cannot be enumerated ahead of time. The graduator mints both
+ * axes on demand instead — Story #4828, where their absence made every
+ * `gh issue create` fail and the whole feedback loop file zero.
+ */
 export const LABEL_COLORS = {
   TYPE: '#7057FF',
   AGENT: '#0E8A16',
   STATUS_BLOCKED: '#D93F0B',
   ACCEPTANCE: '#FBCA04',
   PLANNING: '#FEF2C0',
+  META: '#1D76DB',
+  FRICTION: '#D4C5F9',
 };

--- a/.agents/scripts/lib/orchestration/run-epilogue.js
+++ b/.agents/scripts/lib/orchestration/run-epilogue.js
@@ -21,9 +21,11 @@ import { gitSpawn } from '../git-utils.js';
 import { Logger } from '../Logger.js';
 import { composeRoutedProposals } from './retro-proposals.js';
 import {
+  assessRollupOutcome,
   buildFollowUpsCommentBody,
   gatherRunFrictionSignals,
   resolveFollowUpRepos,
+  summarizeSignalCategories,
 } from './story-follow-ups.js';
 import { upsertStructuredComment } from './ticketing.js';
 
@@ -550,6 +552,7 @@ async function executeFollowUpRollup({
   provider,
   config,
   cwd,
+  graduateFn = graduateRetroProposals,
 }) {
   // Shared with the story-scoped gather (Story #4649): `storyId` + `details`
   // are what the composer's recovery-netting keys on, and two hand-rolled
@@ -570,7 +573,7 @@ async function executeFollowUpRollup({
     item.title = item.title.replace(/plan-run \d+/, `plan-run ${planRunId}`);
     item.body = item.body.replace(/plan-run \d+/g, `plan-run ${planRunId}`);
   }
-  const graduated = await graduateRetroProposals({
+  const graduated = await graduateFn({
     epicId: primaryId,
     provider,
     config,
@@ -582,6 +585,16 @@ async function executeFollowUpRollup({
     routedProposals: proposals,
     cwd,
   });
+  const categories = summarizeSignalCategories(signals);
+  const proposalCount = proposals.framework.length + proposals.consumer.length;
+  const outcome = assessRollupOutcome({
+    signalCount: signals.length,
+    proposalCount,
+    discardedCount: proposals.discarded.length,
+    filedCount: graduated.filed?.length ?? 0,
+    filingErrors: graduated.errors,
+    filingSkipped: graduated.skipped,
+  });
   if (Number.isInteger(primaryId) && primaryId > 0) {
     const body = buildFollowUpsCommentBody({
       storyId: primaryId,
@@ -591,6 +604,10 @@ async function executeFollowUpRollup({
       // render as a flagged claim ("0 signals across N Stories") rather than
       // as "nothing to follow up".
       storyCount: stories.length,
+      // Story #4828 — and the corpus is what lets a zero-proposal or
+      // zero-filed roll-up name what it saw instead of rendering as clean.
+      signalCount: signals.length,
+      categories,
     }).replace(
       `from Story #${primaryId}`,
       `from plan-run \`${planRunId}\` (primary Story #${primaryId})`,
@@ -602,6 +619,22 @@ async function executeFollowUpRollup({
     signalCount: signals.length,
     storyCount: stories.length,
     filed: graduated.filed?.length ?? 0,
+    // Story #4828 — everything below is what the roll-up saw and what became
+    // of it. The pre-#4828 result reported `signalCount` and `filed` and
+    // nothing in between, so nine signals routing into one proposal whose
+    // every filing attempt errored rendered as `{signalCount: 9, filed: 0,
+    // discarded: []}` — arithmetically consistent, and indistinguishable from
+    // a run with nothing to do.
+    proposalCount,
+    // The categories the corpus actually contained, so a zero-proposal
+    // roll-up names its own input rather than asserting emptiness.
+    categories,
+    filingErrors: Array.isArray(graduated.errors) ? graduated.errors : [],
+    filingSkipped: outcome.blockingSkipReasons,
+    // Signals in, nothing out — not even a below-threshold row.
+    zeroProposalSuspect: outcome.zeroProposals,
+    // Proposals cleared the threshold and the filer produced none of them.
+    unfiledProposalSuspect: outcome.unfiledProposals,
     // Story #4824 — a roll-up that discards every candidate must still name
     // what it discarded. Rendering that as "nothing to follow up" is how a
     // defect recurring once per Story survived eighteen consecutive Stories.
@@ -710,6 +743,9 @@ async function executeSiblingCoherence({ planRunId, stories, provider }) {
  * @param {string} [args.cwd]
  * @param {{ gitSpawn: Function }} [args.git] - Injection seam for tests.
  * @param {typeof selectAudits} [args.selectAuditsFn] - Injection seam for tests.
+ * @param {typeof graduateRetroProposals} [args.graduateFn] - Injection seam so
+ *   the roll-up's reporting layer can be asserted against a filer that fails
+ *   (Story #4828) without spawning a real `gh`.
  * @returns {Promise<object>}
  */
 export async function runPlanRunEpilogue({
@@ -720,6 +756,7 @@ export async function runPlanRunEpilogue({
   cwd = process.cwd(),
   git = { gitSpawn },
   selectAuditsFn = selectAudits,
+  graduateFn = graduateRetroProposals,
 } = {}) {
   const plan = planRunEpilogue({ planRunId, stories });
   if (!plan.applicable) {
@@ -753,6 +790,7 @@ export async function runPlanRunEpilogue({
             provider,
             config,
             cwd,
+            graduateFn,
           }),
         );
       } else if (step.kind === 'sibling-coherence') {

--- a/.agents/scripts/lib/orchestration/story-follow-ups.js
+++ b/.agents/scripts/lib/orchestration/story-follow-ups.js
@@ -225,6 +225,142 @@ function renderEmptyRollupLines(storyCount) {
 }
 
 /**
+ * Skip reasons that are a deliberate outcome rather than a broken loop. A
+ * roll-up whose every proposal was skipped for one of these filed nothing
+ * *on purpose*; anything else is the loop failing quietly.
+ */
+const BENIGN_SKIP_REASONS = new Set([
+  'already-filed',
+  'toggle-disabled',
+  'cross-repo-deferred',
+  'cap-reached',
+  'no-actionable-proposals',
+]);
+
+/**
+ * Summarize a category corpus for the "name what you saw" lines. Pure.
+ *
+ * @param {Array<{ category?: string }>} signals
+ * @returns {Array<{ category: string, occurrences: number }>}
+ */
+export function summarizeSignalCategories(signals) {
+  const counts = new Map();
+  for (const sig of Array.isArray(signals) ? signals : []) {
+    if (sig === null || typeof sig !== 'object') continue;
+    const category =
+      typeof sig.category === 'string' ? sig.category.trim() : '';
+    if (category.length === 0) continue;
+    counts.set(category, (counts.get(category) ?? 0) + 1);
+  }
+  return [...counts.entries()]
+    .map(([category, occurrences]) => ({ category, occurrences }))
+    .sort((a, b) => a.category.localeCompare(b.category));
+}
+
+/**
+ * Classify what a roll-up's own numbers say about it — the reporting-layer
+ * assertion Story #4828 adds. Pure, so the run epilogue's step result and the
+ * rendered comment cannot disagree about whether a roll-up succeeded.
+ *
+ * Two suspect shapes, both of which previously rendered as success:
+ *
+ *   - `zeroProposals` — signals were gathered and **nothing** came out, not
+ *     even a below-threshold row. That is the third instance of the failure
+ *     mode Story #4578 fixed for the zero-signal case and Story #4824 for the
+ *     all-discarded case: an all-empty routed result is silence, and a routing
+ *     regression is exactly what it looks like.
+ *   - `unfiledProposals` — proposals cleared the threshold and none were
+ *     filed for a reason that is not a deliberate one. This is what actually
+ *     happened in Story #4828: `gh issue create` rejected every call over an
+ *     absent label, the error landed in a bucket nobody rendered, and the
+ *     roll-up reported `filed: 0`.
+ *
+ * @param {object} args
+ * @param {number} args.signalCount
+ * @param {number} args.proposalCount   framework + consumer
+ * @param {number} args.discardedCount
+ * @param {number} args.filedCount
+ * @param {string[]} [args.filingErrors]
+ * @param {Array<{ reason?: string }>} [args.filingSkipped]
+ * @returns {{ zeroProposals: boolean, unfiledProposals: boolean, blockingSkipReasons: string[] }}
+ */
+export function assessRollupOutcome({
+  signalCount,
+  proposalCount,
+  discardedCount,
+  filedCount,
+  filingErrors = [],
+  filingSkipped = [],
+}) {
+  const blockingSkipReasons = [
+    ...new Set(
+      (Array.isArray(filingSkipped) ? filingSkipped : [])
+        .map((entry) => (typeof entry?.reason === 'string' ? entry.reason : ''))
+        .filter((reason) => reason && !BENIGN_SKIP_REASONS.has(reason)),
+    ),
+  ].sort();
+  const errors = Array.isArray(filingErrors) ? filingErrors : [];
+  return {
+    zeroProposals:
+      signalCount > 0 && proposalCount === 0 && discardedCount === 0,
+    unfiledProposals:
+      proposalCount > 0 &&
+      filedCount === 0 &&
+      (errors.length > 0 || blockingSkipReasons.length > 0),
+    blockingSkipReasons,
+  };
+}
+
+/**
+ * Render the "N signals in, zero proposals out" warning (Story #4828).
+ *
+ * @param {number} signalCount
+ * @param {Array<{ category: string, occurrences: number }>} categories
+ * @returns {string[]}
+ */
+function renderZeroProposalLines(signalCount, categories) {
+  const named =
+    categories.length > 0
+      ? categories.map((c) => `\`${c.category}\` ×${c.occurrences}`).join(', ')
+      : '_none — every gathered signal carried an unusable category_';
+  return [
+    `> ⚠️ **${signalCount} friction signals gathered, 0 proposals produced — a routing outcome, not a clean run.**`,
+    `> Categories seen: ${named}.`,
+    '> Nothing cleared the actionable threshold AND nothing was recorded below',
+    '> it, so every signal was netted out as recovered or dropped in routing.',
+    '> A regression in routing renders byte-identically to this, which is why',
+    '> the roll-up states it rather than rendering silence.',
+  ];
+}
+
+/**
+ * Render the "proposals cleared the threshold but none were filed" warning
+ * (Story #4828).
+ *
+ * @param {number} proposalCount
+ * @param {string[]} filingErrors
+ * @param {string[]} blockingSkipReasons
+ * @returns {string[]}
+ */
+function renderUnfiledProposalLines(
+  proposalCount,
+  filingErrors,
+  blockingSkipReasons,
+) {
+  const lines = [
+    `> ⚠️ **${proposalCount} actionable proposal(s) reached the filer and none were filed.**`,
+    '> Auto-file is on, so this is the feedback loop failing, not declining.',
+  ];
+  if (blockingSkipReasons.length > 0) {
+    lines.push(`> Skipped: ${blockingSkipReasons.join(', ')}.`);
+  }
+  for (const error of filingErrors) {
+    lines.push(`> ${error}`);
+  }
+  return lines;
+}
+
+/**
  * Render one discarded (below-threshold) roll-up row (Story #4824).
  *
  * The pre-#4824 row was `` `category` ×N `` and nothing else. That is exactly
@@ -262,8 +398,13 @@ function renderDiscardedItem(item) {
  *   proposals: object,
  *   graduated: object,
  *   storyCount?: number,
+ *   signalCount?: number,
+ *   categories?: Array<{ category: string, occurrences: number }>,
  * }} args - `storyCount` (default 1) is how many Stories the roll-up spans;
  *   it decides whether an empty result reads as quiet or as a flagged claim.
+ *   `signalCount` / `categories` (Story #4828) are what the roll-up actually
+ *   gathered, so a zero-proposal or zero-filed outcome can name its own
+ *   corpus instead of rendering as a clean run.
  * @returns {string}
  */
 export function buildFollowUpsCommentBody({
@@ -271,17 +412,37 @@ export function buildFollowUpsCommentBody({
   proposals,
   graduated,
   storyCount = 1,
+  signalCount = 0,
+  categories = [],
 }) {
   const filed = Array.isArray(graduated?.filed) ? graduated.filed : [];
   const framework = proposals?.framework ?? [];
   const consumer = proposals?.consumer ?? [];
   const discarded = proposals?.discarded ?? [];
+  const outcome = assessRollupOutcome({
+    signalCount,
+    proposalCount: framework.length + consumer.length,
+    discardedCount: discarded.length,
+    filedCount: filed.length,
+    filingErrors: graduated?.errors,
+    filingSkipped: graduated?.skipped,
+  });
   const lines = [
     '### follow-ups',
     '',
     `Actionable follow-ups captured from Story #${storyId} after merge.`,
     '',
   ];
+  if (outcome.unfiledProposals) {
+    lines.push(
+      ...renderUnfiledProposalLines(
+        framework.length + consumer.length,
+        Array.isArray(graduated?.errors) ? graduated.errors : [],
+        outcome.blockingSkipReasons,
+      ),
+      '',
+    );
+  }
   if (filed.length > 0) {
     lines.push('**Filed**');
     for (const item of filed) {
@@ -315,7 +476,14 @@ export function buildFollowUpsCommentBody({
     consumer.length === 0 &&
     discarded.length === 0
   ) {
-    lines.push(...renderEmptyRollupLines(storyCount));
+    // Story #4828 — "no proposals" has two readings, and only one of them is
+    // a quiet run. Signals gathered but nothing routed is the third instance
+    // of the silence Stories #4578 and #4824 each fixed once.
+    lines.push(
+      ...(outcome.zeroProposals
+        ? renderZeroProposalLines(signalCount, categories)
+        : renderEmptyRollupLines(storyCount)),
+    );
     lines.push('');
   }
   lines.push('```json');
@@ -324,6 +492,11 @@ export function buildFollowUpsCommentBody({
       {
         storyId,
         storyCount,
+        // Story #4828 — the corpus the roll-up actually read. Without it a
+        // reader cannot tell "0 proposals because nothing recurred" from
+        // "0 proposals because routing broke".
+        signalCount,
+        categories,
         framework: framework.map((i) => i.category),
         consumer: consumer.map((i) => i.category),
         // Story #4824 — the machine-readable twin of the row above. A bare
@@ -348,7 +521,13 @@ export function buildFollowUpsCommentBody({
           filed.length === 0 &&
           framework.length === 0 &&
           consumer.length === 0 &&
-          discarded.length === 0,
+          discarded.length === 0 &&
+          signalCount === 0,
+        // Story #4828 — the two remaining shapes that used to render as
+        // success. Machine-readable twins of the warning prose above.
+        zeroProposalSuspect: outcome.zeroProposals,
+        unfiledProposalSuspect: outcome.unfiledProposals,
+        filingErrors: Array.isArray(graduated?.errors) ? graduated.errors : [],
       },
       null,
       2,
@@ -422,6 +601,8 @@ export async function captureStoryFollowUps({
       storyId: sid,
       proposals,
       graduated,
+      signalCount: signals.length,
+      categories: summarizeSignalCategories(signals),
     });
     await upsertStructuredComment(provider, sid, FOLLOW_UPS_COMMENT_TYPE, body);
     progress?.(

--- a/tests/lib/feedback-loop/graduator-core.test.js
+++ b/tests/lib/feedback-loop/graduator-core.test.js
@@ -281,8 +281,13 @@ describe('graduate (parametrized walk)', () => {
     assert.equal(env.filed.length, 1);
     assert.equal(env.filed[0].path, 'src/x.js');
     assert.equal(env.filed[0].url, 'https://x/issues/1');
-    // The injected builder body must have been threaded through.
-    const createCall = spawnImpl.calls.find((c) => c.args[1] === 'create');
+    // The injected builder body must have been threaded through. Match
+    // `issue create` specifically: since Story #4828 the walk also spawns
+    // `gh label create` for a label the repo does not carry yet, and both
+    // share `create` at args[1].
+    const createCall = spawnImpl.calls.find(
+      (c) => c.args[0] === 'issue' && c.args[1] === 'create',
+    );
     const bodyIdx = createCall.args.indexOf('--body') + 1;
     assert.match(createCall.args[bodyIdx], /<!-- f-42-0 --> consumer 42/);
   });
@@ -466,7 +471,9 @@ describe('graduate — dedup dispatch (Story #4657)', () => {
     assert.equal(env.filed.length, 0, 'the window duplicate is not re-filed');
     assert.equal(env.skipped[0]?.reason, 'already-filed');
     assert.ok(
-      !spawnImpl.calls.some((c) => c.args[1] === 'create'),
+      !spawnImpl.calls.some(
+        (c) => c.args[0] === 'issue' && c.args[1] === 'create',
+      ),
       'createFollowUpIssue was never spawned',
     );
     // The strong read is a strongly-consistent (`--state all`), label-scoped

--- a/tests/lib/orchestration/retro-proposals.test.js
+++ b/tests/lib/orchestration/retro-proposals.test.js
@@ -621,3 +621,104 @@ test('a framework proposal routes to frameworkRepo, not the consumer it ran in',
     `expected a cross-repo skip; got ${JSON.stringify(result.skipped)}`,
   );
 });
+
+/**
+ * Story #4828 — the run epilogue over Stories 4824 + 4825 gathered nine
+ * friction signals and filed nothing, and the leading hypothesis was that
+ * `normaliseInput` had rejected the epilogue's input and short-circuited
+ * `composeRoutedProposals` to `emptyResult()`.
+ *
+ * It had not. Replaying the real corpus proved the composer routes it
+ * correctly, which is what moved the investigation downstream to the filer.
+ * These two tests pin that verdict so the disproven hypothesis stays
+ * disproven: the first fixes the exact shape the epilogue builds, the second
+ * fixes what `emptyResult()` is actually for, so a future regression cannot
+ * quietly re-answer either question.
+ */
+
+/** The exact corpus the run epilogue read: 9 signals across two Stories. */
+function epilogueCorpus() {
+  const toolDegraded = [4825, 4801, 4802, 4808, 4811].map((storyId) => ({
+    category: 'tool-degraded',
+    source: 'consumer',
+    storyId,
+    tool: 'native-review-lint',
+    details: { surface: 'scoped-lint', reason: 'no parseable output' },
+  }));
+  return [
+    ...toolDegraded,
+    // Both of these self-resolved, so each incident carries a recovery marker
+    // and nets out — which is why the real roll-up's `discarded` was empty.
+    { category: 'story-blocked', source: 'framework', storyId: 4824 },
+    {
+      category: 'story-blocked',
+      source: 'framework',
+      storyId: 4824,
+      details: { recovered: true },
+    },
+    { category: 'close-failed', source: 'framework', storyId: 4825 },
+    {
+      category: 'close-failed',
+      source: 'framework',
+      storyId: 4825,
+      details: { recovered: true },
+    },
+  ];
+}
+
+test('the run epilogue input shape routes rather than returning an empty result', () => {
+  const signals = epilogueCorpus();
+  assert.equal(signals.length, 9, 'the pinned corpus is the measured one');
+
+  const out = composeRoutedProposals({
+    anchorId: 4824,
+    anchorKind: 'run',
+    // In a framework-repo run `resolveFollowUpRepos` returns the same slug
+    // for both, which is the shape the epilogue actually passed.
+    frameworkRepo: FRAMEWORK_REPO,
+    consumerRepo: FRAMEWORK_REPO,
+    signals,
+    unresolvedBlockedEvents: [],
+  });
+
+  assert.notDeepEqual(
+    out,
+    { framework: [], consumer: [], discarded: [] },
+    'a 9-signal corpus at threshold must not compose to the empty result',
+  );
+  assert.equal(out.consumer.length, 1);
+  assert.equal(out.consumer[0].category, 'tool-degraded');
+  assert.equal(out.consumer[0].occurrences, 5);
+  assert.deepEqual(out.framework, [], 'both framework categories netted out');
+  assert.deepEqual(out.discarded, [], 'nothing sat below the threshold');
+});
+
+test('emptyResult is reserved for input the composer cannot use at all', () => {
+  const empty = { framework: [], consumer: [], discarded: [] };
+  const signals = epilogueCorpus();
+  // A non-numeric anchor is the rejection `normaliseInput` really implements —
+  // an anchorId the epilogue never passes, because it anchors on the primary
+  // Story id rather than the hex plan-run token.
+  assert.deepEqual(
+    composeRoutedProposals({
+      anchorId: 'e8caf51a',
+      anchorKind: 'run',
+      frameworkRepo: FRAMEWORK_REPO,
+      consumerRepo: FRAMEWORK_REPO,
+      signals,
+      unresolvedBlockedEvents: [],
+    }),
+    empty,
+  );
+  assert.deepEqual(
+    composeRoutedProposals({
+      anchorId: 4824,
+      anchorKind: 'run',
+      frameworkRepo: '',
+      consumerRepo: FRAMEWORK_REPO,
+      signals,
+      unresolvedBlockedEvents: [],
+    }),
+    empty,
+  );
+});

--- a/tests/lib/orchestration/run-epilogue.test.js
+++ b/tests/lib/orchestration/run-epilogue.test.js
@@ -696,3 +696,166 @@ describe('follow-up-rollup — an empty roll-up over N>1 asserts (Story #4578)',
     }
   });
 });
+
+/**
+ * Story #4828 — the reporting layer is where this is asserted, deliberately.
+ *
+ * The measured failure was a roll-up that gathered nine signals, composed one
+ * proposal at threshold, failed every filing attempt, and reported
+ * `{signalCount: 9, storyCount: 2, filed: 0, discarded: []}`. Every number in
+ * that envelope is correct. Nothing in it says the loop broke, because the
+ * step result reported what went in and what came out and nothing about what
+ * happened in between.
+ *
+ * Asserting the fix only at the routing layer would leave the next routing
+ * regression free to render as success again — which is exactly how this
+ * failure mode survived being fixed twice already (#4578 for zero signals,
+ * #4824 for all-discarded). So these tests read the step result and the
+ * rendered comment.
+ */
+describe('follow-up-rollup — zero proposals from N signals (Story #4828)', () => {
+  function rollupProvider(comments) {
+    return {
+      getTicket: async (id) => ({
+        id,
+        title: `Story ${id}`,
+        body: '',
+        labels: ['type::story'],
+      }),
+      getTicketComments: async () => [],
+      postComment: async (ticketId, payload) => {
+        comments.push({ ticketId, body: payload.body });
+        return { commentId: comments.length };
+      },
+      deleteComment: async () => {},
+    };
+  }
+
+  it('flags a corpus that produced no proposal at all, and names its categories', async () => {
+    const comments = [];
+    const tempRoot = makeTempDir('rollup-zero-proposal-');
+    const config = {
+      github: { owner: 'o', repo: 'r' },
+      project: { paths: { tempRoot } },
+    };
+    try {
+      // A close that failed and then landed: the incident and its recovery
+      // marker net each other out, so signals exist and nothing routes.
+      for (const storyId of [9301, 9302]) {
+        await emitRuntimeFriction({
+          storyId,
+          category: RUNTIME_FRICTION_CATEGORIES.CLOSE_FAILED,
+          tool: 'single-story-close',
+          details: { phase: 'push' },
+          config,
+        });
+        await emitRuntimeFriction({
+          storyId,
+          category: RUNTIME_FRICTION_CATEGORIES.CLOSE_FAILED,
+          tool: 'runPostLandTail',
+          details: { recovered: true },
+          config,
+        });
+      }
+
+      const result = await runPlanRunEpilogue({
+        planRunId: 'adhoc-9301-9302',
+        stories: [9301, 9302],
+        provider: rollupProvider(comments),
+        config,
+        cwd: process.cwd(),
+      });
+
+      const rollup = result.results.find((r) => r.kind === 'follow-up-rollup');
+      assert.equal(rollup.signalCount, 4, 'the corpus was not empty');
+      assert.equal(rollup.proposalCount, 0);
+      assert.deepEqual(rollup.discarded, []);
+      assert.equal(rollup.filed, 0);
+      assert.equal(
+        rollup.zeroProposalSuspect,
+        true,
+        'signals in and nothing out is a routing outcome the roll-up must state',
+      );
+      assert.equal(
+        rollup.emptyRollupSuspect,
+        false,
+        'the #4578 flag means zero signals — a non-empty corpus is a different shape',
+      );
+      assert.deepEqual(rollup.categories, [
+        { category: 'close-failed', occurrences: 4 },
+      ]);
+
+      const body = comments.find((c) => /### follow-ups/.test(c.body))?.body;
+      assert.match(body, /4 friction signals gathered, 0 proposals produced/);
+      assert.match(body, /`close-failed` ×4/);
+      assert.doesNotMatch(
+        body,
+        /nothing to follow up/,
+        'the reassuring line is what made this shape invisible',
+      );
+      assert.match(body, /"zeroProposalSuspect": true/);
+    } finally {
+      rmSync(tempRoot, { recursive: true, force: true });
+    }
+  });
+
+  it('flags a proposal at threshold that the filer failed to file', async () => {
+    const comments = [];
+    const tempRoot = makeTempDir('rollup-unfiled-');
+    const config = {
+      github: { owner: 'o', repo: 'r' },
+      project: { paths: { tempRoot } },
+    };
+    try {
+      for (const storyId of [9401, 9402]) {
+        await emitRuntimeFriction({
+          storyId,
+          category: RUNTIME_FRICTION_CATEGORIES.TOOL_DEGRADED,
+          tool: 'native-review-lint',
+          details: { surface: 'scoped-lint', reason: 'no parseable output' },
+          config,
+        });
+      }
+
+      // The filer as it actually behaved: every `gh issue create` rejected
+      // over a label the repo did not carry.
+      const result = await runPlanRunEpilogue({
+        planRunId: 'adhoc-9401-9402',
+        stories: [9401, 9402],
+        provider: rollupProvider(comments),
+        config,
+        cwd: process.cwd(),
+        graduateFn: async () => ({
+          filed: [],
+          skipped: [{ reason: 'label-ensure-failed' }],
+          errors: [
+            'gh label create "friction::tool-degraded" in o/r failed: HTTP 403',
+          ],
+        }),
+      });
+
+      const rollup = result.results.find((r) => r.kind === 'follow-up-rollup');
+      assert.equal(rollup.signalCount, 2);
+      assert.equal(rollup.proposalCount, 1, 'the bucket cleared the threshold');
+      assert.equal(rollup.filed, 0);
+      assert.equal(
+        rollup.unfiledProposalSuspect,
+        true,
+        'a proposal that reached the filer and did not land is a broken loop',
+      );
+      assert.deepEqual(rollup.filingSkipped, ['label-ensure-failed']);
+      assert.equal(rollup.filingErrors.length, 1);
+      assert.match(rollup.filingErrors[0], /gh label create/);
+
+      const body = comments.find((c) => /### follow-ups/.test(c.body))?.body;
+      assert.match(
+        body,
+        /1 actionable proposal\(s\) reached the filer and none were filed/,
+      );
+      assert.match(body, /"unfiledProposalSuspect": true/);
+      assert.match(body, /"signalCount": 2/);
+    } finally {
+      rmSync(tempRoot, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/lib/orchestration/story-follow-ups.test.js
+++ b/tests/lib/orchestration/story-follow-ups.test.js
@@ -1,6 +1,8 @@
 import assert from 'node:assert/strict';
+import { EventEmitter } from 'node:events';
 import fs from 'node:fs/promises';
 import { afterEach, beforeEach, describe, it } from 'node:test';
+import { graduateRetroProposals } from '../../../.agents/scripts/lib/feedback-loop/retro-proposals-graduator.js';
 import {
   emitBlockRecoveredFriction,
   emitRuntimeFriction,
@@ -12,11 +14,13 @@ import {
 } from '../../../.agents/scripts/lib/orchestration/retro-proposals.js';
 import { runPostLandTail } from '../../../.agents/scripts/lib/orchestration/single-story-close/phases/post-land.js';
 import {
+  assessRollupOutcome,
   buildFollowUpsCommentBody,
   captureStoryFollowUps,
   gatherRunFrictionSignals,
   gatherStoryFrictionSignals,
   resolveFollowUpRepos,
+  summarizeSignalCategories,
 } from '../../../.agents/scripts/lib/orchestration/story-follow-ups.js';
 import { makeTempDir } from '../../../.agents/scripts/lib/test-temp.js';
 
@@ -539,5 +543,299 @@ describe('empty roll-up assertion (Story #4578)', () => {
     });
     assert.doesNotMatch(body, /telemetry may not|not a clean bill of health/);
     assert.match(body, /"emptyRollupSuspect": false/);
+  });
+});
+
+/**
+ * Story #4828 — the roll-up over Stories 4824 + 4825 composed a routed
+ * proposal at threshold and still filed zero.
+ *
+ * The composer was fine. `gh issue create` resolves every `--label` against
+ * the repo before it creates anything and rejects the whole call when one is
+ * absent, and the two axes the feedback loop stamps —
+ * `meta::consumer-improvement` and `friction::<category>` — were absent:
+ * neither is in `LABEL_TAXONOMY`, and a `friction::` name is minted from live
+ * telemetry, so no bootstrap could have pre-created it. Every filing failed
+ * into the graduator's `errors[]`, which nothing rendered.
+ *
+ * The fake below is the repo as it actually was: no labels, and a create that
+ * rejects a label the repo does not carry.
+ */
+describe('a routed bucket at threshold reaches the filer (Story #4828)', () => {
+  /**
+   * @param {{ labelCreateFails?: boolean }} [opts]
+   */
+  function makeLabelAwareGh({ labelCreateFails = false } = {}) {
+    const live = new Set();
+    const created = [];
+    const fn = function spawnImpl(cmd, args) {
+      const child = new EventEmitter();
+      child.stdout = new EventEmitter();
+      child.stderr = new EventEmitter();
+      let result = { stdout: '', stderr: '', code: 0 };
+      const [a0, a1] = args;
+      if (cmd !== 'gh') {
+        result = { stdout: '', stderr: '', code: 1 };
+      } else if (a0 === 'label' && a1 === 'list') {
+        result = {
+          stdout: JSON.stringify([...live].map((name) => ({ name }))),
+          stderr: '',
+          code: 0,
+        };
+      } else if (a0 === 'label' && a1 === 'create') {
+        if (labelCreateFails) {
+          result = {
+            stdout: '',
+            stderr: 'HTTP 403: Resource not accessible',
+            code: 1,
+          };
+        } else {
+          live.add(args[2]);
+          result = { stdout: '', stderr: '', code: 0 };
+        }
+      } else if (a0 === 'search' || (a0 === 'issue' && a1 === 'list')) {
+        result = { stdout: '[]', stderr: '', code: 0 };
+      } else if (a0 === 'issue' && a1 === 'create') {
+        const labels = [];
+        for (let i = 0; i < args.length; i += 1) {
+          if (args[i] === '--label') labels.push(args[i + 1]);
+        }
+        const absent = labels.filter((label) => !live.has(label));
+        if (absent.length > 0) {
+          result = {
+            stdout: '',
+            stderr: `could not add label: '${absent[0]}' not found`,
+            code: 1,
+          };
+        } else {
+          created.push({ labels });
+          result = {
+            stdout: `https://github.com/acme/app/issues/${created.length}`,
+            stderr: '',
+            code: 0,
+          };
+        }
+      }
+      queueMicrotask(() => {
+        if (result.stdout)
+          child.stdout.emit('data', Buffer.from(result.stdout));
+        if (result.stderr)
+          child.stderr.emit('data', Buffer.from(result.stderr));
+        child.emit('close', result.code);
+      });
+      return child;
+    };
+    fn.created = created;
+    fn.live = live;
+    return fn;
+  }
+
+  const provider = {
+    getTicketComments: async () => [],
+    postComment: async () => ({ commentId: 1 }),
+    deleteComment: async () => {},
+  };
+
+  /** A category at the ≥2 threshold, routed to the repo the roll-up runs in. */
+  function thresholdProposals() {
+    return composeRoutedProposals({
+      anchorId: 4824,
+      anchorKind: 'run',
+      frameworkRepo: 'acme/app',
+      consumerRepo: 'acme/app',
+      signals: [
+        { category: 'tool-degraded', source: 'consumer', storyId: 4824 },
+        { category: 'tool-degraded', source: 'consumer', storyId: 4825 },
+      ],
+      unresolvedBlockedEvents: [],
+    });
+  }
+
+  it('mints the absent routing labels so a proposal at threshold files', async () => {
+    const proposals = thresholdProposals();
+    assert.equal(
+      proposals.consumer.length,
+      1,
+      'arrange: the bucket is non-empty',
+    );
+    const gh = makeLabelAwareGh();
+
+    const result = await graduateRetroProposals({
+      epicId: 4824,
+      provider,
+      config: {},
+      currentRepo: { owner: 'acme', repo: 'app' },
+      frameworkRepo: { owner: 'acme', repo: 'app' },
+      routedProposals: proposals,
+      spawnImpl: gh,
+    });
+
+    assert.equal(
+      result.filed.length,
+      1,
+      `expected one filing; got errors=${JSON.stringify(result.errors)} skipped=${JSON.stringify(result.skipped)}`,
+    );
+    assert.deepEqual(result.errors, []);
+    assert.deepEqual(
+      [...gh.live].sort(),
+      ['friction::tool-degraded', 'meta::consumer-improvement'],
+      'both absent axes are minted before the create',
+    );
+    assert.deepEqual(gh.created[0].labels.sort(), [
+      'friction::tool-degraded',
+      'meta::consumer-improvement',
+    ]);
+  });
+
+  it('reports a filer that could not mint the label instead of returning a bare zero', async () => {
+    const proposals = thresholdProposals();
+    const gh = makeLabelAwareGh({ labelCreateFails: true });
+
+    const result = await graduateRetroProposals({
+      epicId: 4824,
+      provider,
+      config: {},
+      currentRepo: { owner: 'acme', repo: 'app' },
+      frameworkRepo: { owner: 'acme', repo: 'app' },
+      routedProposals: proposals,
+      spawnImpl: gh,
+    });
+
+    assert.equal(result.filed.length, 0);
+    assert.equal(
+      gh.created.length,
+      0,
+      'never attempts a create it knows will fail',
+    );
+    assert.ok(
+      result.errors.some((e) => /gh label create/.test(e)),
+      `expected a label-create error; got ${JSON.stringify(result.errors)}`,
+    );
+    assert.ok(result.skipped.some((s) => s.reason === 'label-ensure-failed'));
+
+    // The reporting layer must call this what it is — a failing loop, not a
+    // loop with nothing to say.
+    const outcome = assessRollupOutcome({
+      signalCount: 2,
+      proposalCount: 1,
+      discardedCount: 0,
+      filedCount: 0,
+      filingErrors: result.errors,
+      filingSkipped: result.skipped,
+    });
+    assert.equal(outcome.unfiledProposals, true);
+    assert.deepEqual(outcome.blockingSkipReasons, ['label-ensure-failed']);
+
+    const body = buildFollowUpsCommentBody({
+      storyId: 4824,
+      proposals,
+      graduated: result,
+      storyCount: 2,
+      signalCount: 2,
+      categories: summarizeSignalCategories([
+        { category: 'tool-degraded' },
+        { category: 'tool-degraded' },
+      ]),
+    });
+    assert.match(
+      body,
+      /1 actionable proposal\(s\) reached the filer and none were filed/,
+    );
+    assert.match(body, /gh label create/);
+    assert.match(body, /"unfiledProposalSuspect": true/);
+  });
+});
+
+/**
+ * Story #4828 — the third instance of a silence this codebase has now fixed
+ * three times: zero signals (#4578), all-discarded (#4824), and here, signals
+ * gathered that produced no proposal at all.
+ */
+describe('zero proposals from a non-empty corpus (Story #4828)', () => {
+  it('summarizes the categories it saw, in a stable order', () => {
+    assert.deepEqual(
+      summarizeSignalCategories([
+        { category: 'tool-degraded' },
+        { category: 'close-failed' },
+        { category: 'tool-degraded' },
+        { category: '  ' },
+        null,
+      ]),
+      [
+        { category: 'close-failed', occurrences: 1 },
+        { category: 'tool-degraded', occurrences: 2 },
+      ],
+    );
+  });
+
+  it('flags signals-in / nothing-out, and does not flag a genuinely empty stream', () => {
+    assert.equal(
+      assessRollupOutcome({
+        signalCount: 9,
+        proposalCount: 0,
+        discardedCount: 0,
+        filedCount: 0,
+      }).zeroProposals,
+      true,
+    );
+    assert.equal(
+      assessRollupOutcome({
+        signalCount: 0,
+        proposalCount: 0,
+        discardedCount: 0,
+        filedCount: 0,
+      }).zeroProposals,
+      false,
+      'zero signals is the #4578 shape, reported by emptyRollupSuspect',
+    );
+    assert.equal(
+      assessRollupOutcome({
+        signalCount: 3,
+        proposalCount: 0,
+        discardedCount: 1,
+        filedCount: 0,
+      }).zeroProposals,
+      false,
+      'a below-threshold row is a rendered outcome, not silence',
+    );
+  });
+
+  it('treats a deliberate skip as a decision, not a failure', () => {
+    const outcome = assessRollupOutcome({
+      signalCount: 4,
+      proposalCount: 2,
+      discardedCount: 0,
+      filedCount: 0,
+      filingSkipped: [
+        { reason: 'already-filed' },
+        { reason: 'toggle-disabled' },
+      ],
+    });
+    assert.equal(outcome.unfiledProposals, false);
+    assert.deepEqual(outcome.blockingSkipReasons, []);
+  });
+
+  it('names the corpus when nothing routed out of it', () => {
+    const body = buildFollowUpsCommentBody({
+      storyId: 4824,
+      proposals: { framework: [], consumer: [], discarded: [] },
+      graduated: { filed: [], skipped: [], errors: [] },
+      storyCount: 2,
+      signalCount: 4,
+      categories: [
+        { category: 'close-failed', occurrences: 2 },
+        { category: 'story-blocked', occurrences: 2 },
+      ],
+    });
+    assert.match(body, /4 friction signals gathered, 0 proposals produced/);
+    assert.match(body, /`close-failed` ×2/);
+    assert.match(body, /`story-blocked` ×2/);
+    assert.doesNotMatch(
+      body,
+      /nothing to follow up/,
+      'a corpus that produced nothing must not read as a clean run',
+    );
+    assert.match(body, /"zeroProposalSuspect": true/);
+    assert.match(body, /"signalCount": 4/);
   });
 });


### PR DESCRIPTION
Closes #4828

_Auto-opened by `/deliver`._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes GitHub label creation and issue filing in the feedback loop; failures are surfaced but incorrect minting or skip logic could still block or mis-report follow-ups.
> 
> **Overview**
> Fixes the feedback loop reporting **`filed: 0`** when proposals were actionable but **`gh issue create`** failed because **`meta::*`** and **`friction::<category>`** labels were not on the repo.
> 
> **Filing path:** Before dedup and create, **`ensureIssueLabels`** lists repo labels (memoized per repo via **`labelCache`**), creates any missing routing/friction labels with **`LABEL_COLORS`**, and skips with **`label-ensure-failed`** if minting fails. The retro graduator shares one cache across framework/consumer buckets.
> 
> **Roll-up visibility:** **`assessRollupOutcome`** and **`summarizeSignalCategories`** classify **signals → zero proposals** vs **proposals → zero filed** (excluding benign skips). Follow-up comments and the plan-run epilogue step result expose **`zeroProposalSuspect`**, **`unfiledProposalSuspect`**, categories, and filing errors so broken loops no longer look like a clean run. **`graduateFn`** is injectable on the epilogue for tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 51a0d4fa3a7f775381573bbb021dce49bfe477d5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->