### PR TITLE
fix: give the raised GitHub write fan-outs transient-retry backoff and single-source their concurrency bound (#4961)

### DIFF
--- a/.agents/scripts/lib/orchestration/plan-context.js
+++ b/.agents/scripts/lib/orchestration/plan-context.js
@@ -31,25 +31,13 @@ import {
   renderAcceptanceSpecSystemPrompt,
   renderTechSpecSystemPrompt,
 } from '../templates/spec-author-prompts.js';
-import { concurrentMap } from '../util/concurrent-map.js';
+import { concurrentMap, FANOUT_CONCURRENCY } from '../util/concurrent-map.js';
 import { buildComplexitySignals } from './complexity-gate.js';
 import { parseDeliverySlicingTable } from './consolidation-precondition.js';
 import { buildDocsDigest } from './docs-digest.js';
 import { buildAuthoringContext } from './planning/authoring-context.js';
 import { buildDecomposerSystemPrompt } from './planning/decomposer-context.js';
 
-/** Bounded concurrency for `--tickets` source-ticket hydration. */
-const SOURCE_TICKET_FETCH_CONCURRENCY = 4;
-/**
- * Bounded concurrency for the per-mode envelope gathers (Story #4952).
- *
- * The duplicate search, the authoring-context fold and the docs digest have
- * no data dependency on one another — the serialization was incidental, and
- * `/plan` pays it with the operator waiting at Gate #1. Same small bound as
- * {@link SOURCE_TICKET_FETCH_CONCURRENCY}: the win here is overlapping three
- * unrelated waits, not saturating the GitHub API.
- */
-const ENVELOPE_GATHER_CONCURRENCY = 4;
 /**
  * Envelope byte ceiling (regression guard for the design's named PR2 risk:
  * two envelopes → one bigger one). This is the **only** live bound on
@@ -885,7 +873,11 @@ async function gatherEnvelopeInputs({
         }),
     ],
     (gather) => gather(),
-    { concurrency: ENVELOPE_GATHER_CONCURRENCY },
+    // The per-mode envelope gathers (Story #4952): the duplicate search, the
+    // authoring-context fold and the docs digest have no data dependency on
+    // one another, so their serialization was incidental and `/plan` paid it
+    // with the operator waiting at Gate #1.
+    { concurrency: FANOUT_CONCURRENCY },
   );
 
   return {
@@ -1040,7 +1032,8 @@ async function fetchSourceTickets(ticketIds, provider) {
         state: ticket.state ?? undefined,
       };
     },
-    { concurrency: SOURCE_TICKET_FETCH_CONCURRENCY },
+    // `--tickets` source-ticket hydration: one independent read per id.
+    { concurrency: FANOUT_CONCURRENCY },
   );
 }
 
@@ -1210,7 +1203,8 @@ async function buildAmendmentModeEnvelope({
         }),
     ],
     (gather) => gather(),
-    { concurrency: ENVELOPE_GATHER_CONCURRENCY },
+    // Same independent-gather fan-out as the seed-mode envelope above.
+    { concurrency: FANOUT_CONCURRENCY },
   );
 
   return {

--- a/.agents/scripts/lib/orchestration/plan-persist/run-plan-persist.js
+++ b/.agents/scripts/lib/orchestration/plan-persist/run-plan-persist.js
@@ -42,7 +42,10 @@ import { getLimits, PROJECT_ROOT } from '../../config-resolver.js';
 import { gitSpawn } from '../../git-utils.js';
 import { Logger } from '../../Logger.js';
 import { sweepTempRetention } from '../../temp-retention.js';
-import { concurrentMap } from '../../util/concurrent-map.js';
+import {
+  concurrentMap,
+  FANOUT_CONCURRENCY,
+} from '../../util/concurrent-map.js';
 import {
   deriveStoryShape,
   LITE_ROUTE_LABEL,
@@ -82,14 +85,6 @@ const PLAN_CHECKPOINT_SCHEMA_VERSION_V2 = 2;
 
 /** Structured-comment type for the per-plan Story checkpoint. */
 const STORY_PLAN_STATE_TYPE = 'story-plan-state';
-
-/**
- * Bounded concurrency for the per-Story checkpoint upserts (Story #4952).
- * Each upsert targets a different issue and reads nothing another writes, so
- * the loop was serial only by construction — but see
- * {@link persistStoryArtifacts} for the ordering that is *not* incidental.
- */
-const CHECKPOINT_WRITE_CONCURRENCY = 4;
 
 /**
  * Write the `story-plan-state` checkpoint on a Story.
@@ -521,7 +516,11 @@ async function persistStoryArtifacts({
         // is the standard full path.
         ...(route ? { route } : {}),
       }),
-    { concurrency: CHECKPOINT_WRITE_CONCURRENCY },
+    // The per-Story checkpoint upserts (Story #4952): each targets a
+    // different issue and reads nothing another writes, so this loop was
+    // serial only by construction — but see {@link persistStoryArtifacts}
+    // for the phase ordering that is *not* incidental.
+    { concurrency: FANOUT_CONCURRENCY },
   );
   await upsertStructuredComment(
     provider,

--- a/.agents/scripts/lib/orchestration/plan-persist/story-ops.js
+++ b/.agents/scripts/lib/orchestration/plan-persist/story-ops.js
@@ -24,7 +24,10 @@ import {
   parse as parseStoryBody,
   serialize as serializeStoryBody,
 } from '../../story-body/story-body.js';
-import { concurrentMap } from '../../util/concurrent-map.js';
+import {
+  concurrentMap,
+  FANOUT_CONCURRENCY,
+} from '../../util/concurrent-map.js';
 import { assertSpecWithinBudget } from '../spec-spill.js';
 import { assertAcceptancePartition } from '../split-policy-validator.js';
 import {
@@ -57,15 +60,6 @@ const LITE_ROUTE_LABEL_COLOR = '#D4C5F9';
 
 /** Length of the derived plan-run id (hex chars). */
 const PLAN_RUN_ID_LENGTH = 8;
-
-/**
- * Bounded concurrency for the terminal per-Story `agent::ready` PATCHes
- * (Story #4952). Each flip is an independent single-issue write, so the loop
- * was serial only by construction. Deliberately the same small bound the rest
- * of the `/plan` path uses — this is a latency fix, not a throughput one, and
- * raising it would only push harder on the same GitHub API.
- */
-const READY_FLIP_CONCURRENCY = 4;
 
 /**
  * Normalize a caller-supplied plan-run token. Kept shared so human-readable
@@ -1015,7 +1009,10 @@ export async function markStoriesReady({ provider, created }) {
         };
       }
     },
-    { concurrency: READY_FLIP_CONCURRENCY },
+    // The terminal per-Story `agent::ready` PATCHes (Story #4952): each flip
+    // is an independent single-issue write, so the loop was serial only by
+    // construction. A latency fix, not a throughput one.
+    { concurrency: FANOUT_CONCURRENCY },
   );
   const readied = outcomes
     .filter((outcome) => outcome.failure === null)

--- a/.agents/scripts/lib/orchestration/plan-persist/supersede-ops.js
+++ b/.agents/scripts/lib/orchestration/plan-persist/supersede-ops.js
@@ -36,23 +36,14 @@
  */
 
 import { Logger } from '../../Logger.js';
-import { concurrentMap } from '../../util/concurrent-map.js';
+import {
+  concurrentMap,
+  FANOUT_CONCURRENCY,
+} from '../../util/concurrent-map.js';
 import { upsertStructuredComment } from '../ticketing.js';
 
 /** Structured-comment type marking a source issue as superseded. */
 const SUPERSEDED_BY_COMMENT_TYPE = 'superseded-by';
-
-/**
- * Bounded concurrency for the per-source-ticket close (Story #4952).
- *
- * The fan-out is across **distinct** tickets — `assertSupersedePartition` has
- * already failed the run closed if two Stories claim the same id, so no two
- * units in flight can touch the same issue. Within one unit the probe →
- * comment → close sequence stays strictly ordered: commenting on an issue the
- * probe reported closed, or closing one the comment never landed on, is the
- * whole failure mode this phase is careful about.
- */
-const SUPERSEDE_CLOSE_CONCURRENCY = 4;
 
 /**
  * GitHub `state_reason` used when closing a superseded source issue.
@@ -476,7 +467,14 @@ export async function closeSupersededTickets({
         sourceTicketIds: sources,
       });
     },
-    { concurrency: SUPERSEDE_CLOSE_CONCURRENCY },
+    // The per-source-ticket close (Story #4952) fans out across **distinct**
+    // tickets — `assertSupersedePartition` has already failed the run closed
+    // if two Stories claim the same id, so no two units in flight can touch
+    // the same issue. Within one unit the probe → comment → close sequence
+    // stays strictly ordered: commenting on an issue the probe reported
+    // closed, or closing one the comment never landed on, is the whole
+    // failure mode this phase is careful about.
+    { concurrency: FANOUT_CONCURRENCY },
   );
 
   const report = emptyReport({ enabled: true, dryRun });

--- a/.agents/scripts/lib/orchestration/planning/authoring-context.js
+++ b/.agents/scripts/lib/orchestration/planning/authoring-context.js
@@ -17,16 +17,12 @@ import { getPaths, PROJECT_ROOT } from '../../config-resolver.js';
 import { fetchPriorFeedback } from '../../feedback-loop/prior-feedback-fetcher.js';
 import { Logger } from '../../Logger.js';
 import { hasTicketSection } from '../../ticket-body-sections.js';
-import { concurrentMap } from '../../util/concurrent-map.js';
+import {
+  concurrentMap,
+  FANOUT_CONCURRENCY,
+} from '../../util/concurrent-map.js';
 import { ensureDocsDigest } from '../docs-digest.js';
 import { buildMemoryPoolAdvisory } from './memory-pool-advisory.js';
-
-/**
- * Bounded concurrency for the independent context gathers (Story #4952).
- * Small on purpose and consistent with the other `/plan`-path fan-outs: these
- * are a handful of local probes plus one `gh` read, not an API sweep.
- */
-const CONTEXT_GATHER_CONCURRENCY = 4;
 
 /**
  * Build the digest-first `docsContext` envelope field (Story #4433 — hard
@@ -170,7 +166,10 @@ export async function buildAuthoringContext(
         }),
     ],
     (gather) => gather(),
-    { concurrency: CONTEXT_GATHER_CONCURRENCY },
+    // The independent context gathers (Story #4952): a handful of local
+    // probes plus one `gh` read, so this rides the shared fan-out bound
+    // rather than declaring its own.
+    { concurrency: FANOUT_CONCURRENCY },
   );
 
   // Story #4811 — the codebase snapshot (#2634), its authoring grounding

--- a/.agents/scripts/lib/orchestration/single-story-close/phases/options.js
+++ b/.agents/scripts/lib/orchestration/single-story-close/phases/options.js
@@ -15,18 +15,21 @@ import { PROJECT_ROOT } from '../../../project-root.js';
 import { isOperatorMergeReason } from './auto-merge.js';
 
 /**
- * Resolve a flag value from an explicit override, a parsed CLI arg, or a
- * hard default.
+ * Resolve a flag value from an explicit override or a parsed CLI arg.
+ *
+ * Returns `undefined` when neither is supplied — that absence is itself the
+ * answer here, letting each caller below apply its own default (a `!!` coerce,
+ * a config lookup, or a deliberate `undefined` passed further down). The
+ * former third `defaultValue` parameter was dropped in Story #4961: no call
+ * site passed it, so it documented a mode nobody used.
  *
  * @template T
  * @param {T|undefined} paramValue
  * @param {T|undefined} parsedValue
- * @param {T} [defaultValue] Omitted when "neither supplied" is itself the
- *   answer — the caller then distinguishes absence from a real value.
- * @returns {T}
+ * @returns {T|undefined}
  */
-function resolveFlag(paramValue, parsedValue, defaultValue) {
-  return paramValue ?? parsedValue ?? defaultValue;
+function resolveFlag(paramValue, parsedValue) {
+  return paramValue ?? parsedValue;
 }
 
 /**

--- a/.agents/scripts/lib/util/concurrent-map.js
+++ b/.agents/scripts/lib/util/concurrent-map.js
@@ -14,6 +14,23 @@
  */
 
 /**
+ * The one bound every independent-write fan-out over the GitHub API uses
+ * (Story #4952 raised those loops off serial; Story #4961 made this the single
+ * owner of the number they share). Imported by the `/plan` context gathers,
+ * the persist checkpoint fan-out, the `agent::ready` flips and the supersede
+ * close loop, so re-tuning the policy is one edit rather than six.
+ *
+ * **Why bounded and not unbounded.** Every unit in those fan-outs is its own
+ * API round-trip, so an unbounded map over an N-Story plan dispatches N writes
+ * at once — and GitHub answers a burst with a secondary rate limit rather than
+ * with throughput. The goal is overlapping unrelated waits, not saturating the
+ * API, and four is enough to collapse the latency the serial loops paid while
+ * staying well under the burst threshold. Callers whose ordering is
+ * load-bearing (`createStoryIssues`) stay serial instead of importing this.
+ */
+export const FANOUT_CONCURRENCY = 4;
+
+/**
  * @template T, R
  * @param {ReadonlyArray<T>} items
  * @param {(item: T, index: number) => Promise<R> | R} mapper

--- a/.agents/scripts/providers/github/tickets.js
+++ b/.agents/scripts/providers/github/tickets.js
@@ -321,6 +321,16 @@ export class TicketGateway {
    * avoid a read-before-write. When other PATCH fields are present, or when
    * removing labels, computes the final label set and returns it to the
    * caller for inclusion in the PATCH.
+   *
+   * The additive POST goes through `withTransientRetry` (Story #4961) on the
+   * same policy as every other call in this file. Story #4952 raised the
+   * `/plan` write loops that reach this endpoint — the `agent::ready` flips
+   * and the checkpoint fan-out — off serial, which is precisely what makes
+   * GitHub's secondary rate limit likelier; `gh-exec` already classifies that
+   * as transient, so the only thing missing was a backoff behind it.
+   * Retry does not change what the caller observes on a genuine failure: an
+   * exhausted or non-transient error still throws, so `markStoriesReady`
+   * still collects it into the complete failure set.
    */
   async _applyLabelMutations(
     ticketId,
@@ -331,11 +341,15 @@ export class TicketGateway {
     const { add = [], remove = [] } = labelMutations;
 
     if (add.length > 0 && remove.length === 0 && !hasOtherPatchFields) {
-      await this._gh.api({
-        method: 'POST',
-        endpoint: `/repos/${this.owner}/${this.repo}/issues/${ticketId}/labels`,
-        body: { labels: add },
-      });
+      await withTransientRetry(
+        () =>
+          this._gh.api({
+            method: 'POST',
+            endpoint: `/repos/${this.owner}/${this.repo}/issues/${ticketId}/labels`,
+            body: { labels: add },
+          }),
+        { label: `addLabels #${ticketId}`, onRetry: defaultRetryWarn },
+      );
       return { skipPatch: true };
     }
 
@@ -351,6 +365,11 @@ export class TicketGateway {
   }
 
   /**
+   * The issue PATCH is wrapped in `withTransientRetry` (Story #4961) for the
+   * same reason as the additive label POST above — see
+   * {@link TicketGateway#_applyLabelMutations}. Both are the write half of the
+   * fan-outs Story #4952 raised; the reads in this file were already wrapped.
+   *
    * @field-manifest PATCH /repos/{owner}/{repo}/issues/{n}:
    *                 body, assignees, state, state_reason, labels
    */
@@ -379,11 +398,15 @@ export class TicketGateway {
     }
 
     if (Object.keys(patch).length > 0) {
-      await this._gh.api({
-        method: 'PATCH',
-        endpoint: `/repos/${this.owner}/${this.repo}/issues/${ticketId}`,
-        body: patch,
-      });
+      await withTransientRetry(
+        () =>
+          this._gh.api({
+            method: 'PATCH',
+            endpoint: `/repos/${this.owner}/${this.repo}/issues/${ticketId}`,
+            body: patch,
+          }),
+        { label: `updateTicket #${ticketId}`, onRetry: defaultRetryWarn },
+      );
       this.invalidateTicket(ticketId);
     }
   }

--- a/tests/providers/github/tickets.test.js
+++ b/tests/providers/github/tickets.test.js
@@ -33,7 +33,7 @@ const ghExecMod = await import(
 
 const { TicketGateway } = ticketsMod;
 const { createInlineTicketCache } = cacheMod;
-const { createGh } = ghExecMod;
+const { createGh, GhExecError, GhRateLimitError } = ghExecMod;
 
 /**
  * Build a fake gh-exec facade that routes on the argv shape
@@ -59,6 +59,30 @@ function makeFakeGh(routes) {
         err.code = val.status;
         throw err;
       }
+    }
+    return { stdout: '{}', stderr: '', code: 0 };
+  };
+  exec.calls = calls;
+  const gh = createGh(exec);
+  gh.__exec = exec;
+  return gh;
+}
+
+/**
+ * Fake gh facade that rejects the first `failures` calls with `error()` and
+ * succeeds afterwards, so the write path's retry can be driven without a
+ * subprocess. `gh-exec` classifies a real secondary rate limit into
+ * `GhRateLimitError`, so throwing that class exercises the production shape
+ * rather than a message that merely looks like one.
+ */
+function makeFlakyGh({ failures, error }) {
+  let remaining = failures;
+  const calls = [];
+  const exec = async ({ args, input }) => {
+    calls.push({ args, input });
+    if (remaining > 0) {
+      remaining -= 1;
+      throw error();
     }
     return { stdout: '{}', stderr: '', code: 0 };
   };
@@ -431,6 +455,74 @@ describe('providers/github/tickets.js — TicketGateway', () => {
     assert.ok(body.labels.includes('fresh'));
     assert.ok(body.labels.includes('existing'));
     assert.ok(!body.labels.includes('old'));
+  });
+
+  it('updateTicket: the additive label POST retries a transient rate limit rather than surfacing it on the first attempt (Story #4961)', async () => {
+    const cache = createInlineTicketCache();
+    cache.set(70, { id: 70, title: 'T70', labels: [], body: '' });
+    const gh = makeFlakyGh({
+      failures: 1,
+      error: () => new GhRateLimitError('gh-exec: gh API rate limit exceeded'),
+    });
+    const gateway = new TicketGateway({ gh, owner: 'o', repo: 'r', cache });
+
+    await gateway.updateTicket(70, { labels: { add: ['agent::ready'] } });
+
+    assert.equal(
+      gh.__exec.calls.length,
+      2,
+      'the rate-limited POST is retried, not surfaced to the caller',
+    );
+    for (const call of gh.__exec.calls) {
+      assert.equal(call.args[2], 'POST');
+      assert.match(call.args[3], /\/issues\/70\/labels$/);
+    }
+    assert.equal(cache.has(70), false, 'the retried write still invalidates');
+  });
+
+  it('updateTicket: the issue PATCH retries a transient rate limit rather than surfacing it on the first attempt (Story #4961)', async () => {
+    const cache = createInlineTicketCache();
+    cache.set(80, { id: 80, title: 'T80', labels: [], body: '' });
+    const gh = makeFlakyGh({
+      failures: 1,
+      error: () => new GhRateLimitError('gh-exec: gh API rate limit exceeded'),
+    });
+    const gateway = new TicketGateway({ gh, owner: 'o', repo: 'r', cache });
+
+    await gateway.updateTicket(80, { body: 'new body' });
+
+    assert.equal(
+      gh.__exec.calls.length,
+      2,
+      'the rate-limited PATCH is retried, not surfaced to the caller',
+    );
+    for (const call of gh.__exec.calls) {
+      assert.equal(call.args[2], 'PATCH');
+      assert.equal(JSON.parse(call.input).body, 'new body');
+    }
+    assert.equal(cache.has(80), false);
+  });
+
+  it('updateTicket: a non-transient write failure still throws on the first attempt — the wrapper never converts it into a silent success (Story #4961)', async () => {
+    // What `markStoriesReady`'s collect-every-failure contract depends on:
+    // a real failure still reaches the caller, so the closing error can name
+    // the complete set of ids that need the label by hand.
+    const gh = makeFlakyGh({
+      failures: Number.POSITIVE_INFINITY,
+      error: () =>
+        new GhExecError('gh-exec: gh exited with code 422: Validation Failed'),
+    });
+    const gateway = new TicketGateway({ gh, owner: 'o', repo: 'r' });
+
+    await assert.rejects(
+      () => gateway.updateTicket(90, { body: 'x' }),
+      /Validation Failed/,
+    );
+    assert.equal(
+      gh.__exec.calls.length,
+      1,
+      'a permanent error bubbles on the first attempt — no backoff burned',
+    );
   });
 
   it('primeTicketCache / invalidateTicket: exposed for parent provider compatibility', () => {

--- a/tests/scripts/plan-persist.flat-stories.test.js
+++ b/tests/scripts/plan-persist.flat-stories.test.js
@@ -9,6 +9,11 @@ import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { describe, it } from 'node:test';
 import {
+  createGh,
+  GhExecError,
+  GhRateLimitError,
+} from '../../.agents/scripts/lib/gh-exec.js';
+import {
   AGENT_LABELS,
   TYPE_LABELS,
 } from '../../.agents/scripts/lib/label-constants.js';
@@ -34,6 +39,7 @@ import { resolveSourceTicketIds } from '../../.agents/scripts/lib/orchestration/
 import { serialize } from '../../.agents/scripts/lib/story-body/story-body.js';
 import { makeTempDir } from '../../.agents/scripts/lib/test-temp.js';
 import { FANOUT_CONCURRENCY } from '../../.agents/scripts/lib/util/concurrent-map.js';
+import { TicketGateway } from '../../.agents/scripts/providers/github/tickets.js';
 
 /**
  * Story sizes for the fan-out guards below. Every assertion about *how* a
@@ -1607,6 +1613,67 @@ describe('markStoriesReady — bounded concurrency (Story #4952)', () => {
         `#${story.id} must still have been flipped`,
       );
     }
+  });
+
+  it('keeps collecting every failure when the flips run through the real retrying write path (Story #4961)', async () => {
+    // The two halves of this Story meet here: the ready flip now goes through
+    // `withTransientRetry` inside TicketGateway, and `markStoriesReady` must
+    // still report the COMPLETE failure set on the other side of it. Driven
+    // through the real gateway rather than a hand-rolled fake, so the retry is
+    // the production one.
+    //
+    // #7200 is rate-limited once and then succeeds — it must NOT appear as a
+    // failure. #7201 is refused permanently — it must, and on the first
+    // attempt, because a permanent error is not retry-eligible.
+    const rateLimitedOnce = new Set([7200]);
+    const calls = [];
+    const exec = async ({ args }) => {
+      const id = Number(args[3].match(/issues\/(\d+)/)[1]);
+      calls.push(id);
+      if (rateLimitedOnce.has(id)) {
+        rateLimitedOnce.delete(id);
+        throw new GhRateLimitError('gh-exec: gh API rate limit exceeded');
+      }
+      if (id === 7201) {
+        throw new GhExecError('gh-exec: gh exited with code 422: refused');
+      }
+      return { stdout: '{}', stderr: '', code: 0 };
+    };
+    const provider = new TicketGateway({
+      gh: createGh(exec),
+      owner: 'o',
+      repo: 'r',
+    });
+    const created = [
+      { id: 7200, slug: 'retried' },
+      { id: 7201, slug: 'refused' },
+      { id: 7202, slug: 'clean' },
+    ];
+
+    await assert.rejects(
+      () => markStoriesReady({ provider, created }),
+      (err) => {
+        assert.match(err.message, /#7201 \(refused\): .*refused/);
+        assert.doesNotMatch(
+          err.message,
+          /#7200/,
+          'a retried-then-successful flip is not a failure',
+        );
+        assert.match(err.message, /1 Story\(ies\) were created/);
+        return true;
+      },
+    );
+    assert.deepEqual(
+      calls.filter((id) => id === 7200).length,
+      2,
+      'the rate-limited flip was retried',
+    );
+    assert.equal(
+      calls.filter((id) => id === 7201).length,
+      1,
+      'the permanent refusal was not retried',
+    );
+    assert.ok(calls.includes(7202), 'the remaining flip was still attempted');
   });
 });
 

--- a/tests/scripts/plan-persist.flat-stories.test.js
+++ b/tests/scripts/plan-persist.flat-stories.test.js
@@ -33,6 +33,17 @@ import { PLAN_SUMMARY_COMMENT_TYPE } from '../../.agents/scripts/lib/orchestrati
 import { resolveSourceTicketIds } from '../../.agents/scripts/lib/orchestration/plan-persist/supersede-ops.js';
 import { serialize } from '../../.agents/scripts/lib/story-body/story-body.js';
 import { makeTempDir } from '../../.agents/scripts/lib/test-temp.js';
+import { FANOUT_CONCURRENCY } from '../../.agents/scripts/lib/util/concurrent-map.js';
+
+/**
+ * Story sizes for the fan-out guards below. Every assertion about *how* a
+ * fan-out behaves — abandonment, phase ordering — has to run above the bound,
+ * because at or below it `concurrentMap` dispatches the whole set up front and
+ * the behaviour under test cannot occur. Derived from the bound rather than
+ * hard-coded, so a re-tune cannot silently make these guards inert again
+ * (Story #4961).
+ */
+const ABOVE_FANOUT_BOUND = FANOUT_CONCURRENCY + 1;
 
 function ticket(slug) {
   const acceptance = [`${slug} done`];
@@ -411,6 +422,11 @@ describe('runPlanPersist — flat Story ops', () => {
     // while story-plan-state was upserted afterwards, so a /deliver that picked
     // a Story up inside that window read a null checkpoint.
     // Ready must mean fully persisted.
+    //
+    // Story #4961 — run ABOVE the fan-out bound. This used to run at N=1 and
+    // assert `order.at(-1) === 'ready'`, which is true of a single Story
+    // however the two phases interleave; only a run wider than the bound can
+    // expose a ready flip that overlaps a still-pending checkpoint.
     const labelsAtCreate = [];
     const provider = fakeProvider({
       createHook: ({ labels }) => labelsAtCreate.push([...labels]),
@@ -432,29 +448,41 @@ describe('runPlanPersist — flat Story ops', () => {
       return updateTicket(id, mutations);
     };
 
+    const stories = Array.from({ length: ABOVE_FANOUT_BOUND }, (_, i) =>
+      ticket(`story-${i}`),
+    );
     const result = await runPlanPersist({
       provider,
-      artifacts: { stories: [ticket('solo')] },
+      artifacts: { stories },
       config: {},
       opts: { skipCleanup: true },
     });
 
-    assert.equal(labelsAtCreate.length, 1);
+    assert.equal(labelsAtCreate.length, ABOVE_FANOUT_BOUND);
+    for (const labels of labelsAtCreate) {
+      assert.ok(
+        labels.includes(TYPE_LABELS.STORY),
+        'the creating POST carries type::story',
+      );
+      assert.ok(
+        !labels.includes(AGENT_LABELS.READY),
+        'the creating POST must not carry agent::ready',
+      );
+      assert.deepEqual(
+        labels.filter((l) => l.startsWith('plan-run::')),
+        [result.planRunLabel],
+        'the creating POST carries the cohort grouping label (Story #4692)',
+      );
+    }
+    assert.equal(
+      order.filter((e) => e === 'checkpoint').length,
+      ABOVE_FANOUT_BOUND,
+    );
+    assert.equal(order.filter((e) => e === 'ready').length, ABOVE_FANOUT_BOUND);
     assert.ok(
-      labelsAtCreate[0].includes(TYPE_LABELS.STORY),
-      'the creating POST carries type::story',
+      order.lastIndexOf('checkpoint') < order.indexOf('ready'),
+      `every checkpoint must land before the first ready flip (${order.join(',')})`,
     );
-    assert.ok(
-      !labelsAtCreate[0].includes(AGENT_LABELS.READY),
-      'the creating POST must not carry agent::ready',
-    );
-    assert.deepEqual(
-      labelsAtCreate[0].filter((l) => l.startsWith('plan-run::')),
-      [result.planRunLabel],
-      'the creating POST carries the cohort grouping label (Story #4692)',
-    );
-    assert.equal(order.at(-1), 'ready', 'the ready flip must be terminal');
-    assert.ok(order.includes('checkpoint'));
     // And the end state is still a ready Story.
     assert.ok(
       provider.issues
@@ -1524,20 +1552,33 @@ describe('markStoriesReady — bounded concurrency (Story #4952)', () => {
     // COMPLETE set of ids that still need the label by hand, so every Story is
     // attempted even after an earlier PATCH rejects. concurrentMap's
     // first-rejection-wins policy would abandon the rest.
+    //
+    // Story #4961 — sized ABOVE the bound on purpose. At n <= concurrency every
+    // unit is dispatched before the first rejection can be observed, so an
+    // implementation that DID abandon the remainder would still attempt all of
+    // them and this assertion could never fail. The failures are seeded in the
+    // first dispatched window so the abandoned tail is the one being counted.
     const provider = fakeProvider();
-    const created = [
-      { id: 7100, slug: 'alpha' },
-      { id: 7101, slug: 'beta' },
-      { id: 7102, slug: 'gamma' },
-      { id: 7103, slug: 'delta' },
-    ];
+    const size = ABOVE_FANOUT_BOUND + 4;
+    const created = Array.from({ length: size }, (_, i) => ({
+      id: 7100 + i,
+      slug: `story-${i}`,
+    }));
+    assert.ok(
+      created.length > FANOUT_CONCURRENCY,
+      'the guard is only meaningful above the fan-out bound',
+    );
     for (const story of created) {
       provider.issues.set(story.id, { id: story.id, labels: [] });
     }
+    const failing = new Set([7100, 7102]);
     const attempted = [];
     provider.updateTicket = async (id) => {
       attempted.push(id);
-      if (id === 7100 || id === 7102) {
+      // Yield so the first rejections land while later units are still
+      // undispatched — the exact window an abandoning implementation loses.
+      await new Promise((resolve) => setTimeout(resolve, 1));
+      if (failing.has(id)) {
         throw new Error(`boom ${id}`);
       }
       provider.issues.get(id).labels.push(AGENT_LABELS.READY);
@@ -1546,20 +1587,26 @@ describe('markStoriesReady — bounded concurrency (Story #4952)', () => {
     await assert.rejects(
       () => markStoriesReady({ provider, created }),
       (err) => {
-        assert.match(err.message, /#7100 \(alpha\): boom 7100/);
-        assert.match(err.message, /#7102 \(gamma\): boom 7102/);
+        assert.match(err.message, /#7100 \(story-0\): boom 7100/);
+        assert.match(err.message, /#7102 \(story-2\): boom 7102/);
         assert.match(err.message, /2 Story\(ies\) were created/);
         return true;
       },
     );
     assert.deepEqual(
-      attempted.sort(),
-      [7100, 7101, 7102, 7103],
+      attempted.sort((a, b) => a - b),
+      created.map((s) => s.id),
       'the first failure must not abandon the remaining flips',
     );
-    // The Stories that could be flipped still were.
-    assert.ok(provider.issues.get(7101).labels.includes(AGENT_LABELS.READY));
-    assert.ok(provider.issues.get(7103).labels.includes(AGENT_LABELS.READY));
+    // Every Story that could be flipped still was — including the tail an
+    // abandoning fan-out would never have reached.
+    for (const story of created) {
+      if (failing.has(story.id)) continue;
+      assert.ok(
+        provider.issues.get(story.id).labels.includes(AGENT_LABELS.READY),
+        `#${story.id} must still have been flipped`,
+      );
+    }
   });
 });
 
@@ -1603,7 +1650,9 @@ describe('createStoryIssues — deliberately serial (Story #4952 AC-3)', () => {
 describe('persist write loops — concurrent, ordering preserved (Story #4952)', () => {
   it('fans the checkpoints out but lands every one before the first ready flip', async () => {
     // Story #4541's invariant survives the fan-out: agent::ready still means
-    // "fully persisted", so no phase may overlap the next.
+    // "fully persisted", so no phase may overlap the next. Sized above the
+    // bound (Story #4961) so the checkpoint phase cannot be dispatched in a
+    // single window — a leaked ready flip has somewhere to interleave.
     const provider = fakeProvider();
     const order = [];
     let checkpointsInFlight = 0;
@@ -1632,21 +1681,30 @@ describe('persist write loops — concurrent, ordering preserved (Story #4952)',
     const result = await runPlanPersist({
       provider,
       artifacts: {
-        stories: [ticket('one'), ticket('two'), ticket('three')],
+        stories: Array.from({ length: ABOVE_FANOUT_BOUND }, (_, i) =>
+          ticket(`story-${i}`),
+        ),
       },
       config: {},
       opts: { skipCleanup: true },
     });
 
-    assert.equal(result.stories.length, 3);
+    assert.equal(result.stories.length, ABOVE_FANOUT_BOUND);
     assert.ok(
       checkpointPeak > 1,
       `expected the checkpoint writes to overlap, peak=${checkpointPeak}`,
     );
+    assert.ok(
+      checkpointPeak <= FANOUT_CONCURRENCY,
+      `expected a bounded fan-out, peak=${checkpointPeak}`,
+    );
     const lastCheckpoint = order.lastIndexOf('checkpoint');
     const firstReady = order.indexOf('ready');
-    assert.equal(order.filter((e) => e === 'checkpoint').length, 3);
-    assert.equal(order.filter((e) => e === 'ready').length, 3);
+    assert.equal(
+      order.filter((e) => e === 'checkpoint').length,
+      ABOVE_FANOUT_BOUND,
+    );
+    assert.equal(order.filter((e) => e === 'ready').length, ABOVE_FANOUT_BOUND);
     assert.ok(
       lastCheckpoint < firstReady,
       `every checkpoint must land before the first ready flip (${order.join(',')})`,
@@ -1725,13 +1783,23 @@ describe('supersede close — bounded concurrency (Story #4952)', () => {
   });
 
   it('keeps per-unit failures per-unit — one bad ticket never abandons the rest', async () => {
-    const sourceIds = [950, 951, 952];
+    // Story #4961 — sized above the fan-out bound. At n <= concurrency every
+    // unit is already dispatched when the first one refuses, so a unit that
+    // let its rejection escape would still leave the rest closed and this
+    // assertion could not fail. The refusal is seeded in the first dispatched
+    // window so the tail is genuinely at risk.
+    const sourceIds = Array.from(
+      { length: ABOVE_FANOUT_BOUND + 2 },
+      (_, i) => 950 + i,
+    );
+    const refusedId = 951;
     const provider = fakeProvider({
       sources: sourceIds.map((id) => ({ id })),
     });
     const { updateTicket } = provider;
     provider.updateTicket = async (id, mutations) => {
-      if (id === 951 && mutations.state === 'closed') {
+      if (id === refusedId && mutations.state === 'closed') {
+        await new Promise((resolve) => setTimeout(resolve, 1));
         throw new Error('close refused');
       }
       return updateTicket(id, mutations);
@@ -1747,11 +1815,17 @@ describe('supersede close — bounded concurrency (Story #4952)', () => {
       opts: { skipCleanup: true, sourceTicketIds: sourceIds },
     });
 
-    assert.deepEqual(result.supersede.closed, [950, 952]);
+    const expectedClosed = sourceIds.filter((id) => id !== refusedId);
+    assert.deepEqual(
+      result.supersede.closed,
+      expectedClosed,
+      'one refused unit must not abandon the tail',
+    );
     assert.deepEqual(result.supersede.failed, [
-      { ticket: 951, reason: 'close refused' },
+      { ticket: refusedId, reason: 'close refused' },
     ]);
-    assert.equal(provider.issues.get(950).state, 'closed');
-    assert.equal(provider.issues.get(952).state, 'closed');
+    for (const id of expectedClosed) {
+      assert.equal(provider.issues.get(id).state, 'closed', `#${id} closed`);
+    }
   });
 });


### PR DESCRIPTION
Closes #4961

_Auto-opened by `/deliver`._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches GitHub write paths and concurrent plan-persist ordering invariants; changes are bounded retries and shared concurrency with expanded tests rather than new behavior.
> 
> **Overview**
> **Centralizes bounded concurrency** for `/plan` and plan-persist GitHub fan-outs behind exported `FANOUT_CONCURRENCY` (4) in `concurrent-map.js`, replacing six duplicate module-local constants (envelope gathers, ticket hydration, checkpoints, `agent::ready` flips, supersede closes, authoring context).
> 
> **Adds `withTransientRetry`** on `TicketGateway` additive label POSTs and issue PATCHes—the write paths hit by those fan-outs—so secondary rate limits get the same backoff as reads; permanent failures still throw and `markStoriesReady` still aggregates all failures.
> 
> **Tests** use cohort sizes above the fan-out bound so checkpoint-before-ready ordering and “collect every failure” behavior are actually observable; new unit tests cover retry vs non-retry on writes.
> 
> **Minor:** `resolveFlag` in single-story-close options drops an unused third `defaultValue` parameter.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 173bf993d5885bc76dfaf2a1dcb3c7bdb7a166e0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->