### PR TITLE
docs: give deliver-digest section 3 the actual call shapes for deriveChangeLevel and resolveCeremonyForRisk, and guard them against drift (#4904)

### DIFF
--- a/.agents/workflows/helpers/deliver-digest.md
+++ b/.agents/workflows/helpers/deliver-digest.md
@@ -54,21 +54,32 @@ the only sanctioned landing. A silent local build is not a delivery.
 ## 3. Change set — computed once, handed to everyone
 
 One enumeration per Story. A critic that re-runs its own `git diff`
-can score a different set than the one that routed it:
+can score a different set than the one that routed it. Both routing calls take
+a single options object and are **total — they never throw**, so a wrong-shaped
+argument is absorbed into the `null` fail-safe and reports nothing:
 
 ```bash
 node --input-type=module -e '
-  import { computeChangeSet } from "<main-repo>/.agents/scripts/lib/orchestration/change-set.js";
+  const lib = "<main-repo>/.agents/scripts/lib/orchestration";
+  const { computeChangeSet } = await import(`${lib}/change-set.js`);
+  const { deriveChangeLevel } = await import(`${lib}/review-depth.js`);
+  const { resolveCeremonyForRisk } = await import(`${lib}/ceremony-routing.js`);
   const { files } = computeChangeSet({ baseRef: "main", headRef: "story-<storyId>" });
-  console.log(JSON.stringify(files));
+  // deriveChangeLevel({ changedFiles, injectedRules?, selectSensitivePathClassesFn? })
+  //   -> { level, classes } — an OBJECT, never a bare level.
+  const { level, classes } = deriveChangeLevel({ changedFiles: files });
+  // resolveCeremonyForRisk({ derivedLevel, clusterIndex?, freshCriticSampleRate?,
+  //   ceremonyProfile? }) -> { mode, reason, sampled, profile, verdictOwner }.
+  // derivedLevel is that level STRING. Handing it the object above matches no
+  // tier, so it routes to the null fail-safe: a fresh critic, silently.
+  const ceremony = resolveCeremonyForRisk({ derivedLevel: level, clusterIndex: 0 });
+  console.log(JSON.stringify({ files, level, classes, ...ceremony }));
 '
 ```
 
-Derive the level with `deriveChangeLevel`
-([`review-depth.js`](../../scripts/lib/orchestration/review-depth.js)) over
-that one list: a sensitive path registered in `audit-rules.json` → `high`, none
-→ `low`, an unenumerable diff (`files === null`) → `null`. Resolve
-fresh-vs-inline critics with `resolveCeremonyForRisk`
+Level rules ([`review-depth.js`](../../scripts/lib/orchestration/review-depth.js)):
+a sensitive path registered in `audit-rules.json` → `high`, none → `low`, an
+unenumerable diff (`files === null`) → `null`. Ceremony rules
 ([`ceremony-routing.js`](../../scripts/lib/orchestration/ceremony-routing.js)):
 `minimal` → always inline, `strict` → always fresh, `standard` → `high`/`null`
 → fresh and `low` → inline unless the `freshCriticSampleRate` floor forces

--- a/tests/workflows/deliver-digest.test.js
+++ b/tests/workflows/deliver-digest.test.js
@@ -27,6 +27,8 @@ import path from 'node:path';
 import { describe, it } from 'node:test';
 import { fileURLToPath } from 'node:url';
 
+import { resolveCeremonyForRisk } from '../../.agents/scripts/lib/orchestration/ceremony-routing.js';
+import { deriveChangeLevel } from '../../.agents/scripts/lib/orchestration/review-depth.js';
 import { assertDocMentions } from '../helpers/doc-assert.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -52,6 +54,9 @@ describe('helpers/deliver-digest.md — the one bundled deliver read (AC-5)', ()
       ['the branch/merge invariants', 'story-<id>'],
       ['the change-set-once discipline', 'computeChangeSet'],
       ['the ceremony resolution', 'resolveCeremonyForRisk'],
+      ['the deriveChangeLevel argument key', 'changedFiles'],
+      ['the deriveChangeLevel return shape', '{ level, classes }'],
+      ['the resolveCeremonyForRisk argument key', 'derivedLevel'],
       ['the acceptance gate invocation', 'acceptance-eval.js'],
       ['the terminal envelope marker', '--- STORY DELIVER TERMINAL ---'],
       ['the state-transition command', 'update-ticket-state.js'],
@@ -129,6 +134,102 @@ describe('helpers/deliver-story.md — the orphaned-envelope fallback (#4816)', 
       spine(),
       /never re-init underneath it/i,
       'the hazard (two closes racing one PR) must be stated where the operator reads it',
+    );
+  });
+});
+
+describe('deliver-digest § 3 — the ceremony incantation, verified by execution (#4904)', () => {
+  // § 3 is the only place the deliver path learns how to route ceremony, and a
+  // prose assertion cannot protect it: both functions are total, so a
+  // wrong-shaped argument raises nothing and merely resolves to the `null`
+  // fail-safe — a fresh critic sub-agent bought on every low-risk Story, with
+  // no error anywhere to attribute the cost to. Grepping the markdown for
+  // `changedFiles` would still pass after the parameter was renamed in source.
+  // So these two tests CALL the documented composition instead.
+
+  it('yields a real level and a real mode when called with the documented shapes', () => {
+    // Arrange — the digest's own argument shape and nothing else, against the
+    // real audit-rules.json manifest the deliverer would hit.
+    const changedFiles = ['docs/onboarding.md', 'README.md'];
+
+    // Act — the composition exactly as § 3 spells it out.
+    const derived = deriveChangeLevel({ changedFiles });
+    const ceremony = resolveCeremonyForRisk({
+      derivedLevel: derived.level,
+      clusterIndex: 0,
+    });
+
+    // Assert — a derivable level is the whole point: `null` here would mean
+    // `changedFiles` is no longer the key `deriveChangeLevel` reads.
+    assert.notEqual(
+      derived.level,
+      null,
+      'deriveChangeLevel({ changedFiles }) returned the null fail-safe for an enumerable, non-sensitive change set — the documented argument key no longer reaches the derivation',
+    );
+    assert.ok(
+      Array.isArray(derived.classes),
+      'deriveChangeLevel must return { level, classes } — § 3 documents the classes array, so a caller destructuring it cannot get undefined',
+    );
+    assert.ok(
+      ceremony.mode === 'fresh' || ceremony.mode === 'inline',
+      `resolveCeremonyForRisk({ derivedLevel }) must resolve a concrete mode, got ${JSON.stringify(ceremony.mode)}`,
+    );
+    assert.equal(
+      ceremony.verdictOwner,
+      ceremony.mode === 'fresh' ? 'fresh-critic' : 'inline-self-eval',
+      'the resolved decision must name its single verdict owner — § 3 promises verdictOwner on the returned object',
+    );
+  });
+
+  it('routes the object-for-string mistake to the null fail-safe, never a low verdict', () => {
+    // Arrange — pin the level to `low` independently of the shipped manifest by
+    // injecting the documented `selectSensitivePathClassesFn` seam, so the only
+    // variable between the two resolutions below is the argument SHAPE.
+    const derived = deriveChangeLevel({
+      changedFiles: ['docs/onboarding.md'],
+      selectSensitivePathClassesFn: () => [],
+    });
+    assert.equal(
+      derived.level,
+      'low',
+      'precondition: an injected no-match selector must derive `low`',
+    );
+
+    // Act — the documented composition, then the mistake the old § 3 wording
+    // invited: handing `derivedLevel` the whole result object. Sampling is
+    // disabled in both so the floor cannot account for any difference.
+    const documented = resolveCeremonyForRisk({
+      derivedLevel: derived.level,
+      clusterIndex: 1,
+      freshCriticSampleRate: 0,
+    });
+    const mistaken = resolveCeremonyForRisk({
+      derivedLevel: derived,
+      clusterIndex: 1,
+      freshCriticSampleRate: 0,
+    });
+
+    // Assert — the two disagree, which is what makes the documented shape
+    // load-bearing rather than decorative.
+    assert.equal(
+      documented.mode,
+      'inline',
+      'a `low` level with sampling off must resolve inline — otherwise the digest is documenting a composition that never buys the cheap path',
+    );
+    assert.equal(
+      mistaken.mode,
+      'fresh',
+      'passing the { level, classes } object as derivedLevel must hit the null fail-safe; if this ever resolves inline the fail-safe has inverted',
+    );
+    assert.match(
+      mistaken.reason,
+      /underivable/,
+      'the fail-safe must say the level was underivable — that string is the only evidence a deliverer has that it paid for a fresh critic by mis-shaping the call',
+    );
+    assert.notEqual(
+      mistaken.mode,
+      documented.mode,
+      'object-for-string must be observably different from the documented call, or § 3 stating the shape guards nothing',
     );
   });
 });


### PR DESCRIPTION
Closes #4904

_Auto-opened by `/deliver`._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and workflow test changes only; no runtime orchestration or delivery logic is modified.
> 
> **Overview**
> **`deliver-digest.md` §3** now documents the real call contract for change-set ceremony routing: `deriveChangeLevel({ changedFiles })` returns **`{ level, classes }`**, and `resolveCeremonyForRisk` must receive **`derivedLevel` as the level string**—not the whole object. The section adds a runnable `node -e` snippet that composes `computeChangeSet`, both routing helpers, and JSON output, and explains that both APIs are **total (never throw)**, so mis-shaped arguments silently hit the **`null` fail-safe** (extra fresh critics) instead of errors.
> 
> **`deliver-digest.test.js`** extends digest coverage checks for those argument/return tokens and adds **#4904 execution tests** that call the documented composition against real modules: correct shapes yield a concrete mode and `verdictOwner`, and passing the `{ level, classes }` object as `derivedLevel` must route **`fresh`** with an **underivable** reason while the string form stays **`inline`** on pinned `low` risk.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 35387bc7576024694d53568a2d04864832449f3c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->