### PR TITLE
fix: hold the Story assignee-lease until the PR is confirmed merged instead of dropping it at PR creation (#4860)

### DIFF
--- a/.agents/schemas/story-deliver-terminal.schema.json
+++ b/.agents/schemas/story-deliver-terminal.schema.json
@@ -87,7 +87,8 @@
         "statusResync",
         "refCleanup",
         "baseFastForward",
-        "tempPurge"
+        "tempPurge",
+        "leaseRelease"
       ],
       "properties": {
         "followUps": { "type": "boolean" },
@@ -97,6 +98,10 @@
         "tempPurge": {
           "type": "boolean",
           "description": "Story #4794 — the merged Story's spent temp artifacts (gate transcripts, validation evidence) were purged under delivery.tempRetention. A disabled policy reports true: the operator turned the purge off, so doing nothing IS the correct outcome. Only a real failure — an unreadable temp root, an undeletable artifact — reports false, and like every tail step that degrades the report, never the land."
+        },
+        "leaseRelease": {
+          "type": "boolean",
+          "description": "Story #4860 — the operator's assignee-lease on the Story was released now that the merge is confirmed. The close deliberately no longer releases it at PR creation, so the ticket stays assigned for the whole time its PR is open; every non-merged ending (merge.unlanded block, exhausted wait budget, --no-wait-merge, --no-auto-merge) retains the claim and never reaches this step. A no-op release — the operator is no longer the recorded owner, as on a re-run or a belated manual confirm — reports true: an already-unassigned ticket is the desired end state. Only a throw reports false, and like every tail step that degrades the report, never the land."
         },
         "details": {
           "type": "object",

--- a/.agents/scripts/lib/orchestration/single-story-close/phases/post-land.js
+++ b/.agents/scripts/lib/orchestration/single-story-close/phases/post-land.js
@@ -11,7 +11,7 @@
  * Story is already `agent::done`, so confirm short-circuits `noop` and the
  * capture's `action === 'done'` gate never opens).
  *
- * This module folds all four steps into one phase both landing surfaces
+ * This module folds every such step into one phase both landing surfaces
  * reach — the in-close wait (`phases/confirm-merge.js`) and the standalone
  * `single-story-confirm-merge.js` CLI — so the two paths cannot diverge and
  * "landed" means the whole tail ran.
@@ -45,6 +45,7 @@ import {
   planFastForward as defaultPlanFastForward,
 } from '../../git-cleanup/phases/fast-forward.js';
 import { reassertStatusColumn as defaultReassertStatusColumn } from '../../reassert-status-column.js';
+import { releaseStoryLease as defaultReleaseStoryLease } from '../../single-story-lease-guard.js';
 import { captureStoryFollowUps as defaultCaptureStoryFollowUps } from '../../story-follow-ups.js';
 
 /**
@@ -242,6 +243,54 @@ async function stepTempPurge({ storyId, config, purgeStoryTempArtifactsFn }) {
 }
 
 /**
+ * Release the Story's assignee-lease now that the merge is confirmed
+ * (Story #4860).
+ *
+ * The close used to release here-ish — immediately after the PR was opened
+ * and armed, before the merge wait ran — so a Story's ticket read *unassigned*
+ * for the entire window its PR was open, and indefinitely on the
+ * operator-merge path where a human owns the land. The claim is the only
+ * ticket-visible record of who owns in-flight work, so dropping it at PR
+ * creation is dropping it at exactly the wrong moment.
+ *
+ * It lives in the tail rather than in either landing surface because the tail
+ * is the one seam **both** reach — the in-close merge wait
+ * (`phases/confirm-merge.js`) and the standalone
+ * `single-story-confirm-merge.js` CLI. Homing it anywhere else re-opens the
+ * surface divergence this module exists to close.
+ *
+ * Idempotent by construction: `releaseStoryLease` no-ops when the resolved
+ * operator is no longer the recorded owner, so a re-run (or the belated
+ * manual confirm that backfills an already-`agent::done` Story) reports the
+ * no-op reason rather than yanking a claim someone else has since taken.
+ *
+ * A `released: false` no-op is **not** a step failure: an already-released
+ * ticket is the desired end state, and reporting it as `false` would train
+ * readers to ignore the field. Only a throw — an unreachable API, an
+ * unresolvable operator identity — degrades the step, and like every tail
+ * step that degrades the report, never the land.
+ */
+async function stepLeaseRelease({
+  storyId,
+  provider,
+  config,
+  progress,
+  releaseStoryLeaseFn,
+}) {
+  const outcome = await releaseStoryLeaseFn({ provider, storyId, config });
+  progress?.(
+    'POST-LAND',
+    outcome?.released
+      ? `🔓 Story #${storyId} lease released (merge confirmed).`
+      : `⏭  Story #${storyId} lease not released (${outcome?.reason ?? 'unknown'}).`,
+  );
+  return {
+    ok: true,
+    detail: outcome?.released ? null : (outcome?.reason ?? null),
+  };
+}
+
+/**
  * Run the whole post-land tail. Never throws.
  *
  * Steps run **sequentially** and in this order deliberately: follow-up
@@ -280,7 +329,8 @@ async function stepTempPurge({ storyId, config, purgeStoryTempArtifactsFn }) {
  * @param {Function} [args.executeFastForwardFn]    Test seam.
  * @param {Function} [args.acquireLockWithWaitFn]   Test seam.
  * @param {Function} [args.purgeStoryTempArtifactsFn] Test seam.
- * @returns {Promise<{ followUps: boolean, statusResync: boolean, refCleanup: boolean, baseFastForward: boolean, tempPurge: boolean, details: Record<string, string|null> }>}
+ * @param {Function} [args.releaseStoryLeaseFn]     Test seam.
+ * @returns {Promise<{ followUps: boolean, statusResync: boolean, refCleanup: boolean, baseFastForward: boolean, tempPurge: boolean, leaseRelease: boolean, details: Record<string, string|null> }>}
  */
 export async function runPostLandTail({
   storyId,
@@ -299,6 +349,7 @@ export async function runPostLandTail({
   executeFastForwardFn = defaultExecuteFastForward,
   acquireLockWithWaitFn = defaultAcquireLockWithWait,
   purgeStoryTempArtifactsFn = defaultPurgeStoryTempArtifacts,
+  releaseStoryLeaseFn = defaultReleaseStoryLease,
 }) {
   progress?.('POST-LAND', `🧾 Running land tail for Story #${storyId}...`);
 
@@ -401,18 +452,35 @@ export async function runPostLandTail({
     { name: 'temp purge', progress },
   );
 
+  // Story #4860 — the merge is confirmed, so the operator's claim on this
+  // Story has finally done its job. Released here rather than at PR creation
+  // so the ticket stays assigned for the whole time its PR is open.
+  const leaseRelease = await step(
+    () =>
+      stepLeaseRelease({
+        storyId,
+        provider,
+        config,
+        progress,
+        releaseStoryLeaseFn,
+      }),
+    { name: 'lease release', progress },
+  );
+
   const tail = {
     followUps: followUps.ok,
     statusResync: statusResync.ok,
     refCleanup: refCleanup.ok,
     baseFastForward: baseFastForward.ok,
     tempPurge: tempPurge.ok,
+    leaseRelease: leaseRelease.ok,
     details: {
       followUps: followUps.detail,
       statusResync: statusResync.detail,
       refCleanup: refCleanup.detail,
       baseFastForward: baseFastForward.detail,
       tempPurge: tempPurge.detail,
+      leaseRelease: leaseRelease.detail,
     },
   };
   const degraded = Object.entries(tail)

--- a/.agents/scripts/lib/orchestration/single-story-close/runner.js
+++ b/.agents/scripts/lib/orchestration/single-story-close/runner.js
@@ -353,8 +353,8 @@ function closeResult({
     note: waitedForMerge
       ? 'Close-and-land: PR merge confirmed. Story flipped agent::closing → agent::done, the issue closed (confirmStoryMerged), and the post-land tail ran.'
       : autoMergeEnabled
-        ? 'PR open against baseBranch with auto-merge enabled. Story rests at agent::closing (issue stays OPEN). GitHub will squash-merge when required checks pass; run single-story-confirm-merge.js after the merge confirms to flip agent::done and close the issue (the Closes #<id> footer also auto-closes it).'
-        : 'PR open against baseBranch. Story rests at agent::closing (issue stays OPEN). Operator merges via GitHub UI; run single-story-confirm-merge.js after the merge confirms to flip agent::done (the Closes #<id> footer also auto-closes the issue).',
+        ? 'PR open against baseBranch with auto-merge enabled. Story rests at agent::closing (issue stays OPEN and assigned to the operator). GitHub will squash-merge when required checks pass; run single-story-confirm-merge.js after the merge confirms to flip agent::done, release the lease, and close the issue (the Closes #<id> footer also auto-closes it).'
+        : 'PR open against baseBranch. Story rests at agent::closing (issue stays OPEN and assigned to the operator). Operator merges via GitHub UI; run single-story-confirm-merge.js after the merge confirms to flip agent::done and release the lease (the Closes #<id> footer also auto-closes the issue).',
   };
 }
 
@@ -552,7 +552,18 @@ async function runClosePipeline({
     config,
     progress,
   });
-  const leaseReleased = await releaseLease(leaseArgs);
+  // Story #4860 — the clean-path lease release USED to sit here, immediately
+  // after the arm and the `agent::closing` flip. That dropped the operator's
+  // claim the moment the PR opened, so a ticket read unassigned for the whole
+  // time its PR was in flight — and forever on the operator-merge path, where
+  // nothing downstream ever re-claimed it. The release now belongs to the
+  // post-land tail, which runs only on a CONFIRMED merge and which both
+  // landing surfaces reach. Every non-merged ending below — the
+  // `merge.unlanded` block, an exhausted wait budget, `--no-wait-merge`,
+  // `--no-auto-merge` — deliberately RETAINS the claim: the PR is open and the
+  // work still has an owner. The only releases that survive here are
+  // `releaseLeaseOnBlock`'s two throwing exits above, which fire before the PR
+  // is ever armed (Story #4257's hand-off property).
 
   // Close-and-land (Story #4428; default since `delivery.routing.closeAndLand`
   // — Story #4539): poll the just-armed PR to merge confirmation, or block
@@ -625,7 +636,11 @@ async function runClosePipeline({
       autoMergeEnabled,
       autoMergeReason,
       worktreeReaped,
-      leaseReleased,
+      // Story #4860 — the release is a post-land tail step now, so the tail's
+      // own per-step boolean IS the answer. A wait that ended anything other
+      // than landed never ran the tail, and correctly reports `false`: the
+      // claim is still held, by design.
+      leaseReleased: waitOutcome.tail?.leaseRelease === true,
       localCleanupDeferred,
       directMerged,
       waitedForMerge: true,
@@ -663,7 +678,10 @@ async function runClosePipeline({
     autoMergeEnabled,
     autoMergeReason,
     worktreeReaped,
-    leaseReleased,
+    // Story #4860 — this is the no-wait ending: the PR is open and a human
+    // owns the merge, so the Story stays assigned until the confirm-merge
+    // surface lands it and runs the tail.
+    leaseReleased: false,
     localCleanupDeferred,
     directMerged,
   });

--- a/tests/contract/story-deliver-terminal.test.js
+++ b/tests/contract/story-deliver-terminal.test.js
@@ -70,6 +70,7 @@ const CLEAN_TAIL = {
   refCleanup: true,
   baseFastForward: true,
   tempPurge: true,
+  leaseRelease: true,
 };
 
 describe('story-deliver-terminal — the status contract', () => {
@@ -273,6 +274,7 @@ describe('story-deliver-terminal — landed', () => {
       [
         'baseFastForward',
         'followUps',
+        'leaseRelease',
         'refCleanup',
         'statusResync',
         'tempPurge',

--- a/tests/lib/orchestration/post-land-lease-release.test.js
+++ b/tests/lib/orchestration/post-land-lease-release.test.js
@@ -1,0 +1,155 @@
+/**
+ * Story #4860 — the assignee-lease is released by the post-land tail, on a
+ * CONFIRMED merge, and nowhere else.
+ *
+ * The close used to release it immediately after the PR was opened and armed,
+ * so a Story's ticket read unassigned for the whole time its PR was open (and
+ * forever on the operator-merge path, where nothing downstream re-claimed it).
+ * Homing the release in the tail is what makes "assigned until merged" true on
+ * BOTH landing surfaces — the in-close merge wait and the standalone
+ * `single-story-confirm-merge.js` CLI — since the tail is the only phase both
+ * reach.
+ *
+ * These tests pin the step's contract: it runs, it reports per-step, a no-op
+ * release is a success, and a throwing release degrades the report without
+ * failing the land.
+ */
+
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, it } from 'node:test';
+
+import { runPostLandTail } from '../../../.agents/scripts/lib/orchestration/single-story-close/phases/post-land.js';
+import { makeTempDir } from '../../../.agents/scripts/lib/test-temp.js';
+
+/**
+ * Seams for a tail whose every OTHER step succeeds quietly, so an assertion
+ * about `leaseRelease` is never confounded by a neighbour. Each stub exists
+ * for the isolation reason the sibling suites document: unstubbed, these
+ * steps reach the main checkout's signal stream, its temp tree, or GitHub.
+ */
+function quietSeams() {
+  return {
+    emitCloseRecoveredFrictionFn: async () => true,
+    emitRecoveredFrictionMarkerFn: async () => true,
+    captureStoryFollowUpsFn: async () => ({ ok: true }),
+    reassertStatusColumnFn: async () => ({ status: 'synced' }),
+    gitSpawnFn: () => ({ status: 0 }),
+    planFastForwardFn: () => ({
+      runnable: false,
+      reason: 'already-up-to-date',
+    }),
+    executeFastForwardFn: () => ({ applied: true, behind: 0 }),
+    acquireLockWithWaitFn: async () => ({
+      acquired: true,
+      release: () => {},
+      ownerId: 't',
+    }),
+    purgeStoryTempArtifactsFn: async () => ({
+      skipped: null,
+      purged: [],
+      errors: [],
+      bytesReclaimed: 0,
+    }),
+  };
+}
+
+let tmpDir;
+beforeEach(() => {
+  tmpDir = makeTempDir('post-land-lease-');
+  fs.mkdirSync(path.join(tmpDir, '.git'), { recursive: true });
+});
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+/** Run the tail with the quiet seams plus whatever this test overrides. */
+function runTail(overrides = {}) {
+  return runPostLandTail({
+    storyId: 4860,
+    storyBranch: 'story-4860',
+    baseBranch: 'main',
+    cwd: tmpDir,
+    provider: { marker: 'provider' },
+    config: { marker: 'config' },
+    ...quietSeams(),
+    ...overrides,
+  });
+}
+
+describe('runPostLandTail — lease release (Story #4860)', () => {
+  it('releases the lease and reports leaseRelease: true', async () => {
+    const calls = [];
+    const tail = await runTail({
+      releaseStoryLeaseFn: async (args) => {
+        calls.push(args);
+        return { released: true, owner: 'tester', reason: 'released' };
+      },
+    });
+
+    assert.equal(tail.leaseRelease, true);
+    assert.equal(tail.details.leaseRelease, null);
+    assert.equal(calls.length, 1, 'released exactly once');
+    // The provider and config are threaded through verbatim — the release
+    // resolves its operator identity from config, so a dropped config would
+    // silently fail closed on every land.
+    assert.deepEqual(calls[0], {
+      provider: { marker: 'provider' },
+      storyId: 4860,
+      config: { marker: 'config' },
+    });
+  });
+
+  it('treats a no-op release as a success, carrying the reason as detail', async () => {
+    // The operator is no longer the recorded owner — a re-run, or the belated
+    // manual confirm that backfills an already-`agent::done` Story. An
+    // already-unassigned ticket IS the desired end state, so reporting this
+    // as a failed step would train readers to ignore the field.
+    const tail = await runTail({
+      releaseStoryLeaseFn: async () => ({
+        released: false,
+        owner: null,
+        reason: 'not-owner',
+      }),
+    });
+
+    assert.equal(tail.leaseRelease, true);
+    assert.equal(tail.details.leaseRelease, 'not-owner');
+  });
+
+  it('degrades to leaseRelease: false when the release throws, without failing the land', async () => {
+    const tail = await runTail({
+      releaseStoryLeaseFn: async () => {
+        throw new Error('assignees PATCH rejected');
+      },
+    });
+
+    assert.equal(tail.leaseRelease, false);
+    assert.match(tail.details.leaseRelease, /assignees PATCH rejected/);
+    // The merge already landed: every other step still ran and reported.
+    assert.equal(tail.followUps, true);
+    assert.equal(tail.statusResync, true);
+    assert.equal(tail.baseFastForward, true);
+    assert.equal(tail.tempPurge, true);
+  });
+
+  it('still releases when an earlier tail step degrades', async () => {
+    // The claim must not survive a land just because an unrelated best-effort
+    // step failed — that would strand exactly the ticket whose report already
+    // looks worst.
+    const tail = await runTail({
+      reassertStatusColumnFn: async () => {
+        throw new Error('projects v2 flaked');
+      },
+      releaseStoryLeaseFn: async () => ({
+        released: true,
+        owner: 'tester',
+        reason: 'released',
+      }),
+    });
+
+    assert.equal(tail.statusResync, false);
+    assert.equal(tail.leaseRelease, true);
+  });
+});

--- a/tests/lib/orchestration/post-land-lock.test.js
+++ b/tests/lib/orchestration/post-land-lock.test.js
@@ -71,6 +71,13 @@ function baseSeams(trace) {
       trace?.push('tempPurge');
       return { skipped: null, purged: [], errors: [], bytesReclaimed: 0 };
     },
+    // Stubbed for the same isolation reason (Story #4860): the real release
+    // resolves an operator handle from `config` and PATCHes a live ticket's
+    // assignees, so an unstubbed call would reach GitHub for a real Story id.
+    releaseStoryLeaseFn: async () => {
+      trace?.push('leaseRelease');
+      return { released: true, owner: 'tester', reason: 'released' };
+    },
   };
 }
 
@@ -116,12 +123,14 @@ describe('runPostLandTail — lock scope (Story #4622)', () => {
       refCleanup: true,
       baseFastForward: true,
       tempPurge: true,
+      leaseRelease: true,
       details: {
         followUps: null,
         statusResync: null,
         refCleanup: null,
         baseFastForward: null,
         tempPurge: null,
+        leaseRelease: null,
       },
     });
     assert.ok(released, 'the lock is released');
@@ -129,9 +138,12 @@ describe('runPostLandTail — lock scope (Story #4622)', () => {
     // capture reads the signal stream, so a marker written after it would
     // arrive too late to net the failure it cancels out of this very run.
     // GitHub steps then precede the lock; both mutations are inside it.
-    // The temp purge (Story #4794) is LAST and outside the lock: it touches
-    // only the temp tree, so it contends with nothing, and running it after
-    // every other step means no step can still be reading what it deletes.
+    // The temp purge (Story #4794) is outside the lock: it touches only the
+    // temp tree, so it contends with nothing, and running it after every
+    // other step means no step can still be reading what it deletes. The
+    // lease release (Story #4860) is last and also outside — it is a pure
+    // GitHub write, and running it after every step means the claim outlives
+    // everything that could still fail.
     assert.deepEqual(events, [
       'closeRecovered',
       'followUps',
@@ -141,6 +153,7 @@ describe('runPostLandTail — lock scope (Story #4622)', () => {
       'baseFastForward',
       'release',
       'tempPurge',
+      'leaseRelease',
     ]);
   });
 
@@ -245,6 +258,13 @@ describe('runPostLandTail — real cross-process serialization (Story #4622)', (
         inside -= 1;
         return { applied: true, behind: 1 };
       },
+      // Same isolation contract (Story #4860): the real release would PATCH a
+      // live ticket's assignees for these fixture ids.
+      releaseStoryLeaseFn: async () => ({
+        released: true,
+        owner: 'tester',
+        reason: 'released',
+      }),
     });
 
     const run = (storyId) =>

--- a/tests/single-story-close-confirm-merge.test.js
+++ b/tests/single-story-close-confirm-merge.test.js
@@ -144,6 +144,7 @@ function phaseArgs(overrides = {}) {
       refCleanup: true,
       baseFastForward: true,
       tempPurge: true,
+      leaseRelease: true,
       details: {},
     }),
     emitMergeUnlandedFn: () => {},
@@ -176,6 +177,7 @@ describe('merge wait — the confirmed path', () => {
             refCleanup: true,
             baseFastForward: true,
             tempPurge: true,
+            leaseRelease: true,
             details: {},
           };
         },
@@ -1242,6 +1244,7 @@ describe('Story #4681 — local branch-delete failure never blocks a landed merg
             refCleanup: true,
             baseFastForward: true,
             tempPurge: true,
+            leaseRelease: true,
             details: {},
           };
         },

--- a/tests/single-story-close-orchestration.test.js
+++ b/tests/single-story-close-orchestration.test.js
@@ -69,6 +69,15 @@ function mockCloseValidation(t, { namedExports }) {
 const WORKTREE_MANAGER_URL = pathToFileURL(
   path.resolve(REPO_ROOT, '.agents/scripts/lib/worktree-manager.js'),
 ).href;
+// Story #4860 — the merge wait is not an injection seam on the runner, so the
+// lease-retention tests below stub the phase at its module URL to drive a
+// chosen terminal (landed / blocked) without a live PR.
+const CONFIRM_MERGE_PHASE_URL = pathToFileURL(
+  path.resolve(
+    REPO_ROOT,
+    '.agents/scripts/lib/orchestration/single-story-close/phases/confirm-merge.js',
+  ),
+).href;
 // Story #2990: the close-tail phases reach `gh` through the
 // `lib/gh-exec.js` facade rather than direct `execFileSync('gh', …)`
 // calls. Tests inject a fake `gh` facade via `injectedGh` (or pass it
@@ -1433,6 +1442,192 @@ describe('runSingleStoryClose — lease release on recoverable-blocked exits (St
           },
         }),
       /Story-scope review reported 1 critical blocker/,
+    );
+  });
+});
+
+/**
+ * Story #4860 — the close no longer drops the operator's claim the moment the
+ * PR opens. The clean post-arm release is gone; the only releases left in this
+ * runner are `releaseLeaseOnBlock`'s two throwing exits (pinned by the #4257
+ * suite above), and the post-land tail's own step, which runs on a CONFIRMED
+ * merge only.
+ *
+ * The property under test is a NEGATIVE one — "no release happened" — so each
+ * test injects a release seam that records every call and asserts it stayed
+ * empty. A future re-introduction of an eager release fails here rather than
+ * quietly un-assigning tickets again.
+ */
+describe('runSingleStoryClose — the lease is held until the merge confirms (Story #4860)', () => {
+  /** A `gh` that opens a PR and arms it, refusing anything else. */
+  function ghOpeningPr(prUrl) {
+    return makeFakeGh((args) => {
+      if (args[1] === 'list') return [];
+      if (args[1] === 'create') return `${prUrl}\n`;
+      if (args[1] === 'merge') return 'ok';
+      throw new Error(`unexpected gh: ${args.join(' ')}`);
+    });
+  }
+
+  /** Stub the merge-wait phase to return a chosen outcome verbatim. */
+  function mockConfirmMergePhase(t, outcome) {
+    t.mock.module(CONFIRM_MERGE_PHASE_URL, {
+      namedExports: {
+        runConfirmMergePhase: async () => outcome,
+        // The runner imports only the phase; these are re-exported so any
+        // sibling importing the module URL still resolves.
+        resolveMergeWaitConfig: () => ({ maxWaitSeconds: 1, pollMs: 1 }),
+      },
+    });
+  }
+
+  it('does not release on the no-wait ending: the PR is open and the human owns the merge', async (t) => {
+    t.mock.module(GIT_UTILS_URL, defaultGitUtilsMock());
+    mockCloseValidation(t, defaultCloseValidationMock());
+    t.mock.module(WORKTREE_MANAGER_URL, defaultWorktreeManagerMock());
+
+    const releaseCalls = [];
+    const { runSingleStoryClose } = await import(
+      `${SUT_URL}?t=lease-hold-nowait`
+    );
+    const { result } = await runSingleStoryClose({
+      storyId: 4860,
+      cwd: '/repo',
+      skipValidation: true,
+      skipSync: true,
+      noWaitForMerge: true,
+      injectedProvider: makeFakeProvider({
+        initialStory: {
+          id: 4860,
+          state: 'open',
+          title: 'hold the lease',
+          labels: ['agent::executing'],
+        },
+      }),
+      injectedConfig: fakeConfig(),
+      injectedGh: ghOpeningPr('https://github.com/owner/repo/pull/860'),
+      injectedRunCodeReview: noopReview(),
+      injectedReleaseLease: async ({ storyId }) => {
+        releaseCalls.push(storyId);
+        return { released: true, owner: 'alice', reason: 'released' };
+      },
+    });
+
+    assert.deepEqual(
+      releaseCalls,
+      [],
+      'the PR is open — the Story must stay assigned to its operator',
+    );
+    assert.equal(result.leaseReleased, false);
+    assert.match(
+      result.note,
+      /assigned to the operator/,
+      'the note tells the operator the claim is deliberately retained',
+    );
+  });
+
+  it('does not release on a merge.unlanded blocked terminal', async (t) => {
+    t.mock.module(GIT_UTILS_URL, defaultGitUtilsMock());
+    mockCloseValidation(t, defaultCloseValidationMock());
+    t.mock.module(WORKTREE_MANAGER_URL, defaultWorktreeManagerMock());
+    mockConfirmMergePhase(t, {
+      confirmed: false,
+      terminal: 'blocked',
+      blockClass: 'checks-failed',
+      reason: 'a required check went red',
+      frictionCommentId: 'c-9',
+    });
+
+    const releaseCalls = [];
+    const { runSingleStoryClose } = await import(
+      `${SUT_URL}?t=lease-hold-blocked`
+    );
+    const { terminal } = await runSingleStoryClose({
+      storyId: 4861,
+      cwd: '/repo',
+      skipValidation: true,
+      skipSync: true,
+      injectedProvider: makeFakeProvider({
+        initialStory: {
+          id: 4861,
+          state: 'open',
+          title: 'blocked but still owned',
+          labels: ['agent::executing'],
+        },
+      }),
+      injectedConfig: fakeConfig(),
+      injectedGh: ghOpeningPr('https://github.com/owner/repo/pull/861'),
+      injectedRunCodeReview: noopReview(),
+      injectedReleaseLease: async ({ storyId }) => {
+        releaseCalls.push(storyId);
+        return { released: true, owner: 'alice', reason: 'released' };
+      },
+    });
+
+    assert.equal(terminal.status, 'blocked');
+    assert.deepEqual(
+      releaseCalls,
+      [],
+      'a blocked Story keeps its owner: the PR is open and someone must fix it',
+    );
+  });
+
+  it('reports leaseReleased from the tail on a landed terminal, never from its own call', async (t) => {
+    t.mock.module(GIT_UTILS_URL, defaultGitUtilsMock());
+    mockCloseValidation(t, defaultCloseValidationMock());
+    t.mock.module(WORKTREE_MANAGER_URL, defaultWorktreeManagerMock());
+    mockConfirmMergePhase(t, {
+      confirmed: true,
+      terminal: 'landed',
+      action: 'done',
+      tail: {
+        followUps: true,
+        statusResync: true,
+        refCleanup: true,
+        baseFastForward: true,
+        tempPurge: true,
+        leaseRelease: true,
+        details: {},
+      },
+      prProbe: { checksStatus: 'success' },
+    });
+
+    const releaseCalls = [];
+    const { runSingleStoryClose } = await import(
+      `${SUT_URL}?t=lease-hold-landed`
+    );
+    const { result, terminal } = await runSingleStoryClose({
+      storyId: 4862,
+      cwd: '/repo',
+      skipValidation: true,
+      skipSync: true,
+      injectedProvider: makeFakeProvider({
+        initialStory: {
+          id: 4862,
+          state: 'open',
+          title: 'landed and released',
+          labels: ['agent::executing'],
+        },
+      }),
+      injectedConfig: fakeConfig(),
+      injectedGh: ghOpeningPr('https://github.com/owner/repo/pull/862'),
+      injectedRunCodeReview: noopReview(),
+      injectedReleaseLease: async ({ storyId }) => {
+        releaseCalls.push(storyId);
+        return { released: true, owner: 'alice', reason: 'released' };
+      },
+    });
+
+    assert.equal(terminal.status, 'landed');
+    assert.equal(
+      result.leaseReleased,
+      true,
+      'the tail released it, so the result says so',
+    );
+    assert.deepEqual(
+      releaseCalls,
+      [],
+      'the runner itself never releases on the clean path — the tail owns it',
     );
   });
 });

--- a/tests/single-story-close-second-delivery.test.js
+++ b/tests/single-story-close-second-delivery.test.js
@@ -309,6 +309,7 @@ describe('second delivery reaches the landed state (AC-2)', () => {
           refCleanup: true,
           baseFastForward: true,
           tempPurge: true,
+          leaseRelease: true,
           details: {},
         };
       },

--- a/tests/single-story-confirm-merge-backfill.test.js
+++ b/tests/single-story-confirm-merge-backfill.test.js
@@ -34,6 +34,7 @@ const TAIL = Object.freeze({
   refCleanup: true,
   baseFastForward: true,
   tempPurge: true,
+  leaseRelease: true,
   details: {},
 });
 

--- a/tests/single-story-confirm-merge-resume.test.js
+++ b/tests/single-story-confirm-merge-resume.test.js
@@ -141,6 +141,7 @@ describe('single-story-confirm-merge --wait', () => {
           refCleanup: true,
           baseFastForward: true,
           tempPurge: true,
+          leaseRelease: true,
           details: {},
         },
         prProbe: { state: 'MERGED', checksStatus: 'success' },


### PR DESCRIPTION
Closes #4860

_Auto-opened by `/deliver`._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes ticket assignee visibility and lease timing across all close endings; behavior is well-tested but affects operator workflow and GitHub assignee state until merge.
> 
> **Overview**
> **Story #4860** changes when the operator’s assignee-lease is cleared: the close no longer calls `releaseStoryLease` right after the PR is armed and `agent::closing` is set. The ticket stays **assigned** while the PR is open (including operator-merge and `--no-wait-merge` paths). Release runs only in **`runPostLandTail`** as a new last step after temp purge, so both landing surfaces (in-close confirm-merge and `single-story-confirm-merge.js`) share one behavior.
> 
> The **story-deliver-terminal** schema and tail object gain required **`leaseRelease`** (per-step boolean + optional `details`). No-op releases (`released: false`, e.g. re-run / not owner) count as success; only throws set `leaseRelease: false` without failing the land.
> 
> **`runSingleStoryClose`** sets `result.leaseReleased` from `waitOutcome.tail?.leaseRelease === true` when close-and-land lands; otherwise **`false`** (pending, blocked, or no-wait). User-facing **notes** mention the issue stays assigned until confirm-merge releases the lease.
> 
> Tests add **`post-land-lease-release.test.js`**, extend lock-step ordering to include lease release, and guard the runner against eager release on no-wait / blocked / landed (tail-only) paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 47ddf3bae7df22bf558e269b83f958aaece6277f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->