### PR TITLE
fix: ratchet baseline shrinkage instead of passing it silently, and stop the updater CLIs writing a baseline on --help (#4872)

### DIFF
--- a/.agents/scripts/check-context-budget.js
+++ b/.agents/scripts/check-context-budget.js
@@ -47,9 +47,18 @@
  * Ratchet semantics (mirroring the sibling ratchets):
  *   - A gated tier grows beyond `baseline.tiers.<tier>.totalBytes +
  *     baseline.toleranceBytes` → exit 1, naming the tier and its delta.
- *   - A gated tier shrinks below its baseline total → printed as a `-`
- *     (removal) note, warning the baseline can be refreshed downward.
- *     Shrink-only exits 0.
+ *   - A gated tier shrinks below its baseline total → exit 1 (Story #4872).
+ *     A ratchet that only tightens in one direction lets every measured
+ *     improvement evaporate: the recorded total keeps promising headroom the
+ *     tree no longer spends, so the next growth is absorbed by stale slack
+ *     instead of being reported. Shrinkage is therefore **actionable** —
+ *     refresh the baseline down and the gain is locked in. Unlike growth this
+ *     is deliberately **zero-tolerance**: `toleranceBytes` exists to keep a
+ *     trivial addition from churning the file, and applying it downward would
+ *     silently discard every sub-tolerance gain.
+ *   - A recorded row naming a path the measured tier no longer contains →
+ *     exit 1. The row describes a file that has been deleted or de-listed, so
+ *     the bytes it contributes to the recorded total are fiction.
  *   - Within tolerance / clean → exit 0.
  *   - Baseline file absent → warn + exit 0 (no-op; nothing to ratchet against).
  *
@@ -304,15 +313,44 @@ export function buildBaseline(tierMap, toleranceBytes) {
 }
 
 /**
+ * Collect the recorded rows of one gated tier that name a path the measured
+ * tier no longer contains (Story #4872). A deleted file drops out of the
+ * resolved tier, and so does one that has been de-listed from the read set —
+ * either way the row's bytes are counted into a recorded total that no live
+ * file backs, so the row is drift and not a detail.
+ *
+ * @param {string} tier
+ * @param {Array<{ path: string, bytes: number }>} files live tier measurement
+ * @param {{ files?: Array<{ path: string, bytes?: number }> }} baseTier recorded tier
+ * @returns {Array<{ tier: string, path: string, bytes: number|null }>}
+ */
+function absentRows(tier, files, baseTier) {
+  const live = new Set(files.map((f) => f.path));
+  const out = [];
+  for (const row of baseTier?.files ?? []) {
+    if (typeof row?.path !== 'string' || live.has(row.path)) continue;
+    out.push({
+      tier,
+      path: row.path,
+      bytes: Number.isFinite(row.bytes) ? row.bytes : null,
+    });
+  }
+  return out;
+}
+
+/**
  * Pure diff: compare the current tier map against the committed baseline. A
  * gated tier with no current files is skipped; a tier absent from the baseline
- * is skipped. `grown` entries fail the gate; `shrunk` entries are informational.
+ * is skipped. `grown`, `shrunk` and `absent` entries all fail the gate — see
+ * the ratchet semantics in the module header for why shrinkage is actionable
+ * rather than informational (Story #4872).
  *
  * @param {{ tiers: Record<string, Array<{ path: string, bytes: number }>> }} tierMap
  * @param {{ toleranceBytes?: number, tiers?: Record<string, { totalBytes: number }> }} baseline
  * @returns {{
  *   grown: Array<{ tier: string, current: number, baseline: number, tolerance: number, delta: number }>,
- *   shrunk: Array<{ tier: string, current: number, baseline: number }>,
+ *   shrunk: Array<{ tier: string, current: number, baseline: number, delta: number }>,
+ *   absent: Array<{ tier: string, path: string, bytes: number|null }>,
  *   skipped: string[],
  * }}
  */
@@ -322,6 +360,7 @@ export function diffBudget(tierMap, baseline) {
     : 0;
   const grown = [];
   const shrunk = [];
+  const absent = [];
   const skipped = [];
   for (const tier of GATED_TIERS) {
     const files = tierMap.tiers[tier] ?? [];
@@ -345,16 +384,42 @@ export function diffBudget(tierMap, baseline) {
         delta: current - baselineBytes,
       });
     } else if (current < baselineBytes) {
-      shrunk.push({ tier, current, baseline: baselineBytes });
+      // Deliberately zero-tolerance: `tolerance` guards against churn from a
+      // trivial *addition*; mirroring it downward would discard every gain
+      // smaller than the tolerance, which is the leak this branch closes.
+      shrunk.push({
+        tier,
+        current,
+        baseline: baselineBytes,
+        delta: baselineBytes - current,
+      });
     }
+    absent.push(...absentRows(tier, files, baseTier));
   }
-  return { grown, shrunk, skipped };
+  return { grown, shrunk, absent, skipped };
+}
+
+/**
+ * Count the drift entries that fail the gate. Every direction is actionable
+ * (Story #4872), so this is the one place the failure set is defined and both
+ * the summary tag and the exit code read it.
+ *
+ * @param {ReturnType<typeof diffBudget>} diff
+ * @returns {number}
+ */
+export function budgetFailureCount(diff) {
+  return (
+    (diff?.grown?.length ?? 0) +
+    (diff?.shrunk?.length ?? 0) +
+    (diff?.absent?.length ?? 0)
+  );
 }
 
 /**
  * Render the human-readable diff. `+` lines are tiers that grew beyond
- * tolerance (gate fail); `-` lines are tiers that shrank (refreshable
- * baseline). A one-line summary always follows.
+ * tolerance; `-` lines are tiers that shrank below their recorded total or
+ * rows naming a path the tree no longer carries. All three fail the gate. A
+ * one-line summary always follows.
  *
  * @param {ReturnType<typeof diffBudget>} diff
  * @returns {string}
@@ -368,12 +433,17 @@ export function renderDiff(diff) {
   }
   for (const s of diff.shrunk) {
     lines.push(
-      `- ${s.tier}: ${s.current} bytes below baseline ${s.baseline} — refresh baselines/context-budget.json`,
+      `- ${s.tier}: ${s.current} bytes is under the recorded ${s.baseline} (delta -${s.delta}) — the ratchet is holding slack the tree no longer spends; refresh baselines/context-budget.json`,
     );
   }
-  const tag = diff.grown.length > 0 ? '(gate fail)' : '(ok)';
+  for (const a of diff.absent ?? []) {
+    lines.push(
+      `- ${a.tier}: recorded row ${a.path} names a path the measured tier no longer contains — refresh baselines/context-budget.json`,
+    );
+  }
+  const tag = budgetFailureCount(diff) > 0 ? '(gate fail)' : '(ok)';
   lines.push(
-    `[context-budget] grown=${diff.grown.length} shrunk=${diff.shrunk.length} skipped=${diff.skipped.length} ${tag}`,
+    `[context-budget] grown=${diff.grown.length} shrunk=${diff.shrunk.length} absent=${diff.absent?.length ?? 0} skipped=${diff.skipped.length} ${tag}`,
   );
   return lines.join('\n');
 }
@@ -454,7 +524,7 @@ export async function runCli({
   if (!baseline) {
     if (json) {
       stdout.write(
-        `${JSON.stringify({ kind: 'context-budget-report', baselinePath: resolvedBaselinePath, tiers: tierMap.tiers, grown: [], shrunk: [], skipped: GATED_TIERS, exitCode: 0, noBaseline: true }, null, 2)}\n`,
+        `${JSON.stringify({ kind: 'context-budget-report', baselinePath: resolvedBaselinePath, tiers: tierMap.tiers, grown: [], shrunk: [], absent: [], skipped: GATED_TIERS, exitCode: 0, noBaseline: true }, null, 2)}\n`,
       );
     } else {
       stderr.write(
@@ -472,7 +542,7 @@ export async function runCli({
   const bootDrift = agentBootDrift(tierMap, baseline, ceiling);
   const permissiveDrift = bootDrift.filter((d) => d.direction === 'permissive');
   const exitCode =
-    diff.grown.length > 0 ||
+    budgetFailureCount(diff) > 0 ||
     bootOverflow.length > 0 ||
     permissiveDrift.length > 0
       ? 1
@@ -490,6 +560,7 @@ export async function runCli({
       ),
       grown: diff.grown,
       shrunk: diff.shrunk,
+      absent: diff.absent,
       skipped: diff.skipped,
       agentBootCeilingBytes: ceiling,
       agentBootOverflow: bootOverflow,
@@ -525,6 +596,16 @@ export async function runCli({
       if (diff.grown.length > 0) {
         stderr.write(
           `[context-budget] ❌ a documentation tier grew beyond tolerance — refresh the budget consciously with \`node .agents/scripts/check-context-budget.js --update\` once the growth is intentional\n`,
+        );
+      }
+      if (diff.shrunk.length > 0) {
+        stderr.write(
+          `[context-budget] ❌ a documentation tier came in under its recorded total — the ratchet is holding slack the tree no longer spends, so the next growth would be absorbed silently. Lock the gain in with \`node .agents/scripts/check-context-budget.js --update\`\n`,
+        );
+      }
+      if (diff.absent.length > 0) {
+        stderr.write(
+          `[context-budget] ❌ a recorded row names a path the measured tier no longer contains — its bytes inflate the recorded total against nothing. Refresh with \`node .agents/scripts/check-context-budget.js --update\`\n`,
         );
       }
     }

--- a/.agents/scripts/update-crap-baseline.js
+++ b/.agents/scripts/update-crap-baseline.js
@@ -5,6 +5,7 @@ import './lib/runtime-deps/ensure-installed.js';
 import path from 'node:path';
 import { parseDiffScopeFlag } from './lib/baselines/diff-scope-cli.js';
 import { refreshBaseline } from './lib/baselines/refresh-service.js';
+import { runAsCli } from './lib/cli-utils.js';
 import { getBaselineEpsilon } from './lib/config/quality.js';
 import {
   getBaselines,
@@ -43,6 +44,40 @@ import { Logger } from './lib/Logger.js';
  * so downstream `check-crap` can tell "intentional empty baseline" apart from
  * "no baseline yet".
  */
