### PR TITLE
fix(baselines): settle the exit through runAsCli so a piped report is not truncated

### DIFF
--- a/.agents/scripts/check-baseline-drift.js
+++ b/.agents/scripts/check-baseline-drift.js
@@ -118,21 +118,34 @@ export async function runCheckBaselineDrift({
   return { exitCode: run.ok ? 0 : 1, output };
 }
 
+/**
+ * Run the drift check and *return* its exit code rather than calling
+ * `process.exit()` — this CLI prints one row per drifted baseline entry
+ * full-scope, so its report is exactly the kind of payload that outgrows the
+ * 64 KiB pipe buffer under a `| tee`. `process.exit()` terminates before a
+ * queued async pipe write drains, silently truncating it (Story #4783, the
+ * same defect `check-baselines.js` carried). Handing the code back lets
+ * `runAsCli`'s `propagateExitCode` path settle it through
+ * `settleCli`/`flushStdio` instead. The 0/1/2 contract documented at the top
+ * of this file is unchanged — only *when* the process leaves is.
+ *
+ * @returns {Promise<number>} 0 no drift, 1 drift detected, 2 could not run.
+ */
 async function main() {
   let result;
   try {
     result = await runCheckBaselineDrift({ argv: process.argv.slice(2) });
   } catch (err) {
     process.stdout.write(`${err?.message ?? String(err)}\n`);
-    process.exit(2);
-    return;
+    return 2;
   }
   process.stdout.write(`${result.output}\n`);
-  process.exit(result.exitCode);
+  return result.exitCode;
 }
 
 runAsCli(import.meta.url, main, {
   source: 'check-baseline-drift',
   usage: HELP_TEXT,
   exitCode: 2,
+  propagateExitCode: true,
 });

--- a/.agents/scripts/check-baselines.js
+++ b/.agents/scripts/check-baselines.js
@@ -65,6 +65,22 @@ export {
   selectEnabledGates,
 };
 
+/**
+ * Run the dispatcher and *return* its exit code rather than calling
+ * `process.exit()`.
+ *
+ * The return is load-bearing (Story #4783's defect, reintroduced here):
+ * `process.exit()` terminates before a queued async pipe write drains, so a
+ * full `--gate coverage` report — a quarter of a megabyte of JSON — arrived
+ * truncated at the 64 KiB pipe boundary under the `| tee` in CI's coverage
+ * step, while still exiting 0. Handing the code back to `runAsCli`'s
+ * `propagateExitCode` path settles it through `settleCli`/`flushStdio`
+ * instead, which assigns `process.exitCode` and lets Node terminate once
+ * stdout has drained. The 0/1/2/3/4 contract in `lib/baselines/exit-codes.js`
+ * is unchanged — only *when* the process leaves is.
+ *
+ * @returns {Promise<number>} An exit code from the `EXIT_*` contract.
+ */
 async function main() {
   let result;
   try {
@@ -74,14 +90,14 @@ async function main() {
     process.stdout.write(
       `${JSON.stringify({ schemaVersion: '1', error: message }, null, 2)}\n`,
     );
-    process.exit(EXIT_CONFIG);
-    return;
+    return EXIT_CONFIG;
   }
   process.stdout.write(`${result.output}\n`);
-  process.exit(result.exitCode);
+  return result.exitCode;
 }
 
 runAsCli(import.meta.url, main, {
   source: 'check-baselines',
   usage: HELP_TEXT,
+  propagateExitCode: true,
 });

--- a/tests/check-baselines-pipe-flush.test.js
+++ b/tests/check-baselines-pipe-flush.test.js
@@ -1,0 +1,320 @@
+// tests/check-baselines-pipe-flush.test.js
+//
+// check-baselines must not truncate its own report when stdout is a pipe.
+//
+// Story #4783 removed the eager `process.exit()` from `runAsCli`'s shared
+// settle path precisely because it terminates before a queued async pipe
+// write drains — "any CLI emitting more than 64 KiB into a pipe truncated
+// silently". `check-baselines.js` adopted `runAsCli` but kept calling
+// `process.exit()` from inside its own `main()`, on both the success arm and
+// the EXIT_CONFIG catch arm, which reinstated the defect for the one gate
+// whose report is routinely a quarter of a megabyte.
+//
+// Observed: CI's coverage step is `npm run test:coverage 2>&1 | tee
+// test-output.txt`, so the verdict was cut off mid-object in both the Actions
+// log and the uploaded artifact, ending on a dangling `"functions": 1` with
+// no npm error block — which reads as a crash and misdirects triage.
+//
+// As in `tests/cli-utils-exit-flush.test.js`, these spawn a real child
+// process: `process.stdout` is synchronous on a TTY and on a file and only
+// goes asynchronous once the 64 KiB kernel pipe buffer fills, so the
+// truncation cannot be reproduced by stubbing `process.exit` in-process.
+//
+// Invariants pinned here:
+//   - A >64 KiB report read by a slow pipe reader arrives complete and parses
+//     as JSON (the defect: valid-prefix-then-nothing, still exit 0).
+//   - Piping does not change the exit code — a piped run and a
+//     redirected-to-file run agree on both bytes and status.
+//   - The EXIT_CONFIG (3) catch arm still exits 3 now that it returns rather
+//     than calling `process.exit()`.
+//   - Structurally: `check-baselines.js` holds no `process.exit()` callsite.
+
+import assert from 'node:assert/strict';
+import { execFileSync, spawn, spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import test, { after, before, describe } from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+import { currentKernelVersion } from '../.agents/scripts/lib/baselines/kernel.js';
+import { makeTempDir } from '../.agents/scripts/lib/test-temp.js';
+
+const CLI = fileURLToPath(
+  new URL('../.agents/scripts/check-baselines.js', import.meta.url),
+);
+
+/** One kernel pipe buffer on Linux and macOS — the truncation boundary. */
+const PIPE_BUFFER = 64 * 1024;
+
+/**
+ * Rows in the fixture baseline. The compare arm emits one entry per row, so
+ * this is what pushes the report clear of `PIPE_BUFFER`. The test asserts
+ * that precondition rather than trusting it, so a future report-shape change
+ * cannot quietly make this file pass vacuously.
+ */
+const ROW_COUNT = 900;
+
+const BASELINE_REL = 'baselines/maintainability.json';
+
+// Env with every `GIT_*` variable dropped. Under a husky pre-push from a
+// linked worktree, git exports GIT_DIR pointing at the shared main gitdir —
+// a fixture `git init` under that env writes `core.bare=true` into the MAIN
+// checkout's `.git/config` (#4580).
+const CLEAN_ENV = Object.fromEntries(
+  Object.entries(process.env).filter(([k]) => !k.startsWith('GIT_')),
+);
+
+// `realpathSync`: on macOS `os.tmpdir()` is a symlink, and config resolution
+// compares resolved paths — the fixture root must be the resolved one.
+const TMP = fs.realpathSync(makeTempDir('check-baselines-pipe-flush-'));
+
+/** @type {string} */
+let root;
+
+after(() => {
+  fs.rmSync(TMP, { recursive: true, force: true });
+});
+
+/**
+ * A throwaway repo whose single enabled gate is a maintainability baseline of
+ * `ROW_COUNT` long-pathed rows, committed at `origin/main` and identical in
+ * the working tree. Floor-clean and regression-free by construction, so the
+ * only thing under test is that a large report survives the pipe: every row
+ * lands in the compare arm's `unchanged` list, which is what makes the
+ * rendered JSON exceed one pipe buffer.
+ *
+ * @returns {string} Absolute path to the fixture root.
+ */
+function setupBulkRepo() {
+  const dir = path.join(TMP, 'bulk-repo');
+  fs.mkdirSync(path.join(dir, 'baselines'), { recursive: true });
+  const git = (...args) =>
+    execFileSync('git', args, {
+      cwd: dir,
+      stdio: ['pipe', 'pipe', 'pipe'],
+      encoding: 'utf-8',
+      env: CLEAN_ENV,
+    });
+
+  const rows = Array.from({ length: ROW_COUNT }, (_, i) => ({
+    path: `src/module-${String(i).padStart(4, '0')}/deeply/nested/segment/file-name.js`,
+    mi: 80 + (i % 10),
+  }));
+  fs.writeFileSync(
+    path.join(dir, BASELINE_REL),
+    JSON.stringify(
+      {
+        $schema: '.agents/schemas/baselines/maintainability.schema.json',
+        kernelVersion: currentKernelVersion('maintainability'),
+        generatedAt: '2026-01-01T00:00:00.000Z',
+        rollup: { '*': { min: 80, p50: 90, p95: 100 } },
+        rows,
+      },
+      null,
+      2,
+    ),
+  );
+  fs.writeFileSync(
+    path.join(dir, '.agentrc.json'),
+    JSON.stringify(
+      {
+        project: {
+          baseBranch: 'main',
+          paths: { agentRoot: '.agents', docsRoot: 'docs', tempRoot: 'temp' },
+          docsContextFiles: [],
+          commands: { lintBaseline: 'echo', test: 'echo', typecheck: 'echo' },
+        },
+        github: { owner: 'x', repo: 'y', operatorHandle: '@ci' },
+        delivery: {
+          quality: {
+            gates: {
+              maintainability: {
+                enabled: true,
+                baselinePath: BASELINE_REL,
+                tolerance: { kind: 'absolute', value: 0.5 },
+                floors: { '*': { min: 70 } },
+              },
+            },
+          },
+        },
+      },
+      null,
+      2,
+    ),
+  );
+
+  git('init', '-q', '-b', 'main');
+  git('add', BASELINE_REL, '.agentrc.json');
+  execFileSync(
+    'git',
+    [
+      '-c',
+      'user.email=test@example.com',
+      '-c',
+      'user.name=Test',
+      '-c',
+      'commit.gpgsign=false',
+      'commit',
+      '-q',
+      '-m',
+      'seed baseline',
+    ],
+    { cwd: dir, stdio: ['pipe', 'pipe', 'pipe'], env: CLEAN_ENV },
+  );
+  // The compare arm reads `origin/<baseBranch>`; point the remote-tracking
+  // ref at the local commit so `git show` resolves it without a remote.
+  git('update-ref', 'refs/remotes/origin/main', 'main');
+
+  return dir;
+}
+
+before(() => {
+  root = setupBulkRepo();
+});
+
+/**
+ * Spawn the CLI with stdout on a pipe and collect everything that reaches
+ * the reader.
+ *
+ * @param {string[]} argv Arguments after the script path.
+ * @param {{ slow?: boolean }} [opts] `slow` holds stdout paused so the child
+ *   fills the pipe buffer and reaches its exit path with bytes still queued —
+ *   the window the eager `process.exit()` discarded — then drains it in
+ *   delayed slices. Only meaningful for a payload larger than `PIPE_BUFFER`:
+ *   a child whose whole output fits in the buffer exits while the stream is
+ *   still paused, and Node tears the pipe down with the buffered bytes
+ *   unread, which would fail for a reason unrelated to the defect.
+ * @returns {Promise<{ code: number, stdout: string, stderr: string }>}
+ */
+async function runPiped(argv, { slow = false } = {}) {
+  const child = spawn(process.execPath, [CLI, ...argv], {
+    cwd: root,
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+
+  let stderr = '';
+  child.stderr.setEncoding('utf8');
+  child.stderr.on('data', (chunk) => {
+    stderr += chunk;
+  });
+
+  const exited = new Promise((resolve) => {
+    child.on('close', (code) => resolve(code));
+  });
+
+  if (slow) {
+    child.stdout.pause();
+    await new Promise((resolve) => setTimeout(resolve, 300));
+  }
+
+  let stdout = '';
+  for await (const chunk of child.stdout) {
+    stdout += chunk.toString('utf8');
+    if (slow) await new Promise((resolve) => setTimeout(resolve, 5));
+  }
+
+  return { code: await exited, stdout, stderr };
+}
+
+describe('check-baselines: stdout on a pipe', () => {
+  test('a >64 KiB report survives a slow pipe reader intact', async () => {
+    const { code, stdout, stderr } = await runPiped(['--no-friction'], {
+      slow: true,
+    });
+
+    assert.ok(
+      Buffer.byteLength(stdout, 'utf8') > PIPE_BUFFER,
+      `fixture too small to exercise the defect: ${Buffer.byteLength(stdout, 'utf8')} bytes ` +
+        `does not exceed one ${PIPE_BUFFER}-byte pipe buffer (stderr: ${stderr})`,
+    );
+
+    // The pre-fix binary delivered a valid *prefix* — one pipe buffer's worth
+    // of well-formed JSON text that stops mid-object — so the assertion has
+    // to be that the document parses, not that output was non-empty.
+    let report;
+    assert.doesNotThrow(
+      () => {
+        report = JSON.parse(stdout);
+      },
+      `report truncated at the pipe boundary (${Buffer.byteLength(stdout, 'utf8')} bytes)`,
+    );
+    assert.equal(report.schemaVersion, '1');
+    assert.ok(
+      Array.isArray(report.gates),
+      'the report carries its gates array',
+    );
+    assert.equal(code, 0, `expected a green gate; stderr: ${stderr}`);
+  });
+
+  test('piping changes neither the byte count nor the exit code', async () => {
+    const piped = await runPiped(['--no-friction'], { slow: true });
+
+    // stdout on a file is synchronous, so this leg is the uncorrupted
+    // reference the piped leg has to match exactly.
+    const redirect = path.join(TMP, 'redirect.json');
+    const fd = fs.openSync(redirect, 'w');
+    const direct = spawnSync(process.execPath, [CLI, '--no-friction'], {
+      cwd: root,
+      stdio: ['ignore', fd, 'pipe'],
+      encoding: 'utf8',
+    });
+    fs.closeSync(fd);
+    const onFile = fs.readFileSync(redirect, 'utf8');
+
+    assert.equal(
+      Buffer.byteLength(piped.stdout, 'utf8'),
+      Buffer.byteLength(onFile, 'utf8'),
+      'a pipe must deliver the same bytes a file redirect does',
+    );
+    assert.equal(piped.stdout, onFile);
+    assert.equal(
+      piped.code,
+      direct.status,
+      'the exit code must not depend on what stdout is attached to',
+    );
+  });
+
+  test('the EXIT_CONFIG arm still exits 3 through a pipe', async () => {
+    // `--format` pre-validation throws before any gate runs, which is the
+    // catch arm that used to call `process.exit(EXIT_CONFIG)` directly.
+    const { code, stdout } = await runPiped([
+      '--no-friction',
+      '--format',
+      'bogus',
+    ]);
+
+    assert.equal(code, 3, `expected EXIT_CONFIG; stdout: ${stdout}`);
+    const report = JSON.parse(stdout);
+    assert.equal(report.schemaVersion, '1');
+    assert.match(report.error, /--format expects "json" or "text"/);
+  });
+
+  // The defect is a property of the source — `main()` bypassing the shared
+  // non-eager settle path — so pin the source, not only the behaviour.
+  // Mirrors the structural guard `cli-utils.js` carries for the same bug.
+  //
+  // `check-baseline-drift.js` is included because it is the same `main()`
+  // verbatim (write `result.output`, `process.exit(result.exitCode)`, plus a
+  // catch arm) over an equally unbounded payload — it prints one row per
+  // drifted baseline entry full-scope.
+  for (const rel of [
+    '.agents/scripts/check-baselines.js',
+    '.agents/scripts/check-baseline-drift.js',
+  ]) {
+    test(`${rel} contains no process.exit call`, () => {
+      const source = fs.readFileSync(
+        fileURLToPath(new URL(`../${rel}`, import.meta.url)),
+        'utf8',
+      );
+      const code = source
+        .replace(/\/\*[\s\S]*?\*\//g, '')
+        .replace(/(^|[^:])\/\/[^\n]*/g, '$1');
+      assert.equal(
+        /process\.exit\s*\(/.test(code),
+        false,
+        `${rel} must return its exit code for runAsCli to settle, ` +
+          'never call process.exit()',
+      );
+    });
+  }
+});


### PR DESCRIPTION
## Why

`check-baselines.js` adopted `runAsCli` but kept calling `process.exit()` from inside its own `main()` — on both the success arm and the `EXIT_CONFIG` catch arm — which bypassed the non-eager settle path and reinstated the defect Story #4783 removed. `process.exit()` terminates before a queued async pipe write drains, so any CLI emitting more than 64 KiB into a pipe truncates silently while still reporting its exit code.

Measured on this branch, `--gate coverage`:

| stdout target | bytes | result |
| --- | --- | --- |
| `> file` | 262,820 | complete JSON, exit 0 |
| `\| tee` | 65,536 | cut off mid-object, exit 0 |

CI's coverage step is `npm run test:coverage 2>&1 | tee test-output.txt`, so in [run 30752731305](https://github.com/dsj1984/mandrel/actions/runs/30752731305) the gate's verdict was truncated in both the Actions log and the uploaded `test-results` artifact. The step ended on a dangling `"functions": 1` with no npm error block, which reads as a crash and sent triage down the wrong path.

## What changed

- **`.agents/scripts/check-baselines.js`** — `main()` returns its exit code; `runAsCli` carries `propagateExitCode: true` so `settleCli`/`flushStdio` settles it. The 0/1/2/3/4 contract in `lib/baselines/exit-codes.js` is unchanged — only *when* the process leaves is.
- **`.agents/scripts/check-baseline-drift.js`** — the one exact twin the sibling sweep found: the same `main()` verbatim over an equally unbounded payload (one row per drifted baseline entry, full-scope). Same fix; its documented 0/1/2 contract and `exitCode: 2` fatal path are unchanged.
- **`tests/check-baselines-pipe-flush.test.js`** (new, 5 tests) — spawns the real CLI against a throwaway repo whose 900-row baseline is committed at `origin/main`, so every row lands in the compare arm's `unchanged` list and the report clears one pipe buffer. A slow reader holds stdout paused past the child's exit path. Asserts the JSON parses complete, that piped and file-redirected runs agree on both bytes and status, that the `EXIT_CONFIG` arm still exits 3, and structurally that neither baselines CLI holds a `process.exit()` callsite.

## Verification

- The new test fails 3/5 against the pre-fix source, passes 5/5 after.
- Exit codes confirmed unchanged on both CLIs, pre- vs post-fix: `check-baselines` 0 and 3; `check-baseline-drift` 1 on drift, 2 on a bad flag. The existing binary-spawn contract test asserting `EXIT_CONFIG` still passes.
- `npm test` — 9,869 pass / 0 fail. `npm run lint` and `npx biome ci` clean. `check-baselines --format text` — all 4 gates PASS. `npm run quality:preview` — 0 MI regressions, 0 CRAP violations.

## Notes for reviewers

The slow-reader pattern in the new test only works for payloads **above** 64 KiB. Below that the child exits while the stream is still paused and Node tears the pipe down with the buffered bytes unread — 0 bytes delivered, for a reason unrelated to the defect. That is why `slow` is opt-in per case and the small `EXIT_CONFIG` case does not use it; it is documented on the helper.

21 further `runAsCli` adopters under `.agents/scripts/` still call `process.exit()` directly. Highest-risk by payload: `lint-baseline.js`, `validate-skills.js`, `signals-view.js`, `test-isolate.js`, `validate-docs-freshness.js`. They each carry their own `onError`/exit-code subtleties, so they are left for a follow-up Story rather than swept in here.

refs #4783

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI lifecycle fix in agent scripts with regression tests; exit semantics preserved, no auth or production runtime path changes.
> 
> **Overview**
> Fixes **silent truncation** of large baseline CLI output when CI pipes stdout (e.g. `| tee`), which could cut ~260 KiB JSON reports at the 64 KiB pipe buffer while still exiting 0.
> 
> **`check-baselines.js`** and **`check-baseline-drift.js`** no longer call `process.exit()` from `main()`; they **return** their exit codes and register **`propagateExitCode: true`** on `runAsCli` so **`settleCli`/`flushStdio`** drains stdout before the process ends. Documented exit-code contracts are unchanged.
> 
> Adds **`tests/check-baselines-pipe-flush.test.js`**: child-process tests with a slow pipe reader on a >64 KiB report, parity between pipe and file redirect, `EXIT_CONFIG` still exiting 3, and a source guard that neither script contains `process.exit()`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d9c1694669b99eea33f141455fe1709a5bd1f1b1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->