### PR TITLE
feat: dispatch acceptance cluster critics in parallel and merge their verdicts into one gate call per round (#4951)

### DIFF
--- a/.agents/agents/acceptance-critic.md
+++ b/.agents/agents/acceptance-critic.md
@@ -115,10 +115,13 @@ For each acceptance item in your cluster:
 
 ## Verdict schema (MUST)
 
-Emit a verdict file under `temp/` conforming to
+Write a verdict file under `temp/` at a **cluster-unique path** (e.g.
+`temp/acceptance-verdict-<storyId>-r<round>-c<clusterIndex>.json`) so parallel
+sibling critics cannot overwrite each other, conforming to
 [`acceptance-eval-verdict.schema.json`](../schemas/acceptance-eval-verdict.schema.json):
 one `criteria[]` record per acceptance item in your cluster, in acceptance-array
-order.
+order. Each `index` is the criterion's position in the Story's **full**
+`acceptance[]` array, not within your cluster — the caller merges on it.
 
 ```json
 {
@@ -146,10 +149,11 @@ order.
 - `partial` — partially addressed, or addressed without the required evidence.
 - `unmet` — not addressed, or the evidence contradicts the claim.
 
-Hand the verdict path to the caller's `acceptance-eval.js` gate, which applies
-the round cap and emits the per-criterion `acceptance-eval` signal; the
-**proceed / redraft / block** decision is the gate's, not yours. You score; the
-gate decides.
+**Return the verdict file's absolute path to your caller — never invoke
+`acceptance-eval.js` yourself.** The caller merges every cluster's records into
+one verdict and calls the gate **once** per round; a per-cluster call would burn
+a Story-level round per cluster. The **proceed / redraft / block** decision is
+the gate's, not yours. You score; the gate decides.
 
 ## Boundaries
 

--- a/.agents/scripts/acceptance-eval.js
+++ b/.agents/scripts/acceptance-eval.js
@@ -41,10 +41,20 @@
  * tier along with the per-AC-cluster `--epic <id> --cluster <id>` mode that
  * scored an Epic `## Acceptance Table` against a `main..epic/<id>` diff.)
  *
+ * One gate call per round (Story #4951). A round may fan out into N parallel
+ * maker-blind cluster critics, but their per-cluster verdicts are merged by
+ * the caller into ONE verdict — `criteria[]` in acceptance-array order — and
+ * scored here exactly once. Invoking the gate per cluster instead would burn
+ * one Story-level round per cluster (distinct fingerprints defeat the replay
+ * guard) and race the `signals.ndjson` round ledger. `--expected-criteria`
+ * makes that contract enforceable: a partial (single-cluster) verdict is
+ * rejected before scoring, so the mistake costs no round.
+ *
  * CLI:
- *   --story <id>           Story ID (required).
- *   --verdict <path>       Path to the round's verdict JSON (required).
- *   --no-signal            Suppress the signal emit (tests).
+ *   --story <id>              Story ID (required).
+ *   --verdict <path>          Path to the round's verdict JSON (required).
+ *   --expected-criteria <n>   Reject a verdict not covering exactly n criteria.
+ *   --no-signal               Suppress the signal emit (tests).
  *
  * Stdout: a single JSON envelope
  *   { storyId, epicId, decision, round, cap, capReached, totalCriteria,
@@ -143,6 +153,7 @@ function parseCliArgs(argv) {
     options: {
       story: { type: 'string' },
       verdict: { type: 'string' },
+      'expected-criteria': { type: 'string' },
       'no-signal': { type: 'boolean', default: false },
     },
     strict: false,
@@ -151,8 +162,62 @@ function parseCliArgs(argv) {
   return {
     storyId: Number.isInteger(storyId) && storyId > 0 ? storyId : null,
     verdictPath: values.verdict ?? null,
+    expectedCriteria: values['expected-criteria'] ?? null,
     emitSignal: values['no-signal'] !== true,
   };
+}
+
+/**
+ * The merge contract, stated once so both the flag error and the coverage
+ * error name the same shape the caller has to produce.
+ */
+const MERGE_CONTRACT =
+  'One round = N parallel cluster critics -> ONE merged verdict -> ONE gate call: ' +
+  "merge every cluster's records into a single criteria[] in acceptance[] order, " +
+  'one per acceptance item, before scoring.';
+
+/**
+ * Resolve the optional `--expected-criteria` flag to a positive integer, or
+ * `null` when the flag is absent (which preserves the pre-#4951 behaviour
+ * exactly — no coverage assertion is made).
+ *
+ * Exported for tests.
+ *
+ * @param {string|null|undefined} raw
+ * @returns {number|null}
+ */
+export function resolveExpectedCriteria(raw) {
+  if (raw === null || raw === undefined) return null;
+  const expected = Number.parseInt(String(raw), 10);
+  if (!Number.isInteger(expected) || expected < 1) {
+    throw new Error(
+      `acceptance-eval: --expected-criteria must be a positive integer (the Story's acceptance[] count). ${MERGE_CONTRACT}`,
+    );
+  }
+  return expected;
+}
+
+/**
+ * Reject a verdict that does not cover exactly `expectedCriteria` criteria.
+ *
+ * Called **before** `runAcceptanceEval`, which is where the round ledger is
+ * read and appended — so a partial cluster verdict handed to the gate by
+ * mistake costs no round and can never escalate a `redraft` into a `block`.
+ *
+ * Exported for tests.
+ *
+ * @param {object} verdict — schema-validated verdict.
+ * @param {number|null} expectedCriteria — `null` disables the assertion.
+ * @returns {void}
+ */
+export function assertCriteriaCoverage(verdict, expectedCriteria) {
+  if (expectedCriteria === null) return;
+  const actual = Array.isArray(verdict?.criteria) ? verdict.criteria.length : 0;
+  if (actual === expectedCriteria) return;
+  throw new Error(
+    `acceptance-eval: verdict covers ${actual} criteria but --expected-criteria is ${expectedCriteria}. ` +
+      `${MERGE_CONTRACT} No round was consumed.`,
+  );
 }
 
 /**
@@ -294,11 +359,13 @@ export async function runAcceptanceEvalCli(
     runAcceptanceEvalImpl = runAcceptanceEval,
     logger = Logger,
   } = deps;
-  const { storyId, verdictPath, emitSignal } = parseCliArgs(argv);
+  const { storyId, verdictPath, expectedCriteria, emitSignal } =
+    parseCliArgs(argv);
+  const expected = resolveExpectedCriteria(expectedCriteria);
 
   if (!storyId) {
     throw new Error(
-      'Usage: node acceptance-eval.js --story <id> --verdict <path> [--no-signal]',
+      'Usage: node acceptance-eval.js --story <id> --verdict <path> [--expected-criteria <n>] [--no-signal]',
     );
   }
   if (!verdictPath) {
@@ -328,6 +395,11 @@ export async function runAcceptanceEvalCli(
   }
 
   const verdict = validateVerdictImpl(parsed);
+
+  // Story #4951: a merged verdict must cover every acceptance[] item. This
+  // runs before the round ledger is touched, so a partial cluster verdict is
+  // a free mistake.
+  assertCriteriaCoverage(verdict, expected);
 
   // A verdict whose embedded storyId disagrees with the CLI flag is a
   // wiring error worth failing on, not a silent mismatch.
@@ -372,12 +444,18 @@ runAsCli(import.meta.url, main, {
   source: 'acceptance-eval',
   usage: {
     invocation:
-      'node .agents/scripts/acceptance-eval.js --story <id> --verdict <path> [--no-signal]',
+      'node .agents/scripts/acceptance-eval.js --story <id> --verdict <path> [--expected-criteria <n>] [--no-signal]',
     summary:
       "Score an authored acceptance verdict against the Story's acceptance[] criteria and emit the bounded loop's proceed / redraft / block decision.",
     flags: [
       ['--story <id>', 'GitHub issue number of the Story (required).'],
       ['--verdict <path>', 'Path to the authored verdict JSON (required).'],
+      [
+        '--expected-criteria <n>',
+        'Reject — before scoring, consuming no round — a verdict whose criteria[] ' +
+          "length is not n. Pass the Story's acceptance[] count so a partial " +
+          'cluster verdict cannot be scored as the round.',
+      ],
       [
         '--no-signal',
         "Skip appending the per-criterion signal to the Story's signals ledger.",

--- a/.agents/workflows/helpers/acceptance-self-eval.md
+++ b/.agents/workflows/helpers/acceptance-self-eval.md
@@ -40,8 +40,8 @@ mid-delivery, and evaluates the actual work product.
    `resolveCeremonyForRisk`). **Never run both**, and never run a
    preliminary self-assessment pass before dispatching the fresh critic —
    the redundant pre-pass buys no measurable quality and roughly triples
-   the acceptance-block cost. Step 2's gate is the deterministic **scorer**
-   of the one authored verdict, not a second (or third) pass over the
+   the acceptance-block cost. Step 3's gate is the deterministic **scorer**
+   of the one merged verdict, not a second (or third) pass over the
    criteria.
 
    > **Sub-agent type + derived-level ceremony.** When
@@ -134,19 +134,55 @@ mid-delivery, and evaluates the actual work product.
      fresh — a false-fresh coverage record without `coverage-final.json`
      silently weakens the floor. Limit the evidence-share to `lint` and
      `typecheck`.
-   - Emits a verdict file under `temp/` conforming to
+   - Emits a **cluster** verdict file under `temp/` conforming to
      [`acceptance-eval-verdict.schema.json`](../../schemas/acceptance-eval-verdict.schema.json):
      one `{ index, criterion, verdict: met|partial|unmet, evidence,
-     verifyEvidence[] }` record per acceptance item.
-2. **Decide.** Run the gate against the verdict (the caller's Step 1a names the
-   exact invocation — omit `--epic`). The gate **scores the single verdict
-   the round's owner authored** — schema validation, round cap, decision —
-   and never re-scores the criteria itself:
+     verifyEvidence[] }` record per acceptance item **in that cluster**, each
+     `index` being the item's position in the Story's full `acceptance[]`
+     array. A fresh critic **returns that path to you** rather than calling the
+     gate itself.
+2. **Dispatch the round's clusters in parallel, then merge into one verdict.**
+   The clusters of a round are independent, so dispatch **all** of the round's
+   fresh critics as N `Agent` calls **in a single assistant turn** —
+   [`parallel-tooling.md`](parallel-tooling.md) **Rule 3** — never serially,
+   and never one round per cluster. Clusters routed `inline` are authored in
+   the same round alongside them.
+
+   Then **merge** the cluster verdicts into **one** verdict file under `temp/`:
+   concatenate every cluster's `criteria[]` records and order the merged array
+   by `index`, so it holds exactly one record per `acceptance[]` item in
+   **acceptance-array order**, under a single top-level `storyId`,
+   `schemaVersion`, `round` and `commitSha`. The verdict schema deliberately
+   carries **no `clusterId`** — the round's artifact is the merged verdict, and
+   which critic scored which record is not part of the contract.
+
+   > **Why one gate call and not N.** The round counter is **Story-scoped** —
+   > derived by counting `acceptance-eval` signals in the Story's
+   > `signals.ndjson` — and each cluster verdict has a distinct fingerprint, so
+   > the replay guard never collapses them. A gate call per cluster would spend
+   > one of the (default 2) rounds *per cluster*, so a Story with more than 8
+   > acceptance criteria would exhaust its redraft budget on cluster arithmetic
+   > alone; N concurrent calls would also race that same ledger. Cluster-scoped
+   > round counting exists in
+   > [`acceptance-eval-decision.js`](../../scripts/lib/orchestration/acceptance-eval-decision.js)
+   > but requires an integer `epicId`, which v2 pins `null` — it is not a way
+   > around the merge.
+3. **Decide — exactly one gate call per round.** Run the gate against the
+   **merged** verdict (the caller's Step 1a names the exact invocation — omit
+   `--epic`). The gate **scores the single verdict the round produced** —
+   schema validation, round cap, decision — and never re-scores the criteria
+   itself:
 
    ```bash
    node <main-repo>/.agents/scripts/acceptance-eval.js \
-     --story <storyId> --verdict <verdict-path>
+     --story <storyId> --verdict <merged-verdict-path> \
+     --expected-criteria <number of acceptance[] items>
    ```
+
+   Pass `--expected-criteria` from the `acceptance[]` count you already read
+   off the Story body: a verdict whose `criteria[]` length differs — a single
+   cluster's verdict handed over unmerged — is rejected **before scoring**,
+   with an error naming the merge contract and consuming **no round**.
 
    The gate validates the verdict against the schema, applies the round cap,
    emits the per-criterion `acceptance-eval` signal into the retro / feedback
@@ -161,4 +197,5 @@ mid-delivery, and evaluates the actual work product.
      (transition to `agent::blocked`) and post a `friction` comment naming the
      unmet criteria and their evidence. Never silently proceed to close.
 
-Write the verdict files under `temp/` only — they are scratch artifacts.
+Write both the per-cluster verdicts and the merged verdict under `temp/` only —
+they are scratch artifacts.

--- a/baselines/context-budget.json
+++ b/baselines/context-budget.json
@@ -180,8 +180,8 @@
     "files": [
       {
         "path": ".agents/agents/acceptance-critic.md",
-        "bytes": 7440,
-        "headroomBytes": 752
+        "bytes": 7861,
+        "headroomBytes": 331
       },
       {
         "path": ".agents/agents/auditor.md",

--- a/tests/acceptance-eval.test.js
+++ b/tests/acceptance-eval.test.js
@@ -2,6 +2,8 @@ import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 
 import {
+  assertCriteriaCoverage,
+  resolveExpectedCriteria,
   runAcceptanceEval,
   runAcceptanceEvalCli,
   validateVerdict,
@@ -228,6 +230,112 @@ describe('runAcceptanceEvalCli', () => {
     // The envelope is still printed before the throw — the loop's record of
     // why it blocked must survive the non-zero exit.
     assert.equal(JSON.parse(h.infos[0]).decision, 'block');
+  });
+});
+
+/**
+ * Story #4951 — one round = N parallel cluster critics → ONE merged verdict →
+ * ONE gate call.
+ *
+ * The round counter is Story-scoped, so a gate call per cluster spends a whole
+ * round per cluster. `--expected-criteria` is the guard: a verdict that does
+ * not cover every `acceptance[]` item is refused before the scoring path is
+ * ever entered, which the `seen` spy makes observable — an empty `seen` means
+ * the round ledger was never read or appended.
+ */
+describe('--expected-criteria — the merge contract (Story #4951)', () => {
+  const clusterVerdict = (count) =>
+    verdictFixture({
+      criteria: Array.from({ length: count }, (_, index) => ({
+        index,
+        criterion: `AC-${index + 1} holds`,
+        verdict: 'met',
+        evidence: 'npm test exits 0',
+      })),
+    });
+
+  it('resolves an absent flag to null so the assertion is opt-in', () => {
+    assert.equal(resolveExpectedCriteria(null), null);
+    assert.equal(resolveExpectedCriteria(undefined), null);
+    assert.equal(resolveExpectedCriteria('4'), 4);
+  });
+
+  it('refuses a non-positive or non-numeric --expected-criteria', () => {
+    for (const raw of ['0', '-2', 'four', '']) {
+      assert.throws(
+        () => resolveExpectedCriteria(raw),
+        /--expected-criteria must be a positive integer/,
+        `--expected-criteria ${raw} should be refused`,
+      );
+    }
+  });
+
+  it('passes a verdict covering exactly the expected criteria', () => {
+    assert.doesNotThrow(() => assertCriteriaCoverage(clusterVerdict(4), 4));
+  });
+
+  it('is a no-op when no expectation was given', () => {
+    assert.doesNotThrow(() => assertCriteriaCoverage(clusterVerdict(1), null));
+  });
+
+  it('scores a merged full-coverage verdict as one round', async () => {
+    const h = harness({ verdict: clusterVerdict(4) });
+    const envelope = await runAcceptanceEvalCli(
+      [
+        '--story',
+        '4780',
+        '--verdict',
+        'merged.json',
+        '--expected-criteria',
+        '4',
+      ],
+      h.deps,
+    );
+    assert.equal(envelope.decision, 'proceed');
+    assert.equal(h.seen.length, 1, 'the gate scores the merged verdict once');
+  });
+
+  it('rejects an unmerged cluster verdict before scoring, consuming no round', async () => {
+    const h = harness({ verdict: clusterVerdict(2) });
+    await assert.rejects(
+      () =>
+        runAcceptanceEvalCli(
+          [
+            '--story',
+            '4780',
+            '--verdict',
+            'cluster-1.json',
+            '--expected-criteria',
+            '4',
+          ],
+          h.deps,
+        ),
+      (err) => {
+        assert.match(
+          err.message,
+          /verdict covers 2 criteria but --expected-criteria is 4/,
+        );
+        assert.match(err.message, /ONE merged verdict -> ONE gate call/);
+        assert.match(err.message, /No round was consumed/);
+        return true;
+      },
+    );
+    assert.deepEqual(h.seen, [], 'the scoring path must never be entered');
+    assert.deepEqual(
+      h.infos,
+      [],
+      'no envelope is printed for a refused verdict',
+    );
+  });
+
+  it('preserves current behaviour exactly when the flag is omitted', async () => {
+    const h = harness({ verdict: clusterVerdict(2) });
+    const envelope = await runAcceptanceEvalCli(
+      ['--story', '4780', '--verdict', 'cluster-1.json'],
+      h.deps,
+    );
+    assert.equal(envelope.decision, 'proceed');
+    assert.equal(h.seen.length, 1);
   });
 });
 

--- a/tests/contract/acceptance-eval-gate.test.js
+++ b/tests/contract/acceptance-eval-gate.test.js
@@ -20,6 +20,7 @@ import addFormats from 'ajv-formats';
 
 import {
   runAcceptanceEval,
+  runAcceptanceEvalCli,
   validateVerdict,
 } from '../../.agents/scripts/acceptance-eval.js';
 
@@ -221,6 +222,87 @@ describe('runAcceptanceEval — decision → exit-code mapping + signal emission
     assert.equal(envelope.decision, 'proceed');
     assert.equal(exitCode, 0);
     assert.equal(envelope.signalEmitted, false);
+  });
+});
+
+/**
+ * Story #4951 — the gate boundary for the "one round = N parallel cluster
+ * critics → ONE merged verdict → ONE gate call" contract.
+ *
+ * These drive the real `runAcceptanceEval` (only the signal writer and the
+ * ledger resolver are injected) through the CLI core, so "consumes no round"
+ * is asserted where it is actually observable: the round signal that would
+ * have been appended is not.
+ */
+describe('one gate call per round — merged-verdict coverage (Story #4951)', () => {
+  const mergedVerdict = (count) =>
+    validVerdict({
+      storyId: 4951,
+      criteria: Array.from({ length: count }, (_, index) => ({
+        index,
+        criterion: `AC-${index + 1}`,
+        verdict: 'met',
+        evidence: `acceptance-eval.js covers AC-${index + 1}`,
+      })),
+    });
+
+  const cliDeps = (verdict, appended) => ({
+    readFileSyncImpl: () => JSON.stringify(verdict),
+    resolveConfigImpl: () => ({
+      delivery: { acceptanceEval: { maxRounds: 2 } },
+    }),
+    runAcceptanceEvalImpl: (args) =>
+      runAcceptanceEval(args, {
+        appendSignalFn: async ({ signal }) => {
+          appended.push(signal);
+          return true;
+        },
+        resolveRoundFn: () => ({ round: 1, replay: false }),
+      }),
+    logger: { info: () => {} },
+  });
+
+  it('scores a merged full-coverage verdict normally in one round', async () => {
+    const appended = [];
+    const envelope = await runAcceptanceEvalCli(
+      [
+        '--story',
+        '4951',
+        '--verdict',
+        'merged.json',
+        '--expected-criteria',
+        '4',
+      ],
+      cliDeps(mergedVerdict(4), appended),
+    );
+    assert.equal(envelope.decision, 'proceed');
+    assert.equal(envelope.totalCriteria, 4);
+    assert.equal(envelope.round, 1);
+    assert.equal(appended.length, 1, 'exactly one round is consumed');
+  });
+
+  it('rejects a partial cluster verdict without advancing the round counter', async () => {
+    const appended = [];
+    await assert.rejects(
+      () =>
+        runAcceptanceEvalCli(
+          [
+            '--story',
+            '4951',
+            '--verdict',
+            'cluster-1.json',
+            '--expected-criteria',
+            '4',
+          ],
+          cliDeps(mergedVerdict(2), appended),
+        ),
+      /verdict covers 2 criteria but --expected-criteria is 4/,
+    );
+    assert.deepEqual(
+      appended,
+      [],
+      'a refused verdict must append no acceptance-eval signal, so no round is spent',
+    );
   });
 });
 


### PR DESCRIPTION
Closes #4951

_Auto-opened by `/deliver`._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes orchestration of the bounded acceptance loop and round ledger semantics; mistakes could still burn rounds or block Stories, but partial-verdict rejection and docs/tests reduce that risk.
> 
> **Overview**
> Story delivery acceptance now treats **one round** as: run **N parallel** cluster critics → **merge** their verdicts → call **`acceptance-eval.js` once**.
> 
> The **acceptance-critic** agent writes cluster-scoped verdict files under unique `temp/` paths, uses **`index`** against the Story’s full `acceptance[]`, and **returns the path** instead of invoking the gate. **`acceptance-self-eval`** workflow prose adds parallel `Agent` dispatch (one turn), merge-by-`index` into a single verdict, and a single gate invocation with **`--expected-criteria`**.
> 
> **`acceptance-eval.js`** gains optional **`--expected-criteria <n>`** plus **`assertCriteriaCoverage`**, which rejects verdicts whose `criteria[]` length ≠ `n` **before** the round ledger runs, so an unmerged cluster verdict does not consume a round. Omitting the flag keeps prior behavior.
> 
> Tests cover the merge contract; **`context-budget.json`** reflects the larger acceptance-critic boot doc.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7f8b560cff3baa51a4ba2a530cd774a0d6468679. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->