### PR TITLE
docs: repair the entry-point and operations docs: wrong commands, undercounted gates, and a decayed review snapshot (#4925)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,8 +25,9 @@ materialized into consumer projects' `.agents/` directories by
   [`package.json`](package.json) (run `npm ls mandrel` in a consumer project)
 - **License:** MIT
 
-> **Key distinction:** the package ships `.agents/`, `bin/`, `lib/` — the rest
-> of this repository is internal development tooling.
+> **Key distinction:** the package ships `.agents/`, `bin/`, `lib/`, and
+> `docs/CHANGELOG.md` (the `files` array in [`package.json`](package.json)) —
+> the rest of this repository is internal development tooling.
 
 ---
 
@@ -41,8 +42,11 @@ not `@`-imported, so it is not re-paid on every session and subagent spawn.
 
 Two orientation pointers are load-bearing often enough to keep here:
 
-- **Configuration** lives in [`.agentrc.json`](.agentrc.json) (`project`,
-  `github`, `planning`, `delivery`). Project-specific technology choices are
+- **Configuration** lives in [`.agentrc.json`](.agentrc.json) — this repo's
+  file carries `project`, `github`, and `delivery`; every key the schema
+  accepts is documented in
+  [`.agents/docs/configuration.md`](.agents/docs/configuration.md).
+  Project-specific technology choices are
   deliberately kept out of it — the Tech Stack inventory lives under the
   **Tech Stack** heading in [`docs/architecture.md`](docs/architecture.md).
 - **Skills and rules are read on demand**, not preloaded — each `SKILL.md`

--- a/README.md
+++ b/README.md
@@ -182,7 +182,9 @@ dimensions, run model, and how to benchmark a new version.
 ## Contributors
 
 The published `mandrel` package ships three directories — `.agents/`, `bin/`,
-and `lib/` (see the `files` array in [`package.json`](package.json)).
+and `lib/` — plus the single file `docs/CHANGELOG.md`, and excludes the
+`__tests__` subtrees under `.agents/` and `lib/` (see the `files` array in
+[`package.json`](package.json)).
 `.agents/` is the payload `mandrel sync` materializes into a consumer's
 `./.agents/` directory; `bin/mandrel.js` and its `lib/` implementation stay
 inside `node_modules/mandrel/` and back the `npx mandrel …` CLI used
@@ -193,8 +195,8 @@ tooling and is not published.
 Common commands while developing the framework itself:
 
 ```bash
-npm run lint           # markdown + biome
-npm run format         # auto-format
+npm run lint           # biome + markdownlint + repo ratchets + generated-doc drift
+npm run format         # biome format — JavaScript/JSON only, not markdown
 npm test               # framework tests
 npm run test:coverage  # tests with coverage gate
 ```
@@ -226,9 +228,14 @@ against malicious lifecycle scripts in compromised transitive packages
 install scripts for a specific install, run
 `npm install --ignore-scripts=false` for that invocation only.
 
-CRAP and Maintainability gates fire at three sites — close-validation
-(story close), `.husky/pre-push`, and CI (`ci.yml`, push + PR) — against
-the same thresholds from `delivery.quality.*` in `.agentrc.json`.
+CRAP and Maintainability gates fire at four sites — `.husky/pre-commit`
+(`quality-preview.js --staged`, scored on the staged index), `.husky/pre-push`
+(diff-scoped against `origin/main`), close-validation (story close), and CI
+(`ci.yml`, push + PR) — against the same thresholds from
+`delivery.quality.*` in `.agentrc.json`. All four are **blocking**: the
+pre-commit hook fires earliest and refuses the commit on a threshold
+violation, and a green `npm run lint` / `npm test` / `check-baselines.js`
+run does not predict it.
 
 ## License
 

--- a/docs/archive/claude-coupling-review-2026-07.md
+++ b/docs/archive/claude-coupling-review-2026-07.md
@@ -1,0 +1,141 @@
+# Archived Claude coupling inventory — 2026-07
+
+**Snapshot date:** 2026-07-17 · **Commit:** `493b3eb0` · **Scope:** whole repository
+
+Verbatim citation tables relocated out of
+[`docs/claude-coupling-review.md`](../claude-coupling-review.md) by Story #4925.
+This is the **evidence record** for
+[ADR `20260512-coupling-stance`](../decisions.md) — archived, never deleted. The
+live doc keeps the findings that still bind; this file keeps the point-in-time
+file:line proof they rested on.
+
+> **These citations are stale by design.** They were accurate at commit
+> `493b3eb0` on 2026-07-17 and have **not** been re-verified since. A
+> 2026-08 spot-check of 16 citations found **6 no longer landing** — files
+> moved, line numbers drifted, and at least one cited surface was retired
+> outright. Treat every `path:line` below as a historical pointer, not a
+> lookup. Re-derive from the current tree before acting on any of it.
+
+**Edits made during relocation.** Prose is word-for-word as it stood in
+`docs/claude-coupling-review.md`. Two mechanical changes only:
+
+1. **Link re-rooting** — relative links were re-pointed one level up so they
+   still resolve from this directory (`../.agents/…` → `../../.agents/…`,
+   `decisions.md` → `../decisions.md`, and so on).
+2. **One bullet was lifted, not copied.** The `mcp__chrome-devtools__*`
+   host-dependency bullet from § 7 stayed in the live doc rather than moving
+   here, because it still binds current code — and the retired lens it cited
+   is corrected there to `audit-accessibility`, the WCAG lens that replaced
+   it wholesale.
+
+---
+
+## Host-integration clusters — the citations
+
+The seven clusters, ordered hardest to easiest to abstract. Cluster *names* and
+their still-live "Already mitigated" notes remain in
+[the live doc](../claude-coupling-review.md); the file:line evidence is below.
+
+### 1. The `.claude/` projection pipeline — the single biggest lever
+
+The distribution model itself: materialize `.agents/`, then project workflows
+into `.claude/commands/` and agent definitions into `.claude/agents/`. The CLI
+orbits this projection.
+
+| Location | Coupling |
+| --- | --- |
+| [`.agents/scripts/sync-claude-commands.js`](../../.agents/scripts/sync-claude-commands.js) | Projects `.agents/workflows/*` → `.claude/commands/*.md`; namespaces subpaths as `/loops:<name>` |
+| [`.agents/scripts/sync-claude-agents.js`](../../.agents/scripts/sync-claude-agents.js) | Projects role defs → `.claude/agents/<name>.md` for `subagent_type: <name>` |
+| [`bin/mandrel.js:57`](../../bin/mandrel.js) | `sync-commands` / `sync-agents` subcommands hardcode the `.claude/` targets |
+| [`lib/cli/sync-commands.js`](../../lib/cli/sync-commands.js), [`lib/cli/sync-agents.js`](../../lib/cli/sync-agents.js) | Delegators to the two engines above |
+| [`lib/cli/registry.js:224`](../../lib/cli/registry.js) | Doctor checks `commands-in-sync` / `agents-in-sync`; the latter is **fatal** when `roleScopedAgents` is default-true and the tree is unmaterialized |
+| [`lib/cli/update.js:743`](../../lib/cli/update.js) | Upgrade + drift-heal steps regenerate both trees |
+| [`lib/cli/uninstall.js:126`](../../lib/cli/uninstall.js) | `revertClaudeMd`, `revertClaudeSettings`, `revertClaudeCommands` |
+| [`lib/cli/doctor.js:85`](../../lib/cli/doctor.js) | `context-closure` resolves the `CLAUDE.md` `@`-import graph |
+| `.agents/scripts/lib/bootstrap/project-bootstrap.js` | Writes consumer `CLAUDE.md` (`SYSTEM_PROMPT_CLAUDE_MD`), wires the `.claude/settings.json` hook, injects gitignore rules |
+| `.agents/scripts/lib/command-header.js` | Exists solely to satisfy Claude Code's command-frontmatter parsing |
+| [`.github/workflows/install-matrix.yml:285`](../../.github/workflows/install-matrix.yml) | CI asserts the projection so `doctor` reports green |
+| [`.gitignore:50`](../../.gitignore) | Ignore block for the generated `.claude/*` trees |
+
+### 2. `Agent` / `subagent_type` dispatch semantics
+
+- `delivery.routing.roleScopedAgents` — converted spawns boot on
+  `.claude/agents/<role>.md` instead of the `CLAUDE.md` closure
+  (`.agents/schemas/agentrc.schema.json`,
+  `.agents/scripts/lib/config-settings-schema-delivery.js:181`).
+- `.agents/workflows/helpers/acceptance-self-eval.md` — dispatches
+  `subagent_type: acceptance-critic`, noting "Claude Code ≥ 2.1.202".
+- [`.agents/instructions.md`](../../.agents/instructions.md) § 4 and
+  `.agents/scripts/lib/checks/subagent-agent-tool-required.js` — hardcode Claude
+  Code nesting-depth facts (verified depth 2, announced max 5).
+
+### 3. `claude` CLI shell-outs (review providers)
+
+- `.agents/scripts/lib/orchestration/review-providers/security-review.js` —
+  `spawnSync('claude', ['--print', …])`, probes `claude --version`.
+- `.agents/scripts/lib/orchestration/review-providers/codex.js` —
+  `spawnSync('claude', …)`, probes `~/.claude/plugins/codex-plugin-cc`.
+- `.agents/scripts/lib/orchestration/review-providers/ultrareview.js` —
+  prompt-only; degrades gracefully on a non-Claude host.
+
+### 4. Hook, env, and session contract
+
+- `.agents/scripts/lib/observability/tool-trace-hook.js` — invoked from
+  `.claude/settings.json` `PreToolUse` / `PostToolUse`; parses the harness's
+  stdin contract.
+- `.agents/scripts/lib/observability/active-story-env.js` — `CC_STORY_ID`
+  re-spawn semantics; `CC_EPIC_ID` / `CC_PHASE` / `CC_OPERATOR` / `CC_SLICE_ID`
+  are the propagation channel throughout.
+- `.agents/scripts/lib/config/runtime.js` — remote/web detection keyed entirely
+  on `CLAUDE_CODE_REMOTE` and `CLAUDE_CODE_REMOTE_SESSION_ID`.
+
+### 5. Dynamic-workflows feature gating
+
+`.agents/scripts/lib/dynamic-workflow/capability.js` gates a Claude Code-only,
+paid-plan, research-preview feature: env flags `CLAUDE_CODE_DISABLE_WORKFLOWS`,
+`CLAUDE_CODE_RUNTIME`, `CLAUDE_CODE_VERSION`, `CLAUDE_CODE_PLAN`, and the
+`not-claude-runtime` reason sentinel. Six `audit-*.md` workflows carry an
+identical `.claude/workflows/<name>.workflow.js` block, mirrored in the
+`*-report-contract.js` files.
+
+### 6. `~/.claude/projects/<repo>/memory/` reads
+
+- `.agents/scripts/lib/orchestration/planning/authoring-context.js:34`
+- `.agents/scripts/lib/feedback-loop/memory-freshness.js:6`
+
+### 7. Host tool-name assumptions in skills and schemas
+
+- `AskUserQuestion` named directly in
+  `.agents/skills/core/idea-refinement/SKILL.md` and
+  `.agents/schemas/lifecycle/intervention.recorded.schema.json`.
+- `.agents/skills/core/browser-testing-with-devtools/SKILL.md:50` — install
+  snippet names Claude Code config and the `@anthropic/chrome-devtools-mcp`
+  package.
+
+---
+
+## Config and schema coupling
+
+Small and centralized — each item below is a single choke point.
+
+| Location | Item |
+| --- | --- |
+| `.agents/scripts/lib/orchestration/model-attribution.js` | `deriveFamily()` recognizes only Opus/Sonnet/Haiku; env fallbacks `CLAUDE_MODEL`, `ANTHROPIC_MODEL`. The one choke point for model identity. |
+| `.agents/schemas/model-attribution.schema.json:24` | Example model IDs (`claude-opus-4-7`, `claude-sonnet-4-6`) and family labels |
+| `.agents/scripts/lib/observability/tool-trace-hook.js:265` | `haiku` / `sonnet` / `opus` redaction allowlist |
+| `context-envelope.js:85`, `plan-context.js:49`, `checklist-threading.js:48` | The ≈4-chars/token estimate — Anthropic-flavored heuristic, provider-neutral in form |
+
+---
+
+## Branding and prose
+
+Cosmetic tier — a find-and-replace if the stance ever changes, but the ADR
+should move first.
+
+- [`package.json`](../../package.json) — "Claude Code-first…" description, the
+  `claude-code` keyword
+- [`AGENTS.md`](../../AGENTS.md), [`architecture.md`](../architecture.md),
+  [`.agents/docs/SDLC.md`](../../.agents/docs/SDLC.md) — the coupling-stance prose
+  (deliberate, ADR-governed)
+- [`README.md:37`](../../README.md), [`patterns.md:171`](../patterns.md), the
+  loop-units ADR, and roughly 25 further prose spots across `.agents/`

--- a/docs/ci-contract.md
+++ b/docs/ci-contract.md
@@ -6,8 +6,8 @@ CI mirror** for every gate it *can* prove on a developer's machine: it runs
 the full `npm test` suite, the unified baselines (`check-baselines.js`), and —
 as of Story #4549 — the standalone ratchets CI's `baselines` job runs in its
 "Architecture Cycle Check" step (`check-dead-exports.js` and
-`check-context-budget.js`; the third, `check-arch-cycles.js`, is already run by
-the `lint` step) — the same shape CI runs.
+`check-context-budget.js`; `check-arch-cycles.js` is already run by the `lint`
+step) — the same shape CI runs.
 
 A green `npm run verify` therefore no longer hides a high-severity advisory
 that CI's audit step would fail on. It is still **not** a total substitute for
