### PR TITLE
fix: review: stop the scoped-lint gate failing open silently, and fix why its runner cannot execute (#4839)

### DIFF
--- a/.agents/scripts/lib/orchestration/code-review.js
+++ b/.agents/scripts/lib/orchestration/code-review.js
@@ -44,6 +44,10 @@ import { resolveConfig } from '../config-resolver.js';
 import { computeChangeSet } from './change-set.js';
 import { deriveChangeLevel, resolveDepth } from './review-depth.js';
 import {
+  collectProviderDegradations,
+  degradationEnvelope,
+} from './review-providers/degraded-gates.js';
+import {
   countBySeverity,
   renderFindings,
 } from './review-providers/findings-renderer.js';
@@ -176,6 +180,7 @@ function resolveScopeEnvelope(opts, config) {
  *   postedCommentId: number|null,
  *   commentTargetId: number,
  *   halted: boolean,
+ *   degraded: boolean, degradations: Array<object>,
  *   blockerReason: string|null,
  * }>}
  */
@@ -357,6 +362,11 @@ async function executeReviewPipeline({ opts, config, envelope }) {
     logger,
   );
 
+  // Story #4839 — degraded gates ride beside the findings, never inside them.
+  const degradations = await collectProviderDegradations(
+    reviewProvider,
+    logger,
+  );
   const severity = countBySeverity(findings);
   const halted = hasSurvivingCritical(severity);
   const report = renderFindingsFn({
@@ -367,6 +377,7 @@ async function executeReviewPipeline({ opts, config, envelope }) {
     findings,
     provider: providerName,
     promptMessages,
+    degradations,
   });
 
   const { posted, postedCommentId } = await postReviewComment({
@@ -385,6 +396,7 @@ async function executeReviewPipeline({ opts, config, envelope }) {
     postedCommentId,
     commentTargetId,
     halted,
+    ...degradationEnvelope(degradations),
     blockerReason: halted
       ? `code-review reported ${severity.critical} critical blocker(s)`
       : null,

--- a/.agents/scripts/lib/orchestration/review-providers/degraded-gates.js
+++ b/.agents/scripts/lib/orchestration/review-providers/degraded-gates.js
@@ -1,0 +1,222 @@
+/**
+ * review-providers/degraded-gates.js — the review's "a gate did not run"
+ * channel (Story #4839).
+ *
+ * ## The defect this closes
+ *
+ * Story #4699 correctly decided that a tool which **could not execute** is an
+ * operational degradation, not a code finding: it is routed to friction
+ * telemetry so severity tiers keep reflecting code findings only. What #4699
+ * did not add was any *other* channel, so the review's own verdict became
+ * unable to distinguish "lint ran and found nothing" from "lint never ran" —
+ * both rendered `✅ No findings` with an all-zero severity tally, and the close
+ * pipeline read the second as the first. A gate that reports success when it
+ * did not run is worse than no gate, because it is trusted.
+ *
+ * This module is that missing channel. A degradation travels **beside** the
+ * `Finding[]`, never inside it:
+ *
+ *   - it never becomes a `Finding`, so `countBySeverity` is untouched and no
+ *     execution failure can appear as a critical / high / medium (or even a
+ *     suggestion) — #4699's intent survives intact;
+ *   - it is rendered as its own section in the structured comment, and it
+ *     suppresses the false `✅ No findings` claim;
+ *   - it is carried on the `runCodeReview` envelope as `degraded` /
+ *     `degradations[]`, so the close pipeline sees it too.
+ *
+ * ## Report, not block — and why
+ *
+ * A degraded gate is reported loudly and does **not** halt the close. The close
+ * pipeline already runs the canonical `npm run lint` as a hard
+ * close-validation gate *before* the review phase; the review's scoped lint is
+ * a second, narrower read of the same surface. Failing a merge because a
+ * *secondary* read of an already-gated surface could not start would block
+ * delivery on an operational condition the hard gate has already covered. What
+ * was actually broken was the silence, so the fix is to make the silence
+ * impossible: every surface that reads the review outcome now states the
+ * degradation explicitly. Escalating to a block is a one-line change here if
+ * the operator posture ever needs it.
+ */
+
+/**
+ * @typedef {object} GateDegradation
+ * @property {string} tool     Emitter (e.g. `native-review-lint`).
+ * @property {string} gate     Gate that degraded (e.g. `scoped-lint`).
+ * @property {string} surface  Sub-surface that could not run (e.g. `markdownlint`).
+ * @property {string} reason   Machine-readable reason code.
+ */
+
+/**
+ * Pure: keep only well-formed degradation records. A misbehaving provider must
+ * not be able to corrupt the rendered comment or the envelope.
+ *
+ * @param {unknown} input
+ * @returns {GateDegradation[]}
+ */
+export function normalizeDegradations(input) {
+  if (!Array.isArray(input)) return [];
+  const out = [];
+  for (const d of input) {
+    if (!d || typeof d !== 'object') continue;
+    const surface = typeof d.surface === 'string' ? d.surface : null;
+    const reason = typeof d.reason === 'string' ? d.reason : null;
+    if (surface === null || reason === null) continue;
+    out.push({
+      tool: typeof d.tool === 'string' ? d.tool : 'unknown',
+      gate: typeof d.gate === 'string' ? d.gate : 'unknown',
+      surface,
+      reason,
+    });
+  }
+  return out;
+}
+
+/**
+ * Feature-detect a provider's degradation channel, mirroring how
+ * `getPromptMessages` is feature-detected. Providers predating this contract
+ * carry no `getDegradations`, so the empty array keeps their output byte-stable;
+ * a throw degrades to empty (observability must never fail a review).
+ *
+ * MUST be called **after** `runReview` — a provider records its degradations
+ * during the run.
+ *
+ * @param {{ getDegradations?: Function }} reviewProvider
+ * @param {{ warn?: Function }} [logger]
+ * @returns {Promise<GateDegradation[]>}
+ */
+export async function collectProviderDegradations(reviewProvider, logger) {
+  if (typeof reviewProvider?.getDegradations !== 'function') return [];
+  try {
+    return normalizeDegradations(await reviewProvider.getDegradations());
+  } catch (err) {
+    logger?.warn?.(
+      `[code-review] getDegradations threw; treating as none. ${
+        err?.message ?? err
+      }`,
+    );
+    return [];
+  }
+}
+
+/**
+ * Pure: one-line operator-facing summary of the degraded gates, for progress
+ * output and comment tallies. Empty input renders `none` so the field is always
+ * present — a missing degradation line must never be read as "no degradation".
+ *
+ * @param {ReadonlyArray<GateDegradation>} degradations
+ * @returns {string}
+ */
+export function summarizeDegradations(degradations) {
+  const rows = normalizeDegradations(degradations);
+  if (rows.length === 0) return 'none';
+  return rows.map((d) => `${d.gate}/${d.surface} (${d.reason})`).join(', ');
+}
+
+/**
+ * Pure: the `{ degraded, degradations }` pair every outcome envelope carries, so
+ * a caller adds the channel by spreading one helper rather than restating the
+ * derivation (and cannot ship `degradations` without `degraded`).
+ *
+ * @param {unknown} degradations
+ * @returns {{ degraded: boolean, degradations: GateDegradation[] }}
+ */
+export function degradationEnvelope(degradations) {
+  const rows = normalizeDegradations(degradations);
+  return { degraded: rows.length > 0, degradations: rows };
+}
+
+/**
+ * Merge the degraded-gate records of every inline chain entry that carries the
+ * channel. A provider predating the contract contributes nothing; a throw is
+ * logged and skipped, because a chain must never lose a "this gate did not run"
+ * signal *or* fail a review over reporting one.
+ *
+ * @param {ReadonlyArray<{ name: string, provider: { getDegradations?: Function } }>} entries
+ * @param {{ warn?: Function }} [logger]
+ * @returns {Promise<GateDegradation[]>}
+ */
+export async function mergeChainDegradations(entries, logger) {
+  const merged = [];
+  for (const entry of entries) {
+    if (typeof entry.provider?.getDegradations !== 'function') continue;
+    try {
+      merged.push(
+        ...normalizeDegradations(await entry.provider.getDegradations()),
+      );
+    } catch (err) {
+      logger?.warn?.(
+        `[code-review] Inline provider "${entry.name}" getDegradations threw; skipping. ${
+          err?.message ?? err
+        }`,
+      );
+    }
+  }
+  return merged;
+}
+
+/**
+ * Pure: the header field naming how many gates did not run. Empty when the
+ * review was healthy, so a healthy body stays byte-identical to pre-#4839.
+ *
+ * @param {ReadonlyArray<GateDegradation>} degraded  Already normalized.
+ * @returns {string[]}
+ */
+export function renderDegradedHeaderLines(degraded) {
+  if (degraded.length === 0) return [];
+  return [`**Degraded gates**: ${degraded.length} (did not run)`];
+}
+
+/**
+ * Pure: the "nothing surfaced" block. This is the exact sentence the defect
+ * turned into a lie — with a degraded gate present, an all-zero tally is not a
+ * clean verdict and must not read like one.
+ *
+ * @param {ReadonlyArray<GateDegradation>} degraded  Already normalized.
+ * @returns {string[]}
+ */
+export function renderNoFindingsBlock(degraded) {
+  if (degraded.length === 0) {
+    return [
+      '### ✅ No findings',
+      '',
+      'No issues surfaced by the review provider.',
+    ];
+  }
+  return [
+    `### ⚠️ No findings — ${degraded.length} gate(s) did not run`,
+    '',
+    'The gates that ran surfaced no issues. This review does **not** vouch ' +
+      'for the degraded surface(s) listed above.',
+  ];
+}
+
+/**
+ * Pure: render the "Degraded Gates" section of the structured comment. Returns
+ * an empty array when nothing degraded, so a healthy review's body stays
+ * byte-identical to the pre-#4839 output.
+ *
+ * @param {ReadonlyArray<GateDegradation>} degradations
+ * @returns {string[]} markdown lines
+ */
+export function renderDegradedGatesSection(degradations) {
+  const rows = normalizeDegradations(degradations);
+  if (rows.length === 0) return [];
+  const lines = [
+    `### ⚠️ Degraded Gates (${rows.length})`,
+    '',
+    'The following review gate(s) **did not run**. Their surface is',
+    'unreviewed — an all-zero finding tally below does not vouch for it.',
+    '',
+  ];
+  for (const d of rows) {
+    lines.push(
+      `- \`${d.gate}\` → \`${d.surface}\` could not execute — ${d.reason} (emitter: \`${d.tool}\`).`,
+    );
+  }
+  lines.push('');
+  lines.push(
+    'Verify with the canonical `npm run lint` before trusting this review.',
+  );
+  lines.push('');
+  return lines;
+}

--- a/.agents/scripts/lib/orchestration/review-providers/findings-renderer.js
+++ b/.agents/scripts/lib/orchestration/review-providers/findings-renderer.js
@@ -15,6 +15,13 @@
  * @typedef {import('./types.js').Severity} Severity
  */
 
+import {
+  normalizeDegradations,
+  renderDegradedGatesSection,
+  renderDegradedHeaderLines,
+  renderNoFindingsBlock,
+} from './degraded-gates.js';
+
 /**
  * Canonical severity ordering. The render output always lists the
  * severity-tier counts in this order and emits the per-finding sections
@@ -115,6 +122,12 @@ export function renderManualPromptsSection(messages) {
  * manual-prompt provider output; rendered as a trailing section when
  * non-empty.
  *
+ * Story #4839 — an optional `degradations` field names review gates that could
+ * not execute. They are **not** findings and never enter `countBySeverity`; they
+ * render as their own section and suppress the unqualified "no findings" claim,
+ * because a review that could not run a gate has not established that the
+ * gate's surface is clean.
+ *
  * @param {{
  *   ticketId: number,
  *   baseRef: string,
@@ -122,6 +135,7 @@ export function renderManualPromptsSection(messages) {
  *   findings: ReadonlyArray<Finding>,
  *   provider?: string,
  *   promptMessages?: ReadonlyArray<string>,
+ *   degradations?: ReadonlyArray<object>,
  * }} input
  * @returns {string}
  */
@@ -131,6 +145,7 @@ export function renderFindings(input) {
   const counts = countBySeverity(findings);
   const totalKnown =
     counts.critical + counts.high + counts.medium + counts.suggestion;
+  const degraded = normalizeDegradations(input.degradations);
 
   const providerLine = provider
     ? `**Provider**: \`${provider}\``
@@ -142,6 +157,7 @@ export function renderFindings(input) {
     `**Comparison**: \`${baseRef}\` … \`${headRef}\``,
     providerLine,
     `**Findings**: ${totalKnown}`,
+    ...renderDegradedHeaderLines(degraded),
     '',
     '### 📦 Severity Tier Counts',
     '',
@@ -150,12 +166,11 @@ export function renderFindings(input) {
       return `- ${meta.emoji} ${meta.label}: ${counts[sev]}`;
     }),
     '',
+    ...renderDegradedGatesSection(degraded),
   ];
 
   if (totalKnown === 0) {
-    lines.push('### ✅ No findings');
-    lines.push('');
-    lines.push('No issues surfaced by the review provider.');
+    lines.push(...renderNoFindingsBlock(degraded));
   } else {
     for (const sev of SEVERITY_ORDER) {
       const tierFindings = findings.filter((f) => f && f.severity === sev);

--- a/.agents/scripts/lib/orchestration/review-providers/native.js
+++ b/.agents/scripts/lib/orchestration/review-providers/native.js
@@ -53,22 +53,20 @@ import {
 } from '../../observability/runtime-friction.js';
 import { PROJECT_ROOT } from '../../project-root.js';
 import { transpileIfNeeded } from '../../transpile.js';
-import { runScopedLint as runScopedLintImpl } from './scoped-lint.js';
+import {
+  parseLintOutput,
+  partitionFilesForLint,
+  runScopedLint,
+} from './scoped-lint.js';
 
 /**
  * The scoped-lint surface lives in [`scoped-lint.js`](scoped-lint.js), which
  * owns runner resolution, per-surface classification, and the merge. Story
  * #4839 moved it there while fixing the three invocation defects that made this
  * gate fail open on ~78% of deliveries; the module docstring there carries the
- * diagnosis. Re-exported here because `runScopedLint` (with `parseLintOutput`
- * and `partitionFilesForLint`) is this provider's published lint seam.
+ * diagnosis. The three names stay part of this provider's published lint seam.
  */
-export {
-  parseLintOutput,
-  partitionFilesForLint,
-  resolveMarkdownRunner,
-  runScopedLint,
-} from './scoped-lint.js';
+export { parseLintOutput, partitionFilesForLint, runScopedLint };
 
 /** Worker entry that scores one file into a full maintainability report. */
 const MAINTAINABILITY_REPORT_WORKER_URL = new URL(
@@ -465,7 +463,7 @@ function buildLintDegradations(lintSummary) {
  *
  * @param {{
  *   gitSpawnFn?: typeof gitSpawn,
- *   runScopedLintFn?: typeof runScopedLintImpl,
+ *   runScopedLintFn?: typeof runScopedLint,
  *   analyzeChangedFilesFn?: typeof analyzeChangedFiles,
  *   buildLintFindingsFn?: typeof buildLintFindings,
  *   emitToolDegradationFn?: typeof emitRuntimeFriction,
@@ -477,7 +475,7 @@ function buildLintDegradations(lintSummary) {
 export function createNativeProvider(deps = {}) {
   const {
     gitSpawnFn = gitSpawn,
-    runScopedLintFn = runScopedLintImpl,
+    runScopedLintFn = runScopedLint,
     analyzeChangedFilesFn = analyzeChangedFiles,
     buildLintFindingsFn = buildLintFindings,
     emitToolDegradationFn = emitRuntimeFriction,

--- a/.agents/scripts/lib/orchestration/review-providers/native.js
+++ b/.agents/scripts/lib/orchestration/review-providers/native.js
@@ -40,7 +40,6 @@
  * @typedef {import('./types.js').ReviewProvider} ReviewProvider
  */
 
-import { spawnSync } from 'node:child_process';
 import path from 'node:path';
 import { POOL_SERIAL_THRESHOLD, runOnPool } from '../../cpu-pool.js';
 import { gitSpawn } from '../../git-utils.js';
@@ -54,6 +53,22 @@ import {
 } from '../../observability/runtime-friction.js';
 import { PROJECT_ROOT } from '../../project-root.js';
 import { transpileIfNeeded } from '../../transpile.js';
+import { runScopedLint as runScopedLintImpl } from './scoped-lint.js';
+
+/**
+ * The scoped-lint surface lives in [`scoped-lint.js`](scoped-lint.js), which
+ * owns runner resolution, per-surface classification, and the merge. Story
+ * #4839 moved it there while fixing the three invocation defects that made this
+ * gate fail open on ~78% of deliveries; the module docstring there carries the
+ * diagnosis. Re-exported here because `runScopedLint` (with `parseLintOutput`
+ * and `partitionFilesForLint`) is this provider's published lint seam.
+ */
+export {
+  parseLintOutput,
+  partitionFilesForLint,
+  resolveMarkdownRunner,
+  runScopedLint,
+} from './scoped-lint.js';
 
 /** Worker entry that scores one file into a full maintainability report. */
 const MAINTAINABILITY_REPORT_WORKER_URL = new URL(
@@ -73,72 +88,6 @@ const MAINTAINABILITY_REPORT_WORKER_URL = new URL(
 export const SERIAL_THRESHOLD = POOL_SERIAL_THRESHOLD;
 
 const JS_MAINTAINABILITY_EXTS = new Set(['.js', '.mjs', '.cjs']);
-
-/**
- * Parse stdout/stderr from a lint runner to estimate error vs warning counts.
- *
- * Handles the two runners composing `npm run lint` in this project:
- *   - Biome: emits "Found N error(s)." and "Found N warning(s)." lines.
- *   - markdownlint: emits one diagnostic per issue, plus a trailing
- *     "Summary: N error(s)" line.
- *
- * Severity classification: when the runner exits non-zero but its output
- * matches neither known reporter format, the result is "could not classify" —
- * `executionFailed: true` so callers can degrade the gate to a suggestion +
- * skipped marker rather than mislabelling an environment problem as high risk.
- *
- * Exported for testing.
- *
- * @param {{ status: number, stdout: string, stderr: string }} result
- * @returns {{ errors: number, warnings: number, parsed: boolean, executionFailed: boolean }}
- */
-export function parseLintOutput(result) {
-  const combined = `${result.stdout ?? ''}\n${result.stderr ?? ''}`;
-
-  let errors = 0;
-  let warnings = 0;
-  let parsed = false;
-
-  const errMatches = combined.matchAll(/Found\s+(\d+)\s+error/gi);
-  for (const m of errMatches) {
-    errors += Number(m[1]);
-    parsed = true;
-  }
-  const warnMatches = combined.matchAll(/Found\s+(\d+)\s+warning/gi);
-  for (const m of warnMatches) {
-    warnings += Number(m[1]);
-    parsed = true;
-  }
-
-  const mdSummary = combined.match(/Summary:\s+(\d+)\s+error/i);
-  if (mdSummary) {
-    errors += Number(mdSummary[1]);
-    parsed = true;
-  }
-
-  const executionFailed = !parsed && result.status !== 0;
-
-  return { errors, warnings, parsed, executionFailed };
-}
-
-/**
- * Pure: split changed paths into the file lists each lint runner consumes.
- *
- * Exported for testing.
- *
- * @param {string[]} changedFiles
- * @returns {{ code: string[], md: string[] }}
- */
-export function partitionFilesForLint(changedFiles) {
-  const CODE = /\.(js|mjs|cjs|jsx|ts|tsx|json|jsonc)$/i;
-  const code = [];
-  const md = [];
-  for (const f of changedFiles) {
-    if (CODE.test(f)) code.push(f);
-    else if (/\.md$/i.test(f)) md.push(f);
-  }
-  return { code, md };
-}
 
 /**
  * Read a changed file's content as it exists at `headRef` via
@@ -195,61 +144,6 @@ export function scoreSourceReport(source, relPath) {
     };
   }
   return calculateReport(prepared);
-}
-
-function spawnLintRunner(bin, args, cwd) {
-  const result = spawnSync('npx', ['--no', bin, ...args], {
-    cwd,
-    encoding: 'utf-8',
-    shell: process.platform === 'win32',
-  });
-  return {
-    status: result.status ?? 1,
-    stdout: result.stdout ?? '',
-    stderr: result.stderr ?? '',
-  };
-}
-
-/**
- * Run lint scoped to the changed surface only. Returns a normalized summary
- * compatible with `parseLintOutput` plus a `skipped` flag set when there is
- * no JS or markdown file in the changed set (nothing to lint).
- *
- * @param {string[]} changedFiles
- * @param {string} cwd
- * @param {(bin: string, args: string[], cwd: string) => { status: number, stdout: string, stderr: string }} [runnerFn]
- * @returns {{ errors: number, warnings: number, parsed: boolean, skipped: boolean, mode: 'changed-only', executionFailed?: boolean }}
- */
-export function runScopedLint(changedFiles, cwd, runnerFn = spawnLintRunner) {
-  const { code, md } = partitionFilesForLint(changedFiles);
-  if (code.length === 0 && md.length === 0) {
-    return {
-      errors: 0,
-      warnings: 0,
-      parsed: false,
-      skipped: true,
-      mode: 'changed-only',
-    };
-  }
-
-  const runs = [];
-  if (code.length > 0) runs.push(runnerFn('biome', ['lint', ...code], cwd));
-  if (md.length > 0) {
-    runs.push(
-      runnerFn('markdownlint', [...md, '--ignore', 'node_modules'], cwd),
-    );
-  }
-
-  let status = 0;
-  let stdout = '';
-  let stderr = '';
-  for (const r of runs) {
-    if ((r.status ?? 1) > status) status = r.status ?? 1;
-    stdout += r.stdout ?? '';
-    stderr += r.stderr ?? '';
-  }
-  const summary = parseLintOutput({ status, stdout, stderr });
-  return { ...summary, skipped: false, mode: 'changed-only' };
 }
 
 /**
@@ -523,12 +417,43 @@ async function runLintPhase({
       parsed: false,
       skipped: true,
       mode: 'off',
+      executionFailed: false,
+      degradations: [],
     };
   }
   logger?.info?.(
     '[native-review] Linting changed files only (biome + markdownlint, scoped to diff)...',
   );
   return runScopedLintFn(changedFiles, PROJECT_ROOT);
+}
+
+/**
+ * Pure: turn an `executionFailed` lint summary into the degradation records the
+ * review outcome carries beside its findings (Story #4839).
+ *
+ * A summary from `runScopedLint` names each failed surface; an injected or
+ * legacy summary that sets only `executionFailed` degrades to one record for
+ * the gate as a whole, so the outcome is never silent about a gate that did not
+ * run just because the summary predates the per-surface contract.
+ *
+ * @param {{ executionFailed?: boolean, degradations?: Array<{ surface: string, reason: string }> }} lintSummary
+ * @returns {Array<{ tool: string, gate: string, surface: string, reason: string }>}
+ */
+function buildLintDegradations(lintSummary) {
+  if (!lintSummary.executionFailed) return [];
+  const rows = Array.isArray(lintSummary.degradations)
+    ? lintSummary.degradations
+    : [];
+  const surfaces =
+    rows.length > 0
+      ? rows
+      : [{ surface: 'scoped-lint', reason: 'unparseable-output' }];
+  return surfaces.map((row) => ({
+    tool: 'native-review-lint',
+    gate: 'scoped-lint',
+    surface: row.surface,
+    reason: row.reason,
+  }));
 }
 
 /**
@@ -540,7 +465,7 @@ async function runLintPhase({
  *
  * @param {{
  *   gitSpawnFn?: typeof gitSpawn,
- *   runScopedLintFn?: typeof runScopedLint,
+ *   runScopedLintFn?: typeof runScopedLintImpl,
  *   analyzeChangedFilesFn?: typeof analyzeChangedFiles,
  *   buildLintFindingsFn?: typeof buildLintFindings,
  *   emitToolDegradationFn?: typeof emitRuntimeFriction,
@@ -552,7 +477,7 @@ async function runLintPhase({
 export function createNativeProvider(deps = {}) {
   const {
     gitSpawnFn = gitSpawn,
-    runScopedLintFn = runScopedLint,
+    runScopedLintFn = runScopedLintImpl,
     analyzeChangedFilesFn = analyzeChangedFiles,
     buildLintFindingsFn = buildLintFindings,
     emitToolDegradationFn = emitRuntimeFriction,
@@ -560,12 +485,33 @@ export function createNativeProvider(deps = {}) {
     scopeLint = 'changed-only',
   } = deps;
 
+  /**
+   * Degradations recorded by the most recent `runReview`. Read through
+   * `getDegradations()` after the run, mirroring how `getPromptMessages` is
+   * feature-detected by the orchestrator — findings and degradations travel
+   * side by side, so an unexecutable tool never has to become a `Finding` to
+   * be visible (Story #4699's intent; Story #4839's fix).
+   *
+   * @type {Array<{ tool: string, gate: string, surface: string, reason: string }>}
+   */
+  let recordedDegradations = [];
+
   return {
+    /**
+     * Gate degradations from the last `runReview`. Never a `Finding`, so
+     * severity counts stay code-findings-only.
+     *
+     * @returns {Array<{ tool: string, gate: string, surface: string, reason: string }>}
+     */
+    getDegradations() {
+      return recordedDegradations;
+    },
     /**
      * @param {ReviewInput} input
      * @returns {Promise<Finding[]>}
      */
     async runReview(input) {
+      recordedDegradations = [];
       const { scope, ticketId, baseRef, headRef } = input ?? {};
       if (!baseRef || !headRef) {
         throw new TypeError(
@@ -623,8 +569,19 @@ export function createNativeProvider(deps = {}) {
         // Story #4699 — a tool that could not execute is an operational
         // degradation, not a code finding. Route it to friction telemetry
         // (best-effort) so severity counts reflect code findings only.
+        //
+        // Story #4839 — telemetry alone left the review's own verdict unable to
+        // distinguish "lint ran and found nothing" from "lint never ran", so
+        // the same degradation is also recorded on the outcome channel. It is
+        // still never a `Finding`: the friction emission below is unchanged and
+        // severity counts remain code-findings-only.
+        recordedDegradations = buildLintDegradations(lintSummary);
         logger?.warn?.(
-          '[native-review] Lint runner could not execute — recorded as friction telemetry, no finding emitted. Verify with the canonical `npm run lint` before merging.',
+          `[native-review] Lint runner could not execute (${recordedDegradations
+            .map((d) => `${d.surface}: ${d.reason}`)
+            .join(
+              '; ',
+            )}) — reported as a degraded gate on the review outcome and recorded as friction telemetry; no finding emitted. Verify with the canonical \`npm run lint\` before merging.`,
         );
         try {
           await emitToolDegradationFn({
@@ -646,9 +603,10 @@ export function createNativeProvider(deps = {}) {
 
       // Canonical ordering: critical (maintainability) first, then high
       // (lint errors), then medium (size/volume warnings), then suggestion
-      // (lint warnings / executionFailed). The renderer re-bucketizes by
-      // severity tier, so this order only matters for stability of fixture
-      // outputs.
+      // (lint warnings). An execution failure contributes to none of these
+      // tiers — it travels on the degradation channel. The renderer
+      // re-bucketizes by severity tier, so this order only matters for
+      // stability of fixture outputs.
       return [
         ...results.criticalFindings,
         ...lintFindings.filter((f) => f.severity === 'high'),

--- a/.agents/scripts/lib/orchestration/review-providers/review-provider-factory.js
+++ b/.agents/scripts/lib/orchestration/review-providers/review-provider-factory.js
@@ -35,6 +35,7 @@
  */
 
 import { createCodexProviderForRegistry } from './codex.js';
+import { mergeChainDegradations } from './degraded-gates.js';
 import { createNativeProviderForRegistry } from './native.js';
 import { createSecurityReviewProviderForRegistry } from './security-review.js';
 import { createUltrareviewProviderForRegistry } from './ultrareview.js';
@@ -287,6 +288,15 @@ export function createChainProvider(chain, opts = {}) {
         for (const f of findings) merged.push(f);
       }
       return merged;
+    },
+    /**
+     * Degraded gates across the inline chain (Story #4839). Called after
+     * `runReview`.
+     *
+     * @returns {Promise<Array<object>>}
+     */
+    async getDegradations() {
+      return mergeChainDegradations(chain.inline, logger);
     },
     /**
      * @param {ReviewInput} input

--- a/.agents/scripts/lib/orchestration/review-providers/scoped-lint.js
+++ b/.agents/scripts/lib/orchestration/review-providers/scoped-lint.js
@@ -1,0 +1,297 @@
+/**
+ * review-providers/scoped-lint.js — the scoped-lint surface of the native
+ * review provider (extracted from `native.js` by Story #4839).
+ *
+ * ## Why this module exists
+ *
+ * The scoped-lint gate reported `executionFailed` — and therefore emitted zero
+ * findings while the review reported clean — on 18 of 23 Beestera/swarm-os
+ * Stories carrying friction (78%) and on 5 mandrel Stories. Measured
+ * 2026-07-29, the cause was **not** environmental and **not** a parse failure.
+ * Three defects in how the runners were invoked and reconciled produced the
+ * same symptom:
+ *
+ * 1. **The markdown runner was never resolvable.** The provider spawned
+ *    `npx --no markdownlint`, but the binary this project (and the consumer)
+ *    installs is `markdownlint-cli2` — `markdownlint-cli2` is the package and
+ *    the bin name; a bare `markdownlint` bin does not exist. `npx --no` with an
+ *    unresolvable bin exits 1 printing `could not determine executable to run`
+ *    and nothing else, so the summary parsed nothing and the gate degraded.
+ *    The parser was already written for **cli2's** `Summary: N error(s)` line,
+ *    so the invocation and the parser had never agreed. The `--ignore
+ *    node_modules` flag was likewise `markdownlint-cli` (v1) syntax, which
+ *    cli2 does not accept. Fix: resolve the runner from what is actually
+ *    installed and pass each candidate its own argument shape.
+ *
+ * 2. **One runner's failure poisoned the other's verdict.** The two runs were
+ *    folded into a *single* `parseLintOutput` call over concatenated output and
+ *    the maximum exit status. So the unresolvable markdown runner's exit 1
+ *    became the verdict for biome too: any change set containing at least one
+ *    `.md` file degraded the whole gate whenever biome itself had nothing to
+ *    report — i.e. exactly the clean case the gate exists to confirm. Fix:
+ *    classify each surface independently and merge structurally.
+ *
+ * 3. **Biome's "nothing in scope" exit was read as a failure.** `biome lint`
+ *    exits 1 with `No files were processed in the specified paths.` when every
+ *    supplied path is excluded by `biome.json` (`temp/`, `dist/`,
+ *    `.worktrees/`, anything in the VCS ignore file). That is an empty scope,
+ *    not a runner that could not execute. Fix: recognise the sentinel.
+ *
+ * ## What a degraded surface now produces
+ *
+ * `runScopedLint` still reports `executionFailed` — the friction-telemetry
+ * emission in `native.js` is deliberately unchanged (Story #4699 routed an
+ * unexecutable tool to telemetry so severity tiers reflect code findings only,
+ * and that intent stands). It additionally reports a `degradations[]` array
+ * naming **which** surface could not run and **why**, so the review outcome can
+ * say "this gate did not run" instead of silently reading clean.
+ */
+
+import { spawnSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import path from 'node:path';
+
+/** Paths these extensions land on the biome (code) runner. */
+const CODE_EXTENSIONS = /\.(js|mjs|cjs|jsx|ts|tsx|json|jsonc)$/i;
+
+/** npx's message when the requested bin cannot be resolved. */
+const NPX_UNRESOLVABLE = /could not determine executable to run/i;
+
+/** Biome's exit-1 message when every supplied path is config-excluded. */
+const BIOME_EMPTY_SCOPE = /No files were processed in the specified paths/i;
+
+/**
+ * Markdown runners in preference order, each with the argument shape *it*
+ * accepts. `markdownlint-cli2` takes bare paths/globs and rejects `--ignore`;
+ * `markdownlint` (cli v1) takes `--ignore`. Explicit changed-file paths are
+ * passed either way, so the v1 ignore flag is belt-and-braces only.
+ */
+const MARKDOWN_RUNNERS = Object.freeze([
+  Object.freeze({ bin: 'markdownlint-cli2', extraArgs: Object.freeze([]) }),
+  Object.freeze({
+    bin: 'markdownlint',
+    extraArgs: Object.freeze(['--ignore', 'node_modules']),
+  }),
+]);
+
+/** Reason codes carried on a degradation record. */
+export const LINT_DEGRADATION_REASONS = Object.freeze({
+  RUNNER_NOT_INSTALLED: 'runner-not-installed',
+  RUNNER_NOT_RESOLVABLE: 'runner-not-resolvable',
+  UNPARSEABLE_OUTPUT: 'unparseable-output',
+});
+
+/**
+ * Spawn one lint runner through `npx --no` (never install on the fly).
+ *
+ * @param {string} bin
+ * @param {string[]} args
+ * @param {string} cwd
+ * @returns {{ status: number, stdout: string, stderr: string }}
+ */
+function spawnLintRunner(bin, args, cwd) {
+  const result = spawnSync('npx', ['--no', bin, ...args], {
+    cwd,
+    encoding: 'utf-8',
+    shell: process.platform === 'win32',
+  });
+  return {
+    status: result.status ?? 1,
+    stdout: result.stdout ?? '',
+    stderr: result.stderr ?? '',
+  };
+}
+
+/**
+ * Pure-ish: pick the first markdown runner whose bin is actually installed
+ * under `<cwd>/node_modules/.bin`. Returns `null` when none is — an honest
+ * "this surface has no runner" that the caller reports rather than silently
+ * folding into a generic parse failure.
+ *
+ * The disk probe (rather than "spawn and see") is what makes the failure
+ * *nameable*: `npx --no <missing-bin>` yields only a generic npm error, which
+ * is precisely how the defect hid for months.
+ *
+ * @param {string} cwd
+ * @param {(p: string) => boolean} [existsFn]  Injected for testing.
+ * @returns {{ bin: string, extraArgs: ReadonlyArray<string> }|null}
+ */
+export function resolveMarkdownRunner(cwd, existsFn = existsSync) {
+  for (const candidate of MARKDOWN_RUNNERS) {
+    const base = path.join(cwd, 'node_modules', '.bin', candidate.bin);
+    if (existsFn(base)) return candidate;
+    if (
+      process.platform === 'win32' &&
+      (existsFn(`${base}.cmd`) || existsFn(`${base}.ps1`))
+    ) {
+      return candidate;
+    }
+  }
+  return null;
+}
+
+/**
+ * Pure: split changed paths into the file lists each lint runner consumes.
+ *
+ * @param {string[]} changedFiles
+ * @returns {{ code: string[], md: string[] }}
+ */
+export function partitionFilesForLint(changedFiles) {
+  const code = [];
+  const md = [];
+  for (const f of changedFiles) {
+    if (CODE_EXTENSIONS.test(f)) code.push(f);
+    else if (/\.md$/i.test(f)) md.push(f);
+  }
+  return { code, md };
+}
+
+/**
+ * Pure: classify **one** runner's result into a summary.
+ *
+ * Handles the reporter formats composing `npm run lint` here:
+ *   - Biome: `Found N error(s).` / `Found N warning(s).`
+ *   - markdownlint-cli2: a trailing `Summary: N error(s)` line.
+ *
+ * A non-zero exit whose output matches no known reporter format is "could not
+ * classify" → `executionFailed: true`, with `reason` naming what was actually
+ * observed. Biome's empty-scope exit is recognised separately as
+ * `emptyScope` — nothing to lint is not a broken runner.
+ *
+ * @param {{ status?: number, stdout?: string, stderr?: string }} result
+ * @returns {{ errors: number, warnings: number, parsed: boolean, executionFailed: boolean, emptyScope: boolean, reason: string|null }}
+ */
+export function parseLintOutput(result) {
+  const combined = `${result.stdout ?? ''}\n${result.stderr ?? ''}`;
+
+  let errors = 0;
+  let warnings = 0;
+  let parsed = false;
+
+  for (const m of combined.matchAll(/Found\s+(\d+)\s+error/gi)) {
+    errors += Number(m[1]);
+    parsed = true;
+  }
+  for (const m of combined.matchAll(/Found\s+(\d+)\s+warning/gi)) {
+    warnings += Number(m[1]);
+    parsed = true;
+  }
+  const mdSummary = combined.match(/Summary:\s+(\d+)\s+error/i);
+  if (mdSummary) {
+    errors += Number(mdSummary[1]);
+    parsed = true;
+  }
+
+  const failedExit = !parsed && (result.status ?? 0) !== 0;
+  const emptyScope = failedExit && BIOME_EMPTY_SCOPE.test(combined);
+  const executionFailed = failedExit && !emptyScope;
+  const reason = executionFailed
+    ? NPX_UNRESOLVABLE.test(combined)
+      ? LINT_DEGRADATION_REASONS.RUNNER_NOT_RESOLVABLE
+      : LINT_DEGRADATION_REASONS.UNPARSEABLE_OUTPUT
+    : null;
+
+  return { errors, warnings, parsed, executionFailed, emptyScope, reason };
+}
+
+/**
+ * Pure: merge per-surface summaries into the gate's single summary. Counts add;
+ * `executionFailed` is the OR across surfaces; each failed surface contributes
+ * one degradation record naming itself. Merging *summaries* rather than raw
+ * output is what stops one runner's failure from becoming the other's verdict.
+ *
+ * @param {Array<{ surface: string, summary: ReturnType<typeof parseLintOutput> }>} surfaces
+ */
+function mergeSurfaceSummaries(surfaces) {
+  let errors = 0;
+  let warnings = 0;
+  let parsed = false;
+  let executionFailed = false;
+  const degradations = [];
+
+  for (const { surface, summary } of surfaces) {
+    errors += summary.errors;
+    warnings += summary.warnings;
+    if (summary.parsed) parsed = true;
+    if (summary.executionFailed) {
+      executionFailed = true;
+      degradations.push({
+        surface,
+        reason: summary.reason ?? LINT_DEGRADATION_REASONS.UNPARSEABLE_OUTPUT,
+      });
+    }
+  }
+
+  return {
+    errors,
+    warnings,
+    parsed,
+    executionFailed,
+    skipped: false,
+    mode: 'changed-only',
+    degradations,
+  };
+}
+
+/**
+ * Run lint scoped to the changed surface only.
+ *
+ * @param {string[]} changedFiles
+ * @param {string} cwd
+ * @param {typeof spawnLintRunner} [runnerFn]
+ * @param {{ existsFn?: (p: string) => boolean }} [deps]  Test seam for runner resolution.
+ * @returns {{ errors: number, warnings: number, parsed: boolean, skipped: boolean, mode: 'changed-only'|'off', executionFailed: boolean, degradations: Array<{ surface: string, reason: string }> }}
+ */
+export function runScopedLint(
+  changedFiles,
+  cwd,
+  runnerFn = spawnLintRunner,
+  deps = {},
+) {
+  const { existsFn = existsSync } = deps;
+  const { code, md } = partitionFilesForLint(changedFiles);
+  if (code.length === 0 && md.length === 0) {
+    return {
+      errors: 0,
+      warnings: 0,
+      parsed: false,
+      skipped: true,
+      mode: 'changed-only',
+      executionFailed: false,
+      degradations: [],
+    };
+  }
+
+  const surfaces = [];
+  if (code.length > 0) {
+    surfaces.push({
+      surface: 'biome',
+      summary: parseLintOutput(runnerFn('biome', ['lint', ...code], cwd)),
+    });
+  }
+  if (md.length > 0) {
+    const runner = resolveMarkdownRunner(cwd, existsFn);
+    if (runner === null) {
+      surfaces.push({
+        surface: 'markdownlint',
+        summary: {
+          errors: 0,
+          warnings: 0,
+          parsed: false,
+          executionFailed: true,
+          emptyScope: false,
+          reason: LINT_DEGRADATION_REASONS.RUNNER_NOT_INSTALLED,
+        },
+      });
+    } else {
+      surfaces.push({
+        surface: runner.bin,
+        summary: parseLintOutput(
+          runnerFn(runner.bin, [...md, ...runner.extraArgs], cwd),
+        ),
+      });
+    }
+  }
+
+  return mergeSurfaceSummaries(surfaces);
+}

--- a/.agents/scripts/lib/orchestration/review-providers/scoped-lint.js
+++ b/.agents/scripts/lib/orchestration/review-providers/scoped-lint.js
@@ -75,7 +75,7 @@ const MARKDOWN_RUNNERS = Object.freeze([
 ]);
 
 /** Reason codes carried on a degradation record. */
-export const LINT_DEGRADATION_REASONS = Object.freeze({
+const DEGRADATION_REASONS = Object.freeze({
   RUNNER_NOT_INSTALLED: 'runner-not-installed',
   RUNNER_NOT_RESOLVABLE: 'runner-not-resolvable',
   UNPARSEABLE_OUTPUT: 'unparseable-output',
@@ -112,11 +112,14 @@ function spawnLintRunner(bin, args, cwd) {
  * *nameable*: `npx --no <missing-bin>` yields only a generic npm error, which
  * is precisely how the defect hid for months.
  *
+ * Not exported: it is reachable — and asserted — through {@link runScopedLint},
+ * whose `existsFn` seam drives every resolution branch.
+ *
  * @param {string} cwd
  * @param {(p: string) => boolean} [existsFn]  Injected for testing.
  * @returns {{ bin: string, extraArgs: ReadonlyArray<string> }|null}
  */
-export function resolveMarkdownRunner(cwd, existsFn = existsSync) {
+function resolveMarkdownRunner(cwd, existsFn = existsSync) {
   for (const candidate of MARKDOWN_RUNNERS) {
     const base = path.join(cwd, 'node_modules', '.bin', candidate.bin);
     if (existsFn(base)) return candidate;
@@ -187,8 +190,8 @@ export function parseLintOutput(result) {
   const executionFailed = failedExit && !emptyScope;
   const reason = executionFailed
     ? NPX_UNRESOLVABLE.test(combined)
-      ? LINT_DEGRADATION_REASONS.RUNNER_NOT_RESOLVABLE
-      : LINT_DEGRADATION_REASONS.UNPARSEABLE_OUTPUT
+      ? DEGRADATION_REASONS.RUNNER_NOT_RESOLVABLE
+      : DEGRADATION_REASONS.UNPARSEABLE_OUTPUT
     : null;
 
   return { errors, warnings, parsed, executionFailed, emptyScope, reason };
@@ -217,7 +220,7 @@ function mergeSurfaceSummaries(surfaces) {
       executionFailed = true;
       degradations.push({
         surface,
-        reason: summary.reason ?? LINT_DEGRADATION_REASONS.UNPARSEABLE_OUTPUT,
+        reason: summary.reason ?? DEGRADATION_REASONS.UNPARSEABLE_OUTPUT,
       });
     }
   }
@@ -280,7 +283,7 @@ export function runScopedLint(
           parsed: false,
           executionFailed: true,
           emptyScope: false,
-          reason: LINT_DEGRADATION_REASONS.RUNNER_NOT_INSTALLED,
+          reason: DEGRADATION_REASONS.RUNNER_NOT_INSTALLED,
         },
       });
     } else {

--- a/.agents/scripts/lib/orchestration/single-story-close/phases/code-review.js
+++ b/.agents/scripts/lib/orchestration/single-story-close/phases/code-review.js
@@ -28,8 +28,13 @@
  */
 
 import { parsePrNumberFromUrl } from '../../../github-url.js';
+import { degradationEnvelope } from '../../review-providers/degraded-gates.js';
 import { runStoryReviewCore } from '../../story-close/phases/review-core.js';
 import { postStructuredComment } from '../../ticketing/state.js';
+import {
+  buildOutcomeTally,
+  formatReviewOutcomeLines,
+} from './review-outcome.js';
 
 /**
  * Extract the numeric PR ID from a `gh pr create` URL. The CLI returns a
@@ -62,13 +67,11 @@ export function buildStoryReviewCrossRefBody({
   prNumber,
   commentUrl,
   severity,
+  degradations,
 }) {
-  const tally =
-    `critical:${severity.critical} · high:${severity.high} · ` +
-    `medium:${severity.medium} · suggestion:${severity.suggestion}`;
   return (
     `🔬 Story-scope code review posted on PR [#${prNumber}](${prUrl}): ` +
-    `[view findings](${commentUrl}) — ${tally}.`
+    `[view findings](${commentUrl}) — ${buildOutcomeTally({ severity, degradations })}.`
   );
 }
 
@@ -116,6 +119,7 @@ async function postStoryReviewCrossRef({
       prNumber,
       commentUrl,
       severity,
+      degradations: result.degradations,
     });
     try {
       await postStructuredComment(provider, storyId, 'notification', body);
@@ -174,6 +178,8 @@ async function postStoryReviewCrossRef({
  *   severity?: { critical: number, high: number, medium: number, suggestion: number },
  *   posted?: boolean,
  *   postedCommentId?: number|null,
+ *   degraded?: boolean,
+ *   degradations?: Array<object>,
  *   crossRefPosted?: boolean,
  *   localLensReview?: object,
  * }>}
@@ -222,10 +228,13 @@ export async function runStoryScopeReview({
     medium: 0,
     suggestion: 0,
   };
-  progress(
-    'REVIEW',
-    `Findings — critical:${sev.critical} high:${sev.high} medium:${sev.medium} suggestion:${sev.suggestion}. Posted to PR #${prNumber}: ${result.posted}.`,
-  );
+  const outcome = formatReviewOutcomeLines({
+    severity: sev,
+    degradations: result.degradations,
+    prNumber,
+    posted: result.posted,
+  });
+  for (const line of outcome) progress('REVIEW', line);
 
   const crossRefPosted = await postStoryReviewCrossRef({
     provider,
@@ -242,6 +251,7 @@ export async function runStoryScopeReview({
     severity: sev,
     posted: result.posted,
     postedCommentId: result.postedCommentId ?? null,
+    ...degradationEnvelope(result.degradations),
     crossRefPosted,
     localLensReview: result.localLensReview,
   };

--- a/.agents/scripts/lib/orchestration/single-story-close/phases/review-outcome.js
+++ b/.agents/scripts/lib/orchestration/single-story-close/phases/review-outcome.js
@@ -1,0 +1,66 @@
+/**
+ * phases/review-outcome.js — operator-facing rendering of the Story-scope
+ * review outcome (Story #4839).
+ *
+ * The review phase used to report a severity tally and nothing else, which made
+ * "every gate ran and found nothing" and "a gate never ran" render identically.
+ * Both surfaces the operator actually reads — the close progress stream and the
+ * cross-reference comment on the Story — now state the degraded gates
+ * explicitly, and always state them (as `none` when healthy) so an absent line
+ * can never be mistaken for a clean gate.
+ *
+ * A degraded gate is **reported, not blocking**: the canonical `npm run lint`
+ * close-validation gate has already covered this diff before the review phase
+ * runs, so failing the merge on a secondary read of an already-gated surface
+ * would cost delivery without buying coverage. The rationale for that posture
+ * lives with the channel itself in
+ * [`review-providers/degraded-gates.js`](../../review-providers/degraded-gates.js).
+ */
+
+import { summarizeDegradations } from '../../review-providers/degraded-gates.js';
+
+/**
+ * Pure: the tally suffix shared by the progress line and the cross-reference
+ * comment — severity counts plus the degraded-gate state.
+ *
+ * @param {{ severity: { critical: number, high: number, medium: number, suggestion: number }, degradations?: unknown }} args
+ * @returns {string}
+ */
+export function buildOutcomeTally({ severity, degradations }) {
+  return (
+    `critical:${severity.critical} · high:${severity.high} · ` +
+    `medium:${severity.medium} · suggestion:${severity.suggestion} · ` +
+    `degraded gates: ${summarizeDegradations(degradations)}`
+  );
+}
+
+/**
+ * Pure: the progress lines announcing a completed review. Always one line
+ * naming the tally; a second, explicitly-worded line when a gate did not run so
+ * the degradation cannot be skimmed past.
+ *
+ * @param {{
+ *   severity: { critical: number, high: number, medium: number, suggestion: number },
+ *   degradations?: unknown,
+ *   prNumber: number,
+ *   posted: boolean,
+ * }} args
+ * @returns {string[]}
+ */
+export function formatReviewOutcomeLines({
+  severity,
+  degradations,
+  prNumber,
+  posted,
+}) {
+  const tally = buildOutcomeTally({ severity, degradations });
+  const lines = [`Findings — ${tally}. Posted to PR #${prNumber}: ${posted}.`];
+  if (summarizeDegradations(degradations) !== 'none') {
+    lines.push(
+      '⚠️ Review ran DEGRADED — the surface(s) above were not reviewed. The close ' +
+        'is not blocked (the canonical `npm run lint` close gate already covered ' +
+        'this diff), but this review does not vouch for them.',
+    );
+  }
+  return lines;
+}

--- a/.agents/scripts/lib/orchestration/story-close/phases/code-review.js
+++ b/.agents/scripts/lib/orchestration/story-close/phases/code-review.js
@@ -38,6 +38,7 @@
 
 import { Logger } from '../../../Logger.js';
 import { runCodeReview } from '../../code-review.js';
+import { summarizeDegradations } from '../../review-providers/degraded-gates.js';
 import { emitBlockedCloseResult } from '../emit-blocked.js';
 import { runLocalLensReview } from './local-lens-review.js';
 import { runStoryReviewCore } from './review-core.js';
@@ -86,7 +87,10 @@ function buildCodeReviewBlockedExtra({ storyId, reviewResult }) {
 function formatReviewSummary(reviewResult) {
   const { high, medium, suggestion } = resolveSeverity(reviewResult);
   const posted = reviewResult?.posted ?? false;
-  return `Review complete — high=${high} medium=${medium} suggestion=${suggestion} (posted=${posted}).`;
+  // Story #4839 — `degraded` is always stated: an absent degradation line must
+  // never be the way an operator concludes that every gate ran.
+  const degraded = summarizeDegradations(reviewResult?.degradations);
+  return `Review complete — high=${high} medium=${medium} suggestion=${suggestion} degraded=${degraded} (posted=${posted}).`;
 }
 
 /**

--- a/tests/code-review.test.js
+++ b/tests/code-review.test.js
@@ -174,6 +174,10 @@ test('runCodeReview: derives the sensitive-path level from the enumerated diff',
 // --- Byte-compatible output envelope --------------------------------------
 
 test('runCodeReview: output envelope keys are byte-compatible across depths', async () => {
+  // `degraded` / `degradations` were added deliberately by Story #4839 so the
+  // close pipeline can tell "a gate ran and found nothing" from "a gate never
+  // ran". The invariant this test guards is unchanged: the key set must be
+  // identical across every depth, and `depth` must never leak into it.
   const EXPECTED_KEYS = [
     'status',
     'severity',
@@ -182,6 +186,8 @@ test('runCodeReview: output envelope keys are byte-compatible across depths', as
     'postedCommentId',
     'commentTargetId',
     'halted',
+    'degraded',
+    'degradations',
     'blockerReason',
   ].sort();
 

--- a/tests/lib/orchestration/review-providers/native.test.js
+++ b/tests/lib/orchestration/review-providers/native.test.js
@@ -33,7 +33,6 @@ import {
   parseLintOutput,
   partitionFilesForLint,
   readHeadSource,
-  resolveMarkdownRunner,
   runScopedLint,
   SERIAL_THRESHOLD,
   scoreSourceReport,
@@ -809,18 +808,19 @@ test('parseLintOutput: an unresolvable npx bin is reported as runner-not-resolva
   assert.equal(out.reason, 'runner-not-resolvable');
 });
 
-test('resolveMarkdownRunner: falls back to markdownlint (cli v1) with its own --ignore arg shape', () => {
-  const resolved = resolveMarkdownRunner(
-    '/repo',
-    binsInstalled('markdownlint'),
-  );
+test('runScopedLint: falls back to markdownlint (cli v1) with its own --ignore arg shape', () => {
+  const { calls, runner } = recordingRunner({
+    markdownlint: { status: 0, stdout: 'Summary: 0 error(s)\n', stderr: '' },
+  });
 
-  assert.equal(resolved.bin, 'markdownlint');
-  assert.deepEqual(resolved.extraArgs, ['--ignore', 'node_modules']);
-  assert.equal(
-    resolveMarkdownRunner('/repo', () => false),
-    null,
-  );
+  const out = runScopedLint(['docs/a.md'], '/repo', runner, {
+    existsFn: binsInstalled('markdownlint'),
+  });
+
+  assert.deepEqual(calls, [
+    { bin: 'markdownlint', args: ['docs/a.md', '--ignore', 'node_modules'] },
+  ]);
+  assert.equal(out.executionFailed, false);
 });
 
 test('runReview: a degraded lint gate is visible on the outcome channel while emitting zero findings (Story #4839 AC-2/AC-3/AC-4)', async () => {

--- a/tests/lib/orchestration/review-providers/native.test.js
+++ b/tests/lib/orchestration/review-providers/native.test.js
@@ -12,11 +12,19 @@
  *     findings, healthy tier is filtered out.
  *   - No GitHub provider methods are called from the adapter.
  *   - Invalid input shapes throw a TypeError.
+ *
+ * Story #4839 — adds the reproduction + regression set for the defect that made
+ * this gate fail open on ~78% of deliveries: the markdown runner was spawned
+ * under a bin name nothing installs, one runner's failure was folded into the
+ * other's verdict, and biome's empty-scope exit was read as a broken runner.
+ * Plus the visibility contract: a degraded gate is reported on the review
+ * outcome (provider channel + rendered comment) while still emitting zero
+ * findings, so #4699's severity-tier intent survives.
  */
 
 import assert from 'node:assert/strict';
 import test from 'node:test';
-
+import { renderFindings } from '../../../../.agents/scripts/lib/orchestration/review-providers/findings-renderer.js';
 import {
   analyzeChangedFiles,
   buildLintFindings,
@@ -25,6 +33,7 @@ import {
   parseLintOutput,
   partitionFilesForLint,
   readHeadSource,
+  resolveMarkdownRunner,
   runScopedLint,
   SERIAL_THRESHOLD,
   scoreSourceReport,
@@ -63,6 +72,8 @@ test('parseLintOutput: biome error + warning counts captured', () => {
     warnings: 3,
     parsed: true,
     executionFailed: false,
+    emptyScope: false,
+    reason: null,
   });
 });
 
@@ -657,4 +668,377 @@ test('runReview: a lint runner that cannot execute records friction telemetry an
   assert.equal(frictionCalls[0].storyId, 4699);
   assert.equal(frictionCalls[0].category, 'tool-degraded');
   assert.equal(frictionCalls[0].tool, 'native-review-lint');
+});
+
+/* ------------------------------------------------------------------------ */
+/* Story #4839 — why the runner could not execute, and why nobody noticed   */
+/* ------------------------------------------------------------------------ */
+
+/** A `node_modules/.bin` probe that reports only the named bins as installed. */
+function binsInstalled(...names) {
+  return (probePath) => names.some((n) => probePath.endsWith(`.bin/${n}`));
+}
+
+/** Record every `(bin, args)` the scoped-lint gate spawns. */
+function recordingRunner(byBin) {
+  const calls = [];
+  const runner = (bin, args) => {
+    calls.push({ bin, args });
+    return byBin[bin] ?? { status: 0, stdout: '', stderr: '' };
+  };
+  return { calls, runner };
+}
+
+test('runScopedLint: resolves the installed markdownlint-cli2 bin, never the bare `markdownlint` name (Story #4839 root cause)', () => {
+  const { calls, runner } = recordingRunner({
+    'markdownlint-cli2': {
+      status: 0,
+      stdout: 'Finding: README.md\nLinting: 1 file(s)\nSummary: 0 error(s)\n',
+      stderr: '',
+    },
+  });
+
+  const out = runScopedLint(['README.md'], '/repo', runner, {
+    existsFn: binsInstalled('markdownlint-cli2', 'biome'),
+  });
+
+  assert.deepEqual(
+    calls.map((c) => c.bin),
+    ['markdownlint-cli2'],
+    'the gate must spawn the bin that is actually installed',
+  );
+  assert.equal(
+    calls[0].args.includes('--ignore'),
+    false,
+    'markdownlint-cli2 rejects the cli-v1 --ignore flag; it must not be passed',
+  );
+  assert.equal(
+    out.executionFailed,
+    false,
+    'a resolvable runner whose Summary line parses is not a degraded gate',
+  );
+  assert.deepEqual(out.degradations, []);
+});
+
+test('runScopedLint: an unresolvable markdown runner degrades that surface by name instead of failing open', () => {
+  const { calls, runner } = recordingRunner({});
+
+  const out = runScopedLint(['README.md'], '/repo', runner, {
+    existsFn: binsInstalled('biome'),
+  });
+
+  assert.equal(
+    calls.length,
+    0,
+    'no markdown runner is spawned when none exists',
+  );
+  assert.equal(out.executionFailed, true);
+  assert.deepEqual(out.degradations, [
+    { surface: 'markdownlint', reason: 'runner-not-installed' },
+  ]);
+});
+
+test('runScopedLint: a degraded markdown surface no longer poisons the biome verdict (Story #4839)', () => {
+  const { runner } = recordingRunner({
+    biome: { status: 1, stdout: 'Found 3 errors.\n', stderr: '' },
+  });
+
+  const out = runScopedLint(['a.js', 'README.md'], '/repo', runner, {
+    existsFn: binsInstalled('biome'),
+  });
+
+  assert.equal(
+    out.errors,
+    3,
+    "biome's real error count must survive a sibling runner's failure",
+  );
+  assert.deepEqual(
+    out.degradations.map((d) => d.surface),
+    ['markdownlint'],
+    'only the surface that could not run is reported degraded',
+  );
+});
+
+test('runScopedLint: a clean biome run plus a working markdown runner is not degraded (the pre-fix false positive)', () => {
+  const { runner } = recordingRunner({
+    biome: {
+      status: 0,
+      stdout: 'Checked 1 file in 4ms. No fixes applied.\n',
+      stderr: '',
+    },
+    'markdownlint-cli2': {
+      status: 0,
+      stdout: 'Summary: 0 error(s)\n',
+      stderr: '',
+    },
+  });
+
+  const out = runScopedLint(['a.js', 'README.md'], '/repo', runner, {
+    existsFn: binsInstalled('markdownlint-cli2'),
+  });
+
+  assert.equal(out.executionFailed, false);
+  assert.equal(out.errors, 0);
+  assert.deepEqual(out.degradations, []);
+});
+
+test("parseLintOutput: biome's empty-scope exit is not an execution failure (Story #4839)", () => {
+  const out = parseLintOutput({
+    status: 1,
+    stdout: 'Checked 0 files in 484µs. No fixes applied.\n',
+    stderr:
+      '  × No files were processed in the specified paths.\n  i Check your biome.json\n',
+  });
+
+  assert.equal(
+    out.executionFailed,
+    false,
+    'every supplied path being config-ignored is an empty scope, not a broken runner',
+  );
+  assert.equal(out.emptyScope, true);
+});
+
+test('parseLintOutput: an unresolvable npx bin is reported as runner-not-resolvable', () => {
+  const out = parseLintOutput({
+    status: 1,
+    stdout: '',
+    stderr: 'npm error could not determine executable to run\n',
+  });
+
+  assert.equal(out.executionFailed, true);
+  assert.equal(out.reason, 'runner-not-resolvable');
+});
+
+test('resolveMarkdownRunner: falls back to markdownlint (cli v1) with its own --ignore arg shape', () => {
+  const resolved = resolveMarkdownRunner(
+    '/repo',
+    binsInstalled('markdownlint'),
+  );
+
+  assert.equal(resolved.bin, 'markdownlint');
+  assert.deepEqual(resolved.extraArgs, ['--ignore', 'node_modules']);
+  assert.equal(
+    resolveMarkdownRunner('/repo', () => false),
+    null,
+  );
+});
+
+test('runReview: a degraded lint gate is visible on the outcome channel while emitting zero findings (Story #4839 AC-2/AC-3/AC-4)', async () => {
+  const frictionCalls = [];
+  const provider = createNativeProvider({
+    gitSpawnFn: fakeDiff('README.md\n'),
+    runScopedLintFn: () => ({
+      errors: 0,
+      warnings: 0,
+      parsed: false,
+      executionFailed: true,
+      skipped: false,
+      mode: 'changed-only',
+      degradations: [
+        { surface: 'markdownlint', reason: 'runner-not-installed' },
+      ],
+    }),
+    analyzeChangedFilesFn: async () => ({
+      totalFiles: 1,
+      jsFiles: 0,
+      maintainability: [],
+      criticalFindings: [],
+      mediumFindings: [],
+    }),
+    emitToolDegradationFn: async (args) => {
+      frictionCalls.push(args);
+      return true;
+    },
+  });
+
+  const findings = await provider.runReview({
+    scope: 'story',
+    ticketId: 4839,
+    baseRef: 'main',
+    headRef: 'story-4839',
+  });
+
+  // AC-3: no severity tier gains a row — the degradation is not a finding.
+  assert.deepEqual(findings, []);
+  // AC-4: the friction emission is unchanged.
+  assert.equal(frictionCalls.length, 1);
+  assert.equal(frictionCalls[0].category, 'tool-degraded');
+  assert.equal(frictionCalls[0].tool, 'native-review-lint');
+  // AC-2: and the outcome now says the gate did not run.
+  assert.deepEqual(provider.getDegradations(), [
+    {
+      tool: 'native-review-lint',
+      gate: 'scoped-lint',
+      surface: 'markdownlint',
+      reason: 'runner-not-installed',
+    },
+  ]);
+});
+
+test('runReview: a legacy summary carrying only executionFailed still degrades the outcome, never silently', async () => {
+  const provider = createNativeProvider({
+    gitSpawnFn: fakeDiff('README.md\n'),
+    runScopedLintFn: () => ({
+      errors: 0,
+      warnings: 0,
+      parsed: false,
+      executionFailed: true,
+      skipped: false,
+      mode: 'changed-only',
+    }),
+    analyzeChangedFilesFn: async () => ({
+      totalFiles: 1,
+      jsFiles: 0,
+      maintainability: [],
+      criticalFindings: [],
+      mediumFindings: [],
+    }),
+    emitToolDegradationFn: async () => true,
+  });
+
+  await provider.runReview({
+    scope: 'story',
+    ticketId: 4839,
+    baseRef: 'main',
+    headRef: 'story-4839',
+  });
+
+  assert.deepEqual(provider.getDegradations(), [
+    {
+      tool: 'native-review-lint',
+      gate: 'scoped-lint',
+      surface: 'scoped-lint',
+      reason: 'unparseable-output',
+    },
+  ]);
+});
+
+test('runReview: a lint gate that executes reports no degradation, and a re-run clears the previous one (AC-5)', async () => {
+  const provider = createNativeProvider({
+    gitSpawnFn: fakeDiff('README.md\n'),
+    runScopedLintFn: () => ({
+      errors: 0,
+      warnings: 0,
+      parsed: true,
+      executionFailed: false,
+      skipped: false,
+      mode: 'changed-only',
+      degradations: [],
+    }),
+    analyzeChangedFilesFn: async () => ({
+      totalFiles: 1,
+      jsFiles: 0,
+      maintainability: [],
+      criticalFindings: [],
+      mediumFindings: [],
+    }),
+    emitToolDegradationFn: async () => {
+      throw new Error('friction must not be emitted for a healthy gate');
+    },
+  });
+
+  const findings = await provider.runReview({
+    scope: 'story',
+    ticketId: 4839,
+    baseRef: 'main',
+    headRef: 'story-4839',
+  });
+
+  assert.deepEqual(findings, []);
+  assert.deepEqual(
+    provider.getDegradations(),
+    [],
+    'a healthy gate must not report a degradation',
+  );
+});
+
+test('runReview: lint errors from an executing runner still surface as a high finding alongside no degradation (AC-5)', async () => {
+  const provider = createNativeProvider({
+    gitSpawnFn: fakeDiff('a.js\n'),
+    runScopedLintFn: () => ({
+      errors: 2,
+      warnings: 1,
+      parsed: true,
+      executionFailed: false,
+      skipped: false,
+      mode: 'changed-only',
+      degradations: [],
+    }),
+    analyzeChangedFilesFn: async () => ({
+      totalFiles: 1,
+      jsFiles: 1,
+      maintainability: [],
+      criticalFindings: [],
+      mediumFindings: [],
+    }),
+  });
+
+  const findings = await provider.runReview({
+    scope: 'story',
+    ticketId: 4839,
+    baseRef: 'main',
+    headRef: 'story-4839',
+  });
+
+  assert.deepEqual(
+    findings.map((f) => f.severity),
+    ['high'],
+    'lint errors collapse into a single high finding (warnings ride in its body)',
+  );
+  assert.match(findings[0].title, /2 error\(s\)/);
+  assert.deepEqual(provider.getDegradations(), []);
+});
+
+test('renderFindings: a degraded gate suppresses the unqualified "No findings" claim (Story #4839 AC-2)', () => {
+  const degradations = [
+    {
+      tool: 'native-review-lint',
+      gate: 'scoped-lint',
+      surface: 'markdownlint',
+      reason: 'runner-not-installed',
+    },
+  ];
+
+  const degradedBody = renderFindings({
+    ticketId: 4839,
+    baseRef: 'main',
+    headRef: 'story-4839',
+    findings: [],
+    provider: 'native',
+    degradations,
+  });
+
+  assert.equal(
+    degradedBody.includes('### ✅ No findings'),
+    false,
+    'a review that could not run a gate must never render an unqualified clean verdict',
+  );
+  assert.match(degradedBody, /Degraded gates\*\*: 1 \(did not run\)/);
+  assert.match(degradedBody, /### ⚠️ Degraded Gates \(1\)/);
+  assert.match(degradedBody, /scoped-lint.+markdownlint.+runner-not-installed/);
+  assert.match(degradedBody, /### ⚠️ No findings — 1 gate\(s\) did not run/);
+
+  // AC-3: the severity tally is untouched — the degradation is not a finding.
+  assert.match(degradedBody, /- 🔴 Critical Blocker: 0/);
+  assert.match(degradedBody, /- 🟠 High Risk: 0/);
+  assert.match(degradedBody, /- 🟡 Medium Risk: 0/);
+  assert.match(degradedBody, /- 🟢 Suggestion: 0/);
+  assert.match(degradedBody, /\*\*Findings\*\*: 0/);
+});
+
+test('renderFindings: a healthy review body is byte-identical with an absent or empty degradation list (AC-5)', () => {
+  const base = {
+    ticketId: 4839,
+    baseRef: 'main',
+    headRef: 'story-4839',
+    findings: [],
+    provider: 'native',
+  };
+
+  const withoutField = renderFindings(base);
+  const withEmpty = renderFindings({ ...base, degradations: [] });
+
+  assert.equal(withEmpty, withoutField);
+  assert.match(withoutField, /### ✅ No findings/);
+  assert.equal(withoutField.includes('Degraded'), false);
 });


### PR DESCRIPTION
Closes #4839

## Root-cause diagnosis

The scoped-lint review gate reported `executionFailed` — and therefore emitted
**zero findings while the review rendered a clean verdict** — on 18 of 23
Beestera/swarm-os Stories carrying friction (78%) and on 5 mandrel Stories
(#4801, #4815, #4816, #4821, plus one during #4824's own close). The gate had
effectively never run in the primary consumer.

The cause was **neither environmental nor a parse failure.** It was reproduced
directly against this repository, and it is three separate deterministic
invocation defects that all collapse into the same symptom.

### 1. The markdown runner was never resolvable (the dominant cause)

The provider spawned `npx --no markdownlint`. The binary this project — and the
consumer — installs is **`markdownlint-cli2`**; there is no bare `markdownlint`
bin in `node_modules/.bin`. Measured:

```
$ npx --no markdownlint README.md --ignore node_modules
npm error could not determine executable to run     # exit 1, no other output
```

`parseLintOutput` was *already* written for cli2's `Summary: N error(s)` line, so
the invocation and the parser had never agreed with each other. The
`--ignore node_modules` flag was likewise `markdownlint-cli` v1 syntax that cli2
rejects.

Because `npx` exits non-zero and prints nothing a reporter regex can match, the
summary came back `parsed: false, status: 1` → `executionFailed: true`.

### 2. One runner's failure became the other's verdict

`runScopedLint` ran biome and markdownlint and then folded both into a **single**
`parseLintOutput` call over concatenated output and the maximum exit status. So
defect 1's exit 1 became biome's verdict too: **any** change set containing at
least one `.md` file degraded the whole gate whenever biome had nothing to
report — which is precisely the clean case the gate exists to confirm. That is
the 78%: nearly every Story diff touches a markdown file.

### 3. Biome's empty-scope exit was read as a broken runner

`biome lint` exits 1 with `No files were processed in the specified paths.` when
every supplied path is excluded by `biome.json` (`temp/`, `dist/`,
`.worktrees/`, anything in the VCS ignore file). Same shape: non-zero exit,
nothing parseable, `executionFailed: true`. That is an empty scope, not a runner
that could not execute.

### Reproduction, before and after

`runScopedLint` against real change sets in this repo:

| change set | before | after |
| --- | --- | --- |
| code only, clean | `executionFailed=false` | `executionFailed=false` |
| markdown only | **`executionFailed=true`** | `executionFailed=false` |
| mixed code + markdown | **`executionFailed=true`** | `executionFailed=false` |
| all paths biome-excluded | **`executionFailed=true`** | `executionFailed=false` |

And the gate now *detects markdown errors at all* — a `.md` file with four
violations previously produced `executionFailed` plus zero findings, and now
produces `{ errors: 4, parsed: true }` and one `high` finding.

## The second defect: why nobody noticed

Story #4699 correctly routed an unexecutable tool to friction telemetry rather
than making it a code finding, so severity tiers keep reflecting code findings
only. What it did not add was any *other* channel — so the review's own verdict
became unable to distinguish **"lint ran and found nothing"** from **"lint never
ran"**. Both rendered `✅ No findings` with an all-zero tally, and the close
pipeline read the second as the first.

A degradation now travels **beside** the `Finding[]`, never inside it
(`review-providers/degraded-gates.js`):

- the provider exposes `getDegradations()`; the chain merges across inline entries;
- `runCodeReview`'s envelope — the object the close pipeline reads — carries
  `degraded` and `degradations[]`;
- the structured comment gains a `### ⚠️ Degraded Gates (N)` section and **can no
  longer print `✅ No findings`** when a gate did not run;
- the close phase states it on both operator surfaces (progress stream and the
  Story cross-reference comment), and states it *always* — rendering `none` when
  healthy, so an absent line can never be read as a clean gate.

**#4699's intent is preserved exactly.** An execution failure still produces no
`Finding` at any tier (not even `suggestion`), `countBySeverity` is untouched,
and the `tool-degraded` friction emission is byte-for-byte unchanged.

### Judgement call: report loudly, do not block

A degraded gate does not halt the close. The close pipeline already runs the
canonical `npm run lint` as a **hard close-validation gate before** the review
phase; the review's scoped lint is a second, narrower read of the same surface.
Failing a merge because a *secondary* read of an already-gated surface could not
start would cost delivery without buying coverage. What was broken was the
silence, so the fix makes the silence impossible. Escalating to a block is a
one-line change in `degraded-gates.js` if the operator posture ever needs it.

## Notes

- Runner resolution, per-surface classification and the merge were extracted to
  `review-providers/scoped-lint.js`; the per-file MI tolerance (absolute 0.5)
  drove the extraction rather than a baseline refresh.
- No baseline file was rewritten. The production dead-exports ratchet reports
  `added=0 removed=51 (ok)`, matching main's own verdict.
- This review gate runs from the **main checkout's** code, so this PR's own
  review comment was produced by the pre-fix path and shows no degraded-gate
  line. That is expected, and it is the last time it can happen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
