### PR TITLE
fix: deliver: make the declared-edge channel trustworthy — paginate native reads, fail loud on 404, parse footers strictly (#5046)

### DIFF
--- a/.agents/scripts/lib/dependency-parser.js
+++ b/.agents/scripts/lib/dependency-parser.js
@@ -7,18 +7,31 @@
  * lib/story-adjacency.js, lib/branch-name-guard.js).
  */
 
+import { parseFooterBlockedByIds } from './story-body/footer-block.js';
+
 /**
- * Parse `blocked by #NNN` and `depends on #NNN` references from text.
- * Handles case-insensitive variations.
+ * Parse a body's declared blocker issue numbers — **footer-scoped and
+ * strict**.
+ *
+ * Only a `blocked by #N` line standing alone inside the `---` footer block
+ * declares an edge. The unanchored predecessor scanned the whole body for
+ * `blocked by|depends on #N` anywhere, so a Story whose prose merely mentioned
+ * a blocker — an example, a changelog note, an acceptance criterion describing
+ * this very defect — minted a real dispatch gate that withheld the Story until
+ * an unrelated issue closed.
+ *
+ * The behaviour change is deliberate and user-visible: prose-only mentions
+ * outside the footer no longer gate. Every machine-authored body already
+ * carries the canonical footer form (`plan-persist` has always serialized it),
+ * so only hand-written prose edges are affected — those must be moved into the
+ * footer block to keep gating. The grammar itself lives in
+ * `lib/story-body/footer-block.js`, shared with the body parser.
  *
  * @param {string} body - Issue body or freeform text.
- * @returns {number[]} Array of issue numbers this text declares as blockers.
+ * @returns {number[]} Array of issue numbers this body declares as blockers.
  */
 export function parseBlockedBy(body) {
-  if (!body) return [];
-  const re = /(?:blocked\s+by|depends\s+on):?\s+#(\d+)/gi;
-  const ids = [...body.matchAll(re)].map((m) => Number.parseInt(m[1], 10));
-  return [...new Set(ids)];
+  return parseFooterBlockedByIds(body);
 }
 
 /**

--- a/.agents/scripts/lib/orchestration/resolve-stories.js
+++ b/.agents/scripts/lib/orchestration/resolve-stories.js
@@ -182,9 +182,16 @@ export function storyFootprintPaths(body, id, warn) {
 }
 
 /**
- * Build the DAG nodes. `dependsOn` is the union the adjacency builder already
- * computes (body-parsed `blocked by #N` + explicit fields), plus any native
- * edges threaded in via `nativeEdges`. `files` is a plain `string[]`.
+ * Build the DAG nodes. `dependsOn` is the **union of the two declared-edge
+ * channels**: the Story body's `---` footer (`blocked by #N`) and the native
+ * GitHub `blocked_by` relations threaded in via `nativeEdges`. `files` is a
+ * plain `string[]`.
+ *
+ * The body channel is footer-scoped and strict (`parseBlockedBy`, Story
+ * #5046) — a `blocked by #123` mention in prose no longer mints a dispatch
+ * gate. Only `{ id, dependsOn }` is handed to the adjacency builder, never the
+ * body: the edge set is decided here, once, so the builder's own body parse
+ * cannot re-derive a different one behind this function's back.
  *
  * @param {object[]} stories
  * @param {Map<number, number[]>} [nativeEdges]
@@ -193,7 +200,7 @@ export function storyFootprintPaths(body, id, warn) {
  */
 export function storiesToDag(stories, nativeEdges = new Map(), warn) {
   const withNative = stories.map((s) => ({
-    ...s,
+    id: s.id,
     dependsOn: [
       ...new Set([
         ...parseBlockedBy(s.body ?? ''),
@@ -222,28 +229,39 @@ export function storiesToDag(stories, nativeEdges = new Map(), warn) {
  * matching no Story, foreign to the set, never satisfiable, and (because
  * foreign edges are real gates) a silent permanent wedge.
  *
- * Cross-repo blockers are rejected rather than matched: another repo's #4530
- * is not this repo's #4530, and treating it as one could satisfy a gate that
- * is still open.
+ * A cross-repo blocker is **dropped with a loud warning**, never matched:
+ * another repo's #4530 is not this repo's #4530, and treating it as one could
+ * satisfy a gate that is still open. It used to throw, which failed the WHOLE
+ * resolution — one Story's unsupported edge took every sibling down with it
+ * (Story #5046). The degrade is now scoped to the Story carrying the edge:
+ * its siblings resolve normally, and the operator is told, by number, which
+ * Story lost which edge.
  *
  * @param {unknown} data Parsed API response.
- * @param {{ owner: string, repo: string, issueNumber: number }} ctx
+ * @param {{ owner: string, repo: string, issueNumber: number, warn?: (msg: string) => void }} ctx
  * @returns {number[]}
  */
-export function nativeBlockedByNumbers(data, { owner, repo, issueNumber }) {
+export function nativeBlockedByNumbers(
+  data,
+  { owner, repo, issueNumber, warn },
+) {
   if (!Array.isArray(data)) return [];
   const out = [];
   for (const item of data) {
     const repoUrl = item?.repository_url ?? item?.repository?.url ?? null;
-    if (typeof repoUrl === 'string' && repoUrl.length > 0) {
-      const expected = `/repos/${owner}/${repo}`;
-      if (!repoUrl.endsWith(expected)) {
-        throw new Error(
-          `[resolve-stories] #${issueNumber} is blocked by an issue in another repository ` +
-            `(${repoUrl}). Cross-repo dependency edges are not supported — its number cannot ` +
-            `be matched against this repo's Stories without risking a false match.`,
-        );
-      }
+    if (
+      typeof repoUrl === 'string' &&
+      repoUrl.length > 0 &&
+      !repoUrl.endsWith(`/repos/${owner}/${repo}`)
+    ) {
+      warn?.(
+        `[resolve-stories] #${issueNumber} declares a native blocked_by edge on an issue in ` +
+          `another repository (${repoUrl}). Cross-repo edges are not supported — its number ` +
+          `cannot be matched against this repo's Stories without risking a false match, so the ` +
+          `edge is DROPPED for #${issueNumber} only. Its siblings resolve normally; re-declare ` +
+          `the ordering in this repo if #${issueNumber} must wait.`,
+      );
+      continue;
     }
     const number = Number(item?.number);
     if (Number.isInteger(number) && number > 0) out.push(number);
@@ -252,17 +270,33 @@ export function nativeBlockedByNumbers(data, { owner, repo, issueNumber }) {
 }
 
 /**
- * Read an issue's native `blocked_by` edges as issue numbers.
+ * Read an issue's native `blocked_by` edges as issue numbers, **paginated to
+ * exhaustion**.
  *
- * **Fails loud**, deliberately inverting the write path's non-fatal contract.
- * A dropped write-side edge is cosmetic (the ordering still lives in the
- * `blocked by #N` body footer); a dropped READ-side edge silently removes a
- * dispatch gate, so a 403 (dependencies API disabled, or a token without the
- * scope) would erase every native edge at once and co-dispatch the whole run
- * against unlanded blockers. A 404 means "no dependencies on this issue" and
- * is a legitimate empty result.
+ * The read used to take the first page only, so a Story with more than a
+ * page of blockers silently lost every edge past the boundary — the exact
+ * failure this function's fail-loud contract exists to prevent, arriving
+ * through the one door that never raised (Story #5046). `paginate` is
+ * injected (the CLI passes `paginateRest`) so the lib layer stays free of a
+ * provider import and the page walk stays testable without a live round-trip.
  *
- * @param {{ gh: object, owner: string, repo: string, issueNumber: number, parseJson: Function }} opts
+ * **Fails loud on every non-OK read**, deliberately inverting the write path's
+ * non-fatal contract. A dropped write-side edge is cosmetic (the ordering
+ * still lives in the `blocked by #N` body footer); a dropped READ-side edge
+ * silently removes a dispatch gate, so one failure would erase every native
+ * edge at once and co-dispatch the run against unlanded blockers.
+ *
+ * **A 404 is not an empty result.** It used to be treated as "this issue has
+ * no dependencies", which is how GitHub answers an issue that genuinely has
+ * none — but it is *also* how GitHub answers a token that cannot see the
+ * dependencies API at all. Reading the second as the first erases every
+ * native edge in the run under a mis-scoped token, silently, with a clean
+ * exit code. An issue with no dependencies returns `200 []`, so the empty
+ * case needs no 404 escape hatch and the ambiguity resolves loud.
+ *
+ * @param {{ gh: object, owner: string, repo: string, issueNumber: number,
+ *   paginate: (gh: object, endpoint: string, opts?: object) => Promise<unknown[]>,
+ *   warn?: (msg: string) => void }} opts
  * @returns {Promise<number[]>}
  */
 export async function readNativeBlockedBy({
@@ -270,27 +304,30 @@ export async function readNativeBlockedBy({
   owner,
   repo,
   issueNumber,
-  parseJson,
+  paginate,
+  warn,
 }) {
-  let result;
+  const endpoint = `/repos/${owner}/${repo}/issues/${issueNumber}/dependencies/blocked_by`;
+  let items;
   try {
-    result = await gh.api({
-      method: 'GET',
-      endpoint: `/repos/${owner}/${repo}/issues/${issueNumber}/dependencies/blocked_by`,
+    items = await paginate(gh, endpoint, {
+      label: `[resolve-stories] blocked_by #${issueNumber}`,
     });
   } catch (err) {
     const detail = String(err?.message ?? err);
-    if (/404|not found/i.test(detail)) return [];
     throw new Error(
       `[resolve-stories] Could not read native blocked_by edges for #${issueNumber}: ${detail}. ` +
         `Refusing to continue: a dropped dependency edge would silently remove a dispatch gate ` +
-        `and co-dispatch this Story against an unlanded blocker.`,
+        `and co-dispatch this Story against an unlanded blocker. A 404 here is NOT "no ` +
+        `dependencies" (that answers 200 with an empty list) — check the token's scopes and ` +
+        `that the dependencies API is enabled for ${owner}/${repo}.`,
     );
   }
-  return nativeBlockedByNumbers(parseJson(result), {
+  return nativeBlockedByNumbers(items, {
     owner,
     repo,
     issueNumber,
+    warn,
   });
 }
 

--- a/.agents/scripts/lib/story-body/footer-block.js
+++ b/.agents/scripts/lib/story-body/footer-block.js
@@ -1,0 +1,97 @@
+/**
+ * footer-block.js — the Story body's `---` footer grammar.
+ *
+ * A Story body is prose an operator edits. Its **declared dependency edges**
+ * are not: they live in a footer block, in one exact line shape, and that
+ * distinction is the whole safety property. An unanchored whole-body scan
+ * (what `parseBlockedBy` used to be) turned any sentence that merely mentioned
+ * a blocker into a real dispatch gate — an example, a changelog note, an
+ * acceptance criterion quoting the phrase — and withheld the Story until an
+ * unrelated issue closed.
+ *
+ * This module is the single home for that grammar. Both readers go through it:
+ * `lib/story-body/story-body.js` (what a body round-trips as `depends_on`) and
+ * `lib/dependency-parser.js` (what gates dispatch). Sharing one implementation
+ * is what keeps them from drifting apart into two different answers about the
+ * same body.
+ *
+ * @module lib/story-body/footer-block
+ */
+
+/**
+ * The one line shape that declares a dependency edge: `blocked by #N` alone on
+ * its own line inside the footer block. Anchored at both ends deliberately —
+ * `depends on #N`, `Blocked by: #N`, and `blocked by #N once X lands` all
+ * declare nothing.
+ */
+const FOOTER_BLOCKED_BY_LINE_RE = /^blocked by\s+(#\d+)$/i;
+
+/** A `---` rule on its own line. */
+const FOOTER_RULE_RE = /^---\s*$/;
+
+/** Footer keys that qualify a bare `---` rule as the footer separator. */
+const FOOTER_KEY_RE = /^(parent:|Epic:|blocked by)/im;
+
+/**
+ * True when line `index` opens the footer block: a `---` on its own line whose
+ * remaining lines start with a recognised footer key (`parent:`, `Epic:`,
+ * `blocked by`). A `---` opening a thematic break or a table mid-body is
+ * therefore not mistaken for the footer.
+ *
+ * @param {string} line
+ * @param {string[]} lines
+ * @param {number} index
+ * @returns {boolean}
+ */
+export function isFooterSeparator(line, lines, index) {
+  if (!FOOTER_RULE_RE.test(line)) return false;
+  return FOOTER_KEY_RE.test(lines.slice(index + 1).join('\n'));
+}
+
+/**
+ * Return the footer block of a body — everything after the footer separator —
+ * or `''` when the body carries no footer.
+ *
+ * Module-private: `parseFooterBlockedByIds` is its only caller. The body
+ * parser splits its own sections and reaches for `parseFooterBlockedByRefs`
+ * with the footer it already has, so exporting this would ship a symbol with
+ * no consumer.
+ *
+ * @param {string} body
+ * @returns {string}
+ */
+function extractFooterBlock(body) {
+  if (!body) return '';
+  const lines = String(body).split('\n');
+  const start = lines.findIndex((line, i) => isFooterSeparator(line, lines, i));
+  return start === -1 ? '' : lines.slice(start + 1).join('\n');
+}
+
+/**
+ * Extract the `blocked by #N` refs from an already-split footer block, as the
+ * `"#N"` strings a Story body's `depends_on` field round-trips.
+ *
+ * @param {string} footerBlock
+ * @returns {string[]}
+ */
+export function parseFooterBlockedByRefs(footerBlock) {
+  if (!footerBlock) return [];
+  return String(footerBlock)
+    .split('\n')
+    .map((line) => line.trim().match(FOOTER_BLOCKED_BY_LINE_RE)?.[1])
+    .filter((ref) => typeof ref === 'string');
+}
+
+/**
+ * Parse a body's declared blocker issue **numbers**, deduped — the
+ * dispatch-edge view of the same footer the body parser reads.
+ *
+ * @param {string} body
+ * @returns {number[]}
+ */
+export function parseFooterBlockedByIds(body) {
+  const ids = parseFooterBlockedByRefs(extractFooterBlock(body)).map((ref) =>
+    Number.parseInt(ref.slice(1), 10),
+  );
+  return [...new Set(ids)];
+}

--- a/.agents/scripts/lib/story-body/story-body.js
+++ b/.agents/scripts/lib/story-body/story-body.js
@@ -48,6 +48,7 @@ import {
 } from '../framework-version.js';
 import { FILE_ASSUMPTION_VALUES } from '../orchestration/file-assumption-enum.js';
 import { suggestPathEntryFix } from './body-format-lints.js';
+import { isFooterSeparator, parseFooterBlockedByRefs } from './footer-block.js';
 
 // ---------------------------------------------------------------------------
 // Public types (JSDoc only — no runtime schema file)
@@ -313,16 +314,15 @@ function pathEntryFixIt(raw) {
  * Extract the `blocked by #N` lines from the footer block (text after
  * the last `---` separator). Returns an array of "#N" strings.
  *
+ * Delegates to `./footer-block.js`, which owns the footer-block grammar
+ * (Story #5046) so the body parser and the dispatch-edge parser cannot
+ * disagree about what declares an edge.
+ *
  * @param {string} footerBlock
  * @returns {string[]}
  */
 function extractBlockedBy(footerBlock) {
-  const deps = [];
-  for (const line of footerBlock.split('\n')) {
-    const m = line.trim().match(/^blocked by\s+(#\d+)$/i);
-    if (m) deps.push(m[1]);
-  }
-  return deps;
+  return parseFooterBlockedByRefs(footerBlock);
 }
 
 // Matches any trailing `<!-- meta: … -->` block. Object payloads are the
@@ -489,22 +489,6 @@ function splitSections(markdown) {
     footerStart >= 0 ? lines.slice(footerStart + 1).join('\n') : '';
   const preamble = preambleLines.join('\n').trim();
   return { sections, footer, preamble };
-}
-
-/**
- * True when line `index` opens the footer block: a `---` on its own line
- * whose remaining lines start with a recognised footer key (`parent:`,
- * `Epic:`, `blocked by`).
- *
- * @param {string} line
- * @param {string[]} lines
- * @param {number} index
- * @returns {boolean}
- */
-function isFooterSeparator(line, lines, index) {
-  if (!/^---\s*$/.test(line)) return false;
-  const remaining = lines.slice(index + 1).join('\n');
-  return /^(parent:|Epic:|blocked by)/im.test(remaining);
 }
 
 /**

--- a/.agents/scripts/providers/github/blocked-by-add.js
+++ b/.agents/scripts/providers/github/blocked-by-add.js
@@ -22,7 +22,7 @@
 
 import { Logger } from '../../lib/Logger.js';
 import { concurrentMap } from '../../lib/util/concurrent-map.js';
-import { parseApiJson } from './request-helpers.js';
+import { paginateRest } from './request-helpers.js';
 
 /**
  * Bounded concurrency for the GitHub dependency-edge round-trips. Kept modest
@@ -32,22 +32,37 @@ import { parseApiJson } from './request-helpers.js';
 const EDGE_CONCURRENCY = 5;
 
 /**
- * Fetch the existing blocked-by issue numbers for a given issue.
+ * Fetch the existing blocked-by database ids for a given issue, **paginated
+ * to exhaustion**.
+ *
+ * This read is the idempotency check: an edge it fails to see is re-POSTed.
+ * Reading only the first page therefore made the writer non-idempotent past
+ * the page boundary — every edge beyond it looked missing on every run
+ * (Story #5046). `paginateRest` walks the pages and carries the shared
+ * transient-retry and page-cap guards.
  *
  * Returns `[]` on any error so the caller falls back to posting the full
  * set of missing edges (worst case: a duplicate POST, which GitHub
- * handles idempotently).
+ * handles idempotently). That non-fatal contract is deliberate and is the
+ * inverse of the READ path in `lib/orchestration/resolve-stories.js`: a lost
+ * write-side edge is cosmetic, a lost read-side edge removes a dispatch gate.
  *
- * @param {{ gh: object, owner: string, repo: string, issueNumber: number }} opts
+ * @param {{ gh: object, owner: string, repo: string, issueNumber: number, paginate?: Function }} opts
  * @returns {Promise<number[]>} Database ids of the issues that currently block `issueNumber`.
  */
-async function fetchExistingBlockedBy({ gh, owner, repo, issueNumber }) {
+async function fetchExistingBlockedBy({
+  gh,
+  owner,
+  repo,
+  issueNumber,
+  paginate = paginateRest,
+}) {
   try {
-    const result = await gh.api({
-      method: 'GET',
-      endpoint: `/repos/${owner}/${repo}/issues/${issueNumber}/dependencies/blocked_by`,
-    });
-    const data = parseApiJson(result);
+    const data = await paginate(
+      gh,
+      `/repos/${owner}/${repo}/issues/${issueNumber}/dependencies/blocked_by`,
+      { label: `[blocked-by-add] blocked_by #${issueNumber}` },
+    );
     if (!Array.isArray(data)) return [];
     return data.map((item) => item?.id).filter((id) => typeof id === 'number');
   } catch (err) {

--- a/.agents/scripts/resolve-stories.js
+++ b/.agents/scripts/resolve-stories.js
@@ -11,8 +11,11 @@
  * What it resolves, per Story:
  *   - the issue itself, fetched with **state=all** so an already-landed
  *     sibling is present rather than silently dropped;
- *   - its dependency edges: the union of body-parsed `blocked by #N` /
- *     `depends on #N` and native GitHub `blocked_by` edges;
+ *   - its dependency edges: the union of the body's `---` footer
+ *     (`blocked by #N`, footer-scoped and strict — prose mentioning a blocker
+ *     elsewhere in the body declares nothing) and native GitHub `blocked_by`
+ *     edges, read to exhaustion and failing loud rather than degrading to
+ *     "no edges";
  *   - its declared file footprint, as plain path strings, so the scheduler's
  *     co-dispatch overlap guard has something to work with.
  *
@@ -45,7 +48,7 @@ import {
 } from './lib/orchestration/resolve-stories.js';
 import { createProvider } from './lib/provider-factory.js';
 import { concurrentMap } from './lib/util/concurrent-map.js';
-import { parseApiJson } from './providers/github/request-helpers.js';
+import { paginateRest } from './providers/github/request-helpers.js';
 
 export { buildStoriesEnvelope, parseIds, readNativeBlockedBy, toStoryRecord };
 
@@ -111,9 +114,21 @@ export async function fetchStories(provider, ids) {
 /**
  * Read native blocked_by edges for every Story in the set.
  *
+ * `paginate` is injected rather than imported inside the lib layer so
+ * `readNativeBlockedBy` stays provider-agnostic and unit-testable; production
+ * passes `paginateRest`, which walks every page (the read used to stop at the
+ * first, silently truncating a Story's gates — Story #5046).
+ *
  * @returns {Promise<Map<number, number[]>>}
  */
-export async function readNativeEdges({ provider, stories, owner, repo }) {
+export async function readNativeEdges({
+  provider,
+  stories,
+  owner,
+  repo,
+  paginate = paginateRest,
+  warn = (m) => Logger.warn(m),
+}) {
   const entries = await concurrentMap(
     stories,
     async (story) => [
@@ -123,7 +138,8 @@ export async function readNativeEdges({ provider, stories, owner, repo }) {
         owner,
         repo,
         issueNumber: story.id,
-        parseJson: parseApiJson,
+        paginate,
+        warn,
       }),
     ],
     { concurrency: FETCH_CONCURRENCY },

--- a/.agents/workflows/helpers/deliver-story-reference.md
+++ b/.agents/workflows/helpers/deliver-story-reference.md
@@ -161,6 +161,63 @@ terminal envelope are byte-identical either way.
 
 ---
 
+## Declared dependency edges — what actually gates dispatch
+
+`resolve-stories.js` builds each `dag[].dependsOn` from the **union of two
+declared-edge channels**, and nothing else: the Story body's footer block and
+the issue's native GitHub `blocked_by` relations. Both are read strictly — an
+edge the resolver cannot read is never quietly reported as an edge that does
+not exist.
+
+**The body channel is footer-scoped.** Only a `blocked by #N` line standing
+alone inside the `---` footer block declares an edge:
+
+```markdown
+## Goal
+
+…
+
+---
+
+blocked by #42
+```
+
+Prose elsewhere in the body declares **nothing**, and this is a deliberate,
+user-visible change from the whole-body scan that preceded it. A sentence
+merely mentioning a blocker — an example, a changelog note, an acceptance
+criterion quoting the phrase — used to mint a real dispatch gate that withheld
+the Story until an unrelated issue closed. `plan-persist` has always
+serialized the canonical footer form, so no machine-authored body is affected;
+only a **hand-written prose edge** stops gating, and the fix is to move it into
+the footer block. The loose spellings never reached the footer grammar either:
+`depends on #N`, `Blocked by: #N`, and `blocked by #N once X lands` all declare
+nothing. One grammar serves both readers — the body parser and the
+dispatch-edge parser share it — so what a Story body round-trips and what gates
+dispatch cannot drift apart.
+
+**The native channel fails loud.** The read paginates to exhaustion (a
+first-page read silently truncated a Story's gates at GitHub's 30-item
+default), and **a 404 is not an empty result**. An issue with no dependencies
+answers `200 []`; a 404 is how GitHub also answers a token that cannot see the
+dependencies API, so treating it as "no edges" erased every native edge in the
+run under a mis-scoped token, silently, with a clean exit code. Any non-OK
+read now fails the resolution naming the Story — check the token's scopes
+first. The one degrade that is scoped rather than fatal is a **cross-repo
+edge**: another repository's issue number cannot be matched against this
+repo's same-numbered issue without risking a false match, so that edge is
+dropped with a warning naming the Story, and its siblings resolve normally.
+
+**Edges are monotone — retraction is not built.** Both channels only ever
+_add_ a gate for the current resolution. Removing a `blocked by` footer line
+or deleting a native relation makes the edge absent from the **next** resolve,
+but nothing reconciles an edge that a previous run already acted on, and the
+write path never deletes a native relation it did not need. In practice that
+means: re-resolve after editing edges, and treat a stale gate as a body/issue
+edit plus a fresh `resolve-stories.js` run, never as something delivery
+un-declares on your behalf. This is a known limitation, not an oversight.
+
+---
+
 ## Step 1 — Implementation detail
 
 **Docs context — digest-first.** Read a full doc only when the Story's own

--- a/baselines/coverage.json
+++ b/baselines/coverage.json
@@ -1,12 +1,12 @@
 {
   "$schema": ".agents/schemas/baselines/coverage.schema.json",
   "kernelVersion": "1.0.0",
-  "generatedAt": "2026-08-07T11:55:32.344Z",
+  "generatedAt": "2026-08-07T13:24:41.046Z",
   "rollup": {
     "*": {
-      "lines": 95.9,
-      "branches": 86.62,
-      "functions": 88.81
+      "lines": 95.91,
+      "branches": 86.65,
+      "functions": 88.82
     }
   },
   "rows": [
@@ -1225,7 +1225,7 @@
     {
       "path": ".agents/scripts/lib/dependency-parser.js",
       "lines": 100,
-      "branches": 97.06,
+      "branches": 96.67,
       "functions": 100
     },
     {
@@ -2040,8 +2040,8 @@
     },
     {
       "path": ".agents/scripts/lib/orchestration/resolve-stories.js",
-      "lines": 97.39,
-      "branches": 79.52,
+      "lines": 97.57,
+      "branches": 78.95,
       "functions": 100
     },
     {
@@ -2597,9 +2597,15 @@
       "functions": 100
     },
     {
+      "path": ".agents/scripts/lib/story-body/footer-block.js",
+      "lines": 100,
+      "branches": 100,
+      "functions": 100
+    },
+    {
       "path": ".agents/scripts/lib/story-body/story-body.js",
-      "lines": 99.34,
-      "branches": 94.92,
+      "lines": 99.74,
+      "branches": 95.51,
       "functions": 100
     },
     {
@@ -3060,9 +3066,9 @@
     },
     {
       "path": ".agents/scripts/resolve-stories.js",
-      "lines": 81.85,
-      "branches": 90.91,
-      "functions": 63.64
+      "lines": 82.91,
+      "branches": 91.67,
+      "functions": 58.33
     },
     {
       "path": ".agents/scripts/resync-status-column.js",

--- a/baselines/maintainability.json
+++ b/baselines/maintainability.json
@@ -1,7 +1,7 @@
 {
   "$schema": ".agents/schemas/baselines/maintainability.schema.json",
   "kernelVersion": "0.1.0",
-  "generatedAt": "2026-08-07T11:55:39.057Z",
+  "generatedAt": "2026-08-07T13:23:36.131Z",
   "rollup": {
     "*": {
       "min": 76.381,
@@ -792,7 +792,7 @@
     },
     {
       "path": ".agents/scripts/lib/dependency-parser.js",
-      "mi": 111.597
+      "mi": 112.265
     },
     {
       "path": ".agents/scripts/lib/detect-package-manager.js",
@@ -1336,7 +1336,7 @@
     },
     {
       "path": ".agents/scripts/lib/orchestration/resolve-stories.js",
-      "mi": 103.288
+      "mi": 103.8
     },
     {
       "path": ".agents/scripts/lib/orchestration/retro-proposals.js",
@@ -1707,8 +1707,12 @@
       "mi": 83.974
     },
     {
+      "path": ".agents/scripts/lib/story-body/footer-block.js",
+      "mi": 117.261
+    },
+    {
       "path": ".agents/scripts/lib/story-body/story-body.js",
-      "mi": 94.035
+      "mi": 94.57
     },
     {
       "path": ".agents/scripts/lib/temp-retention.js",

--- a/tests/lib/dependency-parser.test.js
+++ b/tests/lib/dependency-parser.test.js
@@ -9,36 +9,75 @@ import {
 } from '../../.agents/scripts/lib/dependency-parser.js';
 
 describe('dependency-parser', () => {
-  describe('parseBlockedBy', () => {
+  describe('parseBlockedBy — footer-scoped and strict (Story #5046)', () => {
+    // A declared edge lives on its own line inside the `---` footer block.
+    // The unanchored predecessor scanned the whole body, so any prose
+    // mentioning a blocker minted a real dispatch gate.
+    const footer = (...lines) =>
+      ['## Goal', 'Do the thing.', '', '---', ...lines].join('\n');
+
     it('returns empty array for falsy input', () => {
       assert.deepEqual(parseBlockedBy(null), []);
       assert.deepEqual(parseBlockedBy(undefined), []);
       assert.deepEqual(parseBlockedBy(''), []);
     });
 
-    it('parses "blocked by #NNN"', () => {
-      assert.deepEqual(parseBlockedBy('This is blocked by #123.'), [123]);
-      assert.deepEqual(parseBlockedBy('blocked by #456'), [456]);
+    it('parses a footer "blocked by #NNN" line', () => {
+      assert.deepEqual(parseBlockedBy(footer('blocked by #123')), [123]);
     });
 
-    it('parses "depends on #NNN"', () => {
-      assert.deepEqual(parseBlockedBy('depends on #789'), [789]);
+    it('is case-insensitive within the footer', () => {
+      assert.deepEqual(parseBlockedBy(footer('BLOCKED BY #333')), [333]);
     });
 
-    it('handles colons', () => {
-      assert.deepEqual(parseBlockedBy('Blocked by: #111'), [111]);
-      assert.deepEqual(parseBlockedBy('Depends on: #222'), [222]);
-    });
-
-    it('is case-insensitive', () => {
-      assert.deepEqual(parseBlockedBy('BLOCKED BY #333'), [333]);
-      assert.deepEqual(parseBlockedBy('DePeNdS oN #444'), [444]);
-    });
-
-    it('extracts multiple dependencies', () => {
+    it('extracts and dedupes multiple footer dependencies', () => {
       assert.deepEqual(
-        parseBlockedBy('blocked by #1\nBlocked by: #2\ndepends on #3'),
-        [1, 2, 3],
+        parseBlockedBy(
+          footer('blocked by #1', 'blocked by #2', 'blocked by #1'),
+        ),
+        [1, 2],
+      );
+    });
+
+    it('reads a footer alongside the other recognised footer keys', () => {
+      assert.deepEqual(
+        parseBlockedBy(footer('parent: #900', 'blocked by #901')),
+        [901],
+      );
+    });
+
+    it('does NOT mint a gate from prose outside the footer', () => {
+      // The live reproduction: Story #5046's own acceptance text contained
+      // the phrase below as an EXAMPLE, and the old parser turned it into a
+      // real dispatch edge on #123.
+      assert.deepEqual(parseBlockedBy('This is blocked by #123.'), []);
+      assert.deepEqual(parseBlockedBy('blocked by #456'), []);
+      assert.deepEqual(
+        parseBlockedBy('## Goal\nA body mentioning blocked by #123 in prose.'),
+        [],
+      );
+    });
+
+    it('does NOT accept the loose "depends on" / colon spellings', () => {
+      // Only the canonical footer form declares. `plan-persist` has always
+      // serialized that form, so no machine-authored body is affected.
+      assert.deepEqual(parseBlockedBy(footer('depends on #789')), []);
+      assert.deepEqual(parseBlockedBy(footer('Blocked by: #111')), []);
+    });
+
+    it('does NOT accept a footer line carrying trailing prose', () => {
+      assert.deepEqual(
+        parseBlockedBy(footer('blocked by #123 once the API lands')),
+        [],
+      );
+    });
+
+    it('ignores a `---` rule that opens no footer block', () => {
+      // A thematic break mid-body is not a footer separator: the lines after
+      // it must start with a recognised footer key.
+      assert.deepEqual(
+        parseBlockedBy('## Goal\n\n---\n\nSome prose. blocked by #123'),
+        [],
       );
     });
 

--- a/tests/providers/github/blocked-by-add.test.js
+++ b/tests/providers/github/blocked-by-add.test.js
@@ -395,6 +395,63 @@ describe('providers/github/blocked-by-add.js — applyBlockedByDependencies', ()
     assert.deepEqual(rawFetches, [10]);
   });
 
+  it('AC-1: the read-back paginates to exhaustion, so an edge past the first page is not re-POSTed', async () => {
+    // This GET is the idempotency check. Reading only the first page made the
+    // writer non-idempotent past the page boundary: every edge beyond it
+    // looked missing on every run and was POSTed again (Story #5046). The
+    // fake honours `page`/`per_page` and falls back to GitHub's real default
+    // of 30 when the caller does not ask — the boundary that truncated.
+    const existing = Array.from({ length: 145 }, (_, i) => ({ id: i + 1 }));
+    const calls = [];
+    const gh = {
+      calls,
+      api: async ({ method, endpoint, body }) => {
+        calls.push({ method, endpoint, body });
+        if (method !== 'GET') {
+          return { stdout: JSON.stringify({ id: 999 }), stderr: '', code: 0 };
+        }
+        const params = new URL(endpoint, 'https://api.github.test')
+          .searchParams;
+        const page = Number(params.get('page') ?? 1);
+        const perPage = Number(params.get('per_page') ?? 30);
+        return {
+          stdout: JSON.stringify(
+            existing.slice((page - 1) * perPage, page * perPage),
+          ),
+          stderr: '',
+          code: 0,
+        };
+      },
+    };
+
+    const result = await applyBlockedByDependencies({
+      stories: [{ slug: 'story-b', dependsOn: ['story-a'] }],
+      slugToIssueNumber: { 'story-a': 10, 'story-b': 20 },
+      // internalId 145 is the LAST existing edge — on page 2, invisible to a
+      // first-page-only read.
+      getTicket: async () => ({ internalId: 145 }),
+      owner,
+      repo,
+      gh,
+    });
+
+    assert.deepEqual(result, {
+      edgesAdded: 0,
+      edgesSkipped: 1,
+      edgesFailed: 0,
+      storiesProcessed: 1,
+    });
+    assert.equal(
+      calls.filter((c) => c.method === 'POST').length,
+      0,
+      'an edge that already exists is never re-POSTed',
+    );
+    assert.ok(
+      calls.filter((c) => c.method === 'GET').length > 1,
+      'more than one page was requested',
+    );
+  });
+
   it('gracefully handles a GET failure by assuming no existing edges', async () => {
     let getCallCount = 0;
     const gh = {

--- a/tests/providers/github/provider-issues.test.js
+++ b/tests/providers/github/provider-issues.test.js
@@ -126,7 +126,11 @@ describe('GitHubProvider — getTicketDependencies()', () => {
         json: {
           number: 5,
           title: 'Dependent task',
-          body: 'This is blocked by #3\nAlso depends on #4\nblocks #6',
+          // `blockedBy` is footer-scoped (Story #5046): only a `blocked by #N`
+          // line inside the `---` footer block declares an edge, so the prose
+          // mention of #4 below deliberately declares nothing. `blocks #N`
+          // stays a whole-body scan — it is advisory, never a dispatch gate.
+          body: 'Also depends on #4\nblocks #6\n\n---\nblocked by #3',
           labels: [],
           assignees: [],
           state: 'open',
@@ -136,7 +140,7 @@ describe('GitHubProvider — getTicketDependencies()', () => {
     const provider = createTestProvider({ gh });
     const deps = await provider.getTicketDependencies(5);
 
-    assert.deepEqual(deps.blockedBy, [3, 4]);
+    assert.deepEqual(deps.blockedBy, [3]);
     assert.deepEqual(deps.blocks, [6]);
   });
 

--- a/tests/providers/github/tickets.test.js
+++ b/tests/providers/github/tickets.test.js
@@ -282,7 +282,10 @@ describe('providers/github/tickets.js — TicketGateway', () => {
           id: 550,
           node_id: 'node_55',
           title: 'T55',
-          body: 'blocked by #10\nblocks #20',
+          // `blockedBy` is footer-scoped (Story #5046): only a `blocked by #N`
+          // line inside the `---` footer block declares an edge. `blocks #N`
+          // stays a whole-body scan — it is advisory, never a dispatch gate.
+          body: 'blocks #20\n\n---\nblocked by #10',
           labels: [],
           assignees: [],
           state: 'open',

--- a/tests/scripts/resolve-stories.test.js
+++ b/tests/scripts/resolve-stories.test.js
@@ -33,10 +33,39 @@ import {
   planReadySet,
   storiesOverlap,
 } from '../../.agents/scripts/lib/wave-runner/ready-set.js';
-import { runResolveStories } from '../../.agents/scripts/resolve-stories.js';
+import { paginateRest } from '../../.agents/scripts/providers/github/request-helpers.js';
+import {
+  readNativeEdges,
+  runResolveStories,
+} from '../../.agents/scripts/resolve-stories.js';
 import { parseDag } from '../../.agents/scripts/stories-wave-tick.js';
 
 const REPO = { owner: 'dsj1984', repo: 'mandrel', issueNumber: 4534 };
+
+/**
+ * A `gh` fake for the dependencies endpoint that honours `page` / `per_page`
+ * the way GitHub does — including the default page size of **30** when the
+ * caller does not ask for one. Modelling that default is the whole point: it
+ * is the boundary the first-page-only read silently truncated against.
+ *
+ * @param {object[]} edges Full edge list the endpoint would serve.
+ * @param {{ failWith?: string }} [opts] Throw this message instead of serving.
+ */
+function makeDependenciesGh(edges, { failWith = null } = {}) {
+  const calls = [];
+  return {
+    calls,
+    api: async ({ endpoint }) => {
+      calls.push(endpoint);
+      if (failWith) throw new Error(failWith);
+      const params = new URL(endpoint, 'https://api.github.test').searchParams;
+      const page = Number(params.get('page') ?? 1);
+      const perPage = Number(params.get('per_page') ?? 30);
+      const slice = edges.slice((page - 1) * perPage, page * perPage);
+      return { stdout: JSON.stringify(slice), stderr: '', code: 0 };
+    },
+  };
+}
 
 function storyBody({
   changes = ['.agents/scripts/a.js'],
@@ -184,21 +213,28 @@ describe('nativeBlockedByNumbers — issue numbers, not database ids (run-breake
     assert.deepEqual(nativeBlockedByNumbers(data, REPO), [4530]);
   });
 
-  it('rejects a cross-repo blocker rather than matching its number locally', () => {
-    assert.throws(
-      () =>
-        nativeBlockedByNumbers(
-          [
-            {
-              id: 1,
-              number: 4530,
-              repository_url: 'https://api.github.com/repos/other/repo',
-            },
-          ],
-          REPO,
-        ),
-      /another repository/,
+  it('drops a cross-repo blocker rather than matching its number locally', () => {
+    // Matching another repo's #4530 against this repo's #4530 could satisfy a
+    // gate that is still open — so the edge is dropped, loudly, never mapped.
+    const warnings = [];
+    assert.deepEqual(
+      nativeBlockedByNumbers(
+        [
+          {
+            id: 1,
+            number: 4530,
+            repository_url: 'https://api.github.com/repos/other/repo',
+          },
+          { id: 2, number: 4531 },
+        ],
+        { ...REPO, warn: (m) => warnings.push(m) },
+      ),
+      [4531],
+      'the in-repo edge survives; only the unmatchable one is dropped',
     );
+    assert.equal(warnings.length, 1);
+    assert.match(warnings[0], /another repository/);
+    assert.match(warnings[0], /#4534/, 'the warning names the affected Story');
   });
 
   it('dedupes and tolerates a non-array payload', () => {
@@ -211,51 +247,123 @@ describe('nativeBlockedByNumbers — issue numbers, not database ids (run-breake
 });
 
 describe('readNativeBlockedBy — fails loud (run-breaker #3)', () => {
-  const parseJson = (r) => JSON.parse(r.stdout);
-
   it('returns the edges on success', async () => {
-    const gh = {
-      api: async () => ({ stdout: JSON.stringify([{ id: 9, number: 42 }]) }),
-    };
+    const gh = makeDependenciesGh([{ id: 9, number: 42 }]);
     assert.deepEqual(
-      await readNativeBlockedBy({ gh, ...REPO, parseJson }),
+      await readNativeBlockedBy({ gh, ...REPO, paginate: paginateRest }),
       [42],
     );
-  });
-
-  it('treats 404 as a legitimate empty result', async () => {
-    const gh = {
-      api: async () => {
-        throw new Error('HTTP 404: Not Found');
-      },
-    };
-    assert.deepEqual(await readNativeBlockedBy({ gh, ...REPO, parseJson }), []);
   });
 
   it('throws on 403 — a dropped edge would remove a real dispatch gate', async () => {
     // One 403 (dependencies API disabled, or a token missing the scope)
     // would otherwise erase EVERY native edge at once and co-dispatch the
     // whole run against unlanded blockers.
-    const gh = {
-      api: async () => {
-        throw new Error('HTTP 403: Resource not accessible by integration');
-      },
-    };
+    const gh = makeDependenciesGh([], {
+      failWith: 'HTTP 403: Resource not accessible by integration',
+    });
     await assert.rejects(
-      () => readNativeBlockedBy({ gh, ...REPO, parseJson }),
+      () => readNativeBlockedBy({ gh, ...REPO, paginate: paginateRest }),
       /Refusing to continue.*dispatch gate/s,
     );
   });
 
   it('throws on a 5xx rather than degrading to no edges', async () => {
-    const gh = {
-      api: async () => {
-        throw new Error('HTTP 502: Bad Gateway');
-      },
-    };
+    const gh = makeDependenciesGh([], { failWith: 'HTTP 502: Bad Gateway' });
     await assert.rejects(
-      () => readNativeBlockedBy({ gh, ...REPO, parseJson }),
+      () => readNativeBlockedBy({ gh, ...REPO, paginate: paginateRest }),
       /Could not read native blocked_by/,
+    );
+  });
+});
+
+describe('AC-2: a 404 on the native read is an auth failure, not "no edges"', () => {
+  // GitHub answers "this issue has no dependencies" with `200 []` — and
+  // answers "your token cannot see the dependencies API" with 404. Reading
+  // the second as the first erased every native edge in the run under a
+  // mis-scoped token, silently, with a clean exit code (Story #5046).
+  it('the read no longer resolves edge-free on 404 — it degrades loud, naming the story', async () => {
+    const gh = makeDependenciesGh([], { failWith: 'HTTP 404: Not Found' });
+    await assert.rejects(
+      () => readNativeBlockedBy({ gh, ...REPO, paginate: paginateRest }),
+      (err) => {
+        assert.match(
+          err.message,
+          new RegExp(`blocked_by edges for #${REPO.issueNumber}`),
+          'the failure names the story whose edges could not be read',
+        );
+        assert.match(
+          err.message,
+          /404 here is NOT "no dependencies"/,
+          'the failure explains why a 404 is not an empty result',
+        );
+        assert.match(err.message, /token's scopes/);
+        return true;
+      },
+    );
+  });
+
+  it('an issue that genuinely has no dependencies still resolves to no edges', async () => {
+    // The 200-empty path is what "no dependencies" looks like, so removing
+    // the 404 escape hatch costs nothing legitimate.
+    const gh = makeDependenciesGh([]);
+    assert.deepEqual(
+      await readNativeBlockedBy({ gh, ...REPO, paginate: paginateRest }),
+      [],
+    );
+  });
+});
+
+describe('AC-1: native reads are complete — the page walk runs to exhaustion', () => {
+  // The fake models GitHub's real default: a caller that does not ask for a
+  // page size gets 30 items. That default is exactly what the first-page-only
+  // read silently truncated against.
+  const manyEdges = Array.from({ length: 145 }, (_, i) => ({
+    id: 9000 + i,
+    number: 4000 + i,
+  }));
+
+  it('resolve-stories reads every edge of a 145-edge story, past the 30-item default', async () => {
+    const gh = makeDependenciesGh(manyEdges);
+    const numbers = await readNativeBlockedBy({
+      gh,
+      ...REPO,
+      paginate: paginateRest,
+    });
+    assert.equal(numbers.length, 145, 'no edge is dropped past the boundary');
+    assert.deepEqual(
+      numbers,
+      manyEdges.map((e) => e.number),
+      'every declared blocker is present, in order',
+    );
+    assert.ok(
+      numbers.includes(4144),
+      'the last edge — the one a first-page-only read loses — is a real gate',
+    );
+    assert.ok(gh.calls.length > 1, 'more than one page was requested');
+  });
+
+  it('a first-page-only read would have lost the tail — the fixture proves the defect is real', async () => {
+    // Same fixture, read the way the shipped code used to: one un-paged GET.
+    const gh = makeDependenciesGh(manyEdges);
+    const firstPageOnly = async (ghFacade, endpoint) => {
+      const result = await ghFacade.api({ method: 'GET', endpoint });
+      return JSON.parse(result.stdout);
+    };
+    const truncated = await readNativeBlockedBy({
+      gh,
+      ...REPO,
+      paginate: firstPageOnly,
+    });
+    assert.equal(
+      truncated.length,
+      30,
+      'the old read stopped at GitHub default',
+    );
+    assert.equal(
+      truncated.includes(4144),
+      false,
+      'and silently dropped a real dispatch gate',
     );
   });
 });
@@ -278,6 +386,168 @@ describe('storiesToDag — body and native edges union into one graph', () => {
     ];
     const dag = storiesToDag(stories);
     assert.deepEqual(dag[0].dependsOn, [4530]);
+  });
+});
+
+describe('AC-4: prose no longer mints dispatch gates — only the footer declares', () => {
+  // The live reproduction this Story shipped from: Story #5046's own body
+  // contained the phrase "blocked by #123" inside an acceptance criterion
+  // describing this very defect, and the unanchored whole-body scan minted it
+  // into a real dispatch edge (`resolve-stories --ids 5046` reported
+  // `dependsOn [123]`). A body is prose an operator writes; it must not gate
+  // dispatch by accident.
+  const prose = [
+    'Prose that merely MENTIONS a blocker declares nothing:',
+    'a body containing "blocked by #123" outside the footer block must',
+    'produce no dispatch edge. Nor may a sentence that depends on #456.',
+  ].join('\n');
+
+  it('a "blocked by #123" mention outside the footer produces no edge', () => {
+    const stories = [
+      toStoryRecord(issue({ body: `${storyBody()}\n\n${prose}` })),
+    ];
+    assert.deepEqual(
+      storiesToDag(stories)[0].dependsOn,
+      [],
+      'prose mentioning #123 and #456 declares neither as a gate',
+    );
+  });
+
+  it('the canonical footer form still declares a real gate', () => {
+    const stories = [
+      toStoryRecord(issue({ body: storyBody({ blockedBy: 777 }) })),
+    ];
+    assert.deepEqual(storiesToDag(stories)[0].dependsOn, [777]);
+  });
+
+  it('one body carrying both keeps only the footer edge', () => {
+    // The discriminator is position, not phrasing: the same words gate from
+    // inside the footer block and do not gate from outside it.
+    const stories = [
+      toStoryRecord(
+        issue({ body: `${storyBody({ blockedBy: 777 })}\n${prose}` }),
+      ),
+    ];
+    assert.deepEqual(storiesToDag(stories)[0].dependsOn, [777]);
+  });
+
+  it('a footer edge still unions with the native channel', () => {
+    // Semantics stay the UNION of native relations and body footers — the
+    // strict parse narrows the body channel, it does not replace it.
+    const stories = [
+      toStoryRecord(
+        issue({ body: `${storyBody({ blockedBy: 777 })}\n${prose}` }),
+      ),
+    ];
+    const dag = storiesToDag(stories, new Map([[101, [888]]]));
+    assert.deepEqual(
+      dag[0].dependsOn.sort((a, b) => a - b),
+      [777, 888],
+    );
+  });
+
+  it('end to end: the resolved envelope carries no prose edge', async () => {
+    const provider = {
+      getTicket: async (id) =>
+        id === 101 ? issue({ body: `${storyBody()}\n\n${prose}` }) : null,
+      _gh: makeDependenciesGh([]),
+    };
+    const chunks = [];
+    await runResolveStories(
+      { ids: '101', native: false },
+      {
+        provider,
+        config: { github: { owner: 'dsj1984', repo: 'mandrel' } },
+        stdout: { write: (s) => chunks.push(s) },
+      },
+    );
+    const envelope = JSON.parse(chunks.join(''));
+    assert.deepEqual(envelope.dag.find((n) => n.id === 101).dependsOn, []);
+    assert.deepEqual(envelope.done, [], 'no phantom blocker to resolve either');
+  });
+});
+
+describe('AC-3: a cross-repo edge degrades its own Story, never the whole set', () => {
+  // It used to throw out of the per-Story read and take the entire resolution
+  // down: one Story's unsupported edge meant no sibling resolved at all.
+  const CROSS_REPO = {
+    id: 1,
+    number: 4530,
+    repository_url: 'https://api.github.com/repos/other/repo',
+  };
+
+  function providerServing(byIssue) {
+    return {
+      _gh: {
+        api: async ({ endpoint }) => {
+          const issueNumber = Number(endpoint.match(/\/issues\/(\d+)\//)[1]);
+          const params = new URL(endpoint, 'https://api.github.test')
+            .searchParams;
+          const page = Number(params.get('page') ?? 1);
+          const perPage = Number(params.get('per_page') ?? 30);
+          const all = byIssue[issueNumber] ?? [];
+          return {
+            stdout: JSON.stringify(
+              all.slice((page - 1) * perPage, page * perPage),
+            ),
+            stderr: '',
+            code: 0,
+          };
+        },
+      },
+    };
+  }
+
+  it('the carrier loses only the unmatchable edge; its siblings resolve intact', async () => {
+    const warnings = [];
+    const edges = await readNativeEdges({
+      provider: providerServing({
+        101: [CROSS_REPO, { id: 2, number: 4531 }],
+        102: [{ id: 3, number: 4532 }],
+        103: [],
+      }),
+      stories: [{ id: 101 }, { id: 102 }, { id: 103 }],
+      owner: 'dsj1984',
+      repo: 'mandrel',
+      paginate: paginateRest,
+      warn: (m) => warnings.push(m),
+    });
+
+    assert.deepEqual(
+      edges.get(101),
+      [4531],
+      'the carrier keeps every edge this repo can match',
+    );
+    assert.deepEqual(edges.get(102), [4532], 'a sibling resolves untouched');
+    assert.deepEqual(edges.get(103), [], 'and so does an edge-free sibling');
+    assert.equal(warnings.length, 1, 'exactly one Story degraded');
+    assert.match(warnings[0], /#101/, 'the warning names the degraded Story');
+    assert.match(warnings[0], /DROPPED for #101 only/);
+  });
+
+  it('a hard read failure on one Story still fails the run — a lost gate is not degradable', async () => {
+    // The contrast that keeps the degrade honest: an unmatchable cross-repo
+    // edge is a KNOWN edge we decline to map, while an unreadable channel is
+    // an UNKNOWN edge set. Only the first is safe to continue past.
+    const provider = {
+      _gh: {
+        api: async () => {
+          throw new Error('HTTP 403: Resource not accessible by integration');
+        },
+      },
+    };
+    await assert.rejects(
+      () =>
+        readNativeEdges({
+          provider,
+          stories: [{ id: 101 }],
+          owner: 'dsj1984',
+          repo: 'mandrel',
+          paginate: paginateRest,
+          warn: () => {},
+        }),
+      /Refusing to continue/,
+    );
   });
 });
 

--- a/tests/scripts/story-adjacency.test.js
+++ b/tests/scripts/story-adjacency.test.js
@@ -39,7 +39,9 @@ function ticketStories() {
       id: 102,
       labels: ['type::story'],
       state: 'open',
-      body: 'Blocked by #101.',
+      // Footer-scoped edge (Story #5046): prose mentioning a blocker
+      // declares nothing — only a `blocked by #N` line in the `---` footer.
+      body: 'Story 102.\n\n---\nblocked by #101',
     },
     {
       id: 103,
@@ -52,14 +54,14 @@ function ticketStories() {
       id: 104,
       labels: ['type::story'],
       state: 'open',
-      body: 'Blocked by #102.',
+      body: 'Story 104.\n\n---\nblocked by #102',
       dependencies: [103],
     },
     {
       id: 105,
       labels: ['type::story'],
       state: 'open',
-      body: 'Depends on #104.',
+      body: 'Story 105.\n\n---\nblocked by #104',
     },
     { id: 106, labels: ['type::story'], state: 'open', body: 'Isolated.' },
   ];
@@ -84,7 +86,7 @@ describe('lib/story-adjacency — buildStoryAdjacency', () => {
   it('merges body blocked-by refs with explicit dependencies, deduped', () => {
     const adjacency = buildStoryAdjacency([
       { id: 1, body: '' },
-      { id: 2, body: 'blocked by #1', dependencies: [1] },
+      { id: 2, body: '---\nblocked by #1', dependencies: [1] },
     ]);
     assert.deepEqual(adjacency.get(2), [1]);
   });
@@ -92,7 +94,7 @@ describe('lib/story-adjacency — buildStoryAdjacency', () => {
   it('drops self-edges and foreign ids when dropForeign is true', () => {
     const adjacency = buildStoryAdjacency(
       [
-        { id: 1, body: 'blocked by #1', dependencies: [99] },
+        { id: 1, body: '---\nblocked by #1', dependencies: [99] },
         { id: 2, dependencies: [1, 2, 500] },
       ],
       { dropForeign: true },


### PR DESCRIPTION
Closes #5046

_Auto-opened by `/deliver`._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes orchestration dispatch gates and parsing semantics (footer-only body edges, stricter native reads); behavior is intentional and heavily tested but mis-scoped tokens or hand-written prose edges will surface differently in production.
> 
> **Overview**
> Makes **Story dispatch gating** depend only on edges the resolver can read reliably, fixing false gates and silent edge loss from Story #5046.
> 
> **Footer-scoped body edges:** `parseBlockedBy` no longer scans the whole issue body for `blocked by` / `depends on`. Only a standalone `blocked by #N` line inside the `---` footer counts; prose mentions and loose spellings declare nothing. Grammar lives in new `lib/story-body/footer-block.js`, shared with the body parser so `depends_on` and dispatch stay aligned. **User-visible:** hand-written prose edges stop gating until moved into the footer.
> 
> **Native `blocked_by` reads:** Resolution and `blocked-by-add` idempotency checks **paginate to exhaustion** (first-page reads could drop gates past GitHub’s default page size). **404 is no longer treated as “no dependencies”** — resolution fails with guidance on token scopes/API access. **Cross-repo native edges** are dropped with a per-Story warning instead of aborting the entire resolve.
> 
> **DAG build:** `storiesToDag` unions footer + native edges once and passes only `{ id, dependsOn }` into adjacency so the builder cannot re-parse the body differently.
> 
> Docs in `deliver-story-reference.md` describe the two channels, monotone edge retraction, and failure modes. Tests and coverage baselines updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f9f8ae3be5f8b17b4d015e1ba4faf85b61d42022. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->