### PR TITLE
fix: stop the friction interceptor recording a signal about its own failure to spawn, and make the always-on invocation unambiguous (#4915)

### DIFF
--- a/.agents/instructions.md
+++ b/.agents/instructions.md
@@ -79,7 +79,7 @@ present, else the **Tech Stack** section of `docs/architecture.md`.
 
 You MUST log operational friction (repeated tool errors, unrecoverable
 command failures, self-corrected ambiguity, automatable boilerplate):
-`node .agents/scripts/diagnose-friction.js --story [STORY_ID] --cmd [FAILED_COMMAND]`
+`node .agents/scripts/diagnose-friction.js --story [STORY_ID] --cmd <cmd> <args...>`
 — a **local NDJSON signal** (not posted to the ticket). Schema and the
 `AGENT_LOG_LEVEL` table:
 [`docs/execution-reference.md`](docs/execution-reference.md#friction-telemetry).

--- a/.agents/scripts/diagnose-friction.js
+++ b/.agents/scripts/diagnose-friction.js
@@ -16,7 +16,11 @@
  *
  * Usage:
  *   node diagnose-friction.js [--story <STORY_ID>] \
- *     [--epic <EPIC_ID>] --cmd <command with args...>
+ *     [--epic <EPIC_ID>] --cmd <cmd> <args...>
+ *
+ * `--cmd` consumes the remaining argv as separate words and spawns them with
+ * no shell. Quoting the whole command as one string is a usage error, not
+ * friction — it is refused loudly and writes no ledger row.
  *
  * Story/Epic resolution order:
  *   1. CLI flags (--story, --epic).
@@ -108,6 +112,16 @@ function classifyFrictionCategory(errorOutput) {
  */
 const INTERCEPTOR_TIMEOUT_SIGNAL = 'SIGTERM';
 
+/**
+ * A `maxBuffer` overflow presents identically to a timeout — `status: null`,
+ * `signal: 'SIGTERM'` — because Node kills the child the same way. The only
+ * discriminator is `result.error.code`, so a SIGTERM carrying this code is a
+ * buffer overflow and must never be reported as a timeout (Story #4915).
+ *
+ * @type {string}
+ */
+const OVERFLOW_ERROR_CODE = 'ENOBUFS';
+
 /** Shell convention for "the process died by signal N": exit `128 + N`. */
 const SIGNAL_EXIT_BASE = 128;
 
@@ -118,8 +132,10 @@ const SIGNAL_EXIT_BASE = 128;
  * interceptor would report success for a command it just watched get killed
  * (Story #4851).
  *
- * Which signal fired is the diagnostic value: SIGTERM points at the
- * interceptor's own bound, anything else at the host. Recording that plus the
+ * Which signal fired is the diagnostic value: SIGTERM points at one of the
+ * interceptor's own bounds, anything else at the host. A SIGTERM splits again
+ * on `error.code`: `ENOBUFS` means the output blew past `executionMaxBuffer`,
+ * anything else means `executionTimeoutMs` fired. Recording that plus the
  * bound itself is what makes the row actionable to a consumer who cannot edit
  * the materialized framework tree.
  *
@@ -128,13 +144,17 @@ const SIGNAL_EXIT_BASE = 128;
  * the file's per-file maintainability-delta headroom. The CLI contract is the
  * seam the unit tests drive.
  *
- * @param {{signal: (string|null), error?: {message?: string}}} result A
- *   `spawnSync` result whose `status` is `null`.
- * @param {number} executionTimeoutMs The resolved interceptor bound, in ms.
+ * @param {{signal: (string|null), error?: {message?: string, code?: string}}}
+ *   result A `spawnSync` result whose `status` is `null`.
+ * @param {{executionTimeoutMs: number, executionMaxBuffer: number}} bounds The
+ *   resolved interceptor bounds — the timeout in ms, the buffer in bytes.
  * @returns {{category: string, remediation: string, details: object,
  *   preview: string, exitCode: number}}
  */
-function describeAbnormalExit(result, executionTimeoutMs) {
+function describeAbnormalExit(
+  result,
+  { executionTimeoutMs, executionMaxBuffer },
+) {
   const signal = typeof result.signal === 'string' ? result.signal : null;
   if (signal === null) {
     return {
@@ -150,15 +170,42 @@ function describeAbnormalExit(result, executionTimeoutMs) {
     };
   }
 
-  const timedOut = signal === INTERCEPTOR_TIMEOUT_SIGNAL;
-  const killOrigin = timedOut ? 'interceptor-timeout' : 'external';
+  const sentByInterceptor = signal === INTERCEPTOR_TIMEOUT_SIGNAL;
+  const overflowed =
+    sentByInterceptor && result.error?.code === OVERFLOW_ERROR_CODE;
+  let killOrigin = 'external';
+  if (overflowed) killOrigin = 'buffer-overflow';
+  else if (sentByInterceptor) killOrigin = 'interceptor-timeout';
+
+  const shapes = {
+    'buffer-overflow': {
+      category: 'Tool Limitation',
+      remediation: ` - ${signal} was sent because the command's output overflowed the interceptor's executionMaxBuffer bound (${executionMaxBuffer} bytes / 10 MiB) — the executionTimeoutMs bound (${executionTimeoutMs}ms) did not fire. Do NOT split the command into smaller steps: quieten or redirect its output, or raise the buffer bound.`,
+      extraDetails: { executionMaxBuffer },
+    },
+    'interceptor-timeout': {
+      category: 'Execution Timeout',
+      remediation: ` - ${signal} matches the interceptor's own executionTimeoutMs bound (${executionTimeoutMs}ms), so the command was almost certainly cut off rather than broken. Split it into smaller steps, or raise the bound.`,
+      extraDetails: {},
+    },
+    external: {
+      category: 'Execution Killed',
+      remediation: ` - ${signal} originated outside the interceptor — the executionTimeoutMs bound (${executionTimeoutMs}ms) did not fire, so suspect an OOM kill or a hard kill from the host. Reduce the command's memory footprint or give the host more headroom.`,
+      extraDetails: {},
+    },
+  };
+
+  const shape = shapes[killOrigin];
   const signum = osConstants.signals[signal];
   return {
-    category: timedOut ? 'Execution Timeout' : 'Execution Killed',
-    remediation: timedOut
-      ? ` - ${signal} matches the interceptor's own executionTimeoutMs bound (${executionTimeoutMs}ms), so the command was almost certainly cut off rather than broken. Split it into smaller steps, or raise the bound.`
-      : ` - ${signal} originated outside the interceptor — the executionTimeoutMs bound (${executionTimeoutMs}ms) did not fire, so suspect an OOM kill or a hard kill from the host. Reduce the command's memory footprint or give the host more headroom.`,
-    details: { killedBySignal: signal, killOrigin, executionTimeoutMs },
+    category: shape.category,
+    remediation: shape.remediation,
+    details: {
+      killedBySignal: signal,
+      killOrigin,
+      executionTimeoutMs,
+      ...shape.extraDetails,
+    },
     preview: `Command terminated by signal ${signal} (${killOrigin}); executionTimeoutMs=${executionTimeoutMs}.`,
     exitCode: Number.isInteger(signum) ? SIGNAL_EXIT_BASE + signum : 1,
   };
@@ -221,7 +268,23 @@ export async function main(args = process.argv.slice(2)) {
 
   if (cmdArgs.length === 0) {
     throw new Error(
-      'Usage: node diagnose-friction.js [--story <STORY_ID>] [--epic <EPIC_ID>] --cmd <command with args...>',
+      'Usage: node diagnose-friction.js [--story <STORY_ID>] [--epic <EPIC_ID>] --cmd <cmd> <args...>',
+    );
+  }
+
+  // Story #4915 — the interceptor spawns `cmdArgs[0]` directly, with no shell.
+  // A single argument containing whitespace therefore names an executable that
+  // cannot exist, and the resulting ENOENT is a usage error in the
+  // interceptor's OWN invocation, not friction in the wrapped command. It must
+  // be reported as one and MUST NOT reach the ledger — otherwise the real
+  // friction is discarded and the roll-up eventually auto-files a framework-gap
+  // ticket about the framework's own instrumentation being misused. The
+  // discriminator is this argv shape, never the ENOENT result: a correctly
+  // split command whose binary is genuinely absent yields the identical
+  // `spawnSync` result and stays real friction.
+  if (cmdArgs.length === 1 && /\s/.test(cmdArgs[0])) {
+    throw new Error(
+      `Usage: --cmd takes the command as separate argv words, not one quoted string. Received a single quoted argument: "${cmdArgs[0]}". Drop the quotes so each word is its own argv entry — \`--cmd ${cmdArgs[0]}\`. No friction signal was recorded.`,
     );
   }
 
@@ -251,7 +314,10 @@ export async function main(args = process.argv.slice(2)) {
     // `result.signal`, not in the status.
     const abnormal =
       result.status === null
-        ? describeAbnormalExit(result, executionTimeoutMs)
+        ? describeAbnormalExit(result, {
+            executionTimeoutMs,
+            executionMaxBuffer,
+          })
         : null;
     // With both streams empty an abnormal termination names its signal; the
     // `Unknown exit code` fallback is therefore reachable only with a real
@@ -343,15 +409,15 @@ runAsCli(import.meta.url, main, {
   source: 'DiagnoseFriction',
   usage: {
     invocation:
-      'node .agents/scripts/diagnose-friction.js [--story <id>] [--epic <id>] --cmd <command with args...>',
+      'node .agents/scripts/diagnose-friction.js [--story <id>] [--epic <id>] --cmd <cmd> <args...>',
     summary:
       'Run a command through the diagnostic interceptor: stream its output, then append a local friction signal describing the failure. Never posts to the ticket.',
     flags: [
       ['--story <id>', 'Story the friction belongs to.'],
       ['--epic <id>', 'Epic the friction belongs to.'],
       [
-        '--cmd <command...>',
-        'The command to execute; everything after it is the argv (required).',
+        '--cmd <cmd> <args...>',
+        'The command to execute; everything after it is the argv, as separate words — never one quoted string (required).',
       ],
     ],
   },

--- a/.agents/skills/core/diagnose-friction/SKILL.md
+++ b/.agents/skills/core/diagnose-friction/SKILL.md
@@ -15,6 +15,7 @@ allowed_tools:
 ## Policy Capsule
 
 - Invoke via the wrapping CLI `node .agents/scripts/diagnose-friction.js --story <id> [--epic <id>] --cmd <command args...>`; this is the single supported entry point.
+- `--cmd` takes the command as **separate argv words** — the CLI spawns them with no shell. Quoting the whole command as one string (`--cmd "npm run lint"`) makes the entire string the executable name, so the spawn fails ENOENT. That is a usage error in your own invocation, not friction: the CLI refuses it with a usage message and appends **no** ledger row. Re-run it unquoted.
 - Pass the wrapped command's stdout and stderr through **unchanged** — never reformat, redact, or buffer in a way that loses the original failure shape.
 - Never mutate the wrapped command's exit code. The Skill observes; the caller decides whether the failure is fatal.
 - Operate as **best-effort observation**: a write failure on the signals stream MUST NOT halt the runner. A missing signal is preferable to a stalled wave.
@@ -39,7 +40,9 @@ that want to dispatch via the Skill tool rather than spawn the CLI.
 
 ## Inputs
 
-- `--cmd <command args...>` — the command to invoke and observe.
+- `--cmd <command args...>` — the command to invoke and observe, passed as
+  separate argv words. A single whitespace-containing argument is rejected as
+  a quoting mistake before anything is spawned or recorded.
 - `--story <id>` / `--epic <id>` (optional) — when resolved, the Skill
   appends a `friction` signal to
   `temp/run-<eid>/stories/story-<sid>/signals.ndjson` on non-zero exit

--- a/.agents/skills/skills.index.json
+++ b/.agents/skills/skills.index.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-07-21T13:53:23.232Z",
+  "generatedAt": "2026-08-02T11:35:53.522Z",
   "generator": "generate-skills-index.js@1",
   "skills": [
     {
@@ -48,7 +48,7 @@
       "category": "core",
       "path": ".agents/skills/core/diagnose-friction/SKILL.md",
       "description": "Wrap a shell command with diagnostic capture. On failure, print static suggestions and append a structured `friction` record to the per-Story signals.ndjson stream. Use whenever a script in the orchestration loop invokes a tool whose failure shape we want the analyzer to attribute.",
-      "policyCapsuleBullets": 8,
+      "policyCapsuleBullets": 9,
       "allowedTools": ["Bash", "Read"],
       "vendor": null
     },

--- a/baselines/context-budget.json
+++ b/baselines/context-budget.json
@@ -1,10 +1,10 @@
 {
   "$schema": "https://mandrel.dev/baselines/context-budget.schema.json",
-  "generatedAt": "2026-08-02T01:58:36.417Z",
+  "generatedAt": "2026-08-02T11:36:41.707Z",
   "toleranceBytes": 2048,
   "tiers": {
     "alwaysLoaded": {
-      "totalBytes": 21135,
+      "totalBytes": 21134,
       "files": [
         {
           "path": ".agentrc.json",
@@ -12,7 +12,7 @@
         },
         {
           "path": ".agents/instructions.md",
-          "bytes": 9036
+          "bytes": 9035
         },
         {
           "path": ".agents/rules/git-conventions.md",
@@ -197,7 +197,7 @@
     ]
   },
   "workflowClosure": {
-    "reachableTotalBytes": 424186,
+    "reachableTotalBytes": 424374,
     "entryPoints": [
       {
         "path": ".agents/workflows/audit-accessibility.md",
@@ -237,7 +237,7 @@
       {
         "path": ".agents/workflows/audit-documentation.md",
         "mandatoryBytes": 11889,
-        "reachableBytes": 208295
+        "reachableBytes": 208483
       },
       {
         "path": ".agents/workflows/audit-navigability.md",
@@ -277,7 +277,7 @@
       {
         "path": ".agents/workflows/audit-to-stories.md",
         "mandatoryBytes": 14506,
-        "reachableBytes": 196406
+        "reachableBytes": 196594
       },
       {
         "path": ".agents/workflows/audit-ux-ui.md",
@@ -287,7 +287,7 @@
       {
         "path": ".agents/workflows/deliver.md",
         "mandatoryBytes": 7300,
-        "reachableBytes": 196406
+        "reachableBytes": 196594
       },
       {
         "path": ".agents/workflows/git-cleanup.md",
@@ -297,12 +297,12 @@
       {
         "path": ".agents/workflows/git-deliver.md",
         "mandatoryBytes": 7640,
-        "reachableBytes": 221171
+        "reachableBytes": 221359
       },
       {
         "path": ".agents/workflows/helpers/deliver-story.md",
         "mandatoryBytes": 15309,
-        "reachableBytes": 196406
+        "reachableBytes": 196594
       },
       {
         "path": ".agents/workflows/mandrel-update.md",
@@ -312,27 +312,27 @@
       {
         "path": ".agents/workflows/plan.md",
         "mandatoryBytes": 7367,
-        "reachableBytes": 196406
+        "reachableBytes": 196594
       },
       {
         "path": ".agents/workflows/prototype.md",
         "mandatoryBytes": 5148,
-        "reachableBytes": 196406
+        "reachableBytes": 196594
       },
       {
         "path": ".agents/workflows/qa-assist.md",
         "mandatoryBytes": 16561,
-        "reachableBytes": 261306
+        "reachableBytes": 261494
       },
       {
         "path": ".agents/workflows/qa-explore.md",
         "mandatoryBytes": 13422,
-        "reachableBytes": 261306
+        "reachableBytes": 261494
       },
       {
         "path": ".agents/workflows/qa-run.md",
         "mandatoryBytes": 13618,
-        "reachableBytes": 261306
+        "reachableBytes": 261494
       }
     ]
   }

--- a/tests/diagnose-friction.test.js
+++ b/tests/diagnose-friction.test.js
@@ -19,7 +19,7 @@
 
 import assert from 'node:assert/strict';
 import { spawnSync } from 'node:child_process';
-import { readFileSync, rmSync } from 'node:fs';
+import { existsSync, readFileSync, rmSync } from 'node:fs';
 import { constants as osConstants } from 'node:os';
 import path from 'node:path';
 import { afterEach, beforeEach, describe, it } from 'node:test';
@@ -45,11 +45,12 @@ afterEach(() => {
   rmSync(tmpRoot, { recursive: true, force: true });
 });
 
-function runScript(extraArgs, extraEnv = {}) {
+function runScript(extraArgs, extraEnv = {}, spawnOverrides = {}) {
   return spawnSync('node', [SCRIPT_PATH, ...extraArgs], {
     cwd: tmpRoot,
     encoding: 'utf-8',
-    timeout: 15000,
+    timeout: 60000,
+    ...spawnOverrides,
     env: {
       ...process.env,
       GITHUB_TOKEN: 'fake-token-for-test',
@@ -131,6 +132,88 @@ describe('diagnose-friction.js — v5 (CLI contract)', () => {
       combined.includes('Auto-Remediation Suggestions'),
       'Should print auto-remediation suggestions on failure',
     );
+  });
+});
+
+describe('diagnose-friction.js — quoted-command usage error (Story #4915)', () => {
+  /** Where a signal for the story/epic pair used below would land. */
+  function ledgerPath(epicId = 1030, storyId = 1042) {
+    return path.join(
+      tmpRoot,
+      'temp',
+      `run-${epicId}`,
+      'stories',
+      `story-${storyId}`,
+      'signals.ndjson',
+    );
+  }
+
+  it('refuses a whole command passed as one quoted argument, naming the mistake', () => {
+    // AC-2: `cmdArgs.length === 1` with whitespace inside can only be a caller
+    // that quoted the command; the interceptor spawns argv words with no shell,
+    // so the string could never be an executable name.
+    const result = runScript([
+      '--story',
+      '1042',
+      '--epic',
+      '1030',
+      '--cmd',
+      'npm run lint',
+    ]);
+
+    assert.notEqual(result.status, 0, 'a usage error must exit non-zero');
+    const combined = (result.stdout ?? '') + (result.stderr ?? '');
+    assert.match(
+      combined,
+      /Usage:/,
+      'the failure is reported as a usage error, not a wrapped-command failure',
+    );
+    assert.match(
+      combined,
+      /quoted/i,
+      'the message names the quoting mistake rather than the ENOENT symptom',
+    );
+    assert.match(
+      combined,
+      /--cmd npm run lint/,
+      'the message shows the corrected argv-split invocation',
+    );
+  });
+
+  it('appends no ledger row for the quoting mistake', () => {
+    // AC-2: recording it would discard the friction the caller meant to log and
+    // eventually auto-file a framework-gap ticket about the interceptor itself.
+    runScript(['--story', '1042', '--epic', '1030', '--cmd', 'npm run lint']);
+    assert.equal(
+      existsSync(ledgerPath()),
+      false,
+      'a usage error in the interceptor own invocation is not friction',
+    );
+  });
+
+  it('still records a genuinely missing executable as spawn-failure friction', () => {
+    // AC-3: the missing binary and the quoted misuse are indistinguishable from
+    // the spawnSync result (both `status: null` + ENOENT). This pins that the
+    // discrimination happens on `cmdArgs`, so real missing-tool friction lives.
+    const result = runScript([
+      '--story',
+      '1042',
+      '--epic',
+      '1030',
+      '--cmd',
+      '__mandrel_no_such_executable__',
+      '--version',
+    ]);
+
+    assert.notEqual(result.status, 0, 'a missing executable still fails');
+    const signal = readSignal();
+    assert.equal(signal.category, 'Execution Error');
+    assert.equal(
+      signal.details.killOrigin,
+      'spawn-failure',
+      'the missing-tool friction signal is preserved unchanged',
+    );
+    assert.equal(signal.details.killedBySignal, null);
   });
 });
 
@@ -443,6 +526,88 @@ describe(
         result.status,
         128 + osConstants.signals.SIGKILL,
         'exit code follows the shell 128 + signum convention',
+      );
+    });
+
+    it('separates a maxBuffer overflow from a timeout, though both are SIGTERM (Story #4915)', () => {
+      // AC-7 + AC-8: Node kills a `maxBuffer` overflow with SIGTERM too, so the
+      // two shapes are distinguishable only by `error.code: 'ENOBUFS'`. Drive
+      // both through the CLI seam and pin that they cannot silently re-merge.
+      // The child's output must exceed the interceptor's 10 MiB
+      // `executionMaxBuffer`; this test's own capture buffer must exceed that
+      // again, since the interceptor passes the truncated output through.
+      const overflow = runScript(
+        [
+          '--story',
+          '1042',
+          '--epic',
+          '1030',
+          '--cmd',
+          'node',
+          '-e',
+          "process.stdout.write('x'.repeat(11 * 1024 * 1024))",
+        ],
+        {},
+        { maxBuffer: 64 * 1024 * 1024 },
+      );
+      assert.notEqual(overflow.status, 0, 'an overflowed child is a failure');
+      const overflowSignal = readSignal();
+      assert.equal(
+        overflowSignal.details.killedBySignal,
+        'SIGTERM',
+        'the overflow presents as SIGTERM, exactly like a timeout',
+      );
+      assert.equal(
+        overflowSignal.details.killOrigin,
+        'buffer-overflow',
+        'ENOBUFS gets its own killOrigin, distinct from interceptor-timeout',
+      );
+      assert.equal(
+        overflowSignal.details.executionMaxBuffer,
+        10485760,
+        'the row records the bound that actually fired',
+      );
+      const overflowStderr = overflow.stderr ?? '';
+      assert.match(
+        overflowStderr,
+        /executionMaxBuffer bound \(10485760 bytes \/ 10 MiB\)/,
+        'remediation names the buffer bound, not the timeout bound',
+      );
+      assert.match(
+        overflowStderr,
+        /Do NOT split the command into smaller steps/,
+        'the overflow must not inherit the timeout advice to split the command',
+      );
+
+      rmSync(path.join(tmpRoot, 'temp'), { recursive: true, force: true });
+
+      const timeout = runSelfKill('SIGTERM');
+      const timeoutSignal = readSignal();
+      assert.equal(
+        timeoutSignal.details.killedBySignal,
+        'SIGTERM',
+        'both shapes report the same signal — only error.code separates them',
+      );
+      assert.notEqual(
+        timeoutSignal.details.killOrigin,
+        overflowSignal.details.killOrigin,
+        'SIGTERM with and without ENOBUFS must yield different killOrigin',
+      );
+      assert.equal(timeoutSignal.details.killOrigin, 'interceptor-timeout');
+      assert.equal(
+        timeoutSignal.details.executionMaxBuffer,
+        undefined,
+        'a real timeout carries no buffer bound — its details are unchanged',
+      );
+      assert.match(
+        timeout.stderr ?? '',
+        /Split it into smaller steps, or raise the bound/,
+        'the timeout keeps the remediation it emits today',
+      );
+      assert.notEqual(
+        timeout.stderr,
+        overflowStderr,
+        'the two shapes must not share remediation text',
       );
     });
 


### PR DESCRIPTION
Closes #4915

_Auto-opened by `/deliver`._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to friction telemetry CLI behavior, docs, and tests; no auth, data, or production runtime paths.
> 
> **Overview**
> **`diagnose-friction.js`** no longer treats interceptor misuse as friction and labels **`maxBuffer`** kills separately from timeouts.
> 
> Callers who pass **`--cmd`** as one quoted string (e.g. `--cmd "npm run lint"`) get a **usage error** before spawn, with **no** `signals.ndjson` row—so ENOENT from a bogus executable name is not logged as wrapped-command friction. A correctly split argv with a missing binary still records **`spawn-failure`** friction.
> 
> When a child dies with **`SIGTERM`** and **`status: null`**, abnormal exits now branch on **`error.code === 'ENOBUFS'`**: **`killOrigin: buffer-overflow`**, category **Tool Limitation**, remediation that cites **`executionMaxBuffer`** (10 MiB) and explicitly says **not** to split the command; real interceptor timeouts stay **`interceptor-timeout`** with the existing split-or-raise-timeout advice.
> 
> Agent docs (**`instructions.md`**, **`diagnose-friction` skill**, CLI help) document argv-split **`--cmd`**. Tests cover quoting refusal, ledger skip, missing-binary discrimination, and overflow vs timeout remediation/details.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ec693eca782ee56384304efbfd62f430ef1918a9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->