### PR TITLE
docs: repair the four always-loaded reference docs: broken contracts, contradictions, and finished-work bloat (#4924)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -74,9 +74,10 @@ graph TB
 
 ## Repository Layout
 
-The **distributed product** is the three directories in `package.json`'s
-`files` array — `.agents/`, `bin/`, `lib/`; only `.agents/` is *materialized*
-into a consumer tree (`mandrel sync`). The rest is **dev tooling**.
+Directories marked *Distributed* below are the published package; everything
+else is **dev tooling**. What ships, what is materialized into a consumer
+tree, and how a release is cut are stated once, under
+[**Distribution Model**](#distribution-model) — not repeated here.
 
 ```text
 mandrel/
@@ -240,10 +241,9 @@ graph TB
 #### Ready-set / DAG helpers
 
 Multi-Story ordering for `/deliver` uses `lib/wave-runner/ready-set.js`
-(`selectReadySet`) driven by `stories-wave-tick.js`. Pre-v2
-`dispatch-engine.js` / `dispatcher.js` entry scripts are deleted; residual
-DAG helpers under `lib/orchestration/` remain only where live paths still
-import them.
+(`selectReadySet`) driven by `stories-wave-tick.js` — there is no
+`dispatch-engine.js` / `dispatcher.js` entry script. Residual DAG helpers
+under `lib/orchestration/` remain only where live paths still import them.
 
 | Helper                        | Responsibility                                                                            |
 | ----------------------------- | ----------------------------------------------------------------------------------------- |
@@ -253,18 +253,15 @@ import them.
 
 #### Failure auditability
 
-There is **no** `ErrorJournal` and no `lib/orchestration/error-journal.js`. It
-was an in-process-runner concept threaded through the typed context classes in
-`lib/orchestration/context.js`, and died with them and the epic-runner stratum
-(#3908) — do not write `errorJournal?.record(...)`; nothing can inject it. Two
-file-based surfaces replace it: the append-only signals stream
+There is **no** `ErrorJournal` and no epic-runner progress reporter — do not
+write `errorJournal?.record(...)`; nothing can inject it. Two file-based
+surfaces carry failure auditability instead: the append-only signals stream
 (`lib/observability/signals-writer.js`, written by `diagnose-friction.js`) and
-the per-script logs under `temp/orchestration/`.
-
-The epic-runner progress reporter went with the same stratum (#3908). Live
-Story progress surfaces via lifecycle ledger events and structured comments
-(`story-init`, `friction`, `verification-results`, `follow-ups`) posted by the
-single-story init/close path.
+the per-script logs under `temp/orchestration/`. Live Story progress surfaces
+via lifecycle ledger events and structured comments (`story-init`, `friction`,
+`verification-results`, `follow-ups`) posted by the single-story init/close
+path. History:
+[Failure auditability — what `ErrorJournal` was](archive/architecture-2026-08.md#failure-auditability--what-errorjournal-was).
 
 #### Spec grounding (no codebase snapshot)
 
@@ -273,12 +270,8 @@ its authoring-grounding companion, and the spec-freshness helpers behind them
 were deleted in Story #4811, along with the planning config block that tuned
 them — do not reintroduce a manifest-derived replacement.
 
-The snapshot grounded nothing it promised. Its default include globs guessed
-`app/**` singular and matched zero product files under the standard `apps/**`
-monorepo layout; its remedies pointed at knobs (`tier: "medium"`, a narrower
-`include`) that re-signatured the same already-filtered set and could not fix
-a missing include; and its cited-but-absent signal inverted into noise
-whenever the snapshot itself was the incomplete artifact.
+The post-mortem — why the snapshot grounded nothing it promised — is archived
+at [Why the codebase snapshot was deleted](archive/architecture-2026-08.md#why-the-codebase-snapshot-was-deleted).
 
 Two mechanisms ground spec authoring instead, both reading the real tree:
 
@@ -302,10 +295,9 @@ Two mechanisms ground spec authoring instead, both reading the real tree:
 | `lib/observability/signals-writer.js`               | Append-only NDJSON writer for `friction` / trace records under `temp/run-<eid>/stories/story-<sid>/signals.ndjson` (standalone Stories: `temp/standalone/stories/story-<sid>/`). The single producer for the telemetry pipeline; the reader is the `read()` async generator in `lib/signals/read.js`. |
 | `lib/orchestration/column-sync.js`                  | Drives the Projects v2 Status column from `agent::` labels (best-effort). Invoked from inside `transitionTicketState` (Story #2548) so every label flip mirrors onto the board.                  |
 
-The `CommitAssertion` post-wave guard and its `verifySingleResult` successor
-both went with the epic-runner / wave machinery. The guard against a Story
-being reported "done" without verifiable completion is now structural:
-`agent::done` follows the confirmed squash-merge of the Story's own PR.
+The guard against a Story being reported "done" without verifiable completion
+is structural: `agent::done` follows the confirmed squash-merge of the Story's
+own PR.
 
 #### Throughput primitives
 
@@ -321,13 +313,9 @@ being reported "done" without verifiable completion is now structural:
 The fan-out cap is resolved deterministically by
 `resolveConcurrencyCap` in `stories-wave-tick.js`
 (from `delivery.deliverRunner.concurrencyCap`) and surfaced on the
-ready-set envelopes the same script emits. The whole epic-runner-era
-concurrency surface (`DEFAULT_CONCURRENCY` / `resolveConcurrency`,
-`CommitAssertion`, the `ProgressReporter` listener) went with the dead
-in-process stratum (#3908) — do not confuse the surviving
-`resolveConcurrencyCap` with the deleted `resolveConcurrency`. Story #4545
-deleted the perf-summary throughput surface; the local `signals.ndjson`
-stream and the retro's aggregate over it are what remain.
+ready-set envelopes the same script emits. Do not confuse it with the deleted
+`resolveConcurrency`; the throughput surface it belonged to is archived at
+[The epic-runner-era concurrency surface](archive/architecture-2026-08.md#the-epic-runner-era-concurrency-surface).
 
 #### Direct CLIs (no MCP server)
 
@@ -576,10 +564,9 @@ The `/deliver <storyId...>` slash command is the sole entry point for Story
 delivery. It runs end-to-end inside the operator's Claude session, composing the
 orchestration primitives into a Story-sequencing coordinator (see
 [`workflows/deliver.md`](../.agents/workflows/deliver.md)) with the lifecycle
-bus chain at its core. There is no remote-trigger surface — delivery only ever
-runs locally, in the operator's session, with Story sub-agents launched through
-the Agent tool. Story #2259 (Epic #2172) retired the legacy deliver-runner CLI
-wrapper; the slash command supplants it entirely.
+bus chain at its core. There is no remote-trigger surface and no deliver-runner
+CLI — delivery only ever runs locally, in the operator's session, with Story
+sub-agents launched through the Agent tool.
 
 The bus is the **single canonical runner model** under Epic #2172:
 every phase transition, ticket-state flip, structured-comment upsert,
@@ -621,8 +608,11 @@ the default `standard` routes by the same `deriveChangeLevel` signal that
 sets review depth — sensitive-path (`high`) clusters go fresh, `low`
 clusters stay inline except for a deterministic sampling floor
 (`freshCriticSampleRate`, default 0.2), and an unknown level fails safe
-to fresh. Cluster count is `ceil(totalACs / clusterCeiling)` clamped to
-`[1, 8]` (`acceptance-clusters.js`); routing never changes it.
+to fresh. Cluster count is `ceil(totalACs / clusterCeiling)`
+(`acceptance-clusters.js`); routing never changes it. The `[1, 8]` clamp is
+on **cluster size** — `clusterCeiling` (config
+`delivery.acceptanceEval.clusterCeiling`, default 4) is hard-clamped into
+that range before the division, and the clamp is undisableable.
 
 **Evidence share.** A fresh critic re-runs the Story's `verify[]`
 commands itself as required evidence; its byte-identical `lint` /
@@ -672,10 +662,8 @@ close.
 | `code-review`       | `lib/orchestration/code-review.js` — inline review (companion to `helpers/code-review.md`). |
 | `run-epilogue`      | Cross-Story epilogue for rare N>1 runs (`plan-run-epilogue.js` / `lib/orchestration/run-epilogue.js`). |
 
-The epic-runner-era `blocker-handler` and `wave-observer` listeners were
-deleted with the in-process stratum (#3908); `agent::blocked` remains the
-sole runtime pause point, enforced by the workflow prose rather than a
-resident listener.
+`agent::blocked` is the sole runtime pause point, enforced by the workflow
+prose rather than a resident listener.
 
 ### Change-set-matched audit lenses
 
@@ -683,15 +671,13 @@ During the review/audit ceremony, `/deliver` resolves audit lenses inline with
 the Story review path. `plan-run-epilogue` / the Story close path call the
 audit-suite `selectAudits` SDK: it selects the audit lenses whose file patterns
 or keyword triggers match the change-set. Findings feed a bounded auto-fix loop.
-The retired `epic-audit-prepare.js` / `epic-audit-recheck.js` CLIs were deleted
-with the v2 Story-only cutover.
+There is no audit-suite CLI.
 
-Lens selection is **not** risk-routed. Story #4542 deleted the risk→lens router
-(`resolveAuditLenses`): it had zero callers while this section and two other
-shipped documents claimed it ran inside close. What the sensitive-path classes
-in `audit-rules.json` route is review **depth** (`light` / `standard` / `deep`,
-via `review-depth.js#deriveChangeLevel`), derived from the diff rather than from
-a planner's self-assessment.
+Lens selection is **not** risk-routed — there is no risk→lens router. What the
+sensitive-path classes in `audit-rules.json` route is review **depth** (`light`
+/ `standard` / `deep`, via `review-depth.js#deriveChangeLevel`), derived from
+the diff rather than from a planner's self-assessment. Removal notes:
+[Deleted listeners, CLIs and the heartbeat emitter](archive/architecture-2026-08.md#deleted-listeners-clis-and-the-heartbeat-emitter).
 
 ### HITL touchpoints
 
@@ -1069,13 +1055,10 @@ exits non-zero rather than falling silent; its commits on `story-<id>` and
 that label are the observable progress surface. Multi-Story ready-set
 sequencing is owned by `stories-wave-tick.js` (not an idle watchdog CLI).
 
-There is **no live liveness beat**. A `story.heartbeat` event and its
-PostToolUse-hook emitter once existed, but the emitter required an
-`epicId >= 1` that v2 — which has no Epics — never supplied, so it could
-never fire; it was deleted (A22) rather than repaired. A child that stalls
-without an `agent::blocked` label and without commits is indistinguishable
-from a dead one, and is escalated by operator observation, not by an
-automatic staleness check.
+There is **no live liveness beat**. A child that stalls without an
+`agent::blocked` label and without commits is indistinguishable from a dead
+one, and is escalated by operator observation, not by an automatic staleness
+check.
 
 ---
 
@@ -1090,10 +1073,9 @@ The framework emits a closed taxonomy of **thirteen** NDJSON record kinds —
 Enumerated ≠ produced: only **two** detector modules ship
 (`lib/signals/detectors/`: `rework.js`, `retry.js`), beside the
 `diagnose-friction.js` writer and the raw `trace` hook. `hotspot`, `churn`,
-`idle` are **reserved names with no detector** — `churn`/`idle` dropped under
-Epic #1721, `hotspot` retired with its detector under Epic #4406 (ADR in
-[`docs/decisions.md`](decisions.md)). The names stay so a re-introduction
-needs no schema bump, but the config keys are gone: `SIGNALS_DEFAULTS`
+`idle` are **reserved names with no detector**. The names stay so a
+re-introduction needs no schema bump, but the config keys are gone:
+`SIGNALS_DEFAULTS`
 (`lib/config/limits.js`) carries `rework` and `retry` only under an
 `additionalProperties: false` block, so `delivery.signals.hotspot` fails AJV
 validation. Records are written **append-only to local disk** under
@@ -1121,13 +1103,11 @@ The model has three layers:
    `rework.editsPerFile` (default 5) and `retry.repeatCount` (default 3),
    overridable under `delivery.signals.*`. The resolver shallow-merges per
    detector, so re-tuning one does not require re-listing the other.
-3. **Analyzers — the retro.** Story #4545 deleted the perf-summary /
-   perf-report analyzers: the CLI hard-failed without an Epic id, read
-   signals from a path a standalone Story can never produce, and no workflow
-   invoked it. The surviving consumer is the retro proposal composer
+3. **Analyzers — the retro.** The only analyzer is the retro proposal composer
    (`lib/orchestration/retro-proposals.js`), which routes recurring friction
    into framework / consumer / discarded proposals. Nothing writes a
-   `structured:story-perf-summary` or `structured:epic-perf-report` comment.
+   `structured:story-perf-summary` or `structured:epic-perf-report` comment —
+   Story #4545 deleted those analyzers.
 
 The split — events local, summaries on tickets — keeps the comment surface
 bounded and the raw stream cheap enough that detectors can fire on every
@@ -1212,11 +1192,8 @@ with three jobs:
 3. **Windows Smoke** — advisory (non-required) Windows leg (Story #3389):
    bootstrap dry-run, command sync, and config-resolution tests.
 
-Distribution is **not** handled by `ci.yml`. A separate `release-please.yml`
-workflow cuts releases and runs the `npm-publish` job that publishes
-`mandrel` to npm with Sigstore build provenance once a release is
-tagged. The retired `dist`-branch mirror that `ci.yml` once synced no longer
-exists.
+Distribution is **not** handled by `ci.yml` — see
+[**Distribution Model**](#distribution-model).
 
 The baseline-refresh CI guardrail was removed alongside the bot-approver
 pipeline; the `baseline-refresh:` commit subject + non-empty body
@@ -1275,35 +1252,12 @@ fails the gate identically at the others.
 
 - **Husky** + **lint-staged**: Auto-lint and format staged files on commit.
 
-#### `lint-staged` biome config: `--no-errors-on-unmatched`
-
-The biome steps in `.lintstagedrc` (`biome check` / `biome format`) carry
-the `--no-errors-on-unmatched` flag. This is the canonical fix for the
-defect tracked in **Story #3529**.
-
-**Background.** `biome.json` sets `vcs.useIgnoreFile=true`, so biome honours
-`.gitignore`. Epic #3436 (PR #3485) briefly added `/.agents/` to
-`.gitignore` as part of the in-flight npm-distribution migration. Because
-`.agents/` is the framework's own committed source tree, every staged
-`.agents/**/*.js` change was then handed to biome as an *ignored* path:
-biome processed 0 files and **exited 1**, hard-failing the pre-commit hook
-on any framework `.js` commit. Story #3489 (PR #3531) removed the
-`/.agents/` ignore in this source repo (the `.gitignore` NOTE block records
-why the framework repo keeps `.agents/` tracked while consumer projects
-ignore their materialized copy), which eliminates the original trigger.
-
-**Why the flag stays.** `--no-errors-on-unmatched` is retained as a
-defensive default rather than reverted now that #3489 fixed the root cause.
-Without it, biome treats an "all staged paths ignored" set as an error and
-exits non-zero; with it, biome still lints/formats every *non-ignored*
-staged file (no silent coverage loss — verified: a staged `.agents/scripts/`
-edit passes the hook and is linted) but no longer hard-fails when a commit
-happens to stage only ignored paths. The `.gitignore` in this repo still
-ignores local-override paths (`.agents/*.local.md`, `.agents/*local.json`)
-and consumer projects ignore their entire materialized `/.agents/` copy, so
-an all-ignored staged set remains a reachable state the flag guards against
-at zero cost. `.lintstagedrc` is plain JSON and cannot carry an inline
-comment, so this rationale lives here.
+  The biome steps in `.lintstagedrc` carry `--no-errors-on-unmatched` as a
+  defensive default: without it biome exits non-zero when every staged path is
+  gitignored, which is still reachable (local-override paths here, the whole
+  materialized `/.agents/` copy in a consumer). `.lintstagedrc` is plain JSON
+  and cannot carry the note inline, so it lives here. Full incident write-up:
+  [`lint-staged` biome config: `--no-errors-on-unmatched`](archive/architecture-2026-08.md#lint-staged-biome-config---no-errors-on-unmatched).
 
 ---
 
@@ -1336,12 +1290,19 @@ validation. The surviving ceilings are **fixed framework constants**:
 
 ## Distribution Model
 
-Mandrel is distributed as the
-[`mandrel`](https://www.npmjs.com/package/mandrel) npm package, whose `files`
-array publishes `.agents/`, `bin/`, and `lib/`. Only **`.agents/`** is
-materialized into the consumer's `./.agents/` directory as plain regular files
-by `mandrel sync` (best-effort from `postinstall`, or invoked directly);
-`bin/` + `lib/` stay in `node_modules/mandrel/`, reached via `npx mandrel`:
+**The single statement of the release/distribution topology.** Mandrel is
+distributed as the [`mandrel`](https://www.npmjs.com/package/mandrel) npm
+package. Its `package.json` `files` array publishes `.agents/`, `bin/`,
+`lib/`, and `docs/CHANGELOG.md`, minus two negations that strip the shipped
+test trees (`!lib/**/__tests__`, `!.agents/**/__tests__`). Releases are cut by
+the `release-please.yml` workflow — never by `ci.yml` — whose `npm-publish`
+job publishes to npm with Sigstore build provenance once a release is tagged;
+the `dist`-branch mirror `ci.yml` once synced no longer exists.
+
+Only **`.agents/`** is materialized into the consumer's `./.agents/` directory
+as plain regular files by `mandrel sync` (best-effort from `postinstall`, or
+invoked directly); `bin/` + `lib/` stay in `node_modules/mandrel/`, reached
+via `npx mandrel`:
 
 ```text
 Consumer Project/

--- a/docs/archive/architecture-2026-08.md
+++ b/docs/archive/architecture-2026-08.md
@@ -1,0 +1,125 @@
+# Archived architecture history — 2026-08
+
+Finished-work history relocated verbatim out of
+[`docs/architecture.md`](../architecture.md) by Story #4924. Each section below
+narrates machinery the repository no longer ships, or a defect that was
+diagnosed and closed — record, not guidance.
+
+**Archived, not deleted.** The bodies below are word-for-word as they stood in
+`docs/architecture.md` before this Story. No prose was rewritten, summarized,
+or reordered.
+
+**Still-live guidance was lifted out before the move.** Every constraint in
+these sections that still binds current code stayed in `docs/architecture.md`
+as a one-line "do not reintroduce" note at the same place the section used to
+sit. Read the live doc for what applies; read this file for the record of what
+was removed and why.
+
+| Section | Relocated because |
+| --- | --- |
+| Failure auditability — what `ErrorJournal` was | The typed-context stratum it lived in was deleted (#3908). The live doc keeps the "nothing can inject it" warning; this is the backstory. |
+| Why the codebase snapshot was deleted | The snapshot and its config block were deleted in Story #4811. The live doc keeps the two grounding mechanisms that replaced it; this is the post-mortem. |
+| The epic-runner-era concurrency surface | `DEFAULT_CONCURRENCY` / `resolveConcurrency` / `CommitAssertion` / `ProgressReporter` all went with the in-process stratum (#3908). |
+| `lint-staged` biome config: `--no-errors-on-unmatched` | Story #3529's root cause was fixed by Story #3489 (PR #3531). The flag's one-line rationale stays live; the 29-line incident write-up is history. |
+| Deleted listeners, CLIs and the heartbeat emitter | Four one-off tombstones for surfaces removed between #3908 and Story #4542. The live doc keeps each surviving statement; these are the removal notes. |
+
+---
+
+## Deleted listeners, CLIs and the heartbeat emitter
+
+The epic-runner-era `blocker-handler` and `wave-observer` listeners were
+deleted with the in-process stratum (#3908); `agent::blocked` remains the
+sole runtime pause point, enforced by the workflow prose rather than a
+resident listener.
+
+The retired `epic-audit-prepare.js` / `epic-audit-recheck.js` CLIs were deleted
+with the v2 Story-only cutover.
+
+Lens selection is **not** risk-routed. Story #4542 deleted the risk→lens router
+(`resolveAuditLenses`): it had zero callers while this section and two other
+shipped documents claimed it ran inside close.
+
+A `story.heartbeat` event and its
+PostToolUse-hook emitter once existed, but the emitter required an
+`epicId >= 1` that v2 — which has no Epics — never supplied, so it could
+never fire; it was deleted (A22) rather than repaired.
+
+Story #2259 (Epic #2172) retired the legacy deliver-runner CLI
+wrapper; the slash command supplants it entirely.
+
+---
+
+## Failure auditability — what `ErrorJournal` was
+
+There is **no** `ErrorJournal` and no `lib/orchestration/error-journal.js`. It
+was an in-process-runner concept threaded through the typed context classes in
+`lib/orchestration/context.js`, and died with them and the epic-runner stratum
+(#3908) — do not write `errorJournal?.record(...)`; nothing can inject it. Two
+file-based surfaces replace it: the append-only signals stream
+(`lib/observability/signals-writer.js`, written by `diagnose-friction.js`) and
+the per-script logs under `temp/orchestration/`.
+
+The epic-runner progress reporter went with the same stratum (#3908). Live
+Story progress surfaces via lifecycle ledger events and structured comments
+(`story-init`, `friction`, `verification-results`, `follow-ups`) posted by the
+single-story init/close path.
+
+---
+
+## Why the codebase snapshot was deleted
+
+The snapshot grounded nothing it promised. Its default include globs guessed
+`app/**` singular and matched zero product files under the standard `apps/**`
+monorepo layout; its remedies pointed at knobs (`tier: "medium"`, a narrower
+`include`) that re-signatured the same already-filtered set and could not fix
+a missing include; and its cited-but-absent signal inverted into noise
+whenever the snapshot itself was the incomplete artifact.
+
+---
+
+## The epic-runner-era concurrency surface
+
+The whole epic-runner-era
+concurrency surface (`DEFAULT_CONCURRENCY` / `resolveConcurrency`,
+`CommitAssertion`, the `ProgressReporter` listener) went with the dead
+in-process stratum (#3908) — do not confuse the surviving
+`resolveConcurrencyCap` with the deleted `resolveConcurrency`. Story #4545
+deleted the perf-summary throughput surface; the local `signals.ndjson`
+stream and the retro's aggregate over it are what remain.
+
+The `CommitAssertion` post-wave guard and its `verifySingleResult` successor
+both went with the epic-runner / wave machinery. The guard against a Story
+being reported "done" without verifiable completion is now structural:
+`agent::done` follows the confirmed squash-merge of the Story's own PR.
+
+---
+
+## `lint-staged` biome config: `--no-errors-on-unmatched`
+
+The biome steps in `.lintstagedrc` (`biome check` / `biome format`) carry
+the `--no-errors-on-unmatched` flag. This is the canonical fix for the
+defect tracked in **Story #3529**.
+
+**Background.** `biome.json` sets `vcs.useIgnoreFile=true`, so biome honours
+`.gitignore`. Epic #3436 (PR #3485) briefly added `/.agents/` to
+`.gitignore` as part of the in-flight npm-distribution migration. Because
+`.agents/` is the framework's own committed source tree, every staged
+`.agents/**/*.js` change was then handed to biome as an *ignored* path:
+biome processed 0 files and **exited 1**, hard-failing the pre-commit hook
+on any framework `.js` commit. Story #3489 (PR #3531) removed the
+`/.agents/` ignore in this source repo (the `.gitignore` NOTE block records
+why the framework repo keeps `.agents/` tracked while consumer projects
+ignore their materialized copy), which eliminates the original trigger.
+
+**Why the flag stays.** `--no-errors-on-unmatched` is retained as a
+defensive default rather than reverted now that #3489 fixed the root cause.
+Without it, biome treats an "all staged paths ignored" set as an error and
+exits non-zero; with it, biome still lints/formats every *non-ignored*
+staged file (no silent coverage loss — verified: a staged `.agents/scripts/`
+edit passes the hook and is linted) but no longer hard-fails when a commit
+happens to stage only ignored paths. The `.gitignore` in this repo still
+ignores local-override paths (`.agents/*.local.md`, `.agents/*local.json`)
+and consumer projects ignore their entire materialized `/.agents/` copy, so
+an all-ignored staged set remains a reachable state the flag guards against
+at zero cost. `.lintstagedrc` is plain JSON and cannot carry an inline
+comment, so this rationale lives here.

--- a/docs/archive/data-dictionary-2026-08.md
+++ b/docs/archive/data-dictionary-2026-08.md
@@ -1,0 +1,67 @@
+# Archived data-dictionary entries — 2026-08
+
+Retired sections relocated verbatim out of
+[`docs/data-dictionary.md`](../data-dictionary.md) by Story #4924. Each
+documents a surface the repository no longer implements — its entire body was
+already a statement that the thing is gone, so it defined no live vocabulary.
+
+**Archived, not deleted.** The bodies below are word-for-word as they stood in
+`docs/data-dictionary.md` before this Story. No prose was rewritten or
+summarized.
+
+**Nothing live was lifted out.** Each section's replacement surface was already
+named inside it and is repeated in the one-line pointer left in the live doc.
+
+| Section | Retired because |
+| --- | --- |
+| StoryPerfSummary / EpicPerfReport | Both payloads and their schemas were deleted with the execution-analysis surface (Story #4545). |
+| Dispatch Manifest | Deleted with the Epic tier in v2.0.0; nothing writes it. |
+| Health-Monitor Refresh Cadence | The `epic-run-progress` comment and its progress reporter went with the in-process epic-runner stratum (#3908 / PR #3936). |
+| Retro Heuristic | The `epic-retro` helper and `retro-heuristics.js` were deleted with the Epic delivery path. |
+
+---
+
+## StoryPerfSummary / EpicPerfReport
+
+Both payloads and their schemas were deleted with the execution-analysis
+surface that produced them. Nothing writes a `structured:story-perf-summary`
+or `structured:epic-perf-report` comment, and neither is a valid structured
+comment type any more.
+
+---
+
+## Dispatch Manifest
+
+> **Historical.** The dispatch manifest (`temp/dispatch-manifest-<epicId>.json`,
+> its structured comment, and its renderer `render-manifest.js`) was deleted
+> with the Epic tier in v2.0.0 — nothing writes it. The v2 dispatch record is
+> the Story's own GitHub surface: labels, structured comments, and the
+> `story-<id>` PR.
+
+---
+
+## Health-Monitor Refresh Cadence
+
+> **Historical.** The Epic Health (`epic-run-progress`) structured comment
+> and `lib/orchestration/epic-runner/progress-reporter/` were deleted with
+> the in-process epic-runner stratum (PR #3936 / #3908). v2 Story delivery
+> does not refresh an Epic health comment on a wave cadence.
+>
+> Live progress surfaces are Story-scoped structured comments
+> (`story-init`, `friction`, `verification-results`, `follow-ups`) plus the
+> lifecycle ledger under `temp/run-<id>/`. The former lifecycle-bus
+> `structured-comment-poster` listener is also deleted.
+
+---
+
+## Retro Heuristic
+
+> **Removed in v2.** The `epic-retro` helper and
+> `lib/orchestration/retro-heuristics.js` (`isCleanManifest`) were deleted with
+> the Epic delivery path; compact-vs-full retro branching no longer applies.
+> Kept as a glossary for archived docs that still name the predicate.
+
+| Term                       | Kind     | Definition                                                                                                                                                |
+| -------------------------- | -------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `isCleanManifest(signals)` | Predicate | *(deleted)* Formerly returned `true` iff friction/parked/recuts/hotfixes/hitl were all zero. |
+| `--full-retro`             | CLI flag | *(deleted)* Former `/deliver` override forcing the six-section retro body. |

--- a/docs/data-dictionary.md
+++ b/docs/data-dictionary.md
@@ -40,34 +40,45 @@ being reserved names with no shipped detector.
 
 ---
 
-## StoryPerfSummary / EpicPerfReport — removed (Story #4545)
+## Retired vocabulary (archived)
 
-Both payloads and their schemas were deleted with the execution-analysis
-surface that produced them. Nothing writes a `structured:story-perf-summary`
-or `structured:epic-perf-report` comment, and neither is a valid structured
-comment type any more.
+Four sections whose entire body recorded that a surface was gone — they defined
+no live vocabulary — are archived verbatim:
+[StoryPerfSummary / EpicPerfReport](archive/data-dictionary-2026-08.md#storyperfsummary--epicperfreport),
+[Dispatch Manifest](archive/data-dictionary-2026-08.md#dispatch-manifest),
+[Health-Monitor Refresh Cadence](archive/data-dictionary-2026-08.md#health-monitor-refresh-cadence),
+[Retro Heuristic](archive/data-dictionary-2026-08.md#retro-heuristic).
 
-## FrictionEvent (`friction` NDJSON signal)
+---
 
-Appended to `temp/run-<eid>/stories/story-<sid>/signals.ndjson` (or
-`temp/standalone/stories/story-<sid>/signals.ndjson`) by
-`signals-writer.appendSignal` when detector or gate-failure paths
-trip. (Pre Epic #1030 Story #1042 the same payload was posted as a
-GitHub structured comment by the now-deleted in-process emitter.)
-Schema lives at
-[`friction-event.schema.json`](../.agents/schemas/friction-event.schema.json);
-the table below mirrors that schema — update both together.
+## FrictionEvent (legacy schema — not the live `friction` record)
+
+**A live `friction` record is a `SignalEvent` with `kind: "friction"`** — see
+the table above. `appendSignal` validates against `signal-event.schema.json`
+(the only file `signal-validator.js` compiles), and
+`diagnose-friction.js#buildFrictionSignal` is the producer.
+
+[`friction-event.schema.json`](../.agents/schemas/friction-event.schema.json)
+is the pre-cutover document from Epic #1030, superseded by
+`signal-event.schema.json` in the Epic #4406 envelope cutover. No writer,
+reader, or validator loads it — a retained record, not a contract. Mirrored
+here field for field so the two shapes are not confused:
 
 | Field      | Type                | Required | Description                                                            |
 | ---------- | ------------------- | -------- | ---------------------------------------------------------------------- |
 | `eventId`  | `uuid string`       | Yes      | Unique event identifier.                                               |
-| `timestamp`| `ISO8601 date-time` | Yes      | When the event occurred.                                               |
-| `sprintId` | `string`            | Yes      | Epic identifier the event belongs to. Field is `sprintId` for back-compat with the schema; rename to `epicId` is a planned breaking change tracked in the next major. |
-| `taskId`   | `integer`           | Yes      | GitHub issue number of the Story (legacy field name `taskId`).          |
+| `timestamp`| `ISO8601 date-time` | Yes      | When the event occurred. The live envelope's key is `ts`.               |
+| `sprintId` | `string`            | Yes      | Epic identifier the event belongs to. The live envelope's key is `epicId`. |
 | `category` | `enum`              | Yes      | One of `Prompt Ambiguity`, `Missing Skill`, `Incorrect Persona`, `Tool Limitation`, `Execution Error`. |
-| `details`  | `string`            | Yes      | Specific error message or observation.                                  |
-| `source`   | `object`            | No       | `{ tool?: string, command?: string }` — failed tool / command.          |
+| `details`  | `string`            | Yes      | Specific error message or observation. The live envelope requires an **object** here. |
+| `source`   | `object`            | No       | `{ tool?, command? }` — failed tool / command. The live envelope moved this to `emitter` and reuses `source` for the framework/consumer tag. |
 | `context`  | `object`            | No       | `{ protocolFile?: string }` — relevant protocol file path.              |
+
+`required` is exactly `["eventId", "timestamp", "sprintId", "category",
+"details"]`. **`taskId` is not in it and is not a property of this schema at
+all** — `additionalProperties: false` rejects it outright. (The live
+`SignalEvent` envelope does carry an optional `taskId`, always `null` since
+the 2-tier hierarchy landed.)
 
 ---
 
@@ -112,6 +123,10 @@ outside this set MUST be proposed in a PR that updates the rule before use.
 | `@platform-mobile`| Platform exclusive     | Scenario only makes sense on the mobile client.                                                      |
 | `@domain-<slug>`  | Domain scope (required)| Exactly one per scenario. Slug is project-defined (e.g. `@domain-billing`, `@domain-auth`).          |
 | `@flaky`          | Operational quarantine | Scenario excluded from the gating suite; runs in a non-blocking job until stabilized. Debt marker.   |
+| `@skip`           | Scaffold gating        | Scenario scaffolded ahead of its implementation; excluded from the gating suite until the implementing Story removes the tag (the "de-skip" edit). Unlike `@flaky`, it marks planned not-yet-implemented behavior, never instability. |
+
+Retired: `@epic-<id>-ac-N` is inert — never apply it to new scenarios;
+`mandrel update` strips surviving instances from consumer files.
 
 ---
 
@@ -204,16 +219,6 @@ readers should not re-implement the fence-extraction logic inline.
 
 ---
 
-## Dispatch Manifest (historical)
-
-> **Historical.** The dispatch manifest (`temp/dispatch-manifest-<epicId>.json`,
-> its structured comment, and its renderer `render-manifest.js`) was deleted
-> with the Epic tier in v2.0.0 — nothing writes it. The v2 dispatch record is
-> the Story's own GitHub surface: labels, structured comments, and the
-> `story-<id>` PR.
-
----
-
 ## Resilience & Throughput Primitives
 
 | Term                                                | Kind     | Definition                                                                                                                                                                       |
@@ -245,7 +250,13 @@ readers should not re-implement the fence-extraction logic inline.
 | --------- | ----------------------------------------------------------------------------------------------------- |
 | `silent`  | Only `fatal` emits.                                                                                   |
 | `info`    | Default. `info` / `warn` / `error` / `fatal` emit; `debug` is suppressed.                             |
-| `verbose` | All levels emit, including `debug` trace output. `debug` is accepted as a backward-compat alias.       |
+| `verbose` | All levels emit, including `debug` trace output.                                                      |
+
+`VALID_LEVELS` (`resolveLevel`) accepts **only** these three. There is no
+`debug` level and no backward-compat alias for one: any other value —
+`debug` included — falls back to `info`, so `AGENT_LOG_LEVEL=debug`
+silently suppresses the trace output it looks like it enables. Use
+`verbose`.
 
 ---
 
@@ -334,20 +345,6 @@ and overwrites the record on success.
 
 ---
 
-## Health-Monitor Refresh Cadence
-
-> **Historical.** The Epic Health (`epic-run-progress`) structured comment
-> and `lib/orchestration/epic-runner/progress-reporter/` were deleted with
-> the in-process epic-runner stratum (PR #3936 / #3908). v2 Story delivery
-> does not refresh an Epic health comment on a wave cadence.
->
-> Live progress surfaces are Story-scoped structured comments
-> (`story-init`, `friction`, `verification-results`, `follow-ups`) plus the
-> lifecycle ledger under `temp/run-<id>/`. The former lifecycle-bus
-> `structured-comment-poster` listener is also deleted.
-
----
-
 ## QA Session & Ledger Artifacts
 
 `/qa-assist` (human-led) and `/qa-explore` (agent-led) share a persistent,
@@ -364,17 +361,3 @@ before it reaches disk.
 | `resolveQaSession({ sessionId, config, env })` | Helper  | `lib/qa/qa-session.js`. Resolves `{ sessionId, ledgerPath, reused, untriaged }`. Session-id precedence: explicit `--session-id` → `QA_SESSION_ID` env var → derived `qa-<YYYY-MM-DD>-<hex8>`. Ids are slugified (path-traversal safe). `reused: true` signals an existing ledger that must be appended to. |
 | `QaLedgerItem`                           | Record shape  | Required: `id` (`L1`, `L2`, … in capture order), `class` (`product-bug` \| `environment-setup` \| `tooling-dx` \| `test-gap` \| `enhancement`), `severity` (`critical` \| `high` \| `medium` \| `low` \| `info`), `evidence` (one-line, scrubbed), `coverage` (surface/scenario label, `unknown` fallback), `missingTest` (string or `null`). Optional: `disposition`, `relates` (ids of folded-in items). |
 | `disposition`                            | Field         | Two-phase lifecycle marker. Capture phase: absent, `null`, or a `pending`/`untriaged` sentinel — these items form the rolling backlog (`untriaged`) a resume run carries forward. Triage phase: `file` (promote to follow-up ticket), `defer` (park), or `dismiss` (non-actionable). `TRIAGED_DISPOSITIONS` in `qa-session.js` is the SSOT. |
-
----
-
-## Retro Heuristic (historical)
-
-> **Removed in v2.** The `epic-retro` helper and
-> `lib/orchestration/retro-heuristics.js` (`isCleanManifest`) were deleted with
-> the Epic delivery path; compact-vs-full retro branching no longer applies.
-> Kept as a glossary for archived docs that still name the predicate.
-
-| Term                       | Kind     | Definition                                                                                                                                                |
-| -------------------------- | -------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `isCleanManifest(signals)` | Predicate | *(deleted)* Formerly returned `true` iff friction/parked/recuts/hotfixes/hitl were all zero. |
-| `--full-retro`             | CLI flag | *(deleted)* Former `/deliver` override forcing the six-section retro body. |

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -11,9 +11,14 @@ under `docs/archive/` — see the Pruning & Archiving section of
 [`documentation-and-adrs`](../.agents/skills/core/documentation-and-adrs/reference.md).
 
 Every entry that is still **Accepted** carries a `**Surface:**` line naming the
-one primary path the decision governs. That line is the machine-checkable
-contract behind this log: a decision cannot claim to be in force while the file
-it decided is absent from the tree (`tests/docs/decisions-and-archive-contract.test.js`).
+one primary path the decision governs. What that line is machine-checked for is
+**existence only** — `tests/docs/decisions-and-archive-contract.test.js` runs
+`existsSync` on the path, nothing more. It catches the loud failure (an ADR
+still Accepted after its file was deleted) and cannot catch the quiet one: a
+decision whose mechanism was dismantled while the named file lived on, or whose
+Surface names a file too broad to witness anything. Treat a passing Surface as
+necessary, never sufficient. Entries known to be in that state carry an
+explicit `**Materially dead:**` line — grep for it.
 
 **Identifiers are unique and stable.** An entry is cited by its `<date>-<ticket>`
 identifier, and the same contract test rejects a collision. Story #4786 resolved
@@ -127,7 +132,14 @@ at the release tag named in the entry.
 [`20260501-900a`](#adr-20260501-900a-epic-centric-workflow-rework--four-skill-split-single-session-fan-out-retire-github-triggers-superseded),
 [`20260512-destructive-replan-retired`](#adr-20260512-destructive-replan-retired-epic-1182--retire-delete-epicjs-re-plan--edit-spec--reconcile-superseded),
 [`20260427-868a`](#adr-20260427-868a-open-root-dispatch-manifest-schema-ajv-fixture-drift-test-as-enforcement-boundary-superseded),
-and the Epic-scoped `ADR-202604*` cluster (each flagged in place).
+and seven Epic-scoped entries flagged in place: `20260422-413a`,
+`20260422-413b`, `20260423`, `20260423-511c`, `20260424-553a`,
+`20260424-553b`, `20260426-817b`.
+
+Those thirteen are the whole list — each carries the reciprocal
+`Superseded by <this entry>` status. The earlier blanket "the Epic-scoped
+`ADR-202604*` cluster" was false: most such entries are still Accepted or
+superseded by something else.
 
 ### Context
 
@@ -501,10 +513,12 @@ a command. This mirrors the `worktree-lifecycle` row's treatment.
   operator runs the drain directly via
   `node .agents/scripts/drain-pending-cleanup.js` when a wedged worktree
   needs a manual nudge.
-- **The automatic drain paths are unchanged.** epic-runner Phase 7,
-  story-close post-merge, and the plan-boot sweep continue to call
-  `forceDrainPendingCleanup()` directly — they never depended on the
-  slash command.
+- **The automatic drain paths never depended on the slash command.** Of the
+  three cited here in 2026, only the plan-boot sweep survives
+  (`lib/orchestration/plan-runner/worktree-sweep.js` calls
+  `forceDrainPendingCleanup()` from `lib/worktree/lifecycle/force-drain.js`);
+  the epic-runner Phase 7 and story-close post-merge callers went with the
+  in-process stratum.
 - **The script is the SSOT for the manual path.** No behaviour changed in
   `drain-pending-cleanup.js`; only the `.md` projection was removed.
 
@@ -556,11 +570,13 @@ as a bare `/<name>` command. No plugin manifest, no repo-local marketplace, no
 frontmatter-preserving header injection (`lib/command-header.js#applyHeader`,
 so each command's `description` parses) are kept.
 
-The single-brand discoverability affordance reverts to ADR 20260513: a bare
-`/mandrel` catalog command (the `mandrel.md` workflow) plus descriptive base
-names. The collision-risk and provenance concerns #3576 raised are accepted as
-the cost of universal reachability — a command that does not load has no
-namespace to protect.
+What reverts from ADR 20260513 is the **descriptive base-name discipline**,
+not the single-brand affordance: the `/mandrel` catalog entry is **not**
+restored. No `mandrel.md` workflow exists and nothing projects a `/mandrel`
+command, so the framework ships no discoverability entry point — the `/` menu
+is the catalog. The collision-risk and provenance concerns #3576 raised are
+accepted as the cost of universal reachability: a command that does not load
+has no namespace to protect.
 
 ### Consequences
 
@@ -1437,6 +1453,13 @@ Concretely:
 **Status:** Accepted
 **Date:** 2026-04-24
 **Surface:** `.agents/scripts/post-structured-comment.js`
+**Materially dead (in part):** the core decision holds — the framework ships no
+MCP server — but its "one entry point per capability" consequence does not.
+The Surface file has **no production importer**: `code-review.js`,
+`run-epilogue.js`, and `single-story-init.js` import `upsertStructuredComment`
+from `lib/orchestration/ticketing.js` directly, and the CLI is named only in
+two script-name allowlists and its own test. The check passes on a file
+nothing calls.
 **Epic:** #702
 
 **Supersedes:** ADR-20260422-441b (_Canonical structured-comment writer is the MCP tool_),
@@ -1497,15 +1520,19 @@ doesn't carry a framework-shipped entry anymore.
 
 ### Where the capabilities live now
 
+Unlike the backticked paths in an entry's body, this table is a migration list
+an operator *acts on*, so it is kept current rather than frozen at its
+2026-04-24 wording (original: `git show mandrel-v2.16.0:docs/decisions.md`).
+
 | Retired MCP tool                               | Successor                                                                                                                                    |
 | ---------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
-| `mcp__mandrel__dispatch_wave`          | `node .agents/scripts/dispatcher.js --epic <id>` (same SDK, same dispatch-manifest output).                                                  |
-| `mcp__mandrel__hydrate_context`        | `node .agents/scripts/hydrate-context.js --ticket <id> --epic <id>` for the JSON envelope; add `--emit prompt` for the raw prompt. The only supported hydration CLI. |
-| `mcp__mandrel__transition_ticket_state`| `node .agents/scripts/update-ticket-state.js --task <id> --state <state>` (auto-cascades on `agent::done`).                                  |
-| `mcp__mandrel__cascade_completion`     | Inlined into `update-ticket-state.js`; also runs at Story close inside `story-close.js`.                                              |
-| `mcp__mandrel__post_structured_comment`| `node .agents/scripts/post-structured-comment.js --ticket <id> --marker <marker> --body-file <path>`; direct `provider.postComment` in lib code. |
-| `mcp__mandrel__select_audits`          | `node .agents/scripts/select-audits.js --ticket <id> --gate <gate>`.                                                                         |
-| `mcp__mandrel__run_audit_suite`        | `node .agents/scripts/run-audit-suite.js --audits <comma-list>`.                                                                             |
+| `mcp__mandrel__dispatch_wave`          | No CLI. Multi-Story ordering is `node .agents/scripts/stories-wave-tick.js` over `lib/wave-runner/ready-set.js`, driven by `/deliver`; the `dispatcher.js` entry script and the dispatch manifest were deleted in v2. |
+| `mcp__mandrel__hydrate_context`        | `node .agents/scripts/plan-context.js` for the `/plan` authoring envelope and `node .agents/scripts/resolve-stories.js` for the delivery envelope; the single `hydrate-context.js` CLI was deleted. |
+| `mcp__mandrel__transition_ticket_state`| `node .agents/scripts/update-ticket-state.js --ticket <id> --state <state>` (auto-cascades on `agent::done`).                                |
+| `mcp__mandrel__cascade_completion`     | Inlined into `update-ticket-state.js`; also runs at Story close inside `single-story-close.js`.                                              |
+| `mcp__mandrel__post_structured_comment`| `node .agents/scripts/post-structured-comment.js --ticket <id> --marker <marker> --body-file <path>`; lib code imports `upsertStructuredComment` from `lib/orchestration/ticketing.js` directly. |
+| `mcp__mandrel__select_audits`          | No CLI. `selectAudits()` from the `lib/audit-suite/index.js` SDK barrel; the `select-audits.js` entry script was deleted. |
+| `mcp__mandrel__run_audit_suite`        | No CLI. `runAuditSuite()` from the same barrel; the `run-audit-suite.js` entry script was deleted. |
 
 The SDK modules under `.agents/scripts/lib/orchestration/` (the things
 these tools delegated into) are unchanged — the retirement is a surface
@@ -1764,6 +1791,14 @@ Triggered Epic-level orchestration from a GitHub label via `epic-orchestrator.ym
 
 *   **Status:** Accepted (Epic #321 Story #334, v5.14.0).
 *   **Surface:** `.agents/instructions.md`
+*   **Materially dead:** the outcome holds — no runtime `risk::high` gate
+    exists — but every mechanism below is gone and the Surface is a doc file
+    that cannot witness it either way. `risk-gate-handler.js`,
+    `wave-dispatcher.js`, `story-close.js` are absent;
+    `handleRiskHighGate` / `handleHighRiskGate` occur nowhere but here; and
+    `hitl.riskHighApproval` / `hitl.riskHighRuntimeGate` are not config keys —
+    the escape hatch this ADR preserved went with the in-process stratum.
+    Read the Decision as a 2026-04 record, not as live wiring.
 *   **Context:** `risk-gate-handler.js` halted the dispatcher on
     `risk::high` tasks, and `story-close.js` halted close for
     `risk::high` stories. In the new HITL-minimal model this becomes
@@ -2421,12 +2456,14 @@ The Story-level verdict therefore collapses the four candidate outcomes into one
 
 ## ADR 20260513-command-naming-discipline: Domain-vocabulary command names; single Mandrel-prefixed discoverability entry
 
-**Status:** Accepted — **superseded on the collision axis** by
-[`20260603-plugin-namespace-cutover`](#adr-20260603-plugin-namespace-cutover-project-workflows-as-a-claude-code-plugin-mandrelname-superseded).
-The base-name naming discipline below still holds (descriptive names, no
-`mandrel-` filename prefix); the *single brand affordance* is now the
-plugin namespace `/mandrel:<name>` rather than the lone `/mandrel`
-discoverability entry, which itself became `/mandrel:mandrel`.
+**Status:** Accepted in part — the **base-name discipline below still holds**
+(descriptive names, no `mandrel-` prefix, projected as flat `/<name>`
+commands). The **single-brand `/mandrel` catalog entry is retired**:
+`20260603-plugin-namespace-cutover` replaced it with a `/mandrel:<name>`
+namespace, then
+[`20260604-flat-command-projection-revert`](#adr-20260604-flat-command-projection-revert-revert-the-plugin-cutover--project-workflows-as-flat-name-commands)
+reverted that cutover without restoring the catalog command; no `mandrel.md`
+workflow exists. Defer to `20260604` on the projection axis.
 **Date:** 2026-05-13
 **Surface:** `.agents/scripts/sync-claude-commands.js`
 **Epic:** #1184 (v6.0.0 Epic F — Cut-over + Mandrel rebrand)

--- a/docs/patterns.md
+++ b/docs/patterns.md
@@ -538,9 +538,19 @@ newline-terminated JSON record per friction event to
 must not halt the runner) and are picked up out-of-band by the analyzer
 (Epic #1030).
 
-1. **Shape.** `{ kind: 'friction', timestamp, epicId, storyId,
-   category, source: { tool }, details, ... }` — callers own the rest of
-   the payload.
+1. **Shape.** `signal-validator.js` validates every record against
+   [`signal-event.schema.json`](../.agents/schemas/signal-event.schema.json)
+   before appending; a failure is **dropped** with a `Logger.warn`, never
+   thrown. Only `kind` and `ts` are required (`additionalProperties: true`),
+   but three keys are easy to get wrong: the timestamp key is `ts` (no
+   `timestamp` alias), provenance is `emitter: { tool, command }` (`source`
+   carries only the `framework`/`consumer` tag `tagSignalSource` injects), and
+   `details` MUST be an object. `diagnose-friction.js` writes the canonical
+   record: `{ kind: 'friction', eventId, ts, epicId, storyId, taskId,
+   category, emitter: { tool, command }, details: { errorPreview, ... } }`.
+   The pre-cutover `friction-event.schema.json` is a retained record, not a
+   contract — nothing loads it, and a payload authored from it is dropped for
+   the missing `ts` / `kind`.
 2. **Consumers.** `diagnose-friction.js` (per-failure detector) and the
    quality-gate friction path (`lib/gates/friction.js`, fronting the
    unified `check-baselines.js` gate and its per-kind logic under

--- a/tests/contract/docs-reference-sync.test.js
+++ b/tests/contract/docs-reference-sync.test.js
@@ -397,10 +397,17 @@ describe('data-dictionary.md — SignalEvent row mirrors the live schema (Story 
     assert.deepEqual([...required].sort(), ['kind', 'ts']);
 
     // Every SignalEvent row in the table, keyed by field name.
+    // Bound the slice at the next `## ` heading rather than a named one: the
+    // sections that followed SignalEvent were archived in Story #4924, and a
+    // missing sentinel would silently widen the slice over the neighbouring
+    // FrictionEvent table (whose Required column mirrors a different schema).
     const md = dataDictionary();
+    const start = md.indexOf('## SignalEvent');
+    assert.notEqual(start, -1, 'data-dictionary.md lost its SignalEvent table');
+    const nextHeading = md.indexOf('\n## ', start + 1);
     const section = md.slice(
-      md.indexOf('## SignalEvent'),
-      md.indexOf('## StoryPerfSummary'),
+      start,
+      nextHeading === -1 ? md.length : nextHeading,
     );
     // Cells may carry escaped pipes inside a type expression, which would
     // shift every column index if split naively. The Required column never


### PR DESCRIPTION
Closes #4924

_Auto-opened by `/deliver`._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and a contract test only; no production runtime or orchestration behavior changes.
> 
> **Overview**
> Story **#4924** trims the four always-loaded reference docs by moving verbatim “machinery we no longer ship” prose into **`docs/archive/architecture-2026-08.md`** and **`docs/archive/data-dictionary-2026-08.md`**, leaving **`docs/architecture.md`** and **`docs/data-dictionary.md`** with short live guidance plus archive links.
> 
> **`architecture.md`** drops repeated distribution/release narrative (single **Distribution Model** section), replaces long epic-runner tombstones with one-line “do not reintroduce” notes, and **corrects acceptance-ceremony routing**: the `[1, 8]` clamp applies to **cluster size** (`clusterCeiling`), not cluster count.
> 
> **`data-dictionary.md`** archives retired glossary sections, reframes **`FrictionEvent`** as the superseded pre-#4406 schema (live friction = **`SignalEvent`** with `kind: "friction"`), documents **`@skip`** / retired **`@epic-*-ac-*`**, and states **`AGENT_LOG_LEVEL=debug`** is not a valid level (use **`verbose`**).
> 
> **`decisions.md`** and **`patterns.md`** fix contradictions: ADR **`Surface:`** checks are existence-only (new **`Materially dead:`** callouts), MCP-retirement successor table and drain paths match v2, and friction telemetry matches **`signal-event.schema.json`** (`ts`, `emitter`, object **`details`**).
> 
> **`tests/contract/docs-reference-sync.test.js`** bounds the SignalEvent table slice at the next `##` heading so archived sections do not pull in the FrictionEvent table.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 324e02e1d8a4846dfb4a5735b5af1f06f6be3683. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->