### PR TITLE
fix(observability): attribute terminal friction to the emitting CLI

### DIFF
--- a/.agents/scripts/lib/observability/runtime-friction.js
+++ b/.agents/scripts/lib/observability/runtime-friction.js
@@ -534,18 +534,33 @@ function frictionForTerminal(envelope) {
  * Emit the friction record (if any) implied by a terminal envelope.
  * Best-effort; never throws.
  *
+ * `tool` is the CALLER's name, threaded in rather than assumed: TWO CLIs emit
+ * terminal envelopes — `single-story-close.js` (plus its runner) and
+ * `single-story-confirm-merge.js` — and `retro-proposals.js` reads
+ * `emitter.tool` (via {@link normalizeGatheredSignal}) to name the surface a
+ * candidate came from, so hard-coding the close name here attributed every
+ * confirm-merge record to a CLI that never ran and misdirected the follow-up.
+ * Both callers already declare their name once via `runAsCli({ source })`;
+ * pass that same string. The default keeps the close paths — the original
+ * callers, which pass none — emitting exactly what they always did.
+ *
  * @param {object} args
  * @param {object} args.envelope
+ * @param {string} [args.tool] Emitting surface (default `single-story-close`).
  * @param {object} [args.config]
  * @returns {Promise<boolean>} true when a record was appended.
  */
-export async function emitTerminalFriction({ envelope, config } = {}) {
+export async function emitTerminalFriction({
+  envelope,
+  tool = 'single-story-close',
+  config,
+} = {}) {
   const verdict = frictionForTerminal(envelope);
   if (!verdict) return false;
   return emitRuntimeFriction({
     storyId: envelope?.storyId,
     category: verdict.category,
-    tool: 'single-story-close',
+    tool,
     details: verdict.details,
     config,
   });

--- a/.agents/scripts/single-story-confirm-merge.js
+++ b/.agents/scripts/single-story-confirm-merge.js
@@ -67,6 +67,15 @@ const progress = Logger.createProgress('single-story-confirm-merge', {
 });
 
 /**
+ * This CLI's own surface name — the `runAsCli` source, and the `emitter.tool`
+ * every friction record it emits carries. Single-homed so the two cannot
+ * drift: `emitTerminalFriction` defaults to the CLOSE CLI's name, so a record
+ * emitted from here without it is attributed to a CLI that never ran, and the
+ * retro roll-up sends the follow-up to the wrong surface.
+ */
+const CLI_SOURCE = 'single-story-confirm-merge';
+
+/**
  * Default `gh` facade for this CLI, bound to the merge wait's spawn-level
  * timeout (Story #4710). This CLI is the resume surface async mode hands the
  * merge wait to — a background invocation with no host tool ceiling — so an
@@ -204,7 +213,7 @@ async function logConfirmResult(result, terminal, config) {
     },
   });
   emitTerminalEnvelope(terminal, { config });
-  await emitTerminalFriction({ envelope: terminal, config });
+  await emitTerminalFriction({ envelope: terminal, tool: CLI_SOURCE, config });
   return { success: terminal.status !== 'failed', result, terminal };
 }
 
@@ -528,13 +537,13 @@ async function main() {
       `[single-story-confirm-merge] Fatal error: ${formatCliError(err)}`,
     );
     emitTerminalEnvelope(terminal);
-    await emitTerminalFriction({ envelope: terminal });
+    await emitTerminalFriction({ envelope: terminal, tool: CLI_SOURCE });
     return exitCodeForTerminal(terminal);
   }
 }
 
 runAsCli(import.meta.url, main, {
-  source: 'single-story-confirm-merge',
+  source: CLI_SOURCE,
   propagateExitCode: true,
   usage: {
     invocation:

--- a/tests/lib/observability/runtime-friction.test.js
+++ b/tests/lib/observability/runtime-friction.test.js
@@ -202,6 +202,37 @@ describe('terminal-envelope friction policy', () => {
     );
   });
 
+  it('attributes the record to the CALLER that names itself, not to a fixed CLI', async () => {
+    // `emitter.tool` is what the retro roll-up uses to NAME the surface a
+    // candidate came from (`normalizeGatheredSignal`), and two CLIs emit
+    // terminal envelopes. A hard-coded name sent every confirm-merge record
+    // to a CLI that never ran.
+    await emitTerminalFriction({
+      envelope: {
+        storyId: 15,
+        status: 'failed',
+        phase: 'confirm-merge',
+        failure: { reason: 'gh view flaked' },
+      },
+      tool: 'single-story-confirm-merge',
+      config,
+    });
+    const [row] = await readStorySignals(15);
+    assert.equal(row.emitter.tool, 'single-story-confirm-merge');
+  });
+
+  it('defaults to the close CLI when no caller name is threaded', async () => {
+    // The original callers (close + its runner) pass none and must keep
+    // emitting exactly what they always did.
+    const row = await emitAndRead({
+      storyId: 16,
+      status: 'failed',
+      phase: 'push',
+      failure: { reason: 'boom' },
+    });
+    assert.equal(row.emitter.tool, 'single-story-close');
+  });
+
   it('tolerates a malformed envelope rather than throwing', async () => {
     assert.equal(await emitTerminalFriction({ envelope: null, config }), false);
     assert.equal(

--- a/tests/single-story-confirm-merge-resume.test.js
+++ b/tests/single-story-confirm-merge-resume.test.js
@@ -16,9 +16,12 @@
  */
 
 import assert from 'node:assert/strict';
-import { describe, it } from 'node:test';
+import fs from 'node:fs/promises';
+import { afterEach, beforeEach, describe, it } from 'node:test';
 
+import { forEachLine } from '../.agents/scripts/lib/observability/signals-writer.js';
 import { NEXT_COMMANDS } from '../.agents/scripts/lib/orchestration/story-deliver-terminal.js';
+import { makeTempDir } from '../.agents/scripts/lib/test-temp.js';
 import { runConfirmMerge } from '../.agents/scripts/single-story-confirm-merge.js';
 
 function fakeConfig() {
@@ -181,5 +184,65 @@ describe('single-story-confirm-merge --wait', () => {
 
     assert.equal(entered, false, 'the default path must not wait');
     assert.equal(terminal.status, 'landed');
+  });
+});
+
+/**
+ * `emitTerminalFriction` used to hard-code `emitter.tool: 'single-story-close'`,
+ * so every record this CLI emitted named a CLI that never ran. The roll-up
+ * (`retro-proposals.js`) reads that field to name the surface a candidate came
+ * from, so the misattribution misdirected the follow-up.
+ *
+ * Asserted through the real CLI entry point rather than the emitter's own
+ * signature: what regressed is the CALLER forgetting to name itself, which a
+ * unit test on the emitter cannot see.
+ */
+describe('confirm-merge friction attribution', () => {
+  /** Absolute per-test tempRoot — never the shared main-checkout temp. */
+  let tempRoot;
+  let config;
+
+  beforeEach(async () => {
+    tempRoot = await makeTempDir('confirm-merge-friction-');
+    config = {
+      ...fakeConfig(),
+      project: { baseBranch: 'main', paths: { tempRoot } },
+    };
+  });
+
+  afterEach(async () => {
+    await fs.rm(tempRoot, { recursive: true, force: true });
+  });
+
+  it('records its OWN tool name, not the close CLI that never ran', async () => {
+    // A resumed wait that spends the whole cumulative budget with the PR
+    // still in flight — the one terminal this CLI emits friction for.
+    await runConfirmMerge({
+      storyId: 555,
+      cwd: '/repo',
+      pr: 77,
+      wait: true,
+      injectedProvider: makeProvider(OPEN_STORY),
+      injectedConfig: config,
+      injectedGh: makeGh(),
+      injectedNotify: async () => {},
+      runConfirmMergePhaseFn: async () => ({
+        confirmed: false,
+        terminal: 'pending',
+        waitBudget: {
+          maxWaitSeconds: 300,
+          waitedSeconds: 300,
+          cumulativeSeconds: 3600,
+          maxBudgetSeconds: 3600,
+        },
+        prProbe: { state: 'OPEN', checksStatus: 'still-running' },
+      }),
+    });
+
+    const rows = [];
+    await forEachLine(null, 555, (parsed) => rows.push(parsed), config);
+    assert.equal(rows.length, 1, 'the exhausted budget must be recorded');
+    assert.equal(rows[0].category, 'merge-wait-exhausted');
+    assert.equal(rows[0].emitter.tool, 'single-story-confirm-merge');
   });
 });


### PR DESCRIPTION
## Why

`emitTerminalFriction` hardcoded `emitter.tool: 'single-story-close'`, but `single-story-confirm-merge.js` calls it too — from `logConfirmResult` and from its `main()` catch. Every friction record that CLI emitted named a CLI that never ran:

```
node .agents/scripts/single-story-confirm-merge.js --story 1 --merge-watch-mode bogus
→ "emitter":{"tool":"single-story-close"}
```

`retro-proposals.js` aggregates friction and reads `emitter.tool` (via `normalizeGatheredSignal`) to name the surface a candidate came from, so the misattribution misdirects any follow-up.

## What changed

- `emitTerminalFriction({ envelope, tool, config })` takes the caller's surface name, defaulting to `single-story-close` — the close CLI and its runner pass none and are unchanged.
- `single-story-confirm-merge.js` gained a `CLI_SOURCE` constant, now the single home for its name: it feeds `runAsCli({ source })` and both emit call sites, so the declared source and the emitted `emitter.tool` cannot drift.

## Tests

- Unit: a threaded name lands in `emitter.tool`; an absent one defaults to the close CLI.
- End-to-end through `runConfirmMerge` — a `--wait` resume whose cumulative budget is exhausted (the one terminal this CLI emits friction for), read back off an absolute per-test tempRoot with the roll-up's own reader. Asserted through the CLI rather than the emitter's signature, because what regressed is the caller forgetting to name itself.

Both new tests fail against the pre-fix source (41/43) and pass after.

## Verification

`npm run lint`, `check-baselines.js`, and the full suite (10071 tests) all green locally; `quality:preview` reports 0 MI regressions / 0 CRAP violations.

Follow-up to #4959, which observed this and deliberately left it alone as out of scope for its acceptance criteria.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability-only attribution fix with backward-compatible default; no auth, merge, or close-path behavior changes beyond signal metadata.
> 
> **Overview**
> **Terminal friction records now carry the CLI that actually emitted them**, instead of always labeling `emitter.tool` as `single-story-close`.
> 
> `emitTerminalFriction` accepts an optional `tool` argument (default unchanged for close paths). `single-story-confirm-merge.js` centralizes its surface name in `CLI_SOURCE` and passes it into both friction emit sites and `runAsCli({ source })`, so retro roll-ups that read `emitter.tool` via `normalizeGatheredSignal` can point follow-ups at the right command.
> 
> Tests cover the emitter default/threaded `tool` behavior and an end-to-end `runConfirmMerge` `--wait` budget-exhaustion path that asserts `single-story-confirm-merge` on the written signal.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d9634603a3ab6cb986c6cc6fd69d496ab43cfe7e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->