### PR TITLE
fix: stop check-baselines silently disabling its compare arm when the base baseline cannot be read (#4914)

### DIFF
--- a/.agents/scripts/lib/baselines/git-base.js
+++ b/.agents/scripts/lib/baselines/git-base.js
@@ -29,10 +29,15 @@
 //     loader treats this as a normal "no baseline at base ref" case
 //     and returns `null`. Callers branch on `result === null` rather
 //     than catching an error.
-//   - Any other non-zero exit (bad ref, corrupted repo, git binary
-//     missing): rethrown so the dispatcher can surface a config-error
-//     exit code rather than silently treating the failure as "no
-//     baseline". A bad ref is a config bug, not a missing file.
+//   - Any other outcome (bad ref, corrupted repo, git binary missing, or
+//     the child killed by signal so `status` is `null`): thrown so the
+//     dispatcher can surface a config-error exit code rather than
+//     silently treating the failure as "no baseline". A bad ref is a
+//     config bug, not a missing file.
+//
+// That two-way split is load-bearing (Story #4914): `null` means and only
+// means "path absent at ref". Callers may therefore treat a throw as a
+// hard failure without having to re-diagnose it.
 
 import { spawnSync } from 'node:child_process';
 
@@ -46,6 +51,21 @@ import { spawnSync } from 'node:child_process';
 // ---------------------------------------------------------------------------
 
 const DEFAULT_MAX_ENTRIES = 64;
+
+/**
+ * Story #4914 — explicit stdout ceiling for every git read in this module.
+ *
+ * `child_process.spawnSync` defaults `maxBuffer` to 1 MB. A committed
+ * baseline legitimately grows past that (a real consumer's crap baseline
+ * measured 1,178,910 bytes), at which point the child is killed —
+ * `status: null`, `signal: 'SIGTERM'`, `error.code: 'ENOBUFS'` — and the
+ * read fails for a reason that has nothing to do with the repository.
+ *
+ * 64 MB is not a new number: it is the bound already used at
+ * `run-test-profile.js:87`, `audit-baselines/trend.js:61` and
+ * `audit-baselines/weights.js:65`. This module was the outlier.
+ */
+const MAX_BUFFER_BYTES = 64 * 1024 * 1024;
 
 let _spawnSync = spawnSync;
 let _cache = new Map();
@@ -165,6 +185,7 @@ export function readBaseFromGit(ref, file, opts = {}) {
     encoding: 'utf-8',
     shell: false,
     env: cleanGitEnv(),
+    maxBuffer: MAX_BUFFER_BYTES,
   });
 
   // `child_process.spawnSync` returns `status: null` when the child died
