### PR TITLE
feat: baseline hotspot engine: config-driven outlier extraction, clustering, ranking, and gate-surface health signals (#4902)

### DIFF
--- a/.agents/schemas/baselines/audit-baselines-envelope.schema.json
+++ b/.agents/schemas/baselines/audit-baselines-envelope.schema.json
@@ -1,0 +1,215 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://mandrel/.agents/schemas/baselines/audit-baselines-envelope.schema.json",
+  "title": "AuditBaselinesEnvelope",
+  "description": "Evidence envelope emitted by `.agents/scripts/audit-baselines.js` (Story #4902). Unlike its siblings in this directory it does NOT describe a committed baseline — it describes an engine's read-only report ABOUT the baseline surface, so it deliberately does not extend baseline-envelope.schema.json. Four sections: gateSurface (instrument health per kind), hotspots (ranked per-file clusters joining top-N outliers across gates), trend (rollup deltas from each baseline file's git history), and headroom (configured floor vs measured rollup).",
+  "type": "object",
+  "required": [
+    "kind",
+    "schemaVersion",
+    "generatedAt",
+    "cwd",
+    "topN",
+    "configError",
+    "degradations",
+    "gateSurface",
+    "hotspots",
+    "trend",
+    "headroom"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "kind": { "const": "audit-baselines-envelope" },
+    "schemaVersion": { "type": "string", "minLength": 1 },
+    "generatedAt": { "type": "string", "format": "date-time" },
+    "cwd": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Repository root the engine ran against."
+    },
+    "topN": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Per-gate bound on extracted outlier rows. The envelope never embeds a full baseline; crap.json alone is ~650KB of per-method rows."
+    },
+    "configError": {
+      "type": ["string", "null"],
+      "description": "Message from a failed config resolution. Non-null means floors, targetDirs, and ignoreGlobs were unavailable and the engine fell back to default baseline paths."
+    },
+    "degradations": {
+      "type": "object",
+      "description": "Which optional inputs were unavailable. Each degradation collapses its rank multiplier to exactly 1.0 and never changes the exit code.",
+      "required": ["gitHistory", "importGraph", "frictionLedger"],
+      "additionalProperties": false,
+      "properties": {
+        "gitHistory": { "type": "boolean" },
+        "importGraph": { "type": "boolean" },
+        "frictionLedger": { "type": "boolean" }
+      }
+    },
+    "gateSurface": {
+      "type": "array",
+      "description": "One entry per kind across BOTH halves of the surface: the closed delivery.quality.gates kinds and the out-of-band ratchet baselines the CI baselines job owns.",
+      "items": {
+        "type": "object",
+        "required": [
+          "kind",
+          "surface",
+          "baselinePath",
+          "configured",
+          "baselineExists",
+          "stub",
+          "rowCount",
+          "generatedAt",
+          "staleDays",
+          "deadIgnoreGlobs",
+          "parseError"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "kind": { "type": "string", "minLength": 1 },
+          "surface": { "enum": ["gate", "ratchet"] },
+          "baselinePath": { "type": "string", "minLength": 1 },
+          "configured": {
+            "type": "boolean",
+            "description": "A gate block for this kind is present in the resolved config."
+          },
+          "baselineExists": { "type": "boolean" },
+          "stub": {
+            "type": "boolean",
+            "description": "Zero rows AND an all-zero rollup — an instrument that passes every run vacuously. Both halves are required, so a ratchet baseline with nothing to report (e.g. zero import cycles) is never mistaken for a dead instrument."
+          },
+          "rowCount": { "type": "integer", "minimum": 0 },
+          "generatedAt": { "type": ["string", "null"] },
+          "staleDays": {
+            "type": ["integer", "null"],
+            "description": "Whole days since generatedAt. Null when the stamp is absent or unparseable — never a fabricated 0."
+          },
+          "deadIgnoreGlobs": {
+            "type": "array",
+            "description": "Configured ignoreGlobs matching zero files on disk.",
+            "items": { "type": "string" }
+          },
+          "parseError": { "type": ["string", "null"] }
+        }
+      }
+    },
+    "hotspots": {
+      "type": "array",
+      "description": "Per-file clusters, highest rank first. Severity sums across gate memberships, so a file that is an outlier in two gates outranks a single-gate outlier of equal per-gate severity.",
+      "items": {
+        "type": "object",
+        "required": [
+          "path",
+          "gates",
+          "gateKinds",
+          "gateCount",
+          "severityWeight",
+          "churnWeight",
+          "centralityWeight",
+          "frictionWeight",
+          "rank"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "path": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Cluster key. A repository file path for every kind except lighthouse (route) and bundle-size (bundle name)."
+          },
+          "gates": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+              "type": "object",
+              "required": [
+                "kind",
+                "metric",
+                "value",
+                "rowCount",
+                "severityWeight"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "kind": { "type": "string", "minLength": 1 },
+                "metric": { "type": "string", "minLength": 1 },
+                "value": { "type": "number" },
+                "rowCount": { "type": "integer", "minimum": 1 },
+                "severityWeight": { "type": "number", "minimum": 0 }
+              }
+            }
+          },
+          "gateKinds": { "type": "array", "items": { "type": "string" } },
+          "gateCount": { "type": "integer", "minimum": 1 },
+          "severityWeight": { "type": "number", "minimum": 0 },
+          "churnWeight": { "type": "number", "minimum": 1 },
+          "centralityWeight": { "type": "number", "minimum": 1 },
+          "frictionWeight": { "type": "number", "minimum": 1 },
+          "rank": { "type": "number", "minimum": 0 }
+        }
+      }
+    },
+    "trend": {
+      "type": "array",
+      "description": "Newest-vs-previous rollup deltas parsed from each baseline file's git history. Empty when no history is readable.",
+      "items": {
+        "type": "object",
+        "required": [
+          "kind",
+          "baselinePath",
+          "sampleCount",
+          "from",
+          "to",
+          "deltas"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "kind": { "type": "string", "minLength": 1 },
+          "baselinePath": { "type": "string", "minLength": 1 },
+          "sampleCount": { "type": "integer", "minimum": 2 },
+          "from": { "$ref": "#/definitions/commitRef" },
+          "to": { "$ref": "#/definitions/commitRef" },
+          "deltas": {
+            "type": "object",
+            "additionalProperties": { "type": "number" }
+          }
+        }
+      }
+    },
+    "headroom": {
+      "type": "array",
+      "description": "Configured floor vs measured rollup per axis. Positive headroom is slack the floor could be tightened into; negative means the floor is already breached.",
+      "items": {
+        "type": "object",
+        "required": [
+          "kind",
+          "axis",
+          "floor",
+          "measured",
+          "direction",
+          "headroom"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "kind": { "type": "string", "minLength": 1 },
+          "axis": { "type": "string", "minLength": 1 },
+          "floor": { "type": "number" },
+          "measured": { "type": ["number", "null"] },
+          "direction": { "enum": ["gte", "lte"] },
+          "headroom": { "type": ["number", "null"] }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "commitRef": {
+      "type": "object",
+      "required": ["sha", "committedAt"],
+      "additionalProperties": false,
+      "properties": {
+        "sha": { "type": "string", "minLength": 7 },
+        "committedAt": { "type": "string", "minLength": 1 }
+      }
+    }
+  }
+}

--- a/.agents/scripts/audit-baselines.js
+++ b/.agents/scripts/audit-baselines.js
@@ -1,0 +1,136 @@
+#!/usr/bin/env node
+
+/**
+ * CLI: baseline hotspot engine for the `/audit-baselines` lens (Story #4902).
+ *
+ * Turns the committed `baselines/` folder into ranked hotspot clusters,
+ * gate-surface health signals, trend deltas, and floor-tightening headroom —
+ * the deterministic evidence half of a baseline review, so the lens spends
+ * its judgment on findings instead of re-deriving the numbers by hand.
+ *
+ * Read-only by contract: nothing under `baselines/` is written, and no test,
+ * coverage, or mutation suite is run. The only file this process creates is
+ * the envelope at `--out`.
+ *
+ * Exit 0 whenever evidence was assembled — findings are evidence, not a gate.
+ * A missing git history, absent friction ledger, or unresolvable import graph
+ * are reported as degradations and still exit 0. Only an unwritable `--out`
+ * (or a missing one) is a failure.
+ *
+ * Usage:
+ *   node .agents/scripts/audit-baselines.js --out temp/audit-baselines/envelope.json
+ */
+
+// Fail-fast if the framework's runtime deps are not installed — must be the
+// first import so the check runs before any third-party-importing sibling
+// module is evaluated (Story #3432).
+import './lib/runtime-deps/ensure-installed.js';
+import fs from 'node:fs';
+import path from 'node:path';
+import process from 'node:process';
+import {
+  DEFAULT_HOTSPOT_LIMIT,
+  runEngine,
+  summarize,
+} from './lib/audit-baselines/engine.js';
+import { DEFAULT_TOP_N } from './lib/audit-baselines/outliers.js';
+import { buildBaselineSchemaAjv } from './lib/baseline-schema-registry.js';
+import { defineFlags } from './lib/cli-args.js';
+import { runAsCli } from './lib/cli-utils.js';
+
+const ENVELOPE_SCHEMA_FILE = 'audit-baselines-envelope.schema.json';
+
+const FLAG_SPEC = {
+  out: { type: 'string' },
+  cwd: { type: 'string' },
+  'top-n': { type: 'integer' },
+  'hotspot-limit': { type: 'integer' },
+  'trend-depth': { type: 'integer' },
+};
+
+/**
+ * Validate the envelope against its shipped schema through the shared
+ * baseline schema registry. Throws with the AJV error list on mismatch —
+ * a malformed envelope is an engine bug, not evidence.
+ *
+ * @param {object} envelope
+ * @returns {void}
+ */
+export function assertEnvelope(envelope) {
+  const validate = buildBaselineSchemaAjv().getSchema(ENVELOPE_SCHEMA_FILE);
+  if (!validate) {
+    throw new Error(
+      `[audit-baselines] ${ENVELOPE_SCHEMA_FILE} is not registered in the baseline schema registry`,
+    );
+  }
+  if (validate(envelope)) return;
+  const detail = (validate.errors ?? [])
+    .map((e) => `${e.instancePath || '/'} ${e.message}`)
+    .join('; ');
+  throw new Error(
+    `[audit-baselines] envelope failed schema validation: ${detail}`,
+  );
+}
+
+/**
+ * Assemble the envelope, validate it, write it, and return the stdout
+ * summary. Exported so tests drive the whole pipeline without spawning.
+ *
+ * @param {{ argv?: string[], cwd?: string, stdout?: { write: (s: string) => void } }} [opts]
+ * @returns {Promise<number>} exit code
+ */
+export async function runCli({
+  argv = process.argv.slice(2),
+  cwd = process.cwd(),
+  stdout = process.stdout,
+} = {}) {
+  const { values } = defineFlags(FLAG_SPEC, argv);
+  if (!values.out) {
+    throw new Error('[audit-baselines] --out <path> is required');
+  }
+  const repoRoot = path.resolve(values.cwd ?? cwd);
+  const outPath = path.resolve(repoRoot, values.out);
+
+  const envelope = runEngine({
+    cwd: repoRoot,
+    topN: values.topN ?? DEFAULT_TOP_N,
+    hotspotLimit: values.hotspotLimit ?? DEFAULT_HOTSPOT_LIMIT,
+    trendDepth: values.trendDepth ?? 5,
+  });
+  assertEnvelope(envelope);
+
+  fs.mkdirSync(path.dirname(outPath), { recursive: true });
+  fs.writeFileSync(outPath, `${JSON.stringify(envelope, null, 2)}\n`, 'utf8');
+
+  stdout.write(`${JSON.stringify(summarize(envelope, outPath), null, 2)}\n`);
+  return 0;
+}
+
+runAsCli(import.meta.url, async () => runCli(), {
+  source: 'audit-baselines',
+  propagateExitCode: true,
+  errorPrefix: '[audit-baselines] ❌ Fatal error',
+  usage: {
+    invocation:
+      'node .agents/scripts/audit-baselines.js --out <path> [--cwd <dir>] [--top-n <n>] [--hotspot-limit <n>] [--trend-depth <n>]',
+    summary:
+      'Read-only baseline hotspot engine: extract bounded per-gate outliers, cluster them per file, rank by severity x churn x import in-degree x friction, and report gate-surface health, trend deltas, and floor headroom.',
+    flags: [
+      ['--out <path>', 'Write the JSON envelope here (required).'],
+      ['--cwd <dir>', 'Repository root to analyse (default: cwd).'],
+      [
+        '--top-n <n>',
+        `Outlier rows extracted per gate (default: ${DEFAULT_TOP_N}).`,
+      ],
+      [
+        '--hotspot-limit <n>',
+        `Hotspot clusters emitted (default: ${DEFAULT_HOTSPOT_LIMIT}).`,
+      ],
+      ['--trend-depth <n>', 'Baseline commits sampled per kind (default: 5).'],
+    ],
+    notes: [
+      'Never writes under baselines/ and never runs a test, coverage, or mutation suite.',
+      'Exit codes:\n  0  evidence assembled (including every degraded input)\n  1  the envelope could not be built or written',
+    ],
+  },
+});

--- a/.agents/scripts/check-arch-cycles.js
+++ b/.agents/scripts/check-arch-cycles.js
@@ -37,16 +37,19 @@ import fs from 'node:fs';
 import path from 'node:path';
 import process from 'node:process';
 import { runAsCli } from './lib/cli-utils.js';
+import {
+  buildGraph,
+  collectJsFiles,
+  DEFAULT_ROOTS,
+  parseRelativeImports,
+} from './lib/import-graph.js';
 
-/**
- * Default scan roots making up the project's distributed surface — the
- * directories published to npm via `package.json` `files[]`. Resolving
- * them into one graph (relativized against the repo root) means a cycle
- * crossing two roots is visible to `findCycles`.
- *
- * @type {string[]}
- */
-export const DEFAULT_ROOTS = [path.join('.agents', 'scripts'), 'bin', 'lib'];
+// The import-graph builder itself lives in `lib/import-graph.js` (Story
+// #4902) so `audit-baselines.js` can rank hotspots by import in-degree
+// against the same graph this ratchet detects cycles in. Re-exported here
+// because this module's named exports are its unit-test surface and its
+// documented contract; the behaviour is unchanged by the move.
+export { buildGraph, collectJsFiles, DEFAULT_ROOTS, parseRelativeImports };
 
 /**
  * Parse argv for `--baseline <path>`, `--root <path>`, and `--json`.
@@ -78,90 +81,6 @@ export function parseArgv(argv = []) {
     }
   }
   return { baselinePath, rootPath, json };
-}
-
-/**
- * Recursively collect `.js` files under `rootDir`, skipping
- * `node_modules`. Returns absolute paths, sorted for determinism.
- *
- * @param {string} rootDir
- * @returns {string[]}
- */
-export function collectJsFiles(rootDir) {
-  const out = [];
-  const walk = (dir) => {
-    let entries;
-    try {
-      entries = fs.readdirSync(dir, { withFileTypes: true });
-    } catch {
-      return;
-    }
-    for (const entry of entries) {
-      if (entry.name === 'node_modules') continue;
-      const full = path.join(dir, entry.name);
-      if (entry.isDirectory()) {
-        walk(full);
-      } else if (entry.isFile() && entry.name.endsWith('.js')) {
-        out.push(full);
-      }
-    }
-  };
-  walk(rootDir);
-  return out.sort();
-}
-
-const IMPORT_RE = /from\s+['"](\.\.?\/[^'"]+\.js)['"]/g;
-
-/**
- * Pure helper: extract relative static-import specifiers from source text.
- *
- * @param {string} source
- * @returns {string[]}
- */
-export function parseRelativeImports(source) {
-  const specs = [];
-  for (const m of source.matchAll(IMPORT_RE)) {
-    specs.push(m[1]);
-  }
-  return specs;
-}
-
-/**
- * Build a directed import graph over the given files. Node identity is the
- * file path relative to `rootDir`, posix-separated, so the graph (and any
- * cycles found in it) serializes identically across platforms. Edges that
- * resolve outside the scanned file set are dropped.
- *
- * @param {string[]} files absolute paths
- * @param {string} rootDir
- * @param {{ readFile?: (p: string) => string }} [opts]
- * @returns {Map<string, string[]>}
- */
-export function buildGraph(files, rootDir, { readFile } = {}) {
-  const read = readFile ?? ((p) => fs.readFileSync(p, 'utf-8'));
-  const toId = (abs) => path.relative(rootDir, abs).split(path.sep).join('/');
-  const idSet = new Set(files.map(toId));
-  const graph = new Map();
-  for (const file of files) {
-    const id = toId(file);
-    let source;
-    try {
-      source = read(file);
-    } catch {
-      graph.set(id, []);
-      continue;
-    }
-    const edges = [];
-    for (const spec of parseRelativeImports(source)) {
-      const target = path
-        .relative(rootDir, path.resolve(path.dirname(file), spec))
-        .split(path.sep)
-        .join('/');
-      if (idSet.has(target) && target !== id) edges.push(target);
-    }
-    graph.set(id, [...new Set(edges)].sort());
-  }
-  return graph;
 }
 
 /**

--- a/.agents/scripts/lib/audit-baselines/__tests__/degradation.test.js
+++ b/.agents/scripts/lib/audit-baselines/__tests__/degradation.test.js
@@ -1,0 +1,142 @@
+/**
+ * degradation.test.js — the three optional inputs, all absent at once
+ * (Story #4902).
+ *
+ * Git history, the friction ledger, and the import graph are all things a
+ * consumer repository may simply not have — a shallow CI clone, a fresh
+ * checkout, sources outside the scanned roots. The engine's contract is that
+ * each collapses to a neutral 1.0 multiplier, `trend[]` goes empty, and the
+ * run still exits 0 with a schema-valid envelope. A hard failure here would
+ * make the lens unusable in exactly the repositories that most need it.
+ */
+
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { before, describe, it } from 'node:test';
+import { runCli } from '../../../audit-baselines.js';
+import { makeTempDir } from '../../test-temp.js';
+import { readChurn, readFriction } from '../weights.js';
+
+/** The neutral multiplier every degraded weight must collapse to. */
+const NEUTRAL_WEIGHT = 1;
+
+/**
+ * A repository-shaped fixture with baselines but nothing else: no `.git`, no
+ * `temp/` ledger, and none of the roots the import graph scans.
+ *
+ * @returns {string} fixture root
+ */
+function writeBareFixture() {
+  const root = makeTempDir('audit-baselines-degraded-');
+  fs.mkdirSync(path.join(root, 'baselines'), { recursive: true });
+  fs.writeFileSync(
+    path.join(root, 'baselines', 'crap.json'),
+    JSON.stringify({
+      kernelVersion: '1.0.0',
+      generatedAt: '2026-01-01T00:00:00.000Z',
+      rollup: { '*': { p50: 2, p95: 20, max: 30, methodsAbove20: 2 } },
+      rows: [
+        { path: 'src/a.js', method: 'x', startLine: 1, crap: 30 },
+        { path: 'src/b.js', method: 'y', startLine: 1, crap: 1 },
+      ],
+    }),
+  );
+  return root;
+}
+
+describe('engine over a repo with no git, no friction ledger, no import graph', () => {
+  const root = writeBareFixture();
+  const outPath = path.join(makeTempDir('audit-baselines-out-'), 'env.json');
+  let exitCode;
+  let envelope;
+
+  before(async () => {
+    exitCode = await runCli({
+      argv: ['--out', outPath, '--cwd', root],
+      stdout: { write: () => {} },
+    });
+    envelope = JSON.parse(fs.readFileSync(outPath, 'utf8'));
+  });
+
+  it('exits 0', () => {
+    assert.equal(exitCode, 0);
+  });
+
+  it('reports all three inputs as degraded', () => {
+    assert.deepEqual(envelope.degradations, {
+      gitHistory: true,
+      importGraph: true,
+      frictionLedger: true,
+    });
+  });
+
+  it('emits an empty trend[]', () => {
+    assert.deepEqual(envelope.trend, []);
+  });
+
+  it('gives every hotspot rank weights of exactly 1.0', () => {
+    assert.ok(envelope.hotspots.length > 0, 'fixture produced no hotspots');
+    for (const hotspot of envelope.hotspots) {
+      assert.equal(hotspot.churnWeight, NEUTRAL_WEIGHT, hotspot.path);
+      assert.equal(hotspot.centralityWeight, NEUTRAL_WEIGHT, hotspot.path);
+      assert.equal(hotspot.frictionWeight, NEUTRAL_WEIGHT, hotspot.path);
+      assert.equal(hotspot.rank, hotspot.severityWeight, hotspot.path);
+    }
+  });
+
+  it('still reports the missing halves of the gate surface', () => {
+    const missing = envelope.gateSurface
+      .filter((entry) => !entry.baselineExists)
+      .map((entry) => entry.kind);
+    assert.ok(missing.includes('lint'));
+    assert.ok(missing.includes('arch-cycles'));
+    // A missing baseline is not a stub — there is no instrument to call dead.
+    for (const entry of envelope.gateSurface) {
+      if (!entry.baselineExists) assert.equal(entry.stub, false);
+    }
+  });
+});
+
+describe('degradation probes in isolation', () => {
+  it('readChurn degrades when git cannot answer', () => {
+    const { counts, degraded } = readChurn({
+      cwd: makeTempDir('audit-baselines-nogit-'),
+    });
+    assert.equal(degraded, true);
+    assert.equal(counts.size, 0);
+  });
+
+  it('readFriction degrades when no signals stream exists', () => {
+    const { degraded, streams } = readFriction({
+      tempRootAbs: path.join(makeTempDir('audit-baselines-nosig-'), 'temp'),
+    });
+    assert.equal(degraded, true);
+    assert.equal(streams, 0);
+  });
+
+  it('readFriction counts blamed files when a stream is present', () => {
+    const tempRoot = makeTempDir('audit-baselines-sig-');
+    const dir = path.join(tempRoot, 'standalone', 'stories', 'story-1');
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(
+      path.join(dir, 'signals.ndjson'),
+      [
+        JSON.stringify({
+          kind: 'friction',
+          ts: '2026-01-01T00:00:00.000Z',
+          details: { errorPreview: 'failed in lib/target.js' },
+        }),
+        'not json at all',
+        JSON.stringify({ kind: 'trace', ts: '2026-01-01T00:00:00.000Z' }),
+        '',
+      ].join('\n'),
+    );
+    const { counts, degraded, streams } = readFriction({
+      tempRootAbs: tempRoot,
+    });
+    assert.equal(degraded, false);
+    assert.equal(streams, 1);
+    assert.equal(counts.get('lib/target.js'), 1);
+  });
+});

--- a/.agents/scripts/lib/audit-baselines/__tests__/gate-surface.test.js
+++ b/.agents/scripts/lib/audit-baselines/__tests__/gate-surface.test.js
@@ -1,0 +1,220 @@
+/**
+ * gate-surface.test.js — instrument-health reporting across both halves of
+ * the baseline surface (Story #4902).
+ *
+ * The load-bearing case is the **stub instrument**: a baseline committed with
+ * no rows and an all-zero rollup passes its gate on every run without
+ * measuring anything, and reads as green from the exit code. This suite pins
+ * that four of Mandrel's own gates are exactly that today, and — the
+ * asymmetry that makes the signal usable — that a ratchet baseline with
+ * nothing to report (zero import cycles, the success state) is NOT flagged.
+ *
+ * Everything is driven through `buildGateSurface`, the module's only export:
+ * the stub rule, the glob check, and the staleness clock are internals, and
+ * pinning them through the composed surface is what a consumer of this
+ * envelope actually depends on.
+ */
+
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { describe, it } from 'node:test';
+import { fileURLToPath } from 'node:url';
+import { getQuality, resolveConfig } from '../../config-resolver.js';
+import { makeTempDir } from '../../test-temp.js';
+import { buildGateSurface } from '../gate-surface.js';
+import { GATE_KINDS } from '../kinds.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+// __tests__ → audit-baselines → lib → scripts → .agents → repo root
+const REPO_ROOT = path.resolve(__dirname, '..', '..', '..', '..', '..');
+
+/** The out-of-band ratchets the engine walks alongside the gate kinds. */
+const EXPECTED_RATCHETS = [
+  'arch-cycles',
+  'context-budget',
+  'dead-exports',
+  'dead-exports-production',
+];
+
+/**
+ * Build a fixture repo root, writing each `[relPath, body]` pair.
+ *
+ * @param {Array<[string, object | string]>} files
+ * @returns {string}
+ */
+function makeFixture(files) {
+  const root = makeTempDir('audit-baselines-surface-');
+  for (const [rel, body] of files) {
+    const abs = path.join(root, rel);
+    fs.mkdirSync(path.dirname(abs), { recursive: true });
+    fs.writeFileSync(
+      abs,
+      typeof body === 'string' ? body : JSON.stringify(body, null, 2),
+    );
+  }
+  return root;
+}
+
+/**
+ * Index a fixture's surface entries by kind.
+ *
+ * @param {string} root
+ * @param {object} quality
+ * @returns {Map<string, object>}
+ */
+function surfaceOf(root, quality = { gates: {} }) {
+  const { entries } = buildGateSurface({ cwd: root, quality });
+  return new Map(entries.map((e) => [e.kind, e]));
+}
+
+describe('stub-instrument detection', () => {
+  it('flags a baseline with no rows AND an all-zero rollup', () => {
+    const byKind = surfaceOf(
+      makeFixture([
+        [
+          'baselines/lint.json',
+          {
+            kernelVersion: '1.0.0',
+            generatedAt: '2026-01-01T00:00:00.000Z',
+            rollup: { '*': { errorCount: 0, warningCount: 0 } },
+            rows: [],
+          },
+        ],
+      ]),
+    );
+    assert.equal(byKind.get('lint').stub, true);
+    assert.equal(byKind.get('lint').rowCount, 0);
+    assert.equal(byKind.get('lint').baselineExists, true);
+  });
+
+  it('does not flag a measuring instrument that happens to report zero rows', () => {
+    // arch-cycles ships `cycles: []` and no rollup at all. Zero cycles is the
+    // ratchet passing, not the instrument being dead.
+    const byKind = surfaceOf(
+      makeFixture([
+        [
+          'baselines/arch-cycles.json',
+          { generatedAt: '2026-01-01T00:00:00.000Z', cycles: [] },
+        ],
+      ]),
+    );
+    assert.equal(byKind.get('arch-cycles').baselineExists, true);
+    assert.equal(byKind.get('arch-cycles').rowCount, 0);
+    assert.equal(byKind.get('arch-cycles').stub, false);
+  });
+
+  it('does not flag a baseline whose rollup carries a non-zero value', () => {
+    const byKind = surfaceOf(
+      makeFixture([
+        [
+          'baselines/lint.json',
+          {
+            kernelVersion: '1.0.0',
+            generatedAt: '2026-01-01T00:00:00.000Z',
+            rollup: { '*': { errorCount: 4, warningCount: 0 } },
+            rows: [],
+          },
+        ],
+      ]),
+    );
+    assert.equal(byKind.get('lint').stub, false);
+  });
+
+  it('does not flag a missing baseline — there is no instrument to call dead', () => {
+    const byKind = surfaceOf(makeFixture([]));
+    assert.equal(byKind.get('lint').baselineExists, false);
+    assert.equal(byKind.get('lint').stub, false);
+    assert.equal(byKind.get('lint').staleDays, null);
+  });
+});
+
+describe('dead ignoreGlobs', () => {
+  it('reports only the configured globs that match nothing on disk', () => {
+    const root = makeFixture([
+      ['src/a.js', 'export const a = 1;\n'],
+      ['src/nested/b.js', 'export const b = 2;\n'],
+    ]);
+    const byKind = surfaceOf(root, {
+      gates: {
+        crap: {
+          targetDirs: ['src'],
+          ignoreGlobs: ['src/**/*.js', 'src/gone/**', 'src/a.js'],
+        },
+      },
+    });
+    assert.deepEqual(byKind.get('crap').deadIgnoreGlobs, ['src/gone/**']);
+  });
+
+  it('reports an empty list for a gate declaring no ignoreGlobs', () => {
+    const root = makeFixture([['src/a.js', 'export const a = 1;\n']]);
+    const byKind = surfaceOf(root, {
+      gates: { crap: { targetDirs: ['src'] } },
+    });
+    assert.deepEqual(byKind.get('crap').deadIgnoreGlobs, []);
+  });
+});
+
+describe('staleness', () => {
+  it('reports whole days since generatedAt', () => {
+    const root = makeFixture([
+      [
+        'baselines/coverage.json',
+        {
+          kernelVersion: '1.0.0',
+          generatedAt: '2026-01-01T00:00:00.000Z',
+          rollup: { '*': { lines: 90, branches: 80, functions: 85 } },
+          rows: [{ path: 'src/a.js', lines: 90, branches: 80, functions: 85 }],
+        },
+      ],
+    ]);
+    const { entries } = buildGateSurface({
+      cwd: root,
+      quality: { gates: {} },
+      now: new Date('2026-01-11T00:00:00.000Z'),
+    });
+    const coverage = entries.find((e) => e.kind === 'coverage');
+    assert.equal(coverage.staleDays, 10);
+    assert.equal(coverage.generatedAt, '2026-01-01T00:00:00.000Z');
+  });
+});
+
+describe('buildGateSurface over the live repository', () => {
+  const quality = getQuality(resolveConfig({ cwd: REPO_ROOT }));
+  const { entries } = buildGateSurface({ cwd: REPO_ROOT, quality });
+  const byKind = new Map(entries.map((e) => [e.kind, e]));
+
+  it('walks both halves — the closed gate kinds and the out-of-band ratchets', () => {
+    for (const kind of GATE_KINDS) {
+      assert.equal(byKind.get(kind)?.surface, 'gate', `${kind} missing`);
+    }
+    for (const kind of EXPECTED_RATCHETS) {
+      assert.equal(byKind.get(kind)?.surface, 'ratchet', `${kind} missing`);
+    }
+    assert.equal(entries.length, GATE_KINDS.length + EXPECTED_RATCHETS.length);
+  });
+
+  it('marks lighthouse, mutation, lint, and bundle-size as stub instruments', () => {
+    const stubs = entries
+      .filter((e) => e.stub)
+      .map((e) => e.kind)
+      .sort();
+    assert.deepEqual(stubs, ['bundle-size', 'lighthouse', 'lint', 'mutation']);
+  });
+
+  it('reports every stub as present on disk with zero rows', () => {
+    for (const entry of entries.filter((e) => e.stub)) {
+      assert.equal(entry.rowCount, 0, `${entry.kind} rowCount`);
+      assert.equal(entry.baselineExists, true, `${entry.kind} exists`);
+    }
+  });
+
+  it('never synthesises a gate block the consumer did not declare', () => {
+    for (const entry of entries.filter((e) => e.configured)) {
+      assert.ok(
+        quality.gates[entry.kind],
+        `${entry.kind} reported configured without a gate block`,
+      );
+    }
+  });
+});

--- a/.agents/scripts/lib/audit-baselines/__tests__/hotspots.test.js
+++ b/.agents/scripts/lib/audit-baselines/__tests__/hotspots.test.js
@@ -1,0 +1,149 @@
+/**
+ * hotspots.test.js — cross-gate clustering and ranking (Story #4902).
+ *
+ * The property under test is the reason the section exists: a file that is an
+ * outlier in two gates is one cluster carrying both memberships, and it
+ * outranks a single-gate outlier of *equal per-gate severity*. Rank the two
+ * separately — as reading each baseline's own top-20 does — and the
+ * convergence that makes the first file the real hotspot is invisible.
+ *
+ * Fixture-backed: the outliers are extracted from baseline files on disk, so
+ * the test covers the on-disk read and the aggregation as well as the join.
+ */
+
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { describe, it } from 'node:test';
+import { makeTempDir } from '../../test-temp.js';
+import { buildHotspots } from '../hotspots.js';
+import { extractOutliers } from '../outliers.js';
+import { readJsonFile } from '../read.js';
+
+const SHARED = 'src/shared.js';
+const LONELY = 'src/lonely.js';
+const CALM = 'src/calm.js';
+
+/** Neutral weights, so ranking differences can only come from severity. */
+const flatWeights = () => ({
+  churnWeight: 1,
+  centralityWeight: 1,
+  frictionWeight: 1,
+});
+
+/**
+ * Write a two-gate fixture where SHARED and LONELY are equally severe CRAP
+ * outliers and only SHARED is also a maintainability outlier.
+ *
+ * @returns {string} fixture repo root
+ */
+function writeFixture() {
+  const root = makeTempDir('audit-baselines-hotspots-');
+  fs.mkdirSync(path.join(root, 'baselines'), { recursive: true });
+  const write = (name, body) =>
+    fs.writeFileSync(
+      path.join(root, 'baselines', name),
+      JSON.stringify(body, null, 2),
+    );
+  write('crap.json', {
+    $schema: '../.agents/schemas/baselines/crap.schema.json',
+    kernelVersion: '1.0.0',
+    generatedAt: '2026-01-01T00:00:00.000Z',
+    rollup: { '*': { p50: 2, p95: 20, max: 30, methodsAbove20: 2 } },
+    rows: [
+      { path: SHARED, method: 'a', startLine: 1, crap: 30 },
+      { path: LONELY, method: 'b', startLine: 1, crap: 30 },
+      { path: CALM, method: 'c', startLine: 1, crap: 1 },
+    ],
+  });
+  write('maintainability.json', {
+    $schema: '../.agents/schemas/baselines/maintainability.schema.json',
+    kernelVersion: '1.0.0',
+    generatedAt: '2026-01-01T00:00:00.000Z',
+    rollup: { '*': { min: 40, p50: 70, p95: 100 } },
+    rows: [
+      { path: SHARED, mi: 40 },
+      { path: CALM, mi: 100 },
+    ],
+  });
+  return root;
+}
+
+/**
+ * Extract outliers for both fixture gates.
+ *
+ * @param {string} root
+ * @returns {Array<object>}
+ */
+function outliersFrom(root) {
+  return ['crap', 'maintainability'].flatMap((kind) =>
+    extractOutliers({
+      kind,
+      baseline: readJsonFile(path.join(root, 'baselines', `${kind}.json`))
+        .parsed,
+      topN: 20,
+    }),
+  );
+}
+
+describe('cross-gate hotspot clustering', () => {
+  const root = writeFixture();
+  const outliers = outliersFrom(root);
+  const hotspots = buildHotspots({ outliers, weightsFor: flatWeights });
+  const byPath = new Map(hotspots.map((h) => [h.path, h]));
+
+  it('emits a file outlying in two gates as ONE cluster with both memberships', () => {
+    const shared = byPath.get(SHARED);
+    assert.ok(shared, 'shared file missing from hotspots');
+    assert.equal(shared.gateCount, 2);
+    assert.deepEqual(shared.gateKinds, ['crap', 'maintainability']);
+    assert.equal(hotspots.filter((h) => h.path === SHARED).length, 1);
+  });
+
+  it('gives the two gate memberships equal per-gate severity to the single-gate file', () => {
+    const sharedCrap = byPath.get(SHARED).gates.find((g) => g.kind === 'crap');
+    const lonelyCrap = byPath.get(LONELY).gates.find((g) => g.kind === 'crap');
+    assert.equal(sharedCrap.severityWeight, lonelyCrap.severityWeight);
+  });
+
+  it('ranks the two-gate cluster above the single-gate outlier', () => {
+    assert.equal(hotspots[0].path, SHARED);
+    assert.ok(byPath.get(SHARED).rank > byPath.get(LONELY).rank);
+    assert.equal(byPath.get(LONELY).gateCount, 1);
+  });
+
+  it('aggregates per-method rows to the file grain', () => {
+    // CALM is a CRAP row and a maintainability row but the best value on
+    // both axes — it clusters, it just ranks last.
+    assert.ok(byPath.get(CALM).rank < byPath.get(LONELY).rank);
+  });
+});
+
+describe('bounded extraction', () => {
+  it('never emits more rows per gate than topN', () => {
+    const root = makeTempDir('audit-baselines-topn-');
+    fs.mkdirSync(path.join(root, 'baselines'), { recursive: true });
+    const rows = Array.from({ length: 100 }, (_, i) => ({
+      path: `src/f${i}.js`,
+      method: 'm',
+      startLine: 1,
+      crap: i,
+    }));
+    fs.writeFileSync(
+      path.join(root, 'baselines', 'crap.json'),
+      JSON.stringify({
+        kernelVersion: '1.0.0',
+        generatedAt: '2026-01-01T00:00:00.000Z',
+        rollup: { '*': { p50: 50, p95: 95, max: 99, methodsAbove20: 79 } },
+        rows,
+      }),
+    );
+    const extracted = extractOutliers({
+      kind: 'crap',
+      baseline: readJsonFile(path.join(root, 'baselines', 'crap.json')).parsed,
+      topN: 5,
+    });
+    assert.equal(extracted.length, 5);
+    assert.equal(extracted[0].id, 'src/f99.js');
+  });
+});

--- a/.agents/scripts/lib/audit-baselines/__tests__/read-only.test.js
+++ b/.agents/scripts/lib/audit-baselines/__tests__/read-only.test.js
@@ -1,0 +1,105 @@
+/**
+ * read-only.test.js — the invariant the whole engine rests on (Story #4902).
+ *
+ * A hotspot engine that refreshed a baseline while measuring it would destroy
+ * the evidence it was asked to gather: the ratchet's whole value is that the
+ * committed number was produced by a deliberate, reviewed refresh. So the
+ * engine reads `baselines/` and writes nothing there — not a reformat, not a
+ * timestamp bump — and never runs a test, coverage, or mutation suite to
+ * "get a current number".
+ *
+ * The check hashes every file under `baselines/` in the live repository
+ * before and after a full CLI run, and pins the envelope against its shipped
+ * schema in the same pass.
+ */
+
+import assert from 'node:assert/strict';
+import { createHash } from 'node:crypto';
+import fs from 'node:fs';
+import path from 'node:path';
+import { before, describe, it } from 'node:test';
+import { fileURLToPath } from 'node:url';
+import { assertEnvelope, runCli } from '../../../audit-baselines.js';
+import { makeTempDir } from '../../test-temp.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+// __tests__ → audit-baselines → lib → scripts → .agents → repo root
+const REPO_ROOT = path.resolve(__dirname, '..', '..', '..', '..', '..');
+const BASELINES_DIR = path.join(REPO_ROOT, 'baselines');
+
+/**
+ * SHA-256 of every file under `baselines/`, keyed by relative path.
+ *
+ * @returns {Map<string, string>}
+ */
+function hashBaselines() {
+  const hashes = new Map();
+  for (const name of fs.readdirSync(BASELINES_DIR).sort()) {
+    const abs = path.join(BASELINES_DIR, name);
+    if (!fs.statSync(abs).isFile()) continue;
+    hashes.set(
+      name,
+      createHash('sha256').update(fs.readFileSync(abs)).digest('hex'),
+    );
+  }
+  return hashes;
+}
+
+describe('read-only invariant over baselines/', () => {
+  const outPath = path.join(makeTempDir('audit-baselines-ro-'), 'env.json');
+  let before_;
+  let after;
+  let exitCode;
+  let envelope;
+
+  before(async () => {
+    before_ = hashBaselines();
+    exitCode = await runCli({
+      argv: ['--out', outPath, '--cwd', REPO_ROOT],
+      stdout: { write: () => {} },
+    });
+    after = hashBaselines();
+    envelope = JSON.parse(fs.readFileSync(outPath, 'utf8'));
+  });
+
+  it('leaves every file under baselines/ byte-identical', () => {
+    assert.ok(before_.size > 0, 'no baseline files were hashed');
+    assert.deepEqual([...after.keys()], [...before_.keys()]);
+    for (const [name, digest] of before_) {
+      assert.equal(after.get(name), digest, `${name} changed during the run`);
+    }
+  });
+
+  it('exits 0 and writes an envelope that validates against the shipped schema', () => {
+    assert.equal(exitCode, 0);
+    assert.doesNotThrow(() => assertEnvelope(envelope));
+    assert.equal(envelope.kind, 'audit-baselines-envelope');
+  });
+
+  it('bounds the envelope well below the size of the baselines it reads', () => {
+    // crap.json alone is ~650KB of per-method rows; embedding a baseline
+    // wholesale is the failure mode the topN bound exists to prevent.
+    const envelopeBytes = fs.statSync(outPath).size;
+    const crapBytes = fs.statSync(path.join(BASELINES_DIR, 'crap.json')).size;
+    assert.ok(
+      envelopeBytes < crapBytes,
+      `envelope ${envelopeBytes}B is not smaller than crap.json ${crapBytes}B`,
+    );
+    for (const entry of envelope.gateSurface) {
+      const emitted = envelope.hotspots.flatMap((h) =>
+        h.gates.filter((g) => g.kind === entry.kind),
+      );
+      assert.ok(
+        emitted.length <= envelope.topN,
+        `${entry.kind} emitted ${emitted.length} rows above topN ${envelope.topN}`,
+      );
+    }
+  });
+
+  it('rejects a malformed envelope rather than writing it', () => {
+    assert.throws(
+      () => assertEnvelope({ ...envelope, hotspots: 'not-an-array' }),
+      /failed schema validation/,
+    );
+  });
+});

--- a/.agents/scripts/lib/audit-baselines/engine.js
+++ b/.agents/scripts/lib/audit-baselines/engine.js
@@ -1,0 +1,177 @@
+/**
+ * engine.js — assemble the `/audit-baselines` evidence envelope
+ * (Story #4902).
+ *
+ * Strictly read-only and strictly offline: it reads committed baselines, the
+ * resolved config, git history, the static import graph, and any friction
+ * ledger it finds. It never writes under `baselines/`, never refreshes a
+ * baseline, and never runs a test, coverage, or mutation suite — the whole
+ * point is that a baseline review costs a file read, not a CI run.
+ *
+ * Findings are evidence, not a verdict: assembling the envelope is success,
+ * however alarming its contents, so the CLI exits 0 whenever it got this far.
+ * Judgment belongs to the lens that reads the envelope.
+ *
+ * @module lib/audit-baselines/engine
+ */
+
+import path from 'node:path';
+import { mainCheckoutRoot, tempRootFrom } from '../config/temp-paths.js';
+import { getQuality, resolveConfig } from '../config-resolver.js';
+import { buildGateSurface } from './gate-surface.js';
+import { buildHeadroom } from './headroom.js';
+import { buildHotspots } from './hotspots.js';
+import { ALL_KINDS, baselinePathFor, GATE_KINDS } from './kinds.js';
+import { DEFAULT_TOP_N, extractOutliers } from './outliers.js';
+import { buildTrend } from './trend.js';
+import {
+  makeWeightResolver,
+  readCentrality,
+  readChurn,
+  readFriction,
+} from './weights.js';
+
+/** Envelope `kind` discriminator; matches the shipped schema's const. */
+const ENVELOPE_KIND = 'audit-baselines-envelope';
+
+/** Envelope schema version — bumped on any breaking shape change. */
+const ENVELOPE_SCHEMA_VERSION = '1';
+
+/** Cap on emitted hotspot clusters, independent of the per-gate `topN`. */
+export const DEFAULT_HOTSPOT_LIMIT = 50;
+
+/**
+ * Resolve the repository config without letting a broken `.agentrc.json`
+ * abort the run — an unreadable config still leaves the baseline files
+ * themselves readable at their default paths.
+ *
+ * @param {string} cwd
+ * @returns {{ quality: object, configError: string | null }}
+ */
+function resolveQualityBlock(cwd) {
+  try {
+    return { quality: getQuality(resolveConfig({ cwd })), configError: null };
+  } catch (err) {
+    return { quality: { gates: {} }, configError: err?.message ?? String(err) };
+  }
+}
+
+/**
+ * Absolute temp root the friction ledger is searched under, anchored to the
+ * **analysed** repository rather than the process cwd. `resolvedTempRoot()`
+ * anchors to whichever checkout the current process sits in, which is the
+ * right answer for a writer and the wrong one here: an engine pointed at
+ * another repo with `--cwd` must read that repo's ledger, not this one's.
+ *
+ * @param {string} cwd
+ * @returns {string}
+ */
+function tempRootFor(cwd) {
+  let relative = 'temp';
+  try {
+    relative = tempRootFrom(resolveConfig({ cwd }));
+  } catch {
+    // Unreadable config — the framework default root is still worth probing.
+  }
+  if (path.isAbsolute(relative)) return relative;
+  return path.join(mainCheckoutRoot(cwd) ?? cwd, relative);
+}
+
+/**
+ * Run the engine and return the envelope object. Pure with respect to the
+ * filesystem apart from the reads named in the module docstring — writing
+ * the result is the caller's job.
+ *
+ * @param {{
+ *   cwd: string,
+ *   topN?: number,
+ *   hotspotLimit?: number,
+ *   trendDepth?: number,
+ *   now?: Date,
+ * }} args
+ * @returns {object} the `audit-baselines-envelope`
+ */
+export function runEngine({
+  cwd,
+  topN = DEFAULT_TOP_N,
+  hotspotLimit = DEFAULT_HOTSPOT_LIMIT,
+  trendDepth = 5,
+  now = new Date(),
+}) {
+  const { quality, configError } = resolveQualityBlock(cwd);
+  const { entries, baselines } = buildGateSurface({ cwd, quality, now });
+
+  const outliers = ALL_KINDS.flatMap((kind) =>
+    extractOutliers({ kind, baseline: baselines.get(kind) ?? null, topN }),
+  );
+
+  const churn = readChurn({ cwd });
+  const centrality = readCentrality({ cwd });
+  const friction = readFriction({ tempRootAbs: tempRootFor(cwd) });
+
+  return {
+    kind: ENVELOPE_KIND,
+    schemaVersion: ENVELOPE_SCHEMA_VERSION,
+    generatedAt: now.toISOString(),
+    cwd,
+    topN,
+    configError,
+    degradations: {
+      gitHistory: churn.degraded,
+      importGraph: centrality.degraded,
+      frictionLedger: friction.degraded,
+    },
+    gateSurface: entries,
+    hotspots: buildHotspots({
+      outliers,
+      weightsFor: makeWeightResolver({ churn, centrality, friction }),
+      limit: hotspotLimit,
+    }),
+    trend: buildTrend({
+      cwd,
+      kinds: ALL_KINDS,
+      pathFor: (kind) => baselinePathFor(kind, quality),
+      depth: trendDepth,
+    }),
+    headroom: buildHeadroom({ kinds: GATE_KINDS, quality, baselines }),
+  };
+}
+
+/**
+ * Condense an envelope into the pure-JSON stdout summary. Small enough to
+ * read in a terminal, and never carrying a row set.
+ *
+ * @param {object} envelope
+ * @param {string} outPath absolute path the full envelope was written to
+ * @returns {object}
+ */
+export function summarize(envelope, outPath) {
+  return {
+    kind: 'audit-baselines-summary',
+    schemaVersion: ENVELOPE_SCHEMA_VERSION,
+    out: outPath,
+    generatedAt: envelope.generatedAt,
+    gateSurface: {
+      total: envelope.gateSurface.length,
+      configured: envelope.gateSurface.filter((g) => g.configured).length,
+      missingBaseline: envelope.gateSurface
+        .filter((g) => !g.baselineExists)
+        .map((g) => g.kind),
+      stubs: envelope.gateSurface.filter((g) => g.stub).map((g) => g.kind),
+      deadIgnoreGlobs: envelope.gateSurface.reduce(
+        (n, g) => n + g.deadIgnoreGlobs.length,
+        0,
+      ),
+    },
+    hotspots: {
+      total: envelope.hotspots.length,
+      multiGate: envelope.hotspots.filter((h) => h.gateCount > 1).length,
+      top: envelope.hotspots
+        .slice(0, 5)
+        .map((h) => ({ path: h.path, gates: h.gateKinds, rank: h.rank })),
+    },
+    trend: { kinds: envelope.trend.length },
+    headroom: { axes: envelope.headroom.length },
+    degradations: envelope.degradations,
+  };
+}

--- a/.agents/scripts/lib/audit-baselines/gate-surface.js
+++ b/.agents/scripts/lib/audit-baselines/gate-surface.js
@@ -1,0 +1,143 @@
+/**
+ * gate-surface.js — per-kind health of the measuring instruments themselves
+ * (Story #4902).
+ *
+ * A baseline review that only reads the numbers cannot see the failure mode
+ * that matters most: an instrument that is not measuring anything. A gate can
+ * be unconfigured, its baseline file can be missing, it can be a **stub**
+ * (committed with no rows and an all-zero rollup, so it passes every run
+ * vacuously), it can be years stale, and its `ignoreGlobs` can name paths
+ * that no longer exist — each of which reads as "green" from the gate's exit
+ * code. This section reports all five as declarative fields.
+ *
+ * @module lib/audit-baselines/gate-surface
+ */
+
+import path from 'node:path';
+import picomatch from 'picomatch';
+import {
+  ALL_KINDS,
+  baselinePathFor,
+  GATE_KINDS,
+  KIND_SPECS,
+  rollupOf,
+} from './kinds.js';
+import { ageInDays, listFilesUnder, readJsonFile } from './read.js';
+
+/**
+ * True when every numeric leaf of the rollup is zero. A rollup with no
+ * numeric leaves at all is not all-zero — it carries no measurement to call
+ * zero, and treating it as such would flag shapes this engine cannot read.
+ *
+ * @param {object | null} rollup
+ * @returns {boolean}
+ */
+function isAllZeroRollup(rollup) {
+  if (!rollup || typeof rollup !== 'object') return false;
+  const numbers = Object.values(rollup).filter((v) => typeof v === 'number');
+  return numbers.length > 0 && numbers.every((v) => v === 0);
+}
+
+/**
+ * A **stub instrument**: zero rows AND an all-zero rollup. Both halves are
+ * required. Ratchet baselines carry no rollup, so a clean `arch-cycles`
+ * allowlist — genuinely zero cycles, the success state — is never mistaken
+ * for a dead instrument.
+ *
+ * @param {{ rowCount: number, rollup: object | null }} args
+ * @returns {boolean}
+ */
+function isStubInstrument({ rowCount, rollup }) {
+  return rowCount === 0 && isAllZeroRollup(rollup);
+}
+
+/**
+ * Every `targetDirs` entry declared by any gate, deduplicated. This is the
+ * file universe an `ignoreGlobs` entry is checked against — a glob that
+ * matches nothing inside the dirs its own gate scans is dead weight.
+ *
+ * @param {object | null | undefined} quality
+ * @returns {string[]}
+ */
+function declaredTargetDirs(quality) {
+  const dirs = new Set();
+  for (const kind of GATE_KINDS) {
+    for (const dir of quality?.gates?.[kind]?.targetDirs ?? []) {
+      if (typeof dir === 'string' && dir.length > 0) dirs.add(dir);
+    }
+  }
+  return [...dirs].sort();
+}
+
+/**
+ * Which of a gate's configured `ignoreGlobs` match zero files on disk.
+ *
+ * @param {string[]} ignoreGlobs
+ * @param {string[]} files repo-relative posix paths
+ * @returns {string[]}
+ */
+function findDeadIgnoreGlobs(ignoreGlobs, files) {
+  const dead = [];
+  for (const glob of ignoreGlobs ?? []) {
+    if (typeof glob !== 'string' || glob.length === 0) continue;
+    const isMatch = picomatch(glob, { dot: true });
+    if (!files.some((f) => isMatch(f))) dead.push(glob);
+  }
+  return dead;
+}
+
+/**
+ * Assemble one `gateSurface[]` entry from an already-read baseline.
+ *
+ * @param {{
+ *   kind: string, quality: object, read: object, relPath: string,
+ *   files: string[], now: Date,
+ * }} args
+ * @returns {object}
+ */
+function surfaceEntryFor({ kind, quality, read, relPath, files, now }) {
+  const gateBlock = quality?.gates?.[kind] ?? null;
+  const { exists, parsed, parseError } = read;
+  const rows = parsed ? KIND_SPECS[kind].rows(parsed) : [];
+  const rollup = rollupOf(parsed);
+  const generatedAt =
+    typeof parsed?.generatedAt === 'string' ? parsed.generatedAt : null;
+  return {
+    kind,
+    surface: GATE_KINDS.includes(kind) ? 'gate' : 'ratchet',
+    baselinePath: relPath,
+    configured: gateBlock !== null && typeof gateBlock === 'object',
+    baselineExists: exists,
+    stub: isStubInstrument({ rowCount: rows.length, rollup }),
+    rowCount: rows.length,
+    generatedAt,
+    staleDays: ageInDays(generatedAt, now),
+    deadIgnoreGlobs: findDeadIgnoreGlobs(gateBlock?.ignoreGlobs, files),
+    parseError,
+  };
+}
+
+/**
+ * Walk both halves of the gate surface — the closed `delivery.quality.gates`
+ * kinds and the out-of-band ratchet baselines — and report each instrument's
+ * health.
+ *
+ * @param {{ cwd: string, quality: object, now?: Date }} args
+ * @returns {{ entries: object[], baselines: Map<string, object|null> }}
+ *   `baselines` carries each parsed envelope forward so the hotspot, trend,
+ *   and headroom sections never re-read a 650KB file off disk.
+ */
+export function buildGateSurface({ cwd, quality, now = new Date() }) {
+  const files = declaredTargetDirs(quality).flatMap((dir) =>
+    listFilesUnder(cwd, dir),
+  );
+  const entries = [];
+  const baselines = new Map();
+  for (const kind of ALL_KINDS) {
+    const relPath = baselinePathFor(kind, quality);
+    const read = readJsonFile(path.resolve(cwd, relPath));
+    entries.push(surfaceEntryFor({ kind, quality, read, relPath, files, now }));
+    baselines.set(kind, read.parsed);
+  }
+  return { entries, baselines };
+}

--- a/.agents/scripts/lib/audit-baselines/headroom.js
+++ b/.agents/scripts/lib/audit-baselines/headroom.js
@@ -1,0 +1,72 @@
+/**
+ * headroom.js — how much slack sits between each configured floor and the
+ * number actually measured (Story #4902).
+ *
+ * A floor set far from reality is a gate that cannot fail. Headroom is the
+ * distance the measurement could still drift before the gate notices, and it
+ * is the direct input to the only remediation this lens ever recommends:
+ * tighten the floor to what the repo already achieves.
+ *
+ * Both sides come from the repository, never from this module: the floor
+ * from `resolveQuality()` over `.agentrc.json` (so a consumer's own floors
+ * are the ones reported), and the measurement from the committed baseline's
+ * whole-repo rollup. Polarity comes from `axisDirection` in the gate's own
+ * floors phase, so "better" always means the same thing here as it does when
+ * `check-baselines.js` decides pass or fail.
+ *
+ * @module lib/audit-baselines/headroom
+ */
+
+import { axisDirection } from '../orchestration/check-baselines/phases/floors.js';
+import { rollupOf } from './kinds.js';
+
+/**
+ * Signed distance from the floor, positive when the measurement sits on the
+ * good side of it. Null when the baseline carries no value for the axis.
+ *
+ * @param {number | undefined} measured
+ * @param {number} floor
+ * @param {'gte' | 'lte'} direction
+ * @returns {number | null}
+ */
+function headroomFor(measured, floor, direction) {
+  if (typeof measured !== 'number') return null;
+  return direction === 'gte' ? measured - floor : floor - measured;
+}
+
+/**
+ * Build the `headroom[]` section across every configured gate kind.
+ *
+ * @param {{
+ *   kinds: string[],
+ *   quality: object,
+ *   baselines: Map<string, object | null>,
+ * }} args
+ * @returns {Array<object>}
+ */
+export function buildHeadroom({ kinds, quality, baselines }) {
+  const out = [];
+  for (const kind of kinds) {
+    const floors = quality?.gates?.[kind]?.floors?.['*'];
+    if (!floors || typeof floors !== 'object') continue;
+    const rollup = rollupOf(baselines.get(kind) ?? null);
+    for (const [axis, floor] of Object.entries(floors)) {
+      if (typeof floor !== 'number' || !Number.isFinite(floor)) continue;
+      const measured = rollup?.[axis];
+      const direction = axisDirection(kind, axis);
+      out.push({
+        kind,
+        axis,
+        floor,
+        measured: typeof measured === 'number' ? measured : null,
+        direction,
+        // Positive headroom = the measurement is on the good side of the
+        // floor by this much; negative = the floor is already breached.
+        headroom: headroomFor(measured, floor, direction),
+      });
+    }
+  }
+  return out.sort(
+    (a, b) => a.kind.localeCompare(b.kind) || a.axis.localeCompare(b.axis),
+  );
+}

--- a/.agents/scripts/lib/audit-baselines/hotspots.js
+++ b/.agents/scripts/lib/audit-baselines/hotspots.js
@@ -1,0 +1,69 @@
+/**
+ * hotspots.js — join per-gate outliers into ranked, per-file clusters
+ * (Story #4902).
+ *
+ * The signal a baseline review is looking for is *convergence*: the file that
+ * is simultaneously a CRAP outlier, a maintainability outlier, and a
+ * duplication outlier is a different kind of problem from three unrelated
+ * files each bad at one thing. Reading the baselines one at a time cannot see
+ * it, because each gate's own top-20 is a different list.
+ *
+ * So severity **adds across gate memberships** and the three cost
+ * multipliers apply to the sum. Two gate memberships of severity s therefore
+ * outrank one membership of severity s at equal churn, centrality, and
+ * friction — which is the ranking property this section exists to provide.
+ *
+ * @module lib/audit-baselines/hotspots
+ */
+
+/**
+ * Group per-gate outlier rows by cluster id and rank them.
+ *
+ * @param {{
+ *   outliers: Array<object>,
+ *   weightsFor: (id: string) => {
+ *     churnWeight: number, centralityWeight: number, frictionWeight: number,
+ *   },
+ *   limit?: number,
+ * }} args
+ * @returns {Array<object>} highest rank first
+ */
+export function buildHotspots({ outliers, weightsFor, limit = 50 }) {
+  const clusters = new Map();
+  for (const row of outliers) {
+    let cluster = clusters.get(row.id);
+    if (!cluster) {
+      cluster = { path: row.id, gates: [], severityWeight: 0 };
+      clusters.set(row.id, cluster);
+    }
+    cluster.gates.push({
+      kind: row.kind,
+      metric: row.metric,
+      value: row.value,
+      rowCount: row.rowCount,
+      severityWeight: row.severityWeight,
+    });
+    cluster.severityWeight += row.severityWeight;
+  }
+
+  const ranked = [];
+  for (const cluster of clusters.values()) {
+    const weights = weightsFor(cluster.path);
+    cluster.gates.sort((a, b) => a.kind.localeCompare(b.kind));
+    ranked.push({
+      path: cluster.path,
+      gates: cluster.gates,
+      gateKinds: cluster.gates.map((g) => g.kind),
+      gateCount: cluster.gates.length,
+      severityWeight: cluster.severityWeight,
+      ...weights,
+      rank:
+        cluster.severityWeight *
+        weights.churnWeight *
+        weights.centralityWeight *
+        weights.frictionWeight,
+    });
+  }
+  ranked.sort((a, b) => b.rank - a.rank || a.path.localeCompare(b.path));
+  return ranked.slice(0, Math.max(0, limit));
+}

--- a/.agents/scripts/lib/audit-baselines/kinds.js
+++ b/.agents/scripts/lib/audit-baselines/kinds.js
@@ -1,0 +1,246 @@
+/**
+ * kinds.js — the two halves of the gate surface, and how to read a row out
+ * of each (Story #4902).
+ *
+ * Mandrel's baseline surface is not one list. `delivery.quality.gates` is a
+ * **closed** AJV schema of eight kinds, enforced by `check-baselines.js`.
+ * Alongside it sit out-of-band **ratchet** baselines — dead exports (two
+ * passes), import cycles, context budget — which no gate block declares and
+ * only the CI baselines job runs. An engine that walks one half and calls it
+ * "the baselines" silently drops the other; both halves are enumerated here.
+ *
+ * `GATE_KINDS` is derived from `GATES_SCHEMA` rather than re-typed, so a
+ * ninth gate kind landing in the schema reaches this engine automatically.
+ *
+ * @module lib/audit-baselines/kinds
+ */
+
+import { GATES_SCHEMA } from '../config/gates/index.js';
+
+/** The closed `delivery.quality.gates` kind set, in stable order. */
+export const GATE_KINDS = Object.freeze(
+  Object.keys(GATES_SCHEMA.properties).sort(),
+);
+
+/**
+ * Out-of-band ratchet baselines: committed under `baselines/` and enforced
+ * only by the CI baselines job, never by `check-baselines.js`.
+ */
+const RATCHET_KINDS = Object.freeze([
+  'arch-cycles',
+  'context-budget',
+  'dead-exports',
+  'dead-exports-production',
+]);
+
+/** Every kind the engine walks, gates first then ratchets. */
+export const ALL_KINDS = Object.freeze([...GATE_KINDS, ...RATCHET_KINDS]);
+
+/**
+ * Resolve a kind's baseline path from config, falling back to the framework
+ * default layout. Never hardcodes a consumer's location: a repo that moved
+ * `baselines/crap.json` via `gates.crap.baselinePath` is followed.
+ *
+ * @param {string} kind
+ * @param {object | null | undefined} quality resolved `delivery.quality`
+ * @returns {string} repo-relative path
+ */
+export function baselinePathFor(kind, quality) {
+  const configured = quality?.gates?.[kind]?.baselinePath;
+  if (typeof configured === 'string' && configured.length > 0) {
+    return configured;
+  }
+  return `baselines/${kind}.json`;
+}
+
+/**
+ * Flatten `context-budget.json` into `{ id, value }` rows. Its three
+ * sections all measure the same axis (bytes of context a file costs) under
+ * different keys, so they fold into one row set rather than three.
+ *
+ * @param {object} baseline
+ * @returns {Array<{ id: string, value: number }>}
+ */
+function contextBudgetRows(baseline) {
+  const out = [];
+  for (const tier of Object.values(baseline?.tiers ?? {})) {
+    for (const f of tier?.files ?? []) out.push({ id: f.path, value: f.bytes });
+  }
+  for (const f of baseline?.agentBoot?.files ?? []) {
+    out.push({ id: f.path, value: f.bytes });
+  }
+  for (const e of baseline?.workflowClosure?.entryPoints ?? []) {
+    out.push({ id: e.path, value: e.reachableBytes });
+  }
+  return out.filter(
+    (r) => typeof r.id === 'string' && Number.isFinite(r.value),
+  );
+}
+
+/**
+ * Count how many allowlisted cycles each module participates in. A module in
+ * three cycles is a worse architectural hotspot than one in a single cycle.
+ *
+ * @param {object} baseline
+ * @returns {Array<{ id: string, value: number }>}
+ */
+function archCycleRows(baseline) {
+  const counts = new Map();
+  for (const cycle of baseline?.cycles ?? []) {
+    for (const member of new Set(cycle ?? [])) {
+      counts.set(member, (counts.get(member) ?? 0) + 1);
+    }
+  }
+  return [...counts].map(([id, value]) => ({ id, value }));
+}
+
+/**
+ * Count dead exports per file. The row grain is `{ file, symbol }`; the
+ * hotspot grain is the file.
+ *
+ * @param {object} baseline
+ * @returns {Array<{ id: string, value: number }>}
+ */
+function deadExportRows(baseline) {
+  const counts = new Map();
+  for (const row of baseline?.rows ?? []) {
+    if (typeof row?.file !== 'string') continue;
+    counts.set(row.file, (counts.get(row.file) ?? 0) + 1);
+  }
+  return [...counts].map(([id, value]) => ({ id, value }));
+}
+
+/**
+ * Build the `{ id, value }` extractor for an envelope-shaped gate kind.
+ *
+ * @param {string} idKey row property carrying the cluster identity
+ * @param {string} metric row property carrying the measured value
+ * @returns {(baseline: object) => Array<{ id: string, value: number }>}
+ */
+function envelopeRows(idKey, metric) {
+  return (baseline) =>
+    (baseline?.rows ?? [])
+      .map((row) => ({ id: row?.[idKey], value: row?.[metric] }))
+      .filter((r) => typeof r.id === 'string' && Number.isFinite(r.value));
+}
+
+/**
+ * Per-kind row spec.
+ *
+ * - `metric`  — the axis a hotspot is measured on.
+ * - `worse`   — which end of that axis is the bad end.
+ * - `rows`    — baseline → `{ id, value }` pairs, already aggregated where
+ *               the on-disk grain is finer than the file (dead exports,
+ *               cycles).
+ * - `idKind`  — what the cluster key names. Every kind but `lighthouse`
+ *               (routes) and `bundle-size` (bundle names) keys on a
+ *               repository file path.
+ */
+export const KIND_SPECS = Object.freeze({
+  'bundle-size': {
+    metric: 'rawKb',
+    worse: 'higher',
+    idKind: 'bundle',
+    rows: envelopeRows('bundle', 'rawKb'),
+  },
+  coverage: {
+    metric: 'lines',
+    worse: 'lower',
+    idKind: 'path',
+    rows: envelopeRows('path', 'lines'),
+  },
+  crap: {
+    metric: 'crap',
+    worse: 'higher',
+    idKind: 'path',
+    rows: envelopeRows('path', 'crap'),
+  },
+  duplication: {
+    metric: 'percentage',
+    worse: 'higher',
+    idKind: 'path',
+    rows: envelopeRows('path', 'percentage'),
+  },
+  lighthouse: {
+    metric: 'performance',
+    worse: 'lower',
+    idKind: 'route',
+    rows: envelopeRows('route', 'performance'),
+  },
+  lint: {
+    metric: 'errorCount',
+    worse: 'higher',
+    idKind: 'path',
+    rows: envelopeRows('path', 'errorCount'),
+  },
+  maintainability: {
+    metric: 'mi',
+    worse: 'lower',
+    idKind: 'path',
+    rows: envelopeRows('path', 'mi'),
+  },
+  mutation: {
+    metric: 'score',
+    worse: 'lower',
+    idKind: 'path',
+    rows: envelopeRows('path', 'score'),
+  },
+  'arch-cycles': {
+    metric: 'cycleMemberships',
+    worse: 'higher',
+    idKind: 'path',
+    rows: archCycleRows,
+  },
+  'context-budget': {
+    metric: 'bytes',
+    worse: 'higher',
+    idKind: 'path',
+    rows: contextBudgetRows,
+  },
+  'dead-exports': {
+    metric: 'deadExports',
+    worse: 'higher',
+    idKind: 'path',
+    rows: deadExportRows,
+  },
+  'dead-exports-production': {
+    metric: 'deadExports',
+    worse: 'higher',
+    idKind: 'path',
+    rows: deadExportRows,
+  },
+});
+
+/**
+ * The whole-repo rollup for a kind, or `null` when the kind does not carry
+ * one. Ratchet baselines have no rollup — which is why stub detection asks
+ * for an all-zero rollup rather than merely empty rows: an `arch-cycles`
+ * baseline with zero cycles is a passing gate, not a dead instrument.
+ *
+ * @param {object | null} baseline
+ * @returns {object | null}
+ */
+export function rollupOf(baseline) {
+  const rollup = baseline?.rollup?.['*'];
+  return rollup && typeof rollup === 'object' ? rollup : null;
+}
+
+/**
+ * The rollup a trend sample compares on. Gate kinds carry their own; ratchet
+ * baselines carry none, so their row count stands in — "dead exports went
+ * 170 → 165" is exactly the direction-of-travel question trend answers, and
+ * skipping the ratchet half here would leave it visible in `gateSurface[]`
+ * but invisible in `trend[]`.
+ *
+ * @param {string} kind
+ * @param {object | null} baseline
+ * @returns {object | null}
+ */
+export function trendRollupOf(kind, baseline) {
+  if (!baseline) return null;
+  const declared = rollupOf(baseline);
+  if (declared) return declared;
+  const spec = KIND_SPECS[kind];
+  if (!spec) return null;
+  return { rowCount: spec.rows(baseline).length };
+}

--- a/.agents/scripts/lib/audit-baselines/outliers.js
+++ b/.agents/scripts/lib/audit-baselines/outliers.js
@@ -1,0 +1,100 @@
+/**
+ * outliers.js — bounded top-N outlier extraction per gate (Story #4902).
+ *
+ * `baselines/crap.json` alone is ~650KB of per-method rows. The engine must
+ * never embed a whole baseline in its envelope, so every kind is narrowed to
+ * at most `topN` rows here, before anything downstream sees them.
+ *
+ * Narrowing happens in two steps:
+ *
+ *   1. **Aggregate to the cluster grain.** Baseline rows are per-method
+ *      (crap) or per-symbol (dead exports); hotspots are per-file. Each id
+ *      keeps its single worst value, plus how many rows it contributed.
+ *   2. **Score, then cut.** `severityWeight` is the row's position in its
+ *      own kind's distribution, from 0 (the best value present) to 1 (the
+ *      worst). Scoring within the kind is what makes CRAP 29 and MI 74
+ *      comparable at all — the two axes share no unit, and the whole point
+ *      of a cluster is to add them up.
+ *
+ * @module lib/audit-baselines/outliers
+ */
+
+import { KIND_SPECS } from './kinds.js';
+
+/** Default bound on rows extracted per gate. */
+export const DEFAULT_TOP_N = 20;
+
+/**
+ * Fold `{ id, value }` rows to one entry per id, keeping the worst value.
+ *
+ * @param {Array<{ id: string, value: number }>} rows
+ * @param {'higher' | 'lower'} worse
+ * @returns {Array<{ id: string, value: number, rowCount: number }>}
+ */
+function aggregateById(rows, worse) {
+  const byId = new Map();
+  for (const { id, value } of rows) {
+    const prev = byId.get(id);
+    if (prev === undefined) {
+      byId.set(id, { id, value, rowCount: 1 });
+      continue;
+    }
+    prev.rowCount += 1;
+    const isWorse =
+      worse === 'higher' ? value > prev.value : value < prev.value;
+    if (isWorse) prev.value = value;
+  }
+  return [...byId.values()];
+}
+
+/**
+ * Position of `value` in `[min, max]` normalized so 1 is always the worst
+ * end. A degenerate distribution (every value identical) scores 1 for every
+ * row: they are all equally the worst, and equally the best.
+ *
+ * @param {number} value
+ * @param {number} min
+ * @param {number} max
+ * @param {'higher' | 'lower'} worse
+ * @returns {number} 0..1
+ */
+function normalizeSeverity(value, min, max, worse) {
+  if (!(max > min)) return 1;
+  const ratio = (value - min) / (max - min);
+  return worse === 'higher' ? ratio : 1 - ratio;
+}
+
+/**
+ * Extract the bounded worst-N rows for one kind.
+ *
+ * @param {{ kind: string, baseline: object | null, topN?: number }} args
+ * @returns {Array<{
+ *   kind: string, id: string, metric: string, value: number,
+ *   rowCount: number, severityWeight: number,
+ * }>} worst first
+ */
+export function extractOutliers({ kind, baseline, topN = DEFAULT_TOP_N }) {
+  const spec = KIND_SPECS[kind];
+  if (!spec || !baseline) return [];
+  const aggregated = aggregateById(spec.rows(baseline), spec.worse);
+  if (aggregated.length === 0) return [];
+  let min = Number.POSITIVE_INFINITY;
+  let max = Number.NEGATIVE_INFINITY;
+  for (const row of aggregated) {
+    if (row.value < min) min = row.value;
+    if (row.value > max) max = row.value;
+  }
+  return aggregated
+    .map((row) => ({
+      kind,
+      id: row.id,
+      metric: spec.metric,
+      value: row.value,
+      rowCount: row.rowCount,
+      severityWeight: normalizeSeverity(row.value, min, max, spec.worse),
+    }))
+    .sort(
+      (a, b) => b.severityWeight - a.severityWeight || a.id.localeCompare(b.id),
+    )
+    .slice(0, Math.max(0, topN));
+}

--- a/.agents/scripts/lib/audit-baselines/read.js
+++ b/.agents/scripts/lib/audit-baselines/read.js
@@ -1,0 +1,87 @@
+/**
+ * read.js — tolerant, strictly read-only filesystem access for the baseline
+ * hotspot engine (Story #4902).
+ *
+ * The engine's job is to *report on* the baseline surface, including the
+ * parts of it that are missing or malformed. So no read here throws: a
+ * missing file, an unreadable directory, or a JSON parse error is evidence
+ * the envelope carries, not a crash. Nothing in this module opens a file for
+ * writing — the read-only invariant over `baselines/` starts here.
+ *
+ * @module lib/audit-baselines/read
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+
+/**
+ * Read and parse a JSON file without throwing.
+ *
+ * @param {string} absolutePath
+ * @returns {{ exists: boolean, parsed: object | null, parseError: string | null }}
+ */
+export function readJsonFile(absolutePath) {
+  let raw;
+  try {
+    raw = fs.readFileSync(absolutePath, 'utf8');
+  } catch {
+    return { exists: false, parsed: null, parseError: null };
+  }
+  try {
+    return { exists: true, parsed: JSON.parse(raw), parseError: null };
+  } catch (err) {
+    return {
+      exists: true,
+      parsed: null,
+      parseError: err?.message ?? String(err),
+    };
+  }
+}
+
+/**
+ * List every file under `rootDir` as a posix repo-relative path, skipping
+ * `node_modules`, `.git`, and `.worktrees`. Returns `[]` for an absent or
+ * unreadable root rather than throwing.
+ *
+ * @param {string} repoRoot
+ * @param {string} rootDir repo-relative directory to walk
+ * @returns {string[]} sorted repo-relative posix paths
+ */
+export function listFilesUnder(repoRoot, rootDir) {
+  const skip = new Set(['node_modules', '.git', '.worktrees']);
+  const out = [];
+  const walk = (abs) => {
+    let entries;
+    try {
+      entries = fs.readdirSync(abs, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    for (const entry of entries) {
+      if (skip.has(entry.name)) continue;
+      const child = path.join(abs, entry.name);
+      if (entry.isDirectory()) {
+        walk(child);
+      } else if (entry.isFile()) {
+        out.push(path.relative(repoRoot, child).split(path.sep).join('/'));
+      }
+    }
+  };
+  walk(path.resolve(repoRoot, rootDir));
+  return out.sort();
+}
+
+/**
+ * Age in whole days between `generatedAt` and `now`. Null when the stamp is
+ * absent or unparseable — the engine reports "unknown", never a fabricated 0.
+ *
+ * @param {unknown} generatedAt
+ * @param {Date} now
+ * @returns {number | null}
+ */
+export function ageInDays(generatedAt, now) {
+  if (typeof generatedAt !== 'string') return null;
+  const then = Date.parse(generatedAt);
+  if (Number.isNaN(then)) return null;
+  return Math.floor((now.getTime() - then) / 86_400_000);
+}

--- a/.agents/scripts/lib/audit-baselines/trend.js
+++ b/.agents/scripts/lib/audit-baselines/trend.js
@@ -1,0 +1,125 @@
+/**
+ * trend.js — per-kind rollup deltas read out of each baseline file's own git
+ * history (Story #4902).
+ *
+ * A ratchet only tells you whether today is worse than yesterday. The
+ * question a baseline review asks is the other one: which direction has this
+ * number been moving, and is the ratchet actually ratcheting? That answer is
+ * already committed — every baseline refresh is a commit against the same
+ * path — so it is read with `git log` + `git show`, never recomputed by
+ * re-running an instrument.
+ *
+ * Degradation: any git failure (shallow clone, no history for the path, not
+ * a work tree) yields an empty `trend[]` and exit 0. A missing history is
+ * missing evidence, not an error.
+ *
+ * @module lib/audit-baselines/trend
+ */
+
+import { execFileSync } from 'node:child_process';
+import { trendRollupOf } from './kinds.js';
+
+/**
+ * List the most recent commits touching `relPath`, newest first.
+ *
+ * @param {{ cwd: string, relPath: string, limit: number, run?: Function }} args
+ * @returns {Array<{ sha: string, committedAt: string }>}
+ */
+function listCommits({ cwd, relPath, limit, run = execFileSync }) {
+  let stdout;
+  try {
+    stdout = run(
+      'git',
+      ['log', `-n${limit}`, '--format=%H %cI', '--', relPath],
+      { cwd, encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] },
+    );
+  } catch {
+    return [];
+  }
+  return String(stdout)
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((line) => line.includes(' '))
+    .map((line) => {
+      const [sha, committedAt] = line.split(' ');
+      return { sha, committedAt };
+    });
+}
+
+/**
+ * Read the comparable rollup of a baseline as it existed at `sha`.
+ *
+ * @param {{ cwd: string, kind: string, sha: string, relPath: string, run?: Function }} args
+ * @returns {object | null}
+ */
+function rollupAt({ cwd, kind, sha, relPath, run = execFileSync }) {
+  let stdout;
+  try {
+    stdout = run('git', ['show', `${sha}:${relPath}`], {
+      cwd,
+      encoding: 'utf8',
+      maxBuffer: 64 * 1024 * 1024,
+      stdio: ['ignore', 'pipe', 'ignore'],
+    });
+  } catch {
+    return null;
+  }
+  try {
+    return trendRollupOf(kind, JSON.parse(stdout));
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Numeric axis-by-axis difference `to - from`. Axes missing from either side
+ * are omitted rather than defaulted — a rollup that gained an axis has no
+ * delta on it, and inventing one would read as a regression.
+ *
+ * @param {object} from
+ * @param {object} to
+ * @returns {Record<string, number>}
+ */
+function rollupDelta(from, to) {
+  const deltas = {};
+  for (const [axis, current] of Object.entries(to ?? {})) {
+    const previous = from?.[axis];
+    if (typeof current === 'number' && typeof previous === 'number') {
+      deltas[axis] = current - previous;
+    }
+  }
+  return deltas;
+}
+
+/**
+ * Build the `trend[]` section: newest-vs-previous rollup deltas per kind.
+ *
+ * @param {{
+ *   cwd: string, kinds: string[], pathFor: (kind: string) => string,
+ *   depth?: number, run?: Function,
+ * }} args
+ * @returns {Array<object>}
+ */
+export function buildTrend({ cwd, kinds, pathFor, depth = 5, run }) {
+  const out = [];
+  for (const kind of kinds) {
+    const relPath = pathFor(kind);
+    const commits = listCommits({ cwd, relPath, limit: depth, run });
+    const samples = [];
+    for (const commit of commits) {
+      const rollup = rollupAt({ cwd, kind, sha: commit.sha, relPath, run });
+      if (rollup) samples.push({ ...commit, rollup });
+    }
+    if (samples.length < 2) continue;
+    const [current, previous] = samples;
+    out.push({
+      kind,
+      baselinePath: relPath,
+      sampleCount: samples.length,
+      from: { sha: previous.sha, committedAt: previous.committedAt },
+      to: { sha: current.sha, committedAt: current.committedAt },
+      deltas: rollupDelta(previous.rollup, current.rollup),
+    });
+  }
+  return out;
+}

--- a/.agents/scripts/lib/audit-baselines/weights.js
+++ b/.agents/scripts/lib/audit-baselines/weights.js
@@ -1,0 +1,193 @@
+/**
+ * weights.js — the three ranking multipliers, and their degradations
+ * (Story #4902).
+ *
+ * A hotspot's severity says how bad the code measures. These three say how
+ * much that badness costs: how often the file changes (churn), how much of
+ * the repository depends on it (import in-degree), and how often agents have
+ * actually tripped over it (friction signals).
+ *
+ * All three are **optional inputs**. A shallow clone has no git history, a
+ * fresh checkout has no friction ledger, and a consumer whose sources live
+ * outside the scanned roots has no resolvable import graph. Each degrades to
+ * a neutral multiplier of exactly 1.0 — never 0 (which would erase the
+ * hotspot) and never a guess. The engine exits 0 in every degraded case.
+ *
+ * @module lib/audit-baselines/weights
+ */
+
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import { computeInDegree, resolveRepoGraph } from '../import-graph.js';
+
+/** Neutral multiplier every degraded weight collapses to. */
+const NEUTRAL_WEIGHT = 1.0;
+
+/**
+ * Saturating count → multiplier in `[1, 2)`. Zero observations gives exactly
+ * `NEUTRAL_WEIGHT`, so "no signal" and "signal says nothing notable" are the
+ * same number — the degradation is indistinguishable from an honest zero,
+ * which is the point: neither should move the ranking.
+ *
+ * @param {number} count
+ * @param {number} half count at which the multiplier reaches 1.5
+ * @returns {number}
+ */
+function saturate(count, half) {
+  if (!Number.isFinite(count) || count <= 0) return NEUTRAL_WEIGHT;
+  return NEUTRAL_WEIGHT + count / (count + half);
+}
+
+/**
+ * Count commits touching each file in the recent history window.
+ *
+ * @param {{ cwd: string, windowDays?: number, run?: Function }} args
+ * @returns {{ counts: Map<string, number>, degraded: boolean }}
+ *   `degraded` is true when git could not answer at all — not a git work
+ *   tree, no commits yet, or the binary is unavailable.
+ */
+export function readChurn({ cwd, windowDays = 180, run = execFileSync }) {
+  let stdout;
+  try {
+    stdout = run(
+      'git',
+      [
+        'log',
+        `--since=${windowDays}.days.ago`,
+        '--name-only',
+        '--pretty=format:',
+        '--no-renames',
+      ],
+      {
+        cwd,
+        encoding: 'utf8',
+        maxBuffer: 64 * 1024 * 1024,
+        // git narrates "not a git repository" on stderr; the degradation is
+        // reported in the envelope, not shouted at the operator.
+        stdio: ['ignore', 'pipe', 'ignore'],
+      },
+    );
+  } catch {
+    return { counts: new Map(), degraded: true };
+  }
+  const counts = new Map();
+  for (const line of String(stdout).split('\n')) {
+    const file = line.trim();
+    if (file.length === 0) continue;
+    counts.set(file, (counts.get(file) ?? 0) + 1);
+  }
+  return { counts, degraded: false };
+}
+
+/**
+ * Import in-degree per module, keyed by repo-relative posix path.
+ *
+ * @param {{ cwd: string, graph?: Map<string, string[]> | null }} args
+ * @returns {{ degrees: Map<string, number>, degraded: boolean }}
+ */
+export function readCentrality({ cwd, graph }) {
+  const resolved = graph === undefined ? resolveRepoGraph(cwd) : graph;
+  if (!resolved) return { degrees: new Map(), degraded: true };
+  return { degrees: computeInDegree(resolved), degraded: false };
+}
+
+/** Path tokens that look like repository files, harvested from signal text. */
+const PATH_TOKEN_RE = /[\w@][\w./@-]*\.(?:js|mjs|cjs|ts|tsx|json|md)\b/g;
+
+/**
+ * Collect every `signals.ndjson` under `tempRoot`. Absent tree → empty list.
+ *
+ * @param {string} tempRootAbs
+ * @returns {string[]} absolute paths
+ */
+function findSignalStreams(tempRootAbs) {
+  const out = [];
+  const walk = (dir, depth) => {
+    if (depth > 6) return;
+    let entries;
+    try {
+      entries = fs.readdirSync(dir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    for (const entry of entries) {
+      const child = path.join(dir, entry.name);
+      if (entry.isDirectory()) walk(child, depth + 1);
+      else if (entry.name === 'signals.ndjson') out.push(child);
+    }
+  };
+  walk(tempRootAbs, 0);
+  return out.sort();
+}
+
+/**
+ * Count friction signals blaming each file.
+ *
+ * Signal records carry no dedicated path field — the blamed file surfaces
+ * inside free-form `details` / `emitter.command` text — so paths are
+ * harvested by token scan over each record's serialized form. A malformed
+ * line is skipped, never fatal.
+ *
+ * @param {{ tempRootAbs: string, kinds?: Set<string> }} args
+ * @returns {{ counts: Map<string, number>, degraded: boolean, streams: number }}
+ */
+export function readFriction({
+  tempRootAbs,
+  kinds = new Set(['friction', 'hotspot', 'rework', 'churn', 'retry']),
+}) {
+  const streams = findSignalStreams(tempRootAbs);
+  if (streams.length === 0) {
+    return { counts: new Map(), degraded: true, streams: 0 };
+  }
+  const counts = new Map();
+  for (const stream of streams) {
+    let raw;
+    try {
+      raw = fs.readFileSync(stream, 'utf8');
+    } catch {
+      continue;
+    }
+    for (const line of raw.split('\n')) {
+      if (line.trim().length === 0) continue;
+      let record;
+      try {
+        record = JSON.parse(line);
+      } catch {
+        continue;
+      }
+      if (!kinds.has(record?.kind)) continue;
+      const text =
+        JSON.stringify(record.details ?? {}) + (record?.emitter?.command ?? '');
+      for (const token of text.match(PATH_TOKEN_RE) ?? []) {
+        counts.set(token, (counts.get(token) ?? 0) + 1);
+      }
+    }
+  }
+  return { counts, degraded: false, streams: streams.length };
+}
+
+/**
+ * Bundle the three weight lookups into one resolver the hotspot builder can
+ * call per cluster id, plus the degradation flags the envelope reports.
+ *
+ * @param {{
+ *   churn: { counts: Map<string, number>, degraded: boolean },
+ *   centrality: { degrees: Map<string, number>, degraded: boolean },
+ *   friction: { counts: Map<string, number>, degraded: boolean },
+ * }} sources
+ * @returns {(id: string) => { churnWeight: number, centralityWeight: number, frictionWeight: number }}
+ */
+export function makeWeightResolver({ churn, centrality, friction }) {
+  return (id) => ({
+    churnWeight: churn.degraded
+      ? NEUTRAL_WEIGHT
+      : saturate(churn.counts.get(id) ?? 0, 12),
+    centralityWeight: centrality.degraded
+      ? NEUTRAL_WEIGHT
+      : saturate(centrality.degrees.get(id) ?? 0, 8),
+    frictionWeight: friction.degraded
+      ? NEUTRAL_WEIGHT
+      : saturate(friction.counts.get(id) ?? 0, 4),
+  });
+}

--- a/.agents/scripts/lib/baseline-schema-registry.js
+++ b/.agents/scripts/lib/baseline-schema-registry.js
@@ -45,10 +45,22 @@ export const BASELINE_KIND_SCHEMA_FILES = Object.freeze([
   'duplication.schema.json',
 ]);
 
-/** Every baseline schema filename (envelope + per-kind) in registration order. */
+/**
+ * Report schemas that live under `.agents/schemas/baselines/` but describe
+ * an *engine's output about* the baselines rather than a committed baseline
+ * (Story #4902). They are registered here for two reasons: the AJV instance
+ * below is the one place a caller can compile a baselines-directory schema
+ * without re-registering the envelope, and the mirror-drift test compares
+ * this registry against the on-disk listing — an unregistered file there is
+ * drift regardless of which category it belongs to.
+ */
+const BASELINE_REPORT_SCHEMA_FILES = ['audit-baselines-envelope.schema.json'];
+
+/** Every baseline schema filename (envelope + per-kind + report) in registration order. */
 export const BASELINE_SCHEMA_FILES = Object.freeze([
   BASELINE_ENVELOPE_FILE,
   ...BASELINE_KIND_SCHEMA_FILES,
+  ...BASELINE_REPORT_SCHEMA_FILES,
 ]);
 
 /**

--- a/.agents/scripts/lib/import-graph.js
+++ b/.agents/scripts/lib/import-graph.js
@@ -1,0 +1,156 @@
+/**
+ * import-graph.js — the shared static-import graph seam (Story #4902).
+ *
+ * Extracted verbatim from `check-arch-cycles.js`, which owned the only
+ * import-graph builder in the repository and kept it private to its own
+ * cycle ratchet. A second consumer now needs the same graph for a very
+ * different question — `audit-baselines.js` ranks hotspot files by import
+ * in-degree — and re-deriving "which module imports which" a second time
+ * would guarantee the two answers drift.
+ *
+ * Note this is a **module** graph, not the task/DAG graph in `lib/Graph.js`;
+ * the two are unrelated despite the shared word.
+ *
+ * The extraction is behaviour-preserving: `check-arch-cycles.js` imports
+ * these helpers and re-exports them, so its public surface (and the ratchet's
+ * output) is unchanged.
+ *
+ * @module lib/import-graph
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+
+/**
+ * Default scan roots making up the project's distributed surface — the
+ * directories published to npm via `package.json` `files[]`. Resolving
+ * them into one graph (relativized against the repo root) means a cycle
+ * crossing two roots is visible to consumers of the graph.
+ *
+ * @type {string[]}
+ */
+export const DEFAULT_ROOTS = [path.join('.agents', 'scripts'), 'bin', 'lib'];
+
+/**
+ * Recursively collect `.js` files under `rootDir`, skipping
+ * `node_modules`. Returns absolute paths, sorted for determinism.
+ *
+ * @param {string} rootDir
+ * @returns {string[]}
+ */
+export function collectJsFiles(rootDir) {
+  const out = [];
+  const walk = (dir) => {
+    let entries;
+    try {
+      entries = fs.readdirSync(dir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    for (const entry of entries) {
+      if (entry.name === 'node_modules') continue;
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        walk(full);
+      } else if (entry.isFile() && entry.name.endsWith('.js')) {
+        out.push(full);
+      }
+    }
+  };
+  walk(rootDir);
+  return out.sort();
+}
+
+const IMPORT_RE = /from\s+['"](\.\.?\/[^'"]+\.js)['"]/g;
+
+/**
+ * Pure helper: extract relative static-import specifiers from source text.
+ *
+ * @param {string} source
+ * @returns {string[]}
+ */
+export function parseRelativeImports(source) {
+  const specs = [];
+  for (const m of source.matchAll(IMPORT_RE)) {
+    specs.push(m[1]);
+  }
+  return specs;
+}
+
+/**
+ * Build a directed import graph over the given files. Node identity is the
+ * file path relative to `rootDir`, posix-separated, so the graph (and any
+ * cycles found in it) serializes identically across platforms. Edges that
+ * resolve outside the scanned file set are dropped.
+ *
+ * @param {string[]} files absolute paths
+ * @param {string} rootDir
+ * @param {{ readFile?: (p: string) => string }} [opts]
+ * @returns {Map<string, string[]>}
+ */
+export function buildGraph(files, rootDir, { readFile } = {}) {
+  const read = readFile ?? ((p) => fs.readFileSync(p, 'utf-8'));
+  const toId = (abs) => path.relative(rootDir, abs).split(path.sep).join('/');
+  const idSet = new Set(files.map(toId));
+  const graph = new Map();
+  for (const file of files) {
+    const id = toId(file);
+    let source;
+    try {
+      source = read(file);
+    } catch {
+      graph.set(id, []);
+      continue;
+    }
+    const edges = [];
+    for (const spec of parseRelativeImports(source)) {
+      const target = path
+        .relative(rootDir, path.resolve(path.dirname(file), spec))
+        .split(path.sep)
+        .join('/');
+      if (idSet.has(target) && target !== id) edges.push(target);
+    }
+    graph.set(id, [...new Set(edges)].sort());
+  }
+  return graph;
+}
+
+/**
+ * Build the whole-repository import graph by scanning the roots that exist
+ * under `cwd`. Returns `null` when none of the roots is present — the
+ * "no resolvable import graph" degradation every consumer must tolerate
+ * rather than treating an absent graph as a graph with no edges.
+ *
+ * @param {string} cwd repository root the ids are relativized against
+ * @param {{ roots?: string[] }} [opts]
+ * @returns {Map<string, string[]> | null}
+ */
+export function resolveRepoGraph(cwd, { roots = DEFAULT_ROOTS } = {}) {
+  const present = roots
+    .map((dir) => path.resolve(cwd, dir))
+    .filter((dir) => fs.existsSync(dir));
+  if (present.length === 0) return null;
+  const files = present.flatMap((dir) => collectJsFiles(dir));
+  if (files.length === 0) return null;
+  return buildGraph(files, path.resolve(cwd));
+}
+
+/**
+ * Count inbound edges per node. Nodes with no inbound edge are present in
+ * the result with a count of 0, so callers never have to distinguish
+ * "unknown module" from "module nothing imports".
+ *
+ * @param {Map<string, string[]> | null} graph
+ * @returns {Map<string, number>} empty when `graph` is null
+ */
+export function computeInDegree(graph) {
+  const degrees = new Map();
+  if (!graph) return degrees;
+  for (const node of graph.keys()) degrees.set(node, 0);
+  for (const edges of graph.values()) {
+    for (const target of edges) {
+      degrees.set(target, (degrees.get(target) ?? 0) + 1);
+    }
+  }
+  return degrees;
+}

--- a/.agents/scripts/lib/orchestration/check-baselines/phases/floors.js
+++ b/.agents/scripts/lib/orchestration/check-baselines/phases/floors.js
@@ -10,7 +10,18 @@
 
 import { EXIT_CONFIG } from '../../../baselines/exit-codes.js';
 
-function axisDirection(kind, axis) {
+/**
+ * Which way a floor axis is compared: `gte` means the measured value must be
+ * at or above the floor, `lte` at or below it. Exported (Story #4902) so the
+ * baseline hotspot engine reports floor headroom with the same polarity the
+ * gate enforces — a second copy of this table would let the two disagree
+ * about which direction is "better" for a given axis.
+ *
+ * @param {string} kind
+ * @param {string} axis
+ * @returns {'gte' | 'lte'}
+ */
+export function axisDirection(kind, axis) {
   if (kind === 'lint') return 'lte';
   if (kind === 'crap') return 'lte';
   if (kind === 'bundle-size') return 'lte';


### PR DESCRIPTION
Closes #4902

_Auto-opened by `/deliver`._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive tooling and tests with no changes to baseline gating behavior; arch-cycles refactor is a behavior-preserving move to a shared module.
> 
> **Overview**
> Adds **`audit-baselines.js`**, a read-only CLI for the `/audit-baselines` lens: it reads committed `baselines/` (never writes there or runs instruments), validates output against **`audit-baselines-envelope.schema.json`**, and writes a bounded JSON envelope to `--out`.
> 
> The engine assembles four evidence sections: **`gateSurface`** (per-kind health—missing baselines, stub instruments, staleness, dead `ignoreGlobs`), **`hotspots`** (top-N outliers per gate clustered by file, ranked by summed severity × git churn × import in-degree × friction), **`trend`** (newest-vs-previous rollup deltas from `git log`/`git show` on each baseline path), and **`headroom`** (configured floors vs measured rollups using exported **`axisDirection`** from `floors.js`).
> 
> Optional inputs (git history, import graph, friction ledger) **degrade** to neutral 1.0 rank multipliers and are flagged in the envelope; the CLI still exits **0** unless the output path cannot be written.
> 
> **`lib/import-graph.js`** is extracted from `check-arch-cycles.js` (re-exported there unchanged) so cycle detection and hotspot centrality share one graph. **`baseline-schema-registry.js`** registers the new envelope schema for AJV validation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6c32b6a7574913c9291f5a959fe9e0f0b64f04fb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->