### PR TITLE
fix(baselines): carry provenanceStamped through the reader's narrowing

### DIFF
--- a/.agents/scripts/lib/baselines/reader.js
+++ b/.agents/scripts/lib/baselines/reader.js
@@ -183,6 +183,56 @@ function validate(kind, parsed, sourceHint) {
 }
 
 /**
+ * Internal: the ONE narrowing projection every loaded envelope passes through.
+ *
+ * `load` and `loadFile` reach a validated `parsed` envelope by different routes
+ * — one resolves the path from config, the other infers the kind from
+ * `$schema` — but the shape they hand back is the same narrow contract, so it
+ * is built here rather than written out at each exit.
+ *
+ * **That single-sourcing is the point, not tidiness.** The projection is an
+ * ALLOW-LIST: a field absent from it is silently dropped, and the envelope
+ * stamps below are read off the LOADED object by compat axes that fail closed
+ * when a stamp reads `undefined`. While the list was duplicated at the two
+ * exits, adding a stamp to one and not the other produced a gate that rejected
+ * every baseline in the repo for a stamp that was present on disk — which is
+ * exactly what happened to `provenanceStamped` between Story #4901 and this
+ * fix. One list means a new stamp cannot be half-added.
+ *
+ * @param {string} kind
+ * @param {object} parsed A validated baseline envelope.
+ * @returns {{ rollup: object, rows: Array<object>, kernelVersion: string, generatedAt: string }}
+ */
+function shapeEnvelope(kind, parsed) {
+  const rows = Array.isArray(parsed.rows)
+    ? parsed.rows.map((row) => canonicaliseRow(kind, row))
+    : [];
+  return {
+    rollup: parsed.rollup ?? { '*': {} },
+    rows,
+    kernelVersion: parsed.kernelVersion,
+    generatedAt: parsed.generatedAt,
+    // Story #4775 — carry the per-kind scoring-semantics stamp through the
+    // narrowing. The gate's compat check reads it off the LOADED envelope, so
+    // dropping it here would make every baseline look unstamped and fail the
+    // whole repo closed on a stamp that is actually present on disk.
+    scoringSemantics: parsed.scoringSemantics,
+    // Story #4866 — same contract for the transpiler stamp. Dropping it here
+    // would leave the ts-transpiler compat axis reachable but blind: it would
+    // read `undefined` off every loaded envelope and pass vacuously, which is
+    // the exact deadness this Story exists to end.
+    tsTranspilerVersion: parsed.tsTranspilerVersion,
+    // Story #4901 — the coordinate-provenance marker, and the stamp that proved
+    // the warnings above were not hypothetical. Its `provenance-unstamped` axis
+    // keys on `!== true`, so while this line was missing the axis read
+    // `undefined` off every envelope and rejected each one with "baseline
+    // predates coordinate-provenance stamping" — un-satisfiable, because
+    // re-deriving the baseline writes the marker the reader then drops.
+    provenanceStamped: parsed.provenanceStamped,
+  };
+}
+
+/**
  * Internal: parse + validate + canonicalise. Used by both `load` and
  * `loadFile`.
  *
@@ -208,25 +258,7 @@ function readAndShape(kind, absolutePath) {
     );
   }
   validate(kind, parsed, absolutePath);
-  const rows = Array.isArray(parsed.rows)
-    ? parsed.rows.map((row) => canonicaliseRow(kind, row))
-    : [];
-  return {
-    rollup: parsed.rollup ?? { '*': {} },
-    rows,
-    kernelVersion: parsed.kernelVersion,
-    generatedAt: parsed.generatedAt,
-    // Story #4775 — carry the per-kind scoring-semantics stamp through the
-    // narrowing. The gate's compat check reads it off the LOADED envelope, so
-    // dropping it here would make every baseline look unstamped and fail the
-    // whole repo closed on a stamp that is actually present on disk.
-    scoringSemantics: parsed.scoringSemantics,
-    // Story #4866 — same contract for the transpiler stamp. Dropping it here
-    // would leave the ts-transpiler compat axis reachable but blind: it would
-    // read `undefined` off every loaded envelope and pass vacuously, which is
-    // the exact deadness this Story exists to end.
-    tsTranspilerVersion: parsed.tsTranspilerVersion,
-  };
+  return shapeEnvelope(kind, parsed);
 }
 
 /**
@@ -306,25 +338,7 @@ export function loadFile(absolutePath, opts = {}) {
     );
   }
   validate(kind, parsed, absolutePath);
-  const rows = Array.isArray(parsed.rows)
-    ? parsed.rows.map((row) => canonicaliseRow(kind, row))
-    : [];
-  return {
-    rollup: parsed.rollup ?? { '*': {} },
-    rows,
-    kernelVersion: parsed.kernelVersion,
-    generatedAt: parsed.generatedAt,
-    // Story #4775 — carry the per-kind scoring-semantics stamp through the
-    // narrowing. The gate's compat check reads it off the LOADED envelope, so
-    // dropping it here would make every baseline look unstamped and fail the
-    // whole repo closed on a stamp that is actually present on disk.
-    scoringSemantics: parsed.scoringSemantics,
-    // Story #4866 — same contract for the transpiler stamp. Dropping it here
-    // would leave the ts-transpiler compat axis reachable but blind: it would
-    // read `undefined` off every loaded envelope and pass vacuously, which is
-    // the exact deadness this Story exists to end.
-    tsTranspilerVersion: parsed.tsTranspilerVersion,
-  };
+  return shapeEnvelope(kind, parsed);
 }
 
 export const _internals = Object.freeze({

--- a/tests/baselines/reader.test.js
+++ b/tests/baselines/reader.test.js
@@ -196,3 +196,86 @@ describe('baselines/reader — load (config-driven)', () => {
     assert.throws(() => load('nonsense', { cwd: tmp }), /unknown kind/);
   });
 });
+
+// The projection in `shapeEnvelope` is an ALLOW-LIST, so a stamp that is not
+// named there is dropped silently — and the compat axes that read these stamps
+// off the LOADED envelope fail closed when one reads `undefined`. That pairing
+// turns a one-line omission into a gate that rejects every baseline in a repo
+// for a stamp which is present on disk, and it is not hypothetical: it is what
+// `provenanceStamped` did between Story #4901 (which added the marker and its
+// `provenance-unstamped` axis) and the fix these tests land with.
+//
+// Nothing caught it because no test asserted carry-through for ANY stamp —
+// `scoringSemantics` and `tsTranspilerVersion` were each added with a comment
+// warning of this exact failure and no assertion behind it. So this block pins
+// every stamp at BOTH exits rather than only the one that regressed: the bug
+// was never about which stamp, it was about the projection being writable in
+// two places with nothing checking they agree.
+const ENVELOPE_STAMPS = [
+  ['scoringSemantics', 'method-identity-v3'],
+  ['tsTranspilerVersion', '5.9.3'],
+  ['provenanceStamped', true],
+];
+
+describe('baselines/reader — envelope stamps survive the narrowing', () => {
+  let tmp;
+  beforeEach(() => {
+    tmp = makeTempDir('baseline-reader-stamps-');
+  });
+  afterEach(() => {
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  for (const [field, value] of ENVELOPE_STAMPS) {
+    it(`loadFile carries ${field} through to the loaded envelope`, () => {
+      const file = path.join(tmp, 'crap.json');
+      writeJson(file, envelope('crap', { [field]: value }));
+      assert.deepEqual(loadFile(file)[field], value);
+    });
+
+    it(`load carries ${field} through to the loaded envelope`, () => {
+      const dir = path.join(tmp, 'baselines');
+      mkdirSync(dir, { recursive: true });
+      writeJson(
+        path.join(dir, 'crap.json'),
+        envelope('crap', { [field]: value }),
+      );
+      assert.deepEqual(load('crap', { cwd: tmp })[field], value);
+    });
+  }
+
+  it('carries every stamp on one envelope, through both entry points alike', () => {
+    // The parity assertion the duplicated projection needed and never had: the
+    // two exits must hand back the same shape, so a stamp added to one and not
+    // the other fails here rather than in a consumer's gate.
+    const stamped = Object.fromEntries(ENVELOPE_STAMPS);
+    const dir = path.join(tmp, 'baselines');
+    mkdirSync(dir, { recursive: true });
+    const file = path.join(dir, 'crap.json');
+    writeJson(file, envelope('crap', stamped));
+
+    const viaFile = loadFile(file);
+    const viaConfig = load('crap', { cwd: tmp });
+    for (const [field, value] of ENVELOPE_STAMPS) {
+      assert.deepEqual(viaFile[field], value, `loadFile dropped ${field}`);
+      assert.deepEqual(viaConfig[field], value, `load dropped ${field}`);
+    }
+    assert.deepEqual(
+      Object.keys(viaFile).sort(),
+      Object.keys(viaConfig).sort(),
+    );
+  });
+
+  it('leaves an unstamped envelope undefined rather than inventing a value', () => {
+    // The other half of the contract. `provenance-unstamped` keys on
+    // `!== true`, so a reader that defaulted a missing marker to `true` would
+    // silence the axis on exactly the pre-#4901 baselines it exists to catch —
+    // the opposite failure, and the quieter one.
+    const file = path.join(tmp, 'crap.json');
+    writeJson(file, envelope('crap'));
+    const out = loadFile(file);
+    for (const [field] of ENVELOPE_STAMPS) {
+      assert.equal(out[field], undefined, `${field} was invented`);
+    }
+  });
+});


### PR DESCRIPTION
Resolves #4973.

## The bug

`check-baselines` rejects **every** CRAP baseline on v2.26.0 — exit 2, schema class — on baselines that
carry the stamp on disk.

`readAndShape` and `loadFile` each built the loaded envelope from a **duplicated allow-list projection**.
That list carried `scoringSemantics` (#4775) and `tsTranspilerVersion` (#4866), each with a comment
warning that dropping it would break its compat axis — but #4901's `provenanceStamped` was never added
to either copy. `provenance-unstamped` keys on `!== true`, so it read `undefined` off every loaded
envelope and refused it.

| Envelope | `assertBaselineCompatible` |
| --- | --- |
| `baselines/crap.json` raw from disk | passes (`null`) |
| same file after `reader.load('crap')` | **fails** |
| loaded envelope with the stamp restored | passes |

## Why this needed a patch release rather than a normal fix

The failure was **un-escapable from the consumer side**:

- The error's own remedy — `crap:update --full-scope` + a `baseline-refresh:` subject — writes a stamp
  that is already `true` and that the reader drops again. It returns the identical error after rewriting
  a megabyte-scale baseline into a large meaningless diff. One consumer session ran exactly that
  (6245 rows, `scope=full`, correctly-tagged subject) and still got exit 2.
- `CRAP_REFRESH=1` does not reach it: the schema phase returns at `evaluate.js` before any refresh
  handling.

So affected consumers could land nothing, and the documented escape hatch actively made it worse. Two
Stories in Beestera/swarm-os (#1249, #1235) were blocked on it simultaneously, from a clean `main`.

## The fix

Single-source the projection into one `shapeEnvelope(kind, parsed)` that both exits call, and add
`provenanceStamped`.

**The duplication is the actual defect** — a stamp addable in two places with nothing checking they
agree was always going to produce this, and did, on the third stamp. One list means it cannot recur.

`$schema` is also absent from the projection. That one is deliberate and stays: `inferKindFromSchema`
reads it off `parsed` before shaping, and nothing reads it off a loaded envelope.

## Tests

The reason two prophetic comments did not prevent this: **no test asserted carry-through for any stamp.**

Adds, in `tests/baselines/reader.test.js`:

- carry-through for all three stamps × both entry points (`load`, `loadFile`)
- a **parity** assertion that the two exits return the same key set — the check the duplicated
  projection never had
- the negative case: a missing stamp stays `undefined` rather than defaulting to `true`, which would
  silence the axis on exactly the pre-#4901 baselines it exists to catch

Verified as a real regression test — the three provenance assertions **fail on the parent commit**
(`ℹ pass 20 / fail 3`) and pass here (`ℹ pass 23 / fail 0`).

## Verification

| Check | Result |
| --- | --- |
| `npm run test` | 10126 tests, 10122 pass, **0 fail** |
| `npm run lint` | clean |
| `npm run format:check` | clean |
| `npm run typecheck` | clean |
| End-to-end on a blocked consumer | `check-baselines --gate crap` → **exit 0**, 0 schema errors, 0 breaches, 0 regressions |

The last row is the one that matters: patching only the reader turns the blocked consumer's gate green
with no baseline change at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the shared baseline read path used by all quality gates; incorrect projection would break compat checks repo-wide, but the change is a straight refactor plus one missing field with targeted regression tests.
> 
> **Overview**
> Fixes **`check-baselines`** falsely rejecting CRAP baselines that already had **`provenanceStamped: true` on disk** because the reader’s allow-list projection dropped that field after load.
> 
> **Reader:** Duplicated narrowing logic in **`readAndShape`** and **`loadFile`** is consolidated into **`shapeEnvelope`**, which now forwards **`scoringSemantics`**, **`tsTranspilerVersion`**, and **`provenanceStamped`** so compat gates read the same stamps from loaded envelopes as from raw JSON.
> 
> **Tests:** New coverage asserts each stamp survives **`load`** and **`loadFile`**, both paths return the same key set, and missing stamps stay **`undefined`** (no invented defaults).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f0e132d5750703c8ee122e460dcf722a795d5aaf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->