### PR TITLE
perf: run the /plan path's serial-but-independent gathers and write loops under bounded concurrency (#4952)

### DIFF
--- a/.agents/scripts/lib/orchestration/plan-context.js
+++ b/.agents/scripts/lib/orchestration/plan-context.js
@@ -41,6 +41,16 @@ import { buildDecomposerSystemPrompt } from './planning/decomposer-context.js';
 /** Bounded concurrency for `--tickets` source-ticket hydration. */
 const SOURCE_TICKET_FETCH_CONCURRENCY = 4;
 /**
+ * Bounded concurrency for the per-mode envelope gathers (Story #4952).
+ *
+ * The duplicate search, the authoring-context fold and the docs digest have
+ * no data dependency on one another — the serialization was incidental, and
+ * `/plan` pays it with the operator waiting at Gate #1. Same small bound as
+ * {@link SOURCE_TICKET_FETCH_CONCURRENCY}: the win here is overlapping three
+ * unrelated waits, not saturating the GitHub API.
+ */
+const ENVELOPE_GATHER_CONCURRENCY = 4;
+/**
  * Envelope byte ceiling (regression guard for the design's named PR2 risk:
  * two envelopes → one bigger one). This is the **only** live bound on
  * envelope size: Story #4541 removed the `applyBudget` pass from
@@ -815,6 +825,80 @@ async function searchStoryDuplicates({
 }
 
 /**
+ * Gather the three independent envelope inputs — the open-Story duplicate
+ * search, the folded authoring context, and the inline docs digest — under
+ * bounded concurrency (Story #4952).
+ *
+ * None of the three reads a value the others produce, so the result is a pure
+ * function of `seed` and the injected config: the assembled envelope is
+ * **byte-identical** to the serial build for the same inputs, whichever order
+ * the three happen to settle in. `concurrentMap` preserves input order, so the
+ * destructuring below is positional and stable.
+ *
+ * `docsContextFiles` is emptied for the `buildAuthoringContext` call: the
+ * per-plan digest-file path needs a plan id that does not exist yet — the
+ * inline digest gathered alongside it replaces that pointer.
+ *
+ * @param {{
+ *   seed: string,
+ *   epicTitle: string,
+ *   excludeIds?: Iterable<number|string>,
+ *   provider: object,
+ *   config: object,
+ *   settings: object,
+ *   cwd?: string,
+ * }} args
+ * @returns {Promise<{
+ *   duplicates: Array<object>,
+ *   authoring: object,
+ *   docsContext: { mode: 'digest-inline', digest: string }|null,
+ * }>}
+ */
+async function gatherEnvelopeInputs({
+  seed,
+  epicTitle,
+  excludeIds = [],
+  provider,
+  config,
+  settings,
+  cwd,
+}) {
+  const paths = settings?.paths ?? {};
+  const [duplicates, authoring, inlineDigest] = await concurrentMap(
+    [
+      () => searchStoryDuplicates({ seed, provider, config, excludeIds }),
+      () =>
+        buildAuthoringContext(
+          0,
+          /* provider (unused behind the prefetch seam) */ {},
+          { ...settings, docsContextFiles: [] },
+          {
+            epic: { id: 0, title: epicTitle, body: seed },
+            github: config.github ?? null,
+            cwd,
+          },
+        ),
+      () =>
+        buildDocsDigest({
+          docsContextFiles: settings?.docsContextFiles,
+          docsRoot: paths.docsRoot,
+        }),
+    ],
+    (gather) => gather(),
+    { concurrency: ENVELOPE_GATHER_CONCURRENCY },
+  );
+
+  return {
+    duplicates,
+    authoring,
+    docsContext:
+      inlineDigest == null
+        ? null
+        : { mode: 'digest-inline', digest: inlineDigest },
+  };
+}
+
+/**
  * Build the seed-file (ideation) envelope. No parent ticket
  * exists yet — creation moves to the persist half — so the open-Story
  * dup search is the mode's gating input. `docsContext` is inline-digest:
@@ -837,36 +921,16 @@ async function buildSeedFileModeEnvelope({
     );
   }
 
-  const duplicates = await searchStoryDuplicates({
+  // Dup search, the authoring-context fold grounded in the seed prose, and the
+  // inline docs digest are independent — gathered concurrently (Story #4952).
+  const { duplicates, authoring, docsContext } = await gatherEnvelopeInputs({
     seed: content,
+    epicTitle: seedFilePath ?? 'seed',
     provider,
     config,
+    settings,
+    cwd,
   });
-
-  // Fold the authoring-context builders grounded in the seed prose.
-  // `docsContextFiles` is emptied for this call: the per-plan digest-file
-  // path needs a plan id that does not exist yet — the inline digest
-  // below replaces it.
-  const authoring = await buildAuthoringContext(
-    0,
-    /* provider (unused behind the prefetch seam) */ {},
-    { ...settings, docsContextFiles: [] },
-    {
-      epic: { id: 0, title: seedFilePath ?? 'seed', body: content },
-      github: config.github ?? null,
-      cwd,
-    },
-  );
-
-  const paths = settings?.paths ?? {};
-  const inlineDigest = await buildDocsDigest({
-    docsContextFiles: settings?.docsContextFiles,
-    docsRoot: paths.docsRoot,
-  });
-  const docsContext =
-    inlineDigest == null
-      ? null
-      : { mode: 'digest-inline', digest: inlineDigest };
 
   const limits = getLimits(config);
   const heuristics = resolveRiskHeuristics(config);
