### PR TITLE
fix: check-knip-entries: resolve the entry list through knip's own config resolver, and skip cleanly when there is no knip config (#5039)

### DIFF
--- a/.agents/runtime-deps.json
+++ b/.agents/runtime-deps.json
@@ -12,6 +12,7 @@
     "@commitlint/load": "^21.0.0",
     "chokidar": "^5.0.0",
     "jscpd": "^4.0.0",
+    "knip": "^6.17.1",
     "typescript": ">=5.0.0"
   }
 }

--- a/.agents/scripts/README.md
+++ b/.agents/scripts/README.md
@@ -13,6 +13,15 @@ GitHub Actions surfaces first. `check-knip-entries.js` derives that
 caller set mechanically, so a CLI no invoker names is dead, not
 operator-only.
 
+It reads the entry list from whatever configuration knip itself would
+load — `knip.json`, `knip.jsonc`, `.knip.json(c)`, `knip.ts`, `knip.js`,
+`knip.config.ts`, `knip.config.js`, or `package.json#knip` — evaluating
+TS/JS modules rather than parsing them, and counting entries declared
+per-workspace as well as at the top level. A project with no knip
+configuration at all exits 0 with a skip line, so the gate is safe to
+wire everywhere; a configuration that exists but cannot be resolved
+still exits 2.
+
 ## See Also
 
 - [`/.agents/README.md`](../README.md) — consumer user guide.

--- a/.agents/scripts/check-knip-entries.js
+++ b/.agents/scripts/check-knip-entries.js
@@ -19,19 +19,29 @@
 // This gate removes the luck. It derives the invoked set from the executable
 // surfaces #5001's own acceptance criterion named — package.json scripts, husky
 // hooks, `.github/workflows`, `.agents` workflow/skill/agent/rule markdown, and
-// script-to-script spawns — and asserts it matches `knip.json`'s entry array in
-// both directions. See `lib/knip-entry-sync.js` for why liveness means
-// *invoked* rather than *present*, and why documentation prose does not count.
+// script-to-script spawns — and asserts it matches the entry array of whatever
+// configuration knip itself would load, in both directions. See
+// `lib/knip-entry-sync.js` for why liveness means *invoked* rather than
+// *present*, and why documentation prose does not count.
 //
-// Measurement-free by construction: no knip spawn, no scorer, no coverage
-// artifact. It is a directory read and a handful of regexes, which is what
-// makes it cheap enough to sit in the required-check set next to
-// `check-baseline-scope.js`.
+// Analysis-free by construction: knip's config resolver is loaded (a
+// `knip.config.ts` has to be evaluated, not parsed), but nothing is scanned —
+// no knip run, no scorer, no coverage artifact. Past that it is a directory
+// read and a handful of regexes, which is what keeps it cheap enough to sit in
+// the required-check set next to `check-baseline-scope.js`.
+//
+// Not-applicable is not failure (Story #5039). A repository with no knip
+// configuration at all — and one where `knip` is not installed — exits 0 with a
+// skip line, the same opt-in posture `qa.gherkinLint` uses. Without that, the
+// gate could not be wired into a consumer that does not run knip, and #5001's
+// guard stayed unbuilt everywhere it was most needed. A configuration that
+// EXISTS but cannot be resolved still exits 2: absence and breakage are
+// different answers.
 //
 // Exit codes:
-//   0  entry list matches the invoked set
-//   1  divergence — a missing, stale, or phantom entry
-//   2  the check could not run (unreadable knip.json, unusable repository)
+//   0  entry list matches the invoked set, or there is no configuration to check
+//   1  divergence — a missing, stale, phantom, or unsuffixed entry
+//   2  the check could not run (unresolvable configuration, unusable repository)
 
 import process from 'node:process';
 import { runAsCli } from './lib/cli-utils.js';
@@ -49,16 +59,34 @@ const HELP = {
   invocation:
     'node .agents/scripts/check-knip-entries.js [--cwd <dir>] [--json]',
   summary:
-    "Assert knip.json's explicit .agents/scripts entry list matches the set of CLIs something actually invokes.",
+    "Assert the explicit .agents/scripts entry list in knip's resolved configuration matches the set of CLIs something actually invokes.",
   flags: [
     ['--cwd <dir>', 'Repository root to check. Default: process.cwd().'],
     ['--json', 'Emit the report as JSON instead of text.'],
   ],
   notes: [
-    'Exit codes:\n  0  entry list matches\n  1  divergence\n  2  the check could not run',
+    'Resolves the config through knip itself, so every location knip supports works\n(knip.json/.jsonc, .knip.json(c), knip.ts/.js, knip.config.ts/.js,\npackage.json#knip). A TS config is evaluated, so a computed entry array reads\ncorrectly, and per-workspace entries count alongside the top-level array.',
+    'Exit codes:\n  0  entry list matches, or there is no config to check (skip)\n  1  divergence\n  2  the check could not run — a config that EXISTS but will not resolve',
     'A missing entry is the dangerous one: knip calls the CLI dead, and accepting\nthe dead-exports diff would record a live CLI as expected-dead (Story #5012).',
   ],
 };
