### PR TITLE
fix: exclude transpiled-coordinate rows from the 0%-coverage fill, and refuse a baseline that predates provenance stamping (#4901)

### DIFF
--- a/.agents/schemas/baselines/baseline-envelope.schema.json
+++ b/.agents/schemas/baselines/baseline-envelope.schema.json
@@ -29,6 +29,10 @@
       "type": "string",
       "description": "Optional per-kind stamp identifying the TypeScript transpiler that produced the sourcemap these rows' line coordinates were resolved through (Story #4866). Only meaningful for kinds whose rows carry a line coordinate derived from transpiled sources; a transpiler change can move every such coordinate, and for kinds that key rows on a line that coordinate is half the row identity."
     },
+    "provenanceStamped": {
+      "type": "boolean",
+      "description": "Optional per-kind POSITIVE assertion that the writer which produced these rows recorded each row's coordinate provenance (Story #4901). Only meaningful for kinds whose rows carry a line coordinate that may be transpiled. Absence is the only evidence a baseline written before provenance existed leaves behind — such a baseline claims by omission that every row is an original-source coordinate — so the kind's compat axis fails it closed with re-seed guidance rather than letting the comparator key rows against a coordinate space they are not in."
+    },
     "rollup": {
       "type": "object",
       "description": "Aggregate metrics keyed by component. The '*' key is reserved for the whole-repo rollup and is REQUIRED; additional keys MAY be present, one per declared component.",

--- a/.agents/schemas/baselines/crap.schema.json
+++ b/.agents/schemas/baselines/crap.schema.json
@@ -10,6 +10,10 @@
       "type": "string",
       "description": "Identifier for the per-method coverage-join semantics that produced these rows (Story #4775). Deliberately NOT constrained to the current value here: an old-semantics baseline must reach the gate's compat axis, which fails it closed with an explicit re-baseline command, rather than being rejected with a raw schema error."
     },
+    "provenanceStamped": {
+      "type": "boolean",
+      "description": "Positive assertion that the writer which produced these rows recorded coordinate provenance per row (Story #4901). Absence is the ONLY evidence a pre-Story-#4866 baseline leaves — such a baseline claims by omission that every row is an original-source coordinate while some are transpiled. Deliberately optional and unconstrained here for the same reason as scoringSemantics: an unstamped baseline must reach the `provenance-unstamped` compat axis, which fails it closed with the re-seed command when it also carries transpiled-source rows, rather than dying on a raw schema error. A pure-JavaScript baseline never needs it."
+    },
     "rollup": {
       "type": "object",
       "required": ["*"],

--- a/.agents/scripts/lib/baselines/kinds/crap.js
+++ b/.agents/scripts/lib/baselines/kinds/crap.js
@@ -116,12 +116,22 @@ const SCORING_SEMANTICS = 'coverage-join-v2';
  * the stamp on disk the `ts-transpiler-drift` axis had nothing to compare and
  * passed vacuously.
  *
- * @returns {{scoringSemantics: string, tsTranspilerVersion: string}}
+ * `provenanceStamped` joined in Story #4901 as a **positive** marker: the
+ * writer asserting it recorded per-row provenance at all. Absence is the only
+ * evidence a pre-#4866 baseline leaves, and no other stamp detects it —
+ * `kernelVersion` / `escomplexVersion` track the escomplex package (unmoved
+ * by the fix), `scoringSemantics` did not change, and `tsTranspilerVersion`
+ * is unreliable in the negative (the `'0.0.0'` sentinel). See the
+ * `provenance-unstamped` axis.
+ *
+ * @returns {{scoringSemantics: string, tsTranspilerVersion: string,
+ *   provenanceStamped: boolean}}
  */
 export function envelopeExtras() {
   return {
     scoringSemantics: SCORING_SEMANTICS,
     tsTranspilerVersion: resolveTsTranspilerVersion(),
+    provenanceStamped: true,
   };
 }
 
@@ -636,6 +646,17 @@ export function assessComparisonBasis(compareResult, opts = {}) {
  * and `tsTranspilerVersion` drift to **warn**, not fail; `escomplexVersion`
  * mismatch continues to fail closed.
  */
+/**
+ * The one re-seed recipe every coordinate-invalidating axis ends on. Three
+ * axes and the unsound-basis diagnostic previously carried their own copy of
+ * this sentence; a single constant keeps them from drifting apart on the
+ * command an operator is told to run.
+ */
+const RESEED_REMEDY =
+  "Re-derive the baseline: run 'npm run test:coverage' then " +
+  "'npm run crap:update -- --full-scope' and commit the result with a " +
+  "'baseline-refresh:' subject.";
+
 export const CRAP_COMPAT_AXES = [
   // Universal axes hoisted into envelope.js (Story #2467, Task #2492). The
   // missing-baseline and kernel-drift checks live in exactly one place;
@@ -661,9 +682,7 @@ export const CRAP_COMPAT_AXES = [
         `[CRAP] scoring semantics changed: baseline=${stamped ?? '<unstamped>'} ` +
         `running=${SCORING_SEMANTICS}. Rows scored by the previous per-method ` +
         'coverage join are not comparable to rows scored by the current one, ' +
-        'so this baseline cannot be compared — it must be re-derived. Run ' +
-        "'npm run test:coverage' then 'npm run crap:update -- --full-scope' " +
-        "and commit the result with a 'baseline-refresh:' subject."
+        `so this baseline cannot be compared. ${RESEED_REMEDY}`
       );
     },
   },
@@ -688,12 +707,33 @@ export const CRAP_COMPAT_AXES = [
         `[CRAP] tsTranspilerVersion changed: baseline=${baselineTs} running=${runningTsTranspilerVersion}. ` +
         "A TS row's startLine is an original-source coordinate only because the transpiler's " +
         'sourcemap said so, and that coordinate is half the row identity key — so rows scored ' +
-        'under the previous transpiler are not comparable to rows scored under this one. ' +
-        "Re-derive the baseline: run 'npm run test:coverage' then " +
-        "'npm run crap:update -- --full-scope' and commit the result with a " +
-        "'baseline-refresh:' subject."
+        `under the previous transpiler are not comparable to rows scored under this one. ${RESEED_REMEDY}`
       );
     },
