### PR TITLE
fix: pin the base branch at init and fail closed at close when config has changed mid-run (#4891)

### DIFF
--- a/.agents/scripts/lib/orchestration/run-scoped-config.js
+++ b/.agents/scripts/lib/orchestration/run-scoped-config.js
@@ -1,0 +1,276 @@
+/**
+ * run-scoped-config.js — pin the config values a delivery run was seeded
+ * from, and fail closed when the file they came from changed underneath it.
+ *
+ * The problem this exists for: `single-story-init.js` resolves config and
+ * seeds `story-<id>` from `project.baseBranch`; `single-story-close` used to
+ * re-resolve the SAME key and run close-validation, format-autofix, the gate
+ * baseline and base-sync against its own second answer. Nothing pinned the
+ * first value and nothing checked the two agreed — and the window between
+ * them is however long implementation takes. A concurrent session editing
+ * `.agentrc.json` / `.agentrc.local.json` mid-run therefore base-synced a
+ * Story against a base it was never seeded from, which surfaced only as an
+ * ordinary content conflict with nothing pointing at config.
+ *
+ * The base a Story was seeded from is a property of **that run**, not of
+ * whatever the config file says later. So init pins it and close reads the
+ * pin back.
+ *
+ * ## Where the pin lives
+ *
+ * The `story-init` structured comment, not a temp log: the post-land tail
+ * purges the temp tree, while the ticket comment survives every close re-run
+ * and every recovery path. `single-story-init.js` already upserts that
+ * comment; `pinRunScopedConfig` supplies the block it records, and
+ * `resolveRunScopedConfig` reads it back through the existing
+ * `findStructuredComment` seam.
+ *
+ * ## Adding another run-scoped key
+ *
+ * Add one row to `RUN_SCOPED_CONFIG_KEYS`. Both halves — the pin init writes
+ * and the comparison close makes — enumerate that registry, so a new key
+ * needs no second mechanism, no reader change and no writer change. Only
+ * `baseBranch` is enforced today because only its corruption is destructive
+ * (a wrong base merged into the Story branch permanently contaminates the
+ * branch and its PR diff); ceremony profile, quality floors and the
+ * concurrency cap are deliberately NOT pinned here.
+ */
+
+import { parseFencedJsonComment } from './structured-comment-parser.js';
+import { findStructuredComment } from './ticketing.js';
+
+/**
+ * The run-scoped config registry. One row per key whose value belongs to the
+ * run that seeded the Story rather than to the current contents of the config
+ * file. `read` resolves the key from a resolved config (including its
+ * default); `label` is the dotted config path the operator has to go fix.
+ *
+ * @type {Record<string, { read: (config: object) => unknown, label: string }>}
+ */
+const RUN_SCOPED_CONFIG_KEYS = {
+  baseBranch: {
+    read: (config) => config?.project?.baseBranch ?? 'main',
+    label: 'project.baseBranch',
+  },
+};
+
+/**
+ * Snapshot the run-scoped config values from a resolved config. This is the
+ * write half of the pin: `single-story-init.js` records the returned object
+ * in the `story-init` receipt so close can compare against it later.
+ *
+ * @param {object} config Resolved config (`resolveConfig` output).
+ * @param {typeof RUN_SCOPED_CONFIG_KEYS} [keys] Registry override — the
+ *   default is the module registry; supplying one is how a caller (or a test)
+ *   exercises the registry-driven property without a second mechanism.
+ * @returns {Record<string, unknown>} the pinned values, keyed by config key.
+ */
+export function pinRunScopedConfig(config, keys = RUN_SCOPED_CONFIG_KEYS) {
+  const pinned = {};
+  for (const [key, spec] of Object.entries(keys)) {
+    pinned[key] = spec.read(config);
+  }
+  return pinned;
+}
+
+/**
+ * Read the pinned block out of the run's `story-init` receipt.
+ *
+ * Three distinct non-success states, all reported rather than collapsed —
+ * the whole point of this module is that a fallback is never silent:
+ *   - `absent`: no `story-init` comment on the ticket. Real and expected —
+ *     the upsert is best-effort (init logs and continues on failure), and a
+ *     recovery path may close a Story whose init predates this receipt.
+ *   - `unreadable`: the comment exists but carries no parseable JSON payload.
+ *   - `provider-error`: the comment read itself failed.
+ *
+ * @param {{
+ *   provider: object,
+ *   storyId: number,
+ *   findCommentFn?: typeof findStructuredComment,
+ * }} args
+ * @returns {Promise<{ status: string, values: Record<string, unknown>|null, detail: string|null }>}
+ */
+async function readRunScopedConfigReceipt({
+  provider,
+  storyId,
+  findCommentFn = findStructuredComment,
+}) {
+  let comment;
+  try {
+    comment = await findCommentFn(provider, Number(storyId), 'story-init');
+  } catch (err) {
+    return {
+      status: 'provider-error',
+      values: null,
+      detail: `story-init comment could not be read (${err?.message ?? err})`,
+    };
+  }
+  if (!comment) {
+    return {
+      status: 'absent',
+      values: null,
+      detail: 'no story-init comment on the ticket',
+    };
+  }
+  const payload = parseFencedJsonComment(comment);
+  if (!payload || typeof payload !== 'object') {
+    return {
+      status: 'unreadable',
+      values: null,
+      detail: 'story-init comment carries no parseable JSON payload',
+    };
+  }
+  // Receipts written before the `runScopedConfig` block existed carry the
+  // pinned values as top-level payload fields (`baseBranch` has been recorded
+  // there since Story #831). Reading the payload itself as the fallback block
+  // is what lets a Story initialized by an older init still close against its
+  // own pinned base instead of degrading to the fallback warning.
+  const block =
+    payload.runScopedConfig && typeof payload.runScopedConfig === 'object'
+      ? payload.runScopedConfig
+      : payload;
+  return { status: 'found', values: block, detail: null };
+}
+
+/**
+ * Build the refusal message for a mid-run config change. Names BOTH values
+ * for every conflicting key — the pinned one and the one config resolves to
+ * now — because "which base was this branch actually seeded from" is the
+ * question the operator could not previously answer.
+ *
+ * @param {{ storyId: number, conflicts: Array<{ label: string, pinned: unknown, current: unknown }> }} args
+ * @returns {string}
+ */
+function formatRunScopedConflict({ storyId, conflicts }) {
+  const rows = conflicts.map(
+    ({ label, pinned, current }) =>
+      `${label}: pinned at init = \`${String(pinned)}\`, currently resolves to \`${String(current)}\``,
+  );
+  return (
+    `[single-story-close] Refusing to close Story #${storyId}: run-scoped config changed mid-run. ` +
+    `${rows.join('; ')}. ` +
+    'The Story branch was seeded from the pinned value, so closing against the current one would ' +
+    'base-sync it onto a base it was never seeded from. No base-sync, format-autofix or gate run was ' +
+    'performed. A concurrent session most likely edited `.agentrc.json` / `.agentrc.local.json` during ' +
+    'the implementation window: restore the pinned value and re-run close, or re-init the Story against ' +
+    'the new value deliberately.'
+  );
+}
+
+/**
+ * Resolve the run-scoped config for a close, preferring the run's pin over a
+ * fresh resolution of the config file.
+ *
+ * Throws on disagreement — fail closed, before any gate, format-autofix or
+ * base-sync has run, with both values named. Never silently prefers either
+ * side: preferring the pin would base-sync correctly but hide a config change
+ * the operator needs to know about, and preferring current config is the bug
+ * this module exists to close.
+ *
+ * @param {{
+ *   provider: object,
+ *   storyId: number,
+ *   config: object,
+ *   keys?: typeof RUN_SCOPED_CONFIG_KEYS,
+ *   findCommentFn?: typeof findStructuredComment,
+ *   progress?: (tag: string, msg: string) => void,
+ * }} args
+ * @returns {Promise<{
+ *   values: Record<string, unknown>,
+ *   confirmed: boolean,
+ *   receiptStatus: string,
+ *   warning: string|null,
+ * }>} `confirmed` is true only when every key came from the receipt and
+ *   agreed with current config — i.e. when downstream remediation may safely
+ *   assume the pinned value is the one in play.
+ */
+export async function resolveRunScopedConfig({
+  provider,
+  storyId,
+  config,
+  keys = RUN_SCOPED_CONFIG_KEYS,
+  findCommentFn,
+  progress,
+}) {
+  const current = pinRunScopedConfig(config, keys);
+  const receipt = await readRunScopedConfigReceipt({
+    provider,
+    storyId,
+    findCommentFn,
+  });
+
+  if (receipt.status !== 'found') {
+    // A missing receipt is a real state, not an error — but the fallback is
+    // announced, because a silent one reintroduces exactly the bug above.
+    const warning =
+      `Run-scoped config could not be read from the run's init receipt ` +
+      `(${receipt.detail}); falling back to the currently-resolved config ` +
+      `(${describeValues(current, keys)}). This close cannot confirm the Story ` +
+      'was seeded from these values.';
+    progress?.('PIN', `⚠️ ${warning}`);
+    return {
+      values: current,
+      confirmed: false,
+      receiptStatus: receipt.status,
+      warning,
+    };
+  }
+
+  const values = {};
+  const conflicts = [];
+  const unpinned = [];
+  for (const [key, spec] of Object.entries(keys)) {
+    const pinned = receipt.values?.[key];
+    if (pinned === undefined || pinned === null) {
+      unpinned.push(spec.label);
+      values[key] = current[key];
+      continue;
+    }
+    values[key] = pinned;
+    if (pinned !== current[key]) {
+      conflicts.push({ label: spec.label, pinned, current: current[key] });
+    }
+  }
+
+  if (conflicts.length > 0) {
+    throw new Error(formatRunScopedConflict({ storyId, conflicts }));
+  }
+
+  if (unpinned.length > 0) {
+    const warning =
+      `The run's init receipt pins no value for ${unpinned.join(', ')}; ` +
+      `falling back to the currently-resolved config (${describeValues(values, keys)}).`;
+    progress?.('PIN', `⚠️ ${warning}`);
+    return {
+      values,
+      confirmed: false,
+      receiptStatus: receipt.status,
+      warning,
+    };
+  }
+
+  progress?.(
+    'PIN',
+    `📌 Run-scoped config pinned by the story-init receipt (${describeValues(values, keys)}).`,
+  );
+  return {
+    values,
+    confirmed: true,
+    receiptStatus: receipt.status,
+    warning: null,
+  };
+}
+
+/**
+ * Render `label=value` pairs for the operator-facing lines above.
+ *
+ * @param {Record<string, unknown>} values
+ * @param {typeof RUN_SCOPED_CONFIG_KEYS} keys
+ * @returns {string}
+ */
+function describeValues(values, keys) {
+  return Object.entries(keys)
+    .map(([key, spec]) => `${spec.label}=\`${String(values[key])}\``)
+    .join(', ');
+}

--- a/.agents/scripts/lib/orchestration/single-story-close/phases/base-sync.js
+++ b/.agents/scripts/lib/orchestration/single-story-close/phases/base-sync.js
@@ -35,6 +35,7 @@ import {
  *   cwd: string,
  *   worktreePath: string|null,
  *   baseBranch: string,
+ *   baseConfirmed?: boolean,
  *   storyBranch: string,
  *   storyId: number,
  *   provider: object,
@@ -46,6 +47,7 @@ export async function runBaseSyncPhase({
   cwd,
   worktreePath,
   baseBranch,
+  baseConfirmed = false,
   storyBranch,
   storyId,
   provider,
@@ -69,6 +71,7 @@ export async function runBaseSyncPhase({
       storyId,
       syncCwd,
       baseBranch,
+      baseConfirmed,
       storyBranch,
       result: syncResult,
       progress,
@@ -95,6 +98,7 @@ export async function runBaseSyncPhase({
  *   storyId: number,
  *   syncCwd: string,
  *   baseBranch: string,
+ *   baseConfirmed?: boolean,
  *   storyBranch: string,
  *   result: { kind: string, conflictFiles?: string[], stderr?: string },
  *   progress: (tag: string, msg: string) => void,
@@ -105,6 +109,7 @@ export async function handleSyncFailure({
   storyId,
   syncCwd,
   baseBranch,
+  baseConfirmed = false,
   storyBranch,
   result,
   progress,
@@ -113,6 +118,7 @@ export async function handleSyncFailure({
     storyId,
     storyBranch,
     baseBranch,
+    baseConfirmed,
     syncCwd,
     result,
   });
@@ -147,13 +153,23 @@ export async function handleSyncFailure({
  * Build the markdown body posted on a base-sync failure. Pure; exported
  * for tests so the operator-recoverable surface stays reviewable.
  *
- * @param {{ storyId: number, storyBranch: string, baseBranch: string, syncCwd: string, result: { kind: string, conflictFiles?: string[], stderr?: string } }} args
+ * Story #4891 — `baseConfirmed` gates the merge-the-base recovery block, and
+ * defaults to `false` so it fails closed. Telling the operator to run
+ * `git merge origin/<baseBranch>` is actively harmful when `<baseBranch>` is
+ * not the base the Story was seeded from: it permanently contaminates the
+ * branch and its PR diff with an unrelated base. Close confirms the base
+ * against the run's `story-init` receipt before that advice is emitted; when
+ * it could not (receipt absent, unreadable, or unpinned), the operator is
+ * told to establish the real base first instead.
+ *
+ * @param {{ storyId: number, storyBranch: string, baseBranch: string, baseConfirmed?: boolean, syncCwd: string, result: { kind: string, conflictFiles?: string[], stderr?: string } }} args
  * @returns {string}
  */
 export function buildSyncFailureCommentBody({
   storyId,
   storyBranch,
   baseBranch,
+  baseConfirmed = false,
   syncCwd,
   result,
 }) {
@@ -170,15 +186,30 @@ export function buildSyncFailureCommentBody({
     `sync against \`origin/${baseBranch}\` could not complete. The Story has`,
     `been transitioned to \`agent::blocked\`. To resume:`,
     '',
-    '```bash',
-    `cd ${syncCwd}`,
-    `git fetch origin ${baseBranch}`,
-    `git merge --no-edit origin/${baseBranch}`,
-    '# resolve any conflicts, then:',
-    `git add -A ; git commit --no-edit`,
-    '# re-run close:',
-    `node .agents/scripts/single-story-close.js --story ${storyId}`,
-    '```',
+    ...(baseConfirmed
+      ? [
+          '```bash',
+          `cd ${syncCwd}`,
+          `git fetch origin ${baseBranch}`,
+          `git merge --no-edit origin/${baseBranch}`,
+          '# resolve any conflicts, then:',
+          `git add -A ; git commit --no-edit`,
+          '# re-run close:',
+          `node .agents/scripts/single-story-close.js --story ${storyId}`,
+          '```',
+        ]
+      : [
+          `⚠️ **No merge advice: \`${baseBranch}\` is unconfirmed.** This close could not`,
+          `read the base branch \`${storyBranch}\` was seeded from off the run's`,
+          '`story-init` receipt, so merging that base in could contaminate the branch',
+          'and its PR diff with an unrelated base. Establish the real base first —',
+          `check the \`story-init\` comment on this issue and \`project.baseBranch\` in`,
+          '`.agentrc.json` / `.agentrc.local.json` — then merge that base and re-run:',
+          '',
+          '```bash',
+          `node .agents/scripts/single-story-close.js --story ${storyId}`,
+          '```',
+        ]),
   ];
   if (kind === 'conflict' && fileList.length > 0) {
     lines.push('', '**Conflicting files:**', '', ...fileList);

--- a/.agents/scripts/lib/orchestration/single-story-close/runner.js
+++ b/.agents/scripts/lib/orchestration/single-story-close/runner.js
@@ -12,6 +12,7 @@ import { createProvider } from '../../provider-factory.js';
 import { flipLabelAndNotify } from '../../single-story/story-merged-notify.js';
 import { WorktreeManager } from '../../worktree-manager.js';
 import { runCodeReview as runCodeReviewDefault } from '../code-review.js';
+import { resolveRunScopedConfig } from '../run-scoped-config.js';
 import { releaseStoryLease } from '../single-story-lease-guard.js';
 import {
   buildTerminalEnvelope,
@@ -144,6 +145,7 @@ async function runPrePushPhases({
   worktreePath,
   config,
   baseBranch,
+  baseConfirmed,
   storyBranch,
   storyId,
   provider,
@@ -185,6 +187,7 @@ async function runPrePushPhases({
       cwd,
       worktreePath,
       baseBranch,
+      baseConfirmed,
       storyBranch,
       storyId,
       provider,
@@ -450,7 +453,6 @@ async function runClosePipeline({
   const startedAtMs = Date.now();
   const config = injectedConfig || resolveConfig({ cwd: options.cwd });
   const provider = injectedProvider || createProvider(config);
-  const baseBranch = config.project?.baseBranch ?? 'main';
   const storyBranch = getStoryBranch(options.storyId);
 
   progress('INIT', `Closing standalone Story #${options.storyId}...`);
@@ -468,6 +470,22 @@ async function runClosePipeline({
       config,
     );
   }
+
+  // Story #4891 — the base branch this run was SEEDED from, read back off the
+  // run's `story-init` receipt rather than re-resolved from a config file that
+  // may have changed during the whole implementation window. Throws (fail
+  // closed, naming both values) when the pin and current config disagree —
+  // deliberately here, before the gate chain, format-autofix and base-sync,
+  // so a wrong base is never merged into the Story branch. `baseConfirmed`
+  // gates the base-merge remediation advice further down.
+  const { values: runScoped, confirmed: baseConfirmed } =
+    await resolveRunScopedConfig({
+      provider,
+      storyId: options.storyId,
+      config,
+      progress,
+    });
+  const baseBranch = runScoped.baseBranch;
 
   const worktreePath = resolveWorktreePath({
     cwd: options.cwd,
@@ -490,6 +508,7 @@ async function runClosePipeline({
         ...options,
         config,
         baseBranch,
+        baseConfirmed,
         storyBranch,
         provider,
         worktreePath,

--- a/.agents/scripts/single-story-close.js
+++ b/.agents/scripts/single-story-close.js
@@ -90,6 +90,7 @@ import { runAsCli } from './lib/cli-utils.js';
 import { formatCliError } from './lib/error-redactor.js';
 import { Logger } from './lib/Logger.js';
 import { emitTerminalFriction } from './lib/observability/runtime-friction.js';
+import { resolveRunScopedConfig } from './lib/orchestration/run-scoped-config.js';
 import {
   failedTerminalFor,
   gatesForFailedPhase,
@@ -123,12 +124,17 @@ export const enableAutoMerge = enableAutoMergeWith;
 // `gatesForFailedPhase` now lives beside the envelope it feeds
 // (`single-story-close/failed-terminal.js`); it is re-exported here so the
 // CLI's public surface is unchanged by that move.
+// `resolveRunScopedConfig` (Story #4891) is the run-scoped config pin the
+// pipeline reads before its first phase; it is part of this CLI's surface for
+// the same reason the sync helpers are — the runner reaches it only through a
+// dynamic import, so this file is where it is statically visible.
 export {
   buildStoryReviewCrossRefBody,
   buildSyncFailureCommentBody,
   gatesForFailedPhase,
   handleSyncFailure,
   parsePrNumber,
+  resolveRunScopedConfig,
   runStoryScopeReview,
 };
 

--- a/.agents/scripts/single-story-init.js
+++ b/.agents/scripts/single-story-init.js
@@ -61,6 +61,7 @@ import {
   planFastForward,
 } from './lib/orchestration/git-cleanup/phases/fast-forward.js';
 import { verifyRemote } from './lib/orchestration/remote-verifier.js';
+import { pinRunScopedConfig } from './lib/orchestration/run-scoped-config.js';
 import {
   acquireStoryLease,
   releaseStoryLease,
@@ -735,6 +736,11 @@ export async function runSingleStoryInit({
     standalone: true,
     storyBranch,
     baseBranch,
+    // The write half of the run-scoped config pin. `baseBranch` above is the
+    // legacy field close still reads as a fallback; this block is the
+    // registry-driven form a second run-scoped key joins without a second
+    // mechanism (`lib/orchestration/run-scoped-config.js`).
+    runScopedConfig: pinRunScopedConfig(config),
     storyTitle: story.title,
     worktreeEnabled: runtime.worktreeEnabled,
     workCwd,
@@ -805,6 +811,7 @@ export function renderSingleStoryInitComment(result) {
     standalone: true,
     storyBranch: result.storyBranch,
     baseBranch: result.baseBranch,
+    runScopedConfig: result.runScopedConfig,
     worktreeEnabled: result.worktreeEnabled,
     workCwd: result.workCwd,
     worktreeCreated: result.worktreeCreated,

--- a/baselines/dead-exports-production.json
+++ b/baselines/dead-exports-production.json
@@ -2069,6 +2069,10 @@
       "symbol": "gatherStoryFrictionSignals"
     },
     {
+      "file": ".agents/scripts/lib/orchestration/structured-comment-parser.js",
+      "symbol": "parseFencedJson"
+    },
+    {
       "file": ".agents/scripts/lib/orchestration/task-body-validator.js",
       "symbol": "VERIFY_TIER_VALUES"
     },

--- a/tests/single-story-close-sync.test.js
+++ b/tests/single-story-close-sync.test.js
@@ -1,22 +1,25 @@
 /**
  * tests/single-story-close-sync.test.js — coverage for the Story #2580
- * sync-from-base step inside `single-story-close.js`.
+ * sync-from-base step inside `single-story-close.js`, and for the Story #4891
+ * run-scoped config pin that decides WHICH base that step syncs from.
  *
- * The pure helpers (`buildSyncFailureCommentBody`, `handleSyncFailure`)
- * are exercised in isolation. The end-to-end integration through
- * `runSingleStoryClose` is covered with the standard injection seams
- * (`injectedSync`, `injectedProvider`, `injectedConfig`, `injectedNotify`)
- * plus `t.mock.module` for the validation / push / worktree-manager
- * collaborators.
+ * The pure helpers (`buildSyncFailureCommentBody`, `handleSyncFailure`,
+ * `pinRunScopedConfig`, `resolveRunScopedConfig`) are exercised in isolation.
+ * The end-to-end integration through `runSingleStoryClose` is covered with the
+ * standard injection seams (`injectedSync`, `injectedProvider`,
+ * `injectedConfig`, `injectedNotify`) plus `t.mock.module` for the validation /
+ * push / worktree-manager collaborators.
  */
 
 import assert from 'node:assert/strict';
 import path from 'node:path';
 import { describe, it } from 'node:test';
 import { fileURLToPath, pathToFileURL } from 'node:url';
+import { pinRunScopedConfig } from '../.agents/scripts/lib/orchestration/run-scoped-config.js';
 import {
   buildSyncFailureCommentBody,
   handleSyncFailure,
+  resolveRunScopedConfig,
 } from '../.agents/scripts/single-story-close.js';
 
 const REPO_ROOT = path
@@ -54,6 +57,39 @@ function mockCloseValidation(t, { namedExports }) {
 const WORKTREE_MANAGER_URL = pathToFileURL(
   path.resolve(REPO_ROOT, '.agents/scripts/lib/worktree-manager.js'),
 ).href;
+const FORMAT_AUTOFIX_URL = pathToFileURL(
+  path.resolve(
+    REPO_ROOT,
+    '.agents/scripts/lib/orchestration/story-close/format-autofix.js',
+  ),
+).href;
+
+/**
+ * Story #4891 — render a `story-init` receipt comment body the way
+ * `renderSingleStoryInitComment` does: a fenced JSON payload behind the
+ * structured-comment marker. `legacy: true` omits the `runScopedConfig` block
+ * so the top-level-field fallback (receipts written before the block existed)
+ * is exercised too.
+ */
+function storyInitComment({ baseBranch, legacy = false, extra = null }) {
+  const payload = {
+    storyId: 4242,
+    standalone: true,
+    storyBranch: 'story-4242',
+    baseBranch,
+    ...(legacy ? {} : { runScopedConfig: { baseBranch, ...(extra ?? {}) } }),
+  };
+  return [
+    '<!-- ap:structured-comment type="story-init" -->',
+    '',
+    '## Story init (standalone)',
+    '',
+    '```json',
+    JSON.stringify(payload, null, 2),
+    '```',
+    '',
+  ].join('\n');
+}
 
 /**
  * Story #2990: build a fake `lib/gh-exec.js` `gh` facade for direct
@@ -150,7 +186,7 @@ function fakeConfig() {
   };
 }
 
-function fakeProvider({ labels = ['agent::executing'] } = {}) {
+function fakeProvider({ labels = ['agent::executing'], comments } = {}) {
   let story = {
     id: 4242,
     state: 'open',
@@ -158,8 +194,19 @@ function fakeProvider({ labels = ['agent::executing'] } = {}) {
     labels: [...labels],
   };
   const updates = [];
+  const posted = [];
   return {
     getTicket: async () => ({ ...story, labels: [...story.labels] }),
+    // Story #4891 — close reads the run's `story-init` receipt through
+    // `findStructuredComment`, which lists the ticket's comments. Omitting
+    // `comments` models the absent-receipt fallback path.
+    getTicketComments: async () =>
+      (comments ?? []).map((body, i) => ({ id: i + 1, body })),
+    postComment: async (id, { type, body }) => {
+      posted.push({ id, type, body });
+      return { id: 900 + posted.length };
+    },
+    _posted: () => posted,
     updateTicket: async (id, patch) => {
       updates.push({ id, patch });
       if (patch.labels) {
@@ -185,6 +232,7 @@ describe('buildSyncFailureCommentBody', () => {
       storyId: 100,
       storyBranch: 'story-100',
       baseBranch: 'main',
+      baseConfirmed: true,
       syncCwd: '/repo/.worktrees/story-100',
       result: {
         kind: 'conflict',
@@ -206,6 +254,7 @@ describe('buildSyncFailureCommentBody', () => {
       storyId: 7,
       storyBranch: 'story-7',
       baseBranch: 'main',
+      baseConfirmed: true,
       syncCwd: '/repo',
       result: {
         kind: 'fetch-failed',
@@ -217,17 +266,56 @@ describe('buildSyncFailureCommentBody', () => {
     assert.match(body, /unable to access/);
   });
 
-  it('emits a recovery cd / git fetch / merge block', () => {
+  it('emits a recovery cd / git fetch / merge block when the base is confirmed', () => {
     const body = buildSyncFailureCommentBody({
       storyId: 1,
       storyBranch: 'story-1',
       baseBranch: 'main',
+      baseConfirmed: true,
       syncCwd: '/repo',
       result: { kind: 'conflict', conflictFiles: ['a'] },
     });
     assert.match(body, /cd \/repo/);
     assert.match(body, /git fetch origin main/);
     assert.match(body, /git merge --no-edit origin\/main/);
+  });
+
+  // Story #4891 AC-3 — advising `git merge origin/<base>` against a base the
+  // Story was never seeded from permanently contaminates the branch and its
+  // PR diff. The advice is withheld until close has confirmed the base.
+  it('withholds the base-merge advice when the base is unconfirmed', () => {
+    const body = buildSyncFailureCommentBody({
+      storyId: 1,
+      storyBranch: 'story-1',
+      baseBranch: 'develop',
+      baseConfirmed: false,
+      syncCwd: '/repo',
+      result: { kind: 'conflict', conflictFiles: ['a'] },
+    });
+    assert.doesNotMatch(body, /git merge --no-edit origin\/develop/);
+    assert.doesNotMatch(body, /git fetch origin develop/);
+    assert.match(body, /`develop` is unconfirmed/);
+    assert.match(body, /story-init/);
+    // The re-run command still has to be there — the operator is blocked, not
+    // stranded without a next step.
+    assert.match(
+      body,
+      /node \.agents\/scripts\/single-story-close\.js --story 1/,
+    );
+    // The conflicting-file evidence is orthogonal to the advice and stays.
+    assert.match(body, /Conflicting files:/);
+  });
+
+  it('defaults to withholding the base-merge advice (fails closed)', () => {
+    const body = buildSyncFailureCommentBody({
+      storyId: 2,
+      storyBranch: 'story-2',
+      baseBranch: 'main',
+      syncCwd: '/repo',
+      result: { kind: 'conflict', conflictFiles: ['a'] },
+    });
+    assert.doesNotMatch(body, /git merge --no-edit origin\/main/);
+    assert.match(body, /`main` is unconfirmed/);
   });
 });
 
@@ -294,6 +382,237 @@ describe('handleSyncFailure', () => {
         result: { kind: 'fetch-failed', stderr: 'boom' },
         progress: () => {},
       }),
+    );
+  });
+});
+
+describe('pinRunScopedConfig (Story #4891 — the write half)', () => {
+  it('pins project.baseBranch, defaulting to main when unset', () => {
+    assert.deepEqual(pinRunScopedConfig({ project: { baseBranch: 'trunk' } }), {
+      baseBranch: 'trunk',
+    });
+    assert.deepEqual(pinRunScopedConfig({}), { baseBranch: 'main' });
+  });
+
+  // AC-5 — the pin is registry-driven on both halves, so a second run-scoped
+  // key is one registry row and needs no second mechanism.
+  it('enumerates every registry row it is given', () => {
+    const keys = {
+      baseBranch: {
+        read: (c) => c?.project?.baseBranch ?? 'main',
+        label: 'project.baseBranch',
+      },
+      ceremonyProfile: {
+        read: (c) => c?.delivery?.routing?.ceremonyProfile ?? 'standard',
+        label: 'delivery.routing.ceremonyProfile',
+      },
+    };
+    assert.deepEqual(
+      pinRunScopedConfig(
+        { project: { baseBranch: 'trunk' }, delivery: { routing: {} } },
+        keys,
+      ),
+      { baseBranch: 'trunk', ceremonyProfile: 'standard' },
+    );
+  });
+});
+
+describe('resolveRunScopedConfig (Story #4891 — the read half)', () => {
+  const provider = { id: 'unused-by-the-injected-find' };
+  const findReturning = (comment) => {
+    const calls = [];
+    const fn = async (_provider, ticketId, type) => {
+      calls.push({ ticketId, type });
+      return comment;
+    };
+    fn.calls = calls;
+    return fn;
+  };
+
+  // AC-1 — the value comes off the run's receipt, and `confirmed` is a fact
+  // only a receipt read can establish.
+  it('derives the base branch from the story-init receipt', async () => {
+    const findCommentFn = findReturning({
+      id: 1,
+      body: storyInitComment({ baseBranch: 'trunk' }),
+    });
+    const out = await resolveRunScopedConfig({
+      provider,
+      storyId: 4242,
+      config: { project: { baseBranch: 'trunk' } },
+      findCommentFn,
+    });
+    assert.equal(out.values.baseBranch, 'trunk');
+    assert.equal(out.confirmed, true);
+    assert.equal(out.receiptStatus, 'found');
+    assert.equal(out.warning, null);
+    assert.deepEqual(findCommentFn.calls, [
+      { ticketId: 4242, type: 'story-init' },
+    ]);
+  });
+
+  it('reads a legacy receipt that carries the value as a top-level field', async () => {
+    const out = await resolveRunScopedConfig({
+      provider,
+      storyId: 4242,
+      config: { project: { baseBranch: 'main' } },
+      findCommentFn: findReturning({
+        id: 1,
+        body: storyInitComment({ baseBranch: 'main', legacy: true }),
+      }),
+    });
+    assert.equal(out.values.baseBranch, 'main');
+    assert.equal(out.confirmed, true);
+  });
+
+  // AC-2 — fail closed, naming BOTH values. Throwing is what keeps every
+  // downstream phase (gates, format-autofix, base-sync) from running.
+  it('throws naming both values when the pin and current config disagree', async () => {
+    await assert.rejects(
+      () =>
+        resolveRunScopedConfig({
+          provider,
+          storyId: 4242,
+          config: { project: { baseBranch: 'release-3' } },
+          findCommentFn: findReturning({
+            id: 1,
+            body: storyInitComment({ baseBranch: 'main' }),
+          }),
+        }),
+      (err) => {
+        assert.match(err.message, /run-scoped config changed mid-run/);
+        assert.match(err.message, /project\.baseBranch/);
+        assert.match(err.message, /pinned at init = `main`/);
+        assert.match(err.message, /currently resolves to `release-3`/);
+        assert.match(
+          err.message,
+          /No base-sync, format-autofix or gate run was\s+performed/,
+        );
+        return true;
+      },
+    );
+  });
+
+  // AC-4 — a missing receipt is a real state (the upsert is best-effort, and a
+  // recovery path may close a Story whose init predates the receipt). It falls
+  // back, but never silently.
+  it('falls back to config with an explicit warning when the receipt is absent', async () => {
+    const lines = [];
+    const out = await resolveRunScopedConfig({
+      provider,
+      storyId: 4242,
+      config: { project: { baseBranch: 'main' } },
+      findCommentFn: findReturning(null),
+      progress: (tag, msg) => lines.push({ tag, msg }),
+    });
+    assert.equal(out.values.baseBranch, 'main');
+    assert.equal(out.confirmed, false);
+    assert.equal(out.receiptStatus, 'absent');
+    assert.match(out.warning, /no story-init comment on the ticket/);
+    assert.match(out.warning, /falling back to the currently-resolved config/);
+    assert.match(out.warning, /project\.baseBranch=`main`/);
+    assert.ok(
+      lines.some((l) => l.msg.includes('⚠️') && l.msg.includes(out.warning)),
+      'the fallback must be announced through progress, never silent',
+    );
+  });
+
+  it('falls back with a warning when the receipt carries no JSON payload', async () => {
+    const out = await resolveRunScopedConfig({
+      provider,
+      storyId: 4242,
+      config: { project: { baseBranch: 'main' } },
+      findCommentFn: findReturning({
+        id: 1,
+        body: '<!-- ap:structured-comment type="story-init" -->\n\nno fence here',
+      }),
+    });
+    assert.equal(out.confirmed, false);
+    assert.equal(out.receiptStatus, 'unreadable');
+    assert.match(out.warning, /no parseable JSON payload/);
+  });
+
+  it('falls back with a warning (never throws) when the comment read fails', async () => {
+    const out = await resolveRunScopedConfig({
+      provider,
+      storyId: 4242,
+      config: { project: { baseBranch: 'main' } },
+      findCommentFn: async () => {
+        throw new Error('provider down');
+      },
+    });
+    assert.equal(out.confirmed, false);
+    assert.equal(out.receiptStatus, 'provider-error');
+    assert.match(out.warning, /provider down/);
+  });
+
+  it('warns rather than confirms when the receipt pins no value for a key', async () => {
+    const out = await resolveRunScopedConfig({
+      provider,
+      storyId: 4242,
+      config: { project: { baseBranch: 'main' } },
+      findCommentFn: findReturning({
+        id: 1,
+        body: [
+          '<!-- ap:structured-comment type="story-init" -->',
+          '',
+          '```json',
+          JSON.stringify({ storyId: 4242, runScopedConfig: {} }),
+          '```',
+        ].join('\n'),
+      }),
+    });
+    assert.equal(out.values.baseBranch, 'main');
+    assert.equal(out.confirmed, false);
+    assert.match(out.warning, /pins no value for project\.baseBranch/);
+  });
+
+  // AC-5 — the comparison half enumerates the same registry, so an added key
+  // is enforced by the existing mechanism with no reader change.
+  it('compares every registry row it is given', async () => {
+    const keys = {
+      baseBranch: {
+        read: (c) => c?.project?.baseBranch ?? 'main',
+        label: 'project.baseBranch',
+      },
+      ceremonyProfile: {
+        read: (c) => c?.delivery?.routing?.ceremonyProfile ?? 'standard',
+        label: 'delivery.routing.ceremonyProfile',
+      },
+    };
+    const findCommentFn = findReturning({
+      id: 1,
+      body: storyInitComment({
+        baseBranch: 'main',
+        extra: { ceremonyProfile: 'standard' },
+      }),
+    });
+    const ok = await resolveRunScopedConfig({
+      provider,
+      storyId: 4242,
+      config: { project: { baseBranch: 'main' } },
+      keys,
+      findCommentFn,
+    });
+    assert.deepEqual(ok.values, {
+      baseBranch: 'main',
+      ceremonyProfile: 'standard',
+    });
+    assert.equal(ok.confirmed, true);
+
+    await assert.rejects(
+      () =>
+        resolveRunScopedConfig({
+          provider,
+          storyId: 4242,
+          config: {
+            project: { baseBranch: 'main' },
+            delivery: { routing: { ceremonyProfile: 'strict' } },
+          },
+          keys,
+          findCommentFn,
+        }),
+      /delivery\.routing\.ceremonyProfile: pinned at init = `standard`, currently resolves to `strict`/,
     );
   });
 });
@@ -429,5 +748,167 @@ describe('runSingleStoryClose — sync integration', () => {
       false,
       'syncBranchFromBase must not be called when skipSync=true',
     );
+  });
+});
+
+describe('runSingleStoryClose — run-scoped base pin (Story #4891)', () => {
+  /**
+   * `fakeConfig()` resolves `project.baseBranch` to the `main` default (its
+   * legacy `agentSettings` shape carries no `project` block), so a receipt
+   * pinning anything else models "a concurrent session edited `.agentrc`
+   * during the implementation window".
+   */
+  function pinnedConfig(baseBranch) {
+    return { ...fakeConfig(), project: { baseBranch } };
+  }
+
+  // AC-2 — the refusal happens before ANY of the three destructive-adjacent
+  // steps, which is why it is asserted on all three at once.
+  it('refuses with a config-changed error and runs no gates, autofix or sync', async (t) => {
+    let pushAttempted = false;
+    let autofixInvoked = false;
+    let gatesBuilt = false;
+    let validationRun = false;
+    let syncInvoked = false;
+    t.mock.module(GIT_UTILS_URL, {
+      namedExports: {
+        ...gitUtilsMock().namedExports,
+        gitSync: (_cwd, ...args) => {
+          if (args[0] === 'push') pushAttempted = true;
+          return '';
+        },
+      },
+    });
+    mockCloseValidation(t, {
+      namedExports: {
+        buildDefaultGates: () => {
+          gatesBuilt = true;
+          return [];
+        },
+        runCloseValidation: async () => {
+          validationRun = true;
+          return { ok: true, failed: [] };
+        },
+      },
+    });
+    t.mock.module(FORMAT_AUTOFIX_URL, {
+      namedExports: {
+        runScopedFormatAutofix: () => {
+          autofixInvoked = true;
+          return { committed: false, reason: 'clean' };
+        },
+      },
+    });
+    t.mock.module(WORKTREE_MANAGER_URL, worktreeManagerMock());
+
+    const { runSingleStoryClose } = await import(`${SUT_URL}?t=pin-conflict`);
+    const provider = fakeProvider({
+      comments: [storyInitComment({ baseBranch: 'main' })],
+    });
+    await assert.rejects(
+      () =>
+        runSingleStoryClose({
+          storyId: 4242,
+          noWaitForMerge: true,
+          cwd: REPO_ROOT,
+          injectedProvider: provider,
+          injectedConfig: pinnedConfig('release-3'),
+          injectedSync: async () => {
+            syncInvoked = true;
+            return { synced: true, kind: 'fast-forward' };
+          },
+          injectedGh: makeFakeGh(() => {
+            throw new Error('gh must not be invoked on a pin conflict');
+          }),
+        }),
+      (err) => {
+        assert.match(err.message, /run-scoped config changed mid-run/);
+        assert.match(err.message, /pinned at init = `main`/);
+        assert.match(err.message, /currently resolves to `release-3`/);
+        return true;
+      },
+    );
+    assert.equal(syncInvoked, false, 'base-sync must not run');
+    assert.equal(autofixInvoked, false, 'format-autofix must not run');
+    assert.equal(gatesBuilt, false, 'the gate chain must not be built');
+    assert.equal(validationRun, false, 'the gate chain must not run');
+    assert.equal(pushAttempted, false, 'push must not run');
+  });
+
+  // AC-1 — the base handed to base-sync is the receipt's, and AC-3 — with the
+  // base confirmed against the receipt, the merge advice is emitted.
+  it('base-syncs against the receipt base and advises the merge on a conflict', async (t) => {
+    t.mock.module(GIT_UTILS_URL, gitUtilsMock());
+    mockCloseValidation(t, closeValidationMock());
+    t.mock.module(WORKTREE_MANAGER_URL, worktreeManagerMock());
+    const syncedFrom = [];
+
+    const { runSingleStoryClose } = await import(`${SUT_URL}?t=pin-confirmed`);
+    const provider = fakeProvider({
+      comments: [storyInitComment({ baseBranch: 'trunk' })],
+    });
+    await assert.rejects(() =>
+      runSingleStoryClose({
+        storyId: 4242,
+        noWaitForMerge: true,
+        cwd: REPO_ROOT,
+        injectedProvider: provider,
+        injectedConfig: pinnedConfig('trunk'),
+        injectedSync: async ({ baseBranch }) => {
+          syncedFrom.push(baseBranch);
+          return {
+            synced: false,
+            kind: 'conflict',
+            conflictFiles: ['src/x.js'],
+          };
+        },
+        injectedGh: makeFakeGh(() => {
+          throw new Error('gh must not be invoked when sync fails');
+        }),
+      }),
+    );
+    assert.deepEqual(syncedFrom, ['trunk']);
+    const friction = provider._posted().find((c) => c.type === 'friction');
+    assert.ok(friction, 'a friction comment must be posted');
+    assert.match(friction.body, /git merge --no-edit origin\/trunk/);
+  });
+
+  // AC-4 — no receipt: close still runs, but on the announced fallback, and
+  // AC-3 — an unconfirmed base withholds the merge advice.
+  it('falls back with a warning when the receipt is absent and withholds merge advice', async (t) => {
+    t.mock.module(GIT_UTILS_URL, gitUtilsMock());
+    mockCloseValidation(t, closeValidationMock());
+    t.mock.module(WORKTREE_MANAGER_URL, worktreeManagerMock());
+    const syncedFrom = [];
+
+    const { runSingleStoryClose } = await import(`${SUT_URL}?t=pin-absent`);
+    // No `comments` — the best-effort init upsert never landed, or the Story
+    // is being closed from a recovery path.
+    const provider = fakeProvider();
+    await assert.rejects(() =>
+      runSingleStoryClose({
+        storyId: 4242,
+        noWaitForMerge: true,
+        cwd: REPO_ROOT,
+        injectedProvider: provider,
+        injectedConfig: pinnedConfig('main'),
+        injectedSync: async ({ baseBranch }) => {
+          syncedFrom.push(baseBranch);
+          return {
+            synced: false,
+            kind: 'conflict',
+            conflictFiles: ['src/x.js'],
+          };
+        },
+        injectedGh: makeFakeGh(() => {
+          throw new Error('gh must not be invoked when sync fails');
+        }),
+      }),
+    );
+    assert.deepEqual(syncedFrom, ['main'], 'the fallback base is used');
+    const friction = provider._posted().find((c) => c.type === 'friction');
+    assert.ok(friction, 'a friction comment must be posted');
+    assert.doesNotMatch(friction.body, /git merge --no-edit origin\/main/);
+    assert.match(friction.body, /`main` is unconfirmed/);
   });
 });


### PR DESCRIPTION
Closes #4891

_Auto-opened by `/deliver`._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes pre-push close behavior and git remediation guidance for base-sync failures—wrong handling could block closes or mislead recovery, but the fail-closed design reduces risk of merging the wrong base.
> 
> **Overview**
> **Pins `project.baseBranch` at story init and enforces it at close** so a Story is never base-synced or remediated against a base it was not seeded from if `.agentrc` changes mid-run.
> 
> Init records `runScopedConfig` (via new `pinRunScopedConfig`) in the ticket’s `story-init` structured comment. Close calls `resolveRunScopedConfig` **before** gates, format-autofix, and base-sync: if the receipt disagrees with current config it throws with both values; if the receipt is missing or unreadable it falls back to current config with an explicit warning and `confirmed: false`.
> 
> Base-sync failure friction comments now take `baseConfirmed` (default false): **`git merge origin/<base>` recovery steps are only shown when the base was confirmed** against the init receipt; otherwise operators are told to establish the real base from the `story-init` comment first.
> 
> `resolveRunScopedConfig` is re-exported from `single-story-close.js` for tests; coverage is expanded in `single-story-close-sync.test.js`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e403ebf9063f9b080a7b1e2f5ad417e5c4478413. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->