### PR TITLE
feat: give a delivery agent a way to exercise a Playwright `webServer` tier — attach-don't-boot seam, plus an `unreproducible-tier` CI verdict when no attachable origin exists (#4994)

### DIFF
--- a/.agents/rules/ci-remediation.md
+++ b/.agents/rules/ci-remediation.md
@@ -51,6 +51,7 @@ the two options above. Name the verdict you reached in the `friction` comment.
 | **defect-in-diff** | The failure reproduces on the branch and not on an unmodified `main` | Option 1 — fix at source |
 | **pre-existing** | The same check fails on an unmodified `main` too | Option 2 — file `meta::framework-gap`; remediate here only if it blocks this delivery |
 | **capacity** | Proven exhaustion of a runner resource, not a property of the diff (see below) | Option 2 — file `meta::framework-gap` **and** escalate to the operator |
+| **unreproducible-tier** | The tier cannot be exercised in this sandbox at all, proven by an attempted attach (see below) | Option 2 — file `meta::framework-gap` **and** escalate on first encounter |
 
 ### The `capacity` verdict
 
@@ -82,9 +83,45 @@ the operator, who owns the runner pool. Do not sit in a retry loop waiting for
 capacity to return.
 
 **Rerunning a failed job to reach green stays forbidden under every verdict,
-`capacity` included.** The verdict changes who owns the fix and where it is
+`capacity` and `unreproducible-tier` included.** The verdict changes who owns the fix and where it is
 filed; it never licenses a re-run, and it is not a route to a green bar. A
 capacity-blocked delivery ends `agent::blocked` — not merged.
+
+### The `unreproducible-tier` verdict
+
+A check can fail on a tier the sandbox cannot run at all — most often a
+browser suite whose Playwright `webServer` block supervises a dev server the
+local process manager daemonizes, which aborts the run with
+`Process from config.webServer exited early` before any test executes. The
+failure is a property of the sandbox's ability to *host* the suite, not of the
+diff.
+
+This is the same structural hole the `capacity` verdict was added to fill, one
+step earlier in the loop. Without it the honest reading is `flaky`, which routes
+to Option 1 — and fix-at-source requires reproducing the failure, which is the
+one thing that cannot be done. The agent then spends the full timebox
+rediscovering that before escalating anyway, and any fix it does author is
+written blind against a tier it never ran.
+
+**Unreproducible must be proven, not inferred.** "The suite did not run for me"
+is not the verdict — it is the symptom every misconfiguration produces. Cite
+both:
+
+- **The attempted attach.** Work the attach-don't-boot seam in the
+  [`playwright`](../skills/stack/qa/playwright/SKILL.md) skill — boot the server
+  out-of-band, point the suite at the running origin, set `reuseExistingServer`
+  — and name which step failed and how. A tier that runs once attached was never
+  unreproducible.
+- **The observed signature.** The verbatim line the runner aborted on, so a
+  later reader can tell a lifetime-ownership mismatch from a genuine boot
+  failure in the app under test.
+
+Absent both readings the verdict is unavailable and the failure routes as it did
+before. On the verdict: file the `meta::framework-gap` issue with the run link,
+the failure signature, and the attach attempt; flip the Story to
+`agent::blocked` with a `friction` comment naming the verdict; and hand back to
+the operator, who owns the sandbox. Do not author a fix for a tier you could not
+run — a blind fix to a suite nobody exercised is how the gap compounds.
 
 ## Verifier
 
@@ -131,3 +168,9 @@ operator under **any** of:
   signature) and escalate on the first encounter rather than burning iterations
   trying to code around it. A proven-capacity failure is this case: reach the
   `capacity` verdict above and escalate on the first encounter.
+- **Unrunnable tier → escalate immediately.** A tier the sandbox cannot host at
+  all is this case too: work the attach seam once, reach the
+  `unreproducible-tier` verdict above with its two readings, and escalate on the
+  **first encounter**. The 30-minute timebox is a ceiling here, never a budget
+  to spend — every minute past the failed attach buys nothing, because no
+  iteration can make an unhostable suite run.

