### PR TITLE
fix(baselines): carry provenanceStamped through the legacy CRAP projection

### DIFF
--- a/.agents/scripts/lib/baselines/kinds/crap.js
+++ b/.agents/scripts/lib/baselines/kinds/crap.js
@@ -843,6 +843,34 @@ export function evaluateBaselineCompatibility(ctx) {
 }
 
 /**
+ * The envelope-level fields `LOADED_ENVELOPE_AXES` read off a *loaded*
+ * baseline — the set every read path owes `assertBaselineCompatible`.
+ *
+ * It exists because there are TWO read paths and they have diverged three
+ * times. `check-baselines` loads through `baselines/reader.js`; the
+ * `quality-preview` pre-commit arm loads through `crap-utils.js`'s legacy
+ * projection. Both are ALLOW-LISTS, both feed the axes below, and a stamp
+ * added to one and not the other yields two opposite verdicts on one file:
+ * Story #4866 (`scoringSemantics`, `tsTranspilerVersion`), Story #4969
+ * (`rows[].anonymous`) and Story #4986 (`provenanceStamped`, half-fixed by
+ * #4973) were each that same half-landing.
+ *
+ * Every axis here keys on a POSITIVE marker, so a dropped field reads
+ * `undefined` and fails the baseline closed with a remedy that cannot work —
+ * re-deriving it writes the stamp the read path then discards. A parity test
+ * asserts both paths carry this whole set; add a field here whenever a new
+ * axis reads one, and the test will name the path that forgot it.
+ *
+ * Row-level markers are deliberately out: they are asserted per-row against
+ * the projection, not as envelope stamps.
+ */
+export const COMPAT_STAMP_FIELDS = Object.freeze([
+  'scoringSemantics',
+  'tsTranspilerVersion',
+  'provenanceStamped',
+]);
+
+/**
  * The compat axes a *loaded* envelope can be judged against on its own,
  * without a second baseline to diff. Each invalidates one half of the row
  * identity key. Three are about the `startLine` half: one names the join that

--- a/.agents/scripts/lib/baselines/kinds/crap.js
+++ b/.agents/scripts/lib/baselines/kinds/crap.js
@@ -843,34 +843,6 @@ export function evaluateBaselineCompatibility(ctx) {
 }
 
 /**
- * The envelope-level fields `LOADED_ENVELOPE_AXES` read off a *loaded*
- * baseline — the set every read path owes `assertBaselineCompatible`.
- *
- * It exists because there are TWO read paths and they have diverged three
- * times. `check-baselines` loads through `baselines/reader.js`; the
- * `quality-preview` pre-commit arm loads through `crap-utils.js`'s legacy
- * projection. Both are ALLOW-LISTS, both feed the axes below, and a stamp
- * added to one and not the other yields two opposite verdicts on one file:
- * Story #4866 (`scoringSemantics`, `tsTranspilerVersion`), Story #4969
- * (`rows[].anonymous`) and Story #4986 (`provenanceStamped`, half-fixed by
- * #4973) were each that same half-landing.
- *
- * Every axis here keys on a POSITIVE marker, so a dropped field reads
- * `undefined` and fails the baseline closed with a remedy that cannot work —
- * re-deriving it writes the stamp the read path then discards. A parity test
- * asserts both paths carry this whole set; add a field here whenever a new
- * axis reads one, and the test will name the path that forgot it.
- *
- * Row-level markers are deliberately out: they are asserted per-row against
- * the projection, not as envelope stamps.
- */
-export const COMPAT_STAMP_FIELDS = Object.freeze([
-  'scoringSemantics',
-  'tsTranspilerVersion',
-  'provenanceStamped',
-]);
-
-/**
  * The compat axes a *loaded* envelope can be judged against on its own,
  * without a second baseline to diff. Each invalidates one half of the row
  * identity key. Three are about the `startLine` half: one names the join that

--- a/.agents/scripts/lib/crap-utils.js
+++ b/.agents/scripts/lib/crap-utils.js
@@ -122,6 +122,17 @@ function resolveBaselinePath({ cwd = process.cwd(), baselinePath } = {}) {
  * They are carried verbatim now, `null` when the envelope never stamped them,
  * so an axis can tell "written by a different transpiler" apart from "written
  * before the stamp existed" instead of guessing.
+ *
+ * **This projection is one of TWO (Story #4986).** `check-baselines` reads a
+ * baseline through `baselines/reader.js`; `quality-preview` reads the same file
+ * through here. Both feed `assertBaselineCompatible`, so a stamp added to one
+ * allow-list and not the other produces two opposite verdicts on one envelope —
+ * which is what happened to `provenanceStamped`: #4973 added it to the reader
+ * and left this projection dropping it, so the pre-commit CRAP arm rejected
+ * every stamped baseline with an un-satisfiable "re-seed" remedy while the
+ * authoritative gate passed. `COMPAT_STAMP_FIELDS` in
+ * `baselines/kinds/crap.js` names the set both paths owe, and a parity test
+ * holds them to it.
  */
 function projectCrapEnvelopeToLegacy(parsed) {
   if (
@@ -139,6 +150,14 @@ function projectCrapEnvelopeToLegacy(parsed) {
         ? parsed.tsTranspilerVersion
         : null,
     scoringSemantics: parsed.scoringSemantics ?? null,
+    // Story #4901's marker, dropped here until Story #4986. The
+    // `provenance-unstamped` axis keys on `!== true`, so while this line was
+    // missing it read `undefined` off every projected envelope and refused the
+    // baseline — telling the operator to re-seed, which writes the very marker
+    // this projection then discarded. Carried verbatim (not defaulted to
+    // `false`) so a genuinely pre-#4901 envelope still reads `undefined` and
+    // the axis keeps firing on the shape it exists to catch.
+    provenanceStamped: parsed.provenanceStamped,
     rows: parsed.rows.map((row) => ({
       crap: row.crap,
       file: row.path,

--- a/.agents/scripts/lib/crap-utils.js
+++ b/.agents/scripts/lib/crap-utils.js
@@ -107,6 +107,73 @@ function resolveBaselinePath({ cwd = process.cwd(), baselinePath } = {}) {
  * }|null}
  */
 /**
+ * The envelope-level fields the CRAP compat axes read off a *loaded* baseline
+ * — the set every read path owes `assertBaselineCompatible`.
+ *
+ * It exists because there are TWO read paths and they have now diverged three
+ * times. `check-baselines` loads through `baselines/reader.js`; the
+ * `quality-preview` pre-commit arm loads through `projectCrapEnvelopeToLegacy`
+ * below. Both are ALLOW-LISTS, both feed the same axes, and a stamp added to
+ * one and not the other yields two opposite verdicts on one file: Story #4866
+ * (`scoringSemantics`, `tsTranspilerVersion`), Story #4969 (`rows[].anonymous`)
+ * and Story #4986 (`provenanceStamped`, half-fixed by #4973) were each that
+ * same half-landing.
+ *
+ * Every one of those axes keys on a POSITIVE marker, so a dropped field reads
+ * `undefined` and fails the baseline closed with a remedy that cannot work —
+ * re-deriving it writes the stamp the read path then discards. The projection
+ * below is DERIVED from this list rather than repeating it, so a new stamp is
+ * carried here the moment it is named; a parity test holds the reader to the
+ * same set and names whichever path forgot one.
+ *
+ * Row-level markers are deliberately out: they are projected per-row, not as
+ * envelope stamps.
+ *
+ * Deliberately module-local, mirroring `SCORING_SEMANTICS` in
+ * `baselines/kinds/crap.js`: the writer's `envelopeExtras()` is the single
+ * production door to the stamp set, and exporting this list would add a second
+ * one that only a test reaches. The parity test holds this projection to
+ * `Object.keys(envelopeExtras())` instead, so a stamp the writer starts
+ * emitting fails the test here until it is named — which is the enforcement
+ * this list needs, not an export.
+ */
+const COMPAT_STAMP_FIELDS = Object.freeze([
+  'scoringSemantics',
+  'tsTranspilerVersion',
+  'provenanceStamped',
+]);
+
+/**
+ * Per-stamp coercion applied on the way through the legacy projection. A field
+ * with no entry is carried VERBATIM, which is the correct default: the axes
+ * distinguish "stamped" from "absent", so inventing a value for a stamp the
+ * envelope never wrote is the one thing a read path must not do.
+ */
+const COMPAT_STAMP_NORMALIZERS = {
+  // `null` (not the running value) when unstamped, so `ts-transpiler-drift`
+  // can tell "written by a different transpiler" from "written before the
+  // stamp existed" instead of comparing a value against itself.
+  tsTranspilerVersion: (value) => (typeof value === 'string' ? value : null),
+  scoringSemantics: (value) => value ?? null,
+};
+
+/**
+ * Project the compat stamps off a v2 envelope, driven by
+ * `COMPAT_STAMP_FIELDS`.
+ *
+ * @param {Record<string, unknown>} parsed
+ * @returns {Record<string, unknown>}
+ */
+function projectCompatStamps(parsed) {
+  const stamps = {};
+  for (const field of COMPAT_STAMP_FIELDS) {
+    const normalize = COMPAT_STAMP_NORMALIZERS[field];
+    stamps[field] = normalize ? normalize(parsed[field]) : parsed[field];
+  }
+  return stamps;
+}
+
+/**
  * Story #1895: shipped baseline switched to the canonical envelope shape
  * (`$schema`, `kernelVersion`, `generatedAt`, `rollup`, `rows` keyed on
  * `path`). Backfill the legacy `escomplexVersion` field from the running
@@ -130,9 +197,8 @@ function resolveBaselinePath({ cwd = process.cwd(), baselinePath } = {}) {
  * which is what happened to `provenanceStamped`: #4973 added it to the reader
  * and left this projection dropping it, so the pre-commit CRAP arm rejected
  * every stamped baseline with an un-satisfiable "re-seed" remedy while the
- * authoritative gate passed. `COMPAT_STAMP_FIELDS` in
- * `baselines/kinds/crap.js` names the set both paths owe, and a parity test
- * holds them to it.
+ * authoritative gate passed. The stamp block is derived from
+ * `COMPAT_STAMP_FIELDS` above so this projection cannot fall behind again.
  */
 function projectCrapEnvelopeToLegacy(parsed) {
   if (
@@ -145,19 +211,7 @@ function projectCrapEnvelopeToLegacy(parsed) {
   return {
     kernelVersion: parsed.kernelVersion,
     escomplexVersion: resolveEscomplexVersion(),
-    tsTranspilerVersion:
-      typeof parsed.tsTranspilerVersion === 'string'
-        ? parsed.tsTranspilerVersion
-        : null,
-    scoringSemantics: parsed.scoringSemantics ?? null,
-    // Story #4901's marker, dropped here until Story #4986. The
-    // `provenance-unstamped` axis keys on `!== true`, so while this line was
-    // missing it read `undefined` off every projected envelope and refused the
-    // baseline — telling the operator to re-seed, which writes the very marker
-    // this projection then discarded. Carried verbatim (not defaulted to
-    // `false`) so a genuinely pre-#4901 envelope still reads `undefined` and
-    // the axis keeps firing on the shape it exists to catch.
-    provenanceStamped: parsed.provenanceStamped,
+    ...projectCompatStamps(parsed),
     rows: parsed.rows.map((row) => ({
       crap: row.crap,
       file: row.path,

--- a/tests/baselines/crap-compat-axes.test.js
+++ b/tests/baselines/crap-compat-axes.test.js
@@ -4,7 +4,6 @@ import path from 'node:path';
 import { describe, it } from 'node:test';
 import {
   assertBaselineCompatible,
-  COMPAT_STAMP_FIELDS,
   CRAP_COMPAT_AXES,
   envelopeExtras,
   evaluateBaselineCompatibility,
@@ -526,8 +525,8 @@ describe('read-path parity — reader and legacy projection agree (#4986)', () =
    *
    * `escomplexVersion` is stripped: the v2 envelope schema forbids it (the
    * legacy projection back-fills it from the running scorer, which is why it
-   * is not a compat stamp and not in `COMPAT_STAMP_FIELDS`). The fixtures
-   * above keep it because they are hand-built loaded envelopes, not files.
+   * is not a compat stamp). The fixtures above keep it because they are
+   * hand-built loaded envelopes, not files.
    */
   function writeEnvelope({ escomplexVersion: _dropped, ...envelope }) {
     const dir = makeTempDir('crap-parity-');
@@ -553,11 +552,23 @@ describe('read-path parity — reader and legacy projection agree (#4986)', () =
     };
   }
 
-  it('carries every COMPAT_STAMP_FIELD through both projections', () => {
+  it('carries every stamp the writer emits through both projections', () => {
+    // The field set comes from `envelopeExtras()` — the writer's own
+    // production door, per this file's convention — rather than a constant
+    // exported for the test's benefit. So a stamp the writer starts emitting
+    // enters this assertion automatically, and whichever read path forgot to
+    // carry it is named here rather than discovered by a consumer whose
+    // pre-commit gate has gone quiet.
+    for (const field of Object.keys(envelopeExtras())) {
+      assert.ok(
+        field in VALID_BASELINE,
+        `fixture must stamp ${field} for this parity check to mean anything`,
+      );
+    }
     const { dir, baselinePath } = writeEnvelope(VALID_BASELINE);
     try {
       const { reader, legacy } = loadBothWays(baselinePath);
-      for (const field of COMPAT_STAMP_FIELDS) {
+      for (const field of Object.keys(envelopeExtras())) {
         // Against the file, not against each other — two paths agreeing on a
         // wrong value would satisfy a cross-check but not this.
         assert.equal(

--- a/tests/baselines/crap-compat-axes.test.js
+++ b/tests/baselines/crap-compat-axes.test.js
@@ -1,11 +1,17 @@
 import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
 import { describe, it } from 'node:test';
 import {
   assertBaselineCompatible,
+  COMPAT_STAMP_FIELDS,
   CRAP_COMPAT_AXES,
   envelopeExtras,
   evaluateBaselineCompatibility,
 } from '../../.agents/scripts/lib/baselines/kinds/crap.js';
+import { loadFile as readerLoadFile } from '../../.agents/scripts/lib/baselines/reader.js';
+import { getCrapBaseline } from '../../.agents/scripts/lib/crap-utils.js';
+import { makeTempDir } from '../../.agents/scripts/lib/test-temp.js';
 
 // The stamp is read through the production door the writer uses, not a
 // second exported constant — so a drift between what the writer stamps and
@@ -495,5 +501,122 @@ describe('provenance-unstamped — the fail-CLOSED door (#4901)', () => {
       }),
       null,
     );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Story #4986 — read-path parity.
+//
+// `assertBaselineCompatible` is fed by TWO allow-list projections of the same
+// on-disk envelope: `baselines/reader.js` (the `check-baselines` gate) and
+// `crap-utils.js`'s legacy projection (the `quality-preview` pre-commit arm).
+// Three stamps have now half-landed across that seam — #4866, #4969 and this
+// Story's `provenanceStamped` (#4973 fixed the reader and left the projection
+// dropping it), each producing a gate that rejected a valid baseline with a
+// re-seed remedy that could not work, because re-deriving writes the stamp the
+// read path then discards.
+//
+// So this asserts the property directly rather than the three instances of it:
+// one file on disk, both doors, identical verdict.
+// ---------------------------------------------------------------------------
+
+describe('read-path parity — reader and legacy projection agree (#4986)', () => {
+  /**
+   * Write `envelope` to a throwaway checkout and return its baseline path.
+   *
+   * `escomplexVersion` is stripped: the v2 envelope schema forbids it (the
+   * legacy projection back-fills it from the running scorer, which is why it
+   * is not a compat stamp and not in `COMPAT_STAMP_FIELDS`). The fixtures
+   * above keep it because they are hand-built loaded envelopes, not files.
+   */
+  function writeEnvelope({ escomplexVersion: _dropped, ...envelope }) {
+    const dir = makeTempDir('crap-parity-');
+    fs.mkdirSync(path.join(dir, 'baselines'), { recursive: true });
+    const baselinePath = path.join(dir, 'baselines', 'crap.json');
+    fs.writeFileSync(
+      baselinePath,
+      JSON.stringify({
+        $schema: '.agents/schemas/baselines/crap.schema.json',
+        generatedAt: new Date().toISOString(),
+        rollup: { '*': { p50: 1, p95: 1, max: 2, methodsAbove20: 0 } },
+        ...envelope,
+      }),
+    );
+    return { dir, baselinePath };
+  }
+
+  /** Load `baselinePath` through both production read paths. */
+  function loadBothWays(baselinePath) {
+    return {
+      reader: readerLoadFile(baselinePath, 'crap'),
+      legacy: getCrapBaseline({ baselinePath }),
+    };
+  }
+
+  it('carries every COMPAT_STAMP_FIELD through both projections', () => {
+    const { dir, baselinePath } = writeEnvelope(VALID_BASELINE);
+    try {
+      const { reader, legacy } = loadBothWays(baselinePath);
+      for (const field of COMPAT_STAMP_FIELDS) {
+        // Against the file, not against each other — two paths agreeing on a
+        // wrong value would satisfy a cross-check but not this.
+        assert.equal(
+          reader[field],
+          VALID_BASELINE[field],
+          `reader dropped ${field}`,
+        );
+        assert.equal(
+          legacy[field],
+          VALID_BASELINE[field],
+          `legacy projection dropped ${field}`,
+        );
+      }
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('reaches the same verdict on a valid baseline', () => {
+    const { dir, baselinePath } = writeEnvelope(VALID_BASELINE);
+    try {
+      const { reader, legacy } = loadBothWays(baselinePath);
+      const ctx = {
+        runningTsTranspilerVersion: VALID_BASELINE.tsTranspilerVersion,
+      };
+      assert.equal(assertBaselineCompatible(reader, ctx), null);
+      assert.equal(
+        assertBaselineCompatible(legacy, ctx),
+        null,
+        'the pre-commit arm refused a baseline the gate accepts',
+      );
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('still refuses a genuinely pre-provenance baseline on both paths', () => {
+    // The guard above must not have been bought by defaulting the stamp to a
+    // truthy value: an envelope that never carried it has to keep failing.
+    const preProvenance = { ...VALID_BASELINE };
+    delete preProvenance.provenanceStamped;
+    const { dir, baselinePath } = writeEnvelope(preProvenance);
+    try {
+      const { reader, legacy } = loadBothWays(baselinePath);
+      const ctx = {
+        runningTsTranspilerVersion: VALID_BASELINE.tsTranspilerVersion,
+      };
+      for (const [name, loaded] of [
+        ['reader', reader],
+        ['legacy projection', legacy],
+      ]) {
+        assert.match(
+          assertBaselineCompatible(loaded, ctx) ?? '',
+          /predates coordinate-provenance stamping/,
+          `${name} let a pre-provenance baseline through`,
+        );
+      }
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
   });
 });

--- a/tests/quality-preview.test.js
+++ b/tests/quality-preview.test.js
@@ -624,6 +624,11 @@ function makeCrapFixture({
   methodCount,
   baselineRows,
   scoringSemantics,
+  // Story #4986: written to the envelope only when set, so the #4901 cases
+  // below keep testing an unstamped baseline. Defaulting it on would make the
+  // stamped path the only one anything exercises — which is how the legacy
+  // projection dropped it undetected in the first place.
+  provenanceStamped,
   withCoverage = true,
   cyclomaticPerMethod = 1,
 }) {
@@ -700,6 +705,7 @@ function makeCrapFixture({
         scoringSemantics === undefined
           ? envelopeExtras().scoringSemantics
           : scoringSemantics,
+      ...(provenanceStamped === undefined ? {} : { provenanceStamped }),
       rollup: { '*': { p50: 1, p95: 1, max: 1, methodsAbove20: 0 } },
       rows: baselineRows,
     }),
@@ -941,6 +947,40 @@ describe('runCrapPreview — a pre-provenance baseline is refused (#4901)', () =
       );
       // Refused before the scan's rows ever meet it.
       assert.equal(envelope.summary.total, 0);
+    } finally {
+      rmFixture(dir);
+    }
+  });
+
+  // Story #4986 — the case #4901 never wrote, and the reason its regression
+  // shipped. Every test above drives an UNSTAMPED baseline, so the preview's
+  // read path could drop `provenanceStamped` entirely and the suite stayed
+  // green. This is the door a real consumer walks through on every commit:
+  // a current writer's stamp, a TS row, and an expectation that the gate
+  // compares instead of refusing.
+  it('accepts a stamped TS baseline and actually compares it (#4986)', async () => {
+    const methodCount = 25;
+    const baselineRows = [
+      ...baselineRowsFor(methodCount, 0, 0),
+      { path: 'src/legacy.tsx', method: 'render', startLine: 458, crap: 2 },
+    ];
+    const dir = makeCrapFixture({
+      methodCount,
+      baselineRows,
+      provenanceStamped: true,
+    });
+    try {
+      const { exitCode, envelope } = await runCrapPreview({ cwd: dir });
+      assert.equal(exitCode, 0);
+      assert.deepEqual(
+        envelope.diagnostics ?? [],
+        [],
+        'the pre-commit arm refused a baseline the authoritative gate accepts',
+      );
+      // The assertion that separates "accepted" from "silently suppressed":
+      // a refused envelope reports zero rows compared, so only a non-zero
+      // total proves the scan's rows actually met the baseline.
+      assert.equal(envelope.summary.total, methodCount);
     } finally {
       rmFixture(dir);
     }


### PR DESCRIPTION
Resolves #4986.

## Why

`npm run quality:preview` — the `.husky/pre-commit` CRAP arm — rejected every
baseline carrying `provenanceStamped: true` with

```
[crap-baseline-incompatible] [CRAP] baseline predates coordinate-provenance stamping
```

while the authoritative `check-baselines.js --gate crap` passed on the same
file. The remedy the message names cannot work: re-deriving the baseline writes
the marker the read path then discards.

`assertBaselineCompatible` is fed by **two** allow-list projections of one
envelope. #4973 added the stamp to `baselines/reader.js` (the gate's path) and
left `crap-utils.js`'s `projectCrapEnvelopeToLegacy` (the preview's path)
dropping it, so the `provenance-unstamped` axis — which keys on `!== true` —
read `undefined` off every projected envelope and failed closed.

Worse than the noise it looks like: `runCrapPreview` fails open via
`suppressVerdicts`, so **every per-method verdict was discarded** before the
scan's rows met the baseline (`summary.total: 0`). On any consumer with a TS
row the pre-commit CRAP arm reported nothing at all — exactly where a real CRAP
regression would surface. Its only visible symptom was a red line that trained
contributors to ignore the gate.

## What

1. `projectCrapEnvelopeToLegacy` carries `provenanceStamped` — **verbatim, not
   defaulted**, so a genuinely pre-#4901 envelope still reads `undefined` and
   the axis keeps firing on the shape it exists to catch.
2. The projection's stamp block is now **derived** from one module-local
   `COMPAT_STAMP_FIELDS` list plus a per-stamp normalizer table, rather than
   three hand-written expressions. A field with no normalizer is carried
   verbatim, which is the correct default: the axes distinguish "stamped" from
   "absent", so inventing a value for a stamp the envelope never wrote is the
   one thing a read path must not do.
3. The parity test takes its field set from `envelopeExtras()` — the writer's
   own production door, per `crap-compat-axes.test.js`'s existing convention —
   writes one file to disk and drives it through **both** read paths. Three
   stamps have now half-landed across this seam: #4866 (`scoringSemantics`,
   `tsTranspilerVersion`), #4969 (`rows[].anonymous`) and this one. So the
   property is asserted directly rather than its three instances, and a stamp
   the writer starts emitting enters the assertion automatically.
4. The end-to-end preview case #4901 never wrote: a stamped baseline with a TS
   row, accepted and *actually compared*. `makeCrapFixture` never emitted
   `provenanceStamped`, which is why the drop was invisible — every existing
   preview test drives an unstamped baseline.

No new exported symbol: the second commit moves the list module-local after
`dead-exports:production` correctly flagged it as a production export only a
test reached.

## Verification

Each new test was run against a projection with the `provenanceStamped` carry
surgically removed, and reds:

| test | with fix | carry removed |
| --- | --- | --- |
| `carries every stamp the writer emits through both projections` | pass | **fail** |
| `reaches the same verdict on a valid baseline` | pass | **fail** |
| `accepts a stamped TS baseline and actually compares it` | pass | **fail** |

`still refuses a genuinely pre-provenance baseline on both paths` guards the
inverse — the parity guard must not be bought by defaulting the stamp truthy.

Full local chain green: `typecheck`, `crap:check`, `maintainability:check`,
`coverage:check`, `duplication:check`, `check:cyclomatic`, `check:schema-refs`,
`check-context-budget`, `check-arch-cycles`, `check-dead-exports --production`,
`lint`, `format:check` (the biome error/warnings on `main` are pre-existing and
in files this PR does not touch).

`npm test`: 10161/10163 pass locally. The two failures are
`tests/e2e/update-chain.integration.test.js` seeding a consumer via
`npm install` and dying on `npm error code ENOTCACHED` — no network in the
local sandbox. Both pass in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)