@@ -23,9 +23,13 @@ authoritative verdict is the CI run on the pull request.
 > deliberately left off by default and is unchanged — the audit belongs in the
 > full `verify` gate, not on every push.
 
+Nor are the architecture ratchets, for the same reason:
+
 > **Not** CI-only gates: the standalone ratchets in CI's "Architecture Cycle
-> Check" step. All three are pure-Node, baseline-aware and full-tree-safe, so
-> `npm run verify` covers every one (Story #4549):
+> Check" step. Every ratchet that step runs is pure-Node, baseline-aware and
+> full-tree-safe, so `npm run verify` covers each one (Story #4549). The step
+> itself is the SSOT for the command list —
+> [`ci.yml`](../.github/workflows/ci.yml), `baselines` job:
 >
 > | Ratchet | How `npm run verify` covers it |
 > | --- | --- |
@@ -53,6 +57,7 @@ authoritative verdict is the CI run on the pull request.
 | TruffleHog secret scan                   | `trufflesecurity/trufflehog@…` action with `--only-verified` (`.github/workflows/ci.yml`) | A pinned third-party GitHub Action that scans the *full fetched git history* for verified secrets. It needs the Actions runner and the action's own container — there is no local `verify` equivalent.                        |
 | Push-scoped maintainability (`BASELINE_SCOPE=full`) | `npm run maintainability:check` with `BASELINE_SCOPE=full` on push-to-`main` (`.github/workflows/ci.yml`) | On PR runs maintainability is diff-scoped to `main`; **push-to-`main`** runs export `BASELINE_SCOPE=full` so *untouched* files still surface regressions. `npm run verify` runs the diff/local scope, not the full push-scoped sweep, so a whole-repo MI regression can only be caught by the remote push run. |
 | Test-temp hygiene (`--snapshot` / `--assert`) | `node .agents/scripts/check-test-temp-hygiene.js --snapshot` before the test run, `--assert` after (`.github/workflows/ci.yml`) | Brackets the CI test run (Story #4696): fingerprints the friction / lifecycle / trace NDJSON streams under `temp/` pre-test and fails the build if any stream file was added or grew — catching a test writer that bypasses the scratch seam and pollutes real telemetry. `npm run verify` does not bracket its test run with this snapshot/assert pair. |
+| `Windows Smoke` (advisory) | the `windows-smoke` job of `.github/workflows/ci.yml` — `bootstrap.js --dry-run --assume-yes --skip-github`, `npm run sync:commands`, the config-resolution slice (`tests/shipped-configs-validate.test.js` + `tests/lib/config-resolver.test.js`), then `npm run test:quick` | The only `windows-latest` surface in the repo (Story #3389). It catches Windows-only regressions in worktree path handling, PowerShell/npm wiring, and platform-conditional code — the largest gap a local green on macOS/Linux structurally cannot cover, since no local run executes on Windows. It is **deliberately advisory**: the job is *not* in the branch-protection required-status-check set, so a red `Windows Smoke` does not block a merge (it deliberately stays out to avoid reintroducing the c8/timing baseline flap that retired the full Windows matrix leg, #1270). Read it, do not ignore it. |
 | OS-temp-root hygiene (same bracket) | the same `--assert` step, plus `--lint-globs` (`.github/workflows/ci.yml`) | Two further dimensions added in Story #4808, riding the bracket above. **Runtime:** the snapshot also records the `mandrel-suite-*` roots already present in `os.tmpdir()`, and `--assert` fails on any that appeared during the run and survived — i.e. a process minted a suite root and exited without reaping it. Diffing against the snapshot (rather than asserting an empty set) is what keeps a concurrent suite in another checkout from failing this one. **Static:** `--lint-globs` fails when a test file calls `mkdtemp` against `os.tmpdir()` directly instead of `makeTempDir()` from `.agents/scripts/lib/test-temp.js`, catching the next leaking file at authoring time. Both are CI-only for the same reason as the row above; the static one is additionally **off unless `--lint-globs` is passed**, because this script ships in the materialized `.agents/` payload and the rule must not fire on a consumer's tests. |
 
 ## `trust-ci` auto-merge prerequisite: configure required checks
@@ -70,7 +75,7 @@ semantics.
 
 Operators running `trust-ci` unattended MUST therefore keep a non-empty
 required-status-check set configured on the base branch. In **this**
-repository that set is the four contexts declared in
+repository that set is the contexts recorded in
 [`.github/ruleset.json`](../.github/ruleset.json):
 
 | Required check context     | Produced by                                                    |
@@ -79,6 +84,19 @@ repository that set is the four contexts declared in
 | `baselines`                | the `baselines` job of `.github/workflows/ci.yml`              |
 | `install (npm / ubuntu-latest)`   | the Gate profile of `.github/workflows/install-matrix.yml` |
 | `install (yarn / windows-latest)` | the Gate profile of `.github/workflows/install-matrix.yml` |
+
+> **`.github/ruleset.json` is a non-enforcing snapshot, not the declaration.**
+> It is a committed *record* of the live `Protect Main` ruleset (id
+> `14286998`) so the intended contract is reviewable in version control —
+> **committing an edit to it changes nothing**. The live ruleset is the only
+> enforcement source, and an operator MUST re-apply the file out of band
+> (`gh api --method PUT repos/dsj1984/mandrel/rulesets/14286998 --input
+> .github/ruleset.json`, or the GitHub UI) for a change to take effect. See
+> [`.github/README.md`](../.github/README.md) for the full procedure. Read the
+> authoritative set off the live ruleset
+> (`gh api repos/{owner}/{repo}/rulesets`) whenever it matters.
+
+A second confusion is worth stating just as plainly:
 
 > **`.agentrc.json` `requiredChecks` names are NOT check contexts.** The
 > `github.branchProtection.requiredChecks` entries are `{ name, cmd }` pairs —
@@ -103,6 +121,6 @@ arming gate regardless of the required-check configuration.
 ## Practical implication
 
 Run `npm run verify` before opening a PR for fast, local confidence across
-audit + lint + test + baselines + ratchets. Treat the four gates above as the residual
-risk that only the CI run on the pull request can close — do not read a local
-green as a guaranteed remote green.
+audit + lint + test + baselines + ratchets. Treat every gate in the CI-only
+table above as the residual risk that only the CI run on the pull request can
+close — do not read a local green as a guaranteed remote green.

--- a/docs/claude-coupling-review.md
+++ b/docs/claude-coupling-review.md
@@ -1,25 +1,27 @@
 # Claude Coupling Inventory
 
-**Snapshot date:** 2026-07-17 · **Commit:** `493b3eb0` · **Scope:** whole repository
+This document records **where** Mandrel is coupled to Claude (the model) or
+Claude Code (the host runtime). It is **evidence for**, not a revision of, the
+coupling stance fixed in [ADR `20260512-coupling-stance`](decisions.md) — that
+ADR remains the authoritative statement of what Mandrel deliberately couples
+to. Read this file before widening the supported-host set, before touching the
+projection pipeline, or when scoping a provider-agnosticism effort.
 
-This document inventories every point at which Mandrel is coupled to Claude
-(the model) or Claude Code (the host runtime). It is **evidence for**, not a
-revision of, the coupling stance fixed in
-[ADR `20260512-coupling-stance`](decisions.md) — that ADR remains the
-authoritative statement of what Mandrel deliberately couples to. Read this file
-when you need to know *where* the coupling actually lives: before widening the
-supported-host set, before touching the projection pipeline, or when scoping a
-provider-agnosticism effort.
-
-It is a point-in-time inventory. Treat the file:line citations as accurate as
-of the commit above and re-verify before acting on them.
+> **The verbatim file:line citation tables have been archived.** The
+> point-in-time inventory taken at commit `493b3eb0` (2026-07-17) — the
+> per-cluster citations, the config/schema table, and the branding sweep —
+> now lives in
+> [`archive/claude-coupling-review-2026-07.md`](archive/claude-coupling-review-2026-07.md).
+> Those citations were **not** re-verified and a spot-check found several no
+> longer landing; read them as a historical record, and re-derive from the
+> current tree before acting. What remains below is the part that still binds.
 
 ---
 
 ## Headline
 
 **There is no coupling to Claude the model.** The repository carries no
-`@anthropic-ai/*` dependency, makes no Anthropic API calls, holds no
+`@anthropic-ai/*` dependency, makes no Anthropic API calls, reads no
 `ANTHROPIC_API_KEY`, hardcodes no model IDs in runtime logic, and contains no
 prompt addressed to "Claude". The runtime is the host process, not an API
 client.
@@ -39,134 +41,52 @@ comments as the cross-runtime contract, while the workflow / `.claude/` / hook
 
 ## Host-integration clusters
 
-The seven clusters below are the real coupling, ordered hardest to easiest to
-abstract. Everything outside this section is prose or a centralized constant.
+Seven clusters carry the real coupling, ordered hardest to easiest to abstract.
+Everything outside them is prose or a centralized constant.
 
-### 1. The `.claude/` projection pipeline — the single biggest lever
-
-The distribution model itself: materialize `.agents/`, then project workflows
-into `.claude/commands/` and agent definitions into `.claude/agents/`. The CLI
-orbits this projection.
-
-| Location | Coupling |
-| --- | --- |
-| [`.agents/scripts/sync-claude-commands.js`](../.agents/scripts/sync-claude-commands.js) | Projects `.agents/workflows/*` → `.claude/commands/*.md`; namespaces subpaths as `/loops:<name>` |
-| [`.agents/scripts/sync-claude-agents.js`](../.agents/scripts/sync-claude-agents.js) | Projects role defs → `.claude/agents/<name>.md` for `subagent_type: <name>` |
-| [`bin/mandrel.js:57`](../bin/mandrel.js) | `sync-commands` / `sync-agents` subcommands hardcode the `.claude/` targets |
-| [`lib/cli/sync-commands.js`](../lib/cli/sync-commands.js), [`lib/cli/sync-agents.js`](../lib/cli/sync-agents.js) | Delegators to the two engines above |
-| [`lib/cli/registry.js:224`](../lib/cli/registry.js) | Doctor checks `commands-in-sync` / `agents-in-sync`; the latter is **fatal** when `roleScopedAgents` is default-true and the tree is unmaterialized |
-| [`lib/cli/update.js:743`](../lib/cli/update.js) | Upgrade + drift-heal steps regenerate both trees |
-| [`lib/cli/uninstall.js:126`](../lib/cli/uninstall.js) | `revertClaudeMd`, `revertClaudeSettings`, `revertClaudeCommands` |
-| [`lib/cli/doctor.js:85`](../lib/cli/doctor.js) | `context-closure` resolves the `CLAUDE.md` `@`-import graph |
-| `.agents/scripts/lib/bootstrap/project-bootstrap.js` | Writes consumer `CLAUDE.md` (`SYSTEM_PROMPT_CLAUDE_MD`), wires the `.claude/settings.json` hook, injects gitignore rules |
-| `.agents/scripts/lib/command-header.js` | Exists solely to satisfy Claude Code's command-frontmatter parsing |
-| [`.github/workflows/install-matrix.yml:285`](../.github/workflows/install-matrix.yml) | CI asserts the projection so `doctor` reports green |
-| [`.gitignore:50`](../.gitignore) | Ignore block for the generated `.claude/*` trees |
-
-### 2. `Agent` / `subagent_type` dispatch semantics
-
-- `delivery.routing.roleScopedAgents` — converted spawns boot on
-  `.claude/agents/<role>.md` instead of the `CLAUDE.md` closure
-  (`.agents/schemas/agentrc.schema.json`,
-  `.agents/scripts/lib/config-settings-schema-delivery.js:181`).
-- `.agents/workflows/helpers/acceptance-self-eval.md` — dispatches
-  `subagent_type: acceptance-critic`, noting "Claude Code ≥ 2.1.202".
-- [`.agents/instructions.md`](../.agents/instructions.md) § 4 and
-  `.agents/scripts/lib/checks/subagent-agent-tool-required.js` — hardcode Claude
-  Code nesting-depth facts (verified depth 2, announced max 5).
-
-**Already mitigated:** every converted spawn falls back to
-`subagent_type: general-purpose`, documented as the escape for hosts that
-ignore `.claude/agents/`, and `roleScopedAgents: false` is a kill-switch.
-
-### 3. `claude` CLI shell-outs (review providers)
-
-- `.agents/scripts/lib/orchestration/review-providers/security-review.js` —
-  `spawnSync('claude', ['--print', …])`, probes `claude --version`.
-- `.agents/scripts/lib/orchestration/review-providers/codex.js` —
-  `spawnSync('claude', …)`, probes `~/.claude/plugins/codex-plugin-cc`.
-- `.agents/scripts/lib/orchestration/review-providers/ultrareview.js` —
-  prompt-only; degrades gracefully on a non-Claude host.
-
-**Already mitigated, and the pattern to copy elsewhere:** all three sit behind
-`review-provider-factory.js` with `optional: true` skip semantics and
-injectable `invokeFn` / `probeFn` / `spawnFn` seams. The `native` provider is
-fully host-agnostic.
-
-### 4. Hook, env, and session contract
-
-- `.agents/scripts/lib/observability/tool-trace-hook.js` — invoked from
-  `.claude/settings.json` `PreToolUse` / `PostToolUse`; parses the harness's
-  stdin contract.
-- `.agents/scripts/lib/observability/active-story-env.js` — `CC_STORY_ID`
-  re-spawn semantics; `CC_EPIC_ID` / `CC_PHASE` / `CC_OPERATOR` / `CC_SLICE_ID`
-  are the propagation channel throughout.
-- `.agents/scripts/lib/config/runtime.js` — remote/web detection keyed entirely
-  on `CLAUDE_CODE_REMOTE` and `CLAUDE_CODE_REMOTE_SESSION_ID`.
-
-### 5. Dynamic-workflows feature gating
-
-`.agents/scripts/lib/dynamic-workflow/capability.js` gates a Claude Code-only,
-paid-plan, research-preview feature: env flags `CLAUDE_CODE_DISABLE_WORKFLOWS`,
-`CLAUDE_CODE_RUNTIME`, `CLAUDE_CODE_VERSION`, `CLAUDE_CODE_PLAN`, and the
-`not-claude-runtime` reason sentinel. Six `audit-*.md` workflows carry an
-identical `.claude/workflows/<name>.workflow.js` block, mirrored in the
-`*-report-contract.js` files.
-
-### 6. `~/.claude/projects/<repo>/memory/` reads
-
-- `.agents/scripts/lib/orchestration/planning/authoring-context.js:34`
-- `.agents/scripts/lib/feedback-loop/memory-freshness.js:6`
-
-### 7. Host tool-name assumptions in skills and schemas
-
-- `AskUserQuestion` named directly in
-  `.agents/skills/core/idea-refinement/SKILL.md` and
-  `.agents/schemas/lifecycle/intervention.recorded.schema.json`.
-- The `mcp__chrome-devtools__*` surface assumed by `qa-run`,
-  `audit-lighthouse`, and the qa-harness skill — already documented as a
-  host-provided dependency that degrades with a clear error.
-- `.agents/skills/core/browser-testing-with-devtools/SKILL.md:50` — install
-  snippet names Claude Code config and the `@anthropic/chrome-devtools-mcp`
-  package.
-
----
-
-## Config and schema coupling
-
-Small and centralized — each item below is a single choke point.
-
-| Location | Item |
-| --- | --- |
-| `.agents/scripts/lib/orchestration/model-attribution.js` | `deriveFamily()` recognizes only Opus/Sonnet/Haiku; env fallbacks `CLAUDE_MODEL`, `ANTHROPIC_MODEL`. The one choke point for model identity. |
-| `.agents/schemas/model-attribution.schema.json:24` | Example model IDs (`claude-opus-4-7`, `claude-sonnet-4-6`) and family labels |
-| `.agents/scripts/lib/observability/tool-trace-hook.js:265` | `haiku` / `sonnet` / `opus` redaction allowlist |
-| `context-envelope.js:85`, `plan-context.js:49`, `checklist-threading.js:48` | The ≈4-chars/token estimate — Anthropic-flavored heuristic, provider-neutral in form |
+1. **The `.claude/` projection pipeline** — the single biggest lever. The
+   distribution model itself: materialize `.agents/`, then project workflows
+   into `.claude/commands/` and agent definitions into `.claude/agents/`. The
+   CLI, the doctor checks, the upgrade path, uninstall, and consumer bootstrap
+   all orbit this projection.
+2. **`Agent` / `subagent_type` dispatch semantics** — `roleScopedAgents` boots
+   converted spawns on `.claude/agents/<role>.md` instead of the `CLAUDE.md`
+   closure, and Claude Code nesting-depth facts are hardcoded.
+   **Already mitigated:** every converted spawn falls back to
+   `subagent_type: general-purpose`, documented as the escape for hosts that
+   ignore `.claude/agents/`, and `roleScopedAgents: false` is a kill-switch.
+3. **`claude` CLI shell-outs (review providers)** — the `security-review`,
+   `codex`, and `ultrareview` providers spawn or probe the `claude` binary.
+   **Already mitigated, and the pattern to copy elsewhere:** all three sit
+   behind `review-provider-factory.js` with `optional: true` skip semantics and
+   injectable `invokeFn` / `probeFn` / `spawnFn` seams. The `native` provider is
+   fully host-agnostic.
+4. **Hook, env, and session contract** — the tool-trace hook parses the
+   harness's stdin contract from `.claude/settings.json`; `CC_*` vars are the
+   propagation channel throughout; remote/web detection keys entirely on
+   `CLAUDE_CODE_REMOTE*`.
+5. **Dynamic-workflows feature gating** — a Claude Code-only, paid-plan,
+   research-preview feature gated on `CLAUDE_CODE_*` env flags and a
+   `not-claude-runtime` reason sentinel, with per-lens workflow blocks mirrored
+   in the report-contract files.
+6. **`~/.claude/projects/<repo>/memory/` reads** — planning authoring-context
+   and memory-freshness both read the host's memory directory.
+7. **Host tool-name assumptions in skills and schemas** — `AskUserQuestion` is
+   named directly in a skill and a lifecycle schema, and the
+   `mcp__chrome-devtools__*` surface is assumed by `qa-run`,
+   `audit-accessibility`, and the qa-harness skill.
+   **Already mitigated** for the last one: it is documented as a host-provided
+   dependency that degrades with a clear error.
 
 Two things worth recording because they look coupled and are not:
 
-- **`DEFAULT_MODEL_CAPACITY`** (`ticket-validator-sizing.js:99`) is a frozen
+- **`DEFAULT_MODEL_CAPACITY`** (`ticket-validator-sizing.js`) is a frozen
   authored-token ceiling bag, not a Claude-model constant. It names no model.
   Provider-neutral in substance; only the thresholds would merit revisiting
   per-provider.
 - **[`.agentrc.json`](../.agentrc.json)** is clean — no model names, no
   Claude-specific keys. The `agentrc` schema already speaks in neutral terms
   ("host-LLM", "cross-runtime portability").
-
----
-
-## Branding and prose
-
-Cosmetic tier — a find-and-replace if the stance ever changes, but the ADR
-should move first.
-
-- [`package.json`](../package.json) — "Claude Code-first…" description, the
-  `claude-code` keyword
-- [`AGENTS.md`](../AGENTS.md), [`architecture.md`](architecture.md),
-  [`.agents/docs/SDLC.md`](../.agents/docs/SDLC.md) — the coupling-stance prose
-  (deliberate, ADR-governed)
-- [`README.md:37`](../README.md), [`patterns.md:171`](patterns.md), the
-  loop-units ADR, and roughly 25 further prose spots across `.agents/`
 
 ---
 

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -20,29 +20,35 @@ mandrel/
 ├── .agents/                  # Distributed: the materialized payload
 │   ├── instructions.md       # ★ Primary system prompt — load this first
 │   ├── agents/               # Role-scoped spawn boot contexts (optional)
+│   ├── audit-checklists/     # Generated per-lens audit checklists
 │   ├── rules/                # Domain-agnostic coding/ops rules
 │   ├── skills/               # Two-tier skill library (core/ + stack/)
 │   ├── workflows/            # SDLC & audit slash-command workflows
 │   ├── scripts/              # Deterministic JS tooling (orchestration engine)
 │   ├── schemas/              # JSON Schemas for structured output validation
 │   ├── templates/            # Planning prompt templates
-│   ├── docs/                 # Shipped consumer reference docs (SDLC.md, configuration.md, agentrc-reference.json)
+│   ├── docs/                 # Shipped consumer reference docs (SDLC.md, configuration.md, execution-reference.md, quality-gates.md, workflows.md, agentrc-reference.json)
+│   ├── runtime-deps.json     # Runtime dependencies the payload needs present
 │   ├── starter-agentrc.json  # Bootstrap delta-seed — consumers copy to project root
 │   └── README.md             # Detailed consumer user guide
 ├── bin/                      # Distributed: mandrel.js (CLI dispatcher) + postinstall.js
 ├── lib/                      # Distributed: cli/ subcommand impls + migrations/
 ├── .agentrc.json             # Root config for this repo (dogfooding)
+├── baselines/                # Committed quality/ratchet baselines
 ├── docs/                     # Implementation plans and changelog
+├── scripts/                  # Repo-local dev scripts (not distributed)
 ├── tests/                    # Framework tests
 ├── package.json              # Tooling: biome, markdownlint, husky
 ```
 
-> **Key distinction:** the published package ships exactly the three
-> directories marked *Distributed* above — `.agents/`, `bin/`, and `lib/`, per
-> the `files` array in [`package.json`](../package.json). Only `.agents/` is
-> *materialized* into the consumer's working tree (by `mandrel sync`); `bin/`
-> and `lib/` stay in `node_modules/mandrel/` and back the `npx mandrel …` CLI.
-> Everything else in this repository is internal development tooling.
+> **Key distinction:** the published package ships the three directories marked
+> *Distributed* above — `.agents/`, `bin/`, and `lib/` — plus the single file
+> `docs/CHANGELOG.md`, per the `files` array in
+> [`package.json`](../package.json) (which also excludes the `__tests__`
+> subtrees under `.agents/` and `lib/`). Only `.agents/` is *materialized* into
+> the consumer's working tree (by `mandrel sync`); `bin/` and `lib/` stay in
+> `node_modules/mandrel/` and back the `npx mandrel …` CLI. Everything else in
+> this repository is internal development tooling.
 
 ---
 
@@ -53,8 +59,10 @@ mandrel/
    taking any action.
 
 2. **Resolve configuration:** Settings are in
-   [`.agentrc.json`](../.agentrc.json). See the `project`, `github`,
-   `planning`, and `delivery` sections for project-specific values.
+   [`.agentrc.json`](../.agentrc.json). This repository's file carries the
+   `project`, `github`, and `delivery` sections; the full key set the schema
+   accepts (including `planning`) is documented in
+   [`.agents/docs/configuration.md`](../.agents/docs/configuration.md).
    Tech-stack context lives in [`architecture.md`](architecture.md) under the
    **Tech Stack** section, not in the JSON config.
 
@@ -81,23 +89,37 @@ mandrel/
 | Area         | Tool / Convention                                              |
 | ------------ | -------------------------------------------------------------- |
 | Language     | Markdown (prose), JavaScript ESM (scripts), JSON (config)      |
-| Linter       | `biome` + `markdownlint` — run via `npm run lint`              |
-| Formatter    | `biome` — run via `npm run format`                             |
-| Git Hooks    | Husky + lint-staged (auto-lint `.md` files on commit)          |
+| Linter       | `biome` + `markdownlint` + the repo's own ratchets — `npm run lint` |
+| Formatter    | `biome format` — **JavaScript and JSON only**; markdown is not formatted by `npm run format` (see below) |
+| Git Hooks    | Husky — `pre-commit` runs version-sync, lint-staged, and the blocking `quality-preview.js --staged` MI/CRAP gate; `pre-push` runs the diff-scoped quality preview plus the coverage/CRAP ratchet |
 | Node Version | >=22.22.1 <25                                                  |
 | Package Mgr  | npm                                                            |
 | Shell        | PowerShell (Windows) — use `;` not `&&` as statement separator |
-| CI/CD        | GitHub Actions (`ci.yml`) — validates markdown + tests         |
+| CI/CD        | GitHub Actions (`ci.yml`) — `Validate and Test` + `baselines` (required) and the advisory `Windows Smoke` leg |
+
+**Markdown is not auto-formatted by `npm run format`.** That script is
+`biome format --write .`, and [`biome.json`](../biome.json) declares only a
+`javascript.formatter` — Biome ignores `.md` paths entirely, so the command
+reports `Checked 0 files` for markdown and changes nothing. The only markdown
+fixer wired up is `markdownlint-cli2 --fix`, which runs from
+[`.lintstagedrc`](../.lintstagedrc) on **staged** `.md` files at commit time.
+To fix a markdown file outside a commit, invoke it directly:
+
+```bash
+npx markdownlint-cli2 --fix path/to/file.md
+```
 
 ### Key Commands
 
 ```text
-npm run lint              # Markdown lint + generated-doc drift gate (docs:check);
-                          #   if it fails on drift, run docs:gen to regenerate
+npm run lint              # biome ci + markdownlint + the lifecycle/workflow-cli/
+                          #   label-vocabulary/arch-cycles ratchets, then the
+                          #   generated-doc drift gate (docs:check); if it fails
+                          #   on drift, run docs:gen to regenerate
 npm run docs:gen          # Regenerate config/lifecycle/workflows docs
 npm run skills:index      # Regenerate the skills index
-npm run format            # Auto-format all markdown files
-npm run format:check      # Verify formatting without modifying files
+npm run format            # biome format --write . — JavaScript/JSON only, NOT markdown
+npm run format:check      # biome ci . — verify without modifying files
 npm run test:quick        # TDD loop — excludes slow integration-style suites
 npm run test:integration  # Real-git / hook-chain / long orchestration suites only
 npm test                  # Full suite (same as CI test gate)
@@ -120,6 +142,23 @@ cannot be reproduced from a local working tree — those are catalogued in
 sufficient. Pre-push runs only diff-scoped quality preview plus coverage/CRAP
 ratchet; it does not run full lint or `npm test`. CI always runs the full
 `npm test` suite.
+
+### Where the CRAP / Maintainability gates fire
+
+The same `delivery.quality.*` thresholds from [`.agentrc.json`](../.agentrc.json)
+are enforced at four sites, earliest first:
+
+| Site | Scope | Blocking? |
+| --- | --- | --- |
+| [`.husky/pre-commit`](../.husky/pre-commit) — `quality-preview.js --staged` | staged index paths only | **Yes** — a threshold violation exits non-zero and the commit is refused |
+| [`.husky/pre-push`](../.husky/pre-push) — `quality-preview.js --changed-since origin/main` plus `crap:check` | diff against `origin/main` | **Yes** — the push is refused |
+| Story close-validation (`single-story-close.js`) | the Story's whole change set | **Yes** — close stops |
+| CI (`ci.yml`, push + PR) | diff-scoped on PR, `BASELINE_SCOPE=full` on push to `main` | **Yes** — a required check fails |
+
+`.husky/pre-commit` is the one most easily forgotten and the one that bites
+first: it fires before any other gate, and a green `npm run lint` /
+`npm test` / `check-baselines.js` run does **not** predict it, because none of
+those measures per-file maintainability-index or CRAP deltas.
 
 ### Slow-test profiling
 

--- a/docs/release-operations.md
+++ b/docs/release-operations.md
@@ -185,16 +185,61 @@ token sitting in repo secrets.
    OIDC exchange.
 3. Trusted Publishing requires **npm CLI >=11.5.1**. `.nvmrc` pins Node 22
    (which bundles an older npm), so the job runs
-   `npm install -g npm@latest` after `npm ci` and before `npm publish` to
-   pick up a CLI that supports the OIDC flow. Re-check this step is still
-   needed if `.nvmrc` is ever bumped to a Node version that bundles a
-   sufficiently new npm by default.
+   `npm install -g npm@11.18.0` after `npm ci` and before `npm publish` to
+   pick up a CLI that supports the OIDC flow.
+
+> **The `npm@11.18.0` pin is deliberate — do not float it to `@latest`.**
+> npm 12.0.0's in-place global self-upgrade leaves the freshly-replaced global
+> npm tree unable to resolve the bundled `sigstore` module from
+> `libnpmpublish/lib/provenance.js`, so `npm publish` with
+> `publishConfig.provenance: true` dies with `Cannot find module 'sigstore'` —
+> with no change on our side. The pin is the last known-good npm 11 line and
+> keeps the `>=11.5.1` Trusted-Publishing floor. **Re-check trigger:** bump it
+> once a 12.x self-upgrade is verified clean — *not* when `.nvmrc` moves to a
+> newer Node. The pinned value lives in the `Upgrade npm for Trusted
+> Publishing` step of
+> [`release-please.yml`](../.github/workflows/release-please.yml).
 
 If the Trusted Publisher is not configured (or its repo/workflow fields
 don't match), `npm publish` fails authentication and the package is not
 published — release-please still tags `main` and creates the GitHub
 Release regardless, so a publish failure here does not block the release
 itself, only the npm artifact.
+
+#### Recovering a stuck release (`workflow_dispatch` republish)
+
+A release whose tag and GitHub Release were created but whose `npm publish`
+failed leaves the version missing on npm. `release-please.yml` also triggers on
+`workflow_dispatch`, and `npm-publish` runs on that event as well as on a root
+release cut, so the gap can be filled without waiting for a new version:
+
+```bash
+gh workflow run release-please.yml --repo dsj1984/mandrel
+```
+
+This is safe to re-run: the npm registry rejects re-publishing an
+already-present version, so a dispatch can only publish the current
+`package.json` version if it is missing on npm — it can never clobber an
+existing one. Fix the root cause first (Trusted Publisher fields, or the npm
+pin above), then dispatch.
+
+#### The `update-loc-baseline` post-release PR
+
+After a root release is cut, the `update-loc-baseline` job regenerates
+`baselines/agents-loc.csv` (the `.agents/` payload LOC/bytes tracker, produced
+by `baselines/agents-loc-baseline.mjs`) with a row for the freshly released
+version. If the file changed, the job opens a **CSV-only, auto-merged PR**
+titled `chore(baselines): record .agents loc/bytes for mandrel-vX.Y.Z` from
+branch `chore/loc-baseline-<tag>`, authored by `github-actions[bot]` under
+`RELEASE_PLEASE_TOKEN`.
+
+It goes through a PR rather than a direct push because `main` is
+branch-protected; it is opened under the PAT (not the default `GITHUB_TOKEN`)
+for the same reason the release PR is — a `GITHUB_TOKEN`-authored PR does not
+trigger `Validate and Test` / `baselines`, so auto-merge could never satisfy
+branch protection. **This bot PR is expected after every release** and needs no
+operator action; if the baseline did not change, the job logs that and exits
+without opening one.
 
 ### Versioning policy
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -14,7 +14,7 @@
 > `mandrel-v2.0.0`. How the resulting system works is documented in
 > [`architecture.md`](architecture.md) and the workflow prose, not here.
 >
-> **Last reviewed:** 2026-07-16 against framework version 2.0.0.
+> **Last reviewed:** 2026-08-02 against framework version 2.25.0.
 
 ## 1. Someday — aspirational & model-shift monitors
 
@@ -28,10 +28,12 @@ dependency trip-wires live in the appendix, not here.
    related capability lift). Until then worktree isolation is concurrency
    physics and keeps.
 2. **Remaining sequential-only audit lenses** (`audit-dependencies`,
-   `audit-devops`, `audit-sre`, `audit-privacy`, `audit-seo`, `audit-ux-ui`,
-   `audit-lighthouse`) — re-price on inference economics. Several are
+   `audit-devops`, `audit-sre`, `audit-privacy`, `audit-seo`, `audit-ux-ui`)
+   — re-price on inference economics. Several are
    externally bound or not dimensionally decomposable; sequential may be the
-   correct default forever. Any generalization must clear the measured
+   correct default forever. (A lens dropping off this list means it was
+   retired, not that it was parallelized — the roster is the live lens set.)
+   Any generalization must clear the measured
    **~5× token-multiple / no-precision-loss gate** lens-by-lens (anchor:
    `audit-clean-code`, 2026-06-04 — 23 agents, ~2.47M tokens, 49/51 findings
    kept). Do not batch-convert.

--- a/tests/contract/docs-reference-sync.test.js
+++ b/tests/contract/docs-reference-sync.test.js
@@ -248,6 +248,8 @@ const UNRESOLVED_BY_DESIGN = Object.freeze({
   // --- Not this repository's files ----------------------------------------
   'src/index.ts': 'file in release-please-action v5.0.0, an external repo',
   'pnpm-lock.yaml': "a consumer project's lockfile, not this repo's",
+  'libnpmpublish/lib/provenance.js':
+    "a module inside the npm CLI's own bundled tree, not this repo's — cited by docs/release-operations.md as the npm 12.0.0 sigstore-resolution failure site",
 });
 
 describe('docs in scope — every backticked path resolves (Story #4785)', () => {


### PR DESCRIPTION
Closes #4925

_Auto-opened by `/deliver`._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Markdown and contract-test allowlist only; no runtime, auth, or orchestration behavior changes.
> 
> **Overview**
> **Repairs contributor-facing docs** so they match how the repo actually runs: published npm surface includes `docs/CHANGELOG.md` and `__tests__` exclusions; `npm run lint` / `npm run format` scope; markdown fixed via `markdownlint-cli2`, not Biome; and **four blocking** MI/CRAP enforcement sites (including **pre-commit** `quality-preview.js --staged`), with an explicit warning that green lint/test does not predict the hook.
> 
> **CI and release operations** gain accuracy: `ci-contract.md` points ratchet SSOT at `ci.yml`, documents advisory **Windows Smoke**, and clarifies that `.github/ruleset.json` is a **non-enforcing snapshot** (live ruleset must be applied out of band). `release-operations.md` pins **npm@11.18.0** (not `@latest`) for Trusted Publishing/sigstore, plus `workflow_dispatch` republish and the post-release **loc-baseline** bot PR.
> 
> **Claude coupling inventory** is split: binding narrative stays in `claude-coupling-review.md`; verbatim stale `path:line` tables move to `docs/archive/claude-coupling-review-2026-07.md` with retirement of `audit-lighthouse` → `audit-accessibility` in live text. Smaller touch-ups: `onboarding.md` layout/keys, `roadmap.md` review stamp and sequential-audit lens list, `AGENTS.md` config pointer.
> 
> **Test:** `docs-reference-sync.test.js` allowlists `libnpmpublish/lib/provenance.js` as an external path cited by release docs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 92fc9636743d50a3b78d1920bfd48efac2391cba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->