### PR TITLE
fix: retune the advisory Spec word budget to 350 and repair the soft-finding report channel (#4907)

### DIFF
--- a/.agents/scripts/lib/orchestration/plan-context.js
+++ b/.agents/scripts/lib/orchestration/plan-context.js
@@ -229,7 +229,8 @@ export function renderStoriesTemplate({ complexitySignals = null } = {}) {
           'codes, security invariants, and load-bearing constraints with ' +
           'their why. Implementation choices belong to the deliverer unless ' +
           'load-bearing. No per-file behavior paragraphs, no current-state ' +
-          'narration. Keep it under ~250 words (soft advisory budget). ' +
+          'narration. Aim for ~250 words; an advisory warning fires past 350, ' +
+          'and it never fails the persist. ' +
           'Delete this field when acceptance[] carries the whole contract.',
         changes: buildTemplateChanges(complexitySignals),
         non_goals: [],

--- a/.agents/scripts/lib/orchestration/plan-persist/fan-out-gate.js
+++ b/.agents/scripts/lib/orchestration/plan-persist/fan-out-gate.js
@@ -7,6 +7,7 @@
 
 import { Logger } from '../../Logger.js';
 import {
+  CONFLICT_KINDS,
   renderFanOutEvidence,
   renderFanOutRemedy,
   renderHardConflictError,
@@ -54,6 +55,15 @@ export function enforceFanOutGate(
 }
 
 /**
+ * Report every soft finding the validator produced, each under its own kind.
+ *
+ * Only the {@link CONFLICT_KINDS} are cross-Story conflicts. The advisory
+ * kinds — `spec-word-budget` and the sizing findings — are single-Story
+ * nudges, and announcing them as conflicts overstated them and taught readers
+ * to discount the whole channel (Story #4907). `fan-out-warning` is excluded
+ * throughout: {@link enforceFanOutGate} owns it and has already either thrown
+ * or logged the override.
+ *
  * @param {object[]} findings
  * @param {string} [tag]
  */
@@ -62,10 +72,26 @@ export function surfaceSoftConflictFindings(findings, tag = 'plan-persist') {
     (f) => f?.severity === 'soft' && f?.kind !== 'fan-out-warning',
   );
   if (soft.length === 0) return;
-  Logger.warn(
-    `[${tag}] ${soft.length} soft cross-Story conflict finding(s) — review before approving the plan:`,
-  );
-  for (const finding of soft) {
-    Logger.warn(`[${tag}] soft conflict: ${renderHardConflictError(finding)}`);
+  const conflicts = soft.filter((f) => CONFLICT_KINDS.has(f?.kind));
+  const advisories = soft.filter((f) => !CONFLICT_KINDS.has(f?.kind));
+  if (conflicts.length > 0) {
+    Logger.warn(
+      `[${tag}] ${conflicts.length} soft cross-Story conflict finding(s) — review before approving the plan:`,
+    );
+    for (const finding of conflicts) {
+      Logger.warn(
+        `[${tag}] soft conflict: ${renderHardConflictError(finding)}`,
+      );
+    }
+  }
+  if (advisories.length > 0) {
+    Logger.warn(
+      `[${tag}] ${advisories.length} advisory finding(s) — the persist proceeds:`,
+    );
+    for (const finding of advisories) {
+      Logger.warn(
+        `[${tag}] advisory (${finding.kind}): ${renderHardConflictError(finding)}`,
+      );
+    }
   }
 }

--- a/.agents/scripts/lib/orchestration/spec-budget.js
+++ b/.agents/scripts/lib/orchestration/spec-budget.js
@@ -9,13 +9,24 @@
 import { parse as parseStoryBody } from '../story-body/story-body.js';
 
 /**
- * Soft advisory word budget for a Story's inline `## Spec` (Story #4723).
- * ~250 words is the #4707 contract-level-prose target: interfaces,
- * invariants, and load-bearing constraints — not route-by-route behavior
- * narration. Distinct from the hard ~1500-token fail-closed ceiling in
+ * Warn threshold (words) for a Story's inline `## Spec` (Story #4723,
+ * retuned by Story #4907). The budget carries **two distinct numbers**, and
+ * both belong in any surface that documents it:
+ *
+ * - **~250 words — the authoring target.** The #4707 contract-level-prose
+ *   aim: interfaces, invariants, and load-bearing constraints, not
+ *   route-by-route behavior narration. It lives in the story-author template
+ *   placeholder (`plan-context.js`), which is what an author actually reads.
+ * - **350 words — this warn threshold.** Deliberately slack against the
+ *   target so the warning marks a real outlier rather than ordinary
+ *   authoring variance. Measured over the 45 most recent Stories carrying a
+ *   Spec, a 250-word threshold fired on 22% of *accepted* work (median 233,
+ *   p75 249) — a warning that common trains its readers to ignore it.
+ *
+ * Distinct again from the hard ~1500-token fail-closed ceiling in
  * `spec-spill.js`: this budget only warns; it never fails the persist.
  */
-export const SPEC_SOFT_WORD_BUDGET = 250;
+export const SPEC_SOFT_WORD_BUDGET = 350;
 
 /**
  * Resolve a Story's Spec prose across both authoring shapes: the canonical

--- a/.agents/scripts/lib/orchestration/ticket-validator-conflicts.js
+++ b/.agents/scripts/lib/orchestration/ticket-validator-conflicts.js
@@ -817,6 +817,28 @@ export function renderFanOutRemedy(finding) {
 }
 
 /**
+ * The finding kinds that are genuinely **cross-Story conflicts** — the SSOT
+ * for that question (Story #4907).
+ *
+ * Two readers need it and must not disagree: the validator, which renders
+ * these through {@link renderHardConflictError} when policy upgrades them to
+ * `errors[]`, and the persist soft-finding surface, which announces a
+ * conflict as a conflict and every other soft kind (`spec-word-budget`,
+ * `merge-candidate`, `unanchored-constant`, `missing-reason-to-exist`) as the
+ * advisory it is. A second copy of this list is how the two drift back apart,
+ * so it is defined exactly once and imported.
+ */
+export const CONFLICT_KINDS = Object.freeze(
+  new Set([
+    'shared-editor',
+    'implicit-cross-story-dep',
+    'cross-cutting-registries',
+    'fan-out-warning',
+    'missing-bdd-scaffold',
+  ]),
+);
+
+/**
  * Render a `'hard'`-severity conflict finding as a human-readable error
  * message. Used by the validator when policy flags upgrade a finding to
  * the AC-visible `errors[]` channel.

--- a/.agents/scripts/lib/orchestration/ticket-validator.js
+++ b/.agents/scripts/lib/orchestration/ticket-validator.js
@@ -10,6 +10,7 @@ import {
   parseStoryBodyOrThrow,
 } from './story-body-gate.js';
 import {
+  CONFLICT_KINDS,
   computeConflictFindings,
   renderHardConflictError,
 } from './ticket-validator-conflicts.js';
@@ -666,25 +667,18 @@ export function validateAndNormalizeTickets(tickets, opts = {}) {
     policy: opts.conflictPolicy,
   });
   // Advisory `## Spec` word-budget pass (Story #4723) — soft findings only,
-  // surfaced as warnings here and via the persist soft-finding channel;
   // never promoted to `errors[]`, so an over-budget Spec cannot fail the
   // persist. Runs after `assertStoryBodiesParse`, so string bodies parse.
+  // This pass computes but does not report: the sole production caller always
+  // runs the persist soft-finding surface, which reports every soft kind
+  // uniformly. Warning here too made `spec-word-budget` the only kind logged
+  // twice per run (Story #4907).
   const specBudgetFindings = computeSpecBudgetFindings({ stories });
-  for (const finding of specBudgetFindings) {
-    Logger.warn(`[ticket-validator] spec-word-budget: ${finding.message}`);
-  }
   const findings = [
     ...sizingFindings,
     ...conflictFindings,
     ...specBudgetFindings,
   ];
-  const CONFLICT_KINDS = new Set([
-    'shared-editor',
-    'implicit-cross-story-dep',
-    'cross-cutting-registries',
-    'fan-out-warning',
-    'missing-bdd-scaffold',
-  ]);
   const errors = findings
     .filter((f) => f.severity === 'hard')
     .map((f) =>

--- a/.agents/workflows/helpers/plan-reference.md
+++ b/.agents/workflows/helpers/plan-reference.md
@@ -215,12 +215,14 @@ ceilings on `STORY_SHAPE_CEILINGS` in
   against the repo before overriding one (authoring `creates` for a file
   that exists at base is a validator rejection). The persist gates stay
   authoritative: they probe the base branch ref, not the working tree.
-- **Keep `## Spec` near contract-level prose.** Persist emits an
-  **advisory** warning past ~250 words (`SPEC_SOFT_WORD_BUDGET`) — it never
-  fails the persist, but it is the nudge toward a contract-level
+- **Keep `## Spec` near contract-level prose.** **Aim for ~250 words; an
+  advisory warning fires past 350** (`SPEC_SOFT_WORD_BUDGET`). Two numbers,
+  two jobs: ~250 is the authoring target — the nudge toward a contract-level
   Spec (interfaces, invariants, load-bearing constraints; no per-file
-  behavior narration). The hard fail-closed ceiling (~1500 tokens,
-  `spec-spill.js`) is unchanged.
+  behavior narration) — while 350 is the slacker threshold at which persist
+  actually warns, so the warning marks a real outlier instead of ordinary
+  variance. Neither fails the persist. The hard fail-closed ceiling
+  (~1500 tokens, `spec-spill.js`) is unchanged.
 
 A faithfully-filled skeleton — placeholders replaced, pre-resolved entries
 kept, tags valid — passes the persist ticket validators with no

--- a/tests/lib/orchestration/fan-out-gate.test.js
+++ b/tests/lib/orchestration/fan-out-gate.test.js
@@ -1,0 +1,168 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { Logger } from '../../../.agents/scripts/lib/Logger.js';
+import {
+  enforceFanOutGate,
+  surfaceSoftConflictFindings,
+} from '../../../.agents/scripts/lib/orchestration/plan-persist/fan-out-gate.js';
+
+/**
+ * plan-persist's soft-finding surface (Story #4907).
+ *
+ * `surfaceSoftConflictFindings` is the one place an operator reads the
+ * validator's soft findings, and it used to announce every one of them as a
+ * "soft cross-Story conflict". Only the conflict kinds are one: the advisory
+ * kinds (`spec-word-budget` and the sizing findings) are single-Story nudges,
+ * and overstating them taught readers to discount the whole channel.
+ */
+
+function conflictFinding(overrides = {}) {
+  return {
+    kind: 'shared-editor',
+    severity: 'soft',
+    path: 'src/shared.js',
+    storySlugs: ['story-a', 'story-b'],
+    ...overrides,
+  };
+}
+
+function specBudgetFinding(overrides = {}) {
+  return {
+    kind: 'spec-word-budget',
+    severity: 'soft',
+    ticketSlug: 'wordy-story',
+    words: 401,
+    budget: 350,
+    message: 'Story "wordy-story" ## Spec is ~401 words (soft budget 350).',
+    ...overrides,
+  };
+}
+
+function warnLines(mock) {
+  return mock.mock.calls.map((c) => String(c.arguments[0]));
+}
+
+describe('surfaceSoftConflictFindings: labels each soft finding by its kind (Story #4907)', () => {
+  it('announces a genuine cross-Story conflict as a conflict', (t) => {
+    const warn = t.mock.method(Logger, 'warn', () => {});
+
+    surfaceSoftConflictFindings([conflictFinding()]);
+
+    const lines = warnLines(warn);
+    assert.ok(
+      lines.some((l) => /soft cross-Story conflict finding\(s\)/.test(l)),
+      'expected the conflict header',
+    );
+    assert.ok(
+      lines.some((l) => /soft conflict: Shared-editor conflict/.test(l)),
+      'expected the conflict to render through renderHardConflictError',
+    );
+  });
+
+  it('never calls an advisory spec-word-budget finding a cross-Story conflict', (t) => {
+    const warn = t.mock.method(Logger, 'warn', () => {});
+
+    surfaceSoftConflictFindings([specBudgetFinding()]);
+
+    const lines = warnLines(warn);
+    assert.equal(
+      lines.some((l) => /conflict/i.test(l)),
+      false,
+      'a single-Story Spec-length nudge is not a cross-Story conflict',
+    );
+    assert.ok(
+      lines.some((l) => /advisory \(spec-word-budget\)/.test(l)),
+      'expected the finding reported under its own kind',
+    );
+  });
+
+  it('treats the sizing findings as advisories, not conflicts', (t) => {
+    const warn = t.mock.method(Logger, 'warn', () => {});
+
+    surfaceSoftConflictFindings([
+      {
+        kind: 'merge-candidate',
+        severity: 'soft',
+        ticketSlug: 'thin-slice',
+        message: 'Story "thin-slice" is a thin dependent slice.',
+      },
+    ]);
+
+    const lines = warnLines(warn);
+    assert.equal(
+      lines.some((l) => /conflict/i.test(l)),
+      false,
+    );
+    assert.ok(lines.some((l) => /advisory \(merge-candidate\)/.test(l)));
+  });
+
+  it('separates a mixed set so each finding lands under the right heading', (t) => {
+    const warn = t.mock.method(Logger, 'warn', () => {});
+
+    surfaceSoftConflictFindings([conflictFinding(), specBudgetFinding()]);
+
+    const lines = warnLines(warn);
+    assert.ok(
+      lines.some((l) => /1 soft cross-Story conflict finding\(s\)/.test(l)),
+      'the conflict count must not absorb the advisory',
+    );
+    assert.ok(
+      lines.some((l) => /1 advisory finding\(s\)/.test(l)),
+      'the advisory count must not absorb the conflict',
+    );
+  });
+
+  it('leaves fan-out warnings to the gate that owns them', (t) => {
+    const warn = t.mock.method(Logger, 'warn', () => {});
+
+    surfaceSoftConflictFindings([
+      { kind: 'fan-out-warning', severity: 'soft', storySlug: 's', path: 'p' },
+    ]);
+
+    assert.equal(warn.mock.calls.length, 0);
+  });
+
+  it('stays silent when there is nothing soft to report', (t) => {
+    const warn = t.mock.method(Logger, 'warn', () => {});
+
+    surfaceSoftConflictFindings([{ kind: 'shared-editor', severity: 'hard' }]);
+    surfaceSoftConflictFindings([]);
+    surfaceSoftConflictFindings(undefined);
+
+    assert.equal(warn.mock.calls.length, 0);
+  });
+});
+
+describe('enforceFanOutGate: fails closed on large-fan-out deletions', () => {
+  const fanOut = {
+    kind: 'fan-out-warning',
+    severity: 'soft',
+    storySlug: 'delete-legacy',
+    path: 'lib/legacy.js',
+    callSiteCount: 12,
+    threshold: 5,
+  };
+
+  it('throws naming the Story, the path and the importer count', () => {
+    assert.throws(
+      () => enforceFanOutGate([fanOut], false),
+      /delete-legacy[\s\S]*lib\/legacy\.js[\s\S]*12 importer/,
+    );
+  });
+
+  it('warns and proceeds under the operator override', (t) => {
+    const warn = t.mock.method(Logger, 'warn', () => {});
+
+    assert.doesNotThrow(() => enforceFanOutGate([fanOut], true));
+
+    assert.ok(
+      warnLines(warn).some((l) => /--allow-large-fan-out/.test(l)),
+      'the override must stay visible in the log',
+    );
+  });
+
+  it('no-ops when no fan-out finding is present', () => {
+    assert.doesNotThrow(() => enforceFanOutGate([specBudgetFinding()], false));
+    assert.doesNotThrow(() => enforceFanOutGate([], false));
+  });
+});

--- a/tests/lib/orchestration/ticket-validator.test.js
+++ b/tests/lib/orchestration/ticket-validator.test.js
@@ -1,5 +1,6 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
+import { Logger } from '../../../.agents/scripts/lib/Logger.js';
 import { SPEC_SOFT_WORD_BUDGET } from '../../../.agents/scripts/lib/orchestration/spec-budget.js';
 import {
   _internal,
@@ -173,5 +174,53 @@ describe('ticket-validator: soft ## Spec word budget (Story #4723)', () => {
     const withoutSpec = story('no-spec');
     const validated = validateAndNormalizeTickets([withSpec, withoutSpec]);
     assert.deepEqual(specFindings(validated), []);
+  });
+
+  /**
+   * The threshold is retuned to 350 (Story #4907) and pinned by value here.
+   * The tests above reference `SPEC_SOFT_WORD_BUDGET` symbolically, so they
+   * follow the constant wherever it moves and cannot catch a regression in
+   * the number itself. A 300-word Spec is ordinary authoring variance under
+   * the ~250 target and must stay silent; 400 words is the outlier the
+   * warning exists for.
+   */
+  function specOf(words) {
+    return Array.from({ length: words }, (_v, i) => `word${i}`).join(' ');
+  }
+
+  it('is silent at 300 words and fires at 400 — the threshold is 350', () => {
+    const quiet = story('three-hundred');
+    quiet.body.spec = specOf(300);
+    assert.deepEqual(specFindings(validateAndNormalizeTickets([quiet])), []);
+
+    const loud = story('four-hundred');
+    loud.body.spec = specOf(400);
+    const findings = specFindings(validateAndNormalizeTickets([loud]));
+    assert.equal(findings.length, 1);
+    assert.equal(findings[0].budget, 350);
+  });
+
+  /**
+   * `spec-word-budget` was the only finding kind logged twice per run — once
+   * by this pass and again by plan-persist's soft-finding surface. The
+   * validator now computes without reporting, matching how it already treats
+   * the sizing and conflict kinds (Story #4907).
+   */
+  it('computes the finding without warning — reporting belongs to persist', (t) => {
+    const warn = t.mock.method(Logger, 'warn', () => {});
+    const s = story('over-budget-quiet');
+    s.body.spec = overBudgetSpec;
+
+    const validated = validateAndNormalizeTickets([s]);
+
+    assert.equal(specFindings(validated).length, 1);
+    const spoke = warn.mock.calls
+      .map((c) => String(c.arguments[0]))
+      .filter((l) => /spec-word-budget|## Spec is ~/.test(l));
+    assert.deepEqual(
+      spoke,
+      [],
+      'the validator must not warn; persist surfaces it exactly once',
+    );
   });
 });


### PR DESCRIPTION
Closes #4907

_Auto-opened by `/deliver`._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Orchestration logging and advisory thresholds only; persist behavior unchanged except clearer warnings and a higher Spec nudge threshold.
> 
> **Overview**
> Raises the advisory **`## Spec` word warn threshold** from 250 to **350** while keeping **~250** as the authoring target in the story template and `plan-reference.md`, so warnings fire on real outliers instead of ~22% of accepted Stories.
> 
> **Soft-finding reporting** is repaired: a shared **`CONFLICT_KINDS`** set in `ticket-validator-conflicts.js` drives both the validator and plan-persist. **`surfaceSoftConflictFindings`** now logs true cross-Story soft conflicts separately from **advisory** kinds (`spec-word-budget`, sizing nudges); **`fan-out-warning`** stays owned by **`enforceFanOutGate`**. The ticket validator **stops** `Logger.warn` on spec budget—persist surfaces those findings once.
> 
> Tests cover the 300/350/400 boundary, no duplicate spec warnings, and the new conflict vs advisory labels.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4476f51b65e29ad7625420ea2b2ebc0926f5a14e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->