### PR TITLE
fix(scripts): make --help short-circuit before check-test-temp-hygiene does work

### DIFF
--- a/.agents/scripts/check-test-temp-hygiene.js
+++ b/.agents/scripts/check-test-temp-hygiene.js
@@ -656,5 +656,42 @@ runAsCli(
     const code = runHygiene(parseArgv(process.argv.slice(2)));
     return code;
   },
-  { source: 'check-test-temp-hygiene', propagateExitCode: true },
+  {
+    source: 'check-test-temp-hygiene',
+    propagateExitCode: true,
+    usage: {
+      invocation:
+        'node .agents/scripts/check-test-temp-hygiene.js [--snapshot | --assert | --clean] [--baseline <path>] [--lint-globs <globs>] [--ids <ids>] [--root <dir>]',
+      summary:
+        'Regression guard for test-fixture pollution of the temp trees: the repo temp/ telemetry streams every retro reads, and the OS temp root the suite scratch dirs nest under.',
+      flags: [
+        [
+          '--snapshot',
+          'Fingerprint every temp/ stream file and the pre-existing OS suite roots. Run BEFORE the suite.',
+        ],
+        [
+          '--assert',
+          'Re-scan and fail on any stream added or grown, or a surviving suite root. Run AFTER the suite. This is the default when no mode flag is passed.',
+        ],
+        [
+          '--clean',
+          'List stream directories whose Epic/Story id matches a known fixture id. Report-only — deletes nothing.',
+        ],
+        [
+          '--baseline <path>',
+          'Explicit snapshot path (CI sets a runner-temp path). Defaults to an OS scratch location keyed by the repo root; refused inside the protected temp/ tree.',
+        ],
+        [
+          '--lint-globs <globs>',
+          'Comma-separated repo-relative globs scanned for tests calling mkdtemp against os.tmpdir() instead of makeTempDir(). Off unless passed.',
+        ],
+        ['--ids <ids>', 'Comma-separated fixture ids for --clean.'],
+        ['--root <dir>', 'Repository root to scan (default: repo root).'],
+      ],
+      notes: [
+        '--assert requires a snapshot recorded by an earlier --snapshot run: a missing one is a hard failure, never a silent re-baseline.',
+        'Exit codes:\n  0  clean\n  1  a breach, or --assert with no snapshot to attest against',
+      ],
+    },
+  },
 );

--- a/tests/scripts/cli-help-contract.test.js
+++ b/tests/scripts/cli-help-contract.test.js
@@ -1,0 +1,133 @@
+/**
+ * tests/scripts/cli-help-contract.test.js — `--help` must never do work.
+ *
+ * `runAsCli` (lib/cli-utils.js) short-circuits `--help` *before* invoking
+ * `main`, but only when the caller supplies a `usage` block:
+ *
+ *     if (usage && respondToHelp(process.argv.slice(2), usage)) return;
+ *
+ * A script that omits `usage` therefore falls straight through to its work
+ * path on `--help`. For `check-test-temp-hygiene.js` that surfaced as a
+ * confusing hard failure — `--help` landed on the default `--assert` mode and
+ * exited 1 with "snapshot missing" — which is what this file's first test
+ * pins. The family matters more than the instance: several baseline CLIs
+ * mutate `baselines/` when invoked with a mode flag, so "`--help` reaches the
+ * work path" is a shape that is elsewhere destructive.
+ *
+ * The second test is the ratchet. It is deliberately **static** — executing
+ * every entry point would run real scans — and it asserts the set of
+ * `runAsCli` callers lacking a `usage` block equals a known list, so a new
+ * script cannot silently join it and a fixed one forces the list to shrink.
+ */
+
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { readdirSync, readFileSync } from 'node:fs';
+import path from 'node:path';
+import { describe, it } from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+const SCRIPTS_DIR = path.join(REPO_ROOT, '.agents', 'scripts');
+
+/**
+ * Entry points that route through `runAsCli` but pass no `usage` block, so
+ * `--help` executes their work path. Every entry is a known gap, not an
+ * approval: shrink this list, never grow it. `check-test-temp-hygiene.js` was
+ * removed from it by the change that added this file.
+ */
+const KNOWN_HELP_GAPS = new Set([
+  'check-action-pinning.js',
+  'check-context-budget.js',
+  'check-gherkin-placeholders.js',
+  'check-lifecycle-lint.js',
+  'check-schema-references.js',
+  'check-workflow-cli-lint.js',
+  'check-workflow-timeouts.js',
+]);
+
+/** Scripts that deliberately do not route through `runAsCli` at all. */
+const CLI_OPT_OUT_MARKER = 'cli-opt-out';
+
+function entryPoints() {
+  return readdirSync(SCRIPTS_DIR)
+    .filter((f) => f.endsWith('.js'))
+    .filter((f) => f.startsWith('check-') || f.startsWith('update-'))
+    .sort();
+}
+
+/**
+ * True when the file hands `runAsCli` a `usage` option. Scoped to the text
+ * from the `runAsCli(` call onward so an unrelated `usage:` key elsewhere in
+ * the module cannot vouch for the call site.
+ */
+function passesUsageToRunAsCli(source) {
+  const call = source.indexOf('runAsCli(');
+  if (call === -1) return null; // not a runAsCli entry point
+  return /\busage\s*:/.test(source.slice(call));
+}
+
+describe('CLI --help contract', () => {
+  it('check-test-temp-hygiene.js --help exits 0 and prints its invocation line', () => {
+    const script = path.join(SCRIPTS_DIR, 'check-test-temp-hygiene.js');
+    const run = spawnSync(process.execPath, [script, '--help'], {
+      encoding: 'utf8',
+      cwd: REPO_ROOT,
+    });
+
+    assert.equal(
+      run.status,
+      0,
+      `--help exited ${run.status}; stderr: ${run.stderr}`,
+    );
+    assert.match(
+      run.stdout,
+      /^Usage: node \.agents\/scripts\/check-test-temp-hygiene\.js /m,
+      'usage block did not print the invocation line',
+    );
+    // The regression: --help must not reach the default --assert path.
+    const combined = `${run.stdout}${run.stderr}`;
+    assert.doesNotMatch(
+      combined,
+      /snapshot missing|guard cannot attest/,
+      '--help fell through to the assert work path',
+    );
+  });
+
+  it('no new entry point omits its usage block', () => {
+    const observed = new Set();
+    for (const file of entryPoints()) {
+      const source = readFileSync(path.join(SCRIPTS_DIR, file), 'utf8');
+      if (source.includes(CLI_OPT_OUT_MARKER)) continue;
+      const passesUsage = passesUsageToRunAsCli(source);
+      if (passesUsage === false) observed.add(file);
+    }
+
+    const added = [...observed].filter((f) => !KNOWN_HELP_GAPS.has(f));
+    assert.deepEqual(
+      added,
+      [],
+      `these entry points run work on --help; give each a usage block (see .agents/scripts/audit-baselines.js): ${added.join(', ')}`,
+    );
+
+    const fixed = [...KNOWN_HELP_GAPS].filter((f) => !observed.has(f));
+    assert.deepEqual(
+      fixed,
+      [],
+      `these are fixed — remove them from KNOWN_HELP_GAPS: ${fixed.join(', ')}`,
+    );
+  });
+
+  it('every write-capable baseline updater guards --help', () => {
+    // The destructive half of the family: these mutate baselines/ when given
+    // a mode flag, so a --help that reached main would be the costly case.
+    for (const file of entryPoints().filter((f) => f.startsWith('update-'))) {
+      const source = readFileSync(path.join(SCRIPTS_DIR, file), 'utf8');
+      const guarded = source.includes(CLI_OPT_OUT_MARKER)
+        ? source.includes('respondToHelp')
+        : passesUsageToRunAsCli(source);
+      assert.equal(guarded, true, `${file} does not short-circuit --help`);
+    }
+  });
+});


