### PR TITLE
fix(diagnose-friction): name the signal that killed a child instead of reporting "Unknown exit code null" and exiting 0 (#4851)

### DIFF
--- a/.agents/scripts/diagnose-friction.js
+++ b/.agents/scripts/diagnose-friction.js
@@ -31,6 +31,7 @@
  */
 import { spawnSync } from 'node:child_process';
 import crypto from 'node:crypto';
+import { constants as osConstants } from 'node:os';
 import { getLimits, resolveConfig } from './lib/config-resolver.js';
 import { Logger } from './lib/Logger.js';
 import { appendSignal } from './lib/observability/signals-writer.js';
@@ -97,6 +98,72 @@ function classifyFrictionCategory(errorOutput) {
   return { category: matched.category, remediation: matched.remediation };
 }
 
+/**
+ * `spawnSync`'s own `timeout` option kills the child with `SIGTERM`, so a
+ * SIGTERM observed here almost always means the interceptor's configured
+ * `executionTimeoutMs` bound fired. Any other signal — a `SIGKILL` from the
+ * OOM killer, an operator `kill -9` — originated outside this process.
+ *
+ * @type {string}
+ */
+const INTERCEPTOR_TIMEOUT_SIGNAL = 'SIGTERM';
+
+/** Shell convention for "the process died by signal N": exit `128 + N`. */
+const SIGNAL_EXIT_BASE = 128;
+
+/**
+ * Describe a child that never exited normally — `status === null`, Node's
+ * documented representation of "did not exit normally". The raw status must
+ * never reach `process.exit`, because `process.exit(null)` exits **0**: the
+ * interceptor would report success for a command it just watched get killed
+ * (Story #4851).
+ *
+ * Which signal fired is the diagnostic value: SIGTERM points at the
+ * interceptor's own bound, anything else at the host. Recording that plus the
+ * bound itself is what makes the row actionable to a consumer who cannot edit
+ * the materialized framework tree.
+ *
+ * Deliberately module-local and pure — exporting it for tests would fail the
+ * `--production` dead-exports ratchet, and folding it into `main` would spend
+ * the file's per-file maintainability-delta headroom. The CLI contract is the
+ * seam the unit tests drive.
+ *
+ * @param {{signal: (string|null), error?: {message?: string}}} result A
+ *   `spawnSync` result whose `status` is `null`.
+ * @param {number} executionTimeoutMs The resolved interceptor bound, in ms.
+ * @returns {{category: string, remediation: string, details: object,
+ *   preview: string, exitCode: number}}
+ */
+function describeAbnormalExit(result, executionTimeoutMs) {
+  const signal = typeof result.signal === 'string' ? result.signal : null;
+  if (signal === null) {
+    return {
+      category: FRICTION_DEFAULT.category,
+      remediation: FRICTION_DEFAULT.remediation,
+      details: {
+        killedBySignal: null,
+        killOrigin: 'spawn-failure',
+        executionTimeoutMs,
+      },
+      preview: `Command did not exit normally and reported no signal: ${result.error?.message ?? 'spawn produced no exit status'}.`,
+      exitCode: 1,
+    };
+  }
+
+  const timedOut = signal === INTERCEPTOR_TIMEOUT_SIGNAL;
+  const killOrigin = timedOut ? 'interceptor-timeout' : 'external';
+  const signum = osConstants.signals[signal];
+  return {
+    category: timedOut ? 'Execution Timeout' : 'Execution Killed',
+    remediation: timedOut
+      ? ` - ${signal} matches the interceptor's own executionTimeoutMs bound (${executionTimeoutMs}ms), so the command was almost certainly cut off rather than broken. Split it into smaller steps, or raise the bound.`
+      : ` - ${signal} originated outside the interceptor — the executionTimeoutMs bound (${executionTimeoutMs}ms) did not fire, so suspect an OOM kill or a hard kill from the host. Reduce the command's memory footprint or give the host more headroom.`,
+    details: { killedBySignal: signal, killOrigin, executionTimeoutMs },
+    preview: `Command terminated by signal ${signal} (${killOrigin}); executionTimeoutMs=${executionTimeoutMs}.`,
+    exitCode: Number.isInteger(signum) ? SIGNAL_EXIT_BASE + signum : 1,
+  };
+}
+
 function toIntOrNull(value) {
   if (value == null) return null;
   const n = Number.parseInt(String(value), 10);
@@ -121,6 +188,7 @@ function buildFrictionSignal({
   category,
   commandStr,
   errorPreview,
+  terminationDetails = null,
 }) {
   return {
     kind: 'friction',
@@ -133,11 +201,14 @@ function buildFrictionSignal({
     // and always null.
     taskId: null,
     category,
+    // `emitter.command` is what `classifySignalSource` step 1 scans, so the
+    // command-scan stays authoritative for `source`: a consumer command killed
+    // by its own host remains consumer-actionable (Story #4851).
     emitter: {
       tool: 'diagnose-friction.js',
       command: commandStr,
     },
-    details: { errorPreview },
+    details: { errorPreview, ...(terminationDetails ?? {}) },
   };
 }
 
@@ -176,10 +247,22 @@ export async function main(args = process.argv.slice(2)) {
   if (result.stderr) process.stderr.write(result.stderr);
 
   if (result.status !== 0) {
+    // A `null` status means the child never exited normally; the cause lives in
+    // `result.signal`, not in the status.
+    const abnormal =
+      result.status === null
+        ? describeAbnormalExit(result, executionTimeoutMs)
+        : null;
+    // With both streams empty an abnormal termination names its signal; the
+    // `Unknown exit code` fallback is therefore reachable only with a real
+    // numeric status, never as `Unknown exit code null`.
+    const noOutputFallback = abnormal
+      ? abnormal.preview
+      : `Unknown exit code ${result.status}`;
     const errorOutput = (
       result.stderr ||
       result.stdout ||
-      `Unknown exit code ${result.status}`
+      noOutputFallback
     ).trim();
     const errorPreview = errorOutput.substring(0, 500);
 
@@ -188,7 +271,12 @@ export async function main(args = process.argv.slice(2)) {
       'Command failed. Appending friction signal to NDJSON stream...',
     );
 
-    const { category, remediation } = classifyFrictionCategory(errorOutput);
+    // An abnormal termination classifies itself: the marker scan reads output
+    // the kill may have truncated (or never produced), so it cannot name the
+    // signal.
+    const classified = classifyFrictionCategory(errorOutput);
+    const category = abnormal?.category ?? classified.category;
+    const remediation = abnormal?.remediation ?? classified.remediation;
 
     const { storyId: resolvedStoryId, epicId: resolvedEpicId } =
       resolveContextIds({ storyId, epicId }, config);
@@ -199,6 +287,7 @@ export async function main(args = process.argv.slice(2)) {
       category,
       commandStr,
       errorPreview,
+      terminationDetails: abnormal?.details ?? null,
     });
 
     // Story #2874 — accept story-only context (no parent Epic). When
@@ -236,7 +325,9 @@ export async function main(args = process.argv.slice(2)) {
     Logger.error(remediation);
     Logger.error('----------------------------------------\n');
 
-    process.exit(result.status);
+    // Never `process.exit(result.status)` on a null status — that exits 0 and
+    // reports success for a killed command.
+    process.exit(abnormal?.exitCode ?? result.status);
   } else {
     process.exit(0);
   }

--- a/baselines/maintainability.json
+++ b/baselines/maintainability.json
@@ -1,7 +1,7 @@
 {
   "$schema": ".agents/schemas/baselines/maintainability.schema.json",
   "kernelVersion": "0.1.0",
-  "generatedAt": "2026-07-30T02:34:35.132Z",
+  "generatedAt": "2026-07-30T22:03:29.781Z",
   "rollup": {
     "*": {
       "min": 74.146,
@@ -104,7 +104,7 @@
     },
     {
       "path": ".agents/scripts/diagnose-friction.js",
-      "mi": 88.538
+      "mi": 86.005
     },
     {
       "path": ".agents/scripts/diagnose.js",

--- a/tests/diagnose-friction.test.js
+++ b/tests/diagnose-friction.test.js
@@ -20,6 +20,7 @@
 import assert from 'node:assert/strict';
 import { spawnSync } from 'node:child_process';
 import { readFileSync, rmSync } from 'node:fs';
+import { constants as osConstants } from 'node:os';
 import path from 'node:path';
 import { afterEach, beforeEach, describe, it } from 'node:test';
 import { fileURLToPath } from 'node:url';
@@ -62,6 +63,24 @@ function runScript(extraArgs, extraEnv = {}) {
       ...extraEnv,
     },
   });
+}
+
+/**
+ * Read the single friction record the CLI appended for the story/epic pair the
+ * tests below use, asserting the stream holds exactly one line.
+ */
+function readSignal(epicId = 1030, storyId = 1042) {
+  const ndjsonPath = path.join(
+    tmpRoot,
+    'temp',
+    `run-${epicId}`,
+    'stories',
+    `story-${storyId}`,
+    'signals.ndjson',
+  );
+  const lines = readFileSync(ndjsonPath, 'utf-8').trim().split('\n');
+  assert.equal(lines.length, 1, 'exactly one friction signal is appended');
+  return JSON.parse(lines[0]);
 }
 
 describe('diagnose-friction.js — v5 (CLI contract)', () => {
@@ -235,6 +254,47 @@ describe('diagnose-friction.js — appends friction signal to NDJSON', () => {
     );
   });
 
+  it('records an ordinary non-zero exit exactly as before signal handling (Story #4851 regression pin)', () => {
+    // AC-6: a child that exits normally with a non-zero status must keep its
+    // pre-#4851 category, preview, remediation text and exit code — the signal
+    // branch may not leak into the ordinary failure path.
+    const result = runScript([
+      '--story',
+      '1042',
+      '--epic',
+      '1030',
+      '--cmd',
+      'node',
+      '-e',
+      'process.exit(3)',
+    ]);
+
+    assert.equal(result.status, 3, 'exit code is passed through unchanged');
+
+    const signal = readSignal();
+    assert.equal(
+      signal.category,
+      'Execution Error',
+      'no output + no marker → the generic default category, as before',
+    );
+    assert.equal(
+      signal.details.errorPreview,
+      'Unknown exit code 3',
+      'the numeric-status fallback preview is unchanged',
+    );
+    assert.deepEqual(
+      Object.keys(signal.details),
+      ['errorPreview'],
+      'details carries no termination keys for an ordinary exit',
+    );
+    assert.ok(
+      (result.stderr ?? '').includes(
+        'Generic failure. Review stderr above, refine your approach',
+      ),
+      'the default remediation text is unchanged',
+    );
+  });
+
   it('does not call postStructuredComment / write GitHub friction comments', () => {
     // Smoke check: with NO_NETWORK=1, the v5/Epic#1030 detector path must
     // not attempt any GitHub round-trip. The presence of the NDJSON write
@@ -261,3 +321,142 @@ describe('diagnose-friction.js — appends friction signal to NDJSON', () => {
     );
   });
 });
+
+/**
+ * A child killed by a signal reports `status: null` with the cause in `signal`.
+ * These cases drive that shape end-to-end through the real CLI, so they need a
+ * platform where `process.kill` delivers a POSIX signal — on win32 there is no
+ * signal to name and the OS reports an ordinary exit code instead.
+ */
+const POSIX_ONLY = { skip: process.platform === 'win32' };
+
+/** The interceptor's own `executionTimeoutMs` bound under this repo's config. */
+const EXECUTION_TIMEOUT_MS = 600000;
+
+/** Run the CLI over a child that kills itself with `signalName`. */
+function runSelfKill(signalName) {
+  return runScript([
+    '--story',
+    '1042',
+    '--epic',
+    '1030',
+    '--cmd',
+    'node',
+    '-e',
+    `process.kill(process.pid, '${signalName}')`,
+  ]);
+}
+
+describe(
+  'diagnose-friction.js — signal-terminated child (Story #4851)',
+  POSIX_ONLY,
+  () => {
+    it('records an externally-originated SIGKILL by name, not as Execution Error', () => {
+      // AC-1 + AC-3: the signal is the whole diagnostic payload, and SIGKILL is
+      // not the signal `spawnSync`'s own timeout would have sent.
+      const result = runSelfKill('SIGKILL');
+      assert.equal(
+        result.signal,
+        null,
+        'the interceptor itself exits normally',
+      );
+
+      const signal = readSignal();
+      assert.equal(
+        signal.category,
+        'Execution Killed',
+        'category names the kill instead of the generic Execution Error bucket',
+      );
+      assert.equal(
+        signal.details.killedBySignal,
+        'SIGKILL',
+        'details carries the signal name spawnSync reported',
+      );
+      assert.equal(
+        signal.details.killOrigin,
+        'external',
+        'SIGKILL is not the interceptor timeout signal → externally originated',
+      );
+      assert.equal(
+        signal.details.executionTimeoutMs,
+        EXECUTION_TIMEOUT_MS,
+        'details records the resolved bound in milliseconds',
+      );
+      assert.ok(
+        (result.stderr ?? '').includes('originated outside the interceptor'),
+        'the remediation tells the operator the bound did not fire',
+      );
+    });
+
+    it('attributes a SIGTERM kill to the interceptor own timeout bound', () => {
+      // AC-3: `spawnSync`'s `timeout` option kills with SIGTERM, so SIGTERM is
+      // the interceptor cutting the command off rather than a host-level kill.
+      runSelfKill('SIGTERM');
+      const signal = readSignal();
+      assert.equal(
+        signal.category,
+        'Execution Timeout',
+        'a timeout-shaped kill gets its own category',
+      );
+      assert.equal(signal.details.killedBySignal, 'SIGTERM');
+      assert.equal(
+        signal.details.killOrigin,
+        'interceptor-timeout',
+        'the interceptor timeout signal is attributed to the interceptor',
+      );
+      assert.equal(signal.details.executionTimeoutMs, EXECUTION_TIMEOUT_MS);
+    });
+
+    it('never emits the "Unknown exit code null" preview', () => {
+      // AC-2: both streams are empty on a hard kill, which is precisely how the
+      // pre-#4851 fallback reached a literal that named nothing.
+      const result = runSelfKill('SIGKILL');
+      const combined = (result.stdout ?? '') + (result.stderr ?? '');
+      assert.ok(
+        !combined.includes('Unknown exit code null'),
+        'no printed diagnostic contains "Unknown exit code null"',
+      );
+
+      const signal = readSignal();
+      assert.ok(
+        !JSON.stringify(signal).includes('Unknown exit code null'),
+        'no emitted record contains "Unknown exit code null"',
+      );
+      assert.match(
+        signal.details.errorPreview,
+        /terminated by signal SIGKILL \(external\)/,
+        'with both streams empty the preview names the signal',
+      );
+    });
+
+    it('exits non-zero so the caller cannot read the run as successful', () => {
+      // AC-4: the branch used to end in `process.exit(result.status)`, and
+      // `process.exit(null)` exits 0 — the interceptor reported success for a
+      // command it had just watched get killed.
+      const result = runSelfKill('SIGKILL');
+      assert.notEqual(
+        result.status,
+        0,
+        'a signal-killed child must not surface as a successful run',
+      );
+      assert.equal(
+        result.status,
+        128 + osConstants.signals.SIGKILL,
+        'exit code follows the shell 128 + signum convention',
+      );
+    });
+
+    it('leaves source classification to the existing command scan', () => {
+      // AC-5: naming the signal must not force `source: framework`. The scan in
+      // source-classifier.js stays authoritative, so a consumer command killed
+      // by its own host stays consumer-actionable.
+      runSelfKill('SIGKILL');
+      const signal = readSignal();
+      assert.equal(
+        signal.source,
+        'consumer',
+        'a consumer command killed by a signal stays classified consumer',
+      );
+    });
+  },
+);


### PR DESCRIPTION
Closes #4851

_Auto-opened by `/deliver`._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 9a9d06911b2b0a167fd8b3eea831c4121453d7ab. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->