### PR TITLE
feat: make the coverage instrument measure: widen CI's run to every test tier, configure the gate, and reseed the baseline (#4922)

### DIFF
--- a/.agentrc.json
+++ b/.agentrc.json
@@ -33,6 +33,9 @@
     },
     "quality": {
       "gates": {
+        "coverage": {
+          "floors": { "*": { "lines": 94, "branches": 85, "functions": 87 } }
+        },
         "crap": {
           "floors": { "*": { "methodsAbove20": 13 } },
           "targetDirs": [".agents/scripts", "bin", "lib"],

--- a/.agents/docs/quality-gates.md
+++ b/.agents/docs/quality-gates.md
@@ -102,13 +102,18 @@ npm run coverage:update # writes baselines/coverage.json from the run
 runners that orchestrate coverage capture separately).
 
 The files-out-of-scope list is declared in [`.c8rc.cjs`](../../.c8rc.cjs) —
-thin CLI shells (e.g. `agents-bootstrap-github.js`, `plan-context.js`,
-`plan-persist.js`) plus the larger Story #1702 carve-out of
-top-level/orchestration/git CLIs and `lib/*` glue, each with a per-entry
-rationale in the `.c8rc.cjs` header comment (the authoritative list). Every
-excluded file also carries `/* node:coverage ignore file */` at the top of its
-source as a second line of defence; the header comment MUST be updated when the
-list changes.
+thin CLI shells plus the larger Story #1702 carve-out of
+top-level/orchestration/git CLIs and `lib/*` glue. The `exclude[]` array is
+the **single** declaration: each entry carries its rationale as an inline
+comment on the line above it. Story #4922 removed the prose inventory the
+header used to duplicate — two copies of one list in one file, 27 files
+apart by the time it was measured. Do not reintroduce one. Every excluded
+file also carries `/* node:coverage ignore file */` at the top of its source
+as a second line of defence.
+
+`.c8rc.cjs`'s `include` globs and `delivery.quality.gates.coverage.targetDirs`
+in [`.agentrc.json`](../../.agentrc.json) MUST name the same roots — the gate
+scores what c8 measures. `tests/c8rc-scope.test.js` asserts both invariants.
 
 ---
 
@@ -123,11 +128,30 @@ touched it:
 
 | Metric | Floor | Scope |
 | --- | --- | --- |
-| Coverage — lines | ≥ 90 % | per file |
-| Coverage — branches | ≥ 85 % | per file |
-| Coverage — functions | ≥ 90 % | per file |
-| Maintainability Index | ≥ 70 | per file |
-| CRAP | ≤ 20 | per method |
+| Coverage — lines | ≥ 94 % | repo rollup |
+| Coverage — branches | ≥ 85 % | repo rollup |
+| Coverage — functions | ≥ 87 % | repo rollup |
+| Maintainability Index | ≥ 70 | repo rollup |
+| CRAP — methods above 20 | ≤ 13 | repo rollup |
+
+Floors are enforced against the baseline's `rollup` components — the
+`applyFloors` phase compares `rollup["*"]` (and any named component), never
+individual rows. Story #4922 corrected this table, which previously read
+"per file" and quoted 90/85/90 for coverage; those numbers came from the
+example in `.agents/docs/agentrc-reference.json`, which is validated only
+against itself, and the coverage gate was not configured at all.
+
+The live coverage floors are derived from the measurement in
+[`baselines/coverage.json`](../../baselines/coverage.json) — a full-tier run
+scored 95.65 / 86.16 / 88.52, and each floor sits ~1–1.7 points under its
+axis. Re-derive them, do not invent them, whenever the baseline is
+regenerated wholesale.
+
+The coverage gate deliberately declares **no `tolerance`**, so its
+head-vs-base ratchet arm reports regressions without failing the build (the
+same shape the `crap` gate uses). Story #4922's scope was making the
+instrument honest; arming the ratchet belongs with the debt burn-down that
+the widened measurement newly exposes.
 
 The floors are declared in [`.agentrc.json`](../../.agentrc.json) under
 `delivery.quality.gates.<gate>.floors.*` (defaults baked into the helper
@@ -173,11 +197,11 @@ The floor gate is only as strict as its scope, so the `exclude` list in
 [`.c8rc.cjs`](../../.c8rc.cjs) carries three hard requirements that are
 enforced by review (and partially by the audit suite):
 
-1. **One-line rationale per entry.** Every file in `exclude[]` MUST have
-   a bulleted justification in the `.c8rc.cjs` header comment naming
-   *why* it is excluded — typically "thin CLI shell, meaningful logic
-   lives in `lib/<X>` and is unit-tested there." A bare path with no
-   rationale is a review-block.
+1. **One-line rationale per entry.** Every file in `exclude[]` MUST carry
+   an inline comment on the line(s) directly above it naming *why* it is
+   excluded — typically "thin CLI shell, meaningful logic lives in
+   `lib/<X>` and is unit-tested there." A bare path with no rationale is a
+   review-block, and `tests/c8rc-scope.test.js` fails on one.
 2. **`/* node:coverage ignore file */` pragma at source.** Every
    excluded file MUST carry the Node coverage pragma at the top of its
    own source. This is the second line of defence: when `c8 report` and

--- a/.agents/scripts/lib/baselines/scope.js
+++ b/.agents/scripts/lib/baselines/scope.js
@@ -1,32 +1,43 @@
 // .agents/scripts/lib/baselines/scope.js
 //
-// Story #1962 / Task #1970 — One ScopeResolution helper that the
-// `check-baselines.js` dispatcher and the per-kind regression writers
-// (Epic #1943) both consume. Routing every scope decision through this
-// single function is what guarantees read/write parity: the dispatcher
-// can never decide "diff against epic/1943" while the writer assumes
-// "full repo", because both call `resolveScope()` with the same inputs.
+// Story #1962 / Task #1970 — the ScopeResolution helper behind the
+// `check-baselines.js` dispatcher: `resolveDispatchScope` in
+// `lib/orchestration/check-baselines/phases/compare.js` is its one
+// caller. Routing the read side's scope decision through a single pure
+// function keeps the precedence rules from being re-implemented per gate.
+//
+// It is NOT the writers' resolver. `lib/baselines/refresh-service.js`
+// defines its own private `resolveScope` (Story #3658) over a different
+// input set, and the header here used to claim otherwise — a claim that
+// made the read/write pair look coupled when it is not. Corrected in
+// Story #4922.
 //
 // The resolver is intentionally pure — it takes already-extracted
-// inputs and returns a frozen ScopeResolution. CLI parsing, env
-// reading, and config loading happen in the caller; that keeps this
-// module trivially testable and prevents the precedence rules from
-// being silently re-implemented at every call site.
+// inputs and returns a frozen ScopeResolution. Env reading and config
+// loading happen in the caller; that keeps this module trivially
+// testable.
 //
 // Precedence (highest → lowest):
 //
-//   1. CLI flags — `cliFlags.fullScope: true` or `cliFlags.changedSinceRef`.
-//      Operator-typed beats anything in env/config. A CLI override of
-//      `--full-scope` wins even if the config says `'diff'`.
-//   2. Environment — `BASELINE_SCOPE` ('full' | 'diff') and
+//   1. Environment — `BASELINE_SCOPE` ('full' | 'diff') and
 //      `BASELINE_REF` (any git ref). The dispatcher reads these from
-//      `process.env` and forwards via `cliFlags.envScope` /
-//      `cliFlags.envRef` so the resolver itself never touches process
-//      state. CI usually sets these.
-//   3. Config — `configScope` ('full' | 'diff') and `configRef` (any
+//      `process.env` and forwards via `envScope` / `envRef` so the
+//      resolver itself never touches process state. CI sets these.
+//   2. Config — `configScope` ('full' | 'diff') and `configRef` (any
 //      git ref) from `delivery.quality.gateScoping` in `.agentrc.json`.
-//   4. Default — `mode='diff'` against `ref='main'`. This is the
+//   3. Default — `mode='diff'` against `ref='main'`. This is the
 //      framework-wide fallback when nothing else is configured.
+//
+// Story #4922 removed a fourth, highest-precedence layer: a
+// `cliFlags.fullScope` / `cliFlags.changedSinceRef` operator override,
+// plus the `cliFlags.changedFiles` → `files` plumbing that fed it. No
+// production caller ever populated any of the three — only this module's
+// own unit tests did — so the layer's only effect was to advertise a
+// `--full-scope` / `--changed-since` contract that `check-baselines.js`
+// does not implement, and a `files` set that no consumer read. Operators
+// who need full scope set `BASELINE_SCOPE=full`, which is what CI does.
+// (`mergeRowsByScope` below still takes a `files`-bearing scope — that
+// one comes from the refresh service's own resolver, not from here.)
 //
 // Missing-ref fallback: when the resolved mode is `'diff'` but no ref
 // is supplied at any layer, the resolver falls back to `'main'` rather
@@ -45,17 +56,8 @@
 //     kind: string,        // echoed back for caller convenience
 //     mode: 'full' | 'diff',
 //     ref:  string | null, // null in full mode; ref string in diff mode
-//     files: Set<string>,  // empty Set in full mode (sentinel for "all")
 //     source: string,      // which layer won (debug / friction signal)
 //   }
-//
-// `files` is intentionally a Set rather than an Array — callers
-// repeatedly check membership during per-row filtering, and Set lookup
-// is O(1). An empty Set in `'full'` mode means "no filter applies".
-// A non-empty Set in `'diff'` mode means "only these paths are in
-// scope" (the dispatcher pre-computes them via `git diff --name-only`
-// and forwards via `cliFlags.changedFiles`); when omitted, the writer
-// is expected to compute the diff itself against `ref`.
 
 const VALID_MODES = new Set(['full', 'diff']);
 const DEFAULT_DIFF_REF = 'main';
@@ -84,45 +86,19 @@ function asMode(v) {
 }
 
 /**
- * Coerce a candidate set/array of files to a frozen Set. Returns an
- * empty Set when the input is missing or empty.
- *
- * @param {unknown} v
- * @returns {Set<string>}
- */
-function asFilesSet(v) {
-  if (v instanceof Set) {
-    return new Set(
-      Array.from(v).filter((f) => typeof f === 'string' && f.length > 0),
-    );
-  }
-  if (Array.isArray(v)) {
-    return new Set(v.filter((f) => typeof f === 'string' && f.length > 0));
-  }
-  return new Set();
-}
-
-/**
- * Resolve a scope against the layered precedence (CLI > env > config >
+ * Resolve a scope against the layered precedence (env > config >
  * default). Pure; no I/O.
  *
  * @param {object} input
- * @param {string} input.kind         - Baseline kind (e.g. `'lint'`).
+ * @param {string} input.kind          - Baseline kind (e.g. `'lint'`).
  * @param {string} [input.configScope] - `'full'` | `'diff'` from agentrc.
  * @param {string} [input.configRef]   - Diff ref from agentrc.
- * @param {object} [input.cliFlags]    - Pre-parsed CLI / env layer.
- * @param {boolean} [input.cliFlags.fullScope]      - `--full-scope`.
- * @param {string}  [input.cliFlags.changedSinceRef] - `--changed-since <ref>`.
- * @param {string}  [input.cliFlags.envScope]        - From `BASELINE_SCOPE`.
- * @param {string}  [input.cliFlags.envRef]          - From `BASELINE_REF`.
- * @param {Iterable<string>} [input.cliFlags.changedFiles]
- *        Pre-computed diff paths (when caller already ran `git diff
- *        --name-only`). Becomes `files`; only meaningful in `'diff'` mode.
+ * @param {string} [input.envScope]    - From `BASELINE_SCOPE`.
+ * @param {string} [input.envRef]      - From `BASELINE_REF`.
  * @returns {{
  *   kind: string,
  *   mode: 'full' | 'diff',
  *   ref: string | null,
- *   files: Set<string>,
  *   source: string,
  * }}
  */
@@ -131,59 +107,34 @@ export function resolveScope(input = {}) {
     typeof input.kind === 'string' && input.kind.length > 0
       ? input.kind
       : 'unknown';
-  const cli = input.cliFlags ?? {};
 
-  // ---- Layer 1: CLI flags (highest precedence) -------------------------
-  if (cli.fullScope === true) {
-    return Object.freeze({
-      kind,
-      mode: 'full',
-      ref: null,
-      files: new Set(),
-      source: 'cli:--full-scope',
-    });
-  }
-  const cliRef = asNonEmptyString(cli.changedSinceRef);
-  if (cliRef) {
-    return Object.freeze({
-      kind,
-      mode: 'diff',
-      ref: cliRef,
-      files: asFilesSet(cli.changedFiles),
-      source: 'cli:--changed-since',
-    });
-  }
-
-  // ---- Layer 2: Environment (extracted by caller into cliFlags.env*) ---
-  const envMode = asMode(cli.envScope);
+  // ---- Layer 1: Environment (extracted by the caller) ------------------
+  const envMode = asMode(input.envScope);
   if (envMode === 'full') {
     return Object.freeze({
       kind,
       mode: 'full',
       ref: null,
-      files: new Set(),
       source: 'env:BASELINE_SCOPE=full',
     });
   }
-  const envRef = asNonEmptyString(cli.envRef);
+  const envRef = asNonEmptyString(input.envRef);
   if (envMode === 'diff' || envRef) {
     return Object.freeze({
       kind,
       mode: 'diff',
       ref: envRef ?? DEFAULT_DIFF_REF,
-      files: asFilesSet(cli.changedFiles),
       source: envRef ? 'env:BASELINE_REF' : 'env:BASELINE_SCOPE=diff',
     });
   }
 
-  // ---- Layer 3: Config (delivery.quality.gateScoping) -----------------
+  // ---- Layer 2: Config (delivery.quality.gateScoping) ------------------
   const cfgMode = asMode(input.configScope);
   if (cfgMode === 'full') {
     return Object.freeze({
       kind,
       mode: 'full',
       ref: null,
-      files: new Set(),
       source: 'config:gateScoping.scope=full',
     });
   }
@@ -193,19 +144,17 @@ export function resolveScope(input = {}) {
       kind,
       mode: 'diff',
       ref: cfgRef ?? DEFAULT_DIFF_REF,
-      files: asFilesSet(cli.changedFiles),
       source: cfgRef
         ? 'config:gateScoping.diffRef'
         : 'config:gateScoping.scope=diff',
     });
   }
 
-  // ---- Layer 4: Default ------------------------------------------------
+  // ---- Layer 3: Default ------------------------------------------------
   return Object.freeze({
     kind,
     mode: 'diff',
     ref: DEFAULT_DIFF_REF,
-    files: asFilesSet(cli.changedFiles),
     source: 'default',
   });
 }

--- a/.agents/scripts/lib/orchestration/check-baselines/phases/compare.js
+++ b/.agents/scripts/lib/orchestration/check-baselines/phases/compare.js
@@ -31,10 +31,8 @@ export function resolveDispatchScope({ kind, quality, env }) {
     kind,
     configScope: cfg.scope,
     configRef: cfg.diffRef,
-    cliFlags: {
-      envScope: env?.BASELINE_SCOPE,
-      envRef: env?.BASELINE_REF,
-    },
+    envScope: env?.BASELINE_SCOPE,
+    envRef: env?.BASELINE_REF,
   });
 }
 

--- a/.agents/scripts/lib/orchestration/git-cleanup/phases/phase-drivers.js
+++ b/.agents/scripts/lib/orchestration/git-cleanup/phases/phase-drivers.js
@@ -376,7 +376,11 @@ export async function executeStashPhase(action) {
   );
 }
 
