### PR TITLE
fix: stop a glob footprint serializing the whole run, and delete the dead selectReadySet wrapper (#4960)

### DIFF
--- a/.agents/scripts/lib/story-adjacency.js
+++ b/.agents/scripts/lib/story-adjacency.js
@@ -7,10 +7,10 @@
  * records into the `Map<storyId, number[]>` adjacency the kernel consumes.
  * This module is now the one home for that step; the live consumer is:
  *
- *   - `lib/wave-runner/ready-set.js` (`selectReadySet`, the path-agnostic
+ *   - `lib/wave-runner/ready-set.js` (`planReadySet`, the path-agnostic
  *     continuous scheduler the `stories-wave-tick.js` adapter dispatches through)
  *   - `stories-wave-tick.js` (for cycle detection, before delegating
- *     selection to `selectReadySet`)
+ *     selection to `planReadySet`)
  *
  * (Pre-v2: `epic-runner/phases/build-wave-dag.js` and `dispatch-pipeline.js`
  * also called here; both entry seams were deleted.)
@@ -44,7 +44,7 @@ import { parseBlockedBy } from './dependency-parser.js';
  * @param {object} [opts]
  * @param {boolean} [opts.dropForeign=false] When `false` (the v2 default,
  *   matching the `/deliver` path — `stories-wave-tick.js` and the
- *   `selectReadySet` core), the operator-DAG contract is preserved: a
+ *   `planReadySet` core), the operator-DAG contract is preserved: a
  *   dependency on an id absent from the input is treated as not-yet-done
  *   and withholds the dependent until it completes. When `true` (the
  *   pre-v2 Epic-scoped-wrapper semantics), edges pointing at ids outside

--- a/.agents/scripts/lib/wave-runner/live-probe.js
+++ b/.agents/scripts/lib/wave-runner/live-probe.js
@@ -2,7 +2,7 @@
  * lib/wave-runner/live-probe.js — the state-probing adapter that feeds the
  * ready-set kernel from live GitHub state.
  *
- * `selectReadySet` (`./ready-set.js`) is deliberately a pure, side-effect-free
+ * `planReadySet` (`./ready-set.js`) is deliberately a pure, side-effect-free
  * kernel: callers hand it the live Story records, the done set, and the
  * in-flight count, and it decides. Until now the only adapter was the
  * flag-driven one (`stories-wave-tick.js --dag/--done/--in-flight`), which
