### PR TITLE
fix: close six defects found reviewing the v2.32.0 release diff

### DIFF
--- a/.agents/docs/quality-gates.md
+++ b/.agents/docs/quality-gates.md
@@ -720,8 +720,14 @@ without being measured needs its producer (`npm run coverage:update`,
 `npm run maintainability:update`), because inventing a row would be claiming a
 measurement nobody took.
 
-CI runs `--check` only. Writing is always an operator (or agent) decision made
-with the branch in hand.
+**CI does not run the pruner in either mode.** `--check` exits 1 on any stale
+row without asking which change set introduced it, so pairing it with
+`check-baseline-scope.js` in the required job cancelled that gate's merge-base
+attribution: a row inherited from `main` — say one PR deletes a file while a
+second, branched earlier, re-adds its row through a baseline refresh — reds
+every open PR on divergence its author did not create and cannot fix from
+their branch. The scope gate reports that row as an inherited warning; the
+pruner is the remedy an operator (or agent) runs with the branch in hand.
 
 ---
 

--- a/.agents/rules/known-tooling-behavior.md
+++ b/.agents/rules/known-tooling-behavior.md
@@ -69,14 +69,20 @@ commands** the script knows nothing about, so a locally green
 | `check-workflow-citations.js` | no | no | **no** |
 | `check-cyclomatic.js` | no | no | **yes** |
 | `check-schema-references.js` | no | no | **yes** |
+| `check-knip-entries.js` | no | no | **yes** |
 | `check-baseline-scope.js` | no | no | **no** |
-| `prune-baseline-orphans.js --check` | no | no | **no** |
 
-Three are still in **no** local aggregate command —
-`check-workflow-citations.js`, `check-baseline-scope.js` and
-`prune-baseline-orphans.js --check`. Each is reachable only as its own npm
-script (`check:workflow-citations`, `baselines:scope`, `baselines:prune`) or a
+Two are still in **no** local aggregate command —
+`check-workflow-citations.js` and `check-baseline-scope.js`. Each is reachable
+only as its own npm script (`check:workflow-citations`, `baselines:scope`) or a
 direct invocation.
+
+`prune-baseline-orphans.js --check` left this table in v2.32.0: it no longer
+runs in CI in any mode. It reports the same absent / out-of-scope rows as
+`check-baseline-scope.js` but without merge-base attribution, so holding it in
+the required job made the scope gate's inherited-divergence warning
+unreachable — a stale row on `main` red every open PR regardless of who landed
+it. It stays the operator's remedy, via `npm run baselines:prune`.
 
 `check-context-budget.js` additionally runs in `.husky/pre-push`. It is
 zero-tolerance in **both** directions — a change that *shrinks* the

--- a/.agents/scripts/check-gherkin-corpus.js
+++ b/.agents/scripts/check-gherkin-corpus.js
@@ -36,7 +36,43 @@
 //   0  clean, or `qa.gherkinLint` is not configured
 //   1  a parse error, an unbound step, or a fail-closed condition
 
-import { readFileSync } from 'node:fs';
+// .agents/scripts/check-gherkin-corpus.js — static gate over a project's
+// Gherkin corpus: must-compile, then must-bind, scoped per step root.
+//
+// The framework ships the bddgen harness but nothing that inspects the corpus
+// it generates from. Two corpus-wide failures are invisible until generation
+// time, and both take the whole acceptance suite dark at once: a `.feature`
+// the parser rejects, and a step no definition claims. This gate catches both
+// offline, in the same `npm run lint` that already guards every other
+// framework-owned surface.
+//
+// Two contracts make the findings trustworthy rather than merely loud:
+//
+//   must-compile parses with the REAL `@cucumber/gherkin` parser. A gate that
+//   re-implements acceptance is the defect it is trying to prevent: a
+//   hand-rolled line reader silently skips what it does not recognise, so a
+//   corpus that cannot generate reads clean. Whatever bddgen accepts is what
+//   this gate must accept, and the only way to guarantee that is to run the
+//   same parser.
+//
+//   A file failing must-compile is EXCLUDED from must-bind. A broken file
+//   parses as an arbitrary subset of itself, so linting its surviving steps
+//   invents unbound findings that bury the one actionable line — the syntax
+//   error — under noise.
+//
+// The parser is an optional peer dependency (plus a framework devDependency),
+// resolved through a require path rooted at the consumer project rather than
+// imported by bare specifier. `.agents/` reaches a consumer by plain file
+// copy, so a bare specifier here would resolve against the consumer's own
+// module chain, which under a non-hoisting linker need not hold it at all.
+// This mirrors the `typescript` optional-peer precedent and keeps a consumer
+// with no BDD tier from gaining a runtime dependency.
+//
+// Exit codes:
+//   0  clean, or `qa.gherkinLint` is not configured
+//   1  a parse error, an unbound step, or a fail-closed condition
+
+import fs, { readFileSync } from 'node:fs';
 import { createRequire } from 'node:module';
 import path from 'node:path';
 import process from 'node:process';
