### PR TITLE
feat(baselines): schedule the full-scope re-score and correct #5004's record of what it removed

### DIFF
--- a/.agents/docs/quality-gates.md
+++ b/.agents/docs/quality-gates.md
@@ -172,15 +172,20 @@ baseline still trips the gate.
   run on push; use `npm run verify` locally before a PR. CI enforces the
   authoritative full gate set on every PR.
 - **CI** (`.github/workflows/ci.yml`): the `validate` job runs
-  **Lint and Format** (`npm run lint`), a **Maintainability Check**
-  (`npm run maintainability:check` → `check-baselines.js --gate
-  maintainability`, diff-scoped on PRs via
-  `delivery.quality.gateScoping`, full scope on push-to-main via
-  `BASELINE_SCOPE=full`), and **Run Tests with Coverage**
+  **Lint and Format** (`npm run lint`) and **Run Tests with Coverage**
   (`npm run test:coverage`), uploading the `test-results` and
   `coverage-final` artifacts. A separate required **baselines** job runs
   the unified `node .agents/scripts/check-baselines.js --format text`,
-  which enforces floors across every configured gate.
+  which enforces floors across every configured gate and is the only
+  baseline gate on the per-change path. (Story #5004 removed a
+  `Maintainability Check` step from `validate` that re-ran
+  `check-baselines.js --gate maintainability` at the same scope; a later
+  correction pass revisited its record of what the step's
+  `BASELINE_SCOPE=full` branch did — see `docs/ci-contract.md`.)
+- **Nightly** (`.github/workflows/baseline-drift.yml`): the only
+  automated **full-scope re-score**. See
+  [`check-baseline-drift.js`](#check-baseline-driftjs--the-scheduled-full-scope-re-score)
+  below.
 
 ### Opt-out
 
@@ -567,9 +572,33 @@ tolerance, **in either direction**. A row that silently improved is equally
 strong evidence the baseline no longer describes the tree.
 
 Exit codes: `0` no drift (or every kind skipped), `1` drift detected, `2` the
-check could not run. It is designed to be wired as a scheduled CI job;
-scheduling it is deliberately consumer-side work, and nothing in this
-repository runs it automatically.
+check could not run.
+
+**`--require-scored`.** "Every kind skipped" mapping to `0` is a
+fail-open trap for the scheduled use this CLI was built for. Measured: with no
+`coverage/coverage-final.json` on disk, `check-baseline-drift.js --gate crap`
+prints `✅ No baseline drift detected` and exits `0` — a nightly job wired that
+way is green and inert. Pass `--require-scored` and any skipped kind exits `2`
+instead, naming the kind and the skip reason. Use it in every scheduled
+invocation.
+
+This repository schedules the maintainability kind in
+`.github/workflows/baseline-drift.yml` (framework repo only — that path is not
+part of the materialized `.agents/` payload) — nightly at 05:43 UTC plus
+`workflow_dispatch`; it files or updates one
+`meta::baseline-drift` issue with the report, closes it when the tree comes
+back clean, and fails the run. A consumer materializing `.agents/` still owns
+its own schedule.
+
+`crap` is deliberately **not** in that job. Its drift identity is
+`path::method@startLine`, so anything that shifts a method's line re-keys its
+row: measured on this tree with a real coverage artifact, 82 rows drifted but
+1438 were reported added and 898 removed — and 853 of those removals are the
+same `path::method` reappearing at a different line. The added/removed axis is
+re-keying churn, not drift, and the remedy the report prints
+(`npm run crap:update -- --full-scope`) additionally re-measures, pulling in
+near-empty coverage entries minted by CLI-spawning tests. Fixing the identity
+is a prerequisite to scheduling the kind.
 
 ### `check-baseline-scope.js` — is this baseline still measuring the tree?
 

--- a/.agents/scripts/check-baseline-drift.js
+++ b/.agents/scripts/check-baseline-drift.js
@@ -13,13 +13,23 @@
 // directory through the same scorer that writes the baseline, prints a per-row
 // before/after table for everything that moved beyond the gate's tolerance,
 // and exits non-zero when it finds any — so a consumer can wire it as a
-// scheduled CI job without wrapping it in verdict-parsing glue. Wiring it is
-// deliberately consumer-side work; nothing in this repo schedules it.
+// scheduled CI job without wrapping it in verdict-parsing glue. This repo
+// schedules the maintainability kind in `.github/workflows/baseline-drift.yml`;
+// a consumer materializing `.agents/` still owns its own schedule.
+//
+// `--require-scored` exists because the default skip-is-green contract below
+// is a fail-open trap for exactly that scheduled use. Measured on this repo:
+// `check-baseline-drift.js --gate crap` with no `coverage/coverage-final.json`
+// present prints "✅ No baseline drift detected" and exits 0 — a nightly job
+// wired that way reports green while having measured nothing. The flag turns
+// every skip into exit 2, so a job that asked for a kind and did not get it
+// reds instead.
 //
 // Exit codes:
 //   0 — no drift (or every kind skipped: disabled gate, no baseline, no scorer)
 //   1 — drift detected in at least one kind
-//   2 — the check itself could not run
+//   2 — the check itself could not run (including: a requested kind was
+//       skipped and `--require-scored` was passed)
 
 // Fail-fast if the framework's runtime deps are not installed — must be the
 // first import so the check runs before any third-party-importing sibling
@@ -42,6 +52,10 @@ diff-scoped gates structurally cannot see.
 Options:
   --gate <kind>       Restrict to one kind (repeatable). Default: ${DRIFT_KINDS.join(', ')}.
   --tolerance <n>     Override the per-gate absolute tolerance.
+  --require-scored    Treat a skipped kind (gate disabled, no baseline, no
+                      scorer, nothing scored) as a failure rather than a pass.
+                      Use this in scheduled jobs: without it a kind that could
+                      not be scored at all reports green.
   --json              Emit the machine-readable report instead of the table.
   -h, --help          Show this help.
 
@@ -55,16 +69,21 @@ commit the result with a \`baseline-refresh:\` tagged subject (non-empty body).`
  * cannot silently widen a scheduled job's scope.
  *
  * @param {string[]} argv
- * @returns {{ kinds: string[], tolerance: number|null, json: boolean }}
+ * @returns {{ kinds: string[], tolerance: number|null, json: boolean, requireScored: boolean }}
  */
 export function parseArgs(argv = []) {
   const kinds = [];
   let tolerance = null;
   let json = false;
-  for (let i = 0; i < argv.length; i += 1) {
-    const arg = argv[i];
-    if (arg === '--gate' && argv[i + 1]) {
-      const kind = argv[i + 1];
+  // Lifted out of the loop rather than added to its else-if chain: the chain
+  // is the file's most complex method already, and a valueless boolean flag
+  // needs no positional handling to be recognised.
+  const requireScored = argv.includes('--require-scored');
+  const rest = argv.filter((a) => a !== '--require-scored');
+  for (let i = 0; i < rest.length; i += 1) {
+    const arg = rest[i];
+    if (arg === '--gate' && rest[i + 1]) {
+      const kind = rest[i + 1];
       if (!DRIFT_KINDS.includes(kind)) {
         throw new Error(
           `[drift] unknown --gate "${kind}"; expected one of ${DRIFT_KINDS.join(', ')}`,
@@ -72,11 +91,11 @@ export function parseArgs(argv = []) {
       }
       kinds.push(kind);
       i += 1;
-    } else if (arg === '--tolerance' && argv[i + 1]) {
-      const value = Number(argv[i + 1]);
+    } else if (arg === '--tolerance' && rest[i + 1]) {
+      const value = Number(rest[i + 1]);
       if (!Number.isFinite(value)) {
         throw new Error(
-          `[drift] --tolerance must be a number (got ${argv[i + 1]})`,
+          `[drift] --tolerance must be a number (got ${rest[i + 1]})`,
         );
       }
       tolerance = value;
@@ -91,7 +110,42 @@ export function parseArgs(argv = []) {
     kinds: kinds.length > 0 ? kinds : [...DRIFT_KINDS],
     tolerance,
     json,
+    requireScored,
   };
+}
+
+/**
+ * Render the `--require-scored` verdict for a completed run.
+ *
+ * A skip is the detector's honest answer to "I could not score this kind" —
+ * `{ ok: true, skipped: '<reason>' }` — and the default contract maps that to
+ * a pass so an ad-hoc run does not red because coverage happened to be absent.
+ * Under `--require-scored` the same answer is a failure: the caller named the
+ * kinds it wanted measured, and a kind that was not measured is a gap, not a
+ * clean bill of health.
+ *
+ * Returns `null` when the flag is off or nothing was skipped, so the caller
+ * keeps the run's own 0/1 verdict untouched. Both "off" and "nothing skipped"
+ * are answered here rather than at the call site: the caller is the file's
+ * ratcheted entry point, and this is the branch's natural home anyway.
+ *
+ * @param {{ results?: Array<{ kind: string, skipped?: string }> }} run
+ * @param {boolean} requireScored  Whether `--require-scored` was passed.
+ * @returns {string|null} the operator-facing failure note, or null.
+ */
+function requireScoredFailure(run, requireScored) {
+  if (!requireScored) return null;
+  const skipped = (run?.results ?? []).filter((r) => r?.skipped);
+  if (skipped.length === 0) return null;
+  const detail = skipped.map((r) => `${r.kind} (${r.skipped})`).join(', ');
+  return (
+    `[drift] ❌ --require-scored: ${skipped.length} requested kind(s) were ` +
+    `not scored — ${detail}. The verdict above covers only the kinds that ` +
+    'DID score, which is why it can read clean. A scheduled run that cannot ' +
+    'measure a kind is not a clean run; fix the cause (a missing coverage ' +
+    'artifact, a missing baseline, a disabled gate) or drop the kind from ' +
+    'the invocation.'
+  );
 }
 
 /**
@@ -112,10 +166,16 @@ export async function runCheckBaselineDrift({
     cwd,
     tolerance: args.tolerance,
   });
-  const output = args.json
+  const base = args.json
     ? JSON.stringify({ schemaVersion: '1', ...run }, null, 2)
     : formatDriftReport(run);
-  return { exitCode: run.ok ? 0 : 1, output };
+  // The note is appended rather than substituted: the drift table is still the
+  // useful half of the report for whichever kinds DID score. A note present at
+  // all means a requested kind went unmeasured, which is exit 2 regardless of
+  // what the measured kinds reported.
+  const unscored = requireScoredFailure(run, args.requireScored);
+  if (unscored) return { exitCode: 2, output: `${base}\n${unscored}` };
+  return { exitCode: run.ok ? 0 : 1, output: base };
 }
 
 /**

--- a/.agents/scripts/run-verify.js
+++ b/.agents/scripts/run-verify.js
@@ -37,9 +37,11 @@
  * and `prune-baseline-orphans.js --check` run in CI's `baselines` job only —
  * `.agents/rules/known-tooling-behavior.md` entry 2 carries the current
  * coverage table. Nor are the CI gates this command structurally cannot
- * reproduce (action pinning, TruffleHog secret scan, the BASELINE_SCOPE=full
- * push-scoped maintainability run) — those are catalogued in
- * docs/ci-contract.md.
+ * reproduce (action pinning, TruffleHog secret scan) — those are catalogued
+ * in docs/ci-contract.md. The nightly full-scope re-score
+ * (.github/workflows/baseline-drift.yml) is deliberately outside this
+ * mirror too: it re-scores the whole tree, which is the cost `verify` exists
+ * to avoid paying on every run.
  */
 
 import { spawnSync } from 'node:child_process';

--- a/.github/workflows/baseline-drift.yml
+++ b/.github/workflows/baseline-drift.yml
@@ -1,0 +1,179 @@
+name: Baseline Drift
+
+# Nightly full-scope baseline re-score.
+#
+# ── Why this exists ──────────────────────────────────────────────────────────
+# Every per-change enforcement site for the baselines is DIFF-SCOPED:
+# close-validation, `.husky/pre-push`, and CI's required `baselines` job all
+# compare the files a branch touched against their committed rows. A file
+# nobody touches after its row is written is never re-scored, so drift
+# introduced indirectly — a dependency getting more complex, a shared helper
+# moving underneath a file — is invisible for as long as nobody happens to edit
+# that file. `check-baseline-drift.js` is the counterpart that re-scores the
+# whole tree; until this workflow, nothing ran it, and its own header said so.
+#
+# ── What this does NOT restore ───────────────────────────────────────────────
+# Story #5004 deleted the `validate` job's `Maintainability Check` step, whose
+# `BASELINE_SCOPE: ${{ github.event_name == 'pull_request' && '' || 'full' }}`
+# env block was recorded (in this file and in docs/ci-contract.md) as a
+# push-to-main full-scope sweep lost with the step. That record was wrong, and
+# this workflow is not its replacement, because there was nothing to replace:
+# `BASELINE_SCOPE=full` on the READ path does not re-score anything.
+# `check-baselines.js` reads the COMMITTED baseline envelope; `full` only makes
+# `evaluateCompare` skip the head-vs-base compare arm
+# (`.agents/scripts/lib/orchestration/check-baselines/phases/compare.js`), so
+# the push leg ran floors-only over rows the diff-scoped PR leg had already
+# compared — strictly weaker, and a strict subset of the required `baselines`
+# job on push runs too. Full-scope RE-SCORING has only ever existed on the
+# WRITE path (`*:update -- --full-scope`) and in `check-baseline-drift.js`.
+#
+# So this is a new capability, not a restoration: nothing in this repository
+# has ever re-scored untouched files automatically.
+#
+# ── Why maintainability only ─────────────────────────────────────────────────
+# `DRIFT_KINDS` is `['maintainability', 'crap']`, and `crap` is deliberately
+# NOT wired here yet. Two measured reasons:
+#
+#   1. Its drift identity is `path::method@startLine`, and `startLine` moves
+#      whenever anything above a method changes. Measured on this tree with a
+#      real coverage artifact: 82 drifted, 1438 added, 898 removed — and 853 of
+#      those 898 removals are the same `path::method` reappearing at a new
+#      line. The added/removed axis is almost entirely re-keying churn, so a
+#      job that failed on it would red every night on noise.
+#   2. The remedy it prints, `npm run crap:update -- --full-scope`, is a known
+#      trap: `NODE_V8_COVERAGE` covers the whole suite process tree, so a test
+#      that spawns a CLI mints near-empty coverage entries whose methods then
+#      score against the ceiling and breach the `methodsAbove20` floor.
+#
+# Maintainability has neither problem — its identity is the file path, and this
+# tree's first full-scope run produced 20 drifted rows with 0 added and 0
+# removed. Wiring `crap` needs its drift identity fixed first; that is tracked
+# separately, not silently skipped here.
+#
+# Action pinning mirrors ci.yml: first-party `actions/*` stay on major-version
+# tags so Dependabot's github-actions ecosystem can bump them in place.
+
+on:
+  schedule:
+    # 05:43 UTC nightly — ahead of install-matrix.yml's 06:17 sweep so the two
+    # nightly jobs do not contend for the same runner slot.
+    - cron: '43 5 * * *'
+  workflow_dispatch: # Allow manual triggering
+
+concurrency:
+  group: ${{ github.workflow }}
+  # Never cancel in flight: a cancelled run silently skips a night's check, and
+  # this job's whole purpose is that nobody is watching it.
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  maintainability-drift:
+    name: Full-scope maintainability drift
+    runs-on: ubuntu-latest
+    # Observed 1.7s to re-score all 556 rows; the runtime here is checkout plus
+    # `npm ci`. 15 minutes is comfortably inside the 10–30 window
+    # `check-workflow-timeouts.js` enforces.
+    timeout-minutes: 15
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+
+      - name: Setup Node & Install
+        uses: ./.github/actions/setup
+
+      - name: Re-score maintainability full-scope
+        id: drift
+        # `--require-scored` is load-bearing, not belt-and-braces: without it a
+        # kind the detector cannot score at all returns `{ ok: true, skipped }`
+        # and this job goes green having measured nothing. `pipefail` makes the
+        # pipeline carry node's status rather than tee's, and `|| code=$?`
+        # keeps the step alive so the reporting steps below still run.
+        run: |
+          set -o pipefail
+          code=0
+          node .agents/scripts/check-baseline-drift.js \
+            --gate maintainability --require-scored 2>&1 \
+            | tee drift-report.txt || code=$?
+          echo "code=$code" >> "$GITHUB_OUTPUT"
+
+      - name: Upload drift report
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: baseline-drift-report
+          path: drift-report.txt
+          if-no-files-found: warn
+
+      - name: File or update the drift tracking issue
+        if: steps.drift.outputs.code != '0'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        # One tracking issue, reused. The label is the lookup key rather than a
+        # title search because `gh issue list --label` hits the list endpoint
+        # directly — GitHub's issue SEARCH index lags, and a lookup that misses
+        # opens a duplicate every night. `--force` makes label creation
+        # idempotent so the workflow is self-sufficient in a fresh clone.
+        run: |
+          set -euo pipefail
+          gh label create meta::baseline-drift --force \
+            --color 'B60205' \
+            --description 'Full-scope baseline re-score found drift the diff-scoped gates cannot see'
+
+          # Bound the body: the report is one line per drifted row and GitHub
+          # rejects bodies over 65536 chars.
+          {
+            echo "The nightly full-scope re-score found the committed baseline no longer describes the tree."
+            echo
+            echo "Run: $RUN_URL"
+            echo
+            echo '```'
+            head -c 30000 drift-report.txt
+            echo
+            echo '```'
+            echo
+            echo "This is drift the diff-scoped gates structurally cannot see — the rows belong to files no recent branch touched. Refresh with the command the report prints and commit it with a \`baseline-refresh:\` tagged subject."
+          } > issue-body.md
+
+          existing="$(gh issue list --label meta::baseline-drift --state open \
+            --limit 1 --json number --jq '.[0].number // empty')"
+
+          if [ -n "$existing" ]; then
+            gh issue comment "$existing" --body-file issue-body.md
+            echo "Updated existing drift issue #$existing"
+          else
+            gh issue create \
+              --title 'Baseline drift: full-scope re-score disagrees with the committed baseline' \
+              --label meta::baseline-drift \
+              --body-file issue-body.md
+          fi
+
+      - name: Close the drift tracking issue
+        if: steps.drift.outputs.code == '0'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        # A tracking issue left open after someone refreshed the baseline is
+        # the same rot in a different place — the surface has to be able to go
+        # quiet on its own or it stops being read.
+        run: |
+          set -euo pipefail
+          existing="$(gh issue list --label meta::baseline-drift --state open \
+            --limit 1 --json number --jq '.[0].number // empty')"
+          if [ -n "$existing" ]; then
+            gh issue close "$existing" \
+              --comment 'Full-scope re-score is clean again — the committed baseline describes the tree. Closing automatically.'
+          fi
+
+      - name: Fail on drift
+        if: steps.drift.outputs.code != '0'
+        # Fail last, so the artifact and the tracking issue both exist before
+        # the run goes red. GitHub emails the repo owner on a failed SCHEDULED
+        # run, which is the second half of "fails loudly" — the issue is the
+        # durable surface, the failed run is the notification.
+        run: |
+          echo "::error::check-baseline-drift.js exited ${{ steps.drift.outputs.code }} — see the tracking issue and the baseline-drift-report artifact."
+          exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,14 +84,30 @@ jobs:
       # maintainability`, a strict subset of the `Run check-baselines` step in
       # the required `baselines` job below, against the same default scope on
       # PR runs. It failed on nothing the required job did not already fail on,
-      # so it bought a second full escomplex pass and no protection.
+      # so it bought a second baseline read and no protection.
       #
-      # It ALSO carried a push-to-main-only `BASELINE_SCOPE=full` sweep, which
-      # was NOT a duplicate — that leg re-scored untouched files. Deleting the
-      # step retires it, and nothing here re-scores maintainability full-scope
-      # automatically any more. That is a recorded loss, not an oversight:
-      # docs/ci-contract.md § "Retired: push-scoped maintainability" names
-      # `check-baseline-drift.js` as the operator-run replacement.
+      # A later correction pass revisited the rest of what #5004 recorded here. That comment
+      # claimed the step's push-to-main-only
+      # `BASELINE_SCOPE: ${{ github.event_name == 'pull_request' && '' || 'full' }}`
+      # leg was a full-scope SWEEP that re-scored untouched files, and that
+      # deleting the step lost it. It was not, and it did not.
+      # `check-baselines.js` is a reader: it loads the COMMITTED baseline
+      # envelope and never invokes a scorer. On that path `full` means only
+      # "skip the head-vs-base compare arm" — see `evaluateCompare` in
+      # .agents/scripts/lib/orchestration/check-baselines/phases/compare.js,
+      # which returns an empty result whenever `scope.mode !== 'diff'`.
+      # Measured: the default scope compares 556 rows against the base
+      # baseline; `BASELINE_SCOPE=full` compares 0 and reports
+      # `baseRead: false`, in 0.18s (no escomplex pass happens at all). The
+      # push leg was therefore floors-only — strictly WEAKER than the PR leg,
+      # and a strict subset of the required `baselines` job on push runs too.
+      # Nothing was lost with the step.
+      #
+      # Full-scope RE-SCORING lives on the write path (`*:update
+      # -- --full-scope`) and in `check-baseline-drift.js`. Nothing in CI ran
+      # the latter until this repository added
+      # `.github/workflows/baseline-drift.yml` — a nightly job, deliberately
+      # off the per-PR path so this duplication is not reintroduced.
 
       - name: Build node-pty for the PTY init guard
         # node-pty (1.x) ships no Linux prebuild and the shared setup installs

--- a/baselines/crap.json
+++ b/baselines/crap.json
@@ -1,7 +1,7 @@
 {
   "$schema": ".agents/schemas/baselines/crap.schema.json",
   "kernelVersion": "0.1.0",
-  "generatedAt": "2026-08-06T10:02:47.931Z",
+  "generatedAt": "2026-08-06T10:26:11.732Z",
   "scoringSemantics": "method-identity-v3",
   "tsTranspilerVersion": "6.0.3",
   "provenanceStamped": true,
@@ -605,19 +605,46 @@
     {
       "path": ".agents/scripts/check-baseline-drift.js",
       "method": "parseArgs",
-      "startLine": 60,
+      "startLine": 74,
       "crap": 10
     },
     {
       "path": ".agents/scripts/check-baseline-drift.js",
-      "method": "runCheckBaselineDrift",
-      "startLine": 104,
+      "method": "<anon parseArgs/(a)#0>",
+      "startLine": 82,
+      "crap": 1,
+      "anonymous": true
+    },
+    {
+      "path": ".agents/scripts/check-baseline-drift.js",
+      "method": "requireScoredFailure",
+      "startLine": 136,
       "crap": 3
     },
     {
       "path": ".agents/scripts/check-baseline-drift.js",
+      "method": "<anon requireScoredFailure/(r)#0>",
+      "startLine": 138,
+      "crap": 1,
+      "anonymous": true
+    },
+    {
+      "path": ".agents/scripts/check-baseline-drift.js",
+      "method": "<anon requireScoredFailure/(r)#1>",
+      "startLine": 140,
+      "crap": 1,
+      "anonymous": true
+    },
+    {
+      "path": ".agents/scripts/check-baseline-drift.js",
+      "method": "runCheckBaselineDrift",
+      "startLine": 158,
+      "crap": 4
+    },
+    {
+      "path": ".agents/scripts/check-baseline-drift.js",
       "method": "main",
-      "startLine": 121,
+      "startLine": 194,
       "crap": 2
     },
     {

--- a/baselines/dead-exports-production.json
+++ b/baselines/dead-exports-production.json
@@ -5,10 +5,6 @@
   "mode": "production",
   "rows": [
     {
-      "file": ".agents/scripts/check-baseline-drift.js",
-      "symbol": "*"
-    },
-    {
       "file": ".agents/scripts/post-structured-comment.js",
       "symbol": "*"
     },
@@ -26,10 +22,6 @@
     },
     {
       "file": ".agents/scripts/lib/audit-suite/frontmatter-lint.js",
-      "symbol": "*"
-    },
-    {
-      "file": ".agents/scripts/lib/baselines/drift-detector.js",
       "symbol": "*"
     },
     {
@@ -1331,10 +1323,6 @@
     {
       "file": ".agents/scripts/lib/preflight-runner.js",
       "symbol": "logNonBlockers"
-    },
-    {
-      "file": ".agents/scripts/lib/baselines/refresh-service.js",
-      "symbol": "resolveDefaultScorer"
     },
     {
       "file": ".agents/scripts/lib/baselines/refresh-service.js",

--- a/baselines/dead-exports.json
+++ b/baselines/dead-exports.json
@@ -4,10 +4,6 @@
   "generatedAt": "2026-08-06T09:27:43.712789Z",
   "rows": [
     {
-      "file": ".agents/scripts/check-baseline-drift.js",
-      "symbol": "HELP_TEXT"
-    },
-    {
       "file": ".agents/scripts/lib/Logger.js",
       "symbol": "STDERR_LOGGER"
     },

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1190,11 +1190,10 @@ with three jobs:
 1. **Validate and Test** — the main job, in step order: `npm audit`
    (SCA), TruffleHog secret scanning, **Lint and Format** via
    `npm run lint` (which folds in the Biome format check — Story #1829),
-   **Maintainability Check** via `npm run maintainability:check`
-   (`node .agents/scripts/check-baselines.js --gate maintainability`;
-   diff-scoped on PRs, `BASELINE_SCOPE=full` on push-to-main), and
-   **Run Tests with Coverage** via `npm run test:coverage`. Artifacts:
+   and **Run Tests with Coverage** via `npm run test:coverage`. Artifacts:
    `test-results` (test output) and `coverage-final` (c8 coverage map).
+   A `Maintainability Check` step sat between the last two until Story
+   #5004 removed it as a duplicate of the `baselines` job.
 2. **baselines** — `node .agents/scripts/check-baselines.js --format text`,
    surfaced as its own required status check (Epic #1943 / Story #1981);
    the unified floor + tolerance + schema gate that replaced the retired
@@ -1202,6 +1201,11 @@ with three jobs:
    scripts.
 3. **Windows Smoke** — advisory (non-required) Windows leg (Story #3389):
    bootstrap dry-run, command sync, and config-resolution tests.
+
+A second workflow, `baseline-drift.yml`, runs on a nightly schedule rather
+than per change. It is the only automated **full-scope**
+baseline re-score in the repository: every gate in `ci.yml` reads committed
+baseline rows, so none of them can see drift in a file no branch touched.
 
 Distribution is **not** handled by `ci.yml` — see
 [**Distribution Model**](#distribution-model).
@@ -1234,12 +1238,24 @@ close ▶ │ close-validation DEFAULT_GATES:       │
                             │
         ┌───────────────────▼───────────────────┐
 CI    ▶ │ ci.yml:                               │
-        │   audit+secrets → lint+format → MI    │
-        │   (check-baselines --gate maint.) →   │
+        │   audit+secrets → lint+format →       │
         │   test:coverage → baselines job       │
         │   (check-baselines --format text)     │
+        └───────────────────┬───────────────────┘
+                            │
+        ┌───────────────────▼───────────────────┐
+night ▶ │ baseline-drift.yml (05:43 UTC):       │
+        │   check-baseline-drift --gate         │
+        │   maintainability --require-scored    │
+        │   (the ONLY full-scope re-score;      │
+        │    files no diff touched)             │
         └───────────────────────────────────────┘
 ```
+
+Every box above `baseline-drift.yml` is **diff-scoped** — it reads the
+committed baseline rows for the files a change touched. The nightly box is
+the only one that re-scores the tree, which is why drift in an untouched file
+is invisible to all of them.
 
 ### Evidence-aware gate caching
 

--- a/docs/ci-contract.md
+++ b/docs/ci-contract.md
@@ -65,25 +65,73 @@ Until Story #5004 this table carried a **Push-scoped maintainability** row: the
 `validate` job's `Maintainability Check` step exported
 `BASELINE_SCOPE: ${{ github.event_name == 'pull_request' && '' || 'full' }}`,
 so on PR runs it was diff-scoped — a byte-for-byte duplicate of the required
-`baselines` job's `check-baselines.js` run — and on push-to-`main` it widened to
-a full-scope sweep that re-scored untouched files.
+`baselines` job's `check-baselines.js` run — and on push-to-`main` it took the
+`full` branch.
 
-The step is gone, and with it **both** halves: the duplicate and the sweep. The
-duplicate was the reason to delete it; losing the sweep is the price, recorded
-here rather than left as a silent gap. Nothing in this repository now re-scores
-maintainability full-scope automatically.
+#### Correction: the `full` leg was not a sweep
 
-The deliberate replacement is
-[`check-baseline-drift.js`](../.agents/docs/quality-gates.md#check-baseline-driftjs--the-scheduled-full-scope-re-score)
-— it re-scores full-scope through the same scorer that writes the baseline, in
-either direction, and reports rows that moved beyond tolerance. It is
-operator-run: scheduling it is deliberately consumer-side work. Run it
-periodically on `main`, or when a refactor touched a dependency many untouched
-files score against:
+Story #5004 recorded the deleted `full` leg as a full-scope sweep that
+"re-scored untouched files", and called losing it the price of removing the
+duplicate. **That was wrong on the mechanism, and so wrong on the loss.**
+
+`check-baselines.js` is a **reader**. It loads the committed baseline envelope
+via `lib/baselines/reader.js` and never invokes a scorer. On the read path
+`BASELINE_SCOPE=full` does one thing: it makes `evaluateCompare`
+([`phases/compare.js`](../.agents/scripts/lib/orchestration/check-baselines/phases/compare.js))
+return an empty result, because that function short-circuits whenever
+`scope.mode !== 'diff'`. Full scope **disables the head-vs-base ratchet arm**;
+it does not widen a re-score, because there is no re-score to widen.
+
+Measured on this repository:
+
+| Invocation | Rows compared | `baseRead` | Wall clock |
+| --- | --- | --- | --- |
+| `check-baselines.js --gate maintainability` | 556 | `true` | 0.18s |
+| `BASELINE_SCOPE=full` + the same command | 0 | `false` | 0.14s |
+
+Both finish in under a fifth of a second, which is the tell on its own: a real
+full-scope maintainability re-score of this tree takes ~1.7s of escomplex work.
+
+So the push-to-`main` leg ran **floors only** over the committed rollup —
+strictly weaker than the diff-scoped PR leg, and a strict subset of the
+required `baselines` job on push runs as well as on PR runs. Deleting the step
+lost nothing. There is no gap here to attribute to Story #5004.
+
+#### The real gap, and what now covers it
+
+Full-scope **re-scoring** has only ever existed in two places: the write path
+(`*:update -- --full-scope`) and
+[`check-baseline-drift.js`](../.agents/docs/quality-gates.md#check-baseline-driftjs--the-scheduled-full-scope-re-score).
+Nothing automated ran the latter — before Story #5004 or after it — so drift in
+untouched files has always accumulated invisibly. That is a real hole; it was
+simply never the deleted step's to fill.
+
+[`.github/workflows/baseline-drift.yml`](../.github/workflows/baseline-drift.yml)
+now fills it: a nightly (05:43 UTC) + `workflow_dispatch` job that re-scores
+maintainability full-scope with `--require-scored`, opens or updates one
+`meta::baseline-drift` tracking issue with the report, closes that issue when
+the tree comes back clean, and fails the run. It is deliberately off the
+per-PR path, so the duplication #5004 removed is not reintroduced. Its first
+run on this tree found **20 of 556 rows** drifted beyond the 0.5 tolerance
+(all improvements — a slack ratchet, up to 8.5 MI points on one file).
+
+The same check remains available ad hoc, and a consumer materializing
+`.agents/` still owns its own schedule:
 
 ```bash
 node .agents/scripts/check-baseline-drift.js --gate maintainability
 ```
+
+`crap` is the other `DRIFT_KIND` and is **not** in the nightly job yet: its
+drift identity is `path::method@startLine`, so any edit above a method re-keys
+its row. Measured against a real coverage artifact: 82 drifted but 1438 added
+and 898 removed, of which 853 removals are the same `path::method` reappearing
+at a new line. Coverage and duplication are not `DRIFT_KIND`s at all — coverage
+rows carry three metric axes (`lines`/`branches`/`functions`) rather than the
+single scalar `KIND_SPECS` assumes, and duplication rows exist only where
+clones do, so an appearing or vanishing row is ordinary churn rather than
+drift. None of the three were ever in the deleted step, which ran
+`--gate maintainability` alone.
 
 `check-baseline-scope.js` (in CI's `baselines` job) covers the adjacent
 question — whether the baseline's row set still describes the tree — but not

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -134,9 +134,8 @@ touched git/orchestration hooks, and `npm run verify` when you want pre-PR
 confidence (audit + lint + full tests + baselines + the dead-exports and
 context-budget ratchets; the arch-cycles ratchet rides along inside `lint`).
 `npm run verify` is a **true CI mirror** for the gates it can prove locally,
-but a small set of CI gates (action pinning, the TruffleHog secret scan, the
-push-scoped `BASELINE_SCOPE=full` maintainability run, and the
-`check-test-temp-hygiene.js` snapshot/assert bracket around the test run)
+but a small set of CI gates (action pinning, the TruffleHog secret scan, and
+the `check-test-temp-hygiene.js` snapshot/assert bracket around the test run)
 cannot be reproduced from a local working tree — those are catalogued in
 [`ci-contract.md`](ci-contract.md), so a local green is necessary but not
 sufficient. Pre-push runs only diff-scoped quality preview plus coverage/CRAP
@@ -153,7 +152,8 @@ are enforced at four sites, earliest first:
 | [`.husky/pre-commit`](../.husky/pre-commit) — `quality-preview.js --staged` | staged index paths only | **Yes** — a threshold violation exits non-zero and the commit is refused |
 | [`.husky/pre-push`](../.husky/pre-push) — `quality-preview.js --changed-since origin/main` plus `crap:check` | diff against `origin/main` | **Yes** — the push is refused |
 | Story close-validation (`single-story-close.js`) | the Story's whole change set | **Yes** — close stops |
-| CI (`ci.yml`, push + PR) | diff-scoped on PR, `BASELINE_SCOPE=full` on push to `main` | **Yes** — a required check fails |
+| CI (`ci.yml`, push + PR) | diff-scoped — the `baselines` job reads the committed rows for the changed files | **Yes** — a required check fails |
+| Nightly (`baseline-drift.yml`, 05:43 UTC) | **full-scope re-score** — every file, including ones no diff touched | **Yes** — the run fails and a `meta::baseline-drift` issue is filed |
 
 `.husky/pre-commit` is the one most easily forgotten and the one that bites
 first: it fires before any other gate, and a green `npm run lint` /

--- a/knip.json
+++ b/knip.json
@@ -14,6 +14,7 @@
     ".agents/scripts/bootstrap.js!",
     ".agents/scripts/check-action-pinning.js!",
     ".agents/scripts/check-arch-cycles.js!",
+    ".agents/scripts/check-baseline-drift.js!",
     ".agents/scripts/check-baseline-scope.js!",
     ".agents/scripts/check-baselines.js!",
     ".agents/scripts/check-context-budget.js!",

--- a/tests/contract/baseline-drift-workflow.test.js
+++ b/tests/contract/baseline-drift-workflow.test.js
@@ -1,0 +1,98 @@
+// tests/contract/baseline-drift-workflow.test.js
+/**
+ * The nightly full-scope baseline re-score.
+ *
+ * Every other baseline gate in this repository is diff-scoped: it reads the
+ * committed rows for the files a change touched. `baseline-drift.yml` is the
+ * only thing that re-scores the tree, so drift in an untouched file is
+ * invisible without it. That makes the workflow load-bearing in a way a
+ * scheduled job usually is not — nobody watches a nightly, so if it silently
+ * stops measuring, the gap it was built to close reopens unnoticed.
+ *
+ * These pin the three properties that failure mode turns on:
+ *
+ *   1. the job actually invokes the drift CLI;
+ *   2. it passes `--require-scored`, without which a kind the detector cannot
+ *      score returns `{ ok: true, skipped }` and the run goes green having
+ *      measured nothing (the exact fail-open this Story closed);
+ *   3. it stays off the per-PR path, so the duplication Story #5004 removed
+ *      is not quietly reintroduced under a new name.
+ */
+
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { describe, it } from 'node:test';
+import { fileURLToPath } from 'node:url';
+import yaml from 'js-yaml';
+
+const REPO_ROOT = path.join(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '..',
+  '..',
+);
+const WORKFLOW_PATH = path.join(
+  REPO_ROOT,
+  '.github/workflows/baseline-drift.yml',
+);
+
+const source = readFileSync(WORKFLOW_PATH, 'utf8');
+const workflow = yaml.load(source);
+const job = workflow.jobs['maintainability-drift'];
+/** The step that runs the CLI, found by the command rather than by name. */
+const driftStep = job.steps.find((s) =>
+  String(s.run ?? '').includes('check-baseline-drift.js'),
+);
+
+describe('baseline-drift.yml — the only full-scope re-score', () => {
+  it('runs the drift CLI', () => {
+    assert.ok(
+      driftStep,
+      'no step in the `maintainability-drift` job invokes check-baseline-drift.js',
+    );
+  });
+
+  it('passes --require-scored, so a kind that cannot be scored reds', () => {
+    assert.match(
+      driftStep.run,
+      /--require-scored/,
+      'without --require-scored a skipped kind exits 0 and the nightly is ' +
+        'green while measuring nothing — the fail-open this job exists to avoid',
+    );
+  });
+
+  it('stays off the per-PR path', () => {
+    // `on:` parses as the YAML boolean `true` — 1.1 semantics, which js-yaml
+    // still applies to bare `on`.
+    const triggers = Object.keys(workflow[true] ?? workflow.on ?? {});
+    assert.deepEqual(
+      triggers.filter((t) => t === 'pull_request' || t === 'push'),
+      [],
+      'a per-change trigger here reintroduces the duplication Story #5004 removed',
+    );
+    assert.ok(triggers.includes('schedule'), 'expected a schedule trigger');
+  });
+
+  it('can file the tracking issue it promises', () => {
+    assert.equal(
+      workflow.permissions?.issues,
+      'write',
+      'the job opens/updates/closes a meta::baseline-drift issue; without ' +
+        '`issues: write` those gh calls fail and the only surviving signal ' +
+        'is a red run nobody is watching',
+    );
+  });
+
+  it('fails the run on drift rather than only filing an issue', () => {
+    const failStep = job.steps.find((s) => /exit 1/.test(String(s.run ?? '')));
+    assert.ok(
+      failStep,
+      'no step fails the run when the drift CLI exits non-zero',
+    );
+    assert.match(
+      String(failStep.if),
+      /steps\.drift\.outputs\.code/,
+      "the failing step must be gated on the drift step's exit code",
+    );
+  });
+});

--- a/tests/lib/baselines/drift-detector.test.js
+++ b/tests/lib/baselines/drift-detector.test.js
@@ -307,11 +307,18 @@ describe('check-baseline-drift CLI (AC-7)', () => {
       kinds: ['maintainability', 'crap'],
       tolerance: null,
       json: false,
+      requireScored: false,
     });
     assert.deepEqual(
       parseArgs(['--gate', 'crap', '--tolerance', '2', '--json']),
-      { kinds: ['crap'], tolerance: 2, json: true },
+      { kinds: ['crap'], tolerance: 2, json: true, requireScored: false },
     );
+    assert.deepEqual(parseArgs(['--require-scored']), {
+      kinds: ['maintainability', 'crap'],
+      tolerance: null,
+      json: false,
+      requireScored: true,
+    });
   });
 
   it('rejects an unknown gate, a non-numeric tolerance, and stray argv', () => {
@@ -358,6 +365,92 @@ describe('check-baseline-drift CLI (AC-7)', () => {
     });
     assert.deepEqual(seen.kinds, ['crap']);
     assert.equal(seen.tolerance, 3);
+  });
+
+  /**
+   * Story #5023 — the skip-is-green contract is a fail-open trap for the
+   * scheduled use this CLI exists for. Measured on the real repo: `--gate
+   * crap` with no coverage artifact prints "✅ No baseline drift detected"
+   * and exits 0. These pin the opt-in that closes it.
+   */
+  describe('--require-scored', () => {
+    /** A run where `crap` skipped and `maintainability` came back clean. */
+    const mixedRun = {
+      ok: true,
+      results: [
+        {
+          kind: 'maintainability',
+          ok: true,
+          drifted: [],
+          added: [],
+          removed: [],
+        },
+        { kind: 'crap', ok: true, skipped: 'no-scored-rows' },
+      ],
+    };
+
+    it('turns a skipped kind into exit 2 naming the kind and the reason', async () => {
+      const res = await runCheckBaselineDrift({
+        argv: ['--require-scored'],
+        detect: async () => mixedRun,
+      });
+      assert.equal(res.exitCode, 2);
+      assert.match(res.output, /--require-scored/);
+      assert.match(res.output, /crap \(no-scored-rows\)/);
+      // The drift table for the kinds that DID score is still rendered.
+      assert.match(res.output, /maintainability/);
+    });
+
+    it('leaves the same run at exit 0 without the flag', async () => {
+      const res = await runCheckBaselineDrift({
+        argv: [],
+        detect: async () => mixedRun,
+      });
+      assert.equal(res.exitCode, 0);
+      assert.doesNotMatch(res.output, /--require-scored/);
+    });
+
+    it('does not mask real drift: a drifted kind still exits 1', async () => {
+      const res = await runCheckBaselineDrift({
+        argv: ['--require-scored'],
+        detect: async () => ({
+          ok: false,
+          results: [
+            {
+              kind: 'maintainability',
+              refreshCommand: 'npm run maintainability:update -- --full-scope',
+              ok: false,
+              tolerance: 0.5,
+              scanned: 1,
+              baselineRows: 1,
+              drifted: [
+                {
+                  key: 'src/a.js',
+                  label: 'src/a.js',
+                  baseline: 80,
+                  current: 70,
+                  delta: -10,
+                },
+              ],
+              added: [],
+              removed: [],
+            },
+          ],
+        }),
+      });
+      assert.equal(res.exitCode, 1);
+    });
+
+    it('appends the note to the --json payload too', async () => {
+      const res = await runCheckBaselineDrift({
+        argv: ['--require-scored', '--json'],
+        detect: async () => mixedRun,
+      });
+      assert.equal(res.exitCode, 2);
+      const [payload, note] = res.output.split(/\n(?=\[drift\])/);
+      assert.equal(JSON.parse(payload).ok, true);
+      assert.match(note, /crap \(no-scored-rows\)/);
+    });
   });
 
   it('emits a machine-readable report under --json', async () => {


### PR DESCRIPTION
## Why

Story #5004 removed the `validate` job's `Maintainability Check` step and recorded, in `ci.yml` and in `docs/ci-contract.md`, that its push-to-`main` `BASELINE_SCOPE=full` leg was a full-scope sweep re-scoring untouched files — a loss taken as the price of deleting the duplicate.

**That record is wrong, and the real gap is different and older.**

### `BASELINE_SCOPE=full` on the read path is not a re-score

`check-baselines.js` is a reader. It loads the committed baseline envelope through `lib/baselines/reader.js` and never invokes a scorer. On that path `full` does exactly one thing: `evaluateCompare` returns an empty result whenever `scope.mode !== 'diff'`, i.e. it **disables the head-vs-base ratchet arm**.

| Invocation | Rows compared | `baseRead` | Wall clock |
| --- | --- | --- | --- |
| `check-baselines.js --gate maintainability` | 556 | `true` | 0.18s |
| `BASELINE_SCOPE=full` + the same command | 0 | `false` | 0.14s |

Both finish in under a fifth of a second — a real full-scope maintainability re-score of this tree takes ~1.7s. The push leg ran **floors only**: strictly weaker than the diff-scoped PR leg, and a strict subset of the required `baselines` job on push runs as well as PR runs. Nothing was lost.

### The gap that is real

Full-scope *re-scoring* has only ever lived on the write path (`*:update -- --full-scope`) and in `check-baseline-drift.js`. Nothing scheduled the latter — its own header said so. So drift in untouched files has always accumulated invisibly, before #5004 and after it.

Proof it is not theoretical: the first full-scope run on this tree found **20 of 556 maintainability rows** drifted beyond the 0.5 tolerance — all improvements, meaning the ratchet is anchored up to 8.5 MI points below reality on one file.

## What this adds

- **`.github/workflows/baseline-drift.yml`** — nightly 05:43 UTC + `workflow_dispatch`. Runs `check-baseline-drift.js --gate maintainability --require-scored`, uploads the report, files or updates one `meta::baseline-drift` issue, **closes that issue when the tree comes back clean**, and fails the run. Deliberately off the per-PR path, so #5004's duplication is not reintroduced.
- **`--require-scored` on `check-baseline-drift.js`** — closes a measured fail-open. With no coverage artifact on disk, `--gate crap` prints `✅ No baseline drift detected` and exits **0**; a nightly wired without the flag is green while measuring nothing. The flag maps any skip to exit 2, naming the kind and reason.
- **Doc corrections** — `ci-contract.md`'s "Retired" section rewritten with the measurements, plus the stale descriptions of the deleted step that #5004 left behind in `quality-gates.md`, `architecture.md`, `onboarding.md` and `run-verify.js`.

## The other baseline kinds

The deleted step ran `--gate maintainability` alone, so coverage/CRAP/duplication were never in it. On whether they should join the nightly:

- **`crap`** — the other `DRIFT_KIND`, deliberately excluded. Its drift key is `path::method@startLine`, so anything that shifts a method's line re-keys the row. Measured with a real coverage artifact: 82 drifted, **1438 added, 898 removed — 853 of those removals are the same `path::method` reappearing at a new line**. Failing on that would red every night on churn, and the remedy it prints (`crap:update -- --full-scope`) additionally re-measures, pulling in near-empty coverage entries from CLI-spawning tests. Fixing the identity is a prerequisite.
- **`coverage`** — not a `DRIFT_KIND`: rows carry three metric axes (`lines`/`branches`/`functions`) where `KIND_SPECS` assumes one scalar.
- **`duplication`** — not a `DRIFT_KIND`: rows exist only where clones do, so an appearing or vanishing row is ordinary churn.

## Verification

- `npm test` — 9673 pass, 0 fail
- `npm run lint` — 0
- `check-baselines.js` — all 4 gates PASS, 0 breaches, 0 regressions
- Every standalone ratchet green: arch-cycles, dead-exports (+`--production`), context-budget, workflow-citations, cyclomatic, schema-references, baseline-scope, prune-orphans `--check`, action-pinning, workflow-timeouts
- Five new contract tests pin the workflow's load-bearing properties; **each was verified to fail** when its property is violated (flag removed, `pull_request` trigger added, `issues: write` downgraded, the failing step neutered)

## Baseline change

One narrowly scoped refresh, diff-scoped to the single edited file via `refreshBaseline({ scopeFiles })` — no re-score of anything else, rollup byte-identical. `runCheckBaselineDrift` crap 3 → 4, the one new code path the `--require-scored` exit adds, at 100% coverage against a ceiling of 30. `parseArgs` holds at 10: the flag is read with `argv.includes` ahead of the parse loop rather than added to its else-if chain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds scheduled CI with issue automation and changes drift CLI exit semantics under `--require-scored`; scope is quality-governance and docs, not auth or data paths, but a misconfigured nightly could noise operators until baselines are refreshed.
> 
> **Overview**
> **Automated full-scope baseline drift** is new: `.github/workflows/baseline-drift.yml` runs nightly (05:43 UTC) and on `workflow_dispatch`, invoking `check-baseline-drift.js --gate maintainability --require-scored`, uploading the report, opening or updating a `meta::baseline-drift` issue when drift is found, auto-closing it when clean, and failing the workflow. **CRAP is intentionally excluded** from that job (line-key churn and update-path traps are documented in the workflow).
> 
> **`--require-scored`** on `check-baseline-drift.js` turns “kind skipped” from exit 0 into exit 2 so scheduled runs cannot go green without measuring; contract tests cover the workflow and CLI behavior.
> 
> **Documentation and comments** are corrected: `BASELINE_SCOPE=full` on `check-baselines.js` only disables the diff compare arm—it does not re-score untouched files—so removing the duplicate `Maintainability Check` step did not drop a full-scope sweep. `docs/ci-contract.md`, `ci.yml`, `architecture.md`, `onboarding.md`, `quality-gates.md`, and `run-verify.js` are aligned with that. **`knip.json`** whitelists the drift script; **dead-export baselines** drop rows for newly wired exports; **crap baseline** reflects the drift CLI edits.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9cf182fe2870d932f2a1f911aa8eb88055408abe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->