### PR TITLE
fix(close): review lens must honour maintainability ignoreGlobs; add a logged override

### DIFF
--- a/.agents/schemas/story-deliver-terminal.schema.json
+++ b/.agents/schemas/story-deliver-terminal.schema.json
@@ -73,10 +73,10 @@
     },
     "gates": {
       "type": "object",
-      "description": "Outcome of each close gate this invocation was responsible for. A gate the run skipped (--skip-validation, or a phase it never reached) reports \"skipped\" rather than being omitted, so a missing gate is never mistaken for a passing one.",
+      "description": "Outcome of each close gate this invocation was responsible for. A gate the run skipped (--skip-validation, or a phase it never reached) reports \"skipped\" rather than being omitted, so a missing gate is never mistaken for a passing one. \"overridden\" is distinct from both: the gate ran, it FAILED, and an operator authorized delivery anyway via --override-review-block with a recorded reason. Reporting that as \"passed\" would erase the one fact a reader of this envelope most needs, and reporting it as \"skipped\" would claim the gate never ran.",
       "additionalProperties": {
         "type": "string",
-        "enum": ["passed", "failed", "skipped"]
+        "enum": ["passed", "failed", "skipped", "overridden"]
       }
     },
     "tail": {

--- a/.agents/scripts/lib/cli-args.js
+++ b/.agents/scripts/lib/cli-args.js
@@ -110,6 +110,59 @@ function tolerantMergeWatchMode(value) {
 }
 
 /**
+ * Shortest override reason that can plausibly name a rejected finding. Below
+ * this, the flag is being used to silence the gate rather than to record a
+ * judgement, which is the failure mode the reason requirement exists to stop.
+ */
+const MIN_OVERRIDE_REASON_LENGTH = 12;
+
+/**
+ * Parse `--override-review-block <reason>` — the sanctioned,
+ * logged override of a Story-scope code-review critical blocker.
+ *
+ * The reason is **mandatory and validated**, because the alternative it
+ * replaces is not "no override" but `gh pr merge` run by hand: before this
+ * flag, a review blocker the operator had reviewed and rejected left bypassing
+ * the gate entirely as the only way to land, and that bypass wrote nothing
+ * down anywhere. An override that records why is strictly more auditable than
+ * the hand-merge it displaces; an override that records nothing is not, so a
+ * bare or blank `--override-review-block` fails closed here — before any phase
+ * runs, at no mutation cost — rather than arming a silent one.
+ *
+ * @param {unknown} value
+ * @returns {string|undefined} the trimmed reason, or `undefined` when absent.
+ */
+export function parseOverrideReviewBlock(value) {
+  if (value == null) return undefined;
+  // `parseArgs` with `strict: false` yields `true` for a bare string flag.
+  const reason = typeof value === 'string' ? value.trim() : '';
+  if (reason.length >= MIN_OVERRIDE_REASON_LENGTH) return reason;
+  throw new Error(
+    '--override-review-block requires a reason of at least ' +
+      `${MIN_OVERRIDE_REASON_LENGTH} characters naming the finding you reviewed ` +
+      `and rejected (got ${JSON.stringify(value)}). The reason is posted to the ` +
+      'PR and the Story and recorded as friction telemetry.',
+  );
+}
+
+/**
+ * {@link parseOverrideReviewBlock} degraded to absent instead of throwing, for
+ * the tolerant reporting parse. Same contract as
+ * {@link tolerantMergeWatchMode}: safe only because a tolerant parse runs no
+ * phase.
+ *
+ * @param {unknown} value
+ * @returns {string|undefined}
+ */
+function tolerantOverrideReviewBlock(value) {
+  try {
+    return parseOverrideReviewBlock(value);
+  } catch {
+    return undefined;
+  }
+}
+
+/**
  * Standardized CLI argument parser for sprint scripts.
  * Supports options like --epic, --story, --dry-run, --skip-dashboard.
  *
@@ -147,6 +200,11 @@ export function parseSprintArgs(
       // Absent means "use the config"; see `parseMergeWatchMode` for why an
       // unrecognized value fails closed instead of degrading to absent.
       'merge-watch-mode': { type: 'string' },
+      // Sanctioned override of a code-review critical blocker.
+      // Absent means "the blocker blocks"; see `parseOverrideReviewBlock` for
+      // why a bare or too-short reason fails closed instead of arming a silent
+      // override.
+      'override-review-block': { type: 'string' },
       executor: { type: 'string' },
       cwd: { type: 'string' },
       'recut-of': { type: 'string' },
@@ -183,6 +241,12 @@ export function parseSprintArgs(
     mergeWatchMode: tolerant
       ? tolerantMergeWatchMode(values['merge-watch-mode'])
       : parseMergeWatchMode(values['merge-watch-mode']),
+    // The operator's recorded reason for overriding a review
+    // blocker. `undefined` when the flag is absent, which is what keeps the
+    // blocker blocking by default.
+    overrideReviewBlock: tolerant
+      ? tolerantOverrideReviewBlock(values['override-review-block'])
+      : parseOverrideReviewBlock(values['override-review-block']),
     executor: values.executor ?? null,
     // Resolve worktree cwd from flag or env. Empty string/whitespace → null.
     cwd:

--- a/.agents/scripts/lib/observability/runtime-friction.js
+++ b/.agents/scripts/lib/observability/runtime-friction.js
@@ -83,6 +83,16 @@ export const RUNTIME_FRICTION_CATEGORIES = Object.freeze({
    * ceilings recalibratable from recorded evidence.
    */
   LIGHT_SCOPE_REJECTED: 'light-scope-rejected',
+  /**
+   * An operator overrode a Story-scope code-review critical blocker with
+   * `--override-review-block <reason>`. Deliberately its own
+   * bucket: this is the one signal that says a gate's verdict was rejected by
+   * a human who then shipped anyway, so a rising `occurrences` count is direct
+   * evidence the gate is miscalibrated rather than the code being bad. It is
+   * *not* `TOOL_DEGRADED` — the tool ran fine and produced a verdict; what
+   * failed was the verdict's usefulness.
+   */
+  REVIEW_BLOCK_OVERRIDDEN: 'review-block-overridden',
 });
 
 /** Cap on free-form reason text copied into a signal's `details`. */

