### PR TITLE
fix!: derive the squash subject from release impact, keep acronyms, propagate breaking changes

### DIFF
--- a/.agents/rules/git-conventions-reference.md
+++ b/.agents/rules/git-conventions-reference.md
@@ -43,6 +43,33 @@ Practical guidance when authoring a contract change:
   can detect "I cannot read this artifact"); they are **not** an
   invitation to keep multiple readers alive in the same release.
 
+### Declaring the break so consumers see it
+
+A hard cutover is only honest if the consumer can find out about it. Prose in
+a commit body does not qualify: release-please recognizes exactly two signals,
+a `!` before the colon in the subject and a `BREAKING CHANGE:` footer, and
+sees nothing else. Story #5004 removed `project.commands.lintBaseline` from a
+schema block that is `additionalProperties: false` — a config that used to be
+silently ignored now fails validation — described it in three body paragraphs,
+and shipped with neither signal. It reached `main` as `docs:` and would have
+been absent from the release notes entirely.
+
+So a contract change MUST declare itself in one of two places, and close
+(`normalize-pr-title.js`) propagates either to the squash subject and PR body:
+
+1. **A commit footer** — a `BREAKING CHANGE:` (or `BREAKING-CHANGE:`) line in
+   the body of whichever commit does the breaking. This is the default; write
+   it as you write the commit. The keyword is uppercase and starts its own
+   line, per Conventional Commits.
+2. **A Story-body declaration** — the same footer as its own line in the Story
+   issue, naturally at the end of `## Spec`. Use this when the break is known
+   at plan time, or when it spans several commits and no single one owns it.
+
+Close reads both, marks the PR title `<type>!: …`, and appends the collected
+note to the PR body as a footer. Consumers whose on-disk state needs changing
+should also get a step in `lib/migrations/` — see that directory's README;
+`2.32.0-retire-lint-baseline-command.js` is the step #5004 should have shipped.
+
 ## Push Validation — the known false-negative signature
 
 The core rule is: **never bypass hooks** (`--no-verify`, `--no-gpg-sign`, or

--- a/.agents/rules/git-conventions.md
+++ b/.agents/rules/git-conventions.md
@@ -32,6 +32,8 @@ subject referencing the Story via `(refs #<storyId>)` — see
   It does **not** run on squash-merge titles edited in the GitHub UI —
   author the PR title in conventional form so the squash commit parses
   for release-please.
+- Consumer-breaking changes MUST carry a `BREAKING CHANGE:` footer
+  (breaking commit or Story body); prose never reaches release-please.
 
 ## Push Validation & Reliability (MUSTs)
 

--- a/.agents/scripts/lib/orchestration/single-story-close/phases/__tests__/conventional-subject.test.js
+++ b/.agents/scripts/lib/orchestration/single-story-close/phases/__tests__/conventional-subject.test.js
@@ -1,0 +1,233 @@
+/**
+ * conventional-subject.test.js — regression gates for the three squash-subject
+ * rules the squash-subject repair fixed. Each `assert` here corresponds to a subject
+ * observed live on `main` that the old derivation got wrong.
+ */
+
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  collectBreakingNotes,
+  isConventionalSubject,
+  markBreaking,
+  pickDominantType,
+  shapeDescription,
+} from '../conventional-subject.js';
+
+// ---------------------------------------------------------------------------
+// Rule 1 — type precedence follows release impact
+// ---------------------------------------------------------------------------
+
+test('pickDominantType: a release-significant type outranks housekeeping', () => {
+  assert.equal(
+    pickDominantType(['chore(gates): x', 'feat(cli): y', 'docs(ci): z']),
+    'feat',
+  );
+  assert.equal(pickDominantType(['docs: a', 'fix: b']), 'fix');
+  assert.equal(pickDominantType(['chore: a', 'perf: b', 'docs: c']), 'perf');
+  assert.equal(pickDominantType(['test: a', 'refactor: b']), 'refactor');
+});
+
+test('pickDominantType: the visible tier is strictly ordered', () => {
+  const all = [
+    'ci: k',
+    'chore: j',
+    'style: i',
+    'test: h',
+    'docs: g',
+    'refactor: f',
+    'revert: e',
+    'perf: d',
+    'fix: c',
+    'feat: b',
+  ];
+  assert.equal(pickDominantType(all), 'feat');
+  assert.equal(pickDominantType(all.slice(0, -1)), 'fix');
+  assert.equal(pickDominantType(all.slice(0, -2)), 'perf');
+  assert.equal(pickDominantType(all.slice(0, -3)), 'revert');
+  assert.equal(pickDominantType(all.slice(0, -4)), 'refactor');
+});
+
+test('pickDominantType: Story #5004 resolves to chore, not docs', () => {
+  // The live defect: `docs` outranked `chore` on a hand-ordered list, so a
+  // three-commit sweep that deleted five modules, two CLIs and a dependency
+  // landed on `main` as `docs: …`. Inside the hidden tier there is no honest
+  // ordering, so the branch's own weight decides — two chores beat one docs.
+  assert.equal(
+    pickDominantType([
+      'chore(gates): baseline-refresh: retire vacuous gates, mirror CI in verify (refs #5004)',
+      'docs(ci): rewrite known-tooling-behavior entry 2 (refs #5004)',
+      'chore(baselines): prune orphan rows (refs #5004)',
+    ]),
+    'chore',
+  );
+});
+
+test('pickDominantType: an even hidden-tier split falls to the primary commit', () => {
+  // `subjects` is oldest-first, so index 0 is the commit the operator wrote
+  // before any fixup piled on.
+  assert.equal(pickDominantType(['docs: a', 'chore: b']), 'docs');
+  assert.equal(pickDominantType(['chore: a', 'docs: b']), 'chore');
+});
+
+test('pickDominantType: non-conventional subjects are ignored, empty is null', () => {
+  assert.equal(pickDominantType(['Rename the package', 'docs: a']), 'docs');
+  assert.equal(pickDominantType(['Rename the package']), null);
+  assert.equal(pickDominantType([]), null);
+  assert.equal(pickDominantType(undefined), null);
+});
+
+test('pickDominantType: a breaking marker does not hide the type', () => {
+  assert.equal(pickDominantType(['chore: a', 'feat(api)!: b']), 'feat');
+});
+
+// ---------------------------------------------------------------------------
+// Rule 2 — casing leaves acronyms alone
+// ---------------------------------------------------------------------------
+
+test('shapeDescription: preserves a leading acronym', () => {
+  // The live defect: `refactor: cRAP surface diet …` on `main`.
+  assert.equal(
+    shapeDescription('CRAP surface diet: delete the dead combined scan'),
+    'CRAP surface diet: delete the dead combined scan',
+  );
+  assert.equal(shapeDescription('API surface diet'), 'API surface diet');
+  assert.equal(shapeDescription('CI mirror repair'), 'CI mirror repair');
+  assert.equal(shapeDescription('QA loop rework'), 'QA loop rework');
+  assert.equal(shapeDescription('CI/CD split'), 'CI/CD split');
+  assert.equal(shapeDescription('CRAP: retire rows'), 'CRAP: retire rows');
+});
+
+test('shapeDescription: still lowercases an ordinary leading word', () => {
+  assert.equal(
+    shapeDescription('Rename the published npm package'),
+    'rename the published npm package',
+  );
+  assert.equal(shapeDescription('Story #4321'), 'story #4321');
+  // Mixed-case and single-letter heads are not acronyms.
+  assert.equal(shapeDescription('A11y sweep'), 'a11y sweep');
+  assert.equal(shapeDescription('A sweep'), 'a sweep');
+  assert.equal(shapeDescription('cRAP surface diet'), 'cRAP surface diet');
+});
+
+test('shapeDescription: trims and tolerates empty input', () => {
+  assert.equal(shapeDescription('  Padded title  '), 'padded title');
+  assert.equal(shapeDescription(''), '');
+  assert.equal(shapeDescription(undefined), '');
+});
+
+// ---------------------------------------------------------------------------
+// Rule 3 — breaking changes survive the squash
+// ---------------------------------------------------------------------------
+
+test('collectBreakingNotes: reads a footer out of any constituent commit', () => {
+  const result = collectBreakingNotes({
+    commitMessages: [
+      'chore(gates): retire the lint-baseline shell\n\nSome prose.\n',
+      'docs(ci): rewrite entry 2\n\nBREAKING CHANGE: `project.commands.lintBaseline` was removed from a\nschema block that is additionalProperties:false.\n',
+      'chore(baselines): prune orphan rows\n',
+    ],
+  });
+  assert.equal(result.breaking, true);
+  assert.deepEqual(result.notes, [
+    '`project.commands.lintBaseline` was removed from a schema block that is additionalProperties:false.',
+  ]);
+});
+
+test('collectBreakingNotes: honours the hyphenated spelling and a `!` header', () => {
+  assert.equal(
+    collectBreakingNotes({
+      commitMessages: ['fix: x\n\nBREAKING-CHANGE: the flag is gone.\n'],
+    }).breaking,
+    true,
+  );
+  const bang = collectBreakingNotes({
+    commitMessages: ['feat(api)!: drop the v1 endpoint\n'],
+  });
+  assert.equal(bang.breaking, true);
+  // No footer text → the `!` commit's own description is the note.
+  assert.deepEqual(bang.notes, ['drop the v1 endpoint']);
+});
+
+test('collectBreakingNotes: a Story can declare the break itself', () => {
+  const result = collectBreakingNotes({
+    commitMessages: ['chore: tidy up\n'],
+    storyBody:
+      '## Spec\n\nRetire the shell.\n\nBREAKING CHANGE: consumers must delete\n`project.commands.lintBaseline`.\n\n## Verify\n\n- npm test\n',
+  });
+  assert.equal(result.breaking, true);
+  assert.deepEqual(result.notes, [
+    'consumers must delete `project.commands.lintBaseline`.',
+  ]);
+});
+
+test('collectBreakingNotes: prose describing a break is not a declaration', () => {
+  const result = collectBreakingNotes({
+    commitMessages: [
+      'chore: retire the shell\n\nThis is a breaking change for consumers who set the key.\n',
+    ],
+    storyBody: 'This story introduces a breaking change to the config schema.',
+  });
+  assert.equal(result.breaking, false);
+  assert.deepEqual(result.notes, []);
+});
+
+test('collectBreakingNotes: a lowercase footer keyword does not fire', () => {
+  // `conventional-commits-parser` matches the uppercase token only; announcing
+  // a break release-please will not see would be worse than staying quiet.
+  assert.equal(
+    collectBreakingNotes({
+      commitMessages: ['fix: x\n\nbreaking change: nope\n'],
+    }).breaking,
+    false,
+  );
+});
+
+test('collectBreakingNotes: a trailer ends the note, and duplicates collapse', () => {
+  const result = collectBreakingNotes({
+    commitMessages: [
+      'fix: a\n\nBREAKING CHANGE: the key is gone.\nRefs: #1\n',
+      'fix: b\n\nBREAKING CHANGE: the key is gone.\n',
+    ],
+  });
+  assert.deepEqual(result.notes, ['the key is gone.']);
+});
+
+test('collectBreakingNotes: nothing declared is not breaking', () => {
+  assert.deepEqual(collectBreakingNotes({}), { breaking: false, notes: [] });
+  assert.deepEqual(
+    collectBreakingNotes({ commitMessages: ['chore: a\n'], storyBody: '' }),
+    { breaking: false, notes: [] },
+  );
+});
+
+test('markBreaking: inserts `!` where the parser reads it', () => {
+  assert.equal(markBreaking('feat: add a thing'), 'feat!: add a thing');
+  assert.equal(
+    markBreaking('chore(gates): retire a gate'),
+    'chore(gates)!: retire a gate',
+  );
+  // Idempotent, and a no-op on a subject it cannot parse.
+  assert.equal(markBreaking('feat!: add a thing'), 'feat!: add a thing');
+  assert.equal(markBreaking('Rename the package'), 'Rename the package');
+});
+
+// ---------------------------------------------------------------------------
+// Shared predicates
+// ---------------------------------------------------------------------------
+
+test('isConventionalSubject', () => {
+  assert.equal(isConventionalSubject('feat(cli): add a flag'), true);
+  assert.equal(isConventionalSubject('feat(cli)!: add a flag'), true);
+  assert.equal(isConventionalSubject('Rename the package'), false);
+  assert.equal(isConventionalSubject('nope: not a known type'), false);
+  assert.equal(isConventionalSubject('feat:'), false);
+});
+
+test('a scoped, breaking-marked subject still yields its type', () => {
+  // `parseConventionalType` is module-private; `pickDominantType` is the seam
+  // that reads it, so the scope/`!` tolerance is pinned through that.
+  assert.equal(pickDominantType(['chore(gates)!: x']), 'chore');
+  assert.equal(pickDominantType(['Rename the package']), null);
+});