@@ -200,15 +236,39 @@ export function collectActiveSteps(feature, exemptionTags) {
   const featureTags = tagNames(feature);
   const steps = [];
 
-  const walkContainer = (container, inheritedTags) => {
-    const backgrounds = [];
+  // A background step is reachable from more than one container once Rules are
+  // in play, so emitting is keyed on the step's own line to check it exactly
+  // once per feature rather than once per container that inherits it.
+  const emittedBackgroundLines = new Set();
+  const pushBackgroundSteps = (backgrounds) => {
+    for (const background of backgrounds) {
+      for (const step of background.steps ?? []) {
+        if (emittedBackgroundLines.has(step.location.line)) continue;
+        emittedBackgroundLines.add(step.location.line);
+        steps.push({ line: step.location.line, text: step.text, examples: [] });
+      }
+    }
+  };
+
+  const walkContainer = (container, inheritedTags, inheritedBackgrounds) => {
+    const backgrounds = [...inheritedBackgrounds];
     const scenarios = [];
     for (const child of container?.children ?? []) {
       if (child.background) backgrounds.push(child.background);
       if (child.scenario) scenarios.push(child.scenario);
-      if (child.rule) {
-        walkContainer(child.rule, [...inheritedTags, ...tagNames(child.rule)]);
-      }
+    }
+    // Gherkin runs a feature-level Background for every scenario in the
+    // feature, Rule-nested ones included, so the rule walk inherits the
+    // backgrounds collected above. Recursing before the no-active-scenarios
+    // return is what lets a feature whose scenarios all live under Rules still
+    // have its Background checked.
+    for (const child of container?.children ?? []) {
+      if (!child.rule) continue;
+      walkContainer(
+        child.rule,
+        [...inheritedTags, ...tagNames(child.rule)],
+        backgrounds,
+      );
     }
     const active = scenarios.filter(
       (scenario) =>
@@ -217,11 +277,7 @@ export function collectActiveSteps(feature, exemptionTags) {
         ),
     );
     if (active.length === 0) return;
-    for (const background of backgrounds) {
-      for (const step of background.steps ?? []) {
-        steps.push({ line: step.location.line, text: step.text, examples: [] });
-      }
-    }
+    pushBackgroundSteps(backgrounds);
     for (const scenario of active) {
       for (const step of scenario.steps ?? []) {
         steps.push({
@@ -233,7 +289,7 @@ export function collectActiveSteps(feature, exemptionTags) {
     }
   };
 
-  walkContainer(feature, featureTags);
+  walkContainer(feature, featureTags, []);
   return steps;
 }
 
@@ -323,6 +379,33 @@ export function scanScope({
   };
 }
 
+/**
+ * The featureRoots half of the blackout contract the stepRoots check already
+ * covers on the definitions side. A renamed or typo'd root resolves zero
+ * features, and "nothing to check" would then report green over a corpus
+ * nobody is checking. A root that exists but holds no `.feature` file yet is
+ * the legitimate not-written-them-yet case and stays passing — absence of the
+ * directory is what separates misconfiguration from an empty corpus.
+ *
+ * @param {Array<{ name: string, featureRoots: string[] }>} scopes
+ * @param {string} root
+ * @returns {string | null} the operator-facing message, or null when clean
+ */
+function findMissingFeatureRoots(scopes, root) {
+  for (const scope of scopes) {
+    const missing = scope.featureRoots.filter(
+      (r) => !fs.existsSync(path.resolve(root, r)),
+    );
+    if (missing.length === 0) continue;
+    return (
+      `scope "${scope.name}" names featureRoots that do not exist: ${missing.join(', ')} — ` +
+      'every feature in this scope would go unchecked, which is a blackout, ' +
+      "not a clean run. Point featureRoots at the directory holding this scope's .feature files."
+    );
+  }
+  return null;
+}
+
 /** Render one finding as a single operator-readable line. */
 export function renderFinding(finding) {
   if (finding.kind === 'parse-error') {
@@ -355,6 +438,12 @@ export async function runCli({
       `${TAG} not configured — add a \`qa.gherkinLint\` block to .agentrc.json to enable this gate.\n`,
     );
     return 0;
+  }
+
+  const blackout = findMissingFeatureRoots(contract.scopes, root);
+  if (blackout) {
+    stderr.write(`${TAG} ❌ ${blackout}\n`);
+    return 1;
   }
 
   const corpusSize = contract.scopes.reduce(

--- a/.agents/scripts/check-knip-entries.js
+++ b/.agents/scripts/check-knip-entries.js
@@ -36,6 +36,7 @@
 import process from 'node:process';
 import { runAsCli } from './lib/cli-utils.js';
 import {
+  countDivergences,
   renderEntrySyncReport,
   resolveEntrySync,
 } from './lib/knip-entry-sync.js';
@@ -114,10 +115,7 @@ export async function runCli({
       `${JSON.stringify({ kind: 'knip-entry-sync', ...report }, null, 2)}\n`,
     );
     if (report.error) return EXIT_CANNOT_RUN;
-    return report.missing.length + report.stale.length + report.phantom.length >
-      0
-      ? EXIT_DIVERGED
-      : EXIT_PASS;
+    return countDivergences(report) > 0 ? EXIT_DIVERGED : EXIT_PASS;
   }
 
   if (report.error) {
@@ -127,9 +125,7 @@ export async function runCli({
 
   stdout.write(`\n--- knip-entries ---\n`);
   stdout.write(`${renderEntrySyncReport(report)}\n`);
-  return report.missing.length + report.stale.length + report.phantom.length > 0
-    ? EXIT_DIVERGED
-    : EXIT_PASS;
+  return countDivergences(report) > 0 ? EXIT_DIVERGED : EXIT_PASS;
 }
 
 runAsCli(import.meta.url, async () => runCli(), {

--- a/.agents/scripts/lib/knip-entry-sync.js
+++ b/.agents/scripts/lib/knip-entry-sync.js
@@ -265,8 +265,17 @@ function listTopLevelClis({ repoRoot, fsImpl = fs }) {
  * `entry` array. Glob-bearing patterns are ignored — this reads the explicit
  * enumeration only, which is the surface #5001 made authoritative.
  *
+ * The trailing `!` is knip's production-mode marker and is load-bearing, not
+ * decoration: in a `--production` run knip keeps only the suffixed entries and
+ * *negates* the rest (`WorkspaceWorker`'s `hasProductionSuffix` /
+ * `hasNoProductionSuffix` split). So an entry written without it leaves the CLI
+ * unreachable in exactly the pass that emits whole-file rows — the #5012 shape
+ * this gate exists to catch. Reading it as satisfied would point the operator
+ * away from the cause, so unsuffixed entries are reported as their own
+ * divergence rather than silently normalized.
+ *
  * @param {{ repoRoot: string, fsImpl?: typeof fs }} opts
- * @returns {{ entries: string[], error: string | null }}
+ * @returns {{ entries: string[], unsuffixed: string[], error: string | null }}
  */
 function readKnipEntries({ repoRoot, fsImpl = fs }) {
   const configPath = path.join(repoRoot, 'knip.json');
@@ -274,19 +283,36 @@ function readKnipEntries({ repoRoot, fsImpl = fs }) {
   try {
     parsed = JSON.parse(fsImpl.readFileSync(configPath, 'utf8'));
   } catch (error) {
-    return { entries: [], error: `cannot read knip.json: ${error.message}` };
+    return {
+      entries: [],
+      unsuffixed: [],
+      error: `cannot read knip.json: ${error.message}`,
+    };
   }
   if (!Array.isArray(parsed?.entry)) {
-    return { entries: [], error: 'knip.json has no "entry" array' };
+    return {
+      entries: [],
+      unsuffixed: [],
+      error: 'knip.json has no "entry" array',
+    };
   }
   const prefix = '.agents/scripts/';
-  const entries = parsed.entry
+  const declared = parsed.entry
     .filter((e) => typeof e === 'string' && e.startsWith(prefix))
-    .map((e) => e.replace(/!$/, ''))
     .filter((e) => !e.includes('*'))
-    .map((e) => e.slice(prefix.length))
-    .filter((e) => !e.includes('/'));
-  return { entries: [...new Set(entries)].sort(), error: null };
+    .map((e) => ({
+      cli: e.slice(prefix.length).replace(/!$/, ''),
+      suffixed: e.endsWith('!'),
+    }))
+    .filter((e) => !e.cli.includes('/'));
+
+  const entries = declared.map((e) => e.cli);
+  const unsuffixed = declared.filter((e) => !e.suffixed).map((e) => e.cli);
+  return {
+    entries: [...new Set(entries)].sort(),
+    unsuffixed: [...new Set(unsuffixed)].sort(),
+    error: null,
+  };
 }
 
 /**
@@ -300,14 +326,29 @@ function readKnipEntries({ repoRoot, fsImpl = fs }) {
  *   missing: Array<{ cli: string, invokers: string[] }>,
  *   stale: string[],
  *   phantom: string[],
+ *   unsuffixed: string[],
  * }}
  *   `missing` — invoked but not declared (the #5012 bug).
  *   `stale` — declared but invoked by nothing.
  *   `phantom` — declared but no such file on disk (a rename left the list behind).
+ *   `unsuffixed` — declared without the `!` production marker, which knip's
+ *     production pass negates rather than honours (the #5012 bug wearing a
+ *     declared entry).
  */
 export function resolveEntrySync({ repoRoot, fsImpl = fs }) {
-  const { entries: declared, error } = readKnipEntries({ repoRoot, fsImpl });
-  const empty = { clis: [], declared, missing: [], stale: [], phantom: [] };
+  const {
+    entries: declared,
+    unsuffixed,
+    error,
+  } = readKnipEntries({ repoRoot, fsImpl });
+  const empty = {
+    clis: [],
+    declared,
+    missing: [],
+    stale: [],
+    phantom: [],
+    unsuffixed: [],
+  };
   if (error) return { error, ...empty };
 
   const clis = listTopLevelClis({ repoRoot, fsImpl });
@@ -338,7 +379,24 @@ export function resolveEntrySync({ repoRoot, fsImpl = fs }) {
   const onDisk = new Set(clis);
   const phantom = declared.filter((cli) => !onDisk.has(cli));
 
-  return { error: null, clis, declared, missing, stale, phantom };
+  return { error: null, clis, declared, missing, stale, phantom, unsuffixed };
+}
+
+/**
+ * Total divergences across every direction. Single source of the gate's
+ * pass/fail arithmetic so a newly added direction cannot be counted in the
+ * report but missed by the exit code.
+ *
+ * @param {ReturnType<typeof resolveEntrySync>} report
+ * @returns {number}
+ */
+export function countDivergences(report) {
+  return (
+    report.missing.length +
+    report.stale.length +
+    report.phantom.length +
+    report.unsuffixed.length
+  );
 }
 
 /**
@@ -376,12 +434,21 @@ export function renderEntrySyncReport(report) {
     lines.push(`? ${cli} — declared in knip.json "entry" but not on disk`);
     lines.push('    drop the stale path (the file was renamed or removed).');
   }
-  const total =
-    report.missing.length + report.stale.length + report.phantom.length;
+  for (const cli of report.unsuffixed) {
+    lines.push(`! ${cli} — declared in knip.json "entry" without a "!" suffix`);
+    lines.push(
+      `    write it as ".agents/scripts/${cli}!" — the production pass negates an`,
+    );
+    lines.push(
+      '    unsuffixed entry, so knip still reads the CLI as unreachable.',
+    );
+  }
+  const total = countDivergences(report);
   lines.push(
     `[knip-entries] clis=${report.clis.length} declared=${report.declared.length} ` +
       `missing=${report.missing.length} stale=${report.stale.length} ` +
-      `phantom=${report.phantom.length} ${total > 0 ? '(gate fail)' : '(ok)'}`,
+      `phantom=${report.phantom.length} unsuffixed=${report.unsuffixed.length} ` +
+      `${total > 0 ? '(gate fail)' : '(ok)'}`,
   );
   return lines.join('\n');
 }

--- a/.agents/scripts/lib/orchestration/single-story-close/phases/__tests__/conventional-subject.test.js
+++ b/.agents/scripts/lib/orchestration/single-story-close/phases/__tests__/conventional-subject.test.js
@@ -173,6 +173,38 @@ test('collectBreakingNotes: prose describing a break is not a declaration', () =
   assert.deepEqual(result.notes, []);
 });
 
+test('collectBreakingNotes: a footer quoted inside a code fence is not a declaration', () => {
+  // A Story whose Spec documents this very contract quotes the footer in a
+  // fence. Reading that as a declaration ships a `<type>!:` subject and a
+  // release note for a break nobody made.
+  const result = collectBreakingNotes({
+    storyBody:
+      '## Spec\n\nDeclare the break like this:\n\n```\nBREAKING CHANGE: example only\n```\n\nThat is all.\n',
+  });
+  assert.equal(result.breaking, false);
+  assert.deepEqual(result.notes, []);
+});
+
+test('collectBreakingNotes: a fenced example does not mask a real footer beside it', () => {
+  const result = collectBreakingNotes({
+    commitMessages: [
+      'feat: x\n\n```\nBREAKING CHANGE: example only\n```\n\nBREAKING CHANGE: the flag is gone.\n',
+    ],
+  });
+  assert.equal(result.breaking, true);
+  assert.deepEqual(result.notes, ['the flag is gone.']);
+});
+
+test('collectBreakingNotes: a real footer stops at a fence rather than eating it', () => {
+  const result = collectBreakingNotes({
+    commitMessages: [
+      'feat: x\n\nBREAKING CHANGE: the flag is gone.\n```\nsample\n```\n',
+    ],
+  });
+  assert.equal(result.breaking, true);
+  assert.deepEqual(result.notes, ['the flag is gone.']);
+});
+
 test('collectBreakingNotes: a lowercase footer keyword does not fire', () => {
   // `conventional-commits-parser` matches the uppercase token only; announcing
   // a break release-please will not see would be worse than staying quiet.

--- a/.agents/scripts/lib/orchestration/single-story-close/phases/conventional-subject.js
+++ b/.agents/scripts/lib/orchestration/single-story-close/phases/conventional-subject.js
@@ -120,6 +120,8 @@ const BREAKING_FOOTER_RE = /^BREAKING[ -]CHANGE:[ \t]*(.*)$/;
 
 /** A git-trailer-shaped line (`Some-Token: value`) — ends a footer's text. */
 const TRAILER_RE = /^[A-Za-z][A-Za-z-]*:[ \t]/;
+/** An opening or closing markdown code fence: ``` or ~~~, optionally indented. */
+const FENCE_RE = /^\s{0,3}(`{3,}|~{3,})/;
 
 /**
  * True iff `subject` is a parseable Conventional Commit subject under the
@@ -276,8 +278,32 @@ function readFooterNote(lines, start, head) {
  *   counts. False for the Story body, which has no header.
  * @returns {{ breaking: boolean, notes: string[], subject: string|null }}
  */
+/**
+ * Blank every line inside a markdown code fence, keeping line indices intact.
+ *
+ * A Story `## Spec` that documents this very contract quotes the footer in a
+ * fence; reading that as a declaration ships a `<type>!:` subject and a release
+ * note for a break nobody made. Fenced spans are the only place the anchored
+ * footer regex can fire on non-footer text — an indented block or a blockquote
+ * already fails the `^` anchor. Blanking rather than dropping means a fence
+ * also closes an open footer note, which is what a paragraph break would do.
+ *
+ * @param {string[]} lines
+ * @returns {string[]}
+ */
+function blankFencedLines(lines) {
+  let fence = null;
+  return lines.map((line) => {
+    const marker = line.match(FENCE_RE)?.[1][0];
+    if (!marker) return fence === null ? line : '';
+    if (fence === null) fence = marker;
+    else if (fence === marker) fence = null;
+    return '';
+  });
+}
+
 function scanForBreaking(text, readHeaderBang) {
-  const lines = String(text ?? '').split('\n');
+  const lines = blankFencedLines(String(text ?? '').split('\n'));
   const notes = [];
   let breaking = false;
   let subject = null;

--- a/.agents/scripts/run-verify.js
+++ b/.agents/scripts/run-verify.js
@@ -33,10 +33,12 @@
  * being added here, so a green `verify` still hid both. Like their neighbours
  * they are pure-Node and cost milliseconds.
  *
- * Still NOT mirrored: `check-workflow-citations.js`, `check-baseline-scope.js`
- * and `prune-baseline-orphans.js --check` run in CI's `baselines` job only —
+ * Still NOT mirrored: `check-workflow-citations.js` and
+ * `check-baseline-scope.js` run in CI's `baselines` job only —
  * `.agents/rules/known-tooling-behavior.md` entry 2 carries the current
- * coverage table. Nor are the CI gates this command structurally cannot
+ * coverage table. (`prune-baseline-orphans.js --check` used to sit in that
+ * list; it no longer runs in CI at all — the un-attributed duplicate of the
+ * scope gate's `extra` direction reds every open PR on inherited rows.) Nor are the CI gates this command structurally cannot
  * reproduce (action pinning, TruffleHog secret scan) — those are catalogued
  * in docs/ci-contract.md. The nightly full-scope re-score
  * (.github/workflows/baseline-drift.yml) is deliberately outside this

--- a/.agents/scripts/update-dead-exports-baseline.js
+++ b/.agents/scripts/update-dead-exports-baseline.js
@@ -222,6 +222,7 @@ export function describeUnusableReport(envelope) {
  *   readKnipOutputImpl?: typeof readKnipOutput,
  *   readFileImpl?: typeof fs.readFileSync,
  *   writeFileImpl?: typeof fs.writeFileSync,
+ *   renameImpl?: typeof fs.renameSync,
  *   now?: () => string,
  * }} [opts]
  * @returns {Promise<number>} 0 on a written baseline; 1 on any fail-closed path.
@@ -235,6 +236,7 @@ export async function runCli({
   readKnipOutputImpl = readKnipOutput,
   readFileImpl = fs.readFileSync,
   writeFileImpl = fs.writeFileSync,
+  renameImpl = fs.renameSync,
   now = () => new Date().toISOString(),
 } = {}) {
   const { baselinePath, knipOutputPath, production } = parseArgv(argv);
@@ -273,7 +275,13 @@ export async function runCli({
     rows,
     generatedAt: now(),
   });
-  writeFileImpl(target, `${JSON.stringify(envelope, null, 2)}\n`, 'utf-8');
+  // Write-then-rename, matching `lib/baselines/writer.js`: a crash or a full
+  // disk mid-write must not leave a truncated envelope behind. An unparseable
+  // baseline reads as empty to `check-dead-exports.js`, which would report
+  // every pre-existing row as newly added.
+  const tmpTarget = `${target}.tmp`;
+  writeFileImpl(tmpTarget, `${JSON.stringify(envelope, null, 2)}\n`, 'utf-8');
+  renameImpl(tmpTarget, target);
   stdout.write(
     `[${label}] ✅ wrote ${rows.length} row(s) to ${target} (kernelVersion=${kernelVersion}).\n`,
   );

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -264,17 +264,25 @@ jobs:
         # baseline: the answer is always zero, and a deliberate exception is
         # declared in the schema's own `x-mandrel-uncompiled` block.
         #
-        # Story #5012: the baseline honesty surface joins the slot as two
-        # instruments rather than one. `check-baseline-scope.js` asserts that
-        # each committed baseline's ROW SET still describes the tree — an
-        # in-scope file with no row, a row whose file is gone or has left the
-        # gate's scope — because every gate above can be green while measuring
-        # almost nothing, and nothing checked that. `prune-baseline-orphans.js
-        # --check` is its companion: the gate's hard failure is only defensible
-        # while the remedy is a command rather than a full re-score, and
-        # `--check` keeps `main` honest about there being nothing left to prune.
-        # Both are measurement-free — no scorer, no coverage artifact — so they
-        # cost milliseconds and need no test run to have happened.
+        # Story #5012: the baseline honesty surface. `check-baseline-scope.js`
+        # asserts that each committed baseline's ROW SET still describes the
+        # tree — an in-scope file with no row, a row whose file is gone or has
+        # left the gate's scope — because every gate above can be green while
+        # measuring almost nothing, and nothing checked that. It is
+        # measurement-free — no scorer, no coverage artifact — so it costs
+        # milliseconds and needs no test run to have happened.
+        #
+        # `prune-baseline-orphans.js --check` deliberately does NOT run here.
+        # It reports the same `extra` direction (absent / out-of-scope rows)
+        # that `check-baseline-scope.js` covers, but with no merge-base
+        # attribution: it exits 1 on any stale row whatever landed it. That is
+        # exactly the whole-tree equality the scope gate refuses, and pairing
+        # them made the attribution unreachable — one PR deleting a file while
+        # another re-adds its row via a baseline refresh leaves `main` carrying
+        # a stale row, and every open PR then reds on divergence its author did
+        # not create and cannot fix from their branch. The scope gate already
+        # surfaces that row as an inherited warning; the pruner stays the
+        # operator's remedy for clearing it.
         #
         # `check-knip-entries.js` runs ahead of the dead-exports pair it exists
         # to protect. #5001 made knip's entry list explicit (so an uninvoked CLI
@@ -297,7 +305,6 @@ jobs:
           node .agents/scripts/check-cyclomatic.js
           node .agents/scripts/check-schema-references.js
           node .agents/scripts/check-baseline-scope.js
-          node .agents/scripts/prune-baseline-orphans.js --check
 
   windows-smoke:
     # Story #3389 — advisory Windows leg. Exercises bootstrap, command sync,

--- a/lib/migrations/steps/2.32.0-retire-lint-baseline-command.js
+++ b/lib/migrations/steps/2.32.0-retire-lint-baseline-command.js
@@ -15,6 +15,14 @@
  * upgrade, not a warning. This step strips the key before that check runs —
  * the same contract-cutover pattern as `2.11.0-retire-max-seed-words.js`.
  *
+ * It sweeps **both** config surfaces. `config-resolver.js` deep-merges
+ * `.agentrc.local.json` over `.agentrc.json` and validates the result, so a
+ * key surviving in the operator's overlay fails exactly as a base one would.
+ * Sweeping only the base would report "nothing to migrate" and leave that
+ * consumer hard-broken with no self-service remedy — re-running
+ * `mandrel update` would keep reporting clean — while this commit's
+ * `BREAKING CHANGE:` footer promises the upgrade deletes the key for them.
+ *
  * The `lint` baseline KIND survives for consumers whose own linter writes
  * `baselines/lint.json`; only the framework-owned capture shell is gone, so
  * nothing here touches the baseline file or the gate config.
@@ -29,25 +37,40 @@
 import nodeFs from 'node:fs';
 import path from 'node:path';
 
-const AGENTRC_FILENAME = '.agentrc.json';
+/**
+ * Both config surfaces the resolver reads. `.agentrc.local.json` is deep-merged
+ * over the base *before* the AJV gate runs
+ * (`.agents/scripts/lib/config-resolver.js`), so a `lintBaseline` surviving in
+ * the overlay fails validation exactly as one in the base would — and a step
+ * that swept only the base would leave that consumer hard-broken with no
+ * self-service remedy, since re-running `mandrel update` would keep reporting
+ * clean. The overlay is operator-owned and gitignored, which is why it is easy
+ * to forget and why the sweep has to name it explicitly.
+ */
+const AGENTRC_FILENAMES = Object.freeze([
+  '.agentrc.json',
+  '.agentrc.local.json',
+]);
 
 /**
  * @param {unknown} ctx
+ * @param {string} filename
  * @returns {string}
  */
-function resolveAgentrcPath(ctx) {
+function resolveAgentrcPath(ctx, filename) {
   const projectRoot = ctx?.projectRoot ?? process.cwd();
-  return path.join(projectRoot, AGENTRC_FILENAME);
+  return path.join(projectRoot, filename);
 }
 
 /**
  * @param {unknown} ctx
  * @param {typeof nodeFs} fsImpl
+ * @param {string} filename
  * @returns {object | null}
  */
-function readAgentrcConfig(ctx, fsImpl) {
+function readAgentrcConfig(ctx, fsImpl, filename) {
   try {
-    const raw = fsImpl.readFileSync(resolveAgentrcPath(ctx), 'utf8');
+    const raw = fsImpl.readFileSync(resolveAgentrcPath(ctx, filename), 'utf8');
     return JSON.parse(raw);
   } catch {
     return null;
@@ -74,7 +97,9 @@ export const retireLintBaselineCommand = {
    */
   detect(ctx) {
     const fsImpl = ctx?.fs ?? nodeFs;
-    return hasRetiredKey(readAgentrcConfig(ctx, fsImpl));
+    return AGENTRC_FILENAMES.some((filename) =>
+      hasRetiredKey(readAgentrcConfig(ctx, fsImpl, filename)),
+    );
   },
   /**
    * @param {{ projectRoot?: string, fs?: typeof nodeFs }} [ctx]
@@ -82,21 +107,21 @@ export const retireLintBaselineCommand = {
    */
   apply(ctx) {
     const fsImpl = ctx?.fs ?? nodeFs;
-    const config = readAgentrcConfig(ctx, fsImpl);
-    if (!config) return;
+    for (const filename of AGENTRC_FILENAMES) {
+      const config = readAgentrcConfig(ctx, fsImpl, filename);
+      // An absent overlay is the common case, not an error.
+      if (!config || !hasRetiredKey(config)) continue;
 
-    const commands = config.project?.commands;
-    if (commands && Object.hasOwn(commands, 'lintBaseline')) {
-      delete commands.lintBaseline;
+      delete config.project.commands.lintBaseline;
       // An emptied `commands` block is left in place: unlike
       // `planning.complexityGate`, `project` is a required block and an empty
       // `commands` object is valid against the schema, so pruning it would be
       // a cosmetic edit to a config the consumer owns.
-    }
 
-    fsImpl.writeFileSync(
-      resolveAgentrcPath(ctx),
-      `${JSON.stringify(config, null, 2)}\n`,
-    );
+      fsImpl.writeFileSync(
+        resolveAgentrcPath(ctx, filename),
+        `${JSON.stringify(config, null, 2)}\n`,
+      );
+    }
   },
 };

--- a/tests/check-knip-entries.test.js
+++ b/tests/check-knip-entries.test.js
@@ -5,6 +5,7 @@ import { test } from 'node:test';
 import { runCli } from '../.agents/scripts/check-knip-entries.js';
 import {
   __testing,
+  countDivergences,
   renderEntrySyncReport,
   resolveEntrySync,
 } from '../.agents/scripts/lib/knip-entry-sync.js';
@@ -131,6 +132,36 @@ test('readKnipEntries: reads explicit top-level entries and ignores globs', () =
   const { entries, error } = readKnipEntries({ repoRoot: root });
   assert.equal(error, null);
   assert.deepEqual(entries, ['a.js']);
+});
+
+test('readKnipEntries: reports an entry declared without the `!` production marker', () => {
+  const root = makeFixtureRepo({ clis: ['a.js', 'b.js'] });
+  fs.writeFileSync(
+    path.join(root, 'knip.json'),
+    JSON.stringify({
+      entry: ['.agents/scripts/a.js!', '.agents/scripts/b.js'],
+    }),
+  );
+  const { entries, unsuffixed, error } = readKnipEntries({ repoRoot: root });
+  assert.equal(error, null);
+  // Still declared — the CLI is named — but knip's production pass negates it.
+  assert.deepEqual(entries, ['a.js', 'b.js']);
+  assert.deepEqual(unsuffixed, ['b.js']);
+});
+
+test('resolveEntrySync: an unsuffixed entry is a divergence, not a satisfied one', () => {
+  const root = makeFixtureRepo({ clis: ['a.js'] });
+  fs.writeFileSync(
+    path.join(root, 'knip.json'),
+    JSON.stringify({ entry: ['.agents/scripts/a.js'] }),
+  );
+  const report = resolveEntrySync({ repoRoot: root });
+  assert.deepEqual(report.unsuffixed, ['a.js']);
+  // The gate must fail: reading it as declared points the operator away from
+  // the cause, and accepting the dead-exports diff would then record a live
+  // CLI as expected-dead (Story #5012).
+  assert.ok(countDivergences(report) > 0);
+  assert.match(renderEntrySyncReport(report), /without a "!" suffix/);
 });
 
 test('readKnipEntries: reports an unreadable or entry-less config as an error', () => {

--- a/tests/fixtures/gherkin-corpus/missing-root/.agentrc.json
+++ b/tests/fixtures/gherkin-corpus/missing-root/.agentrc.json
@@ -1,0 +1,15 @@
+{
+  "project": {
+    "paths": { "agentRoot": ".agents", "docsRoot": "docs", "tempRoot": "temp" }
+  },
+  "qa": {
+    "gherkinLint": {
+      "scopes": {
+        "app": {
+          "featureRoots": ["featurez"],
+          "stepRoots": ["steps"]
+        }
+      }
+    }
+  }
+}

--- a/tests/fixtures/gherkin-corpus/missing-root/features/real.feature
+++ b/tests/fixtures/gherkin-corpus/missing-root/features/real.feature
@@ -1,0 +1,6 @@
+Feature: A corpus the config cannot see
+
+  # These live in `features/`, but the scope points at `featurez/`. Nothing
+  # here is checked — the blackout this fixture exists to catch.
+  Scenario: an unbound step nobody checks
+    Given no definition anywhere claims this step

--- a/tests/fixtures/gherkin-corpus/missing-root/steps/steps.js
+++ b/tests/fixtures/gherkin-corpus/missing-root/steps/steps.js
@@ -1,0 +1,3 @@
+import { Given } from '../../registrar.js';
+
+Given('I am signed in', async () => {});

--- a/tests/fixtures/gherkin-corpus/rule-background/.agentrc.json
+++ b/tests/fixtures/gherkin-corpus/rule-background/.agentrc.json
@@ -1,0 +1,15 @@
+{
+  "project": {
+    "paths": { "agentRoot": ".agents", "docsRoot": "docs", "tempRoot": "temp" }
+  },
+  "qa": {
+    "gherkinLint": {
+      "scopes": {
+        "app": {
+          "featureRoots": ["features"],
+          "stepRoots": ["steps"]
+        }
+      }
+    }
+  }
+}

--- a/tests/fixtures/gherkin-corpus/rule-background/features/rule-scoped.feature
+++ b/tests/fixtures/gherkin-corpus/rule-background/features/rule-scoped.feature
@@ -1,0 +1,14 @@
+Feature: Roster under rules
+
+  # Gherkin runs this Background for every scenario in the feature, including
+  # the Rule-nested ones below. This feature has no scenario of its own, so a
+  # walker that only emits a container's Background when that same container
+  # holds scenarios never checks these steps.
+  Background:
+    Given I am signed in
+    And no definition anywhere claims this background step
+
+  Rule: a coach sees their own roster
+
+    Scenario: the roster loads
+      Then I see the roster

--- a/tests/fixtures/gherkin-corpus/rule-background/steps/steps.js
+++ b/tests/fixtures/gherkin-corpus/rule-background/steps/steps.js
@@ -1,0 +1,4 @@
+import { Given, Then } from '../../registrar.js';
+
+Given('I am signed in', async () => {});
+Then('I see the roster', async () => {});

--- a/tests/lib/migrations/retire-lint-baseline-command.test.js
+++ b/tests/lib/migrations/retire-lint-baseline-command.test.js
@@ -1,0 +1,158 @@
+import assert from 'node:assert/strict';
+import path from 'node:path';
+import { describe, it } from 'node:test';
+
+import { retireLintBaselineCommand } from '../../../lib/migrations/steps/2.32.0-retire-lint-baseline-command.js';
+
+/**
+ * The step strips the retired `project.commands.lintBaseline` key on upgrade.
+ *
+ * The case worth pinning is the **overlay**: `.agentrc.local.json` is
+ * deep-merged over the base *before* the AJV gate runs, and `project.commands`
+ * is `additionalProperties: false` — so a key surviving there fails validation
+ * exactly as one in the base would. A step that swept only the base would
+ * report "nothing to migrate" and leave that consumer hard-broken with no
+ * self-service remedy, while the commit's own `BREAKING CHANGE:` footer
+ * promises `npx mandrel update` deletes it for them.
+ *
+ * Every stub is a plain object passed through the step's optional `ctx.fs`
+ * seam (`.agents/rules/test-seams.md` rules 1 and 5) — no module mocking.
+ */
+
+const ROOT = path.join(path.sep, 'repo');
+
+/**
+ * Build an in-memory `node:fs` stub over a `{ '<filename>': <config> }` map,
+ * keyed by basename under a fixed project root.
+ *
+ * @param {Record<string, object>} files
+ */
+function makeFsStub(files) {
+  const disk = new Map(
+    Object.entries(files).map(([name, config]) => [
+      path.join(ROOT, name),
+      `${JSON.stringify(config, null, 2)}\n`,
+    ]),
+  );
+  return {
+    disk,
+    readFileSync(file) {
+      if (!disk.has(file)) throw new Error(`ENOENT: ${file}`);
+      return disk.get(file);
+    },
+    writeFileSync(file, body) {
+      disk.set(file, body);
+    },
+    read(name) {
+      return JSON.parse(disk.get(path.join(ROOT, name)));
+    },
+  };
+}
+
+/** @param {Record<string, object>} files */
+function ctxFor(files) {
+  const fs = makeFsStub(files);
+  return { ctx: { projectRoot: ROOT, fs }, fs };
+}
+
+const WITH_KEY = {
+  project: {
+    commands: { typecheck: 'tsc --noEmit', lintBaseline: 'eslint -f json' },
+  },
+};
+const WITHOUT_KEY = { project: { commands: { typecheck: 'tsc --noEmit' } } };
+
+describe('2.32.0 retire lintBaseline — base config', () => {
+  it('detects and strips the key, leaving its siblings alone', () => {
+    const { ctx, fs } = ctxFor({ '.agentrc.json': WITH_KEY });
+    assert.equal(retireLintBaselineCommand.detect(ctx), true);
+
+    retireLintBaselineCommand.apply(ctx);
+
+    assert.deepEqual(fs.read('.agentrc.json'), WITHOUT_KEY);
+    assert.equal(retireLintBaselineCommand.detect(ctx), false);
+  });
+
+  it('is a no-op for a consumer that never set the key', () => {
+    const { ctx, fs } = ctxFor({ '.agentrc.json': WITHOUT_KEY });
+    assert.equal(retireLintBaselineCommand.detect(ctx), false);
+
+    retireLintBaselineCommand.apply(ctx);
+
+    // Not merely equal — untouched. Rewriting a config the consumer owns to
+    // change nothing would show up as a spurious diff on their next commit.
+    assert.equal(
+      fs.disk.get(path.join(ROOT, '.agentrc.json')).includes('lintBaseline'),
+      false,
+    );
+    assert.deepEqual(fs.read('.agentrc.json'), WITHOUT_KEY);
+  });
+
+  it('survives an absent or unparsable config without throwing', () => {
+    const { ctx } = ctxFor({});
+    assert.equal(retireLintBaselineCommand.detect(ctx), false);
+    assert.doesNotThrow(() => retireLintBaselineCommand.apply(ctx));
+  });
+});
+
+describe('2.32.0 retire lintBaseline — local overlay', () => {
+  it('detects the key when only the overlay carries it', () => {
+    const { ctx } = ctxFor({
+      '.agentrc.json': WITHOUT_KEY,
+      '.agentrc.local.json': WITH_KEY,
+    });
+    // The whole point: the resolver validates the MERGED config, so an overlay
+    // key is as fatal as a base one and the step must see it.
+    assert.equal(retireLintBaselineCommand.detect(ctx), true);
+  });
+
+  it('strips the key from the overlay', () => {
+    const { ctx, fs } = ctxFor({
+      '.agentrc.json': WITHOUT_KEY,
+      '.agentrc.local.json': WITH_KEY,
+    });
+
+    retireLintBaselineCommand.apply(ctx);
+
+    assert.deepEqual(fs.read('.agentrc.local.json'), WITHOUT_KEY);
+    assert.equal(retireLintBaselineCommand.detect(ctx), false);
+  });
+
+  it('strips the key from both surfaces in one pass', () => {
+    const { ctx, fs } = ctxFor({
+      '.agentrc.json': WITH_KEY,
+      '.agentrc.local.json': WITH_KEY,
+    });
+
+    retireLintBaselineCommand.apply(ctx);
+
+    assert.deepEqual(fs.read('.agentrc.json'), WITHOUT_KEY);
+    assert.deepEqual(fs.read('.agentrc.local.json'), WITHOUT_KEY);
+    assert.equal(retireLintBaselineCommand.detect(ctx), false);
+  });
+
+  it('leaves an untouched base config alone when only the overlay is dirty', () => {
+    const { ctx, fs } = ctxFor({
+      '.agentrc.json': WITHOUT_KEY,
+      '.agentrc.local.json': WITH_KEY,
+    });
+    const baseBefore = fs.disk.get(path.join(ROOT, '.agentrc.json'));
+
+    retireLintBaselineCommand.apply(ctx);
+
+    assert.equal(fs.disk.get(path.join(ROOT, '.agentrc.json')), baseBefore);
+  });
+
+  it('is idempotent — a second apply changes nothing', () => {
+    const { ctx, fs } = ctxFor({
+      '.agentrc.json': WITH_KEY,
+      '.agentrc.local.json': WITH_KEY,
+    });
+
+    retireLintBaselineCommand.apply(ctx);
+    const after = new Map(fs.disk);
+    retireLintBaselineCommand.apply(ctx);
+
+    assert.deepEqual([...fs.disk.entries()], [...after.entries()]);
+  });
+});

--- a/tests/scripts/check-gherkin-corpus.test.js
+++ b/tests/scripts/check-gherkin-corpus.test.js
@@ -149,7 +149,34 @@ describe('opt-in', () => {
   });
 });
 
+describe('background inheritance', () => {
+  it('checks a feature Background whose only scenarios live under a Rule', async () => {
+    const { code, stderr } = await run('rule-background');
+    assert.equal(code, 1);
+    assert.match(stderr, /no definition anywhere claims this background step/);
+  });
+
+  it('reports an inherited background step once, not once per container', async () => {
+    const { stderr } = await run('rule-background');
+    const hits = stderr.match(/claims this background step/g) ?? [];
+    assert.equal(hits.length, 1, `duplicated findings:\n${stderr}`);
+  });
+});
+
 describe('fail-closed inside the opt-in', () => {
+  it('refuses a scope whose featureRoots do not exist, naming them', async () => {
+    const { code, stderr } = await run('missing-root');
+    assert.equal(code, 1);
+    assert.match(stderr, /scope "app" names featureRoots that do not exist/);
+    assert.match(stderr, /featurez/);
+    // It must not report the friendly "nothing to check" line: the corpus is
+    // real, the config just cannot see it.
+    assert.ok(
+      !/nothing to check/.test(stderr),
+      `reported a clean run over an unchecked corpus:\n${stderr}`,
+    );
+  });
+
   it('refuses a scope that resolves zero step definitions, naming its step roots', async () => {
     const { code, stderr } = await run('blackout');
     assert.equal(code, 1);

--- a/tests/scripts/run-verify.test.js
+++ b/tests/scripts/run-verify.test.js
@@ -93,10 +93,12 @@ const CI_RATCHETS_NOT_MIRRORED_LOCALLY = new Map([
     'check-baseline-scope.js',
     'Row-set honesty gate — meaningful only against a fully-scored tree; reachable as `npm run baselines:scope`.',
   ],
-  [
-    'prune-baseline-orphans.js',
-    'Companion remedy to check-baseline-scope; reachable as `npm run baselines:prune -- --check`.',
-  ],
+  // `prune-baseline-orphans.js` left this map in v2.32.0 along with the CI step
+  // it exempted: `--check` has no merge-base attribution, so holding it in the
+  // required job cancelled `check-baseline-scope.js`'s inherited-divergence
+  // warning. It is an operator remedy now (`npm run baselines:prune`), and this
+  // assertion is bidirectional — a stale exemption fails as loudly as a missing
+  // one.
 ]);
 
 test('every ratchet CI’s `baselines` job runs is mirrored locally or exempted', () => {

--- a/tests/update-dead-exports-baseline.test.js
+++ b/tests/update-dead-exports-baseline.test.js
@@ -262,6 +262,38 @@ test('runCli: the default pass writes the envelope the checker reads', async () 
   assert.deepEqual(fs.readFileSync(productionBaseline), productionBefore);
 });
 
+test('runCli: writes through a temp file and renames, never in place', async () => {
+  const { cwd, defaultBaseline, reportPath } = makeRepo();
+  const writes = [];
+  const renames = [];
+
+  const { code } = await run({
+    argv: ['--knip-output', path.relative(cwd, reportPath)],
+    cwd,
+    writeFileImpl: (target, body, enc) => {
+      writes.push(target);
+      fs.writeFileSync(target, body, enc);
+    },
+    renameImpl: (from, to) => {
+      renames.push([from, to]);
+      fs.renameSync(from, to);
+    },
+  });
+
+  assert.equal(code, 0);
+  // A crash between the write and the rename must leave the committed
+  // baseline untouched: an unparseable one reads as empty to
+  // check-dead-exports.js, which then reports every existing row as added.
+  assert.deepEqual(writes, [`${defaultBaseline}.tmp`]);
+  assert.deepEqual(renames, [[`${defaultBaseline}.tmp`, defaultBaseline]]);
+  assert.equal(fs.existsSync(`${defaultBaseline}.tmp`), false);
+  assert.deepEqual(JSON.parse(fs.readFileSync(defaultBaseline, 'utf-8')).rows, [
+    { file: 'lib/a.js', symbol: '*' },
+    { file: 'lib/b.js', symbol: 'alpha' },
+    { file: 'lib/b.js', symbol: 'beta' },
+  ]);
+});
+
 test('runCli: the production pass self-labels and leaves its sibling alone', async () => {
   const { cwd, defaultBaseline, productionBaseline, reportPath } = makeRepo();
   const defaultBefore = fs.readFileSync(defaultBaseline);


### PR DESCRIPTION
## Why

Pre-release code review of `mandrel-v2.31.0..main` (20 commits, +21.6k/−38.5k
across 472 files) surfaced **six verified defects, every one in code this
release introduces**. None are pre-existing debt. This PR closes all six
before v2.32.0 is cut.

Each fix ships with a test that was confirmed to **fail against the unfixed
source** and pass with it.

## The findings

### 1. The 2.32.0 migration step could not heal a `lintBaseline` in `.agentrc.local.json`

The one on the upgrade path, and the reason this PR should land before the
release. `config-resolver.js` deep-merges `.agentrc.local.json` over
`.agentrc.json` and runs the AJV gate on the **merged** result, and
`project.commands` is `additionalProperties: false`. The step swept only the
base file, so a consumer carrying the retired key in their operator overlay
would run `npx mandrel update`, be told there was nothing to migrate, and then
hard-fail validation on the next script invocation — with re-running update
never fixing it. The commit's own `BREAKING CHANGE:` footer promises the
upgrade deletes the key for them.

It now sweeps both surfaces, writing only the files that actually carry the
key. New test file covers base, overlay, both, absent-config, and idempotency.

### 2. The gherkin gate never checked a `Background:` under `Rule:` blocks

`collectActiveSteps` emitted a container's backgrounds only when that same
container held active scenarios, and rule recursion did not inherit them.
Gherkin runs a feature-level Background for **every** scenario in the feature,
Rule-nested ones included — so a feature organising its scenarios under Rules
shipped an unbound Background step green, and died at bddgen/run time. That is
precisely the invisible corpus failure the gate exists to catch.

Backgrounds now descend into rules, keyed on step line so an inherited step is
checked once rather than once per inheriting container.

### 3. The knip entry-sync gate greenlit the misconfiguration it was built to catch

`readKnipEntries` stripped the trailing `!` as if it were decoration. In knip's
production pass the suffix is load-bearing and its absence is *worse* than a
no-op: `WorkspaceWorker` keeps the suffixed entries and **negates** the rest.
So an unsuffixed entry read as "declared, fine" while
`check-dead-exports --production` still saw the CLI as unreachable and emitted
the whole-file row — the #5012 shape, with the gate now pointing *away* from
the cause and making "accept the ratchet diff" look right again.

Unsuffixed entries are now their own divergence with their own remedy line.
`countDivergences` centralises the pass/fail arithmetic so a future direction
cannot be reported but missed by the exit code. Verified `unsuffixed=0` on this
repo — the gate stays green here.

### 4. `prune-baseline-orphans.js --check` left CI entirely

It reports the same absent / out-of-scope rows as `check-baseline-scope.js`,
but with **no merge-base attribution** — it exits 1 on any stale row regardless
of who landed it. Pairing them in the required job made the scope gate's
attribution machinery unreachable for that direction: PR-A deletes a file
(pruning its row), PR-B branched earlier refreshes the baseline re-adding it,
both independently green, B lands after A → `main` carries a stale row, and
every open PR now reds on divergence its author did not create and cannot fix
from their branch. That is exactly the whole-tree equality the scope gate
refuses.

The scope gate already surfaces the row as an inherited warning. The pruner
stays the operator's remedy via `npm run baselines:prune`. Docs, the
`known-tooling-behavior.md` coverage table, and the `run-verify.js` mirror
comment updated to match; the bidirectional CI-mirror test correctly demanded
its exemption be dropped.

### 5. The breaking-change scanner false-fired on fenced code

`scanForBreaking` matched `BREAKING CHANGE:` on every line with no markdown
awareness, contradicting its own docstring. A Story `## Spec` that documents
the footer syntax in a code fence — plausible here, where Stories routinely
discuss the release pipeline — shipped a spurious `<type>!:` squash subject and
a garbage footer that swallowed the closing fence, announcing a consumer break
that never happened.

Fenced spans are now blanked before the scan (which also closes an open footer
note at a fence, the way a paragraph break would). A real footer sitting beside
a fenced example still fires.

### 6. The dead-exports baseline was written non-atomically

`update-dead-exports-baseline.js` wrote straight to the final path — the one
baseline write in this release without the tmp+rename every sibling producer
uses. A crash or full disk mid-write truncates it, and an unparseable baseline
reads as **empty** to `check-dead-exports.js`. Now write-then-rename, with the
temp path and rename asserted through injected seams.

## Verification

All green on the final commit:

| gate | result |
| --- | --- |
| `npm run lint` | pass |
| `npm test` | pass |
| `check-baselines.js` | pass |
| `check-baseline-scope.js` | pass |
| `check-knip-entries.js` | pass (`unsuffixed=0`) |
| `check-dead-exports.js` (both passes) | pass |
| `quality:preview --staged` | 0 MI regressions, 0 CRAP violations |

Each of the six fixes was additionally verified by reverting the source and
confirming the new tests fail.

Two files initially tripped the pre-commit MI gate; resolved by extracting
`blankFencedLines` and `findMissingFeatureRoots` / `pushBackgroundSteps`
helpers — deduplication and idiom, not comment trimming.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect required CI gates, consumer upgrade migration, and release-breaking detection at story close—high impact areas—but each fix is narrow with regression tests and CI behavior is intentionally relaxed for the pruner only.
> 
> **Overview**
> Pre-release hardening across **config migration**, **lint gates**, **CI**, and **story close** so v2.32.0 behavior matches documented contracts.
> 
> The **2.32.0 `lintBaseline` migration** now strips `project.commands.lintBaseline` from both `.agentrc.json` and `.agentrc.local.json`, matching merged validation so upgrades do not report clean while the overlay still fails AJV.
> 
> **Gherkin corpus gate** fixes **Background** steps when scenarios live only under **Rule** blocks (inheritance + dedupe by line), and **fails closed** when configured `featureRoots` paths do not exist instead of exiting green with nothing checked.
> 
> **Knip entry sync** treats `knip.json` entries **without a trailing `!`** as a separate divergence (production pass negates them); **`countDivergences`** centralizes pass/fail so new directions cannot be reported but ignored.
> 
> **CI** drops **`prune-baseline-orphans.js --check`** from the required `baselines` job so it no longer duplicates **`check-baseline-scope.js`** without merge-base attribution and blocks inherited stale rows on unrelated PRs; docs and **`run-verify`** comments align, and the CI-mirror test removes the pruner exemption.
> 
> **Squash close** **`collectBreakingNotes`** blanks markdown **code fences** before scanning so fenced `BREAKING CHANGE:` examples in Story specs are not real declarations; real footers beside fences still count.
> 
> **Dead-exports baseline update** uses **write-then-rename** like other baseline writers to avoid truncated JSON that the checker would read as an empty baseline.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 84d81585196d842d3179f4862ce3053bdf9b1e25. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->