--- a/.agents/scripts/lib/orchestration/review-providers/mi-exemptions.js
+++ b/.agents/scripts/lib/orchestration/review-providers/mi-exemptions.js
@@ -1,0 +1,130 @@
+/**
+ * review-providers/mi-exemptions.js — the maintainability gate's exemption list,
+ * as the native review provider reads it.
+ *
+ * `delivery.quality.gates.maintainability.ignoreGlobs` is the one declared
+ * answer to "which files is the maintainability index meaningless for" —
+ * declarative schema blobs, generated code, vendored trees. Every other MI
+ * consumer already honours it: the baseline writer excludes those files
+ * (`update-maintainability-baseline.js`), so the `check-baselines.js` ratchet
+ * and the pre-merge MI advisory never see them either.
+ *
+ * `review-providers/native.js` did not, and the split produced a live
+ * contradiction on Story #5007 / PR #5022: the ratchet PASSED while the review
+ * lens raised a **critical blocker** on three exempted
+ * `config-settings-schema*.js` modules in the same close run. Because a critical
+ * finding halts `single-story-close.js` before auto-merge, the only way to land
+ * legitimate work was to merge the PR by hand. A gate that must be
+ * hand-bypassed to ship is not a gate.
+ *
+ * This module is that reconciliation, kept separate from the provider so the
+ * exemption concern has one home and the provider keeps one reason to change.
+ */
+
+import { getQuality } from '../../config/quality.js';
+import { resolveConfig } from '../../config-resolver.js';
+import { isIgnoredByGlobs } from '../../maintainability-utils.js';
+
+/**
+ * Read `delivery.quality.gates.maintainability.ignoreGlobs` so a review's
+ * maintainability dimension scores the same file set the ratchet does.
+ *
+ * Best-effort and total. A config that cannot be resolved yields `[]`, which
+ * scores every changed JS file. That direction is deliberate: degrading to
+ * "score everything" can only produce an advisory the operator must read,
+ * whereas degrading to "score nothing" would silently retire the dimension.
+ *
+ * @param {{ resolveConfigFn?: typeof resolveConfig, getQualityFn?: typeof getQuality }} [deps]
+ * @returns {string[]} minimatch patterns; `[]` when unset or unresolvable.
+ */
+export function resolveMaintainabilityIgnoreGlobs({
+  resolveConfigFn = resolveConfig,
+  getQualityFn = getQuality,
+} = {}) {
+  try {
+    const globs = getQualityFn(resolveConfigFn())?.maintainability?.ignoreGlobs;
+    return Array.isArray(globs) ? globs.slice() : [];
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Pure: split a changed-file list into the set to score and the set the
+ * maintainability gate exempts.
+ *
+ * Matching funnels through `maintainability-utils.js#isIgnoredByGlobs` — the
+ * declared single source of truth for how the MI scorer decides a file is
+ * ignored — so an exempted file is excluded here by exactly the same rule that
+ * kept it out of the baseline. Re-implementing the match with a local
+ * `minimatch` call is what let the two surfaces disagree in the first place.
+ *
+ * Module-local: {@link scopeMaintainabilityFiles} is the single door, and its
+ * `scored` / `ignored` split is where this behaviour is observable.
+ *
+ * @param {string[]} files
+ * @param {string[]} ignoreGlobs
+ * @param {string} cwd root for repo-relative glob resolution
+ * @returns {{ scored: string[], ignored: string[] }}
+ */
+function partitionByIgnoreGlobs(files, ignoreGlobs, cwd) {
+  if (!Array.isArray(ignoreGlobs) || ignoreGlobs.length === 0) {
+    return { scored: files, ignored: [] };
+  }
+  const scored = [];
+  const ignored = [];
+  for (const relPath of files) {
+    if (isIgnoredByGlobs(relPath, ignoreGlobs, cwd)) ignored.push(relPath);
+    else scored.push(relPath);
+  }
+  return { scored, ignored };
+}
+
+/**
+ * Render the operator-facing notice naming the files the gate exempted, or
+ * `null` when nothing was exempted so the caller can `if` past the log call.
+ *
+ * The notice exists because silence is ambiguous: an operator reading a review
+ * that says nothing about three changed schema modules cannot tell "scored and
+ * healthy" from "never scored".
+ *
+ * Module-local: reached through {@link scopeMaintainabilityFiles}'s `notice`.
+ *
+ * @param {string[]|undefined} ignoredFiles
+ * @returns {string|null}
+ */
+function formatExemptionNotice(ignoredFiles) {
+  const files = Array.isArray(ignoredFiles) ? ignoredFiles : [];
+  if (files.length === 0) return null;
+  return (
+    `[native-review] Maintainability: ${files.length} changed file(s) exempt via ` +
+    `delivery.quality.gates.maintainability.ignoreGlobs — not scored: ${files.join(', ')}.`
+  );
+}
+
+/**
+ * Resolve the exemption list and split a review's changed-file set into the
+ * paths whose maintainability should be scored and the paths the gate exempts.
+ *
+ * This is the one door the native provider uses: it keeps the resolve → match →
+ * report sequence here rather than spread across the provider, so the provider
+ * carries no knowledge of how an exemption is decided.
+ *
+ * @param {string[]} changedFiles
+ * @param {{
+ *   cwd: string,
+ *   resolveIgnoreGlobsFn?: typeof resolveMaintainabilityIgnoreGlobs,
+ * }} opts
+ * @returns {{ scored: string[], ignored: string[], notice: string|null }}
+ */
+export function scopeMaintainabilityFiles(
+  changedFiles,
+  { cwd, resolveIgnoreGlobsFn = resolveMaintainabilityIgnoreGlobs } = {},
+) {
+  const { scored, ignored } = partitionByIgnoreGlobs(
+    changedFiles,
+    resolveIgnoreGlobsFn(),
+    cwd,
+  );
+  return { scored, ignored, notice: formatExemptionNotice(ignored) };
+}

--- a/.agents/scripts/lib/orchestration/review-providers/native.js
+++ b/.agents/scripts/lib/orchestration/review-providers/native.js
@@ -7,9 +7,20 @@
  *
  *   1. Diffs `headRef` against `baseRef` to enumerate changed files.
  *   2. Runs scoped lint (biome + markdownlint) over the changed surface.
- *   3. Computes per-file maintainability reports for changed JS files.
+ *   3. Computes per-file maintainability reports for changed JS files, minus
+ *      the files the maintainability gate exempts (see below).
  *   4. Maps each signal to a `Finding` with a `severity` ∈ {critical, high,
  *      medium, suggestion}.
+ *
+ * **The maintainability dimension honours the gate's exemption list**, read via
+ * [`mi-exemptions.js`](mi-exemptions.js) — see that module for why this
+ * provider disagreeing with the ratchet was a live delivery blocker. Exempted
+ * files are named on the log rather than silently dropped.
+ *
+ * The lint dimension is deliberately NOT filtered through the same list:
+ * lint carries its own exclusion surface (biome's `files.includes`,
+ * `.markdownlintignore`), and a quality-gate ignore glob makes no claim about
+ * whether a file should parse or format cleanly.
  *
  * The adapter does NOT post to GitHub, does NOT render a markdown body,
  * and does NOT consult the lifecycle bus. Those concerns belong to
@@ -53,6 +64,10 @@ import {
 } from '../../observability/runtime-friction.js';
 import { PROJECT_ROOT } from '../../project-root.js';
 import { transpileIfNeeded } from '../../transpile.js';
+import {
+  resolveMaintainabilityIgnoreGlobs,
+  scopeMaintainabilityFiles,
+} from './mi-exemptions.js';
 import {
   parseLintOutput,
   partitionFilesForLint,
@@ -389,16 +404,6 @@ export function buildLintFindings(lintSummary) {
   return findings;
 }
 
-function _emptyResults() {
-  return {
-    totalFiles: 0,
-    jsFiles: 0,
-    maintainability: [],
-    criticalFindings: [],
-    mediumFindings: [],
-  };
-}
-
 async function runLintPhase({
   scopeLint,
   changedFiles,
@@ -467,6 +472,7 @@ function buildLintDegradations(lintSummary) {
  *   analyzeChangedFilesFn?: typeof analyzeChangedFiles,
  *   buildLintFindingsFn?: typeof buildLintFindings,
  *   emitToolDegradationFn?: typeof emitRuntimeFriction,
+ *   resolveIgnoreGlobsFn?: typeof resolveMaintainabilityIgnoreGlobs,
  *   logger?: { info?: Function, warn?: Function, error?: Function },
  *   scopeLint?: 'changed-only'|'off',
  * }} [deps]
@@ -479,6 +485,10 @@ export function createNativeProvider(deps = {}) {
     analyzeChangedFilesFn = analyzeChangedFiles,
     buildLintFindingsFn = buildLintFindings,
     emitToolDegradationFn = emitRuntimeFriction,
+    // The maintainability-gate exemption seam. The resolution itself — gate-key
+    // read and fail-open — is unit-tested in `mi-exemptions.js`; this dep is
+    // here so a provider test can pin the WIRING without a config on disk.
+    resolveIgnoreGlobsFn = resolveMaintainabilityIgnoreGlobs,
     logger,
     scopeLint = 'changed-only',
   } = deps;
@@ -551,7 +561,12 @@ export function createNativeProvider(deps = {}) {
       logger?.info?.(
         `[native-review] Analyzing ${changedFiles.length} changed file(s)...`,
       );
-      const results = await analyzeChangedFilesFn(changedFiles, {
+      const mi = scopeMaintainabilityFiles(changedFiles, {
+        cwd: PROJECT_ROOT,
+        resolveIgnoreGlobsFn,
+      });
+      if (mi.notice) logger?.info?.(mi.notice);
+      const results = await analyzeChangedFilesFn(mi.scored, {
         headRef,
         gitSpawnFn,
       });

--- a/.agents/scripts/lib/orchestration/single-story-close/phases/options.js
+++ b/.agents/scripts/lib/orchestration/single-story-close/phases/options.js
@@ -9,7 +9,11 @@
  */
 
 import path from 'node:path';
-import { parseMergeWatchMode, parseSprintArgs } from '../../../cli-args.js';
+import {
+  parseMergeWatchMode,
+  parseOverrideReviewBlock,
+  parseSprintArgs,
+} from '../../../cli-args.js';
 import { getDeliveryRouting } from '../../../config/delivery-routing.js';
 import { PROJECT_ROOT } from '../../../project-root.js';
 import { isOperatorMergeReason } from './auto-merge.js';
@@ -91,8 +95,8 @@ export function resolveWaitForMerge({
  * (`waitForMergeExplicit` / `noWaitForMerge`) for the runner to resolve once
  * the config and the arm outcome exist.
  *
- * @param {{ storyIdParam, cwdParam, skipValidationParam, skipSyncParam, noAutoMergeParam, waitForMergeParam, noWaitForMergeParam, maxWaitSecondsParam, mergeWatchModeParam }} raw
- * @returns {{ storyId, cwd, skipValidation, skipSync, noAutoMerge, waitForMergeExplicit, noWaitForMerge, maxWaitSeconds, mergeWatchMode }}
+ * @param {{ storyIdParam, cwdParam, skipValidationParam, skipSyncParam, noAutoMergeParam, waitForMergeParam, noWaitForMergeParam, maxWaitSecondsParam, mergeWatchModeParam, overrideReviewBlockParam }} raw
+ * @returns {{ storyId, cwd, skipValidation, skipSync, noAutoMerge, waitForMergeExplicit, noWaitForMerge, maxWaitSeconds, mergeWatchMode, overrideReviewBlock }}
  */
 export function parseCloseOptions({
   storyIdParam,
@@ -104,6 +108,7 @@ export function parseCloseOptions({
   noWaitForMergeParam,
   maxWaitSecondsParam,
   mergeWatchModeParam,
+  overrideReviewBlockParam,
 }) {
   // An injecting caller (`storyIdParam` supplied) is not reading argv at all,
   // so there is nothing to parse and `parsed` stays empty. This used to build a
@@ -148,5 +153,12 @@ export function parseCloseOptions({
         ? waitForMergeExplicit
         : undefined,
     noWaitForMerge: !!resolveFlag(noWaitForMergeParam, parsed.noWaitForMerge),
+    // `undefined` when unsupplied, which is what keeps a review
+    // critical blocker blocking. An injecting caller passes the reason string
+    // directly; both doors run the same validating parser, so neither can arm
+    // a reasonless override.
+    overrideReviewBlock: parseOverrideReviewBlock(
+      resolveFlag(overrideReviewBlockParam, parsed.overrideReviewBlock),
+    ),
   };
 }

--- a/.agents/scripts/lib/orchestration/single-story-close/phases/review-block.js
+++ b/.agents/scripts/lib/orchestration/single-story-close/phases/review-block.js
@@ -20,6 +20,11 @@ export async function handleCriticalReviewBlock({
     '',
     `The Story-scope review reported **${criticalCount} critical blocker(s)** on ${prUrl}.`,
     'Remediate the posted findings, then re-run `/deliver`.',
+    '',
+    'If you have reviewed a finding and judged it wrong, re-run close with',
+    '`--override-review-block "<reason>"` rather than merging by hand — see',
+    '`phases/review-override.js`. The override is recorded on the Story, on the',
+    'PR, and as friction telemetry.',
   ].join('\n');
   try {
     await upsertStructuredComment(provider, storyId, 'friction', body);

--- a/.agents/scripts/lib/orchestration/single-story-close/phases/review-override.js
+++ b/.agents/scripts/lib/orchestration/single-story-close/phases/review-override.js
@@ -1,0 +1,157 @@
+/**
+ * phases/review-override.js — the sanctioned, logged override of a Story-scope
+ * code-review critical blocker.
+ *
+ * Split out of `phases/review-block.js`, which owns the opposite outcome: the
+ * blocker that *holds*. Keeping the two in one module meant one file owning
+ * both "park this Story" and "ship it anyway", and the override's audit trail is
+ * substantial enough — three write surfaces, each independently best-effort —
+ * to be its own reason to change.
+ *
+ * **Why an override exists at all.** A critical review finding halts
+ * `single-story-close.js` before auto-merge, and no flag overrode a review
+ * verdict: `--skip-validation` bypasses the gate chain and `--no-auto-merge`
+ * declines to arm, but neither touches the review. So an operator who had read a
+ * finding and judged it wrong could only land by merging the PR by hand, which
+ * bypasses the gate with no record anywhere of what was overridden or why. This
+ * module does not weaken the gate; it relocates that escape hatch out of an
+ * untraceable hand-merge and into a mandatory-reason audit trail.
+ *
+ * Live provenance: Story #5007 / PR #5022, where a FALSE critical blocker — an
+ * MI finding on files `delivery.quality.gates.maintainability.ignoreGlobs`
+ * exempts, which the `check-baselines.js` ratchet correctly ignored in the same
+ * run — halted a legitimate delivery with a hand-merge as the only way out.
+ */
+
+import { Logger } from '../../../Logger.js';
+import {
+  emitRuntimeFriction,
+  RUNTIME_FRICTION_CATEGORIES,
+} from '../../../observability/runtime-friction.js';
+import {
+  postStructuredComment,
+  upsertStructuredComment,
+} from '../../ticketing.js';
+
+/** Cap on the reason text copied into the friction signal's `details`. */
+const REASON_SIGNAL_LIMIT = 500;
+
+/**
+ * Build the audit record posted when an operator overrides a review blocker.
+ * Pure.
+ *
+ * The body restates the count, the reason, and the fact that auto-merge was
+ * armed anyway — an override whose trail says only "overridden" is no better
+ * than the hand-merge it replaces.
+ *
+ * Module-local: an implementation detail of
+ * {@link handleOverriddenReviewBlock}, whose posted body is observable through
+ * that public entry point. Exporting it would add a public symbol no production
+ * path reaches — the exact dead-export shape this repo ratchets against.
+ *
+ * @param {{ prUrl: string, criticalCount: number, reason: string }} args
+ * @returns {string}
+ */
+function buildReviewOverrideBody({ prUrl, criticalCount, reason }) {
+  return [
+    '### Code-review blocker overridden by operator',
+    '',
+    `The Story-scope review reported **${criticalCount} critical blocker(s)** on ${prUrl}.`,
+    'The operator reviewed and rejected the finding(s) and authorized delivery',
+    'with `--override-review-block`; auto-merge was armed.',
+    '',
+    '**Recorded reason:**',
+    '',
+    `> ${reason.split('\n').join('\n> ')}`,
+    '',
+    'The findings comment on the PR is left in place unchanged — this record',
+    'sits beside it rather than resolving it.',
+  ].join('\n');
+}
+
+/**
+ * Post one audit record, swallowing the failure into a warning.
+ *
+ * Every write here is best-effort by design: an override whose audit trail
+ * partly failed must still land the delivery the operator authorized, because
+ * the close would otherwise fail for a reason the operator cannot act on. The
+ * friction signal is the durable record — it is what makes a rising override
+ * count visible to the retro.
+ *
+ * Module-local: the two call sites below are its only callers.
+ *
+ * @param {{ post: () => Promise<unknown>, surface: string }} args
+ * @returns {Promise<boolean>} true when the record landed.
+ */
+async function postAuditRecord({ post, surface }) {
+  try {
+    await post();
+    return true;
+  } catch (err) {
+    Logger.warn(
+      `[single-story-close] failed to post review-override record on ${surface}: ${err?.message ?? err}`,
+    );
+    return false;
+  }
+}
+
+/**
+ * Record an operator-authorized override of a critical code-review blocker,
+ * then let close continue to the auto-merge phase.
+ *
+ * Writes to three surfaces: the Story issue via `upsert` so a re-run does not
+ * stack duplicates; the PR via `post` so the trail is append-only on the surface
+ * a human reviews, and so a reviewer reading the PR need not open the Story to
+ * learn the blocker was overridden; and the friction stream.
+ *
+ * @param {{
+ *   provider: object,
+ *   storyId: number,
+ *   prUrl: string,
+ *   prNumber: number|null,
+ *   criticalCount: number,
+ *   reason: string,
+ *   config?: object,
+ *   emitFrictionFn?: typeof emitRuntimeFriction,
+ * }} args
+ * @returns {Promise<{ overridden: true, reason: string, criticalCount: number }>}
+ */
+export async function handleOverriddenReviewBlock({
+  provider,
+  storyId,
+  prUrl,
+  prNumber,
+  criticalCount,
+  reason,
+  config,
+  emitFrictionFn = emitRuntimeFriction,
+}) {
+  const body = buildReviewOverrideBody({ prUrl, criticalCount, reason });
+  Logger.warn(
+    `[single-story-close] ⚠️ Story-scope review reported ${criticalCount} critical blocker(s) on ` +
+      `PR ${prUrl} — OVERRIDDEN by operator: ${reason}`,
+  );
+  await postAuditRecord({
+    post: () => upsertStructuredComment(provider, storyId, 'friction', body),
+    surface: `Story #${storyId}`,
+  });
+  if (Number.isInteger(prNumber)) {
+    await postAuditRecord({
+      post: () =>
+        postStructuredComment(provider, prNumber, 'notification', body),
+      surface: `PR #${prNumber}`,
+    });
+  }
+  await emitFrictionFn({
+    storyId,
+    category: RUNTIME_FRICTION_CATEGORIES.REVIEW_BLOCK_OVERRIDDEN,
+    tool: 'single-story-close',
+    details: {
+      prUrl,
+      criticalCount,
+      reason: reason.slice(0, REASON_SIGNAL_LIMIT),
+    },
+    config,
+  });
+  return { overridden: true, reason, criticalCount };
+}

--- a/.agents/scripts/lib/orchestration/single-story-close/runner.js
+++ b/.agents/scripts/lib/orchestration/single-story-close/runner.js
@@ -29,6 +29,7 @@ import { parseCloseOptions, resolveWaitForMerge } from './phases/options.js';
 import { ensurePullRequestWith } from './phases/pull-request.js';
 import { pushStoryBranch } from './phases/push.js';
 import { handleCriticalReviewBlock } from './phases/review-block.js';
+import { handleOverriddenReviewBlock } from './phases/review-override.js';
 import { reapWorktreePhase } from './phases/worktree-reap.js';
 import { runWrongTreeGuardPhase } from './phases/wrong-tree-guard.js';
 
@@ -207,6 +208,8 @@ async function openAndReviewPr({
   storyBranch,
   baseBranch,
   provider,
+  config,
+  overrideReviewBlock,
   injectedGh,
   injectedRunCodeReview,
   setPhase = () => {},
@@ -251,6 +254,27 @@ async function openAndReviewPr({
   });
   if (reviewOutcome.halted) {
     const criticalCount = reviewOutcome.severity?.critical ?? 0;
+    // The sanctioned override. Checked BEFORE the blocked
+    // transition so an overridden run never touches `agent::blocked`: the
+    // Story is proceeding, and parking it would make the label lie for the
+    // rest of the close.
+    if (overrideReviewBlock) {
+      const override = await handleOverriddenReviewBlock({
+        provider,
+        storyId,
+        prUrl,
+        prNumber,
+        criticalCount,
+        reason: overrideReviewBlock,
+        config,
+      });
+      return {
+        prUrl,
+        prNumber,
+        alreadyMerged: false,
+        reviewOverride: override,
+      };
+    }
     await handleCriticalReviewBlock({
       provider,
       storyId,
@@ -259,10 +283,12 @@ async function openAndReviewPr({
     });
     throw new Error(
       `[single-story-close] Story-scope review reported ${criticalCount} critical blocker(s) on PR ${prUrl}. ` +
-        'Auto-merge was not enabled. Remediate the findings posted to the PR and re-run `/deliver`.',
+        'Auto-merge was not enabled. Remediate the findings posted to the PR and re-run `/deliver`. ' +
+        'If you have reviewed a finding and judged it wrong, re-run with ' +
+        '`--override-review-block "<reason>"` rather than merging by hand.',
     );
   }
-  return { prUrl, prNumber, alreadyMerged: false };
+  return { prUrl, prNumber, alreadyMerged: false, reviewOverride: null };
 }
 
 async function releaseLease({
@@ -383,6 +409,7 @@ export async function runSingleStoryClose({
   noWaitForMerge: noWaitForMergeParam,
   maxWaitSeconds: maxWaitSecondsParam,
   mergeWatchMode: mergeWatchModeParam,
+  overrideReviewBlock: overrideReviewBlockParam,
   injectedProvider,
   injectedConfig,
   injectedNotify,
@@ -402,10 +429,11 @@ export async function runSingleStoryClose({
     noWaitForMergeParam,
     maxWaitSecondsParam,
     mergeWatchModeParam,
+    overrideReviewBlockParam,
   });
   if (!options.storyId) {
     throw new Error(
-      'Usage: node single-story-close.js --story <STORY_ID> [--cwd <main-repo>] [--skip-validation] [--skip-sync] [--no-auto-merge] [--wait-merge|--no-wait-merge] [--max-wait-seconds <n>] [--merge-watch-mode <sync|async>]',
+      'Usage: node single-story-close.js --story <STORY_ID> [--cwd <main-repo>] [--skip-validation] [--skip-sync] [--no-auto-merge] [--wait-merge|--no-wait-merge] [--max-wait-seconds <n>] [--merge-watch-mode <sync|async>] [--override-review-block <reason>]',
     );
   }
 
@@ -730,22 +758,25 @@ async function runClosePipeline({
     leaseArgs,
   );
 
-  const { prUrl, prNumber, alreadyMerged } = await releaseLeaseOnBlock(
-    () =>
-      openAndReviewPr({
-        cwd: options.cwd,
-        worktreePath,
-        story,
-        storyId: options.storyId,
-        storyBranch,
-        baseBranch,
-        provider,
-        injectedGh,
-        injectedRunCodeReview,
-        setPhase,
-      }),
-    leaseArgs,
-  );
+  const { prUrl, prNumber, alreadyMerged, reviewOverride } =
+    await releaseLeaseOnBlock(
+      () =>
+        openAndReviewPr({
+          cwd: options.cwd,
+          worktreePath,
+          story,
+          storyId: options.storyId,
+          storyBranch,
+          baseBranch,
+          provider,
+          config,
+          overrideReviewBlock: options.overrideReviewBlock,
+          injectedGh,
+          injectedRunCodeReview,
+          setPhase,
+        }),
+      leaseArgs,
+    );
   // Reap the per-Story worktree BEFORE the arm (Story #4681). Arming runs
   // `gh pr merge --auto --squash --delete-branch`, which — against an
   // already-mergeable PR — merges immediately and then shells out to local
@@ -843,7 +874,10 @@ async function runClosePipeline({
     gates: {
       validation: options.skipValidation ? 'skipped' : 'passed',
       baseSync: options.skipSync ? 'skipped' : 'passed',
-      codeReview: 'passed',
+      // An overridden blocker reports `overridden`, never
+      // `passed`. The review DID fail; a human authorized shipping anyway, and
+      // the envelope is the machine-readable trail that says so.
+      codeReview: reviewOverride ? 'overridden' : 'passed',
     },
   };
 

--- a/.agents/scripts/single-story-close.js
+++ b/.agents/scripts/single-story-close.js
@@ -44,6 +44,18 @@
  *                              [--no-auto-merge]
  *                              [--wait-merge | --no-wait-merge]
  *                              [--merge-watch-mode <sync|async>]
+ *                              [--override-review-block <reason>]
+ *
+ * `--override-review-block <reason>` is the one sanctioned way
+ * past a code-review CRITICAL blocker. A critical finding halts this script
+ * before auto-merge, and until this flag existed there was no override at all —
+ * so an operator who had read a finding and judged it wrong could only land by
+ * running `gh pr merge` themselves, bypassing the gate with nothing written
+ * down. The flag does not weaken the gate; it moves that escape hatch into a
+ * mandatory-reason audit trail (Story comment + PR comment + a
+ * `review-block-overridden` friction signal) and reports
+ * `gates.codeReview: "overridden"` on the terminal envelope. A bare or
+ * too-short reason fails during option parsing, before any phase runs.
  *
  * `--merge-watch-mode` (Story #4949) overrides `delivery.mergeWatch.mode` for
  * one invocation, on the same explicit-wins-over-config precedence
@@ -216,6 +228,14 @@ runAsCli(import.meta.url, main, {
       [
         '--merge-watch-mode <sync|async>',
         'Override delivery.mergeWatch.mode for this invocation only. `async` caps the merge wait to a short probe window and returns the resumable `pending` terminal instead of holding the foreground slot — pass it on every close of a multi-Story run. An invalid value exits non-zero before any phase runs.',
+      ],
+      [
+        '--override-review-block <reason>',
+        // Deliberately does not spell the merge CLI invocation: the
+        // merge-lockout rule in `check-lifecycle-lint.js` forbids that literal
+        // in any string outside `phases/auto-merge.js`, and it is right to —
+        // the point of this flag is that arming stays on the one code path.
+        'Land despite a Story-scope code-review CRITICAL blocker you have reviewed and judged wrong. The reason is mandatory (≥12 chars) and is recorded on the Story, on the PR, and as a `review-block-overridden` friction signal; the terminal envelope reports `gates.codeReview: "overridden"`. Use this instead of merging the PR by hand with the GitHub CLI — a hand-merge bypasses the gate with no record at all.',
       ],
       ['--no-evidence', 'Do not reuse or write gate evidence stamps.'],
       ['--dry-run', 'Report the plan; mutate nothing.'],

--- a/.agents/workflows/helpers/deliver-story-reference.md
+++ b/.agents/workflows/helpers/deliver-story-reference.md
@@ -394,6 +394,16 @@ judgment that help text cannot carry.
   wants the PR left at `agent::closing` for a human land (or a wrapper that
   will invoke `single-story-confirm-merge.js` itself). Reports `pending` —
   the work is not done, nothing is broken, and one named command finishes it.
+- `--override-review-block "<reason>"` — when the Story-scope review's
+  **critical** blocker is one you have read and judged wrong (a false positive,
+  or a finding the ratchet correctly exempts). It is the only sanctioned way
+  past that halt: reach for it instead of merging the PR by hand, because a
+  hand-merge bypasses the gate and records nothing. The reason is mandatory and
+  is written to three places (Story comment, PR comment, a
+  `review-block-overridden` friction signal), and the terminal envelope reports
+  `gates.codeReview: "overridden"` rather than `"passed"`. If you find yourself
+  reaching for it twice for the same shape of finding, the gate is
+  miscalibrated — fix the gate, not the run.
 - `--max-wait-seconds <n>` — from a headless caller with no host
   tool-invocation ceiling, to keep single-block semantics
   without editing the consumer's config.

--- a/baselines/coverage.json
+++ b/baselines/coverage.json
@@ -1,12 +1,12 @@
 {
   "$schema": ".agents/schemas/baselines/coverage.schema.json",
   "kernelVersion": "1.0.0",
-  "generatedAt": "2026-08-06T10:46:27.495Z",
+  "generatedAt": "2026-08-06T10:55:16.737Z",
   "rollup": {
     "*": {
-      "lines": 95.81,
-      "branches": 86.47,
-      "functions": 88.61
+      "lines": 95.85,
+      "branches": 86.41,
+      "functions": 88.75
     }
   },
   "rows": [
@@ -828,8 +828,8 @@
     },
     {
       "path": ".agents/scripts/lib/cli-args.js",
-      "lines": 97.85,
-      "branches": 85.27,
+      "lines": 97.82,
+      "branches": 86.54,
       "functions": 100
     },
     {
@@ -1530,8 +1530,8 @@
     },
     {
       "path": ".agents/scripts/lib/observability/runtime-friction.js",
-      "lines": 96.92,
-      "branches": 81.72,
+      "lines": 97.05,
+      "branches": 82.11,
       "functions": 100
     },
     {
@@ -2075,10 +2075,16 @@
       "functions": 100
     },
     {
+      "path": ".agents/scripts/lib/orchestration/review-providers/mi-exemptions.js",
+      "lines": 100,
+      "branches": 90.48,
+      "functions": 100
+    },
+    {
       "path": ".agents/scripts/lib/orchestration/review-providers/native.js",
-      "lines": 93.62,
-      "branches": 80.65,
-      "functions": 93.75
+      "lines": 97.51,
+      "branches": 86.73,
+      "functions": 100
     },
     {
       "path": ".agents/scripts/lib/orchestration/review-providers/parse-findings.js",
@@ -2190,8 +2196,8 @@
     },
     {
       "path": ".agents/scripts/lib/orchestration/single-story-close/phases/options.js",
-      "lines": 98.65,
-      "branches": 87.5,
+      "lines": 98.78,
+      "branches": 95.24,
       "functions": 100
     },
     {
@@ -2214,7 +2220,7 @@
     },
     {
       "path": ".agents/scripts/lib/orchestration/single-story-close/phases/review-block.js",
-      "lines": 90.91,
+      "lines": 91.84,
       "branches": 66.67,
       "functions": 100
     },
@@ -2222,6 +2228,12 @@
       "path": ".agents/scripts/lib/orchestration/single-story-close/phases/review-outcome.js",
       "lines": 90.91,
       "branches": 75,
+      "functions": 100
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/single-story-close/phases/review-override.js",
+      "lines": 96.82,
+      "branches": 85.71,
       "functions": 100
     },
     {
@@ -2238,8 +2250,8 @@
     },
     {
       "path": ".agents/scripts/lib/orchestration/single-story-close/runner.js",
-      "lines": 96.75,
-      "branches": 83.54,
+      "lines": 96.88,
+      "branches": 84.34,
       "functions": 89.47
     },
     {
@@ -3084,9 +3096,9 @@
     },
     {
       "path": ".agents/scripts/single-story-close.js",
-      "lines": 91.04,
-      "branches": 100,
-      "functions": 50
+      "lines": 100,
+      "branches": 50,
+      "functions": 100
     },
     {
       "path": ".agents/scripts/single-story-confirm-merge.js",

--- a/baselines/crap.json
+++ b/baselines/crap.json
@@ -5947,12 +5947,6 @@
     },
     {
       "path": ".agents/scripts/lib/cli-args.js",
-      "method": "parseSprintArgs",
-      "startLine": 71,
-      "crap": 4
-    },
-    {
-      "path": ".agents/scripts/lib/cli-args.js",
       "method": "camelCase",
       "startLine": 148,
       "crap": 1
@@ -5975,6 +5969,12 @@
       "method": "coerceValue",
       "startLine": 159,
       "crap": 4.074074074074074
+    },
+    {
+      "path": ".agents/scripts/lib/cli-args.js",
+      "method": "parseSprintArgs",
+      "startLine": 179,
+      "crap": 6
     },
     {
       "path": ".agents/scripts/lib/cli-args.js",
@@ -15276,8 +15276,8 @@
     {
       "path": ".agents/scripts/lib/orchestration/review-providers/native.js",
       "method": "createNativeProvider",
-      "startLine": 475,
-      "crap": 8.016294553673958
+      "startLine": 481,
+      "crap": 9.008069531050543
     },
     {
       "path": ".agents/scripts/lib/orchestration/review-providers/native.js",
@@ -16582,8 +16582,8 @@
     {
       "path": ".agents/scripts/lib/orchestration/single-story-close/runner.js",
       "method": "openAndReviewPr",
-      "startLine": 202,
-      "crap": 3.000287945866177
+      "startLine": 203,
+      "crap": 4.000175582990398
     },
     {
       "path": ".agents/scripts/lib/orchestration/single-story-close/runner.js",
@@ -16655,8 +16655,8 @@
     {
       "path": ".agents/scripts/lib/orchestration/single-story-close/runner.js",
       "method": "runClosePipeline",
-      "startLine": 652,
-      "crap": 8
+      "startLine": 680,
+      "crap": 9
     },
     {
       "path": ".agents/scripts/lib/orchestration/single-story-close/runner.js",

--- a/baselines/dead-exports-production.json
+++ b/baselines/dead-exports-production.json
@@ -1821,6 +1821,10 @@
       "symbol": "*"
     },
     {
+      "file": ".agents/scripts/lib/orchestration/single-story-close/phases/review-override.js",
+      "symbol": "*"
+    },
+    {
       "file": ".agents/scripts/lib/orchestration/single-story-close/phases/worktree-reap.js",
       "symbol": "*"
     },

--- a/baselines/dead-exports.json
+++ b/baselines/dead-exports.json
@@ -268,6 +268,10 @@
       "symbol": "*"
     },
     {
+      "file": ".agents/scripts/lib/orchestration/single-story-close/phases/review-override.js",
+      "symbol": "*"
+    },
+    {
       "file": ".agents/scripts/lib/orchestration/single-story-close/runner.js",
       "symbol": "*"
     },

--- a/baselines/maintainability.json
+++ b/baselines/maintainability.json
@@ -1,11 +1,11 @@
 {
   "$schema": ".agents/schemas/baselines/maintainability.schema.json",
   "kernelVersion": "0.1.0",
-  "generatedAt": "2026-08-06T10:46:27.843Z",
+  "generatedAt": "2026-08-06T10:55:15.476Z",
   "rollup": {
     "*": {
       "min": 76.381,
-      "p50": 98.344,
+      "p50": 98.358,
       "p95": 122.913
     }
   },
@@ -568,7 +568,7 @@
     },
     {
       "path": ".agents/scripts/lib/cli-args.js",
-      "mi": 89.234
+      "mi": 90.688
     },
     {
       "path": ".agents/scripts/lib/cli-usage.js",
@@ -1359,8 +1359,12 @@
       "mi": 97.791
     },
     {
+      "path": ".agents/scripts/lib/orchestration/review-providers/mi-exemptions.js",
+      "mi": 105.32
+    },
+    {
       "path": ".agents/scripts/lib/orchestration/review-providers/native.js",
-      "mi": 93.44
+      "mi": 92.442
     },
     {
       "path": ".agents/scripts/lib/orchestration/review-providers/parse-findings.js",
@@ -1459,6 +1463,10 @@
       "mi": 121.456
     },
     {
+      "path": ".agents/scripts/lib/orchestration/single-story-close/phases/review-override.js",
+      "mi": 107.61
+    },
+    {
       "path": ".agents/scripts/lib/orchestration/single-story-close/phases/worktree-reap.js",
       "mi": 113.344
     },
@@ -1468,7 +1476,7 @@
     },
     {
       "path": ".agents/scripts/lib/orchestration/single-story-close/runner.js",
-      "mi": 80.523
+      "mi": 79.707
     },
     {
       "path": ".agents/scripts/lib/orchestration/single-story-lease-guard.js",

--- a/tests/lib/orchestration/review-providers/mi-exemptions.test.js
+++ b/tests/lib/orchestration/review-providers/mi-exemptions.test.js
@@ -1,0 +1,139 @@
+/**
+ * Unit tests for `review-providers/mi-exemptions.js` — the maintainability
+ * gate's exemption list as the native review provider reads it.
+ *
+ * Live defect this module exists for (Story #5007 / PR #5022): the review lens
+ * scored files `delivery.quality.gates.maintainability.ignoreGlobs` exempts, so
+ * the `check-baselines.js` ratchet PASSED while the lens raised a **critical
+ * blocker** on the same three `config-settings-schema*.js` modules in the same
+ * close run. A critical finding halts close before auto-merge, so the only way
+ * to land legitimate work was to merge the PR by hand.
+ *
+ * The bar here: the resolver reads the same gate key the ratchet reads, and it
+ * fails OPEN — never closed — when the config cannot be resolved.
+ */
+
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+  resolveMaintainabilityIgnoreGlobs,
+  scopeMaintainabilityFiles,
+} from '../../../../.agents/scripts/lib/orchestration/review-providers/mi-exemptions.js';
+
+/** The three real paths from PR #5022, and the glob that exempts all of them. */
+const EXEMPT_FILES = [
+  '.agents/scripts/lib/config-settings-schema-delivery.js',
+  '.agents/scripts/lib/config-settings-schema-quality.js',
+  '.agents/scripts/lib/config-settings-schema.js',
+];
+const EXEMPT_GLOB = '.agents/scripts/lib/config-settings-schema*.js';
+
+function configWithIgnoreGlobs(globs) {
+  return () => ({
+    delivery: {
+      quality: { gates: { maintainability: { ignoreGlobs: globs } } },
+    },
+  });
+}
+
+test('resolveMaintainabilityIgnoreGlobs: reads the same gate key the ratchet reads', () => {
+  const globs = resolveMaintainabilityIgnoreGlobs({
+    resolveConfigFn: configWithIgnoreGlobs(['a/**.js', 'b*.js']),
+  });
+  assert.deepEqual(globs, ['a/**.js', 'b*.js']);
+});
+
+test('resolveMaintainabilityIgnoreGlobs: returns a copy, so a caller cannot poison the config', () => {
+  const config = configWithIgnoreGlobs(['a/**.js']);
+  const first = resolveMaintainabilityIgnoreGlobs({ resolveConfigFn: config });
+  first.push('mutated');
+  assert.deepEqual(
+    resolveMaintainabilityIgnoreGlobs({ resolveConfigFn: config }),
+    ['a/**.js'],
+  );
+});
+
+test('resolveMaintainabilityIgnoreGlobs: an unresolvable config fails OPEN', () => {
+  // `[]` scores every changed file and at worst produces an advisory a human
+  // reads. Degrading the other way would silently retire the dimension, which
+  // is strictly worse than the false positive it prevents.
+  const globs = resolveMaintainabilityIgnoreGlobs({
+    resolveConfigFn: () => {
+      throw new Error('unreadable .agentrc.json');
+    },
+  });
+  assert.deepEqual(globs, []);
+});
+
+test('resolveMaintainabilityIgnoreGlobs: a missing or non-array key fails OPEN', () => {
+  for (const value of [undefined, null, 'not-an-array', 42, {}]) {
+    assert.deepEqual(
+      resolveMaintainabilityIgnoreGlobs({
+        resolveConfigFn: configWithIgnoreGlobs(value),
+      }),
+      [],
+      `ignoreGlobs=${JSON.stringify(value)} must degrade to []`,
+    );
+  }
+  assert.deepEqual(
+    resolveMaintainabilityIgnoreGlobs({ resolveConfigFn: () => ({}) }),
+    [],
+  );
+});
+
+/** Scope a file list with an explicit glob list, bypassing config resolution. */
+function scopeWith(files, globs) {
+  return scopeMaintainabilityFiles(files, {
+    cwd: '/repo',
+    resolveIgnoreGlobsFn: () => globs,
+  });
+}
+
+test('scopeMaintainabilityFiles: splits the real PR #5022 file set on the real glob', () => {
+  const scoredPath = '.agents/scripts/lib/orchestration/runner.js';
+  const { scored, ignored } = scopeWith(
+    [...EXEMPT_FILES, scoredPath],
+    [EXEMPT_GLOB],
+  );
+  assert.deepEqual(ignored, EXEMPT_FILES);
+  assert.deepEqual(scored, [scoredPath]);
+});
+
+test('scopeMaintainabilityFiles: an empty or absent list is a no-op that scores everything', () => {
+  for (const globs of [[], undefined, null, 'nope']) {
+    const { scored, ignored, notice } = scopeWith(EXEMPT_FILES, globs);
+    assert.deepEqual(scored, EXEMPT_FILES);
+    assert.deepEqual(ignored, []);
+    assert.equal(notice, null, 'nothing exempted renders no notice');
+  }
+});
+
+test('scopeMaintainabilityFiles: matches dot-prefixed roots like .agents/', () => {
+  // The repo's own exemptions all live under `.agents/`, so a matcher without
+  // minimatch's `{ dot: true }` would silently exempt nothing here.
+  const { ignored } = scopeWith(
+    ['.agents/scripts/lib/config/gates/crap.schema.js'],
+    ['.agents/scripts/lib/config/gates/*.schema.js'],
+  );
+  assert.equal(ignored.length, 1);
+});
+
+test('scopeMaintainabilityFiles: the notice names every exempt file and the gate key', () => {
+  const { notice } = scopeWith(EXEMPT_FILES, [EXEMPT_GLOB]);
+  assert.match(notice, /3 changed file\(s\) exempt via/);
+  assert.match(
+    notice,
+    /delivery\.quality\.gates\.maintainability\.ignoreGlobs/,
+  );
+  for (const file of EXEMPT_FILES) assert.ok(notice.includes(file));
+});
+
+test('scopeMaintainabilityFiles: reads the gate key when no resolver is injected', () => {
+  // The production default path — no `resolveIgnoreGlobsFn`. This repo's own
+  // .agentrc.json exempts config-settings-schema*.js, so the real read must
+  // exempt all three.
+  const { ignored } = scopeMaintainabilityFiles(EXEMPT_FILES, {
+    cwd: process.cwd(),
+  });
+  assert.deepEqual(ignored, EXEMPT_FILES);
+});

--- a/tests/lib/orchestration/review-providers/native.test.js
+++ b/tests/lib/orchestration/review-providers/native.test.js
@@ -1050,3 +1050,117 @@ test('renderFindings: a healthy review body is byte-identical with an absent or 
   assert.match(withoutField, /### ✅ No findings/);
   assert.equal(withoutField.includes('Degraded'), false);
 });
+
+/**
+ * The maintainability dimension honours
+ * `delivery.quality.gates.maintainability.ignoreGlobs`.
+ *
+ * Live defect (Story #5007 / PR #5022): the ratchet (`check-baselines.js`)
+ * PASSED because the exempted `config-settings-schema*.js` files are absent
+ * from the MI baseline, while this lens raised a critical blocker on the very
+ * same files in the very same close run. A critical finding halts
+ * `single-story-close.js` before auto-merge, so the two surfaces disagreeing
+ * meant a hand-run merge was the only way to land legitimate work.
+ *
+ * The bar these tests hold: an exempted file produces NO finding at ANY
+ * severity — not a downgraded one. The matching rules themselves are unit-tested
+ * in `mi-exemptions.test.js`; these pin the provider's wiring and its output.
+ */
+
+/** The three real paths from PR #5022, and the glob that exempts all of them. */
+const EXEMPT_FILES = [
+  '.agents/scripts/lib/config-settings-schema-delivery.js',
+  '.agents/scripts/lib/config-settings-schema-quality.js',
+  '.agents/scripts/lib/config-settings-schema.js',
+];
+const EXEMPT_GLOB = '.agents/scripts/lib/config-settings-schema*.js';
+
+/** A body fat enough to classify below the healthy tier when scored. */
+const FAT_SOURCE = `export const blob = {\n${Array.from(
+  { length: 400 },
+  (_v, i) => `  key${i}: { a: ${i}, b: '${i}', c: [${i}, ${i + 1}] },`,
+).join('\n')}\n};\n`;
+
+/**
+ * Build a provider whose diff is `files`, every one of them scoring badly if
+ * scored at all — which is what makes "no finding" evidence of the exemption
+ * rather than evidence of health.
+ */
+function providerOverFiles(files, { resolveIgnoreGlobsFn }) {
+  const infoLines = [];
+  const gitSpawnFn = (_cwd, sub) => {
+    if (sub === 'diff')
+      return { status: 0, stdout: `${files.join('\n')}\n`, stderr: '' };
+    if (sub === 'show') return { status: 0, stdout: FAT_SOURCE, stderr: '' };
+    return { status: 0, stdout: '', stderr: '' };
+  };
+  const provider = createNativeProvider({
+    gitSpawnFn,
+    resolveIgnoreGlobsFn,
+    logger: { info: (m) => infoLines.push(m), warn: () => {} },
+    scopeLint: 'off',
+  });
+  return { provider, infoLines };
+}
+
+const REVIEW_INPUT = {
+  scope: 'story',
+  ticketId: 5007,
+  baseRef: 'main',
+  headRef: 'story-5007',
+};
+
+test('runReview: an exempt file produces no finding at any severity, and is named on the log', async () => {
+  const { provider, infoLines } = providerOverFiles(EXEMPT_FILES, {
+    resolveIgnoreGlobsFn: () => [EXEMPT_GLOB],
+  });
+
+  const findings = await provider.runReview(REVIEW_INPUT);
+
+  // No finding of ANY severity — the whole point. A downgraded finding would
+  // still be a false positive, just a quieter one.
+  assert.deepEqual(findings, []);
+  for (const severity of ALLOWED_SEVERITIES) {
+    assert.equal(
+      findings.filter((f) => f.severity === severity).length,
+      0,
+      `expected zero ${severity} findings on exempt files`,
+    );
+  }
+
+  const exemptLine = infoLines.find((l) => l.includes('exempt via'));
+  assert.ok(exemptLine, `expected an exemption log line, got: ${infoLines}`);
+  assert.match(exemptLine, /3 changed file\(s\) exempt via/);
+  for (const file of EXEMPT_FILES) assert.ok(exemptLine.includes(file));
+});
+
+test('runReview: exemptions spare only the matched files — an unmatched sibling still reports', async () => {
+  const scoredPath = '.agents/scripts/lib/orchestration/some-runner.js';
+  const { provider } = providerOverFiles([...EXEMPT_FILES, scoredPath], {
+    resolveIgnoreGlobsFn: () => [EXEMPT_GLOB],
+  });
+
+  const findings = await provider.runReview(REVIEW_INPUT);
+
+  assert.ok(findings.length > 0, 'the unmatched file must still be scored');
+  for (const finding of findings) assert.equal(finding.file, scoredPath);
+});
+
+test('runReview: an empty exemption list scores every changed file', async () => {
+  // Also the shape an unresolvable config degrades to — see
+  // `mi-exemptions.test.js` for the fail-open itself. Scoring everything at
+  // worst yields an advisory a human reads; failing the other way would
+  // silently retire the dimension.
+  const { provider, infoLines } = providerOverFiles(EXEMPT_FILES, {
+    resolveIgnoreGlobsFn: () => [],
+  });
+
+  const findings = await provider.runReview(REVIEW_INPUT);
+
+  assert.ok(findings.length > 0, 'nothing is exempt, so everything is scored');
+  assert.equal(
+    infoLines.some((l) => l.includes('exempt via')),
+    false,
+    'nothing was exempted, so nothing is reported as exempt',
+  );
+});

--- a/tests/single-story-close-review.test.js
+++ b/tests/single-story-close-review.test.js
@@ -719,4 +719,108 @@ describe('runSingleStoryClose review-halt orchestration', () => {
       /Code review blocked delivery/,
     );
   });
+
+  /**
+   * The sanctioned override.
+   *
+   * The forced choice this replaces: on Story #5007 / PR #5022 a FALSE critical
+   * blocker (an exempt-by-config schema module the ratchet correctly ignored)
+   * halted close, and `--help` offered no flag that overrides a review verdict.
+   * The only way to land was a hand-run `gh pr merge`, which bypasses the gate
+   * with no record of what was overridden or why. The bar here: the override
+   * arms auto-merge, never parks the Story at `agent::blocked`, and leaves a
+   * trail on both the Story and the PR.
+   */
+  it('--override-review-block lands the PR, records the reason, and never blocks the Story', async (t) => {
+    if (typeof t.mock?.module !== 'function') {
+      t.skip(
+        'module mocking unavailable without --experimental-test-module-mocks',
+      );
+      return;
+    }
+    const REASON =
+      'exempt schema blob per gates.maintainability.ignoreGlobs; ratchet passed';
+    const ghCalls = [];
+    const gh = makeFakeGh((args) => {
+      ghCalls.push(args.slice());
+      if (args[1] === 'list') return [];
+      if (args[1] === 'create') {
+        return 'https://github.com/owner/repo/pull/555\n';
+      }
+      if (args[1] === 'merge') return '';
+      throw new Error(`unexpected gh: ${args.join(' ')}`);
+    });
+    t.mock.module(GIT_UTILS_URL, gitUtilsMock());
+    mockCloseValidation(t, closeValidationMock());
+    t.mock.module(WORKTREE_MANAGER_URL, worktreeManagerMock());
+
+    const { runSingleStoryClose } = await import(`${SUT_URL}?t=override`);
+    const recorder = fakeProviderRecorder();
+    const outcome = await runSingleStoryClose({
+      storyId: 2839,
+      noWaitForMerge: true,
+      cwd: '/repo',
+      skipValidation: true,
+      skipSync: true,
+      overrideReviewBlock: REASON,
+      injectedProvider: recorder.provider,
+      injectedConfig: fakeConfig(),
+      injectedGh: gh,
+      injectedRunCodeReview: async () => ({
+        status: 'ok',
+        severity: { critical: 1, high: 0, medium: 0, suggestion: 0 },
+        posted: true,
+        postedCommentId: 9999,
+        commentTargetId: 555,
+        halted: true,
+        blockerReason: '1 critical blocker(s)',
+      }),
+    });
+
+    // The PR was armed — the whole point of the flag.
+    assert.ok(
+      ghCalls.find((c) => c[1] === 'merge'),
+      'auto-merge must be armed when the blocker is overridden',
+    );
+    // The Story is proceeding, so it must NOT be parked at agent::blocked.
+    for (const u of recorder.updates) {
+      assert.equal(
+        (u.payload?.labels?.add ?? []).includes('agent::blocked'),
+        false,
+        'an overridden run must never transition the Story to agent::blocked',
+      );
+    }
+    // The trail: the reason is recorded verbatim, on the Story AND on the PR.
+    const overrideRecords = recorder.postedComments.filter((c) =>
+      /Code-review blocker overridden by operator/.test(c.payload.body),
+    );
+    assert.equal(
+      overrideRecords.length,
+      2,
+      'the override is recorded on both the Story and the PR',
+    );
+    for (const record of overrideRecords) {
+      assert.ok(record.payload.body.includes(REASON));
+      assert.match(record.payload.body, /1 critical blocker\(s\)/);
+    }
+    assert.deepEqual(
+      overrideRecords.map((c) => c.ticketId).sort((a, b) => a - b),
+      [555, 2839].sort((a, b) => a - b),
+    );
+    // The envelope says `overridden`, never `passed` — the review DID fail.
+    assert.equal(outcome.terminal.gates.codeReview, 'overridden');
+  });
+
+  it('a reasonless override is rejected before any phase runs', async () => {
+    const { runSingleStoryClose } = await import(`${SUT_URL}?t=override-bare`);
+    await assert.rejects(
+      runSingleStoryClose({
+        storyId: 2839,
+        cwd: '/repo',
+        // A bare `--override-review-block` reaches the parser as `true`.
+        overrideReviewBlock: true,
+      }),
+      /--override-review-block requires a reason of at least 12 characters/,
+    );
+  });
 });


### PR DESCRIPTION
## Why

The Story-scope code review's maintainability dimension read no config, so it
scored every changed JS file — including the ones
`delivery.quality.gates.maintainability.ignoreGlobs` exempts. Every other MI
consumer already honours that list: the baseline writer excludes those files, so
the `check-baselines.js` ratchet and the pre-merge MI advisory never see them.

Observed live on Story #5007 / PR #5022:

```text
### 🔴 Critical Blocker (1)
#### 🔴 Low Maintainability — .agents/scripts/lib/config-settings-schema-delivery.js
Module reports a critical maintainability tier — module score 38.9.

### 🟡 Medium Risk (2)
#### 🟡 .agents/scripts/lib/config-settings-schema-quality.js — module 47.1
#### 🟡 .agents/scripts/lib/config-settings-schema.js — module 53.3
```

All three match the **first** entry in
`delivery.quality.gates.maintainability.ignoreGlobs`. They are declarative AJV
schema blobs, which is exactly why they were exempted. So the ratchet **passed**
while the review lens raised a **critical blocker** on the same files in the same
close run. A critical finding halts `single-story-close.js` before auto-merge,
and no flag overrode a review verdict — `--skip-validation` bypasses the gate
chain and `--no-auto-merge` declines to arm, neither touches the review — so the
only way to land legitimate work was a hand-merge that bypasses the gate with no
record at all. A gate that must be hand-bypassed to ship is not a gate.

Reproduced and verified against the exact three files:

| | critical | medium | scored |
|---|---|---|---|
| before | 1 | 2 | 4 |
| after | 0 | 0 | 1 |

## What changed

**`review-providers/mi-exemptions.js`** — new; owns the exemption read behind one
door, `scopeMaintainabilityFiles`. The provider filters its changed-file set
through it before scoring, matching via the declared SSOT
`maintainability-utils.js#isIgnoredByGlobs` rather than a second local matcher —
re-implementing the match is how the two surfaces came to disagree. Exempt files
are **named on the log**, never silently dropped: an operator reading a review
that says nothing about three changed schema modules cannot otherwise tell
"scored and healthy" from "never scored". An unresolvable config **fails open**,
because scoring everything at worst yields an advisory a human reads, while
failing closed would silently retire the dimension. `analyzeChangedFiles` keeps
its original signature — filtering happens once at the call site, so the scorer
carries no knowledge of exemptions.

**`phases/review-override.js`** — new; adds `--override-review-block "<reason>"`,
the sanctioned escape hatch. The reason is mandatory and validated at parse time,
before any phase runs, and is recorded on three surfaces: the Story issue, the
PR, and a new `review-block-overridden` friction category. The terminal envelope
reports `gates.codeReview: "overridden"` — a new enum value beside
passed/failed/skipped, because reporting an override as `passed` erases the one
fact a reader most needs and `skipped` would claim the gate never ran. The
override is checked **before** the `agent::blocked` transition, so an overridden
run never parks a Story that is in fact proceeding.

## The other dimensions were checked — one blind spot, not three

- **CRAP advisory** honours `ignoreGlobs` explicitly via `createCrapScorer`.
- **MI advisory** is *implicitly* immune: it keys on `baseline[file]` and skips
  rows-less files. Verified — 0 of 556 MI rows and 0 CRAP rows match the exempt
  globs, so it can never fire on one. Deliberately left alone.
- **Duplication** has no review-lens or projection surface at all; it exists only
  as a baseline gate. Nothing to fix.
- **Lint** is deliberately left unfiltered — it carries its own exclusion
  surface, and a quality-gate glob makes no claim about whether a file should
  parse or format cleanly.

Also removes `_emptyResults`, dead in `native.js` and stale against the envelope
it claimed to build.

## Verification

- **9832 tests pass, 0 fail.** New: a regression test that an ignoreGlob-matched
  file produces **no finding at any severity**, plus the override landing the PR,
  recording its reason on both surfaces, never blocking the Story, and rejecting
  a reasonless invocation.
- Every gate green: `check-baselines` overall and per-gate for maintainability,
  crap, duplication and coverage; `dead-exports` in both modes; `cyclomatic`;
  `arch-cycles`; `context-budget`; `lifecycle-lint`; `lifecycle-doc-drift`;
  `workflow-citations`; `workflow-cli-lint`. `npm audit` clean.

## Reviewer notes

Two things worth a look:

1. **`check-lifecycle-lint.js` caught the first draft** of the flag's help text
   for containing the literal merge-CLI invocation in a string. The rule is
   right — arming must stay on one code path — so the text was reworded rather
   than the rule widened.
2. **The baseline commit is separated and scoped.** It carries the
   `baseline-refresh:` tag for the one real MI cost: `native.js` 93.44 -> 92.44,
   still 17 points above the floor. The logic was extracted into
   `mi-exemptions.js` across three passes to shrink that from -1.89 to -1.00, and
   what remains is the irreducible footprint. Every baseline row is scoped to a
   file this PR touches; a full `maintainability:reanchor` also wanted to tighten
   17 untouched stale files, and a full `crap:reanchor` was **measured and
   rejected** — it churns 3888 -> 4438 rows across 134 untouched files, the
   row-identity migration this repo has been burned by before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes story-close gating and auto-merge behavior when review reports critical findings; override is auditable but allows shipping despite a failed review gate.
> 
> **Overview**
> Fixes a **delivery blocker** where the native code-review lens scored maintainability on files the ratchet already exempts via `delivery.quality.gates.maintainability.ignoreGlobs`, producing critical findings that halted close while `check-baselines` passed.
> 
> **Maintainability alignment:** New `mi-exemptions.js` resolves the same ignore globs and splits the diff through `isIgnoredByGlobs` before scoring; the native provider logs which files were exempted. Lint is unchanged (separate exclusion surfaces).
> 
> **Sanctioned override:** `--override-review-block "<reason>"` (≥12 characters, validated at parse time) lets an operator proceed past a **critical** review halt without hand-merging. Close records the reason on the Story and PR, emits `review-block-overridden` friction, arms auto-merge **without** `agent::blocked`, and sets terminal `gates.codeReview` to **`overridden`** (schema enum extended). Blocked-path messaging and deliver docs point operators at this flag instead of silent bypass.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bc381ae7237bbb7699a47b6bde2c2a84327972b1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->