### PR TITLE
fix: stamp the version cache with the real clock and stop the env loader fusing inline comments into values (#4878)

### DIFF
--- a/.agents/scripts/lib/env-loader.js
+++ b/.agents/scripts/lib/env-loader.js
@@ -3,6 +3,51 @@ import path from 'node:path';
 import { Logger } from './Logger.js';
 
 /**
+ * Parse the right-hand side of a `KEY=` line into its value.
+ *
+ * Two rules, and the quoting decides which one applies:
+ *
+ *  - **Quoted** (`"…"` / `'…'`): the contents between the opening quote and
+ *    its matching closing quote are kept **verbatim** — a `#` inside quotes is
+ *    part of the value, not a comment. Anything after the closing quote is
+ *    trailing commentary and is discarded.
+ *  - **Unquoted**: the value ends at the first **unescaped** `#`. A `\#`
+ *    escape emits a literal `#` and keeps the scan going, so a value that
+ *    genuinely contains a hash can still be written without quotes.
+ *
+ * An opening quote with no closing partner is not a quoted value — it falls
+ * through to the unquoted rule so a malformed line still yields something
+ * rather than swallowing the rest of the file's intent.
+ *
+ * @param {string} raw — the text after the `=`, unparsed.
+ * @returns {string} The value with any inline comment removed.
+ */
+function parseEnvValue(raw) {
+  const trimmed = raw.trim();
+  if (trimmed.length === 0) return '';
+
+  const quote = trimmed.charAt(0);
+  if (quote === '"' || quote === "'") {
+    const closing = trimmed.indexOf(quote, 1);
+    // Verbatim contents: no comment stripping, no unescaping.
+    if (closing !== -1) return trimmed.slice(1, closing);
+  }
+
+  let value = '';
+  for (let i = 0; i < trimmed.length; i += 1) {
+    const char = trimmed.charAt(i);
+    if (char === '\\' && trimmed.charAt(i + 1) === '#') {
+      value += '#';
+      i += 1;
+      continue;
+    }
+    if (char === '#') break;
+    value += char;
+  }
+  return value.trim();
+}
+
+/**
  * Auto-load .env from the project root if it exists
  */
 export function loadEnv(projectRoot) {
@@ -31,22 +76,7 @@ export function loadEnv(projectRoot) {
     const match = line.match(/^\s*([\w.-]+)\s*=\s*(.*)?\s*$/);
     if (match) {
       const key = match[1];
-      let value = (match[2] || '').trim();
-      // Remove quotes if present
-      if (
-        value.length > 0 &&
-        value.charAt(0) === '"' &&
-        value.charAt(value.length - 1) === '"'
-      ) {
-        value = value.substring(1, value.length - 1);
-      } else if (
-        value.length > 0 &&
-        value.charAt(0) === "'" &&
-        value.charAt(value.length - 1) === "'"
-      ) {
-        value = value.substring(1, value.length - 1);
-      }
-      process.env[key] = value;
+      process.env[key] = parseEnvValue(match[2] || '');
     }
   });
 }

--- a/lib/cli/__tests__/update-4046.test.js
+++ b/lib/cli/__tests__/update-4046.test.js
@@ -15,6 +15,7 @@ import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 
 import run, { runUpdate } from '../update.js';