+
+/**
+ * Usage block for `--help` (Story #4872). This CLI *writes* on invocation, so
+ * the help branch must short-circuit before `main` runs rather than inside it —
+ * `runAsCli` answers help first, which makes "a usage probe never mutates a
+ * baseline" structural instead of a check `main` has to remember.
+ */
+const USAGE = {
+  invocation:
+    'node .agents/scripts/update-crap-baseline.js [--baseline <path>] [--coverage <path>] [--full-scope | --diff-scope <ref>]',
+  summary:
+    'Scan → score → write the CRAP baseline. With no scope flag the refresh is scoped to the files changed in `origin/main..HEAD`; out-of-scope rows are preserved verbatim.',
+  flags: [
+    [
+      '--baseline <path>',
+      'Write to this path instead of `delivery.quality.baselines.crap.path`.',
+    ],
+    [
+      '--coverage <path>',
+      'Read coverage from this path (default `coverage/coverage-final.json`).',
+    ],
+    [
+      '--full-scope',
+      'Rescore every file in every target dir (no out-of-scope merge).',
+    ],
+    [
+      '--diff-scope <ref>',
+      'Scope the refresh to files changed between <ref> and HEAD. Incompatible with --full-scope.',
+    ],
+  ],
+  notes: [
+    'Run `npm run test:coverage` first — without a coverage artifact every file is skipped.',
+  ],
+};
 
 function parseCliArgs(argv = process.argv.slice(2)) {
   const out = {
@@ -183,8 +218,11 @@ async function main() {
   );
 }
 
-// cli-opt-out: top-level main().catch predates runAsCli; never imported elsewhere so the auto-run risk is moot.
-main().catch((err) => {
-  Logger.error(`[CRAP] ❌ Fatal error: ${err?.stack ?? err?.message ?? err}`);
-  process.exit(1);
+runAsCli(import.meta.url, main, {
+  source: 'crap-baseline',
+  usage: USAGE,
+  onError: (err) => {
+    Logger.error(`[CRAP] ❌ Fatal error: ${err?.stack ?? err?.message ?? err}`);
+    process.exitCode = 1;
+  },
 });

--- a/.agents/scripts/update-maintainability-baseline.js
+++ b/.agents/scripts/update-maintainability-baseline.js
@@ -43,9 +43,33 @@ import './lib/runtime-deps/ensure-installed.js';
 import path from 'node:path';
 import { parseDiffScopeFlag } from './lib/baselines/diff-scope-cli.js';
 import { refreshBaseline } from './lib/baselines/refresh-service.js';
+import { runAsCli } from './lib/cli-utils.js';
 import { getBaselineEpsilon } from './lib/config/quality.js';
 import { getBaselines, resolveConfig } from './lib/config-resolver.js';
 import { Logger } from './lib/Logger.js';
+
+/**
+ * Usage block for `--help` (Story #4872). This CLI *writes* on invocation, so
+ * the help branch must short-circuit before `main` runs rather than inside it —
+ * `runAsCli` answers help first, which makes "a usage probe never mutates a
+ * baseline" structural instead of a check `main` has to remember.
+ */
+const USAGE = {
+  invocation:
+    'node .agents/scripts/update-maintainability-baseline.js [--full-scope | --diff-scope <ref>]',
+  summary:
+    'Score → write the maintainability baseline. With no scope flag the refresh is scoped to the files changed in `origin/main..HEAD`; out-of-scope rows are preserved verbatim.',
+  flags: [
+    [
+      '--full-scope',
+      'Rescore every file in every target dir (no out-of-scope merge).',
+    ],
+    [
+      '--diff-scope <ref>',
+      'Scope the refresh to files changed between <ref> and HEAD. Incompatible with --full-scope.',
+    ],
+  ],
+};
 
 /**
  * Parse `--full-scope` (boolean opt-out flag).
@@ -119,8 +143,11 @@ async function main() {
   );
 }
 
-// cli-opt-out: top-level main().catch predates runAsCli; never imported elsewhere so the auto-run risk is moot.
-main().catch((err) => {
-  Logger.error(`[Maintainability] ❌ Fatal error: ${err.message}`);
-  process.exit(1);
+runAsCli(import.meta.url, main, {
+  source: 'maintainability-baseline',
+  usage: USAGE,
+  onError: (err) => {
+    Logger.error(`[Maintainability] ❌ Fatal error: ${err.message}`);
+    process.exitCode = 1;
+  },
 });

--- a/baselines/context-budget.json
+++ b/baselines/context-budget.json
@@ -1,18 +1,18 @@
 {
   "$schema": "https://mandrel.dev/baselines/context-budget.schema.json",
-  "generatedAt": "2026-07-25T10:52:12.409Z",
+  "generatedAt": "2026-08-01T11:24:22.213Z",
   "toleranceBytes": 2048,
   "tiers": {
     "alwaysLoaded": {
-      "totalBytes": 21314,
+      "totalBytes": 21135,
       "files": [
         {
           "path": ".agentrc.json",
-          "bytes": 1933
+          "bytes": 1944
         },
         {
           "path": ".agents/instructions.md",
-          "bytes": 9154
+          "bytes": 9036
         },
         {
           "path": ".agents/rules/git-conventions.md",
@@ -24,7 +24,7 @@
         },
         {
           "path": "AGENTS.md",
-          "bytes": 2531
+          "bytes": 2459
         },
         {
           "path": "CLAUDE.md",
@@ -33,28 +33,28 @@
       ]
     },
     "mandatoryRead": {
-      "totalBytes": 363627,
+      "totalBytes": 326734,
       "files": [
         {
           "path": "docs/architecture.md",
-          "bytes": 88546
+          "bytes": 89966
         },
         {
           "path": "docs/data-dictionary.md",
-          "bytes": 37654
+          "bytes": 39134
         },
         {
           "path": "docs/decisions.md",
-          "bytes": 184959
+          "bytes": 146649
         },
         {
           "path": "docs/patterns.md",
-          "bytes": 52468
+          "bytes": 50985
         }
       ]
     },
     "workflow": {
-      "totalBytes": 228277,
+      "totalBytes": 227542,
       "files": [
         {
           "path": ".agents/workflows/audit-accessibility.md",
@@ -90,7 +90,7 @@
         },
         {
           "path": ".agents/workflows/audit-performance.md",
-          "bytes": 9933
+          "bytes": 9892
         },
         {
           "path": ".agents/workflows/audit-privacy.md",
@@ -121,12 +121,8 @@
           "bytes": 5008
         },
         {
-          "path": ".agents/workflows/deliver-light.md",
-          "bytes": 6990
-        },
-        {
           "path": ".agents/workflows/deliver.md",
-          "bytes": 7940
+          "bytes": 8127
         },
         {
           "path": ".agents/workflows/git-cleanup.md",
@@ -138,19 +134,23 @@
         },
         {
           "path": ".agents/workflows/helpers/deliver-digest.md",
-          "bytes": 6456
+          "bytes": 6657
         },
         {
           "path": ".agents/workflows/helpers/deliver-story.md",
-          "bytes": 7976
+          "bytes": 8166
         },
         {
           "path": ".agents/workflows/mandrel-update.md",
-          "bytes": 12326
+          "bytes": 12482
         },
         {
           "path": ".agents/workflows/plan.md",
-          "bytes": 7774
+          "bytes": 8188
+        },
+        {
+          "path": ".agents/workflows/prototype.md",
+          "bytes": 5148
         },
         {
           "path": ".agents/workflows/qa-assist.md",
@@ -193,7 +193,7 @@
     ]
   },
   "workflowClosure": {
-    "reachableTotalBytes": 368984,
+    "reachableTotalBytes": 394686,
     "entryPoints": [
       {
         "path": ".agents/workflows/audit-accessibility.md",
@@ -228,7 +228,7 @@
       {
         "path": ".agents/workflows/audit-documentation.md",
         "mandatoryBytes": 11889,
-        "reachableBytes": 145359
+        "reachableBytes": 199249
       },
       {
         "path": ".agents/workflows/audit-navigability.md",
@@ -237,8 +237,8 @@
       },
       {
         "path": ".agents/workflows/audit-performance.md",
-        "mandatoryBytes": 9933,
-        "reachableBytes": 27544
+        "mandatoryBytes": 9892,
+        "reachableBytes": 27503
       },
       {
         "path": ".agents/workflows/audit-privacy.md",
@@ -268,7 +268,7 @@
       {
         "path": ".agents/workflows/audit-to-stories.md",
         "mandatoryBytes": 12782,
-        "reachableBytes": 115859
+        "reachableBytes": 187360
       },
       {
         "path": ".agents/workflows/audit-ux-ui.md",
@@ -276,14 +276,9 @@
         "reachableBytes": 38924
       },
       {
-        "path": ".agents/workflows/deliver-light.md",
-        "mandatoryBytes": 6990,
-        "reachableBytes": 122849
-      },
-      {
         "path": ".agents/workflows/deliver.md",
-        "mandatoryBytes": 7940,
-        "reachableBytes": 115859
+        "mandatoryBytes": 8127,
+        "reachableBytes": 187360
       },
       {
         "path": ".agents/workflows/git-cleanup.md",
@@ -293,37 +288,42 @@
       {
         "path": ".agents/workflows/git-deliver.md",
         "mandatoryBytes": 7640,
-        "reachableBytes": 140624
+        "reachableBytes": 212125
       },
       {
         "path": ".agents/workflows/helpers/deliver-story.md",
-        "mandatoryBytes": 14432,
-        "reachableBytes": 115859
+        "mandatoryBytes": 14823,
+        "reachableBytes": 187360
       },
       {
         "path": ".agents/workflows/mandrel-update.md",
-        "mandatoryBytes": 12326,
-        "reachableBytes": 24067
+        "mandatoryBytes": 12482,
+        "reachableBytes": 24223
       },
       {
         "path": ".agents/workflows/plan.md",
-        "mandatoryBytes": 7774,
-        "reachableBytes": 115859
+        "mandatoryBytes": 8188,
+        "reachableBytes": 187360
+      },
+      {
+        "path": ".agents/workflows/prototype.md",
+        "mandatoryBytes": 5148,
+        "reachableBytes": 187360
       },
       {
         "path": ".agents/workflows/qa-assist.md",
         "mandatoryBytes": 16561,
-        "reachableBytes": 180759
+        "reachableBytes": 252260
       },
       {
         "path": ".agents/workflows/qa-explore.md",
         "mandatoryBytes": 13422,
-        "reachableBytes": 180759
+        "reachableBytes": 252260
       },
       {
         "path": ".agents/workflows/qa-run.md",
         "mandatoryBytes": 13618,
-        "reachableBytes": 180759
+        "reachableBytes": 252260
       }
     ]
   }

--- a/tests/check-context-budget.test.js
+++ b/tests/check-context-budget.test.js
@@ -8,6 +8,7 @@ import {
   AGENT_BOOT_CEILING_BYTES,
   agentBootDrift,
   agentBootOverflow,
+  budgetFailureCount,
   buildBaseline,
   diffBudget,
   GATED_TIERS,
@@ -114,7 +115,7 @@ test('diffBudget flags growth beyond tolerance and names the tier', () => {
   assert.ok(diff.skipped.includes('mandatoryRead'));
 });
 
-test('diffBudget treats within-tolerance growth as clean and shrink as informational', () => {
+test('diffBudget treats within-tolerance growth as clean and shrink as actionable drift', () => {
   const baseline = {
     toleranceBytes: 500,
     tiers: { alwaysLoaded: { totalBytes: 4000 } },
@@ -124,6 +125,7 @@ test('diffBudget treats within-tolerance growth as clean and shrink as informati
     baseline,
   );
   assert.deepEqual(within.grown, []);
+  assert.deepEqual(within.shrunk, []);
 
   const shrunk = diffBudget(
     { tiers: { alwaysLoaded: [{ path: 'x', bytes: 3000 }] } },
@@ -132,6 +134,59 @@ test('diffBudget treats within-tolerance growth as clean and shrink as informati
   assert.equal(shrunk.grown.length, 0);
   assert.equal(shrunk.shrunk.length, 1);
   assert.equal(shrunk.shrunk[0].tier, 'alwaysLoaded');
+  assert.equal(shrunk.shrunk[0].delta, 1000);
+  assert.equal(budgetFailureCount(shrunk), 1);
+});
+
+test('diffBudget applies tolerance upward only — a sub-tolerance shrink is still drift', () => {
+  // Story #4872: mirroring the tolerance downward would silently discard every
+  // gain smaller than it, which is precisely the leak the ratchet must close.
+  const diff = diffBudget(
+    { tiers: { alwaysLoaded: [{ path: 'x', bytes: 3999 }] } },
+    { toleranceBytes: 500, tiers: { alwaysLoaded: { totalBytes: 4000 } } },
+  );
+  assert.equal(diff.shrunk.length, 1);
+  assert.equal(diff.shrunk[0].delta, 1);
+  assert.equal(budgetFailureCount(diff), 1);
+});
+
+test('diffBudget reports a recorded row naming a path the tier no longer contains', () => {
+  const diff = diffBudget(
+    { tiers: { workflow: [{ path: 'a.md', bytes: 100 }] } },
+    {
+      toleranceBytes: 0,
+      tiers: {
+        workflow: {
+          totalBytes: 100,
+          files: [
+            { path: 'a.md', bytes: 100 },
+            { path: 'deleted.md', bytes: 0 },
+          ],
+        },
+      },
+    },
+  );
+  // The total still agrees — only the row-level check can see this one.
+  assert.deepEqual(diff.grown, []);
+  assert.deepEqual(diff.shrunk, []);
+  assert.equal(diff.absent.length, 1);
+  assert.equal(diff.absent[0].path, 'deleted.md');
+  assert.equal(diff.absent[0].tier, 'workflow');
+  assert.equal(budgetFailureCount(diff), 1);
+});
+
+test('diffBudget reports no absent rows when every recorded path is still measured', () => {
+  const diff = diffBudget(
+    { tiers: { workflow: [{ path: 'a.md', bytes: 100 }] } },
+    {
+      toleranceBytes: 0,
+      tiers: {
+        workflow: { totalBytes: 100, files: [{ path: 'a.md', bytes: 100 }] },
+      },
+    },
+  );
+  assert.deepEqual(diff.absent, []);
+  assert.equal(budgetFailureCount(diff), 0);
 });
 
 test('buildBaseline records only the gated tiers with totals', () => {
@@ -165,11 +220,36 @@ test('renderDiff tags a gate fail and a clean pass', () => {
         },
       ],
       shrunk: [],
+      absent: [],
       skipped: [],
     }),
     /\(gate fail\)/,
   );
-  assert.match(renderDiff({ grown: [], shrunk: [], skipped: [] }), /\(ok\)/);
+  assert.match(
+    renderDiff({ grown: [], shrunk: [], absent: [], skipped: [] }),
+    /\(ok\)/,
+  );
+});
+
+test('renderDiff tags shrinkage and an absent row as gate failures too', () => {
+  const shrink = renderDiff({
+    grown: [],
+    shrunk: [{ tier: 'workflow', current: 900, baseline: 1000, delta: 100 }],
+    absent: [],
+    skipped: [],
+  });
+  assert.match(shrink, /\(gate fail\)/);
+  assert.match(shrink, /- workflow: 900 bytes is under the recorded 1000/);
+
+  const missing = renderDiff({
+    grown: [],
+    shrunk: [],
+    absent: [{ tier: 'workflow', path: 'gone.md', bytes: 12 }],
+    skipped: [],
+  });
+  assert.match(missing, /\(gate fail\)/);
+  assert.match(missing, /recorded row gone\.md names a path/);
+  assert.match(missing, /absent=1/);
 });
 
 // ---------------------------------------------------------------------------
@@ -613,7 +693,7 @@ test('growth in the reachable-only closure is reported but never gates', async (
   assert.match(stdout.text(), /never gated/);
 });
 
-test('a shrunken workflow closure prints the informational marker and still exits 0', async () => {
+test('a shrunken workflow tier fails the gate instead of passing silently', async () => {
   const { root, config, write } = makeRepo({ withWorkflows: true });
   write('.agents/workflows/helpers/digest.md', `# Digest\n${'q'.repeat(3000)}`);
   await runCli({
@@ -625,15 +705,51 @@ test('a shrunken workflow closure prints the informational marker and still exit
   });
   write('.agents/workflows/helpers/digest.md', '# Digest\n');
   const stdout = makeSink();
-  const code = await runCli({
-    argv: [],
+  const stderr = makeSink();
+  const code = await runCli({ argv: [], cwd: root, config, stdout, stderr });
+  assert.equal(code, 1);
+  assert.match(stdout.text(), /- workflow: \d+ bytes is under the recorded/);
+  assert.match(stderr.text(), /came in under its recorded total/);
+});
+
+test('a recorded row whose file was deleted fails the gate and is named', async () => {
+  const { root, config, write } = makeRepo({ withWorkflows: true });
+  write('.agents/workflows/retired.md', `# Retired\n${'q'.repeat(300)}`);
+  await runCli({
+    argv: ['--update'],
     cwd: root,
     config,
-    stdout,
+    stdout: makeSink(),
     stderr: makeSink(),
   });
-  assert.equal(code, 0);
-  assert.match(stdout.text(), /- workflow: \d+ bytes below baseline/);
+  fs.rmSync(path.join(root, '.agents/workflows/retired.md'));
+  const stdout = makeSink();
+  const stderr = makeSink();
+  const code = await runCli({ argv: [], cwd: root, config, stdout, stderr });
+  assert.equal(code, 1);
+  assert.match(stdout.text(), /recorded row \.agents\/workflows\/retired\.md/);
+  assert.match(stderr.text(), /no longer contains/);
+});
+
+test('the committed context-budget baseline carries no tier drift against this repo tree', () => {
+  // Story #4872: now that shrinkage and a stale row both fail, the committed
+  // baseline must agree with the tree exactly — a later Story that trims a
+  // tracked file refreshes the rows it changed.
+  const repoRoot = path.resolve(
+    path.dirname(fileURLToPath(import.meta.url)),
+    '..',
+  );
+  const result = spawnSync(
+    process.execPath,
+    [path.join(repoRoot, '.agents', 'scripts', 'check-context-budget.js')],
+    { cwd: repoRoot, encoding: 'utf8', timeout: 120_000 },
+  );
+  assert.match(result.stdout ?? '', /grown=0 shrunk=0 absent=0/);
+  assert.equal(
+    result.status,
+    0,
+    `context-budget gate exited ${result.status}:\n${result.stdout}\n${result.stderr}`,
+  );
 });
 
 test('renderReachable is silent without a workflow closure and cites the recorded total with one', () => {

--- a/tests/enforcement/workflow-script-help.test.js
+++ b/tests/enforcement/workflow-script-help.test.js
@@ -196,3 +196,68 @@ describe('workflow-invoked scripts are self-describing', () => {
     );
   });
 });
+
+/**
+ * Story #4872 — the baseline updaters are not referenced from any workflow
+ * document, so the derived adoption set above never covered them, and both
+ * performed a real baseline write when asked for their usage. They are named
+ * explicitly here because for a CLI whose whole job is to mutate, "a usage
+ * probe leaves the artifact byte-identical" is the load-bearing half of the
+ * contract, not an incidental one.
+ */
+const MUTATING_UPDATERS = [
+  'update-crap-baseline.js',
+  'update-maintainability-baseline.js',
+];
+
+/** `{ relPath: sha-ish content }` for every committed baseline file. */
+function snapshotBaselines() {
+  const dir = path.join(REPO_ROOT, 'baselines');
+  const snapshot = {};
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    if (!entry.isFile()) continue;
+    snapshot[entry.name] = fs.readFileSync(path.join(dir, entry.name));
+  }
+  return snapshot;
+}
+
+describe('baseline updaters answer --help without writing a baseline', () => {
+  for (const script of MUTATING_UPDATERS) {
+    it(`${script} --help prints usage, exits 0, and mutates no baseline`, () => {
+      const before = snapshotBaselines();
+      const result = spawnSync(
+        process.execPath,
+        [path.join(SCRIPTS_DIR, script), '--help'],
+        {
+          cwd: REPO_ROOT,
+          encoding: 'utf8',
+          timeout: 120_000,
+          env: { ...process.env, AGENT_LOG_LEVEL: 'silent' },
+        },
+      );
+
+      assert.equal(
+        result.status,
+        0,
+        `${script} --help exited ${result.status}.\nstderr: ${(result.stderr ?? '').slice(0, 800)}`,
+      );
+      assert.ok(
+        (result.stdout ?? '').trim().length > 0,
+        `${script} --help wrote nothing to stdout`,
+      );
+
+      const after = snapshotBaselines();
+      assert.deepEqual(
+        Object.keys(after).sort(),
+        Object.keys(before).sort(),
+        `${script} --help added or removed a baseline file`,
+      );
+      for (const [name, bytes] of Object.entries(before)) {
+        assert.ok(
+          bytes.equals(after[name]),
+          `${script} --help rewrote baselines/${name} — a usage probe must not mutate the artifact it describes`,
+        );
+      }
+    });
+  }
+});


### PR DESCRIPTION
Closes #4872

_Auto-opened by `/deliver`._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CI gate behavior for documentation context budgets (shrinkage and stale rows now fail builds until baseline refresh) and baseline updater CLI entrypoints; scope is framework tooling and tests, not app runtime auth or data paths.
> 
> **Overview**
> **Context-budget ratchet (#4872)** now treats tier **shrinkage** and **stale file rows** as gate failures, not informational passes. A tier below its recorded `totalBytes` fails with zero downward tolerance (growth still uses `toleranceBytes`). Recorded per-file rows whose paths are no longer in the live tier are reported as `absent` and also fail. `budgetFailureCount` centralizes exit code and `(gate fail)` tagging; JSON reports include `absent`, and CLI stderr guides `--update` for shrink/absent cases.
> 
> **CRAP and maintainability baseline updaters** route through `runAsCli` with explicit `usage` so `--help` exits before `main` and never writes baseline files.
> 
> **`baselines/context-budget.json`** is refreshed so tier totals and workflow file lists match the repo (e.g. workflow row churn, updated closure totals).
> 
> Tests cover shrink/absent semantics, committed-baseline drift, and enforcement that mutating updaters’ `--help` leaves baseline bytes unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b0c8a23730aeddcdea332214b8ee8d290c5c2a8f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->