@@ -1002,37 +1066,18 @@ async function buildTicketsModeEnvelope({
     .map((t) => `# ${t.title}\n\n${t.body}`)
     .join('\n\n---\n\n');
 
-  const duplicates = await searchStoryDuplicates({
+  // Same three independent gathers as seed-file mode, concurrent under the
+  // same bound (Story #4952); only the source-ticket hydration above is a
+  // genuine data dependency, because `seed` is derived from it.
+  const { duplicates, authoring, docsContext } = await gatherEnvelopeInputs({
     seed,
+    epicTitle: sourceTickets[0]?.title ?? 'tickets',
+    excludeIds: ticketIds,
     provider,
     config,
-    excludeIds: ticketIds,
+    settings,
+    cwd,
   });
-
-  const authoring = await buildAuthoringContext(
-    0,
-    {},
-    { ...settings, docsContextFiles: [] },
-    {
-      epic: {
-        id: 0,
-        title: sourceTickets[0]?.title ?? 'tickets',
-        body: seed,
-      },
-      github: config.github ?? null,
-      cwd,
-    },
-  );
-
-  const paths = settings?.paths ?? {};
-  const inlineDigest = await buildDocsDigest({
-    docsContextFiles: settings?.docsContextFiles,
-    docsRoot: paths.docsRoot,
-  });
-  const docsContext =
-    inlineDigest == null
-      ? null
-      : { mode: 'digest-inline', digest: inlineDigest };
 
   const limits = getLimits(config);
   const heuristics = resolveRiskHeuristics(config);
@@ -1148,12 +1193,25 @@ async function buildAmendmentModeEnvelope({
 
   const heuristics = resolveRiskHeuristics(config);
   const limits = getLimits(config);
-  const duplicates = await searchStoryDuplicates({
-    seed: priorBody,
-    provider,
-    config,
-    excludeIds: [amendsId],
-  });
+  // Story #4952 — this builder's independent-gather set has exactly one
+  // member. `provider.getTicket` above is a hard data dependency (the prior
+  // body IS the seed), and the mode deliberately carries no authoring-context
+  // fold and no docs digest — the prior artifacts are the grounding. It still
+  // goes through the same bounded gather as the other two builders so one file
+  // does not carry two ways of gathering independent envelope inputs.
+  const [duplicates] = await concurrentMap(
+    [
+      () =>
+        searchStoryDuplicates({
+          seed: priorBody,
+          provider,
+          config,
+          excludeIds: [amendsId],
+        }),
+    ],
+    (gather) => gather(),
+    { concurrency: ENVELOPE_GATHER_CONCURRENCY },
+  );
 
   return {
     mode: 'amends',

--- a/.agents/scripts/lib/orchestration/plan-persist/run-plan-persist.js
+++ b/.agents/scripts/lib/orchestration/plan-persist/run-plan-persist.js
@@ -38,11 +38,11 @@
  */
 
 import { rm } from 'node:fs/promises';
-import path from 'node:path';
 import { getLimits, PROJECT_ROOT } from '../../config-resolver.js';
 import { gitSpawn } from '../../git-utils.js';
 import { Logger } from '../../Logger.js';
 import { sweepTempRetention } from '../../temp-retention.js';
+import { concurrentMap } from '../../util/concurrent-map.js';
 import {
   deriveStoryShape,
   LITE_ROUTE_LABEL,
@@ -82,6 +82,14 @@ const PLAN_CHECKPOINT_SCHEMA_VERSION_V2 = 2;
 
 /** Structured-comment type for the per-plan Story checkpoint. */
 const STORY_PLAN_STATE_TYPE = 'story-plan-state';
+
+/**
+ * Bounded concurrency for the per-Story checkpoint upserts (Story #4952).
+ * Each upsert targets a different issue and reads nothing another writes, so
+ * the loop was serial only by construction — but see
+ * {@link persistStoryArtifacts} for the ordering that is *not* incidental.
+ */
+const CHECKPOINT_WRITE_CONCURRENCY = 4;
 
 /**
  * Write the `story-plan-state` checkpoint on a Story.
@@ -474,6 +482,15 @@ async function enforceReachability(reachability, config) {
  * `agent::ready` lands last so it can honestly mean "fully persisted"
  * (Story #4541). A dry run performs none of it.
  *
+ * **The checkpoints fan out; the phase boundary does not** (Story #4952). The
+ * per-Story upserts are independent of one another and run under bounded
+ * concurrency, but the `await` on that whole fan-out is what keeps the
+ * Story #4541 invariant intact: *every* checkpoint is on its ticket before the
+ * first `agent::ready` flip is issued, so `ready` still means "fully
+ * persisted" and a `/deliver` that picks a Story up cannot read a null
+ * checkpoint. Concurrency inside the phase is safe; overlapping the phases is
+ * the race this ordering exists to close.
+ *
  * @param {object} args
  * @returns {Promise<void>}
  */
@@ -484,24 +501,28 @@ async function persistStoryArtifacts({
   route,
   summaryBody,
 }) {
-  for (const story of created) {
-    await writeCheckpointV2(provider, story.id, {
-      persist: {
-        completedAt: new Date().toISOString(),
-        storyCount: created.length,
-        primaryStoryId: primary.id,
-        stories: created.map((createdStory) => ({
-          slug: createdStory.slug,
-          id: createdStory.id,
-        })),
-      },
-      // Ledger the authored route verdict — the recorded reason and the
-      // per-Story shape evidence, including a shape-refused claim — on plan
-      // state (Story #4722). No authored verdict writes no block: absence
-      // is the standard full path.
-      ...(route ? { route } : {}),
-    });
-  }
+  const cohort = created.map((createdStory) => ({
+    slug: createdStory.slug,
+    id: createdStory.id,
+  }));
+  await concurrentMap(
+    created,
+    (story) =>
+      writeCheckpointV2(provider, story.id, {
+        persist: {
+          completedAt: new Date().toISOString(),
+          storyCount: created.length,
+          primaryStoryId: primary.id,
+          stories: cohort,
+        },
+        // Ledger the authored route verdict — the recorded reason and the
+        // per-Story shape evidence, including a shape-refused claim — on plan
+        // state (Story #4722). No authored verdict writes no block: absence
+        // is the standard full path.
+        ...(route ? { route } : {}),
+      }),
+    { concurrency: CHECKPOINT_WRITE_CONCURRENCY },
+  );
   await upsertStructuredComment(
     provider,
     primary.id,

--- a/.agents/scripts/lib/orchestration/plan-persist/story-ops.js
+++ b/.agents/scripts/lib/orchestration/plan-persist/story-ops.js
@@ -24,6 +24,7 @@ import {
   parse as parseStoryBody,
   serialize as serializeStoryBody,
 } from '../../story-body/story-body.js';
+import { concurrentMap } from '../../util/concurrent-map.js';
 import { assertSpecWithinBudget } from '../spec-spill.js';
 import { assertAcceptancePartition } from '../split-policy-validator.js';
 import {
@@ -56,6 +57,15 @@ const LITE_ROUTE_LABEL_COLOR = '#D4C5F9';
 
 /** Length of the derived plan-run id (hex chars). */
 const PLAN_RUN_ID_LENGTH = 8;
+
+/**
+ * Bounded concurrency for the terminal per-Story `agent::ready` PATCHes
+ * (Story #4952). Each flip is an independent single-issue write, so the loop
+ * was serial only by construction. Deliberately the same small bound the rest
+ * of the `/plan` path uses — this is a latency fix, not a throughput one, and
+ * raising it would only push harder on the same GitHub API.
+ */
+const READY_FLIP_CONCURRENCY = 4;
 
 /**
  * Normalize a caller-supplied plan-run token. Kept shared so human-readable
@@ -795,6 +805,14 @@ async function ensurePersistLabel({
  * (see `ensureCohortLabel`). `/deliver` never reads it — delivery stays
  * ids-only over live state (Story #4540's actual point).
  *
+ * **The create loop stays serial and dependency-ordered** — deliberately, and
+ * unlike every other per-Story loop on this path (Story #4952). It is not an
+ * independent fan-out: `renderStoryBodyForCreate(story, idBySlug)` resolves a
+ * Story's `depends_on` slugs to the real issue ids its siblings were just
+ * minted with, and `idBySlug` is filled *in loop order* by the POSTs
+ * themselves. Running it concurrently would render `#undefined` dependency
+ * refs for any Story whose dependency had not yet returned an id.
+ *
  * **Sibling order is mirrored into native GitHub `blocked_by` edges** once
  * every id is known (Story #4544), so plan-created order stops depending on
  * prose. That pass is non-fatal — see `mirrorNativeDependencyEdges`.
@@ -960,6 +978,16 @@ export async function createStoryIssues({ provider, stories, opts = {} }) {
  * Fails closed: an un-flipped Story is invisible to `/deliver`, which is the
  * safe direction — the operator is told exactly which ids need the label.
  *
+ * **Collect failures, never fast-fail** (preserved verbatim under the
+ * Story #4952 concurrency conversion). Every Story is attempted even when an
+ * earlier one's PATCH rejects, because the whole value of the closing error is
+ * naming the *complete* set of ids that still need the label by hand. The
+ * mapper below therefore absorbs its own rejection into a per-Story outcome
+ * rather than letting `concurrentMap`'s first-rejection-wins policy abandon
+ * the remaining flips. `concurrentMap` preserves input order, so `readied[]`
+ * and the reported failures come back in `created[]` order exactly as the
+ * serial loop produced them.
+ *
  * @param {object} args
  * @param {object} args.provider
  * @param {Array<{ id: number, slug: string }>} args.created
@@ -972,18 +1000,29 @@ export async function markStoriesReady({ provider, created }) {
         'Stories to agent::ready.',
     );
   }
-  const readied = [];
-  const failed = [];
-  for (const story of created) {
-    try {
-      await provider.updateTicket(story.id, {
-        labels: { add: [AGENT_LABELS.READY] },
-      });
-      readied.push(story.id);
-    } catch (err) {
-      failed.push(`#${story.id} (${story.slug}): ${err.message}`);
-    }
-  }
+  const outcomes = await concurrentMap(
+    created,
+    async (story) => {
+      try {
+        await provider.updateTicket(story.id, {
+          labels: { add: [AGENT_LABELS.READY] },
+        });
+        return { id: story.id, failure: null };
+      } catch (err) {
+        return {
+          id: story.id,
+          failure: `#${story.id} (${story.slug}): ${err.message}`,
+        };
+      }
+    },
+    { concurrency: READY_FLIP_CONCURRENCY },
+  );
+  const readied = outcomes
+    .filter((outcome) => outcome.failure === null)
+    .map((outcome) => outcome.id);
+  const failed = outcomes
+    .filter((outcome) => outcome.failure !== null)
+    .map((outcome) => outcome.failure);
   if (failed.length > 0) {
     throw new Error(
       `[plan-persist] ${failed.length} Story(ies) were created with their ` +

--- a/.agents/scripts/lib/orchestration/plan-persist/supersede-ops.js
+++ b/.agents/scripts/lib/orchestration/plan-persist/supersede-ops.js
@@ -36,10 +36,23 @@
  */
 
 import { Logger } from '../../Logger.js';
+import { concurrentMap } from '../../util/concurrent-map.js';
 import { upsertStructuredComment } from '../ticketing.js';
 
 /** Structured-comment type marking a source issue as superseded. */
 const SUPERSEDED_BY_COMMENT_TYPE = 'superseded-by';
+
+/**
+ * Bounded concurrency for the per-source-ticket close (Story #4952).
+ *
+ * The fan-out is across **distinct** tickets — `assertSupersedePartition` has
+ * already failed the run closed if two Stories claim the same id, so no two
+ * units in flight can touch the same issue. Within one unit the probe →
+ * comment → close sequence stays strictly ordered: commenting on an issue the
+ * probe reported closed, or closing one the comment never landed on, is the
+ * whole failure mode this phase is careful about.
+ */
+const SUPERSEDE_CLOSE_CONCURRENCY = 4;
 
 /**
  * GitHub `state_reason` used when closing a superseded source issue.
@@ -440,39 +453,85 @@ export async function closeSupersededTickets({
   const createdBySlug = new Map(
     (created ?? []).map((story) => [story.slug, story]),
   );
+  const units = collectSupersedeUnits(stories, createdBySlug);
 
-  const report = emptyReport({ enabled: true, dryRun });
-
-  for (const story of stories ?? []) {
-    const createdStory = createdBySlug.get(story.slug);
-    for (const { id, note } of story.supersedes ?? []) {
+  // Story #4952 — one bounded fan-out across distinct source tickets. The
+  // mapper inherits `closeOneSupersededTicket`'s never-throw contract (and
+  // resolves the two pre-write outcomes itself), so `concurrentMap`'s
+  // first-rejection-wins policy can never fire and no unit is abandoned
+  // because a sibling failed. Input order is preserved, so the report arrays
+  // below read exactly as the serial nested loop wrote them.
+  const outcomes = await concurrentMap(
+    units,
+    ({ id, note, createdStory }) => {
       if (!createdStory) {
-        report.skipped.push({ ticket: id, reason: 'story-not-created' });
-        continue;
+        return { outcome: 'skipped', reason: 'story-not-created' };
       }
-      if (dryRun) {
-        report.planned.push({ ticket: id, storySlug: createdStory.slug });
-        continue;
-      }
-      const result = await closeOneSupersededTicket({
+      if (dryRun) return { outcome: 'planned' };
+      return closeOneSupersededTicket({
         provider,
         id,
         note,
         story: createdStory,
         sourceTicketIds: sources,
       });
-      if (result.outcome === 'closed') {
-        report.closed.push(id);
-      } else if (result.outcome === 'skipped') {
-        report.skipped.push({ ticket: id, reason: result.reason });
-      } else {
-        report.failed.push({ ticket: id, reason: result.reason });
-      }
-    }
-  }
+    },
+    { concurrency: SUPERSEDE_CLOSE_CONCURRENCY },
+  );
+
+  const report = emptyReport({ enabled: true, dryRun });
+  outcomes.forEach((result, index) => {
+    recordSupersedeOutcome(report, units[index], result);
+  });
 
   logSupersedeReport(report);
   return report;
+}
+
+/**
+ * Flatten the per-Story `supersedes[]` maps into one list of close units, in
+ * the nested iteration order the report arrays are expected to follow.
+ *
+ * @param {Array<{ slug: string, supersedes?: Array<{ id: number, note: string|null }> }>|undefined} stories
+ * @param {Map<string, { slug: string, id: number, title: string }>} createdBySlug
+ * @returns {Array<{ id: number, note: string|null, createdStory: object|undefined }>}
+ */
+function collectSupersedeUnits(stories, createdBySlug) {
+  const units = [];
+  for (const story of stories ?? []) {
+    const createdStory = createdBySlug.get(story.slug);
+    for (const { id, note } of story.supersedes ?? []) {
+      units.push({ id, note, createdStory });
+    }
+  }
+  return units;
+}
+
+/**
+ * File one unit's outcome onto the report.
+ *
+ * @param {SupersedeReport} report
+ * @param {{ id: number, createdStory: object|undefined }} unit
+ * @param {{ outcome: string, reason?: string }} result
+ * @returns {void}
+ */
+function recordSupersedeOutcome(report, unit, result) {
+  if (result.outcome === 'closed') {
+    report.closed.push(unit.id);
+    return;
+  }
+  if (result.outcome === 'planned') {
+    report.planned.push({
+      ticket: unit.id,
+      storySlug: unit.createdStory.slug,
+    });
+    return;
+  }
+  if (result.outcome === 'skipped') {
+    report.skipped.push({ ticket: unit.id, reason: result.reason });
+    return;
+  }
+  report.failed.push({ ticket: unit.id, reason: result.reason });
 }
 
 /**

--- a/.agents/scripts/lib/orchestration/planning/authoring-context.js
+++ b/.agents/scripts/lib/orchestration/planning/authoring-context.js
@@ -17,8 +17,16 @@ import { getPaths, PROJECT_ROOT } from '../../config-resolver.js';
 import { fetchPriorFeedback } from '../../feedback-loop/prior-feedback-fetcher.js';
 import { Logger } from '../../Logger.js';
 import { hasTicketSection } from '../../ticket-body-sections.js';
+import { concurrentMap } from '../../util/concurrent-map.js';
 import { ensureDocsDigest } from '../docs-digest.js';
 import { buildMemoryPoolAdvisory } from './memory-pool-advisory.js';
+
+/**
+ * Bounded concurrency for the independent context gathers (Story #4952).
+ * Small on purpose and consistent with the other `/plan`-path fan-outs: these
+ * are a handful of local probes plus one `gh` read, not an API sweep.
+ */
+const CONTEXT_GATHER_CONCURRENCY = 4;
 
 /**
  * Build the digest-first `docsContext` envelope field (Story #4433 — hard
@@ -67,6 +75,24 @@ async function buildPlanningDocsContext({ seedIssueId, settings, cwd }) {
 }
 
 /**
+ * Story #2637 — index existing BDD scenarios so the Acceptance Engineer step
+ * can annotate planned ACs with matches from the project's `.feature` files.
+ * Empty array when the project has not adopted BDD; the scanner is
+ * best-effort and never throws on filesystem errors.
+ *
+ * @returns {Array<object>}
+ */
+function scanBddScenariosBestEffort() {
+  try {
+    const featureRoots = resolveFeatureRoots({ cwd: PROJECT_ROOT });
+    return scanBddScenarios({ featureRoots });
+  } catch (err) {
+    Logger.warn(`[plan-context] BDD scenario scan skipped: ${err.message}`);
+    return [];
+  }
+}
+
+/**
  * Build the authoring context the host LLM (or the
  * `/plan` author step) needs to write the Tech Spec.
  *
@@ -101,49 +127,51 @@ export async function buildAuthoringContext(
 
   const { cwd = PROJECT_ROOT } = opts;
 
-  const docsContext = await buildPlanningDocsContext({
-    seedIssueId: epic.id,
-    settings,
-    cwd,
-  });
-
-  // Story #2094 Task #2103 — verify the project's BDD runner pending-tag
-  // support so the acceptance-spec body can record either the verified tag
-  // (features-first ordering) or "fallback: dependencies-first ordering"
-  // when no supported runner is present.
-  const bddRunner = await verifyBddRunnerPendingTag({ cwd: PROJECT_ROOT });
-
-  // Story #2637 — index existing BDD scenarios so the Acceptance Engineer
-  // step can annotate planned ACs with matches from the project's
-  // `.feature` files. Empty array when the project has not adopted BDD;
-  // the scanner is best-effort and never throws on filesystem errors.
-  let bddScenarios = [];
-  try {
-    const featureRoots = resolveFeatureRoots({ cwd: PROJECT_ROOT });
-    bddScenarios = scanBddScenarios({ featureRoots });
-  } catch (err) {
-    Logger.warn(`[plan-context] BDD scenario scan skipped: ${err.message}`);
-  }
-
-  // Story #4919 — the memory-freshness pre-flight (#2557 / #4414) is retired
-  // and this advisory replaces it in the same slot. The scanner marked an
-  // entry stale when a cited issue was closed, but the memory corpus is
-  // delivery retrospectives whose subject IS a delivered Story — and its
-  // directory (`~/.claude/projects/<repo>/memory/`) never resolved, because
-  // harness project dirs are cwd-slugs. This renders no per-entry verdict at
-  // all: it stats and counts, and the `/plan` spine surfaces `recommend` at
-  // Gate #1. Filesystem-only and total — it never throws.
   const githubCfg = opts.github ?? null;
-  const memoryPoolAdvisory = buildMemoryPoolAdvisory({ cwd: PROJECT_ROOT });
 
-  // Story #2554 — surface open meta feedback issues to the planner so retro
-  // signals are routed into durable substrates rather than lost in chat.
-  // The fetcher is best-effort: missing owner/repo or gh-CLI failures land
-  // in `errors[]` and never throw.
-  const priorFeedback = await fetchPriorFeedback({
-    owner: githubCfg?.owner,
-    repo: githubCfg?.repo,
-  });
+  // Story #4952 — these five gathers share no data, so they run under bounded
+  // concurrency instead of five sequential awaits on the interactive `/plan`
+  // path. `concurrentMap` preserves input order, so the destructuring is
+  // positional and the produced context is identical to the serial build:
+  //
+  //   1. the digest-first `docsContext` pointer (Story #4433);
+  //   2. Story #2094 Task #2103 — the project's BDD runner pending-tag
+  //      support, so the acceptance-spec body records either the verified tag
+  //      (features-first ordering) or "fallback: dependencies-first ordering"
+  //      when no supported runner is present;
+  //   3. the best-effort `.feature` scenario index;
+  //   4. Story #4919 — the memory-pool advisory that replaced the retired
+  //      memory-freshness pre-flight (#2557 / #4414) in the same slot. The
+  //      scanner marked an entry stale when a cited issue was closed, but the
+  //      memory corpus is delivery retrospectives whose subject IS a delivered
+  //      Story — and its directory (`~/.claude/projects/<repo>/memory/`) never
+  //      resolved, because harness project dirs are cwd-slugs. This renders no
+  //      per-entry verdict at all: it stats and counts, and the `/plan` spine
+  //      surfaces `recommend` at Gate #1. Filesystem-only and total;
+  //   5. Story #2554 — open meta feedback issues, so retro signals are routed
+  //      into durable substrates rather than lost in chat. Best-effort:
+  //      missing owner/repo or gh-CLI failures land in `errors[]`, never throw.
+  const [
+    docsContext,
+    bddRunner,
+    bddScenarios,
+    memoryPoolAdvisory,
+    priorFeedback,
+  ] = await concurrentMap(
+    [
+      () => buildPlanningDocsContext({ seedIssueId: epic.id, settings, cwd }),
+      () => verifyBddRunnerPendingTag({ cwd: PROJECT_ROOT }),
+      () => scanBddScenariosBestEffort(),
+      () => buildMemoryPoolAdvisory({ cwd: PROJECT_ROOT }),
+      () =>
+        fetchPriorFeedback({
+          owner: githubCfg?.owner,
+          repo: githubCfg?.repo,
+        }),
+    ],
+    (gather) => gather(),
+    { concurrency: CONTEXT_GATHER_CONCURRENCY },
+  );
 
   // Story #4811 — the codebase snapshot (#2634), its authoring grounding
   // (#4139 F10) and the spec-freshness helpers behind it are retired. The

--- a/tests/plan-context.test.js
+++ b/tests/plan-context.test.js
@@ -1411,3 +1411,157 @@ describe('plan-context amends mode — delta envelope (Story #4741 AC-4)', () =>
     assert.deepEqual(env.amends.deliveredFiles, []);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Story #4952 — the per-mode envelope gathers run under bounded concurrency.
+// ---------------------------------------------------------------------------
+
+describe('plan-context concurrent envelope gathers (Story #4952)', () => {
+  /**
+   * A provider whose duplicate-search read settles after every other gather.
+   *
+   * This is the axis the conversion actually risks: the dup search, the
+   * authoring-context fold, and the docs digest are now in flight together, so
+   * an envelope that depended on their *completion order* would differ run to
+   * run. Delaying one gather past the others is what makes that order differ.
+   */
+  /**
+   * Serialize an envelope for byte comparison, neutralising the one field that
+   * is a function of *when* the build ran rather than *what* it was built
+   * from: `priorFeedback.fetchedAt`, the wall clock the feedback fetcher
+   * stamps on its own result. Everything else must match byte for byte.
+   */
+  function stableEnvelope(env) {
+    return JSON.stringify(env, (key, value) =>
+      key === 'fetchedAt' ? '<stamped>' : value,
+    );
+  }
+
+  function slowDupSearchProvider(delayMs = 40) {
+    const provider = buildProvider();
+    const { listIssuesByLabel } = provider;
+    provider.listIssuesByLabel = async (filters) => {
+      await new Promise((resolve) => setTimeout(resolve, delayMs));
+      return listIssuesByLabel(filters);
+    };
+    return provider;
+  }
+
+  it('seed-file: the envelope is byte-identical whichever gather settles first', async () => {
+    const args = {
+      mode: 'seed-file',
+      seedFilePath: '/tmp/one-pager.md',
+      seedFileContent: ONE_PAGER,
+      config: {},
+      settings: {},
+    };
+    const natural = await buildPlanContext({
+      ...args,
+      provider: buildProvider(),
+    });
+    const reordered = await buildPlanContext({
+      ...args,
+      provider: slowDupSearchProvider(),
+    });
+    assert.equal(stableEnvelope(reordered), stableEnvelope(natural));
+    // Guard against a vacuous pass: the gathered fields must carry content.
+    assert.ok(natural.duplicates.length > 0);
+    assert.equal(natural.mode, 'seed-file');
+  });
+
+  it('tickets: the envelope is byte-identical whichever gather settles first', async () => {
+    const args = {
+      mode: 'tickets',
+      ticketIds: [301, 302],
+      config: { github: { owner: 'o', repo: 'r' } },
+      settings: {},
+    };
+    const natural = await buildPlanContext({
+      ...args,
+      provider: buildProvider(),
+    });
+    const reordered = await buildPlanContext({
+      ...args,
+      provider: slowDupSearchProvider(),
+    });
+    assert.equal(stableEnvelope(reordered), stableEnvelope(natural));
+    assert.deepEqual(
+      natural.sourceTickets.map((t) => t.id),
+      [301, 302],
+    );
+  });
+
+  it('amends: the envelope is byte-identical whichever gather settles first', async () => {
+    // The amends builder's independent-gather set is a single item — the prior
+    // ticket read is a hard data dependency — so this pins that routing it
+    // through the same bounded gather changed nothing observable.
+    const args = { mode: 'amends', amendsId: 4700, config: {}, settings: {} };
+    const priorTicket = async (id) => ({
+      id,
+      number: id,
+      title: 'Widget exporter',
+      body: PRIOR_STORY_BODY,
+      labels: ['type::story'],
+    });
+
+    const fast = buildProvider();
+    fast.getTicket = priorTicket;
+    const slow = slowDupSearchProvider();
+    slow.getTicket = priorTicket;
+
+    const natural = await buildPlanContext({ ...args, provider: fast });
+    const reordered = await buildPlanContext({ ...args, provider: slow });
+    assert.equal(stableEnvelope(reordered), stableEnvelope(natural));
+    assert.equal(natural.amends.priorBody, PRIOR_STORY_BODY);
+  });
+
+  it('starts the authoring fold and the docs digest while the dup search is still in flight', async () => {
+    // The discriminating observation. Both the authoring fold and the docs
+    // digest read `settings.docsContextFiles` as they are *entered*, so a
+    // counting getter on that key reports whether they were entered at all.
+    // Serial, they are unreachable until the dup search resolves — with the
+    // search parked on a gate the count stays 0. Concurrent, all three gathers
+    // are dispatched together and the count is non-zero before the gate opens.
+    let docsContextReads = 0;
+    const settings = {};
+    Object.defineProperty(settings, 'docsContextFiles', {
+      enumerable: true,
+      get() {
+        docsContextReads += 1;
+        return [];
+      },
+    });
+
+    let openGate;
+    const gate = new Promise((resolve) => {
+      openGate = resolve;
+    });
+    const provider = buildProvider();
+    const { listIssuesByLabel } = provider;
+    provider.listIssuesByLabel = async (filters) => {
+      await gate;
+      return listIssuesByLabel(filters);
+    };
+
+    const pending = buildPlanContext({
+      mode: 'seed-file',
+      seedFilePath: '/tmp/one-pager.md',
+      seedFileContent: ONE_PAGER,
+      provider,
+      config: {},
+      settings,
+    });
+
+    await new Promise((resolve) => setImmediate(resolve));
+    assert.ok(
+      docsContextReads > 0,
+      'the authoring fold / docs digest must be in flight while the ' +
+        `duplicate search is parked (reads=${docsContextReads})`,
+    );
+
+    openGate();
+    const env = await pending;
+    assert.ok(env.duplicates.length > 0);
+    assert.ok(env.bddRunner !== undefined, 'the authoring fold still landed');
+  });
+});

--- a/tests/scripts/plan-persist.flat-stories.test.js
+++ b/tests/scripts/plan-persist.flat-stories.test.js
@@ -23,6 +23,9 @@ import {
   runPlanPersist,
 } from '../../.agents/scripts/lib/orchestration/plan-persist/run-plan-persist.js';
 import {
+  assemblePlanStories,
+  createStoryIssues,
+  markStoriesReady,
   planStoryFingerprint,
   sanitizeAuthoredLabels,
 } from '../../.agents/scripts/lib/orchestration/plan-persist/story-ops.js';
@@ -1453,5 +1456,302 @@ describe('reapStalePlanDirs (Story #4541)', () => {
       }),
       { reaped: [] },
     );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Story #4952 — the independent per-Story write loops run under bounded
+// concurrency; the loop that is NOT independent stays serial.
+// ---------------------------------------------------------------------------
+
+/**
+ * Wrap a provider method so the test can observe how many calls are in flight
+ * at once, and hold each call open long enough for overlap to be visible.
+ *
+ * A serial loop can never exceed a peak of 1; a bounded fan-out must exceed 1
+ * and must never exceed its bound.
+ */
+function trackInFlight(target, method, { hold = 5 } = {}) {
+  const original = target[method].bind(target);
+  const state = { peak: 0, inFlight: 0, calls: [] };
+  target[method] = async (...args) => {
+    state.inFlight += 1;
+    state.peak = Math.max(state.peak, state.inFlight);
+    state.calls.push(args[0]);
+    try {
+      await new Promise((resolve) => setTimeout(resolve, hold));
+      return await original(...args);
+    } finally {
+      state.inFlight -= 1;
+    }
+  };
+  return state;
+}
+
+describe('markStoriesReady — bounded concurrency (Story #4952)', () => {
+  it('flips every Story concurrently, under the bound, in created order', async () => {
+    const provider = fakeProvider();
+    const created = Array.from({ length: 9 }, (_, i) => ({
+      id: 7000 + i,
+      slug: `story-${i}`,
+    }));
+    for (const story of created) {
+      provider.issues.set(story.id, { id: story.id, labels: [] });
+    }
+
+    const flips = trackInFlight(provider, 'updateTicket');
+    const { readied } = await markStoriesReady({ provider, created });
+
+    assert.deepEqual(
+      readied,
+      created.map((s) => s.id),
+      'readied[] follows created[] order, as the serial loop produced it',
+    );
+    assert.ok(flips.peak > 1, `expected concurrent flips, peak=${flips.peak}`);
+    assert.ok(
+      flips.peak <= 4,
+      `expected a bounded fan-out, peak=${flips.peak}`,
+    );
+    for (const story of created) {
+      assert.ok(
+        provider.issues.get(story.id).labels.includes(AGENT_LABELS.READY),
+      );
+    }
+  });
+
+  it('collects every failure instead of fast-failing on the first one', async () => {
+    // The contract the conversion must not lose: the closing error names the
+    // COMPLETE set of ids that still need the label by hand, so every Story is
+    // attempted even after an earlier PATCH rejects. concurrentMap's
+    // first-rejection-wins policy would abandon the rest.
+    const provider = fakeProvider();
+    const created = [
+      { id: 7100, slug: 'alpha' },
+      { id: 7101, slug: 'beta' },
+      { id: 7102, slug: 'gamma' },
+      { id: 7103, slug: 'delta' },
+    ];
+    for (const story of created) {
+      provider.issues.set(story.id, { id: story.id, labels: [] });
+    }
+    const attempted = [];
+    provider.updateTicket = async (id) => {
+      attempted.push(id);
+      if (id === 7100 || id === 7102) {
+        throw new Error(`boom ${id}`);
+      }
+      provider.issues.get(id).labels.push(AGENT_LABELS.READY);
+    };
+
+    await assert.rejects(
+      () => markStoriesReady({ provider, created }),
+      (err) => {
+        assert.match(err.message, /#7100 \(alpha\): boom 7100/);
+        assert.match(err.message, /#7102 \(gamma\): boom 7102/);
+        assert.match(err.message, /2 Story\(ies\) were created/);
+        return true;
+      },
+    );
+    assert.deepEqual(
+      attempted.sort(),
+      [7100, 7101, 7102, 7103],
+      'the first failure must not abandon the remaining flips',
+    );
+    // The Stories that could be flipped still were.
+    assert.ok(provider.issues.get(7101).labels.includes(AGENT_LABELS.READY));
+    assert.ok(provider.issues.get(7103).labels.includes(AGENT_LABELS.READY));
+  });
+});
+
+describe('createStoryIssues — deliberately serial (Story #4952 AC-3)', () => {
+  it('creates dependency-ordered Stories one at a time so idBySlug is filled in order', async () => {
+    // NOT an independent fan-out: renderStoryBodyForCreate resolves a Story's
+    // depends_on slugs against ids its siblings were just minted with, and
+    // idBySlug fills in loop order. Concurrent creation would render
+    // `#undefined` dependency refs.
+    const provider = fakeProvider();
+    const creates = trackInFlight(provider, 'createIssue');
+
+    const { stories } = assemblePlanStories([
+      { ...ticket('base'), depends_on: [] },
+      { ...ticket('middle'), depends_on: ['base'] },
+      { ...ticket('leaf'), depends_on: ['middle'] },
+    ]);
+    const { created } = await createStoryIssues({ provider, stories });
+
+    assert.equal(
+      creates.peak,
+      1,
+      `createStoryIssues must stay serial, peak=${creates.peak}`,
+    );
+    assert.deepEqual(
+      created.map((s) => s.slug),
+      ['base', 'middle', 'leaf'],
+      'creation follows the dependency order',
+    );
+
+    const idBySlug = new Map(created.map((s) => [s.slug, s.id]));
+    const middleBody = provider.issues.get(idBySlug.get('middle')).body;
+    const leafBody = provider.issues.get(idBySlug.get('leaf')).body;
+    assert.match(middleBody, new RegExp(`#${idBySlug.get('base')}`));
+    assert.match(leafBody, new RegExp(`#${idBySlug.get('middle')}`));
+    assert.doesNotMatch(middleBody, /#undefined/);
+    assert.doesNotMatch(leafBody, /#undefined/);
+  });
+});
+
+describe('persist write loops — concurrent, ordering preserved (Story #4952)', () => {
+  it('fans the checkpoints out but lands every one before the first ready flip', async () => {
+    // Story #4541's invariant survives the fan-out: agent::ready still means
+    // "fully persisted", so no phase may overlap the next.
+    const provider = fakeProvider();
+    const order = [];
+    let checkpointsInFlight = 0;
+    let checkpointPeak = 0;
+
+    const { postComment } = provider;
+    provider.postComment = async (issueNumber, payload) => {
+      const body = typeof payload === 'string' ? payload : payload.body;
+      if (body.includes('story-plan-state')) {
+        checkpointsInFlight += 1;
+        checkpointPeak = Math.max(checkpointPeak, checkpointsInFlight);
+        await new Promise((resolve) => setTimeout(resolve, 5));
+        checkpointsInFlight -= 1;
+        order.push('checkpoint');
+      }
+      return postComment(issueNumber, payload);
+    };
+    const { updateTicket } = provider;
+    provider.updateTicket = async (id, mutations) => {
+      if (mutations.labels?.add?.includes(AGENT_LABELS.READY)) {
+        order.push('ready');
+      }
+      return updateTicket(id, mutations);
+    };
+
+    const result = await runPlanPersist({
+      provider,
+      artifacts: {
+        stories: [ticket('one'), ticket('two'), ticket('three')],
+      },
+      config: {},
+      opts: { skipCleanup: true },
+    });
+
+    assert.equal(result.stories.length, 3);
+    assert.ok(
+      checkpointPeak > 1,
+      `expected the checkpoint writes to overlap, peak=${checkpointPeak}`,
+    );
+    const lastCheckpoint = order.lastIndexOf('checkpoint');
+    const firstReady = order.indexOf('ready');
+    assert.equal(order.filter((e) => e === 'checkpoint').length, 3);
+    assert.equal(order.filter((e) => e === 'ready').length, 3);
+    assert.ok(
+      lastCheckpoint < firstReady,
+      `every checkpoint must land before the first ready flip (${order.join(',')})`,
+    );
+  });
+});
+
+describe('supersede close — bounded concurrency (Story #4952)', () => {
+  function supersedingTicket(slug, supersedes) {
+    return { ...ticket(slug), supersedes };
+  }
+
+  it('closes distinct tickets concurrently, keeping probe → comment → close per ticket', async () => {
+    const sourceIds = [940, 941, 942, 943, 944];
+    const provider = fakeProvider({
+      sources: sourceIds.map((id) => ({ id, title: `Source ${id}` })),
+    });
+
+    /** Per-ticket call log, plus the cross-ticket overlap peak. */
+    const log = new Map(sourceIds.map((id) => [id, []]));
+    let inFlight = 0;
+    let peak = 0;
+
+    const { getTicket } = provider;
+    provider.getTicket = async (id, opts) => {
+      if (log.has(id)) {
+        inFlight += 1;
+        peak = Math.max(peak, inFlight);
+        log.get(id).push('probe');
+        await new Promise((resolve) => setTimeout(resolve, 5));
+        inFlight -= 1;
+      }
+      return getTicket(id, opts);
+    };
+    const { postComment } = provider;
+    provider.postComment = async (issueNumber, payload) => {
+      if (log.has(issueNumber)) log.get(issueNumber).push('comment');
+      return postComment(issueNumber, payload);
+    };
+    const { updateTicket } = provider;
+    provider.updateTicket = async (id, mutations) => {
+      if (log.has(id) && mutations.state === 'closed') {
+        log.get(id).push('close');
+      }
+      return updateTicket(id, mutations);
+    };
+
+    const result = await runPlanPersist({
+      provider,
+      artifacts: {
+        stories: sourceIds.map((id, i) =>
+          supersedingTicket(`story-${i}`, [id]),
+        ),
+      },
+      opts: { skipCleanup: true, sourceTicketIds: sourceIds },
+    });
+
+    assert.deepEqual(
+      result.supersede.closed,
+      sourceIds,
+      'report order is stable',
+    );
+    assert.deepEqual(result.supersede.failed, []);
+    assert.ok(
+      peak > 1,
+      `expected concurrent probes across tickets, peak=${peak}`,
+    );
+    assert.ok(peak <= 4, `expected a bounded fan-out, peak=${peak}`);
+    for (const id of sourceIds) {
+      assert.deepEqual(
+        log.get(id),
+        ['probe', 'comment', 'close'],
+        `#${id} must stay probe → comment → close`,
+      );
+    }
+  });
+
+  it('keeps per-unit failures per-unit — one bad ticket never abandons the rest', async () => {
+    const sourceIds = [950, 951, 952];
+    const provider = fakeProvider({
+      sources: sourceIds.map((id) => ({ id })),
+    });
+    const { updateTicket } = provider;
+    provider.updateTicket = async (id, mutations) => {
+      if (id === 951 && mutations.state === 'closed') {
+        throw new Error('close refused');
+      }
+      return updateTicket(id, mutations);
+    };
+
+    const result = await runPlanPersist({
+      provider,
+      artifacts: {
+        stories: sourceIds.map((id, i) =>
+          supersedingTicket(`story-${i}`, [id]),
+        ),
+      },
+      opts: { skipCleanup: true, sourceTicketIds: sourceIds },
+    });
+
+    assert.deepEqual(result.supersede.closed, [950, 952]);
+    assert.deepEqual(result.supersede.failed, [
+      { ticket: 951, reason: 'close refused' },
+    ]);
+    assert.equal(provider.issues.get(950).state, 'closed');
+    assert.equal(provider.issues.get(952).state, 'closed');
   });
 });


### PR DESCRIPTION
Closes #4952

_Auto-opened by `/deliver`._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches plan-persist ordering invariants (`agent::ready` after checkpoints) and GitHub write concurrency; behavior is heavily tested but regressions would affect `/plan` latency or delivery visibility of Stories.
> 
> **Overview**
> **Story #4952** cuts Gate #1 wait time by running independent work in parallel instead of back-to-back `await`s, using the shared `concurrentMap` helper with a concurrency cap of **4** (same bound as existing ticket hydration).
> 
> **Plan context:** New `gatherEnvelopeInputs` runs duplicate search, `buildAuthoringContext`, and inline docs digest together for seed-file and `--tickets` modes; amends mode routes its single dup search through the same helper for consistency. **`buildAuthoringContext`** now fans out five unrelated probes (docs digest pointer, BDD runner tag, scenario scan, memory-pool advisory, prior feedback) concurrently, with BDD scanning extracted to `scanBddScenariosBestEffort`.
> 
> **Plan persist:** Per-Story checkpoint upserts, `agent::ready` label flips, and superseded-ticket closes fan out under bounded concurrency. **`createStoryIssues` stays serial** because `depends_on` slug→id resolution depends on loop order. Checkpoint writes complete before any ready flip (Story #4541 invariant). **`markStoriesReady`** still collects every failure instead of fast-failing on the first PATCH rejection.
> 
> Tests assert byte-identical envelopes under reordered gather timing, concurrent overlap where expected, peak concurrency ≤ 4, and preserved phase ordering.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 980724198340076ced9fe70f77ce30e8fab0bee2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->