### PR TITLE
fix: make the close crash path emit its envelope and the acceptance merge guard reach the live path (#4959)

### DIFF
--- a/.agents/scripts/acceptance-eval.js
+++ b/.agents/scripts/acceptance-eval.js
@@ -188,7 +188,12 @@ const MERGE_CONTRACT =
  */
 export function resolveExpectedCriteria(raw) {
   if (raw === null || raw === undefined) return null;
-  const expected = Number.parseInt(String(raw), 10);
+  // Digits only. `Number.parseInt` stops at the first non-digit, so `4abc`
+  // resolved to 4 — a guard whose entire job is to reject a wrong-sized
+  // verdict was itself accepting a malformed count, and a typo'd `--expected-
+  // criteria` would then wave through a verdict of the wrong length.
+  const text = String(raw).trim();
+  const expected = /^\d+$/.test(text) ? Number(text) : Number.NaN;
   if (!Number.isInteger(expected) || expected < 1) {
     throw new Error(
       `acceptance-eval: --expected-criteria must be a positive integer (the Story's acceptance[] count). ${MERGE_CONTRACT}`,

--- a/.agents/scripts/lib/cli-args.js
+++ b/.agents/scripts/lib/cli-args.js
@@ -92,12 +92,41 @@ export function parseMergeWatchMode(value) {
 }
 
 /**
+ * {@link parseMergeWatchMode} degraded to the "absent" value instead of
+ * throwing — how the tolerant parse below treats a flag that failed
+ * validation. Reporting `undefined` is safe there and only there, because a
+ * tolerant parse never drives a pipeline: its caller surfaces the rejection
+ * as the run's failure and runs no phase at all.
+ *
+ * @param {unknown} value
+ * @returns {'sync'|'async'|undefined}
+ */
+function tolerantMergeWatchMode(value) {
+  try {
+    return parseMergeWatchMode(value);
+  } catch {
+    return undefined;
+  }
+}
+
+/**
  * Standardized CLI argument parser for sprint scripts.
  * Supports options like --epic, --story, --dry-run, --skip-dashboard.
+ *
+ * Throws when a *validating* parser rejects a flag value (currently only
+ * `--merge-watch-mode`). Callers that must not throw — an error handler
+ * needing `storyId` to report an envelope — use {@link parseSprintArgsTolerant}
+ * rather than calling this a second time inside their own catch.
+ *
  * @param {string[]} args Array of arguments (defaults to process.argv)
+ * @param {{ tolerant?: boolean }} [options] `tolerant` degrades a rejected
+ *   flag to its absent value instead of throwing. For reporting only.
  * @returns {object} Parsed and typed argument values
  */
-export function parseSprintArgs(args = process.argv) {
+export function parseSprintArgs(
+  args = process.argv,
+  { tolerant = false } = {},
+) {
   const { values, positionals } = parseArgs({
     args: args.slice(2),
     options: {
@@ -151,7 +180,9 @@ export function parseSprintArgs(args = process.argv) {
     // Story #4949 — per-invocation override of `delivery.mergeWatch.mode`.
     // `undefined` when the flag is absent, which is what lets the merge wait
     // fall back to the config; anything unrecognized throws here.
-    mergeWatchMode: parseMergeWatchMode(values['merge-watch-mode']),
+    mergeWatchMode: tolerant
+      ? tolerantMergeWatchMode(values['merge-watch-mode'])
+      : parseMergeWatchMode(values['merge-watch-mode']),
     executor: values.executor ?? null,
     // Resolve worktree cwd from flag or env. Empty string/whitespace → null.
     cwd:
@@ -172,6 +203,52 @@ export function parseSprintArgs(args = process.argv) {
     parseTicketId(positionals[0]) ?? parsed.storyId ?? parsed.epicId ?? null;
 
   return parsed;
+}
+
+/**
+ * Last-resort tolerant parse: the fields, or an empty bag if even the
+ * tolerant pass cannot produce one.
+ *
+ * @param {string[]} args
+ * @returns {object}
+ */
+function parseSprintArgsOrEmpty(args) {
+  try {
+    return parseSprintArgs(args, { tolerant: true });
+  } catch {
+    return {};
+  }
+}
+
+/**
+ * Parse argv **without ever throwing**, returning the fields alongside the
+ * rejection rather than in place of it.
+ *
+ * `parseSprintArgs` gained its first *validating* parser in
+ * {@link parseMergeWatchMode} (Story #4949), which made a latent shape in the
+ * CLI entries fatal: their catch blocks called
+ * `failedTerminalFor(err, parseSprintArgs())` — re-invoking the very parser
+ * that had just thrown. The second throw escaped the catch, so an
+ * unparseable argv produced a bare stack trace with **no terminal envelope
+ * and no friction signal**, on the two surfaces whose whole contract is that
+ * they always emit one. An error handler must not depend on an operation
+ * already known to fail.
+ *
+ * So the entries parse **once**, up front, through this wrapper: `args`
+ * carries the `storyId` and skip flags the envelope is built from, and
+ * `error` is the failure to report. The tolerant re-parse degrades **only**
+ * the flag that failed validation; every other field parses normally. Use
+ * the result to *report*, never to run a pipeline.
+ *
+ * @param {string[]} [args] Array of arguments (defaults to `process.argv`)
+ * @returns {{ args: object, error: Error|null }}
+ */
+export function parseSprintArgsTolerant(args = process.argv) {
+  try {
+    return { args: parseSprintArgs(args), error: null };
+  } catch (error) {
+    return { args: parseSprintArgsOrEmpty(args), error };
+  }
 }
 
 const SUPPORTED_FLAG_TYPES = new Set([

--- a/.agents/scripts/single-story-close.js
+++ b/.agents/scripts/single-story-close.js
@@ -95,7 +95,7 @@
  * @see .agents/schemas/story-deliver-terminal.schema.json
  */
 
-import { parseSprintArgs } from './lib/cli-args.js';
+import { parseSprintArgsTolerant } from './lib/cli-args.js';
 import { runAsCli } from './lib/cli-utils.js';
 import { formatCliError } from './lib/error-redactor.js';
 import { Logger } from './lib/Logger.js';
@@ -161,13 +161,25 @@ export async function runSingleStoryClose(opts) {
  * status rather than from a thrown/not-thrown distinction, so `pending`
  * (resumable) is distinguishable from `blocked` (come look) without parsing
  * stdout.
+ *
+ * The catch parses argv through the **non-throwing** wrapper (Story #4959).
+ * It used to call `parseSprintArgs()` — re-invoking the very parser that had
+ * just thrown, since `parseMergeWatchMode` made argv parsing fallible. The
+ * second throw escaped the handler, so an unparseable argv produced a bare
+ * stack trace with no envelope and no friction signal, on the surface whose
+ * whole contract is that every invocation emits exactly one envelope. An
+ * error handler may not depend on an operation already known to fail.
+ *
+ * A parse rejection carries no `closePhase`, so the envelope reports `init` —
+ * accurate: the runner rejected the flag before any phase ran, and nothing
+ * was mutated.
  */
 async function main() {
   try {
     const outcome = await runSingleStoryClose();
     return exitCodeForTerminal(outcome?.terminal ?? { status: 'failed' });
   } catch (err) {
-    const terminal = failedTerminalFor(err, parseSprintArgs());
+    const terminal = failedTerminalFor(err, parseSprintArgsTolerant().args);
     if (!terminal) throw err;
     // Mirror runAsCli's default error line (which this catch pre-empts) so the
     // human-facing failure text is unchanged, then emit the envelope.

--- a/.agents/scripts/single-story-confirm-merge.js
+++ b/.agents/scripts/single-story-confirm-merge.js
@@ -37,7 +37,7 @@
  */
 
 import { parseArgs } from 'node:util';
-import { parseSprintArgs } from './lib/cli-args.js';
+import { parseSprintArgsTolerant } from './lib/cli-args.js';
 import { runAsCli } from './lib/cli-utils.js';
 import { resolveConfig } from './lib/config-resolver.js';
 import { formatCliError } from './lib/error-redactor.js';
@@ -512,14 +512,21 @@ async function main() {
     const outcome = await runConfirmMerge();
     return exitCodeForTerminal(outcome?.terminal ?? { status: 'failed' });
   } catch (err) {
-    const storyId = Number(parseSprintArgs().storyId);
+    // Non-throwing by construction (Story #4959): this used to call
+    // `parseSprintArgs()`, so a rejected `--merge-watch-mode` threw a second
+    // time here and escaped the handler — no envelope, no friction. Close
+    // carries the identical shape; both landing surfaces behave the same.
+    const { args, error: argvError } = parseSprintArgsTolerant();
+    const storyId = Number(args.storyId);
     // No story id → a usage error; there is nothing to report an envelope
     // about, so let runAsCli surface it as a plain fatal.
     if (!Number.isInteger(storyId) || storyId <= 0) throw err;
     const terminal = buildTerminalEnvelope({
       storyId,
       status: 'failed',
-      phase: 'confirm-merge',
+      // An argv rejection happens before any phase runs, so it reports at
+      // `init` rather than claiming a confirm-merge attempt that never began.
+      phase: argvError ? 'init' : 'confirm-merge',
       failure: { reason: String(err?.message ?? err) },
       nextCommand: NEXT_COMMANDS.recover(storyId),
       elapsedSeconds: 0,

--- a/.agents/workflows/helpers/deliver-digest.md
+++ b/.agents/workflows/helpers/deliver-digest.md
@@ -10,10 +10,9 @@ description: >-
 # Deliver digest (read once per session)
 
 > **Bundle, not a procedure.** [`deliver-story.md`](deliver-story.md) is still
-> the steps. This file is the material those steps referenced across five
-> separate files and a JSON schema — bundled so one read covers the whole happy
-> path. Situational material (lease preflight, recovery routers, merge-wait
-> budgets, CI remediation) stays on demand in
+> the steps; this file is the material they reference, bundled so one read
+> covers the happy path. Situational material (lease preflight, recovery
+> routers, merge-wait budgets, CI remediation) stays on demand in
 > [`deliver-story-reference.md`](deliver-story-reference.md) and
 > [`deliver-reference.md`](deliver-reference.md); read those **only** when an
 > envelope or a failure routes you there.
@@ -28,10 +27,10 @@ rule produces it:
    whatever its shape — sub-agent isolation is load-bearing only against a
    *concurrent* sibling racing the same checkout, and a one-Story run has none.
 2. **Every other run is `subagent`.** A multi-Story run dispatches every Story
-   as a sub-agent however trivial its shape: a lite body does not conjure a
-   second session for a sibling to run in, and the wave tick may hand you the
-   whole set on one beat. Shape still sets ceremony and is reported alongside;
-   the `route::lite` label is a human-visible hint, never the control signal.
+   as a sub-agent however trivial its shape — a lite body does not conjure a
+   second session for a sibling, and the wave tick may hand you the whole set
+   on one beat. Shape still sets ceremony; the `route::lite` label is a
+   human-visible hint, never the control signal.
 
 `inline` removes model-side fan-out only — no `story-worker` boot, no fresh
 acceptance-critic spawn. **`subagent` and `inline` run the same engine**: same
@@ -56,7 +55,7 @@ the only sanctioned landing. A silent local build is not a delivery.
 One enumeration per Story. A critic that re-runs its own `git diff`
 can score a different set than the one that routed it. Both routing calls take
 a single options object and are **total — they never throw**, so a wrong-shaped
-argument is absorbed into the `null` fail-safe and reports nothing:
+argument is silently absorbed into the `null` fail-safe:
 
 ```bash
 node --input-type=module -e '
@@ -89,15 +88,25 @@ fresh. An `inline` dispatch mode overrides all of it to inline critics. Close's
 ## 4. Acceptance self-eval (Step 1a, required)
 
 **One verdict-owner per cluster** — the fresh critic *or* the inline
-self-eval, named by `verdictOwner`, never both and never a warm-up pass. It
-scores each `acceptance[]` item against the change set above, with `verify[]`
-output as evidence. Bounded by `delivery.acceptanceEval.maxRounds` (default 2).
-Then score the authored verdict:
+self-eval, named by `verdictOwner`, never both and never a warm-up pass. Each
+scores its cluster's `acceptance[]` items against the change set above, with
+`verify[]` output as evidence. Bounded by `delivery.acceptanceEval.maxRounds`
+(default 2).
+
+**One round = N cluster critics → ONE merged verdict → ONE gate call.** Merge
+every cluster's records into a single `criteria[]` in `acceptance[]` order, one
+per acceptance item, and score that once. A gate call per cluster spends a
+round *per cluster* and races the round ledger:
 
 ```bash
 node <main-repo>/.agents/scripts/acceptance-eval.js \
-  --story <storyId> --verdict <verdict-path>
+  --story <storyId> --verdict <merged-verdict-path> \
+  --expected-criteria <acceptance[] count>
 ```
+
+Pass `--expected-criteria` — **without it the coverage assertion is inert**, so
+an unmerged cluster verdict scores a fraction of the criteria and still reports
+`proceed`. A mismatch is rejected before scoring and costs no round.
 
 `proceed` → close. `redraft` → one more round inside the cap. `block` → **do
 not close**: post a `friction` comment and flip `agent::blocked`.

--- a/.agents/workflows/helpers/deliver-story-reference.md
+++ b/.agents/workflows/helpers/deliver-story-reference.md
@@ -203,6 +203,29 @@ round cap, proceed / redraft / block — not an independent additional pass
 over the criteria. The M4-B floor holds: one verdict per cluster, the
 cluster count owned by `acceptance-clusters.js` alone.
 
+**One round = N cluster critics → ONE merged verdict → ONE gate call.** The
+clusters are how a round is _authored_; they are not how it is _scored_.
+Concatenate every cluster's records into a single `criteria[]` ordered by
+`index` — exactly one per `acceptance[]` item, under one `storyId`,
+`schemaVersion`, `round` and `commitSha` — and hand that merged file to the
+gate once, with `--expected-criteria` set to the Story's `acceptance[]` count:
+
+```bash
+node <main-repo>/.agents/scripts/acceptance-eval.js \
+  --story <storyId> --verdict <merged-verdict-path> \
+  --expected-criteria <acceptance[] count>
+```
+
+The flag is what makes the merge enforceable: `assertCriteriaCoverage` returns
+early on the `null` default, so **omitting it leaves the guard inert** and a
+single cluster's verdict handed over unmerged scores a fraction of the criteria
+and still reports `proceed`. A length mismatch is rejected before scoring and
+consumes no round. Calling the gate once per cluster instead spends a round
+_per cluster_ — a Story past the cluster ceiling would burn its whole redraft
+budget on cluster arithmetic — and N concurrent calls race the Story-scoped
+round ledger. Full per-round mechanics, including the parallel dispatch and the
+merge shape: [`acceptance-self-eval.md`](acceptance-self-eval.md).
+
 **Critic evidence-share.** When the critic runs a `verify[]`
 command that is byte-identical to a close gate (`lint` / `typecheck`), it
 records the pass into the Story evidence keyspace via `--standalone` so
@@ -318,12 +341,23 @@ The wait probes the checks every poll: a red required check fails fast as
 base is brought up to date within `updateAttempts` tries.
 
 **Async merge-confirm mode (`delivery.mergeWatch.mode: "async"`).** Under
-the default `"sync"` the merge wait runs in the foreground as
-described above. When a consumer's CI routinely takes longer than the host
-tool ceiling (~10 min) can hold a single close invocation, the foreground
-wait almost always expires `pending` after burning ~5 minutes of the slot —
-so `"async"` makes that async confirm a designed mode instead of an expiry
-accident. In async mode the close arms auto-merge, runs one short **~60s
+the default `"sync"` the merge wait runs in the foreground as described above.
+
+**On a multi-Story run, async is the posture — pass `--merge-watch-mode async`
+on every close.** This is not a slow-CI opt-in. Implementation fans out, but
+the close tail is serialized one Story at a time, and under `sync` each close
+holds the foreground for its full merge wait before the next may start; that
+is the run's dominant serialized cost, paid once per sibling. Close sees one
+Story and cannot see run topology, so the orchestrator — which can — makes the
+call per invocation while the config default stays `"sync"`, which is right for
+a solo delivery with no sibling waiting behind it
+([`deliver-reference.md`](deliver-reference.md) § Async merge-confirm mode).
+A slow-CI consumer reaches for the same mode for the separate reason that a
+foreground wait longer than the host tool ceiling (~10 min) almost always
+expires `pending` after burning ~5 minutes of the slot — `"async"` makes that
+confirm a designed ending instead of an expiry accident.
+
+In async mode the close arms auto-merge, runs one short **~60s
 probe window** (long enough to catch an instant merge and, via the
 head-anchored required-check predicate, an instantly-red required check),
 then returns the standard `pending` terminal with a `nextCommand`. When you
@@ -362,6 +396,13 @@ judgment that help text cannot carry.
 - `--max-wait-seconds <n>` — from a headless caller with no host
   tool-invocation ceiling, to keep single-block semantics
   without editing the consumer's config.
+- `--merge-watch-mode <sync|async>` — the per-invocation override of
+  `delivery.mergeWatch.mode`. **Pass `async` on every close of a multi-Story
+  run** (above); leave it off for a solo delivery. It composes with
+  `--max-wait-seconds` — pass both and the explicit bound still wins over the
+  async probe cap. An unrecognized value is refused before any phase runs, so a
+  typo cannot silently drop the run back onto synchronous waiting; the refusal
+  reports a `failed` terminal envelope at `phase: init`, mutating nothing.
 
 ---
 

--- a/tests/acceptance-eval.test.js
+++ b/tests/acceptance-eval.test.js
@@ -270,6 +270,22 @@ describe('--expected-criteria — the merge contract (Story #4951)', () => {
     }
   });
 
+  it('AC-5: refuses a digit-prefixed value instead of truncating it (Story #4959)', () => {
+    // `Number.parseInt` stops at the first non-digit, so each of these used to
+    // resolve to a plausible-looking count. The guard exists to reject a
+    // wrong-sized verdict — accepting a malformed count is the one failure it
+    // cannot afford, because the resulting number is silently believed.
+    for (const raw of ['4abc', '4.9', '4 5', '0x10', '1e3', ' 4a ']) {
+      assert.throws(
+        () => resolveExpectedCriteria(raw),
+        /--expected-criteria must be a positive integer/,
+        `--expected-criteria ${raw} should be refused, not coerced`,
+      );
+    }
+    // Surrounding whitespace on an otherwise clean integer stays acceptable.
+    assert.equal(resolveExpectedCriteria(' 12 '), 12);
+  });
+
   it('passes a verdict covering exactly the expected criteria', () => {
     assert.doesNotThrow(() => assertCriteriaCoverage(clusterVerdict(4), 4));
   });

--- a/tests/single-story-close-confirm-merge.test.js
+++ b/tests/single-story-close-confirm-merge.test.js
@@ -23,8 +23,18 @@
  */
 
 import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, readdirSync, readFileSync } from 'node:fs';
 import { readFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
 import { describe, it } from 'node:test';
+import { fileURLToPath } from 'node:url';
+import {
+  parseSprintArgs,
+  parseSprintArgsTolerant,
+} from '../.agents/scripts/lib/cli-args.js';
+import { TEST_TEMP_ROOT_ENV } from '../.agents/scripts/lib/config/temp-paths.js';
 import {
   enableAutoMergeWith,
   runAutoMergePhase,
@@ -43,7 +53,12 @@ import {
   parseCloseOptions,
   resolveWaitForMerge,
 } from '../.agents/scripts/lib/orchestration/single-story-close/phases/options.js';
-import { terminalFromWaitOutcome } from '../.agents/scripts/lib/orchestration/story-deliver-terminal.js';
+import {
+  TERMINAL_BEGIN_MARKER,
+  TERMINAL_END_MARKER,
+  terminalFromWaitOutcome,
+  validateTerminalEnvelope,
+} from '../.agents/scripts/lib/orchestration/story-deliver-terminal.js';
 import { confirmStoryMerged } from '../.agents/scripts/lib/single-story/confirm-merge.js';
 
 /**
@@ -1588,4 +1603,158 @@ describe('Story #4873 — shared poll primitive and progress heartbeat', () => {
     assert.match(heartbeat, /state=unknown/);
     assert.match(heartbeat, /probe error: PR probe failed: gh exploded/);
   });
+});
+
+/**
+ * Story #4959 — the argv path itself.
+ *
+ * Every `--merge-watch-mode` assertion above drives `parseCloseOptions`, the
+ * injection seam. That seam was green throughout the window in which the real
+ * CLI could not survive the flag at all: `parseSprintArgs` threw, and the
+ * catch in each entry's `main()` called `parseSprintArgs()` *again* to build
+ * its envelope, so the second throw escaped the handler. An unparseable argv
+ * produced a bare stack trace with no terminal envelope and no friction
+ * signal — on the two surfaces whose entire contract is that they emit one.
+ *
+ * These cases drive real argv, and the spawn cases drive the real process.
+ */
+describe('argv path — --merge-watch-mode (Story #4959)', () => {
+  /** Real argv shape: node:util slices the first two entries off. */
+  const argv = (...flags) => ['node', 'single-story-close.js', ...flags];
+
+  const scriptPath = (basename) =>
+    fileURLToPath(new URL(`../.agents/scripts/${basename}`, import.meta.url));
+
+  /** Pull the one envelope out from between the terminal markers. */
+  function readTerminalEnvelope(stdout) {
+    const begin = stdout.indexOf(TERMINAL_BEGIN_MARKER);
+    const end = stdout.indexOf(TERMINAL_END_MARKER);
+    assert.ok(
+      begin >= 0 && end > begin,
+      `stdout carried no terminal envelope:\n${stdout}`,
+    );
+    return JSON.parse(
+      stdout.slice(begin + TERMINAL_BEGIN_MARKER.length, end).trim(),
+    );
+  }
+
+  it('honours a valid --merge-watch-mode read off real argv', () => {
+    for (const [flags, expected] of [
+      [['--merge-watch-mode', 'async'], 'async'],
+      [['--merge-watch-mode=sync'], 'sync'],
+      [['--merge-watch-mode', '  ASYNC  '], 'async'],
+      [[], undefined],
+    ]) {
+      assert.equal(
+        parseSprintArgs(argv('--story', '7', ...flags)).mergeWatchMode,
+        expected,
+      );
+    }
+  });
+
+  it('an UNREGISTERED flag spelling parses to nothing — the silent class strict:false permits', () => {
+    // `strict: false` means `node:util`'s parseArgs neither rejects nor
+    // reports an unknown flag: a near-miss spelling is dropped on the floor
+    // and the run silently keeps the config default, with the wall clock as
+    // the only evidence. Pinned here so the hazard is asserted rather than
+    // assumed — and so the spawn cases below are read for what they also are:
+    // the canary that the REGISTERED spelling is still wired. Rename or drop
+    // `merge-watch-mode` from the parser spec and `bogus` parses to nothing,
+    // no error is raised, and those cases fail on a missing envelope.
+    const parsed = parseSprintArgs(
+      argv('--story', '7', '--merge-watch-modes', 'bogus'),
+    );
+    assert.equal(parsed.mergeWatchMode, undefined);
+    assert.equal(parsed.storyId, 7, 'the rest of argv still parses');
+  });
+
+  it('parseSprintArgsTolerant returns the rejection ALONGSIDE the fields, never instead of them', () => {
+    const { args, error } = parseSprintArgsTolerant(
+      argv('--story', '42', '--skip-validation', '--merge-watch-mode', 'bogus'),
+    );
+    assert.match(
+      error.message,
+      /--merge-watch-mode must be one of sync\|async/,
+    );
+    // The fields an error handler needs to report an envelope survive the
+    // rejection; only the flag that failed validation degrades to absent.
+    assert.equal(args.storyId, 42);
+    assert.equal(args.skipValidation, true);
+    assert.equal(args.mergeWatchMode, undefined);
+    // A clean argv reports no error and parses exactly as parseSprintArgs does.
+    const clean = parseSprintArgsTolerant(
+      argv('--story', '42', '--merge-watch-mode', 'async'),
+    );
+    assert.equal(clean.error, null);
+    assert.equal(clean.args.mergeWatchMode, 'async');
+  });
+
+  for (const basename of [
+    'single-story-close.js',
+    'single-story-confirm-merge.js',
+  ]) {
+    it(`AC-1: ${basename} emits a failed init envelope AND friction for an invalid --merge-watch-mode`, () => {
+      // A per-spawn scratch tempRoot: the child inherits the env, so its
+      // friction record lands here instead of the repo's real ledger, where a
+      // fixture story id has previously been mistaken for a live signal.
+      const scratch = mkdtempSync(path.join(tmpdir(), 'merge-watch-argv-'));
+      const storyId = 424242;
+      const run = spawnSync(
+        process.execPath,
+        [
+          scriptPath(basename),
+          '--story',
+          String(storyId),
+          '--merge-watch-mode',
+          'bogus',
+        ],
+        {
+          encoding: 'utf8',
+          env: { ...process.env, [TEST_TEMP_ROOT_ENV]: scratch },
+        },
+      );
+
+      assert.equal(run.status, 1, `expected exit 1, got ${run.status}`);
+      const envelope = readTerminalEnvelope(run.stdout);
+      const { valid, errors } = validateTerminalEnvelope(envelope);
+      assert.ok(
+        valid,
+        `envelope must be schema-valid: ${JSON.stringify(errors)}`,
+      );
+      assert.equal(envelope.status, 'failed');
+      // `init`, not a phase name: the flag is rejected before the pipeline
+      // starts, so nothing was mutated and the envelope must not imply it was.
+      assert.equal(envelope.phase, 'init');
+      assert.equal(envelope.storyId, storyId);
+      assert.match(
+        envelope.failure.reason,
+        /--merge-watch-mode must be one of/,
+      );
+
+      // Story #4578's contract: a close that dies before the runner can report
+      // its own terminal is exactly the friction the retro must see. Located
+      // by search rather than by a hand-built path — the scratch root is a
+      // base the configured `project.paths.tempRoot` nests under, so spelling
+      // the layout out here would couple the assertion to that config value.
+      const ledger = readdirSync(scratch, { recursive: true })
+        .map(String)
+        .find(
+          (entry) =>
+            entry.endsWith('signals.ndjson') &&
+            entry.includes(`story-${storyId}`),
+        );
+      assert.ok(ledger, `no signals ledger was written under ${scratch}`);
+      const signals = readFileSync(path.join(scratch, ledger), 'utf8');
+      const records = signals
+        .trim()
+        .split('\n')
+        .map((line) => JSON.parse(line));
+      assert.ok(
+        records.some(
+          (r) => r.kind === 'friction' && r.category === 'close-failed',
+        ),
+        `no close-failed friction record was emitted: ${signals}`,
+      );
+    });
+  }
 });

--- a/tests/single-story-close-confirm-merge.test.js
+++ b/tests/single-story-close-confirm-merge.test.js
@@ -24,9 +24,8 @@
 
 import assert from 'node:assert/strict';
 import { spawnSync } from 'node:child_process';
-import { mkdtempSync, readdirSync, readFileSync } from 'node:fs';
+import { readdirSync, readFileSync } from 'node:fs';
 import { readFile } from 'node:fs/promises';
-import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { describe, it } from 'node:test';
 import { fileURLToPath } from 'node:url';
@@ -60,6 +59,7 @@ import {
   validateTerminalEnvelope,
 } from '../.agents/scripts/lib/orchestration/story-deliver-terminal.js';
 import { confirmStoryMerged } from '../.agents/scripts/lib/single-story/confirm-merge.js';
+import { makeTempDir } from '../.agents/scripts/lib/test-temp.js';
 
 /**
  * Fake ticketing provider mirroring the minimal surface the sibling suites
@@ -1697,7 +1697,7 @@ describe('argv path — --merge-watch-mode (Story #4959)', () => {
       // A per-spawn scratch tempRoot: the child inherits the env, so its
       // friction record lands here instead of the repo's real ledger, where a
       // fixture story id has previously been mistaken for a live signal.
-      const scratch = mkdtempSync(path.join(tmpdir(), 'merge-watch-argv-'));
+      const scratch = makeTempDir('merge-watch-argv-');
       const storyId = 424242;
       const run = spawnSync(
         process.execPath,


### PR DESCRIPTION
Closes #4959

_Auto-opened by `/deliver`._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes delivery landing CLIs' fatal error paths and acceptance gate input validation; behavior is fail-closed with new integration tests, but mistakes here affect every close/confirm invocation and acceptance scoring.
> 
> **Overview**
> **Close and confirm-merge** now build failure terminals from `parseSprintArgsTolerant()` instead of calling `parseSprintArgs()` again in `catch`. Invalid `--merge-watch-mode` used to throw twice and skip the terminal envelope and friction signal; argv rejections report `phase: init` on confirm-merge when parsing failed before any phase ran.
> 
> **CLI parsing** adds `parseSprintArgsTolerant` and an optional tolerant mode that degrades only a rejected `--merge-watch-mode` to absent so error handlers can still read `storyId` and other flags.
> 
> **Acceptance eval** `resolveExpectedCriteria` rejects malformed counts (`4abc`, `4.9`, etc.) with strict digit-only parsing instead of `Number.parseInt`, which could accept wrong-sized verdict coverage.
> 
> **Workflow docs** (`deliver-digest`, `deliver-story-reference`) spell out one merged verdict per round with `--expected-criteria`, and that multi-Story runs should pass `--merge-watch-mode async` on every close.
> 
> Tests cover criteria coercion, tolerant parse behavior, and spawned CLI processes for invalid merge-watch mode.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 80a5e90d5c461d1d84e32cc8692b52ab7a058c43. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->