### PR TITLE
fix(maintainability): score the Babel AST the escomplex kernel actually parses

### DIFF
--- a/.agents/scripts/lib/baselines/kinds/maintainability.js
+++ b/.agents/scripts/lib/baselines/kinds/maintainability.js
@@ -30,10 +30,25 @@ export const name = 'maintainability';
 export const keyField = 'path';
 
 /**
- * Files the maintainability scorer cannot measure because `typhonjs-escomplex`
- * (the upstream kernel) parse-fails on syntax the runtime supports but the
- * library has never been updated for. Each entry must carry a one-line reason
- * so a future engine bump can audit the list and drop the exclusion.
+ * Files the maintainability scorer cannot measure because the upstream kernel
+ * throws on them. Each entry must carry a one-line reason so a future engine
+ * bump can audit the list and drop the exclusion.
+ *
+ * **This list is empty, and the goal is to keep it that way.** It previously
+ * held seven paths, all attributed to escomplex "choking on modern
+ * destructuring / regex-property patterns". That diagnosis was wrong. The real
+ * defect is that `typhonjs-escomplex`'s code generator is written against
+ * ESTree while its own parser emits Babel, so a regex literal in a loop head,
+ * an `await` in a loop head, a `?.`, a dynamic `import()`, or an object spread
+ * in a default parameter aborted the whole file's analysis. That is now
+ * repaired at the kernel boundary by `lib/escomplex-ast-compat.js`, which makes
+ * all four surviving entries scorable — and the audit incidentally showed the
+ * other three had been pointing at deleted files, because nothing audits an
+ * allowlist whose only effect is to suppress output.
+ *
+ * Before adding a path here, check whether `escomplex-ast-compat.js` can handle
+ * the construct instead. An entry here is a file nobody measures; a handler
+ * there gets it measured for every consumer.
  *
  * Story #2467 / Task #2494 — the prior behaviour stored these files with
  * `mi: 0` in `baselines/maintainability.json`, which corrupted the global
@@ -44,34 +59,7 @@ export const keyField = 'path';
  *
  * Canonicalised POSIX repo-relative paths.
  */
-export const MAINTAINABILITY_EXCLUSIONS = Object.freeze(
-  new Set([
-    // escomplex: "Cannot read properties of undefined (reading 'pattern')" —
-    // chokes on modern destructuring / regex-property patterns used in the
-    // reconciler's spec walker.
-    '.agents/scripts/acceptance-spec-reconciler.js',
-    // escomplex: same "pattern" parse failure as acceptance-spec-reconciler;
-    // both files share the lifecycle-lint regex-driven scan helpers.
-    '.agents/scripts/check-lifecycle-lint.js',
-    // escomplex: "this[node.callee.type] is not a function" — the cyclomatic
-    // visitor lacks a handler for one of the quality-watch CLI's call shapes.
-    '.agents/scripts/quality-watch.js',
-    // escomplex: "Cannot read properties of undefined (reading 'pattern')" —
-    // the audit-to-stories parser reuses the same regex-property scan
-    // patterns as acceptance-spec-reconciler.
-    '.agents/scripts/lib/audit-to-stories/parse-audit-md.js',
-    // escomplex: same "pattern" parse failure family — the BDD scanner walks
-    // source trees with regex visitors that hit the upstream destructuring
-    // bug.
-    '.agents/scripts/lib/bdd-scenario-scanner.js',
-    // escomplex: same "pattern" parse failure — the wave-runner tick uses
-    // the regex-property destructuring escomplex chokes on.
-    '.agents/scripts/lib/wave-runner/tick.js',
-    // escomplex: same "pattern" parse failure — exercises the same
-    // destructuring shape in a test fixture.
-    'tests/scripts/story-close-merge-subject.test.js',
-  ]),
-);
+export const MAINTAINABILITY_EXCLUSIONS = Object.freeze(new Set());
 
 /**
  * Filter parse-unscorable files out of a rows array. Used by the scorer

--- a/.agents/scripts/lib/escomplex-ast-compat.js
+++ b/.agents/scripts/lib/escomplex-ast-compat.js
@@ -354,11 +354,7 @@ function ASTUtil() {
   return mod?.default ?? mod;
 }
 
-/**
- * Test seam: forget the memoised install so a test can re-run `install()`
- * against a fresh table. Not for production use — the patches themselves are
- * idempotent via `PATCH_MARKER`, so production callers just call `install()`.
- */
-export function __resetForTests() {
-  installResult = null;
-}
+// A test that needs to re-run the install against the already-patched table
+// passes `{ memoise: false }` rather than resetting module state — the patches
+// are self-detecting via PATCH_MARKER, so a non-memoised re-run is exactly the
+// idempotency assertion worth making.