@@ -232,6 +253,7 @@ export function readRangeSubjectsTouchingFile(baseRef, file, opts = {}) {
         encoding: 'utf-8',
         shell: false,
         env: cleanGitEnv(),
+        maxBuffer: MAX_BUFFER_BYTES,
       },
     );
   } catch {

--- a/.agents/scripts/lib/orchestration/check-baselines/phases/compare.js
+++ b/.agents/scripts/lib/orchestration/check-baselines/phases/compare.js
@@ -9,6 +9,7 @@
  * @module lib/orchestration/check-baselines/phases/compare
  */
 
+import { EXIT_CONFIG } from '../../../baselines/exit-codes.js';
 import { readBaseFromGit } from '../../../baselines/git-base.js';
 import { getKindModule } from '../../../baselines/kernel.js';
 import { resolveScope } from '../../../baselines/scope.js';
@@ -41,13 +42,44 @@ function emptyCompareResult(baseRef) {
   return { baseRef, baseRead: false };
 }
 
+/**
+ * Story #4914 — a base read that FAILS is not a base that is ABSENT.
+ *
+ * `readBaseFromGit` already draws that line itself: it returns `null` only
+ * for git exit 128 ("path does not exist in this revision") and throws on
+ * everything else. Swallowing the throw conflated the two, so a broken read
+ * silently emptied the whole head-vs-base arm — regressions AND additions —
+ * while the floors arm kept the run at exit 0. A gate that fails open is
+ * worse than no gate, because it is trusted.
+ *
+ * So the read failure fails CLOSED as `EXIT_CONFIG` (3) — "the gate could
+ * not even start", the same code `assertFloorAxesExist` uses for a
+ * misconfigured floor axis. `check-baselines.js#main` maps any throw out of
+ * the pipeline onto that code.
+ */
+function buildBaseReadError({ kind, ref, file, cause }) {
+  const detail = cause?.message ?? String(cause);
+  const err = new Error(
+    `[check-baselines:${kind}] could not read the base baseline at ` +
+      `${ref}:${file} — the head-vs-base compare arm cannot run, so the gate ` +
+      `fails closed rather than reporting zero regressions: ${detail}`,
+  );
+  err.code = 'EXIT_CONFIG';
+  err.exitCode = EXIT_CONFIG;
+  err.kind = kind;
+  err.baseRef = ref;
+  err.baselinePath = file;
+  err.cause = cause;
+  return err;
+}
+
 function readBaseBaselinePayload(scope, kind, gateBlock, cwd) {
   const rel = baselineRelativePath(kind, gateBlock);
   let raw;
   try {
     raw = readBaseFromGit(scope.ref, rel, { cwd });
-  } catch {
-    return null;
+  } catch (cause) {
+    throw buildBaseReadError({ kind, ref: scope.ref, file: rel, cause });
   }
   if (raw === null) return null;
   try {

--- a/.agents/scripts/lib/orchestration/check-baselines/phases/evaluate.js
+++ b/.agents/scripts/lib/orchestration/check-baselines/phases/evaluate.js
@@ -206,6 +206,11 @@ function buildGateReport({
     additions: compareOutput.additions ?? [],
     regressionCount: compareOutput.regressions.length,
     baseRef: cmp.baseRef ?? null,
+    // Story #4914 — the compare arm's read status was internal to compare.js,
+    // which is why a dead compare arm looked byte-identical to a clean run.
+    // Surfacing it makes "the head-vs-base arm did not run" diagnosable from
+    // the JSON report alone.
+    baseRead: cmp.baseRead === true,
     generatedAt: baseline.generatedAt,
     acknowledged,
   };

--- a/.agents/scripts/lib/orchestration/check-baselines/phases/report.js
+++ b/.agents/scripts/lib/orchestration/check-baselines/phases/report.js
@@ -27,8 +27,15 @@ function formatGateLine(g) {
     ? ''
     : ` [kernel drift ${g.kernelBaseline} → ${g.kernelCurrent}]`;
   const baseRef = g.baseRef ? ` [baseRef=${g.baseRef}]` : '';
+  // Story #4914 — a compare arm that never read its base reports zero
+  // regressions and zero additions, which is indistinguishable from a clean
+  // run unless the text report says so out loud.
+  const baseRead =
+    g.baseRef && g.baseRead === false
+      ? ' [baseRead=false — compare skipped]'
+      : '';
   const ack = g.acknowledged ? ' [ACKNOWLEDGED — this run only]' : '';
-  return `  - ${g.kind}: ${status}${drift}${baseRef}${ack}`;
+  return `  - ${g.kind}: ${status}${drift}${baseRef}${baseRead}${ack}`;
 }
 
 function formatViolationLine(component, v) {

--- a/tests/baselines/git-base.integration.test.js
+++ b/tests/baselines/git-base.integration.test.js
@@ -52,4 +52,42 @@ describe('readBaseFromGit — real git repo (integration)', () => {
       rmSync(dir, { recursive: true, force: true });
     }
   });
+
+  // Story #4914 / AC-9 — the leg that would have caught the defect
+  // originally. Every mock in the unit suite reports whatever shape it is
+  // told to; only a real `git show` through a real pipe exercises the
+  // spawnSync stdout ceiling. Pre-fix this read died with
+  // `status: null / SIGTERM / ENOBUFS` at ~1,064,960 bytes.
+  it('reads a baseline larger than the 1 MB spawnSync default in full', () => {
+    // Comfortably past the 1 MB default, and JSON so the shape matches a
+    // real baseline envelope rather than an opaque blob.
+    const rows = Array.from({ length: 26000 }, (_, i) => ({
+      path: `src/generated/module-${String(i).padStart(6, '0')}.js`,
+      mi: 80,
+    }));
+    const fileContent = JSON.stringify({ kernelVersion: '0.1.0', rows });
+    assert.ok(
+      fileContent.length > 1024 * 1024,
+      `fixture must exceed the 1 MB default to be a witness; got ${fileContent.length}`,
+    );
+
+    const dir = makeGitRepo({
+      prefix: 'git-fixture-oversize-',
+      fileName: 'big-baseline.json',
+      fileContent,
+    });
+    try {
+      __resetForTests(); // restore real spawnSync
+      const got = readBaseFromGit('HEAD', 'big-baseline.json', { cwd: dir });
+      assert.ok(got !== null, 'oversize baseline must not read as absent');
+      assert.equal(
+        got.length,
+        fileContent.length,
+        'the full byte length must come back — a truncated read is the defect',
+      );
+      assert.equal(JSON.parse(got).rows.length, rows.length);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
 });

--- a/tests/baselines/git-base.test.js
+++ b/tests/baselines/git-base.test.js
@@ -18,7 +18,11 @@ import {
   __resetForTests,
   __setSpawnRunner,
   readBaseFromGit,
+  readRangeSubjectsTouchingFile,
 } from '../../.agents/scripts/lib/baselines/git-base.js';
+
+/** The explicit stdout ceiling both git reads must pass (Story #4914). */
+const EXPECTED_MAX_BUFFER = 64 * 1024 * 1024;
 
 describe('readBaseFromGit', () => {
   afterEach(() => {
@@ -133,6 +137,113 @@ describe('readBaseFromGit', () => {
     assert.throws(
       () => readBaseFromGit('main', ''),
       /file must be a non-empty string/,
+    );
+  });
+
+  // Story #4914 / AC-2 — the observed production failure. A base baseline
+  // larger than spawnSync's 1 MB default kills the child: `status` is null
+  // (died by signal), not a git exit code. That MUST throw, because the
+  // compare phase now treats `null` as "path absent at ref" and nothing else.
+  it('throws when the child is killed by ENOBUFS (status null / SIGTERM)', () => {
+    __setSpawnRunner({
+      spawn: () => ({
+        status: null,
+        signal: 'SIGTERM',
+        stdout: 'x'.repeat(1024),
+        stderr: '',
+        error: Object.assign(new Error('spawnSync git ENOBUFS'), {
+          code: 'ENOBUFS',
+        }),
+      }),
+    });
+    let thrown = null;
+    try {
+      readBaseFromGit('main', 'baselines/crap.json');
+    } catch (err) {
+      thrown = err;
+    }
+    assert.ok(
+      thrown instanceof Error,
+      'an ENOBUFS-killed read must throw, never return null',
+    );
+    assert.match(thrown.message, /status=null/);
+  });
+
+  // Story #4914 / AC-3 — the other half of the same distinction: exit 128
+  // still means "path absent at ref" and still returns null rather than
+  // throwing. AC-2 and AC-3 together pin the contract compare.js depends on.
+  it('still returns null (does not throw) on git exit 128, alongside the ENOBUFS throw', () => {
+    __setSpawnRunner({
+      spawn: () => ({
+        status: 128,
+        stdout: '',
+        stderr: "fatal: path 'baselines/crap.json' does not exist in 'main'",
+      }),
+    });
+    assert.equal(readBaseFromGit('main', 'baselines/crap.json'), null);
+  });
+
+  // Story #4914 / AC-4 — read the bound off the mock's recorded options, not
+  // off the source text, so the assertion tracks behaviour rather than syntax.
+  it('passes an explicit 64 MB maxBuffer to git show', () => {
+    let lastOpts = null;
+    __setSpawnRunner({
+      spawn: (_cmd, _args, opts) => {
+        lastOpts = opts;
+        return { status: 0, stdout: '{}', stderr: '' };
+      },
+    });
+    readBaseFromGit('main', 'baselines/crap.json');
+    assert.equal(lastOpts.maxBuffer, EXPECTED_MAX_BUFFER);
+    assert.equal(lastOpts.maxBuffer, 67108864);
+  });
+});
+
+describe('readRangeSubjectsTouchingFile (Story #4914)', () => {
+  afterEach(() => {
+    __resetForTests();
+  });
+
+  // AC-4 — the second spawn site carries the same bound. A refresh-tag walk
+  // over a long range is exactly as capable of overflowing 1 MB.
+  it('passes the same explicit 64 MB maxBuffer to git log', () => {
+    let lastOpts = null;
+    __setSpawnRunner({
+      spawn: (_cmd, _args, opts) => {
+        lastOpts = opts;
+        return { status: 0, stdout: 'chore: seed\n', stderr: '' };
+      },
+    });
+    const subjects = readRangeSubjectsTouchingFile(
+      'main',
+      'baselines/maintainability.json',
+    );
+    assert.deepEqual(subjects, ['chore: seed']);
+    assert.equal(lastOpts.maxBuffer, 67108864);
+  });
+
+  // AC-8 — the tolerant contract is deliberate and unchanged: this path
+  // reports "no acknowledging commit found", which is the safe answer when
+  // the range cannot be walked. It must never throw into the gate.
+  it('still returns [] (never throws) on a non-zero git status', () => {
+    __setSpawnRunner({
+      spawn: () => ({ status: 128, stdout: '', stderr: 'fatal: bad revision' }),
+    });
+    assert.deepEqual(
+      readRangeSubjectsTouchingFile('nope', 'baselines/maintainability.json'),
+      [],
+    );
+  });
+
+  it('still returns [] when the spawn itself throws', () => {
+    __setSpawnRunner({
+      spawn: () => {
+        throw new Error('spawnSync git ENOENT');
+      },
+    });
+    assert.deepEqual(
+      readRangeSubjectsTouchingFile('main', 'baselines/maintainability.json'),
+      [],
     );
   });
 });

--- a/tests/check-baselines-base-read-failure.test.js
+++ b/tests/check-baselines-base-read-failure.test.js
@@ -19,9 +19,11 @@
 //     from the JSON alone (AC-7).
 
 import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
 import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
 import path from 'node:path';
 import { afterEach, beforeEach, describe, it } from 'node:test';
+import { fileURLToPath } from 'node:url';
 
 import { runCheckBaselines } from '../.agents/scripts/check-baselines.js';
 import { EXIT_CONFIG } from '../.agents/scripts/lib/baselines/exit-codes.js';
@@ -155,6 +157,43 @@ describe('check-baselines — base-read failure fails closed (#4914)', () => {
     assert.equal(thrown.exitCode, 3);
     assert.equal(thrown.code, 'EXIT_CONFIG');
     assert.match(thrown.message, /could not read the base baseline/);
+  });
+
+  // AC-5 — the same failure driven through the real CLI, so the assertion is
+  // the process exit status rather than a mapping read off the source. A `git`
+  // shim earlier on PATH fails the `show` the way a broken read fails it; the
+  // shim is a POSIX shell script, so the leg is skipped on Windows.
+  it('the check-baselines CLI exits 3 (not 0) when the base read fails', {
+    skip: process.platform === 'win32' ? 'POSIX git shim' : false,
+  }, () => {
+    const binDir = path.join(root, 'shim-bin');
+    mkdirSync(binDir, { recursive: true });
+    const shim = path.join(binDir, 'git');
+    // `show` fails hard (status 1 — not 128, so not "path absent"); every
+    // other subcommand succeeds emptily so nothing else is disturbed.
+    writeFileSync(
+      shim,
+      '#!/bin/sh\nif [ "$1" = "show" ]; then\n' +
+        '  echo "fatal: simulated hard read failure" >&2\n  exit 1\nfi\nexit 0\n',
+      { mode: 0o755 },
+    );
+
+    const cli = fileURLToPath(
+      new URL('../.agents/scripts/check-baselines.js', import.meta.url),
+    );
+    const res = spawnSync(process.execPath, [cli, '--no-friction'], {
+      cwd: root,
+      encoding: 'utf-8',
+      env: { ...process.env, PATH: `${binDir}:${process.env.PATH}` },
+    });
+
+    assert.equal(
+      res.status,
+      3,
+      `expected EXIT_CONFIG; got ${res.status}\nstdout: ${res.stdout}\nstderr: ${res.stderr}`,
+    );
+    assert.notEqual(res.status, 0, 'the pre-fix behaviour was a green exit 0');
+    assert.match(res.stdout, /could not read the base baseline/);
   });
 
   // AC-6 — the pre-fix scenario stated as its own assertion: the exact shape

--- a/tests/check-baselines-base-read-failure.test.js
+++ b/tests/check-baselines-base-read-failure.test.js
@@ -1,0 +1,213 @@
+// tests/check-baselines-base-read-failure.test.js
+//
+// Story #4914 — check-baselines must not silently disable its compare arm
+// when the base baseline cannot be read.
+//
+// The pre-fix behaviour: `readBaseBaselinePayload` wrapped the git read in a
+// bare `catch { return null }`, so ANY hard read failure (the observed one
+// being an ENOBUFS kill on a baseline larger than spawnSync's 1 MB default)
+// collapsed to "no base baseline". The whole head-vs-base arm — regressions
+// AND additions — then reported empty while the floors arm kept the run at
+// exit 0. The gate looked green because it had stopped looking.
+//
+// Invariants pinned here:
+//   - A hard base-read failure fails CLOSED as EXIT_CONFIG (3), never as a
+//     clean exit 0 with an empty compare (AC-5, AC-6).
+//   - An ABSENT base (git exit 128) keeps its old tolerant behaviour — that
+//     distinction is what `readBaseFromGit` draws and what this fix relies on.
+//   - The per-gate report carries `baseRead`, so the condition is diagnosable
+//     from the JSON alone (AC-7).
+
+import assert from 'node:assert/strict';
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, it } from 'node:test';
+
+import { runCheckBaselines } from '../.agents/scripts/check-baselines.js';
+import { EXIT_CONFIG } from '../.agents/scripts/lib/baselines/exit-codes.js';
+import {
+  __resetForTests,
+  __setSpawnRunner,
+} from '../.agents/scripts/lib/baselines/git-base.js';
+import { currentKernelVersion } from '../.agents/scripts/lib/baselines/kernel.js';
+import { makeTempDir } from '../.agents/scripts/lib/test-temp.js';
+
+const MI_BASELINE_REL = 'baselines/maintainability.json';
+
+function miEnvelope(rows) {
+  return {
+    $schema: 'maintainability.schema.json',
+    kernelVersion: currentKernelVersion('maintainability'),
+    generatedAt: '2026-01-01T00:00:00.000Z',
+    rollup: { '*': { min: 80, p50: 90, p95: 100 } },
+    rows,
+  };
+}
+
+/** Temp project root with one diff-scoped maintainability gate. */
+function setupTmpRepo() {
+  const root = makeTempDir('check-baselines-base-read-');
+  mkdirSync(path.join(root, 'baselines'), { recursive: true });
+  writeFileSync(
+    path.join(root, '.agentrc.json'),
+    JSON.stringify(
+      {
+        project: {
+          baseBranch: 'main',
+          paths: { agentRoot: '.agents', docsRoot: 'docs', tempRoot: 'temp' },
+          docsContextFiles: [],
+          commands: { lintBaseline: 'echo', test: 'echo', typecheck: 'echo' },
+        },
+        github: { owner: 'x', repo: 'y', operatorHandle: '@ci' },
+        delivery: {
+          quality: {
+            gateScoping: { scope: 'diff', diffRef: 'main' },
+            gates: {
+              maintainability: {
+                enabled: true,
+                baselinePath: MI_BASELINE_REL,
+                tolerance: { kind: 'absolute', value: 0.5 },
+                floors: { '*': { min: 70 } },
+              },
+            },
+          },
+        },
+      },
+      null,
+      2,
+    ),
+  );
+  // Head baseline: floor-clean, so nothing but the compare arm can fail.
+  writeFileSync(
+    path.join(root, MI_BASELINE_REL),
+    JSON.stringify(miEnvelope([{ path: 'src/a.js', mi: 80 }]), null, 2),
+  );
+  return root;
+}
+
+/**
+ * Git stub whose `show` dies the way an oversize baseline dies under the 1 MB
+ * spawnSync default: killed by signal, so `status` is null rather than a git
+ * exit code. `log` stays healthy so the failure under test is unambiguous.
+ */
+function installEnobufsStub() {
+  __setSpawnRunner({
+    spawn: (_cmd, args) => {
+      if (args?.[0] === 'show') {
+        return {
+          status: null,
+          signal: 'SIGTERM',
+          stdout: 'x'.repeat(1024),
+          stderr: '',
+          error: Object.assign(new Error('spawnSync git ENOBUFS'), {
+            code: 'ENOBUFS',
+          }),
+        };
+      }
+      return { status: 0, stdout: '', stderr: '' };
+    },
+  });
+}
+
+function installHealthyStub(baseRows) {
+  const baseJson = JSON.stringify(miEnvelope(baseRows));
+  __setSpawnRunner({
+    spawn: (_cmd, args) => {
+      if (args?.[0] === 'show') {
+        const spec = args?.[1] ?? '';
+        if (spec.endsWith(`:${MI_BASELINE_REL}`)) {
+          return { status: 0, stdout: baseJson, stderr: '' };
+        }
+        return { status: 128, stdout: '', stderr: 'no base' };
+      }
+      return { status: 0, stdout: '', stderr: '' };
+    },
+  });
+}
+
+describe('check-baselines — base-read failure fails closed (#4914)', () => {
+  let root;
+
+  beforeEach(() => {
+    __resetForTests();
+    root = setupTmpRepo();
+  });
+
+  afterEach(() => {
+    __resetForTests();
+    if (root) rmSync(root, { recursive: true, force: true });
+    root = undefined;
+  });
+
+  // AC-5 — the read failure propagates as an EXIT_CONFIG-carrying error.
+  // `check-baselines.js#main` maps any throw out of the pipeline onto that
+  // code, so this is the run's exit status: 3, not 0.
+  it('propagates a hard base-read failure as an EXIT_CONFIG (3) error', async () => {
+    installEnobufsStub();
+    let thrown = null;
+    try {
+      await runCheckBaselines({ argv: ['--no-friction'], cwd: root });
+    } catch (err) {
+      thrown = err;
+    }
+    assert.ok(thrown instanceof Error, 'the run must not resolve');
+    assert.equal(thrown.exitCode, EXIT_CONFIG);
+    assert.equal(thrown.exitCode, 3);
+    assert.equal(thrown.code, 'EXIT_CONFIG');
+    assert.match(thrown.message, /could not read the base baseline/);
+  });
+
+  // AC-6 — the pre-fix scenario stated as its own assertion: the exact shape
+  // that used to come back (a clean report, empty compare, exit 0) must now
+  // be unreachable for this input.
+  it('never reports an empty compare at exit 0 when the base read failed', async () => {
+    installEnobufsStub();
+    let resolved = null;
+    try {
+      resolved = await runCheckBaselines({
+        argv: ['--no-friction'],
+        cwd: root,
+      });
+    } catch {
+      resolved = null;
+    }
+    assert.equal(
+      resolved,
+      null,
+      'a failed base read must not yield a report at all — the pre-fix bug ' +
+        'returned regressions: [] / additions: [] at exit 0',
+    );
+  });
+
+  // The other side of the distinction: an ABSENT base at the ref (git exit
+  // 128) is not a failure and keeps its tolerant exit-0 behaviour.
+  it('still exits 0 when the base baseline is merely absent at the ref', async () => {
+    __setSpawnRunner({
+      spawn: (_cmd, args) => {
+        if (args?.[0] === 'show') {
+          return { status: 128, stdout: '', stderr: 'fatal: path missing' };
+        }
+        return { status: 0, stdout: '', stderr: '' };
+      },
+    });
+    const res = await runCheckBaselines({ argv: ['--no-friction'], cwd: root });
+    assert.equal(res.exitCode, 0);
+    const gate = res.report.gates.find((g) => g.kind === 'maintainability');
+    assert.equal(gate.baseRead, false, 'absent base is reported, not hidden');
+  });
+
+  // AC-7 — a normal run that DID read its base says so on the gate report.
+  it('reports baseRead: true on a gate whose base baseline was read', async () => {
+    installHealthyStub([{ path: 'src/a.js', mi: 80 }]);
+    const res = await runCheckBaselines({ argv: ['--no-friction'], cwd: root });
+    assert.equal(res.exitCode, 0);
+    const gate = res.report.gates.find((g) => g.kind === 'maintainability');
+    assert.ok(gate, 'maintainability gate present');
+    assert.equal(
+      Object.hasOwn(gate, 'baseRead'),
+      true,
+      'baseRead must reach the per-gate report object',
+    );
+    assert.equal(gate.baseRead, true);
+  });
+});


### PR DESCRIPTION
Closes #4914

_Auto-opened by `/deliver`._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes check-baselines exit behavior when base reads fail (now exit 3 instead of a misleading pass), which affects CI quality gates but is intentional and heavily tested.
> 
> **Overview**
> Fixes a **fail-open** bug where oversized or broken base baseline reads were treated like “no base at ref,” so the compare arm reported zero regressions while floors still passed.
> 
> **`git-base.js`** sets an explicit **64 MB** `maxBuffer` on `git show` and `git log` (matching other baseline tooling), preventing ENOBUFS kills on baselines larger than spawnSync’s 1 MB default. The contract is documented: **`null` only for git exit 128** (path absent); signal kills and other failures **throw**.
> 
> **`compare.js`** no longer catches those throws and returns null; it surfaces **`EXIT_CONFIG` (3)** via `buildBaseReadError`. **Absent** bases (exit 128) still skip compare with exit 0.
> 
> Reports now expose **`baseRead`** on each gate (JSON) and **`[baseRead=false — compare skipped]`** in the text summary when compare did not run. New unit, integration, and end-to-end tests lock ENOBUFS behavior, buffer size, and CLI exit 3 vs tolerant absent-base exit 0.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a03ef2ac2d3f5ee32e48a42aab08aefdc3015a3b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->