### PR TITLE
fix: scope the light diff backstop by change magnitude, and recycle the receipt instead of orphaning it (#4856)

### DIFF
--- a/.agents/scripts/deliver-light.js
+++ b/.agents/scripts/deliver-light.js
@@ -61,10 +61,10 @@ import { parseArgs } from 'node:util';
 import { runAsCli } from './lib/cli-utils.js';
 import { resolveConfig } from './lib/config-resolver.js';
 import { Logger, routeAllOutputToStderr } from './lib/Logger.js';
-import { computeChangeSet } from './lib/orchestration/change-set.js';
+import { resolveBackstopOutcome } from './lib/orchestration/light-backstop.js';
+import { recordGateRefusal } from './lib/orchestration/light-escalation.js';
 import {
   buildReceiptStoryTicket,
-  checkLightDiffBackstop,
   deriveLightSuitability,
   resolveLightGateOutcome,
 } from './lib/orchestration/light-suitability.js';
@@ -121,7 +121,11 @@ Gate options:
                      envelope and ENDS the session (no prompt, no fallback).
 
 Backstop options:
-  --backstop         Re-check the ACTUAL diff after implementation.
+  --backstop         Re-check the ACTUAL diff after implementation. Bounds the
+                     change's IMPLEMENTATION half by magnitude (changed lines +
+                     file sprawl); test/doc/baseline companions are exempt from
+                     the counts but still matched for sensitive paths. A block
+                     emits a nextCommand recycling the receipt through /plan.
   --story <id>       Story issue number whose story-<id> branch to diff.
 
   --pretty           Pretty-print the JSON envelope.
@@ -130,8 +134,6 @@ Backstop options:
 
 /** Exit code when the gate did not resolve to proceed-light. */
 const EXIT_NOT_PROCEED = 2;
-/** Exit code when the diff backstop blocked the land. */
-const EXIT_BACKSTOP_BLOCKED = 3;
 
 /**
  * Split a comma-separated path list into trimmed, non-empty entries.
@@ -293,33 +295,6 @@ export function buildNextCommands(storyId) {
 }
 
 /**
- * Run the diff backstop against a Story branch's actual change set.
- *
- * @param {{
- *   storyId: number,
- *   baseRef?: string,
- *   cwd?: string,
- *   computeFn?: typeof computeChangeSet,
- *   injectedRules?: object,
- * }} args
- * @returns {ReturnType<typeof checkLightDiffBackstop>}
- */
-export function runDiffBackstop({
-  storyId,
-  baseRef = 'main',
-  cwd = process.cwd(),
-  computeFn = computeChangeSet,
-  injectedRules,
-} = {}) {
-  const { files } = computeFn({
-    baseRef,
-    headRef: `story-${storyId}`,
-    cwd,
-  });
-  return checkLightDiffBackstop({ changedFiles: files, injectedRules });
-}
-
-/**
  * Was a non-blank `--operator-proceed-light` supplied? The gate core decides
  * whether it *applies*; this only asks whether the operator typed one, so the
  * attended-only refusal can fire before any adjudication.
@@ -348,27 +323,28 @@ function emit(envelope, pretty) {
 }
 
 /**
- * Backstop mode — re-check the actual diff.
+ * Backstop mode — re-check the actual diff. The decision lives in
+ * {@link module:lib/orchestration/light-backstop}; this branches and prints.
  *
- * @param {{ story?: string, pretty: boolean }} values
+ * @param {object} values Parsed CLI values.
+ * @param {{ resolveFn?: typeof resolveBackstopOutcome }} [deps]
  * @returns {Promise<number>}
  */
-async function runBackstopMode(values) {
+async function runBackstopMode(values, deps = {}) {
+  const { resolveFn = resolveBackstopOutcome } = deps;
   const storyId = Number.parseInt(String(values.story ?? ''), 10);
   if (!Number.isInteger(storyId) || storyId <= 0) {
     process.stderr.write(HELP);
     throw new Error('[deliver-light] --backstop requires --story <id>');
   }
-  const result = runDiffBackstop({ storyId });
-  emit({ mode: 'backstop', storyId, ...result }, values.pretty);
-  if (result.blocked) {
-    Logger.warn(
-      `[deliver-light] diff backstop BLOCKED Story #${storyId}: ${result.reasons.join('; ')}`,
-    );
-    return EXIT_BACKSTOP_BLOCKED;
-  }
-  Logger.info(`[deliver-light] diff backstop clean for Story #${storyId}.`);
-  return 0;
+  const { result, nextCommand, exitCode, message } = await resolveFn({
+    storyId,
+  });
+  const extra = nextCommand === null ? {} : { nextCommand };
+  emit({ mode: 'backstop', storyId, ...result, ...extra }, values.pretty);
+  if (result.blocked) Logger.warn(message);
+  else Logger.info(message);
+  return exitCode;
 }
 
 /**
@@ -407,6 +383,7 @@ export async function runGateMode(values, deps = {}) {
     createReceiptFn = createLightReceipt,
     emitFn = emit,
     emitTerminalFn = emitTerminalEnvelope,
+    recordRefusalFn = recordGateRefusal,
   } = deps;
 
   if (!values.prompt || String(values.prompt).trim() === '') {
@@ -457,6 +434,7 @@ export async function runGateMode(values, deps = {}) {
       { mode: 'gate', action: gate.action, outcome: gate.outcome },
       values.pretty,
     );
+    await recordRefusalFn({ gate, amends: values.amends });
     Logger.warn(
       `[deliver-light] gate did not proceed light (${gate.action}): ${gate.outcome.reasons.join('; ')}`,
     );

--- a/.agents/scripts/lib/audit-suite/lens-diff-floor.js
+++ b/.agents/scripts/lib/audit-suite/lens-diff-floor.js
@@ -28,6 +28,7 @@
  */
 
 import { gitSpawn } from '../git-utils.js';
+import { readNumstatRows } from '../orchestration/diff-magnitude.js';
 import { selectSensitivePathClasses } from './selector.js';
 
 /**
@@ -58,6 +59,12 @@ export function resolveLensDiffFloor(config) {
  * Count the changed lines (additions + deletions) in the
  * `baseRef...headRef` diff via `git diff --numstat`.
  *
+ * The read and the parse are shared with the light path's magnitude backstop
+ * ({@link module:lib/orchestration/diff-magnitude.readNumstatRows}) so the two
+ * cannot disagree about how a diff is measured. This one keeps a whole-diff
+ * total: the lens floor asks "is this diff small", not "is its implementation
+ * half small", so it deliberately does **not** apply the companion exemption.
+ *
  * Total — never throws. Returns `null` (the neutral "count unknown" signal
  * the floor fails open on) for any git failure or unparseable output, and
  * `0` for a genuinely empty diff. Binary rows (`-\t-\tpath`) contribute 0
@@ -77,31 +84,9 @@ export function countChangedLines({
   cwd = process.cwd(),
   gitSpawnFn = gitSpawn,
 } = {}) {
-  if (typeof baseRef !== 'string' || baseRef.length === 0) return null;
-  if (typeof headRef !== 'string' || headRef.length === 0) return null;
-  try {
-    const result = gitSpawnFn(
-      cwd,
-      'diff',
-      '--numstat',
-      `${baseRef}...${headRef}`,
-    );
-    if (!result || result.status !== 0 || typeof result.stdout !== 'string') {
-      return null;
-    }
-    let total = 0;
-    for (const line of result.stdout.split('\n')) {
-      const trimmedEnd = line.replace(/\s+$/, '');
-      if (trimmedEnd.length === 0) continue;
-      const match = /^(\d+|-)\t(\d+|-)\t/.exec(trimmedEnd);
-      if (!match) return null; // Unexpected format — the count is not trustworthy.
-      if (match[1] !== '-') total += Number(match[1]);
-      if (match[2] !== '-') total += Number(match[2]);
-    }
-    return total;
-  } catch {
-    return null;
-  }
+  const rows = readNumstatRows({ baseRef, headRef, cwd, gitSpawnFn });
+  if (rows === null) return null;
+  return rows.reduce((total, row) => total + row.additions + row.deletions, 0);
 }
 
 /**

--- a/.agents/scripts/lib/observability/runtime-friction.js
+++ b/.agents/scripts/lib/observability/runtime-friction.js
@@ -75,6 +75,14 @@ export const RUNTIME_FRICTION_CATEGORIES = Object.freeze({
    * reflect code findings only.
    */
   TOOL_DEGRADED: 'tool-degraded',
+  /**
+   * The light delivery path refused a scope — a suitability-gate `ask-operator`
+   * or a blocked diff backstop. Story #4856 added it because neither rejection
+   * emitted anything, so an over-tight ceiling could only reach the framework
+   * as anecdote; the roll-up aggregating these by category is what makes the
+   * ceilings recalibratable from recorded evidence.
+   */
+  LIGHT_SCOPE_REJECTED: 'light-scope-rejected',
 });
 
 /** Cap on free-form reason text copied into a signal's `details`. */