+
+/**
+ * The gate's single exit-code decision, shared by the text and `--json` paths.
+ *
+ * Kept in one place for the same reason `countDivergences` is: a direction
+ * added to the report must not be able to change one path's verdict and not
+ * the other's. Skip outranks error outranks divergence — a repository with no
+ * configuration has nothing to diverge from.
+ *
+ * @param {Awaited<ReturnType<typeof resolveEntrySync>>} report
+ * @returns {number}
+ */
+function exitCodeFor(report) {
+  if (report.skipped) return EXIT_PASS;
+  if (report.error) return EXIT_CANNOT_RUN;
+  return countDivergences(report) > 0 ? EXIT_DIVERGED : EXIT_PASS;
+}
 
 /**
  * Parse argv into an options bag. An unknown flag is a config error rather than
@@ -107,25 +135,20 @@ export async function runCli({
     stderr.write(`[knip-entries] ❌ ${err?.message ?? String(err)}\n`);
     return EXIT_CANNOT_RUN;
   }
-  const repoRoot = args.cwd ?? cwd;
-  const report = resolveEntrySync({ repoRoot });
+  const report = await resolveEntrySync({ repoRoot: args.cwd ?? cwd });
 
   if (args.json) {
     stdout.write(
       `${JSON.stringify({ kind: 'knip-entry-sync', ...report }, null, 2)}\n`,
     );
-    if (report.error) return EXIT_CANNOT_RUN;
-    return countDivergences(report) > 0 ? EXIT_DIVERGED : EXIT_PASS;
-  }
-
-  if (report.error) {
+  } else if (report.skipped) {
+    stdout.write(`[knip-entries] ⏭️  not applicable: ${report.skipped}\n`);
+  } else if (report.error) {
     stderr.write(`[knip-entries] ❌ ${report.error}\n`);
-    return EXIT_CANNOT_RUN;
+  } else {
+    stdout.write(`\n--- knip-entries ---\n${renderEntrySyncReport(report)}\n`);
   }
-
-  stdout.write(`\n--- knip-entries ---\n`);
-  stdout.write(`${renderEntrySyncReport(report)}\n`);
-  return countDivergences(report) > 0 ? EXIT_DIVERGED : EXIT_PASS;
+  return exitCodeFor(report);
 }
 
 runAsCli(import.meta.url, async () => runCli(), {

--- a/.agents/scripts/lib/knip-config-resolver.js
+++ b/.agents/scripts/lib/knip-config-resolver.js
@@ -1,0 +1,181 @@
+/**
+ * knip-config-resolver.js — resolve a repository's knip configuration the way
+ * knip itself would, and hand back its declared entry patterns.
+ *
+ * Split out of `knip-entry-sync.js` (Story #5039) because these are two
+ * concerns that change for different reasons: *what knip's config says* tracks
+ * knip's own releases, while *which CLIs something invokes* tracks this
+ * repository's callers. Keeping them in one file also pushed that module's
+ * maintainability index below its floor.
+ *
+ * Why not read the file ourselves: #5026 hardcoded
+ * `JSON.parse(<root>/knip.json)`, so all seven of knip's other config
+ * locations plus `package.json#knip` resolved to ENOENT and failed the gate
+ * closed. That made it unusable in exactly the repositories that adopt the
+ * shared `knip.base.json` — knip 6 has no root-level `extends`, so inheriting
+ * the base means spreading it inside a TypeScript module, which a static
+ * `knip.json` structurally cannot express.
+ *
+ * Going through `createOptions` also drops the assumption that `entry` is
+ * *statically declared*. A config may build the array programmatically, so
+ * even a purpose-built `knip.config.ts` parser would read the wrong thing;
+ * knip evaluates the module and returns the computed value.
+ */
+
+/**
+ * Load knip's own config resolver.
+ *
+ * Deliberately a dynamic import behind an injectable seam. `knip` is declared
+ * in `runtime-deps.json` as an **optional** dependency, mirroring `typescript`:
+ * the `.agents/` payload is materialized into consumers that may not run knip
+ * at all, so an unresolvable `knip` must degrade to the skip path rather than
+ * crash the gate at module load — and must never be preflight-blocked.
+ *
+ * @returns {Promise<{ createOptions?: Function }>}
+ */
+function importKnipSession() {
+  return import('knip/session');
+}
+
+/**
+ * Collect every declared entry pattern from a resolved knip configuration.
+ *
+ * Entries live in two places and #5026 read only the first. A pnpm-workspace
+ * config — the shape that made this gate unusable in `Beestera/swarm-os` —
+ * declares them per workspace, so a config with no top-level `entry` at all is
+ * still fully enumerated. A named workspace's patterns are workspace-relative
+ * and are joined to the workspace name; the root workspace (`.`) is already
+ * repo-relative. A leading `!` is knip's *negation* marker (as opposed to the
+ * trailing production marker) and stays at the front of the pattern rather
+ * than getting buried behind the workspace prefix.
+ *
+ * `sawEntryArray` separates "declared nothing under `.agents/scripts/`" — a
+ * legitimate result, reported as `missing` divergences — from "this config
+ * enumerates no entry points anywhere", which leaves the gate nothing to
+ * compare against.
+ *
+ * @param {object} parsedConfig knip's schema-parsed configuration
+ * @returns {{ patterns: string[], sawEntryArray: boolean }}
+ */
+function collectEntryPatterns(parsedConfig) {
+  const patterns = [];
+  let sawEntryArray = false;
+
+  const push = (value, prefix) => {
+    if (typeof value !== 'string') return;
+    if (!prefix) patterns.push(value);
+    else if (value.startsWith('!'))
+      patterns.push(`!${prefix}${value.slice(1)}`);
+    else patterns.push(`${prefix}${value}`);
+  };
+
+  const addAll = (entry, prefix) => {
+    if (!Array.isArray(entry)) return;
+    sawEntryArray = true;
+    for (const value of entry) push(value, prefix);
+  };
+
+  addAll(parsedConfig?.entry, '');
+
+  const workspaces = parsedConfig?.workspaces;
+  if (workspaces && typeof workspaces === 'object') {
+    for (const [name, workspace] of Object.entries(workspaces)) {
+      const trimmed = name.replace(/^\.\/+/, '').replace(/\/+$/, '');
+      const prefix = trimmed === '' || trimmed === '.' ? '' : `${trimmed}/`;
+      addAll(workspace?.entry, prefix);
+    }
+  }
+
+  return { patterns, sawEntryArray };
+}
+
+/**
+ * Resolve the entry patterns knip would see for `repoRoot`.
+ *
+ * Three outcomes, deliberately distinct — collapsing the first two is how a
+ * broken configuration would come to look like an absent one:
+ *
+ *   skipped — nothing to check (no config file, no `package.json#knip`, or no
+ *     resolvable `knip`). The gate exits 0. This is what makes it safe to wire
+ *     into every consumer, matching `qa.gherkinLint`'s opt-in posture.
+ *   error — a configuration exists but could not be resolved, or enumerates no
+ *     entry points at all. The gate exits 2.
+ *   resolved — `patterns` carries every declared entry, top-level and
+ *     per-workspace, with knip's trailing `!` production markers intact.
+ *
+ * @param {{ repoRoot: string, loadKnipSession?: () => Promise<object> }} opts
+ * @returns {Promise<{
+ *   patterns: string[],
+ *   configFilePath: string | null,
+ *   skipped: string | null,
+ *   error: string | null,
+ * }>}
+ */
+export async function resolveKnipEntryPatterns({
+  repoRoot,
+  loadKnipSession = importKnipSession,
+}) {
+  const nothing = { patterns: [], configFilePath: null };
+
+  let createOptions;
+  try {
+    ({ createOptions } = await loadKnipSession());
+  } catch (error) {
+    return {
+      ...nothing,
+      skipped: `the "knip" package is not resolvable from ${repoRoot} (${error.message})`,
+      error: null,
+    };
+  }
+  if (typeof createOptions !== 'function') {
+    return {
+      ...nothing,
+      skipped: null,
+      error:
+        'the installed "knip" does not export createOptions from "knip/session" — this gate needs knip 6 or newer',
+    };
+  }
+
+  let options;
+  try {
+    options = await createOptions({ cwd: repoRoot, args: {} });
+  } catch (error) {
+    return {
+      ...nothing,
+      skipped: null,
+      error: `cannot resolve the knip configuration: ${error.message}`,
+    };
+  }
+
+  const configFilePath = options?.configFilePath ?? null;
+  if (!configFilePath) {
+    return {
+      ...nothing,
+      skipped: `no knip configuration found under ${repoRoot} (no config file, no package.json#knip)`,
+      error: null,
+    };
+  }
+
+  const { patterns, sawEntryArray } = collectEntryPatterns(
+    options?.parsedConfig,
+  );
+  if (!sawEntryArray) {
+    return {
+      patterns: [],
+      configFilePath,
+      skipped: null,
+      error: `${configFilePath} declares no "entry" array, at the top level or in any workspace`,
+    };
+  }
+
+  return { patterns, configFilePath, skipped: null, error: null };
+}
+
+/**
+ * Test-only seam. Not API — `collectEntryPatterns` is exercised directly so the
+ * workspace-prefix and negation rules can be pinned without a fixture tree.
+ */
+export const __testing = Object.freeze({
+  collectEntryPatterns,
+  importKnipSession,
+});

