### PR TITLE
feat(quality): derive knip's CLI entry list instead of trusting memory

### DIFF
--- a/.agents/scripts/check-knip-entries.js
+++ b/.agents/scripts/check-knip-entries.js
@@ -1,0 +1,140 @@
+#!/usr/bin/env node
+
+// .agents/scripts/check-knip-entries.js — the guard #5001 left unbuilt.
+//
+// Story #5001 made two changes that are individually right and jointly unsafe:
+// it replaced knip's blanket `.agents/scripts/*.js!` entry glob with an
+// explicit list (so an uninvoked CLI surfaces as dead), and it promoted knip's
+// `files` rule to `error` (so whole-file death produces baseline rows). The
+// explicit list is hand-maintained; nothing checked it.
+//
+// So any CLI added after #5001 is, by default, invisible to knip: absent from
+// the entry list, it reads as unreachable, emits a `{ file, symbol: '*' }` row,
+// and drags every lib module only it imports into the dead set with it. Story
+// #5012 hit exactly this — 5 false rows — and the ratchet's natural remedy
+// (accept the diff) would have written live operator CLIs into
+// `baselines/dead-exports-production.json` as expected-dead, permanently. It
+// was caught by luck: a base-sync conflict forced a manual read of the diff.
+//
+// This gate removes the luck. It derives the invoked set from the executable
+// surfaces #5001's own acceptance criterion named — package.json scripts, husky
+// hooks, `.github/workflows`, `.agents` workflow/skill/agent/rule markdown, and
+// script-to-script spawns — and asserts it matches `knip.json`'s entry array in
+// both directions. See `lib/knip-entry-sync.js` for why liveness means
+// *invoked* rather than *present*, and why documentation prose does not count.
+//
+// Measurement-free by construction: no knip spawn, no scorer, no coverage
+// artifact. It is a directory read and a handful of regexes, which is what
+// makes it cheap enough to sit in the required-check set next to
+// `check-baseline-scope.js`.
+//
+// Exit codes:
+//   0  entry list matches the invoked set
+//   1  divergence — a missing, stale, or phantom entry
+//   2  the check could not run (unreadable knip.json, unusable repository)
+
+import process from 'node:process';
+import { runAsCli } from './lib/cli-utils.js';
+import {
+  renderEntrySyncReport,
+  resolveEntrySync,
+} from './lib/knip-entry-sync.js';
+
+const EXIT_PASS = 0;
+const EXIT_DIVERGED = 1;
+const EXIT_CANNOT_RUN = 2;
+
+const HELP = {
+  invocation:
+    'node .agents/scripts/check-knip-entries.js [--cwd <dir>] [--json]',
+  summary:
+    "Assert knip.json's explicit .agents/scripts entry list matches the set of CLIs something actually invokes.",
+  flags: [
+    ['--cwd <dir>', 'Repository root to check. Default: process.cwd().'],
+    ['--json', 'Emit the report as JSON instead of text.'],
+  ],
+  notes: [
+    'Exit codes:\n  0  entry list matches\n  1  divergence\n  2  the check could not run',
+    'A missing entry is the dangerous one: knip calls the CLI dead, and accepting\nthe dead-exports diff would record a live CLI as expected-dead (Story #5012).',
+  ],
+};
+
+/**
+ * Parse argv into an options bag. An unknown flag is a config error rather than
+ * a silent no-op, matching `check-baseline-scope.js`.
+ *
+ * @param {string[]} argv
+ * @returns {{ cwd: string | null, json: boolean }}
+ */
+export function parseArgs(argv = []) {
+  const out = { cwd: null, json: false };
+  let i = 0;
+  while (i < argv.length) {
+    const arg = argv[i];
+    i += 1;
+    if (arg === '--json') out.json = true;
+    else if (arg === '--cwd') {
+      out.cwd = argv[i];
+      i += 1;
+    } else throw new Error(`unknown flag "${arg}" (try --help)`);
+  }
+  return out;
+}
+
+/**
+ * Top-level CLI entry. Exported so tests can drive it against a fixture tree
+ * without spawning a process.
+ *
+ * @param {{
+ *   argv?: string[],
+ *   cwd?: string,
+ *   stdout?: { write: (s: string) => void },
+ *   stderr?: { write: (s: string) => void },
+ * }} [opts]
+ * @returns {Promise<number>} 0 pass, 1 divergence, 2 cannot run
+ */
+export async function runCli({
+  argv = process.argv.slice(2),
+  cwd = process.cwd(),
+  stdout = process.stdout,
+  stderr = process.stderr,
+} = {}) {
+  let args;
+  try {
+    args = parseArgs(argv);
+  } catch (err) {
+    stderr.write(`[knip-entries] ❌ ${err?.message ?? String(err)}\n`);
+    return EXIT_CANNOT_RUN;
+  }
+  const repoRoot = args.cwd ?? cwd;
+  const report = resolveEntrySync({ repoRoot });
+
+  if (args.json) {
+    stdout.write(
+      `${JSON.stringify({ kind: 'knip-entry-sync', ...report }, null, 2)}\n`,
+    );
+    if (report.error) return EXIT_CANNOT_RUN;
+    return report.missing.length + report.stale.length + report.phantom.length >
+      0
+      ? EXIT_DIVERGED
+      : EXIT_PASS;
+  }
+
+  if (report.error) {
+    stderr.write(`[knip-entries] ❌ ${report.error}\n`);
+    return EXIT_CANNOT_RUN;
+  }
+
+  stdout.write(`\n--- knip-entries ---\n`);
+  stdout.write(`${renderEntrySyncReport(report)}\n`);
+  return report.missing.length + report.stale.length + report.phantom.length > 0
+    ? EXIT_DIVERGED
+    : EXIT_PASS;
+}
+
+runAsCli(import.meta.url, async () => runCli(), {
+  source: 'knip-entries',
+  propagateExitCode: true,
+  errorPrefix: '[knip-entries] ❌ Fatal error',
+  usage: HELP,
+});

