### PR TITLE
feat: enforce the no-rerun verifier: disarm auto-merge on the first red and gate re-arming on the head SHA moving (#4865)

### DIFF
--- a/.agents/rules/ci-remediation.md
+++ b/.agents/rules/ci-remediation.md
@@ -19,8 +19,10 @@ exactly one of two ways, and no others:
    caused by the diff under review — **verify the same check against an
    unmodified `main` checkout**; if it also fails on `main` the defect is
    pre-existing and belongs in a separate change — then fix it at source,
-   commit on `story-<storyId>`, push, and re-run the watcher. Auto-merge stays
-   armed across retries. Route deterministic per-check failures (lint/format,
+   commit on `story-<storyId>`, push, and re-run the watcher. Auto-merge is
+   **disarmed on the first red** and re-armed only by a green on a **new head
+   SHA**, so the fix must be a new commit. Route deterministic per-check
+   failures (lint/format,
    maintainability/CRAP baseline drift, test failure, coverage threshold)
    through the fix table in
    [`deliver-story-reference.md` § Step 4](../workflows/helpers/deliver-story-reference.md#step-4--ci-watch--fix-recovery);
@@ -47,6 +49,23 @@ deleted or loosened assertion** introduced to reach green. You may **not**
 re-run a failed job to "see if it goes green," and you may **not** skip,
 `.only`, or quarantine a flaky test to get a green bar. Both mask the defect
 and are prohibited by this rule.
+
+**The enforcement point is
+[`pr-watch-with-update.js`](../scripts/pr-watch-with-update.js)**, and it acts
+on the **first red** — GitHub's native auto-merge fires server-side, so it
+races any attempt to detect a rerun-green and block it after the fact. On the
+first red the watcher **disarms native auto-merge** (a disarm failure is a
+blocker, not a warning) and records the PR **head SHA** in the digest
+alongside the failing check-run identity. On green it adjudicates:
+
+- **Same head SHA** → the green came from re-running the failed job. The
+  watcher exits non-zero, flips the Story to `agent::blocked` with a
+  `friction` comment, and requires the `meta::framework-gap` issue (run link +
+  failure signature, both already in the digest) before the delivery proceeds.
+- **New head SHA** → fix at source. The digest is retired, auto-merge is
+  re-armed, and the delivery continues unobstructed.
+
+A delivery that never went red has no digest and is untouched.
 
 ## Escalation
 

--- a/.agents/scripts/lib/orchestration/ci-rerun-guard.js
+++ b/.agents/scripts/lib/orchestration/ci-rerun-guard.js
@@ -1,0 +1,544 @@
+// .agents/scripts/lib/orchestration/ci-rerun-guard.js
+/**
+ * ci-rerun-guard.js — the machine enforcement behind the no-rerun MUST in
+ * [`rules/ci-remediation.md`](../../../rules/ci-remediation.md) § Verifier
+ * (Story #4865). Owns the CI failure digest (write / read / retire), the
+ * head-SHA discriminator, the auto-merge disarm, and the blocked-delivery
+ * escalation. `pr-watch-with-update.js` is the enforcement point; this
+ * module is the mechanism it drives.
+ *
+ * **Why the first red, and not the rerun-green.** The obvious design —
+ * observe a green that arrives on a re-run of the same commit, then disarm
+ * auto-merge and block — cannot enforce anything. GitHub's native
+ * auto-merge fires server-side the moment branch protection is satisfied,
+ * so it races the watcher's next poll: by the time the rerun-green is
+ * observed, the PR may already be merged. The only race-free observation
+ * point is the **first red**, which necessarily precedes any green. So the
+ * watcher disarms on red and records the PR head SHA; the head SHA is then
+ * read at **re-arm** time, not at merge time.
+ *
+ * **Head SHA is the discriminator.** A green on a *different* head SHA is a
+ * fix at source — legal, and it retires the digest. A green on the *same*
+ * head SHA is a re-run of a failed job, which the rule forbids: the
+ * delivery hard-stops at `agent::blocked` and a `meta::framework-gap` issue
+ * (carrying the run link and failure signature the digest already holds) is
+ * required before it can proceed.
+ *
+ * **Fail closed on an unverifiable green.** A digest whose head SHA is
+ * missing, or a current head SHA that `gh` could not resolve, leaves no
+ * evidence that the red was fixed at source. An unresolved red plus no
+ * evidence of a new commit is treated as a violation rather than waved
+ * through — the same unknown-is-blocking posture the arming probe takes on
+ * an unrecognized check state.
+ */
+
+import { spawnSync } from 'node:child_process';
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import path from 'node:path';
+import { resolveConfig } from '../config-resolver.js';
+import { Logger } from '../Logger.js';
+import { createProvider } from '../provider-factory.js';
+import {
+  STATE_LABELS,
+  transitionTicketState,
+  upsertStructuredComment,
+} from './ticketing.js';
+
+/** How many superseded unresolved reds a digest carries before the oldest is dropped. */
+const MAX_PRIOR_REDS = 10;
+
+/**
+ * Resolve which ticket the digest is keyed to. Story #4539: the digest used
+ * to be Epic-scoped by filename and returned `null` without an epic id — so
+ * on the v2 Story path (which has no Epic and invokes the watch with `--pr`
+ * alone) a red check wrote no digest at all, despite the module header
+ * advertising one. v2.0.0 removed the Epic tier; Story scope is the only
+ * scope.
+ *
+ * @param {{ storyId?: number|string|null }} opts
+ * @returns {{ kind: 'story', id: number } | null}
+ */
+export function resolveDigestScope({ storyId = null } = {}) {
+  if (storyId == null || String(storyId).length === 0) return null;
+  const parsed = Number.parseInt(String(storyId), 10);
+  return Number.isInteger(parsed) && parsed > 0
+    ? { kind: 'story', id: parsed }
+    : null;
+}
+
+/**
+ * Coarse failure classification from a failing-check name. Pure —
+ * exported for tests. Deliberately shallow: it steers the operator's
+ * next move (which `/loop` unit to reach for), not a root-cause verdict.
+ *
+ * @param {string} name  failing required-check name.
+ * @returns {'test'|'lint'|'baseline'|'build'|'unknown'}
+ */
+export function classifyFailure(name) {
+  const n = String(name ?? '').toLowerCase();
+  if (/lint|format|biome|markdownlint/.test(n)) return 'lint';
+  if (/baseline|coverage|crap|maintainab|duplicat/.test(n)) return 'baseline';
+  if (/build|compile|typecheck|bundle/.test(n)) return 'build';
+  if (/test|spec|validate|ci|check/.test(n)) return 'test';
+  return 'unknown';
+}
+
+/**
+ * Resolve the `.json` / `.md` digest paths for a scope. Returns `null` when
+ * no scope can be keyed (the digest is scoped by filename and has nothing
+ * to key on).
+ *
+ * @param {{ storyId?: number|string|null, tempRoot: string, cwd: string }} opts
+ * @returns {{ scope: { kind: 'story', id: number }, jsonPath: string, mdPath: string } | null}
+ */
+export function ciDigestPaths({ storyId = null, tempRoot, cwd }) {
+  const scope = resolveDigestScope({ storyId });
+  if (!scope) return null;
+  const dir = path.isAbsolute(tempRoot) ? tempRoot : path.join(cwd, tempRoot);
+  const base = `${scope.kind}-${scope.id}-ci-digest`;
+  return {
+    scope,
+    jsonPath: path.join(dir, `${base}.json`),
+    mdPath: path.join(dir, `${base}.md`),
+  };
+}
+
+/**
+ * Default `gh run view --log-failed` spawn — pulls the tail of the failed
+ * job log so the digest carries an actionable excerpt. Best-effort:
+ * returns an empty tail when the run id is unknown or `gh` errors.
+ * Injected into `writeCiDigest` so tests never shell out.
+ */
+function ghRunLogTail({ runId, cwd, spawnFn = spawnSync, maxLines = 40 }) {
+  if (!runId) return '';
+  const result = spawnFn('gh', ['run', 'view', String(runId), '--log-failed'], {
+    cwd,
+    encoding: 'utf-8',
+    shell: false,
+    maxBuffer: 10 * 1024 * 1024,
+  });
+  const out = (result.stdout ?? '').trim();
+  if (out.length === 0) return '';
+  const lines = out.split('\n');
+  return lines.slice(-maxLines).join('\n');
+}
+
+/**
+ * Resolve the failing check's run identity — the GitHub Actions run id AND
+ * the run URL. Best-effort via `gh pr checks --json name,link`: the `link`
+ * field carries the run URL whose trailing path segment is the run id. The
+ * URL matters as much as the id, because the `meta::framework-gap` issue a
+ * rerun violation demands must carry a run **link**.
+ *
+ * @returns {{ runId: string|null, url: string|null }}
+ */
+function resolveFailingCheckRun({
+  prRef,
+  checkName,
+  cwd,
+  spawnFn = spawnSync,
+}) {
+  const result = spawnFn('gh', ['pr', 'checks', prRef, '--json', 'name,link'], {
+    cwd,
+    encoding: 'utf-8',
+    shell: false,
+  });
+  try {
+    const parsed = JSON.parse((result.stdout ?? '').trim() || '[]');
+    const entry = Array.isArray(parsed)
+      ? parsed.find((e) => e?.name === checkName)
+      : null;
+    const link = entry?.link ? String(entry.link) : null;
+    const m = link ? /\/runs\/(\d+)/.exec(link) : null;
+    return { runId: m ? m[1] : null, url: link };
+  } catch {
+    return { runId: null, url: null };
+  }
+}
+
+/**
+ * Resolve the PR's current head SHA (`headRefOid`) — the discriminator
+ * between a legal fix-at-source green and a forbidden rerun green. Returns
+ * `null` when `gh` fails or the payload is unparseable; callers treat an
+ * unresolvable head as unverifiable, never as "changed".
+ *
+ * @param {{ prRef: string, cwd: string, spawnFn?: typeof spawnSync }} opts
+ * @returns {string|null}
+ */
+export function resolvePrHeadSha({ prRef, cwd, spawnFn = spawnSync }) {
+  const result = spawnFn('gh', ['pr', 'view', prRef, '--json', 'headRefOid'], {
+    cwd,
+    encoding: 'utf-8',
+    shell: false,
+  });
+  if ((result?.status ?? 1) !== 0) return null;
+  try {
+    const parsed = JSON.parse((result.stdout ?? '').trim() || '{}');
+    const sha = parsed?.headRefOid;
+    return typeof sha === 'string' && sha.length > 0 ? sha : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * A `gh` refusal that means auto-merge was never armed in the first place —
+ * there is nothing to disarm, so the PR is already in the un-armed posture
+ * the guard wants. Distinguishing this from a genuine disarm failure is
+ * load-bearing: an armed PR that could not be disarmed is a blocker, while
+ * a never-armed PR is the desired end state.
+ */
+const NOT_ARMED = /not enabled|isn't enabled|is not set|no auto-?merge/i;
+
+/**
+ * Disarm GitHub native auto-merge for the PR — the race-free response to the
+ * first red. Never throws.
+ *
+ * @param {{ prRef: string, cwd: string, spawnFn?: typeof spawnSync }} opts
+ * @returns {{ disarmed: boolean, alreadyUnarmed: boolean, detail: string }}
+ *   `disarmed` is true when the PR is (now) un-armed; `alreadyUnarmed`
+ *   distinguishes "there was nothing armed" from an executed disarm.
+ */
+export function disarmAutoMerge({ prRef, cwd, spawnFn = spawnSync }) {
+  let result;
+  try {
+    result = spawnFn('gh', ['pr', 'merge', prRef, '--disable-auto'], {
+      cwd,
+      encoding: 'utf-8',
+      shell: false,
+    });
+  } catch (err) {
+    return {
+      disarmed: false,
+      alreadyUnarmed: false,
+      detail: `gh-spawn-error: ${err?.message ?? err}`,
+    };
+  }
+  const status = result?.status ?? 1;
+  const stderr = String(result?.stderr ?? '').trim();
+  if (status === 0) {
+    return { disarmed: true, alreadyUnarmed: false, detail: 'disarmed' };
+  }
+  if (NOT_ARMED.test(stderr)) {
+    return {
+      disarmed: true,
+      alreadyUnarmed: true,
+      detail: `auto-merge was not armed: ${stderr.slice(0, 160)}`,
+    };
+  }
+  return {
+    disarmed: false,
+    alreadyUnarmed: false,
+    detail: `gh-exit-${status}: ${stderr.slice(0, 200)}`,
+  };
+}
+
+/**
+ * Read the CI failure digest for a scope, or `null` when none exists (or it
+ * is unreadable / malformed — an unparseable digest carries no enforceable
+ * evidence, so it is treated as absent).
+ *
+ * @param {{ storyId?: number|string|null, tempRoot: string, cwd: string }} opts
+ * @returns {object|null}
+ */
+export function readCiDigest({ storyId = null, tempRoot, cwd }) {
+  const paths = ciDigestPaths({ storyId, tempRoot, cwd });
+  if (!paths || !existsSync(paths.jsonPath)) return null;
+  try {
+    const parsed = JSON.parse(readFileSync(paths.jsonPath, 'utf8'));
+    return parsed && typeof parsed === 'object' ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Retire the digest for a scope — the red it recorded was resolved at
+ * source. Best-effort; returns the paths removed (or `null`).
+ *
+ * @param {{ storyId?: number|string|null, tempRoot: string, cwd: string }} opts
+ * @returns {{ jsonPath: string, mdPath: string } | null}
+ */
+export function retireCiDigest({ storyId = null, tempRoot, cwd }) {
+  const paths = ciDigestPaths({ storyId, tempRoot, cwd });
+  if (!paths) return null;
+  rmSync(paths.jsonPath, { force: true });
+  rmSync(paths.mdPath, { force: true });
+  return { jsonPath: paths.jsonPath, mdPath: paths.mdPath };
+}
+
+/**
+ * Condense a digest into the record kept in a successor digest's
+ * `priorReds`, so a second red on a new head never silently erases the
+ * evidence of an unresolved earlier one.
+ */
+function summarizeRed(digest) {
+  return {
+    headSha: digest?.headSha ?? null,
+    failingCheck: digest?.failingCheck ?? null,
+    runId: digest?.runId ?? null,
+    runUrl: digest?.runUrl ?? null,
+    generatedAt: digest?.generatedAt ?? null,
+  };
+}
+
+/**
+ * Carry forward the unresolved reds an incoming digest must not lose. A
+ * re-red on the SAME head is the same unresolved red observed again, so it
+ * is not duplicated into the history.
+ */
+function carryPriorReds(previous, headSha) {
+  if (!previous) return [];
+  const inherited = Array.isArray(previous.priorReds) ? previous.priorReds : [];
+  const history =
+    previous.headSha && previous.headSha === headSha
+      ? inherited
+      : [...inherited, summarizeRed(previous)];
+  return history.slice(-MAX_PRIOR_REDS);
+}
+
+/**
+ * Render the human-readable digest. Names the head SHA, because that is the
+ * field the green path adjudicates on.
+ */
+function renderDigestMarkdown(digest, failures) {
+  return [
+    `# CI failure digest — Story #${digest.storyId} (PR #${digest.prNumber})`,
+    '',
+    `- **Failing check:** \`${digest.failingCheck}\` (${digest.failingOutcome})`,
+    `- **Head SHA:** ${digest.headSha ?? 'unresolved'}`,
+    `- **Run id:** ${digest.runId ?? 'unresolved'}`,
+    `- **Run link:** ${digest.runUrl ?? 'unresolved'}`,
+    `- **Classification:** ${digest.classification}`,
+    `- **Generated:** ${digest.generatedAt}`,
+    '',
+    failures.length > 1
+      ? `Other non-green checks: ${failures
+          .slice(1)
+          .map((f) => `\`${f.name}\`=${f.outcome}`)
+          .join(', ')}`
+      : '',
+    digest.priorReds.length > 0
+      ? `Unresolved earlier red(s): ${digest.priorReds
+          .map((r) => `\`${r.failingCheck}\`@${r.headSha ?? 'unknown'}`)
+          .join(', ')}`
+      : '',
+    '',
+    'A green on THIS head SHA is a re-run of a failed job and is forbidden',
+    '(`.agents/rules/ci-remediation.md` § Verifier). Fix at source and push a',
+    'new commit — the head SHA moving is what clears this digest.',
+    '',
+    '## `gh run view --log-failed` tail',
+    '',
+    '```text',
+    digest.logTail || '(no failed-log output available)',
+    '```',
+    '',
+  ].join('\n');
+}
+
+/**
+ * Write the CI failure digest (`.json` + `.md`) for a red watch. Returns
+ * the two paths written, or `null` when no story id was supplied (the
+ * digest is scoped by filename and has nothing to key on).
+ *
+ * @param {object} opts
+ * @param {number|string|null} [opts.storyId] The v2 delivery scope.
+ * @param {number} opts.prNumber
+ * @param {string|null} [opts.headSha] PR head SHA at the moment of the red.
+ * @param {Array<{name:string, outcome:string}>} opts.failures
+ * @param {string} opts.tempRoot
+ * @param {string} opts.cwd
+ * @param {string} opts.prRef
+ * @param {Function} [opts.checkRunFn]
+ * @param {Function} [opts.logTailFn]
+ * @returns {{ jsonPath: string, mdPath: string } | null}
+ */
+export function writeCiDigest({
+  storyId = null,
+  prNumber,
+  headSha = null,
+  failures,
+  tempRoot,
+  cwd,
+  prRef,
+  checkRunFn = resolveFailingCheckRun,
+  logTailFn = ghRunLogTail,
+}) {
+  const paths = ciDigestPaths({ storyId, tempRoot, cwd });
+  if (!paths) return null;
+  const primary = failures[0] ?? { name: 'unknown', outcome: 'failure' };
+  const checkRun = checkRunFn({ prRef, checkName: primary.name, cwd }) ?? {};
+  const logTail = logTailFn({ runId: checkRun.runId, cwd });
+  const previous = readCiDigest({ storyId, tempRoot, cwd });
+  const digest = {
+    storyId: paths.scope.id,
+    prNumber,
+    headSha,
+    failingCheck: primary.name,
+    failingOutcome: primary.outcome,
+    runId: checkRun.runId ?? null,
+    runUrl: checkRun.url ?? null,
+    failingCheckRun: {
+      name: primary.name,
+      outcome: primary.outcome,
+      runId: checkRun.runId ?? null,
+      url: checkRun.url ?? null,
+    },
+    classification: classifyFailure(primary.name),
+    allFailures: failures,
+    priorReds: carryPriorReds(previous, headSha),
+    logTail,
+    generatedAt: new Date().toISOString(),
+  };
+  mkdirSync(path.dirname(paths.jsonPath), { recursive: true });
+  writeFileSync(paths.jsonPath, `${JSON.stringify(digest, null, 2)}\n`);
+  writeFileSync(paths.mdPath, renderDigestMarkdown(digest, failures));
+  return { jsonPath: paths.jsonPath, mdPath: paths.mdPath };
+}
+
+/**
+ * Adjudicate an all-green watch against any digest recorded for the scope.
+ *
+ * @param {{ digest: object|null, headSha: string|null }} opts
+ * @returns {{ verdict: 'clean'|'fix-at-source'|'rerun'|'unverifiable', reason: string }}
+ *   - `clean`         — no digest: this delivery never went red.
+ *   - `fix-at-source` — the head SHA moved since the red; legal.
+ *   - `rerun`         — green on the SAME head SHA; forbidden.
+ *   - `unverifiable`  — an unresolved red with no head-SHA evidence either
+ *                       side; fail closed and treat it as a rerun.
+ */
+export function classifyGreenVerdict({ digest, headSha }) {
+  if (!digest) return { verdict: 'clean', reason: 'no digest for this scope' };
+  const recorded = digest.headSha ?? null;
+  if (!recorded || !headSha) {
+    return {
+      verdict: 'unverifiable',
+      reason: `cannot prove the red was fixed at source (digest head=${recorded ?? 'unknown'}, current head=${headSha ?? 'unresolved'})`,
+    };
+  }
+  if (recorded === headSha) {
+    return {
+      verdict: 'rerun',
+      reason: `green on the SAME head SHA the red was recorded against (${headSha})`,
+    };
+  }
+  return {
+    verdict: 'fix-at-source',
+    reason: `head SHA moved ${recorded} → ${headSha}`,
+  };
+}
+
+/**
+ * The failure signature a `meta::framework-gap` issue must carry: the first
+ * distinctive line of the captured failed-job log.
+ */
+function failureSignature(digest) {
+  const tail = String(digest?.logTail ?? '');
+  const line = tail
+    .split('\n')
+    .map((l) => l.trim())
+    .find((l) => l.length > 0);
+  return line ?? '(no failed-log output captured)';
+}
+
+/**
+ * Render the rerun-violation report — used verbatim as the friction comment
+ * body and, line by line, as the watcher's stderr report.
+ *
+ * @param {{ digest: object, headSha: string|null, prNumber: number, reason: string }} opts
+ * @returns {string}
+ */
+export function formatRerunViolation({ digest, headSha, prNumber, reason }) {
+  return [
+    '### Forbidden CI re-run detected — delivery blocked',
+    '',
+    `Required check \`${digest.failingCheck}\` went red on PR #${prNumber}, and the checks are`,
+    `now green with no new commit: ${reason}.`,
+    '',
+    `- **Head SHA:** ${headSha ?? 'unresolved'}`,
+    `- **Run link:** ${digest.runUrl ?? `run id ${digest.runId ?? 'unresolved'}`}`,
+    `- **Failure signature:** \`${failureSignature(digest)}\``,
+    `- **Classification:** ${digest.classification ?? 'unknown'}`,
+    '',
+    'A green reached by re-running a failed job masks the defect and is',
+    'prohibited by `.agents/rules/ci-remediation.md` § Verifier. Native',
+    'auto-merge was disarmed when the check first went red, so nothing merged.',
+    '',
+    '**To proceed**, do exactly one of:',
+    '',
+    '1. Fix the root cause on `story-<id>` and push a new commit — the head SHA',
+    '   moving is what clears the block.',
+    '2. File a `meta::framework-gap` issue carrying the run link and failure',
+    '   signature above when the root cause is outside this delivery, then',
+    '   resume.',
+  ].join('\n');
+}
+
+/**
+ * Hard-stop the delivery: post the `friction` comment and flip the Story to
+ * `agent::blocked`. Both halves are best-effort — a failure to reach GitHub
+ * must not turn the block into a crash, and the watcher's non-zero exit is
+ * what actually stops the delivery.
+ *
+ * Routed through `transitionTicketState` rather than a bare label write so
+ * the Projects v2 column sync runs (Story #2548 / #4539).
+ *
+ * @param {{
+ *   storyId: number|string,
+ *   body: string,
+ *   provider?: object,
+ *   config?: object,
+ *   logger?: object,
+ * }} opts
+ * @returns {Promise<{ blocked: boolean, commented: boolean }>}
+ */
+export async function blockStoryDelivery({
+  storyId,
+  body,
+  provider,
+  config,
+  logger = Logger,
+}) {
+  const scope = resolveDigestScope({ storyId });
+  if (!scope) {
+    logger?.error?.(
+      '[ci-rerun-guard] no Story id — cannot flip agent::blocked; the non-zero exit is the only stop.',
+    );
+    return { blocked: false, commented: false };
+  }
+  let ticketing;
+  try {
+    ticketing = provider ?? createProvider(config ?? resolveConfig());
+  } catch (err) {
+    logger?.error?.(
+      `[ci-rerun-guard] could not resolve the ticketing provider: ${err?.message ?? err}`,
+    );
+    return { blocked: false, commented: false };
+  }
+  let commented = false;
+  try {
+    await upsertStructuredComment(ticketing, scope.id, 'friction', body);
+    commented = true;
+  } catch (err) {
+    logger?.error?.(
+      `[ci-rerun-guard] failed to post the friction comment: ${err?.message ?? err}`,
+    );
+  }
+  let blocked = false;
+  try {
+    await transitionTicketState(ticketing, scope.id, STATE_LABELS.BLOCKED, {});
+    blocked = true;
+  } catch (err) {
+    logger?.error?.(
+      `[ci-rerun-guard] failed to flip Story #${scope.id} to blocked: ${err?.message ?? err}`,
+    );
+  }
+  return { blocked, commented };
+}

--- a/.agents/scripts/lib/orchestration/ci-rerun-guard.js
+++ b/.agents/scripts/lib/orchestration/ci-rerun-guard.js
@@ -94,10 +94,14 @@ export function classifyFailure(name) {
  * no scope can be keyed (the digest is scoped by filename and has nothing
  * to key on).
  *
+ * Module-private: `writeCiDigest` / `readCiDigest` / `retireCiDigest` are the
+ * only callers and are the surface worth pinning, so the keying is asserted
+ * through them rather than through an export nothing in production reaches.
+ *
  * @param {{ storyId?: number|string|null, tempRoot: string, cwd: string }} opts
  * @returns {{ scope: { kind: 'story', id: number }, jsonPath: string, mdPath: string } | null}
  */
-export function ciDigestPaths({ storyId = null, tempRoot, cwd }) {
+function ciDigestPaths({ storyId = null, tempRoot, cwd }) {
   const scope = resolveDigestScope({ storyId });
   if (!scope) return null;
   const dir = path.isAbsolute(tempRoot) ? tempRoot : path.join(cwd, tempRoot);

--- a/.agents/scripts/lib/orchestration/deliver-recover.js
+++ b/.agents/scripts/lib/orchestration/deliver-recover.js
@@ -406,8 +406,8 @@ export function decideRecovery({
         nextCommand: NEXT_COMMANDS.watchCi(storyId, pr.number),
         detail:
           `PR #${pr.number} has a red required check. Waiting cannot help — fix the ` +
-          `failure and push a new commit on \`story-${storyId}\`; auto-merge stays armed ` +
-          `across retries.`,
+          `failure and push a new commit on \`story-${storyId}\`; the red disarmed ` +
+          `auto-merge, and only a green on a new head SHA re-arms it.`,
         evidence,
       };
     }

--- a/.agents/scripts/lib/orchestration/lifecycle/listeners/__tests__/watcher-still-running.test.js
+++ b/.agents/scripts/lib/orchestration/lifecycle/listeners/__tests__/watcher-still-running.test.js
@@ -23,14 +23,13 @@
 
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
-
 import {
-  classifyFailure,
   resolveWatchKnobs,
   runPrWatch,
   STILL_RUNNING_EXIT_CODE,
   WATCH_DEFAULTS,
 } from '../../../../../pr-watch-with-update.js';
+import { classifyFailure } from '../../../ci-rerun-guard.js';
 import {
   hasFailingCheck,
   promotePendingToStillRunning,
@@ -194,6 +193,15 @@ describe('runPrWatch — three-way exit codes (Story #4358)', () => {
         digestArgs = args;
         return { jsonPath: '/tmp/story-4355-ci-digest.json', mdPath: '/x.md' };
       },
+      // Story #4865 — the red path now disarms native auto-merge and reads
+      // the PR head SHA. Both are `gh` calls; stub them so this unit test
+      // never touches the network (or a real PR).
+      headShaFn: () => 'head-sha',
+      disarmAutoMergeFn: () => ({
+        disarmed: true,
+        alreadyUnarmed: false,
+        detail: 'ok',
+      }),
       logger: quietLogger(),
       print,
     });

--- a/.agents/scripts/lib/orchestration/single-story-close/phases/confirm-merge.js
+++ b/.agents/scripts/lib/orchestration/single-story-close/phases/confirm-merge.js
@@ -363,7 +363,8 @@ function formatUnlandedFriction({
   const remedy =
     blockClass === 'checks-failed'
       ? `A required check is **red**. Fix the failure and push a new commit on \`story-${storyId}\`; ` +
-        `auto-merge stays armed across retries. Watch the checks with:\n\n` +
+        `the red disarms auto-merge, and only a green on a new head SHA re-arms it — ` +
+        `re-running the failed job is forbidden. Watch the checks with:\n\n` +
         `\`\`\`bash\n${NEXT_COMMANDS.watchCi(storyId, prNumber)}\n\`\`\``
       : `Resolve the underlying condition (branch protection, required checks, ` +
         `or a manual merge), then resume the land:\n\n` +

--- a/.agents/scripts/pr-watch-with-update.js
+++ b/.agents/scripts/pr-watch-with-update.js
@@ -12,15 +12,16 @@
  * created; this is a direct, synchronous watch with a real exit code.
  *
  * Slow-vs-failed semantics (Story #4358):
- *   - GREEN — every required check terminal + green → exit 0.
+ *   - GREEN — every required check terminal + green → exit 0, unless the
+ *             no-rerun guard says otherwise (below).
  *   - RED   — one or more required checks genuinely failed → exit 1
  *             IMMEDIATELY, consuming no resume budget. On red the CLI
- *             writes `temp/story-<id>-ci-digest.{json,md}` (failing check
- *             name, run id, a `gh run view --log-failed` tail, and a
- *             coarse classification) and prints the red-green
- *             remediation handoff. The digest is scoped by filename, so
- *             it requires `--story` (Story #4539: the digest was
- *             Epic-scoped and therefore never written on the only
+ *             disarms native auto-merge and writes
+ *             `temp/story-<id>-ci-digest.{json,md}` (failing check name,
+ *             head SHA, run id + run link, a `gh run view --log-failed`
+ *             tail, and a coarse classification). The digest is scoped by
+ *             filename, so it requires `--story` (Story #4539: the digest
+ *             was Epic-scoped and therefore never written on the only
  *             delivery path v2 has).
  *   - STILL-RUNNING — the poll cap fired with checks still pending and
  *             none failed; the watcher re-armed up to
@@ -28,6 +29,19 @@
  *             `still-running` verdict → exit 2 (NEVER 1, NEVER
  *             `timed_out`). The CLI prints the `gh pr checks --watch`
  *             handoff so the host can keep polling on its own cadence.
+ *
+ * No-rerun enforcement (Story #4865). `rules/ci-remediation.md` § Verifier
+ * forbids re-running a failed job to reach green; this CLI is the point
+ * that enforces it. Enforcement acts on the **first red** — GitHub's native
+ * auto-merge fires server-side and races any post-green detection, so a
+ * green can already have merged by the time it is observed. On red the
+ * watcher disarms auto-merge and records the head SHA; on green it reads
+ * the digest and adjudicates: a green on the SAME head SHA is a forbidden
+ * re-run (exit 1, `agent::blocked`, `meta::framework-gap` required), while
+ * a green on a NEW head SHA is a fix at source — the digest is retired,
+ * auto-merge is re-armed, and the delivery proceeds. A delivery that never
+ * went red has no digest and is untouched. Mechanism:
+ * `lib/orchestration/ci-rerun-guard.js`.
  *
  * Config (Story #4356 namespace, read via `getCiDelivery`):
  *   - `delivery.ci.watch.pollIntervalMs`
@@ -40,15 +54,25 @@
  *     [--repo owner/repo] [--max-updates N] [--poll-interval-ms MS]
  *     [--max-polls N] [--max-resumes N]
  */
-import { spawnSync } from 'node:child_process';
-import { mkdirSync, writeFileSync } from 'node:fs';
-import path from 'node:path';
 import { parseArgs } from 'node:util';
 import { runAsCli } from './lib/cli-utils.js';
 import { getCiDelivery } from './lib/config/ci.js';
 import { resolveConfig } from './lib/config-resolver.js';
 import { Logger } from './lib/Logger.js';
+import {
+  blockStoryDelivery,
+  classifyFailure,
+  classifyGreenVerdict,
+  disarmAutoMerge,
+  formatRerunViolation,
+  readCiDigest,
+  resolveDigestScope,
+  resolvePrHeadSha,
+  retireCiDigest,
+  writeCiDigest,
+} from './lib/orchestration/ci-rerun-guard.js';
 import { watchPrToTerminal } from './lib/orchestration/lifecycle/listeners/watcher.js';
+import { enableAutoMergeWith } from './lib/orchestration/single-story-close/phases/auto-merge.js';
 
 /** Framework fallbacks when neither a CLI flag nor config supplies a value. */
 export const WATCH_DEFAULTS = Object.freeze({
@@ -99,162 +123,156 @@ export function resolveWatchKnobs({ config, flags = {} } = {}) {
   };
 }
 
+/** Default re-arm: the sanctioned auto-merge enablement path. */
+function defaultReArm({ cwd, prNumber }) {
+  return enableAutoMergeWith({ cwd, prNumber });
+}
+
 /**
- * Coarse failure classification from a failing-check name. Pure —
- * exported for tests. Deliberately shallow: it steers the operator's
- * next move (which `/loop` unit to reach for), not a root-cause verdict.
+ * Red path (Story #4865). Disarm native auto-merge FIRST — that is the
+ * race-free moment, before any green can exist — then record the digest so
+ * the green path can adjudicate against the head SHA the red happened on.
  *
- * @param {string} name  failing required-check name.
- * @returns {'test'|'lint'|'baseline'|'build'|'unknown'}
- */
-export function classifyFailure(name) {
-  const n = String(name ?? '').toLowerCase();
-  if (/lint|format|biome|markdownlint/.test(n)) return 'lint';
-  if (/baseline|coverage|crap|maintainab|duplicat/.test(n)) return 'baseline';
-  if (/build|compile|typecheck|bundle/.test(n)) return 'build';
-  if (/test|spec|validate|ci|check/.test(n)) return 'test';
-  return 'unknown';
-}
-
-/**
- * Default `gh run view --log-failed` spawn — pulls the tail of the failed
- * job log so the digest carries an actionable excerpt. Best-effort:
- * returns an empty tail when the run id is unknown or `gh` errors.
- * Exported indirectly via `writeCiDigest` injection so tests can stub
- * without shelling out.
- */
-function ghRunLogTail({ runId, cwd, spawnFn = spawnSync, maxLines = 40 }) {
-  if (!runId) return '';
-  const result = spawnFn('gh', ['run', 'view', String(runId), '--log-failed'], {
-    cwd,
-    encoding: 'utf-8',
-    shell: false,
-    maxBuffer: 10 * 1024 * 1024,
-  });
-  const out = (result.stdout ?? '').trim();
-  if (out.length === 0) return '';
-  const lines = out.split('\n');
-  return lines.slice(-maxLines).join('\n');
-}
-
-/**
- * Resolve the GitHub Actions run id for a failing check. Best-effort via
- * `gh pr checks --json name,link` — the `link` field carries the run URL
- * whose trailing path segment is the run id. Returns `null` when
- * unresolvable.
- */
-function resolveRunId({ prRef, checkName, cwd, spawnFn = spawnSync }) {
-  const result = spawnFn('gh', ['pr', 'checks', prRef, '--json', 'name,link'], {
-    cwd,
-    encoding: 'utf-8',
-    shell: false,
-  });
-  try {
-    const parsed = JSON.parse((result.stdout ?? '').trim() || '[]');
-    const entry = Array.isArray(parsed)
-      ? parsed.find((e) => e?.name === checkName)
-      : null;
-    const link = entry?.link ?? '';
-    const m = /\/runs\/(\d+)/.exec(String(link));
-    return m ? m[1] : null;
-  } catch {
-    return null;
-  }
-}
-
-/**
- * Resolve which ticket the digest is keyed to. Story #4539: the digest used
- * to be Epic-scoped by filename and returned `null` without an epic id — so
- * on the v2 Story path (which has no Epic and invokes the watch with `--pr`
- * alone) a red check wrote no digest at all, despite the module header
- * advertising one. v2.0.0 removed the Epic tier; Story scope is the only
- * scope.
+ * A disarm failure is a **blocker**, not a warning: an armed PR whose
+ * required check went red can still be merged by GitHub the instant a
+ * re-run turns it green, which is precisely what this guard exists to stop.
  *
- * @param {{ storyId?: number|string|null }} opts
- * @returns {{ kind: 'story', id: number } | null}
+ * @returns {Promise<{ headSha: string|null, disarm: object, digestPaths: object|null, blocked: boolean }>}
  */
-export function resolveDigestScope({ storyId = null } = {}) {
-  if (storyId == null || String(storyId).length === 0) return null;
-  const parsed = Number.parseInt(String(storyId), 10);
-  return Number.isInteger(parsed) && parsed > 0
-    ? { kind: 'story', id: parsed }
-    : null;
-}
-
-/**
- * Write the CI failure digest (`.json` + `.md`) for a red watch. Returns
- * the two paths written, or `null` when no story id was supplied (the
- * digest is scoped by filename and has nothing to key on). Exported for
- * tests.
- *
- * @param {object} opts
- * @param {number|string|null} [opts.storyId] The v2 delivery scope.
- * @param {number} opts.prNumber
- * @param {Array<{name:string, outcome:string}>} opts.failures
- * @param {string} opts.tempRoot
- * @param {string} opts.cwd
- * @param {string} opts.prRef
- * @param {Function} [opts.runIdFn]
- * @param {Function} [opts.logTailFn]
- * @returns {{ jsonPath: string, mdPath: string } | null}
- */
-export function writeCiDigest({
-  storyId = null,
+async function handleRedWatch({
+  storyId,
   prNumber,
+  prRef,
   failures,
   tempRoot,
   cwd,
+  writeDigestFn,
+  headShaFn,
+  disarmFn,
+  blockFn,
+  logger,
+}) {
+  const disarm = disarmFn({ prRef, cwd });
+  const scope = resolveDigestScope({ storyId });
+  const headSha = scope ? headShaFn({ prRef, cwd }) : null;
+  let digestPaths = null;
+  try {
+    digestPaths = writeDigestFn({
+      storyId,
+      prNumber,
+      headSha,
+      failures,
+      tempRoot,
+      cwd,
+      prRef,
+    });
+  } catch (err) {
+    logger.warn?.(
+      `[pr-watch] failed to write CI digest (non-fatal): ${err?.message ?? err}`,
+    );
+  }
+  let blocked = false;
+  if (!disarm.disarmed) {
+    logger.error?.(
+      `[pr-watch] BLOCKER: auto-merge could NOT be disarmed on PR #${prNumber} (${disarm.detail}). ` +
+        'An armed PR can merge the moment a re-run turns it green — the no-rerun rule cannot be enforced.',
+    );
+    const outcome = await blockFn({
+      storyId,
+      body: [
+        '### Auto-merge could not be disarmed after a red check — delivery blocked',
+        '',
+        `A required check went red on PR #${prNumber}, but disarming native auto-merge failed:`,
+        '',
+        `> ${disarm.detail}`,
+        '',
+        'While the PR stays armed, GitHub can merge it server-side the instant the',
+        'checks read green — including a green reached by re-running the failed job,',
+        'which `.agents/rules/ci-remediation.md` § Verifier forbids. Disarm the PR by',
+        'hand (or fix the `gh` fault), then resume the delivery.',
+      ].join('\n'),
+    });
+    blocked = Boolean(outcome?.blocked);
+  } else {
+    logger.error?.(
+      `[pr-watch] native auto-merge ${disarm.alreadyUnarmed ? 'was already un-armed' : 'DISARMED'} on PR #${prNumber} — ` +
+        'it is re-armed only by a green on a NEW head SHA.',
+    );
+  }
+  if (digestPaths) {
+    logger.error?.(`[pr-watch] CI failure digest → ${digestPaths.jsonPath}`);
+  }
+  return { headSha, disarm, digestPaths, blocked };
+}
+
+/**
+ * Green path (Story #4865). Adjudicate the green against any digest the
+ * scope recorded, and return the exit code with the report the caller
+ * prints.
+ *
+ * @returns {Promise<{ verdict: string, reason: string, exitCode: number, headSha: string|null, reArmed?: boolean, blocked?: boolean }>}
+ */
+async function evaluateGreenWatch({
+  storyId,
+  prNumber,
   prRef,
-  runIdFn = resolveRunId,
-  logTailFn = ghRunLogTail,
+  tempRoot,
+  cwd,
+  readDigestFn,
+  retireDigestFn,
+  headShaFn,
+  reArmFn,
+  blockFn,
+  logger,
 }) {
   const scope = resolveDigestScope({ storyId });
-  if (!scope) return null;
-  const primary = failures[0] ?? { name: 'unknown', outcome: 'failure' };
-  const runId = runIdFn({ prRef, checkName: primary.name, cwd });
-  const logTail = logTailFn({ runId, cwd });
-  const classification = classifyFailure(primary.name);
-  const digest = {
-    storyId: scope.id,
-    prNumber,
-    failingCheck: primary.name,
-    failingOutcome: primary.outcome,
-    runId,
-    classification,
-    allFailures: failures,
-    logTail,
-    generatedAt: new Date().toISOString(),
+  if (!scope) {
+    return {
+      verdict: 'clean',
+      reason: 'no --story scope: no digest can be keyed, guard inert',
+      exitCode: 0,
+      headSha: null,
+    };
+  }
+  const digest = readDigestFn({ storyId, tempRoot, cwd });
+  if (!digest) {
+    return {
+      verdict: 'clean',
+      reason: 'no digest for this scope: this delivery never went red',
+      exitCode: 0,
+      headSha: null,
+    };
+  }
+  const headSha = headShaFn({ prRef, cwd });
+  const { verdict, reason } = classifyGreenVerdict({ digest, headSha });
+  if (verdict === 'fix-at-source') {
+    retireDigestFn({ storyId, tempRoot, cwd });
+    const reArm = await reArmFn({ cwd, prNumber });
+    const reArmed = Boolean(reArm?.enabled);
+    logger.info?.(
+      `[pr-watch] green on a NEW head SHA (${reason}) — fix at source; digest retired, ` +
+        `auto-merge ${reArmed ? 're-armed' : `NOT re-armed (${reArm?.reason ?? 'unknown'})`}.`,
+    );
+    return { verdict, reason, exitCode: 0, headSha, reArmed };
+  }
+  const body = formatRerunViolation({ digest, headSha, prNumber, reason });
+  logger.error?.(
+    `[pr-watch] FORBIDDEN CI RE-RUN: ${reason}. Required check \`${digest.failingCheck}\` was red on this exact commit.`,
+  );
+  logger.error?.(
+    `[pr-watch] run link: ${digest.runUrl ?? `run id ${digest.runId ?? 'unresolved'}`} — classification: ${digest.classification ?? 'unknown'}`,
+  );
+  logger.error?.(
+    '[pr-watch] fix the root cause and push a new commit, or file a `meta::framework-gap` issue carrying the run link and failure signature.',
+  );
+  const outcome = await blockFn({ storyId, body });
+  return {
+    verdict,
+    reason,
+    exitCode: 1,
+    headSha,
+    blocked: Boolean(outcome?.blocked),
   };
-  const dir = path.isAbsolute(tempRoot) ? tempRoot : path.join(cwd, tempRoot);
-  mkdirSync(dir, { recursive: true });
-  const base = `${scope.kind}-${scope.id}-ci-digest`;
-  const jsonPath = path.join(dir, `${base}.json`);
-  const mdPath = path.join(dir, `${base}.md`);
-  writeFileSync(jsonPath, `${JSON.stringify(digest, null, 2)}\n`);
-  const md = [
-    `# CI failure digest — Story #${scope.id} (PR #${prNumber})`,
-    '',
-    `- **Failing check:** \`${digest.failingCheck}\` (${digest.failingOutcome})`,
-    `- **Run id:** ${runId ?? 'unresolved'}`,
-    `- **Classification:** ${classification}`,
-    `- **Generated:** ${digest.generatedAt}`,
-    '',
-    failures.length > 1
-      ? `Other non-green checks: ${failures
-          .slice(1)
-          .map((f) => `\`${f.name}\`=${f.outcome}`)
-          .join(', ')}`
-      : '',
-    '',
-    '## `gh run view --log-failed` tail',
-    '',
-    '```text',
-    logTail || '(no failed-log output available)',
-    '```',
-    '',
-  ].join('\n');
-  writeFileSync(mdPath, md);
-  return { jsonPath, mdPath };
 }
 
 /**
@@ -262,8 +280,9 @@ export function writeCiDigest({
  * the green / red / still-running / BEHIND paths can be exercised with
  * injected `gh` spawns and no `process.exit`.
  *
- *   0 → all required checks green.
- *   1 → a required check genuinely failed (red).
+ *   0 → all required checks green (and the no-rerun guard cleared them).
+ *   1 → a required check genuinely failed (red), OR the green was reached
+ *       by a forbidden re-run of the same commit.
  *   2 → still-running (slow CI): cap + resume budget exhausted, none red.
  *
  * @param {object} opts
@@ -280,6 +299,12 @@ export function writeCiDigest({
  * @param {Function} [opts.ghPrUpdateBranchFn] inject for tests
  * @param {Function} [opts.sleepFn]           inject for tests
  * @param {Function} [opts.writeDigestFn]     inject for tests (default writeCiDigest)
+ * @param {Function} [opts.readDigestFn]      inject for tests (default readCiDigest)
+ * @param {Function} [opts.retireDigestFn]    inject for tests (default retireCiDigest)
+ * @param {Function} [opts.headShaFn]         inject for tests (default resolvePrHeadSha)
+ * @param {Function} [opts.disarmAutoMergeFn] inject for tests (default disarmAutoMerge)
+ * @param {Function} [opts.reArmAutoMergeFn]  inject for tests (default enableAutoMergeWith)
+ * @param {Function} [opts.blockDeliveryFn]   inject for tests (default blockStoryDelivery)
  * @param {object} [opts.logger]
  * @param {(line: string) => void} [opts.print] stdout sink (default process.stdout)
  * @returns {Promise<number>} process exit code.
@@ -299,6 +324,12 @@ export async function runPrWatch({
   ghPrUpdateBranchFn,
   sleepFn,
   writeDigestFn = writeCiDigest,
+  readDigestFn = readCiDigest,
+  retireDigestFn = retireCiDigest,
+  headShaFn = resolvePrHeadSha,
+  disarmAutoMergeFn = disarmAutoMerge,
+  reArmAutoMergeFn = defaultReArm,
+  blockDeliveryFn = blockStoryDelivery,
   logger = Logger,
   print = (line) => process.stdout.write(`${line}\n`),
 } = {}) {
@@ -313,6 +344,7 @@ export async function runPrWatch({
   });
   const effectiveTempRoot =
     tempRoot ?? resolvedConfig?.project?.paths?.tempRoot ?? 'temp';
+  const cwd = process.cwd();
 
   // `gh` accepts a bare PR number or a URL; passing `<repo>#<n>` lets
   // `gh` resolve the right repository without a URL. When `--repo` is
@@ -321,7 +353,7 @@ export async function runPrWatch({
 
   const result = await watchPrToTerminal({
     prUrl: prRef,
-    cwd: process.cwd(),
+    cwd,
     maxPolls: knobs.maxPolls,
     maxUpdates: knobs.maxUpdates,
     maxResumes: knobs.maxResumes,
@@ -335,22 +367,21 @@ export async function runPrWatch({
 
   // Always print the final outcomes map so the operator (and the
   // workflow log) can see exactly which check blocked.
-  print(
-    JSON.stringify({
-      prNumber,
-      checkOutcomes: result.outcomes,
-      requiredChecks: result.requiredChecks,
-      polls: result.polls,
-      updatesApplied: result.updatesApplied,
-      resumesApplied: result.resumesApplied,
-      terminal: result.terminal,
-      green: result.green,
-      stillRunning: result.stillRunning,
-      ...(result.error ? { error: result.error } : {}),
-    }),
-  );
+  const envelope = {
+    prNumber,
+    checkOutcomes: result.outcomes,
+    requiredChecks: result.requiredChecks,
+    polls: result.polls,
+    updatesApplied: result.updatesApplied,
+    resumesApplied: result.resumesApplied,
+    terminal: result.terminal,
+    green: result.green,
+    stillRunning: result.stillRunning,
+    ...(result.error ? { error: result.error } : {}),
+  };
 
   if (result.error) {
+    print(JSON.stringify(envelope));
     logger.error?.(
       `[pr-watch] could not resolve required checks: ${result.error}`,
     );
@@ -358,14 +389,31 @@ export async function runPrWatch({
   }
 
   if (result.green) {
-    logger.info?.('[pr-watch] all required checks green.');
-    return 0;
+    const guard = await evaluateGreenWatch({
+      storyId,
+      prNumber,
+      prRef,
+      tempRoot: effectiveTempRoot,
+      cwd,
+      readDigestFn,
+      retireDigestFn,
+      headShaFn,
+      reArmFn: reArmAutoMergeFn,
+      blockFn: blockDeliveryFn,
+      logger,
+    });
+    print(JSON.stringify({ ...envelope, rerunGuard: guard }));
+    if (guard.exitCode === 0) {
+      logger.info?.('[pr-watch] all required checks green.');
+    }
+    return guard.exitCode;
   }
 
   // Slow-but-not-red: the cap AND resume budget are exhausted with checks
   // still pending and none failed. Never exit 1, never `timed_out` — hand
   // off to the host's interval loop and exit 2.
   if (result.stillRunning) {
+    print(JSON.stringify(envelope));
     const stillPending = Object.entries(result.outcomes)
       .filter(([, v]) => v === 'still-running')
       .map(([k]) => k)
@@ -377,8 +425,8 @@ export async function runPrWatch({
     return STILL_RUNNING_EXIT_CODE;
   }
 
-  // Genuine red check — exit 1 immediately, write the digest, and surface
-  // the fix-loop handoff.
+  // Genuine red check — exit 1 immediately, disarm auto-merge, write the
+  // digest, and surface the fix-loop handoff.
   // Exclude 'still-running' as well as the non-failing states: when the cap
   // fires with a mixed failed+pending map, promotePendingToStillRunning has
   // rewritten the pending entries, and a still-running check is slow, not
@@ -395,26 +443,36 @@ export async function runPrWatch({
     .map(([name, outcome]) => ({ name, outcome }));
   const red = failures.map((f) => `${f.name}=${f.outcome}`).join(', ');
   logger.error?.(`[pr-watch] required check(s) not green: ${red}`);
-  let digestPaths = null;
-  try {
-    digestPaths = writeDigestFn({
-      storyId,
-      prNumber,
-      failures,
-      tempRoot: effectiveTempRoot,
-      cwd: process.cwd(),
-      prRef,
-    });
-  } catch (err) {
-    logger.warn?.(
-      `[pr-watch] failed to write CI digest (non-fatal): ${err?.message ?? err}`,
-    );
-  }
-  if (digestPaths) {
-    logger.error?.(`[pr-watch] CI failure digest → ${digestPaths.jsonPath}`);
-  }
+  const redOutcome = await handleRedWatch({
+    storyId,
+    prNumber,
+    prRef,
+    failures,
+    tempRoot: effectiveTempRoot,
+    cwd,
+    writeDigestFn,
+    headShaFn,
+    disarmFn: disarmAutoMergeFn,
+    blockFn: blockDeliveryFn,
+    logger,
+  });
+  print(
+    JSON.stringify({
+      ...envelope,
+      classification: classifyFailure(failures[0]?.name),
+      rerunGuard: {
+        verdict: 'red',
+        headSha: redOutcome.headSha,
+        autoMergeDisarmed: redOutcome.disarm.disarmed,
+        disarmDetail: redOutcome.disarm.detail,
+        digestPath: redOutcome.digestPaths?.jsonPath ?? null,
+        blocked: redOutcome.blocked,
+      },
+    }),
+  );
   logger.error?.(
-    '[pr-watch] a required check failed. Read the digest, apply the smallest fix, and re-run the suite until green.',
+    '[pr-watch] a required check failed. Read the digest, reproduce the failure, and apply the smallest fix at source, ' +
+      'then push a new commit — re-running the failed job is forbidden (`.agents/rules/ci-remediation.md` § Verifier).',
   );
   return 1;
 }

--- a/.agents/workflows/helpers/deliver-story-reference.md
+++ b/.agents/workflows/helpers/deliver-story-reference.md
@@ -27,7 +27,7 @@ caller: helpers/deliver-story.md
 
 Before any git mutation, init takes an exclusive, time-bounded **lease** on
 the Story ticket via the assignee-as-lease primitive
-(`lib/orchestration/ticket-lease.js`). The single assignee *is* the lease
+(`lib/orchestration/ticket-lease.js`). The single assignee _is_ the lease
 owner (resolved from `github.operatorHandle`). The standalone path has no
 Epic-scoped dispatch manifest to serialise two operators driving the same
 Story, so this lease is the only guard against a concurrent
@@ -38,7 +38,7 @@ has **no Epic-scoped lifecycle ledger** to read a per-owner
 `story.heartbeat` from, so there is no live-heartbeat source to decide
 whether a foreign claim is stale. Rather than silently reclaim every
 foreign assignee (which would leave the guard inert), the standalone lease
-**fails closed**: a foreign assignee is treated as a *live* claim. Outcomes:
+**fails closed**: a foreign assignee is treated as a _live_ claim. Outcomes:
 
 - **Unclaimed / self-held** → init proceeds (a self-held claim is
   re-affirmed without re-writing assignees).
@@ -80,9 +80,9 @@ The sweep applies two hardening layers:
     changes.
   - `ticket-not-done` — the parent Story ticket isn't closed and
     doesn't carry `agent::done`.
-  Protected candidates are skipped, listed in the sweep result envelope
-  under `protected[]`, and named in the `CLEANUP` log line so the
-  operator can see what was preserved.
+    Protected candidates are skipped, listed in the sweep result envelope
+    under `protected[]`, and named in the `CLEANUP` log line so the
+    operator can see what was preserved.
 - **Cross-session lock.** The sweep acquires a process-scoped lockfile
   at `<tempRoot>/single-story-sweep.lock` before planning. On
   contention (another `/deliver-story` already in the sweep
@@ -116,16 +116,16 @@ not a substitute for prefixing paths correctly.
 
 The v2 engine's trait table:
 
-| Trait | v2 `/deliver-story` |
-| --- | --- |
-| Ticket type | `type::story` only |
-| Branch | `story-<id>` seeded from `project.baseBranch` (`main`) |
-| Merge target | `main` via PR (squash + required checks) |
-| Spec / slices | Folded `## Spec` + optional `## Slicing` checkpoints in-session |
-| Ceremony | Per-Story, routed off the derived change level via `ceremony-routing.js` |
+| Trait         | v2 `/deliver-story`                                                      |
+| ------------- | ------------------------------------------------------------------------ |
+| Ticket type   | `type::story` only                                                       |
+| Branch        | `story-<id>` seeded from `project.baseBranch` (`main`)                   |
+| Merge target  | `main` via PR (squash + required checks)                                 |
+| Spec / slices | Folded `## Spec` + optional `## Slicing` checkpoints in-session          |
+| Ceremony      | Per-Story, routed off the derived change level via `ceremony-routing.js` |
 
 **Ceremony-lite Stories still land through this engine unchanged.** A
-lite-routed Story collapses only the *advisory* plan/deliver
+lite-routed Story collapses only the _advisory_ plan/deliver
 ceremony — the fresh-critic / Tech-Spec authoring a one-artifact scope does
 not earn. It does **not** get a cheaper landing: the close-validation gates
 (lint / test / format / coverage / CRAP / maintainability), the PR to `main`,
@@ -135,7 +135,7 @@ record of those non-negotiables; there is no lite-specific gate bypass.
 
 **Deliver derives the route from the Story body's shape — and the
 dispatch mode from the run.** Persist stamps a lite cohort's Stories with the
-`route::lite` label as a *human-visible hint only* (and ledgers the authored
+`route::lite` label as a _human-visible hint only_ (and ledgers the authored
 verdict — recorded reason plus per-Story shape evidence — on the
 `story-plan-state` checkpoint); the label is never the control signal.
 `/deliver` computes the route from the fetched Story body via
@@ -280,7 +280,7 @@ separate (`delivery.mergeWatch.*`):
   it when your host has no such ceiling and you want to land in one block.
 - **`maxBudgetSeconds`** (default 3600) bounds the **cumulative** wait across
   resumes, anchored at the PR's `createdAt` so resuming does not restart the
-  clock. Exhausting *this* is the genuine give-up → `blocked`.
+  clock. Exhausting _this_ is the genuine give-up → `blocked`.
 
 The wait probes the checks every poll: a red required check fails fast as
 `checks-failed` instead of burning the budget, and a PR that falls behind its
@@ -312,7 +312,7 @@ checks pass. Under `"strict"`, the close **does not arm auto-merge** — the
 PR opens and waits for an **operator merge**, exactly as `--no-auto-merge`
 does per-run.
 
-**When to reach for a close flag.** What each one *does* is in
+**When to reach for a close flag.** What each one _does_ is in
 `node .agents/scripts/single-story-close.js --help`; below is only the
 judgment that help text cannot carry.
 
@@ -346,7 +346,7 @@ The `single-story-close.js` script, in order:
    captured tail inline so the evidence is in front of you without opening a
    file. Read the artifact when you need the full text — or re-run under
    `AGENT_LOG_LEVEL=verbose` for live streaming.
-1a. **Syncs the Story branch from `origin/<baseBranch>`** before push.
+   1a. **Syncs the Story branch from `origin/<baseBranch>`** before push.
    Runs `git fetch origin <baseBranch>` followed by
    `git merge --no-edit origin/<baseBranch>` inside the worktree. This
    defends against the parallel-`/deliver-story` race: when
@@ -370,12 +370,13 @@ The `single-story-close.js` script, in order:
    defence against the parallel race. Without merge queue, the sync
    closes the PR-open-time race but a residual race remains between PR
    open and auto-merge fire.
+
 2. Pushes `story-<id>` to `origin`.
 3. Probes for an existing open PR with `head = story-<id>`. If none
    exists, opens one via `gh pr create --base <baseBranch>`. The PR
    body carries `Closes #<storyId>` so the GitHub merge auto-closes the
    issue.
-3a. **Enables GitHub native auto-merge by default** via
+   3a. **Enables GitHub native auto-merge by default** via
    `gh pr merge <prNumber> --auto --squash --delete-branch`. Once CI's
    required checks turn green, GitHub squash-merges the PR and deletes
    the source branch — the operator does not need to babysit the merge
@@ -385,7 +386,7 @@ The `single-story-close.js` script, in order:
    pre-merge eyeball.
 4. Flips the Story to **`agent::closing`** (NOT `agent::done`) and leaves
    the GitHub issue **OPEN**. Auto-merge completes
-   asynchronously *after* this script exits, so closing the issue here
+   asynchronously _after_ this script exits, so closing the issue here
    would strand a CLOSED issue with no merged work if the PR later failed
    CI, went `BEHIND` base, or was closed without merging. The Story rests
    at `agent::closing` while the PR is open with auto-merge armed; the
@@ -430,9 +431,10 @@ close-validation gates pass on the dev host's environment; CI runs on a
 different OS and concurrency, and coverage rounding, platform-conditional
 branches, and timing-sensitive tests routinely drift between the two.
 
-Fix the failure and push a new commit on `story-<storyId>` — auto-merge stays
-armed across retries, so you do not re-arm — then resume the land with the
-envelope's `nextCommand`.
+Fix the failure and push a new commit on `story-<storyId>` — the watcher
+**disarmed native auto-merge on the first red** and re-arms it
+only when the checks go green on a **new head SHA**, so the fix must be a real
+commit — then resume the land with the envelope's `nextCommand`.
 
 To watch the checks on the red path, drive `pr-watch-with-update.js` — the
 **single CI-watch mechanism**. It polls the required checks to a
@@ -444,8 +446,10 @@ node <agentRoot>/scripts/pr-watch-with-update.js --pr <prNumber> --story <storyI
 ```
 
 `--story` is what keys the red-path CI digest
-(`temp/story-<id>-ci-digest.{json,md}` — failing check name, run id, and a
-`gh run view --log-failed` tail). Omit it and a red check writes no digest.
+(`temp/story-<id>-ci-digest.{json,md}` — failing check name, the PR head SHA,
+run id + run link, and a `gh run view --log-failed` tail). Omit it and a red
+check writes no digest — and with no digest the no-rerun guard has nothing to
+adjudicate the next green against, so always pass it.
 Poll cadence and caps come from `delivery.ci.watch.*` (`pollIntervalMs`,
 `maxPolls`, `maxResumes`); pass `--poll-interval-ms`, `--max-polls`, or
 `--max-resumes` to override for one run.
@@ -454,14 +458,19 @@ When the watch exits, branch on the exit code:
 
 - **Exit 0 (all checks ✓)** — auto-merge will fire (or has already). The Story
   is still at `agent::closing` with its issue OPEN. **Proceed to merge
-  confirmation (§ Step 5) within the same turn** — green CI is the *start* of
+  confirmation (§ Step 5) within the same turn** — green CI is the _start_ of
   the merge-confirm sequence, not a terminal state.
-- **Exit 1 (a check genuinely failed)** — diagnose, fix, and push a new commit
-  on `story-<storyId>`, then re-watch. Auto-merge stays enabled across retries;
-  no need to re-arm it. The Story stays at `agent::closing` throughout, so a
-  failed/abandoned PR never strands a CLOSED issue. If the same failure class
-  recurs, hand convergence off to a self-paced host loop (`/loop`) that re-runs
-  the failing check and applies the smallest fix until it exits green.
+- **Exit 1 (a check genuinely failed, or the green was a forbidden re-run)** —
+  diagnose, fix at source, and push a new commit on `story-<storyId>`, then
+  re-watch: the watcher disarmed auto-merge on the red and re-arms it only for
+  a green on a **new head SHA**. The Story stays at `agent::closing`
+  throughout, so a failed/abandoned PR never strands a CLOSED issue. If the
+  same failure class recurs, hand convergence off to a self-paced host loop
+  (`/loop`) that applies the smallest fix and pushes a new commit each pass —
+  **never** a bare re-run of the failed job. A green the guard rejects as a
+  re-run of the same commit flips the Story to `agent::blocked` with a
+  `friction` comment; clear it per
+  [`ci-remediation.md`](../../rules/ci-remediation.md) § Verifier.
 - **Exit 2 (still-running — slow CI, not red)** — the poll cap fired with checks
   still pending and the watcher exhausted its resume budget with nothing red.
   This is **never** a failure. Hand the wait off to the host's interval loop
@@ -485,7 +494,7 @@ then ends its turn with **free-form prose** — e.g. "I'll wait for the
 background watch task to complete" or "the next event will be its completion
 notification" — leaving the merge unconfirmed and the Story stranded at
 `agent::closing`. **Do not do this.**
-`pr-watch-with-update.js --pr <prNumber>` *blocks the current turn* until CI
+`pr-watch-with-update.js --pr <prNumber>` _blocks the current turn_ until CI
 resolves — that is the mechanism by which you wait. You MUST keep your turn alive
 across the wait: watch → (fix + push + re-watch on red) → confirm the merge
 (Step 5) → flip `agent::done` → run the post-merge steps → and only then
@@ -555,8 +564,9 @@ the watch exits clean.
 
 - The PR stays open across retries; `gh pr create` is a one-shot at
   close, the loop only pushes new commits.
-- Auto-merge stays armed across retries — pushing a new commit does
-  not disarm `gh pr merge --auto`.
+- Auto-merge is disarmed by the watcher on the first red and re-armed
+  when the checks go green on a new head SHA; pushing a new commit is
+  what re-opens the merge path.
 - If the operator manually merges or disables auto-merge mid-loop,
   exit the loop and report.
 
@@ -612,7 +622,7 @@ no-op-safe (`no-project` / `not-on-project` exit 0).
 
 The GitHub Projects v2 built-in workflows `Pull request merged` and
 `Pull request linked to issue` are enabled by default on most boards
-and fire ~minutes *after* auto-merge lands. They overwrite the Status
+and fire ~minutes _after_ auto-merge lands. They overwrite the Status
 field as a side-effect, clobbering the `Done` value
 `single-story-confirm-merge.js` set at the `agent::done` flip in Step 5
 and leaving closed Stories stuck at `In Progress` on the board. The
@@ -680,7 +690,7 @@ GitHub deletes the **remote** branch on auto-merge (via the
 `--delete-branch` flag `single-story-close.js` passes to `gh pr merge`).
 The **local** `story-<storyId>` ref, however, lingers in the main
 checkout until something prunes it — `single-story-init.js` runs a
-merged-sweep at the start of every *subsequent* `/deliver-story`
+merged-sweep at the start of every _subsequent_ `/deliver-story`
 invocation, but that's next-run cleanup, not end-of-run cleanup. Stale
 local refs accumulate between sessions, clutter `git branch`, and shadow
 the lessons the sweep is meant to surface.
@@ -724,7 +734,7 @@ The field-level contract is the shipped schema
 — not this file, and not
 [`agents/story-worker.md`](../../agents/story-worker.md). All three used to
 carry their own prose version; the schema is now the only definition. What
-follows is the *judgement* around it, which a schema cannot express.
+follows is the _judgement_ around it, which a schema cannot express.
 
 ### `pending` is a real status — and it is not a park
 

--- a/.agents/workflows/helpers/deliver-story.md
+++ b/.agents/workflows/helpers/deliver-story.md
@@ -111,9 +111,7 @@ node <main-repo>/.agents/scripts/single-story-close.js --story <storyId> --cwd <
 post-land tail in one process. Run it and **branch on the terminal envelope's
 `status`** per the table in **digest § 5** (`landed` → Step 7; `pending` → run
 `nextCommand`; `blocked`/`checks-failed` → Step 4; `failed` → diagnose and
-re-run). Gate output is captured to
-`temp/orchestration/close-gates-<storyId>.log` — a clean run prints a digest
-line, a red gate replays its tail inline.
+re-run). Gate output is captured, not streamed — digest § 5.
 
 Internals (gate order, base-sync, auto-merge arming), the merge-wait
 budgets, the slow-CI **async** confirm mode (launch the `pending`
@@ -126,8 +124,9 @@ poll), the `autoMerge` policy, and every close flag: reference
 A `landed` envelope means everything ran — go straight to Step 7. Enter a
 recovery path **only** when the envelope routes you there:
 
-- **`blocked` / `checks-failed`** → fix, push a new commit (auto-merge stays
-  armed), resume via `nextCommand`; triage per
+- **`blocked` / `checks-failed`** → the red **disarms auto-merge**; fix at
+  source and push a new commit (only a green on a NEW head SHA re-arms — a
+  re-run is refused), resume via `nextCommand`; triage per
   [`rules/ci-remediation.md`](../../rules/ci-remediation.md). The watch is
   internally blocking — never end a turn with prose and an unconfirmed
   merge. Reference § Step 4.

--- a/tests/lib/orchestration/lifecycle/pr-watch-with-update.test.js
+++ b/tests/lib/orchestration/lifecycle/pr-watch-with-update.test.js
@@ -102,8 +102,15 @@ describe('runPrWatch — red path', () => {
       pollIntervalMs: 0,
       maxResumes: 0,
       sleepFn: async () => {},
-      // No epicId → no digest is written (Epic-scoped by filename), so
-      // this test never touches the filesystem.
+      // No storyId → no digest is written (scoped by filename), so this
+      // test never touches the filesystem. Story #4865: the red path also
+      // disarms native auto-merge — stub that `gh` call so the unit test
+      // never reaches a real PR.
+      disarmAutoMergeFn: () => ({
+        disarmed: true,
+        alreadyUnarmed: false,
+        detail: 'ok',
+      }),
       ghPrChecksFn: () => ({
         status: 0,
         stdout: JSON.stringify([

--- a/tests/scripts/pr-watch-digest.test.js
+++ b/tests/scripts/pr-watch-digest.test.js
@@ -1,22 +1,27 @@
 /**
- * pr-watch-digest.test.js — Story #4539.
+ * pr-watch-digest.test.js — Story #4539, extended by Story #4865.
  *
  * The red-path CI digest was Epic-scoped by filename and bailed out
  * (`return null`) whenever no story id was supplied. The v2 Story delivery
  * path has no Epic and invoked the watch with `--pr` alone, so a red check
  * wrote no digest at all — while the module header advertised one. These
  * tests pin the Story-scoped keying and the no-scope bail-out.
+ *
+ * Story #4865 moved the digest into `lib/orchestration/ci-rerun-guard.js`
+ * (the module that also owns the head-SHA discriminator) and gave it the
+ * two fields the no-rerun guard adjudicates on: the PR head SHA and the
+ * failing check-run identity (run id + run link).
  */
 
 import assert from 'node:assert/strict';
 import { readFileSync, rmSync } from 'node:fs';
 import path from 'node:path';
 import { describe, it } from 'node:test';
-import { makeTempDir } from '../../.agents/scripts/lib/test-temp.js';
 import {
   resolveDigestScope,
   writeCiDigest,
-} from '../../.agents/scripts/pr-watch-with-update.js';
+} from '../../.agents/scripts/lib/orchestration/ci-rerun-guard.js';
+import { makeTempDir } from '../../.agents/scripts/lib/test-temp.js';
 
 const FAILURES = [
   { name: 'test', outcome: 'failure' },
@@ -53,11 +58,15 @@ describe('writeCiDigest', () => {
       const out = writeCiDigest({
         storyId: 4539,
         prNumber: 12,
+        headSha: 'abc123',
         failures: FAILURES,
         tempRoot,
         cwd: tempRoot,
         prRef: '12',
-        runIdFn: () => '987654',
+        checkRunFn: () => ({
+          runId: '987654',
+          url: 'https://github.com/o/r/actions/runs/987654',
+        }),
         logTailFn: () => 'AssertionError: boom',
       });
 
@@ -79,6 +88,92 @@ describe('writeCiDigest', () => {
     });
   });
 
+  it('records the head SHA and the failing check-run identity (AC-1)', () => {
+    withTempRoot((tempRoot) => {
+      const out = writeCiDigest({
+        storyId: 4865,
+        prNumber: 77,
+        headSha: 'deadbeefcafe',
+        failures: [{ name: 'baselines', outcome: 'failure' }],
+        tempRoot,
+        cwd: tempRoot,
+        prRef: '77',
+        checkRunFn: () => ({
+          runId: '5150',
+          url: 'https://github.com/o/r/actions/runs/5150',
+        }),
+        logTailFn: () => 'crap: methodsAbove20 regressed',
+      });
+
+      const digest = JSON.parse(readFileSync(out.jsonPath, 'utf8'));
+      assert.equal(digest.headSha, 'deadbeefcafe');
+      assert.equal(digest.runUrl, 'https://github.com/o/r/actions/runs/5150');
+      assert.deepEqual(digest.failingCheckRun, {
+        name: 'baselines',
+        outcome: 'failure',
+        runId: '5150',
+        url: 'https://github.com/o/r/actions/runs/5150',
+      });
+      assert.equal(digest.classification, 'baseline');
+
+      const md = readFileSync(out.mdPath, 'utf8');
+      assert.match(md, /\*\*Head SHA:\*\* deadbeefcafe/);
+      assert.match(md, /\*\*Run link:\*\* https/);
+    });
+  });
+
+  it('carries an unresolved earlier red forward instead of overwriting it away', () => {
+    withTempRoot((tempRoot) => {
+      const common = {
+        storyId: 4865,
+        prNumber: 77,
+        tempRoot,
+        cwd: tempRoot,
+        prRef: '77',
+        logTailFn: () => '',
+      };
+      writeCiDigest({
+        ...common,
+        headSha: 'sha-one',
+        failures: [{ name: 'test', outcome: 'failure' }],
+        checkRunFn: () => ({ runId: '1', url: 'u/1' }),
+      });
+      const out = writeCiDigest({
+        ...common,
+        headSha: 'sha-two',
+        failures: [{ name: 'lint', outcome: 'failure' }],
+        checkRunFn: () => ({ runId: '2', url: 'u/2' }),
+      });
+
+      const digest = JSON.parse(readFileSync(out.jsonPath, 'utf8'));
+      assert.equal(digest.headSha, 'sha-two');
+      assert.equal(digest.priorReds.length, 1);
+      assert.equal(digest.priorReds[0].headSha, 'sha-one');
+      assert.equal(digest.priorReds[0].failingCheck, 'test');
+      assert.match(readFileSync(out.mdPath, 'utf8'), /Unresolved earlier red/);
+    });
+  });
+
+  it('does not duplicate history when the SAME head reds twice', () => {
+    withTempRoot((tempRoot) => {
+      const common = {
+        storyId: 4865,
+        prNumber: 77,
+        headSha: 'same-sha',
+        tempRoot,
+        cwd: tempRoot,
+        prRef: '77',
+        failures: [{ name: 'test', outcome: 'failure' }],
+        checkRunFn: () => ({ runId: '1', url: 'u/1' }),
+        logTailFn: () => '',
+      };
+      writeCiDigest(common);
+      const out = writeCiDigest(common);
+      const digest = JSON.parse(readFileSync(out.jsonPath, 'utf8'));
+      assert.deepEqual(digest.priorReds, []);
+    });
+  });
+
   it('returns null when neither scope is supplied, rather than writing an unkeyed file', () => {
     withTempRoot((tempRoot) => {
       const out = writeCiDigest({
@@ -87,7 +182,7 @@ describe('writeCiDigest', () => {
         tempRoot,
         cwd: tempRoot,
         prRef: '12',
-        runIdFn: () => '1',
+        checkRunFn: () => ({ runId: '1', url: null }),
         logTailFn: () => '',
       });
       assert.equal(out, null);

--- a/tests/scripts/pr-watch-rerun-guard.test.js
+++ b/tests/scripts/pr-watch-rerun-guard.test.js
@@ -1,0 +1,528 @@
+/**
+ * pr-watch-rerun-guard.test.js — Story #4865.
+ *
+ * `rules/ci-remediation.md` § Verifier forbids re-running a failed job to
+ * reach green, and until this Story nothing enforced it: a red check wrote
+ * a digest nobody read, and native auto-merge stayed armed, so a rerun-green
+ * merged silently.
+ *
+ * The enforcement point is `pr-watch-with-update.js`, and it acts on the
+ * FIRST RED — GitHub's auto-merge fires server-side and races any post-green
+ * detection. These tests pin the whole contract through `runPrWatch` with
+ * every `gh` port injected (no network, no filesystem outside a temp root,
+ * no `process.exit`):
+ *
+ *   - red    → auto-merge disarmed, digest records the head SHA (AC-2)
+ *   - red    → a disarm FAILURE is a blocker, not a warning (AC-2)
+ *   - green + digest, SAME head → exit 1 + agent::blocked (AC-3)
+ *   - green + digest, NEW head  → exit 0, digest retired, re-armed (AC-4)
+ *   - green, no digest          → exit 0 unchanged; still-running → 2 (AC-5)
+ *   - the failure guidance no longer tells the operator to re-run (AC-6)
+ */
+
+import assert from 'node:assert/strict';
+import { existsSync, rmSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+import { describe, it } from 'node:test';
+import {
+  classifyGreenVerdict,
+  disarmAutoMerge,
+  formatRerunViolation,
+  resolvePrHeadSha,
+} from '../../.agents/scripts/lib/orchestration/ci-rerun-guard.js';
+import { makeTempDir } from '../../.agents/scripts/lib/test-temp.js';
+import { runPrWatch } from '../../.agents/scripts/pr-watch-with-update.js';
+
+const RED_CHECKS = {
+  status: 0,
+  stdout: JSON.stringify([
+    { name: 'Validate and Test', state: 'SUCCESS', bucket: 'pass' },
+    { name: 'baselines', state: 'FAILURE', bucket: 'fail' },
+  ]),
+  stderr: '',
+};
+
+const GREEN_CHECKS = {
+  status: 0,
+  stdout: JSON.stringify([
+    { name: 'Validate and Test', state: 'SUCCESS', bucket: 'pass' },
+    { name: 'baselines', state: 'SUCCESS', bucket: 'pass' },
+  ]),
+  stderr: '',
+};
+
+const CLEAN_VIEW = {
+  status: 0,
+  stdout: JSON.stringify({ mergeStateStatus: 'CLEAN' }),
+  stderr: '',
+};
+
+function recorder() {
+  const lines = { info: [], warn: [], error: [], print: [] };
+  return {
+    lines,
+    logger: {
+      info: (m) => lines.info.push(m),
+      warn: (m) => lines.warn.push(m),
+      error: (m) => lines.error.push(m),
+      debug: () => {},
+    },
+    print: (l) => lines.print.push(l),
+  };
+}
+
+async function withTempRoot(fn) {
+  const dir = makeTempDir('mandrel-rerun-guard-');
+  try {
+    await fn(dir);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+/** A digest as the red path would have written it. */
+function seedDigest(tempRoot, storyId, digest) {
+  const file = path.join(tempRoot, `story-${storyId}-ci-digest.json`);
+  writeFileSync(file, JSON.stringify(digest, null, 2));
+  writeFileSync(path.join(tempRoot, `story-${storyId}-ci-digest.md`), '# seed');
+  return file;
+}
+
+/** Baseline watch options: red or green checks, everything else stubbed. */
+function watchOpts({ checks, tempRoot, storyId, rec, ...rest }) {
+  return {
+    prNumber: 4865,
+    storyId,
+    config: null,
+    tempRoot,
+    pollIntervalMs: 0,
+    maxResumes: 0,
+    sleepFn: async () => {},
+    ghPrChecksFn: () => checks,
+    ghPrViewFn: () => CLEAN_VIEW,
+    logger: rec.logger,
+    print: rec.print,
+    ...rest,
+  };
+}
+
+describe('no-rerun guard — red path (AC-1, AC-2)', () => {
+  it('disarms native auto-merge and records the head SHA on the first red', async () => {
+    await withTempRoot(async (tempRoot) => {
+      const rec = recorder();
+      const disarmCalls = [];
+      const written = [];
+      const code = await runPrWatch(
+        watchOpts({
+          checks: RED_CHECKS,
+          tempRoot,
+          storyId: 4865,
+          rec,
+          headShaFn: () => 'red-sha',
+          disarmAutoMergeFn: (args) => {
+            disarmCalls.push(args);
+            return { disarmed: true, alreadyUnarmed: false, detail: 'ok' };
+          },
+          writeDigestFn: (args) => {
+            written.push(args);
+            return { jsonPath: '/tmp/d.json', mdPath: '/tmp/d.md' };
+          },
+          blockDeliveryFn: async () => ({ blocked: true, commented: true }),
+        }),
+      );
+
+      assert.equal(code, 1, 'a red check still exits 1');
+      assert.equal(disarmCalls.length, 1, 'auto-merge is disarmed on red');
+      assert.equal(
+        written[0].headSha,
+        'red-sha',
+        'digest carries the head SHA',
+      );
+      assert.equal(written[0].failures[0].name, 'baselines');
+
+      const out = JSON.parse(rec.lines.print[0]);
+      assert.equal(out.rerunGuard.autoMergeDisarmed, true);
+      assert.equal(out.rerunGuard.headSha, 'red-sha');
+      assert.equal(out.classification, 'baseline');
+    });
+  });
+
+  it('treats a disarm FAILURE as a blocker, not a warning', async () => {
+    await withTempRoot(async (tempRoot) => {
+      const rec = recorder();
+      const blocks = [];
+      const code = await runPrWatch(
+        watchOpts({
+          checks: RED_CHECKS,
+          tempRoot,
+          storyId: 4865,
+          rec,
+          headShaFn: () => 'red-sha',
+          disarmAutoMergeFn: () => ({
+            disarmed: false,
+            alreadyUnarmed: false,
+            detail: 'gh-exit-1: HTTP 403',
+          }),
+          writeDigestFn: () => null,
+          blockDeliveryFn: async (args) => {
+            blocks.push(args);
+            return { blocked: true, commented: true };
+          },
+        }),
+      );
+
+      assert.equal(code, 1);
+      assert.equal(blocks.length, 1, 'the delivery is routed to blocked');
+      assert.match(blocks[0].body, /could not be disarmed/i);
+      assert.ok(
+        rec.lines.error.some((l) => /BLOCKER/.test(l)),
+        'the disarm failure is reported as a blocker',
+      );
+      const out = JSON.parse(rec.lines.print[0]);
+      assert.equal(out.rerunGuard.autoMergeDisarmed, false);
+      assert.equal(out.rerunGuard.blocked, true);
+    });
+  });
+
+  it('no longer instructs the operator to re-run the suite until green (AC-6)', async () => {
+    await withTempRoot(async (tempRoot) => {
+      const rec = recorder();
+      await runPrWatch(
+        watchOpts({
+          checks: RED_CHECKS,
+          tempRoot,
+          storyId: 4865,
+          rec,
+          headShaFn: () => 'red-sha',
+          disarmAutoMergeFn: () => ({
+            disarmed: true,
+            alreadyUnarmed: false,
+            detail: 'ok',
+          }),
+          writeDigestFn: () => null,
+          blockDeliveryFn: async () => ({ blocked: true, commented: true }),
+        }),
+      );
+
+      const all = [...rec.lines.error, ...rec.lines.warn, ...rec.lines.info];
+      assert.ok(
+        !all.some((l) => /re-run the suite/i.test(l)),
+        'the forbidden affordance is gone',
+      );
+      assert.ok(
+        all.some((l) => /re-running the failed job is forbidden/i.test(l)),
+        'the guidance names the prohibition instead',
+      );
+    });
+  });
+});
+
+describe('no-rerun guard — green path (AC-3, AC-4, AC-5)', () => {
+  it('blocks a green reached on the SAME head SHA the red was recorded against', async () => {
+    await withTempRoot(async (tempRoot) => {
+      const rec = recorder();
+      seedDigest(tempRoot, 4865, {
+        storyId: 4865,
+        prNumber: 4865,
+        headSha: 'same-sha',
+        failingCheck: 'baselines',
+        runId: '5150',
+        runUrl: 'https://github.com/o/r/actions/runs/5150',
+        classification: 'baseline',
+        logTail: 'crap: methodsAbove20 regressed',
+        priorReds: [],
+      });
+      const blocks = [];
+      let reArmed = 0;
+      const code = await runPrWatch(
+        watchOpts({
+          checks: GREEN_CHECKS,
+          tempRoot,
+          storyId: 4865,
+          rec,
+          headShaFn: () => 'same-sha',
+          reArmAutoMergeFn: async () => {
+            reArmed += 1;
+            return { enabled: true };
+          },
+          blockDeliveryFn: async (args) => {
+            blocks.push(args);
+            return { blocked: true, commented: true };
+          },
+        }),
+      );
+
+      assert.equal(code, 1, 'a rerun-green must NOT exit 0');
+      assert.equal(reArmed, 0, 'a rerun-green never re-arms auto-merge');
+      assert.equal(blocks.length, 1);
+      assert.match(blocks[0].body, /meta::framework-gap/);
+      assert.match(blocks[0].body, /runs\/5150/, 'the run link is carried');
+      assert.match(
+        blocks[0].body,
+        /methodsAbove20 regressed/,
+        'the failure signature is carried',
+      );
+      assert.ok(
+        existsSync(path.join(tempRoot, 'story-4865-ci-digest.json')),
+        'the unresolved digest is NOT retired by a violation',
+      );
+
+      const out = JSON.parse(rec.lines.print[0]);
+      assert.equal(out.green, true);
+      assert.equal(out.rerunGuard.verdict, 'rerun');
+      assert.equal(out.rerunGuard.blocked, true);
+    });
+  });
+
+  it('fails closed when the red carries no head SHA to adjudicate against', async () => {
+    await withTempRoot(async (tempRoot) => {
+      const rec = recorder();
+      seedDigest(tempRoot, 4865, {
+        storyId: 4865,
+        prNumber: 4865,
+        failingCheck: 'baselines',
+        classification: 'baseline',
+        logTail: '',
+      });
+      const code = await runPrWatch(
+        watchOpts({
+          checks: GREEN_CHECKS,
+          tempRoot,
+          storyId: 4865,
+          rec,
+          headShaFn: () => 'whatever',
+          blockDeliveryFn: async () => ({ blocked: true, commented: true }),
+        }),
+      );
+
+      assert.equal(code, 1);
+      const out = JSON.parse(rec.lines.print[0]);
+      assert.equal(out.rerunGuard.verdict, 'unverifiable');
+    });
+  });
+
+  it('lets a green on a NEW head SHA through, retiring the digest and re-arming', async () => {
+    await withTempRoot(async (tempRoot) => {
+      const rec = recorder();
+      seedDigest(tempRoot, 4865, {
+        storyId: 4865,
+        prNumber: 4865,
+        headSha: 'old-sha',
+        failingCheck: 'baselines',
+        runUrl: 'https://github.com/o/r/actions/runs/1',
+        classification: 'baseline',
+        logTail: '',
+      });
+      const blocks = [];
+      const reArms = [];
+      const code = await runPrWatch(
+        watchOpts({
+          checks: GREEN_CHECKS,
+          tempRoot,
+          storyId: 4865,
+          rec,
+          headShaFn: () => 'new-sha',
+          reArmAutoMergeFn: async (args) => {
+            reArms.push(args);
+            return { enabled: true };
+          },
+          blockDeliveryFn: async (args) => {
+            blocks.push(args);
+            return { blocked: true, commented: true };
+          },
+        }),
+      );
+
+      assert.equal(code, 0, 'fix-at-source is unobstructed');
+      assert.equal(blocks.length, 0, 'nothing is blocked');
+      assert.equal(reArms.length, 1, 'auto-merge is re-armed');
+      assert.equal(reArms[0].prNumber, 4865);
+      assert.equal(
+        existsSync(path.join(tempRoot, 'story-4865-ci-digest.json')),
+        false,
+        'the resolved digest is retired',
+      );
+      assert.equal(
+        existsSync(path.join(tempRoot, 'story-4865-ci-digest.md')),
+        false,
+      );
+
+      const out = JSON.parse(rec.lines.print[0]);
+      assert.equal(out.rerunGuard.verdict, 'fix-at-source');
+      assert.equal(out.rerunGuard.reArmed, true);
+    });
+  });
+
+  it('exits 0 unchanged for a delivery that never went red (no digest)', async () => {
+    await withTempRoot(async (tempRoot) => {
+      const rec = recorder();
+      let reArmed = 0;
+      const code = await runPrWatch(
+        watchOpts({
+          checks: GREEN_CHECKS,
+          tempRoot,
+          storyId: 4865,
+          rec,
+          headShaFn: () => {
+            throw new Error('the head SHA must not be probed with no digest');
+          },
+          reArmAutoMergeFn: async () => {
+            reArmed += 1;
+            return { enabled: true };
+          },
+        }),
+      );
+
+      assert.equal(code, 0);
+      assert.equal(reArmed, 0, 'a clean green never re-arms');
+      const out = JSON.parse(rec.lines.print[0]);
+      assert.equal(out.green, true);
+      assert.equal(out.rerunGuard.verdict, 'clean');
+    });
+  });
+
+  it('leaves the still-running (exit 2) contract untouched', async () => {
+    await withTempRoot(async (tempRoot) => {
+      const rec = recorder();
+      const code = await runPrWatch(
+        watchOpts({
+          checks: {
+            status: 8,
+            stdout: JSON.stringify([
+              { name: 'baselines', state: 'IN_PROGRESS', bucket: 'pending' },
+            ]),
+            stderr: '',
+          },
+          tempRoot,
+          storyId: 4865,
+          rec,
+          maxPolls: 1,
+          headShaFn: () => {
+            throw new Error('a still-running watch must not probe the head');
+          },
+          disarmAutoMergeFn: () => {
+            throw new Error('a still-running watch must not disarm');
+          },
+        }),
+      );
+
+      assert.equal(code, 2);
+      const out = JSON.parse(rec.lines.print[0]);
+      assert.equal(out.stillRunning, true);
+      assert.equal(out.rerunGuard, undefined);
+    });
+  });
+});
+
+describe('ci-rerun-guard units', () => {
+  it('classifyGreenVerdict discriminates on the head SHA', () => {
+    assert.equal(
+      classifyGreenVerdict({ digest: null, headSha: 'a' }).verdict,
+      'clean',
+    );
+    assert.equal(
+      classifyGreenVerdict({ digest: { headSha: 'a' }, headSha: 'a' }).verdict,
+      'rerun',
+    );
+    assert.equal(
+      classifyGreenVerdict({ digest: { headSha: 'a' }, headSha: 'b' }).verdict,
+      'fix-at-source',
+    );
+    assert.equal(
+      classifyGreenVerdict({ digest: { headSha: 'a' }, headSha: null }).verdict,
+      'unverifiable',
+    );
+    assert.equal(
+      classifyGreenVerdict({ digest: {}, headSha: 'a' }).verdict,
+      'unverifiable',
+    );
+  });
+
+  it('resolvePrHeadSha reads headRefOid and degrades to null', () => {
+    assert.equal(
+      resolvePrHeadSha({
+        prRef: '1',
+        cwd: '.',
+        spawnFn: () => ({
+          status: 0,
+          stdout: JSON.stringify({ headRefOid: 'abc' }),
+        }),
+      }),
+      'abc',
+    );
+    assert.equal(
+      resolvePrHeadSha({
+        prRef: '1',
+        cwd: '.',
+        spawnFn: () => ({ status: 1, stdout: '', stderr: 'boom' }),
+      }),
+      null,
+    );
+    assert.equal(
+      resolvePrHeadSha({
+        prRef: '1',
+        cwd: '.',
+        spawnFn: () => ({ status: 0, stdout: 'not json' }),
+      }),
+      null,
+    );
+  });
+
+  it('disarmAutoMerge separates a never-armed PR from a genuine failure', () => {
+    assert.deepEqual(
+      disarmAutoMerge({
+        prRef: '1',
+        cwd: '.',
+        spawnFn: () => ({ status: 0, stdout: '', stderr: '' }),
+      }),
+      { disarmed: true, alreadyUnarmed: false, detail: 'disarmed' },
+    );
+
+    const notArmed = disarmAutoMerge({
+      prRef: '1',
+      cwd: '.',
+      spawnFn: () => ({
+        status: 1,
+        stdout: '',
+        stderr: 'auto-merge is not enabled for this pull request',
+      }),
+    });
+    assert.equal(notArmed.disarmed, true);
+    assert.equal(notArmed.alreadyUnarmed, true);
+
+    const failed = disarmAutoMerge({
+      prRef: '1',
+      cwd: '.',
+      spawnFn: () => ({ status: 1, stdout: '', stderr: 'HTTP 403: forbidden' }),
+    });
+    assert.equal(failed.disarmed, false);
+    assert.match(failed.detail, /gh-exit-1/);
+
+    const threw = disarmAutoMerge({
+      prRef: '1',
+      cwd: '.',
+      spawnFn: () => {
+        throw new Error('ENOENT');
+      },
+    });
+    assert.equal(threw.disarmed, false);
+    assert.match(threw.detail, /gh-spawn-error/);
+  });
+
+  it('formatRerunViolation carries the run link and failure signature', () => {
+    const body = formatRerunViolation({
+      digest: {
+        failingCheck: 'test',
+        runUrl: 'https://github.com/o/r/actions/runs/9',
+        classification: 'test',
+        logTail: '\n  AssertionError: expected 1 to equal 2\nmore\n',
+      },
+      headSha: 'sha',
+      prNumber: 12,
+      reason: 'green on the SAME head SHA',
+    });
+    assert.match(body, /runs\/9/);
+    assert.match(body, /AssertionError: expected 1 to equal 2/);
+    assert.match(body, /meta::framework-gap/);
+  });
+});


### PR DESCRIPTION
Closes #4865

_Auto-opened by `/deliver`._