-/* node:coverage ignore next */
+// Story #4922 — the `node:coverage ignore next` directive that used to sit
+// here is gone. It was never justified: `runStashPhase` is drivable end to
+// end (planStashes degrades to an empty list outside a repo, and the
+// decide/execute pair below is pure given an allowlist), so the directive
+// only hid a sequencer nothing exercised.
 export async function runStashPhase(opts, cwd) {
   Logger.info(`${TAG} ── phase: stashes ──`);
   const { stashes } = planStashes({ cwd });

--- a/.agents/scripts/lib/test-tiers.js
+++ b/.agents/scripts/lib/test-tiers.js
@@ -35,7 +35,9 @@ const matchesIntegration = picomatch(INTEGRATION_INCLUDE, { dot: true });
  * same way (Story #4195). Without each root here, both the quick /
  * integration walk and the full-tier glob set miss the colocated tests,
  * leaving that coverage dark in `npm test`. The matching full-tier globs
- * live in `FULL_TIER_GLOBS`.
+ * live in the exported `FULL_TIER_GLOBS` — every full-tier runner
+ * (`run-tests.js`, `run-coverage.js`) MUST consume that constant rather than
+ * restate a glob literal, or a runner silently walks a narrower surface.
  */
 const TEST_WALK_ROOTS = ['tests', 'lib', '.agents/scripts'];
 
@@ -44,8 +46,15 @@ const TEST_WALK_ROOTS = ['tests', 'lib', '.agents/scripts'];
  * The `tests` glob is a flat recursive sweep; the `lib` and `.agents/scripts`
  * globs are scoped to `__tests__` subtrees so they only match colocated
  * tests, never the shipped source modules themselves.
+ *
+ * Exported because the full tier has two runners, not one: `run-tests.js`
+ * (via `listTestFilesForTier`) and `run-coverage.js`. Story #4922 — the
+ * coverage runner used to restate `tests/**` on its own, so the 47 colocated
+ * `__tests__` files ran under `npm test` but were absent from the measured
+ * surface, leaving the coverage and CRAP numbers computed over code the
+ * measuring run never executed. Consume this constant; never restate a glob.
  */
-const FULL_TIER_GLOBS = [
+export const FULL_TIER_GLOBS = [
   'tests/**/*.test.js',
   'lib/**/__tests__/**/*.test.js',
   '.agents/scripts/**/__tests__/**/*.test.js',

--- a/.agents/scripts/run-coverage.js
+++ b/.agents/scripts/run-coverage.js
@@ -11,7 +11,10 @@
  *
  * Pipeline:
  *   1. Run the test suite under `NODE_V8_COVERAGE` so each worker writes
- *      raw V8 dumps under `coverage/tmp/`.
+ *      raw V8 dumps under `coverage/tmp/`. The suite targets are the
+ *      shared `FULL_TIER_GLOBS` from `lib/test-tiers.js` — the same set
+ *      `run-tests.js` walks — so the measured surface and `npm test`'s
+ *      surface are the same set by construction.
  *   2. `c8 report` post-processes the dumps into `coverage/coverage-final.json`
  *      plus the printed text table. Include/exclude scope from `.c8rc.cjs`
  *      is passed explicitly because `c8 report` does not auto-load the
@@ -46,6 +49,7 @@ import { fileURLToPath } from 'node:url';
 import { cleanupRepoTestTempArtifacts } from './cleanup-repo-test-temp.js';
 import { C8_CLI } from './lib/c8-cli-path.js';
 import { buildWebhookSafeTestEnv } from './lib/test-env.js';
+import { FULL_TIER_GLOBS } from './lib/test-tiers.js';
 import { TEST_RUNNER_FLAGS } from './run-tests.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -58,21 +62,31 @@ const V8_TMP = path.join(COVERAGE_DIR, 'tmp');
 /**
  * Build the `node --test` argv for the coverage suite spawn.
  *
- * Reuses the shared `TEST_RUNNER_FLAGS` (the single source of truth for
- * the host-aware, clamped `--test-concurrency` value) so the coverage
- * path never drifts from `run-tests.js`. The `runnerFlags` parameter is
- * injected in tests so the argv can be asserted without touching the OS.
+ * Reuses two shared constants so the coverage path cannot drift from
+ * `run-tests.js`:
+ *
+ *   - `TEST_RUNNER_FLAGS` — the single source of truth for the host-aware,
+ *     clamped `--test-concurrency` value.
+ *   - `FULL_TIER_GLOBS` — the single source of truth for *which files the
+ *     full tier runs*. Story #4922: this script used to restate
+ *     `tests/**\/*.test.js` on its own, so the 47 colocated `__tests__`
+ *     suites under `lib/` and `.agents/scripts/` executed under `npm test`
+ *     but never under the measuring run — the coverage and CRAP numbers
+ *     were computed over code the coverage run had not executed.
+ *
+ * Both parameters are injected in tests so the argv can be asserted without
+ * touching the OS.
  *
  * @param {object} [opts]
  * @param {readonly string[]} [opts.runnerFlags]
- * @param {string} [opts.testGlob]
+ * @param {readonly string[]} [opts.testGlobs]
  * @returns {string[]}
  */
 export function buildCoverageTestArgs({
   runnerFlags = TEST_RUNNER_FLAGS,
-  testGlob = 'tests/**/*.test.js',
+  testGlobs = FULL_TIER_GLOBS,
 } = {}) {
-  return [...runnerFlags, testGlob];
+  return [...runnerFlags, ...testGlobs];
 }
 
 /**
@@ -106,6 +120,12 @@ function runCoveragePipeline() {
     p,
   ]);
 
+  // `c8 report` does not auto-load `.c8rc.cjs`, so every scope knob it needs
+  // is forwarded explicitly from the config object — including `all`, which
+  // is what puts a 0 % row on a source file no test ever loaded (Story
+  // #4922). Reading it off the config keeps `.c8rc.cjs` the one declaration.
+  const allArgs = C8_CONFIG.all ? ['--all'] : [];
+
   const reportRun = spawnSync(
     process.execPath,
     [
@@ -113,6 +133,7 @@ function runCoveragePipeline() {
       'report',
       '--reporter=json',
       '--reporter=text',
+      ...allArgs,
       '--temp-directory',
       V8_TMP,
       ...includeArgs,

--- a/.agents/scripts/validate-docs-freshness.js
+++ b/.agents/scripts/validate-docs-freshness.js
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+/* node:coverage ignore file -- top-level docs-freshness gate shell; the tested logic lives in lib/docs-freshness.js */
 
 /**
  * .agents/scripts/validate-docs-freshness.js — Documentation Freshness Gate

--- a/.c8rc.cjs
+++ b/.c8rc.cjs
@@ -9,56 +9,38 @@
  * [`.agents/docs/quality-gates.md`](./.agents/docs/quality-gates.md) for the full ratchet
  * workflow.
  *
- * The `exclude` list below removes thin CLI shells whose meaningful
- * logic lives in `lib/` (which the per-file baseline still scores).
- * Each excluded file also carries `/* node:coverage ignore file *​/`
- * at the top of its source as a second line of defence; new exclusions
- * MUST add that pragma at the same time as touching this list, or
- * `c8 report` and the baseline checker disagree on what's in scope.
+ * ## One declaration, not two (Story #4922)
  *
- *   - agents-bootstrap-github.js — one-shot bootstrap CLI run once per
- *     consuming repo to seed labels, project fields, and views from
- *     `lib/label-taxonomy.js`. The taxonomy itself is unit-tested; the
- *     CLI shell only argv-parses and calls a single provider method
- *     loop. Real coverage requires hitting a live GitHub repo, which
- *     belongs in integration tests, not the unit-test gate.
+ * This header used to restate the whole `exclude` inventory in prose, so
+ * the scope was declared twice in one file and the two copies drifted.
+ * The arrays below are now the **only** declaration; each entry carries
+ * its rationale inline, where it cannot drift away from the path it
+ * justifies. Do not reintroduce a prose inventory here.
  *
- * --- Story #1702 (Epic #1653) bounded-sweep additions ---
+ * `include` mirrors `delivery.quality.gates.coverage.targetDirs` in
+ * `.agentrc.json` — the gate scores what c8 measures, so the two must name
+ * the same roots. `tests/c8rc-scope.test.js` asserts that correspondence.
  *
- * The block below carves out floor-gap offenders from Story #1702 (see
- * git history under `epic/1653` for the full inventory table; the v2
- * Story-only cutover deleted many of the original entries). Each entry
- * meets one of the operator-approved criteria from Story #1702's body:
- * thin CLI shell, pure I/O glue, deprecation/one-shot script, or
- * unit-mock-only test surface. Per-file rationale lives in the
- * `node:coverage ignore file` pragma at the top of each source file;
- * aggregate categories:
- *
- *   Top-level CLI gates (lint/baselines gate):
- *     lint-baseline.js, validate-docs-freshness.js
- *
- *   Top-level orchestration CLIs (already pragma'd; promoted to the c8
- *   exclude list to keep `c8 report` and the per-file baseline in sync):
- *     single-story-init.js, post-structured-comment.js,
- *     diagnose-friction.js, run-tests.js, test-wrapper.js, notify.js
- *
- *   Git-manipulation CLIs (branch sweepers, integration-shaped):
- *     git-cleanup.js
- *
- *   Long-lived dev tools (one-shot watchers):
- *     quality-watch.js
- *
- *   lib/* carve-outs (data-as-code schemas and orchestration glue over
- *   live git/filesystem state where unit-mocking asserts only the mock
- *   structure):
- *     lib/config-schema.js, lib/config-settings-schema.js,
- *     lib/worktree/node-modules-strategy.js
+ * Every excluded file MUST also carry `/* node:coverage ignore file *​/` at
+ * the top of its own source as a second line of defence; new exclusions add
+ * that pragma at the same time as touching this list, or `c8 report` and the
+ * baseline checker disagree on what is in scope.
  */
 
 module.exports = {
   reporter: ['json', 'text'],
+  // Story #4922 — score EVERY in-scope source file, not only the ones some
+  // test happened to load. Without `all`, a module no test imports is absent
+  // from `coverage-final.json` entirely, so it gets no baseline row, no floor,
+  // and no way to regress: it reads as "not measured" where the honest
+  // reading is 0 %. Four files sat in exactly that hole. This is what makes
+  // "every in-scope source file has a row" a checkable invariant.
+  all: true,
+  // Coverage target roots — keep in lockstep with
+  // `delivery.quality.gates.coverage.targetDirs` in `.agentrc.json`.
   include: ['.agents/scripts/**', 'bin/**', 'lib/**'],
   exclude: [
+    // --- Colocated test sources (test code, not production source) ------
     // Story #4125 — colocated test files under lib/ are test sources, not
     // production sources. Excluding them keeps `c8 report` and the
     // per-file coverage baseline from scoring test code as instrumented
@@ -71,27 +53,48 @@ module.exports = {
     // test code is never scored as instrumented production source.
     '.agents/scripts/**/__tests__/**',
 
-    // Pre-Story-#1702 baseline carve-outs.
+    // --- Thin CLI shells: argv-parse + delegate to a unit-tested lib/ ----
+    // One-shot bootstrap CLI run once per consuming repo to seed labels,
+    // project fields, and views from `lib/label-taxonomy.js`. The taxonomy
+    // itself is unit-tested; the shell only argv-parses and calls a single
+    // provider method loop. Real coverage requires a live GitHub repo,
+    // which belongs in integration tests, not the unit-test gate.
     '.agents/scripts/agents-bootstrap-github.js',
-    // Story #1702 — top-level CLI gates and orchestrators.
+
+    // --- Story #1702 bounded sweep: top-level CLI gates and orchestrators
+    // Each entry below is a thin CLI shell, pure I/O glue, or a one-shot
+    // dev tool whose meaningful logic lives in a unit-tested `lib/` module.
+    // Friction-telemetry CLI: NDJSON append over a spawned child.
     '.agents/scripts/diagnose-friction.js',
+    // Git-manipulation CLI (branch sweeper) — integration-shaped.
     '.agents/scripts/git-cleanup.js',
+    // Lint gate shell over `run-lint.js` / the lint baseline kind.
     '.agents/scripts/lint-baseline.js',
+    // Desktop/terminal notification glue — pure side effect.
     '.agents/scripts/notify.js',
+    // Structured-comment CLI shell over the ticketing provider.
     '.agents/scripts/post-structured-comment.js',
+    // Long-lived dev watcher (one-shot, interactive).
     '.agents/scripts/quality-watch.js',
+    // Test-tier driver: spawns `node --test`; the tier logic it delegates
+    // to lives in `lib/test-tiers.js` and is unit-tested there.
     '.agents/scripts/run-tests.js',
-    // single-story-close.js — Story #1827 brings this file back in scope.
-    // The orchestration body is exercised through `runSingleStoryClose`
-    // with an injected provider, fake gh runner, and in-memory worktree;
-    // `ensurePullRequest` is exercised through `execFileSync` module mocks.
+    // Story #1827 note: `single-story-close.js` is deliberately NOT
+    // excluded — its orchestration body is exercised through
+    // `runSingleStoryClose` with an injected provider, a fake gh runner,
+    // and an in-memory worktree. Only the init shell stays out.
     '.agents/scripts/single-story-init.js',
+    // Test harness wrapper — spawns the runner, no logic of its own.
     '.agents/scripts/test-wrapper.js',
+    // Docs-freshness gate shell over `lib/docs-freshness.js`.
     '.agents/scripts/validate-docs-freshness.js',
 
-    // Story #1702 — lib/* carve-outs (data-as-code + orchestration glue).
+    // --- Story #1702 lib/* carve-outs: data-as-code and process glue ----
+    // Data-as-code JSON Schema literals — no branches to cover.
     '.agents/scripts/lib/config-schema.js',
     '.agents/scripts/lib/config-settings-schema.js',
+    // Orchestration glue over live filesystem/npm state; unit-mocking it
+    // asserts only the mock's structure.
     '.agents/scripts/lib/worktree/node-modules-strategy.js',
   ],
 };

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,8 +110,19 @@ jobs:
         # Capture stderr too — Node's test runner and the coverage-threshold
         # gate both emit failures on stderr, and a stdout-only redirect
         # hides them in the uploaded artifact (see Epic #441 Story 4.1).
+        #
+        # Story #4922: the preflight is invoked EXPLICITLY, not left to npm's
+        # `pre<script>` hook. This repo's `.npmrc` sets `ignore-scripts=true`
+        # (supply-chain defence, CWE-1357), and that config suppresses every
+        # `pre*` / `post*` lifecycle hook for `npm run` as well as for
+        # installs — so `pretest`, `pretest:quick`, `pretest:integration` and
+        # `pretest:coverage` are all inert as hooks. The coverage tier is the
+        # measuring run, so it names its preflight rather than assuming npm
+        # will fire it. `npm run pretest:coverage` is still the single
+        # definition of what that preflight is.
         run: |
           set -o pipefail
+          npm run pretest:coverage
           npm run test:coverage 2>&1 | tee test-output.txt
 
       - name: Assert temp hygiene (post-test)
@@ -246,3 +257,15 @@ jobs:
 
       - name: Fast Test Slice
         run: npm run test:quick
+
+      - name: Worktree Manager Real-Git Contract
+        # Story #4922: this suite is integration-tier, so `test:quick` above
+        # excludes it — and the ubuntu leg is the only job that ran it. Its
+        # drive-letter-case regression guard (v5.11.5) is gated on
+        # `process.platform === 'win32'`, so the one assertion that exists
+        # solely to catch a Windows defect executed in no CI job at all: on
+        # Linux it skipped, on Windows it never ran. Running the file here is
+        # what makes that guard real.
+        run: >-
+          node --experimental-test-module-mocks --test
+          tests/lib/worktree-manager.integration.test.js

--- a/baselines/coverage.json
+++ b/baselines/coverage.json
@@ -1,134 +1,284 @@
 {
   "$schema": ".agents/schemas/baselines/coverage.schema.json",
   "kernelVersion": "1.0.0",
-  "generatedAt": "2026-06-14T17:09:53.073Z",
+  "generatedAt": "2026-08-02T14:28:17.959Z",
   "rollup": {
     "*": {
-      "lines": 95.21,
-      "branches": 84.42,
-      "functions": 89.26
+      "lines": 95.65,
+      "branches": 86.16,
+      "functions": 88.52
     }
   },
   "rows": [
     {
-      "path": ".agents/scripts/acceptance-spec-reconciler.js",
-      "lines": 84.35,
-      "branches": 87.23,
-      "functions": 72.73
+      "path": ".agents/scripts/acceptance-eval.js",
+      "lines": 99.48,
+      "branches": 89.13,
+      "functions": 83.33
     },
     {
-      "path": ".agents/scripts/analyze-execution.js",
-      "lines": 91.87,
-      "branches": 52.94,
-      "functions": 100
+      "path": ".agents/scripts/apply-quality-bootstrap.js",
+      "lines": 89.41,
+      "branches": 100,
+      "functions": 50
+    },
+    {
+      "path": ".agents/scripts/audit-baselines.js",
+      "lines": 95.59,
+      "branches": 54.55,
+      "functions": 66.67
     },
     {
       "path": ".agents/scripts/audit-labels-bootstrap.js",
-      "lines": 77.48,
-      "branches": 76.92,
-      "functions": 75
+      "lines": 84.29,
+      "branches": 84.21,
+      "functions": 83.33
+    },
+    {
+      "path": ".agents/scripts/audit-to-stories.js",
+      "lines": 97.2,
+      "branches": 70.71,
+      "functions": 90.91
+    },
+    {
+      "path": ".agents/scripts/boot-sweep.js",
+      "lines": 98.92,
+      "branches": 84.31,
+      "functions": 57.14
     },
     {
       "path": ".agents/scripts/bootstrap.js",
-      "lines": 91.2,
-      "branches": 81.82,
-      "functions": 79.41
+      "lines": 94.49,
+      "branches": 79.03,
+      "functions": 87.23
+    },
+    {
+      "path": ".agents/scripts/check-action-pinning.js",
+      "lines": 98.08,
+      "branches": 95.56,
+      "functions": 87.5
+    },
+    {
+      "path": ".agents/scripts/check-arch-cycles.js",
+      "lines": 99.07,
+      "branches": 90.91,
+      "functions": 83.33
+    },
+    {
+      "path": ".agents/scripts/check-baseline-drift.js",
+      "lines": 91.3,
+      "branches": 100,
+      "functions": 66.67
     },
     {
       "path": ".agents/scripts/check-baselines.js",
-      "lines": 90.91,
-      "branches": 66.67,
+      "lines": 100,
+      "branches": 83.33,
+      "functions": 100
+    },
+    {
+      "path": ".agents/scripts/check-context-budget.js",
+      "lines": 95.36,
+      "branches": 87.23,
       "functions": 100
     },
     {
       "path": ".agents/scripts/check-dead-exports.js",
-      "lines": 89.4,
-      "branches": 83.93,
-      "functions": 81.82
+      "lines": 98.52,
+      "branches": 93.75,
+      "functions": 87.5
     },
     {
       "path": ".agents/scripts/check-doc-links.js",
-      "lines": 93.92,
-      "branches": 86.36,
-      "functions": 84.62
+      "lines": 95.61,
+      "branches": 89.77,
+      "functions": 86.67
+    },
+    {
+      "path": ".agents/scripts/check-gherkin-placeholders.js",
+      "lines": 91.86,
+      "branches": 75,
+      "functions": 91.3
     },
     {
       "path": ".agents/scripts/check-lifecycle-doc-drift.js",
-      "lines": 92.54,
-      "branches": 83.95,
+      "lines": 92.46,
+      "branches": 82.43,
       "functions": 100
     },
     {
       "path": ".agents/scripts/check-lifecycle-lint.js",
-      "lines": 93.4,
-      "branches": 96.55,
+      "lines": 93.35,
+      "branches": 96.23,
       "functions": 83.33
     },
     {
-      "path": ".agents/scripts/check-prepush-recovery.js",
-      "lines": 100,
-      "branches": 95.24,
-      "functions": 100
+      "path": ".agents/scripts/check-test-temp-hygiene.js",
+      "lines": 99.7,
+      "branches": 91.96,
+      "functions": 88
+    },
+    {
+      "path": ".agents/scripts/check-windows-git-perf.js",
+      "lines": 0,
+      "branches": 0,
+      "functions": 0
+    },
+    {
+      "path": ".agents/scripts/check-workflow-citations.js",
+      "lines": 97.89,
+      "branches": 93.65,
+      "functions": 90
+    },
+    {
+      "path": ".agents/scripts/check-workflow-cli-lint.js",
+      "lines": 91.97,
+      "branches": 96,
+      "functions": 85.71
     },
     {
       "path": ".agents/scripts/cleanup-repo-test-temp.js",
-      "lines": 91.04,
-      "branches": 91.67,
+      "lines": 91.89,
+      "branches": 92.86,
       "functions": 100
     },
     {
       "path": ".agents/scripts/coverage-capture.js",
-      "lines": 66.96,
-      "branches": 41.67,
-      "functions": 66.67
+      "lines": 98.49,
+      "branches": 90.91,
+      "functions": 100
+    },
+    {
+      "path": ".agents/scripts/deliver-light.js",
+      "lines": 97.29,
+      "branches": 83.02,
+      "functions": 100
+    },
+    {
+      "path": ".agents/scripts/deliver-recover.js",
+      "lines": 100,
+      "branches": 95.65,
+      "functions": 100
     },
     {
       "path": ".agents/scripts/diagnose.js",
-      "lines": 92.92,
+      "lines": 93.09,
       "branches": 82.5,
       "functions": 71.43
     },
     {
-      "path": ".agents/scripts/epic-audit-prepare.js",
-      "lines": 93.2,
-      "branches": 68.18,
-      "functions": 66.67
-    },
-    {
-      "path": ".agents/scripts/epic-audit-recheck.js",
-      "lines": 90.04,
-      "branches": 76.47,
-      "functions": 100
-    },
-    {
-      "path": ".agents/scripts/epic-deliver-preflight.js",
-      "lines": 86.24,
-      "branches": 77.78,
-      "functions": 57.14
+      "path": ".agents/scripts/drain-pending-cleanup.js",
+      "lines": 98.57,
+      "branches": 96.88,
+      "functions": 80
     },
     {
       "path": ".agents/scripts/evidence-gate.js",
-      "lines": 97.87,
-      "branches": 85.71,
+      "lines": 98.08,
+      "branches": 84.62,
       "functions": 80
     },
     {
       "path": ".agents/scripts/generate-config-docs.js",
-      "lines": 90.89,
-      "branches": 81.36,
+      "lines": 92.63,
+      "branches": 83.08,
       "functions": 100
+    },
+    {
+      "path": ".agents/scripts/generate-lens-checklists.js",
+      "lines": 98.7,
+      "branches": 100,
+      "functions": 85.71
+    },
+    {
+      "path": ".agents/scripts/generate-lifecycle-docs.js",
+      "lines": 50.63,
+      "branches": 100,
+      "functions": 0
     },
     {
       "path": ".agents/scripts/generate-skills-index.js",
-      "lines": 88.49,
-      "branches": 58.33,
+      "lines": 89.18,
+      "branches": 64.1,
       "functions": 100
     },
     {
-      "path": ".agents/scripts/hierarchy-gate.js",
-      "lines": 92.61,
-      "branches": 88.1,
-      "functions": 80
+      "path": ".agents/scripts/generate-workflows-doc.js",
+      "lines": 96.26,
+      "branches": 87.5,
+      "functions": 100
+    },
+    {
+      "path": ".agents/scripts/install-matrix-assert.js",
+      "lines": 96.45,
+      "branches": 90,
+      "functions": 75
+    },
+    {
+      "path": ".agents/scripts/lib/audit-baselines/engine.js",
+      "lines": 97.74,
+      "branches": 85,
+      "functions": 100
+    },
+    {
+      "path": ".agents/scripts/lib/audit-baselines/gate-surface.js",
+      "lines": 100,
+      "branches": 97.06,
+      "functions": 100
+    },
+    {
+      "path": ".agents/scripts/lib/audit-baselines/headroom.js",
+      "lines": 100,
+      "branches": 72.22,
+      "functions": 100
+    },
+    {
+      "path": ".agents/scripts/lib/audit-baselines/hotspots.js",
+      "lines": 100,
+      "branches": 100,
+      "functions": 100
+    },
+    {
+      "path": ".agents/scripts/lib/audit-baselines/kinds.js",
+      "lines": 99.19,
+      "branches": 73.91,
+      "functions": 100
+    },
+    {
+      "path": ".agents/scripts/lib/audit-baselines/outliers.js",
+      "lines": 100,
+      "branches": 91.3,
+      "functions": 100
+    },
+    {
+      "path": ".agents/scripts/lib/audit-baselines/read.js",
+      "lines": 90.8,
+      "branches": 76.47,
+      "functions": 100
+    },
+    {
+      "path": ".agents/scripts/lib/audit-baselines/trend.js",
+      "lines": 96.8,
+      "branches": 83.33,
+      "functions": 100
+    },
+    {
+      "path": ".agents/scripts/lib/audit-baselines/weights.js",
+      "lines": 98.96,
+      "branches": 90.74,
+      "functions": 100
+    },
+    {
+      "path": ".agents/scripts/lib/audit-suite/audit-rules-reader.js",
+      "lines": 91.67,
+      "branches": 83.33,
+      "functions": 100
+    },
+    {
+      "path": ".agents/scripts/lib/audit-suite/checklist-threading.js",
+      "lines": 96.9,
+      "branches": 94.29,
+      "functions": 100
     },
     {
       "path": ".agents/scripts/lib/audit-suite/cli.js",
@@ -137,9 +287,15 @@
       "functions": 100
     },
     {
+      "path": ".agents/scripts/lib/audit-suite/dispatch-checklist.js",
+      "lines": 96.97,
+      "branches": 94.12,
+      "functions": 75
+    },
+    {
       "path": ".agents/scripts/lib/audit-suite/findings.js",
-      "lines": 97.56,
-      "branches": 78.13,
+      "lines": 96.79,
+      "branches": 76.47,
       "functions": 100
     },
     {
@@ -151,7 +307,7 @@
     {
       "path": ".agents/scripts/lib/audit-suite/frontmatter.js",
       "lines": 100,
-      "branches": 91.18,
+      "branches": 93.55,
       "functions": 100
     },
     {
@@ -161,21 +317,33 @@
       "functions": 0
     },
     {
-      "path": ".agents/scripts/lib/audit-suite/runner.js",
-      "lines": 100,
-      "branches": 91.18,
+      "path": ".agents/scripts/lib/audit-suite/lens-checklist.js",
+      "lines": 99.06,
+      "branches": 79.17,
       "functions": 100
     },
     {
-      "path": ".agents/scripts/lib/audit-suite/selector.js",
-      "lines": 93.62,
-      "branches": 80.95,
+      "path": ".agents/scripts/lib/audit-suite/lens-diff-floor.js",
+      "lines": 100,
+      "branches": 91.43,
       "functions": 100
+    },
+    {
+      "path": ".agents/scripts/lib/audit-suite/runner.js",
+      "lines": 63.83,
+      "branches": 60,
+      "functions": 62.5
+    },
+    {
+      "path": ".agents/scripts/lib/audit-suite/selector.js",
+      "lines": 97.1,
+      "branches": 88.95,
+      "functions": 93.33
     },
     {
       "path": ".agents/scripts/lib/audit-suite/substitutions.js",
       "lines": 100,
-      "branches": 95.24,
+      "branches": 94.74,
       "functions": 100
     },
     {
@@ -185,39 +353,57 @@
       "functions": 100
     },
     {
-      "path": ".agents/scripts/lib/audit-to-stories/build-story-body.js",
+      "path": ".agents/scripts/lib/audit-to-stories/audit-label-taxonomy.js",
       "lines": 100,
-      "branches": 72.41,
+      "branches": 100,
+      "functions": 100
+    },
+    {
+      "path": ".agents/scripts/lib/audit-to-stories/audit-lenses.js",
+      "lines": 100,
+      "branches": 100,
+      "functions": 100
+    },
+    {
+      "path": ".agents/scripts/lib/audit-to-stories/build-story-body.js",
+      "lines": 97.51,
+      "branches": 82.46,
       "functions": 100
     },
     {
       "path": ".agents/scripts/lib/audit-to-stories/dedupe-against-github.js",
-      "lines": 100,
-      "branches": 90.48,
+      "lines": 97.99,
+      "branches": 86.27,
+      "functions": 100
+    },
+    {
+      "path": ".agents/scripts/lib/audit-to-stories/finding-adapter.js",
+      "lines": 96.95,
+      "branches": 83.33,
       "functions": 100
     },
     {
       "path": ".agents/scripts/lib/audit-to-stories/group-findings.js",
-      "lines": 94.34,
-      "branches": 69.05,
+      "lines": 94.53,
+      "branches": 74.42,
+      "functions": 100
+    },
+    {
+      "path": ".agents/scripts/lib/audit-to-stories/ledger.js",
+      "lines": 95.7,
+      "branches": 73.77,
       "functions": 100
     },
     {
       "path": ".agents/scripts/lib/audit-to-stories/parse-audit-md.js",
-      "lines": 98.37,
-      "branches": 84.13,
+      "lines": 98.9,
+      "branches": 85.42,
       "functions": 100
     },
     {
       "path": ".agents/scripts/lib/audit-to-stories/seed-from-findings.js",
       "lines": 100,
-      "branches": 97.3,
-      "functions": 100
-    },
-    {
-      "path": ".agents/scripts/lib/auto-refresh-baselines.js",
-      "lines": 99.35,
-      "branches": 88.41,
+      "branches": 95.24,
       "functions": 100
     },
     {
@@ -233,12 +419,6 @@
       "functions": 100
     },
     {
-      "path": ".agents/scripts/lib/baseline-snapshot.js",
-      "lines": 95.45,
-      "branches": 77.5,
-      "functions": 75
-    },
-    {
       "path": ".agents/scripts/lib/baselines/component-matcher.js",
       "lines": 100,
       "branches": 100,
@@ -252,9 +432,21 @@
     },
     {
       "path": ".agents/scripts/lib/baselines/diff-scope-cli.js",
-      "lines": 75.48,
-      "branches": 95.65,
+      "lines": 74.88,
+      "branches": 100,
       "functions": 37.5
+    },
+    {
+      "path": ".agents/scripts/lib/baselines/drift-detector.js",
+      "lines": 93.16,
+      "branches": 87.5,
+      "functions": 84.62
+    },
+    {
+      "path": ".agents/scripts/lib/baselines/duplication-scanner.js",
+      "lines": 92.27,
+      "branches": 66.67,
+      "functions": 85.71
     },
     {
       "path": ".agents/scripts/lib/baselines/env-overrides.js",
@@ -264,8 +456,8 @@
     },
     {
       "path": ".agents/scripts/lib/baselines/envelope.js",
-      "lines": 97.28,
-      "branches": 95.08,
+      "lines": 97.33,
+      "branches": 95.31,
       "functions": 100
     },
     {
@@ -276,38 +468,56 @@
     },
     {
       "path": ".agents/scripts/lib/baselines/git-base.js",
-      "lines": 97.03,
-      "branches": 85.19,
+      "lines": 97.85,
+      "branches": 85,
       "functions": 100
     },
     {
       "path": ".agents/scripts/lib/baselines/kernel.js",
-      "lines": 100,
-      "branches": 100,
+      "lines": 99.39,
+      "branches": 91.67,
       "functions": 100
+    },
+    {
+      "path": ".agents/scripts/lib/baselines/kinds/_shared-metric.js",
+      "lines": 97.73,
+      "branches": 69.35,
+      "functions": 90
     },
     {
       "path": ".agents/scripts/lib/baselines/kinds/bundle-size.js",
       "lines": 92.99,
-      "branches": 58.49,
+      "branches": 60,
       "functions": 100
     },
     {
       "path": ".agents/scripts/lib/baselines/kinds/coverage.js",
-      "lines": 98.45,
-      "branches": 77.59,
+      "lines": 100,
+      "branches": 81.82,
       "functions": 100
     },
     {
       "path": ".agents/scripts/lib/baselines/kinds/crap.js",
-      "lines": 97.98,
-      "branches": 78.26,
-      "functions": 95.65
+      "lines": 95.49,
+      "branches": 83.33,
+      "functions": 90.32
+    },
+    {
+      "path": ".agents/scripts/lib/baselines/kinds/duplication.js",
+      "lines": 100,
+      "branches": 66.67,
+      "functions": 100
+    },
+    {
+      "path": ".agents/scripts/lib/baselines/kinds/kind-factory.js",
+      "lines": 98.44,
+      "branches": 88.24,
+      "functions": 90
     },
     {
       "path": ".agents/scripts/lib/baselines/kinds/lighthouse.js",
-      "lines": 97.84,
-      "branches": 69.81,
+      "lines": 98.84,
+      "branches": 63.64,
       "functions": 100
     },
     {
@@ -318,14 +528,26 @@
     },
     {
       "path": ".agents/scripts/lib/baselines/kinds/maintainability.js",
-      "lines": 95.88,
-      "branches": 79.22,
+      "lines": 95.89,
+      "branches": 85.29,
       "functions": 100
     },
     {
       "path": ".agents/scripts/lib/baselines/kinds/mutation.js",
-      "lines": 96.73,
-      "branches": 67.35,
+      "lines": 100,
+      "branches": 45.45,
+      "functions": 100
+    },
+    {
+      "path": ".agents/scripts/lib/baselines/maintainability-baseline-io.js",
+      "lines": 100,
+      "branches": 100,
+      "functions": 100
+    },
+    {
+      "path": ".agents/scripts/lib/baselines/maintainability-baseline-save.js",
+      "lines": 100,
+      "branches": 75,
       "functions": 100
     },
     {
@@ -336,32 +558,32 @@
     },
     {
       "path": ".agents/scripts/lib/baselines/preview-gates.js",
-      "lines": 78.87,
-      "branches": 21.74,
-      "functions": 66.67
+      "lines": 91.62,
+      "branches": 64.1,
+      "functions": 100
     },
     {
       "path": ".agents/scripts/lib/baselines/reader.js",
-      "lines": 92.79,
-      "branches": 66.18,
+      "lines": 93.77,
+      "branches": 71.43,
       "functions": 100
     },
     {
       "path": ".agents/scripts/lib/baselines/refresh-service.js",
-      "lines": 93.76,
-      "branches": 95,
-      "functions": 90
+      "lines": 89.69,
+      "branches": 76.67,
+      "functions": 82.35
     },
     {
       "path": ".agents/scripts/lib/baselines/scope.js",
-      "lines": 99.31,
-      "branches": 94.92,
+      "lines": 99.17,
+      "branches": 93.75,
       "functions": 100
     },
     {
       "path": ".agents/scripts/lib/baselines/writer.js",
-      "lines": 96.15,
-      "branches": 90.63,
+      "lines": 96.32,
+      "branches": 91.43,
       "functions": 100
     },
     {
@@ -379,67 +601,91 @@
     {
       "path": ".agents/scripts/lib/bootstrap/baselines-layout-migration.js",
       "lines": 100,
-      "branches": 87.1,
+      "branches": 87.5,
       "functions": 100
     },
     {
       "path": ".agents/scripts/lib/bootstrap/branch-protection.js",
-      "lines": 96.85,
-      "branches": 88.41,
+      "lines": 98.2,
+      "branches": 91.78,
       "functions": 100
     },
     {
       "path": ".agents/scripts/lib/bootstrap/ci-workflow-template.js",
       "lines": 100,
-      "branches": 66.67,
+      "branches": 85.71,
+      "functions": 100
+    },
+    {
+      "path": ".agents/scripts/lib/bootstrap/commit-push.js",
+      "lines": 95.89,
+      "branches": 83.33,
       "functions": 100
     },
     {
       "path": ".agents/scripts/lib/bootstrap/gh-list.js",
-      "lines": 92.81,
-      "branches": 76.92,
+      "lines": 92.16,
+      "branches": 75.61,
       "functions": 75
     },
     {
       "path": ".agents/scripts/lib/bootstrap/gh-preflight.js",
-      "lines": 91.16,
-      "branches": 75,
-      "functions": 80
+      "lines": 93.75,
+      "branches": 78.26,
+      "functions": 90
     },
     {
       "path": ".agents/scripts/lib/bootstrap/hitl-confirm.js",
       "lines": 100,
-      "branches": 63.16,
+      "branches": 90.48,
       "functions": 100
+    },
+    {
+      "path": ".agents/scripts/lib/bootstrap/install-ledger.js",
+      "lines": 100,
+      "branches": 88.89,
+      "functions": 100
+    },
+    {
+      "path": ".agents/scripts/lib/bootstrap/issue-forms-template.js",
+      "lines": 100,
+      "branches": 96.67,
+      "functions": 100
+    },
+    {
+      "path": ".agents/scripts/lib/bootstrap/manifest.js",
+      "lines": 88.55,
+      "branches": 66.67,
+      "functions": 66.67
     },
     {
       "path": ".agents/scripts/lib/bootstrap/merge-methods.js",
       "lines": 100,
-      "branches": 93.1,
+      "branches": 92.31,
       "functions": 100
     },
     {
       "path": ".agents/scripts/lib/bootstrap/preflight.js",
-      "lines": 94.41,
-      "branches": 84.62,
+      "lines": 88.89,
+      "branches": 78.57,
       "functions": 85.71
     },
     {
       "path": ".agents/scripts/lib/bootstrap/project-bootstrap.js",
-      "lines": 81.64,
-      "branches": 84.42,
-      "functions": 43.75
+      "lines": 85.5,
+      "branches": 86.87,
+      "functions": 50
     },
     {
       "path": ".agents/scripts/lib/bootstrap/prompt.js",
-      "lines": 99.52,
-      "branches": 90.98,
+      "lines": 99.59,
+      "branches": 91.91,
       "functions": 100
     },
     {
       "path": ".agents/scripts/lib/bootstrap/quality-bootstrap.js",
-      "lines": 97.93,
-      "branches": 81.54,
+      "lines": 98.91,
+      "branches": 85.94,
       "functions": 100
     },
     {
@@ -450,8 +696,8 @@
     },
     {
       "path": ".agents/scripts/lib/bootstrap/workflow-audit.js",
-      "lines": 100,
-      "branches": 86,
+      "lines": 99.26,
+      "branches": 84,
       "functions": 100
     },
     {
@@ -461,15 +707,21 @@
       "functions": 100
     },
     {
+      "path": ".agents/scripts/lib/c8-cli-path.js",
+      "lines": 100,
+      "branches": 100,
+      "functions": 0
+    },
+    {
       "path": ".agents/scripts/lib/changed-files.js",
       "lines": 100,
-      "branches": 92,
+      "branches": 85.71,
       "functions": 100
     },
     {
       "path": ".agents/scripts/lib/checks/baseline-drift-main-checkout.js",
-      "lines": 99.03,
-      "branches": 77.27,
+      "lines": 98.08,
+      "branches": 70,
       "functions": 100
     },
     {
@@ -479,15 +731,15 @@
       "functions": 100
     },
     {
-      "path": ".agents/scripts/lib/checks/epic-merge-lock-stale.js",
-      "lines": 100,
-      "branches": 71.43,
+      "path": ".agents/scripts/lib/checks/index.js",
+      "lines": 95.85,
+      "branches": 71.15,
       "functions": 100
     },
     {
-      "path": ".agents/scripts/lib/checks/index.js",
-      "lines": 96.53,
-      "branches": 74.55,
+      "path": ".agents/scripts/lib/checks/loop-health.js",
+      "lines": 99.41,
+      "branches": 81.69,
       "functions": 100
     },
     {
@@ -497,27 +749,21 @@
       "functions": 100
     },
     {
-      "path": ".agents/scripts/lib/checks/stale-origin-epic.js",
+      "path": ".agents/scripts/lib/checks/state.js",
       "lines": 100,
-      "branches": 90,
+      "branches": 95.16,
       "functions": 100
     },
     {
-      "path": ".agents/scripts/lib/checks/state.js",
-      "lines": 94.27,
-      "branches": 88.43,
-      "functions": 91.3
-    },
-    {
       "path": ".agents/scripts/lib/checks/story-init-not-backgrounded.js",
-      "lines": 97.85,
-      "branches": 92.11,
+      "lines": 100,
+      "branches": 97.73,
       "functions": 100
     },
     {
       "path": ".agents/scripts/lib/checks/subagent-agent-tool-required.js",
-      "lines": 96.7,
-      "branches": 79.49,
+      "lines": 95.35,
+      "branches": 81.4,
       "functions": 100
     },
     {
@@ -540,14 +786,20 @@
     },
     {
       "path": ".agents/scripts/lib/cli-args.js",
-      "lines": 98.25,
-      "branches": 91.13,
+      "lines": 97.85,
+      "branches": 85.27,
+      "functions": 100
+    },
+    {
+      "path": ".agents/scripts/lib/cli-usage.js",
+      "lines": 99.43,
+      "branches": 78.57,
       "functions": 100
     },
     {
       "path": ".agents/scripts/lib/cli-utils.js",
       "lines": 100,
-      "branches": 93.75,
+      "branches": 100,
       "functions": 100
     },
     {
@@ -558,15 +810,39 @@
     },
     {
       "path": ".agents/scripts/lib/cli/standard-args.js",
-      "lines": 96.31,
-      "branches": 88.39,
+      "lines": 96.2,
+      "branches": 88.99,
       "functions": 100
     },
     {
-      "path": ".agents/scripts/lib/close-validation.js",
-      "lines": 90.83,
-      "branches": 84.55,
-      "functions": 82.61
+      "path": ".agents/scripts/lib/close-validation/commands.js",
+      "lines": 80.32,
+      "branches": 83.33,
+      "functions": 71.43
+    },
+    {
+      "path": ".agents/scripts/lib/close-validation/gates.js",
+      "lines": 98.55,
+      "branches": 92.06,
+      "functions": 100
+    },
+    {
+      "path": ".agents/scripts/lib/close-validation/process.js",
+      "lines": 91.63,
+      "branches": 80,
+      "functions": 55.56
+    },
+    {
+      "path": ".agents/scripts/lib/close-validation/projections/advisories.js",
+      "lines": 98.91,
+      "branches": 79.41,
+      "functions": 85.71
+    },
+    {
+      "path": ".agents/scripts/lib/close-validation/projections/crap.js",
+      "lines": 90.43,
+      "branches": 82,
+      "functions": 88.89
     },
     {
       "path": ".agents/scripts/lib/close-validation/projections/head-sha.js",
@@ -582,20 +858,32 @@
     },
     {
       "path": ".agents/scripts/lib/close-validation/projections/maintainability.js",
-      "lines": 100,
-      "branches": 84.44,
+      "lines": 96.85,
+      "branches": 66.67,
       "functions": 100
     },
     {
-      "path": ".agents/scripts/lib/codebase-snapshot.js",
-      "lines": 95.17,
-      "branches": 74.68,
+      "path": ".agents/scripts/lib/close-validation/runner.js",
+      "lines": 79.43,
+      "branches": 50,
+      "functions": 77.78
+    },
+    {
+      "path": ".agents/scripts/lib/close-validation/telemetry.js",
+      "lines": 98.73,
+      "branches": 77.78,
+      "functions": 100
+    },
+    {
+      "path": ".agents/scripts/lib/command-header.js",
+      "lines": 100,
+      "branches": 100,
       "functions": 100
     },
     {
       "path": ".agents/scripts/lib/config-resolver.js",
-      "lines": 100,
-      "branches": 92.68,
+      "lines": 97.61,
+      "branches": 87.3,
       "functions": 100
     },
     {
@@ -605,15 +893,33 @@
       "functions": 0
     },
     {
-      "path": ".agents/scripts/lib/config/baselines.js",
-      "lines": 81.67,
+      "path": ".agents/scripts/lib/config-settings-schema-delivery.js",
+      "lines": 100,
       "branches": 100,
-      "functions": 66.67
+      "functions": 0
+    },
+    {
+      "path": ".agents/scripts/lib/config-settings-schema-quality.js",
+      "lines": 100,
+      "branches": 100,
+      "functions": 0
+    },
+    {
+      "path": ".agents/scripts/lib/config/acceptance-eval.js",
+      "lines": 100,
+      "branches": 100,
+      "functions": 100
+    },
+    {
+      "path": ".agents/scripts/lib/config/baselines.js",
+      "lines": 100,
+      "branches": 100,
+      "functions": 100
     },
     {
       "path": ".agents/scripts/lib/config/ci.js",
       "lines": 100,
-      "branches": 87.5,
+      "branches": 100,
       "functions": 100
     },
     {
@@ -624,8 +930,20 @@
     },
     {
       "path": ".agents/scripts/lib/config/defaults.js",
-      "lines": 95.65,
+      "lines": 95.8,
       "branches": 89.29,
+      "functions": 100
+    },
+    {
+      "path": ".agents/scripts/lib/config/delivery-routing.js",
+      "lines": 98.08,
+      "branches": 90.91,
+      "functions": 100
+    },
+    {
+      "path": ".agents/scripts/lib/config/explain.js",
+      "lines": 100,
+      "branches": 87.5,
       "functions": 100
     },
     {
@@ -642,6 +960,12 @@
     },
     {
       "path": ".agents/scripts/lib/config/gates/crap.schema.js",
+      "lines": 100,
+      "branches": 100,
+      "functions": 0
+    },
+    {
+      "path": ".agents/scripts/lib/config/gates/duplication.schema.js",
       "lines": 100,
       "branches": 100,
       "functions": 0
@@ -689,12 +1013,6 @@
       "functions": 100
     },
     {
-      "path": ".agents/scripts/lib/config/lifecycle.js",
-      "lines": 100,
-      "branches": 77.78,
-      "functions": 100
-    },
-    {
       "path": ".agents/scripts/lib/config/limits.js",
       "lines": 100,
       "branches": 100,
@@ -707,21 +1025,9 @@
       "functions": 100
     },
     {
-      "path": ".agents/scripts/lib/config/preflight.js",
-      "lines": 100,
-      "branches": 91.67,
-      "functions": 100
-    },
-    {
       "path": ".agents/scripts/lib/config/quality.js",
-      "lines": 97.1,
-      "branches": 77.86,
-      "functions": 100
-    },
-    {
-      "path": ".agents/scripts/lib/config/retro.js",
-      "lines": 100,
-      "branches": 100,
+      "lines": 97.48,
+      "branches": 80.6,
       "functions": 100
     },
     {
@@ -745,14 +1051,14 @@
     {
       "path": ".agents/scripts/lib/config/sync-agentrc.js",
       "lines": 99.18,
-      "branches": 84.09,
+      "branches": 85.11,
       "functions": 100
     },
     {
       "path": ".agents/scripts/lib/config/temp-paths.js",
-      "lines": 96.11,
-      "branches": 100,
-      "functions": 90.48
+      "lines": 100,
+      "branches": 97.83,
+      "functions": 96
     },
     {
       "path": ".agents/scripts/lib/config/validate-orchestration.js",
@@ -763,7 +1069,7 @@
     {
       "path": ".agents/scripts/lib/config/worktree-isolation.js",
       "lines": 100,
-      "branches": 57.14,
+      "branches": 41.67,
       "functions": 100
     },
     {
@@ -774,32 +1080,44 @@
     },
     {
       "path": ".agents/scripts/lib/coverage-capture.js",
-      "lines": 96.92,
-      "branches": 85.11,
+      "lines": 97.63,
+      "branches": 85.54,
       "functions": 100
     },
     {
       "path": ".agents/scripts/lib/coverage-utils.js",
       "lines": 100,
-      "branches": 88.51,
+      "branches": 90.52,
       "functions": 100
     },
     {
       "path": ".agents/scripts/lib/cpu-pool.js",
-      "lines": 98.21,
-      "branches": 90,
+      "lines": 98.31,
+      "branches": 90.7,
       "functions": 100
     },
     {
       "path": ".agents/scripts/lib/crap-engine.js",
       "lines": 100,
-      "branches": 84,
+      "branches": 89.13,
       "functions": 100
     },
     {
       "path": ".agents/scripts/lib/crap-utils.js",
-      "lines": 84.79,
-      "branches": 76.53,
+      "lines": 91.83,
+      "branches": 75.96,
+      "functions": 100
+    },
+    {
+      "path": ".agents/scripts/lib/dead-exports-knip.js",
+      "lines": 89.52,
+      "branches": 58.33,
+      "functions": 100
+    },
+    {
+      "path": ".agents/scripts/lib/dead-exports-mode.js",
+      "lines": 100,
+      "branches": 100,
       "functions": 100
     },
     {
@@ -815,9 +1133,33 @@
       "functions": 100
     },
     {
+      "path": ".agents/scripts/lib/detect-package-manager.js",
+      "lines": 100,
+      "branches": 100,
+      "functions": 100
+    },
+    {
+      "path": ".agents/scripts/lib/doc-tiers.js",
+      "lines": 98.92,
+      "branches": 84.62,
+      "functions": 100
+    },
+    {
       "path": ".agents/scripts/lib/duplicate-search.js",
-      "lines": 99.47,
-      "branches": 83.33,
+      "lines": 97.44,
+      "branches": 79.45,
+      "functions": 100
+    },
+    {
+      "path": ".agents/scripts/lib/dynamic-workflow/architecture-report-contract.js",
+      "lines": 100,
+      "branches": 100,
+      "functions": 100
+    },
+    {
+      "path": ".agents/scripts/lib/dynamic-workflow/audit-orchestrator.js",
+      "lines": 100,
+      "branches": 92.31,
       "functions": 100
     },
     {
@@ -829,31 +1171,49 @@
     {
       "path": ".agents/scripts/lib/dynamic-workflow/clean-code-report-contract.js",
       "lines": 100,
-      "branches": 83.33,
+      "branches": 100,
       "functions": 100
     },
     {
-      "path": ".agents/scripts/lib/env-loader.js",
+      "path": ".agents/scripts/lib/dynamic-workflow/degraded-coverage.js",
       "lines": 100,
-      "branches": 93.75,
+      "branches": 81.82,
       "functions": 100
     },
     {
-      "path": ".agents/scripts/lib/epic-merge-lock.js",
-      "lines": 96.23,
-      "branches": 78.38,
-      "functions": 88.89
-    },
-    {
-      "path": ".agents/scripts/lib/epic-plan-clarity.js",
+      "path": ".agents/scripts/lib/dynamic-workflow/documentation-report-contract.js",
       "lines": 100,
       "branches": 100,
       "functions": 100
     },
     {
-      "path": ".agents/scripts/lib/epic-plan-ideation.js",
-      "lines": 99.06,
-      "branches": 97.44,
+      "path": ".agents/scripts/lib/dynamic-workflow/performance-report-contract.js",
+      "lines": 100,
+      "branches": 100,
+      "functions": 100
+    },
+    {
+      "path": ".agents/scripts/lib/dynamic-workflow/quality-report-contract.js",
+      "lines": 100,
+      "branches": 100,
+      "functions": 100
+    },
+    {
+      "path": ".agents/scripts/lib/dynamic-workflow/report-contract-core.js",
+      "lines": 100,
+      "branches": 83.33,
+      "functions": 100
+    },
+    {
+      "path": ".agents/scripts/lib/dynamic-workflow/security-report-contract.js",
+      "lines": 100,
+      "branches": 100,
+      "functions": 100
+    },
+    {
+      "path": ".agents/scripts/lib/env-loader.js",
+      "lines": 100,
+      "branches": 95.45,
       "functions": 100
     },
     {
@@ -864,74 +1224,122 @@
     },
     {
       "path": ".agents/scripts/lib/errors/index.js",
+      "lines": 95.52,
+      "branches": 100,
+      "functions": 83.33
+    },
+    {
+      "path": ".agents/scripts/lib/escomplex-ast-compat.js",
+      "lines": 96.39,
+      "branches": 72.92,
+      "functions": 100
+    },
+    {
+      "path": ".agents/scripts/lib/feedback-loop/audit-results-graduator.js",
+      "lines": 91.1,
+      "branches": 82.05,
+      "functions": 90
+    },
+    {
+      "path": ".agents/scripts/lib/feedback-loop/graduator-core.js",
+      "lines": 97.51,
+      "branches": 81.67,
+      "functions": 100
+    },
+    {
+      "path": ".agents/scripts/lib/feedback-loop/prior-feedback-fetcher.js",
+      "lines": 93.25,
+      "branches": 67.8,
+      "functions": 100
+    },
+    {
+      "path": ".agents/scripts/lib/feedback-loop/retro-proposals-graduator.js",
+      "lines": 95.59,
+      "branches": 69.57,
+      "functions": 94.44
+    },
+    {
+      "path": ".agents/scripts/lib/findings/classify-finding.js",
       "lines": 100,
       "branches": 100,
       "functions": 100
     },
     {
-      "path": ".agents/scripts/lib/feedback-loop/audit-results-graduator.js",
-      "lines": 83.23,
-      "branches": 69.23,
+      "path": ".agents/scripts/lib/findings/promote-finding.js",
+      "lines": 100,
+      "branches": 90.16,
       "functions": 100
     },
     {
-      "path": ".agents/scripts/lib/feedback-loop/code-review-graduator.js",
-      "lines": 92.37,
-      "branches": 80.77,
+      "path": ".agents/scripts/lib/findings/route-finding.js",
+      "lines": 100,
+      "branches": 94.74,
       "functions": 100
     },
     {
-      "path": ".agents/scripts/lib/feedback-loop/memory-freshness.js",
-      "lines": 79.38,
-      "branches": 72.15,
-      "functions": 85.71
+      "path": ".agents/scripts/lib/findings/semantic-issue-search.js",
+      "lines": 100,
+      "branches": 97.67,
+      "functions": 100
     },
     {
-      "path": ".agents/scripts/lib/feedback-loop/prior-feedback-fetcher.js",
-      "lines": 96.85,
-      "branches": 76.36,
+      "path": ".agents/scripts/lib/findings/severity.js",
+      "lines": 100,
+      "branches": 100,
+      "functions": 100
+    },
+    {
+      "path": ".agents/scripts/lib/format-generated-json.js",
+      "lines": 97.94,
+      "branches": 57.14,
+      "functions": 100
+    },
+    {
+      "path": ".agents/scripts/lib/framework-version.js",
+      "lines": 100,
+      "branches": 100,
       "functions": 100
     },
     {
       "path": ".agents/scripts/lib/gates/baseline-store.js",
-      "lines": 96.23,
-      "branches": 78.26,
+      "lines": 98.11,
+      "branches": 81.82,
       "functions": 100
     },
     {
       "path": ".agents/scripts/lib/gates/friction.js",
-      "lines": 90.7,
-      "branches": 83.33,
+      "lines": 90.57,
+      "branches": 77.78,
       "functions": 100
     },
     {
       "path": ".agents/scripts/lib/gh-exec.js",
-      "lines": 97.83,
-      "branches": 94.38,
-      "functions": 86.84
+      "lines": 97.15,
+      "branches": 90.11,
+      "functions": 84.62
     },
     {
       "path": ".agents/scripts/lib/git-branch-cleanup.js",
       "lines": 100,
-      "branches": 88.33,
+      "branches": 85.45,
       "functions": 100
     },
     {
       "path": ".agents/scripts/lib/git-branch-lifecycle.js",
       "lines": 100,
-      "branches": 100,
+      "branches": 97.87,
       "functions": 100
     },
     {
       "path": ".agents/scripts/lib/git-utils.js",
-      "lines": 96.42,
-      "branches": 86.15,
-      "functions": 90
+      "lines": 97.35,
+      "branches": 91.53,
+      "functions": 85.71
     },
     {
       "path": ".agents/scripts/lib/git/cached-fetch.js",
       "lines": 94.81,
-      "branches": 96,
+      "branches": 95.83,
       "functions": 63.64
     },
     {
@@ -941,28 +1349,40 @@
       "functions": 100
     },
     {
+      "path": ".agents/scripts/lib/github-url.js",
+      "lines": 100,
+      "branches": 87.5,
+      "functions": 100
+    },
+    {
+      "path": ".agents/scripts/lib/github/framework-repo.js",
+      "lines": 100,
+      "branches": 100,
+      "functions": 0
+    },
+    {
       "path": ".agents/scripts/lib/Graph.js",
       "lines": 100,
-      "branches": 92.31,
+      "branches": 92.21,
+      "functions": 100
+    },
+    {
+      "path": ".agents/scripts/lib/import-graph.js",
+      "lines": 96.79,
+      "branches": 84.38,
       "functions": 100
     },
     {
       "path": ".agents/scripts/lib/install-cmd-parser.js",
-      "lines": 84.31,
-      "branches": 80,
-      "functions": 50
-    },
-    {
-      "path": ".agents/scripts/lib/issue-link-parser.js",
-      "lines": 100,
-      "branches": 100,
+      "lines": 92.16,
+      "branches": 37.5,
       "functions": 100
     },
     {
       "path": ".agents/scripts/lib/ITicketingProvider.js",
-      "lines": 95.99,
+      "lines": 95.18,
       "branches": 100,
-      "functions": 69.57
+      "functions": 61.9
     },
     {
       "path": ".agents/scripts/lib/json-utils.js",
@@ -980,30 +1400,36 @@
       "path": ".agents/scripts/lib/label-taxonomy.js",
       "lines": 100,
       "branches": 100,
-      "functions": 100
+      "functions": 0
     },
     {
       "path": ".agents/scripts/lib/Logger.js",
       "lines": 100,
       "branches": 100,
-      "functions": 84.62
+      "functions": 80.77
     },
     {
       "path": ".agents/scripts/lib/maintainability-engine.js",
-      "lines": 92.68,
-      "branches": 72.5,
+      "lines": 94.92,
+      "branches": 72,
+      "functions": 100
+    },
+    {
+      "path": ".agents/scripts/lib/maintainability-unscorable.js",
+      "lines": 100,
+      "branches": 100,
       "functions": 100
     },
     {
       "path": ".agents/scripts/lib/maintainability-utils.js",
-      "lines": 93.59,
-      "branches": 82.05,
+      "lines": 93.75,
+      "branches": 85.71,
       "functions": 100
     },
     {
       "path": ".agents/scripts/lib/mandrel-catalog.js",
-      "lines": 100,
-      "branches": 90,
+      "lines": 91.75,
+      "branches": 88.1,
       "functions": 100
     },
     {
@@ -1025,45 +1451,51 @@
       "functions": 100
     },
     {
+      "path": ".agents/scripts/lib/mutation/survivor-report.js",
+      "lines": 100,
+      "branches": 92.11,
+      "functions": 100
+    },
+    {
       "path": ".agents/scripts/lib/notifications/notifier.js",
       "lines": 100,
       "branches": 89.47,
       "functions": 100
     },
     {
+      "path": ".agents/scripts/lib/npm-scripts.js",
+      "lines": 100,
+      "branches": 100,
+      "functions": 100
+    },
+    {
       "path": ".agents/scripts/lib/observability/active-story-env.js",
-      "lines": 96.7,
-      "branches": 93.1,
+      "lines": 92.94,
+      "branches": 88.89,
       "functions": 100
     },
     {
-      "path": ".agents/scripts/lib/observability/baseline-refresh-rate.js",
-      "lines": 100,
-      "branches": 86.96,
+      "path": ".agents/scripts/lib/observability/metrics-ledger.js",
+      "lines": 93.09,
+      "branches": 83.87,
       "functions": 100
     },
     {
-      "path": ".agents/scripts/lib/observability/perf-aggregator.js",
-      "lines": 98.5,
-      "branches": 75.88,
+      "path": ".agents/scripts/lib/observability/runtime-friction.js",
+      "lines": 96.92,
+      "branches": 81.72,
       "functions": 100
     },
     {
-      "path": ".agents/scripts/lib/observability/perf-report-readers.js",
-      "lines": 90.91,
-      "branches": 71.21,
-      "functions": 100
-    },
-    {
-      "path": ".agents/scripts/lib/observability/perf-report-render.js",
-      "lines": 100,
-      "branches": 75,
+      "path": ".agents/scripts/lib/observability/signal-validator.js",
+      "lines": 84.8,
+      "branches": 51.35,
       "functions": 100
     },
     {
       "path": ".agents/scripts/lib/observability/signals-writer.js",
-      "lines": 95.61,
-      "branches": 75.47,
+      "lines": 94.34,
+      "branches": 78.05,
       "functions": 100
     },
     {
@@ -1073,33 +1505,75 @@
       "functions": 100
     },
     {
-      "path": ".agents/scripts/lib/observability/tool-trace-hook.js",
-      "lines": 92.81,
-      "branches": 79.73,
-      "functions": 90.91
+      "path": ".agents/scripts/lib/observability/terse-result.js",
+      "lines": 100,
+      "branches": 85.71,
+      "functions": 100
     },
     {
-      "path": ".agents/scripts/lib/orchestration/cascade-grouping.js",
-      "lines": 97.09,
-      "branches": 95.45,
-      "functions": 83.33
+      "path": ".agents/scripts/lib/observability/tool-trace-hook.js",
+      "lines": 93.42,
+      "branches": 82.35,
+      "functions": 91.67
+    },
+    {
+      "path": ".agents/scripts/lib/onboard/init-tail.js",
+      "lines": 98.06,
+      "branches": 73.91,
+      "functions": 60
+    },
+    {
+      "path": ".agents/scripts/lib/onboard/scaffold-docs.js",
+      "lines": 100,
+      "branches": 82.35,
+      "functions": 100
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/acceptance-clusters.js",
+      "lines": 100,
+      "branches": 95.83,
+      "functions": 100
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/acceptance-eval-decision.js",
+      "lines": 99.73,
+      "branches": 80,
+      "functions": 88.89
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/auto-merge-cwd.js",
+      "lines": 100,
+      "branches": 100,
+      "functions": 100
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/ceremony-routing.js",
+      "lines": 100,
+      "branches": 86.49,
+      "functions": 100
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/change-set.js",
+      "lines": 100,
+      "branches": 100,
+      "functions": 100
     },
     {
       "path": ".agents/scripts/lib/orchestration/check-baselines/phases/compare.js",
-      "lines": 81.68,
-      "branches": 66.67,
-      "functions": 77.78
+      "lines": 91.33,
+      "branches": 77.78,
+      "functions": 100
     },
     {
       "path": ".agents/scripts/lib/orchestration/check-baselines/phases/evaluate.js",
-      "lines": 100,
-      "branches": 52.94,
+      "lines": 97.45,
+      "branches": 66.67,
       "functions": 100
     },
     {
       "path": ".agents/scripts/lib/orchestration/check-baselines/phases/floors.js",
       "lines": 100,
-      "branches": 79.66,
+      "branches": 82.54,
       "functions": 100
     },
     {
@@ -1110,8 +1584,8 @@
     },
     {
       "path": ".agents/scripts/lib/orchestration/check-baselines/phases/parse-args.js",
-      "lines": 98.64,
-      "branches": 85.29,
+      "lines": 98.83,
+      "branches": 86.11,
       "functions": 100
     },
     {
@@ -1122,20 +1596,38 @@
     },
     {
       "path": ".agents/scripts/lib/orchestration/check-baselines/phases/report.js",
-      "lines": 96.43,
-      "branches": 83.33,
+      "lines": 96.88,
+      "branches": 82.14,
       "functions": 100
     },
     {
+      "path": ".agents/scripts/lib/orchestration/ci-rerun-guard.js",
+      "lines": 85.4,
+      "branches": 71.3,
+      "functions": 82.35
+    },
+    {
       "path": ".agents/scripts/lib/orchestration/code-review.js",
-      "lines": 92.96,
-      "branches": 63.89,
+      "lines": 96.63,
+      "branches": 78.46,
       "functions": 100
     },
     {
       "path": ".agents/scripts/lib/orchestration/column-sync.js",
-      "lines": 96.91,
-      "branches": 83.58,
+      "lines": 97.69,
+      "branches": 86.05,
+      "functions": 100
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/complexity-gate.js",
+      "lines": 98.68,
+      "branches": 92.54,
+      "functions": 100
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/consolidation-precondition.js",
+      "lines": 99.1,
+      "branches": 87.5,
       "functions": 100
     },
     {
@@ -1145,255 +1637,39 @@
       "functions": 100
     },
     {
-      "path": ".agents/scripts/lib/orchestration/context-hydration-engine.js",
-      "lines": 94.54,
-      "branches": 69.86,
-      "functions": 94.12
+      "path": ".agents/scripts/lib/orchestration/deliver-recover.js",
+      "lines": 99.43,
+      "branches": 85.71,
+      "functions": 92.31
     },
     {
       "path": ".agents/scripts/lib/orchestration/dependency-analyzer.js",
-      "lines": 98.19,
-      "branches": 88.89,
+      "lines": 100,
+      "branches": 92.86,
       "functions": 100
     },
     {
       "path": ".agents/scripts/lib/orchestration/detectors-phase.js",
-      "lines": 97.34,
-      "branches": 81.82,
+      "lines": 97.42,
+      "branches": 71.88,
       "functions": 100
     },
     {
-      "path": ".agents/scripts/lib/orchestration/dispatch-engine.js",
-      "lines": 95.83,
-      "branches": 75,
-      "functions": 100
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/dispatch-pipeline.js",
-      "lines": 97.57,
-      "branches": 66.67,
+      "path": ".agents/scripts/lib/orchestration/diff-magnitude.js",
+      "lines": 99.29,
+      "branches": 87.27,
       "functions": 100
     },
     {
       "path": ".agents/scripts/lib/orchestration/doc-reader.js",
-      "lines": 92.55,
-      "branches": 85.71,
-      "functions": 100
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/epic-plan-decompose/phases/cli.js",
-      "lines": 54.49,
-      "branches": 40,
-      "functions": 42.86
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/epic-plan-decompose/phases/context.js",
-      "lines": 98.6,
-      "branches": 90.91,
-      "functions": 100
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/epic-plan-decompose/phases/creation.js",
-      "lines": 87.16,
-      "branches": 81.13,
-      "functions": 93.33
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/epic-plan-decompose/phases/dag.js",
-      "lines": 91.49,
-      "branches": 93.75,
-      "functions": 100
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/epic-plan-decompose/phases/diagnostics.js",
-      "lines": 94.03,
-      "branches": 46.67,
-      "functions": 100
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/epic-plan-decompose/phases/persist-helpers.js",
-      "lines": 77.85,
-      "branches": 61.11,
-      "functions": 100
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/epic-plan-decompose/phases/persist.js",
-      "lines": 94.96,
-      "branches": 68.75,
-      "functions": 100
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/epic-plan-decompose/phases/planning-artifacts.js",
-      "lines": 93.33,
-      "branches": 92.31,
-      "functions": 100
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/epic-plan-decompose/phases/reconcile-spawn.js",
-      "lines": 94.2,
-      "branches": 25,
-      "functions": 100
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/epic-plan-spec/phases/authoring-context.js",
-      "lines": 97.83,
-      "branches": 72.5,
-      "functions": 100
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/epic-plan-spec/phases/drain.js",
       "lines": 100,
-      "branches": 38.46,
+      "branches": 66.67,
       "functions": 100
     },
     {
-      "path": ".agents/scripts/lib/orchestration/epic-plan-spec/phases/plan-epic.js",
-      "lines": 94.19,
-      "branches": 88.24,
-      "functions": 100
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/epic-plan-spec/phases/prompts.js",
+      "path": ".agents/scripts/lib/orchestration/docs-digest.js",
       "lines": 100,
-      "branches": 100,
-      "functions": 0
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/epic-plan-spec/phases/run-spec-phase.js",
-      "lines": 94.51,
-      "branches": 28.57,
-      "functions": 100
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/epic-plan-spec/phases/spec-freshness.js",
-      "lines": 100,
-      "branches": 100,
-      "functions": 100
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/epic-plan-state-store.js",
-      "lines": 98.73,
-      "branches": 88.46,
-      "functions": 100
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/epic-run-state-store.js",
-      "lines": 100,
-      "branches": 81.82,
-      "functions": 100
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/epic-runner/concurrency-gate.js",
-      "lines": 100,
-      "branches": 83.33,
-      "functions": 100
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/epic-runner/deliver-phases.js",
-      "lines": 92,
-      "branches": 71.43,
-      "functions": 100
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/epic-runner/phases/build-wave-dag.js",
-      "lines": 100,
-      "branches": 67.92,
-      "functions": 100
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/epic-runner/phases/snapshot.js",
-      "lines": 100,
-      "branches": 86.36,
-      "functions": 100
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/epic-runner/progress-reporter/composition.js",
-      "lines": 84.44,
-      "branches": 87.8,
-      "functions": 78.57
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/epic-runner/progress-reporter/signals.js",
-      "lines": 100,
-      "branches": 80,
-      "functions": 100
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/epic-runner/progress-reporter/transport.js",
-      "lines": 98.66,
-      "branches": 70.31,
-      "functions": 100
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/epic-runner/progress-signals/crap-drift.js",
-      "lines": 99.33,
-      "branches": 77.27,
-      "functions": 100
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/epic-runner/progress-signals/maintainability-drift.js",
-      "lines": 98.91,
-      "branches": 80,
-      "functions": 100
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/epic-runner/progress-signals/stalled-worktree.js",
-      "lines": 100,
-      "branches": 77.78,
-      "functions": 100
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/epic-runner/story-launcher.js",
-      "lines": 100,
-      "branches": 82.98,
-      "functions": 80
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/epic-runner/story-run-progress-writer.js",
-      "lines": 99.04,
-      "branches": 76.32,
-      "functions": 100
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/epic-runner/sub-agent-return.js",
-      "lines": 95.21,
-      "branches": 86.67,
-      "functions": 100
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/epic-runner/wave-scheduler.js",
-      "lines": 100,
-      "branches": 100,
-      "functions": 100
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/epic-spec-reconciler-apply.js",
-      "lines": 98.09,
-      "branches": 85.21,
-      "functions": 100
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/epic-spec-reconciler-diff.js",
-      "lines": 99.68,
-      "branches": 76.07,
-      "functions": 100
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/epic-spec-reconciler-discriminator.js",
-      "lines": 100,
-      "branches": 88.14,
-      "functions": 100
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/epic-spec-reconciler-format.js",
-      "lines": 97.39,
-      "branches": 80.49,
-      "functions": 100
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/error-journal.js",
-      "lines": 95.68,
-      "branches": 84.62,
+      "branches": 92.11,
       "functions": 100
     },
     {
@@ -1404,45 +1680,21 @@
     },
     {
       "path": ".agents/scripts/lib/orchestration/file-assumptions.js",
-      "lines": 95.1,
-      "branches": 88.24,
-      "functions": 100
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/finalize/close-planning-tickets.js",
-      "lines": 94.83,
-      "branches": 85.71,
-      "functions": 100
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/finalize/open-or-locate-pr.js",
-      "lines": 93.36,
-      "branches": 87.88,
-      "functions": 100
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/finalize/post-handoff-comment.js",
-      "lines": 93.53,
-      "branches": 67.31,
-      "functions": 100
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/finalize/sanitize-skip-ci.js",
-      "lines": 100,
-      "branches": 100,
-      "functions": 100
+      "lines": 95.92,
+      "branches": 89.47,
+      "functions": 90
     },
     {
       "path": ".agents/scripts/lib/orchestration/git-cleanup/phases/branches-reap.js",
-      "lines": 100,
-      "branches": 94.74,
+      "lines": 98.17,
+      "branches": 91.43,
       "functions": 100
     },
     {
       "path": ".agents/scripts/lib/orchestration/git-cleanup/phases/branches.js",
       "lines": 100,
-      "branches": 98.25,
-      "functions": 63.64
+      "branches": 97.3,
+      "functions": 78.57
     },
     {
       "path": ".agents/scripts/lib/orchestration/git-cleanup/phases/cli.js",
@@ -1452,27 +1704,27 @@
     },
     {
       "path": ".agents/scripts/lib/orchestration/git-cleanup/phases/fast-forward.js",
-      "lines": 92.68,
-      "branches": 82.61,
+      "lines": 94.27,
+      "branches": 87.5,
       "functions": 100
     },
     {
       "path": ".agents/scripts/lib/orchestration/git-cleanup/phases/filters.js",
       "lines": 100,
-      "branches": 95.45,
+      "branches": 95.65,
       "functions": 100
     },
     {
       "path": ".agents/scripts/lib/orchestration/git-cleanup/phases/git-probes-ff.js",
-      "lines": 41.38,
-      "branches": 100,
-      "functions": 100
+      "lines": 68.68,
+      "branches": 75,
+      "functions": 68.75
     },
     {
       "path": ".agents/scripts/lib/orchestration/git-cleanup/phases/git-probes.js",
-      "lines": 79.1,
-      "branches": 82.54,
-      "functions": 83.33
+      "lines": 93.92,
+      "branches": 81.13,
+      "functions": 94.44
     },
     {
       "path": ".agents/scripts/lib/orchestration/git-cleanup/phases/parse-args.js",
@@ -1482,32 +1734,32 @@
     },
     {
       "path": ".agents/scripts/lib/orchestration/git-cleanup/phases/phase-drivers.js",
-      "lines": 65.93,
-      "branches": 100,
-      "functions": 75
+      "lines": 81.3,
+      "branches": 90,
+      "functions": 100
     },
     {
       "path": ".agents/scripts/lib/orchestration/git-cleanup/phases/prompts.js",
-      "lines": 45.76,
+      "lines": 59.72,
       "branches": 100,
       "functions": 100
     },
     {
       "path": ".agents/scripts/lib/orchestration/git-cleanup/phases/prune.js",
       "lines": 100,
-      "branches": 87.5,
-      "functions": 66.67
+      "branches": 90,
+      "functions": 100
     },
     {
       "path": ".agents/scripts/lib/orchestration/git-cleanup/phases/render.js",
-      "lines": 98.94,
-      "branches": 86.96,
+      "lines": 99.37,
+      "branches": 89.31,
       "functions": 100
     },
     {
       "path": ".agents/scripts/lib/orchestration/git-cleanup/phases/stashes.js",
-      "lines": 97.08,
-      "branches": 91.67,
+      "lines": 99.27,
+      "branches": 89.47,
       "functions": 100
     },
     {
@@ -1517,93 +1769,75 @@
       "functions": 100
     },
     {
+      "path": ".agents/scripts/lib/orchestration/lease-guard-shared.js",
+      "lines": 99.31,
+      "branches": 72.73,
+      "functions": 100
+    },
+    {
       "path": ".agents/scripts/lib/orchestration/lifecycle/bus.js",
       "lines": 95.15,
-      "branches": 88.33,
+      "branches": 87.27,
       "functions": 90.91
     },
     {
+      "path": ".agents/scripts/lib/orchestration/lifecycle/emit-ledger-event.js",
+      "lines": 90.85,
+      "branches": 60,
+      "functions": 100
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/lifecycle/emit-loop-tick.js",
+      "lines": 90.61,
+      "branches": 50,
+      "functions": 100
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/lifecycle/emit-merge-flip-failed.js",
+      "lines": 55.81,
+      "branches": 100,
+      "functions": 0
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/lifecycle/emit-merge-unlanded.js",
+      "lines": 96.85,
+      "branches": 60,
+      "functions": 100
+    },
+    {
       "path": ".agents/scripts/lib/orchestration/lifecycle/ledger-writer.js",
-      "lines": 99.12,
-      "branches": 89.74,
+      "lines": 99.13,
+      "branches": 89.47,
       "functions": 91.67
     },
     {
-      "path": ".agents/scripts/lib/orchestration/lifecycle/listeners/acceptance-reconciler.js",
-      "lines": 88.22,
-      "branches": 81.82,
-      "functions": 80
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/lifecycle/listeners/automerge-armer.js",
-      "lines": 92.46,
-      "branches": 73.33,
-      "functions": 77.78
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/lifecycle/listeners/automerge-predicate.js",
-      "lines": 93.8,
-      "branches": 84.26,
-      "functions": 87.5
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/lifecycle/listeners/branch-cleaner.js",
-      "lines": 100,
-      "branches": 91.67,
-      "functions": 100
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/lifecycle/listeners/checkpoint-pointer-writer.js",
-      "lines": 93.71,
-      "branches": 93.55,
-      "functions": 75
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/lifecycle/listeners/cleaner.js",
-      "lines": 84.96,
-      "branches": 76.6,
-      "functions": 77.78
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/lifecycle/listeners/finalizer.js",
-      "lines": 92.74,
-      "branches": 77.3,
-      "functions": 85.71
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/lifecycle/listeners/index.js",
-      "lines": 97.81,
-      "branches": 77.78,
-      "functions": 100
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/lifecycle/listeners/intervention-recorder.js",
-      "lines": 100,
-      "branches": 93.94,
-      "functions": 100
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/lifecycle/listeners/merge-watcher.js",
-      "lines": 82.12,
-      "branches": 69.7,
-      "functions": 63.64
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/lifecycle/listeners/notify-dispatcher.js",
-      "lines": 92.81,
-      "branches": 65.22,
-      "functions": 66.67
-    },
-    {
       "path": ".agents/scripts/lib/orchestration/lifecycle/listeners/watcher.js",
-      "lines": 84.21,
-      "branches": 76.32,
-      "functions": 70.59
+      "lines": 94.65,
+      "branches": 83.22,
+      "functions": 84.21
     },
     {
       "path": ".agents/scripts/lib/orchestration/lifecycle/trace-logger.js",
-      "lines": 98.46,
-      "branches": 85.33,
+      "lines": 96.51,
+      "branches": 83.33,
+      "functions": 100
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/light-backstop.js",
+      "lines": 100,
+      "branches": 100,
+      "functions": 100
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/light-escalation.js",
+      "lines": 100,
+      "branches": 85.29,
+      "functions": 100
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/light-suitability.js",
+      "lines": 99.29,
+      "branches": 91.3,
       "functions": 100
     },
     {
@@ -1613,21 +1847,27 @@
       "functions": 100
     },
     {
-      "path": ".agents/scripts/lib/orchestration/manifest-builder.js",
+      "path": ".agents/scripts/lib/orchestration/merge-block-class.js",
+      "lines": 99.38,
+      "branches": 82.14,
+      "functions": 100
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/merge-poll.js",
       "lines": 100,
-      "branches": 72.55,
+      "branches": 98.21,
       "functions": 100
     },
     {
       "path": ".agents/scripts/lib/orchestration/model-attribution.js",
-      "lines": 97.44,
-      "branches": 81.63,
+      "lines": 97.61,
+      "branches": 83.02,
       "functions": 100
     },
     {
       "path": ".agents/scripts/lib/orchestration/parked-follow-ons.js",
       "lines": 100,
-      "branches": 80.95,
+      "branches": 78.95,
       "functions": 100
     },
     {
@@ -1637,81 +1877,111 @@
       "functions": 100
     },
     {
-      "path": ".agents/scripts/lib/orchestration/plan-review-routing.js",
+      "path": ".agents/scripts/lib/orchestration/plan-context.js",
+      "lines": 97.85,
+      "branches": 78.53,
+      "functions": 100
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/plan-critic-conditions.js",
+      "lines": 100,
+      "branches": 95,
+      "functions": 100
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/plan-critics-evaluate.js",
+      "lines": 95.56,
+      "branches": 50,
+      "functions": 100
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/plan-metrics.js",
+      "lines": 99.53,
+      "branches": 90.57,
+      "functions": 100
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/plan-navigation.js",
+      "lines": 98.91,
+      "branches": 90.91,
+      "functions": 100
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/plan-persist/fan-out-gate.js",
+      "lines": 100,
+      "branches": 95.65,
+      "functions": 100
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/plan-persist/persist-helpers.js",
+      "lines": 96.73,
+      "branches": 78.85,
+      "functions": 100
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/plan-persist/plan-context-source.js",
       "lines": 100,
       "branches": 100,
       "functions": 100
     },
     {
-      "path": ".agents/scripts/lib/orchestration/plan-runner/plan-router.js",
+      "path": ".agents/scripts/lib/orchestration/plan-persist/run-plan-persist.js",
+      "lines": 93.2,
+      "branches": 78.89,
+      "functions": 100
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/plan-persist/story-ops.js",
+      "lines": 94.38,
+      "branches": 82.11,
+      "functions": 100
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/plan-persist/summary.js",
       "lines": 100,
-      "branches": 100,
+      "branches": 86.84,
+      "functions": 100
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/plan-persist/supersede-ops.js",
+      "lines": 100,
+      "branches": 92.25,
+      "functions": 100
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/plan-reachability.js",
+      "lines": 100,
+      "branches": 87.5,
       "functions": 100
     },
     {
       "path": ".agents/scripts/lib/orchestration/plan-runner/worktree-sweep.js",
       "lines": 99.53,
-      "branches": 77.55,
+      "branches": 75.51,
       "functions": 100
     },
     {
-      "path": ".agents/scripts/lib/orchestration/planning-context-budget.js",
+      "path": ".agents/scripts/lib/orchestration/plan-text-hygiene.js",
       "lines": 100,
-      "branches": 88.33,
+      "branches": 84.44,
       "functions": 100
     },
     {
-      "path": ".agents/scripts/lib/orchestration/planning-risk.js",
-      "lines": 94.46,
-      "branches": 84.48,
-      "functions": 75
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/planning-state-manager.js",
-      "lines": 95.91,
-      "branches": 85.96,
+      "path": ".agents/scripts/lib/orchestration/planning/authoring-context.js",
+      "lines": 97.85,
+      "branches": 70,
       "functions": 100
     },
     {
-      "path": ".agents/scripts/lib/orchestration/post-merge-pipeline.js",
+      "path": ".agents/scripts/lib/orchestration/planning/decomposer-context.js",
       "lines": 100,
-      "branches": 73.33,
+      "branches": 100,
       "functions": 100
     },
     {
-      "path": ".agents/scripts/lib/orchestration/post-merge/phases/branch-cleanup.js",
-      "lines": 100,
-      "branches": 54.55,
-      "functions": 100
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/post-merge/phases/dashboard-refresh.js",
-      "lines": 100,
-      "branches": 85.71,
-      "functions": 100
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/post-merge/phases/notification.js",
-      "lines": 100,
-      "branches": 70.59,
-      "functions": 100
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/post-merge/phases/temp-cleanup.js",
-      "lines": 100,
-      "branches": 88.89,
-      "functions": 100
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/post-merge/phases/ticket-closure.js",
-      "lines": 85.59,
-      "branches": 57.89,
-      "functions": 100
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/post-merge/phases/worktree-reap.js",
-      "lines": 97.22,
-      "branches": 77.53,
+      "path": ".agents/scripts/lib/orchestration/planning/memory-pool-advisory.js",
+      "lines": 98.27,
+      "branches": 87.5,
       "functions": 100
     },
     {
@@ -1721,28 +1991,22 @@
       "functions": 100
     },
     {
-      "path": ".agents/scripts/lib/orchestration/preflight-cache.js",
-      "lines": 85.37,
-      "branches": 51.28,
+      "path": ".agents/scripts/lib/orchestration/project-meta-cache.js",
+      "lines": 96.64,
+      "branches": 80.49,
+      "functions": 100
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/project-meta-resolver.js",
+      "lines": 100,
+      "branches": 95.65,
       "functions": 100
     },
     {
       "path": ".agents/scripts/lib/orchestration/reassert-status-column.js",
-      "lines": 90.1,
-      "branches": 81.25,
+      "lines": 90.2,
+      "branches": 83.33,
       "functions": 50
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/reconciler.js",
-      "lines": 88.32,
-      "branches": 94.59,
-      "functions": 85.71
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/recurring-failure-detector.js",
-      "lines": 94.74,
-      "branches": 82.26,
-      "functions": 100
     },
     {
       "path": ".agents/scripts/lib/orchestration/recut.js",
@@ -1751,88 +2015,94 @@
       "functions": 100
     },
     {
+      "path": ".agents/scripts/lib/orchestration/remote-verifier.js",
+      "lines": 100,
+      "branches": 75,
+      "functions": 100
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/resolve-stories.js",
+      "lines": 97.39,
+      "branches": 79.52,
+      "functions": 100
+    },
+    {
       "path": ".agents/scripts/lib/orchestration/resolves-token.js",
-      "lines": 100,
+      "lines": 98.43,
       "branches": 100,
-      "functions": 100
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/retro-heuristics.js",
-      "lines": 100,
-      "branches": 100,
-      "functions": 100
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/retro-perf-heuristics.js",
-      "lines": 97,
-      "branches": 82.26,
-      "functions": 100
+      "functions": 75
     },
     {
       "path": ".agents/scripts/lib/orchestration/retro-proposals.js",
-      "lines": 99.75,
-      "branches": 91.78,
+      "lines": 100,
+      "branches": 96.08,
       "functions": 100
     },
     {
-      "path": ".agents/scripts/lib/orchestration/retro-runner.js",
-      "lines": 98.91,
-      "branches": 76.47,
-      "functions": 100
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/retro/phases/checks.js",
-      "lines": 94.68,
-      "branches": 80,
-      "functions": 100
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/retro/phases/compose-body.js",
-      "lines": 99.1,
-      "branches": 79.59,
-      "functions": 100
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/retro/phases/gather-signals.js",
-      "lines": 96.55,
-      "branches": 73.02,
-      "functions": 100
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/retro/phases/post-and-mirror.js",
-      "lines": 97.18,
-      "branches": 71.43,
+      "path": ".agents/scripts/lib/orchestration/review-depth.js",
+      "lines": 100,
+      "branches": 84.85,
       "functions": 100
     },
     {
       "path": ".agents/scripts/lib/orchestration/review-providers/codex.js",
-      "lines": 94.43,
-      "branches": 85.14,
-      "functions": 75
+      "lines": 92.21,
+      "branches": 75,
+      "functions": 66.67
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/review-providers/degraded-gates.js",
+      "lines": 91.44,
+      "branches": 72.73,
+      "functions": 100
     },
     {
       "path": ".agents/scripts/lib/orchestration/review-providers/findings-renderer.js",
       "lines": 100,
-      "branches": 95,
+      "branches": 94.87,
       "functions": 100
     },
     {
       "path": ".agents/scripts/lib/orchestration/review-providers/native.js",
-      "lines": 87.28,
-      "branches": 70.53,
-      "functions": 89.47
+      "lines": 93.62,
+      "branches": 80.65,
+      "functions": 93.75
     },
     {
-      "path": ".agents/scripts/lib/orchestration/review-providers/review-provider-factory.js",
-      "lines": 95.45,
-      "branches": 88.37,
+      "path": ".agents/scripts/lib/orchestration/review-providers/parse-findings.js",
+      "lines": 100,
+      "branches": 98.11,
       "functions": 100
     },
     {
+      "path": ".agents/scripts/lib/orchestration/review-providers/review-depth.js",
+      "lines": 100,
+      "branches": 100,
+      "functions": 100
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/review-providers/review-provider-factory.js",
+      "lines": 95.15,
+      "branches": 89.29,
+      "functions": 100
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/review-providers/scoped-lint.js",
+      "lines": 95,
+      "branches": 85,
+      "functions": 83.33
+    },
+    {
       "path": ".agents/scripts/lib/orchestration/review-providers/security-review.js",
-      "lines": 90.63,
-      "branches": 68.12,
+      "lines": 90.34,
+      "branches": 64.52,
       "functions": 70
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/review-providers/types.js",
+      "lines": 0,
+      "branches": 0,
+      "functions": 0
     },
     {
       "path": ".agents/scripts/lib/orchestration/review-providers/ultrareview.js",
@@ -1841,39 +2111,81 @@
       "functions": 100
     },
     {
+      "path": ".agents/scripts/lib/orchestration/run-epilogue.js",
+      "lines": 97,
+      "branches": 78.81,
+      "functions": 100
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/run-scoped-config.js",
+      "lines": 100,
+      "branches": 95.35,
+      "functions": 100
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/single-story-close/failed-terminal.js",
+      "lines": 83.61,
+      "branches": 100,
+      "functions": 50
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/single-story-close/gate-log.js",
+      "lines": 98.91,
+      "branches": 92.5,
+      "functions": 100
+    },
+    {
       "path": ".agents/scripts/lib/orchestration/single-story-close/phases/auto-merge.js",
-      "lines": 98.74,
-      "branches": 62.5,
+      "lines": 99.54,
+      "branches": 77.05,
       "functions": 100
     },
     {
       "path": ".agents/scripts/lib/orchestration/single-story-close/phases/base-sync.js",
-      "lines": 98.97,
-      "branches": 70,
+      "lines": 99.56,
+      "branches": 79.17,
       "functions": 75
     },
     {
       "path": ".agents/scripts/lib/orchestration/single-story-close/phases/close-validation.js",
-      "lines": 100,
-      "branches": 57.14,
-      "functions": 50
+      "lines": 97.91,
+      "branches": 78.95,
+      "functions": 100
     },
     {
       "path": ".agents/scripts/lib/orchestration/single-story-close/phases/code-review.js",
-      "lines": 95.19,
-      "branches": 85,
+      "lines": 96.12,
+      "branches": 89.47,
+      "functions": 100
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/single-story-close/phases/confirm-merge.js",
+      "lines": 96.23,
+      "branches": 76.19,
+      "functions": 94.74
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/single-story-close/phases/normalize-pr-title.js",
+      "lines": 92.53,
+      "branches": 42.86,
       "functions": 60
     },
     {
       "path": ".agents/scripts/lib/orchestration/single-story-close/phases/options.js",
-      "lines": 100,
-      "branches": 44.44,
+      "lines": 98.65,
+      "branches": 87.5,
       "functions": 100
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/single-story-close/phases/post-land.js",
+      "lines": 97.58,
+      "branches": 72.37,
+      "functions": 84.21
     },
     {
       "path": ".agents/scripts/lib/orchestration/single-story-close/phases/pull-request.js",
       "lines": 100,
-      "branches": 76.47,
+      "branches": 77.5,
       "functions": 100
     },
     {
@@ -1883,202 +2195,136 @@
       "functions": 100
     },
     {
+      "path": ".agents/scripts/lib/orchestration/single-story-close/phases/review-block.js",
+      "lines": 90.91,
+      "branches": 66.67,
+      "functions": 100
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/single-story-close/phases/review-outcome.js",
+      "lines": 90.91,
+      "branches": 75,
+      "functions": 100
+    },
+    {
       "path": ".agents/scripts/lib/orchestration/single-story-close/phases/worktree-reap.js",
-      "lines": 71.23,
-      "branches": 50,
-      "functions": 20
+      "lines": 94.34,
+      "branches": 75,
+      "functions": 60
     },
     {
       "path": ".agents/scripts/lib/orchestration/single-story-close/phases/wrong-tree-guard.js",
-      "lines": 97.78,
-      "branches": 86.49,
+      "lines": 97.05,
+      "branches": 84.21,
       "functions": 100
     },
     {
-      "path": ".agents/scripts/lib/orchestration/skill-capsule-loader.js",
-      "lines": 96.36,
-      "branches": 86.36,
-      "functions": 83.33
+      "path": ".agents/scripts/lib/orchestration/single-story-close/runner.js",
+      "lines": 96.4,
+      "branches": 83.78,
+      "functions": 84.62
     },
     {
-      "path": ".agents/scripts/lib/orchestration/spec-freshness.js",
-      "lines": 95.31,
-      "branches": 91.67,
-      "functions": 85.71
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/spec-renderer.js",
-      "lines": 95.61,
-      "branches": 79.34,
-      "functions": 100
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/story-close/auto-refresh-runner.js",
-      "lines": 97.27,
-      "branches": 62.28,
-      "functions": 100
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/story-close/baseline-attribution-wiring.js",
-      "lines": 100,
-      "branches": 100,
-      "functions": 0
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/story-close/baseline-attribution.js",
-      "lines": 100,
-      "branches": 82.35,
-      "functions": 100
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/story-close/baseline-attribution/phases/gate-failure.js",
-      "lines": 92.93,
-      "branches": 68.89,
-      "functions": 100
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/story-close/baseline-attribution/phases/refresh-commit.js",
-      "lines": 76.29,
-      "branches": 71.11,
-      "functions": 75
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/story-close/baseline-attribution/phases/regression-projection.js",
-      "lines": 76.32,
-      "branches": 80,
-      "functions": 72.73
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/story-close/baseline-attribution/phases/scope-discovery.js",
-      "lines": 100,
-      "branches": 87.5,
-      "functions": 100
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/story-close/baseline-friction-body.js",
-      "lines": 100,
-      "branches": 84.62,
-      "functions": 100
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/story-close/cd-out-guard.js",
+      "path": ".agents/scripts/lib/orchestration/single-story-lease-guard.js",
       "lines": 100,
       "branches": 100,
       "functions": 100
     },
     {
-      "path": ".agents/scripts/lib/orchestration/story-close/cleanup-reconciler.js",
-      "lines": 100,
-      "branches": 76.32,
+      "path": ".agents/scripts/lib/orchestration/spec-budget.js",
+      "lines": 97.75,
+      "branches": 75,
       "functions": 100
     },
     {
-      "path": ".agents/scripts/lib/orchestration/story-close/close-inputs.js",
-      "lines": 98.59,
-      "branches": 78.26,
-      "functions": 100
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/story-close/comment-bodies.js",
+      "path": ".agents/scripts/lib/orchestration/spec-section-validator.js",
       "lines": 100,
       "branches": 100,
       "functions": 100
     },
     {
-      "path": ".agents/scripts/lib/orchestration/story-close/format-autofix-scoped.js",
-      "lines": 97.58,
-      "branches": 63.16,
+      "path": ".agents/scripts/lib/orchestration/spec-spill.js",
+      "lines": 100,
+      "branches": 75,
       "functions": 100
     },
     {
-      "path": ".agents/scripts/lib/orchestration/story-close/format-autofix-shared.js",
+      "path": ".agents/scripts/lib/orchestration/split-policy-validator.js",
+      "lines": 98.4,
+      "branches": 85,
+      "functions": 100
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/story-body-gate.js",
       "lines": 100,
-      "branches": 100,
+      "branches": 62.5,
+      "functions": 100
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/story-close/emit-blocked.js",
+      "lines": 92.73,
+      "branches": 60,
       "functions": 100
     },
     {
       "path": ".agents/scripts/lib/orchestration/story-close/format-autofix.js",
-      "lines": 98.61,
-      "branches": 85.19,
-      "functions": 100
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/story-close/merge-runner.js",
-      "lines": 95.18,
-      "branches": 93.24,
-      "functions": 72
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/story-close/merge-subject.js",
-      "lines": 94.44,
-      "branches": 70,
-      "functions": 100
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/story-close/phases/branch-restore.js",
-      "lines": 91.43,
-      "branches": 80,
-      "functions": 100
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/story-close/phases/close.js",
-      "lines": 94.59,
-      "branches": 79.17,
+      "lines": 98.27,
+      "branches": 79.69,
       "functions": 100
     },
     {
       "path": ".agents/scripts/lib/orchestration/story-close/phases/code-review.js",
-      "lines": 97.24,
-      "branches": 47.06,
-      "functions": 50
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/story-close/phases/gates.js",
-      "lines": 56.27,
-      "branches": 80,
-      "functions": 40
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/story-close/phases/locked-pipeline.js",
-      "lines": 64.68,
-      "branches": 50,
-      "functions": 50
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/story-close/phases/preflight.js",
-      "lines": 68.47,
-      "branches": 66.67,
-      "functions": 33.33
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/story-close/phases/refresh.js",
-      "lines": 81.4,
-      "branches": 94.12,
-      "functions": 33.33
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/story-close/phases/timeout-blocked-emitter.js",
-      "lines": 39.02,
-      "branches": 100,
-      "functions": 0
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/story-close/phases/timeout-blocked.js",
-      "lines": 88.54,
-      "branches": 75,
-      "functions": 80
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/story-close/post-merge-close.js",
-      "lines": 96.08,
-      "branches": 93.88,
+      "lines": 97.63,
+      "branches": 70.59,
       "functions": 100
     },
     {
-      "path": ".agents/scripts/lib/orchestration/story-close/pre-merge-validation.js",
-      "lines": 92.16,
-      "branches": 85.45,
-      "functions": 80
+      "path": ".agents/scripts/lib/orchestration/story-close/phases/local-lens-review.js",
+      "lines": 98.89,
+      "branches": 86.05,
+      "functions": 100
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/story-close/phases/review-core.js",
+      "lines": 97.42,
+      "branches": 93.55,
+      "functions": 50
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/story-deliver-terminal-schema.js",
+      "lines": 98.8,
+      "branches": 85,
+      "functions": 100
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/story-deliver-terminal.js",
+      "lines": 99.64,
+      "branches": 88.31,
+      "functions": 100
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/story-follow-ups.js",
+      "lines": 98.01,
+      "branches": 82.17,
+      "functions": 100
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/story-init-remote.js",
+      "lines": 84.31,
+      "branches": 62.5,
+      "functions": 100
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/story-plan-state.js",
+      "lines": 100,
+      "branches": 100,
+      "functions": 100
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/story-reachability.js",
+      "lines": 100,
+      "branches": 91.67,
+      "functions": 100
     },
     {
       "path": ".agents/scripts/lib/orchestration/structured-comment-parser.js",
@@ -2088,27 +2334,33 @@
     },
     {
       "path": ".agents/scripts/lib/orchestration/task-body-validator.js",
-      "lines": 100,
+      "lines": 97.74,
       "branches": 97.12,
       "functions": 100
     },
     {
+      "path": ".agents/scripts/lib/orchestration/ticket-lease.js",
+      "lines": 100,
+      "branches": 96.36,
+      "functions": 100
+    },
+    {
       "path": ".agents/scripts/lib/orchestration/ticket-validator-conflicts.js",
-      "lines": 96.95,
-      "branches": 84.21,
+      "lines": 99.22,
+      "branches": 88.76,
       "functions": 100
     },
     {
       "path": ".agents/scripts/lib/orchestration/ticket-validator-sizing.js",
-      "lines": 99.67,
-      "branches": 86.67,
+      "lines": 99.1,
+      "branches": 86.36,
       "functions": 100
     },
     {
       "path": ".agents/scripts/lib/orchestration/ticket-validator.js",
-      "lines": 97.74,
-      "branches": 88.19,
-      "functions": 93.75
+      "lines": 98.17,
+      "branches": 87.94,
+      "functions": 100
     },
     {
       "path": ".agents/scripts/lib/orchestration/ticketing.js",
@@ -2118,44 +2370,26 @@
     },
     {
       "path": ".agents/scripts/lib/orchestration/ticketing/bulk.js",
-      "lines": 93,
-      "branches": 84.27,
-      "functions": 95.65
+      "lines": 95.26,
+      "branches": 84.51,
+      "functions": 94.74
     },
     {
       "path": ".agents/scripts/lib/orchestration/ticketing/reads.js",
-      "lines": 99.79,
-      "branches": 91.8,
+      "lines": 99.8,
+      "branches": 91.67,
       "functions": 100
     },
     {
       "path": ".agents/scripts/lib/orchestration/ticketing/state.js",
-      "lines": 98.08,
-      "branches": 92.31,
+      "lines": 97.69,
+      "branches": 87.5,
       "functions": 100
     },
     {
-      "path": ".agents/scripts/lib/orchestration/wave-marker.js",
-      "lines": 100,
-      "branches": 100,
-      "functions": 100
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/wave-record-io.js",
-      "lines": 87.75,
-      "branches": 78.26,
-      "functions": 85.71
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/wave-record-notifications.js",
-      "lines": 96.83,
-      "branches": 95,
-      "functions": 100
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/wave-record-projection.js",
-      "lines": 99.05,
-      "branches": 90.55,
+      "path": ".agents/scripts/lib/orchestration/ticketing/transition.js",
+      "lines": 99.15,
+      "branches": 94.94,
       "functions": 100
     },
     {
@@ -2166,69 +2400,27 @@
     },
     {
       "path": ".agents/scripts/lib/plan-phase-cleanup.js",
-      "lines": 98.45,
-      "branches": 76.47,
+      "lines": 97.83,
+      "branches": 66.67,
       "functions": 100
     },
     {
-      "path": ".agents/scripts/lib/preflight-runner.js",
-      "lines": 91.33,
-      "branches": 58.82,
-      "functions": 50
-    },
-    {
-      "path": ".agents/scripts/lib/presentation/dispatch-manifest-render.js",
-      "lines": 100,
-      "branches": 85.71,
-      "functions": 100
-    },
-    {
-      "path": ".agents/scripts/lib/presentation/manifest-builder.js",
-      "lines": 100,
-      "branches": 96.83,
-      "functions": 100
-    },
-    {
-      "path": ".agents/scripts/lib/presentation/manifest-formatter.js",
-      "lines": 88.8,
-      "branches": 80,
-      "functions": 100
-    },
-    {
-      "path": ".agents/scripts/lib/presentation/manifest-helpers.js",
-      "lines": 100,
-      "branches": 92,
-      "functions": 100
-    },
-    {
-      "path": ".agents/scripts/lib/presentation/manifest-persistence.js",
-      "lines": 97.37,
-      "branches": 76.09,
-      "functions": 100
-    },
-    {
-      "path": ".agents/scripts/lib/presentation/manifest-procedures.js",
+      "path": ".agents/scripts/lib/planning-corpus.js",
       "lines": 100,
       "branches": 100,
       "functions": 100
     },
     {
-      "path": ".agents/scripts/lib/presentation/manifest-render-waves.js",
-      "lines": 99.3,
-      "branches": 80,
-      "functions": 100
+      "path": ".agents/scripts/lib/preflight-runner.js",
+      "lines": 87.76,
+      "branches": 53.33,
+      "functions": 37.5
     },
     {
-      "path": ".agents/scripts/lib/presentation/manifest-renderer.js",
+      "path": ".agents/scripts/lib/project-root.js",
       "lines": 100,
-      "branches": 94.74,
-      "functions": 100
-    },
-    {
-      "path": ".agents/scripts/lib/presentation/manifest-story-views.js",
-      "lines": 100,
-      "branches": 73.68,
-      "functions": 100
+      "branches": 100,
+      "functions": 0
     },
     {
       "path": ".agents/scripts/lib/provider-factory.js",
@@ -2237,21 +2429,51 @@
       "functions": 100
     },
     {
-      "path": ".agents/scripts/lib/push-epic-retry.js",
-      "lines": 91.87,
-      "branches": 70.73,
-      "functions": 85.71
-    },
-    {
       "path": ".agents/scripts/lib/qa/console-allowlist.js",
       "lines": 98.68,
-      "branches": 82.14,
+      "branches": 81.48,
+      "functions": 100
+    },
+    {
+      "path": ".agents/scripts/lib/qa/coverage-report.js",
+      "lines": 100,
+      "branches": 68.57,
+      "functions": 100
+    },
+    {
+      "path": ".agents/scripts/lib/qa/coverage-verdict.js",
+      "lines": 99.32,
+      "branches": 92.38,
+      "functions": 100
+    },
+    {
+      "path": ".agents/scripts/lib/qa/propose-missing-test.js",
+      "lines": 100,
+      "branches": 92.86,
+      "functions": 100
+    },
+    {
+      "path": ".agents/scripts/lib/qa/qa-context-hydrator.js",
+      "lines": 100,
+      "branches": 86.49,
+      "functions": 100
+    },
+    {
+      "path": ".agents/scripts/lib/qa/qa-session.js",
+      "lines": 100,
+      "branches": 90.48,
+      "functions": 100
+    },
+    {
+      "path": ".agents/scripts/lib/qa/redact-evidence.js",
+      "lines": 100,
+      "branches": 94.12,
       "functions": 100
     },
     {
       "path": ".agents/scripts/lib/qa/resolve-qa-contract.js",
-      "lines": 100,
-      "branches": 94.74,
+      "lines": 98.47,
+      "branches": 95,
       "functions": 100
     },
     {
@@ -2261,15 +2483,39 @@
       "functions": 100
     },
     {
-      "path": ".agents/scripts/lib/signals/detectors/common.js",
+      "path": ".agents/scripts/lib/reserved-test-ids.js",
       "lines": 100,
       "branches": 100,
       "functions": 100
     },
     {
-      "path": ".agents/scripts/lib/signals/detectors/hotspot.js",
-      "lines": 99.34,
-      "branches": 88.41,
+      "path": ".agents/scripts/lib/runtime-deps/ensure-installed.js",
+      "lines": 98,
+      "branches": 88.89,
+      "functions": 100
+    },
+    {
+      "path": ".agents/scripts/lib/runtime-deps/manifest.js",
+      "lines": 100,
+      "branches": 76.92,
+      "functions": 100
+    },
+    {
+      "path": ".agents/scripts/lib/runtime-deps/preflight.js",
+      "lines": 100,
+      "branches": 90.91,
+      "functions": 100
+    },
+    {
+      "path": ".agents/scripts/lib/runtime-deps/scan-imports.js",
+      "lines": 100,
+      "branches": 97.92,
+      "functions": 100
+    },
+    {
+      "path": ".agents/scripts/lib/signals/detectors/common.js",
+      "lines": 100,
+      "branches": 100,
       "functions": 100
     },
     {
@@ -2280,14 +2526,14 @@
     },
     {
       "path": ".agents/scripts/lib/signals/detectors/retry.js",
-      "lines": 97.92,
-      "branches": 78.85,
+      "lines": 98.42,
+      "branches": 73.53,
       "functions": 100
     },
     {
       "path": ".agents/scripts/lib/signals/detectors/rework.js",
-      "lines": 96.08,
-      "branches": 81.25,
+      "lines": 97.6,
+      "branches": 70.37,
       "functions": 100
     },
     {
@@ -2298,20 +2544,20 @@
     },
     {
       "path": ".agents/scripts/lib/signals/read.js",
-      "lines": 96.27,
-      "branches": 91.3,
+      "lines": 95.15,
+      "branches": 86.21,
       "functions": 100
     },
     {
       "path": ".agents/scripts/lib/signals/schema.js",
       "lines": 100,
-      "branches": 100,
+      "branches": 95.24,
       "functions": 100
     },
     {
       "path": ".agents/scripts/lib/signals/span-tree.js",
       "lines": 99.31,
-      "branches": 79.52,
+      "branches": 78.48,
       "functions": 100
     },
     {
@@ -2322,9 +2568,15 @@
     },
     {
       "path": ".agents/scripts/lib/single-story-sweep.js",
-      "lines": 96.66,
-      "branches": 84.62,
-      "functions": 100
+      "lines": 97.89,
+      "branches": 85.92,
+      "functions": 84.62
+    },
+    {
+      "path": ".agents/scripts/lib/single-story-sweep/protection-ctx.js",
+      "lines": 100,
+      "branches": 100,
+      "functions": 66.67
     },
     {
       "path": ".agents/scripts/lib/single-story-sweep/protection.js",
@@ -2334,9 +2586,15 @@
     },
     {
       "path": ".agents/scripts/lib/single-story-sweep/sweep-lock.js",
-      "lines": 92.31,
-      "branches": 85.19,
-      "functions": 100
+      "lines": 95.04,
+      "branches": 90.48,
+      "functions": 88.89
+    },
+    {
+      "path": ".agents/scripts/lib/single-story/confirm-merge.js",
+      "lines": 94.03,
+      "branches": 88.24,
+      "functions": 75
     },
     {
       "path": ".agents/scripts/lib/single-story/story-merged-notify.js",
@@ -2346,96 +2604,66 @@
     },
     {
       "path": ".agents/scripts/lib/skills/parse-skill.js",
-      "lines": 88.61,
-      "branches": 81.58,
+      "lines": 89.3,
+      "branches": 82.93,
       "functions": 100
     },
     {
       "path": ".agents/scripts/lib/skills/walk-skill-files.js",
       "lines": 96.43,
-      "branches": 80,
+      "branches": 78.57,
       "functions": 100
     },
     {
-      "path": ".agents/scripts/lib/spec/index.js",
+      "path": ".agents/scripts/lib/stdio-flush.js",
       "lines": 100,
-      "branches": 100,
-      "functions": 0
-    },
-    {
-      "path": ".agents/scripts/lib/spec/loader.js",
-      "lines": 98.35,
-      "branches": 88.24,
+      "branches": 75,
       "functions": 100
     },
     {
-      "path": ".agents/scripts/lib/spec/state.js",
+      "path": ".agents/scripts/lib/story-adjacency.js",
       "lines": 100,
-      "branches": 97.37,
+      "branches": 93.33,
+      "functions": 100
+    },
+    {
+      "path": ".agents/scripts/lib/story-body/body-format-lints.js",
+      "lines": 100,
+      "branches": 88.89,
       "functions": 100
     },
     {
       "path": ".agents/scripts/lib/story-body/story-body.js",
-      "lines": 99.71,
-      "branches": 88.32,
-      "functions": 100
-    },
-    {
-      "path": ".agents/scripts/lib/story-init/blocker-validator.js",
-      "lines": 100,
-      "branches": 94.74,
-      "functions": 100
-    },
-    {
-      "path": ".agents/scripts/lib/story-init/context-resolver.js",
-      "lines": 86.67,
-      "branches": 72.73,
-      "functions": 100
-    },
-    {
-      "path": ".agents/scripts/lib/story-init/donor-precheck.js",
-      "lines": 89.86,
-      "branches": 78.79,
-      "functions": 100
-    },
-    {
-      "path": ".agents/scripts/lib/story-init/hierarchy-tracer.js",
-      "lines": 100,
-      "branches": 100,
-      "functions": 100
-    },
-    {
-      "path": ".agents/scripts/lib/story-init/state-transitioner.js",
-      "lines": 100,
-      "branches": 87.5,
-      "functions": 100
-    },
-    {
-      "path": ".agents/scripts/lib/story-init/task-graph-builder.js",
-      "lines": 100,
-      "branches": 97.22,
-      "functions": 100
-    },
-    {
-      "path": ".agents/scripts/lib/story-init/transition-summary.js",
-      "lines": 100,
-      "branches": 100,
+      "lines": 99.34,
+      "branches": 94.92,
       "functions": 100
     },
     {
       "path": ".agents/scripts/lib/story-lifecycle.js",
-      "lines": 98.92,
-      "branches": 85.19,
+      "lines": 97.94,
+      "branches": 80,
       "functions": 100
     },
     {
-      "path": ".agents/scripts/lib/task-utils.js",
+      "path": ".agents/scripts/lib/story-plan.js",
+      "lines": 97.63,
+      "branches": 89.04,
+      "functions": 100
+    },
+    {
+      "path": ".agents/scripts/lib/temp-retention.js",
+      "lines": 98.95,
+      "branches": 92.11,
+      "functions": 100
+    },
+    {
+      "path": ".agents/scripts/lib/templates/decomposer-prompts.js",
       "lines": 100,
       "branches": 100,
       "functions": 100
     },
     {
-      "path": ".agents/scripts/lib/templates/decomposer-prompts.js",
+      "path": ".agents/scripts/lib/templates/spec-author-prompts.js",
       "lines": 100,
       "branches": 100,
       "functions": 100
@@ -2483,15 +2711,27 @@
       "functions": 100
     },
     {
-      "path": ".agents/scripts/lib/test-reserved-epic-temp-ids.js",
-      "lines": 100,
-      "branches": 100,
-      "functions": 100
+      "path": ".agents/scripts/lib/test-temp.js",
+      "lines": 99.36,
+      "branches": 93.55,
+      "functions": 87.5
     },
     {
       "path": ".agents/scripts/lib/test-tiers.js",
       "lines": 100,
-      "branches": 95.83,
+      "branches": 96.15,
+      "functions": 100
+    },
+    {
+      "path": ".agents/scripts/lib/ticket-body-sections.js",
+      "lines": 100,
+      "branches": 88.89,
+      "functions": 100
+    },
+    {
+      "path": ".agents/scripts/lib/transpile.js",
+      "lines": 93.64,
+      "branches": 81.13,
       "functions": 100
     },
     {
@@ -2503,13 +2743,13 @@
     {
       "path": ".agents/scripts/lib/util/phase-timer-state.js",
       "lines": 100,
-      "branches": 90.91,
+      "branches": 90,
       "functions": 100
     },
     {
       "path": ".agents/scripts/lib/util/phase-timer.js",
       "lines": 100,
-      "branches": 97.06,
+      "branches": 93.94,
       "functions": 100
     },
     {
@@ -2526,24 +2766,24 @@
     },
     {
       "path": ".agents/scripts/lib/validation-evidence.js",
-      "lines": 97.12,
-      "branches": 93.75,
+      "lines": 97.3,
+      "branches": 90.63,
       "functions": 100
     },
     {
-      "path": ".agents/scripts/lib/wave-runner/tick.js",
-      "lines": 96.41,
-      "branches": 88.27,
-      "functions": 100
-    },
-    {
-      "path": ".agents/scripts/lib/wave-runner/wave-checkpoint.js",
+      "path": ".agents/scripts/lib/wave-runner/live-probe.js",
       "lines": 100,
-      "branches": 89.19,
+      "branches": 88.14,
+      "functions": 87.5
+    },
+    {
+      "path": ".agents/scripts/lib/wave-runner/ready-set.js",
+      "lines": 100,
+      "branches": 95.05,
       "functions": 100
     },
     {
-      "path": ".agents/scripts/lib/wave-runner/wave-runner-error.js",
+      "path": ".agents/scripts/lib/workers/combined-mi-crap-worker.js",
       "lines": 100,
       "branches": 100,
       "functions": 100
@@ -2551,13 +2791,13 @@
     {
       "path": ".agents/scripts/lib/workers/crap-worker.js",
       "lines": 100,
-      "branches": 97.22,
+      "branches": 100,
       "functions": 100
     },
     {
       "path": ".agents/scripts/lib/workers/maintainability-report-worker.js",
-      "lines": 90.11,
-      "branches": 84.62,
+      "lines": 87.59,
+      "branches": 91.67,
       "functions": 100
     },
     {
@@ -2567,27 +2807,33 @@
       "functions": 100
     },
     {
+      "path": ".agents/scripts/lib/workflow-closure.js",
+      "lines": 99.07,
+      "branches": 89.9,
+      "functions": 100
+    },
+    {
       "path": ".agents/scripts/lib/workspace-provisioner.js",
-      "lines": 96.53,
-      "branches": 89.36,
+      "lines": 96.83,
+      "branches": 89.58,
       "functions": 100
     },
     {
       "path": ".agents/scripts/lib/worktree-manager.js",
-      "lines": 92.94,
-      "branches": 83.33,
-      "functions": 70
+      "lines": 90.95,
+      "branches": 79.31,
+      "functions": 68.42
     },
     {
       "path": ".agents/scripts/lib/worktree/bootstrapper.js",
-      "lines": 87.5,
-      "branches": 82.67,
-      "functions": 92.31
+      "lines": 100,
+      "branches": 85.71,
+      "functions": 83.33
     },
     {
       "path": ".agents/scripts/lib/worktree/inspector.js",
       "lines": 100,
-      "branches": 97.62,
+      "branches": 95,
       "functions": 100
     },
     {
@@ -2598,8 +2844,8 @@
     },
     {
       "path": ".agents/scripts/lib/worktree/lifecycle/creation.js",
-      "lines": 84.87,
-      "branches": 83.33,
+      "lines": 86.76,
+      "branches": 80,
       "functions": 100
     },
     {
@@ -2610,9 +2856,9 @@
     },
     {
       "path": ".agents/scripts/lib/worktree/lifecycle/force-drain.js",
-      "lines": 87.68,
-      "branches": 85.48,
-      "functions": 60
+      "lines": 89.62,
+      "branches": 82.8,
+      "functions": 71.43
     },
     {
       "path": ".agents/scripts/lib/worktree/lifecycle/gc.js",
@@ -2640,13 +2886,13 @@
     },
     {
       "path": ".agents/scripts/lib/worktree/lifecycle/reap.js",
-      "lines": 90.97,
-      "branches": 75.17,
-      "functions": 100
+      "lines": 91.46,
+      "branches": 77.06,
+      "functions": 96.3
     },
     {
       "path": ".agents/scripts/lib/worktree/lifecycle/registry-sync.js",
-      "lines": 92.39,
+      "lines": 94.35,
       "branches": 88.89,
       "functions": 100
     },
@@ -2657,28 +2903,58 @@
       "functions": 100
     },
     {
-      "path": ".agents/scripts/lifecycle-diff.js",
-      "lines": 83.21,
-      "branches": 81.36,
-      "functions": 100
-    },
-    {
-      "path": ".agents/scripts/lifecycle-emit-story-dispatch.js",
-      "lines": 71.13,
-      "branches": 54.55,
-      "functions": 50
-    },
-    {
-      "path": ".agents/scripts/lifecycle-emit.js",
-      "lines": 75,
-      "branches": 83.33,
-      "functions": 71.43
+      "path": ".agents/scripts/lint-issue-body.js",
+      "lines": 86.99,
+      "branches": 86.21,
+      "functions": 62.5
     },
     {
       "path": ".agents/scripts/lint-label-vocabulary.js",
       "lines": 94.51,
       "branches": 82.61,
       "functions": 100
+    },
+    {
+      "path": ".agents/scripts/mandrel-update-preflight.js",
+      "lines": 72.54,
+      "branches": 95.83,
+      "functions": 50
+    },
+    {
+      "path": ".agents/scripts/nav-registry-diff.js",
+      "lines": 100,
+      "branches": 99.21,
+      "functions": 100
+    },
+    {
+      "path": ".agents/scripts/plan-context.js",
+      "lines": 85.04,
+      "branches": 41.67,
+      "functions": 83.33
+    },
+    {
+      "path": ".agents/scripts/plan-critics.js",
+      "lines": 99.38,
+      "branches": 95.65,
+      "functions": 100
+    },
+    {
+      "path": ".agents/scripts/plan-persist.js",
+      "lines": 82.45,
+      "branches": 72,
+      "functions": 55.56
+    },
+    {
+      "path": ".agents/scripts/plan-run-epilogue.js",
+      "lines": 100,
+      "branches": 100,
+      "functions": 100
+    },
+    {
+      "path": ".agents/scripts/pr-watch-with-update.js",
+      "lines": 94.98,
+      "branches": 88.89,
+      "functions": 81.25
     },
     {
       "path": ".agents/scripts/providers/github.js",
@@ -2693,9 +2969,21 @@
       "functions": 100
     },
     {
+      "path": ".agents/scripts/providers/github/blocked-by-add.js",
+      "lines": 99.21,
+      "branches": 91.18,
+      "functions": 100
+    },
+    {
+      "path": ".agents/scripts/providers/github/board-add.js",
+      "lines": 100,
+      "branches": 93.33,
+      "functions": 100
+    },
+    {
       "path": ".agents/scripts/providers/github/branch-protection.js",
       "lines": 100,
-      "branches": 83.33,
+      "branches": 84.09,
       "functions": 100
     },
     {
@@ -2707,31 +2995,31 @@
     {
       "path": ".agents/scripts/providers/github/comments.js",
       "lines": 100,
-      "branches": 87.5,
+      "branches": 86.67,
       "functions": 100
     },
     {
       "path": ".agents/scripts/providers/github/compose.js",
-      "lines": 98.2,
+      "lines": 98.18,
       "branches": 100,
-      "functions": 66.67
+      "functions": 45
     },
     {
       "path": ".agents/scripts/providers/github/errors.js",
-      "lines": 99.59,
-      "branches": 98.11,
+      "lines": 99.64,
+      "branches": 92.98,
       "functions": 100
     },
     {
       "path": ".agents/scripts/providers/github/issues.js",
-      "lines": 91.11,
-      "branches": 79.17,
-      "functions": 91.67
+      "lines": 92.86,
+      "branches": 86,
+      "functions": 92.86
     },
     {
       "path": ".agents/scripts/providers/github/labels.js",
-      "lines": 98.26,
-      "branches": 89.47,
+      "lines": 98.32,
+      "branches": 89.66,
       "functions": 100
     },
     {
@@ -2748,15 +3036,15 @@
     },
     {
       "path": ".agents/scripts/providers/github/project-board.js",
-      "lines": 95.74,
+      "lines": 95.35,
       "branches": 100,
-      "functions": 80
+      "functions": 75
     },
     {
       "path": ".agents/scripts/providers/github/projects-v2-graphql.js",
-      "lines": 81.73,
-      "branches": 82.18,
-      "functions": 73.33
+      "lines": 79.41,
+      "branches": 75.82,
+      "functions": 76.47
     },
     {
       "path": ".agents/scripts/providers/github/prs.js",
@@ -2771,34 +3059,64 @@
       "functions": 100
     },
     {
+      "path": ".agents/scripts/providers/github/search-budget.js",
+      "lines": 100,
+      "branches": 100,
+      "functions": 85.71
+    },
+    {
+      "path": ".agents/scripts/providers/github/search-query.js",
+      "lines": 100,
+      "branches": 85.71,
+      "functions": 100
+    },
+    {
       "path": ".agents/scripts/providers/github/sub-issues.js",
-      "lines": 84.01,
-      "branches": 74.07,
+      "lines": 83.23,
+      "branches": 71.74,
       "functions": 100
     },
     {
       "path": ".agents/scripts/providers/github/tickets.js",
-      "lines": 97.55,
-      "branches": 80,
+      "lines": 99.49,
+      "branches": 85.94,
       "functions": 100
     },
     {
       "path": ".agents/scripts/quality-preview.js",
-      "lines": 96.94,
-      "branches": 79.1,
+      "lines": 97.33,
+      "branches": 82.28,
       "functions": 100
     },
     {
-      "path": ".agents/scripts/render-manifest.js",
-      "lines": 87.94,
-      "branches": 62.5,
-      "functions": 75
+      "path": ".agents/scripts/resolve-doc-tiers.js",
+      "lines": 97.17,
+      "branches": 100,
+      "functions": 66.67
+    },
+    {
+      "path": ".agents/scripts/resolve-stories.js",
+      "lines": 81.78,
+      "branches": 90.91,
+      "functions": 63.64
     },
     {
       "path": ".agents/scripts/resync-status-column.js",
-      "lines": 72.73,
-      "branches": 77.78,
-      "functions": 66.67
+      "lines": 79.89,
+      "branches": 82.35,
+      "functions": 83.33
+    },
+    {
+      "path": ".agents/scripts/run-coverage.js",
+      "lines": 65,
+      "branches": 50,
+      "functions": 50
+    },
+    {
+      "path": ".agents/scripts/run-lint.js",
+      "lines": 0,
+      "branches": 0,
+      "functions": 0
     },
     {
       "path": ".agents/scripts/run-test-profile.js",
@@ -2808,45 +3126,99 @@
     },
     {
       "path": ".agents/scripts/run-verify.js",
-      "lines": 89.29,
+      "lines": 94,
       "branches": 62.5,
       "functions": 50
     },
     {
       "path": ".agents/scripts/signals-view.js",
-      "lines": 90.14,
-      "branches": 65.71,
+      "lines": 90.61,
+      "branches": 68.12,
       "functions": 81.82
     },
     {
       "path": ".agents/scripts/single-story-close.js",
-      "lines": 98.76,
-      "branches": 81.82,
-      "functions": 100
+      "lines": 91.04,
+      "branches": 100,
+      "functions": 50
+    },
+    {
+      "path": ".agents/scripts/single-story-confirm-merge.js",
+      "lines": 81.08,
+      "branches": 55.77,
+      "functions": 77.78
     },
     {
       "path": ".agents/scripts/stories-wave-tick.js",
-      "lines": 98.36,
-      "branches": 94.34,
+      "lines": 98.45,
+      "branches": 94.12,
+      "functions": 100
+    },
+    {
+      "path": ".agents/scripts/story-plan.js",
+      "lines": 88.38,
+      "branches": 75.51,
+      "functions": 90
+    },
+    {
+      "path": ".agents/scripts/sync-agentrc.js",
+      "lines": 100,
+      "branches": 88.24,
       "functions": 100
     },
     {
       "path": ".agents/scripts/sync-branch-from-base.js",
-      "lines": 97.1,
+      "lines": 97.32,
       "branches": 71.43,
       "functions": 66.67
     },
     {
-      "path": ".agents/scripts/sync-claude-commands.js",
-      "lines": 93.41,
-      "branches": 44.44,
+      "path": ".agents/scripts/sync-claude-agents.js",
+      "lines": 95.15,
+      "branches": 73.68,
       "functions": 100
     },
     {
-      "path": ".agents/scripts/update-maintainability-baseline.js",
-      "lines": 81.56,
-      "branches": 42.86,
+      "path": ".agents/scripts/sync-claude-commands.js",
+      "lines": 99.31,
+      "branches": 95,
       "functions": 100
+    },
+    {
+      "path": ".agents/scripts/test-isolate.js",
+      "lines": 0,
+      "branches": 0,
+      "functions": 0
+    },
+    {
+      "path": ".agents/scripts/update-coverage-baseline.js",
+      "lines": 44.03,
+      "branches": 100,
+      "functions": 0
+    },
+    {
+      "path": ".agents/scripts/update-crap-baseline.js",
+      "lines": 39.04,
+      "branches": 100,
+      "functions": 0
+    },
+    {
+      "path": ".agents/scripts/update-duplication-baseline.js",
+      "lines": 55.36,
+      "branches": 100,
+      "functions": 0
+    },
+    {
+      "path": ".agents/scripts/update-maintainability-baseline.js",
+      "lines": 88.89,
+      "branches": 42.86,
+      "functions": 66.67
+    },
+    {
+      "path": ".agents/scripts/update-ticket-state.js",
+      "lines": 37.04,
+      "branches": 25,
+      "functions": 0
     },
     {
       "path": ".agents/scripts/validate-skills.js",
@@ -2855,14 +3227,8 @@
       "functions": 92.31
     },
     {
-      "path": ".agents/scripts/wave-tick.js",
-      "lines": 83.09,
-      "branches": 69.23,
-      "functions": 83.33
-    },
-    {
       "path": "bin/mandrel.js",
-      "lines": 94.91,
+      "lines": 95.1,
       "branches": 91.3,
       "functions": 100
     },
@@ -2874,9 +3240,9 @@
     },
     {
       "path": "lib/cli/doctor.js",
-      "lines": 98.8,
-      "branches": 95,
-      "functions": 62.5
+      "lines": 99.05,
+      "branches": 92.86,
+      "functions": 72.73
     },
     {
       "path": "lib/cli/explain.js",
@@ -2892,56 +3258,92 @@
     },
     {
       "path": "lib/cli/migrate.js",
-      "lines": 68.46,
-      "branches": 58.33,
-      "functions": 50
+      "lines": 100,
+      "branches": 91.18,
+      "functions": 75
     },
     {
       "path": "lib/cli/registry.js",
-      "lines": 93.11,
-      "branches": 86.73,
-      "functions": 91.3
+      "lines": 95.1,
+      "branches": 89.33,
+      "functions": 90
+    },
+    {
+      "path": "lib/cli/sync-agents.js",
+      "lines": 100,
+      "branches": 100,
+      "functions": 80
     },
     {
       "path": "lib/cli/sync-commands.js",
       "lines": 100,
       "branches": 100,
-      "functions": 100
+      "functions": 80
     },
     {
       "path": "lib/cli/sync.js",
-      "lines": 96.66,
-      "branches": 95.56,
+      "lines": 98.26,
+      "branches": 96.77,
       "functions": 100
     },
     {
       "path": "lib/cli/uninstall.js",
-      "lines": 95.18,
-      "branches": 83.06,
-      "functions": 75
+      "lines": 96.02,
+      "branches": 84.62,
+      "functions": 100
     },
     {
       "path": "lib/cli/update.js",
-      "lines": 73.63,
-      "branches": 56.41,
-      "functions": 55.88
+      "lines": 99.23,
+      "branches": 91.86,
+      "functions": 80.95
     },
     {
       "path": "lib/cli/version-check.js",
-      "lines": 91.75,
-      "branches": 77.78,
-      "functions": 60
+      "lines": 100,
+      "branches": 100,
+      "functions": 100
     },
     {
       "path": "lib/cli/version-helpers.js",
-      "lines": 96.61,
-      "branches": 87.5,
-      "functions": 66.67
+      "lines": 100,
+      "branches": 100,
+      "functions": 100
     },
     {
       "path": "lib/migrations/index.js",
-      "lines": 99.39,
-      "branches": 78.57,
+      "lines": 100,
+      "branches": 93.75,
+      "functions": 100
+    },
+    {
+      "path": "lib/migrations/steps/2.1.0-retire-mi-drop-knobs.js",
+      "lines": 100,
+      "branches": 88,
+      "functions": 100
+    },
+    {
+      "path": "lib/migrations/steps/2.1.0-retire-verify-concurrency-cap.js",
+      "lines": 100,
+      "branches": 82.35,
+      "functions": 100
+    },
+    {
+      "path": "lib/migrations/steps/2.11.0-retire-max-seed-words.js",
+      "lines": 100,
+      "branches": 85.71,
+      "functions": 100
+    },
+    {
+      "path": "lib/migrations/steps/2.2.0-retire-epic-ac-tags.js",
+      "lines": 100,
+      "branches": 92.11,
+      "functions": 100
+    },
+    {
+      "path": "lib/migrations/steps/2.20.0-retire-codebase-snapshot.js",
+      "lines": 100,
+      "branches": 83.33,
       "functions": 100
     }
   ]

--- a/baselines/coverage.json
+++ b/baselines/coverage.json
@@ -1,12 +1,12 @@
 {
   "$schema": ".agents/schemas/baselines/coverage.schema.json",
   "kernelVersion": "1.0.0",
-  "generatedAt": "2026-08-02T14:28:17.959Z",
+  "generatedAt": "2026-08-02T14:58:31.348Z",
   "rollup": {
     "*": {
-      "lines": 95.65,
-      "branches": 86.16,
-      "functions": 88.52
+      "lines": 95.67,
+      "branches": 86.19,
+      "functions": 88.57
     }
   },
   "rows": [
@@ -229,7 +229,7 @@
     {
       "path": ".agents/scripts/lib/audit-baselines/headroom.js",
       "lines": 100,
-      "branches": 72.22,
+      "branches": 78.95,
       "functions": 100
     },
     {
@@ -1561,19 +1561,19 @@
     {
       "path": ".agents/scripts/lib/orchestration/check-baselines/phases/compare.js",
       "lines": 91.33,
-      "branches": 77.78,
+      "branches": 80.3,
       "functions": 100
     },
     {
       "path": ".agents/scripts/lib/orchestration/check-baselines/phases/evaluate.js",
       "lines": 97.45,
-      "branches": 66.67,
+      "branches": 70.59,
       "functions": 100
     },
     {
       "path": ".agents/scripts/lib/orchestration/check-baselines/phases/floors.js",
       "lines": 100,
-      "branches": 82.54,
+      "branches": 82.26,
       "functions": 100
     },
     {
@@ -1591,7 +1591,7 @@
     {
       "path": ".agents/scripts/lib/orchestration/check-baselines/phases/pipeline.js",
       "lines": 100,
-      "branches": 92.68,
+      "branches": 92.86,
       "functions": 100
     },
     {
@@ -1705,7 +1705,7 @@
     {
       "path": ".agents/scripts/lib/orchestration/git-cleanup/phases/fast-forward.js",
       "lines": 94.27,
-      "branches": 87.5,
+      "branches": 87.88,
       "functions": 100
     },
     {
@@ -1716,9 +1716,9 @@
     },
     {
       "path": ".agents/scripts/lib/orchestration/git-cleanup/phases/git-probes-ff.js",
-      "lines": 68.68,
-      "branches": 75,
-      "functions": 68.75
+      "lines": 81.87,
+      "branches": 65,
+      "functions": 81.25
     },
     {
       "path": ".agents/scripts/lib/orchestration/git-cleanup/phases/git-probes.js",
@@ -2741,6 +2741,12 @@
       "functions": 100
     },
     {
+      "path": ".agents/scripts/lib/util/parse-id-list.js",
+      "lines": 100,
+      "branches": 100,
+      "functions": 100
+    },
+    {
       "path": ".agents/scripts/lib/util/phase-timer-state.js",
       "lines": 100,
       "branches": 90,
@@ -3096,7 +3102,7 @@
     },
     {
       "path": ".agents/scripts/resolve-stories.js",
-      "lines": 81.78,
+      "lines": 81.99,
       "branches": 90.91,
       "functions": 63.64
     },
@@ -3108,7 +3114,7 @@
     },
     {
       "path": ".agents/scripts/run-coverage.js",
-      "lines": 65,
+      "lines": 62.28,
       "branches": 50,
       "functions": 50
     },
@@ -3150,8 +3156,8 @@
     },
     {
       "path": ".agents/scripts/stories-wave-tick.js",
-      "lines": 98.45,
-      "branches": 94.12,
+      "lines": 98.44,
+      "branches": 93.75,
       "functions": 100
     },
     {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,8 @@
     "test:isolate": "node .agents/scripts/test-isolate.js",
     "verify": "node .agents/scripts/run-verify.js",
     "typecheck": "node -e \"process.exit(0)\"",
+    "//pretest-hooks": "The four pretest* entries are named preflight DEFINITIONS, not working npm hooks: .npmrc sets ignore-scripts=true (supply-chain defence), which suppresses every pre*/post* lifecycle script for `npm run` too. Callers that need the preflight invoke it by name — see the `Run Tests with Coverage` step in .github/workflows/ci.yml.",
+    "pretest:coverage": "node .agents/scripts/test-wrapper.js && node .agents/scripts/validate-skills.js",
     "test:coverage": "node .agents/scripts/run-coverage.js",
     "coverage:check": "node .agents/scripts/check-baselines.js --gate coverage",
     "coverage:update": "node .agents/scripts/update-coverage-baseline.js",

--- a/tests/baselines/scope.test.js
+++ b/tests/baselines/scope.test.js
@@ -1,10 +1,18 @@
 // tests/baselines/scope.test.js
 //
 // Story #1962 / Task #1970 — Lock the precedence ladder for the unified
-// `resolveScope({kind, configScope, configRef, cliFlags})` helper. Every
-// future per-kind regression CLI in Epic #1943 calls this exactly once
-// per run; the wrong precedence here would silently desync the
-// dispatcher's read scope from the writer's write scope.
+// `resolveScope({kind, configScope, configRef, envScope, envRef})` helper.
+// The check-baselines dispatcher calls it exactly once per gate per run;
+// the wrong precedence here silently changes which ref every gate compares
+// against.
+//
+// Story #4922 — the CLI/operator-override layer (`cliFlags.fullScope`,
+// `cliFlags.changedSinceRef`) and the `cliFlags.changedFiles` → `files`
+// plumbing were removed. Nothing in production ever populated them; only
+// this file did, which is how a shipped `--full-scope` / `--changed-since`
+// contract that `check-baselines.js` never implemented stayed green for
+// nine Stories. The tests below now assert the layer is GONE — a resolver
+// that starts honouring those keys again would break these.
 
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
@@ -12,27 +20,12 @@ import { describe, it } from 'node:test';
 import { resolveScope } from '../../.agents/scripts/lib/baselines/scope.js';
 
 describe('resolveScope — full mode (acceptance)', () => {
-  it("returns mode='full', files=Set(), ref=null when configScope='full'", () => {
+  it("returns mode='full', ref=null when configScope='full'", () => {
     const r = resolveScope({ kind: 'lint', configScope: 'full' });
     assert.equal(r.kind, 'lint');
     assert.equal(r.mode, 'full');
     assert.equal(r.ref, null);
-    assert.ok(r.files instanceof Set);
-    assert.equal(r.files.size, 0);
     assert.equal(r.source, 'config:gateScoping.scope=full');
-  });
-
-  it("CLI --full-scope flag forces mode='full' even when config says diff", () => {
-    const r = resolveScope({
-      kind: 'crap',
-      configScope: 'diff',
-      configRef: 'main',
-      cliFlags: { fullScope: true },
-    });
-    assert.equal(r.mode, 'full');
-    assert.equal(r.ref, null);
-    assert.equal(r.files.size, 0);
-    assert.equal(r.source, 'cli:--full-scope');
   });
 
   it("env BASELINE_SCOPE='full' forces mode='full' over config diff", () => {
@@ -40,7 +33,7 @@ describe('resolveScope — full mode (acceptance)', () => {
       kind: 'coverage',
       configScope: 'diff',
       configRef: 'epic/1943',
-      cliFlags: { envScope: 'full' },
+      envScope: 'full',
     });
     assert.equal(r.mode, 'full');
     assert.equal(r.ref, null);
@@ -54,28 +47,12 @@ describe('resolveScope — full mode (acceptance)', () => {
 });
 
 describe('resolveScope — precedence layers', () => {
-  it('CLI --changed-since beats env, config, and default', () => {
-    const r = resolveScope({
-      kind: 'mutation',
-      configScope: 'diff',
-      configRef: 'main',
-      cliFlags: {
-        changedSinceRef: 'epic/1943',
-        envRef: 'origin/main',
-        envScope: 'diff',
-      },
-    });
-    assert.equal(r.mode, 'diff');
-    assert.equal(r.ref, 'epic/1943');
-    assert.equal(r.source, 'cli:--changed-since');
-  });
-
-  it('env BASELINE_REF beats config when no CLI flag is set', () => {
+  it('env BASELINE_REF beats config', () => {
     const r = resolveScope({
       kind: 'lighthouse',
       configScope: 'diff',
       configRef: 'main',
-      cliFlags: { envRef: 'origin/main' },
+      envRef: 'origin/main',
     });
     assert.equal(r.mode, 'diff');
     assert.equal(r.ref, 'origin/main');
@@ -110,10 +87,7 @@ describe('resolveScope — missing-ref fallback', () => {
   });
 
   it("env scope='diff' with no envRef falls back to ref=main", () => {
-    const r = resolveScope({
-      kind: 'coverage',
-      cliFlags: { envScope: 'diff' },
-    });
+    const r = resolveScope({ kind: 'coverage', envScope: 'diff' });
     assert.equal(r.mode, 'diff');
     assert.equal(r.ref, 'main');
     assert.equal(r.source, 'env:BASELINE_SCOPE=diff');
@@ -124,7 +98,7 @@ describe('resolveScope — missing-ref fallback', () => {
       kind: 'lint',
       configScope: 'diff',
       configRef: '',
-      cliFlags: { changedSinceRef: '', envRef: '' },
+      envRef: '',
     });
     assert.equal(r.mode, 'diff');
     assert.equal(r.ref, 'main');
@@ -132,38 +106,52 @@ describe('resolveScope — missing-ref fallback', () => {
   });
 });
 
-describe('resolveScope — diff-vs-full inputs', () => {
-  it('forwards changedFiles into files Set in diff mode', () => {
-    const r = resolveScope({
-      kind: 'lint',
-      configScope: 'diff',
-      configRef: 'main',
-      cliFlags: {
-        changedFiles: ['src/a.ts', 'src/b.ts', 'src/a.ts'],
-      },
-    });
-    assert.equal(r.mode, 'diff');
-    assert.deepEqual([...r.files].sort(), ['src/a.ts', 'src/b.ts']);
+describe('resolveScope — the operator-override layer is gone (#4922)', () => {
+  it('does not ship a files Set — no consumer ever read one', () => {
+    const r = resolveScope({ kind: 'lint', configScope: 'diff' });
+    assert.equal(
+      Object.hasOwn(r, 'files'),
+      false,
+      'resolveScope must not advertise a `files` set: the only reader of a ' +
+        'scope-scoped file list is mergeRowsByScope, fed by the refresh ' +
+        "service's own resolver",
+    );
   });
 
-  it('drops non-string entries from changedFiles defensively', () => {
+  it('ignores a cliFlags.fullScope override entirely', () => {
     const r = resolveScope({
       kind: 'crap',
       configScope: 'diff',
       configRef: 'main',
-      cliFlags: { changedFiles: ['ok.ts', 42, null, '', 'also-ok.ts'] },
+      cliFlags: { fullScope: true },
     });
-    assert.deepEqual([...r.files].sort(), ['also-ok.ts', 'ok.ts']);
+    assert.equal(r.mode, 'diff');
+    assert.equal(r.ref, 'main');
+    assert.equal(r.source, 'config:gateScoping.diffRef');
   });
 
-  it('ignores changedFiles in full mode (files is always empty)', () => {
+  it('ignores a cliFlags.changedSinceRef override entirely', () => {
+    const r = resolveScope({
+      kind: 'mutation',
+      configScope: 'diff',
+      configRef: 'main',
+      cliFlags: { changedSinceRef: 'epic/1943' },
+    });
+    assert.equal(r.ref, 'main');
+    assert.equal(r.source, 'config:gateScoping.diffRef');
+  });
+
+  it('does not read env values nested under cliFlags', () => {
+    // The dispatcher now passes envScope/envRef at the top level. A caller
+    // still nesting them under cliFlags gets the default, loudly, rather
+    // than a silently half-resolved scope.
     const r = resolveScope({
       kind: 'lint',
-      configScope: 'full',
-      cliFlags: { changedFiles: ['ignored.ts'] },
+      cliFlags: { envScope: 'full', envRef: 'origin/main' },
     });
-    assert.equal(r.mode, 'full');
-    assert.equal(r.files.size, 0);
+    assert.equal(r.mode, 'diff');
+    assert.equal(r.ref, 'main');
+    assert.equal(r.source, 'default');
   });
 });
 
@@ -185,13 +173,10 @@ describe('resolveScope — input hardening', () => {
     assert.equal(r.source, 'config:gateScoping.diffRef');
   });
 
-  it('accepts a Set as changedFiles input', () => {
-    const r = resolveScope({
-      kind: 'lint',
-      configScope: 'diff',
-      configRef: 'main',
-      cliFlags: { changedFiles: new Set(['x.ts']) },
-    });
-    assert.deepEqual([...r.files], ['x.ts']);
+  it('ignores unknown envScope values', () => {
+    const r = resolveScope({ kind: 'lint', envScope: 'partial' });
+    assert.equal(r.mode, 'diff');
+    assert.equal(r.ref, 'main');
+    assert.equal(r.source, 'default');
   });
 });

--- a/tests/c8rc-scope.test.js
+++ b/tests/c8rc-scope.test.js
@@ -1,0 +1,266 @@
+// tests/c8rc-scope.test.js
+//
+// Story #4922 — the coverage scope is a contract between three files that
+// must agree, and it used to be declared twice inside one of them.
+//
+//   1. `.c8rc.cjs`      — what `c8 report` instruments and prints.
+//   2. `.agentrc.json`  — `delivery.quality.gates.<crap|maintainability|
+//                          duplication>.targetDirs`, the configured target
+//                          directories the quality gates police. The
+//                          coverage gate's own schema is closed and carries
+//                          no `targetDirs` of its own (see
+//                          `lib/config/gates/coverage.schema.js`), so these
+//                          are the repository's target-dir declaration — and
+//                          the CRAP gate joins coverage rows with complexity
+//                          rows across exactly this set, so a file c8 does
+//                          not measure silently drops out of that join.
+//   3. each excluded source — its `node:coverage ignore file` pragma, the
+//                          second line of defence when the two configs are
+//                          read from different cwds.
+//
+// When (1) and (2) drift, the gate polices a surface the reporter never
+// measured — which is exactly how a coverage instrument reports green over
+// code it has never executed.
+
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import { createRequire } from 'node:module';
+import path from 'node:path';
+import { describe, test } from 'node:test';
+
+import { buildScopePredicate } from '../.agents/scripts/lib/coverage-baseline.js';
+
+const require = createRequire(import.meta.url);
+const REPO_ROOT = path.resolve(import.meta.dirname, '..');
+const C8RC_PATH = path.join(REPO_ROOT, '.c8rc.cjs');
+
+const c8rc = require(C8RC_PATH);
+const agentrc = JSON.parse(
+  fs.readFileSync(path.join(REPO_ROOT, '.agentrc.json'), 'utf8'),
+);
+const gates = agentrc.delivery?.quality?.gates ?? {};
+const TARGET_DIR_GATES = ['crap', 'maintainability', 'duplication'];
+
+const SOURCE_EXT = new Set(['.js', '.mjs', '.cjs']);
+
+/**
+ * Every source file c8 is configured to instrument, walked from the same
+ * include/exclude declaration `c8 report` is handed. Mirrors the scope
+ * predicate rather than restating it.
+ */
+function enumerateInScopeSources() {
+  const inScope = buildScopePredicate({
+    include: c8rc.include,
+    exclude: c8rc.exclude,
+  });
+  const roots = c8rc.include.map((g) => g.replace(/\/\*\*$/, ''));
+  const out = [];
+  const walk = (dir) => {
+    for (const ent of fs.readdirSync(path.join(REPO_ROOT, dir), {
+      withFileTypes: true,
+    })) {
+      const rel = `${dir}/${ent.name}`;
+      if (ent.isDirectory()) {
+        if (ent.name === 'node_modules') continue;
+        walk(rel);
+      } else if (SOURCE_EXT.has(path.extname(ent.name)) && inScope(rel)) {
+        out.push(rel);
+      }
+    }
+  };
+  for (const root of roots) walk(root);
+  return out.sort();
+}
+
+describe('.c8rc.cjs — declared scope matches the configured target dirs', () => {
+  test('the coverage gate is configured at all', () => {
+    // A missing `coverage` block makes `check-baselines.js --gate coverage`
+    // select zero gates and exit 0 unconditionally (Story #4922).
+    assert.ok(
+      gates.coverage && typeof gates.coverage === 'object',
+      'delivery.quality.gates.coverage must be configured',
+    );
+    assert.ok(gates.coverage.floors?.['*'], 'coverage needs a `*` floor');
+  });
+
+  test('the target-dir declaration is consistent across every gate', () => {
+    const declared = TARGET_DIR_GATES.map((k) => gates[k]?.targetDirs);
+    for (const [i, dirs] of declared.entries()) {
+      assert.ok(
+        Array.isArray(dirs) && dirs.length > 0,
+        `gate ${TARGET_DIR_GATES[i]} must declare targetDirs`,
+      );
+      assert.deepEqual(
+        [...dirs].sort(),
+        [...declared[0]].sort(),
+        `gate ${TARGET_DIR_GATES[i]} polices a different target-dir set than ` +
+          `${TARGET_DIR_GATES[0]} — the CRAP join reads coverage and ` +
+          'complexity over one surface, not two',
+      );
+    }
+  });
+
+  test('every c8 include glob is a configured target dir', () => {
+    const includeRoots = c8rc.include.map((g) => g.replace(/\/\*\*$/, ''));
+    assert.deepEqual(
+      [...includeRoots].sort(),
+      [...gates[TARGET_DIR_GATES[0]].targetDirs].sort(),
+      'the c8 include globs and the configured quality-gate targetDirs name ' +
+        'different roots — the gates would police a surface c8 never measured',
+    );
+  });
+
+  test('every c8 include glob is a recursive root glob', () => {
+    for (const glob of c8rc.include) {
+      assert.match(
+        glob,
+        /\/\*\*$/,
+        `include glob ${glob} must end in /** so the whole root is measured`,
+      );
+    }
+  });
+
+  test('every configured target dir exists on disk', () => {
+    for (const dir of gates[TARGET_DIR_GATES[0]].targetDirs) {
+      assert.ok(
+        fs.existsSync(path.join(REPO_ROOT, dir)),
+        `targetDir ${dir} does not exist`,
+      );
+    }
+  });
+
+  test('c8 measures every in-scope source file (all: true)', () => {
+    // Without `all`, a module no test loads is absent from
+    // coverage-final.json entirely — no row, no floor, nothing to regress.
+    assert.equal(
+      c8rc.all,
+      true,
+      '.c8rc.cjs must set `all: true` so an unloaded source file scores 0 ' +
+        'rather than vanishing from the measurement',
+    );
+  });
+});
+
+describe('baselines/coverage.json covers exactly the declared scope', () => {
+  const baseline = JSON.parse(
+    fs.readFileSync(path.join(REPO_ROOT, 'baselines', 'coverage.json'), 'utf8'),
+  );
+  const inScope = enumerateInScopeSources();
+  const rowPaths = new Set(baseline.rows.map((r) => r.path));
+
+  test('no row names a path absent from the tree', () => {
+    const ghosts = baseline.rows
+      .map((r) => r.path)
+      .filter((p) => !fs.existsSync(path.join(REPO_ROOT, p)));
+    assert.deepEqual(
+      ghosts,
+      [],
+      `${ghosts.length} baseline rows name files that no longer exist. A ` +
+        'baseline scored against a deleted tree is not a measurement; ' +
+        're-run `npm run test:coverage && npm run coverage:update -- --full-scope`.',
+    );
+  });
+
+  test('every in-scope source file has a row', () => {
+    const missing = inScope.filter((f) => !rowPaths.has(f));
+    assert.deepEqual(
+      missing,
+      [],
+      `${missing.length} in-scope source files have no baseline row, so they ` +
+        'have no floor and nothing to regress against.',
+    );
+  });
+
+  test('the rollup is the arithmetic mean of the rows it summarises', () => {
+    // The floors are checked against `rollup["*"]`, not against rows. If the
+    // stored rollup drifts from the rows, the gate polices a number nothing
+    // produced.
+    for (const axis of ['lines', 'branches', 'functions']) {
+      const mean =
+        baseline.rows.reduce((s, r) => s + (r[axis] ?? 0), 0) /
+        baseline.rows.length;
+      assert.ok(
+        Math.abs(mean - baseline.rollup['*'][axis]) < 0.02,
+        `rollup["*"].${axis}=${baseline.rollup['*'][axis]} does not match the ` +
+          `row mean ${mean.toFixed(2)}`,
+      );
+    }
+  });
+});
+
+describe('.c8rc.cjs — the scope is declared exactly once', () => {
+  const source = fs.readFileSync(C8RC_PATH, 'utf8');
+
+  test('no exclude path is restated anywhere else in the file', () => {
+    // The header used to carry a prose inventory of the exclude list, so the
+    // scope was declared twice in one file and the copies drifted (27 files
+    // apart by the time Story #4922 measured it). Rationale now lives inline
+    // next to the path it justifies, where it cannot drift.
+    const restated = c8rc.exclude.filter(
+      (entry) => source.split(entry).length - 1 !== 1,
+    );
+    assert.deepEqual(
+      restated,
+      [],
+      `these exclude paths appear more than once in .c8rc.cjs — the scope is ` +
+        `declared twice: ${restated.join(', ')}`,
+    );
+  });
+
+  test('every exclude entry carries a rationale comment', () => {
+    const lines = source.split('\n');
+    for (const entry of c8rc.exclude) {
+      const idx = lines.findIndex((l) => l.includes(`'${entry}'`));
+      assert.ok(idx > 0, `exclude entry ${entry} not found as a literal line`);
+      // Walk back over the contiguous run of comment lines and sibling path
+      // literals; at least one comment must govern the group.
+      let cursor = idx - 1;
+      let rationale = false;
+      while (cursor >= 0) {
+        const line = lines[cursor].trim();
+        if (line.startsWith('//')) {
+          rationale = true;
+          break;
+        }
+        if (!line.startsWith("'")) break;
+        cursor -= 1;
+      }
+      assert.ok(
+        rationale,
+        `exclude entry ${entry} has no inline rationale — a bare path with ` +
+          `no justification is a review block`,
+      );
+    }
+  });
+});
+
+describe('.c8rc.cjs — excluded files carry the source-side pragma', () => {
+  test('every excluded file exists and declares node:coverage ignore file', () => {
+    const missing = [];
+    const unpragmad = [];
+    for (const entry of c8rc.exclude) {
+      if (entry.includes('*')) continue; // directory globs have no single source
+      const abs = path.join(REPO_ROOT, entry);
+      if (!fs.existsSync(abs)) {
+        missing.push(entry);
+        continue;
+      }
+      if (!fs.readFileSync(abs, 'utf8').includes('node:coverage ignore file')) {
+        unpragmad.push(entry);
+      }
+    }
+    assert.deepEqual(missing, [], `excluded paths not on disk: ${missing}`);
+    assert.deepEqual(
+      unpragmad,
+      [],
+      `excluded files missing the /* node:coverage ignore file */ pragma: ${unpragmad}`,
+    );
+  });
+
+  // The converse does NOT hold and must not be asserted: many in-scope files
+  // carry the pragma without being c8-excluded. The pragma only governs
+  // Node's built-in `--experimental-test-coverage`; c8 reads V8's dumps and
+  // still measures those files. Promoting every pragma'd file into
+  // `exclude[]` would SHRINK the measured surface — the opposite of what
+  // Story #4922 exists to fix.
+});

--- a/tests/ci-workflow-stderr-capture.test.js
+++ b/tests/ci-workflow-stderr-capture.test.js
@@ -47,3 +47,52 @@ test('CI workflow Run Tests with Coverage step preserves stderr-capture regressi
     'Coverage step must still invoke `npm run test:coverage`.',
   );
 });
+
+// ---------------------------------------------------------------------------
+// Story #4922 — the coverage instrument's CI wiring.
+// ---------------------------------------------------------------------------
+
+test('the coverage step runs the pretest preflight explicitly', () => {
+  const source = readFileSync(CI_WORKFLOW, 'utf8');
+  const step = getTestCoverageStep(source);
+  assert.match(
+    step,
+    /npm run pretest:coverage/,
+    "The coverage step must invoke the preflight by name. npm's `pre<script>` " +
+      'hook cannot be relied on here: .npmrc sets ignore-scripts=true, which ' +
+      'suppresses every pre*/post* lifecycle script for `npm run` as well as ' +
+      'for installs, so `pretest:coverage` never fires as a hook.',
+  );
+  assert.ok(
+    step.indexOf('npm run pretest:coverage') <
+      step.indexOf('npm run test:coverage 2>&1'),
+    'the preflight must run BEFORE the measured suite',
+  );
+});
+
+test('the worktree-manager real-git contract executes in a CI job', () => {
+  const source = readFileSync(CI_WORKFLOW, 'utf8');
+  assert.match(
+    source,
+    /tests\/lib\/worktree-manager\.integration\.test\.js/,
+    'tests/lib/worktree-manager.integration.test.js must be invoked by a CI ' +
+      'job. It is integration-tier (so `test:quick` on the Windows leg skips ' +
+      'it) and its drive-letter-case guard is win32-gated, so without an ' +
+      'explicit Windows invocation that assertion runs in no job at all.',
+  );
+});
+
+test('the Windows leg is where the win32-gated guard runs', () => {
+  const source = readFileSync(CI_WORKFLOW, 'utf8');
+  const windowsJob = source.slice(source.indexOf('  windows-smoke:'));
+  assert.ok(
+    windowsJob.length > 0,
+    'windows-smoke job not found in .github/workflows/ci.yml',
+  );
+  assert.match(
+    windowsJob,
+    /tests\/lib\/worktree-manager\.integration\.test\.js/,
+    'the worktree-manager contract must run on the Windows leg — its ' +
+      'drive-letter-case regression only reproduces there',
+  );
+});

--- a/tests/contract/coverage-gate-enabled.test.js
+++ b/tests/contract/coverage-gate-enabled.test.js
@@ -1,0 +1,218 @@
+// tests/contract/coverage-gate-enabled.test.js
+//
+// Story #4922 — the coverage gate must be able to FAIL.
+//
+// Before this Story `delivery.quality.gates.coverage` was absent from
+// `.agentrc.json`, and `selectEnabledGates` treats a missing gate block as
+// disabled. `check-baselines.js --gate coverage` therefore selected zero
+// gates and exited 0 unconditionally: `npm run coverage:check` was green in
+// every possible state of the repository, including a baseline of pure
+// zeroes. A gate that cannot fail is worse than no gate, because it is
+// trusted.
+//
+// These tests drive the REAL `.agentrc.json` floors against the REAL
+// `baselines/coverage.json`, copied into a synthetic git repo so the
+// head-vs-base compare arm has a base to read. Using the shipped config —
+// not a fixture — is the point: a fixture would keep passing if someone
+// deleted the coverage block again.
+
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import { after, before, describe, it } from 'node:test';
+
+import { getQuality } from '../../.agents/scripts/lib/config-resolver.js';
+import {
+  runCheckBaselines,
+  selectEnabledGates,
+} from '../../.agents/scripts/lib/orchestration/check-baselines/phases/pipeline.js';
+import { makeTempDir } from '../../.agents/scripts/lib/test-temp.js';
+
+const REPO_ROOT = path.resolve(import.meta.dirname, '..', '..');
+const DISPATCHER = path.join(
+  REPO_ROOT,
+  '.agents',
+  'scripts',
+  'check-baselines.js',
+);
+const REAL_AGENTRC = JSON.parse(
+  fs.readFileSync(path.join(REPO_ROOT, '.agentrc.json'), 'utf8'),
+);
+const REAL_BASELINE = JSON.parse(
+  fs.readFileSync(path.join(REPO_ROOT, 'baselines', 'coverage.json'), 'utf8'),
+);
+
+const EXIT_PASS = 0;
+const EXIT_FLOOR = 1;
+
+// Drop every GIT_* var so a fixture `git init` under a husky hook cannot
+// inherit the parent checkout's GIT_DIR (#4580).
+const CLEAN_ENV = Object.fromEntries(
+  Object.entries(process.env).filter(([k]) => !k.startsWith('GIT_')),
+);
+
+function runGit(args, cwd) {
+  const res = spawnSync('git', args, {
+    cwd,
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+    env: CLEAN_ENV,
+  });
+  if (res.status !== 0) {
+    throw new Error(`git ${args.join(' ')} failed: ${res.stderr}`);
+  }
+}
+
+function writeJson(p, value) {
+  fs.writeFileSync(p, JSON.stringify(value, null, 2));
+}
+
+/**
+ * Build a git repo carrying the repository's real agentrc + real coverage
+ * baseline on `main`, so the dispatcher's base read resolves.
+ */
+function setupRepo(agentrc = REAL_AGENTRC) {
+  const root = makeTempDir('coverage-gate-');
+  fs.mkdirSync(path.join(root, 'baselines'), { recursive: true });
+  writeJson(path.join(root, '.agentrc.json'), agentrc);
+  writeJson(path.join(root, 'baselines', 'coverage.json'), REAL_BASELINE);
+  runGit(['init', '--initial-branch=main'], root);
+  runGit(['config', 'user.email', 'contract@example.com'], root);
+  runGit(['config', 'user.name', 'contract'], root);
+  runGit(['config', 'commit.gpgsign', 'false'], root);
+  runGit(['add', '.agentrc.json', 'baselines/coverage.json'], root);
+  runGit(['commit', '-m', 'baseline: initial'], root);
+  return root;
+}
+
+/**
+ * Spawn the real binary — this is the exit-code contract `npm run
+ * coverage:check` and the CI `baselines` job actually consume. Text format:
+ * the JSON report over 556 rows exceeds the pipe buffer and comes back
+ * truncated, so the structured assertions go through `reportFor` instead.
+ */
+function runGate(cwd) {
+  return spawnSync(
+    process.execPath,
+    [DISPATCHER, '--gate', 'coverage', '--no-friction', '--format', 'text'],
+    { cwd, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] },
+  );
+}
+
+/** In-process run of the same pipeline, for assertions on the report shape. */
+function reportFor(cwd) {
+  return runCheckBaselines({
+    argv: ['--gate', 'coverage', '--no-friction'],
+    cwd,
+  });
+}
+
+describe('coverage gate — selection', () => {
+  it('the shipped config selects the coverage gate', () => {
+    const gates = selectEnabledGates(getQuality(REAL_AGENTRC));
+    assert.ok(
+      gates.includes('coverage'),
+      'delivery.quality.gates.coverage must be configured — a missing block ' +
+        'makes `check-baselines.js --gate coverage` a no-op that exits 0',
+    );
+  });
+
+  it('a config WITHOUT the coverage block selects zero gates (the old bug)', () => {
+    // The contrast case. This is precisely the state `.agentrc.json` was in
+    // before Story #4922, and it is why `npm run coverage:check` could never
+    // report anything.
+    const stripped = structuredClone(REAL_AGENTRC);
+    delete stripped.delivery.quality.gates.coverage;
+    const gates = selectEnabledGates(getQuality(stripped));
+    assert.equal(gates.includes('coverage'), false);
+  });
+
+  it('the shipped floors declare all three coverage axes', () => {
+    const floors = REAL_AGENTRC.delivery.quality.gates.coverage.floors['*'];
+    for (const axis of ['lines', 'branches', 'functions']) {
+      assert.equal(
+        typeof floors[axis],
+        'number',
+        `coverage floor '${axis}' must be a number`,
+      );
+    }
+  });
+});
+
+describe('coverage gate — floors are derived from the regenerated baseline', () => {
+  it('every floor sits at or below the measured rollup it was derived from', () => {
+    const floors = REAL_AGENTRC.delivery.quality.gates.coverage.floors['*'];
+    const measured = REAL_BASELINE.rollup['*'];
+    for (const axis of ['lines', 'branches', 'functions']) {
+      assert.ok(
+        floors[axis] <= measured[axis],
+        `coverage floor ${axis}=${floors[axis]} exceeds the measured ` +
+          `rollup ${measured[axis]} — a floor above the measurement fails on ` +
+          'the very run it was configured from',
+      );
+      // ...and not so far below it that the floor is decorative. The
+      // 90/85/90 example in .agents/docs/agentrc-reference.json is validated
+      // only against itself; these floors track the real number.
+      assert.ok(
+        measured[axis] - floors[axis] <= 5,
+        `coverage floor ${axis}=${floors[axis]} is more than 5 points below ` +
+          `the measured ${measured[axis]} — that much slack makes the floor ` +
+          'unable to catch a real drop',
+      );
+    }
+  });
+});
+
+describe('coverage gate — it can actually fail', () => {
+  let root;
+
+  before(() => {
+    root = setupRepo();
+  });
+
+  after(() => {
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  it('passes on the real baseline with the real floors', async () => {
+    const res = runGate(root);
+    assert.equal(
+      res.status,
+      EXIT_PASS,
+      `expected exit 0 on the shipped baseline; stdout=${res.stdout} stderr=${res.stderr}`,
+    );
+    const { report } = await reportFor(root);
+    assert.equal(report.gates.length, 1, 'exactly one gate must be selected');
+    assert.equal(report.gates[0].kind, 'coverage');
+    assert.equal(report.totalBreaches, 0);
+  });
+
+  for (const axis of ['lines', 'branches', 'functions']) {
+    it(`fails when the measured ${axis} rollup drops below its floor`, async () => {
+      const floor =
+        REAL_AGENTRC.delivery.quality.gates.coverage.floors['*'][axis];
+      const poisoned = structuredClone(REAL_BASELINE);
+      poisoned.rollup['*'][axis] = floor - 0.01;
+      writeJson(path.join(root, 'baselines', 'coverage.json'), poisoned);
+
+      const res = runGate(root);
+      assert.equal(
+        res.status,
+        EXIT_FLOOR,
+        `expected exit ${EXIT_FLOOR} with ${axis} below floor ${floor}; ` +
+          `stdout=${res.stdout} stderr=${res.stderr}`,
+      );
+      const { report, exitCode } = await reportFor(root);
+      assert.equal(exitCode, EXIT_FLOOR);
+      assert.equal(report.totalBreaches, 1);
+      assert.deepEqual(
+        report.gates[0].breaches.map((b) => b.axis),
+        [axis],
+      );
+
+      // Restore for the next case.
+      writeJson(path.join(root, 'baselines', 'coverage.json'), REAL_BASELINE);
+    });
+  }
+});

--- a/tests/lib/orchestration/git-cleanup-phase-drivers-decide.test.js
+++ b/tests/lib/orchestration/git-cleanup-phase-drivers-decide.test.js
@@ -3,9 +3,14 @@
  * (Story #2994 CRAP-30+ refactor).
  *
  * These tests cover every branch of the decision logic without any
- * git, prompt, or filesystem I/O. The companion impure executeXPhase
- * functions are exercised through the existing integration suites
- * (`tests/scripts/git-cleanup*.test.js`).
+ * git, prompt, or filesystem I/O.
+ *
+ * The companion impure `executeXPhase` functions live in
+ * `git-cleanup-phase-drivers-execute.test.js`. This header used to claim
+ * they were "exercised through the existing integration suites
+ * (tests/scripts/git-cleanup*.test.js)" — they were not: those suites
+ * drive `planCleanup` / `executeCleanup` and the CLI pipeline, never the
+ * three phase sequencers. Story #4922 wrote the missing suite.
  */
 
 import assert from 'node:assert/strict';

--- a/tests/lib/orchestration/git-cleanup-phase-drivers-execute.test.js
+++ b/tests/lib/orchestration/git-cleanup-phase-drivers-execute.test.js
@@ -1,0 +1,309 @@
+/**
+ * Unit tests for the IMPURE half of `phase-drivers.js` — the
+ * `execute*Phase` functions and the `runStashPhase` sequencer.
+ *
+ * Story #4922. The decide* companions have had a suite since #2994, whose
+ * header asserted that "the companion impure executeXPhase functions are
+ * exercised through the existing integration suites". They were not:
+ * `tests/scripts/git-cleanup*.test.js` drives `planCleanup` /
+ * `executeCleanup` and the CLI pipeline, never these three sequencers. The
+ * claim is why nobody noticed — a file can look covered by assertion alone.
+ *
+ * Every execute path here is driven through the injected seams the
+ * underlying phase modules already expose (`checkoutFn` / `mergeFn` /
+ * `deleteLocalFn` / …), so no test in this file spawns git.
+ */
+
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import {
+  executeBranchPhase,
+  executeFastForwardPhase,
+  executeStashPhase,
+  runStashPhase,
+} from '../../../.agents/scripts/lib/orchestration/git-cleanup/phases/phase-drivers.js';
+import { makeTempDir } from '../../../.agents/scripts/lib/test-temp.js';
+
+const ok = () => ({ ok: true });
+
+// ---------------------------------------------------------------------
+// executeFastForwardPhase
+// ---------------------------------------------------------------------
+
+describe('executeFastForwardPhase', () => {
+  it('returns the decided result verbatim on the skip action', async () => {
+    const result = {
+      ok: true,
+      applied: false,
+      skipped: true,
+      reason: 'dirty-tree',
+      behind: 0,
+    };
+    const out = await executeFastForwardPhase({
+      kind: 'skip',
+      result,
+      logMessage: '[git-cleanup] skipped',
+    });
+    assert.deepEqual(out, result);
+  });
+
+  it('returns the decided result verbatim on the dry-run action', async () => {
+    const result = {
+      ok: true,
+      applied: false,
+      skipped: true,
+      reason: 'dry-run',
+      behind: 4,
+    };
+    const out = await executeFastForwardPhase({ kind: 'dry-run', result });
+    assert.deepEqual(out, result);
+  });
+
+  it('tolerates a skip/dry-run action carrying no logMessage', async () => {
+    const result = { ok: true, applied: false, skipped: true, behind: 0 };
+    assert.deepEqual(
+      await executeFastForwardPhase({ kind: 'skip', result }),
+      result,
+    );
+  });
+
+  it('performs the fast-forward on the execute action', async () => {
+    const merged = [];
+    const out = await executeFastForwardPhase({
+      kind: 'execute',
+      executeArgs: {
+        cwd: '/repo',
+        baseBranch: 'main',
+        plan: { runnable: true, behind: 2, currentBranch: 'main' },
+        checkoutFn: () => ok(),
+        mergeFn: (_cwd, ref) => {
+          merged.push(ref);
+          return ok();
+        },
+        logger: { info() {}, warn() {} },
+      },
+    });
+    assert.deepEqual(merged, ['origin/main']);
+    assert.deepEqual(out, {
+      ok: true,
+      applied: true,
+      skipped: false,
+      behind: 2,
+    });
+  });
+
+  it('surfaces a failed merge as ok:false rather than throwing', async () => {
+    const out = await executeFastForwardPhase({
+      kind: 'execute',
+      executeArgs: {
+        cwd: '/repo',
+        baseBranch: 'main',
+        plan: { runnable: true, behind: 1, currentBranch: 'main' },
+        checkoutFn: () => ok(),
+        mergeFn: () => ({ ok: false, stderr: 'diverged' }),
+        logger: { info() {}, warn() {} },
+      },
+    });
+    assert.equal(out.ok, false);
+    assert.equal(out.reason, 'merge-failed');
+  });
+
+  it('throws on an unsupported action kind', async () => {
+    await assert.rejects(
+      () => executeFastForwardPhase({ kind: 'prompt-then-execute' }),
+      /unsupported action kind 'prompt-then-execute'/,
+    );
+  });
+});
+
+// ---------------------------------------------------------------------
+// executeBranchPhase
+// ---------------------------------------------------------------------
+
+describe('executeBranchPhase', () => {
+  it('returns the decided result verbatim on the dry-run action', async () => {
+    const plan = { candidates: [] };
+    const result = { plan, result: null };
+    const out = await executeBranchPhase({ kind: 'dry-run', plan, result });
+    assert.deepEqual(out, result);
+  });
+
+  it('returns the decided result verbatim on the no-candidates action', async () => {
+    const plan = { candidates: [] };
+    const result = { plan, result: null };
+    const out = await executeBranchPhase({
+      kind: 'no-candidates',
+      plan,
+      result,
+    });
+    assert.deepEqual(out, result);
+  });
+
+  it('reaps the candidates and returns {plan, result} on execute', async () => {
+    const deleted = [];
+    const plan = { candidates: [{ branch: 'story-1' }] };
+    const out = await executeBranchPhase({
+      kind: 'execute',
+      plan,
+      executeArgs: {
+        candidates: plan.candidates,
+        cwd: '/repo',
+        remote: false,
+        removeWorktreeFn: () => ok(),
+        deleteLocalFn: (branch) => {
+          deleted.push(branch);
+          return { deleted: true };
+        },
+        deleteRemoteFn: () => ok(),
+        logger: { info() {}, warn() {}, error() {} },
+      },
+    });
+    assert.deepEqual(deleted, ['story-1']);
+    assert.equal(out.plan, plan);
+    assert.equal(out.result.ok, true);
+    assert.deepEqual(
+      out.result.local.map((r) => r.branch),
+      ['story-1'],
+    );
+  });
+
+  it('reports a failed local delete without throwing', async () => {
+    const plan = { candidates: [{ branch: 'story-2' }] };
+    const out = await executeBranchPhase({
+      kind: 'execute',
+      plan,
+      executeArgs: {
+        candidates: plan.candidates,
+        cwd: '/repo',
+        remote: false,
+        removeWorktreeFn: () => ok(),
+        deleteLocalFn: () => ({
+          deleted: false,
+          reason: 'not-merged',
+          stderr: 'not fully merged',
+        }),
+        deleteRemoteFn: () => ok(),
+        logger: { info() {}, warn() {}, error() {} },
+      },
+    });
+    assert.equal(out.result.ok, false);
+  });
+
+  it('throws on an unsupported action kind', async () => {
+    await assert.rejects(
+      () => executeBranchPhase({ kind: 'prompt-then-execute' }),
+      /unsupported action kind 'prompt-then-execute'/,
+    );
+  });
+});
+
+// ---------------------------------------------------------------------
+// executeStashPhase
+// ---------------------------------------------------------------------
+
+describe('executeStashPhase', () => {
+  it('returns the decided result verbatim on the no-stashes action', async () => {
+    const result = { ok: true, actions: [], failures: [] };
+    const out = await executeStashPhase({ kind: 'no-stashes', result });
+    assert.deepEqual(out, result);
+  });
+
+  it('returns the decided result verbatim on the dry-run action', async () => {
+    const result = {
+      ok: true,
+      actions: [{ ref: 'stash@{0}', action: 'keep' }],
+      failures: [],
+    };
+    const out = await executeStashPhase({
+      kind: 'dry-run',
+      stashes: [{ ref: 'stash@{0}' }],
+      result,
+    });
+    assert.deepEqual(out, result);
+  });
+
+  it('keeps every stash when the allowlist is empty', async () => {
+    const out = await executeStashPhase({
+      kind: 'execute-allowlist',
+      executeArgs: {
+        cwd: '/repo',
+        stashes: [
+          { ref: 'stash@{0}', message: 'a' },
+          { ref: 'stash@{1}', message: 'b' },
+        ],
+        allowlist: [],
+      },
+    });
+    assert.equal(out.ok, true);
+    assert.deepEqual(
+      out.actions.map((a) => a.action),
+      ['keep', 'keep'],
+    );
+    // High index first — git renumbers from the top of the stack.
+    assert.deepEqual(
+      out.actions.map((a) => a.ref),
+      ['stash@{1}', 'stash@{0}'],
+    );
+  });
+
+  it('drops only the allowlisted refs', async () => {
+    // `cwd` points at an empty scratch dir, so the real `git stash drop`
+    // the allowlist path reaches fails deterministically — which is the
+    // failure branch the phase must surface rather than throw.
+    const cwd = makeTempDir('stash-phase-');
+    const out = await executeStashPhase({
+      kind: 'execute-allowlist',
+      executeArgs: {
+        cwd,
+        stashes: [
+          { ref: 'stash@{0}', message: 'keep me' },
+          { ref: 'stash@{1}', message: 'drop me' },
+        ],
+        allowlist: ['stash@{1}'],
+      },
+    });
+    const byRef = Object.fromEntries(out.actions.map((a) => [a.ref, a]));
+    assert.equal(byRef['stash@{0}'].action, 'keep');
+    assert.equal(byRef['stash@{1}'].action, 'drop');
+    assert.equal(byRef['stash@{1}'].dropped, false);
+    assert.equal(out.ok, false);
+    assert.equal(out.failures.length, 1);
+  });
+
+  it('runs the interactive engine without prompting when there are no stashes', async () => {
+    const out = await executeStashPhase({
+      kind: 'execute-interactive',
+      executeArgs: { cwd: '/repo', stashes: [] },
+    });
+    assert.deepEqual(out, { ok: true, actions: [], failures: [] });
+  });
+
+  it('throws on an unsupported action kind', async () => {
+    await assert.rejects(
+      () => executeStashPhase({ kind: 'prompt-then-decide' }),
+      /unsupported action kind 'prompt-then-decide'/,
+    );
+  });
+});
+
+// ---------------------------------------------------------------------
+// runStashPhase — the sequencer whose `node:coverage ignore` directive
+// Story #4922 removed. `planStashes` degrades to an empty list when
+// `git stash list` cannot run, so the no-stash path is drivable against a
+// plain scratch directory.
+// ---------------------------------------------------------------------
+
+describe('runStashPhase', () => {
+  it('short-circuits with an empty result when no stashes exist', async () => {
+    const cwd = makeTempDir('stash-run-');
+    const out = await runStashPhase({ dryRun: false, yes: true }, cwd);
+    assert.deepEqual(out, { ok: true, actions: [], failures: [] });
+  });
+
+  it('short-circuits the same way under --dry-run', async () => {
+    const cwd = makeTempDir('stash-run-dry-');
+    const out = await runStashPhase({ dryRun: true }, cwd);
+    assert.deepEqual(out, { ok: true, actions: [], failures: [] });
+  });
+});

--- a/tests/lib/test-tiers.test.js
+++ b/tests/lib/test-tiers.test.js
@@ -2,8 +2,10 @@ import assert from 'node:assert/strict';
 import fs from 'node:fs';
 import path from 'node:path';
 import { test } from 'node:test';
+import picomatch from 'picomatch';
 import { makeTempDir } from '../../.agents/scripts/lib/test-temp.js';
 import {
+  FULL_TIER_GLOBS,
   INTEGRATION_INCLUDE,
   listTestFilesForTier,
   parseTierArgv,
@@ -136,5 +138,64 @@ test('every curated INTEGRATION_INCLUDE entry resolves to a file on disk', () =>
     missing,
     [],
     `curated integration entries name files that do not exist: ${missing.join(', ')}`,
+  );
+});
+
+// ---------------------------------------------------------------------------
+// Story #4922 — FULL_TIER_GLOBS is the single source of truth for the full
+// tier's file set, and it has two consumers: run-tests.js (via
+// listTestFilesForTier) and run-coverage.js. The coverage runner used to
+// restate `tests/**/*.test.js` on its own, so the colocated __tests__ suites
+// ran under `npm test` but were invisible to every coverage / CRAP reading.
+// ---------------------------------------------------------------------------
+
+test('FULL_TIER_GLOBS names one glob per test walk root', () => {
+  assert.ok(Array.isArray(FULL_TIER_GLOBS));
+  assert.deepEqual(FULL_TIER_GLOBS, [
+    'tests/**/*.test.js',
+    'lib/**/__tests__/**/*.test.js',
+    '.agents/scripts/**/__tests__/**/*.test.js',
+  ]);
+});
+
+test('listTestFilesForTier("full") returns exactly FULL_TIER_GLOBS', () => {
+  const root = makeTempDir('tier-full-');
+  assert.deepEqual(listTestFilesForTier('full', root), [...FULL_TIER_GLOBS]);
+  fs.rmSync(root, { recursive: true, force: true });
+});
+
+test('every FULL_TIER_GLOB matches at least one real test file', () => {
+  const repoRoot = path.resolve(import.meta.dirname, '..', '..');
+  const all = listTestFilesForTier('quick', repoRoot).concat(
+    listTestFilesForTier('integration', repoRoot),
+  );
+  for (const glob of FULL_TIER_GLOBS) {
+    const isMatch = picomatch(glob, { dot: true });
+    assert.ok(
+      all.some((f) => isMatch(f)),
+      `full-tier glob ${glob} matches no file on disk — the tier walks a surface that does not exist`,
+    );
+  }
+});
+
+test('the coverage runner consumes FULL_TIER_GLOBS rather than a literal', () => {
+  const repoRoot = path.resolve(import.meta.dirname, '..', '..');
+  const src = fs.readFileSync(
+    path.join(repoRoot, '.agents', 'scripts', 'run-coverage.js'),
+    'utf8',
+  );
+  assert.ok(
+    /FULL_TIER_GLOBS/.test(src),
+    'run-coverage.js must import FULL_TIER_GLOBS',
+  );
+  // No glob literal of its own: a bare quoted `*.test.js` target in the
+  // executable body is exactly the drift this SSOT exists to prevent.
+  const code = src
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .replace(/^\s*\/\/.*$/gm, '');
+  assert.equal(
+    /['"`][^'"`]*\*[^'"`]*\.test\.js['"`]/.test(code),
+    false,
+    'run-coverage.js restates a test glob literal instead of consuming FULL_TIER_GLOBS',
   );
 });

--- a/tests/scripts/run-coverage.test.js
+++ b/tests/scripts/run-coverage.test.js
@@ -1,5 +1,6 @@
 import assert from 'node:assert/strict';
 import { test } from 'node:test';
+import { FULL_TIER_GLOBS } from '../../.agents/scripts/lib/test-tiers.js';
 import { buildCoverageTestArgs } from '../../.agents/scripts/run-coverage.js';
 import {
   resolveTestConcurrency,
@@ -65,8 +66,46 @@ test('buildCoverageTestArgs honours an injected clamped runner-flag set', () => 
   assert.ok(!args.includes('--test-concurrency=8'));
 });
 
-test('buildCoverageTestArgs targets the full test glob after the runner flags', () => {
+// ---------------------------------------------------------------------------
+// Story #4922 — the coverage runner must target the SAME file set the full
+// tier runs. It previously restated `tests/**/*.test.js` as its own literal,
+// so the colocated `__tests__` suites under lib/ and .agents/scripts/ ran
+// under `npm test` but were absent from every coverage and CRAP reading.
+// ---------------------------------------------------------------------------
+
+test('buildCoverageTestArgs targets every full-tier glob after the runner flags', () => {
   const args = buildCoverageTestArgs();
-  assert.equal(args.at(-1), 'tests/**/*.test.js');
   assert.ok(args.includes('--test'));
+
+  // The trailing positionals are exactly FULL_TIER_GLOBS, in order.
+  assert.deepEqual(args.slice(-FULL_TIER_GLOBS.length), [...FULL_TIER_GLOBS]);
+
+  // Every runner flag still precedes the first positional.
+  const firstGlobIdx = args.indexOf(FULL_TIER_GLOBS[0]);
+  assert.equal(firstGlobIdx, args.length - FULL_TIER_GLOBS.length);
+});
+
+test('buildCoverageTestArgs restates no glob literal of its own', () => {
+  // Injecting a sentinel glob set proves the builder has no hardcoded
+  // fallback target: nothing but the injected globs reaches the argv tail.
+  const args = buildCoverageTestArgs({ testGlobs: ['sentinel/**/*.test.js'] });
+  assert.equal(args.at(-1), 'sentinel/**/*.test.js');
+  assert.ok(
+    !args.some((a) => a.includes('tests/**')),
+    'coverage argv must not carry a hardcoded tests/** literal',
+  );
+});
+
+test('buildCoverageTestArgs covers the colocated __tests__ roots', () => {
+  const args = buildCoverageTestArgs();
+  assert.ok(
+    args.some((a) => a.startsWith('lib/') && a.includes('__tests__')),
+    'coverage argv must reach the colocated lib/ __tests__ suites',
+  );
+  assert.ok(
+    args.some(
+      (a) => a.startsWith('.agents/scripts/') && a.includes('__tests__'),
+    ),
+    'coverage argv must reach the colocated .agents/scripts/ __tests__ suites',
+  );
 });


### PR DESCRIPTION
Closes #4922

_Auto-opened by `/deliver`._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how CI measures coverage and enables a gate that can fail the build on rollup regressions; scope is quality/CI infrastructure rather than auth or data handling, but the widened surface and new 0% rows will surface follow-on test work.
> 
> **Overview**
> **Makes the coverage pipeline measure the same tests `npm test` runs and actually fail when rollup floors are missed** — previously the coverage gate block was missing from `.agentrc.json`, `check-baselines --gate coverage` was a no-op, and the measuring run only walked `tests/**` while colocated `__tests__` suites did not execute under coverage.
> 
> **Measurement alignment:** `run-coverage.js` now uses exported `FULL_TIER_GLOBS` from `test-tiers.js`; `.c8rc.cjs` sets `all: true` and consolidates exclude rationales inline; `c8 report` forwards `--all` from config. **`baselines/coverage.json` is reseeded** with many more per-file rows (including explicit 0% for previously invisible modules).
> 
> **Gate configuration:** Adds `delivery.quality.gates.coverage` rollup floors (94 / 85 / 87 lines/branches/functions). Docs now describe **repo rollup** floors, not per-file. New contract tests (`tests/c8rc-scope.test.js`, `tests/contract/coverage-gate-enabled.test.js`) lock scope parity and that the gate can exit non-zero.
> 
> **CI / npm:** Ubuntu coverage step runs `npm run pretest:coverage` explicitly because `ignore-scripts=true` disables npm `pre*` hooks; adds `worktree-manager.integration.test.js` on Ubuntu and Windows smoke. **`resolveScope`** drops unused CLI `--full-scope` / `changed-since` precedence; dispatcher passes `envScope`/`envRef` at top level.
> 
> **Test debt:** Removes bogus `node:coverage ignore` on `runStashPhase`; adds `git-cleanup-phase-drivers-execute.test.js` for impure phase drivers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cbc105c2b0001c2485605ebd44fbf6aca4064132. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->