### PR TITLE
fix(test): probe bins on either path separator so #4839's tests pass on Windows

### DIFF
--- a/tests/lib/orchestration/review-providers/native.test.js
+++ b/tests/lib/orchestration/review-providers/native.test.js
@@ -673,9 +673,17 @@ test('runReview: a lint runner that cannot execute records friction telemetry an
 /* Story #4839 — why the runner could not execute, and why nobody noticed   */
 /* ------------------------------------------------------------------------ */
 
-/** A `node_modules/.bin` probe that reports only the named bins as installed. */
+/**
+ * A `node_modules/.bin` probe that reports only the named bins as installed.
+ *
+ * The comparison is on the path's last segment, split on **either** separator:
+ * `resolveMarkdownRunner` builds its probe path with `path.join`, so on Windows
+ * the double receives `node_modules\.bin\markdownlint-cli2`. A `/`-only match
+ * silently reported every bin as missing there, which made these tests fail on
+ * the Windows leg alone while passing on POSIX.
+ */
 function binsInstalled(...names) {
-  return (probePath) => names.some((n) => probePath.endsWith(`.bin/${n}`));
+  return (probePath) => names.includes(probePath.split(/[\\/]/).pop());
 }
 
 /** Record every `(bin, args)` the scoped-lint gate spawns. */


### PR DESCRIPTION
Fixes the Windows Smoke failure introduced by #4840 (Story #4839).

Three of the scoped-lint tests that PR added failed on the Windows leg while
passing on POSIX. **The production code was correct; the test double was not.**

`resolveMarkdownRunner` builds its probe path with `path.join`, so on Windows it
asks the injected `existsFn` about `node_modules\.bin\markdownlint-cli2`. The
double matched with `endsWith('.bin/<name>')` — a forward slash only — so on
Windows it reported every candidate bin as missing, `resolveMarkdownRunner`
returned `null`, and no runner was spawned at all:

```
not ok 283 - runScopedLint: resolves the installed markdownlint-cli2 bin ...
    + []
    - [ 'markdownlint-cli2' ]
```

The probe now compares the path's last segment split on **either** separator.
Verified against all four shapes it must discriminate:

| probe path | matches `markdownlint-cli2` |
| --- | --- |
| `/repo/node_modules/.bin/markdownlint-cli2` | yes |
| `C:\repo\node_modules\.bin\markdownlint-cli2` | yes |
| `...\.bin\markdownlint-cli2.cmd` | no |
| `.../.bin/markdownlint` | no |

`node --test tests/lib/orchestration/review-providers/native.test.js` → 39/39,
`npm run lint` → 0, `quality-preview` → 0 MI regressions.

Refs #4839

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change to a path-matching helper; no production or runtime lint resolution logic is modified.
> 
> **Overview**
> Fixes **Windows-only failures** in Story #4839 scoped-lint tests introduced by #4840. **Production behavior is unchanged**; only the `binsInstalled` test double is updated.
> 
> The helper that simulates `existsFn` for `node_modules/.bin` probes used `endsWith('.bin/<name>')`, which only matches POSIX paths. `resolveMarkdownRunner` probes with `path.join`, so on Windows the path uses backslashes and the double treated every bin as missing—tests saw no spawned runners while POSIX passed.
> 
> Matching now uses the **last path segment** after splitting on `/` or `\`, with a short comment explaining the Windows vs POSIX mismatch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9c549092eabb4c659a614f45af10f2a34ec1a921. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->