### PR TITLE
chore(deps): bump js-yaml to ^4.3.1 to clear GHSA-5p4m-2wfm-xmqj

### DIFF
--- a/.agents/runtime-deps.json
+++ b/.agents/runtime-deps.json
@@ -3,7 +3,7 @@
   "dependencies": {
     "ajv": "^8.20.0",
     "ajv-formats": "^3.0.1",
-    "js-yaml": "^4.1.1",
+    "js-yaml": "^4.3.1",
     "minimatch": "^10.0.0",
     "picomatch": "^4.0.4",
     "typhonjs-escomplex": "^0.1.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
       "dependencies": {
         "ajv": "^8.20.0",
         "ajv-formats": "^3.0.1",
-        "js-yaml": "^4.2.0",
+        "js-yaml": "^4.3.1",
         "minimatch": "^10.0.0",
         "picomatch": "^4.0.4",
         "typhonjs-escomplex": "^0.1.0"
@@ -3928,9 +3928,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "funding": [
         {
           "type": "github",

--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
   "dependencies": {
     "ajv": "^8.20.0",
     "ajv-formats": "^3.0.1",
-    "js-yaml": "^4.2.0",
+    "js-yaml": "^4.3.1",
     "minimatch": "^10.0.0",
     "picomatch": "^4.0.4",
     "typhonjs-escomplex": "^0.1.0"
@@ -129,7 +129,7 @@
     "dependencies.js-yaml": "States the SAME range as overrides.js-yaml above. The two are deliberate duplicates — npm has no way to reference the direct range from the overrides block — so they MUST move in lockstep; changing one without the other silently splits the direct and transitive resolutions."
   },
   "overrides": {
-    "js-yaml": "^4.2.0",
+    "js-yaml": "^4.3.1",
     "markdown-it": "^14.2.0"
   }
 }


### PR DESCRIPTION
## Why

`npm audit --audit-level=high` is red on `main`, so the required **Validate and Test** check fails on every PR. It blocked Story #5039 ([run 31176377775](https://github.com/dsj1984/mandrel/actions/runs/31176377775)), and this is the same class of red the repo has hit repeatedly.

Verified pre-existing: the audit fails identically on unmodified `main` at 25a5af7b.

## Why not npm's suggested fix

`npm audit fix --force` proposes `markdownlint-cli2@0.23.2` — a semver-major bump of the lint tool. That is npm's conservative resolver, not the only path. The advisory range is `4.0.0 - 4.3.0`; **js-yaml 4.3.1 sits outside it**.

Bumping the direct dependency and the existing `overrides` entry — the decoupling #4784 put in place precisely so `markdownlint-cli2`'s exact `4.1.1` pin cannot hold the tree back — clears both findings with **no breaking change**, leaving `markdownlint-cli2` at 0.22.1.

`.agents/runtime-deps.json` moves with it: that manifest is the contract consumers install against, so leaving it at `^4.1.1` would keep telling every consumer a vulnerable range is acceptable.

## Verification

- `npm ls js-yaml` → 4.3.1 at all three sites (root, markdownlint-cli2, cosmiconfig)
- `npm audit --audit-level=high` → **0 vulnerabilities**
- `npm test` → 9752 tests, 0 failures
- `npm run lint` → exit 0
- `node .agents/scripts/check-baselines.js` → exit 0

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Patch-level dependency bump with no application code changes; override pattern is already established for js-yaml.
> 
> **Overview**
> Bumps **js-yaml** to **^4.3.1** everywhere the repo pins it so high-severity audit findings clear without a semver-major **markdownlint-cli2** upgrade.
> 
> The direct dependency and npm **overrides** entry in `package.json` move from **^4.2.0** to **^4.3.1** in lockstep (as documented in the package comment). **`.agents/runtime-deps.json`** is updated to the same range so consumer installs match the framework contract. **`package-lock.json`** resolves the tree to **js-yaml@4.3.1**, including transitive consumers still declaring older pins (e.g. **markdownlint-cli2**).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1715deec467bdd6b4b9d3b5d561bfdfe8d45474a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->