### PR TITLE
refactor: restore clean-code gate headroom: cover CRAP-capacity shells, flatten selectAudits, table-drive story-body parsing (#4842)

### DIFF
--- a/.agents/scripts/lib/audit-suite/selector.js
+++ b/.agents/scripts/lib/audit-suite/selector.js
@@ -324,16 +324,20 @@ export function _resetWebSurfaceCache() {
 }
 
 /**
- * True when the root `package.json` declares a web-framework dependency.
+ * True when the root `package.json` declares a dependency whose name (or a
+ * scope/name segment of it) appears in `packageList`. The shared probe behind
+ * {@link declaresWebFramework} and {@link declaresOrmDependency}.
+ *
  * Returns `null` — *indeterminate* — when the manifest exists but cannot be
- * read or parsed; the caller fails open on that (see {@link hasWebSurface}).
- * A genuinely absent manifest (`ENOENT`) is determinate: there is no
- * declaration, so there is no signal, and the file scan gets its turn.
+ * read or parsed; callers fail open on that. A genuinely absent manifest
+ * (`ENOENT`) is determinate: there is no declaration, so there is no signal,
+ * and the file scan gets its turn.
  *
  * @param {string} root
+ * @param {readonly string[]} packageList
  * @returns {boolean|null}
  */
-function declaresWebFramework(root) {
+function declaresDependencyIn(root, packageList) {
   let raw;
   try {
     raw = readFileSync(path.join(root, 'package.json'), 'utf8');
@@ -355,8 +359,20 @@ function declaresWebFramework(root) {
     name
       .replace(/^@/, '')
       .split('/')
-      .some((segment) => WEB_FRAMEWORK_PACKAGES.includes(segment)),
+      .some((segment) => packageList.includes(segment)),
   );
+}
+
+/**
+ * True when the root `package.json` declares a web-framework dependency.
+ * Tri-state contract per {@link declaresDependencyIn}; the fail-open caller
+ * is {@link hasWebSurface}.
+ *
+ * @param {string} root
+ * @returns {boolean|null}
+ */
+function declaresWebFramework(root) {
+  return declaresDependencyIn(root, WEB_FRAMEWORK_PACKAGES);
 }
 
 /**
@@ -514,38 +530,14 @@ export function _resetPersistenceLayerCache() {
 
 /**
  * True when the root `package.json` declares an ORM / query-builder dependency.
- * Returns `null` — *indeterminate* — when the manifest exists but cannot be
- * read or parsed (the caller fails open on that). A genuinely absent manifest
- * (`ENOENT`) is determinate: there is no declaration, so the file scan gets its
- * turn. Mirrors {@link declaresWebFramework}.
+ * Tri-state contract per {@link declaresDependencyIn}; the fail-open caller
+ * is {@link hasPersistenceLayer}.
  *
  * @param {string} root
  * @returns {boolean|null}
  */
 function declaresOrmDependency(root) {
-  let raw;
-  try {
-    raw = readFileSync(path.join(root, 'package.json'), 'utf8');
-  } catch (err) {
-    if (err?.code === 'ENOENT') return false;
-    return null;
-  }
-  let pkg;
-  try {
-    pkg = JSON.parse(raw);
-  } catch {
-    return null;
-  }
-  const names = [
-    ...Object.keys(pkg?.dependencies ?? {}),
-    ...Object.keys(pkg?.devDependencies ?? {}),
-  ];
-  return names.some((name) =>
-    name
-      .replace(/^@/, '')
-      .split('/')
-      .some((segment) => ORM_PACKAGES.includes(segment)),
-  );
+  return declaresDependencyIn(root, ORM_PACKAGES);
 }
 
 /**
@@ -802,24 +794,10 @@ export async function selectAudits({
 }) {
   const config = resolveConfig();
   const timeoutMs = gitTimeoutMsOverride ?? DEFAULT_GIT_TIMEOUT_MS;
-
-  const rulesPath = path.join(
-    PROJECT_ROOT,
-    getPaths(config).schemasRoot,
-    'audit-rules.json',
-  );
-  let rulesData;
-  try {
-    rulesData = JSON.parse(await fs.readFile(rulesPath, 'utf8'));
-  } catch (err) {
-    throw new Error(
-      `Failed to read audit-rules from ${rulesPath}: ${err.message}`,
-    );
-  }
+  const rulesData = await loadAuditRules(config);
 
   const ticket = await provider.getTicket(ticketId);
-  const contentToSearch =
-    `${ticket.title || ''} ${ticket.body || ''}`.toLowerCase();
+  const contentToSearch = ticketSearchText(ticket);
 
   const runGit = injectedGitSpawn ?? (async (...args) => gitSpawn(...args));
 
@@ -831,141 +809,44 @@ export async function selectAudits({
   // empty by construction.
   const hasInjectedChangedFiles = Array.isArray(injectedChangedFiles);
 
-  // Resolve `headRef` to a commit before diffing. A non-default `headRef`
-  // (Epic-mode callers pass `refs/heads/epic/<id>`) that the repo can't
-  // resolve means the requested Epic's branch is not present in this
-  // checkout — diffing `baseBranch...HEAD` would silently report a
-  // *different* Epic's change set (Story #3362). Surface that as an explicit
-  // degraded signal instead of leaking the wrong scope. `HEAD` is always
-  // resolvable in a valid repo, so the default-path callers skip the probe
-  // cost on the common case.
   if (!hasInjectedChangedFiles && headRef !== 'HEAD') {
-    let resolved;
-    try {
-      resolved = await withTimeout(
-        runGit(process.cwd(), 'rev-parse', '--verify', '--quiet', headRef),
-        timeoutMs,
-        { label: 'select-audits rev-parse headRef' },
-      );
-    } catch (err) {
-      if (err?.code === 'ETIMEDOUT') {
-        return softFailOrThrow(
-          'GIT_DIFF_TIMEOUT',
-          `select-audits: git rev-parse ${headRef} timed out after ${timeoutMs} ms`,
-          gateModeOpts,
-        );
-      }
-      throw err;
-    }
-    if (resolved?.status !== 0 || !resolved.stdout.trim()) {
-      return softFailOrThrow(
-        'HEAD_REF_UNRESOLVED',
-        `select-audits: requested ref '${headRef}' could not be resolved in this checkout; refusing to diff against a phantom change set`,
-        gateModeOpts,
-      );
-    }
+    const degraded = await resolveHeadRefOrDegrade({
+      runGit,
+      headRef,
+      timeoutMs,
+      gateModeOpts,
+    });
+    if (degraded) return degraded;
   }
 
-  let changedFiles = hasInjectedChangedFiles
-    ? injectedChangedFiles.map((f) => String(f).trim()).filter(Boolean)
-    : [];
-  try {
-    const diff = hasInjectedChangedFiles
-      ? null
-      : await withTimeout(
-          runGit(
-            process.cwd(),
-            'diff',
-            '--name-only',
-            `${baseBranch}...${headRef}`,
-          ),
-          timeoutMs,
-          { label: 'select-audits git diff' },
-        );
-    if (diff?.status === 0) {
-      changedFiles = diff.stdout
-        .split('\n')
-        .map((f) => f.trim())
-        .filter(Boolean);
-    }
-  } catch (err) {
-    if (err?.code === 'ETIMEDOUT') {
-      // Soft-fail contract (Tech Spec #819): in default mode, return a
-      // degraded envelope so the caller sees the explicit signal instead of
-      // silently falling through to keyword-only matching. In gate-mode,
-      // hard-fail closed.
-      return softFailOrThrow(
-        'GIT_DIFF_TIMEOUT',
-        `select-audits: git diff against ${baseBranch} timed out after ${timeoutMs} ms`,
-        gateModeOpts,
-      );
-    }
-    throw err;
+  let changedFiles;
+  if (hasInjectedChangedFiles) {
+    changedFiles = injectedChangedFiles
+      .map((f) => String(f).trim())
+      .filter(Boolean);
+  } else {
+    const acquired = await acquireChangedFilesFromDiff({
+      runGit,
+      baseBranch,
+      headRef,
+      timeoutMs,
+      gateModeOpts,
+    });
+    if (acquired.degraded) return acquired.degraded;
+    changedFiles = acquired.files;
   }
 
-  const selectedAudits = [];
-
-  // Applicability probes, resolved at most once per target per call, and only
-  // if a lens declaring that target actually clears its gate — a Node-only
-  // project must not pay a filesystem scan on a roster with no `web` lens in
-  // it, nor a DB-less project pay one for `data-model`.
-  const targetProbes = {
-    web: hasWebSurfaceFn,
-    'data-model': hasPersistenceLayerFn,
-  };
-  const targetApplicabilityMemo = new Map();
-  const projectSupportsTarget = (target) => {
-    if (!targetApplicabilityMemo.has(target)) {
-      const probe = targetProbes[target];
-      targetApplicabilityMemo.set(target, probe ? probe({ config }) : true);
-    }
-    return targetApplicabilityMemo.get(target);
-  };
-
-  for (const [auditName, ruleOpts] of Object.entries(rulesData.audits || {})) {
-    const triggers = ruleOpts.triggers || {};
-
-    const gateMatch = triggers.gates?.includes(gate);
-    if (!gateMatch) continue;
-
-    // Target-applicability gate (#4579, #4633). A lens declaring a `target`
-    // has nothing to read on a project lacking that surface, yet still
-    // whole-word-matches ordinary prose — `audit-seo` fires on the `meta`
-    // inside every Story body's `<!-- meta: {...} -->` machine comment. The
-    // roster's own instruction is that the host MUST walk every listed lens,
-    // so an inapplicable entry is not just wasted spend: it teaches operators
-    // to ignore the MUST. An absent `target` (or `any`) means "always
-    // applicable", so no existing lens changes behaviour.
-    const { target } = ruleOpts;
-    if (target && target !== 'any' && !projectSupportsTarget(target)) continue;
-
-    const keywords = triggers.keywords || [];
-    let keywordMatch = false;
-    for (const kw of keywords) {
-      // Whole-word match: a bare substring test selects lenses on accidental
-      // fragments ("ui" inside "requires", "auth" inside "author" — #4579).
-      const escaped = kw.toLowerCase().replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-      if (new RegExp(`\\b${escaped}\\b`).test(contentToSearch)) {
-        keywordMatch = true;
-        break;
-      }
-    }
-
-    const fileMatch = matchesAnyFilePattern(
-      triggers.filePatterns || [],
-      changedFiles,
-    );
-
-    // Coverage-gap routing (#4628): a lens declaring `sourceWithoutSiblingTest`
-    // fires when the change set touches source lacking a sibling test.
-    const siblingMatch =
-      triggers.sourceWithoutSiblingTest === true &&
-      changeSetLacksSiblingTest(changedFiles);
-
-    if (keywordMatch || fileMatch || siblingMatch) {
-      selectedAudits.push(auditName);
-    }
-  }
+  const selectedAudits = matchAuditRules({
+    audits: rulesData.audits ?? {},
+    gate,
+    contentToSearch,
+    changedFiles,
+    projectSupportsTarget: makeTargetApplicabilityProbe({
+      config,
+      hasWebSurfaceFn,
+      hasPersistenceLayerFn,
+    }),
+  });
 
   return {
     selectedAudits,
@@ -986,4 +867,236 @@ export async function selectAudits({
       ticketTitle: ticket.title,
     },
   };
+}
+
+/**
+ * Read and parse `audit-rules.json` from the configured schemas root.
+ *
+ * @param {object} config Resolved `.agentrc.json` wrapper.
+ * @returns {Promise<object>}
+ */
+async function loadAuditRules(config) {
+  const rulesPath = path.join(
+    PROJECT_ROOT,
+    getPaths(config).schemasRoot,
+    'audit-rules.json',
+  );
+  try {
+    return JSON.parse(await fs.readFile(rulesPath, 'utf8'));
+  } catch (err) {
+    throw new Error(
+      `Failed to read audit-rules from ${rulesPath}: ${err.message}`,
+    );
+  }
+}
+
+/** Lower-cased ticket text the keyword triggers match against. */
+function ticketSearchText(ticket) {
+  return `${ticket.title || ''} ${ticket.body || ''}`.toLowerCase();
+}
+
+/**
+ * Resolve a non-default `headRef` to a commit before diffing. A ref the repo
+ * cannot resolve means the requested branch is not present in this checkout —
+ * diffing `baseBranch...HEAD` would silently report a *different* change set
+ * (Story #3362) — so that surfaces as an explicit degraded signal instead of
+ * leaking the wrong scope. Returns `null` when the ref resolves; otherwise
+ * the degraded envelope from `softFailOrThrow` (which throws in gate-mode).
+ * A non-timeout spawn failure propagates.
+ *
+ * @param {{ runGit: Function, headRef: string, timeoutMs: number, gateModeOpts?: object }} params
+ * @returns {Promise<object|null>}
+ */
+async function resolveHeadRefOrDegrade({
+  runGit,
+  headRef,
+  timeoutMs,
+  gateModeOpts,
+}) {
+  let resolved;
+  try {
+    resolved = await withTimeout(
+      runGit(process.cwd(), 'rev-parse', '--verify', '--quiet', headRef),
+      timeoutMs,
+      { label: 'select-audits rev-parse headRef' },
+    );
+  } catch (err) {
+    if (err?.code === 'ETIMEDOUT') {
+      return softFailOrThrow(
+        'GIT_DIFF_TIMEOUT',
+        `select-audits: git rev-parse ${headRef} timed out after ${timeoutMs} ms`,
+        gateModeOpts,
+      );
+    }
+    throw err;
+  }
+  if (resolved?.status !== 0 || !resolved.stdout.trim()) {
+    return softFailOrThrow(
+      'HEAD_REF_UNRESOLVED',
+      `select-audits: requested ref '${headRef}' could not be resolved in this checkout; refusing to diff against a phantom change set`,
+      gateModeOpts,
+    );
+  }
+  return null;
+}
+
+/**
+ * Acquire the change set from `git diff --name-only base...head`. Returns
+ * `{ files }` on success — a diff that exits non-zero yields an empty list,
+ * preserving the pre-extraction flow — or `{ degraded }` with the soft-fail
+ * envelope on timeout. A non-timeout spawn failure propagates.
+ *
+ * @param {{ runGit: Function, baseBranch: string, headRef: string, timeoutMs: number, gateModeOpts?: object }} params
+ * @returns {Promise<{ files?: string[], degraded?: object }>}
+ */
+async function acquireChangedFilesFromDiff({
+  runGit,
+  baseBranch,
+  headRef,
+  timeoutMs,
+  gateModeOpts,
+}) {
+  let diff;
+  try {
+    diff = await withTimeout(
+      runGit(
+        process.cwd(),
+        'diff',
+        '--name-only',
+        `${baseBranch}...${headRef}`,
+      ),
+      timeoutMs,
+      { label: 'select-audits git diff' },
+    );
+  } catch (err) {
+    if (err?.code === 'ETIMEDOUT') {
+      // Soft-fail contract (Tech Spec #819): in default mode, return a
+      // degraded envelope so the caller sees the explicit signal instead of
+      // silently falling through to keyword-only matching. In gate-mode,
+      // hard-fail closed.
+      return {
+        degraded: softFailOrThrow(
+          'GIT_DIFF_TIMEOUT',
+          `select-audits: git diff against ${baseBranch} timed out after ${timeoutMs} ms`,
+          gateModeOpts,
+        ),
+      };
+    }
+    throw err;
+  }
+  if (diff?.status !== 0) return { files: [] };
+  return {
+    files: diff.stdout
+      .split('\n')
+      .map((f) => f.trim())
+      .filter(Boolean),
+  };
+}
+
+/**
+ * Whole-word keyword match over the ticket's search text: a bare substring
+ * test selects lenses on accidental fragments ("ui" inside "requires",
+ * "auth" inside "author" — #4579).
+ *
+ * @param {string[]} keywords
+ * @param {string} content Lower-cased ticket text.
+ * @returns {boolean}
+ */
+function matchesAnyKeyword(keywords, content) {
+  return keywords.some((kw) => {
+    const escaped = kw.toLowerCase().replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    return new RegExp(`\\b${escaped}\\b`).test(content);
+  });
+}
+
+/**
+ * Build the once-per-call target-applicability probe. Probes resolve at most
+ * once per target, and only if a lens declaring that target actually clears
+ * its gate — a Node-only project must not pay a filesystem scan on a roster
+ * with no `web` lens in it, nor a DB-less project pay one for `data-model`.
+ *
+ * @param {{ config: object, hasWebSurfaceFn: Function, hasPersistenceLayerFn: Function }} params
+ * @returns {(target: string) => boolean}
+ */
+function makeTargetApplicabilityProbe({
+  config,
+  hasWebSurfaceFn,
+  hasPersistenceLayerFn,
+}) {
+  const probes = {
+    web: hasWebSurfaceFn,
+    'data-model': hasPersistenceLayerFn,
+  };
+  const memo = new Map();
+  return (target) => {
+    if (!memo.has(target)) {
+      const probe = probes[target];
+      memo.set(target, probe ? probe({ config }) : true);
+    }
+    return memo.get(target);
+  };
+}
+
+/**
+ * True when any of a lens's content triggers fires against the change set:
+ * whole-word keywords, file-pattern globs, or the coverage-gap
+ * `sourceWithoutSiblingTest` predicate (#4628).
+ *
+ * @param {object} triggers The lens's `triggers` block.
+ * @param {string} contentToSearch Lower-cased ticket text.
+ * @param {string[]} changedFiles
+ * @returns {boolean}
+ */
+function lensTriggerFires(triggers, contentToSearch, changedFiles) {
+  return (
+    matchesAnyKeyword(triggers.keywords || [], contentToSearch) ||
+    matchesAnyFilePattern(triggers.filePatterns || [], changedFiles) ||
+    (triggers.sourceWithoutSiblingTest === true &&
+      changeSetLacksSiblingTest(changedFiles))
+  );
+}
+
+/**
+ * Run the audit-rules matching loop over one gate's roster: a lens is
+ * selected when its gate matches, its `target` applicability gate passes,
+ * and any of its keyword / file-pattern / sibling-test triggers fires.
+ *
+ * @param {{
+ *   audits: Record<string, object>,
+ *   gate: string,
+ *   contentToSearch: string,
+ *   changedFiles: string[],
+ *   projectSupportsTarget: (target: string) => boolean,
+ * }} params
+ * @returns {string[]} Selected lens identifiers, in manifest order.
+ */
+function matchAuditRules({
+  audits,
+  gate,
+  contentToSearch,
+  changedFiles,
+  projectSupportsTarget,
+}) {
+  const selectedAudits = [];
+  for (const [auditName, ruleOpts] of Object.entries(audits)) {
+    const triggers = ruleOpts.triggers || {};
+
+    if (!triggers.gates?.includes(gate)) continue;
+
+    // Target-applicability gate (#4579, #4633). A lens declaring a `target`
+    // has nothing to read on a project lacking that surface, yet still
+    // whole-word-matches ordinary prose — `audit-seo` fires on the `meta`
+    // inside every Story body's `<!-- meta: {...} -->` machine comment. The
+    // roster's own instruction is that the host MUST walk every listed lens,
+    // so an inapplicable entry is not just wasted spend: it teaches operators
+    // to ignore the MUST. An absent `target` (or `any`) means "always
+    // applicable", so no existing lens changes behaviour.
+    const { target } = ruleOpts;
+    if (target && target !== 'any' && !projectSupportsTarget(target)) continue;
+
+    if (lensTriggerFires(triggers, contentToSearch, changedFiles)) {
+      selectedAudits.push(auditName);
+    }
+  }
+  return selectedAudits;
 }

--- a/.agents/scripts/lib/story-body/story-body.js
+++ b/.agents/scripts/lib/story-body/story-body.js
@@ -203,66 +203,95 @@ const WIDE_MARKER_LINE_RE = /^>\s*\*\*Wide:\*\*/;
 function parsePathEntry(raw, warnings) {
   // Already a structured object (from a parsed JSON body, not markdown).
   if (raw !== null && typeof raw === 'object') {
-    if (
-      typeof raw.path === 'string' &&
-      raw.path.trim().length > 0 &&
-      FILE_ASSUMPTION_VALUES.includes(raw.assumption)
-    ) {
-      return { path: raw.path.trim(), assumption: raw.assumption };
-    }
-    // Malformed object: fail closed.
-    throw new StoryBodyParseError(
-      `changes/references entry is an object but not a valid PathEntry: ${JSON.stringify(raw)}`,
-      { field: 'changes', raw: JSON.stringify(raw) },
-    );
+    return pathEntryFromObject(raw);
   }
 
   const str = typeof raw === 'string' ? raw.trim() : String(raw).trim();
   if (str.length === 0) return null;
 
-  // Humanized bullet shape (the canonical serialize() output since
-  // Story #4600): `path` — assumption.
-  const humanized = str.match(HUMANIZED_PATH_ENTRY_RE);
-  if (humanized) {
-    const path = humanized[1].trim();
-    if (path.length > 0 && FILE_ASSUMPTION_VALUES.includes(humanized[2])) {
-      return { path, assumption: humanized[2] };
-    }
-    // Recognized the humanized shape but the fields are invalid: fail closed.
-    throw new StoryBodyParseError(
-      `changes/references entry is a humanized bullet but not a valid PathEntry: ${str.slice(0, 120)}${pathEntryFixIt(str)}`,
-      { field: 'changes', raw: str },
-    );
-  }
-
-  // Try to detect inline JSON object shape: `{ "path": "...", "assumption": "..." }`
-  if (str.startsWith('{')) {
-    try {
-      const parsed = JSON.parse(str);
-      // It's a JSON object — treat it as a path entry.
-      // If the path is missing or assumption is invalid, fail closed.
-      if (typeof parsed === 'object' && parsed !== null) {
-        if (
-          typeof parsed.path === 'string' &&
-          FILE_ASSUMPTION_VALUES.includes(parsed.assumption)
-        ) {
-          return { path: parsed.path.trim(), assumption: parsed.assumption };
-        }
-        // Parsed successfully as JSON object but has invalid fields — fail closed.
-        throw new StoryBodyParseError(
-          `changes/references entry is a JSON object but not a valid PathEntry: ${str}`,
-          { field: 'changes', raw: str },
-        );
-      }
-    } catch (err) {
-      // Re-throw StoryBodyParseError so it propagates.
-      if (err instanceof StoryBodyParseError) throw err;
-      // JSON parse failed — fall through to reject plain-string form.
-    }
-  }
+  const entry = pathEntryFromHumanized(str) ?? pathEntryFromInlineJson(str);
+  if (entry) return entry;
 
   throw new StoryBodyParseError(
     `changes/references entry must be a { path, assumption } object; plain string bullets are no longer accepted: ${str.slice(0, 120)}${pathEntryFixIt(str)}`,
+    { field: 'changes', raw: str },
+  );
+}
+
+/**
+ * Validate an already-structured `{ path, assumption }` object. Fails closed
+ * on a malformed object.
+ *
+ * @param {object} raw
+ * @returns {PathEntry}
+ */
+function pathEntryFromObject(raw) {
+  if (
+    typeof raw.path === 'string' &&
+    raw.path.trim().length > 0 &&
+    FILE_ASSUMPTION_VALUES.includes(raw.assumption)
+  ) {
+    return { path: raw.path.trim(), assumption: raw.assumption };
+  }
+  // Malformed object: fail closed.
+  throw new StoryBodyParseError(
+    `changes/references entry is an object but not a valid PathEntry: ${JSON.stringify(raw)}`,
+    { field: 'changes', raw: JSON.stringify(raw) },
+  );
+}
+
+/**
+ * Parse the humanized bullet shape (the canonical serialize() output since
+ * Story #4600): `` `path` — assumption ``. Returns `null` when the line is
+ * not that shape at all; fails closed when the shape is recognized but the
+ * fields are invalid.
+ *
+ * @param {string} str
+ * @returns {PathEntry|null}
+ */
+function pathEntryFromHumanized(str) {
+  const humanized = str.match(HUMANIZED_PATH_ENTRY_RE);
+  if (!humanized) return null;
+  const path = humanized[1].trim();
+  if (path.length > 0 && FILE_ASSUMPTION_VALUES.includes(humanized[2])) {
+    return { path, assumption: humanized[2] };
+  }
+  // Recognized the humanized shape but the fields are invalid: fail closed.
+  throw new StoryBodyParseError(
+    `changes/references entry is a humanized bullet but not a valid PathEntry: ${str.slice(0, 120)}${pathEntryFixIt(str)}`,
+    { field: 'changes', raw: str },
+  );
+}
+
+/**
+ * Parse the legacy inline-JSON object bullet:
+ * `{ "path": "...", "assumption": "..." }`. Returns `null` when the line is
+ * not a JSON object at all (including a JSON parse failure — the caller then
+ * rejects the plain-string form); fails closed when it parses to an object
+ * without valid PathEntry fields.
+ *
+ * @param {string} str
+ * @returns {PathEntry|null}
+ */
+function pathEntryFromInlineJson(str) {
+  if (!str.startsWith('{')) return null;
+  let parsed;
+  try {
+    parsed = JSON.parse(str);
+  } catch {
+    // JSON parse failed — the caller rejects the plain-string form.
+    return null;
+  }
+  if (typeof parsed !== 'object' || parsed === null) return null;
+  if (
+    typeof parsed.path === 'string' &&
+    FILE_ASSUMPTION_VALUES.includes(parsed.assumption)
+  ) {
+    return { path: parsed.path.trim(), assumption: parsed.assumption };
+  }
+  // Parsed successfully as JSON object but has invalid fields — fail closed.
+  throw new StoryBodyParseError(
+    `changes/references entry is a JSON object but not a valid PathEntry: ${str}`,
     { field: 'changes', raw: str },
   );
 }
@@ -420,13 +449,9 @@ function splitSections(markdown) {
   for (let i = 0; i < lines.length; i++) {
     const line = lines[i];
 
-    // Detect footer separator: `---` on its own line
-    if (/^---\s*$/.test(line)) {
-      const remaining = lines.slice(i + 1).join('\n');
-      if (/^(parent:|Epic:|blocked by)/im.test(remaining)) {
-        footerStart = i;
-        break;
-      }
+    if (isFooterSeparator(line, lines, i)) {
+      footerStart = i;
+      break;
     }
 
     // Detect `## Heading` (canonical) or `### Heading` lines. GitHub Issue
@@ -440,7 +465,7 @@ function splitSections(markdown) {
     // `-` folded to `_`) before the HEADING_TO_FIELD lookup, so `Non-Goals`
     // resolves to the `non_goals` field. Multi-word headings that contain a
     // space (`## Out of Scope`, `## Agent Prompts`) still do NOT match this
-    // single-token shape — they fall through to the catch-all heading branch
+    // single-token shape — they fall through to the section-terminator branch
     // below, which closes the open section. The chosen canonical spelling is
     // therefore the hyphenated single token `## Non-Goals`.
     const fieldHeadingMatch = line.match(/^#{2,3}\s+([\w-]+)\s*$/i);
@@ -452,47 +477,12 @@ function splitSections(markdown) {
       continue;
     }
 
-    // Any other markdown heading (`## …` / `### …`, single- or multi-word)
-    // that is NOT a canonical field heading TERMINATES the current structured
-    // section. Trailing extended content a producer appends after the
-    // canonical block — `audit-to-stories`'s `## Agent Prompts` / `## Context`
-    // / `## Sequencing` blocks, for instance — must not bleed into the last
-    // structured section's bullet list (Story #4270). Without this, those
-    // lines were silently absorbed into `verify[]` / `acceptance[]`. The
-    // heading and everything under it is dropped from structured parsing
-    // (it is extended, non-canonical markdown).
-    if (
-      !inPreamble &&
-      /^#{1,6}\s+\S/.test(line) &&
-      !TEXT_BLOCK_FIELDS.has(currentSection)
-    ) {
+    if (isSectionTerminatorHeading(line, inPreamble, currentSection)) {
       currentSection = null;
       continue;
     }
 
-    // The trailing `<!-- meta: {...} -->` block is machine metadata, not
-    // section content. Skip it so a `## References` section immediately
-    // followed by the meta block does not swallow the comment as a
-    // references entry. `extractMeta` reads it separately from the raw body.
-    if (META_BLOCK_RE.test(line)) {
-      continue;
-    }
-
-    // The visible `> 🏷️ Authored with Mandrel …` provenance marker is
-    // machine-managed metadata too (emitted alongside the meta block by the
-    // authoring path). Skip it so it never bleeds into the trailing structured
-    // section (e.g. `## Verify`); the value round-trips via the meta block.
-    if (AUTHORED_MARKER_LINE_RE.test(line)) {
-      continue;
-    }
-
-    // The visible `> **Wide:** <reason>` rationale line is presentation only
-    // (Story #4600): the meta block remains the canonical carrier for
-    // `wide.reason`, so this line must not bleed into the goal (or any other)
-    // section. Skip it wherever it appears.
-    if (WIDE_MARKER_LINE_RE.test(line)) {
-      continue;
-    }
+    if (isMachineMarkerLine(line)) continue;
 
     if (inPreamble) {
       preambleLines.push(line);
@@ -505,6 +495,70 @@ function splitSections(markdown) {
     footerStart >= 0 ? lines.slice(footerStart + 1).join('\n') : '';
   const preamble = preambleLines.join('\n').trim();
   return { sections, footer, preamble };
+}
+
+/**
+ * True when line `index` opens the footer block: a `---` on its own line
+ * whose remaining lines start with a recognised footer key (`parent:`,
+ * `Epic:`, `blocked by`).
+ *
+ * @param {string} line
+ * @param {string[]} lines
+ * @param {number} index
+ * @returns {boolean}
+ */
+function isFooterSeparator(line, lines, index) {
+  if (!/^---\s*$/.test(line)) return false;
+  const remaining = lines.slice(index + 1).join('\n');
+  return /^(parent:|Epic:|blocked by)/im.test(remaining);
+}
+
+/**
+ * True for a non-canonical markdown heading that TERMINATES the current
+ * structured section. Trailing extended content a producer appends after the
+ * canonical block — `audit-to-stories`'s `## Agent Prompts` / `## Context`
+ * / `## Sequencing` blocks, for instance — must not bleed into the last
+ * structured section's bullet list (Story #4270). Without this, those
+ * lines were silently absorbed into `verify[]` / `acceptance[]`. The
+ * heading and everything under it is dropped from structured parsing
+ * (it is extended, non-canonical markdown).
+ *
+ * @param {string} line
+ * @param {boolean} inPreamble
+ * @param {string|null} currentSection
+ * @returns {boolean}
+ */
+function isSectionTerminatorHeading(line, inPreamble, currentSection) {
+  return (
+    !inPreamble &&
+    /^#{1,6}\s+\S/.test(line) &&
+    !TEXT_BLOCK_FIELDS.has(currentSection)
+  );
+}
+
+/**
+ * True for machine-managed marker lines section parsing skips wherever they
+ * appear:
+ *   - the trailing `<!-- meta: {...} -->` block — machine metadata, not
+ *     section content, read separately by `extractMeta`, and skipped so a
+ *     `## References` section immediately followed by it does not swallow
+ *     the comment as a references entry;
+ *   - the visible `> 🏷️ Authored with Mandrel …` provenance marker (emitted
+ *     alongside the meta block by the authoring path; the value round-trips
+ *     via the meta block);
+ *   - the visible `> **Wide:** <reason>` rationale line (Story #4600):
+ *     presentation only — the meta block remains the canonical carrier for
+ *     `wide.reason`.
+ *
+ * @param {string} line
+ * @returns {boolean}
+ */
+function isMachineMarkerLine(line) {
+  return (
+    META_BLOCK_RE.test(line) ||
+    AUTHORED_MARKER_LINE_RE.test(line) ||
+    WIDE_MARKER_LINE_RE.test(line)
+  );
 }
 
 // ---------------------------------------------------------------------------
@@ -771,90 +825,25 @@ export function parse(input) {
 function parseStructuredObject(obj) {
   const warnings = [];
 
-  const goal = typeof obj.goal === 'string' ? obj.goal.trim() : '';
-
-  // slicing — optional v2 intra-Story delivery slice plan (verbatim text).
-  const slicing = typeof obj.slicing === 'string' ? obj.slicing.trim() : '';
-
-  // spec — optional folded Tech Spec (verbatim text).
-  const spec = typeof obj.spec === 'string' ? obj.spec.trim() : '';
-
-  // changes
-  const rawChanges = Array.isArray(obj.changes) ? obj.changes : [];
-  const changes = [];
-  for (const raw of rawChanges) {
-    const entry = parsePathEntry(raw, warnings);
-    if (entry !== null) changes.push(entry);
+  // The declarative half of the normalization: every field whose value is a
+  // pure function of its raw input (plus the shared warnings sink) is one
+  // table row, walked in canonical body-key order. Adding a field of an
+  // existing kind is a one-row change.
+  const body = {};
+  for (const { name, kind } of STRUCTURED_FIELD_SPECS) {
+    body[name] = STRUCTURED_FIELD_NORMALIZERS[kind](obj[name], warnings);
   }
 
-  // acceptance
-  const acceptance = Array.isArray(obj.acceptance)
-    ? obj.acceptance.filter((a) => typeof a === 'string' && a.trim().length > 0)
-    : [];
-
-  // verify
-  const verify = Array.isArray(obj.verify)
-    ? obj.verify.filter((v) => typeof v === 'string' && v.trim().length > 0)
-    : [];
-
-  // references
-  const rawRefs = Array.isArray(obj.references) ? obj.references : [];
-  const references = [];
-  for (const raw of rawRefs) {
-    const entry = parsePathEntry(raw, warnings);
-    if (entry !== null) references.push(entry);
-  }
-
-  // non_goals (advisory negative-scope bullets)
-  const non_goals = Array.isArray(obj.non_goals)
-    ? obj.non_goals.filter((n) => typeof n === 'string' && n.trim().length > 0)
-    : [];
-
-  const wide = normalizeWide(obj.wide);
-  const reason_to_exist = normalizeReasonToExist(obj.reason_to_exist);
-
-  // depends_on: may be at top level or in body
-  const rawDeps = Array.isArray(obj.depends_on) ? obj.depends_on : [];
-  const depends_on = rawDeps.filter(
-    (d) => typeof d === 'string' && d.trim().length > 0,
+  // estimated_test_files is the one warning-coupled scalar: absent (== null)
+  // warns; a non-number, non-null value stays null silently.
+  body.estimated_test_files = normalizeEstimatedTestFiles(
+    obj.estimated_test_files,
+    warnings,
   );
 
-  // estimated_test_files
-  let estimated_test_files = null;
-  if (typeof obj.estimated_test_files === 'number') {
-    estimated_test_files = obj.estimated_test_files;
-  } else if (obj.estimated_test_files == null) {
-    warnings.push(
-      'test-surface-unestimated: estimated_test_files not present.',
-    );
-  }
-
   // Provenance stamp (preserved verbatim; never re-derived here).
-  const mandrel_version =
-    typeof obj.mandrel_version === 'string' && obj.mandrel_version.trim()
-      ? obj.mandrel_version.trim()
-      : null;
-  const authored_at =
-    typeof obj.authored_at === 'string' && obj.authored_at.trim()
-      ? obj.authored_at.trim()
-      : null;
-
-  const body = {
-    goal,
-    slicing,
-    spec,
-    changes,
-    acceptance,
-    verify,
-    references,
-    non_goals,
-    wide,
-    reason_to_exist,
-    depends_on,
-    estimated_test_files,
-    mandrel_version,
-    authored_at,
-  };
+  body.mandrel_version = normalizeProvenanceString(obj.mandrel_version);
+  body.authored_at = normalizeProvenanceString(obj.authored_at);
 
   return {
     body,
@@ -871,6 +860,91 @@ function parseStructuredObject(obj) {
       isUnstructuredBody: false,
     },
   };
+}
+
+/**
+ * The field-spec table driving {@link parseStructuredObject}, in canonical
+ * body-key order. `kind` selects the normalizer from
+ * {@link STRUCTURED_FIELD_NORMALIZERS}:
+ *   - `text`          — trimmed string, or `''` when absent/non-string.
+ *   - `stringList`    — array filtered to non-empty strings, else `[]`.
+ *   - `pathEntryList` — array normalized entry-wise via `parsePathEntry`
+ *                       (fails closed on a malformed entry), else `[]`.
+ *   - `wide` / `reasonToExist` — the dedicated normalizers shared with the
+ *                       markdown parse path's meta-block recovery.
+ *
+ * @type {Array<{ name: string, kind: keyof typeof STRUCTURED_FIELD_NORMALIZERS }>}
+ */
+const STRUCTURED_FIELD_SPECS = [
+  { name: 'goal', kind: 'text' },
+  // slicing — optional v2 intra-Story delivery slice plan (verbatim text).
+  { name: 'slicing', kind: 'text' },
+  // spec — optional folded Tech Spec (verbatim text).
+  { name: 'spec', kind: 'text' },
+  { name: 'changes', kind: 'pathEntryList' },
+  { name: 'acceptance', kind: 'stringList' },
+  { name: 'verify', kind: 'stringList' },
+  { name: 'references', kind: 'pathEntryList' },
+  // non_goals — advisory negative-scope bullets.
+  { name: 'non_goals', kind: 'stringList' },
+  { name: 'wide', kind: 'wide' },
+  { name: 'reason_to_exist', kind: 'reasonToExist' },
+  // depends_on — may be at top level or in body.
+  { name: 'depends_on', kind: 'stringList' },
+];
+
+/**
+ * One normalizer per {@link STRUCTURED_FIELD_SPECS} kind. Each takes the raw
+ * field value plus the shared warnings sink and returns the canonical value.
+ *
+ * @type {Record<string, (raw: unknown, warnings: string[]) => unknown>}
+ */
+const STRUCTURED_FIELD_NORMALIZERS = {
+  text: (raw) => (typeof raw === 'string' ? raw.trim() : ''),
+  stringList: (raw) =>
+    Array.isArray(raw)
+      ? raw.filter((s) => typeof s === 'string' && s.trim().length > 0)
+      : [],
+  pathEntryList: (raw, warnings) => {
+    const entries = [];
+    for (const item of Array.isArray(raw) ? raw : []) {
+      const entry = parsePathEntry(item, warnings);
+      if (entry !== null) entries.push(entry);
+    }
+    return entries;
+  },
+  wide: (raw) => normalizeWide(raw),
+  reasonToExist: (raw) => normalizeReasonToExist(raw),
+};
+
+/**
+ * Normalize `estimated_test_files`: a number passes through; an absent
+ * (`null`/`undefined`) value warns `test-surface-unestimated`; any other
+ * value stays `null` silently.
+ *
+ * @param {unknown} raw
+ * @param {string[]} warnings
+ * @returns {number|null}
+ */
+function normalizeEstimatedTestFiles(raw, warnings) {
+  if (typeof raw === 'number') return raw;
+  if (raw == null) {
+    warnings.push(
+      'test-surface-unestimated: estimated_test_files not present.',
+    );
+  }
+  return null;
+}
+
+/**
+ * Normalize a provenance stamp field (`mandrel_version` / `authored_at`) to
+ * a non-empty trimmed string or `null`.
+ *
+ * @param {unknown} raw
+ * @returns {string|null}
+ */
+function normalizeProvenanceString(raw) {
+  return typeof raw === 'string' && raw.trim() ? raw.trim() : null;
 }
 
 // ---------------------------------------------------------------------------

--- a/.agents/scripts/resolve-stories.js
+++ b/.agents/scripts/resolve-stories.js
@@ -166,6 +166,57 @@ export async function resolveForeignDone({ provider, dag, inSetIds }) {
   return resolved.filter((id) => id !== null);
 }
 
+/**
+ * Resolve the requested ids into the `{ stories, dag, done }` envelope and
+ * write it to `stdout`. The flow core behind `main` — provider, config, and
+ * stdout are injected so the whole path is unit-testable without a live
+ * GitHub round-trip. Exported for testing.
+ *
+ * @param {{ ids: string, native?: boolean, pretty?: boolean }} args
+ * @param {{ provider: object, config: object, stdout?: { write(s: string): void } }} deps
+ * @returns {Promise<number>}
+ */
+export async function runResolveStories(
+  { ids: rawIds, native = true, pretty = false },
+  { provider, config, stdout = process.stdout },
+) {
+  const ids = parseIds(rawIds);
+  const owner = config.github?.owner;
+  const repo = config.github?.repo;
+
+  const stories = await fetchStories(provider, ids);
+  const nativeEdges = native
+    ? await readNativeEdges({ provider, stories, owner, repo })
+    : new Map();
+
+  const inSetIds = new Set(stories.map((s) => s.id));
+  const provisional = buildStoriesEnvelope({
+    stories,
+    nativeEdges,
+    warn: (m) => Logger.warn(m),
+    config,
+  });
+  const foreignDone = await resolveForeignDone({
+    provider,
+    dag: provisional.dag,
+    inSetIds,
+  });
+  const envelope = buildStoriesEnvelope({
+    stories,
+    nativeEdges,
+    foreignDone,
+    warn: () => {},
+    config,
+  });
+
+  stdout.write(
+    pretty
+      ? `${JSON.stringify(envelope, null, 2)}\n`
+      : `${JSON.stringify(envelope)}\n`,
+  );
+  return 0;
+}
+
 async function main() {
   const { values } = parseArgs({
     options: {
@@ -194,42 +245,10 @@ async function main() {
   // headless caller can pipe this straight into stories-wave-tick.js.
   routeAllOutputToStderr();
 
-  const ids = parseIds(values.ids);
-  const { provider, config } = resolveStoriesProvider();
-  const owner = config.github?.owner;
-  const repo = config.github?.repo;
-
-  const stories = await fetchStories(provider, ids);
-  const nativeEdges = values.native
-    ? await readNativeEdges({ provider, stories, owner, repo })
-    : new Map();
-
-  const inSetIds = new Set(stories.map((s) => s.id));
-  const provisional = buildStoriesEnvelope({
-    stories,
-    nativeEdges,
-    warn: (m) => Logger.warn(m),
-    config,
-  });
-  const foreignDone = await resolveForeignDone({
-    provider,
-    dag: provisional.dag,
-    inSetIds,
-  });
-  const envelope = buildStoriesEnvelope({
-    stories,
-    nativeEdges,
-    foreignDone,
-    warn: () => {},
-    config,
-  });
-
-  process.stdout.write(
-    values.pretty
-      ? `${JSON.stringify(envelope, null, 2)}\n`
-      : `${JSON.stringify(envelope)}\n`,
+  return runResolveStories(
+    { ids: values.ids, native: values.native, pretty: values.pretty },
+    resolveStoriesProvider(),
   );
-  return 0;
 }
 
 runAsCli(import.meta.url, main, {

--- a/.agents/scripts/single-story-confirm-merge.js
+++ b/.agents/scripts/single-story-confirm-merge.js
@@ -158,14 +158,13 @@ function readMaxWaitSecondsFlag() {
  * Resolve the PR number for the Story branch when one was not passed on
  * the CLI. Probes `gh pr list --head <branch> --state all` (the merged PR
  * is no longer `open`, so `--state all` is required). Returns `null` when
- * no PR is found.
+ * no PR is found. Exported for testing.
  *
- * @param {{ cwd: string, storyBranch: string, gh: object }} args
+ * @param {{ storyBranch: string, gh: object }} args
  * @returns {Promise<number|null>}
  */
-async function resolvePrNumber({ cwd, storyBranch, gh }) {
+export async function resolvePrNumber({ storyBranch, gh }) {
   try {
-    void cwd;
     const rows = await gh.pr.list(
       ['--head', storyBranch, '--state', 'all'],
       ['number', 'url'],
@@ -293,11 +292,11 @@ function buildConfirmTerminal({
   });
 }
 
-async function resolveConfirmPrNumber({ prParam, cwd, storyBranch, gh }) {
+async function resolveConfirmPrNumber({ prParam, storyBranch, gh }) {
   const rawPr = prParam ?? readPrFlag();
   let prNumber = Number.parseInt(String(rawPr ?? ''), 10);
   if (!Number.isInteger(prNumber) || prNumber <= 0) {
-    prNumber = await resolvePrNumber({ cwd, storyBranch, gh });
+    prNumber = await resolvePrNumber({ storyBranch, gh });
   }
   return Number.isInteger(prNumber) && prNumber > 0 ? prNumber : null;
 }
@@ -340,7 +339,6 @@ export async function runConfirmMerge({
 
   const prNumber = await resolveConfirmPrNumber({
     prParam,
-    cwd,
     storyBranch,
     gh,
   });

--- a/baselines/crap.json
+++ b/baselines/crap.json
@@ -1,14 +1,14 @@
 {
   "$schema": ".agents/schemas/baselines/crap.schema.json",
   "kernelVersion": "0.1.0",
-  "generatedAt": "2026-07-26T21:10:01.647Z",
+  "generatedAt": "2026-07-30T02:34:12.345Z",
   "scoringSemantics": "coverage-join-v2",
   "rollup": {
     "*": {
       "p50": 2,
-      "p95": 10.58179012345679,
-      "max": 30,
-      "methodsAbove20": 13
+      "p95": 10.078743741465637,
+      "max": 29.000120920774684,
+      "methodsAbove20": 8
     }
   },
   "rows": [
@@ -967,82 +967,28 @@
       "crap": 2
     },
     {
+      "path": ".agents/scripts/check-baseline-drift.js",
+      "method": "parseArgs",
+      "startLine": 60,
+      "crap": 10
+    },
+    {
+      "path": ".agents/scripts/check-baseline-drift.js",
+      "method": "runCheckBaselineDrift",
+      "startLine": 104,
+      "crap": 3
+    },
+    {
+      "path": ".agents/scripts/check-baseline-drift.js",
+      "method": "main",
+      "startLine": 121,
+      "crap": 2
+    },
+    {
       "path": ".agents/scripts/check-baselines.js",
       "method": "main",
       "startLine": 68,
       "crap": 1.1016296296296297
-    },
-    {
-      "path": ".agents/scripts/check-context-budget.js",
-      "method": "agentBootOverflow",
-      "startLine": 94,
-      "crap": 1
-    },
-    {
-      "path": ".agents/scripts/check-context-budget.js",
-      "method": "<anon method-1>",
-      "startLine": 97,
-      "crap": 2
-    },
-    {
-      "path": ".agents/scripts/check-context-budget.js",
-      "method": "<anon method-2>",
-      "startLine": 98,
-      "crap": 1
-    },
-    {
-      "path": ".agents/scripts/check-context-budget.js",
-      "method": "parseArgv",
-      "startLine": 108,
-      "crap": 10
-    },
-    {
-      "path": ".agents/scripts/check-context-budget.js",
-      "method": "loadBaseline",
-      "startLine": 143,
-      "crap": 4.128
-    },
-    {
-      "path": ".agents/scripts/check-context-budget.js",
-      "method": "buildBaseline",
-      "startLine": 162,
-      "crap": 1
-    },
-    {
-      "path": ".agents/scripts/check-context-budget.js",
-      "method": "diffBudget",
-      "startLine": 203,
-      "crap": 7
-    },
-    {
-      "path": ".agents/scripts/check-context-budget.js",
-      "method": "renderDiff",
-      "startLine": 246,
-      "crap": 2
-    },
-    {
-      "path": ".agents/scripts/check-context-budget.js",
-      "method": "renderReachable",
-      "startLine": 274,
-      "crap": 3
-    },
-    {
-      "path": ".agents/scripts/check-context-budget.js",
-      "method": "runCli",
-      "startLine": 298,
-      "crap": 19.455350394125908
-    },
-    {
-      "path": ".agents/scripts/check-context-budget.js",
-      "method": "<anon method-3>",
-      "startLine": 366,
-      "crap": 1.0134974624770543
-    },
-    {
-      "path": ".agents/scripts/check-context-budget.js",
-      "method": "main",
-      "startLine": 404,
-      "crap": 1
     },
     {
       "path": ".agents/scripts/check-dead-exports.js",
@@ -1106,86 +1052,116 @@
     },
     {
       "path": ".agents/scripts/check-doc-links.js",
-      "method": "isExcludedRelPath",
-      "startLine": 129,
-      "crap": 2
-    },
-    {
-      "path": ".agents/scripts/check-doc-links.js",
-      "method": "walkMarkdown",
-      "startLine": 134,
-      "crap": 7.06721536351166
-    },
-    {
-      "path": ".agents/scripts/check-doc-links.js",
-      "method": "discoverMarkdown",
-      "startLine": 153,
-      "crap": 2
-    },
-    {
-      "path": ".agents/scripts/check-doc-links.js",
-      "method": "maskCodeRegions",
-      "startLine": 170,
+      "method": "escapesPayload",
+      "startLine": 176,
       "crap": 6
     },
     {
       "path": ".agents/scripts/check-doc-links.js",
       "method": "<anon method-1>",
-      "startLine": 199,
+      "startLine": 185,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/check-doc-links.js",
+      "method": "isExcludedRelPath",
+      "startLine": 192,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/check-doc-links.js",
+      "method": "walkMarkdown",
+      "startLine": 197,
+      "crap": 7.06721536351166
+    },
+    {
+      "path": ".agents/scripts/check-doc-links.js",
+      "method": "discoverMarkdown",
+      "startLine": 224,
+      "crap": 3
+    },
+    {
+      "path": ".agents/scripts/check-doc-links.js",
+      "method": "<anon method-2>",
+      "startLine": 231,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/check-doc-links.js",
+      "method": "<anon method-3>",
+      "startLine": 233,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/check-doc-links.js",
+      "method": "maskCodeRegions",
+      "startLine": 247,
+      "crap": 6
+    },
+    {
+      "path": ".agents/scripts/check-doc-links.js",
+      "method": "<anon method-4>",
+      "startLine": 276,
       "crap": 1
     },
     {
       "path": ".agents/scripts/check-doc-links.js",
       "method": "offsetToLine",
-      "startLine": 207,
+      "startLine": 284,
       "crap": 3
     },
     {
       "path": ".agents/scripts/check-doc-links.js",
       "method": "extractLinks",
-      "startLine": 221,
+      "startLine": 298,
       "crap": 2
     },
     {
       "path": ".agents/scripts/check-doc-links.js",
       "method": "isExternalOrInternalAnchor",
-      "startLine": 235,
+      "startLine": 312,
       "crap": 4
     },
     {
       "path": ".agents/scripts/check-doc-links.js",
       "method": "stripAnchorAndQuery",
-      "startLine": 242,
+      "startLine": 319,
       "crap": 3
     },
     {
       "path": ".agents/scripts/check-doc-links.js",
       "method": "extractSlashTokens",
-      "startLine": 273,
+      "startLine": 350,
       "crap": 2
     },
     {
       "path": ".agents/scripts/check-doc-links.js",
       "method": "checkFile",
-      "startLine": 289,
-      "crap": 12.00169045830203
+      "startLine": 366,
+      "crap": 13.001073261189859
     },
     {
       "path": ".agents/scripts/check-doc-links.js",
       "method": "runCheck",
-      "startLine": 388,
+      "startLine": 488,
       "crap": 2
     },
     {
       "path": ".agents/scripts/check-doc-links.js",
       "method": "formatViolation",
-      "startLine": 404,
+      "startLine": 505,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/check-doc-links.js",
+      "method": "parseArgs",
+      "startLine": 514,
       "crap": 2
     },
     {
       "path": ".agents/scripts/check-doc-links.js",
       "method": "main",
-      "startLine": 408,
+      "startLine": 528,
       "crap": 6
     },
     {
@@ -1443,121 +1419,145 @@
     {
       "path": ".agents/scripts/check-test-temp-hygiene.js",
       "method": "tempDirFor",
-      "startLine": 74,
+      "startLine": 105,
       "crap": 1
     },
     {
       "path": ".agents/scripts/check-test-temp-hygiene.js",
       "method": "defaultBaselinePath",
-      "startLine": 90,
+      "startLine": 121,
       "crap": 1
     },
     {
       "path": ".agents/scripts/check-test-temp-hygiene.js",
       "method": "checkedBaselinePath",
-      "startLine": 111,
+      "startLine": 142,
       "crap": 3
     },
     {
       "path": ".agents/scripts/check-test-temp-hygiene.js",
       "method": "isStreamFile",
-      "startLine": 130,
+      "startLine": 161,
       "crap": 3
     },
     {
       "path": ".agents/scripts/check-test-temp-hygiene.js",
       "method": "listStreamFiles",
-      "startLine": 144,
+      "startLine": 175,
       "crap": 2
     },
     {
       "path": ".agents/scripts/check-test-temp-hygiene.js",
       "method": "<anon method-1>",
-      "startLine": 148,
+      "startLine": 179,
       "crap": 5
     },
     {
       "path": ".agents/scripts/check-test-temp-hygiene.js",
       "method": "fingerprintFile",
-      "startLine": 168,
+      "startLine": 199,
       "crap": 1
     },
     {
       "path": ".agents/scripts/check-test-temp-hygiene.js",
       "method": "buildManifest",
-      "startLine": 182,
+      "startLine": 213,
       "crap": 1
     },
     {
       "path": ".agents/scripts/check-test-temp-hygiene.js",
       "method": "writeSnapshot",
-      "startLine": 198,
+      "startLine": 230,
       "crap": 1
     },
     {
       "path": ".agents/scripts/check-test-temp-hygiene.js",
       "method": "readSnapshot",
-      "startLine": 215,
+      "startLine": 256,
       "crap": 2
     },
     {
       "path": ".agents/scripts/check-test-temp-hygiene.js",
       "method": "diffAgainstSnapshot",
-      "startLine": 237,
+      "startLine": 278,
       "crap": 4
     },
     {
       "path": ".agents/scripts/check-test-temp-hygiene.js",
       "method": "runDirId",
-      "startLine": 262,
+      "startLine": 303,
       "crap": 2
     },
     {
       "path": ".agents/scripts/check-test-temp-hygiene.js",
       "method": "findFixtureDirs",
-      "startLine": 277,
+      "startLine": 318,
       "crap": 10
     },
     {
       "path": ".agents/scripts/check-test-temp-hygiene.js",
       "method": "<anon method-2>",
-      "startLine": 302,
+      "startLine": 343,
       "crap": 1
     },
     {
       "path": ".agents/scripts/check-test-temp-hygiene.js",
       "method": "cleanFixtureDirs",
-      "startLine": 314,
+      "startLine": 355,
       "crap": 2
     },
     {
       "path": ".agents/scripts/check-test-temp-hygiene.js",
       "method": "parseArgv",
-      "startLine": 336,
-      "crap": 9
+      "startLine": 377,
+      "crap": 10
     },
     {
       "path": ".agents/scripts/check-test-temp-hygiene.js",
       "method": "<anon method-3>",
-      "startLine": 352,
+      "startLine": 394,
       "crap": 1
     },
     {
       "path": ".agents/scripts/check-test-temp-hygiene.js",
       "method": "<anon method-4>",
-      "startLine": 353,
+      "startLine": 400,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/check-test-temp-hygiene.js",
+      "method": "<anon method-5>",
+      "startLine": 401,
       "crap": 2
     },
     {
       "path": ".agents/scripts/check-test-temp-hygiene.js",
       "method": "runHygiene",
-      "startLine": 374,
-      "crap": 8
+      "startLine": 423,
+      "crap": 6
     },
     {
       "path": ".agents/scripts/check-test-temp-hygiene.js",
-      "method": "<anon method-5>",
-      "startLine": 433,
+      "method": "assertStreamTree",
+      "startLine": 488,
+      "crap": 3
+    },
+    {
+      "path": ".agents/scripts/check-test-temp-hygiene.js",
+      "method": "assertNoSurvivingSuiteRoots",
+      "startLine": 518,
+      "crap": 3
+    },
+    {
+      "path": ".agents/scripts/check-test-temp-hygiene.js",
+      "method": "assertNoRawTmpdirMkdtemp",
+      "startLine": 546,
+      "crap": 4
+    },
+    {
+      "path": ".agents/scripts/check-test-temp-hygiene.js",
+      "method": "<anon method-6>",
+      "startLine": 572,
       "crap": 1.125
     },
     {
@@ -1737,98 +1737,104 @@
     {
       "path": ".agents/scripts/deliver-light.js",
       "method": "parseCsvPaths",
-      "startLine": 130,
+      "startLine": 142,
       "crap": 3
     },
     {
       "path": ".agents/scripts/deliver-light.js",
       "method": "<anon method-1>",
-      "startLine": 134,
+      "startLine": 146,
       "crap": 1
     },
     {
       "path": ".agents/scripts/deliver-light.js",
       "method": "<anon method-2>",
-      "startLine": 135,
-      "crap": 1
-    },
-    {
-      "path": ".agents/scripts/deliver-light.js",
-      "method": "buildPredictedChanges",
-      "startLine": 145,
-      "crap": 1
-    },
-    {
-      "path": ".agents/scripts/deliver-light.js",
-      "method": "<anon method-3>",
       "startLine": 147,
       "crap": 1
     },
     {
       "path": ".agents/scripts/deliver-light.js",
+      "method": "buildPredictedChanges",
+      "startLine": 157,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/deliver-light.js",
+      "method": "<anon method-3>",
+      "startLine": 159,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/deliver-light.js",
       "method": "<anon method-4>",
-      "startLine": 148,
+      "startLine": 160,
       "crap": 1
     },
     {
       "path": ".agents/scripts/deliver-light.js",
       "method": "synthesizeAcceptance",
-      "startLine": 161,
+      "startLine": 173,
       "crap": 4
     },
     {
       "path": ".agents/scripts/deliver-light.js",
       "method": "<anon method-5>",
-      "startLine": 166,
+      "startLine": 178,
       "crap": 1
     },
     {
       "path": ".agents/scripts/deliver-light.js",
       "method": "runLightGate",
-      "startLine": 192,
+      "startLine": 207,
       "crap": 1
     },
     {
       "path": ".agents/scripts/deliver-light.js",
       "method": "createLightReceipt",
-      "startLine": 232,
-      "crap": 3.0839772561597902
+      "startLine": 254,
+      "crap": 3.036864
     },
     {
       "path": ".agents/scripts/deliver-light.js",
       "method": "buildNextCommands",
-      "startLine": 260,
+      "startLine": 288,
       "crap": 1
     },
     {
       "path": ".agents/scripts/deliver-light.js",
       "method": "runDiffBackstop",
-      "startLine": 279,
+      "startLine": 307,
       "crap": 1
     },
     {
       "path": ".agents/scripts/deliver-light.js",
+      "method": "hasOperatorOverride",
+      "startLine": 330,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/deliver-light.js",
       "method": "emit",
-      "startLine": 301,
+      "startLine": 342,
       "crap": 6
     },
     {
       "path": ".agents/scripts/deliver-light.js",
       "method": "runBackstopMode",
-      "startLine": 315,
+      "startLine": 356,
       "crap": 20
     },
     {
       "path": ".agents/scripts/deliver-light.js",
       "method": "runGateMode",
-      "startLine": 360,
-      "crap": 6.002129090339581
+      "startLine": 403,
+      "crap": 10.002958343240131
     },
     {
       "path": ".agents/scripts/deliver-light.js",
       "method": "main",
-      "startLine": 438,
-      "crap": 3.007415771484375
+      "startLine": 501,
+      "crap": 3.006761833208114
     },
     {
       "path": ".agents/scripts/deliver-recover.js",
@@ -2876,177 +2882,225 @@
     },
     {
       "path": ".agents/scripts/lib/audit-suite/selector.js",
-      "method": "declaresWebFramework",
-      "startLine": 336,
+      "method": "declaresDependencyIn",
+      "startLine": 340,
       "crap": 2.002048
     },
     {
       "path": ".agents/scripts/lib/audit-suite/selector.js",
       "method": "<anon method-2>",
-      "startLine": 354,
-      "crap": 1.000512
-    },
-    {
-      "path": ".agents/scripts/lib/audit-suite/selector.js",
-      "method": "<anon method-3>",
       "startLine": 358,
       "crap": 1.000512
     },
     {
       "path": ".agents/scripts/lib/audit-suite/selector.js",
+      "method": "<anon method-3>",
+      "startLine": 362,
+      "crap": 1.000512
+    },
+    {
+      "path": ".agents/scripts/lib/audit-suite/selector.js",
+      "method": "declaresWebFramework",
+      "startLine": 374,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/audit-suite/selector.js",
       "method": "scanForWebAssets",
-      "startLine": 377,
+      "startLine": 393,
       "crap": 10.022261179285973
     },
     {
       "path": ".agents/scripts/lib/audit-suite/selector.js",
       "method": "hasWebSurface",
-      "startLine": 441,
+      "startLine": 457,
       "crap": 5
     },
     {
       "path": ".agents/scripts/lib/audit-suite/selector.js",
       "method": "_resetPersistenceLayerCache",
-      "startLine": 511,
+      "startLine": 527,
       "crap": 1.2962962962962963
     },
     {
       "path": ".agents/scripts/lib/audit-suite/selector.js",
       "method": "declaresOrmDependency",
-      "startLine": 525,
-      "crap": 2.032
-    },
-    {
-      "path": ".agents/scripts/lib/audit-suite/selector.js",
-      "method": "<anon method-4>",
-      "startLine": 543,
-      "crap": 1.008
-    },
-    {
-      "path": ".agents/scripts/lib/audit-suite/selector.js",
-      "method": "<anon method-5>",
-      "startLine": 547,
-      "crap": 1.008
+      "startLine": 539,
+      "crap": 1
     },
     {
       "path": ".agents/scripts/lib/audit-suite/selector.js",
       "method": "scanForPersistenceArtifacts",
-      "startLine": 566,
+      "startLine": 558,
       "crap": 10.735168038408778
     },
     {
       "path": ".agents/scripts/lib/audit-suite/selector.js",
       "method": "hasPersistenceLayer",
-      "startLine": 631,
+      "startLine": 623,
       "crap": 4
     },
     {
       "path": ".agents/scripts/lib/audit-suite/selector.js",
       "method": "matchesFilePattern",
-      "startLine": 652,
+      "startLine": 644,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/audit-suite/selector.js",
       "method": "matchesAnyFilePattern",
-      "startLine": 660,
+      "startLine": 652,
       "crap": 3
     },
     {
       "path": ".agents/scripts/lib/audit-suite/selector.js",
+      "method": "<anon method-4>",
+      "startLine": 654,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/audit-suite/selector.js",
+      "method": "<anon method-5>",
+      "startLine": 655,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/audit-suite/selector.js",
       "method": "<anon method-6>",
-      "startLine": 662,
-      "crap": 1
-    },
-    {
-      "path": ".agents/scripts/lib/audit-suite/selector.js",
-      "method": "<anon method-7>",
-      "startLine": 663,
-      "crap": 1
-    },
-    {
-      "path": ".agents/scripts/lib/audit-suite/selector.js",
-      "method": "<anon method-8>",
-      "startLine": 663,
+      "startLine": 655,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/audit-suite/selector.js",
       "method": "isTestFile",
-      "startLine": 692,
+      "startLine": 684,
       "crap": 2
     },
     {
       "path": ".agents/scripts/lib/audit-suite/selector.js",
       "method": "stemOf",
-      "startLine": 703,
+      "startLine": 695,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/audit-suite/selector.js",
       "method": "changeSetLacksSiblingTest",
+      "startLine": 719,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/audit-suite/selector.js",
+      "method": "<anon method-7>",
+      "startLine": 721,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/audit-suite/selector.js",
+      "method": "<anon method-8>",
+      "startLine": 724,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/audit-suite/selector.js",
+      "method": "<anon method-9>",
+      "startLine": 724,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/audit-suite/selector.js",
+      "method": "<anon method-10>",
       "startLine": 727,
       "crap": 2
     },
     {
       "path": ".agents/scripts/lib/audit-suite/selector.js",
-      "method": "<anon method-9>",
-      "startLine": 729,
-      "crap": 2
-    },
-    {
-      "path": ".agents/scripts/lib/audit-suite/selector.js",
-      "method": "<anon method-10>",
-      "startLine": 732,
-      "crap": 1
-    },
-    {
-      "path": ".agents/scripts/lib/audit-suite/selector.js",
       "method": "<anon method-11>",
-      "startLine": 732,
-      "crap": 1
-    },
-    {
-      "path": ".agents/scripts/lib/audit-suite/selector.js",
-      "method": "<anon method-12>",
-      "startLine": 735,
-      "crap": 2
-    },
-    {
-      "path": ".agents/scripts/lib/audit-suite/selector.js",
-      "method": "<anon method-13>",
-      "startLine": 737,
+      "startLine": 729,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/audit-suite/selector.js",
       "method": "selectAudits",
-      "startLine": 790,
-      "crap": 25.263671875
+      "startLine": 782,
+      "crap": 7
+    },
+    {
+      "path": ".agents/scripts/lib/audit-suite/selector.js",
+      "method": "<anon method-12>",
+      "startLine": 802,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/audit-suite/selector.js",
+      "method": "<anon method-13>",
+      "startLine": 825,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/audit-suite/selector.js",
+      "method": "loadAuditRules",
+      "startLine": 878,
+      "crap": 1.0233236151603498
+    },
+    {
+      "path": ".agents/scripts/lib/audit-suite/selector.js",
+      "method": "ticketSearchText",
+      "startLine": 894,
+      "crap": 3
+    },
+    {
+      "path": ".agents/scripts/lib/audit-suite/selector.js",
+      "method": "resolveHeadRefOrDegrade",
+      "startLine": 910,
+      "crap": 4.35595703125
+    },
+    {
+      "path": ".agents/scripts/lib/audit-suite/selector.js",
+      "method": "acquireChangedFilesFromDiff",
+      "startLine": 952,
+      "crap": 3.000905580640698
     },
     {
       "path": ".agents/scripts/lib/audit-suite/selector.js",
       "method": "<anon method-14>",
-      "startLine": 824,
+      "startLine": 991,
+      "crap": 1.0001006200711886
+    },
+    {
+      "path": ".agents/scripts/lib/audit-suite/selector.js",
+      "method": "matchesAnyKeyword",
+      "startLine": 1005,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/audit-suite/selector.js",
       "method": "<anon method-15>",
-      "startLine": 870,
-      "crap": 1.000421875
+      "startLine": 1006,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/audit-suite/selector.js",
+      "method": "makeTargetApplicabilityProbe",
+      "startLine": 1021,
+      "crap": 1
     },
     {
       "path": ".agents/scripts/lib/audit-suite/selector.js",
       "method": "<anon method-16>",
-      "startLine": 888,
-      "crap": 1.000421875
+      "startLine": 1031,
+      "crap": 3
     },
     {
       "path": ".agents/scripts/lib/audit-suite/selector.js",
-      "method": "<anon method-17>",
-      "startLine": 917,
-      "crap": 3
+      "method": "lensTriggerFires",
+      "startLine": 1050,
+      "crap": 6
+    },
+    {
+      "path": ".agents/scripts/lib/audit-suite/selector.js",
+      "method": "matchAuditRules",
+      "startLine": 1073,
+      "crap": 7
     },
     {
       "path": ".agents/scripts/lib/audit-suite/substitutions.js",
@@ -3643,6 +3697,96 @@
       "crap": 18.00246568587162
     },
     {
+      "path": ".agents/scripts/lib/baselines/drift-detector.js",
+      "method": "<anon method-1>",
+      "startLine": 57,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/baselines/drift-detector.js",
+      "method": "<anon method-2>",
+      "startLine": 58,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/baselines/drift-detector.js",
+      "method": "<anon method-3>",
+      "startLine": 64,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/baselines/drift-detector.js",
+      "method": "<anon method-4>",
+      "startLine": 65,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/baselines/drift-detector.js",
+      "method": "resolveTolerance",
+      "startLine": 81,
+      "crap": 5
+    },
+    {
+      "path": ".agents/scripts/lib/baselines/drift-detector.js",
+      "method": "projectScoredRows",
+      "startLine": 104,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/baselines/drift-detector.js",
+      "method": "diffRows",
+      "startLine": 124,
+      "crap": 4
+    },
+    {
+      "path": ".agents/scripts/lib/baselines/drift-detector.js",
+      "method": "detectKindDrift",
+      "startLine": 182,
+      "crap": 8.0034390805833
+    },
+    {
+      "path": ".agents/scripts/lib/baselines/drift-detector.js",
+      "method": "detectBaselineDrift",
+      "startLine": 242,
+      "crap": 2.0354258067161424
+    },
+    {
+      "path": ".agents/scripts/lib/baselines/drift-detector.js",
+      "method": "<anon method-5>",
+      "startLine": 269,
+      "crap": 1.0088564516790357
+    },
+    {
+      "path": ".agents/scripts/lib/baselines/drift-detector.js",
+      "method": "defaultLoadBaselineRows",
+      "startLine": 277,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/baselines/drift-detector.js",
+      "method": "defaultScoreFullScope",
+      "startLine": 290,
+      "crap": 6
+    },
+    {
+      "path": ".agents/scripts/lib/baselines/drift-detector.js",
+      "method": "formatKindDrift",
+      "startLine": 304,
+      "crap": 6.058619987787503
+    },
+    {
+      "path": ".agents/scripts/lib/baselines/drift-detector.js",
+      "method": "<anon method-6>",
+      "startLine": 313,
+      "crap": 1.0016283329940974
+    },
+    {
+      "path": ".agents/scripts/lib/baselines/drift-detector.js",
+      "method": "formatDriftReport",
+      "startLine": 345,
+      "crap": 2
+    },
+    {
       "path": ".agents/scripts/lib/baselines/env-overrides.js",
       "method": "resolveCrapEnvOverrides",
       "startLine": 31,
@@ -3650,20 +3794,20 @@
     },
     {
       "path": ".agents/scripts/lib/baselines/env-overrides.js",
-      "method": "resolveBundleSizeEnvOverrides",
-      "startLine": 110,
+      "method": "kindRefreshEnvVar",
+      "startLine": 99,
       "crap": 3
     },
     {
       "path": ".agents/scripts/lib/baselines/env-overrides.js",
-      "method": "resolveMaintainabilityRefreshOverrides",
-      "startLine": 143,
-      "crap": 3
+      "method": "resolveKindRefreshOverrides",
+      "startLine": 133,
+      "crap": 4
     },
     {
       "path": ".agents/scripts/lib/baselines/env-overrides.js",
       "method": "resolveMaintainabilityEnvOverrides",
-      "startLine": 168,
+      "startLine": 160,
       "crap": 8
     },
     {
@@ -4047,163 +4191,163 @@
     {
       "path": ".agents/scripts/lib/baselines/kinds/crap.js",
       "method": "envelopeExtras",
-      "startLine": 104,
+      "startLine": 109,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/baselines/kinds/crap.js",
       "method": "projectRow",
-      "startLine": 108,
+      "startLine": 113,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/baselines/kinds/crap.js",
       "method": "sortRows",
-      "startLine": 117,
+      "startLine": 122,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/baselines/kinds/crap.js",
       "method": "<anon method-1>",
-      "startLine": 118,
+      "startLine": 123,
       "crap": 3
     },
     {
       "path": ".agents/scripts/lib/baselines/kinds/crap.js",
       "method": "<anon method-2>",
-      "startLine": 134,
+      "startLine": 139,
       "crap": 2
     },
     {
       "path": ".agents/scripts/lib/baselines/kinds/crap.js",
       "method": "<anon method-3>",
-      "startLine": 136,
+      "startLine": 141,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/baselines/kinds/crap.js",
       "method": "<anon method-4>",
-      "startLine": 168,
+      "startLine": 173,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/baselines/kinds/crap.js",
       "method": "crapRowKey",
-      "startLine": 171,
+      "startLine": 176,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/baselines/kinds/crap.js",
       "method": "mergeRows",
-      "startLine": 203,
-      "crap": 1
-    },
-    {
-      "path": ".agents/scripts/lib/baselines/kinds/crap.js",
-      "method": "<anon method-5>",
       "startLine": 208,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/baselines/kinds/crap.js",
+      "method": "<anon method-5>",
+      "startLine": 213,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/baselines/kinds/crap.js",
       "method": "<anon method-6>",
-      "startLine": 209,
+      "startLine": 214,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/baselines/kinds/crap.js",
       "method": "filterRowsByFileScope",
-      "startLine": 233,
-      "crap": 3.6875
+      "startLine": 238,
+      "crap": 2
     },
     {
       "path": ".agents/scripts/lib/baselines/kinds/crap.js",
       "method": "<anon method-7>",
-      "startLine": 235,
-      "crap": 1.421875
+      "startLine": 240,
+      "crap": 1
     },
     {
       "path": ".agents/scripts/lib/baselines/kinds/crap.js",
       "method": "checkCrapRegression",
-      "startLine": 258,
+      "startLine": 263,
       "crap": 3
     },
     {
       "path": ".agents/scripts/lib/baselines/kinds/crap.js",
       "method": "compareCrap",
-      "startLine": 284,
+      "startLine": 289,
       "crap": 12
     },
     {
       "path": ".agents/scripts/lib/baselines/kinds/crap.js",
       "method": "<anon method-8>",
-      "startLine": 399,
+      "startLine": 404,
       "crap": 3
     },
     {
       "path": ".agents/scripts/lib/baselines/kinds/crap.js",
       "method": "<anon method-9>",
-      "startLine": 408,
+      "startLine": 413,
       "crap": 3
     },
     {
       "path": ".agents/scripts/lib/baselines/kinds/crap.js",
       "method": "<anon method-10>",
-      "startLine": 425,
+      "startLine": 430,
       "crap": 4
     },
     {
       "path": ".agents/scripts/lib/baselines/kinds/crap.js",
       "method": "evaluateBaselineCompatibility",
-      "startLine": 447,
+      "startLine": 452,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/baselines/kinds/crap.js",
       "method": "assertBaselineCompatible",
-      "startLine": 467,
+      "startLine": 472,
       "crap": 3
     },
     {
       "path": ".agents/scripts/lib/baselines/kinds/crap.js",
       "method": "<anon method-11>",
-      "startLine": 470,
+      "startLine": 475,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/baselines/kinds/crap.js",
       "method": "loadCrapBaseline",
-      "startLine": 485,
+      "startLine": 490,
       "crap": 9.021751535698701
     },
     {
       "path": ".agents/scripts/lib/baselines/kinds/crap.js",
       "method": "buildCrapReport",
-      "startLine": 526,
+      "startLine": 531,
       "crap": 3
     },
     {
       "path": ".agents/scripts/lib/baselines/kinds/crap.js",
       "method": "<anon method-12>",
-      "startLine": 537,
+      "startLine": 542,
       "crap": 4
     },
     {
       "path": ".agents/scripts/lib/baselines/kinds/crap.js",
       "method": "printSummaryHeader",
-      "startLine": 583,
+      "startLine": 588,
       "crap": 5.20262390670554
     },
     {
       "path": ".agents/scripts/lib/baselines/kinds/crap.js",
       "method": "printViolation",
-      "startLine": 598,
+      "startLine": 603,
       "crap": 10.503358436800326
     },
     {
       "path": ".agents/scripts/lib/baselines/kinds/crap.js",
       "method": "printRemovedRows",
-      "startLine": 616,
+      "startLine": 621,
       "crap": 5.005259203606311
     },
     {
@@ -4401,67 +4545,67 @@
     {
       "path": ".agents/scripts/lib/baselines/kinds/maintainability.js",
       "method": "filterExcludedRows",
-      "startLine": 99,
+      "startLine": 98,
       "crap": 2
     },
     {
       "path": ".agents/scripts/lib/baselines/kinds/maintainability.js",
       "method": "<anon method-1>",
-      "startLine": 102,
+      "startLine": 101,
       "crap": 2
     },
     {
       "path": ".agents/scripts/lib/baselines/kinds/maintainability.js",
       "method": "projectRow",
-      "startLine": 106,
+      "startLine": 105,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/baselines/kinds/maintainability.js",
       "method": "aggregate",
-      "startLine": 113,
+      "startLine": 112,
       "crap": 3
     },
     {
       "path": ".agents/scripts/lib/baselines/kinds/maintainability.js",
       "method": "<anon method-2>",
-      "startLine": 115,
+      "startLine": 114,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/baselines/kinds/maintainability.js",
       "method": "<anon method-3>",
-      "startLine": 115,
+      "startLine": 114,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/baselines/kinds/maintainability.js",
       "method": "<anon method-4>",
-      "startLine": 141,
+      "startLine": 140,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/baselines/kinds/maintainability.js",
       "method": "buildMaintainabilityReport",
-      "startLine": 169,
+      "startLine": 168,
       "crap": 3
     },
     {
       "path": ".agents/scripts/lib/baselines/kinds/maintainability.js",
       "method": "<anon method-5>",
-      "startLine": 171,
+      "startLine": 170,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/baselines/kinds/maintainability.js",
       "method": "loadMaintainabilityBaseline",
-      "startLine": 195,
+      "startLine": 194,
       "crap": 13.913106866890216
     },
     {
       "path": ".agents/scripts/lib/baselines/kinds/maintainability.js",
       "method": "<anon method-6>",
-      "startLine": 206,
+      "startLine": 205,
       "crap": 1
     },
     {
@@ -4599,73 +4743,73 @@
     {
       "path": ".agents/scripts/lib/baselines/reader.js",
       "method": "ajv",
-      "startLine": 67,
+      "startLine": 68,
       "crap": 2
     },
     {
       "path": ".agents/scripts/lib/baselines/reader.js",
       "method": "resolveBaselinePath",
-      "startLine": 81,
+      "startLine": 82,
       "crap": 6.0703125
     },
     {
       "path": ".agents/scripts/lib/baselines/reader.js",
       "method": "canonicaliseRowPath",
-      "startLine": 118,
+      "startLine": 119,
       "crap": 3
     },
     {
       "path": ".agents/scripts/lib/baselines/reader.js",
       "method": "canonicaliseRow",
-      "startLine": 133,
+      "startLine": 134,
       "crap": 7
     },
     {
       "path": ".agents/scripts/lib/baselines/reader.js",
       "method": "validate",
-      "startLine": 158,
+      "startLine": 159,
       "crap": 5.024
     },
     {
       "path": ".agents/scripts/lib/baselines/reader.js",
       "method": "<anon method-1>",
-      "startLine": 176,
+      "startLine": 177,
       "crap": 2.2560000000000002
     },
     {
       "path": ".agents/scripts/lib/baselines/reader.js",
       "method": "readAndShape",
-      "startLine": 192,
-      "crap": 2.0932944606413995
+      "startLine": 193,
+      "crap": 2.05698861897209
     },
     {
       "path": ".agents/scripts/lib/baselines/reader.js",
       "method": "<anon method-2>",
-      "startLine": 211,
-      "crap": 1.0233236151603498
+      "startLine": 212,
+      "crap": 1.0142471547430225
     },
     {
       "path": ".agents/scripts/lib/baselines/reader.js",
       "method": "inferKindFromSchema",
-      "startLine": 230,
+      "startLine": 236,
       "crap": 3
     },
     {
       "path": ".agents/scripts/lib/baselines/reader.js",
       "method": "load",
-      "startLine": 248,
+      "startLine": 254,
       "crap": 2
     },
     {
       "path": ".agents/scripts/lib/baselines/reader.js",
       "method": "loadFile",
-      "startLine": 269,
+      "startLine": 275,
       "crap": 6
     },
     {
       "path": ".agents/scripts/lib/baselines/reader.js",
       "method": "<anon method-3>",
-      "startLine": 299,
+      "startLine": 305,
       "crap": 1
     },
     {
@@ -4767,103 +4911,103 @@
     {
       "path": ".agents/scripts/lib/baselines/refresh-service.js",
       "method": "resolveDefaultScorer",
-      "startLine": 362,
+      "startLine": 368,
       "crap": 2
     },
     {
       "path": ".agents/scripts/lib/baselines/refresh-service.js",
       "method": "refreshBaseline",
-      "startLine": 404,
+      "startLine": 410,
       "crap": 6.010937840286881
     },
     {
       "path": ".agents/scripts/lib/baselines/refresh-service.js",
       "method": "<anon method-13>",
-      "startLine": 469,
+      "startLine": 475,
       "crap": 1.0003038288968578
     },
     {
       "path": ".agents/scripts/lib/baselines/refresh-service.js",
       "method": "assertRequiredScopeRows",
-      "startLine": 524,
+      "startLine": 530,
       "crap": 6
     },
     {
       "path": ".agents/scripts/lib/baselines/refresh-service.js",
       "method": "<anon method-14>",
-      "startLine": 535,
-      "crap": 1
-    },
-    {
-      "path": ".agents/scripts/lib/baselines/refresh-service.js",
-      "method": "<anon method-15>",
       "startLine": 541,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/baselines/refresh-service.js",
+      "method": "<anon method-15>",
+      "startLine": 547,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/baselines/refresh-service.js",
       "method": "<anon method-16>",
-      "startLine": 542,
+      "startLine": 548,
       "crap": 2
     },
     {
       "path": ".agents/scripts/lib/baselines/refresh-service.js",
       "method": "<anon method-17>",
-      "startLine": 544,
+      "startLine": 550,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/baselines/refresh-service.js",
       "method": "defaultGitDiff",
-      "startLine": 562,
+      "startLine": 568,
       "crap": 2
     },
     {
       "path": ".agents/scripts/lib/baselines/refresh-service.js",
       "method": "<anon method-18>",
-      "startLine": 572,
+      "startLine": 578,
       "crap": 2
     },
     {
       "path": ".agents/scripts/lib/baselines/refresh-service.js",
       "method": "<anon method-19>",
-      "startLine": 573,
+      "startLine": 579,
       "crap": 2
     },
     {
       "path": ".agents/scripts/lib/baselines/refresh-service.js",
       "method": "deriveScopeFromDiff",
-      "startLine": 603,
+      "startLine": 609,
       "crap": 5
     },
     {
       "path": ".agents/scripts/lib/baselines/refresh-service.js",
       "method": "fileFilterFor",
-      "startLine": 631,
+      "startLine": 637,
       "crap": 2
     },
     {
       "path": ".agents/scripts/lib/baselines/refresh-service.js",
       "method": "resolveScope",
-      "startLine": 653,
+      "startLine": 659,
       "crap": 3
     },
     {
       "path": ".agents/scripts/lib/baselines/refresh-service.js",
       "method": "<anon method-20>",
-      "startLine": 668,
+      "startLine": 674,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/baselines/refresh-service.js",
       "method": "readPriorEnvelope",
-      "startLine": 691,
+      "startLine": 697,
       "crap": 7.226851851851852
     },
     {
       "path": ".agents/scripts/lib/baselines/refresh-service.js",
       "method": "validateOptions",
-      "startLine": 720,
+      "startLine": 726,
       "crap": 9
     },
     {
@@ -4955,6 +5099,12 @@
       "method": "writeFile",
       "startLine": 248,
       "crap": 5
+    },
+    {
+      "path": ".agents/scripts/lib/baselines/writer.js",
+      "method": "scopeMergeRows",
+      "startLine": 293,
+      "crap": 4
     },
     {
       "path": ".agents/scripts/lib/baselines/writer.js",
@@ -6519,26 +6669,20 @@
     {
       "path": ".agents/scripts/lib/cli-utils.js",
       "method": "isDirectInvocation",
-      "startLine": 29,
+      "startLine": 30,
       "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/cli-utils.js",
+      "method": "settleCli",
+      "startLine": 55,
+      "crap": 3
     },
     {
       "path": ".agents/scripts/lib/cli-utils.js",
       "method": "runAsCli",
-      "startLine": 57,
-      "crap": 5
-    },
-    {
-      "path": ".agents/scripts/lib/cli-utils.js",
-      "method": "<anon method-1>",
-      "startLine": 70,
-      "crap": 1
-    },
-    {
-      "path": ".agents/scripts/lib/cli-utils.js",
-      "method": "<anon method-2>",
-      "startLine": 72,
-      "crap": 2
+      "startLine": 98,
+      "crap": 4
     },
     {
       "path": ".agents/scripts/lib/cli/parse-numeric.js",
@@ -6865,6 +7009,114 @@
       "crap": 1.0132051089406462
     },
     {
+      "path": ".agents/scripts/lib/close-validation/projections/advisories.js",
+      "method": "resolveBaselinePath",
+      "startLine": 50,
+      "crap": 4
+    },
+    {
+      "path": ".agents/scripts/lib/close-validation/projections/advisories.js",
+      "method": "isEnabled",
+      "startLine": 66,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/close-validation/projections/advisories.js",
+      "method": "runOne",
+      "startLine": 78,
+      "crap": 4
+    },
+    {
+      "path": ".agents/scripts/lib/close-validation/projections/advisories.js",
+      "method": "runProjectionAdvisories",
+      "startLine": 119,
+      "crap": 3.000250438266967
+    },
+    {
+      "path": ".agents/scripts/lib/close-validation/projections/advisories.js",
+      "method": "<anon method-1>",
+      "startLine": 145,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/close-validation/projections/advisories.js",
+      "method": "<anon method-2>",
+      "startLine": 163,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/close-validation/projections/crap.js",
+      "method": "normaliseSkipReason",
+      "startLine": 62,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/close-validation/projections/crap.js",
+      "method": "loadCrapBaselineRows",
+      "startLine": 80,
+      "crap": 6
+    },
+    {
+      "path": ".agents/scripts/lib/close-validation/projections/crap.js",
+      "method": "<anon method-1>",
+      "startLine": 88,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/close-validation/projections/crap.js",
+      "method": "createCrapScorer",
+      "startLine": 111,
+      "crap": 1.1984953703703702
+    },
+    {
+      "path": ".agents/scripts/lib/close-validation/projections/crap.js",
+      "method": "<anon method-2>",
+      "startLine": 118,
+      "crap": 7.175925925925925
+    },
+    {
+      "path": ".agents/scripts/lib/close-validation/projections/crap.js",
+      "method": "refreshBaseRef",
+      "startLine": 146,
+      "crap": 4
+    },
+    {
+      "path": ".agents/scripts/lib/close-validation/projections/crap.js",
+      "method": "diffScorableFiles",
+      "startLine": 164,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/close-validation/projections/crap.js",
+      "method": "<anon method-3>",
+      "startLine": 171,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/close-validation/projections/crap.js",
+      "method": "projectCrapBreaches",
+      "startLine": 204,
+      "crap": 11
+    },
+    {
+      "path": ".agents/scripts/lib/close-validation/projections/crap.js",
+      "method": "<anon method-4>",
+      "startLine": 215,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/close-validation/projections/crap.js",
+      "method": "formatBreach",
+      "startLine": 273,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/close-validation/projections/crap.js",
+      "method": "formatCrapProjection",
+      "startLine": 292,
+      "crap": 4
+    },
+    {
       "path": ".agents/scripts/lib/close-validation/projections/head-sha.js",
       "method": "parseHeadSha",
       "startLine": 22,
@@ -6927,38 +7179,44 @@
     {
       "path": ".agents/scripts/lib/close-validation/runner.js",
       "method": "applyChangedFileScope",
-      "startLine": 26,
+      "startLine": 27,
       "crap": 5.592315839874638
     },
     {
       "path": ".agents/scripts/lib/close-validation/runner.js",
       "method": "runCloseValidation",
-      "startLine": 110,
-      "crap": 18.952739131450485
+      "startLine": 124,
+      "crap": 17.206031861629494
     },
     {
       "path": ".agents/scripts/lib/close-validation/runner.js",
       "method": "<anon method-1>",
-      "startLine": 143,
+      "startLine": 161,
       "crap": 11.442524417731029
     },
     {
       "path": ".agents/scripts/lib/close-validation/runner.js",
       "method": "<anon method-2>",
-      "startLine": 166,
+      "startLine": 184,
       "crap": 5.13508260447036
     },
     {
       "path": ".agents/scripts/lib/close-validation/runner.js",
       "method": "<anon method-3>",
-      "startLine": 199,
+      "startLine": 217,
       "crap": 6
     },
     {
       "path": ".agents/scripts/lib/close-validation/runner.js",
       "method": "<anon method-4>",
-      "startLine": 228,
-      "crap": 10.254291742087759
+      "startLine": 246,
+      "crap": 9.046867546654529
+    },
+    {
+      "path": ".agents/scripts/lib/close-validation/runner.js",
+      "method": "runAdvisoryProjections",
+      "startLine": 402,
+      "crap": 3
     },
     {
       "path": ".agents/scripts/lib/close-validation/telemetry.js",
@@ -7113,37 +7371,37 @@
     {
       "path": ".agents/scripts/lib/config/explain.js",
       "method": "isSecretKey",
-      "startLine": 290,
+      "startLine": 282,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/config/explain.js",
       "method": "<anon method-1>",
-      "startLine": 293,
+      "startLine": 285,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/config/explain.js",
       "method": "<anon method-2>",
-      "startLine": 294,
+      "startLine": 286,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/config/explain.js",
       "method": "meaningFor",
-      "startLine": 304,
+      "startLine": 296,
       "crap": 7
     },
     {
       "path": ".agents/scripts/lib/config/explain.js",
       "method": "attribute",
-      "startLine": 333,
+      "startLine": 325,
       "crap": 2
     },
     {
       "path": ".agents/scripts/lib/config/explain.js",
       "method": "explainConfig",
-      "startLine": 356,
+      "startLine": 348,
       "crap": 3
     },
     {
@@ -7395,121 +7653,151 @@
     {
       "path": ".agents/scripts/lib/config/temp-paths.js",
       "method": "mainCheckoutRoot",
-      "startLine": 85,
+      "startLine": 87,
       "crap": 6
     },
     {
       "path": ".agents/scripts/lib/config/temp-paths.js",
       "method": "_clearMainCheckoutRootCache",
-      "startLine": 115,
+      "startLine": 117,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/config/temp-paths.js",
       "method": "testScratchTempRoot",
-      "startLine": 145,
+      "startLine": 147,
       "crap": 4
     },
     {
       "path": ".agents/scripts/lib/config/temp-paths.js",
       "method": "_clearTestContextScratchCache",
-      "startLine": 175,
+      "startLine": 177,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/config/temp-paths.js",
       "method": "inNodeTestContext",
-      "startLine": 190,
-      "crap": 2
+      "startLine": 196,
+      "crap": 3
     },
     {
       "path": ".agents/scripts/lib/config/temp-paths.js",
       "method": "anchorTempRoot",
-      "startLine": 230,
-      "crap": 8
+      "startLine": 242,
+      "crap": 9
     },
     {
       "path": ".agents/scripts/lib/config/temp-paths.js",
       "method": "tempRootFrom",
-      "startLine": 268,
+      "startLine": 289,
       "crap": 5
     },
     {
       "path": ".agents/scripts/lib/config/temp-paths.js",
       "method": "orchestrationLogDir",
-      "startLine": 300,
+      "startLine": 321,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/config/temp-paths.js",
+      "method": "closeGateLogName",
+      "startLine": 340,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/config/temp-paths.js",
+      "method": "closeGateLogPath",
+      "startLine": 351,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/config/temp-paths.js",
+      "method": "storyTerminalEnvelopeName",
+      "startLine": 361,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/config/temp-paths.js",
+      "method": "storyTerminalEnvelopePath",
+      "startLine": 383,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/config/temp-paths.js",
       "method": "<anon method-1>",
-      "startLine": 304,
+      "startLine": 387,
       "crap": 3
     },
     {
       "path": ".agents/scripts/lib/config/temp-paths.js",
       "method": "<anon method-2>",
-      "startLine": 318,
+      "startLine": 401,
       "crap": 4
     },
     {
       "path": ".agents/scripts/lib/config/temp-paths.js",
       "method": "<anon method-3>",
-      "startLine": 328,
+      "startLine": 411,
       "crap": 3
     },
     {
       "path": ".agents/scripts/lib/config/temp-paths.js",
       "method": "<anon method-4>",
-      "startLine": 337,
+      "startLine": 420,
       "crap": 6
     },
     {
       "path": ".agents/scripts/lib/config/temp-paths.js",
       "method": "runTempDir",
-      "startLine": 359,
+      "startLine": 442,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/config/temp-paths.js",
       "method": "storyTempDir",
-      "startLine": 383,
+      "startLine": 466,
       "crap": 2
     },
     {
       "path": ".agents/scripts/lib/config/temp-paths.js",
       "method": "signalsFile",
-      "startLine": 401,
+      "startLine": 492,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/config/temp-paths.js",
+      "method": "resolvedTempRoot",
+      "startLine": 518,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/config/temp-paths.js",
       "method": "<anon method-5>",
-      "startLine": 426,
+      "startLine": 543,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/config/temp-paths.js",
       "method": "runArtifactPath",
-      "startLine": 440,
+      "startLine": 557,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/config/temp-paths.js",
       "method": "storyArtifactPath",
-      "startLine": 454,
+      "startLine": 571,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/config/temp-paths.js",
       "method": "<anon method-6>",
-      "startLine": 471,
+      "startLine": 588,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/config/temp-paths.js",
       "method": "<anon method-7>",
-      "startLine": 476,
+      "startLine": 593,
       "crap": 1
     },
     {
@@ -8026,7 +8314,7 @@
       "path": ".agents/scripts/lib/crap-utils.js",
       "method": "scanAndScore",
       "startLine": 389,
-      "crap": 14.962948
+      "crap": 14.349055291204051
     },
     {
       "path": ".agents/scripts/lib/crap-utils.js",
@@ -8038,7 +8326,13 @@
       "path": ".agents/scripts/lib/crap-utils.js",
       "method": "<anon method-7>",
       "startLine": 473,
-      "crap": 6.627343392775492
+      "crap": 6.0641121963436015
+    },
+    {
+      "path": ".agents/scripts/lib/crap-utils.js",
+      "method": "scoreFileSerial",
+      "startLine": 497,
+      "crap": 5
     },
     {
       "path": ".agents/scripts/lib/crap-utils.js",
@@ -8060,9 +8354,51 @@
     },
     {
       "path": ".agents/scripts/lib/crap-utils.js",
+      "method": "scoreFileCombinedSerial",
+      "startLine": 571,
+      "crap": 8.06988385090149
+    },
+    {
+      "path": ".agents/scripts/lib/crap-utils.js",
+      "method": "scoreFilesCombinedViaPool",
+      "startLine": 629,
+      "crap": 1.0182242309374545
+    },
+    {
+      "path": ".agents/scripts/lib/crap-utils.js",
+      "method": "<anon method-10>",
+      "startLine": 630,
+      "crap": 1.0182242309374545
+    },
+    {
+      "path": ".agents/scripts/lib/crap-utils.js",
+      "method": "<anon method-11>",
+      "startLine": 637,
+      "crap": 3.16401807843709
+    },
+    {
+      "path": ".agents/scripts/lib/crap-utils.js",
       "method": "scanAndScoreCombined",
       "startLine": 700,
-      "crap": 19.201693172062658
+      "crap": 15.123909049656138
+    },
+    {
+      "path": ".agents/scripts/lib/crap-utils.js",
+      "method": "<anon method-12>",
+      "startLine": 744,
+      "crap": 1.0005507068873607
+    },
+    {
+      "path": ".agents/scripts/lib/crap-utils.js",
+      "method": "<anon method-13>",
+      "startLine": 796,
+      "crap": 3.0049563619862454
+    },
+    {
+      "path": ".agents/scripts/lib/crap-utils.js",
+      "method": "<anon method-14>",
+      "startLine": 804,
+      "crap": 6.019825447944982
     },
     {
       "path": ".agents/scripts/lib/dead-exports-knip.js",
@@ -8415,49 +8751,79 @@
     {
       "path": ".agents/scripts/lib/dynamic-workflow/audit-orchestrator.js",
       "method": "defaultContractError",
-      "startLine": 117,
+      "startLine": 140,
       "crap": 3
     },
     {
       "path": ".agents/scripts/lib/dynamic-workflow/audit-orchestrator.js",
-      "method": "runAuditOrchestration",
-      "startLine": 137,
+      "method": "describeRejection",
+      "startLine": 154,
       "crap": 2
     },
     {
       "path": ".agents/scripts/lib/dynamic-workflow/audit-orchestrator.js",
-      "method": "<anon method-1>",
-      "startLine": 147,
+      "method": "partitionSettled",
+      "startLine": 170,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/dynamic-workflow/audit-orchestrator.js",
+      "method": "<anon method-1>",
+      "startLine": 173,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/dynamic-workflow/audit-orchestrator.js",
+      "method": "runAuditOrchestration",
+      "startLine": 199,
+      "crap": 4
+    },
+    {
+      "path": ".agents/scripts/lib/dynamic-workflow/audit-orchestrator.js",
       "method": "<anon method-2>",
-      "startLine": 153,
+      "startLine": 209,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/dynamic-workflow/audit-orchestrator.js",
       "method": "<anon method-3>",
-      "startLine": 155,
+      "startLine": 216,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/dynamic-workflow/audit-orchestrator.js",
       "method": "<anon method-4>",
-      "startLine": 167,
+      "startLine": 218,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/dynamic-workflow/audit-orchestrator.js",
       "method": "<anon method-5>",
-      "startLine": 169,
+      "startLine": 233,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/dynamic-workflow/audit-orchestrator.js",
       "method": "<anon method-6>",
-      "startLine": 182,
+      "startLine": 234,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/dynamic-workflow/audit-orchestrator.js",
+      "method": "<anon method-7>",
+      "startLine": 236,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/dynamic-workflow/audit-orchestrator.js",
+      "method": "<anon method-8>",
+      "startLine": 253,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/dynamic-workflow/audit-orchestrator.js",
+      "method": "<anon method-9>",
+      "startLine": 261,
       "crap": 1
     },
     {
@@ -8517,6 +8883,30 @@
     {
       "path": ".agents/scripts/lib/dynamic-workflow/clean-code-report-contract.js",
       "method": "assertReportContract",
+      "startLine": 75,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/dynamic-workflow/degraded-coverage.js",
+      "method": "formatDegradedCoverageNote",
+      "startLine": 45,
+      "crap": 3
+    },
+    {
+      "path": ".agents/scripts/lib/dynamic-workflow/degraded-coverage.js",
+      "method": "<anon method-1>",
+      "startLine": 47,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/dynamic-workflow/degraded-coverage.js",
+      "method": "withDegradedCoverageNote",
+      "startLine": 71,
+      "crap": 4
+    },
+    {
+      "path": ".agents/scripts/lib/dynamic-workflow/degraded-coverage.js",
+      "method": "<anon method-2>",
       "startLine": 75,
       "crap": 1
     },
@@ -8672,182 +9062,254 @@
     },
     {
       "path": ".agents/scripts/lib/feedback-loop/graduator-core.js",
+      "method": "resolveFilingContext",
+      "startLine": 154,
+      "crap": 8
+    },
+    {
+      "path": ".agents/scripts/lib/feedback-loop/graduator-core.js",
       "method": "contentFingerprint",
-      "startLine": 111,
+      "startLine": 198,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/feedback-loop/graduator-core.js",
       "method": "<anon method-1>",
-      "startLine": 112,
+      "startLine": 199,
       "crap": 3
     },
     {
       "path": ".agents/scripts/lib/feedback-loop/graduator-core.js",
       "method": "runChild",
-      "startLine": 143,
+      "startLine": 230,
       "crap": 1.000056895766955
     },
     {
       "path": ".agents/scripts/lib/feedback-loop/graduator-core.js",
       "method": "<anon method-2>",
-      "startLine": 150,
+      "startLine": 237,
       "crap": 3.0005120619025942
     },
     {
       "path": ".agents/scripts/lib/feedback-loop/graduator-core.js",
       "method": "<anon method-3>",
-      "startLine": 172,
+      "startLine": 259,
       "crap": 3
     },
     {
       "path": ".agents/scripts/lib/feedback-loop/graduator-core.js",
       "method": "<anon method-4>",
-      "startLine": 179,
+      "startLine": 266,
       "crap": 1.000056895766955
     },
     {
       "path": ".agents/scripts/lib/feedback-loop/graduator-core.js",
       "method": "<anon method-5>",
-      "startLine": 207,
+      "startLine": 294,
       "crap": 1.000056895766955
     },
     {
       "path": ".agents/scripts/lib/feedback-loop/graduator-core.js",
       "method": "<anon method-6>",
-      "startLine": 210,
+      "startLine": 297,
       "crap": 1.000056895766955
     },
     {
       "path": ".agents/scripts/lib/feedback-loop/graduator-core.js",
       "method": "<anon method-7>",
-      "startLine": 213,
+      "startLine": 300,
       "crap": 1.000056895766955
     },
     {
       "path": ".agents/scripts/lib/feedback-loop/graduator-core.js",
       "method": "<anon method-8>",
-      "startLine": 216,
+      "startLine": 303,
       "crap": 1.000056895766955
     },
     {
       "path": ".agents/scripts/lib/feedback-loop/graduator-core.js",
       "method": "makeIsAutoFileEnabled",
-      "startLine": 231,
+      "startLine": 318,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/feedback-loop/graduator-core.js",
       "method": "isAutoFileEnabled",
-      "startLine": 232,
+      "startLine": 319,
       "crap": 2
     },
     {
       "path": ".agents/scripts/lib/feedback-loop/graduator-core.js",
       "method": "probePathStatus",
-      "startLine": 256,
+      "startLine": 343,
       "crap": 3
     },
     {
       "path": ".agents/scripts/lib/feedback-loop/graduator-core.js",
       "method": "normalizeMarkerQuery",
-      "startLine": 291,
+      "startLine": 378,
       "crap": 2
     },
     {
       "path": ".agents/scripts/lib/feedback-loop/graduator-core.js",
-      "method": "probeMarkerExists",
-      "startLine": 305,
-      "crap": 6.009667349199423
+      "method": "toFollowUpRef",
+      "startLine": 393,
+      "crap": 4
     },
     {
       "path": ".agents/scripts/lib/feedback-loop/graduator-core.js",
-      "method": "confirmMarkerFiled",
-      "startLine": 364,
-      "crap": 6.0056857441809965
+      "method": "searchFollowUpByMarker",
+      "startLine": 415,
+      "crap": 7.011962890625
+    },
+    {
+      "path": ".agents/scripts/lib/feedback-loop/graduator-core.js",
+      "method": "probeMarkerExists",
+      "startLine": 457,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/feedback-loop/graduator-core.js",
+      "method": "findExistingFollowUp",
+      "startLine": 494,
+      "crap": 9.00460855712335
     },
     {
       "path": ".agents/scripts/lib/feedback-loop/graduator-core.js",
       "method": "<anon method-9>",
-      "startLine": 395,
-      "crap": 2.000631749353444
+      "startLine": 505,
+      "crap": 2.0002275830678196
+    },
+    {
+      "path": ".agents/scripts/lib/feedback-loop/graduator-core.js",
+      "method": "<anon method-10>",
+      "startLine": 533,
+      "crap": 2.0002275830678196
+    },
+    {
+      "path": ".agents/scripts/lib/feedback-loop/graduator-core.js",
+      "method": "<anon method-11>",
+      "startLine": 535,
+      "crap": 1.000056895766955
+    },
+    {
+      "path": ".agents/scripts/lib/feedback-loop/graduator-core.js",
+      "method": "<anon method-12>",
+      "startLine": 542,
+      "crap": 1.000056895766955
+    },
+    {
+      "path": ".agents/scripts/lib/feedback-loop/graduator-core.js",
+      "method": "updateFollowUpIssue",
+      "startLine": 558,
+      "crap": 7
+    },
+    {
+      "path": ".agents/scripts/lib/feedback-loop/graduator-core.js",
+      "method": "describeMintedLabel",
+      "startLine": 606,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/feedback-loop/graduator-core.js",
+      "method": "readLiveLabelNames",
+      "startLine": 628,
+      "crap": 12.028549962434258
+    },
+    {
+      "path": ".agents/scripts/lib/feedback-loop/graduator-core.js",
+      "method": "ensureIssueLabels",
+      "startLine": 702,
+      "crap": 12
+    },
+    {
+      "path": ".agents/scripts/lib/feedback-loop/graduator-core.js",
+      "method": "<anon method-13>",
+      "startLine": 713,
+      "crap": 2
     },
     {
       "path": ".agents/scripts/lib/feedback-loop/graduator-core.js",
       "method": "createFollowUpIssue",
-      "startLine": 408,
+      "startLine": 779,
       "crap": 7
     },
     {
       "path": ".agents/scripts/lib/feedback-loop/graduator-core.js",
       "method": "checkGraduatePreconditions",
-      "startLine": 452,
+      "startLine": 823,
       "crap": 10.119744
     },
     {
       "path": ".agents/scripts/lib/feedback-loop/graduator-core.js",
       "method": "loadGraduateFindings",
-      "startLine": 484,
+      "startLine": 855,
       "crap": 4.010520259718912
     },
     {
       "path": ".agents/scripts/lib/feedback-loop/graduator-core.js",
-      "method": "<anon method-10>",
-      "startLine": 496,
+      "method": "<anon method-14>",
+      "startLine": 867,
       "crap": 2.002630064929728
     },
     {
       "path": ".agents/scripts/lib/feedback-loop/graduator-core.js",
       "method": "resolveAlreadyFiled",
-      "startLine": 516,
+      "startLine": 891,
       "crap": 5
     },
     {
       "path": ".agents/scripts/lib/feedback-loop/graduator-core.js",
-      "method": "<anon method-11>",
-      "startLine": 527,
+      "method": "<anon method-15>",
+      "startLine": 902,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/feedback-loop/graduator-core.js",
-      "method": "processGraduateFinding",
-      "startLine": 559,
-      "crap": 14.006708167865193
+      "method": "resolveFollowUpRecurrence",
+      "startLine": 943,
+      "crap": 6
     },
     {
       "path": ".agents/scripts/lib/feedback-loop/graduator-core.js",
-      "method": "<anon method-12>",
-      "startLine": 578,
+      "method": "processGraduateFinding",
+      "startLine": 1002,
+      "crap": 16.003311396367213
+    },
+    {
+      "path": ".agents/scripts/lib/feedback-loop/graduator-core.js",
+      "method": "<anon method-16>",
+      "startLine": 1022,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/feedback-loop/graduator-core.js",
       "method": "renderCrossRepoDeferredBody",
-      "startLine": 720,
+      "startLine": 1222,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/feedback-loop/graduator-core.js",
-      "method": "<anon method-13>",
-      "startLine": 724,
+      "method": "<anon method-17>",
+      "startLine": 1226,
       "crap": 3
     },
     {
       "path": ".agents/scripts/lib/feedback-loop/graduator-core.js",
       "method": "persistCrossRepoDeferred",
-      "startLine": 743,
+      "startLine": 1245,
       "crap": 2.0210405194378236
     },
     {
       "path": ".agents/scripts/lib/feedback-loop/graduator-core.js",
       "method": "graduate",
-      "startLine": 818,
-      "crap": 6
+      "startLine": 1334,
+      "crap": 9
     },
     {
       "path": ".agents/scripts/lib/feedback-loop/graduator-core.js",
-      "method": "<anon method-14>",
-      "startLine": 840,
+      "method": "<anon method-18>",
+      "startLine": 1359,
       "crap": 1
     },
     {
@@ -9074,110 +9536,122 @@
     },
     {
       "path": ".agents/scripts/lib/feedback-loop/retro-proposals-graduator.js",
+      "method": "proposalFingerprint",
+      "startLine": 62,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/feedback-loop/retro-proposals-graduator.js",
       "method": "buildContentMarker",
-      "startLine": 65,
+      "startLine": 97,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/feedback-loop/retro-proposals-graduator.js",
+      "method": "buildMatchTokens",
+      "startLine": 120,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/feedback-loop/retro-proposals-graduator.js",
       "method": "metaSourceLabel",
-      "startLine": 86,
+      "startLine": 130,
       "crap": 2
     },
     {
       "path": ".agents/scripts/lib/feedback-loop/retro-proposals-graduator.js",
       "method": "makeSpec",
-      "startLine": 100,
-      "crap": 1.0007513148009015
+      "startLine": 144,
+      "crap": 1.0000254427030328
     },
     {
       "path": ".agents/scripts/lib/feedback-loop/retro-proposals-graduator.js",
       "method": "<anon method-1>",
-      "startLine": 109,
+      "startLine": 153,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/feedback-loop/retro-proposals-graduator.js",
       "method": "<anon method-2>",
-      "startLine": 112,
+      "startLine": 157,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/feedback-loop/retro-proposals-graduator.js",
       "method": "<anon method-3>",
-      "startLine": 117,
-      "crap": 1.216
+      "startLine": 162,
+      "crap": 1.008
     },
     {
       "path": ".agents/scripts/lib/feedback-loop/retro-proposals-graduator.js",
       "method": "<anon method-4>",
-      "startLine": 122,
+      "startLine": 167,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/feedback-loop/retro-proposals-graduator.js",
       "method": "toFinding",
-      "startLine": 143,
+      "startLine": 188,
       "crap": 6
     },
     {
       "path": ".agents/scripts/lib/feedback-loop/retro-proposals-graduator.js",
       "method": "graduateRetroProposals",
-      "startLine": 189,
+      "startLine": 234,
       "crap": 7
     },
     {
       "path": ".agents/scripts/lib/feedback-loop/retro-proposals-graduator.js",
       "method": "<anon method-5>",
-      "startLine": 238,
+      "startLine": 288,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/feedback-loop/retro-proposals-graduator.js",
       "method": "<anon method-6>",
-      "startLine": 247,
+      "startLine": 297,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/feedback-loop/retro-proposals-graduator.js",
       "method": "issueNumberFromUrl",
-      "startLine": 275,
+      "startLine": 326,
       "crap": 3
     },
     {
       "path": ".agents/scripts/lib/feedback-loop/retro-proposals-graduator.js",
       "method": "enrichRoutedProposalsWithFilings",
-      "startLine": 292,
+      "startLine": 343,
       "crap": 8.010107989655104
     },
     {
       "path": ".agents/scripts/lib/feedback-loop/retro-proposals-graduator.js",
       "method": "<anon method-7>",
-      "startLine": 317,
+      "startLine": 368,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/feedback-loop/retro-proposals-graduator.js",
       "method": "<anon method-8>",
-      "startLine": 318,
+      "startLine": 369,
       "crap": 2
     },
     {
       "path": ".agents/scripts/lib/feedback-loop/retro-proposals-graduator.js",
       "method": "parseRepoSlug",
-      "startLine": 337,
+      "startLine": 388,
       "crap": 5
     },
     {
       "path": ".agents/scripts/lib/feedback-loop/retro-proposals-graduator.js",
       "method": "fileRetroProposals",
-      "startLine": 370,
+      "startLine": 421,
       "crap": 3.1352169503628433
     },
     {
       "path": ".agents/scripts/lib/feedback-loop/retro-proposals-graduator.js",
       "method": "<anon method-9>",
-      "startLine": 384,
+      "startLine": 435,
       "crap": 2
     },
     {
@@ -10749,25 +11223,25 @@
     {
       "path": ".agents/scripts/lib/observability/runtime-friction.js",
       "method": "normalizeGatheredSignal",
-      "startLine": 355,
-      "crap": 9
+      "startLine": 362,
+      "crap": 12
     },
     {
       "path": ".agents/scripts/lib/observability/runtime-friction.js",
       "method": "isRecoveredSignal",
-      "startLine": 387,
+      "startLine": 399,
       "crap": 7
     },
     {
       "path": ".agents/scripts/lib/observability/runtime-friction.js",
       "method": "frictionForTerminal",
-      "startLine": 439,
+      "startLine": 451,
       "crap": 9
     },
     {
       "path": ".agents/scripts/lib/observability/runtime-friction.js",
       "method": "emitTerminalFriction",
-      "startLine": 494,
+      "startLine": 506,
       "crap": 2
     },
     {
@@ -10801,70 +11275,40 @@
       "crap": 5.048828125
     },
     {
-      "path": ".agents/scripts/lib/observability/signals-writer.js",
-      "method": "tracesFile",
-      "startLine": 51,
-      "crap": 1
-    },
-    {
-      "path": ".agents/scripts/lib/observability/signals-writer.js",
-      "method": "tagSignalSource",
-      "startLine": 80,
-      "crap": 9
-    },
-    {
-      "path": ".agents/scripts/lib/observability/signals-writer.js",
-      "method": "validateOrDrop",
-      "startLine": 118,
-      "crap": 2
-    },
-    {
-      "path": ".agents/scripts/lib/observability/signals-writer.js",
-      "method": "appendOne",
-      "startLine": 137,
-      "crap": 3.1756372325898954
-    },
-    {
-      "path": ".agents/scripts/lib/observability/signals-writer.js",
-      "method": "appendSignal",
-      "startLine": 174,
-      "crap": 4
-    },
-    {
-      "path": ".agents/scripts/lib/observability/signals-writer.js",
-      "method": "appendTrace",
-      "startLine": 204,
-      "crap": 4
-    },
-    {
-      "path": ".agents/scripts/lib/observability/signals-writer.js",
-      "method": "forEachLineIn",
-      "startLine": 242,
-      "crap": 5.045899242662496
-    },
-    {
-      "path": ".agents/scripts/lib/observability/signals-writer.js",
-      "method": "forEachLine",
-      "startLine": 304,
-      "crap": 3
-    },
-    {
       "path": ".agents/scripts/lib/observability/source-classifier.js",
       "method": "toScanString",
-      "startLine": 52,
+      "startLine": 58,
       "crap": 2
     },
     {
       "path": ".agents/scripts/lib/observability/source-classifier.js",
       "method": "containsFrameworkPrefix",
-      "startLine": 67,
+      "startLine": 73,
       "crap": 3
     },
     {
       "path": ".agents/scripts/lib/observability/source-classifier.js",
       "method": "classifyPathSource",
-      "startLine": 95,
+      "startLine": 101,
       "crap": 3
+    },
+    {
+      "path": ".agents/scripts/lib/observability/source-classifier.js",
+      "method": "isSupplied",
+      "startLine": 140,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/observability/source-classifier.js",
+      "method": "detailsScanText",
+      "startLine": 150,
+      "crap": 4
+    },
+    {
+      "path": ".agents/scripts/lib/observability/source-classifier.js",
+      "method": "classifySignalSource",
+      "startLine": 203,
+      "crap": 11
     },
     {
       "path": ".agents/scripts/lib/observability/terse-result.js",
@@ -11145,128 +11589,128 @@
     {
       "path": ".agents/scripts/lib/orchestration/check-baselines/phases/compare.js",
       "method": "baselineRelativePath",
-      "startLine": 17,
+      "startLine": 18,
       "crap": 3
     },
     {
       "path": ".agents/scripts/lib/orchestration/check-baselines/phases/compare.js",
       "method": "resolveDispatchScope",
-      "startLine": 26,
+      "startLine": 27,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/orchestration/check-baselines/phases/compare.js",
       "method": "emptyCompareResult",
-      "startLine": 39,
+      "startLine": 40,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/orchestration/check-baselines/phases/compare.js",
       "method": "readBaseBaselinePayload",
-      "startLine": 43,
+      "startLine": 44,
       "crap": 2.075851851851852
     },
     {
       "path": ".agents/scripts/lib/orchestration/check-baselines/phases/compare.js",
       "method": "evaluateCompare",
-      "startLine": 59,
+      "startLine": 60,
       "crap": 5.2
     },
     {
       "path": ".agents/scripts/lib/orchestration/check-baselines/phases/compare.js",
+      "method": "baseIsComparable",
+      "startLine": 88,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/check-baselines/phases/compare.js",
       "method": "runCompareStage",
-      "startLine": 70,
-      "crap": 5.011379153390988
+      "startLine": 94,
+      "crap": 7.228120743095177
     },
     {
       "path": ".agents/scripts/lib/orchestration/check-baselines/phases/compare.js",
       "method": "tolerantNumericFields",
-      "startLine": 97,
+      "startLine": 132,
       "crap": 3
     },
     {
       "path": ".agents/scripts/lib/orchestration/check-baselines/phases/compare.js",
       "method": "<anon method-1>",
-      "startLine": 101,
+      "startLine": 136,
       "crap": 2
     },
     {
       "path": ".agents/scripts/lib/orchestration/check-baselines/phases/compare.js",
       "method": "<anon method-2>",
-      "startLine": 103,
+      "startLine": 138,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/orchestration/check-baselines/phases/compare.js",
       "method": "regressionExceedsTolerance",
-      "startLine": 106,
+      "startLine": 141,
       "crap": 2
     },
     {
       "path": ".agents/scripts/lib/orchestration/check-baselines/phases/compare.js",
       "method": "<anon method-3>",
-      "startLine": 109,
+      "startLine": 144,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/orchestration/check-baselines/phases/compare.js",
       "method": "applyTolerance",
-      "startLine": 116,
-      "crap": 6.2373046875
+      "startLine": 151,
+      "crap": 6.0087890625
     },
     {
       "path": ".agents/scripts/lib/orchestration/check-baselines/phases/evaluate.js",
       "method": "rollupExcludingIgnored",
-      "startLine": 59,
+      "startLine": 56,
       "crap": 8.042081038875647
     },
     {
       "path": ".agents/scripts/lib/orchestration/check-baselines/phases/evaluate.js",
       "method": "<anon method-1>",
-      "startLine": 72,
+      "startLine": 69,
       "crap": 2.002630064929728
     },
     {
       "path": ".agents/scripts/lib/orchestration/check-baselines/phases/evaluate.js",
       "method": "loadHeadBaseline",
-      "startLine": 83,
+      "startLine": 80,
       "crap": 2
     },
     {
       "path": ".agents/scripts/lib/orchestration/check-baselines/phases/evaluate.js",
-      "method": "applyBundleSizeAcknowledgment",
-      "startLine": 103,
-      "crap": 4
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/check-baselines/phases/evaluate.js",
-      "method": "resolveMaintainabilityRefreshTrigger",
-      "startLine": 141,
-      "crap": 8
+      "method": "resolveRefreshTrigger",
+      "startLine": 113,
+      "crap": 10
     },
     {
       "path": ".agents/scripts/lib/orchestration/check-baselines/phases/evaluate.js",
       "method": "<anon method-2>",
-      "startLine": 161,
+      "startLine": 136,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/orchestration/check-baselines/phases/evaluate.js",
-      "method": "applyMaintainabilityAcknowledgment",
-      "startLine": 183,
-      "crap": 4
+      "method": "applyRefreshAcknowledgment",
+      "startLine": 160,
+      "crap": 3
     },
     {
       "path": ".agents/scripts/lib/orchestration/check-baselines/phases/evaluate.js",
       "method": "buildGateReport",
-      "startLine": 207,
+      "startLine": 181,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/orchestration/check-baselines/phases/evaluate.js",
       "method": "evaluateKind",
-      "startLine": 240,
-      "crap": 4.011388483965015
+      "startLine": 214,
+      "crap": 3.006406022230321
     },
     {
       "path": ".agents/scripts/lib/orchestration/check-baselines/phases/floors.js",
@@ -11409,31 +11853,31 @@
     {
       "path": ".agents/scripts/lib/orchestration/check-baselines/phases/parse-args.js",
       "method": "helpReport",
-      "startLine": 68,
+      "startLine": 76,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/orchestration/check-baselines/phases/parse-args.js",
       "method": "flattenGateTokens",
-      "startLine": 83,
+      "startLine": 91,
       "crap": 6
     },
     {
       "path": ".agents/scripts/lib/orchestration/check-baselines/phases/parse-args.js",
       "method": "parseArgs",
-      "startLine": 117,
+      "startLine": 125,
       "crap": 10.007705421727364
     },
     {
       "path": ".agents/scripts/lib/orchestration/check-baselines/phases/parse-args.js",
       "method": "<anon method-1>",
-      "startLine": 120,
+      "startLine": 128,
       "crap": 2.0003082168690947
     },
     {
       "path": ".agents/scripts/lib/orchestration/check-baselines/phases/parse-args.js",
       "method": "<anon method-2>",
-      "startLine": 136,
+      "startLine": 144,
       "crap": 2.0003082168690947
     },
     {
@@ -11541,73 +11985,73 @@
     {
       "path": ".agents/scripts/lib/orchestration/code-review.js",
       "method": "resolveConfigBase",
-      "startLine": 72,
+      "startLine": 76,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/orchestration/code-review.js",
       "method": "resolveCommentTargetId",
-      "startLine": 77,
+      "startLine": 81,
       "crap": 3
     },
     {
       "path": ".agents/scripts/lib/orchestration/code-review.js",
       "method": "resolveStoryScope",
-      "startLine": 95,
+      "startLine": 99,
       "crap": 5.150262960180315
     },
     {
       "path": ".agents/scripts/lib/orchestration/code-review.js",
       "method": "resolveScopeEnvelope",
-      "startLine": 123,
+      "startLine": 127,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/orchestration/code-review.js",
       "method": "resolveProviderName",
-      "startLine": 188,
+      "startLine": 193,
       "crap": 5
     },
     {
       "path": ".agents/scripts/lib/orchestration/code-review.js",
       "method": "<anon method-1>",
-      "startLine": 197,
+      "startLine": 202,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/orchestration/code-review.js",
       "method": "resolveInjectedChangedFiles",
-      "startLine": 215,
+      "startLine": 220,
       "crap": 3
     },
     {
       "path": ".agents/scripts/lib/orchestration/code-review.js",
       "method": "buildReviewInput",
-      "startLine": 231,
+      "startLine": 236,
       "crap": 3
     },
     {
       "path": ".agents/scripts/lib/orchestration/code-review.js",
       "method": "resolvePromptMessages",
-      "startLine": 261,
+      "startLine": 266,
       "crap": 3.0885568513119535
     },
     {
       "path": ".agents/scripts/lib/orchestration/code-review.js",
       "method": "postReviewComment",
-      "startLine": 281,
+      "startLine": 286,
       "crap": 3.002416837299856
     },
     {
       "path": ".agents/scripts/lib/orchestration/code-review.js",
       "method": "executeReviewPipeline",
-      "startLine": 319,
-      "crap": 3.002776242275877
+      "startLine": 324,
+      "crap": 3.002116885976054
     },
     {
       "path": ".agents/scripts/lib/orchestration/code-review.js",
       "method": "runCodeReview",
-      "startLine": 394,
+      "startLine": 406,
       "crap": 1
     },
     {
@@ -11619,241 +12063,241 @@
     {
       "path": ".agents/scripts/lib/orchestration/complexity-gate.js",
       "method": "normalizeBucket",
-      "startLine": 198,
+      "startLine": 199,
       "crap": 6
     },
     {
       "path": ".agents/scripts/lib/orchestration/complexity-gate.js",
       "method": "resolveChangeKinds",
-      "startLine": 213,
+      "startLine": 214,
       "crap": 4
     },
     {
       "path": ".agents/scripts/lib/orchestration/complexity-gate.js",
       "method": "<anon method-1>",
-      "startLine": 214,
+      "startLine": 215,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/orchestration/complexity-gate.js",
       "method": "<anon method-2>",
-      "startLine": 216,
+      "startLine": 217,
       "crap": 2
     },
     {
       "path": ".agents/scripts/lib/orchestration/complexity-gate.js",
       "method": "<anon method-3>",
-      "startLine": 217,
+      "startLine": 218,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/orchestration/complexity-gate.js",
       "method": "<anon method-4>",
-      "startLine": 220,
+      "startLine": 221,
       "crap": 5
     },
     {
       "path": ".agents/scripts/lib/orchestration/complexity-gate.js",
       "method": "resolveDeployables",
-      "startLine": 236,
+      "startLine": 237,
       "crap": 3
     },
     {
       "path": ".agents/scripts/lib/orchestration/complexity-gate.js",
       "method": "<anon method-5>",
-      "startLine": 241,
+      "startLine": 242,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/orchestration/complexity-gate.js",
       "method": "spansMigrationAndConsumers",
-      "startLine": 257,
+      "startLine": 258,
       "crap": 2
     },
     {
       "path": ".agents/scripts/lib/orchestration/complexity-gate.js",
       "method": "<anon method-6>",
-      "startLine": 258,
+      "startLine": 259,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/orchestration/complexity-gate.js",
       "method": "<anon method-7>",
-      "startLine": 274,
+      "startLine": 316,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/orchestration/complexity-gate.js",
       "method": "<anon method-8>",
-      "startLine": 275,
+      "startLine": 317,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/orchestration/complexity-gate.js",
       "method": "<anon method-9>",
-      "startLine": 279,
+      "startLine": 322,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/orchestration/complexity-gate.js",
       "method": "<anon method-10>",
-      "startLine": 282,
+      "startLine": 325,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/orchestration/complexity-gate.js",
       "method": "<anon method-11>",
-      "startLine": 286,
+      "startLine": 330,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/orchestration/complexity-gate.js",
       "method": "<anon method-12>",
-      "startLine": 289,
+      "startLine": 333,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/orchestration/complexity-gate.js",
       "method": "<anon method-13>",
-      "startLine": 293,
+      "startLine": 338,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/orchestration/complexity-gate.js",
       "method": "<anon method-14>",
-      "startLine": 294,
+      "startLine": 339,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/orchestration/complexity-gate.js",
       "method": "<anon method-15>",
-      "startLine": 298,
+      "startLine": 344,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/orchestration/complexity-gate.js",
       "method": "<anon method-16>",
-      "startLine": 299,
+      "startLine": 345,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/orchestration/complexity-gate.js",
       "method": "<anon method-17>",
-      "startLine": 303,
+      "startLine": 350,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/orchestration/complexity-gate.js",
       "method": "<anon method-18>",
-      "startLine": 304,
+      "startLine": 351,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/orchestration/complexity-gate.js",
       "method": "firstEffortViolation",
-      "startLine": 316,
+      "startLine": 364,
       "crap": 2
     },
     {
       "path": ".agents/scripts/lib/orchestration/complexity-gate.js",
       "method": "normalizeCeiling",
-      "startLine": 346,
+      "startLine": 396,
       "crap": 4
     },
     {
       "path": ".agents/scripts/lib/orchestration/complexity-gate.js",
       "method": "resolveComplexityGate",
-      "startLine": 369,
+      "startLine": 419,
       "crap": 4
     },
     {
       "path": ".agents/scripts/lib/orchestration/complexity-gate.js",
       "method": "countSeedArtifacts",
-      "startLine": 392,
+      "startLine": 442,
       "crap": 3
     },
     {
       "path": ".agents/scripts/lib/orchestration/complexity-gate.js",
       "method": "<anon method-19>",
-      "startLine": 396,
+      "startLine": 446,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/orchestration/complexity-gate.js",
       "method": "extractPredictedPaths",
-      "startLine": 410,
+      "startLine": 460,
       "crap": 5
     },
     {
       "path": ".agents/scripts/lib/orchestration/complexity-gate.js",
       "method": "buildComplexitySignals",
-      "startLine": 467,
+      "startLine": 517,
       "crap": 6.00182898948331
     },
     {
       "path": ".agents/scripts/lib/orchestration/complexity-gate.js",
       "method": "<anon method-20>",
-      "startLine": 483,
+      "startLine": 533,
       "crap": 3.0004572473708278
     },
     {
       "path": ".agents/scripts/lib/orchestration/complexity-gate.js",
       "method": "resolvePlannerRouteVerdict",
-      "startLine": 545,
+      "startLine": 595,
       "crap": 3
     },
     {
       "path": ".agents/scripts/lib/orchestration/complexity-gate.js",
       "method": "buildEffortShape",
-      "startLine": 590,
+      "startLine": 640,
       "crap": 2
     },
     {
       "path": ".agents/scripts/lib/orchestration/complexity-gate.js",
       "method": "deriveStoryShape",
-      "startLine": 662,
+      "startLine": 715,
       "crap": 7
     },
     {
       "path": ".agents/scripts/lib/orchestration/complexity-gate.js",
       "method": "<anon method-21>",
-      "startLine": 673,
+      "startLine": 726,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/orchestration/complexity-gate.js",
       "method": "<anon method-22>",
-      "startLine": 698,
+      "startLine": 754,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/orchestration/complexity-gate.js",
       "method": "<anon method-23>",
-      "startLine": 714,
+      "startLine": 770,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/orchestration/complexity-gate.js",
       "method": "deriveStoryRouteFromBody",
-      "startLine": 764,
-      "crap": 1.0939143501126973
+      "startLine": 826,
+      "crap": 1.109394263170872
     },
     {
       "path": ".agents/scripts/lib/orchestration/complexity-gate.js",
       "method": "routeForReporting",
-      "startLine": 797,
+      "startLine": 860,
       "crap": 3
     },
     {
       "path": ".agents/scripts/lib/orchestration/complexity-gate.js",
       "method": "resolveStoryDispatchMode",
-      "startLine": 845,
+      "startLine": 916,
       "crap": 8
     },
     {
       "path": ".agents/scripts/lib/orchestration/complexity-gate.js",
       "method": "<anon method-24>",
-      "startLine": 854,
+      "startLine": 925,
       "crap": 1
     },
     {
@@ -11991,61 +12435,85 @@
     {
       "path": ".agents/scripts/lib/orchestration/deliver-recover.js",
       "method": "probeTicket",
-      "startLine": 49,
+      "startLine": 68,
       "crap": 2
     },
     {
       "path": ".agents/scripts/lib/orchestration/deliver-recover.js",
       "method": "<anon method-1>",
-      "startLine": 54,
+      "startLine": 73,
       "crap": 2
     },
     {
       "path": ".agents/scripts/lib/orchestration/deliver-recover.js",
       "method": "probeBranch",
-      "startLine": 75,
+      "startLine": 94,
       "crap": 4
     },
     {
       "path": ".agents/scripts/lib/orchestration/deliver-recover.js",
       "method": "probePr",
-      "startLine": 114,
+      "startLine": 133,
       "crap": 4
     },
     {
       "path": ".agents/scripts/lib/orchestration/deliver-recover.js",
+      "method": "probeCloseArtifacts",
+      "startLine": 186,
+      "crap": 6.001333333333333
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/deliver-recover.js",
+      "method": "closeLooksLive",
+      "startLine": 260,
+      "crap": 3
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/deliver-recover.js",
+      "method": "envelopeOnDiskVerdict",
+      "startLine": 276,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/deliver-recover.js",
+      "method": "closeInFlightVerdict",
+      "startLine": 301,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/deliver-recover.js",
       "method": "decideRecovery",
-      "startLine": 144,
-      "crap": 12
+      "startLine": 334,
+      "crap": 17
     },
     {
       "path": ".agents/scripts/lib/orchestration/deliver-recover.js",
       "method": "buildInTransitionVerdict",
-      "startLine": 303,
+      "startLine": 532,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/orchestration/deliver-recover.js",
       "method": "probeAndDecide",
-      "startLine": 325,
-      "crap": 2
+      "startLine": 554,
+      "crap": 3
     },
     {
       "path": ".agents/scripts/lib/orchestration/deliver-recover.js",
       "method": "recoverStory",
-      "startLine": 370,
+      "startLine": 615,
       "crap": 4
     },
     {
       "path": ".agents/scripts/lib/orchestration/deliver-recover.js",
       "method": "renderRecovery",
-      "startLine": 439,
+      "startLine": 686,
       "crap": 2.006513331976389
     },
     {
       "path": ".agents/scripts/lib/orchestration/deliver-recover.js",
       "method": "<anon method-2>",
-      "startLine": 446,
+      "startLine": 693,
       "crap": 1.0016283329940974
     },
     {
@@ -12147,73 +12615,73 @@
     {
       "path": ".agents/scripts/lib/orchestration/file-assumptions.js",
       "method": "defaultGitRunner",
-      "startLine": 69,
+      "startLine": 71,
       "crap": 2
     },
     {
       "path": ".agents/scripts/lib/orchestration/file-assumptions.js",
       "method": "collectStoryAssumptionEntries",
-      "startLine": 92,
+      "startLine": 94,
       "crap": 9.021064696647178
     },
     {
       "path": ".agents/scripts/lib/orchestration/file-assumptions.js",
       "method": "hasLegacyChangeBullets",
-      "startLine": 149,
+      "startLine": 151,
       "crap": 4
     },
     {
       "path": ".agents/scripts/lib/orchestration/file-assumptions.js",
       "method": "<anon method-1>",
-      "startLine": 153,
+      "startLine": 155,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/orchestration/file-assumptions.js",
       "method": "renderMismatch",
-      "startLine": 173,
+      "startLine": 175,
       "crap": 4
     },
     {
       "path": ".agents/scripts/lib/orchestration/file-assumptions.js",
       "method": "renderNormalization",
-      "startLine": 201,
+      "startLine": 203,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/orchestration/file-assumptions.js",
       "method": "indexPathMutations",
-      "startLine": 217,
+      "startLine": 219,
       "crap": 7
     },
     {
       "path": ".agents/scripts/lib/orchestration/file-assumptions.js",
       "method": "predecessorMutator",
-      "startLine": 254,
+      "startLine": 256,
       "crap": 3
     },
     {
       "path": ".agents/scripts/lib/orchestration/file-assumptions.js",
       "method": "validateStoryFileAssumptions",
-      "startLine": 295,
+      "startLine": 297,
       "crap": 13
     },
     {
       "path": ".agents/scripts/lib/orchestration/file-assumptions.js",
       "method": "<anon method-2>",
-      "startLine": 302,
+      "startLine": 304,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/orchestration/file-assumptions.js",
       "method": "concurrentCoCreator",
-      "startLine": 425,
+      "startLine": 427,
       "crap": 6
     },
     {
       "path": ".agents/scripts/lib/orchestration/file-assumptions.js",
       "method": "checkAssumption",
-      "startLine": 456,
+      "startLine": 458,
       "crap": 12.186027190112403
     },
     {
@@ -12484,13 +12952,13 @@
       "path": ".agents/scripts/lib/orchestration/git-cleanup/phases/git-probes-ff.js",
       "method": "<anon method-3>",
       "startLine": 91,
-      "crap": 3.1851851851851856
+      "crap": 2
     },
     {
       "path": ".agents/scripts/lib/orchestration/git-cleanup/phases/git-probes-ff.js",
       "method": "<anon method-4>",
       "startLine": 97,
-      "crap": 23.78287002253944
+      "crap": 5.150262960180315
     },
     {
       "path": ".agents/scripts/lib/orchestration/git-cleanup/phases/git-probes-ff.js",
@@ -13287,67 +13755,85 @@
     {
       "path": ".agents/scripts/lib/orchestration/light-suitability.js",
       "method": "normalizeMaxFiles",
-      "startLine": 77,
+      "startLine": 104,
       "crap": 4
     },
     {
       "path": ".agents/scripts/lib/orchestration/light-suitability.js",
       "method": "resolveLedgeredVerdict",
-      "startLine": 102,
+      "startLine": 129,
       "crap": 5
     },
     {
       "path": ".agents/scripts/lib/orchestration/light-suitability.js",
       "method": "deriveLightSuitability",
-      "startLine": 164,
+      "startLine": 191,
       "crap": 3
     },
     {
       "path": ".agents/scripts/lib/orchestration/light-suitability.js",
-      "method": "resolveLightGateOutcome",
-      "startLine": 210,
-      "crap": 4
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/light-suitability.js",
-      "method": "checkLightDiffBackstop",
-      "startLine": 273,
-      "crap": 10.0244140625
+      "method": "resolveOperatorOverride",
+      "startLine": 260,
+      "crap": 7
     },
     {
       "path": ".agents/scripts/lib/orchestration/light-suitability.js",
       "method": "<anon method-1>",
-      "startLine": 284,
+      "startLine": 267,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/light-suitability.js",
+      "method": "resolveLightGateOutcome",
+      "startLine": 335,
+      "crap": 6
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/light-suitability.js",
+      "method": "checkLightDiffBackstop",
+      "startLine": 419,
+      "crap": 10.0244140625
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/light-suitability.js",
+      "method": "<anon method-2>",
+      "startLine": 430,
       "crap": 2.0009765625
     },
     {
       "path": ".agents/scripts/lib/orchestration/light-suitability.js",
       "method": "slugifyPrompt",
-      "startLine": 347,
+      "startLine": 493,
       "crap": 2
     },
     {
       "path": ".agents/scripts/lib/orchestration/light-suitability.js",
       "method": "normalizeAmends",
-      "startLine": 367,
+      "startLine": 513,
       "crap": 8.233045061447429
     },
     {
       "path": ".agents/scripts/lib/orchestration/light-suitability.js",
       "method": "deriveReceiptTitle",
-      "startLine": 388,
+      "startLine": 534,
       "crap": 3
     },
     {
       "path": ".agents/scripts/lib/orchestration/light-suitability.js",
       "method": "toReceiptChanges",
-      "startLine": 407,
+      "startLine": 553,
+      "crap": 5
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/light-suitability.js",
+      "method": "renderOverrideNote",
+      "startLine": 576,
       "crap": 5
     },
     {
       "path": ".agents/scripts/lib/orchestration/light-suitability.js",
       "method": "buildReceiptStoryTicket",
-      "startLine": 431,
+      "startLine": 607,
       "crap": 4
     },
     {
@@ -14553,50 +15039,26 @@
     {
       "path": ".agents/scripts/lib/orchestration/planning/authoring-context.js",
       "method": "resolveMemoryDir",
-      "startLine": 43,
+      "startLine": 40,
       "crap": 5
     },
     {
       "path": ".agents/scripts/lib/orchestration/planning/authoring-context.js",
       "method": "buildPlanningDocsContext",
-      "startLine": 77,
+      "startLine": 74,
       "crap": 4
     },
     {
       "path": ".agents/scripts/lib/orchestration/planning/authoring-context.js",
       "method": "buildAuthoringContext",
-      "startLine": 118,
-      "crap": 5.001478534958043
+      "startLine": 115,
+      "crap": 2.0002342762647944
     },
     {
       "path": ".agents/scripts/lib/orchestration/planning/decomposer-context.js",
       "method": "buildDecomposerSystemPrompt",
       "startLine": 14,
       "crap": 3
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/planning/spec-authoring-grounding.js",
-      "method": "buildTruncationSignal",
-      "startLine": 56,
-      "crap": 6
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/planning/spec-authoring-grounding.js",
-      "method": "findCitedButAbsent",
-      "startLine": 93,
-      "crap": 6
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/planning/spec-authoring-grounding.js",
-      "method": "<anon method-1>",
-      "startLine": 99,
-      "crap": 1
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/planning/spec-authoring-grounding.js",
-      "method": "buildAuthoringGrounding",
-      "startLine": 130,
-      "crap": 1
     },
     {
       "path": ".agents/scripts/lib/orchestration/pr-base-guard.js",
@@ -14817,31 +15279,31 @@
     {
       "path": ".agents/scripts/lib/orchestration/resolve-stories.js",
       "method": "<anon method-11>",
-      "startLine": 335,
+      "startLine": 338,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/orchestration/resolve-stories.js",
       "method": "<anon method-12>",
-      "startLine": 350,
+      "startLine": 353,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/orchestration/resolve-stories.js",
       "method": "parseIds",
-      "startLine": 360,
+      "startLine": 363,
       "crap": 2
     },
     {
       "path": ".agents/scripts/lib/orchestration/resolve-stories.js",
       "method": "<anon method-13>",
-      "startLine": 363,
+      "startLine": 366,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/orchestration/resolve-stories.js",
       "method": "<anon method-14>",
-      "startLine": 365,
+      "startLine": 368,
       "crap": 4
     },
     {
@@ -14871,139 +15333,205 @@
     {
       "path": ".agents/scripts/lib/orchestration/retro-proposals.js",
       "method": "emptyResult",
-      "startLine": 100,
+      "startLine": 108,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/orchestration/retro-proposals.js",
       "method": "asString",
-      "startLine": 110,
+      "startLine": 118,
       "crap": 2
     },
     {
       "path": ".agents/scripts/lib/orchestration/retro-proposals.js",
       "method": "incidentKey",
-      "startLine": 122,
+      "startLine": 130,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/orchestration/retro-proposals.js",
       "method": "netOutRecoveredIncidents",
-      "startLine": 152,
-      "crap": 4
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/retro-proposals.js",
-      "method": "<anon method-1>",
       "startLine": 160,
       "crap": 4
     },
     {
       "path": ".agents/scripts/lib/orchestration/retro-proposals.js",
+      "method": "<anon method-1>",
+      "startLine": 168,
+      "crap": 4
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/retro-proposals.js",
       "method": "deriveUnresolvedBlockedEvents",
-      "startLine": 186,
+      "startLine": 194,
       "crap": 11
     },
     {
       "path": ".agents/scripts/lib/orchestration/retro-proposals.js",
       "method": "<anon method-2>",
-      "startLine": 216,
+      "startLine": 224,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/retro-proposals.js",
+      "method": "fingerprintBucket",
+      "startLine": 245,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/orchestration/retro-proposals.js",
       "method": "aggregateByCategory",
-      "startLine": 235,
-      "crap": 6
+      "startLine": 281,
+      "crap": 13
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/retro-proposals.js",
+      "method": "describeBucket",
+      "startLine": 341,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/retro-proposals.js",
+      "method": "describeEvidence",
+      "startLine": 380,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/retro-proposals.js",
+      "method": "<anon method-3>",
+      "startLine": 385,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/retro-proposals.js",
+      "method": "emptyEvidence",
+      "startLine": 390,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/retro-proposals.js",
+      "method": "evidenceLine",
+      "startLine": 416,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/retro-proposals.js",
+      "method": "storiesLine",
+      "startLine": 430,
+      "crap": 3
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/retro-proposals.js",
+      "method": "<anon method-4>",
+      "startLine": 432,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/retro-proposals.js",
+      "method": "reasonsLine",
+      "startLine": 446,
+      "crap": 3
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/retro-proposals.js",
+      "method": "<anon method-5>",
+      "startLine": 450,
+      "crap": 1
     },
     {
       "path": ".agents/scripts/lib/orchestration/retro-proposals.js",
       "method": "dominantSource",
-      "startLine": 266,
+      "startLine": 462,
       "crap": 3
     },
     {
       "path": ".agents/scripts/lib/orchestration/retro-proposals.js",
       "method": "formatAnchor",
-      "startLine": 278,
+      "startLine": 474,
       "crap": 3.072
     },
     {
       "path": ".agents/scripts/lib/orchestration/retro-proposals.js",
       "method": "isActionableFriction",
-      "startLine": 292,
+      "startLine": 488,
       "crap": 2
     },
     {
       "path": ".agents/scripts/lib/orchestration/retro-proposals.js",
       "method": "renderIssueBody",
-      "startLine": 310,
+      "startLine": 517,
+      "crap": 3
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/retro-proposals.js",
+      "method": "<anon method-6>",
+      "startLine": 532,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/orchestration/retro-proposals.js",
       "method": "renderIssueCommand",
-      "startLine": 345,
+      "startLine": 561,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/orchestration/retro-proposals.js",
       "method": "buildRoutedItem",
-      "startLine": 370,
+      "startLine": 587,
       "crap": 3
     },
     {
       "path": ".agents/scripts/lib/orchestration/retro-proposals.js",
       "method": "normalizeAnchorKind",
-      "startLine": 415,
+      "startLine": 634,
       "crap": 3
     },
     {
       "path": ".agents/scripts/lib/orchestration/retro-proposals.js",
       "method": "normaliseInput",
-      "startLine": 419,
+      "startLine": 638,
       "crap": 9
     },
     {
       "path": ".agents/scripts/lib/orchestration/retro-proposals.js",
       "method": "blockedForceMap",
-      "startLine": 439,
+      "startLine": 658,
       "crap": 6
     },
     {
       "path": ".agents/scripts/lib/orchestration/retro-proposals.js",
       "method": "pushRouted",
-      "startLine": 454,
+      "startLine": 673,
       "crap": 2
     },
     {
       "path": ".agents/scripts/lib/orchestration/retro-proposals.js",
       "method": "routeCategoryBuckets",
-      "startLine": 459,
+      "startLine": 678,
       "crap": 4
     },
     {
       "path": ".agents/scripts/lib/orchestration/retro-proposals.js",
-      "method": "<anon method-3>",
-      "startLine": 507,
+      "method": "<anon method-7>",
+      "startLine": 735,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/orchestration/retro-proposals.js",
-      "method": "<anon method-4>",
-      "startLine": 508,
+      "method": "<anon method-8>",
+      "startLine": 736,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/orchestration/retro-proposals.js",
-      "method": "<anon method-5>",
-      "startLine": 509,
+      "method": "<anon method-9>",
+      "startLine": 737,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/orchestration/retro-proposals.js",
       "method": "composeRoutedProposals",
-      "startLine": 526,
+      "startLine": 754,
       "crap": 2
     },
     {
@@ -15073,183 +15601,231 @@
       "crap": 1.2962962962962963
     },
     {
+      "path": ".agents/scripts/lib/orchestration/review-providers/degraded-gates.js",
+      "method": "normalizeDegradations",
+      "startLine": 56,
+      "crap": 10
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/review-providers/degraded-gates.js",
+      "method": "collectProviderDegradations",
+      "startLine": 87,
+      "crap": 2.6244879380974053
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/review-providers/degraded-gates.js",
+      "method": "summarizeDegradations",
+      "startLine": 109,
+      "crap": 2.032
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/review-providers/degraded-gates.js",
+      "method": "<anon method-1>",
+      "startLine": 112,
+      "crap": 1.008
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/review-providers/degraded-gates.js",
+      "method": "degradationEnvelope",
+      "startLine": 123,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/review-providers/degraded-gates.js",
+      "method": "mergeChainDegradations",
+      "startLine": 138,
+      "crap": 2.912894375857339
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/review-providers/degraded-gates.js",
+      "method": "renderDegradedHeaderLines",
+      "startLine": 164,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/review-providers/degraded-gates.js",
+      "method": "renderNoFindingsBlock",
+      "startLine": 177,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/review-providers/degraded-gates.js",
+      "method": "renderDegradedGatesSection",
+      "startLine": 201,
+      "crap": 2
+    },
+    {
       "path": ".agents/scripts/lib/orchestration/review-providers/findings-renderer.js",
       "method": "countBySeverity",
-      "startLine": 54,
+      "startLine": 61,
       "crap": 3
     },
     {
       "path": ".agents/scripts/lib/orchestration/review-providers/findings-renderer.js",
       "method": "renderFinding",
-      "startLine": 77,
+      "startLine": 84,
       "crap": 3
     },
     {
       "path": ".agents/scripts/lib/orchestration/review-providers/findings-renderer.js",
       "method": "renderManualPromptsSection",
-      "startLine": 98,
+      "startLine": 105,
       "crap": 3
     },
     {
       "path": ".agents/scripts/lib/orchestration/review-providers/findings-renderer.js",
       "method": "<anon method-1>",
-      "startLine": 100,
+      "startLine": 107,
       "crap": 2
     },
     {
       "path": ".agents/scripts/lib/orchestration/review-providers/findings-renderer.js",
       "method": "renderFindings",
-      "startLine": 128,
+      "startLine": 142,
       "crap": 5
     },
     {
       "path": ".agents/scripts/lib/orchestration/review-providers/findings-renderer.js",
       "method": "<anon method-2>",
-      "startLine": 148,
+      "startLine": 164,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/orchestration/review-providers/findings-renderer.js",
       "method": "<anon method-3>",
-      "startLine": 161,
+      "startLine": 176,
       "crap": 2
     },
     {
       "path": ".agents/scripts/lib/orchestration/review-providers/findings-renderer.js",
       "method": "buildAttribution",
-      "startLine": 189,
+      "startLine": 204,
       "crap": 4
     },
     {
       "path": ".agents/scripts/lib/orchestration/review-providers/native.js",
-      "method": "parseLintOutput",
-      "startLine": 95,
-      "crap": 3.011069606413994
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/review-providers/native.js",
-      "method": "partitionFilesForLint",
-      "startLine": 132,
-      "crap": 3
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/review-providers/native.js",
       "method": "readHeadSource",
-      "startLine": 167,
+      "startLine": 114,
       "crap": 2
     },
     {
       "path": ".agents/scripts/lib/orchestration/review-providers/native.js",
       "method": "scoreSourceReport",
-      "startLine": 186,
+      "startLine": 133,
       "crap": 2.9321802457897133
     },
     {
       "path": ".agents/scripts/lib/orchestration/review-providers/native.js",
-      "method": "spawnLintRunner",
-      "startLine": 200,
-      "crap": 2
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/review-providers/native.js",
-      "method": "runScopedLint",
-      "startLine": 223,
-      "crap": 14.28854351985499
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/review-providers/native.js",
       "method": "classifyChangedFile",
-      "startLine": 263,
+      "startLine": 155,
       "crap": 6
     },
     {
       "path": ".agents/scripts/lib/orchestration/review-providers/native.js",
       "method": "accumulateClassified",
-      "startLine": 323,
+      "startLine": 215,
       "crap": 4
     },
     {
       "path": ".agents/scripts/lib/orchestration/review-providers/native.js",
       "method": "isJsMaintainabilityFile",
-      "startLine": 331,
+      "startLine": 223,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/orchestration/review-providers/native.js",
       "method": "analyzeChangedFiles",
-      "startLine": 368,
+      "startLine": 260,
       "crap": 13
     },
     {
       "path": ".agents/scripts/lib/orchestration/review-providers/native.js",
       "method": "<anon method-1>",
-      "startLine": 393,
+      "startLine": 285,
       "crap": 2
     },
     {
       "path": ".agents/scripts/lib/orchestration/review-providers/native.js",
       "method": "<anon method-2>",
-      "startLine": 401,
+      "startLine": 293,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/orchestration/review-providers/native.js",
       "method": "<anon method-3>",
-      "startLine": 413,
+      "startLine": 305,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/orchestration/review-providers/native.js",
       "method": "<anon method-4>",
-      "startLine": 451,
+      "startLine": 343,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/orchestration/review-providers/native.js",
       "method": "buildLintFindings",
-      "startLine": 471,
+      "startLine": 363,
       "crap": 7
     },
     {
       "path": ".agents/scripts/lib/orchestration/review-providers/native.js",
       "method": "_emptyResults",
-      "startLine": 500,
+      "startLine": 392,
       "crap": 2
     },
     {
       "path": ".agents/scripts/lib/orchestration/review-providers/native.js",
       "method": "runLintPhase",
-      "startLine": 510,
-      "crap": 2.568094024821238
+      "startLine": 402,
+      "crap": 2.702464
     },
     {
       "path": ".agents/scripts/lib/orchestration/review-providers/native.js",
-      "method": "createNativeProvider",
-      "startLine": 552,
-      "crap": 8.00617746784049
+      "method": "buildLintDegradations",
+      "startLine": 440,
+      "crap": 4
     },
     {
       "path": ".agents/scripts/lib/orchestration/review-providers/native.js",
       "method": "<anon method-5>",
-      "startLine": 600,
-      "crap": 1.0001658768715886
+      "startLine": 449,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/review-providers/native.js",
+      "method": "createNativeProvider",
+      "startLine": 475,
+      "crap": 8.016294553673958
     },
     {
       "path": ".agents/scripts/lib/orchestration/review-providers/native.js",
       "method": "<anon method-6>",
-      "startLine": 654,
-      "crap": 1.0001658768715886
+      "startLine": 544,
+      "crap": 1.0006480783454712
     },
     {
       "path": ".agents/scripts/lib/orchestration/review-providers/native.js",
       "method": "<anon method-7>",
-      "startLine": 656,
-      "crap": 1.0001658768715886
+      "startLine": 579,
+      "crap": 1.0006480783454712
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/review-providers/native.js",
+      "method": "<anon method-8>",
+      "startLine": 610,
+      "crap": 1.0006480783454712
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/review-providers/native.js",
+      "method": "<anon method-9>",
+      "startLine": 612,
+      "crap": 1.0006480783454712
     },
     {
       "path": ".agents/scripts/lib/orchestration/review-providers/native.js",
       "method": "createNativeProviderForRegistry",
-      "startLine": 669,
+      "startLine": 625,
       "crap": 1
     },
     {
@@ -15297,85 +15873,85 @@
     {
       "path": ".agents/scripts/lib/orchestration/review-providers/review-provider-factory.js",
       "method": "buildGate",
-      "startLine": 81,
+      "startLine": 82,
       "crap": 8.074646449919813
     },
     {
       "path": ".agents/scripts/lib/orchestration/review-providers/review-provider-factory.js",
       "method": "<anon method-1>",
-      "startLine": 82,
+      "startLine": 83,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/orchestration/review-providers/review-provider-factory.js",
       "method": "<anon method-2>",
-      "startLine": 85,
+      "startLine": 86,
       "crap": 2.004665403119988
     },
     {
       "path": ".agents/scripts/lib/orchestration/review-providers/review-provider-factory.js",
       "method": "<anon method-3>",
-      "startLine": 88,
+      "startLine": 89,
       "crap": 1.001166350779997
     },
     {
       "path": ".agents/scripts/lib/orchestration/review-providers/review-provider-factory.js",
       "method": "<anon method-4>",
-      "startLine": 90,
+      "startLine": 91,
       "crap": 7.057151188219857
     },
     {
       "path": ".agents/scripts/lib/orchestration/review-providers/review-provider-factory.js",
       "method": "<anon method-5>",
-      "startLine": 94,
+      "startLine": 95,
       "crap": 1.001166350779997
     },
     {
       "path": ".agents/scripts/lib/orchestration/review-providers/review-provider-factory.js",
       "method": "isScopeApplicable",
-      "startLine": 111,
+      "startLine": 112,
       "crap": 3
     },
     {
       "path": ".agents/scripts/lib/orchestration/review-providers/review-provider-factory.js",
       "method": "createReviewProvider",
-      "startLine": 139,
+      "startLine": 140,
       "crap": 4
     },
     {
       "path": ".agents/scripts/lib/orchestration/review-providers/review-provider-factory.js",
       "method": "buildProviderChain",
-      "startLine": 174,
+      "startLine": 175,
       "crap": 12.157083248524323
     },
     {
       "path": ".agents/scripts/lib/orchestration/review-providers/review-provider-factory.js",
       "method": "<anon method-6>",
-      "startLine": 193,
+      "startLine": 194,
       "crap": 2
     },
     {
       "path": ".agents/scripts/lib/orchestration/review-providers/review-provider-factory.js",
       "method": "createChainProvider",
-      "startLine": 256,
-      "crap": 6.0703125
+      "startLine": 257,
+      "crap": 6.049382716049383
     },
     {
       "path": ".agents/scripts/lib/orchestration/review-providers/review-provider-factory.js",
       "method": "listRegisteredProviders",
-      "startLine": 335,
+      "startLine": 345,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/orchestration/review-providers/review-provider-factory.js",
       "method": "listInlineProviders",
-      "startLine": 350,
+      "startLine": 360,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/orchestration/review-providers/review-provider-factory.js",
       "method": "listPromptProviders",
-      "startLine": 359,
+      "startLine": 369,
       "crap": 1
     },
     {
@@ -15453,176 +16029,182 @@
     {
       "path": ".agents/scripts/lib/orchestration/run-epilogue.js",
       "method": "normalizeStoryId",
-      "startLine": 44,
+      "startLine": 46,
       "crap": 12
     },
     {
       "path": ".agents/scripts/lib/orchestration/run-epilogue.js",
       "method": "normalizeStoryIds",
-      "startLine": 60,
+      "startLine": 62,
       "crap": 4
     },
     {
       "path": ".agents/scripts/lib/orchestration/run-epilogue.js",
       "method": "planRunEpilogue",
-      "startLine": 81,
+      "startLine": 83,
       "crap": 5
     },
     {
       "path": ".agents/scripts/lib/orchestration/run-epilogue.js",
       "method": "<anon method-1>",
-      "startLine": 106,
+      "startLine": 108,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/orchestration/run-epilogue.js",
       "method": "readFirstParentHistory",
-      "startLine": 158,
+      "startLine": 160,
       "crap": 3
     },
     {
       "path": ".agents/scripts/lib/orchestration/run-epilogue.js",
       "method": "<anon method-2>",
-      "startLine": 185,
+      "startLine": 187,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/orchestration/run-epilogue.js",
       "method": "<anon method-3>",
-      "startLine": 187,
+      "startLine": 189,
       "crap": 2
     },
     {
       "path": ".agents/scripts/lib/orchestration/run-epilogue.js",
       "method": "trailingMarkerIds",
-      "startLine": 231,
+      "startLine": 233,
       "crap": 3
     },
     {
       "path": ".agents/scripts/lib/orchestration/run-epilogue.js",
       "method": "resolveRunBaseSha",
-      "startLine": 269,
+      "startLine": 271,
       "crap": 7
     },
     {
       "path": ".agents/scripts/lib/orchestration/run-epilogue.js",
       "method": "<anon method-4>",
-      "startLine": 278,
+      "startLine": 280,
       "crap": 2
     },
     {
       "path": ".agents/scripts/lib/orchestration/run-epilogue.js",
       "method": "<anon method-5>",
-      "startLine": 298,
+      "startLine": 300,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/orchestration/run-epilogue.js",
       "method": "<anon method-6>",
-      "startLine": 321,
+      "startLine": 323,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/orchestration/run-epilogue.js",
       "method": "listChangedFiles",
-      "startLine": 333,
+      "startLine": 335,
       "crap": 3.474609375
     },
     {
       "path": ".agents/scripts/lib/orchestration/run-epilogue.js",
       "method": "<anon method-7>",
-      "startLine": 353,
+      "startLine": 355,
       "crap": 1.052734375
     },
     {
       "path": ".agents/scripts/lib/orchestration/run-epilogue.js",
       "method": "resolveCombinedDiff",
-      "startLine": 365,
+      "startLine": 367,
       "crap": 3.129528359623319
     },
     {
       "path": ".agents/scripts/lib/orchestration/run-epilogue.js",
       "method": "renderDiffLines",
-      "startLine": 410,
+      "startLine": 412,
       "crap": 2
     },
     {
       "path": ".agents/scripts/lib/orchestration/run-epilogue.js",
       "method": "resolveBaseRef",
-      "startLine": 432,
+      "startLine": 434,
       "crap": 3
     },
     {
       "path": ".agents/scripts/lib/orchestration/run-epilogue.js",
       "method": "executeAuditRoster",
-      "startLine": 441,
+      "startLine": 443,
       "crap": 14.000169312169312
     },
     {
       "path": ".agents/scripts/lib/orchestration/run-epilogue.js",
       "method": "<anon method-8>",
-      "startLine": 492,
+      "startLine": 494,
       "crap": 1.0000008638375986
     },
     {
       "path": ".agents/scripts/lib/orchestration/run-epilogue.js",
       "method": "executeFollowUpRollup",
-      "startLine": 547,
-      "crap": 5.002574920654297
+      "startLine": 549,
+      "crap": 6
     },
     {
       "path": ".agents/scripts/lib/orchestration/run-epilogue.js",
       "method": "<anon method-9>",
-      "startLine": 578,
-      "crap": 1.0001029968261719
+      "startLine": 581,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/run-epilogue.js",
+      "method": "<anon method-10>",
+      "startLine": 642,
+      "crap": 1
     },
     {
       "path": ".agents/scripts/lib/orchestration/run-epilogue.js",
       "method": "extractSection",
-      "startLine": 612,
+      "startLine": 657,
       "crap": 3
     },
     {
       "path": ".agents/scripts/lib/orchestration/run-epilogue.js",
       "method": "executeSiblingCoherence",
-      "startLine": 622,
+      "startLine": 667,
       "crap": 11
     },
     {
       "path": ".agents/scripts/lib/orchestration/run-epilogue.js",
-      "method": "<anon method-10>",
-      "startLine": 636,
-      "crap": 1
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/run-epilogue.js",
       "method": "<anon method-11>",
-      "startLine": 639,
+      "startLine": 681,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/orchestration/run-epilogue.js",
       "method": "<anon method-12>",
-      "startLine": 640,
+      "startLine": 684,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/orchestration/run-epilogue.js",
       "method": "<anon method-13>",
-      "startLine": 656,
+      "startLine": 685,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/orchestration/run-epilogue.js",
       "method": "<anon method-14>",
-      "startLine": 668,
+      "startLine": 701,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/run-epilogue.js",
+      "method": "<anon method-15>",
+      "startLine": 713,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/orchestration/run-epilogue.js",
       "method": "runPlanRunEpilogue",
-      "startLine": 703,
-      "crap": 7.033660696112355
+      "startLine": 751,
+      "crap": 7.030857142857143
     },
     {
       "path": ".agents/scripts/lib/orchestration/single-story-close/failed-terminal.js",
@@ -15639,61 +16221,61 @@
     {
       "path": ".agents/scripts/lib/orchestration/single-story-close/gate-log.js",
       "method": "logNameFor",
-      "startLine": 74,
+      "startLine": 84,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/orchestration/single-story-close/gate-log.js",
       "method": "createArtifactWriter",
-      "startLine": 179,
+      "startLine": 189,
       "crap": 1.0011070564598794
     },
     {
       "path": ".agents/scripts/lib/orchestration/single-story-close/gate-log.js",
       "method": "<anon method-3>",
-      "startLine": 181,
+      "startLine": 191,
       "crap": 1.0011070564598794
     },
     {
       "path": ".agents/scripts/lib/orchestration/single-story-close/gate-log.js",
       "method": "<anon method-4>",
-      "startLine": 186,
+      "startLine": 196,
       "crap": 2
     },
     {
       "path": ".agents/scripts/lib/orchestration/single-story-close/gate-log.js",
       "method": "<anon method-5>",
-      "startLine": 194,
+      "startLine": 204,
       "crap": 1.0046296296296295
     },
     {
       "path": ".agents/scripts/lib/orchestration/single-story-close/gate-log.js",
       "method": "<anon method-6>",
-      "startLine": 195,
+      "startLine": 205,
       "crap": 1.0046296296296295
     },
     {
       "path": ".agents/scripts/lib/orchestration/single-story-close/gate-log.js",
       "method": "<anon method-7>",
-      "startLine": 196,
+      "startLine": 206,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/orchestration/single-story-close/gate-log.js",
       "method": "createGateLogSink",
-      "startLine": 226,
+      "startLine": 236,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/orchestration/single-story-close/gate-log.js",
       "method": "<anon method-8>",
-      "startLine": 234,
+      "startLine": 244,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/orchestration/single-story-close/gate-log.js",
       "method": "<anon method-9>",
-      "startLine": 252,
+      "startLine": 262,
       "crap": 1
     },
     {
@@ -15783,26 +16365,26 @@
     {
       "path": ".agents/scripts/lib/orchestration/single-story-close/phases/code-review.js",
       "method": "buildStoryReviewCrossRefBody",
-      "startLine": 60,
+      "startLine": 65,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/orchestration/single-story-close/phases/code-review.js",
       "method": "invokeStoryReviewCore",
-      "startLine": 75,
+      "startLine": 78,
       "crap": 3
     },
     {
       "path": ".agents/scripts/lib/orchestration/single-story-close/phases/code-review.js",
       "method": "postStoryReviewCrossRef",
-      "startLine": 103,
-      "crap": 4.054
+      "startLine": 106,
+      "crap": 4.050144368189667
     },
     {
       "path": ".agents/scripts/lib/orchestration/single-story-close/phases/code-review.js",
       "method": "runStoryScopeReview",
-      "startLine": 181,
-      "crap": 2.0008141664970487
+      "startLine": 187,
+      "crap": 2.0006858710562416
     },
     {
       "path": ".agents/scripts/lib/orchestration/single-story-close/phases/confirm-merge.js",
@@ -16077,13 +16659,13 @@
     {
       "path": ".agents/scripts/lib/orchestration/single-story-close/phases/post-land.js",
       "method": "<anon method-10>",
-      "startLine": 420,
+      "startLine": 419,
       "crap": 2
     },
     {
       "path": ".agents/scripts/lib/orchestration/single-story-close/phases/post-land.js",
       "method": "<anon method-11>",
-      "startLine": 421,
+      "startLine": 420,
       "crap": 1
     },
     {
@@ -16103,6 +16685,18 @@
       "method": "handleCriticalReviewBlock",
       "startLine": 12,
       "crap": 1.0017808943428779
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/single-story-close/phases/review-outcome.js",
+      "method": "buildOutcomeTally",
+      "startLine": 29,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/single-story-close/phases/review-outcome.js",
+      "method": "formatReviewOutcomeLines",
+      "startLine": 50,
+      "crap": 2.1758599633625075
     },
     {
       "path": ".agents/scripts/lib/orchestration/single-story-close/phases/worktree-reap.js",
@@ -16381,18 +16975,6 @@
       "crap": 2
     },
     {
-      "path": ".agents/scripts/lib/orchestration/spec-freshness.js",
-      "method": "hasNewFileCue",
-      "startLine": 93,
-      "crap": 2
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/spec-freshness.js",
-      "method": "collectReferences",
-      "startLine": 112,
-      "crap": 2
-    },
-    {
       "path": ".agents/scripts/lib/orchestration/spec-section-validator.js",
       "method": "validateSpecSections",
       "startLine": 75,
@@ -16569,37 +17151,37 @@
     {
       "path": ".agents/scripts/lib/orchestration/story-close/phases/code-review.js",
       "method": "resolveSeverity",
-      "startLine": 52,
+      "startLine": 53,
       "crap": 1.125
     },
     {
       "path": ".agents/scripts/lib/orchestration/story-close/phases/code-review.js",
       "method": "buildCodeReviewBlockedExtra",
-      "startLine": 69,
+      "startLine": 70,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/orchestration/story-close/phases/code-review.js",
       "method": "formatReviewSummary",
-      "startLine": 86,
+      "startLine": 87,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/orchestration/story-close/phases/code-review.js",
       "method": "invokeReviewCore",
-      "startLine": 101,
+      "startLine": 105,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/orchestration/story-close/phases/code-review.js",
       "method": "emitCriticalBlock",
-      "startLine": 124,
+      "startLine": 128,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/orchestration/story-close/phases/code-review.js",
       "method": "runStoryCodeReview",
-      "startLine": 167,
+      "startLine": 171,
       "crap": 3
     },
     {
@@ -16671,206 +17253,308 @@
     {
       "path": ".agents/scripts/lib/orchestration/story-deliver-terminal-schema.js",
       "method": "loadSchemaSource",
-      "startLine": 56,
+      "startLine": 63,
       "crap": 1.008
     },
     {
       "path": ".agents/scripts/lib/orchestration/story-deliver-terminal-schema.js",
       "method": "getValidator",
-      "startLine": 92,
+      "startLine": 99,
       "crap": 3
     },
     {
       "path": ".agents/scripts/lib/orchestration/story-deliver-terminal-schema.js",
       "method": "warnUnvalidated",
-      "startLine": 117,
+      "startLine": 124,
       "crap": 2
     },
     {
       "path": ".agents/scripts/lib/orchestration/story-deliver-terminal-schema.js",
       "method": "validateTerminalEnvelope",
-      "startLine": 144,
+      "startLine": 151,
       "crap": 3
     },
     {
       "path": ".agents/scripts/lib/orchestration/story-deliver-terminal-schema.js",
       "method": "<anon method-1>",
-      "startLine": 156,
+      "startLine": 163,
       "crap": 2
     },
     {
       "path": ".agents/scripts/lib/orchestration/story-deliver-terminal.js",
       "method": "quoteForPlan",
-      "startLine": 87,
+      "startLine": 91,
       "crap": 3
     },
     {
       "path": ".agents/scripts/lib/orchestration/story-deliver-terminal.js",
       "method": "<anon method-1>",
-      "startLine": 111,
+      "startLine": 115,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/orchestration/story-deliver-terminal.js",
       "method": "<anon method-2>",
-      "startLine": 114,
+      "startLine": 118,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/orchestration/story-deliver-terminal.js",
       "method": "<anon method-3>",
-      "startLine": 117,
+      "startLine": 121,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/orchestration/story-deliver-terminal.js",
       "method": "<anon method-4>",
-      "startLine": 120,
+      "startLine": 124,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/orchestration/story-deliver-terminal.js",
       "method": "<anon method-5>",
-      "startLine": 123,
+      "startLine": 127,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/orchestration/story-deliver-terminal.js",
       "method": "<anon method-6>",
-      "startLine": 126,
+      "startLine": 130,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/orchestration/story-deliver-terminal.js",
       "method": "<anon method-7>",
-      "startLine": 129,
+      "startLine": 133,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/orchestration/story-deliver-terminal.js",
       "method": "<anon method-8>",
-      "startLine": 142,
+      "startLine": 146,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/orchestration/story-deliver-terminal.js",
       "method": "compact",
-      "startLine": 153,
+      "startLine": 157,
       "crap": 2
     },
     {
       "path": ".agents/scripts/lib/orchestration/story-deliver-terminal.js",
       "method": "buildTerminalEnvelope",
-      "startLine": 197,
+      "startLine": 201,
       "crap": 5
     },
     {
       "path": ".agents/scripts/lib/orchestration/story-deliver-terminal.js",
       "method": "<anon method-9>",
-      "startLine": 246,
+      "startLine": 250,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/orchestration/story-deliver-terminal.js",
       "method": "buildEscalationTerminal",
-      "startLine": 279,
+      "startLine": 283,
       "crap": 5
     },
     {
       "path": ".agents/scripts/lib/orchestration/story-deliver-terminal.js",
       "method": "<anon method-10>",
-      "startLine": 294,
+      "startLine": 298,
       "crap": 2
     },
     {
       "path": ".agents/scripts/lib/orchestration/story-deliver-terminal.js",
       "method": "exitCodeForTerminal",
-      "startLine": 321,
+      "startLine": 325,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/orchestration/story-deliver-terminal.js",
+      "method": "tolerantConfig",
+      "startLine": 343,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/story-deliver-terminal.js",
+      "method": "persistTerminalEnvelope",
+      "startLine": 391,
+      "crap": 4.005830903790088
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/story-deliver-terminal.js",
       "method": "emitTerminalEnvelope",
-      "startLine": 349,
+      "startLine": 449,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/orchestration/story-deliver-terminal.js",
       "method": "terminalFromWaitOutcome",
-      "startLine": 369,
+      "startLine": 482,
       "crap": 5
     },
     {
       "path": ".agents/scripts/lib/orchestration/story-follow-ups.js",
       "method": "resolveFollowUpRepos",
-      "startLine": 29,
+      "startLine": 33,
       "crap": 9
     },
     {
       "path": ".agents/scripts/lib/orchestration/story-follow-ups.js",
       "method": "gatherStoryFrictionSignals",
-      "startLine": 71,
+      "startLine": 75,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/orchestration/story-follow-ups.js",
       "method": "<anon method-1>",
-      "startLine": 76,
+      "startLine": 80,
       "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/story-follow-ups.js",
+      "method": "signalIdentity",
+      "startLine": 103,
+      "crap": 5
     },
     {
       "path": ".agents/scripts/lib/orchestration/story-follow-ups.js",
       "method": "gatherRunFrictionSignals",
-      "startLine": 101,
+      "startLine": 152,
       "crap": 3
     },
     {
       "path": ".agents/scripts/lib/orchestration/story-follow-ups.js",
-      "method": "renderEmptyRollupLines",
-      "startLine": 138,
-      "crap": 2
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/story-follow-ups.js",
-      "method": "buildFollowUpsCommentBody",
-      "startLine": 164,
-      "crap": 18.264607304014742
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/story-follow-ups.js",
       "method": "<anon method-2>",
-      "startLine": 222,
-      "crap": 1.014509365795621
+      "startLine": 155,
+      "crap": 3
     },
     {
       "path": ".agents/scripts/lib/orchestration/story-follow-ups.js",
       "method": "<anon method-3>",
-      "startLine": 223,
-      "crap": 1.014509365795621
+      "startLine": 169,
+      "crap": 1
     },
     {
       "path": ".agents/scripts/lib/orchestration/story-follow-ups.js",
       "method": "<anon method-4>",
-      "startLine": 224,
-      "crap": 1.014509365795621
+      "startLine": 176,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/story-follow-ups.js",
+      "method": "renderEmptyRollupLines",
+      "startLine": 211,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/story-follow-ups.js",
+      "method": "summarizeSignalCategories",
+      "startLine": 246,
+      "crap": 5
     },
     {
       "path": ".agents/scripts/lib/orchestration/story-follow-ups.js",
       "method": "<anon method-5>",
-      "startLine": 225,
-      "crap": 1.014509365795621
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/story-follow-ups.js",
-      "method": "captureStoryFollowUps",
-      "startLine": 269,
-      "crap": 3.001679300291545
+      "startLine": 256,
+      "crap": 1
     },
     {
       "path": ".agents/scripts/lib/orchestration/story-follow-ups.js",
       "method": "<anon method-6>",
-      "startLine": 300,
-      "crap": 1.0001865889212829
+      "startLine": 257,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/story-follow-ups.js",
+      "method": "assessRollupOutcome",
+      "startLine": 287,
+      "crap": 8
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/story-follow-ups.js",
+      "method": "<anon method-7>",
+      "startLine": 298,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/story-follow-ups.js",
+      "method": "<anon method-8>",
+      "startLine": 299,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/story-follow-ups.js",
+      "method": "renderZeroProposalLines",
+      "startLine": 321,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/story-follow-ups.js",
+      "method": "<anon method-9>",
+      "startLine": 324,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/story-follow-ups.js",
+      "method": "renderUnfiledProposalLines",
+      "startLine": 345,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/story-follow-ups.js",
+      "method": "renderDiscardedItem",
+      "startLine": 380,
+      "crap": 8
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/story-follow-ups.js",
+      "method": "<anon method-10>",
+      "startLine": 387,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/story-follow-ups.js",
+      "method": "buildFollowUpsCommentBody",
+      "startLine": 410,
+      "crap": 20.18633346516426
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/story-follow-ups.js",
+      "method": "<anon method-11>",
+      "startLine": 500,
+      "crap": 1.0004658336629106
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/story-follow-ups.js",
+      "method": "<anon method-12>",
+      "startLine": 501,
+      "crap": 1.0004658336629106
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/story-follow-ups.js",
+      "method": "<anon method-13>",
+      "startLine": 506,
+      "crap": 1.0004658336629106
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/story-follow-ups.js",
+      "method": "<anon method-14>",
+      "startLine": 512,
+      "crap": 1.0004658336629106
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/story-follow-ups.js",
+      "method": "captureStoryFollowUps",
+      "startLine": 562,
+      "crap": 3.001543209876543
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/story-follow-ups.js",
+      "method": "<anon method-15>",
+      "startLine": 593,
+      "crap": 1.0001714677640603
     },
     {
       "path": ".agents/scripts/lib/orchestration/story-init-remote.js",
@@ -19423,6 +20107,36 @@
       "crap": 3
     },
     {
+      "path": ".agents/scripts/lib/stdio-flush.js",
+      "method": "drainStream",
+      "startLine": 41,
+      "crap": 6
+    },
+    {
+      "path": ".agents/scripts/lib/stdio-flush.js",
+      "method": "<anon method-1>",
+      "startLine": 46,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/stdio-flush.js",
+      "method": "<anon method-2>",
+      "startLine": 48,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/stdio-flush.js",
+      "method": "flushStdio",
+      "startLine": 69,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/stdio-flush.js",
+      "method": "<anon method-3>",
+      "startLine": 70,
+      "crap": 1
+    },
+    {
       "path": ".agents/scripts/lib/story-adjacency.js",
       "method": "buildStoryAdjacency",
       "startLine": 55,
@@ -19468,258 +20182,318 @@
       "path": ".agents/scripts/lib/story-body/story-body.js",
       "method": "parsePathEntry",
       "startLine": 203,
-      "crap": 17
+      "crap": 6
+    },
+    {
+      "path": ".agents/scripts/lib/story-body/story-body.js",
+      "method": "pathEntryFromObject",
+      "startLine": 228,
+      "crap": 4
+    },
+    {
+      "path": ".agents/scripts/lib/story-body/story-body.js",
+      "method": "pathEntryFromHumanized",
+      "startLine": 252,
+      "crap": 4
+    },
+    {
+      "path": ".agents/scripts/lib/story-body/story-body.js",
+      "method": "pathEntryFromInlineJson",
+      "startLine": 276,
+      "crap": 6.091284748309541
     },
     {
       "path": ".agents/scripts/lib/story-body/story-body.js",
       "method": "pathEntryFixIt",
-      "startLine": 279,
+      "startLine": 308,
       "crap": 2
     },
     {
       "path": ".agents/scripts/lib/story-body/story-body.js",
       "method": "extractBlockedBy",
-      "startLine": 292,
+      "startLine": 321,
       "crap": 2
     },
     {
       "path": ".agents/scripts/lib/story-body/story-body.js",
       "method": "extractMeta",
-      "startLine": 326,
+      "startLine": 355,
       "crap": 10.210725062796069
     },
     {
       "path": ".agents/scripts/lib/story-body/story-body.js",
       "method": "normalizeReasonToExist",
-      "startLine": 376,
+      "startLine": 405,
       "crap": 3
     },
     {
       "path": ".agents/scripts/lib/story-body/story-body.js",
       "method": "normalizeWide",
-      "startLine": 391,
+      "startLine": 420,
       "crap": 5
     },
     {
       "path": ".agents/scripts/lib/story-body/story-body.js",
       "method": "splitSections",
-      "startLine": 412,
-      "crap": 15
+      "startLine": 441,
+      "crap": 10
+    },
+    {
+      "path": ".agents/scripts/lib/story-body/story-body.js",
+      "method": "isFooterSeparator",
+      "startLine": 510,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/story-body/story-body.js",
+      "method": "isSectionTerminatorHeading",
+      "startLine": 531,
+      "crap": 3
+    },
+    {
+      "path": ".agents/scripts/lib/story-body/story-body.js",
+      "method": "isMachineMarkerLine",
+      "startLine": 556,
+      "crap": 3
     },
     {
       "path": ".agents/scripts/lib/story-body/story-body.js",
       "method": "parseUnstructuredBody",
-      "startLine": 525,
+      "startLine": 579,
       "crap": 2
     },
     {
       "path": ".agents/scripts/lib/story-body/story-body.js",
       "method": "parseGoalSection",
-      "startLine": 570,
+      "startLine": 624,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/story-body/story-body.js",
       "method": "<anon method-1>",
-      "startLine": 572,
+      "startLine": 626,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/story-body/story-body.js",
       "method": "parseTextBlockSection",
-      "startLine": 586,
+      "startLine": 640,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/story-body/story-body.js",
       "method": "<anon method-2>",
-      "startLine": 588,
+      "startLine": 642,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/story-body/story-body.js",
       "method": "parsePathEntrySection",
-      "startLine": 602,
+      "startLine": 656,
       "crap": 3
     },
     {
       "path": ".agents/scripts/lib/story-body/story-body.js",
       "method": "parseTextListSection",
-      "startLine": 620,
+      "startLine": 674,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/story-body/story-body.js",
       "method": "<anon method-3>",
-      "startLine": 621,
+      "startLine": 675,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/story-body/story-body.js",
       "method": "parse",
-      "startLine": 646,
+      "startLine": 700,
       "crap": 11
     },
     {
       "path": ".agents/scripts/lib/story-body/story-body.js",
       "method": "<anon method-4>",
-      "startLine": 704,
+      "startLine": 758,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/story-body/story-body.js",
       "method": "parseStructuredObject",
-      "startLine": 771,
-      "crap": 18
+      "startLine": 825,
+      "crap": 1
     },
     {
       "path": ".agents/scripts/lib/story-body/story-body.js",
       "method": "<anon method-5>",
-      "startLine": 792,
+      "startLine": 903,
       "crap": 2
     },
     {
       "path": ".agents/scripts/lib/story-body/story-body.js",
       "method": "<anon method-6>",
-      "startLine": 797,
+      "startLine": 904,
       "crap": 2
     },
     {
       "path": ".agents/scripts/lib/story-body/story-body.js",
       "method": "<anon method-7>",
-      "startLine": 810,
+      "startLine": 906,
       "crap": 2
     },
     {
       "path": ".agents/scripts/lib/story-body/story-body.js",
       "method": "<anon method-8>",
-      "startLine": 819,
-      "crap": 2
-    },
-    {
-      "path": ".agents/scripts/lib/story-body/story-body.js",
-      "method": "serializePathEntry",
-      "startLine": 886,
+      "startLine": 908,
       "crap": 2
     },
     {
       "path": ".agents/scripts/lib/story-body/story-body.js",
       "method": "<anon method-9>",
-      "startLine": 910,
-      "crap": 3
+      "startLine": 916,
+      "crap": 1
     },
     {
       "path": ".agents/scripts/lib/story-body/story-body.js",
       "method": "<anon method-10>",
-      "startLine": 922,
+      "startLine": 917,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/story-body/story-body.js",
+      "method": "normalizeEstimatedTestFiles",
+      "startLine": 929,
+      "crap": 3
+    },
+    {
+      "path": ".agents/scripts/lib/story-body/story-body.js",
+      "method": "normalizeProvenanceString",
+      "startLine": 946,
+      "crap": 3
+    },
+    {
+      "path": ".agents/scripts/lib/story-body/story-body.js",
+      "method": "serializePathEntry",
+      "startLine": 960,
       "crap": 2
     },
     {
       "path": ".agents/scripts/lib/story-body/story-body.js",
       "method": "<anon method-11>",
-      "startLine": 933,
+      "startLine": 984,
       "crap": 3
     },
     {
       "path": ".agents/scripts/lib/story-body/story-body.js",
       "method": "<anon method-12>",
-      "startLine": 942,
-      "crap": 3
+      "startLine": 996,
+      "crap": 2
     },
     {
       "path": ".agents/scripts/lib/story-body/story-body.js",
       "method": "<anon method-13>",
-      "startLine": 949,
+      "startLine": 1007,
       "crap": 3
     },
     {
       "path": ".agents/scripts/lib/story-body/story-body.js",
       "method": "<anon method-14>",
-      "startLine": 951,
-      "crap": 1
+      "startLine": 1016,
+      "crap": 3
     },
     {
       "path": ".agents/scripts/lib/story-body/story-body.js",
       "method": "<anon method-15>",
-      "startLine": 960,
+      "startLine": 1023,
       "crap": 3
     },
     {
       "path": ".agents/scripts/lib/story-body/story-body.js",
       "method": "<anon method-16>",
-      "startLine": 962,
+      "startLine": 1025,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/story-body/story-body.js",
       "method": "<anon method-17>",
-      "startLine": 967,
+      "startLine": 1034,
       "crap": 3
     },
     {
       "path": ".agents/scripts/lib/story-body/story-body.js",
       "method": "<anon method-18>",
-      "startLine": 969,
+      "startLine": 1036,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/story-body/story-body.js",
       "method": "<anon method-19>",
-      "startLine": 974,
+      "startLine": 1041,
       "crap": 3
     },
     {
       "path": ".agents/scripts/lib/story-body/story-body.js",
       "method": "<anon method-20>",
-      "startLine": 976,
+      "startLine": 1043,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/story-body/story-body.js",
       "method": "<anon method-21>",
-      "startLine": 986,
+      "startLine": 1048,
       "crap": 3
     },
     {
       "path": ".agents/scripts/lib/story-body/story-body.js",
       "method": "<anon method-22>",
-      "startLine": 988,
+      "startLine": 1050,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/story-body/story-body.js",
+      "method": "<anon method-23>",
+      "startLine": 1060,
+      "crap": 3
+    },
+    {
+      "path": ".agents/scripts/lib/story-body/story-body.js",
+      "method": "<anon method-24>",
+      "startLine": 1062,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/story-body/story-body.js",
       "method": "serializeMetaBlock",
-      "startLine": 1008,
+      "startLine": 1082,
       "crap": 9
     },
     {
       "path": ".agents/scripts/lib/story-body/story-body.js",
       "method": "serializeAuthoredMarker",
-      "startLine": 1042,
+      "startLine": 1116,
       "crap": 5
     },
     {
       "path": ".agents/scripts/lib/story-body/story-body.js",
       "method": "serializeFooter",
-      "startLine": 1059,
+      "startLine": 1133,
       "crap": 4
     },
     {
       "path": ".agents/scripts/lib/story-body/story-body.js",
       "method": "serialize",
-      "startLine": 1090,
+      "startLine": 1164,
       "crap": 4
     },
     {
       "path": ".agents/scripts/lib/story-body/story-body.js",
       "method": "extractChangePaths",
-      "startLine": 1126,
+      "startLine": 1200,
       "crap": 2
     },
     {
       "path": ".agents/scripts/lib/story-body/story-body.js",
-      "method": "<anon method-23>",
-      "startLine": 1128,
+      "method": "<anon method-25>",
+      "startLine": 1202,
       "crap": 4
     },
     {
@@ -19845,25 +20619,25 @@
     {
       "path": ".agents/scripts/lib/test-env.js",
       "method": "_clearTestScratchTempRootCache",
-      "startLine": 18,
+      "startLine": 19,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/test-env.js",
       "method": "ensureTestScratchTempRoot",
-      "startLine": 42,
-      "crap": 5
+      "startLine": 53,
+      "crap": 6
     },
     {
       "path": ".agents/scripts/lib/test-env.js",
       "method": "buildWebhookSafeTestEnv",
-      "startLine": 98,
+      "startLine": 110,
       "crap": 2
     },
     {
       "path": ".agents/scripts/lib/test-env.js",
       "method": "<anon method-1>",
-      "startLine": 100,
+      "startLine": 112,
       "crap": 1
     },
     {
@@ -20147,6 +20921,132 @@
       "method": "renderProfileReport",
       "startLine": 8,
       "crap": 3.0001640180784372
+    },
+    {
+      "path": ".agents/scripts/lib/test-temp.js",
+      "method": "_resetSuiteTempRootForTests",
+      "startLine": 64,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/test-temp.js",
+      "method": "_currentSuiteTempRoot",
+      "startLine": 73,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/test-temp.js",
+      "method": "reapSuiteTempRoot",
+      "startLine": 91,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/test-temp.js",
+      "method": "suiteTempRoot",
+      "startLine": 116,
+      "crap": 3
+    },
+    {
+      "path": ".agents/scripts/lib/test-temp.js",
+      "method": "<anon method-1>",
+      "startLine": 127,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/test-temp.js",
+      "method": "makeTempDir",
+      "startLine": 144,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/test-temp.js",
+      "method": "reapOnExit",
+      "startLine": 166,
+      "crap": 1.001953125
+    },
+    {
+      "path": ".agents/scripts/lib/test-temp.js",
+      "method": "<anon method-2>",
+      "startLine": 174,
+      "crap": 1.001953125
+    },
+    {
+      "path": ".agents/scripts/lib/test-temp.js",
+      "method": "listSuiteTempRoots",
+      "startLine": 193,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/test-temp.js",
+      "method": "<anon method-3>",
+      "startLine": 198,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/test-temp.js",
+      "method": "<anon method-4>",
+      "startLine": 200,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/test-temp.js",
+      "method": "survivingSuiteTempRoots",
+      "startLine": 217,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/test-temp.js",
+      "method": "<anon method-5>",
+      "startLine": 219,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/test-temp.js",
+      "method": "findRawTmpdirMkdtemp",
+      "startLine": 254,
+      "crap": 5
+    },
+    {
+      "path": ".agents/scripts/lib/test-temp.js",
+      "method": "<anon method-6>",
+      "startLine": 260,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/test-temp.js",
+      "method": "<anon method-7>",
+      "startLine": 262,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/test-temp.js",
+      "method": "<anon method-8>",
+      "startLine": 263,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/test-temp.js",
+      "method": "<anon method-9>",
+      "startLine": 266,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/test-temp.js",
+      "method": "<anon method-10>",
+      "startLine": 273,
+      "crap": 5
+    },
+    {
+      "path": ".agents/scripts/lib/test-temp.js",
+      "method": "walkFiles",
+      "startLine": 294,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/test-temp.js",
+      "method": "<anon method-11>",
+      "startLine": 297,
+      "crap": 6
     },
     {
       "path": ".agents/scripts/lib/test-tiers.js",
@@ -22820,27 +23720,33 @@
     },
     {
       "path": ".agents/scripts/resolve-stories.js",
-      "method": "main",
-      "startLine": 169,
-      "crap": 30
+      "method": "runResolveStories",
+      "startLine": 179,
+      "crap": 3
     },
     {
       "path": ".agents/scripts/resolve-stories.js",
       "method": "<anon method-7>",
-      "startLine": 207,
-      "crap": 2
+      "startLine": 192,
+      "crap": 1
     },
     {
       "path": ".agents/scripts/resolve-stories.js",
       "method": "<anon method-8>",
-      "startLine": 211,
-      "crap": 2
+      "startLine": 196,
+      "crap": 1
     },
     {
       "path": ".agents/scripts/resolve-stories.js",
       "method": "<anon method-9>",
-      "startLine": 223,
-      "crap": 2
+      "startLine": 208,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/resolve-stories.js",
+      "method": "main",
+      "startLine": 220,
+      "crap": 12
     },
     {
       "path": ".agents/scripts/resync-status-column.js",
@@ -23044,36 +23950,36 @@
       "path": ".agents/scripts/single-story-confirm-merge.js",
       "method": "resolvePrNumber",
       "startLine": 166,
-      "crap": 30
+      "crap": 5
     },
     {
       "path": ".agents/scripts/single-story-confirm-merge.js",
       "method": "logConfirmResult",
-      "startLine": 193,
+      "startLine": 192,
       "crap": 1
     },
     {
       "path": ".agents/scripts/single-story-confirm-merge.js",
       "method": "buildConfirmTerminal",
-      "startLine": 227,
+      "startLine": 226,
       "crap": 17.012826302666397
     },
     {
       "path": ".agents/scripts/single-story-confirm-merge.js",
       "method": "resolveConfirmPrNumber",
-      "startLine": 296,
+      "startLine": 295,
       "crap": 5.390625
     },
     {
       "path": ".agents/scripts/single-story-confirm-merge.js",
       "method": "runConfirmMerge",
-      "startLine": 308,
-      "crap": 8.254695163749226
+      "startLine": 307,
+      "crap": 8.258916545355381
     },
     {
       "path": ".agents/scripts/single-story-confirm-merge.js",
       "method": "main",
-      "startLine": 504,
+      "startLine": 502,
       "crap": 20
     },
     {
@@ -23314,25 +24220,25 @@
       "path": ".agents/scripts/sync-agentrc.js",
       "method": "parseArgs",
       "startLine": 45,
-      "crap": 30
+      "crap": 5
     },
     {
       "path": ".agents/scripts/sync-agentrc.js",
       "method": "main",
       "startLine": 58,
-      "crap": 24.663177059626765
+      "crap": 5
     },
     {
       "path": ".agents/scripts/sync-agentrc.js",
       "method": "trimAdvisories",
       "startLine": 72,
-      "crap": 2
+      "crap": 1
     },
     {
       "path": ".agents/scripts/sync-agentrc.js",
       "method": "<anon method-1>",
       "startLine": 75,
-      "crap": 2
+      "crap": 1
     },
     {
       "path": ".agents/scripts/sync-branch-from-base.js",
@@ -24310,7 +25216,7 @@
       "path": "lib/cli/version-check.js",
       "method": "isStale",
       "startLine": 159,
-      "crap": 7.0986328125
+      "crap": 6.020833333333333
     },
     {
       "path": "lib/cli/version-helpers.js",
@@ -24351,31 +25257,31 @@
     {
       "path": "lib/migrations/index.js",
       "method": "parseVersion",
-      "startLine": 86,
+      "startLine": 88,
       "crap": 4
     },
     {
       "path": "lib/migrations/index.js",
       "method": "compareVersions",
-      "startLine": 104,
+      "startLine": 106,
       "crap": 3.017578125
     },
     {
       "path": "lib/migrations/index.js",
       "method": "runMigrations",
-      "startLine": 144,
+      "startLine": 146,
       "crap": 2
     },
     {
       "path": "lib/migrations/index.js",
       "method": "<anon method-1>",
-      "startLine": 153,
+      "startLine": 155,
       "crap": 2
     },
     {
       "path": "lib/migrations/index.js",
       "method": "<anon method-2>",
-      "startLine": 157,
+      "startLine": 159,
       "crap": 1
     },
     {
@@ -24473,6 +25379,36 @@
       "method": "<anon method-3>",
       "startLine": 131,
       "crap": 1
+    },
+    {
+      "path": "lib/migrations/steps/2.20.0-retire-codebase-snapshot.js",
+      "method": "resolveAgentrcPath",
+      "startLine": 37,
+      "crap": 2
+    },
+    {
+      "path": "lib/migrations/steps/2.20.0-retire-codebase-snapshot.js",
+      "method": "readAgentrcConfig",
+      "startLine": 48,
+      "crap": 2
+    },
+    {
+      "path": "lib/migrations/steps/2.20.0-retire-codebase-snapshot.js",
+      "method": "hasRetiredKey",
+      "startLine": 61,
+      "crap": 6
+    },
+    {
+      "path": "lib/migrations/steps/2.20.0-retire-codebase-snapshot.js",
+      "method": "stripRetiredKey",
+      "startLine": 73,
+      "crap": 6
+    },
+    {
+      "path": "lib/migrations/steps/2.20.0-retire-codebase-snapshot.js",
+      "method": "<anon method-1>",
+      "startLine": 92,
+      "crap": 1.2962962962962963
     }
   ]
 }

--- a/baselines/maintainability.json
+++ b/baselines/maintainability.json
@@ -1,11 +1,11 @@
 {
   "$schema": ".agents/schemas/baselines/maintainability.schema.json",
   "kernelVersion": "0.1.0",
-  "generatedAt": "2026-07-26T21:08:58.213Z",
+  "generatedAt": "2026-07-30T02:34:35.132Z",
   "rollup": {
     "*": {
       "min": 74.146,
-      "p50": 98.065,
+      "p50": 98.091,
       "p95": 126.637
     }
   },
@@ -192,7 +192,7 @@
     },
     {
       "path": ".agents/scripts/lib/audit-suite/selector.js",
-      "mi": 96.019
+      "mi": 98.886
     },
     {
       "path": ".agents/scripts/lib/audit-suite/substitutions.js",
@@ -1616,7 +1616,7 @@
     },
     {
       "path": ".agents/scripts/lib/story-body/story-body.js",
-      "mi": 89.915
+      "mi": 94.035
     },
     {
       "path": ".agents/scripts/lib/story-lifecycle.js",

--- a/tests/config/sync-agentrc.test.js
+++ b/tests/config/sync-agentrc.test.js
@@ -10,6 +10,7 @@ import {
   syncAgentrc,
 } from '../../.agents/scripts/lib/config/sync-agentrc.js';
 import { makeTempDir } from '../../.agents/scripts/lib/test-temp.js';
+import { main } from '../../.agents/scripts/sync-agentrc.js';
 
 const STARTER_PATH = fileURLToPath(
   new URL('../../.agents/starter-agentrc.json', import.meta.url),
@@ -304,5 +305,39 @@ describe('full-agentrc runtime parity', () => {
     const raw = JSON.parse(readFileSync(FULL_PATH, 'utf8'));
     delete raw.$schema;
     assert.deepEqual(defaults, raw);
+  });
+});
+
+describe('sync-agentrc CLI main — exit codes (Story #4842)', () => {
+  let root;
+  beforeEach(() => {
+    root = makeTmpProject();
+  });
+
+  function writeValidConfig(dir) {
+    const starter = JSON.parse(readFileSync(STARTER_PATH, 'utf8'));
+    starter.github.owner = 'acme';
+    starter.github.repo = 'demo';
+    starter.github.operatorHandle = '@octocat';
+    return writeConfig(dir, starter);
+  }
+
+  it('returns 0 for a valid config named via --cwd', () => {
+    writeValidConfig(root);
+    assert.equal(main(['--cwd', root]), 0);
+  });
+
+  it('returns 0 under --quiet, trimming advisory rows', () => {
+    writeValidConfig(root);
+    assert.equal(main(['--cwd', root, '--quiet']), 0);
+  });
+
+  it('returns 1 for malformed JSON', () => {
+    writeConfig(root, '{ not json');
+    assert.equal(main(['--cwd', root]), 1);
+  });
+
+  it('returns 1 for a missing config, ignoring unknown flags', () => {
+    assert.equal(main(['--cwd', root, '--bogus']), 1);
   });
 });

--- a/tests/scripts/resolve-stories.test.js
+++ b/tests/scripts/resolve-stories.test.js
@@ -29,6 +29,7 @@ import {
   storyFootprintPaths,
   toStoryRecord,
 } from '../../.agents/scripts/lib/orchestration/resolve-stories.js';
+import { runResolveStories } from '../../.agents/scripts/resolve-stories.js';
 import {
   selectReadySet,
   storiesOverlap,
@@ -602,5 +603,89 @@ describe('storyFootprintPaths — an unreadable footprint fails SAFE, not open',
       '- npm test (unit)',
     ].join('\n');
     assert.deepEqual(storyFootprintPaths(body, 1), []);
+  });
+});
+
+describe('runResolveStories — the injectable CLI flow core (Story #4842)', () => {
+  const CONFIG = { github: { owner: 'dsj1984', repo: 'mandrel' } };
+
+  function makeProvider(byId) {
+    return {
+      getTicket: async (id) => byId[id] ?? null,
+      // readNativeEdges reaches gh through this seam; an empty payload
+      // exercises the native branch without shape assumptions.
+      _gh: { api: async () => ({ stdout: '[]' }) },
+    };
+  }
+
+  function capture() {
+    const chunks = [];
+    return { write: (s) => chunks.push(s), text: () => chunks.join('') };
+  }
+
+  it('writes the compact single-line envelope with a trailing newline', async () => {
+    const provider = makeProvider({
+      101: issue(),
+      102: issue({ number: 102, body: storyBody({ blockedBy: 101 }) }),
+    });
+    const out = capture();
+    const code = await runResolveStories(
+      { ids: '101,102', native: false },
+      { provider, config: CONFIG, stdout: out },
+    );
+    assert.equal(code, 0);
+    const text = out.text();
+    assert.ok(text.endsWith('\n'), 'envelope line is newline-terminated');
+    assert.equal(
+      text.trimEnd().includes('\n'),
+      false,
+      'compact mode emits exactly one stdout line',
+    );
+    const envelope = JSON.parse(text);
+    assert.equal(envelope.kind, 'stories');
+    assert.deepEqual(
+      envelope.stories.map((s) => s.id),
+      [101, 102],
+    );
+    const node = envelope.dag.find((n) => n.id === 102);
+    assert.deepEqual(node.dependsOn, [101]);
+    assert.deepEqual(envelope.done, []);
+  });
+
+  it('pretty-prints the same envelope when asked', async () => {
+    const provider = makeProvider({ 101: issue() });
+    const out = capture();
+    await runResolveStories(
+      { ids: '101', native: false, pretty: true },
+      { provider, config: CONFIG, stdout: out },
+    );
+    const text = out.text();
+    assert.ok(text.includes('\n  '), 'pretty mode indents');
+    assert.equal(JSON.parse(text).kind, 'stories');
+  });
+
+  it('a closed foreign blocker lands in done[]', async () => {
+    const provider = makeProvider({
+      101: issue({ body: storyBody({ blockedBy: 4000 }) }),
+      4000: issue({ number: 4000, state: 'closed' }),
+    });
+    const out = capture();
+    await runResolveStories(
+      { ids: '101', native: false },
+      { provider, config: CONFIG, stdout: out },
+    );
+    const envelope = JSON.parse(out.text());
+    assert.deepEqual(envelope.done, [4000]);
+  });
+
+  it('reads native edges through the injected provider gh seam', async () => {
+    const provider = makeProvider({ 101: issue() });
+    const out = capture();
+    await runResolveStories(
+      { ids: '101' },
+      { provider, config: CONFIG, stdout: out },
+    );
+    const envelope = JSON.parse(out.text());
+    assert.deepEqual(envelope.dag.find((n) => n.id === 101).dependsOn, []);
   });
 });

--- a/tests/scripts/resolve-stories.test.js
+++ b/tests/scripts/resolve-stories.test.js
@@ -29,11 +29,11 @@ import {
   storyFootprintPaths,
   toStoryRecord,
 } from '../../.agents/scripts/lib/orchestration/resolve-stories.js';
-import { runResolveStories } from '../../.agents/scripts/resolve-stories.js';
 import {
   selectReadySet,
   storiesOverlap,
 } from '../../.agents/scripts/lib/wave-runner/ready-set.js';
+import { runResolveStories } from '../../.agents/scripts/resolve-stories.js';
 import { parseDag } from '../../.agents/scripts/stories-wave-tick.js';
 
 const REPO = { owner: 'dsj1984', repo: 'mandrel', issueNumber: 4534 };

--- a/tests/single-story-confirm-merge.test.js
+++ b/tests/single-story-confirm-merge.test.js
@@ -23,7 +23,10 @@ import { describe, it } from 'node:test';
 
 import { resolveMergeWaitConfig } from '../.agents/scripts/lib/orchestration/single-story-close/phases/confirm-merge.js';
 import { confirmStoryMerged } from '../.agents/scripts/lib/single-story/confirm-merge.js';
-import { runConfirmMerge } from '../.agents/scripts/single-story-confirm-merge.js';
+import {
+  resolvePrNumber,
+  runConfirmMerge,
+} from '../.agents/scripts/single-story-confirm-merge.js';
 
 /**
  * Fake ticketing provider. Records every `updateTicket` patch and applies
@@ -365,5 +368,52 @@ describe('single-story-confirm-merge --max-wait-seconds (Story #4710 AC-3)', () 
       calls[0].maxWaitSeconds,
     );
     assert.equal(resolved.maxWaitSeconds, 45);
+  });
+});
+
+describe('resolvePrNumber — the gh pr list probe (Story #4842)', () => {
+  function ghWithRows(rows) {
+    return { pr: { list: async () => rows } };
+  }
+
+  it('returns the first row number when it is a valid PR number', async () => {
+    const n = await resolvePrNumber({
+      storyBranch: 'story-1',
+      gh: ghWithRows([{ number: 77, url: 'https://github.com/o/r/pull/77' }]),
+    });
+    assert.equal(n, 77);
+  });
+
+  it('falls back to parsing the PR url when the number field is unusable', async () => {
+    const n = await resolvePrNumber({
+      storyBranch: 'story-1',
+      gh: ghWithRows([{ url: 'https://github.com/o/r/pull/88' }]),
+    });
+    assert.equal(n, 88);
+  });
+
+  it('returns null when no PR exists for the branch', async () => {
+    assert.equal(
+      await resolvePrNumber({ storyBranch: 'story-1', gh: ghWithRows([]) }),
+      null,
+    );
+    assert.equal(
+      await resolvePrNumber({
+        storyBranch: 'story-1',
+        gh: ghWithRows(undefined),
+      }),
+      null,
+    );
+  });
+
+  it('degrades to null instead of throwing when the probe fails', async () => {
+    const gh = {
+      pr: {
+        list: async () => {
+          throw new Error('gh exploded');
+        },
+      },
+    };
+    assert.equal(await resolvePrNumber({ storyBranch: 'story-1', gh }), null);
   });
 });


### PR DESCRIPTION
Closes #4842

_Auto-opened by `/deliver`._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Structural refactor with preserved contracts (degraded envelopes, parse fail-closed, CLI stdout); risk is mainly regression in edge cases covered by existing tests.
> 
> **Overview**
> Refactors several agent scripts to **lower cyclomatic complexity** (clean-code / CRAP gate headroom) without changing runtime behavior. Selection, parsing, and CLI flows are split into smaller, testable units.
> 
> In **`selector.js`**, web-framework and ORM `package.json` probes share **`declaresDependencyIn`**. **`selectAudits`** is decomposed into helpers (`loadAuditRules`, `resolveHeadRefOrDegrade`, `acquireChangedFilesFromDiff`, `matchAuditRules`, `lensTriggerFires`, etc.) so git/ref resolution and rule matching are no longer one monolithic function.
> 
> In **`story-body.js`**, path-entry parsing and markdown section splitting move into named helpers (`pathEntryFromHumanized`, `isMachineMarkerLine`, …). **`parseStructuredObject`** normalizes fields via **`STRUCTURED_FIELD_SPECS`** / **`STRUCTURED_FIELD_NORMALIZERS`** instead of inline per-field code.
> 
> **`resolve-stories.js`** exposes **`runResolveStories`** with injectable provider/config/stdout for unit tests; **`single-story-confirm-merge.js`** exports **`resolvePrNumber`** and drops an unused `cwd` argument from that probe.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8061ed8211f4ffe1b5531b2ffb75f516c97b8b6d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->