### PR TITLE
feat: default multi-Story closes to async merge-watch and mandate one-turn sub-agent dispatch at the three sanctioned fan-out points (#4949)

### DIFF
--- a/.agents/scripts/lib/cli-args.js
+++ b/.agents/scripts/lib/cli-args.js
@@ -62,6 +62,35 @@ function parsePositiveInt(value) {
   return Number.isInteger(parsed) && parsed > 0 ? parsed : undefined;
 }
 
+/** The only two merge-watch postures `--merge-watch-mode` accepts. */
+const MERGE_WATCH_MODES = ['sync', 'async'];
+
+/**
+ * Parse `--merge-watch-mode` (Story #4949), the per-invocation override of
+ * `delivery.mergeWatch.mode`. Absence is preserved as `undefined` so the
+ * caller can distinguish "not supplied" (fall back to config) from an explicit
+ * posture — the same contract {@link parsePositiveInt} gives
+ * `--max-wait-seconds`.
+ *
+ * Unlike that sibling, an unrecognized value **throws** rather than degrading
+ * to absent. A `--max-wait-seconds` typo falls back to a sane bound; a
+ * `--merge-watch-mode` typo would fall back to `sync` and silently return a
+ * multi-Story run to a serialized foreground wait per close, with the wall
+ * clock as the only evidence. Parsing runs before the first close phase, so
+ * failing here costs no mutation.
+ *
+ * @param {unknown} value
+ * @returns {'sync'|'async'|undefined}
+ */
+export function parseMergeWatchMode(value) {
+  if (value == null) return undefined;
+  const mode = String(value).trim().toLowerCase();
+  if (MERGE_WATCH_MODES.includes(mode)) return mode;
+  throw new Error(
+    `--merge-watch-mode must be one of ${MERGE_WATCH_MODES.join('|')} (got "${value}")`,
+  );
+}
+
 /**
  * Standardized CLI argument parser for sprint scripts.
  * Supports options like --epic, --story, --dry-run, --skip-dashboard.
@@ -85,6 +114,10 @@ export function parseSprintArgs(args = process.argv) {
       // Story #4543 — per-run override of `delivery.mergeWatch.maxWaitSeconds`
       // (the merge wait's per-invocation bound). Absent means "use the config".
       'max-wait-seconds': { type: 'string' },
+      // Story #4949 — per-invocation override of `delivery.mergeWatch.mode`.
+      // Absent means "use the config"; see `parseMergeWatchMode` for why an
+      // unrecognized value fails closed instead of degrading to absent.
+      'merge-watch-mode': { type: 'string' },
       executor: { type: 'string' },
       cwd: { type: 'string' },
       'recut-of': { type: 'string' },
@@ -115,6 +148,10 @@ export function parseSprintArgs(args = process.argv) {
     // headless caller with no host tool-invocation ceiling, so it lands in
     // one block instead of returning `pending` at the default 300s.
     maxWaitSeconds: parsePositiveInt(values['max-wait-seconds']),
+    // Story #4949 — per-invocation override of `delivery.mergeWatch.mode`.
+    // `undefined` when the flag is absent, which is what lets the merge wait
+    // fall back to the config; anything unrecognized throws here.
+    mergeWatchMode: parseMergeWatchMode(values['merge-watch-mode']),
     executor: values.executor ?? null,
     // Resolve worktree cwd from flag or env. Empty string/whitespace → null.
     cwd:

--- a/.agents/scripts/lib/orchestration/run-epilogue.js
+++ b/.agents/scripts/lib/orchestration/run-epilogue.js
@@ -494,6 +494,18 @@ async function executeAuditRoster({
       ? selectedAudits.map((lens) => `- \`${lens}\``)
       : ['- _(none — docs-only or no matching change-set lenses)_']),
     '',
+    // Story #4949 — the roster used to name the lenses and say nothing about
+    // how to dispatch them, which made a serial walk (and a nested
+    // coordinator) fully compliant with it. The lenses are read-only and share
+    // no write paths, so they are the textbook independent fan-out; naming the
+    // shape here is what turns that from an option into the instruction.
+    '**Dispatch shape (MUST): flat, parallel, one turn.** Spawn one ' +
+      '`auditor` sub-agent per lens listed above and issue every one of those ' +
+      'spawns in a SINGLE turn — no nested fan-out, no serial walk. A ' +
+      'coordinator sub-agent that re-dispatches the lenses is the failure ' +
+      'this line exists to prevent: a grandchild routes its findings to the ' +
+      'wrong parent or loses them outright.',
+    '',
     '```json',
     JSON.stringify(
       {

--- a/.agents/scripts/lib/orchestration/single-story-close/phases/confirm-merge.js
+++ b/.agents/scripts/lib/orchestration/single-story-close/phases/confirm-merge.js
@@ -282,15 +282,33 @@ export async function readPrWaitProbe({
  * explicit `maxWaitSecondsOverride` still wins over the async cap — a headless
  * caller with no host ceiling opts back into single-block waiting.
  *
+ * `modeOverride` is the per-invocation `--merge-watch-mode` flag (Story #4949)
+ * and wins over `delivery.mergeWatch.mode` on exactly the precedence
+ * `maxWaitSecondsOverride` already uses. It exists because run topology is
+ * knowable only to the orchestrator: close sees one Story and cannot tell a
+ * solo delivery (where a foreground wait is the cheapest ending) from the Nth
+ * close of a wave (where each foreground wait is serialized dead time). The
+ * config default therefore stays `sync`, and the caller that knows better says
+ * so per invocation. The two flags remain composable — `--merge-watch-mode
+ * async --max-wait-seconds 900` selects the async posture and then overrides
+ * its probe cap, because the cap check below keys on the override's presence,
+ * not on where the mode came from.
+ *
  * @param {object} [config]
  * @param {number} [maxWaitSecondsOverride]
+ * @param {'sync'|'async'} [modeOverride]
  * @returns {{ mode: 'sync'|'async', intervalSeconds: number, maxWaitSeconds: number, maxBudgetSeconds: number, updateAttempts: number }}
  */
-export function resolveMergeWaitConfig(config, maxWaitSecondsOverride) {
+export function resolveMergeWaitConfig(
+  config,
+  maxWaitSecondsOverride,
+  modeOverride,
+) {
   const mergeWatch = config?.delivery?.mergeWatch ?? {};
   const int = (value, fallback, min = 1) =>
     Number.isInteger(value) && value >= min ? value : fallback;
-  const mode = mergeWatch.mode === 'async' ? 'async' : 'sync';
+  const requestedMode = modeOverride ?? mergeWatch.mode;
+  const mode = requestedMode === 'async' ? 'async' : 'sync';
   const configuredMaxWait = int(
     maxWaitSecondsOverride,
     int(mergeWatch.maxWaitSeconds, DEFAULT_MAX_WAIT_SECONDS),
@@ -759,6 +777,9 @@ async function onMergeObserved({
  * @param {string|null} args.autoMergeReason
  * @param {object} args.provider
  * @param {object} [args.config]
+ * @param {'sync'|'async'} [args.mergeWatchMode] Per-invocation
+ *   `--merge-watch-mode` override (Story #4949); wins over
+ *   `delivery.mergeWatch.mode`.
  * @param {(tag: string, msg: string) => void} [args.progress]
  * @param {object} [args.injectedGh]
  * @param {Function} [args.injectedNotify]
@@ -791,6 +812,7 @@ export async function runConfirmMergePhase({
   provider,
   config,
   maxWaitSeconds: maxWaitSecondsOverride,
+  mergeWatchMode: mergeWatchModeOverride,
   progress,
   injectedGh,
   injectedNotify,
@@ -833,7 +855,11 @@ export async function runConfirmMergePhase({
     maxWaitSeconds,
     maxBudgetSeconds,
     updateAttempts,
-  } = resolveMergeWaitConfig(config, maxWaitSecondsOverride);
+  } = resolveMergeWaitConfig(
+    config,
+    maxWaitSecondsOverride,
+    mergeWatchModeOverride,
+  );
   const intervalMs = intervalSeconds * 1000;
   const startedAtMs = nowMsFn();
   let anchorMs = startedAtMs;

--- a/.agents/scripts/lib/orchestration/single-story-close/phases/options.js
+++ b/.agents/scripts/lib/orchestration/single-story-close/phases/options.js
@@ -9,7 +9,7 @@
  */
 
 import path from 'node:path';
-import { parseSprintArgs } from '../../../cli-args.js';
+import { parseMergeWatchMode, parseSprintArgs } from '../../../cli-args.js';
 import { getDeliveryRouting } from '../../../config/delivery-routing.js';
 import { PROJECT_ROOT } from '../../../project-root.js';
 import { isOperatorMergeReason } from './auto-merge.js';
@@ -21,7 +21,8 @@ import { isOperatorMergeReason } from './auto-merge.js';
  * @template T
  * @param {T|undefined} paramValue
  * @param {T|undefined} parsedValue
- * @param {T} defaultValue
+ * @param {T} [defaultValue] Omitted when "neither supplied" is itself the
+ *   answer — the caller then distinguishes absence from a real value.
  * @returns {T}
  */
 function resolveFlag(paramValue, parsedValue, defaultValue) {
@@ -87,8 +88,8 @@ export function resolveWaitForMerge({
  * (`waitForMergeExplicit` / `noWaitForMerge`) for the runner to resolve once
  * the config and the arm outcome exist.
  *
- * @param {{ storyIdParam, cwdParam, skipValidationParam, skipSyncParam, noAutoMergeParam, waitForMergeParam, noWaitForMergeParam, maxWaitSecondsParam }} raw
- * @returns {{ storyId, cwd, skipValidation, skipSync, noAutoMerge, waitForMergeExplicit, noWaitForMerge, maxWaitSeconds }}
+ * @param {{ storyIdParam, cwdParam, skipValidationParam, skipSyncParam, noAutoMergeParam, waitForMergeParam, noWaitForMergeParam, maxWaitSecondsParam, mergeWatchModeParam }} raw
+ * @returns {{ storyId, cwd, skipValidation, skipSync, noAutoMerge, waitForMergeExplicit, noWaitForMerge, maxWaitSeconds, mergeWatchMode }}
  */
 export function parseCloseOptions({
   storyIdParam,
@@ -99,26 +100,27 @@ export function parseCloseOptions({
   waitForMergeParam,
   noWaitForMergeParam,
   maxWaitSecondsParam,
+  mergeWatchModeParam,
 }) {
-  const parsed =
-    storyIdParam !== undefined
-      ? {
-          storyId: storyIdParam,
-          cwd: cwdParam ?? null,
-          skipValidation: !!skipValidationParam,
-          skipSync: !!skipSyncParam,
-          noAutoMerge: !!noAutoMergeParam,
-          // Preserve undefined so resolveWaitForMerge can apply the
-          // closeAndLand config default when neither flag was injected.
-          waitForMerge: waitForMergeParam,
-          noWaitForMerge: !!noWaitForMergeParam,
-          maxWaitSeconds: maxWaitSecondsParam,
-        }
-      : parseSprintArgs();
-  const waitForMergeExplicit = waitForMergeParam ?? parsed.waitForMerge;
-  const maxWaitSeconds = maxWaitSecondsParam ?? parsed.maxWaitSeconds;
+  // An injecting caller (`storyIdParam` supplied) is not reading argv at all,
+  // so there is nothing to parse and `parsed` stays empty. This used to build a
+  // stand-in object that copied every `*Param` into the slot of the same name —
+  // which is precisely what `resolveFlag` already does below, preferring the
+  // param over the parsed slot. One expression per flag now serves both
+  // callers, so a new flag is added in one place instead of two that can drift.
+  const parsed = storyIdParam === undefined ? parseSprintArgs() : {};
+  // Preserve undefined so resolveWaitForMerge can apply the closeAndLand
+  // config default when neither flag was supplied.
+  const waitForMergeExplicit = resolveFlag(
+    waitForMergeParam,
+    parsed.waitForMerge,
+  );
+  const maxWaitSeconds = resolveFlag(
+    maxWaitSecondsParam,
+    parsed.maxWaitSeconds,
+  );
   return {
-    storyId: parsed.storyId,
+    storyId: resolveFlag(storyIdParam, parsed.storyId),
     cwd: path.resolve(cwdParam ?? parsed.cwd ?? PROJECT_ROOT),
     // `undefined` when unsupplied — the merge wait then reads
     // `delivery.mergeWatch.maxWaitSeconds`. A per-run override exists so a
@@ -128,21 +130,20 @@ export function parseCloseOptions({
       Number.isInteger(maxWaitSeconds) && maxWaitSeconds > 0
         ? maxWaitSeconds
         : undefined,
-    skipValidation: resolveFlag(
-      skipValidationParam,
-      parsed.skipValidation,
-      false,
+    // `undefined` when unsupplied — the merge wait then reads
+    // `delivery.mergeWatch.mode`. The two merge-watch flags stay composable and
+    // mode-agnostic: `--merge-watch-mode async` picks the posture, and an
+    // explicit `--max-wait-seconds` still wins over that posture's probe cap.
+    mergeWatchMode: parseMergeWatchMode(
+      resolveFlag(mergeWatchModeParam, parsed.mergeWatchMode),
     ),
-    skipSync: resolveFlag(skipSyncParam, parsed.skipSync, false),
-    noAutoMerge: resolveFlag(noAutoMergeParam, parsed.noAutoMerge, false),
+    skipValidation: !!resolveFlag(skipValidationParam, parsed.skipValidation),
+    skipSync: !!resolveFlag(skipSyncParam, parsed.skipSync),
+    noAutoMerge: !!resolveFlag(noAutoMergeParam, parsed.noAutoMerge),
     waitForMergeExplicit:
       typeof waitForMergeExplicit === 'boolean'
         ? waitForMergeExplicit
         : undefined,
-    noWaitForMerge: resolveFlag(
-      noWaitForMergeParam,
-      parsed.noWaitForMerge,
-      false,
-    ),
+    noWaitForMerge: !!resolveFlag(noWaitForMergeParam, parsed.noWaitForMerge),
   };
 }

--- a/.agents/scripts/lib/orchestration/single-story-close/runner.js
+++ b/.agents/scripts/lib/orchestration/single-story-close/runner.js
@@ -377,6 +377,7 @@ export async function runSingleStoryClose({
   waitForMerge: waitForMergeParam,
   noWaitForMerge: noWaitForMergeParam,
   maxWaitSeconds: maxWaitSecondsParam,
+  mergeWatchMode: mergeWatchModeParam,
   injectedProvider,
   injectedConfig,
   injectedNotify,
@@ -395,10 +396,11 @@ export async function runSingleStoryClose({
     waitForMergeParam,
     noWaitForMergeParam,
     maxWaitSecondsParam,
+    mergeWatchModeParam,
   });
   if (!options.storyId) {
     throw new Error(
-      'Usage: node single-story-close.js --story <STORY_ID> [--cwd <main-repo>] [--skip-validation] [--skip-sync] [--no-auto-merge] [--wait-merge|--no-wait-merge] [--max-wait-seconds <n>]',
+      'Usage: node single-story-close.js --story <STORY_ID> [--cwd <main-repo>] [--skip-validation] [--skip-sync] [--no-auto-merge] [--wait-merge|--no-wait-merge] [--max-wait-seconds <n>] [--merge-watch-mode <sync|async>]',
     );
   }
 
@@ -509,6 +511,7 @@ async function finishWithMergeWait(prCtx, deps) {
     provider: deps.provider,
     config: prCtx.config,
     maxWaitSeconds: deps.maxWaitSeconds,
+    mergeWatchMode: deps.mergeWatchMode,
     progress,
     injectedGh: deps.injectedGh,
     injectedNotify: deps.injectedNotify,
@@ -843,6 +846,7 @@ async function runClosePipeline({
       cwd: options.cwd,
       provider,
       maxWaitSeconds: options.maxWaitSeconds,
+      mergeWatchMode: options.mergeWatchMode,
       setPhase,
       injectedGh,
       injectedNotify,

--- a/.agents/scripts/single-story-close.js
+++ b/.agents/scripts/single-story-close.js
@@ -43,6 +43,16 @@
  *                              [--skip-validation] [--skip-sync]
  *                              [--no-auto-merge]
  *                              [--wait-merge | --no-wait-merge]
+ *                              [--merge-watch-mode <sync|async>]
+ *
+ * `--merge-watch-mode` (Story #4949) overrides `delivery.mergeWatch.mode` for
+ * one invocation, on the same explicit-wins-over-config precedence
+ * `--max-wait-seconds` uses, and the two compose. It exists because run
+ * topology is invisible from inside close: a solo delivery is cheapest waiting
+ * in the foreground, while the Nth close of a wave pays that wait as
+ * serialized dead time. The config default therefore stays `sync` and the
+ * orchestrator — the only party that knows N — passes `async` per close. An
+ * unrecognized value fails during option parsing, before any phase runs.
  *
  * Close-and-land is the DEFAULT for every run (Story #4428 introduced it as
  * `--wait-merge`; `delivery.routing.closeAndLand` — default `true` — made it
@@ -191,6 +201,10 @@ runAsCli(import.meta.url, main, {
       ['--wait-merge', 'Force the in-close merge wait.'],
       ['--no-wait-merge', 'Return as soon as the PR is open; do not wait.'],
       ['--max-wait-seconds <n>', 'Per-invocation merge-wait bound.'],
+      [
+        '--merge-watch-mode <sync|async>',
+        'Override delivery.mergeWatch.mode for this invocation only. `async` caps the merge wait to a short probe window and returns the resumable `pending` terminal instead of holding the foreground slot — pass it on every close of a multi-Story run. An invalid value exits non-zero before any phase runs.',
+      ],
       ['--no-evidence', 'Do not reuse or write gate evidence stamps.'],
       ['--dry-run', 'Report the plan; mutate nothing.'],
     ],

--- a/.agents/workflows/helpers/deliver-reference.md
+++ b/.agents/workflows/helpers/deliver-reference.md
@@ -124,6 +124,18 @@ footprint keeps the fresh acceptance critic), and the `route::lite` label
 remains a human-visible hint only, never the control signal — a lost or
 never-written label cannot misroute delivery.
 
+**Issue a beat's spawns in one turn.** A wave tick hands you a ready set, not a
+queue: those Stories have no dependency edge between them (the resolver already
+withheld any that do) and no shared write paths (each owns its own worktree and
+branch). Dispatch them the way
+[`parallel-tooling.md`](parallel-tooling.md) Rule 3 prescribes — **N `Agent`
+calls issued together in a single assistant turn**, one per ready Story, not
+`Agent` → wait → `Agent`. Serial dispatch is compliant with every other rule on
+this page and costs the run a full Story's implementation time per sibling for
+nothing; the wave aggregator is built for the parallel shape. Respect
+`delivery.deliverRunner.concurrencyCap`: when the ready set exceeds it, slice
+into batches of `cap` and dispatch each batch in its own turn.
+
 **Dispatch each `ready` Story (role-scoped by default).** When
 `delivery.routing.roleScopedAgents` is enabled (the **default**) and the host
 exposes agent dispatch, spawn each ready Story as its own
@@ -263,8 +275,32 @@ A slow-CI consumer can opt the close into `"async"` mode so the merge wait
 probes once for ~60s (catching an instant merge or an instantly-red required
 check) and then returns `pending` instead of burning ~5 minutes of the host
 tool slot polling a merge that lands after the wait would have expired anyway.
-When a worker returns that `pending` envelope, launch its `nextCommand` as a
+When a close returns that `pending` envelope, launch its `nextCommand` as a
 **background** invocation (host background Bash — its completion re-invokes the
 agent) and move on to the next Story; `single-story-confirm-merge.js` is
 idempotent and owns the whole tail. Do not foreground-poll the merge. The
 default `"sync"` behaviour is unchanged.
+
+**On a multi-Story run, pass `--merge-watch-mode async` on every close.** Close
+sees one Story and cannot see run topology, so it cannot make this call for
+itself — you can. Implementation runs in parallel but the close tail is
+serialized one at a time, and under `sync` each of those closes holds the
+foreground for its full merge wait before the next Story's close may start.
+That is the run's dominant serialized cost, and it is paid per sibling:
+
+```bash
+node <main-repo>/.agents/scripts/single-story-close.js \
+  --story <storyId> --cwd <main-repo> --merge-watch-mode async
+```
+
+The flag overrides `delivery.mergeWatch.mode` for that invocation only — the
+config default stays `"sync"`, which is right for the solo delivery that has no
+sibling waiting behind it. It composes with `--max-wait-seconds`: pass both and
+the explicit bound still wins over the async probe cap. An unrecognized value
+exits non-zero before any phase runs, so a typo cannot silently drop the run
+back onto synchronous waiting. Expect a `pending` envelope from each async
+close — that is the designed ending here, not a failure; background its
+`nextCommand` and move to the next Story's close immediately.
+
+A one-Story run should keep the `sync` default: there is no sibling to unblock,
+and the foreground wait is the cheapest path to `landed`.

--- a/.agents/workflows/helpers/plan-reference.md
+++ b/.agents/workflows/helpers/plan-reference.md
@@ -315,6 +315,14 @@ output shape standalone. When the kill-switch is off
 (`roleScopedAgents: false`) or the host cannot spawn at this depth, fall back
 to a generic sub-agent and hand it the same charter (the `consolidation` /
 `pre-mortem` definitions in [`plan-critic.md`](../../agents/plan-critic.md)).
+**When both critics fire, dispatch them in a single turn.** Consolidation and
+pre-mortem read the same immutable draft, share no write path, and neither
+consumes the other's verdict — the textbook independent fan-out of
+[`parallel-tooling.md`](parallel-tooling.md) Rule 3. Issue both `Agent` calls
+together in one assistant turn rather than awaiting the first verdict before
+spawning the second; serialized critics double the round's wall clock and buy
+nothing, because you fold both verdicts into the same re-author round anyway.
+
 Either way the critic is **maker-blind**: hand it the draft artifacts
 (`stories.json`, and `techspec.md` when present) — never the authoring
 transcript or the reasons the planner believed its own draft is sound. A

--- a/tests/plan-run-epilogue.test.js
+++ b/tests/plan-run-epilogue.test.js
@@ -1,6 +1,7 @@
 import assert from 'node:assert/strict';
 import { afterEach, describe, it } from 'node:test';
 
+import { runPlanRunEpilogue } from '../.agents/scripts/lib/orchestration/run-epilogue.js';
 import { main } from '../.agents/scripts/plan-run-epilogue.js';
 
 /**
@@ -153,5 +154,92 @@ describe('plan-run-epilogue main', () => {
     await main(['--stories', '1'], h.deps);
     assert.deepEqual(h.warn, []);
     assert.equal(h.info.length, 1);
+  });
+});
+
+/**
+ * Story #4949 — the roster comment names the lenses; before this it said
+ * nothing about how to dispatch them, so a serial walk (or a coordinator
+ * sub-agent that re-dispatched them as grandchildren) was fully compliant
+ * with it. Lenses are read-only and share no write paths — the textbook
+ * independent fan-out — and grandchild routing is measured-lossy, so the shape
+ * is a MUST rather than a suggestion. This pins the wording: the instruction
+ * lives in a GitHub comment body, which has no other gate over it.
+ */
+describe('audit-roster — the emitted dispatch instruction (Story #4949 AC-4)', () => {
+  const US = String.fromCharCode(31);
+
+  /** A run whose two Stories landed as squash-merges on `origin/main`. */
+  const landedRunGit = {
+    gitSpawn: (_cwd, ...args) => {
+      if (args[0] === 'log') {
+        return {
+          status: 0,
+          stdout: [
+            `ccc${US}bbb${US}fix: second (#2)`,
+            `bbb${US}aaa${US}feat: first (#1)`,
+            `aaa${US}${US}chore: pre-run base`,
+          ].join('\n'),
+          stderr: '',
+        };
+      }
+      if (args[0] === 'diff') {
+        return { status: 0, stdout: 'lib/a.js\nlib/b.js\n', stderr: '' };
+      }
+      return { status: 0, stdout: '', stderr: '' };
+    },
+  };
+
+  async function rosterBody(selectedAudits) {
+    const comments = [];
+    await runPlanRunEpilogue({
+      planRunId: 'run-4949',
+      stories: [1, 2],
+      provider: {
+        getTicket: async (id) => ({
+          id,
+          title: `Story ${id}`,
+          body: '',
+          labels: ['type::story'],
+        }),
+        getTicketComments: async () => [],
+        postComment: async (ticketId, payload) => {
+          comments.push({ ticketId, body: payload.body });
+          return { commentId: comments.length };
+        },
+        deleteComment: async () => {},
+      },
+      git: landedRunGit,
+      selectAuditsFn: async () => ({ selectedAudits }),
+    });
+    return comments.find((c) => c.body.includes('plan-run-audit-roster')).body;
+  }
+
+  it('mandates one auditor sub-agent per lens, dispatched flat in a single turn', async () => {
+    const body = await rosterBody(['audit-clean-code', 'audit-performance']);
+    assert.match(
+      body,
+      /\*\*Dispatch shape \(MUST\): flat, parallel, one turn\.\*\*/,
+    );
+    assert.match(body, /one `auditor` sub-agent per lens/);
+    assert.match(body, /in a SINGLE turn/);
+    assert.match(
+      body,
+      /no nested fan-out/,
+      'a coordinator that re-dispatches the lenses as grandchildren loses findings',
+    );
+    assert.match(body, /no serial walk/);
+  });
+
+  it('emits the instruction even when the roster selected no lenses', async () => {
+    // A roster is not always non-empty, and the dispatch contract must not be
+    // conditional on the count — a lens added on the next run would otherwise
+    // inherit an instruction-free comment.
+    const body = await rosterBody([]);
+    assert.match(body, /Dispatch shape \(MUST\)/);
+    assert.match(
+      body,
+      /_\(none — docs-only or no matching change-set lenses\)_/,
+    );
   });
 });

--- a/tests/single-story-close-confirm-merge.test.js
+++ b/tests/single-story-close-confirm-merge.test.js
@@ -774,6 +774,97 @@ describe('merge wait — async mode (Story #4698)', () => {
   });
 });
 
+/**
+ * Story #4949 — `--merge-watch-mode` exists because run topology is invisible
+ * from inside close. Close sees one Story; only the orchestrator knows whether
+ * a sibling's close is queued behind this one, and therefore whether the
+ * foreground merge wait is the cheapest ending or the run's dominant
+ * serialized cost. The config default deliberately stays `sync`.
+ */
+describe('merge wait — --merge-watch-mode override (Story #4949)', () => {
+  it('AC-1: the explicit mode wins over delivery.mergeWatch.mode in both directions', () => {
+    // Config sync (and config-absent) → the override selects async.
+    assert.equal(resolveMergeWaitConfig({}).mode, 'sync');
+    assert.equal(resolveMergeWaitConfig({}, undefined, 'async').mode, 'async');
+    assert.equal(
+      resolveMergeWaitConfig(
+        { delivery: { mergeWatch: { mode: 'sync' } } },
+        undefined,
+        'async',
+      ).mode,
+      'async',
+    );
+    // Config async → the override selects sync. An override that could only
+    // ever escalate would leave an async-configured consumer unable to ask a
+    // solo close for the cheaper foreground wait.
+    const asyncConfig = { delivery: { mergeWatch: { mode: 'async' } } };
+    assert.equal(resolveMergeWaitConfig(asyncConfig).mode, 'async');
+    assert.equal(
+      resolveMergeWaitConfig(asyncConfig, undefined, 'sync').mode,
+      'sync',
+    );
+  });
+
+  it('AC-1: an absent override defers to the config, exactly as --max-wait-seconds does', () => {
+    const asyncConfig = { delivery: { mergeWatch: { mode: 'async' } } };
+    for (const absent of [undefined, null]) {
+      assert.equal(
+        resolveMergeWaitConfig(asyncConfig, undefined, absent).mode,
+        'async',
+      );
+      assert.equal(resolveMergeWaitConfig({}, undefined, absent).mode, 'sync');
+    }
+  });
+
+  it('AC-1: the mode override carries the async probe cap, and --max-wait-seconds still wins over it', () => {
+    // Mode override alone → the same clamp a config-selected async gets.
+    assert.equal(
+      resolveMergeWaitConfig({}, undefined, 'async').maxWaitSeconds,
+      ASYNC_PROBE_WINDOW_SECONDS,
+    );
+    // The two flags compose and stay mode-agnostic: the explicit bound wins
+    // over the probe cap regardless of where the async mode came from.
+    const composed = resolveMergeWaitConfig({}, 3600, 'async');
+    assert.equal(composed.mode, 'async');
+    assert.equal(composed.maxWaitSeconds, 3600);
+    // A sync override leaves the configured bound untouched.
+    assert.equal(
+      resolveMergeWaitConfig(
+        { delivery: { mergeWatch: { mode: 'async', maxWaitSeconds: 300 } } },
+        undefined,
+        'sync',
+      ).maxWaitSeconds,
+      300,
+    );
+  });
+
+  it('AC-1: the phase honours the override — a sync-configured close returns pending inside the probe window', async () => {
+    const provider = makeFakeProvider();
+    const emitted = [];
+    const outcome = await runConfirmMergePhase(
+      phaseArgs({
+        provider,
+        // Config says sync — only the per-invocation flag asks for async.
+        config: { delivery: { mergeWatch: { mode: 'sync' } } },
+        mergeWatchMode: 'async',
+        nowMsFn: makeClock(40_000),
+        readPrWaitProbeFn: async () => openProbe(),
+        emitMergeUnlandedFn: () => emitted.push('unlanded'),
+      }),
+    );
+    assert.equal(outcome.terminal, 'pending');
+    assert.equal(
+      outcome.waitBudget.maxWaitSeconds,
+      ASYNC_PROBE_WINDOW_SECONDS,
+      'the flag must reach resolveMergeWaitConfig, not just the log line',
+    );
+    // The async ending is the SAME resumable pending contract: nothing mutated.
+    assert.equal(emitted.length, 0);
+    assert.equal(provider._updates().length, 0);
+    assert.equal(provider._comments().length, 0);
+  });
+});
+
 describe('merge wait — a PR that falls behind its base', () => {
   it('updates a BEHIND PR within a bounded number of attempts', async () => {
     let updates = 0;
@@ -1143,6 +1234,35 @@ describe('parseCloseOptions / resolveWaitForMerge — flag compatibility', () =>
       parseCloseOptions({ storyIdParam: 1 }).maxWaitSeconds,
       undefined,
     );
+  });
+
+  it('AC-1: accepts --merge-watch-mode sync|async and REFUSES anything else before a phase runs', () => {
+    for (const [raw, expected] of [
+      ['async', 'async'],
+      ['sync', 'sync'],
+      ['  ASYNC  ', 'async'],
+    ]) {
+      assert.equal(
+        parseCloseOptions({ storyIdParam: 1, mergeWatchModeParam: raw })
+          .mergeWatchMode,
+        expected,
+      );
+    }
+    // Absent → undefined, which is what defers to delivery.mergeWatch.mode.
+    assert.equal(
+      parseCloseOptions({ storyIdParam: 1 }).mergeWatchMode,
+      undefined,
+    );
+    // Fail closed. Coercing a typo to the config default would silently put a
+    // multi-Story run back on synchronous merge-watch — every close burning
+    // its foreground slot, with the wall clock as the only evidence. Parsing
+    // runs before the first phase, so this throw costs no mutation.
+    for (const bad of ['ASYNCH', 'true', 'background', '', 1]) {
+      assert.throws(
+        () => parseCloseOptions({ storyIdParam: 1, mergeWatchModeParam: bad }),
+        /--merge-watch-mode must be one of sync\|async/,
+      );
+    }
   });
 
   it('--no-wait-merge always wins; an un-armed PR is never waited on', () => {


### PR DESCRIPTION
Closes #4949

_Auto-opened by `/deliver`._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes merge-wait behavior and host-facing orchestration contracts for multi-Story delivery; misconfiguration or ignored docs could still serialize closes or audits, but parsing fails closed and tests cover the new flag and roster wording.
> 
> **Overview**
> Adds **`--merge-watch-mode sync|async`** on sprint/close CLIs so the orchestrator can override `delivery.mergeWatch.mode` per close (same precedence as `--max-wait-seconds`). Invalid values **throw at parse time** instead of silently falling back to sync. The flag flows through `parseCloseOptions` → merge confirm → `resolveMergeWaitConfig`, which now takes a `modeOverride` that beats config in both directions and still composes with an explicit max-wait override.
> 
> **`parseCloseOptions`** is simplified so injected params and argv share one `resolveFlag` path (no duplicate stand-in object when `storyIdParam` is set).
> 
> **Parallel dispatch is now explicit** at three fan-out points: the plan-run **audit roster** GitHub comment requires flat, one-turn `auditor` spawns per lens; **`deliver-reference.md`** requires all ready Stories on a wave beat in a single turn (with concurrency-cap batching); **`plan-reference.md`** requires consolidation + pre-mortem critics together when both fire.
> 
> Workflow/docs and CLI help tell multi-Story runs to pass **`--merge-watch-mode async`** on every close while keeping config default **`sync`** for solo deliveries.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fcd3b912451dcc14025407a86d66498d35ba7a60. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->