--- a/.agents/scripts/lib/knip-entry-sync.js
+++ b/.agents/scripts/lib/knip-entry-sync.js
@@ -1,0 +1,403 @@
+/**
+ * knip-entry-sync.js — derive which top-level `.agents/scripts/*.js` CLIs are
+ * actually invoked, and diff that set against `knip.json`'s `entry` array.
+ *
+ * Why this exists (Story #5001 → the #5012 near-miss):
+ *
+ * #5001 replaced the blanket `.agents/scripts/*.js!` entry glob with an
+ * explicit list, precisely so that a top-level CLI **nothing invokes** stops
+ * being declared live by the glob and surfaces as dead. It simultaneously
+ * promoted knip's `files` rule to `error`, so whole-file death now produces
+ * `{ file, symbol: '*' }` baseline rows.
+ *
+ * That pairing has a silent failure mode. A CLI added *after* #5001 is not in
+ * the hand-written list, so knip reads it as unreachable and emits a whole-file
+ * row for it — plus transitive rows for every lib module only that CLI imports.
+ * During #5012's delivery this produced 5 false rows (`check-baseline-scope.js`,
+ * `prune-baseline-orphans.js`, and their three `lib/baselines/*` modules). The
+ * natural remedy — accept the ratchet's diff — would have permanently recorded
+ * live, working operator CLIs as expected-dead, blinding the ratchet to their
+ * real death later. It was caught only because a base-sync conflict forced a
+ * manual read of the diff.
+ *
+ * The fix is to stop depending on a human remembering to edit `knip.json`.
+ * #5001's own wording already names the derivation rule — entries are derived
+ * "from what package.json scripts, husky hooks, .github/workflows, and the
+ * .agents workflow/skill markdown actually invoke". This module mechanizes
+ * exactly that rule and asserts it in both directions:
+ *
+ *   missing — invoked by a real caller but absent from `entry`. This is the
+ *     #5012 bug: knip will call it dead and the ratchet will offer to record
+ *     the lie.
+ *   stale — listed in `entry` but invoked by nothing. This is the blind spot
+ *     #5001 closed: a declared entry point is immortal, so its death can never
+ *     surface.
+ *
+ * Deliberately NOT a filesystem-derived list. Restoring `.agents/scripts/*.js!`
+ * — or regenerating the array from `readdirSync` — would make every file live
+ * by construction and undo #5001's AC-2. Liveness here means *invoked*, not
+ * *present*.
+ *
+ * Deliberately NOT conferred by documentation prose. `.agents/docs/**` and
+ * `docs/**` describe operator-run commands; a paragraph naming a CLI is not a
+ * caller. Four CLIs are named only in prose today
+ * (`check-baseline-drift.js`, `post-structured-comment.js`,
+ * `provision-git-hooks.js`, `validate-docs-freshness.js`) and #5001 recorded
+ * all four as whole-file dead rows on purpose. Counting prose would silently
+ * resurrect them.
+ *
+ * A CLI that is only *imported* by another script (`cleanup-repo-test-temp.js`,
+ * imported by `run-tests.js` and `run-coverage.js`) is correctly neither: it is
+ * reachable through the module graph from a real entry, so knip already sees it
+ * and it must not be declared an entry point of its own.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+
+// Only `resolveEntrySync` and `renderEntrySyncReport` are public — they are
+// what `check-knip-entries.js` calls. Everything else is module-private and
+// reached by the suite through the `__testing` bundle at the foot of this file,
+// the same seam `source-classifier.js` and five sibling modules use. Exporting
+// the internals individually would put seven test-only symbols on the
+// production dead-export baseline and make private helpers look like API.
+
+/** Top-level CLI directory, repo-relative. */
+const SCRIPTS_DIR = path.join('.agents', 'scripts');
+
+/**
+ * Executable surfaces — a mention of a CLI here is an instruction to run it.
+ *
+ * `dirs` entries are walked recursively and filtered by `test`. `files` are
+ * read directly. Documentation trees are absent by design (see module header).
+ *
+ * @type {ReadonlyArray<{ kind: 'file' | 'dir', at: string, test?: RegExp }>}
+ */
+const INVOCATION_SURFACES = Object.freeze([
+  { kind: 'file', at: 'package.json' },
+  { kind: 'dir', at: '.husky', test: /^(?!.*[/\\]_[/\\]).*$/ },
+  { kind: 'dir', at: path.join('.github', 'workflows'), test: /\.ya?ml$/ },
+  { kind: 'dir', at: path.join('.agents', 'workflows'), test: /\.md$/ },
+  { kind: 'dir', at: path.join('.agents', 'skills'), test: /\.md$/ },
+  { kind: 'dir', at: path.join('.agents', 'agents'), test: /\.md$/ },
+  { kind: 'dir', at: path.join('.agents', 'rules'), test: /\.md$/ },
+  { kind: 'dir', at: SCRIPTS_DIR, test: /\.js$/ },
+]);
+
+/**
+ * Strip line and block comments from JavaScript source, preserving string and
+ * template literals so a `'https://…'` or a `` `${x}//y` `` is not mangled.
+ *
+ * Comments are stripped before scanning `.js` surfaces so a JSDoc paragraph
+ * that merely *names* a CLI ("superseded by `node .agents/scripts/foo.js`")
+ * cannot confer liveness on it. Several such mentions exist today; every one
+ * of them is prose about a script's internals, not a call.
+ *
+ * Replaces comment bodies with equivalent whitespace rather than deleting
+ * them, so byte offsets and line numbers survive for any future caller that
+ * wants to report a position.
+ *
+ * @param {string} source
+ * @returns {string}
+ */
+function stripJsComments(source) {
+  const text = String(source ?? '');
+  let out = '';
+  let i = 0;
+  const blank = (s) => s.replace(/[^\n]/g, ' ');
+  while (i < text.length) {
+    const two = text.slice(i, i + 2);
+    if (two === '//') {
+      const end = text.indexOf('\n', i);
+      const stop = end === -1 ? text.length : end;
+      out += blank(text.slice(i, stop));
+      i = stop;
+    } else if (two === '/*') {
+      const end = text.indexOf('*/', i + 2);
+      const stop = end === -1 ? text.length : end + 2;
+      out += blank(text.slice(i, stop));
+      i = stop;
+    } else {
+      const ch = text[i];
+      if (ch === "'" || ch === '"' || ch === '`') {
+        let j = i + 1;
+        while (j < text.length) {
+          if (text[j] === '\\') {
+            j += 2;
+            continue;
+          }
+          if (text[j] === ch) break;
+          j += 1;
+        }
+        const stop = Math.min(j + 1, text.length);
+        out += text.slice(i, stop);
+        i = stop;
+      } else {
+        out += ch;
+        i += 1;
+      }
+    }
+  }
+  return out;
+}
+
+/**
+ * Recursively list files under `dir`, skipping `node_modules` and `.git`.
+ *
+ * @param {string} dir absolute path
+ * @param {typeof fs} fsImpl
+ * @param {string[]} [acc]
+ * @returns {string[]} absolute file paths
+ */
+function walk(dir, fsImpl, acc = []) {
+  let entries;
+  try {
+    entries = fsImpl.readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return acc;
+  }
+  for (const entry of entries) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (entry.name === 'node_modules' || entry.name === '.git') continue;
+      walk(full, fsImpl, acc);
+    } else {
+      acc.push(full);
+    }
+  }
+  return acc;
+}
+
+/**
+ * Read every executable surface under `repoRoot`.
+ *
+ * `.js` surfaces arrive comment-stripped; every other surface arrives verbatim.
+ * Test files are excluded: a test importing or naming a CLI does not make it
+ * invoked, which is the same test-only-importer discount `--production` applies
+ * to the dead-exports ratchet itself.
+ *
+ * @param {{ repoRoot: string, fsImpl?: typeof fs }} opts
+ * @returns {Array<{ path: string, text: string }>} repo-relative path + content
+ */
+function collectInvocationSurfaces({ repoRoot, fsImpl = fs }) {
+  const surfaces = [];
+  const push = (absolute) => {
+    const rel = path.relative(repoRoot, absolute);
+    if (rel.includes('__tests__') || /\.test\.[cm]?js$/.test(rel)) return;
+    let text;
+    try {
+      text = fsImpl.readFileSync(absolute, 'utf8');
+    } catch {
+      return;
+    }
+    surfaces.push({
+      path: rel.split(path.sep).join('/'),
+      text: rel.endsWith('.js') ? stripJsComments(text) : text,
+    });
+  };
+
+  for (const surface of INVOCATION_SURFACES) {
+    const absolute = path.join(repoRoot, surface.at);
+    if (surface.kind === 'file') {
+      push(absolute);
+      continue;
+    }
+    for (const file of walk(absolute, fsImpl)) {
+      const rel = path.relative(repoRoot, file);
+      if (surface.test && !surface.test.test(rel)) continue;
+      push(file);
+    }
+  }
+  return surfaces;
+}
+
+/**
+ * Build the two recognizers for one CLI basename.
+ *
+ * `pathLiteral` — the CLI named by its repo path (`.agents/scripts/foo.js`),
+ *   in either separator style. This is how package.json scripts, husky hooks,
+ *   workflow `run:` blocks and workflow markdown spell an invocation.
+ *
+ * `joinedSpawn` — the CLI named by bare basename as the tail of a
+ *   `path.join(…, 'scripts', 'foo.js')` construction, which is how
+ *   `lib/bootstrap/project-bootstrap.js` spawns `check-windows-git-perf.js`
+ *   into a consumer checkout. Requiring the `'scripts'` sibling argument is
+ *   what separates a real spawn from the several *data* inventories that list
+ *   the same basenames as plain array elements (`source-classifier.js`'s
+ *   `FRAMEWORK_SCRIPT_BASENAMES`, `check-lifecycle-lint.js`'s allowlist) —
+ *   those are catalogues of names, not calls.
+ *
+ * @param {string} cli basename, e.g. `check-dead-exports.js`
+ * @returns {{ pathLiteral: RegExp, joinedSpawn: RegExp }}
+ */
+function buildInvocationPatterns(cli) {
+  const escaped = cli.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  return {
+    pathLiteral: new RegExp(`\\.agents[/\\\\]scripts[/\\\\]${escaped}`),
+    joinedSpawn: new RegExp(
+      `['"\`]scripts['"\`]\\s*,\\s*['"\`]${escaped}['"\`]`,
+    ),
+  };
+}
+
+/**
+ * List the top-level CLI basenames actually present in `.agents/scripts/`.
+ *
+ * @param {{ repoRoot: string, fsImpl?: typeof fs }} opts
+ * @returns {string[]} sorted basenames
+ */
+function listTopLevelClis({ repoRoot, fsImpl = fs }) {
+  let entries;
+  try {
+    entries = fsImpl.readdirSync(path.join(repoRoot, SCRIPTS_DIR), {
+      withFileTypes: true,
+    });
+  } catch {
+    return [];
+  }
+  return entries
+    .filter((e) => e.isFile() && e.name.endsWith('.js'))
+    .map((e) => e.name)
+    .sort();
+}
+
+/**
+ * Read the top-level `.agents/scripts/*.js` basenames declared in `knip.json`'s
+ * `entry` array. Glob-bearing patterns are ignored — this reads the explicit
+ * enumeration only, which is the surface #5001 made authoritative.
+ *
+ * @param {{ repoRoot: string, fsImpl?: typeof fs }} opts
+ * @returns {{ entries: string[], error: string | null }}
+ */
+function readKnipEntries({ repoRoot, fsImpl = fs }) {
+  const configPath = path.join(repoRoot, 'knip.json');
+  let parsed;
+  try {
+    parsed = JSON.parse(fsImpl.readFileSync(configPath, 'utf8'));
+  } catch (error) {
+    return { entries: [], error: `cannot read knip.json: ${error.message}` };
+  }
+  if (!Array.isArray(parsed?.entry)) {
+    return { entries: [], error: 'knip.json has no "entry" array' };
+  }
+  const prefix = '.agents/scripts/';
+  const entries = parsed.entry
+    .filter((e) => typeof e === 'string' && e.startsWith(prefix))
+    .map((e) => e.replace(/!$/, ''))
+    .filter((e) => !e.includes('*'))
+    .map((e) => e.slice(prefix.length))
+    .filter((e) => !e.includes('/'));
+  return { entries: [...new Set(entries)].sort(), error: null };
+}
+
+/**
+ * Resolve the full entry-sync report for a repository.
+ *
+ * @param {{ repoRoot: string, fsImpl?: typeof fs }} opts
+ * @returns {{
+ *   error: string | null,
+ *   clis: string[],
+ *   declared: string[],
+ *   missing: Array<{ cli: string, invokers: string[] }>,
+ *   stale: string[],
+ *   phantom: string[],
+ * }}
+ *   `missing` — invoked but not declared (the #5012 bug).
+ *   `stale` — declared but invoked by nothing.
+ *   `phantom` — declared but no such file on disk (a rename left the list behind).
+ */
+export function resolveEntrySync({ repoRoot, fsImpl = fs }) {
+  const { entries: declared, error } = readKnipEntries({ repoRoot, fsImpl });
+  const empty = { clis: [], declared, missing: [], stale: [], phantom: [] };
+  if (error) return { error, ...empty };
+
+  const clis = listTopLevelClis({ repoRoot, fsImpl });
+  if (clis.length === 0) {
+    return { error: `no CLIs found under ${SCRIPTS_DIR}`, ...empty };
+  }
+  const surfaces = collectInvocationSurfaces({ repoRoot, fsImpl });
+  const declaredSet = new Set(declared);
+
+  const missing = [];
+  const stale = [];
+  for (const cli of clis) {
+    const self = `${SCRIPTS_DIR.split(path.sep).join('/')}/${cli}`;
+    const { pathLiteral, joinedSpawn } = buildInvocationPatterns(cli);
+    const invokers = surfaces
+      .filter(
+        (s) =>
+          s.path !== self &&
+          (pathLiteral.test(s.text) ||
+            (s.path.endsWith('.js') && joinedSpawn.test(s.text))),
+      )
+      .map((s) => s.path);
+    const isDeclared = declaredSet.has(cli);
+    if (invokers.length > 0 && !isDeclared) missing.push({ cli, invokers });
+    if (invokers.length === 0 && isDeclared) stale.push(cli);
+  }
+
+  const onDisk = new Set(clis);
+  const phantom = declared.filter((cli) => !onDisk.has(cli));
+
+  return { error: null, clis, declared, missing, stale, phantom };
+}
+
+/**
+ * Render the human-readable report. Each divergence names its own remedy —
+ * the whole point of the gate is that the *wrong* remedy (accepting the
+ * dead-exports ratchet's diff) is the tempting one.
+ *
+ * @param {ReturnType<typeof resolveEntrySync>} report
+ * @returns {string}
+ */
+export function renderEntrySyncReport(report) {
+  const lines = [];
+  for (const { cli, invokers } of report.missing) {
+    lines.push(
+      `+ ${cli} — invoked by ${invokers.slice(0, 3).join(', ')}${
+        invokers.length > 3 ? ` (+${invokers.length - 3} more)` : ''
+      }`,
+    );
+    lines.push(
+      `    add ".agents/scripts/${cli}!" to knip.json "entry" — until you do, knip`,
+    );
+    lines.push(
+      '    reads it as unreachable and check-dead-exports will offer a false whole-file row.',
+    );
+  }
+  for (const cli of report.stale) {
+    lines.push(
+      `- ${cli} — declared in knip.json "entry" but nothing invokes it`,
+    );
+    lines.push(
+      '    remove the entry so its death can surface, or wire up the caller.',
+    );
+  }
+  for (const cli of report.phantom) {
+    lines.push(`? ${cli} — declared in knip.json "entry" but not on disk`);
+    lines.push('    drop the stale path (the file was renamed or removed).');
+  }
+  const total =
+    report.missing.length + report.stale.length + report.phantom.length;
+  lines.push(
+    `[knip-entries] clis=${report.clis.length} declared=${report.declared.length} ` +
+      `missing=${report.missing.length} stale=${report.stale.length} ` +
+      `phantom=${report.phantom.length} ${total > 0 ? '(gate fail)' : '(ok)'}`,
+  );
+  return lines.join('\n');
+}
+
+/**
+ * Test-only seam. Not API: these helpers are exercised directly by
+ * `tests/check-knip-entries.test.js` so the recognizers can be pinned
+ * independently of a full fixture tree.
+ */
+export const __testing = Object.freeze({
+  buildInvocationPatterns,
+  collectInvocationSurfaces,
+  INVOCATION_SURFACES,
+  listTopLevelClis,
+  readKnipEntries,
+  SCRIPTS_DIR,
+  stripJsComments,
+});

