### PR TITLE
fix: make the ready-set overlap guard reserve in-flight Story footprints instead of de-conflicting only within one beat (#4950)

### DIFF
--- a/.agents/scripts/lib/wave-runner/live-probe.js
+++ b/.agents/scripts/lib/wave-runner/live-probe.js
@@ -247,6 +247,7 @@ export function createProbeContext({
  *
  * @returns {Promise<{
  *   nodes: Array<{id: number, dependsOn: number[], files: string[], body: string, labels: string[]}>,
+ *   inFlightRecords: Array<{id: number, dependsOn: number[], files: string[], body: string, labels: string[]}>,
  *   doneIds: Set<number>,
  *   inFlight: number,
  *   blockedIds: number[],
@@ -294,15 +295,24 @@ export async function probeLiveState({
   // never dispatched by this run.
   const foreignHeld = deriveForeignHeld(stories, self, warn);
   for (const id of foreignHeld.keys()) inFlightIds.add(id);
+  const nodes = envelope.dag.map((node) => ({
+    ...node,
+    body: bodyById.get(node.id) ?? '',
+    labels: projectInFlightLabels(
+      labelsById.get(node.id) ?? [],
+      inFlightIds.has(node.id),
+    ),
+  }));
   return {
-    nodes: envelope.dag.map((node) => ({
-      ...node,
-      body: bodyById.get(node.id) ?? '',
-      labels: projectInFlightLabels(
-        labelsById.get(node.id) ?? [],
-        inFlightIds.has(node.id),
-      ),
-    })),
+    nodes,
+    // The same nodes, narrowed to the Stories occupying a slot. `inFlight` is
+    // only a count, so it can shrink capacity but can never stop a Story
+    // admitted now from sharing files with one dispatched on an earlier beat
+    // and still implementing. These records carry the `files[]` and `body` the
+    // co-dispatch guard needs, so the kernel can RESERVE those footprints
+    // rather than merely count them (Story #4950). No extra fetch: this is a
+    // projection of what the probe already read.
+    inFlightRecords: nodes.filter((node) => inFlightIds.has(node.id)),
     doneIds: new Set(envelope.done),
     inFlight: inFlightIds.size,
     blockedIds: deriveBlockedIds(stories),

--- a/.agents/scripts/lib/wave-runner/ready-set.js
+++ b/.agents/scripts/lib/wave-runner/ready-set.js
@@ -28,15 +28,20 @@
  *   - `storiesOverlap(a, b)` — the file-overlap co-dispatch guard: true
  *     when two Stories' file footprints intersect. Two Stories that would
  *     touch the same file MUST NOT be dispatched onto parallel
- *     `story-<id>` branches in the same beat (they would race the same
- *     path and produce a merge conflict at close). The comparison runs over
+ *     `story-<id>` branches **concurrently** — not merely on the same beat
+ *     (they would race the same path and produce a merge conflict at
+ *     close). The comparison runs over
  *     the **widened** footprint (`storyWidenedFootprint`) — a declared
  *     `changes[]` is treated as a lower bound and widened from the paths the
  *     Story's own text names, because a guard that trusts a prediction cannot
  *     prevent the collision nobody predicted (Story #4875).
- *   - `selectReadySet({ stories, doneIds, inFlight, globalCap })` — the
- *     scheduler. Returns the deterministic, overlap-free set of ready
- *     Stories, capped at `globalCap − inFlight`.
+ *   - `planReadySet({ stories, doneIds, inFlight, globalCap,
+ *     inFlightRecords })` — the scheduler. Returns the deterministic,
+ *     overlap-free dispatch set (capped at `globalCap − inFlight`) **and**
+ *     the Stories it withheld because their footprint is reserved by a Story
+ *     still in flight from an earlier beat.
+ *   - `selectReadySet(args)` — `planReadySet(args).selected`, the
+ *     dispatch-set-only view for callers that do not report withholdings.
  *
  * Adjacency is re-derived from the supplied records via the shared
  * `buildStoryAdjacency` builder (`lib/story-adjacency.js`) — the same
@@ -227,10 +232,11 @@ function storyWidenedFootprint(story) {
 
 /**
  * File-overlap co-dispatch guard. Returns `true` when two Stories' declared
- * file footprints intersect — meaning they would race the same file if
- * dispatched onto parallel `story-<id>` branches in the same beat. Two
- * Stories that overlap MUST NOT both appear in one dispatch set; one is
- * withheld until the other clears.
+ * file footprints intersect — meaning they would race the same file if their
+ * `story-<id>` branches were ever live at the same time. Two Stories that
+ * overlap MUST NOT run concurrently: one is withheld until the other clears,
+ * whether the peer was admitted on this beat or dispatched on an earlier one
+ * and is still implementing (Story #4950).
  *
  * Comparison runs over the **widened** footprint
  * ({@link storyWidenedFootprint}), not the declaration: a declared `changes[]`
@@ -304,10 +310,11 @@ export function storiesOverlap(a, b) {
  *      already occupying a slot (executing / closing / dispatched-not-yet-
  *      labelled). When `slots <= 0`, the result is empty.
  *   5. **Overlap guard.** Greedily admit eligible Stories in ascending-id
- *      order, skipping any whose file footprint overlaps an
- *      already-admitted Story (`storiesOverlap`). A withheld Story stays
- *      eligible and is naturally re-considered on the next beat once its
- *      overlapping peer has cleared.
+ *      order, skipping any whose file footprint overlaps either a Story
+ *      **already admitted this beat** or a Story **still in flight from an
+ *      earlier beat** (`inFlightRecords`). A withheld Story stays eligible
+ *      and is naturally re-considered on the next beat once the Story
+ *      reserving its files has cleared.
  *
  * The result is deterministic: eligible Stories are considered in
  * ascending-id order, so the same inputs always yield the same set.
@@ -325,22 +332,36 @@ export function storiesOverlap(a, b) {
  *   step 1 above). `false` keeps a foreign dependency as a gate
  *   (standalone / operator-DAG semantics); `true` prunes foreign edges so
  *   the DAG stays closed over the scheduled set (Epic semantics).
- * @returns {StoryRecord[]} The dispatch set: a subset of `stories`,
- *   ascending by id, overlap-free, length ≤ `globalCap − inFlight`.
+ * @param {StoryRecord[]} [args.inFlightRecords=[]] Records for the Stories
+ *   already in flight, whose footprints this beat must **reserve** rather
+ *   than merely count. `inFlight` is a number and can only shrink capacity;
+ *   without the records a Story admitted now can share files with one
+ *   dispatched on an earlier beat and still implementing — a guaranteed
+ *   merge conflict at close (Story #4950). Callers that hold only ids (the
+ *   `--dag`/`--in-flight` flag mode) pass nothing and get the pre-#4950
+ *   same-beat-only behaviour.
+ * @returns {{ selected: StoryRecord[], withheldByInFlight: Array<{id: number, blockedBy: number}> }}
+ *   `selected` is the dispatch set: a subset of `stories`, ascending by id,
+ *   overlap-free, length ≤ `globalCap − inFlight`. `withheldByInFlight`
+ *   names each eligible Story a reservation held back and the in-flight
+ *   Story that holds it.
  */
-export function selectReadySet({
+export function planReadySet({
   stories,
   doneIds = [],
   inFlight = 0,
   globalCap,
   dropForeign = false,
+  inFlightRecords = [],
 } = {}) {
   const records = Array.isArray(stories) ? stories : [];
   const cap = Number.isInteger(globalCap) ? globalCap : 0;
   const inFlightCount =
     Number.isInteger(inFlight) && inFlight > 0 ? inFlight : 0;
   const slots = Math.max(0, cap - inFlightCount);
-  if (slots <= 0 || records.length === 0) return [];
+  if (slots <= 0 || records.length === 0) {
+    return { selected: [], withheldByInFlight: [] };
+  }
 
   // Step 1 — adjacency keyed by id. The `dropForeign` policy decides whether
   // a dependency on an id outside the supplied set gates the dependent
@@ -373,13 +394,91 @@ export function selectReadySet({
   }
 
   // Steps 4 + 5 — greedily admit up to `slots`, skipping file-overlap
-  // collisions against the already-admitted set.
+  // collisions against the already-admitted set AND against the footprints
+  // reserved by Stories still in flight from an earlier beat.
+  return admitStories({
+    eligibleIds,
+    byId,
+    slots,
+    reserved: Array.isArray(inFlightRecords) ? inFlightRecords : [],
+  });
+}
+
+/**
+ * The dispatch set alone — `planReadySet(args).selected`.
+ *
+ * The scheduling contract every caller has always consumed. Callers that also
+ * report *why* a slot went unfilled (the `stories-wave-tick.js` envelope) use
+ * {@link planReadySet} directly.
+ *
+ * @param {Parameters<typeof planReadySet>[0]} [args]
+ * @returns {StoryRecord[]}
+ */
+export function selectReadySet(args) {
+  return planReadySet(args).selected;
+}
+
+/**
+ * Greedily admit eligible Stories in ascending-id order under two distinct
+ * withholding rules, and report which ones a reservation held back.
+ *
+ * The reservation check runs **first**, so a Story racing both an in-flight
+ * Story and a same-beat peer is reported against the in-flight one: that is
+ * the longer-lived and more informative blocker (a Story that has been
+ * implementing for beats, not one merely admitted a moment ago), and checking
+ * it first is what makes the report complete — every withheld-by-reservation
+ * Story appears in it. Ordering cannot change `selected`: either rule skips
+ * the same candidate.
+ *
+ * @param {object} args
+ * @param {number[]} args.eligibleIds        Ascending eligible Story ids.
+ * @param {Map<number, StoryRecord>} args.byId
+ * @param {number} args.slots                Remaining dispatch capacity.
+ * @param {StoryRecord[]} args.reserved      In-flight Story records.
+ * @returns {{ selected: StoryRecord[], withheldByInFlight: Array<{id: number, blockedBy: number}> }}
+ */
+function admitStories({ eligibleIds, byId, slots, reserved }) {
   const selected = [];
+  const withheldByInFlight = [];
   for (const id of eligibleIds) {
     if (selected.length >= slots) break;
     const rec = byId.get(id);
+    const blockedBy = findInFlightBlocker(rec, id, reserved);
+    if (blockedBy !== null) {
+      withheldByInFlight.push({ id, blockedBy });
+      continue;
+    }
     if (selected.some((picked) => storiesOverlap(picked, rec))) continue;
     selected.push(rec);
   }
-  return selected;
+  return { selected, withheldByInFlight };
+}
+
+/**
+ * The id of the in-flight Story whose widened footprint the candidate would
+ * race, or `null` when none does.
+ *
+ * Two records are skipped rather than treated as blockers:
+ *
+ *   - **The candidate itself.** Probe mode hands the whole record set to both
+ *     arguments, and an in-flight Story classifies `executing` rather than
+ *     `ready`, so a candidate can never legitimately appear here — but a
+ *     caller that double-lists one Story must not have it withhold itself.
+ *   - **An unidentifiable record.** A withholding this function cannot name
+ *     is one the envelope cannot explain, and an unexplained unfilled slot is
+ *     the exact operator-facing failure this reservation exists to remove.
+ *     Probe-mode records always carry an integer id, so this is defensive.
+ *
+ * @param {StoryRecord} candidate
+ * @param {number} candidateId
+ * @param {StoryRecord[]} reserved
+ * @returns {number|null}
+ */
+function findInFlightBlocker(candidate, candidateId, reserved) {
+  for (const held of reserved) {
+    const heldId = storyIdOf(held);
+    if (heldId === null || heldId === candidateId) continue;
+    if (storiesOverlap(held, candidate)) return heldId;
+  }
+  return null;
 }

--- a/.agents/scripts/stories-wave-tick.js
+++ b/.agents/scripts/stories-wave-tick.js
@@ -54,8 +54,17 @@
  *     concurrencyCap: number,
  *     inFlight: number,
  *     cycleError: string | null,
- *     wedged: { reason, stories: [{ id, unmetBlockers }] } | null
+ *     wedged: { reason, stories: [{ id, unmetBlockers }] } | null,
+ *     inFlightReservation: { available, withheld: [{ id, blockedBy }], note }
  *   }
+ *
+ * `inFlightReservation` reports the cross-beat half of the co-dispatch guard
+ * (Story #4875 widened the footprint; Story #4950 made it reserve). Under
+ * `--probe-live` the in-flight Stories' own records are handed to the kernel,
+ * so a candidate racing a Story dispatched on an EARLIER beat is withheld and
+ * named here with its blocker. Flag mode carries a count and no records, so it
+ * reports `available: false` rather than an empty — and therefore
+ * indistinguishable — result.
  *
  * Probe mode adds fields the caller can no longer compute for itself:
  * `done: number[]` (the resolved done set, in-set ∪ satisfied foreign
@@ -110,7 +119,7 @@ import {
   probeLiveState,
   validateProbeFlags,
 } from './lib/wave-runner/live-probe.js';
-import { selectReadySet } from './lib/wave-runner/ready-set.js';
+import { planReadySet } from './lib/wave-runner/ready-set.js';
 
 /**
  * Exit code for a wedged run — deliberately distinct from the cycle exit (2)
@@ -198,8 +207,19 @@ Output envelope:
     },
     "inFlight": 0,
     "cycleError": null,
-    "wedged": null
+    "wedged": null,
+    "inFlightReservation": {
+      "available": true,
+      "withheld": [{ "id": 4951, "blockedBy": 4949 }],
+      "note": "..."
+    }
   }
+
+inFlightReservation names each Story withheld this beat because its file
+footprint overlaps one still IN FLIGHT from an earlier beat, together with the
+blocking id — so an unfilled slot is explained rather than mysterious. It needs
+the in-flight Stories' footprints, which only --probe-live has: under --dag the
+report is { available: false } and selection de-conflicts within the beat only.
 
 Exit codes:
   0 - Success, ready set emitted
@@ -233,9 +253,60 @@ function inputErrorResult(message, concurrencyCap = null, inFlightValue = 0) {
       inFlight: inFlightValue,
       cycleError: null,
       wedged: null,
+      inFlightReservation: null,
       inputError: message,
     },
     exitCode: 1,
+  };
+}
+
+/**
+ * Describe this beat's in-flight footprint reservation for the envelope
+ * (Story #4950).
+ *
+ * The reservation needs the in-flight Stories' **records** — their footprints
+ * — not just how many there are, so its availability is a property of the
+ * mode rather than of the run:
+ *
+ *   - **Probe mode** hands over the records `live-probe.js` already fetched,
+ *     so `inFlightRecords` is an array (possibly empty) and reservation is
+ *     `available: true`.
+ *   - **Flag mode** (`--dag` + `--in-flight <n>`) supplies a graph and a
+ *     count; no node carries a label, so nothing there can even classify as
+ *     in-flight. There is no footprint to reserve against, and selection is
+ *     unchanged from before #4950. Saying so explicitly is the point: a
+ *     silently-absent guard reads exactly like a guard that found nothing.
+ *
+ * @param {object[]|null|undefined} inFlightRecords
+ * @param {Array<{id: number, blockedBy: number}>} withheld
+ * @returns {{ available: boolean, withheld: Array<{id: number, blockedBy: number}>, note: string|null }}
+ */
+export function buildReservationReport(inFlightRecords, withheld) {
+  if (!Array.isArray(inFlightRecords)) {
+    return {
+      available: false,
+      withheld: [],
+      note:
+        'In-flight footprint reservation is UNAVAILABLE this beat: flag mode ' +
+        'supplies a dependency graph and an --in-flight count, never the ' +
+        'in-flight Stories themselves, so there are no footprints to reserve ' +
+        'against. Selection is unchanged (same-beat de-confliction only). ' +
+        'Use --probe-live to reserve in-flight footprints.',
+    };
+  }
+  if (withheld.length === 0) {
+    return { available: true, withheld: [], note: null };
+  }
+  const detail = withheld.map((w) => `#${w.id} ← #${w.blockedBy}`).join('; ');
+  return {
+    available: true,
+    withheld,
+    note:
+      `${withheld.length} Story(ies) withheld because their file footprint ` +
+      `overlaps a Story still in flight from an earlier beat — ${detail}. ` +
+      `This is not a wedge and not a failure: each re-admits automatically ` +
+      `on a later beat, once the Story reserving its files leaves the ` +
+      `in-flight set.`,
   };
 }
 
@@ -483,6 +554,10 @@ export function resolveCapPrecedence({ cwd, config, override } = {}) {
  *   record explaining which source set the cap.
  * @param {Set<number>} [args.doneIds] Story IDs already completed this run.
  * @param {number} [args.inFlight]     Stories already occupying a slot.
+ * @param {object[]|null} [args.inFlightRecords] Records for the Stories
+ *   already in flight, so the kernel reserves their footprints instead of
+ *   merely counting them (Story #4950). `null` (flag mode) means reservation
+ *   is structurally unavailable — see {@link buildReservationReport}.
  * @returns {{
  *   envelope: {
  *     kind: 'stories-ready-set',
@@ -497,7 +572,13 @@ export function resolveCapPrecedence({ cwd, config, override } = {}) {
  */
 export function buildReadySetEnvelope(
   nodes,
-  { concurrencyCap, capPrecedence = null, doneIds = new Set(), inFlight = 0 },
+  {
+    concurrencyCap,
+    capPrecedence = null,
+    doneIds = new Set(),
+    inFlight = 0,
+    inFlightRecords = null,
+  },
 ) {
   const totalStories = nodes.length;
 
@@ -513,6 +594,10 @@ export function buildReadySetEnvelope(
     inFlight,
     cycleError: null,
     wedged: null,
+    // Whether this beat could reserve the in-flight Stories' footprints, and
+    // which Stories a reservation withheld (Story #4950). Never omitted on a
+    // resolved beat: an absent report reads exactly like an empty one.
+    inFlightReservation: buildReservationReport(inFlightRecords, []),
   };
 
   if (totalStories === 0) {
@@ -559,12 +644,21 @@ export function buildReadySetEnvelope(
     return rec;
   });
 
-  const ready = selectReadySet({
+  const { selected, withheldByInFlight } = planReadySet({
     stories: records,
     doneIds,
     inFlight,
     globalCap: concurrencyCap,
-  }).map((rec) => rec.id);
+    // Flag mode has no in-flight records at all; `?? []` keeps the kernel's
+    // contract (an array) while `base.inFlightReservation` reports that the
+    // reservation itself was unavailable rather than merely empty.
+    inFlightRecords: inFlightRecords ?? [],
+  });
+  const ready = selected.map((rec) => rec.id);
+  const reservation = buildReservationReport(
+    inFlightRecords,
+    withheldByInFlight,
+  );
 
   // Wedge detection (Story #4540). `ready: []` is normal while work is in
   // flight — the loop is simply waiting. But ready-empty AND nothing in
@@ -580,12 +674,25 @@ export function buildReadySetEnvelope(
   const wedge = detectWedge({ nodes, doneIds, ready, inFlight });
   if (wedge) {
     return {
-      envelope: { ...base, ready, wedged: wedge },
+      envelope: {
+        ...base,
+        ready,
+        wedged: wedge,
+        inFlightReservation: reservation,
+      },
       exitCode: WEDGED_EXIT_CODE,
     };
   }
 
-  return { envelope: { ...base, ready, wedged: null }, exitCode: 0 };
+  return {
+    envelope: {
+      ...base,
+      ready,
+      wedged: null,
+      inFlightReservation: reservation,
+    },
+    exitCode: 0,
+  };
 }
 
 /**
@@ -810,12 +917,16 @@ export async function runProbedStoriesWaveTick({
     inFlight,
     blockedIds = [],
     foreignHeld = [],
+    inFlightRecords = [],
   } = probed;
   const { envelope, exitCode } = buildReadySetEnvelope(nodes, {
     concurrencyCap,
     capPrecedence,
     doneIds,
     inFlight,
+    // Probe mode is the only mode that HAS the in-flight Stories' records, so
+    // it is the only mode that can reserve their footprints (Story #4950).
+    inFlightRecords,
   });
 
   const done = [...doneIds].sort((a, b) => a - b);

--- a/.agents/workflows/helpers/deliver-reference.md
+++ b/.agents/workflows/helpers/deliver-reference.md
@@ -91,6 +91,16 @@ different operator holds, unless you pass `--steal`. Assignee-based withholding
 needs `github.operatorHandle` set (in `.agentrc.local.json`); without it the
 probe logs a warning and leans on init's lease refusal alone.
 
+**Overlapping footprints are reserved across beats, not just within one.** A
+Story whose files a still-implementing Story already touches is withheld and
+named in `inFlightReservation: { available, withheld: [{ id, blockedBy }],
+note }`. Like `foreignHeld` this is neither a failure nor a wedge — the Story
+re-admits automatically once its blocker leaves the in-flight set — and it
+exists so an unfilled slot is explained rather than mysterious. Reservation
+needs the in-flight Stories' footprints, so it is a `--probe-live` capability:
+under `--dag` the report is `available: false` and selection de-conflicts
+within the beat only.
+
 ## Dispatch mechanics (role-scoped by default)
 
 **A single-Story run executes inline.** Sub-agent isolation is

--- a/baselines/dead-exports-production.json
+++ b/baselines/dead-exports-production.json
@@ -2166,6 +2166,10 @@
     },
     {
       "file": ".agents/scripts/lib/wave-runner/ready-set.js",
+      "symbol": "selectReadySet"
+    },
+    {
+      "file": ".agents/scripts/lib/wave-runner/ready-set.js",
       "symbol": "storiesOverlap"
     },
     {

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -517,9 +517,14 @@ The `Graph.js` module provides the mathematical foundation for task scheduling:
 That is the complete live export surface — in particular there is **no**
 `autoSerializeOverlaps()`. The focus-area auto-serialization pass it named is
 gone; its job now happens at *selection* time via `storiesOverlap()` in
-`lib/wave-runner/ready-set.js`, where `selectReadySet` skips a Story whose
-**declared** footprint overlaps an already-selected peer — de-conflicting
-within one tick only, reserving nothing against a later one.
+`lib/wave-runner/ready-set.js`, where `planReadySet` skips a Story whose
+**widened** footprint overlaps either an already-selected peer or a Story
+still **in flight** from an earlier beat. The cross-beat half needs the
+in-flight Stories' records, which only probe mode holds: `live-probe.js`
+returns them as `inFlightRecords`, and the tick reports each withholding in
+the envelope's `inFlightReservation` naming the blocking id. Flag mode carries
+a count and no records, so it reports `available: false` rather than an
+indistinguishable empty result.
 
 ---
 

--- a/tests/scripts/stories-wave-tick.test.js
+++ b/tests/scripts/stories-wave-tick.test.js
@@ -37,6 +37,7 @@ import {
   parseInFlight,
   resolveCapPrecedence,
   resolveConcurrencyCap,
+  runProbedStoriesWaveTick,
   runStoriesWaveTick,
   WEDGED_EXIT_CODE,
 } from '../../.agents/scripts/stories-wave-tick.js';
@@ -932,5 +933,180 @@ describe('the beat envelope reports the cap precedence (AC-6)', () => {
     assert.strictEqual(envelope.concurrencyCap, 8);
     assert.strictEqual(envelope.capPrecedence.source, 'flag');
     assert.strictEqual(typeof envelope.capPrecedence.note, 'string');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Story #4950 — the tick reports the in-flight footprint reservation
+// ---------------------------------------------------------------------------
+
+describe('buildReadySetEnvelope — inFlightReservation (Story #4950)', () => {
+  const held = (id, files) => ({
+    id,
+    dependsOn: [],
+    files,
+    labels: ['agent::executing'],
+  });
+
+  it('withholds a candidate racing an in-flight Story and names the blocker (AC-4)', () => {
+    const { envelope } = buildReadySetEnvelope(
+      [
+        { id: 1, dependsOn: [], files: ['lib/shared.js'] },
+        { id: 2, dependsOn: [], files: ['lib/other.js'] },
+      ],
+      {
+        concurrencyCap: 3,
+        inFlight: 1,
+        inFlightRecords: [held(9, ['lib/shared.js'])],
+      },
+    );
+
+    assert.deepEqual(envelope.ready, [2]);
+    assert.strictEqual(envelope.inFlightReservation.available, true);
+    assert.deepEqual(envelope.inFlightReservation.withheld, [
+      { id: 1, blockedBy: 9 },
+    ]);
+    // The note must name both sides — an unfilled slot with no explanation is
+    // exactly what this report exists to remove.
+    assert.match(envelope.inFlightReservation.note, /#1/);
+    assert.match(envelope.inFlightReservation.note, /#9/);
+    assert.match(envelope.inFlightReservation.note, /in flight/i);
+  });
+
+  it('reports available with no withholdings when nothing collides', () => {
+    const { envelope } = buildReadySetEnvelope(
+      [{ id: 1, dependsOn: [], files: ['lib/a.js'] }],
+      {
+        concurrencyCap: 3,
+        inFlight: 1,
+        inFlightRecords: [held(9, ['lib/held.js'])],
+      },
+    );
+    assert.deepEqual(envelope.ready, [1]);
+    assert.deepEqual(envelope.inFlightReservation, {
+      available: true,
+      withheld: [],
+      note: null,
+    });
+  });
+
+  it('says reservation is UNAVAILABLE in flag mode, and leaves selection unchanged (AC-2)', () => {
+    // Flag mode supplies a graph and an --in-flight count; no node carries a
+    // label, so nothing can classify in-flight and there is no footprint to
+    // reserve against. Reporting that explicitly is the point: a silently
+    // absent guard reads exactly like a guard that found nothing.
+    const nodes = [
+      { id: 1, dependsOn: [], files: ['lib/shared.js'] },
+      { id: 2, dependsOn: [], files: ['lib/other.js'] },
+    ];
+    const { envelope } = buildReadySetEnvelope(nodes, {
+      concurrencyCap: 3,
+      inFlight: 1,
+    });
+
+    assert.deepEqual(envelope.ready, [1, 2], 'selection is unchanged');
+    assert.strictEqual(envelope.inFlightReservation.available, false);
+    assert.deepEqual(envelope.inFlightReservation.withheld, []);
+    assert.match(envelope.inFlightReservation.note, /UNAVAILABLE/);
+    assert.match(envelope.inFlightReservation.note, /--probe-live/);
+  });
+
+  it('reports the reservation on the empty-DAG and cycle short-circuits too', () => {
+    const { envelope: empty } = buildReadySetEnvelope([], {
+      concurrencyCap: 3,
+      inFlightRecords: [],
+    });
+    assert.deepEqual(empty.inFlightReservation, {
+      available: true,
+      withheld: [],
+      note: null,
+    });
+
+    const { envelope: cyclic, exitCode } = buildReadySetEnvelope(
+      [
+        { id: 1, dependsOn: [2] },
+        { id: 2, dependsOn: [1] },
+      ],
+      { concurrencyCap: 3 },
+    );
+    assert.strictEqual(exitCode, 2);
+    assert.strictEqual(cyclic.inFlightReservation.available, false);
+  });
+
+  it('keeps a same-beat withholding out of the reservation report', () => {
+    // Two peers racing each other is the pre-existing guard, not a
+    // reservation — conflating them would misreport why the slot went unused.
+    const { envelope } = buildReadySetEnvelope(
+      [
+        { id: 1, dependsOn: [], files: ['lib/shared.js'] },
+        { id: 2, dependsOn: [], files: ['lib/shared.js'] },
+      ],
+      { concurrencyCap: 3, inFlightRecords: [] },
+    );
+    assert.deepEqual(envelope.ready, [1]);
+    assert.deepEqual(envelope.inFlightReservation.withheld, []);
+  });
+});
+
+describe('runProbedStoriesWaveTick — threads the probed in-flight records (AC-2)', () => {
+  const CONFIG = { delivery: { deliverRunner: { concurrencyCap: 3 } } };
+
+  /** Run a probe-mode tick against an injected probe result. */
+  const tick = (probed) =>
+    runProbedStoriesWaveTick({
+      stories: '1,2,9',
+      config: CONFIG,
+      context: () => ({ provider: {}, owner: 'o', repo: 'r', self: null }),
+      probe: async () => probed,
+    });
+
+  it('reserves the footprints live-probe already fetched', async () => {
+    const inFlightRecord = {
+      id: 9,
+      dependsOn: [],
+      files: ['lib/shared.js'],
+      body: '',
+      labels: ['agent::executing'],
+    };
+    const { envelope, exitCode } = await tick({
+      nodes: [
+        {
+          id: 1,
+          dependsOn: [],
+          files: ['lib/shared.js'],
+          body: '',
+          labels: [],
+        },
+        { id: 2, dependsOn: [], files: ['lib/other.js'], body: '', labels: [] },
+        inFlightRecord,
+      ],
+      inFlightRecords: [inFlightRecord],
+      doneIds: new Set(),
+      inFlight: 1,
+      blockedIds: [],
+      foreignHeld: [],
+    });
+
+    assert.strictEqual(exitCode, 0);
+    assert.deepEqual(envelope.ready, [2], '#1 races the in-flight #9');
+    assert.deepEqual(envelope.inFlightReservation.withheld, [
+      { id: 1, blockedBy: 9 },
+    ]);
+  });
+
+  it('stays available (and empty) when the probe reports nothing in flight', async () => {
+    const { envelope } = await tick({
+      nodes: [
+        { id: 1, dependsOn: [], files: ['lib/a.js'], body: '', labels: [] },
+      ],
+      inFlightRecords: [],
+      doneIds: new Set(),
+      inFlight: 0,
+      blockedIds: [],
+      foreignHeld: [],
+    });
+    assert.deepEqual(envelope.ready, [1]);
+    assert.strictEqual(envelope.inFlightReservation.available, true);
+    assert.deepEqual(envelope.inFlightReservation.withheld, []);
   });
 });

--- a/tests/wave-runner/live-probe.test.js
+++ b/tests/wave-runner/live-probe.test.js
@@ -715,3 +715,106 @@ describe('probeLiveState — foreign-lease withholding (Story #4620)', () => {
     assert.equal(exitCode, 0);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Story #4950 — the probe surfaces the in-flight Stories' RECORDS, not a count
+// ---------------------------------------------------------------------------
+
+describe('probeLiveState — inFlightRecords feed the footprint reservation', () => {
+  it('returns the full record for every Story occupying a slot', async () => {
+    const provider = stubProvider({
+      101: issue(101, {
+        labels: ['agent::executing'],
+        changes: ['lib/shared.js'],
+      }),
+      102: issue(102, { labels: ['agent::closing'], changes: ['lib/b.js'] }),
+      103: issue(103, { changes: ['lib/c.js'] }),
+    });
+
+    const { inFlightRecords, inFlight } = await probeLiveState({
+      ids: [101, 102, 103],
+      provider,
+      owner: 'dsj1984',
+      repo: 'mandrel',
+    });
+
+    assert.equal(inFlight, 2);
+    assert.deepEqual(
+      inFlightRecords.map((r) => r.id),
+      [101, 102],
+      'executing AND closing both hold a slot',
+    );
+    // The footprint is what makes reservation possible — a count cannot
+    // de-conflict anything.
+    assert.deepEqual(inFlightRecords[0].files, ['lib/shared.js']);
+    assert.equal(typeof inFlightRecords[0].body, 'string');
+  });
+
+  it('includes a dispatched-but-unlabelled Story, so the init window reserves too', async () => {
+    const provider = stubProvider({
+      101: issue(101, { changes: ['lib/shared.js'] }),
+      102: issue(102, { changes: ['lib/b.js'] }),
+    });
+
+    const { inFlightRecords } = await probeLiveState({
+      ids: [101, 102],
+      provider,
+      owner: 'dsj1984',
+      repo: 'mandrel',
+      dispatched: [101],
+    });
+
+    assert.deepEqual(
+      inFlightRecords.map((r) => r.id),
+      [101],
+    );
+  });
+
+  it('excludes done Stories — a landed footprint reserves nothing', async () => {
+    const provider = stubProvider({
+      101: issue(101, { labels: ['agent::done'], changes: ['lib/shared.js'] }),
+      102: issue(102, { changes: ['lib/shared.js'] }),
+    });
+
+    const { inFlightRecords } = await probeLiveState({
+      ids: [101, 102],
+      provider,
+      owner: 'dsj1984',
+      repo: 'mandrel',
+    });
+
+    assert.deepEqual(inFlightRecords, []);
+  });
+
+  it('withholds a ready Story that races an in-flight one, end to end', async () => {
+    // The whole point, through the real probe + kernel path: #102 declares the
+    // same file as the already-executing #101, so it must not be dispatched
+    // onto a parallel branch this beat.
+    const { envelope, exitCode } = await tick({
+      101: issue(101, {
+        labels: ['agent::executing'],
+        changes: ['lib/shared.js'],
+      }),
+      102: issue(102, { changes: ['lib/shared.js'] }),
+      103: issue(103, { changes: ['lib/other.js'] }),
+    });
+
+    assert.equal(exitCode, 0);
+    assert.deepEqual(envelope.ready, [103]);
+    assert.equal(envelope.inFlightReservation.available, true);
+    assert.deepEqual(envelope.inFlightReservation.withheld, [
+      { id: 102, blockedBy: 101 },
+    ]);
+  });
+
+  it('re-admits the withheld Story on the next beat, once its blocker lands', async () => {
+    const { envelope } = await tick({
+      101: issue(101, { labels: ['agent::done'], changes: ['lib/shared.js'] }),
+      102: issue(102, { changes: ['lib/shared.js'] }),
+      103: issue(103, { changes: ['lib/other.js'] }),
+    });
+
+    assert.deepEqual(envelope.ready, [102, 103]);
+    assert.deepEqual(envelope.inFlightReservation.withheld, []);
+  });
+});

--- a/tests/wave-runner/ready-set.test.js
+++ b/tests/wave-runner/ready-set.test.js
@@ -4,6 +4,7 @@ import { describe, it } from 'node:test';
 import { AGENT_LABELS } from '../../.agents/scripts/lib/label-constants.js';
 import {
   classifyStory,
+  planReadySet,
   selectReadySet,
   storiesOverlap,
   storyFootprint,
@@ -499,5 +500,337 @@ describe('storiesOverlap — real edits collide even when declarations do not (A
       [1, 3],
       '#2 races #1 on lib/a.js despite declaring only lib/b.js',
     );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Story #4950 — the overlap guard RESERVES in-flight footprints
+// ---------------------------------------------------------------------------
+
+describe('planReadySet — in-flight footprints are reserved, not just counted', () => {
+  /** A Story already dispatched on an earlier beat and still implementing. */
+  const inFlight = (id, opts) =>
+    story(id, { ...opts, labels: [AGENT_LABELS.EXECUTING] });
+
+  it('withholds a candidate whose footprint overlaps an in-flight Story (AC-1)', () => {
+    // The cross-beat window: #2 was admitted on an earlier beat and is still
+    // implementing. Before #4950 it only shrank the slot count, so #1 was
+    // admitted onto a branch racing it for lib/shared.js.
+    const held = inFlight(2, { files: ['lib/shared.js'] });
+    const { selected, withheldByInFlight } = planReadySet({
+      stories: [story(1, { files: ['lib/shared.js', 'lib/a.js'] }), held],
+      inFlight: 1,
+      globalCap: 3,
+      inFlightRecords: [held],
+    });
+
+    assert.deepEqual(ids(selected), []);
+    assert.deepEqual(withheldByInFlight, [{ id: 1, blockedBy: 2 }]);
+  });
+
+  it('is not merely the same-beat check: nothing was admitted this beat', () => {
+    // `selected` is empty when the reservation fires, so no already-admitted
+    // peer could explain the withholding — only the in-flight record can.
+    const held = inFlight(9, { files: ['lib/shared.js'] });
+    const { selected } = planReadySet({
+      stories: [story(1, { files: ['lib/shared.js'] }), held],
+      inFlight: 1,
+      globalCap: 5,
+      inFlightRecords: [held],
+    });
+    assert.deepEqual(selected, []);
+  });
+
+  it('reserves the WIDENED footprint, not just the in-flight declaration', () => {
+    // The in-flight Story declared lib/b.js but its own text names lib/a.js —
+    // the same lower-bound problem #4875 fixed for the same-beat comparison.
+    const held = inFlight(2, {
+      files: ['lib/b.js'],
+      body: 'The fix also has to change lib/a.js to keep the caller honest.',
+    });
+    const { withheldByInFlight } = planReadySet({
+      stories: [story(1, { files: ['lib/a.js'] }), held],
+      inFlight: 1,
+      globalCap: 5,
+      inFlightRecords: [held],
+    });
+    assert.deepEqual(withheldByInFlight, [{ id: 1, blockedBy: 2 }]);
+  });
+
+  it('admits a candidate whose footprint is disjoint from every in-flight one', () => {
+    const held = inFlight(9, { files: ['lib/held.js'] });
+    const { selected, withheldByInFlight } = planReadySet({
+      stories: [story(1, { files: ['lib/a.js'] }), held],
+      inFlight: 1,
+      globalCap: 5,
+      inFlightRecords: [held],
+    });
+    assert.deepEqual(ids(selected), [1]);
+    assert.deepEqual(withheldByInFlight, []);
+  });
+
+  it('reports every reservation-withheld Story, each with its blocker (AC-4)', () => {
+    const heldA = inFlight(8, { files: ['lib/a.js'] });
+    const heldB = inFlight(9, { files: ['lib/b.js'] });
+    const { selected, withheldByInFlight } = planReadySet({
+      stories: [
+        story(1, { files: ['lib/a.js'] }),
+        story(2, { files: ['lib/b.js'] }),
+        story(3, { files: ['lib/c.js'] }),
+        heldA,
+        heldB,
+      ],
+      inFlight: 2,
+      globalCap: 5,
+      inFlightRecords: [heldA, heldB],
+    });
+    assert.deepEqual(ids(selected), [3]);
+    assert.deepEqual(withheldByInFlight, [
+      { id: 1, blockedBy: 8 },
+      { id: 2, blockedBy: 9 },
+    ]);
+  });
+
+  it('keeps admission deterministic and ascending-id under reservation (AC-3)', () => {
+    const held = inFlight(7, { files: ['lib/b.js'] });
+    const stories = [
+      story(5, { files: ['lib/e.js'] }),
+      story(2, { files: ['lib/b.js'] }), // reserved by #7
+      story(4, { files: ['lib/d.js'] }),
+      held,
+    ];
+    // Input order is shuffled; the result is not.
+    const first = planReadySet({
+      stories,
+      inFlight: 1,
+      globalCap: 9,
+      inFlightRecords: [held],
+    });
+    const second = planReadySet({
+      stories: [...stories].reverse(),
+      inFlight: 1,
+      globalCap: 9,
+      inFlightRecords: [held],
+    });
+    assert.deepEqual(
+      first.selected.map((r) => r.id),
+      [4, 5],
+      'ascending id, not input order',
+    );
+    assert.deepEqual(
+      first.selected.map((r) => r.id),
+      second.selected.map((r) => r.id),
+    );
+    assert.deepEqual(first.withheldByInFlight, second.withheldByInFlight);
+  });
+
+  it('re-admits a withheld Story once its blocker leaves the in-flight set (AC-3)', () => {
+    const A = story(1, { files: ['lib/shared.js'] });
+
+    // Beat 1: #9 holds lib/shared.js → #1 is withheld and named.
+    const held = inFlight(9, { files: ['lib/shared.js'] });
+    const beat1 = planReadySet({
+      stories: [A, held],
+      inFlight: 1,
+      globalCap: 5,
+      inFlightRecords: [held],
+    });
+    assert.deepEqual(ids(beat1.selected), []);
+    assert.deepEqual(beat1.withheldByInFlight, [{ id: 1, blockedBy: 9 }]);
+
+    // Beat 2: #9 has landed, so it is no longer in flight. Nothing about #1
+    // changed — eligibility was never lost, only deferred.
+    const landed = story(9, {
+      labels: [AGENT_LABELS.DONE],
+      files: ['lib/shared.js'],
+    });
+    const beat2 = planReadySet({
+      stories: [A, landed],
+      inFlight: 0,
+      globalCap: 5,
+      inFlightRecords: [],
+    });
+    assert.deepEqual(ids(beat2.selected), [1]);
+    assert.deepEqual(beat2.withheldByInFlight, []);
+  });
+
+  it('never withholds on an empty footprint, on either side (AC-3)', () => {
+    // Withholding on absence would serialize every run: most Stories declare
+    // nothing, so "unknown" must stay permissive on BOTH sides of the compare.
+    const bareHeld = inFlight(9);
+    const bareCandidate = planReadySet({
+      stories: [story(1), bareHeld],
+      inFlight: 1,
+      globalCap: 5,
+      inFlightRecords: [bareHeld],
+    });
+    assert.deepEqual(ids(bareCandidate.selected), [1]);
+    assert.deepEqual(bareCandidate.withheldByInFlight, []);
+
+    // A footprint-bearing candidate against a footprint-less in-flight Story.
+    const declaredHeld = inFlight(9, { files: ['lib/a.js'] });
+    const noFootprint = planReadySet({
+      stories: [story(1), declaredHeld],
+      inFlight: 1,
+      globalCap: 5,
+      inFlightRecords: [declaredHeld],
+    });
+    assert.deepEqual(ids(noFootprint.selected), [1]);
+
+    // And the mirror: a declared candidate against a bare in-flight Story.
+    const bareBlocker = planReadySet({
+      stories: [story(1, { files: ['lib/a.js'] }), bareHeld],
+      inFlight: 1,
+      globalCap: 5,
+      inFlightRecords: [bareHeld],
+    });
+    assert.deepEqual(ids(bareBlocker.selected), [1]);
+  });
+
+  it('lets an in-flight glob footprint reserve everything (AC-3)', () => {
+    // Unknown width is not no width: an in-flight Story declaring lib/** may
+    // touch any of these files, so exact-string comparison must fail safe.
+    const held = inFlight(9, { files: ['.agents/scripts/lib/**'] });
+    const { selected, withheldByInFlight } = planReadySet({
+      stories: [
+        story(1, { files: ['.agents/scripts/lib/story-adjacency.js'] }),
+        story(2, { files: ['docs/README.md'] }),
+        held,
+      ],
+      inFlight: 1,
+      globalCap: 5,
+      inFlightRecords: [held],
+    });
+    assert.deepEqual(ids(selected), []);
+    assert.deepEqual(withheldByInFlight, [
+      { id: 1, blockedBy: 9 },
+      { id: 2, blockedBy: 9 },
+    ]);
+  });
+
+  it('never lets a Story reserve against itself', () => {
+    // Probe mode passes the whole record set, and a defensive caller may list
+    // a Story in both arguments. A Story overlaps itself trivially, so a naive
+    // comparison would withhold every candidate forever.
+    const A = story(1, { files: ['lib/a.js'] });
+    const { selected, withheldByInFlight } = planReadySet({
+      stories: [A],
+      inFlight: 0,
+      globalCap: 5,
+      inFlightRecords: [A],
+    });
+    assert.deepEqual(ids(selected), [1]);
+    assert.deepEqual(withheldByInFlight, []);
+  });
+
+  it('is total: absent, non-array, or unidentifiable in-flight records', () => {
+    const stories = [story(1, { files: ['lib/a.js'] })];
+    for (const inFlightRecords of [undefined, null, 'nope', 42]) {
+      const { selected, withheldByInFlight } = planReadySet({
+        stories,
+        globalCap: 5,
+        inFlightRecords,
+      });
+      assert.deepEqual(ids(selected), [1]);
+      assert.deepEqual(withheldByInFlight, []);
+    }
+    // A record with no usable id cannot be NAMED as a blocker, so it does not
+    // withhold — an unexplained empty slot is the failure this report exists
+    // to remove.
+    const anonymous = planReadySet({
+      stories,
+      globalCap: 5,
+      inFlightRecords: [{ files: ['lib/a.js'] }],
+    });
+    assert.deepEqual(ids(anonymous.selected), [1]);
+  });
+
+  it('reports an in-flight blocker rather than the same-beat peer', () => {
+    // #2 races BOTH #1 (admitted this beat) and #9 (in flight). It is withheld
+    // either way; naming the longer-lived blocker keeps the report complete.
+    const held = inFlight(9, { files: ['lib/shared.js'] });
+    const { selected, withheldByInFlight } = planReadySet({
+      stories: [
+        story(1, { files: ['lib/shared.js', 'lib/a.js'] }),
+        story(2, { files: ['lib/a.js', 'lib/shared.js'] }),
+        held,
+      ],
+      inFlight: 1,
+      globalCap: 5,
+      inFlightRecords: [held],
+    });
+    assert.deepEqual(ids(selected), []);
+    assert.deepEqual(withheldByInFlight, [
+      { id: 1, blockedBy: 9 },
+      { id: 2, blockedBy: 9 },
+    ]);
+  });
+
+  it('reserves nothing when the caller supplies no records (flag-mode parity)', () => {
+    // Flag mode holds ids and a count, never records. Behaviour there is the
+    // pre-#4950 same-beat-only guard, unchanged.
+    const { selected, withheldByInFlight } = planReadySet({
+      stories: [story(1, { files: ['lib/shared.js'] })],
+      inFlight: 1,
+      globalCap: 3,
+    });
+    assert.deepEqual(ids(selected), [1]);
+    assert.deepEqual(withheldByInFlight, []);
+  });
+
+  it('still withholds a same-beat peer when no reservation applies', () => {
+    const { selected, withheldByInFlight } = planReadySet({
+      stories: [
+        story(1, { files: ['lib/shared.js'] }),
+        story(2, { files: ['lib/shared.js'] }),
+      ],
+      globalCap: 5,
+      inFlightRecords: [],
+    });
+    assert.deepEqual(ids(selected), [1]);
+    assert.deepEqual(
+      withheldByInFlight,
+      [],
+      'a same-beat skip is NOT reported as an in-flight reservation',
+    );
+  });
+
+  it('reports nothing for a Story never considered because the cap ran out', () => {
+    // A Story below the slot line was not withheld by a reservation — it was
+    // simply not reached. Reporting it would misattribute the empty slot.
+    const held = inFlight(9, { files: ['lib/held.js'] });
+    const { selected, withheldByInFlight } = planReadySet({
+      stories: [
+        story(1, { files: ['lib/a.js'] }),
+        story(2, { files: ['lib/held.js'] }),
+        held,
+      ],
+      inFlight: 2,
+      globalCap: 3,
+      inFlightRecords: [held],
+    });
+    assert.deepEqual(ids(selected), [1], '1 slot left, #1 takes it');
+    assert.deepEqual(withheldByInFlight, [], '#2 was never reached');
+  });
+});
+
+describe('selectReadySet — the dispatch-set-only view of planReadySet', () => {
+  it('returns exactly planReadySet(...).selected', () => {
+    const held = story(9, {
+      labels: [AGENT_LABELS.EXECUTING],
+      files: ['lib/shared.js'],
+    });
+    const args = {
+      stories: [
+        story(1, { files: ['lib/shared.js'] }),
+        story(2, { files: ['lib/b.js'] }),
+        held,
+      ],
+      inFlight: 1,
+      globalCap: 5,
+      inFlightRecords: [held],
+    };
+    assert.deepEqual(selectReadySet(args), planReadySet(args).selected);
+    assert.deepEqual(ids(selectReadySet(args)), [2]);
   });
 });


### PR DESCRIPTION
Closes #4950

_Auto-opened by `/deliver`._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the continuous `/deliver` scheduling kernel and probe tick envelope on a correctness-critical path (parallel branch file conflicts), but behavior is gated on probe-provided records, flag mode is explicitly unchanged, and coverage is extensive.
> 
> **Overview**
> Extends the **co-dispatch overlap guard** so it blocks concurrent file races **across beats**, not only among Stories picked on the same beat. Previously, `inFlight` only reduced capacity; a new ready Story could still be admitted while an older beat’s Story was still implementing the same paths.
> 
> **Scheduler:** `selectReadySet` is refactored into **`planReadySet`**, which takes optional **`inFlightRecords`** and returns `{ selected, withheldByInFlight }`. Admission skips candidates whose **widened** footprint overlaps either a same-beat peer or a reserved in-flight record (`admitStories` / `findInFlightBlocker`). **`selectReadySet`** remains `planReadySet(...).selected` for callers that only need the dispatch list.
> 
> **Probe path:** `probeLiveState` now returns **`inFlightRecords`** (a projection of nodes already occupying slots, with `files` and `body`). Probe-mode `stories-wave-tick` passes those into the kernel.
> 
> **Operator visibility:** Each beat envelope gains **`inFlightReservation`** (`available`, `withheld: [{ id, blockedBy }]`, `note`) via `buildReservationReport`. Under **`--probe-live`**, reservation is active and explains withheld slots; under **`--dag`** flag mode it reports **`available: false`** (count-only, same-beat de-conflict unchanged).
> 
> Docs (`deliver-reference.md`, `architecture.md`) and tests cover reservation, flag-mode parity, and end-to-end probe ticks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dce02642f4a0bb298f6585979ae5c438f045c5b5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->