--- a/.agents/scripts/lib/knip-entry-sync.js
+++ b/.agents/scripts/lib/knip-entry-sync.js
@@ -1,6 +1,8 @@
 /**
  * knip-entry-sync.js — derive which top-level `.agents/scripts/*.js` CLIs are
- * actually invoked, and diff that set against `knip.json`'s `entry` array.
+ * actually invoked, and diff that set against the `entry` array of whatever
+ * configuration knip itself would load (Story #5039; #5026 could only read a
+ * literal `knip.json`).
  *
  * Why this exists (Story #5001 → the #5012 near-miss):
  *
@@ -20,7 +22,7 @@
  * real death later. It was caught only because a base-sync conflict forced a
  * manual read of the diff.
  *
- * The fix is to stop depending on a human remembering to edit `knip.json`.
+ * The fix is to stop depending on a human remembering to edit the config.
  * #5001's own wording already names the derivation rule — entries are derived
  * "from what package.json scripts, husky hooks, .github/workflows, and the
  * .agents workflow/skill markdown actually invoke". This module mechanizes
@@ -53,6 +55,10 @@
 
 import fs from 'node:fs';
 import path from 'node:path';
+import {
+  resolveKnipEntryPatterns,
+  __testing as resolverTesting,
+} from './knip-config-resolver.js';
 
 // Only `resolveEntrySync` and `renderEntrySyncReport` are public — they are
 // what `check-knip-entries.js` calls. Everything else is module-private and
@@ -261,9 +267,13 @@ function listTopLevelClis({ repoRoot, fsImpl = fs }) {
 }
 
 /**
- * Read the top-level `.agents/scripts/*.js` basenames declared in `knip.json`'s
- * `entry` array. Glob-bearing patterns are ignored — this reads the explicit
- * enumeration only, which is the surface #5001 made authoritative.
+ * Read the `.agents/scripts/*.js` basenames declared as knip entry points.
+ *
+ * Resolution goes through knip's own loader — see
+ * `knip-config-resolver.js` for why, and for the skipped / error / resolved
+ * contract this forwards. All this adds is the projection onto top-level CLI
+ * basenames: glob-bearing patterns are dropped, so what remains is the explicit
+ * enumeration #5001 made authoritative.
  *
  * The trailing `!` is knip's production-mode marker and is load-bearing, not
  * decoration: in a `--production` run knip keeps only the suffixed entries and
@@ -272,45 +282,41 @@ function listTopLevelClis({ repoRoot, fsImpl = fs }) {
  * unreachable in exactly the pass that emits whole-file rows — the #5012 shape
  * this gate exists to catch. Reading it as satisfied would point the operator
  * away from the cause, so unsuffixed entries are reported as their own
- * divergence rather than silently normalized.
+ * divergence rather than silently normalized. `createOptions` preserves the
+ * suffix, so the marker survives resolution.
  *
- * @param {{ repoRoot: string, fsImpl?: typeof fs }} opts
- * @returns {{ entries: string[], unsuffixed: string[], error: string | null }}
+ * @param {{ repoRoot: string, loadKnipSession?: () => Promise<object> }} opts
+ * @returns {Promise<{
+ *   entries: string[],
+ *   unsuffixed: string[],
+ *   configFilePath: string | null,
+ *   skipped: string | null,
+ *   error: string | null,
+ * }>}
  */