+import { isStale } from '../version-check.js';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -292,5 +293,99 @@ describe('run default export — cache bypass on explicit update (A1b)', () => {
     });
 
     assert.equal(runnerCallCount, 1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Story #4878 — the bypass must not poison the cache it bypasses
+// ---------------------------------------------------------------------------
+
+describe('run default export — cache bypass stamps the real clock (#4878)', () => {
+  const CACHE_PATH = '/virtual/temp/version-check.json';
+
+  /** In-memory fs seam over a path→contents map. */
+  function makeMemoryFs(seed = new Map()) {
+    const files = new Map(seed);
+    return {
+      files,
+      readFileSync(p) {
+        if (!files.has(p)) {
+          throw Object.assign(new Error(`ENOENT: ${p}`), { code: 'ENOENT' });
+        }
+        return files.get(p);
+      },
+      writeFileSync(p, content) {
+        files.set(p, content);
+      },
+      mkdirSync() {},
+      existsSync(p) {
+        return files.has(p);
+      },
+    };
+  }
+
+  it('persists a checkedAt that is not in the future', async () => {
+    const cap = makeCapture();
+    const memFs = makeMemoryFs();
+    const probeTime = new Date();
+
+    await run(['--dry-run'], {
+      currentVersion: '1.43.0',
+      cachePath: CACHE_PATH,
+      fs: memFs,
+      now: probeTime,
+      versionRunner: () => '1.44.0',
+      write: cap.write,
+      writeErr: cap.writeErr,
+      exit: cap.exit,
+    });
+
+    const persisted = JSON.parse(memFs.files.get(CACHE_PATH));
+    assert.equal(
+      persisted.checkedAt,
+      probeTime.toISOString(),
+      'checkedAt must record when the probe actually happened',
+    );
+    assert.ok(
+      new Date(persisted.checkedAt).getTime() <= Date.now(),
+      `checkedAt ${persisted.checkedAt} must not be in the future relative to the real clock`,
+    );
+  });
+
+  it('leaves the cache reusable by a passive check inside the 24h window', async () => {
+    const cap = makeCapture();
+    const memFs = makeMemoryFs();
+    const probeTime = new Date('2026-01-01T00:00:00.000Z');
+
+    await run(['--dry-run'], {
+      currentVersion: '1.43.0',
+      cachePath: CACHE_PATH,
+      fs: memFs,
+      now: probeTime,
+      versionRunner: () => '1.44.0',
+      write: cap.write,
+      writeErr: cap.writeErr,
+      exit: cap.exit,
+    });
+
+    // A passive staleness check one hour later must reuse the cache.
+    let passiveProbes = 0;
+    const passive = await isStale({
+      cachePath: CACHE_PATH,
+      now: new Date(probeTime.getTime() + 60 * 60 * 1000),
+      runner: () => {
+        passiveProbes += 1;
+        return '1.44.0';
+      },
+      fs: memFs,
+    });
+
+    assert.equal(
+      passiveProbes,
+      0,
+      'a passive check within 24h of an explicit update must not probe again',
+    );
+    assert.equal(passive.stale, false);
+    assert.equal(passive.latestVersion, '1.44.0');
   });
 });

--- a/lib/cli/__tests__/version-check.test.js
+++ b/lib/cli/__tests__/version-check.test.js
@@ -232,6 +232,32 @@ describe('isStale with a stale cache', () => {
     assert.equal(result.latestVersion, '4.4.4');
     assert.equal(result.refreshed, true);
   });
+
+  it('forceRefresh probes past a fresh cache and stamps the passed clock (#4878)', async () => {
+    const now = new Date('2026-06-03T12:00:00.000Z');
+    const checkedAt = new Date(now.getTime() - 60 * 1000).toISOString();
+    const fs = makeFs({
+      [CACHE_PATH]: JSON.stringify({ latestVersion: '1.0.0', checkedAt }),
+    });
+
+    let runnerCalls = 0;
+    const result = await isStale({
+      cachePath: CACHE_PATH,
+      now,
+      forceRefresh: true,
+      runner: () => {
+        runnerCalls++;
+        return '2.0.0';
+      },
+      fs,
+    });
+
+    assert.equal(runnerCalls, 1, 'forceRefresh must ignore a fresh cache');
+    assert.equal(result.latestVersion, '2.0.0');
+    // The persisted stamp is the caller's clock — not a shifted one.
+    const persisted = JSON.parse(fs.files.get(CACHE_PATH));
+    assert.equal(persisted.checkedAt, now.toISOString());
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/lib/cli/update.js
+++ b/lib/cli/update.js
@@ -247,10 +247,15 @@ function resolveProjectRoot() {
  * `mandrel` version via the daily freshness cache (`version-check.js`).
  *
  * When `bypassCache` is `true` (the default for an explicit `mandrel update`
- * call — Story #4046 A1b), the cache freshness window is effectively zeroed by
- * passing `now` as far in the future, which makes `isStale` treat any existing
- * cache as stale and always issue exactly one network probe. The cache is still
- * written so the post-update `version-current` advisory has a fresh baseline.
+ * call — Story #4046 A1b), `isStale` is asked to skip its freshness read via
+ * `forceRefresh`, so any existing cache is ignored and exactly one network
+ * probe is issued. The cache is still written so the post-update
+ * `version-current` advisory has a fresh baseline.
+ *
+ * The bypass deliberately does **not** shift `now`: the same clock is stamped
+ * into the refreshed `checkedAt`, so a shifted clock would persist a
+ * ~48h-future timestamp and defeat the 24h window for every later passive
+ * check until real time caught up (Story #4878).
  *
  * When `bypassCache` is `false` (passive staleness checks only), the normal
  * 24h-cache semantics apply: a fresh cache returns the cached version with
@@ -281,16 +286,14 @@ async function defaultResolveTargetVersion({
   bypassCache = false,
   log = () => {},
 } = {}) {
-  // When bypassCache is true, push `now` far enough into the future that any
-  // cached checkedAt value is guaranteed to be older than the STALE_AFTER_MS
-  // window, forcing a fresh network probe (Story #4046 A1b).
-  const effectiveNow = bypassCache
-    ? new Date(now.getTime() + 48 * 60 * 60 * 1000)
-    : now;
+  // Bypass the cache by telling isStale to skip its freshness read — never by
+  // shifting `now`, which is also the clock persisted as `checkedAt`
+  // (Story #4046 A1b forcing the probe; Story #4878 keeping the stamp honest).
   const result = await isStale({
     cachePath,
-    now: effectiveNow,
+    now,
     runner,
+    forceRefresh: bypassCache,
     fs,
     log,
   });

--- a/lib/cli/version-check.js
+++ b/lib/cli/version-check.js
@@ -142,10 +142,17 @@ export function refreshCache({
  * The freshness comparison uses `>=` so an exactly-24h-old cache counts as
  * stale (the boundary is treated as "due for refresh").
  *
+ * `forceRefresh` skips the freshness read entirely and always probes. It is
+ * the supported way to bypass the cache: callers must **not** fake staleness
+ * by shifting `now` forward, because `now` is also the clock stamped into the
+ * refreshed `checkedAt` — a shifted clock persists a future timestamp and
+ * defeats the freshness window for every later reader (Story #4878).
+ *
  * @param {{
  *   cachePath: string,
  *   now?: Date,
  *   runner: () => (string | Promise<string>),
+ *   forceRefresh?: boolean,
  *   fs?: typeof import('node:fs'),
  *   log?: (msg: string) => void,
  * }} opts
@@ -160,10 +167,11 @@ export async function isStale({
   cachePath,
   now = new Date(),
   runner,
+  forceRefresh = false,
   fs = nodeFs,
   log = () => {},
 }) {
-  const cached = readCache({ cachePath, fs });
+  const cached = forceRefresh ? null : readCache({ cachePath, fs });
 
   if (cached) {
     const ageMs = now.getTime() - new Date(cached.checkedAt).getTime();

--- a/tests/lib/env-loader.test.js
+++ b/tests/lib/env-loader.test.js
@@ -68,6 +68,56 @@ describe('loadEnv', () => {
     assert.strictEqual(process.env.TEST_AFTER_BLANK, 'yes');
   });
 
+  it('drops a trailing inline comment from an unquoted value', () => {
+    track('TEST_INLINE_COMMENT');
+    fs.writeFileSync(
+      path.join(tmpDir, '.env'),
+      'TEST_INLINE_COMMENT=ghp_realtoken # classic PAT, rotate quarterly\n',
+    );
+    loadEnv(tmpDir);
+    assert.strictEqual(process.env.TEST_INLINE_COMMENT, 'ghp_realtoken');
+  });
+
+  it('keeps a comment marker inside a double-quoted value', () => {
+    track('TEST_DQ_HASH');
+    fs.writeFileSync(
+      path.join(tmpDir, '.env'),
+      'TEST_DQ_HASH="pa#ssword" # trailing note\n',
+    );
+    loadEnv(tmpDir);
+    assert.strictEqual(process.env.TEST_DQ_HASH, 'pa#ssword');
+  });
+
+  it('keeps a comment marker inside a single-quoted value', () => {
+    track('TEST_SQ_HASH');
+    fs.writeFileSync(
+      path.join(tmpDir, '.env'),
+      "TEST_SQ_HASH='chan#nel' # where it posts\n",
+    );
+    loadEnv(tmpDir);
+    assert.strictEqual(process.env.TEST_SQ_HASH, 'chan#nel');
+  });
+
+  it('honours a backslash escape for a literal hash in an unquoted value', () => {
+    track('TEST_ESCAPED_HASH');
+    fs.writeFileSync(
+      path.join(tmpDir, '.env'),
+      'TEST_ESCAPED_HASH=se\\#cret # note\n',
+    );
+    loadEnv(tmpDir);
+    assert.strictEqual(process.env.TEST_ESCAPED_HASH, 'se#cret');
+  });
+
+  it('yields an empty value for a line that is only an inline comment', () => {
+    track('TEST_ONLY_COMMENT');
+    fs.writeFileSync(
+      path.join(tmpDir, '.env'),
+      'TEST_ONLY_COMMENT= # unset for now\n',
+    );
+    loadEnv(tmpDir);
+    assert.strictEqual(process.env.TEST_ONLY_COMMENT, '');
+  });
+
   it('does nothing when .env is missing', () => {
     // No .env file in tmpDir
     assert.doesNotThrow(() => loadEnv(tmpDir));


### PR DESCRIPTION
Closes #4878

_Auto-opened by `/deliver`._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect how `.env` values (often secrets) are parsed and how the CLI version cache behaves after `mandrel update`; behavior is covered by new unit tests but both paths are operationally sensitive.
> 
> **Overview**
> Fixes **#4878** by stopping `mandrel update` from writing a **future** `checkedAt` into the version freshness cache. Cache bypass no longer advances `now` by ~48h; `isStale` gains **`forceRefresh`** so explicit updates still probe the registry while **`checkedAt` uses the real clock**, so passive checks within 24h reuse the cache again.
> 
> Separately, **`.env` loading** now parses values through **`parseEnvValue`**: trailing **`#` comments** are stripped on unquoted values, **`#` inside quotes** is kept, and **`\#`** can emit a literal hash—avoiding tokens or secrets being corrupted when someone adds an inline note after `=`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ed564c86fc62d80ddfaf1f3f88be429ba8f0bc42. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->