--- a/.agents/scripts/lib/observability/source-classifier.js
+++ b/.agents/scripts/lib/observability/source-classifier.js
@@ -94,6 +94,7 @@ const FRAMEWORK_SCRIPT_BASENAMES = Object.freeze([
   'check-cyclomatic.js',
   'check-dead-exports.js',
   'check-doc-links.js',
+  'check-knip-entries.js',
   'check-lifecycle-doc-drift.js',
   'check-lifecycle-lint.js',
   'check-schema-references.js',

--- a/.agents/scripts/run-verify.js
+++ b/.agents/scripts/run-verify.js
@@ -45,44 +45,38 @@
 import { spawnSync } from 'node:child_process';
 import { runAsCli } from './lib/cli-utils.js';
 
+/**
+ * A gate step: `node .agents/scripts/<script>` plus any extra args. Seven of
+ * the ten steps share exactly that shape, so spelling it once leaves the list
+ * below readable as what it actually is — a gate *order* — instead of a wall
+ * of spawn tuples.
+ *
+ * @param {string} label reported as `failedStep` when the gate exits non-zero
+ * @param {string} script basename under `.agents/scripts/`
+ * @param {...string} args extra CLI args
+ * @returns {{ label: string, cmd: string, args: string[] }}
+ */
+const gate = (label, script, ...args) => ({
+  label,
+  cmd: 'node',
+  args: [`.agents/scripts/${script}`, ...args],
+});
+
 const STEPS = [
-  {
-    label: 'audit',
-    cmd: 'npm',
-    args: ['audit', '--audit-level=high'],
-  },
+  { label: 'audit', cmd: 'npm', args: ['audit', '--audit-level=high'] },
   { label: 'lint', cmd: 'npm', args: ['run', 'lint'] },
   { label: 'test', cmd: 'npm', args: ['test'] },
-  {
-    label: 'baselines',
-    cmd: 'node',
-    args: ['.agents/scripts/check-baselines.js'],
-  },
-  {
-    label: 'dead-exports',
-    cmd: 'node',
-    args: ['.agents/scripts/check-dead-exports.js'],
-  },
-  {
-    label: 'dead-exports-production',
-    cmd: 'node',
-    args: ['.agents/scripts/check-dead-exports.js', '--production'],
-  },
-  {
-    label: 'context-budget',
-    cmd: 'node',
-    args: ['.agents/scripts/check-context-budget.js'],
-  },
-  {
-    label: 'cyclomatic',
-    cmd: 'node',
-    args: ['.agents/scripts/check-cyclomatic.js'],
-  },
-  {
-    label: 'schema-references',
-    cmd: 'node',
-    args: ['.agents/scripts/check-schema-references.js'],
-  },
+  gate('baselines', 'check-baselines.js'),
+  // Ordered ahead of the dead-exports pair deliberately. When a new CLI is
+  // missing from knip.json's entry list, both gates fail — but only this one
+  // names the cause. Seeing the ratchet's whole-file diff first is what made
+  // "accept the diff" look like the fix during Story #5012.
+  gate('knip-entries', 'check-knip-entries.js'),
+  gate('dead-exports', 'check-dead-exports.js'),
+  gate('dead-exports-production', 'check-dead-exports.js', '--production'),
+  gate('context-budget', 'check-context-budget.js'),
+  gate('cyclomatic', 'check-cyclomatic.js'),
+  gate('schema-references', 'check-schema-references.js'),
 ];
 
 export function runVerifySteps({

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -259,8 +259,21 @@ jobs:
         # `--check` keeps `main` honest about there being nothing left to prune.
         # Both are measurement-free — no scorer, no coverage artifact — so they
         # cost milliseconds and need no test run to have happened.
+        #
+        # `check-knip-entries.js` runs ahead of the dead-exports pair it exists
+        # to protect. #5001 made knip's entry list explicit (so an uninvoked CLI
+        # surfaces as dead) and its `files` rule fatal (so whole-file death
+        # produces rows) — but left the list hand-maintained. A CLI added after
+        # #5001 is therefore unreachable to knip by default and emits a false
+        # whole-file row, dragging its private lib modules along; #5012 produced
+        # 5 such rows and was one accepted ratchet diff away from recording live
+        # operator CLIs as expected-dead. This gate derives the invoked set from
+        # the executable surfaces #5001's own AC-2 named and asserts it matches
+        # the list, so the failure names its cause instead of arriving disguised
+        # as debt.
         run: |
           node .agents/scripts/check-arch-cycles.js --format text
+          node .agents/scripts/check-knip-entries.js
           node .agents/scripts/check-dead-exports.js
           node .agents/scripts/check-dead-exports.js --production
           node .agents/scripts/check-context-budget.js

--- a/baselines/coverage.json
+++ b/baselines/coverage.json
@@ -1,12 +1,12 @@
 {
   "$schema": ".agents/schemas/baselines/coverage.schema.json",
   "kernelVersion": "1.0.0",
-  "generatedAt": "2026-08-06T09:25:56.820Z",
+  "generatedAt": "2026-08-06T10:09:22.971Z",
   "rollup": {
     "*": {
-      "lines": 95.74,
-      "branches": 86.35,
-      "functions": 88.42
+      "lines": 95.75,
+      "branches": 86.36,
+      "functions": 88.43
     }
   },
   "rows": [
@@ -105,6 +105,12 @@
       "lines": 95.61,
       "branches": 89.77,
       "functions": 86.67
+    },
+    {
+      "path": ".agents/scripts/check-knip-entries.js",
+      "lines": 100,
+      "branches": 80.95,
+      "functions": 66.67
     },
     {
       "path": ".agents/scripts/check-lifecycle-doc-drift.js",
@@ -1448,6 +1454,12 @@
       "path": ".agents/scripts/lib/json-utils.js",
       "lines": 100,
       "branches": 100,
+      "functions": 100
+    },
+    {
+      "path": ".agents/scripts/lib/knip-entry-sync.js",
+      "lines": 97.77,
+      "branches": 90.59,
       "functions": 100
     },
     {
@@ -3054,9 +3066,9 @@
     },
     {
       "path": ".agents/scripts/run-verify.js",
-      "lines": 94,
-      "branches": 62.5,
-      "functions": 50
+      "lines": 94.74,
+      "branches": 66.67,
+      "functions": 66.67
     },
     {
       "path": ".agents/scripts/single-story-close.js",

--- a/baselines/dead-exports-production.json
+++ b/baselines/dead-exports-production.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://mandrel.dev/baselines/dead-exports.schema.json",
   "kernelVersion": "6.17.1",
-  "generatedAt": "2026-08-06T09:44:09.996Z",
+  "generatedAt": "2026-08-06T10:08:43.175Z",
   "mode": "production",
   "rows": [
     {
@@ -623,6 +623,10 @@
     {
       "file": ".agents/scripts/lib/cli/standard-args.js",
       "symbol": "SUPPORTED_FLAGS"
+    },
+    {
+      "file": ".agents/scripts/lib/knip-entry-sync.js",
+      "symbol": "__testing"
     },
     {
       "file": ".agents/scripts/lib/config/temp-paths.js",

--- a/baselines/maintainability.json
+++ b/baselines/maintainability.json
@@ -1,7 +1,7 @@
 {
   "$schema": ".agents/schemas/baselines/maintainability.schema.json",
   "kernelVersion": "0.1.0",
-  "generatedAt": "2026-08-06T09:25:46.413Z",
+  "generatedAt": "2026-08-06T09:58:52.595Z",
   "rollup": {
     "*": {
       "min": 76.058,
@@ -77,6 +77,10 @@
     {
       "path": ".agents/scripts/check-doc-links.js",
       "mi": 89.461
+    },
+    {
+      "path": ".agents/scripts/check-knip-entries.js",
+      "mi": 92.67
     },
     {
       "path": ".agents/scripts/check-lifecycle-doc-drift.js",
@@ -941,6 +945,10 @@
     {
       "path": ".agents/scripts/lib/json-utils.js",
       "mi": 95.486
+    },
+    {
+      "path": ".agents/scripts/lib/knip-entry-sync.js",
+      "mi": 91.321
     },
     {
       "path": ".agents/scripts/lib/label-constants.js",
@@ -2032,7 +2040,7 @@
     },
     {
       "path": ".agents/scripts/run-verify.js",
-      "mi": 93.708
+      "mi": 101.048
     },
     {
       "path": ".agents/scripts/single-story-close.js",

--- a/knip.json
+++ b/knip.json
@@ -20,6 +20,7 @@
     ".agents/scripts/check-cyclomatic.js!",
     ".agents/scripts/check-dead-exports.js!",
     ".agents/scripts/check-doc-links.js!",
+    ".agents/scripts/check-knip-entries.js!",
     ".agents/scripts/check-lifecycle-doc-drift.js!",
     ".agents/scripts/check-lifecycle-lint.js!",
     ".agents/scripts/check-schema-references.js!",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "check:context-budget": "node .agents/scripts/check-context-budget.js",
     "check:cyclomatic": "node .agents/scripts/check-cyclomatic.js",
     "cyclomatic:update": "node .agents/scripts/check-cyclomatic.js --update",
+    "check:knip-entries": "node .agents/scripts/check-knip-entries.js",
     "check:schema-refs": "node .agents/scripts/check-schema-references.js",
     "check:workflow-citations": "node .agents/scripts/check-workflow-citations.js",
     "crap:check": "node .agents/scripts/check-baselines.js --gate crap",

--- a/tests/check-knip-entries.test.js
+++ b/tests/check-knip-entries.test.js
@@ -1,0 +1,418 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { test } from 'node:test';
+import { runCli } from '../.agents/scripts/check-knip-entries.js';
+import {
+  __testing,
+  renderEntrySyncReport,
+  resolveEntrySync,
+} from '../.agents/scripts/lib/knip-entry-sync.js';
+import { makeTempDir } from '../.agents/scripts/lib/test-temp.js';
+
+/**
+ * Unit + invariant coverage for the knip entry-sync gate.
+ *
+ * The defect this suite exists to prevent (observed live during Story #5012):
+ * Story #5001 replaced knip's blanket `.agents/scripts/*.js!` entry glob with
+ * an explicit hand-written list and promoted the `files` rule to `error`. A CLI
+ * added afterwards is absent from that list, so knip reads it as unreachable,
+ * emits a whole-file `{ file, symbol: '*' }` row for it, and marks every lib
+ * module only that CLI imports dead too. Accepting the ratchet's diff — the
+ * obvious remedy — permanently records live operator CLIs as expected-dead.
+ *
+ * Modeled on the sibling `check-action-pinning.test.js`: exercise the pure
+ * helpers, drive `resolveEntrySync` over fixture trees, then assert the live
+ * repository's own invariants.
+ */
+
+const {
+  buildInvocationPatterns,
+  collectInvocationSurfaces,
+  readKnipEntries,
+  stripJsComments,
+} = __testing;
+
+const REPO_ROOT = path.resolve(import.meta.dirname, '..');
+
+/**
+ * Build a minimal fixture repository.
+ *
+ * @param {{
+ *   clis: string[],
+ *   entry?: string[],
+ *   packageJson?: object,
+ *   extraFiles?: Record<string, string>,
+ * }} spec
+ * @returns {string} absolute repo root
+ */
+function makeFixtureRepo({ clis, entry, packageJson, extraFiles = {} }) {
+  const root = makeTempDir('knip-entry-');
+  const scriptsDir = path.join(root, '.agents', 'scripts');
+  fs.mkdirSync(scriptsDir, { recursive: true });
+  for (const cli of clis) {
+    fs.writeFileSync(path.join(scriptsDir, cli), `// ${cli}\n`);
+  }
+  fs.writeFileSync(
+    path.join(root, 'knip.json'),
+    JSON.stringify({
+      entry: (entry ?? clis).map((c) => `.agents/scripts/${c}!`),
+    }),
+  );
+  fs.writeFileSync(
+    path.join(root, 'package.json'),
+    JSON.stringify(packageJson ?? { scripts: {} }),
+  );
+  for (const [rel, body] of Object.entries(extraFiles)) {
+    const full = path.join(root, rel);
+    fs.mkdirSync(path.dirname(full), { recursive: true });
+    fs.writeFileSync(full, body);
+  }
+  return root;
+}
+
+// --- pure helpers -----------------------------------------------------------
+
+test('stripJsComments: blanks line and block comments, preserving line count', () => {
+  const src = [
+    'const a = 1; // trailing',
+    '/* block',
+    ' * body',
+    ' */',
+    'b()',
+  ].join('\n');
+  const out = stripJsComments(src);
+  assert.match(out, /const a = 1;/);
+  assert.ok(!out.includes('trailing'));
+  assert.ok(!out.includes('body'));
+  assert.equal(out.split('\n').length, src.split('\n').length);
+});
+
+test('stripJsComments: does not mangle // inside string or template literals', () => {
+  const src = `const u = 'https://example.com/x'; const t = \`a//b\`; // gone`;
+  const out = stripJsComments(src);
+  assert.match(out, /https:\/\/example\.com\/x/);
+  assert.match(out, /a\/\/b/);
+  assert.ok(!out.includes('gone'));
+});
+
+test('buildInvocationPatterns: pathLiteral matches both separator styles', () => {
+  const { pathLiteral } = buildInvocationPatterns('foo.js');
+  assert.ok(pathLiteral.test('node .agents/scripts/foo.js --flag'));
+  assert.ok(pathLiteral.test('node .agents\\scripts\\foo.js'));
+  assert.ok(!pathLiteral.test('node .agents/scripts/foo-bar.js'));
+});
+
+test('buildInvocationPatterns: joinedSpawn requires the "scripts" sibling argument', () => {
+  const { joinedSpawn } = buildInvocationPatterns('foo.js');
+  assert.ok(joinedSpawn.test(`path.join(root, 'scripts', 'foo.js')`));
+  assert.ok(
+    joinedSpawn.test(`path.join(\n  root,\n  'scripts',\n  'foo.js',\n)`),
+  );
+  // A bare catalogue entry — the shape of source-classifier's basename
+  // inventory — is a list of names, not a call.
+  assert.ok(!joinedSpawn.test(`const NAMES = ['bar.js', 'foo.js'];`));
+});
+
+test('readKnipEntries: reads explicit top-level entries and ignores globs', () => {
+  const root = makeFixtureRepo({ clis: ['a.js'] });
+  fs.writeFileSync(
+    path.join(root, 'knip.json'),
+    JSON.stringify({
+      entry: [
+        'bin/*.js!',
+        '.agents/scripts/a.js!',
+        '.agents/scripts/*.js!',
+        '.agents/scripts/**/__tests__/**/*.test.js',
+        '.agents/scripts/lib/nested.js!',
+      ],
+    }),
+  );
+  const { entries, error } = readKnipEntries({ repoRoot: root });
+  assert.equal(error, null);
+  assert.deepEqual(entries, ['a.js']);
+});
+
+test('readKnipEntries: reports an unreadable or entry-less config as an error', () => {
+  const root = makeTempDir('knip-entry-bad-');
+  assert.match(
+    readKnipEntries({ repoRoot: root }).error,
+    /cannot read knip\.json/,
+  );
+  fs.writeFileSync(path.join(root, 'knip.json'), JSON.stringify({}));
+  assert.match(readKnipEntries({ repoRoot: root }).error, /no "entry" array/);
+});
+
+// --- the regression the gate exists for -------------------------------------
+
+test('REGRESSION: a newly-added, invoked CLI absent from knip entry is reported missing', () => {
+  // Exactly the Story #5012 shape: the CLI is real, wired into package.json and
+  // CI, and simply not yet listed in knip.json. Without this gate knip calls it
+  // unreachable and check-dead-exports offers a whole-file dead row for it.
+  const root = makeFixtureRepo({
+    clis: ['existing.js', 'brand-new.js'],
+    entry: ['existing.js'],
+    packageJson: {
+      scripts: {
+        existing: 'node .agents/scripts/existing.js',
+        'check:new': 'node .agents/scripts/brand-new.js',
+      },
+    },
+    extraFiles: {
+      '.github/workflows/ci.yml':
+        'jobs:\n  b:\n    steps:\n      - run: node .agents/scripts/brand-new.js\n',
+    },
+  });
+
+  const report = resolveEntrySync({ repoRoot: root });
+  assert.equal(report.error, null);
+  assert.deepEqual(
+    report.missing.map((m) => m.cli),
+    ['brand-new.js'],
+    'a new CLI that something invokes must be flagged before knip can call it dead',
+  );
+  assert.deepEqual(report.missing[0].invokers.sort(), [
+    '.github/workflows/ci.yml',
+    'package.json',
+  ]);
+  assert.deepEqual(report.stale, []);
+
+  // And the remedy the operator is told to apply must actually clear it —
+  // adding the entry, NOT accepting a dead-exports diff.
+  const rendered = renderEntrySyncReport(report);
+  assert.match(
+    rendered,
+    /add "\.agents\/scripts\/brand-new\.js!" to knip\.json/,
+  );
+  assert.match(rendered, /\(gate fail\)/);
+
+  fs.writeFileSync(
+    path.join(root, 'knip.json'),
+    JSON.stringify({
+      entry: ['.agents/scripts/existing.js!', '.agents/scripts/brand-new.js!'],
+    }),
+  );
+  const after = resolveEntrySync({ repoRoot: root });
+  assert.deepEqual(after.missing, []);
+  assert.deepEqual(after.stale, []);
+  assert.deepEqual(after.phantom, []);
+  assert.match(renderEntrySyncReport(after), /\(ok\)/);
+});
+
+test('a CLI declared in entry that nothing invokes is reported stale', () => {
+  // The blind spot #5001 closed: a declared entry point is immortal, so its
+  // death can never surface. An entry outliving its last caller restores it.
+  const root = makeFixtureRepo({
+    clis: ['live.js', 'orphaned.js'],
+    packageJson: { scripts: { live: 'node .agents/scripts/live.js' } },
+  });
+  const report = resolveEntrySync({ repoRoot: root });
+  assert.deepEqual(report.stale, ['orphaned.js']);
+  assert.deepEqual(report.missing, []);
+  assert.match(renderEntrySyncReport(report), /nothing invokes it/);
+});
+
+test('an entry whose file is gone is reported phantom', () => {
+  const root = makeFixtureRepo({
+    clis: ['live.js'],
+    entry: ['live.js', 'renamed-away.js'],
+    packageJson: { scripts: { live: 'node .agents/scripts/live.js' } },
+  });
+  const report = resolveEntrySync({ repoRoot: root });
+  assert.deepEqual(report.phantom, ['renamed-away.js']);
+});
+
+// --- what does and does not confer liveness ---------------------------------
+
+test('documentation prose does not make an uninvoked CLI live', () => {
+  // Four CLIs are named only in docs today; #5001 recorded all four as
+  // whole-file dead on purpose. Counting prose would silently resurrect them.
+  const root = makeFixtureRepo({
+    clis: ['operator-tool.js'],
+    entry: [],
+    extraFiles: {
+      'docs/onboarding.md':
+        'Run `node .agents/scripts/operator-tool.js` by hand.\n',
+      '.agents/docs/quality-gates.md':
+        'The operator-run replacement is `node .agents/scripts/operator-tool.js`.\n',
+    },
+  });
+  const report = resolveEntrySync({ repoRoot: root });
+  assert.deepEqual(report.missing, [], 'prose is not a caller');
+  assert.deepEqual(report.stale, []);
+});
+
+test('a comment naming a CLI does not make it live, but a real spawn does', () => {
+  const root = makeFixtureRepo({
+    clis: ['mentioned.js', 'spawned.js'],
+    entry: ['spawned.js'],
+    extraFiles: {
+      '.agents/scripts/lib/notes.js': [
+        '/**',
+        ' * Superseded by `node .agents/scripts/mentioned.js` (Story #1).',
+        ' */',
+        "const script = path.join(root, 'scripts', 'spawned.js');",
+        'spawnSync(process.execPath, [script]);',
+      ].join('\n'),
+    },
+  });
+  const report = resolveEntrySync({ repoRoot: root });
+  assert.deepEqual(
+    report.missing,
+    [],
+    'a JSDoc mention must not confer liveness',
+  );
+  assert.deepEqual(report.stale, [], 'a path.join spawn must confer liveness');
+});
+
+test('a CLI reachable only by import is neither missing nor stale', () => {
+  // `cleanup-repo-test-temp.js` is imported by run-tests.js, so knip already
+  // reaches it through the module graph; declaring it an entry would be wrong.
+  const root = makeFixtureRepo({
+    clis: ['runner.js', 'helper.js'],
+    entry: ['runner.js'],
+    packageJson: { scripts: { t: 'node .agents/scripts/runner.js' } },
+  });
+  fs.writeFileSync(
+    path.join(root, '.agents', 'scripts', 'runner.js'),
+    "import { help } from './helper.js';\nhelp();\n",
+  );
+  const report = resolveEntrySync({ repoRoot: root });
+  assert.deepEqual(report.missing, []);
+  assert.deepEqual(report.stale, []);
+});
+
+test('collectInvocationSurfaces: excludes test files from the invoked set', () => {
+  const root = makeFixtureRepo({
+    clis: ['only-tested.js'],
+    entry: [],
+    extraFiles: {
+      '.agents/scripts/__tests__/only-tested.test.js':
+        "spawnSync('node', ['.agents/scripts/only-tested.js']);\n",
+    },
+  });
+  const surfaces = collectInvocationSurfaces({ repoRoot: root });
+  assert.ok(!surfaces.some((s) => s.path.includes('__tests__')));
+  assert.deepEqual(resolveEntrySync({ repoRoot: root }).missing, []);
+});
+
+// --- CLI exit codes ---------------------------------------------------------
+
+test('runCli: exits 0 clean, 1 on divergence, 2 when it cannot run', async () => {
+  const sink = () => ({
+    out: '',
+    write(s) {
+      this.out += s;
+    },
+  });
+
+  const clean = makeFixtureRepo({
+    clis: ['a.js'],
+    packageJson: { scripts: { a: 'node .agents/scripts/a.js' } },
+  });
+  assert.equal(
+    await runCli({ argv: ['--cwd', clean], stdout: sink(), stderr: sink() }),
+    0,
+  );
+
+  const diverged = makeFixtureRepo({
+    clis: ['a.js'],
+    entry: [],
+    packageJson: { scripts: { a: 'node .agents/scripts/a.js' } },
+  });
+  assert.equal(
+    await runCli({ argv: ['--cwd', diverged], stdout: sink(), stderr: sink() }),
+    1,
+  );
+
+  const broken = makeTempDir('knip-entry-empty-');
+  assert.equal(
+    await runCli({ argv: ['--cwd', broken], stdout: sink(), stderr: sink() }),
+    2,
+  );
+
+  const badFlag = sink();
+  assert.equal(
+    await runCli({ argv: ['--nope'], stdout: sink(), stderr: badFlag }),
+    2,
+  );
+  assert.match(badFlag.out, /unknown flag/);
+});
+
+test('runCli: --json emits the machine-readable report', async () => {
+  const root = makeFixtureRepo({
+    clis: ['a.js'],
+    entry: [],
+    packageJson: { scripts: { a: 'node .agents/scripts/a.js' } },
+  });
+  const stdout = {
+    out: '',
+    write(s) {
+      this.out += s;
+    },
+  };
+  const code = await runCli({
+    argv: ['--cwd', root, '--json'],
+    stdout,
+    stderr: { write() {} },
+  });
+  assert.equal(code, 1);
+  const parsed = JSON.parse(stdout.out);
+  assert.equal(parsed.kind, 'knip-entry-sync');
+  assert.deepEqual(
+    parsed.missing.map((m) => m.cli),
+    ['a.js'],
+  );
+});
+
+// --- live-repository invariants ---------------------------------------------
+
+test('INVARIANT: this repository\u2019s knip entry list matches its invoked CLI set', () => {
+  const report = resolveEntrySync({ repoRoot: REPO_ROOT });
+  assert.equal(report.error, null);
+  assert.deepEqual(
+    report.missing.map((m) => m.cli),
+    [],
+    'a CLI under .agents/scripts/ is invoked but missing from knip.json "entry" — ' +
+      'add it, or knip reads it as unreachable and check-dead-exports will offer ' +
+      'a false whole-file dead row for it and its private lib modules (Story #5012)',
+  );
+  assert.deepEqual(
+    report.stale,
+    [],
+    'a knip.json "entry" is invoked by nothing — remove it so its death can ' +
+      'surface, or wire up the caller (Story #5001)',
+  );
+  assert.deepEqual(
+    report.phantom,
+    [],
+    'a knip.json "entry" names a file that is gone',
+  );
+});
+
+test('INVARIANT: no entry-declared CLI is also recorded as a whole-file dead row', () => {
+  // The two artifacts must stay disjoint by construction. A CLI appearing in
+  // both is precisely the poisoning #5012 nearly committed: declared live to
+  // knip, yet recorded as expected-dead in the ratchet's own baseline.
+  const { entries } = readKnipEntries({ repoRoot: REPO_ROOT });
+  const declared = new Set(entries);
+  for (const baseline of [
+    'baselines/dead-exports.json',
+    'baselines/dead-exports-production.json',
+  ]) {
+    const { rows } = JSON.parse(
+      fs.readFileSync(path.join(REPO_ROOT, baseline), 'utf8'),
+    );
+    const contradictions = rows
+      .filter((r) => r.symbol === '*')
+      .map((r) => r.file)
+      .filter((f) => /^\.agents\/scripts\/[^/]+\.js$/.test(f))
+      .filter((f) => declared.has(f.slice('.agents/scripts/'.length)));
+    assert.deepEqual(
+      contradictions,
+      [],
+      `${baseline} records a whole-file dead row for a CLI that knip.json ` +
+        'declares as an entry point — one of the two is a lie',
+    );
+  }
+});

--- a/tests/scripts/run-verify.test.js
+++ b/tests/scripts/run-verify.test.js
@@ -45,6 +45,11 @@ test('runVerifySteps runs audit, lint, test, baselines, then the ratchets in ord
     ['npm', 'run', 'lint'],
     ['npm', 'test'],
     ['node', '.agents/scripts/check-baselines.js'],
+    // Ahead of the dead-exports pair on purpose: when a new CLI is missing from
+    // knip.json's entry list both gates fail, but only this one names the cause
+    // (Story #5012 read the ratchet's diff first and nearly recorded live CLIs
+    // as expected-dead).
+    ['node', '.agents/scripts/check-knip-entries.js'],
     ['node', '.agents/scripts/check-dead-exports.js'],
     ['node', '.agents/scripts/check-dead-exports.js', '--production'],
     ['node', '.agents/scripts/check-context-budget.js'],


### PR DESCRIPTION
## Why

Story #5001 made two changes that are individually right and jointly unsafe:

- it replaced knip's blanket `.agents/scripts/*.js!` entry glob with an explicit list, so an **uninvoked** CLI surfaces as dead rather than being declared live by the glob; and
- it promoted knip's `files` rule from `warn` to `error`, so whole-file death now produces `{ file, symbol: "*" }` baseline rows.

The explicit list is hand-maintained, and nothing checked it. So a CLI added *after* #5001 is invisible to knip by default: absent from the list, it reads as unreachable, emits a whole-file row, and drags every lib module only it imports into the dead set with it.

Story #5012 hit exactly this — 5 false rows (`check-baseline-scope.js`, `prune-baseline-orphans.js`, and their three `lib/baselines/*` modules). The ratchet's natural remedy, accepting the diff, would have permanently recorded live operator CLIs as expected-dead, blinding the ratchet to their *real* death later. It was caught only because a base-sync conflict forced a manual read of the diff.

## What

`check-knip-entries.js` mechanizes the derivation rule #5001's own AC-2 already stated — entries come from what `package.json`, husky hooks, `.github/workflows` and the `.agents` workflow/skill markdown *actually invoke* — and asserts that set against `knip.json` in both directions:

| kind | meaning | remedy the gate prints |
| --- | --- | --- |
| `missing` | invoked, but absent from `entry` (the #5012 bug) | add the entry — **not** accept the ratchet diff |
| `stale` | declared in `entry`, invoked by nothing (the blind spot #5001 closed) | drop the entry so its death can surface |
| `phantom` | declared, but no such file on disk | drop the stale path |

### Why not the other two options

- **Restoring a glob** would make every file live by construction and undo #5001's AC-2 outright.
- **Generating the array from `readdirSync`** is the same thing wearing a different hat — it also makes presence imply liveness.

Liveness here means *invoked*, not *present*. Two consequences are deliberate and covered by tests:

- **Documentation prose does not confer liveness.** Four CLIs are named only in `docs/**` prose today (`check-baseline-drift.js`, `post-structured-comment.js`, `provision-git-hooks.js`, `validate-docs-freshness.js`); #5001 recorded all four as whole-file dead on purpose, and counting prose would silently resurrect them.
- **A CLI reachable only by import is neither.** `cleanup-repo-test-temp.js` is imported by `run-tests.js`, so knip already reaches it through the module graph; declaring it an entry point would be wrong.

Recognizers are comment-stripped before scanning `.js` surfaces, and the bare-basename form requires the `path.join(…, 'scripts', '<name>.js')` shape — which is how `project-bootstrap.js` spawns `check-windows-git-perf.js` — so the several *data* inventories that list the same basenames (e.g. `source-classifier.js`'s `FRAMEWORK_SCRIPT_BASENAMES`) are not mistaken for calls.

## Measurement

On the current tree: **80 CLIs, 75 declared, zero divergence** in all three directions — so both directions are enforced with no exceptions or allowlist.

Simulating the pre-#5012 state (both CLIs removed from `entry`) reproduces the defect exactly:

```
+ check-baseline-scope.js — invoked by package.json, .github/workflows/ci.yml
    add ".agents/scripts/check-baseline-scope.js!" to knip.json "entry" — until you do, knip
    reads it as unreachable and check-dead-exports will offer a false whole-file row.
```

## Regression coverage

`tests/check-knip-entries.test.js` (17 tests). The headline one builds a fixture repo with a new CLI wired into `package.json` and CI but absent from `entry`, asserts the gate fires, then asserts adding the entry clears it. Two live-repo invariants stand guard permanently:

- this repository's entry list matches its invoked CLI set;
- **no entry-declared CLI is also recorded as a whole-file dead row** — the two artifacts must stay disjoint, since a CLI in both is precisely the poisoning #5012 nearly committed.

Both invariants were mutation-tested: removing the entry reds the first, injecting a whole-file row reds the second.

## Wiring

Runs in `npm run verify` and CI's `baselines` job, **ordered ahead of the dead-exports pair**. When a new CLI is missing from `entry` both gates fail, but only this one names the cause — seeing the ratchet's diff first is what made "accept the diff" look like the fix.

## Notes

- `run-verify.js`'s `STEPS` is deduped through a `gate()` helper: adding a tenth step regressed the file's MI past the pre-commit threshold, and collapsing the seven identical spawn tuples is the fix that costs no comment.
- The one new production dead-export row is `knip-entry-sync.js`'s `__testing` seam — the same test-only-seam category six sibling modules already occupy, chosen over exporting seven internals individually.
- Branch was rebased onto `a019c144`; the baselines are refreshed against it.

## Verification

- `npm test` — 9681 pass, 0 fail
- `npm run lint` — 0 errors
- All 11 gates in CI's `baselines` job — exit 0

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a read-only quality gate and CI ordering; no runtime product or auth paths change, only tooling enforcement with broad test coverage.
> 
> **Overview**
> Adds **`check-knip-entries.js`** and **`lib/knip-entry-sync.js`** so the hand-maintained `knip.json` `entry` list stays aligned with CLIs that are actually invoked (package.json, husky, workflows, `.agents` markdown, script spawns). The gate reports **missing** (invoked but not listed—would make knip treat live CLIs as dead), **stale** (listed but never called), and **phantom** (listed file gone).
> 
> It runs in **CI** and **`npm run verify`** **before** the dead-exports checks so failures point at the real fix (update `knip.json`) instead of tempting a false dead-exports baseline accept. **`knip.json`**, **`package.json`** (`check:knip-entries`), **`source-classifier`**, and **`run-verify`**’s `gate()` helper are updated accordingly; tests and baselines cover the new scripts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7bc59a53f6f6cd1fd6c22343bb8ba36247dbbfc9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->