-function readKnipEntries({ repoRoot, fsImpl = fs }) {
-  const configPath = path.join(repoRoot, 'knip.json');
-  let parsed;
-  try {
-    parsed = JSON.parse(fsImpl.readFileSync(configPath, 'utf8'));
-  } catch (error) {
-    return {
-      entries: [],
-      unsuffixed: [],
-      error: `cannot read knip.json: ${error.message}`,
-    };
+async function readKnipEntries({ repoRoot, loadKnipSession }) {
+  const { patterns, configFilePath, skipped, error } =
+    await resolveKnipEntryPatterns({ repoRoot, loadKnipSession });
+  if (skipped || error) {
+    return { entries: [], unsuffixed: [], configFilePath, skipped, error };
   }
-  if (!Array.isArray(parsed?.entry)) {
-    return {
-      entries: [],
-      unsuffixed: [],
-      error: 'knip.json has no "entry" array',
-    };
-  }
+
   const prefix = '.agents/scripts/';
-  const declared = parsed.entry
-    .filter((e) => typeof e === 'string' && e.startsWith(prefix))
-    .filter((e) => !e.includes('*'))
+  const declared = patterns
+    .filter((e) => e.startsWith(prefix) && !e.includes('*'))
     .map((e) => ({
       cli: e.slice(prefix.length).replace(/!$/, ''),
       suffixed: e.endsWith('!'),
     }))
     .filter((e) => !e.cli.includes('/'));
 
-  const entries = declared.map((e) => e.cli);
-  const unsuffixed = declared.filter((e) => !e.suffixed).map((e) => e.cli);
   return {
-    entries: [...new Set(entries)].sort(),
-    unsuffixed: [...new Set(unsuffixed)].sort(),
+    entries: [...new Set(declared.map((e) => e.cli))].sort(),
+    unsuffixed: [
+      ...new Set(declared.filter((e) => !e.suffixed).map((e) => e.cli)),
+    ].sort(),
+    configFilePath,
+    skipped: null,
     error: null,
   };
 }
@@ -318,16 +324,27 @@ function readKnipEntries({ repoRoot, fsImpl = fs }) {
 /**
  * Resolve the full entry-sync report for a repository.
  *
- * @param {{ repoRoot: string, fsImpl?: typeof fs }} opts
- * @returns {{
+ * Async because knip's config loader is: a `knip.config.ts` has to be
+ * *evaluated*, not read. `EntrySync` names entry-list synchronization, not
+ * synchronous I/O, so the name still describes what this returns.
+ *
+ * @param {{
+ *   repoRoot: string,
+ *   fsImpl?: typeof fs,
+ *   loadKnipSession?: () => Promise<object>,
+ * }} opts
+ * @returns {Promise<{
  *   error: string | null,
+ *   skipped: string | null,
+ *   configFilePath: string | null,
  *   clis: string[],
  *   declared: string[],
  *   missing: Array<{ cli: string, invokers: string[] }>,
  *   stale: string[],
  *   phantom: string[],
  *   unsuffixed: string[],
- * }}
+ * }>}
+ *   `skipped` — nothing to check; the caller passes rather than failing.
  *   `missing` — invoked but not declared (the #5012 bug).
  *   `stale` — declared but invoked by nothing.
  *   `phantom` — declared but no such file on disk (a rename left the list behind).
@@ -335,13 +352,21 @@ function readKnipEntries({ repoRoot, fsImpl = fs }) {
  *     production pass negates rather than honours (the #5012 bug wearing a
  *     declared entry).
  */
-export function resolveEntrySync({ repoRoot, fsImpl = fs }) {
+export async function resolveEntrySync({
+  repoRoot,
+  fsImpl = fs,
+  loadKnipSession,
+}) {
   const {
     entries: declared,
     unsuffixed,
+    configFilePath,
+    skipped,
     error,
-  } = readKnipEntries({ repoRoot, fsImpl });
+  } = await readKnipEntries({ repoRoot, loadKnipSession });
   const empty = {
+    skipped: null,
+    configFilePath,
     clis: [],
     declared,
     missing: [],
@@ -349,6 +374,7 @@ export function resolveEntrySync({ repoRoot, fsImpl = fs }) {
     phantom: [],
     unsuffixed: [],
   };
+  if (skipped) return { error: null, ...empty, skipped };
   if (error) return { error, ...empty };
 
   const clis = listTopLevelClis({ repoRoot, fsImpl });
@@ -379,7 +405,17 @@ export function resolveEntrySync({ repoRoot, fsImpl = fs }) {
   const onDisk = new Set(clis);
   const phantom = declared.filter((cli) => !onDisk.has(cli));
 
-  return { error: null, clis, declared, missing, stale, phantom, unsuffixed };
+  return {
+    error: null,
+    skipped: null,
+    configFilePath,
+    clis,
+    declared,
+    missing,
+    stale,
+    phantom,
+    unsuffixed,
+  };
 }
 
 /**
@@ -460,6 +496,9 @@ export function renderEntrySyncReport(report) {
  */
 export const __testing = Object.freeze({
   buildInvocationPatterns,
+  // Re-exported from `knip-config-resolver.js` so the suite reaches the whole
+  // gate through one seam rather than importing two modules to test one gate.
+  collectEntryPatterns: resolverTesting.collectEntryPatterns,
   collectInvocationSurfaces,
   INVOCATION_SURFACES,
   listTopLevelClis,

--- a/baselines/coverage.json
+++ b/baselines/coverage.json
@@ -1,12 +1,12 @@
 {
   "$schema": ".agents/schemas/baselines/coverage.schema.json",
   "kernelVersion": "1.0.0",
-  "generatedAt": "2026-08-06T11:50:06.682Z",
+  "generatedAt": "2026-08-07T11:55:32.344Z",
   "rollup": {
     "*": {
       "lines": 95.9,
-      "branches": 86.58,
-      "functions": 88.78
+      "branches": 86.62,
+      "functions": 88.81
     }
   },
   "rows": [
@@ -115,8 +115,8 @@
     {
       "path": ".agents/scripts/check-knip-entries.js",
       "lines": 100,
-      "branches": 80.95,
-      "functions": 66.67
+      "branches": 92.59,
+      "functions": 75
     },
     {
       "path": ".agents/scripts/check-lifecycle-lint.js",
@@ -1481,9 +1481,15 @@
       "functions": 100
     },
     {
+      "path": ".agents/scripts/lib/knip-config-resolver.js",
+      "lines": 100,
+      "branches": 97.14,
+      "functions": 100
+    },
+    {
       "path": ".agents/scripts/lib/knip-entry-sync.js",
-      "lines": 97.77,
-      "branches": 90.59,
+      "lines": 98.23,
+      "branches": 91.11,
       "functions": 100
     },
     {

--- a/baselines/crap.json
+++ b/baselines/crap.json
@@ -1,7 +1,7 @@
 {
   "$schema": ".agents/schemas/baselines/crap.schema.json",
   "kernelVersion": "0.1.0",
-  "generatedAt": "2026-08-06T11:50:10.268Z",
+  "generatedAt": "2026-08-07T11:55:32.944Z",
   "scoringSemantics": "method-identity-v3",
   "tsTranspilerVersion": "6.0.3",
   "provenanceStamped": true,
@@ -834,6 +834,31 @@
       "method": "main",
       "startLine": 528,
       "crap": 6
+    },
+    {
+      "path": ".agents/scripts/check-knip-entries.js",
+      "method": "exitCodeFor",
+      "startLine": 85,
+      "crap": 4
+    },
+    {
+      "path": ".agents/scripts/check-knip-entries.js",
+      "method": "parseArgs",
+      "startLine": 98,
+      "crap": 4
+    },
+    {
+      "path": ".agents/scripts/check-knip-entries.js",
+      "method": "runCli",
+      "startLine": 125,
+      "crap": 4
+    },
+    {
+      "path": ".agents/scripts/check-knip-entries.js",
+      "method": "<anon ()#0>",
+      "startLine": 154,
+      "crap": 1,
+      "anonymous": true
     },
     {
       "path": ".agents/scripts/check-lifecycle-lint.js",
@@ -10230,136 +10255,181 @@
       "crap": 14
     },
     {
+      "path": ".agents/scripts/lib/knip-config-resolver.js",
+      "method": "importKnipSession",
+      "startLine": 36,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/knip-config-resolver.js",
+      "method": "collectEntryPatterns",
+      "startLine": 60,
+      "crap": 5
+    },
+    {
+      "path": ".agents/scripts/lib/knip-config-resolver.js",
+      "method": "<anon collectEntryPatterns/(value,prefix)#0>",
+      "startLine": 64,
+      "crap": 4,
+      "anonymous": true
+    },
+    {
+      "path": ".agents/scripts/lib/knip-config-resolver.js",
+      "method": "<anon collectEntryPatterns/(entry,prefix)#0>",
+      "startLine": 72,
+      "crap": 2,
+      "anonymous": true
+    },
+    {
+      "path": ".agents/scripts/lib/knip-config-resolver.js",
+      "method": "resolveKnipEntryPatterns",
+      "startLine": 114,
+      "crap": 4
+    },
+    {
       "path": ".agents/scripts/lib/knip-entry-sync.js",
       "method": "stripJsComments",
-      "startLine": 102,
+      "startLine": 108,
       "crap": 12
     },
     {
       "path": ".agents/scripts/lib/knip-entry-sync.js",
       "method": "<anon stripJsComments/(s)#0>",
-      "startLine": 106,
+      "startLine": 112,
       "crap": 1,
       "anonymous": true
     },
     {
       "path": ".agents/scripts/lib/knip-entry-sync.js",
       "method": "walk",
-      "startLine": 151,
+      "startLine": 157,
       "crap": 4
     },
     {
       "path": ".agents/scripts/lib/knip-entry-sync.js",
       "method": "collectInvocationSurfaces",
-      "startLine": 181,
+      "startLine": 187,
       "crap": 4.004296599644188
     },
     {
       "path": ".agents/scripts/lib/knip-entry-sync.js",
       "method": "<anon collectInvocationSurfaces/(absolute)#0>",
-      "startLine": 183,
+      "startLine": 189,
       "crap": 4.0466472303206995,
       "anonymous": true
     },
     {
       "path": ".agents/scripts/lib/knip-entry-sync.js",
       "method": "buildInvocationPatterns",
-      "startLine": 232,
+      "startLine": 238,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/knip-entry-sync.js",
       "method": "listTopLevelClis",
-      "startLine": 248,
+      "startLine": 254,
       "crap": 1.0029154518950438
     },
     {
       "path": ".agents/scripts/lib/knip-entry-sync.js",
       "method": "<anon listTopLevelClis/(e)#0>",
-      "startLine": 258,
+      "startLine": 264,
       "crap": 2.011661807580175,
       "anonymous": true
     },
     {
       "path": ".agents/scripts/lib/knip-entry-sync.js",
       "method": "<anon listTopLevelClis/(e)#1>",
-      "startLine": 259,
+      "startLine": 265,
       "crap": 1.0029154518950438,
       "anonymous": true
     },
     {
       "path": ".agents/scripts/lib/knip-entry-sync.js",
       "method": "readKnipEntries",
-      "startLine": 271,
-      "crap": 2
+      "startLine": 297,
+      "crap": 3
     },
     {
       "path": ".agents/scripts/lib/knip-entry-sync.js",
       "method": "<anon readKnipEntries/(e)#0>",
-      "startLine": 284,
+      "startLine": 306,
       "crap": 2,
       "anonymous": true
     },
     {
       "path": ".agents/scripts/lib/knip-entry-sync.js",
       "method": "<anon readKnipEntries/(e)#1>",
-      "startLine": 285,
+      "startLine": 307,
       "crap": 1,
       "anonymous": true
     },
     {
       "path": ".agents/scripts/lib/knip-entry-sync.js",
       "method": "<anon readKnipEntries/(e)#2>",
-      "startLine": 286,
+      "startLine": 311,
       "crap": 1,
       "anonymous": true
     },
     {
       "path": ".agents/scripts/lib/knip-entry-sync.js",
       "method": "<anon readKnipEntries/(e)#3>",
-      "startLine": 287,
+      "startLine": 314,
+      "crap": 1,
+      "anonymous": true
+    },
+    {
+      "path": ".agents/scripts/lib/knip-entry-sync.js",
+      "method": "<anon readKnipEntries/(e)#4/(e)#0>",
+      "startLine": 316,
       "crap": 1,
       "anonymous": true
     },
     {
       "path": ".agents/scripts/lib/knip-entry-sync.js",
       "method": "<anon readKnipEntries/(e)#4>",
-      "startLine": 288,
+      "startLine": 316,
       "crap": 1,
       "anonymous": true
     },
     {
       "path": ".agents/scripts/lib/knip-entry-sync.js",
       "method": "resolveEntrySync",
-      "startLine": 308,
-      "crap": 7.009142857142857
+      "startLine": 355,
+      "crap": 8.00186436049158
     },
     {
       "path": ".agents/scripts/lib/knip-entry-sync.js",
       "method": "<anon resolveEntrySync/(s)#0>",
-      "startLine": 327,
-      "crap": 4.002985422740525,
+      "startLine": 394,
+      "crap": 4.000466090122895,
       "anonymous": true
     },
     {
       "path": ".agents/scripts/lib/knip-entry-sync.js",
       "method": "<anon resolveEntrySync/(s)#1>",
-      "startLine": 332,
-      "crap": 1.0001865889212829,
+      "startLine": 399,
+      "crap": 1.000029130632681,
       "anonymous": true
     },
     {
       "path": ".agents/scripts/lib/knip-entry-sync.js",
       "method": "<anon resolveEntrySync/(cli)#0>",
-      "startLine": 339,
-      "crap": 1.0001865889212829,
+      "startLine": 406,
+      "crap": 1.000029130632681,
       "anonymous": true
     },
     {
       "path": ".agents/scripts/lib/knip-entry-sync.js",
+      "method": "countDivergences",
+      "startLine": 429,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/knip-entry-sync.js",
       "method": "renderEntrySyncReport",
-      "startLine": 352,
-      "crap": 3.0052083333333335
+      "startLine": 446,
+      "crap": 3.002666666666667
     },
     {
       "path": ".agents/scripts/lib/label-constants.js",

--- a/baselines/maintainability.json
+++ b/baselines/maintainability.json
@@ -1,11 +1,11 @@
 {
   "$schema": ".agents/schemas/baselines/maintainability.schema.json",
   "kernelVersion": "0.1.0",
-  "generatedAt": "2026-08-06T11:50:07.753Z",
+  "generatedAt": "2026-08-07T11:55:39.057Z",
   "rollup": {
     "*": {
       "min": 76.381,
-      "p50": 98.358,
+      "p50": 98.588,
       "p95": 122.913
     }
   },
@@ -84,7 +84,7 @@
     },
     {
       "path": ".agents/scripts/check-knip-entries.js",
-      "mi": 92.67
+      "mi": 95.873
     },
     {
       "path": ".agents/scripts/check-lifecycle-lint.js",
@@ -192,7 +192,7 @@
     },
     {
       "path": ".agents/scripts/lib/audit-baselines/kinds.js",
-      "mi": 97.921
+      "mi": 98.578
     },
     {
       "path": ".agents/scripts/lib/audit-baselines/outliers.js",
@@ -332,7 +332,7 @@
     },
     {
       "path": ".agents/scripts/lib/baselines/diff-scope-cli.js",
-      "mi": 101.053
+      "mi": 106.344
     },
     {
       "path": ".agents/scripts/lib/baselines/drift-detector.js",
@@ -340,7 +340,7 @@
     },
     {
       "path": ".agents/scripts/lib/baselines/duplication-scanner.js",
-      "mi": 90.847
+      "mi": 92.1
     },
     {
       "path": ".agents/scripts/lib/baselines/env-overrides.js",
@@ -432,7 +432,7 @@
     },
     {
       "path": ".agents/scripts/lib/baselines/reader.js",
-      "mi": 93.895
+      "mi": 95.043
     },
     {
       "path": ".agents/scripts/lib/baselines/refresh-service.js",
@@ -660,7 +660,7 @@
     },
     {
       "path": ".agents/scripts/lib/config/commands.js",
-      "mi": 110.571
+      "mi": 113.626
     },
     {
       "path": ".agents/scripts/lib/config/defaults.js",
@@ -961,6 +961,10 @@
     {
       "path": ".agents/scripts/lib/json-utils.js",
       "mi": 95.486
+    },
+    {
+      "path": ".agents/scripts/lib/knip-config-resolver.js",
+      "mi": 93.327
     },
     {
       "path": ".agents/scripts/lib/knip-entry-sync.js",
@@ -1268,11 +1272,11 @@
     },
     {
       "path": ".agents/scripts/lib/orchestration/plan-persist/run-plan-persist.js",
-      "mi": 90.533
+      "mi": 94.385
     },
     {
       "path": ".agents/scripts/lib/orchestration/plan-persist/story-ops.js",
-      "mi": 94.219
+      "mi": 95.716
     },
     {
       "path": ".agents/scripts/lib/orchestration/plan-persist/summary.js",
@@ -1280,7 +1284,7 @@
     },
     {
       "path": ".agents/scripts/lib/orchestration/plan-persist/supersede-ops.js",
-      "mi": 97.905
+      "mi": 99.598
     },
     {
       "path": ".agents/scripts/lib/orchestration/plan-reachability.js",
@@ -1428,7 +1432,7 @@
     },
     {
       "path": ".agents/scripts/lib/orchestration/single-story-close/phases/conventional-subject.js",
-      "mi": 91.925
+      "mi": 92.982
     },
     {
       "path": ".agents/scripts/lib/orchestration/single-story-close/phases/normalize-pr-title.js",
@@ -1516,7 +1520,7 @@
     },
     {
       "path": ".agents/scripts/lib/orchestration/story-follow-ups.js",
-      "mi": 95.541
+      "mi": 98.792
     },
     {
       "path": ".agents/scripts/lib/orchestration/story-init-remote.js",
@@ -1796,15 +1800,15 @@
     },
     {
       "path": ".agents/scripts/lib/workers/crap-worker.js",
-      "mi": 87
+      "mi": 88.469
     },
     {
       "path": ".agents/scripts/lib/workers/maintainability-report-worker.js",
-      "mi": 94.191
+      "mi": 96.195
     },
     {
       "path": ".agents/scripts/lib/workers/maintainability-worker.js",
-      "mi": 96.776
+      "mi": 99.91
     },
     {
       "path": ".agents/scripts/lib/workers/serve-worker-messages.js",
@@ -2004,7 +2008,7 @@
     },
     {
       "path": ".agents/scripts/providers/github/tickets.js",
-      "mi": 94.98
+      "mi": 96.306
     },
     {
       "path": ".agents/scripts/provision-git-hooks.js",
@@ -2068,7 +2072,7 @@
     },
     {
       "path": ".agents/scripts/stories-wave-tick.js",
-      "mi": 89.91
+      "mi": 91.958
     },
     {
       "path": ".agents/scripts/sync-agentrc.js",
@@ -2104,7 +2108,7 @@
     },
     {
       "path": ".agents/scripts/update-duplication-baseline.js",
-      "mi": 97.514
+      "mi": 106.025
     },
     {
       "path": ".agents/scripts/update-maintainability-baseline.js",
@@ -2200,7 +2204,7 @@
     },
     {
       "path": "lib/migrations/steps/2.32.0-retire-lint-baseline-command.js",
-      "mi": 103.921
+      "mi": 105.909
     }
   ]
 }

--- a/tests/check-knip-entries.test.js
+++ b/tests/check-knip-entries.test.js
@@ -29,6 +29,7 @@ import { makeTempDir } from '../.agents/scripts/lib/test-temp.js';
 
 const {
   buildInvocationPatterns,
+  collectEntryPatterns,
   collectInvocationSurfaces,
   readKnipEntries,
   stripJsComments,
@@ -115,7 +116,7 @@ test('buildInvocationPatterns: joinedSpawn requires the "scripts" sibling argume
   assert.ok(!joinedSpawn.test(`const NAMES = ['bar.js', 'foo.js'];`));
 });
 
-test('readKnipEntries: reads explicit top-level entries and ignores globs', () => {
+test('readKnipEntries: reads explicit top-level entries and ignores globs', async () => {
   const root = makeFixtureRepo({ clis: ['a.js'] });
   fs.writeFileSync(
     path.join(root, 'knip.json'),
@@ -129,12 +130,12 @@ test('readKnipEntries: reads explicit top-level entries and ignores globs', () =
       ],
     }),
   );
-  const { entries, error } = readKnipEntries({ repoRoot: root });
+  const { entries, error } = await readKnipEntries({ repoRoot: root });
   assert.equal(error, null);
   assert.deepEqual(entries, ['a.js']);
 });
 
-test('readKnipEntries: reports an entry declared without the `!` production marker', () => {
+test('readKnipEntries: reports an entry declared without the `!` production marker', async () => {
   const root = makeFixtureRepo({ clis: ['a.js', 'b.js'] });
   fs.writeFileSync(
     path.join(root, 'knip.json'),
@@ -142,20 +143,22 @@ test('readKnipEntries: reports an entry declared without the `!` production mark
       entry: ['.agents/scripts/a.js!', '.agents/scripts/b.js'],
     }),
   );
-  const { entries, unsuffixed, error } = readKnipEntries({ repoRoot: root });
+  const { entries, unsuffixed, error } = await readKnipEntries({
+    repoRoot: root,
+  });
   assert.equal(error, null);
   // Still declared — the CLI is named — but knip's production pass negates it.
   assert.deepEqual(entries, ['a.js', 'b.js']);
   assert.deepEqual(unsuffixed, ['b.js']);
 });
 
-test('resolveEntrySync: an unsuffixed entry is a divergence, not a satisfied one', () => {
+test('resolveEntrySync: an unsuffixed entry is a divergence, not a satisfied one', async () => {
   const root = makeFixtureRepo({ clis: ['a.js'] });
   fs.writeFileSync(
     path.join(root, 'knip.json'),
     JSON.stringify({ entry: ['.agents/scripts/a.js'] }),
   );
-  const report = resolveEntrySync({ repoRoot: root });
+  const report = await resolveEntrySync({ repoRoot: root });
   assert.deepEqual(report.unsuffixed, ['a.js']);
   // The gate must fail: reading it as declared points the operator away from
   // the cause, and accepting the dead-exports diff would then record a live
@@ -164,19 +167,27 @@ test('resolveEntrySync: an unsuffixed entry is a divergence, not a satisfied one
   assert.match(renderEntrySyncReport(report), /without a "!" suffix/);
 });
 
-test('readKnipEntries: reports an unreadable or entry-less config as an error', () => {
+test('readKnipEntries: an unusable repository and an entry-less config are errors, not skips', async () => {
+  // No package.json at all: knip's resolver cannot even start. A broken
+  // repository is not an opt-out, so it must not take the skip path.
   const root = makeTempDir('knip-entry-bad-');
-  assert.match(
-    readKnipEntries({ repoRoot: root }).error,
-    /cannot read knip\.json/,
-  );
+  const unusable = await readKnipEntries({ repoRoot: root });
+  assert.equal(unusable.skipped, null);
+  assert.match(unusable.error, /cannot resolve the knip configuration/);
+
+  // A config that resolves but enumerates no entry points anywhere leaves the
+  // gate nothing to compare against. Reporting every CLI as `missing` would be
+  // a lie, so this is an error too.
+  fs.writeFileSync(path.join(root, 'package.json'), JSON.stringify({}));
   fs.writeFileSync(path.join(root, 'knip.json'), JSON.stringify({}));
-  assert.match(readKnipEntries({ repoRoot: root }).error, /no "entry" array/);
+  const entryless = await readKnipEntries({ repoRoot: root });
+  assert.equal(entryless.skipped, null);
+  assert.match(entryless.error, /declares no "entry" array/);
 });
 
 // --- the regression the gate exists for -------------------------------------
 
-test('REGRESSION: a newly-added, invoked CLI absent from knip entry is reported missing', () => {
+test('REGRESSION: a newly-added, invoked CLI absent from knip entry is reported missing', async () => {
   // Exactly the Story #5012 shape: the CLI is real, wired into package.json and
   // CI, and simply not yet listed in knip.json. Without this gate knip calls it
   // unreachable and check-dead-exports offers a whole-file dead row for it.
@@ -195,7 +206,7 @@ test('REGRESSION: a newly-added, invoked CLI absent from knip entry is reported 
     },
   });
 
-  const report = resolveEntrySync({ repoRoot: root });
+  const report = await resolveEntrySync({ repoRoot: root });
   assert.equal(report.error, null);
   assert.deepEqual(
     report.missing.map((m) => m.cli),
@@ -223,39 +234,39 @@ test('REGRESSION: a newly-added, invoked CLI absent from knip entry is reported 
       entry: ['.agents/scripts/existing.js!', '.agents/scripts/brand-new.js!'],
     }),
   );
-  const after = resolveEntrySync({ repoRoot: root });
+  const after = await resolveEntrySync({ repoRoot: root });
   assert.deepEqual(after.missing, []);
   assert.deepEqual(after.stale, []);
   assert.deepEqual(after.phantom, []);
   assert.match(renderEntrySyncReport(after), /\(ok\)/);
 });
 
-test('a CLI declared in entry that nothing invokes is reported stale', () => {
+test('a CLI declared in entry that nothing invokes is reported stale', async () => {
   // The blind spot #5001 closed: a declared entry point is immortal, so its
   // death can never surface. An entry outliving its last caller restores it.
   const root = makeFixtureRepo({
     clis: ['live.js', 'orphaned.js'],
     packageJson: { scripts: { live: 'node .agents/scripts/live.js' } },
   });
-  const report = resolveEntrySync({ repoRoot: root });
+  const report = await resolveEntrySync({ repoRoot: root });
   assert.deepEqual(report.stale, ['orphaned.js']);
   assert.deepEqual(report.missing, []);
   assert.match(renderEntrySyncReport(report), /nothing invokes it/);
 });
 
-test('an entry whose file is gone is reported phantom', () => {
+test('an entry whose file is gone is reported phantom', async () => {
   const root = makeFixtureRepo({
     clis: ['live.js'],
     entry: ['live.js', 'renamed-away.js'],
     packageJson: { scripts: { live: 'node .agents/scripts/live.js' } },
   });
-  const report = resolveEntrySync({ repoRoot: root });
+  const report = await resolveEntrySync({ repoRoot: root });
   assert.deepEqual(report.phantom, ['renamed-away.js']);
 });
 
 // --- what does and does not confer liveness ---------------------------------
 
-test('documentation prose does not make an uninvoked CLI live', () => {
+test('documentation prose does not make an uninvoked CLI live', async () => {
   // Four CLIs are named only in docs today; #5001 recorded all four as
   // whole-file dead on purpose. Counting prose would silently resurrect them.
   const root = makeFixtureRepo({
@@ -268,12 +279,12 @@ test('documentation prose does not make an uninvoked CLI live', () => {
         'The operator-run replacement is `node .agents/scripts/operator-tool.js`.\n',
     },
   });
-  const report = resolveEntrySync({ repoRoot: root });
+  const report = await resolveEntrySync({ repoRoot: root });
   assert.deepEqual(report.missing, [], 'prose is not a caller');
   assert.deepEqual(report.stale, []);
 });
 
-test('a comment naming a CLI does not make it live, but a real spawn does', () => {
+test('a comment naming a CLI does not make it live, but a real spawn does', async () => {
   const root = makeFixtureRepo({
     clis: ['mentioned.js', 'spawned.js'],
     entry: ['spawned.js'],
@@ -287,7 +298,7 @@ test('a comment naming a CLI does not make it live, but a real spawn does', () =
       ].join('\n'),
     },
   });
-  const report = resolveEntrySync({ repoRoot: root });
+  const report = await resolveEntrySync({ repoRoot: root });
   assert.deepEqual(
     report.missing,
     [],
@@ -296,7 +307,7 @@ test('a comment naming a CLI does not make it live, but a real spawn does', () =
   assert.deepEqual(report.stale, [], 'a path.join spawn must confer liveness');
 });
 
-test('a CLI reachable only by import is neither missing nor stale', () => {
+test('a CLI reachable only by import is neither missing nor stale', async () => {
   // `cleanup-repo-test-temp.js` is imported by run-tests.js, so knip already
   // reaches it through the module graph; declaring it an entry would be wrong.
   const root = makeFixtureRepo({
@@ -308,12 +319,12 @@ test('a CLI reachable only by import is neither missing nor stale', () => {
     path.join(root, '.agents', 'scripts', 'runner.js'),
     "import { help } from './helper.js';\nhelp();\n",
   );
-  const report = resolveEntrySync({ repoRoot: root });
+  const report = await resolveEntrySync({ repoRoot: root });
   assert.deepEqual(report.missing, []);
   assert.deepEqual(report.stale, []);
 });
 
-test('collectInvocationSurfaces: excludes test files from the invoked set', () => {
+test('collectInvocationSurfaces: excludes test files from the invoked set', async () => {
   const root = makeFixtureRepo({
     clis: ['only-tested.js'],
     entry: [],
@@ -324,7 +335,7 @@ test('collectInvocationSurfaces: excludes test files from the invoked set', () =
   });
   const surfaces = collectInvocationSurfaces({ repoRoot: root });
   assert.ok(!surfaces.some((s) => s.path.includes('__tests__')));
-  assert.deepEqual(resolveEntrySync({ repoRoot: root }).missing, []);
+  assert.deepEqual((await resolveEntrySync({ repoRoot: root })).missing, []);
 });
 
 // --- CLI exit codes ---------------------------------------------------------
@@ -396,10 +407,256 @@ test('runCli: --json emits the machine-readable report', async () => {
   );
 });
 
+// --- config resolution (Story #5039) ----------------------------------------
+
+/**
+ * Rewrite a fixture's configuration into one of knip's other supported
+ * locations, removing the `knip.json` `makeFixtureRepo` seeds by default.
+ *
+ * @param {string} root fixture repo root
+ * @param {string} name config filename, or `package.json` for the manifest key
+ * @param {object|string} body parsed object, or verbatim source for a TS/JS module
+ */
+function relocateConfig(root, name, body) {
+  const entry = JSON.parse(
+    fs.readFileSync(path.join(root, 'knip.json'), 'utf8'),
+  );
+  fs.rmSync(path.join(root, 'knip.json'));
+  if (name === 'package.json') {
+    const manifest = JSON.parse(
+      fs.readFileSync(path.join(root, 'package.json'), 'utf8'),
+    );
+    manifest.knip = body ?? entry;
+    fs.writeFileSync(path.join(root, 'package.json'), JSON.stringify(manifest));
+    return;
+  }
+  fs.writeFileSync(
+    path.join(root, name),
+    typeof body === 'string' ? body : JSON.stringify(body ?? entry),
+  );
+}
+
+for (const [name, body] of [
+  ['knip.jsonc', null],
+  ['.knip.json', null],
+  ['package.json', null],
+  [
+    'knip.config.ts',
+    // A type annotation and a computed array: proof the module is EVALUATED,
+    // not parsed. A purpose-built parser would see neither the mapped suffix
+    // nor the interpolated prefix.
+    [
+      "const clis: string[] = ['a.js'];",
+      'export default {',
+      '  entry: clis.map((cli: string) => `.agents/scripts/${cli}!`),',
+      '};',
+      '',
+    ].join('\n'),
+  ],
+  [
+    'knip.ts',
+    // Function-form config — knip unwraps it via `loadResolvedConfigFile`.
+    [
+      'export default () => ({',
+      "  entry: ['.agents/scripts/a.js!'],",
+      '});',
+      '',
+    ].join('\n'),
+  ],
+]) {
+  test(`resolves an entry list declared in ${name}`, async () => {
+    const root = makeFixtureRepo({
+      clis: ['a.js'],
+      packageJson: { scripts: { a: 'node .agents/scripts/a.js' } },
+    });
+    relocateConfig(root, name, body);
+
+    const report = await resolveEntrySync({ repoRoot: root });
+    assert.equal(report.error, null, `${name} must resolve`);
+    assert.equal(report.skipped, null, `${name} exists — this is not a skip`);
+    assert.deepEqual(report.declared, ['a.js']);
+    assert.deepEqual(report.missing, []);
+    assert.deepEqual(report.stale, []);
+    assert.deepEqual(report.unsuffixed, []);
+  });
+}
+
+test('a knip.config.ts that spreads an imported base resolves to the COMPUTED entry array', async () => {
+  // The `Beestera/swarm-os` shape verbatim: knip 6 has no root-level `extends`,
+  // so a consumer inheriting the shared `knip.base.json` must spread it inside a
+  // TS module. #5026 read the file as JSON and saw an ENOENT; a hand-written TS
+  // parser would see a spread it cannot evaluate. Only knip's own loader gets
+  // the final array — which is why this gate goes through `createOptions`.
+  const root = makeFixtureRepo({
+    clis: ['from-base.js', 'from-local.js'],
+    packageJson: {
+      scripts: {
+        base: 'node .agents/scripts/from-base.js',
+        local: 'node .agents/scripts/from-local.js',
+      },
+    },
+  });
+  fs.writeFileSync(
+    path.join(root, 'knip.base.json'),
+    JSON.stringify({ entry: ['.agents/scripts/from-base.js!'] }),
+  );
+  relocateConfig(
+    root,
+    'knip.config.ts',
+    [
+      "import base from './knip.base.json';",
+      'const config = {',
+      '  ...base,',
+      "  entry: [...base.entry, '.agents/scripts/from-local.js!'],",
+      '};',
+      'export default config;',
+      '',
+    ].join('\n'),
+  );
+
+  const report = await resolveEntrySync({ repoRoot: root });
+  assert.equal(report.error, null);
+  assert.deepEqual(report.declared, ['from-base.js', 'from-local.js']);
+  assert.deepEqual(report.missing, [], 'the inherited entry must count');
+  assert.deepEqual(report.stale, []);
+});
+
+test('entries declared under a workspace count alongside the top-level entry array', async () => {
+  // A pnpm-workspace config puts entries under `workspaces`, so #5026 read an
+  // empty declared set even when the config was plain JSON — every CLI would
+  // have been reported missing.
+  const root = makeFixtureRepo({
+    clis: ['top.js', 'root-ws.js'],
+    packageJson: {
+      scripts: {
+        top: 'node .agents/scripts/top.js',
+        ws: 'node .agents/scripts/root-ws.js',
+      },
+    },
+  });
+  relocateConfig(root, 'knip.jsonc', {
+    entry: ['.agents/scripts/top.js!'],
+    workspaces: {
+      '.': { entry: ['.agents/scripts/root-ws.js!'] },
+      'packages/app': { entry: ['src/index.ts!'] },
+    },
+  });
+
+  const report = await resolveEntrySync({ repoRoot: root });
+  assert.equal(report.error, null);
+  assert.deepEqual(report.declared, ['root-ws.js', 'top.js']);
+  assert.deepEqual(report.missing, []);
+  assert.deepEqual(report.stale, []);
+});
+
+test('collectEntryPatterns: joins named-workspace patterns, leaves the root workspace alone, keeps negation leading', () => {
+  const { patterns, sawEntryArray } = collectEntryPatterns({
+    entry: ['top.js!'],
+    workspaces: {
+      '.': { entry: ['.agents/scripts/root.js!'] },
+      './also-root': { entry: ['rel.js!'] },
+      'packages/app/': { entry: ['src/index.ts!', '!src/ignored.ts'] },
+      'packages/no-entry': { ignore: ['**/*.d.ts'] },
+    },
+  });
+  assert.equal(sawEntryArray, true);
+  assert.deepEqual(patterns.sort(), [
+    '!packages/app/src/ignored.ts',
+    '.agents/scripts/root.js!',
+    'also-root/rel.js!',
+    'packages/app/src/index.ts!',
+    'top.js!',
+  ]);
+  // A config with no entry array anywhere is distinguishable from one that
+  // simply declares nothing under .agents/scripts/.
+  assert.equal(collectEntryPatterns({ workspaces: {} }).sawEntryArray, false);
+  assert.equal(collectEntryPatterns(undefined).sawEntryArray, false);
+});
+
+test('no knip configuration at all is a clean skip, not a failure', async () => {
+  // The whole point of Story #5039's opt-in posture: until this, wiring the
+  // gate into a consumer that does not run knip red the build, and leaving it
+  // unwired left #5001's guard unbuilt. Neither was the intended outcome.
+  const root = makeFixtureRepo({
+    clis: ['a.js'],
+    packageJson: { scripts: { a: 'node .agents/scripts/a.js' } },
+  });
+  fs.rmSync(path.join(root, 'knip.json'));
+
+  const report = await resolveEntrySync({ repoRoot: root });
+  assert.equal(report.error, null);
+  assert.match(report.skipped, /no knip configuration found/);
+  assert.equal(countDivergences(report), 0);
+
+  const stdout = {
+    out: '',
+    write(s) {
+      this.out += s;
+    },
+  };
+  assert.equal(
+    await runCli({ argv: ['--cwd', root], stdout, stderr: { write() {} } }),
+    0,
+  );
+  assert.match(stdout.out, /not applicable/);
+});
+
+test('an unresolvable knip package is a clean skip; an incompatible one is not', async () => {
+  const root = makeFixtureRepo({
+    clis: ['a.js'],
+    packageJson: { scripts: { a: 'node .agents/scripts/a.js' } },
+  });
+
+  const absent = await resolveEntrySync({
+    repoRoot: root,
+    loadKnipSession: () => {
+      throw new Error("Cannot find package 'knip'");
+    },
+  });
+  assert.equal(absent.error, null);
+  assert.match(absent.skipped, /not resolvable/);
+
+  // Present but too old to export the resolver: that is a real breakage and
+  // must not be swallowed as "nothing to check".
+  const incompatible = await resolveEntrySync({
+    repoRoot: root,
+    loadKnipSession: async () => ({}),
+  });
+  assert.equal(incompatible.skipped, null);
+  assert.match(incompatible.error, /does not export createOptions/);
+});
+
+test('a configuration that exists but throws on load exits 2, never 0', async () => {
+  const root = makeFixtureRepo({
+    clis: ['a.js'],
+    packageJson: { scripts: { a: 'node .agents/scripts/a.js' } },
+  });
+  relocateConfig(
+    root,
+    'knip.config.ts',
+    "throw new Error('boom from the config');\n",
+  );
+
+  const report = await resolveEntrySync({ repoRoot: root });
+  assert.equal(report.skipped, null, 'breakage is not absence');
+  assert.match(report.error, /cannot resolve the knip configuration/);
+
+  const stderr = {
+    out: '',
+    write(s) {
+      this.out += s;
+    },
+  };
+  assert.equal(
+    await runCli({ argv: ['--cwd', root], stdout: { write() {} }, stderr }),
+    2,
+  );
+});
+
 // --- live-repository invariants ---------------------------------------------
 
-test('INVARIANT: this repository\u2019s knip entry list matches its invoked CLI set', () => {
-  const report = resolveEntrySync({ repoRoot: REPO_ROOT });
+test('INVARIANT: this repository\u2019s knip entry list matches its invoked CLI set', async () => {
+  const report = await resolveEntrySync({ repoRoot: REPO_ROOT });
   assert.equal(report.error, null);
   assert.deepEqual(
     report.missing.map((m) => m.cli),
@@ -421,11 +678,11 @@ test('INVARIANT: this repository\u2019s knip entry list matches its invoked CLI 
   );
 });
 
-test('INVARIANT: no entry-declared CLI is also recorded as a whole-file dead row', () => {
+test('INVARIANT: no entry-declared CLI is also recorded as a whole-file dead row', async () => {
   // The two artifacts must stay disjoint by construction. A CLI appearing in
   // both is precisely the poisoning #5012 nearly committed: declared live to
   // knip, yet recorded as expected-dead in the ratchet's own baseline.
-  const { entries } = readKnipEntries({ repoRoot: REPO_ROOT });
+  const { entries } = await readKnipEntries({ repoRoot: REPO_ROOT });
   const declared = new Set(entries);
   for (const baseline of [
     'baselines/dead-exports.json',

--- a/tests/check-knip-entries.test.js
+++ b/tests/check-knip-entries.test.js
@@ -640,6 +640,9 @@ test('a configuration that exists but throws on load exits 2, never 0', async ()
   const report = await resolveEntrySync({ repoRoot: root });
   assert.equal(report.skipped, null, 'breakage is not absence');
   assert.match(report.error, /cannot resolve the knip configuration/);
+  // The message must name the file it tried, or the operator is left guessing
+  // which of knip's eight config locations was picked up.
+  assert.match(report.error, /knip\.config\.ts/);
 
   const stderr = {
     out: '',

--- a/tests/scripts/runtime-deps-drift.test.js
+++ b/tests/scripts/runtime-deps-drift.test.js
@@ -76,6 +76,23 @@ describe('runtime-deps drift', () => {
     );
   });
 
+  it('declares knip as an optional dependency (the entry gate degrades without it)', () => {
+    // `check-knip-entries.js` imports `knip/session` behind a try/catch and
+    // skips cleanly when it does not resolve (Story #5039). Promoting it to
+    // `dependencies` would make the preflight guard fail-fast, forcing every
+    // consumer — including those that do not run knip at all — to install it
+    // just to have `.agents/` materialized.
+    const { optionalDependencies, dependencies } = loadRuntimeDepsManifest();
+    assert.ok(
+      Object.hasOwn(optionalDependencies, 'knip'),
+      'knip must be in optionalDependencies (not dependencies)',
+    );
+    assert.ok(
+      !Object.hasOwn(dependencies, 'knip'),
+      'knip must never be preflight-blocked — the gate is opt-in by absence',
+    );
+  });
+
   it('fails the drift check when a declaration is removed (negative control)', () => {
     const { packages } = scanThirdPartyImports(SCRIPTS_DIR);
     assert.ok(packages.has('minimatch'), 'precondition: minimatch is imported');


### PR DESCRIPTION
Closes #5039

_Auto-opened by `/deliver`._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Quality-gate tooling only; behavior is opt-in on skip and covered by expanded tests, with no production runtime or auth impact.
> 
> **Overview**
> **`check-knip-entries`** no longer reads a root **`knip.json`** with **`JSON.parse`**. It loads knip’s resolved config through **`knip/session`**’s **`createOptions`**, so every supported config location works (including **`knip.config.ts`** with spreads/computed **`entry`** arrays) and **per-workspace** **`entry`** patterns are included alongside top-level ones.
> 
> A new **`knip-config-resolver.js`** module owns that resolution; **`knip-entry-sync.js`** and the CLI are **async** and delegate entry discovery to it. **`exitCodeFor`** centralizes pass/fail: **exit 0** when there is no knip config or **`knip`** is not installed (skip), **exit 2** only when a config exists but cannot be resolved.
> 
> **`knip`** is added to **`runtime-deps.json`** **`optionalDependencies`** (with a drift test) so consumers that do not run knip are not preflight-blocked. Tests and docs are expanded for skip vs error, workspace entries, and TS config shapes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 86e55dc4aab12334be42c13f4206db44c112f77c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->