### PR TITLE
fix: stop the git-cleanup branches phase announcing a DRY RUN before it deletes

### DIFF
--- a/.agents/scripts/lib/orchestration/git-cleanup/phases/phase-drivers.js
+++ b/.agents/scripts/lib/orchestration/git-cleanup/phases/phase-drivers.js
@@ -26,8 +26,8 @@ import { buildGlobFilter } from './filters.js';
 import { promptStashDecision, promptYesNo } from './prompts.js';
 import { executePrune } from './prune.js';
 import {
+  renderCandidateList,
   renderDeferredLine,
-  renderDryRun,
   renderExecutionLine,
   renderExecutionSummary,
   renderPruneLine,
@@ -41,8 +41,9 @@ import {
 const TAG = '[git-cleanup]';
 
 /* node:coverage ignore next */
-function emitDryRunHuman(plan, baseBranch) {
-  for (const line of renderDryRun(plan, { baseBranch })) Logger.info(line);
+function emitCandidateList(plan, opts, baseBranch) {
+  for (const l of renderCandidateList({ plan, opts, baseBranch }))
+    Logger.info(l);
 }
 
 /* node:coverage ignore next */
@@ -291,7 +292,7 @@ export async function runBranchPhase(opts, cwd, baseBranch) {
     filter,
     includeRemoteOnly: true,
   });
-  emitDryRunHuman(plan, baseBranch);
+  emitCandidateList(plan, opts, baseBranch);
   const action = decideBranchPhase({ plan, opts, cwd });
   if (action.kind === 'prompt-then-execute') {
     const go = await promptYesNo(action.promptMessage);

--- a/.agents/scripts/lib/orchestration/git-cleanup/phases/render.js
+++ b/.agents/scripts/lib/orchestration/git-cleanup/phases/render.js
@@ -61,11 +61,28 @@ function contentMergedNote(candidate) {
     : '';
 }
 
-/** Pure: render the dry-run plan as the operator-facing text block. */
+/**
+ * Pure: render the branch-phase candidate list as the operator-facing text
+ * block.
+ *
+ * The header states the run mode: `execute` opts into the reap wording and
+ * defaults to `false`, so a caller that forgets it still gets the harmless
+ * preview line. Prefer {@link renderCandidateList}, which derives the mode
+ * from the phase's own CLI options rather than making the caller restate
+ * it — the header used to be hardcoded to the preview wording, so an
+ * `--execute` run announced "nothing deleted" and then reaped.
+ *
+ * @param {{ candidates: Array, skipped?: Array, ghDegraded?: boolean }} plan
+ * @param {{ baseBranch?: string|null, now?: number, execute?: boolean }} [opts]
+ * @returns {string[]}
+ */
 export function renderDryRun(plan, opts = {}) {
-  const { baseBranch = null, now } = opts;
+  const { baseBranch = null, now, execute = false } = opts;
+  const count = plan.candidates.length;
   const lines = [
-    `${TAG} DRY RUN (nothing deleted) — ${plan.candidates.length} candidate(s)`,
+    execute
+      ? `${TAG} EXECUTE — ${count} candidate(s) to reap`
+      : `${TAG} DRY RUN (nothing deleted) — ${count} candidate(s)`,
   ];
   if (plan.candidates.length === 0) {
     lines.push('  (no merged branches to clean up)');
@@ -103,6 +120,25 @@ export function renderDryRun(plan, opts = {}) {
     );
   }
   return lines;
+}
+
+/**
+ * Pure: the branch phase's candidate-list block, with the header's run
+ * mode derived from the phase's own CLI options — the same `opts.dryRun`
+ * the reap path reads. Taking the whole bag (rather than a restated
+ * boolean) is the point: the driver cannot get the wording wrong because
+ * it never names the flag, so a destructive `--execute` run can no longer
+ * announce itself as a `DRY RUN (nothing deleted)` preview and then
+ * delete every candidate.
+ *
+ * @param {object} args
+ * @param {{ candidates: Array, skipped?: Array }} args.plan
+ * @param {{ dryRun?: boolean }} args.opts   Parsed CLI options.
+ * @param {string|null} [args.baseBranch]
+ * @returns {string[]}
+ */
+export function renderCandidateList({ plan, opts = {}, baseBranch = null }) {
+  return renderDryRun(plan, { baseBranch, execute: !opts.dryRun });
 }
 
 /**

--- a/tests/scripts/git-cleanup.test.js
+++ b/tests/scripts/git-cleanup.test.js
@@ -29,6 +29,7 @@ import {
   renderPruneLine,
   stashRefIndex,
 } from '../../.agents/scripts/git-cleanup.js';
+import { renderCandidateList } from '../../.agents/scripts/lib/orchestration/git-cleanup/phases/render.js';
 
 describe('git-cleanup.parseCleanupArgs', () => {
   it('defaults to dry-run with no flags', () => {
@@ -1187,6 +1188,18 @@ describe('git-cleanup renderers', () => {
   it('renderDryRun says "no merged branches" when empty', () => {
     const lines = renderDryRun({ candidates: [] });
     assert.match(lines[1], /no merged branches to clean up/);
+  });
+
+  it('renderDryRun promises "nothing deleted" unless the caller opts into execute', () => {
+    const plan = { candidates: [{ branch: 'fix/a', prNumber: 1 }] };
+    assert.match(
+      renderDryRun(plan)[0],
+      /DRY RUN \(nothing deleted\) — 1 candidate\(s\)/,
+    );
+    assert.match(
+      renderDryRun(plan, { execute: true })[0],
+      /EXECUTE — 1 candidate\(s\) to reap/,
+    );
   });
 
   it('renderDryRun marks remote-only candidates with a (remote-only) note', () => {
@@ -2520,5 +2533,58 @@ describe('git-cleanup.renderDryRun content-merged distinctness (Story #4395)', (
       skipped: [],
     });
     assert.doesNotMatch(lines[1], /weaker signal/);
+  });
+});
+
+describe('git-cleanup.renderCandidateList — header states the run mode', () => {
+  // Regression: the branches phase used to render this block through a
+  // helper hardcoded to the dry-run header, so `--execute` printed
+  // "DRY RUN (nothing deleted)" and then reaped every candidate. The
+  // wording now comes from the phase's own opts bag, which is also what
+  // the reap path reads.
+  const plan = {
+    candidates: [{ branch: 'fix/a', prNumber: 1, detectedBy: 'gh' }],
+    skipped: [],
+  };
+
+  it('promises "nothing deleted" on a dry run', () => {
+    const [header] = renderCandidateList({ plan, opts: { dryRun: true } });
+    assert.match(header, /DRY RUN \(nothing deleted\) — 1 candidate\(s\)/);
+  });
+
+  it('announces the reap — never a dry run — under --execute', () => {
+    const [header] = renderCandidateList({
+      plan,
+      opts: { dryRun: false, yes: true },
+    });
+    assert.match(header, /EXECUTE — 1 candidate\(s\) to reap/);
+    assert.doesNotMatch(header, /DRY RUN|nothing deleted/);
+  });
+
+  it('treats an absent dryRun flag as execute, not as a preview', () => {
+    const [header] = renderCandidateList({ plan, opts: {} });
+    assert.doesNotMatch(header, /DRY RUN|nothing deleted/);
+  });
+
+  it('the dry-run and --execute headers differ', () => {
+    const [preview] = renderCandidateList({ plan, opts: { dryRun: true } });
+    const [reap] = renderCandidateList({ plan, opts: { dryRun: false } });
+    assert.notEqual(preview, reap);
+  });
+
+  it('still renders the candidate rows and the current-head hint', () => {
+    const lines = renderCandidateList({
+      plan: {
+        candidates: plan.candidates,
+        skipped: [{ branch: 'feat/wip', reason: 'current-head' }],
+      },
+      opts: { dryRun: true },
+      baseBranch: 'main',
+    });
+    assert.match(lines[1], /fix\/a — PR #1/);
+    assert.match(
+      lines.find((l) => /current HEAD/.test(l)),
+      /checkout main first/,
+    );
   });
 });


### PR DESCRIPTION
## Why

`node .agents/scripts/git-cleanup.js --execute --yes` printed this, and then deleted all four branches:

```
[git-cleanup] ── phase: branches ──
[git-cleanup] DRY RUN (nothing deleted) — 4 candidate(s)
...
[git-cleanup] ✅ Reaped 4 local + 0 remote + 0 worktree(s).
```

The branches phase rendered its candidate list through a helper hardcoded to the dry-run header, so the line stated the opposite of what the tool was about to do on a destructive phase. An operator scanning the log for confirmation that a run was a preview would be actively misled — the trailing `Reaped 4 local` line is the only correction, and it appears after the deletions. `fast-forward-main` and `prune-remotes` label correctly in the same run; branches was the odd one out.

## What changed

- `renderCandidateList` (new, in `render.js`) owns the block and derives the header from the phase's own CLI options — the same `opts.dryRun` the reap path reads. Taking the whole opts bag rather than a restated boolean is the point: the driver cannot get the wording wrong because it never names the flag.
- `renderDryRun` keeps its contract for direct callers and gains an `execute` opt-in flag defaulting to the preview wording, so a caller that forgets it fails safe.
- An execute run now prints `EXECUTE — N candidate(s) to reap`. "to reap" rather than "reaping" because the header also precedes the interactive confirmation the operator can still decline.

## Tests

Regression coverage on `renderCandidateList`: dry-run vs `--execute` headers differ, an absent `dryRun` flag reads as execute rather than as a preview, and the rows/current-head hint still render. Plus the two `renderDryRun` modes directly.

Verified end-to-end in a throwaway repo with one merged branch — dry run prints `DRY RUN (nothing deleted) — 1 candidate(s)` and deletes nothing; `--execute --yes` prints `EXECUTE — 1 candidate(s) to reap` and reaps it.

Gates: `npm run lint` (0 errors), `npm test` (9688 pass / 0 fail), `check-arch-cycles` `added=0`, `check-dead-exports` and `--production` both `added=0`, `check-baselines` exit 0, pre-commit `quality:preview` MI/CRAP regressions 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Logging-only fix for branch-phase headers; branch deletion behavior and planning logic are unchanged.
> 
> **Overview**
> Fixes misleading operator output in the **branches** phase of `git-cleanup`: `--execute` runs no longer print **DRY RUN (nothing deleted)** before reaping merged branches.
> 
> The driver now logs the candidate list via **`renderCandidateList`**, which sets the header from the same **`opts.dryRun`** flag the reap path uses. **`renderDryRun`** keeps its existing API for direct callers and adds an opt-in **`execute`** flag (default preview wording) so forgotten callers still fail safe. Execute mode shows **`EXECUTE — N candidate(s) to reap`** instead of the dry-run line.
> 
> Regression tests cover **`renderCandidateList`** and both **`renderDryRun`** header modes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cfcbcbb5024708aa3e01bd21ffc15bb6d0a3507a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->