### PR DESCRIPTION
## Why

`runAsCli` guards `--help` with `if (usage && respondToHelp(...)) return;` — the `usage &&` is load-bearing. A caller that passes no `usage` block never reaches the help handler, so `--help` falls through to `main` and the script does its work.

`check-test-temp-hygiene.js` was the worst case: `--help` landed on its default `--assert` mode and exited **1** with "snapshot missing — guard cannot attest", which reads as a broken guard rather than a missing usage block.

## What changed

- `check-test-temp-hygiene.js` gets a `usage` block, so `--help` prints its invocation and exits 0. Both real modes (`--snapshot`, `--assert`) are unchanged and re-verified.
- `tests/scripts/cli-help-contract.test.js` pins the regression and ratchets the family:
  - `--help` exits 0, prints the invocation line, and does **not** reach the assert path.
  - The set of `runAsCli` callers lacking a `usage` block equals a known list, so a new entry point cannot silently join it and a fixed one forces the list to shrink.
  - Every write-capable baseline updater guards `--help` — that half of the family is already clean.

## Audit of the family

Eight entry points had the gap; the other seven are read-only `check-*` scripts that silently run their full scan on `--help` and exit 0. They are enumerated as a burn-down list in the test rather than fixed here, because their flag surfaces need reading to document accurately and guessed help text is worse than none.

**The destructive half is clean**: all four `update-*-baseline.js` pass `usage` to `runAsCli`, and `update-ticket-state.js` calls `respondToHelp` directly.

## Note on the bypassed hooks

Committed and pushed with `--no-verify` under explicit operator authorization. The `quality:preview` gate reports a **phantom** CRAP regression on this file, pre-existing and unrelated to this change:

- baseline `<anon method-6>`: crap 1.125 ⇒ c=1, cov=0.5, startLine 572
- current ordinal-6 method: crap 2 ⇒ c=2, cov=1.0, startLine 484

Different functions, paired by `pickDriftCandidate`'s nearest-`startLine` fallback, which treats unstable `<anon method-N>` ordinals as stable identity. Appending a single comment line to the file reproduces the identical `+0.88` with no other change. `check-baselines.js` — the gate CI runs — is green.

The comparator defect is being planned separately.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test and CLI help wiring only; no change to snapshot/assert/clean behavior beyond `--help` handling.
> 
> **Overview**
> **`check-test-temp-hygiene.js`** now passes a `usage` block into `runAsCli`, so `--help` prints usage and exits 0 instead of falling through to default `--assert` and failing with “snapshot missing”.
> 
> **`tests/scripts/cli-help-contract.test.js`** locks that behavior in and ratchets the broader CLI family: a spawn test for the hygiene script, a static scan that forbids new `runAsCli` entry points without `usage` (seven known gaps remain on a burn-down list), and a check that every `update-*` baseline script guards `--help`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e3a88d9574f8e1e5acd4663f71d6827b2a8e23aa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->