### PR TITLE
fix: lifecycle-lint: give the CLI an explicit scan root so the planting test stops mutating the shared .agents/ tree (#5052)

### DIFF
--- a/.agents/scripts/check-lifecycle-lint.js
+++ b/.agents/scripts/check-lifecycle-lint.js
@@ -46,6 +46,23 @@
  *   The exempt path is matched by suffix so it bites even before the
  *   armer file lands (Wave 7); pre-existence is not required.
  *
+ * Scan root:
+ *   --root <dir>  Scan <dir> instead of this checkout. Both surfaces are
+ *                 derived from it, so one flag moves the whole scan.
+ *                 Defaults to the repository this script ships in, which is
+ *                 what `npm run lint` gets by passing nothing.
+ *
+ *   The seam exists for tests (Story #5052). The CLI test that proves a
+ *   violation is *caught* has to plant one, and it used to plant into the
+ *   live `.agents/` tree — which `tests/e2e/sync-prune.integration.test.js`
+ *   copies with the real binary, so the two raced: the sync either lost the
+ *   file between enumeration and `copyfile` (ENOENT) or copied it once and
+ *   pruned it on the second pass, tripping an idempotence assertion. Pointing
+ *   the planting test at a temp root keeps what that test was written for —
+ *   discovery is still the CLI's own walk, not an injected file list — while
+ *   leaving the shared tree untouched. Mirrors the `--root` seam
+ *   `check-test-temp-hygiene.js` already ships for the same reason.
+ *
  * Exit codes:
  *   0 — clean.
  *   1 — at least one violation; offending file + line printed to stderr.
@@ -65,15 +82,22 @@ import { walkFilesByExtension } from './lib/fs-walk.js';
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = path.resolve(__dirname, '..', '..');
 
-const LIFECYCLE_DIR = path.join(
-  REPO_ROOT,
-  '.agents',
-  'scripts',
-  'lib',
-  'orchestration',
-  'lifecycle',
-);
-const SCRIPTS_DIR = path.join(REPO_ROOT, '.agents', 'scripts');
+/** Rule 1's scan surface for a given repository root. */
+function lifecycleDirFor(root) {
+  return path.join(
+    root,
+    '.agents',
+    'scripts',
+    'lib',
+    'orchestration',
+    'lifecycle',
+  );
+}
+
+/** Rule 3's scan surface for a given repository root. */
+function scriptsDirFor(root) {
+  return path.join(root, '.agents', 'scripts');
+}
 
 /**
  * Files exempt from the merge-lockout rule. The path is matched by
@@ -269,10 +293,31 @@ export function findMergeLockoutViolations(
   return violations;
 }
 
+/**
+ * Parse the argument vector. The only option is the scan root; anything
+ * else is ignored so an extra flag can never silently narrow the scan.
+ *
+ * @param {string[]} argv Arguments without the node/script entries.
+ * @returns {{ root: string }}
+ */
+function parseArgv(argv) {
+  let root = REPO_ROOT;
+  for (let i = 0; i < argv.length; i += 1) {
+    if (argv[i] === '--root') {
+      i += 1;
+      root = path.resolve(String(argv[i] ?? '.'));
+    }
+  }
+  return { root };
+}
+
 async function main() {
-  // Per-rule discovery.
-  const v1 = findPromiseAllViolations(LIFECYCLE_DIR);
-  const v3 = findMergeLockoutViolations(SCRIPTS_DIR);
+  const { root } = parseArgv(process.argv.slice(2));
+  // Per-rule discovery. Both rules' exemptions match by absolute-path
+  // SUFFIX, which is what lets an injected root keep the same allow-list
+  // semantics as the live tree — do not re-anchor them to `root`.
+  const v1 = findPromiseAllViolations(lifecycleDirFor(root));
+  const v3 = findMergeLockoutViolations(scriptsDirFor(root));
   const all = [
     ...v1.map((v) => ({ rule: 'no-promise-all-lifecycle', ...v })),
     ...v3.map((v) => ({ rule: 'merge-lockout', ...v })),
@@ -297,4 +342,19 @@ async function main() {
 await runAsCli(import.meta.url, main, {
   source: 'check-lifecycle-lint',
   propagateExitCode: true,
+  usage: {
+    invocation: 'node .agents/scripts/check-lifecycle-lint.js [--root <dir>]',
+    summary:
+      'Enforce the two lifecycle lint rules biome cannot express: no Promise.all on the append-only lifecycle surface, and the auto-merge lockout on string literals under .agents/scripts/.',
+    flags: [
+      [
+        '--root <dir>',
+        'Repository root to scan (default: the checkout this script ships in). Both rule surfaces derive from it; used by tests so a planted violation never touches the shared tree.',
+      ],
+    ],
+    notes: [
+      'Ships as part of `npm run lint`, which invokes it with no arguments.',
+      'Exit codes:\n  0  clean\n  1  at least one violation; offending file and line printed to stderr',
+    ],
+  },
 });

--- a/tests/lifecycle/lifecycle-lint.test.js
+++ b/tests/lifecycle/lifecycle-lint.test.js
@@ -1,7 +1,7 @@
 // tests/lifecycle/lifecycle-lint.test.js
 import assert from 'node:assert/strict';
 import { spawnSync } from 'node:child_process';
-import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
 import path from 'node:path';
 import { afterEach, beforeEach, describe, it } from 'node:test';
 import { fileURLToPath } from 'node:url';
@@ -100,9 +100,53 @@ describe('lifecycle-lint/cli', () => {
   });
 
   it('exits 1 and tags the offending rule when a violation is planted', () => {
-    // Plant a Promise.all under the real lifecycle dir, so the CLI's own
-    // discovery (not an injected fixture path) is what finds it.
-    const planted = path.join(
+    // Plant into a temp root, NOT the live tree. The property this test was
+    // written for — that the CLI's own discovery finds the violation, rather
+    // than an injected fixture path — survives, because `--root` only moves
+    // where the walk starts; the walk is still the CLI's.
+    //
+    // Planting into the real `.agents/` tree raced
+    // `tests/e2e/sync-prune.integration.test.js`, which copies that same tree
+    // with the real binary: the sync either lost the file between enumeration
+    // and `copyfile` (ENOENT) or copied it on the first pass and pruned it on
+    // the second, tripping the idempotence assertion. Both tests were correct
+    // in isolation; this one mutated shared state the other read (Story #5052,
+    // filed as #5051).
+    const root = makeTempDir('mandrel-lint-cli-');
+    try {
+      const lifecycleDir = path.join(
+        root,
+        '.agents',
+        'scripts',
+        'lib',
+        'orchestration',
+        'lifecycle',
+      );
+      mkdirSync(lifecycleDir, { recursive: true });
+      writeFileSync(
+        path.join(lifecycleDir, 'zz-planted-violation.js'),
+        'export const x = Promise.all([]);\n',
+        'utf8',
+      );
+
+      const result = spawnSync(
+        process.execPath,
+        [SCRIPT_PATH, '--root', root],
+        { cwd: REPO_ROOT, encoding: 'utf8' },
+      );
+      assert.equal(result.status, 1, `stdout: ${result.stdout}`);
+      assert.match(result.stderr, /no-promise-all-lifecycle/);
+      assert.match(result.stderr, /zz-planted-violation\.js/);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('leaves the real .agents/ tree untouched while scanning an injected root', () => {
+    // The regression guard for #5051: the CLI test must not create the file
+    // whose transient presence broke the sync e2e. Asserting on the exact path
+    // keeps the guard honest if someone reinstates the live-tree plant.
+    const livePlant = path.join(
       REPO_ROOT,
       '.agents',
       'scripts',
@@ -111,18 +155,96 @@ describe('lifecycle-lint/cli', () => {
       'lifecycle',
       'zz-planted-violation.js',
     );
-    writeFileSync(planted, 'export const x = Promise.all([]);\n', 'utf8');
+    const root = makeTempDir('mandrel-lint-cli-untouched-');
     try {
-      const result = spawnSync(process.execPath, [SCRIPT_PATH], {
+      const lifecycleDir = path.join(
+        root,
+        '.agents',
+        'scripts',
+        'lib',
+        'orchestration',
+        'lifecycle',
+      );
+      mkdirSync(lifecycleDir, { recursive: true });
+      writeFileSync(
+        path.join(lifecycleDir, 'zz-planted-violation.js'),
+        'export const x = Promise.all([]);\n',
+        'utf8',
+      );
+
+      spawnSync(process.execPath, [SCRIPT_PATH, '--root', root], {
         cwd: REPO_ROOT,
         encoding: 'utf8',
       });
-      assert.equal(result.status, 1, `stdout: ${result.stdout}`);
-      assert.match(result.stderr, /no-promise-all-lifecycle/);
-      assert.match(result.stderr, /zz-planted-violation\.js/);
+
+      assert.equal(
+        existsSync(livePlant),
+        false,
+        'scanning an injected root must never write into the shared source tree',
+      );
     } finally {
-      rmSync(planted, { force: true });
+      rmSync(root, { recursive: true, force: true });
     }
+  });
+
+  it('keeps the merge-lockout exemptions suffix-matched under an injected root', () => {
+    // The allow-list is matched by absolute-path SUFFIX, so it has to keep
+    // biting when the root moves. Re-anchoring it to the repo root would make
+    // the authorized carrier report a violation under any other root.
+    const root = makeTempDir('mandrel-lint-cli-exempt-');
+    try {
+      const phasesDir = path.join(
+        root,
+        '.agents',
+        'scripts',
+        'lib',
+        'orchestration',
+        'single-story-close',
+        'phases',
+      );
+      mkdirSync(phasesDir, { recursive: true });
+      writeFileSync(
+        path.join(phasesDir, 'auto-merge.js'),
+        "const cmd = 'gh pr merge --auto --squash';\n",
+        'utf8',
+      );
+
+      const result = spawnSync(
+        process.execPath,
+        [SCRIPT_PATH, '--root', root],
+        { cwd: REPO_ROOT, encoding: 'utf8' },
+      );
+      assert.equal(
+        result.status,
+        0,
+        `the authorized carrier must stay exempt; stderr: ${result.stderr}`,
+      );
+      assert.match(result.stdout, /\[lifecycle-lint\] clean/);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('--help exits 0 with a usage block and never reaches the scan', () => {
+    // Supplying `usage` is what makes runAsCli short-circuit --help before
+    // main(); this script used to fall through and run a full scan, which is
+    // why it sat in KNOWN_HELP_GAPS (tests/scripts/cli-help-contract.test.js).
+    const result = spawnSync(process.execPath, [SCRIPT_PATH, '--help'], {
+      cwd: REPO_ROOT,
+      encoding: 'utf8',
+    });
+    assert.equal(result.status, 0, `stderr: ${result.stderr}`);
+    assert.match(
+      result.stdout,
+      /^Usage: node \.agents\/scripts\/check-lifecycle-lint\.js /m,
+      'usage block did not print the invocation line',
+    );
+    assert.match(result.stdout, /--root <dir>/);
+    assert.doesNotMatch(
+      `${result.stdout}${result.stderr}`,
+      /\[lifecycle-lint\] clean/,
+      '--help fell through to the scan path',
+    );
   });
 });
 

--- a/tests/scripts/cli-help-contract.test.js
+++ b/tests/scripts/cli-help-contract.test.js
@@ -40,7 +40,6 @@ const SCRIPTS_DIR = path.join(REPO_ROOT, '.agents', 'scripts');
 const KNOWN_HELP_GAPS = new Set([
   'check-action-pinning.js',
   'check-context-budget.js',
-  'check-lifecycle-lint.js',
   'check-schema-references.js',
   'check-workflow-cli-lint.js',
   'check-workflow-timeouts.js',


### PR DESCRIPTION
Closes #5052

_Auto-opened by `/deliver`._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test and CLI ergonomics only; default lint behavior is unchanged when `--root` is omitted.
> 
> **Overview**
> Adds **`--root <dir>`** to `check-lifecycle-lint.js` so both rule surfaces scan under an alternate repository root (default unchanged for `npm run lint`). Scan paths are derived via `lifecycleDirFor` / `scriptsDirFor` instead of fixed constants.
> 
> The lifecycle-lint CLI test that plants a `Promise.all` violation **no longer writes into the live `.agents/` tree**; it uses a temp root with `--root`, fixing flakiness/races with `sync-prune.integration.test.js` (#5051). New tests guard that the shared tree stays untouched, that merge-lockout suffix exemptions still apply under an injected root, and that **`--help`** prints usage without running a scan.
> 
> Registers a **`usage`** block on `runAsCli` and removes `check-lifecycle-lint.js` from **`KNOWN_HELP_GAPS`** in the CLI help contract test.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 77eb0e7998e0a99d2bb88489a4630f7dedae5568. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->