### PR TITLE
feat: plan: stamp only the provenance a Story owns, and run cross-Story conflict analysis over the bodies persist actually writes (#5045)

### DIFF
--- a/.agents/scripts/lib/findings/provenance-field.js
+++ b/.agents/scripts/lib/findings/provenance-field.js
@@ -1,0 +1,135 @@
+/**
+ * lib/findings/provenance-field.js — the per-Story `provenance` field.
+ *
+ * An audit-seeded plan carries dedup identities forward so the next sweep
+ * recognises what it already planned. The optional top-level `provenance`
+ * field on a `stories.json` entry says **which of them that Story owns**:
+ *
+ * ```jsonc
+ * { "fingerprints": ["<40-char sha1>"], "semanticKeys": ["architecture␟lib/a.js"] }
+ * ```
+ *
+ * Two callers, deliberately split from
+ * [`route-finding.js`](route-finding.js): the ticket validator shape-checks
+ * the authored field, and plan-persist's assembly renders the owned identities
+ * into the footer source it stamps. Neither is dedup *routing*, which is what
+ * `route-finding.js` is for — this module reads its identity vocabulary
+ * (`SHA1_RE`, `SEMANTIC_KEY_RE`, and the two footer renderers) from there so
+ * there is exactly one definition of what a fingerprint or a semantic key
+ * looks like.
+ *
+ * @module lib/findings/provenance-field
+ */
+
+import {
+  fingerprintFooter,
+  SEMANTIC_KEY_RE,
+  SHA1_RE,
+  semanticKeyFooter,
+} from './route-finding.js';
+
+/** Human-readable rendering of the `provenance` field's two lists. */
+const PROVENANCE_SHAPE = 'fingerprints[] / semanticKeys[]';
+
+/** What each `provenance` list accepts, and how to say so when it does not. */
+const PROVENANCE_FIELDS = Object.freeze({
+  fingerprints: { pattern: SHA1_RE, expected: 'a 40-char sha1 hex string' },
+  semanticKeys: {
+    pattern: SEMANTIC_KEY_RE,
+    expected: 'a non-empty key carrying no comma or ">"',
+  },
+});
+
+/**
+ * Validate one authored `provenance` list into its normalized form.
+ *
+ * @param {unknown} list
+ * @param {{ where: string, field: string, pattern: RegExp, expected: string }} spec
+ * @returns {string[]} Trimmed, de-duplicated, first-seen order.
+ */
+function normalizeList(list, { where, field, pattern, expected }) {
+  if (list === null || list === undefined) return [];
+  if (!Array.isArray(list)) {
+    throw new Error(`${where}: ${field} must be an array of strings`);
+  }
+  const out = [];
+  for (const entry of list) {
+    const value = typeof entry === 'string' ? entry.trim() : '';
+    if (!pattern.test(value)) {
+      throw new Error(
+        `${where}: ${field} entry ${JSON.stringify(entry)} is not ${expected}`,
+      );
+    }
+    if (!out.includes(value)) out.push(value);
+  }
+  return out;
+}
+
+/**
+ * Normalize the optional per-Story `provenance` field a plan may author —
+ * the identities of the findings **that Story owns**.
+ *
+ * Absence is meaningful and must stay cheap: `undefined` / `null` returns
+ * `null`, which is the caller's signal to fall back to the whole-seed union
+ * carry. That fallback is not vestigial — leaving the authoring agent to
+ * hand-carry provenance out of the seed's HTML comments was measured to fail,
+ * and the mechanical union is what closed it. Attribution is **additive**: a
+ * plan that attributes gets exact stamping, a plan that does not keeps recall.
+ *
+ * An empty object is therefore *not* the same as an absent field: it means
+ * "this Story owns nothing", and stamps nothing.
+ *
+ * Present-but-malformed is a hard error rather than a silent drop, because a
+ * dropped identity is invisible until the next sweep re-files work that was
+ * already planned.
+ *
+ * @param {unknown} raw
+ * @param {string} [label] Identifier for the error message (a Story slug).
+ * @returns {{ fingerprints: string[], semanticKeys: string[] }|null}
+ * @throws {Error} On any shape the stamper cannot honour exactly.
+ */
+export function normalizeOwnedProvenance(raw, label = 'story') {
+  if (raw === undefined || raw === null) return null;
+  const where = `provenance on "${label}"`;
+  if (typeof raw !== 'object' || Array.isArray(raw)) {
+    throw new Error(`${where} must be an object of ${PROVENANCE_SHAPE}`);
+  }
+  const out = { fingerprints: [], semanticKeys: [] };
+  for (const [field, list] of Object.entries(raw)) {
+    const spec = PROVENANCE_FIELDS[field];
+    if (!spec) {
+      throw new Error(
+        `${where} carries an unknown field: ${field} — only ${PROVENANCE_SHAPE} are stamped`,
+      );
+    }
+    out[field] = normalizeList(list, { where, field, ...spec });
+  }
+  return out;
+}
+
+/**
+ * Render the provenance **source document** for a set of owned identities, in
+ * the same footer vocabulary `carryProvenanceFooters` harvests from an audit
+ * seed. That reuse is the point: attribution changes *which* identities reach
+ * a Story body, never how they are stamped, so the carry stays additive,
+ * union-preserving and idempotent for an attributed plan exactly as it is for
+ * an un-attributed one.
+ *
+ * An empty (or absent) set renders the empty string, which the carry treats as
+ * nothing-to-do — so a Story that owns no findings is stamped with none rather
+ * than inheriting its siblings'.
+ *
+ * Expects the normalized shape {@link normalizeOwnedProvenance} returns; the
+ * validator runs first on every production path.
+ *
+ * @param {{ fingerprints?: string[], semanticKeys?: string[] }|null} [provenance]
+ * @returns {string}
+ */
+export function ownedProvenanceSource(provenance) {
+  const shas = provenance?.fingerprints ?? [];
+  const keys = provenance?.semanticKeys ?? [];
+  const parts = [];
+  if (shas.length > 0) parts.push(fingerprintFooter(shas));
+  if (keys.length > 0) parts.push(semanticKeyFooter(keys));
+  return parts.join('\n');
+}

--- a/.agents/scripts/lib/findings/route-finding.js
+++ b/.agents/scripts/lib/findings/route-finding.js
@@ -35,11 +35,11 @@ import { fingerprintSeverity } from './severity.js';
 const SEP = '␟'; // unit separator — keeps fingerprint fields unambiguous
 const MARKER = 'audit-fingerprints:';
 const SEMANTIC_MARKER = 'audit-semantic-keys:';
-const SHA1_RE = /^[0-9a-f]{40}$/;
+export const SHA1_RE = /^[0-9a-f]{40}$/;
 // A semantic key round-trips through a comma-joined footer, so it must not
 // carry a comma or a `>` (which would truncate the HTML comment). Both are
 // stripped when the key is built, so this guard is defence-in-depth.
-const SEMANTIC_KEY_RE = /^[^,>]+$/;
+export const SEMANTIC_KEY_RE = /^[^,>]+$/;
 
 /**
  * Normalise a single scalar identity field to a stable string.
@@ -344,11 +344,58 @@ function decisionForIssue(issue) {
 }
 
 /**
+ * Resolve the pool that **attributes** a finding, out of everything that
+ * confirmed it (Story #5045).
+ *
+ * Confirmation admits two different strengths of claim, and collapsing them
+ * was the source of two wrong routes:
+ *
+ * - An issue carrying the finding's exact **fingerprint** owns it. That is
+ *   identity: this issue tracks *this* finding.
+ * - An issue matching only on the location-based **semantic key** is merely
+ *   adjacent: it tracks *a* finding at the same `area␟primaryFile`.
+ *
+ * Owners win outright when any exist. Location-only matches are not discarded
+ * — they are the whole point of the semantic key and remain the pool when
+ * nothing carries the fingerprint (a reworded finding at an unchanged
+ * location). The pool is sorted by issue number so a genuine tie resolves to
+ * the earliest-filed issue rather than to whatever order the search port
+ * happened to return.
+ *
+ * @param {Array<{ number: number, state: string, body?: string }>} confirmed
+ * @param {string} sha
+ * @returns {Array<{ number: number, state: string }>}
+ */
+function attributedPool(confirmed, sha) {
+  const owns = (issue) => issueCarriesFingerprint(issue, sha);
+  const owners = confirmed.filter(owns);
+  const pool = owners.length > 0 ? owners : confirmed.filter((i) => !owns(i));
+  return [...pool].sort((a, b) => (a?.number ?? 0) - (b?.number ?? 0));
+}
+
+/**
  * Decide the final route from a confirmed-match pool (issues that both
- * surfaced in the candidate/search pass AND carry the finding's fingerprint
- * in their footer). Shared by both the semantic-first and fingerprint-only
- * code paths so the decision enum is identical regardless of how candidates
- * were gathered.
+ * surfaced in the candidate/search pass AND carry a confirming footer).
+ * Shared by both the semantic-first and fingerprint-only code paths so the
+ * decision enum is identical regardless of how candidates were gathered.
+ *
+ * **Attribution decides, not array order (Story #5045).** The pool used to be
+ * read flat, which produced two wrong answers whenever more than one issue
+ * confirmed:
+ *
+ *   1. Two open matches routed `duplicate` pinned to `open[0]` — whichever
+ *    issue the search port happened to return first. With per-Story
+ *    provenance that pick is answerable rather than arbitrary: the issue
+ *    carrying the finding's own fingerprint owns it, and a sibling matching
+ *    only by location does not.
+ *   2. Any open match at all masked a closed one, so a finding whose
+ *    fingerprint is owned by a **closed** Story routed `update-existing`
+ *    against an open neighbour — a genuine regression filed as a
+ *    business-as-usual update. Attribution restores it: state is read off the
+ *    owning issue, not off whatever else shares its location.
+ *
+ * {@link attributedPool} owns that selection; the decision below reads only
+ * the pool it returns.
  *
  * @param {Array<{ number: number, state: string }>} confirmed
  * @param {string} sha
@@ -359,7 +406,8 @@ function decideFromConfirmed(confirmed, sha) {
     return { decision: 'new', matchedIssue: null, fingerprint: sha };
   }
 
-  const open = confirmed.filter((h) => normaliseField(h.state) === 'open');
+  const attributed = attributedPool(confirmed, sha);
+  const open = attributed.filter((h) => normaliseField(h.state) === 'open');
   if (open.length > 1) {
     return { decision: 'duplicate', matchedIssue: open[0], fingerprint: sha };
   }
@@ -371,7 +419,7 @@ function decideFromConfirmed(confirmed, sha) {
     };
   }
 
-  const closed = confirmed[0];
+  const closed = attributed[0];
   return {
     decision: decisionForIssue(closed),
     matchedIssue: closed,
@@ -484,4 +532,5 @@ export const __testing = {
   decideFromConfirmed,
   issueCarriesSemanticKey,
   parseSemanticKeyFooter,
+  attributedPool,
 };

--- a/.agents/scripts/lib/orchestration/plan-persist/run-plan-persist.js
+++ b/.agents/scripts/lib/orchestration/plan-persist/run-plan-persist.js
@@ -62,6 +62,11 @@ import {
   evaluateDraftReachability,
   renderReachabilityOrphans,
 } from '../plan-reachability.js';
+import {
+  computeAssembledConflictFindings,
+  conflictFindingKey,
+  renderHardConflictError,
+} from '../ticket-validator-conflicts.js';
 import { upsertStructuredComment } from '../ticketing.js';
 import {
   enforceFanOutGate,
@@ -374,6 +379,50 @@ function resolveEffectiveRoute({
     authored: verdict.authored,
     shape: perStory,
   };
+}
+
+/**
+ * Re-run the cross-Story conflict passes over the assembled bodies and route
+ * the result (Story #5045).
+ *
+ * `validateTickets` runs before assembly, over the raw payload, so until now
+ * plan-time conflict analysis judged an artifact that is not the one persist
+ * writes — and the passes that scan `body.acceptance` / `body.verify` were
+ * inert on the canonical top-level authoring shape as a result.
+ *
+ * Three outcomes, in order:
+ *
+ * 1. **Hard findings throw.** Policy upgrades (`planning.failOnSharedEditors`,
+ *    `planning.requireExplicitCrossStoryDeps`) are off by default; when an
+ *    operator turns one on it must bite on the persisted artifact too, and it
+ *    must bite **before** the first `createIssue`.
+ * 2. **Soft findings the raw pass already reported are dropped**, so the same
+ *    collision is not announced twice per run.
+ * 3. **Everything else is returned** for the plan-summary comment, which is
+ *    where these findings stop being a stderr line nobody keeps.
+ *
+ * @param {{ stories: object[], config: object, rawFindings: object[] }} args
+ * @returns {object[]} The assembled-pass findings, for the summary comment.
+ */
+function analyzeAssembledStories({ stories, config, rawFindings }) {
+  const findings = computeAssembledConflictFindings({ stories, config });
+  const hard = findings.filter((finding) => finding.severity === 'hard');
+  if (hard.length > 0) {
+    throw new Error(
+      `[plan-persist] ${hard.length} cross-Story conflict(s) in the assembled ` +
+        `Story bodies:\n${hard.map((f) => `  - ${renderHardConflictError(f)}`).join('\n')}`,
+    );
+  }
+  const alreadyReported = new Set(
+    (rawFindings ?? []).map((finding) => conflictFindingKey(finding)),
+  );
+  surfaceSoftConflictFindings(
+    findings.filter(
+      (finding) => !alreadyReported.has(conflictFindingKey(finding)),
+    ),
+    'plan-persist/assembled',
+  );
+  return findings;
 }
 
 /**
@@ -702,12 +751,23 @@ export async function runPlanPersist({
     sharedSpec: techSpecContent,
     planAcceptance: planAcceptance ?? undefined,
     sourceTicketIds,
-    // The seed this plan was authored from is the provenance source: an audit
-    // sweep's Single-plan seed carries the `audit-fingerprints` /
-    // `audit-semantic-keys` footers, which assembly copies into every persisted
-    // Story body so the next sweep recognises what it already planned
-    // (Story #4877). Empty for a `--tickets` run, which is a no-op.
+    // The seed this plan was authored from: an audit sweep's Single-plan seed
+    // carries the `audit-fingerprints` / `audit-semantic-keys` footers, and
+    // assembly copies them into the persisted Story bodies so the next sweep
+    // recognises what it already planned (Story #4877). Since Story #5045 this
+    // is the **fallback** — it is carried onto every Story that did not
+    // attribute its own `provenance`, which keeps an un-attributed plan exactly
+    // as recall-safe as it was. Empty for a `--tickets` run, a no-op there.
     provenanceSource: planContextEnvelope?.seed?.content ?? '',
+  });
+
+  // Story #5045: the cross-Story conflict passes re-run over the assembled,
+  // footer-stamped bodies — the artifact persist actually writes — before any
+  // GitHub call, so a policy upgrade still refuses the plan pre-creation.
+  const assembledConflicts = analyzeAssembledStories({
+    stories,
+    config,
+    rawFindings: validated.findings,
   });
 
   // Effective complexity route (Story #4722): the planner's authored lite
@@ -764,6 +824,10 @@ export async function runPlanPersist({
     mode: 'stories',
     planMetricsLine,
     stories: created,
+    // Story #5045: the wave table promises what can run in parallel; the
+    // collisions the conflict passes found belong on the same surface, or the
+    // promise is the only half anyone reads.
+    conflictFindings: assembledConflicts,
   });
 
   if (!dryRun) {

--- a/.agents/scripts/lib/orchestration/plan-persist/story-ops.js
+++ b/.agents/scripts/lib/orchestration/plan-persist/story-ops.js
@@ -17,6 +17,10 @@
 
 import { createHash } from 'node:crypto';
 import { applyBlockedByDependencies } from '../../../providers/github/blocked-by-add.js';
+import {
+  normalizeOwnedProvenance,
+  ownedProvenanceSource,
+} from '../../findings/provenance-field.js';
 import { carryProvenanceFooters } from '../../findings/route-finding.js';
 import { Logger } from '../../Logger.js';
 import { AGENT_LABELS, TYPE_LABELS } from '../../label-constants.js';
@@ -319,8 +323,12 @@ function syncContractFieldFromTopLevel(ticket, bodyObject, field) {
  * bookkeeping for the `--tickets` source issues, not part of the Story's
  * executable body, so it is deliberately not serialized into the markdown.
  *
+ * `provenance` is likewise top-level-only (Story #5045) — it names the audit
+ * identities *this* Story owns, and is stamped into the body as footers rather
+ * than serialized as a section.
+ *
  * @param {object} ticket
- * @returns {{ slug: string, title: string, bodyObject: object, depends_on: string[], labels: string[], supersedes: Array<{ id: number, note: string|null }> }}
+ * @returns {{ slug: string, title: string, bodyObject: object, depends_on: string[], labels: string[], supersedes: Array<{ id: number, note: string|null }>, provenance: { fingerprints: string[], semanticKeys: string[] }|null }}
  */
 export function normalizeStoryTicket(ticket) {
   if (!ticket || typeof ticket !== 'object') {
@@ -345,8 +353,22 @@ export function normalizeStoryTicket(ticket) {
   const depends_on = normalizeDependsOn(ticket, bodyObject);
   const supersedes = normalizeSupersedes(ticket, slug);
   const labels = sanitizeAuthoredLabels(ticket.labels, slug);
+  let provenance;
+  try {
+    provenance = normalizeOwnedProvenance(ticket.provenance, slug);
+  } catch (err) {
+    throw new Error(`[plan-persist] ${err.message}`);
+  }
 
-  return { slug, title, bodyObject, depends_on, labels, supersedes };
+  return {
+    slug,
+    title,
+    bodyObject,
+    depends_on,
+    labels,
+    supersedes,
+    provenance,
+  };
 }
 
 /**
@@ -388,24 +410,59 @@ export function foldSpecIntoStoryBody(bodyObject, slug, opts = {}) {
   return { bodyObject: next };
 }
 
+/**
+ * Resolve the provenance source one Story is stamped from (Story #5045).
+ *
+ * Two channels, and the precedence between them is the whole contract:
+ *
+ * - **Attributed** — the Story authored a `provenance` field naming the audit
+ *   identities *it* owns. Exactly those are stamped. This is what makes the
+ *   footers answer "which Story tracks this finding?" instead of "which sweep
+ *   planned it?": under the union every sibling carried every key, so the next
+ *   sweep's confirmation pass could only pick an arbitrary open Story, and a
+ *   key whose owner had since closed was masked by any open neighbour.
+ * - **Union fallback** — no `provenance` field, so the whole seed's footers are
+ *   carried, exactly as before. This is **not** dead weight to be tidied away:
+ *   hand-carried provenance is the failure Stories #4626 / #4877 measured, and
+ *   the union is what closed it. Attribution is additive and recall-safe;
+ *   deleting the fallback would re-open that hole for every plan that does not
+ *   attribute.
+ *
+ * @param {{ fingerprints: string[], semanticKeys: string[] }|null} provenance
+ * @param {object} opts Assembly options carrying `provenanceSource`.
+ * @returns {string}
+ */
+function resolveProvenanceSource(provenance, opts) {
+  if (provenance !== null) return ownedProvenanceSource(provenance);
+  return opts.provenanceSource ?? '';
+}
+
 function assembleOnePlanStory(ticket, opts) {
-  const { slug, title, bodyObject, depends_on, labels, supersedes } =
-    normalizeStoryTicket(ticket);
+  const {
+    slug,
+    title,
+    bodyObject,
+    depends_on,
+    labels,
+    supersedes,
+    provenance,
+  } = normalizeStoryTicket(ticket);
   const { bodyObject: folded } = foldSpecIntoStoryBody(bodyObject, slug, {
     sharedSpec: opts.sharedSpec ?? null,
   });
   // Body first: the fingerprint is an identity over the *assembled* content,
   // so it cannot be computed until that content exists.
   const serialized = serializeStoryBody({ ...folded, depends_on });
-  // Carry audit dedup provenance out of the seed this plan was authored from
-  // (Story #4877). The audit sweep's Single-plan path stamps the
-  // `audit-fingerprints` / `audit-semantic-keys` footers into the seed it hands
-  // `/plan`; without this the persisted Story carries no provenance and the
-  // next sweep re-files work it already planned. Mechanical on purpose — the
-  // authoring agent is not asked to notice HTML comments in a one-pager. A
-  // non-audit seed carries no footers, so this is a no-op there.
+  // Carry audit dedup provenance into the persisted body (Story #4877). The
+  // audit sweep's Single-plan path stamps the `audit-fingerprints` /
+  // `audit-semantic-keys` footers into the seed it hands `/plan`; without this
+  // the persisted Story carries no provenance and the next sweep re-files work
+  // it already planned. Mechanical on purpose — the authoring agent is not
+  // asked to notice HTML comments in a one-pager. A non-audit seed carries no
+  // footers, so this is a no-op there. Which identities reach *this* Story is
+  // `resolveProvenanceSource`'s call (Story #5045).
   const { body } = carryProvenanceFooters({
-    from: opts.provenanceSource ?? '',
+    from: resolveProvenanceSource(provenance, opts),
     into: serialized,
   });
   const fingerprint = planStoryFingerprint({ slug, title, body });

--- a/.agents/scripts/lib/orchestration/plan-persist/summary.js
+++ b/.agents/scripts/lib/orchestration/plan-persist/summary.js
@@ -66,6 +66,53 @@ function renderWaveTableLines(waveTable) {
 }
 
 /**
+ * Render the shared-editor collisions beside the wave table (Story #5045).
+ *
+ * The wave table is a promise about parallelism — "these Stories can run
+ * together". `computeSharedEditorFindings` knows exactly where that promise
+ * breaks down: a path two same-wave Stories both write will conflict on every
+ * merge after the first. Until now those findings degraded to a `Logger.warn`
+ * on stderr and were discarded, so the comment carried the optimistic half of
+ * the analysis and none of the caveat. Rendering them here puts the promise
+ * and its known exceptions on one durable surface.
+ *
+ * Advisory by default and labelled as such — `planning.failOnSharedEditors`
+ * is the knob that makes a collision refuse the plan, and it stays off.
+ *
+ * @param {object[]|null} conflictFindings
+ * @returns {string[]} Lines to splice after the wave table, or `[]`.
+ */
+function renderSharedEditorLines(conflictFindings) {
+  const shared = (
+    Array.isArray(conflictFindings) ? conflictFindings : []
+  ).filter((finding) => finding?.kind === 'shared-editor');
+  if (shared.length === 0) return [];
+  const rows = shared
+    .slice()
+    .sort((a, b) => String(a.path).localeCompare(String(b.path)))
+    .map(
+      (finding) =>
+        `| \`${finding.path}\` | ${(finding.storySlugs ?? [])
+          .map((slug) => `\`${slug}\``)
+          .join(', ')} |`,
+    );
+  return [
+    '',
+    `#### ⚠️ Known collisions (${shared.length} shared file(s))`,
+    '',
+    '| Path | Stories in the same order |',
+    '| --- | --- |',
+    ...rows,
+    '',
+    '_These Stories are scheduled to run together **and** write the same ' +
+      'file — expect a merge conflict on every landing after the first. Add a ' +
+      '`depends_on` edge to serialize them, or move the shared edit into one ' +
+      'Story. Advisory: `planning.failOnSharedEditors` turns this into a ' +
+      'refusal and is off by default._',
+  ];
+}
+
+/**
  * Build the `plan-summary` structured-comment body.
  *
  * @param {object} input
@@ -81,6 +128,7 @@ export function buildPlanSummaryCommentBody({
   mode = 'stories',
   planMetricsLine = null,
   stories = null,
+  conflictFindings = null,
   // legacy unused knobs kept so older test call sites don't crash mid-migration
   single = null,
   amend = null,
@@ -132,6 +180,7 @@ export function buildPlanSummaryCommentBody({
     '#### Delivery order (`depends_on`)',
     '',
     ...renderWaveTableLines(waveTable),
+    ...renderSharedEditorLines(conflictFindings),
     '',
     `_Deliver with \`${deliverCommand}\` — \`/deliver\` resolves the dependency graph from live state, so edges may point at Stories from earlier plan runs._`,
   ].join('\n');

--- a/.agents/scripts/lib/orchestration/ticket-validator-conflicts.js
+++ b/.agents/scripts/lib/orchestration/ticket-validator-conflicts.js
@@ -763,6 +763,79 @@ export function computeConflictFindings({ stories, policy } = {}) {
 }
 
 /**
+ * Re-run the cross-Story conflict passes over the **assembled** Story bodies —
+ * the artifact persist actually writes (Story #5045).
+ *
+ * `validateTickets` runs before `assemblePlanStories`, over the raw
+ * `stories.json` payload, so plan-time conflict analysis never saw what got
+ * persisted. That is not a cosmetic ordering nit: the canonical authoring shape
+ * carries `acceptance[]` / `verify[]` at the ticket's **top level**, and it is
+ * assembly's `syncContractFieldFromTopLevel` that folds them into the body.
+ * `indexConsumers` scans `body.acceptance` / `body.verify` for producer paths —
+ * so on the real payload it scanned two empty arrays, and every
+ * `implicit-cross-story-dep` and `missing-bdd-scaffold` finding was silently
+ * unreachable. Running the passes again over the serialized bodies restores
+ * them.
+ *
+ * **The fan-out pass is deliberately not re-run.** It is a `git grep` per
+ * deleted path and its inputs (`changes[]` deletes) are identical on both
+ * sides, so re-probing would double the git cost for a byte-identical answer;
+ * `enforceFanOutGate` already owns that class over the raw payload.
+ *
+ * @param {object} args
+ * @param {Array<{ slug: string, title?: string, body: string, depends_on?: string[] }>} args.stories
+ *   Assembled Stories — `body` is the serialized, footer-stamped markdown.
+ * @param {object} [args.config] Resolved config; `planning.*` supplies the
+ *   severity policy (the same keys `persist-helpers.resolveConflictPolicy`
+ *   reads, minus the fan-out half this pass does not run).
+ * @returns {ConflictFinding[]}
+ */
+export function computeAssembledConflictFindings({ stories, config } = {}) {
+  const planning = config?.planning;
+  return computeConflictFindings({
+    stories: (Array.isArray(stories) ? stories : []).map((story) => ({
+      slug: story.slug,
+      title: story.title,
+      body: story.body,
+      depends_on: Array.isArray(story.depends_on) ? story.depends_on : [],
+    })),
+    policy: {
+      failOnSharedEditors: planning?.failOnSharedEditors === true,
+      requireExplicitCrossStoryDeps:
+        planning?.requireExplicitCrossStoryDeps === true,
+      failOnRegistryConflicts: planning?.failOnRegistryConflicts === true,
+      failOnMissingBddScaffold: planning?.failOnMissingBddScaffold === true,
+      fanOutCounter: null,
+    },
+  });
+}
+
+/**
+ * Stable identity for one conflict finding, so the post-assembly pass can be
+ * diffed against the raw pass and only the genuinely-new findings reported
+ * (Story #5045). Without it the two passes announce the same shared-editor
+ * collision twice per run, which is how a warning channel gets discounted.
+ *
+ * The separator is written as the `\u0000` escape and never as a raw byte — a
+ * literal NUL would make git classify this file as binary and drop its diffs.
+ *
+ * @param {object} finding
+ * @returns {string}
+ */
+export function conflictFindingKey(finding) {
+  return [
+    finding?.kind ?? '',
+    finding?.path ?? finding?.registryPath ?? '',
+    Array.isArray(finding?.storySlugs)
+      ? [...finding.storySlugs].sort().join(',')
+      : (finding?.storySlug ?? ''),
+    finding?.producer?.storySlug ?? '',
+    finding?.consumer?.storySlug ?? '',
+    finding?.consumer?.sourceField ?? '',
+  ].join('\u0000');
+}
+
+/**
  * Render the audit trail behind a fan-out finding's number, so an operator
  * can check the figure rather than trust it (Story #4547).
  *

--- a/.agents/scripts/lib/orchestration/ticket-validator.js
+++ b/.agents/scripts/lib/orchestration/ticket-validator.js
@@ -1,4 +1,5 @@
 import { ValidationError } from '../errors/index.js';
+import { normalizeOwnedProvenance } from '../findings/provenance-field.js';
 import { detectCycle } from '../Graph.js';
 import { gitSpawn } from '../git-utils.js';
 
@@ -528,6 +529,41 @@ function assertEveryStoryHasInlineContract({ stories }) {
   );
 }
 
+/**
+ * Shape-check the optional per-Story `provenance` field (Story #5045).
+ *
+ * The field decides which audit identities persist stamps into a Story body,
+ * so a malformed entry has to fail at the validator rather than at the
+ * stamper: by the time assembly runs, an unnoticed drop is indistinguishable
+ * from a Story that legitimately owns nothing — and the cost lands a whole
+ * sweep later, when the next audit re-files work this plan already tracked.
+ *
+ * Absence is valid and common: a Story with no `provenance` inherits the
+ * whole-seed union carry, which is the recall-safe default.
+ *
+ * Errors are batched across the backlog so one pass names every offender.
+ *
+ * @param {{ stories: object[] }} args
+ * @throws {Error} naming each malformed field.
+ */
+function assertStoryProvenanceShape({ stories }) {
+  const violations = [];
+  for (const story of stories) {
+    try {
+      normalizeOwnedProvenance(story?.provenance, story?.slug ?? '<unknown>');
+    } catch (err) {
+      violations.push(`  - ${err.message}`);
+    }
+  }
+  if (violations.length === 0) return;
+  throw new Error(
+    `Cross-Validation Failed: ${violations.length} Story provenance field(s) ` +
+      `are malformed:\n${violations.join('\n')}\n\nAuthor provenance as ` +
+      '{ "fingerprints": ["<40-char sha1>"], "semanticKeys": ["<area␟path>"] }, ' +
+      'or omit it entirely to inherit the seed-wide union.',
+  );
+}
+
 function assertNoUnknownDeps({ tickets, ticketBySlug }) {
   const unknownDeps = [];
   for (const t of tickets) {
@@ -575,6 +611,7 @@ export function validateAndNormalizeTickets(tickets, opts = {}) {
 
   assertAllTicketsAreStories({ tickets, stories });
   assertEveryStoryHasInlineContract({ stories });
+  assertStoryProvenanceShape({ stories });
   assertNoUnknownDeps({ tickets, ticketBySlug });
 
   assertAcyclic(slugAdjacency);
@@ -704,6 +741,7 @@ export const _internal = {
   indexTicketsBySlug,
   assertAllTicketsAreStories,
   assertEveryStoryHasInlineContract,
+  assertStoryProvenanceShape,
   assertNoUnknownDeps,
   assertAcyclic,
   attachFindingsAndErrors,

--- a/.agents/workflows/helpers/plan-reference.md
+++ b/.agents/workflows/helpers/plan-reference.md
@@ -243,6 +243,82 @@ as a hard error — so the grounding contract is the author's own targeted reads
 plus that gate. There is no pre-computed codebase snapshot to fall back on,
 and no manifest-derived replacement to build.
 
+### Per-Story audit provenance (`provenance`)
+
+An audit-seeded plan carries dedup identities forward so the next sweep
+recognises what it already planned. The optional top-level `provenance` field
+says **which of them this Story owns**:
+
+```jsonc
+{
+  "slug": "own-the-seam",
+  "provenance": {
+    "fingerprints": ["<40-char sha1, one per finding this Story tracks>"],
+    "semanticKeys": ["architecture␟lib/owned.js"]
+  }
+}
+```
+
+Both arrays are optional; a malformed entry is a validator rejection, never a
+silent drop — a dropped identity is invisible until the next sweep re-files
+work this plan already tracked.
+
+| `provenance` | What persist stamps |
+| --- | --- |
+| Present | **Exactly** the identities listed — siblings' groups never leak in. |
+| Present but empty (`{}`) | Nothing. "Owns no findings" is a real answer. |
+| **Absent** | The **whole seed's** footers (the union) — the recall-safe default. |
+
+**The union fallback is load-bearing, not legacy.** Leaving the authoring agent
+to hand-carry provenance out of the seed's HTML comments was measured to fail —
+a remembered step is no step at all — and the mechanical union carry is what
+closed it. Attribution is additive: it sharpens a plan that opts in and changes
+nothing for one that does not. Never remove the fallback to "finish the
+migration".
+
+Attribution is what makes the next sweep's dedup answerable rather than
+arbitrary. Under the union every sibling carried every key, so a finding
+confirming against several open Stories could only pick one at random, and a
+key whose owning Story had since **closed** was masked by any open neighbour —
+a genuine regression filed as a routine update. With ownership stamped, the
+issue carrying a finding's own fingerprint decides both the match and its
+state (`lib/findings/route-finding.js`).
+
+The audit path authors this mechanically from the per-group footers the seed
+already carries — see [`audit-to-stories`](../audit-to-stories.md). A `--seed`
+or `--tickets` plan has nothing to attribute and omits the field.
+
+## Cross-Story conflict analysis at persist
+
+The conflict passes run **twice**: once over the raw `stories.json` payload
+(alongside the freshness, file-assumption and sizing gates), and again over the
+**assembled, footer-stamped bodies** — the artifact persist actually posts.
+The second pass is not belt-and-braces. The canonical authoring shape carries
+`acceptance[]` / `verify[]` at the ticket's top level and assembly folds them
+into the body, so the passes that scan `body.acceptance` / `body.verify`
+(`implicit-cross-story-dep`, `missing-bdd-scaffold`) saw two empty arrays on
+the real payload and emitted nothing. Both passes complete before the first
+`createIssue`, so a refusal still costs no writes.
+
+`shared-editor` findings are rendered into the posted `plan-summary` comment,
+directly beneath the wave table: the table promises which Stories can run
+together, and a path two same-wave Stories both write is exactly where that
+promise breaks. Promise and caveat belong on one durable surface — previously
+the caveat was a stderr warning nobody kept.
+
+Two `planning.*` knobs upgrade a conflict class from advisory to a hard
+refusal. **Both default to `false` and are documented, not recommended:**
+
+| Knob | Upgrades | Why it is off |
+| --- | --- | --- |
+| `planning.failOnSharedEditors` | `shared-editor` → `hard` | Co-editing one file is routine and often correct; the delivery scheduler already serializes file-overlapping Stories. |
+| `planning.requireExplicitCrossStoryDeps` | `implicit-cross-story-dep` → `hard` | Path references are matched by substring, so a legitimate mention in prose can read as a dependency. |
+
+Turn one on for a repo where the class is genuinely fatal; expect a refusal to
+name the Stories and the fix (a `depends_on` edge, or folding the shared edit
+into one Story). The sibling knobs `failOnRegistryConflicts`,
+`failOnMissingBddScaffold` and `failOnLargeFanOut` behave the same way.
+
 ## Tickets mode — authoring `supersedes[]`
 
 In `--tickets` mode each Story carries a top-level `supersedes` array claiming

--- a/baselines/coverage.json
+++ b/baselines/coverage.json
@@ -1,12 +1,12 @@
 {
   "$schema": ".agents/schemas/baselines/coverage.schema.json",
   "kernelVersion": "1.0.0",
-  "generatedAt": "2026-08-07T13:24:41.046Z",
+  "generatedAt": "2026-08-07T13:37:15.710Z",
   "rollup": {
     "*": {
-      "lines": 95.91,
-      "branches": 86.65,
-      "functions": 88.82
+      "lines": 95.93,
+      "branches": 86.66,
+      "functions": 88.84
     }
   },
   "rows": [
@@ -1355,9 +1355,15 @@
       "functions": 100
     },
     {
+      "path": ".agents/scripts/lib/findings/provenance-field.js",
+      "lines": 100,
+      "branches": 93.94,
+      "functions": 100
+    },
+    {
       "path": ".agents/scripts/lib/findings/route-finding.js",
       "lines": 100,
-      "branches": 94.74,
+      "branches": 93.14,
       "functions": 100
     },
     {
@@ -1944,20 +1950,20 @@
     },
     {
       "path": ".agents/scripts/lib/orchestration/plan-persist/run-plan-persist.js",
-      "lines": 93.2,
-      "branches": 78.89,
+      "lines": 93.91,
+      "branches": 80.65,
       "functions": 100
     },
     {
       "path": ".agents/scripts/lib/orchestration/plan-persist/story-ops.js",
-      "lines": 94.38,
-      "branches": 82.11,
+      "lines": 95.78,
+      "branches": 84.24,
       "functions": 100
     },
     {
       "path": ".agents/scripts/lib/orchestration/plan-persist/summary.js",
       "lines": 100,
-      "branches": 86.84,
+      "branches": 87.5,
       "functions": 100
     },
     {
@@ -2358,8 +2364,8 @@
     },
     {
       "path": ".agents/scripts/lib/orchestration/ticket-validator-conflicts.js",
-      "lines": 99.22,
-      "branches": 88.76,
+      "lines": 99.28,
+      "branches": 88.58,
       "functions": 100
     },
     {
@@ -2370,8 +2376,8 @@
     },
     {
       "path": ".agents/scripts/lib/orchestration/ticket-validator.js",
-      "lines": 98.17,
-      "branches": 87.94,
+      "lines": 98.26,
+      "branches": 87.76,
       "functions": 100
     },
     {

--- a/baselines/crap.json
+++ b/baselines/crap.json
@@ -1,7 +1,7 @@
 {
   "$schema": ".agents/schemas/baselines/crap.schema.json",
   "kernelVersion": "0.1.0",
-  "generatedAt": "2026-08-07T13:32:06.209Z",
+  "generatedAt": "2026-08-07T13:37:14.691Z",
   "scoringSemantics": "method-identity-v3",
   "tsTranspilerVersion": "6.0.3",
   "provenanceStamped": true,

--- a/baselines/crap.json
+++ b/baselines/crap.json
@@ -1,7 +1,7 @@
 {
   "$schema": ".agents/schemas/baselines/crap.schema.json",
   "kernelVersion": "0.1.0",
-  "generatedAt": "2026-08-07T11:55:32.944Z",
+  "generatedAt": "2026-08-07T13:32:06.209Z",
   "scoringSemantics": "method-identity-v3",
   "tsTranspilerVersion": "6.0.3",
   "provenanceStamped": true,
@@ -9227,170 +9227,227 @@
       "anonymous": true
     },
     {
+      "path": ".agents/scripts/lib/findings/provenance-field.js",
+      "method": "normalizeList",
+      "startLine": 50,
+      "crap": 7
+    },
+    {
+      "path": ".agents/scripts/lib/findings/provenance-field.js",
+      "method": "normalizeOwnedProvenance",
+      "startLine": 91,
+      "crap": 6
+    },
+    {
+      "path": ".agents/scripts/lib/findings/provenance-field.js",
+      "method": "ownedProvenanceSource",
+      "startLine": 128,
+      "crap": 3
+    },
+    {
       "path": ".agents/scripts/lib/findings/route-finding.js",
       "method": "normaliseField",
-      "startLine": 47,
+      "startLine": 49,
       "crap": 3
     },
     {
       "path": ".agents/scripts/lib/findings/route-finding.js",
       "method": "normaliseLabels",
-      "startLine": 57,
+      "startLine": 59,
       "crap": 2
     },
     {
       "path": ".agents/scripts/lib/findings/route-finding.js",
       "method": "<anon normaliseLabels/(l)#0>",
-      "startLine": 60,
+      "startLine": 62,
       "crap": 1,
       "anonymous": true
     },
     {
       "path": ".agents/scripts/lib/findings/route-finding.js",
       "method": "<anon normaliseLabels/(l)#1>",
-      "startLine": 61,
+      "startLine": 63,
       "crap": 1,
       "anonymous": true
     },
     {
       "path": ".agents/scripts/lib/findings/route-finding.js",
       "method": "fingerprintComponents",
-      "startLine": 71,
-      "crap": 1
-    },
-    {
-      "path": ".agents/scripts/lib/findings/route-finding.js",
-      "method": "fingerprintFinding",
       "startLine": 87,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/findings/route-finding.js",
+      "method": "fingerprintFinding",
+      "startLine": 103,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/findings/route-finding.js",
       "method": "semanticKeyFor",
-      "startLine": 117,
+      "startLine": 133,
       "crap": 4
     },
     {
       "path": ".agents/scripts/lib/findings/route-finding.js",
       "method": "semanticKeyFooter",
-      "startLine": 135,
+      "startLine": 151,
       "crap": 2
     },
     {
       "path": ".agents/scripts/lib/findings/route-finding.js",
       "method": "<anon semanticKeyFooter/(k)#0>",
-      "startLine": 137,
+      "startLine": 153,
       "crap": 2,
       "anonymous": true
     },
     {
       "path": ".agents/scripts/lib/findings/route-finding.js",
       "method": "<anon semanticKeyFooter/(k)#1>",
-      "startLine": 138,
+      "startLine": 154,
       "crap": 1,
       "anonymous": true
     },
     {
       "path": ".agents/scripts/lib/findings/route-finding.js",
       "method": "<anon semanticKeyFooter/(k)#2>",
-      "startLine": 139,
+      "startLine": 155,
       "crap": 1,
       "anonymous": true
     },
     {
       "path": ".agents/scripts/lib/findings/route-finding.js",
       "method": "parseSemanticKeyFooter",
-      "startLine": 151,
-      "crap": 3
+      "startLine": 167,
+      "crap": 1
     },
     {
       "path": ".agents/scripts/lib/findings/route-finding.js",
       "method": "<anon parseSemanticKeyFooter/(s)#0>",
-      "startLine": 157,
-      "crap": 1,
-      "anonymous": true
-    },
-    {
-      "path": ".agents/scripts/lib/findings/route-finding.js",
-      "method": "<anon parseFingerprintFooter/(s)#0>",
-      "startLine": 158,
+      "startLine": 171,
       "crap": 1,
       "anonymous": true
     },
     {
       "path": ".agents/scripts/lib/findings/route-finding.js",
       "method": "fingerprintFooter",
-      "startLine": 174,
+      "startLine": 188,
       "crap": 4
     },
     {
       "path": ".agents/scripts/lib/findings/route-finding.js",
       "method": "parseFingerprintFooter",
-      "startLine": 192,
-      "crap": 3
+      "startLine": 206,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/findings/route-finding.js",
+      "method": "<anon parseFingerprintFooter/(s)#0>",
+      "startLine": 210,
+      "crap": 1,
+      "anonymous": true
+    },
+    {
+      "path": ".agents/scripts/lib/findings/route-finding.js",
+      "method": "parseAllFooterValues",
+      "startLine": 232,
+      "crap": 4
+    },
+    {
+      "path": ".agents/scripts/lib/findings/route-finding.js",
+      "method": "carryProvenanceFooters",
+      "startLine": 277,
+      "crap": 9
     },
     {
       "path": ".agents/scripts/lib/findings/route-finding.js",
       "method": "<anon carryProvenanceFooters/(sha)#0>",
-      "startLine": 198,
+      "startLine": 284,
       "crap": 1,
       "anonymous": true
     },
     {
       "path": ".agents/scripts/lib/findings/route-finding.js",
       "method": "<anon carryProvenanceFooters/(key)#0>",
-      "startLine": 199,
+      "startLine": 287,
       "crap": 1,
       "anonymous": true
     },
     {
       "path": ".agents/scripts/lib/findings/route-finding.js",
       "method": "issueCarriesFingerprint",
-      "startLine": 211,
+      "startLine": 316,
       "crap": 2
     },
     {
       "path": ".agents/scripts/lib/findings/route-finding.js",
       "method": "issueCarriesSemanticKey",
-      "startLine": 226,
+      "startLine": 331,
       "crap": 3
     },
     {
       "path": ".agents/scripts/lib/findings/route-finding.js",
       "method": "decisionForIssue",
-      "startLine": 236,
+      "startLine": 341,
       "crap": 2
     },
     {
       "path": ".agents/scripts/lib/findings/route-finding.js",
+      "method": "attributedPool",
+      "startLine": 369,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/findings/route-finding.js",
+      "method": "<anon attributedPool/(issue)#0>",
+      "startLine": 370,
+      "crap": 1,
+      "anonymous": true
+    },
+    {
+      "path": ".agents/scripts/lib/findings/route-finding.js",
+      "method": "<anon attributedPool/(i)#0>",
+      "startLine": 372,
+      "crap": 1,
+      "anonymous": true
+    },
+    {
+      "path": ".agents/scripts/lib/findings/route-finding.js",
+      "method": "<anon attributedPool/(a,b)#0>",
+      "startLine": 373,
+      "crap": 1,
+      "anonymous": true
+    },
+    {
+      "path": ".agents/scripts/lib/findings/route-finding.js",
       "method": "decideFromConfirmed",
-      "startLine": 252,
+      "startLine": 404,
       "crap": 4
     },
     {
       "path": ".agents/scripts/lib/findings/route-finding.js",
       "method": "<anon decideFromConfirmed/(h)#0>",
-      "startLine": 257,
+      "startLine": 410,
       "crap": 1,
       "anonymous": true
     },
     {
       "path": ".agents/scripts/lib/findings/route-finding.js",
       "method": "confirmCandidates",
-      "startLine": 292,
+      "startLine": 445,
       "crap": 2
     },
     {
       "path": ".agents/scripts/lib/findings/route-finding.js",
       "method": "<anon confirmCandidates/(h)#0>",
-      "startLine": 295,
+      "startLine": 448,
       "crap": 5,
       "anonymous": true
     },
     {
       "path": ".agents/scripts/lib/findings/route-finding.js",
       "method": "routeFinding",
-      "startLine": 343,
+      "startLine": 496,
       "crap": 5
     },
     {
@@ -13703,398 +13760,516 @@
     {
       "path": ".agents/scripts/lib/orchestration/plan-persist/run-plan-persist.js",
       "method": "writeCheckpointV2",
-      "startLine": 93,
+      "startLine": 101,
       "crap": 2.0030052592036065
     },
     {
       "path": ".agents/scripts/lib/orchestration/plan-persist/run-plan-persist.js",
       "method": "enforceTicketValidation",
-      "startLine": 135,
+      "startLine": 143,
       "crap": 4.025155017797175
     },
     {
       "path": ".agents/scripts/lib/orchestration/plan-persist/run-plan-persist.js",
       "method": "<anon enforceTicketValidation/(error)#0>",
-      "startLine": 137,
+      "startLine": 145,
       "crap": 1.0015721886123234,
       "anonymous": true
     },
     {
       "path": ".agents/scripts/lib/orchestration/plan-persist/run-plan-persist.js",
       "method": "<anon enforceTicketValidation/(error)#1>",
-      "startLine": 141,
+      "startLine": 149,
       "crap": 1.0015721886123234,
       "anonymous": true
     },
     {
       "path": ".agents/scripts/lib/orchestration/plan-persist/run-plan-persist.js",
       "method": "<anon enforceTicketValidation/(error)#2>",
-      "startLine": 146,
+      "startLine": 154,
       "crap": 1.0015721886123234,
       "anonymous": true
     },
     {
       "path": ".agents/scripts/lib/orchestration/plan-persist/run-plan-persist.js",
       "method": "<anon enforceTicketValidation/(error)#3>",
-      "startLine": 169,
+      "startLine": 177,
       "crap": 1.0015721886123234,
       "anonymous": true
     },
     {
       "path": ".agents/scripts/lib/orchestration/plan-persist/run-plan-persist.js",
       "method": "runSupersedePhase",
-      "startLine": 189,
+      "startLine": 197,
       "crap": 1.4614012021036813
     },
     {
       "path": ".agents/scripts/lib/orchestration/plan-persist/run-plan-persist.js",
       "method": "<anon runSupersedePhase/(ticket)#0>",
-      "startLine": 204,
+      "startLine": 212,
       "crap": 1.4614012021036813,
       "anonymous": true
     },
     {
       "path": ".agents/scripts/lib/orchestration/plan-persist/run-plan-persist.js",
       "method": "renderRunScopedPlanMetricsLine",
-      "startLine": 239,
+      "startLine": 247,
       "crap": 2.0044282258395176
     },
     {
       "path": ".agents/scripts/lib/orchestration/plan-persist/run-plan-persist.js",
       "method": "resolveEffectiveRoute",
-      "startLine": 312,
+      "startLine": 320,
       "crap": 5
     },
     {
       "path": ".agents/scripts/lib/orchestration/plan-persist/run-plan-persist.js",
       "method": "<anon resolveEffectiveRoute/(story)#0>",
-      "startLine": 339,
+      "startLine": 347,
       "crap": 1,
       "anonymous": true
     },
     {
       "path": ".agents/scripts/lib/orchestration/plan-persist/run-plan-persist.js",
       "method": "<anon resolveEffectiveRoute/(entry)#0>",
-      "startLine": 352,
+      "startLine": 360,
       "crap": 1,
       "anonymous": true
     },
     {
       "path": ".agents/scripts/lib/orchestration/plan-persist/run-plan-persist.js",
       "method": "<anon resolveEffectiveRoute/(entry)#1>",
-      "startLine": 359,
+      "startLine": 367,
       "crap": 1,
       "anonymous": true
     },
     {
       "path": ".agents/scripts/lib/orchestration/plan-persist/run-plan-persist.js",
+      "method": "analyzeAssembledStories",
+      "startLine": 407,
+      "crap": 2.0625
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/plan-persist/run-plan-persist.js",
+      "method": "<anon analyzeAssembledStories/(finding)#0>",
+      "startLine": 409,
+      "crap": 1.015625,
+      "anonymous": true
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/plan-persist/run-plan-persist.js",
+      "method": "<anon analyzeAssembledStories/(f)#0>",
+      "startLine": 413,
+      "crap": 1.015625,
+      "anonymous": true
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/plan-persist/run-plan-persist.js",
+      "method": "<anon analyzeAssembledStories/(finding)#1>",
+      "startLine": 417,
+      "crap": 1.015625,
+      "anonymous": true
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/plan-persist/run-plan-persist.js",
+      "method": "<anon analyzeAssembledStories/(finding)#2>",
+      "startLine": 421,
+      "crap": 1.015625,
+      "anonymous": true
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/plan-persist/run-plan-persist.js",
       "method": "reapStalePlanDirs",
-      "startLine": 398,
+      "startLine": 450,
       "crap": 2
     },
     {
       "path": ".agents/scripts/lib/orchestration/plan-persist/run-plan-persist.js",
       "method": "<anon reapStalePlanDirs/(entry)#0>",
-      "startLine": 410,
+      "startLine": 462,
+      "crap": 1,
+      "anonymous": true
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/plan-persist/run-plan-persist.js",
+      "method": "assertPersistablePlan",
+      "startLine": 475,
+      "crap": 17.30135588278175
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/plan-persist/run-plan-persist.js",
+      "method": "enforceReachability",
+      "startLine": 503,
+      "crap": 3
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/plan-persist/run-plan-persist.js",
+      "method": "persistStoryArtifacts",
+      "startLine": 541,
+      "crap": 1
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/plan-persist/run-plan-persist.js",
+      "method": "<anon persistStoryArtifacts/(createdStory)#0>",
+      "startLine": 548,
+      "crap": 1,
+      "anonymous": true
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/plan-persist/run-plan-persist.js",
+      "method": "<anon persistStoryArtifacts/(story)#0>",
+      "startLine": 554,
+      "crap": 2,
+      "anonymous": true
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/plan-persist/run-plan-persist.js",
+      "method": "cleanupPlanDirs",
+      "startLine": 590,
+      "crap": 7.4559999999999995
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/plan-persist/run-plan-persist.js",
+      "method": "logEffectiveRoute",
+      "startLine": 609,
+      "crap": 3
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/plan-persist/run-plan-persist.js",
+      "method": "logPersistEpilogue",
+      "startLine": 634,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/plan-persist/run-plan-persist.js",
+      "method": "<anon logPersistEpilogue/(story)#0>",
+      "startLine": 635,
+      "crap": 1,
+      "anonymous": true
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/plan-persist/run-plan-persist.js",
+      "method": "<anon logPersistEpilogue/(s2)#0>",
+      "startLine": 639,
+      "crap": 1,
+      "anonymous": true
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/plan-persist/run-plan-persist.js",
+      "method": "<anon logPersistEpilogue/(s2)#1>",
+      "startLine": 647,
       "crap": 1,
       "anonymous": true
     },
     {
       "path": ".agents/scripts/lib/orchestration/plan-persist/run-plan-persist.js",
       "method": "runPlanPersist",
-      "startLine": 443,
-      "crap": 19.196954412986514
+      "startLine": 687,
+      "crap": 4
     },
     {
       "path": ".agents/scripts/lib/orchestration/plan-persist/run-plan-persist.js",
-      "method": "<anon persistStoryArtifacts/(createdStory)#0>",
-      "startLine": 577,
-      "crap": 1.0005455800913754,
-      "anonymous": true
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/plan-persist/run-plan-persist.js",
-      "method": "<anon persistStoryArtifacts/(story)#0>",
-      "startLine": 618,
-      "crap": 1.0005455800913754,
-      "anonymous": true
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/plan-persist/run-plan-persist.js",
-      "method": "<anon logPersistEpilogue/(story)#0>",
-      "startLine": 667,
-      "crap": 1.0005455800913754,
-      "anonymous": true
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/plan-persist/run-plan-persist.js",
-      "method": "<anon logPersistEpilogue/(s2)#0>",
-      "startLine": 671,
-      "crap": 1.0005455800913754,
-      "anonymous": true
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/plan-persist/run-plan-persist.js",
-      "method": "<anon logPersistEpilogue/(s2)#1>",
-      "startLine": 679,
-      "crap": 1.0005455800913754,
+      "method": "<anon runPlanPersist/(s)#0>",
+      "startLine": 795,
+      "crap": 1,
       "anonymous": true
     },
     {
       "path": ".agents/scripts/lib/orchestration/plan-persist/story-ops.js",
       "method": "normalizePlanRunId",
-      "startLine": 66,
+      "startLine": 75,
       "crap": 2
     },
     {
       "path": ".agents/scripts/lib/orchestration/plan-persist/story-ops.js",
       "method": "planRunLabel",
-      "startLine": 88,
+      "startLine": 97,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/orchestration/plan-persist/story-ops.js",
       "method": "derivePlanRunId",
-      "startLine": 107,
+      "startLine": 116,
       "crap": 2
     },
     {
       "path": ".agents/scripts/lib/orchestration/plan-persist/story-ops.js",
       "method": "planStoryFingerprint",
-      "startLine": 172,
+      "startLine": 181,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/orchestration/plan-persist/story-ops.js",
       "method": "planFingerprintMarker",
-      "startLine": 187,
+      "startLine": 196,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/orchestration/plan-persist/story-ops.js",
       "method": "sanitizeAuthoredLabels",
-      "startLine": 225,
+      "startLine": 234,
       "crap": 7
     },
     {
       "path": ".agents/scripts/lib/orchestration/plan-persist/story-ops.js",
       "method": "<anon sanitizeAuthoredLabels/(p)#0>",
-      "startLine": 235,
+      "startLine": 244,
       "crap": 1,
       "anonymous": true
     },
     {
       "path": ".agents/scripts/lib/orchestration/plan-persist/story-ops.js",
       "method": "bodyObjectFromTicket",
-      "startLine": 250,
-      "crap": 4.03125
+      "startLine": 259,
+      "crap": 4
     },
     {
       "path": ".agents/scripts/lib/orchestration/plan-persist/story-ops.js",
       "method": "normalizeDependsOn",
-      "startLine": 275,
+      "startLine": 283,
       "crap": 3
     },
     {
       "path": ".agents/scripts/lib/orchestration/plan-persist/story-ops.js",
       "method": "<anon normalizeDependsOn/(d)#0>",
-      "startLine": 277,
+      "startLine": 285,
       "crap": 1,
       "anonymous": true
     },
     {
       "path": ".agents/scripts/lib/orchestration/plan-persist/story-ops.js",
       "method": "arraysEqual",
-      "startLine": 282,
+      "startLine": 290,
       "crap": 2
     },
     {
       "path": ".agents/scripts/lib/orchestration/plan-persist/story-ops.js",
       "method": "<anon arraysEqual/(value,index)#0>",
-      "startLine": 283,
+      "startLine": 291,
       "crap": 1,
       "anonymous": true
     },
     {
       "path": ".agents/scripts/lib/orchestration/plan-persist/story-ops.js",
       "method": "syncContractFieldFromTopLevel",
-      "startLine": 296,
+      "startLine": 304,
       "crap": 5
     },
     {
       "path": ".agents/scripts/lib/orchestration/plan-persist/story-ops.js",
       "method": "normalizeStoryTicket",
-      "startLine": 321,
-      "crap": 8.78652708238507
+      "startLine": 333,
+      "crap": 8.216
     },
     {
       "path": ".agents/scripts/lib/orchestration/plan-persist/story-ops.js",
       "method": "foldSpecIntoStoryBody",
-      "startLine": 361,
+      "startLine": 387,
       "crap": 7
     },
     {
       "path": ".agents/scripts/lib/orchestration/plan-persist/story-ops.js",
+      "method": "resolveProvenanceSource",
+      "startLine": 435,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/plan-persist/story-ops.js",
       "method": "assembleOnePlanStory",
-      "startLine": 387,
+      "startLine": 440,
       "crap": 2
     },
     {
       "path": ".agents/scripts/lib/orchestration/plan-persist/story-ops.js",
       "method": "assertSharedSpecAllowed",
-      "startLine": 419,
+      "startLine": 491,
       "crap": 4
     },
     {
       "path": ".agents/scripts/lib/orchestration/plan-persist/story-ops.js",
       "method": "assemblePlanStories",
-      "startLine": 443,
+      "startLine": 515,
       "crap": 3.072
     },
     {
       "path": ".agents/scripts/lib/orchestration/plan-persist/story-ops.js",
       "method": "<anon assemblePlanStories/(ticket)#0>",
-      "startLine": 453,
+      "startLine": 525,
       "crap": 1.008,
       "anonymous": true
     },
     {
       "path": ".agents/scripts/lib/orchestration/plan-persist/story-ops.js",
       "method": "orderStoriesByDependencies",
-      "startLine": 464,
+      "startLine": 536,
       "crap": 5.065603345770635
     },
     {
       "path": ".agents/scripts/lib/orchestration/plan-persist/story-ops.js",
       "method": "<anon orderStoriesByDependencies/(story)#0>",
-      "startLine": 466,
+      "startLine": 538,
       "crap": 1.0026241338308253,
       "anonymous": true
     },
     {
       "path": ".agents/scripts/lib/orchestration/plan-persist/story-ops.js",
       "method": "<anon orderStoriesByDependencies/(slug)#0>",
-      "startLine": 468,
+      "startLine": 540,
       "crap": 1.0026241338308253,
       "anonymous": true
     },
     {
       "path": ".agents/scripts/lib/orchestration/plan-persist/story-ops.js",
       "method": "<anon orderStoriesByDependencies/(story)#1>",
-      "startLine": 479,
+      "startLine": 551,
       "crap": 1.0026241338308253,
       "anonymous": true
     },
     {
       "path": ".agents/scripts/lib/orchestration/plan-persist/story-ops.js",
       "method": "<anon orderStoriesByDependencies/(story)#1/(slug)#0>",
-      "startLine": 480,
+      "startLine": 552,
       "crap": 1.0026241338308253,
       "anonymous": true
     },
     {
       "path": ".agents/scripts/lib/orchestration/plan-persist/story-ops.js",
       "method": "<anon orderStoriesByDependencies/(story)#2>",
-      "startLine": 484,
+      "startLine": 556,
       "crap": 1.0026241338308253,
       "anonymous": true
     },
     {
       "path": ".agents/scripts/lib/orchestration/plan-persist/story-ops.js",
       "method": "indexExistingStories",
-      "startLine": 517,
+      "startLine": 589,
       "crap": 6.079888222240487
     },
     {
       "path": ".agents/scripts/lib/orchestration/plan-persist/story-ops.js",
       "method": "warnOnDivergentSameTitleStory",
-      "startLine": 578,
+      "startLine": 650,
       "crap": 2
     },
     {
       "path": ".agents/scripts/lib/orchestration/plan-persist/story-ops.js",
       "method": "<anon warnOnDivergentSameTitleStory/(id)#0>",
-      "startLine": 583,
+      "startLine": 655,
       "crap": 1,
       "anonymous": true
     },
     {
       "path": ".agents/scripts/lib/orchestration/plan-persist/story-ops.js",
       "method": "renderStoryBodyForCreate",
-      "startLine": 599,
+      "startLine": 671,
       "crap": 2
     },
     {
       "path": ".agents/scripts/lib/orchestration/plan-persist/story-ops.js",
       "method": "<anon renderStoryBodyForCreate/(slug)#0>",
-      "startLine": 601,
+      "startLine": 673,
       "crap": 1,
       "anonymous": true
     },
     {
       "path": ".agents/scripts/lib/orchestration/plan-persist/story-ops.js",
       "method": "mirrorNativeDependencyEdges",
-      "startLine": 643,
+      "startLine": 715,
       "crap": 5.0432
     },
     {
       "path": ".agents/scripts/lib/orchestration/plan-persist/story-ops.js",
       "method": "<anon mirrorNativeDependencyEdges/(story)#0>",
-      "startLine": 644,
+      "startLine": 716,
       "crap": 1.001728,
       "anonymous": true
     },
     {
       "path": ".agents/scripts/lib/orchestration/plan-persist/story-ops.js",
       "method": "<anon mirrorNativeDependencyEdges/(story)#1>",
-      "startLine": 662,
+      "startLine": 734,
       "crap": 1.001728,
       "anonymous": true
     },
     {
       "path": ".agents/scripts/lib/orchestration/plan-persist/story-ops.js",
       "method": "<anon mirrorNativeDependencyEdges/(issueNumber)#0>",
-      "startLine": 667,
+      "startLine": 739,
       "crap": 1,
       "anonymous": true
     },
     {
       "path": ".agents/scripts/lib/orchestration/plan-persist/story-ops.js",
       "method": "ensurePersistLabel",
-      "startLine": 719,
+      "startLine": 791,
       "crap": 4.16748046875
     },
     {
       "path": ".agents/scripts/lib/orchestration/plan-persist/story-ops.js",
       "method": "createStoryIssues",
-      "startLine": 815,
+      "startLine": 895,
       "crap": 13.045382833741733
     },
     {
       "path": ".agents/scripts/lib/orchestration/plan-persist/story-ops.js",
       "method": "<anon createStoryIssues/(story)#0>",
-      "startLine": 832,
+      "startLine": 912,
       "crap": 1.0002685374777618,
       "anonymous": true
     },
     {
       "path": ".agents/scripts/lib/orchestration/plan-persist/story-ops.js",
       "method": "<anon createStoryIssues/(s,i)#0>",
-      "startLine": 837,
+      "startLine": 917,
       "crap": 1.0002685374777618,
       "anonymous": true
     },
     {
       "path": ".agents/scripts/lib/orchestration/plan-persist/story-ops.js",
       "method": "markStoriesReady",
-      "startLine": 956,
-      "crap": 4.125
+      "startLine": 1046,
+      "crap": 3.013206705484598
     },
     {
       "path": ".agents/scripts/lib/orchestration/plan-persist/story-ops.js",
       "method": "<anon markStoriesReady/(story)#0>",
-      "startLine": 979,
-      "crap": 1.125,
+      "startLine": 1055,
+      "crap": 1,
+      "anonymous": true
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/plan-persist/story-ops.js",
+      "method": "<anon markStoriesReady/(outcome)#0>",
+      "startLine": 1074,
+      "crap": 1.001467411720511,
+      "anonymous": true
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/plan-persist/story-ops.js",
+      "method": "<anon markStoriesReady/(outcome)#1>",
+      "startLine": 1075,
+      "crap": 1.001467411720511,
+      "anonymous": true
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/plan-persist/story-ops.js",
+      "method": "<anon markStoriesReady/(outcome)#2>",
+      "startLine": 1077,
+      "crap": 1.001467411720511,
+      "anonymous": true
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/plan-persist/story-ops.js",
+      "method": "<anon markStoriesReady/(outcome)#3>",
+      "startLine": 1078,
+      "crap": 1.001467411720511,
+      "anonymous": true
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/plan-persist/story-ops.js",
+      "method": "<anon markStoriesReady/(f)#0>",
+      "startLine": 1083,
+      "crap": 1.001467411720511,
       "anonymous": true
     },
     {
@@ -14146,21 +14321,55 @@
     },
     {
       "path": ".agents/scripts/lib/orchestration/plan-persist/summary.js",
+      "method": "renderSharedEditorLines",
+      "startLine": 85,
+      "crap": 3
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/plan-persist/summary.js",
+      "method": "<anon renderSharedEditorLines/(finding)#0>",
+      "startLine": 88,
+      "crap": 1,
+      "anonymous": true
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/plan-persist/summary.js",
+      "method": "<anon renderSharedEditorLines/(a,b)#0>",
+      "startLine": 92,
+      "crap": 1,
+      "anonymous": true
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/plan-persist/summary.js",
+      "method": "<anon renderSharedEditorLines/(finding)#1>",
+      "startLine": 94,
+      "crap": 1,
+      "anonymous": true
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/plan-persist/summary.js",
+      "method": "<anon renderSharedEditorLines/(finding)#1/(slug)#0>",
+      "startLine": 96,
+      "crap": 1,
+      "anonymous": true
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/plan-persist/summary.js",
       "method": "buildPlanSummaryCommentBody",
-      "startLine": 74,
+      "startLine": 121,
       "crap": 12
     },
     {
       "path": ".agents/scripts/lib/orchestration/plan-persist/summary.js",
       "method": "<anon buildPlanSummaryCommentBody/(s)#0>",
-      "startLine": 104,
+      "startLine": 152,
       "crap": 1,
       "anonymous": true
     },
     {
       "path": ".agents/scripts/lib/orchestration/plan-persist/summary.js",
       "method": "<anon buildPlanSummaryCommentBody/(s)#1>",
-      "startLine": 118,
+      "startLine": 166,
       "crap": 1,
       "anonymous": true
     },
@@ -17686,34 +17895,53 @@
     },
     {
       "path": ".agents/scripts/lib/orchestration/ticket-validator-conflicts.js",
+      "method": "computeAssembledConflictFindings",
+      "startLine": 793,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/ticket-validator-conflicts.js",
+      "method": "<anon computeAssembledConflictFindings/(story)#0>",
+      "startLine": 796,
+      "crap": 2,
+      "anonymous": true
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/ticket-validator-conflicts.js",
+      "method": "conflictFindingKey",
+      "startLine": 825,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/ticket-validator-conflicts.js",
       "method": "renderFanOutEvidence",
-      "startLine": 782,
+      "startLine": 855,
       "crap": 5
     },
     {
       "path": ".agents/scripts/lib/orchestration/ticket-validator-conflicts.js",
       "method": "renderFanOutRemedy",
-      "startLine": 805,
+      "startLine": 878,
       "crap": 3
     },
     {
       "path": ".agents/scripts/lib/orchestration/ticket-validator-conflicts.js",
       "method": "renderHardConflictError",
-      "startLine": 824,
-      "crap": 9.21362962962963
+      "startLine": 919,
+      "crap": 8.064
     },
     {
       "path": ".agents/scripts/lib/orchestration/ticket-validator-conflicts.js",
       "method": "<anon renderHardConflictError/(s)#0>",
-      "startLine": 826,
-      "crap": 1.018962962962963,
+      "startLine": 921,
+      "crap": 1.001,
       "anonymous": true
     },
     {
       "path": ".agents/scripts/lib/orchestration/ticket-validator-conflicts.js",
       "method": "<anon renderHardConflictError/(s)#1>",
-      "startLine": 833,
-      "crap": 1.018962962962963,
+      "startLine": 928,
+      "crap": 1.001,
       "anonymous": true
     },
     {
@@ -17887,193 +18115,199 @@
     {
       "path": ".agents/scripts/lib/orchestration/ticket-validator.js",
       "method": "collectPathsFromText",
-      "startLine": 35,
+      "startLine": 37,
       "crap": 4
     },
     {
       "path": ".agents/scripts/lib/orchestration/ticket-validator.js",
       "method": "resolveAcceptanceLines",
-      "startLine": 64,
+      "startLine": 66,
       "crap": 7
     },
     {
       "path": ".agents/scripts/lib/orchestration/ticket-validator.js",
       "method": "collectTaskPathReferences",
-      "startLine": 82,
+      "startLine": 84,
       "crap": 7
     },
     {
       "path": ".agents/scripts/lib/orchestration/ticket-validator.js",
       "method": "collectTaskChangesPaths",
-      "startLine": 130,
+      "startLine": 132,
       "crap": 17.001560534145458
     },
     {
       "path": ".agents/scripts/lib/orchestration/ticket-validator.js",
       "method": "defaultGitRunner",
-      "startLine": 196,
+      "startLine": 198,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/orchestration/ticket-validator.js",
       "method": "makeMemoizedGitRunner",
-      "startLine": 216,
+      "startLine": 218,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/orchestration/ticket-validator.js",
       "method": "memoizedGitRunner",
-      "startLine": 218,
+      "startLine": 220,
       "crap": 2
     },
     {
       "path": ".agents/scripts/lib/orchestration/ticket-validator.js",
       "method": "validateAcFreshness",
-      "startLine": 245,
+      "startLine": 247,
       "crap": 7
     },
     {
       "path": ".agents/scripts/lib/orchestration/ticket-validator.js",
       "method": "<anon validateAcFreshness/(t)#0>",
-      "startLine": 256,
+      "startLine": 258,
       "crap": 1,
       "anonymous": true
     },
     {
       "path": ".agents/scripts/lib/orchestration/ticket-validator.js",
       "method": "<anon validateAcFreshness/(m)#0>",
-      "startLine": 287,
+      "startLine": 289,
       "crap": 1,
       "anonymous": true
     },
     {
       "path": ".agents/scripts/lib/orchestration/ticket-validator.js",
       "method": "validateAcceptanceSubjectPrefix",
-      "startLine": 365,
+      "startLine": 367,
       "crap": 4
     },
     {
       "path": ".agents/scripts/lib/orchestration/ticket-validator.js",
       "method": "<anon validateAcceptanceSubjectPrefix/(t)#0>",
-      "startLine": 367,
+      "startLine": 369,
       "crap": 1,
       "anonymous": true
     },
     {
       "path": ".agents/scripts/lib/orchestration/ticket-validator.js",
       "method": "<anon validateAcceptanceSubjectPrefix/(v)#0>",
-      "startLine": 393,
+      "startLine": 395,
       "crap": 1,
       "anonymous": true
     },
     {
       "path": ".agents/scripts/lib/orchestration/ticket-validator.js",
       "method": "renderMissLine",
-      "startLine": 411,
+      "startLine": 413,
       "crap": 2
     },
     {
       "path": ".agents/scripts/lib/orchestration/ticket-validator.js",
       "method": "indexTicketsBySlug",
-      "startLine": 449,
+      "startLine": 451,
       "crap": 4
     },
     {
       "path": ".agents/scripts/lib/orchestration/ticket-validator.js",
       "method": "assertAllTicketsAreStories",
-      "startLine": 474,
+      "startLine": 476,
       "crap": 3
     },
     {
       "path": ".agents/scripts/lib/orchestration/ticket-validator.js",
       "method": "<anon assertAllTicketsAreStories/(t)#0>",
-      "startLine": 475,
+      "startLine": 477,
       "crap": 1,
       "anonymous": true
     },
     {
       "path": ".agents/scripts/lib/orchestration/ticket-validator.js",
       "method": "<anon assertAllTicketsAreStories/(t)#1>",
-      "startLine": 478,
+      "startLine": 480,
       "crap": 1,
       "anonymous": true
     },
     {
       "path": ".agents/scripts/lib/orchestration/ticket-validator.js",
       "method": "hasInlineAcceptanceAndVerify",
-      "startLine": 504,
+      "startLine": 506,
       "crap": 6
     },
     {
       "path": ".agents/scripts/lib/orchestration/ticket-validator.js",
       "method": "assertEveryStoryHasInlineContract",
-      "startLine": 515,
+      "startLine": 517,
       "crap": 2
     },
     {
       "path": ".agents/scripts/lib/orchestration/ticket-validator.js",
       "method": "<anon assertEveryStoryHasInlineContract/(s)#0>",
-      "startLine": 522,
-      "crap": 1,
-      "anonymous": true
-    },
-    {
-      "path": ".agents/scripts/lib/orchestration/ticket-validator.js",
-      "method": "<anon assertEveryStoryHasInlineContract/(s)#1>",
       "startLine": 524,
       "crap": 1,
       "anonymous": true
     },
     {
       "path": ".agents/scripts/lib/orchestration/ticket-validator.js",
+      "method": "<anon assertEveryStoryHasInlineContract/(s)#1>",
+      "startLine": 526,
+      "crap": 1,
+      "anonymous": true
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/ticket-validator.js",
+      "method": "assertStoryProvenanceShape",
+      "startLine": 549,
+      "crap": 2
+    },
+    {
+      "path": ".agents/scripts/lib/orchestration/ticket-validator.js",
       "method": "assertNoUnknownDeps",
-      "startLine": 530,
+      "startLine": 567,
       "crap": 3
     },
     {
       "path": ".agents/scripts/lib/orchestration/ticket-validator.js",
       "method": "<anon assertNoUnknownDeps/(u)#0>",
-      "startLine": 541,
+      "startLine": 578,
       "crap": 1,
       "anonymous": true
     },
     {
       "path": ".agents/scripts/lib/orchestration/ticket-validator.js",
       "method": "assertAcyclic",
-      "startLine": 548,
+      "startLine": 585,
       "crap": 2
     },
     {
       "path": ".agents/scripts/lib/orchestration/ticket-validator.js",
       "method": "attachFindingsAndErrors",
-      "startLine": 557,
+      "startLine": 594,
       "crap": 1
     },
     {
       "path": ".agents/scripts/lib/orchestration/ticket-validator.js",
       "method": "validateAndNormalizeTickets",
-      "startLine": 572,
-      "crap": 6.025854244039326
+      "startLine": 609,
+      "crap": 6.0296630859375
     },
     {
       "path": ".agents/scripts/lib/orchestration/ticket-validator.js",
       "method": "<anon validateAndNormalizeTickets/(n)#0>",
-      "startLine": 637,
-      "crap": 1.0007181734455368,
+      "startLine": 675,
+      "crap": 1.000823974609375,
       "anonymous": true
     },
     {
       "path": ".agents/scripts/lib/orchestration/ticket-validator.js",
       "method": "<anon validateAndNormalizeTickets/(f)#0>",
-      "startLine": 689,
-      "crap": 1.0007181734455368,
+      "startLine": 720,
+      "crap": 1.000823974609375,
       "anonymous": true
     },
     {
       "path": ".agents/scripts/lib/orchestration/ticket-validator.js",
       "method": "<anon validateAndNormalizeTickets/(f)#1>",
-      "startLine": 690,
-      "crap": 2.0028726937821473,
+      "startLine": 721,
+      "crap": 2.0032958984375,
       "anonymous": true
     },
     {

--- a/baselines/maintainability.json
+++ b/baselines/maintainability.json
@@ -1,7 +1,7 @@
 {
   "$schema": ".agents/schemas/baselines/maintainability.schema.json",
   "kernelVersion": "0.1.0",
-  "generatedAt": "2026-08-07T13:23:36.131Z",
+  "generatedAt": "2026-08-07T13:37:15.267Z",
   "rollup": {
     "*": {
       "min": 76.381,
@@ -879,8 +879,12 @@
       "mi": 98.091
     },
     {
+      "path": ".agents/scripts/lib/findings/provenance-field.js",
+      "mi": 93.873
+    },
+    {
       "path": ".agents/scripts/lib/findings/route-finding.js",
-      "mi": 104.674
+      "mi": 105.27
     },
     {
       "path": ".agents/scripts/lib/findings/semantic-issue-search.js",
@@ -1272,7 +1276,7 @@
     },
     {
       "path": ".agents/scripts/lib/orchestration/plan-persist/run-plan-persist.js",
-      "mi": 94.385
+      "mi": 95.892
     },
     {
       "path": ".agents/scripts/lib/orchestration/plan-persist/story-ops.js",
@@ -1280,7 +1284,7 @@
     },
     {
       "path": ".agents/scripts/lib/orchestration/plan-persist/summary.js",
-      "mi": 107.628
+      "mi": 109.344
     },
     {
       "path": ".agents/scripts/lib/orchestration/plan-persist/supersede-ops.js",
@@ -1548,7 +1552,7 @@
     },
     {
       "path": ".agents/scripts/lib/orchestration/ticket-validator-conflicts.js",
-      "mi": 85.87
+      "mi": 86.485
     },
     {
       "path": ".agents/scripts/lib/orchestration/ticket-validator-sizing.js",

--- a/tests/lib/findings/route-finding.test.js
+++ b/tests/lib/findings/route-finding.test.js
@@ -1,6 +1,10 @@
 import assert from 'node:assert/strict';
 import { test } from 'node:test';
 import {
+  normalizeOwnedProvenance,
+  ownedProvenanceSource,
+} from '../../../.agents/scripts/lib/findings/provenance-field.js';
+import {
   __testing,
   carryProvenanceFooters,
   fingerprintFinding,
@@ -8,6 +12,7 @@ import {
   parseFingerprintFooter,
   routeFinding,
   semanticKeyFooter,
+  semanticKeyFor,
 } from '../../../.agents/scripts/lib/findings/route-finding.js';
 
 // Internal helper: the module's three call sites reach it directly, so it is
@@ -427,4 +432,286 @@ test('a Story carrying carried-through provenance dedupes on the next sweep (AC-
     'the second sweep must recognise the planned Story, not re-file it',
   );
   assert.equal(result.matchedIssue.number, 99);
+});
+
+// ---------------------------------------------------------------------------
+// Dedup attribution (Story #5045, AC-2)
+//
+// Confirmation admits two strengths of claim: an issue carrying the finding's
+// exact FINGERPRINT owns it, while one carrying only the location-based
+// SEMANTIC KEY is merely adjacent. Reading the confirmed pool flat conflated
+// them, which produced two wrong routes — an arbitrary `open[0]` pick, and a
+// closed owner masked by any open neighbour.
+// ---------------------------------------------------------------------------
+
+/** A finding and the two identities an Issue body can confirm it by. */
+const attributedFinding = {
+  title: 'Unread field nothing populates',
+  area: 'architecture',
+  primaryFile: 'lib/opts.js',
+  severity: 'medium',
+  labels: ['audit::architecture'],
+};
+const ATTRIBUTED_SHA = fingerprintFinding(attributedFinding).full;
+const ATTRIBUTED_KEY = semanticKeyFor(attributedFinding);
+
+/** An Issue body stamped with exactly the identities that Story owns. */
+function stampedBody({ shas = [], keys = [] } = {}) {
+  const parts = ['## Goal', '', 'Remediate.', ''];
+  if (shas.length > 0) parts.push(fingerprintFooter(shas));
+  if (keys.length > 0) parts.push(semanticKeyFooter(keys));
+  return parts.join('\n');
+}
+
+/** Route through the semantic-first port with semantic-key confirmation on. */
+function routeAgainst(issues) {
+  return routeFinding(
+    attributedFinding,
+    { searchCandidates: async () => issues },
+    { semanticKeyConfirm: true },
+  );
+}
+
+test('a semantic key matches the OWNING open Story, never an arbitrary open[0]', async () => {
+  // #201 merely shares the location; #202 carries the finding's fingerprint.
+  // The search port returns the neighbour first, which is exactly how the old
+  // `open[0]` pick landed on the wrong Story.
+  const issues = [
+    {
+      number: 201,
+      state: 'open',
+      body: stampedBody({ keys: [ATTRIBUTED_KEY] }),
+    },
+    {
+      number: 202,
+      state: 'open',
+      body: stampedBody({ shas: [ATTRIBUTED_SHA], keys: [ATTRIBUTED_KEY] }),
+    },
+  ];
+
+  const result = await routeAgainst(issues);
+
+  assert.equal(
+    result.decision,
+    'update-existing',
+    'one owner and one neighbour is not a duplicate',
+  );
+  assert.equal(
+    result.matchedIssue.number,
+    202,
+    'the issue carrying the fingerprint owns the finding',
+  );
+});
+
+test('the owning open Story wins regardless of the port’s return order', async () => {
+  const owner = {
+    number: 202,
+    state: 'open',
+    body: stampedBody({ shas: [ATTRIBUTED_SHA] }),
+  };
+  const neighbour = {
+    number: 201,
+    state: 'open',
+    body: stampedBody({ keys: [ATTRIBUTED_KEY] }),
+  };
+  for (const order of [
+    [owner, neighbour],
+    [neighbour, owner],
+  ]) {
+    const result = await routeAgainst(order);
+    assert.equal(result.matchedIssue.number, 202);
+    assert.equal(result.decision, 'update-existing');
+  }
+});
+
+test('a key owned by a CLOSED Story routes as a regression, not skip-open', async () => {
+  // The regression the flat read masked: #300 tracked this exact finding and
+  // was closed; #301 is an open Story at the same location tracking something
+  // else. Routing to #301 would file a genuine regression as business as usual.
+  const issues = [
+    {
+      number: 301,
+      state: 'open',
+      body: stampedBody({ keys: [ATTRIBUTED_KEY] }),
+    },
+    {
+      number: 300,
+      state: 'closed',
+      body: stampedBody({ shas: [ATTRIBUTED_SHA], keys: [ATTRIBUTED_KEY] }),
+    },
+  ];
+
+  const result = await routeAgainst(issues);
+
+  assert.equal(
+    result.decision,
+    'regression-of-closed',
+    'the owning issue’s state decides the route',
+  );
+  assert.equal(result.matchedIssue.number, 300);
+});
+
+test('two open owners are still a duplicate, pinned deterministically', async () => {
+  // A genuine duplicate — both carry the fingerprint — stays a duplicate. The
+  // pin is the earliest-filed issue, not whichever the port returned first.
+  const a = {
+    number: 410,
+    state: 'open',
+    body: stampedBody({ shas: [ATTRIBUTED_SHA] }),
+  };
+  const b = {
+    number: 405,
+    state: 'open',
+    body: stampedBody({ shas: [ATTRIBUTED_SHA] }),
+  };
+  for (const order of [
+    [a, b],
+    [b, a],
+  ]) {
+    const result = await routeAgainst(order);
+    assert.equal(result.decision, 'duplicate');
+    assert.equal(result.matchedIssue.number, 405);
+  }
+});
+
+test('a location-only match still routes when nothing carries the fingerprint', async () => {
+  // The semantic key exists to catch a reworded finding whose fingerprint has
+  // drifted. Attribution must not narrow that away.
+  const result = await routeAgainst([
+    {
+      number: 501,
+      state: 'open',
+      body: stampedBody({ keys: [ATTRIBUTED_KEY] }),
+    },
+  ]);
+  assert.equal(result.decision, 'update-existing');
+  assert.equal(result.matchedIssue.number, 501);
+});
+
+test('a closed location-only match is still a regression', async () => {
+  const result = await routeAgainst([
+    {
+      number: 502,
+      state: 'closed',
+      body: stampedBody({ keys: [ATTRIBUTED_KEY] }),
+    },
+  ]);
+  assert.equal(result.decision, 'regression-of-closed');
+});
+
+test('attributedPool keeps owners and drops location-only matches beside them', () => {
+  const owner = {
+    number: 9,
+    state: 'open',
+    body: stampedBody({ shas: [ATTRIBUTED_SHA] }),
+  };
+  const located = {
+    number: 2,
+    state: 'open',
+    body: stampedBody({ keys: [ATTRIBUTED_KEY] }),
+  };
+  assert.deepEqual(
+    __testing
+      .attributedPool([located, owner], ATTRIBUTED_SHA)
+      .map((i) => i.number),
+    [9],
+    'an owner outranks a neighbour regardless of input order',
+  );
+  // With no owner the location-only pool stands in, sorted by issue number.
+  assert.deepEqual(
+    __testing
+      .attributedPool(
+        [
+          {
+            number: 7,
+            state: 'open',
+            body: stampedBody({ keys: [ATTRIBUTED_KEY] }),
+          },
+          located,
+        ],
+        ATTRIBUTED_SHA,
+      )
+      .map((i) => i.number),
+    [2, 7],
+  );
+});
+
+// ---------------------------------------------------------------------------
+// The per-Story `provenance` field (Story #5045, AC-1 support)
+// ---------------------------------------------------------------------------
+
+test('normalizeOwnedProvenance returns null for an absent field', () => {
+  // `null` is what selects the recall-safe union fallback downstream — an
+  // empty object would mean "this Story owns nothing" and strip its footers.
+  assert.equal(normalizeOwnedProvenance(undefined), null);
+  assert.equal(normalizeOwnedProvenance(null), null);
+});
+
+test('normalizeOwnedProvenance shape-checks, trims and de-duplicates', () => {
+  assert.deepEqual(
+    normalizeOwnedProvenance({
+      fingerprints: [` ${ATTRIBUTED_SHA} `, ATTRIBUTED_SHA],
+      semanticKeys: [ATTRIBUTED_KEY],
+    }),
+    { fingerprints: [ATTRIBUTED_SHA], semanticKeys: [ATTRIBUTED_KEY] },
+  );
+  assert.deepEqual(normalizeOwnedProvenance({}), {
+    fingerprints: [],
+    semanticKeys: [],
+  });
+});
+
+test('normalizeOwnedProvenance rejects rather than silently dropping', () => {
+  // A dropped identity is invisible until the NEXT sweep re-files planned
+  // work, so every malformed shape fails at the validator instead.
+  for (const bad of [
+    'a string',
+    ['an array'],
+    { fingerprints: {} },
+    { fingerprints: ['deadbeef'] },
+    { fingerprints: [ATTRIBUTED_SHA.toUpperCase()] },
+    { semanticKeys: [''] },
+    { semanticKeys: ['carries,a,comma'] },
+    { semanticKeys: ['carries>a>bracket'] },
+    { extra: true },
+  ]) {
+    assert.throws(
+      () => normalizeOwnedProvenance(bad, 'own-the-seam'),
+      /provenance on "own-the-seam"/,
+      `expected a throw for ${JSON.stringify(bad)}`,
+    );
+  }
+});
+
+test('ownedProvenanceSource renders a carryable footer document', () => {
+  const source = ownedProvenanceSource({
+    fingerprints: [ATTRIBUTED_SHA],
+    semanticKeys: [ATTRIBUTED_KEY],
+  });
+  // The point of rendering the SAME footer vocabulary: the carry stays
+  // additive, union-preserving and idempotent for an attributed plan.
+  const carried = carryProvenanceFooters({
+    from: source,
+    into: '## Goal\n',
+  });
+  assert.deepEqual(parseFingerprintFooter(carried.body), [ATTRIBUTED_SHA]);
+  assert.deepEqual(parseSemanticKeyFooter(carried.body), [ATTRIBUTED_KEY]);
+  assert.equal(
+    carryProvenanceFooters({ from: source, into: carried.body }).carried,
+    false,
+    're-stamping an attributed body is still a no-op',
+  );
+});
+
+test('ownedProvenanceSource renders nothing for an empty or absent set', () => {
+  for (const empty of [null, undefined, {}, { fingerprints: [] }]) {
+    assert.equal(ownedProvenanceSource(empty), '');
+    assert.equal(
+      carryProvenanceFooters({
+        from: ownedProvenanceSource(empty),
+        into: '## Goal\n',
+      }).carried,
+      false,
+    );
+  }
 });

--- a/tests/lib/orchestration/plan-persist-story-ops.test.js
+++ b/tests/lib/orchestration/plan-persist-story-ops.test.js
@@ -20,6 +20,10 @@ import {
 } from '../../../.agents/scripts/lib/orchestration/plan-persist/story-ops.js';
 import { DEFAULT_SPEC_BODY_TOKEN_BUDGET } from '../../../.agents/scripts/lib/orchestration/spec-spill.js';
 import {
+  computeAssembledConflictFindings,
+  computeConflictFindings,
+} from '../../../.agents/scripts/lib/orchestration/ticket-validator-conflicts.js';
+import {
   parse,
   serialize,
 } from '../../../.agents/scripts/lib/story-body/story-body.js';
@@ -725,5 +729,259 @@ describe('audit dedup provenance carry (Story #4877, AC-5)', () => {
       1,
       'exactly one fingerprint footer',
     );
+  });
+});
+
+describe('per-Story provenance attribution (Story #5045, AC-1)', () => {
+  const SHA_OWNED = 'a'.repeat(40);
+  const SHA_SIBLING = 'b'.repeat(40);
+  const KEY_OWNED = 'architecture␟lib/owned.js';
+  const KEY_SIBLING = 'quality␟lib/sibling.js';
+
+  /** A two-group audit seed: the union both groups' footers add up to. */
+  const auditSeed = [
+    '# Idea Seed: Audit Remediation',
+    '',
+    '## MVP Scope',
+    '',
+    '1. **Own the seam** — architecture (`lib/owned.js`)',
+    `   <!-- audit-fingerprints: ${SHA_OWNED} -->`,
+    `   <!-- audit-semantic-keys: ${KEY_OWNED} -->`,
+    '2. **Cover the gap** — quality (`lib/sibling.js`)',
+    `   <!-- audit-fingerprints: ${SHA_SIBLING} -->`,
+    `   <!-- audit-semantic-keys: ${KEY_SIBLING} -->`,
+    '',
+  ].join('\n');
+
+  const attributed = {
+    slug: 'own-the-seam',
+    type: 'story',
+    title: 'Own the seam',
+    goal: 'Wire the unread seam.',
+    changes: [{ path: 'lib/owned.js', assumption: 'refactors-existing' }],
+    acceptance: ['The seam is wired and a test fails without it.'],
+    verify: ['npm test (unit)'],
+    provenance: {
+      fingerprints: [SHA_OWNED],
+      semanticKeys: [KEY_OWNED],
+    },
+  };
+
+  const unattributed = {
+    slug: 'cover-the-gap',
+    type: 'story',
+    title: 'Cover the gap',
+    goal: 'Cover the untested branch.',
+    changes: [{ path: 'lib/sibling.js', assumption: 'refactors-existing' }],
+    acceptance: ['The untested branch has a failing-first test.'],
+    verify: ['npm test (unit)'],
+  };
+
+  it('stamps exactly the keys the attributed Story owns', () => {
+    const { stories } = assemblePlanStories([attributed], {
+      provenanceSource: auditSeed,
+    });
+    const { body } = stories[0];
+    assert.match(body, new RegExp(`audit-fingerprints:\\s*${SHA_OWNED}`));
+    assert.ok(body.includes(`audit-semantic-keys: ${KEY_OWNED}`));
+    // The whole point: the sibling group's identities are in the seed and
+    // must NOT reach this Story. Under the union every sibling carried every
+    // key, which is what made the next sweep's attribution arbitrary.
+    assert.ok(
+      !body.includes(SHA_SIBLING),
+      "an attributed Story must not carry a sibling group's fingerprint",
+    );
+    assert.ok(
+      !body.includes(KEY_SIBLING),
+      "an attributed Story must not carry a sibling group's semantic key",
+    );
+  });
+
+  it('a sibling without the field still receives the whole-seed union', () => {
+    // Recall safety: deleting the union fallback re-opens the measured
+    // #4626 / #4877 hand-carry failure. Attribution is additive, not a swap.
+    const { stories } = assemblePlanStories([attributed, unattributed], {
+      provenanceSource: auditSeed,
+    });
+    const bySlug = new Map(stories.map((s) => [s.slug, s.body]));
+
+    const owned = bySlug.get('own-the-seam');
+    assert.ok(!owned.includes(SHA_SIBLING));
+
+    const inherited = bySlug.get('cover-the-gap');
+    assert.ok(
+      inherited.includes(SHA_OWNED) && inherited.includes(SHA_SIBLING),
+      'an un-attributed sibling keeps the recall-safe union fallback',
+    );
+    assert.ok(
+      inherited.includes(KEY_OWNED) && inherited.includes(KEY_SIBLING),
+      'and the union covers semantic keys too',
+    );
+  });
+
+  it('an empty provenance object stamps nothing at all', () => {
+    // "Owns no findings" is a real answer and must not silently inherit.
+    const { stories } = assemblePlanStories(
+      [{ ...attributed, provenance: {} }],
+      { provenanceSource: auditSeed },
+    );
+    assert.ok(!stories[0].body.includes('audit-fingerprints'));
+    assert.ok(!stories[0].body.includes('audit-semantic-keys'));
+  });
+
+  it('a Story may own fingerprints without semantic keys', () => {
+    const { stories } = assemblePlanStories(
+      [{ ...attributed, provenance: { fingerprints: [SHA_OWNED] } }],
+      { provenanceSource: auditSeed },
+    );
+    assert.match(
+      stories[0].body,
+      new RegExp(`audit-fingerprints:\\s*${SHA_OWNED}`),
+    );
+    assert.ok(!stories[0].body.includes('audit-semantic-keys'));
+  });
+
+  it('normalizeStoryTicket surfaces the owned identities, deduplicated', () => {
+    const { provenance } = normalizeStoryTicket({
+      ...attributed,
+      provenance: {
+        fingerprints: [SHA_OWNED, SHA_OWNED],
+        semanticKeys: [KEY_OWNED],
+      },
+    });
+    assert.deepEqual(provenance, {
+      fingerprints: [SHA_OWNED],
+      semanticKeys: [KEY_OWNED],
+    });
+  });
+
+  it('an absent provenance field normalizes to null, not an empty set', () => {
+    // `null` is what selects the union fallback — an empty object would
+    // silently mean "owns nothing" and strip every Story of its provenance.
+    assert.equal(normalizeStoryTicket(unattributed).provenance, null);
+  });
+
+  it('rejects a malformed provenance field rather than dropping identities', () => {
+    for (const bad of [
+      { fingerprints: 'not-an-array' },
+      { fingerprints: ['too-short'] },
+      { semanticKeys: ['has,a,comma'] },
+      { unknownField: [] },
+      ['an', 'array'],
+    ]) {
+      assert.throws(
+        () => normalizeStoryTicket({ ...attributed, provenance: bad }),
+        /provenance on "own-the-seam"/,
+        `expected a throw for ${JSON.stringify(bad)}`,
+      );
+    }
+  });
+});
+
+describe('conflict analysis sees the persisted artifact (Story #5045, AC-3)', () => {
+  // The canonical authoring shape carries `acceptance[]` / `verify[]` at the
+  // ticket's TOP LEVEL; assembly folds them into the body. `indexConsumers`
+  // scans `body.acceptance` / `body.verify`, so on the raw payload it scanned
+  // two empty arrays and the implicit-cross-story-dep pass was inert — the
+  // exact defect running the passes post-assembly closes.
+  const producer = {
+    slug: 'produce-the-fixture',
+    type: 'story',
+    title: 'Produce the fixture',
+    goal: 'Create the shared fixture module.',
+    changes: [{ path: 'lib/fixture.js', assumption: 'creates' }],
+    acceptance: ['The fixture module exists and exports the builder.'],
+    verify: ['npm test (unit)'],
+  };
+  const consumer = {
+    slug: 'consume-the-fixture',
+    type: 'story',
+    title: 'Consume the fixture',
+    goal: 'Verify the reader against the shared fixture.',
+    changes: [{ path: 'lib/reader.js', assumption: 'refactors-existing' }],
+    acceptance: ['The reader resolves every entry.'],
+    // No depends_on edge — this is the implicit dependency the pass exists
+    // to name, and it is only visible once the body carries `verify[]`.
+    verify: ['node --test lib/fixture.js (unit)'],
+  };
+
+  it('the raw payload hides the implicit dependency the assembled body reveals', () => {
+    const rawFindings = computeConflictFindings({
+      stories: [producer, consumer],
+    });
+    assert.deepEqual(
+      rawFindings.filter((f) => f.kind === 'implicit-cross-story-dep'),
+      [],
+      'pre-assembly the consumer scan has no body.verify to read',
+    );
+
+    const { stories } = assemblePlanStories([producer, consumer]);
+    const assembled = computeAssembledConflictFindings({ stories });
+    const implicit = assembled.filter(
+      (f) => f.kind === 'implicit-cross-story-dep',
+    );
+    assert.equal(
+      implicit.length,
+      1,
+      `expected the assembled pass to find the edge, got ${JSON.stringify(assembled)}`,
+    );
+    assert.equal(implicit[0].path, 'lib/fixture.js');
+    assert.equal(implicit[0].producer.storySlug, 'produce-the-fixture');
+    assert.equal(implicit[0].consumer.storySlug, 'consume-the-fixture');
+  });
+
+  it('scans the footer-stamped bodies, not a re-serialization of the tickets', () => {
+    // The bodies handed to the pass are the same strings persist posts —
+    // provenance footers and all — so what validation judged is what landed.
+    const seed = `1. **Fix it**\n   <!-- audit-fingerprints: ${'c'.repeat(40)} -->`;
+    const { stories } = assemblePlanStories([producer, consumer], {
+      provenanceSource: seed,
+    });
+    for (const story of stories) {
+      assert.ok(
+        story.body.includes('audit-fingerprints:'),
+        'the assembled body carries its provenance footer',
+      );
+    }
+    const assembled = computeAssembledConflictFindings({ stories });
+    assert.equal(
+      assembled.filter((f) => f.kind === 'implicit-cross-story-dep').length,
+      1,
+      'the footers must not disturb the conflict passes',
+    );
+  });
+
+  it('an explicit depends_on edge clears the finding', () => {
+    const { stories } = assemblePlanStories([
+      producer,
+      { ...consumer, depends_on: ['produce-the-fixture'] },
+    ]);
+    assert.deepEqual(
+      computeAssembledConflictFindings({ stories }).filter(
+        (f) => f.kind === 'implicit-cross-story-dep',
+      ),
+      [],
+    );
+  });
+
+  it('a policy upgrade bites on the assembled artifact too', () => {
+    const shared = [
+      {
+        ...producer,
+        changes: [{ path: 'lib/shared.js', assumption: 'refactors-existing' }],
+      },
+      {
+        ...consumer,
+        changes: [{ path: 'lib/shared.js', assumption: 'refactors-existing' }],
+      },
+    ];
+    const { stories } = assemblePlanStories(shared);
+    const findings = computeAssembledConflictFindings({
+      stories,
+      config: { planning: { failOnSharedEditors: true } },
+    });
+    const sharedEditor = findings.filter((f) => f.kind === 'shared-editor');
+    assert.equal(sharedEditor.length, 1);
+    assert.equal(sharedEditor[0].severity, 'hard');
   });
 });

--- a/tests/lib/orchestration/ticket-validator-conflicts.test.js
+++ b/tests/lib/orchestration/ticket-validator-conflicts.test.js
@@ -3,7 +3,9 @@ import test from 'node:test';
 import { validateAndNormalizeTickets } from '../../../.agents/scripts/lib/orchestration/ticket-validator.js';
 import {
   _internal,
+  computeAssembledConflictFindings,
   computeConflictFindings,
+  conflictFindingKey,
   renderHardConflictError,
 } from '../../../.agents/scripts/lib/orchestration/ticket-validator-conflicts.js';
 import { serialize as serializeStoryBody } from '../../../.agents/scripts/lib/story-body/story-body.js';
@@ -1233,4 +1235,110 @@ test('registry pass: every collaborating predicate is injectable through the fin
   assert.equal(seen.waveChecks, 1);
   assert.equal(findings.length, 1);
   assert.equal(findings[0].registryPath, 'anything/at/all.js');
+});
+
+// ---------------------------------------------------------------------------
+// Post-assembly re-run (Story #5045)
+//
+// `validateTickets` runs over the raw `stories.json` payload, before assembly
+// serializes the bodies persist actually posts. `computeAssembledConflictFindings`
+// is the second pass over that artifact.
+// ---------------------------------------------------------------------------
+
+test('computeAssembledConflictFindings scans the serialized body strings', () => {
+  const assembled = ['s-a', 's-b'].map((slug) => ({
+    slug,
+    title: `Story ${slug}`,
+    body: serializeStoryBody({
+      goal: `Goal for ${slug}.`,
+      changes: [{ path: 'lib/shared.js', assumption: 'refactors-existing' }],
+      acceptance: ['observable criterion'],
+      verify: ['npm test (unit)'],
+    }),
+    depends_on: [],
+  }));
+
+  const findings = computeAssembledConflictFindings({ stories: assembled });
+  const shared = findings.filter((f) => f.kind === 'shared-editor');
+  assert.equal(shared.length, 1);
+  assert.equal(shared[0].path, 'lib/shared.js');
+  assert.deepEqual(shared[0].storySlugs, ['s-a', 's-b']);
+  assert.equal(
+    shared[0].severity,
+    'soft',
+    'advisory unless policy upgrades it',
+  );
+});
+
+test('computeAssembledConflictFindings never re-runs the fan-out probe', () => {
+  // The probe is a `git grep` per deleted path and its inputs are identical on
+  // both sides, so re-probing would double the git cost for the same answer.
+  let probed = 0;
+  const findings = computeAssembledConflictFindings({
+    stories: [
+      {
+        slug: 's-a',
+        body: serializeStoryBody({
+          goal: 'Delete it.',
+          changes: [{ path: 'lib/gone.js', assumption: 'deletes' }],
+          acceptance: ['observable criterion'],
+          verify: ['npm test (unit)'],
+        }),
+        depends_on: [],
+      },
+    ],
+    config: {
+      planning: {
+        fanOutCounter: () => {
+          probed += 1;
+          return 999;
+        },
+      },
+    },
+  });
+  assert.equal(probed, 0);
+  assert.deepEqual(
+    findings.filter((f) => f.kind === 'fan-out-warning'),
+    [],
+  );
+});
+
+test('computeAssembledConflictFindings is total on absent and malformed input', () => {
+  // It runs on the pre-creation path, so a shape surprise must not strand a
+  // plan between validation and its first createIssue.
+  assert.deepEqual(computeAssembledConflictFindings(), []);
+  assert.deepEqual(computeAssembledConflictFindings({ stories: null }), []);
+  assert.deepEqual(
+    computeAssembledConflictFindings({
+      stories: [{ slug: 's-a', body: 'not a parseable story body' }],
+    }),
+    [],
+  );
+});
+
+test('conflictFindingKey is stable across passes and separates distinct findings', () => {
+  const finding = {
+    kind: 'shared-editor',
+    severity: 'soft',
+    path: 'lib/shared.js',
+    storySlugs: ['s-a', 's-b'],
+  };
+  assert.equal(
+    conflictFindingKey(finding),
+    conflictFindingKey({
+      ...finding,
+      severity: 'hard',
+      storySlugs: ['s-b', 's-a'],
+    }),
+    'severity and slug order are not identity — the same collision keys alike',
+  );
+  assert.notEqual(
+    conflictFindingKey(finding),
+    conflictFindingKey({ ...finding, path: 'lib/other.js' }),
+  );
+  assert.notEqual(
+    conflictFindingKey(finding),
+    conflictFindingKey({ ...finding, kind: 'cross-cutting-registries' }),
+  );
+  assert.equal(typeof conflictFindingKey({}), 'string');
 });

--- a/tests/lib/orchestration/ticket-validator.test.js
+++ b/tests/lib/orchestration/ticket-validator.test.js
@@ -224,3 +224,71 @@ describe('ticket-validator: soft ## Spec word budget (Story #4723)', () => {
     );
   });
 });
+
+/**
+ * Optional per-Story `provenance` shape gate (Story #5045).
+ *
+ * The field decides which audit identities persist stamps into a Story body.
+ * A malformed entry must fail here rather than at the stamper: past assembly,
+ * a dropped identity is indistinguishable from a Story that legitimately owns
+ * nothing, and the cost lands a whole sweep later when the next audit re-files
+ * work this plan already tracked.
+ */
+describe('ticket-validator: per-Story provenance shape (Story #5045)', () => {
+  const SHA = 'a'.repeat(40);
+
+  function withProvenance(provenance) {
+    return { ...story('owns-a-finding'), provenance };
+  }
+
+  it('accepts a well-formed provenance field', () => {
+    const validated = validateAndNormalizeTickets([
+      withProvenance({
+        fingerprints: [SHA],
+        semanticKeys: ['architecture␟lib/owned.js'],
+      }),
+    ]);
+    assert.equal(validated.length, 1);
+  });
+
+  it('accepts an absent field — the union fallback is the recall-safe default', () => {
+    assert.equal(
+      validateAndNormalizeTickets([story('no-provenance')]).length,
+      1,
+    );
+  });
+
+  it('rejects a malformed field and names the offending Story', () => {
+    assert.throws(
+      () =>
+        validateAndNormalizeTickets([
+          withProvenance({ fingerprints: ['nope'] }),
+        ]),
+      /Cross-Validation Failed:.*provenance on "owns-a-finding"/s,
+    );
+  });
+
+  it('batches every offender in one pass', () => {
+    assert.throws(
+      () =>
+        validateAndNormalizeTickets([
+          { ...story('bad-one'), provenance: { fingerprints: 'not-an-array' } },
+          {
+            ...story('bad-two'),
+            provenance: { semanticKeys: ['has,a,comma'] },
+          },
+        ]),
+      /2 Story provenance field\(s\) are malformed/,
+    );
+  });
+
+  it('the assertion is reachable through _internal for a targeted check', () => {
+    assert.throws(
+      () =>
+        _internal.assertStoryProvenanceShape({
+          stories: [{ slug: 'direct', provenance: { unknownKey: [] } }],
+        }),
+      /unknown field: unknownKey/,
+    );
+  });
+});

--- a/tests/scripts/plan-persist.summary.test.js
+++ b/tests/scripts/plan-persist.summary.test.js
@@ -98,3 +98,83 @@ describe('plan summary — names the exact deliver command (Story #4540)', () =>
     assert.doesNotMatch(body, /--run/);
   });
 });
+
+describe('plan summary — findings persist beside the promise (Story #5045)', () => {
+  const sharedEditor = (path, storySlugs) => ({
+    kind: 'shared-editor',
+    severity: 'soft',
+    path,
+    storySlugs,
+  });
+
+  it('renders shared-editor findings next to the wave table', () => {
+    // The wave table promises "these run together"; the shared-editor pass
+    // knows exactly where that promise breaks. Until now the promise was
+    // posted and the caveat died on stderr.
+    const body = buildPlanSummaryCommentBody({
+      ...BASE,
+      conflictFindings: [sharedEditor('lib/shared.js', ['a', 'b'])],
+    });
+
+    const lines = body.split('\n');
+    const waveHeading = lines.findIndex((l) =>
+      l.startsWith('#### Delivery order'),
+    );
+    const collisionHeading = lines.findIndex((l) =>
+      l.includes('Known collisions'),
+    );
+    assert.ok(waveHeading >= 0, `expected a wave table:\n${body}`);
+    assert.ok(
+      collisionHeading > waveHeading,
+      `expected collisions after the wave table:\n${body}`,
+    );
+
+    assert.match(body, /\| `lib\/shared\.js` \| `a`, `b` \|/);
+    assert.match(body, /1 shared file\(s\)/);
+  });
+
+  it('names the knob that would turn the advisory into a refusal', () => {
+    const body = buildPlanSummaryCommentBody({
+      ...BASE,
+      conflictFindings: [sharedEditor('lib/shared.js', ['a', 'b'])],
+    });
+    assert.match(body, /planning\.failOnSharedEditors/);
+    assert.match(body, /off by default/);
+  });
+
+  it('renders one row per colliding path, ordered deterministically', () => {
+    const body = buildPlanSummaryCommentBody({
+      ...BASE,
+      conflictFindings: [
+        sharedEditor('lib/z.js', ['b', 'a']),
+        sharedEditor('lib/a.js', ['a', 'b']),
+      ],
+    });
+    const rows = body
+      .split('\n')
+      .filter((line) => line.startsWith('| `lib/'))
+      .map((line) => line.split('|')[1].trim());
+    assert.deepEqual(rows, ['`lib/a.js`', '`lib/z.js`']);
+    assert.match(body, /2 shared file\(s\)/);
+  });
+
+  it('says nothing when the passes found no collision', () => {
+    for (const conflictFindings of [
+      null,
+      undefined,
+      [],
+      // Other conflict kinds have their own remediation and are not a
+      // parallelism caveat — only shared-editor belongs beside the table.
+      [
+        {
+          kind: 'implicit-cross-story-dep',
+          severity: 'soft',
+          path: 'lib/x.js',
+        },
+      ],
+    ]) {
+      const body = buildPlanSummaryCommentBody({ ...BASE, conflictFindings });
+      assert.doesNotMatch(body, /Known collisions/);
+    }
+  });
+});


### PR DESCRIPTION
Closes #5045

_Auto-opened by `/deliver`._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches plan-persist validation, GitHub issue creation ordering, and audit dedup routing—incorrect attribution or assembled conflict handling could block valid plans or mis-route findings, though behavior is heavily tested and policy knobs stay off by default.
> 
> **Overview**
> **Per-Story audit provenance** — Stories can author an optional top-level `provenance` (`fingerprints` / `semanticKeys`). Persist validates it, then stamps **only** those identities into that Story’s body; missing `provenance` still uses the whole-seed union carry. An empty `{}` means “owns nothing” and stamps nothing.
> 
> **Dedup routing** — When several issues confirm a finding, routing now prefers issues that carry the finding’s **fingerprint** over location-only **semantic-key** matches, sorts ties by issue number, and uses the owning issue’s state so a closed owner is not masked by an open neighbor.
> 
> **Conflict analysis on the real artifact** — After assembly (with top-level `acceptance`/`verify` folded into the body and footers applied), plan-persist re-runs cross-Story conflict passes **before** `createIssue`. Hard policy findings still fail closed; new soft findings are deduped against the raw pass; **shared-editor** advisories are added to the posted plan-summary under the wave table.
> 
> Docs in `plan-reference.md` describe the provenance contract and the two-pass conflict behavior. Coverage/crap baselines and tests cover the new modules and paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0bd5516c56805a0f8a90cb4166e477ecf2cafbd2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->