### PR TITLE
feat: make the dash range concept explicitly supported when invoking /deliver… (#4927)

### DIFF
--- a/.agents/scripts/lib/orchestration/resolve-stories.js
+++ b/.agents/scripts/lib/orchestration/resolve-stories.js
@@ -34,6 +34,7 @@ import {
   extractChangePaths,
   parse as parseStoryBody,
 } from '../story-body/story-body.js';
+import { expandIdList } from '../util/parse-id-list.js';
 import { resolveStoryDispatchMode } from './complexity-gate.js';
 
 /** Labels/state that mean a blocker no longer gates its dependents. */
@@ -355,29 +356,29 @@ export function buildStoriesEnvelope({
 }
 
 /**
- * Parse and validate the `--ids` list.
+ * Parse and validate the `--ids` list, expanding any `A-B` dash range.
+ *
+ * A contiguous span is how an operator names a plan run — `/deliver 4922 -
+ * 4926` — so the range is expanded here rather than transcribed by the host.
+ * `stories-wave-tick.js --stories` reads through this same function, which is
+ * what keeps the sequencing set identical to the resolved one.
  *
  * @param {string|undefined} raw
+ * @param {string} [flag] Flag name, for the error message.
  * @returns {number[]}
  */
-export function parseIds(raw) {
-  const ids = String(raw ?? '')
-    .split(',')
-    .map((s) => s.trim())
-    .filter(Boolean)
-    .map((s) => {
-      const n = Number.parseInt(s, 10);
-      if (!Number.isInteger(n) || n <= 0 || String(n) !== s) {
-        throw new Error(
-          `[resolve-stories] --ids must be a comma-separated list of positive issue numbers (got "${s}").`,
-        );
-      }
-      return n;
-    });
+export function parseIds(raw, flag = '--ids') {
+  const { ids, error } = expandIdList(raw, {
+    flag,
+    prefix: '[resolve-stories] ',
+  });
+  if (error) {
+    throw new Error(error);
+  }
   if (ids.length === 0) {
     throw new Error(
-      '[resolve-stories] --ids is required: node resolve-stories.js --ids 101,102',
+      `[resolve-stories] ${flag} is required: node resolve-stories.js --ids 101,102 (or a range: --ids 101-104)`,
     );
   }
-  return [...new Set(ids)];
+  return ids;
 }

--- a/.agents/scripts/lib/util/parse-id-list.js
+++ b/.agents/scripts/lib/util/parse-id-list.js
@@ -1,0 +1,103 @@
+/**
+ * parse-id-list — expand a Story-id list that may contain dash ranges.
+ *
+ * Operators name a contiguous span of Stories the way they read one — as a
+ * range: `/deliver 4922 - 4926`. Enumerating it by hand is the kind of
+ * transcription step that silently drops or invents an id, so the range is a
+ * first-class shape of every delivery id list rather than something the host
+ * expands from prose.
+ *
+ * Accepted tokens, comma-separated:
+ *   - a single id, with an optional `#` — `4922`, `#4922`
+ *   - an inclusive range — `4922-4926`, `4922 - 4926`, `#4922-#4926`
+ *     (hyphen-minus, en dash, or em dash; whitespace around it is fine)
+ *
+ * Everything else is a hard error, never a silent drop: a wrong id list
+ * co-dispatches against the wrong graph, so it must fail where it is typed.
+ * Two range-specific guards exist for the same reason — a backwards range is
+ * refused rather than expanded to nothing, and a span above `MAX_RANGE_SPAN`
+ * is refused rather than resolving thousands of issues off a typo.
+ */
+
+/**
+ * Inclusive-span ceiling for a single range token. Generous against any real
+ * plan run (a handful of Stories) and tight enough that `1-4926` is caught as
+ * the typo it is rather than fanning out into a live resolution sweep.
+ *
+ * Deliberately module-private: the cap is a published contract
+ * (`helpers/deliver-reference.md` § Ranges), so a test that imported it could
+ * not notice the number silently moving out from under the doc.
+ */
+const MAX_RANGE_SPAN = 50;
+
+/** Hyphen-minus, en dash, em dash — whichever the operator's keyboard emits. */
+const DASH = '[-–—]';
+const SINGLE_RE = /^#?(\d+)$/;
+const RANGE_RE = new RegExp(`^#?(\\d+)\\s*${DASH}\\s*#?(\\d+)$`);
+
+/**
+ * Parse a comma-separated Story-id list, expanding any `A-B` range token.
+ *
+ * Absent or empty input is not an error here — it yields an empty list, and
+ * the caller decides whether that is a usage error (`--ids`) or a legitimate
+ * empty set (`--done`).
+ *
+ * @param {string|undefined|null} raw
+ * @param {object} [options]
+ * @param {string} [options.flag] Flag name, for the error message.
+ * @param {string} [options.prefix] Message prefix, for the caller's log tag.
+ * @param {number} [options.maxSpan] Inclusive-span ceiling per range token.
+ * @returns {{ ids: number[]|null, error: string|null }}
+ */
+export function expandIdList(raw, options = {}) {
+  const { flag = '--ids', prefix = '', maxSpan = MAX_RANGE_SPAN } = options;
+  const fail = (message) => ({ ids: null, error: `${prefix}${message}` });
+
+  const ids = [];
+  const seen = new Set();
+  const push = (n) => {
+    if (seen.has(n)) return;
+    seen.add(n);
+    ids.push(n);
+  };
+
+  for (const token of String(raw ?? '').split(',')) {
+    const trimmed = token.trim();
+    if (trimmed === '') continue;
+
+    const range = RANGE_RE.exec(trimmed);
+    if (range) {
+      const start = Number(range[1]);
+      const end = Number(range[2]);
+      if (start <= 0 || end <= 0) {
+        return fail(
+          `${flag} range "${trimmed}" must use positive issue numbers.`,
+        );
+      }
+      if (end < start) {
+        return fail(
+          `${flag} range "${trimmed}" runs backwards — write it low-to-high (e.g. 4922-4926).`,
+        );
+      }
+      const span = end - start + 1;
+      if (span > maxSpan) {
+        return fail(
+          `${flag} range "${trimmed}" spans ${span} ids, above the ${maxSpan}-id cap. Narrow it, or list the ids.`,
+        );
+      }
+      for (let n = start; n <= end; n++) push(n);
+      continue;
+    }
+
+    const single = SINGLE_RE.exec(trimmed);
+    const n = single ? Number(single[1]) : Number.NaN;
+    if (!Number.isInteger(n) || n <= 0) {
+      return fail(
+        `${flag} must be a comma-separated list of positive issue numbers or A-B ranges (got "${trimmed}").`,
+      );
+    }
+    push(n);
+  }
+
+  return { ids, error: null };
+}

--- a/.agents/scripts/plan-run-epilogue.js
+++ b/.agents/scripts/plan-run-epilogue.js
@@ -5,6 +5,7 @@
  *
  * Usage:
  *   node .agents/scripts/plan-run-epilogue.js --stories 1,2,3
+ *   node .agents/scripts/plan-run-epilogue.js --stories 101-104   # inclusive range
  *
  * Keyed on the delivered id set: an `adhoc-<sorted-ids>` run id is
  * synthesized from `--stories`. Story #4540 retired the `--run <planRunId>`
@@ -19,6 +20,7 @@ import { resolveConfig } from './lib/config-resolver.js';
 import { Logger } from './lib/Logger.js';
 import { runPlanRunEpilogue } from './lib/orchestration/run-epilogue.js';
 import { createProvider } from './lib/provider-factory.js';
+import { expandIdList } from './lib/util/parse-id-list.js';
 
 const CLI_OPTIONS = {
   stories: { type: 'string' },
@@ -65,10 +67,17 @@ export async function main(argv = process.argv.slice(2), deps = {}) {
   // along with the label itself. The epilogue is keyed on the delivered id
   // set, and the synthesized `adhoc-<ids>` id it already used for positional
   // runs is now the only id it needs.
-  const stories = values.stories
-    .split(',')
-    .map((s) => Number(s.trim()))
-    .filter((n) => Number.isInteger(n) && n > 0);
+  // Range tokens expand here too (`--stories 101-104`): /deliver blesses the
+  // dash range at the operator surface, so the id set the epilogue is keyed on
+  // must read the same shape. Rejecting a bad token is deliberate — the old
+  // silent filter turned a typo into an empty, wrongly-keyed rollup.
+  const { ids: stories, error: storiesError } = expandIdList(values.stories, {
+    flag: '--stories',
+    prefix: '[plan-run-epilogue] ',
+  });
+  if (storiesError) {
+    throw new Error(storiesError);
+  }
 
   const planRunId = `adhoc-${[...stories].sort((a, b) => a - b).join('-')}`;
 
@@ -162,7 +171,10 @@ await runAsCli(import.meta.url, main, {
     summary:
       'Close out a delivery run: roll up the delivered Stories’ signals and report the run’s loop health.',
     flags: [
-      ['--stories <ids>', 'Comma-separated delivered Story ids (required).'],
+      [
+        '--stories <ids>',
+        'Comma-separated delivered Story ids, singles or A-B ranges (required).',
+      ],
       ['--cwd <path>', 'Repository root (default: process cwd).'],
     ],
   },

--- a/.agents/scripts/resolve-stories.js
+++ b/.agents/scripts/resolve-stories.js
@@ -24,6 +24,7 @@
  *
  * Usage:
  *   node .agents/scripts/resolve-stories.js --ids 101,102
+ *   node .agents/scripts/resolve-stories.js --ids 101-104        # inclusive range
  *   node .agents/scripts/resolve-stories.js --ids 101,102 --pretty
  *   node .agents/scripts/resolve-stories.js --ids 101 --no-native   # skip the dependencies API
  *
@@ -65,7 +66,9 @@ blocked_by edges, with every blocker (in-set or foreign) resolved against its
 real issue state.
 
 Options:
-  --ids <csv>    Comma-separated Story issue numbers. Required.
+  --ids <csv>    Comma-separated Story issue numbers. Required. A token may be
+                 a single id (4922) or an inclusive dash range (4922-4926);
+                 ranges expand in place and dedupe against the rest.
   --pretty       Pretty-print the JSON envelope.
   --no-native    Skip the native blocked_by read (body edges only).
   --help         Show this help.

--- a/.agents/scripts/stories-wave-tick.js
+++ b/.agents/scripts/stories-wave-tick.js
@@ -104,6 +104,7 @@ import { Logger } from './lib/Logger.js';
 import { AGENT_LABELS } from './lib/label-constants.js';
 import { parseIds } from './lib/orchestration/resolve-stories.js';
 import { buildStoryAdjacency } from './lib/story-adjacency.js';
+import { expandIdList } from './lib/util/parse-id-list.js';
 import {
   createProbeContext,
   probeLiveState,
@@ -153,9 +154,10 @@ Each entry must include:
   dependsOn  - Array of Story IDs that must complete before this Story runs
 
 Options:
-  --stories <csv>    Story ids to deliver (probe mode). The graph, the done
-                     set, and the in-flight count are resolved from live
-                     state — no --done / --in-flight bookkeeping.
+  --stories <csv>    Story ids to deliver (probe mode). Singles or inclusive
+                     A-B ranges (101,104-107). The graph, the done set, and
+                     the in-flight count are resolved from live state — no
+                     --done / --in-flight bookkeeping.
   --probe-live       Enable probe mode. Requires --stories.
   --dispatched <csv> Probe mode only. Ids you have SPAWNED this run. Unioned
                      into the live-derived in-flight set, then filtered by
@@ -308,33 +310,22 @@ export function parseDag(raw) {
 }
 
 /**
- * Parse a comma-separated list of Story IDs into a deduped set of positive
- * integers. Empty / absent input yields an empty set. Rejects any token that
- * is not a positive integer so a typo never silently drops a dependency gate
- * (`--done`) or a held dispatch slot (`--dispatched`).
+ * Parse a comma-separated list of Story IDs — singles or `A-B` dash ranges —
+ * into a deduped set of positive integers. Empty / absent input yields an
+ * empty set. Rejects any token that is not a positive integer or a valid
+ * range, so a typo never silently drops a dependency gate (`--done`) or a
+ * held dispatch slot (`--dispatched`).
+ *
+ * Ranges are accepted here for the same reason `--stories` accepts them: an
+ * operator delivering `4922-4926` writes the dispatched set back the same way.
  *
  * @param {string|undefined} raw
  * @param {string} flag Flag name, for the error message.
  * @returns {{ ids: Set<number>|null, error: string|null }}
  */
 export function parseIdCsv(raw, flag) {
-  if (raw == null || raw === '') {
-    return { ids: new Set(), error: null };
-  }
-  const ids = new Set();
-  for (const token of String(raw).split(',')) {
-    const trimmed = token.trim();
-    if (trimmed === '') continue;
-    const num = Number(trimmed);
-    if (!Number.isInteger(num) || num <= 0) {
-      return {
-        ids: null,
-        error: `${flag} must be a comma-separated list of positive integers, got "${trimmed}"`,
-      };
-    }
-    ids.add(num);
-  }
-  return { ids, error: null };
+  const { ids, error } = expandIdList(raw, { flag });
+  return error ? { ids: null, error } : { ids: new Set(ids), error: null };
 }
 
 /**
@@ -775,7 +766,7 @@ export async function runProbedStoriesWaveTick({
 
   let ids;
   try {
-    ids = parseIds(stories);
+    ids = parseIds(stories, '--stories');
   } catch (err) {
     return inputErrorResult(err.message);
   }

--- a/.agents/workflows/deliver.md
+++ b/.agents/workflows/deliver.md
@@ -35,12 +35,15 @@ you read:
 | `/deliver` | bare | List the open `agent::ready` Stories and ask which to deliver. Deliver nothing until answered. |
 | `/deliver 4712` | ids | One Story via `helpers/deliver-story.md`, **inline in this session** — no `story-worker` spawn. |
 | `/deliver 4712 4713 …` | ids | Resolve the set, sequence by the discovered graph via `stories-wave-tick.js`, dispatch sub-agents. |
+| `/deliver 4712 - 4716` | ids | A **range** — every id in the inclusive span. |
 | `/deliver add a --json flag to doctor` | prompt | Unplanned work: gate, author a receipt Story, land it — [`helpers/deliver-light.md`](helpers/deliver-light.md). |
 
-**The discriminator is lexical and total.** Every positional argument matching
-`^#?\d+$` means ids; anything else means a prompt. A **mixed** invocation (ids
-*and* prose) is a **hard error** — refuse it and ask which was meant. A ticket
-not `type::story`, or carrying an `Epic: #N` footer, is a hard error too.
+**The discriminator is lexical and total.** An argument matching `^#?\d+$` is an
+id, and `^#?\d+\s*[-–—]\s*#?\d+$` an inclusive **range** — pass one on as a
+single unspaced token, never hand-expanded (reference § Ranges). Either shape
+means ids; anything else means a prompt. A **mixed** invocation (ids *and*
+prose) is a **hard error** — refuse it and ask which was meant. A ticket not
+`type::story`, or carrying an `Epic: #N` footer, is a hard error too.
 
 ## Saying what you want
 

--- a/.agents/workflows/helpers/deliver-reference.md
+++ b/.agents/workflows/helpers/deliver-reference.md
@@ -12,6 +12,34 @@ Reference-only detail split out of [`deliver.md`](../deliver.md) so the
 always-resident spine stays lean. Nothing here is a new MUST —
 it is the mechanics an operator consults when the matching lever is engaged.
 
+## Ranges (`4922 - 4926`) {#ranges}
+
+A contiguous span is how an operator reads a plan run, so the dash range is a
+first-class id shape rather than prose to interpret — `/deliver 4922 - 4926`
+means exactly the five ids in it.
+
+**Pass the span through; never expand it by hand.** Every id-list flag on the
+delivery path takes range tokens — `resolve-stories.js --ids`,
+`stories-wave-tick.js --stories` and `--dispatched`, and
+`plan-run-epilogue.js --stories`. Normalize the operator's spacing away and hand
+the scripts one unspaced token (`--ids 4922-4926`), mixed freely with singles
+and commas (`--ids 4901,4922-4926`); overlaps dedupe. A hand-typed enumeration
+is where an id gets dropped or invented, and the drop is silent.
+
+The shared expander (`lib/util/parse-id-list.js`) refuses rather than guesses,
+so a typo fails where it was typed instead of resolving the wrong set:
+
+| Input | Outcome |
+| --- | --- |
+| `4922-4926`, `4922 - 4926` | Expands to the inclusive span. En and em dashes, and a `#` on either endpoint, are accepted too. |
+| `4926-4922` | Refused — write it low-to-high. |
+| `1-4926` | Refused — above the 50-id span cap (`MAX_RANGE_SPAN`). |
+| `4922-`, `-4926`, `4922-4923-4924` | Refused as a malformed token. |
+
+The cap is per range token, not per run: a genuine 60-Story delivery is still
+expressible as two ranges, but a slipped digit cannot fan out into a live
+resolution sweep of thousands of issues.
+
 ## Sequencing edge cases (`stories-wave-tick.js`)
 
 **What "discovered, not declared" means concretely.** `resolve-stories.js` reads

--- a/tests/plan-run-epilogue.test.js
+++ b/tests/plan-run-epilogue.test.js
@@ -56,11 +56,24 @@ describe('plan-run-epilogue main', () => {
     assert.deepEqual(h.calls[0].stories, [30, 4, 12]);
   });
 
-  it('drops non-integer and non-positive ids', async () => {
+  // Tightened deliberately, not loosened: this used to silently DROP a bad
+  // token, which turned a typo into an epilogue keyed on the wrong id set and
+  // an empty roll-up that reads like a clean run. Every sibling id parser
+  // fails loud, and now so does this one.
+  it('refuses a non-integer or non-positive id rather than dropping it', async () => {
+    for (const bad of ['5, abc , 7', '5,0', '5,-2']) {
+      await assert.rejects(
+        () => main(['--stories', bad], harness().deps),
+        /\[plan-run-epilogue\] --stories/,
+      );
+    }
+  });
+
+  it('expands a dash range into the delivered id set', async () => {
     const h = harness();
-    await main(['--stories', '5, abc ,0,-2, 7 '], h.deps);
-    assert.deepEqual(h.calls[0].stories, [5, 7]);
-    assert.equal(h.calls[0].planRunId, 'adhoc-5-7');
+    await main(['--stories', '12,30-32'], h.deps);
+    assert.deepEqual(h.calls[0].stories, [12, 30, 31, 32]);
+    assert.equal(h.calls[0].planRunId, 'adhoc-12-30-31-32');
   });
 
   it('defaults cwd to the process cwd and threads --cwd when given', async () => {

--- a/tests/scripts/parse-id-list.test.js
+++ b/tests/scripts/parse-id-list.test.js
@@ -1,0 +1,141 @@
+/**
+ * parse-id-list.test.js — the shared Story-id list expander.
+ *
+ * Tier: unit. Pure parsing, no I/O.
+ *
+ * Covers the dash-range shape an operator types at `/deliver` — a contiguous
+ * span written `4922-4926` rather than enumerated — plus the guards that keep
+ * a typo (`1-4926`) or a backwards span from being read as a delivery set.
+ */
+
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import { expandIdList } from '../../.agents/scripts/lib/util/parse-id-list.js';
+
+/**
+ * The default span cap, asserted as the literal the docs publish rather than
+ * imported from the module — `helpers/deliver-reference.md` § Ranges states
+ * it, so a test reading the constant back could not catch the two drifting.
+ */
+const MAX_RANGE_SPAN = 50;
+
+describe('expandIdList — plain lists', () => {
+  it('returns an empty list for absent / empty input', () => {
+    assert.deepEqual(expandIdList(undefined), { ids: [], error: null });
+    assert.deepEqual(expandIdList(''), { ids: [], error: null });
+  });
+
+  it('parses a comma-separated list, deduped in first-seen order', () => {
+    const { ids, error } = expandIdList('101, 103,101');
+    assert.equal(error, null);
+    assert.deepEqual(ids, [101, 103]);
+  });
+
+  it('skips empty tokens from a trailing comma or stray whitespace', () => {
+    const { ids, error } = expandIdList('5, ,6,');
+    assert.equal(error, null);
+    assert.deepEqual(ids, [5, 6]);
+  });
+
+  it('accepts an optional # prefix, matching what an operator types', () => {
+    const { ids, error } = expandIdList('#101,#103');
+    assert.equal(error, null);
+    assert.deepEqual(ids, [101, 103]);
+  });
+
+  it('rejects a non-numeric token', () => {
+    const { ids, error } = expandIdList('5,abc');
+    assert.equal(ids, null);
+    assert.match(error, /positive issue numbers or A-B ranges/);
+    assert.match(error, /"abc"/);
+  });
+
+  it('rejects a non-positive token', () => {
+    const { ids, error } = expandIdList('5,0');
+    assert.equal(ids, null);
+    assert.match(error, /"0"/);
+  });
+});
+
+describe('expandIdList — dash ranges', () => {
+  it('expands an inclusive A-B range', () => {
+    const { ids, error } = expandIdList('4922-4926');
+    assert.equal(error, null);
+    assert.deepEqual(ids, [4922, 4923, 4924, 4925, 4926]);
+  });
+
+  it('tolerates whitespace around the dash, as typed', () => {
+    const { ids, error } = expandIdList('4922 - 4924');
+    assert.equal(error, null);
+    assert.deepEqual(ids, [4922, 4923, 4924]);
+  });
+
+  it('accepts en dash and em dash separators', () => {
+    assert.deepEqual(expandIdList('101–103').ids, [101, 102, 103]);
+    assert.deepEqual(expandIdList('101—103').ids, [101, 102, 103]);
+  });
+
+  it('accepts a # prefix on either endpoint', () => {
+    const { ids, error } = expandIdList('#101-#103');
+    assert.equal(error, null);
+    assert.deepEqual(ids, [101, 102, 103]);
+  });
+
+  it('treats a single-id range as that one id', () => {
+    assert.deepEqual(expandIdList('4922-4922').ids, [4922]);
+  });
+
+  it('mixes ranges and singles in one list, deduping the overlap', () => {
+    const { ids, error } = expandIdList('4920,4922-4924,4923');
+    assert.equal(error, null);
+    assert.deepEqual(ids, [4920, 4922, 4923, 4924]);
+  });
+
+  it('rejects a backwards range rather than silently emptying it', () => {
+    const { ids, error } = expandIdList('4926-4922');
+    assert.equal(ids, null);
+    assert.match(error, /low-to-high/);
+    assert.match(error, /"4926-4922"/);
+  });
+
+  it('rejects a range wider than the span cap', () => {
+    const { ids, error } = expandIdList(`1-${MAX_RANGE_SPAN + 1}`);
+    assert.equal(ids, null);
+    assert.match(error, new RegExp(String(MAX_RANGE_SPAN)));
+  });
+
+  it('accepts a range exactly at the span cap', () => {
+    const { ids, error } = expandIdList(`1-${MAX_RANGE_SPAN}`);
+    assert.equal(error, null);
+    assert.equal(ids.length, MAX_RANGE_SPAN);
+  });
+
+  it('rejects a malformed range (missing endpoint, triple dash)', () => {
+    assert.equal(expandIdList('4922-').ids, null);
+    assert.equal(expandIdList('-4926').ids, null);
+    assert.equal(expandIdList('4922-4923-4924').ids, null);
+  });
+
+  it('rejects a non-positive range endpoint', () => {
+    const { ids, error } = expandIdList('0-3');
+    assert.equal(ids, null);
+    assert.ok(error);
+  });
+});
+
+describe('expandIdList — message shaping', () => {
+  it('names the flag and prefix the caller supplies', () => {
+    const { error } = expandIdList('abc', {
+      flag: '--done',
+      prefix: '[wave-tick] ',
+    });
+    assert.match(error, /^\[wave-tick\] --done /);
+  });
+
+  it('honours a caller-supplied span cap', () => {
+    const { ids, error } = expandIdList('1-5', { maxSpan: 4 });
+    assert.equal(ids, null);
+    assert.match(error, /5 ids/);
+  });
+});

--- a/tests/scripts/resolve-stories.test.js
+++ b/tests/scripts/resolve-stories.test.js
@@ -549,6 +549,20 @@ describe('parseIds', () => {
   it('rejects an empty list', () => {
     assert.throws(() => parseIds(''), /--ids is required/);
   });
+  it('expands an inclusive dash range, as the operator types it', () => {
+    assert.deepEqual(parseIds('4922-4925'), [4922, 4923, 4924, 4925]);
+    assert.deepEqual(parseIds('4922 - 4924'), [4922, 4923, 4924]);
+  });
+  it('dedupes a range against the singles around it', () => {
+    assert.deepEqual(parseIds('4920,4922-4924,4923'), [4920, 4922, 4923, 4924]);
+  });
+  it('rejects a backwards range instead of resolving nothing', () => {
+    assert.throws(() => parseIds('4926-4922'), /low-to-high/);
+  });
+  it('names the caller flag in the error, so --stories does not report --ids', () => {
+    assert.throws(() => parseIds('abc', '--stories'), /--stories must be/);
+    assert.throws(() => parseIds('', '--stories'), /--stories is required/);
+  });
 });
 
 describe('storyFootprintPaths — an unreadable footprint fails SAFE, not open', () => {

--- a/tests/scripts/stories-wave-tick.test.js
+++ b/tests/scripts/stories-wave-tick.test.js
@@ -158,6 +158,21 @@ describe('parseDoneIds', () => {
     assert.strictEqual(ids, null);
     assert.ok(error);
   });
+
+  it('expands a dash range, so a ranged run reports back in the same shape', () => {
+    const { ids, error } = parseDoneIds('101,103-105');
+    assert.strictEqual(error, null);
+    assert.deepEqual(
+      [...ids].sort((a, b) => a - b),
+      [101, 103, 104, 105],
+    );
+  });
+
+  it('rejects a backwards range', () => {
+    const { ids, error } = parseDoneIds('105-103');
+    assert.strictEqual(ids, null);
+    assert.match(error, /--done/);
+  });
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #4927

_Auto-opened by `/deliver`._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are localized to CLI id parsing and agent workflow docs; wrong-id-set risk is reduced by explicit errors and a 50-id range cap, with broad unit test coverage.
> 
> **Overview**
> **`/deliver` and the delivery CLIs now treat inclusive dash ranges as first-class Story id input** (e.g. `4922-4926` or `4922 - 4926`), so operators can name a plan run as a span instead of hand-enumerating ids.
> 
> A shared **`expandIdList`** in `lib/util/parse-id-list.js` parses comma-separated singles and ranges (optional `#`, hyphen/en/em dash, dedupe), refuses backwards or over-50-id spans, and errors on bad tokens instead of dropping them. **`parseIds`** in resolve-stories delegates to it (with a configurable flag name for errors). **`stories-wave-tick`** routes `--stories`, `--done`, and `--dispatched` through the same expander via **`parseIdCsv`**. **`plan-run-epilogue --stories`** switches from silently filtering bad ids to the same fail-loud parsing.
> 
> Workflow docs add a **range** invocation shape and a **Ranges** reference section: pass normalized unspaced tokens to scripts; do not expand ranges by hand in the host session.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6b3de9722813661c8e33629a12869553cf1bc23d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->