--- a/.agents/skills/skills.index.json
+++ b/.agents/skills/skills.index.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-08-02T11:35:53.522Z",
+  "generatedAt": "2026-08-05T00:59:17.768Z",
   "generator": "generate-skills-index.js@1",
   "skills": [
     {
@@ -148,7 +148,7 @@
       "category": "qa",
       "path": ".agents/skills/stack/qa/playwright/SKILL.md",
       "description": "Robust E2E browser testing with Playwright. Use when writing browser-driven tests — leverage auto-waiting (no `waitForTimeout`), prefer user-visible locators (`getByRole`, `getByText`, `getByLabel`) over CSS/XPath, reuse `storageState` for auth, and enable trace-on-first-retry for CI debugging.",
-      "policyCapsuleBullets": 7,
+      "policyCapsuleBullets": 8,
       "allowedTools": null,
       "vendor": "playwright"
     },

--- a/.agents/skills/stack/qa/playwright/SKILL.md
+++ b/.agents/skills/stack/qa/playwright/SKILL.md
@@ -19,3 +19,51 @@ vendor: playwright
 - Write tests independent of one another so they run in parallel; clean up shared state in fixtures, not afterwards.
 - Enable `trace: 'on-first-retry'` (or `'retain-on-failure'`) so CI failures are debuggable in the Trace Viewer.
 - Use a unique data set per test run, or tear down state explicitly, to prevent cross-test contamination.
+- Never let Playwright own the lifetime of a dev server it did not start: boot the server out-of-band, point the suite at the running origin, and set `reuseExistingServer` so `webServer` only probes readiness.
+
+## Running a `webServer`-backed suite outside CI
+
+Playwright's `webServer` block **watches the process it spawned**. That
+assumption holds for a dev server that stays in the foreground, and breaks for
+any manager that daemonizes one — the foreground process exits `0` while the
+server keeps serving, Playwright reads the exit as a crash, and the run aborts
+before a single test executes:
+
+```text
+Process from config.webServer exited early
+```
+
+Read that line as a **lifetime-ownership mismatch, not a flake**. It reproduces
+on every invocation, clean tree or not, and no amount of retrying, tree-cleaning
+or timeout-raising changes it. Agent sandboxes and IDE harnesses commonly manage
+dev servers this way (`Dev server already running at … (pid N)`), so an agent
+meets this far more often than a developer does.
+
+### Attach, don't boot
+
+Invert the ownership instead of fighting it — the manager owns the process,
+Playwright owns only the probe:
+
+1. **Boot the server out-of-band** through whatever manages it, and confirm it
+   is serving. Its lifetime is now the manager's concern, not the runner's.
+2. **Point the suite at the already-running origin** — set the config's
+   `baseURL` (or the `webServer.url` the block probes) to that origin, via the
+   project's own environment seam rather than an edit to committed config.
+3. **Set `reuseExistingServer: true`** so Playwright probes the URL, finds it
+   live, and never spawns or supervises a process of its own.
+
+This is the same convention the QA harness already encodes as
+`qa.environments[].baseUrl`: attach to a running origin, never boot one. A suite
+run this way exercises identical browser behavior — only the process supervision
+differs.
+
+### When no attachable origin exists
+
+Some apps genuinely cannot be reached this way — the server is unreachable from
+the sandbox, or the suite depends on a build step the sandbox cannot run. Do
+**not** burn a timebox rediscovering that. Record the observed signature, state
+which of the three steps above failed, and escalate on the first encounter:
+that evidence is exactly what the `unreproducible-tier` verdict in
+[`ci-remediation.md`](../../../../rules/ci-remediation.md) requires, and it is
+the only verdict that lets an unrunnable tier route somewhere other than a dead
+end.

--- a/tests/contract/webserver-tier-prose-contract.test.js
+++ b/tests/contract/webserver-tier-prose-contract.test.js
@@ -1,0 +1,183 @@
+/**
+ * Story #4994 — contract tests over the `webServer`-tier prose.
+ *
+ * Both surfaces under test are executable in the only sense that matters: they
+ * are the instructions an agent runs on when a browser tier fails. The defect
+ * this Story fixed was entirely in the instructions — a delivery agent had no
+ * documented way to exercise a Playwright `webServer` suite, and the CI-triage
+ * rule offered no landing for a tier that genuinely cannot be run, so `flaky`
+ * dead-ended into a fix-at-source route that requires reproduction.
+ *
+ * No code test can catch a regression in prose, so these pin the claims that
+ * carry the behavior:
+ *
+ *  1. The `playwright` skill documents the attach-don't-boot seam, names the
+ *     abort signature verbatim, and carries the constraint in its Policy
+ *     Capsule (AC-1..AC-3).
+ *  2. `ci-remediation.md` defines the `unreproducible-tier` verdict, routes it
+ *     to Option 2, and gates it behind a proof bar (AC-4, AC-5).
+ *  3. Rerunning to green stays forbidden under every verdict, the new one
+ *     included (AC-6).
+ */
+
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { describe, it } from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+const REPO_ROOT = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '..',
+  '..',
+);
+
+const read = (rel) => readFileSync(path.join(REPO_ROOT, rel), 'utf8');
+
+const PLAYWRIGHT_SKILL = '.agents/skills/stack/qa/playwright/SKILL.md';
+const CI_REMEDIATION = '.agents/rules/ci-remediation.md';
+
+/**
+ * The verbatim line Playwright aborts on when it supervises a server that
+ * detaches. It is the recognition cue the whole seam hangs off — an agent that
+ * cannot match this string against the prose has to diagnose from scratch.
+ */
+const ABORT_SIGNATURE = 'Process from config.webServer exited early';
+
+describe("the playwright skill documents the attach-don't-boot seam (Story #4994, AC-1..AC-3)", () => {
+  it('names the abort signature verbatim', () => {
+    assert.ok(
+      read(PLAYWRIGHT_SKILL).includes(ABORT_SIGNATURE),
+      `${PLAYWRIGHT_SKILL} must quote "${ABORT_SIGNATURE}" so the failure is recognized on sight rather than re-diagnosed`,
+    );
+  });
+
+  it('names reuseExistingServer as the mechanism', () => {
+    assert.match(
+      read(PLAYWRIGHT_SKILL),
+      /reuseExistingServer/,
+      `${PLAYWRIGHT_SKILL} must name reuseExistingServer — it is what stops Playwright supervising a process it did not start`,
+    );
+  });
+
+  it('states that Playwright must never own a server it did not start', () => {
+    const text = read(PLAYWRIGHT_SKILL).toLowerCase();
+    assert.ok(
+      text.includes('never let playwright own the lifetime') ||
+        text.includes('never own the lifetime'),
+      `${PLAYWRIGHT_SKILL} must state the lifetime-ownership constraint, not merely the mechanism`,
+    );
+  });
+
+  it('carries the constraint in the Policy Capsule, not only the body', () => {
+    const text = read(PLAYWRIGHT_SKILL);
+    const capsuleStart = text.indexOf('## Policy Capsule');
+    assert.notEqual(
+      capsuleStart,
+      -1,
+      `${PLAYWRIGHT_SKILL} must keep its Policy Capsule heading`,
+    );
+    // The capsule runs to the next h2; a constraint below that line is invisible
+    // on engagement, which is the whole point of the capsule.
+    const afterCapsule = text.indexOf('\n## ', capsuleStart + 1);
+    const capsule = text.slice(
+      capsuleStart,
+      afterCapsule === -1 ? text.length : afterCapsule,
+    );
+    assert.match(
+      capsule,
+      /reuseExistingServer/,
+      `${PLAYWRIGHT_SKILL}'s Policy Capsule must carry the seam — a constraint only in the body is not read on engagement`,
+    );
+  });
+
+  it('gives an ordered procedure and a bounded fallback', () => {
+    const text = read(PLAYWRIGHT_SKILL);
+    assert.match(
+      text,
+      /1\.\s+\*\*Boot the server out-of-band/,
+      `${PLAYWRIGHT_SKILL} must give the ordered boot-then-attach procedure`,
+    );
+    assert.match(
+      text,
+      /When no attachable origin exists/,
+      `${PLAYWRIGHT_SKILL} must name the fallback for a tier with no attachable origin`,
+    );
+    assert.match(
+      text,
+      /unreproducible-tier/,
+      `${PLAYWRIGHT_SKILL}'s fallback must route to the ci-remediation verdict rather than dead-ending`,
+    );
+  });
+});
+
+describe('ci-remediation defines the unreproducible-tier verdict (Story #4994, AC-4..AC-6)', () => {
+  it('lists the verdict in the Verdicts table routing to Option 2', () => {
+    const row = read(CI_REMEDIATION)
+      .split('\n')
+      .find(
+        (line) =>
+          line.startsWith('|') && line.includes('**unreproducible-tier**'),
+      );
+    assert.ok(row, `${CI_REMEDIATION} must carry an unreproducible-tier row`);
+    assert.match(
+      row,
+      /Option 2/,
+      'the unreproducible-tier verdict must route to Option 2 — Option 1 requires a reproduction that is by definition unavailable',
+    );
+    assert.match(
+      row,
+      /meta::framework-gap/,
+      'the verdict must name the label the escalation is filed under',
+    );
+  });
+
+  it('gates the verdict behind a proof bar, as capacity is', () => {
+    const text = read(CI_REMEDIATION);
+    assert.match(
+      text,
+      /\*\*Unreproducible must be proven, not inferred\.\*\*/,
+      `${CI_REMEDIATION} must carry the proof bar — without it the verdict launders any suite an agent failed to run`,
+    );
+    assert.match(
+      text,
+      /The attempted attach/,
+      'the proof bar must require the attach attempt to have been worked',
+    );
+    assert.match(
+      text,
+      /The observed signature/,
+      'the proof bar must require the observed abort signature',
+    );
+    assert.match(
+      text,
+      /the verdict is unavailable and the failure routes as it did\s+before/,
+      'the prose must state what happens when the evidence is absent',
+    );
+  });
+
+  it('escalates on first encounter rather than spending the timebox', () => {
+    assert.match(
+      read(CI_REMEDIATION),
+      /Unrunnable tier → escalate immediately/,
+      `${CI_REMEDIATION} must route the verdict through the immediate-escalation branch — the cost this Story removes is the burned timebox`,
+    );
+  });
+
+  it('still forbids rerunning to green under every verdict, the new one included', () => {
+    const text = read(CI_REMEDIATION);
+    assert.match(
+      text,
+      /Rerunning a failed job to reach green stays forbidden under every verdict,\s+`capacity` and `unreproducible-tier` included\./,
+      `${CI_REMEDIATION} must keep the rerun prohibition total — a new verdict must not read as a new exemption`,
+    );
+  });
+
+  it('points at the skill for the seam instead of restating it', () => {
+    assert.match(
+      read(CI_REMEDIATION),
+      /skills\/stack\/qa\/playwright\/SKILL\.md/,
+      `${CI_REMEDIATION} must cite the playwright skill — the seam has one prose home`,
+    );
+  });
+});


### PR DESCRIPTION
Closes #4994

_Auto-opened by `/deliver`._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Agent-facing documentation and contract tests only; no runtime, CI, or application code paths change.
> 
> **Overview**
> Documents how delivery agents should run Playwright **`webServer`** suites in sandboxes where the dev server is already managed (attach via **`reuseExistingServer`** instead of letting Playwright supervise the process), and adds a CI triage path when that tier still cannot be exercised.
> 
> The **playwright** skill gains an **attach, don't boot** procedure (out-of-band boot, point at the running origin, **`reuseExistingServer`**), quotes the **`Process from config.webServer exited early`** signature, and puts the lifetime-ownership rule in the Policy Capsule. **`ci-remediation.md`** adds the **`unreproducible-tier`** verdict (proof: attempted attach + observed signature → Option 2 / **`meta::framework-gap`**, escalate on first encounter), extends the no-rerun-to-green rule to include it, and adds an immediate-escalation branch for unrunnable tiers. **`skills.index.json`** reflects the extra capsule bullet; **`tests/contract/webserver-tier-prose-contract.test.js`** pins the prose so those instructions do not regress.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2f1561242c6954bd74613fd312b90361da11025b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->