+  },
+  {
+    // Story #4901. Closes the exemption directly above: `ts-transpiler-drift`
+    // returns null for an unstamped baseline rather than fail every
+    // pre-existing one for want of evidence — and a pre-#4866 baseline is
+    // exactly that shape, so the one door that could catch it lets it through
+    // while it asserts by omission that all its rows are original coordinates.
+    // Keyed on a positive marker because absence alone cannot separate
+    // "written before provenance existed" from "typescript was unresolvable".
+    // Scoped like `ts-transpiler-drift`: a pure-JavaScript baseline's two
+    // coordinate systems coincide, so it was never affected and must not fail.
+    name: 'provenance-unstamped',
+    severity: 'fatal',
+    check: ({ baseline }) =>
+      baseline &&
+      baseline.provenanceStamped !== true &&
+      hasTranspiledRows(baseline)
+        ? '[CRAP] baseline predates coordinate-provenance stamping: it carries ' +
+          'transpiled-source rows but no `provenanceStamped` marker, so it ' +
+          'asserts by omission that every row is an original-source coordinate. ' +
+          '`startLine` is half the row identity key, so the comparator would ' +
+          'key those rows against a coordinate space they are not in and ' +
+          `report regressions no edit can satisfy. ${RESEED_REMEDY}`
+        : null,
   },
 ];
 
