### PR TITLE
feat: /audit-baselines lens: ratchet-tightening audit workflow over the committed baseline surface (#4903)

### DIFF
--- a/.agents/audit-checklists/baselines.md
+++ b/.agents/audit-checklists/baselines.md
@@ -1,0 +1,21 @@
+<!-- GENERATED FILE — do not edit by hand.
+     Source of truth: .agents/workflows/audit-baselines.md
+     Regenerate: node .agents/scripts/generate-lens-checklists.js
+     Drift is gated by: npm run docs:check
+-->
+
+# Baseline & Ratchet Audit — authoring checklist
+
+> Audit the committed baseline surface — dead instruments, stale baselines, cross-gate hotspot clusters, trend drift, and floor-tightening headroom — and emit findings whose remediation burns the measured debt down and tightens the ratchet behind it.
+
+Self-check your change against this lens's concerns before you ship:
+
+- [ ] `configError` non-null.
+- [ ] `degradations`.
+- [ ] Dead Instruments.
+- [ ] Staleness.
+- [ ] Hotspot Clusters.
+- [ ] Trend Drift.
+- [ ] Tightening Headroom.
+- [ ] Hotspot Cluster template
+- [ ] Tightening Headroom template

--- a/.agents/docs/workflows.md
+++ b/.agents/docs/workflows.md
@@ -32,12 +32,13 @@ by `node .agents/scripts/generate-workflows-doc.js`; `npm run docs:check`
 fails when it drifts from the on-disk workflow set. To change a command’s
 description, edit the workflow file’s front-matter and regenerate.
 
-## Commands (25)
+## Commands (26)
 
 | Command | Description |
 | --- | --- |
 | `/audit-accessibility` | Audit WCAG accessibility conformance (static-first) with an optional runtime verification pass, and produce a structured findings report |
 | `/audit-architecture` | Audit architectural boundaries, module coupling, layering violations, and shipped-but-uncalled seams; emit a structured findings report keyed to the canonical severity scale. |
+| `/audit-baselines` | Audit the committed baseline surface — dead instruments, stale baselines, cross-gate hotspot clusters, trend drift, and floor-tightening headroom — and emit findings whose remediation burns the measured debt down and tightens the ratchet behind it. |
 | `/audit-clean-code` | Audit code smells, dead code, complexity hotspots, and maintainability-index outliers; emit a structured findings report. |
 | `/audit-data-model` | Audit the persistence layer as a first-class artifact — model↔migration↔seed drift, constraint completeness, migration hygiene, type fidelity, and access-pattern fit; gated by a persistence-layer applicability probe so DB-less repos skip cleanly. |
 | `/audit-dependencies` | Audit `package.json` for unused, outdated, and major-version-stale dependencies; surface Node-engine drift and propose upgrade batches. |

--- a/.agents/schemas/audit-rules.json
+++ b/.agents/schemas/audit-rules.json
@@ -167,6 +167,21 @@
       "scope": "cumulative",
       "substitutionKeys": []
     },
