### PR TITLE
fix: classify a framework script named by bare basename as framework rather than consumer (#4916)

### DIFF
--- a/.agents/scripts/lib/observability/source-classifier.js
+++ b/.agents/scripts/lib/observability/source-classifier.js
@@ -17,6 +17,9 @@
  *       - `.agentrc.json`
  *       - `.claude/`
  *       - `node .agents/scripts/`
+ *     …or (Story #4916) names one of the CLI entry points shipped at the
+ *     top level of `.agents/scripts/` by **bare basename**, so recognition
+ *     does not depend on how the caller spelled the reference.
  *   - Anything else (or empty input) defaults to `"consumer"`. The default
  *     is intentional — most friction comes from consumer code touching
  *     framework tooling, and we'd rather under-tag than mis-route a
@@ -46,6 +49,129 @@ const FRAMEWORK_PREFIXES = Object.freeze([
   '.claude/',
   'node .agents/scripts/',
 ]);
+
+/**
+ * Basenames of the CLI entry points shipped at the top level of
+ * `.agents/scripts/` (Story #4916).
+ *
+ * The prefix scan above recognises a framework script only when the caller
+ * spelled a path — `node .agents/scripts/acceptance-eval.js` classifies
+ * `framework`, while the same script named bare (`acceptance-eval.js --story
+ * 4901`) matched no prefix and fell through to `consumer`, so a real framework
+ * defect was routed as consumer-actionable and discarded. Recognition must not
+ * depend on how the caller spelled the reference.
+ *
+ * Kept as **static data**, not a directory read: `classifySignalSource` is
+ * called once per signal and MUST stay pure — no filesystem I/O at classify
+ * time. The sync test in
+ * `tests/lib/observability/source-classifier.test.js` reads the real directory
+ * and fails when a script is added, renamed, or removed without this list
+ * being updated, so the set cannot go stale and silently restore the blind
+ * spot.
+ *
+ * Scoped to the top level deliberately: those are the entry points a command
+ * line names. Library modules under `.agents/scripts/lib/` carry generic
+ * basenames (`index.js`, `config.js`) that a consumer command could plausibly
+ * name, and widening to them would trade one mis-route for another.
+ *
+ * @type {readonly string[]}
+ */
+const FRAMEWORK_SCRIPT_BASENAMES = Object.freeze([
+  'acceptance-eval.js',
+  'agents-bootstrap-github.js',
+  'apply-quality-bootstrap.js',
+  'audit-baselines.js',
+  'audit-labels-bootstrap.js',
+  'audit-to-stories.js',
+  'boot-sweep.js',
+  'bootstrap.js',
+  'check-action-pinning.js',
+  'check-arch-cycles.js',
+  'check-baseline-drift.js',
+  'check-baselines.js',
+  'check-context-budget.js',
+  'check-dead-exports.js',
+  'check-doc-links.js',
+  'check-gherkin-placeholders.js',
+  'check-lifecycle-doc-drift.js',
+  'check-lifecycle-lint.js',
+  'check-test-temp-hygiene.js',
+  'check-windows-git-perf.js',
+  'check-workflow-citations.js',
+  'check-workflow-cli-lint.js',
+  'cleanup-repo-test-temp.js',
+  'coverage-capture.js',
+  'deliver-light.js',
+  'deliver-recover.js',
+  'diagnose-friction.js',
+  'diagnose.js',
+  'drain-pending-cleanup.js',
+  'evidence-gate.js',
+  'generate-config-docs.js',
+  'generate-lens-checklists.js',
+  'generate-lifecycle-docs.js',
+  'generate-skills-index.js',
+  'generate-workflows-doc.js',
+  'git-cleanup.js',
+  'install-matrix-assert.js',
+  'lint-baseline.js',
+  'lint-issue-body.js',
+  'lint-label-vocabulary.js',
+  'mandrel-update-preflight.js',
+  'nav-registry-diff.js',
+  'notify.js',
+  'plan-context.js',
+  'plan-critics.js',
+  'plan-persist.js',
+  'plan-run-epilogue.js',
+  'post-structured-comment.js',
+  'pr-watch-with-update.js',
+  'quality-preview.js',
+  'quality-watch.js',
+  'resolve-doc-tiers.js',
+  'resolve-stories.js',
+  'resync-status-column.js',
+  'run-coverage.js',
+  'run-lint.js',
+  'run-test-profile.js',
+  'run-tests.js',
+  'run-verify.js',
+  'signals-view.js',
+  'single-story-close.js',
+  'single-story-confirm-merge.js',
+  'single-story-init.js',
+  'stories-wave-tick.js',
+  'story-plan.js',
+  'sync-agentrc.js',
+  'sync-branch-from-base.js',
+  'sync-claude-agents.js',
+  'sync-claude-commands.js',
+  'test-isolate.js',
+  'test-wrapper.js',
+  'update-coverage-baseline.js',
+  'update-crap-baseline.js',
+  'update-duplication-baseline.js',
+  'update-maintainability-baseline.js',
+  'update-ticket-state.js',
+  'validate-docs-freshness.js',
+  'validate-skills.js',
+]);
+
+/**
+ * Membership index over {@link FRAMEWORK_SCRIPT_BASENAMES}, built once at
+ * module load so the per-signal scan is a hash lookup.
+ *
+ * @type {ReadonlySet<string>}
+ */
+const FRAMEWORK_SCRIPT_BASENAME_SET = new Set(FRAMEWORK_SCRIPT_BASENAMES);
+
+/**
+ * Characters a shell-ish command line can wrap a token in. Stripped from both
+ * ends before the membership test so `"acceptance-eval.js",` still resolves.
+ *
+ * @type {RegExp}
+ */
+const TOKEN_TRIM = /^[\s'"`(,;:]+|[\s'"`),;:]+$/g;
 
 /**
  * Normalise a value to a string for prefix scanning. Anything that is not
@@ -79,6 +205,44 @@ function containsFrameworkPrefix(haystack) {
 }
 
 /**
+ * Return true when `haystack` names a top-level framework script by **bare
+ * basename** — no path segment at all (Story #4916).
+ *
+ * Whitespace-tokenised and matched whole: only a token that *equals* a known
+ * basename counts. A token carrying any path segment is deliberately left to
+ * {@link containsFrameworkPrefix} — `./tools/notify.js` is the consumer's own
+ * script and must stay `consumer`, while `.agents/scripts/notify.js` already
+ * matches a prefix. Likewise `my-notify.js` is not `notify.js`.
+ *
+ * @param {string} haystack
+ * @returns {boolean}
+ */
+function containsFrameworkScriptBasename(haystack) {
+  if (haystack.length === 0) return false;
+  for (const rawToken of haystack.split(/\s+/)) {
+    const token = rawToken.replace(TOKEN_TRIM, '');
+    if (FRAMEWORK_SCRIPT_BASENAME_SET.has(token)) return true;
+  }
+  return false;
+}
+
+/**
+ * True when `haystack` names the framework's own surface, by either
+ * recognition route: a path prefix, or a bare framework-script basename.
+ *
+ * Purely additive over {@link containsFrameworkPrefix} — every string that
+ * matched a prefix still matches here, so widening can only ever move a
+ * classification from `consumer` to `framework`, never the reverse.
+ *
+ * @param {string} haystack
+ * @returns {boolean}
+ */
+function namesFrameworkSurface(haystack) {
+  if (containsFrameworkPrefix(haystack)) return true;
+  return containsFrameworkScriptBasename(haystack);
+}
+
+/**
  * Classify a friction signal as `"framework"` or `"consumer"`.
  *
  * Both arguments are best-effort: pass whatever the detector already has
@@ -92,6 +256,10 @@ function containsFrameworkPrefix(haystack) {
  * `node .agents/scripts/single-story-init.js` — that's framework friction even
  * though the failing test path lives under the consumer.
  *
+ * Either input matches on a framework path prefix **or** on a bare framework
+ * script basename (Story #4916), so `single-story-close.js --story 4906` is
+ * recognised exactly like its fully-pathed spelling.
+ *
  * @param {unknown} failingPath  The path of the file or directory the
  *                               signal blames (e.g. `"tests/foo.test.js"`).
  * @param {unknown} command       The command line the signal blames
@@ -101,8 +269,8 @@ function containsFrameworkPrefix(haystack) {
 export function classifyPathSource(failingPath, command) {
   const path = toScanString(failingPath);
   const cmd = toScanString(command);
-  if (containsFrameworkPrefix(path)) return 'framework';
-  if (containsFrameworkPrefix(cmd)) return 'framework';
+  if (namesFrameworkSurface(path)) return 'framework';
+  if (namesFrameworkSurface(cmd)) return 'framework';
   return 'consumer';
 }
 
@@ -229,5 +397,6 @@ export function classifySignalSource(record) {
 
 export const __testing = Object.freeze({
   FRAMEWORK_PREFIXES,
+  FRAMEWORK_SCRIPT_BASENAMES,
   TOOL_DEGRADED_CATEGORY,
 });

--- a/tests/lib/observability/source-classifier.test.js
+++ b/tests/lib/observability/source-classifier.test.js
@@ -8,7 +8,10 @@
  */
 
 import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
 import { describe, it } from 'node:test';
+import { fileURLToPath } from 'node:url';
 
 import { RUNTIME_FRICTION_CATEGORIES } from '../../../.agents/scripts/lib/observability/runtime-friction.js';
 import {
@@ -349,6 +352,241 @@ describe('classifySignalSource — defaults & coercion', () => {
         details: 'boom',
       }),
       'framework',
+    );
+  });
+});
+
+/**
+ * Story #4916 — recognition must not depend on how the caller spelled the
+ * reference.
+ *
+ * `node .agents/scripts/acceptance-eval.js --story 4901` classified
+ * `framework` while `acceptance-eval.js --story 4901` classified `consumer`,
+ * so two signals of otherwise identical shape carried different `source`
+ * values and a real framework defect was routed as consumer-actionable and
+ * discarded.
+ */
+const REPO_ROOT = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '../../..',
+);
+const SCRIPTS_DIR = path.join(REPO_ROOT, '.agents/scripts');
+const CLASSIFIER_PATH = path.join(
+  SCRIPTS_DIR,
+  'lib/observability/source-classifier.js',
+);
+
+describe('classifySignalSource — a bare framework-script basename is framework (Story #4916)', () => {
+  it('classifies the two live shapes measured on main as framework', () => {
+    // Both were measured returning `consumer` before this Story.
+    assert.equal(
+      classifySignalSource({
+        category: 'Execution Error',
+        emitter: {
+          tool: 'diagnose-friction',
+          command: 'single-story-close.js --story 4906',
+        },
+      }),
+      'framework',
+    );
+    assert.equal(
+      classifySignalSource({
+        category: 'Execution Error',
+        emitter: {
+          tool: 'diagnose-friction',
+          command: 'acceptance-eval.js --story 4901',
+        },
+      }),
+      'framework',
+    );
+  });
+
+  it('recognises the basename wherever it sits on the command line', () => {
+    assert.equal(classifyPathSource('', 'node run-tests.js'), 'framework');
+    assert.equal(
+      classifyPathSource('', 'npx --no-install plan-persist.js --dry-run'),
+      'framework',
+    );
+    assert.equal(
+      classifyPathSource('', 'sh -c "check-baselines.js"'),
+      'framework',
+      'surrounding quotes are stripped before the membership test',
+    );
+  });
+
+  it('recognises a bare basename supplied as the failingPath', () => {
+    assert.equal(classifyPathSource('update-ticket-state.js', ''), 'framework');
+  });
+
+  it('is spelling-independent: the pathed and bare forms agree', () => {
+    for (const basename of __testing.FRAMEWORK_SCRIPT_BASENAMES) {
+      assert.equal(
+        classifyPathSource('', `node ${basename} --story 4916`),
+        classifyPathSource('', `node .agents/scripts/${basename} --story 4916`),
+        `${basename}: bare and pathed spellings must classify alike`,
+      );
+    }
+  });
+});
+
+describe('classifySignalSource — the widening does not collapse into always-framework (Story #4916)', () => {
+  it('keeps a plain tool invocation consumer', () => {
+    assert.equal(classifyPathSource('', 'npm test'), 'consumer');
+    assert.equal(
+      classifyPathSource('', 'npm run build --workspace web'),
+      'consumer',
+    );
+    assert.equal(classifyPathSource('', 'pytest -k checkout'), 'consumer');
+  });
+
+  it('keeps a script basename that is not shipped under .agents/scripts/ consumer', () => {
+    assert.equal(classifyPathSource('', 'node seed-database.js'), 'consumer');
+    assert.equal(
+      classifyPathSource('', 'node scripts/deploy.js --env prod'),
+      'consumer',
+    );
+  });
+
+  it('does not match a basename carrying a consumer path segment', () => {
+    // The consumer's own `notify.js` is not the framework's.
+    assert.equal(classifyPathSource('', 'node ./tools/notify.js'), 'consumer');
+    assert.equal(classifyPathSource('tools/notify.js', ''), 'consumer');
+  });
+
+  it('matches whole tokens only, never a substring', () => {
+    assert.equal(classifyPathSource('', 'node my-notify.js'), 'consumer');
+    assert.equal(classifyPathSource('', 'node run-tests.js.bak'), 'consumer');
+  });
+});
+
+describe('source-classifier — widening is one-directional (Story #4916)', () => {
+  it('still returns framework for each of the four FRAMEWORK_PREFIXES forms', () => {
+    assert.deepEqual(__testing.FRAMEWORK_PREFIXES, [
+      '.agents/',
+      '.agentrc.json',
+      '.claude/',
+      'node .agents/scripts/',
+    ]);
+    for (const prefix of __testing.FRAMEWORK_PREFIXES) {
+      assert.equal(
+        classifyPathSource('', `host ${prefix} tail`),
+        'framework',
+        `${prefix} must still classify framework via the command route`,
+      );
+      assert.equal(
+        classifyPathSource(`host/${prefix}tail`, ''),
+        'framework',
+        `${prefix} must still classify framework via the failingPath route`,
+      );
+    }
+  });
+
+  it('still returns framework for the details-scan and tool-degraded tiers', () => {
+    assert.equal(
+      classifySignalSource({
+        category: 'close-failed',
+        details: { reason: 'conflicting files = .agents/scripts/foo.js' },
+      }),
+      'framework',
+      'details-scan tier unchanged',
+    );
+    assert.equal(
+      classifySignalSource({
+        category: 'tool-degraded',
+        emitter: { tool: 'native-review-lint' },
+      }),
+      'framework',
+      'tool-degraded tier unchanged',
+    );
+  });
+
+  it('reclassifies nothing from framework to consumer', () => {
+    // Every input the suite asserts as framework is re-asserted here as a set,
+    // so a future narrowing of the scan cannot pass by editing one case.
+    const frameworkInputs = [
+      ['.agents/scripts/story-init.js', ''],
+      ['repo/.agents/rules/security-baseline.md', ''],
+      ['.agentrc.json', ''],
+      ['subproject/.agentrc.json', ''],
+      ['.claude/settings.json', ''],
+      ['host/.claude/hooks/post-commit', ''],
+      ['', 'node .agents/scripts/story-init.js --story 2553'],
+      ['', 'ls .agents/scripts'],
+      ['', 'cat .agentrc.json'],
+      ['', 'rg foo .claude/'],
+      ['.agents/scripts/foo.js', 'npm run test'],
+      ['src/checkout/index.ts', 'node .agents/scripts/story-init.js'],
+    ];
+    for (const [failingPath, command] of frameworkInputs) {
+      assert.equal(
+        classifyPathSource(failingPath, command),
+        'framework',
+        `(${failingPath}, ${command}) must stay framework`,
+      );
+    }
+  });
+});
+
+describe('source-classifier — the recognized basename set cannot go stale (Story #4916)', () => {
+  it('matches the scripts actually shipped at the top level of .agents/scripts/', () => {
+    const shipped = fs
+      .readdirSync(SCRIPTS_DIR, { withFileTypes: true })
+      .filter((entry) => entry.isFile() && entry.name.endsWith('.js'))
+      .map((entry) => entry.name)
+      .sort();
+    assert.deepEqual(
+      [...__testing.FRAMEWORK_SCRIPT_BASENAMES].sort(),
+      shipped,
+      'a script was added, renamed, or removed without updating ' +
+        'FRAMEWORK_SCRIPT_BASENAMES in source-classifier.js — update the list, ' +
+        'or the classifier silently mis-routes that script’s friction signals',
+    );
+  });
+});
+
+describe('source-classifier — classification performs no filesystem access (Story #4916)', () => {
+  it('reads nothing while classifying', (t) => {
+    const readMethods = [
+      'readFileSync',
+      'readdirSync',
+      'existsSync',
+      'statSync',
+      'openSync',
+      'realpathSync',
+    ];
+    for (const method of readMethods) {
+      t.mock.method(fs, method, () => {
+        throw new Error(`source-classifier must not call fs.${method}`);
+      });
+    }
+    for (const basename of __testing.FRAMEWORK_SCRIPT_BASENAMES) {
+      classifySignalSource({
+        category: 'Execution Error',
+        emitter: {
+          tool: 'diagnose-friction',
+          command: `${basename} --story 1`,
+        },
+      });
+    }
+    classifySignalSource({ category: 'close-failed' });
+    for (const method of readMethods) {
+      assert.equal(
+        fs[method].mock.callCount(),
+        0,
+        `fs.${method} was called during classification`,
+      );
+    }
+  });
+
+  it('imports nothing from node:fs — the set is static data', () => {
+    // Belt-and-braces over the runtime mock above: a named `import { readdirSync }
+    // from 'node:fs'` would bind past the mocked property, so pin the source too.
+    const source = fs.readFileSync(CLASSIFIER_PATH, 'utf8');
+    assert.equal(
+      /from\s+'(node:)?fs(\/promises)?'/.test(source),
+      false,
+      'source-classifier.js must not import node:fs — it is called per signal ' +
+        'and stays pure',
     );
   });
 });


### PR DESCRIPTION
Closes #4916

_Auto-opened by `/deliver`._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive routing heuristic in observability tagging with broad unit coverage; no auth, data, or runtime I/O changes.
> 
> **Overview**
> Friction signals that blame a Mandrel CLI by **bare script name** (e.g. `acceptance-eval.js --story 4901`) were tagged `consumer` while the same invocation with a full `.agents/scripts/` path was `framework`, so real framework failures could be dropped from the framework retro stream.
> 
> **`source-classifier.js`** adds a static list of top-level `.agents/scripts/*.js` basenames and treats whitespace-delimited command tokens (with light quote/comma trimming) as framework when they match that set. Path-prefix rules are unchanged; matching is routed through `namesFrameworkSurface`, which is **additive** so nothing should flip from `framework` to `consumer`. Library paths under `lib/` are intentionally excluded to avoid false positives on generic names like `notify.js`.
> 
> **Tests** cover the production command shapes, pathed vs bare parity for every listed script, guardrails (consumer paths, substring mismatches), regression on prefix/details/`tool-degraded` tiers, a directory sync check so the basename list cannot drift, and asserts the classifier stays pure (no `fs` at classify time).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7f2f6a4687da6d658acaf6ccd304deee7129d2c8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->