--- a/.agents/scripts/lib/orchestration/diff-magnitude.js
+++ b/.agents/scripts/lib/orchestration/diff-magnitude.js
@@ -1,0 +1,283 @@
+/**
+ * lib/orchestration/diff-magnitude.js — the changed-line magnitude of a diff,
+ * split into implementation and mandated-companion halves (Story #4856).
+ *
+ * ## Why magnitude, and why the split
+ *
+ * The light path's diff backstop used to bound scope with a single
+ * `maxFiles: 4` ceiling. Measured against this repository's own history that
+ * ceiling was wrong in both directions:
+ *
+ *   - **Too tight.** Of 33 real-work squash merges on `main` (excluding
+ *     release-please and `chore(baselines)` automation) only 7 — 21% — touch
+ *     four files or fewer; the median is 8. The framework's *own* narrow-diff
+ *     scale, `DEFAULT_DIFF_WIDTH.softFiles` in `review-depth.js`, is 15.
+ *   - **Blind.** A three-file, 323-line rewrite passed while a 190-file change
+ *     was rejected 47× over — even though 186 of those files were tests and its
+ *     implementation was 7 files.
+ *
+ * So the axis is **changed lines over implementation files**, and the companion
+ * classes the framework itself mandates are exempt from the count: obeying
+ * `rules/testing-standards.md` (test-first), the `delivery.docsFreshness` gate,
+ * and the baseline ratchets must not inflate the number that then rejects the
+ * change. Re-counting those same 33 merges on implementation files alone moves
+ * the four-file pass rate from 21% to 58%.
+ *
+ * ## Three contracts worth not rediscovering
+ *
+ *   1. **Additions plus deletions, never net.** A modified line counts twice
+ *      (one `+`, one `-`), which is the intended weighting. Net is actively
+ *      broken as a size signal: the merge retiring the planner snapshot is
+ *      1119 add+del but **−803** net, so a large deletion would measure as
+ *      trivial.
+ *   2. **A pure rename is free.** `git diff --numstat` reports `0\t0` for one,
+ *      and its path arrives in `old => new` form — normalized here to the
+ *      destination so the file still counts toward the implementation tally.
+ *   3. **Exemption is from *counting*, never from *risk*.** Nothing here
+ *      touches sensitive-path derivation, which every caller runs over the
+ *      full changed set including companions.
+ *
+ * Companion matching runs through the audit suite's picomatch seam as a
+ * **positive** glob list negated by the caller. A `!`-prefixed picomatch
+ * pattern widens a match rather than narrowing it, so expressing the
+ * behavior-bearing exceptions as negations would silently exempt more than
+ * intended.
+ *
+ * Every export is total: no throws. {@link readNumstatRows} owns the one git
+ * read; everything else is pure.
+ *
+ * The public surface is deliberately just those two functions. The numstat
+ * parse, the rename normalization, and the companion classifier are internal:
+ * each is fully observable through them (a stubbed `gitSpawnFn` drives the
+ * parse, an `isCompanionFn` seam drives the classification), so exporting them
+ * would widen the module's contract for no caller.
+ *
+ * @module lib/orchestration/diff-magnitude
+ */
+
+import { matchesAnyFilePattern } from '../audit-suite/selector.js';
+import { gitSpawn } from '../git-utils.js';
+
+/**
+ * Paths whose churn is a **mandated companion** of a change rather than the
+ * change itself, exempt from the implementation line and file counts.
+ *
+ * Deliberately absent, and load-bearing in their absence: `.agentrc.json`,
+ * `.agents/schemas/**`, `.github/workflows/**`, and `package.json`. Those are
+ * "config" by file type but behavior by effect, and `.agents/schemas/audit-rules.json`
+ * is the sensitive-path SSOT — exempting it would let a change widen the very
+ * allowlist that decides whether it is risky.
+ *
+ * Note the anchoring: `baselines/**` is the generated baseline **data** at the
+ * repository root. The baseline *schemas* under `.agents/schemas/baselines/`
+ * are unanchored by this pattern and therefore still count as implementation.
+ *
+ * Markdown is exempt wholesale, which includes `.agents/workflows/**` and
+ * `.agents/rules/**`. That is intended: rewriting a workflow contract is not
+ * *effort* the way a module rewrite is, and its real guards are the close-time
+ * context-budget, doc-link, and docs-reference-sync gates — none of which this
+ * ceiling replaces.
+ */
+const COMPANION_PATH_GLOBS = Object.freeze([
+  // Tests — mandated by rules/testing-standards.md's test-first discipline.
+  '**/__tests__/**',
+  '**/*.test.js',
+  '**/*.test.mjs',
+  '**/*.test.cjs',
+  '**/*.test.ts',
+  '**/*.test.tsx',
+  'tests/**',
+  'features/**',
+  // Documentation — mandated by the delivery.docsFreshness gate.
+  'docs/**',
+  '**/*.md',
+  // Generated baseline data — written by the ratchets, not hand-authored.
+  'baselines/**',
+  // Lockfiles — regenerated wholesale; their line count means nothing.
+  'package-lock.json',
+  'pnpm-lock.yaml',
+  'yarn.lock',
+]);
+
+/**
+ * Normalize a `git diff --numstat` path field to the single file it names.
+ * Rename rows arrive as `old => new` or with a braced infix
+ * (`dir/{old => new}/file.js`); both resolve to the destination, so a renamed
+ * implementation file still counts as one implementation file.
+ *
+ * Pure and total.
+ *
+ * @param {string} raw
+ * @returns {string}
+ */
+function normalizeNumstatPath(raw) {
+  const value = typeof raw === 'string' ? raw.trim() : '';
+  if (value === '') return '';
+  const braced = /^(.*)\{(.*) => (.*)\}(.*)$/.exec(value);
+  if (braced) {
+    const [, prefix, , to, suffix] = braced;
+    return `${prefix}${to}${suffix}`.replace(/\/{2,}/g, '/');
+  }
+  const arrow = value.split(' => ');
+  return (arrow.length > 1 ? arrow[arrow.length - 1] : value).trim();
+}
+
+/**
+ * Parse `git diff --numstat` output into per-file rows.
+ *
+ * Binary rows (`-\t-\tpath`) contribute zero text lines without poisoning the
+ * parse. Any line that does not match the numstat shape makes the whole result
+ * untrustworthy, so the function returns `null` — the "magnitude unknown"
+ * signal every caller fails closed (or fails open) on deliberately.
+ *
+ * Pure and total.
+ *
+ * @param {unknown} stdout
+ * @returns {Array<{ additions: number, deletions: number, path: string }>|null}
+ */
+function parseNumstatRows(stdout) {
+  if (typeof stdout !== 'string') return null;
+  const rows = [];
+  for (const line of stdout.split('\n')) {
+    const trimmedEnd = line.replace(/\s+$/, '');
+    if (trimmedEnd.length === 0) continue;
+    const match = /^(\d+|-)\t(\d+|-)\t(.+)$/.exec(trimmedEnd);
+    if (!match) return null;
+    rows.push({
+      additions: match[1] === '-' ? 0 : Number(match[1]),
+      deletions: match[2] === '-' ? 0 : Number(match[2]),
+      path: normalizeNumstatPath(match[3]),
+    });
+  }
+  return rows;
+}
+
+/**
+ * True when `file` is a mandated companion rather than implementation.
+ *
+ * Pure and total — a throwing matcher resolves to `false`, which counts the
+ * file as implementation. That is the conservative direction: a
+ * classification failure must never shrink the measured magnitude.
+ *
+ * @param {unknown} file
+ * @param {{ matchFn?: typeof matchesAnyFilePattern }} [deps]
+ * @returns {boolean}
+ */
+function isCompanionPath(file, { matchFn = matchesAnyFilePattern } = {}) {
+  if (typeof file !== 'string' || file.trim() === '') return false;
+  try {
+    return matchFn(COMPANION_PATH_GLOBS, [file.trim()]) === true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Read the per-file numstat rows for the `baseRef...headRef` diff. The one
+ * side-effecting function in this module.
+ *
+ * Total — never throws; returns `null` on any git failure or unparseable
+ * output.
+ *
+ * @param {{
+ *   baseRef?: string,
+ *   headRef?: string,
+ *   cwd?: string,
+ *   gitSpawnFn?: typeof gitSpawn,
+ * }} [args]
+ * @returns {Array<{ additions: number, deletions: number, path: string }>|null}
+ */
+export function readNumstatRows({
+  baseRef,
+  headRef,
+  cwd = process.cwd(),
+  gitSpawnFn = gitSpawn,
+} = {}) {
+  if (typeof baseRef !== 'string' || baseRef.length === 0) return null;
+  if (typeof headRef !== 'string' || headRef.length === 0) return null;
+  try {
+    const result = gitSpawnFn(
+      cwd,
+      'diff',
+      '--numstat',
+      `${baseRef}...${headRef}`,
+    );
+    if (!result || result.status !== 0) return null;
+    return parseNumstatRows(result.stdout);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Summarize a diff's magnitude, splitting implementation from mandated
+ * companions.
+ *
+ * `implFiles` is counted from `changedFiles` — the canonical
+ * `git diff --name-only` enumeration produced by `change-set.js` — rather than
+ * from the numstat rows, so file counting uses clean paths from the one
+ * enumerator every other consumer reads. `implLines` comes from the numstat
+ * rows, which is the only surface carrying line counts.
+ *
+ * Returns `null` when either input is unusable: the magnitude is then *unknown*,
+ * which is deliberately distinct from *zero* so a caller can fail closed on the
+ * absence of evidence.
+ *
+ * Pure and total.
+ *
+ * @param {{
+ *   changedFiles?: unknown,
+ *   rows?: unknown,
+ *   isCompanionFn?: typeof isCompanionPath,
+ * }} [args]
+ * @returns {{
+ *   implFiles: number,
+ *   implLines: number,
+ *   companionFiles: number,
+ *   companionLines: number,
+ *   totalFiles: number,
+ * }|null}
+ */
+export function summarizeDiffMagnitude({
+  changedFiles,
+  rows,
+  isCompanionFn = isCompanionPath,
+} = {}) {
+  if (!Array.isArray(changedFiles) || !Array.isArray(rows)) return null;
+  const files = changedFiles.filter(
+    (f) => typeof f === 'string' && f.trim() !== '',
+  );
+
+  // A classification failure resolves to "implementation" — the conservative
+  // direction, since counting a companion as implementation can only ever make
+  // the measured magnitude larger. Guarded here as well as inside the default
+  // classifier so an injected one cannot break this function's totality.
+  const isCompanion = (file) => {
+    try {
+      return isCompanionFn(file) === true;
+    } catch {
+      return false;
+    }
+  };
+
+  let implFiles = 0;
+  for (const file of files) {
+    if (!isCompanion(file)) implFiles += 1;
+  }
+
+  let implLines = 0;
+  let companionLines = 0;
+  for (const row of rows) {
+    const lines = (row?.additions ?? 0) + (row?.deletions ?? 0);
+    if (isCompanion(row?.path)) companionLines += lines;
+    else implLines += lines;
+  }
+
+  return {
+    implFiles,
+    implLines,
+    companionFiles: files.length - implFiles,
+    companionLines,
+    totalFiles: files.length,
+  };
+}

--- a/.agents/scripts/lib/orchestration/light-backstop.js
+++ b/.agents/scripts/lib/orchestration/light-backstop.js
@@ -27,7 +27,7 @@ import { handleBlockedBackstop } from './light-escalation.js';
 import { checkLightDiffBackstop } from './light-suitability.js';
 
 /** Exit code when the diff backstop blocked the land. */
-export const EXIT_BACKSTOP_BLOCKED = 3;
+const EXIT_BACKSTOP_BLOCKED = 3;
 
 /**
  * Run the diff backstop against a Story branch's actual change set.
@@ -42,7 +42,7 @@ export const EXIT_BACKSTOP_BLOCKED = 3;
  * }} args
  * @returns {ReturnType<typeof checkLightDiffBackstop>}
  */
-export function runDiffBackstop({
+function runDiffBackstop({
   storyId,
   baseRef = 'main',
   cwd = process.cwd(),
@@ -70,7 +70,9 @@ export function runDiffBackstop({
  *   storyId: number,
  *   runFn?: typeof runDiffBackstop,
  *   handleBlockedFn?: typeof handleBlockedBackstop,
- * }} args
+ * }} args Any further keys (`baseRef`, `cwd`, `computeFn`, `readRowsFn`,
+ *   `injectedRules`) forward to the backstop run, so the git-surface join is
+ *   drivable through this one entry point.
  * @returns {Promise<{
  *   result: ReturnType<typeof checkLightDiffBackstop>,
  *   nextCommand: string|null,
@@ -82,8 +84,9 @@ export async function resolveBackstopOutcome({
   storyId,
   runFn = runDiffBackstop,
   handleBlockedFn = handleBlockedBackstop,
+  ...seams
 } = {}) {
-  const result = runFn({ storyId });
+  const result = runFn({ storyId, ...seams });
   if (!result.blocked) {
     return {
       result,

--- a/.agents/scripts/lib/orchestration/light-backstop.js
+++ b/.agents/scripts/lib/orchestration/light-backstop.js
@@ -1,0 +1,104 @@
+/**
+ * lib/orchestration/light-backstop.js — the light path's diff-backstop pass
+ * (Story #4856).
+ *
+ * The backstop is invariant 3 of the light path: after implementation the
+ * **actual** change set is re-checked, because the diff — not the prompt — is
+ * the real scope signal. This module owns that pass end to end so
+ * `deliver-light.js` stays the thin CLI shell it claims to be: it reads the two
+ * git surfaces, applies
+ * {@link module:lib/orchestration/light-suitability.checkLightDiffBackstop},
+ * and resolves what a refusal means.
+ *
+ * ## Two git surfaces, each used for what it reports reliably
+ *
+ *   - `--name-only`, via the one canonical `computeChangeSet` enumerator, gives
+ *     the clean full file list. Sensitive-path derivation and
+ *     implementation-file counting both read it, so the backstop and every
+ *     other consumer are looking at the same change set.
+ *   - `--numstat` gives per-file line counts, the only surface carrying them.
+ *
+ * @module lib/orchestration/light-backstop
+ */
+
+import { computeChangeSet } from './change-set.js';
+import { readNumstatRows, summarizeDiffMagnitude } from './diff-magnitude.js';
+import { handleBlockedBackstop } from './light-escalation.js';
+import { checkLightDiffBackstop } from './light-suitability.js';
+
+/** Exit code when the diff backstop blocked the land. */
+export const EXIT_BACKSTOP_BLOCKED = 3;
+
+/**
+ * Run the diff backstop against a Story branch's actual change set.
+ *
+ * @param {{
+ *   storyId: number,
+ *   baseRef?: string,
+ *   cwd?: string,
+ *   computeFn?: typeof computeChangeSet,
+ *   readRowsFn?: typeof readNumstatRows,
+ *   injectedRules?: object,
+ * }} args
+ * @returns {ReturnType<typeof checkLightDiffBackstop>}
+ */
+export function runDiffBackstop({
+  storyId,
+  baseRef = 'main',
+  cwd = process.cwd(),
+  computeFn = computeChangeSet,
+  readRowsFn = readNumstatRows,
+  injectedRules,
+} = {}) {
+  const headRef = `story-${storyId}`;
+  const { files } = computeFn({ baseRef, headRef, cwd });
+  const rows = readRowsFn({ baseRef, headRef, cwd });
+  const magnitude = summarizeDiffMagnitude({ changedFiles: files, rows });
+  return checkLightDiffBackstop({
+    changedFiles: files,
+    magnitude,
+    injectedRules,
+  });
+}
+
+/**
+ * Resolve the backstop pass into everything the CLI needs to print and exit
+ * with: the verdict, the recycle command on a refusal (`null` when clean), the
+ * exit code, and the log line.
+ *
+ * @param {{
+ *   storyId: number,
+ *   runFn?: typeof runDiffBackstop,
+ *   handleBlockedFn?: typeof handleBlockedBackstop,
+ * }} args
+ * @returns {Promise<{
+ *   result: ReturnType<typeof checkLightDiffBackstop>,
+ *   nextCommand: string|null,
+ *   exitCode: number,
+ *   message: string,
+ * }>}
+ */
+export async function resolveBackstopOutcome({
+  storyId,
+  runFn = runDiffBackstop,
+  handleBlockedFn = handleBlockedBackstop,
+} = {}) {
+  const result = runFn({ storyId });
+  if (!result.blocked) {
+    return {
+      result,
+      nextCommand: null,
+      exitCode: 0,
+      message: `[deliver-light] diff backstop clean for Story #${storyId}.`,
+    };
+  }
+  const nextCommand = await handleBlockedFn({ storyId, result });
+  return {
+    result,
+    nextCommand,
+    exitCode: EXIT_BACKSTOP_BLOCKED,
+    message:
+      `[deliver-light] diff backstop BLOCKED Story #${storyId}: ` +
+      `${result.reasons.join('; ')} — recycle the receipt with "${nextCommand}"`,
+  };
+}

--- a/.agents/scripts/lib/orchestration/light-escalation.js
+++ b/.agents/scripts/lib/orchestration/light-escalation.js
@@ -42,7 +42,7 @@ import {
  * @param {number} storyId
  * @returns {string}
  */
-export function buildRecycleCommand(storyId) {
+function buildRecycleCommand(storyId) {
   return `/plan ${storyId}`;
 }
 
@@ -60,7 +60,7 @@ export function buildRecycleCommand(storyId) {
  * @param {unknown} amends
  * @returns {number|null}
  */
-export function normalizeAmendsId(amends) {
+function normalizeAmendsId(amends) {
   const match = /^#?(\d+)$/.exec(String(amends ?? '').trim());
   if (!match) return null;
   const n = Number.parseInt(match[1], 10);
@@ -81,9 +81,11 @@ export function normalizeAmendsId(amends) {
 export async function recordGateRefusal({
   gate,
   amends,
+  emitFn,
   recordFrictionFn = recordScopeFriction,
 } = {}) {
   return recordFrictionFn({
+    emitFn,
     storyId: normalizeAmendsId(amends),
     surface: 'suitability-gate',
     reasons: gate?.outcome?.reasons ?? [],
@@ -112,9 +114,11 @@ export async function recordGateRefusal({
 export async function handleBlockedBackstop({
   storyId,
   result,
+  emitFn,
   recordFrictionFn = recordScopeFriction,
 } = {}) {
   await recordFrictionFn({
+    emitFn,
     storyId,
     surface: 'diff-backstop',
     reasons: result?.reasons ?? [],
@@ -144,15 +148,16 @@ export async function handleBlockedBackstop({
  * }} args
  * @returns {Promise<boolean>}
  */
-export async function recordScopeFriction({
+async function recordScopeFriction({
   storyId,
   surface,
   reasons = [],
   details = {},
-  emitFn = emitRuntimeFriction,
+  emitFn,
 } = {}) {
+  const emit = emitFn ?? emitRuntimeFriction;
   try {
-    return await emitFn({
+    return await emit({
       storyId,
       category: RUNTIME_FRICTION_CATEGORIES.LIGHT_SCOPE_REJECTED,
       tool: 'deliver-light',

--- a/.agents/scripts/lib/orchestration/light-escalation.js
+++ b/.agents/scripts/lib/orchestration/light-escalation.js
@@ -1,0 +1,164 @@
+/**
+ * lib/orchestration/light-escalation.js — what the light path does when it
+ * refuses a scope (Story #4856).
+ *
+ * Two behaviors, both previously missing, and both about a refusal rather than
+ * a verdict — the verdicts live in
+ * {@link module:lib/orchestration/light-suitability}:
+ *
+ *   1. **Recycling the receipt.** A blocked diff backstop used to tell the
+ *      operator to "escalate to `/plan`", which authored a brand-new Story and
+ *      left the receipt open with no successor — orphaning its branch, its
+ *      worktree, and a finished implementation. Naming the receipt as `/plan`'s
+ *      *input* recycles it instead: tickets mode already fetches a ticket,
+ *      rewrites it into properly-planned Stories, and closes the source as
+ *      superseded.
+ *
+ *      Deferring receipt creation until after the backstop would be the other
+ *      fix, and is deliberately not taken: the issue id is load-bearing in
+ *      `single-story-init.js` (the assignee lease, the `story-<id>` branch, the
+ *      label state machine) and in the `(refs #<id>)` commit subject.
+ *
+ *   2. **Telemetering the refusal.** Neither light-path rejection emitted any
+ *      signal, so an over-tight ceiling could only reach the framework as
+ *      anecdote — which is exactly how the `maxFiles: 4` defect surfaced. The
+ *      roll-up aggregates by category, so recording these makes the ceilings
+ *      recalibratable from evidence.
+ *
+ * Telemetry is best-effort by construction: a signals-write failure must never
+ * change a gate's verdict.
+ *
+ * @module lib/orchestration/light-escalation
+ */
+
+import {
+  emitRuntimeFriction,
+  RUNTIME_FRICTION_CATEGORIES,
+} from '../observability/runtime-friction.js';
+
+/**
+ * The `/plan` invocation that owns a Story the light path could not land.
+ *
+ * @param {number} storyId
+ * @returns {string}
+ */
+export function buildRecycleCommand(storyId) {
+  return `/plan ${storyId}`;
+}
+
+/**
+ * Coerce an `--amends` argument (`#123` or `123`) into a positive integer issue
+ * number, or `null` when absent/malformed.
+ *
+ * This is the only Story context a **gate-stage** rejection can legitimately
+ * claim: the signals stream is keyed on a Story id, and an `ask-operator` gate
+ * has authored no receipt yet — deliberately, since not creating one is the
+ * point of that outcome. A bare prompt's rejection therefore has no stream to
+ * land in, and attributing it to a fabricated id would be worse than recording
+ * nothing.
+ *
+ * @param {unknown} amends
+ * @returns {number|null}
+ */
+export function normalizeAmendsId(amends) {
+  const match = /^#?(\d+)$/.exec(String(amends ?? '').trim());
+  if (!match) return null;
+  const n = Number.parseInt(match[1], 10);
+  return Number.isInteger(n) && n > 0 ? n : null;
+}
+
+/**
+ * Record a suitability-gate refusal (`ask-operator`) as friction, attributed to
+ * the `--amends` target when there is one.
+ *
+ * @param {{
+ *   gate: object,
+ *   amends?: unknown,
+ *   recordFrictionFn?: typeof recordScopeFriction,
+ * }} args
+ * @returns {Promise<boolean>}
+ */
+export async function recordGateRefusal({
+  gate,
+  amends,
+  recordFrictionFn = recordScopeFriction,
+} = {}) {
+  return recordFrictionFn({
+    storyId: normalizeAmendsId(amends),
+    surface: 'suitability-gate',
+    reasons: gate?.outcome?.reasons ?? [],
+    details: {
+      action: gate?.action ?? null,
+      code: gate?.suitability?.shape?.code ?? null,
+    },
+  });
+}
+
+/**
+ * Handle a blocked diff backstop: record the refusal as friction and return the
+ * `/plan` invocation that recycles the receipt.
+ *
+ * Lives here rather than in the CLI so the shell stays a shell — the backstop
+ * mode's job is to branch and print, not to decide what a refusal means.
+ *
+ * @param {{
+ *   storyId: number,
+ *   result: object,
+ *   recordFrictionFn?: typeof recordScopeFriction,
+ * }} args `result` is a {@link module:lib/orchestration/light-suitability.checkLightDiffBackstop}
+ *   verdict.
+ * @returns {Promise<string>} The recycle command.
+ */
+export async function handleBlockedBackstop({
+  storyId,
+  result,
+  recordFrictionFn = recordScopeFriction,
+} = {}) {
+  await recordFrictionFn({
+    storyId,
+    surface: 'diff-backstop',
+    reasons: result?.reasons ?? [],
+    details: {
+      fileCount: result?.fileCount ?? null,
+      implFiles: result?.magnitude?.implFiles ?? null,
+      implLines: result?.magnitude?.implLines ?? null,
+      ceilings: result?.ceilings ?? null,
+      classes: result?.classes ?? [],
+    },
+  });
+  return buildRecycleCommand(storyId);
+}
+
+/**
+ * Record a light-path scope rejection as friction.
+ *
+ * Total: never throws, and returns `false` rather than propagating when the
+ * signals surface is unavailable.
+ *
+ * @param {{
+ *   storyId?: number|null,
+ *   surface: string,
+ *   reasons?: string[],
+ *   details?: object,
+ *   emitFn?: typeof emitRuntimeFriction,
+ * }} args
+ * @returns {Promise<boolean>}
+ */
+export async function recordScopeFriction({
+  storyId,
+  surface,
+  reasons = [],
+  details = {},
+  emitFn = emitRuntimeFriction,
+} = {}) {
+  try {
+    return await emitFn({
+      storyId,
+      category: RUNTIME_FRICTION_CATEGORIES.LIGHT_SCOPE_REJECTED,
+      tool: 'deliver-light',
+      details: { surface, reasons, ...details },
+    });
+  } catch {
+    return false;
+  }
+}

--- a/.agents/scripts/lib/orchestration/light-suitability.js
+++ b/.agents/scripts/lib/orchestration/light-suitability.js
@@ -36,9 +36,13 @@
  *      Under `--yes` (unattended) it fails closed to recommending `/plan`.
  *   3. **Diff-derived backstop ({@link checkLightDiffBackstop}).** After
  *      implementation the **actual** change set is re-checked with
- *      {@link module:lib/orchestration/review-depth.deriveChangeLevel} plus a
- *      file-count ceiling — the diff is the real scope signal — and an
- *      over-ceiling diff is blocked rather than landed silently.
+ *      {@link module:lib/orchestration/review-depth.deriveChangeLevel} plus the
+ *      implementation-only magnitude ceilings of {@link LIGHT_DIFF_CEILINGS} —
+ *      the diff is the real scope signal — and an over-ceiling diff is blocked
+ *      rather than landed silently. Story #4856 moved this from a `maxFiles: 4`
+ *      cardinality ceiling to changed lines over implementation files, and made
+ *      a block **recycle** its receipt Story through `/plan` tickets mode
+ *      instead of orphaning it.
  *   4. **Minimal receipt Story ({@link buildReceiptStoryTicket}).** A
  *      `type::story` ticket is authored inline so `refs #`, history, telemetry,
  *      and the `agent::executing -> agent::done` state machine survive.
@@ -79,33 +83,67 @@ export const OVERRIDABLE_SHAPE_CODES = Object.freeze([
 ]);
 
 /**
- * File-count ceiling for the **actual landed** change set the diff backstop
- * ({@link checkLightDiffBackstop}) enforces. This is the light path's **only**
- * cardinality ceiling, and deliberately so (Story #4764): the predicted
- * footprint is a declaration — a guess, and a gameable one — so the gate that
- * counts must be the one reading ground truth. A genuinely-light change stays
- * small; conservative by construction, since a ceiling an operator could widen
- * past what a single session safely absorbs is a ceiling that fails silently.
- * A framework constant, not a knob.
+ * Ceilings for the **actual landed** change set the diff backstop
+ * ({@link checkLightDiffBackstop}) enforces, measured on the change's
+ * implementation half (Story #4856 — see
+ * {@link module:lib/orchestration/diff-magnitude} for the measured case and the
+ * companion-class boundary).
+ *
+ * The backstop reads ground truth, so it is where size is genuinely enforced;
+ * the prediction gate above it is a declaration and stays coarse (Story #4764).
+ * What changed is the **axis**: this used to be `maxFiles: 4`, a cardinality
+ * ceiling that rejected 79% of this repository's real merged work while passing
+ * a three-file 323-line rewrite.
+ *
+ *   - `maxImplLines` — additions plus deletions across implementation files.
+ *                      Simulated over 41 merges, 1000 admits 83% of real work
+ *                      and rejects exactly the genuinely large changes.
+ *   - `maxImplFiles` — implementation files touched, a *sprawl* tripwire rather
+ *                      than a size gate. Set to `DEFAULT_DIFF_WIDTH.softFiles`
+ *                      so the light path and `review-depth.js` stop holding two
+ *                      different definitions of a narrow diff.
+ *
+ * Framework constants, not knobs: a ceiling an operator could widen past what a
+ * single session safely absorbs is a ceiling that fails silently.
  */
 export const LIGHT_DIFF_CEILINGS = Object.freeze({
-  maxFiles: 4,
+  maxImplLines: 1000,
+  maxImplFiles: 15,
 });
 
 /**
- * Coerce a candidate `maxFiles` ceiling into a positive integer, falling back
- * to the framework default for anything malformed — a stray `0`, `-1`, or `NaN`
- * must never widen (or zero out) the light diff ceiling.
+ * Coerce a candidate ceiling into a positive integer, falling back to the
+ * framework default for anything malformed — a stray `0`, `-1`, or `NaN` must
+ * never widen (or zero out) a light diff ceiling.
  *
  * @param {unknown} value
  * @param {number} fallback
  * @returns {number}
  */
-function normalizeMaxFiles(value, fallback) {
+function normalizeCeiling(value, fallback) {
   if (typeof value !== 'number' || !Number.isFinite(value) || value < 1) {
     return fallback;
   }
   return Math.floor(value);
+}
+
+/**
+ * Resolve the effective diff ceilings from a caller-supplied partial override.
+ *
+ * @param {{ maxImplLines?: unknown, maxImplFiles?: unknown }} [ceilings]
+ * @returns {{ maxImplLines: number, maxImplFiles: number }}
+ */
+function resolveDiffCeilings(ceilings) {
+  return {
+    maxImplLines: normalizeCeiling(
+      ceilings?.maxImplLines,
+      LIGHT_DIFF_CEILINGS.maxImplLines,
+    ),
+    maxImplFiles: normalizeCeiling(
+      ceilings?.maxImplFiles,
+      LIGHT_DIFF_CEILINGS.maxImplFiles,
+    ),
+  };
 }
 
 /**
@@ -389,11 +427,23 @@ export function resolveLightGateOutcome({
 }
 
 /**
- * Diff-derived backstop (Story #4740 AC-4): re-check the **actual** change set
- * after implementation, because the diff — not the prompt — is the real scope
- * signal. Blocks (rather than landing) when the diff intersects a sensitive-
- * path class, exceeds the file-count ceiling, or cannot be classified. A clean
- * result is the only path that lands light.
+ * Diff-derived backstop (Story #4740 AC-4, re-based on magnitude by Story
+ * #4856): re-check the **actual** change set after implementation, because the
+ * diff — not the prompt — is the real scope signal. Blocks (rather than landing)
+ * when the diff intersects a sensitive-path class, exceeds an implementation
+ * ceiling, or cannot be measured. A clean result is the only path that lands
+ * light.
+ *
+ * Two inputs, two different scopes, and the difference is load-bearing:
+ *
+ *   - `changedFiles` is the **full** change set, companions included, and is
+ *     what sensitive-path derivation reads. Exempting a companion from the
+ *     *count* must never exempt it from *risk* — a test file under a registered
+ *     sensitive class still blocks.
+ *   - `magnitude` is the implementation-only summary from
+ *     {@link module:lib/orchestration/diff-magnitude.summarizeDiffMagnitude}.
+ *     `null` means the magnitude could not be measured, which blocks: absence
+ *     of evidence is not evidence the diff is small.
  *
  * Reuses close's own {@link module:lib/orchestration/review-depth.deriveChangeLevel}
  * — one taxonomy, applied to the predicted shape at the gate and the actual
@@ -403,7 +453,8 @@ export function resolveLightGateOutcome({
  *
  * @param {{
  *   changedFiles?: unknown,
- *   ceilings?: { maxFiles?: number },
+ *   magnitude?: { implFiles?: number, implLines?: number }|null,
+ *   ceilings?: { maxImplLines?: number, maxImplFiles?: number },
  *   injectedRules?: object,
  *   selectSensitivePathClassesFn?: Function,
  * }} [args]
@@ -412,20 +463,19 @@ export function resolveLightGateOutcome({
  *   level: 'low'|'high'|null,
  *   classes: string[],
  *   fileCount: number|null,
- *   ceilings: { maxFiles: number },
+ *   magnitude: { implFiles: number, implLines: number }|null,
+ *   ceilings: { maxImplLines: number, maxImplFiles: number },
  *   reasons: string[],
  * }}
  */
 export function checkLightDiffBackstop({
   changedFiles,
+  magnitude,
   ceilings,
   injectedRules,
   selectSensitivePathClassesFn,
 } = {}) {
-  const maxFiles = normalizeMaxFiles(
-    ceilings?.maxFiles,
-    LIGHT_DIFF_CEILINGS.maxFiles,
-  );
+  const resolved = resolveDiffCeilings(ceilings);
   const files = Array.isArray(changedFiles)
     ? changedFiles.filter((f) => typeof f === 'string' && f.trim() !== '')
     : null;
@@ -436,7 +486,8 @@ export function checkLightDiffBackstop({
       level: null,
       classes: [],
       fileCount: files === null ? null : 0,
-      ceilings: { maxFiles },
+      magnitude: null,
+      ceilings: resolved,
       reasons: [
         'actual change set is unknown or empty — cannot verify the diff is light; escalate to /plan',
       ],
@@ -448,23 +499,12 @@ export function checkLightDiffBackstop({
     injectedRules,
     selectSensitivePathClassesFn,
   });
+  const measured = normalizeMagnitude(magnitude);
 
-  const reasons = [];
-  if (classes.length > 0) {
-    reasons.push(
-      `diff intersects sensitive-path class(es) ${classes.join(', ')} — escalate to /plan (do not land light)`,
-    );
-  }
-  if (files.length > maxFiles) {
-    reasons.push(
-      `diff touches ${files.length} file(s) (> maxFiles ${maxFiles}) — escalate to /plan (do not land light)`,
-    );
-  }
-  if (level !== 'low' && classes.length === 0) {
-    reasons.push(
-      'sensitive-path classification unavailable — cannot verify the diff is non-sensitive; escalate to /plan',
-    );
-  }
+  const reasons = [
+    ...describeSensitivity({ level, classes }),
+    ...describeMagnitude(measured, resolved),
+  ];
 
   const blocked = reasons.length > 0;
   return {
@@ -472,13 +512,78 @@ export function checkLightDiffBackstop({
     level,
     classes,
     fileCount: files.length,
-    ceilings: { maxFiles },
+    magnitude: measured,
+    ceilings: resolved,
     reasons: blocked
       ? reasons
       : [
-          `diff is light: ${files.length} file(s) ≤ ${maxFiles}, no sensitive-path class — safe to land`,
+          `diff is light: ${measured.implLines} implementation line(s) ≤ ${resolved.maxImplLines} ` +
+            `across ${measured.implFiles} implementation file(s) ≤ ${resolved.maxImplFiles} ` +
+            `(${files.length} file(s) total, companions exempt), no sensitive-path class — safe to land`,
         ],
   };
+}
+
+/**
+ * Coerce a magnitude summary into non-negative integer counts, or `null` when
+ * it was not measurable. Pure.
+ *
+ * @param {unknown} magnitude
+ * @returns {{ implFiles: number, implLines: number }|null}
+ */
+function normalizeMagnitude(magnitude) {
+  const implFiles = magnitude?.implFiles;
+  const implLines = magnitude?.implLines;
+  if (!Number.isFinite(implFiles) || !Number.isFinite(implLines)) return null;
+  if (implFiles < 0 || implLines < 0) return null;
+  return { implFiles: Math.floor(implFiles), implLines: Math.floor(implLines) };
+}
+
+/**
+ * Sensitivity objections, over the **full** change set. Pure.
+ *
+ * @param {{ level: 'low'|'high'|null, classes: string[] }} derived
+ * @returns {string[]}
+ */
+function describeSensitivity({ level, classes }) {
+  if (classes.length > 0) {
+    return [
+      `diff intersects sensitive-path class(es) ${classes.join(', ')} — escalate to /plan (do not land light)`,
+    ];
+  }
+  if (level !== 'low') {
+    return [
+      'sensitive-path classification unavailable — cannot verify the diff is non-sensitive; escalate to /plan',
+    ];
+  }
+  return [];
+}
+
+/**
+ * Magnitude objections, over the implementation half only. Pure.
+ *
+ * @param {{ implFiles: number, implLines: number }|null} measured
+ * @param {{ maxImplLines: number, maxImplFiles: number }} ceilings
+ * @returns {string[]}
+ */
+function describeMagnitude(measured, ceilings) {
+  if (measured === null) {
+    return [
+      'change magnitude could not be measured (unreadable or unparseable numstat) — cannot verify the diff is light; escalate to /plan',
+    ];
+  }
+  const reasons = [];
+  if (measured.implLines > ceilings.maxImplLines) {
+    reasons.push(
+      `diff changes ${measured.implLines} implementation line(s) (> maxImplLines ${ceilings.maxImplLines}) — escalate to /plan (do not land light)`,
+    );
+  }
+  if (measured.implFiles > ceilings.maxImplFiles) {
+    reasons.push(
+      `diff spans ${measured.implFiles} implementation file(s) (> maxImplFiles ${ceilings.maxImplFiles}) — escalate to /plan (do not land light)`,
+    );
+  }
+  return reasons;
 }
 
 /** Cap on a receipt slug's length — keep the branch/id readable. */

--- a/.agents/scripts/lib/orchestration/plan-context.js
+++ b/.agents/scripts/lib/orchestration/plan-context.js
@@ -379,14 +379,21 @@ function resolveRiskHeuristics(config = {}) {
  * this one screens a seed, that one decides. Collapsing them would make a
  * confirm a bypass.
  *
- *   - `maxArtifacts`           — enumerated seed items (one artifact each).
+ * **Risk only, never cardinality (Story #4856).** This carried a
+ * `maxArtifacts: 2` ceiling — the second surviving artifact count after Story
+ * #4764 retired the axis from the routing gate, and the more misleading of the
+ * two, because the artifacts it counted were **paths scraped from seed prose**
+ * rather than a measured footprint. Observed on the seed that produced Story
+ * #4856: a change spanning four framework modules was suggested as light off
+ * two scraped paths, one of which did not exist at the scraped location. A count
+ * of guesses is not a size signal, so the screen now keys on risk alone.
+ *
  *   - `maxRiskHeuristicHits`   — any risk-heuristic hit disqualifies: risk
  *                                is exactly what a light path should not carry.
  *   - `maxSensitivePathClasses`— any sensitive-path class disqualifies, the
  *                                same taxonomy close applies to a landed diff.
  */
 const DELIVER_LIGHT_SUGGESTION_CEILINGS = Object.freeze({
-  maxArtifacts: 2,
   maxRiskHeuristicHits: 0,
   maxSensitivePathClasses: 0,
 });
@@ -413,9 +420,6 @@ export function buildDeliverLightSuggestion(complexitySignals) {
   const advisory = /** @type {const} */ (true);
   const automatic = /** @type {const} */ (false);
   const s = complexitySignals ?? {};
-  const artifactCount = Number.isInteger(s.artifactCount)
-    ? s.artifactCount
-    : Number.POSITIVE_INFINITY;
   const riskHits = Array.isArray(s.riskHeuristicHits)
     ? s.riskHeuristicHits.length
     : Number.POSITIVE_INFINITY;
@@ -424,11 +428,6 @@ export function buildDeliverLightSuggestion(complexitySignals) {
     : Number.POSITIVE_INFINITY;
 
   const reasons = [];
-  if (artifactCount > ceilings.maxArtifacts) {
-    reasons.push(
-      `seed enumerates ${artifactCount} artifacts (> ${ceilings.maxArtifacts})`,
-    );
-  }
   if (riskHits > ceilings.maxRiskHeuristicHits) {
     reasons.push(`seed hits ${riskHits} risk-heuristic phrase(s)`);
   }
@@ -446,9 +445,9 @@ export function buildDeliverLightSuggestion(complexitySignals) {
     ceilings,
     reasons: suggested
       ? [
-          `seed fits the light-path ceilings (≤${ceilings.maxArtifacts} artifacts, ` +
-            'no risk-heuristic hits, no sensitive-path classes) — the operator ' +
-            'may prefer /deliver for this scope',
+          'seed carries no risk signal (no risk-heuristic hits, no ' +
+            'sensitive-path classes) — the operator may prefer /deliver for ' +
+            "this scope; the light path's own gate and diff backstop decide size",
         ]
       : reasons,
   };

--- a/.agents/workflows/helpers/deliver-light.md
+++ b/.agents/workflows/helpers/deliver-light.md
@@ -48,6 +48,11 @@ Because the predicted footprint is a *declaration* — a guess, and a gameable o
 multi-capability enumeration). Size is enforced where ground truth is available:
 the diff backstop in step 4. Do not talk yourself past that one.
 
+**The backstop counts by the same principle.** It reads magnitude — changed
+lines over implementation files — not artifacts, and exempts the test and doc
+companions the framework itself mandates. A ceiling that punishes a repo for
+obeying its own test-first rule is a ceiling that over-fires.
+
 Sensitivity is the exception and stays absolute: a footprint touching an auth,
 crypto, billing, or migration class routes `full` however small or mechanical —
 and unlike a ceiling, it is **not overridable** (§ Recording a proceed-light
@@ -136,10 +141,22 @@ answer).
    node .agents/scripts/deliver-light.js --backstop --story <storyId>
    ```
 
-   Exit `3` (`blocked: true`) means the landed diff exceeds the light ceilings
-   (file count or a sensitive-path class). STOP, flip `agent::blocked`, and
-   escalate to `/plan` — do not land. This is the pass that actually bounds
-   size, which is why the prediction gate above can afford to be coarse.
+   This is the pass that actually bounds size, which is why the prediction gate
+   above can afford to be coarse. It measures **magnitude on the change's
+   implementation half** — changed lines (additions + deletions) plus a file
+   sprawl tripwire — never raw artifact count. Tests, `docs/**`, `**/*.md`,
+   `baselines/**`, and lockfiles are exempt from the counts, because the
+   framework mandates those companions and obeying it must not inflate the
+   number that then rejects the change. They are **not** exempt from
+   sensitive-path matching, which runs over the full change set.
+
+   Exit `3` (`blocked: true`) means the diff exceeds a light ceiling or touches a
+   sensitive-path class. STOP, flip `agent::blocked`, and **recycle the receipt**
+   through the envelope's `nextCommand` (`/plan <storyId>`) — tickets mode
+   rewrites it into properly-planned Stories and closes it as superseded. Do not
+   land, and do not leave the receipt open with no successor: it already carries
+   the branch, the worktree, and the implementation, all of which are evidence
+   the plan should read.
 
 5. **Close and land (same engine).** Exactly [`/deliver`](../deliver.md)'s close:
 

--- a/tests/lib/orchestration/diff-magnitude.test.js
+++ b/tests/lib/orchestration/diff-magnitude.test.js
@@ -1,0 +1,277 @@
+// tests/lib/orchestration/diff-magnitude.test.js
+//
+// Unit tier (Story #4856): the changed-line magnitude of a diff, split into
+// implementation and mandated-companion halves. This is the measurement the
+// light path's diff backstop replaced a `maxFiles: 4` cardinality ceiling with,
+// so the suite pins the three contracts that make the replacement sound:
+//
+//   - additions + deletions, never net (a large deletion must not read small);
+//   - the companion boundary — what is exempt from the counts, and critically
+//     what is NOT, since exempting behavior-bearing config would let a change
+//     widen the very allowlist that decides whether it is risky;
+//   - a rename is free, and an unparseable numstat is `null` rather than 0.
+//
+// The module exports exactly two functions. The parse, the rename
+// normalization, and the companion classifier are internal and are driven here
+// through those two — a stubbed `gitSpawnFn` for the parse, the `isCompanionFn`
+// seam for classification — rather than by widening the module's surface to
+// satisfy a test.
+
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import test, { describe } from 'node:test';
+import { fileURLToPath } from 'node:url';
+import {
+  readNumstatRows,
+  summarizeDiffMagnitude,
+} from '../../../.agents/scripts/lib/orchestration/diff-magnitude.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, '..', '..', '..');
+
+/** Drive the internal parse by stubbing the one git read. */
+const parseVia = (stdout, status = 0) =>
+  readNumstatRows({
+    baseRef: 'main',
+    headRef: 'story-1',
+    gitSpawnFn: () => ({ status, stdout }),
+  });
+
+const rowsOf = (...triples) =>
+  triples.map(([additions, deletions, path]) => ({
+    additions,
+    deletions,
+    path,
+  }));
+
+describe('readNumstatRows — per-file rows, or null when untrustworthy', () => {
+  test('parses additions, deletions, and path', () => {
+    assert.deepEqual(parseVia('10\t5\ta.js\n1\t0\tb.js\n'), [
+      { additions: 10, deletions: 5, path: 'a.js' },
+      { additions: 1, deletions: 0, path: 'b.js' },
+    ]);
+  });
+
+  test('a binary row contributes zero without poisoning the parse', () => {
+    assert.deepEqual(parseVia('-\t-\timg.png\n4\t2\ta.js\n'), [
+      { additions: 0, deletions: 0, path: 'img.png' },
+      { additions: 4, deletions: 2, path: 'a.js' },
+    ]);
+  });
+
+  test('an empty diff is an empty row list, NOT null', () => {
+    // Zero is a fact; null is the absence of evidence. Callers fail closed on
+    // the latter, so conflating them would block every empty diff as unknown.
+    assert.deepEqual(parseVia(''), []);
+  });
+
+  test('unparseable output is null', () => {
+    for (const bad of ['garbage', 'x\ty\tz.js']) {
+      assert.equal(parseVia(bad), null, bad);
+    }
+  });
+
+  test('a rename resolves to its destination, and costs nothing', () => {
+    assert.deepEqual(parseVia('0\t0\tlib/{old => new}/file.js\n'), [
+      { additions: 0, deletions: 0, path: 'lib/new/file.js' },
+    ]);
+    assert.deepEqual(parseVia('0\t0\told.js => new.js\n'), [
+      { additions: 0, deletions: 0, path: 'new.js' },
+    ]);
+  });
+
+  test('passes the three-dot range to git', () => {
+    let args;
+    readNumstatRows({
+      baseRef: 'main',
+      headRef: 'story-1',
+      gitSpawnFn: (...rest) => {
+        args = rest;
+        return { status: 0, stdout: '' };
+      },
+    });
+    assert.deepEqual(args.slice(1), ['diff', '--numstat', 'main...story-1']);
+  });
+
+  test('null on a non-zero exit, a throw, or a missing ref', () => {
+    assert.equal(parseVia('3\t1\ta.js\n', 128), null);
+    assert.equal(
+      readNumstatRows({
+        baseRef: 'main',
+        headRef: 'story-1',
+        gitSpawnFn: () => {
+          throw new Error('spawn failed');
+        },
+      }),
+      null,
+    );
+    assert.equal(readNumstatRows({ headRef: 'story-1' }), null);
+    assert.equal(readNumstatRows({ baseRef: 'main' }), null);
+    assert.equal(readNumstatRows(), null);
+  });
+});
+
+describe('summarizeDiffMagnitude — the companion boundary', () => {
+  /** Summarize a single file, reporting whether it counted as implementation. */
+  const countsAsImplementation = (file) => {
+    const s = summarizeDiffMagnitude({
+      changedFiles: [file],
+      rows: rowsOf([10, 0, file]),
+    });
+    return s.implFiles === 1 && s.implLines === 10;
+  };
+
+  test('mandated companions are exempt from the counts', () => {
+    for (const file of [
+      'tests/lib/x.test.js',
+      'foo.test.js',
+      '.agents/scripts/lib/__tests__/x.js',
+      'features/login.feature',
+      'docs/onboarding.md',
+      'README.md',
+      '.agents/workflows/helpers/deliver-light.md',
+      'baselines/crap.json',
+      'baselines/agents-loc.csv',
+      'package-lock.json',
+    ]) {
+      assert.equal(countsAsImplementation(file), false, file);
+    }
+  });
+
+  test('behavior-bearing config is NOT exempt, however JSON it looks', () => {
+    // The load-bearing half of the boundary. audit-rules.json is the
+    // sensitive-path SSOT: exempting it would let a change widen the allowlist
+    // that decides whether that very change is risky.
+    for (const file of [
+      '.agentrc.json',
+      '.agents/schemas/audit-rules.json',
+      '.agents/schemas/agentrc.schema.json',
+      '.github/workflows/ci.yml',
+      'package.json',
+      '.agents/scripts/deliver-light.js',
+    ]) {
+      assert.equal(countsAsImplementation(file), true, file);
+    }
+  });
+
+  test('the baselines exemption is anchored at the repo root', () => {
+    // Generated baseline DATA is exempt; the baseline SCHEMAS are behavior.
+    assert.equal(
+      countsAsImplementation('baselines/maintainability.json'),
+      false,
+    );
+    assert.equal(
+      countsAsImplementation('.agents/schemas/baselines/coverage.schema.json'),
+      true,
+    );
+  });
+
+  test('the companion globs are positive — a ! negation would widen the match', () => {
+    // picomatch treats a leading `!` as negation, which WIDENS rather than
+    // narrows, so the behavior-bearing exceptions are expressed by omission.
+    // Pinned against the source because the list is deliberately not exported.
+    const src = readFileSync(
+      path.join(
+        REPO_ROOT,
+        '.agents',
+        'scripts',
+        'lib',
+        'orchestration',
+        'diff-magnitude.js',
+      ),
+      'utf8',
+    );
+    const list =
+      /const COMPANION_PATH_GLOBS = Object\.freeze\(\[([\s\S]*?)\]\)/.exec(src);
+    assert.ok(list, 'the companion glob list must be a frozen literal');
+    assert.doesNotMatch(list[1], /'!/);
+  });
+});
+
+describe('summarizeDiffMagnitude — implementation vs companion halves', () => {
+  test('splits lines and files by the companion boundary', () => {
+    const summary = summarizeDiffMagnitude({
+      changedFiles: ['src/a.js', 'tests/a.test.js', 'docs/x.md'],
+      rows: rowsOf(
+        [100, 20, 'src/a.js'],
+        [300, 10, 'tests/a.test.js'],
+        [50, 5, 'docs/x.md'],
+      ),
+    });
+    assert.deepEqual(summary, {
+      implFiles: 1,
+      implLines: 120,
+      companionFiles: 2,
+      companionLines: 365,
+      totalFiles: 3,
+    });
+  });
+
+  test('additions plus deletions, never net', () => {
+    // The trap this contract exists for: measured as net, a large deletion
+    // reads as trivial (the merge retiring the planner snapshot is +1119
+    // add+del but -803 net).
+    const summary = summarizeDiffMagnitude({
+      changedFiles: ['src/a.js'],
+      rows: rowsOf([8, 1111, 'src/a.js']),
+    });
+    assert.equal(summary.implLines, 1119);
+  });
+
+  test('a test-only change measures zero implementation lines', () => {
+    const files = Array.from({ length: 40 }, (_v, i) => `tests/g${i}.test.js`);
+    const summary = summarizeDiffMagnitude({
+      changedFiles: files,
+      rows: rowsOf(...files.map((f) => [200, 0, f])),
+    });
+    assert.equal(summary.implFiles, 0);
+    assert.equal(summary.implLines, 0);
+    assert.equal(summary.totalFiles, 40);
+  });
+
+  test('an empty diff summarizes to zero, not null', () => {
+    assert.deepEqual(summarizeDiffMagnitude({ changedFiles: [], rows: [] }), {
+      implFiles: 0,
+      implLines: 0,
+      companionFiles: 0,
+      companionLines: 0,
+      totalFiles: 0,
+    });
+  });
+
+  test('either input missing yields null — the magnitude is unknown', () => {
+    assert.equal(
+      summarizeDiffMagnitude({ changedFiles: ['a.js'], rows: null }),
+      null,
+    );
+    assert.equal(
+      summarizeDiffMagnitude({ changedFiles: null, rows: [] }),
+      null,
+    );
+    assert.equal(summarizeDiffMagnitude(), null);
+  });
+
+  test('blank and non-string file entries are dropped from the file tally', () => {
+    const summary = summarizeDiffMagnitude({
+      changedFiles: ['src/a.js', '', '   ', null, 7],
+      rows: rowsOf([1, 1, 'src/a.js']),
+    });
+    assert.equal(summary.implFiles, 1);
+    assert.equal(summary.totalFiles, 1);
+  });
+
+  test('a throwing classifier counts everything as implementation, never less', () => {
+    // The conservative direction: a classification failure must never shrink
+    // the measured magnitude.
+    const summary = summarizeDiffMagnitude({
+      changedFiles: ['tests/a.test.js'],
+      rows: rowsOf([50, 0, 'tests/a.test.js']),
+      isCompanionFn: () => {
+        throw new Error('boom');
+      },
+    });
+    assert.equal(summary.implFiles, 1);
+    assert.equal(summary.implLines, 50);
+  });
+});

--- a/tests/lib/orchestration/light-suitability.test.js
+++ b/tests/lib/orchestration/light-suitability.test.js
@@ -50,15 +50,14 @@ import {
   buildPredictedChanges,
   createLightReceipt,
   parseCsvPaths,
-  runDiffBackstop,
   runGateMode,
   runLightGate,
   synthesizeAcceptance,
 } from '../../../.agents/scripts/deliver-light.js';
+import { resolveBackstopOutcome } from '../../../.agents/scripts/lib/orchestration/light-backstop.js';
 import {
-  buildRecycleCommand,
-  normalizeAmendsId,
-  recordScopeFriction,
+  handleBlockedBackstop,
+  recordGateRefusal,
 } from '../../../.agents/scripts/lib/orchestration/light-escalation.js';
 import {
   buildReceiptStoryTicket,
@@ -668,9 +667,21 @@ const rowsOf = (...triples) =>
     path,
   }));
 
-describe('runDiffBackstop — re-checks the ACTUAL branch diff (AC-4)', () => {
-  test('a clean small diff is not blocked', () => {
-    const r = runDiffBackstop({
+/**
+ * Drive the backstop pass through its public entry point, which forwards the
+ * git seams to the internal run. Returns the verdict.
+ */
+const backstop = async (args) =>
+  (
+    await resolveBackstopOutcome({
+      handleBlockedFn: async () => '/plan x',
+      ...args,
+    })
+  ).result;
+
+describe('the backstop pass re-checks the ACTUAL branch diff (AC-4)', () => {
+  test('a clean small diff is not blocked', async () => {
+    const r = await backstop({
       storyId: 4741,
       injectedRules: RULES,
       computeFn: () => ({ files: ['bin/hello.js'] }),
@@ -680,8 +691,8 @@ describe('runDiffBackstop — re-checks the ACTUAL branch diff (AC-4)', () => {
     assert.deepEqual(r.magnitude, { implFiles: 1, implLines: 24 });
   });
 
-  test('an over-magnitude diff is blocked', () => {
-    const r = runDiffBackstop({
+  test('an over-magnitude diff is blocked', async () => {
+    const r = await backstop({
       storyId: 4741,
       injectedRules: RULES,
       computeFn: () => ({ files: ['a.js', 'b.js'] }),
@@ -691,8 +702,8 @@ describe('runDiffBackstop — re-checks the ACTUAL branch diff (AC-4)', () => {
     assert.match(r.reasons.join(' '), /maxImplLines/);
   });
 
-  test('a sensitive-path diff is blocked whatever its magnitude', () => {
-    const r = runDiffBackstop({
+  test('a sensitive-path diff is blocked whatever its magnitude', async () => {
+    const r = await backstop({
       storyId: 4741,
       injectedRules: RULES,
       computeFn: () => ({ files: ['src/auth/a.js'] }),
@@ -701,8 +712,8 @@ describe('runDiffBackstop — re-checks the ACTUAL branch diff (AC-4)', () => {
     assert.equal(r.blocked, true);
   });
 
-  test('an unenumerable diff (files: null) is blocked', () => {
-    const r = runDiffBackstop({
+  test('an unenumerable diff (files: null) is blocked', async () => {
+    const r = await backstop({
       storyId: 4741,
       computeFn: () => ({ files: null }),
       readRowsFn: () => rowsOf([1, 1, 'a.js']),
@@ -710,8 +721,8 @@ describe('runDiffBackstop — re-checks the ACTUAL branch diff (AC-4)', () => {
     assert.equal(r.blocked, true);
   });
 
-  test('Story #4856: an unreadable numstat (rows: null) is blocked', () => {
-    const r = runDiffBackstop({
+  test('Story #4856: an unreadable numstat (rows: null) is blocked', async () => {
+    const r = await backstop({
       storyId: 4741,
       injectedRules: RULES,
       computeFn: () => ({ files: ['bin/hello.js'] }),
@@ -721,9 +732,9 @@ describe('runDiffBackstop — re-checks the ACTUAL branch diff (AC-4)', () => {
     assert.match(r.reasons.join(' '), /could not be measured/);
   });
 
-  test('Story #4856: both git surfaces are read against the same refs', () => {
+  test('Story #4856: both git surfaces are read against the same refs', async () => {
     const seen = [];
-    runDiffBackstop({
+    await backstop({
       storyId: 4741,
       baseRef: 'main',
       injectedRules: RULES,
@@ -1566,11 +1577,19 @@ describe('the workflow tells the agent how to act on the answer (AC-8)', () => {
 // ---------------------------------------------------------------------------
 
 describe('a blocked backstop recycles the receipt Story (Story #4856)', () => {
-  test('the recycle command hands the receipt to /plan tickets mode', () => {
+  test('the recycle command hands the receipt to /plan tickets mode', async () => {
     // Tickets mode already rewrites a ticket into planned Stories and closes it
     // as superseded — so the receipt becomes the plan's INPUT rather than an
     // open issue with no successor.
-    assert.equal(buildRecycleCommand(4741), '/plan 4741');
+    const next = await handleBlockedBackstop({
+      storyId: 4741,
+      result: {
+        reasons: ['too big'],
+        magnitude: { implFiles: 9, implLines: 4000 },
+      },
+      emitFn: async () => true,
+    });
+    assert.equal(next, '/plan 4741');
   });
 
   test('the CLI emits the recycle nextCommand on a blocked backstop', () => {
@@ -1586,9 +1605,9 @@ describe('a blocked backstop recycles the receipt Story (Story #4856)', () => {
     assert.equal(envelope.nextCommand, '/plan 999999');
   });
 
-  test('a clean backstop carries no recycle command', () => {
+  test('a clean backstop carries no recycle command', async () => {
     // Nothing to recycle when nothing was refused.
-    const r = runDiffBackstop({
+    const r = await backstop({
       storyId: 4741,
       injectedRules: RULES,
       computeFn: () => ({ files: ['bin/hello.js'] }),
@@ -1626,67 +1645,102 @@ describe('a blocked backstop recycles the receipt Story (Story #4856)', () => {
 describe('light-path rejections are telemetered (Story #4856)', () => {
   test('a scope rejection emits one light-scope-rejected friction signal', async () => {
     const seen = [];
-    const ok = await recordScopeFriction({
+    const next = await handleBlockedBackstop({
       storyId: 4741,
-      surface: 'diff-backstop',
-      reasons: ['too big'],
-      details: { implLines: 4000 },
+      result: {
+        reasons: ['too big'],
+        fileCount: 20,
+        magnitude: { implFiles: 9, implLines: 4000 },
+        ceilings: { maxImplLines: 1000, maxImplFiles: 15 },
+        classes: [],
+      },
       emitFn: async (args) => {
         seen.push(args);
         return true;
       },
     });
-    assert.equal(ok, true);
+    assert.equal(next, '/plan 4741');
     assert.equal(seen.length, 1);
     assert.equal(seen[0].category, 'light-scope-rejected');
     assert.equal(seen[0].tool, 'deliver-light');
+    assert.equal(seen[0].storyId, 4741);
     assert.equal(seen[0].details.surface, 'diff-backstop');
     assert.equal(seen[0].details.implLines, 4000);
+    assert.equal(seen[0].details.implFiles, 9);
   });
 
   test('telemetry never changes the verdict — a throwing emitter is swallowed', async () => {
-    const ok = await recordScopeFriction({
+    const next = await handleBlockedBackstop({
       storyId: 4741,
-      surface: 'diff-backstop',
+      result: { reasons: ['too big'] },
       emitFn: async () => {
         throw new Error('signals unwritable');
       },
     });
-    assert.equal(ok, false);
+    assert.equal(next, '/plan 4741');
   });
 
-  test('an ask-operator gate records the rejection, attributed to --amends when present', async () => {
+  test('an ask-operator gate hands the refusal to the recorder', async () => {
     const seen = [];
-    const values = {
-      prompt: 'rework the whole reporting pipeline end to end',
-      refactors: 'apps/api/x.js,apps/web/y.js',
-      acceptance: '1',
-      route: 'lite',
-      reason: 'claims small but is not',
+    const code = await runGateMode(
+      {
+        prompt: 'rework the whole reporting pipeline end to end',
+        refactors: 'apps/api/x.js,apps/web/y.js',
+        acceptance: '1',
+        route: 'lite',
+        reason: 'claims small but is not',
+        amends: '#4321',
+      },
+      {
+        emitFn: () => {},
+        recordRefusalFn: async (args) => {
+          seen.push(args);
+          return true;
+        },
+      },
+    );
+    assert.equal(code, 2);
+    assert.equal(seen.length, 1);
+    assert.equal(seen[0].gate.action, 'ask-operator');
+    assert.equal(seen[0].amends, '#4321');
+  });
+
+  test('the recorder attributes a gate refusal to the --amends Story', async () => {
+    const seen = [];
+    await recordGateRefusal({
+      gate: {
+        action: 'ask-operator',
+        outcome: { reasons: ['too big'] },
+        suitability: { shape: { code: 'deployable-span' } },
+      },
       amends: '#4321',
-    };
-    const code = await runGateMode(values, {
-      emitFn: () => {},
       recordFrictionFn: async (args) => {
         seen.push(args);
         return true;
       },
     });
-    assert.equal(code, 2);
     assert.equal(seen.length, 1);
-    assert.equal(seen[0].surface, 'suitability-gate');
     assert.equal(seen[0].storyId, 4321);
+    assert.equal(seen[0].surface, 'suitability-gate');
     assert.equal(seen[0].details.action, 'ask-operator');
+    assert.equal(seen[0].details.code, 'deployable-span');
   });
 
-  test('a bare prompt has no Story context to attribute a signal to', () => {
+  test('a bare prompt has no Story context to attribute a signal to', async () => {
     // Deliberate: the ask-operator path creates no receipt, and the signals
     // stream is keyed on a Story id. Attributing it to a fabricated id would be
     // worse than recording nothing.
-    assert.equal(normalizeAmendsId(undefined), null);
-    assert.equal(normalizeAmendsId('#12'), 12);
-    assert.equal(normalizeAmendsId('12'), 12);
-    assert.equal(normalizeAmendsId('nonsense'), null);
-    assert.equal(normalizeAmendsId('0'), null);
+    const attributions = [];
+    for (const amends of [undefined, '#12', '12', 'nonsense', '0']) {
+      await recordGateRefusal({
+        gate: { action: 'ask-operator', outcome: { reasons: [] } },
+        amends,
+        emitFn: async (args) => {
+          attributions.push(args.storyId);
+          return true;
+        },
+      });
+    }
+    assert.deepEqual(attributions, [null, 12, 12, null, null]);
   });
 });

--- a/tests/lib/orchestration/light-suitability.test.js
+++ b/tests/lib/orchestration/light-suitability.test.js
@@ -56,6 +56,11 @@ import {
   synthesizeAcceptance,
 } from '../../../.agents/scripts/deliver-light.js';
 import {
+  buildRecycleCommand,
+  normalizeAmendsId,
+  recordScopeFriction,
+} from '../../../.agents/scripts/lib/orchestration/light-escalation.js';
+import {
   buildReceiptStoryTicket,
   checkLightDiffBackstop,
   deriveLightSuitability,
@@ -65,6 +70,7 @@ import {
   resolveLightGateOutcome,
   resolveOperatorOverride,
 } from '../../../.agents/scripts/lib/orchestration/light-suitability.js';
+import { DEFAULT_DIFF_WIDTH } from '../../../.agents/scripts/lib/orchestration/review-depth.js';
 import {
   TERMINAL_BEGIN_MARKER,
   TERMINAL_END_MARKER,
@@ -299,10 +305,14 @@ describe('resolveLightGateOutcome — over-scope STOPS and asks (AC-3)', () => {
 // checkLightDiffBackstop (AC-4) — the actual diff is the real scope signal
 // ---------------------------------------------------------------------------
 
-describe('checkLightDiffBackstop — blocks over-ceiling actual diffs (AC-4)', () => {
+/** A measured magnitude summary, the shape summarizeDiffMagnitude returns. */
+const magnitudeOf = (implFiles, implLines) => ({ implFiles, implLines });
+
+describe('checkLightDiffBackstop — blocks over-magnitude actual diffs (AC-4)', () => {
   test('a small non-sensitive diff is not blocked', () => {
     const r = checkLightDiffBackstop({
       changedFiles: ['bin/hello.js', 'tests/hello.test.js'],
+      magnitude: magnitudeOf(1, 40),
       injectedRules: RULES,
     });
     assert.equal(r.blocked, false);
@@ -310,22 +320,65 @@ describe('checkLightDiffBackstop — blocks over-ceiling actual diffs (AC-4)', (
     assert.equal(r.fileCount, 2);
   });
 
-  test('a diff exceeding the file-count ceiling is blocked', () => {
-    const files = Array.from(
-      { length: LIGHT_DIFF_CEILINGS.maxFiles + 1 },
-      (_v, i) => `src/mod${i}.js`,
-    );
+  test('Story #4856: a wide-but-shallow diff lands; a narrow-but-deep one does not', () => {
+    // The inversion the retired maxFiles ceiling produced, both directions.
+    // Twelve implementation files at 900 lines is real work a single session
+    // absorbs; six files at 3712 lines is not, however few files it touches.
+    const wide = checkLightDiffBackstop({
+      changedFiles: Array.from({ length: 12 }, (_v, i) => `src/mod${i}.js`),
+      magnitude: magnitudeOf(12, 900),
+      injectedRules: RULES,
+    });
+    assert.equal(wide.blocked, false);
+
+    const deep = checkLightDiffBackstop({
+      changedFiles: Array.from({ length: 6 }, (_v, i) => `src/mod${i}.js`),
+      magnitude: magnitudeOf(6, 3712),
+      injectedRules: RULES,
+    });
+    assert.equal(deep.blocked, true);
+    assert.match(deep.reasons.join(' '), /maxImplLines/);
+  });
+
+  test('Story #4856: companion churn cannot push a small change over — 40 test files, 8000 lines', () => {
+    // The 190-file merge that measured 47x over the old ceiling: 186 of those
+    // files were tests. Its implementation is one file.
     const r = checkLightDiffBackstop({
-      changedFiles: files,
+      changedFiles: [
+        'src/one.js',
+        ...Array.from({ length: 40 }, (_v, i) => `tests/gen${i}.test.js`),
+      ],
+      magnitude: magnitudeOf(1, 600),
+      injectedRules: RULES,
+    });
+    assert.equal(r.blocked, false);
+    assert.equal(r.fileCount, 41);
+  });
+
+  test('the implementation-file sprawl tripwire blocks genuine sprawl', () => {
+    const r = checkLightDiffBackstop({
+      changedFiles: Array.from({ length: 42 }, (_v, i) => `src/mod${i}.js`),
+      magnitude: magnitudeOf(42, 803),
       injectedRules: RULES,
     });
     assert.equal(r.blocked, true);
-    assert.match(r.reasons.join(' '), /maxFiles/);
+    assert.match(r.reasons.join(' '), /maxImplFiles/);
   });
 
   test('a diff intersecting a sensitive-path class is blocked', () => {
     const r = checkLightDiffBackstop({
       changedFiles: ['src/auth/session.js'],
+      magnitude: magnitudeOf(1, 3),
+      injectedRules: RULES,
+    });
+    assert.equal(r.blocked, true);
+    assert.deepEqual(r.classes, ['security']);
+  });
+
+  test('Story #4856: a COMPANION under a sensitive class still blocks — exemption is from counting, not risk', () => {
+    const r = checkLightDiffBackstop({
+      changedFiles: ['tests/auth/session.test.js', 'src/auth/session.js'],
+      magnitude: magnitudeOf(0, 0),
       injectedRules: RULES,
     });
     assert.equal(r.blocked, true);
@@ -334,8 +387,8 @@ describe('checkLightDiffBackstop — blocks over-ceiling actual diffs (AC-4)', (
 
   test('AC-4 (Story #4764): relaxing the PREDICTION gate cannot land oversized work', () => {
     // The same five same-kind files the prediction gate now admits: the
-    // backstop reads ground truth, so it still refuses to land them. This pair
-    // is the whole trade — coarse prediction, strict diff.
+    // backstop reads ground truth, so it still refuses to land them when their
+    // magnitude is genuinely large. Coarse prediction, measured diff.
     const files = ['a', 'b', 'c', 'd', 'e'].map((p) => `src/widgets/${p}.js`);
     assert.equal(
       deriveLightSuitability({
@@ -351,37 +404,72 @@ describe('checkLightDiffBackstop — blocks over-ceiling actual diffs (AC-4)', (
     );
     const backstop = checkLightDiffBackstop({
       changedFiles: files,
+      magnitude: magnitudeOf(5, 4000),
       injectedRules: RULES,
     });
     assert.equal(backstop.blocked, true);
-    assert.match(backstop.reasons.join(' '), /maxFiles/);
+    assert.match(backstop.reasons.join(' '), /maxImplLines/);
   });
 
   test('an empty or unknown change set is blocked (cannot verify light)', () => {
     for (const changedFiles of [[], null, undefined, 'x']) {
-      const r = checkLightDiffBackstop({ changedFiles });
+      const r = checkLightDiffBackstop({
+        changedFiles,
+        magnitude: magnitudeOf(1, 1),
+      });
       assert.equal(r.blocked, true);
     }
   });
 
+  test('Story #4856: an unmeasurable magnitude blocks — absence of evidence is not evidence of smallness', () => {
+    for (const magnitude of [null, undefined, {}, { implFiles: 1 }, 'x']) {
+      const r = checkLightDiffBackstop({
+        changedFiles: ['src/one.js'],
+        magnitude,
+        injectedRules: RULES,
+      });
+      assert.equal(r.blocked, true);
+      assert.match(r.reasons.join(' '), /could not be measured/);
+    }
+  });
+
   test('honors a caller ceiling but rejects a malformed one', () => {
-    const files = ['a.js', 'b.js', 'c.js'];
     assert.equal(
       checkLightDiffBackstop({
-        changedFiles: files,
-        ceilings: { maxFiles: 2 },
+        changedFiles: ['a.js', 'b.js', 'c.js'],
+        magnitude: magnitudeOf(3, 300),
+        ceilings: { maxImplLines: 200 },
         injectedRules: RULES,
       }).blocked,
       true,
     );
     // A malformed ceiling falls back to the framework default (not 0/∞).
-    assert.equal(
-      checkLightDiffBackstop({
-        changedFiles: files,
-        ceilings: { maxFiles: 0 },
+    for (const bad of [0, -1, Number.NaN, 'four', null]) {
+      const r = checkLightDiffBackstop({
+        changedFiles: ['a.js'],
+        magnitude: magnitudeOf(1, 10),
+        ceilings: { maxImplLines: bad, maxImplFiles: bad },
         injectedRules: RULES,
-      }).ceilings.maxFiles,
-      LIGHT_DIFF_CEILINGS.maxFiles,
+      });
+      assert.deepEqual(r.ceilings, {
+        maxImplLines: LIGHT_DIFF_CEILINGS.maxImplLines,
+        maxImplFiles: LIGHT_DIFF_CEILINGS.maxImplFiles,
+      });
+    }
+  });
+
+  test('Story #4856: cardinality is no longer an axis anywhere in the ceilings', () => {
+    assert.deepEqual(Object.keys(LIGHT_DIFF_CEILINGS).sort(), [
+      'maxImplFiles',
+      'maxImplLines',
+    ]);
+    assert.equal(LIGHT_DIFF_CEILINGS.maxFiles, undefined);
+    assert.equal(LIGHT_DIFF_CEILINGS.maxImplLines, 1000);
+    // Aligned with review-depth's own narrow-diff scale (DEFAULT_DIFF_WIDTH
+    // .softFiles) so the two stop holding different definitions of "narrow".
+    assert.equal(
+      LIGHT_DIFF_CEILINGS.maxImplFiles,
+      DEFAULT_DIFF_WIDTH.softFiles,
     );
   });
 });
@@ -569,8 +657,16 @@ describe('createLightReceipt — authors the receipt via the plan-persist surfac
 });
 
 // ---------------------------------------------------------------------------
-// runDiffBackstop (AC-4) — wraps computeChangeSet over the Story branch
+// runDiffBackstop (AC-4) — joins computeChangeSet with the numstat magnitude
 // ---------------------------------------------------------------------------
+
+/** Numstat rows for a list of `[additions, deletions, path]` triples. */
+const rowsOf = (...triples) =>
+  triples.map(([additions, deletions, path]) => ({
+    additions,
+    deletions,
+    path,
+  }));
 
 describe('runDiffBackstop — re-checks the ACTUAL branch diff (AC-4)', () => {
   test('a clean small diff is not blocked', () => {
@@ -578,17 +674,29 @@ describe('runDiffBackstop — re-checks the ACTUAL branch diff (AC-4)', () => {
       storyId: 4741,
       injectedRules: RULES,
       computeFn: () => ({ files: ['bin/hello.js'] }),
+      readRowsFn: () => rowsOf([20, 4, 'bin/hello.js']),
     });
     assert.equal(r.blocked, false);
+    assert.deepEqual(r.magnitude, { implFiles: 1, implLines: 24 });
   });
 
-  test('an over-ceiling diff is blocked', () => {
+  test('an over-magnitude diff is blocked', () => {
     const r = runDiffBackstop({
       storyId: 4741,
       injectedRules: RULES,
-      computeFn: () => ({
-        files: ['src/auth/a.js', 'b.js', 'c.js', 'd.js', 'e.js'],
-      }),
+      computeFn: () => ({ files: ['a.js', 'b.js'] }),
+      readRowsFn: () => rowsOf([2000, 500, 'a.js'], [10, 2, 'b.js']),
+    });
+    assert.equal(r.blocked, true);
+    assert.match(r.reasons.join(' '), /maxImplLines/);
+  });
+
+  test('a sensitive-path diff is blocked whatever its magnitude', () => {
+    const r = runDiffBackstop({
+      storyId: 4741,
+      injectedRules: RULES,
+      computeFn: () => ({ files: ['src/auth/a.js'] }),
+      readRowsFn: () => rowsOf([1, 0, 'src/auth/a.js']),
     });
     assert.equal(r.blocked, true);
   });
@@ -597,8 +705,41 @@ describe('runDiffBackstop — re-checks the ACTUAL branch diff (AC-4)', () => {
     const r = runDiffBackstop({
       storyId: 4741,
       computeFn: () => ({ files: null }),
+      readRowsFn: () => rowsOf([1, 1, 'a.js']),
     });
     assert.equal(r.blocked, true);
+  });
+
+  test('Story #4856: an unreadable numstat (rows: null) is blocked', () => {
+    const r = runDiffBackstop({
+      storyId: 4741,
+      injectedRules: RULES,
+      computeFn: () => ({ files: ['bin/hello.js'] }),
+      readRowsFn: () => null,
+    });
+    assert.equal(r.blocked, true);
+    assert.match(r.reasons.join(' '), /could not be measured/);
+  });
+
+  test('Story #4856: both git surfaces are read against the same refs', () => {
+    const seen = [];
+    runDiffBackstop({
+      storyId: 4741,
+      baseRef: 'main',
+      injectedRules: RULES,
+      computeFn: (args) => {
+        seen.push(args);
+        return { files: ['bin/hello.js'] };
+      },
+      readRowsFn: (args) => {
+        seen.push(args);
+        return rowsOf([1, 0, 'bin/hello.js']);
+      },
+    });
+    assert.equal(seen.length, 2);
+    assert.equal(seen[0].headRef, 'story-4741');
+    assert.equal(seen[1].headRef, 'story-4741');
+    assert.equal(seen[0].baseRef, seen[1].baseRef);
   });
 });
 
@@ -1416,5 +1557,136 @@ describe('the workflow tells the agent how to act on the answer (AC-8)', () => {
       /the operator waives a \*guess\*, never the\s*diff backstop/,
       'the backstop is what licenses waiving the prediction at all',
     );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Story #4856 — a blocked backstop RECYCLES its receipt instead of orphaning it,
+// and both light-path rejections are telemetered
+// ---------------------------------------------------------------------------
+
+describe('a blocked backstop recycles the receipt Story (Story #4856)', () => {
+  test('the recycle command hands the receipt to /plan tickets mode', () => {
+    // Tickets mode already rewrites a ticket into planned Stories and closes it
+    // as superseded — so the receipt becomes the plan's INPUT rather than an
+    // open issue with no successor.
+    assert.equal(buildRecycleCommand(4741), '/plan 4741');
+  });
+
+  test('the CLI emits the recycle nextCommand on a blocked backstop', () => {
+    const res = spawnSync(
+      process.execPath,
+      [DELIVER_LIGHT_SRC, '--backstop', '--story', '999999'],
+      { encoding: 'utf8', cwd: REPO_ROOT },
+    );
+    // A branch that does not exist yields an unenumerable diff → blocked (3).
+    assert.equal(res.status, 3);
+    const envelope = JSON.parse(res.stdout.trim().split('\n').pop());
+    assert.equal(envelope.blocked, true);
+    assert.equal(envelope.nextCommand, '/plan 999999');
+  });
+
+  test('a clean backstop carries no recycle command', () => {
+    // Nothing to recycle when nothing was refused.
+    const r = runDiffBackstop({
+      storyId: 4741,
+      injectedRules: RULES,
+      computeFn: () => ({ files: ['bin/hello.js'] }),
+      readRowsFn: () => [{ additions: 2, deletions: 0, path: 'bin/hello.js' }],
+    });
+    assert.equal(r.blocked, false);
+    assert.equal(r.nextCommand, undefined);
+  });
+
+  test('the workflow routes the receipt through /plan rather than orphaning it', () => {
+    const doc = readDoc(
+      path.join(
+        REPO_ROOT,
+        '.agents',
+        'workflows',
+        'helpers',
+        'deliver-light.md',
+      ),
+    );
+    for (const pattern of [
+      /recycle the receipt/,
+      /tickets mode/,
+      /no successor/,
+      /implementation half/,
+    ]) {
+      assertDocMentions(
+        doc,
+        pattern,
+        'step 4 must route a blocked backstop through /plan tickets mode rather than leaving the receipt open',
+      );
+    }
+  });
+});
+
+describe('light-path rejections are telemetered (Story #4856)', () => {
+  test('a scope rejection emits one light-scope-rejected friction signal', async () => {
+    const seen = [];
+    const ok = await recordScopeFriction({
+      storyId: 4741,
+      surface: 'diff-backstop',
+      reasons: ['too big'],
+      details: { implLines: 4000 },
+      emitFn: async (args) => {
+        seen.push(args);
+        return true;
+      },
+    });
+    assert.equal(ok, true);
+    assert.equal(seen.length, 1);
+    assert.equal(seen[0].category, 'light-scope-rejected');
+    assert.equal(seen[0].tool, 'deliver-light');
+    assert.equal(seen[0].details.surface, 'diff-backstop');
+    assert.equal(seen[0].details.implLines, 4000);
+  });
+
+  test('telemetry never changes the verdict — a throwing emitter is swallowed', async () => {
+    const ok = await recordScopeFriction({
+      storyId: 4741,
+      surface: 'diff-backstop',
+      emitFn: async () => {
+        throw new Error('signals unwritable');
+      },
+    });
+    assert.equal(ok, false);
+  });
+
+  test('an ask-operator gate records the rejection, attributed to --amends when present', async () => {
+    const seen = [];
+    const values = {
+      prompt: 'rework the whole reporting pipeline end to end',
+      refactors: 'apps/api/x.js,apps/web/y.js',
+      acceptance: '1',
+      route: 'lite',
+      reason: 'claims small but is not',
+      amends: '#4321',
+    };
+    const code = await runGateMode(values, {
+      emitFn: () => {},
+      recordFrictionFn: async (args) => {
+        seen.push(args);
+        return true;
+      },
+    });
+    assert.equal(code, 2);
+    assert.equal(seen.length, 1);
+    assert.equal(seen[0].surface, 'suitability-gate');
+    assert.equal(seen[0].storyId, 4321);
+    assert.equal(seen[0].details.action, 'ask-operator');
+  });
+
+  test('a bare prompt has no Story context to attribute a signal to', () => {
+    // Deliberate: the ask-operator path creates no receipt, and the signals
+    // stream is keyed on a Story id. Attributing it to a fabricated id would be
+    // worse than recording nothing.
+    assert.equal(normalizeAmendsId(undefined), null);
+    assert.equal(normalizeAmendsId('#12'), 12);
+    assert.equal(normalizeAmendsId('12'), 12);
+    assert.equal(normalizeAmendsId('nonsense'), null);
+    assert.equal(normalizeAmendsId('0'), null);
   });
 });

--- a/tests/plan-context.test.js
+++ b/tests/plan-context.test.js
@@ -1021,20 +1021,24 @@ describe('plan-context deliverLightSuggestion (Story #4741 AC-6)', () => {
     // The two contract flags: advisory, and NEVER an automatic reroute.
     assert.equal(s.advisory, true);
     assert.equal(s.automatic, false);
-    assert.match(s.reasons[0], /light-path ceilings/);
+    assert.match(s.reasons[0], /no risk signal/);
     // Story #4760 retired the /deliver-light command; the suggestion must
     // name a command the operator can actually type.
     assert.doesNotMatch(s.reasons[0], /\/deliver-light/);
   });
 
-  it('does not suggest when the seed exceeds the artifact ceiling', () => {
+  it('Story #4856: an artifact count no longer disqualifies a risk-free seed', () => {
+    // The second surviving cardinality ceiling, and the more misleading one:
+    // the "artifacts" were paths scraped from seed prose, not a measured
+    // footprint. Six scraped paths with no risk signal is not a size verdict.
     const s = buildDeliverLightSuggestion({
-      artifactCount: 5,
+      artifactCount: 6,
       riskHeuristicHits: [],
       sensitivePathClasses: [],
     });
-    assert.equal(s.suggested, false);
-    assert.match(s.reasons[0], /5 artifacts/);
+    assert.equal(s.suggested, true);
+    assert.equal(s.ceilings.maxArtifacts, undefined);
+    assert.doesNotMatch(s.reasons.join(' '), /artifact/i);
   });
 
   it('does not suggest when a risk heuristic hits — risk is what a light path must not carry', () => {


### PR DESCRIPTION
Closes #4856

_Auto-opened by `/deliver`._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes enforcement gates for the light delivery path (backstop ceilings, escalation, and telemetry) and shared diff measurement; behavior is heavily tested but mispaired companion globs or ceiling tuning could admit or reject real work incorrectly.
> 
> **Overview**
> The light delivery **diff backstop** no longer uses a **`maxFiles: 4`** ceiling. It bounds the **implementation half** of the landed diff with **`maxImplLines: 1000`** and **`maxImplFiles: 15`** (aligned with `review-depth`), using shared **`diff-magnitude`** measurement from `git diff --numstat` plus the canonical file list. Mandated companions (tests, docs, `baselines/**`, lockfiles) are **exempt from counts** but still count for **sensitive-path** checks; unmeasurable magnitude **blocks** like over-ceiling.
> 
> **`deliver-light`** delegates backstop resolution to **`light-backstop`** and, on refusal, emits **`nextCommand: /plan <storyId>`** so tickets mode **recycles the receipt** instead of orphaning branch/worktree work. Gate **`ask-operator`** and blocked backstop paths record **`light-scope-rejected`** runtime friction (best-effort). **`lens-diff-floor`** reuses the same numstat reader so line counting stays consistent. Plan seed **deliver-light suggestion** drops the misleading **`maxArtifacts`** screen and keys only on risk/sensitive-path signals.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7ba39d9b2ed93f1cdeefff9f820114b8c87b79ec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->