+    "audit-baselines": {
+      "triggers": {
+        "gates": ["gate3"],
+        "keywords": [
+          "baseline",
+          "ratchet",
+          "floor",
+          "headroom",
+          "quality gate"
+        ],
+        "filePatterns": ["baselines/**", ".agentrc.json"]
+      },
+      "scope": "cumulative",
+      "substitutionKeys": []
+    },
     "audit-documentation": {
       "triggers": {
         "gates": ["gate1", "gate3"],

--- a/.agents/scripts/lib/audit-to-stories/audit-lenses.js
+++ b/.agents/scripts/lib/audit-to-stories/audit-lenses.js
@@ -27,6 +27,7 @@
 export const AUDIT_LENSES = Object.freeze([
   'accessibility',
   'architecture',
+  'baselines',
   'clean-code',
   'data-model',
   'dependencies',

--- a/.agents/scripts/update-coverage-baseline.js
+++ b/.agents/scripts/update-coverage-baseline.js
@@ -1,5 +1,4 @@
 #!/usr/bin/env node
-// cli-opt-out: top-level main()-driven CLI invoked via npm run coverage:update; no runAsCli() wrapper required.
 /**
  * Refresh `baselines/coverage.json` from the most recent
  * `coverage/coverage-final.json`. Run this when you intentionally add,
@@ -29,7 +28,34 @@ import {
   readCoverageFinal,
   scoreCoverageFinal,
 } from './lib/coverage-baseline.js';
+import { runAsCli } from './lib/cli-utils.js';
 import { Logger } from './lib/Logger.js';
+
+/**
+ * Usage block for `--help`. This CLI *writes* on invocation, so the help
+ * branch must short-circuit before `main` runs rather than inside it —
+ * `runAsCli` answers help first, which makes "a usage probe never mutates a
+ * baseline" structural instead of a check `main` has to remember.
+ */
+const USAGE = {
+  invocation:
+    'node .agents/scripts/update-coverage-baseline.js [--full-scope | --diff-scope <ref>]',
+  summary:
+    'Score → write the coverage baseline from the coverage-final.json already on disk. With no scope flag the refresh is scoped to the files changed in `origin/main..HEAD`; out-of-scope rows are preserved verbatim.',
+  flags: [
+    [
+      '--full-scope',
+      'Rescore every file in every target dir (no out-of-scope merge).',
+    ],
+    [
+      '--diff-scope <ref>',
+      'Scope the refresh to files changed between <ref> and HEAD. Incompatible with --full-scope.',
+    ],
+  ],
+  notes: [
+    'Run `npm run test:coverage` first — this script never runs the suite itself.',
+  ],
+};
 
 const require = createRequire(import.meta.url);
 
@@ -123,7 +149,11 @@ function main() {
   });
 }
 
-main().catch((err) => {
-  Logger.error(`[Coverage] ❌ Fatal error: ${err?.message ?? err}`);
-  process.exit(1);
+runAsCli(import.meta.url, main, {
+  source: 'coverage-baseline',
+  usage: USAGE,
+  onError: (err) => {
+    Logger.error(`[Coverage] ❌ Fatal error: ${err?.message ?? err}`);
+    process.exitCode = 1;
+  },
 });

--- a/.agents/scripts/update-coverage-baseline.js
+++ b/.agents/scripts/update-coverage-baseline.js
@@ -21,6 +21,7 @@ import { createRequire } from 'node:module';
 import path from 'node:path';
 import { parseDiffScopeFlag } from './lib/baselines/diff-scope-cli.js';
 import { refreshBaseline } from './lib/baselines/refresh-service.js';
+import { runAsCli } from './lib/cli-utils.js';
 import { getBaselineEpsilon } from './lib/config/quality.js';
 import {
   buildScopePredicate,
@@ -28,7 +29,6 @@ import {
   readCoverageFinal,
   scoreCoverageFinal,
 } from './lib/coverage-baseline.js';
-import { runAsCli } from './lib/cli-utils.js';
 import { Logger } from './lib/Logger.js';
 
 /**

--- a/.agents/scripts/update-duplication-baseline.js
+++ b/.agents/scripts/update-duplication-baseline.js
@@ -7,8 +7,8 @@ import path from 'node:path';
 import { buildWriterScopeArgs } from './lib/baselines/diff-scope-cli.js';
 import { scanDuplication } from './lib/baselines/duplication-scanner.js';
 import { write, writeFile } from './lib/baselines/writer.js';
-import { getBaselineEpsilon } from './lib/config/quality.js';
 import { runAsCli } from './lib/cli-utils.js';
+import { getBaselineEpsilon } from './lib/config/quality.js';
 import { getQuality, resolveConfig } from './lib/config-resolver.js';
 import { Logger } from './lib/Logger.js';
 

--- a/.agents/scripts/update-duplication-baseline.js
+++ b/.agents/scripts/update-duplication-baseline.js
@@ -8,8 +8,39 @@ import { buildWriterScopeArgs } from './lib/baselines/diff-scope-cli.js';
 import { scanDuplication } from './lib/baselines/duplication-scanner.js';
 import { write, writeFile } from './lib/baselines/writer.js';
 import { getBaselineEpsilon } from './lib/config/quality.js';
+import { runAsCli } from './lib/cli-utils.js';
 import { getQuality, resolveConfig } from './lib/config-resolver.js';
 import { Logger } from './lib/Logger.js';
+
+/**
+ * Usage block for `--help`. This CLI *writes* on invocation, so the help
+ * branch must short-circuit before `main` runs rather than inside it —
+ * `runAsCli` answers help first, which makes "a usage probe never mutates a
+ * baseline" structural instead of a check `main` has to remember.
+ */
+const USAGE = {
+  invocation:
+    'node .agents/scripts/update-duplication-baseline.js [--baseline <path>] [--full-scope | --diff-scope <ref>]',
+  summary:
+    'Scan → score → write the code-duplication (DRY) baseline. With no scope flag the refresh is scoped to the files changed in `origin/main..HEAD`; out-of-scope rows are preserved verbatim.',
+  flags: [
+    [
+      '--baseline <path>',
+      'Write to this path instead of `delivery.quality.gates.duplication.baselinePath`.',
+    ],
+    [
+      '--full-scope',
+      'Rescan every file in every target dir (no out-of-scope merge).',
+    ],
+    [
+      '--diff-scope <ref>',
+      'Scope the refresh to files changed between <ref> and HEAD. Incompatible with --full-scope.',
+    ],
+  ],
+  notes: [
+    'Backed by jscpd; the scan reads the working tree and runs no test suite.',
+  ],
+};
 
 /**
  * CLI: scan → score → save the code-duplication (DRY) baseline (Story #3664).
@@ -125,10 +156,13 @@ async function main() {
   );
 }
 
-// cli-opt-out: top-level main().catch predates runAsCli; never imported elsewhere so the auto-run risk is moot.
-main().catch((err) => {
-  Logger.error(
-    `[Duplication] ❌ Fatal error: ${err?.stack ?? err?.message ?? err}`,
-  );
-  process.exit(1);
+runAsCli(import.meta.url, main, {
+  source: 'duplication-baseline',
+  usage: USAGE,
+  onError: (err) => {
+    Logger.error(
+      `[Duplication] ❌ Fatal error: ${err?.stack ?? err?.message ?? err}`,
+    );
+    process.exitCode = 1;
+  },
 });

--- a/.agents/workflows/audit-baselines.md
+++ b/.agents/workflows/audit-baselines.md
@@ -1,0 +1,264 @@
+---
+description: Audit the committed baseline surface — dead instruments, stale baselines, cross-gate hotspot clusters, trend drift, and floor-tightening headroom — and emit findings whose remediation burns the measured debt down and tightens the ratchet behind it.
+---
+
+# Baseline & Ratchet Audit
+
+You are a Principal Engineer and Quality-Systems Owner auditing this
+repository's **committed baseline surface**: the ratchet artifacts under
+`baselines/` and the gate floors under `delivery.quality.gates` in
+`.agentrc.json`. Those instruments only prevent **regression** — nothing owns
+the loop that burns the measured debt **down** and tightens the floors behind
+it, so a repo can hold a floor it cleared years ago and never notice. This lens
+is that loop's read-only entry point. The shared lens machinery — read-only
+constraint, scope interpretation, report envelope + finding-block skeleton,
+severity scale, self-cross-check, and execution strategy — lives in
+[`helpers/audit-lens-core.md`](helpers/audit-lens-core.md). Write the report to
+`{{auditOutputDir}}/audit-baselines-results.md`. Dimension values:
+`Dead Instrument | Staleness | Hotspot Cluster | Trend Drift | Tightening Headroom`.
+
+> **Value-free titles (mandatory).** A finding title MUST NOT embed a measured
+> number — write ``### `baselines/crap.json` — crap floor holds unused slack``,
+> not ``… — crap floor 13 vs measured 8``. Every re-run re-measures, so a title
+> carrying the reading changes each pass, its fingerprint changes with it, and
+> `/audit-to-stories` files a duplicate instead of deduping against the open
+> Story. Numbers belong in Current State, never in the title.
+
+## Scope
+
+Interpret this lens's change-set fence per the core's Scope interpretation:
+
+```text
+{{changedFiles}}
+```
+
+When the fence resolves to a file list, keep only Hotspot Cluster findings
+whose cluster key is in that list. The other four dimensions are properties of
+the instrument set as a whole rather than of any changed file, so report them
+only in codebase-wide mode.
+
+## Constraint (lens-specific carve-out)
+
+This lens **refines** the core's read-only constraint; it never relaxes it.
+
+- The only command it runs is the read-only engine in Step 0. It never runs a
+  test, coverage, mutation, duplication, or lint suite.
+- It never writes under `baselines/` and never edits `.agentrc.json`. It never
+  invokes an `update-*-baseline` script. **Regeneration is a finding, never an
+  in-run step** — the remediation Story owns every write to the surface.
+- Reading committed baseline rows is explicitly permitted and required: citing
+  an already-computed metric is analysis, not measurement.
+
+## Execution strategy
+
+Run this lens as a single `subagent_type: auditor` dispatch returning the report
+path + Executive Summary; sequential inline execution is the fallback (see the
+core's Execution strategy).
+
+## Step 0: Run the engine (mandatory — measure before you judge)
+
+```bash
+node .agents/scripts/audit-baselines.js --out temp/audit-baselines/envelope.json
+```
+
+Optional flags: `--cwd` (repository root), `--top-n` (outlier rows per gate,
+default 20), `--hotspot-limit` (clusters emitted, default 50), `--trend-depth`
+(baseline commits sampled per kind, default 5). Exit 0 means evidence was
+assembled **including every degraded input**; exit 1 means the envelope could
+not be built or written — report that and stop, because no evidence base
+exists to author against.
+
+The envelope is validated against
+`.agents/schemas/baselines/audit-baselines-envelope.schema.json` and is this
+lens's sole evidence base. Cite its fields by name:
+
+| Section | Fields you cite |
+| --- | --- |
+| root | `generatedAt`, `cwd`, `topN`, `configError`, `degradations` |
+| `gateSurface[]` | `kind`, `surface`, `baselinePath`, `configured`, `baselineExists`, `stub`, `rowCount`, `generatedAt`, `staleDays`, `deadIgnoreGlobs`, `parseError` |
+| `hotspots[]` | `path`, `gates` (each `kind`, `metric`, `value`, `rowCount`, `severityWeight`), `gateKinds`, `gateCount`, `severityWeight`, `churnWeight`, `centralityWeight`, `frictionWeight`, `rank` |
+| `trend[]` | `kind`, `baselinePath`, `sampleCount`, `from`, `to` (each a `sha` plus `committedAt`), `deltas` |
+| `headroom[]` | `kind`, `axis`, `floor`, `measured`, `direction`, `headroom` |
+
+`surface` is `gate` (a closed `delivery.quality.gates` kind) or `ratchet` (an
+out-of-band baseline the CI baselines job owns). `direction` is `gte` or `lte`.
+
+Two envelope-level reads come **before** any finding:
+
+- **`configError` non-null.** Floors, target directories, and ignore globs
+  were unavailable and the engine fell back to default baseline paths. Every
+  Tightening Headroom finding would be unfounded this run: file the config
+  failure itself as one `Dead Instrument` finding and skip that dimension.
+- **`degradations`.** Each of `gitHistory`, `importGraph`, `frictionLedger`
+  reading `true` collapsed its rank multiplier to exactly 1.0, so the hotspot
+  ordering is weaker evidence. Name the degraded inputs in the Executive
+  Summary; never present a degraded rank as a churn-informed one.
+
+## Step 1: Evaluation Dimensions
+
+1. **Dead Instruments.** An instrument that cannot fail is worse than none: it
+   reads green forever and the surface it names looks governed. Four shapes,
+   read straight off `gateSurface[]`:
+   - `stub` is `true` — zero rows **and** an all-zero rollup, so the gate
+     passes vacuously. The engine requires both halves, so a ratchet with
+     genuinely nothing to report is never mistaken for a dead one.
+   - `configured` is `false` on a `gate` row — a baseline is committed but no
+     `delivery.quality.gates` block enforces it, so nothing reads it.
+   - `baselineExists` is `false`, or `parseError` is non-null — the instrument
+     cannot be read at all.
+   - `deadIgnoreGlobs` is non-empty — a configured ignore pattern matches zero
+     files. It protects nothing today and silently exempts the next file that
+     happens to match it.
+
+   Grade a stub or unenforced gate **Medium**, a `parseError` on an enforced
+   gate **High** (delivery reads that file every run), a dead glob **Low**.
+
+2. **Staleness.** `staleDays` is whole days since the baseline's own
+   `generatedAt`. A `null` is never a fabricated zero — it means the stamp is
+   absent or unparseable, which is itself the finding. Grade an enforced gate
+   stale beyond roughly a month **Medium**, a `null` stamp **Medium**, an
+   unenforced kind **Low** or **Info**.
+
+   **Regeneration is the remediation, never an in-run step.** The Agent Prompt
+   names the matching script and its one-shot acknowledgment:
+
+   | Kind | Regeneration script | Acknowledgment |
+   | --- | --- | --- |
+   | `coverage` | `.agents/scripts/update-coverage-baseline.js` | `COVERAGE_REFRESH=1` |
+   | `crap` | `.agents/scripts/update-crap-baseline.js` | `CRAP_REFRESH=1` |
+   | `duplication` | `.agents/scripts/update-duplication-baseline.js` | `DUPLICATION_REFRESH=1` |
+   | `maintainability` | `.agents/scripts/update-maintainability-baseline.js` | `MAINTAINABILITY_REFRESH=1` |
+
+   The acknowledgment is the kind upper-snaked. It demotes that kind's
+   head-vs-base regressions to unchanged **for one run only** — floors stay
+   enforced, so a genuine breach is still caught. The durable equivalent is a
+   commit in the compared range whose subject carries the gate's `refreshTag`
+   (default `baseline-refresh:`) **and** whose diff touches that kind's
+   baseline file. Confirm both against
+   `node .agents/scripts/check-baselines.js --help` before writing the prompt,
+   and never invent an acknowledgment for a kind that ships no regeneration
+   script — there, the remediation is to add one, not to hand-edit rows.
+
+3. **Hotspot Clusters.** `hotspots[]` is already the cross-gate join, one entry
+   per cluster key, ranked highest first. **Emit one finding per cluster —
+   never one per metric row.** A file that is a CRAP outlier and a
+   maintainability outlier is one debt item with two symptoms; splitting it
+   files two Stories that fight over the same refactor. The cluster key is a
+   repository file path for every kind except `lighthouse` (a route) and
+   `bundle-size` (a bundle name) — say which it is when it is not a file.
+
+   Quote `rank` with the four factors behind it — `severityWeight`,
+   `churnWeight`, `centralityWeight`, `frictionWeight` — and the per-gate rows
+   under `gates`. Grade by breadth first: three or more entries in `gateKinds`
+   is **High**, two is **Medium**, one is **Low** unless its `severityWeight`
+   alone is extreme.
+
+4. **Trend Drift.** `trend[]` carries newest-versus-previous rollup deltas per
+   kind, bracketed by the commits in `from` and `to`. A delta moving **away**
+   from the floor is the finding; one moving toward it is headroom the next
+   dimension owns. Read the axis's `direction` in `headroom[]` before assigning
+   a sign — lower is not universally better. An entry needs `sampleCount` of at
+   least 2 to mean anything, and an empty `trend[]` means no readable history:
+   record that as **Info** rather than inferring a flat trend from silence.
+
+5. **Tightening Headroom.** `headroom[]` is what this lens exists for. Positive
+   headroom is slack the floor could be tightened into; negative headroom means
+   the floor is already breached — grade that **High** and route it as a
+   regression, not an opportunity. File a tightening finding only when the
+   slack is **durable**: the same kind's trend is flat or improving. A one-run
+   dip tightened into a floor turns the next honest change red for no defect.
+   Grade durable multi-point slack **Medium**, marginal slack **Low**.
+
+## Step 2: Hotspot budget and the dropped log
+
+Cap the Detailed Findings at the **top 8 hotspot clusters by `rank`**. The
+engine emits up to `--hotspot-limit` clusters, and the point of the lens is a
+ranked actionable batch, not an exhaustive dump nobody schedules.
+
+A silent truncation reads as full coverage, so the report MUST carry a
+**Dropped Hotspots** section naming every cluster the cap excluded with its
+cluster key, `rank`, and `gateKinds`. Write `_None dropped._` when the cap did
+not bite; the section's absence is itself a defect. This budget log is separate
+from — and additional to — the core's self-cross-check `kept / dropped` line,
+which counts evidence-bar drops rather than budget drops. State the cap in the
+Executive Summary and change it only on an explicit operator instruction.
+
+## Step 3: The floor-tightening contract (mandatory)
+
+A remediation Story that only burns debt down leaves the floor where it was,
+and the reclaimed slack is silently re-spent by the next change — the loop
+runs and the ratchet never moves. So **every Hotspot Cluster and Tightening
+Headroom finding's Agent Prompt MUST** end the remediation with the ratchet
+tightened and gate-enforced:
+
+1. Lower the floor under `delivery.quality.gates` in `.agentrc.json` to the
+   newly measured level, **or** delete the burnt-down rows from that kind's
+   file under `baselines/`.
+2. Carry `node .agents/scripts/check-baselines.js --gate <kind>` in the
+   remediation Story's `verify[]`, so the tightened floor is enforced by the
+   gate that already exists at that Story's delivery time rather than by prose
+   nobody runs.
+
+Use these two Agent Prompt templates verbatim, substituting the envelope's own
+values for the angle-bracketed slots:
+
+- **Hotspot Cluster template:**
+  `Burn down the measured debt in <hotspots.path>, an outlier across <gateKinds>. Refactor and add tests until its rows leave that kind's file under baselines/, then regenerate that baseline with the matching update-*-baseline script in a commit whose subject carries the baseline-refresh: tag. Finish by TIGHTENING the ratchet in the same Story — lower the kind's floor under delivery.quality.gates in .agentrc.json to the new measured level, or delete the burnt-down rows — and carry node .agents/scripts/check-baselines.js --gate <kind> in this Story's verify[] so the tightened floor is enforced at delivery.`
+- **Tightening Headroom template:**
+  `The <kind> gate's <axis> floor sits at <floor> while the measured rollup is <measured> (headroom <headroom>, direction <direction>), and that kind's trend is flat or improving. Tighten it: set that axis under delivery.quality.gates in .agentrc.json to the measured level so no slack remains for the next change to re-spend, and carry node .agents/scripts/check-baselines.js --gate <kind> in this Story's verify[] so the new floor is enforced. Regenerate no baseline in this Story — the floor edit is the whole change.`
+
+Staleness, Dead Instrument, and Trend Drift findings do **not** carry the
+tightening clause: there is no measured slack to claim until the instrument is
+alive and current again.
+
+## Step 4: Cadence (host-owned — documented, never scheduled)
+
+This lens ships **no scheduler**, and building one is out of scope; cadence
+belongs to the host that invokes it. Document the intent and let the operator
+or the host's own timer drive it: **monthly** for a codebase-wide pass (long
+enough for `trend[]` to hold signal, short enough to catch a stale instrument
+before a release leans on it); **after a large refactor lands**, when headroom
+appears and is most likely to be silently re-spent; and **before any floor is
+raised**, so the raise is argued against measured headroom rather than
+convenience. Nothing here self-triggers.
+
+## Step 5: Hand off to `/audit-to-stories`
+
+The report is the deliverable. Hand it to the converter, which parses the
+shared finding skeleton, fingerprints each finding for dedupe, and groups the
+batch:
+
+```bash
+node .agents/scripts/audit-to-stories.js --scan --glob temp/audits/audit-baselines-results.md --out temp/audits/audit-to-stories-plan.json
+```
+
+Report the plan path and the group count; the converter owns everything
+downstream, including whether a finding becomes a Story at all.
+
+## Report additions
+
+Beyond the shared skeleton (Executive Summary + Detailed Findings from the
+core), this report carries its own title, a Gate Surface Health table, a
+Tightening Ledger, and the Dropped Hotspots budget log:
+
+```markdown
+# Baseline & Ratchet Audit Report
+
+## Gate Surface Health
+
+| Kind | Surface | Configured | Rows | Stale (days) | Verdict |
+| --- | --- | --- | --- | --- | --- |
+| [kind] | [gate / ratchet] | [yes / no] | [rowCount] | [staleDays or `null`] | [Live / Stub / Unenforced / Unreadable] |
+
+## Tightening Ledger
+
+| Kind | Axis | Floor | Measured | Headroom | Trend | Proposed floor |
+| --- | --- | --- | --- | --- | --- | --- |
+| [kind] | [axis] | [floor] | [measured] | [headroom] | [improving / flat / worsening] | [value] |
+
+## Dropped Hotspots
+
+| Cluster key | Rank | Gates |
+| --- | --- | --- |
+| [key] | [rank] | [gateKinds] |
+```

--- a/baselines/context-budget.json
+++ b/baselines/context-budget.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://mandrel.dev/baselines/context-budget.schema.json",
-  "generatedAt": "2026-08-01T19:19:17.616Z",
+  "generatedAt": "2026-08-02T01:58:36.417Z",
   "toleranceBytes": 2048,
   "tiers": {
     "alwaysLoaded": {
@@ -54,7 +54,7 @@
       ]
     },
     "workflow": {
-      "totalBytes": 232463,
+      "totalBytes": 248558,
       "files": [
         {
           "path": ".agents/workflows/audit-accessibility.md",
@@ -63,6 +63,10 @@
         {
           "path": ".agents/workflows/audit-architecture.md",
           "bytes": 17387
+        },
+        {
+          "path": ".agents/workflows/audit-baselines.md",
+          "bytes": 14821
         },
         {
           "path": ".agents/workflows/audit-clean-code.md",
@@ -134,11 +138,11 @@
         },
         {
           "path": ".agents/workflows/helpers/deliver-digest.md",
-          "bytes": 6657
+          "bytes": 7580
         },
         {
           "path": ".agents/workflows/helpers/deliver-story.md",
-          "bytes": 7378
+          "bytes": 7729
         },
         {
           "path": ".agents/workflows/mandrel-update.md",
@@ -193,7 +197,7 @@
     ]
   },
   "workflowClosure": {
-    "reachableTotalBytes": 406898,
+    "reachableTotalBytes": 424186,
     "entryPoints": [
       {
         "path": ".agents/workflows/audit-accessibility.md",
@@ -204,6 +208,11 @@
         "path": ".agents/workflows/audit-architecture.md",
         "mandatoryBytes": 17387,
         "reachableBytes": 48922
+      },
+      {
+        "path": ".agents/workflows/audit-baselines.md",
+        "mandatoryBytes": 14821,
+        "reachableBytes": 33932
       },
       {
         "path": ".agents/workflows/audit-clean-code.md",
@@ -228,7 +237,7 @@
       {
         "path": ".agents/workflows/audit-documentation.md",
         "mandatoryBytes": 11889,
-        "reachableBytes": 205828
+        "reachableBytes": 208295
       },
       {
         "path": ".agents/workflows/audit-navigability.md",
@@ -268,7 +277,7 @@
       {
         "path": ".agents/workflows/audit-to-stories.md",
         "mandatoryBytes": 14506,
-        "reachableBytes": 193939
+        "reachableBytes": 196406
       },
       {
         "path": ".agents/workflows/audit-ux-ui.md",
@@ -278,7 +287,7 @@
       {
         "path": ".agents/workflows/deliver.md",
         "mandatoryBytes": 7300,
-        "reachableBytes": 193939
+        "reachableBytes": 196406
       },
       {
         "path": ".agents/workflows/git-cleanup.md",
@@ -288,12 +297,12 @@
       {
         "path": ".agents/workflows/git-deliver.md",
         "mandatoryBytes": 7640,
-        "reachableBytes": 218704
+        "reachableBytes": 221171
       },
       {
         "path": ".agents/workflows/helpers/deliver-story.md",
-        "mandatoryBytes": 14035,
-        "reachableBytes": 193939
+        "mandatoryBytes": 15309,
+        "reachableBytes": 196406
       },
       {
         "path": ".agents/workflows/mandrel-update.md",
@@ -303,27 +312,27 @@
       {
         "path": ".agents/workflows/plan.md",
         "mandatoryBytes": 7367,
-        "reachableBytes": 193939
+        "reachableBytes": 196406
       },
       {
         "path": ".agents/workflows/prototype.md",
         "mandatoryBytes": 5148,
-        "reachableBytes": 193939
+        "reachableBytes": 196406
       },
       {
         "path": ".agents/workflows/qa-assist.md",
         "mandatoryBytes": 16561,
-        "reachableBytes": 258839
+        "reachableBytes": 261306
       },
       {
         "path": ".agents/workflows/qa-explore.md",
         "mandatoryBytes": 13422,
-        "reachableBytes": 258839
+        "reachableBytes": 261306
       },
       {
         "path": ".agents/workflows/qa-run.md",
         "mandatoryBytes": 13618,
-        "reachableBytes": 258839
+        "reachableBytes": 261306
       }
     ]
   }

--- a/tests/audit-suite/resolve-lens-tier.test.js
+++ b/tests/audit-suite/resolve-lens-tier.test.js
@@ -6,10 +6,11 @@
  *   - `resolveLensTier` (imported from the audit-suite SDK barrel) returns one
  *     of `local | cumulative | global` for every lens registered in
  *     `audit-rules.json`, and throws on an unknown lens.
- *   - `audit-rules.json` declares a scope on all 15 lenses (including
+ *   - `audit-rules.json` declares a scope on all 16 lenses (including
  *     `audit-sre`, re-homed from the dead gate4-only state to gate3 with ops
- *     filePatterns by Story #4629, and `audit-data-model`, the persistence
- *     lens added by Story #4633) and no longer carries `alwaysRun`.
+ *     filePatterns by Story #4629, `audit-data-model`, the persistence lens
+ *     added by Story #4633, and `audit-baselines`, the ratchet-tightening
+ *     lens) and no longer carries `alwaysRun`.
  *   - `audit-rules.schema.json` requires the `scope` enum and no longer
  *     permits `alwaysRun` (a fixture rule carrying it fails validation).
  */
@@ -55,6 +56,7 @@ const EXPECTED_TIERS = {
   'audit-ux-ui': 'local',
   'audit-seo': 'local',
   'audit-architecture': 'cumulative',
+  'audit-baselines': 'cumulative',
   'audit-dependencies': 'cumulative',
   'audit-devops': 'cumulative',
   'audit-documentation': 'cumulative',
@@ -67,11 +69,11 @@ test('LENS_TIERS is the frozen local|cumulative|global tuple', () => {
   assert.ok(Object.isFrozen(LENS_TIERS), 'LENS_TIERS must be frozen');
 });
 
-test('audit-rules.json registers all 15 lenses, each with a scope in the enum', () => {
+test('audit-rules.json registers all 16 lenses, each with a scope in the enum', () => {
   assert.equal(
     LENS_KEYS.length,
-    15,
-    `expected 15 registered lenses, got ${LENS_KEYS.length}: ${LENS_KEYS.join(', ')}`,
+    16,
+    `expected 16 registered lenses, got ${LENS_KEYS.length}: ${LENS_KEYS.join(', ')}`,
   );
   for (const lens of LENS_KEYS) {
     const { scope } = rules.audits[lens];

--- a/tests/enforcement/workflow-script-help.test.js
+++ b/tests/enforcement/workflow-script-help.test.js
@@ -198,15 +198,17 @@ describe('workflow-invoked scripts are self-describing', () => {
 });
 
 /**
- * Story #4872 — the baseline updaters are not referenced from any workflow
- * document, so the derived adoption set above never covered them, and both
- * performed a real baseline write when asked for their usage. They are named
- * explicitly here because for a CLI whose whole job is to mutate, "a usage
- * probe leaves the artifact byte-identical" is the load-bearing half of the
- * contract, not an incidental one.
+ * Story #4872 — the baseline updaters performed a real baseline write when
+ * asked for their usage. They are named explicitly here (rather than left to
+ * the derived adoption set above) because for a CLI whose whole job is to
+ * mutate, "a usage probe leaves the artifact byte-identical" is the
+ * load-bearing half of the contract, not an incidental one — and the derived
+ * set only covers them for as long as some workflow happens to cite them.
  */
 const MUTATING_UPDATERS = [
+  'update-coverage-baseline.js',
   'update-crap-baseline.js',
+  'update-duplication-baseline.js',
   'update-maintainability-baseline.js',
 ];
 


### PR DESCRIPTION
Closes #4903

_Auto-opened by `/deliver`._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are mostly agent workflows, audit routing metadata, and CLI help handling; no production runtime or auth paths are modified.
> 
> **Overview**
> Adds **`/audit-baselines`**, a cumulative gate3 audit lens that runs the read-only `audit-baselines.js` engine and turns envelope evidence into structured findings (dead instruments, staleness, cross-gate hotspots, trend drift, floor headroom), with mandatory **ratchet-tightening** agent prompts for hotspot and headroom remediations.
> 
> Wiring includes a new workflow (`.agents/workflows/audit-baselines.md`), generated checklist and workflows index entry, **`audit-baselines`** in `audit-rules.json` (triggers on `baselines/**` and `.agentrc.json`), **`baselines`** in `AUDIT_LENSES`, and test updates for **16 lenses** with `audit-baselines` as **cumulative**.
> 
> **Coverage** and **duplication** baseline updaters now use **`runAsCli`** with explicit **`USAGE`** so `--help` exits before `main` and does not write baselines; enforcement tests extend **`MUTATING_UPDATERS`** to include those two scripts. **`baselines/context-budget.json`** is refreshed for the new workflow bytes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit caffd646c6b05a30681b84c36139a32bc4732dd8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->