### PR TITLE
chore(deps): npm audit fix — brace-expansion 5.0.9, fast-uri 3.1.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2259,9 +2259,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
@@ -3134,9 +3134,9 @@
       }
     },
     "node_modules/fast-uri": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
## Summary
- Fixes 2 high-severity npm audit advisories that were red on `main` and blocking the required "Validate and Test" check on every open PR, including #4982 (Story #4981).
- Both are transitive, lockfile-only patch bumps via `npm audit fix`:
  - `brace-expansion` 5.0.8 → 5.0.9 (GHSA-rgw5-rvv9-x895 — DoS via unbounded intermediate arrays)
  - `fast-uri` 3.1.4 → 3.1.5 (GHSA-7p8r-x3mc-p8w7 — host confusion via backslash authority introducer)
- No direct dependency version changes; `package.json` is untouched.

## Test plan
- [x] `npm audit --audit-level=high` → 0 vulnerabilities
- [x] `npm run lint` clean
- [x] `node .agents/scripts/check-baselines.js` — 0 breaches, 0 regressions

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Patch-level transitive dependency updates with no application code or direct dependency manifest changes.
> 
> **Overview**
> Resolves two **high-severity** npm audit findings by bumping transitive dependencies in **`package-lock.json` only** (`package.json` unchanged): **`brace-expansion`** 5.0.8 → 5.0.9 (DoS via unbounded intermediate arrays) and **`fast-uri`** 3.1.4 → 3.1.5 (host confusion via backslash in authority). These come through existing trees such as **`minimatch`** and **`ajv`**, via `npm audit fix`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 47800bfb127f38850fa467639c17584235f9ae98. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->