--- a/.agents/scripts/lib/escomplex-ast-compat.js
+++ b/.agents/scripts/lib/escomplex-ast-compat.js
@@ -1,0 +1,364 @@
+/**
+ * escomplex-ast-compat.js — reconcile the `typhonjs-escomplex` code generator
+ * with the Babel AST that `typhonjs-escomplex`'s own default parser emits.
+ *
+ * ## The upstream defect
+ *
+ * `typhonjs-escomplex` parses with `@typhonjs/babel-parser`, so every AST it
+ * analyses is a **Babel** AST. But `typhonjs-escomplex-commons`'
+ * `utils/ast/astSyntax.js` — the code generator that `ASTGenerator` drives —
+ * was written against **ESTree**. The two disagree on node names
+ * (`OptionalMemberExpression` vs a `MemberExpression` with `optional: true`)
+ * and on node shapes (Babel's `RegExpLiteral` carries `pattern`/`flags`
+ * directly; ESTree wraps them in a `regex` object on a `Literal`).
+ *
+ * That mismatch is invisible for most code because the metric traversal runs
+ * off the syntax plugin's trait tables, not off `astSyntax`. `astSyntax` is
+ * only reached where a trait re-serialises a **sub-AST** to synthesise a
+ * Halstead operand or a function signature — nine traits do this:
+ * `For`/`ForIn`/`ForOf` heads, `Function`/`FunctionExpression`/
+ * `ArrowFunctionExpression` parameter lists, `Class`/`ClassExpression`
+ * bodies, and `YieldExpression` arguments.
+ *
+ * Reach one of those with a Babel-only node and `analyzeModule()` throws —
+ * aborting the whole module, not just the sub-expression. The constructs that
+ * trip it are ordinary modern JavaScript:
+ *
+ * ```js
+ * for (const t of s.split(/[^a-z]+/)) {}   // TypeError: …reading 'pattern'
+ * for (const t of await xs()) {}           // …generator[node.type] is not a function
+ * for (const t of a?.b) {}                 // …generator[node.type] is not a function
+ * function f(a = () => import('x')) {}     // …this[node.callee.type] is not a function
+ * function f(a = { ...b }) {}              // TypeError: …reading 'type'
+ * function f(a = { m() {} }) {}            // TypeError: …reading 'generator'
+ * function f(a = class { m() {} }) {}      // …this[statement.type] is not a function
+ * ```
+ *
+ * The `{ ...b }` case is upstream issue #24, open and untouched since
+ * 2020-12-16 with a byte-identical stack trace. The package last published in
+ * June 2022 and the repo that holds the defective file has issues *disabled*,
+ * so waiting for an upstream release is not a plan. Consumers of this kernel
+ * previously absorbed the breakage as an allowlist of "unscorable" files that
+ * grew every time someone wrote a `?.` in a loop head.
+ *
+ * ## What this module does
+ *
+ * Installs the missing handlers and repairs the two shape assumptions, on the
+ * shared `astSyntax` table, once per process. Every patch is **conditional**:
+ * a handler is only installed where the table lacks one, and the two repairs
+ * wrap the original rather than replacing its behaviour. If a future kernel
+ * bump fixes any of this upstream, the corresponding patch silently stops
+ * applying and `install()` reports a shorter list — which
+ * `tests/lib/escomplex-ast-compat.test.js` asserts on, so the shrinkage is
+ * visible rather than silent.
+ *
+ * Nothing here changes the score of a file that already parses: the patched
+ * paths are exactly the paths that previously threw.
+ *
+ * @see https://github.com/typhonjs-node-escomplex/typhonjs-escomplex/issues/24
+ */
+
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+
+/** Marker set on every function this module installs, for idempotency. */
+const PATCH_MARKER = Symbol.for('mandrel.escomplexAstCompat');
+
+/** Memoised result of the one-time install. */
+let installResult = null;
+
+/**
+ * Resolve the shared `astSyntax` generator table.
+ *
+ * This is a deep import into a transitive dependency's `dist/`, which is
+ * exactly as fragile as it looks — hence the soft failure. If upstream ever
+ * restructures, `install()` reports `available: false` and the engine falls
+ * back to today's behaviour (unscorable files, now reported explicitly by
+ * the engine rather than silently scored 0).
+ *
+ * The patch must land on the *same* `typhonjs-escomplex-commons` instance the
+ * kernel loads, so `commons` is resolved **through `typhonjs-escomplex`'s own
+ * resolution** rather than from here. Resolving it directly would be a coin
+ * flip: under a hoisting installer it usually finds the same copy, but under
+ * pnpm's isolated layout — or as soon as anything declares `commons` directly —
+ * it can find a *different* physical copy, and the patch then lands on a table
+ * nobody reads while `install()` cheerfully reports success. Anchoring makes
+ * that failure mode unreachable.
+ *
+ * `requireFn` is the test seam: a cross-checkout verification harness passes
+ * its own `createRequire` so the anchor starts from that checkout's escomplex.
+ *
+ * @param {NodeJS.Require} [requireFn]
+ * @returns {Record<string, Function>|null}
+ */
+function resolveSyntaxTable(requireFn = require) {
+  try {
+    const fromKernel = createRequire(requireFn.resolve('typhonjs-escomplex'));
+    const mod = fromKernel(
+      'typhonjs-escomplex-commons/dist/utils/ast/astSyntax.js',
+    );
+    const table = mod?.default ?? mod;
+    if (!table || typeof table !== 'object') return null;
+    // Sanity-check that this is the table we think it is before mutating it.
+    if (typeof table.MemberExpression !== 'function') return null;
+    if (Object.isFrozen(table)) return null;
+    return table;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Tag a handler as ours so a second `install()` is a no-op.
+ *
+ * @template {Function} F
+ * @param {F} fn
+ * @returns {F}
+ */
+function mark(fn) {
+  fn[PATCH_MARKER] = true;
+  return fn;
+}
+
+/**
+ * Install `name` only if the table has no handler for it. Returns whether the
+ * install happened, so the caller can report the applied surface.
+ *
+ * @param {Record<string, Function>} table
+ * @param {string} name
+ * @param {Function} handler
+ * @returns {boolean}
+ */
+function addMissing(table, name, handler) {
+  if (typeof table[name] === 'function') return false;
+  table[name] = mark(handler);
+  return true;
+}
+
+/**
+ * Build an ESTree-shaped stand-in for a Babel `ObjectMethod` / `ClassMethod`,
+ * whose function bits sit on the node itself rather than under `value`.
+ * `MethodDefinition` reads `node.value.{generator,params,body}`, so handing it
+ * a synthesized `value` lets the original handler do the work unchanged.
+ *
+ * @param {object} node
+ * @returns {object}
+ */
+function asMethodDefinition(node) {
+  return {
+    ...node,
+    kind:
+      typeof node.kind === 'string' && node.kind.length > 0
+        ? node.kind
+        : 'init',
+    value: {
+      type: 'FunctionExpression',
+      generator: Boolean(node.generator),
+      async: Boolean(node.async),
+      params: node.params ?? [],
+      body: node.body,
+    },
+  };
+}
+
+/**
+ * Patch the shared `astSyntax` table. Idempotent; safe to call from every
+ * entry point that is about to run `analyzeModule`.
+ *
+ * @param {{ requireFn?: NodeJS.Require, memoise?: boolean }} [options] Test
+ *   seam only — see {@link resolveSyntaxTable}. Production callers pass
+ *   nothing.
+ * @returns {{ available: boolean, applied: string[] }} `available` is false
+ *   when the upstream internals could not be resolved. `applied` names each
+ *   patch that was actually needed, so an upstream fix shows up as a
+ *   shorter list.
+ */
+export function install(options = {}) {
+  const { requireFn, memoise = true } = options;
+  if (memoise && installResult !== null) return installResult;
+
+  const table = resolveSyntaxTable(requireFn);
+  if (table === null) {
+    const unavailable = { available: false, applied: [] };
+    if (memoise) installResult = unavailable;
+    return unavailable;
+  }
+
+  const applied = [];
+  const add = (name, handler) => {
+    if (addMissing(table, name, handler)) applied.push(name);
+  };
+
+  // ---- Repair 1: Babel's RegExpLiteral shape -------------------------------
+  // Upstream reads `node.regex.pattern`, which only exists on an ESTree
+  // `Literal`. Babel puts `pattern`/`flags` on the node. Wrapped rather than
+  // replaced so the ESTree delegate path (`Literal` → `RegExpLiteral`) keeps
+  // its exact original output.
+  if (
+    typeof table.RegExpLiteral === 'function' &&
+    !table.RegExpLiteral[PATCH_MARKER]
+  ) {
+    const original = table.RegExpLiteral;
+    table.RegExpLiteral = mark(function RegExpLiteral(node, state) {
+      if (node?.regex === undefined) {
+        state.output.write(
+          `new RegExp(${JSON.stringify(node?.pattern ?? '')}, ` +
+            `${JSON.stringify(node?.flags ?? '')})`,
+        );
+        return;
+      }
+      return original.call(this, node, state);
+    });
+    applied.push('RegExpLiteral');
+  }
+
+  // ---- Repair 2: ObjectExpression's hard `this.Property()` dispatch --------
+  // `ObjectExpression` calls `this.Property(el)` on every element regardless
+  // of the element's actual type. Two Babel shapes get mis-routed by that:
+  //
+  //   `{ ...b }`    → a `SpreadElement` lands in `Property`, which reads
+  //                   `node.key.type` and throws. Upstream issue #24.
+  //   `{ m() {} }`  → an `ObjectMethod` has `kind: 'method'`, so `Property`'s
+  //                   `node.kind[0] !== 'i'` test sends the raw Babel node to
+  //                   `MethodDefinition`, which reads `node.value.generator`
+  //                   and throws.
+  //
+  // Patching `Property` rather than `ObjectExpression` keeps the patch small
+  // and leaves the indentation-sensitive object serialisation untouched:
+  // anything arriving here that is not actually a property node gets
+  // re-dispatched on its real type.
+  //
+  // `Property` and `ObjectProperty` are excluded from re-dispatch because the
+  // table aliases `ObjectProperty` to `Property` — re-dispatching either would
+  // recurse into this wrapper forever.
+  if (typeof table.Property === 'function' && !table.Property[PATCH_MARKER]) {
+    const original = table.Property;
+    const PROPERTY_TYPES = new Set(['Property', 'ObjectProperty']);
+    table.Property = mark(function Property(node, state) {
+      const type = node?.type;
+      if (
+        typeof type === 'string' &&
+        !PROPERTY_TYPES.has(type) &&
+        typeof this[type] === 'function'
+      ) {
+        return this[type](node, state);
+      }
+      return original.call(this, node, state);
+    });
+    applied.push('Property');
+  }
+
+  // ---- Missing handlers: Babel-only node types ----------------------------
+
+  // `await x` — mirrors upstream's `YieldExpression`.
+  add('AwaitExpression', function AwaitExpression(node, state) {
+    const output = state.output;
+    output.write('await ');
+    output.operators.push('await');
+    if (node.argument) this[node.argument.type](node.argument, state);
+  });
+
+  // `a?.b` / `a?.[b]` — mirrors upstream's `MemberExpression`, with `?.`
+  // recorded as its own operator so optional access is not counted as plain
+  // member access.
+  add(
+    'OptionalMemberExpression',
+    function OptionalMemberExpression(node, state) {
+      const output = state.output;
+      this[node.object.type](node.object, state);
+      if (node.computed) {
+        output.write('?.[');
+        this[node.property.type](node.property, state);
+        output.write(']');
+        output.operators.push('?.[]');
+      } else {
+        output.write('?.');
+        output.operators.push('?.');
+        this[node.property.type](node.property, state);
+      }
+    },
+  );
+
+  // `a?.()` — mirrors upstream's `CallExpression`.
+  add('OptionalCallExpression', function OptionalCallExpression(node, state) {
+    this[node.callee.type](node.callee, state);
+    state.output.write('?.');
+    state.output.operators.push('?.()');
+    ASTUtil().formatSequence(node.arguments ?? [], state, this);
+  });
+
+  // The callee node of a dynamic `import(...)`. Babel models the `import`
+  // keyword as its own node type; ESTree has no equivalent.
+  add('Import', function Import(_node, state) {
+    state.output.write('import');
+    state.output.operators.push('import()');
+  });
+
+  // `{ m() {} }` / `{ get m() {} }` — Babel's ObjectMethod.
+  add('ObjectMethod', function ObjectMethod(node, state) {
+    return this.MethodDefinition(asMethodDefinition(node), state);
+  });
+
+  // `class { m() {} }` — Babel's ClassMethod (ESTree: MethodDefinition).
+  add('ClassMethod', function ClassMethod(node, state) {
+    return this.MethodDefinition(asMethodDefinition(node), state);
+  });
+
+  // `class { p = 1 }` — Babel's ClassProperty (ESTree: PropertyDefinition).
+  const classProperty = function ClassProperty(node, state) {
+    const output = state.output;
+    if (node.static) {
+      output.write('static ');
+      output.operators.push('static');
+    }
+    if (node.computed) {
+      output.write('[');
+      this[node.key.type](node.key, state);
+      output.write(']');
+    } else {
+      this[node.key.type](node.key, state);
+    }
+    if (node.value) {
+      output.write(' = ');
+      output.operators.push('=');
+      this[node.value.type](node.value, state);
+    }
+    output.write(';');
+  };
+  add('ClassProperty', classProperty);
+  add('PropertyDefinition', classProperty);
+
+  const result = { available: true, applied };
+  if (memoise) installResult = result;
+  return result;
+}
+
+/**
+ * `ASTUtil` is only needed by the `OptionalCallExpression` handler, and only at
+ * call time — resolving it lazily keeps `install()` free of a second deep
+ * import that could fail at module load. Anchored through the kernel for the
+ * same reason as {@link resolveSyntaxTable}.
+ *
+ * `formatSequence` is a pure helper that takes the traveler and state as
+ * arguments, so which copy answers is immaterial — but resolving it the same
+ * way keeps one rule in this file rather than two.
+ *
+ * @returns {{ formatSequence: Function }}
+ */
+function ASTUtil() {
+  const fromKernel = createRequire(require.resolve('typhonjs-escomplex'));
+  const mod = fromKernel(
+    'typhonjs-escomplex-commons/dist/utils/ast/ASTUtil.js',
+  );
+  return mod?.default ?? mod;
+}
+
+/**
+ * Test seam: forget the memoised install so a test can re-run `install()`
+ * against a fresh table. Not for production use — the patches themselves are
+ * idempotent via `PATCH_MARKER`, so production callers just call `install()`.
+ */
+export function __resetForTests() {
+  installResult = null;
+}

--- a/.agents/scripts/lib/maintainability-engine.js
+++ b/.agents/scripts/lib/maintainability-engine.js
@@ -25,11 +25,13 @@ installAstCompat();
  * rows, so an unscorable file silently vanishes from the baseline instead of
  * being reported, and no amount of re-seeding can ever give it a row.
  *
- * The numeric return is kept for backwards compatibility, but callers that
- * need to tell "unscorable" from "genuinely terrible" should use
- * {@link scoreSource} / {@link scoreFile}, which say so explicitly.
+ * Deliberately module-private. The numeric return is kept for backwards
+ * compatibility, but the *value* is not something a caller should branch on —
+ * that is the overload this change exists to stop propagating. Callers that
+ * need to tell "unscorable" from "genuinely terrible" read the `unscorable`
+ * flag from {@link scoreSource} / {@link scoreFile}.
  */
-export const UNSCORABLE = 0;
+const UNSCORABLE = 0;
 
 /**
  * Score a raw string, distinguishing "the kernel could not analyse this" from

--- a/.agents/scripts/lib/maintainability-engine.js
+++ b/.agents/scripts/lib/maintainability-engine.js
@@ -1,25 +1,78 @@
 import fs from 'node:fs';
 import escomplex from 'typhonjs-escomplex';
+import { install as installAstCompat } from './escomplex-ast-compat.js';
 import { transpileIfNeeded } from './transpile.js';
 
 /**
  * Calculates the maintainability score of a JavaScript source file or string.
  * Uses `typhonjs-escomplex` internally, which provides a maintainability index
  * based on the Halstead Volume, Cyclomatic Complexity, and Lines of Code.
+ *
+ * The kernel's code generator predates the Babel AST its own parser emits, so
+ * ordinary modern syntax (`?.`, `await` in a loop head, a regex in a loop
+ * head, object spread in a default parameter) aborts the whole analysis.
+ * `escomplex-ast-compat` repairs that before any scoring runs — see that
+ * module for the defect and the upstream status.
  */
+installAstCompat();
+
+/**
+ * Sentinel score for a file the kernel cannot analyse.
+ *
+ * A real maintainability index never reaches 0 for runnable code — the
+ * escomplex floor is ~10–20 — so 0 has long been used as an out-of-band
+ * "unscorable" marker. That overload is the bug: consumers drop `mi === 0`
+ * rows, so an unscorable file silently vanishes from the baseline instead of
+ * being reported, and no amount of re-seeding can ever give it a row.
+ *
+ * The numeric return is kept for backwards compatibility, but callers that
+ * need to tell "unscorable" from "genuinely terrible" should use
+ * {@link scoreSource} / {@link scoreFile}, which say so explicitly.
+ */
+export const UNSCORABLE = 0;
+
+/**
+ * Score a raw string, distinguishing "the kernel could not analyse this" from
+ * "this scored badly".
+ *
+ * @param {string} sourceCode The JavaScript source code.
+ * @returns {{ score: number, unscorable: boolean, reason: string|null }}
+ *   `score` is {@link UNSCORABLE} when `unscorable` is true; `reason` carries
+ *   the kernel's own error message so a consumer can report *why* rather than
+ *   just omitting the file.
+ */
+export function scoreSource(sourceCode) {
+  try {
+    const score = escomplex.analyzeModule(sourceCode)?.maintainability;
+    return Number.isFinite(score)
+      ? { score, unscorable: false, reason: null }
+      : unscorable(`kernel returned a non-finite index (${String(score)})`);
+  } catch (err) {
+    return unscorable(
+      `${err?.constructor?.name ?? 'Error'}: ${err?.message ?? 'unknown kernel failure'}`,
+    );
+  }
+}
+
+/**
+ * @param {string} reason
+ * @returns {{ score: number, unscorable: boolean, reason: string }}
+ */
+function unscorable(reason) {
+  return { score: UNSCORABLE, unscorable: true, reason };
+}
+
 /**
  * Calculate score for a raw string of source code.
+ *
+ * Returns 0 for unscorable input, which is ambiguous by construction — see
+ * {@link UNSCORABLE}. Prefer {@link scoreSource} in new code.
+ *
  * @param {string} sourceCode The JavaScript source code.
  * @returns {number} Score between 0 and 171. Higher is better.
  */
 export function calculateForSource(sourceCode) {
-  try {
-    const result = escomplex.analyzeModule(sourceCode);
-    return result.maintainability;
-  } catch (_err) {
-    // Return 0 if the parser fails (e.g. invalid syntax)
-    return 0;
-  }
+  return scoreSource(sourceCode).score;
 }
 
 /**
@@ -34,17 +87,34 @@ export function calculateForSource(sourceCode) {
  *   be parsed (escomplex parse error or TS transpile failure).
  */
 export function calculateForFile(filePath) {
+  return scoreFile(filePath).score;
+}
+
+/**
+ * Score a file, distinguishing "unscorable" from "scored badly".
+ *
+ * The transpile-failure and kernel-failure cases are reported separately
+ * because they need different fixes: a transpile failure is usually the
+ * consumer's own syntax or `tsconfig`, whereas a kernel failure is the
+ * upstream generator gap described in `escomplex-ast-compat.js`.
+ *
+ * @param {string} filePath Path to the JS/TS source file.
+ * @returns {{ score: number, unscorable: boolean, reason: string|null }}
+ */
+export function scoreFile(filePath) {
+  let sourceCode;
   try {
-    const sourceCode = fs.readFileSync(filePath, 'utf-8');
-    const prepared = transpileIfNeeded(filePath, sourceCode);
-    if (prepared === null) return 0;
-    return calculateForSource(prepared);
+    sourceCode = fs.readFileSync(filePath, 'utf-8');
   } catch (err) {
     if (err.code === 'ENOENT') {
       throw new Error(`File not found: ${filePath}`);
     }
     throw err;
   }
+
+  const prepared = transpileIfNeeded(filePath, sourceCode);
+  if (prepared === null) return unscorable('TypeScript transpile failed');
+  return scoreSource(prepared);
 }
 
 /**

--- a/.agents/scripts/lib/maintainability-unscorable.js
+++ b/.agents/scripts/lib/maintainability-unscorable.js
@@ -44,13 +44,17 @@ export function reportUnscorable(perFile) {
  * Whether a per-file entry carries a real maintainability index and so belongs
  * in the baseline.
  *
- * An unscorable entry carries the `UNSCORABLE` sentinel, not an index — letting
- * it through would write an `mi: 0` phantom and drag the rollup floor down with
- * it (Story #2467). `score === null` is the separate I/O-failure case.
+ * An unscorable entry carries the sentinel score, not an index — letting it
+ * through would write an `mi: 0` phantom and drag the rollup floor down with it
+ * (Story #2467). `score === null` is the separate I/O-failure case.
+ *
+ * Tests for a *number* rather than `score !== null`, because the latter passes
+ * anything absent: `undefined !== null` is true, so a missing entry or one with
+ * no `score` key at all would have been treated as scored.
  *
  * @param {{ score?: number|null, unscorable?: boolean }} entry
  * @returns {boolean}
  */
 export function isScored(entry) {
-  return entry?.score !== null && !entry?.unscorable;
+  return typeof entry?.score === 'number' && !entry.unscorable;
 }

--- a/.agents/scripts/lib/maintainability-unscorable.js
+++ b/.agents/scripts/lib/maintainability-unscorable.js
@@ -1,0 +1,56 @@
+/**
+ * maintainability-unscorable.js — reporting for files the MI kernel cannot
+ * analyse.
+ *
+ * A file the kernel throws on has no maintainability index, so it gets no
+ * baseline row — a phantom `mi: 0` would poison the `min`/p50 rollup and let
+ * real regressions hide behind it. Dropping the row is therefore correct; doing
+ * it *silently* is not. Without a report, an unscorable file is
+ * indistinguishable from a file nobody added yet: the scorer emits nothing, the
+ * scope gate sees an absence it cannot explain, and re-seeding the baseline can
+ * never produce the missing row no matter how many times it runs.
+ *
+ * Kept separate from `maintainability-utils.js` so the scoring path stays about
+ * scoring and this stays about explaining.
+ */
+
+import { Logger } from './Logger.js';
+
+/**
+ * Report every unscorable file, then summarise.
+ *
+ * @param {Array<{ relPath: string, unscorable?: boolean, reason?: string|null }>} perFile
+ * @returns {number} how many files were unscorable, for the caller's own use.
+ */
+export function reportUnscorable(perFile) {
+  const unscorable = (perFile ?? []).filter((entry) => entry?.unscorable);
+  if (unscorable.length === 0) return 0;
+
+  for (const { relPath, reason } of unscorable) {
+    Logger.error(
+      `[Maintainability] UNSCORABLE ${relPath}: ${reason ?? 'unknown kernel failure'}`,
+    );
+  }
+  Logger.error(
+    `[Maintainability] ${unscorable.length} file(s) could not be scored and will have ` +
+      'no baseline row, so the maintainability gate cannot see them. If the cause is a ' +
+      'kernel AST gap, add a handler in lib/escomplex-ast-compat.js rather than an ' +
+      'allowlist entry.',
+  );
+  return unscorable.length;
+}
+
+/**
+ * Whether a per-file entry carries a real maintainability index and so belongs
+ * in the baseline.
+ *
+ * An unscorable entry carries the `UNSCORABLE` sentinel, not an index — letting
+ * it through would write an `mi: 0` phantom and drag the rollup floor down with
+ * it (Story #2467). `score === null` is the separate I/O-failure case.
+ *
+ * @param {{ score?: number|null, unscorable?: boolean }} entry
+ * @returns {boolean}
+ */
+export function isScored(entry) {
+  return entry?.score !== null && !entry?.unscorable;
+}

--- a/.agents/scripts/lib/maintainability-utils.js
+++ b/.agents/scripts/lib/maintainability-utils.js
@@ -4,7 +4,8 @@ import { minimatch } from 'minimatch';
 import { canonicalise as canonicalisePath } from './baselines/path-canon.js';
 import { POOL_SERIAL_THRESHOLD, runOnPool } from './cpu-pool.js';
 import { Logger } from './Logger.js';
-import { calculateForFile } from './maintainability-engine.js';
+import { scoreFile } from './maintainability-engine.js';
+import { isScored, reportUnscorable } from './maintainability-unscorable.js';
 
 const MAINTAINABILITY_WORKER_URL = new URL(
   './workers/maintainability-worker.js',
@@ -128,6 +129,13 @@ export function scanDirectory(dir, fileList = [], opts = {}) {
  * worker-side per-item failures surface as a `null` score that is
  * filtered out before assembly.
  *
+ * A file the kernel cannot analyse is also dropped — a phantom `mi: 0` row
+ * poisons the rollup — but it is **reported** on the way out, with the
+ * kernel's own error text, and the count is summarised at the end of the run.
+ * Silently omitting these is what let a file sit unmeasured indefinitely: the
+ * scorer emitted no row, so no amount of re-seeding could ever produce one,
+ * and nothing said so.
+ *
  * @param {string[]} paths
  * @returns {Promise<Record<string, number>>}
  */
@@ -142,7 +150,7 @@ export async function calculateAll(paths) {
   if (indexed.length < SERIAL_THRESHOLD) {
     perFile = indexed.map(({ abs, relPath }) => {
       try {
-        return { relPath, score: calculateForFile(abs) };
+        return { relPath, ...scoreFile(abs) };
       } catch (err) {
         Logger.error(
           `[Maintainability] Failed to process ${abs}: ${err.message}`,
@@ -166,7 +174,7 @@ export async function calculateAll(paths) {
       if (r.score === null && r.error) {
         Logger.error(`[Maintainability] Failed to process ${abs}: ${r.error}`);
       }
-      return { relPath, score: r.score };
+      return { relPath, ...r };
     });
   }
 
@@ -174,9 +182,10 @@ export async function calculateAll(paths) {
     a.relPath < b.relPath ? -1 : a.relPath > b.relPath ? 1 : 0,
   );
 
+  reportUnscorable(perFile);
+
   const scores = {};
-  for (const { relPath, score } of perFile) {
-    if (score === null) continue;
+  for (const { relPath, score } of perFile.filter(isScored)) {
     scores[relPath] = score;
   }
   return scores;

--- a/.agents/scripts/lib/workers/maintainability-worker.js
+++ b/.agents/scripts/lib/workers/maintainability-worker.js
@@ -7,16 +7,20 @@
  * Message contract — see lib/cpu-pool.js:
  *   IN  : { item: string }      — absolute file path to score
  *         { exit: true }        — drain & terminate
- *   OUT : { ok: true, result: { filePath, score: number | null } }
+ *   OUT : { ok: true, result: { filePath, score, unscorable?, reason? } }
  *
  * `score` is `null` only when the file genuinely cannot be read (ENOENT
- * or other I/O error). Parse failures inside escomplex still resolve to
- * `0` to preserve byte-for-byte parity with the pre-pool serial path
- * (calculateForSource swallows parse errors and returns 0).
+ * or other I/O error).
+ *
+ * A file the kernel cannot analyse comes back as `unscorable: true` with the
+ * kernel's own `reason`, rather than as a bare `0`. The `0` is still carried in
+ * `score` for wire compatibility, but it is no longer the only signal — the
+ * point of the flag is that the caller can *report* the file instead of
+ * silently dropping it (see `maintainability-engine.js`'s `UNSCORABLE`).
  */
 
 import { parentPort } from 'node:worker_threads';
-import { calculateForFile } from '../maintainability-engine.js';
+import { scoreFile } from '../maintainability-engine.js';
 
 /**
  * Pure handler for a single inbound worker message. Exported so unit
@@ -24,7 +28,7 @@ import { calculateForFile } from '../maintainability-engine.js';
  * without spawning a real `Worker` thread.
  *
  * @param {unknown} msg
- * @param {{ score?: (filePath: string) => number | null }} [deps]
+ * @param {{ score?: (filePath: string) => { score: number, unscorable: boolean, reason: string|null } }} [deps]
  * @returns {{kind: 'exit'} | {kind: 'reply', message: object}}
  */
 export function handleMaintainabilityWorkerMessage(msg, deps = {}) {
@@ -40,12 +44,13 @@ export function handleMaintainabilityWorkerMessage(msg, deps = {}) {
     };
   }
   const filePath = msg.item;
-  const scoreFn = deps.score ?? calculateForFile;
+  const scoreFn = deps.score ?? scoreFile;
   try {
-    const score = scoreFn(filePath);
+    // `scoreFn` returns `{ score, unscorable, reason }` — spread so the flag
+    // and its reason reach the pool caller intact.
     return {
       kind: 'reply',
-      message: { ok: true, result: { filePath, score } },
+      message: { ok: true, result: { filePath, ...scoreFn(filePath) } },
     };
   } catch (err) {
     // I/O or other unexpected error — surface as a per-item null score

--- a/baselines/dead-exports-production.json
+++ b/baselines/dead-exports-production.json
@@ -1322,7 +1322,15 @@
     },
     {
       "file": ".agents/scripts/lib/maintainability-engine.js",
+      "symbol": "calculateForFile"
+    },
+    {
+      "file": ".agents/scripts/lib/maintainability-engine.js",
       "symbol": "calculateForSource"
+    },
+    {
+      "file": ".agents/scripts/lib/maintainability-engine.js",
+      "symbol": "scoreSource"
     },
     {
       "file": ".agents/scripts/lib/mandrel-catalog.js",

--- a/tests/lib/escomplex-ast-compat.test.js
+++ b/tests/lib/escomplex-ast-compat.test.js
@@ -1,0 +1,177 @@
+/**
+ * escomplex-ast-compat.test.js — the Babel-AST constructs that used to abort a
+ * whole module's maintainability analysis.
+ *
+ * Each case below is a one-line reduction of a real crash observed on a
+ * consumer's tree. The kernel's code generator was written for ESTree while its
+ * own parser emits Babel, so any of these reached through a serialised sub-AST
+ * (loop head, parameter list, class body, yield argument) threw and took the
+ * entire file's score with it — which the pipeline then swallowed as `0` and
+ * dropped from the baseline.
+ *
+ * The three guards that matter:
+ *   1. every construct scores (no throw, finite index);
+ *   2. genuinely invalid syntax is still reported unscorable — the shim must
+ *      not paper over real parse errors;
+ *   3. the patch is additive — a file that already scored keeps its exact
+ *      score, so installing this cannot move a committed baseline row.
+ */
+
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import {
+  __resetForTests,
+  install,
+} from '../../.agents/scripts/lib/escomplex-ast-compat.js';
+import {
+  scoreSource,
+  UNSCORABLE,
+} from '../../.agents/scripts/lib/maintainability-engine.js';
+
+/**
+ * Constructs that crashed the kernel before this shim. The comment on each is
+ * the error it produced.
+ */
+const RESCUED_CONSTRUCTS = {
+  // TypeError: Cannot read properties of undefined (reading 'pattern')
+  'regex literal in a for-of head': 'for (const t of s.split(/a+/)) { x(t); }',
+  'regex literal in a parameter default': 'function f(a = /x/) { return a; }',
+  // TypeError: state.generator[node.type] is not a function
+  'await in a for-of head':
+    'async function f() { for (const t of await g()) { x(t); } }',
+  'optional member in a for-of head': 'for (const t of a?.b) { x(t); }',
+  'optional call in a for-of head': 'for (const t of a?.()) { x(t); }',
+  'chained optional call in a for-of head':
+    'for (const t of a?.b?.()) { x(t); }',
+  // TypeError: this[node.callee.type] is not a function
+  'dynamic import in a parameter default':
+    'function f(a = () => import("x")) { return a; }',
+  // TypeError: Cannot read properties of undefined (reading 'type') — upstream #24
+  'object spread in a parameter default':
+    'function f({ a = { ...b } } = {}) { return a; }',
+  'object spread in a for-of head': 'for (const t of [{ ...b }]) { x(t); }',
+  // TypeError: Cannot read properties of undefined (reading 'generator')
+  'object method in a parameter default':
+    'function f(a = { m() { return 1; } }) { return a; }',
+  'object getter in a parameter default':
+    'function f(a = { get m() { return 1; } }) { return a; }',
+  'object setter in a parameter default':
+    'function f(a = { set m(v) { this.x = v; } }) { return a; }',
+  'async object method in a parameter default':
+    'function f(a = { async m() { return 1; } }) { return a; }',
+  'generator object method in a parameter default':
+    'function f(a = { *m() { yield 1; } }) { return a; }',
+  // TypeError: this[statement.type] is not a function
+  'class method in a parameter default':
+    'function f(a = class { m() { return 1; } }) { return a; }',
+  'class property in a parameter default':
+    'function f(a = class { p = 1; }) { return a; }',
+};
+
+/** Ordinary code that always scored — the no-drift control group. */
+const ALREADY_SCORABLE = {
+  'plain for-of': 'for (const t of xs) { x(t); }',
+  'plain object literal': 'function f(a = { b: 1 }) { return a; }',
+  'shorthand properties': 'function f(a = { b, c }) { return a; }',
+  'computed key': 'function f(a = { [k]: 1 }) { return a; }',
+  'array spread': 'function f(a = [...b]) { return a; }',
+  'object rest in a destructured param':
+    'function f({ a, ...rest }) { return rest; }',
+  // Written as a template literal with escapes so the linter does not read the
+  // interpolation-in-a-plain-string as a mistake — it is fixture source, not a
+  // string we mean to interpolate.
+  'template literal default': `function f(a = \`x\${b}y\`) { return a; }`,
+  'nullish coalescing default': 'function f(a = b ?? c) { return a; }',
+  'async arrow default': 'function f(a = async () => 1) { return a; }',
+  'spread argument': 'function f(a = g(...b)) { return a; }',
+  'yield a regex': 'function* f() { yield /x/; }',
+  'class with a member-expression superclass':
+    'function f(a = class extends b.c {}) { return a; }',
+};
+
+describe('escomplex-ast-compat', () => {
+  it('resolves the upstream generator table and reports what it patched', () => {
+    const report = install();
+    assert.equal(
+      report.available,
+      true,
+      'could not resolve typhonjs-escomplex-commons astSyntax — the deep import ' +
+        'has moved; install() correctly degrades, but the shim is now inert',
+    );
+    assert.ok(
+      report.applied.length > 0,
+      'nothing was patched — if the kernel was bumped and fixed upstream, delete ' +
+        'the corresponding branch in escomplex-ast-compat.js and the allowlists ' +
+        'that reference it',
+    );
+  });
+
+  it('is idempotent', () => {
+    const first = install();
+    const second = install();
+    assert.deepEqual(second, first);
+
+    // A non-memoised re-run against the already-patched table must find
+    // nothing left to add — proving the patches are self-detecting and a
+    // second install cannot double-wrap a handler.
+    __resetForTests();
+    const rerun = install({ memoise: false });
+    assert.deepEqual(
+      rerun.applied,
+      [],
+      'a second install re-applied patches — PATCH_MARKER detection is broken, ' +
+        'which would stack wrappers and change scores',
+    );
+    __resetForTests();
+    install();
+  });
+
+  for (const [name, source] of Object.entries(RESCUED_CONSTRUCTS)) {
+    it(`scores ${name}`, () => {
+      const result = scoreSource(source);
+      assert.equal(
+        result.unscorable,
+        false,
+        `still unscorable: ${result.reason}`,
+      );
+      assert.ok(
+        Number.isFinite(result.score) && result.score > 0,
+        `expected a finite positive index, got ${result.score}`,
+      );
+    });
+  }
+
+  for (const [name, source] of Object.entries(ALREADY_SCORABLE)) {
+    it(`still scores ${name}`, () => {
+      const result = scoreSource(source);
+      assert.equal(result.unscorable, false, `regressed: ${result.reason}`);
+      assert.ok(Number.isFinite(result.score) && result.score > 0);
+    });
+  }
+
+  it('still reports genuinely invalid syntax as unscorable', () => {
+    const result = scoreSource('function ( { ] }');
+    assert.equal(result.unscorable, true);
+    assert.equal(result.score, UNSCORABLE);
+    assert.match(result.reason, /SyntaxError/);
+  });
+
+  it('distinguishes unscorable from a genuinely low score', () => {
+    const unscorable = scoreSource('function ( { ] }');
+    const scored = scoreSource('for (const t of xs) { x(t); }');
+
+    assert.equal(unscorable.score, UNSCORABLE);
+    assert.equal(unscorable.unscorable, true);
+    assert.notEqual(
+      scored.score,
+      UNSCORABLE,
+      'the control must not collide with the unscorable sentinel',
+    );
+    assert.equal(scored.unscorable, false);
+    assert.equal(scored.reason, null);
+    assert.ok(
+      typeof unscorable.reason === 'string' && unscorable.reason.length > 0,
+      'an unscorable result must carry a reason a human can act on',
+    );
+  });
+});

--- a/tests/lib/escomplex-ast-compat.test.js
+++ b/tests/lib/escomplex-ast-compat.test.js
@@ -19,14 +19,16 @@
 
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
-import {
-  __resetForTests,
-  install,
-} from '../../.agents/scripts/lib/escomplex-ast-compat.js';
-import {
-  scoreSource,
-  UNSCORABLE,
-} from '../../.agents/scripts/lib/maintainability-engine.js';
+import { install } from '../../.agents/scripts/lib/escomplex-ast-compat.js';
+import { scoreSource } from '../../.agents/scripts/lib/maintainability-engine.js';
+
+/**
+ * The score an unscorable result carries. Asserted as a literal rather than
+ * imported, because the *value* is deliberately not public API: `unscorable` is
+ * the signal a caller branches on, and overloading a score with out-of-band
+ * meaning is the bug this change exists to stop propagating.
+ */
+const UNSCORABLE_SCORE = 0;
 
 /**
  * Constructs that crashed the kernel before this shim. The comment on each is
@@ -111,10 +113,9 @@ describe('escomplex-ast-compat', () => {
     const second = install();
     assert.deepEqual(second, first);
 
-    // A non-memoised re-run against the already-patched table must find
-    // nothing left to add — proving the patches are self-detecting and a
-    // second install cannot double-wrap a handler.
-    __resetForTests();
+    // A non-memoised re-run bypasses the memo and re-examines the real table,
+    // which must now have nothing left to add — proving the patches are
+    // self-detecting and a second install cannot double-wrap a handler.
     const rerun = install({ memoise: false });
     assert.deepEqual(
       rerun.applied,
@@ -122,8 +123,6 @@ describe('escomplex-ast-compat', () => {
       'a second install re-applied patches — PATCH_MARKER detection is broken, ' +
         'which would stack wrappers and change scores',
     );
-    __resetForTests();
-    install();
   });
 
   for (const [name, source] of Object.entries(RESCUED_CONSTRUCTS)) {
@@ -152,7 +151,7 @@ describe('escomplex-ast-compat', () => {
   it('still reports genuinely invalid syntax as unscorable', () => {
     const result = scoreSource('function ( { ] }');
     assert.equal(result.unscorable, true);
-    assert.equal(result.score, UNSCORABLE);
+    assert.equal(result.score, UNSCORABLE_SCORE);
     assert.match(result.reason, /SyntaxError/);
   });
 
@@ -160,11 +159,11 @@ describe('escomplex-ast-compat', () => {
     const unscorable = scoreSource('function ( { ] }');
     const scored = scoreSource('for (const t of xs) { x(t); }');
 
-    assert.equal(unscorable.score, UNSCORABLE);
+    assert.equal(unscorable.score, UNSCORABLE_SCORE);
     assert.equal(unscorable.unscorable, true);
     assert.notEqual(
       scored.score,
-      UNSCORABLE,
+      UNSCORABLE_SCORE,
       'the control must not collide with the unscorable sentinel',
     );
     assert.equal(scored.unscorable, false);

--- a/tests/lib/maintainability-unscorable.test.js
+++ b/tests/lib/maintainability-unscorable.test.js
@@ -1,0 +1,136 @@
+/**
+ * maintainability-unscorable.test.js — the "we could not score this, and we are
+ * saying so" path.
+ *
+ * A file the kernel throws on gets no baseline row. That part is correct: an
+ * `mi: 0` phantom would drag the rollup floor down. What was wrong was doing it
+ * silently — the scorer emitted nothing, so an unmeasured file was
+ * indistinguishable from a file nobody had added, and no amount of re-seeding
+ * could ever produce the missing row.
+ *
+ * These tests pin the two halves: unscorable files stay out of the score map,
+ * and they get reported with the kernel's own reason attached.
+ */
+
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { after, before, describe, it } from 'node:test';
+import {
+  isScored,
+  reportUnscorable,
+} from '../../.agents/scripts/lib/maintainability-unscorable.js';
+import { calculateAll } from '../../.agents/scripts/lib/maintainability-utils.js';
+import { makeTempDir } from '../../.agents/scripts/lib/test-temp.js';
+
+describe('isScored', () => {
+  it('accepts an entry carrying a real index', () => {
+    assert.equal(isScored({ relPath: 'a.js', score: 87.5 }), true);
+    assert.equal(
+      isScored({ relPath: 'a.js', score: 87.5, unscorable: false }),
+      true,
+    );
+  });
+
+  it('rejects an unscorable entry even though its score is a number', () => {
+    // The whole point: `score: 0` looks like a valid index to a naive filter.
+    assert.equal(
+      isScored({ relPath: 'a.js', score: 0, unscorable: true }),
+      false,
+    );
+  });
+
+  it('rejects the null-score I/O-failure entry', () => {
+    assert.equal(isScored({ relPath: 'a.js', score: null }), false);
+  });
+
+  it('rejects a missing entry rather than throwing', () => {
+    assert.equal(isScored(undefined), false);
+    assert.equal(isScored(null), false);
+  });
+});
+
+describe('reportUnscorable', () => {
+  it('returns 0 and stays silent when everything scored', () => {
+    assert.equal(reportUnscorable([{ relPath: 'a.js', score: 90 }]), 0);
+    assert.equal(reportUnscorable([]), 0);
+    assert.equal(reportUnscorable(undefined), 0);
+  });
+
+  it('counts every unscorable entry', () => {
+    const count = reportUnscorable([
+      { relPath: 'a.js', score: 90 },
+      {
+        relPath: 'b.js',
+        score: 0,
+        unscorable: true,
+        reason: 'TypeError: boom',
+      },
+      { relPath: 'c.js', score: 0, unscorable: true, reason: null },
+    ]);
+    assert.equal(count, 2);
+  });
+});
+
+describe('calculateAll — unscorable files', () => {
+  let workDir;
+  let originalCwd;
+
+  before(() => {
+    workDir = fs.realpathSync(makeTempDir('mi-unscorable-'));
+    originalCwd = process.cwd();
+    process.chdir(workDir);
+  });
+
+  after(() => {
+    process.chdir(originalCwd);
+    fs.rmSync(workDir, { recursive: true, force: true });
+  });
+
+  it('omits an unscorable file from the score map but keeps its neighbours', async () => {
+    const good = path.join(workDir, 'good.js');
+    const broken = path.join(workDir, 'broken.js');
+    fs.writeFileSync(good, 'export function f(a) { return a + 1; }\n');
+    // Genuinely invalid syntax — the one thing that must still be unscorable
+    // after the AST compat shim closed the Babel-shape gaps.
+    fs.writeFileSync(broken, 'export function ( { ] }\n');
+
+    const scores = await calculateAll([good, broken]);
+
+    assert.ok(
+      Object.hasOwn(scores, 'good.js'),
+      'the scorable neighbour must still get a row',
+    );
+    assert.equal(
+      Object.hasOwn(scores, 'broken.js'),
+      false,
+      'an unscorable file must NOT get a row — an mi:0 phantom poisons the rollup',
+    );
+  });
+
+  it('scores a file whose only oddity is syntax the kernel used to choke on', async () => {
+    // Regression guard for the whole point of escomplex-ast-compat: this file
+    // is perfectly valid and used to abort the entire analysis.
+    const modern = path.join(workDir, 'modern.js');
+    fs.writeFileSync(
+      modern,
+      [
+        'export function tokenise(text) {',
+        '  const out = [];',
+        '  for (const token of text.toLowerCase().split(/[^a-z0-9]+/)) {',
+        '    if (token) out.push(token);',
+        '  }',
+        '  return out;',
+        '}',
+        '',
+      ].join('\n'),
+    );
+
+    const scores = await calculateAll([modern]);
+
+    assert.ok(
+      typeof scores['modern.js'] === 'number' && scores['modern.js'] > 0,
+      `expected a real index, got ${scores['modern.js']}`,
+    );
+  });
+});

--- a/tests/lib/workers/maintainability-worker.test.js
+++ b/tests/lib/workers/maintainability-worker.test.js
@@ -27,19 +27,41 @@ describe('handleMaintainabilityWorkerMessage — score path', () => {
   it('returns the computed score on success', () => {
     const out = handleMaintainabilityWorkerMessage(
       { item: '/abs/foo.js' },
-      { score: () => 87.5 },
+      { score: () => ({ score: 87.5, unscorable: false, reason: null }) },
     );
     assert.equal(out.message.ok, true);
+    // `unscorable`/`reason` ride along on every reply so the caller can tell a
+    // kernel failure from a genuinely low score instead of inferring it from a
+    // bare `0` — see maintainability-engine's UNSCORABLE.
     assert.deepEqual(out.message.result, {
       filePath: '/abs/foo.js',
       score: 87.5,
+      unscorable: false,
+      reason: null,
     });
+  });
+
+  it('propagates an unscorable outcome with its reason', () => {
+    const out = handleMaintainabilityWorkerMessage(
+      { item: '/abs/foo.js' },
+      {
+        score: () => ({
+          score: 0,
+          unscorable: true,
+          reason:
+            "TypeError: Cannot read properties of undefined (reading 'pattern')",
+        }),
+      },
+    );
+    assert.equal(out.message.ok, true);
+    assert.equal(out.message.result.unscorable, true);
+    assert.match(out.message.result.reason, /reading 'pattern'/);
   });
 
   it('honors null score (file present but escomplex returns null)', () => {
     const out = handleMaintainabilityWorkerMessage(
       { item: '/abs/foo.js' },
-      { score: () => null },
+      { score: () => ({ score: null, unscorable: false, reason: null }) },
     );
     assert.equal(out.message.result.score, null);
     assert.equal('error' in out.message.result, false);


### PR DESCRIPTION
## Why

`typhonjs-escomplex` parses with `@typhonjs/babel-parser`, so every AST it analyses is a **Babel** AST. But `typhonjs-escomplex-commons`' `utils/ast/astSyntax.js` — the code generator `ASTGenerator` drives — is written against **ESTree**. They disagree on node names (`OptionalMemberExpression`) and on shapes (Babel's `RegExpLiteral` carries `pattern`/`flags` on the node; ESTree wraps them in `regex` on a `Literal`).

That is invisible for most code, because the metric traversal runs off the syntax plugin's trait tables rather than `astSyntax`. `astSyntax` is only reached where a trait re-serialises a **sub-AST** to synthesise a Halstead operand or a function signature — **nine** traits do this: the three loop heads, the three function/arrow parameter lists, the two class bodies, and `YieldExpression`.

Reach one of those with a Babel-only node and `analyzeModule()` throws for the **whole module**. The constructs are ordinary modern JavaScript:

```js
for (const t of s.split(/a+/)) {}        // TypeError: …reading 'pattern'
for (const t of await g()) {}            // …generator[node.type] is not a function
for (const t of a?.b) {}                 // …generator[node.type] is not a function
for (const t of a?.()) {}                // …generator[node.type] is not a function
function f(a = () => import('x')) {}     // …this[node.callee.type] is not a function
function f(a = { ...b }) {}              // TypeError: …reading 'type'
function f(a = { m() {} }) {}            // TypeError: …reading 'generator'
function f(a = class { m() {} }) {}      // …this[statement.type] is not a function
```

Two of those are structural dispatch bugs rather than missing handlers: `ObjectExpression` hard-calls `this.Property(el)` on every element regardless of type, so a `SpreadElement` or `ObjectMethod` is mis-routed into `Property`, which reads `node.key.type`.

`calculateForSource` swallowed the throw as `0`, and the writer drops `mi === 0` rows — so an affected file could **never** receive a baseline row no matter how often the baseline was re-seeded, and nothing said so.

## What changed

- **`escomplex-ast-compat.js`** installs the missing handlers and repairs the two shape assumptions on the shared generator table, once per process. Every patch is conditional and self-marking, so an upstream fix makes it stop applying rather than double-wrap, and `install()` reports the surface it had to touch.

  `commons` is resolved **through** `typhonjs-escomplex` rather than directly. This matters: declaring `typhonjs-escomplex-commons` as a direct dependency was measured to *cause* the bug under pnpm's isolated layout — you get a second physical copy, the patch lands on a table nobody reads, and `install()` cheerfully reports success.

- **The engine distinguishes "unscorable" from "scored 0"** (`scoreSource` / `scoreFile` / `UNSCORABLE`), and the worker carries the flag across the thread boundary. The shim closes today's gap; this makes tomorrow's gap loud instead of silent.

- **`maintainability-unscorable.js`** reports each unscorable file with the kernel's own error text, and points at the compat module rather than at an allowlist.

- **`MAINTAINABILITY_EXCLUSIONS` is now empty.** All four live entries score. The audit incidentally found the other three had been pointing at **deleted files** — an allowlist whose only effect is to suppress output has no feedback loop. Their "modern destructuring" attribution was wrong, so the docstring is corrected.

## Verification

Scored this repo (1234 files) and a consumer (901 files) **twice in one process**, before and after the patch:

| | mandrel | consumer |
|---|---|---|
| identical score | 1210 | 892 |
| rescued (was unscorable) | 24 | 9 |
| **drifted** | **0** | **0** |
| **newly broken** | **0** | **0** |
| still unscorable | 0 | 0 |

Zero drift is the load-bearing property: installing this cannot move a committed baseline row, because the patched paths are exactly the paths that previously threw.

Also: full suite 9380/9384 pass (4 pre-existing skips), `run-lint` 0 errors, and the MI and CRAP gates report 0 breaches / 0 regressions.

`tests/lib/escomplex-ast-compat.test.js` covers all 16 rescued constructs, a 12-case no-drift control group, idempotency (a second install must find nothing to add), and that genuinely invalid syntax is *still* reported unscorable — the shim must not paper over real parse errors.

## Deliberately not included

The baseline is **not** re-seeded here. Newly-scorable files land as `additions`, which never gate, and a full-scope rewrite would fold in 24 rows of unrelated accumulated drift that predate this change. That drift deserves its own `baseline-refresh:` commit.

## Upstream

Dormant: last publish 2022-06, last repo push 2022-12, and the repo holding the defective file has **issues disabled**. The object-spread case is [typhonjs-escomplex#24](https://github.com/typhonjs-node-escomplex/typhonjs-escomplex/issues/24), open since 2020-12-16 with a byte-identical stack trace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes maintainability gate scoring and monkey-patches a transitive dependency’s internals, but patches are conditional and scoped to previously throwing paths with tests asserting no baseline score drift.
> 
> **Overview**
> Fixes maintainability scoring for modern JavaScript by patching `typhonjs-escomplex` where its ESTree-oriented code generator mishandles the Babel AST its parser emits, instead of maintaining a growing file exclusion list.
> 
> **`escomplex-ast-compat.js`** installs idempotent handlers at module load (via `maintainability-engine`) for constructs that used to abort whole-file analysis—regex in loop heads, `await`/`?.` in `for-of`, dynamic `import()` in defaults, object spread/methods in parameters, class fields—by patching the shared `astSyntax` table resolved through the kernel’s dependency graph.
> 
> **Scoring API** adds `scoreSource` / `scoreFile` returning `{ score, unscorable, reason }` so kernel failures are not conflated with a bare `0`; `calculateAll`, the CPU pool worker, and **`maintainability-unscorable.js`** log unscorable paths and omit them from baseline rows (still avoiding phantom `mi: 0` rollup poison). **`MAINTAINABILITY_EXCLUSIONS`** is cleared now that those paths are scorable.
> 
> Tests cover rescued syntax, no-drift controls, idempotent install, and end-to-end `calculateAll` behavior; the maintainability baseline is intentionally not re-seeded in this PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ac14e57717c64fd109c4ffc0d7cef96ea2045539. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->