@@ -742,15 +782,20 @@ export function evaluateBaselineCompatibility(ctx) {
 
 /**
  * The compat axes a *loaded* envelope can be judged against on its own,
- * without a second baseline to diff. Both are coordinate-invalidating: one
- * names the join that produced the rows, the other names the transpiler whose
- * sourcemap decided what a TS row's `startLine` even means.
+ * without a second baseline to diff. All three are coordinate-invalidating:
+ * one names the join that produced the rows, one names the transpiler whose
+ * sourcemap decided what a TS row's `startLine` even means, and one (Story
+ * #4901) catches a baseline predating both questions.
  *
  * `escomplex-mismatch` and `kernel-drift` stay out — the v2 envelope carries
  * no `escomplexVersion`, so that axis would compare `undefined` to `undefined`
  * and pass vacuously, which is worse than not running it.
  */
-const LOADED_ENVELOPE_AXES = ['scoring-semantics-drift', 'ts-transpiler-drift'];
+const LOADED_ENVELOPE_AXES = [
+  'scoring-semantics-drift',
+  'ts-transpiler-drift',
+  'provenance-unstamped',
+];
 
 /**
  * Kind-module hook (Story #4775, extended by Story #4866): judge a *loaded*

--- a/.agents/scripts/lib/crap-engine.js
+++ b/.agents/scripts/lib/crap-engine.js
@@ -132,10 +132,16 @@ export function methodRowsFromReport(report, coverageForFile, mapLine = null) {
  * so `requireCoverage: false` keeps meaning "score untested code" whenever a
  * real coverage run stands behind the verdict.
  *
- * `resolvedMethods` / `totalMethods` count the *join*, not the fill: a
- * method scored 0% because its coverage was unresolved counts as
- * unresolved. That is what makes them usable as a health signal for the
- * updater's fail-closed resolution-rate floor.
+ * **Unjoinable is not untested (Story #4901).** Both policies above are about
+ * a method whose coverage is *absent*; neither is about one whose coverage
+ * could not be **joined**. A transpiled `startLine` is the latter — not in
+ * the coordinate space the `fnMap` or the baseline is keyed against — so 0%
+ * is not a measurement but a number invented for it, and `crapFormula(c, 0)`
+ * is the maximal `c² + c`. Excluded under **either** policy, and counted.
+ *
+ * `resolvedMethods` / `totalMethods` count the *join*, not the fill, which is
+ * what makes them a health signal for the updater's fail-closed
+ * resolution-rate floor — so the exclusion is applied *after* both counters.
  *
  * @param {Array<object>} rawRows Rows from `methodRowsFromReport`.
  * @param {{requireCoverage?: boolean, coverageAvailable?: boolean}} [opts]
@@ -158,7 +164,11 @@ export function finalizeMethodRows(
     totalMethods += 1;
     const unresolved = mr.crap === null || mr.coverage === null;
     if (!unresolved) resolvedMethods += 1;
-    if (unresolved && (requireCoverage || !coverageAvailable)) {
+    // Unjoinable is not untested (Story #4901) — see the block comment above.
+    if (
+      mr.coordinateSystem === COORDINATE_TRANSPILED ||
+      (unresolved && (requireCoverage || !coverageAvailable))
+    ) {
       skippedMethodsNoCoverage += 1;
       continue;
     }

--- a/baselines/crap.json
+++ b/baselines/crap.json
@@ -4,6 +4,7 @@
   "generatedAt": "2026-07-30T02:34:12.345Z",
   "scoringSemantics": "coverage-join-v2",
   "tsTranspilerVersion": "6.0.3",
+  "provenanceStamped": true,
   "rollup": {
     "*": {
       "p50": 2,

--- a/tests/baselines/crap-compat-axes.test.js
+++ b/tests/baselines/crap-compat-axes.test.js
@@ -30,11 +30,15 @@ function axis(name) {
 // Story #4866: the ts-transpiler axis is scoped to baselines that actually
 // contain transpiled sources, so the shared fixture carries one TS row. A
 // transpiler change moves TS row coordinates and nothing else.
+// Story #4901: a current writer stamps `provenanceStamped`, so a baseline
+// that is valid in every other respect carries it too — without it the
+// `provenance-unstamped` axis would (correctly) refuse this TS-row fixture.
 const VALID_BASELINE = {
   escomplexVersion: '0.8.0',
   kernelVersion: '0.8.0',
   tsTranspilerVersion: '5.4.0',
   scoringSemantics: SCORING_SEMANTICS,
+  provenanceStamped: true,
   rows: [{ path: 'src/a.ts', method: 'run', startLine: 3, crap: 2 }],
 };
 
@@ -361,5 +365,102 @@ describe('scoring-semantics-drift axis', () => {
 
   it('treats a null baseline as the missing-baseline axis job, not its own', () => {
     assert.equal(assertBaselineCompatible(null), null);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Story #4901 — the pre-provenance baseline axis.
+//
+// The hole this closes is `ts-transpiler-drift`'s own deliberate exemption:
+// it returns null for an unstamped baseline so that pre-existing baselines
+// are not failed for no evidence. A pre-#4866 baseline is exactly that shape.
+// ---------------------------------------------------------------------------
+describe('provenance-unstamped axis (#4901)', () => {
+  // The real pre-#4866 shape: neither stamp exists, because neither had been
+  // written yet. Keeping `tsTranspilerVersion` here would be unfaithful AND
+  // would let the earlier ts-transpiler axis short-circuit the reduce — the
+  // very exemption that makes this axis necessary is what routes a genuine
+  // pre-provenance baseline through to it.
+  const PRE_PROVENANCE_BASELINE = (() => {
+    const b = { ...VALID_BASELINE };
+    delete b.provenanceStamped;
+    delete b.tsTranspilerVersion;
+    return b;
+  })();
+
+  it('is fatal, not a warning', () => {
+    assert.equal(axis('provenance-unstamped').severity, 'fatal');
+  });
+
+  it('fires on a TS-row baseline with no provenanceStamped marker', () => {
+    const message = axis('provenance-unstamped').check({
+      baseline: PRE_PROVENANCE_BASELINE,
+    });
+    assert.match(message, /predates coordinate-provenance stamping/);
+  });
+
+  it('passes a baseline carrying the marker', () => {
+    assert.equal(
+      axis('provenance-unstamped').check({ baseline: VALID_BASELINE }),
+      null,
+    );
+  });
+
+  it('never fires on a pure-JavaScript baseline, marker or not', () => {
+    // The load-bearing exemption: JS coordinates already ARE original-source
+    // coordinates, so a JS-only baseline was never affected by #4866 and must
+    // not be forced through a re-seed it does not need.
+    const jsLegacy = { ...JS_ONLY_BASELINE };
+    delete jsLegacy.provenanceStamped;
+    assert.equal(
+      axis('provenance-unstamped').check({ baseline: jsLegacy }),
+      null,
+    );
+  });
+
+  it('does not accept a truthy non-true marker', () => {
+    // The marker is an assertion, not a hint — only the writer's literal
+    // `true` counts, so a hand-edited string cannot wave a baseline through.
+    const spoofed = { ...PRE_PROVENANCE_BASELINE, provenanceStamped: 'yes' };
+    assert.match(
+      axis('provenance-unstamped').check({ baseline: spoofed }),
+      /predates coordinate-provenance stamping/,
+    );
+  });
+
+  it('treats a null baseline as the missing-baseline axis job', () => {
+    assert.equal(axis('provenance-unstamped').check({ baseline: null }), null);
+  });
+
+  it('names the exact re-seed command in its guidance', () => {
+    const message = axis('provenance-unstamped').check({
+      baseline: PRE_PROVENANCE_BASELINE,
+    });
+    assert.match(message, /npm run test:coverage/);
+    assert.match(message, /crap:update -- --full-scope/);
+    assert.match(message, /baseline-refresh:/);
+  });
+
+  it('is reachable through assertBaselineCompatible (the loaded-envelope door)', () => {
+    // Without this registration the axis exists but nothing in production
+    // reaches it — the exact shape of the #4866 gap it closes.
+    const message = assertBaselineCompatible(PRE_PROVENANCE_BASELINE);
+    assert.match(message, /predates coordinate-provenance stamping/);
+  });
+
+  it('fails the whole reduce closed', () => {
+    const out = evaluateBaselineCompatibility({
+      ...VALID_CTX,
+      baseline: PRE_PROVENANCE_BASELINE,
+    });
+    assert.equal(out.ok, false);
+    assert.equal(out.exitCode, 1);
+    assert.equal(out.kind, 'provenance-unstamped');
+  });
+});
+
+describe('envelopeExtras — provenance marker (#4901)', () => {
+  it('stamps provenanceStamped: true so new baselines carry the assertion', () => {
+    assert.equal(envelopeExtras().provenanceStamped, true);
   });
 });

--- a/tests/baselines/crap-compat-axes.test.js
+++ b/tests/baselines/crap-compat-axes.test.js
@@ -464,3 +464,36 @@ describe('envelopeExtras — provenance marker (#4901)', () => {
     assert.equal(envelopeExtras().provenanceStamped, true);
   });
 });
+
+describe('provenance-unstamped — the fail-CLOSED door (#4901)', () => {
+  it('reaches check-baselines through checkBaselineSemantics', async () => {
+    // The other half of the Story's disposition contract. `preview-gates.js`
+    // fails OPEN on this message (asserted in tests/quality-preview.test.js);
+    // `check-baselines` fails CLOSED on it. Both read the same axis, but they
+    // read it through different doors — this is the one evaluate.js calls,
+    // which maps any non-null message to `{ schemaError: { tag: 'semantics' } }`.
+    const { checkBaselineSemantics } = await import(
+      '../../.agents/scripts/lib/baselines/kernel.js'
+    );
+    const preProvenance = { ...VALID_BASELINE };
+    delete preProvenance.provenanceStamped;
+    delete preProvenance.tsTranspilerVersion;
+
+    assert.match(
+      checkBaselineSemantics('crap', preProvenance),
+      /predates coordinate-provenance stamping/,
+    );
+    // And a current baseline is not refused, so the gate stays usable. This
+    // door resolves the running versions from the environment rather than
+    // taking them injected, so the control must carry the writer's own stamps
+    // — otherwise the ts-transpiler axis fires first on a fixture-pinned
+    // version and this assertion would pass for the wrong reason.
+    assert.equal(
+      checkBaselineSemantics('crap', {
+        ...VALID_BASELINE,
+        ...envelopeExtras(),
+      }),
+      null,
+    );
+  });
+});

--- a/tests/lib/crap-engine.test.js
+++ b/tests/lib/crap-engine.test.js
@@ -299,7 +299,7 @@ describe('methodRowsFromReport — an un-remapped line joins no coverage (AC-2)'
   });
 });
 
-describe('finalizeMethodRows — provenance survives the policy step', () => {
+describe('finalizeMethodRows — provenance gates the fill (#4866, #4901)', () => {
   const raw = [
     {
       method: 'mapped',
@@ -331,14 +331,55 @@ describe('finalizeMethodRows — provenance survives the policy step', () => {
     assert.equal(out.skippedMethodsNoCoverage, 1);
   });
 
-  it('keeps the flag on a row scored 0% under requireCoverage: false', () => {
-    // Here the row DOES land in the baseline, so the flag is the only thing
-    // stopping the compare from keying a transpiled line as an original one.
+  it('drops the un-remapped row under requireCoverage: false too (#4901)', () => {
+    // Story #4901. This row used to be KEPT here and scored 0% — the flag
+    // rode along, but the scoring branch never read it, so `crapFormula(3, 0)`
+    // put a maximal 12 into the baseline for a method whose coverage was
+    // merely unjoinable. Against a baseline row at the other coordinate that
+    // reads as a drifted-regression no edit to the file can satisfy.
     const out = finalizeMethodRows(raw, { requireCoverage: false });
-    const unmapped = out.rows.find((r) => r.method === 'unmapped');
-    assert.equal(unmapped.coordinateSystem, COORDINATE_TRANSPILED);
-    assert.equal(unmapped.coverage, 0);
-    assert.equal(unmapped.crap, 3 ** 2 + 3);
+    assert.deepEqual(
+      out.rows.map((r) => r.method),
+      ['mapped'],
+    );
+    assert.equal(out.skippedMethodsNoCoverage, 1);
+  });
+
+  it('still scores a genuinely uninstrumented ORIGINAL row at 0%', () => {
+    // The `requireCoverage: false` policy itself is untouched: an unresolved
+    // row whose coordinate IS joinable is untested code, and 0% is a real
+    // measurement of it. Only the unjoinable case changed.
+    const out = finalizeMethodRows(
+      [
+        {
+          method: 'untested',
+          startLine: 7,
+          cyclomatic: 3,
+          coverage: null,
+          crap: null,
+          coordinateSystem: COORDINATE_ORIGINAL,
+        },
+      ],
+      { requireCoverage: false, coverageAvailable: true },
+    );
+    assert.equal(out.rows.length, 1);
+    assert.equal(out.rows[0].coverage, 0);
+    assert.equal(out.rows[0].crap, 3 ** 2 + 3);
+  });
+
+  it('leaves the join counters untouched under either policy', () => {
+    // The resolution-rate floor reads the JOIN, not the fill, so excluding a
+    // transpiled row must not move these — otherwise the updater's
+    // fail-closed floor would drift as a side effect of this Story.
+    for (const requireCoverage of [true, false]) {
+      const out = finalizeMethodRows(raw, { requireCoverage });
+      assert.equal(out.totalMethods, 2, `totalMethods @ ${requireCoverage}`);
+      assert.equal(
+        out.resolvedMethods,
+        1,
+        `resolvedMethods @ ${requireCoverage}`,
+      );
+    }
   });
 
   it('defaults a row with no stamp to original coordinates', () => {

--- a/tests/quality-preview.test.js
+++ b/tests/quality-preview.test.js
@@ -775,6 +775,61 @@ describe('runCrapPreview — compat check runs BEFORE the compare (AC-6)', () =>
   });
 });
 
+// ---------------------------------------------------------------------------
+// Story #4901 — the upgrade door. A baseline written before provenance
+// stamping asserts by omission that all its rows are original coordinates.
+// The preview must fail OPEN and say "re-seed", not emit regressions derived
+// from a join it cannot key.
+// ---------------------------------------------------------------------------
+describe('runCrapPreview — a pre-provenance baseline is refused (#4901)', () => {
+  it('exits 0, suppresses verdicts, and names the re-seed remedy', async () => {
+    const methodCount = 25;
+    // A TS row with no `provenanceStamped` marker: the pre-#4866 writer's
+    // exact output shape, and the one the ts-transpiler axis deliberately
+    // exempts.
+    const baselineRows = [
+      ...baselineRowsFor(methodCount, 0, 0),
+      { path: 'src/legacy.tsx', method: 'render', startLine: 458, crap: 2 },
+    ];
+    const dir = makeCrapFixture({ methodCount, baselineRows });
+    try {
+      const { exitCode, envelope } = await runCrapPreview({ cwd: dir });
+      assert.equal(exitCode, 0, 'the preview fails open, never closed');
+      assert.deepEqual(envelope.violations, []);
+      assert.equal(envelope.diagnostics[0].name, 'crap-baseline-incompatible');
+      assert.match(
+        envelope.diagnostics[0].message,
+        /predates coordinate-provenance stamping/,
+      );
+      assert.match(
+        envelope.diagnostics[0].message,
+        /crap:update -- --full-scope/,
+      );
+      // Refused before the scan's rows ever meet it.
+      assert.equal(envelope.summary.total, 0);
+    } finally {
+      rmFixture(dir);
+    }
+  });
+
+  it('leaves a pure-JavaScript baseline alone even without the marker', async () => {
+    // The invariant that keeps every JS consumer (this repo included) off the
+    // re-seed path: no transpiled row means no coordinate that could be wrong.
+    const methodCount = 25;
+    const dir = makeCrapFixture({
+      methodCount,
+      baselineRows: baselineRowsFor(methodCount, 0, 0),
+    });
+    try {
+      const { envelope } = await runCrapPreview({ cwd: dir });
+      assert.deepEqual(envelope.diagnostics ?? [], []);
+      assert.equal(envelope.summary.total, methodCount);
+    } finally {
+      rmFixture(dir);
+    }
+  });
+});
+
 test('renderDiagnostics — a suppressed gate is never silent', () => {
   assert.equal(renderDiagnostics([{ envelope: null }, { envelope: {} }]), null);
   const rendered = renderDiagnostics([


### PR DESCRIPTION
Closes #4901

_Auto-opened by `/deliver`._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CRAP scoring and baseline gate behavior for TypeScript consumers; legacy TS baselines without `provenanceStamped` will need a deliberate re-seed, but JS-only repos are unchanged.
> 
> **Overview**
> Closes a gap where **transpiled-coordinate** methods could still enter baselines with a **0% / maximal CRAP** fill under `requireCoverage: false`, producing phantom regressions. **`finalizeMethodRows`** now skips those rows under **both** coverage policies (same as truly unjoinable), while genuinely untested **original-coordinate** methods still get the 0% fill.
> 
> Adds **`provenanceStamped: true`** on new CRAP envelopes and a fatal **`provenance-unstamped`** compat axis for baselines with **TS/TSX rows** but no marker—**`check-baselines`** fails closed; **quality preview** fails open with re-seed guidance. **Pure-JS** baselines stay exempt. Re-seed instructions are centralized in **`RESEED_REMEDY`**; committed **`baselines/crap.json`** is restamped.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit da9ba98f5947746c46762e42e42cb0a2694af3cc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->