### PR TITLE
fix: read prior baseline rows per kind so duplication's diff-scope preservation and epsilon damping actually work (#4937)

### DIFF
--- a/.agents/scripts/lib/baselines/diff-scope-cli.js
+++ b/.agents/scripts/lib/baselines/diff-scope-cli.js
@@ -170,12 +170,14 @@ const PRIOR_ROW_METRIC_FIELDS = Object.freeze({
  * every unlisted kind the maintainability filter, so an unmodelled kind
  * read as "prior is empty" instead of "prior is unreadable".
  *
- * Pure; no I/O.
+ * Pure; no I/O. Module-private: `readPriorBaselineRows` is the only caller
+ * and the only surface tests drive it through, so exporting it would add an
+ * unused export the dead-export ratchet refuses.
  *
  * @param {string} kind
  * @returns {(row: object) => boolean}
  */
-export function priorRowPredicateFor(kind) {
+function priorRowPredicateFor(kind) {
   const metricFields = PRIOR_ROW_METRIC_FIELDS[kind];
   if (!metricFields) {
     throw new Error(

--- a/.agents/scripts/lib/baselines/diff-scope-cli.js
+++ b/.agents/scripts/lib/baselines/diff-scope-cli.js
@@ -17,11 +17,18 @@
  * four scripts: same argv parser, same git invocation, same forward-slash
  * path normalisation. The four CLIs differ only in how they pipe the
  * resolved scope through to their writer.
+ *
+ * Preservation is only as good as the prior it reads, so the prior reader
+ * dispatches on the kind's own row contract (see `PRIOR_ROW_METRIC_FIELDS`)
+ * rather than defaulting every non-`crap` kind to the maintainability row
+ * shape — that default filtered every duplication row out and left the
+ * writer with nothing to preserve (Story #4937).
  */
 
 import { spawnSync } from 'node:child_process';
 import fs from 'node:fs';
 import { parseNameOnlyStdout } from '../changed-files.js';
+import { getKindModule } from './kernel.js';
 
 /**
  * Parse `--diff-scope <ref>` (and the legacy `--diff-scope=<ref>` form)
@@ -101,19 +108,6 @@ export function resolveDiffScope({ argv, cwd, spawnImpl } = {}) {
   return { ref, files, scope: { mode: 'diff', files } };
 }
 
-/**
- * Read + parse the prior baseline at `absBaselinePath` and return the
- * canonical `rows[]` array (per-kind row shape with `path:` keys, as
- * expected by the per-kind `mergeRows` / `applyEpsilon` helpers from
- * Story #1974). Returns `null` when the file is absent, malformed, or
- * missing a `rows[]` envelope; the caller treats `null` as "skip the
- * merge" (regression-fail-safe — equivalent to a fresh write).
- *
- * Pure-by-design (file I/O through the injected `fsImpl` seam).
- *
- * @param {{ kind: 'maintainability' | 'crap', absBaselinePath: string, fsImpl?: typeof fs }} args
- * @returns {Array<object> | null}
- */
 // Read + JSON-parse a baseline file. Returns `null` on any I/O or parse
 // failure (the caller treats "no prior" the same as "unreadable prior").
 function readBaselineJson(absBaselinePath, fsImpl) {
@@ -131,26 +125,90 @@ function readBaselineJson(absBaselinePath, fsImpl) {
   }
 }
 
-// CRAP path: envelope `rows[]` only; rows already carry canonical `path:`.
-function readCrapPriorRows(parsed) {
-  if (!Array.isArray(parsed.rows)) return null;
-  return parsed.rows;
+/**
+ * Numeric metric fields a canonical baseline row carries, per kind.
+ *
+ * The table is closed over the same kind set as the gates schema
+ * (`lib/config/gates/index.js`) and the writer's kernel registry, and it
+ * exists because every kind keys its rows on a *different* metric: only
+ * maintainability rows carry `mi`, only duplication rows carry
+ * `percentage`, only bundle-size rows carry `rawKb`/`gzippedKb`, and so
+ * on. Reading a prior through another kind's field filters every row out
+ * and hands the writer an empty `prior` — which silently disables epsilon
+ * damping and makes a `--diff-scope` write truncate the baseline to the
+ * files in the diff, because preservation has no prior rows to carry
+ * forward (Story #4937).
+ *
+ * Row identity is deliberately NOT duplicated here — it is read from the
+ * kind module's own `keyField` (`path` / `route` / `bundle`), so the
+ * reader and the writer cannot drift apart on what identifies a row.
+ */
+const PRIOR_ROW_METRIC_FIELDS = Object.freeze({
+  'bundle-size': Object.freeze(['rawKb', 'gzippedKb']),
+  coverage: Object.freeze(['lines', 'branches', 'functions']),
+  crap: Object.freeze(['crap']),
+  duplication: Object.freeze(['percentage']),
+  lighthouse: Object.freeze([
+    'performance',
+    'accessibility',
+    'bestPractices',
+    'seo',
+  ]),
+  lint: Object.freeze(['errorCount', 'warningCount']),
+  maintainability: Object.freeze(['mi']),
+  mutation: Object.freeze(['score']),
+});
+
+/**
+ * Build the prior-row predicate for `kind`: a row survives when it carries
+ * a non-empty identity key under the kind's own `keyField` and a finite
+ * number on every metric field the kind's `compare` / `applyEpsilon`
+ * inspect.
+ *
+ * Throws on a kind with no declared row contract. Failing loudly is the
+ * point: the defect this replaces was a `return` fall-through that gave
+ * every unlisted kind the maintainability filter, so an unmodelled kind
+ * read as "prior is empty" instead of "prior is unreadable".
+ *
+ * Pure; no I/O.
+ *
+ * @param {string} kind
+ * @returns {(row: object) => boolean}
+ */
+export function priorRowPredicateFor(kind) {
+  const metricFields = PRIOR_ROW_METRIC_FIELDS[kind];
+  if (!metricFields) {
+    throw new Error(
+      `[diff-scope-cli] no prior-row contract registered for kind "${kind}" ` +
+        `(known: ${Object.keys(PRIOR_ROW_METRIC_FIELDS).join(', ')})`,
+    );
+  }
+  const { keyField } = getKindModule(kind);
+  return (row) =>
+    Boolean(row) &&
+    typeof row[keyField] === 'string' &&
+    row[keyField].length > 0 &&
+    metricFields.every((field) => Number.isFinite(row[field]));
 }
 
-// Maintainability path: envelope `rows[]` only; rows already carry
-// canonical `path:` + `mi:`.
-function readMaintainabilityPriorRows(parsed) {
-  if (!Array.isArray(parsed.rows)) return null;
-  return parsed.rows.filter(
-    (r) => r && typeof r.path === 'string' && typeof r.mi === 'number',
-  );
-}
-
+/**
+ * Read + parse the prior baseline at `absBaselinePath` and return its
+ * canonical `rows[]` array, filtered through `kind`'s own row contract (as
+ * expected by the per-kind `mergeRows` / `applyEpsilon` helpers from Story
+ * #1974). Returns `null` when the file is absent, malformed, or missing a
+ * `rows[]` envelope; the caller treats `null` as "skip the merge"
+ * (regression-fail-safe — equivalent to a fresh write).
+ *
+ * Pure-by-design (file I/O through the injected `fsImpl` seam).
+ *
+ * @param {{ kind: string, absBaselinePath: string, fsImpl?: typeof fs }} args
+ * @returns {Array<object> | null}
+ */
 export function readPriorBaselineRows({ kind, absBaselinePath, fsImpl = fs }) {
+  const predicate = priorRowPredicateFor(kind);
   const parsed = readBaselineJson(absBaselinePath, fsImpl);
-  if (!parsed) return null;
-  if (kind === 'crap') return readCrapPriorRows(parsed);
-  return readMaintainabilityPriorRows(parsed);
+  if (!parsed || !Array.isArray(parsed.rows)) return null;
+  return parsed.rows.filter(predicate);
 }
 
 /**
@@ -162,14 +220,19 @@ export function readPriorBaselineRows({ kind, absBaselinePath, fsImpl = fs }) {
  *
  * Returns a flat record so each CLI can spread it into the writer call.
  *
+ * The `fsImpl` / `spawnImpl` seams exist so the composed payload can be
+ * exercised hermetically — production callers omit both.
+ *
  * @param {{
- *   kind: 'maintainability' | 'crap',
+ *   kind: string,
  *   absBaselinePath: string,
  *   epsilon: number,
  *   argv?: string[],
  *   cwd?: string,
  *   logger?: { info?: (msg: string) => void },
  *   logTag: string,
+ *   fsImpl?: typeof fs,
+ *   spawnImpl?: typeof spawnSync,
  * }} args
  * @returns {{
  *   prior: Array<object> | undefined,
@@ -186,9 +249,11 @@ export function buildWriterScopeArgs({
   cwd,
   logger,
   logTag,
+  fsImpl = fs,
+  spawnImpl = spawnSync,
 }) {
-  const prior = readPriorBaselineRows({ kind, absBaselinePath });
-  const diffScope = resolveDiffScope({ argv, cwd });
+  const prior = readPriorBaselineRows({ kind, absBaselinePath, fsImpl });
+  const diffScope = resolveDiffScope({ argv, cwd, spawnImpl });
   if (diffScope && logger?.info) {
     logger.info(
       `${logTag} --diff-scope ${diffScope.ref}: ${diffScope.files.size} file(s) in scope; out-of-scope rows preserved verbatim.`,

--- a/baselines/dead-exports.json
+++ b/baselines/dead-exports.json
@@ -28,10 +28,6 @@
       "symbol": "_internals"
     },
     {
-      "file": ".agents/scripts/lib/baselines/diff-scope-cli.js",
-      "symbol": "readPriorBaselineRows"
-    },
-    {
       "file": ".agents/scripts/lib/baselines/duplication-scanner.js",
       "symbol": "readLineCount"
     },

--- a/tests/baselines/writer-scope.test.js
+++ b/tests/baselines/writer-scope.test.js
@@ -16,11 +16,22 @@
  */
 
 import assert from 'node:assert/strict';
+import path from 'node:path';
 import { describe, it } from 'node:test';
+import { fileURLToPath } from 'node:url';
 
+import {
+  buildWriterScopeArgs,
+  readPriorBaselineRows,
+} from '../../.agents/scripts/lib/baselines/diff-scope-cli.js';
 import { write } from '../../.agents/scripts/lib/baselines/writer.js';
 
 const FIXED = '2026-05-15T00:00:00Z';
+
+const REPO_ROOT = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '../..',
+);
 
 const PRIOR_MI_ROWS = [
   { path: 'src/a.js', mi: 70 },
@@ -202,5 +213,222 @@ describe('writer.write — scope parameter (Story #1974)', () => {
     // Without scope, the merger does not run — out-of-scope prior rows are
     // NOT backfilled. (Same contract as pre-#1974.)
     assert.equal(byPath['src/b.js'], undefined);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Story #4937 — the prior reader must dispatch per kind, or scope
+// preservation and epsilon damping are both inert for every kind whose rows
+// are not keyed on `mi`.
+// ---------------------------------------------------------------------------
+
+/**
+ * One canonical row per baseline kind, in the exact shape that kind's
+ * `projectRow` emits. The fixture is the audit: a kind whose rows survive
+ * this reader is a kind the reader models correctly.
+ */
+const CANONICAL_ROWS_BY_KIND = Object.freeze({
+  'bundle-size': [{ bundle: 'main', rawKb: 120.5, gzippedKb: 40.25 }],
+  coverage: [{ path: 'src/a.js', lines: 90, branches: 80, functions: 85 }],
+  crap: [{ path: 'src/a.js', method: 'render', startLine: 12, crap: 18 }],
+  duplication: [
+    { path: 'src/a.js', duplicatedLines: 10, totalLines: 100, percentage: 10 },
+  ],
+  lighthouse: [
+    {
+      route: 'dashboard',
+      performance: 92,
+      accessibility: 96,
+      bestPractices: 90,
+      seo: 88,
+    },
+  ],
+  lint: [{ path: 'src/a.js', errorCount: 0, warningCount: 3 }],
+  maintainability: [{ path: 'src/a.js', mi: 70 }],
+  mutation: [{ path: 'src/a.js', score: 81, killed: 8, survived: 2 }],
+});
+
+/** The pre-#4937 default reader, kept verbatim as the regression oracle. */
+function legacyMaintainabilityFilter(rows) {
+  return rows.filter(
+    (r) => r && typeof r.path === 'string' && typeof r.mi === 'number',
+  );
+}
+
+/** An `fs` seam that serves one in-memory baseline envelope. */
+function fsServing(envelope) {
+  return { readFileSync: () => JSON.stringify(envelope) };
+}
+
+/** A `spawnSync` seam that reports `files` as the diff footprint. */
+function spawnDiffing(files) {
+  return () => ({ status: 0, stdout: `${files.join('\n')}\n` });
+}
+
+describe('readPriorBaselineRows — per-kind dispatch (Story #4937)', () => {
+  it('AC-4: every kind reads its own rows back, whether or not they carry `mi`', () => {
+    for (const [kind, rows] of Object.entries(CANONICAL_ROWS_BY_KIND)) {
+      const prior = readPriorBaselineRows({
+        kind,
+        absBaselinePath: `/virtual/${kind}.json`,
+        fsImpl: fsServing({ rows }),
+      });
+      assert.deepEqual(
+        prior,
+        rows,
+        `kind "${kind}" must read its own canonical rows back intact`,
+      );
+    }
+  });
+
+  it('AC-4: the kinds that regressed are exactly those whose rows lack `mi`', () => {
+    // Guards the fix against a silent re-introduction: if a kind's rows
+    // survive the legacy `mi` filter, that kind was never at risk; every
+    // other kind was returning an empty prior before this Story.
+    const wouldHaveBeenEmptied = Object.entries(CANONICAL_ROWS_BY_KIND)
+      .filter(
+        ([kind, rows]) =>
+          kind !== 'crap' && legacyMaintainabilityFilter(rows).length === 0,
+      )
+      .map(([kind]) => kind);
+    assert.deepEqual(wouldHaveBeenEmptied.sort(), [
+      'bundle-size',
+      'coverage',
+      'duplication',
+      'lighthouse',
+      'lint',
+      'mutation',
+    ]);
+  });
+
+  it('AC-1: a kind with no declared row contract throws instead of borrowing one', () => {
+    assert.throws(
+      () =>
+        readPriorBaselineRows({
+          kind: 'not-a-kind',
+          absBaselinePath: '/virtual/none.json',
+          fsImpl: fsServing({ rows: [] }),
+        }),
+      /no prior-row contract registered for kind "not-a-kind"/,
+    );
+  });
+
+  it('AC-2: the committed duplication baseline reads back as a non-empty prior', () => {
+    const prior = readPriorBaselineRows({
+      kind: 'duplication',
+      absBaselinePath: path.join(REPO_ROOT, 'baselines/duplication.json'),
+    });
+    assert.ok(Array.isArray(prior), 'prior must be an array');
+    assert.ok(
+      prior.length > 0,
+      'update-duplication-baseline.js must receive a non-empty prior',
+    );
+    assert.equal(typeof prior[0].percentage, 'number');
+  });
+
+  it('AC-3: a --diff-scope duplication run PRESERVES out-of-scope rows', () => {
+    const priorRows = [
+      {
+        path: 'src/a.js',
+        duplicatedLines: 10,
+        totalLines: 100,
+        percentage: 10,
+      },
+      {
+        path: 'src/b.js',
+        duplicatedLines: 30,
+        totalLines: 100,
+        percentage: 30,
+      },
+      { path: 'src/c.js', duplicatedLines: 5, totalLines: 100, percentage: 5 },
+    ];
+    // The CLI's own compose call, with only the I/O seams substituted.
+    const scopeArgs = buildWriterScopeArgs({
+      kind: 'duplication',
+      absBaselinePath: '/virtual/duplication.json',
+      epsilon: 0.5,
+      argv: ['--diff-scope', 'main'],
+      logTag: '[Duplication]',
+      fsImpl: fsServing({ rows: priorRows }),
+      spawnImpl: spawnDiffing(['src/a.js']),
+    });
+    // A rescan: src/a.js is the only file in the diff. src/b.js comes back
+    // re-measured and src/c.js does not come back at all (jscpd only reports
+    // files it currently finds clones in). Both are out of scope, so both
+    // must land from the prior — the second is the truncation case.
+    const env = write({
+      kind: 'duplication',
+      rows: [
+        {
+          path: 'src/a.js',
+          duplicatedLines: 40,
+          totalLines: 100,
+          percentage: 40,
+        },
+        {
+          path: 'src/b.js',
+          duplicatedLines: 0,
+          totalLines: 100,
+          percentage: 0,
+        },
+      ],
+      generatedAt: FIXED,
+      ...scopeArgs,
+    });
+    assert.deepEqual(
+      env.rows.map((r) => r.path).sort(),
+      ['src/a.js', 'src/b.js', 'src/c.js'],
+      'a diff-scoped run must not truncate the baseline to the diff',
+    );
+    const byPath = Object.fromEntries(
+      env.rows.map((r) => [r.path, r.percentage]),
+    );
+    assert.equal(byPath['src/a.js'], 40, 'in-scope row is regenerated');
+    assert.equal(byPath['src/b.js'], 30, 'out-of-scope row preserved verbatim');
+    assert.equal(
+      byPath['src/c.js'],
+      5,
+      'an out-of-scope row absent from the rescan is carried forward, not dropped',
+    );
+  });
+
+  it('AC-5: an explicit epsilon folds a sub-epsilon percentage back to the prior', () => {
+    const priorRows = [
+      {
+        path: 'src/a.js',
+        duplicatedLines: 10,
+        totalLines: 100,
+        percentage: 10,
+      },
+    ];
+    const scopeArgs = buildWriterScopeArgs({
+      kind: 'duplication',
+      absBaselinePath: '/virtual/duplication.json',
+      epsilon: 0.5,
+      argv: ['--diff-scope', 'main'],
+      logTag: '[Duplication]',
+      fsImpl: fsServing({ rows: priorRows }),
+      spawnImpl: spawnDiffing(['src/a.js']),
+    });
+    assert.equal(scopeArgs.epsilon, 0.5, 'a readable prior arms epsilon');
+    const env = write({
+      kind: 'duplication',
+      // In-scope, and 0.3pp away from the prior — inside epsilon.
+      rows: [
+        {
+          path: 'src/a.js',
+          duplicatedLines: 10,
+          totalLines: 100,
+          percentage: 10.3,
+        },
+      ],
+      generatedAt: FIXED,
+      ...scopeArgs,
+    });
+    assert.equal(
+      env.rows[0].percentage,
+      10,
+      'a sub-epsilon reading must fold back to the prior percentage',
+    );
   });
 });


### PR DESCRIPTION
Closes #4937

_Auto-opened by `/deliver`._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes baseline write behavior for manual update CLIs using `--diff-scope`; incorrect contracts could still corrupt baselines, but scope is limited to the diff-scope helper with strong regression tests.
> 
> **Overview**
> Fixes **`--diff-scope`** baseline updates for non-maintainability kinds (especially **duplication**), where the prior reader wrongly applied a maintainability (`path` + `mi`) filter so priors came back empty and scoped writes could **truncate** baselines and skip **epsilon** damping.
> 
> **`readPriorBaselineRows`** now validates rows per kind via **`PRIOR_ROW_METRIC_FIELDS`** and each kind’s **`keyField`** from **`getKindModule`**, throws on unknown kinds instead of silently emptying the prior, and **`buildWriterScopeArgs`** accepts injectable **`fsImpl`** / **`spawnImpl`** for hermetic tests. **`baselines/dead-exports.json`** drops the unused **`readPriorBaselineRows`** export entry.
> 
> **`writer-scope.test.js`** adds Story #4937 coverage: all kinds round-trip canonical rows, duplication **`--diff-scope`** preserves out-of-scope rows (including rows missing from a rescan), and sub-epsilon duplication metrics fold to the prior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fb8480a40b08054bfd2bc8203669ec5bc97e8c5f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->