@@ -41,7 +41,7 @@
  *     "waiting" (Story #4601).
  *
  * It is an **adapter, not a kernel change**: it gathers inputs and hands them
- * to `selectReadySet` unchanged. The kernel stays pure and flag-driven, and
+ * to `planReadySet` unchanged. The kernel stays pure and flag-driven, and
  * the legacy flag mode stays byte-compatible.
  *
  * The graph resolution is **not** reimplemented here — it reuses
@@ -217,7 +217,7 @@ export function createProbeContext({
 
 /**
  * Probe live state for a set of Story ids and return the exact inputs
- * `selectReadySet` consumes.
+ * `planReadySet` consumes.
  *
  * Mirrors `resolve-stories.js`'s two-pass envelope build: a provisional pass
  * yields the DAG whose foreign dependency ids are then resolved against live
@@ -239,7 +239,7 @@ export function createProbeContext({
  *   skipped (the probe never fails closed).
  * @param {(msg: string) => void} [args.warn]
  * Each returned node carries its **live labels**. That is load-bearing, not
- * decoration: `selectReadySet` classifies from labels, so a node stripped of
+ * decoration: `planReadySet` classifies from labels, so a node stripped of
  * them reads as `ready` and an `agent::executing` Story gets re-dispatched
  * onto a second branch while its first run is still going. The resolver's DAG
  * projection (`{id, dependsOn, files}`) drops labels because flag mode's
@@ -285,7 +285,7 @@ export async function probeLiveState({
   const labelsById = new Map(stories.map((s) => [s.id, s.labels ?? []]));
   // Bodies ride along with the node so the co-dispatch guard can widen a
   // declared footprint from the paths a Story's own text names (Story #4875).
-  // They are consumed in-process by `selectReadySet` and never serialized into
+  // They are consumed in-process by `planReadySet` and never serialized into
   // the beat envelope, which stays a list of ids.
   const bodyById = new Map(stories.map((s) => [s.id, s.body ?? '']));
   const inFlightIds = deriveInFlightIds(stories, dispatched);
@@ -326,7 +326,7 @@ export async function probeLiveState({
  *
  * This is the load-bearing half of the dispatch-window fix, and it is why
  * `inFlight` alone is not enough. The two inputs do **different** jobs inside
- * `selectReadySet`:
+ * `planReadySet`:
  *
  *   - `inFlight` is only a **count**. It reserves capacity (`slots = cap −
  *     inFlight`) and nothing more.

--- a/.agents/scripts/lib/wave-runner/ready-set.js
+++ b/.agents/scripts/lib/wave-runner/ready-set.js
@@ -19,18 +19,17 @@
  * `stories-wave-tick.js` adapter wires this core; this module does not
  * modify that CLI surface.
  *
- * Three exports:
+ * The scheduling surface:
  *   - `classifyStory(story)` — live-label classifier mapping a Story
  *     record's labels + issue state to one of `done | blocked | executing |
  *     ready`. Mirrors the done-predicate this module uses
  *     (`agent::done` OR closed issue) so a Story closed manually through
  *     the GitHub UI is recognised as done.
- *   - `storiesOverlap(a, b)` — the file-overlap co-dispatch guard: true
- *     when two Stories' file footprints intersect. Two Stories that would
- *     touch the same file MUST NOT be dispatched onto parallel
- *     `story-<id>` branches **concurrently** — not merely on the same beat
- *     (they would race the same path and produce a merge conflict at
- *     close). The comparison runs over
+ *   - `storiesOverlap(a, b)` — the **beat-local** file-overlap co-dispatch
+ *     guard: true when two Stories' file footprints intersect. Two Stories
+ *     that would touch the same file MUST NOT be admitted onto parallel
+ *     `story-<id>` branches on the same beat (they would race the same path
+ *     and produce a merge conflict at close). The comparison runs over
  *     the **widened** footprint (`storyWidenedFootprint`) — a declared
  *     `changes[]` is treated as a lower bound and widened from the paths the
  *     Story's own text names, because a guard that trusts a prediction cannot
@@ -38,10 +37,18 @@
  *   - `planReadySet({ stories, doneIds, inFlight, globalCap,
  *     inFlightRecords })` — the scheduler. Returns the deterministic,
  *     overlap-free dispatch set (capped at `globalCap − inFlight`) **and**
- *     the Stories it withheld because their footprint is reserved by a Story
- *     still in flight from an earlier beat.
- *   - `selectReadySet(args)` — `planReadySet(args).selected`, the
- *     dispatch-set-only view for callers that do not report withholdings.
+ *     the Stories it withheld because a **concrete** path in their footprint
+ *     is reserved by a Story still in flight from an earlier beat.
+ *
+ * The two guards deliberately draw the glob/UNKNOWN class differently
+ * (Story #4960). Within a beat an unknown-width footprint overlaps
+ * everything, because admitting two Stories whose real widths are unknown is
+ * the collision the guard exists to prevent. Across beats it reserves
+ * nothing: an in-flight Story's window spans its whole implementation, so a
+ * glob that reserved cross-beat would withhold every other Story for
+ * minutes-to-hours — and `resolve-stories.js` substitutes the UNKNOWN
+ * sentinel for any body it cannot parse, so a single malformed Story body
+ * would collapse an N-Story run to fully serial.
  *
  * Adjacency is re-derived from the supplied records via the shared
  * `buildStoryAdjacency` builder (`lib/story-adjacency.js`) — the same
@@ -231,12 +238,29 @@ function storyWidenedFootprint(story) {
 }
 
 /**
- * File-overlap co-dispatch guard. Returns `true` when two Stories' declared
- * file footprints intersect — meaning they would race the same file if their
- * `story-<id>` branches were ever live at the same time. Two Stories that
- * overlap MUST NOT run concurrently: one is withheld until the other clears,
- * whether the peer was admitted on this beat or dispatched on an earlier one
- * and is still implementing (Story #4950).
+ * Both Stories' widened footprints, or `null` when either is empty.
+ *
+ * **An empty footprint means "no known overlap"**, so both guards below
+ * short-circuit to `false` on one. This is permissive by necessity: a Story
+ * with no declared footprint and no path evidence in its text carries no
+ * information, and withholding on absence would serialize every run.
+ *
+ * @param {StoryRecord} a
+ * @param {StoryRecord} b
+ * @returns {[Set<string>, Set<string>]|null}
+ */
+function widenedFootprintPair(a, b) {
+  const fa = storyWidenedFootprint(a);
+  if (fa.size === 0) return null;
+  const fb = storyWidenedFootprint(b);
+  if (fb.size === 0) return null;
+  return [fa, fb];
+}
+
+/**
+ * **Beat-local** file-overlap co-dispatch guard. Returns `true` when two
+ * Stories' file footprints intersect — meaning they would race the same file
+ * if both were admitted onto parallel `story-<id>` branches on this beat.
  *
  * Comparison runs over the **widened** footprint
  * ({@link storyWidenedFootprint}), not the declaration: a declared `changes[]`
@@ -244,35 +268,65 @@ function storyWidenedFootprint(story) {
  * collide were being co-dispatched whenever the collision was not predicted
  * (Story #4875).
  *
- * Two deliberate asymmetries:
+ * **A glob footprint overlaps EVERYTHING** → `true` (Story #4539/#4540).
+ * Comparison is exact-string, so a Story declaring `.agents/scripts/lib/**`
+ * would not match another declaring `.agents/scripts/lib/story-adjacency.js` —
+ * the guard would silently pass two Stories that genuinely race. Unknown width
+ * is not the same as no width: fail safe by serializing the rest of the beat.
  *
- *   - **An empty footprint means "no known overlap"** → `false`. A Story with
- *     no declared footprint and no path evidence in its text is never
- *     withheld. This is permissive by necessity: a genuinely unknown footprint
- *     carries no information, and withholding on absence would serialize every
- *     run.
- *   - **A glob footprint overlaps EVERYTHING** → `true` (Story #4539/#4540).
- *     Comparison is exact-string, so a Story declaring
- *     `.agents/scripts/lib/**` would not match another declaring
- *     `.agents/scripts/lib/story-adjacency.js` — the guard would silently
- *     pass two Stories that genuinely race. Unknown width is not the same as
- *     no width: fail safe by serializing.
+ * That fail-safe is **beat-local and stays that way**. The cross-beat
+ * reservation uses {@link reservesConcretePath} instead, because a beat is a
+ * moment and an in-flight window is an implementation (Story #4960).
  *
  * @param {StoryRecord} a
  * @param {StoryRecord} b
  * @returns {boolean}
  */
 export function storiesOverlap(a, b) {
-  const fa = storyWidenedFootprint(a);
-  if (fa.size === 0) return false;
-  const fb = storyWidenedFootprint(b);
-  if (fb.size === 0) return false;
+  const pair = widenedFootprintPair(a, b);
+  if (pair === null) return false;
+  const [fa, fb] = pair;
   for (const path of fa) {
-    if (isGlobPath(path)) return true;
-    if (fb.has(path)) return true;
+    if (isGlobPath(path) || fb.has(path)) return true;
   }
   for (const path of fb) {
     if (isGlobPath(path)) return true;
+  }
+  return false;
+}
+
+/**
+ * **Cross-beat** reservation guard: `true` only when the two widened
+ * footprints share a **concrete** (non-glob) path.
+ *
+ * A Story dispatched on an earlier beat holds its footprint for its entire
+ * implementation window, not for a moment, so the two guards cannot share a
+ * predicate (Story #4960):
+ *
+ *   - A **concrete** shared path is a real, named collision — two branches
+ *     editing `lib/foo.js` conflict at close whether the peer was admitted
+ *     alongside or hours ago. It reserves, exactly as Story #4950 shipped.
+ *   - A **glob** — or the UNKNOWN sentinel `resolve-stories.js` substitutes
+ *     for an unparseable body — names no file. Reserving on it withheld every
+ *     eligible Story against a single unknown-width blocker for that blocker's
+ *     whole window, which is strictly worse than the serial run the
+ *     reservation was meant to speed up. Glob paths are therefore skipped on
+ *     both sides here; the beat-local {@link storiesOverlap} fail-safe is
+ *     unchanged and still serializes them within a beat.
+ *
+ * Set intersection is symmetric, so scanning the reserving side alone finds
+ * every shared concrete path.
+ *
+ * @param {StoryRecord} held      The in-flight Story holding the reservation.
+ * @param {StoryRecord} candidate The Story being considered for admission.
+ * @returns {boolean}
+ */
+function reservesConcretePath(held, candidate) {
+  const pair = widenedFootprintPair(held, candidate);
+  if (pair === null) return false;
+  const [fa, fb] = pair;
+  for (const path of fa) {
+    if (!isGlobPath(path) && fb.has(path)) return true;
   }
   return false;
 }
@@ -310,11 +364,12 @@ export function storiesOverlap(a, b) {
  *      already occupying a slot (executing / closing / dispatched-not-yet-
  *      labelled). When `slots <= 0`, the result is empty.
  *   5. **Overlap guard.** Greedily admit eligible Stories in ascending-id
- *      order, skipping any whose file footprint overlaps either a Story
- *      **already admitted this beat** or a Story **still in flight from an
- *      earlier beat** (`inFlightRecords`). A withheld Story stays eligible
- *      and is naturally re-considered on the next beat once the Story
- *      reserving its files has cleared.
+ *      order, skipping any whose file footprint overlaps a Story **already
+ *      admitted this beat** ({@link storiesOverlap}) or shares a **concrete**
+ *      path with a Story **still in flight from an earlier beat**
+ *      (`inFlightRecords`, {@link reservesConcretePath}). A withheld Story
+ *      stays eligible and is naturally re-considered on the next beat once
+ *      the Story reserving its files has cleared.
  *
  * The result is deterministic: eligible Stories are considered in
  * ascending-id order, so the same inputs always yield the same set.
@@ -333,11 +388,12 @@ export function storiesOverlap(a, b) {
  *   (standalone / operator-DAG semantics); `true` prunes foreign edges so
  *   the DAG stays closed over the scheduled set (Epic semantics).
  * @param {StoryRecord[]} [args.inFlightRecords=[]] Records for the Stories
- *   already in flight, whose footprints this beat must **reserve** rather
- *   than merely count. `inFlight` is a number and can only shrink capacity;
- *   without the records a Story admitted now can share files with one
- *   dispatched on an earlier beat and still implementing — a guaranteed
- *   merge conflict at close (Story #4950). Callers that hold only ids (the
+ *   already in flight, whose **concrete** footprint paths this beat must
+ *   **reserve** rather than merely count. `inFlight` is a number and can only
+ *   shrink capacity; without the records a Story admitted now can share files
+ *   with one dispatched on an earlier beat and still implementing — a
+ *   guaranteed merge conflict at close (Story #4950). A glob / UNKNOWN
+ *   footprint reserves nothing (Story #4960). Callers that hold only ids (the
  *   `--dag`/`--in-flight` flag mode) pass nothing and get the pre-#4950
  *   same-beat-only behaviour.
  * @returns {{ selected: StoryRecord[], withheldByInFlight: Array<{id: number, blockedBy: number}> }}
@@ -405,30 +461,22 @@ export function planReadySet({
 }
 
 /**
- * The dispatch set alone — `planReadySet(args).selected`.
- *
- * The scheduling contract every caller has always consumed. Callers that also
- * report *why* a slot went unfilled (the `stories-wave-tick.js` envelope) use
- * {@link planReadySet} directly.
- *
- * @param {Parameters<typeof planReadySet>[0]} [args]
- * @returns {StoryRecord[]}
- */
-export function selectReadySet(args) {
-  return planReadySet(args).selected;
-}
-
-/**
  * Greedily admit eligible Stories in ascending-id order under two distinct
  * withholding rules, and report which ones a reservation held back.
+ *
+ * The two rules are distinct predicates, not one applied twice: the
+ * cross-beat reservation matches only a shared **concrete** path
+ * ({@link reservesConcretePath}), while the same-beat guard also serializes
+ * unknown-width footprints ({@link storiesOverlap}). See both for why.
  *
  * The reservation check runs **first**, so a Story racing both an in-flight
  * Story and a same-beat peer is reported against the in-flight one: that is
  * the longer-lived and more informative blocker (a Story that has been
  * implementing for beats, not one merely admitted a moment ago), and checking
  * it first is what makes the report complete — every withheld-by-reservation
- * Story appears in it. Ordering cannot change `selected`: either rule skips
- * the same candidate.
+ * Story appears in it. Ordering cannot change `selected`: a candidate either
+ * rule rejects is skipped whichever runs first; only which list it is
+ * reported in depends on the order.
  *
  * @param {object} args
  * @param {number[]} args.eligibleIds        Ascending eligible Story ids.
@@ -455,8 +503,8 @@ function admitStories({ eligibleIds, byId, slots, reserved }) {
 }
 
 /**
- * The id of the in-flight Story whose widened footprint the candidate would
- * race, or `null` when none does.
+ * The id of the in-flight Story whose widened footprint reserves a concrete
+ * path the candidate would race, or `null` when none does.
  *
  * Two records are skipped rather than treated as blockers:
  *
@@ -478,7 +526,7 @@ function findInFlightBlocker(candidate, candidateId, reserved) {
   for (const held of reserved) {
     const heldId = storyIdOf(held);
     if (heldId === null || heldId === candidateId) continue;
-    if (storiesOverlap(held, candidate)) return heldId;
+    if (reservesConcretePath(held, candidate)) return heldId;
   }
   return null;
 }

--- a/.agents/scripts/stories-wave-tick.js
+++ b/.agents/scripts/stories-wave-tick.js
@@ -5,7 +5,7 @@
  * `/deliver` story-list path.
  *
  * Thin **adapter** over the path-agnostic ready-set scheduling core
- * (`lib/wave-runner/ready-set.js#selectReadySet`). It emits the set of
+ * (`lib/wave-runner/ready-set.js#planReadySet`). It emits the set of
  * Stories safe to dispatch **on this beat** — a Story becomes dispatchable
  * the instant its own dependencies are done, under the same global
  * concurrency cap and the same file-overlap co-dispatch guard
@@ -15,7 +15,7 @@
  * The previous static wave-batch plan (group N must fully drain before
  * group N+1 opens, via `Graph.js#assignLayers`) is gone. The scheduling
  * kernel — adjacency derivation, the done-predicate classifier, the
- * eligibility rule, and the overlap guard — lives once in `selectReadySet`;
+ * eligibility rule, and the overlap guard — lives once in `planReadySet`;
  * this file only gathers input, resolves the cap, and renders the envelope.
  *
  * **Two modes, one kernel.**
@@ -55,16 +55,20 @@
  *     inFlight: number,
  *     cycleError: string | null,
  *     wedged: { reason, stories: [{ id, unmetBlockers }] } | null,
- *     inFlightReservation: { available, withheld: [{ id, blockedBy }], note }
+ *     inFlightReservation: { available, withheld: [{ id, blockedBy, reason }], note }
  *   }
  *
  * `inFlightReservation` reports the cross-beat half of the co-dispatch guard
  * (Story #4875 widened the footprint; Story #4950 made it reserve). Under
  * `--probe-live` the in-flight Stories' own records are handed to the kernel,
- * so a candidate racing a Story dispatched on an EARLIER beat is withheld and
- * named here with its blocker. Flag mode carries a count and no records, so it
- * reports `available: false` rather than an empty — and therefore
- * indistinguishable — result.
+ * so a candidate sharing a CONCRETE path with a Story dispatched on an EARLIER
+ * beat is withheld and named here with its blocker and a `reason`
+ * (`in-flight-earlier-beat` or `foreign-lease`). A glob / UNKNOWN footprint
+ * reserves nothing across beats — it would withhold the whole run for one
+ * blocker's entire implementation window — while still serializing its own
+ * beat (Story #4960). Flag mode carries a count and no records, so it reports
+ * `available: false` rather than an empty — and therefore indistinguishable —
+ * result.
  *
  * Probe mode adds fields the caller can no longer compute for itself:
  * `done: number[]` (the resolved done set, in-set ∪ satisfied foreign
@@ -145,7 +149,7 @@ const HELP = `Usage:
 Continuous ready-set planner for standalone Story delivery. Emits the set of
 Stories safe to dispatch on this beat — a Story is dispatchable the instant
 its own dependencies are done — plus the resolved per-beat concurrency cap
-and the same file-overlap guard as selectReadySet.
+and the same file-overlap guard as planReadySet.
 
 Two modes:
   --probe-live  Resolve the graph and derive done / in-flight from LIVE state
@@ -261,6 +265,16 @@ function inputErrorResult(message, concurrencyCap = null, inFlightValue = 0) {
 }
 
 /**
+ * Why a reservation withheld a Story. Machine-readable companion to the
+ * operator-facing `note`, so a consumer never has to parse prose to tell an
+ * earlier-beat blocker from a foreign-lease one (Story #4960).
+ */
+const RESERVATION_REASONS = Object.freeze({
+  EARLIER_BEAT: 'in-flight-earlier-beat',
+  FOREIGN_LEASE: 'foreign-lease',
+});
+
+/**
  * Describe this beat's in-flight footprint reservation for the envelope
  * (Story #4950).
  *
@@ -277,11 +291,24 @@ function inputErrorResult(message, concurrencyCap = null, inFlightValue = 0) {
  *     unchanged from before #4950. Saying so explicitly is the point: a
  *     silently-absent guard reads exactly like a guard that found nothing.
  *
+ * A reservation is held either by a Story **this run** dispatched on an
+ * earlier beat or by one **another operator's lease** holds — `live-probe.js`
+ * folds both into the in-flight set, and they reserve identically but read
+ * very differently to an operator. Reporting a foreign-held peer as "still in
+ * flight from an earlier beat" is simply false: this run never dispatched it
+ * and no later beat of this run will clear it. `foreignHeldIds` splits the two
+ * so each carries its own reason (Story #4960).
+ *
  * @param {object[]|null|undefined} inFlightRecords
  * @param {Array<{id: number, blockedBy: number}>} withheld
- * @returns {{ available: boolean, withheld: Array<{id: number, blockedBy: number}>, note: string|null }}
+ * @param {Iterable<number>} [foreignHeldIds] Ids held by a foreign lease.
+ * @returns {{ available: boolean, withheld: Array<{id: number, blockedBy: number, reason: string}>, note: string|null }}
  */
-export function buildReservationReport(inFlightRecords, withheld) {
+export function buildReservationReport(
+  inFlightRecords,
+  withheld,
+  foreignHeldIds = [],
+) {
   if (!Array.isArray(inFlightRecords)) {
     return {
       available: false,
@@ -297,17 +324,55 @@ export function buildReservationReport(inFlightRecords, withheld) {
   if (withheld.length === 0) {
     return { available: true, withheld: [], note: null };
   }
-  const detail = withheld.map((w) => `#${w.id} ← #${w.blockedBy}`).join('; ');
+  const foreign = new Set(foreignHeldIds);
+  const classified = withheld.map((w) => ({
+    ...w,
+    reason: foreign.has(w.blockedBy)
+      ? RESERVATION_REASONS.FOREIGN_LEASE
+      : RESERVATION_REASONS.EARLIER_BEAT,
+  }));
   return {
     available: true,
-    withheld,
-    note:
-      `${withheld.length} Story(ies) withheld because their file footprint ` +
-      `overlaps a Story still in flight from an earlier beat — ${detail}. ` +
-      `This is not a wedge and not a failure: each re-admits automatically ` +
-      `on a later beat, once the Story reserving its files leaves the ` +
-      `in-flight set.`,
+    withheld: classified,
+    note: reservationNote(classified),
   };
+}
+
+/**
+ * Render the operator-facing reservation note, one sentence per reason class
+ * present. Neither class is a failure or a wedge, but they clear by different
+ * events, so each names its own.
+ *
+ * @param {Array<{id: number, blockedBy: number, reason: string}>} withheld
+ * @returns {string}
+ */
+function reservationNote(withheld) {
+  const detail = (entries) =>
+    entries.map((w) => `#${w.id} ← #${w.blockedBy}`).join('; ');
+  const byBeat = withheld.filter(
+    (w) => w.reason === RESERVATION_REASONS.EARLIER_BEAT,
+  );
+  const byLease = withheld.filter(
+    (w) => w.reason === RESERVATION_REASONS.FOREIGN_LEASE,
+  );
+  const parts = [];
+  if (byBeat.length > 0) {
+    parts.push(
+      `${byBeat.length} Story(ies) withheld because their file footprint ` +
+        `overlaps a Story still in flight from an earlier beat — ${detail(byBeat)}. ` +
+        `Each re-admits automatically on a later beat, once the Story ` +
+        `reserving its files leaves the in-flight set.`,
+    );
+  }
+  if (byLease.length > 0) {
+    parts.push(
+      `${byLease.length} Story(ies) withheld because their file footprint ` +
+        `overlaps a Story another operator's lease holds — ${detail(byLease)}. ` +
+        `No beat of THIS run clears that: the peer is the holder's work, and ` +
+        `each re-admits once their lease clears (see foreignHeldReason).`,
+    );
+  }
+  return `${parts.join(' ')} Neither is a wedge and neither is a failure.`;
 }
 
 /**
@@ -542,7 +607,7 @@ export function resolveCapPrecedence({ cwd, config, override } = {}) {
  * understands (`{ id, dependsOn }`), tags any node already in the done set
  * as `agent::done` so the core's classifier excludes it from the dispatch
  * set **and** counts it as a satisfied dependency, then delegates the
- * scheduling decision to `selectReadySet`. A cyclic operator DAG is a
+ * scheduling decision to `planReadySet`. A cyclic operator DAG is a
  * planning error (the core would silently never schedule the cycle), so we
  * detect it up front via the shared `detectCycle` kernel and short-circuit
  * with a `cycleError` and exit code 2.
@@ -558,6 +623,10 @@ export function resolveCapPrecedence({ cwd, config, override } = {}) {
  *   already in flight, so the kernel reserves their footprints instead of
  *   merely counting them (Story #4950). `null` (flag mode) means reservation
  *   is structurally unavailable — see {@link buildReservationReport}.
+ * @param {number[]} [args.foreignHeldIds] Ids among `inFlightRecords` that a
+ *   **foreign operator's lease** holds rather than this run's own earlier
+ *   beat, so a withholding against one is reported for what it is
+ *   (Story #4960). Flag mode has no lease view and passes none.
  * @returns {{
  *   envelope: {
  *     kind: 'stories-ready-set',
@@ -578,6 +647,7 @@ export function buildReadySetEnvelope(
     doneIds = new Set(),
     inFlight = 0,
     inFlightRecords = null,
+    foreignHeldIds = [],
   },
 ) {
   const totalStories = nodes.length;
@@ -607,7 +677,7 @@ export function buildReadySetEnvelope(
   // Cycle detection before scheduling — a cycle is a planning error the
   // operator must fix. dropForeign:false preserves the operator-DAG contract
   // (a dependency on an id outside the supplied set is honored, not pruned),
-  // matching the same builder seam selectReadySet uses internally.
+  // matching the same builder seam planReadySet uses internally.
   const adjacency = buildStoryAdjacency(nodes, { dropForeign: false });
   const cycle = detectCycle(adjacency);
   if (cycle) {
@@ -658,6 +728,7 @@ export function buildReadySetEnvelope(
   const reservation = buildReservationReport(
     inFlightRecords,
     withheldByInFlight,
+    foreignHeldIds,
   );
 
   // Wedge detection (Story #4540). `ready: []` is normal while work is in
@@ -927,6 +998,9 @@ export async function runProbedStoriesWaveTick({
     // Probe mode is the only mode that HAS the in-flight Stories' records, so
     // it is the only mode that can reserve their footprints (Story #4950).
     inFlightRecords,
+    // ...and the only mode that can tell a foreign lease-holder apart from
+    // this run's own earlier-beat dispatch (Story #4960).
+    foreignHeldIds: foreignHeld.map((h) => h.id),
   });
 
   const done = [...doneIds].sort((a, b) => a - b);

--- a/.agents/workflows/helpers/deliver-reference.md
+++ b/.agents/workflows/helpers/deliver-reference.md
@@ -92,14 +92,16 @@ needs `github.operatorHandle` set (in `.agentrc.local.json`); without it the
 probe logs a warning and leans on init's lease refusal alone.
 
 **Overlapping footprints are reserved across beats, not just within one.** A
-Story whose files a still-implementing Story already touches is withheld and
-named in `inFlightReservation: { available, withheld: [{ id, blockedBy }],
-note }`. Like `foreignHeld` this is neither a failure nor a wedge — the Story
-re-admits automatically once its blocker leaves the in-flight set — and it
-exists so an unfilled slot is explained rather than mysterious. Reservation
-needs the in-flight Stories' footprints, so it is a `--probe-live` capability:
-under `--dag` the report is `available: false` and selection de-conflicts
-within the beat only.
+Story sharing a **concrete** path with a still-implementing Story is withheld
+and named in `inFlightReservation: { available, withheld: [{ id, blockedBy,
+reason }], note }`, where `reason` is `in-flight-earlier-beat` or
+`foreign-lease`. Like `foreignHeld` this is neither a failure nor a wedge — the
+Story re-admits automatically once its blocker leaves the in-flight set — and
+it exists so an unfilled slot is explained rather than mysterious. A **glob**
+footprint (or the UNKNOWN sentinel for an unparseable body) reserves nothing
+across beats; it still serializes its own beat. Reservation needs the in-flight
+Stories' footprints, so it is a `--probe-live` capability: under `--dag` the
+report is `available: false` and selection de-conflicts within the beat only.
 
 ## Dispatch mechanics (role-scoped by default)
 

--- a/baselines/dead-exports-production.json
+++ b/baselines/dead-exports-production.json
@@ -2166,10 +2166,6 @@
     },
     {
       "file": ".agents/scripts/lib/wave-runner/ready-set.js",
-      "symbol": "selectReadySet"
-    },
-    {
-      "file": ".agents/scripts/lib/wave-runner/ready-set.js",
       "symbol": "storiesOverlap"
     },
     {

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -224,7 +224,7 @@ graph TB
 | `plan-critics.js`                | Single critic-dispatch evaluation point for `/plan`, run between Author and Persist: prints the consolidation + pre-mortem verdict as JSON (advisory — exits 0 on any verdict) and ledgers every skip. Exits 1 on a usage/IO error, where no critic ran and no skip was ledgered: do not proceed to Persist. |
 | `plan-persist.js`                | Single GitHub-write surface for `/plan`: section gate, ticket validator + file-assumption + DAG + budget gates, Story creation, terminal `agent::ready` flip, `plan-summary` comment. |
 | `single-story-init.js`           | Validates a standalone Story, branches from `main`, creates the worktree, flips `agent::executing`. |
-| `stories-wave-tick.js`           | Ready-set planner for multi-Story `/deliver` (shared `selectReadySet` core; default concurrency 3). |
+| `stories-wave-tick.js`           | Ready-set planner for multi-Story `/deliver` (shared `planReadySet` core; default concurrency 3). |
 | `single-story-close.js`          | Close-validation gate chain, opens PR to `main` with auto-merge armed, rests Story at `agent::closing`. |
 | `single-story-confirm-merge.js`  | Post-merge confirmation: after checks go green and the PR merges, flips `agent::closing → agent::done`. |
 | `update-ticket-state.js`         | Syncs ticket status via GitHub labels (`agent::ready` → `agent::done`). |
@@ -241,14 +241,14 @@ graph TB
 #### Ready-set / DAG helpers
 
 Multi-Story ordering for `/deliver` uses `lib/wave-runner/ready-set.js`
-(`selectReadySet`) driven by `stories-wave-tick.js` — there is no
+(`planReadySet`) driven by `stories-wave-tick.js` — there is no
 `dispatch-engine.js` / `dispatcher.js` entry script. Residual DAG helpers
 under `lib/orchestration/` remain only where live paths still import them.
 
 | Helper                        | Responsibility                                                                            |
 | ----------------------------- | ----------------------------------------------------------------------------------------- |
 | `lib/wave-runner/ready-set.js` | Select the next ready Story set given deps + concurrency. |
-| `lib/wave-runner/live-probe.js` | State-probing adapter feeding the pure `selectReadySet` kernel from live GitHub state (done / in-flight / foreign blockers) instead of caller-transcribed flags. |
+| `lib/wave-runner/live-probe.js` | State-probing adapter feeding the pure `planReadySet` kernel from live GitHub state (done / in-flight / foreign blockers) instead of caller-transcribed flags. |
 | `dependency-parser.js`        | Parse `depends_on` / `blocked by #N` edges from Story bodies. |
 
 #### Failure auditability
@@ -518,13 +518,15 @@ That is the complete live export surface — in particular there is **no**
 `autoSerializeOverlaps()`. The focus-area auto-serialization pass it named is
 gone; its job now happens at *selection* time via `storiesOverlap()` in
 `lib/wave-runner/ready-set.js`, where `planReadySet` skips a Story whose
-**widened** footprint overlaps either an already-selected peer or a Story
-still **in flight** from an earlier beat. The cross-beat half needs the
-in-flight Stories' records, which only probe mode holds: `live-probe.js`
-returns them as `inFlightRecords`, and the tick reports each withholding in
-the envelope's `inFlightReservation` naming the blocking id. Flag mode carries
-a count and no records, so it reports `available: false` rather than an
-indistinguishable empty result.
+**widened** footprint overlaps an already-selected peer, or which shares a
+**concrete** path with a Story still **in flight** from an earlier beat. The
+cross-beat half needs the in-flight Stories' records, which only probe mode
+holds: `live-probe.js` returns them as `inFlightRecords`, and the tick reports
+each withholding in the envelope's `inFlightReservation` naming the blocking
+id and why. Flag mode carries a count and no records, so it reports
+`available: false` rather than an indistinguishable empty result. The two
+halves treat unknown width differently on purpose — § Scheduler safety
+mechanics.
 
 ---
 
@@ -660,7 +662,7 @@ close.
 
 | Module              | Role                                                                                                |
 | ------------------- | --------------------------------------------------------------------------------------------------- |
-| `stories-wave-tick` | Continuous ready-set planner for multi-Story `/deliver` — adapter over `selectReadySet`; emits the per-beat dispatch set (no Epic wave barrier). |
+| `stories-wave-tick` | Continuous ready-set planner for multi-Story `/deliver` — adapter over `planReadySet`; emits the per-beat dispatch set (no Epic wave barrier). |
 | (host fan-out)      | There is no `story-launcher` module: the `/deliver` host session itself fans out up to `concurrencyCap` Story sub-agents per ready-set beat, per [`workflows/deliver.md`](../.agents/workflows/deliver.md). |
 | `notification-hook` | Fire-and-forget webhook; never blocks execution.                                                    |
 | `column-sync`       | Drives the Projects v2 Status column from `agent::` labels (best-effort).                           |
@@ -726,7 +728,7 @@ Story. The script surface is:
 | Script                         | Responsibility                                                                                                   |
 | ------------------------------ | ----------------------------------------------------------------------------------------------------------------- |
 | `single-story-init.js`         | Validates the standalone Story, branches directly from `main` (no `epic/<id>` seed, no dispatch-manifest gate).   |
-| `stories-wave-tick.js`         | Continuous ready-set planner for the standalone fan-out — a thin adapter over the shared `selectReadySet` core; emits the per-beat dispatch set on the `stories-ready-set` envelope and resolves the global `concurrencyCap` (default 3). |
+| `stories-wave-tick.js`         | Continuous ready-set planner for the standalone fan-out — a thin adapter over the shared `planReadySet` core; emits the per-beat dispatch set on the `stories-ready-set` envelope and resolves the global `concurrencyCap` (default 3). |
 | `single-story-close.js`        | Runs the canonical close-validation gate chain against the base branch, opens the PR straight to `main` with auto-merge armed, and rests the Story at `agent::closing`. |
 | `single-story-confirm-merge.js` | Post-merge confirmation: once `gh pr checks --watch` exits green and the PR merges, flips `agent::closing → agent::done` and closes the issue. |
 
@@ -737,17 +739,26 @@ asynchronous auto-merge completes.
 
 ### Scheduler safety mechanics
 
-The per-beat selector (`lib/wave-runner/ready-set.js#selectReadySet`) is
+The per-beat selector (`lib/wave-runner/ready-set.js#planReadySet`) is
 stateless and side-effect-free; these guards make the loop fail safe:
 
-- **File-overlap footprint guard.** Ready candidates are admitted
-  greedily in ascending-id order and skipped when their declared `files`
-  footprint overlaps an already-admitted Story's. An **empty** footprint
-  means "no known overlap" and is never withheld; a **glob** footprint —
-  or the UNKNOWN sentinel `resolve-stories.js` substitutes for an
-  unparseable body — overlaps *everything* and serializes the rest of
-  the beat. Safe by construction, but a broadly-scoped glob footprint
-  silently drops the beat to concurrency 1.
+- **File-overlap footprint guard.** Candidates are admitted greedily in
+  ascending-id order and skipped when their **widened** footprint — the
+  declared `files` plus the paths the Story's own title and body name,
+  a declaration being only a lower bound (#4875) — collides. An
+  **empty** footprint means "no known overlap" and is never withheld.
+- **Beat-local and cross-beat differ.** Against a peer admitted **this
+  beat**, a **glob** — or the UNKNOWN sentinel `resolve-stories.js`
+  substitutes for an unparseable body — overlaps *everything*: unknown
+  width is not no width. Against a Story **in flight from an earlier
+  beat** (or held by a foreign lease) only a shared **concrete** path
+  reserves; the glob class reserves nothing (#4960), because that
+  window spans a whole implementation, so one glob withheld the entire
+  run and one unparseable body made it serial. Reservation needs the
+  in-flight records, so it is `--probe-live`-only; each withholding is
+  named in `inFlightReservation` with its blocker and a `reason`
+  (`in-flight-earlier-beat` / `foreign-lease`), and flag mode reports
+  `available: false` rather than an indistinguishable empty result.
 - **Cycle vs. wedge, distinct exits.** A dependency cycle is detected up
   front (`detectCycle`, exit 2); a wedge — nothing ready, nothing in
   flight, undone work with unmet blockers — exits 3 via `detectWedge`.

--- a/tests/deliver-epic-single.test.js
+++ b/tests/deliver-epic-single.test.js
@@ -159,7 +159,7 @@ describe('/deliver takes only Story ids (Story #4540)', () => {
 
   it('drives the beat from live state rather than hand-maintained flags (Story #4594)', () => {
     // Was: "mandates seeding the first beat --done from the resolver
-    // envelope". That prose existed because selectReadySet satisfies a
+    // envelope". That prose existed because planReadySet satisfies a
     // foreign gate only via the done set, so a host that seeded it empty
     // silently discarded the cross-run resolution and wedged the run.
     //

--- a/tests/scripts/resolve-stories.test.js
+++ b/tests/scripts/resolve-stories.test.js
@@ -30,7 +30,7 @@ import {
   toStoryRecord,
 } from '../../.agents/scripts/lib/orchestration/resolve-stories.js';
 import {
-  selectReadySet,
+  planReadySet,
   storiesOverlap,
 } from '../../.agents/scripts/lib/wave-runner/ready-set.js';
 import { runResolveStories } from '../../.agents/scripts/resolve-stories.js';
@@ -454,7 +454,7 @@ describe('buildStoriesEnvelope ↔ ready set — one run, one consistent answer'
 
       // The tick's view of the same run: every Story ready, cap 5 — the
       // reported condition, reproduced rather than assumed.
-      const ready = selectReadySet({
+      const ready = planReadySet({
         stories: stories.map((s) => ({
           id: s.id,
           dependsOn: [],
@@ -463,7 +463,7 @@ describe('buildStoriesEnvelope ↔ ready set — one run, one consistent answer'
         doneIds: new Set(),
         inFlight: 0,
         globalCap: 5,
-      }).map((s) => s.id);
+      }).selected.map((s) => s.id);
       assert.deepEqual(ready, ids, 'the measured ready set must reproduce');
 
       const inline = env.stories.filter((s) => s.dispatchMode === 'inline');
@@ -478,12 +478,12 @@ describe('buildStoriesEnvelope ↔ ready set — one run, one consistent answer'
   it('a one-Story run keeps inline — and its ready set is the one Story', () => {
     const stories = [liteStory(4829)];
     const env = buildStoriesEnvelope({ stories, injectedRules: RULES });
-    const ready = selectReadySet({
+    const ready = planReadySet({
       stories: [{ id: 4829, dependsOn: [], files: ['src/feature-4829.js'] }],
       doneIds: new Set(),
       inFlight: 0,
       globalCap: 5,
-    });
+    }).selected;
     assert.equal(ready.length, 1);
     assert.equal(
       env.stories[0].dispatchMode,
@@ -594,12 +594,12 @@ describe('storyFootprintPaths — an unreadable footprint fails SAFE, not open',
     };
     const other = { id: 2, dependsOn: [], files: ['docs/README.md'] };
     assert.equal(storiesOverlap(unknown, other), true);
-    const ready = selectReadySet({
+    const ready = planReadySet({
       stories: [unknown, other],
       doneIds: new Set(),
       inFlight: 0,
       globalCap: 5,
-    }).map((s) => s.id);
+    }).selected.map((s) => s.id);
     assert.deepEqual(ready, [1], 'the unreadable Story takes the beat alone');
   });
 

--- a/tests/scripts/stories-wave-tick.test.js
+++ b/tests/scripts/stories-wave-tick.test.js
@@ -4,7 +4,7 @@
  * Unit tests for the continuous ready-set adapter in stories-wave-tick.js.
  *
  * The file is now a thin adapter over the path-agnostic scheduling core
- * (`lib/wave-runner/ready-set.js#selectReadySet`): it no longer batches
+ * (`lib/wave-runner/ready-set.js#planReadySet`): it no longer batches
  * Stories into fully-draining waves (the static wave-batch plan built via
  * `Graph.js#assignLayers` is gone). It parses the operator DAG + the live
  * run progress (`--done` / `--in-flight`) and emits the set of Stories safe
@@ -15,7 +15,7 @@
  *   - parseDag: validates the DAG input format
  *   - parseDoneIds / parseInFlight: validate the live-progress flags
  *   - parseConcurrencyOverride / resolveConcurrencyCap: cap resolution
- *   - buildReadySetEnvelope: continuous selection through selectReadySet
+ *   - buildReadySetEnvelope: continuous selection through planReadySet
  *   - runStoriesWaveTick: end-to-end helper (no subprocess)
  *   - CLI via spawnSync: smoke-tests --help, --dag, --dag-file, --done,
  *     cycle detection
@@ -335,7 +335,7 @@ describe('buildReadySetEnvelope', () => {
 
   it('honors the file-overlap guard the Epic path uses (co-dispatch withhold)', () => {
     // Two unblocked roots that declare the same file footprint MUST NOT both
-    // dispatch on one beat — selectReadySet withholds one. The DAG-node
+    // dispatch on one beat — planReadySet withholds one. The DAG-node
     // builder forwards `files` through unchanged.
     const nodes = [
       { id: 1, dependsOn: [], files: ['lib/shared.js'] },
@@ -964,7 +964,7 @@ describe('buildReadySetEnvelope — inFlightReservation (Story #4950)', () => {
     assert.deepEqual(envelope.ready, [2]);
     assert.strictEqual(envelope.inFlightReservation.available, true);
     assert.deepEqual(envelope.inFlightReservation.withheld, [
-      { id: 1, blockedBy: 9 },
+      { id: 1, blockedBy: 9, reason: 'in-flight-earlier-beat' },
     ]);
     // The note must name both sides — an unfilled slot with no explanation is
     // exactly what this report exists to remove.
@@ -1090,7 +1090,7 @@ describe('runProbedStoriesWaveTick — threads the probed in-flight records (AC-
     assert.strictEqual(exitCode, 0);
     assert.deepEqual(envelope.ready, [2], '#1 races the in-flight #9');
     assert.deepEqual(envelope.inFlightReservation.withheld, [
-      { id: 1, blockedBy: 9 },
+      { id: 1, blockedBy: 9, reason: 'in-flight-earlier-beat' },
     ]);
   });
 

--- a/tests/scripts/story-adjacency.test.js
+++ b/tests/scripts/story-adjacency.test.js
@@ -6,7 +6,7 @@
  *     turning Story records into the `Map<storyId, deps[]>` shape the
  *     `lib/Graph.js` kernel consumes.
  *   - The standalone `stories-wave-tick.js` adapter (Story #4156 routed it
- *     through `lib/wave-runner/ready-set.js#selectReadySet`, which re-derives
+ *     through `lib/wave-runner/ready-set.js#planReadySet`, which re-derives
  *     adjacency from the **same** `buildStoryAdjacency` builder) agrees with
  *     that wave numbering: its continuous, beat-by-beat ready-set reveals
  *     exactly those strata in order. The standalone path no longer computes a

--- a/tests/wave-runner/live-probe.test.js
+++ b/tests/wave-runner/live-probe.test.js
@@ -803,7 +803,7 @@ describe('probeLiveState — inFlightRecords feed the footprint reservation', ()
     assert.deepEqual(envelope.ready, [103]);
     assert.equal(envelope.inFlightReservation.available, true);
     assert.deepEqual(envelope.inFlightReservation.withheld, [
-      { id: 102, blockedBy: 101 },
+      { id: 102, blockedBy: 101, reason: 'in-flight-earlier-beat' },
     ]);
   });
 
@@ -816,5 +816,67 @@ describe('probeLiveState — inFlightRecords feed the footprint reservation', ()
 
     assert.deepEqual(envelope.ready, [102, 103]);
     assert.deepEqual(envelope.inFlightReservation.withheld, []);
+  });
+
+  it('names a foreign-lease blocker as such, not as an earlier beat (Story #4960)', async () => {
+    // #101 is held by another operator's lease, so the probe folds it into the
+    // in-flight set and it reserves lib/shared.js — sound, and it stays. But
+    // THIS run never dispatched it and no later beat of this run clears it, so
+    // reporting #102 as racing "a Story still in flight from an earlier beat"
+    // was simply false.
+    const { envelope } = await tick(
+      {
+        101: issue(101, { assignees: ['bob'], changes: ['lib/shared.js'] }),
+        102: issue(102, { changes: ['lib/shared.js'] }),
+        103: issue(103, { changes: ['lib/other.js'] }),
+      },
+      { self: 'dsj1984' },
+    );
+
+    assert.deepEqual(envelope.ready, [103]);
+    assert.deepEqual(envelope.foreignHeld, [{ id: 101, holder: 'bob' }]);
+    assert.deepEqual(envelope.inFlightReservation.withheld, [
+      { id: 102, blockedBy: 101, reason: 'foreign-lease' },
+    ]);
+    assert.match(
+      envelope.inFlightReservation.note,
+      /another operator's lease holds/,
+    );
+    assert.doesNotMatch(
+      envelope.inFlightReservation.note,
+      /still in flight from an earlier beat/,
+      'the earlier-beat wording must not be applied to a foreign lease',
+    );
+  });
+
+  it('keeps the two reasons apart when one beat has both', async () => {
+    const { envelope } = await tick(
+      {
+        101: issue(101, { assignees: ['bob'], changes: ['lib/shared.js'] }),
+        102: issue(102, {
+          labels: ['agent::executing'],
+          changes: ['lib/other.js'],
+        }),
+        103: issue(103, { changes: ['lib/shared.js'] }),
+        104: issue(104, { changes: ['lib/other.js'] }),
+      },
+      { self: 'dsj1984' },
+    );
+
+    assert.deepEqual(envelope.ready, []);
+    assert.deepEqual(envelope.inFlightReservation.withheld, [
+      { id: 103, blockedBy: 101, reason: 'foreign-lease' },
+      { id: 104, blockedBy: 102, reason: 'in-flight-earlier-beat' },
+    ]);
+    assert.match(envelope.inFlightReservation.note, /#103 ← #101/);
+    assert.match(envelope.inFlightReservation.note, /#104 ← #102/);
+    assert.match(
+      envelope.inFlightReservation.note,
+      /still in flight from an earlier beat/,
+    );
+    assert.match(
+      envelope.inFlightReservation.note,
+      /another operator's lease holds/,
+    );
   });
 });

--- a/tests/wave-runner/ready-set.test.js
+++ b/tests/wave-runner/ready-set.test.js
@@ -5,11 +5,18 @@ import { AGENT_LABELS } from '../../.agents/scripts/lib/label-constants.js';
 import {
   classifyStory,
   planReadySet,
-  selectReadySet,
   storiesOverlap,
   storyFootprint,
   storyIdOf,
 } from '../../.agents/scripts/lib/wave-runner/ready-set.js';
+
+/**
+ * The dispatch set alone. `planReadySet` is the only scheduling entry point
+ * (Story #4960 deleted the `selectReadySet` wrapper that had lost its last
+ * production caller); cases that assert only on admission read better against
+ * this local projection than against `.selected` at every call site.
+ */
+const dispatchSet = (args) => planReadySet(args).selected;
 
 /**
  * Convenience factory for a Story record. `dependsOn` feeds the explicit
@@ -124,16 +131,16 @@ describe('lib/wave-runner/ready-set — storyFootprint & storiesOverlap', () => 
   });
 });
 
-describe('lib/wave-runner/ready-set — selectReadySet dependency gating', () => {
+describe('lib/wave-runner/ready-set — planReadySet dependency gating', () => {
   // Acceptance: Given a graph where Story C depends only on Story A,
-  // selectReadySet includes C as soon as A is in the done set, even when an
+  // planReadySet includes C as soon as A is in the done set, even when an
   // unrelated Story B is not in it. (No false barrier.)
   it('selects C (deps only on A) once A is done, while unrelated B is still pending', () => {
     const A = story(1, { labels: [AGENT_LABELS.DONE] });
     const B = story(2); // unrelated, not done, not a dependency of C
     const C = story(3, { dependsOn: [1] });
 
-    const selected = selectReadySet({
+    const selected = dispatchSet({
       stories: [A, B, C],
       inFlight: 0,
       globalCap: 5,
@@ -151,7 +158,7 @@ describe('lib/wave-runner/ready-set — selectReadySet dependency gating', () =>
     const B = story(2); // not done
     const C = story(3, { dependsOn: [1, 2] }); // needs BOTH A and B
 
-    const selected = selectReadySet({
+    const selected = dispatchSet({
       stories: [A, B, C],
       inFlight: 0,
       globalCap: 5,
@@ -164,7 +171,7 @@ describe('lib/wave-runner/ready-set — selectReadySet dependency gating', () =>
   it('honours caller-supplied doneIds in addition to live-done records', () => {
     // A is not in the record set at all; the caller asserts it is done.
     const C = story(3, { dependsOn: [1] });
-    const selected = selectReadySet({
+    const selected = dispatchSet({
       stories: [C],
       doneIds: [1],
       inFlight: 0,
@@ -176,7 +183,7 @@ describe('lib/wave-runner/ready-set — selectReadySet dependency gating', () =>
   it('treats an absent (foreign, not-done) dependency as a barrier', () => {
     // C depends on 99, which is neither in the set nor in doneIds.
     const C = story(3, { dependsOn: [99] });
-    const selected = selectReadySet({
+    const selected = dispatchSet({
       stories: [C],
       inFlight: 0,
       globalCap: 5,
@@ -190,7 +197,7 @@ describe('lib/wave-runner/ready-set — selectReadySet dependency gating', () =>
     const executing = story(3, { labels: [AGENT_LABELS.EXECUTING] });
     const ready = story(4);
 
-    const selected = selectReadySet({
+    const selected = dispatchSet({
       stories: [done, blocked, executing, ready],
       inFlight: 0,
       globalCap: 10,
@@ -199,7 +206,7 @@ describe('lib/wave-runner/ready-set — selectReadySet dependency gating', () =>
   });
 });
 
-describe('lib/wave-runner/ready-set — selectReadySet dropForeign policy', () => {
+describe('lib/wave-runner/ready-set — planReadySet dropForeign policy', () => {
   // The default (dropForeign:false) keeps a foreign dependency as a gate —
   // the standalone / operator-DAG contract (see the "absent foreign
   // dependency as a barrier" test above). The Epic path opts into
@@ -208,7 +215,7 @@ describe('lib/wave-runner/ready-set — selectReadySet dropForeign policy', () =
   // unsatisfiable gate that would silently strand the dependent.
   it('dropForeign:true prunes a foreign dependency so the dependent becomes schedulable', () => {
     const C = story(3, { dependsOn: [99] }); // 99 is not in scope
-    const selected = selectReadySet({
+    const selected = dispatchSet({
       stories: [C],
       inFlight: 0,
       globalCap: 5,
@@ -222,7 +229,7 @@ describe('lib/wave-runner/ready-set — selectReadySet dropForeign policy', () =
     // scope and not yet done must still withhold the dependent.
     const A = story(1); // in scope, not done
     const C = story(3, { dependsOn: [1] });
-    const selected = selectReadySet({
+    const selected = dispatchSet({
       stories: [A, C],
       inFlight: 0,
       globalCap: 5,
@@ -234,16 +241,16 @@ describe('lib/wave-runner/ready-set — selectReadySet dropForeign policy', () =
 
   it('defaults to dropForeign:false — a foreign dependency stays a barrier', () => {
     const C = story(3, { dependsOn: [99] });
-    const selected = selectReadySet({ stories: [C], globalCap: 5 });
+    const selected = dispatchSet({ stories: [C], globalCap: 5 });
     assert.deepEqual(ids(selected), []);
   });
 });
 
-describe('lib/wave-runner/ready-set — selectReadySet capacity', () => {
-  // Acceptance: selectReadySet never returns more than (globalCap - inFlight).
+describe('lib/wave-runner/ready-set — planReadySet capacity', () => {
+  // Acceptance: planReadySet never returns more than (globalCap - inFlight).
   it('never returns more than globalCap - inFlight stories', () => {
     const stories = [story(1), story(2), story(3), story(4), story(5)];
-    const selected = selectReadySet({
+    const selected = dispatchSet({
       stories,
       inFlight: 2,
       globalCap: 4,
@@ -256,24 +263,18 @@ describe('lib/wave-runner/ready-set — selectReadySet capacity', () => {
 
   it('returns an empty set when inFlight has saturated globalCap', () => {
     const stories = [story(1), story(2)];
-    assert.deepEqual(
-      selectReadySet({ stories, inFlight: 3, globalCap: 3 }),
-      [],
-    );
-    assert.deepEqual(
-      selectReadySet({ stories, inFlight: 5, globalCap: 3 }),
-      [],
-    );
+    assert.deepEqual(dispatchSet({ stories, inFlight: 3, globalCap: 3 }), []);
+    assert.deepEqual(dispatchSet({ stories, inFlight: 5, globalCap: 3 }), []);
   });
 
   it('returns an empty set for a non-positive or missing globalCap', () => {
     const stories = [story(1)];
-    assert.deepEqual(selectReadySet({ stories, globalCap: 0 }), []);
-    assert.deepEqual(selectReadySet({ stories }), []);
+    assert.deepEqual(dispatchSet({ stories, globalCap: 0 }), []);
+    assert.deepEqual(dispatchSet({ stories }), []);
   });
 });
 
-describe('lib/wave-runner/ready-set — selectReadySet file-overlap guard', () => {
+describe('lib/wave-runner/ready-set — planReadySet file-overlap guard', () => {
   // Acceptance: Two ready stories whose file footprints overlap are never
   // both returned in one dispatch set; one is withheld until the other clears.
   it('never returns two overlapping-footprint stories in one set', () => {
@@ -281,7 +282,7 @@ describe('lib/wave-runner/ready-set — selectReadySet file-overlap guard', () =
     const B = story(2, { files: ['lib/shared.js', 'lib/b.js'] }); // overlaps A
     const C = story(3, { files: ['lib/c.js'] }); // disjoint
 
-    const selected = selectReadySet({
+    const selected = dispatchSet({
       stories: [A, B, C],
       inFlight: 0,
       globalCap: 10,
@@ -307,7 +308,7 @@ describe('lib/wave-runner/ready-set — selectReadySet file-overlap guard', () =
     const B = story(2, { files: ['lib/shared.js'] });
 
     // Beat 1: A and B both ready & overlapping → only A goes.
-    const beat1 = selectReadySet({
+    const beat1 = dispatchSet({
       stories: [A, B],
       inFlight: 0,
       globalCap: 10,
@@ -319,7 +320,7 @@ describe('lib/wave-runner/ready-set — selectReadySet file-overlap guard', () =
       labels: [AGENT_LABELS.DONE],
       files: ['lib/shared.js'],
     });
-    const beat2 = selectReadySet({
+    const beat2 = dispatchSet({
       stories: [Adone, B],
       inFlight: 0,
       globalCap: 10,
@@ -331,7 +332,7 @@ describe('lib/wave-runner/ready-set — selectReadySet file-overlap guard', () =
     // Two footprint-less stories never collide → both selected.
     const A = story(1);
     const B = story(2);
-    const selected = selectReadySet({
+    const selected = dispatchSet({
       stories: [A, B],
       inFlight: 0,
       globalCap: 10,
@@ -340,11 +341,11 @@ describe('lib/wave-runner/ready-set — selectReadySet file-overlap guard', () =
   });
 });
 
-describe('lib/wave-runner/ready-set — selectReadySet edge cases', () => {
+describe('lib/wave-runner/ready-set — planReadySet edge cases', () => {
   it('returns an empty set for an empty / missing story list', () => {
-    assert.deepEqual(selectReadySet({ stories: [], globalCap: 5 }), []);
-    assert.deepEqual(selectReadySet({ globalCap: 5 }), []);
-    assert.deepEqual(selectReadySet(), []);
+    assert.deepEqual(dispatchSet({ stories: [], globalCap: 5 }), []);
+    assert.deepEqual(dispatchSet({ globalCap: 5 }), []);
+    assert.deepEqual(dispatchSet(), []);
   });
 });
 
@@ -385,7 +386,7 @@ describe('storiesOverlap — glob footprints fail safe (Story #4540)', () => {
   });
 
   it('a glob-bearing Story is not co-dispatched with anything', () => {
-    const ready = selectReadySet({
+    const ready = dispatchSet({
       stories: [glob, exact, unrelated],
       doneIds: new Set(),
       inFlight: 0,
@@ -496,7 +497,7 @@ describe('storiesOverlap — real edits collide even when declarations do not (A
       story(3, { files: ['lib/c.js'] }),
     ];
     assert.deepEqual(
-      ids(selectReadySet({ stories, globalCap: 5 })),
+      ids(dispatchSet({ stories, globalCap: 5 })),
       [1, 3],
       '#2 races #1 on lib/a.js despite declaring only lib/b.js',
     );
@@ -687,9 +688,12 @@ describe('planReadySet — in-flight footprints are reserved, not just counted',
     assert.deepEqual(ids(bareBlocker.selected), [1]);
   });
 
-  it('lets an in-flight glob footprint reserve everything (AC-3)', () => {
-    // Unknown width is not no width: an in-flight Story declaring lib/** may
-    // touch any of these files, so exact-string comparison must fail safe.
+  it('does NOT let an in-flight glob footprint reserve anything (Story #4960)', () => {
+    // #4950 shipped this as "unknown width fails safe across beats too", and
+    // it inverted the throughput goal: an in-flight window spans a whole
+    // implementation, so one glob withheld every other Story for minutes to
+    // hours. The beat-local fail-safe is unchanged (see the case below); only
+    // the cross-beat RESERVATION is exempt.
     const held = inFlight(9, { files: ['.agents/scripts/lib/**'] });
     const { selected, withheldByInFlight } = planReadySet({
       stories: [
@@ -701,11 +705,8 @@ describe('planReadySet — in-flight footprints are reserved, not just counted',
       globalCap: 5,
       inFlightRecords: [held],
     });
-    assert.deepEqual(ids(selected), []);
-    assert.deepEqual(withheldByInFlight, [
-      { id: 1, blockedBy: 9 },
-      { id: 2, blockedBy: 9 },
-    ]);
+    assert.deepEqual(ids(selected), [1, 2]);
+    assert.deepEqual(withheldByInFlight, []);
   });
 
   it('never lets a Story reserve against itself', () => {
@@ -814,23 +815,113 @@ describe('planReadySet — in-flight footprints are reserved, not just counted',
   });
 });
 
-describe('selectReadySet — the dispatch-set-only view of planReadySet', () => {
-  it('returns exactly planReadySet(...).selected', () => {
-    const held = story(9, {
-      labels: [AGENT_LABELS.EXECUTING],
-      files: ['lib/shared.js'],
+// ---------------------------------------------------------------------------
+// Story #4960 — glob/UNKNOWN serializes a BEAT, never a run
+// ---------------------------------------------------------------------------
+
+describe('planReadySet — unknown width is beat-local, concrete width reserves', () => {
+  const inFlight = (id, opts) =>
+    story(id, { ...opts, labels: [AGENT_LABELS.EXECUTING] });
+
+  /** Three eligible Stories with pairwise-disjoint concrete footprints. */
+  const eligible = () => [
+    story(11, { files: ['lib/a.js'] }),
+    story(12, { files: ['lib/b.js'] }),
+    story(13, { files: ['lib/c.js'] }),
+  ];
+
+  it('a glob in flight no longer withholds the whole run (the #4950 regression)', () => {
+    // The reproduced regression: three eligible Stories, one glob-footprint
+    // Story in flight, and the beat selected NOTHING — for that blocker's
+    // entire implementation window.
+    const held = inFlight(10, { files: ['.agents/scripts/**'] });
+    const { selected, withheldByInFlight } = planReadySet({
+      stories: eligible(),
+      inFlight: 1,
+      globalCap: 4,
+      inFlightRecords: [held],
     });
-    const args = {
+    assert.deepEqual(ids(selected), [11, 12, 13]);
+    assert.deepEqual(withheldByInFlight, []);
+  });
+
+  it('the UNKNOWN sentinel an unparseable body yields reserves nothing either', () => {
+    // `resolve-stories.js` substitutes `['**']` for a body it cannot parse.
+    // Reserving on that let ONE malformed Story body collapse an N-Story run
+    // to fully serial.
+    const held = inFlight(10, { files: ['**'] });
+    assert.deepEqual(
+      ids(
+        dispatchSet({
+          stories: eligible(),
+          inFlight: 1,
+          globalCap: 4,
+          inFlightRecords: [held],
+        }),
+      ),
+      [11, 12, 13],
+    );
+  });
+
+  it('a candidate declaring a glob is not withheld by a concrete reservation', () => {
+    // The exemption is a property of the glob CLASS, not of which side it sits
+    // on: an unknown-width candidate names no file the in-flight Story holds.
+    const held = inFlight(10, { files: ['lib/b.js'] });
+    assert.deepEqual(
+      ids(
+        dispatchSet({
+          stories: [story(14, { files: ['lib/**'] })],
+          inFlight: 1,
+          globalCap: 4,
+          inFlightRecords: [held],
+        }),
+      ),
+      [14],
+    );
+  });
+
+  it('a glob in the SAME beat still overlaps everything (fail-safe unchanged)', () => {
+    // A beat is a moment, not a window: co-admitting two Stories whose real
+    // widths are unknown is exactly the collision the guard exists to stop.
+    assert.deepEqual(
+      ids(
+        dispatchSet({
+          stories: [story(9, { files: ['**'] }), ...eligible()],
+          globalCap: 4,
+        }),
+      ),
+      [9],
+      'the glob Story takes the beat alone',
+    );
+  });
+
+  it('a concrete overlap still reserves across beats, exactly as #4950 shipped', () => {
+    const held = inFlight(10, { files: ['lib/b.js'] });
+    const { selected, withheldByInFlight } = planReadySet({
+      stories: eligible(),
+      inFlight: 1,
+      globalCap: 4,
+      inFlightRecords: [held],
+    });
+    assert.deepEqual(ids(selected), [11, 13]);
+    assert.deepEqual(withheldByInFlight, [{ id: 12, blockedBy: 10 }]);
+  });
+
+  it('a concrete path the candidate only names in PROSE still reserves', () => {
+    // The widened footprint (Story #4875) feeds the reservation too — only the
+    // glob arm is exempt, not the evidence arm.
+    const held = inFlight(10, { files: ['lib/held.js'] });
+    const { withheldByInFlight } = planReadySet({
       stories: [
-        story(1, { files: ['lib/shared.js'] }),
-        story(2, { files: ['lib/b.js'] }),
-        held,
+        story(11, {
+          files: ['lib/a.js'],
+          body: 'the caller in lib/held.js changes shape',
+        }),
       ],
       inFlight: 1,
-      globalCap: 5,
+      globalCap: 4,
       inFlightRecords: [held],
-    };
-    assert.deepEqual(selectReadySet(args), planReadySet(args).selected);
-    assert.deepEqual(ids(selectReadySet(args)), [2]);
+    });
+    assert.deepEqual(withheldByInFlight, [{ id: 11, blockedBy: 10 }]);
   });
 });


### PR DESCRIPTION
Closes #4960

_Auto-opened by `/deliver`._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the core `/deliver` ready-set scheduler and cross-beat co-dispatch rules; behavior change is intentional and heavily tested, but mistakes could affect parallelism or reintroduce merge conflicts on concrete shared paths.
> 
> **Overview**
> Fixes **#4960** by splitting file-overlap logic so **same-beat** admission still uses `storiesOverlap` (globs/UNKNOWN still serialize the beat), while **cross-beat** reservations use new `reservesConcretePath` so in-flight glob or `**` footprints no longer block every other Story for the whole implementation window. Concrete path collisions across beats behave as before (#4950).
> 
> The ready-set API is consolidated on **`planReadySet`**; **`selectReadySet`** is removed (dead-exports baseline updated). **`stories-wave-tick.js`** classifies `inFlightReservation.withheld` entries with **`reason`**: `in-flight-earlier-beat` vs **`foreign-lease`**, with operator notes split accordingly. Docs (`deliver-reference.md`, `architecture.md`) and tests reflect the new semantics.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 67103b0bf36b58d8f91ad8f4bb0a37caac02cd48. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->