### PR TITLE
fix: carry audit provenance footers onto dependent Stories so the next sweep can dedup against them (#4935)

### DIFF
--- a/.agents/scripts/lib/orchestration/plan-persist/story-ops.js
+++ b/.agents/scripts/lib/orchestration/plan-persist/story-ops.js
@@ -604,6 +604,21 @@ function warnOnDivergentSameTitleStory(story, idsByTitle) {
  * sibling `depends_on` slugs resolved to real issue ids, plus the invisible
  * plan-fingerprint marker that makes the create loop resumable.
  *
+ * **The dependent branch re-serializes, so it must re-carry the provenance**
+ * (Story #4935). `assembleOnePlanStory` appends the audit footers to the
+ * serialized body *string*, but a `blocked by #N` footer cannot be written
+ * until the sibling's real issue number exists — so this function rebuilds the
+ * markdown from `bodyObject`, which never held those footers. Without the
+ * re-carry, provenance was silently dropped for exactly the Stories carrying an
+ * edge (observed live on `plan-run::6cc05d2b`: the two Stories with a
+ * `depends_on` persisted with zero footers while their three siblings carried
+ * the full union), which makes them invisible to `/audit-to-stories` Phase 6's
+ * footer confirmation and re-files work already planned. `story.body` is the
+ * carried assembly, so it is the provenance source here;
+ * `carryProvenanceFooters` is additive, union-preserving and idempotent, so
+ * re-applying it is safe by construction. The fingerprint is computed upstream
+ * over `story.body` and is untouched by this — no re-minting.
+ *
  * @param {object} story
  * @param {Map<string, number>} idBySlug
  * @returns {string}
@@ -612,13 +627,17 @@ function renderStoryBodyForCreate(story, idBySlug) {
   const dependencyRefs = story.depends_on.map(
     (slug) => `#${idBySlug.get(slug)}`,
   );
-  const base =
-    dependencyRefs.length === 0
-      ? story.body
-      : serializeStoryBody(
-          { ...story.bodyObject, depends_on: dependencyRefs },
-          { includeFooter: true },
-        );
+  let base = story.body;
+  if (dependencyRefs.length > 0) {
+    const reserialized = serializeStoryBody(
+      { ...story.bodyObject, depends_on: dependencyRefs },
+      { includeFooter: true },
+    );
+    base = carryProvenanceFooters({
+      from: story.body,
+      into: reserialized,
+    }).body;
+  }
   return `${base}\n\n${planFingerprintMarker(story.fingerprint)}`;
 }
 

--- a/tests/lib/orchestration/plan-persist-story-ops.test.js
+++ b/tests/lib/orchestration/plan-persist-story-ops.test.js
@@ -4,6 +4,7 @@
 
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
+import { parseFingerprintFooter } from '../../../.agents/scripts/lib/findings/route-finding.js';
 import {
   AGENT_LABELS,
   TYPE_LABELS,
@@ -725,5 +726,106 @@ describe('audit dedup provenance carry (Story #4877, AC-5)', () => {
       1,
       'exactly one fingerprint footer',
     );
+  });
+
+  describe('the dependent path re-carries the provenance (Story #4935)', () => {
+    /**
+     * Persist a two-Story cohort where `consumer` depends on `migration`, and
+     * hand back the bodies actually POSTed.
+     *
+     * This must go through `createStoryIssues`, not `assemblePlanStories`: the
+     * defect lives in `renderStoryBodyForCreate`, which re-serializes the body
+     * from `bodyObject` once a sibling's real issue number is known so it can
+     * write the `blocked by #N` footer — discarding the footers the assembly
+     * appended to the body *string*. Every pre-#4935 carry test stops at
+     * assembly, which is exactly why they stayed green while the two Stories on
+     * `plan-run::6cc05d2b` that carried an edge persisted footerless.
+     */
+    async function persistDependentCohort() {
+      const payloads = [];
+      const provider = {
+        createIssue: async (payload) => {
+          payloads.push(payload);
+          return { id: 300 + payloads.length };
+        },
+      };
+      const { stories } = assemblePlanStories(
+        [
+          storyTicket('consumer', { depends_on: ['migration'] }),
+          storyTicket('migration'),
+        ],
+        { provenanceSource: auditSeed },
+      );
+      const { created } = await createStoryIssues({ provider, stories });
+      const bodyBySlug = new Map(
+        created.map((story, index) => [story.slug, payloads[index].body]),
+      );
+      return { created, bodyBySlug };
+    }
+
+    it('a Story with a non-empty depends_on keeps BOTH carried footers', async () => {
+      const { bodyBySlug } = await persistDependentCohort();
+      const dependent = bodyBySlug.get('consumer');
+
+      assert.match(dependent, new RegExp(`audit-fingerprints:\\s*${SHA}`));
+      assert.ok(
+        dependent.includes(`audit-semantic-keys: ${KEY}`),
+        'the semantic-key footer must survive the dependency re-serialization too',
+      );
+    });
+
+    it('the carried footers coexist with the blocked-by line', async () => {
+      const { created, bodyBySlug } = await persistDependentCohort();
+      const migrationId = created.find((s) => s.slug === 'migration').id;
+      const dependent = bodyBySlug.get('consumer');
+
+      assert.match(
+        dependent,
+        new RegExp(`^blocked by #${migrationId}$`, 'm'),
+        'the dependency footer this re-serialization exists to write is still there',
+      );
+      assert.deepEqual(parse(dependent).body.depends_on, [`#${migrationId}`]);
+      assert.match(dependent, new RegExp(`audit-fingerprints:\\s*${SHA}`));
+    });
+
+    it('the persisted dependent Story satisfies the sweep confirmation predicate', async () => {
+      // Why the defect mattered: `/audit-to-stories` Phase 6 confirms a search
+      // hit by parsing this exact footer out of the issue body. A footerless
+      // Story fails the confirmation, the finding routes `new`, and a duplicate
+      // Story opens.
+      const { bodyBySlug } = await persistDependentCohort();
+      assert.deepEqual(parseFingerprintFooter(bodyBySlug.get('consumer')), [
+        SHA,
+      ]);
+    });
+
+    it('a Story with no depends_on is unaffected', async () => {
+      const { bodyBySlug } = await persistDependentCohort();
+      const independent = bodyBySlug.get('migration');
+
+      assert.deepEqual(parseFingerprintFooter(independent), [SHA]);
+      assert.ok(independent.includes(`audit-semantic-keys: ${KEY}`));
+      assert.ok(
+        !/^blocked by /m.test(independent),
+        'and it carries no dependency footer',
+      );
+    });
+
+    it('does not stack a second footer onto the dependent body', async () => {
+      // The fix re-applies an additive, idempotent carry; it must not double
+      // the union onto a body that already round-tripped through assembly.
+      const { bodyBySlug } = await persistDependentCohort();
+      const dependent = bodyBySlug.get('consumer');
+      assert.equal(
+        (dependent.match(/audit-fingerprints:/g) ?? []).length,
+        1,
+        'exactly one fingerprint footer',
+      );
+      assert.equal(
+        (dependent.match(/audit-semantic-keys:/g) ?? []).length,
+        1,
+        'exactly one semantic-key footer',
+      );
+    });
   });
 });


### PR DESCRIPTION
Closes #4935

_Auto-opened by `/deliver`._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to posted issue bodies for dependent Stories during plan persist, with regression tests; no auth or broad orchestration behavior changes beyond audit dedup metadata.
> 
> **Overview**
> Fixes a bug where **Stories with `depends_on` siblings** were persisted **without** `audit-fingerprints` / `audit-semantic-keys` footers, so `/audit-to-stories` could not confirm them and might open duplicate Stories.
> 
> At create time, `renderStoryBodyForCreate` must re-serialize the body from `bodyObject` to turn slug dependencies into `blocked by #N` lines. That path replaced the assembled `story.body` string and **dropped** audit footers that assembly had only appended to the string, not to `bodyObject`. The change runs **`carryProvenanceFooters`** from `story.body` into the re-serialized markdown before appending the plan fingerprint marker; stories with no dependencies are unchanged.
> 
> Tests now exercise **`createStoryIssues`** (not just assembly) for a dependent cohort: footers survive alongside the blocked-by footer, `parseFingerprintFooter` matches Phase 6 confirmation, and footers are not duplicated.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit df5fdbdf53fb4ee96f7cbce4afe852937c4771ce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->