### PR TITLE
fix: push the Story branch from the Story worktree so pre-push validates the tree being pushed (#4991)

### DIFF
--- a/.agents/scripts/lib/orchestration/single-story-close/phases/push.js
+++ b/.agents/scripts/lib/orchestration/single-story-close/phases/push.js
@@ -15,6 +15,18 @@
  * added because it would re-ask a question the push exit code already
  * answered authoritatively.
  *
+ * Issue #4990 — the push runs in the Story worktree, not the main
+ * checkout. `core.hooksPath` is the relative `.husky/_`, so the
+ * invocation directory is what selects which tree `pre-push` resolves
+ * and measures. Pushing from the main checkout therefore validated a
+ * tree other than the one being sent — false red when that checkout sat
+ * on unrelated work, and worse, false green whenever it happened to be
+ * clean. `worktreePath` falls back to `cwd` because single-tree mode and
+ * a disabled `delivery.worktreeIsolation` both legitimately have no
+ * worktree, and there the main checkout IS the tree being pushed. The
+ * two sibling phases resolve their tree the same way
+ * (`base-sync.js`, `close-validation.js`).
+ *
  * `gitSync` is accepted as an injected dependency rather than statically
  * imported so the caller's (cache-busted) binding wins. The
  * `single-story-close.js` orchestrator owns the static import; test
@@ -29,6 +41,7 @@ import { gitSync as defaultGitSync } from '../../../git-utils.js';
  *
  * @param {{
  *   cwd: string,
+ *   worktreePath?: string|null,
  *   storyBranch: string,
  *   gitSync?: typeof defaultGitSync,
  *   progress: (tag: string, msg: string) => void,
@@ -36,6 +49,7 @@ import { gitSync as defaultGitSync } from '../../../git-utils.js';
  */
 export function pushStoryBranch({
   cwd,
+  worktreePath = null,
   storyBranch,
   gitSync = defaultGitSync,
   progress,
@@ -46,8 +60,9 @@ export function pushStoryBranch({
     // before this point, but `--skip-validation` skips that chain, and the
     // bypass then left nothing running at all. `pre-push` is the backstop,
     // and it only became reachable once hooks were materialized into
-    // worktrees — which is where every Story branch is built.
-    gitSync(cwd, 'push', '-u', 'origin', storyBranch);
+    // worktrees — which is where every Story branch is built, and where the
+    // cwd below now resolves so the hook reads that tree.
+    gitSync(worktreePath ?? cwd, 'push', '-u', 'origin', storyBranch);
     progress('GIT', `✅ Pushed ${storyBranch}.`);
   } catch (err) {
     throw new Error(

--- a/.agents/scripts/lib/orchestration/single-story-close/runner.js
+++ b/.agents/scripts/lib/orchestration/single-story-close/runner.js
@@ -201,6 +201,7 @@ async function runPrePushPhases({
 
 async function openAndReviewPr({
   cwd,
+  worktreePath,
   story,
   storyId,
   storyBranch,
@@ -211,7 +212,11 @@ async function openAndReviewPr({
   setPhase = () => {},
 }) {
   setPhase('push');
-  pushStoryBranch({ cwd, storyBranch, gitSync, progress });
+  // Issue #4990 — push from the Story worktree so `pre-push` measures the
+  // tree being sent. `gh` and the review's ref-based diffs below keep the
+  // caller's `cwd`: they read the shared `.git`, so they resolve identically
+  // from either tree.
+  pushStoryBranch({ cwd, worktreePath, storyBranch, gitSync, progress });
   setPhase('pull-request');
   const { url: prUrl, alreadyMerged } = await ensurePullRequestWith({
     cwd,
@@ -729,6 +734,7 @@ async function runClosePipeline({
     () =>
       openAndReviewPr({
         cwd: options.cwd,
+        worktreePath,
         story,
         storyId: options.storyId,
         storyBranch,

--- a/tests/lib/orchestration/single-story-close/push-phase.test.js
+++ b/tests/lib/orchestration/single-story-close/push-phase.test.js
@@ -5,6 +5,10 @@
 // a linked worktree, so removing `--no-verify` would have changed nothing
 // observable. Now that they do fire, the flag is the one thing that would put
 // the delivery push back outside the gate — so it is asserted, not assumed.
+//
+// Issue #4990 adds the other half: running the gate is worthless if it reads
+// the wrong tree. `core.hooksPath` is relative, so the invocation directory
+// decides which tree `pre-push` measures — these tests pin that directory.
 
 import assert from 'node:assert/strict';
 import test from 'node:test';
@@ -50,6 +54,40 @@ test('pushStoryBranch carries no hook-bypass flag', () => {
     [],
     `the delivery push must stay subject to pre-push, got: ${calls[0].args.join(' ')}`,
   );
+});
+
+test('pushStoryBranch pushes from the Story worktree when one is supplied', () => {
+  const { calls, gitSync } = capture();
+  pushStoryBranch({
+    cwd: '/repo',
+    worktreePath: '/repo/.worktrees/story-4990',
+    storyBranch: 'story-4990',
+    gitSync,
+    progress: () => {},
+  });
+  assert.equal(
+    calls[0].cwd,
+    '/repo/.worktrees/story-4990',
+    'pre-push must resolve inside the tree being pushed, not the main checkout',
+  );
+});
+
+test('pushStoryBranch falls back to the main checkout when there is no worktree', () => {
+  for (const worktreePath of [null, undefined]) {
+    const { calls, gitSync } = capture();
+    pushStoryBranch({
+      cwd: '/repo',
+      worktreePath,
+      storyBranch: 'story-4990',
+      gitSync,
+      progress: () => {},
+    });
+    assert.equal(
+      calls[0].cwd,
+      '/repo',
+      `single-tree mode pushes from the main checkout (worktreePath=${worktreePath})`,
+    );
+  }
 });
 
 test('pushStoryBranch surfaces a push failure as a throw', () => {

--- a/tests/single-story-close-push-tree.test.js
+++ b/tests/single-story-close-push-tree.test.js
@@ -193,7 +193,45 @@ function findPush(calls) {
   return push;
 }
 
+/**
+ * A throwaway checkout root, so the DEFAULT `.worktrees/story-<id>` layout can
+ * be exercised without creating directories inside the repository.
+ */
+function tempCheckout(t) {
+  const root = nodeFs.mkdtempSync(path.join(os.tmpdir(), 'mandrel-checkout-'));
+  t.after(() => nodeFs.rmSync(root, { recursive: true, force: true }));
+  return root;
+}
+
 describe('single-story-close — which tree the close-time push runs in', () => {
+  // The default layout, spelled out end to end: an unconfigured
+  // `worktreeIsolation.root` resolves `<cwd>/.worktrees/story-<id>`, which is
+  // what a real delivery has on disk.
+  it('pushes from <cwd>/.worktrees/story-<id> under the default worktree root', async (t) => {
+    const checkout = tempCheckout(t);
+    const worktreePath = path.join(checkout, '.worktrees', `story-${STORY_ID}`);
+    nodeFs.mkdirSync(worktreePath, { recursive: true });
+
+    const calls = [];
+    mockCollaborators(t, calls);
+
+    const { runSingleStoryClose } = await import(
+      `${SUT_URL}?t=push-default-root`
+    );
+    await runSingleStoryClose(
+      closeArgs({
+        cwd: checkout,
+        config: { agentSettings: { baseBranch: 'main', commands: {} } },
+      }),
+    );
+
+    assert.equal(
+      path.resolve(findPush(calls).cwd),
+      path.resolve(worktreePath),
+      'the default .worktrees/story-<id> layout must be the push cwd',
+    );
+  });
+
   it('pushes from the Story worktree so pre-push validates the tree being sent', async (t) => {
     const worktreeRoot = nodeFs.mkdtempSync(
       path.join(os.tmpdir(), 'mandrel-push-tree-'),

--- a/tests/single-story-close-push-tree.test.js
+++ b/tests/single-story-close-push-tree.test.js
@@ -1,0 +1,280 @@
+// tests/single-story-close-push-tree.test.js — Issue #4990.
+//
+// Close ran `git push` in the caller's `--cwd` (the main checkout) while every
+// other tree-sensitive phase ran in the Story worktree. Because `core.hooksPath`
+// is the relative `.husky/_`, the invocation directory is what decides which
+// tree `pre-push` resolves and measures — so the gate reported on a tree that
+// was not being pushed. That failed in both directions: false red when the main
+// checkout sat on unrelated work, and false green whenever it happened to be
+// clean.
+//
+// `phases/push.js` owns the `worktreePath ?? cwd` resolution and is unit-tested
+// in `tests/lib/orchestration/single-story-close/push-phase.test.js`. The defect
+// itself was one level up — `openAndReviewPr` was never handed `worktreePath` at
+// all — so these tests drive the whole `runSingleStoryClose` pipeline and assert
+// on the working directory the push actually reached. A unit test on the phase
+// alone would have stayed green throughout the bug.
+
+import assert from 'node:assert/strict';
+import nodeFs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { describe, it } from 'node:test';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const REPO_ROOT = path
+  .resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
+  .replace(/\\/g, '/');
+
+const SUT_URL = pathToFileURL(
+  path.resolve(REPO_ROOT, '.agents/scripts/single-story-close.js'),
+).href;
+const GIT_UTILS_URL = pathToFileURL(
+  path.resolve(REPO_ROOT, '.agents/scripts/lib/git-utils.js'),
+).href;
+const CLOSE_VALIDATION_GATES_URL = pathToFileURL(
+  path.resolve(REPO_ROOT, '.agents/scripts/lib/close-validation/gates.js'),
+).href;
+const CLOSE_VALIDATION_RUNNER_URL = pathToFileURL(
+  path.resolve(REPO_ROOT, '.agents/scripts/lib/close-validation/runner.js'),
+).href;
+const WORKTREE_MANAGER_URL = pathToFileURL(
+  path.resolve(REPO_ROOT, '.agents/scripts/lib/worktree-manager.js'),
+).href;
+
+const STORY_ID = 4242;
+
+/**
+ * Record every `gitSync` invocation so the test can find the push and read the
+ * cwd it ran in. Mirrors `tests/single-story-close-sync.test.js#gitUtilsMock`,
+ * duplicated here so this file stays self-contained (DAMP over DRY).
+ *
+ * `gitSpawn` returns status 1 deliberately: the wrong-tree guard fails open on
+ * a non-zero status probe, which keeps this suite focused on the push cwd
+ * rather than on the guard's own behaviour.
+ */
+function gitUtilsMock(calls) {
+  return {
+    namedExports: {
+      getStoryBranch: (s) => `story-${Number(s)}`,
+      gitSync: (cwd, ...args) => {
+        calls.push({ cwd, args });
+        return { status: 0, stdout: '', stderr: '' };
+      },
+      gitFetchWithRetry: async () => ({ status: 0, stdout: '', stderr: '' }),
+      gitPullWithRetry: async () => ({ status: 0, stdout: '', stderr: '' }),
+      gitSpawn: () => ({ status: 1, stdout: '', stderr: '' }),
+      createGitInterface: () => ({
+        gitSync: () => '',
+        gitSpawn: () => ({ status: 0, stdout: '', stderr: '' }),
+        gitFetchWithRetry: async () => ({ status: 0, stdout: '', stderr: '' }),
+        gitPullWithRetry: async () => ({ status: 0, stdout: '', stderr: '' }),
+      }),
+    },
+  };
+}
+
+function mockCollaborators(t, calls) {
+  t.mock.module(GIT_UTILS_URL, gitUtilsMock(calls));
+  t.mock.module(CLOSE_VALIDATION_GATES_URL, {
+    namedExports: { buildDefaultGates: () => [] },
+  });
+  t.mock.module(CLOSE_VALIDATION_RUNNER_URL, {
+    namedExports: {
+      runCloseValidation: async () => ({ ok: true, failed: [] }),
+    },
+  });
+  t.mock.module(WORKTREE_MANAGER_URL, {
+    namedExports: {
+      WorktreeManager: class {
+        async reap() {}
+      },
+      parseWorktreePorcelain: () => [],
+    },
+  });
+}
+
+function makeFakeGh() {
+  const dispatch = async (args) => {
+    const wantsJson = Array.isArray(args) && args.includes('--json');
+    const raw = args[1] === 'create' ? 'https://github.com/o/r/pull/7' : '';
+    if (wantsJson) return [];
+    return { stdout: raw, stderr: '', code: 0 };
+  };
+  return {
+    pr: {
+      list: (flags = [], fields) =>
+        dispatch([
+          'pr',
+          'list',
+          ...flags,
+          ...(Array.isArray(fields) && fields.length
+            ? ['--json', fields.join(',')]
+            : []),
+        ]),
+      create: (flags = []) => dispatch(['pr', 'create', ...flags]),
+      merge: (id, flags = []) =>
+        dispatch(['pr', 'merge', String(id), ...flags]),
+    },
+  };
+}
+
+function fakeProvider() {
+  let story = {
+    id: STORY_ID,
+    state: 'open',
+    title: 'Push-tree test story',
+    labels: ['agent::executing'],
+  };
+  return {
+    getTicket: async () => ({ ...story, labels: [...story.labels] }),
+    getTicketComments: async () => [],
+    postComment: async () => ({ id: 901 }),
+    updateTicket: async (_id, patch) => {
+      if (patch.labels) {
+        const add = patch.labels.add ?? [];
+        const remove = patch.labels.remove ?? [];
+        story = {
+          ...story,
+          labels: [
+            ...story.labels.filter((l) => !remove.includes(l)),
+            ...add.filter((l) => !story.labels.includes(l)),
+          ],
+        };
+      }
+    },
+  };
+}
+
+/**
+ * `resolveWorktreePath` resolves `<cwd>/<root>/story-<id>` and probes it with
+ * `existsSync`. An ABSOLUTE `root` wins over `cwd` in `path.resolve`, so
+ * pointing it at a temp directory gives a deterministic worktree path without
+ * writing anything into the repository checkout.
+ */
+function fakeConfig(worktreeRoot) {
+  return {
+    agentSettings: { baseBranch: 'main', commands: {} },
+    delivery: {
+      worktreeIsolation: {
+        enabled: true,
+        root: worktreeRoot,
+        reapOnSuccess: false,
+      },
+    },
+  };
+}
+
+function closeArgs({ cwd, config }) {
+  return {
+    storyId: STORY_ID,
+    cwd,
+    injectedProvider: fakeProvider(),
+    injectedConfig: config,
+    skipSync: true,
+    noWaitForMerge: true,
+    injectedNotify: () => Promise.resolve(),
+    injectedGh: makeFakeGh(),
+    injectedRunCodeReview: async () => ({
+      status: 'ok',
+      severity: { critical: 0, high: 0, medium: 0, suggestion: 0 },
+      posted: false,
+      postedCommentId: null,
+      commentTargetId: 0,
+      halted: false,
+      blockerReason: null,
+    }),
+  };
+}
+
+function findPush(calls) {
+  const push = calls.find((c) => c.args[0] === 'push');
+  assert.ok(push, 'close must run a git push');
+  return push;
+}
+
+describe('single-story-close — which tree the close-time push runs in', () => {
+  it('pushes from the Story worktree so pre-push validates the tree being sent', async (t) => {
+    const worktreeRoot = nodeFs.mkdtempSync(
+      path.join(os.tmpdir(), 'mandrel-push-tree-'),
+    );
+    const worktreePath = path.join(worktreeRoot, `story-${STORY_ID}`);
+    nodeFs.mkdirSync(worktreePath, { recursive: true });
+    t.after(() =>
+      nodeFs.rmSync(worktreeRoot, { recursive: true, force: true }),
+    );
+
+    const calls = [];
+    mockCollaborators(t, calls);
+
+    const { runSingleStoryClose } = await import(`${SUT_URL}?t=push-worktree`);
+    await runSingleStoryClose(
+      closeArgs({ cwd: REPO_ROOT, config: fakeConfig(worktreeRoot) }),
+    );
+
+    const push = findPush(calls);
+    assert.deepEqual(push.args, ['push', '-u', 'origin', `story-${STORY_ID}`]);
+    assert.equal(
+      path.resolve(push.cwd),
+      path.resolve(worktreePath),
+      'the push must run in the Story worktree — pushing from the main ' +
+        'checkout makes pre-push measure a tree that is not being pushed',
+    );
+  });
+
+  it('falls back to the main checkout when no Story worktree exists on disk', async (t) => {
+    const worktreeRoot = nodeFs.mkdtempSync(
+      path.join(os.tmpdir(), 'mandrel-push-tree-'),
+    );
+    t.after(() =>
+      nodeFs.rmSync(worktreeRoot, { recursive: true, force: true }),
+    );
+
+    const calls = [];
+    mockCollaborators(t, calls);
+
+    const { runSingleStoryClose } = await import(
+      `${SUT_URL}?t=push-single-tree`
+    );
+    await runSingleStoryClose(
+      closeArgs({ cwd: REPO_ROOT, config: fakeConfig(worktreeRoot) }),
+    );
+
+    const push = findPush(calls);
+    assert.equal(
+      path.resolve(push.cwd),
+      path.resolve(REPO_ROOT),
+      'single-tree mode has no worktree — the main checkout IS the tree ' +
+        'being pushed',
+    );
+  });
+
+  it('pushes without a hook-bypass flag from the worktree', async (t) => {
+    const worktreeRoot = nodeFs.mkdtempSync(
+      path.join(os.tmpdir(), 'mandrel-push-tree-'),
+    );
+    nodeFs.mkdirSync(path.join(worktreeRoot, `story-${STORY_ID}`), {
+      recursive: true,
+    });
+    t.after(() =>
+      nodeFs.rmSync(worktreeRoot, { recursive: true, force: true }),
+    );
+
+    const calls = [];
+    mockCollaborators(t, calls);
+
+    const { runSingleStoryClose } = await import(`${SUT_URL}?t=push-no-bypass`);
+    await runSingleStoryClose(
+      closeArgs({ cwd: REPO_ROOT, config: fakeConfig(worktreeRoot) }),
+    );
+
+    const bypass = findPush(calls).args.filter((a) =>
+      ['--no-verify', '--no-gpg-sign'].includes(a),
+    );
+    assert.deepEqual(
+      bypass,
+      [],
+      'moving the push into the worktree must not relax the gate it runs',
+    );
+  });
+});

--- a/tests/single-story-close-push-tree.test.js
+++ b/tests/single-story-close-push-tree.test.js
@@ -17,10 +17,10 @@
 
 import assert from 'node:assert/strict';
 import nodeFs from 'node:fs';
-import os from 'node:os';
 import path from 'node:path';
 import { describe, it } from 'node:test';
 import { fileURLToPath, pathToFileURL } from 'node:url';
+import { makeTempDir } from '../.agents/scripts/lib/test-temp.js';
 
 const REPO_ROOT = path
   .resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
@@ -196,11 +196,17 @@ function findPush(calls) {
 /**
  * A throwaway checkout root, so the DEFAULT `.worktrees/story-<id>` layout can
  * be exercised without creating directories inside the repository.
+ *
+ * `makeTempDir` nests the directory in this process's suite root and registers
+ * its reaping structurally, so no per-test teardown is needed.
  */
-function tempCheckout(t) {
-  const root = nodeFs.mkdtempSync(path.join(os.tmpdir(), 'mandrel-checkout-'));
-  t.after(() => nodeFs.rmSync(root, { recursive: true, force: true }));
-  return root;
+function tempCheckout() {
+  return makeTempDir('push-tree-checkout-');
+}
+
+/** A bare worktree root for the configured-`root` cases. */
+function tempWorktreeRoot() {
+  return makeTempDir('push-tree-root-');
 }
 
 describe('single-story-close — which tree the close-time push runs in', () => {
@@ -208,7 +214,7 @@ describe('single-story-close — which tree the close-time push runs in', () => 
   // `worktreeIsolation.root` resolves `<cwd>/.worktrees/story-<id>`, which is
   // what a real delivery has on disk.
   it('pushes from <cwd>/.worktrees/story-<id> under the default worktree root', async (t) => {
-    const checkout = tempCheckout(t);
+    const checkout = tempCheckout();
     const worktreePath = path.join(checkout, '.worktrees', `story-${STORY_ID}`);
     nodeFs.mkdirSync(worktreePath, { recursive: true });
 
@@ -233,14 +239,9 @@ describe('single-story-close — which tree the close-time push runs in', () => 
   });
 
   it('pushes from the Story worktree so pre-push validates the tree being sent', async (t) => {
-    const worktreeRoot = nodeFs.mkdtempSync(
-      path.join(os.tmpdir(), 'mandrel-push-tree-'),
-    );
+    const worktreeRoot = tempWorktreeRoot();
     const worktreePath = path.join(worktreeRoot, `story-${STORY_ID}`);
     nodeFs.mkdirSync(worktreePath, { recursive: true });
-    t.after(() =>
-      nodeFs.rmSync(worktreeRoot, { recursive: true, force: true }),
-    );
 
     const calls = [];
     mockCollaborators(t, calls);
@@ -261,12 +262,7 @@ describe('single-story-close — which tree the close-time push runs in', () => 
   });
 
   it('falls back to the main checkout when no Story worktree exists on disk', async (t) => {
-    const worktreeRoot = nodeFs.mkdtempSync(
-      path.join(os.tmpdir(), 'mandrel-push-tree-'),
-    );
-    t.after(() =>
-      nodeFs.rmSync(worktreeRoot, { recursive: true, force: true }),
-    );
+    const worktreeRoot = tempWorktreeRoot();
 
     const calls = [];
     mockCollaborators(t, calls);
@@ -288,15 +284,10 @@ describe('single-story-close — which tree the close-time push runs in', () => 
   });
 
   it('pushes without a hook-bypass flag from the worktree', async (t) => {
-    const worktreeRoot = nodeFs.mkdtempSync(
-      path.join(os.tmpdir(), 'mandrel-push-tree-'),
-    );
+    const worktreeRoot = tempWorktreeRoot();
     nodeFs.mkdirSync(path.join(worktreeRoot, `story-${STORY_ID}`), {
       recursive: true,
     });
-    t.after(() =>
-      nodeFs.rmSync(worktreeRoot, { recursive: true, force: true }),
-    );
 
     const calls = [];
     mockCollaborators(t, calls);


### PR DESCRIPTION
Closes #4991

_Auto-opened by `/deliver`._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the close-time push working directory and hook behavior on the delivery path; scope is narrow and aligned with existing worktree-sensitive phases, but a bad fallback could still block or mis-gate pushes.
> 
> **Overview**
> **Single-story close** now runs `git push` from the Story worktree (when one exists) instead of the main `--cwd` checkout, so Husky **`pre-push`** inspects the same tree that is being sent to origin.
> 
> `pushStoryBranch` takes optional `worktreePath` and uses `worktreePath ?? cwd`, matching **base-sync** and **close-validation**. The close runner passes `worktreePath` into `openAndReviewPr`; PR/`gh` steps still use the main `cwd` because they read the shared `.git`.
> 
> **Tests** cover worktree vs fallback cwd at the phase level and end-to-end via `runSingleStoryClose`, including default `.worktrees/story-<id>` layout and no `--no-verify` on the delivery push.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6455efd64256a7892c46e0113b49e9dacb8e4111. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->