--- a/.agents/scripts/lib/orchestration/single-story-close/phases/__tests__/normalize-pr-title.test.js
+++ b/.agents/scripts/lib/orchestration/single-story-close/phases/__tests__/normalize-pr-title.test.js
@@ -1,0 +1,208 @@
+/**
+ * normalize-pr-title.test.js — the assembled PR title and body.
+ *
+ * `conventional-subject.test.js` pins the rules in isolation; this file drives
+ * the module's one public seam, `buildPullRequestFields`, with an injected
+ * `git log` so the branch read is exercised for real: the NUL record split,
+ * the oldest-first ordering the type tie-break depends on, and the degraded
+ * path when git cannot answer.
+ */
+
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { buildPullRequestFields } from '../normalize-pr-title.js';
+
+const NUL = String.fromCharCode(0);
+
+/** A `gitSpawn` stand-in that replays `messages` as one `git log` payload. */
+function gitLog(messages) {
+  const calls = [];
+  const fn = (cwd, ...args) => {
+    calls.push({ cwd, args });
+    return { status: 0, stdout: messages.map((m) => `${m}${NUL}\n`).join('') };
+  };
+  fn.calls = calls;
+  return fn;
+}
+
+/** Build fields for `storyTitle` against a canned branch history. */
+function build({ storyTitle, storyId = 4321, storyBody = '', messages = [] }) {
+  return buildPullRequestFields({
+    storyTitle,
+    storyId,
+    storyBody,
+    storyBranch: `story-${storyId}`,
+    baseBranch: 'main',
+    cwd: '/repo',
+    gitSpawn: gitLog(messages),
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Title
+// ---------------------------------------------------------------------------
+
+test('an already-conventional Story title is preserved verbatim', () => {
+  const { title } = build({
+    storyTitle:
+      'feat(gates): make the dead-exports ratchet detect whole-file death',
+    storyId: 5001,
+    messages: ['docs: unrelated'],
+  });
+  assert.equal(
+    title,
+    'feat(gates): make the dead-exports ratchet detect whole-file death (#5001)',
+  );
+});
+
+test('a prose title is synthesized with the branch dominant type', () => {
+  const { title } = build({
+    storyTitle: 'Check/CI gate sweep: retire vacuous and orphaned gates',
+    storyId: 5004,
+    messages: [
+      'chore(gates): retire vacuous gates (refs #5004)\n\nbody',
+      'docs(ci): rewrite entry 2 (refs #5004)',
+      'chore(baselines): prune orphan rows (refs #5004)',
+    ],
+  });
+  assert.equal(
+    title,
+    'chore: check/CI gate sweep: retire vacuous and orphaned gates (#5004)',
+  );
+});
+
+test('an acronym-led title keeps its casing', () => {
+  const { title } = build({
+    storyTitle: 'CRAP surface diet: delete the dead combined scan',
+    storyId: 5002,
+    messages: ['refactor(crap): delete the dead combined scan'],
+  });
+  assert.equal(
+    title,
+    'refactor: CRAP surface diet: delete the dead combined scan (#5002)',
+  );
+});
+
+test('no commits → the safe default type', () => {
+  const { title, breaking } = build({
+    storyTitle: 'Rename the published npm package',
+    storyId: 42,
+  });
+  assert.equal(title, 'chore: rename the published npm package (#42)');
+  assert.equal(breaking, false);
+});
+
+test('an empty title falls back to the Story reference', () => {
+  assert.equal(
+    build({ storyTitle: '   ', storyId: 42 }).title,
+    'chore: story #42 (#42)',
+  );
+  assert.equal(
+    build({ storyTitle: undefined, storyId: 42 }).title,
+    'chore: story #42 (#42)',
+  );
+});
+
+test('a declared break marks both title shapes', () => {
+  const synthesized = build({
+    storyTitle: 'Retire the lint-baseline shell',
+    storyId: 5004,
+    messages: [
+      'chore(gates): retire the shell\n\nBREAKING CHANGE: delete `project.commands.lintBaseline`.',
+    ],
+  });
+  assert.equal(
+    synthesized.title,
+    'chore!: retire the lint-baseline shell (#5004)',
+  );
+  assert.equal(synthesized.breaking, true);
+  assert.deepEqual(synthesized.breakingNotes, [
+    'delete `project.commands.lintBaseline`.',
+  ]);
+
+  const preserved = build({
+    storyTitle: 'refactor(config): retire the lint-baseline shell',
+    storyId: 5004,
+    storyBody: 'BREAKING CHANGE: delete `project.commands.lintBaseline`.',
+  });
+  assert.equal(
+    preserved.title,
+    'refactor(config)!: retire the lint-baseline shell (#5004)',
+  );
+});
+
+test('a title that already carries `!` is not double-marked', () => {
+  const { title } = build({
+    storyTitle: 'feat(api)!: drop the v1 endpoint',
+    storyId: 7,
+    messages: ['feat(api)!: drop the v1 endpoint'],
+  });
+  assert.equal(title, 'feat(api)!: drop the v1 endpoint (#7)');
+});
+
+// ---------------------------------------------------------------------------
+// Body
+// ---------------------------------------------------------------------------
+
+test('the body carries the Closes footer, and nothing else when clean', () => {
+  const { body } = build({ storyTitle: 'Tidy up', storyId: 5004 });
+  assert.equal(body, 'Closes #5004\n\n_Auto-opened by `/deliver`._');
+});
+
+test('the BREAKING CHANGE footer goes last', () => {
+  const { body } = build({
+    storyTitle: 'Tidy up',
+    storyId: 5004,
+    storyBody: 'BREAKING CHANGE: delete `project.commands.lintBaseline`.',
+  });
+  assert.match(body, /^Closes #5004\n/);
+  assert.equal(
+    body.split('\n').at(-1),
+    'BREAKING CHANGE: delete `project.commands.lintBaseline`.',
+  );
+});
+
+// ---------------------------------------------------------------------------
+// The branch read
+// ---------------------------------------------------------------------------
+
+test('the branch read is oldest-first over the base..head range', () => {
+  const gitSpawn = gitLog(['docs: older', 'chore: newer']);
+  const { title } = buildPullRequestFields({
+    storyTitle: 'A sweep',
+    storyId: 1,
+    storyBranch: 'story-1',
+    baseBranch: 'main',
+    cwd: '/repo',
+    gitSpawn,
+  });
+  assert.deepEqual(gitSpawn.calls[0].args, [
+    'log',
+    '--no-merges',
+    '--reverse',
+    '--format=%B%x00',
+    'main..story-1',
+  ]);
+  // Same hidden rank and same count → the oldest commit's type wins.
+  assert.equal(title, 'docs: a sweep (#1)');
+});
+
+test('a failed or throwing read degrades to the default type', () => {
+  const failing = () => ({ status: 128, stdout: '' });
+  const throwing = () => {
+    throw new Error('boom');
+  };
+  for (const gitSpawn of [failing, throwing]) {
+    const { title, breaking } = buildPullRequestFields({
+      storyTitle: 'A sweep',
+      storyId: 1,
+      storyBranch: 'story-1',
+      baseBranch: 'main',
+      cwd: '/repo',
+      gitSpawn,
+    });
+    assert.equal(title, 'chore: a sweep (#1)');
+    assert.equal(breaking, false);
+  }
+});

--- a/.agents/scripts/lib/orchestration/single-story-close/phases/conventional-subject.js
+++ b/.agents/scripts/lib/orchestration/single-story-close/phases/conventional-subject.js
@@ -1,0 +1,350 @@
+/**
+ * conventional-subject.js — the pure Conventional-Commit rules behind the
+ * squash-merge subject a standalone Story lands on `main`.
+ *
+ * Split out of `normalize-pr-title.js` so the rules that decide
+ * what the release notes say are testable without a git read. The three rules
+ * here each closed a defect observed live on `main`:
+ *
+ *   1. **Type precedence follows release impact.** A multi-commit Story used
+ *      to resolve its type off a hand-ordered list in which `docs` outranked
+ *      `chore` for no stated reason. Story #5004 (`chore(gates)`, `docs(ci)`,
+ *      `chore(baselines)`) therefore landed as
+ *      `docs: check/CI gate sweep …` — a change that deleted five
+ *      `lib/checks` modules, two CLIs and a dependency, filed under
+ *      documentation. `TYPE_RANK` now mirrors `changelog-sections` in
+ *      `release-please-config.json`: rank IS how visible the type is in the
+ *      release notes. Types that render identically (the six `hidden: true`
+ *      ones) share a rank, because there is no honest ordering between them —
+ *      those ties break on how much of the branch carries the type, then on
+ *      the Story's primary (oldest) commit.
+ *
+ *   2. **Casing leaves acronyms alone.** The old synthesizer lowercased the
+ *      first character unconditionally to satisfy commitlint's `subject-case`
+ *      rule, which turned Story #5002's "CRAP surface diet" into
+ *      `refactor: cRAP surface diet`. `shapeDescription` lowercases only when
+ *      the leading word is not an all-caps token, so CRAP / CI / QA / API
+ *      survive. That is a deliberate, narrow trade: commitlint's
+ *      `subject-case` treats ANY leading capital as sentence-case and would
+ *      flag `CRAP surface diet` — but commitlint never runs on a PR title or
+ *      a GitHub squash subject (see `rules/git-conventions.md` §
+ *      Conventional Commits), so the rule it would fail is not a gate this
+ *      subject passes through, while a mangled acronym is permanent in the
+ *      changelog.
+ *
+ *   3. **A breaking change survives the squash.** release-please only sees a
+ *      breaking change through a `!` in the subject or a `BREAKING CHANGE:`
+ *      footer. Story #5004 removed `project.commands.lintBaseline` from a
+ *      schema block that is `additionalProperties: false` — a hard consumer
+ *      break — described in prose in the commit body and therefore invisible
+ *      to the parser. `collectBreakingNotes` reads the footer out of any
+ *      constituent commit (or a Story-body declaration) and `markBreaking`
+ *      puts the `!` where the parser looks.
+ */
+
+/**
+ * The Conventional-Commit types Mandrel accepts. Mirrors
+ * `commitlint.config.js` → `type-enum` and `release-please-config.json` →
+ * `changelog-sections`. Kept in sync by hand (single hard-cutover, no
+ * shim) — adding a type means touching all three.
+ */
+const CONVENTIONAL_TYPES = Object.freeze([
+  'feat',
+  'fix',
+  'perf',
+  'refactor',
+  'revert',
+  'docs',
+  'style',
+  'chore',
+  'test',
+  'build',
+  'ci',
+]);
+
+/**
+ * Release-impact rank per type — LOWER wins. Derived from
+ * `changelog-sections` in `release-please-config.json`: the five types that
+ * render a visible section are ordered by how much a reader needs to see
+ * them, and the six `hidden: true` types share the bottom rank because the
+ * release notes draw no distinction between them.
+ *
+ * @type {Readonly<Record<string, number>>}
+ */
+const TYPE_RANK = Object.freeze({
+  feat: 0, // "Added"
+  fix: 1, // "Fixed"
+  perf: 2, // "Performance"
+  revert: 3, // "Reverted"
+  refactor: 4, // "Changed"
+  docs: 5, // hidden
+  style: 5, // hidden
+  chore: 5, // hidden
+  test: 5, // hidden
+  build: 5, // hidden
+  ci: 5, // hidden
+});
+
+/** Rank for a type absent from `TYPE_RANK` — always loses. */
+const UNRANKED = Number.MAX_SAFE_INTEGER;
+
+const TYPE_GROUP = CONVENTIONAL_TYPES.join('|');
+
+// Anchored Conventional-Commit header matcher:
+//   <type>(<optional scope>)<optional !>: <non-empty description>
+// Mirrors the shape `@commitlint/config-conventional` enforces (a known
+// type, an optional parenthesised scope, an optional breaking `!`, a
+// colon-space separator, and a non-empty subject). Used for the pure
+// "is this already conventional?" check and to pull the type off a branch
+// commit subject without spawning commitlint per call.
+const CONVENTIONAL_HEADER_RE = new RegExp(
+  `^(?:${TYPE_GROUP})(?:\\([^()\\r\\n]+\\))?!?: \\S.*$`,
+);
+const LEADING_TYPE_RE = new RegExp(
+  `^(${TYPE_GROUP})(?:\\([^()\\r\\n]+\\))?(!?):`,
+);
+// Splits a conventional header into `<type><scope?>`, `<!?>`, `<description>`
+// so the breaking marker can be inserted at the one position the parser reads.
+const HEADER_PARTS_RE = new RegExp(
+  `^((?:${TYPE_GROUP})(?:\\([^()\\r\\n]+\\))?)(!?): (.*)$`,
+);
+
+/**
+ * The Conventional-Commits breaking footer, in both spellings the spec
+ * defines (`BREAKING CHANGE:` and the hyphenated `BREAKING-CHANGE:`). Case is
+ * significant — the spec requires uppercase, and so does
+ * `conventional-commits-parser`'s default `noteKeywords`, so matching
+ * case-insensitively here would announce breaks release-please will not.
+ */
+const BREAKING_FOOTER_RE = /^BREAKING[ -]CHANGE:[ \t]*(.*)$/;
+
+/** A git-trailer-shaped line (`Some-Token: value`) — ends a footer's text. */
+const TRAILER_RE = /^[A-Za-z][A-Za-z-]*:[ \t]/;
+
+/**
+ * True iff `subject` is a parseable Conventional Commit subject under the
+ * repo's type vocabulary. Pure.
+ *
+ * @param {string} subject
+ * @returns {boolean}
+ */
+export function isConventionalSubject(subject) {
+  if (typeof subject !== 'string') return false;
+  return CONVENTIONAL_HEADER_RE.test(subject.trim());
+}
+
+/**
+ * Extract the Conventional-Commit `type` from a single commit subject, or
+ * `null` when the subject is not conventional. Pure.
+ *
+ * @param {string} subject
+ * @returns {string|null}
+ */
+function parseConventionalType(subject) {
+  if (typeof subject !== 'string') return null;
+  const match = subject.trim().match(LEADING_TYPE_RE);
+  return match ? match[1] : null;
+}
+
+/**
+ * Order two type candidates: release impact first, then how much of the
+ * branch carries the type, then the earliest commit that used it. The second
+ * and third keys only ever decide a tie inside the hidden tier — every
+ * visible type holds its rank alone.
+ *
+ * @param {{rank: number, count: number, firstIndex: number}} a
+ * @param {{rank: number, count: number, firstIndex: number}} b
+ * @returns {number}
+ */
+function compareTypeCandidates(a, b) {
+  if (a.rank !== b.rank) return a.rank - b.rank;
+  if (a.count !== b.count) return b.count - a.count;
+  return a.firstIndex - b.firstIndex;
+}
+
+/**
+ * Pick the type the squash subject should carry from the branch's own commit
+ * subjects. Returns `null` when no subject is conventional.
+ *
+ * `subjects` MUST be oldest-first: the final tie-break reads index 0 as the
+ * Story's primary commit, the one whose type the operator chose before any
+ * fixup or baseline-refresh commit piled on.
+ *
+ * @param {string[]} subjects Commit subjects, oldest first.
+ * @returns {string|null}
+ */
+export function pickDominantType(subjects) {
+  /** @type {Map<string, {type: string, rank: number, count: number, firstIndex: number}>} */
+  const candidates = new Map();
+  const list = Array.isArray(subjects) ? subjects : [];
+  list.forEach((subject, index) => {
+    const type = parseConventionalType(subject);
+    if (!type) return;
+    const seen = candidates.get(type);
+    if (seen) {
+      seen.count += 1;
+      return;
+    }
+    candidates.set(type, {
+      type,
+      rank: TYPE_RANK[type] ?? UNRANKED,
+      count: 1,
+      firstIndex: index,
+    });
+  });
+  if (candidates.size === 0) return null;
+  return [...candidates.values()].sort(compareTypeCandidates)[0].type;
+}
+
+/**
+ * True when the leading word of `text` is an all-caps token — an acronym the
+ * synthesizer must not touch. Requires two or more letters so a stray leading
+ * "A" or "I" still lowercases; punctuation and digits are ignored so
+ * `CRAP:`, `CI/CD` and `API-surface` all read as acronyms while `A11y` does
+ * not.
+ *
+ * @param {string} text
+ * @returns {boolean}
+ */
+function leadsWithAcronym(text) {
+  const [word = ''] = text.split(/\s+/, 1);
+  const letters = word.replace(/[^A-Za-z]/g, '');
+  return letters.length >= 2 && letters === letters.toUpperCase();
+}
+
+/**
+ * Shape a human Story title into the description half of a synthesized
+ * Conventional-Commit subject: lowercase the first character so the subject
+ * reads as a sentence fragment, EXCEPT when the leading word is an acronym.
+ * Pure.
+ *
+ * @param {string} text
+ * @returns {string}
+ */
+export function shapeDescription(text) {
+  const trimmed = typeof text === 'string' ? text.trim() : '';
+  if (trimmed.length === 0) return trimmed;
+  if (leadsWithAcronym(trimmed)) return trimmed;
+  return trimmed.charAt(0).toLowerCase() + trimmed.slice(1);
+}
+
+/**
+ * Insert the breaking-change `!` into a conventional subject, at the one
+ * position `conventional-commits-parser` reads it: immediately before the
+ * colon, after any scope. A subject that already carries `!`, or that is not
+ * conventional, is returned unchanged. Pure.
+ *
+ * @param {string} subject
+ * @returns {string}
+ */
+export function markBreaking(subject) {
+  const parts = String(subject ?? '').match(HEADER_PARTS_RE);
+  if (!parts) return subject;
+  const [, prefix, bang, description] = parts;
+  if (bang === '!') return subject;
+  return `${prefix}!: ${description}`;
+}
+
+/**
+ * Pull the text of one `BREAKING CHANGE:` footer out of `lines`, starting at
+ * the footer line itself. The note runs to the end of its paragraph: a blank
+ * line, another trailer, or the end of the message closes it.
+ *
+ * @param {string[]} lines
+ * @param {number} start Index of the matched footer line.
+ * @param {string} head The footer line's own text (may be empty).
+ * @returns {{ note: string, next: number }}
+ */
+function readFooterNote(lines, start, head) {
+  const collected = head.trim().length > 0 ? [head.trim()] : [];
+  let cursor = start + 1;
+  while (cursor < lines.length) {
+    const line = lines[cursor];
+    if (line.trim().length === 0) break;
+    if (BREAKING_FOOTER_RE.test(line) || TRAILER_RE.test(line)) break;
+    collected.push(line.trim());
+    cursor += 1;
+  }
+  return { note: collected.join(' ').trim(), next: cursor };
+}
+
+/**
+ * Scan one commit message (or the Story body) for breaking-change evidence.
+ *
+ * @param {string} text
+ * @param {boolean} readHeaderBang Whether line 0 is a commit header whose `!`
+ *   counts. False for the Story body, which has no header.
+ * @returns {{ breaking: boolean, notes: string[], subject: string|null }}
+ */
+function scanForBreaking(text, readHeaderBang) {
+  const lines = String(text ?? '').split('\n');
+  const notes = [];
+  let breaking = false;
+  let subject = null;
+
+  if (readHeaderBang) {
+    const header = lines[0]?.trim() ?? '';
+    const parts = header.match(HEADER_PARTS_RE);
+    if (parts?.[2] === '!') {
+      breaking = true;
+      subject = parts[3].trim();
+    }
+  }
+
+  let cursor = 0;
+  while (cursor < lines.length) {
+    const match = lines[cursor].match(BREAKING_FOOTER_RE);
+    if (!match) {
+      cursor += 1;
+      continue;
+    }
+    breaking = true;
+    const { note, next } = readFooterNote(lines, cursor, match[1]);
+    if (note.length > 0) notes.push(note);
+    cursor = Math.max(next, cursor + 1);
+  }
+
+  return { breaking, notes, subject };
+}
+
+/**
+ * Collect the branch's breaking-change declarations.
+ *
+ * Two sources, both honoured:
+ *
+ *   - **Any constituent commit** — a `BREAKING CHANGE:` / `BREAKING-CHANGE:`
+ *     footer, or a `!` in the header. This is the path a maker takes while
+ *     writing the commit that does the breaking.
+ *   - **The Story body** — the same footer, written as its own line anywhere
+ *     in the Story issue (the `## Spec` block is the natural home). This is
+ *     the declarative path: `/plan` can state the break up front and close
+ *     propagates it even when no individual commit remembered the footer.
+ *     Only the footer form counts; prose describing a break does not, because
+ *     a keyword-free sentence is exactly what release-please cannot parse.
+ *
+ * When something is breaking but no footer supplied text, the `!` commit's
+ * own description becomes the note — the fallback Conventional Commits
+ * itself prescribes for a `!` header with no footer.
+ *
+ * @param {{ commitMessages?: string[], storyBody?: string }} args
+ * @returns {{ breaking: boolean, notes: string[] }}
+ */
+export function collectBreakingNotes({ commitMessages = [], storyBody = '' }) {
+  const notes = [];
+  let breaking = false;
+  let bangSubject = null;
+
+  for (const message of Array.isArray(commitMessages) ? commitMessages : []) {
+    const scan = scanForBreaking(message, true);
+    breaking = breaking || scan.breaking;
+    notes.push(...scan.notes);
+    bangSubject ??= scan.subject;
+  }
+
+  const bodyScan = scanForBreaking(storyBody, false);
+  breaking = breaking || bodyScan.breaking;
+  notes.push(...bodyScan.notes);
+
+  if (breaking && notes.length === 0 && bangSubject) notes.push(bangSubject);
+  return { breaking, notes: [...new Set(notes)] };
+}

--- a/.agents/scripts/lib/orchestration/single-story-close/phases/normalize-pr-title.js
+++ b/.agents/scripts/lib/orchestration/single-story-close/phases/normalize-pr-title.js
@@ -19,7 +19,7 @@
  * module mechanizes it.
  *
  * Contract (pure where possible — the only side effect is an injectable
- * `git log` read used to derive the type):
+ * `git log` read):
  *
  *   - If `storyTitle` is **already** a parseable Conventional Commit
  *     subject, it is preserved verbatim and suffixed with `(#<storyId>)`.
@@ -28,116 +28,48 @@
  *     `<type>: <descriptive text> (#<storyId>)`. The `type` is derived
  *     from the branch's own (already-conventional) commit subjects when
  *     available, falling back to a safe configured default (`chore`).
+ *   - Either way, a branch (or Story) that declares a breaking change gets
+ *     the `!` marker and a `BREAKING CHANGE:` footer on the PR body.
  *
- * Mirrors the already-normalized Epic-finalize default in
- * `lib/orchestration/finalize/open-or-locate-pr.js` (`feat: Epic #<id>`),
- * bringing the standalone path to the same guarantee.
+ * The rules that decide *what* the subject says now live in
+ * `conventional-subject.js` — type precedence, acronym-safe casing, and
+ * breaking-change collection are pure and unit-tested there. What is left
+ * here is the git read those rules consume and the assembly of the two
+ * strings `gh pr create` needs.
  */
 
 import { gitSpawn as defaultGitSpawn } from '../../../git-utils.js';
 import { Logger as DefaultLogger } from '../../../Logger.js';
+import {
+  collectBreakingNotes,
+  isConventionalSubject,
+  markBreaking,
+  pickDominantType,
+  shapeDescription,
+} from './conventional-subject.js';
 
 /** Safe default Conventional-Commit type when none can be derived. */
 const DEFAULT_CONVENTIONAL_TYPE = 'chore';
 
 /**
- * The Conventional-Commit types Mandrel accepts. Mirrors
- * `commitlint.config.js` → `type-enum` and `release-please-config.json` →
- * `changelog-sections`. Kept in sync by hand (single hard-cutover, no
- * shim) — adding a type means touching all three.
+ * Record separator between whole commit messages in the `git log` read. A NUL
+ * cannot occur inside a commit message, so splitting on it is unambiguous —
+ * unlike a blank-line or subject-prefix heuristic, which a commit body can
+ * forge.
  */
-const CONVENTIONAL_TYPES = Object.freeze([
-  'feat',
-  'fix',
-  'perf',
-  'refactor',
-  'revert',
-  'docs',
-  'style',
-  'chore',
-  'test',
-  'build',
-  'ci',
-]);
-
-// Precedence used when a branch carries a mix of conventional types: pick
-// the most release-significant one so the squash subject communicates the
-// branch's headline impact (and release-please bumps appropriately).
-const TYPE_PRECEDENCE = Object.freeze([
-  'feat',
-  'fix',
-  'perf',
-  'refactor',
-  'revert',
-  'docs',
-  'style',
-  'test',
-  'build',
-  'ci',
-  'chore',
-]);
-
-const TYPE_GROUP = CONVENTIONAL_TYPES.join('|');
-// Anchored Conventional-Commit header matcher:
-//   <type>(<optional scope>)<optional !>: <non-empty description>
-// Mirrors the shape `@commitlint/config-conventional` enforces (a known
-// type, an optional parenthesised scope, an optional breaking `!`, a
-// colon-space separator, and a non-empty subject). Used for the pure
-// "is this already conventional?" check and to pull the type off a branch
-// commit subject without spawning commitlint per call.
-const CONVENTIONAL_HEADER_RE = new RegExp(
-  `^(?:${TYPE_GROUP})(?:\\([^()\\r\\n]+\\))?!?: \\S.*$`,
-);
-const LEADING_TYPE_RE = new RegExp(
-  `^(${TYPE_GROUP})(?:\\([^()\\r\\n]+\\))?!?:`,
-);
+const RECORD_SEP = '\u0000';
 
 /**
- * True iff `subject` is a parseable Conventional Commit subject under the
- * repo's type vocabulary. Pure.
+ * Read the branch's own commits (those unique to the Story branch relative to
+ * the base branch) as whole messages — subject AND body, because the body is
+ * where a `BREAKING CHANGE:` footer lives.
  *
- * @param {string} subject
- * @returns {boolean}
- */
-function isConventionalSubject(subject) {
-  if (typeof subject !== 'string') return false;
-  return CONVENTIONAL_HEADER_RE.test(subject.trim());
-}
-
-/**
- * Extract the Conventional-Commit `type` from a single commit subject, or
- * `null` when the subject is not conventional. Pure.
+ * Returns `[]` when the read fails, which degrades every downstream rule to
+ * its safe default (type `chore`, no breaking marker) rather than throwing a
+ * close that is otherwise healthy.
  *
- * @param {string} subject
- * @returns {string|null}
- */
-function parseConventionalType(subject) {
-  if (typeof subject !== 'string') return null;
-  const match = subject.trim().match(LEADING_TYPE_RE);
-  return match ? match[1] : null;
-}
-
-/**
- * Pick the most release-significant type from a list of conventional
- * types, honouring `TYPE_PRECEDENCE`. Returns `null` for an empty list.
- * Pure.
- *
- * @param {string[]} types
- * @returns {string|null}
- */
-function pickDominantType(types) {
-  const present = new Set(types.filter(Boolean));
-  for (const candidate of TYPE_PRECEDENCE) {
-    if (present.has(candidate)) return candidate;
-  }
-  return null;
-}
-
-/**
- * Read the branch's own commit subjects (commits unique to the Story
- * branch relative to the base branch) and derive the dominant
- * Conventional-Commit type. Returns `DEFAULT_CONVENTIONAL_TYPE` when no
- * conventional subject is found or the git read fails.
+ * Oldest-first (`--reverse`) is load-bearing: `pickDominantType` breaks a tie
+ * on the Story's primary commit, which is the first one authored.
  *
  * @param {{
  *   storyBranch: string,
@@ -146,96 +78,174 @@ function pickDominantType(types) {
  *   gitSpawn?: typeof defaultGitSpawn,
  *   logger?: { warn?: Function },
  * }} args
- * @returns {string}
+ * @returns {string[]} Whole commit messages, oldest first.
  */
-function deriveTypeFromBranchCommits({
+function readBranchCommits({
   storyBranch,
   baseBranch,
   cwd = process.cwd(),
   gitSpawn = defaultGitSpawn,
   logger = DefaultLogger,
 }) {
+  if (!storyBranch || !baseBranch) return [];
+  const range = `${baseBranch}..${storyBranch}`;
   try {
-    const range = `${baseBranch}..${storyBranch}`;
-    const result = gitSpawn(cwd, 'log', '--no-merges', '--format=%s', range);
-    if (!result || result.status !== 0) {
+    const result = gitSpawn(
+      cwd,
+      'log',
+      '--no-merges',
+      '--reverse',
+      '--format=%B%x00',
+      range,
+    );
+    if (result?.status !== 0) {
       logger?.warn?.(
         `[normalize-pr-title] git log ${range} failed (status=${result?.status ?? 'n/a'}); ` +
-          `defaulting type to "${DEFAULT_CONVENTIONAL_TYPE}".`,
+          `defaulting type to "${DEFAULT_CONVENTIONAL_TYPE}" and assuming no breaking change.`,
       );
-      return DEFAULT_CONVENTIONAL_TYPE;
+      return [];
     }
-    const types = String(result.stdout ?? '')
-      .split('\n')
-      .map((line) => parseConventionalType(line))
-      .filter(Boolean);
-    return pickDominantType(types) ?? DEFAULT_CONVENTIONAL_TYPE;
+    return String(result.stdout ?? '')
+      .split(RECORD_SEP)
+      .map((message) => message.trim())
+      .filter((message) => message.length > 0);
   } catch (err) {
     logger?.warn?.(
-      `[normalize-pr-title] could not derive type from branch commits ` +
-        `(defaulting to "${DEFAULT_CONVENTIONAL_TYPE}"): ${err?.message ?? err}`,
+      `[normalize-pr-title] could not read branch commits ` +
+        `(defaulting to "${DEFAULT_CONVENTIONAL_TYPE}", no breaking change): ${err?.message ?? err}`,
     );
-    return DEFAULT_CONVENTIONAL_TYPE;
+    return [];
   }
 }
 
 /**
- * Produce a PR title that parses as a Conventional Commit.
+ * Produce the PR title and the breaking-change notes that belong with it.
  *
  *   - Already-conventional `storyTitle` → preserved verbatim + `(#<id>)`.
- *   - Otherwise → `<derivedType>: <storyTitle> (#<id>)`.
- *   - Empty / missing `storyTitle` → `<derivedType>: Story #<id>`.
+ *   - Otherwise → `<derivedType>: <shaped storyTitle> (#<id>)`.
+ *   - Empty / missing `storyTitle` → `<derivedType>: story #<id>`.
+ *   - Breaking → `!` inserted before the colon in either shape.
  *
- * The type derivation (`deriveTypeFromBranchCommits`) is the only side
- * effect, and is skipped entirely when the title is already conventional.
+ * `commitMessages` is the branch read (`readBranchCommits`); passing `[]`
+ * yields the safe default type and no breaking marker. `storyBody` is the
+ * Story issue's body, scanned for a declared `BREAKING CHANGE:` footer.
  *
  * @param {{
  *   storyTitle: string,
  *   storyId: number|string,
- *   storyBranch?: string,
- *   baseBranch?: string,
- *   cwd?: string,
- *   gitSpawn?: typeof defaultGitSpawn,
- *   logger?: { warn?: Function },
+ *   commitMessages?: string[],
+ *   storyBody?: string,
  * }} args
- * @returns {string}
+ * @returns {{ title: string, breaking: boolean, breakingNotes: string[] }}
  */
-export function normalizePrTitle({
+function normalizePrTitle({
   storyTitle,
   storyId,
+  commitMessages = [],
+  storyBody = '',
+}) {
+  const idSuffix = `(#${storyId})`;
+  const trimmed = typeof storyTitle === 'string' ? storyTitle.trim() : '';
+  const { breaking, notes } = collectBreakingNotes({
+    commitMessages,
+    storyBody,
+  });
+
+  // Already conventional → preserve verbatim (the maker's own casing and
+  // scope survive), append the id reference. Only the breaking marker may be
+  // added, and only when it is not already there.
+  const subject = isConventionalSubject(trimmed)
+    ? trimmed
+    : synthesizeSubject({ description: trimmed, storyId, commitMessages });
+
+  const marked = breaking ? markBreaking(subject) : subject;
+  return { title: `${marked} ${idSuffix}`, breaking, breakingNotes: notes };
+}
+
+/**
+ * Build a conventional subject for a Story whose title is plain prose.
+ *
+ * @param {{ description: string, storyId: number|string, commitMessages: string[] }} args
+ * @returns {string}
+ */
+function synthesizeSubject({ description, storyId, commitMessages }) {
+  const subjects = commitMessages.map((message) => message.split('\n')[0]);
+  const type = pickDominantType(subjects) ?? DEFAULT_CONVENTIONAL_TYPE;
+  const raw = description.length > 0 ? description : `Story #${storyId}`;
+  return `${type}: ${shapeDescription(raw)}`;
+}
+
+/**
+ * Build the PR body.
+ *
+ * The `Closes #<id>` footer is what auto-closes the Story on merge. A
+ * `BREAKING CHANGE:` footer goes LAST, as the spec requires, so that a repo
+ * configured to use the PR body as the squash-commit message hands
+ * release-please a parseable note rather than prose. When the squash body is
+ * built from the constituent commit messages instead (GitHub's default, and
+ * this repo's setting), the note still reaches `main` through whichever
+ * commit carried the footer — and the `!` in the subject carries the signal
+ * either way.
+ *
+ * @param {{ storyId: number|string, breakingNotes?: string[] }} args
+ * @returns {string}
+ */
+function buildPrBody({ storyId, breakingNotes }) {
+  const lines = [`Closes #${storyId}`, '', '_Auto-opened by `/deliver`._'];
+  if (breakingNotes.length > 0) {
+    lines.push('', `BREAKING CHANGE: ${breakingNotes.join(' ')}`);
+  }
+  return lines.join('\n');
+}
+
+/**
+ * Derive the two strings `gh pr create` needs. One `git log` read serves both
+ * halves: the commit SUBJECTS decide the type, and the commit BODIES — plus
+ * the Story body — decide whether this is a breaking change.
+ *
+ * A declared break is announced on the progress channel, because a `!` the
+ * operator did not expect in the squash subject should be visible while the
+ * close is running rather than discovered in the release notes.
+ *
+ * @param {{ storyTitle: string, storyId: number|string, storyBody?: string,
+ *   storyBranch: string, baseBranch: string, cwd?: string,
+ *   gitSpawn?: typeof defaultGitSpawn,
+ *   progress?: (tag: string, msg: string) => void }} args
+ * @returns {{ title: string, body: string, breaking: boolean, breakingNotes: string[] }}
+ */
+export function buildPullRequestFields({
+  storyTitle,
+  storyId,
+  storyBody = '',
   storyBranch,
   baseBranch,
   cwd = process.cwd(),
   gitSpawn = defaultGitSpawn,
-  logger = DefaultLogger,
+  progress = () => {},
 }) {
-  const idSuffix = `(#${storyId})`;
-  const trimmed = typeof storyTitle === 'string' ? storyTitle.trim() : '';
-
-  // Already conventional → preserve verbatim, append the id reference.
-  if (isConventionalSubject(trimmed)) {
-    return `${trimmed} ${idSuffix}`;
+  const commitMessages = readBranchCommits({
+    storyBranch,
+    baseBranch,
+    cwd,
+    gitSpawn,
+  });
+  const { title, breaking, breakingNotes } = normalizePrTitle({
+    storyTitle,
+    storyId,
+    commitMessages,
+    storyBody,
+  });
+  if (breaking) {
+    progress(
+      'PR',
+      '⚠️  Breaking change declared — the PR title carries `!` and the body a ' +
+        `BREAKING CHANGE footer: ${breakingNotes.join(' ') || '(no note text)'}`,
+    );
   }
-
-  // Not conventional → derive a type and synthesize.
-  const type =
-    storyBranch && baseBranch
-      ? deriveTypeFromBranchCommits({
-          storyBranch,
-          baseBranch,
-          cwd,
-          gitSpawn,
-          logger,
-        })
-      : DEFAULT_CONVENTIONAL_TYPE;
-
-  // Lowercase the leading character of a synthesized description so the
-  // subject satisfies commitlint's `subject-case` rule (matching the
-  // `shapeMergeSubject` behaviour). An already-conventional title is left
-  // untouched (it was preserved verbatim above). The empty-title fallback
-  // uses a lowercased `story #<id>` for the same reason.
-  const rawDescription = trimmed.length > 0 ? trimmed : `Story #${storyId}`;
-  const description =
-    rawDescription.charAt(0).toLowerCase() + rawDescription.slice(1);
-  return `${type}: ${description} ${idSuffix}`;
+  return {
+    title,
+    body: buildPrBody({ storyId, breakingNotes }),
+    breaking,
+    breakingNotes,
+  };
 }

--- a/.agents/scripts/lib/orchestration/single-story-close/phases/pull-request.js
+++ b/.agents/scripts/lib/orchestration/single-story-close/phases/pull-request.js
@@ -44,7 +44,7 @@
 import { gh as defaultGh } from '../../../gh-exec.js';
 import { Logger } from '../../../Logger.js';
 import { computeChangeSet as defaultComputeChangeSet } from '../../change-set.js';
-import { normalizePrTitle } from './normalize-pr-title.js';
+import { buildPullRequestFields } from './normalize-pr-title.js';
 
 /**
  * Pick the PR this head branch should resolve to from a `gh pr list
@@ -112,6 +112,7 @@ function probeEmptyDiff({ cwd, baseBranch, storyBranch, computeChangeSet }) {
  *   cwd: string,
  *   storyId: number,
  *   storyTitle: string,
+ *   storyBody?: string,
  *   storyBranch: string,
  *   baseBranch: string,
  *   gh?: ReturnType<typeof import('../../../gh-exec.js').createGh>,
@@ -124,6 +125,7 @@ export async function ensurePullRequestWith({
   cwd: _cwd,
   storyId,
   storyTitle,
+  storyBody = '',
   storyBranch,
   baseBranch,
   gh = defaultGh,
@@ -185,26 +187,19 @@ export async function ensurePullRequestWith({
   }
 
   progress('PR', `Opening PR for ${storyBranch} → ${baseBranch}...`);
-  // The repo squash-merges and GitHub uses the PR title as the squash
-  // subject on `main`. A raw human issue title is not a Conventional
-  // Commit, so release-please silently counts it as 0 releasable commits
-  // (Story #3969). Normalize the title to conventional form: preserve an
-  // already-conventional `storyTitle` verbatim, otherwise synthesize a
-  // type derived from the branch's own commit subjects (default `chore`).
-  // `gh-exec` spawns `gh` against the current process cwd (the worktree),
-  // so the branch-commit read uses the same cwd.
-  const title = normalizePrTitle({
+  // The repo squash-merges and GitHub uses the PR title as the squash subject
+  // on `main`, so both fields are derived rather than typed — see
+  // `normalize-pr-title.js`. `gh-exec` spawns `gh` against the current process
+  // cwd (the worktree), so the branch read uses the same cwd.
+  const { title, body } = buildPullRequestFields({
     storyTitle,
     storyId,
+    storyBody,
     storyBranch,
     baseBranch,
     cwd: _cwd ?? process.cwd(),
+    progress,
   });
-  const body = [
-    `Closes #${storyId}`,
-    '',
-    `_Auto-opened by \`/deliver\`._`,
-  ].join('\n');
   try {
     const createResult = await gh.pr.create([
       '--base',

--- a/.agents/scripts/lib/orchestration/single-story-close/runner.js
+++ b/.agents/scripts/lib/orchestration/single-story-close/runner.js
@@ -222,6 +222,8 @@ async function openAndReviewPr({
     cwd,
     storyId,
     storyTitle: story.title,
+    // Scanned for a declared `BREAKING CHANGE:` footer — see pull-request.js.
+    storyBody: story.body,
     storyBranch,
     baseBranch,
     gh: injectedGh,

--- a/baselines/coverage.json
+++ b/baselines/coverage.json
@@ -1,12 +1,12 @@
 {
   "$schema": ".agents/schemas/baselines/coverage.schema.json",
   "kernelVersion": "1.0.0",
-  "generatedAt": "2026-08-06T10:16:31.302Z",
+  "generatedAt": "2026-08-06T10:31:25.748Z",
   "rollup": {
     "*": {
-      "lines": 95.77,
-      "branches": 86.4,
-      "functions": 88.47
+      "lines": 95.8,
+      "branches": 86.47,
+      "functions": 88.59
     }
   },
   "rows": [
@@ -2177,10 +2177,16 @@
       "functions": 95.65
     },
     {
+      "path": ".agents/scripts/lib/orchestration/single-story-close/phases/conventional-subject.js",
+      "lines": 100,
+      "branches": 87.3,
+      "functions": 100
+    },
+    {
       "path": ".agents/scripts/lib/orchestration/single-story-close/phases/normalize-pr-title.js",
-      "lines": 92.53,
-      "branches": 42.86,
-      "functions": 60
+      "lines": 100,
+      "branches": 83.87,
+      "functions": 100
     },
     {
       "path": ".agents/scripts/lib/orchestration/single-story-close/phases/options.js",
@@ -2232,9 +2238,9 @@
     },
     {
       "path": ".agents/scripts/lib/orchestration/single-story-close/runner.js",
-      "lines": 96.4,
-      "branches": 83.78,
-      "functions": 84.62
+      "lines": 96.75,
+      "branches": 83.54,
+      "functions": 89.47
     },
     {
       "path": ".agents/scripts/lib/orchestration/single-story-lease-guard.js",
@@ -3272,6 +3278,12 @@
       "path": "lib/migrations/steps/2.20.0-retire-codebase-snapshot.js",
       "lines": 100,
       "branches": 83.33,
+      "functions": 100
+    },
+    {
+      "path": "lib/migrations/steps/2.32.0-retire-lint-baseline-command.js",
+      "lines": 100,
+      "branches": 82.35,
       "functions": 100
     }
   ]

--- a/baselines/crap.json
+++ b/baselines/crap.json
@@ -1,7 +1,7 @@
 {
   "$schema": ".agents/schemas/baselines/crap.schema.json",
   "kernelVersion": "0.1.0",
-  "generatedAt": "2026-08-06T10:26:11.732Z",
+  "generatedAt": "2026-08-06T10:31:24.534Z",
   "scoringSemantics": "method-identity-v3",
   "tsTranspilerVersion": "6.0.3",
   "provenanceStamped": true,
@@ -15908,41 +15908,122 @@
       "crap": 1
     },
     {
-      "path": ".agents/scripts/lib/orchestration/single-story-close/phases/normalize-pr-title.js",
+      "path": ".agents/scripts/lib/orchestration/single-story-close/phases/conventional-subject.js",
       "method": "isConventionalSubject",
-      "startLine": 102,
+      "startLine": 131,
       "crap": 2
     },
     {
-      "path": ".agents/scripts/lib/orchestration/single-story-close/phases/normalize-pr-title.js",
+      "path": ".agents/scripts/lib/orchestration/single-story-close/phases/conventional-subject.js",
       "method": "parseConventionalType",
-      "startLine": 114,
-      "crap": 7.608000000000001
+      "startLine": 143,
+      "crap": 3
     },
     {
-      "path": ".agents/scripts/lib/orchestration/single-story-close/phases/normalize-pr-title.js",
+      "path": ".agents/scripts/lib/orchestration/single-story-close/phases/conventional-subject.js",
+      "method": "compareTypeCandidates",
+      "startLine": 159,
+      "crap": 3
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/single-story-close/phases/conventional-subject.js",
       "method": "pickDominantType",
-      "startLine": 128,
-      "crap": 4.518950437317785
+      "startLine": 176,
+      "crap": 3
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/single-story-close/phases/conventional-subject.js",
+      "method": "<anon pickDominantType/(subject,index)#0>",
+      "startLine": 180,
+      "crap": 3,
+      "anonymous": true
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/single-story-close/phases/conventional-subject.js",
+      "method": "leadsWithAcronym",
+      "startLine": 209,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/single-story-close/phases/conventional-subject.js",
+      "method": "shapeDescription",
+      "startLine": 224,
+      "crap": 4
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/single-story-close/phases/conventional-subject.js",
+      "method": "markBreaking",
+      "startLine": 240,
+      "crap": 3
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/single-story-close/phases/conventional-subject.js",
+      "method": "readFooterNote",
+      "startLine": 258,
+      "crap": 6
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/single-story-close/phases/conventional-subject.js",
+      "method": "scanForBreaking",
+      "startLine": 279,
+      "crap": 6
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/single-story-close/phases/conventional-subject.js",
+      "method": "collectBreakingNotes",
+      "startLine": 332,
+      "crap": 6
     },
     {
       "path": ".agents/scripts/lib/orchestration/single-story-close/phases/normalize-pr-title.js",
-      "method": "deriveTypeFromBranchCommits",
-      "startLine": 151,
-      "crap": 3.072
+      "method": "readBranchCommits",
+      "startLine": 83,
+      "crap": 4
     },
     {
       "path": ".agents/scripts/lib/orchestration/single-story-close/phases/normalize-pr-title.js",
-      "method": "<anon deriveTypeFromBranchCommits/(line)#0>",
-      "startLine": 170,
-      "crap": 1.008,
+      "method": "<anon readBranchCommits/(message)#0>",
+      "startLine": 110,
+      "crap": 1,
+      "anonymous": true
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/single-story-close/phases/normalize-pr-title.js",
+      "method": "<anon readBranchCommits/(message)#1>",
+      "startLine": 111,
+      "crap": 1,
       "anonymous": true
     },
     {
       "path": ".agents/scripts/lib/orchestration/single-story-close/phases/normalize-pr-title.js",
       "method": "normalizePrTitle",
-      "startLine": 203,
-      "crap": 6.004855105446821
+      "startLine": 141,
+      "crap": 4
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/single-story-close/phases/normalize-pr-title.js",
+      "method": "synthesizeSubject",
+      "startLine": 171,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/single-story-close/phases/normalize-pr-title.js",
+      "method": "<anon synthesizeSubject/(message)#0>",
+      "startLine": 172,
+      "crap": 1,
+      "anonymous": true
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/single-story-close/phases/normalize-pr-title.js",
+      "method": "buildPrBody",
+      "startLine": 193,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/single-story-close/phases/normalize-pr-title.js",
+      "method": "buildPullRequestFields",
+      "startLine": 216,
+      "crap": 3
     },
     {
       "path": ".agents/scripts/lib/orchestration/single-story-close/phases/options.js",
@@ -16089,8 +16170,20 @@
     },
     {
       "path": ".agents/scripts/lib/orchestration/single-story-close/phases/pull-request.js",
+      "method": "pickHeadPullRequest",
+      "startLine": 69,
+      "crap": 7
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/single-story-close/phases/pull-request.js",
+      "method": "probeEmptyDiff",
+      "startLine": 98,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/single-story-close/phases/pull-request.js",
       "method": "ensurePullRequestWith",
-      "startLine": 39,
+      "startLine": 124,
       "crap": 4
     },
     {
@@ -16319,87 +16412,87 @@
     {
       "path": ".agents/scripts/lib/orchestration/single-story-close/runner.js",
       "method": "releaseLease",
-      "startLine": 266,
+      "startLine": 268,
       "crap": 2
     },
     {
       "path": ".agents/scripts/lib/orchestration/single-story-close/runner.js",
       "method": "releaseLeaseOnBlock",
-      "startLine": 319,
+      "startLine": 321,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/orchestration/single-story-close/runner.js",
       "method": "closeResult",
-      "startLine": 328,
+      "startLine": 330,
       "crap": 3
     },
     {
       "path": ".agents/scripts/lib/orchestration/single-story-close/runner.js",
       "method": "runSingleStoryClose",
-      "startLine": 374,
+      "startLine": 376,
       "crap": 5.005565294821493
     },
     {
       "path": ".agents/scripts/lib/orchestration/single-story-close/runner.js",
       "method": "<anon runSingleStoryClose/(next)#0>",
-      "startLine": 417,
+      "startLine": 419,
       "crap": 1,
       "anonymous": true
     },
     {
       "path": ".agents/scripts/lib/orchestration/single-story-close/runner.js",
       "method": "resolveAutoMergeOutcome",
-      "startLine": 451,
+      "startLine": 453,
       "crap": 3.0308039068369643
     },
     {
       "path": ".agents/scripts/lib/orchestration/single-story-close/runner.js",
       "method": "reportWaitTerminal",
-      "startLine": 472,
+      "startLine": 474,
       "crap": 3.616172051089406
     },
     {
       "path": ".agents/scripts/lib/orchestration/single-story-close/runner.js",
       "method": "finishWithMergeWait",
-      "startLine": 503,
+      "startLine": 505,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/orchestration/single-story-close/runner.js",
       "method": "finishWithoutMergeWait",
-      "startLine": 567,
+      "startLine": 569,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/orchestration/single-story-close/runner.js",
       "method": "elapsedSecondsSince",
-      "startLine": 615,
+      "startLine": 617,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/orchestration/single-story-close/runner.js",
       "method": "reportOperatorMergeSkip",
-      "startLine": 628,
+      "startLine": 630,
       "crap": 3.474609375
     },
     {
       "path": ".agents/scripts/lib/orchestration/single-story-close/runner.js",
       "method": "runClosePipeline",
-      "startLine": 650,
+      "startLine": 652,
       "crap": 8
     },
     {
       "path": ".agents/scripts/lib/orchestration/single-story-close/runner.js",
       "method": "<anon runClosePipeline/()#0>",
-      "startLine": 715,
+      "startLine": 717,
       "crap": 1,
       "anonymous": true
     },
     {
       "path": ".agents/scripts/lib/orchestration/single-story-close/runner.js",
       "method": "<anon runClosePipeline/()#1>",
-      "startLine": 732,
+      "startLine": 734,
       "crap": 1,
       "anonymous": true
     },
@@ -24332,32 +24425,32 @@
     {
       "path": "lib/migrations/index.js",
       "method": "parseVersion",
-      "startLine": 88,
+      "startLine": 90,
       "crap": 4
     },
     {
       "path": "lib/migrations/index.js",
       "method": "compareVersions",
-      "startLine": 106,
-      "crap": 3.017578125
+      "startLine": 108,
+      "crap": 3
     },
     {
       "path": "lib/migrations/index.js",
       "method": "runMigrations",
-      "startLine": 146,
+      "startLine": 148,
       "crap": 2
     },
     {
       "path": "lib/migrations/index.js",
       "method": "<anon runMigrations/(step)#0>",
-      "startLine": 155,
+      "startLine": 157,
       "crap": 2,
       "anonymous": true
     },
     {
       "path": "lib/migrations/index.js",
       "method": "<anon runMigrations/(a,b)#0>",
-      "startLine": 159,
+      "startLine": 161,
       "crap": 1,
       "anonymous": true
     },
@@ -24491,6 +24584,24 @@
       "startLine": 92,
       "crap": 1.2962962962962963,
       "anonymous": true
+    },
+    {
+      "path": "lib/migrations/steps/2.32.0-retire-lint-baseline-command.js",
+      "method": "resolveAgentrcPath",
+      "startLine": 38,
+      "crap": 1
+    },
+    {
+      "path": "lib/migrations/steps/2.32.0-retire-lint-baseline-command.js",
+      "method": "readAgentrcConfig",
+      "startLine": 48,
+      "crap": 1
+    },
+    {
+      "path": "lib/migrations/steps/2.32.0-retire-lint-baseline-command.js",
+      "method": "hasRetiredKey",
+      "startLine": 61,
+      "crap": 2
     }
   ]
 }

--- a/baselines/duplication.json
+++ b/baselines/duplication.json
@@ -1,13 +1,13 @@
 {
   "$schema": ".agents/schemas/baselines/duplication.schema.json",
   "kernelVersion": "1.0.0",
-  "generatedAt": "2026-08-06T09:56:22.975Z",
+  "generatedAt": "2026-08-06T10:31:29.291Z",
   "rollup": {
     "*": {
-      "percentage": 7.9,
-      "duplicatedLines": 1726,
-      "totalLines": 21840,
-      "filesWithDuplication": 78
+      "percentage": 7.89,
+      "duplicatedLines": 1799,
+      "totalLines": 22804,
+      "filesWithDuplication": 80
     }
   },
   "rows": [
@@ -264,6 +264,12 @@
       "percentage": 3.37
     },
     {
+      "path": ".agents/scripts/lib/orchestration/single-story-close/runner.js",
+      "duplicatedLines": 20,
+      "totalLines": 862,
+      "percentage": 2.32
+    },
+    {
       "path": ".agents/scripts/lib/orchestration/story-close/format-autofix.js",
       "duplicatedLines": 11,
       "totalLines": 520,
@@ -478,6 +484,12 @@
       "duplicatedLines": 55,
       "totalLines": 113,
       "percentage": 48.67
+    },
+    {
+      "path": "lib/migrations/steps/2.32.0-retire-lint-baseline-command.js",
+      "duplicatedLines": 53,
+      "totalLines": 102,
+      "percentage": 51.96
     }
   ]
 }

--- a/baselines/maintainability.json
+++ b/baselines/maintainability.json
@@ -1,10 +1,10 @@
 {
   "$schema": ".agents/schemas/baselines/maintainability.schema.json",
   "kernelVersion": "0.1.0",
-  "generatedAt": "2026-08-06T10:16:31.702Z",
+  "generatedAt": "2026-08-06T10:31:23.849Z",
   "rollup": {
     "*": {
-      "min": 76.058,
+      "min": 76.381,
       "p50": 98.358,
       "p95": 122.913
     }
@@ -1427,8 +1427,12 @@
       "mi": 90.578
     },
     {
+      "path": ".agents/scripts/lib/orchestration/single-story-close/phases/conventional-subject.js",
+      "mi": 91.925
+    },
+    {
       "path": ".agents/scripts/lib/orchestration/single-story-close/phases/normalize-pr-title.js",
-      "mi": 100.606
+      "mi": 101.211
     },
     {
       "path": ".agents/scripts/lib/orchestration/single-story-close/phases/options.js",
@@ -1464,7 +1468,7 @@
     },
     {
       "path": ".agents/scripts/lib/orchestration/single-story-close/runner.js",
-      "mi": 76.058
+      "mi": 80.523
     },
     {
       "path": ".agents/scripts/lib/orchestration/single-story-lease-guard.js",
@@ -2189,6 +2193,10 @@
     {
       "path": "lib/migrations/steps/2.20.0-retire-codebase-snapshot.js",
       "mi": 107.31
+    },
+    {
+      "path": "lib/migrations/steps/2.32.0-retire-lint-baseline-command.js",
+      "mi": 103.921
     }
   ]
 }

--- a/lib/migrations/__tests__/index.test.js
+++ b/lib/migrations/__tests__/index.test.js
@@ -72,19 +72,21 @@ describe('migrations module exports', () => {
   // verify-concurrency-cap retirement (both 2.1.0); Story #4604 appended the
   // epic-AC-tag retirement at 2.2.0; the Story #4722 follow-up appended the
   // maxSeedWords retirement at 2.11.0; Story #4811 appended the
-  // codebaseSnapshot retirement at 2.20.0. The registry's declaration order is
-  // what fixes the run order within a version — pin it.
+  // codebaseSnapshot retirement at 2.20.0; the Story #5004 follow-up appended
+  // the lintBaseline-command retirement at 2.32.0. The registry's declaration
+  // order is what fixes the run order within a version — pin it.
   it('ships the real steps in ascending version + declaration order', () => {
-    assert.equal(migrations.length, 5);
+    assert.equal(migrations.length, 6);
     assert.deepEqual(
       migrations.map((s) => s.version),
-      ['2.1.0', '2.1.0', '2.2.0', '2.11.0', '2.20.0'],
+      ['2.1.0', '2.1.0', '2.2.0', '2.11.0', '2.20.0', '2.32.0'],
     );
     assert.match(migrations[0].description, /mi|maintainability/i);
     assert.match(migrations[1].description, /concurrency/i);
     assert.match(migrations[2].description, /epic-<id>-ac-N/);
     assert.match(migrations[3].description, /maxSeedWords/);
     assert.match(migrations[4].description, /codebaseSnapshot/);
+    assert.match(migrations[5].description, /lintBaseline/);
   });
 });
 

--- a/lib/migrations/index.js
+++ b/lib/migrations/index.js
@@ -57,6 +57,7 @@ import { retireVerifyConcurrencyCap } from './steps/2.1.0-retire-verify-concurre
 import { retireEpicAcTags } from './steps/2.2.0-retire-epic-ac-tags.js';
 import { retireMaxSeedWords } from './steps/2.11.0-retire-max-seed-words.js';
 import { retireCodebaseSnapshot } from './steps/2.20.0-retire-codebase-snapshot.js';
+import { retireLintBaselineCommand } from './steps/2.32.0-retire-lint-baseline-command.js';
 
 /**
  * Ordered registry of migration steps. MUST stay sorted ascending by
@@ -75,6 +76,7 @@ export const migrations = [
   retireEpicAcTags,
   retireMaxSeedWords,
   retireCodebaseSnapshot,
+  retireLintBaselineCommand,
 ];
 
 /**

--- a/lib/migrations/steps/2.32.0-retire-lint-baseline-command.js
+++ b/lib/migrations/steps/2.32.0-retire-lint-baseline-command.js
@@ -1,0 +1,102 @@
+// lib/migrations/steps/2.32.0-retire-lint-baseline-command.js
+/**
+ * Story #5004 follow-up — strip the retired `project.commands.lintBaseline`
+ * key from a consumer's `.agentrc.json`.
+ *
+ * #5004 (PR #5019) deleted `lint-baseline.js` and
+ * `lib/orchestration/lint-baseline-service.js`: the CLI spawned the configured
+ * command and parsed ESLint-shaped JSON, a shape this repo's own `npm run
+ * lint` (Biome + markdownlint fan-out) never produced, and nothing invoked the
+ * service. The key left the runtime AJV schema, the published mirror,
+ * `.agentrc.json` and `agentrc-reference.json` in the same change.
+ *
+ * `project.commands` carries `additionalProperties: false`, so a consumer
+ * whose config still sets `lintBaseline` hits a hard validation failure on
+ * upgrade, not a warning. This step strips the key before that check runs —
+ * the same contract-cutover pattern as `2.11.0-retire-max-seed-words.js`.
+ *
+ * The `lint` baseline KIND survives for consumers whose own linter writes
+ * `baselines/lint.json`; only the framework-owned capture shell is gone, so
+ * nothing here touches the baseline file or the gate config.
+ *
+ * This step is also the carrier for the release note #5004 never emitted: its
+ * commit ships the `BREAKING CHANGE:` footer that the squash subject on `main`
+ * (`227e1af4`) lacks, and which release-please therefore could not surface.
+ * See `single-story-close/phases/conventional-subject.js` for the close-side
+ * fix that stops the next one being lost.
+ */
+
+import nodeFs from 'node:fs';
+import path from 'node:path';
+
+const AGENTRC_FILENAME = '.agentrc.json';
+
+/**
+ * @param {unknown} ctx
+ * @returns {string}
+ */
+function resolveAgentrcPath(ctx) {
+  const projectRoot = ctx?.projectRoot ?? process.cwd();
+  return path.join(projectRoot, AGENTRC_FILENAME);
+}
+
+/**
+ * @param {unknown} ctx
+ * @param {typeof nodeFs} fsImpl
+ * @returns {object | null}
+ */
+function readAgentrcConfig(ctx, fsImpl) {
+  try {
+    const raw = fsImpl.readFileSync(resolveAgentrcPath(ctx), 'utf8');
+    return JSON.parse(raw);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * @param {object | null} config
+ * @returns {boolean}
+ */
+function hasRetiredKey(config) {
+  const commands = config?.project?.commands;
+  return Boolean(commands) && Object.hasOwn(commands, 'lintBaseline');
+}
+
+export const retireLintBaselineCommand = {
+  version: '2.32.0',
+  description:
+    'strip retired project.commands.lintBaseline from .agentrc.json ' +
+    '(the framework lint-baseline capture CLI is gone — Story #5004)',
+  /**
+   * @param {{ projectRoot?: string, fs?: typeof nodeFs }} [ctx]
+   * @returns {boolean}
+   */
+  detect(ctx) {
+    const fsImpl = ctx?.fs ?? nodeFs;
+    return hasRetiredKey(readAgentrcConfig(ctx, fsImpl));
+  },
+  /**
+   * @param {{ projectRoot?: string, fs?: typeof nodeFs }} [ctx]
+   * @returns {void}
+   */
+  apply(ctx) {
+    const fsImpl = ctx?.fs ?? nodeFs;
+    const config = readAgentrcConfig(ctx, fsImpl);
+    if (!config) return;
+
+    const commands = config.project?.commands;
+    if (commands && Object.hasOwn(commands, 'lintBaseline')) {
+      delete commands.lintBaseline;
+      // An emptied `commands` block is left in place: unlike
+      // `planning.complexityGate`, `project` is a required block and an empty
+      // `commands` object is valid against the schema, so pruning it would be
+      // a cosmetic edit to a config the consumer owns.
+    }
+
+    fsImpl.writeFileSync(
+      resolveAgentrcPath(ctx),
+      `${JSON.stringify(config, null, 2)}\n`,
+    );
+  },
+};

--- a/lib/migrations/steps/__tests__/2.32.0-retire-lint-baseline-command.test.js
+++ b/lib/migrations/steps/__tests__/2.32.0-retire-lint-baseline-command.test.js
@@ -1,0 +1,107 @@
+// lib/migrations/steps/__tests__/2.32.0-retire-lint-baseline-command.test.js
+/**
+ * Unit tests for the Story #5004 follow-up migration step — strips the
+ * retired `project.commands.lintBaseline` key from a consumer
+ * `.agentrc.json`. All tests drive `detect`/`apply` against an in-memory
+ * fake fs (testing-standards § Unit) — no real filesystem I/O.
+ */
+
+import assert from 'node:assert/strict';
+import path from 'node:path';
+import { describe, it } from 'node:test';
+
+import { retireLintBaselineCommand } from '../2.32.0-retire-lint-baseline-command.js';
+
+const PROJECT_ROOT = '/consumer';
+const AGENTRC_PATH = path.join(PROJECT_ROOT, '.agentrc.json');
+
+/**
+ * @param {object | null} initialConfig - `null` means no file on disk.
+ * @returns {{ ctx: object, readConfig: () => object }}
+ */
+function makeCtx(initialConfig) {
+  const files = new Map();
+  if (initialConfig !== null) {
+    files.set(AGENTRC_PATH, JSON.stringify(initialConfig, null, 2));
+  }
+
+  const fs = {
+    readFileSync(filePath) {
+      if (!files.has(filePath)) {
+        const err = new Error(`ENOENT: ${filePath}`);
+        err.code = 'ENOENT';
+        throw err;
+      }
+      return files.get(filePath);
+    },
+    writeFileSync(filePath, contents) {
+      files.set(filePath, contents);
+    },
+  };
+
+  return {
+    ctx: { projectRoot: PROJECT_ROOT, fs },
+    readConfig: () => JSON.parse(files.get(AGENTRC_PATH)),
+  };
+}
+
+describe('retireLintBaselineCommand — detect', () => {
+  it('detects a config carrying project.commands.lintBaseline', () => {
+    const { ctx } = makeCtx({
+      project: { commands: { lintBaseline: 'npm run lint -- --format json' } },
+    });
+    assert.equal(retireLintBaselineCommand.detect(ctx), true);
+  });
+
+  it('does not detect a commands block without the key', () => {
+    const { ctx } = makeCtx({
+      project: { commands: { typecheck: 'tsc --noEmit' } },
+    });
+    assert.equal(retireLintBaselineCommand.detect(ctx), false);
+  });
+
+  it('does not detect an absent commands block or an absent config', () => {
+    assert.equal(retireLintBaselineCommand.detect(makeCtx({}).ctx), false);
+    assert.equal(retireLintBaselineCommand.detect(makeCtx(null).ctx), false);
+  });
+});
+
+describe('retireLintBaselineCommand — apply', () => {
+  it('removes the key and leaves the rest of the config intact', () => {
+    const { ctx, readConfig } = makeCtx({
+      project: {
+        paths: { agentRoot: '.agents' },
+        commands: { lintBaseline: 'npm run lint', typecheck: 'tsc --noEmit' },
+      },
+      delivery: { quality: { gates: { lint: { baselinePath: 'b.json' } } } },
+    });
+    retireLintBaselineCommand.apply(ctx);
+    const config = readConfig();
+    assert.equal(Object.hasOwn(config.project.commands, 'lintBaseline'), false);
+    assert.equal(config.project.commands.typecheck, 'tsc --noEmit');
+    assert.equal(config.project.paths.agentRoot, '.agents');
+    // The `lint` baseline KIND survives — only the capture shell was retired.
+    assert.equal(config.delivery.quality.gates.lint.baselinePath, 'b.json');
+  });
+
+  it('leaves an emptied commands block in place', () => {
+    const { ctx, readConfig } = makeCtx({
+      project: { commands: { lintBaseline: 'npm run lint' } },
+    });
+    retireLintBaselineCommand.apply(ctx);
+    assert.deepEqual(readConfig().project.commands, {});
+  });
+
+  it('is idempotent — a second pass detects nothing', () => {
+    const { ctx } = makeCtx({
+      project: { commands: { lintBaseline: 'npm run lint' } },
+    });
+    retireLintBaselineCommand.apply(ctx);
+    assert.equal(retireLintBaselineCommand.detect(ctx), false);
+  });
+
+  it('is a no-op when there is no config on disk', () => {
+    const { ctx } = makeCtx(null);
+    assert.doesNotThrow(() => retireLintBaselineCommand.apply(ctx));
+  });
+});


### PR DESCRIPTION
## Why

The PR title `single-story-close` writes becomes the squash-merge subject on `main`, and that subject is the only thing release-please parses. Three defects in that derivation, each observed live:

| Live subject | Defect |
| --- | --- |
| `227e1af4 docs: check/CI gate sweep… (#5004)` | Story #5004's three commits were `chore(gates)`, `docs(ci)`, `chore(baselines)`. The precedence list put `docs` above `chore` for no stated reason, so a change that deleted five `lib/checks` modules, two CLIs and a dependency filed as documentation — and `docs` is `hidden: true`, so it renders in **no** changelog section at all. |
| `7624c125 refactor: cRAP surface diet…` | The first character was lowercased unconditionally, mangling the acronym. |
| `227e1af4` again | `project.commands.lintBaseline` was removed from a schema block that is `additionalProperties: false` — a hard consumer break — described in three body paragraphs with no `BREAKING CHANGE:` footer and no `!`. release-please cannot see prose. |

`38dfc3c6 feat(gates): … (refs #5001)` is the control: a single-commit Story whose own subject passed through intact.

## What changed

**1. Type precedence follows release impact.** `TYPE_RANK` now mirrors `changelog-sections` in `release-please-config.json` — rank *is* release-notes visibility. The five visible types (`feat` > `fix` > `perf` > `revert` > `refactor`) are strictly ordered; the six `hidden: true` types share one rank, because the release notes draw no distinction between them. Ties inside that tier break on how much of the branch carries the type, then on the Story's primary (oldest) commit. #5004 now resolves to `chore`, not `docs`.

**2. Casing leaves acronyms alone.** `shapeDescription` lowercases the leading character only when the first word is not an all-caps token, so CRAP / CI / QA / API survive and ordinary prose titles still lowercase. Deliberate trade, documented in the module header: commitlint's `subject-case` treats *any* leading capital as sentence-case and would flag `CRAP surface diet` — but commitlint never runs on a PR title or a GitHub squash subject, while a mangled acronym is permanent in the changelog.

**3. Breaking changes survive the squash.** The branch read widened from `--format=%s` to whole messages (`--format=%B%x00 --reverse`), so close reads a `BREAKING CHANGE:` / `BREAKING-CHANGE:` footer out of *any* constituent commit — or out of the **Story body**, which is the new declarative path for a break known at plan time or spanning several commits. It marks the title `<type>!:`, appends the collected note to the PR body as a footer, and announces it on the progress channel. Prose is deliberately **not** matched: a keyword-free sentence is exactly what release-please cannot parse, and announcing a break the parser will not see is worse than staying quiet.

The rules moved into a new pure `conventional-subject.js`, testable without a git read; `normalize-pr-title.js` keeps the git read and the string assembly behind one export, `buildPullRequestFields`.

## One-off remediation

`227e1af4` cannot be rewritten, so the #5004 break is carried into the same release by `2.32.0-retire-lint-baseline-command.js` — the migration step #5004 should have shipped. It strips `project.commands.lintBaseline` from a consumer's `.agentrc.json` on `mandrel update`, and its commit carries the `BREAKING CHANGE:` footer release-please needs. This is a changelog-classification fix only: versioning is `always-bump-minor` and capped at 2.x, so the version number is unaffected.

For the record, the other four unreleased commits (`a019c144`, `073415eb`, `7c19dc5d`, `a62efd5d`) already carry footers and will surface on their own; #5004 was the only one with a real break and none.

## Tests

30 new unit tests across the two suites, including the two live subjects above as named regressions:

- type precedence across the full vocabulary, the #5004 three-commit case, the hidden-tier count and primary-commit tie-breaks, non-conventional and `!`-marked subjects;
- casing for CRAP / API / CI / QA / `CI/CD` / `A11y` / single letters / mixed case;
- breaking detection from a commit footer, the hyphenated spelling, a `!` header with no footer, a Story-body declaration, duplicate collapsing, trailer termination — and the two negatives that matter: prose describing a break, and a lowercase `breaking change:`;
- the branch read itself: NUL record split, `--reverse` ordering, and the degraded path when `git log` fails or throws.

## Verification

- `npm test` — 9701 pass, 0 fail, 4 skipped
- `npm run verify` — exit 0 (baselines, dead-exports both modes, context-budget, cyclomatic, schema references)
- `npm run lint` — 0 errors
- `node .agents/scripts/check-baselines.js` — exit 0

The always-on closure budget is respected: `rules/git-conventions.md` gains a two-line MUST and the detail lives in the on-demand reference file.

BREAKING CHANGE: `project.commands.lintBaseline` is removed from the `.agentrc.json` schema. The `project.commands` block is `additionalProperties: false`, so a config still carrying the key now fails validation instead of being ignored. `npx mandrel update` deletes it for you; delete it by hand otherwise. Nothing replaces it — the framework no longer ships a lint-baseline capture CLI, and a consumer that wants the `lint` baseline kind writes `baselines/lint.json` from its own linter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect every Story PR title/body at close (release-please and changelog classification) and ship a consumer config migration on `mandrel update`; behavior is heavily tested but is on the delivery critical path.
> 
> **Overview**
> **`/deliver` close** now builds squash-merge-ready PR titles and bodies so release-please can parse them. Logic moved into pure **`conventional-subject.js`**; **`normalize-pr-title.js`** exposes **`buildPullRequestFields`** (replacing title-only **`normalizePrTitle`**) and reads full commit messages oldest-first via `git log`.
> 
> **Type choice** follows **`release-please-config.json` changelog visibility** (`TYPE_RANK`), not a fixed list where `docs` beat `chore`. Hidden-tier ties use commit count, then the oldest commit.
> 
> **Prose Story titles** use **`shapeDescription`**, which keeps leading acronyms (e.g. CRAP, CI) instead of blind lowercasing.
> 
> **Breaking changes** are collected from commit footers, `!` headers, or a **`BREAKING CHANGE:`** line in the Story body; close adds **`!`** to the title and appends the footer to the PR body, with progress warnings. **`pull-request.js`** / **`runner.js`** pass **`storyBody`** through.
> 
> **Docs:** git conventions now require formal breaking declarations and document how close propagates them.
> 
> **Remediation:** **`2.32.0-retire-lint-baseline-command.js`** strips retired **`project.commands.lintBaseline`** on update (the #5004 break that never hit release notes). **~30 unit tests** cover the new rules and integration paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 40306c0757b0f5da015ebc3baf66912a7878e6a6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->